### PR TITLE
[v1.12.x] prov/efa: backport 3 commits

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -217,6 +217,7 @@ struct rxr_env {
 	int shm_av_size;
 	int shm_max_medium_size;
 	int recvwin_size;
+	int ooo_pool_chunk_size;
 	int readcopy_pool_size;
 	int atomrsp_pool_size;
 	int cq_size;

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1214,14 +1214,10 @@ static int rxr_create_pkt_pool(struct rxr_ep *ep, size_t size,
 	return ofi_bufpool_create_attr(&attr, buf_pool);
 }
 
-/** @brief Initializes the endpoint and allocates the packet pools.
+/** @brief Initializes the endpoint.
  *
- * This function allocates the various packet pools for the EFA and SHM
+ * This function allocates the various buffer pools for the EFA and SHM
  * provider and does other endpoint initialization.
- *
- * Note that ofi_bufpool_create currently does lazy allocation, so memory is
- * not allocated here. Memory will be allocated the first time the pool is
- * used.
  *
  * @param ep rxr_ep struct to initialize.
  * @return 0 on success, fi_errno on error.
@@ -1262,6 +1258,14 @@ int rxr_ep_init(struct rxr_ep *ep)
 
 		if (ret)
 			goto err_free;
+
+		ret = ofi_bufpool_grow(ep->rx_unexp_pkt_pool);
+		if (ret) {
+			FI_WARN(&rxr_prov, FI_LOG_CQ,
+				"cannot allocate memory for unexpected packet pool. error: %s\n",
+				strerror(-ret));
+			goto err_free;
+		}
 	}
 
 	if (rxr_env.rx_copy_ooo) {
@@ -1271,6 +1275,14 @@ int rxr_ep_init(struct rxr_ep *ep)
 
 		if (ret)
 			goto err_free;
+
+		ret = ofi_bufpool_grow(ep->rx_ooo_pkt_pool);
+		if (ret) {
+			FI_WARN(&rxr_prov, FI_LOG_CQ,
+				"cannot allocate memory for out-of-order packet pool. error: %s\n",
+				strerror(-ret));
+			goto err_free;
+		}
 	}
 
 	if ((rxr_env.rx_copy_unexp || rxr_env.rx_copy_ooo) &&

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1706,6 +1706,15 @@ void rxr_ep_progress_internal(struct rxr_ep *ep)
 		if (OFI_UNLIKELY(ret))
 			goto rx_err;
 
+		/* it can happen that rxr_pkt_post_ctrl() released rx_entry
+		 * (if the packet type is EOR and inject is used). In
+		 * that case rx_entry's state has been set to RXR_RX_FREE and
+		 * it has been removed from ep->rx_queued_entry_list, so nothing
+		 * is left to do.
+		 */
+		if (rx_entry->state == RXR_RX_FREE)
+			continue;
+
 		dlist_remove(&rx_entry->queued_entry);
 		rx_entry->state = RXR_RX_RECV;
 	}

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1271,7 +1271,7 @@ int rxr_ep_init(struct rxr_ep *ep)
 	if (rxr_env.rx_copy_ooo) {
 		ret = ofi_bufpool_create(&ep->rx_ooo_pkt_pool, entry_sz,
 					 RXR_BUF_POOL_ALIGNMENT, 0,
-					 rxr_env.recvwin_size, 0);
+					 rxr_env.ooo_pool_chunk_size, 0);
 
 		if (ret)
 			goto err_free;

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -56,6 +56,7 @@ struct rxr_env rxr_env = {
 	.shm_av_size = 128,
 	.shm_max_medium_size = 4096,
 	.recvwin_size = RXR_RECVWIN_SIZE,
+	.ooo_pool_chunk_size = 64,
 	.readcopy_pool_size = 256,
 	.atomrsp_pool_size = 1024,
 	.cq_size = RXR_DEF_CQ_SIZE,


### PR DESCRIPTION
backport the following commits to v1.12.x branch

prov/efa: fix a bug in rxr_relase_rx_entry()
prov/efa: adjust out-of-order packet pool chunk size
prov/efa: allocate memory for various packet pools during initialization