### PR TITLE
prov/efa: fix a bug in posting application buffer for zero copy receive

### DIFF
--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -353,11 +353,13 @@ int rxr_ep_post_buf(struct rxr_ep *ep, const struct fi_msg *posted_recv, uint64_
 		msg.desc = &desc;
 		/*
 		 * Use the actual receive sizes from the application
-		 * rather than posting the full MTU size, like we do
-		 * when using the bufpool.
+		 * minus size of struct rxr_pkt_entry.
+		 * This is because we use the application buffer to
+		 * construct a pkt_entry, and use pkt_entry->pkt to
+		 * receive data.
 		 */
 		if (posted_recv) {
-			msg_iov.iov_len = posted_recv->msg_iov->iov_len;
+			msg_iov.iov_len = posted_recv->msg_iov->iov_len - sizeof(struct rxr_pkt_entry);
 			msg.data = posted_recv->data;
 			assert(msg_iov.iov_len <= ep->mtu_size);
 		}


### PR DESCRIPTION
In zero copy receive mode, EFA will post application buffer to
directly receive data. Under this mode, EFA will not allocate a
packet entry, instead it convert the application buffer into
a packet entry.

The first part of application buffer is used to store rxr_pkt_entry
object, which store some information of the transaction. This part
is not used to receive data.

Two arguments are required to post a buffer to receive data:
buffer pointer, and buffer length.

Curretly, buffer pointer is pkt_entry->pkt, which points to
the end of the rxr_pkt_entry structure, which is correct.

However, current buffer length is wrong. It is application
buffer length, but it should be application buffer length
subtract sizeof(struct rxr_pkt_entry).

This patch address the issue by specifying correct buffer
length.

Signed-off-by: Wei Zhang <wzam@amazon.com>