### PR TITLE
tcp/rxm: adjust default tx/rx attribute sizes

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -153,9 +153,14 @@ struct ofi_common_locks {
 /*
  * Provider details
  */
+typedef int (*ofi_alter_info_t)(uint32_t version, const struct fi_info *src_info,
+				const struct fi_info *base_info,
+				struct fi_info *dest_info);
+
 struct util_prov {
 	const struct fi_provider	*prov;
 	const struct fi_info		*info;
+	ofi_alter_info_t		alter_defaults;
 	const int			flags;
 };
 
@@ -948,10 +953,6 @@ static inline int ofi_has_util_prefix(const char *str)
 {
 	return !strncasecmp(str, OFI_UTIL_PREFIX, strlen(OFI_UTIL_PREFIX));
 }
-
-typedef int (*ofi_alter_info_t)(uint32_t version, const struct fi_info *src_info,
-				const struct fi_info *base_info,
-				struct fi_info *dest_info);
 
 int ofi_get_core_info(uint32_t version, const char *node, const char *service,
 		      uint64_t flags, const struct util_prov *util_prov,

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -125,6 +125,11 @@ extern struct util_prov rxm_util_prov;
 extern struct fi_ops_rma rxm_ops_rma;
 extern struct fi_ops_atomic rxm_ops_atomic;
 
+enum {
+	RXM_MSG_RXTX_SIZE = 128,
+	RXM_MSG_SRX_SIZE = 4096
+};
+
 extern size_t rxm_msg_tx_size;
 extern size_t rxm_msg_rx_size;
 extern size_t rxm_cm_progress_interval;

--- a/prov/rxm/src/rxm_attr.c
+++ b/prov/rxm/src/rxm_attr.c
@@ -53,7 +53,7 @@ struct fi_tx_attr rxm_tx_attr = {
 	.op_flags = RXM_PASSTHRU_TX_OP_FLAGS | RXM_TX_OP_FLAGS,
 	.msg_order = ~0x0ULL,
 	.comp_order = FI_ORDER_NONE,
-	.size = 65536,
+	.size = 16384,
 	.iov_limit = RXM_IOV_LIMIT,
 	.rma_iov_limit = RXM_IOV_LIMIT,
 };
@@ -63,7 +63,7 @@ struct fi_rx_attr rxm_rx_attr = {
 	.op_flags = RXM_PASSTHRU_RX_OP_FLAGS | RXM_RX_OP_FLAGS,
 	.msg_order = ~0x0ULL,
 	.comp_order = FI_ORDER_NONE,
-	.size = 65536,
+	.size = 16384,
 	.iov_limit= RXM_IOV_LIMIT,
 };
 
@@ -72,7 +72,7 @@ struct fi_tx_attr rxm_tx_attr_coll = {
 	.op_flags = RXM_PASSTHRU_TX_OP_FLAGS | RXM_TX_OP_FLAGS,
 	.msg_order = ~0x0ULL,
 	.comp_order = FI_ORDER_NONE,
-	.size = 65536,
+	.size = 16384,
 	.iov_limit = RXM_IOV_LIMIT,
 	.rma_iov_limit = RXM_IOV_LIMIT,
 };
@@ -82,7 +82,7 @@ struct fi_rx_attr rxm_rx_attr_coll = {
 	.op_flags = RXM_PASSTHRU_RX_OP_FLAGS | RXM_RX_OP_FLAGS,
 	.msg_order = ~0x0ULL,
 	.comp_order = FI_ORDER_NONE,
-	.size = 65536,
+	.size = 16384,
 	.iov_limit= RXM_IOV_LIMIT,
 };
 

--- a/prov/tcp/src/tcpx_attr.c
+++ b/prov/tcp/src/tcpx_attr.c
@@ -117,8 +117,26 @@ struct fi_info tcpx_info = {
 	.fabric_attr = &tcpx_fabric_attr
 };
 
+
+/* User hints will still override the modified dest_info attributes
+ * through ofi_alter_info
+ */
+static int
+tcpx_alter_defaults(uint32_t version, const struct fi_info *hints,
+		    const struct fi_info *base_info,
+		    struct fi_info *dest_info)
+{
+	dest_info->tx_attr->size = 256;
+	if (hints && hints->ep_attr &&
+	    hints->ep_attr->rx_ctx_cnt != FI_SHARED_CONTEXT)
+		dest_info->rx_attr->size = 256;
+	return 0;
+}
+
+
 struct util_prov tcpx_util_prov = {
 	.prov = &tcpx_prov,
 	.info = &tcpx_info,
+	.alter_defaults = &tcpx_alter_defaults,
 	.flags = 0,
 };

--- a/prov/tcp/src/tcpx_attr.c
+++ b/prov/tcp/src/tcpx_attr.c
@@ -67,7 +67,7 @@ static struct fi_rx_attr tcpx_rx_attr = {
 	.comp_order = FI_ORDER_STRICT,
 	.msg_order = TCPX_MSG_ORDER,
 	.total_buffered_recv = 0,
-	.size = 1024,
+	.size = 8192,
 	.iov_limit = TCPX_IOV_LIMIT
 };
 
@@ -97,7 +97,7 @@ static struct fi_domain_attr tcpx_domain_attr = {
 	.ep_cnt = 8192,
 	.tx_ctx_cnt = 8192,
 	.rx_ctx_cnt = 8192,
-	.max_ep_srx_ctx = 128,
+	.max_ep_srx_ctx = 8192,
 	.max_ep_tx_ctx = 1,
 	.max_ep_rx_ctx = 1
 };

--- a/prov/tcp/src/tcpx_msg.c
+++ b/prov/tcp/src/tcpx_msg.c
@@ -581,7 +581,8 @@ tcpx_tinject(struct fid_ep *fid_ep, const void *buf, size_t len,
 	tx_entry->hdr.base_hdr.payload_off = (uint8_t)
 					     sizeof(tx_entry->hdr.tag_hdr);
 
-	memcpy((uint8_t *) (&tx_entry->hdr.tag_hdr + 1), (uint8_t *) buf, len);
+	memcpy((uint8_t *) &tx_entry->hdr + sizeof(tx_entry->hdr.tag_hdr),
+	       (uint8_t *) buf, len);
 
 	tx_entry->iov[0].iov_base = (void *) &tx_entry->hdr;
 	tx_entry->iov[0].iov_len = len + sizeof(tx_entry->hdr.tag_hdr);

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -989,10 +989,18 @@ int ofi_prov_check_dup_info(const struct util_prov *util_prov,
 				     api_version, user_info);
 	    	if (ret)
 			continue;
+
 		if (!(fi = fi_dupinfo(prov_info))) {
 			ret = -FI_ENOMEM;
 			goto err;
 		}
+
+		if (util_prov->alter_defaults) {
+			ret = util_prov->alter_defaults(api_version, user_info,
+							prov_info, fi);
+			assert(ret == FI_SUCCESS);
+		}
+
 		if (!*info)
 			*info = fi;
 		else


### PR DESCRIPTION
- Fix coverity warning (false positive)
- tcp: increase maximum supported ep attributes to allow larger srx sizes
- rxm: adjust default rx/tx sizes to reduce memory footprint. use different msg rx/tx sizes based on use of srx
- rxm: adjust buffer pool growth sizes and remove use of hugepages
- core: allow a provider to modify the default fi_info values (currently set to the max values)

Details in commit messages.  The goal is to allow rxm to use a larger size for shared receive contexts, versus the same size used when each msg ep has its own rx.  Update tcp to support a larger rx size (so that getinfo doesn't fail those requests), but specify different rx sizes for when shared rx is used vs not.