### PR TITLE
[v1.9.x] util/mr_cache: add argument flush_lru to ofi_mr_cache_flush

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -284,7 +284,8 @@ void ofi_mr_cache_cleanup(struct ofi_mr_cache *cache);
 
 void ofi_mr_cache_notify(struct ofi_mr_cache *cache, const void *addr, size_t len);
 
-bool ofi_mr_cache_flush(struct ofi_mr_cache *cache);
+bool ofi_mr_cache_flush(struct ofi_mr_cache *cache, bool flush_lru);
+
 int ofi_mr_cache_search(struct ofi_mr_cache *cache, const struct fi_mr_attr *attr,
 			struct ofi_mr_entry **entry);
 /**

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -71,6 +71,8 @@ int efa_mr_cache_entry_reg(struct ofi_mr_cache *cache,
 	md->mr_fid.fid.fclass = FI_CLASS_MR;
 	md->mr_fid.fid.context = NULL;
 
+	ofi_mr_cache_flush(cache, false);
+
 	md->mr = efa_cmd_reg_mr(md->domain->pd, entry->info.iov.iov_base,
 				entry->info.iov.iov_len, fi_ibv_access);
 	if (!md->mr) {

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -150,7 +150,7 @@ void ofi_mr_cache_notify(struct ofi_mr_cache *cache, const void *addr, size_t le
 		util_mr_uncache_entry(cache, entry);
 }
 
-bool ofi_mr_cache_flush(struct ofi_mr_cache *cache)
+bool ofi_mr_cache_flush(struct ofi_mr_cache *cache, bool flush_lru)
 {
 	struct ofi_mr_entry *entry;
 
@@ -166,7 +166,7 @@ bool ofi_mr_cache_flush(struct ofi_mr_cache *cache)
 		pthread_mutex_lock(&cache->monitor->lock);
 	}
 
-	if (dlist_empty(&cache->lru_list)) {
+	if (!flush_lru || dlist_empty(&cache->lru_list)) {
 		pthread_mutex_unlock(&cache->monitor->lock);
 		return false;
 	}
@@ -303,7 +303,7 @@ int ofi_mr_cache_search(struct ofi_mr_cache *cache, const struct fi_mr_attr *att
 		if ((cache->cached_cnt >= cache_params.max_cnt) ||
 		    (cache->cached_size >= cache_params.max_size)) {
 			pthread_mutex_unlock(&cache->monitor->lock);
-			ofi_mr_cache_flush(cache);
+			ofi_mr_cache_flush(cache, true);
 			pthread_mutex_lock(&cache->monitor->lock);
 		}
 
@@ -323,7 +323,7 @@ int ofi_mr_cache_search(struct ofi_mr_cache *cache, const struct fi_mr_attr *att
 
 		ret = util_mr_cache_create(cache, &info, entry);
 		if (ret && ret != -FI_EAGAIN) {
-			if (ofi_mr_cache_flush(cache))
+			if (ofi_mr_cache_flush(cache, true))
 				ret = -FI_EAGAIN;
 		}
 	} while (ret == -FI_EAGAIN);
@@ -419,7 +419,7 @@ void ofi_mr_cache_cleanup(struct ofi_mr_cache *cache)
 		cache->search_cnt, cache->delete_cnt, cache->hit_cnt,
 		cache->notify_cnt);
 
-	while (ofi_mr_cache_flush(cache))
+	while (ofi_mr_cache_flush(cache, true))
 		;
 
 	pthread_mutex_destroy(&cache->lock);


### PR DESCRIPTION
This patch introduce an argument flush_lru to

    ofi_mr_cache_flush_unmapped().

Currently ofi_mr_cache_flush_unmapped() does two things:

it will clear the registration in mr_cache->flush_list.

it will remove the first registration in mr_cache->lru_list
if it is not empty.

mr_cache->flush_list contains registrations whose
corresponding memory region was not mapped any more, thus
is always good to clear.

mr_cache->lru_list contains registrations whose use_cnt is 0,
but memory region is still mapped, so they can be reused.

Sometimes, caller want to clear the flush list for some
applications, but do not want to touch lru list because it
might impact performance of other applications. This patch
will allow them to do that by calling ofi_mr_cache_flush()
with flush_lru set to false.

Signed-off-by: Wei Zhang <wzam@amazon.com>

(cherry picked from 4f4bbf891)