### PR TITLE
prov/efa: fix a dead lock in zero copy receive

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -572,4 +572,14 @@ static inline bool efa_is_cache_available(struct efa_domain *efa_domain)
 #define RXR_REQ_OPT_HDR_ALIGNMENT 8
 #define RXR_REQ_OPT_RAW_ADDR_HDR_SIZE (((sizeof(struct rxr_req_opt_raw_addr_hdr) + EFA_EP_ADDR_LEN - 1)/RXR_REQ_OPT_HDR_ALIGNMENT + 1) * RXR_REQ_OPT_HDR_ALIGNMENT)
 
+
+/*
+ * Per libfabric standard, the prefix must be a multiple of 8, hence the static assert
+ */
+#define RXR_MSG_PREFIX_SIZE (sizeof(struct rxr_pkt_entry) + sizeof(struct rxr_eager_msgrtm_hdr) + RXR_REQ_OPT_RAW_ADDR_HDR_SIZE)
+
+#if defined(static_assert) && defined(__x86_64__)
+static_assert(RXR_MSG_PREFIX_SIZE % 8 == 0, "message prefix size alignment check");
+#endif
+
 #endif /* EFA_H */

--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -569,4 +569,7 @@ static inline bool efa_is_cache_available(struct efa_domain *efa_domain)
 	return efa_domain->cache;
 }
 
+#define RXR_REQ_OPT_HDR_ALIGNMENT 8
+#define RXR_REQ_OPT_RAW_ADDR_HDR_SIZE (((sizeof(struct rxr_req_opt_raw_addr_hdr) + EFA_EP_ADDR_LEN - 1)/RXR_REQ_OPT_HDR_ALIGNMENT + 1) * RXR_REQ_OPT_HDR_ALIGNMENT)
+
 #endif /* EFA_H */

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -890,8 +890,8 @@ int rxr_endpoint(struct fid_domain *domain, struct fi_info *info,
 /* EP sub-functions */
 void rxr_ep_progress(struct util_ep *util_ep);
 void rxr_ep_progress_internal(struct rxr_ep *rxr_ep);
-int rxr_ep_post_buf(struct rxr_ep *ep, const struct fi_msg *posted_recv,
-		    uint64_t flags, enum rxr_lower_ep_type lower_ep);
+int rxr_ep_post_buf(struct rxr_ep *ep, uint64_t flags,
+		    enum rxr_lower_ep_type lower_ep);
 
 int rxr_ep_set_tx_credit_request(struct rxr_ep *rxr_ep,
 				 struct rxr_tx_entry *tx_entry);

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -592,6 +592,9 @@ struct rxr_ep {
 	/* Application's maximum msg size hint */
 	size_t max_msg_size;
 
+	/* Applicaiton's message prefix size. */
+	size_t msg_prefix_size;
+
 	/* RxR protocol's max header size */
 	size_t max_proto_hdr_size;
 

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -167,7 +167,7 @@ int rxr_ep_post_buf(struct rxr_ep *ep, const struct fi_msg *posted_recv, uint64_
 		break;
 	case EFA_EP:
 		if (posted_recv)
-			rx_pkt_entry = rxr_pkt_entry_init_prefix(ep, posted_recv, ep->rx_pkt_efa_pool);
+			rx_pkt_entry = rxr_pkt_entry_from_iov(ep, &posted_recv->msg_iov[0], &posted_recv->desc[0]);
 		else
 			rx_pkt_entry = rxr_pkt_entry_alloc(ep, ep->rx_pkt_efa_pool);
 		break;

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -264,7 +264,6 @@ void rxr_tx_entry_init(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
 	tx_entry->bytes_acked = 0;
 	tx_entry->bytes_sent = 0;
 	tx_entry->window = 0;
-	tx_entry->total_len = ofi_total_iov_len(msg->msg_iov, msg->iov_count);
 	tx_entry->iov_count = msg->iov_count;
 	tx_entry->iov_index = 0;
 	tx_entry->iov_mr_start = 0;
@@ -279,16 +278,13 @@ void rxr_tx_entry_init(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
 	else
 		memset(tx_entry->desc, 0, sizeof(tx_entry->desc));
 
-	/*
-	 * The prefix is currently not used by the sender, but needs to be
-	 * accounted for when copying the payload into the bounce-buffer.
-	 */
-	if (ep->use_zcpy_rx) {
-		assert(tx_entry->iov[0].iov_len >= sizeof(struct rxr_pkt_entry) + sizeof(struct rxr_eager_msgrtm_hdr));
-		tx_entry->iov[0].iov_base = (char *)tx_entry->iov[0].iov_base
-					     + sizeof(struct rxr_pkt_entry)
-					     + sizeof(struct rxr_eager_msgrtm_hdr);
+	if (ep->msg_prefix_size) {
+		assert(tx_entry->iov[0].iov_len >= ep->msg_prefix_size);
+		tx_entry->iov[0].iov_base = (char *)tx_entry->iov[0].iov_base + ep->msg_prefix_size;
+		tx_entry->iov[0].iov_len -= ep->msg_prefix_size;
 	}
+
+	tx_entry->total_len = ofi_total_iov_len(tx_entry->iov, tx_entry->iov_count);
 
 	/* set flags */
 	assert(ep->util_ep.tx_msg_flags == 0 ||
@@ -1844,6 +1840,7 @@ int rxr_endpoint(struct fid_domain *domain, struct fi_info *info,
 	rxr_ep->core_msg_order = rdm_info->rx_attr->msg_order;
 	rxr_ep->core_inject_size = rdm_info->tx_attr->inject_size;
 	rxr_ep->max_msg_size = info->ep_attr->max_msg_size;
+	rxr_ep->msg_prefix_size = info->ep_attr->msg_prefix_size;
 	rxr_ep->max_proto_hdr_size = rxr_pkt_max_header_size();
 	rxr_ep->mtu_size = rdm_info->ep_attr->max_msg_size;
 	fi_freeinfo(rdm_info);

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -475,14 +475,7 @@ static int rxr_info_to_rxr(uint32_t version, const struct fi_info *core_info,
 			info->mode |= FI_MSG_PREFIX;
 			info->tx_attr->mode |= FI_MSG_PREFIX;
 			info->rx_attr->mode |= FI_MSG_PREFIX;
-
-			/*
-			 * The prefix needs to be a multiple of 8. The pkt_entry
-			 * is already at 64 bytes (128 with debug).
-			 */
-			info->ep_attr->msg_prefix_size =  sizeof(struct rxr_pkt_entry)
-							  + sizeof(struct rxr_eager_msgrtm_hdr);
-			assert(!(info->ep_attr->msg_prefix_size % 8));
+			info->ep_attr->msg_prefix_size = RXR_MSG_PREFIX_SIZE;
 			FI_INFO(&rxr_prov, FI_LOG_CORE,
 				"FI_MSG_PREFIX size = %ld\n", info->ep_attr->msg_prefix_size);
 		}

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -198,20 +198,6 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 		return rxr_pkt_post_ctrl(rxr_ep, RXR_TX_ENTRY, tx_entry, ctrl_type + tagged, 0);
 	}
 
-	if (rxr_ep->use_zcpy_rx) {
-		/*
-		 * The application can not deal with varying packet header sizes
-		 * before and after receiving a handshake. Forcing a handshake
-		 * here so we can always use the smallest eager msg packet
-		 * header size to determine the msg_prefix_size.
-		 */
-		err = rxr_pkt_wait_handshake(rxr_ep, tx_entry->addr, peer);
-		if (OFI_UNLIKELY(err))
-			return err;
-
-		assert(peer->flags & RXR_PEER_HANDSHAKE_RECEIVED);
-	}
-
 	if (efa_ep_is_cuda_mr(tx_entry->desc[0])) {
 		return rxr_msg_post_cuda_rtm(rxr_ep, tx_entry);
 	}

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -1019,6 +1019,8 @@ ssize_t rxr_msg_zero_copy_recv(struct rxr_ep *ep, const struct fi_msg *msg,
 	ret = fi_recv(ep->rdm_ep, recv_iov.iov_base, recv_iov.iov_len,
 		      msg->desc[0], FI_ADDR_UNSPEC, pkt_entry);
 	if (OFI_UNLIKELY(ret)) {
+		/* no need to call rxr_pkt_entry_release_rx because we do not own
+		 * the buffer */
 		rxr_release_rx_entry(ep, rx_entry);
 		FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,
 			"failed to post buf %ld (%s)\n", -ret,

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -885,8 +885,8 @@ void rxr_pkt_handle_zero_copy_recv_completion(struct rxr_ep *ep,
 	}
 
 	rxr_cq_write_rx_completion(ep, rx_entry);
-	rxr_pkt_entry_release_rx(ep, pkt_entry);
 	rxr_release_rx_entry(ep, rx_entry);
+	/* no need to call rxr_pkt_entry_release_rx because we do not own the buffer */
 }
 
 void rxr_pkt_handle_recv_completion(struct rxr_ep *ep,

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -850,16 +850,11 @@ void rxr_pkt_handle_zero_copy_recv_completion(struct rxr_ep *ep,
 	 */
 
 	/*
-	 * In zero copy receive mode, an RX entry was created in rxr_msg_generic_recv(),
-	 * the rx_entry was put in ep->rx_list, and ready to be matched.
-	 * At the same time, rxr_msg_generic_recv() posted a packet entry to receive
-	 * data, which is the one we are processing.
-	 * Calling rxr_pkt_get_msgrtm_rx_entry() should match that RX entry with this
-	 * paket entry, and return us a matched RX entry.
+	 * In zero copy receive mode, rx_entry was created in rxr_msg_zero_copy_recv(),
+	 * and assigned to pkt_entry->x_entry
 	 */
-	rx_entry = rxr_pkt_get_msgrtm_rx_entry(ep, &pkt_entry);
+	rx_entry = pkt_entry->x_entry;
 	assert(rx_entry && rx_entry->state == RXR_RX_MATCHED);
-	pkt_entry->x_entry = rx_entry;
 
 	/* data is already in user provided buffer, so no need to do memory
 	 * copy. However, we do need to make sure the packet header length

--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -170,9 +170,7 @@ void rxr_pkt_entry_release_rx(struct rxr_ep *ep,
 			      struct rxr_pkt_entry *pkt_entry)
 {
 	assert(pkt_entry->next == NULL);
-
-	if (ep->use_zcpy_rx && pkt_entry->type == RXR_PKT_ENTRY_USER)
-		return;
+	assert(pkt_entry->type != RXR_PKT_ENTRY_USER);
 
 	if (pkt_entry->type == RXR_PKT_ENTRY_POSTED) {
 		struct rdm_peer *peer;

--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -48,9 +48,18 @@
  *   General purpose utility functions
  */
 
-struct rxr_pkt_entry *rxr_pkt_entry_init_prefix(struct rxr_ep *ep,
-						const struct fi_msg *posted_buf,
-						struct ofi_bufpool *pkt_pool)
+/**
+ * @brief construct a packet entry from user supplied iov.
+ *
+ * @param[in] ep     endpoint
+ * @param[in] iov    user buffer
+ * @param[in] desc   memory descriptor
+ * @return a pointer to rxr_pkt_entry, pointing to the begining
+ *         of the user buffer
+ */
+struct rxr_pkt_entry *rxr_pkt_entry_from_iov(struct rxr_ep *ep,
+					     const struct iovec *iov,
+					     void *desc)
 {
 	struct rxr_pkt_entry *pkt_entry;
 	struct efa_mr *mr;
@@ -60,8 +69,8 @@ struct rxr_pkt_entry *rxr_pkt_entry_init_prefix(struct rxr_ep *ep,
 	 * fields, we can directly map the user-provided fi_msg address
 	 * as the pkt_entry, which will hold the metadata in the prefix.
 	 */
-	assert(posted_buf->msg_iov->iov_len >= sizeof(struct rxr_pkt_entry) + sizeof(struct rxr_eager_msgrtm_hdr));
-	pkt_entry = (struct rxr_pkt_entry *) posted_buf->msg_iov->iov_base;
+	assert(iov->iov_len >= ep->msg_prefix_size);
+	pkt_entry = (struct rxr_pkt_entry *) iov->iov_base;
 	if (!pkt_entry)
 		return NULL;
 
@@ -72,7 +81,7 @@ struct rxr_pkt_entry *rxr_pkt_entry_init_prefix(struct rxr_ep *ep,
 	 * completion.
 	 */
 	dlist_init(&pkt_entry->entry);
-	mr = (struct efa_mr *) posted_buf->desc[0];
+	mr = (struct efa_mr *)desc;
 	pkt_entry->mr = &mr->mr_fid;
 
 	pkt_entry->type = RXR_PKT_ENTRY_USER;

--- a/prov/efa/src/rxr/rxr_pkt_entry.h
+++ b/prov/efa/src/rxr/rxr_pkt_entry.h
@@ -115,9 +115,9 @@ struct rxr_ep;
 
 struct rxr_tx_entry;
 
-struct rxr_pkt_entry *rxr_pkt_entry_init_prefix(struct rxr_ep *ep,
-						const struct fi_msg *posted_buf,
-						struct ofi_bufpool *pkt_pool);
+struct rxr_pkt_entry *rxr_pkt_entry_from_iov(struct rxr_ep *ep,
+					     const struct iovec *iov,
+					     void *desc);
 
 struct rxr_pkt_entry *rxr_pkt_entry_alloc(struct rxr_ep *ep,
 					  struct ofi_bufpool *pkt_pool);

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -138,9 +138,10 @@ void rxr_pkt_init_req_hdr(struct rxr_ep *ep,
 		struct rxr_req_opt_raw_addr_hdr *raw_addr_hdr;
 
 		raw_addr_hdr = (struct rxr_req_opt_raw_addr_hdr *)opt_hdr;
-		raw_addr_hdr->addr_len = ep->core_addrlen;
-		memcpy(raw_addr_hdr->raw_addr, ep->core_addr, raw_addr_hdr->addr_len);
-		opt_hdr += sizeof(*raw_addr_hdr) + raw_addr_hdr->addr_len;
+		raw_addr_hdr->addr_len = RXR_REQ_OPT_RAW_ADDR_HDR_SIZE - sizeof(struct rxr_req_opt_raw_addr_hdr);
+		assert(raw_addr_hdr->addr_len >= ep->core_addrlen);
+		memcpy(raw_addr_hdr->raw_addr, ep->core_addr, ep->core_addrlen);
+		opt_hdr += RXR_REQ_OPT_RAW_ADDR_HDR_SIZE;
 	}
 
 	if (base_hdr->flags & RXR_REQ_OPT_CQ_DATA_HDR) {

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -833,7 +833,6 @@ int rxr_pkt_rtm_match_trecv(struct dlist_entry *item, const void *arg)
 			     match_tag);
 }
 
-static
 struct rxr_rx_entry *rxr_pkt_get_msgrtm_rx_entry(struct rxr_ep *ep,
 						 struct rxr_pkt_entry **pkt_entry_ptr)
 {
@@ -1174,53 +1173,6 @@ ssize_t rxr_pkt_proc_rtm_rta(struct rxr_ep *ep,
 	}
 
 	return -FI_EINVAL;
-}
-
-void rxr_pkt_handle_zcpy_recv(struct rxr_ep *ep,
-			      struct rxr_pkt_entry *pkt_entry)
-{
-	struct rxr_rx_entry *rx_entry;
-
-	struct rxr_base_hdr *base_hdr __attribute__((unused));
-	base_hdr = rxr_get_base_hdr(pkt_entry->pkt);
-	assert(base_hdr->type >= RXR_BASELINE_REQ_PKT_BEGIN);
-	assert(base_hdr->type != RXR_MEDIUM_MSGRTM_PKT);
-	assert(base_hdr->type != RXR_MEDIUM_TAGRTM_PKT);
-	assert(base_hdr->type != RXR_DC_MEDIUM_MSGRTM_PKT);
-	assert(base_hdr->type != RXR_DC_MEDIUM_MSGRTM_PKT);
-	assert(pkt_entry->type == RXR_PKT_ENTRY_USER);
-
-	rx_entry = rxr_pkt_get_msgrtm_rx_entry(ep, &pkt_entry);
-	if (OFI_UNLIKELY(!rx_entry)) {
-		efa_eq_write_error(&ep->util_ep, FI_ENOBUFS, -FI_ENOBUFS);
-		rxr_pkt_entry_release_rx(ep, pkt_entry);
-		return;
-	}
-	pkt_entry->x_entry = rx_entry;
-	if (rx_entry->state != RXR_RX_MATCHED)
-		return;
-
-	/*
-	 * The incoming receive will always get matched to the first posted
-	 * rx_entry available, so this is a constant cost. No real tag or
-	 * address matching happens.
-	 */
-	assert(rx_entry->state == RXR_RX_MATCHED);
-
-	/*
-	 * Adjust rx_entry->cq_entry.len as needed.
-	 * Initialy rx_entry->cq_entry.len is total recv buffer size.
-	 * rx_entry->total_len is from REQ packet and is total send buffer size.
-	 * if send buffer size < recv buffer size, we adjust value of rx_entry->cq_entry.len
-	 * if send buffer size > recv buffer size, we have a truncated message and will
-	 * write error CQ entry.
-	 */
-	if (rx_entry->cq_entry.len > rx_entry->total_len)
-		rx_entry->cq_entry.len = rx_entry->total_len;
-
-	rxr_cq_write_rx_completion(ep, rx_entry);
-	rxr_pkt_entry_release_rx(ep, pkt_entry);
-	rxr_release_rx_entry(ep, rx_entry);
 }
 
 void rxr_pkt_handle_rtm_rta_recv(struct rxr_ep *ep,

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -833,6 +833,7 @@ int rxr_pkt_rtm_match_trecv(struct dlist_entry *item, const void *arg)
 			     match_tag);
 }
 
+static
 struct rxr_rx_entry *rxr_pkt_get_msgrtm_rx_entry(struct rxr_ep *ep,
 						 struct rxr_pkt_entry **pkt_entry_ptr)
 {

--- a/prov/efa/src/rxr/rxr_pkt_type_req.h
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.h
@@ -434,9 +434,6 @@ void rxr_pkt_handle_read_rtm_send_completion(struct rxr_ep *ep,
 void rxr_pkt_rtm_update_rx_entry(struct rxr_pkt_entry *pkt_entry,
 				 struct rxr_rx_entry *rx_entry);
 
-struct rxr_rx_entry *rxr_pkt_get_msgrtm_rx_entry(struct rxr_ep *ep,
-						 struct rxr_pkt_entry **pkt_entry_ptr);
-
 /*         This function is called by both
  *            rxr_pkt_handle_rtm_recv() and
  *            rxr_msg_handle_unexp_match()

--- a/prov/efa/src/rxr/rxr_pkt_type_req.h
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.h
@@ -434,6 +434,9 @@ void rxr_pkt_handle_read_rtm_send_completion(struct rxr_ep *ep,
 void rxr_pkt_rtm_update_rx_entry(struct rxr_pkt_entry *pkt_entry,
 				 struct rxr_rx_entry *rx_entry);
 
+struct rxr_rx_entry *rxr_pkt_get_msgrtm_rx_entry(struct rxr_ep *ep,
+						 struct rxr_pkt_entry **pkt_entry_ptr);
+
 /*         This function is called by both
  *            rxr_pkt_handle_rtm_recv() and
  *            rxr_msg_handle_unexp_match()
@@ -444,11 +447,6 @@ ssize_t rxr_pkt_proc_matched_rtm(struct rxr_ep *ep,
 
 ssize_t rxr_pkt_proc_rtm_rta(struct rxr_ep *ep,
 			     struct rxr_pkt_entry *pkt_entry);
-/*
- *         This function handles zero-copy receives that do not require ordering
- */
-void rxr_pkt_handle_zcpy_recv(struct rxr_ep *ep,
-			      struct rxr_pkt_entry *pkt_entry);
 /*
  *         This function is shared by all RTM packet types which handle
  *         reordering


### PR DESCRIPTION
A series of patches that fix a dead lock in zero copy receive mode.