### PR TITLE
prov/tcp: restructure xfer_entry alloc/free code paths

### DIFF
--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -120,29 +120,6 @@ static int tcpx_cq_close(struct fid *fid)
 	return 0;
 }
 
-struct tcpx_xfer_entry *tcpx_xfer_entry_alloc(struct tcpx_cq *tcpx_cq)
-{
-	struct tcpx_xfer_entry *xfer_entry;
-
-	tcpx_cq->util_cq.cq_fastlock_acquire(&tcpx_cq->util_cq.cq_lock);
-	xfer_entry = ofi_buf_alloc(tcpx_cq->xfer_pool);
-	tcpx_cq->util_cq.cq_fastlock_release(&tcpx_cq->util_cq.cq_lock);
-
-	return xfer_entry;
-}
-
-void tcpx_xfer_entry_free(struct tcpx_cq *tcpx_cq,
-			  struct tcpx_xfer_entry *xfer_entry)
-{
-	xfer_entry->hdr.base_hdr.flags = 0;
-	xfer_entry->flags = 0;
-	xfer_entry->context = 0;
-
-	tcpx_cq->util_cq.cq_fastlock_acquire(&tcpx_cq->util_cq.cq_lock);
-	ofi_buf_free(xfer_entry);
-	tcpx_cq->util_cq.cq_fastlock_release(&tcpx_cq->util_cq.cq_lock);
-}
-
 void tcpx_get_cq_info(struct tcpx_xfer_entry *entry, uint64_t *flags,
 		      uint64_t *data, uint64_t *tag)
 {

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -125,10 +125,7 @@ struct tcpx_xfer_entry *tcpx_xfer_entry_alloc(struct tcpx_cq *tcpx_cq)
 	struct tcpx_xfer_entry *xfer_entry;
 
 	tcpx_cq->util_cq.cq_fastlock_acquire(&tcpx_cq->util_cq.cq_lock);
-	if (!ofi_cirque_isfull(tcpx_cq->util_cq.cirq))
-		xfer_entry = ofi_buf_alloc(tcpx_cq->xfer_pool);
-	else
-		xfer_entry = NULL;
+	xfer_entry = ofi_buf_alloc(tcpx_cq->xfer_pool);
 	tcpx_cq->util_cq.cq_fastlock_release(&tcpx_cq->util_cq.cq_lock);
 
 	return xfer_entry;

--- a/prov/tcp/src/tcpx_shared_ctx.c
+++ b/prov/tcp/src/tcpx_shared_ctx.c
@@ -38,33 +38,6 @@
 #include <unistd.h>
 #include <ofi_iov.h>
 
-void tcpx_srx_entry_free(struct tcpx_rx_ctx *srx_ctx,
-			 struct tcpx_xfer_entry *xfer_entry)
-{
-	if (xfer_entry->ep->cur_rx.entry == xfer_entry)
-		xfer_entry->ep->cur_rx.entry = NULL;
-
-	fastlock_acquire(&srx_ctx->lock);
-	ofi_buf_free(xfer_entry);
-	fastlock_release(&srx_ctx->lock);
-}
-
-struct tcpx_xfer_entry *
-tcpx_srx_entry_alloc(struct tcpx_rx_ctx *srx_ctx, struct tcpx_ep *ep)
-{
-	struct tcpx_xfer_entry *rx_entry = NULL;
-
-	fastlock_acquire(&srx_ctx->lock);
-	if (slist_empty(&srx_ctx->rx_queue))
-		goto out;
-
-	rx_entry = container_of(srx_ctx->rx_queue.head,
-				struct tcpx_xfer_entry, entry);
-	slist_remove_head(&srx_ctx->rx_queue);
-out:
-	fastlock_release(&srx_ctx->lock);
-	return rx_entry;
-}
 
 static ssize_t tcpx_srx_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 				uint64_t flags)


### PR DESCRIPTION
Prep code to add in tx/rx overrun protection.