### PR TITLE
prov/psm3: Add check for avx2 to configure

### DIFF
--- a/config/fi_strip_optflags.m4
+++ b/config/fi_strip_optflags.m4
@@ -1,0 +1,62 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+dnl                         University Research and Technology
+dnl                         Corporation.  All rights reserved.
+dnl Copyright (c) 2004-2005 The University of Tennessee and The University
+dnl                         of Tennessee Research Foundation.  All rights
+dnl                         reserved.
+dnl Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+dnl                         University of Stuttgart.  All rights reserved.
+dnl Copyright (c) 2004-2005 The Regents of the University of California.
+dnl                         All rights reserved.
+dnl Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2008-2009 Sun Microsystems, Inc.  All rights reserved.
+dnl Copyright (c) 2014-2021 Intel, Inc. All rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+dnl
+dnl This file derived from config/opal_strip_optflags.m4 in Open MPI.
+dnl
+dnl Example Usage:
+dnl      FI_STRIP_OPTFLAGS($CFLAGS)
+dnl      CFLAGS_WITHOUT_OPTFLAGS="$s_result"
+
+AC_DEFUN([FI_STRIP_OPTFLAGS],[
+
+# Process a set of flags and remove all debugging and optimization
+# flags
+
+s_arg="$1"
+s_result=
+for s_word in $s_arg; do
+    # See http://www.gnu.org/software/autoconf/manual/html_node/Quadrigraphs.html#Quadrigraphs
+    # for an explanation of @<:@ and @:>@ -- they m4 expand to [ and ]
+    case $s_word in
+    -g)                 ;;
+    -g@<:@1-3@:>@)      ;;
+    +K@<:@0-5@:>@)      ;;
+    -O)                 ;;
+    -O@<:@0-9@:>@)      ;;
+    -xO)                ;;
+    -xO@<:@0-9@:>@)     ;;
+    -fast)              ;;
+    -finline-functions) ;;
+
+    # The below Sun Studio flags require or
+    # trigger -xO optimization
+    -xvector*)          ;;
+    -xdepend=yes)       ;;
+
+    *)     s_result="$s_result $s_word"
+    esac
+done
+
+# Clean up
+
+unset s_word s_arg])

--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,7 @@ AC_CONFIG_HEADERS(config.h)
 AM_INIT_AUTOMAKE([1.11 dist-bzip2 foreign -Wall -Werror subdir-objects parallel-tests tar-pax])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 m4_include(config/fi_check_package.m4)
+m4_include(config/fi_strip_optflags.m4)
 
 AC_CANONICAL_HOST
 

--- a/prov/psm3/Makefile.include
+++ b/prov/psm3/Makefile.include
@@ -29,7 +29,7 @@ _psm3_cppflags = \
 chksum_srcs = $(_psm3_files)
 
 if HAVE_PSM3_SRC
-_psm3_cflags = -mavx2
+_psm3_cflags =
 #include prov/psm3/psm3/Makefile.include
 _nodist_psm3_files = \
 	prov/psm3/src/psm3_revision.c


### PR DESCRIPTION
Minimal support is avx to enable psm3 provider

Remove avx2 from flags in makefile.

Signed-off-by: Goldman, Adam <adam.goldman@intel.com>