### PR TITLE
core: new APIs to export and import fids

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -237,6 +237,7 @@ real_man_pages = \
         man/man3/fi_errno.3 \
         man/man3/fi_eq.3 \
         man/man3/fi_fabric.3 \
+        man/man3/fi_provider.3 \
         man/man3/fi_getinfo.3 \
         man/man3/fi_mr.3 \
         man/man3/fi_msg.3 \

--- a/Makefile.am
+++ b/Makefile.am
@@ -196,6 +196,7 @@ rdmainclude_HEADERS += \
 	$(top_srcdir)/include/rdma/fi_collective.h \
 	$(top_srcdir)/include/rdma/fi_domain.h \
 	$(top_srcdir)/include/rdma/fi_eq.h \
+	$(top_srcdir)/include/rdma/fi_ext.h \
 	$(top_srcdir)/include/rdma/fi_rma.h \
 	$(top_srcdir)/include/rdma/fi_endpoint.h \
 	$(top_srcdir)/include/rdma/fi_errno.h \

--- a/include/ofi_abi.h
+++ b/include/ofi_abi.h
@@ -111,7 +111,7 @@ extern "C" {
  * name appended with the ABI version that it is compatible with.
  */
 
-#define CURRENT_ABI "FABRIC_1.4"
+#define CURRENT_ABI "FABRIC_1.5"
 
 #if  HAVE_ALIAS_ATTRIBUTE == 1
 #define DEFAULT_SYMVER_PRE(a) a##_

--- a/include/ofi_enosys.h
+++ b/include/ofi_enosys.h
@@ -56,12 +56,17 @@ static struct fi_ops X = {
 	.bind = fi_no_bind,
 	.control = fi_no_control,
 	.ops_open = fi_no_ops_open,
+	.tostr = fi_no_ops_tostr,
+	.ops_set = fi_no_ops_set,
 };
  */
 int fi_no_bind(struct fid *fid, struct fid *bfid, uint64_t flags);
 int fi_no_control(struct fid *fid, int command, void *arg);
 int fi_no_ops_open(struct fid *fid, const char *name,
 		uint64_t flags, void **ops, void *context);
+int fi_no_tostr(const struct fid *fid, char *buf, size_t len);
+int fi_no_ops_set(struct fid *fid, const char *name, uint64_t flags,
+		  void *ops, void *context);
 
 /*
 static struct fi_ops_fabric X = {

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -50,6 +50,10 @@
 #include <ofi_tree.h>
 #include <ofi_hmem.h>
 
+
+int ofi_open_mr_cache(uint32_t version, void *attr, size_t attr_len,
+		      uint64_t flags, struct fid **fid, void *context);
+
 struct ofi_mr_info {
 	struct iovec iov;
 	enum fi_hmem_iface iface;
@@ -151,6 +155,8 @@ void ofi_monitor_init(struct ofi_mem_monitor *monitor);
 void ofi_monitor_cleanup(struct ofi_mem_monitor *monitor);
 void ofi_monitors_init(void);
 void ofi_monitors_cleanup(void);
+int ofi_monitor_import(struct fid *fid);
+
 int ofi_monitors_add_cache(struct ofi_mem_monitor **monitors,
 			   struct ofi_mr_cache *cache);
 void ofi_monitors_del_cache(struct ofi_mr_cache *cache);
@@ -191,8 +197,8 @@ struct ofi_memhooks {
 extern struct ofi_mem_monitor *memhooks_monitor;
 
 extern struct ofi_mem_monitor *cuda_monitor;
-
 extern struct ofi_mem_monitor *rocr_monitor;
+extern struct ofi_mem_monitor *import_monitor;
 
 /*
  * Used to store registered memory regions into a lookup map.  This

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -520,6 +520,8 @@ enum {
 	FI_CLASS_MC,
 	FI_CLASS_NIC,
 	FI_CLASS_AV_SET,
+	FI_CLASS_MR_CACHE,
+	FI_CLASS_MEM_MONITOR,
 };
 
 struct fi_eq_attr;

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -578,7 +578,10 @@ struct fid_fabric {
 	uint32_t		api_version;
 };
 
-int fi_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric, void *context);
+int fi_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
+	      void *context);
+int fi_open(uint32_t version, const char *name, void *attr, size_t attr_len,
+	    uint64_t flags, struct fid **fid, void *context);
 
 struct fid_nic {
 	struct fid		fid;

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -645,6 +645,7 @@ enum {
 	FI_GETWAITOBJ,		/*enum fi_wait_obj * */
 	FI_GET_VAL,		/* struct fi_fid_var */
 	FI_SET_VAL,		/* struct fi_fid_var */
+	FI_EXPORT_FID,		/* struct fi_fid_export */
 };
 
 static inline int fi_control(struct fid *fid, int command, void *arg)

--- a/include/rdma/fi_ext.h
+++ b/include/rdma/fi_ext.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2021 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef FI_EXT_H
+#define FI_EXT_H
+
+#include <rdma/fabric.h>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+struct fi_fid_export {
+	struct fid **fid;
+	uint64_t flags;
+	void *context;
+};
+
+static inline int
+fi_export_fid(struct fid *fid, uint64_t flags,
+	      struct fid **expfid, void *context)
+{
+	struct fi_fid_export exp;
+
+	exp.fid = expfid;
+	exp.flags = flags;
+	exp.context = context;
+	return fi_control(fid, FI_EXPORT_FID, &exp);
+}
+
+static inline int
+fi_import_fid(struct fid *fid, struct fid *expfid, uint64_t flags)
+{
+	return fid->ops->bind(fid, expfid, flags);
+}
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FI_EXT_H */

--- a/include/rdma/fi_ext.h
+++ b/include/rdma/fi_ext.h
@@ -66,6 +66,38 @@ fi_import_fid(struct fid *fid, struct fid *expfid, uint64_t flags)
 }
 
 
+/*
+ * System memory monitor import extension:
+ * To use, open mr_cache fid and import.
+ */
+
+struct fid_mem_monitor;
+
+struct fi_ops_mem_monitor {
+	size_t	size;
+	int	(*start)(struct fid_mem_monitor *monitor);
+	void	(*stop)(struct fid_mem_monitor *monitor);
+	int	(*subscribe)(struct fid_mem_monitor *monitor,
+			const void *addr, size_t len);
+	void	(*unsubscribe)(struct fid_mem_monitor *monitor,
+			const void *addr, size_t len);
+	bool	(*valid)(struct fid_mem_monitor *monitor,
+			const void *addr, size_t len);
+};
+
+struct fi_ops_mem_notify {
+	size_t	size;
+	void	(*notify)(struct fid_mem_monitor *monitor, const void *addr,
+			size_t len);
+};
+
+struct fid_mem_monitor {
+	struct fid fid;
+	struct fi_ops_mem_monitor *expops;
+	struct fi_ops_mem_notify *impops;
+};
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/libfabric.map.in
+++ b/libfabric.map.in
@@ -43,3 +43,8 @@ FABRIC_1.4 {
 	global:
 		fi_tostr_r;
 } FABRIC_1.3;
+
+FABRIC_1.5 {
+	global:
+		fi_open;
+} FABRIC_1.4;

--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -745,6 +745,7 @@
     <ClInclude Include="include\rdma\fi_endpoint.h" />
     <ClInclude Include="include\rdma\fi_eq.h" />
     <ClInclude Include="include\rdma\fi_errno.h" />
+    <ClInclude Include="include\rdma\fi_ext.h" />
     <ClInclude Include="include\rdma\fi_rma.h" />
     <ClInclude Include="include\rdma\fi_tagged.h" />
     <ClInclude Include="include\rdma\fi_trigger.h" />

--- a/libfabric.vcxproj.filters
+++ b/libfabric.vcxproj.filters
@@ -563,6 +563,9 @@
     <ClInclude Include="include\rdma\fi_errno.h">
       <Filter>Header Files\rdma</Filter>
     </ClInclude>
+    <ClInclude Include="include\rdma\fi_ext.h">
+      <Filter>Header Files\rdma</Filter>
+    </ClInclude>
     <ClInclude Include="include\rdma\fi_rma.h">
       <Filter>Header Files\rdma</Filter>
     </ClInclude>

--- a/man/fi_fabric.3.md
+++ b/man/fi_fabric.3.md
@@ -7,10 +7,10 @@ tagline: Libfabric Programmer's Manual
 
 # NAME
 
-fi_fabric \- Fabric domain operations
+fi_fabric \- Fabric network operations
 
 fi_fabric / fi_close
-: Open / close a fabric domain
+: Open / close a fabric network
 
 fi_tostr / fi_tostr_r
 : Convert fabric attributes, flags, and capabilities to printable string
@@ -37,7 +37,7 @@ char * fi_tostr(char *buf, size_t len, const void *data,
 : Attributes of fabric to open.
 
 *fabric*
-: Fabric domain
+: Fabric network
 
 *context*
 : User specified context associated with the opened object.  This
@@ -58,22 +58,27 @@ char * fi_tostr(char *buf, size_t len, const void *data,
 
 # DESCRIPTION
 
-A fabric domain represents a collection of hardware and software
+A fabric identifier is used to reference opened fabric resources
+and library related objects.
+
+The fabric network represents a collection of hardware and software
 resources that access a single physical or virtual network.  All
 network ports on a system that can communicate with each other through
-their attached networks belong to the same fabric domain.  A fabric
-domain shares network addresses and can span multiple providers.
+their attached networks belong to the same fabric.  A fabric
+network shares network addresses and can span multiple providers.  An
+application must open a fabric network prior to allocating other network
+resources, such as communication endpoints.
 
 ## fi_fabric
 
-Opens a fabric provider.  The attributes of the fabric provider are
+Opens a fabric network provider.  The attributes of the fabric provider are
 specified through the open call, and may be obtained by calling
 fi_getinfo.
 
 ## fi_close
 
 The fi_close call is used to release all resources associated with a
-fabric domain or interface.  All items associated with the opened
+fabric object.  All items associated with the opened
 fabric must be released prior to calling fi_close.
 
 ## fi_tostr / fi_tostr_r

--- a/man/fi_mr.3.md
+++ b/man/fi_mr.3.md
@@ -800,6 +800,13 @@ configure registration caches.
   are: 0 or 1. Note that the ROCR memory monitor requires a ROCR version with
   unified virtual addressing enabled.
 
+More direct access to the internal registration cache is possible through the
+fi_open() call, using the "mr_cache" service name.  Once opened, custom
+memory monitors may be installed.  A memory monitor is a component of the cache
+responsible for detecting changes in virtual to physical address mappings.
+Some level of control over the cache is possible through the above mentioned
+environment variables.
+
 # SEE ALSO
 
 [`fi_getinfo`(3)](fi_getinfo.3.html),

--- a/man/fi_provider.3.md
+++ b/man/fi_provider.3.md
@@ -1,0 +1,140 @@
+---
+layout: page
+title: fi_provider(3)
+tagline: Libfabric Programmer's Manual
+---
+{% include JB/setup %}
+
+# NAME
+
+fi_prov_ini \- External provider entry point
+
+fi_param_define / fi_param_get
+: Register and retrieve environment variables with the libfabric core
+
+fi_log_enabled / fi_log
+: Control and output debug logging information.
+
+# SYNOPSIS
+
+```c
+#include <rdma/fabric.h>
+#include <rdma/prov/fi_prov.h>
+#include <rdma/prov/fi_log.h>
+
+struct fi_provider* fi_prov_ini(void);
+
+int fi_param_define(const struct fi_provider *provider, const char *param_name,
+	enum fi_param_type type, const char *help_string_fmt, ...);
+
+int fi_param_get_str(struct fi_provider *provider, const char *param_name,
+    char **value);
+
+int fi_param_get_int(struct fi_provider *provider, const char *param_name,
+    int *value);
+
+int fi_param_get_bool(struct fi_provider *provider, const char *param_name,
+    int *value);
+
+int fi_param_get_size_t(struct fi_provider *provider, const char *param_name,
+    size_t *value);
+
+int fi_log_enabled(const struct fi_provider *prov, enum fi_log_level level,
+    enum fi_log_subsys subsys);
+
+void fi_log(const struct fi_provider *prov, enum fi_log_level level,
+    enum fi_log_subsys subsys, const char *func, int line,
+    const char *fmt, ...);
+```
+
+# ARGUMENTS
+
+*provider*
+: Reference to the provider.
+
+# DESCRIPTION
+
+A fabric provider implements the application facing software
+interfaces needed to access network specific protocols,
+drivers, and hardware.  The interfaces and structures defined by
+this man page are exported by the libfabric library, but are
+targeted for provider implementations, rather than for direct
+use by most applications.
+
+Integrated providers are those built directly into the libfabric
+library itself.  External providers are loaded dynamically by
+libfabric at initialization time.  External providers must be in
+a standard library path or in the libfabric library search path
+as specified by environment variable.  Additionally, external
+providers must be named with the suffix "-fi.so" at the end of
+the name.
+
+## fi_prov_ini
+
+This entry point must be defined by external providers.  On loading,
+libfabric will invoke fi_prov_ini() to retrieve the provider's
+fi_provider structure.  Additional interactions between the libfabric
+core and the provider will be through the interfaces defined by that
+struct.
+
+## fi_param_define / fi_param_get
+
+TODO
+
+## fi_log_enabled / fi_log
+
+TODO
+
+# NOTES
+
+TODO
+
+# PROVIDER INTERFACE
+
+The fi_provider structure defines entry points for the libfabric core
+to use to access the provider.  All other calls into a provider are
+through function pointers associated with allocated objects.
+
+```c
+struct fi_provider {
+	uint32_t version;
+	uint32_t fi_version;
+	struct fi_context context;
+	const char *name;
+	int	(*getinfo)(uint32_t version, const char *node, const char *service,
+			uint64_t flags, const struct fi_info *hints,
+			struct fi_info **info);
+	int	(*fabric)(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
+			void *context);
+	void	(*cleanup)(void);
+};
+```
+
+## version
+
+The provider version.  For providers integrated with the library, this is
+often the same as the library version.
+
+## fi_version
+
+The library interface version that the provider was implemented against.
+The provider's fi_version must be greater than or equal to an application's
+requested api version for the application to use the provider.  It is a
+provider's responsibility to support older versions of the api if it
+wishes to supports legacy applications.  For integrated providers
+
+## TODO
+
+# RETURN VALUE
+
+Returns FI_SUCCESS on success. On error, a negative value corresponding to
+fabric errno is returned. Fabric errno values are defined in
+`rdma/fi_errno.h`.
+
+# ERRORS
+
+
+# SEE ALSO
+
+[`fabric`(7)](fabric.7.html),
+[`fi_getinfo`(3)](fi_getinfo.3.html)

--- a/man/fi_provider.3.md
+++ b/man/fi_provider.3.md
@@ -18,12 +18,14 @@ fi_log_enabled / fi_log
 fi_open / fi_close
 : Open a named library object
 
+fi_export_fid / fi_import_fid
+: Share a fabric object between different providers or resources
+
 # SYNOPSIS
 
 ```c
 #include <rdma/fabric.h>
 #include <rdma/prov/fi_prov.h>
-#include <rdma/prov/fi_log.h>
 
 struct fi_provider* fi_prov_ini(void);
 
@@ -31,28 +33,48 @@ int fi_param_define(const struct fi_provider *provider, const char *param_name,
 	enum fi_param_type type, const char *help_string_fmt, ...);
 
 int fi_param_get_str(struct fi_provider *provider, const char *param_name,
-    char **value);
+	char **value);
 
 int fi_param_get_int(struct fi_provider *provider, const char *param_name,
-    int *value);
+	int *value);
 
 int fi_param_get_bool(struct fi_provider *provider, const char *param_name,
-    int *value);
+	int *value);
 
 int fi_param_get_size_t(struct fi_provider *provider, const char *param_name,
-    size_t *value);
+	size_t *value);
+```
+
+```c
+#include <rdma/fabric.h>
+#include <rdma/prov/fi_prov.h>
+#include <rdma/prov/fi_log.h>
 
 int fi_log_enabled(const struct fi_provider *prov, enum fi_log_level level,
-    enum fi_log_subsys subsys);
+	enum fi_log_subsys subsys);
 
 void fi_log(const struct fi_provider *prov, enum fi_log_level level,
-    enum fi_log_subsys subsys, const char *func, int line,
-    const char *fmt, ...);
+	enum fi_log_subsys subsys, const char *func, int line,
+	const char *fmt, ...);
+```
+
+```c
+#include <rdma/fabric.h>
 
 int fi_open(uint32_t version, const char *name, void *attr,
-    size_t attr_len, uint64_t flags, struct fid **fid, void *context);
+	size_t attr_len, uint64_t flags, struct fid **fid, void *context);
 
 int fi_close(struct fid *fid);
+```
+
+```c
+#include <rdma/fabric.h>
+#include <rdma/fi_ext.h>
+
+int fi_export_fid(struct fid *fid, uint64_t flags,
+	struct fid **expfid, void *context);
+
+int fi_import_fid(struct fid *fid, struct fid *expfid, uint64_t flags);
 ```
 
 # ARGUMENTS
@@ -132,6 +154,21 @@ of the service or resource to which they correspond.
 : The mr_cache object references the internal memory registration cache
   used by the different providers.  Additional information on the cache
   is available in the `fi_mr(3)` man page.
+
+## fi_export_fid / fi_import_fid
+
+Generally, fabric objects are allocated and managed entirely by a single
+provider.  Typically only the application facing software interfaces of
+a fabric object are defined, for example, the message or tagged operations
+of an endpoint.  The fi_export_fid and fi_import_fid calls provide a
+a mechanism by which provider facing APIs may be accessed.  This allows
+the creation of fid objects that are shareable between providers, or
+for library plug-in services.  The ability to export a shareable object
+is object and provider implementation dependent.
+
+Shareable fids typically contain at least 3 main components: a
+base fid, a set of exporter defined ops, and a set of importer defined
+ops.
 
 # NOTES
 

--- a/man/fi_provider.3.md
+++ b/man/fi_provider.3.md
@@ -15,6 +15,9 @@ fi_param_define / fi_param_get
 fi_log_enabled / fi_log
 : Control and output debug logging information.
 
+fi_open / fi_close
+: Open a named library object
+
 # SYNOPSIS
 
 ```c
@@ -45,12 +48,33 @@ int fi_log_enabled(const struct fi_provider *prov, enum fi_log_level level,
 void fi_log(const struct fi_provider *prov, enum fi_log_level level,
     enum fi_log_subsys subsys, const char *func, int line,
     const char *fmt, ...);
+
+int fi_open(uint32_t version, const char *name, void *attr,
+    size_t attr_len, uint64_t flags, struct fid **fid, void *context);
+
+int fi_close(struct fid *fid);
 ```
 
 # ARGUMENTS
 
 *provider*
 : Reference to the provider.
+
+*version*
+: API version requested by application.
+
+*name*
+: Well-known name of the library object to open.
+
+*attr*
+: Optional attributes of object to open.
+
+*attr_len*
+: Size of any attribute structure passed to fi_open.  Should be 0
+  if no attributes are give.
+
+*fid*
+: Returned fabric identifier for opened object.
 
 # DESCRIPTION
 
@@ -69,6 +93,10 @@ as specified by environment variable.  Additionally, external
 providers must be named with the suffix "-fi.so" at the end of
 the name.
 
+Named objects are special purpose resources which are accessible directly
+to applications.  They may be used to enhance or modify the behavior of
+library core.  For details, see the fi_open call below.
+
 ## fi_prov_ini
 
 This entry point must be defined by external providers.  On loading,
@@ -84,6 +112,26 @@ TODO
 ## fi_log_enabled / fi_log
 
 TODO
+
+## fi_open
+
+Open a library resource using a well-known name.  This feature allows
+applications and providers a mechanism which can be used to modify or
+enhance core library services and behavior.  The details are specific
+based on the requested object name.  Most applications will not need
+this level of control.
+
+The library API version known to the application should be provided
+through the version parameter.  The use of attributes is object dependent.
+If required, attributes should be provided through the attr parameter,
+with attr_len set to the size of the referenced attribute structure.
+The following is a list of published names, along with descriptions
+of the service or resource to which they correspond.
+
+*mr_cache*
+: The mr_cache object references the internal memory registration cache
+  used by the different providers.  Additional information on the cache
+  is available in the `fi_mr(3)` man page.
 
 # NOTES
 
@@ -138,3 +186,4 @@ fabric errno is returned. Fabric errno values are defined in
 
 [`fabric`(7)](fabric.7.html),
 [`fi_getinfo`(3)](fi_getinfo.3.html)
+[`fi_mr`(3)](fi_mr.3.html),

--- a/man/man3/fi_open.3
+++ b/man/man3/fi_open.3
@@ -1,1 +1,1 @@
-.so man3/fi_domain.3
+.so man3/fi_provider.3

--- a/man/man3/fi_provider.3
+++ b/man/man3/fi_provider.3
@@ -1,0 +1,1 @@
+.so man3/fi_provider.3

--- a/src/enosys.c
+++ b/src/enosys.c
@@ -53,6 +53,15 @@ int fi_no_ops_open(struct fid *fid, const char *name,
 {
 	return -FI_ENOSYS;
 }
+int fi_no_tostr(const struct fid *fid, char *buf, size_t len)
+{
+	return -FI_ENOSYS;
+}
+int fi_no_ops_set(struct fid *fid, const char *name, uint64_t flags,
+		  void *ops, void *context)
+{
+	return -FI_ENOSYS;
+}
 
 /*
  * struct fi_ops_fabric

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -1250,6 +1250,15 @@ uint32_t DEFAULT_SYMVER_PRE(fi_version)(void)
 }
 DEFAULT_SYMVER(fi_version_, fi_version, FABRIC_1.0);
 
+__attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
+int DEFAULT_SYMVER_PRE(fi_open)(uint32_t version, const char *name,
+		void *attr, size_t attr_len, uint64_t flags,
+		struct fid **fid, void *context)
+{
+	return -FI_ENOSYS;
+}
+CURRENT_SYMVER(fi_open_, fi_open);
+
 static const char *const errstr[] = {
 	[FI_EOTHER - FI_ERRNO_OFFSET] = "Unspecified error",
 	[FI_ETOOSMALL - FI_ERRNO_OFFSET] = "Provided buffer is too small",

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -1257,6 +1257,10 @@ int DEFAULT_SYMVER_PRE(fi_open)(uint32_t version, const char *name,
 		void *attr, size_t attr_len, uint64_t flags,
 		struct fid **fid, void *context)
 {
+	if (!strcasecmp("mr_cache", name))
+		return ofi_open_mr_cache(version, attr, attr_len,
+					 flags, fid, context);
+
 	return -FI_ENOSYS;
 }
 CURRENT_SYMVER(fi_open_, fi_open);

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -49,10 +49,12 @@
 #include "ofi_prov.h"
 #include "ofi_perf.h"
 #include "ofi_hmem.h"
+#include "rdma/fi_ext.h"
 
 #ifdef HAVE_LIBDL
 #include <dlfcn.h>
 #endif
+
 
 struct ofi_prov {
 	struct ofi_prov		*next;

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -842,7 +842,7 @@ char *DEFAULT_SYMVER_PRE(fi_tostr_r)(char *buf, size_t len,
 	}
 	return buf;
 }
-CURRENT_SYMVER(fi_tostr_r_, fi_tostr_r);
+DEFAULT_SYMVER(fi_tostr_r_, fi_tostr_r, FABRIC_1.4);
 
 __attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
 char *DEFAULT_SYMVER_PRE(fi_tostr)(const void *data, enum fi_type datatype)


### PR DESCRIPTION
This series defines a standard mechanism for Open MPI to communicate with the libfabric MR cache.

3 new APIs are introduced.  fi_open, fi_import_fid, and fi_export_fid.  Only the first 2 are used in this series. fi_open is the only new exported symbol by the library.

fi_open allows an application to open a fabric object by name.  This works-around the restriction that all fid's map to some provider object.  The series defines a "mr_cache" object, which may be opened by the application.

Once the mr_cache has been opened, an application can use the standard fid ops to interact with it.  E.g. fi_control, fi_bind, fi_close, etc.  In this case, fi_import_fid allows an application to load a new memory monitor object into the cache for use.  fi_import_fid is a mapping to fi_bind.

A new header file is added, fi_ext.h.  That header will be used to define special fabric objects that most applications are not expected to need.  A new fid_memory_monitor object is defined.  That object defines the callbacks needed for an application to communicate with the mr_cache.  The callbacks go both directions.

Some poor documentation is added to the man pages as a starting point only for describing the new APIs.

The changes are untested and will likely need tweaking.  But they are provided as the starting point for developing the application side solution.