### PR TITLE
prov/efa: fix a bug in rxr_pkt_entry_release_tx()

### DIFF
--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -110,9 +110,14 @@ struct rxr_pkt_entry *rxr_pkt_entry_alloc(struct rxr_ep *ep,
 	return pkt_entry;
 }
 
-static
-void rxr_pkt_entry_release_single_tx(struct rxr_ep *ep,
-				     struct rxr_pkt_entry *pkt)
+/**
+ * @brief release a TX packet entry
+ *
+ * @param[in]     ep  the end point
+ * @param[in,out] pkt the pkt_entry to be released
+ */
+void rxr_pkt_entry_release_tx(struct rxr_ep *ep,
+			      struct rxr_pkt_entry *pkt)
 {
 	struct rxr_peer *peer;
 
@@ -140,18 +145,6 @@ void rxr_pkt_entry_release_single_tx(struct rxr_ep *ep,
 #endif
 	pkt->state = RXR_PKT_ENTRY_FREE;
 	ofi_buf_free(pkt);
-}
-
-void rxr_pkt_entry_release_tx(struct rxr_ep *ep,
-			      struct rxr_pkt_entry *pkt_entry)
-{
-	struct rxr_pkt_entry *next;
-
-	while (pkt_entry) {
-		next = pkt_entry->next;
-		rxr_pkt_entry_release_single_tx(ep, pkt_entry);
-		pkt_entry = next;
-	}
 }
 
 /*


### PR DESCRIPTION
Currently, rx_pkt_entry_release_tx() call
rxr_pkt_entry_release_single_tx() in a loop to release
packet entries linked by pkt_entry->next. This is wrong
because TX pkt_entry are not linked.

This patch address the issue by removing the loop
and merge rxr_pkt_entry_release_tx() into
rxr_pkt_entry_release_single_tx().

Signed-off-by: Wei Zhang <wzam@amazon.com>