### PR TITLE
[v1.13.x] prov/efa: make rxr_pkt_req_max_header_size use RXR_REQ_OPT_…

### DIFF
--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -240,7 +240,7 @@ int64_t rxr_pkt_req_cq_data(struct rxr_pkt_entry *pkt_entry)
 size_t rxr_pkt_req_max_header_size(int pkt_type)
 {
 	int max_hdr_size = REQ_INF_LIST[pkt_type].base_hdr_size
-		+ sizeof(struct rxr_req_opt_raw_addr_hdr) + RXR_MAX_NAME_LENGTH
+		+ RXR_REQ_OPT_RAW_ADDR_HDR_SIZE
 		+ sizeof(struct rxr_req_opt_cq_data_hdr);
 
 	if (pkt_type == RXR_EAGER_RTW_PKT ||


### PR DESCRIPTION
…RAW_ADDR_HDR_SIZE

Previous commit b39dd7c55 introduced the macro RXR_REQ_OPT_RAW_ADDR_HDR_SIZE
to make the raw address header align on 8 bytes boundary. However,
rxr_pkt_req_max_header_size() is not using it to calculate the maximum
header size of a REQ packet.

This patch fix the issue.

Signed-off-by: Wei Zhang <wzam@amazon.com>
(cherry picked from commit 9863e4f5bc02423491f7df1adada6dddd7ea7c23)