### PR TITLE
core/mr_cache: Fix flush_lru setting passed to flush

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -311,6 +311,12 @@ void ofi_mr_cache_cleanup(struct ofi_mr_cache *cache);
 
 void ofi_mr_cache_notify(struct ofi_mr_cache *cache, const void *addr, size_t len);
 
+static inline bool ofi_mr_cache_full(struct ofi_mr_cache *cache)
+{
+	return (cache->cached_cnt >= cache_params.max_cnt) ||
+	       (cache->cached_size >= cache_params.max_size);
+}
+
 bool ofi_mr_cache_flush(struct ofi_mr_cache *cache, bool flush_lru);
 
 int ofi_mr_cache_search(struct ofi_mr_cache *cache, const struct fi_mr_attr *attr,


### PR DESCRIPTION
In ofi_mr_cache_search, if there are dead regions that need to
be flushed, we call cache_flush, but pass in true to flush_lru.
The result is that when cleaning up dead regions, we will always
flush an entry from the cache.

To avoid this, only flush the lru if the cache is full (when
searching to add new entries).

Signed-off-by: Sean Hefty <sean.hefty@intel.com>