### PR TITLE
fabtests: Bug fixes related to IPv6 address format

### DIFF
--- a/fabtests/benchmarks/dgram_pingpong.c
+++ b/fabtests/benchmarks/dgram_pingpong.c
@@ -119,6 +119,7 @@ int main(int argc, char **argv)
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->domain_attr->threading = FI_THREAD_DOMAIN;
 	hints->tx_attr->tclass = FI_TC_LOW_LATENCY;
+	hints->addr_format = opts.address_format;
 
 	ret = run();
 

--- a/fabtests/benchmarks/rdm_cntr_pingpong.c
+++ b/fabtests/benchmarks/rdm_cntr_pingpong.c
@@ -101,6 +101,7 @@ int main(int argc, char **argv)
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->domain_attr->threading = FI_THREAD_DOMAIN;
 	hints->tx_attr->tclass = FI_TC_LOW_LATENCY;
+	hints->addr_format = opts.address_format;
 
 	ret = run();
 

--- a/fabtests/benchmarks/rdm_pingpong.c
+++ b/fabtests/benchmarks/rdm_pingpong.c
@@ -102,6 +102,7 @@ int main(int argc, char **argv)
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->domain_attr->threading = FI_THREAD_DOMAIN;
 	hints->tx_attr->tclass = FI_TC_LOW_LATENCY;
+	hints->addr_format = opts.address_format;
 
 	ret = run();
 

--- a/fabtests/benchmarks/rdm_tagged_bw.c
+++ b/fabtests/benchmarks/rdm_tagged_bw.c
@@ -105,6 +105,7 @@ int main(int argc, char **argv)
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->domain_attr->threading = FI_THREAD_DOMAIN;
 	hints->tx_attr->tclass = FI_TC_BULK_DATA;
+	hints->addr_format = opts.address_format;
 
 	ret = run();
 

--- a/fabtests/benchmarks/rdm_tagged_pingpong.c
+++ b/fabtests/benchmarks/rdm_tagged_pingpong.c
@@ -103,6 +103,7 @@ int main(int argc, char **argv)
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->domain_attr->threading = FI_THREAD_DOMAIN;
 	hints->tx_attr->tclass = FI_TC_LOW_LATENCY;
+	hints->addr_format = opts.address_format;
 
 	ret = run();
 

--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -3070,10 +3070,10 @@ void ft_parse_addr_opts(int op, char *optarg, struct ft_opts *opts)
 			opts->oob_port = default_oob_port;
 		break;
 	case 'F':
-		if (!strncasecmp("fi_sockaddr_in", optarg, 14))
-			opts->address_format = FI_SOCKADDR_IN;
-		else if (!strncasecmp("fi_sockaddr_in6", optarg, 15))
+		if (!strncasecmp("fi_sockaddr_in6", optarg, 15))
 			opts->address_format = FI_SOCKADDR_IN6;
+		else if (!strncasecmp("fi_sockaddr_in", optarg, 14))
+			opts->address_format = FI_SOCKADDR_IN;
 		else if (!strncasecmp("fi_sockaddr_ib", optarg, 14))
 			opts->address_format = FI_SOCKADDR_IB;
 		else if (!strncasecmp("fi_sockaddr", optarg, 11)) /* keep me last */


### PR DESCRIPTION
The address format can be specified with the "-F" option, which is checked with
strncasecmp() in a predfined order. Previously the "fi_sockaddr_in" format was
checked before the "fi_sockaddr_in6" format, resulting the latter never being
reached. Fix by reversing the order of the two.

In addtion, the option was previously used by only 3 tests: "fi_msg_pingpong",
"fi_msg_bw" and "fi_rma_bw". Now expand the support to all the tests under the
"benchmark" directory.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>