### PR TITLE
 prov/util: Flush MR Cache entries on the flush list in addition to other flushing criteria.

### DIFF
--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -315,8 +315,8 @@ int ofi_mr_cache_search(struct ofi_mr_cache *cache, const struct fi_mr_attr *att
 	do {
 		pthread_mutex_lock(&mm_lock);
 
-		if ((cache->cached_cnt >= cache_params.max_cnt) ||
-		    (cache->cached_size >= cache_params.max_size)) {
+		if (ofi_mr_cache_status_evaluate(cache) != 
+		    OFI_MR_CACHE_STATUS_NORMAL) {
 			pthread_mutex_unlock(&mm_lock);
 			ofi_mr_cache_flush(cache, true);
 			pthread_mutex_lock(&mm_lock);


### PR DESCRIPTION
prov/util: Improve MR Cache flush triggering

Applications which rapidly register and de-register memory create entries on
the flush list but the list is not serviced due to a deficit in the servicing
criteria.  This commit isolates the servicing criteria into a separate
function and adds an extensible mechanism for the incorporation of future
changes to the MR Cache flush functionality and concomitant flushing criteria.