### PR TITLE
prov/efa: use IBV_SEND_INLINE when message size fits

### DIFF
--- a/prov/efa/src/efa_msg.c
+++ b/prov/efa/src/efa_msg.c
@@ -342,7 +342,7 @@ static ssize_t efa_post_send(struct efa_ep *ep, const struct fi_msg *msg, uint64
 
 	efa_post_send_sgl(ep, msg, ewr);
 
-	if (flags & FI_INJECT)
+	if (len <= ep->domain->ctx->inline_buf_size)
 		wr->send_flags |= IBV_SEND_INLINE;
 
 	wr->opcode = IBV_WR_SEND;


### PR DESCRIPTION
Currently, the IBV_SEND_INLINE flag was added when
FI_INJECT flag is used. This is inappropriate for
two reasons:

First, IBV_SEND_INLINE requires message size to
be less than or equal to maximum inline size, but
there is no check for that.

Second, IBV_SEND_INLINE is different from inject
because inject means no CQ entry, but using IBV_SEND_INLINE
still generates an CQ entry.

This patch change it to that the IBV_SEND_INLINE flag
is used when the message size is less than or equal to
maximum inline size.

Signed-off-by: Wei Zhang <wzam@amazon.com>