### PR TITLE
ci: Add back psm3 with dependencies and enable clang builds

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -8,6 +8,9 @@ jobs:
         os:
           - ubuntu-18.04
           - ubuntu-20.04
+        cc:
+          - gcc
+          - clang
       fail-fast: false
     steps:
       - name: Install dependencies (Linux OS)
@@ -51,7 +54,8 @@ jobs:
                                             --enable-tcp \
                                             --enable-udp \
                                             --enable-usnic \
-                                            --enable-verbs=${RDMA_CORE_PATH}
+                                            --enable-verbs=${RDMA_CORE_PATH} \
+                                            CC=${{ matrix.cc }}
           make -j 4; make install
           $PWD/install/bin/fi_info -l
   macos:

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -13,12 +13,27 @@ jobs:
       - name: Install dependencies (Linux OS)
         run: |
           sudo apt-get update
-          sudo apt-get install -y abi-compliance-checker abi-dumper \
-                                  build-essential debhelper dh-systemd \
-                                  fakeroot gcc git libnl-3-200 libnl-3-dev \
-                                  libnl-route-3-200 libnl-route-3-dev libnuma-dev \
-                                  libudev-dev make ninja-build pandoc \
-                                  pkg-config python rpm sparse valgrind wget
+          sudo apt-get install -y abi-compliance-checker \
+                                  abi-dumper \
+                                  build-essential \
+                                  debhelper \
+                                  dh-systemd \
+                                  fakeroot \
+                                  gcc \
+                                  git \
+                                  libnl-3-200 libnl-3-dev libnl-route-3-200 libnl-route-3-dev \
+                                  libnuma-dev \
+                                  libudev-dev \
+                                  uuid-dev \
+                                  make \
+                                  ninja-build \
+                                  pandoc \
+                                  pkg-config \
+                                  python \
+                                  rpm \
+                                  sparse \
+                                  valgrind \
+                                  wget
       - uses: actions/checkout@v2
       - name: Build Check
         run: |
@@ -27,13 +42,16 @@ jobs:
           export RDMA_CORE_PATH="rdma-core/build"
           export LD_LIBRARY_PATH="$RDMA_CORE_PATH/lib:$LD_LIBRARY_PATH"
           ./autogen.sh
-          ./configure --prefix=$PWD/install --enable-usnic \
-                                            --enable-verbs=${RDMA_CORE_PATH} \
-                                            --enable-efa=${RDMA_CORE_PATH} \
+          ./configure --prefix=$PWD/install --enable-efa=${RDMA_CORE_PATH} \
+                                            --enable-mrail \
+                                            --enable-psm3=${RDMA_CORE_PATH} \
+                                            --enable-rxd \
+                                            --enable-rxm \
                                             --enable-shm \
                                             --enable-tcp \
-                                            --enable-rxm \
-                                            --enable-rxd
+                                            --enable-udp \
+                                            --enable-usnic \
+                                            --enable-verbs=${RDMA_CORE_PATH}
           make -j 4; make install
           $PWD/install/bin/fi_info -l
   macos:


### PR DESCRIPTION

Two commits in this PR. One fixes the PSM3 build issue discussed in https://github.com/ofiwg/libfabric/pull/6896
The other adds clang builds to the matrix, which we had with the Travis setup. Noticed some non-trivial clang warnings with PSM3 (@acgoldma ) and EFA (@wzamazon).

With this, the only thing remaining is coverity. I have a patch for that too, but having trouble getting the script to pickup secrets needed to push results to coverity. Will look at it another day.