### PR TITLE
prov/efa: Allow fork support and MR cache

### DIFF
--- a/man/fi_efa.7.md
+++ b/man/fi_efa.7.md
@@ -169,6 +169,9 @@ These OFI runtime parameters apply only to the RDM endpoint.
 *FI_EFA_INTER_MAX_MEDIUM_MESSAGE_SIZE*
 : The maximum size for inter EFA messages to be sent by using medium message protocol. Messages which can fit in one packet will be sent as eager message. Messages whose sizes are smaller than this value will be sent using medium message protocol. Other messages will be sent using CTS based long message protocol.
 
+*FI_EFA_FORK_SAFE*
+: Enable fork() support. This may have a small performance impact and should only be set when required. Applications that require to register regions backed by huge pages and also require fork support are not supported.
+
 # SEE ALSO
 
 [`fabric`(7)](fabric.7.html),

--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -381,6 +381,23 @@ ssize_t efa_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t count, fi_addr_
 
 ssize_t efa_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *entry, uint64_t flags);
 
+/*
+ * ON will avoid using huge pages for bounce buffers, so that the libibverbs
+ * fork support can be used safely.
+ *
+ * UNNEEDED is currently not used but will be set when rdma-core adds a verb to
+ * check this state. Fork support will become irrelevant once the kernel copies
+ * pages into the fork, leaving the pinned pages intact.
+ *
+ * See https://github.com/linux-rdma/rdma-core/pull/883 for more information.
+ */
+enum efa_fork_support_status {
+	EFA_FORK_SUPPORT_OFF = 0,
+	EFA_FORK_SUPPORT_ON,
+	EFA_FORK_SUPPORT_UNNEEDED,
+};
+extern enum efa_fork_support_status efa_fork_status;
+
 bool efa_device_support_rdma_read(void);
 
 static inline

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -364,6 +364,14 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 	    efa_check_fork_enabled(*domain_fid))
 		efa_fork_status = EFA_FORK_SUPPORT_ON;
 
+	if (efa_fork_status == EFA_FORK_SUPPORT_ON &&
+	    getenv("RDMAV_HUGEPAGES_SAFE")) {
+		EFA_WARN(FI_LOG_DOMAIN,
+			 "Using libibverbs fork support and huge pages is not supported by the EFA provider.\n");
+		ret = -FI_EINVAL;
+		goto err_free_info;
+	}
+
 	/*
 	 * If FI_MR_LOCAL is set, we do not want to use the MR cache.
 	 */

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -260,6 +260,24 @@ static int efa_mr_cache_init(struct efa_domain *domain, struct fi_info *info)
 	return 0;
 }
 
+/* @brief Allocate a domain, open the device, and set it up based on the hints.
+ *
+ * This function creates a domain and uses the info struct to configure the
+ * domain based on what capabilities are set. Fork support is checked here and
+ * the MR cache is also set up here.
+ *
+ * Note the trickery with rxr_domain where detect whether this endpoint is RDM
+ * or DGRAM to set some state in rxr_domain. We can do this as the type field
+ * is at the beginning of efa_domain and rxr_domain, and we know efa_domain
+ * stored within rxr_domain. This will be removed when rxr_domain_open and
+ * efa_domain_open are combined.
+ *
+ * @param fabric_fid fabric that the domain should be tied to
+ * @param info info struct that was validated and returned by fi_getinfo
+ * @param domain_fid pointer where newly domain fid should be stored
+ * @param context void pointer stored with the domain fid
+ * @return 0 on success, fi_errno on error
+ */
 int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 		    struct fid_domain **domain_fid, void *context)
 {

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -208,6 +208,50 @@ static struct fi_ops_domain efa_domain_ops = {
 	.query_collective = fi_no_query_collective,
 };
 
+/* @brief Fork handler that is installed when EFA is loaded
+ *
+ * We register this fork handler so that users do not inadvertently trip over
+ * memory corruption when fork is called. Calling fork() without enabling fork
+ * support in rdma-core can cause corruption, even if the registered pages are
+ * not used in the child process.
+ *
+ * It is critical that this fork handler is only installed once an EFA device
+ * is present and selected. We don't want this to trigger when Libfabric is not
+ * running on an EC2 instance.
+ */
+static
+void efa_atfork_callback()
+{
+	static int visited = 0;
+
+	if (visited)
+		return;
+	visited = 1;
+
+	fprintf(stderr,
+		"A process has executed an operation involving a call\n"
+		"to the fork() system call to create a child process.\n"
+		"\n"
+		"As a result, the Libfabric EFA provider is operating in\n"
+		"a condition that could result in memory corruption or\n"
+		"other system errors.\n"
+		"\n"
+		"For the Libfabric EFA provider to work safely when fork()\n"
+		"is called please set the following environment variable:\n"
+		"          FI_EFA_FORK_SAFE=1\n"
+		"and verify you are using rdma-core v31.1 or later.\n"
+		"\n"
+		"Please note that enabling fork support may cause a\n"
+		"small performance impact.\n"
+		"\n"
+		"You may want to check with your application vendor to see\n"
+		"if an application-level alternative (of not using fork)\n"
+		"exists.\n"
+		"\n"
+		"Your job will now abort.\n");
+	abort();
+}
+
 /* @brief Setup the MR cache.
  *
  * This function enables the MR cache using the util MR cache code. Note that
@@ -281,6 +325,7 @@ static int efa_mr_cache_init(struct efa_domain *domain, struct fi_info *info)
 int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 		    struct fid_domain **domain_fid, void *context)
 {
+	static int fork_handler_installed = 0;
 	struct efa_domain *domain;
 	struct efa_fabric *fabric;
 	const struct fi_info *fi;
@@ -390,6 +435,22 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 		goto err_free_info;
 	}
 
+	/*
+	 * It'd be better to install this during provider init (since that's
+	 * only invoked once) but we need to do a memory registration for the
+	 * fork check above. This can move to the provider init once that check
+	 * is gone.
+	 */
+	if (!fork_handler_installed && efa_fork_status == EFA_FORK_SUPPORT_OFF) {
+		ret = pthread_atfork(efa_atfork_callback, NULL, NULL);
+		if (ret) {
+			EFA_WARN(FI_LOG_DOMAIN,
+				 "Unable to register atfork callback: %s\n",
+				 strerror(-ret));
+			goto err_free_info;
+		}
+		fork_handler_installed = 1;
+	}
 	/*
 	 * If FI_MR_LOCAL is set, we do not want to use the MR cache.
 	 */

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -40,6 +40,8 @@
 fastlock_t pd_list_lock;
 struct efa_pd *pd_list = NULL;
 
+enum efa_fork_support_status efa_fork_status = EFA_FORK_SUPPORT_OFF;
+
 static int efa_domain_close(fid_t fid)
 {
 	struct efa_domain *domain;
@@ -139,11 +141,15 @@ static int efa_open_device_by_name(struct efa_domain *domain, const char *name)
 	return ret;
 }
 
-/*
+/* @brief Check if rdma-core fork support is enabled
+ *
  * Register a temporary buffer and call ibv_fork_init() to determine if fork
  * support is enabled.
  *
  * This relies on internal behavior in rdma-core and is a temporary workaround.
+ *
+ * @param domain_fid domain fid so we can register memory
+ * @return 0 if fork support is not enabled, 1 if it is.
  */
 static int efa_check_fork_enabled(struct fid_domain *domain_fid)
 {
@@ -202,6 +208,58 @@ static struct fi_ops_domain efa_domain_ops = {
 	.query_collective = fi_no_query_collective,
 };
 
+/* @brief Setup the MR cache.
+ *
+ * This function enables the MR cache using the util MR cache code. Note that
+ * if the call to ofi_mr_cache_init fails, we continue but disable the cache.
+ *
+ * @param efa_domain The EFA domain where cache ops should be set
+ * @param info Validated info struct selected by the user
+ * @return 0 on success, fi_errno on failure.
+ */
+static int efa_mr_cache_init(struct efa_domain *domain, struct fi_info *info)
+{
+	struct ofi_mem_monitor *memory_monitors[OFI_HMEM_MAX] = {
+		[FI_HMEM_SYSTEM] = uffd_monitor,
+		[FI_HMEM_CUDA] = cuda_monitor,
+	};
+	int ret;
+
+	domain->cache = (struct ofi_mr_cache *)calloc(1, sizeof(struct ofi_mr_cache));
+	if (!domain->cache)
+		return -FI_ENOMEM;
+
+	if (!efa_mr_max_cached_count)
+		efa_mr_max_cached_count = info->domain_attr->mr_cnt *
+					  EFA_MR_CACHE_LIMIT_MULT;
+	if (!efa_mr_max_cached_size)
+		efa_mr_max_cached_size = domain->ctx->max_mr_size *
+					 EFA_MR_CACHE_LIMIT_MULT;
+	/*
+	 * XXX: we're modifying a global in the util mr cache? do we need an
+	 * API here instead?
+	 */
+	cache_params.max_cnt = efa_mr_max_cached_count;
+	cache_params.max_size = efa_mr_max_cached_size;
+	domain->cache->entry_data_size = sizeof(struct efa_mr);
+	domain->cache->add_region = efa_mr_cache_entry_reg;
+	domain->cache->delete_region = efa_mr_cache_entry_dereg;
+	ret = ofi_mr_cache_init(&domain->util_domain, memory_monitors,
+				domain->cache);
+	if (!ret) {
+		domain->util_domain.domain_fid.mr = &efa_domain_mr_cache_ops;
+		EFA_INFO(FI_LOG_DOMAIN, "EFA MR cache enabled, max_cnt: %zu max_size: %zu\n",
+			 cache_params.max_cnt, cache_params.max_size);
+	} else {
+		EFA_WARN(FI_LOG_DOMAIN, "EFA MR cache init failed: %s\n",
+		         fi_strerror(ret));
+		free(domain->cache);
+		domain->cache = NULL;
+	}
+
+	return 0;
+}
+
 int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 		    struct fid_domain **domain_fid, void *context)
 {
@@ -211,10 +269,6 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 	size_t qp_table_size;
 	bool app_mr_local;
 	int ret;
-	struct ofi_mem_monitor *memory_monitors[OFI_HMEM_MAX] = {
-		[FI_HMEM_SYSTEM] = uffd_monitor,
-		[FI_HMEM_CUDA] = cuda_monitor,
-	};
 
 	fi = efa_get_efa_info(info->domain_attr->name);
 	if (!fi)
@@ -288,52 +342,35 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 	domain->cache = NULL;
 
 	/*
-	 * Check whether fork support is enabled when app does not request
-	 * FI_MR_LOCAL even if the cache is disabled.
+	 * Call ibv_fork_init if the user asked for fork support.
 	 */
-	if (!app_mr_local && efa_check_fork_enabled(*domain_fid)) {
-		fprintf(stderr,
-		         "\nlibibverbs fork support is not supported by the EFA Libfabric\n"
-			 "provider when memory registrations are handled by the provider.\n"
-			 "\nFork support may currently be enabled via the RDMAV_FORK_SAFE\n"
-			 "or IBV_FORK_SAFE environment variable or another library in your\n"
-			 "application may be calling ibv_fork_init().\n"
-			 "\nPlease refer to https://github.com/ofiwg/libfabric/issues/6332\n"
-			 "for more information. Your job will now abort.\n");
-		abort();
+	if (efa_fork_status == EFA_FORK_SUPPORT_ON) {
+		ret = -ibv_fork_init();
+		if (ret) {
+			EFA_WARN(FI_LOG_DOMAIN,
+			         "Fork support requested but ibv_fork_init failed: %s\n",
+			         strerror(-ret));
+			goto err_free_info;
+		}
 	}
+
+	/*
+	 * Run check to see if fork support was enabled by another library. If
+	 * one of the environment variables was set to enable fork support,
+	 * this variable was set to ON during provider init.  Huge pages for
+	 * bounce buffers will not be used if fork support is on.
+	 */
+	if (efa_fork_status == EFA_FORK_SUPPORT_OFF &&
+	    efa_check_fork_enabled(*domain_fid))
+		efa_fork_status = EFA_FORK_SUPPORT_ON;
 
 	/*
 	 * If FI_MR_LOCAL is set, we do not want to use the MR cache.
 	 */
 	if (!app_mr_local && efa_mr_cache_enable) {
-		domain->cache = (struct ofi_mr_cache *)calloc(1, sizeof(struct ofi_mr_cache));
-		if (!domain->cache) {
-			ret = -FI_ENOMEM;
+		ret = efa_mr_cache_init(domain, info);
+		if (ret)
 			goto err_free_info;
-		}
-
-		if (!efa_mr_max_cached_count)
-			efa_mr_max_cached_count = info->domain_attr->mr_cnt *
-			                          EFA_MR_CACHE_LIMIT_MULT;
-		if (!efa_mr_max_cached_size)
-			efa_mr_max_cached_size = domain->ctx->max_mr_size *
-			                         EFA_MR_CACHE_LIMIT_MULT;
-		cache_params.max_cnt = efa_mr_max_cached_count;
-		cache_params.max_size = efa_mr_max_cached_size;
-		domain->cache->entry_data_size = sizeof(struct efa_mr);
-		domain->cache->add_region = efa_mr_cache_entry_reg;
-		domain->cache->delete_region = efa_mr_cache_entry_dereg;
-		ret = ofi_mr_cache_init(&domain->util_domain, memory_monitors,
-					domain->cache);
-		if (!ret) {
-			domain->util_domain.domain_fid.mr = &efa_domain_mr_cache_ops;
-			EFA_INFO(FI_LOG_DOMAIN, "EFA MR cache enabled, max_cnt: %zu max_size: %zu\n",
-			         cache_params.max_cnt, cache_params.max_size);
-		} else {
-			free(domain->cache);
-			domain->cache = NULL;
-		}
 	}
 
 	return 0;

--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -979,7 +979,7 @@ void efa_atfork_callback()
 		"\n"
 		"For the Libfabric EFA provider to work safely when fork()\n"
 		"is called please set the following environment variable:\n"
-		"          RDMAV_FORK_SAFE=1\n"
+		"          FI_EFA_FORK_SAFE=1\n"
 		"and verify you are using rdma-core v31.1 or later.\n"
 		"\n"
 		"Please note that enabling fork support may cause a\n"

--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -950,6 +950,17 @@ static struct fi_ops_fabric efa_ops_fabric = {
 	.trywait = ofi_trywait
 };
 
+/* @brief Fork handler that is installed when EFA is loaded
+ *
+ * We register this fork handler so that users do not inadvertently trip over
+ * memory corruption when fork is called. Calling fork() without enabling fork
+ * support in rdma-core can cause corruption, even if the registered pages are
+ * not used in the child process.
+ *
+ * It is critical that this fork handler is only installed once an EFA device
+ * is present and selected. We don't want this to trigger when Libfabric is not
+ * running on an EC2 instance.
+ */
 static
 void efa_atfork_callback()
 {
@@ -957,36 +968,27 @@ void efa_atfork_callback()
 
 	if (visited)
 		return;
-
 	visited = 1;
-	if (getenv("RDMAV_FORK_SAFE") || getenv("IBV_FORK_SAFE") )
-		return;
 
 	fprintf(stderr,
 		"A process has executed an operation involving a call\n"
 		"to the fork() system call to create a child process.\n"
 		"\n"
-		"As a result, the libfabric EFA provider is operating in\n"
+		"As a result, the Libfabric EFA provider is operating in\n"
 		"a condition that could result in memory corruption or\n"
 		"other system errors.\n"
 		"\n"
-		"For the libfabric EFA provider to work safely when fork()\n"
-		"is called, the application must handle memory registrations\n"
-		"(FI_MR_LOCAL) and you will need to set the following environment\n"
-		"variables:\n"
+		"For the Libfabric EFA provider to work safely when fork()\n"
+		"is called please set the following environment variable:\n"
 		"          RDMAV_FORK_SAFE=1\n"
-		"MPI applications do not support this mode.\n"
+		"and verify you are using rdma-core v31.1 or later.\n"
 		"\n"
-		"However, this setting can result in signficant performance\n"
-		"impact to your application due to increased cost of memory\n"
-		"registration.\n"
+		"Please note that enabling fork support may cause a\n"
+		"small performance impact.\n"
 		"\n"
 		"You may want to check with your application vendor to see\n"
 		"if an application-level alternative (of not using fork)\n"
 		"exists.\n"
-		"\n"
-		"Please refer to https://github.com/ofiwg/libfabric/issues/6332\n"
-		"for more information.\n"
 		"\n"
 		"Your job will now abort.\n");
 	abort();
@@ -999,12 +1001,14 @@ int efa_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric_fid,
 	struct efa_fabric *fab;
 	int ret = 0;
 
-	ret = pthread_atfork(efa_atfork_callback, NULL, NULL);
-	if (ret) {
-		EFA_WARN(FI_LOG_FABRIC,
-			 "Unable to register atfork callback: %s\n",
-			 strerror(-ret));
-		return -ret;
+	if (efa_fork_status == EFA_FORK_SUPPORT_OFF) {
+		ret = pthread_atfork(efa_atfork_callback, NULL, NULL);
+		if (ret) {
+			EFA_WARN(FI_LOG_FABRIC,
+				 "Unable to register atfork callback: %s\n",
+				 strerror(-ret));
+			return -ret;
+		}
 	}
 
 	fab = calloc(1, sizeof(*fab));

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1233,9 +1233,22 @@ static int rxr_create_pkt_pool(struct rxr_ep *ep, size_t size,
 	return ofi_bufpool_create_attr(&attr, buf_pool);
 }
 
+/** @brief Initializes the endpoint and allocates the packet pools.
+ *
+ * This function allocates the various packet pools for the EFA and SHM
+ * provider and does other endpoint initialization.
+ *
+ * Note that ofi_bufpool_create currently does lazy allocation, so memory is
+ * not allocated here. Memory will be allocated the first time the pool is
+ * used.
+ *
+ * @param ep rxr_ep struct to initialize.
+ * @return 0 on success, fi_errno on error.
+ */
 int rxr_ep_init(struct rxr_ep *ep)
 {
 	size_t entry_sz;
+	int hp_pool_flag;
 	int ret;
 
 	entry_sz = ep->mtu_size + sizeof(struct rxr_pkt_entry);
@@ -1244,14 +1257,19 @@ int rxr_ep_init(struct rxr_ep *ep)
 	ep->rx_pkt_pool_entry_sz = entry_sz;
 #endif
 
+	if (efa_fork_status == EFA_FORK_SUPPORT_ON)
+		hp_pool_flag = 0;
+	else
+		hp_pool_flag = OFI_BUFPOOL_HUGEPAGES;
+
 	ret = rxr_create_pkt_pool(ep, entry_sz, rxr_get_tx_pool_chunk_cnt(ep),
-				  OFI_BUFPOOL_HUGEPAGES,
+				  hp_pool_flag,
 				  &ep->tx_pkt_efa_pool);
 	if (ret)
 		goto err_free;
 
 	ret = rxr_create_pkt_pool(ep, entry_sz, rxr_get_rx_pool_chunk_cnt(ep),
-				  OFI_BUFPOOL_HUGEPAGES,
+				  hp_pool_flag,
 				  &ep->rx_pkt_efa_pool);
 	if (ret)
 		goto err_free;

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -125,6 +125,9 @@ static void rxr_init_env(void)
 			    &rxr_env.efa_min_read_write_size);
 	fi_param_get_size_t(&rxr_prov, "inter_read_segment_size",
 			    &rxr_env.efa_read_segment_size);
+
+	if (getenv("RDMAV_FORK_SAFE") || getenv("IBV_FORK_SAFE"))
+		efa_fork_status = EFA_FORK_SUPPORT_ON;
 }
 
 /*

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -77,8 +77,12 @@ struct rxr_env rxr_env = {
 	.efa_read_segment_size = 1073741824,
 };
 
+/* @brief Read and store the FI_EFA_* environment variables.
+ */
 static void rxr_init_env(void)
 {
+	int fork_safe = 0;
+
 	fi_param_get_int(&rxr_prov, "rx_window_size", &rxr_env.rx_window_size);
 	fi_param_get_int(&rxr_prov, "tx_max_credits", &rxr_env.tx_max_credits);
 	fi_param_get_int(&rxr_prov, "tx_min_credits", &rxr_env.tx_min_credits);
@@ -125,8 +129,9 @@ static void rxr_init_env(void)
 			    &rxr_env.efa_min_read_write_size);
 	fi_param_get_size_t(&rxr_prov, "inter_read_segment_size",
 			    &rxr_env.efa_read_segment_size);
+	fi_param_get_bool(&rxr_prov, "fork_safe", &fork_safe);
 
-	if (getenv("RDMAV_FORK_SAFE") || getenv("IBV_FORK_SAFE"))
+	if (fork_safe || getenv("RDMAV_FORK_SAFE") || getenv("IBV_FORK_SAFE"))
 		efa_fork_status = EFA_FORK_SUPPORT_ON;
 }
 
@@ -805,6 +810,8 @@ EFA_INI
 			"The mimimum message size for inter EFA write to use read write protocol. If firmware support RDMA read, and FI_EFA_USE_DEVICE_RDMA is 1, write requests whose size is larger than this value will use the read write protocol (Default 65536).");
 	fi_param_define(&rxr_prov, "inter_read_segment_size", FI_PARAM_INT,
 			"Calls to RDMA read is segmented using this value.");
+	fi_param_define(&rxr_prov, "fork_safe", FI_PARAM_BOOL,
+			"Enables fork support and disables internal usage of huge pages. (Default: false)");
 	rxr_init_env();
 
 #if HAVE_EFA_DL


### PR DESCRIPTION
This series allows applications to use fork again by disabling the internal use of huge pages when fork support is requested and the registration cache is enabled. Applications that require the registration of regions backed by huge pages, fork support, and the registration cache are still not supported and will cause the domain open to fail. That mode will be supported in the future when changes to the linux kernel makes rdma-core fork support irrelevant in general by copying pages into the fork.

For convenience a new environment variable, `FI_EFA_FORK_SAFE`, was also added here and will call `ibv_fork_init()` when set.

Test description: Set the new environment variable and the rdma-core environment variables and verified that huge pages are not used when fork support is not enabled. Also verified that the check still works when another library calls `ibv_fork_init()` directly. Verified setting `RDMAV_HUGEPAGES_SAFE` returns an error from domain open. Finally, I added a fork to MPI ring_c; the handler is triggered when fork support is disabled, and the test passes when fork support is enabled.