### PR TITLE
[v1.12.x] prov/efa: backport 2 fixes

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -595,6 +595,12 @@ struct rxr_ep {
 	struct ofi_bufpool *rx_pkt_efa_pool;
 
 	/*
+	 * buffer pool for rxr_pkt_sendv struct, which is used
+	 * to store iovec related information
+	 */
+	struct ofi_bufpool *pkt_sendv_pool;
+
+	/*
 	 * buffer pool for send & recv for shm as mtu size is different from
 	 * the one of efa, and do not require local memory registration
 	 */

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -764,6 +764,9 @@ static void rxr_ep_free_res(struct rxr_ep *rxr_ep)
 	if (rxr_ep->tx_pkt_efa_pool)
 		ofi_bufpool_destroy(rxr_ep->tx_pkt_efa_pool);
 
+	if (rxr_ep->pkt_sendv_pool)
+		ofi_bufpool_destroy(rxr_ep->pkt_sendv_pool);
+
 	if (rxr_ep->use_shm) {
 		if (rxr_ep->rx_pkt_shm_pool)
 			ofi_bufpool_destroy(rxr_ep->rx_pkt_shm_pool);
@@ -1342,6 +1345,14 @@ int rxr_ep_init(struct rxr_ep *ep)
 	if (ret)
 		goto err_free;
 
+	ret = ofi_bufpool_create(&ep->pkt_sendv_pool,
+				 sizeof(struct rxr_pkt_sendv),
+				 RXR_BUF_POOL_ALIGNMENT,
+				 rxr_get_tx_pool_chunk_cnt(ep),
+				 rxr_get_tx_pool_chunk_cnt(ep), 0);
+	if (ret)
+		goto err_free;
+
 	/* create pkt pool for shm */
 	if (ep->use_shm) {
 		ret = ofi_bufpool_create(&ep->tx_pkt_shm_pool,
@@ -1389,6 +1400,9 @@ int rxr_ep_init(struct rxr_ep *ep)
 err_free:
 	if (ep->tx_pkt_shm_pool)
 		ofi_bufpool_destroy(ep->tx_pkt_shm_pool);
+
+	if (ep->pkt_sendv_pool)
+		ofi_bufpool_destroy(ep->pkt_sendv_pool);
 
 	if (ep->rx_atomrsp_pool)
 		ofi_bufpool_destroy(ep->rx_atomrsp_pool);

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1497,7 +1497,7 @@ static inline int rxr_ep_send_queued_pkts(struct rxr_ep *ep,
 			dlist_remove(&pkt_entry->entry);
 			continue;
 		}
-		ret = rxr_pkt_entry_send(ep, pkt_entry, pkt_entry->addr);
+		ret = rxr_pkt_entry_send(ep, pkt_entry, 0);
 		if (ret)
 			return ret;
 		dlist_remove(&pkt_entry->entry);

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -327,12 +327,8 @@ ssize_t rxr_pkt_post_ctrl_once(struct rxr_ep *rxr_ep, int entry_type, void *x_en
 
 	if (inject)
 		err = rxr_pkt_entry_inject(rxr_ep, pkt_entry, addr);
-	else if (pkt_entry->send->iov_count > 0)
-		err = rxr_pkt_entry_sendv(rxr_ep, pkt_entry, addr,
-					  pkt_entry->send->iov, pkt_entry->send->desc,
-					  pkt_entry->send->iov_count, 0);
 	else
-		err = rxr_pkt_entry_send(rxr_ep, pkt_entry, addr);
+		err = rxr_pkt_entry_send(rxr_ep, pkt_entry, 0);
 
 	pkt_entry->send = NULL;
 	if (OFI_UNLIKELY(err)) {

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -286,7 +286,6 @@ void rxr_pkt_handle_ctrl_sent(struct rxr_ep *rxr_ep, struct rxr_pkt_entry *pkt_e
 ssize_t rxr_pkt_post_ctrl_once(struct rxr_ep *rxr_ep, int entry_type, void *x_entry,
 			       int ctrl_type, bool inject)
 {
-	struct rxr_pkt_sendv send;
 	struct rxr_pkt_entry *pkt_entry;
 	struct rxr_tx_entry *tx_entry;
 	struct rxr_rx_entry *rx_entry;
@@ -313,8 +312,8 @@ ssize_t rxr_pkt_post_ctrl_once(struct rxr_ep *rxr_ep, int entry_type, void *x_en
 	if (!pkt_entry)
 		return -FI_EAGAIN;
 
-	send.iov_count = 0;
-	pkt_entry->send = &send;
+	pkt_entry->send = malloc(sizeof(struct rxr_pkt_sendv));
+	pkt_entry->send->iov_count = 0;
 
 	/*
 	 * rxr_pkt_init_ctrl will set pkt_entry->send if it want to use multi iov
@@ -330,7 +329,6 @@ ssize_t rxr_pkt_post_ctrl_once(struct rxr_ep *rxr_ep, int entry_type, void *x_en
 	else
 		err = rxr_pkt_entry_send(rxr_ep, pkt_entry, 0);
 
-	pkt_entry->send = NULL;
 	if (OFI_UNLIKELY(err)) {
 		rxr_pkt_entry_release_tx(rxr_ep, pkt_entry);
 		return err;

--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -346,51 +346,45 @@ ssize_t rxr_pkt_entry_sendmsg(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry
 	return ret;
 }
 
-ssize_t rxr_pkt_entry_sendv(struct rxr_ep *ep,
-			    struct rxr_pkt_entry *pkt_entry,
-			    fi_addr_t addr, const struct iovec *iov,
-			    void **desc, size_t count, uint64_t flags)
+/**
+ * @brief Construct a fi_msg object with the information stored in pkt_entry,
+ * and send it out
+ *
+ * @param[in] ep	rxr endpoint
+ * @param[in] pkt_entry	packet entry used to construct the fi_msg object
+ * @param[in] flags	flags to be applied to lower provider's send operation
+ * @return		0 on success
+ * 			On error, a negative value corresponding to fabric errno
+ *
+ */
+ssize_t rxr_pkt_entry_send(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry,
+			   uint64_t flags)
 {
+	struct iovec iov;
+	void *desc;
 	struct fi_msg msg;
 	struct rxr_peer *peer;
 
-	msg.msg_iov = iov;
-	msg.desc = desc;
-	msg.iov_count = count;
-	peer = rxr_ep_get_peer(ep, addr);
-	msg.addr = (peer->is_local) ? peer->shm_fiaddr : addr;
+	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
+
+	if (pkt_entry->send && pkt_entry->send->iov_count > 0) {
+		msg.msg_iov = pkt_entry->send->iov;
+		msg.iov_count = pkt_entry->send->iov_count;
+		msg.desc = pkt_entry->send->desc;
+	} else {
+		iov.iov_base = rxr_pkt_start(pkt_entry);
+		iov.iov_len = pkt_entry->pkt_size;
+		desc = peer->is_local ? NULL : fi_mr_desc(pkt_entry->mr);
+		msg.msg_iov = &iov;
+		msg.iov_count = 1;
+		msg.desc = &desc;
+	}
+
+	msg.addr = pkt_entry->addr;
 	msg.context = pkt_entry;
 	msg.data = 0;
 
 	return rxr_pkt_entry_sendmsg(ep, pkt_entry, &msg, flags);
-}
-
-/* rxr_pkt_start currently expects data pkt right after pkt hdr */
-ssize_t rxr_pkt_entry_send_with_flags(struct rxr_ep *ep,
-				      struct rxr_pkt_entry *pkt_entry,
-				      fi_addr_t addr, uint64_t flags)
-{
-	struct iovec iov;
-	void *desc;
-
-	iov.iov_base = rxr_pkt_start(pkt_entry);
-	iov.iov_len = pkt_entry->pkt_size;
-
-	if (rxr_ep_get_peer(ep, addr)->is_local) {
-		assert(ep->use_shm);
-		desc = NULL;
-	} else {
-		desc = fi_mr_desc(pkt_entry->mr);
-	}
-
-	return rxr_pkt_entry_sendv(ep, pkt_entry, addr, &iov, &desc, 1, flags);
-}
-
-ssize_t rxr_pkt_entry_send(struct rxr_ep *ep,
-			   struct rxr_pkt_entry *pkt_entry,
-			   fi_addr_t addr)
-{
-	return rxr_pkt_entry_send_with_flags(ep, pkt_entry, addr, 0);
 }
 
 ssize_t rxr_pkt_entry_inject(struct rxr_ep *ep,

--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -145,7 +145,7 @@ void rxr_pkt_entry_release_tx(struct rxr_ep *ep,
 #endif
 	pkt->state = RXR_PKT_ENTRY_FREE;
 	if (pkt->send) {
-		free(pkt->send);
+		ofi_buf_free(pkt->send);
 		pkt->send = NULL;
 	}
 	ofi_buf_free(pkt);

--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -144,6 +144,10 @@ void rxr_pkt_entry_release_tx(struct rxr_ep *ep,
 	rxr_poison_mem_region((uint32_t *)pkt, ep->tx_pkt_pool_entry_sz);
 #endif
 	pkt->state = RXR_PKT_ENTRY_FREE;
+	if (pkt->send) {
+		free(pkt->send);
+		pkt->send = NULL;
+	}
 	ofi_buf_free(pkt);
 }
 

--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -110,9 +110,14 @@ struct rxr_pkt_entry *rxr_pkt_entry_alloc(struct rxr_ep *ep,
 	return pkt_entry;
 }
 
-static
-void rxr_pkt_entry_release_single_tx(struct rxr_ep *ep,
-				     struct rxr_pkt_entry *pkt)
+/**
+ * @brief release a TX packet entry
+ *
+ * @param[in]     ep  the end point
+ * @param[in,out] pkt the pkt_entry to be released
+ */
+void rxr_pkt_entry_release_tx(struct rxr_ep *ep,
+			      struct rxr_pkt_entry *pkt)
 {
 	struct rxr_peer *peer;
 
@@ -140,18 +145,6 @@ void rxr_pkt_entry_release_single_tx(struct rxr_ep *ep,
 #endif
 	pkt->state = RXR_PKT_ENTRY_FREE;
 	ofi_buf_free(pkt);
-}
-
-void rxr_pkt_entry_release_tx(struct rxr_ep *ep,
-			      struct rxr_pkt_entry *pkt_entry)
-{
-	struct rxr_pkt_entry *next;
-
-	while (pkt_entry) {
-		next = pkt_entry->next;
-		rxr_pkt_entry_release_single_tx(ep, pkt_entry);
-		pkt_entry = next;
-	}
 }
 
 /*

--- a/prov/efa/src/rxr/rxr_pkt_entry.h
+++ b/prov/efa/src/rxr/rxr_pkt_entry.h
@@ -139,18 +139,8 @@ struct rxr_pkt_entry *rxr_pkt_entry_clone(struct rxr_ep *ep,
 struct rxr_pkt_entry *rxr_pkt_get_unexp(struct rxr_ep *ep,
 					struct rxr_pkt_entry **pkt_entry_ptr);
 
-ssize_t rxr_pkt_entry_send_with_flags(struct rxr_ep *ep,
-				      struct rxr_pkt_entry *pkt_entry,
-				      fi_addr_t addr, uint64_t flags);
-
-ssize_t rxr_pkt_entry_sendv(struct rxr_ep *ep,
-			    struct rxr_pkt_entry *pkt_entry,
-			    fi_addr_t addr, const struct iovec *iov,
-			    void **desc, size_t count, uint64_t flags);
-
 ssize_t rxr_pkt_entry_send(struct rxr_ep *ep,
-			   struct rxr_pkt_entry *pkt_entry,
-			   fi_addr_t addr);
+			   struct rxr_pkt_entry *pkt_entry, uint64_t flags);
 
 ssize_t rxr_pkt_entry_inject(struct rxr_ep *ep,
 			     struct rxr_pkt_entry *pkt_entry,

--- a/prov/efa/src/rxr/rxr_pkt_type_data.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_data.c
@@ -207,7 +207,13 @@ ssize_t rxr_pkt_send_data_desc(struct rxr_ep *ep,
 		i++;
 	}
 
-	pkt_entry->send = malloc(sizeof(struct rxr_pkt_sendv));
+	pkt_entry->send = ofi_buf_alloc(ep->pkt_sendv_pool);
+	if (!pkt_entry->send) {
+		FI_WARN(&rxr_prov, FI_LOG_EP_DATA,
+			"Unable to allocate rxr_pkt_sendv from pkt_sendv_pool\n");
+		return -FI_EAGAIN;
+	}
+
 	for (j = 0; j < i; j++) {
 		memcpy(&pkt_entry->send->iov[j], &iov[j], sizeof(struct iovec));
 		pkt_entry->send->desc[j] = desc[j];

--- a/prov/efa/src/rxr/rxr_pkt_type_data.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_data.c
@@ -76,8 +76,7 @@ ssize_t rxr_pkt_send_data(struct rxr_ep *ep,
 	pkt_entry->pkt_size = copied_size + sizeof(struct rxr_data_hdr);
 	pkt_entry->addr = tx_entry->addr;
 
-	return rxr_pkt_entry_send_with_flags(ep, pkt_entry, pkt_entry->addr,
-					     tx_entry->send_flags);
+	return rxr_pkt_entry_send(ep, pkt_entry, tx_entry->send_flags);
 }
 
 /*
@@ -214,9 +213,7 @@ ssize_t rxr_pkt_send_data_desc(struct rxr_ep *ep,
 	FI_DBG(&rxr_prov, FI_LOG_EP_DATA,
 	       "Sending an iov count, %zu with payload size: %lu.\n",
 	       i, payload_size);
-	ret = rxr_pkt_entry_sendv(ep, pkt_entry, tx_entry->addr,
-				  (const struct iovec *)iov,
-				  desc, i, tx_entry->send_flags);
+	ret = rxr_pkt_entry_send(ep, pkt_entry, tx_entry->send_flags);
 	if (OFI_UNLIKELY(ret)) {
 		/* Reset tx_entry iov pointer on send failure. */
 		tx_entry->iov_index = orig_iov_index;

--- a/prov/efa/src/rxr/rxr_pkt_type_data.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_data.c
@@ -147,6 +147,7 @@ ssize_t rxr_pkt_send_data_desc(struct rxr_ep *ep,
 	size_t i = 0;
 	size_t len = 0;
 
+	size_t j;
 	ssize_t ret;
 
 	orig_iov_index = tx_entry->iov_index;
@@ -205,6 +206,14 @@ ssize_t rxr_pkt_send_data_desc(struct rxr_ep *ep,
 		remaining_len -= len;
 		i++;
 	}
+
+	pkt_entry->send = malloc(sizeof(struct rxr_pkt_sendv));
+	for (j = 0; j < i; j++) {
+		memcpy(&pkt_entry->send->iov[j], &iov[j], sizeof(struct iovec));
+		pkt_entry->send->desc[j] = desc[j];
+	}
+	pkt_entry->send->iov_count = i;
+
 	data_pkt->hdr.seg_size = (uint16_t)payload_size;
 	pkt_entry->pkt_size = payload_size + RXR_DATA_HDR_SIZE;
 	pkt_entry->x_entry = tx_entry;

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -89,7 +89,7 @@ ssize_t rxr_pkt_post_handshake(struct rxr_ep *ep, struct rxr_peer *peer)
 
 	rxr_pkt_init_handshake(ep, pkt_entry, addr);
 
-	ret = rxr_pkt_entry_send(ep, pkt_entry, addr);
+	ret = rxr_pkt_entry_send(ep, pkt_entry, 0);
 	if (OFI_UNLIKELY(ret)) {
 		rxr_pkt_entry_release_tx(ep, pkt_entry);
 	}


### PR DESCRIPTION
1. fix a bug in rxr_pkt_entry_release_tx() which is missing in v1.12.x
2. fix RNR queuing 