### PR TITLE
[v1.12.x] prov/efa: Re-post handshake packet failed with EAGAIN previously

### DIFF
--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -339,6 +339,7 @@ int efa_av_insert_addr(struct efa_av *av, struct efa_ep_addr *addr,
 		util_ep = container_of(ep_list_entry, struct util_ep, av_entry);
 		rxr_ep = container_of(util_ep, struct rxr_ep, util_ep);
 		peer = rxr_ep_get_peer(rxr_ep, *fi_addr);
+		peer->efa_fiaddr = *fi_addr;
 		peer->is_self = efa_is_same_addr((struct efa_ep_addr *)rxr_ep->core_addr,
 						 addr);
 	}

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -867,8 +867,8 @@ void rxr_pkt_handle_recv_completion(struct rxr_ep *ep,
 #endif
 #endif
 	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
-	if (!(peer->flags & RXR_PEER_HANDSHAKE_SENT))
-		rxr_pkt_post_handshake(ep, peer, pkt_entry->addr);
+	if (!(peer->flags & RXR_PEER_HANDSHAKE_SENT_OR_QUEUED))
+		rxr_pkt_post_handshake_or_queue(ep, peer);
 
 	if (peer->is_local) {
 		assert(ep->use_shm);

--- a/prov/efa/src/rxr/rxr_pkt_type.h
+++ b/prov/efa/src/rxr/rxr_pkt_type.h
@@ -157,9 +157,10 @@ ssize_t rxr_pkt_init_handshake(struct rxr_ep *ep,
 			       struct rxr_pkt_entry *pkt_entry,
 			       fi_addr_t addr);
 
-void rxr_pkt_post_handshake(struct rxr_ep *ep,
-			    struct rxr_peer *peer,
-			    fi_addr_t addr);
+ssize_t rxr_pkt_post_handshake(struct rxr_ep *ep, struct rxr_peer *peer);
+
+void rxr_pkt_post_handshake_or_queue(struct rxr_ep *ep,
+				     struct rxr_peer *peer);
 
 void rxr_pkt_handle_handshake_recv(struct rxr_ep *ep,
 				   struct rxr_pkt_entry *pkt_entry);


### PR DESCRIPTION
Currently, when using extra feature (e.g., DELIEVERY_COMPLETE),
the sender triggers a handshake procedure, and won't proceed
futher until receiving the handshake packet from the peer.
However, if posting handshake packet fails at peer side, the
sender will keep waiting, which results in hanging issue.

This patch fixes the issue by
1. queuing the peers to which we previously fail to post
   handshake packet with EAGAIN error.
2. re-posting the handshake packet to those queued peers later.

Signed-off-by: Jie Zhang <zhngaj@amazon.com>