### PR TITLE
prov/rxm: Separate eager msg limit from receive buffer size

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -234,7 +234,7 @@ union rxm_cm_data {
 		uint8_t op_version;
 		uint16_t port;
 		uint8_t padding[2];
-		uint32_t eager_size;
+		uint32_t eager_limit;
 		uint32_t rx_size;
 		uint64_t client_conn_id;
 	} connect;

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -64,7 +64,6 @@
 #define RXM_OP_VERSION		3
 #define RXM_CTRL_VERSION	4
 
-extern size_t rxm_eager_limit;
 extern size_t rxm_buffer_size;
 extern size_t rxm_packet_size;
 
@@ -681,6 +680,8 @@ struct rxm_ep {
 	size_t			buffered_min;
 	size_t			buffered_limit;
 	size_t			inject_limit;
+
+	size_t			eager_limit;
 	size_t			sar_limit;
 	size_t			tx_credit;
 

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -474,6 +474,7 @@ struct rxm_rx_buf {
 	size_t rndv_rma_index;
 	struct fid_mr *mr[RXM_IOV_LIMIT];
 
+	/* Only differs from pkt.data for unexpected messages */
 	void *data;
 	/* Must stay at bottom */
 	struct rxm_pkt pkt;
@@ -903,6 +904,11 @@ int rxm_post_recv(struct rxm_rx_buf *rx_buf);
 static inline void
 rxm_rx_buf_free(struct rxm_rx_buf *rx_buf)
 {
+	if (rx_buf->data != rx_buf->pkt.data) {
+		free(rx_buf->data);
+		rx_buf->data = &rx_buf->pkt.data;
+	}
+
 	/* Discard rx buffer if its msg_ep was closed */
 	if (rx_buf->repost && (rx_buf->ep->srx_ctx || rx_buf->conn->msg_ep)) {
 		rxm_post_recv(rx_buf);

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -66,6 +66,7 @@
 
 extern size_t rxm_eager_limit;
 extern size_t rxm_buffer_size;
+extern size_t rxm_packet_size;
 
 #define RXM_SAR_TX_ERROR	UINT64_MAX
 #define RXM_SAR_RX_INIT		UINT64_MAX
@@ -763,8 +764,8 @@ void rxm_rndv_hdr_init(struct rxm_ep *rxm_ep, void *buf,
 
 static inline size_t rxm_ep_max_atomic_size(struct fi_info *info)
 {
-	assert(rxm_eager_limit >= sizeof(struct rxm_atomic_hdr));
-	return rxm_eager_limit - sizeof(struct rxm_atomic_hdr);
+	assert(rxm_buffer_size >= sizeof(struct rxm_atomic_hdr));
+	return rxm_buffer_size - sizeof(struct rxm_atomic_hdr);
 }
 
 static inline ssize_t

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -475,6 +475,7 @@ struct rxm_rx_buf {
 	size_t rndv_rma_index;
 	struct fid_mr *mr[RXM_IOV_LIMIT];
 
+	void *data;
 	/* Must stay at bottom */
 	struct rxm_pkt pkt;
 };

--- a/prov/rxm/src/rxm_atomic.c
+++ b/prov/rxm/src/rxm_atomic.c
@@ -144,7 +144,7 @@ rxm_ep_atomic_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	data_len = buf_len + cmp_len + sizeof(struct rxm_atomic_hdr);
 	tot_len = data_len + sizeof(struct rxm_pkt);
 
-	if (tot_len > rxm_buffer_size) {
+	if (tot_len > rxm_packet_size) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
 			"atomic data too large %zu\n", tot_len);
 		return -FI_EINVAL;

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -957,11 +957,12 @@ rxm_conn_verify_cm_data(union rxm_cm_data *remote_cm_data,
 			remote_cm_data->connect.op_version);
 		goto err;
 	}
-	if (remote_cm_data->connect.eager_size != local_cm_data->connect.eager_size) {
-		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "cm data eager_size mismatch "
+	if (remote_cm_data->connect.eager_limit !=
+	    local_cm_data->connect.eager_limit) {
+		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "cm data eager_limit mismatch "
 			"(local: %" PRIu32 ", remote:  %" PRIu32 ")\n",
-			local_cm_data->connect.eager_size,
-			remote_cm_data->connect.eager_size);
+			local_cm_data->connect.eager_limit,
+			remote_cm_data->connect.eager_limit);
 		goto err;
 	}
 	return FI_SUCCESS;
@@ -991,7 +992,7 @@ rxm_msg_process_connreq(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
 			.endianness = ofi_detect_endianness(),
 			.ctrl_version = RXM_CTRL_VERSION,
 			.op_version = RXM_OP_VERSION,
-			.eager_size = rxm_eager_limit,
+			.eager_limit = rxm_eager_limit,
 		},
 	};
 	union rxm_cm_data reject_cm_data = {
@@ -1406,11 +1407,11 @@ rxm_conn_connect(struct rxm_ep *ep, struct rxm_cmap_handle *handle,
 			.ctrl_version = RXM_CTRL_VERSION,
 			.op_version = RXM_OP_VERSION,
 			.endianness = ofi_detect_endianness(),
-			.eager_size = rxm_eager_limit,
+			.eager_limit = rxm_eager_limit,
 		},
 	};
 
-	assert(sizeof(uint32_t) == sizeof(cm_data.connect.eager_size));
+	assert(sizeof(uint32_t) == sizeof(cm_data.connect.eager_limit));
 	assert(sizeof(uint32_t) == sizeof(cm_data.connect.rx_size));
 	assert(ep->msg_info->rx_attr->size <= (uint32_t) -1);
 

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -992,7 +992,7 @@ rxm_msg_process_connreq(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
 			.endianness = ofi_detect_endianness(),
 			.ctrl_version = RXM_CTRL_VERSION,
 			.op_version = RXM_OP_VERSION,
-			.eager_limit = rxm_eager_limit,
+			.eager_limit = rxm_ep->eager_limit,
 		},
 	};
 	union rxm_cm_data reject_cm_data = {
@@ -1407,7 +1407,7 @@ rxm_conn_connect(struct rxm_ep *ep, struct rxm_cmap_handle *handle,
 			.ctrl_version = RXM_CTRL_VERSION,
 			.op_version = RXM_OP_VERSION,
 			.endianness = ofi_detect_endianness(),
-			.eager_limit = rxm_eager_limit,
+			.eager_limit = ep->eager_limit,
 		},
 	};
 

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -635,7 +635,7 @@ void rxm_handle_eager(struct rxm_rx_buf *rx_buf)
 	done_len = ofi_copy_to_hmem_iov(iface, device,
 					rx_buf->recv_entry->rxm_iov.iov,
 					rx_buf->recv_entry->rxm_iov.count, 0,
-					rx_buf->pkt.data, rx_buf->pkt.hdr.size);
+					rx_buf->data, rx_buf->pkt.hdr.size);
 	assert(done_len == rx_buf->pkt.hdr.size);
 
 	rxm_finish_recv(rx_buf, done_len);
@@ -654,7 +654,7 @@ void rxm_handle_coll_eager(struct rxm_rx_buf *rx_buf)
 	done_len = ofi_copy_to_hmem_iov(iface, device,
 					rx_buf->recv_entry->rxm_iov.iov,
 					rx_buf->recv_entry->rxm_iov.count, 0,
-					rx_buf->pkt.data, rx_buf->pkt.hdr.size);
+					rx_buf->data, rx_buf->pkt.hdr.size);
 	assert(done_len == rx_buf->pkt.hdr.size);
 
 	if (rx_buf->pkt.hdr.tag & OFI_COLL_TAG_FLAG) {
@@ -1591,7 +1591,7 @@ ssize_t rxm_get_dyn_rbuf(struct ofi_cq_rbuf_entry *entry, struct iovec *iov,
 			       sizeof(*iov));
 		} else {
 			*count = 1;
-			iov[0].iov_base = &rx_buf->pkt.data;
+			iov[0].iov_base = rx_buf->data;
 			iov[0].iov_len = rxm_buffer_size;
 		}
 		break;

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1592,7 +1592,7 @@ ssize_t rxm_get_dyn_rbuf(struct ofi_cq_rbuf_entry *entry, struct iovec *iov,
 		} else {
 			*count = 1;
 			iov[0].iov_base = &rx_buf->pkt.data;
-			iov[0].iov_len = rxm_eager_limit;
+			iov[0].iov_len = rxm_buffer_size;
 		}
 		break;
 	case rxm_ctrl_rndv_req:
@@ -1608,7 +1608,7 @@ ssize_t rxm_get_dyn_rbuf(struct ofi_cq_rbuf_entry *entry, struct iovec *iov,
 	case rxm_ctrl_credit:
 		*count = 1;
 		iov[0].iov_base = &rx_buf->pkt.data;
-		iov[0].iov_len = rxm_eager_limit;
+		iov[0].iov_len = rxm_buffer_size;
 		break;
 	case rxm_ctrl_seg:
 	default:
@@ -1616,7 +1616,7 @@ ssize_t rxm_get_dyn_rbuf(struct ofi_cq_rbuf_entry *entry, struct iovec *iov,
 			"Unexpected request for dynamic rbuf\n");
 		*count = 1;
 		iov[0].iov_base = &rx_buf->pkt.data;
-		iov[0].iov_len = rxm_eager_limit;
+		iov[0].iov_len = rxm_buffer_size;
 		break;
 	}
 

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -548,7 +548,7 @@ int rxm_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	rxm_domain->util_domain.mr_map.mode &= ~FI_MR_PROV_KEY;
 
 	rxm_domain->max_atomic_size = rxm_ep_max_atomic_size(info);
-	rxm_domain->rx_post_size = rxm_buffer_size;
+	rxm_domain->rx_post_size = rxm_packet_size;
 
 	*domain = &rxm_domain->util_domain.domain_fid;
 	(*domain)->fid.ops = &rxm_domain_fi_ops;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -149,6 +149,7 @@ static void rxm_init_rx_buf(struct ofi_bufpool_region *region, void *buf)
 	rx_buf->hdr.desc = ep->msg_mr_local ?
 			   fi_mr_desc((struct fid_mr *) region->context) : NULL;
 	rx_buf->ep = ep;
+	rx_buf->data = &rx_buf->pkt.data;
 }
 
 static void rxm_init_tx_buf(struct ofi_bufpool_region *region, void *buf)

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -52,7 +52,6 @@ size_t rxm_msg_tx_size;
 size_t rxm_msg_rx_size;
 
 size_t rxm_buffer_size = 16384;
-size_t rxm_eager_limit;
 size_t rxm_packet_size;
 
 int force_auto_progress		= 0;
@@ -273,7 +272,6 @@ static void rxm_init_infos(void)
 		rxm_buffer_size = buf_size;
 	}
 
-	rxm_eager_limit = rxm_buffer_size;
 	rxm_packet_size = sizeof(struct rxm_pkt) + rxm_buffer_size;
 
 	fi_param_get_size_t(&rxm_prov, "tx_size", &tx_size);

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -469,16 +469,23 @@ static void rxm_get_def_wait(void)
 RXM_INI
 {
 	fi_param_define(&rxm_prov, "buffer_size", FI_PARAM_SIZE_T,
-			"Defines the transmit buffer size / inject size "
-			"(default: 16 KB). Eager protocol would be used to "
-			"transmit messages of size less than eager limit "
-			"(FI_OFI_RXM_BUFFER_SIZE - RxM header size (%zu B)). "
-			"Any message whose size is greater than eager limit would"
-			" be transmitted via rendezvous or SAR "
-			"(Segmentation And Reassembly) protocol depending on "
-			"the value of FI_OFI_RXM_SAR_LIMIT). Also, transmit data "
-			" would be copied up to eager limit.",
-			sizeof(struct rxm_pkt));
+			"Defines the allocated buffer size used for bounce "
+			"buffers, including buffers posted at the receive side "
+			"to handle unexpected messages.  This value "
+			"corresponds to the rxm inject limit, and is also "
+			"typically used as the eager message size. "
+			"(default %zu)", rxm_buffer_size);
+
+	fi_param_define(&rxm_prov, "eager_limit", FI_PARAM_SIZE_T,
+			"Specifies the maximum size transfer that the eager "
+			"protocol will be used.  For transfers smaller than "
+			"this limit, data may be copied into a bounce "
+			"buffer on the transmit side and received into "
+			"bounce buffer at the receiver.  The eager_limit must "
+			"be equal to the buffer_size when using rxm over "
+			"verbs, but may differ in the case of tcp."
+			"(default: %zu)", rxm_buffer_size);
+			/* rxm_buffer_size is correct here */
 
 	fi_param_define(&rxm_prov, "comp_per_progress", FI_PARAM_INT,
 			"Defines the maximum number of MSG provider CQ entries "
@@ -486,13 +493,14 @@ RXM_INI
 			"(RxM CQ read).");
 
 	fi_param_define(&rxm_prov, "sar_limit", FI_PARAM_SIZE_T,
-			"Set this environment variable to enable and control "
-			"RxM SAR (Segmentation And Reassembly) protocol "
-			"(default: 128 KB). This value should be set greater than "
-			" eager limit (FI_OFI_RXM_BUFFER_SIZE - RxM protocol "
-			"header size (%zu B)) for SAR to take effect. Messages "
-			"of size greater than this would be transmitted via "
-			"rendezvous protocol.", sizeof(struct rxm_pkt));
+			"Specifies the maximum size transfer that the SAR "
+			"Segmentation And Reassembly) protocol "
+			"For transfers smaller than SAR, data may be copied "
+			"into multiple bounce buffers on the transmit side "
+			"and received into bounce buffers at the receiver. "
+			"The sar_limit value must be greater than the "
+			"eager_limit to take effect.  (default %zu).",
+			rxm_buffer_size * 8);
 
 	fi_param_define(&rxm_prov, "use_srx", FI_PARAM_BOOL,
 			"Set this environment variable to control the RxM "

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -250,22 +250,22 @@ int rxm_info_to_rxm(uint32_t version, const struct fi_info *core_info,
 static void rxm_init_infos(void)
 {
 	struct fi_info *cur;
-	size_t eager_size, tx_size = 0, rx_size = 0;
+	size_t eager_limit, tx_size = 0, rx_size = 0;
 
 	/* Historically, 'buffer_size' was the name given for the eager message
 	 * size.  Maintain the name for backwards compatability.
 	 */
-	if (!fi_param_get_size_t(&rxm_prov, "buffer_size", &eager_size)) {
+	if (!fi_param_get_size_t(&rxm_prov, "buffer_size", &eager_limit)) {
 		/* We need enough space to carry extra headers */
-		if (eager_size < sizeof(struct rxm_rndv_hdr) ||
-		    eager_size < sizeof(struct rxm_atomic_hdr)) {
+		if (eager_limit < sizeof(struct rxm_rndv_hdr) ||
+		    eager_limit < sizeof(struct rxm_atomic_hdr)) {
 			FI_WARN(&rxm_prov, FI_LOG_CORE,
 				"Requested buffer size too small\n");
-			eager_size = MAX(sizeof(struct rxm_rndv_hdr),
+			eager_limit = MAX(sizeof(struct rxm_rndv_hdr),
 					 sizeof(struct rxm_atomic_hdr));
 		}
 
-		rxm_eager_limit = eager_size;
+		rxm_eager_limit = eager_limit;
 		if (rxm_eager_limit > INT32_MAX)
 			rxm_eager_limit = INT32_MAX;
 


### PR DESCRIPTION
This series creates a distinction between the eager message size and the size of bounce buffers, and targets rxm over tcp.  In the case of rxm over verbs, the two values must be the same.

The eager limit now defines a protocol threshold, similar to sar limit and rendezvous.  That is now independent from the bounce buffer sizes (buffer_size).  When using tcp, send side bounce buffers are not used -- instead 'direct send' is enabled.  With direct send, the user buffers are passed directly to tcp.  Direct send is an existing feature.  On the receiving side, dynamic receive allows tcp to copy data directly into the application buffer, again bypassing any bounce buffer.

The only time receive side bounce buffers are used is in the case of unexpected message handling.  For unexpected messages, we only need to store the exact size of the received data.  Fixing the buffer size to the eager limit can result in significant memory consumption.  This has been seen in practice where a number of very small messages (8 bytes) resulted in a large number (~160+) of unexpected messages at the receiver.  In this case, the eager limit was set to 128k, which resulted in 20 MB of buffer space allocated for unexpected messages, even though the total amount of data was about 1k.

Several recent optimizations greatly improve small message throughput over tcp.  This has the side effect of greatly increasing unexpected messages in some cases.

To reduce memory consumption, memory is dynamically allocated to handle unexpected messages larger than the given buffer_size.  This allows for a very small default buffer_size (< 1k), while still allowing for a large eager limit (> 16k).  Setting the buffer size equal to the eager limit should match current behavior.