### PR TITLE
[v1.12.x] core: Shift psm3 priority

### DIFF
--- a/src/fabric.c
+++ b/src/fabric.c
@@ -362,8 +362,8 @@ static struct ofi_prov *ofi_create_prov_entry(const char *prov_name)
 static void ofi_ordered_provs_init(void)
 {
 	char *ordered_prov_names[] = {
-		"efa", "psm3", "psm2", "psm", "usnic", "gni", "bgq", "verbs",
-		"netdir", "ofi_rxm", "ofi_rxd", "shm",
+		"efa", "psm2", "psm", "usnic", "gni", "bgq", "verbs",
+		"netdir", "psm3", "ofi_rxm", "ofi_rxd", "shm",
 		/* Initialize the socket based providers last of the
 		 * standard providers.  This will result in them being
 		 * the least preferred providers.


### PR DESCRIPTION
Because psm3 can run over OPA hardware, it shows up first in
fi_getinfo.  Move psm2 ahead of psm3, since psm2 is tied to
specific HW.

PSM3 is closest to util providers, such as rxm or rxd.  Set
it's default priority to just ahead of those providers.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>