### PR TITLE
Nroff Elves: no base branch in a scheduled run

### DIFF
--- a/.github/workflows/nroff-elves.yaml
+++ b/.github/workflows/nroff-elves.yaml
@@ -20,4 +20,4 @@ jobs:
             run: .github/workflows/nroff-elves.sh
             env:
               GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              BASE_REF: ${{ github.base_ref }}
+              BASE_REF: ${{ github.event.repository.default_branch }}


### PR DESCRIPTION
The commit e75aa39d2 to fix the Nroff Elves wasn't quite correct.  The
switch from "master" to "main" somehow mucked up "hub"'s ability to
guess the branch that we wanted to push to.  Hence, we need to
explicitly mention the base branch that we want "hub" to open the pull
request against.

The mistake in e75aa39d2 is that I tested the fix by launching the
Nroff Elves GitHub Action via a Pull Request.  In that case, the Elves
can look up the PR base branch create a new PR against that branch.
But the Nroff Elves are actually run via a (cron-like) schedule, and
there is no base branch when GitHub Actions are launched this way.

So instead, what the Elves really want to do is find the repo's
default branch, and then use that branch as the base branch for the
newly-opened PR.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>