### PR TITLE
prov/efa: Add unexpected rx queue for each peer

### DIFF
--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -271,6 +271,8 @@ int efa_conn_rdm_init(struct efa_av *av, struct efa_conn *conn)
 	ofi_recvwin_buf_alloc(&peer->robuf, rxr_env.recvwin_size);
 	peer->rx_credits = rxr_env.rx_window_size;
 	peer->tx_credits = rxr_env.tx_max_credits;
+	dlist_init(&peer->rx_unexp_list);
+	dlist_init(&peer->rx_unexp_tagged_list);
 
 	/* If peer is local, insert the address into shm provider's av */
 	if (rxr_ep->use_shm && efa_is_local_peer(av, &conn->ep_addr)) {

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -325,6 +325,8 @@ struct rdm_peer {
 	int rnr_timeout_exp;		/* RNR timeout exponentation calc val */
 	struct dlist_entry rnr_entry;	/* linked to rxr_ep peer_backoff_list */
 	struct dlist_entry queued_entry; /* linked with peer_queued_list in rxr_ep */
+	struct dlist_entry rx_unexp_list; /* a list of unexpected untagged rx_entry for this peer */
+	struct dlist_entry rx_unexp_tagged_list; /* a list of unexpected tagged rx_entry for this peer */
 	ofi_atomic32_t use_cnt;		/* refcount */
 };
 
@@ -407,6 +409,8 @@ struct rxr_rx_entry {
 
 	/* entry is linked with rx entry lists in rxr_ep */
 	struct dlist_entry entry;
+
+	struct dlist_entry peer_unexp_entry; /* linked to peer->rx_unexp_list or peer->rx_unexp_tagged_list */
 
 	/* queued_entry is linked with rx_queued_ctrl_list in rxr_ep */
 	struct dlist_entry queued_entry;

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -528,30 +528,19 @@ ssize_t rxr_msg_tinjectdata(struct fid_ep *ep_fid, const void *buf, size_t len,
  *   Utility functions and data structures
  */
 struct rxr_match_info {
-	fi_addr_t addr;
 	uint64_t tag;
 	uint64_t ignore;
 };
 
+/**
+ * @brief match function for rx_entry in ep->unexp_tagged_list
+ *
+ * @param[in]	item	pointer to rx_entry->entry.
+ * @param[in]	arg	pointer to rxr_match_info
+ * @return   0 or 1 indicating wether this entry is a match
+ */
 static
-int rxr_msg_match_unexp_anyaddr(struct dlist_entry *item, const void *arg)
-{
-	return 1;
-}
-
-static
-int rxr_msg_match_unexp(struct dlist_entry *item, const void *arg)
-{
-	const struct rxr_match_info *match_info = arg;
-	struct rxr_rx_entry *rx_entry;
-
-	rx_entry = container_of(item, struct rxr_rx_entry, entry);
-
-	return rxr_match_addr(match_info->addr, rx_entry->addr);
-}
-
-static
-int rxr_msg_match_unexp_tagged_anyaddr(struct dlist_entry *item, const void *arg)
+int rxr_msg_match_ep_unexp_by_tag(struct dlist_entry *item, const void *arg)
 {
 	const struct rxr_match_info *match_info = arg;
 	struct rxr_rx_entry *rx_entry;
@@ -562,16 +551,22 @@ int rxr_msg_match_unexp_tagged_anyaddr(struct dlist_entry *item, const void *arg
 			     match_info->tag);
 }
 
+/**
+ * @brief match function for rx_entry in peer->unexp_tagged_list
+ *
+ * @param[in]	item	pointer to rx_entry->peer_unexp_entry.
+ * @param[in]	arg	pointer to rxr_match_info
+ * @return   0 or 1 indicating wether this entry is a match
+ */
 static
-int rxr_msg_match_unexp_tagged(struct dlist_entry *item, const void *arg)
+int rxr_msg_match_peer_unexp_by_tag(struct dlist_entry *item, const void *arg)
 {
 	const struct rxr_match_info *match_info = arg;
 	struct rxr_rx_entry *rx_entry;
 
-	rx_entry = container_of(item, struct rxr_rx_entry, entry);
+	rx_entry = container_of(item, struct rxr_rx_entry, peer_unexp_entry);
 
-	return rxr_match_addr(match_info->addr, rx_entry->addr) &&
-	       rxr_match_tag(rx_entry->tag, match_info->ignore,
+	return rxr_match_tag(rx_entry->tag, match_info->ignore,
 			     match_info->tag);
 }
 
@@ -680,6 +675,7 @@ struct rxr_rx_entry *rxr_msg_alloc_rx_entry(struct rxr_ep *ep,
 struct rxr_rx_entry *rxr_msg_alloc_unexp_rx_entry_for_msgrtm(struct rxr_ep *ep,
 							     struct rxr_pkt_entry **pkt_entry_ptr)
 {
+	struct rdm_peer *peer;
 	struct rxr_rx_entry *rx_entry;
 	struct rxr_pkt_entry *unexp_pkt_entry;
 
@@ -698,12 +694,15 @@ struct rxr_rx_entry *rxr_msg_alloc_unexp_rx_entry_for_msgrtm(struct rxr_ep *ep,
 	rx_entry->unexp_pkt = unexp_pkt_entry;
 	rxr_pkt_rtm_update_rx_entry(unexp_pkt_entry, rx_entry);
 	dlist_insert_tail(&rx_entry->entry, &ep->rx_unexp_list);
+	peer = rxr_ep_get_peer(ep, unexp_pkt_entry->addr);
+	dlist_insert_tail(&rx_entry->peer_unexp_entry, &peer->rx_unexp_list);
 	return rx_entry;
 }
 
 struct rxr_rx_entry *rxr_msg_alloc_unexp_rx_entry_for_tagrtm(struct rxr_ep *ep,
 							     struct rxr_pkt_entry **pkt_entry_ptr)
 {
+	struct rdm_peer *peer;
 	struct rxr_rx_entry *rx_entry;
 	struct rxr_pkt_entry *unexp_pkt_entry;
 
@@ -723,6 +722,8 @@ struct rxr_rx_entry *rxr_msg_alloc_unexp_rx_entry_for_tagrtm(struct rxr_ep *ep,
 	rx_entry->unexp_pkt = unexp_pkt_entry;
 	rxr_pkt_rtm_update_rx_entry(unexp_pkt_entry, rx_entry);
 	dlist_insert_tail(&rx_entry->entry, &ep->rx_unexp_tagged_list);
+	peer = rxr_ep_get_peer(ep, unexp_pkt_entry->addr);
+	dlist_insert_tail(&rx_entry->peer_unexp_entry, &peer->rx_unexp_tagged_list);
 	return rx_entry;
 }
 
@@ -786,6 +787,69 @@ struct rxr_rx_entry *rxr_msg_split_rx_entry(struct rxr_ep *ep,
 	return rx_entry;
 }
 
+/**
+ * @brief find an unexpected rx entry for a receive operation.
+ *
+ * @param[in]	ep	endpoint
+ * @param[in]	addr	fi_addr of the peer want to receive from, can be FI_ADDR_UNSPEC
+ * @param[in]	tag	tag of the unexpected message, used only if op is ofi_op_tagged.
+ * @param[in]	ignore	mask of the tag, used only if op is ofi_op_tagged.
+ * @param[in]	op	either ofi_op_tagged or ofi_op_msg.
+ * @param[in]	claim   whether to claim the rx_entry, e.g. remove it from unexpected queue.
+ * @return	If an unexpected rx_entry was found, return the pointer.
+ * 		Otherwise, return NULL.
+ */
+static inline
+struct rxr_rx_entry *rxr_msg_find_unexp_rx_entry(struct rxr_ep *ep, fi_addr_t addr,
+						 int64_t tag, uint64_t ignore, uint32_t op,
+						 bool claim)
+{
+	struct rxr_match_info match_info;
+	struct rxr_rx_entry *rx_entry;
+	struct dlist_entry *match;
+	struct rdm_peer *peer;
+
+	peer = (ep->util_ep.caps & FI_DIRECTED_RECV) ? rxr_ep_get_peer(ep, addr) : NULL;
+
+	switch(op) {
+	case ofi_op_msg:
+		if (peer) {
+			match = dlist_empty(&peer->rx_unexp_list) ? NULL : peer->rx_unexp_list.next;
+			rx_entry = match ? container_of(match, struct rxr_rx_entry, peer_unexp_entry) : NULL;
+		} else {
+			match = dlist_empty(&ep->rx_unexp_list) ? NULL : ep->rx_unexp_list.next;
+			rx_entry = match ? container_of(match, struct rxr_rx_entry, entry) : NULL;
+		}
+		break;
+	case ofi_op_tagged:
+		match_info.tag = tag;
+		match_info.ignore = ignore;
+
+		if (peer) {
+			match = dlist_find_first_match(&peer->rx_unexp_tagged_list,
+			                               rxr_msg_match_peer_unexp_by_tag,
+						       (void *)&match_info);
+			rx_entry = match ? container_of(match, struct rxr_rx_entry, peer_unexp_entry) : NULL;
+		} else {
+			match = dlist_find_first_match(&ep->rx_unexp_tagged_list,
+						       rxr_msg_match_ep_unexp_by_tag,
+						       (void *)&match_info);
+			rx_entry = match ? container_of(match, struct rxr_rx_entry, entry) : NULL;
+		}
+		break;
+	default:
+		FI_WARN(&rxr_prov, FI_LOG_CQ, "Error: wrong op in rxr_msg_find_unexp_rx_entry()");
+		abort();
+	}
+
+	if (rx_entry && claim) {
+		dlist_remove(&rx_entry->entry);
+		dlist_remove(&rx_entry->peer_unexp_entry);
+	}
+
+	return rx_entry;
+}
+
 /*
  *    Search unexpected list for matching message and process it if found.
  *    Returns 0 if the message is processed, -FI_ENOMSG if no match is found.
@@ -795,40 +859,14 @@ int rxr_msg_proc_unexp_msg_list(struct rxr_ep *ep, const struct fi_msg *msg,
 				uint64_t tag, uint64_t ignore, uint32_t op, uint64_t flags,
 				struct rxr_rx_entry *posted_entry)
 {
-	struct rxr_match_info match_info;
-	struct dlist_entry *match;
 	struct rxr_rx_entry *rx_entry;
-	dlist_func_t *match_func;
 	int ret;
+	bool claim;
 
-	if (op == ofi_op_tagged) {
-		if (ep->util_ep.caps & FI_DIRECTED_RECV)
-			match_func = &rxr_msg_match_unexp_tagged;
-		else
-			match_func = &rxr_msg_match_unexp_tagged_anyaddr;
-
-		match_info.addr = msg->addr;
-		match_info.tag = tag;
-		match_info.ignore = ignore;
-		match = dlist_remove_first_match(&ep->rx_unexp_tagged_list,
-		                                 match_func,
-						 (void *)&match_info);
-	} else {
-		if (ep->util_ep.caps & FI_DIRECTED_RECV)
-			match_func = &rxr_msg_match_unexp;
-		else
-			match_func = &rxr_msg_match_unexp_anyaddr;
-
-		match_info.addr = msg->addr;
-		match = dlist_remove_first_match(&ep->rx_unexp_list,
-		                                 match_func,
-						 (void *)&match_info);
-	}
-
-	if (!match)
+	claim = true;
+	rx_entry = rxr_msg_find_unexp_rx_entry(ep, msg->addr, tag, ignore, op, claim);
+	if (!rx_entry)
 		return -FI_ENOMSG;
-
-	rx_entry = container_of(match, struct rxr_rx_entry, entry);
 
 	/*
 	 * Initialize the matched entry as a multi-recv consumer if the posted
@@ -1126,33 +1164,23 @@ ssize_t rxr_msg_peek_trecv(struct fid_ep *ep_fid,
 {
 	ssize_t ret = 0;
 	struct rxr_ep *ep;
-	struct dlist_entry *match;
-	dlist_func_t *match_func;
-	struct rxr_match_info match_info;
 	struct rxr_rx_entry *rx_entry;
 	struct fi_context *context;
 	struct rxr_pkt_entry *pkt_entry;
 	size_t data_len;
 	int64_t tag;
+	bool claim;
 
 	ep = container_of(ep_fid, struct rxr_ep, util_ep.ep_fid.fid);
 
 	fastlock_acquire(&ep->util_ep.lock);
 
 	rxr_ep_progress_internal(ep);
-	match_info.addr = msg->addr;
-	match_info.tag = msg->tag;
-	match_info.ignore = msg->ignore;
 
-	if (ep->util_ep.caps & FI_DIRECTED_RECV)
-		match_func = &rxr_msg_match_unexp_tagged;
-	else
-		match_func = &rxr_msg_match_unexp_tagged_anyaddr;
-
-	match = dlist_find_first_match(&ep->rx_unexp_tagged_list,
-	                               match_func,
-				       (void *)&match_info);
-	if (!match) {
+	claim = (flags & (FI_CLAIM | FI_DISCARD));
+	rx_entry = rxr_msg_find_unexp_rx_entry(ep, msg->addr, msg->tag, msg->ignore, ofi_op_tagged,
+					       claim);
+	if (!rx_entry) {
 		FI_DBG(&rxr_prov, FI_LOG_EP_CTRL,
 		       "Message not found addr: %" PRIu64
 		       " tag: %lx ignore %lx\n", msg->addr, msg->tag,
@@ -1162,14 +1190,10 @@ ssize_t rxr_msg_peek_trecv(struct fid_ep *ep_fid,
 		goto out;
 	}
 
-	rx_entry = container_of(match, struct rxr_rx_entry, entry);
 	context = (struct fi_context *)msg->context;
 	if (flags & FI_CLAIM) {
 		context->internal[0] = rx_entry;
-		dlist_remove(match);
 	} else if (flags & FI_DISCARD) {
-		dlist_remove(match);
-
 		ret = rxr_msg_discard_trecv(ep, rx_entry, msg, flags);
 		if (ret)
 			goto out;


### PR DESCRIPTION
This patch added an unexpected RX queue for each peer to
improve the performance of matching application's receive
operation with unexpected RX entry.

The peer's unexpected rx queue was updated together with
endpoint's unexpected rx queue.

When application posted a receive buffer, if application
specified peer address, the peer's unexpected rx queue
(instead of ep's unexpected RX queue) is used for matching.
This improved performance because there are less RX entry
to search.

Signed-off-by: Wei Zhang <wzam@amazon.com>