### PR TITLE
rxm + tcp optimizations

### DIFF
--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -214,6 +214,35 @@ static inline ssize_t ofi_byteq_send(struct ofi_byteq *byteq, SOCKET sock)
 
 
 /*
+ * Buffered socket - socket with send/receive staging buffers.
+ */
+struct ofi_bsock {
+	SOCKET sock;
+	struct ofi_byteq sq;
+	struct ofi_byteq rq;
+};
+
+static inline void ofi_bsock_init(struct ofi_bsock *bsock)
+{
+	bsock->sock = INVALID_SOCKET;
+	ofi_byteq_init(&bsock->rq);
+	ofi_byteq_init(&bsock->sq);
+}
+
+static inline size_t ofi_bsock_readable(struct ofi_bsock *bsock)
+{
+	return ofi_byteq_readable(&bsock->rq);
+}
+
+ssize_t ofi_bsock_send(struct ofi_bsock *bsock, const void *buf, size_t len);
+ssize_t ofi_bsock_sendv(struct ofi_bsock *bsock, const struct iovec *iov,
+			size_t cnt);
+ssize_t ofi_bsock_recv(struct ofi_bsock *bsock, void *buf, size_t len);
+ssize_t ofi_bsock_recvv(struct ofi_bsock *bsock, struct iovec *iov,
+			size_t cnt);
+
+
+/*
  * Address utility functions
  */
 

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1488,8 +1488,8 @@ ssize_t rxm_handle_comp(struct rxm_ep *rxm_ep, struct fi_cq_data_entry *comp)
 	}
 }
 
-static int rxm_get_recv_entry(struct rxm_rx_buf *rx_buf,
-			      struct ofi_cq_rbuf_entry *cq_entry)
+static void rxm_get_recv_entry(struct rxm_rx_buf *rx_buf,
+			       struct ofi_cq_rbuf_entry *cq_entry)
 {
 	struct rxm_recv_match_attr match_attr;
 	struct rxm_cmap_handle *cm_handle;
@@ -1529,8 +1529,6 @@ static int rxm_get_recv_entry(struct rxm_rx_buf *rx_buf,
 	} else {
 		recv_queue->dyn_rbuf_unexp_cnt++;
 	}
-
-	return 0;
 }
 
 static void rxm_fake_rx_hdr(struct rxm_rx_buf *rx_buf,
@@ -1577,7 +1575,6 @@ ssize_t rxm_get_dyn_rbuf(struct ofi_cq_rbuf_entry *entry, struct iovec *iov,
 			 size_t *count)
 {
 	struct rxm_rx_buf *rx_buf;
-	int ret;
 
 	rx_buf = entry->op_context;
 	assert(!(rx_buf->ep->rxm_info->mode & FI_BUFFERED_RECV));
@@ -1591,10 +1588,7 @@ ssize_t rxm_get_dyn_rbuf(struct ofi_cq_rbuf_entry *entry, struct iovec *iov,
 
 	switch (rx_buf->pkt.ctrl_hdr.type) {
 	case rxm_ctrl_eager:
-		ret = rxm_get_recv_entry(rx_buf, entry);
-		if (ret)
-			return ret;
-
+		rxm_get_recv_entry(rx_buf, entry);
 		if (rx_buf->recv_entry) {
 			*count = rx_buf->recv_entry->rxm_iov.count;
 			memcpy(iov, rx_buf->recv_entry->rxm_iov.iov, *count *
@@ -1607,9 +1601,7 @@ ssize_t rxm_get_dyn_rbuf(struct ofi_cq_rbuf_entry *entry, struct iovec *iov,
 		break;
 	case rxm_ctrl_rndv_req:
 		/* Find matching receive to maintain message ordering. */
-		ret = rxm_get_recv_entry(rx_buf, entry);
-		if (ret)
-			return ret;
+		rxm_get_recv_entry(rx_buf, entry);
 
 		/* fall through */
 	case rxm_ctrl_atomic:

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -109,7 +109,7 @@ static bool rxm_use_srx(const struct fi_info *hints,
 	info = base_info ? base_info : hints;
 
 	return info && info->fabric_attr && info->fabric_attr->prov_name &&
-	       !strncasecmp(info->fabric_attr->prov_name, "tcp", 3);
+	       !strcasestr(info->fabric_attr->prov_name, "tcp");
 }
 
 int rxm_info_to_core(uint32_t version, const struct fi_info *hints,

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -201,7 +201,12 @@ int rxm_info_to_rxm(uint32_t version, const struct fi_info *core_info,
 					     sizeof(struct rxm_pkt);
 	}
 
-	info->tx_attr->size 		= base_info->tx_attr->size;
+	/* User hints will override the modified info attributes through
+	 * ofi_alter_info.  Set default sizes lower than supported maximums.
+	 */
+	info->tx_attr->size 		= MIN(base_info->tx_attr->size, 2048);
+	info->rx_attr->size 		= MIN(base_info->rx_attr->size, 2048);
+
 	info->tx_attr->iov_limit 	= MIN(base_info->tx_attr->iov_limit,
 					      core_info->tx_attr->iov_limit);
 	info->tx_attr->rma_iov_limit	= MIN(base_info->tx_attr->rma_iov_limit,
@@ -211,7 +216,6 @@ int rxm_info_to_rxm(uint32_t version, const struct fi_info *core_info,
 	info->rx_attr->mode		= info->rx_attr->mode & ~FI_RX_CQ_DATA;
 	info->rx_attr->msg_order 	= core_info->rx_attr->msg_order;
 	info->rx_attr->comp_order 	= base_info->rx_attr->comp_order;
-	info->rx_attr->size 		= base_info->rx_attr->size;
 	info->rx_attr->iov_limit 	= MIN(base_info->rx_attr->iov_limit,
 					      core_info->rx_attr->iov_limit);
 

--- a/prov/tcp/src/tcpx_comm.c
+++ b/prov/tcp/src/tcpx_comm.c
@@ -146,10 +146,8 @@ int tcpx_recv_msg_data(struct tcpx_xfer_entry *rx_entry)
 
 	bytes_recvd = ofi_readv_socket(rx_entry->ep->sock, rx_entry->iov,
 				       rx_entry->iov_cnt);
-	if (bytes_recvd < 0)
-		return bytes_read ? -FI_EAGAIN : -ofi_sockerr();
-	else if (bytes_recvd == 0)
-		return -FI_ENOTCONN;
+	if (bytes_recvd <= 0)
+		return (bytes_recvd) ? -ofi_sockerr(): -FI_ENOTCONN;
 
 	ofi_consume_iov(rx_entry->iov, &rx_entry->iov_cnt, bytes_recvd);
 	return (!rx_entry->iov_cnt || !rx_entry->iov[0].iov_len) ?

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -58,7 +58,7 @@ void tcpx_cq_progress(struct util_cq *cq)
 		tcpx_try_func(&ep->util_ep);
 		fastlock_acquire(&ep->lock);
 		tcpx_progress_tx(ep);
-		if (ep->stage_buf.cur_pos < ep->stage_buf.bytes_avail)
+		if (ofi_bsock_readable(&ep->bsock))
 			tcpx_progress_rx(ep);
 		fastlock_release(&ep->lock);
 	}

--- a/prov/util/src/util_wait.c
+++ b/prov/util/src/util_wait.c
@@ -406,6 +406,11 @@ static int util_wait_fd_run(struct fid_wait *wait_fid, int timeout)
 			return FI_SUCCESS;
 
 		if (ret < 0) {
+#if ENABLE_DEBUG
+			/* ignore interrupts in order to enable debugging */
+			if (ret == -FI_EINTR)
+				continue;
+#endif
 			FI_WARN(wait->util_wait.prov, FI_LOG_FABRIC,
 				"poll failed\n");
 			return ret;


### PR DESCRIPTION
Series of patches targeting rxm + tcp scaling and performance.

- rxm: reduce the default rx/tx sizes, but keep the same max supported value
- rxm: fix check for tcp core provider to ensure srx is used
- tcp: rework use of receive side staging buffer, add send side staging

As part of the changes, introduce 2 new common abstractions.  Byte queue is used to implement staging, or bounce buffer, for sockets.  The goal is to reduce the number of kernel calls and coalesce iovs for small message transfers for both sends and receives.  The send side staging buffer is only used after getting pushback from the kernel accepting new data.  The receive side buffer replaces the existing tcp staging buffer, with a tweaked algorithm.  The receive buffer is used as a prefetch buffer when only a small amount of data needs to be received.

The second abstraction, called a buffered socket, is just a set of helper functions for using the byte queue with socket send/recv calls.  This pushes the staging buffers away below a set of simple socket-like send/recv calls, removing the management of the buffer out of the provider.  This will make it easier to adjust the algorithms that are used.

The performance impact of these changes still needs to be determined.  (In a few simple benchmark runs, it didn't make things better or worse, but the run to run variation is huge).