### PR TITLE
prov/tcp: fix a race condition when the endpoint is disabled during connection establishment handshake

### DIFF
--- a/prov/tcp/src/tcpx_conn_mgr.c
+++ b/prov/tcp/src/tcpx_conn_mgr.c
@@ -240,7 +240,9 @@ static void tcpx_cm_recv_resp(struct util_wait *wait,
 err2:
 	free(cm_entry);
 err1:
+	fastlock_acquire(&ep->lock);
 	tcpx_ep_disable(ep, -ret);
+	fastlock_release(&ep->lock);
 	free(cm_ctx);
 }
 
@@ -293,7 +295,9 @@ static void tcpx_cm_send_resp(struct util_wait *wait,
 delfd:
 	ofi_wait_del_fd(wait, ep->sock);
 disable:
+	fastlock_acquire(&ep->lock);
 	tcpx_ep_disable(ep, -ret);
+	fastlock_release(&ep->lock);
 	free(cm_ctx);
 }
 
@@ -408,7 +412,9 @@ static void tcpx_cm_send_req(struct util_wait *wait,
 delfd:
 	ofi_wait_del_fd(wait, ep->sock);
 disable:
+	fastlock_acquire(&ep->lock);
 	tcpx_ep_disable(ep, -ret);
+	fastlock_release(&ep->lock);
 	free(cm_ctx);
 }
 

--- a/prov/tcp/src/tcpx_conn_mgr.c
+++ b/prov/tcp/src/tcpx_conn_mgr.c
@@ -380,7 +380,7 @@ static void tcpx_cm_send_req(struct util_wait *wait,
 	len = sizeof(status);
 	ret = getsockopt(ep->sock, SOL_SOCKET, SO_ERROR, (char *) &status, &len);
 	if (ret < 0 || status) {
-		ret = (ret < 0)? -ofi_sockerr() : status;
+		ret = (ret < 0)? -ofi_sockerr() : -status;
 		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL, "connection failure\n");
 		goto delfd;
 	}

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -146,7 +146,9 @@ static int tcpx_ep_connect(struct fid_ep *ep, const void *addr,
 	return 0;
 
 disable:
+	fastlock_acquire(&tcpx_ep->lock);
 	tcpx_ep_disable(tcpx_ep, -ret);
+	fastlock_release(&tcpx_ep->lock);
 free:
 	free(cm_ctx);
 	return ret;


### PR DESCRIPTION
    tcpx_ep_disable() must always be executed while holding ep->lock.
    There are a few places in the CM code where tcpx_ep_disable() is
    called without ep->lock, which could cause memory corruptions if
    the same endpoint is accessed in a different context at the same
    time (e.g., call to fi_shutdown()).
    
    I sometimes see Libfabric to SIGSEGV in ofi_cq_readfrom() when a
    connection establishment is in progress but the remote peer exits.
    Sadly, I cannot reproduce the issue reliably but I believe it's
    because of the race described in the current patch.
    
    I suspect the bug was introduced in commit
    30b93ae025fcfe88f0441f155d487957d1c8978a("prov/tcp: Rework CM state
    machine to fix lock inversion").
    
    Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>
