### PR TITLE
prov/tcp: WIP patch for io_uring support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -522,6 +522,37 @@ AC_DEFINE_UNQUOTED(HAVE_CLOCK_GETTIME, [$have_clock_gettime],
        [Define to 1 if clock_gettime is available.])
 AM_CONDITIONAL(HAVE_CLOCK_GETTIME, [test $have_clock_gettime -eq 1])
 
+dnl Check for io_uring runtime libraries (disabled by default)
+AC_ARG_WITH([uring],
+	    [AS_HELP_STRING([--with-uring[=DIR]],
+			    [Enable uring support @<:@default=no@:>@.
+			     Optional=<Path to where liburing is installed.>])],
+	    [], [with_uring="no"])
+
+have_liburing=0
+AS_IF([test x"$with_uring" != x"no"],
+	    [FI_CHECK_PACKAGE([uring],
+			      [liburing.h],
+			      [uring],
+			      [io_uring_queue_init],
+			      [-luring],
+			      [$with_uring],
+			      [],
+			      [have_liburing=1
+			       AC_DEFINE_UNQUOTED([HAVE_LIBURING], [1], [io_uring support])]
+			      [],
+			      [])],
+	    [])
+
+AS_IF([test x"$with_uring" != x"no" && test -n "$with_uring" && test $have_liburing -eq 0],
+	[AC_MSG_ERROR([io_uring support requested but io_uring library not available.])],
+	[])
+
+AS_IF([test x"$with_uring" != x"yes" && test x"$with_uring" != x"no"],
+	[CPPFLAGS="$CPPFLAGS $uring_CPPFLAGS"
+	 LDFLAGS="$LDFLAGS $uring_LDFLAGS"])
+LIBS="$LIBS $uring_LIBS"
+
 dnl Check for CUDA runtime libraries
 AC_ARG_WITH([cuda],
 	[AS_HELP_STRING([--with-cuda=DIR],

--- a/prov/net/Makefile.include
+++ b/prov/net/Makefile.include
@@ -21,12 +21,12 @@ _xnet_files = \
 if HAVE_NET_DL
 pkglib_LTLIBRARIES += libnet-fi.la
 libnet_fi_la_SOURCES = $(_xnet_files) $(common_srcs)
-libnet_fi_la_LIBADD = $(linkback) $(xnet_shm_LIBS)
+libnet_fi_la_LIBADD = $(linkback) $(xnet_shm_LIBS) $(uring_LIBS)
 libnet_fi_la_LDFLAGS = -module -avoid-version -shared -export-dynamic
 libnet_fi_la_DEPENDENCIES = $(linkback)
 else !HAVE_NET_DL
 src_libfabric_la_SOURCES += $(_xnet_files)
-src_libfabric_la_LIBADD += $(xnet_shm_LIBS)
+src_libfabric_la_LIBADD += $(xnet_shm_LIBS) $(uring_LIBS)
 endif !HAVE_NET_DL
 
 prov_install_man_pages += man/man7/fi_net.7

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -85,6 +85,7 @@ extern size_t xnet_default_tx_size;
 extern size_t xnet_default_rx_size;
 extern size_t xnet_zerocopy_size;
 extern int xnet_disable_autoprog;
+extern int xnet_uring;
 
 struct xnet_xfer_entry;
 struct xnet_ep;

--- a/prov/net/src/xnet_init.c
+++ b/prov/net/src/xnet_init.c
@@ -64,6 +64,7 @@ size_t xnet_default_tx_size = 256;
 size_t xnet_default_rx_size = 256;
 size_t xnet_zerocopy_size = SIZE_MAX;
 int xnet_disable_autoprog;
+int xnet_uring;
 
 
 static void xnet_init_env(void)
@@ -137,6 +138,10 @@ static void xnet_init_env(void)
 			"prevent auto-progress thread from starting");
 	fi_param_get_bool(&xnet_prov, "disable_auto_progress",
 			&xnet_disable_autoprog);
+	fi_param_define(&xnet_prov, "uring", FI_PARAM_INT,
+			"Enable uring support, set to 1 to enable");
+	fi_param_get_int(&xnet_prov, "uring",
+			 &xnet_uring);
 }
 
 static void xnet_fini(void)


### PR DESCRIPTION
 prov/tcp: Initial support of io_uring for the TCP provider

This patch implements the support of io_uring in the tcp provider.
The patch is rather small and it doesn't impact much the core of
the TCP provider, which should limit the regressions. In addition,
the patch allows for turning on/off io_uring support at runtime
with the environment variable FI_TCP_URING.

The availability of io_uring is automatically detected by the
configure script. By default io_uring is disabled even if libfabric was
compiled with its support. To enable io_uring at runtime, one needs
to export FI_TCP_URING=1

In order to avoid costly locking mechanisms, each endpoint has its own
io_uring and 4 associated contexts: 2 for TX/RX operations and 2
additional for canceled TX/RS operations.

Each context keeps a variable that reflects the state of the context:
- IDLE: the context is idle and can be used to submit an async operation
- BUSY: the context has a pending async operation waiting for completion.
        In this state, the context doesn't accept new operations and the
        caller must poll the EP ring to progress the corresponding IO operation.
- DONE: the async operation associated to the context has completed and
        it'ss waiting for processing.

Socket operations with io_uring happen as follows:
- If the context is IDLE, a new SQE entry is filled in and submitted to the
  EP ring. The context is flagged as BUSY and the operation returns EAGAIN
  to the caller so it can later retry the operation to check for completion.
- The CQ progress function polls the EP ring and mark completed contexts
  as 'DONE' and store the result of the operation (error or number of bytes
  read/written) is stored in the context.
- When the socket operation is retried and if the context is 'DONE', the
  result of the operation is given to the caller, which can proceed.

The TCP provider uses an epoll set of file descriptors to progress
the endpoints associated to a given completion queue. In addition to
the socket FD, we register both TX and RX ring FDs for POLLIN events in
the epoll set so we get notified when a CQE is available.

Finally, the patch modifies tcpx_update_epoll() so we don't always
wait for the socket events if a SQE event is waiting for completion,
which would wake up epoll when it would complete.