### PR TITLE
prov/efa: zero out hash key before calling HASH_FIND

### DIFF
--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -438,6 +438,7 @@ struct efa_conn *efa_conn_alloc(struct efa_av *av, struct efa_ep_addr *raw_addr,
 		goto err_release;
 	}
 
+	memset(&reverse_av_entry->key, 0, sizeof(reverse_av_entry->key));
 	memcpy(&reverse_av_entry->key, &key, sizeof(key));
 	reverse_av_entry->conn = conn;
 	HASH_ADD(hh, av->reverse_av, key,

--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -401,6 +401,7 @@ struct rxr_rx_entry *rxr_pkt_rx_map_lookup(struct rxr_ep *ep,
 	struct rxr_pkt_rx_map *entry = NULL;
 	struct rxr_pkt_rx_key key;
 
+	memset(&key, 0, sizeof(key));
 	key.msg_id = rxr_pkt_msg_id(pkt_entry);
 	key.addr = pkt_entry->addr;
 	HASH_FIND(hh, ep->pkt_rx_map, &key, sizeof(struct rxr_pkt_rx_key), entry);
@@ -421,6 +422,7 @@ void rxr_pkt_rx_map_insert(struct rxr_ep *ep,
 		return;
 	}
 
+	memset(&entry->key, 0, sizeof(entry->key));
 	entry->key.msg_id = rxr_pkt_msg_id(pkt_entry);
 	entry->key.addr = pkt_entry->addr;
 
@@ -444,6 +446,7 @@ void rxr_pkt_rx_map_remove(struct rxr_ep *ep,
 	struct rxr_pkt_rx_map *entry;
 	struct rxr_pkt_rx_key key;
 
+	memset(&key, 0, sizeof(key));
 	key.msg_id = rxr_pkt_msg_id(pkt_entry);
 	key.addr = pkt_entry->addr;
 


### PR DESCRIPTION
According to uthash document:

    https://troydhanson.github.io/uthash/userguide.html#_structure_keys

We should zero out content of key before calling HASH_FIND/ADD,
this patch does that for packet entry look up.

Signed-off-by: Wei Zhang <wzam@amazon.com>