### PR TITLE
core: Add fastlock_held debug check

### DIFF
--- a/include/ofi_lock.h
+++ b/include/ofi_lock.h
@@ -133,6 +133,11 @@ static inline void fastlock_release(fastlock_t *lock)
 	assert(!ret);
 }
 
+static inline int fastlock_held(fastlock_t *lock)
+{
+	return lock->in_use;
+}
+
 #else /* !ENABLE_DEBUG */
 
 #  define fastlock_t fastlock_t_
@@ -141,6 +146,7 @@ static inline void fastlock_release(fastlock_t *lock)
 #  define fastlock_acquire(lock) fastlock_acquire_(lock)
 #  define fastlock_tryacquire(lock) fastlock_tryacquire_(lock)
 #  define fastlock_release(lock) fastlock_release_(lock)
+#  define fastlock_held(lock)
 
 #endif
 

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -713,7 +713,7 @@ static struct fi_ops_ep rxm_ops_ep = {
 	.tx_size_left = fi_no_tx_size_left,
 };
 
-/* Caller must hold recv_queue->lock */
+/* Caller must hold recv_queue->lock -- TODO which lock? */
 static struct rxm_rx_buf *
 rxm_get_unexp_msg(struct rxm_recv_queue *recv_queue, fi_addr_t addr,
 		  uint64_t tag, uint64_t ignore)

--- a/prov/shm/src/smr_av.c
+++ b/prov/shm/src/smr_av.c
@@ -76,9 +76,12 @@ static int smr_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 			ep_name = smr_no_prefix(addr);
 			ret = smr_map_add(&smr_prov, smr_av->smr_map,
 					  ep_name, &shm_id);
-			if (!ret)
+			if (!ret) {
+				fastlock_acquire(&util_av->lock);
 				ret = ofi_av_insert_addr(util_av, &shm_id,
 							 &util_addr);
+				fastlock_release(&util_av->lock);
+			}
 		} else {
 			FI_WARN(&smr_prov, FI_LOG_AV,
 				"AV insert failed. The maximum number of AV "

--- a/prov/tcp/src/tcpx_conn_mgr.c
+++ b/prov/tcp/src/tcpx_conn_mgr.c
@@ -130,7 +130,10 @@ static int tx_cm_data(SOCKET fd, uint8_t type, struct tcpx_cm_context *cm_ctx)
 	return FI_SUCCESS;
 }
 
-static int tcpx_ep_enable(struct tcpx_ep *ep)
+static int tcpx_ep_enable(struct tcpx_ep *ep,
+			  struct fi_eq_cm_entry *cm_entry,
+			  size_t cm_entry_sz)
+
 {
 	int ret = 0;
 
@@ -175,9 +178,14 @@ static int tcpx_ep_enable(struct tcpx_ep *ep)
 		}
 	}
 
-	/* TODO: Move writing CONNECTED event here */
+	ret = (int) fi_eq_write(&ep->util_ep.eq->eq_fid, FI_CONNECTED, cm_entry,
+				cm_entry_sz, 0);
+	if (ret < 0) {
+		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL, "Error writing to EQ\n");
+		return ret;
+	}
 
-	return ret;
+	return 0;
 unlock:
 	fastlock_release(&ep->lock);
 	return ret;
@@ -224,13 +232,9 @@ static void tcpx_cm_recv_resp(struct util_wait *wait,
 	ep->hdr_bswap = (cm_ctx->msg.hdr.conn_data == 1) ?
 			tcpx_hdr_none : tcpx_hdr_bswap;
 
-	ret = tcpx_ep_enable(ep);
+	ret = tcpx_ep_enable(ep, cm_entry,
+				sizeof(*cm_entry) + cm_ctx->cm_data_sz);
 	if (ret)
-		goto err2;
-
-	ret = (int) fi_eq_write(&ep->util_ep.eq->eq_fid, FI_CONNECTED, cm_entry,
-				sizeof(*cm_entry) + cm_ctx->cm_data_sz, 0);
-	if (ret < 0)
 		goto err2;
 
 	free(cm_entry);
@@ -279,12 +283,8 @@ static void tcpx_cm_send_resp(struct util_wait *wait,
 	}
 
 	cm_entry.fid =  cm_ctx->fid;
-	ret = (int) fi_eq_write(&ep->util_ep.eq->eq_fid, FI_CONNECTED,
-				&cm_entry, sizeof(cm_entry), 0);
-	if (ret < 0)
-		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL, "Error writing to EQ\n");
 
-	ret = tcpx_ep_enable(ep);
+	ret = tcpx_ep_enable(ep, &cm_entry, sizeof(cm_entry));
 	if (ret)
 		goto disable;
 

--- a/prov/tcp/src/tcpx_conn_mgr.c
+++ b/prov/tcp/src/tcpx_conn_mgr.c
@@ -240,7 +240,9 @@ static void tcpx_cm_recv_resp(struct util_wait *wait,
 err2:
 	free(cm_entry);
 err1:
+	fastlock_acquire(&ep->lock);
 	tcpx_ep_disable(ep, -ret);
+	fastlock_release(&ep->lock);
 	free(cm_ctx);
 }
 
@@ -293,7 +295,9 @@ static void tcpx_cm_send_resp(struct util_wait *wait,
 delfd:
 	ofi_wait_del_fd(wait, ep->sock);
 disable:
+	fastlock_acquire(&ep->lock);
 	tcpx_ep_disable(ep, -ret);
+	fastlock_release(&ep->lock);
 	free(cm_ctx);
 }
 
@@ -408,7 +412,9 @@ static void tcpx_cm_send_req(struct util_wait *wait,
 delfd:
 	ofi_wait_del_fd(wait, ep->sock);
 disable:
+	fastlock_acquire(&ep->lock);
 	tcpx_ep_disable(ep, -ret);
+	fastlock_release(&ep->lock);
 	free(cm_ctx);
 }
 

--- a/prov/tcp/src/tcpx_conn_mgr.c
+++ b/prov/tcp/src/tcpx_conn_mgr.c
@@ -380,7 +380,7 @@ static void tcpx_cm_send_req(struct util_wait *wait,
 	len = sizeof(status);
 	ret = getsockopt(ep->sock, SOL_SOCKET, SO_ERROR, (char *) &status, &len);
 	if (ret < 0 || status) {
-		ret = (ret < 0)? -ofi_sockerr() : status;
+		ret = (ret < 0)? -ofi_sockerr() : -status;
 		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL, "connection failure\n");
 		goto delfd;
 	}

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -153,7 +153,9 @@ static int tcpx_ep_connect(struct fid_ep *ep, const void *addr,
 	return 0;
 
 disable:
+	fastlock_acquire(&tcpx_ep->lock);
 	tcpx_ep_disable(tcpx_ep, -ret);
+	fastlock_release(&tcpx_ep->lock);
 free:
 	free(cm_ctx);
 	return ret;

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -396,11 +396,11 @@ int tcpx_op_invalid(struct tcpx_ep *tcpx_ep)
 	return -FI_EINVAL;
 }
 
-/* Must hold ep lock */
 static struct tcpx_xfer_entry *tcpx_rx_entry_alloc(struct tcpx_ep *ep)
 {
 	struct tcpx_xfer_entry *rx_entry;
 
+	assert(fastlock_held(&ep->lock));
 	if (slist_empty(&ep->rx_queue))
 		return NULL;
 
@@ -630,11 +630,11 @@ static int tcpx_get_next_rx_hdr(struct tcpx_ep *ep)
 	return FI_SUCCESS;
 }
 
-/* Must hold ep lock */
 void tcpx_progress_rx(struct tcpx_ep *ep)
 {
 	int ret;
 
+	assert(fastlock_held(&ep->lock));
 	if (!ep->cur_rx_entry &&
 	    (ep->stage_buf.cur_pos == ep->stage_buf.bytes_avail)) {
 		ret = tcpx_read_to_buffer(ep->sock, &ep->stage_buf);
@@ -675,12 +675,12 @@ err:
 		tcpx_ep_disable(ep, 0);
 }
 
-/* Must hold ep lock */
 void tcpx_progress_tx(struct tcpx_ep *ep)
 {
 	struct tcpx_xfer_entry *tx_entry;
 	struct slist_entry *entry;
 
+	assert(fastlock_held(&ep->lock));
 	if (!slist_empty(&ep->tx_queue)) {
 		entry = ep->tx_queue.head;
 		tx_entry = container_of(entry, struct tcpx_xfer_entry, entry);

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -274,13 +274,11 @@ int ofi_verify_av_insert(struct util_av *av, uint64_t flags, void *context)
 	return 0;
 }
 
-/*
- * Must hold AV lock
- */
 int ofi_av_insert_addr(struct util_av *av, const void *addr, fi_addr_t *fi_addr)
 {
 	struct util_av_entry *entry = NULL;
 
+	assert(fastlock_held(&av->lock));
 	HASH_FIND(hh, av->hash, addr, av->addrlen, entry);
 	if (entry) {
 		if (fi_addr)
@@ -318,13 +316,11 @@ int ofi_av_elements_iter(struct util_av *av, ofi_av_apply_func apply, void *arg)
 	return 0;
 }
 
-/*
- * Must hold AV lock
- */
 int ofi_av_remove_addr(struct util_av *av, fi_addr_t fi_addr)
 {
 	struct util_av_entry *av_entry;
 
+	assert(fastlock_held(&av->lock));
 	av_entry = ofi_bufpool_get_ibuf(av->av_entry_pool, fi_addr);
 	if (!av_entry)
 		return -FI_ENOENT;

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -53,13 +53,13 @@ static void ofi_cq_insert_aux(struct util_cq *cq,
 	slist_insert_tail(&entry->list_entry, &cq->aux_queue);
 }
 
-/* Caller must hold 'cq lock' */
 int ofi_cq_write_overflow(struct util_cq *cq, void *context, uint64_t flags,
 			  size_t len, void *buf, uint64_t data, uint64_t tag,
 			  fi_addr_t src)
 {
 	struct util_cq_aux_entry *entry;
 
+	assert(fastlock_held(&cq->cq_lock));
 	FI_DBG(cq->domain->prov, FI_LOG_CQ, "writing to CQ overflow list\n");
 	assert(ofi_cirque_freecnt(cq->cirq) <= 1);
 
@@ -79,12 +79,12 @@ int ofi_cq_write_overflow(struct util_cq *cq, void *context, uint64_t flags,
 	return 0;
 }
 
-/* Caller must hold 'cq lock' */
 int ofi_cq_insert_error(struct util_cq *cq,
 			const struct fi_cq_err_entry *err_entry)
 {
 	struct util_cq_aux_entry *entry;
 
+	assert(fastlock_held(&cq->cq_lock));
 	assert(err_entry->err);
 	if (!(entry = calloc(1, sizeof(*entry))))
 		return -FI_ENOMEM;

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -226,12 +226,12 @@ vrb_cq_sread(struct fid_cq *cq, void *buf, size_t count, const void *cond,
 	return cur ? cur : ret;
 }
 
-/* Must be called with CQ lock held. */
 int vrb_poll_cq(struct vrb_cq *cq, struct ibv_wc *wc)
 {
 	struct vrb_context *ctx;
 	int ret;
 
+	assert(fastlock_held(&cq->util_cq.cq_lock));
 	do {
 		ret = ibv_poll_cq(cq->cq, 1, wc);
 		if (ret <= 0)
@@ -263,11 +263,11 @@ int vrb_poll_cq(struct vrb_cq *cq, struct ibv_wc *wc)
 	return ret;
 }
 
-/* Must be called with CQ lock held. */
 int vrb_save_wc(struct vrb_cq *cq, struct ibv_wc *wc)
 {
 	struct vrb_wc_entry *wce;
 
+	assert(fastlock_held(&cq->util_cq.cq_lock));
 	wce = ofi_buf_alloc(cq->wce_pool);
 	if (!wce) {
 		FI_WARN(&vrb_prov, FI_LOG_CQ,

--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -80,15 +80,15 @@ static inline void vrb_set_ini_conn_key(struct vrb_xrc_ep *ep,
 				  struct vrb_cq, util_cq);
 }
 
-/* Caller must hold domain:xrc.ini_lock */
 int vrb_get_shared_ini_conn(struct vrb_xrc_ep *ep,
-			       struct vrb_ini_shared_conn **ini_conn) {
+			    struct vrb_ini_shared_conn **ini_conn) {
 	struct vrb_domain *domain = vrb_ep_to_domain(&ep->base_ep);
 	struct vrb_ini_conn_key key;
 	struct vrb_ini_shared_conn *conn;
 	struct ofi_rbnode *node;
 	int ret;
 
+	assert(fastlock_held(&domain->xrc.ini_lock));
 	vrb_set_ini_conn_key(ep, &key);
 	node = ofi_rbmap_find(domain->xrc.ini_conn_rbmap, &key);
 	if (node) {
@@ -136,13 +136,13 @@ insert_err:
 	return ret;
 }
 
-/* Caller must hold domain:xrc.ini_lock */
 void _vrb_put_shared_ini_conn(struct vrb_xrc_ep *ep)
 {
 	struct vrb_domain *domain = vrb_ep_to_domain(&ep->base_ep);
 	struct vrb_ini_shared_conn *ini_conn;
 	struct vrb_ini_conn_key key;
 
+	assert(fastlock_held(&domain->xrc.ini_lock));
 	if (!ep->ini_conn)
 		return;
 
@@ -190,10 +190,11 @@ void vrb_put_shared_ini_conn(struct vrb_xrc_ep *ep)
 	domain->xrc.lock_release(&domain->xrc.ini_lock);
 }
 
-/* Caller must hold domain:xrc.ini_lock */
 void vrb_add_pending_ini_conn(struct vrb_xrc_ep *ep, int reciprocal,
-				 void *conn_param, size_t conn_paramlen)
+			      void *conn_param, size_t conn_paramlen)
 {
+	assert(fastlock_held(&vrb_ep_to_domain(&ep->base_ep)->xrc.ini_lock));
+
 	ep->conn_setup->pending_recip = reciprocal;
 	ep->conn_setup->pending_paramlen = MIN(conn_paramlen,
 				sizeof(ep->conn_setup->pending_param));
@@ -428,9 +429,9 @@ static int vrb_put_tgt_qp(struct vrb_xrc_ep *ep)
 	return FI_SUCCESS;
 }
 
-/* Caller must hold eq:lock */
 int vrb_ep_destroy_xrc_qp(struct vrb_xrc_ep *ep)
 {
+	assert(fastlock_held(&ep->base_ep.eq->lock));
 	vrb_put_shared_ini_conn(ep);
 
 	if (ep->base_ep.id) {

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -76,11 +76,11 @@ unlock:
 	return rd;
 }
 
-/* Caller must hold eq:lock */
 void vrb_eq_set_xrc_conn_tag(struct vrb_xrc_ep *ep)
 {
 	struct vrb_eq *eq = ep->base_ep.eq;
 
+	assert(fastlock_held(&eq->lock));
 	assert(ep->conn_setup);
 	assert(ep->conn_setup->conn_tag == VERBS_CONN_TAG_INVALID);
 	ep->conn_setup->conn_tag =
@@ -88,12 +88,12 @@ void vrb_eq_set_xrc_conn_tag(struct vrb_xrc_ep *ep)
 				ofi_idx_insert(eq->xrc.conn_key_map, ep));
 }
 
-/* Caller must hold eq:lock */
 void vrb_eq_clear_xrc_conn_tag(struct vrb_xrc_ep *ep)
 {
 	struct vrb_eq *eq = ep->base_ep.eq;
 	int index;
 
+	assert(fastlock_held(&eq->lock));
 	assert(ep->conn_setup);
 	if (ep->conn_setup->conn_tag == VERBS_CONN_TAG_INVALID)
 		return;
@@ -108,13 +108,13 @@ void vrb_eq_clear_xrc_conn_tag(struct vrb_xrc_ep *ep)
 	ep->conn_setup->conn_tag = VERBS_CONN_TAG_INVALID;
 }
 
-/* Caller must hold eq:lock */
 struct vrb_xrc_ep *vrb_eq_xrc_conn_tag2ep(struct vrb_eq *eq,
-						uint32_t conn_tag)
+					  uint32_t conn_tag)
 {
 	struct vrb_xrc_ep *ep;
 	int index;
 
+	assert(fastlock_held(&eq->lock));
 	index = ofi_key2idx(&eq->xrc.conn_key_idx, (uint64_t)conn_tag);
 	ep = ofi_idx_lookup(eq->xrc.conn_key_map, index);
 	if (!ep || ep->magic != VERBS_XRC_EP_MAGIC) {
@@ -354,14 +354,14 @@ static int vrb_sidr_conn_compare(struct ofi_rbmap *map,
 		-1 : _key->recip > ep->recip_accept;
 }
 
-/* Caller must hold eq:lock */
 struct vrb_xrc_ep *vrb_eq_get_sidr_conn(struct vrb_eq *eq,
-					      struct sockaddr *peer,
-					      uint16_t pep_port, bool recip)
+					struct sockaddr *peer,
+					uint16_t pep_port, bool recip)
 {
 	struct ofi_rbnode *node;
 	struct vrb_sidr_conn_key key;
 
+	assert(fastlock_held(&eq->lock));
 	vrb_set_sidr_conn_key(peer, pep_port, recip, &key);
 	node = ofi_rbmap_find(&eq->xrc.sidr_conn_rbmap, &key);
 	if (OFI_LIKELY(!node))
@@ -370,13 +370,13 @@ struct vrb_xrc_ep *vrb_eq_get_sidr_conn(struct vrb_eq *eq,
 	return (struct vrb_xrc_ep *) node->data;
 }
 
-/* Caller must hold eq:lock */
 int vrb_eq_add_sidr_conn(struct vrb_xrc_ep *ep,
-			    void *param_data, size_t param_len)
+			 void *param_data, size_t param_len)
 {
 	int ret;
 	struct vrb_sidr_conn_key key;
 
+	assert(fastlock_held(&ep->base_ep.eq->lock));
 	assert(!ep->accept_param_data);
 	assert(param_len);
 	assert(ep->tgt_id && ep->tgt_id->ps == RDMA_PS_UDP);
@@ -406,9 +406,9 @@ int vrb_eq_add_sidr_conn(struct vrb_xrc_ep *ep,
 	return FI_SUCCESS;
 }
 
-/* Caller must hold eq:lock */
 void vrb_eq_remove_sidr_conn(struct vrb_xrc_ep *ep)
 {
+	assert(fastlock_held(&ep->base_ep.eq->lock));
 	assert(ep->conn_map_node);
 
 	ofi_rbmap_delete(&ep->base_ep.eq->xrc.sidr_conn_rbmap,
@@ -654,7 +654,6 @@ vrb_eq_xrc_recip_conn_event(struct vrb_eq *eq,
 	return sizeof(*entry) + len;
 }
 
-/* Caller must hold eq:lock */
 static int
 vrb_eq_xrc_rej_event(struct vrb_eq *eq, struct rdma_cm_event *cma_event)
 {
@@ -663,6 +662,7 @@ vrb_eq_xrc_rej_event(struct vrb_eq *eq, struct rdma_cm_event *cma_event)
 	struct vrb_xrc_conn_info xrc_info;
 	enum vrb_xrc_ep_conn_state state;
 
+	assert(fastlock_held(&eq->lock));
 	ep = container_of(fid, struct vrb_xrc_ep, base_ep.util_ep.ep_fid);
 	if (ep->magic != VERBS_XRC_EP_MAGIC) {
 		VERBS_WARN(FI_LOG_EP_CTRL,
@@ -703,11 +703,12 @@ vrb_eq_xrc_rej_event(struct vrb_eq *eq, struct rdma_cm_event *cma_event)
 	return state == VRB_XRC_ORIG_CONNECTING ? FI_SUCCESS : -FI_EAGAIN;
 }
 
-/* Caller must hold eq:lock */
-static inline int
+static int
 vrb_eq_xrc_connect_retry(struct vrb_xrc_ep *ep,
 			 struct rdma_cm_event *cma_event, int *acked)
 {
+	assert(fastlock_held(&ep->base_ep.eq->lock));
+
 	if (ep->base_ep.info_attr.src_addr)
 		ofi_straddr_dbg(&vrb_prov, FI_LOG_EP_CTRL,
 				"Connect retry src ",
@@ -728,15 +729,15 @@ vrb_eq_xrc_connect_retry(struct vrb_xrc_ep *ep,
 			       ep->conn_setup->pending_paramlen);
 }
 
-/* Caller must hold eq:lock */
-static inline int
+static int
 vrb_eq_xrc_cm_err_event(struct vrb_eq *eq,
-                           struct rdma_cm_event *cma_event, int *acked)
+                        struct rdma_cm_event *cma_event, int *acked)
 {
 	struct vrb_xrc_ep *ep;
 	fid_t fid = cma_event->id->context;
 	int ret;
 
+	assert(fastlock_held(&eq->lock));
 	ep = container_of(fid, struct vrb_xrc_ep, base_ep.util_ep.ep_fid);
 	if (ep->magic != VERBS_XRC_EP_MAGIC) {
 		VERBS_WARN(FI_LOG_EP_CTRL, "CM ID context invalid\n");
@@ -776,12 +777,11 @@ vrb_eq_xrc_cm_err_event(struct vrb_eq *eq,
         return FI_SUCCESS;
 }
 
-/* Caller must hold eq:lock */
-static inline int
+static int
 vrb_eq_xrc_connected_event(struct vrb_eq *eq,
-			      struct rdma_cm_event *cma_event, int *acked,
-			      struct fi_eq_cm_entry *entry, size_t len,
-			      uint32_t *event)
+			   struct rdma_cm_event *cma_event, int *acked,
+			   struct fi_eq_cm_entry *entry, size_t len,
+			   uint32_t *event)
 {
 	struct vrb_xrc_ep *ep;
 	fid_t fid = cma_event->id->context;
@@ -789,6 +789,7 @@ vrb_eq_xrc_connected_event(struct vrb_eq *eq,
 
 	ep = container_of(fid, struct vrb_xrc_ep, base_ep.util_ep.ep_fid);
 
+	assert(fastlock_held(&eq->lock));
 	assert(ep->conn_state == VRB_XRC_ORIG_CONNECTING ||
 	       ep->conn_state == VRB_XRC_RECIP_CONNECTING);
 
@@ -807,14 +808,15 @@ vrb_eq_xrc_connected_event(struct vrb_eq *eq,
 	return ret;
 }
 
-/* Caller must hold eq:lock */
-static inline void
+static void
 vrb_eq_xrc_timewait_event(struct vrb_eq *eq,
-			     struct rdma_cm_event *cma_event, int *acked)
+			  struct rdma_cm_event *cma_event, int *acked)
 {
 	fid_t fid = cma_event->id->context;
 	struct vrb_xrc_ep *ep = container_of(fid, struct vrb_xrc_ep,
 						base_ep.util_ep.ep_fid);
+
+	assert(fastlock_held(&eq->lock));
 	assert(ep->magic == VERBS_XRC_EP_MAGIC);
 	assert(ep->conn_setup);
 
@@ -833,14 +835,15 @@ vrb_eq_xrc_timewait_event(struct vrb_eq *eq,
 		vrb_free_xrc_conn_setup(ep, 0);
 }
 
-/* Caller must hold eq:lock */
 static inline void
 vrb_eq_xrc_disconnect_event(struct vrb_eq *eq,
 			       struct rdma_cm_event *cma_event, int *acked)
 {
 	fid_t fid = cma_event->id->context;
 	struct vrb_xrc_ep *ep = container_of(fid, struct vrb_xrc_ep,
-						base_ep.util_ep.ep_fid);
+					     base_ep.util_ep.ep_fid);
+
+	assert(fastlock_held(&eq->lock));
 	assert(ep->magic == VERBS_XRC_EP_MAGIC);
 
 	if (ep->conn_setup && cma_event->id == ep->base_ep.id) {
@@ -1061,12 +1064,12 @@ int vrb_eq_match_event(struct dlist_entry *item, const void *arg)
 	}
 }
 
-/* Caller must hold eq->lock */
 void vrb_eq_remove_events(struct vrb_eq *eq, struct fid *fid)
 {
 	struct dlist_entry *item;
 	struct vrb_eq_entry *entry;
 
+	assert(fastlock_held(&eq->lock));
 	while ((item =
 		dlistfd_remove_first_match(&eq->list_head,
 					   vrb_eq_match_event, fid))) {


### PR DESCRIPTION
Some functions require that a lock be held when they are
called.  Provide a debug check that can verify this.  This
can replace comments in the code that the lock is held with
actual code that documents the requiremen and checks for it.

Update obvious places in the code where locks must be held
to assert on fastlock_held.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>