### PR TITLE
fabtests: Add fi_rdm_multi_client test

### DIFF
--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -432,6 +432,7 @@ dummy_man_pages = \
 	man/man1/fi_getinfo_test.1 \
 	man/man1/fi_mr_test.1 \
 	man/man1/fi_bw.1 \
+	man/man1/fi_rdm_multi_client.1 \
 	man/man1/fi_ubertest.1
 
 nroff:

--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -43,6 +43,7 @@ bin_PROGRAMS = \
 	functional/fi_rdm_atomic \
 	functional/fi_multi_recv \
 	functional/fi_bw \
+	functional/fi_rdm_multi_client \
 	benchmarks/fi_msg_pingpong \
 	benchmarks/fi_msg_bw \
 	benchmarks/fi_rma_bw \
@@ -257,6 +258,10 @@ functional_fi_multi_recv_LDADD = libfabtests.la
 functional_fi_bw_SOURCES = \
 	functional/bw.c
 functional_fi_bw_LDADD = libfabtests.la
+
+functional_fi_rdm_multi_client_SOURCES = \
+	functional/rdm_multi_client.c
+functional_fi_rdm_multi_client_LDADD = libfabtests.la
 
 benchmarks_fi_msg_pingpong_SOURCES = \
 	benchmarks/msg_pingpong.c \

--- a/fabtests/functional/rdm_multi_client.c
+++ b/fabtests/functional/rdm_multi_client.c
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2021, Amazon.com, Inc.  All rights reserved.
+ *
+ * This software is available to you under the BSD license
+ * below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * This program tests the functionality of RDM endpoint in the case
+ * that a persistent server does ping-pong with multiple clients that
+ * come and leave in sequence. The client connects to a server, sends
+ * ping-pong, disconnects with the server by cleaning all fabric
+ * resources, and repeats.
+ * If the `-R` option is specified, it will re-use the first client's 
+ * address for the subsequent clients by setting the src_addr for
+ * endpoints 2..n to the output of fi_getname() of the first client.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <getopt.h>
+
+#include <shared.h>
+#include <rdma/fi_cm.h>
+
+static int run_pingpong(void)
+{
+	int ret, i;
+
+	fprintf(stdout, "Start ping-pong.\n");
+	for (i = 0; i < opts.iterations; i++) {
+		if (opts.dst_addr) {
+			ret = ft_tx(ep, remote_fi_addr, opts.transfer_size, &tx_ctx);
+			if (ret) {
+				FT_PRINTERR("ft_tx", -ret);
+				return ret;
+			}
+			ret = ft_rx(ep, opts.transfer_size);
+			if (ret) {
+				FT_PRINTERR("ft_rx", -ret);
+				return ret;
+			}
+		} else {
+			ret = ft_rx(ep, opts.transfer_size);
+			if (ret) {
+				FT_PRINTERR("ft_rx", -ret);
+				return ret;
+			}
+			ret = ft_tx(ep, remote_fi_addr, opts.transfer_size, &tx_ctx);
+			if (ret) {
+				FT_PRINTERR("ft_tx", -ret);
+				return ret;
+			}
+		}
+	}
+
+	fprintf(stdout, "Ping-pong succeeds.\n");
+	return 0;
+}
+
+static int run_server(void)
+{
+	int nconn, ret;
+
+	ret = ft_init_fabric();
+	if (ret) {
+		FT_PRINTERR("ft_init_fabric", -ret);
+		return ret;
+	}
+
+	nconn = opts.num_connections;
+
+	while (nconn) {
+		ret = run_pingpong();
+		if (ret) {
+			FT_PRINTERR("run_pingpong", -ret);
+			return ret;
+		}
+		if (--nconn) {
+			ret = ft_init_av();
+			if (ret) {
+				FT_PRINTERR("ft_init_av", -ret);
+				return ret;
+			}
+		}
+	}
+	return 0;
+}
+
+static int run_client(int client_id, bool address_reuse)
+{
+	static char name[256];
+	static size_t size = sizeof(name);
+	int ret;
+
+	tx_seq = 0;
+	rx_seq = 0;
+	tx_cq_cntr = 0;
+	rx_cq_cntr = 0;
+
+	ret = ft_init_oob();
+	if (ret) {
+		FT_PRINTERR("ft_init_oob", -ret);
+		return ret;
+	}
+
+	ret = ft_getinfo(hints, &fi);
+	if (ret) {
+		FT_PRINTERR("ft_getinfo", -ret);
+		return ret;
+	}
+
+	ret = ft_open_fabric_res();
+	if (ret) {
+		FT_PRINTERR("ft_open_fabric_res", -ret);
+		return ret;
+	}
+
+	if (client_id > 0 && address_reuse) {
+		memcpy(fi->src_addr, name, size);
+		fi->src_addrlen = size;
+	}
+
+	ret = ft_alloc_active_res(fi);
+	if (ret) {
+		FT_PRINTERR("ft_alloc_active_res", -ret);
+		return ret;
+	}
+
+	ret = ft_enable_ep_recv();
+	if (ret) {
+		FT_PRINTERR("ft_enable_ep_recv", -ret);
+		return ret;
+	}
+
+	ret = ft_init_av();
+	if (ret) {
+		FT_PRINTERR("ft_init_av", -ret);
+		return ret;
+	}
+
+	if (client_id == 0) {
+		ret = fi_getname(&ep->fid, name, &size);
+		if (ret) {
+			FT_PRINTERR("fi_getname", -ret);
+			return ret;
+		}
+	}
+
+	return run_pingpong();
+}
+
+static void print_opts_usage(char *name, char *desc)
+{
+	ft_usage(name, desc);
+	/* rdm_multi_client test op type */
+	FT_PRINT_OPTS_USAGE("-R", "Reuse the address of the first client for subsequent clients");
+}
+
+int main(int argc, char **argv)
+{
+	int op, ret, i;
+	struct fi_info *save;
+	bool address_reuse = false;
+
+	opts = INIT_OPTS;
+	opts.options |= FT_OPT_SIZE;
+
+	hints = fi_allocinfo();
+	if (!hints)
+		return EXIT_FAILURE;
+
+	while ((op = getopt(argc, argv, "URh" ADDR_OPTS INFO_OPTS CS_OPTS)) != -1) {
+		switch (op) {
+		default:
+			ft_parse_addr_opts(op, optarg, &opts);
+			ft_parseinfo(op, optarg, hints, &opts);
+			ft_parsecsopts(op, optarg, &opts);
+			break;
+		case 'U':
+			hints->tx_attr->op_flags |= FI_DELIVERY_COMPLETE;
+			break;
+		case 'R':
+			address_reuse = true;
+			break;
+		case '?':
+		case 'h':
+			print_opts_usage(argv[0], "RDM multi-client test");
+			return EXIT_FAILURE;
+		}
+	}
+
+	if (optind < argc)
+		opts.dst_addr = argv[optind];
+
+	hints->ep_attr->type = FI_EP_RDM;
+	hints->caps = FI_MSG;
+	hints->mode = FI_CONTEXT;
+	hints->domain_attr->mr_mode = opts.mr_mode;
+
+	if (opts.dst_addr) {
+		for (i = 0; i < opts.num_connections; i++) {
+			save = fi_dupinfo(hints);
+			printf("Starting client: %d\n", i);
+			ret = run_client(i, address_reuse);
+			if (ret) {
+				FT_PRINTERR("run_client", -ret);
+				goto out;
+			}
+			ft_free_res();
+			hints = save;
+		}
+	} else {
+		ret = run_server();
+		if (ret)
+			FT_PRINTERR("run_server", -ret);
+	}
+out:
+	ft_free_res();
+	return ft_exit_code(ret);
+}

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2013-2017 Intel Corporation.  All rights reserved.
  * Copyright (c) 2014-2017, Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2021 Amazon.com, Inc. or its affiliates. All rights reserved.
  *
  * This software is available to you under the BSD license below:
  *
@@ -260,6 +261,7 @@ extern char default_port[8];
 	{	.options = FT_OPT_RX_CQ | FT_OPT_TX_CQ, \
 		.iterations = 1000, \
 		.warmup_iterations = 10, \
+		.num_connections = 1, \
 		.transfer_size = 1024, \
 		.window_size = 64, \
 		.av_size = 1, \
@@ -369,6 +371,8 @@ int ft_open_fabric_res();
 int ft_getinfo(struct fi_info *hints, struct fi_info **info);
 int ft_init_fabric();
 int ft_init_oob();
+int ft_close_oob();
+int ft_reset_oob();
 int ft_start_server();
 int ft_server_connect();
 int ft_client_connect();

--- a/fabtests/man/fabtests.7.md
+++ b/fabtests/man/fabtests.7.md
@@ -148,6 +148,10 @@ features of libfabric.
   A sleep time on the receiving side can be enabled in order to allow
   the sender to get ahead of the receiver.
 
+*fi_rdm_multi_client*
+: Tests a persistent server communicating with multiple clients, one at a
+  time, in sequence.
+
 # Benchmarks
 
 The client and the server exchange messages in either a ping-pong manner,

--- a/fabtests/man/man1/fi_rdm_multi_client.1
+++ b/fabtests/man/man1/fi_rdm_multi_client.1
@@ -1,0 +1,1 @@
+.so man7/fabtests.7

--- a/fabtests/scripts/runfabtests.sh
+++ b/fabtests/scripts/runfabtests.sh
@@ -138,6 +138,8 @@ functional_tests=(
 	"fi_bw -e rdm -v -T 1"
 	"fi_bw -e rdm -v -T 1 -U"
 	"fi_bw -e msg -v -T 1"
+	"fi_rdm_multi_client -C 10 -I 5"
+	"fi_rdm_multi_client -C 10 -I 5 -U"
 )
 
 short_tests=(

--- a/fabtests/test_configs/efa/efa.exclude
+++ b/fabtests/test_configs/efa/efa.exclude
@@ -96,3 +96,6 @@ dgram_bw
 
 # Multinode tests failing with an unsupported address format
 multinode
+
+# Remove this once the av bug fix is merged.
+rdm_multi_client

--- a/fabtests/test_configs/psm2/psm2.exclude
+++ b/fabtests/test_configs/psm2/psm2.exclude
@@ -15,3 +15,4 @@ scalable_ep
 shared_av
 rdm_cntr_pingpong
 multi_recv
+rdm_multi_client


### PR DESCRIPTION
This PR adds a new test `fi_rdm_multi_client`

This program tests the functionality of RDM endpoint in the case that a persistent server does ping-pong with multiple clients that come and leave in sequence. The client connects to a server, sends ping-pong, disconnects with the server by cleaning all fabric resources, and repeats. It will re-use the first client's address for the subsequent clients if the `fi_setname` API is implemented for the tested provider.