### PR TITLE
include/ofi_mem.h: remove an assertion in ofi_bufpool_get_ibuf()

### DIFF
--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -440,7 +440,6 @@ static inline void *ofi_bufpool_get_ibuf(struct ofi_bufpool *pool, size_t index)
 	buf = pool->region_table[(size_t)(index / pool->attr.chunk_cnt)]->
 		mem_region + (index % pool->attr.chunk_cnt) * pool->entry_size;
 
-	assert(ofi_buf_region(buf)->use_cnt);
 	return buf;
 }
 


### PR DESCRIPTION
Currently, there is an assertion in ofi_bufpool_get_ibuf() that
the region (where the entry located)'s use_cnt must be > 0, which
means getting an entry from an empyt region will cause application
to crash in debug mode.

However, there is a legitimate case that (getting an entry
from an empty region) can happen, which is demonstrated in
the following workflow:

1. an entry was allocated from a region, region's use_cnt increased to 1.
2. the index was passed to an entity A.
3. the entry was freed by another entity B, and the region has not
   allocated entry thus the use_cnt is 0.
4. A does not know the entry has been freed and called
   ofi_bufpool_get_ibuf() to retreive the entry.

In considering this case, this patch remvoed the assertion
in ofi_bufpool_get_ibuf to avoid crash in a legitimate code path

Signed-off-by: Wei Zhang <wzam@amazon.com>