### PR TITLE
prov/psm3: Update SRC Checksum to generate into custom header

### DIFF
--- a/prov/psm3/Makefile.include
+++ b/prov/psm3/Makefile.include
@@ -30,12 +30,13 @@ chksum_srcs = $(_psm3_files)
 
 if HAVE_PSM3_SRC
 _psm3_cflags =
-#include prov/psm3/psm3/Makefile.include
 _nodist_psm3_files = \
-	prov/psm3/src/psm3_revision.c
+	prov/psm3/src/psm3_revision.c \
+	prov/psm3/src/psm3_src_chksum.h
 
 # builddir is for nodist config headers: See nodist_libpsm3i_la_SOURCES
 _psm3_cppflags += \
+	-I$(top_builddir)/prov/psm3/src \
 	-I$(top_srcdir)/prov/psm3/psm3 \
 	-I$(top_builddir)/prov/psm3/psm3 \
 	-I$(top_srcdir)/prov/psm3/psm3/ptl_ips/ \
@@ -277,19 +278,16 @@ chksum_srcs += \
 	$(libpsm3i_la_SOURCES) $(_psm3_extra_dist)
 
 _psm3_LIBS = libpsm3i.la
-libpsm3_la_DEPENDENCIES = libpsm3i.la
+libpsm3_la_DEPENDENCIES = \
+	prov/psm3/src/psm3_src_chksum.h \
+	libpsm3i.la
 
-all-local:
-	@echo "Building src checksum..."; \
-	chksum=`for file in $(chksum_srcs); do cat $(top_srcdir)/$$file; done | sha1sum | cut -d' ' -f 1`; \
-	if ! grep -q $$chksum $(top_builddir)/prov/psm3/src/psm3_revision.c 2>/dev/null; then \
-		sed -i "/define PSMX3_SRC_CHECKSUM/s/\".*\"/\"$$chksum\"/" $(top_builddir)/prov/psm3/src/psm3_revision.c; \
-		echo "SRC checksum updated to $$chksum"; \
-		timestamp=`date`; \
-		sed -i "/define PSMX3_BUILD_TIMESTAMP/s/\".*\"/\"$$timestamp\"/" $(top_builddir)/prov/psm3/src/psm3_revision.c; \
-		echo "Updated build timestamp: $$timestamp"; \
-	else \
-		echo "SRC checksum not changed: $$chksum"; \
+CLEANFILES = prov/psm3/src/psm3_src_chksum.h
+prov/psm3/src/psm3_src_chksum.h: Makefile $(chksum_srcs)
+	@ chksum=`for file in $(chksum_srcs); do cat $(top_srcdir)/$$file; done | sha1sum | cut -d' ' -f 1`; \
+	if ! grep -q $$chksum prov/psm3/src/psm3_src_chksum.h 2>/dev/null; then \
+		echo "#define PSMX3_SRC_CHECKSUM \"$$chksum\"" > prov/psm3/src/psm3_src_chksum.h; \
+		echo "#define PSMX3_BUILD_TIMESTAMP \"`date`\"" >> prov/psm3/src/psm3_src_chksum.h; \
 	fi
 
 endif HAVE_PSM3_SRC

--- a/prov/psm3/configure.m4
+++ b/prov/psm3/configure.m4
@@ -209,6 +209,11 @@ ifelse('
 	 AC_SUBST(PSM_HAL_CNT)
 	 AC_SUBST(PSM_HAL_INST)
 
+	 AC_SUBST(PSM3_IEFS_VERSION, [""])
+	 AC_SUBST(PSM3_BUILD_TIMESTAMP, ["<Unknown>"])
+	 AC_SUBST(PSM3_SRC_CHECKSUM, ["<Unknown>"])
+	 AC_SUBST(PSM3_GIT_HASH, ["<Unknown>"])
+
 ])
 
 AC_ARG_WITH([psm3-rv],

--- a/prov/psm3/psm3/include/opa_revision.h
+++ b/prov/psm3/psm3/include/opa_revision.h
@@ -56,7 +56,7 @@
 
 /* Those variables are defined in the _revision.c file
 which is dynamically generated during building of the library */
-extern char psmi_hfi_IFS_version[];
+extern char psmi_hfi_IEFS_version[];
 extern char psmi_hfi_build_timestamp[];
 extern char psmi_hfi_sources_checksum[];
 extern char psmi_hfi_git_checksum[];

--- a/prov/psm3/psm3/psm.c
+++ b/prov/psm3/psm3/psm.c
@@ -579,7 +579,7 @@ update:
 	if (psmi_parse_identify()) {
                 Dl_info info_psm;
 		char ofed_delta[100] = "";
-		strcat(strcat(ofed_delta," built for IFS OFA DELTA "),psmi_hfi_IFS_version);
+		strcat(strcat(ofed_delta," built for IEFS OFA DELTA "),psmi_hfi_IEFS_version);
                 printf("%s %s PSM3 v%d.%d%s\n"
 		       "%s %s location %s\n"
 		       "%s %s build date %s\n"
@@ -591,7 +591,7 @@ update:
                        "%s %s Global Rank %d (%d total) Local Rank %d (%d total)\n"
 		       , hfi_get_mylabel(), hfi_ident_tag,
 		       PSM2_VERNO_MAJOR,PSM2_VERNO_MINOR,
-		       (strcmp(psmi_hfi_IFS_version,"") != 0) ? ofed_delta
+		       (strcmp(psmi_hfi_IEFS_version,"") != 0) ? ofed_delta
 #ifdef PSM_CUDA
 		       : "-cuda",
 #else

--- a/prov/psm3/src/.gitignore
+++ b/prov/psm3/src/.gitignore
@@ -1,1 +1,2 @@
 psm3_revision.c
+psm3_src_chksum.h

--- a/prov/psm3/src/psm3_revision.c.in
+++ b/prov/psm3/src/psm3_revision.c.in
@@ -1,20 +1,22 @@
-#ifndef PSMX3_IFS_VERSION
-#define PSMX3_IFS_VERSION	"@IFS_VERSION@"
+#include "psm3_src_chksum.h"
+
+#ifndef PSMX3_IEFS_VERSION
+#define PSMX3_IEFS_VERSION	"@PSM3_IEFS_VERSION@"
 #endif
 
 #ifndef PSMX3_BUILD_TIMESTAMP
-#define PSMX3_BUILD_TIMESTAMP	"@BUILD_TIMESTAMP@"
+#define PSMX3_BUILD_TIMESTAMP  "@PSM3_BUILD_TIMESTAMP@"
 #endif
 
 #ifndef PSMX3_SRC_CHECKSUM
-#define PSMX3_SRC_CHECKSUM	"@SRC_CHECKSUM@"
+#define PSMX3_SRC_CHECKSUM     "@PSM3_SRC_CHECKSUM@"
 #endif
 
 #ifndef PSMX3_GIT_CHECKSUM
-#define PSMX3_GIT_CHECKSUM	"@GIT_HASH@"
+#define PSMX3_GIT_CHECKSUM	"@PSM3_GIT_HASH@"
 #endif
 
-char psmi_hfi_IFS_version[] = PSMX3_IFS_VERSION;
+char psmi_hfi_IEFS_version[] = PSMX3_IEFS_VERSION;
 char psmi_hfi_build_timestamp[] = PSMX3_BUILD_TIMESTAMP;
 char psmi_hfi_sources_checksum[] = PSMX3_SRC_CHECKSUM;
 char psmi_hfi_git_checksum[] = PSMX3_GIT_CHECKSUM;


### PR DESCRIPTION
Use object dependency instead of BUILT_SOURCES as BUILT_SOURCES seem to
randomly retrigger. Without a dependency the header would not get built
at all. See Built Sources Example on automake web manual:
 https://www.gnu.org/software/automake/manual/html_node/Built-Sources-Example.html

Updated IFS to IEFS.

Add missing replace variables to retrun "<Unknown>" if not defined.
Some values are only available for IEFS releases.

Signed-off-by: Goldman, Adam <adam.goldman@intel.com>