### PR TITLE
core: Maintain list of all providers

### DIFF
--- a/src/fabric.c
+++ b/src/fabric.c
@@ -69,7 +69,8 @@ extern struct ofi_common_locks common_locks;
 static struct fi_filter prov_filter;
 
 
-static struct ofi_prov *ofi_alloc_prov(const char *prov_name)
+static struct ofi_prov *
+ofi_alloc_prov(const char *prov_name)
 {
 	struct ofi_prov *prov;
 
@@ -84,6 +85,14 @@ static struct ofi_prov *ofi_alloc_prov(const char *prov_name)
 	}
 
 	return prov;
+}
+
+static void
+ofi_init_prov(struct ofi_prov *prov, struct fi_provider *provider,
+	      void *dlhandle)
+{
+	prov->provider = provider;
+	prov->dlhandle = dlhandle;
 }
 
 static void ofi_cleanup_prov(struct fi_provider *provider, void *dlhandle)
@@ -111,6 +120,30 @@ static void ofi_free_prov(struct ofi_prov *prov)
 
 static void ofi_insert_prov(struct ofi_prov *prov)
 {
+	struct ofi_prov *cur, *prev;
+
+	for (prev = NULL, cur = prov_head; cur; prev = cur, cur = cur->next) {
+		if ((strlen(prov->prov_name) == strlen(cur->prov_name)) &&
+		    !strcasecmp(prov->prov_name, cur->prov_name)) {
+			if (FI_VERSION_LT(cur->provider->version,
+					  prov->provider->version)) {
+				cur->hidden = true;
+				prov->next = cur;
+				if (prev)
+					prev->next = prov;
+				else
+					prov_head = prov;
+			} else {
+				prov->hidden = true;
+				prov->next = cur->next;
+				cur->next = prov;
+				if (prov_tail == cur)
+					prov_tail = prov;
+			}
+			return;
+		}
+	}
+
 	if (prov_tail)
 		prov_tail->next = prov;
 	else
@@ -360,7 +393,6 @@ struct fi_provider *ofi_get_hook(const char *name)
 	return provider;
 }
 
-
 /* This is the default order that providers will be reported when a provider
  * is available.  Initialize the socket(s) provider last.  This will result in
  * it being the least preferred provider.
@@ -467,45 +499,19 @@ static void ofi_register_provider(struct fi_provider *provider, void *dlhandle)
 		ctx->disable_layering = 1;
 
 	prov = ofi_getprov(provider->name, strlen(provider->name));
-	if (prov) {
-		/* If this provider has not been init yet, then we add the
-		 * provider and dlhandle to the struct and exit.
-		 */
-		if (prov->provider == NULL)
-			goto update_prov_registry;
-
-		/* If this provider is older than an already-loaded
-		 * provider of the same name, then discard this one.
-		 */
-		if (FI_VERSION_GE(prov->provider->version, provider->version)) {
-			FI_INFO(&core_prov, FI_LOG_CORE,
-				"a newer %s provider was already loaded; "
-				"ignoring this one\n", provider->name);
-			goto cleanup;
-		}
-
-		/* This provider is newer than an already-loaded
-		 * provider of the same name, so discard the
-		 * already-loaded one.
-		 */
-		FI_INFO(&core_prov, FI_LOG_CORE,
-			"an older %s provider was already loaded; "
-			"keeping this one and ignoring the older one\n",
-			provider->name);
-		ofi_cleanup_prov(prov->provider, prov->dlhandle);
+	if (prov && !prov->provider) {
+		ofi_init_prov(prov, provider, dlhandle);
 	} else {
 		prov = ofi_alloc_prov(provider->name);
 		if (!prov)
 			goto cleanup;
+
+		ofi_init_prov(prov, provider, dlhandle);
 		ofi_insert_prov(prov);
 	}
 
 	if (hidden)
 		prov->hidden = true;
-
-update_prov_registry:
-	prov->dlhandle = dlhandle;
-	prov->provider = provider;
 	return;
 
 cleanup:


### PR DESCRIPTION
If multiple versions of a provider are present, include it in the
list of available provider.  Do not discard the provider just
because it has a lower version number.  This allows loading
different versions of the same provider in case the application
requires a specific version (for testing or features).  To
maintain prior behavior of only exposing the latest version of a
provider, older versions are marked as hidden.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>

Not really tested, but first part of dealing with issue #6708.  Marking the provider as hidden probably isn't necessary, but avoids the off chance of an app searching based on provider name directly and ending up using the wrong one.