### PR TITLE
prov/rxm: enable dynamic rbuf by default

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1501,7 +1501,7 @@ static void rxm_get_recv_entry(struct rxm_rx_buf *rx_buf,
 	}
 
 	match_attr.ignore = 0;
-	if (cq_entry->flags & FI_TAGGED) {
+	if (rx_buf->pkt.hdr.op == ofi_op_tagged) {
 		match_attr.tag = cq_entry->tag;
 		recv_queue = &rx_buf->ep->trecv_queue;
 	} else {

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -485,7 +485,7 @@ struct ofi_ops_dynamic_rbuf rxm_dynamic_rbuf = {
 static void rxm_config_dyn_rbuf(struct rxm_domain *domain, struct fi_info *info,
 				struct fi_info *msg_info)
 {
-	int ret = 0;
+	int ret = 1;
 
 	/* Collective support requires rxm generated and consumed messages.
 	 * Although we could update the code to handle receiving collective

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -541,7 +541,7 @@ RXM_INI
 			"This allows direct placement of received messages "
 			"into application buffers, bypassing RxM bounce "
 			"buffers.  This feature targets using tcp sockets "
-			"for the message transport.  (default: false)");
+			"for the message transport.  (default: true)");
 
 	fi_param_define(&rxm_prov, "enable_direct_send", FI_PARAM_BOOL,
 			"Enable support to pass application buffers directly "


### PR DESCRIPTION
This set of changes fixes a a bug where the TCP receive side isn't able to determine if an incoming message was tagged and was, therefore, selecting the wrong receive queue to progress.