### PR TITLE
fabtests/runfabtest.sh: skip ubertest if not config file found

### DIFF
--- a/fabtests/scripts/runfabtests.sh
+++ b/fabtests/scripts/runfabtests.sh
@@ -505,6 +505,10 @@ function set_cfg_file {
 	local parent=$UTIL
 	local name=$CORE
 
+	if [[ ! -z "$COMPLEX_CFG" ]]; then
+		return
+	fi
+
 	if [ -z $UTIL ]; then
 		parent=$CORE
 		name=$1
@@ -532,9 +536,9 @@ function complex_test {
 	local end_time
 	local test_time
 
-	is_excluded "$test" && return
+	set_cfg_file $config
 	if [[ -z "$COMPLEX_CFG" ]]; then
-		set_cfg_file $config
+		is_excluded "$test" && return
 	fi
 
 	start_time=$(date '+%s')


### PR DESCRIPTION
If -u is not provided, runfabtests will attempt to find a suitable config
file. If it is not able to find a config file, runfabtests will still run
by passing -u {NULL} into the test causing a hang. Check for a null config
file and return after setting the config file.

Signed-off-by: aingerson <alexia.ingerson@intel.com>