### PR TITLE
prov/tcp: optimize epoll event handling

### DIFF
--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -774,7 +774,7 @@ static void *smr_start_listener(void *args)
 {
 	struct smr_ep *ep = (struct smr_ep *) args;
 	struct sockaddr_un sockaddr;
-	void *ctx[SMR_MAX_PEERS + 1];
+	struct ofi_epollfds_event events[SMR_MAX_PEERS + 1];
 	int i, ret, poll_fds, sock = -1;
 	int peer_fds[ZE_MAX_DEVICES];
 	socklen_t len;
@@ -782,7 +782,7 @@ static void *smr_start_listener(void *args)
 
 	ep->region->flags |= SMR_FLAG_IPC_SOCK;
 	while (1) {
-		poll_fds = ofi_epoll_wait(ep->sock_info->epollfd, ctx,
+		poll_fds = ofi_epoll_wait(ep->sock_info->epollfd, events,
 					  SMR_MAX_PEERS + 1, -1);
 
 		if (poll_fds < 0) {
@@ -792,7 +792,7 @@ static void *smr_start_listener(void *args)
 		}
 
 		for (i = 0; i < poll_fds; i++) {
-			if (!ctx[i])
+			if (!events[i].data.ptr)
 				goto out;
 
 			sock = accept(ep->sock_info->listen_sock,

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -197,8 +197,8 @@ struct sock_conn {
 struct sock_conn_map {
 	struct sock_conn *table;
 	ofi_epoll_t epoll_set;
-	void **epoll_ctxs;
-	int epoll_ctxs_sz;
+	struct ofi_epollfds_event *epoll_events;
+	int epoll_size;
 	int used;
 	int size;
 	fastlock_t lock;

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -1171,13 +1171,13 @@ static void *sock_ep_cm_thread(void *arg)
 {
 	int num_fds, i;
 	struct sock_ep_cm_head *cm_head = arg;
-	void *ep_contexts[SOCK_EPOLL_WAIT_EVENTS];
+	struct ofi_epollfds_event events[SOCK_EPOLL_WAIT_EVENTS];
 	struct sock_conn_req_handle *handle;
 
 	while (cm_head->do_listen) {
 		sock_ep_cm_check_closing_rejected_list(cm_head);
 
-		num_fds = ofi_epoll_wait(cm_head->epollfd, ep_contexts,
+		num_fds = ofi_epoll_wait(cm_head->epollfd, events,
 		                        SOCK_EPOLL_WAIT_EVENTS, -1);
 		if (num_fds < 0) {
 			SOCK_LOG_ERROR("poll failed : %s\n", strerror(errno));
@@ -1195,7 +1195,7 @@ static void *sock_ep_cm_thread(void *arg)
 			goto skip;
 		}
 		for (i = 0; i < num_fds; i++) {
-			handle = ep_contexts[i];
+			handle = events[i].data.ptr;
 
 			if (handle == NULL) { /* Signal event */
 				fd_signal_reset(&cm_head->signal);

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -121,7 +121,7 @@ struct tcpx_base_hdr {
 	uint16_t		flags;
 	uint8_t			op_data;
 	uint8_t			rma_iov_cnt;
-	uint8_t			payload_off;
+	uint8_t			hdr_size;
 	union {
 		uint8_t		rsvd;
 		uint8_t		id; /* debug */

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -102,16 +102,10 @@ enum {
 	TCPX_IOV_LIMIT = 4
 };
 
-enum tcpx_op_code {
-	TCPX_OP_MSG_SEND,
-	TCPX_OP_MSG_RECV,
-	TCPX_OP_MSG_RESP,
-	TCPX_OP_WRITE,
-	TCPX_OP_REMOTE_WRITE,
-	TCPX_OP_READ_REQ,
-	TCPX_OP_READ_RSP,
-	TCPX_OP_REMOTE_READ,
-	TCPX_OP_CODE_MAX,
+/* base_hdr::op_data */
+enum {
+	/* backward compatible value */
+	TCPX_OP_MSG_RESP = 2, /* indicates response message */
 };
 
 /* Flags */
@@ -290,15 +284,9 @@ static inline struct ofi_ops_dynamic_rbuf *tcpx_dynamic_rbuf(struct tcpx_ep *ep)
 	return domain->dynamic_rbuf;
 }
 
-struct tcpx_buf_pool {
-	struct ofi_bufpool	*pool;
-	enum tcpx_op_code	op_type;
-};
-
 struct tcpx_cq {
 	struct util_cq		util_cq;
-	/* buf_pools protected by util.cq_lock */
-	struct tcpx_buf_pool	buf_pools[TCPX_OP_CODE_MAX];
+	struct ofi_bufpool	*xfer_pool;
 };
 
 struct tcpx_eq {
@@ -338,8 +326,7 @@ void tcpx_cq_report_error(struct util_cq *cq,
 void tcpx_get_cq_info(struct tcpx_xfer_entry *entry, uint64_t *flags,
 		      uint64_t *data, uint64_t *tag);
 
-struct tcpx_xfer_entry *tcpx_xfer_entry_alloc(struct tcpx_cq *cq,
-					      enum tcpx_op_code type);
+struct tcpx_xfer_entry *tcpx_xfer_entry_alloc(struct tcpx_cq *cq);
 struct tcpx_xfer_entry *tcpx_srx_entry_alloc(struct tcpx_rx_ctx *srx_ctx,
 					     struct tcpx_ep *ep);
 void tcpx_xfer_entry_free(struct tcpx_cq *tcpx_cq,

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -181,7 +181,7 @@ void tcpx_cq_report_success(struct util_cq *cq,
 		return;
 
 	len = xfer_entry->hdr.base_hdr.size -
-	      xfer_entry->hdr.base_hdr.payload_off;
+	      xfer_entry->hdr.base_hdr.hdr_size;
 	tcpx_get_cq_info(xfer_entry, &flags, &data, &tag);
 
 	ofi_cq_write(cq, xfer_entry->context,

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -40,7 +40,7 @@
 
 void tcpx_cq_progress(struct util_cq *cq)
 {
-	void *wait_contexts[MAX_POLL_EVENTS];
+	struct ofi_epollfds_event events[MAX_POLL_EVENTS];
 	struct fid_list_entry *fid_entry;
 	struct util_wait_fd *wait_fd;
 	struct dlist_entry *item;
@@ -72,15 +72,13 @@ void tcpx_cq_progress(struct util_cq *cq)
 	}
 
 	nfds = (wait_fd->util_wait.wait_obj == FI_WAIT_FD) ?
-	       ofi_epoll_wait(wait_fd->epoll_fd, wait_contexts,
-			      MAX_POLL_EVENTS, 0) :
-	       ofi_pollfds_wait(wait_fd->pollfds, wait_contexts,
-				MAX_POLL_EVENTS, 0);
+	       ofi_epoll_wait(wait_fd->epoll_fd, events, MAX_POLL_EVENTS, 0) :
+	       ofi_pollfds_wait(wait_fd->pollfds, events, MAX_POLL_EVENTS, 0);
 	if (nfds <= 0)
 		goto unlock;
 
 	for (i = 0; i < nfds; i++) {
-		fid = wait_contexts[i];
+		fid = events[i].data.ptr;
 		if (fid->fclass != FI_CLASS_EP) {
 			fd_signal_reset(&wait_fd->signal);
 			continue;

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -459,8 +459,6 @@ void tcpx_rx_entry_free(struct tcpx_xfer_entry *rx_entry)
 {
 	struct tcpx_cq *tcpx_cq;
 
-	assert(rx_entry->hdr.base_hdr.op_data == TCPX_OP_MSG_RECV);
-
 	if (rx_entry->ep->srx_ctx) {
 		tcpx_srx_entry_free(rx_entry->ep->srx_ctx, rx_entry);
 	} else {

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -51,29 +51,16 @@ void tcpx_hdr_none(struct tcpx_base_hdr *hdr)
 
 void tcpx_hdr_bswap(struct tcpx_base_hdr *hdr)
 {
-	struct ofi_rma_iov *rma_iov;
-	uint8_t *ptr = (uint8_t *)hdr + sizeof(*hdr);
-	int i;
+	uint64_t *cur;
+	int i, cnt;
 
 	hdr->flags = ntohs(hdr->flags);
 	hdr->size = ntohll(hdr->size);
 
-	if (hdr->flags & TCPX_REMOTE_CQ_DATA) {
-		*((uint64_t *)ptr) = ntohll(*((uint64_t *) ptr));
-		ptr += sizeof(uint64_t);
-	}
-
-	if (hdr->flags & TCPX_TAGGED) {
-		*((uint64_t *)ptr) = ntohll(*((uint64_t *) ptr));
-		ptr += sizeof(uint64_t);
-	}
-
-	rma_iov = (struct ofi_rma_iov *)ptr;
-	for ( i = 0; i < hdr->rma_iov_cnt; i++) {
-		rma_iov[i].addr = ntohll(rma_iov[i].addr);
-		rma_iov[i].len = ntohll(rma_iov[i].len);
-		rma_iov[i].key = ntohll(rma_iov[i].key);
-	}
+	cnt = (hdr->hdr_size - sizeof(*hdr)) >> 3;
+	cur = (uint64_t *) (hdr + 1);
+	for (i = 0; i < cnt; i++)
+		cur[i] = ntohll(cur[i]);
 }
 
 static int tcpx_setup_socket(SOCKET sock, struct fi_info *info)

--- a/prov/tcp/src/tcpx_msg.c
+++ b/prov/tcp/src/tcpx_msg.c
@@ -87,7 +87,7 @@ tcpx_init_tx_sizes(struct tcpx_xfer_entry *tx_entry, size_t hdr_len,
 		   size_t data_len)
 {
 	tx_entry->hdr.base_hdr.size = hdr_len + data_len;
-	tx_entry->hdr.base_hdr.payload_off = (uint8_t) hdr_len;
+	tx_entry->hdr.base_hdr.hdr_size = (uint8_t) hdr_len;
 }
 
 static inline void

--- a/prov/tcp/src/tcpx_msg.c
+++ b/prov/tcp/src/tcpx_msg.c
@@ -56,7 +56,7 @@ tcpx_alloc_recv_entry(struct tcpx_ep *tcpx_ep)
 
 	tcpx_cq = container_of(tcpx_ep->util_ep.rx_cq, struct tcpx_cq, util_cq);
 
-	recv_entry = tcpx_xfer_entry_alloc(tcpx_cq, TCPX_OP_MSG_RECV);
+	recv_entry = tcpx_xfer_entry_alloc(tcpx_cq);
 	if (recv_entry)
 		recv_entry->ep = tcpx_ep;
 
@@ -71,9 +71,13 @@ tcpx_alloc_send_entry(struct tcpx_ep *tcpx_ep)
 
 	tcpx_cq = container_of(tcpx_ep->util_ep.tx_cq, struct tcpx_cq, util_cq);
 
-	send_entry = tcpx_xfer_entry_alloc(tcpx_cq, TCPX_OP_MSG_SEND);
-	if (send_entry)
+	send_entry = tcpx_xfer_entry_alloc(tcpx_cq);
+	if (send_entry) {
+		send_entry->hdr.base_hdr.version = TCPX_HDR_VERSION;
+		send_entry->hdr.base_hdr.op_data = 0;
+		send_entry->hdr.base_hdr.op = ofi_op_msg;
 		send_entry->ep = tcpx_ep;
+	}
 
 	return send_entry;
 }

--- a/prov/tcp/src/tcpx_rma.c
+++ b/prov/tcp/src/tcpx_rma.c
@@ -59,6 +59,9 @@ static void tcpx_rma_read_send_entry_fill(struct tcpx_xfer_entry *send_entry,
 	offset = sizeof(send_entry->hdr.base_hdr);
 	rma_iov = (struct ofi_rma_iov *) ((uint8_t *) &send_entry->hdr + offset);
 
+	send_entry->hdr.base_hdr.version = TCPX_HDR_VERSION;
+	send_entry->hdr.base_hdr.op = ofi_op_read_req;
+	send_entry->hdr.base_hdr.op_data = 0;
 	send_entry->hdr.base_hdr.rma_iov_cnt = msg->rma_iov_count;
 	memcpy(rma_iov, msg->rma_iov,
 	       msg->rma_iov_count * sizeof(msg->rma_iov[0]));
@@ -104,11 +107,11 @@ static ssize_t tcpx_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 	assert(msg->iov_count <= TCPX_IOV_LIMIT);
 	assert(msg->rma_iov_count <= TCPX_IOV_LIMIT);
 
-	send_entry = tcpx_xfer_entry_alloc(tcpx_cq, TCPX_OP_READ_REQ);
+	send_entry = tcpx_xfer_entry_alloc(tcpx_cq);
 	if (!send_entry)
 		return -FI_EAGAIN;
 
-	recv_entry = tcpx_xfer_entry_alloc(tcpx_cq, TCPX_OP_READ_RSP);
+	recv_entry = tcpx_xfer_entry_alloc(tcpx_cq);
 	if (!recv_entry) {
 		tcpx_xfer_entry_free(tcpx_cq, send_entry);
 		return -FI_EAGAIN;
@@ -186,7 +189,7 @@ static ssize_t tcpx_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg
 	tcpx_cq = container_of(tcpx_ep->util_ep.tx_cq, struct tcpx_cq,
 			       util_cq);
 
-	send_entry = tcpx_xfer_entry_alloc(tcpx_cq, TCPX_OP_WRITE);
+	send_entry = tcpx_xfer_entry_alloc(tcpx_cq);
 	if (!send_entry)
 		return -FI_EAGAIN;
 
@@ -196,6 +199,10 @@ static ssize_t tcpx_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg
 	data_len = ofi_total_iov_len(msg->msg_iov, msg->iov_count);
 
 	assert(!(flags & FI_INJECT) || (data_len <= TCPX_MAX_INJECT));
+
+	send_entry->hdr.base_hdr.version = TCPX_HDR_VERSION;
+	send_entry->hdr.base_hdr.op = ofi_op_write;
+	send_entry->hdr.base_hdr.op_data = 0;
 
 	if (flags & FI_REMOTE_CQ_DATA) {
 		send_entry->hdr.base_hdr.flags = TCPX_REMOTE_CQ_DATA;
@@ -341,12 +348,16 @@ static ssize_t tcpx_rma_inject_common(struct fid_ep *ep, const void *buf,
 	tcpx_cq = container_of(tcpx_ep->util_ep.tx_cq, struct tcpx_cq,
 			       util_cq);
 
-	send_entry = tcpx_xfer_entry_alloc(tcpx_cq, TCPX_OP_WRITE);
+	send_entry = tcpx_xfer_entry_alloc(tcpx_cq);
 	if (!send_entry)
 		return -FI_EAGAIN;
 
 	assert(len <= TCPX_MAX_INJECT);
 	offset = sizeof(send_entry->hdr.base_hdr);
+
+	send_entry->hdr.base_hdr.version = TCPX_HDR_VERSION;
+	send_entry->hdr.base_hdr.op = ofi_op_write;
+	send_entry->hdr.base_hdr.op_data = 0;
 
 	if (flags & FI_REMOTE_CQ_DATA) {
 		send_entry->hdr.base_hdr.flags = TCPX_REMOTE_CQ_DATA;

--- a/prov/tcp/src/tcpx_rma.c
+++ b/prov/tcp/src/tcpx_rma.c
@@ -69,7 +69,7 @@ static void tcpx_rma_read_send_entry_fill(struct tcpx_xfer_entry *send_entry,
 	offset += (msg->rma_iov_count * sizeof(*rma_iov));
 
 	send_entry->hdr.base_hdr.size = offset;
-	send_entry->hdr.base_hdr.payload_off = (uint8_t)offset;
+	send_entry->hdr.base_hdr.hdr_size = (uint8_t) offset;
 
 	send_entry->iov[0].iov_base = (void *) &send_entry->hdr;
 	send_entry->iov[0].iov_len = offset;
@@ -219,7 +219,7 @@ static ssize_t tcpx_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg
 
 	offset += (send_entry->hdr.base_hdr.rma_iov_cnt * sizeof(*rma_iov));
 
-	send_entry->hdr.base_hdr.payload_off = (uint8_t)offset;
+	send_entry->hdr.base_hdr.hdr_size = (uint8_t) offset;
 	send_entry->hdr.base_hdr.size = data_len + offset;
 	if (flags & FI_INJECT) {
 		ofi_copy_iov_buf(msg->msg_iov, msg->iov_count, 0,
@@ -373,7 +373,7 @@ static ssize_t tcpx_rma_inject_common(struct fid_ep *ep, const void *buf,
 	send_entry->hdr.base_hdr.rma_iov_cnt = 1;
 	offset += sizeof(*rma_iov);
 
-	send_entry->hdr.base_hdr.payload_off = (uint8_t)offset;
+	send_entry->hdr.base_hdr.hdr_size = (uint8_t) offset;
 	memcpy((uint8_t *)&send_entry->hdr + offset, (uint8_t *)buf, len);
 	offset += len;
 

--- a/prov/usnic/src/usdf_progress.c
+++ b/prov/usnic/src/usdf_progress.c
@@ -93,7 +93,7 @@ usdf_fabric_progression_thread(void *v)
 	int num_blocked_waiting;
 	int sleep_time;
 	ofi_epoll_t epfd;
-	void *context;
+	struct ofi_epollfds_event event;
 	int ret;
 	int n;
 
@@ -111,14 +111,14 @@ usdf_fabric_progression_thread(void *v)
 			sleep_time = -1;
 		}
 
-		n = ofi_epoll_wait(epfd, &context, 1, sleep_time);
+		n = ofi_epoll_wait(epfd, &event, 1, sleep_time);
 		if (fp->fab_exit || (n < 0 && n != EINTR)) {
 			pthread_exit(NULL);
 		}
 
 		/* consume event if there was one */
 		if (n == 1) {
-			pip = context;
+			pip = event.data.ptr;
 			ret = pip->pi_rtn(pip->pi_context);
 			if (ret != 0) {
 				pthread_exit(NULL);

--- a/prov/usnic/src/usdf_wait.c
+++ b/prov/usnic/src/usdf_wait.c
@@ -274,7 +274,7 @@ static int usdf_wait_close(struct fid *waitset)
 static int usdf_wait_wait(struct fid_wait *fwait, int timeout)
 {
 	struct usdf_wait *wait;
-	void *context;
+	struct ofi_epollfds_event event;
 	int ret = FI_SUCCESS;
 	int nevents;
 
@@ -289,7 +289,7 @@ static int usdf_wait_wait(struct fid_wait *fwait, int timeout)
 		return ret;
 	}
 
-	nevents = ofi_epoll_wait(wait->object.epfd, &context, 1, timeout);
+	nevents = ofi_epoll_wait(wait->object.epfd, &event, 1, timeout);
 	if (nevents == 0) {
 		ret = -FI_ETIMEDOUT;
 	} else if (nevents < 0) {

--- a/prov/util/src/util_wait.c
+++ b/prov/util/src/util_wait.c
@@ -383,9 +383,9 @@ release:
 
 static int util_wait_fd_run(struct fid_wait *wait_fid, int timeout)
 {
+	struct ofi_epollfds_event event;
 	struct util_wait_fd *wait;
 	uint64_t endtime;
-	void *ep_context[1];
 	int ret;
 
 	wait = container_of(wait_fid, struct util_wait_fd, util_wait.wait_fid);
@@ -400,8 +400,8 @@ static int util_wait_fd_run(struct fid_wait *wait_fid, int timeout)
 			return -FI_ETIMEDOUT;
 
 		ret = (wait->util_wait.wait_obj == FI_WAIT_FD) ?
-		      ofi_epoll_wait(wait->epoll_fd, ep_context, 1, timeout) :
-		      ofi_pollfds_wait(wait->pollfds, ep_context, 1, timeout);
+		      ofi_epoll_wait(wait->epoll_fd, &event, 1, timeout) :
+		      ofi_pollfds_wait(wait->pollfds, &event, 1, timeout);
 		if (ret > 0)
 			return FI_SUCCESS;
 

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -1208,7 +1208,7 @@ vrb_eq_sread(struct fid_eq *eq_fid, uint32_t *event,
 		void *buf, size_t len, int timeout, uint64_t flags)
 {
 	struct vrb_eq *eq;
-	void *contexts;
+	struct ofi_epollfds_event fdevent;
 	ssize_t ret;
 
 	eq = container_of(eq_fid, struct vrb_eq, eq_fid.fid);
@@ -1218,12 +1218,12 @@ vrb_eq_sread(struct fid_eq *eq_fid, uint32_t *event,
 		if (ret && (ret != -FI_EAGAIN))
 			return ret;
 
-		ret = ofi_epoll_wait(eq->epollfd, &contexts, 1, timeout);
+		ret = ofi_epoll_wait(eq->epollfd, &fdevent, 1, timeout);
 		if (ret == 0)
 			return -FI_EAGAIN;
 		else if (ret < 0)
 			return -errno;
-	};
+	}
 }
 
 static const char *

--- a/src/common.c
+++ b/src/common.c
@@ -1389,8 +1389,9 @@ static void ofi_pollfds_process_work(struct ofi_pollfds *pfds)
 	}
 }
 
-int ofi_pollfds_wait(struct ofi_pollfds *pfds, void **contexts,
-		     int max_contexts, int timeout)
+int ofi_pollfds_wait(struct ofi_pollfds *pfds,
+		     struct ofi_epollfds_event *events,
+		     int maxevents, int timeout)
 {
 	int i, ret;
 	int found = 0;
@@ -1413,13 +1414,18 @@ int ofi_pollfds_wait(struct ofi_pollfds *pfds, void **contexts,
 			ofi_pollfds_process_work(pfds);
 		fastlock_release(&pfds->lock);
 
-		if (pfds->fds[0].revents)
+		if (pfds->fds[0].revents) {
 			fd_signal_reset(&pfds->signal);
+			ret--;
+		}
+
+		ret = MIN(maxevents, ret);
 
 		/* Index 0 is the internal signaling fd, skip it */
-		for (i = 1; i < pfds->nfds && found < max_contexts; i++) {
+		for (i = 1; i < pfds->nfds && found < ret; i++) {
 			if (pfds->fds[i].revents) {
-				contexts[found++] = pfds->context[i];
+				events[found].events = pfds->fds[i].revents;
+				events[found++].data.ptr = pfds->context[i];
 			}
 		}
 


### PR DESCRIPTION
Modify epoll abstraction to return which event was signaled.
Update all providers to the new abstraction.
Update tcp to only check sockets for events that have been signaled.
Replace multiple tcp buffer pools of the same object with a single pool.