### PR TITLE
prov/shm: add shm signal to reduce lock contention

### DIFF
--- a/include/ofi_atom.h
+++ b/include/ofi_atom.h
@@ -159,6 +159,13 @@ typedef atomic_long	ofi_atomic_int64_t;
 							     &expected, desired,			\
 							     memory_order_acq_rel,			\
 							     memory_order_relaxed);			\
+	}												\
+	static inline											\
+	bool ofi_atomic_cas_bool##radix(ofi_atomic##radix##_t *atomic, 					\
+					int##radix##_t expected, 					\
+					int##radix##_t desired)						\
+	{												\
+		return ofi_atomic_cas_bool_strong##radix(atomic, expected, desired);			\
 	}
 
 #elif defined HAVE_BUILTIN_ATOMICS

--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -236,6 +236,8 @@ struct smr_region {
 	fastlock_t	lock; /* lock for shm access
 				 Must hold smr->lock before tx/rx cq locks
 				 in order to progress or post recv */
+	ofi_atomic32_t	signal;
+
 	struct smr_map	*map;
 
 	size_t		total_size;
@@ -360,6 +362,11 @@ struct smr_region *smr_map_get(struct smr_map *map, int64_t id);
 int	smr_create(const struct fi_provider *prov, struct smr_map *map,
 		   const struct smr_attr *attr, struct smr_region *volatile *smr);
 void	smr_free(struct smr_region *smr);
+
+static inline void smr_signal(struct smr_region *smr)
+{
+	ofi_atomic_set32(&smr->signal, 1);
+}
 
 #ifdef __cplusplus
 }

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -252,6 +252,7 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 	smr_format_rma_ioc(cmd, rma_ioc, rma_count);
 	ofi_cirque_commit(smr_cmd_queue(peer_smr));
 	peer_smr->cmd_cnt--;
+	smr_signal(peer_smr);
 unlock_cq:
 	fastlock_release(&ep->util_ep.tx_cq->cq_lock);
 unlock_region:
@@ -373,6 +374,7 @@ static ssize_t smr_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 	smr_format_rma_ioc(cmd, &rma_ioc, 1);
 	ofi_cirque_commit(smr_cmd_queue(peer_smr));
 	peer_smr->cmd_cnt--;
+	smr_signal(peer_smr);
 
 	ofi_ep_tx_cntr_inc_func(&ep->util_ep, ofi_op_atomic);
 unlock_region:

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -210,6 +210,7 @@ static void smr_send_name(struct smr_ep *ep, int64_t id)
 	smr_peer_data(ep->region)[id].name_sent = 1;
 	ofi_cirque_commit(smr_cmd_queue(peer_smr));
 	peer_smr->cmd_cnt--;
+	smr_signal(peer_smr);
 
 out:
 	fastlock_release(&peer_smr->lock);

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -256,6 +256,7 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 commit:
 	ofi_cirque_commit(smr_cmd_queue(peer_smr));
 	peer_smr->cmd_cnt--;
+	smr_signal(peer_smr);
 unlock_cq:
 	fastlock_release(&ep->util_ep.tx_cq->cq_lock);
 unlock_region:
@@ -347,6 +348,7 @@ static ssize_t smr_generic_inject(struct fid_ep *ep_fid, const void *buf,
 	ofi_ep_tx_cntr_inc_func(&ep->util_ep, op);
 	peer_smr->cmd_cnt--;
 	ofi_cirque_commit(smr_cmd_queue(peer_smr));
+	smr_signal(peer_smr);
 unlock:
 	fastlock_release(&peer_smr->lock);
 

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -224,6 +224,7 @@ ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 commit_comp:
 	ofi_cirque_commit(smr_cmd_queue(peer_smr));
 	peer_smr->cmd_cnt--;
+	smr_signal(peer_smr);
 
 	if (!comp)
 		goto unlock_cq;
@@ -415,6 +416,7 @@ ssize_t smr_generic_rma_inject(struct fid_ep *ep_fid, const void *buf,
 commit:
 	ofi_cirque_commit(smr_cmd_queue(peer_smr));
 	peer_smr->cmd_cnt--;
+	smr_signal(peer_smr);
 	ofi_ep_tx_cntr_inc_func(&ep->util_ep, ofi_op_write);
 unlock_region:
 	fastlock_release(&peer_smr->lock);

--- a/prov/util/src/util_shm.c
+++ b/prov/util/src/util_shm.c
@@ -255,6 +255,7 @@ int smr_create(const struct fi_provider *prov, struct smr_map *map,
 
 	*smr = mapped_addr;
 	fastlock_init(&(*smr)->lock);
+	ofi_atomic_initialize32(&(*smr)->signal, 0);
 
 	(*smr)->map = map;
 	(*smr)->version = SMR_VERSION;


### PR DESCRIPTION
In order to make progress, shm needs to check the cmd list for any
incoming messages and the resp queue for any operation completion
notifications. The only protection for these is the shm lock. This
can cause a lot of lock contention when the EP is trying to make
progress on incoming messages while a peer it trying to send a
message.

These issues are especially evident on particular nodes. Unclear
what the actual cause of the increase in contention is.

Regardless, to fix this, add a signal to the shm region which is used
to check whether there could be an incoming cmd or response. Peers can
still send messages without competing with the target for the lock.
Whenever a cmd is inserted or a response is updated, signal the lock
to let the EP know to try to make progress.

See performance impacts below on fi_rdm_pingpong.

Usual performance disclaimer: this is from single runs on one system;
this is not meant as an official performance snapshot.

Before (bad node):

```bytes   iters   total       time     MB/sec    usec/xfer   Mxfers/sec
64      10k     1.2m       18.46s      0.07     923.11       0.00
256     10k     4.8m       22.74s      0.23    1137.00       0.00
1k      10k     19m        20.03s      1.02    1001.65       0.00
4k      10k     78m        15.53s      5.28     776.40       0.00
64k     1k      125m        1.85s     70.86     924.84       0.00
1m      100     200m        0.25s    849.42    1234.46       0.00
```

Before (good node):
```bytes   iters   total       time     MB/sec    usec/xfer   Mxfers/sec
64      10k     1.2m        0.04s     29.00       2.21       0.45
256     10k     4.8m        0.05s    106.42       2.41       0.42
1k      10k     19m         0.05s    420.15       2.44       0.41
4k      10k     78m         0.07s   1109.17       3.69       0.27
64k     1k      125m        0.02s   8009.78       8.18       0.12
1m      100     200m        0.02s  10770.09      97.36       0.01
```

After (bad node):
```bytes   iters   total       time     MB/sec    usec/xfer   Mxfers/sec
64      10k     1.2m        0.03s     40.18       1.59       0.63
256     10k     4.8m        0.04s    143.14       1.79       0.56
1k      10k     19m         0.04s    562.14       1.82       0.55
4k      10k     78m         0.06s   1407.92       2.91       0.34
64k     1k      125m        0.02s   7380.18       8.88       0.11
1m      100     200m        0.02s   9395.42     111.61       0.01
```

After (good node):
```bytes   iters   total       time     MB/sec    usec/xfer   Mxfers/sec
64      10k     1.2m        0.02s     69.94       0.92       1.09
256     10k     4.8m        0.02s    247.39       1.03       0.97
1k      10k     19m         0.02s    939.49       1.09       0.92
4k      10k     78m         0.03s   2411.68       1.70       0.59
64k     1k      125m        0.01s  10310.08       6.36       0.16
1m      100     200m        0.02s  10885.81      96.32       0.01
```

The patch also seems to resolve issues when running shm in a non-debug build
which causes random performance issues. See performance impacts below:

Non-debug build before (sample random bad run, appeared after 2 runs):
```bytes   iters   total       time     MB/sec    usec/xfer   Mxfers/sec
64      10k     1.2m        1.59s      0.81      79.41       0.01
256     10k     4.8m        0.54s      9.51      26.91       0.04
1k      10k     19m         0.21s     99.54      10.29       0.10
4k      10k     78m         3.32s     24.68     165.98       0.01
64k     1k      125m        0.46s    284.46     230.38       0.00
1m      100     200m        0.04s   4968.26     211.05       0.00
```

Non-debug build after (consistent with 50 runs):

```bytes   iters   total       time     MB/sec    usec/xfer   Mxfers/sec
64      10k     1.2m        0.01s    120.63       0.53       1.88
256     10k     4.8m        0.01s    391.23       0.65       1.53
1k      10k     19m         0.01s   1425.69       0.72       1.39
4k      10k     78m         0.03s   3202.00       1.28       0.78
64k     1k      125m        0.01s  10509.30       6.24       0.16
1m      100     200m        0.02s  10098.00     103.84       0.01
```

Signed-off-by: aingerson <alexia.ingerson@intel.com>