### PR TITLE
Nroff Elves: update their contract

### DIFF
--- a/.github/workflows/nroff-elves.sh
+++ b/.github/workflows/nroff-elves.sh
@@ -2,6 +2,44 @@
 
 set -euxo pipefail
 
+# Only do anything meaningful in the main ofiwg/libfabric repo.  If
+# we're not in that repo, then don't do anything because it confuses
+# people who fork the libfabric repo if Nroff Elves commits show up in
+# their fork with different git hashes than the Nroff Elves commits on
+# the ofiwg/libfabric repo.
+if test -n "$REPO"; then
+    first=`echo $REPO | cut -d/ -f1`
+    second=`echo $REPO | cut -d/ -f2`
+
+    if test "$first" != "ofiwg" -o "$second" != "libfabric"; then
+        cat <<EOF
+
+The Nroff Elves are contractually obligated to only operate on the
+ofiwg/libfabric repository.
+
+Exiting without doing anything.
+
+EOF
+        exit 0
+    fi
+fi
+
+# In June of 2021, ofiwg/libfabric changed its default branch from
+# "master" to "main".  This confuses "hub" (because it still falls
+# back to "master" when it can't figure out the target branch name).
+# In nroff-elves.yaml, we load $BASE_REPO with
+# ${{github.event.repository.default_branch}} and use that to tell
+# "hub" what the base branch should be.  This works great... except
+# sometimes $BASE_REPO is blank (when it should have a valid branch
+# name in it).  So if we get here and $BASE_REPO is blank, just assume
+# that it should be "main".  This is lame and shouldn't be necessary,
+# but it prevents us all from getting Github Action failure emails.
+# Sigh.
+if test -z "$BASE_REF"; then
+    BASE_REF=main
+fi
+
+# If we're here, we want to generate some nroff.  Woo hoo!
 for file in `ls man/*.md`; do
     perl config/md2nroff.pl --source=$file
 done

--- a/.github/workflows/nroff-elves.yaml
+++ b/.github/workflows/nroff-elves.yaml
@@ -2,7 +2,7 @@ name: GitHub Action Schedule
 
 on:
   schedule:
-    - cron: '*/15 * * * *'
+    - cron: '0 * * * *'
   workflow_dispatch:
 
 jobs:
@@ -10,6 +10,13 @@ jobs:
         name: The Nroff Elves
         runs-on: ubuntu-latest
         steps:
+          - name: Debug information
+            env:
+              GITHUB_DATA: ${{ toJSON(github) }}
+            run: |
+              echo This is information that may be useful for debugging.
+              echo "$GITHUB_DATA"
+
           - name: Check out the git repo
             uses: actions/checkout@v2
 
@@ -20,4 +27,5 @@ jobs:
             run: .github/workflows/nroff-elves.sh
             env:
               GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              REPO: ${{ github.event.repository.full_name }}
               BASE_REF: ${{ github.event.repository.default_branch }}


### PR DESCRIPTION
The Nroff Elves have been unhappy recently.  Make a few changes:

* Only run once an hour.  When failures happen, we don't need to get
  emails every 15 minutes.  Plus, the Elves only do something
  meaningful when a PR is merged with man pages updates, which doesn't
  happen that often.
* Emit the entire JSON-ized ${{github}} token in the GitHub Action
  logs.  The latest failure is that somehow
  ${{github.event.repository.default_branch}} is blank when running in
  the ofiwg/libfabric repo (but not forks, for some reason).  Since
  the Nroff Elves run on a cron schedule (and not a PR), you can't
  just make a PR with the changes that you want to debug/test (e.g.,
  emit ${{github.event.repository.default_branch}} to see what's going
  wrong).  So add an emit of the entire ${{github}} blob to the job
  that we run on the cron schedule so that we can see what is going
  wrong -- both for this current failure and for potential future
  failures.
* Only have the Nroff Elves do meaningful work on the ofiwg/libfabric
  repository.  If users have forks of the libfabric repo and update
  their branches with (un)lucky timing, they may get confused as to
  why new Nroff Elves commits show up on their fork that have a
  different commit hash than the Nroff Elves commits on the
  ofiwg/libfabric repo.
* As a fallback, if ${{github.event.repository.default_branch}} is
  blank for some reason, just assume that it should be "main".  This
  is lame and shouldn't be necessary, but it should fix the current
  failure scenario.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>