### PR TITLE
util/mr_cache: Add memory monitor for ZE

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -76,6 +76,7 @@ common_srcs =				\
 	prov/util/src/util_mr_cache.c	\
 	prov/util/src/cuda_mem_monitor.c \
 	prov/util/src/rocr_mem_monitor.c \
+	prov/util/src/ze_mem_monitor.c \
 	prov/util/src/util_coll.c
 
 

--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -150,6 +150,7 @@ int ze_hmem_open_shared_handle(int dev_fd, void **handle, int *ze_fd,
 int ze_hmem_close_handle(void *ipc_ptr);
 bool ze_hmem_p2p_enabled(void);
 int ze_hmem_get_base_addr(const void *ptr, void **base);
+int ze_hmem_get_id(const void *ptr, uint64_t *id);
 int *ze_hmem_get_dev_fds(int *nfds);
 
 static inline int ofi_memcpy(uint64_t device, void *dest, const void *src,

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -124,6 +124,7 @@ struct ofi_mr_cache;
 
 union ofi_mr_hmem_info {
 	uint64_t cuda_id;
+	uint64_t ze_id;
 };
 
 struct ofi_mem_monitor {
@@ -174,6 +175,7 @@ void ofi_monitor_unsubscribe(struct ofi_mem_monitor *monitor,
 extern struct ofi_mem_monitor *default_monitor;
 extern struct ofi_mem_monitor *default_cuda_monitor;
 extern struct ofi_mem_monitor *default_rocr_monitor;
+extern struct ofi_mem_monitor *default_ze_monitor;
 
 /*
  * Userfault fd memory monitor
@@ -198,6 +200,7 @@ extern struct ofi_mem_monitor *memhooks_monitor;
 
 extern struct ofi_mem_monitor *cuda_monitor;
 extern struct ofi_mem_monitor *rocr_monitor;
+extern struct ofi_mem_monitor *ze_monitor;
 extern struct ofi_mem_monitor *import_monitor;
 
 /*
@@ -268,6 +271,7 @@ struct ofi_mr_cache_params {
 	char *				monitor;
 	int				cuda_monitor_enabled;
 	int				rocr_monitor_enabled;
+	int				ze_monitor_enabled;
 };
 
 extern struct ofi_mr_cache_params	cache_params;

--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -687,6 +687,7 @@
     <ClCompile Include="prov\util\src\util_mr_cache.c" />
     <ClCompile Include="prov\util\src\cuda_mem_monitor.c" />
     <ClCompile Include="prov\util\src\rocr_mem_monitor.c" />
+    <ClCompile Include="prov\util\src\ze_mem_monitor.c" />
     <ClCompile Include="src\common.c" />
     <ClCompile Include="src\enosys.c">
       <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Debug-ICC|x64'">4127;869</DisableSpecificWarnings>

--- a/libfabric.vcxproj.filters
+++ b/libfabric.vcxproj.filters
@@ -201,6 +201,9 @@
     <ClCompile Include="prov\util\src\rocr_mem_monitor.c">
       <Filter>Source Files\prov\util</Filter>
     </ClCompile>
+    <ClCompile Include="prov\util\src\ze_mem_monitor.c">
+      <Filter>Source Files\prov\util</Filter>
+    </ClCompile>
     <ClCompile Include="src\windows\osd.c">
       <Filter>Source Files\src\windows</Filter>
     </ClCompile>

--- a/man/fi_mr.3.md
+++ b/man/fi_mr.3.md
@@ -800,6 +800,12 @@ configure registration caches.
   are: 0 or 1. Note that the ROCR memory monitor requires a ROCR version with
   unified virtual addressing enabled.
 
+*FI_MR_ZE_CACHE_MONITOR_ENABLED*
+: The ZE cache monitor is responsible for detecting ZE device memory
+  (FI_HMEM_ZE) changes made between the device virtual addresses used by an
+  application and the underlying device physical pages. Valid monitor options
+  are: 0 or 1.
+
 More direct access to the internal registration cache is possible through the
 fi_open() call, using the "mr_cache" service name.  Once opened, custom
 memory monitors may be installed.  A memory monitor is a component of the cache

--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -60,6 +60,7 @@ struct ofi_mem_monitor *uffd_monitor = &uffd.monitor;
 struct ofi_mem_monitor *default_monitor;
 struct ofi_mem_monitor *default_cuda_monitor;
 struct ofi_mem_monitor *default_rocr_monitor;
+struct ofi_mem_monitor *default_ze_monitor;
 
 static size_t ofi_default_cache_size(void)
 {
@@ -97,6 +98,7 @@ void ofi_monitors_init(void)
 	memhooks_monitor->init(memhooks_monitor);
 	cuda_monitor->init(cuda_monitor);
 	rocr_monitor->init(rocr_monitor);
+	ze_monitor->init(ze_monitor);
 
 #if HAVE_MEMHOOKS_MONITOR
         default_monitor = memhooks_monitor;
@@ -133,6 +135,9 @@ void ofi_monitors_init(void)
 	fi_param_define(NULL, "mr_rocr_cache_monitor_enabled", FI_PARAM_BOOL,
 			"Enable or disable the ROCR cache memory monitor. "
 			"Monitor is enabled by default.");
+	fi_param_define(NULL, "mr_ze_cache_monitor_enabled", FI_PARAM_BOOL,
+			"Enable or disable the ZE cache memory monitor. "
+			"Monitor is enabled by default.");
 
 	fi_param_get_size_t(NULL, "mr_cache_max_size", &cache_params.max_size);
 	fi_param_get_size_t(NULL, "mr_cache_max_count", &cache_params.max_cnt);
@@ -141,6 +146,8 @@ void ofi_monitors_init(void)
 			  &cache_params.cuda_monitor_enabled);
 	fi_param_get_bool(NULL, "mr_rocr_cache_monitor_enabled",
 			  &cache_params.rocr_monitor_enabled);
+	fi_param_get_bool(NULL, "mr_ze_cache_monitor_enabled",
+			  &cache_params.ze_monitor_enabled);
 
 	if (!cache_params.max_size)
 		cache_params.max_size = ofi_default_cache_size();
@@ -174,6 +181,11 @@ void ofi_monitors_init(void)
 		default_rocr_monitor = rocr_monitor;
 	else
 		default_rocr_monitor = NULL;
+
+	if (cache_params.ze_monitor_enabled)
+		default_ze_monitor = ze_monitor;
+	else
+		default_ze_monitor = NULL;
 }
 
 void ofi_monitors_cleanup(void)
@@ -182,6 +194,7 @@ void ofi_monitors_cleanup(void)
 	memhooks_monitor->cleanup(memhooks_monitor);
 	cuda_monitor->cleanup(cuda_monitor);
 	rocr_monitor->cleanup(rocr_monitor);
+	ze_monitor->cleanup(ze_monitor);
 }
 
 /* Monitors array must be of size OFI_HMEM_MAX. */

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -48,6 +48,7 @@ struct ofi_mr_cache_params cache_params = {
 	.max_cnt = 1024,
 	.cuda_monitor_enabled = true,
 	.rocr_monitor_enabled = true,
+	.ze_monitor_enabled = true,
 };
 
 static int util_mr_find_within(struct ofi_rbmap *map, void *key, void *data)

--- a/prov/util/src/ze_mem_monitor.c
+++ b/prov/util/src/ze_mem_monitor.c
@@ -1,0 +1,117 @@
+/*
+ * (C) Copyright 2021 Intel Corporation
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "ofi_mr.h"
+
+#if HAVE_LIBZE
+
+#include "ofi_hmem.h"
+
+static int ze_mm_subscribe(struct ofi_mem_monitor *monitor, const void *addr,
+			   size_t len, union ofi_mr_hmem_info *hmem_info)
+{
+	return ze_hmem_get_id(addr, &hmem_info->ze_id);
+}
+
+static void ze_mm_unsubscribe(struct ofi_mem_monitor *monitor,
+			      const void *addr, size_t len,
+			      union ofi_mr_hmem_info *hmem_info)
+{
+	/* no-op */
+}
+
+static bool ze_mm_valid(struct ofi_mem_monitor *monitor,
+			const void *addr, size_t len,
+			union ofi_mr_hmem_info *hmem_info)
+{
+	uint64_t id;
+	int ret;
+
+	ret = ze_hmem_get_id(addr, &id);
+	if (ret)
+		return false;
+
+
+	return id == hmem_info->ze_id;
+}
+
+static int ze_monitor_start(struct ofi_mem_monitor *monitor)
+{
+	/* no-op */
+	return FI_SUCCESS;
+}
+
+#else
+
+static int ze_mm_subscribe(struct ofi_mem_monitor *monitor, const void *addr,
+			   size_t len, union ofi_mr_hmem_info *hmem_info)
+{
+	return -FI_ENOSYS;
+}
+
+static void ze_mm_unsubscribe(struct ofi_mem_monitor *monitor,
+			      const void *addr, size_t len,
+			      union ofi_mr_hmem_info *hmem_info)
+{
+}
+
+static bool ze_mm_valid(struct ofi_mem_monitor *monitor,
+			const void *addr, size_t len,
+			union ofi_mr_hmem_info *hmem_info)
+{
+	return false;
+}
+
+static int ze_monitor_start(struct ofi_mem_monitor *monitor)
+{
+	return -FI_ENOSYS;
+}
+
+#endif /* HAVE_LIBZE */
+
+void ze_monitor_stop(struct ofi_mem_monitor *monitor)
+{
+	/* no-op */
+}
+
+static struct ofi_mem_monitor ze_mm = {
+	.iface = FI_HMEM_ZE,
+	.init = ofi_monitor_init,
+	.cleanup = ofi_monitor_cleanup,
+	.start = ze_monitor_start,
+	.stop = ze_monitor_stop,
+	.subscribe = ze_mm_subscribe,
+	.unsubscribe = ze_mm_unsubscribe,
+	.valid = ze_mm_valid,
+};
+
+struct ofi_mem_monitor *ze_monitor = &ze_mm;

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -283,6 +283,7 @@ vrb_domain(struct fid_fabric *fabric, struct fi_info *info,
 		[FI_HMEM_SYSTEM] = default_monitor,
 		[FI_HMEM_CUDA] = default_cuda_monitor,
 		[FI_HMEM_ROCR] = default_rocr_monitor,
+		[FI_HMEM_ZE] = default_ze_monitor,
 	};
 	enum fi_hmem_iface iface;
 	struct vrb_domain *_domain;


### PR DESCRIPTION
Implement the required memory monitor funcitons for buffers allocated
with the oneAPI L0 (ZE) API. Enable MR caching for such buffers in the
verbs provider. Update the man page accordingly.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>