### PR TITLE
[v1.12.x] core: Move efa provider ahead of psmX providers

### DIFF
--- a/src/fabric.c
+++ b/src/fabric.c
@@ -362,7 +362,7 @@ static struct ofi_prov *ofi_create_prov_entry(const char *prov_name)
 static void ofi_ordered_provs_init(void)
 {
 	char *ordered_prov_names[] = {
-		"psm3", "psm2", "psm", "efa", "usnic", "gni", "bgq", "verbs",
+		"efa", "psm3", "psm2", "psm", "usnic", "gni", "bgq", "verbs",
 		"netdir", "ofi_rxm", "ofi_rxd", "shm",
 		/* Initialize the socket based providers last of the
 		 * standard providers.  This will result in them being


### PR DESCRIPTION
Because EFA supports UD QPs through verbs, the psm3 provider
tries to use it, but fails.  The reason for the failure is
still being investigated.  But anywhere efa can execute, it
should have priority over being matched with another provider.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>