### PR TITLE
prov/efa: fix bugs in rnr support

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -620,6 +620,9 @@ void efa_rdm_peer_reset(struct rdm_peer *peer)
 	if (peer->robuf.pending)
 		ofi_recvwin_free(&peer->robuf);
 
+	if (peer->flags & RXR_PEER_HANDSHAKE_QUEUED)
+		dlist_remove(&peer->handshake_queued_entry);
+
 	memset(peer, 0, sizeof(struct rdm_peer));
 #ifdef ENABLE_EFA_POISONING
 	rxr_poison_mem_region((uint32_t *)peer, sizeof(struct rdm_peer));

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -281,9 +281,9 @@ enum rxr_rx_comm_type {
 	RXR_RX_UNEXP,		/* rx_entry unexp msg waiting for post recv */
 	RXR_RX_MATCHED,		/* rx_entry matched with RTM */
 	RXR_RX_RECV,		/* rx_entry large msg recv data pkts */
-	RXR_RX_QUEUED_CTRL,	/* rx_entry was unable to send ctrl packet */
-	RXR_RX_QUEUED_EOR,	/* rx_entry was unable to send EOR over shm */
-	RXR_RX_QUEUED_CTS_RNR,	/* rx_entry RNR sending CTS */
+	RXR_RX_QUEUED_CTRL,	/* rx_entry encountered error when sending control
+				   it is in rxr_ep->rx_queued_entry_list, progress
+				   engine will resend the ctrl packet */
 	RXR_RX_WAIT_READ_FINISH, /* rx_entry wait for send to finish, FI_READ */
 	RXR_RX_WAIT_ATOMRSP_SENT, /* rx_entry wait for atomrsp packet sent completion */
 };

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -269,10 +269,6 @@ enum rxr_tx_comm_type {
 	RXR_TX_QUEUED_CTRL,	/* tx_entry was unable to send ctrl packet */
 	RXR_TX_QUEUED_REQ_RNR,  /* tx_entry RNR sending REQ packet */
 	RXR_TX_QUEUED_DATA_RNR,	/* tx_entry RNR sending data packets */
-	RXR_TX_WAIT_READ_FINISH, /* tx_entry (on initiating EP) wait
-				  * for rx_entry to finish receiving
-				  * (FI_READ only)
-				  */
 };
 
 enum rxr_rx_comm_type {

--- a/prov/efa/src/rxr/rxr_cq.c
+++ b/prov/efa/src/rxr/rxr_cq.c
@@ -192,8 +192,6 @@ int rxr_cq_handle_tx_error(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
 	case RXR_TX_QUEUED_DATA_RNR:
 		dlist_remove(&tx_entry->queued_entry);
 		break;
-	case RXR_TX_WAIT_READ_FINISH:
-		break;
 	default:
 		FI_WARN(&rxr_prov, FI_LOG_CQ, "tx_entry unknown state %d\n",
 			tx_entry->state);
@@ -538,7 +536,7 @@ void rxr_cq_handle_rx_completion(struct rxr_ep *ep,
 		 *     2. call rxr_cq_write_tx_completion()
 		 */
 		tx_entry = ofi_bufpool_get_ibuf(ep->tx_entry_pool, rx_entry->rma_loc_tx_id);
-		assert(tx_entry->state == RXR_TX_WAIT_READ_FINISH);
+		assert(tx_entry->state == RXR_TX_REQ);
 		if (tx_entry->fi_flags & FI_COMPLETION) {
 			rxr_cq_write_tx_completion(ep, tx_entry);
 		} else {

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1287,7 +1287,7 @@ int rxr_ep_init(struct rxr_ep *ep)
 	dlist_init(&ep->tx_pending_list);
 	dlist_init(&ep->read_pending_list);
 	dlist_init(&ep->peer_backoff_list);
-	dlist_init(&ep->peer_queued_list);
+	dlist_init(&ep->handshake_queued_peer_list);
 #if ENABLE_DEBUG
 	dlist_init(&ep->rx_pending_list);
 	dlist_init(&ep->rx_pkt_list);
@@ -1673,17 +1673,22 @@ void rxr_ep_progress_internal(struct rxr_ep *ep)
 	 * Resend handshake packet for any peers where the first
 	 * handshake send failed.
 	 */
-	dlist_foreach_container_safe(&ep->peer_queued_list,
+	dlist_foreach_container_safe(&ep->handshake_queued_peer_list,
 				     struct rdm_peer, peer,
-				     queued_entry, tmp) {
+				     handshake_queued_entry, tmp) {
+		if (peer->flags & RXR_PEER_IN_BACKOFF)
+			continue;
 
 		ret = rxr_pkt_post_handshake(ep, peer);
 		if (ret == -FI_EAGAIN)
 			break;
+
 		if (OFI_UNLIKELY(ret))
 			goto handshake_err;
 
-		dlist_remove(&peer->queued_entry);
+		dlist_remove(&peer->handshake_queued_entry);
+		peer->flags &= ~RXR_PEER_HANDSHAKE_QUEUED;
+		peer->flags |= RXR_PEER_HANDSHAKE_SENT;
 	}
 
 	/*

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -404,8 +404,7 @@ ssize_t rxr_pkt_post_ctrl_or_queue(struct rxr_ep *ep, int entry_type, void *x_en
 		} else {
 			assert(entry_type == RXR_RX_ENTRY);
 			rx_entry = (struct rxr_rx_entry *)x_entry;
-			assert(rx_entry->state != RXR_RX_QUEUED_CTRL ||
-			       rx_entry->state != RXR_RX_QUEUED_CTS_RNR);
+			assert(rx_entry->state != RXR_RX_QUEUED_CTRL);
 			rx_entry->state = RXR_RX_QUEUED_CTRL;
 			rx_entry->queued_ctrl.type = ctrl_type;
 			rx_entry->queued_ctrl.inject = inject;

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -965,8 +965,7 @@ void rxr_pkt_handle_recv_completion(struct rxr_ep *ep,
 #endif
 	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
 	assert(peer);
-	if (!(peer->flags & RXR_PEER_HANDSHAKE_SENT_OR_QUEUED))
-		rxr_pkt_post_handshake_or_queue(ep, peer);
+	rxr_pkt_post_handshake_or_queue(ep, peer);
 
 	if (peer->is_local) {
 		assert(ep->use_shm);

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -265,7 +265,7 @@ void rxr_pkt_handle_ctrl_sent(struct rxr_ep *rxr_ep, struct rxr_pkt_entry *pkt_e
 		break;
 	case RXR_SHORT_RTR_PKT:
 	case RXR_LONG_RTR_PKT:
-		rxr_pkt_handle_rtr_sent(rxr_ep, pkt_entry);
+		/* nothing can be done when RTR packets are sent */
 		break;
 	case RXR_WRITE_RTA_PKT:
 	case RXR_DC_WRITE_RTA_PKT:

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -1848,19 +1848,6 @@ ssize_t rxr_pkt_init_long_rtr(struct rxr_ep *ep,
 }
 
 /*
- *     handle_sent() functions for RTR packet types
- */
-void rxr_pkt_handle_rtr_sent(struct rxr_ep *ep,
-			     struct rxr_pkt_entry *pkt_entry)
-{
-	struct rxr_tx_entry *tx_entry;
-
-	tx_entry = (struct rxr_tx_entry *)pkt_entry->x_entry;
-	tx_entry->bytes_sent = 0;
-	tx_entry->state = RXR_TX_WAIT_READ_FINISH;
-}
-
-/*
  *     handle_send_completion() funciton for RTR packet
  */
 void rxr_pkt_handle_rtr_send_completion(struct rxr_ep *ep,


### PR DESCRIPTION
This PR fixes bugs in RNR support:

1. A handshake packet encounter RNR was dropped
2. Rx entry encountered RNR when sending RECEIPT packet was not queued thus RECEIPT packets was not resend
3. Tx entry encountered RNR when sending RTR packet was not queued thus RTR packets was not resend
