### PR TITLE
[V1.11.x] prov/efa: backport two bugfix commits 

### DIFF
--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1636,6 +1636,8 @@ void rxr_ep_progress_internal(struct rxr_ep *ep)
 			ret = rxr_pkt_post_data(ep, tx_entry);
 			if (OFI_UNLIKELY(ret)) {
 				tx_entry->send_flags &= ~FI_MORE;
+				if (ret == -FI_EAGAIN)
+					goto out;
 				goto tx_err;
 			}
 		}

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -59,8 +59,12 @@ ssize_t rxr_pkt_post_data(struct rxr_ep *rxr_ep,
 	ssize_t ret;
 
 	pkt_entry = rxr_pkt_entry_alloc(rxr_ep, rxr_ep->tx_pkt_efa_pool);
-	if (OFI_UNLIKELY(!pkt_entry))
-		return -FI_ENOMEM;
+	if (OFI_UNLIKELY(!pkt_entry)) {
+		FI_DBG(&rxr_prov, FI_LOG_EP_DATA,
+		       "TX packets exhausted, current packets in flight %lu",
+		       rxr_ep->tx_pending);
+		return -FI_EAGAIN;
+	}
 
 	pkt_entry->x_entry = (void *)tx_entry;
 	pkt_entry->addr = tx_entry->addr;

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -76,7 +76,11 @@ void rxr_pkt_post_handshake(struct rxr_ep *ep,
 
 	assert(!(peer->flags & RXR_PEER_HANDSHAKE_SENT));
 
-	pkt_entry = rxr_pkt_entry_alloc(ep, ep->tx_pkt_efa_pool);
+	if (peer->is_local)
+		pkt_entry = rxr_pkt_entry_alloc(ep, ep->tx_pkt_shm_pool);
+	else
+		pkt_entry = rxr_pkt_entry_alloc(ep, ep->tx_pkt_efa_pool);
+
 	if (OFI_UNLIKELY(!pkt_entry))
 		return;
 


### PR DESCRIPTION
prov/efa: return EAGAIN when pkts are exhausted sending segments
prov/efa: Fix a bug in rxr_pkt_post_handshake 