### PR TITLE
Nroff Elves: explicitly pass base branch to "hub"

### DIFF
--- a/.github/workflows/nroff-elves.sh
+++ b/.github/workflows/nroff-elves.sh
@@ -25,7 +25,7 @@ fi
 # Yes, we committed something.  Push the branch and make a PR.
 # Extract the PR number.
 git push --set-upstream origin $branch_name
-url=`hub pull-request -m 'Update nroff-generated man pages'`
+url=`hub pull-request -b $BASE_REF -m 'Update nroff-generated man pages'`
 pr_num=`echo $url | cut -d/ -f7`
 
 # Wait for the required "DCO" CI to complete

--- a/.github/workflows/nroff-elves.yaml
+++ b/.github/workflows/nroff-elves.yaml
@@ -20,3 +20,4 @@ jobs:
             run: .github/workflows/nroff-elves.sh
             env:
               GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              BASE_REF: ${{ github.base_ref }}


### PR DESCRIPTION
The recent change of the default branch name from "master" to "main"
appears to somehow break hub's method of figuring out the base branch
name.

So get the base branch from the github JSON blob and pass that
explicitly on the command line to hub.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>