### PR TITLE
Fix fi_param_get's behavior when parsing an invalid boolean value

### DIFF
--- a/include/rdma/providers/fi_prov.h
+++ b/include/rdma/providers/fi_prov.h
@@ -76,14 +76,6 @@ struct fi_provider {
 
 /*
  * Defines a configuration parameter for use with libfabric.
- *
- * This registers the configuration variable "foo" in the specified
- * provider.
- *
- * The help string cannot be NULL or empty.
- *
- * The param_name and help_string parameters will be copied internally;
- * they can be freed upon return from fi_param_define().
  */
 int fi_param_define(const struct fi_provider *provider, const char *param_name,
 		    enum fi_param_type type, const char *help_string_fmt, ...);
@@ -92,22 +84,8 @@ int fi_param_define(const struct fi_provider *provider, const char *param_name,
  * Get the value of a configuration variable.
  *
  * Currently, configuration parameter will only be read from the
- * environment.  The environment variable names will be of the form
- * upper_case(FI_<provider_name>_<param_name>).
- *
- * Someday this call could be expanded to also check config files.
- *
- * If the parameter was previously defined and the user set a value,
- * FI_SUCCESS is returned and (*value) points to the retrieved
- * value.
- *
- * If the parameter name was previously defined, but the user did
- * not set a value, -FI_ENODATA is returned and the value of (*value)
- * is unchanged.
- *
- * If the variable name was not previously defined via
- * fi_param_define(), -FI_ENOENT will be returned and the value of
- * (*value) is unchanged.
+ * environment. Someday this call could be expanded to also check
+ * config files.
  */
 int fi_param_get(struct fi_provider *provider, const char *param_name,
 		 void *value);

--- a/man/fi_provider.3.md
+++ b/man/fi_provider.3.md
@@ -127,9 +127,33 @@ fi_provider structure.  Additional interactions between the libfabric
 core and the provider will be through the interfaces defined by that
 struct.
 
-## fi_param_define / fi_param_get
+## fi_param_define
 
-TODO
+Defines a configuration parameter for use by a specified provider. The
+help_string and param_name arguments must be non-NULL, help_string
+must additionally be non-empty. They are copied internally and may be
+freed after calling fi_param_define.
+
+## fi_param_get
+
+Gets the value of a configuration parameter previously defined using
+fi_param_define(). The value comes from the environment variable name of
+the form FI_<provider_name>_<param_name>, all converted to upper case.
+
+If the parameter was previously defined and the user set a value,
+FI_SUCCESS is returned and (*value) points to the retrieved
+value.
+
+If the parameter name was previously defined, but the user did
+not set a value, -FI_ENODATA is returned and the value of (*value)
+is unchanged.
+
+If the parameter name was not previously defined via
+fi_param_define(), -FI_ENOENT will be returned and the value of
+(*value) is unchanged.
+
+If the value in the environment is not valid for the parameter type,
+-FI_EINVAL will be returned.
 
 ## fi_log_enabled / fi_log
 

--- a/man/fi_provider.3.md
+++ b/man/fi_provider.3.md
@@ -153,7 +153,7 @@ fi_param_define(), -FI_ENOENT will be returned and the value of
 (*value) is unchanged.
 
 If the value in the environment is not valid for the parameter type,
--FI_EINVAL will be returned.
+-FI_EINVAL will be returned and the value of (*value) is unchanged.
 
 ## fi_log_enabled / fi_log
 

--- a/src/var.c
+++ b/src/var.c
@@ -258,6 +258,7 @@ int DEFAULT_SYMVER_PRE(fi_param_get)(struct fi_provider *provider,
 {
 	struct fi_param_entry *param;
 	char *str_value;
+	int parsed_boolean;
 	int ret = FI_SUCCESS;
 
 	if (!provider)
@@ -294,11 +295,17 @@ int DEFAULT_SYMVER_PRE(fi_param_get)(struct fi_provider *provider,
 			"read int var %s=%d\n", param_name, *(int *) value);
 		break;
 	case FI_PARAM_BOOL:
-		* ((int *) value) = fi_parse_bool(str_value);
+		parsed_boolean = fi_parse_bool(str_value);
+		if (parsed_boolean == -1) {
+			ret = -FI_EINVAL;
+			FI_WARN(provider, FI_LOG_CORE,
+					"failed to parse bool var %s=%s\n", param_name, str_value);
+			break;
+		}
+
+		* ((int *) value) = parsed_boolean;
 		FI_INFO(provider, FI_LOG_CORE,
 			"read bool var %s=%d\n", param_name, *(int *) value);
-		if (*(int *) value == -1)
-			ret = -FI_EINVAL;
 		break;
 	case FI_PARAM_SIZE_T:
 		* ((size_t *) value) = strtol(str_value, NULL, 0);


### PR DESCRIPTION
Previously an invalid environment var value for a boolean would result
in the default value being overwritten, this patch fixes that and
prevents the default value from being modified in that case.

Signed-off-by: Peter Gottesman <pgottes@amazon.com>

---

Based off of #6857, resolves #6853 