### PR TITLE
[1.13.x] prov/efa: Use ibv_is_fork_initialized in EFA fork support

### DIFF
--- a/prov/efa/configure.m4
+++ b/prov/efa/configure.m4
@@ -84,6 +84,21 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 	      ])
 	CPPFLAGS=$save_CPPFLAGS
 
+	dnl Check for ibv_is_fork_initialized() in libibverbs
+	have_ibv_is_fork_initialized=0
+	AS_IF([test $efa_happy -eq 1],
+		[AC_CHECK_DECL([ibv_is_fork_initialized],
+			[have_ibv_is_fork_initialized=1],
+			[],
+			[[#include <infiniband/verbs.h>]])
+		])
+
+	AC_DEFINE_UNQUOTED([HAVE_IBV_IS_FORK_INITIALIZED],
+		[$have_ibv_is_fork_initialized],
+		[Define to 1 if libibverbs has ibv_is_fork_initialized])
+
+	AS_IF([test "$enable_efa" = "no"], [efa_happy=0])
+
 	AS_IF([test $efa_happy -eq 1 ], [$1], [$2])
 
 	efa_CPPFLAGS="$efa_ibverbs_CPPFLAGS $efadv_CPPFLAGS"

--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -451,12 +451,6 @@ ssize_t efa_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *entry, uin
 /*
  * ON will avoid using huge pages for bounce buffers, so that the libibverbs
  * fork support can be used safely.
- *
- * UNNEEDED is currently not used but will be set when rdma-core adds a verb to
- * check this state. Fork support will become irrelevant once the kernel copies
- * pages into the fork, leaving the pinned pages intact.
- *
- * See https://github.com/linux-rdma/rdma-core/pull/883 for more information.
  */
 enum efa_fork_support_status {
 	EFA_FORK_SUPPORT_OFF = 0,

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -136,10 +136,27 @@ static void rxr_init_env(void)
 			    &rxr_env.efa_min_read_write_size);
 	fi_param_get_size_t(&rxr_prov, "inter_read_segment_size",
 			    &rxr_env.efa_read_segment_size);
-	fi_param_get_bool(&rxr_prov, "fork_safe", &fork_safe);
 
-	if (fork_safe || getenv("RDMAV_FORK_SAFE") || getenv("IBV_FORK_SAFE"))
-		efa_fork_status = EFA_FORK_SUPPORT_ON;
+	/* Initialize EFA's fork support flag based on the environment and
+	 * system support. */
+	efa_fork_status = EFA_FORK_SUPPORT_OFF;
+
+#if HAVE_IBV_IS_FORK_INITIALIZED == 1
+	if (ibv_is_fork_initialized() == IBV_FORK_UNNEEDED)
+		efa_fork_status = EFA_FORK_SUPPORT_UNNEEDED;
+#endif
+
+	if (efa_fork_status != EFA_FORK_SUPPORT_UNNEEDED) {
+		fi_param_get_bool(&rxr_prov, "fork_safe", &fork_safe);
+
+		/*
+		 * Check if any environment variables which would trigger
+		 * libibverbs' fork support are set. These variables are
+		 * defined by ibv_fork_init(3).
+		 */
+		if (fork_safe || getenv("RDMAV_FORK_SAFE") || getenv("IBV_FORK_SAFE"))
+			efa_fork_status = EFA_FORK_SUPPORT_ON;
+	}
 }
 
 /*
@@ -823,7 +840,8 @@ EFA_INI
 	fi_param_define(&rxr_prov, "inter_read_segment_size", FI_PARAM_INT,
 			"Calls to RDMA read is segmented using this value.");
 	fi_param_define(&rxr_prov, "fork_safe", FI_PARAM_BOOL,
-			"Enables fork support and disables internal usage of huge pages. (Default: false)");
+			"Enables fork support and disables internal usage of huge pages. Has no effect on kernels which set copy-on-fork for registered pages, generally 5.13 and later. (Default: false)");
+
 	rxr_init_env();
 
 #if HAVE_EFA_DL


### PR DESCRIPTION
This commit adds:
- autoconf to detect the existance of ibv_is_fork_initialized in
rdma-core
- updates efa_check_fork_enabled to use ibv_is_fork_initialized if
available
- uses ibv_is_fork_initialized to disable fork support when it returns
IBV_FORK_UNNEEDED
- Updates comments/help messages

Signed-off-by: Peter Gottesman <pgottes@amazon.com>