### PR TITLE
prov/efa: remove unnecessary memset

### DIFF
--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -438,7 +438,6 @@ struct efa_conn *efa_conn_alloc(struct efa_av *av, struct efa_ep_addr *raw_addr,
 		goto err_release;
 	}
 
-	memset(&reverse_av_entry->key, 0, sizeof(reverse_av_entry->key));
 	memcpy(&reverse_av_entry->key, &key, sizeof(key));
 	reverse_av_entry->conn = conn;
 	HASH_ADD(hh, av->reverse_av, key,


### PR DESCRIPTION
This patch remove an unnecessary call to memset, which
zero out the key to HASH_ADD.

it is unnecessary because it is followed by a call to memcpy
and the source of the copy has been zeroed out.

Signed-off-by: Wei Zhang <wzam@amazon.com>