### PR TITLE
tcp + rxm

### DIFF
--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -221,6 +221,42 @@ static inline ssize_t ofi_byteq_send(struct ofi_byteq *byteq, SOCKET sock)
 
 
 /*
+ * Buffered socket - socket with send/receive staging buffers.
+ */
+struct ofi_bsock {
+	SOCKET sock;
+	struct ofi_byteq sq;
+	struct ofi_byteq rq;
+};
+
+static inline void
+ofi_bsock_init(struct ofi_bsock *bsock, ssize_t sbuf_size, ssize_t rbuf_size)
+{
+	bsock->sock = INVALID_SOCKET;
+	ofi_byteq_init(&bsock->sq, sbuf_size);
+	ofi_byteq_init(&bsock->rq, rbuf_size);
+}
+
+static inline size_t ofi_bsock_readable(struct ofi_bsock *bsock)
+{
+	return ofi_byteq_readable(&bsock->rq);
+}
+
+static inline size_t ofi_bsock_tosend(struct ofi_bsock *bsock)
+{
+	return ofi_byteq_readable(&bsock->sq);
+}
+
+ssize_t ofi_bsock_flush(struct ofi_bsock *bsock);
+ssize_t ofi_bsock_send(struct ofi_bsock *bsock, const void *buf, size_t len);
+ssize_t ofi_bsock_sendv(struct ofi_bsock *bsock, const struct iovec *iov,
+			size_t cnt);
+ssize_t ofi_bsock_recv(struct ofi_bsock *bsock, void *buf, size_t len);
+ssize_t ofi_bsock_recvv(struct ofi_bsock *bsock, struct iovec *iov,
+			size_t cnt);
+
+
+/*
  * Address utility functions
  */
 

--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -118,6 +118,109 @@ static inline int ofi_sendall_socket(SOCKET sock, const void *buf, size_t len)
 int ofi_discard_socket(SOCKET sock, size_t len);
 
 /*
+ * Byte queue - streaming socket staging buffer
+ */
+enum {
+	OFI_BYTEQ_SIZE = 8192,
+};
+
+struct ofi_byteq {
+	size_t size;
+	unsigned int head;
+	unsigned int tail;
+	uint8_t data[OFI_BYTEQ_SIZE];
+};
+
+static inline void ofi_byteq_init(struct ofi_byteq *byteq, ssize_t size)
+{
+	memset(byteq, 0, sizeof *byteq);
+	if (size > OFI_BYTEQ_SIZE)
+		byteq->size = OFI_BYTEQ_SIZE;
+	else if (size >= 0)
+		byteq->size = size;
+	else
+		byteq->size = 0;
+}
+
+static inline size_t ofi_byteq_readable(struct ofi_byteq *byteq)
+{
+	return byteq->tail - byteq->head;
+}
+
+static inline size_t ofi_byteq_writeable(struct ofi_byteq *byteq)
+{
+	return byteq->size - byteq->tail;
+}
+
+static inline size_t
+ofi_byteq_read(struct ofi_byteq *byteq, void *buf, size_t len)
+{
+	size_t avail;
+
+	avail = ofi_byteq_readable(byteq);
+	if (!avail)
+		return 0;
+
+	if (len < avail) {
+		memcpy(buf, &byteq->data[byteq->head], len);
+		byteq->head += len;
+		return len;
+	}
+
+	memcpy(buf, &byteq->data[byteq->head], avail);
+	byteq->head = 0;
+	byteq->tail = 0;
+	return avail;
+}
+
+static inline void
+ofi_byteq_write(struct ofi_byteq *byteq, const void *buf, size_t len)
+{
+	assert(len <= ofi_byteq_writeable(byteq));
+	memcpy(&byteq->data[byteq->tail], buf, len);
+	byteq->tail += len;
+}
+
+void ofi_byteq_writev(struct ofi_byteq *byteq, const struct iovec *iov,
+		      size_t cnt, size_t offset);
+
+static inline ssize_t ofi_byteq_recv(struct ofi_byteq *byteq, SOCKET sock)
+{
+	size_t avail;
+	ssize_t ret;
+
+	avail = ofi_byteq_writeable(byteq);
+	assert(avail);
+	ret = ofi_recv_socket(sock, &byteq->data[byteq->tail], avail,
+			      MSG_NOSIGNAL);
+	if (ret > 0)
+		byteq->tail += ret;
+	return ret;
+}
+
+size_t ofi_byteq_readv(struct ofi_byteq *byteq, struct iovec *iov,
+			size_t cnt, size_t offset);
+
+static inline ssize_t ofi_byteq_send(struct ofi_byteq *byteq, SOCKET sock)
+{
+	size_t avail;
+	ssize_t ret;
+
+	avail = ofi_byteq_readable(byteq);
+	assert(avail);
+	ret = ofi_send_socket(sock, &byteq->data[byteq->head], avail,
+			      MSG_NOSIGNAL);
+	if (ret == avail) {
+		byteq->head = 0;
+		byteq->tail = 0;
+	} else if (ret > 0) {
+		byteq->head += ret;
+	}
+	return ret;
+}
+
+
+/*
  * Address utility functions
  */
 

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1488,8 +1488,8 @@ ssize_t rxm_handle_comp(struct rxm_ep *rxm_ep, struct fi_cq_data_entry *comp)
 	}
 }
 
-static int rxm_get_recv_entry(struct rxm_rx_buf *rx_buf,
-			      struct ofi_cq_rbuf_entry *cq_entry)
+static void rxm_get_recv_entry(struct rxm_rx_buf *rx_buf,
+			       struct ofi_cq_rbuf_entry *cq_entry)
 {
 	struct rxm_recv_match_attr match_attr;
 	struct rxm_cmap_handle *cm_handle;
@@ -1529,8 +1529,6 @@ static int rxm_get_recv_entry(struct rxm_rx_buf *rx_buf,
 	} else {
 		recv_queue->dyn_rbuf_unexp_cnt++;
 	}
-
-	return 0;
 }
 
 static void rxm_fake_rx_hdr(struct rxm_rx_buf *rx_buf,
@@ -1577,7 +1575,6 @@ ssize_t rxm_get_dyn_rbuf(struct ofi_cq_rbuf_entry *entry, struct iovec *iov,
 			 size_t *count)
 {
 	struct rxm_rx_buf *rx_buf;
-	int ret;
 
 	rx_buf = entry->op_context;
 	assert(!(rx_buf->ep->rxm_info->mode & FI_BUFFERED_RECV));
@@ -1591,10 +1588,7 @@ ssize_t rxm_get_dyn_rbuf(struct ofi_cq_rbuf_entry *entry, struct iovec *iov,
 
 	switch (rx_buf->pkt.ctrl_hdr.type) {
 	case rxm_ctrl_eager:
-		ret = rxm_get_recv_entry(rx_buf, entry);
-		if (ret)
-			return ret;
-
+		rxm_get_recv_entry(rx_buf, entry);
 		if (rx_buf->recv_entry) {
 			*count = rx_buf->recv_entry->rxm_iov.count;
 			memcpy(iov, rx_buf->recv_entry->rxm_iov.iov, *count *
@@ -1607,9 +1601,7 @@ ssize_t rxm_get_dyn_rbuf(struct ofi_cq_rbuf_entry *entry, struct iovec *iov,
 		break;
 	case rxm_ctrl_rndv_req:
 		/* Find matching receive to maintain message ordering. */
-		ret = rxm_get_recv_entry(rx_buf, entry);
-		if (ret)
-			return ret;
+		rxm_get_recv_entry(rx_buf, entry);
 
 		/* fall through */
 	case rxm_ctrl_atomic:

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -109,7 +109,7 @@ static bool rxm_use_srx(const struct fi_info *hints,
 	info = base_info ? base_info : hints;
 
 	return info && info->fabric_attr && info->fabric_attr->prov_name &&
-	       !strncasecmp(info->fabric_attr->prov_name, "tcp", 3);
+	       !strcasestr(info->fabric_attr->prov_name, "tcp");
 }
 
 int rxm_info_to_core(uint32_t version, const struct fi_info *hints,

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -201,7 +201,12 @@ int rxm_info_to_rxm(uint32_t version, const struct fi_info *core_info,
 					     sizeof(struct rxm_pkt);
 	}
 
-	info->tx_attr->size 		= base_info->tx_attr->size;
+	/* User hints will override the modified info attributes through
+	 * ofi_alter_info.  Set default sizes lower than supported maximums.
+	 */
+	info->tx_attr->size 		= MIN(base_info->tx_attr->size, 2048);
+	info->rx_attr->size 		= MIN(base_info->rx_attr->size, 2048);
+
 	info->tx_attr->iov_limit 	= MIN(base_info->tx_attr->iov_limit,
 					      core_info->tx_attr->iov_limit);
 	info->tx_attr->rma_iov_limit	= MIN(base_info->tx_attr->rma_iov_limit,
@@ -211,7 +216,6 @@ int rxm_info_to_rxm(uint32_t version, const struct fi_info *core_info,
 	info->rx_attr->mode		= info->rx_attr->mode & ~FI_RX_CQ_DATA;
 	info->rx_attr->msg_order 	= core_info->rx_attr->msg_order;
 	info->rx_attr->comp_order 	= base_info->rx_attr->comp_order;
-	info->rx_attr->size 		= base_info->rx_attr->size;
 	info->rx_attr->iov_limit 	= MIN(base_info->rx_attr->iov_limit,
 					      core_info->rx_attr->iov_limit);
 

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -58,6 +58,7 @@
 #include <ofi_signal.h>
 #include <ofi_util.h>
 #include <ofi_proto.h>
+#include <ofi_net.h>
 
 #ifndef _TCP_H_
 #define _TCP_H_
@@ -72,7 +73,10 @@ extern struct fi_provider	tcpx_prov;
 extern struct util_prov		tcpx_util_prov;
 extern struct fi_info		tcpx_info;
 extern struct tcpx_port_range	port_range;
-extern int			tcpx_nodelay;
+extern int tcpx_nodelay;
+extern int tcpx_staging_sbuf_size;
+extern int tcpx_prefetch_rbuf_size;
+
 struct tcpx_xfer_entry;
 struct tcpx_ep;
 
@@ -216,19 +220,9 @@ struct tcpx_rx_ctx {
 
 typedef int (*tcpx_rx_process_fn_t)(struct tcpx_xfer_entry *rx_entry);
 
-enum {
-	STAGE_BUF_SIZE = 512
-};
-
-struct stage_buf {
-	uint8_t			buf[STAGE_BUF_SIZE];
-	size_t			bytes_avail;
-	size_t			cur_pos;
-};
-
 struct tcpx_ep {
 	struct util_ep		util_ep;
-	SOCKET			sock;
+	struct ofi_bsock	bsock;
 	struct tcpx_cur_rx_msg	cur_rx_msg;
 	struct tcpx_xfer_entry	*cur_rx_entry;
 	tcpx_rx_process_fn_t 	cur_rx_proc_fn;
@@ -243,7 +237,6 @@ struct tcpx_ep {
 	fastlock_t		lock;
 	int (*start_op[ofi_op_write + 1])(struct tcpx_ep *ep);
 	void (*hdr_bswap)(struct tcpx_base_hdr *hdr);
-	struct stage_buf	stage_buf;
 	size_t			min_multi_recv_size;
 	bool			pollout_set;
 };
@@ -334,11 +327,9 @@ void tcpx_cq_report_error(struct util_cq *cq,
 void tcpx_get_cq_info(struct tcpx_xfer_entry *entry, uint64_t *flags,
 		      uint64_t *data, uint64_t *tag);
 
-ssize_t tcpx_recv_hdr(SOCKET sock, struct stage_buf *stage_buf,
-		      struct tcpx_cur_rx_msg *cur_rx_msg);
+ssize_t tcpx_recv_hdr(struct tcpx_ep *ep);
 int tcpx_recv_msg_data(struct tcpx_xfer_entry *recv_entry);
 int tcpx_send_msg(struct tcpx_xfer_entry *tx_entry);
-int tcpx_read_to_buffer(SOCKET sock, struct stage_buf *stage_buf);
 
 struct tcpx_xfer_entry *tcpx_xfer_entry_alloc(struct tcpx_cq *cq,
 					      enum tcpx_op_code type);
@@ -359,6 +350,11 @@ void tcpx_hdr_bswap(struct tcpx_base_hdr *hdr);
 
 void tcpx_tx_queue_insert(struct tcpx_ep *tcpx_ep,
 			  struct tcpx_xfer_entry *tx_entry);
+
+static inline bool tcpx_tx_pending(struct tcpx_ep *ep)
+{
+	return !slist_empty(&ep->tx_queue) || ofi_bsock_tosend(&ep->bsock);
+}
 
 void tcpx_conn_mgr_run(struct util_eq *eq);
 int tcpx_eq_wait_try_func(void *arg);

--- a/prov/tcp/src/tcpx_comm.c
+++ b/prov/tcp/src/tcpx_comm.c
@@ -146,10 +146,8 @@ int tcpx_recv_msg_data(struct tcpx_xfer_entry *rx_entry)
 
 	bytes_recvd = ofi_readv_socket(rx_entry->ep->sock, rx_entry->iov,
 				       rx_entry->iov_cnt);
-	if (bytes_recvd < 0)
-		return bytes_read ? -FI_EAGAIN : -ofi_sockerr();
-	else if (bytes_recvd == 0)
-		return -FI_ENOTCONN;
+	if (bytes_recvd <= 0)
+		return (bytes_recvd) ? -ofi_sockerr(): -FI_ENOTCONN;
 
 	ofi_consume_iov(rx_entry->iov, &rx_entry->iov_cnt, bytes_recvd);
 	return (!rx_entry->iov_cnt || !rx_entry->iov[0].iov_len) ?

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -58,7 +58,7 @@ void tcpx_cq_progress(struct util_cq *cq)
 		tcpx_try_func(&ep->util_ep);
 		fastlock_acquire(&ep->lock);
 		tcpx_progress_tx(ep);
-		if (ep->stage_buf.cur_pos < ep->stage_buf.bytes_avail)
+		if (ofi_bsock_readable(&ep->bsock))
 			tcpx_progress_rx(ep);
 		fastlock_release(&ep->lock);
 	}

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -117,8 +117,8 @@ static int tcpx_ep_connect(struct fid_ep *ep, const void *addr,
 	struct tcpx_cm_context *cm_ctx;
 	int ret;
 
-	if (!addr || !tcpx_ep->sock || paramlen > TCPX_MAX_CM_DATA_SIZE ||
-	    tcpx_ep->state != TCPX_IDLE)
+	if (!addr || (tcpx_ep->bsock.sock == INVALID_SOCKET) ||
+	    (paramlen > TCPX_MAX_CM_DATA_SIZE) || (tcpx_ep->state != TCPX_IDLE))
 		return -FI_EINVAL;
 
 	cm_ctx = calloc(1, sizeof(*cm_ctx));
@@ -129,7 +129,7 @@ static int tcpx_ep_connect(struct fid_ep *ep, const void *addr,
 	}
 
 	tcpx_ep->state = TCPX_CONNECTING;
-	ret = connect(tcpx_ep->sock, (struct sockaddr *) addr,
+	ret = connect(tcpx_ep->bsock.sock, (struct sockaddr *) addr,
 		      (socklen_t) ofi_sizeofaddr(addr));
 	if (ret && !OFI_SOCK_TRY_CONN_AGAIN(ofi_sockerr())) {
 		tcpx_ep->state = TCPX_IDLE;
@@ -145,7 +145,7 @@ static int tcpx_ep_connect(struct fid_ep *ep, const void *addr,
 		memcpy(cm_ctx->msg.data, param, paramlen);
 	}
 
-	ret = ofi_wait_add_fd(tcpx_ep->util_ep.eq->wait, tcpx_ep->sock,
+	ret = ofi_wait_add_fd(tcpx_ep->util_ep.eq->wait, tcpx_ep->bsock.sock,
 			      POLLOUT, tcpx_eq_wait_try_func, NULL,cm_ctx);
 	if (ret)
 		goto disable;
@@ -167,7 +167,8 @@ static int tcpx_ep_accept(struct fid_ep *ep, const void *param, size_t paramlen)
 	struct tcpx_cm_context *cm_ctx;
 	int ret;
 
-	if (tcpx_ep->sock == INVALID_SOCKET || tcpx_ep->state != TCPX_RCVD_REQ)
+	if (tcpx_ep->bsock.sock == INVALID_SOCKET ||
+	    tcpx_ep->state != TCPX_RCVD_REQ)
 		return -FI_EINVAL;
 
 	cm_ctx = calloc(1, sizeof(*cm_ctx));
@@ -185,7 +186,7 @@ static int tcpx_ep_accept(struct fid_ep *ep, const void *param, size_t paramlen)
 		memcpy(cm_ctx->msg.data, param, paramlen);
 	}
 
-	ret = ofi_wait_add_fd(tcpx_ep->util_ep.eq->wait, tcpx_ep->sock,
+	ret = ofi_wait_add_fd(tcpx_ep->util_ep.eq->wait, tcpx_ep->bsock.sock,
 			      POLLOUT, tcpx_eq_wait_try_func, NULL, cm_ctx);
 	if (ret)
 		goto free;
@@ -245,20 +246,20 @@ void tcpx_ep_disable(struct tcpx_ep *ep, int cm_err)
 		if (ep->util_ep.tx_cq) {
 			wait = container_of(ep->util_ep.tx_cq->wait,
 					    struct util_wait_fd, util_wait);
-			ofi_wait_fdset_del(wait, ep->sock);
+			ofi_wait_fdset_del(wait, ep->bsock.sock);
 		}
 
 		if (ep->util_ep.rx_cq) {
 			wait = container_of(ep->util_ep.rx_cq->wait,
 					    struct util_wait_fd, util_wait);
-			ofi_wait_fdset_del(wait, ep->sock);
+			ofi_wait_fdset_del(wait, ep->bsock.sock);
 		}
 		/* fall through */
 	case TCPX_ACCEPTING:
 	case TCPX_CONNECTING:
 		wait = container_of(ep->util_ep.eq->wait,
 				    struct util_wait_fd, util_wait);
-		ofi_wait_fdset_del(wait, ep->sock);
+		ofi_wait_fdset_del(wait, ep->bsock.sock);
 		break;
 
 	default:
@@ -289,7 +290,7 @@ static int tcpx_ep_shutdown(struct fid_ep *ep, uint64_t flags)
 
 	tcpx_ep = container_of(ep, struct tcpx_ep, util_ep.ep_fid);
 
-	ret = ofi_shutdown(tcpx_ep->sock, SHUT_RDWR);
+	ret = ofi_shutdown(tcpx_ep->bsock.sock, SHUT_RDWR);
 	if (ret && ofi_sockerr() != ENOTCONN) {
 		FI_WARN(&tcpx_prov, FI_LOG_EP_DATA, "ep shutdown unsuccessful\n");
 	}
@@ -396,7 +397,7 @@ static int tcpx_ep_getname(fid_t fid, void *addr, size_t *addrlen)
 	int ret;
 
 	tcpx_ep = container_of(fid, struct tcpx_ep, util_ep.ep_fid);
-	ret = ofi_getsockname(tcpx_ep->sock, addr, (socklen_t *)addrlen);
+	ret = ofi_getsockname(tcpx_ep->bsock.sock, addr, (socklen_t *) addrlen);
 	if (ret)
 		return -ofi_sockerr();
 
@@ -410,7 +411,7 @@ static int tcpx_ep_getpeer(struct fid_ep *ep, void *addr, size_t *addrlen)
 	int ret;
 
 	tcpx_ep = container_of(ep, struct tcpx_ep, util_ep.ep_fid);
-	ret = ofi_getpeername(tcpx_ep->sock, addr, (socklen_t *)addrlen);
+	ret = ofi_getpeername(tcpx_ep->bsock.sock, addr, (socklen_t *) addrlen);
 	if (ret)
 		return -ofi_sockerr();
 
@@ -509,13 +510,13 @@ static int tcpx_ep_close(struct fid *fid)
 		fastlock_acquire(&eq->close_lock);
 
 	if (ep->util_ep.rx_cq)
-		ofi_wait_del_fd(ep->util_ep.rx_cq->wait, ep->sock);
+		ofi_wait_del_fd(ep->util_ep.rx_cq->wait, ep->bsock.sock);
 
 	if (ep->util_ep.tx_cq)
-		ofi_wait_del_fd(ep->util_ep.tx_cq->wait, ep->sock);
+		ofi_wait_del_fd(ep->util_ep.tx_cq->wait, ep->bsock.sock);
 
 	if (ep->util_ep.eq && ep->util_ep.eq->wait)
-		ofi_wait_del_fd(ep->util_ep.eq->wait, ep->sock);
+		ofi_wait_del_fd(ep->util_ep.eq->wait, ep->bsock.sock);
 
 	if (eq)
 		fastlock_release(&eq->close_lock);
@@ -531,7 +532,7 @@ static int tcpx_ep_close(struct fid *fid)
 		ofi_eq_remove_fid_events(ep->util_ep.eq,
 					 &ep->util_ep.ep_fid.fid);
 	}
-	ofi_close_socket(ep->sock);
+	ofi_close_socket(ep->bsock.sock);
 	ofi_endpoint_close(&ep->util_ep);
 	fastlock_destroy(&ep->lock);
 
@@ -665,34 +666,36 @@ int tcpx_endpoint(struct fid_domain *domain, struct fi_info *info,
 	if (ret)
 		goto err1;
 
+	ofi_bsock_init(&ep->bsock, tcpx_staging_sbuf_size,
+		       tcpx_prefetch_rbuf_size);
 	if (info->handle) {
 		if (((fid_t) info->handle)->fclass == FI_CLASS_PEP) {
 			pep = container_of(info->handle, struct tcpx_pep,
 					   util_pep.pep_fid.fid);
 
-			ep->sock = pep->sock;
+			ep->bsock.sock = pep->sock;
 			pep->sock = INVALID_SOCKET;
 		} else {
 			ep->state = TCPX_RCVD_REQ;
 			handle = container_of(info->handle,
 					      struct tcpx_conn_handle, handle);
-			ep->sock = handle->sock;
+			ep->bsock.sock = handle->sock;
 			ep->hdr_bswap = handle->endian_match ?
 					tcpx_hdr_none : tcpx_hdr_bswap;
 			free(handle);
 
-			ret = tcpx_setup_socket(ep->sock, info);
+			ret = tcpx_setup_socket(ep->bsock.sock, info);
 			if (ret)
 				goto err3;
 		}
 	} else {
-		ep->sock = ofi_socket(ofi_get_sa_family(info), SOCK_STREAM, 0);
-		if (ep->sock == INVALID_SOCKET) {
+		ep->bsock.sock = ofi_socket(ofi_get_sa_family(info), SOCK_STREAM, 0);
+		if (ep->bsock.sock == INVALID_SOCKET) {
 			ret = -ofi_sockerr();
 			goto err2;
 		}
 
-		ret = tcpx_setup_socket(ep->sock, info);
+		ret = tcpx_setup_socket(ep->bsock.sock, info);
 		if (ret)
 			goto err3;
 	}
@@ -726,7 +729,7 @@ int tcpx_endpoint(struct fid_domain *domain, struct fi_info *info,
 	ep->start_op[ofi_op_write] = tcpx_op_write;
 	return 0;
 err3:
-	ofi_close_socket(ep->sock);
+	ofi_close_socket(ep->bsock.sock);
 err2:
 	ofi_endpoint_close(&ep->util_ep);
 err1:

--- a/prov/tcp/src/tcpx_init.c
+++ b/prov/tcp/src/tcpx_init.c
@@ -54,6 +54,9 @@ struct tcpx_port_range port_range = {
 
 int tcpx_nodelay = -1;
 
+int tcpx_staging_sbuf_size = 0; /* disable send buffering for now */
+int tcpx_prefetch_rbuf_size = OFI_BYTEQ_SIZE;
+
 
 static void tcpx_init_env(void)
 {
@@ -69,6 +72,18 @@ static void tcpx_init_env(void)
 	fi_param_define(&tcpx_prov, "nodelay", FI_PARAM_BOOL,
 			"overrides default TCP_NODELAY socket setting");
 	fi_param_get_bool(&tcpx_prov, "nodelay", &tcpx_nodelay);
+
+	fi_param_define(&tcpx_prov, "staging_sbuf_size", FI_PARAM_INT,
+			"size of buffer used to coalesce iovec's or "
+			"send requests before posting to the kernel, "
+			"set to 0 to disable");
+	fi_param_define(&tcpx_prov, "prefetch_rbuf_size", FI_PARAM_INT,
+			"size of buffer used to prefetch received data from "
+			"the kernel, set to 0 to disable");
+	fi_param_get_int(&tcpx_prov, "staging_sbuf_size",
+			 &tcpx_staging_sbuf_size);
+	fi_param_get_int(&tcpx_prov, "prefetch_rbuf_size",
+			 &tcpx_prefetch_rbuf_size);
 
 	fi_param_get_int(&tcpx_prov, "port_high_range", &port_range.high);
 	fi_param_get_int(&tcpx_prov, "port_low_range", &port_range.low);

--- a/prov/util/src/util_wait.c
+++ b/prov/util/src/util_wait.c
@@ -406,6 +406,11 @@ static int util_wait_fd_run(struct fid_wait *wait_fid, int timeout)
 			return FI_SUCCESS;
 
 		if (ret < 0) {
+#if ENABLE_DEBUG
+			/* ignore interrupts in order to enable debugging */
+			if (ret == -FI_EINTR)
+				continue;
+#endif
 			FI_WARN(wait->util_wait.prov, FI_LOG_FABRIC,
 				"poll failed\n");
 			return ret;


### PR DESCRIPTION
Series of patches targeting rxm + tcp scaling and performance.

- rxm: reduce the default rx/tx sizes, but keep the same max supported value
- rxm: fix check for tcp core provider to ensure srx is used
- tcp: rework use of receive side staging buffer, add send side staging

As part of the changes, introduce 2 new common abstractions. Byte queue is used to implement staging, or bounce buffer, for sockets. The goal is to reduce the number of kernel calls and coalesce iovs for small message transfers for both sends and receives. The send side staging buffer is only used after getting pushback from the kernel accepting new data. The receive side buffer replaces the existing tcp staging buffer, with a tweaked algorithm. The receive buffer is used as a prefetch buffer when only a small amount of data needs to be received.

The second abstraction, called a buffered socket, is just a set of helper functions for using the byte queue with socket send/recv calls. This pushes the staging buffers away below a set of simple socket-like send/recv calls, removing the management of the buffer out of the provider. This will make it easier to adjust the algorithms that are used.

The performance impact of these changes still needs to be determined. (In a few simple benchmark runs, it didn't make things better or worse, but the run to run variation is huge).

Fixed tx progress to flush queued data even if no outstanding operations are pending.