### PR TITLE
[v1.12.x] prov/efa: Fix bugs of using uninitialized field and incorrectly releasing rxr_pkt_sendv structure

### DIFF
--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -140,14 +140,14 @@ void rxr_pkt_entry_release_tx(struct rxr_ep *ep,
 		       "reset backoff timer for peer: %" PRIu64 "\n",
 		       pkt->addr);
 	}
-#ifdef ENABLE_EFA_POISONING
-	rxr_poison_mem_region((uint32_t *)pkt, ep->tx_pkt_pool_entry_sz);
-#endif
-	pkt->state = RXR_PKT_ENTRY_FREE;
 	if (pkt->send) {
 		ofi_buf_free(pkt->send);
 		pkt->send = NULL;
 	}
+#ifdef ENABLE_EFA_POISONING
+	rxr_poison_mem_region((uint32_t *)pkt, ep->tx_pkt_pool_entry_sz);
+#endif
+	pkt->state = RXR_PKT_ENTRY_FREE;
 	ofi_buf_free(pkt);
 }
 

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -1849,10 +1849,6 @@ void rxr_pkt_handle_rtr_recv(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 	rx_entry->addr = pkt_entry->addr;
 	rx_entry->bytes_received = 0;
 	rx_entry->bytes_copied = 0;
-	rx_entry->cq_entry.flags |= (FI_RMA | FI_READ);
-	rx_entry->cq_entry.len = ofi_total_iov_len(rx_entry->iov, rx_entry->iov_count);
-	rx_entry->cq_entry.buf = rx_entry->iov[0].iov_base;
-	rx_entry->total_len = rx_entry->cq_entry.len;
 
 	rtr_hdr = (struct rxr_rtr_hdr *)pkt_entry->pkt;
 	rx_entry->rma_initiator_rx_id = rtr_hdr->read_req_rx_id;
@@ -1867,6 +1863,11 @@ void rxr_pkt_handle_rtr_recv(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 		rxr_pkt_entry_release_rx(ep, pkt_entry);
 		return;
 	}
+
+	rx_entry->cq_entry.flags |= (FI_RMA | FI_READ);
+	rx_entry->cq_entry.len = ofi_total_iov_len(rx_entry->iov, rx_entry->iov_count);
+	rx_entry->cq_entry.buf = rx_entry->iov[0].iov_base;
+	rx_entry->total_len = rx_entry->cq_entry.len;
 
 	tx_entry = rxr_rma_alloc_readrsp_tx_entry(ep, rx_entry);
 	if (OFI_UNLIKELY(!tx_entry)) {


### PR DESCRIPTION
4cc9f83 prov/efa: Fix a bug in rxr_pkt_entry_release_tx to ensure we release rxr_pkt_sendv structure before doing memory poisoning.
01c8082 prov/efa: Fix bugs of using uninitialized field.