### PR TITLE
prov/shm: fix issues reported by coverity

### DIFF
--- a/prov/shm/src/smr_av.c
+++ b/prov/shm/src/smr_av.c
@@ -73,6 +73,7 @@ static int smr_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 
 	for (i = 0; i < count; i++, addr = (char *) addr + strlen(addr) + 1) {
 		if (smr_av->used < SMR_MAX_PEERS) {
+			util_addr = FI_ADDR_NOTAVAIL;
 			ep_name = smr_no_prefix(addr);
 			ret = smr_map_add(&smr_prov, smr_av->smr_map,
 					  ep_name, &shm_id);
@@ -86,7 +87,6 @@ static int smr_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 			FI_WARN(&smr_prov, FI_LOG_AV,
 				"AV insert failed. The maximum number of AV "
 				"entries shm supported has been reached.\n");
-			util_addr = FI_ADDR_NOTAVAIL;
 			ret = -FI_ENOMEM;
 		}
 

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -545,7 +545,7 @@ void smr_format_sar(struct smr_cmd *cmd, enum fi_hmem_iface iface, uint64_t devi
 	sar_msg->sar[0].status = SMR_SAR_FREE;
 	sar_msg->sar[1].status = SMR_SAR_FREE;
 	if (cmd->msg.hdr.op != ofi_op_read_req)
-		smr_copy_to_sar(sar_msg, NULL, cmd, iface, device ,iov, count,
+		smr_copy_to_sar(sar_msg, resp, cmd, iface, device ,iov, count,
 				&pending->bytes_done, &pending->next);
 }
 
@@ -764,7 +764,7 @@ static int smr_recvmsg_fd(int sock, int64_t *peer_id, int *fds, int nfds)
 	cmsg = CMSG_FIRSTHDR(&msg);
 	assert(cmsg && cmsg->cmsg_len == CMSG_LEN(ctrl_size) &&
 	       cmsg->cmsg_level == SOL_SOCKET &&
-	       cmsg->cmsg_type == SCM_RIGHTS);
+	       cmsg->cmsg_type == SCM_RIGHTS && CMSG_DATA(cmsg));
 	memcpy(fds, CMSG_DATA(cmsg), ctrl_size);
 out:
 	free(ctrl_buf);


### PR DESCRIPTION
- on av_insert, is smr_map_add fails, util_addr will be uninitialized
  initialize to FI_ADDR_UNSPEC before every insert
- pass resp in to smr_copy_to_sar on smr_format_sar even though it is not needed
  to make coverity happy
- add CMSG_DATA to assert in socket code to surpress coverity warning

Signed-off-by: aingerson <alexia.ingerson@intel.com>