### PR TITLE
prov/efa: handle removed peer

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -142,7 +142,7 @@ struct efa_ah {
 
 struct efa_conn {
 	struct efa_ah		*ah;
-	struct efa_ep_addr	ep_addr;
+	struct efa_ep_addr	*ep_addr;
 	/* for FI_AV_TABLE, fi_addr is same as util_av_fi_addr,
 	 * for FI_AV_MAP, fi_addr is pointer to efa_conn; */
 	fi_addr_t		fi_addr;
@@ -594,7 +594,7 @@ struct rdm_peer *rxr_ep_get_peer(struct rxr_ep *ep, fi_addr_t addr)
 	util_av_entry = ofi_bufpool_get_ibuf(ep->util_ep.av->av_entry_pool,
 	                                     addr);
 	av_entry = (struct efa_av_entry *)util_av_entry->data;
-	return &av_entry->conn.rdm_peer;
+	return av_entry->conn.ep_addr ? &av_entry->conn.rdm_peer : NULL;
 }
 
 static inline

--- a/prov/efa/src/efa_msg.c
+++ b/prov/efa/src/efa_msg.c
@@ -332,6 +332,7 @@ static ssize_t efa_post_send(struct efa_ep *ep, const struct fi_msg *msg, uint64
 	memset(ewr, 0, sizeof(*ewr) + sizeof(*ewr->sge) * msg->iov_count);
 	wr = &ewr->wr;
 	conn = efa_av_addr_to_conn(ep->av, msg->addr);
+	assert(conn && conn->ep_addr);
 
 	ret = efa_post_send_validate(ep, msg, conn, flags, &len);
 	if (OFI_UNLIKELY(ret)) {
@@ -347,8 +348,8 @@ static ssize_t efa_post_send(struct efa_ep *ep, const struct fi_msg *msg, uint64
 	wr->opcode = IBV_WR_SEND;
 	wr->wr_id = (uintptr_t)msg->context;
 	wr->wr.ud.ah = conn->ah->ibv_ah;
-	wr->wr.ud.remote_qpn = conn->ep_addr.qpn;
-	wr->wr.ud.remote_qkey = conn->ep_addr.qkey;
+	wr->wr.ud.remote_qpn = conn->ep_addr->qpn;
+	wr->wr.ud.remote_qkey = conn->ep_addr->qkey;
 
 	ep->xmit_more_wr_tail->next = wr;
 	ep->xmit_more_wr_tail = wr;

--- a/prov/efa/src/efa_rma.c
+++ b/prov/efa/src/efa_rma.c
@@ -102,8 +102,9 @@ ssize_t efa_rma_post_read(struct efa_ep *ep, const struct fi_msg_rma *msg,
 				   qp->qp_num, qp->qkey);
 	} else {
 		conn = efa_av_addr_to_conn(ep->av, msg->addr);
+		assert(conn && conn->ep_addr);
 		ibv_wr_set_ud_addr(qp->ibv_qp_ex, conn->ah->ibv_ah,
-				   conn->ep_addr.qpn, conn->ep_addr.qkey);
+				   conn->ep_addr->qpn, conn->ep_addr->qkey);
 	}
 
 	return ibv_wr_complete(qp->ibv_qp_ex);

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -927,8 +927,10 @@ int rxr_cq_handle_rx_error(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,
 			   ssize_t prov_errno);
 int rxr_cq_handle_tx_error(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
 			   ssize_t prov_errno);
-int rxr_cq_handle_error(struct rxr_ep *ep, ssize_t prov_errno,
-			struct rxr_pkt_entry *pkt_entry);
+
+void rxr_cq_queue_rnr_pkt(struct rxr_ep *ep,
+			  struct dlist_entry *list,
+			  struct rxr_pkt_entry *pkt_entry);
 
 void rxr_cq_write_rx_completion(struct rxr_ep *ep,
 				struct rxr_rx_entry *rx_entry);

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -923,10 +923,11 @@ struct rxr_rx_entry *rxr_ep_split_rx_entry(struct rxr_ep *ep,
 int rxr_ep_efa_addr_to_str(const void *addr, char *temp_name);
 
 /* CQ sub-functions */
-int rxr_cq_handle_rx_error(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,
-			   ssize_t prov_errno);
-int rxr_cq_handle_tx_error(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
-			   ssize_t prov_errno);
+void rxr_cq_write_rx_error(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,
+			   int err, int prov_errno);
+
+void rxr_cq_write_tx_error(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
+			   int err, int prov_errno);
 
 void rxr_cq_queue_rnr_pkt(struct rxr_ep *ep,
 			  struct dlist_entry *list,

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -445,11 +445,12 @@ struct rxr_rx_entry {
 
 	/* linked with rx_entry_list in rdm_peer */
 	struct dlist_entry peer_entry;
+
+	/* linked with rx_entry_list in rxr_ep */
+	struct dlist_entry ep_entry;
 #if ENABLE_DEBUG
 	/* linked with rx_pending_list in rxr_ep */
 	struct dlist_entry rx_pending_entry;
-	/* linked with rx_entry_list in rxr_ep */
-	struct dlist_entry rx_entry_entry;
 #endif
 };
 
@@ -521,10 +522,8 @@ struct rxr_tx_entry {
 	/* peer_entry is linked with tx_entry_list in rdm_peer */
 	struct dlist_entry peer_entry;
 
-#if ENABLE_DEBUG
 	/* linked with tx_entry_list in rxr_ep */
-	struct dlist_entry tx_entry_entry;
-#endif
+	struct dlist_entry ep_entry;
 };
 
 #define RXR_GET_X_ENTRY_TYPE(pkt_entry)	\
@@ -700,16 +699,16 @@ struct rxr_ep {
 	/* tx packets waiting for send completion */
 	struct dlist_entry tx_pkt_list;
 
-	/* track allocated rx_entries and tx_entries for endpoint cleanup */
-	struct dlist_entry rx_entry_list;
-	struct dlist_entry tx_entry_list;
-
 	size_t efa_total_posted_tx_ops;
 	size_t shm_total_posted_tx_ops;
 	size_t send_comps;
 	size_t failed_send_comps;
 	size_t recv_comps;
 #endif
+	/* track allocated rx_entries and tx_entries for endpoint cleanup */
+	struct dlist_entry rx_entry_list;
+	struct dlist_entry tx_entry_list;
+
 	/* number of posted buffer for shm */
 	size_t posted_bufs_shm;
 	size_t rx_bufs_shm_to_post;
@@ -805,9 +804,8 @@ static inline void rxr_release_rx_entry(struct rxr_ep *ep,
 	if (rx_entry->peer)
 		dlist_remove(&rx_entry->peer_entry);
 
-#if ENABLE_DEBUG
-	dlist_remove(&rx_entry->rx_entry_entry);
-#endif
+	dlist_remove(&rx_entry->ep_entry);
+
 	if (!dlist_empty(&rx_entry->queued_pkts)) {
 		dlist_foreach_container_safe(&rx_entry->queued_pkts,
 					     struct rxr_pkt_entry,

--- a/prov/efa/src/rxr/rxr_atomic.c
+++ b/prov/efa/src/rxr/rxr_atomic.c
@@ -83,9 +83,8 @@ rxr_atomic_alloc_tx_entry(struct rxr_ep *rxr_ep,
 		return NULL;
 	}
 
-#if ENABLE_DEBUG
-	dlist_insert_tail(&tx_entry->tx_entry_entry, &rxr_ep->tx_entry_list);
-#endif
+	dlist_insert_tail(&tx_entry->ep_entry, &rxr_ep->tx_entry_list);
+
 	ofi_ioc_to_iov(msg_atomic->msg_iov, iov, msg_atomic->iov_count, datatype_size);
 	msg.addr = msg_atomic->addr;
 	msg.msg_iov = iov;

--- a/prov/efa/src/rxr/rxr_cq.c
+++ b/prov/efa/src/rxr/rxr_cq.c
@@ -67,32 +67,42 @@ static const char *rxr_cq_strerror(struct fid_cq *cq_fid, int prov_errno,
 	return str;
 }
 
-/*
- * Teardown rx_entry and write an error cq entry. With our current protocol we
- * will only encounter an RX error when sending a queued REQ or CTS packet or
- * if we are sending a CTS message. Because of this, the sender will not send
- * any additional data packets if the receiver encounters an error. If there is
- * a scenario in the future where the sender will continue to send data packets
- * we need to prevent rx_id mismatch. Ideally, we should add a NACK message and
- * tear down both RX and TX entires although whatever caused the error may
- * prevent that.
+/**
+ * @brief handle error happened to an RX (receive) operation
+ *
+ * This function will write an error cq entry to notify application the rx
+ * operation failed. If write failed, it will write an eq entry.
+ *
+ * It will also release resources owned by the RX entry, such as unexpected
+ * packet entry, because the RX operation is aborted.
+ *
+ * It will remove the rx_entry from queued rx_entry list for the same reason.
+ *
+ * It will NOT release the rx_entry because it is still possible to receive
+ * packet for this rx_entry.
  *
  * TODO: add a NACK message to tear down state on sender side
+ *
+ * @param[in]	ep		endpoint
+ * @param[in]	rx_entry	rx_entry that contains information of the tx operation
+ * @param[in]	err		positive libfabric error code
+ * @param[in]	prov_errno	positive provider specific error code
  */
-int rxr_cq_handle_rx_error(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,
-			   ssize_t prov_errno)
+void rxr_cq_write_rx_error(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,
+			   int err, int prov_errno)
 {
 	struct fi_cq_err_entry err_entry;
 	struct util_cq *util_cq;
 	struct dlist_entry *tmp;
 	struct rxr_pkt_entry *pkt_entry;
+	int write_cq_err;
 
 	memset(&err_entry, 0, sizeof(err_entry));
 
 	util_cq = ep->util_ep.rx_cq;
 
-	err_entry.err = FI_EIO;
-	err_entry.prov_errno = (int)prov_errno;
+	err_entry.err = err;
+	err_entry.prov_errno = prov_errno;
 
 	switch (rx_entry->state) {
 	case RXR_RX_INIT:
@@ -138,7 +148,7 @@ int rxr_cq_handle_rx_error(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,
 	rxr_msg_multi_recv_free_posted_entry(ep, rx_entry);
 
         FI_WARN(&rxr_prov, FI_LOG_CQ,
-		"rxr_cq_handle_rx_error: err: %d, prov_err: %s (%d)\n",
+		"rxr_cq_write_rx_error: err: %d, prov_err: %s (%d)\n",
 		err_entry.err, fi_strerror(-err_entry.prov_errno),
 		err_entry.prov_errno);
 
@@ -150,35 +160,50 @@ int rxr_cq_handle_rx_error(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,
 	//rxr_release_rx_entry(ep, rx_entry);
 
 	efa_cntr_report_error(&ep->util_ep, err_entry.flags);
-	return ofi_cq_write_error(util_cq, &err_entry);
+	write_cq_err = ofi_cq_write_error(util_cq, &err_entry);
+	if (write_cq_err) {
+		FI_WARN(&rxr_prov, FI_LOG_CQ,
+			"Error writing error cq entry when handling RX error");
+		efa_eq_write_error(&ep->util_ep, err, prov_errno);
+	}
 }
 
-/*
- * Teardown tx_entry and write an error cq entry. With our current protocol the
- * receiver will only send a CTS once the window is exhausted, meaning that all
- * data packets for that window will have been received successfully. This
- * means that the receiver will not send any CTS packets if the sender
- * encounters and error sending data packets. If that changes in the future we
- * will need to be careful to prevent tx_id mismatch.
+/**
+ * @brief write error CQ entry for a TX operation.
+ *
+ * This function write an error cq entry for a TX operation, if writing
+ * CQ error entry failed, it will write eq entry.
+ *
+ * If also remote the TX entry from ep->tx_queued_list and ep->tx_pending_list
+ * if the tx_entry is on it.
+ *
+ * It does NOT release tx entry because it is still possible to receive
+ * send completion for this TX entry
  *
  * TODO: add NACK message to tear down receive side state
+ *
+ * @param[in]	ep		endpoint
+ * @param[in]	tx_entry	tx_entry that contains information of the tx operation
+ * @param[in]	err		positive libfabric error code
+ * @param[in]	prov_errno	positive EFA provider specific error code
  */
-int rxr_cq_handle_tx_error(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
-			   ssize_t prov_errno)
+void rxr_cq_write_tx_error(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
+			   int err, int prov_errno)
 {
 	struct fi_cq_err_entry err_entry;
 	struct util_cq *util_cq;
 	uint32_t api_version;
 	struct dlist_entry *tmp;
 	struct rxr_pkt_entry *pkt_entry;
+	int write_cq_err;
 
 	memset(&err_entry, 0, sizeof(err_entry));
 
 	util_cq = ep->util_ep.tx_cq;
 	api_version = util_cq->domain->fabric->fabric_fid.api_version;
 
-	err_entry.err = FI_EIO;
-	err_entry.prov_errno = (int)prov_errno;
+	err_entry.err = err;
+	err_entry.prov_errno = prov_errno;
 
 	switch (tx_entry->state) {
 	case RXR_TX_REQ:
@@ -212,7 +237,7 @@ int rxr_cq_handle_tx_error(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
 		err_entry.err_data_size = 0;
 
 	FI_WARN(&rxr_prov, FI_LOG_CQ,
-		"rxr_cq_handle_tx_error: err: %d, prov_err: %s (%d)\n",
+		"rxr_cq_write_tx_error: err: %d, prov_err: %s (%d)\n",
 		err_entry.err, fi_strerror(-err_entry.prov_errno),
 		err_entry.prov_errno);
 
@@ -224,7 +249,12 @@ int rxr_cq_handle_tx_error(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
 	//rxr_release_tx_entry(ep, tx_entry);
 
 	efa_cntr_report_error(&ep->util_ep, tx_entry->cq_entry.flags);
-	return ofi_cq_write_error(util_cq, &err_entry);
+	write_cq_err = ofi_cq_write_error(util_cq, &err_entry);
+	if (write_cq_err) {
+		FI_WARN(&rxr_prov, FI_LOG_CQ,
+			"Error writing error cq entry when handling TX error");
+		efa_eq_write_error(&ep->util_ep, err, prov_errno);
+	}
 }
 
 /* @brief Queue a packet that encountered RNR error and setup RNR backoff
@@ -406,8 +436,7 @@ void rxr_cq_write_rx_completion(struct rxr_ep *ep,
 			FI_WARN(&rxr_prov, FI_LOG_CQ,
 				"Unable to write recv completion: %s\n",
 				fi_strerror(-ret));
-			if (rxr_cq_handle_rx_error(ep, rx_entry, ret))
-				assert(0 && "failed to write err cq entry");
+			rxr_cq_write_rx_error(ep, rx_entry, -ret, -ret);
 			return;
 		}
 
@@ -688,8 +717,7 @@ void rxr_cq_write_tx_completion(struct rxr_ep *ep,
 			FI_WARN(&rxr_prov, FI_LOG_CQ,
 				"Unable to write send completion: %s\n",
 				fi_strerror(-ret));
-			if (rxr_cq_handle_tx_error(ep, tx_entry, ret))
-				assert(0 && "failed to write err cq entry");
+			rxr_cq_write_tx_error(ep, tx_entry, -ret, -ret);
 			return;
 		}
 	}

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -105,7 +105,7 @@ struct rxr_rx_entry *rxr_ep_alloc_rx_entry(struct rxr_ep *ep, fi_addr_t addr, ui
 	if (addr != FI_ADDR_UNSPEC) {
 		rx_entry->peer = rxr_ep_get_peer(ep, addr);
 		assert(rx_entry->peer);
-		ofi_atomic_inc32(&rx_entry->peer->use_cnt);
+		dlist_insert_tail(&rx_entry->peer_entry, &rx_entry->peer->rx_entry_list);
 	} else {
 		/*
 		 * If msg->addr is not provided, rx_entry->peer will be set
@@ -347,7 +347,7 @@ void rxr_tx_entry_init(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
 	tx_entry->addr = msg->addr;
 	tx_entry->peer = rxr_ep_get_peer(ep, tx_entry->addr);
 	assert(tx_entry->peer);
-	ofi_atomic_inc32(&tx_entry->peer->use_cnt);
+	dlist_insert_tail(&tx_entry->peer_entry, &tx_entry->peer->tx_entry_list);
 
 	tx_entry->send_flags = 0;
 	tx_entry->rxr_flags = 0;
@@ -453,7 +453,7 @@ void rxr_release_tx_entry(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry)
 	struct rxr_pkt_entry *pkt_entry;
 
 	assert(tx_entry->peer);
-	ofi_atomic_dec32(&tx_entry->peer->use_cnt);
+	dlist_remove(&tx_entry->peer_entry);
 
 	for (i = 0; i < tx_entry->iov_count; i++) {
 		if (tx_entry->mr[i]) {

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -93,9 +93,7 @@ struct rxr_rx_entry *rxr_ep_alloc_rx_entry(struct rxr_ep *ep, fi_addr_t addr, ui
 	}
 	memset(rx_entry, 0, sizeof(struct rxr_rx_entry));
 
-#if ENABLE_DEBUG
-	dlist_insert_tail(&rx_entry->rx_entry_entry, &ep->rx_entry_list);
-#endif
+	dlist_insert_tail(&rx_entry->ep_entry, &ep->rx_entry_list);
 	rx_entry->type = RXR_RX_ENTRY;
 	rx_entry->rx_id = ofi_buf_index(rx_entry);
 	dlist_init(&rx_entry->queued_pkts);
@@ -440,9 +438,7 @@ struct rxr_tx_entry *rxr_ep_alloc_tx_entry(struct rxr_ep *rxr_ep,
 		tx_entry->tag = tag;
 	}
 
-#if ENABLE_DEBUG
-	dlist_insert_tail(&tx_entry->tx_entry_entry, &rxr_ep->tx_entry_list);
-#endif
+	dlist_insert_tail(&tx_entry->ep_entry, &rxr_ep->tx_entry_list);
 	return tx_entry;
 }
 
@@ -467,9 +463,8 @@ void rxr_release_tx_entry(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry)
 		}
 	}
 
-#if ENABLE_DEBUG
-	dlist_remove(&tx_entry->tx_entry_entry);
-#endif
+	dlist_remove(&tx_entry->ep_entry);
+
 	dlist_foreach_container_safe(&tx_entry->queued_pkts,
 				     struct rxr_pkt_entry,
 				     pkt_entry, entry, tmp) {
@@ -605,75 +600,96 @@ int rxr_ep_set_tx_credit_request(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_
 
 static void rxr_ep_free_res(struct rxr_ep *rxr_ep)
 {
-#if ENABLE_DEBUG
-	struct dlist_entry *tmp;
-	struct dlist_entry *entry;
+	struct dlist_entry *entry, *tmp;
 	struct rxr_rx_entry *rx_entry;
 	struct rxr_tx_entry *tx_entry;
+#if ENABLE_DEBUG
 	struct rxr_pkt_entry *pkt;
 #endif
 
-#if ENABLE_DEBUG
-	dlist_foreach(&rxr_ep->rx_unexp_list, entry) {
+	dlist_foreach_safe(&rxr_ep->rx_unexp_list, entry, tmp) {
 		rx_entry = container_of(entry, struct rxr_rx_entry, entry);
+		FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,
+			"Closing ep with unmatched unexpected rx_entry: %p pkt_entry %p\n",
+			rx_entry, rx_entry->unexp_pkt);
 		rxr_pkt_entry_release_rx(rxr_ep, rx_entry->unexp_pkt);
+		rxr_release_rx_entry(rxr_ep, rx_entry);
 	}
 
-	dlist_foreach(&rxr_ep->rx_unexp_tagged_list, entry) {
+	dlist_foreach_safe(&rxr_ep->rx_unexp_tagged_list, entry, tmp) {
 		rx_entry = container_of(entry, struct rxr_rx_entry, entry);
+		FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,
+			"Closing ep with unmatched unexpected tagged rx_entry: %p pkt_entry %p\n",
+			rx_entry, rx_entry->unexp_pkt);
 		rxr_pkt_entry_release_rx(rxr_ep, rx_entry->unexp_pkt);
+		rxr_release_rx_entry(rxr_ep, rx_entry);
 	}
 
-	dlist_foreach(&rxr_ep->rx_entry_queued_list, entry) {
+	dlist_foreach_safe(&rxr_ep->rx_entry_queued_list, entry, tmp) {
 		rx_entry = container_of(entry, struct rxr_rx_entry,
 					queued_entry);
-		dlist_foreach_container_safe(&rx_entry->queued_pkts,
-					     struct rxr_pkt_entry,
-					     pkt, entry, tmp)
-			rxr_pkt_entry_release_tx(rxr_ep, pkt);
+		FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,
+			"Closing ep with queued rx_entry: %p\n",
+			rx_entry);
+		rxr_release_rx_entry(rxr_ep, rx_entry);
 	}
 
-	dlist_foreach(&rxr_ep->tx_entry_queued_list, entry) {
+	dlist_foreach_safe(&rxr_ep->tx_entry_queued_list, entry, tmp) {
 		tx_entry = container_of(entry, struct rxr_tx_entry,
 					queued_entry);
-		dlist_foreach_container_safe(&tx_entry->queued_pkts,
-					     struct rxr_pkt_entry,
-					     pkt, entry, tmp)
-			rxr_pkt_entry_release_tx(rxr_ep, pkt);
+		FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,
+			"Closing ep with queued tx_entry: %p\n",
+			tx_entry);
+		rxr_release_tx_entry(rxr_ep, tx_entry);
 	}
 
-	dlist_foreach_safe(&rxr_ep->rx_pkt_list, entry, tmp) {
-		pkt = container_of(entry, struct rxr_pkt_entry, dbg_entry);
-		rxr_pkt_entry_release_rx(rxr_ep, pkt);
-	}
-
+#if ENABLE_DEBUG
 	dlist_foreach_safe(&rxr_ep->rx_posted_buf_list, entry, tmp) {
 		pkt = container_of(entry, struct rxr_pkt_entry, dbg_entry);
 		ofi_buf_free(pkt);
 	}
 
-	dlist_foreach_safe(&rxr_ep->tx_pkt_list, entry, tmp) {
-		pkt = container_of(entry, struct rxr_pkt_entry, dbg_entry);
-		rxr_pkt_entry_release_tx(rxr_ep, pkt);
-	}
-
-	dlist_foreach_safe(&rxr_ep->rx_entry_list, entry, tmp) {
-		rx_entry = container_of(entry, struct rxr_rx_entry,
-					rx_entry_entry);
-		rxr_release_rx_entry(rxr_ep, rx_entry);
-	}
-	dlist_foreach_safe(&rxr_ep->tx_entry_list, entry, tmp) {
-		tx_entry = container_of(entry, struct rxr_tx_entry,
-					tx_entry_entry);
-		rxr_release_tx_entry(rxr_ep, tx_entry);
-	}
 	if (rxr_ep->use_shm) {
 		dlist_foreach_safe(&rxr_ep->rx_posted_buf_shm_list, entry, tmp) {
 			pkt = container_of(entry, struct rxr_pkt_entry, dbg_entry);
 			ofi_buf_free(pkt);
 		}
 	}
+
+	dlist_foreach_safe(&rxr_ep->rx_pkt_list, entry, tmp) {
+		pkt = container_of(entry, struct rxr_pkt_entry, dbg_entry);
+		FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,
+			"Closing ep with unreleased RX pkt_entry: %p\n",
+			pkt);
+		rxr_pkt_entry_release_rx(rxr_ep, pkt);
+	}
+
+	dlist_foreach_safe(&rxr_ep->tx_pkt_list, entry, tmp) {
+		pkt = container_of(entry, struct rxr_pkt_entry, dbg_entry);
+		FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,
+			"Closing ep with unreleased TX pkt_entry: %p\n",
+			pkt);
+		rxr_pkt_entry_release_tx(rxr_ep, pkt);
+	}
 #endif
+
+	dlist_foreach_safe(&rxr_ep->rx_entry_list, entry, tmp) {
+		rx_entry = container_of(entry, struct rxr_rx_entry,
+					ep_entry);
+		FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,
+			"Closing ep with unreleased rx_entry: %p\n",
+			rx_entry);
+		rxr_release_rx_entry(rxr_ep, rx_entry);
+	}
+
+	dlist_foreach_safe(&rxr_ep->tx_entry_list, entry, tmp) {
+		tx_entry = container_of(entry, struct rxr_tx_entry,
+					ep_entry);
+		FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,
+			"Closing ep with unreleased tx_entry: %p\n",
+			tx_entry);
+		rxr_release_tx_entry(rxr_ep, tx_entry);
+	}
 
 	if (rxr_ep->rx_entry_pool)
 		ofi_bufpool_destroy(rxr_ep->rx_entry_pool);
@@ -1301,9 +1317,10 @@ int rxr_ep_init(struct rxr_ep *ep)
 	dlist_init(&ep->rx_pending_list);
 	dlist_init(&ep->rx_pkt_list);
 	dlist_init(&ep->tx_pkt_list);
+#endif
 	dlist_init(&ep->rx_entry_list);
 	dlist_init(&ep->tx_entry_list);
-#endif
+
 	/* Initialize pkt to rx map */
 	ep->pkt_rx_map = NULL;
 	return 0;

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -2216,8 +2216,13 @@ void rxr_ep_dec_tx_op_counter(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry
 	struct rdm_peer *peer;
 
 	/*
-	 * peer can be NULL when the pkt_entry is a RMA_CONTEXT_PKT,
-	 * and the RMA is a local read toward the endpoint itself
+	 * peer can be NULL when:
+	 *
+	 * 1. the pkt_entry is a RMA_CONTEXT_PKT, and the RMA op is a local read
+	 *    toward the endpoint itself.
+	 * 2. peer's address has been removed from address vector. Either because
+	 *    a new peer has the same GID+QPN was inserted to address, or because
+	 *    application removed the peer from address vector.
 	 */
 	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
 

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -65,8 +65,7 @@ struct efa_ep_addr *rxr_peer_raw_addr(struct rxr_ep *ep, fi_addr_t addr)
 	efa_ep = container_of(ep->rdm_ep, struct efa_ep, util_ep.ep_fid);
 	efa_av = efa_ep->av;
 	efa_conn = efa_av_addr_to_conn(efa_av, addr);
-
-	return &efa_conn->ep_addr;
+	return efa_conn ? efa_conn->ep_addr : NULL;
 }
 
 const char *rxr_peer_raw_addr_str(struct rxr_ep *ep, fi_addr_t addr, char *buf, size_t *buflen)

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -525,9 +525,7 @@ ssize_t rxr_pkt_trigger_handshake(struct rxr_ep *ep,
 	tx_entry->iov_offset = 0;
 	tx_entry->fi_flags = RXR_NO_COMPLETION | RXR_NO_COUNTER;
 
-#if ENABLE_DEBUG
-	dlist_insert_tail(&tx_entry->tx_entry_entry, &ep->tx_entry_list);
-#endif
+	dlist_insert_tail(&tx_entry->ep_entry, &ep->tx_entry_list);
 
 	err = rxr_pkt_post_ctrl(ep, RXR_TX_ENTRY, tx_entry, RXR_EAGER_RTW_PKT, 0);
 

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -504,7 +504,7 @@ ssize_t rxr_pkt_trigger_handshake(struct rxr_ep *ep,
 	tx_entry->addr = addr;
 	tx_entry->peer = rxr_ep_get_peer(ep, tx_entry->addr);
 	assert(tx_entry->peer);
-	ofi_atomic_inc32(&tx_entry->peer->use_cnt);
+	dlist_insert_tail(&tx_entry->peer_entry, &tx_entry->peer->tx_entry_list);
 	tx_entry->msg_id = -1;
 	tx_entry->cq_entry.flags = FI_RMA | FI_WRITE;
 	tx_entry->cq_entry.buf = NULL;

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -671,9 +671,173 @@ void rxr_pkt_handle_data_copied(struct rxr_ep *ep,
 	}
 }
 
-/*
- *   Functions used to handle packet send completion
+/**
+ * @brief handle the a packet that encountered error completion while sending
+ *
+ * Depend on the packet type and error type, the error are handled differently.
+ *
+ * If the packet is associated with an user initialized TX operation:
+ * (TX means send,read or write; such packets include all REQ packets and DATA):
+ *
+ *    If the error is Receiver Not Ready (RNR). there are two cases:
+ *
+ *         If user wants to manager RNR by itself (FI_RM_DISABLED),
+ *         an error CQ entry will be written.
+ *
+ *         Otherwise, the packet will be queued and resnt by progress engine.
+ *
+ *    For other type of error, an error CQ entry is written.
+ *
+ * If the packet is associated with an user initialized recv operiaton,
+ * (such packets include EOR, CTS):
+ *
+ *      If the error is RNR, the packet is queued and resent by progress
+ *      engine. No CQ entry is written.
+ *
+ *      For other types of error, an error CQ entry is written.
+ *
+ * If the packet is not associated with an user operation (such packet include
+ * HANDSHAKE):
+ *
+ *      If the error is RNR, the packet is queued and resent by progress engine.
+ *
+ *      For othre types of error, an error EQ entry is written.
+ *
+ * @param[in]	ep		endpoint
+ * @param[in]	pkt_entry	pkt entry
+ * @param[in]	err		libfabric error code
+ * @param[in]	prov_errno	provider specific error code
  */
+void rxr_pkt_handle_send_error(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry, int err, int prov_errno)
+{
+	struct rdm_peer *peer;
+	struct rxr_tx_entry *tx_entry;
+	struct rxr_rx_entry *rx_entry;
+	int write_cq_err;
+
+	assert(pkt_entry->alloc_type == RXR_PKT_FROM_EFA_TX_POOL ||
+	       pkt_entry->alloc_type == RXR_PKT_FROM_SHM_TX_POOL);
+
+	rxr_ep_dec_tx_op_counter(ep, pkt_entry);
+
+	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
+	if (!peer) {
+		/*
+		 * If peer is NULL, it means the peer has been removed from AV.
+		 * In this case, ignore this error completion.
+		 */
+		FI_WARN(&rxr_prov, FI_LOG_CQ, "ignoring send error completion of a packet to a removed peer.\n");
+		rxr_pkt_entry_release_tx(ep, pkt_entry);
+		return;
+	}
+
+	if (!pkt_entry->x_entry) {
+		/* only handshake packet is not associated with any TX/RX operation */
+		assert(rxr_get_base_hdr(pkt_entry->pkt)->type == RXR_HANDSHAKE_PKT);
+		rxr_pkt_entry_release_tx(ep, pkt_entry);
+		if (prov_errno == IBV_WC_RNR_RETRY_EXC_ERR) {
+			/*
+			 * handshake should always be queued for RNR
+			 */
+			assert(!(peer->flags & RXR_PEER_HANDSHAKE_QUEUED));
+			peer->flags |= RXR_PEER_HANDSHAKE_QUEUED;
+			dlist_insert_tail(&peer->handshake_queued_entry,
+					  &ep->handshake_queued_peer_list);
+		} else if (prov_errno != IBV_WC_REM_INV_RD_REQ_ERR) {
+			/* If prov_errno is IBV_WC_REM_INV_RD_REQ_ERR, the peer has been destroyed.
+			 * Which is normal, as peer does not always need a handshake packet perform
+			 * its duty. (For example, if a peer just want to sent 1 message to the ep, it
+			 * does not need handshake.)
+			 * In this case, it is safe to ignore this error completion.
+			 * In all other cases, we write an eq entry because there is no application
+			 * operation associated with handshake.
+			 */
+			efa_eq_write_error(&ep->util_ep, err, prov_errno);
+		}
+		return;
+	}
+
+	if (RXR_GET_X_ENTRY_TYPE(pkt_entry) == RXR_TX_ENTRY) {
+		tx_entry = pkt_entry->x_entry;
+		if (prov_errno == IBV_WC_RNR_RETRY_EXC_ERR &&
+		    ep->handle_resource_management == FI_RM_ENABLED) {
+			/*
+			 * This packet is assoiciated with a send operation,
+			 * (such packets include all REQ, DATA)
+			 * thus shoud be queued for RNR only if
+			 * application want EFA to manager resource.
+			 */
+			rxr_cq_queue_rnr_pkt(ep, &tx_entry->queued_pkts, pkt_entry);
+			if (tx_entry->state == RXR_TX_SEND) {
+				dlist_remove(&tx_entry->entry);
+				tx_entry->state = RXR_TX_QUEUED_DATA_RNR;
+				dlist_insert_tail(&tx_entry->queued_entry,
+						  &ep->tx_entry_queued_list);
+			} else if (tx_entry->state == RXR_TX_REQ) {
+				tx_entry->state = RXR_TX_QUEUED_REQ_RNR;
+				dlist_insert_tail(&tx_entry->queued_entry,
+						  &ep->tx_entry_queued_list);
+			}
+		} else {
+			write_cq_err = rxr_cq_handle_tx_error(ep, pkt_entry->x_entry, err);
+			if (write_cq_err)
+				efa_eq_write_error(&ep->util_ep, err, prov_errno);
+			rxr_pkt_entry_release_tx(ep, pkt_entry);
+		}
+
+		return;
+	}
+
+	if (RXR_GET_X_ENTRY_TYPE(pkt_entry) == RXR_RX_ENTRY) {
+		rx_entry = pkt_entry->x_entry;
+		if (prov_errno == IBV_WC_RNR_RETRY_EXC_ERR) {
+			/*
+			 * This packet is associated with a recv operation,
+			 * (such packets include CTS and EOR)
+			 * thus should always be queued for RNR.
+			 * This is regardless value of ep->handle_resource_management,
+			 * because resource management is only applied to send operation.
+			 */
+			rxr_cq_queue_rnr_pkt(ep, &rx_entry->queued_pkts, pkt_entry);
+			/*
+			 * rx_entry send one ctrl packet at a time, so if we
+			 * received RNR for the packet, the rx_entry must not
+			 * be in ep's rx_queued_entry_list, thus cannot
+			 * be in QUEUED_CTRL state
+			 */
+			assert(rx_entry->state != RXR_RX_QUEUED_CTRL);
+			rx_entry->state = RXR_RX_QUEUED_CTRL;
+			dlist_insert_tail(&rx_entry->queued_entry,
+					  &ep->rx_entry_queued_list);
+
+		} else {
+			write_cq_err = rxr_cq_handle_rx_error(ep, pkt_entry->x_entry, err);
+			if (write_cq_err)
+				efa_eq_write_error(&ep->util_ep, err, prov_errno);
+			rxr_pkt_entry_release_tx(ep, pkt_entry);
+		}
+
+		return;
+	}
+
+	if (RXR_GET_X_ENTRY_TYPE(pkt_entry) == RXR_READ_ENTRY) {
+		/* read will not encounter RNR */
+		assert(prov_errno != IBV_WC_RNR_RETRY_EXC_ERR);
+		write_cq_err = rxr_read_handle_error(ep, pkt_entry->x_entry, err);
+		if (write_cq_err)
+			efa_eq_write_error(&ep->util_ep, err, prov_errno);
+		rxr_pkt_entry_release_tx(ep, pkt_entry);
+		return;
+	}
+
+	FI_WARN(&rxr_prov, FI_LOG_CQ,
+		"%s unknown x_entry type %d\n",
+		__func__, RXR_GET_X_ENTRY_TYPE(pkt_entry));
+	assert(0 && "unknown x_entry state");
+	efa_eq_write_error(&ep->util_ep, err, prov_errno);
+	rxr_pkt_entry_release_tx(ep, pkt_entry);
+}
+
 void rxr_pkt_handle_send_completion(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 {
 	struct rdm_peer *peer;
@@ -782,7 +946,7 @@ void rxr_pkt_handle_send_completion(struct rxr_ep *ep, struct rxr_pkt_entry *pkt
 			"invalid control pkt type %d\n",
 			rxr_get_base_hdr(pkt_entry->pkt)->type);
 		assert(0 && "invalid control pkt type");
-		rxr_cq_handle_error(ep, FI_EIO, NULL);
+		efa_eq_write_error(&ep->util_ep, FI_EIO, FI_EIO);
 		return;
 	}
 
@@ -790,9 +954,45 @@ void rxr_pkt_handle_send_completion(struct rxr_ep *ep, struct rxr_pkt_entry *pkt
 	rxr_pkt_entry_release_tx(ep, pkt_entry);
 }
 
-/*
- *  Functions used to handle packet receive completion
+/**
+ * @brief handle the a packet that encountered error completion while receiving
+ *
+ * This function will write error cq or eq entry, then release the packet entry.
+ *
+ * @param[in]	ep		endpoint
+ * @param[in]	pkt_entry	pkt entry
+ * @param[in]	err		libfabric error code
+ * @param[in]	prov_errno	provider specific error code
  */
+void rxr_pkt_handle_recv_error(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry, int err, int prov_errno)
+{
+	int write_cq_error;
+
+	if (!pkt_entry->x_entry) {
+		efa_eq_write_error(&ep->util_ep, err, prov_errno);
+		rxr_pkt_entry_release_tx(ep, pkt_entry);
+		return;
+	}
+
+	if (RXR_GET_X_ENTRY_TYPE(pkt_entry) == RXR_TX_ENTRY) {
+		write_cq_error = rxr_cq_handle_tx_error(ep, pkt_entry->x_entry, err);
+		if (write_cq_error)
+			efa_eq_write_error(&ep->util_ep, err, prov_errno);
+	} else if (RXR_GET_X_ENTRY_TYPE(pkt_entry) == RXR_RX_ENTRY) {
+		write_cq_error = rxr_cq_handle_rx_error(ep, pkt_entry->x_entry, err);
+		if (write_cq_error)
+			efa_eq_write_error(&ep->util_ep, err, prov_errno);
+	} else {
+		FI_WARN(&rxr_prov, FI_LOG_CQ,
+		"%s unknown x_entry type %d\n",
+			__func__, RXR_GET_X_ENTRY_TYPE(pkt_entry));
+		assert(0 && "unknown x_entry state");
+		efa_eq_write_error(&ep->util_ep, err, prov_errno);
+	}
+
+	rxr_pkt_entry_release_rx(ep, pkt_entry);
+}
+
 static
 fi_addr_t rxr_pkt_insert_addr(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry, void *raw_addr)
 {
@@ -849,14 +1049,14 @@ void rxr_pkt_proc_received(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 		FI_WARN(&rxr_prov, FI_LOG_CQ,
 			"Received a RTS packet, which has been retired since protocol version 4\n");
 		assert(0 && "deprecated RTS pakcet received");
-		rxr_cq_handle_error(ep, FI_EIO, NULL);
+		efa_eq_write_error(&ep->util_ep, FI_EIO, FI_EIO);
 		rxr_pkt_entry_release_rx(ep, pkt_entry);
 		return;
 	case RXR_RETIRED_CONNACK_PKT:
 		FI_WARN(&rxr_prov, FI_LOG_CQ,
 			"Received a CONNACK packet, which has been retired since protocol version 4\n");
 		assert(0 && "deprecated CONNACK pakcet received");
-		rxr_cq_handle_error(ep, FI_EIO, NULL);
+		efa_eq_write_error(&ep->util_ep, FI_EIO, FI_EIO);
 		rxr_pkt_entry_release_rx(ep, pkt_entry);
 		return;
 	case RXR_EOR_PKT:
@@ -922,7 +1122,7 @@ void rxr_pkt_proc_received(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 			"invalid control pkt type %d\n",
 			rxr_get_base_hdr(pkt_entry->pkt)->type);
 		assert(0 && "invalid control pkt type");
-		rxr_cq_handle_error(ep, FI_EIO, NULL);
+		efa_eq_write_error(&ep->util_ep, FI_EIO, FI_EIO);
 		rxr_pkt_entry_release_rx(ep, pkt_entry);
 		return;
 	}
@@ -944,7 +1144,7 @@ void rxr_pkt_handle_recv_completion(struct rxr_ep *ep,
 			(int)pkt_entry->addr, base_hdr->type);
 
 		assert(0 && "invalid REQ packe type");
-		rxr_cq_handle_error(ep, FI_EIO, NULL);
+		efa_eq_write_error(&ep->util_ep, FI_EIO, FI_EIO);
 		rxr_pkt_entry_release_rx(ep, pkt_entry);
 		return;
 	}

--- a/prov/efa/src/rxr/rxr_pkt_cmd.h
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.h
@@ -56,8 +56,16 @@ void rxr_pkt_handle_data_copied(struct rxr_ep *ep,
 				struct rxr_pkt_entry *pkt_entry,
 				size_t data_size);
 
+void rxr_pkt_handle_send_error(struct rxr_ep *ep,
+			       struct rxr_pkt_entry *pkt_entry,
+			       int err, int prov_errno);
+
 void rxr_pkt_handle_send_completion(struct rxr_ep *ep,
 				    struct rxr_pkt_entry *pkt_entry);
+
+void rxr_pkt_handle_recv_error(struct rxr_ep *ep,
+			       struct rxr_pkt_entry *pkt_entry,
+			       int err, int prov_errno);
 
 void rxr_pkt_handle_recv_completion(struct rxr_ep *ep,
 				    struct rxr_pkt_entry *pkt_entry);

--- a/prov/efa/src/rxr/rxr_pkt_type_data.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_data.c
@@ -317,7 +317,7 @@ void rxr_pkt_proc_data(struct rxr_ep *ep,
 				 pkt_entry, data, seg_size);
 	if (err) {
 		rxr_pkt_entry_release_rx(ep, pkt_entry);
-		rxr_cq_handle_rx_error(ep, rx_entry, err);
+		rxr_cq_write_rx_error(ep, rx_entry, -err, -err);
 	}
 
 	if (all_received)
@@ -328,7 +328,7 @@ void rxr_pkt_proc_data(struct rxr_ep *ep,
 		err = rxr_pkt_post_ctrl_or_queue(ep, RXR_RX_ENTRY, rx_entry, RXR_CTS_PKT, 0);
 		if (err) {
 			FI_WARN(&rxr_prov, FI_LOG_CQ, "post CTS packet failed!\n");
-			rxr_cq_handle_rx_error(ep, rx_entry, err);
+			rxr_cq_write_rx_error(ep, rx_entry, -err, -err);
 		}
 	}
 }

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -451,8 +451,7 @@ void rxr_pkt_handle_rma_read_completion(struct rxr_ep *ep,
 			inject = (read_entry->lower_ep_type == SHM_EP);
 			ret = rxr_pkt_post_ctrl_or_queue(ep, RXR_RX_ENTRY, rx_entry, RXR_EOR_PKT, inject);
 			if (OFI_UNLIKELY(ret)) {
-				if (rxr_cq_handle_rx_error(ep, rx_entry, ret))
-					assert(0 && "failed to write err cq entry");
+				rxr_cq_write_rx_error(ep, rx_entry, -ret, -ret);
 				rxr_release_rx_entry(ep, rx_entry);
 			}
 		} else {

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -1243,7 +1243,7 @@ ssize_t rxr_pkt_proc_rtm_rta(struct rxr_ep *ep,
 		FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,
 			"Unknown packet type ID: %d\n",
 		       base_hdr->type);
-		rxr_cq_handle_error(ep, -FI_EINVAL, NULL);
+		efa_eq_write_error(&ep->util_ep, FI_EINVAL, FI_EINVAL);
 		rxr_pkt_entry_release_rx(ep, pkt_entry);
 	}
 

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -1161,10 +1161,7 @@ ssize_t rxr_pkt_proc_msgrtm(struct rxr_ep *ep,
 	if (rx_entry->state == RXR_RX_MATCHED) {
 		err = rxr_pkt_proc_matched_rtm(ep, rx_entry, pkt_entry);
 		if (OFI_UNLIKELY(err)) {
-			if (rxr_cq_handle_rx_error(ep, rx_entry, err)) {
-				assert(0 && "cannot write cq error entry");
-				efa_eq_write_error(&ep->util_ep, -err, err);
-			}
+			rxr_cq_write_rx_error(ep, rx_entry, -err, -err);
 			rxr_pkt_entry_release_rx(ep, pkt_entry);
 			rxr_release_rx_entry(ep, rx_entry);
 			return err;
@@ -1190,10 +1187,7 @@ ssize_t rxr_pkt_proc_tagrtm(struct rxr_ep *ep,
 	if (rx_entry->state == RXR_RX_MATCHED) {
 		err = rxr_pkt_proc_matched_rtm(ep, rx_entry, pkt_entry);
 		if (OFI_UNLIKELY(err)) {
-			if (rxr_cq_handle_rx_error(ep, rx_entry, err)) {
-				assert(0 && "cannot write error cq entry");
-				efa_eq_write_error(&ep->util_ep, -err, err);
-			}
+			rxr_cq_write_rx_error(ep, rx_entry, -err, -err);
 			rxr_pkt_entry_release_rx(ep, pkt_entry);
 			rxr_release_rx_entry(ep, rx_entry);
 			return err;
@@ -1743,7 +1737,7 @@ void rxr_pkt_handle_long_rtw_recv(struct rxr_ep *ep,
 	err = rxr_pkt_post_ctrl_or_queue(ep, RXR_RX_ENTRY, rx_entry, RXR_CTS_PKT, 0);
 	if (OFI_UNLIKELY(err)) {
 		FI_WARN(&rxr_prov, FI_LOG_CQ, "Cannot post CTS packet\n");
-		rxr_cq_handle_rx_error(ep, rx_entry, err);
+		rxr_cq_write_rx_error(ep, rx_entry, -err, -err);
 		rxr_release_rx_entry(ep, rx_entry);
 	}
 }
@@ -2128,8 +2122,7 @@ int rxr_pkt_proc_dc_write_rta(struct rxr_ep *ep,
 		FI_WARN(&rxr_prov, FI_LOG_CQ,
 			"Posting of receipt packet failed! err=%s\n",
 			fi_strerror(err));
-		if (rxr_cq_handle_rx_error(ep, rx_entry, err))
-			assert(0 && "Cannot handle rx error");
+		rxr_cq_write_rx_error(ep, rx_entry, -err, -err);
 		return err;
 	}
 
@@ -2166,10 +2159,8 @@ int rxr_pkt_proc_fetch_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 	}
 
 	err = rxr_pkt_post_ctrl_or_queue(ep, RXR_RX_ENTRY, rx_entry, RXR_ATOMRSP_PKT, 0);
-	if (OFI_UNLIKELY(err)) {
-		if (rxr_cq_handle_rx_error(ep, rx_entry, err))
-			assert(0 && "Cannot handle rx error");
-	}
+	if (OFI_UNLIKELY(err))
+		rxr_cq_write_rx_error(ep, rx_entry, -err, -err);
 
 	rxr_pkt_entry_release_rx(ep, pkt_entry);
 	return 0;

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -1077,7 +1077,7 @@ ssize_t rxr_pkt_proc_matched_rtm(struct rxr_ep *ep,
 		rx_entry->addr = pkt_entry->addr;
 		rx_entry->peer = rxr_ep_get_peer(ep, rx_entry->addr);
 		assert(rx_entry->peer);
-		ofi_atomic_inc32(&rx_entry->peer->use_cnt);
+		dlist_insert_tail(&rx_entry->peer_entry, &rx_entry->peer->rx_entry_list);
 	}
 
 	/* Adjust rx_entry->cq_entry.len as needed.

--- a/prov/efa/src/rxr/rxr_read.h
+++ b/prov/efa/src/rxr/rxr_read.h
@@ -127,7 +127,7 @@ int rxr_read_post_local_read_or_queue(struct rxr_ep *ep,
 
 void rxr_read_handle_read_completion(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
 
-int rxr_read_handle_error(struct rxr_ep *ep, struct rxr_read_entry *read_entry, int ret);
+void rxr_read_write_error(struct rxr_ep *ep, struct rxr_read_entry *read_entry, int err, int prov_errno);
 
 #endif
 

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -92,9 +92,7 @@ rxr_rma_alloc_readrsp_tx_entry(struct rxr_ep *rxr_ep,
 	}
 
 	assert(tx_entry);
-#if ENABLE_DEBUG
-	dlist_insert_tail(&tx_entry->tx_entry_entry, &rxr_ep->tx_entry_list);
-#endif
+	dlist_insert_tail(&tx_entry->ep_entry, &rxr_ep->tx_entry_list);
 
 	msg.msg_iov = rx_entry->iov;
 	msg.iov_count = rx_entry->iov_count;
@@ -155,9 +153,7 @@ rxr_rma_alloc_tx_entry(struct rxr_ep *rxr_ep,
 	memcpy(tx_entry->rma_iov, msg_rma->rma_iov,
 	       sizeof(struct fi_rma_iov) * msg_rma->rma_iov_count);
 
-#if ENABLE_DEBUG
-	dlist_insert_tail(&tx_entry->tx_entry_entry, &rxr_ep->tx_entry_list);
-#endif
+	dlist_insert_tail(&tx_entry->ep_entry, &rxr_ep->tx_entry_list);
 	return tx_entry;
 }
 


### PR DESCRIPTION
This PR contains a series of patches that handles the case of a peer was removed from address vector.