### PR TITLE
prov/rxd: AV/address cleanup

### DIFF
--- a/prov/rxd/src/rxd_av.c
+++ b/prov/rxd/src/rxd_av.c
@@ -294,42 +294,21 @@ static int rxd_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr, size_t count
 			uint64_t flags)
 {
 	int ret = 0;
-	size_t i, addrlen;
+	size_t i;
 	fi_addr_t rxd_addr;
-	fi_addr_t dg_addr;
 	struct rxd_av *av;
-	uint8_t addr[RXD_NAME_LENGTH];
 
 	av = container_of(av_fid, struct rxd_av, util_av.av_fid);
 	fastlock_acquire(&av->util_av.lock);
 	for (i = 0; i < count; i++) {
-
-		addrlen = RXD_NAME_LENGTH;
 		rxd_addr = (intptr_t)ofi_idx_lookup(&av->fi_addr_idx,
 						    RXD_IDX_OFFSET(fi_addr[i]));
 		if (!rxd_addr)
 			goto err;
 
-		dg_addr = (intptr_t)ofi_idx_lookup(&av->rxdaddr_dg_idx, rxd_addr);
-
-		ret = fi_av_lookup(av->dg_av, dg_addr, addr, &addrlen);
-		if (ret)
-			goto err;
-
-		ret = ofi_rbmap_find_delete(&av->rbmap, (void *) addr);
-		if (ret)
-			goto err;
-
-		ret = fi_av_remove(av->dg_av, &dg_addr, 1, flags);
-
-		if (ret)
-			goto err;
-
 		ofi_idx_remove_ordered(&(av->fi_addr_idx),
 				       RXD_IDX_OFFSET(fi_addr[i]));
-		ofi_idx_remove_ordered(&(av->rxdaddr_dg_idx), rxd_addr);
 		ofi_idm_clear(&(av->rxdaddr_fi_idm), rxd_addr);
-		av->dg_av_used--;
 	}
 
 err:

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -613,19 +613,19 @@ static void rxd_close_peer(struct rxd_ep *ep, struct rxd_peer *peer)
 		peer->unacked_cnt--;
 	}
 
-	while(!dlist_empty(&peer->tx_list)) {
+	while (!dlist_empty(&peer->tx_list)) {
 		dlist_pop_front(&peer->tx_list, struct rxd_x_entry,
 				x_entry, entry);
 		rxd_tx_entry_free(ep, x_entry);
 	}
 
-	while(!dlist_empty(&peer->rx_list)) {
+	while (!dlist_empty(&peer->rx_list)) {
 		dlist_pop_front(&peer->rx_list, struct rxd_x_entry,
 				x_entry, entry);
 		rxd_rx_entry_free(ep, x_entry);
 	}
 
-	while(!dlist_empty(&peer->rma_rx_list)) {
+	while (!dlist_empty(&peer->rma_rx_list)) {
 		dlist_pop_front(&peer->rma_rx_list, struct rxd_x_entry,
 				x_entry, entry);
 		rxd_tx_entry_free(ep, x_entry);
@@ -670,6 +670,9 @@ static int rxd_ep_close(struct fid *fid)
 
 	dlist_foreach_container(&ep->active_peers, struct rxd_peer, peer, entry)
 		rxd_close_peer(ep, peer);
+	dlist_foreach_container(&ep->rts_sent_list, struct rxd_peer, peer, entry)
+		rxd_close_peer(ep, peer);
+	ofi_idm_reset(&(ep->peers_idm), free);
 
 	ret = fi_close(&ep->dg_ep->fid);
 	if (ret)
@@ -696,7 +699,6 @@ static int rxd_ep_close(struct fid *fid)
 		ofi_buf_free(pkt_entry);
 	}
 
-	ofi_idm_reset(&(ep->peers_idm), free);
 	rxd_ep_free_res(ep);
 	ofi_endpoint_close(&ep->util_ep);
 	free(ep);


### PR DESCRIPTION
When removing an address from the AV, the rxd
address/dg address should not be removed as well.
This is because the EP could still be communicating
with a peer for an outstanding transfer (or a retry).

If removed and reinserted, rxd will handle the duplicate
rxd address and map it accordingly.

This fixes a rare failure with the fi_av_xfer test which
is caused by a race condition where a peer tries to send
a retry or ACK after the address was removed from the AV.

Signed-off-by: aingerson <alexia.ingerson@intel.com>