### PR TITLE
configure.m4: Fix non-POSIX syntax.

### DIFF
--- a/prov/bgq/configure.m4
+++ b/prov/bgq/configure.m4
@@ -72,7 +72,7 @@ AC_DEFUN([FI_BGQ_CONFIGURE],[
 				],
 				[bgq_external_source=$with_bgq_src])
 
-			AS_IF([test x"$bgq_external_source" == x"auto"], [
+			AS_IF([test x"$bgq_external_source" = x"auto"], [
 				for bgq_dir in `ls -r /bgsys/source`; do
 					AC_MSG_CHECKING([for bgq opensource distribution])
 					AS_IF([test -f /bgsys/source/$bgq_dir/spi/src/kernel/cnk/memory_impl.c],
@@ -80,7 +80,7 @@ AC_DEFUN([FI_BGQ_CONFIGURE],[
 						AC_MSG_RESULT([$bgq_external_source])
 						break)
 				done
-				AS_IF([test x"$bgq_external_source" == x"auto"], [
+				AS_IF([test x"$bgq_external_source" = x"auto"], [
 					bgq_happy=0
 					AC_MSG_RESULT([no])])
 			])

--- a/prov/efa/configure.m4
+++ b/prov/efa/configure.m4
@@ -29,7 +29,7 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 		],
 		[efa_h_enable_poisoning=$enableval],
 		[efa_h_enable_poisoning=no])
-	AS_IF([test x"$efa_h_enable_poisoning" == x"yes"],
+	AS_IF([test x"$efa_h_enable_poisoning" = x"yes"],
 		[AC_DEFINE([ENABLE_EFA_POISONING], [1],
 			[EFA memory poisoning support for debugging])],
 		[])

--- a/prov/gni/configure.m4
+++ b/prov/gni/configure.m4
@@ -87,7 +87,7 @@ AC_DEFUN([FI_GNI_CONFIGURE],[
                                  ],
                                  [ugni_lib_happy=0])
 
-               AS_IF([test x"$enable_ugni_static" == x"yes" && test $ugni_lib_happy -eq 1],
+               AS_IF([test x"$enable_ugni_static" = x"yes" && test $ugni_lib_happy -eq 1],
                      [gni_LDFLAGS=$(echo $gni_LDFLAGS | sed -e 's/lugni/l:libugni.a/')],[])
 
                FI_PKG_CHECK_MODULES_STATIC([CRAY_ALPS_LLI], [cray-alpslli],

--- a/prov/hook/hook_debug/configure.m4
+++ b/prov/hook/hook_debug/configure.m4
@@ -12,7 +12,7 @@ AC_DEFUN([FI_HOOK_DEBUG_CONFIGURE],[
     # Determine if we can support the debug hooking provider
     hook_debug_happy=0
     AS_IF([test x"$enable_hook_debug" != x"no"], [hook_debug_happy=1])
-    AS_IF([test x"$hook_debug_dl" == x"1"], [
+    AS_IF([test x"$hook_debug_dl" = x"1"], [
 	hook_debug_happy=0
 	AC_MSG_ERROR([debug hooking provider cannot be compiled as DL])
     ])

--- a/prov/hook/perf/configure.m4
+++ b/prov/hook/perf/configure.m4
@@ -12,7 +12,7 @@ AC_DEFUN([FI_PERF_CONFIGURE],[
     # Determine if we can support the perf hooking provider
     perf_happy=0
     AS_IF([test x"$enable_perf" != x"no"], [perf_happy=1])
-    AS_IF([test x"$perf_dl" == x"1"], [
+    AS_IF([test x"$perf_dl" = x"1"], [
 	perf_happy=0
 	AC_MSG_ERROR([perf provider cannot be compiled as DL])
     ])


### PR DESCRIPTION
See: https://github.com/ofiwg/libfabric/pull/6646