### PR TITLE
hmem/ze: Enable loading ZE library with dlopen()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -550,10 +550,7 @@ AS_IF([test x"$with_ze" != x"no"],
 			[$with_ze],
 			[],
 			[have_ze=1],
-			[], [])
-       CPPFLAGS="$CPPFLAGS $ze_CPPFLAGS"
-       LDFLAGS="$LDFLAGS $ze_LDFLAGS"
-       LIBS="$LIBS $ze_LIBS"],
+			[], [])],
       [])
 
 have_drm=0
@@ -567,6 +564,23 @@ AS_IF([test x"$with_ze" != x"no" && test -n "$with_ze" && test "$have_ze" = "0" 
 
 AC_DEFINE_UNQUOTED([HAVE_LIBZE], [$have_ze], [ZE support])
 AC_DEFINE_UNQUOTED([HAVE_DRM], [$have_drm], [i915 DRM header])
+
+AC_ARG_ENABLE([ze-dlopen],
+    [AS_HELP_STRING([--enable-ze-dlopen],
+        [Enable dlopen of ZE libraries @<:@default=no@:>@])
+    ],
+    [
+        AS_IF([test "$freebsd" = "0"], [
+            AC_CHECK_LIB(dl, dlopen, [],
+                [AC_MSG_ERROR([dlopen not found.  libfabric requires libdl.])])
+        ])
+        AC_DEFINE([ENABLE_ZE_DLOPEN], [1], [dlopen ZE libraries])
+    ],
+    [enable_ze_dlopen=no])
+
+CPPFLAGS="$CPPFLAGS $ze_CPPFLAGS"
+LDFLAGS="$LDFLAGS $ze_LDFLAGS"
+AS_IF([test x"$enable_ze_dlopen" != x"yes"], [LIBS="$LIBS $ze_LIBS"])
 
 enable_memhooks=1
 AC_ARG_ENABLE([memhooks-monitor],

--- a/src/hmem_ze.c
+++ b/src/hmem_ze.c
@@ -66,6 +66,224 @@ static const ze_command_list_desc_t cl_desc = {
 	.flags				= 0,
 };
 
+struct libze_ops {
+	ze_result_t (*zeInit)(ze_init_flags_t flags);
+	ze_result_t (*zeDriverGet)(uint32_t *pCount,
+				   ze_driver_handle_t *phDrivers);
+	ze_result_t (*zeDeviceGet)(ze_driver_handle_t hDriver,
+				   uint32_t *pCount,
+				   ze_device_handle_t *phDevices);
+	ze_result_t (*zeDeviceCanAccessPeer)(ze_device_handle_t hDevice,
+					     ze_device_handle_t hPeerDevice,
+					     ze_bool_t *value);
+	ze_result_t (*zeContextCreate)(ze_driver_handle_t hDriver,
+				       const ze_context_desc_t *desc,
+				       ze_context_handle_t *phContext);
+	ze_result_t (*zeContextDestroy)(ze_context_handle_t hContext);
+	ze_result_t (*zeCommandQueueCreate)(ze_context_handle_t hContext,
+					    ze_device_handle_t hDevice,
+					    const ze_command_queue_desc_t *desc,
+					    ze_command_queue_handle_t *phCommandQueue);
+	ze_result_t (*zeCommandQueueDestroy)(ze_command_queue_handle_t hCommandQueue);
+	ze_result_t (*zeCommandQueueExecuteCommandLists)(
+					ze_command_queue_handle_t hCommandQueue,
+					uint32_t numCommandLists,
+					ze_command_list_handle_t *phCommandLists,
+					ze_fence_handle_t hFence);
+	ze_result_t (*zeCommandListCreate)(ze_context_handle_t hContext,
+					   ze_device_handle_t hDevice,
+					   const ze_command_list_desc_t *desc,
+					   ze_command_list_handle_t *phCommandList);
+	ze_result_t (*zeCommandListDestroy)(ze_command_list_handle_t hCommandList);
+	ze_result_t (*zeCommandListClose)(ze_command_list_handle_t hCommandList);
+	ze_result_t (*zeCommandListAppendMemoryCopy)(
+				ze_command_list_handle_t hCommandList,
+				void *dstptr, const void *srcptr, size_t size,
+				ze_event_handle_t hSignalEvent,
+				uint32_t numWaitEvents,
+				ze_event_handle_t *phWaitEvents);
+	ze_result_t (*zeMemGetAllocProperties)(
+				ze_context_handle_t hContext, const void *ptr,
+				ze_memory_allocation_properties_t *pMemAllocProperties,
+				ze_device_handle_t *phDevice);
+	ze_result_t (*zeMemGetAddressRange)(
+				ze_context_handle_t hContext, const void *ptr,
+				void **pBase, size_t *pSize);
+	ze_result_t (*zeMemGetIpcHandle)(ze_context_handle_t hContext,
+					 const void *ptr,
+					 ze_ipc_mem_handle_t *pIpcHandle);
+	ze_result_t (*zeMemOpenIpcHandle)(ze_context_handle_t hContext,
+					  ze_device_handle_t hDevice,
+					  ze_ipc_mem_handle_t handle,
+					  ze_ipc_memory_flags_t flags,
+					  void **pptr);
+	ze_result_t (*zeMemCloseIpcHandle)(ze_context_handle_t hContext,
+					   const void *ptr);
+};
+
+#ifdef ENABLE_ZE_DLOPEN
+
+#include <dlfcn.h>
+
+static void *libze_handle;
+static struct libze_ops libze_ops;
+
+#else
+
+static struct libze_ops libze_ops = {
+	.zeInit = zeInit,
+	.zeDriverGet = zeDriverGet,
+	.zeDeviceGet = zeDeviceGet,
+	.zeDeviceCanAccessPeer = zeDeviceCanAccessPeer,
+	.zeContextCreate = zeContextCreate,
+	.zeContextDestroy = zeContextDestroy,
+	.zeCommandQueueCreate = zeCommandQueueCreate,
+	.zeCommandQueueDestroy = zeCommandQueueDestroy,
+	.zeCommandQueueExecuteCommandLists = zeCommandQueueExecuteCommandLists,
+	.zeCommandListCreate = zeCommandListCreate,
+	.zeCommandListDestroy = zeCommandListDestroy,
+	.zeCommandListClose = zeCommandListClose,
+	.zeCommandListAppendMemoryCopy = zeCommandListAppendMemoryCopy,
+	.zeMemGetAllocProperties = zeMemGetAllocProperties,
+	.zeMemGetAddressRange = zeMemGetAddressRange,
+	.zeMemGetIpcHandle = zeMemGetIpcHandle,
+	.zeMemOpenIpcHandle = zeMemOpenIpcHandle,
+	.zeMemCloseIpcHandle = zeMemCloseIpcHandle,
+};
+
+#endif /* ENABLE_ZE_DLOPEN */
+
+ze_result_t ofi_zeInit(ze_init_flags_t flags)
+{
+	return (*libze_ops.zeInit)(flags);
+}
+
+ze_result_t ofi_zeDriverGet(uint32_t *pCount, ze_driver_handle_t *phDrivers)
+{
+	return (*libze_ops.zeDriverGet)(pCount, phDrivers);
+}
+
+ze_result_t ofi_zeDeviceGet(ze_driver_handle_t hDriver, uint32_t *pCount,
+			    ze_device_handle_t *phDevices)
+{
+	return (*libze_ops.zeDeviceGet)(hDriver, pCount, phDevices);
+}
+
+ze_result_t ofi_zeDeviceCanAccessPeer(ze_device_handle_t hDevice,
+				      ze_device_handle_t hPeerDevice,
+				      ze_bool_t *value)
+{
+	return (*libze_ops.zeDeviceCanAccessPeer)(hDevice, hPeerDevice, value);
+}
+
+ze_result_t ofi_zeContextCreate(ze_driver_handle_t hDriver,
+				const ze_context_desc_t *desc,
+				ze_context_handle_t *phContext)
+{
+	return (*libze_ops.zeContextCreate)(hDriver, desc, phContext);
+}
+
+ze_result_t ofi_zeContextDestroy(ze_context_handle_t hContext)
+{
+	return (*libze_ops.zeContextDestroy)(hContext);
+}
+
+ze_result_t ofi_zeCommandQueueCreate(ze_context_handle_t hContext,
+				     ze_device_handle_t hDevice,
+				     const ze_command_queue_desc_t *desc,
+				     ze_command_queue_handle_t *phCommandQueue)
+{
+	return (*libze_ops.zeCommandQueueCreate)(hContext, hDevice, desc,
+						 phCommandQueue);
+}
+
+ze_result_t ofi_zeCommandQueueDestroy(ze_command_queue_handle_t hCommandQueue)
+{
+	return (*libze_ops.zeCommandQueueDestroy)(hCommandQueue);
+}
+
+ze_result_t ofi_zeCommandQueueExecuteCommandLists(
+				ze_command_queue_handle_t hCommandQueue,
+				uint32_t numCommandLists,
+				ze_command_list_handle_t *phCommandLists,
+				ze_fence_handle_t hFence)
+{
+	return (*libze_ops.zeCommandQueueExecuteCommandLists)(
+				hCommandQueue, numCommandLists, phCommandLists,
+				hFence);
+}
+
+ze_result_t ofi_zeCommandListCreate(ze_context_handle_t hContext,
+				    ze_device_handle_t hDevice,
+				    const ze_command_list_desc_t *desc,
+				    ze_command_list_handle_t *phCommandList)
+{
+	return (*libze_ops.zeCommandListCreate)(hContext, hDevice, desc,
+						phCommandList);
+}
+
+ze_result_t ofi_zeCommandListDestroy(ze_command_list_handle_t hCommandList)
+{
+	return (*libze_ops.zeCommandListDestroy)(hCommandList);
+}
+
+ze_result_t ofi_zeCommandListClose(ze_command_list_handle_t hCommandList)
+{
+	return (*libze_ops.zeCommandListClose)(hCommandList);
+}
+
+ze_result_t ofi_zeCommandListAppendMemoryCopy(
+				ze_command_list_handle_t hCommandList,
+				void *dstptr, const void *srcptr, size_t size,
+				ze_event_handle_t hSignalEvent,
+				uint32_t numWaitEvents,
+				ze_event_handle_t *phWaitEvents)
+{
+	return (*libze_ops.zeCommandListAppendMemoryCopy)(
+				hCommandList, dstptr, srcptr, size, hSignalEvent,
+				numWaitEvents, phWaitEvents);
+}
+
+ze_result_t ofi_zeMemGetAllocProperties(ze_context_handle_t hContext,
+					const void *ptr,
+					ze_memory_allocation_properties_t
+						*pMemAllocProperties,
+					ze_device_handle_t *phDevice)
+{
+	return (*libze_ops.zeMemGetAllocProperties)(
+					hContext, ptr, pMemAllocProperties,
+					phDevice);
+}
+
+ze_result_t ofi_zeMemGetAddressRange(ze_context_handle_t hContext,
+				     const void *ptr, void **pBase,
+				     size_t *pSize)
+{
+	return (*libze_ops.zeMemGetAddressRange)(hContext, ptr, pBase, pSize);
+}
+
+ze_result_t ofi_zeMemGetIpcHandle(ze_context_handle_t hContext, const void *ptr,
+				  ze_ipc_mem_handle_t *pIpcHandle)
+{
+	return (*libze_ops.zeMemGetIpcHandle)(hContext, ptr, pIpcHandle);
+}
+
+ze_result_t ofi_zeMemOpenIpcHandle(ze_context_handle_t hContext,
+				   ze_device_handle_t hDevice,
+				   ze_ipc_mem_handle_t handle,
+				   ze_ipc_memory_flags_t flags,
+				   void **pptr)
+{
+	return (*libze_ops.zeMemOpenIpcHandle)(hContext, hDevice, handle, flags,
+					       pptr);
+}
+
+ze_result_t ofi_zeMemCloseIpcHandle(ze_context_handle_t hContext,
+				    const void *ptr)
+{
+	return (*libze_ops.zeMemCloseIpcHandle)(hContext, ptr);
+}
+
 #if HAVE_DRM
 #include <drm/i915_drm.h>
 #include <sys/ioctl.h>
@@ -182,6 +400,150 @@ bool ze_hmem_p2p_enabled(void)
 
 #endif //HAVE_DRM
 
+static int ze_hmem_dl_init(void)
+{
+#ifdef ENABLE_ZE_DLOPEN
+	libze_handle = dlopen("libze_loader.so", RTLD_NOW);
+	if (!libze_handle) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"Failed to dlopen libze_loader.so\n");
+		goto err_out;
+	}
+
+	libze_ops.zeInit = dlsym(libze_handle, "zeInit");
+	if (!libze_ops.zeInit) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "Failed to find zeInit\n");
+		goto err_dlclose;
+	}
+
+	libze_ops.zeDriverGet = dlsym(libze_handle, "zeDriverGet");
+	if (!libze_ops.zeDriverGet) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "Failed to find zeDriverGet\n");
+		goto err_dlclose;
+	}
+
+	libze_ops.zeDeviceGet = dlsym(libze_handle, "zeDeviceGet");
+	if (!libze_ops.zeDeviceGet) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "Failed to find zeDeviceGet\n");
+		goto err_dlclose;
+	}
+
+	libze_ops.zeDeviceCanAccessPeer = dlsym(libze_handle, "zeDeviceCanAccessPeer");
+	if (!libze_ops.zeDeviceCanAccessPeer) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "Failed to find zeDeviceCanAccessPeer\n");
+		goto err_dlclose;
+	}
+
+	libze_ops.zeContextCreate = dlsym(libze_handle, "zeContextCreate");
+	if (!libze_ops.zeContextCreate) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "Failed to find zeContextCreate\n");
+		goto err_dlclose;
+	}
+
+	libze_ops.zeContextDestroy = dlsym(libze_handle, "zeContextDestroy");
+	if (!libze_ops.zeContextDestroy) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "Failed to find zeContextDestroy\n");
+		goto err_dlclose;
+	}
+
+	libze_ops.zeContextDestroy = dlsym(libze_handle, "zeContextDestroy");
+	if (!libze_ops.zeContextDestroy) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "Failed to find zeContextDestroy\n");
+		goto err_dlclose;
+	}
+
+	libze_ops.zeCommandQueueCreate = dlsym(libze_handle, "zeCommandQueueCreate");
+	if (!libze_ops.zeCommandQueueCreate) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "Failed to find zeCommandQueueCreate\n");
+		goto err_dlclose;
+	}
+
+	libze_ops.zeCommandQueueDestroy = dlsym(libze_handle, "zeCommandQueueDestroy");
+	if (!libze_ops.zeCommandQueueDestroy) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "Failed to find zeCommandQueueDestroy\n");
+		goto err_dlclose;
+	}
+
+	libze_ops.zeCommandQueueExecuteCommandLists = dlsym(libze_handle, "zeCommandQueueExecuteCommandLists");
+	if (!libze_ops.zeCommandQueueExecuteCommandLists) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "Failed to find zeCommandQueueExecuteCommandLists\n");
+		goto err_dlclose;
+	}
+
+	libze_ops.zeCommandListCreate = dlsym(libze_handle, "zeCommandListCreate");
+	if (!libze_ops.zeCommandListCreate) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "Failed to find zeCommandListCreate\n");
+		goto err_dlclose;
+	}
+
+	libze_ops.zeCommandListDestroy = dlsym(libze_handle, "zeCommandListDestroy");
+	if (!libze_ops.zeCommandListDestroy) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "Failed to find zeCommandListDestroy\n");
+		goto err_dlclose;
+	}
+
+	libze_ops.zeCommandListClose = dlsym(libze_handle, "zeCommandListClose");
+	if (!libze_ops.zeCommandListClose) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "Failed to find zeCommandListClose\n");
+		goto err_dlclose;
+	}
+
+	libze_ops.zeCommandListAppendMemoryCopy = dlsym(libze_handle, "zeCommandListAppendMemoryCopy");
+	if (!libze_ops.zeCommandListAppendMemoryCopy) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "Failed to find zeCommandListAppendMemoryCopy\n");
+		goto err_dlclose;
+	}
+
+	libze_ops.zeMemGetAllocProperties = dlsym(libze_handle, "zeMemGetAllocProperties");
+	if (!libze_ops.zeMemGetAllocProperties) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "Failed to find zeMemGetAllocProperties\n");
+		goto err_dlclose;
+	}
+
+	libze_ops.zeMemGetAddressRange = dlsym(libze_handle, "zeMemGetAddressRange");
+	if (!libze_ops.zeMemGetAddressRange) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "Failed to find zeMemGetAddressRange\n");
+		goto err_dlclose;
+	}
+
+	libze_ops.zeMemGetIpcHandle = dlsym(libze_handle, "zeMemGetIpcHandle");
+	if (!libze_ops.zeMemGetIpcHandle) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "Failed to find zeMemGetIpcHandle\n");
+		goto err_dlclose;
+	}
+
+	libze_ops.zeMemOpenIpcHandle = dlsym(libze_handle, "zeMemOpenIpcHandle");
+	if (!libze_ops.zeMemOpenIpcHandle) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "Failed to find zeMemOpenIpcHandle\n");
+		goto err_dlclose;
+	}
+
+	libze_ops.zeMemCloseIpcHandle = dlsym(libze_handle, "zeMemCloseIpcHandle");
+	if (!libze_ops.zeMemCloseIpcHandle) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "Failed to find zeMemCloseIpcHandle\n");
+		goto err_dlclose;
+	}
+
+	return FI_SUCCESS;
+
+err_dlclose:
+	dlclose(libze_handle);
+
+err_out:
+	return -FI_ENODATA;
+
+#else
+	return FI_SUCCESS;
+#endif /* ENABLE_ZE_DLOPEN */
+}
+
+static void ze_hmem_dl_cleanup(void)
+{
+#ifdef ENABLE_ZE_DLOPEN
+	dlclose(libze_handle);
+#endif
+}
+
 int ze_hmem_init(void)
 {
 	ze_driver_handle_t driver;
@@ -192,16 +554,20 @@ int ze_hmem_init(void)
 	bool p2p = true;
 	int ret;
 
-	ze_ret = zeInit(ZE_INIT_FLAG_GPU_ONLY);
+	ret = ze_hmem_dl_init();
+	if (ret)
+		return ret;
+
+	ze_ret = ofi_zeInit(ZE_INIT_FLAG_GPU_ONLY);
 	if (ze_ret)
 		return -FI_EIO;
 
 	count = 1;
-	ze_ret = zeDriverGet(&count, &driver);
+	ze_ret = ofi_zeDriverGet(&count, &driver);
 	if (ze_ret)
 		return -FI_EIO;
 
-	ze_ret = zeContextCreate(driver, &context_desc, &context);
+	ze_ret = ofi_zeContextCreate(driver, &context_desc, &context);
 	if (ze_ret)
 		return -FI_EIO;
 
@@ -209,11 +575,11 @@ int ze_hmem_init(void)
 		;
 
 	count = 0;
-	ze_ret = zeDeviceGet(driver, &count, NULL);
+	ze_ret = ofi_zeDeviceGet(driver, &count, NULL);
 	if (ze_ret || count > ZE_MAX_DEVICES)
 		goto err;
 
-	ze_ret = zeDeviceGet(driver, &count, devices);
+	ze_ret = ofi_zeDeviceGet(driver, &count, devices);
 	if (ze_ret)
 		goto err;
 
@@ -222,13 +588,15 @@ int ze_hmem_init(void)
 		goto err;
 
 	for (num_devices = 0; num_devices < count; num_devices++) {
-		ze_ret = zeCommandQueueCreate(context, devices[num_devices], &cq_desc,
-					      &cmd_queue[num_devices]);
+		ze_ret = ofi_zeCommandQueueCreate(context,
+						  devices[num_devices],
+						  &cq_desc,
+						  &cmd_queue[num_devices]);
 		if (ze_ret)
 			goto err;
 
 		for (i = 0; i < count; i++) {
-			if (zeDeviceCanAccessPeer(devices[num_devices],
+			if (ofi_zeDeviceCanAccessPeer(devices[num_devices],
 					devices[i], &access) || !access)
 				p2p = false;
 		}
@@ -250,7 +618,7 @@ int ze_hmem_cleanup(void)
 	int i, ret = FI_SUCCESS;
 
 	for (i = 0; i < num_devices; i++) {
-		if (cmd_queue[i] && zeCommandQueueDestroy(cmd_queue[i])) {
+		if (cmd_queue[i] && ofi_zeCommandQueueDestroy(cmd_queue[i])) {
 			FI_WARN(&core_prov, FI_LOG_CORE,
 				"Failed to destroy ZE cmd_queue\n");
 			ret = -FI_EINVAL;
@@ -261,9 +629,10 @@ int ze_hmem_cleanup(void)
 		}
 	}
 
-	if (zeContextDestroy(context))
-		return -FI_EINVAL;
+	if (ofi_zeContextDestroy(context))
+		ret = -FI_EINVAL;
 
+	ze_hmem_dl_cleanup();
 	return ret;
 }
 
@@ -273,23 +642,25 @@ int ze_hmem_copy(uint64_t device, void *dst, const void *src, size_t size)
 	ze_result_t ze_ret;
 	int dev_id = (int) device;
 
-	ze_ret = zeCommandListCreate(context, devices[dev_id], &cl_desc, &cmd_list);
+	ze_ret = ofi_zeCommandListCreate(context, devices[dev_id], &cl_desc,
+					 &cmd_list);
 	if (ze_ret)
 		goto err;
 
-	ze_ret = zeCommandListAppendMemoryCopy(cmd_list, dst, src, size, NULL, 0, NULL);
+	ze_ret = ofi_zeCommandListAppendMemoryCopy(cmd_list, dst, src, size,
+						   NULL, 0, NULL);
 	if (ze_ret)
 		goto free;
 
-	ze_ret = zeCommandListClose(cmd_list);
+	ze_ret = ofi_zeCommandListClose(cmd_list);
 	if (ze_ret)
 		goto free;
 
-	ze_ret = zeCommandQueueExecuteCommandLists(cmd_queue[dev_id], 1,
-						   &cmd_list, NULL);
+	ze_ret = ofi_zeCommandQueueExecuteCommandLists(cmd_queue[dev_id], 1,
+						       &cmd_list, NULL);
 
 free:
-	if (!zeCommandListDestroy(cmd_list) && !ze_ret)
+	if (!ofi_zeCommandListDestroy(cmd_list) && !ze_ret)
 		return FI_SUCCESS;
 err:
 	FI_WARN(&core_prov, FI_LOG_CORE,
@@ -306,8 +677,8 @@ bool ze_is_addr_valid(const void *addr)
 
 	mem_props.stype = ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES;
 	mem_props.pNext = NULL;
-	ze_ret = zeMemGetAllocProperties(context, addr, &mem_props,
-					 &device);
+	ze_ret = ofi_zeMemGetAllocProperties(context, addr, &mem_props,
+					     &device);
 
 	return (!ze_ret && mem_props.type == ZE_MEMORY_TYPE_DEVICE);
 }
@@ -316,8 +687,8 @@ int ze_hmem_get_handle(void *dev_buf, void **handle)
 {
 	ze_result_t ze_ret;
 
-	ze_ret = zeMemGetIpcHandle(context, dev_buf,
-				   (ze_ipc_mem_handle_t *) handle);
+	ze_ret = ofi_zeMemGetIpcHandle(context, dev_buf,
+				       (ze_ipc_mem_handle_t *) handle);
 	if (ze_ret) {
 		FI_WARN(&core_prov, FI_LOG_CORE, "Unable to get handle\n");
 		return -FI_EINVAL;
@@ -330,9 +701,9 @@ int ze_hmem_open_handle(void **handle, uint64_t device, void **ipc_ptr)
 {
 	ze_result_t ze_ret;
 
-	ze_ret = zeMemOpenIpcHandle(context, devices[device],
-				    *((ze_ipc_mem_handle_t *) handle),
-				    0, ipc_ptr);
+	ze_ret = ofi_zeMemOpenIpcHandle(context, devices[device],
+					*((ze_ipc_mem_handle_t *) handle),
+					0, ipc_ptr);
 	if (ze_ret) {
 		FI_WARN(&core_prov, FI_LOG_CORE,
 			"Unable to open memory handle\n");
@@ -346,7 +717,7 @@ int ze_hmem_close_handle(void *ipc_ptr)
 {
 	ze_result_t ze_ret;
 
-	ze_ret = zeMemCloseIpcHandle(context, ipc_ptr);
+	ze_ret = ofi_zeMemCloseIpcHandle(context, ipc_ptr);
 	if (ze_ret) {
 		FI_WARN(&core_prov, FI_LOG_CORE,
 			"Unable to close memory handle\n");
@@ -361,7 +732,7 @@ int ze_hmem_get_base_addr(const void *ptr, void **base)
 	ze_result_t ze_ret;
 	size_t size;
 
-	ze_ret = zeMemGetAddressRange(context, ptr, base, &size);
+	ze_ret = ofi_zeMemGetAddressRange(context, ptr, base, &size);
 	if (ze_ret) {
 		FI_WARN(&core_prov, FI_LOG_CORE,
 			"Could not get base addr\n");
@@ -378,7 +749,7 @@ int ze_hmem_get_id(const void *ptr, uint64_t *id)
 
 	mem_props.stype = ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES;
 	mem_props.pNext = NULL;
-	ze_ret = zeMemGetAllocProperties(context, ptr, &mem_props, &device);
+	ze_ret = ofi_zeMemGetAllocProperties(context, ptr, &mem_props, &device);
 	if (ze_ret || mem_props.type == ZE_MEMORY_TYPE_UNKNOWN) {
 		FI_WARN(&core_prov, FI_LOG_CORE,
 			"Could not get memory id\n");


### PR DESCRIPTION
Add configure option '--enable-ze-dlopen' which, when set to true, lets
the ZE library be loaded with dlopen() instead of becoming a runtime
dependency of libfabric.so. This allows libfabric to be built with
ZE support and still be able to run on systems that don't have the ZE
library installed.

Similar work has already been done with hmem/cuda and hmem/rocr.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>

Fix #6915 