### PR TITLE
prov/psm3: Moved generation of psm3_revision.c to psm3 only target

### DIFF
--- a/prov/psm3/Makefile.include
+++ b/prov/psm3/Makefile.include
@@ -278,18 +278,23 @@ chksum_srcs += \
 _psm3_LIBS = libpsm3i.la
 libpsm3_la_DEPENDENCIES = libpsm3i.la
 
-all-local:
+BUILT_SOURCES = prov/psm3/src/psm3_revision.c
+
+prov/psm3/src/psm3_revision.c: prov/psm3/src/psm3_revision.ci
 	@echo "Building src checksum..."; \
 	chksum=`cat $(chksum_srcs) | sha1sum | cut -d' ' -f 1`; \
+	if [ ! -f prov/psm3/src/psm3_revision.c ]; then \
+		cp prov/psm3/src/psm3_revision.ci prov/psm3/src/psm3_revision.c; \
+	fi; \
 	if ! grep -q $$chksum prov/psm3/src/psm3_revision.c 2>/dev/null; then \
 		sed -i "/define PSMX3_SRC_CHECKSUM/s/\".*\"/\"$$chksum\"/" prov/psm3/src/psm3_revision.c; \
 		echo "SRC checksum updated to $$chksum"; \
+		timestamp=`date`; \
+		sed -i "/define PSMX3_BUILD_TIMESTAMP/s/\".*\"/\"$$timestamp\"/" prov/psm3/src/psm3_revision.c; \
+		echo "Updated build timestamp: $$timestamp"; \
 	else \
 		echo "SRC checksum not changed: $$chksum"; \
-	fi; \
-	timestamp=`date`; \
-	sed -i "/define PSMX3_BUILD_TIMESTAMP/s/\".*\"/\"$$timestamp\"/" prov/psm3/src/psm3_revision.c; \
-	echo "Updated build timestamp: $$timestamp"
+	fi
 
 endif HAVE_PSM3_SRC
 

--- a/prov/psm3/configure.m4
+++ b/prov/psm3/configure.m4
@@ -166,7 +166,7 @@ ifelse('
 		AS_IF([test $psm3_happy -eq 1], [
 			AC_CONFIG_FILES([prov/psm3/psm3/psm2_hal_inlines_i.h \
 		                 prov/psm3/psm3/psm2_hal_inlines_d.h \
-		                 prov/psm3/src/psm3_revision.c])
+		                 prov/psm3/src/psm3_revision.ci:prov/psm3/src/psm3_revision.c.in])
 		])
 	       ],[psm3_happy=0])
 

--- a/prov/psm3/src/.gitignore
+++ b/prov/psm3/src/.gitignore
@@ -1,1 +1,2 @@
 psm3_revision.c
+psm3_revision.ci


### PR DESCRIPTION
Udpated configure to generate psm3_revision.ci, a intermediate file,
from psm3_revision.c.in. Then make uses a psm3_revision.c target that
depends on the intermediate file, psm3_revision.ci, to generate the
checksum and timestamp.

Moved timestamp to only update if checksum does.

Signed-off-by: Goldman, Adam <adam.goldman@intel.com>