### PR TITLE
prov/gni: swat a configury bug

### DIFF
--- a/prov/gni/configure.m4
+++ b/prov/gni/configure.m4
@@ -2,6 +2,8 @@ dnl
 dnl Copyright (c) 2015-2019 Cray Inc. All rights reserved.
 dnl Copyright (c) 2015-2018 Los Alamos National Security, LLC.
 dnl                         All rights reserved.
+dnl Copyright (c) 2021      Triad National Security, LLC. All rights
+dnl                         reserved.
 dnl
 dnl This software is available to you under a choice of one of two
 dnl licenses.  You may choose to be licensed under the terms of the GNU
@@ -119,14 +121,15 @@ AC_DEFUN([FI_GNI_CONFIGURE],[
                       [AC_DEFINE_UNQUOTED([HAVE_XPMEM], [0], [Define to 1 if xpmem available])
                       ])
 
-               gni_path_to_gni_pub=${CRAY_GNI_HEADERS_INCLUDE_OPTS:2}/gni_pub.h
-               dnl Trim the leading -I in order to provide a path
 
+               CPPFLAGS_SAVE=$CPPFLAGS
+               CPPFLAGS="$gni_CPPFLAGS $CPPFLAGS"
                AC_CHECK_TYPES([gni_ct_cqw_post_descriptor_t], [],
                               [AC_MSG_WARN([GNI provider requires CLE 5.2.UP04 or higher. Disabling gni provider.])
                                gni_header_happy=0
                               ],
-                              [[#include "$gni_path_to_gni_pub"]])
+                              [[#include "gni_pub.h"]])
+               CPPFLAGS=$CPPFLAGS_SAVE
 
                AS_IF([test -d $srcdir/prov/gni/test],
                      [AC_ARG_WITH([criterion], [AS_HELP_STRING([--with-criterion],


### PR DESCRIPTION
there was some configury code which was brittle and ended up
failing at some point after some kind of cray software moduel file
changes.

use more standard approach of tweaking CPPFLAGS to have AC_CHECK_TYPES
work.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>