### PR TITLE
prov/shm, prov/util, hmem_ze: hmem, ZE optimizations and fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -556,8 +556,9 @@ AS_IF([test x"$with_ze" != x"no"],
        LIBS="$LIBS $ze_LIBS"],
       [])
 
+have_drm=0
 AS_IF([test "$have_ze" = "1"],
-      [AC_CHECK_HEADER(drm/i915_drm.h, [], [have_ze=0])]
+      [AC_CHECK_HEADER(drm/i915_drm.h, [have_drm=1], [])]
       [])
 
 AS_IF([test x"$with_ze" != x"no" && test -n "$with_ze" && test "$have_ze" = "0" ],
@@ -565,6 +566,7 @@ AS_IF([test x"$with_ze" != x"no" && test -n "$with_ze" && test "$have_ze" = "0" 
 	[])
 
 AC_DEFINE_UNQUOTED([HAVE_LIBZE], [$have_ze], [ZE support])
+AC_DEFINE_UNQUOTED([HAVE_DRM], [$have_drm], [i915 DRM header])
 
 enable_memhooks=1
 AC_ARG_ENABLE([memhooks-monitor],

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -182,6 +182,12 @@ static inline enum fi_hmem_iface smr_get_mr_hmem_iface(struct util_domain *domai
 	return ((struct ofi_mr *) *desc)->iface;
 }
 
+static inline uint64_t smr_get_mr_flags(void **desc)
+{
+	assert(desc && *desc);
+	return ((struct ofi_mr *) *desc)->flags;
+}
+
 struct smr_unexp_msg {
 	struct dlist_entry entry;
 	struct smr_cmd cmd;

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -213,7 +213,9 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 			smr_format_iov(cmd, iov, iov_count, total_len, ep->region,
 				       resp);
 		} else {
-			if (iface == FI_HMEM_ZE && iov_count == 1 &&
+			if (iface == FI_HMEM_ZE &&
+			    (smr_get_mr_flags(desc) & FI_HMEM_DEVICE_ONLY) &&
+			    iov_count == 1 &&
 			    smr_ze_ipc_enabled(ep->region, peer_smr)) {
 				ret = smr_format_ze_ipc(ep, id, cmd, iov,
 					device, total_len, ep->region,

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -181,7 +181,9 @@ ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 			smr_format_iov(cmd, iov, iov_count, total_len, ep->region,
 				       resp);
 		} else {
-			if (iface == FI_HMEM_ZE && iov_count == 1 &&
+			if (iface == FI_HMEM_ZE &&
+			    (smr_get_mr_flags(desc) & FI_HMEM_DEVICE_ONLY) &&
+			    iov_count == 1 &&
 			    smr_ze_ipc_enabled(ep->region, peer_smr)) {
 				ret = smr_format_ze_ipc(ep, id, cmd, iov,
 					device, total_len, ep->region,

--- a/prov/util/src/util_mr_map.c
+++ b/prov/util/src/util_mr_map.c
@@ -266,6 +266,13 @@ int ofi_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 
 	ofi_mr_update_attr(domain->fabric->fabric_fid.api_version,
 			   domain->info_domain_caps, attr, &cur_abi_attr);
+	if (!hmem_ops[cur_abi_attr.iface].initialized) {
+		FI_WARN(domain->mr_map.prov, FI_LOG_MR,
+			"MR registration failed - hmem iface not initialized\n");
+		free(mr);
+		return -FI_ENOSYS;
+	}
+
 	fastlock_acquire(&domain->lock);
 
 	mr->mr_fid.fid.fclass = FI_CLASS_MR;

--- a/src/hmem_ze.c
+++ b/src/hmem_ze.c
@@ -40,8 +40,6 @@
 #if HAVE_LIBZE
 
 #include <dirent.h>
-#include <drm/i915_drm.h>
-#include <sys/ioctl.h>
 #include <level_zero/ze_api.h>
 
 static ze_context_handle_t context;
@@ -67,6 +65,10 @@ static const ze_command_list_desc_t cl_desc = {
 	.commandQueueGroupOrdinal	= 0,
 	.flags				= 0,
 };
+
+#if HAVE_DRM
+#include <drm/i915_drm.h>
+#include <sys/ioctl.h>
 
 static int ze_hmem_init_fds(void)
 {
@@ -102,6 +104,83 @@ static int ze_hmem_init_fds(void)
 	}
 	return FI_SUCCESS;
 }
+
+int ze_hmem_get_shared_handle(int dev_fd, void *dev_buf, int *ze_fd,
+			      void **handle)
+{
+	struct drm_prime_handle open_fd = {0, 0, 0};
+	ze_ipc_mem_handle_t ze_handle;
+	int ret;
+
+	ret = ze_hmem_get_handle(dev_buf, (void **) &ze_handle);
+	if (ret)
+		return ret;
+
+	memcpy(ze_fd, &ze_handle, sizeof(*ze_fd));
+	memcpy(&open_fd.fd, &ze_handle, sizeof(open_fd.fd));
+	ret = ioctl(dev_fd, DRM_IOCTL_PRIME_FD_TO_HANDLE, &open_fd);
+	if (ret) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"ioctl call failed on get, err %d\n", errno);
+		return -FI_EINVAL;
+	}
+
+	*(int *) handle = open_fd.handle;
+	return FI_SUCCESS;
+}
+
+int ze_hmem_open_shared_handle(int dev_fd, void **handle, int *ze_fd,
+			       uint64_t device, void **ipc_ptr)
+{
+	struct drm_prime_handle open_fd = {0, 0, 0};
+	ze_ipc_mem_handle_t ze_handle;
+	int ret;
+
+	open_fd.flags = DRM_CLOEXEC | DRM_RDWR;
+	open_fd.handle = *(int *) handle;
+
+	ret = ioctl(dev_fd, DRM_IOCTL_PRIME_HANDLE_TO_FD, &open_fd);
+	if (ret) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"ioctl call failed on open, err %d\n", errno);
+		return -FI_EINVAL;
+	}
+
+	*ze_fd = open_fd.fd;
+	memset(&ze_handle, 0, sizeof(ze_handle));
+	memcpy(&ze_handle, &open_fd.fd, sizeof(open_fd.fd));
+	return ze_hmem_open_handle((void **) &ze_handle, device, ipc_ptr);
+}
+
+bool ze_hmem_p2p_enabled(void)
+{
+	return p2p_enabled;
+}
+
+#else
+
+static int ze_hmem_init_fds(void)
+{
+	return FI_SUCCESS;
+}
+
+int ze_hmem_get_shared_handle(int dev_fd, void *dev_buf, int *ze_fd,
+			      void **handle)
+{
+	return -FI_ENOSYS;
+}
+int ze_hmem_open_shared_handle(int dev_fd, void **handle, int *ze_fd,
+			       uint64_t device, void **ipc_ptr)
+{
+	return -FI_ENOSYS;
+}
+
+bool ze_hmem_p2p_enabled(void)
+{
+	return false;
+}
+
+#endif //HAVE_DRM
 
 int ze_hmem_init(void)
 {
@@ -265,53 +344,6 @@ int ze_hmem_open_handle(void **handle, uint64_t device, void **ipc_ptr)
 	return FI_SUCCESS;
 }
 
-int ze_hmem_get_shared_handle(int dev_fd, void *dev_buf, int *ze_fd,
-			      void **handle)
-{
-	struct drm_prime_handle open_fd = {0, 0, 0};
-	ze_ipc_mem_handle_t ze_handle;
-	int ret;
-
-	ret = ze_hmem_get_handle(dev_buf, (void **) &ze_handle);
-	if (ret)
-		return ret;
-
-	memcpy(ze_fd, &ze_handle, sizeof(*ze_fd));
-	memcpy(&open_fd.fd, &ze_handle, sizeof(open_fd.fd));
-	ret = ioctl(dev_fd, DRM_IOCTL_PRIME_FD_TO_HANDLE, &open_fd);
-	if (ret) {
-		FI_WARN(&core_prov, FI_LOG_CORE,
-			"ioctl call failed on get, err %d\n", errno);
-		return -FI_EINVAL;
-	}
-
-	*(int *) handle = open_fd.handle;
-	return FI_SUCCESS;
-}
-
-int ze_hmem_open_shared_handle(int dev_fd, void **handle, int *ze_fd,
-			       uint64_t device, void **ipc_ptr)
-{
-	struct drm_prime_handle open_fd = {0, 0, 0};
-	ze_ipc_mem_handle_t ze_handle;
-	int ret;
-
-	open_fd.flags = DRM_CLOEXEC | DRM_RDWR;
-	open_fd.handle = *(int *) handle;
-
-	ret = ioctl(dev_fd, DRM_IOCTL_PRIME_HANDLE_TO_FD, &open_fd);
-	if (ret) {
-		FI_WARN(&core_prov, FI_LOG_CORE,
-			"ioctl call failed on open, err %d\n", errno);
-		return -FI_EINVAL;
-	}
-
-	*ze_fd = open_fd.fd;
-	memset(&ze_handle, 0, sizeof(ze_handle));
-	memcpy(&ze_handle, &open_fd.fd, sizeof(open_fd.fd));
-	return ze_hmem_open_handle((void **) &ze_handle, device, ipc_ptr);
-}
-
 int ze_hmem_close_handle(void *ipc_ptr)
 {
 	ze_result_t ze_ret;
@@ -324,11 +356,6 @@ int ze_hmem_close_handle(void *ipc_ptr)
 	}
 
 	return FI_SUCCESS;
-}
-
-bool ze_hmem_p2p_enabled(void)
-{
-	return p2p_enabled;
 }
 
 int ze_hmem_get_base_addr(const void *ptr, void **base)


### PR DESCRIPTION
Various HMEM related fixes and optimizations:
- Fail MR registration for uninitialized interfaces
- Separate ZE and DRM header dependencies since fallbacks are available
- Fix interface used for shm IPC protocol
- Add device only check in shm IPC protocol path