### PR TITLE
core/pollfds: Use direct indexing instead of searches

### DIFF
--- a/include/ofi_epoll.h
+++ b/include/ofi_epoll.h
@@ -69,6 +69,7 @@ struct ofi_pollfds {
 };
 
 int ofi_pollfds_create(struct ofi_pollfds **pfds);
+int ofi_pollfds_grow(struct ofi_pollfds *pfds, int max_size);
 int ofi_pollfds_add(struct ofi_pollfds *pfds, int fd, uint32_t events,
 		    void *context);
 int ofi_pollfds_mod(struct ofi_pollfds *pfds, int fd, uint32_t events,
@@ -77,6 +78,14 @@ int ofi_pollfds_del(struct ofi_pollfds *pfds, int fd);
 int ofi_pollfds_wait(struct ofi_pollfds *pfds, void **contexts,
 		     int max_contexts, int timeout);
 void ofi_pollfds_close(struct ofi_pollfds *pfds);
+
+/* OS specific */
+void ofi_pollfds_do_add(struct ofi_pollfds *pfds,
+			struct ofi_pollfds_work_item *item);
+int ofi_pollfds_do_mod(struct ofi_pollfds *pfds, int fd, uint32_t events,
+		       void *context);
+void ofi_pollfds_do_del(struct ofi_pollfds *pfds,
+			struct ofi_pollfds_work_item *item);
 
 
 #ifdef HAVE_EPOLL

--- a/src/common.c
+++ b/src/common.c
@@ -1228,6 +1228,38 @@ out:
 }
 
 
+int ofi_pollfds_grow(struct ofi_pollfds *pfds, int max_size)
+{
+	struct pollfd *fds;
+	void *contexts;
+	size_t size;
+
+	if (max_size < pfds->size)
+		return FI_SUCCESS;
+
+	size = max_size + 1;
+	if (size < pfds->size + 64)
+		size = pfds->size + 64;
+
+	fds = calloc(size, sizeof(*pfds->fds) + sizeof(*pfds->context));
+	if (!fds)
+		return -FI_ENOMEM;
+
+	contexts = fds + size;
+	if (pfds->size) {
+		memcpy(fds, pfds->fds, pfds->size * sizeof(*pfds->fds));
+		memcpy(contexts, pfds->context, pfds->size * sizeof(*pfds->context));
+		free(pfds->fds);
+	}
+
+	while (pfds->size < size)
+		fds[pfds->size++].fd = INVALID_SOCKET;
+
+	pfds->fds = fds;
+	pfds->context = contexts;
+	return FI_SUCCESS;
+}
+
 int ofi_pollfds_create(struct ofi_pollfds **pfds)
 {
 	int ret;
@@ -1236,14 +1268,9 @@ int ofi_pollfds_create(struct ofi_pollfds **pfds)
 	if (!*pfds)
 		return -FI_ENOMEM;
 
-	(*pfds)->size = 64;
-	(*pfds)->fds = calloc((*pfds)->size, sizeof(*(*pfds)->fds) +
-			    sizeof(*(*pfds)->context));
-	if (!(*pfds)->fds) {
-		ret = -FI_ENOMEM;
+	ret = ofi_pollfds_grow(*pfds, 63);
+	if (ret)
 		goto err1;
-	}
-	(*pfds)->context = (void *)((*pfds)->fds + (*pfds)->size);
 
 	ret = fd_signal_init(&(*pfds)->signal);
 	if (ret)
@@ -1311,16 +1338,12 @@ int ofi_pollfds_mod(struct ofi_pollfds *pfds, int fd, uint32_t events,
 {
 	struct slist_entry *entry;
 	struct ofi_pollfds_work_item *item;
-	int i;
+	int ret;
 
 	fastlock_acquire(&pfds->lock);
-	for (i = 1; i < pfds->nfds; i++) {
-		if (pfds->fds[i].fd == fd) {
-			pfds->fds[i].events = events;
-			pfds->context[i] = context;
-			goto signal;
-		}
-	}
+	ret = ofi_pollfds_do_mod(pfds, fd, events, context);
+	if (!ret)
+		goto signal;
 
 	/* fd may be queued for insertion */
 	entry = slist_find_first_match(&pfds->work_item_list, ofi_pollfds_find,
@@ -1342,83 +1365,28 @@ int ofi_pollfds_del(struct ofi_pollfds *pfds, int fd)
 	return ofi_pollfds_ctl(pfds, POLLFDS_CTL_DEL, fd, 0, NULL);
 }
 
-static int ofi_pollfds_array(struct ofi_pollfds *pfds)
-{
-	struct pollfd *fds;
-	void *contexts;
-
-	fds = calloc(pfds->size + 64,
-		     sizeof(*pfds->fds) + sizeof(*pfds->context));
-	if (!fds)
-		return -FI_ENOMEM;
-
-	pfds->size += 64;
-	contexts = fds + pfds->size;
-
-	memcpy(fds, pfds->fds, pfds->nfds * sizeof(*pfds->fds));
-	memcpy(contexts, pfds->context, pfds->nfds * sizeof(*pfds->context));
-	free(pfds->fds);
-	pfds->fds = fds;
-	pfds->context = contexts;
-	return FI_SUCCESS;
-}
-
-static void ofi_pollfds_cleanup(struct ofi_pollfds *pfds)
-{
-	int i;
-
-	for (i = 0; i < pfds->nfds; i++) {
-		while (pfds->fds[i].fd == INVALID_SOCKET) {
-			pfds->nfds--;
-			if (i == pfds->nfds)
-				break;
-
-			pfds->fds[i].fd = pfds->fds[pfds->nfds].fd;
-			pfds->fds[i].events = pfds->fds[pfds->nfds].events;
-			pfds->fds[i].revents = pfds->fds[pfds->nfds].revents;
-			pfds->context[i] = pfds->context[pfds->nfds];
-		}
-	}
-}
-
 static void ofi_pollfds_process_work(struct ofi_pollfds *pfds)
 {
 	struct slist_entry *entry;
 	struct ofi_pollfds_work_item *item;
-	int i;
 
 	while (!slist_empty(&pfds->work_item_list)) {
-		if ((pfds->nfds == pfds->size) &&
-		    ofi_pollfds_array(pfds))
-			continue;
-
 		entry = slist_remove_head(&pfds->work_item_list);
 		item = container_of(entry, struct ofi_pollfds_work_item, entry);
 
 		switch (item->type) {
 		case POLLFDS_CTL_ADD:
-			pfds->fds[pfds->nfds].fd = item->fd;
-			pfds->fds[pfds->nfds].events = item->events;
-			pfds->fds[pfds->nfds].revents = 0;
-			pfds->context[pfds->nfds] = item->context;
-			pfds->nfds++;
+			ofi_pollfds_do_add(pfds, item);
 			break;
 		case POLLFDS_CTL_DEL:
-			for (i = 0; i < pfds->nfds; i++) {
-				if (pfds->fds[i].fd == item->fd) {
-					pfds->fds[i].fd = INVALID_SOCKET;
-					break;
-				}
-			}
+			ofi_pollfds_do_del(pfds, item);
 			break;
 		default:
 			assert(0);
-			goto out;
+			break;
 		}
 		free(item);
 	}
-out:
-	ofi_pollfds_cleanup(pfds);
 }
 
 int ofi_pollfds_wait(struct ofi_pollfds *pfds, void **contexts,


### PR DESCRIPTION
Convert pollfds to act more like select, where a given fd
can be used directly as an index into the fdset.  This avoids
the linear searches currently done in the code to find the
fd in the fdset array.

Entries that are invalid are marked with an fd of -1, which
signals that poll() should ignore the entry.  This change
slightly increases the size of the fdset allocation, but
assumes that most entries will be used to reference a valid
fd value.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>