### PR TITLE
build: Add --enable-only option to only build specified providers

### DIFF
--- a/config/fi_provider.m4
+++ b/config/fi_provider.m4
@@ -68,7 +68,13 @@ dnl
 					and use $1 installed under PATH)])
 			     ],
 			     [],
-			     [enable_$1=auto])])
+			     [AS_IF([test x"$enable_only" != x"no"],
+			            [AC_MSG_NOTICE([*** Skipping $1 because $enable_only set])
+			             enable_$1=no],
+			            [enable_$1=auto])
+			    ])
+	      ])
+
 
 	# Save CPPFLAGS and LDFLAGS before they are modified by FI_CHECK_PREFIX_DIR.
 	# Provider's local macros could use the value if needed.

--- a/configure.ac
+++ b/configure.ac
@@ -86,6 +86,12 @@ AC_ARG_ENABLE([direct],
 	[],
 	[enable_direct=no])
 
+AC_ARG_ENABLE([only],
+	[AS_HELP_STRING([--enable-only],
+		[Only build explicitly specified fabric providers])
+	],
+	[],
+	[enable_only=no])
 
 AC_ARG_ENABLE([atomics],
 	[AS_HELP_STRING([--enable-atomics],


### PR DESCRIPTION
Rather than needing to explicitly disable the build for all other
providers when a single provider is desired, add an enable-only
option that only builds providers that are explicitly enabled

Signed-off-by: Sean Hefty <sean.hefty@intel.com>