### PR TITLE
prov/tcp: fixes to progress stalls

### DIFF
--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -249,7 +249,8 @@ struct tcpx_ep {
 	int (*start_op[ofi_op_write + 1])(struct tcpx_ep *ep);
 	void (*hdr_bswap)(struct tcpx_base_hdr *hdr);
 	size_t			min_multi_recv_size;
-	bool			pollout_set;
+	bool			rx_pollout_set;
+	bool			tx_pollout_set;
 };
 
 struct tcpx_fabric {
@@ -352,7 +353,7 @@ void tcpx_reset_rx(struct tcpx_ep *ep);
 void tcpx_progress_tx(struct tcpx_ep *ep);
 void tcpx_progress_rx(struct tcpx_ep *ep);
 int tcpx_try_func(void *util_ep);
-int tcpx_mod_epoll(struct tcpx_ep *ep);
+int tcpx_mod_epoll(struct tcpx_ep *ep, struct util_cq *cq);
 
 void tcpx_hdr_none(struct tcpx_base_hdr *hdr);
 void tcpx_hdr_bswap(struct tcpx_base_hdr *hdr);

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -347,6 +347,7 @@ void tcpx_reset_rx(struct tcpx_ep *ep);
 void tcpx_progress_tx(struct tcpx_ep *ep);
 void tcpx_progress_rx(struct tcpx_ep *ep);
 int tcpx_try_func(void *util_ep);
+int tcpx_mod_epoll(struct tcpx_ep *ep);
 
 void tcpx_hdr_none(struct tcpx_base_hdr *hdr);
 void tcpx_hdr_bswap(struct tcpx_base_hdr *hdr);

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -128,7 +128,10 @@ struct tcpx_base_hdr {
 	uint8_t			op_data;
 	uint8_t			rma_iov_cnt;
 	uint8_t			payload_off;
-	uint8_t			rsvd;
+	union {
+		uint8_t		rsvd;
+		uint8_t		id; /* debug */
+	};
 	uint64_t		size;
 };
 
@@ -231,6 +234,8 @@ struct tcpx_ep {
 	struct ofi_bsock	bsock;
 	struct tcpx_cur_rx	cur_rx;
 	struct tcpx_cur_tx	cur_tx;
+	OFI_DBG_VAR(uint8_t, tx_id)
+	OFI_DBG_VAR(uint8_t, rx_id)
 
 	struct dlist_entry	ep_entry;
 	struct slist		rx_queue;

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -67,7 +67,7 @@ void tcpx_cq_progress(struct util_cq *cq)
 		    (ep->cur_rx.handler && !ep->cur_rx.entry))
 			tcpx_progress_rx(ep);
 
-		(void) tcpx_mod_epoll(ep);
+		(void) tcpx_mod_epoll(ep, cq);
 		fastlock_release(&ep->lock);
 	}
 

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -38,23 +38,6 @@
 #define TCPX_DEF_CQ_SIZE (1024)
 
 
-/* If we have data queued in the prefetch buffer, we need to
- * process it before blocking on poll.  Otherwise we may block
- * waiting to receive data that's already been fetched.  We
- * also need to progress receives in the case where we're waiting
- * on the application to post a buffer to consume a receive
- * that we've already read from the kernel.  If the message is
- * of length 0, there's no additional data to read, so failing
- * to progress can result in application hangs.  Finally,
- * if we're expecting data, optimistically go look for it.
- */
-static inline bool tcpx_rx_pending(struct tcpx_ep *ep)
-{
-	return ofi_bsock_readable(&ep->bsock) ||
-	       (ep->cur_rx.handler && !ep->cur_rx.entry) ||
-	       ep->cur_rx.data_left;
-}
-
 void tcpx_cq_progress(struct util_cq *cq)
 {
 	void *wait_contexts[MAX_POLL_EVENTS];
@@ -73,11 +56,19 @@ void tcpx_cq_progress(struct util_cq *cq)
 		ep = container_of(fid_entry->fid, struct tcpx_ep,
 				  util_ep.ep_fid.fid);
 
-		while (tcpx_try_func(&ep->util_ep) == -FI_EAGAIN) {
-			fastlock_acquire(&ep->lock);
+		fastlock_acquire(&ep->lock);
+		/* We need to progress receives in the case where we're waiting
+		 * on the application to post a buffer to consume a receive
+		 * that we've already read from the kernel.  If the message is
+		 * of length 0, there's no additional data to read, so failing
+		 * to progress can result in application hangs.
+		 */
+		if (ofi_bsock_readable(&ep->bsock) ||
+		    (ep->cur_rx.handler && !ep->cur_rx.entry))
 			tcpx_progress_rx(ep);
-			fastlock_release(&ep->lock);
-		}
+
+		(void) tcpx_mod_epoll(ep);
+		fastlock_release(&ep->lock);
 	}
 
 	nfds = (wait_fd->util_wait.wait_obj == FI_WAIT_FD) ?

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -452,6 +452,7 @@ void tcpx_reset_rx(struct tcpx_ep *ep)
 	ep->cur_rx.entry = NULL;
 	ep->cur_rx.hdr_done = 0;
 	ep->cur_rx.hdr_len = sizeof(ep->cur_rx.hdr.base_hdr);
+	OFI_DBG_SET(ep->cur_rx.hdr.base_hdr.version, 0);
 }
 
 void tcpx_rx_entry_free(struct tcpx_xfer_entry *rx_entry)

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -619,6 +619,7 @@ static int tcpx_recv_hdr(struct tcpx_ep *ep)
 
 	assert(ep->cur_rx.hdr_done < ep->cur_rx.hdr_len);
 
+next_hdr:
 	buf = (uint8_t *) &ep->cur_rx.hdr + ep->cur_rx.hdr_done;
 	len = ep->cur_rx.hdr_len - ep->cur_rx.hdr_done;
 	ret = ofi_bsock_recv(&ep->bsock, buf, len);
@@ -636,6 +637,11 @@ static int tcpx_recv_hdr(struct tcpx_ep *ep)
 		}
 		ep->cur_rx.hdr_len = (size_t) ep->cur_rx.hdr.base_hdr.
 					      payload_off;
+		if (ep->cur_rx.hdr_done < ep->cur_rx.hdr_len)
+			goto next_hdr;
+
+	} else if (ep->cur_rx.hdr_done < ep->cur_rx.hdr_len) {
+		return -FI_EAGAIN;
 	}
 
 	if (ep->cur_rx.hdr_done < ep->cur_rx.hdr_len)

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -125,6 +125,7 @@ void tcpx_progress_tx(struct tcpx_ep *ep)
 		ep->cur_tx.entry = container_of(slist_remove_head(&ep->tx_queue),
 						struct tcpx_xfer_entry, entry);
 		ep->cur_tx.data_left = ep->cur_tx.entry->hdr.base_hdr.size;
+		OFI_DBG_SET(ep->cur_tx.entry->hdr.base_hdr.id, ep->tx_id++);
 		ep->hdr_bswap(&ep->cur_tx.entry->hdr.base_hdr);
 	} else {
 		ep->cur_tx.entry = NULL;
@@ -636,6 +637,7 @@ static int tcpx_recv_hdr(struct tcpx_ep *ep)
 		return -FI_EAGAIN;
 
 	ep->hdr_bswap(&ep->cur_rx.hdr.base_hdr);
+	assert(ep->cur_rx.hdr.base_hdr.id == ep->rx_id++);
 	if (ep->cur_rx.hdr.base_hdr.op >= ARRAY_SIZE(ep->start_op)) {
 		FI_WARN(&tcpx_prov, FI_LOG_EP_DATA,
 			"Received invalid opcode\n");
@@ -730,6 +732,7 @@ void tcpx_tx_queue_insert(struct tcpx_ep *ep,
 	if (!ep->cur_tx.entry) {
 		ep->cur_tx.entry = tx_entry;
 		ep->cur_tx.data_left = tx_entry->hdr.base_hdr.size;
+		OFI_DBG_SET(tx_entry->hdr.base_hdr.id, ep->tx_id++);
 		ep->hdr_bswap(&tx_entry->hdr.base_hdr);
 		tcpx_progress_tx(ep);
 

--- a/src/common.c
+++ b/src/common.c
@@ -1288,10 +1288,31 @@ int ofi_pollfds_add(struct ofi_pollfds *pfds, int fd, uint32_t events,
 	return ofi_pollfds_ctl(pfds, POLLFDS_CTL_ADD, fd, events, context);
 }
 
+/* We're not changing the fds, just fields.  This is always 'racy' if
+ * the app modifies the events being monitored for an fd while another
+ * thread waits on the fds.  The other thread can always return before
+ * the modifications have been made.  The caller must be prepared to
+ * handle this, same as if epoll were used directly.
+ *
+ * Updating the events is a common case, so handle this immediately
+ * without the overhead of queuing a work item.
+ */
 int ofi_pollfds_mod(struct ofi_pollfds *pfds, int fd, uint32_t events,
 		    void *context)
 {
-	return ofi_pollfds_ctl(pfds, POLLFDS_CTL_MOD, fd, events, context);
+	int i;
+
+	fastlock_acquire(&pfds->lock);
+	for (i = 1; i < pfds->nfds; i++) {
+		if (pfds->fds[i].fd == fd) {
+			pfds->fds[i].events = events;
+			pfds->context[i] = context;
+			break;
+		}
+	}
+	fd_signal_set(&pfds->signal);
+	fastlock_release(&pfds->lock);
+	return 0;
 }
 
 int ofi_pollfds_del(struct ofi_pollfds *pfds, int fd)
@@ -1364,16 +1385,6 @@ static void ofi_pollfds_process_work(struct ofi_pollfds *pfds)
 			for (i = 0; i < pfds->nfds; i++) {
 				if (pfds->fds[i].fd == item->fd) {
 					pfds->fds[i].fd = INVALID_SOCKET;
-					break;
-				}
-			}
-			break;
-		case POLLFDS_CTL_MOD:
-			for (i = 0; i < pfds->nfds; i++) {
-				if (pfds->fds[i].fd == item->fd) {
-					pfds->fds[i].events = item->events;
-					pfds->fds[i].revents &= item->events;
-					pfds->context[i] = item->context;
 					break;
 				}
 			}


### PR DESCRIPTION
Update to address more progress related issues.

- Add a couple small patches to help debug protocol and progress issues.
- Fix possible hang in tcpx_cq_progress calling try_func in a loop that may never return success
  Problem introduced with a prior patch that used a while loop instead of an if statement
- Drive progress if there's an unmatched, 0-length receive
  Previous change dropped the check for this that was added, re-add
- Fix issue in pollfds where the deferred work list is not processed.
  This can result in updates to the events to watch not being updated.
- Add optimization to pollfds_mod
- Optimize receive processing to avoid needing to iterate back through the progress loop
- Fix epoll event settings, so that both rx and tx cq's are updated