### PR TITLE
include/rdma, man/fi_mr: add FI_HMEM_DEVICE_ONLY flag for use in fi_mr_regattr

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -166,6 +166,7 @@ typedef struct fid *fid_t;
 #define FI_COMMIT_COMPLETE	(1ULL << 30)
 #define FI_MATCH_COMPLETE	(1ULL << 31)
 
+#define FI_HMEM_DEVICE_ONLY	(1ULL << 46)
 #define FI_HMEM			(1ULL << 47)
 #define FI_VARIABLE_MSG		(1ULL << 48)
 #define FI_RMA_PMEM		(1ULL << 49)

--- a/man/fi_mr.3.md
+++ b/man/fi_mr.3.md
@@ -667,6 +667,12 @@ The follow flag may be specified to any memory registration call.
   specified if persistent completion semantics or persistent data transfers
   are required when accessing the registered region.
 
+*FI_HMEM_DEVICE_ONLY*
+: This flag indicates that the memory is only accessible by a device. Which
+  device is specified by the fi_mr_attr fields iface and device. This refers
+  to memory regions that were allocated using a device API AllocDevice call
+  (as opposed to using the host allocation or unified/shared memory allocation). 
+
 # MEMORY DOMAINS
 
 Memory domains identify the physical separation of memory which


### PR DESCRIPTION
Some providers may need to know whether memory allocated by a device
API is only accessible by the device (vs host or unified memory).

Add a flag that can be passed into the fi_mr_regattr call to specify
this condition.

Add definition to man pages as well.

Signed-off-by: aingerson <alexia.ingerson@intel.com>