### PR TITLE
fabtests/hmem: Add device validation

### DIFF
--- a/fabtests/functional/bw.c
+++ b/fabtests/functional/bw.c
@@ -38,9 +38,14 @@ int sleep_time = 0;
 
 static ssize_t post_one_tx(struct ft_context *msg)
 {
-	if (ft_check_opts(FT_OPT_VERIFY_DATA | FT_OPT_ACTIVE))
-		ft_fill_buf(msg->buf + ft_tx_prefix_size(),
-			    opts.transfer_size);
+	ssize_t ret;
+
+	if (ft_check_opts(FT_OPT_VERIFY_DATA | FT_OPT_ACTIVE)) {
+		ret = ft_fill_buf(msg->buf + ft_tx_prefix_size(),
+				  opts.transfer_size);
+		if (ret)
+			return ret;
+	}
 
 	return ft_post_tx_buf(ep, remote_fi_addr, opts.transfer_size,
 			      NO_CQ_DATA, &msg->context, msg->buf,

--- a/fabtests/functional/cm_data.c
+++ b/fabtests/functional/cm_data.c
@@ -150,7 +150,10 @@ static int server_reject(size_t paramlen)
 		return ret;
 
 	/* Data will appear in error event generated on remote end. */
-	ft_fill_buf(cm_data, paramlen);
+	ret = ft_fill_buf(cm_data, paramlen);
+	if (ret)
+		return ret;
+
 	ret = fi_reject(pep, fi->handle, cm_data, paramlen);
 	if (ret)
 		FT_PRINTERR("fi_reject", ret);
@@ -187,7 +190,9 @@ static int server_accept(size_t paramlen)
 		goto err;
 	}
 	/* Data will appear on accept event on remote end. */
-	ft_fill_buf(cm_data, paramlen);
+	ret = ft_fill_buf(cm_data, paramlen);
+	if (ret)
+		return ret;
 
 	/* Accept the incoming connection. Also transitions endpoint to active
 	 * state.
@@ -254,7 +259,11 @@ static int server(size_t paramlen)
 
 static int client_connect(size_t paramlen)
 {
-	ft_fill_buf(cm_data, paramlen);
+	int ret;
+
+	ret = ft_fill_buf(cm_data, paramlen);
+	if (ret)
+		return ret;
 
 	/* Connect to server */
 	return fi_connect(ep, fi->dest_addr, cm_data, paramlen);

--- a/fabtests/functional/inj_complete.c
+++ b/fabtests/functional/inj_complete.c
@@ -44,8 +44,11 @@ static int send_msg(int sendmsg, size_t size)
 	int ret;
 	ft_tag = 0xabcd;
 
-	if (ft_check_opts(FT_OPT_VERIFY_DATA))
-		ft_fill_buf(tx_buf, size);
+	if (ft_check_opts(FT_OPT_VERIFY_DATA)) {
+		ret = ft_fill_buf(tx_buf, size);
+		if (ret)
+			return ret;
+	}
 
 	if (sendmsg) {
 		ret = ft_sendmsg(ep, remote_fi_addr, size,

--- a/fabtests/functional/multi_ep.c
+++ b/fabtests/functional/multi_ep.c
@@ -111,8 +111,11 @@ static int do_transfers(void)
 	}
 
 	for (i = 0; i < num_eps; i++) {
-		if (ft_check_opts(FT_OPT_VERIFY_DATA))
-			ft_fill_buf(send_bufs[i], opts.transfer_size);
+		if (ft_check_opts(FT_OPT_VERIFY_DATA)) {
+			ret = ft_fill_buf(send_bufs[i], opts.transfer_size);
+			if (ret)
+				return ret;
+		}
 
 		tx_buf = send_bufs[i];
 		ret = ft_post_tx(eps[i], remote_addr[i], opts.transfer_size, NO_CQ_DATA, &send_ctx[i]);

--- a/fabtests/functional/multi_mr.c
+++ b/fabtests/functional/multi_mr.c
@@ -184,8 +184,10 @@ static int mr_key_test()
 		tx_buf = (char *)mr_res_array[i].buf;
 
 		if (opts.dst_addr) {
-			ft_fill_buf(mr_res_array[i].buf,
-					opts.transfer_size);
+			ret = ft_fill_buf(mr_res_array[i].buf,
+					  opts.transfer_size);
+			if (ret)
+				return ret;
 
 			if (verbose)
 				printf("write to host's key %lx\n",
@@ -231,8 +233,10 @@ static int mr_key_test()
 					return ret;
 			}
 
-			ft_fill_buf(mr_res_array[i].buf,
-					opts.transfer_size);
+			ret = ft_fill_buf(mr_res_array[i].buf,
+					  opts.transfer_size);
+			if (ret)
+				return ret;
 
 			if (verbose)
 				printf("write to client's key %lx\n",

--- a/fabtests/functional/unexpected_msg.c
+++ b/fabtests/functional/unexpected_msg.c
@@ -132,9 +132,12 @@ static int run_test_loop(void)
 	for (i = 0; i < num_iters; i++) {
 		for (j = 0; j < concurrent_msgs; j++) {
 			op_buf = get_tx_buf(j);
-			if (ft_check_opts(FT_OPT_VERIFY_DATA))
-				ft_fill_buf(op_buf + ft_tx_prefix_size(),
-					    opts.transfer_size);
+			if (ft_check_opts(FT_OPT_VERIFY_DATA)) {
+				ret = ft_fill_buf(op_buf + ft_tx_prefix_size(),
+						  opts.transfer_size);
+				if (ret)
+					return ret;
+			}
 
 			ret = ft_post_tx_buf(ep, remote_fi_addr,
 					     opts.transfer_size,

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -231,7 +231,7 @@ void ft_usage(char *name, char *desc);
 void ft_mcusage(char *name, char *desc);
 void ft_csusage(char *name, char *desc);
 
-void ft_fill_buf(void *buf, size_t size);
+int ft_fill_buf(void *buf, size_t size);
 int ft_check_buf(void *buf, size_t size);
 int ft_check_opts(uint64_t flags);
 uint64_t ft_init_cq_data(struct fi_info *info);

--- a/fabtests/ubertest/verify.c
+++ b/fabtests/ubertest/verify.c
@@ -84,6 +84,7 @@ static const int integ_alphabet_length = (sizeof(integ_alphabet)/sizeof(*integ_a
 
 int ft_sync_fill_bufs(size_t size)
 {
+	int ret;
 	ft_sock_sync(0);
 
 	if (test_info.caps & FI_ATOMIC) {
@@ -94,9 +95,14 @@ int ft_sync_fill_bufs(size_t size)
 		memcpy(ft_atom_ctrl.orig_buf, ft_mr_ctrl.buf, size);
 		memcpy(ft_tx_ctrl.cpy_buf, ft_tx_ctrl.buf, size);
 	} else if (is_read_func(test_info.class_function)) {
-		ft_fill_buf(ft_mr_ctrl.buf, size);
+		ret = ft_fill_buf(ft_mr_ctrl.buf, size);
+		if (ret)
+			return ret;
 	} else {
-		ft_fill_buf(ft_tx_ctrl.buf, size);
+		ret = ft_fill_buf(ft_tx_ctrl.buf, size);
+		if (ret)
+			return ret;
+
 		memcpy(ft_tx_ctrl.cpy_buf, ft_tx_ctrl.buf, size);
 	}
 


### PR DESCRIPTION
Current fill/check functions check directly from a buffer.
If the buffer is on the device, it will fail.
To fix this you must copy the buffer from the device to the host before
checking and vice-versa for filling.

Signed-off-by: zdworkin <zachary.dworkin@intel.com>