### PR TITLE
Move fi_param_get, fi_param_define documentation to fi_provider(3)

### DIFF
--- a/include/rdma/providers/fi_prov.h
+++ b/include/rdma/providers/fi_prov.h
@@ -76,14 +76,6 @@ struct fi_provider {
 
 /*
  * Defines a configuration parameter for use with libfabric.
- *
- * This registers the configuration variable "foo" in the specified
- * provider.
- *
- * The help string cannot be NULL or empty.
- *
- * The param_name and help_string parameters will be copied internally;
- * they can be freed upon return from fi_param_define().
  */
 int fi_param_define(const struct fi_provider *provider, const char *param_name,
 		    enum fi_param_type type, const char *help_string_fmt, ...);
@@ -92,22 +84,8 @@ int fi_param_define(const struct fi_provider *provider, const char *param_name,
  * Get the value of a configuration variable.
  *
  * Currently, configuration parameter will only be read from the
- * environment.  The environment variable names will be of the form
- * upper_case(FI_<provider_name>_<param_name>).
- *
- * Someday this call could be expanded to also check config files.
- *
- * If the parameter was previously defined and the user set a value,
- * FI_SUCCESS is returned and (*value) points to the retrieved
- * value.
- *
- * If the parameter name was previously defined, but the user did
- * not set a value, -FI_ENODATA is returned and the value of (*value)
- * is unchanged.
- *
- * If the variable name was not previously defined via
- * fi_param_define(), -FI_ENOENT will be returned and the value of
- * (*value) is unchanged.
+ * environment. Someday this call could be expanded to also check
+ * config files.
  */
 int fi_param_get(struct fi_provider *provider, const char *param_name,
 		 void *value);

--- a/man/fi_provider.3.md
+++ b/man/fi_provider.3.md
@@ -127,9 +127,33 @@ fi_provider structure.  Additional interactions between the libfabric
 core and the provider will be through the interfaces defined by that
 struct.
 
-## fi_param_define / fi_param_get
+## fi_param_define
 
-TODO
+Defines a configuration parameter for use by a specified provider. The
+help_string and param_name arguments must be non-NULL, help_string
+must additionally be non-empty. They are copied internally and may be
+freed after calling fi_param_define.
+
+## fi_param_get
+
+Gets the value of a configuration parameter previously defined using
+fi_param_define(). The value comes from the environment variable name of
+the form FI_<provider_name>_<param_name>, all converted to upper case.
+
+If the parameter was previously defined and the user set a value,
+FI_SUCCESS is returned and (*value) points to the retrieved
+value.
+
+If the parameter name was previously defined, but the user did
+not set a value, -FI_ENODATA is returned and the value of (*value)
+is unchanged.
+
+If the parameter name was not previously defined via
+fi_param_define(), -FI_ENOENT will be returned and the value of
+(*value) is unchanged.
+
+If the value in the environment is not valid for the parameter type,
+-FI_EINVAL will be returned.
 
 ## fi_log_enabled / fi_log
 


### PR DESCRIPTION
Moved documentation to recently created man page, adds missing information about possible return value (-FI_EINVAL) in fi_param_get.

Addresses documentation issue brought up in #6853

Signed-off-by: Peter Gottesman <pgottes@amazon.com>