### PR TITLE
prov/util Add support for 128-bit integer atomics

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -291,6 +291,8 @@ AS_IF([test x"$enable_atomics" != x"no"],
 
 dnl Check for gcc memory model aware built-in atomics
 dnl If supported check to see if not internal to compiler
+dnl If built-in atomics present, check for 128-bit atomic support
+have_mm_atomics=0
 LIBS_save=$LIBS
 AC_SEARCH_LIBS([__atomic_load_8], [atomic])
 AS_IF([test x"$enable_atomics" != x"no"],
@@ -313,6 +315,7 @@ AS_IF([test x"$enable_atomics" != x"no"],
         [
             AC_MSG_RESULT(yes)
             AC_DEFINE(HAVE_BUILTIN_MM_ATOMICS, 1, [Set to 1 to use built-in intrinsics memory model aware atomics])
+	    have_mm_atomics=1
         ],
         [
             AC_MSG_RESULT(no)
@@ -323,6 +326,34 @@ AS_IF([test x"$enable_atomics" != x"no"],
     LIBS=$LIBS_save
 ])
 unset LIBS_save
+
+dnl Check for 128-bit integer support
+AC_CHECK_TYPE([__int128],
+	[AC_DEFINE(HAVE___INT128, 1, [Set to 1 to use 128-bit ints])])
+
+dnl Check for 128-bit integer built-in atomic support
+AS_IF([test "$have_mm_atomics" -eq 1 && test "$ac_cv_type___int128" == "yes"],
+    AC_MSG_CHECKING(compiler support for built-in memory model aware 128-bit atomics)
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <stdint.h>]],
+        [[__int128 d;
+         __int128 s;
+         __int128 c;
+         __int128 r;
+          r = __atomic_fetch_add(&d, s, __ATOMIC_SEQ_CST);
+          __atomic_load(&d, &r, __ATOMIC_SEQ_CST);
+          __atomic_exchange(&d, &s, &r, __ATOMIC_SEQ_CST);
+          __atomic_compare_exchange(&d, &c, &s, 0, __ATOMIC_SEQ_CST,
+	  			    __ATOMIC_SEQ_CST);
+	 return 0;
+        ]])],
+        [
+            AC_MSG_RESULT(yes)
+            AC_DEFINE(HAVE_BUILTIN_MM_INT128_ATOMICS, 1, [Set to 1 to use built-in intrinsics memory model aware 128-bit integer atomics])
+        ],
+        [
+            AC_MSG_RESULT(no)
+        ]),
+)
 
 dnl Check for gcc cpuid intrinsics
 AC_MSG_CHECKING(compiler support for cpuid)

--- a/configure.ac
+++ b/configure.ac
@@ -332,7 +332,7 @@ AC_CHECK_TYPE([__int128],
 	[AC_DEFINE(HAVE___INT128, 1, [Set to 1 to use 128-bit ints])])
 
 dnl Check for 128-bit integer built-in atomic support
-AS_IF([test "$have_mm_atomics" -eq 1 && test "$ac_cv_type___int128" == "yes"],
+AS_IF([test "$have_mm_atomics" -eq 1 -a "$ac_cv_type___int128" = "yes"],
     AC_MSG_CHECKING(compiler support for built-in memory model aware 128-bit atomics)
     AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <stdint.h>]],
         [[__int128 d;

--- a/include/ofi_atomic.h
+++ b/include/ofi_atomic.h
@@ -63,11 +63,18 @@ size_t ofi_datatype_size(enum fi_datatype datatype);
 #define ofi_atomic_isswap_op(op) \
 	(op >= OFI_SWAP_OP_START && op < OFI_SWAP_OP_LAST)
 
-extern void (*ofi_atomic_write_handlers[OFI_WRITE_OP_CNT][FI_DATATYPE_LAST])
+#define OFI_DATATYPE_CNT	(FI_UINT128 + 1)
+
+#ifdef HAVE___INT128
+typedef __int128 ofi_int128_t;
+typedef unsigned __int128 ofi_uint128_t;
+#endif
+
+extern void (*ofi_atomic_write_handlers[OFI_WRITE_OP_CNT][OFI_DATATYPE_CNT])
 			(void *dst, const void *src, size_t cnt);
-extern void (*ofi_atomic_readwrite_handlers[OFI_READWRITE_OP_CNT][FI_DATATYPE_LAST])
+extern void (*ofi_atomic_readwrite_handlers[OFI_READWRITE_OP_CNT][OFI_DATATYPE_CNT])
 			(void *dst, const void *src, void *res, size_t cnt);
-extern void (*ofi_atomic_swap_handlers[OFI_SWAP_OP_CNT][FI_DATATYPE_LAST])
+extern void (*ofi_atomic_swap_handlers[OFI_SWAP_OP_CNT][OFI_DATATYPE_CNT])
 			(void *dst, const void *src, const void *cmp,
 			 void *res, size_t cnt);
 

--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -123,7 +123,7 @@ struct smr_msg_hdr {
 			uint8_t	atomic_op;
 		};
 	};
-};
+} __attribute__ ((aligned(16)));
 
 #define SMR_MSG_DATA_LEN	(SMR_CMD_SIZE - sizeof(struct smr_msg_hdr))
 #define SMR_COMP_DATA_LEN	(SMR_MSG_DATA_LEN / 2)

--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -52,7 +52,7 @@ extern "C" {
 #endif
 
 
-#define SMR_VERSION	1
+#define SMR_VERSION	2
 
 #ifdef HAVE_ATOMICS
 #define SMR_FLAG_ATOMIC	(1 << 0)

--- a/prov/util/src/util_atomic.c
+++ b/prov/util/src/util_atomic.c
@@ -155,6 +155,72 @@ size_t ofi_datatype_size(enum fi_datatype datatype)
 #define OFI_OP_READ_COMPLEX		OFI_OP_READ
 #define OFI_OP_WRITE_COMPLEX		OFI_OP_WRITE
 
+#if defined(HAVE_BUILTIN_MM_INT128_ATOMICS) || defined(HAVE___INT128)
+
+/*
+ * If the compiler supports 128-bit integer types, then existing macros
+ * will just work.
+ */
+#define OFI_DEF_WRITE_INT128_NAME(op, type)	OFI_DEF_WRITE_NAME(op, type)
+#define OFI_DEF_WRITE_INT128_FUNC(op, type)	OFI_DEF_WRITE_FUNC(op, type)
+#define OFI_DEF_WRITEEXT_INT128_NAME(op, type)	OFI_DEF_WRITEEXT_NAME(op, type)
+#define OFI_DEF_WRITEEXT_INT128_FUNC(op, type)	OFI_DEF_WRITEEXT_FUNC(op, type)
+#define OFI_DEF_WRITEEXT_CMP_INT128_NAME(op, type)	\
+	OFI_DEF_WRITEEXT_CMP_NAME(op, type)
+#define OFI_DEF_WRITEEXT_CMP_INT128_FUNC(op, type)	\
+	OFI_DEF_WRITEEXT_CMP_FUNC(op, type)
+#define OFI_DEF_READ_INT128_NAME(op, type)	OFI_DEF_READ_NAME(op, type)
+#define OFI_DEF_READ_INT128_FUNC(op, type)	OFI_DEF_READ_FUNC(op, type)
+#define OFI_DEF_READWRITE_INT128_NAME(op, type)	OFI_DEF_READWRITE_NAME(op, type)
+#define OFI_DEF_READWRITE_INT128_FUNC(op, type)	OFI_DEF_READWRITE_FUNC(op, type)
+#define OFI_DEF_READWRITEEXT_INT128_NAME(op, type)	\
+	OFI_DEF_READWRITEEXT_NAME(op, type)
+#define OFI_DEF_READWRITEEXT_INT128_FUNC(op, type)	\
+	OFI_DEF_READWRITEEXT_FUNC(op, type)
+#define OFI_DEF_READWRITEEXT_CMP_INT128_NAME(op, type)	\
+	OFI_DEF_READWRITEEXT_CMP_NAME(op, type)
+#define OFI_DEF_READWRITEEXT_CMP_INT128_FUNC(op, type)	\
+	OFI_DEF_READWRITEEXT_CMP_FUNC(op, type)
+#define OFI_DEF_EXCHANGE_INT128_NAME(op, type)	OFI_DEF_EXCHANGE_NAME(op, type)
+#define OFI_DEF_EXCHANGE_INT128_FUNC(op, type)	OFI_DEF_EXCHANGE_FUNC(op, type)
+#define OFI_DEF_CSWAP_INT128_NAME(op, type)	OFI_DEF_CSWAP_NAME(op, type)
+#define OFI_DEF_CSWAP_INT128_FUNC(op, type)	OFI_DEF_CSWAP_FUNC(op, type)
+#define OFI_DEF_CSWAPEXT_INT128_NAME(op, type)	OFI_DEF_CSWAPEXT_NAME(op, type)
+#define OFI_DEF_CSWAPEXT_INT128_FUNC(op, type)	OFI_DEF_CSWAPEXT_FUNC(op, type)
+#define OFI_DEF_CSWAPEXT_CMP_INT128_NAME(op, type)	\
+	OFI_DEF_CSWAPEXT_CMP_NAME(op, type)
+#define OFI_DEF_CSWAPEXT_CMP_INT128_FUNC(op, type)	\
+	OFI_DEF_CSWAPEXT_CMP_FUNC(op, type)
+
+#else /* HAVE_BUILTIN_MM_INT128_ATOMICS || HAVE___INT128 */
+
+/* Otherwise, we support only nothing */
+
+#define OFI_DEF_WRITE_INT128_NAME(op, type)	NULL,
+#define OFI_DEF_WRITE_INT128_FUNC(op, type)
+#define OFI_DEF_WRITEEXT_INT128_NAME(op, type)	NULL,
+#define OFI_DEF_WRITEEXT_INT128_FUNC(op, type)
+#define OFI_DEF_WRITEEXT_CMP_INT128_NAME(op, type) NULL,
+#define OFI_DEF_WRITEEXT_CMP_INT128_FUNC(op, type)
+#define OFI_DEF_READ_INT128_NAME(op, type)	NULL,
+#define OFI_DEF_READ_INT128_FUNC(op, type)
+#define OFI_DEF_READWRITE_INT128_NAME(op, type)	NULL,
+#define OFI_DEF_READWRITE_INT128_FUNC(op, type)
+#define OFI_DEF_READWRITEEXT_INT128_NAME(op, type) NULL,
+#define OFI_DEF_READWRITEEXT_INT128_FUNC(op, type)
+#define OFI_DEF_READWRITEEXT_CMP_INT128_NAME(op, type) NULL,
+#define OFI_DEF_READWRITEEXT_CMP_INT128_FUNC(op, type)
+#define OFI_DEF_EXCHANGE_INT128_NAME(op, type)	NULL,
+#define OFI_DEF_EXCHANGE_INT128_FUNC(op, type)
+#define OFI_DEF_CSWAP_INT128_NAME(op, type)	NULL,
+#define OFI_DEF_CSWAP_INT128_FUNC(op, type)
+#define OFI_DEF_CSWAPEXT_INT128_NAME(op, type)	NULL,
+#define OFI_DEF_CSWAPEXT_INT128_FUNC(op, type)
+#define OFI_DEF_CSWAPEXT_CMP_INT128_NAME(op, type) NULL,
+#define OFI_DEF_CSWAPEXT_CMP_INT128_FUNC(op, type)
+
+#endif /* HAVE_BUILTIN_MM_INT128_ATOMICS || HAVE___INT128 */
+
 /********************************
  * ATOMIC TYPE function templates
  ********************************/
@@ -629,7 +695,7 @@ size_t ofi_datatype_size(enum fi_datatype datatype)
 		for (i = 0; i < cnt; i++) {				\
 			temp_c = c[i];					\
 			temp_s = s[i];					\
-			(void) op(type, d[i], temp_s, temp_c);		\
+			op(type, d[i], temp_s, temp_c);			\
 			/* If d[i] != temp_c then d[i] -> temp_c */	\
 			r[i] = temp_c;					\
 		}							\
@@ -730,11 +796,13 @@ size_t ofi_datatype_size(enum fi_datatype datatype)
 	OFI_DEF_NOOP_##FUNCNAME						\
 	OFI_DEF_NOOP_##FUNCNAME						\
 	OFI_DEF_NOOP_##FUNCNAME						\
-	OFI_DEF_NOOP_##FUNCNAME
+	OFI_DEF_NOOP_##FUNCNAME                                         \
+	OFI_DEF_##ATOMICTYPE##_INT128_##FUNCNAME(op, ofi_int128_t)	\
+	OFI_DEF_##ATOMICTYPE##_INT128_##FUNCNAME(op, ofi_uint128_t)
 
 #ifdef HAVE_BUILTIN_MM_ATOMICS
 
-/* Only support 8 byte and under datatypes */
+/* Only support 8 byte and under datatypes and non-complex 16 byte types */
 #define OFI_DEFINE_ALL_HANDLERS(ATOMICTYPE, FUNCNAME, op)		\
 	OFI_DEF_##ATOMICTYPE##_##FUNCNAME(op, int8_t)			\
 	OFI_DEF_##ATOMICTYPE##_##FUNCNAME(op, uint8_t)			\
@@ -749,7 +817,9 @@ size_t ofi_datatype_size(enum fi_datatype datatype)
 	OFI_DEF_##ATOMICTYPE##_COMPLEX_##FUNCNAME(op ##_COMPLEX, float)	\
 	OFI_DEF_NOOP_##FUNCNAME						\
 	OFI_DEF_NOOP_##FUNCNAME						\
-	OFI_DEF_NOOP_##FUNCNAME
+	OFI_DEF_NOOP_##FUNCNAME						\
+	OFI_DEF_##ATOMICTYPE##_INT128_##FUNCNAME(op, ofi_int128_t)	\
+	OFI_DEF_##ATOMICTYPE##_INT128_##FUNCNAME(op, ofi_uint128_t)
 
 #define OFI_DEFINE_REALNO_HANDLERS(ATOMICTYPE, FUNCNAME, op)		\
 	OFI_DEF_##ATOMICTYPE##_##FUNCNAME(op, int8_t)			\
@@ -765,7 +835,9 @@ size_t ofi_datatype_size(enum fi_datatype datatype)
 	OFI_DEF_NOOP_##FUNCNAME						\
 	OFI_DEF_NOOP_##FUNCNAME						\
 	OFI_DEF_NOOP_##FUNCNAME						\
-	OFI_DEF_NOOP_##FUNCNAME
+	OFI_DEF_NOOP_##FUNCNAME						\
+	OFI_DEF_##ATOMICTYPE##_INT128_##FUNCNAME(op, ofi_int128_t)	\
+	OFI_DEF_##ATOMICTYPE##_INT128_##FUNCNAME(op, ofi_uint128_t)
 
 #else /* HAVE_BUILTIN_MM_ATOMICS */
 
@@ -783,7 +855,9 @@ size_t ofi_datatype_size(enum fi_datatype datatype)
 	OFI_DEF_##ATOMICTYPE##_COMPLEX_##FUNCNAME(op ##_COMPLEX, float)	\
 	OFI_DEF_##ATOMICTYPE##_COMPLEX_##FUNCNAME(op ##_COMPLEX, double)\
 	OFI_DEF_##ATOMICTYPE##_##FUNCNAME(op, long_double)		\
-	OFI_DEF_##ATOMICTYPE##_COMPLEX_##FUNCNAME(op ##_COMPLEX, long_double)
+	OFI_DEF_##ATOMICTYPE##_COMPLEX_##FUNCNAME(op ##_COMPLEX, long_double) \
+	OFI_DEF_##ATOMICTYPE##_INT128_##FUNCNAME(op, ofi_int128_t)	\
+	OFI_DEF_##ATOMICTYPE##_INT128_##FUNCNAME(op, ofi_uint128_t)
 
 #define OFI_DEFINE_REALNO_HANDLERS(ATOMICTYPE, FUNCNAME, op)		\
 	OFI_DEF_##ATOMICTYPE##_##FUNCNAME(op, int8_t)			\
@@ -799,12 +873,18 @@ size_t ofi_datatype_size(enum fi_datatype datatype)
 	OFI_DEF_NOOP_##FUNCNAME						\
 	OFI_DEF_NOOP_##FUNCNAME						\
 	OFI_DEF_##ATOMICTYPE##_##FUNCNAME(op, long_double)		\
-	OFI_DEF_NOOP_##FUNCNAME
+	OFI_DEF_NOOP_##FUNCNAME						\
+	OFI_DEF_##ATOMICTYPE##_INT128_##FUNCNAME(op, ofi_int128_t)	\
+	OFI_DEF_##ATOMICTYPE##_INT128_##FUNCNAME(op, ofi_uint128_t)
 
 #endif /* HAVE_BUILTIN_MM_ATOMICS */
 
-#define OFI_OP_NOT_SUPPORTED(op)	NULL, NULL, NULL, NULL, NULL,	\
-			NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL
+/* 5 per line to be easily counted by inspection. */
+#define OFI_OP_NOT_SUPPORTED(op)		\
+	NULL, NULL, NULL, NULL, NULL,		\
+	NULL, NULL, NULL, NULL, NULL,		\
+	NULL, NULL, NULL, NULL, NULL,		\
+	NULL
 
 #ifdef HAVE_BUILTIN_MM_ATOMICS
 
@@ -824,7 +904,7 @@ OFI_DEFINE_ALL_HANDLERS(WRITEEXT, FUNC, OFI_OP_LXOR)
 OFI_DEFINE_INT_HANDLERS(WRITE, FUNC, OFI_OP_BXOR)
 OFI_DEFINE_ALL_HANDLERS(WRITE, FUNC, OFI_OP_WRITE)
 
-void (*ofi_atomic_write_handlers[OFI_WRITE_OP_CNT][FI_DATATYPE_LAST])
+void (*ofi_atomic_write_handlers[OFI_WRITE_OP_CNT][OFI_DATATYPE_CNT])
 	(void *dst, const void *src, size_t cnt) =
 {
 	{ OFI_DEFINE_REALNO_HANDLERS(WRITEEXT_CMP, NAME, OFI_OP_MIN) },
@@ -858,7 +938,7 @@ OFI_DEFINE_INT_HANDLERS(READWRITE, FUNC, OFI_OP_BXOR)
 OFI_DEFINE_ALL_HANDLERS(READ, FUNC, OFI_OP_READ)
 OFI_DEFINE_ALL_HANDLERS(EXCHANGE, FUNC, OFI_OP_READWRITE)
 
-void (*ofi_atomic_readwrite_handlers[OFI_READWRITE_OP_CNT][FI_DATATYPE_LAST])
+void (*ofi_atomic_readwrite_handlers[OFI_READWRITE_OP_CNT][OFI_DATATYPE_CNT])
 	(void *dst, const void *src, void *res, size_t cnt) =
 {
 	{ OFI_DEFINE_REALNO_HANDLERS(READWRITEEXT_CMP, NAME, OFI_OP_MIN) },
@@ -887,7 +967,7 @@ OFI_DEFINE_REALNO_HANDLERS(CSWAPEXT_CMP, FUNC, OFI_OP_CSWAP_GE)
 OFI_DEFINE_REALNO_HANDLERS(CSWAPEXT_CMP, FUNC, OFI_OP_CSWAP_GT)
 OFI_DEFINE_INT_HANDLERS(CSWAPEXT, FUNC, OFI_OP_MSWAP)
 
-void (*ofi_atomic_swap_handlers[OFI_SWAP_OP_CNT][FI_DATATYPE_LAST])
+void (*ofi_atomic_swap_handlers[OFI_SWAP_OP_CNT][OFI_DATATYPE_CNT])
 	(void *dst, const void *src, const void *cmp, void *res, size_t cnt) =
 {
 	{ OFI_DEFINE_ALL_HANDLERS(CSWAP, NAME, OFI_OP_CSWAP_EQ) },
@@ -922,7 +1002,7 @@ OFI_DEFINE_ALL_HANDLERS(WRITE, FUNC, OFI_OP_LXOR)
 OFI_DEFINE_INT_HANDLERS(WRITE, FUNC, OFI_OP_BXOR)
 OFI_DEFINE_ALL_HANDLERS(WRITE, FUNC, OFI_OP_WRITE)
 
-void (*ofi_atomic_write_handlers[OFI_WRITE_OP_CNT][FI_DATATYPE_LAST])
+void (*ofi_atomic_write_handlers[OFI_WRITE_OP_CNT][OFI_DATATYPE_CNT])
 	(void *dst, const void *src, size_t cnt) =
 {
 	{ OFI_DEFINE_REALNO_HANDLERS(WRITE, NAME, OFI_OP_MIN) },
@@ -956,7 +1036,7 @@ OFI_DEFINE_INT_HANDLERS(READWRITE, FUNC, OFI_OP_BXOR)
 OFI_DEFINE_ALL_HANDLERS(READ, FUNC, OFI_OP_READ)
 OFI_DEFINE_ALL_HANDLERS(READWRITE, FUNC, OFI_OP_WRITE)
 
-void (*ofi_atomic_readwrite_handlers[OFI_READWRITE_OP_CNT][FI_DATATYPE_LAST])
+void (*ofi_atomic_readwrite_handlers[OFI_READWRITE_OP_CNT][OFI_DATATYPE_CNT])
 	(void *dst, const void *src, void *res, size_t cnt) =
 {
 	{ OFI_DEFINE_REALNO_HANDLERS(READWRITE, NAME, OFI_OP_MIN) },
@@ -985,7 +1065,7 @@ OFI_DEFINE_REALNO_HANDLERS(CSWAP, FUNC, OFI_OP_CSWAP_GE)
 OFI_DEFINE_REALNO_HANDLERS(CSWAP, FUNC, OFI_OP_CSWAP_GT)
 OFI_DEFINE_INT_HANDLERS(CSWAP, FUNC, OFI_OP_MSWAP)
 
-void (*ofi_atomic_swap_handlers[OFI_SWAP_OP_CNT][FI_DATATYPE_LAST])
+void (*ofi_atomic_swap_handlers[OFI_SWAP_OP_CNT][OFI_DATATYPE_CNT])
 	(void *dst, const void *src, const void *cmp, void *res, size_t cnt) =
 {
 	{ OFI_DEFINE_ALL_HANDLERS(CSWAP, NAME, OFI_OP_CSWAP_EQ) },
@@ -1026,7 +1106,7 @@ int ofi_atomic_valid(const struct fi_provider *prov,
 		return -FI_EBADFLAGS;
 	}
 
-	if (datatype >= FI_DATATYPE_LAST) {
+	if (datatype > OFI_DATATYPE_CNT) {
 		FI_INFO(prov, FI_LOG_DOMAIN, "Invalid datatype\n");
 		return -FI_EOPNOTSUPP;
 	}

--- a/prov/util/src/util_atomic.c
+++ b/prov/util/src/util_atomic.c
@@ -155,11 +155,11 @@ size_t ofi_datatype_size(enum fi_datatype datatype)
 #define OFI_OP_READ_COMPLEX		OFI_OP_READ
 #define OFI_OP_WRITE_COMPLEX		OFI_OP_WRITE
 
-#if defined(HAVE_BUILTIN_MM_INT128_ATOMICS) || defined(HAVE___INT128)
+#if defined(HAVE_BUILTIN_MM_INT128_ATOMICS)
 
 /*
- * If the compiler supports 128-bit integer types, then existing macros
- * will just work.
+ * If the compiler supports 128-bit integer types and atomics,
+ *  then existing macros will just work.
  */
 #define OFI_DEF_WRITE_INT128_NAME(op, type)	OFI_DEF_WRITE_NAME(op, type)
 #define OFI_DEF_WRITE_INT128_FUNC(op, type)	OFI_DEF_WRITE_FUNC(op, type)
@@ -192,7 +192,7 @@ size_t ofi_datatype_size(enum fi_datatype datatype)
 #define OFI_DEF_CSWAPEXT_CMP_INT128_FUNC(op, type)	\
 	OFI_DEF_CSWAPEXT_CMP_FUNC(op, type)
 
-#else /* HAVE_BUILTIN_MM_INT128_ATOMICS || HAVE___INT128 */
+#else /* HAVE_BUILTIN_MM_INT128_ATOMICS */
 
 /* Otherwise, we support only nothing */
 
@@ -219,7 +219,7 @@ size_t ofi_datatype_size(enum fi_datatype datatype)
 #define OFI_DEF_CSWAPEXT_CMP_INT128_NAME(op, type) NULL,
 #define OFI_DEF_CSWAPEXT_CMP_INT128_FUNC(op, type)
 
-#endif /* HAVE_BUILTIN_MM_INT128_ATOMICS || HAVE___INT128 */
+#endif /* HAVE_BUILTIN_MM_INT128_ATOMICS */
 
 /********************************
  * ATOMIC TYPE function templates
@@ -695,7 +695,7 @@ size_t ofi_datatype_size(enum fi_datatype datatype)
 		for (i = 0; i < cnt; i++) {				\
 			temp_c = c[i];					\
 			temp_s = s[i];					\
-			op(type, d[i], temp_s, temp_c);			\
+			(void) op(type, d[i], temp_s, temp_c);		\
 			/* If d[i] != temp_c then d[i] -> temp_c */	\
 			r[i] = temp_c;					\
 		}							\

--- a/prov/util/src/util_shm.c
+++ b/prov/util/src/util_shm.c
@@ -106,7 +106,8 @@ size_t smr_calculate_size_offsets(size_t tx_count, size_t rx_count,
 	tx_size = roundup_power_of_two(tx_count);
 	rx_size = roundup_power_of_two(rx_count);
 
-	cmd_queue_offset = sizeof(struct smr_region);
+	/* Align cmd_queue offset to 128-bit boundary. */
+	cmd_queue_offset = ofi_get_aligned_size(sizeof(struct smr_region), 16);
 	resp_queue_offset = cmd_queue_offset + sizeof(struct smr_cmd_queue) +
 			    sizeof(struct smr_cmd) * rx_size;
 	inject_pool_offset = resp_queue_offset + sizeof(struct smr_resp_queue) +

--- a/prov/util/src/util_shm.c
+++ b/prov/util/src/util_shm.c
@@ -162,7 +162,8 @@ static int smr_retry_map(const char *name, int *fd)
 	if (old_shm == MAP_FAILED)
 		goto err;
 
-	if (old_shm->version > SMR_VERSION) {
+        /* No backwards compatibility for now. */
+	if (old_shm->version != SMR_VERSION) {
 		munmap(old_shm, sizeof(*old_shm));
 		goto err;
 	}


### PR DESCRIPTION
gcc/clang and libatomic can support 128-bit integer operations on
some platforms. If the compiler/library support is available, compile
128-bit atomic support in the util provider.

Signed-off-by: John Byrne <john.l.byrne@hpe.com>