### PR TITLE
prov/sockets: use correct addrlen when walking through the addr array

### DIFF
--- a/prov/sockets/src/sock_av.c
+++ b/prov/sockets/src/sock_av.c
@@ -194,7 +194,7 @@ static int sock_av_get_next_index(struct sock_av *av)
 	return -1;
 }
 
-static int sock_check_table_in(struct sock_av *_av, const struct sockaddr *addr,
+static int sock_check_table_in(struct sock_av *_av, const void *addr,
 			       fi_addr_t *fi_addr, int count, uint64_t flags,
 			       void *context)
 {
@@ -215,9 +215,10 @@ static int sock_check_table_in(struct sock_av *_av, const struct sockaddr *addr,
 
 	if (_av->attr.flags & FI_READ) {
 		for (i = 0; i < count; i++) {
+			struct sockaddr *sock_addr = (struct sockaddr *) ((char *)addr + i * _av->addrlen);
 			for (j = 0; j < _av->table_hdr->size; j++) {
 				if (_av->table[j].valid &&
-				    !ofi_valid_dest_ipaddr(&addr[i])) {
+				    !ofi_valid_dest_ipaddr(sock_addr)) {
 					sock_av_report_error(_av, fi_addr,
 							context, i, FI_EINVAL,
 							flags);
@@ -225,8 +226,8 @@ static int sock_check_table_in(struct sock_av *_av, const struct sockaddr *addr,
 				}
 
 				av_addr = &_av->table[j];
-				if (memcmp(&av_addr->addr, &addr[i],
-					   ofi_sizeofaddr(&addr[i])) == 0) {
+				if (memcmp(&av_addr->addr, sock_addr,
+					   ofi_sizeofaddr(sock_addr)) == 0) {
 					SOCK_LOG_DBG("Found addr in shared av\n");
 					if (fi_addr)
 						fi_addr[i] = (fi_addr_t)j;
@@ -239,7 +240,8 @@ static int sock_check_table_in(struct sock_av *_av, const struct sockaddr *addr,
 	}
 
 	for (i = 0, ret = 0; i < count; i++) {
-		if (!ofi_valid_dest_ipaddr(&addr[i])) {
+		struct sockaddr *sock_addr = (struct sockaddr *) ((char *)addr + i * _av->addrlen);
+		if (!ofi_valid_dest_ipaddr(sock_addr)) {
 			sock_av_report_error(_av, fi_addr, context, i, FI_EINVAL,
 					     flags);
 			continue;
@@ -260,13 +262,13 @@ static int sock_check_table_in(struct sock_av *_av, const struct sockaddr *addr,
 		}
 
 		av_addr = &_av->table[index];
-		inet_ntop(addr[i].sa_family, ofi_get_ipaddr(&addr[i]),
+		inet_ntop(sock_addr->sa_family, ofi_get_ipaddr(sock_addr),
 			  sa_ip, sizeof sa_ip);
 		SOCK_LOG_DBG("AV-INSERT: dst_addr family: %d, IP %s, port: %d\n",
-			      (&addr[i])->sa_family, sa_ip,
-			      ofi_addr_get_port(&addr[i]));
+			      sock_addr->sa_family, sa_ip,
+			      ofi_addr_get_port(sock_addr));
 
-		memcpy(&av_addr->addr, &addr[i], ofi_sizeofaddr(&addr[i]));
+		memcpy(&av_addr->addr, sock_addr, ofi_sizeofaddr(sock_addr));
 		if (fi_addr)
 			fi_addr[i] = (fi_addr_t)index;
 
@@ -286,8 +288,7 @@ static int sock_av_insert(struct fid_av *av, const void *addr, size_t count,
 	_av = container_of(av, struct sock_av, av_fid);
 
 	fastlock_acquire(&_av->table_lock);
-	ret = sock_check_table_in(_av, (const struct sockaddr *) addr,
-				   fi_addr, count, flags, context);
+	ret = sock_check_table_in(_av, addr, fi_addr, count, flags, context);
 	fastlock_release(&_av->table_lock);
 	return ret;
 }


### PR DESCRIPTION
In sock_av_insert, the socket addresses stored in the addr arary can be
in different address formats (IPv4 or IPv6). Use the actual sock addrlen
stored in sock av when walking through the addr array, instead of
incorrectly assuming it is struct sockaddr.

Signed-off-by: Gengbin Zheng <gengbin.zheng@intel.com>