### PR TITLE
prov/efa: fix incorrect handle of successful injection

### DIFF
--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1606,7 +1606,7 @@ static inline void rxr_ep_poll_cq(struct rxr_ep *ep,
 			if (!is_shm_cq)
 				ep->send_comps++;
 #endif
-			rxr_pkt_handle_send_completion(ep, &cq_entry);
+			rxr_pkt_handle_send_completion(ep, cq_entry.op_context);
 		} else if (cq_entry.flags & (FI_RECV | FI_REMOTE_CQ_DATA)) {
 			rxr_pkt_handle_recv_completion(ep, &cq_entry, src_addr);
 #if ENABLE_DEBUG

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -325,10 +325,6 @@ ssize_t rxr_pkt_post_ctrl_once(struct rxr_ep *rxr_ep, int entry_type, void *x_en
 		return err;
 	}
 
-	/* if send, tx_pkt_entry will be released while handle completion
-	 * if inject, there will not be completion, therefore tx_pkt_entry has to be
-	 * released here
-	 */
 	if (inject)
 		err = rxr_pkt_entry_inject(rxr_ep, pkt_entry, addr);
 	else if (pkt_entry->send->iov_count > 0)
@@ -346,8 +342,13 @@ ssize_t rxr_pkt_post_ctrl_once(struct rxr_ep *rxr_ep, int entry_type, void *x_en
 
 	peer->flags |= RXR_PEER_REQ_SENT;
 	rxr_pkt_handle_ctrl_sent(rxr_ep, pkt_entry);
+
+	/* If injection succeeded, packet should be considered as sent completed.
+	 * therefore call rxr_pkt_handle_send_completion().
+	 * rxr_pkt_handle_send_completion() will release pkt_entry
+	 */
 	if (inject)
-		rxr_pkt_entry_release_tx(rxr_ep, pkt_entry);
+		rxr_pkt_handle_send_completion(rxr_ep, pkt_entry);
 
 	return 0;
 }
@@ -666,12 +667,9 @@ void rxr_pkt_handle_data_copied(struct rxr_ep *ep,
 /*
  *   Functions used to handle packet send completion
  */
-void rxr_pkt_handle_send_completion(struct rxr_ep *ep, struct fi_cq_data_entry *comp)
+void rxr_pkt_handle_send_completion(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_pkt_entry *pkt_entry;
 	struct rxr_peer *peer;
-
-	pkt_entry = (struct rxr_pkt_entry *)comp->op_context;
 
 	switch (rxr_get_base_hdr(pkt_entry->pkt)->type) {
 	case RXR_HANDSHAKE_PKT:

--- a/prov/efa/src/rxr/rxr_pkt_cmd.h
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.h
@@ -57,7 +57,7 @@ void rxr_pkt_handle_data_copied(struct rxr_ep *ep,
 				size_t data_size);
 
 void rxr_pkt_handle_send_completion(struct rxr_ep *ep,
-				    struct fi_cq_data_entry *cq_entry);
+				    struct rxr_pkt_entry *pkt_entry);
 
 void rxr_pkt_handle_recv_completion(struct rxr_ep *ep,
 				    struct fi_cq_data_entry *cq_entry,


### PR DESCRIPTION
Currently, when a packet was injected successfully,
rxr_pkt_post_ctrl_once() only releases the packet, which is not enough.
It should have called the packet's send completion handler.

As a result, the EOR packet's send completion handler was not called
for intra instance communication, causing rx entry leaking.

This patch fix the issue by calling rxr_pkt_handle_send_completion()
upon successfull packet injection.

Signed-off-by: Wei Zhang <wzam@amazon.com>