### PR TITLE
prov/util: Ensure dead regions are removed from MR Cache lists

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -297,7 +297,7 @@ struct ofi_mr_cache {
 
 	struct ofi_mr_storage		storage;
 	struct dlist_entry		lru_list;
-	struct dlist_entry		flush_list;
+	struct dlist_entry		dead_region_list;
 	pthread_mutex_t 		lock;
 
 	size_t				cached_cnt;
@@ -327,6 +327,7 @@ bool ofi_mr_cache_flush(struct ofi_mr_cache *cache, bool flush_lru);
 
 int ofi_mr_cache_search(struct ofi_mr_cache *cache, const struct fi_mr_attr *attr,
 			struct ofi_mr_entry **entry);
+
 /**
  * Given an attr (with an iov range), if the iov range is already registered,
  * return the corresponding ofi_mr_entry. Otherwise, return NULL.

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -131,7 +131,7 @@ static void util_mr_uncache_entry(struct ofi_mr_cache *cache,
 
 	if (entry->use_cnt == 0) {
 		dlist_remove(&entry->list_entry);
-		dlist_insert_tail(&entry->list_entry, &cache->flush_list);
+		dlist_insert_tail(&entry->list_entry, &cache->dead_region_list);
 	} else {
 		cache->uncached_cnt++;
 		cache->uncached_size += entry->info.iov.iov_len;
@@ -153,46 +153,46 @@ void ofi_mr_cache_notify(struct ofi_mr_cache *cache, const void *addr, size_t le
 		util_mr_uncache_entry(cache, entry);
 }
 
+/* Function to remove dead regions and prune MR Cache size.     */
+/* Returns true if dead region removal or pruning was required. */
+
 bool ofi_mr_cache_flush(struct ofi_mr_cache *cache, bool flush_lru)
 {
+	struct dlist_entry free_list;
 	struct ofi_mr_entry *entry;
+	bool entries_freed;
+
+	dlist_init(&free_list);
 
 	pthread_mutex_lock(&mm_lock);
-	while (!dlist_empty(&cache->flush_list)) {
-		dlist_pop_front(&cache->flush_list, struct ofi_mr_entry,
-				entry, list_entry);
-		FI_DBG(cache->domain->prov, FI_LOG_MR, "flush %p (len: %zu)\n",
-		       entry->info.iov.iov_base, entry->info.iov.iov_len);
-		pthread_mutex_unlock(&mm_lock);
 
-		util_mr_free_entry(cache, entry);
-		pthread_mutex_lock(&mm_lock);
-	}
+	dlist_splice_tail(&free_list, &cache->dead_region_list);
 
-	if (!flush_lru || dlist_empty(&cache->lru_list)) {
-		pthread_mutex_unlock(&mm_lock);
-		return false;
-	}
+	if (flush_lru) {
+		while (!dlist_empty(&cache->lru_list) &&
+		       ((cache->cached_cnt >= cache_params.max_cnt) ||
+			(cache->cached_size >= cache_params.max_size))) {	
+			dlist_pop_front(&cache->lru_list, struct ofi_mr_entry,
+					entry, list_entry);
+			dlist_init(&entry->list_entry);
+			util_mr_uncache_entry_storage(cache, entry);
+			dlist_insert_tail(&entry->list_entry, &free_list);
+		}
+	} 
 
-	do {
-		dlist_pop_front(&cache->lru_list, struct ofi_mr_entry,
-				entry, list_entry);
-		dlist_init(&entry->list_entry);
-		FI_DBG(cache->domain->prov, FI_LOG_MR, "flush %p (len: %zu)\n",
-		       entry->info.iov.iov_base, entry->info.iov.iov_len);
-
-		util_mr_uncache_entry_storage(cache, entry);
-		pthread_mutex_unlock(&mm_lock);
-
-		util_mr_free_entry(cache, entry);
-		pthread_mutex_lock(&mm_lock);
-
-	} while (!dlist_empty(&cache->lru_list) &&
-		 ((cache->cached_cnt >= cache_params.max_cnt) ||
-		  (cache->cached_size >= cache_params.max_size)));
 	pthread_mutex_unlock(&mm_lock);
 
-	return true;
+	entries_freed = !dlist_empty(&free_list);
+
+	while(!dlist_empty(&free_list)) {
+		dlist_pop_front(&free_list, struct ofi_mr_entry,
+				entry, list_entry);
+		FI_DBG(cache->domain->prov, FI_LOG_MR, "flush %p (len: %zu)\n",
+			entry->info.iov.iov_base, entry->info.iov.iov_len);	
+		util_mr_free_entry(cache, entry);
+	}
+
+	return entries_freed;
 }
 
 void ofi_mr_cache_delete(struct ofi_mr_cache *cache, struct ofi_mr_entry *entry)
@@ -316,7 +316,8 @@ int ofi_mr_cache_search(struct ofi_mr_cache *cache, const struct fi_mr_attr *att
 		pthread_mutex_lock(&mm_lock);
 
 		if ((cache->cached_cnt >= cache_params.max_cnt) ||
-		    (cache->cached_size >= cache_params.max_size)) {
+		    (cache->cached_size >= cache_params.max_size) ||
+		    (!dlist_empty(&cache->dead_region_list))) {
 			pthread_mutex_unlock(&mm_lock);
 			ofi_mr_cache_flush(cache, true);
 			pthread_mutex_lock(&mm_lock);
@@ -551,7 +552,7 @@ int ofi_mr_cache_init(struct util_domain *domain,
 
 	pthread_mutex_init(&cache->lock, NULL);
 	dlist_init(&cache->lru_list);
-	dlist_init(&cache->flush_list);
+	dlist_init(&cache->dead_region_list);
 	cache->cached_cnt = 0;
 	cache->cached_size = 0;
 	cache->uncached_cnt = 0;


### PR DESCRIPTION
When memory regions become unusable from munmap() or their
reference counts go to 0, the MR Cache places their tracking
data onto a list 'to be disposed of later'.  This commit ensures
that these entries are removed concurrent with other MR Cache
maintenance activities.

In order to make the intent more clear, I have renamed the flush_list to the dead_region_list.

The lack of disposal is a v1.11 bug.  It is my intent that this code find its way into the codebase starting
with this branch.