### PR TITLE
man/cq: Document completion semantics around HMEM

### DIFF
--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -718,16 +718,26 @@ data into target memory for RMA and atomic operations.  Data ordering
 is separate, but dependent on message ordering (defined below).  Data
 ordering is unspecified where message order is not defined.
 
-Data ordering refers to the access of target memory by subsequent
+Data ordering refers to the access of the same target memory by subsequent
 operations.  When back to back RMA read or write operations access the
 same registered memory location, data ordering indicates whether the
 second operation reads or writes the target memory after the first
-operation has completed.  Because RMA ordering applies between two
-operations, and not within a single data transfer, ordering is defined
-per byte-addressable memory location.  I.e.  ordering specifies
+operation has completed.  For example, will an RMA read that follows
+an RMA write read back the data that was written?  Similarly, will an
+RMA write that follows an RMA read update the target buffer after the
+read has transferred the original data?  Data ordering answers these
+questions, even in the presence of errors, such as the need to resend
+data because of lost or corrupted network traffic.
+
+RMA ordering applies between two operations, and not within a single
+data transfer.  Therefore, ordering is defined
+per byte-addressable memory location.  I.e. ordering specifies
 whether location X is accessed by the second operation after the first
 operation.  Nothing is implied about the completion of the first
-operation before the second operation is initiated.
+operation before the second operation is initiated.  For example, if
+the first operation updates locations X and Y, but the second operation
+only accesses location X, there are no guarantees defined relative to
+location Y and the second operation.
 
 In order to support large data transfers being broken into multiple packets
 and sent using multiple paths through the fabric, data ordering may be

--- a/man/fi_mr.3.md
+++ b/man/fi_mr.3.md
@@ -667,6 +667,46 @@ The follow flag may be specified to any memory registration call.
   specified if persistent completion semantics or persistent data transfers
   are required when accessing the registered region.
 
+# MEMORY DOMAINS
+
+Memory domains identify the physical separation of memory which
+may or may not be accessible through the same virtual address space.
+Traditionally, applications only dealt with a single memory domain,
+that of host memory tightly coupled with the system CPUs.  With
+the introduction of device and non-uniform memory subsystems,
+applications often need to be aware of which memory domain a particular
+virtual address maps to.
+
+As a general rule, separate physical devices can be considered to have
+their own memory domains.  For example, a NIC may have user accessible
+memory, and would be considered a separate memory domain from memory
+on a GPU.  Both the NIC and GPU memory domains are separate from host
+system memory.  Individual GPUs or computation accelerators may have
+distinct memory domains, or may be connected in such a way (e.g. a GPU
+specific fabric) that all GPUs would belong to the same memory domain.
+Unfortunately, identifying memory domains is specific to each
+system and its physical and/or virtual configuration.
+
+Understanding memory domains in heterogenous memory environments is
+important as it can impact data ordering and visibility as viewed
+by an application.  It is also important to understand which memory
+domain an application is most tightly coupled to.  In most cases,
+applications are tightly coupled to host memory.  However, an
+application running directly on a GPU or NIC may be more tightly
+coupled to memory associated with those devices.
+
+Memory regions are often associated with a single memory domain.
+The domain is often indicated by the fi_mr_attr iface and device
+fields.  Though it is possible for physical pages backing a virtual
+memory region to migrate between memory domains based on access patterns.
+For example, the physical pages referenced by a virtual address range
+could migrate between host memory and GPU memory, depending on which
+computational unit is actively using it.
+
+See the [`fi_endpoint`(3)](fi_endpoint.3.html) and [`fi_cq`(3)](fi_cq.3.html)
+man pages for addition discussion on message, data, and completion ordering
+semantics, including the impact of memory domains.
+
 # RETURN VALUES
 
 Returns 0 on success.  On error, a negative value corresponding to

--- a/man/fi_msg.3.md
+++ b/man/fi_msg.3.md
@@ -274,9 +274,14 @@ fi_sendmsg.
   generated when the source buffer(s) may be reused.
 
 *FI_TRANSMIT_COMPLETE*
-: Applies to fi_sendmsg.  Indicates that a completion should not be
-  generated until the operation has been successfully transmitted and
-  is no longer being tracked by the provider.
+: Applies to fi_sendmsg and fi_recvmsg.  For sends, indicates that a
+  completion should not be generated until the operation has been
+  successfully transmitted and is no longer being tracked by the provider.
+  For receive operations, indicates that a completion may be generated
+  as soon as the message has been processed by the local provider,
+  even if the message data may not be visible to all processing
+  elements.  See [`fi_cq`(3)](fi_cq.3.html) for target side completion
+  semantics.
 
 *FI_DELIVERY_COMPLETE*
 : Applies to fi_sendmsg.  Indicates that a completion should be


### PR DESCRIPTION
Greatly expand the semantics around completions and target
side visibility of the data.  No attempt is being made to
define new behavior of the APIs here.  Rather it should be
describing the behavior that applications are already seeing,
but developers may not be fully aware of.

The visibility of transfer at the target is defined, with
additional descriptions for how applications must handle
heterogenous memory.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>