### PR TITLE
prov/tcp: rework the data code paths

### DIFF
--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -182,7 +182,7 @@ ofi_byteq_write(struct ofi_byteq *byteq, const void *buf, size_t len)
 }
 
 void ofi_byteq_writev(struct ofi_byteq *byteq, const struct iovec *iov,
-		      size_t cnt, size_t offset);
+		      size_t cnt);
 
 static inline ssize_t ofi_byteq_recv(struct ofi_byteq *byteq, SOCKET sock)
 {
@@ -199,7 +199,7 @@ static inline ssize_t ofi_byteq_recv(struct ofi_byteq *byteq, SOCKET sock)
 }
 
 size_t ofi_byteq_readv(struct ofi_byteq *byteq, struct iovec *iov,
-			size_t cnt, size_t offset);
+		       size_t cnt, size_t offset);
 
 static inline ssize_t ofi_byteq_send(struct ofi_byteq *byteq, SOCKET sock)
 {

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -246,6 +246,7 @@ struct tcpx_fabric {
 	struct util_fabric	util_fabric;
 };
 
+#define TCPX_INTERNAL_XFER	BIT_ULL(60)
 #define TCPX_NEED_DYN_RBUF 	BIT_ULL(61)
 
 struct tcpx_xfer_entry {

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -225,8 +225,10 @@ struct tcpx_ep {
 	struct ofi_bsock	bsock;
 	struct tcpx_cur_rx_msg	cur_rx_msg;
 	struct tcpx_xfer_entry	*cur_rx_entry;
+	size_t			rem_rx_len;
 	tcpx_rx_process_fn_t 	cur_rx_proc_fn;
 	struct tcpx_xfer_entry	*cur_tx_entry;
+	size_t			rem_tx_len;
 	struct dlist_entry	ep_entry;
 	struct slist		rx_queue;
 	struct slist		tx_queue;
@@ -262,7 +264,6 @@ struct tcpx_xfer_entry {
 	struct tcpx_ep		*ep;
 	uint64_t		flags;
 	void			*context;
-	uint64_t		rem_len;
 	void			*mrecv_msg_start;
 };
 
@@ -329,8 +330,8 @@ void tcpx_get_cq_info(struct tcpx_xfer_entry *entry, uint64_t *flags,
 		      uint64_t *data, uint64_t *tag);
 
 ssize_t tcpx_recv_hdr(struct tcpx_ep *ep);
-int tcpx_recv_msg_data(struct tcpx_xfer_entry *recv_entry);
-int tcpx_send_msg(struct tcpx_xfer_entry *tx_entry);
+int tcpx_recv_msg_data(struct tcpx_ep *ep);
+int tcpx_send_msg(struct tcpx_ep *ep);
 
 struct tcpx_xfer_entry *tcpx_xfer_entry_alloc(struct tcpx_cq *cq,
 					      enum tcpx_op_code type);
@@ -351,11 +352,6 @@ void tcpx_hdr_bswap(struct tcpx_base_hdr *hdr);
 
 void tcpx_tx_queue_insert(struct tcpx_ep *tcpx_ep,
 			  struct tcpx_xfer_entry *tx_entry);
-
-static inline bool tcpx_tx_pending(struct tcpx_ep *ep)
-{
-	return !slist_empty(&ep->tx_queue) || ofi_bsock_tosend(&ep->bsock);
-}
 
 void tcpx_conn_mgr_run(struct util_eq *eq);
 int tcpx_eq_wait_try_func(void *arg);

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -218,15 +218,13 @@ struct tcpx_rx_ctx {
 	fastlock_t		lock;
 };
 
-typedef int (*tcpx_rx_process_fn_t)(struct tcpx_xfer_entry *rx_entry);
-
 struct tcpx_ep {
 	struct util_ep		util_ep;
 	struct ofi_bsock	bsock;
 	struct tcpx_cur_rx_msg	cur_rx_msg;
 	struct tcpx_xfer_entry	*cur_rx_entry;
 	size_t			rem_rx_len;
-	tcpx_rx_process_fn_t 	cur_rx_proc_fn;
+	int			(*rx_handler)(struct tcpx_ep *ep);
 	struct tcpx_xfer_entry	*cur_tx_entry;
 	size_t			rem_tx_len;
 	struct dlist_entry	ep_entry;

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -342,6 +342,7 @@ void tcpx_xfer_entry_free(struct tcpx_cq *tcpx_cq,
 void tcpx_srx_entry_free(struct tcpx_rx_ctx *srx_ctx,
 			 struct tcpx_xfer_entry *xfer_entry);
 void tcpx_rx_entry_free(struct tcpx_xfer_entry *rx_entry);
+void tcpx_reset_rx(struct tcpx_ep *ep);
 
 void tcpx_progress_tx(struct tcpx_ep *ep);
 void tcpx_progress_rx(struct tcpx_ep *ep);

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -333,7 +333,6 @@ void tcpx_cq_report_error(struct util_cq *cq,
 void tcpx_get_cq_info(struct tcpx_xfer_entry *entry, uint64_t *flags,
 		      uint64_t *data, uint64_t *tag);
 
-ssize_t tcpx_recv_hdr(struct tcpx_ep *ep);
 int tcpx_recv_msg_data(struct tcpx_ep *ep);
 int tcpx_send_msg(struct tcpx_ep *ep);
 

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -213,6 +213,11 @@ struct tcpx_cur_rx {
 	int			(*handler)(struct tcpx_ep *ep);
 };
 
+struct tcpx_cur_tx {
+	size_t			data_left;
+	struct tcpx_xfer_entry	*entry;
+};
+
 struct tcpx_rx_ctx {
 	struct fid_ep		rx_fid;
 	struct slist		rx_queue;
@@ -225,8 +230,8 @@ struct tcpx_ep {
 	struct util_ep		util_ep;
 	struct ofi_bsock	bsock;
 	struct tcpx_cur_rx	cur_rx;
-	struct tcpx_xfer_entry	*cur_tx_entry;
-	size_t			rem_tx_len;
+	struct tcpx_cur_tx	cur_tx;
+
 	struct dlist_entry	ep_entry;
 	struct slist		rx_queue;
 	struct slist		tx_queue;

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -201,13 +201,16 @@ enum tcpx_state {
 	TCPX_DISCONNECTED,
 };
 
-struct tcpx_cur_rx_msg {
+struct tcpx_cur_rx {
 	union {
 		struct tcpx_base_hdr	base_hdr;
 		uint8_t			max_hdr[TCPX_MAX_HDR];
 	} hdr;
 	size_t			hdr_len;
-	size_t			done_len;
+	size_t			hdr_done;
+	size_t			data_left;
+	struct tcpx_xfer_entry	*entry;
+	int			(*handler)(struct tcpx_ep *ep);
 };
 
 struct tcpx_rx_ctx {
@@ -221,10 +224,7 @@ struct tcpx_rx_ctx {
 struct tcpx_ep {
 	struct util_ep		util_ep;
 	struct ofi_bsock	bsock;
-	struct tcpx_cur_rx_msg	cur_rx_msg;
-	struct tcpx_xfer_entry	*cur_rx_entry;
-	size_t			rem_rx_len;
-	int			(*rx_handler)(struct tcpx_ep *ep);
+	struct tcpx_cur_rx	cur_rx;
 	struct tcpx_xfer_entry	*cur_tx_entry;
 	size_t			rem_tx_len;
 	struct dlist_entry	ep_entry;

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -226,6 +226,7 @@ struct tcpx_ep {
 	struct tcpx_cur_rx_msg	cur_rx_msg;
 	struct tcpx_xfer_entry	*cur_rx_entry;
 	tcpx_rx_process_fn_t 	cur_rx_proc_fn;
+	struct tcpx_xfer_entry	*cur_tx_entry;
 	struct dlist_entry	ep_entry;
 	struct slist		rx_queue;
 	struct slist		tx_queue;

--- a/prov/tcp/src/tcpx_comm.c
+++ b/prov/tcp/src/tcpx_comm.c
@@ -42,14 +42,14 @@ int tcpx_send_msg(struct tcpx_ep *ep)
 	struct tcpx_xfer_entry *tx_entry;
 	ssize_t ret;
 
-	assert(ep->cur_tx_entry);
-	tx_entry = ep->cur_tx_entry;
+	assert(ep->cur_tx.entry);
+	tx_entry = ep->cur_tx.entry;
 	ret = ofi_bsock_sendv(&ep->bsock, tx_entry->iov, tx_entry->iov_cnt);
 	if (ret < 0)
 		return ret;
 
-	ep->rem_tx_len -= ret;
-	if (ep->rem_tx_len) {
+	ep->cur_tx.data_left -= ret;
+	if (ep->cur_tx.data_left) {
 		ofi_consume_iov(tx_entry->iov, &tx_entry->iov_cnt, ret);
 		return -FI_EAGAIN;
 	}

--- a/prov/tcp/src/tcpx_comm.c
+++ b/prov/tcp/src/tcpx_comm.c
@@ -56,18 +56,6 @@ int tcpx_send_msg(struct tcpx_ep *ep)
 	return FI_SUCCESS;
 }
 
-ssize_t tcpx_recv_hdr(struct tcpx_ep *ep)
-{
-	size_t len;
-	void *buf;
-
-	assert(!ep->cur_rx.entry);
-	buf = (uint8_t *) &ep->cur_rx.hdr + ep->cur_rx.hdr_done;
-	len = ep->cur_rx.hdr_len - ep->cur_rx.hdr_done;
-
-	return ofi_bsock_recv(&ep->bsock, buf, len);
-}
-
 int tcpx_recv_msg_data(struct tcpx_ep *ep)
 {
 	struct tcpx_xfer_entry *rx_entry;

--- a/prov/tcp/src/tcpx_comm.c
+++ b/prov/tcp/src/tcpx_comm.c
@@ -61,6 +61,7 @@ ssize_t tcpx_recv_hdr(struct tcpx_ep *ep)
 	size_t len;
 	void *buf;
 
+	assert(!ep->cur_rx_entry);
 	buf = (uint8_t *) &ep->cur_rx_msg.hdr + ep->cur_rx_msg.done_len;
 	len = ep->cur_rx_msg.hdr_len - ep->cur_rx_msg.done_len;
 

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -135,7 +135,6 @@ void tcpx_xfer_entry_free(struct tcpx_cq *tcpx_cq,
 
 	xfer_entry->flags = 0;
 	xfer_entry->context = 0;
-	xfer_entry->rem_len = 0;
 
 	tcpx_cq->util_cq.cq_fastlock_acquire(&tcpx_cq->util_cq.cq_lock);
 	ofi_buf_free(xfer_entry);

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -168,7 +168,7 @@ void tcpx_cq_report_success(struct util_cq *cq,
 	size_t len;
 
 	flags = xfer_entry->flags;
-	if (!(flags & FI_COMPLETION))
+	if (!(flags & FI_COMPLETION) || (flags & TCPX_INTERNAL_XFER))
 		return;
 
 	len = xfer_entry->hdr.base_hdr.size -
@@ -186,6 +186,9 @@ void tcpx_cq_report_error(struct util_cq *cq,
 			  int err)
 {
 	struct fi_cq_err_entry err_entry;
+
+	if (xfer_entry->flags & TCPX_INTERNAL_XFER)
+		return;
 
 	err_entry.flags = xfer_entry->flags;
 	tcpx_get_cq_info(xfer_entry, &err_entry.flags, &err_entry.data,

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -128,11 +128,7 @@ struct tcpx_xfer_entry *tcpx_xfer_entry_alloc(struct tcpx_cq *tcpx_cq,
 void tcpx_xfer_entry_free(struct tcpx_cq *tcpx_cq,
 			  struct tcpx_xfer_entry *xfer_entry)
 {
-	if (xfer_entry->ep->cur_rx_entry == xfer_entry)
-		xfer_entry->ep->cur_rx_entry = NULL;
-
 	xfer_entry->hdr.base_hdr.flags = 0;
-
 	xfer_entry->flags = 0;
 	xfer_entry->context = 0;
 

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -221,6 +221,7 @@ static void tcpx_ep_flush_all_queues(struct tcpx_ep *ep)
 	assert(fastlock_held(&ep->lock));
 	cq = container_of(ep->util_ep.tx_cq, struct tcpx_cq, util_cq);
 	if (ep->cur_tx_entry) {
+		ep->hdr_bswap(&ep->cur_tx_entry->hdr.base_hdr);
 		tcpx_cq_report_error(&cq->util_cq, ep->cur_tx_entry,
 				     FI_ECANCELED);
 		ep->cur_tx_entry = NULL;

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -273,6 +273,7 @@ void tcpx_ep_disable(struct tcpx_ep *ep, int cm_err)
 		return;
 	}
 
+	tcpx_reset_rx(ep);
 	tcpx_ep_flush_all_queues(ep);
 
 	if (cm_err) {

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -220,12 +220,12 @@ static void tcpx_ep_flush_all_queues(struct tcpx_ep *ep)
 
 	assert(fastlock_held(&ep->lock));
 	cq = container_of(ep->util_ep.tx_cq, struct tcpx_cq, util_cq);
-	if (ep->cur_tx_entry) {
-		ep->hdr_bswap(&ep->cur_tx_entry->hdr.base_hdr);
-		tcpx_cq_report_error(&cq->util_cq, ep->cur_tx_entry,
+	if (ep->cur_tx.entry) {
+		ep->hdr_bswap(&ep->cur_tx.entry->hdr.base_hdr);
+		tcpx_cq_report_error(&cq->util_cq, ep->cur_tx.entry,
 				     FI_ECANCELED);
-		tcpx_xfer_entry_free(cq, ep->cur_tx_entry);
-		ep->cur_tx_entry = NULL;
+		tcpx_xfer_entry_free(cq, ep->cur_tx.entry);
+		ep->cur_tx.entry = NULL;
 	}
 
 	tcpx_ep_flush_queue(&ep->tx_queue, cq);
@@ -236,7 +236,7 @@ static void tcpx_ep_flush_all_queues(struct tcpx_ep *ep)
 	if (ep->cur_rx.entry) {
 		tcpx_cq_report_error(&cq->util_cq, ep->cur_rx.entry,
 				     FI_ECANCELED);
-		tcpx_xfer_entry_free(cq, ep->cur_tx_entry);
+		tcpx_xfer_entry_free(cq, ep->cur_tx.entry);
 		tcpx_reset_rx(ep);
 	}
 	tcpx_ep_flush_queue(&ep->rx_queue, cq);

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -449,6 +449,7 @@ static struct fi_ops_cm tcpx_cm_ops = {
 
 void tcpx_reset_rx(struct tcpx_ep *ep)
 {
+	ep->cur_rx.handler = NULL;
 	ep->cur_rx.entry = NULL;
 	ep->cur_rx.hdr_done = 0;
 	ep->cur_rx.hdr_len = sizeof(ep->cur_rx.hdr.base_hdr);

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -233,8 +233,8 @@ static void tcpx_ep_flush_all_queues(struct tcpx_ep *ep)
 	tcpx_ep_flush_queue(&ep->tx_rsp_pend_queue, cq);
 
 	cq = container_of(ep->util_ep.rx_cq, struct tcpx_cq, util_cq);
-	if (ep->cur_rx_entry) {
-		tcpx_cq_report_error(&cq->util_cq, ep->cur_rx_entry,
+	if (ep->cur_rx.entry) {
+		tcpx_cq_report_error(&cq->util_cq, ep->cur_rx.entry,
 				     FI_ECANCELED);
 		tcpx_xfer_entry_free(cq, ep->cur_tx_entry);
 		tcpx_reset_rx(ep);
@@ -449,9 +449,9 @@ static struct fi_ops_cm tcpx_cm_ops = {
 
 void tcpx_reset_rx(struct tcpx_ep *ep)
 {
-	ep->cur_rx_entry = NULL;
-	ep->cur_rx_msg.done_len = 0;
-	ep->cur_rx_msg.hdr_len = sizeof(ep->cur_rx_msg.hdr.base_hdr);
+	ep->cur_rx.entry = NULL;
+	ep->cur_rx.hdr_done = 0;
+	ep->cur_rx.hdr_len = sizeof(ep->cur_rx.hdr.base_hdr);
 }
 
 void tcpx_rx_entry_free(struct tcpx_xfer_entry *rx_entry)
@@ -486,7 +486,7 @@ static void tcpx_ep_cancel_rx(struct tcpx_ep *ep, void *context)
 	slist_foreach(&ep->rx_queue, cur, prev) {
 		xfer_entry = container_of(cur, struct tcpx_xfer_entry, entry);
 		if (xfer_entry->context == context) {
-			if (ep->cur_rx_entry != xfer_entry)
+			if (ep->cur_rx.entry != xfer_entry)
 				goto found;
 			break;
 		}
@@ -732,8 +732,8 @@ int tcpx_endpoint(struct fid_domain *domain, struct fi_info *info,
 	slist_init(&ep->rma_read_queue);
 	slist_init(&ep->tx_rsp_pend_queue);
 
-	ep->cur_rx_msg.done_len = 0;
-	ep->cur_rx_msg.hdr_len = sizeof(ep->cur_rx_msg.hdr.base_hdr);
+	ep->cur_rx.hdr_done = 0;
+	ep->cur_rx.hdr_len = sizeof(ep->cur_rx.hdr.base_hdr);
 	ep->min_multi_recv_size = TCPX_MIN_MULTI_RECV;
 
 	*ep_fid = &ep->util_ep.ep_fid;

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -440,6 +440,13 @@ static struct fi_ops_cm tcpx_cm_ops = {
 	.join = fi_no_join,
 };
 
+void tcpx_reset_rx(struct tcpx_ep *ep)
+{
+	ep->cur_rx_entry = NULL;
+	ep->cur_rx_msg.done_len = 0;
+	ep->cur_rx_msg.hdr_len = sizeof(ep->cur_rx_msg.hdr.base_hdr);
+}
+
 void tcpx_rx_entry_free(struct tcpx_xfer_entry *rx_entry)
 {
 	struct tcpx_cq *tcpx_cq;

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -290,6 +290,8 @@ static int tcpx_ep_shutdown(struct fid_ep *ep, uint64_t flags)
 
 	tcpx_ep = container_of(ep, struct tcpx_ep, util_ep.ep_fid);
 
+	ofi_bsock_flush(&tcpx_ep->bsock);
+
 	ret = ofi_shutdown(tcpx_ep->bsock.sock, SHUT_RDWR);
 	if (ret && ofi_sockerr() != ENOTCONN) {
 		FI_WARN(&tcpx_prov, FI_LOG_EP_DATA, "ep shutdown unsuccessful\n");

--- a/prov/tcp/src/tcpx_msg.c
+++ b/prov/tcp/src/tcpx_msg.c
@@ -227,8 +227,6 @@ static inline void tcpx_queue_send(struct tcpx_ep *ep,
 				   struct tcpx_xfer_entry *tx_entry)
 {
 	tx_entry->rem_len = tx_entry->hdr.base_hdr.size;
-	ep->hdr_bswap(&tx_entry->hdr.base_hdr);
-
 	fastlock_acquire(&ep->lock);
 	tcpx_tx_queue_insert(ep, tx_entry);
 	fastlock_release(&ep->lock);

--- a/prov/tcp/src/tcpx_msg.c
+++ b/prov/tcp/src/tcpx_msg.c
@@ -226,7 +226,6 @@ static ssize_t tcpx_recvv(struct fid_ep *ep, const struct iovec *iov, void **des
 static inline void tcpx_queue_send(struct tcpx_ep *ep,
 				   struct tcpx_xfer_entry *tx_entry)
 {
-	tx_entry->rem_len = tx_entry->hdr.base_hdr.size;
 	fastlock_acquire(&ep->lock);
 	tcpx_tx_queue_insert(ep, tx_entry);
 	fastlock_release(&ep->lock);

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -109,7 +109,7 @@ static int tcpx_queue_msg_resp(struct tcpx_xfer_entry *rx_entry)
 	resp->hdr.base_hdr.size = sizeof(resp->hdr.base_hdr);
 	resp->hdr.base_hdr.payload_off = (uint8_t) sizeof(resp->hdr.base_hdr);
 
-	resp->flags = 0;
+	resp->flags = TCPX_INTERNAL_XFER;
 	resp->context = NULL;
 	resp->ep = ep;
 
@@ -222,7 +222,7 @@ static int tcpx_queue_write_resp(struct tcpx_xfer_entry *rx_entry)
 	resp->hdr.base_hdr.size = sizeof(resp->hdr.base_hdr);
 	resp->hdr.base_hdr.payload_off = (uint8_t) sizeof(resp->hdr.base_hdr);
 
-	resp->flags &= ~FI_COMPLETION;
+	resp->flags |= TCPX_INTERNAL_XFER;
 	resp->context = NULL;
 	resp->ep = ep;
 	tcpx_tx_queue_insert(ep, resp);
@@ -486,7 +486,7 @@ int tcpx_op_read_req(struct tcpx_ep *ep)
 	resp->hdr.base_hdr.op = ofi_op_read_rsp;
 	resp->hdr.base_hdr.payload_off = (uint8_t) sizeof(resp->hdr.base_hdr);
 
-	resp->flags &= ~FI_COMPLETION;
+	resp->flags |= TCPX_INTERNAL_XFER;
 	resp->context = NULL;
 
 	tcpx_tx_queue_insert(ep, resp);
@@ -509,6 +509,8 @@ int tcpx_op_write(struct tcpx_ep *ep)
 	rx_entry->flags = 0;
 	if (ep->cur_rx_msg.hdr.base_hdr.flags & TCPX_REMOTE_CQ_DATA)
 		rx_entry->flags = (FI_COMPLETION | FI_REMOTE_WRITE);
+	else
+		rx_entry->flags = TCPX_INTERNAL_XFER;
 
 	memcpy(&rx_entry->hdr, &ep->cur_rx_msg.hdr,
 	       (size_t) ep->cur_rx_msg.hdr.base_hdr.payload_off);

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -197,6 +197,7 @@ err:
 		"msg recv failed ret = %d (%s)\n", ret, fi_strerror(-ret));
 	tcpx_cq_report_error(rx_entry->ep->util_ep.rx_cq, rx_entry, -ret);
 	tcpx_rx_entry_free(rx_entry);
+	tcpx_reset_rx(ep);
 	return ret;
 }
 
@@ -285,6 +286,7 @@ static int tcpx_process_remote_write(struct tcpx_ep *ep)
 err:
 	FI_WARN(&tcpx_prov, FI_LOG_DOMAIN, "remote write failed %d\n", ret);
 	tcpx_xfer_entry_free(cq, rx_entry);
+	tcpx_reset_rx(ep);
 	return ret;
 }
 
@@ -437,8 +439,7 @@ int tcpx_op_msg(struct tcpx_ep *tcpx_ep)
 truncate_err:
 	FI_WARN(&tcpx_prov, FI_LOG_EP_DATA,
 		"posted rx buffer size is not big enough\n");
-	tcpx_cq_report_error(rx_entry->ep->util_ep.rx_cq,
-				rx_entry, -ret);
+	tcpx_cq_report_error(rx_entry->ep->util_ep.rx_cq, rx_entry, -ret);
 	tcpx_rx_entry_free(rx_entry);
 	return ret;
 }

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -454,7 +454,7 @@ int tcpx_op_read_req(struct tcpx_ep *ep)
 	cq = container_of(ep->util_ep.tx_cq, struct tcpx_cq, util_cq);
 	resp = tcpx_xfer_entry_alloc(cq, TCPX_OP_REMOTE_READ);
 	if (!resp)
-		return -FI_EAGAIN;
+		return -FI_ENOMEM;
 
 	memcpy(&resp->hdr, &ep->cur_rx.hdr,
 	       (size_t) ep->cur_rx.hdr.base_hdr.payload_off);
@@ -504,7 +504,7 @@ int tcpx_op_write(struct tcpx_ep *ep)
 	cq = container_of(ep->util_ep.rx_cq, struct tcpx_cq, util_cq);
 	rx_entry = tcpx_xfer_entry_alloc(cq, TCPX_OP_REMOTE_WRITE);
 	if (!rx_entry)
-		return -FI_EAGAIN;
+		return -FI_ENOMEM;
 
 	rx_entry->flags = 0;
 	if (ep->cur_rx.hdr.base_hdr.flags & TCPX_REMOTE_CQ_DATA)

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -434,7 +434,7 @@ int tcpx_op_msg(struct tcpx_ep *tcpx_ep)
 
 	tcpx_ep->cur_rx.entry = rx_entry;
 	tcpx_ep->cur_rx.handler = tcpx_process_recv;
-	return FI_SUCCESS;
+	return tcpx_process_recv(tcpx_ep);
 
 truncate_err:
 	FI_WARN(&tcpx_prov, FI_LOG_EP_DATA,
@@ -538,8 +538,7 @@ int tcpx_op_write(struct tcpx_ep *ep)
 
 	ep->cur_rx.entry = rx_entry;
 	ep->cur_rx.handler = tcpx_process_remote_write;
-	return FI_SUCCESS;
-
+	return tcpx_process_remote_write(ep);
 }
 
 int tcpx_op_read_rsp(struct tcpx_ep *tcpx_ep)
@@ -559,7 +558,7 @@ int tcpx_op_read_rsp(struct tcpx_ep *tcpx_ep)
 
 	tcpx_ep->cur_rx.entry = rx_entry;
 	tcpx_ep->cur_rx.handler = tcpx_process_remote_read;
-	return FI_SUCCESS;
+	return tcpx_process_remote_read(tcpx_ep);
 }
 
 static int tcpx_recv_hdr(struct tcpx_ep *ep)

--- a/prov/tcp/src/tcpx_rma.c
+++ b/prov/tcp/src/tcpx_rma.c
@@ -72,7 +72,6 @@ static void tcpx_rma_read_send_entry_fill(struct tcpx_xfer_entry *send_entry,
 	send_entry->iov[0].iov_len = offset;
 	send_entry->iov_cnt = 1;
 	send_entry->ep = tcpx_ep;
-	send_entry->rem_len = send_entry->hdr.base_hdr.size;
 }
 
 static void tcpx_rma_read_recv_entry_fill(struct tcpx_xfer_entry *recv_entry,
@@ -242,7 +241,6 @@ static ssize_t tcpx_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg
 
 	send_entry->ep = tcpx_ep;
 	send_entry->context = msg->context;
-	send_entry->rem_len = send_entry->hdr.base_hdr.size;
 
 	fastlock_acquire(&tcpx_ep->lock);
 	tcpx_tx_queue_insert(tcpx_ep, send_entry);
@@ -374,9 +372,7 @@ static ssize_t tcpx_rma_inject_common(struct fid_ep *ep, const void *buf,
 
 	send_entry->hdr.base_hdr.size = offset;
 	send_entry->ep = tcpx_ep;
-	send_entry->rem_len = send_entry->hdr.base_hdr.size;
 
-	tcpx_ep->hdr_bswap(&send_entry->hdr.base_hdr);
 	fastlock_acquire(&tcpx_ep->lock);
 	tcpx_tx_queue_insert(tcpx_ep, send_entry);
 	fastlock_release(&tcpx_ep->lock);

--- a/prov/tcp/src/tcpx_rma.c
+++ b/prov/tcp/src/tcpx_rma.c
@@ -117,7 +117,6 @@ static ssize_t tcpx_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 	tcpx_rma_read_send_entry_fill(send_entry, tcpx_ep, msg);
 	tcpx_rma_read_recv_entry_fill(recv_entry, tcpx_ep, msg, flags);
 
-	tcpx_ep->hdr_bswap(&send_entry->hdr.base_hdr);
 	fastlock_acquire(&tcpx_ep->lock);
 	slist_insert_tail(&recv_entry->entry, &tcpx_ep->rma_read_queue);
 	tcpx_tx_queue_insert(tcpx_ep, send_entry);
@@ -245,7 +244,6 @@ static ssize_t tcpx_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg
 	send_entry->context = msg->context;
 	send_entry->rem_len = send_entry->hdr.base_hdr.size;
 
-	tcpx_ep->hdr_bswap(&send_entry->hdr.base_hdr);
 	fastlock_acquire(&tcpx_ep->lock);
 	tcpx_tx_queue_insert(tcpx_ep, send_entry);
 	fastlock_release(&tcpx_ep->lock);

--- a/prov/tcp/src/tcpx_shared_ctx.c
+++ b/prov/tcp/src/tcpx_shared_ctx.c
@@ -41,8 +41,8 @@
 void tcpx_srx_entry_free(struct tcpx_rx_ctx *srx_ctx,
 			 struct tcpx_xfer_entry *xfer_entry)
 {
-	if (xfer_entry->ep->cur_rx_entry == xfer_entry)
-		xfer_entry->ep->cur_rx_entry = NULL;
+	if (xfer_entry->ep->cur_rx.entry == xfer_entry)
+		xfer_entry->ep->cur_rx.entry = NULL;
 
 	fastlock_acquire(&srx_ctx->lock);
 	ofi_buf_free(xfer_entry);


### PR DESCRIPTION
This series simplifies how the send and receive states are managed.  Each endpoint is active on a single transmit or receive operation at a time.  Until that operation completes, the state associated with the message does not change, except for the remaining data needing to be sent/received.  These changes target a problem where an older received header appears to be processed multiple times as a newly received message.  

The series has gone through a light set of local testing (single node in loopback) only.