### PR TITLE
prov/rxm: Minor non-functional code cleanup/readability changes

### DIFF
--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -582,7 +582,7 @@ int rxm_cmap_process_connreq(struct rxm_cmap *cmap, void *addr,
 						    &handle);
 	}
 	if (ret)
-		goto unlock;
+		return ret;
 
 	switch (handle->state) {
 	case RXM_CMAP_CONNECTED:
@@ -617,7 +617,7 @@ int rxm_cmap_process_connreq(struct rxm_cmap *cmap, void *addr,
 							  RXM_CMAP_CONNREQ_RECV,
 							  &handle);
 			if (ret)
-				goto unlock;
+				return ret;
 
 			assert(fi_addr != FI_ADDR_NOTAVAIL);
 			handle->fi_addr = fi_addr;
@@ -641,7 +641,7 @@ int rxm_cmap_process_connreq(struct rxm_cmap *cmap, void *addr,
 		assert(0);
 		ret = -FI_EOPBADSTATE;
 	}
-unlock:
+
 	return ret;
 }
 

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -568,23 +568,21 @@ int rxm_cmap_process_connreq(struct rxm_cmap *cmap, void *addr,
 	ofi_straddr_dbg(cmap->av->prov, FI_LOG_EP_CTRL,
 			"Processing connreq from remote pep", addr);
 
-	if (fi_addr == FI_ADDR_NOTAVAIL)
+	if (fi_addr == FI_ADDR_NOTAVAIL) {
 		handle = rxm_cmap_get_handle_peer(cmap, addr);
-	else
-		handle = rxm_cmap_acquire_handle(cmap, fi_addr);
-
-	if (!handle) {
-		if (fi_addr == FI_ADDR_NOTAVAIL)
+		if (!handle)
 			ret = rxm_cmap_alloc_handle_peer(cmap, addr,
 							 RXM_CMAP_CONNREQ_RECV,
 							 &handle);
-		else
+	} else {
+		handle = rxm_cmap_acquire_handle(cmap, fi_addr);
+		if (!handle)
 			ret = rxm_cmap_alloc_handle(cmap, fi_addr,
 						    RXM_CMAP_CONNREQ_RECV,
 						    &handle);
-		if (ret)
-			goto unlock;
 	}
+	if (ret)
+		goto unlock;
 
 	switch (handle->state) {
 	case RXM_CMAP_CONNECTED:


### PR DESCRIPTION
Non-functional changes to make rxm_cmap_process_connreq() easier to read and remove misleading label usage.