### PR TITLE
prov/rxm: enable optimizations only for tcp provider

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1611,44 +1611,29 @@ ssize_t rxm_get_dyn_rbuf(struct ofi_cq_rbuf_entry *entry, struct iovec *iov,
 		}
 		break;
 	case rxm_ctrl_rndv_req:
-		/* find matching receive to maintain message ordering, but we
-		 * only need to receive rendezvous header to complete message
-		 */
+		/* Find matching receive to maintain message ordering. */
 		ret = rxm_get_recv_entry(rx_buf, entry);
 		if (ret)
 			return ret;
 
-		*count = 1;
-		iov[0].iov_base = &rx_buf->pkt.data;
-		iov[0].iov_len = sizeof(struct rxm_rndv_hdr);
-		break;
+		/* fall through */
 	case rxm_ctrl_atomic:
-		*count = 1;
-		iov[0].iov_base = &rx_buf->pkt.data;
-		iov[0].iov_len = sizeof(struct rxm_atomic_hdr);
-		break;
 	case rxm_ctrl_atomic_resp:
-		*count = 1;
-		iov[0].iov_base = &rx_buf->pkt.data;
-		iov[0].iov_len = sizeof(struct rxm_atomic_resp_hdr);
-		break;
 	case rxm_ctrl_rndv_wr_data:
-		*count = 1;
-		iov[0].iov_base = &rx_buf->pkt.data;
-		iov[0].iov_len = sizeof(struct rxm_rndv_hdr);
-		break;
 	case rxm_ctrl_rndv_wr_done:
 	case rxm_ctrl_rndv_rd_done:
 	case rxm_ctrl_credit:
-		*count = 0;
-		iov[0].iov_base = NULL;
-		iov[0].iov_len = 0;
+		*count = 1;
+		iov[0].iov_base = &rx_buf->pkt.data;
+		iov[0].iov_len = rxm_eager_limit;
 		break;
 	case rxm_ctrl_seg:
 	default:
 		FI_WARN(&rxm_prov, FI_LOG_CQ,
 			"Unexpected request for dynamic rbuf\n");
-		*count = 0;
+		*count = 1;
+		iov[0].iov_base = &rx_buf->pkt.data;
+		iov[0].iov_len = rxm_eager_limit;
 		break;
 	}
 

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -545,7 +545,7 @@ RXM_INI
 			"copying application buffers through bounce buffers "
 			"before passing them to the core provider.  This "
 			"feature targets small to medium size message "
-			"transfers over the tcp provider.  (default: false)");
+			"transfers over the tcp provider.  (default: true)");
 
 	rxm_init_infos();
 	fi_param_get_size_t(&rxm_prov, "msg_tx_size", &rxm_msg_tx_size);


### PR DESCRIPTION
Disable direct send optimization for verbs.  For some reason, using it over HFI results in corrupted receive data.  (Works for other verbs devices).

This should still result in a failure on AWS NCCL.  The failure there also suggests that either receive data is corrupted, or tags are not being matched correctly (initial address exchange appears to fail).  But that failure looks related to the dynamic receive patch.

Verify that all CI passes prior to merging.