### PR TITLE
prov/rxm: Merge all the tx buffer pools into one to reduce memory footprint

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -443,13 +443,6 @@ struct rxm_iov {
 	uint8_t count;
 };
 
-enum rxm_buf_pool_type {
-	RXM_BUF_POOL_RX		= 0,
-	RXM_BUF_POOL_START	= RXM_BUF_POOL_RX,
-	RXM_BUF_POOL_TX,
-	RXM_BUF_POOL_MAX,
-};
-
 struct rxm_buf {
 	/* Must stay at top */
 	struct fi_context fi_context;
@@ -622,12 +615,6 @@ struct rxm_recv_queue {
 	dlist_func_t		*match_unexp;
 };
 
-struct rxm_buf_pool {
-	enum rxm_buf_pool_type type;
-	struct ofi_bufpool *pool;
-	struct rxm_ep *rxm_ep;
-};
-
 struct rxm_msg_eq_entry {
 	ssize_t			rd;
 	uint32_t		event;
@@ -690,7 +677,8 @@ struct rxm_ep {
 	size_t			inject_limit;
 	size_t			sar_limit;
 
-	struct rxm_buf_pool	*buf_pools;
+	struct ofi_bufpool	*rx_pool;
+	struct ofi_bufpool	*tx_pool;
 
 	struct dlist_entry	repost_ready_list;
 	struct dlist_entry	deferred_tx_conn_queue;
@@ -908,12 +896,6 @@ rxm_ep_format_tx_buf_pkt(struct rxm_conn *rxm_conn, size_t len, uint8_t op,
 	pkt->hdr.tag = tag;
 	pkt->hdr.flags = (flags & FI_REMOTE_CQ_DATA);
 	pkt->hdr.data = data;
-}
-
-static inline void *
-rxm_tx_buf_alloc(struct rxm_ep *rxm_ep, enum rxm_buf_pool_type type)
-{
-	return ofi_buf_alloc(rxm_ep->buf_pools[type].pool);
 }
 
 static inline void

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -478,7 +478,7 @@ struct rxm_rx_buf {
 	struct rxm_pkt pkt;
 };
 
-struct rxm_tx_bounce_buf {
+struct rxm_tx_buf {
 	/* Must stay at top */
 	struct rxm_buf hdr;
 
@@ -499,7 +499,7 @@ struct rxm_tx_bounce_buf {
 		struct rxm_conn *conn;
 		size_t rndv_rma_index;
 		size_t rndv_rma_count;
-		struct rxm_tx_bounce_buf *done_buf;
+		struct rxm_tx_buf *done_buf;
 		struct rxm_rndv_hdr remote_hdr;
 	} write_rndv;
 
@@ -529,7 +529,7 @@ struct rxm_deferred_tx_entry {
 			size_t pkt_size;
 		} rndv_ack;
 		struct {
-			struct rxm_tx_bounce_buf *tx_buf;
+			struct rxm_tx_buf *tx_buf;
 		} rndv_done;
 		struct {
 			struct rxm_rx_buf *rx_buf;
@@ -537,12 +537,12 @@ struct rxm_deferred_tx_entry {
 			struct rxm_iov rxm_iov;
 		} rndv_read;
 		struct {
-			struct rxm_tx_bounce_buf *tx_buf;
+			struct rxm_tx_buf *tx_buf;
 			struct fi_rma_iov rma_iov;
 			struct rxm_iov rxm_iov;
 		} rndv_write;
 		struct {
-			struct rxm_tx_bounce_buf *cur_seg_tx_buf;
+			struct rxm_tx_buf *cur_seg_tx_buf;
 			struct {
 				struct iovec iov[RXM_IOV_LIMIT];
 				uint8_t count;
@@ -562,11 +562,11 @@ struct rxm_deferred_tx_entry {
 			uint64_t device;
 		} sar_seg;
 		struct {
-			struct rxm_tx_bounce_buf *tx_buf;
+			struct rxm_tx_buf *tx_buf;
 			ssize_t len;
 		} atomic_resp;
 		struct {
-			struct rxm_tx_bounce_buf *tx_buf;
+			struct rxm_tx_buf *tx_buf;
 		} credit_msg;
 	};
 };
@@ -593,7 +593,7 @@ struct rxm_recv_entry {
 	/* Used for Rendezvous protocol */
 	struct {
 		/* This is used to send RNDV ACK */
-		struct rxm_tx_bounce_buf *tx_buf;
+		struct rxm_tx_buf *tx_buf;
 	} rndv;
 };
 OFI_DECLARE_FREESTACK(struct rxm_recv_entry, rxm_recv_fs);
@@ -635,7 +635,7 @@ ssize_t rxm_get_dyn_rbuf(struct ofi_cq_rbuf_entry *entry, struct iovec *iov,
 
 struct rxm_eager_ops {
 	void (*comp_tx)(struct rxm_ep *rxm_ep,
-			struct rxm_tx_bounce_buf *tx_eager_buf);
+			struct rxm_tx_buf *tx_eager_buf);
 	void (*handle_rx)(struct rxm_rx_buf *rx_buf);
 };
 
@@ -748,9 +748,9 @@ void rxm_ep_do_progress(struct util_ep *util_ep);
 void rxm_handle_eager(struct rxm_rx_buf *rx_buf);
 void rxm_handle_coll_eager(struct rxm_rx_buf *rx_buf);
 void rxm_finish_eager_send(struct rxm_ep *rxm_ep,
-			   struct rxm_tx_bounce_buf *tx_eager_buf);
+			   struct rxm_tx_buf *tx_eager_buf);
 void rxm_finish_coll_eager_send(struct rxm_ep *rxm_ep,
-				struct rxm_tx_bounce_buf *tx_eager_buf);
+				struct rxm_tx_buf *tx_eager_buf);
 
 int rxm_prepost_recv(struct rxm_ep *rxm_ep, struct fid_ep *rx_ep);
 
@@ -772,7 +772,7 @@ static inline size_t rxm_ep_max_atomic_size(struct fi_info *info)
 
 static inline ssize_t
 rxm_atomic_send_respmsg(struct rxm_ep *rxm_ep, struct rxm_conn *conn,
-			struct rxm_tx_bounce_buf *resp_buf, ssize_t len)
+			struct rxm_tx_buf *resp_buf, ssize_t len)
 {
 	struct iovec iov = {
 		.iov_base = (void *) &resp_buf->pkt,

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -456,7 +456,6 @@ enum rxm_buf_pool_type {
 	RXM_BUF_POOL_TX_ATOMIC,
 	RXM_BUF_POOL_TX_CREDIT,
 	RXM_BUF_POOL_TX_END	= RXM_BUF_POOL_TX_CREDIT,
-	RXM_BUF_POOL_RMA,
 	RXM_BUF_POOL_MAX,
 };
 
@@ -510,6 +509,11 @@ struct rxm_tx_bounce_buf {
 	void *app_context;
 	uint64_t flags;
 
+	struct {
+		struct fid_mr *mr[RXM_IOV_LIMIT];
+		uint8_t count;
+	} rma;
+
 	/* Must stay at bottom */
 	struct rxm_pkt pkt;
 };
@@ -533,21 +537,6 @@ struct rxm_tx_rndv_buf {
 		struct rxm_rndv_hdr remote_hdr;
 	} write_rndv;
 
-	/* Must stay at bottom */
-	struct rxm_pkt pkt;
-};
-
-struct rxm_rma_buf {
-	/* Must stay at top */
-	struct rxm_buf hdr;
-
-	void *app_context;
-	uint64_t flags;
-
-	struct {
-		struct fid_mr *mr[RXM_IOV_LIMIT];
-		uint8_t count;
-	} mr;
 	/* Must stay at bottom */
 	struct rxm_pkt pkt;
 };

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -447,9 +447,6 @@ enum rxm_buf_pool_type {
 	RXM_BUF_POOL_RX		= 0,
 	RXM_BUF_POOL_START	= RXM_BUF_POOL_RX,
 	RXM_BUF_POOL_TX,
-	RXM_BUF_POOL_TX_START	= RXM_BUF_POOL_TX,
-	RXM_BUF_POOL_TX_RNDV_REQ,
-	RXM_BUF_POOL_TX_END	= RXM_BUF_POOL_TX_RNDV_REQ,
 	RXM_BUF_POOL_MAX,
 };
 
@@ -503,19 +500,6 @@ struct rxm_tx_bounce_buf {
 		struct rxm_iov atomic_result;
 	};
 
-	/* Must stay at bottom */
-	struct rxm_pkt pkt;
-};
-
-struct rxm_tx_rndv_buf {
-	/* Must stay at top */
-	struct rxm_buf hdr;
-
-	void *app_context;
-	uint64_t flags;
-	struct fid_mr *mr[RXM_IOV_LIMIT];
-	uint8_t count;
-
 	struct {
 		struct iovec iov[RXM_IOV_LIMIT];
 		void *desc[RXM_IOV_LIMIT];
@@ -552,7 +536,7 @@ struct rxm_deferred_tx_entry {
 			size_t pkt_size;
 		} rndv_ack;
 		struct {
-			struct rxm_tx_rndv_buf *tx_buf;
+			struct rxm_tx_bounce_buf *tx_buf;
 		} rndv_done;
 		struct {
 			struct rxm_rx_buf *rx_buf;
@@ -560,7 +544,7 @@ struct rxm_deferred_tx_entry {
 			struct rxm_iov rxm_iov;
 		} rndv_read;
 		struct {
-			struct rxm_tx_rndv_buf *tx_buf;
+			struct rxm_tx_bounce_buf *tx_buf;
 			struct fi_rma_iov rma_iov;
 			struct rxm_iov rxm_iov;
 		} rndv_write;
@@ -929,8 +913,6 @@ rxm_ep_format_tx_buf_pkt(struct rxm_conn *rxm_conn, size_t len, uint8_t op,
 static inline void *
 rxm_tx_buf_alloc(struct rxm_ep *rxm_ep, enum rxm_buf_pool_type type)
 {
-	assert((type == RXM_BUF_POOL_TX) ||
-	       (type == RXM_BUF_POOL_TX_RNDV_REQ));
 	return ofi_buf_alloc(rxm_ep->buf_pools[type].pool);
 }
 

--- a/prov/rxm/src/rxm_atomic.c
+++ b/prov/rxm/src/rxm_atomic.c
@@ -155,7 +155,7 @@ rxm_ep_atomic_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 		goto restore_credit;
 	}
 
-	tx_buf = rxm_tx_buf_alloc(rxm_ep, RXM_BUF_POOL_TX);
+	tx_buf = ofi_buf_alloc(rxm_ep->tx_pool);
 	if (OFI_UNLIKELY(!tx_buf)) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
 			"Ran out of buffers from Atomic buffer pool\n");

--- a/prov/rxm/src/rxm_atomic.c
+++ b/prov/rxm/src/rxm_atomic.c
@@ -38,14 +38,14 @@
 
 static void
 rxm_ep_format_atomic_pkt_hdr(struct rxm_conn *rxm_conn,
-		 struct rxm_tx_atomic_buf *tx_buf, size_t data_len,
+		 struct rxm_tx_bounce_buf *tx_buf, size_t data_len,
 		 uint32_t pkt_op, enum fi_datatype datatype,
 		 uint8_t atomic_op, uint64_t flags, uint64_t data,
 		 const struct fi_rma_ioc *rma_ioc, size_t rma_ioc_count)
 {
 	struct rxm_atomic_hdr *atomic_hdr;
 
-	atomic_hdr = (struct rxm_atomic_hdr *)tx_buf->pkt.data;
+	atomic_hdr = (struct rxm_atomic_hdr *) tx_buf->pkt.data;
 	rxm_ep_format_tx_buf_pkt(rxm_conn, data_len, pkt_op, data, 0,
 				 flags, &tx_buf->pkt);
 	tx_buf->pkt.ctrl_hdr.type = rxm_ctrl_atomic;
@@ -61,7 +61,7 @@ rxm_ep_format_atomic_pkt_hdr(struct rxm_conn *rxm_conn,
 
 static inline int
 rxm_ep_send_atomic_req(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
-		       struct rxm_tx_atomic_buf *tx_buf, uint64_t len)
+		       struct rxm_tx_bounce_buf *tx_buf, uint64_t len)
 {
 	int ret;
 
@@ -94,7 +94,7 @@ rxm_ep_atomic_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 		struct fi_ioc *resultv, void **result_desc,
 		size_t result_iov_count, uint32_t op, uint64_t flags)
 {
-	struct rxm_tx_atomic_buf *tx_buf;
+	struct rxm_tx_bounce_buf *tx_buf;
 	struct rxm_atomic_hdr *atomic_hdr;
 	struct iovec buf_iov[RXM_IOV_LIMIT];
 	struct iovec cmp_iov[RXM_IOV_LIMIT];
@@ -155,7 +155,7 @@ rxm_ep_atomic_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 		goto restore_credit;
 	}
 
-	tx_buf = rxm_tx_buf_alloc(rxm_ep, RXM_BUF_POOL_TX_ATOMIC);
+	tx_buf = rxm_tx_buf_alloc(rxm_ep, RXM_BUF_POOL_TX);
 	if (OFI_UNLIKELY(!tx_buf)) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
 			"Ran out of buffers from Atomic buffer pool\n");
@@ -163,6 +163,7 @@ rxm_ep_atomic_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 		goto restore_credit;
 	}
 
+	tx_buf->pkt.ctrl_hdr.type = rxm_ctrl_atomic;
 	rxm_ep_format_atomic_pkt_hdr(rxm_conn, tx_buf, tot_len, op,
 				msg->datatype, msg->op, flags, msg->data,
 				msg->rma_iov, msg->rma_iov_count);
@@ -182,14 +183,14 @@ rxm_ep_atomic_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 		assert(ret == cmp_len);
 	}
 
-	tx_buf->result_iov.count = result_iov_count;
+	tx_buf->atomic_result.count = result_iov_count;
 	if (resultv) {
-		ofi_ioc_to_iov(resultv, tx_buf->result_iov.iov,
+		ofi_ioc_to_iov(resultv, tx_buf->atomic_result.iov,
 			       result_iov_count, datatype_sz);
 
 		if (result_desc) {
 			for (i = 0; i < result_iov_count; i++)
-				tx_buf->result_iov.desc[i] = result_desc[i];
+				tx_buf->atomic_result.desc[i] = result_desc[i];
 		}
 	}
 

--- a/prov/rxm/src/rxm_atomic.c
+++ b/prov/rxm/src/rxm_atomic.c
@@ -38,7 +38,7 @@
 
 static void
 rxm_ep_format_atomic_pkt_hdr(struct rxm_conn *rxm_conn,
-		 struct rxm_tx_bounce_buf *tx_buf, size_t data_len,
+		 struct rxm_tx_buf *tx_buf, size_t data_len,
 		 uint32_t pkt_op, enum fi_datatype datatype,
 		 uint8_t atomic_op, uint64_t flags, uint64_t data,
 		 const struct fi_rma_ioc *rma_ioc, size_t rma_ioc_count)
@@ -61,7 +61,7 @@ rxm_ep_format_atomic_pkt_hdr(struct rxm_conn *rxm_conn,
 
 static inline int
 rxm_ep_send_atomic_req(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
-		       struct rxm_tx_bounce_buf *tx_buf, uint64_t len)
+		       struct rxm_tx_buf *tx_buf, uint64_t len)
 {
 	int ret;
 
@@ -94,7 +94,7 @@ rxm_ep_atomic_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 		struct fi_ioc *resultv, void **result_desc,
 		size_t result_iov_count, uint32_t op, uint64_t flags)
 {
-	struct rxm_tx_bounce_buf *tx_buf;
+	struct rxm_tx_buf *tx_buf;
 	struct rxm_atomic_hdr *atomic_hdr;
 	struct iovec buf_iov[RXM_IOV_LIMIT];
 	struct iovec cmp_iov[RXM_IOV_LIMIT];

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -192,7 +192,7 @@ rxm_cq_write_tx_comp(struct rxm_ep *rxm_ep, uint64_t comp_flags,
 	}
 }
 
-static void rxm_finish_rma(struct rxm_ep *rxm_ep, struct rxm_tx_bounce_buf *rma_buf,
+static void rxm_finish_rma(struct rxm_ep *rxm_ep, struct rxm_tx_buf *rma_buf,
 			  uint64_t comp_flags)
 {
 	assert(((comp_flags & FI_WRITE) && !(comp_flags & FI_READ)) ||
@@ -214,7 +214,7 @@ static void rxm_finish_rma(struct rxm_ep *rxm_ep, struct rxm_tx_bounce_buf *rma_
 	ofi_buf_free(rma_buf);
 }
 
-void rxm_finish_eager_send(struct rxm_ep *rxm_ep, struct rxm_tx_bounce_buf *tx_buf)
+void rxm_finish_eager_send(struct rxm_ep *rxm_ep, struct rxm_tx_buf *tx_buf)
 {
 	assert(ofi_tx_cq_flags(tx_buf->pkt.hdr.op) & FI_SEND);
 
@@ -224,9 +224,9 @@ void rxm_finish_eager_send(struct rxm_ep *rxm_ep, struct rxm_tx_bounce_buf *tx_b
 }
 
 static bool rxm_complete_sar(struct rxm_ep *rxm_ep,
-			     struct rxm_tx_bounce_buf *tx_buf)
+			     struct rxm_tx_buf *tx_buf)
 {
-	struct rxm_tx_bounce_buf *first_tx_buf;
+	struct rxm_tx_buf *first_tx_buf;
 
 	assert(ofi_tx_cq_flags(tx_buf->pkt.hdr.op) & FI_SEND);
 	switch (rxm_sar_get_seg_type(&tx_buf->pkt.ctrl_hdr)) {
@@ -247,7 +247,7 @@ static bool rxm_complete_sar(struct rxm_ep *rxm_ep,
 }
 
 static void rxm_handle_sar_comp(struct rxm_ep *rxm_ep,
-				struct rxm_tx_bounce_buf *tx_buf)
+				struct rxm_tx_buf *tx_buf)
 {
 	void *app_context;
 	uint64_t comp_flags, tx_flags;
@@ -280,7 +280,7 @@ static void rxm_rndv_rx_finish(struct rxm_rx_buf *rx_buf)
 }
 
 static void rxm_rndv_tx_finish(struct rxm_ep *rxm_ep,
-			       struct rxm_tx_bounce_buf *tx_buf)
+			       struct rxm_tx_buf *tx_buf)
 {
 	assert(ofi_tx_cq_flags(tx_buf->pkt.hdr.op) & FI_SEND);
 
@@ -303,7 +303,7 @@ static void rxm_rndv_tx_finish(struct rxm_ep *rxm_ep,
 static void rxm_rndv_handle_rd_done(struct rxm_ep *rxm_ep,
 				    struct rxm_rx_buf *rx_buf)
 {
-	struct rxm_tx_bounce_buf *tx_buf;
+	struct rxm_tx_buf *tx_buf;
 
 	FI_DBG(&rxm_prov, FI_LOG_CQ, "Got ACK for msg_id: 0x%" PRIx64 "\n",
 	       rx_buf->pkt.ctrl_hdr.msg_id);
@@ -528,7 +528,7 @@ static ssize_t rxm_rndv_handle_wr_data(struct rxm_rx_buf *rx_buf)
 {
 	int i;
 	ssize_t ret;
-	struct rxm_tx_bounce_buf *tx_buf;
+	struct rxm_tx_buf *tx_buf;
 	size_t total_len, rma_len = 0;
 	struct rxm_rndv_hdr *rx_hdr = (struct rxm_rndv_hdr *) rx_buf->pkt.data;
 
@@ -835,7 +835,7 @@ static ssize_t rxm_sar_handle_segment(struct rxm_rx_buf *rx_buf)
 static void rxm_rndv_send_rd_done(struct rxm_rx_buf *rx_buf)
 {
 	struct rxm_deferred_tx_entry *def_entry;
-	struct rxm_tx_bounce_buf *buf;
+	struct rxm_tx_buf *buf;
 	ssize_t ret;
 
 	assert(rx_buf->conn);
@@ -887,10 +887,10 @@ err:
 }
 
 static void
-rxm_rndv_send_wr_done(struct rxm_ep *rxm_ep, struct rxm_tx_bounce_buf *tx_buf)
+rxm_rndv_send_wr_done(struct rxm_ep *rxm_ep, struct rxm_tx_buf *tx_buf)
 {
 	struct rxm_deferred_tx_entry *def_entry;
-	struct rxm_tx_bounce_buf *buf;
+	struct rxm_tx_buf *buf;
 	ssize_t ret;
 
 	assert(tx_buf->hdr.state == RXM_RNDV_WRITE);
@@ -942,7 +942,7 @@ err:
 ssize_t rxm_rndv_send_wr_data(struct rxm_rx_buf *rx_buf)
 {
 	struct rxm_deferred_tx_entry *def_entry;
-	struct rxm_tx_bounce_buf *buf;
+	struct rxm_tx_buf *buf;
 	ssize_t ret;
 
 	assert(rx_buf->conn);
@@ -1008,7 +1008,7 @@ static void rxm_handle_remote_write(struct rxm_ep *rxm_ep,
 }
 
 static void rxm_format_atomic_resp_pkt_hdr(struct rxm_conn *rxm_conn,
-					   struct rxm_tx_bounce_buf *tx_buf,
+					   struct rxm_tx_buf *tx_buf,
 					   size_t data_len, uint32_t pkt_op,
 					   enum fi_datatype datatype,
 					   uint8_t atomic_op)
@@ -1024,7 +1024,7 @@ static void rxm_format_atomic_resp_pkt_hdr(struct rxm_conn *rxm_conn,
 
 static ssize_t rxm_atomic_send_resp(struct rxm_ep *rxm_ep,
 				    struct rxm_rx_buf *rx_buf,
-				    struct rxm_tx_bounce_buf *resp_buf,
+				    struct rxm_tx_buf *resp_buf,
 				    ssize_t result_len, uint32_t status)
 {
 	struct rxm_deferred_tx_entry *def_tx_entry;
@@ -1112,7 +1112,7 @@ static int rxm_do_device_mem_atomic(struct rxm_mr *dev_mr, uint8_t op,
 				    enum fi_op amo_op, size_t amo_op_size)
 {
 	struct rxm_domain *dom = dev_mr->domain;
-	void *bounce_buf;
+	void *tx_buf;
 	ssize_t ret __attribute__((unused));
 	struct iovec iov = {
 		.iov_base = dev_dst,
@@ -1120,28 +1120,28 @@ static int rxm_do_device_mem_atomic(struct rxm_mr *dev_mr, uint8_t op,
 	};
 
 	fastlock_acquire(&dom->amo_bufpool_lock);
-	bounce_buf = ofi_buf_alloc(dom->amo_bufpool);
+	tx_buf = ofi_buf_alloc(dom->amo_bufpool);
 	fastlock_release(&dom->amo_bufpool_lock);
 
-	if (!bounce_buf)
+	if (!tx_buf)
 		return -FI_ENOMEM;
 
 	fastlock_acquire(&dev_mr->amo_lock);
-	ret = ofi_copy_from_hmem_iov(bounce_buf, amo_op_size, dev_mr->iface, 0,
+	ret = ofi_copy_from_hmem_iov(tx_buf, amo_op_size, dev_mr->iface, 0,
 				    &iov, 1, 0);
 	assert(ret == amo_op_size);
 
-	rxm_do_atomic(op, bounce_buf, src, cmp, res, amo_count, datatype,
+	rxm_do_atomic(op, tx_buf, src, cmp, res, amo_count, datatype,
 		      amo_op);
 
-	ret = ofi_copy_to_hmem_iov(dev_mr->iface, 0, &iov, 1, 0, bounce_buf,
+	ret = ofi_copy_to_hmem_iov(dev_mr->iface, 0, &iov, 1, 0, tx_buf,
 				   amo_op_size);
 	assert(ret == amo_op_size);
 
 	fastlock_release(&dev_mr->amo_lock);
 
 	fastlock_acquire(&dom->amo_bufpool_lock);
-	ofi_buf_free(bounce_buf);
+	ofi_buf_free(tx_buf);
 	fastlock_release(&dom->amo_bufpool_lock);
 
 	return FI_SUCCESS;
@@ -1160,7 +1160,7 @@ static ssize_t rxm_handle_atomic_req(struct rxm_ep *rxm_ep,
 	uint64_t offset;
 	int i;
 	ssize_t ret = 0;
-	struct rxm_tx_bounce_buf *resp_buf;
+	struct rxm_tx_buf *resp_buf;
 	struct rxm_atomic_resp_hdr *resp_hdr;
 	struct rxm_domain *domain = container_of(rxm_ep->util_ep.domain,
 					 struct rxm_domain, util_domain);
@@ -1249,7 +1249,7 @@ static ssize_t rxm_handle_atomic_req(struct rxm_ep *rxm_ep,
 static ssize_t rxm_handle_atomic_resp(struct rxm_ep *rxm_ep,
 				      struct rxm_rx_buf *rx_buf)
 {
-	struct rxm_tx_bounce_buf *tx_buf;
+	struct rxm_tx_buf *tx_buf;
 	struct rxm_atomic_resp_hdr *resp_hdr;
 	struct util_cntr *cntr = NULL;
 	uint64_t len;
@@ -1347,7 +1347,7 @@ static ssize_t rxm_handle_credit(struct rxm_ep *rxm_ep, struct rxm_rx_buf *rx_bu
 }
 
 void rxm_finish_coll_eager_send(struct rxm_ep *rxm_ep,
-			       struct rxm_tx_bounce_buf *tx_eager_buf)
+			        struct rxm_tx_buf *tx_eager_buf)
 {
 	if (tx_eager_buf->pkt.hdr.tag & OFI_COLL_TAG_FLAG) {
 		ofi_coll_handle_xfer_comp(tx_eager_buf->pkt.hdr.tag,
@@ -1360,7 +1360,7 @@ void rxm_finish_coll_eager_send(struct rxm_ep *rxm_ep,
 ssize_t rxm_handle_comp(struct rxm_ep *rxm_ep, struct fi_cq_data_entry *comp)
 {
 	struct rxm_rx_buf *rx_buf;
-	struct rxm_tx_bounce_buf *bounce_buf;
+	struct rxm_tx_buf *tx_buf;
 
 	/* Remote write events may not consume a posted recv so op context
 	 * and hence state would be NULL */
@@ -1371,23 +1371,23 @@ ssize_t rxm_handle_comp(struct rxm_ep *rxm_ep, struct fi_cq_data_entry *comp)
 
 	switch (RXM_GET_PROTO_STATE(comp->op_context)) {
 	case RXM_TX:
-		bounce_buf = comp->op_context;
-		rxm_ep->eager_ops->comp_tx(rxm_ep, bounce_buf);
-		ofi_buf_free(bounce_buf);
+		tx_buf = comp->op_context;
+		rxm_ep->eager_ops->comp_tx(rxm_ep, tx_buf);
+		ofi_buf_free(tx_buf);
 		return 0;
 	case RXM_CREDIT_TX:
-		bounce_buf = comp->op_context;
+		tx_buf = comp->op_context;
 		assert(comp->flags & FI_SEND);
-		ofi_buf_free(bounce_buf);
+		ofi_buf_free(tx_buf);
 		return 0;
 	case RXM_INJECT_TX:
 		assert(0);
 		return 0;
 	case RXM_RMA:
-		bounce_buf = comp->op_context;
+		tx_buf = comp->op_context;
 		assert((comp->flags & (FI_WRITE | FI_RMA)) ||
 		       (comp->flags & (FI_READ | FI_RMA)));
-		rxm_finish_rma(rxm_ep, bounce_buf, comp->flags);
+		rxm_finish_rma(rxm_ep, tx_buf, comp->flags);
 		return 0;
 	case RXM_RX:
 		rx_buf = comp->op_context;
@@ -1420,18 +1420,18 @@ ssize_t rxm_handle_comp(struct rxm_ep *rxm_ep, struct fi_cq_data_entry *comp)
 			return -FI_EINVAL;
 		}
 	case RXM_SAR_TX:
-		bounce_buf = comp->op_context;
+		tx_buf = comp->op_context;
 		assert(comp->flags & FI_SEND);
-		rxm_handle_sar_comp(rxm_ep, bounce_buf);
+		rxm_handle_sar_comp(rxm_ep, tx_buf);
 		return 0;
 	case RXM_RNDV_TX:
-		bounce_buf = comp->op_context;
+		tx_buf = comp->op_context;
 		assert(comp->flags & FI_SEND);
 		if (rxm_ep->rndv_ops == &rxm_rndv_ops_write)
-			RXM_UPDATE_STATE(FI_LOG_CQ, bounce_buf,
+			RXM_UPDATE_STATE(FI_LOG_CQ, tx_buf,
 					 RXM_RNDV_WRITE_DATA_WAIT);
 		else
-			RXM_UPDATE_STATE(FI_LOG_CQ, bounce_buf,
+			RXM_UPDATE_STATE(FI_LOG_CQ, tx_buf,
 					 RXM_RNDV_READ_DONE_WAIT);
 		return 0;
 	case RXM_RNDV_READ_DONE_WAIT:
@@ -1447,13 +1447,13 @@ ssize_t rxm_handle_comp(struct rxm_ep *rxm_ep, struct fi_cq_data_entry *comp)
 		rxm_rndv_send_rd_done(rx_buf);
 		return 0;
 	case RXM_RNDV_WRITE:
-		bounce_buf = comp->op_context;
+		tx_buf = comp->op_context;
 		assert(comp->flags & FI_WRITE);
-		if (++bounce_buf->write_rndv.rndv_rma_index <
-		    bounce_buf->write_rndv.rndv_rma_count)
+		if (++tx_buf->write_rndv.rndv_rma_index <
+		    tx_buf->write_rndv.rndv_rma_count)
 			return 0;
 
-		rxm_rndv_send_wr_done(rxm_ep, bounce_buf);
+		rxm_rndv_send_wr_done(rxm_ep, tx_buf);
 		return 0;
 	case RXM_RNDV_READ_DONE_SENT:
 		assert(comp->flags & FI_SEND);
@@ -1483,9 +1483,9 @@ ssize_t rxm_handle_comp(struct rxm_ep *rxm_ep, struct fi_cq_data_entry *comp)
 		assert(comp->flags & FI_SEND);
 		return 0;
 	case RXM_ATOMIC_RESP_SENT:
-		bounce_buf = comp->op_context;
+		tx_buf = comp->op_context;
 		assert(comp->flags & FI_SEND);
-		ofi_buf_free(bounce_buf);
+		ofi_buf_free(tx_buf);
 		return 0;
 	default:
 		assert(0);
@@ -1710,7 +1710,7 @@ void rxm_cq_write_error_all(struct rxm_ep *rxm_ep, int err)
 
 void rxm_handle_comp_error(struct rxm_ep *rxm_ep)
 {
-	struct rxm_tx_bounce_buf *bounce_buf;
+	struct rxm_tx_buf *tx_buf;
 	struct rxm_rx_buf *rx_buf;
 	struct util_cq *cq;
 	struct util_cntr *cntr;
@@ -1734,42 +1734,42 @@ void rxm_handle_comp_error(struct rxm_ep *rxm_ep)
 
 	switch (RXM_GET_PROTO_STATE(err_entry.op_context)) {
 	case RXM_TX:
-		bounce_buf = err_entry.op_context;
-		err_entry.op_context = bounce_buf->app_context;
-		err_entry.flags = ofi_tx_cq_flags(bounce_buf->pkt.hdr.op);
-		ofi_buf_free(bounce_buf);
+		tx_buf = err_entry.op_context;
+		err_entry.op_context = tx_buf->app_context;
+		err_entry.flags = ofi_tx_cq_flags(tx_buf->pkt.hdr.op);
+		ofi_buf_free(tx_buf);
 		break;
 	case RXM_INJECT_TX:
 		assert(0);
 		return;
 	case RXM_RMA:
-		bounce_buf = err_entry.op_context;
-		err_entry.op_context = bounce_buf->app_context;
+		tx_buf = err_entry.op_context;
+		err_entry.op_context = tx_buf->app_context;
 		/* err_entry.flags pass through from msg ep */
-		if (!(bounce_buf->flags & FI_INJECT) && !rxm_ep->rdm_mr_local &&
+		if (!(tx_buf->flags & FI_INJECT) && !rxm_ep->rdm_mr_local &&
 		    rxm_ep->msg_mr_local) {
-			rxm_msg_mr_closev(bounce_buf->rma.mr, bounce_buf->rma.count);
+			rxm_msg_mr_closev(tx_buf->rma.mr, tx_buf->rma.count);
 		}
-		ofi_buf_free(bounce_buf);
+		ofi_buf_free(tx_buf);
 		break;
 	case RXM_SAR_TX:
-		bounce_buf = err_entry.op_context;
-		err_entry.op_context = bounce_buf->app_context;
-		err_entry.flags = ofi_tx_cq_flags(bounce_buf->pkt.hdr.op);
-		if (!rxm_complete_sar(rxm_ep, bounce_buf))
+		tx_buf = err_entry.op_context;
+		err_entry.op_context = tx_buf->app_context;
+		err_entry.flags = ofi_tx_cq_flags(tx_buf->pkt.hdr.op);
+		if (!rxm_complete_sar(rxm_ep, tx_buf))
 			return;
 		break;
 	case RXM_CREDIT_TX:
-		bounce_buf = err_entry.op_context;
+		tx_buf = err_entry.op_context;
 		err_entry.op_context = 0;
-		err_entry.flags = ofi_tx_cq_flags(bounce_buf->pkt.hdr.op);
+		err_entry.flags = ofi_tx_cq_flags(tx_buf->pkt.hdr.op);
 		break;
 	case RXM_RNDV_WRITE:
 		/* fall through */
 	case RXM_RNDV_TX:
-		bounce_buf = err_entry.op_context;
-		err_entry.op_context = bounce_buf->app_context;
-		err_entry.flags = ofi_tx_cq_flags(bounce_buf->pkt.hdr.op);
+		tx_buf = err_entry.op_context;
+		err_entry.op_context = tx_buf->app_context;
+		err_entry.flags = ofi_tx_cq_flags(tx_buf->pkt.hdr.op);
 		break;
 
 	/* Incoming application data error */

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -389,7 +389,7 @@ static ssize_t rxm_send_credits(struct fid_ep *ep, size_t credits)
 	struct fi_msg msg;
 	ssize_t ret;
 
-	tx_buf = rxm_tx_buf_alloc(rxm_ep, RXM_BUF_POOL_TX);
+	tx_buf = ofi_buf_alloc(rxm_ep->tx_pool);
 	if (!tx_buf) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
 			"Ran out of buffers from TX credit buffer pool.\n");

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -384,7 +384,7 @@ static ssize_t rxm_send_credits(struct fid_ep *ep, size_t credits)
 		container_of(ep->fid.context, struct rxm_conn, handle);
 	struct rxm_ep *rxm_ep = rxm_conn->handle.cmap->ep;
 	struct rxm_deferred_tx_entry *def_tx_entry;
-	struct rxm_tx_bounce_buf *tx_buf;
+	struct rxm_tx_buf *tx_buf;
 	struct iovec iov;
 	struct fi_msg msg;
 	ssize_t ret;

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -384,18 +384,19 @@ static ssize_t rxm_send_credits(struct fid_ep *ep, size_t credits)
 		container_of(ep->fid.context, struct rxm_conn, handle);
 	struct rxm_ep *rxm_ep = rxm_conn->handle.cmap->ep;
 	struct rxm_deferred_tx_entry *def_tx_entry;
-	struct rxm_tx_base_buf *tx_buf;
+	struct rxm_tx_bounce_buf *tx_buf;
 	struct iovec iov;
 	struct fi_msg msg;
 	ssize_t ret;
 
-	tx_buf = rxm_tx_buf_alloc(rxm_ep, RXM_BUF_POOL_TX_CREDIT);
+	tx_buf = rxm_tx_buf_alloc(rxm_ep, RXM_BUF_POOL_TX);
 	if (!tx_buf) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
 			"Ran out of buffers from TX credit buffer pool.\n");
 		return -FI_ENOMEM;
 	}
 
+	tx_buf->hdr.state = RXM_CREDIT_TX;
 	rxm_ep_format_tx_buf_pkt(rxm_conn, 0, rxm_ctrl_credit, 0, 0, FI_SEND,
 				 &tx_buf->pkt);
 	tx_buf->pkt.ctrl_hdr.type = rxm_ctrl_credit;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -152,7 +152,6 @@ static void rxm_buf_init(struct ofi_bufpool_region *region, void *buf)
 	struct rxm_tx_bounce_buf *bounce_buf;
 	struct rxm_tx_rndv_buf *tx_rndv_buf;
 	struct rxm_tx_atomic_buf *tx_atomic_buf;
-	struct rxm_rma_buf *rma_buf;
 	void *mr_desc;
 	uint8_t type;
 
@@ -230,15 +229,6 @@ static void rxm_buf_init(struct ofi_bufpool_region *region, void *buf)
 		tx_base_buf->hdr.desc = mr_desc;
 		pkt = &tx_base_buf->pkt;
 		type = rxm_ctrl_rndv_wr_data;
-		break;
-	case RXM_BUF_POOL_RMA:
-		rma_buf = buf;
-		rma_buf->pkt.hdr.op = ofi_op_msg;
-		rma_buf->hdr.state = RXM_RMA;
-
-		rma_buf->hdr.desc = mr_desc;
-		pkt = &rma_buf->pkt;
-		type = rxm_ctrl_eager;
 		break;
 	default:
 		assert(0);
@@ -386,8 +376,6 @@ static int rxm_ep_txrx_pool_create(struct rxm_ep *rxm_ep)
 		[RXM_BUF_POOL_TX_ATOMIC] = rxm_eager_limit +
 					 sizeof(struct rxm_tx_atomic_buf),
 		[RXM_BUF_POOL_TX_CREDIT] = sizeof(struct rxm_tx_base_buf),
-		[RXM_BUF_POOL_RMA] = rxm_eager_limit +
-				     sizeof(struct rxm_rma_buf),
 	};
 	size_t chunk_cnt, max_size;
 	int ret, i;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -151,7 +151,6 @@ static void rxm_buf_init(struct ofi_bufpool_region *region, void *buf)
 	struct rxm_tx_base_buf *tx_base_buf;
 	struct rxm_tx_bounce_buf *bounce_buf;
 	struct rxm_tx_rndv_buf *tx_rndv_buf;
-	struct rxm_tx_atomic_buf *tx_atomic_buf;
 	void *mr_desc;
 	uint8_t type;
 
@@ -198,13 +197,6 @@ static void rxm_buf_init(struct ofi_bufpool_region *region, void *buf)
 		tx_rndv_buf->hdr.desc = mr_desc;
 		pkt = &tx_rndv_buf->pkt;
 		type = rxm_ctrl_rndv_req;
-		break;
-	case RXM_BUF_POOL_TX_ATOMIC:
-		tx_atomic_buf = buf;
-
-		tx_atomic_buf->hdr.desc = mr_desc;
-		pkt = &tx_atomic_buf->pkt;
-		type = rxm_ctrl_atomic;
 		break;
 	case RXM_BUF_POOL_TX_RNDV_RD_DONE:
 		tx_base_buf = buf;
@@ -373,8 +365,6 @@ static int rxm_ep_txrx_pool_create(struct rxm_ep *rxm_ep)
 					 sizeof(struct rxm_tx_rndv_buf),
 		[RXM_BUF_POOL_TX_RNDV_WR_DATA] = sizeof(struct rxm_rndv_hdr) +
 						   sizeof(struct rxm_tx_base_buf),
-		[RXM_BUF_POOL_TX_ATOMIC] = rxm_eager_limit +
-					 sizeof(struct rxm_tx_atomic_buf),
 		[RXM_BUF_POOL_TX_CREDIT] = sizeof(struct rxm_tx_base_buf),
 	};
 	size_t chunk_cnt, max_size;

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -37,7 +37,7 @@
 static ssize_t
 rxm_ep_rma_reg_iov(struct rxm_ep *rxm_ep, const struct iovec *msg_iov,
 		   void **desc, void **desc_storage, size_t iov_count,
-		   uint64_t access, struct rxm_tx_bounce_buf *rma_buf)
+		   uint64_t access, struct rxm_tx_buf *rma_buf)
 {
 	size_t i, ret;
 
@@ -67,7 +67,7 @@ rxm_ep_rma_common(struct rxm_ep *rxm_ep, const struct fi_msg_rma *msg,
 		  const struct fi_msg_rma *msg, uint64_t flags),
 		  uint64_t comp_flags)
 {
-	struct rxm_tx_bounce_buf *rma_buf;
+	struct rxm_tx_buf *rma_buf;
 	struct fi_msg_rma msg_rma = *msg;
 	struct rxm_conn *rxm_conn;
 	void *mr_desc[RXM_IOV_LIMIT] = { 0 };
@@ -182,7 +182,7 @@ static ssize_t rxm_ep_read(struct fid_ep *ep_fid, void *buf, size_t len,
 }
 
 static void
-rxm_ep_format_rma_msg(struct rxm_tx_bounce_buf *rma_buf,
+rxm_ep_format_rma_msg(struct rxm_tx_buf *rma_buf,
 		      const struct fi_msg_rma *orig_msg,
 		      struct iovec *rxm_iov, struct fi_msg_rma *rxm_msg)
 {
@@ -217,7 +217,7 @@ rxm_ep_rma_emulate_inject_msg(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 			      size_t total_size, const struct fi_msg_rma *msg,
 			      uint64_t flags)
 {
-	struct rxm_tx_bounce_buf *rma_buf;
+	struct rxm_tx_buf *rma_buf;
 	ssize_t ret;
 	struct iovec rxm_msg_iov = { 0 };
 	struct fi_msg_rma rxm_rma_msg = { 0 };

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -81,7 +81,7 @@ rxm_ep_rma_common(struct rxm_ep *rxm_ep, const struct fi_msg_rma *msg,
 	if (OFI_UNLIKELY(ret))
 		goto unlock;
 
-	rma_buf = ofi_buf_alloc(rxm_ep->buf_pools[RXM_BUF_POOL_TX].pool);
+	rma_buf = ofi_buf_alloc(rxm_ep->tx_pool);
 	if (!rma_buf) {
 		ret = -FI_EAGAIN;
 		goto unlock;
@@ -224,7 +224,7 @@ rxm_ep_rma_emulate_inject_msg(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 
 	assert(msg->rma_iov_count <= rxm_ep->rxm_info->tx_attr->rma_iov_limit);
 
-	rma_buf = ofi_buf_alloc(rxm_ep->buf_pools[RXM_BUF_POOL_TX].pool);
+	rma_buf = ofi_buf_alloc(rxm_ep->tx_pool);
 	if (!rma_buf)
 		return -FI_EAGAIN;
 


### PR DESCRIPTION
rxm maintains an array of buffer pools for transmits per endpoint, 9 total.  Each pool by default can hold up to 16k entries, and 4 of the pools have entries equal to the eager message size (default 16k).  Those 4 pools alone can consume 1GB of pinned memory.  Yee-gads.  They consume 64MB basically for existing.

The only purpose for having separate pools is to save setting either 1 or 2 integer values, depending on the code path.  Wow.

Merge all these pools into a single tx pool.  That pool starts by consuming 16 MB of memory (can be reduced by shrinking the eager size), but is allowed to grow as needed.  The latter is required in order to handle receive side processing for response messages.  The receive side is not sufficiently robust to handle being unable to obtain a tx buffer without breaking communication with all peers.

This results is significantly simpler code in several places.