### PR TITLE
v1.12.1rc1 (PR includes adding autogen.sh to package)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -185,7 +185,7 @@ src_libfabric_la_LIBADD =
 src_libfabric_la_DEPENDENCIES = libfabric.map
 
 if !EMBEDDED
-src_libfabric_la_LDFLAGS += -version-info 16:0:15
+src_libfabric_la_LDFLAGS += -version-info 16:1:15
 endif
 src_libfabric_la_LDFLAGS += -export-dynamic \
 			   $(libfabric_version_script)

--- a/Makefile.am
+++ b/Makefile.am
@@ -425,6 +425,7 @@ include prov/hook/hook_debug/Makefile.include
 man_MANS = $(real_man_pages) $(prov_install_man_pages) $(dummy_man_pages)
 
 EXTRA_DIST += \
+        autogen.sh \
         NEWS.md \
         libfabric.spec.in \
         config/distscript.pl \

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,33 @@ bug fixes (and other actions) for each version of Libfabric since
 version 1.0.  New major releases include all fixes from minor
 releases with earlier release dates.
 
+v1.12.1, Fri Apr 2, 2021
+========================
+
+## Core
+
+- Fix initialization checks for CUDA HMEM support
+- Fail if a memory monitor is requested but not available
+- Adjust priority of psm3 provider to prefer HW specific providers,
+  such as efa and psm2
+
+## EFA
+- Adjust timing clearing the deferred MR list to fix memory leak
+- Repost handshake packets on EAGAIN failure
+- Enable mr cache for CUDA memory
+- Support FI_HMEM and FI_LOCAL_COMM when used together
+- Skip using shm provider when FI_HMEM is requested
+
+## PSM3
+- Fix AVX2 configure check
+- Fix conflict with with-psm2-src build option to prevent duplicate
+  symbols
+- Fix checksum generation to support different builddir
+- Remove dependency on librdmacm header files
+- Use AR variable instead of calling ar directly in automake tools
+- Add missing PACK_SUFFIX to header
+
+
 v1.12.0, Mon Mar 8, 2021
 =========================
 

--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ dnl
 dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.60])
-AC_INIT([libfabric], [1.12.0], [ofiwg@lists.openfabrics.org])
+AC_INIT([libfabric], [1.12.1rc1], [ofiwg@lists.openfabrics.org])
 AC_CONFIG_SRCDIR([src/fabric.c])
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_MACRO_DIR(config)

--- a/fabtests/configure.ac
+++ b/fabtests/configure.ac
@@ -5,7 +5,7 @@ dnl
 dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.57)
-AC_INIT([fabtests], [1.12.0], [ofiwg@lists.openfabrics.org])
+AC_INIT([fabtests], [1.12.1rc1], [ofiwg@lists.openfabrics.org])
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_MACRO_DIR(config)
 AC_CONFIG_HEADERS(config.h)

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -80,7 +80,7 @@ extern "C" {
 
 #define FI_MAJOR_VERSION 1
 #define FI_MINOR_VERSION 12
-#define FI_REVISION_VERSION 0
+#define FI_REVISION_VERSION 1
 
 enum {
 	FI_PATH_MAX		= 256,

--- a/include/windows/config.h
+++ b/include/windows/config.h
@@ -165,7 +165,7 @@
 #define PACKAGE_TARNAME PACKAGE
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "1.12.0"
+#define PACKAGE_VERSION "1.12.1rc1"
 
 /* Define to the full name and version of this package. */
 #define PACKAGE_STRING PACKAGE_NAME " " PACKAGE_VERSION


### PR DESCRIPTION
autogen.sh is needed for someone to test changes to configure
on a released package.  This request came out of conversation
with RedHat debugging build issues with v1.12.0 release.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>