### PR TITLE
prov/psm3: Add PACK_SUFFIX define to missing header

### DIFF
--- a/prov/psm3/psm3/include/opa_user.h
+++ b/prov/psm3/psm3/include/opa_user.h
@@ -82,6 +82,11 @@
 #include "opa_udebug.h"
 #include "opa_service.h"
 
+#ifndef PACK_SUFFIX
+/* XXX gcc only */
+#define PACK_SUFFIX __attribute__((packed))
+#endif
+
 #define HFI_TF_NFLOWS                       32
 
 // The sender uses an RDMA Write with Immediate.  The immediate data


### PR DESCRIPTION
https://github.com/ofiwg/libfabric/issues/6614

Reviewed-by: Goldman, Adam <adam.goldman@intel.com>
Signed-off-by: Todd Rimmer <todd.rimmer@intel.com>