### PR TITLE
[v1.12.x] prov/efa: backport bugfixes in local read path

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -499,6 +499,9 @@ struct rxr_peer *efa_ep_get_peer(struct dlist_entry *ep_list_entry,
 	struct util_ep *util_ep;
 	struct rxr_ep *rxr_ep;
 
+	if (OFI_UNLIKELY(addr == FI_ADDR_NOTAVAIL))
+		return NULL;
+
 	util_ep = container_of(ep_list_entry, struct util_ep,
 			       av_entry);
 	rxr_ep = container_of(util_ep, struct rxr_ep, util_ep);

--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -339,6 +339,7 @@ int efa_av_insert_addr(struct efa_av *av, struct efa_ep_addr *addr,
 		util_ep = container_of(ep_list_entry, struct util_ep, av_entry);
 		rxr_ep = container_of(util_ep, struct rxr_ep, util_ep);
 		peer = rxr_ep_get_peer(rxr_ep, *fi_addr);
+		assert(peer);
 		peer->efa_fiaddr = *fi_addr;
 		peer->is_self = efa_is_same_addr((struct efa_ep_addr *)rxr_ep->core_addr,
 						 addr);
@@ -387,6 +388,7 @@ int efa_av_insert_addr(struct efa_av *av, struct efa_ep_addr *addr,
 			rxr_ep = container_of(util_ep, struct rxr_ep, util_ep);
 			if (rxr_ep->use_shm) {
 				peer = rxr_ep_get_peer(rxr_ep, *fi_addr);
+				assert(peer);
 				peer->shm_fiaddr = shm_fiaddr;
 				peer->is_local = 1;
 			}

--- a/prov/efa/src/rxr/rxr_atomic.c
+++ b/prov/efa/src/rxr/rxr_atomic.c
@@ -131,6 +131,7 @@ ssize_t rxr_atomic_generic_efa(struct rxr_ep *rxr_ep,
 	}
 
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
+	assert(peer);
 
 	if (peer->flags & RXR_PEER_IN_BACKOFF) {
 		err = -FI_EAGAIN;
@@ -221,6 +222,7 @@ rxr_atomic_inject(struct fid_ep *ep,
 
 	rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid.fid);
 	peer = rxr_ep_get_peer(rxr_ep, dest_addr);
+	assert(peer);
 	if (peer->is_local) {
 		assert(rxr_ep->use_shm);
 		if (!(shm_info->domain_attr->mr_mode & FI_MR_VIRT_ADDR))
@@ -267,6 +269,7 @@ rxr_atomic_writemsg(struct fid_ep *ep,
 
 	rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid.fid);
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
+	assert(peer);
 	if (peer->is_local) {
 		assert(rxr_ep->use_shm);
 		rxr_atomic_copy_shm_msg(&shm_msg, msg, rma_iov);
@@ -340,6 +343,7 @@ rxr_atomic_readwritemsg(struct fid_ep *ep,
 
 	rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid.fid);
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
+	assert(peer);
 	if (peer->is_local) {
 		assert(rxr_ep->use_shm);
 		rxr_atomic_copy_shm_msg(&shm_msg, msg, rma_iov);
@@ -422,6 +426,7 @@ rxr_atomic_compwritemsg(struct fid_ep *ep,
 
 	rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid.fid);
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
+	assert(peer);
 	if (peer->is_local) {
 		assert(rxr_ep->use_shm);
 		rxr_atomic_copy_shm_msg(&shm_msg, msg, rma_iov);

--- a/prov/efa/src/rxr/rxr_cq.c
+++ b/prov/efa/src/rxr/rxr_cq.c
@@ -241,6 +241,7 @@ static inline void rxr_cq_queue_pkt(struct rxr_ep *ep,
 	struct rxr_peer *peer;
 
 	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
+	assert(peer);
 
 	/*
 	 * Queue the packet if it has not been retransmitted yet.
@@ -347,6 +348,7 @@ int rxr_cq_handle_cq_error(struct rxr_ep *ep, ssize_t err)
 
 	pkt_entry = (struct rxr_pkt_entry *)err_entry.op_context;
 	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
+	assert(peer);
 
 	/*
 	 * A handshake send could fail at the core provider if the peer endpoint
@@ -821,6 +823,7 @@ void rxr_cq_handle_tx_completion(struct rxr_ep *ep, struct rxr_tx_entry *tx_entr
 		dlist_remove(&tx_entry->entry);
 
 	peer = rxr_ep_get_peer(ep, tx_entry->addr);
+	assert(peer);
 	peer->tx_credits += tx_entry->credit_allocated;
 
 	if (tx_entry->cq_entry.flags & FI_READ) {

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -594,6 +594,7 @@ int rxr_ep_set_tx_credit_request(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_
 	int pending;
 
 	peer = rxr_ep_get_peer(rxr_ep, tx_entry->addr);
+	assert(peer);
 
 	/*
 	 * Init tx state for this peer. The rx state and reorder buffers will be
@@ -641,6 +642,7 @@ static void rxr_ep_free_res(struct rxr_ep *rxr_ep)
 		av = container_of(rxr_ep->util_ep.av, struct efa_av, util_av);
 		for (i = 0; i < av->count; ++i) {
 			peer = rxr_ep_get_peer(rxr_ep, i);
+			assert(peer);
 			if (peer->rx_init)
 				efa_free_robuf(peer);
 		}
@@ -652,6 +654,7 @@ static void rxr_ep_free_res(struct rxr_ep *rxr_ep)
 	av = container_of(rxr_ep->util_ep.av, struct efa_av, util_av);
 	for (i = 0; i < av->count; ++i) {
 		peer = rxr_ep_get_peer(rxr_ep, i);
+		assert(peer);
 		/*
 		 * TODO: Add support for wait/signal until all pending messages
 		 * have been sent/received so the core does not attempt to
@@ -884,8 +887,10 @@ static int rxr_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 				 */
 				for (i = 0; i < av->count; i++) {
 					first_ep_peer = rxr_ep_get_peer(rxr_first_ep, i);
+					assert(first_ep_peer);
 					if (first_ep_peer->is_local) {
 						peer = rxr_ep_get_peer(rxr_ep, i);
+						assert(peer);
 						peer->shm_fiaddr = first_ep_peer->shm_fiaddr;
 						peer->is_local = 1;
 					}
@@ -1683,6 +1688,7 @@ void rxr_ep_progress_internal(struct rxr_ep *ep)
 				     struct rxr_rx_entry,
 				     rx_entry, queued_entry, tmp) {
 		peer = rxr_ep_get_peer(ep, rx_entry->addr);
+		assert(peer);
 
 		if (peer->flags & RXR_PEER_IN_BACKOFF)
 			continue;
@@ -1723,6 +1729,7 @@ void rxr_ep_progress_internal(struct rxr_ep *ep)
 				     struct rxr_tx_entry,
 				     tx_entry, queued_entry, tmp) {
 		peer = rxr_ep_get_peer(ep, tx_entry->addr);
+		assert(peer);
 
 		if (peer->flags & RXR_PEER_IN_BACKOFF)
 			continue;
@@ -1767,6 +1774,7 @@ void rxr_ep_progress_internal(struct rxr_ep *ep)
 	dlist_foreach_container(&ep->tx_pending_list, struct rxr_tx_entry,
 				tx_entry, entry) {
 		peer = rxr_ep_get_peer(ep, tx_entry->addr);
+		assert(peer);
 
 		if (peer->flags & RXR_PEER_IN_BACKOFF)
 			continue;
@@ -1806,6 +1814,7 @@ void rxr_ep_progress_internal(struct rxr_ep *ep)
 	dlist_foreach_container_safe(&ep->read_pending_list, struct rxr_read_entry,
 				     read_entry, pending_entry, tmp) {
 		peer = rxr_ep_get_peer(ep, read_entry->addr);
+		assert(peer);
 
 		if (peer->flags & RXR_PEER_IN_BACKOFF)
 			continue;

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -87,6 +87,7 @@ ssize_t rxr_msg_post_cuda_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_ent
 	 * from the receiver, so here we call rxr_pkt_wait_handshake().
 	 */
 	peer = rxr_ep_get_peer(rxr_ep, tx_entry->addr);
+	assert(peer);
 
 	err = rxr_pkt_wait_handshake(rxr_ep, tx_entry->addr, peer);
 	if (OFI_UNLIKELY(err)) {
@@ -140,6 +141,7 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 	else
 		delivery_complete_requested = tx_entry->fi_flags & FI_DELIVERY_COMPLETE;
 	peer = rxr_ep_get_peer(rxr_ep, tx_entry->addr);
+	assert(peer);
 
 	if (delivery_complete_requested && !(peer->is_local)) {
 		tx_entry->rxr_flags |= RXR_DELIVERY_COMPLETE_REQUESTED;
@@ -287,6 +289,7 @@ ssize_t rxr_msg_generic_send(struct fid_ep *ep, const struct fi_msg *msg,
 	}
 
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
+	assert(peer);
 
 	if (peer->flags & RXR_PEER_IN_BACKOFF) {
 		err = -FI_EAGAIN;

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -302,6 +302,7 @@ ssize_t rxr_pkt_post_ctrl_once(struct rxr_ep *rxr_ep, int entry_type, void *x_en
 	}
 
 	peer = rxr_ep_get_peer(rxr_ep, addr);
+	assert(peer);
 	if (peer->is_local) {
 		assert(rxr_ep->use_shm);
 		pkt_entry = rxr_pkt_entry_alloc(rxr_ep, rxr_ep->tx_pkt_shm_pool);
@@ -770,6 +771,7 @@ void rxr_pkt_handle_send_completion(struct rxr_ep *ep, struct rxr_pkt_entry *pkt
 	}
 
 	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
+	assert(peer);
 	if (!peer->is_local)
 		rxr_ep_dec_tx_pending(ep, peer, 0);
 	rxr_pkt_entry_release_tx(ep, pkt_entry);
@@ -869,6 +871,7 @@ void rxr_pkt_handle_recv_completion(struct rxr_ep *ep,
 #endif
 #endif
 	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
+	assert(peer);
 	if (!(peer->flags & RXR_PEER_HANDSHAKE_SENT_OR_QUEUED))
 		rxr_pkt_post_handshake_or_queue(ep, peer);
 

--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -130,6 +130,7 @@ void rxr_pkt_entry_release_tx(struct rxr_ep *ep,
 	 */
 	if (OFI_UNLIKELY(pkt->state == RXR_PKT_ENTRY_RNR_RETRANSMIT)) {
 		peer = rxr_ep_get_peer(ep, pkt->addr);
+		assert(peer);
 		peer->rnr_queued_pkt_cnt--;
 		peer->timeout_interval = 0;
 		peer->rnr_timeout_exp = 0;
@@ -173,6 +174,7 @@ void rxr_pkt_entry_release_rx(struct rxr_ep *ep,
 		struct rxr_peer *peer;
 
 		peer = rxr_ep_get_peer(ep, pkt_entry->addr);
+		assert(peer);
 
 		if (peer->is_local)
 			ep->rx_bufs_shm_to_post++;
@@ -323,12 +325,12 @@ ssize_t rxr_pkt_entry_sendmsg(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry
 	struct rxr_peer *peer;
 	size_t ret;
 
-	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
 	assert(ep->tx_pending <= ep->max_outstanding_tx);
-
 	if (ep->tx_pending == ep->max_outstanding_tx)
 		return -FI_EAGAIN;
 
+	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
+	assert(peer);
 	if (peer->flags & RXR_PEER_IN_BACKOFF)
 		return -FI_EAGAIN;
 
@@ -370,6 +372,7 @@ ssize_t rxr_pkt_entry_send(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry,
 	struct rxr_peer *peer;
 
 	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
+	assert(peer);
 
 	if (pkt_entry->send && pkt_entry->send->iov_count > 0) {
 		msg.msg_iov = pkt_entry->send->iov;
@@ -399,6 +402,7 @@ ssize_t rxr_pkt_entry_inject(struct rxr_ep *ep,
 
 	/* currently only EOR packet is injected using shm ep */
 	peer = rxr_ep_get_peer(ep, addr);
+	assert(peer);
 
 	assert(ep->use_shm && peer->is_local);
 	return fi_inject(ep->shm_ep, rxr_pkt_start(pkt_entry), pkt_entry->pkt_size,

--- a/prov/efa/src/rxr/rxr_pkt_type_data.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_data.c
@@ -296,6 +296,7 @@ void rxr_pkt_proc_data(struct rxr_ep *ep,
 	all_received = (rx_entry->bytes_received == rx_entry->total_len);
 
 	peer = rxr_ep_get_peer(ep, rx_entry->addr);
+	assert(peer);
 	peer->rx_credits += ofi_div_ceil(seg_size, ep->max_data_payload_size);
 
 	rx_entry->window -= seg_size;

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -213,6 +213,7 @@ ssize_t rxr_pkt_init_cts(struct rxr_ep *ep,
 
 	bytes_left = rx_entry->total_len - rx_entry->bytes_received;
 	peer = rxr_ep_get_peer(ep, rx_entry->addr);
+	assert(peer);
 	rxr_pkt_calc_cts_window_credits(ep, peer, bytes_left,
 					rx_entry->credit_request,
 					&window, &rx_entry->credit_cts);
@@ -260,8 +261,10 @@ void rxr_pkt_handle_cts_recv(struct rxr_ep *ep,
 	/* Return any excess tx_credits that were borrowed for the request */
 	peer = rxr_ep_get_peer(ep, tx_entry->addr);
 	tx_entry->credit_allocated = ofi_div_ceil(cts_pkt->window, ep->max_data_payload_size);
-	if (tx_entry->credit_allocated < tx_entry->credit_request)
+	if (tx_entry->credit_allocated < tx_entry->credit_request) {
+		assert(peer);
 		peer->tx_credits += tx_entry->credit_request - tx_entry->credit_allocated;
+	}
 
 	rxr_pkt_entry_release_rx(ep, pkt_entry);
 
@@ -456,6 +459,7 @@ void rxr_pkt_handle_rma_read_completion(struct rxr_ep *ep,
 		ep->tx_pending--;
 	} else {
 		peer = rxr_ep_get_peer(ep, context_pkt_entry->addr);
+		assert(peer);
 		if (!peer->is_local)
 			rxr_ep_dec_tx_pending(ep, peer, 0);
 	}

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -408,6 +408,7 @@ void rxr_pkt_handle_rma_read_completion(struct rxr_ep *ep,
 	struct rxr_read_entry *read_entry;
 	struct rxr_rma_context_pkt *rma_context_pkt;
 	struct rxr_peer *peer;
+	enum rxr_read_context_type read_context_type;
 	int inject;
 	size_t data_size;
 	ssize_t ret;
@@ -419,6 +420,7 @@ void rxr_pkt_handle_rma_read_completion(struct rxr_ep *ep,
 	read_entry = (struct rxr_read_entry *)context_pkt_entry->x_entry;
 	read_entry->bytes_finished += rma_context_pkt->seg_size;
 	assert(read_entry->bytes_finished <= read_entry->total_len);
+	read_context_type = read_entry->context_type;
 
 	if (read_entry->bytes_finished == read_entry->total_len) {
 		if (read_entry->context_type == RXR_READ_CONTEXT_TX_ENTRY) {
@@ -454,7 +456,7 @@ void rxr_pkt_handle_rma_read_completion(struct rxr_ep *ep,
 		rxr_read_release_entry(ep, read_entry);
 	}
 
-	if (read_entry->context_type == RXR_READ_CONTEXT_PKT_ENTRY) {
+	if (read_context_type == RXR_READ_CONTEXT_PKT_ENTRY) {
 		assert(context_pkt_entry->addr == FI_ADDR_NOTAVAIL);
 		ep->tx_pending--;
 	} else {

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -118,6 +118,7 @@ void rxr_pkt_init_req_hdr(struct rxr_ep *ep,
 	base_hdr->flags = 0;
 
 	peer = rxr_ep_get_peer(ep, tx_entry->addr);
+	assert(peer);
 
 	if (OFI_UNLIKELY(!(peer->flags & RXR_PEER_HANDSHAKE_RECEIVED))) {
 		/*
@@ -272,6 +273,7 @@ size_t rxr_pkt_req_max_data_size(struct rxr_ep *ep, fi_addr_t addr, int pkt_type
 	struct rxr_peer *peer;
 
 	peer = rxr_ep_get_peer(ep, addr);
+	assert(peer);
 
 	if (peer->is_local) {
 		assert(ep->use_shm);
@@ -1234,6 +1236,7 @@ void rxr_pkt_handle_rtm_rta_recv(struct rxr_ep *ep,
 
 	need_ordering = false;
 	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
+	assert(peer);
 
 	if (!peer->is_local) {
 		/*

--- a/prov/efa/src/rxr/rxr_read.c
+++ b/prov/efa/src/rxr/rxr_read.c
@@ -488,9 +488,8 @@ int rxr_read_post(struct rxr_ep *ep, struct rxr_read_entry *read_entry)
 			return ret;
 	}
 
-	peer = rxr_ep_get_peer(ep, read_entry->addr);
-
 	if (read_entry->lower_ep_type == SHM_EP) {
+		peer = rxr_ep_get_peer(ep, read_entry->addr);
 		assert(peer);
 		shm_fiaddr = peer->shm_fiaddr;
 	}
@@ -577,6 +576,7 @@ int rxr_read_post(struct rxr_ep *ep, struct rxr_read_entry *read_entry)
 			/* read from self, no peer */
 			ep->tx_pending++;
 		} else if (read_entry->lower_ep_type == EFA_EP) {
+			peer = rxr_ep_get_peer(ep, read_entry->addr);
 			assert(peer);
 			rxr_ep_inc_tx_pending(ep, peer);
 		}

--- a/prov/efa/src/rxr/rxr_read.c
+++ b/prov/efa/src/rxr/rxr_read.c
@@ -330,6 +330,7 @@ int rxr_read_post_remote_read_or_queue(struct rxr_ep *ep, int entry_type, void *
 		assert(entry_type == RXR_RX_ENTRY);
 		peer = rxr_ep_get_peer(ep, ((struct rxr_rx_entry *)x_entry)->addr);
 	}
+	assert(peer);
 
 	lower_ep_type = (peer->is_local) ? SHM_EP : EFA_EP;
 	read_entry = rxr_read_alloc_entry(ep, entry_type, x_entry, lower_ep_type);
@@ -426,6 +427,7 @@ int rxr_read_init_iov(struct rxr_ep *ep,
 		if (!tx_entry->mr[0]) {
 			for (i = 0; i < tx_entry->iov_count; ++i) {
 				assert(!tx_entry->mr[i]);
+				assert(peer);
 
 				if (peer->is_local)
 					err = efa_mr_reg_shm(rxr_ep_domain(ep)->rdm_domain,
@@ -488,8 +490,10 @@ int rxr_read_post(struct rxr_ep *ep, struct rxr_read_entry *read_entry)
 
 	peer = rxr_ep_get_peer(ep, read_entry->addr);
 
-	if (read_entry->lower_ep_type == SHM_EP)
+	if (read_entry->lower_ep_type == SHM_EP) {
+		assert(peer);
 		shm_fiaddr = peer->shm_fiaddr;
+	}
 
 	max_read_size = (read_entry->lower_ep_type == EFA_EP) ?
 				efa_max_rdma_size(ep->rdm_ep) : SIZE_MAX;
@@ -573,6 +577,7 @@ int rxr_read_post(struct rxr_ep *ep, struct rxr_read_entry *read_entry)
 			/* read from self, no peer */
 			ep->tx_pending++;
 		} else if (read_entry->lower_ep_type == EFA_EP) {
+			assert(peer);
 			rxr_ep_inc_tx_pending(ep, peer);
 		}
 

--- a/prov/efa/src/rxr/rxr_read.c
+++ b/prov/efa/src/rxr/rxr_read.c
@@ -378,6 +378,7 @@ int rxr_read_post_local_read_or_queue(struct rxr_ep *ep,
 	assert(pkt_entry->x_entry == rx_entry);
 	assert(rx_entry->desc && efa_ep_is_cuda_mr(rx_entry->desc[0]));
 	read_entry->iov_count = rx_entry->iov_count;
+	memset(read_entry->mr, 0, sizeof(*read_entry->mr) * read_entry->iov_count);
 	memcpy(read_entry->iov, rx_entry->iov, rx_entry->iov_count * sizeof(struct iovec));
 	memcpy(read_entry->mr_desc, rx_entry->desc, rx_entry->iov_count * sizeof(void *));
 	ofi_consume_iov_desc(read_entry->iov, read_entry->mr_desc, &read_entry->iov_count, data_offset);

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -169,6 +169,7 @@ size_t rxr_rma_post_shm_write(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_ent
 
 	assert(tx_entry->op == ofi_op_write);
 	peer = rxr_ep_get_peer(rxr_ep, tx_entry->addr);
+	assert(peer);
 	pkt_entry = rxr_pkt_entry_alloc(rxr_ep, rxr_ep->tx_pkt_shm_pool);
 	if (OFI_UNLIKELY(!pkt_entry))
 		return -FI_EAGAIN;
@@ -268,6 +269,7 @@ ssize_t rxr_rma_post_efa_emulated_read(struct rxr_ep *ep, struct rxr_tx_entry *t
 		err = rxr_pkt_post_ctrl(ep, RXR_TX_ENTRY, tx_entry, RXR_SHORT_RTR_PKT, 0);
 	} else {
 		peer = rxr_ep_get_peer(ep, tx_entry->addr);
+		assert(peer);
 
 		rxr_pkt_calc_cts_window_credits(ep, peer,
 						tx_entry->total_len,
@@ -317,6 +319,7 @@ ssize_t rxr_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uint64_
 	}
 
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
+	assert(peer);
 
 	if (peer->flags & RXR_PEER_IN_BACKOFF) {
 		err = -FI_EAGAIN;
@@ -414,6 +417,7 @@ ssize_t rxr_rma_post_write(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry)
 				  util_domain.domain_fid);
 
 	peer = rxr_ep_get_peer(ep, tx_entry->addr);
+	assert(peer);
 
 	if (peer->is_local)
 		return rxr_rma_post_shm_write(ep, tx_entry);
@@ -504,6 +508,7 @@ ssize_t rxr_rma_writemsg(struct fid_ep *ep,
 	fastlock_acquire(&rxr_ep->util_ep.lock);
 
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
+	assert(peer);
 
 	if (peer->flags & RXR_PEER_IN_BACKOFF) {
 		err = -FI_EAGAIN;


### PR DESCRIPTION
The issues here are

1. uninitialized mr field of struct rxr_read_entry and accessing struct after release, which result in segfault if memory poisoning enabled. Fixed in main branch via PR #6882
de1f8cbc8  [v1.12.x] prov/efa: Fix a bug in rxr_handle_rma_read_completion
6940e12ef [v1.12.x] prov/efa: Fix a bug of using uninitialized field of rxr_read_entry

2. passing FI_ADDR_NOTAVAIL as the address to rxr_ep_get_peer, which also results in segfault. Fixed in main branch via PR #6854
90a0fc419 [v1.12.x] prov/efa: Do not call rxr_ep_get_peer for local read
7fdfaf86f [v1.12.x] prov/efa: Add assertion for peer structure
b336fc2fe [v1.12.x] prov/efa: Handle FI_ADDR_NOTAVAIL in rxr_ep_get_peer
