### PR TITLE
core/mem_monitor: return error when memory minitor failed to start

### DIFF
--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -88,6 +88,25 @@ hsa_status_t ofi_hsa_amd_memory_unlock(void *host_ptr);
 
 #endif /* HAVE_ROCR */
 
+struct ofi_hmem_ops {
+	bool initialized;
+	int (*init)(void);
+	int (*cleanup)(void);
+	int (*copy_to_hmem)(uint64_t device, void *dest, const void *src,
+			    size_t size);
+	int (*copy_from_hmem)(uint64_t device, void *dest, const void *src,
+			      size_t size);
+	bool (*is_addr_valid)(const void *addr);
+	int (*get_handle)(void *dev_buf, void **handle);
+	int (*open_handle)(void **handle, uint64_t device, void **ipc_ptr);
+	int (*close_handle)(void *ipc_ptr);
+	int (*host_register)(void *ptr, size_t size);
+	int (*host_unregister)(void *ptr);
+	int (*get_base_addr)(const void *ptr, void **base);
+};
+
+extern struct ofi_hmem_ops hmem_ops[];
+
 int rocr_copy_from_dev(uint64_t device, void *dest, const void *src,
 		       size_t size);
 int rocr_copy_to_dev(uint64_t device, void *dest, const void *src,

--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -36,6 +36,7 @@
 
 #include <ofi_mr.h>
 #include <unistd.h>
+#include "ofi_hmem.h"
 
 pthread_mutex_t mm_lock = PTHREAD_MUTEX_INITIALIZER;
 pthread_rwlock_t mm_list_rwlock = PTHREAD_RWLOCK_INITIALIZER;
@@ -208,6 +209,9 @@ int ofi_monitors_add_cache(struct ofi_mem_monitor **monitors,
 	for (iface = FI_HMEM_SYSTEM; iface < OFI_HMEM_MAX; iface++) {
 		cache->monitors[iface] = NULL;
 
+		if (!hmem_ops[iface].initialized)
+			continue;
+
 		monitor = monitors[iface];
 		if (!monitor) {
 			FI_DBG(&core_prov, FI_LOG_MR,
@@ -218,9 +222,7 @@ int ofi_monitors_add_cache(struct ofi_mem_monitor **monitors,
 
 		if (dlist_empty(&monitor->list)) {
 			ret = monitor->start(monitor);
-			if (ret == -FI_ENOSYS)
-				continue;
-			else if (ret)
+			if (ret)
 				goto err;
 		}
 

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -39,24 +39,7 @@
 #include "ofi.h"
 #include "ofi_iov.h"
 
-struct ofi_hmem_ops {
-	bool initialized;
-	int (*init)(void);
-	int (*cleanup)(void);
-	int (*copy_to_hmem)(uint64_t device, void *dest, const void *src,
-			    size_t size);
-	int (*copy_from_hmem)(uint64_t device, void *dest, const void *src,
-			      size_t size);
-	bool (*is_addr_valid)(const void *addr);
-	int (*get_handle)(void *dev_buf, void **handle);
-	int (*open_handle)(void **handle, uint64_t device, void **ipc_ptr);
-	int (*close_handle)(void *ipc_ptr);
-	int (*host_register)(void *ptr, size_t size);
-	int (*host_unregister)(void *ptr);
-	int (*get_base_addr)(const void *ptr, void **base);
-};
-
-static struct ofi_hmem_ops hmem_ops[] = {
+struct ofi_hmem_ops hmem_ops[] = {
 	[FI_HMEM_SYSTEM] = {
 		.initialized = false,
 		.init = ofi_hmem_init_noop,


### PR DESCRIPTION
Currently in ofi_monitors_add_cache(), if a minitor failed to
start and the error code is -FI_ENOSYS, the error is ignored.

This behavior was to handle the situation that device memory
monitors cannot start if the device memory was not
configured. However, it has an unintended consequence:
if a system memory monitor failed to start, the error was ignored.
As a result, the MR cache was initialized successfully, but it
does not support system memory.

To address this issue, this PR made the following change to
ofi_monitors_add_cache():

1. It introduced an array iface_enabled, which keep record
   each type of memory's configure status

2. If a type of memory is not enabled, do not check whether
   the monitor can be started.

3. If a type of memory is enabled, and caller specified
   a monitor, and the monitor failed to started, return error.
   (the -FI_ENOSYS error will not be ignored)

Signed-off-by: Ubuntu <ubuntu@ip-172-31-15-224.ec2.internal>