### PR TITLE
prov/sockets: fix mis-calculation of total_len

### DIFF
--- a/prov/sockets/src/sock_atomic.c
+++ b/prov/sockets/src/sock_atomic.c
@@ -133,7 +133,7 @@ ssize_t sock_ep_tx_atomic(struct fid_ep *ep,
 
 		total_len = src_len + cmp_len;
 	} else {
-		total_len = msg->iov_count * sizeof(union sock_iov);
+		total_len = (msg->iov_count + compare_count) * sizeof(union sock_iov);
 	}
 
 	total_len += (sizeof(struct sock_op_send) +


### PR DESCRIPTION
In `sock_ep_tx_atomic`, the calculation of `total_len` missed `compare_count` in
one of its branches, resulting in overflowing the ring buffer.

Fixes #6587