### PR TITLE
util/pollfds: Introduce hot fd list

### DIFF
--- a/include/ofi_epoll.h
+++ b/include/ofi_epoll.h
@@ -71,11 +71,15 @@ struct ofi_pollfds_work_item {
 	struct slist_entry entry;
 };
 
+struct ofi_pollfds_ctx {
+	void		*context;
+};
+
 struct ofi_pollfds {
 	int		size;
 	int		nfds;
 	struct pollfd	*fds;
-	void		**context;
+	struct ofi_pollfds_ctx *ctx;
 	struct fd_signal signal;
 	struct slist	work_item_list;
 	ofi_mutex_t	lock;

--- a/src/unix/osd.c
+++ b/src/unix/osd.c
@@ -309,7 +309,7 @@ void ofi_pollfds_do_add(struct ofi_pollfds *pfds,
 	pfds->fds[item->fd].fd = item->fd;
 	pfds->fds[item->fd].events = item->events;
 	pfds->fds[item->fd].revents = 0;
-	pfds->context[item->fd] = item->context;
+	pfds->ctx[item->fd].context = item->context;
 	if (item->fd >= pfds->nfds)
 		pfds->nfds = item->fd + 1;
 }
@@ -319,7 +319,7 @@ int ofi_pollfds_do_mod(struct ofi_pollfds *pfds, int fd, uint32_t events,
 {
 	if ((fd < pfds->nfds) && (pfds->fds[fd].fd == fd)) {
 		pfds->fds[fd].events = events;
-		pfds->context[fd] = context;
+		pfds->ctx[fd].context = context;
 		return FI_SUCCESS;
 	}
 

--- a/src/windows/osd.c
+++ b/src/windows/osd.c
@@ -613,7 +613,7 @@ void ofi_pollfds_do_add(struct ofi_pollfds *pfds,
 	pfds->fds[pfds->nfds].fd = item->fd;
 	pfds->fds[pfds->nfds].events = item->events;
 	pfds->fds[pfds->nfds].revents = 0;
-	pfds->context[pfds->nfds] = item->context;
+	pfds->ctx[pfds->nfds].context = item->context;
 	pfds->nfds++;
 }
 
@@ -626,7 +626,7 @@ int ofi_pollfds_do_mod(struct ofi_pollfds *pfds, int fd, uint32_t events,
 	for (i = 1; i < pfds->nfds; i++) {
 		if (pfds->fds[i].fd == fd) {
 			pfds->fds[i].events = events;
-			pfds->context[i] = context;
+			pfds->ctx[i].context = context;
 			return FI_SUCCESS;
 		}
 	}
@@ -647,7 +647,7 @@ void ofi_pollfds_do_del(struct ofi_pollfds *pfds,
 			pfds->fds[i].fd = pfds->fds[pfds->nfds].fd;
 			pfds->fds[i].events = pfds->fds[pfds->nfds].events;
 			pfds->fds[i].revents = pfds->fds[pfds->nfds].revents;
-			pfds->context[i] = pfds->context[pfds->nfds];
+			pfds->ctx[i] = pfds->ctx[pfds->nfds];
 			break;
 		}
 	}


### PR DESCRIPTION
When connected to a large number of peers, the poll() system call
can be slow because of the number of fd's to check.  If only a
few peers are actively sending or receiving from the local
endpoint, we can reduce the overhead of checking by maintaining
an array of fd's which are active, or hot.

This adds a hot fd list to the pollfds abstraction, along with
a fairly simple mechanism for tracking fd's which are hot.  A
fairness counter is also maintained to ensure that the full fd
list is periodically checked.  The fairness counter will be
controllable though an environment variable, with a default
value set in follow on patches based on experimentation.

An fd is considered hot if it has data to send and the caller
is blocked waiting for a POLLOUT event.  It is also hot if any
data has been received on the fd.  A hit count is used track
activity, with the hit count reset every time the full fd list
is polled.  Hot fd's are added to a hot pollfd set.   If an
fd on the hot list has not received any events before the
fairness counter expires, it is removed from the list.