### PR TITLE
Minimal changes to support FI_INT128/FI_UINT128

### DIFF
--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -185,6 +185,12 @@ enum fi_datatype {
 	FI_LONG_DOUBLE_COMPLEX,
 	/* End of point to point atomic datatypes */
 	FI_DATATYPE_LAST,
+	/*
+	 * enums for 128-bit integer atomics, existing ordering and
+	 * FI_DATATYPE_LAST preserved for compatabilty.
+	 */
+	FI_INT128 = FI_DATATYPE_LAST,
+	FI_UINT128,
 
 	/* Collective datatypes */
 	FI_VOID = FI_COLLECTIVE_OFFSET,

--- a/man/fi_atomic.3.md
+++ b/man/fi_atomic.3.md
@@ -190,6 +190,12 @@ provider implementation constraints.
 *FI_UINT64*
 : Unsigned 64-bit integer.
 
+*FI_INT128*
+: Signed 128-bit integer.
+
+*FI_UINT128*
+: Unsigned 128-bit integer.
+
 *FI_FLOAT*
 : A single-precision floating point value (IEEE 754).
 

--- a/prov/util/src/util_atomic.c
+++ b/prov/util/src/util_atomic.c
@@ -49,11 +49,14 @@ static const size_t ofi_datatype_size_table[] = {
 	[FI_DOUBLE_COMPLEX] = sizeof(ofi_complex_double),
 	[FI_LONG_DOUBLE]    = sizeof(long double),
 	[FI_LONG_DOUBLE_COMPLEX] = sizeof(ofi_complex_long_double),
+	/* Compute 128-bit integer size, since compiler may not support type. */
+	[FI_INT128]  = sizeof(int64_t) * 2,
+	[FI_UINT128] = sizeof(uint64_t) * 2,
 };
 
 size_t ofi_datatype_size(enum fi_datatype datatype)
 {
-	if (datatype >= FI_DATATYPE_LAST) {
+	if (datatype >= sizeof(ofi_datatype_size_table)) {
 		errno = FI_EINVAL;
 		return 0;
 	}

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -625,6 +625,8 @@ static void ofi_tostr_atomic_type(char *buf, size_t len, enum fi_datatype type)
 	CASEENUMSTRN(FI_UINT32, len);
 	CASEENUMSTRN(FI_INT64, len);
 	CASEENUMSTRN(FI_UINT64, len);
+	CASEENUMSTRN(FI_INT128, len);
+	CASEENUMSTRN(FI_UINT128, len);
 	CASEENUMSTRN(FI_FLOAT, len);
 	CASEENUMSTRN(FI_DOUBLE, len);
 	CASEENUMSTRN(FI_FLOAT_COMPLEX, len);


### PR DESCRIPTION
Just the changes needed to support a HW provider that wanted
to use 128-bit integer atomics.

Signed-off-by: John Byrne <john.l.byrne@hpe.com>