### PR TITLE
prov/efa: Handle FI_ADDR_NOTAVAIL in rxr_ep_get_peer and add assertion against returned peer

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -558,6 +558,10 @@ struct rdm_peer *rxr_ep_get_peer(struct rxr_ep *ep, fi_addr_t addr)
 {
 	struct util_av_entry *util_av_entry;
 	struct efa_av_entry *av_entry;
+
+	if (OFI_UNLIKELY(addr == FI_ADDR_NOTAVAIL))
+		return NULL;
+
 	util_av_entry = ofi_bufpool_get_ibuf(ep->util_ep.av->av_entry_pool,
 	                                     addr);
 	av_entry = (struct efa_av_entry *)util_av_entry->data;

--- a/prov/efa/src/rxr/rxr_atomic.c
+++ b/prov/efa/src/rxr/rxr_atomic.c
@@ -140,6 +140,7 @@ ssize_t rxr_atomic_generic_efa(struct rxr_ep *rxr_ep,
 	}
 
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
+	assert(peer);
 
 	if (peer->flags & RXR_PEER_IN_BACKOFF) {
 		err = -FI_EAGAIN;
@@ -230,6 +231,7 @@ rxr_atomic_inject(struct fid_ep *ep,
 
 	rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid.fid);
 	peer = rxr_ep_get_peer(rxr_ep, dest_addr);
+	assert(peer);
 	if (peer->is_local) {
 		assert(rxr_ep->use_shm);
 		if (!(shm_info->domain_attr->mr_mode & FI_MR_VIRT_ADDR))
@@ -278,6 +280,7 @@ rxr_atomic_writemsg(struct fid_ep *ep,
 
 	rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid.fid);
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
+	assert(peer);
 	if (peer->is_local) {
 		assert(rxr_ep->use_shm);
 		rxr_atomic_init_shm_msg(&shm_msg, msg, rma_iov, shm_desc);
@@ -352,6 +355,7 @@ rxr_atomic_readwritemsg(struct fid_ep *ep,
 
 	rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid.fid);
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
+	assert(peer);
 	if (peer->is_local) {
 		assert(rxr_ep->use_shm);
 		rxr_atomic_init_shm_msg(&shm_msg, msg, shm_rma_iov, shm_desc);
@@ -435,6 +439,7 @@ rxr_atomic_compwritemsg(struct fid_ep *ep,
 
 	rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid.fid);
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
+	assert(peer);
 	if (peer->is_local) {
 		assert(rxr_ep->use_shm);
 		rxr_atomic_init_shm_msg(&shm_msg, msg, shm_rma_iov, shm_desc);

--- a/prov/efa/src/rxr/rxr_cq.c
+++ b/prov/efa/src/rxr/rxr_cq.c
@@ -241,6 +241,7 @@ static inline void rxr_cq_queue_pkt(struct rxr_ep *ep,
 	struct rdm_peer *peer;
 
 	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
+	assert(peer);
 
 	/*
 	 * Queue the packet if it has not been retransmitted yet.
@@ -317,10 +318,10 @@ int rxr_cq_handle_error(struct rxr_ep *ep, ssize_t prov_errno, struct rxr_pkt_en
 	 * writing an error completion or event to the application.
 	 */
 	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
+	assert(peer);
 	if (rxr_get_base_hdr(pkt_entry->pkt)->type == RXR_HANDSHAKE_PKT) {
 		FI_WARN(&rxr_prov, FI_LOG_CQ,
 			"Squelching error CQE for RXR_HANDSHAKE_PKT\n");
-		assert(peer);
 		rxr_ep_dec_tx_pending(ep, peer, 1);
 		rxr_pkt_entry_release_tx(ep, pkt_entry);
 		return 0;
@@ -774,6 +775,7 @@ void rxr_cq_handle_tx_completion(struct rxr_ep *ep, struct rxr_tx_entry *tx_entr
 		dlist_remove(&tx_entry->entry);
 
 	peer = rxr_ep_get_peer(ep, tx_entry->addr);
+	assert(peer);
 	peer->tx_credits += tx_entry->credit_allocated;
 
 	if (tx_entry->cq_entry.flags & FI_READ) {

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -105,6 +105,7 @@ struct rxr_rx_entry *rxr_ep_alloc_rx_entry(struct rxr_ep *ep, fi_addr_t addr, ui
 	rx_entry->addr = addr;
 	if (addr != FI_ADDR_UNSPEC) {
 		rx_entry->peer = rxr_ep_get_peer(ep, addr);
+		assert(rx_entry->peer);
 		ofi_atomic_inc32(&rx_entry->peer->use_cnt);
 	} else {
 		/*
@@ -251,6 +252,7 @@ void rxr_tx_entry_init(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
 	tx_entry->state = RXR_TX_REQ;
 	tx_entry->addr = msg->addr;
 	tx_entry->peer = rxr_ep_get_peer(ep, tx_entry->addr);
+	assert(tx_entry->peer);
 	ofi_atomic_inc32(&tx_entry->peer->use_cnt);
 
 	tx_entry->send_flags = 0;
@@ -481,6 +483,7 @@ int rxr_ep_set_tx_credit_request(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_
 	int pending;
 
 	peer = rxr_ep_get_peer(rxr_ep, tx_entry->addr);
+	assert(peer);
 
 	/*
 	 * Init tx state for this peer. The rx state and reorder buffers will be
@@ -1583,6 +1586,7 @@ void rxr_ep_progress_internal(struct rxr_ep *ep)
 				     struct rxr_rx_entry,
 				     rx_entry, queued_entry, tmp) {
 		peer = rxr_ep_get_peer(ep, rx_entry->addr);
+		assert(peer);
 
 		if (peer->flags & RXR_PEER_IN_BACKOFF)
 			continue;
@@ -1614,6 +1618,7 @@ void rxr_ep_progress_internal(struct rxr_ep *ep)
 				     struct rxr_tx_entry,
 				     tx_entry, queued_entry, tmp) {
 		peer = rxr_ep_get_peer(ep, tx_entry->addr);
+		assert(peer);
 
 		if (peer->flags & RXR_PEER_IN_BACKOFF)
 			continue;
@@ -1658,6 +1663,7 @@ void rxr_ep_progress_internal(struct rxr_ep *ep)
 	dlist_foreach_container(&ep->tx_pending_list, struct rxr_tx_entry,
 				tx_entry, entry) {
 		peer = rxr_ep_get_peer(ep, tx_entry->addr);
+		assert(peer);
 
 		if (peer->flags & RXR_PEER_IN_BACKOFF)
 			continue;
@@ -1697,6 +1703,7 @@ void rxr_ep_progress_internal(struct rxr_ep *ep)
 	dlist_foreach_container_safe(&ep->read_pending_list, struct rxr_read_entry,
 				     read_entry, pending_entry, tmp) {
 		peer = rxr_ep_get_peer(ep, read_entry->addr);
+		assert(peer);
 
 		if (peer->flags & RXR_PEER_IN_BACKOFF)
 			continue;

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -87,6 +87,7 @@ ssize_t rxr_msg_post_cuda_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_ent
 	 * from the receiver, so here we call rxr_pkt_wait_handshake().
 	 */
 	peer = rxr_ep_get_peer(rxr_ep, tx_entry->addr);
+	assert(peer);
 
 	err = rxr_pkt_wait_handshake(rxr_ep, tx_entry->addr, peer);
 	if (OFI_UNLIKELY(err)) {
@@ -140,6 +141,7 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 	else
 		delivery_complete_requested = tx_entry->fi_flags & FI_DELIVERY_COMPLETE;
 	peer = rxr_ep_get_peer(rxr_ep, tx_entry->addr);
+	assert(peer);
 
 	if (delivery_complete_requested && !(peer->is_local)) {
 		tx_entry->rxr_flags |= RXR_DELIVERY_COMPLETE_REQUESTED;
@@ -296,6 +298,7 @@ ssize_t rxr_msg_generic_send(struct fid_ep *ep, const struct fi_msg *msg,
 	}
 
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
+	assert(peer);
 
 	if (peer->flags & RXR_PEER_IN_BACKOFF) {
 		err = -FI_EAGAIN;

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -302,6 +302,7 @@ ssize_t rxr_pkt_post_ctrl_once(struct rxr_ep *rxr_ep, int entry_type, void *x_en
 	}
 
 	peer = rxr_ep_get_peer(rxr_ep, addr);
+	assert(peer);
 	if (peer->is_local) {
 		assert(rxr_ep->use_shm);
 		pkt_entry = rxr_pkt_entry_alloc(rxr_ep, rxr_ep->tx_pkt_shm_pool);
@@ -503,6 +504,7 @@ ssize_t rxr_pkt_trigger_handshake(struct rxr_ep *ep,
 	tx_entry->total_len = 0;
 	tx_entry->addr = addr;
 	tx_entry->peer = rxr_ep_get_peer(ep, tx_entry->addr);
+	assert(tx_entry->peer);
 	ofi_atomic_inc32(&tx_entry->peer->use_cnt);
 	tx_entry->msg_id = -1;
 	tx_entry->cq_entry.flags = FI_RMA | FI_WRITE;
@@ -772,6 +774,7 @@ void rxr_pkt_handle_send_completion(struct rxr_ep *ep, struct rxr_pkt_entry *pkt
 	}
 
 	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
+	assert(peer);
 	if (!peer->is_local)
 		rxr_ep_dec_tx_pending(ep, peer, 0);
 	rxr_pkt_entry_release_tx(ep, pkt_entry);
@@ -863,6 +866,7 @@ void rxr_pkt_handle_recv_completion(struct rxr_ep *ep,
 #endif
 #endif
 	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
+	assert(peer);
 	if (!(peer->flags & RXR_PEER_HANDSHAKE_SENT_OR_QUEUED))
 		rxr_pkt_post_handshake_or_queue(ep, peer);
 

--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -130,6 +130,7 @@ void rxr_pkt_entry_release_tx(struct rxr_ep *ep,
 	 */
 	if (OFI_UNLIKELY(pkt->state == RXR_PKT_ENTRY_RNR_RETRANSMIT)) {
 		peer = rxr_ep_get_peer(ep, pkt->addr);
+		assert(peer);
 		peer->rnr_queued_pkt_cnt--;
 		peer->timeout_interval = 0;
 		peer->rnr_timeout_exp = 0;
@@ -173,6 +174,7 @@ void rxr_pkt_entry_release_rx(struct rxr_ep *ep,
 		struct rdm_peer *peer;
 
 		peer = rxr_ep_get_peer(ep, pkt_entry->addr);
+		assert(peer);
 
 		if (peer->is_local)
 			ep->rx_bufs_shm_to_post++;
@@ -334,11 +336,13 @@ ssize_t rxr_pkt_entry_sendmsg(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry
 	struct rdm_peer *peer;
 	size_t ret;
 
-	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
 	assert(ep->tx_pending <= ep->max_outstanding_tx);
 
 	if (ep->tx_pending == ep->max_outstanding_tx)
 		return -FI_EAGAIN;
+
+	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
+	assert(peer);
 
 	if (peer->flags & RXR_PEER_IN_BACKOFF)
 		return -FI_EAGAIN;
@@ -381,6 +385,7 @@ ssize_t rxr_pkt_entry_send(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry,
 	struct rdm_peer *peer;
 
 	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
+	assert(peer);
 
 	if (pkt_entry->send && pkt_entry->send->iov_count > 0) {
 		msg.msg_iov = pkt_entry->send->iov;
@@ -415,6 +420,7 @@ ssize_t rxr_pkt_entry_inject(struct rxr_ep *ep,
 
 	/* currently only EOR packet is injected using shm ep */
 	peer = rxr_ep_get_peer(ep, addr);
+	assert(peer);
 
 	assert(ep->use_shm && peer->is_local);
 	return fi_inject(ep->shm_ep, rxr_pkt_start(pkt_entry), pkt_entry->pkt_size,

--- a/prov/efa/src/rxr/rxr_pkt_type_data.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_data.c
@@ -296,6 +296,7 @@ void rxr_pkt_proc_data(struct rxr_ep *ep,
 	all_received = (rx_entry->bytes_received == rx_entry->total_len);
 
 	peer = rxr_ep_get_peer(ep, rx_entry->addr);
+	assert(peer);
 	peer->rx_credits += ofi_div_ceil(seg_size, ep->max_data_payload_size);
 
 	rx_entry->window -= seg_size;

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -144,6 +144,7 @@ void rxr_pkt_handle_handshake_recv(struct rxr_ep *ep,
 	assert(pkt_entry->addr != FI_ADDR_NOTAVAIL);
 
 	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
+	assert(peer);
 	assert(!(peer->flags & RXR_PEER_HANDSHAKE_RECEIVED));
 
 	handshake_pkt = (struct rxr_handshake_hdr *)pkt_entry->pkt;
@@ -213,6 +214,7 @@ ssize_t rxr_pkt_init_cts(struct rxr_ep *ep,
 
 	bytes_left = rx_entry->total_len - rx_entry->bytes_received;
 	peer = rxr_ep_get_peer(ep, rx_entry->addr);
+	assert(peer);
 	rxr_pkt_calc_cts_window_credits(ep, peer, bytes_left,
 					rx_entry->credit_request,
 					&window, &rx_entry->credit_cts);
@@ -260,8 +262,10 @@ void rxr_pkt_handle_cts_recv(struct rxr_ep *ep,
 	/* Return any excess tx_credits that were borrowed for the request */
 	peer = rxr_ep_get_peer(ep, tx_entry->addr);
 	tx_entry->credit_allocated = ofi_div_ceil(cts_pkt->window, ep->max_data_payload_size);
-	if (tx_entry->credit_allocated < tx_entry->credit_request)
+	if (tx_entry->credit_allocated < tx_entry->credit_request) {
+		assert(peer);
 		peer->tx_credits += tx_entry->credit_request - tx_entry->credit_allocated;
+	}
 
 	rxr_pkt_entry_release_rx(ep, pkt_entry);
 
@@ -456,6 +460,7 @@ void rxr_pkt_handle_rma_read_completion(struct rxr_ep *ep,
 		ep->tx_pending--;
 	} else {
 		peer = rxr_ep_get_peer(ep, context_pkt_entry->addr);
+		assert(peer);
 		if (!peer->is_local)
 			rxr_ep_dec_tx_pending(ep, peer, 0);
 	}

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -118,6 +118,7 @@ void rxr_pkt_init_req_hdr(struct rxr_ep *ep,
 	base_hdr->flags = 0;
 
 	peer = rxr_ep_get_peer(ep, tx_entry->addr);
+	assert(peer);
 
 	if (OFI_UNLIKELY(!(peer->flags & RXR_PEER_HANDSHAKE_RECEIVED))) {
 		/*
@@ -272,6 +273,7 @@ size_t rxr_pkt_req_max_data_size(struct rxr_ep *ep, fi_addr_t addr, int pkt_type
 	struct rdm_peer *peer;
 
 	peer = rxr_ep_get_peer(ep, addr);
+	assert(peer);
 
 	if (peer->is_local) {
 		assert(ep->use_shm);
@@ -994,6 +996,7 @@ ssize_t rxr_pkt_proc_matched_rtm(struct rxr_ep *ep,
 	if (!rx_entry->peer) {
 		rx_entry->addr = pkt_entry->addr;
 		rx_entry->peer = rxr_ep_get_peer(ep, rx_entry->addr);
+		assert(rx_entry->peer);
 		ofi_atomic_inc32(&rx_entry->peer->use_cnt);
 	}
 
@@ -1256,6 +1259,7 @@ void rxr_pkt_handle_rtm_rta_recv(struct rxr_ep *ep,
 
 	need_ordering = false;
 	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
+	assert(peer);
 
 	if (!peer->is_local) {
 		/*

--- a/prov/efa/src/rxr/rxr_read.c
+++ b/prov/efa/src/rxr/rxr_read.c
@@ -353,6 +353,7 @@ int rxr_read_post_remote_read_or_queue(struct rxr_ep *ep, int entry_type, void *
 		assert(entry_type == RXR_RX_ENTRY);
 		peer = rxr_ep_get_peer(ep, ((struct rxr_rx_entry *)x_entry)->addr);
 	}
+	assert(peer);
 
 	lower_ep_type = (peer->is_local) ? SHM_EP : EFA_EP;
 	read_entry = rxr_read_alloc_entry(ep, entry_type, x_entry, lower_ep_type);
@@ -449,6 +450,7 @@ int rxr_read_init_iov(struct rxr_ep *ep,
 		if (!tx_entry->mr[0]) {
 			for (i = 0; i < tx_entry->iov_count; ++i) {
 				assert(!tx_entry->mr[i]);
+				assert(peer);
 
 				if (peer->is_local)
 					err = efa_mr_reg_shm(rxr_ep_domain(ep)->rdm_domain,
@@ -511,8 +513,10 @@ int rxr_read_post(struct rxr_ep *ep, struct rxr_read_entry *read_entry)
 
 	peer = rxr_ep_get_peer(ep, read_entry->addr);
 
-	if (read_entry->lower_ep_type == SHM_EP)
+	if (read_entry->lower_ep_type == SHM_EP) {
+		assert(peer);
 		shm_fiaddr = peer->shm_fiaddr;
+	}
 
 	max_read_size = (read_entry->lower_ep_type == EFA_EP) ?
 				efa_max_rdma_size(ep->rdm_ep) : SIZE_MAX;
@@ -596,6 +600,7 @@ int rxr_read_post(struct rxr_ep *ep, struct rxr_read_entry *read_entry)
 			/* read from self, no peer */
 			ep->tx_pending++;
 		} else if (read_entry->lower_ep_type == EFA_EP) {
+			assert(peer);
 			rxr_ep_inc_tx_pending(ep, peer);
 		}
 

--- a/prov/efa/src/rxr/rxr_read.c
+++ b/prov/efa/src/rxr/rxr_read.c
@@ -511,9 +511,8 @@ int rxr_read_post(struct rxr_ep *ep, struct rxr_read_entry *read_entry)
 			return ret;
 	}
 
-	peer = rxr_ep_get_peer(ep, read_entry->addr);
-
 	if (read_entry->lower_ep_type == SHM_EP) {
+		peer = rxr_ep_get_peer(ep, read_entry->addr);
 		assert(peer);
 		shm_fiaddr = peer->shm_fiaddr;
 	}
@@ -600,6 +599,7 @@ int rxr_read_post(struct rxr_ep *ep, struct rxr_read_entry *read_entry)
 			/* read from self, no peer */
 			ep->tx_pending++;
 		} else if (read_entry->lower_ep_type == EFA_EP) {
+			peer = rxr_ep_get_peer(ep, read_entry->addr);
 			assert(peer);
 			rxr_ep_inc_tx_pending(ep, peer);
 		}

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -170,6 +170,7 @@ size_t rxr_rma_post_shm_write(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_ent
 
 	assert(tx_entry->op == ofi_op_write);
 	peer = rxr_ep_get_peer(rxr_ep, tx_entry->addr);
+	assert(peer);
 	pkt_entry = rxr_pkt_entry_alloc(rxr_ep, rxr_ep->tx_pkt_shm_pool);
 	if (OFI_UNLIKELY(!pkt_entry))
 		return -FI_EAGAIN;
@@ -269,6 +270,7 @@ ssize_t rxr_rma_post_efa_emulated_read(struct rxr_ep *ep, struct rxr_tx_entry *t
 		err = rxr_pkt_post_ctrl(ep, RXR_TX_ENTRY, tx_entry, RXR_SHORT_RTR_PKT, 0);
 	} else {
 		peer = rxr_ep_get_peer(ep, tx_entry->addr);
+		assert(peer);
 
 		rxr_pkt_calc_cts_window_credits(ep, peer,
 						tx_entry->total_len,
@@ -318,6 +320,7 @@ ssize_t rxr_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uint64_
 	}
 
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
+	assert(peer);
 
 	if (peer->flags & RXR_PEER_IN_BACKOFF) {
 		err = -FI_EAGAIN;
@@ -415,6 +418,7 @@ ssize_t rxr_rma_post_write(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry)
 				  util_domain.domain_fid);
 
 	peer = rxr_ep_get_peer(ep, tx_entry->addr);
+	assert(peer);
 
 	if (peer->is_local)
 		return rxr_rma_post_shm_write(ep, tx_entry);
@@ -505,6 +509,7 @@ ssize_t rxr_rma_writemsg(struct fid_ep *ep,
 	fastlock_acquire(&rxr_ep->util_ep.lock);
 
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
+	assert(peer);
 
 	if (peer->flags & RXR_PEER_IN_BACKOFF) {
 		err = -FI_EAGAIN;


### PR DESCRIPTION
12ad455 Handle FI_ADDR_NOTAVAIL in rxr_ep_get_peer
25ddc04e9c6478c60b6d5cb9b2c08b98094aa720 Add assertion for peer structure
5a840a7d84816e83530e46b996f036cfcb69f998 Do not call rxr_ep_get_peer for local read 