### PR TITLE
prov/verbs: Fix XRC MOFED 5.2 incompatibility issue

### DIFF
--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -58,6 +58,7 @@ static int vrb_create_ini_qp(struct vrb_xrc_ep *ep)
 	attr_ex.comp_mask = IBV_QP_INIT_ATTR_PD;
 	attr_ex.pd = domain->pd;
 	attr_ex.qp_context = domain;
+	attr_ex.srq = NULL;
 
 	ret = rdma_create_qp_ex(ep->base_ep.id, &attr_ex);
 	if (ret) {


### PR DESCRIPTION
MOFED 5.2 and newer linux kernels validate that XRC INI
QP init attributes do not include an SRQ. Adjust XRC INI
QP creation to account for this. This is backwards
compatible with older MOFED versions that didn't have this
additional INI QP check.

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>