### PR TITLE
core + tcp: Optimizations to pollfds and event handling to drive progress

### DIFF
--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -541,7 +541,7 @@ RXM_INI
 			"This allows direct placement of received messages "
 			"into application buffers, bypassing RxM bounce "
 			"buffers.  This feature targets using tcp sockets "
-			"for the message transport.  (default: false)");
+			"for the message transport.  (default: true)");
 
 	fi_param_define(&rxm_prov, "enable_direct_send", FI_PARAM_BOOL,
 			"Enable support to pass application buffers directly "

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -197,8 +197,8 @@ struct sock_conn {
 struct sock_conn_map {
 	struct sock_conn *table;
 	ofi_epoll_t epoll_set;
-	void **epoll_ctxs;
-	int epoll_ctxs_sz;
+	struct ofi_epollfds_event *epoll_events;
+	int epoll_size;
 	int used;
 	int size;
 	fastlock_t lock;

--- a/prov/sockets/src/sock_conn.c
+++ b/prov/sockets/src/sock_conn.c
@@ -97,12 +97,13 @@ int sock_conn_map_init(struct sock_ep *ep, int init_size)
 {
 	struct sock_conn_map *map = &ep->attr->cmap;
 	int ret;
+
 	map->table = calloc(init_size, sizeof(*map->table));
 	if (!map->table)
 		return -FI_ENOMEM;
 
-	map->epoll_ctxs = calloc(init_size, sizeof(*map->epoll_ctxs));
-	if (!map->epoll_ctxs)
+	map->epoll_events = calloc(init_size, sizeof(*map->epoll_events));
+	if (!map->epoll_events)
 		goto err1;
 
 	ret = ofi_epoll_create(&map->epoll_set);
@@ -116,10 +117,11 @@ int sock_conn_map_init(struct sock_ep *ep, int init_size)
 	fastlock_init(&map->lock);
 	map->used = 0;
 	map->size = init_size;
+	map->epoll_size = init_size;
 	return 0;
 
 err2:
-	free(map->epoll_ctxs);
+	free(map->epoll_events);
 err1:
 	free(map->table);
 	return -FI_ENOMEM;
@@ -153,9 +155,9 @@ void sock_conn_map_destroy(struct sock_ep_attr *ep_attr)
 	}
 	free(cmap->table);
 	cmap->table = NULL;
-	free(cmap->epoll_ctxs);
-	cmap->epoll_ctxs = NULL;
-	cmap->epoll_ctxs_sz = 0;
+	free(cmap->epoll_events);
+	cmap->epoll_events = NULL;
+	cmap->epoll_size = 0;
 	cmap->used = cmap->size = 0;
 	ofi_epoll_close(cmap->epoll_set);
 	fastlock_destroy(&cmap->lock);
@@ -317,14 +319,14 @@ static void *sock_conn_listener_thread(void *arg)
 {
 	struct sock_conn_listener *conn_listener = arg;
 	struct sock_conn_handle *conn_handle;
-	void *ep_contexts[SOCK_EPOLL_WAIT_EVENTS];
+	struct ofi_epollfds_event events[SOCK_EPOLL_WAIT_EVENTS];
 	struct sock_ep_attr *ep_attr;
 	int num_fds, i, conn_fd;
 	union ofi_sock_ip remote;
 	socklen_t addr_size;
 
 	while (conn_listener->do_listen) {
-		num_fds = ofi_epoll_wait(conn_listener->epollfd, ep_contexts,
+		num_fds = ofi_epoll_wait(conn_listener->epollfd, events,
 		                        SOCK_EPOLL_WAIT_EVENTS, -1);
 		if (num_fds < 0) {
 			SOCK_LOG_ERROR("poll failed : %s\n", strerror(errno));
@@ -342,7 +344,7 @@ static void *sock_conn_listener_thread(void *arg)
 		}
 
 		for (i = 0; i < num_fds; i++) {
-			conn_handle = ep_contexts[i];
+			conn_handle = events[i].context;
 
 			if (conn_handle == NULL) { /* signal event */
 				fd_signal_reset(&conn_listener->signal);

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -1171,13 +1171,13 @@ static void *sock_ep_cm_thread(void *arg)
 {
 	int num_fds, i;
 	struct sock_ep_cm_head *cm_head = arg;
-	void *ep_contexts[SOCK_EPOLL_WAIT_EVENTS];
+	struct ofi_epollfds_event events[SOCK_EPOLL_WAIT_EVENTS];
 	struct sock_conn_req_handle *handle;
 
 	while (cm_head->do_listen) {
 		sock_ep_cm_check_closing_rejected_list(cm_head);
 
-		num_fds = ofi_epoll_wait(cm_head->epollfd, ep_contexts,
+		num_fds = ofi_epoll_wait(cm_head->epollfd, events,
 		                        SOCK_EPOLL_WAIT_EVENTS, -1);
 		if (num_fds < 0) {
 			SOCK_LOG_ERROR("poll failed : %s\n", strerror(errno));
@@ -1195,7 +1195,7 @@ static void *sock_ep_cm_thread(void *arg)
 			goto skip;
 		}
 		for (i = 0; i < num_fds; i++) {
-			handle = ep_contexts[i];
+			handle = events[i].context;
 
 			if (handle == NULL) { /* Signal event */
 				fd_signal_reset(&cm_head->signal);

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -2376,20 +2376,20 @@ static int sock_pe_progress_rx_ep(struct sock_pe *pe,
 	if (!map->used)
 		return 0;
 
-	if (map->epoll_ctxs_sz < map->used) {
+	if (map->epoll_size < map->used) {
 		uint64_t new_size = map->used * 2;
-		void *ctxs;
+		struct ofi_epollfds_event *events;
 
-		ctxs = realloc(map->epoll_ctxs,
-			       sizeof(*map->epoll_ctxs) * new_size);
-		if (ctxs) {
-			map->epoll_ctxs = ctxs;
-			map->epoll_ctxs_sz = new_size;
+		events = realloc(map->epoll_events,
+				 sizeof(*map->epoll_events) * new_size);
+		if (events) {
+			map->epoll_events = events;
+			map->epoll_size = new_size;
 		}
 	}
 
-	num_fds = ofi_epoll_wait(map->epoll_set, map->epoll_ctxs,
-	                        MIN(map->used, map->epoll_ctxs_sz), 0);
+	num_fds = ofi_epoll_wait(map->epoll_set, map->epoll_events,
+	                        MIN(map->used, map->epoll_size), 0);
 	if (num_fds < 0 || num_fds == 0) {
 		if (num_fds < 0)
 			SOCK_LOG_ERROR("epoll failed: %d\n", num_fds);
@@ -2398,7 +2398,7 @@ static int sock_pe_progress_rx_ep(struct sock_pe *pe,
 
 	fastlock_acquire(&map->lock);
 	for (i = 0; i < num_fds; i++) {
-		conn = map->epoll_ctxs[i];
+		conn = map->epoll_events[i].context;
 		if (!conn)
 			SOCK_LOG_ERROR("ofi_idm_lookup failed\n");
 
@@ -2597,9 +2597,9 @@ static void sock_pe_wait(struct sock_pe *pe)
 {
 	char tmp;
 	int ret;
-	void *ep_contexts[1];
+	struct ofi_epollfds_event event;
 
-	ret = ofi_epoll_wait(pe->epoll_set, ep_contexts, 1, -1);
+	ret = ofi_epoll_wait(pe->epoll_set, &event, 1, -1);
 	if (ret < 0)
 		SOCK_LOG_ERROR("poll failed : %s\n", strerror(ofi_sockerr()));
 

--- a/prov/tcp/src/tcpx_conn_mgr.c
+++ b/prov/tcp/src/tcpx_conn_mgr.c
@@ -520,8 +520,8 @@ void tcpx_conn_mgr_run(struct util_eq *eq)
 {
 	struct util_wait_fd *wait_fd;
 	struct tcpx_eq *tcpx_eq;
-	void *wait_contexts[MAX_POLL_EVENTS];
-	int num_fds = 0, i;
+	struct ofi_epollfds_event events[MAX_POLL_EVENTS];
+	int count, i;
 
 	assert(eq->wait != NULL);
 
@@ -530,23 +530,19 @@ void tcpx_conn_mgr_run(struct util_eq *eq)
 
 	tcpx_eq = container_of(eq, struct tcpx_eq, util_eq);
 	fastlock_acquire(&tcpx_eq->close_lock);
-	num_fds = (wait_fd->util_wait.wait_obj == FI_WAIT_FD) ?
-		  ofi_epoll_wait(wait_fd->epoll_fd, wait_contexts,
-				 MAX_POLL_EVENTS, 0) :
-		  ofi_pollfds_wait(wait_fd->pollfds, wait_contexts,
-				   MAX_POLL_EVENTS, 0);
-	if (num_fds < 0) {
-		fastlock_release(&tcpx_eq->close_lock);
-		return;
-	}
+	count = (wait_fd->util_wait.wait_obj == FI_WAIT_FD) ?
+		ofi_epoll_wait(wait_fd->epoll_fd, events, MAX_POLL_EVENTS, 0) :
+		ofi_pollfds_wait(wait_fd->pollfds, events, MAX_POLL_EVENTS, 0);
+	if (count < 0)
+		goto unlock;
 
-	for ( i = 0; i < num_fds; i++) {
+	for (i = 0; i < count; i++) {
 		/* skip wake up signals */
-		if (&wait_fd->util_wait.wait_fid.fid == wait_contexts[i])
+		if (&wait_fd->util_wait.wait_fid.fid == events[i].context)
 			continue;
 
-		process_cm_ctx(eq->wait, (struct tcpx_cm_context *)
-			       wait_contexts[i]);
+		process_cm_ctx(eq->wait, events[i].context);
 	}
+unlock:
 	fastlock_release(&tcpx_eq->close_lock);
 }

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -40,7 +40,7 @@
 
 void tcpx_cq_progress(struct util_cq *cq)
 {
-	void *wait_contexts[MAX_POLL_EVENTS];
+	struct ofi_epollfds_event events[MAX_POLL_EVENTS];
 	struct fid_list_entry *fid_entry;
 	struct util_wait_fd *wait_fd;
 	struct dlist_entry *item;
@@ -72,15 +72,13 @@ void tcpx_cq_progress(struct util_cq *cq)
 	}
 
 	nfds = (wait_fd->util_wait.wait_obj == FI_WAIT_FD) ?
-	       ofi_epoll_wait(wait_fd->epoll_fd, wait_contexts,
-			      MAX_POLL_EVENTS, 0) :
-	       ofi_pollfds_wait(wait_fd->pollfds, wait_contexts,
-				MAX_POLL_EVENTS, 0);
+	       ofi_epoll_wait(wait_fd->epoll_fd, events, MAX_POLL_EVENTS, 0) :
+	       ofi_pollfds_wait(wait_fd->pollfds, events, MAX_POLL_EVENTS, 0);
 	if (nfds <= 0)
 		goto unlock;
 
 	for (i = 0; i < nfds; i++) {
-		fid = wait_contexts[i];
+		fid = events[i].context;
 		if (fid->fclass != FI_CLASS_EP) {
 			fd_signal_reset(&wait_fd->signal);
 			continue;

--- a/prov/util/src/util_wait.c
+++ b/prov/util/src/util_wait.c
@@ -383,9 +383,9 @@ release:
 
 static int util_wait_fd_run(struct fid_wait *wait_fid, int timeout)
 {
+	struct ofi_epollfds_event event;
 	struct util_wait_fd *wait;
 	uint64_t endtime;
-	void *ep_context[1];
 	int ret;
 
 	wait = container_of(wait_fid, struct util_wait_fd, util_wait.wait_fid);
@@ -400,8 +400,8 @@ static int util_wait_fd_run(struct fid_wait *wait_fid, int timeout)
 			return -FI_ETIMEDOUT;
 
 		ret = (wait->util_wait.wait_obj == FI_WAIT_FD) ?
-		      ofi_epoll_wait(wait->epoll_fd, ep_context, 1, timeout) :
-		      ofi_pollfds_wait(wait->pollfds, ep_context, 1, timeout);
+		      ofi_epoll_wait(wait->epoll_fd, &event, 1, timeout) :
+		      ofi_pollfds_wait(wait->pollfds, &event, 1, timeout);
 		if (ret > 0)
 			return FI_SUCCESS;
 


### PR DESCRIPTION
- Update pollfds to use a sparse array of fd's, rather than trying to compact it.  This allows us to reference an entry in the pollfds using the fd as an index, eliminating linear searches for a matching entry.
- Optimize handling of epoll_mod in pollfds equivalent.  When modifying an fd, handle this directly in the call.  This replaces a memory allocation and the queuing of the modification for asynchronous processing.
- Update epoll/pollfds abstractions to return the events which were signaled.  This update impacts the sockets provider.
- Update the tcp progress handling to act based on which events were set and to skip trying to progress send or receives if the corresponding event is not set.