### PR TITLE
[v1.12.x] prov/efa: Fix a bug in rxr_pkt_post_handshake

### DIFF
--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -80,7 +80,10 @@ ssize_t rxr_pkt_post_handshake(struct rxr_ep *ep, struct rxr_peer *peer)
 	ssize_t ret;
 
 	addr = peer->efa_fiaddr;
-	pkt_entry = rxr_pkt_entry_alloc(ep, ep->tx_pkt_efa_pool);
+	if (peer->is_local)
+		pkt_entry = rxr_pkt_entry_alloc(ep, ep->tx_pkt_shm_pool);
+	else
+		pkt_entry = rxr_pkt_entry_alloc(ep, ep->tx_pkt_efa_pool);
 	if (OFI_UNLIKELY(!pkt_entry))
 		return -FI_EAGAIN;
 


### PR DESCRIPTION
In rxr_pkt_post_handshake, we always allocate pkt_entry
from tx_pkt_efa_pool even though the peer could be local peer.
However, we only increment 'ep->tx_pending' for successful
send to non-local peer. This causes the mismatch between
ep->tx_pending and number of allocated pkt_entry from
tx_pkt_efa_pool.

This patch fixed this issue by allocating pkt_entry
from tx_pkt_shm_pool for local peer.

Signed-off-by: Jie Zhang <zhngaj@amazon.com>