### PR TITLE
prov/shm: use ofi_copy_hmem_iov to handl smr_src_inject

### DIFF
--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -133,8 +133,9 @@ static int smr_progress_resp_entry(struct smr_ep *ep, struct smr_resp *resp,
 
 		src = pending->cmd.msg.hdr.op == ofi_op_atomic_compare ?
 		      tx_buf->buf : tx_buf->data;
-		pending->bytes_done = ofi_copy_to_iov(pending->iov, pending->iov_count,
-				       0, src, pending->cmd.msg.hdr.size);
+		pending->bytes_done = ofi_copy_to_hmem_iov(pending->iface, pending->device,
+							   pending->iov, pending->iov_count,
+							   0, src, pending->cmd.msg.hdr.size);
 
 		if (pending->bytes_done != pending->cmd.msg.hdr.size) {
 			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,


### PR DESCRIPTION
This path uses ofi_copy_to_hmem_iov to copy data to pending->iov.
This is to handle the case when pending->iov is backed by cuda
memory.

Signed-off-by: Wei Zhang <wzam@amazon.com>