### PR TITLE
prov/tcp: Fix and an optimization to progress path

### DIFF
--- a/prov/tcp/src/tcpx_init.c
+++ b/prov/tcp/src/tcpx_init.c
@@ -55,7 +55,7 @@ struct tcpx_port_range port_range = {
 int tcpx_nodelay = -1;
 
 int tcpx_staging_sbuf_size = 0; /* disable send buffering for now */
-int tcpx_prefetch_rbuf_size = OFI_BYTEQ_SIZE;
+int tcpx_prefetch_rbuf_size = 0; /* disable prefetch buffer too! */
 
 
 static void tcpx_init_env(void)

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -684,6 +684,11 @@ int tcpx_try_func(void *util_ep)
 			       struct util_wait_fd, util_wait);
 
 	fastlock_acquire(&ep->lock);
+	if (ofi_bsock_readable(&ep->bsock)) {
+		ret = -FI_EAGAIN;
+		goto out;
+	}
+
 	if (tcpx_tx_pending(ep) && !ep->pollout_set) {
 		ep->pollout_set = true;
 		events = (wait_fd->util_wait.wait_obj == FI_WAIT_FD) ?
@@ -707,6 +712,7 @@ epoll_mod:
 	if (ret)
 		FI_WARN(&tcpx_prov, FI_LOG_EP_DATA,
 			"epoll modify failed\n");
+out:
 	fastlock_release(&ep->lock);
 	return ret;
 }


### PR DESCRIPTION
Fix possible application hang or stall when using blocking cq read calls.  Fail try_wait if there's data queued in the prefetch buffer (previously staging buffer).

Avoid always trying to call send progress on all endpoints unless the socket has been marked writeable.