### PR TITLE
prov/efa: enable mr cache for cuda memory

### DIFF
--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -213,6 +213,7 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 	int ret;
 	struct ofi_mem_monitor *memory_monitors[OFI_HMEM_MAX] = {
 		[FI_HMEM_SYSTEM] = uffd_monitor,
+		[FI_HMEM_CUDA] = cuda_monitor,
 	};
 
 	fi = efa_get_efa_info(info->domain_attr->name);

--- a/prov/efa/src/rxr/rxr_domain.c
+++ b/prov/efa/src/rxr/rxr_domain.c
@@ -97,9 +97,6 @@ int rxr_mr_regattr(struct fid *domain_fid, const struct fi_mr_attr *attr,
 	rxr_domain = container_of(domain_fid, struct rxr_domain,
 				  util_domain.domain_fid.fid);
 
-	if (attr->iface == FI_HMEM_CUDA)
-		flags |= OFI_MR_NOCACHE;
-
 	ret = fi_mr_regattr(rxr_domain->rdm_domain, attr, flags, mr);
 	if (ret) {
 		FI_WARN(&rxr_prov, FI_LOG_MR,


### PR DESCRIPTION
Currently, EFA's mr cache does not support cuda memory, thus
during memory registration, the OFI_MR_NOCACHE flag was added
to prevent MR cache being used for cuda memory.

This patch address the issue by first add cuda memory mointor
to efa's mr cache so it can support cuda memory, then stop
adding the OFI_MR_NOCACHE flag to cuda memory

Signed-off-by: Wei Zhang <wzam@amazon.com>