### PR TITLE
prov/tcp: Add environment variables to override tx/rx size attributes

### DIFF
--- a/man/fi_tcp.7.md
+++ b/man/fi_tcp.7.md
@@ -53,6 +53,12 @@ The tcp provider check for the following enviroment variables -
   tcp provider for its passive endpoint creation. This is useful where
   only a range of ports are allowed by firewall for tcp connections.
 
+*FI_TCP_TX_SIZE*
+: Default tx context size (default: 256)
+
+*FI_TCP_RX_SIZE*
+: Default rx context size (default: 256)
+
 # LIMITATIONS
 
 The tcp provider is implemented over TCP sockets to emulate libfabric API.

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -76,6 +76,8 @@ extern struct tcpx_port_range	port_range;
 extern int tcpx_nodelay;
 extern int tcpx_staging_sbuf_size;
 extern int tcpx_prefetch_rbuf_size;
+extern size_t tcpx_default_tx_size;
+extern size_t tcpx_default_rx_size;
 
 struct tcpx_xfer_entry;
 struct tcpx_ep;

--- a/prov/tcp/src/tcpx_attr.c
+++ b/prov/tcp/src/tcpx_attr.c
@@ -126,10 +126,10 @@ tcpx_alter_defaults(uint32_t version, const struct fi_info *hints,
 		    const struct fi_info *base_info,
 		    struct fi_info *dest_info)
 {
-	dest_info->tx_attr->size = 256;
+	dest_info->tx_attr->size = tcpx_default_tx_size;
 	if (hints && hints->ep_attr &&
 	    hints->ep_attr->rx_ctx_cnt != FI_SHARED_CONTEXT)
-		dest_info->rx_attr->size = 256;
+		dest_info->rx_attr->size = tcpx_default_rx_size;
 	return 0;
 }
 

--- a/prov/tcp/src/tcpx_init.c
+++ b/prov/tcp/src/tcpx_init.c
@@ -56,10 +56,14 @@ int tcpx_nodelay = -1;
 
 int tcpx_staging_sbuf_size = 9000;
 int tcpx_prefetch_rbuf_size = 9000;
-
+size_t tcpx_default_tx_size = 256;
+size_t tcpx_default_rx_size = 256;
 
 static void tcpx_init_env(void)
 {
+	size_t tx_size;
+	size_t rx_size;
+
 	fi_param_define(&tcpx_prov, "iface", FI_PARAM_STRING,
 			"Specify interface name");
 
@@ -68,6 +72,14 @@ static void tcpx_init_env(void)
 
 	fi_param_define(&tcpx_prov,"port_high_range", FI_PARAM_INT,
 			"define port high range");
+
+	fi_param_define(&tcpx_prov,"tx_size", FI_PARAM_SIZE_T,
+			"define default tx context size (default: %zu)",
+			tcpx_default_tx_size);
+
+	fi_param_define(&tcpx_prov,"rx_size", FI_PARAM_SIZE_T,
+			"define default rx context size (default: %zu)",
+			tcpx_default_rx_size);
 
 	fi_param_define(&tcpx_prov, "nodelay", FI_PARAM_BOOL,
 			"overrides default TCP_NODELAY socket setting");
@@ -98,6 +110,15 @@ static void tcpx_init_env(void)
 		port_range.low  = 0;
 		port_range.high = 0;
 	}
+
+	if (!fi_param_get_size_t(&tcpx_prov, "tx_size", &tx_size)) {
+		tcpx_default_tx_size = tx_size;
+	}
+
+	if (!fi_param_get_size_t(&tcpx_prov, "rx_size", &rx_size)) {
+		tcpx_default_rx_size = rx_size;
+	}
+
 }
 
 static void fi_tcp_fini(void)


### PR DESCRIPTION
This patch allows the user to override the default tx and rx
size attributes using the environment variables FI_TCP_TX_SIZE and
FI_TCP_RX_SIZE.

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>