### PR TITLE
prov/rxm: Fix retrieving tag from dyn rbuf

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1502,7 +1502,7 @@ static void rxm_get_recv_entry(struct rxm_rx_buf *rx_buf,
 
 	match_attr.ignore = 0;
 	if (rx_buf->pkt.hdr.op == ofi_op_tagged) {
-		match_attr.tag = cq_entry->tag;
+		match_attr.tag = rx_buf->pkt.hdr.tag;
 		recv_queue = &rx_buf->ep->trecv_queue;
 	} else {
 		match_attr.tag = 0;


### PR DESCRIPTION
The cq entry only contains a valid tag when using the
tcp tagged APIs.  In other cases, the tag is carried
in the rxm header.  Always read from the header, since
we create a fake hdr in the tagged API case.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>