### PR TITLE
[v1.11.x] prov/efa: backport 2 bugfixes

### DIFF
--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1519,7 +1519,7 @@ static inline void rxr_ep_poll_cq(struct rxr_ep *ep,
 			if (!is_shm_cq)
 				ep->send_comps++;
 #endif
-			rxr_pkt_handle_send_completion(ep, &cq_entry);
+			rxr_pkt_handle_send_completion(ep, cq_entry.op_context);
 		} else if (cq_entry.flags & (FI_RECV | FI_REMOTE_CQ_DATA)) {
 			rxr_pkt_handle_recv_completion(ep, &cq_entry, src_addr);
 #if ENABLE_DEBUG

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -325,11 +325,13 @@ int rxr_ep_post_buf(struct rxr_ep *ep, const struct fi_msg *posted_recv, uint64_
 		msg.desc = &desc;
 		/*
 		 * Use the actual receive sizes from the application
-		 * rather than posting the full MTU size, like we do
-		 * when using the bufpool.
+		 * minus size of struct rxr_pkt_entry.
+		 * This is because we use the application buffer to
+		 * construct a pkt_entry, and use pkt_entry->pkt to
+		 * receive data.
 		 */
 		if (posted_recv) {
-			msg_iov.iov_len = posted_recv->msg_iov->iov_len;
+			msg_iov.iov_len = posted_recv->msg_iov->iov_len - sizeof(struct rxr_pkt_entry);
 			msg.data = posted_recv->data;
 			assert(msg_iov.iov_len <= ep->mtu_size);
 		}

--- a/prov/efa/src/rxr/rxr_pkt_cmd.h
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.h
@@ -57,7 +57,7 @@ void rxr_pkt_handle_data_copied(struct rxr_ep *ep,
 				size_t data_size);
 
 void rxr_pkt_handle_send_completion(struct rxr_ep *ep,
-				    struct fi_cq_data_entry *cq_entry);
+				    struct rxr_pkt_entry *pkt_entry);
 
 void rxr_pkt_handle_recv_completion(struct rxr_ep *ep,
 				    struct fi_cq_data_entry *cq_entry,


### PR DESCRIPTION
back port the following 2 commits from master branch to v1.11.x branch:

e81536d prov/efa: fix incorrect handle of successful injection
ac7bf2d prov/efa: fix a bug in posting application buffer for zero copy receive