### PR TITLE
prov/shm: fix av_lookup

### DIFF
--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -210,6 +210,13 @@ struct smr_ep_name {
 	struct dlist_entry entry;
 };
 
+static inline const char *smr_no_prefix(const char *addr)
+{
+	char *start;
+
+	return (start = strstr(addr, "://")) ? start + 3 : addr;
+}
+
 struct smr_peer {
 	struct smr_addr		peer;
 	fi_addr_t		fiaddr;

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -217,13 +217,6 @@ struct smr_domain {
 
 #define SMR_ZE_SOCK_PATH	"/dev/shm/ze_"
 
-static inline const char *smr_no_prefix(const char *addr)
-{
-	char *start;
-
-	return (start = strstr(addr, "://")) ? start + 3 : addr;
-}
-
 #define SMR_RMA_ORDER (OFI_ORDER_RAR_SET | OFI_ORDER_RAW_SET | FI_ORDER_RAS |	\
 		       OFI_ORDER_WAR_SET | OFI_ORDER_WAW_SET | FI_ORDER_WAS |	\
 		       FI_ORDER_SAR | FI_ORDER_SAW)

--- a/prov/shm/src/smr_av.c
+++ b/prov/shm/src/smr_av.c
@@ -62,7 +62,6 @@ static int smr_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 	struct smr_av *smr_av;
 	struct smr_ep *smr_ep;
 	struct dlist_entry *av_entry;
-	const char *ep_name;
 	fi_addr_t util_addr;
 	int64_t shm_id = -1;
 	int i, ret;
@@ -74,9 +73,8 @@ static int smr_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 	for (i = 0; i < count; i++, addr = (char *) addr + strlen(addr) + 1) {
 		if (smr_av->used < SMR_MAX_PEERS) {
 			util_addr = FI_ADDR_NOTAVAIL;
-			ep_name = smr_no_prefix(addr);
 			ret = smr_map_add(&smr_prov, smr_av->smr_map,
-					  ep_name, &shm_id);
+					  addr, &shm_id);
 			if (!ret) {
 				fastlock_acquire(&util_av->lock);
 				ret = ofi_av_insert_addr(util_av, &shm_id,
@@ -162,21 +160,19 @@ static int smr_av_lookup(struct fid_av *av, fi_addr_t fi_addr, void *addr,
 {
 	struct util_av *util_av;
 	struct smr_av *smr_av;
-	struct smr_region *peer_smr;
 	int64_t id;
+	char *name;
 
 	util_av = container_of(av, struct util_av, av_fid);
 	smr_av = container_of(util_av, struct smr_av, util_av);
 
 	id = smr_addr_lookup(util_av, fi_addr);
-	peer_smr = smr_map_get(smr_av->smr_map, id);
+	name = smr_av->smr_map->peers[id].peer.name;
 
-	if (!peer_smr)
-		return -FI_ENODATA;
+	strncpy((char *) addr, name, *addrlen);
 
-	strncpy((char *)addr, smr_name(peer_smr), *addrlen);
-	((char *) addr)[MIN(*addrlen - 1, strlen(smr_name(peer_smr)))] = '\0';
-	*addrlen = strlen(smr_name(peer_smr) + 1);
+	((char *) addr)[MIN(*addrlen - 1, strlen(name))] = '\0';
+	*addrlen = strlen(name) + 1;
 	return 0;
 }
 

--- a/prov/util/src/util_shm.c
+++ b/prov/util/src/util_shm.c
@@ -352,10 +352,10 @@ int smr_map_to_region(const struct fi_provider *prov, struct smr_peer *peer_buf)
 	size_t size;
 	int fd, ret = 0;
 	struct dlist_entry *entry;
+	const char *name = smr_no_prefix(peer_buf->peer.name);
 
 	pthread_mutex_lock(&ep_list_lock);
-	entry = dlist_find_first_match(&ep_name_list, smr_match_name,
-				       peer_buf->peer.name);
+	entry = dlist_find_first_match(&ep_name_list, smr_match_name, name);
 	if (entry) {
 		peer_buf->region = container_of(entry, struct smr_ep_name,
 						entry)->region;
@@ -364,7 +364,7 @@ int smr_map_to_region(const struct fi_provider *prov, struct smr_peer *peer_buf)
 	}
 	pthread_mutex_unlock(&ep_list_lock);
 
-	fd = shm_open(peer_buf->peer.name, O_RDWR, S_IRUSR | S_IWUSR);
+	fd = shm_open(name, O_RDWR, S_IRUSR | S_IWUSR);
 	if (fd < 0) {
 		FI_WARN_ONCE(prov, FI_LOG_AV, "shm_open error\n");
 		return -errno;
@@ -489,7 +489,7 @@ void smr_map_del(struct smr_map *map, int64_t id)
 
 	pthread_mutex_lock(&ep_list_lock);
 	entry = dlist_find_first_match(&ep_name_list, smr_match_name,
-				       map->peers[id].peer.name);
+				       smr_no_prefix(map->peers[id].peer.name));
 	pthread_mutex_unlock(&ep_list_lock);
 
 	fastlock_acquire(&map->lock);


### PR DESCRIPTION
av_lookup was not working properly because it was returning the ep->region name,
not the name in the AV. This causes an issue if the EP has not been mapped yet.
since av_insert can succeed without the peer being mapped yet, av_lookup should
do the same.
This exposed other issues with address name storage inconsistencies. The name being
returned in fi_info->dst_addr/src_addr include the smr_prefix which means they
are being inserted into the AV with those prefixes. However, they were being
stored in the ep without the prefix, since the shm region name does not include
the prefix. This is confusing and causes issues.
This patch moves the prefix elimination to the shm util code since the only reason
it is being removed is because shm regions cannot have '/'s in them. All references
to the EP name in the shm provider that do not refer to the physical shm EP name
have been changed to include the prefix for consistency.

Signed-off-by: aingerson <alexia.ingerson@intel.com>