### PR TITLE
configure.ac: Fix non-POSIX syntax.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -157,7 +157,7 @@ AC_ARG_WITH([dlopen],
 		       [dl-loadable provider support @<:@default=yes@:>@]),
 	)
 
-if test "$freebsd" == "0"; then
+if test "$freebsd" = "0"; then
 AS_IF([test x"$with_dlopen" != x"no"], [
 AC_CHECK_LIB(dl, dlopen, [],
     AC_MSG_ERROR([dlopen not found.  libfabric requires libdl.]))
@@ -520,7 +520,7 @@ AC_ARG_ENABLE([cuda-dlopen],
         [Enable dlopen of CUDA libraries @<:@default=no@:>@])
     ],
     [
-        AS_IF([test "$freebsd" == "0"], [
+        AS_IF([test "$freebsd" = "0"], [
             AC_CHECK_LIB(dl, dlopen, [],
                 [AC_MSG_ERROR([dlopen not found.  libfabric requires libdl.])])
         ])
@@ -558,7 +558,7 @@ AC_ARG_ENABLE([memhooks-monitor],
 AC_DEFINE_UNQUOTED(ENABLE_MEMHOOKS_MONITOR, [$enable_memhooks],
 	[Define to 1 to enable memhooks memory monitor])
 
-AS_IF([test "$enable_memhooks" == "1"], [
+AS_IF([test "$enable_memhooks" = "1"], [
 	AC_CHECK_FUNCS([__curbrk __clear_cache])
 	AC_CHECK_HEADERS([linux/mman.h sys/syscall.h])
 	AC_CHECK_DECLS([__syscall], [], [], [#include <sys/syscall.h>])
@@ -602,13 +602,13 @@ AC_ARG_WITH([gdrcopy],
 			    and runtime libraries are installed.])],
 	    [], [])
 
-AS_IF([test -n "$with_gdrcopy" && test x"$with_gdrcopy" != x"no" && test "$have_libcuda" == "0"],
+AS_IF([test -n "$with_gdrcopy" && test x"$with_gdrcopy" != x"no" && test "$have_libcuda" = "0"],
 	[AC_MSG_ERROR([gdrcopy is requested but cuda is not requested or cuda runtime is not available.])],
 	[])
 
 have_gdrcopy=0
-AS_IF([test "$have_libcuda" == "1" && test x"$with_gdrcopy" != x"no"],
-	[AS_IF([test x"$with_gdrcopy" == x"yes"],[gdrcopy_dir=""],[gdrcopy_dir=$with_gdrcopy])
+AS_IF([test "$have_libcuda" = "1" && test x"$with_gdrcopy" != x"no"],
+	[AS_IF([test x"$with_gdrcopy" = x"yes"],[gdrcopy_dir=""],[gdrcopy_dir=$with_gdrcopy])
 	 FI_CHECK_PACKAGE([gdrcopy],
 			  [gdrapi.h],
 			  [gdrapi],
@@ -632,7 +632,7 @@ AC_ARG_ENABLE([gdrcopy-dlopen],
         [Enable dlopen of gdrcopy libraries @<:@default=no@:>@])
     ],
     [
-        AS_IF([test "$freebsd" == "0"], [
+        AS_IF([test "$freebsd" = "0"], [
             AC_CHECK_LIB(dl, dlopen, [],
                 [AC_MSG_ERROR([dlopen not found.  libfabric requires libdl.])])
         ])
@@ -657,7 +657,7 @@ AC_ARG_ENABLE([rocr-dlopen],
         [Enable dlopen of ROCR libraries @<:@default=no@:>@])
     ],
     [
-        AS_IF([test "$freebsd" == "0"], [
+        AS_IF([test "$freebsd" = "0"], [
             AC_CHECK_LIB(dl, dlopen, [],
                 [AC_MSG_ERROR([dlopen not found.  libfabric requires libdl.])])
         ])
@@ -739,7 +739,7 @@ fi
 
 for i in $PROVIDERS_TO_BUILD; do
 	v=${i}_dl
-	if test `eval echo \\$${v}` == "1"; then
+	if test `eval echo \\$${v}` = "1"; then
 		dso="$i ${dso}"
 	else
 		builtin="$i ${builtin}"


### PR DESCRIPTION
When building libfabric with a minimal shell such as `dash` it will fail.
```
export CONFIG_SHELL=/bin/dash
```
```
./configure: 39333: test: 0: unexpected operator
./configure: 39333: test: 0: unexpected operator
./configure: 39333: test: 0: unexpected operator
./configure: 39333: test: 0: unexpected operator
./configure: 39333: test: 0: unexpected operator
./configure: 39333: test: 0: unexpected operator
./configure: 39333: test: 0: unexpected operator
./configure: 39333: test: 0: unexpected operator
./configure: 39333: test: 0: unexpected operator
./configure: 39333: test: 0: unexpected operator
```
```
/bin/dash ./libtool  --tag=CC   --mode=link clang -Wall -O2 -DNDEBUG -fvisibility=hidden -Wall -Wundef -Wpointer-arith   -o util/fi_info util/info.o src/libfabric.la -latomic -lrt -lpthread     
libtool: link: clang -Wall -O2 -DNDEBUG -fvisibility=hidden -Wall -Wundef -Wpointer-arith -o util/.libs/fi_info util/info.o  src/.libs/libfabric.so -latomic -lrt -lpthread -Wl,-rpath -Wl,/usr/local/lib
/usr/bin/ld: src/.libs/libfabric.so: undefined reference to `dlsym'
clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
make[1]: *** [Makefile:10119: util/fi_info] Error 1
make[1]: Leaving directory '/tmp/libfabric'
make: *** [Makefile:6165: all] Error 2
```
This is because `configure.ac` which is used to generate the `configure` shell script contains several instances of `==` which is not portable shell, they should use just `=` instead which works everywhere.

Full build log: [libfabric.log](https://github.com/ofiwg/libfabric/files/6168037/libfabric.log)

Please also see this downstream issue: https://bugs.gentoo.org/776652
