### PR TITLE
pro/efa: efa_av_remove() remove peer and release resources

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -597,24 +597,6 @@ struct rdm_peer *rxr_ep_get_peer(struct rxr_ep *ep, fi_addr_t addr)
 	return av_entry->conn.ep_addr ? &av_entry->conn.rdm_peer : NULL;
 }
 
-static inline
-int efa_peer_in_use(struct rdm_peer *peer)
-{
-	struct rxr_pkt_entry *pending_pkt;
-
-	if (!dlist_empty(&peer->tx_entry_list) || !dlist_empty(&peer->rx_entry_list))
-		return -FI_EBUSY;
-
-	if ((peer->efa_outstanding_tx_ops > 0) || (peer->flags & RXR_PEER_IN_BACKOFF))
-		return -FI_EBUSY;
-
-	pending_pkt = *ofi_recvwin_peek((&peer->robuf));
-	if (pending_pkt)
-		return -FI_EBUSY;
-
-	return 0;
-}
-
 static inline bool efa_ep_is_cuda_mr(struct efa_mr *efa_mr)
 {
 	return efa_mr ? (efa_mr->peer.iface == FI_HMEM_CUDA): false;

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -328,6 +328,7 @@ struct rdm_peer {
 	uint64_t features[RXR_MAX_NUM_PROTOCOLS]; /* the feature flag for each version */
 	size_t efa_outstanding_tx_ops;	/* tracks outstanding tx ops to this peer on EFA device */
 	size_t shm_outstanding_tx_ops;  /* tracks outstanding tx ops to this peer on SHM */
+	struct dlist_entry outstanding_tx_pkts; /* a list of outstanding tx pkts to the peer */
 	uint16_t tx_credits;		/* available send credits */
 	uint16_t rx_credits;		/* available credits to allocate */
 	uint64_t rnr_backoff_begin_ts;	/* timestamp for RNR backoff period begin */
@@ -836,9 +837,9 @@ static inline int rxr_match_tag(uint64_t tag, uint64_t ignore,
 	return ((tag | ignore) == (match_tag | ignore));
 }
 
-void rxr_ep_inc_tx_op_counter(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
+void rxr_ep_record_tx_op_submitted(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
 
-void rxr_ep_dec_tx_op_counter(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
+void rxr_ep_record_tx_op_completed(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
 
 static inline size_t rxr_get_rx_pool_chunk_cnt(struct rxr_ep *ep)
 {

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -715,7 +715,7 @@ void rxr_pkt_handle_send_error(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entr
 	assert(pkt_entry->alloc_type == RXR_PKT_FROM_EFA_TX_POOL ||
 	       pkt_entry->alloc_type == RXR_PKT_FROM_SHM_TX_POOL);
 
-	rxr_ep_dec_tx_op_counter(ep, pkt_entry);
+	rxr_ep_record_tx_op_completed(ep, pkt_entry);
 
 	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
 	if (!peer) {
@@ -842,7 +842,7 @@ void rxr_pkt_handle_send_completion(struct rxr_ep *ep, struct rxr_pkt_entry *pkt
 		 * Either way, we need to ignore this error completion.
 		 */
 		FI_WARN(&rxr_prov, FI_LOG_CQ, "ignoring send completion of a packet to a removed peer.\n");
-		rxr_ep_dec_tx_op_counter(ep, pkt_entry);
+		rxr_ep_record_tx_op_completed(ep, pkt_entry);
 		rxr_pkt_entry_release_tx(ep, pkt_entry);
 		return;
 	}
@@ -941,7 +941,7 @@ void rxr_pkt_handle_send_completion(struct rxr_ep *ep, struct rxr_pkt_entry *pkt
 		return;
 	}
 
-	rxr_ep_dec_tx_op_counter(ep, pkt_entry);
+	rxr_ep_record_tx_op_completed(ep, pkt_entry);
 	rxr_pkt_entry_release_tx(ep, pkt_entry);
 }
 

--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -318,7 +318,7 @@ ssize_t rxr_pkt_entry_sendmsg(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry
 	if (OFI_UNLIKELY(ret))
 		return ret;
 
-	rxr_ep_inc_tx_op_counter(ep, pkt_entry);
+	rxr_ep_record_tx_op_submitted(ep, pkt_entry);
 	return 0;
 }
 

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -465,7 +465,7 @@ void rxr_pkt_handle_rma_read_completion(struct rxr_ep *ep,
 		rxr_read_release_entry(ep, read_entry);
 	}
 
-	rxr_ep_dec_tx_op_counter(ep, context_pkt_entry);
+	rxr_ep_record_tx_op_completed(ep, context_pkt_entry);
 }
 
 void rxr_pkt_handle_rma_completion(struct rxr_ep *ep,

--- a/prov/efa/src/rxr/rxr_read.c
+++ b/prov/efa/src/rxr/rxr_read.c
@@ -596,7 +596,7 @@ int rxr_read_post(struct rxr_ep *ep, struct rxr_read_entry *read_entry)
 			return ret;
 		}
 
-		rxr_ep_inc_tx_op_counter(ep, pkt_entry);
+		rxr_ep_record_tx_op_submitted(ep, pkt_entry);
 
 		read_entry->bytes_submitted += iov.iov_len;
 


### PR DESCRIPTION
This PR contains commits that would make efa_av_remove to remove a peer with resources, instead of return -FI_EBUSY. This is to conform with the libfabric standard.

For that to work, this PR also contain commits that handle outstanding TX packets when removing a peer.