### PR TITLE
util/pingpong: Add IPv6 support

### DIFF
--- a/util/pingpong.c
+++ b/util/pingpong.c
@@ -120,6 +120,7 @@ struct pp_opts {
 		__LINE__, ##__VA_ARGS__)
 
 int pp_debug;
+int pp_ipv6;
 
 #define PP_DEBUG(fmt, ...)                                                     \
 	do {                                                                   \
@@ -299,7 +300,7 @@ static int pp_getaddrinfo(char *name, uint16_t port, struct addrinfo **results)
 	char port_s[6];
 
 	struct addrinfo hints = {
-	    .ai_family = AF_INET,       /* IPv4 */
+	    .ai_family = pp_ipv6 ? AF_INET6 : AF_INET,
 	    .ai_socktype = SOCK_STREAM, /* TCP socket */
 	    .ai_protocol = IPPROTO_TCP, /* Any protocol */
 	    .ai_flags = AI_NUMERICSERV /* numeric port is used */
@@ -320,9 +321,22 @@ out:
 	return ret;
 }
 
+static void pp_print_addrinfo(struct addrinfo *ai, char *msg)
+{
+	char s[80] = {0};
+	void *addr;
+
+	if (ai->ai_family == AF_INET6)
+		addr = &((struct sockaddr_in6 *)ai->ai_addr)->sin6_addr;
+	else
+		addr = &((struct sockaddr_in *)ai->ai_addr)->sin_addr;
+
+	inet_ntop(ai->ai_family, addr, s, 80);
+	PP_DEBUG("%s %s\n", msg, s);
+}
+
 static int pp_ctrl_init_client(struct ct_pingpong *ct)
 {
-	struct sockaddr_in in_addr = {0};
 	struct addrinfo *results;
 	struct addrinfo *rp;
 	int errno_save = 0;
@@ -346,19 +360,35 @@ static int pp_ctrl_init_client(struct ct_pingpong *ct)
 		}
 
 		if (ct->opts.src_port != 0) {
-			in_addr.sin_family = AF_INET;
-			in_addr.sin_port = htons(ct->opts.src_port);
-			in_addr.sin_addr.s_addr = htonl(INADDR_ANY);
+			if (pp_ipv6) {
+				struct sockaddr_in6 in6_addr = {0};
 
-			ret =
-			    bind(ct->ctrl_connfd, (struct sockaddr *)&in_addr,
-				 sizeof(in_addr));
+				in6_addr.sin6_family = AF_INET6;
+				in6_addr.sin6_port = htons(ct->opts.src_port);
+				in6_addr.sin6_addr = in6addr_any;
+
+				ret =
+				    bind(ct->ctrl_connfd, (struct sockaddr *)&in6_addr,
+					 sizeof(in6_addr));
+			} else {
+				struct sockaddr_in in_addr = {0};
+
+				in_addr.sin_family = AF_INET;
+				in_addr.sin_port = htons(ct->opts.src_port);
+				in_addr.sin_addr.s_addr = htonl(INADDR_ANY);
+
+				ret =
+				    bind(ct->ctrl_connfd, (struct sockaddr *)&in_addr,
+					 sizeof(in_addr));
+			}
 			if (ret == -1) {
 				errno_save = ofi_sockerr();
 				ofi_close_socket(ct->ctrl_connfd);
 				continue;
 			}
 		}
+
+		pp_print_addrinfo(rp, "CLIENT: connecting to");
 
 		ret = connect(ct->ctrl_connfd, rp->ai_addr, rp->ai_addrlen);
 		if (ret != -1)
@@ -383,12 +413,11 @@ static int pp_ctrl_init_client(struct ct_pingpong *ct)
 
 static int pp_ctrl_init_server(struct ct_pingpong *ct)
 {
-	struct sockaddr_in ctrl_addr = {0};
 	int optval = 1;
 	SOCKET listenfd;
 	int ret;
 
-	listenfd = ofi_socket(AF_INET, SOCK_STREAM, 0);
+	listenfd = ofi_socket(pp_ipv6 ? AF_INET6 : AF_INET, SOCK_STREAM, 0);
 	if (listenfd == INVALID_SOCKET) {
 		ret = -ofi_sockerr();
 		PP_PRINTERR("socket", ret);
@@ -403,12 +432,25 @@ static int pp_ctrl_init_server(struct ct_pingpong *ct)
 		goto fail_close_socket;
 	}
 
-	ctrl_addr.sin_family = AF_INET;
-	ctrl_addr.sin_port = htons(ct->opts.src_port);
-	ctrl_addr.sin_addr.s_addr = htonl(INADDR_ANY);
+	if (pp_ipv6) {
+		struct sockaddr_in6 ctrl6_addr = {0};
 
-	ret = bind(listenfd, (struct sockaddr *)&ctrl_addr,
-		   sizeof(ctrl_addr));
+		ctrl6_addr.sin6_family = AF_INET6;
+		ctrl6_addr.sin6_port = htons(ct->opts.src_port);
+		ctrl6_addr.sin6_addr = in6addr_any;
+
+		ret = bind(listenfd, (struct sockaddr *)&ctrl6_addr,
+			   sizeof(ctrl6_addr));
+	} else {
+		struct sockaddr_in ctrl_addr = {0};
+
+		ctrl_addr.sin_family = AF_INET;
+		ctrl_addr.sin_port = htons(ct->opts.src_port);
+		ctrl_addr.sin_addr.s_addr = htonl(INADDR_ANY);
+
+		ret = bind(listenfd, (struct sockaddr *)&ctrl_addr,
+			   sizeof(ctrl_addr));
+	}
 	if (ret == -1) {
 		ret = -ofi_sockerr();
 		PP_PRINTERR("bind", ret);
@@ -1970,6 +2012,7 @@ static void pp_pingpong_usage(struct ct_pingpong *ct, char *name, char *desc)
 
 	fprintf(stderr, " %-20s %s\n", "-h", "display this help output");
 	fprintf(stderr, " %-20s %s\n", "-v", "enable debugging output");
+	fprintf(stderr, " %-20s %s\n", "-6", "use IPv6 address");
 }
 
 static void pp_parse_opts(struct ct_pingpong *ct, int op, char *optarg)
@@ -2050,6 +2093,12 @@ static void pp_parse_opts(struct ct_pingpong *ct, int op, char *optarg)
 	case 'v':
 		pp_debug = 1;
 		break;
+
+	/* IPV6 */
+	case '6':
+		pp_ipv6 = 1;
+		break;
+
 	default:
 		/* let getopt handle unknown opts*/
 		break;
@@ -2245,7 +2294,7 @@ int main(int argc, char **argv)
 
 	ofi_osd_init();
 
-	while ((op = getopt(argc, argv, "hvd:p:e:I:S:B:P:cm:")) != -1) {
+	while ((op = getopt(argc, argv, "hvd:p:e:I:S:B:P:cm:6")) != -1) {
 		switch (op) {
 		default:
 			pp_parse_opts(&ct, op, optarg);


### PR DESCRIPTION
Add option '-6' to use IPv6 address instead of the default IPv4 address.
The server and client must use the same option.

Add debug output showing the address being connected to.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>