### PR TITLE
prov/efa: use shm provider to support cuda buffer

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -881,6 +881,8 @@ int rxr_ep_tx_init_mr_desc(struct rxr_domain *rxr_domain,
 			   struct rxr_tx_entry *tx_entry,
 			   int mr_iov_start, uint64_t access);
 
+void rxr_convert_desc_for_shm(int numdesc, void **desc);
+
 void rxr_prepare_desc_send(struct rxr_domain *rxr_domain,
 			   struct rxr_tx_entry *tx_entry);
 

--- a/prov/efa/src/rxr/rxr_atomic.c
+++ b/prov/efa/src/rxr/rxr_atomic.c
@@ -39,9 +39,10 @@
 #include "rxr_atomic.h"
 #include "rxr_pkt_cmd.h"
 
-static void rxr_atomic_copy_shm_msg(struct fi_msg_atomic *shm_msg,
+static void rxr_atomic_init_shm_msg(struct fi_msg_atomic *shm_msg,
 				    const struct fi_msg_atomic *msg,
-				    struct fi_rma_ioc *rma_iov)
+				    struct fi_rma_ioc *rma_iov,
+				    void **shm_desc)
 {
 	int i;
 
@@ -53,6 +54,14 @@ static void rxr_atomic_copy_shm_msg(struct fi_msg_atomic *shm_msg,
 		for (i = 0; i < msg->rma_iov_count; i++)
 			rma_iov[i].addr = 0;
 		shm_msg->rma_iov = rma_iov;
+	}
+
+	if (msg->desc) {
+		memcpy(shm_desc, msg->desc, msg->iov_count * sizeof(void *));
+		rxr_convert_desc_for_shm(msg->iov_count, shm_desc);
+		shm_msg->desc = shm_desc;
+	} else {
+		shm_msg->desc = NULL;
 	}
 }
 
@@ -225,6 +234,7 @@ rxr_atomic_inject(struct fid_ep *ep,
 		assert(rxr_ep->use_shm);
 		if (!(shm_info->domain_attr->mr_mode & FI_MR_VIRT_ADDR))
 			remote_addr = 0;
+
 		return fi_inject_atomic(rxr_ep->shm_ep, buf, count, peer->shm_fiaddr,
 					remote_addr, remote_key, datatype, op);
 	}
@@ -260,6 +270,7 @@ rxr_atomic_writemsg(struct fid_ep *ep,
 	struct rxr_ep *rxr_ep;
 	struct rxr_peer *peer;
 	struct fi_rma_ioc rma_iov[RXR_IOV_LIMIT];
+	void *shm_desc[RXR_IOV_LIMIT];
 
 	FI_DBG(&rxr_prov, FI_LOG_EP_DATA,
 	       "%s: iov_len: %lu flags: %lx\n",
@@ -269,7 +280,7 @@ rxr_atomic_writemsg(struct fid_ep *ep,
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
 	if (peer->is_local) {
 		assert(rxr_ep->use_shm);
-		rxr_atomic_copy_shm_msg(&shm_msg, msg, rma_iov);
+		rxr_atomic_init_shm_msg(&shm_msg, msg, rma_iov, shm_desc);
 		shm_msg.addr = peer->shm_fiaddr;
 		return fi_atomicmsg(rxr_ep->shm_ep, &shm_msg, flags);
 	}
@@ -331,7 +342,8 @@ rxr_atomic_readwritemsg(struct fid_ep *ep,
 	struct rxr_ep *rxr_ep;
 	struct rxr_peer *peer;
 	struct fi_msg_atomic shm_msg;
-	struct fi_rma_ioc rma_iov[RXR_IOV_LIMIT];
+	struct fi_rma_ioc shm_rma_iov[RXR_IOV_LIMIT];
+	void *shm_desc[RXR_IOV_LIMIT];
 	struct rxr_atomic_ex atomic_ex;
 	size_t datatype_size = ofi_datatype_size(msg->datatype);
 
@@ -342,7 +354,7 @@ rxr_atomic_readwritemsg(struct fid_ep *ep,
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
 	if (peer->is_local) {
 		assert(rxr_ep->use_shm);
-		rxr_atomic_copy_shm_msg(&shm_msg, msg, rma_iov);
+		rxr_atomic_init_shm_msg(&shm_msg, msg, shm_rma_iov, shm_desc);
 		shm_msg.addr = peer->shm_fiaddr;
 		return fi_fetch_atomicmsg(rxr_ep->shm_ep, &shm_msg,
 					  resultv, result_desc, result_count,
@@ -412,7 +424,8 @@ rxr_atomic_compwritemsg(struct fid_ep *ep,
 	struct rxr_ep *rxr_ep;
 	struct rxr_peer *peer;
 	struct fi_msg_atomic shm_msg;
-	struct fi_rma_ioc rma_iov[RXR_IOV_LIMIT];
+	struct fi_rma_ioc shm_rma_iov[RXR_IOV_LIMIT];
+	void *shm_desc[RXR_IOV_LIMIT];
 	struct rxr_atomic_ex atomic_ex;
 	size_t datatype_size = ofi_datatype_size(msg->datatype);
 
@@ -424,7 +437,7 @@ rxr_atomic_compwritemsg(struct fid_ep *ep,
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
 	if (peer->is_local) {
 		assert(rxr_ep->use_shm);
-		rxr_atomic_copy_shm_msg(&shm_msg, msg, rma_iov);
+		rxr_atomic_init_shm_msg(&shm_msg, msg, shm_rma_iov, shm_desc);
 		shm_msg.addr = peer->shm_fiaddr;
 		return fi_compare_atomicmsg(rxr_ep->shm_ep, &shm_msg,
 					    comparev, compare_desc, compare_count,

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -559,6 +559,30 @@ int rxr_ep_tx_init_mr_desc(struct rxr_domain *rxr_domain,
 	return ret;
 }
 
+/**
+ * @brief convert EFA descriptors to shm descriptors.
+ *
+ * Each provider defines its descriptors format. The descriptor for
+ * EFA provider is of struct efa_mr *, which shm provider cannot
+ * understand. This function convert EFA descriptors to descriptors
+ * shm can use.
+ *
+ * @param numdesc[in]       number of descriptors in the array
+ * @param desc[in,out]      descriptors input is EFA descriptor, output
+ *                          is shm descriptor.
+ */
+void rxr_convert_desc_for_shm(int numdesc, void **desc)
+{
+	int i;
+	struct efa_mr *efa_mr;
+
+	for (i = 0; i < numdesc; ++i) {
+		efa_mr = desc[i];
+		if (efa_mr)
+			desc[i] = fi_mr_desc(efa_mr->shm_mr);
+	}
+}
+
 void rxr_prepare_desc_send(struct rxr_domain *rxr_domain,
 			   struct rxr_tx_entry *tx_entry)
 {

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -268,6 +268,12 @@ void rxr_set_shm_hints(struct fi_info *shm_hints)
 	shm_hints->fabric_attr->name = strdup("shm");
 	shm_hints->fabric_attr->prov_name = strdup("shm");
 	shm_hints->ep_attr->type = FI_EP_RDM;
+
+#if HAVE_LIBCUDA
+	shm_hints->caps |= FI_HMEM;
+	shm_hints->domain_attr->mr_mode |= FI_MR_HMEM;
+#endif
+
 }
 
 /* Pass tx/rx attr that user specifies down to core provider */

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -176,8 +176,17 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 
 	if (peer->is_local) {
 		assert(rxr_ep->use_shm);
-		/* intra instance message */
-		if (tx_entry->total_len > max_rtm_data_size)
+		/* intra instance message
+		 *
+		 * Currently shm proivder does not support mixed memory type iov
+		 * (it will crash), which will happen is eager message protocol
+		 * is used for cuda buffer. An GitHub issue has been opened
+		 * regarding this
+		 *     https://github.com/ofiwg/libfabric/issues/6639
+		 * Before it is addressed, we use read message protocol for
+		 * all cuda messages
+		 */
+		if (tx_entry->total_len > max_rtm_data_size || efa_ep_is_cuda_mr(tx_entry->desc[0]))
 			/*
 			 * Read message support
 			 * FI_DELIVERY_COMPLETE implicitly.

--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -319,6 +319,17 @@ void rxr_pkt_entry_append(struct rxr_pkt_entry *dst,
 	dst->next = src;
 }
 
+/**
+ * @brief send a packet using lower provider
+ *
+ * @param ep[in]        rxr end point
+ * @param pkt_entry[in] packet entry to be sent
+ * @param msg[in]       information regarding that the send operation, such as
+ *                      memory buffer, remote EP address and local descriptor.
+ *                      If the shm provider is to be used. Remote EP address
+ *                      and local descriptor must be prepared for shm usage.
+ * @param flags[in]     flags to be passed on to lower provider's send.
+ */
 static inline
 ssize_t rxr_pkt_entry_sendmsg(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry,
 			      const struct fi_msg *msg, uint64_t flags)
@@ -362,12 +373,17 @@ ssize_t rxr_pkt_entry_sendv(struct rxr_ep *ep,
 	struct rxr_peer *peer;
 
 	msg.msg_iov = iov;
+	msg.addr = addr;
 	msg.desc = desc;
 	msg.iov_count = count;
 	peer = rxr_ep_get_peer(ep, addr);
-	msg.addr = (peer->is_local) ? peer->shm_fiaddr : addr;
 	msg.context = pkt_entry;
 	msg.data = 0;
+
+	if (peer->is_local) {
+		msg.addr = peer->shm_fiaddr;
+		rxr_convert_desc_for_shm(msg.iov_count, msg.desc);
+	}
 
 	return rxr_pkt_entry_sendmsg(ep, pkt_entry, &msg, flags);
 }

--- a/prov/efa/src/rxr/rxr_read.c
+++ b/prov/efa/src/rxr/rxr_read.c
@@ -179,6 +179,35 @@ ssize_t rxr_read_mr_reg(struct rxr_ep *ep, struct rxr_read_entry *read_entry)
 	return 0;
 }
 
+/**
+ * @brief convert descriptor from application for lower provider to use
+ *
+ * Each provider define its descriptors format. The descriptor provided
+ * by application is in EFA provider format.
+ * This function convert it to descriptors for lower provider according
+ * to lower provider type. It also handle the case application does not
+ * provider descriptors.
+ *
+ * @param lower_ep_type[in] lower efa type, can be EFA_EP or SHM_EP.
+ * @param numdesc[in]       number of descriptors in the array
+ * @param desc_in[in]       descriptors provided by application
+ * @param desc_out[out]     descriptors for lower provider.
+ */
+static inline
+void rxr_read_copy_desc(enum rxr_lower_ep_type lower_ep_type,
+			int numdesc, void **desc_in, void **desc_out)
+{
+	if (!desc_in) {
+		memset(desc_out, 0, numdesc * sizeof(void *));
+		return;
+	}
+
+	memcpy(desc_out, desc_in, numdesc * sizeof(void *));
+	if (lower_ep_type == SHM_EP) {
+		rxr_convert_desc_for_shm(numdesc, desc_out);
+	}
+}
+
 /* rxr_read_alloc_entry allocates a read entry.
  * It is called by rxr_read_post_or_queue().
  * Input:
@@ -229,10 +258,7 @@ struct rxr_read_entry *rxr_read_alloc_entry(struct rxr_ep *ep, int entry_type, v
 		total_rma_iov_len = ofi_total_rma_iov_len(tx_entry->rma_iov, tx_entry->rma_iov_count);
 		read_entry->total_len = MIN(total_iov_len, total_rma_iov_len);
 
-		if (tx_entry->desc) {
-			memcpy(read_entry->mr_desc, tx_entry->desc,
-			       read_entry->iov_count * sizeof(void *));
-		}
+		rxr_read_copy_desc(lower_ep_type, read_entry->iov_count, tx_entry->desc, read_entry->mr_desc);
 
 	} else {
 		rx_entry = (struct rxr_rx_entry *)x_entry;
@@ -255,10 +281,7 @@ struct rxr_read_entry *rxr_read_alloc_entry(struct rxr_ep *ep, int entry_type, v
 		total_rma_iov_len = ofi_total_rma_iov_len(rx_entry->rma_iov, rx_entry->rma_iov_count);
 		read_entry->total_len = MIN(total_iov_len, total_rma_iov_len);
 
-		if (rx_entry->desc) {
-			memcpy(read_entry->mr_desc, rx_entry->desc,
-			       read_entry->iov_count * sizeof(void *));
-		}
+		rxr_read_copy_desc(lower_ep_type, read_entry->iov_count, rx_entry->desc, read_entry->mr_desc);
 	}
 
 	memset(read_entry->mr, 0, read_entry->iov_count * sizeof(struct fid_mr *));
@@ -378,7 +401,7 @@ int rxr_read_post_local_read_or_queue(struct rxr_ep *ep,
 	assert(rx_entry->desc && efa_ep_is_cuda_mr(rx_entry->desc[0]));
 	read_entry->iov_count = rx_entry->iov_count;
 	memcpy(read_entry->iov, rx_entry->iov, rx_entry->iov_count * sizeof(struct iovec));
-	memcpy(read_entry->mr_desc, rx_entry->desc, rx_entry->iov_count * sizeof(void *));
+	rxr_read_copy_desc(EFA_EP, rx_entry->iov_count, rx_entry->desc, read_entry->mr_desc);
 	ofi_consume_iov_desc(read_entry->iov, read_entry->mr_desc, &read_entry->iov_count, data_offset);
 	if (read_entry->iov_count == 0) {
 		FI_WARN(&rxr_prov, FI_LOG_CQ,

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -188,6 +188,8 @@ size_t rxr_rma_post_shm_write(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_ent
 	msg.rma_iov_count = tx_entry->rma_iov_count;
 	msg.context = pkt_entry;
 	msg.data = tx_entry->cq_entry.data;
+	msg.desc = tx_entry->desc;
+	rxr_convert_desc_for_shm(msg.iov_count, tx_entry->desc);
 
 	err = fi_writemsg(rxr_ep->shm_ep, &msg, tx_entry->fi_flags);
 	if (err)


### PR DESCRIPTION
This PR contain 3 patches that fix several issues when using shm provider to support cuda buffer:

1.  request the FI_HMEM capability in cuda build
2. fix a bug the wrong descriptor was used for shm provider
3. do not use eager protocol for cuda buffer and local peer.

Signed-off-by: Wei Zhang <wzam@amazon.com>