### PR TITLE
prov/tcp: Changes in preparation of zero copy support

### DIFF
--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -248,9 +248,12 @@ static inline size_t ofi_bsock_tosend(struct ofi_bsock *bsock)
 }
 
 ssize_t ofi_bsock_flush(struct ofi_bsock *bsock);
-ssize_t ofi_bsock_send(struct ofi_bsock *bsock, const void *buf, size_t len);
+/* For sends started asynchronously, the return value will be -EINPROGRESS,
+ * and len will be set to the number of bytes that were queued.
+ */
+ssize_t ofi_bsock_send(struct ofi_bsock *bsock, const void *buf, size_t *len);
 ssize_t ofi_bsock_sendv(struct ofi_bsock *bsock, const struct iovec *iov,
-			size_t cnt);
+			size_t cnt, size_t *len);
 ssize_t ofi_bsock_recv(struct ofi_bsock *bsock, void *buf, size_t len);
 ssize_t ofi_bsock_recvv(struct ofi_bsock *bsock, struct iovec *iov,
 			size_t cnt);

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -105,7 +105,7 @@ enum {
 /* base_hdr::op_data */
 enum {
 	/* backward compatible value */
-	TCPX_OP_MSG_RESP = 2, /* indicates response message */
+	TCPX_OP_ACK = 2, /* indicates ack message - should be a flag */
 };
 
 /* Flags */
@@ -234,7 +234,7 @@ struct tcpx_ep {
 	struct dlist_entry	ep_entry;
 	struct slist		rx_queue;
 	struct slist		tx_queue;
-	struct slist		tx_rsp_pend_queue;
+	struct slist		need_ack_queue;
 	struct slist		rma_read_queue;
 	int			rx_avail;
 	struct tcpx_rx_ctx	*srx_ctx;

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -234,6 +234,7 @@ struct tcpx_ep {
 	struct dlist_entry	ep_entry;
 	struct slist		rx_queue;
 	struct slist		tx_queue;
+	struct slist		priority_queue;
 	struct slist		need_ack_queue;
 	struct slist		rma_read_queue;
 	int			rx_avail;

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -65,8 +65,10 @@ void tcpx_cq_progress(struct util_cq *cq)
 		 * to progress can result in application hangs.
 		 */
 		if (ofi_bsock_readable(&ep->bsock) ||
-		    (ep->cur_rx.handler && !ep->cur_rx.entry))
+		    (ep->cur_rx.handler && !ep->cur_rx.entry)) {
+			assert(ep->state == TCPX_CONNECTED);
 			tcpx_progress_rx(ep);
+		}
 
 		(void) tcpx_update_epoll(ep);
 		fastlock_release(&ep->lock);

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -152,10 +152,11 @@ void tcpx_cq_report_success(struct util_cq *cq,
 	uint64_t flags, data, tag;
 	size_t len;
 
-	flags = xfer_entry->flags;
-	if (!(flags & FI_COMPLETION) || (flags & TCPX_INTERNAL_XFER))
+	if (!(xfer_entry->flags & FI_COMPLETION) ||
+	    (xfer_entry->flags & TCPX_INTERNAL_XFER))
 		return;
 
+	flags = xfer_entry->flags & ~TCPX_INTERNAL_MASK;
 	len = xfer_entry->hdr.base_hdr.size -
 	      xfer_entry->hdr.base_hdr.hdr_size;
 	tcpx_get_cq_info(xfer_entry, &flags, &data, &tag);
@@ -175,7 +176,7 @@ void tcpx_cq_report_error(struct util_cq *cq,
 	if (xfer_entry->flags & TCPX_INTERNAL_XFER)
 		return;
 
-	err_entry.flags = xfer_entry->flags;
+	err_entry.flags = xfer_entry->flags & ~TCPX_INTERNAL_MASK;
 	tcpx_get_cq_info(xfer_entry, &err_entry.flags, &err_entry.data,
 			 &err_entry.tag);
 

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -157,9 +157,15 @@ void tcpx_cq_report_success(struct util_cq *cq,
 		return;
 
 	flags = xfer_entry->flags & ~TCPX_INTERNAL_MASK;
-	len = xfer_entry->hdr.base_hdr.size -
-	      xfer_entry->hdr.base_hdr.hdr_size;
-	tcpx_get_cq_info(xfer_entry, &flags, &data, &tag);
+	if (flags & FI_RECV) {
+		len = xfer_entry->hdr.base_hdr.size -
+		      xfer_entry->hdr.base_hdr.hdr_size;
+		tcpx_get_cq_info(xfer_entry, &flags, &data, &tag);
+	} else {
+		len = 0;
+		data = 0;
+		tag = 0;
+	}
 
 	ofi_cq_write(cq, xfer_entry->context,
 		     flags, len, NULL, data, tag);
@@ -177,8 +183,13 @@ void tcpx_cq_report_error(struct util_cq *cq,
 		return;
 
 	err_entry.flags = xfer_entry->flags & ~TCPX_INTERNAL_MASK;
-	tcpx_get_cq_info(xfer_entry, &err_entry.flags, &err_entry.data,
-			 &err_entry.tag);
+	if (err_entry.flags & FI_RECV) {
+		tcpx_get_cq_info(xfer_entry, &err_entry.flags, &err_entry.data,
+				 &err_entry.tag);
+	} else {
+		err_entry.data = 0;
+		err_entry.tag = 0;
+	}
 
 	err_entry.op_context = xfer_entry->context;
 	err_entry.len = 0;

--- a/prov/tcp/src/tcpx_domain.c
+++ b/prov/tcp/src/tcpx_domain.c
@@ -92,9 +92,7 @@ static int tcpx_srx_ctx(struct fid_domain *domain, struct fi_rx_attr *attr,
 	if (ret)
 		goto err2;
 
-	if (attr)
-		srx_ctx->op_flags = attr->op_flags;
-
+	srx_ctx->op_flags = attr->op_flags;
 	*rx_ep = &srx_ctx->rx_fid;
 	return FI_SUCCESS;
 err2:

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -217,7 +217,7 @@ static void tcpx_ep_flush_all_queues(struct tcpx_ep *ep)
 
 	tcpx_ep_flush_queue(&ep->tx_queue, cq);
 	tcpx_ep_flush_queue(&ep->rma_read_queue, cq);
-	tcpx_ep_flush_queue(&ep->tx_rsp_pend_queue, cq);
+	tcpx_ep_flush_queue(&ep->need_ack_queue, cq);
 
 	cq = container_of(ep->util_ep.rx_cq, struct tcpx_cq, util_cq);
 	if (ep->cur_rx.entry) {
@@ -704,7 +704,7 @@ int tcpx_endpoint(struct fid_domain *domain, struct fi_info *info,
 	slist_init(&ep->rx_queue);
 	slist_init(&ep->tx_queue);
 	slist_init(&ep->rma_read_queue);
-	slist_init(&ep->tx_rsp_pend_queue);
+	slist_init(&ep->need_ack_queue);
 	if (info->ep_attr->rx_ctx_cnt != FI_SHARED_CONTEXT)
 		ep->rx_avail = info->rx_attr->size;
 

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -216,6 +216,7 @@ static void tcpx_ep_flush_all_queues(struct tcpx_ep *ep)
 	}
 
 	tcpx_ep_flush_queue(&ep->tx_queue, cq);
+	tcpx_ep_flush_queue(&ep->priority_queue, cq);
 	tcpx_ep_flush_queue(&ep->rma_read_queue, cq);
 	tcpx_ep_flush_queue(&ep->need_ack_queue, cq);
 
@@ -703,6 +704,7 @@ int tcpx_endpoint(struct fid_domain *domain, struct fi_info *info,
 
 	slist_init(&ep->rx_queue);
 	slist_init(&ep->tx_queue);
+	slist_init(&ep->priority_queue);
 	slist_init(&ep->rma_read_queue);
 	slist_init(&ep->need_ack_queue);
 	if (info->ep_attr->rx_ctx_cnt != FI_SHARED_CONTEXT)

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -101,7 +101,6 @@ void tcpx_progress_tx(struct tcpx_ep *ep)
 			return;
 
 		tx_entry = ep->cur_tx.entry;
-		ep->hdr_bswap(&tx_entry->hdr.base_hdr);
 		cq = container_of(ep->util_ep.tx_cq, struct tcpx_cq, util_cq);
 
 		if (ret) {

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -109,8 +109,7 @@ void tcpx_progress_tx(struct tcpx_ep *ep)
 			tcpx_cq_report_error(&cq->util_cq, tx_entry, -ret);
 			tcpx_free_xfer(cq, tx_entry);
 		} else {
-			if (tx_entry->hdr.base_hdr.flags &
-			    (TCPX_DELIVERY_COMPLETE | TCPX_COMMIT_COMPLETE)) {
+			if (tx_entry->flags & TCPX_NEED_ACK) {
 				slist_insert_tail(&tx_entry->entry,
 						  &ep->need_ack_queue);
 			} else {
@@ -240,7 +239,7 @@ retry:
 		goto retry;
 	}
 
-	if (rx_entry->hdr.base_hdr.flags & OFI_DELIVERY_COMPLETE) {
+	if (rx_entry->hdr.base_hdr.flags & TCPX_DELIVERY_COMPLETE) {
 		ret = tcpx_queue_ack(rx_entry);
 		if (ret)
 			goto err;

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -47,10 +47,12 @@ static int tcpx_send_msg(struct tcpx_ep *ep)
 {
 	struct tcpx_xfer_entry *tx_entry;
 	ssize_t ret;
+	size_t len;
 
 	assert(ep->cur_tx.entry);
 	tx_entry = ep->cur_tx.entry;
-	ret = ofi_bsock_sendv(&ep->bsock, tx_entry->iov, tx_entry->iov_cnt);
+	ret = ofi_bsock_sendv(&ep->bsock, tx_entry->iov, tx_entry->iov_cnt,
+			      &len);
 	if (ret < 0)
 		return ret;
 

--- a/prov/tcp/src/tcpx_rma.c
+++ b/prov/tcp/src/tcpx_rma.c
@@ -230,13 +230,7 @@ static ssize_t tcpx_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg
 
 	send_entry->flags = (tcpx_ep->util_ep.tx_op_flags & FI_COMPLETION) |
 			     flags | FI_RMA | FI_WRITE;
-
-	if (flags & (FI_TRANSMIT_COMPLETE | FI_DELIVERY_COMPLETE))
-		send_entry->hdr.base_hdr.flags |= TCPX_DELIVERY_COMPLETE;
-
-	if (flags & FI_COMMIT_COMPLETE)
-		send_entry->hdr.base_hdr.flags |= TCPX_COMMIT_COMPLETE;
-
+	tcpx_set_commit_flags(send_entry, flags);
 	send_entry->context = msg->context;
 
 	fastlock_acquire(&tcpx_ep->lock);


### PR DESCRIPTION
A couple of patches are cleanups which can be pulled out and applied separately.  The rest of the series is an attempt to add support for MSG_ZEROCOPY on larger transfers.  The changes have been tested locally, which forces zerocopy off, so while I believe the general implementation is there, it needs testing where zero copy is supported, plus broad testing on multiple platforms to verify that portability wasn't broken.  And we should probably see if it makes any difference in performance.

More work is needed to make the settings configurable, including forcing zero copy off.  Plus documentation is lacking, which aligns the feature nicely with the zerocopy documentation.