### PR TITLE
prov/tcp: Add support for MSG_ZEROCOPY

### DIFF
--- a/include/linux/osd.h
+++ b/include/linux/osd.h
@@ -43,10 +43,14 @@
 #include <assert.h>
 #include <unistd.h>
 #include <sys/syscall.h>
+#include <sys/types.h>
+#include <sys/socket.h>
 
+#include <linux/errqueue.h>
 #include <ifaddrs.h>
 #include "unix/osd.h"
 #include "rdma/fi_errno.h"
+
 
 static inline int ofi_shm_remap(struct util_shm *shm,
 				size_t newsize, void **mapped)

--- a/include/ofi_epoll.h
+++ b/include/ofi_epoll.h
@@ -107,6 +107,7 @@ void ofi_pollfds_do_del(struct ofi_pollfds *pfds,
 
 #define OFI_EPOLL_IN  EPOLLIN
 #define OFI_EPOLL_OUT EPOLLOUT
+#define OFI_EPOLL_ERR EPOLLERR
 
 typedef int ofi_epoll_t;
 #define OFI_EPOLL_INVALID -1
@@ -167,6 +168,7 @@ static inline void ofi_epoll_close(int ep)
 
 #define OFI_EPOLL_IN  POLLIN
 #define OFI_EPOLL_OUT POLLOUT
+#define OFI_EPOLL_ERR POLLERR
 
 typedef struct ofi_pollfds *ofi_epoll_t;
 #define OFI_EPOLL_INVALID NULL

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -78,6 +78,7 @@ extern int tcpx_staging_sbuf_size;
 extern int tcpx_prefetch_rbuf_size;
 extern size_t tcpx_default_tx_size;
 extern size_t tcpx_default_rx_size;
+extern size_t tcpx_zerocopy_size;
 
 struct tcpx_xfer_entry;
 struct tcpx_ep;

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -68,6 +68,9 @@ static void tcpx_set_zerocopy(SOCKET sock)
 {
 	int val = 1;
 
+	if (tcpx_zerocopy_size == SIZE_MAX)
+		return;
+
 	(void) setsockopt(sock, SOL_SOCKET, SO_ZEROCOPY, &val, sizeof(val));
 }
 
@@ -76,9 +79,12 @@ static void tcpx_config_bsock(struct ofi_bsock *bsock)
 	int ret, val = 0;
 	socklen_t len = sizeof(val);
 
+	if (tcpx_zerocopy_size == SIZE_MAX)
+		return;
+
 	ret = getsockopt(bsock->sock, SOL_SOCKET, SO_ZEROCOPY, &val, &len);
 	if (!ret && val) {
-		bsock->zerocopy_size = OFI_ZEROCOPY_SIZE;
+		bsock->zerocopy_size = tcpx_zerocopy_size;
 		FI_INFO(&tcpx_prov, FI_LOG_EP_CTRL,
 			"zero copy enabled for transfers > %zu\n",
 			bsock->zerocopy_size);

--- a/prov/tcp/src/tcpx_init.c
+++ b/prov/tcp/src/tcpx_init.c
@@ -58,6 +58,8 @@ int tcpx_staging_sbuf_size = 9000;
 int tcpx_prefetch_rbuf_size = 9000;
 size_t tcpx_default_tx_size = 256;
 size_t tcpx_default_rx_size = 256;
+size_t tcpx_zerocopy_size = SIZE_MAX;
+
 
 static void tcpx_init_env(void)
 {
@@ -92,10 +94,15 @@ static void tcpx_init_env(void)
 	fi_param_define(&tcpx_prov, "prefetch_rbuf_size", FI_PARAM_INT,
 			"size of buffer used to prefetch received data from "
 			"the kernel, set to 0 to disable");
+	fi_param_define(&tcpx_prov, "zerocopy_size", FI_PARAM_SIZE_T,
+			"lower threshold where zero copy transfers will be "
+			"used, if supported by the platform, set to -1 to "
+			"disable (default: %zu)", tcpx_zerocopy_size);
 	fi_param_get_int(&tcpx_prov, "staging_sbuf_size",
 			 &tcpx_staging_sbuf_size);
 	fi_param_get_int(&tcpx_prov, "prefetch_rbuf_size",
 			 &tcpx_prefetch_rbuf_size);
+	fi_param_get_size_t(&tcpx_prov, "zerocopy_size", &tcpx_zerocopy_size);
 
 	fi_param_get_int(&tcpx_prov, "port_high_range", &port_range.high);
 	fi_param_get_int(&tcpx_prov, "port_low_range", &port_range.low);


### PR DESCRIPTION
Disabled by default, but code is there for future reference.  Changes negatively impact performance, in some cases significantly.  I'd drop the changes completely, but zerocopy is supposed to provide a benefit, and it's worth trying to uncover why that isn't the case.  However, I won't be able to look into that for a while.