### PR TITLE
util/pingpong.c: fix the call to fi_recv in fi_pingpong_dgram

### DIFF
--- a/util/pingpong.c
+++ b/util/pingpong.c
@@ -2153,7 +2153,9 @@ static int run_pingpong_dgram(struct ct_pingpong *ct)
 	/* Post an extra receive to avoid lacking a posted receive in the
 	 * finalize.
 	 */
-	ret = fi_recv(ct->ep, ct->rx_buf, ct->rx_size, fi_mr_desc(ct->mr), 0,
+	ret = fi_recv(ct->ep, ct->rx_buf,
+		      MAX(ct->rx_size, PP_MAX_CTRL_MSG) +  ct->rx_prefix_size,
+		      fi_mr_desc(ct->mr), 0,
 		      ct->rx_ctx_ptr);
 	if (ret)
 		return ret;


### PR DESCRIPTION
fi_pingpong_dgram() call fi_recv to pre-post a buffer.

Currently, the buffer size in the call to fi_recv is wrong because
it did not include rx_prefix_size and did not conider max control
message size.

This patch address the issue.

Signed-off-by: Wei Zhang <wzam@amazon.com>