### PR TITLE
configure, fabtests/configure: fix ze configure checks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -533,6 +533,7 @@ AC_ARG_WITH([ze],
 					 libraries and headers are installed.]),
 	[], [])
 
+have_ze=0
 AS_IF([test x"$with_ze" != x"no"],
       [FI_CHECK_PACKAGE([ze],
 			[level_zero/ze_api.h],
@@ -541,12 +542,22 @@ AS_IF([test x"$with_ze" != x"no"],
 			[],
 			[$with_ze],
 			[],
-			[AC_DEFINE([HAVE_LIBZE], [1],[ZE support])],
+			[have_ze=1],
 			[], [])
        CPPFLAGS="$CPPFLAGS $ze_CPPFLAGS"
        LDFLAGS="$LDFLAGS $ze_LDFLAGS"
        LIBS="$LIBS $ze_LIBS"],
       [])
+
+AS_IF([test "$have_ze" = "1"],
+      [AC_CHECK_HEADER(drm/i915_drm.h, [], [have_ze=0])]
+      [])
+
+AS_IF([test x"$with_ze" != x"no" && test -n "$with_ze" && test "$have_ze" = "0" ],
+	[AC_MSG_ERROR([ZE support requested but ZE runtime not available.])],
+	[])
+
+AC_DEFINE_UNQUOTED([HAVE_LIBZE], [$have_ze], [ZE support])
 
 enable_memhooks=1
 AC_ARG_ENABLE([memhooks-monitor],

--- a/fabtests/common/hmem_ze.c
+++ b/fabtests/common/hmem_ze.c
@@ -36,7 +36,7 @@
 
 #include "hmem.h"
 
-#ifdef HAVE_LIBZE
+#if HAVE_LIBZE
 
 #include <level_zero/ze_api.h>
 

--- a/fabtests/configure.ac
+++ b/fabtests/configure.ac
@@ -147,17 +147,22 @@ AC_CHECK_HEADER([rdma/fabric.h], [],
 
 AC_ARG_WITH([ze],
             AC_HELP_STRING([--with-ze], [Use non-default ZE location - default NO]),
-            [CPPFLAGS="-I$withval/include $CPPFLAGS"
-             LDFLAGS="-L$withval/$lib $LDFLAGS"],
-            [])
+            AS_IF([test x"$withval" != x"no"],
+		  [CPPFLAGS="-I$withval/include $CPPFLAGS"
+		   LDFLAGS="-L$withval/$lib $LDFLAGS"]))
 
 dnl Checks for ZE libraries
+have_ze=0
 AS_IF([test x"$with_ze" != x"no"],
       [AC_CHECK_LIB([ze_loader], zeInit,
-       AC_CHECK_HEADER([level_zero/ze_api.h],
-			AC_DEFINE([HAVE_LIBZE], 1, [ZE support])),
-			[])]
-      [])
+		    AC_CHECK_HEADER([level_zero/ze_api.h],
+				    [have_ze=1]))])
+
+AS_IF([test x"$with_ze" != x"no" && test -n "$with_ze" && test "$have_ze" = "0" ],
+	[AC_MSG_ERROR([ZE support requested but ZE runtime not available.])],
+	[])
+
+AC_DEFINE_UNQUOTED([HAVE_LIBZE], [$have_ze], [ZE support])
 
 AC_MSG_CHECKING([for fi_trywait support])
 AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <rdma/fi_eq.h>]],

--- a/src/hmem_ze.c
+++ b/src/hmem_ze.c
@@ -37,7 +37,7 @@
 #include "ofi_hmem.h"
 #include "ofi.h"
 
-#ifdef HAVE_LIBZE
+#if HAVE_LIBZE
 
 #include <dirent.h>
 #include <drm/i915_drm.h>


### PR DESCRIPTION
Libfabric configure needs to check 2 dependencies now because of an extra one added for the IPC support.

Fabtests configured was failing when using --with-ze=no option because of incorrect flag setting.

Also fixes the use of --with-ze option in both that should fail if ze is not detected/supported