### PR TITLE
[v1.12.x] efa: bug fixes to support cuda buffer

### DIFF
--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -213,6 +213,7 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 	int ret;
 	struct ofi_mem_monitor *memory_monitors[OFI_HMEM_MAX] = {
 		[FI_HMEM_SYSTEM] = uffd_monitor,
+		[FI_HMEM_CUDA] = cuda_monitor,
 	};
 
 	fi = efa_get_efa_info(info->domain_attr->name);

--- a/prov/efa/src/rxr/rxr_domain.c
+++ b/prov/efa/src/rxr/rxr_domain.c
@@ -97,9 +97,6 @@ int rxr_mr_regattr(struct fid *domain_fid, const struct fi_mr_attr *attr,
 	rxr_domain = container_of(domain_fid, struct rxr_domain,
 				  util_domain.domain_fid.fid);
 
-	if (attr->iface == FI_HMEM_CUDA)
-		flags |= OFI_MR_NOCACHE;
-
 	ret = fi_mr_regattr(rxr_domain->rdm_domain, attr, flags, mr);
 	if (ret) {
 		FI_WARN(&rxr_prov, FI_LOG_MR,

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1812,6 +1812,23 @@ bool rxr_ep_use_shm(struct fi_info *info)
 	    && !(info->caps & FI_LOCAL_COMM))
 		return 0;
 
+	/*
+	 * Currently, shm provider uses the SAR protocol for cuda
+	 * memory buffer, whose performance is worse than using EFA device.
+	 *
+	 * To address this issue, shm usage is disabled if application
+	 * requested the FI_HMEM capablity.
+	 *
+	 * This is not ideal, because host memory commuications are
+	 * also going through device.
+	 *
+	 * The long term fix is make shm provider to support cuda
+	 * buffers through cuda IPC. Once that is implemented, the
+	 * following two lines need to be removed.
+	 */
+	if (info && (info->caps & FI_HMEM))
+		return 0;
+
 	return rxr_env.enable_shm_transfer;
 }
 

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -405,17 +405,6 @@ static int rxr_info_to_rxr(uint32_t version, const struct fi_info *core_info,
 		 * which means FI_MR_HMEM implies FI_MR_LOCAL for cuda buffer
 		 */
 		if (hints->caps & FI_HMEM) {
-			/*
-			 * XXX: remove this once CUDA IPC is supported by SHM
-			 * and we have a fallback path to use the device when
-			 * SHM doesn't support CUDA IPC.
-			 */
-			if (hints->caps & FI_LOCAL_COMM) {
-				FI_WARN(&rxr_prov, FI_LOG_CORE,
-				        "FI_HMEM is currently not supported by the EFA provider when FI_LOCAL_COMM is requested.\n");
-				return -FI_ENODATA;
-			}
-			info->caps &= ~FI_LOCAL_COMM;
 
 			if (!efa_device_support_rdma_read()) {
 				FI_WARN(&rxr_prov, FI_LOG_CORE,


### PR DESCRIPTION
This PR contains 3 fixes to EFA provider to support cuda buffer:
1. do not use shm provider when application request FI_HMEM capability
2. revert "exclude EFA when FI_HMEM and FI_LOCAL_COMM have been requested
3. enable MR cache for cuda memory