### PR TITLE
prov/efa: include av_xfter test for efa provider

### DIFF
--- a/fabtests/test_configs/efa/efa.exclude
+++ b/fabtests/test_configs/efa/efa.exclude
@@ -61,9 +61,6 @@ trigger
 #rdm_cntr_pingpong
 
 
-# This test requires ENA IPs for the OOB sync
-av_xfer
-
 # Connection manager isn't supported
 cm_data
 


### PR DESCRIPTION
This patch enable av_xfer test for efa provider because
OOB address exchange has been supported and this test
works for EFA provider.

Signed-off-by: Wei Zhang <wzam@amazon.com>