### PR TITLE
prov/tcp: Fix progress flow to avoid possible hang

### DIFF
--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -347,6 +347,7 @@ void tcpx_reset_rx(struct tcpx_ep *ep);
 void tcpx_progress_tx(struct tcpx_ep *ep);
 void tcpx_progress_rx(struct tcpx_ep *ep);
 int tcpx_try_func(void *util_ep);
+int tcpx_mod_epoll(struct tcpx_ep *ep);
 
 void tcpx_hdr_none(struct tcpx_base_hdr *hdr);
 void tcpx_hdr_bswap(struct tcpx_base_hdr *hdr);

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -38,23 +38,6 @@
 #define TCPX_DEF_CQ_SIZE (1024)
 
 
-/* If we have data queued in the prefetch buffer, we need to
- * process it before blocking on poll.  Otherwise we may block
- * waiting to receive data that's already been fetched.  We
- * also need to progress receives in the case where we're waiting
- * on the application to post a buffer to consume a receive
- * that we've already read from the kernel.  If the message is
- * of length 0, there's no additional data to read, so failing
- * to progress can result in application hangs.  Finally,
- * if we're expecting data, optimistically go look for it.
- */
-static inline bool tcpx_rx_pending(struct tcpx_ep *ep)
-{
-	return ofi_bsock_readable(&ep->bsock) ||
-	       (ep->cur_rx.handler && !ep->cur_rx.entry) ||
-	       ep->cur_rx.data_left;
-}
-
 void tcpx_cq_progress(struct util_cq *cq)
 {
 	void *wait_contexts[MAX_POLL_EVENTS];
@@ -73,11 +56,19 @@ void tcpx_cq_progress(struct util_cq *cq)
 		ep = container_of(fid_entry->fid, struct tcpx_ep,
 				  util_ep.ep_fid.fid);
 
-		while (tcpx_try_func(&ep->util_ep) == -FI_EAGAIN) {
-			fastlock_acquire(&ep->lock);
+		fastlock_acquire(&ep->lock);
+		/* We need to progress receives in the case where we're waiting
+		 * on the application to post a buffer to consume a receive
+		 * that we've already read from the kernel.  If the message is
+		 * of length 0, there's no additional data to read, so failing
+		 * to progress can result in application hangs.
+		 */
+		if (ofi_bsock_readable(&ep->bsock) ||
+		    (ep->cur_rx.handler && !ep->cur_rx.entry))
 			tcpx_progress_rx(ep);
-			fastlock_release(&ep->lock);
-		}
+
+		(void) tcpx_mod_epoll(ep);
+		fastlock_release(&ep->lock);
 	}
 
 	nfds = (wait_fd->util_wait.wait_obj == FI_WAIT_FD) ?


### PR DESCRIPTION
In fixing the tcpx_try_func, I broke tcpx_cq_progress.  I added a while loop instead of using an if statement, and I dropped one of the conditions that needed to be checked.