### PR TITLE
prov/verbs: Treat setting RNR as non-fatal

### DIFF
--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -424,7 +424,7 @@ fn:
 }
 
 #if ENABLE_DEBUG
-static int vrb_dbg_query_qp_attr(struct ibv_qp *qp)
+static void vrb_dbg_query_qp_attr(struct ibv_qp *qp)
 {
 	struct ibv_qp_init_attr attr = { 0 };
 	struct ibv_qp_attr qp_attr = { 0 };
@@ -434,8 +434,9 @@ static int vrb_dbg_query_qp_attr(struct ibv_qp *qp)
 			   IBV_QP_RNR_RETRY | IBV_QP_MIN_RNR_TIMER, &attr);
 	if (ret) {
 		VERBS_WARN(FI_LOG_EP_CTRL, "Unable to query QP\n");
-		return ret;
+		return;
 	}
+
 	FI_DBG(&vrb_prov, FI_LOG_EP_CTRL, "QP attributes: "
 	       "min_rnr_timer"	": %" PRIu8 ", "
 	       "timeout"	": %" PRIu8 ", "
@@ -443,16 +444,14 @@ static int vrb_dbg_query_qp_attr(struct ibv_qp *qp)
 	       "rnr_retry"	": %" PRIu8 "\n",
 	       qp_attr.min_rnr_timer, qp_attr.timeout, qp_attr.retry_cnt,
 	       qp_attr.rnr_retry);
-	return 0;
 }
 #else
-static int vrb_dbg_query_qp_attr(struct ibv_qp *qp)
+static void vrb_dbg_query_qp_attr(struct ibv_qp *qp)
 {
-	return 0;
 }
 #endif
 
-int vrb_set_rnr_timer(struct ibv_qp *qp)
+void vrb_set_rnr_timer(struct ibv_qp *qp)
 {
 	struct ibv_qp_attr attr = { 0 };
 	int ret;
@@ -468,17 +467,13 @@ int vrb_set_rnr_timer(struct ibv_qp *qp)
 
 	/* XRC initiator QP do not have responder logic */
 	if (qp->qp_type == IBV_QPT_XRC_SEND)
-		return 0;
+		return;
 
 	ret = ibv_modify_qp(qp, &attr, IBV_QP_MIN_RNR_TIMER);
-	if (ret) {
-		VERBS_WARN(FI_LOG_EQ, "Unable to modify QP attribute\n");
-		return ret;
-	}
-	ret = vrb_dbg_query_qp_attr(qp);
 	if (ret)
-		return ret;
-	return 0;
+		VERBS_WARN(FI_LOG_EQ, "Unable to modify QP attribute\n");
+
+	vrb_dbg_query_qp_attr(qp);
 }
 
 int vrb_find_max_inline(struct ibv_pd *pd, struct ibv_context *context,

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -847,7 +847,7 @@ ssize_t vrb_eq_write_event(struct vrb_eq *eq, uint32_t event,
 int vrb_query_atomic(struct fid_domain *domain_fid, enum fi_datatype datatype,
 			enum fi_op op, struct fi_atomic_attr *attr,
 			uint64_t flags);
-int vrb_set_rnr_timer(struct ibv_qp *qp);
+void vrb_set_rnr_timer(struct ibv_qp *qp);
 void vrb_cleanup_cq(struct vrb_ep *cur_ep);
 int vrb_find_max_inline(struct ibv_pd *pd, struct ibv_context *context,
 			   enum ibv_qp_type qp_type);

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -921,9 +921,7 @@ vrb_eq_cm_process_event(struct vrb_eq *eq,
 		if (cma_event->id->qp &&
 		    cma_event->id->qp->context->device->transport_type !=
 		    IBV_TRANSPORT_IWARP) {
-			ret = vrb_set_rnr_timer(cma_event->id->qp);
-			if (ret)
-				goto ack;
+			vrb_set_rnr_timer(cma_event->id->qp);
 		}
 		ep = container_of(fid, struct vrb_ep, util_ep.ep_fid);
 		if (vrb_is_xrc_ep(ep)) {


### PR DESCRIPTION
Do not fail a connection just because we can't override
the default rnr value.  This avoids a failure when running
over hnr HCAs.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>