### PR TITLE
prov/efa: Fix a few bugs

### DIFF
--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -625,8 +625,6 @@ int efa_rdm_av_remove_one(struct efa_av *av, fi_addr_t fi_addr, uint64_t flags)
 	if (ret)
 		return ret;
 
-	efa_rdm_peer_reset(peer);
-
 	/*
 	 * Clearing the 3 resources of an av entry:
 	 *
@@ -647,6 +645,13 @@ int efa_rdm_av_remove_one(struct efa_av *av, fi_addr_t fi_addr, uint64_t flags)
 			av->shm_rdm_addr_map[peer->shm_fiaddr] = FI_ADDR_UNSPEC;
 		}
 	}
+
+	/*
+	 * We still need the information stored in peer strcuture to
+	 * properly remove shm address from av table, so doing peer reset
+	 * after the remove
+	 */
+	efa_rdm_peer_reset(peer);
 
 	efa_conn_release(av, av_entry->conn);
 

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -92,18 +92,13 @@ struct rxr_rx_entry *rxr_ep_alloc_rx_entry(struct rxr_ep *ep, fi_addr_t addr, ui
 		FI_WARN(&rxr_prov, FI_LOG_EP_CTRL, "RX entries exhausted\n");
 		return NULL;
 	}
+	memset(rx_entry, 0, sizeof(struct rxr_rx_entry));
 
 #if ENABLE_DEBUG
 	dlist_insert_tail(&rx_entry->rx_entry_entry, &ep->rx_entry_list);
 #endif
 	rx_entry->type = RXR_RX_ENTRY;
 	rx_entry->rx_id = ofi_buf_index(rx_entry);
-	rx_entry->rxr_flags = 0;
-	rx_entry->bytes_received = 0;
-	rx_entry->bytes_copied = 0;
-	rx_entry->window = 0;
-	rx_entry->unexp_pkt = NULL;
-	rx_entry->rma_iov_count = 0;
 	dlist_init(&rx_entry->queued_pkts);
 
 	rx_entry->state = RXR_RX_INIT;
@@ -120,7 +115,6 @@ struct rxr_rx_entry *rxr_ep_alloc_rx_entry(struct rxr_ep *ep, fi_addr_t addr, ui
 		rx_entry->peer = NULL;
 	} 
 
-	memset(&rx_entry->cq_entry, 0, sizeof(rx_entry->cq_entry));
 	rx_entry->op = op;
 	switch (op) {
 	case ofi_op_tagged:

--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -140,14 +140,14 @@ void rxr_pkt_entry_release_tx(struct rxr_ep *ep,
 		       "reset backoff timer for peer: %" PRIu64 "\n",
 		       pkt->addr);
 	}
-#ifdef ENABLE_EFA_POISONING
-	rxr_poison_mem_region((uint32_t *)pkt, ep->tx_pkt_pool_entry_sz);
-#endif
-	pkt->state = RXR_PKT_ENTRY_FREE;
 	if (pkt->send) {
 		ofi_buf_free(pkt->send);
 		pkt->send = NULL;
 	}
+#ifdef ENABLE_EFA_POISONING
+	rxr_poison_mem_region((uint32_t *)pkt, ep->tx_pkt_pool_entry_sz);
+#endif
+	pkt->state = RXR_PKT_ENTRY_FREE;
 	ofi_buf_free(pkt);
 }
 

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -1867,10 +1867,6 @@ void rxr_pkt_handle_rtr_recv(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 	rx_entry->addr = pkt_entry->addr;
 	rx_entry->bytes_received = 0;
 	rx_entry->bytes_copied = 0;
-	rx_entry->cq_entry.flags |= (FI_RMA | FI_READ);
-	rx_entry->cq_entry.len = ofi_total_iov_len(rx_entry->iov, rx_entry->iov_count);
-	rx_entry->cq_entry.buf = rx_entry->iov[0].iov_base;
-	rx_entry->total_len = rx_entry->cq_entry.len;
 
 	rtr_hdr = (struct rxr_rtr_hdr *)pkt_entry->pkt;
 	rx_entry->rma_initiator_rx_id = rtr_hdr->read_req_rx_id;
@@ -1885,6 +1881,11 @@ void rxr_pkt_handle_rtr_recv(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 		rxr_pkt_entry_release_rx(ep, pkt_entry);
 		return;
 	}
+
+	rx_entry->cq_entry.flags |= (FI_RMA | FI_READ);
+	rx_entry->cq_entry.len = ofi_total_iov_len(rx_entry->iov, rx_entry->iov_count);
+	rx_entry->cq_entry.buf = rx_entry->iov[0].iov_base;
+	rx_entry->total_len = rx_entry->cq_entry.len;
 
 	tx_entry = rxr_rma_alloc_readrsp_tx_entry(ep, rx_entry);
 	if (OFI_UNLIKELY(!tx_entry)) {


### PR DESCRIPTION
263e86583 prov/efa: Fix a bug in rxr_pkt_entry_release_tx to ensure we release rxr_pkt_sendv structure before doing memory poisoning. 
651a76549 prov/efa: Fix a bug in efa_rdm_av_remove_one to ensure we properly remove shm address before doing peer reset.
c75811b14 prov/efa: Fix bugs of using uninitialized field.