### PR TITLE
prov/efa: Two bugfixes in local read logic

### DIFF
--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -408,6 +408,7 @@ void rxr_pkt_handle_rma_read_completion(struct rxr_ep *ep,
 	struct rxr_pkt_entry *pkt_entry;
 	struct rxr_read_entry *read_entry;
 	struct rxr_rma_context_pkt *rma_context_pkt;
+	enum rxr_read_context_type read_context_type;
 	struct rdm_peer *peer;
 	int inject;
 	size_t data_size;
@@ -420,6 +421,7 @@ void rxr_pkt_handle_rma_read_completion(struct rxr_ep *ep,
 	read_entry = (struct rxr_read_entry *)context_pkt_entry->x_entry;
 	read_entry->bytes_finished += rma_context_pkt->seg_size;
 	assert(read_entry->bytes_finished <= read_entry->total_len);
+	read_context_type = read_entry->context_type;
 
 	if (read_entry->bytes_finished == read_entry->total_len) {
 		if (read_entry->context_type == RXR_READ_CONTEXT_TX_ENTRY) {
@@ -455,7 +457,7 @@ void rxr_pkt_handle_rma_read_completion(struct rxr_ep *ep,
 		rxr_read_release_entry(ep, read_entry);
 	}
 
-	if (read_entry->context_type == RXR_READ_CONTEXT_PKT_ENTRY) {
+	if (read_context_type == RXR_READ_CONTEXT_PKT_ENTRY) {
 		assert(context_pkt_entry->addr == FI_ADDR_NOTAVAIL);
 		ep->tx_pending--;
 	} else {

--- a/prov/efa/src/rxr/rxr_read.c
+++ b/prov/efa/src/rxr/rxr_read.c
@@ -401,6 +401,7 @@ int rxr_read_post_local_read_or_queue(struct rxr_ep *ep,
 	assert(pkt_entry->x_entry == rx_entry);
 	assert(rx_entry->desc && efa_ep_is_cuda_mr(rx_entry->desc[0]));
 	read_entry->iov_count = rx_entry->iov_count;
+	memset(read_entry->mr, 0, sizeof(*read_entry->mr) * read_entry->iov_count);
 	memcpy(read_entry->iov, rx_entry->iov, rx_entry->iov_count * sizeof(struct iovec));
 	rxr_read_copy_desc(EFA_EP, rx_entry->iov_count, rx_entry->desc, read_entry->mr_desc);
 	ofi_consume_iov_desc(read_entry->iov, read_entry->mr_desc, &read_entry->iov_count, data_offset);


### PR DESCRIPTION
9d04a6c31f1d3e0efd8f00ba0df4d818373bc7c0 prov/efa: Fix a bug of using uninitialized field of rxr_read_entry
dde4cedad6290fefc570cd3129075acf7a519b23 prov/efa: Fix a bug in rxr_handle_rma_read_completion 