### PR TITLE
prov/rxm: Fail wait calls if an interrupt is received

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -1283,7 +1283,7 @@ int ft_init_av_dst_addr(struct fid_av *av_ptr, struct fid_ep *ep_ptr,
 		if (ret)
 			return ret;
 	} else {
-		ret = (int) ft_rx(ep, FT_MAX_CTRL_MSG);
+		ret = ft_get_rx_comp(rx_seq);
 		if (ret)
 			return ret;
 
@@ -1292,6 +1292,10 @@ int ft_init_av_dst_addr(struct fid_av *av_ptr, struct fid_ep *ep_ptr,
 		ret = ft_av_insert(av_ptr, (char *) rx_buf + ft_rx_prefix_size(),
 				   1, ((fi->domain_attr->av_type == FI_AV_TABLE) ?
 				       NULL : remote_addr), 0, NULL);
+		if (ret)
+			return ret;
+
+		ret = ft_post_rx(ep, rx_size, &rx_ctx);
 		if (ret)
 			return ret;
 
@@ -2087,8 +2091,8 @@ ssize_t ft_post_rx_buf(struct fid_ep *ep, size_t size, void *ctx,
 	if (hints->caps & FI_TAGGED) {
 		op_tag = op_tag ? op_tag : rx_seq;
 		FT_POST(fi_trecv, ft_progress, rxcq, rx_seq, &rx_cq_cntr,
-			"receive", ep, op_buf, size, op_mr_desc, 0, op_tag,
-			0, ctx);
+			"receive", ep, op_buf, size, op_mr_desc,
+			remote_fi_addr, op_tag, 0, ctx);
 	} else {
 		FT_POST(fi_recv, ft_progress, rxcq, rx_seq, &rx_cq_cntr,
 			"receive", ep, op_buf, size, op_mr_desc, 0, ctx);

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -1296,23 +1296,17 @@ static ssize_t rxm_eq_sread(struct rxm_ep *rxm_ep, size_t len,
 			    struct rxm_msg_eq_entry *entry)
 {
 	ssize_t rd;
-	int once = 1;
 
-	do {
-		/* TODO convert this to poll + fi_eq_read so that we can grab
-		 * rxm_ep lock before reading the EQ. This is needed to avoid
-		 * processing events / error entries from closed MSG EPs. This
-		 * can be done only for non-Windows OSes as Windows doesn't
-		 * have poll for a generic file descriptor. */
-		rd = fi_eq_sread(rxm_ep->msg_eq, &entry->event, &entry->cm_entry,
-				 len, -1, 0);
-		if (rd >= 0)
-			return rd;
-		if (rd == -FI_EINTR && once) {
-			FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "Ignoring EINTR\n");
-			once = 0;
-		}
-	} while (rd == -FI_EINTR);
+	/* TODO convert this to poll + fi_eq_read so that we can grab
+	 * rxm_ep lock before reading the EQ. This is needed to avoid
+	 * processing events / error entries from closed MSG EPs. This
+	 * can be done only for non-Windows OSes as Windows doesn't
+	 * have poll for a generic file descriptor.
+	 */
+	rd = fi_eq_sread(rxm_ep->msg_eq, &entry->event, &entry->cm_entry,
+			 len, -1, 0);
+	if (rd >= 0)
+		return rd;
 
 	if (rd != -FI_EAVAIL) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
@@ -1430,11 +1424,9 @@ static void *rxm_conn_atomic_progress(void *arg)
 			fds[1].revents = 0;
 
 			ret = poll(fds, 2, -1);
-			if (ret == -1 && errno != EINTR) {
+			if (ret == -1) {
 				FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
-					"Select error %s, closing CM thread\n",
-					strerror(errno));
-				goto out;
+					"Select error %s\n", strerror(errno));
 			}
 		}
 		rxm_conn_auto_progress_eq(ep, entry);
@@ -1443,7 +1435,6 @@ static void *rxm_conn_atomic_progress(void *arg)
 	}
 	ofi_ep_lock_release(&ep->util_ep);
 
-out:
 	FI_INFO(&rxm_prov, FI_LOG_EP_CTRL, "Stopping auto progress thread\n");
 	return NULL;
 }


### PR DESCRIPTION
Don't discard thread interrupts.  Allow the thread to return to the caller or continue processing as usual.