### PR TITLE
Fixes from PR #6778 

### DIFF
--- a/include/ofi_lock.h
+++ b/include/ofi_lock.h
@@ -146,7 +146,7 @@ static inline int fastlock_held(fastlock_t *lock)
 #  define fastlock_acquire(lock) fastlock_acquire_(lock)
 #  define fastlock_tryacquire(lock) fastlock_tryacquire_(lock)
 #  define fastlock_release(lock) fastlock_release_(lock)
-#  define fastlock_held(lock)
+#  define fastlock_held(lock) true
 
 #endif
 

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -335,6 +335,12 @@ static inline void ofi_ep_lock_release(struct util_ep *ep)
 	ep->lock_release(&ep->lock);
 }
 
+static inline bool ofi_ep_lock_held(struct util_ep *ep)
+{
+	return (ep->lock_acquire == ofi_fastlock_acquire_noop) ||
+		fastlock_held(&ep->lock);
+}
+
 static inline void ofi_ep_tx_cntr_inc(struct util_ep *ep)
 {
 	ep->tx_cntr_inc(ep->tx_cntr);

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -707,8 +707,6 @@ struct rxm_conn {
 	struct dlist_entry deferred_tx_queue;
 	struct dlist_entry sar_rx_msg_list;
 	struct dlist_entry sar_deferred_rx_msg_list;
-
-	uint32_t rndv_tx_credits;
 };
 
 extern struct fi_provider rxm_prov;

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -436,14 +436,11 @@ void rxm_cmap_process_connect(struct rxm_cmap *cmap,
 			      struct rxm_cmap_handle *handle,
 			      union rxm_cm_data *cm_data)
 {
-	struct rxm_conn *rxm_conn = container_of(handle, struct rxm_conn, handle);
-
 	FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL,
 	       "processing FI_CONNECTED event for handle: %p\n", handle);
 	if (cm_data) {
 		assert(handle->state == RXM_CMAP_CONNREQ_SENT);
 		handle->remote_key = cm_data->accept.server_conn_id;
-		rxm_conn->rndv_tx_credits = cm_data->accept.rx_size;
 	} else {
 		assert(handle->state == RXM_CMAP_CONNREQ_RECV);
 	}
@@ -1029,8 +1026,6 @@ rxm_msg_process_connreq(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
 	rxm_conn = container_of(handle, struct rxm_conn, handle);
 
 	rxm_conn->handle.remote_key = remote_cm_data->connect.client_conn_id;
-	rxm_conn->rndv_tx_credits = remote_cm_data->connect.rx_size;
-	assert(rxm_conn->rndv_tx_credits);
 
 	ret = rxm_msg_ep_open(rxm_ep, msg_info, rxm_conn, handle);
 	if (ret)

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -395,6 +395,7 @@ static int rxm_getinfo(uint32_t version, const char *node, const char *service,
 			port_save = ofi_addr_get_port(ai->ai_addr);
 			freeaddrinfo(ai);
 			service = NULL;
+			flags &= ~FI_SOURCE;
 		} else {
 			port_save = ofi_addr_get_port(hints->src_addr);
 			ofi_addr_set_port(hints->src_addr, 0);

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -398,7 +398,7 @@ int ofi_check_fabric_attr(const struct fi_provider *prov,
 	 * user's hints, if one is specified.
 	 */
 	if (prov_attr->prov_name && user_attr->prov_name &&
-	    !strcasestr(user_attr->prov_name, prov_attr->prov_name)) {
+	    strcasestr(user_attr->prov_name, prov_attr->prov_name)) {
 		FI_INFO(prov, FI_LOG_CORE,
 			"Requesting provider %s, skipping %s\n",
 			prov_attr->prov_name, user_attr->prov_name);

--- a/prov/util/src/util_buf.c
+++ b/prov/util/src/util_buf.c
@@ -170,7 +170,9 @@ int ofi_bufpool_create_attr(struct ofi_bufpool_attr *attr,
 
 	entry_sz = (attr->size + sizeof(struct ofi_bufpool_hdr));
 	OFI_DBG_ADD(entry_sz, sizeof(struct ofi_bufpool_ftr));
-	pool->entry_size = ofi_get_aligned_size(entry_sz, attr->alignment);
+	if (!attr->alignment)
+		pool->attr.alignment = entry_sz;
+	pool->entry_size = ofi_get_aligned_size(entry_sz, pool->attr.alignment);
 
 	if (!attr->chunk_cnt) {
 		pool->attr.chunk_cnt =


### PR DESCRIPTION
Pulling current set of fixes out of the rxm CM rework patch in order to merge them quicker.

- core/bufpool -- handle an alignment request of 0
- prov/rxm - remove unused field
- util/ep - add ofi_ep_lock_held macro
- core/getinfo - fix incorrect negation of strcasestr (how did rxm ever work?)
- prov/rxm - fix calling fi_getinfo incorrectly