### PR TITLE
Github Action to test PRs against OS Matrix

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,0 +1,52 @@
+name: OS Matrix Build Checks
+on: [push, pull_request]
+jobs:
+  linux:
+    runs-on: '${{ matrix.os }}'
+    strategy:
+      matrix:
+        os:
+          - ubuntu-18.04
+          - ubuntu-20.04
+      fail-fast: false
+    steps:
+      - name: Install dependencies (Linux OS)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y abi-compliance-checker abi-dumper \
+                                  build-essential debhelper dh-systemd \
+                                  fakeroot gcc git libnl-3-200 libnl-3-dev \
+                                  libnl-route-3-200 libnl-route-3-dev libnuma-dev \
+                                  libudev-dev make ninja-build pandoc \
+                                  pkg-config python rpm sparse valgrind wget
+      - uses: actions/checkout@v2
+      - name: Build Check
+        run: |
+          git clone --depth 1 -b v34.1 https://github.com/linux-rdma/rdma-core.git
+          pushd rdma-core; bash build.sh; popd
+          export RDMA_CORE_PATH="rdma-core/build"
+          export LD_LIBRARY_PATH="$RDMA_CORE_PATH/lib:$LD_LIBRARY_PATH"
+          ./autogen.sh
+          ./configure --prefix=$PWD/install --enable-usnic \
+                                            --enable-verbs=${RDMA_CORE_PATH} \
+                                            --enable-efa=${RDMA_CORE_PATH} \
+                                            --enable-shm \
+                                            --enable-tcp \
+                                            --enable-rxm \
+                                            --enable-rxd
+          make -j 4; make install
+          $PWD/install/bin/fi_info -l
+  macos:
+    runs-on: macos-10.15
+    steps:
+      - name: Install dependencies (Mac OS)
+        run: |
+           brew install automake
+           brew install libtool
+      - uses: actions/checkout@v2
+      - name: Build Check
+        run: |
+          ./autogen.sh
+          ./configure --prefix=$PWD/install
+          make -j 4; make install
+          $PWD/install/bin/fi_info -l


### PR DESCRIPTION
This commit adds a new Github Action to take the place of the test
matrix we had with Travis CI. Turns out, Github also provides two
different MacOS runners, so I have included that here as a separate
build job with a basic sanity check build.

Signed-off-by: Raghu Raja <raghu@enfabrica.net>

---

Example build: https://github.com/rajachan/libfabric/actions/runs/985476987 (or look at the action triggered by this PR)