### PR TITLE
prov/tcp: Add tx and rx overflow checks

### DIFF
--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -236,6 +236,7 @@ struct tcpx_ep {
 	struct slist		tx_queue;
 	struct slist		tx_rsp_pend_queue;
 	struct slist		rma_read_queue;
+	int			rx_avail;
 	struct tcpx_rx_ctx	*srx_ctx;
 	enum tcpx_state		state;
 	/* lock for protecting tx/rx queues, rma list, state*/

--- a/prov/tcp/src/tcpx_domain.c
+++ b/prov/tcp/src/tcpx_domain.c
@@ -88,7 +88,7 @@ static int tcpx_srx_ctx(struct fid_domain *domain, struct fi_rx_attr *attr,
 
 	ret = ofi_bufpool_create(&srx_ctx->buf_pool,
 				 sizeof(struct tcpx_xfer_entry),
-				 16, 0, 1024, 0);
+				 16, attr->size, 1024, 0);
 	if (ret)
 		goto err2;
 

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -471,6 +471,7 @@ found:
 	cq = container_of(ep->util_ep.rx_cq, struct tcpx_cq, util_cq);
 
 	slist_remove(&ep->rx_queue, cur, prev);
+	ep->rx_avail++;
 	tcpx_cq_report_error(&cq->util_cq, xfer_entry, FI_ECANCELED);
 	tcpx_free_xfer(cq, xfer_entry);
 }
@@ -704,6 +705,8 @@ int tcpx_endpoint(struct fid_domain *domain, struct fi_info *info,
 	slist_init(&ep->tx_queue);
 	slist_init(&ep->rma_read_queue);
 	slist_init(&ep->tx_rsp_pend_queue);
+	if (info->ep_attr->rx_ctx_cnt != FI_SHARED_CONTEXT)
+		ep->rx_avail = info->rx_attr->size;
 
 	ep->cur_rx.hdr_done = 0;
 	ep->cur_rx.hdr_len = sizeof(ep->cur_rx.hdr.base_hdr);

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -425,6 +425,7 @@ static struct tcpx_xfer_entry *tcpx_get_rx_entry(struct tcpx_ep *ep)
 		if (!slist_empty(&ep->rx_queue)) {
 			xfer = container_of(slist_remove_head(&ep->rx_queue),
 					    struct tcpx_xfer_entry, entry);
+			ep->rx_avail++;
 		} else {
 			xfer = NULL;
 		}


### PR DESCRIPTION
Limit the number of sends or receives that the user can post before getting EAGAIN.