### PR TITLE
fabtests: back port "Add -K Flag For Benchmark Tests" to v1.11.x branch

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -950,6 +950,9 @@ int ft_server_connect(void)
 	if (ret)
 		goto err;
 
+	if (ft_check_opts(FT_OPT_FORK_CHILD))
+		ft_fork_child();
+
 	return 0;
 
 err:
@@ -1008,6 +1011,9 @@ int ft_client_connect(void)
 	if (ret)
 		return ret;
 
+	if (ft_check_opts(FT_OPT_FORK_CHILD))
+		ft_fork_child();
+
 	return 0;
 }
 
@@ -1042,6 +1048,9 @@ int ft_init_fabric(void)
 	ret = ft_init_av();
 	if (ret)
 		return ret;
+
+	if (ft_check_opts(FT_OPT_FORK_CHILD))
+		ft_fork_child();
 
 	return 0;
 }
@@ -2591,6 +2600,21 @@ int ft_fork_and_pair(void)
 	return 0;
 }
 
+int ft_fork_child(void)
+{
+	ft_child_pid = fork();
+	if (ft_child_pid < 0) {
+		FT_PRINTERR("fork", ft_child_pid);
+		return -errno;
+	}
+
+	if (ft_child_pid == 0) {
+		exit(0);
+	}
+
+	return 0;
+}
+
 int ft_wait_child(void)
 {
 	int ret;
@@ -2802,6 +2826,7 @@ void ft_usage(char *name, char *desc)
 	FT_PRINT_OPTS_USAGE("", "fi_inj_complete");
 	FT_PRINT_OPTS_USAGE("", "fi_bw");
 	FT_PRINT_OPTS_USAGE("-M <mode>", "Disable mode bit from test");
+	FT_PRINT_OPTS_USAGE("-K", "fork a child process after initializing endpoint");
 	FT_PRINT_OPTS_USAGE("", "mr_local");
 	FT_PRINT_OPTS_USAGE("-a <address vector name>", "name of address vector");
 	FT_PRINT_OPTS_USAGE("-h", "display this help output");
@@ -2907,6 +2932,9 @@ void ft_parseinfo(int op, char *optarg, struct fi_info *hints,
 		break;
 	case 'H':
 		opts->options |= FT_OPT_ENABLE_HMEM;
+		break;
+	case 'K':
+		opts->options |= FT_OPT_FORK_CHILD;
 		break;
 	default:
 		/* let getopt handle unknown opts*/

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -113,6 +113,7 @@ enum {
 	FT_OPT_SERVER_PERSIST	= 1 << 16,
 	FT_OPT_ENABLE_HMEM	= 1 << 17,
 	FT_OPT_USE_DEVICE	= 1 << 18,
+	FT_OPT_FORK_CHILD	= 1 << 19,
 	FT_OPT_OOB_CTRL		= FT_OPT_OOB_SYNC | FT_OPT_OOB_ADDR_EXCH,
 };
 
@@ -243,7 +244,7 @@ extern int ft_socket_pair[2];
 extern int sock;
 extern int listen_sock;
 #define ADDR_OPTS "B:P:s:a:b::E::C:F:"
-#define FAB_OPTS "f:d:p:D:i:H"
+#define FAB_OPTS "f:d:p:D:i:H:K"
 #define INFO_OPTS FAB_OPTS "e:M:"
 #define CS_OPTS ADDR_OPTS "I:S:mc:t:w:l"
 #define NO_CQ_DATA 0
@@ -430,6 +431,7 @@ static inline bool ft_check_prefix_forced(struct fi_info *info,
 int ft_sync(void);
 int ft_sync_pair(int status);
 int ft_fork_and_pair(void);
+int ft_fork_child(void);
 int ft_wait_child(void);
 int ft_finalize(void);
 int ft_finalize_ep(struct fid_ep *ep);

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -244,7 +244,7 @@ extern int ft_socket_pair[2];
 extern int sock;
 extern int listen_sock;
 #define ADDR_OPTS "B:P:s:a:b::E::C:F:"
-#define FAB_OPTS "f:d:p:D:i:H:K"
+#define FAB_OPTS "f:d:p:D:i:HK"
 #define INFO_OPTS FAB_OPTS "e:M:"
 #define CS_OPTS ADDR_OPTS "I:S:mc:t:w:l"
 #define NO_CQ_DATA 0

--- a/fabtests/man/fabtests.7.md
+++ b/fabtests/man/fabtests.7.md
@@ -389,6 +389,9 @@ the list available for that test.
 *-F <address_format>
 : Specifies the address format.
 
+*-K
+: Fork a child process after initializing endpoint.
+
 *-b[=oob_port]*
 : Enables out-of-band (via sockets) address exchange and test
   synchronization.  A port for the out-of-band connection may be specified


### PR DESCRIPTION
This PR back-ports https://github.com/ofiwg/libfabric/pull/6694 to v1.11.x branch. This PR had a bug that makes the `-H` argument require an argument. This bug was fixed by https://github.com/ofiwg/libfabric/pull/6751 so back port this PR as well.