### PR TITLE
[v1.13.x] fabtests: Do not immediately kill server process

### DIFF
--- a/fabtests/scripts/runfabtests.sh
+++ b/fabtests/scripts/runfabtests.sh
@@ -476,7 +476,12 @@ function cs_test {
 	wait $c_pid
 	c_ret=$?
 
-	[[ c_ret -ne 0 ]] && kill -9 $s_pid 2> /dev/null
+	if [[ $c_ret -ne 0 ]] && ps -p $s_pid > /dev/null; then
+	    if [[ $STRICT_MODE -eq 0 ]]; then
+	        sleep 2
+	    fi
+	    kill -9 $s_pid 2> /dev/null
+	fi
 
 	wait $s_pid
 	s_ret=$?
@@ -636,7 +641,12 @@ function multinode_test {
 		c_ret=($?)||$c_ret
 	done
 
-	[[ c_ret -ne 0 ]] && kill -9 $s_pid 2> /dev/null
+	if [[ $c_ret -ne 0 ]] && ps -p $s_pid > /dev/null; then
+	    if [[ $STRICT_MODE -eq 0 ]]; then
+	        sleep 2
+	    fi
+	    kill -9 $s_pid 2> /dev/null
+	fi
 
 	wait $s_pid
 	s_ret=$?


### PR DESCRIPTION
Some fabtests are run in server/client mode. In non-strict
mode, if both server and client returning FI_ENODATA or
or FI_ENOSYS, the test is marked as 'Notrun' instead of
'Fail'.

Currently, when the client exits with non-zero code, the
server is immediately killed. However, doing such might
make the test that's supposed to be 'Notrun' to be
reported as 'Fail', because there's no guarantee
that the server has already exited. Killing the server
while it's running will change its return code.

Fix the issue by leaving the server more time (sleep 2s)
to exit.

Signed-off-by: Jie Zhang <zhngaj@amazon.com>
(cherry picked from commit 4a79edee7c27b0a26f53c64ab5140f0bb7216696)