### PR TITLE
prov/efa: support FI_HMEM and FI_LOCAL_COMM together

### DIFF
--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1812,6 +1812,23 @@ bool rxr_ep_use_shm(struct fi_info *info)
 	    && !(info->caps & FI_LOCAL_COMM))
 		return 0;
 
+	/*
+	 * Currently, shm provider uses the SAR protocol for cuda
+	 * memory buffer, whose performance is worse than using EFA device.
+	 *
+	 * To address this issue, shm usage is disabled if application
+	 * requested the FI_HMEM capablity.
+	 *
+	 * This is not ideal, because host memory commuications are
+	 * also going through device.
+	 *
+	 * The long term fix is make shm provider to support cuda
+	 * buffers through cuda IPC. Once that is implemented, the
+	 * following two lines need to be removed.
+	 */
+	if (info && (info->caps & FI_HMEM))
+		return 0;
+
 	return rxr_env.enable_shm_transfer;
 }
 

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -405,17 +405,6 @@ static int rxr_info_to_rxr(uint32_t version, const struct fi_info *core_info,
 		 * which means FI_MR_HMEM implies FI_MR_LOCAL for cuda buffer
 		 */
 		if (hints->caps & FI_HMEM) {
-			/*
-			 * XXX: remove this once CUDA IPC is supported by SHM
-			 * and we have a fallback path to use the device when
-			 * SHM doesn't support CUDA IPC.
-			 */
-			if (hints->caps & FI_LOCAL_COMM) {
-				FI_WARN(&rxr_prov, FI_LOG_CORE,
-				        "FI_HMEM is currently not supported by the EFA provider when FI_LOCAL_COMM is requested.\n");
-				return -FI_ENODATA;
-			}
-			info->caps &= ~FI_LOCAL_COMM;
 
 			if (!efa_device_support_rdma_read()) {
 				FI_WARN(&rxr_prov, FI_LOG_CORE,


### PR DESCRIPTION
This PR contains two commits that enable efa provider to support FI_HMEM and FI_LOCAL_COMM.

1. disable shm provider usage when application request FI_HMEM capability
2. revert the commit that exclude EFA if application requested FI_HMEM and FI_LOCAL_COMM.