### PR TITLE
package: Add autogen.sh to release package

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -425,6 +425,7 @@ include prov/hook/hook_debug/Makefile.include
 man_MANS = $(real_man_pages) $(prov_install_man_pages) $(dummy_man_pages)
 
 EXTRA_DIST += \
+        autogen.sh \
         NEWS.md \
         libfabric.spec.in \
         config/distscript.pl \


### PR DESCRIPTION
autogen.sh is needed for someone to test changes to configure
on a released package.  This request came out of conversation
with RedHat debugging build issues with v1.12.0 release.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>