### PR TITLE
prov/tcp: Flush bsock and shutdown socket in ep_disable

### DIFF
--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -150,6 +150,12 @@ static inline void ofi_byteq_init(struct ofi_byteq *byteq, ssize_t size)
 		byteq->size = 0;
 }
 
+static inline void ofi_byteq_discard(struct ofi_byteq *byteq)
+{
+	byteq->head = 0;
+	byteq->tail = 0;
+}
+
 static inline size_t ofi_byteq_readable(struct ofi_byteq *byteq)
 {
 	return byteq->tail - byteq->head;
@@ -251,6 +257,12 @@ ofi_bsock_init(struct ofi_bsock *bsock, ssize_t sbuf_size, ssize_t rbuf_size)
 	/* first async op will wrap back to 0 as the starting index */
 	bsock->async_index = UINT32_MAX;
 	bsock->done_index = UINT32_MAX;
+}
+
+static inline void ofi_bsock_discard(struct ofi_bsock *bsock)
+{
+	ofi_byteq_discard(&bsock->rq);
+	ofi_byteq_discard(&bsock->sq);
 }
 
 static inline size_t ofi_bsock_readable(struct ofi_bsock *bsock)


### PR DESCRIPTION
tcpx_ep_disable is called in certain error cases, such as
problems during the CM exchange, if the underlying socket
has been disconnected (error on socket recv), or if the
user calls ep_shutdown.  When the ep is disabled, all
message queues are flushed and current operations are
canceled.  However, the ep is still attached with the
CQ and attempts can be made to progress it.

There's a possibility that data may have been queued
in the buffered socket prior to the ep being disabled.
Since the current receive operation was discarded, any
buffered data would be treated as a new message.  This
can lead to hitting an assert in tcpx_cq_progress that
the ep state is still connected.

To avoid hitting the assert, discard any buffered data.
Also call shutdown on the socket to disable further transfers
(in the case we reached ep_disable through one of the
error paths).

Signed-off-by: Sean Hefty <sean.hefty@intel.com>