### PR TITLE
prov/shm: fix communication with peer that was restarted

### DIFF
--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -200,6 +200,7 @@ static void smr_send_name(struct smr_ep *ep, int64_t id)
 
 	cmd->msg.hdr.op = SMR_OP_MAX + ofi_ctrl_connreq;
 	cmd->msg.hdr.id = id;
+	cmd->msg.hdr.data = ep->region->pid;
 
 	tx_buf = smr_freestack_pop(smr_inject_pool(peer_smr));
 	cmd->msg.hdr.src_data = smr_get_offset(peer_smr, tx_buf);

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -689,8 +689,14 @@ static void smr_progress_connreq(struct smr_ep *ep, struct smr_cmd *cmd)
 
 	peer_smr = smr_peer_region(ep->region, idx);
 
+	if (peer_smr->pid != (int) cmd->msg.hdr.data) {
+		//TODO track and update/complete in error any transfers
+		//to or from old mapping
+		munmap(peer_smr, peer_smr->total_size);
+		smr_map_to_region(&smr_prov, &ep->region->map->peers[idx]);
+		peer_smr = smr_peer_region(ep->region, idx);
+	}
 	smr_peer_data(peer_smr)[cmd->msg.hdr.id].addr.id = idx;
-
 	smr_peer_data(ep->region)[idx].addr.id = cmd->msg.hdr.id;
 
 	smr_freestack_push(smr_inject_pool(ep->region), tx_buf);


### PR DESCRIPTION
If a peer was restarted, the server needs to remap the region to
update the smr pointer. Otherwise, the persistent peer will update the
local pointer and not the actual peer.
To recognize if the peer has been restarted or not, send the PID in the
send_name protocol (exchanges smr region on the first send). If the
PID is different than the one currently mapped in the pointer, unlink
the old region and remap to an updated pointer.
To fully fix this, we also need to track and update outstanding transfers
to and from the peer to either resend or complete in error. Adding TODO for this.

Signed-off-by: aingerson <alexia.ingerson@intel.com>