### PR TITLE
prov/tcp: Cast away ofi_bsock_flush return value in progress_tx

### DIFF
--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -675,7 +675,7 @@ void tcpx_progress_tx(struct tcpx_ep *ep)
 		tx_entry = container_of(entry, struct tcpx_xfer_entry, entry);
 		tcpx_process_tx_entry(tx_entry);
 	} else {
-		ofi_bsock_flush(&ep->bsock);
+		(void) ofi_bsock_flush(&ep->bsock);
 	}
 }
 


### PR DESCRIPTION
Fix coverity warning.  We can ignore the return value from
ofi_sock_flush (we have no where to return the value to).

Signed-off-by: Sean Hefty <sean.hefty@intel.com>