### PR TITLE
contrib/intel: Remove mpi_stress

### DIFF
--- a/contrib/intel/jenkins/run.py
+++ b/contrib/intel/jenkins/run.py
@@ -19,17 +19,17 @@ bno = os.environ['BUILD_NUMBER']#args.buildno
 
 #run fi_info test
 def fi_info_test(core, hosts, mode,util=None):
-    
+
     fi_info_test = tests.FiInfoTest(jobname=jbname,buildno=bno,\
                     testname="fi_info", core_prov=core, fabric=fab,\
                          hosts=hosts, ofi_build_mode=mode, util_prov=util)
     print("running fi_info test for {}-{}-{}".format(core, util, fab))
     fi_info_test.execute_cmd()
-        
+
 
 #runfabtests
 def fabtests(core, hosts, mode, util=None):
-       
+
     runfabtest = tests.Fabtest(jobname=jbname,buildno=bno,\
                  testname="runfabtests", core_prov=core, fabric=fab,\
                  hosts=hosts, ofi_build_mode=mode, util_prov=util)
@@ -41,7 +41,7 @@ def fabtests(core, hosts, mode, util=None):
         print("skipping {} as execute condition fails"\
               .format(runfabtest.testname))
     print("----------------------------------------------------------------------------------------\n")
-    
+
 def shmemtest(core, hosts, mode, util=None):
     runshmemtest = tests.ShmemTest(jobname=jbname,buildno=bno,\
                  testname="shmem test", core_prov=core, fabric=fab,\
@@ -59,7 +59,7 @@ def shmemtest(core, hosts, mode, util=None):
         print("skipping {} as execute condition fails"\
               .format(runshmemtest.testname))
     print("----------------------------------------------------------------------------------------\n")
-    
+
 
 #imb-tests
 def intel_mpi_benchmark(core, hosts, mpi, mode, util=None):
@@ -67,7 +67,7 @@ def intel_mpi_benchmark(core, hosts, mpi, mode, util=None):
     imb_test = tests.MpiTestIMB(jobname=jbname,buildno=bno,\
                testname="IntelMPIbenchmark",core_prov=core, fabric=fab,\
                hosts=hosts, mpitype=mpi, ofi_build_mode=mode, util_prov=util)
-    
+
     if (imb_test.execute_condn == True  and imb_test.mpi_gen_execute_condn == True):
         print("running imb-tests for {}-{}-{}-{}".format(core, util, fab, mpi))
         imb_test.execute_cmd()
@@ -87,29 +87,15 @@ def mpich_test_suite(core, hosts, mpi, mode, util=None):
         print("Running mpich test suite: Spawn coll, comm, dt Tests for {}-{}-{}-{}".format(core, util, fab, mpi))
         os.environ["MPITEST_RETURN_WITH_CODE"] = "1"
         mpich_tests.execute_cmd("spawn")
- 
-#mpi_stress benchmark tests
-def mpistress_benchmark(core, hosts, mpi, mode, util=None):
-
-    stress_test = tests.MpiTestStress(jobname=jbname,buildno=bno,\
-                  testname="stress",core_prov=core, fabric=fab, mpitype=mpi,\
-                  hosts=hosts, ofi_build_mode=mode, util_prov=util)
- 
-    if (stress_test.execute_condn == True and stress_test.mpi_gen_execute_condn == True):
-        print("running mpistress-test for {}-{}-{}-{}".format(core, util, fab, mpi))
-        stress_test.execute_cmd()
-    else:
-        print("skipping {} as execute condition fails" \
-                    .format(stress_test.testname))
     print("----------------------------------------------------------------------------------------\n")
 
-#osu benchmark tests    
+#osu benchmark tests
 def osu_benchmark(core, hosts, mpi, mode, util=None):
 
     osu_test = tests.MpiTestOSU(jobname=jbname, buildno=bno, \
                testname="osu-benchmarks",core_prov=core, fabric=fab, mpitype=mpi, \
                hosts=hosts, ofi_build_mode=mode, util_prov=util)
-    
+
     if (osu_test.execute_condn == True and osu_test.mpi_gen_execute_condn == True):
         print("running osu-test for {}-{}-{}-{}".format(core, util, fab, mpi))
         osu_test.execute_cmd()

--- a/contrib/intel/jenkins/runtests.py
+++ b/contrib/intel/jenkins/runtests.py
@@ -28,7 +28,7 @@ node = (os.environ['NODE_NAME']).split('-')[0]
 hosts = [node]
 # Note: Temporarily disabling all mpich testing
 # due to mpich options issues which is causing
-# multiple tests to fail. 
+# multiple tests to fail.
 #mpilist = ['impi', 'mpich', 'ompi']
 mpilist = ['impi', 'ompi']
 
@@ -36,7 +36,7 @@ mpilist = ['impi', 'ompi']
 #this is done since some mpi tests
 #look for a valid location before running
 # the test on the secondary host(client)
-# but jenkins only creates a valid path on 
+# but jenkins only creates a valid path on
 # the primary host (server/test node)
 
 os.chdir('/tmp/')
@@ -51,9 +51,8 @@ if(args_core):
         run.shmemtest(args_core, hosts, ofi_build_mode)
         for mpi in mpilist:
             run.mpich_test_suite(args_core, hosts, mpi, ofi_build_mode)
-            run.intel_mpi_benchmark(args_core, hosts, mpi, ofi_build_mode)   
-            run.mpistress_benchmark(args_core, hosts, mpi, ofi_build_mode)
-            run.osu_benchmark(args_core, hosts, mpi, ofi_build_mode)  
+            run.intel_mpi_benchmark(args_core, hosts, mpi, ofi_build_mode)
+            run.osu_benchmark(args_core, hosts, mpi, ofi_build_mode)
     else:
         run.fi_info_test(args_core, hosts, ofi_build_mode, util=args_util)
         run.fabtests(args_core, hosts, ofi_build_mode, util=args_util)
@@ -64,10 +63,8 @@ if(args_core):
 
             run.intel_mpi_benchmark(args_core, hosts, mpi, ofi_build_mode, \
                                     util=args_util)
-            run.mpistress_benchmark(args_core, hosts, mpi, ofi_build_mode, \
-                                    util=args_util)
             run.osu_benchmark(args_core, hosts, mpi, ofi_build_mode, \
                                              util=args_util)
 else:
     print("Error : Specify a core provider to run tests")
-    
+


### PR DESCRIPTION
mpi_stress is some non-standing internal test of unknown origin
with unknown support.  Remove it from the Intel CI.

Editor automatically fixed some end of line endings as a bonus.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>