### PR TITLE
prov/efa: fix a bug in rxr_relase_rx_entry()

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -776,13 +776,26 @@ struct rxr_rx_entry *rxr_ep_alloc_rx_entry(struct rxr_ep *ep,
 static inline void rxr_release_rx_entry(struct rxr_ep *ep,
 					struct rxr_rx_entry *rx_entry)
 {
+	struct rxr_pkt_entry *pkt_entry;
+	struct dlist_entry *tmp;
+
 	if (rx_entry->peer)
 		ofi_atomic_dec32(&rx_entry->peer->use_cnt);
 
 #if ENABLE_DEBUG
 	dlist_remove(&rx_entry->rx_entry_entry);
 #endif
-	assert(dlist_empty(&rx_entry->queued_pkts));
+	if (!dlist_empty(&rx_entry->queued_pkts)) {
+		dlist_foreach_container_safe(&rx_entry->queued_pkts,
+					     struct rxr_pkt_entry,
+					     pkt_entry, entry, tmp) {
+			rxr_pkt_entry_release_tx(ep, pkt_entry);
+		}
+		dlist_remove(&rx_entry->queued_entry);
+	} else if (rx_entry->state == RXR_RX_QUEUED_CTRL) {
+		dlist_remove(&rx_entry->queued_entry);
+	}
+
 #ifdef ENABLE_EFA_POISONING
 	rxr_poison_mem_region((uint32_t *)rx_entry,
 			      sizeof(struct rxr_rx_entry));

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1717,6 +1717,15 @@ void rxr_ep_progress_internal(struct rxr_ep *ep)
 		if (OFI_UNLIKELY(ret))
 			goto rx_err;
 
+		/* it can happen that rxr_pkt_post_ctrl() released rx_entry
+		 * (if the packet type is EOR and inject is used). In
+		 * that case rx_entry's state has been set to RXR_RX_FREE and
+		 * it has been removed from ep->rx_queued_entry_list, so nothing
+		 * is left to do.
+		 */
+		if (rx_entry->state == RXR_RX_FREE)
+			continue;
+
 		dlist_remove(&rx_entry->queued_entry);
 		rx_entry->state = RXR_RX_RECV;
 	}


### PR DESCRIPTION
This patch fixes two bugs in rxr_release_rx_entry():

First, this function should clear rx_entry->queued_pkts but
did not.

Second, this function should remove rx_entry from ep->rx_queued_entry_list
but did not.

Meanwhile, rxr_ep_progress_internal() was adjusted to accomodate
the changes to rxr_release_rx_entry()

Signed-off-by: Wei Zhang <wzam@amazon.com>