### PR TITLE
prov/efa: fix a bug in rxr_pkt_data_from_tx

### DIFF
--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -287,17 +287,28 @@ size_t rxr_pkt_req_max_data_size(struct rxr_ep *ep, fi_addr_t addr, int pkt_type
  *     init() functions
  */
 
-/*
- * this function is called after you have set header in pkt_entry->pkt
+/**
+ * @brief set up data in a REQ packet using tx_entry information.
+ *        Depend on the tx_entry, this function can either copy data to packet entry, or point
+ *        pkt_entry->iov to applicaiton buffer.
+ *        It requires the packet header to be set.
+ *
+ * @param[in]		ep		end point.
+ * @param[in,out]	pkt_entry	packet entry. Header must have been set when the function is called
+ * @param[in]		tx_entry	This function will use iov, iov_count and desc of tx_entry
+ * @param[in]		data_offset	offset of the data to be set up. In reference to tx_entry->total_len.
+ * @param[in]		data_size	length of the data to be set up. In reference to tx_entry->total_len.
+ * @return		no return
  */
-void rxr_pkt_data_from_tx(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry,
-			  struct rxr_tx_entry *tx_entry, size_t data_offset,
-			  size_t data_size)
+static inline
+void rxr_pkt_req_data_from_tx(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry,
+			      struct rxr_tx_entry *tx_entry, size_t data_offset,
+			      size_t data_size)
 {
 	int tx_iov_index;
 	size_t tx_iov_offset;
 	char *data;
-	size_t hdr_size;
+	size_t hdr_size, copied;
 	struct efa_mr *desc;
 
 	assert(pkt_entry->send);
@@ -316,45 +327,41 @@ void rxr_pkt_data_from_tx(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry,
 	assert(tx_iov_offset < tx_entry->iov[tx_iov_index].iov_len);
 
 	/*
-	 * We want to go through the bounce-buffers here only when
-	 * one of the following conditions are true:
-	 * 1. The application can not register buffers (no FI_MR_LOCAL)
-	 * 2. desc.peer.iface is anything but FI_HMEM_SYSTEM
-	 * 3. prov/shm is not used for this transfer, and #1 or #2 hold true.
-	 *
-	 * In the first case, we use the pre-registered pkt_entry's MR. In the
-	 * second case, this is for the eager and medium-message protocols which
-	 * can not rendezvous and pull the data from a peer. In the third case,
-	 * the bufpool would not have been created with a registration handler,
-	 * so pkt_entry->mr will be NULL.
-	 *
+	 * Copy can be avoid if:
+	 * 1. user provided memory descriptor, or lower provider does not need memory descriptor
+	 * 2. data to be send is in 1 iov, because device only support 2 iov, and we use
+	 *    1st iov for header.
 	 */
-	if (!tx_entry->desc[tx_iov_index] && pkt_entry->mr) {
-		data = (char *)pkt_entry->pkt + hdr_size;
-		data_size = ofi_copy_from_hmem_iov(data,
+	if ((!pkt_entry->mr || tx_entry->desc[tx_iov_index]) &&
+	    (tx_iov_offset + data_size < tx_entry->iov[tx_iov_index].iov_len)) {
+
+		assert(ep->core_iov_limit >= 2);
+		pkt_entry->send->iov[0].iov_base = pkt_entry->pkt;
+		pkt_entry->send->iov[0].iov_len = hdr_size;
+		pkt_entry->send->desc[0] = pkt_entry->mr ? fi_mr_desc(pkt_entry->mr) : NULL;
+
+		pkt_entry->send->iov[1].iov_base = (char *)tx_entry->iov[tx_iov_index].iov_base + tx_iov_offset;
+		pkt_entry->send->iov[1].iov_len = data_size;
+		pkt_entry->send->desc[1] = tx_entry->desc[tx_iov_index];
+		pkt_entry->send->iov_count = 2;
+		pkt_entry->pkt_size = hdr_size + data_size;
+		return;
+	}
+
+	data = (char *)pkt_entry->pkt + hdr_size;
+	copied = ofi_copy_from_hmem_iov(data,
 					data_size,
 					desc ? desc->peer.iface : FI_HMEM_SYSTEM,
 					desc ? desc->peer.device.reserved : 0,
 					tx_entry->iov,
 					tx_entry->iov_count,
 					data_offset);
-		pkt_entry->send->iov_count = 0;
-		pkt_entry->pkt_size = hdr_size + data_size;
-		return;
-	}
-
-	assert(ep->core_iov_limit >= 2);
-	pkt_entry->send->iov[0].iov_base = pkt_entry->pkt;
-	pkt_entry->send->iov[0].iov_len = hdr_size;
-	pkt_entry->send->desc[0] = pkt_entry->mr ? fi_mr_desc(pkt_entry->mr) : NULL;
-
-	pkt_entry->send->iov[1].iov_base = (char *)tx_entry->iov[tx_iov_index].iov_base + tx_iov_offset;
-	pkt_entry->send->iov[1].iov_len = MIN(data_size, tx_entry->iov[tx_iov_index].iov_len - tx_iov_offset);
-	pkt_entry->send->desc[1] = tx_entry->desc[tx_iov_index];
-	pkt_entry->send->iov_count = 2;
-	pkt_entry->pkt_size = hdr_size + pkt_entry->send->iov[1].iov_len;
+	assert(copied == data_size);
+	pkt_entry->send->iov_count = 0;
+	pkt_entry->pkt_size = hdr_size + copied;
 }
 
+static inline
 void rxr_pkt_init_rtm(struct rxr_ep *ep,
 		      struct rxr_tx_entry *tx_entry,
 		      int pkt_type, uint64_t data_offset,
@@ -370,7 +377,7 @@ void rxr_pkt_init_rtm(struct rxr_ep *ep,
 
 	data_size = MIN(tx_entry->total_len - data_offset,
 			ep->mtu_size - rxr_pkt_req_hdr_size(pkt_entry));
-	rxr_pkt_data_from_tx(ep, pkt_entry, tx_entry, data_offset, data_size);
+	rxr_pkt_req_data_from_tx(ep, pkt_entry, tx_entry, data_offset, data_size);
 	pkt_entry->x_entry = tx_entry;
 }
 


### PR DESCRIPTION
rxr_pkt_data_from_tx set up a RTM packet's data using information
from tx_entry.

It can avoid memory copy by using application's memory descriptors
(stored in tx_entry->desc).

Currently, if application provided memory descriptors, and used
multiple iov, only the 1st iov was setup in pkt_entry, the rest
was ignored.

This patch addresses the issue by doing memory copy under such
circumstance.

It also rename the function to rxr_pkt_req_data_from_tx() to
avoid confusion.

Signed-off-by: Wei Zhang <wzam@amazon.com>