### PR TITLE
[v1.11.x] prov/shm: Fixup progress return values, buffer overrun

### DIFF
--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -104,14 +104,19 @@ static int smr_progress_resp_entry(struct smr_ep *ep, struct smr_resp *resp,
 			break;
 		if (pending->cmd.msg.hdr.op == ofi_op_read_req) {
 			if (!*err) {
-				pending->bytes_done = ofi_copy_to_iov(pending->iov,
-						pending->iov_count, 0,
-						pending->map_ptr,
-						pending->cmd.msg.hdr.size);
+				pending->bytes_done =
+					ofi_copy_to_hmem_iov(pending->iface,
+							     pending->device,
+							     pending->iov,
+							     pending->iov_count,
+							     0, pending->map_ptr,
+							     pending->cmd.msg.hdr.size);
 				if (pending->bytes_done != pending->cmd.msg.hdr.size) {
 					FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 						"Incomplete copy from mmapped file\n");
-					*err = -FI_ETRUNC;
+					*err = (pending->bytes_done < 0)
+						? ((int) pending->bytes_done)
+						: -FI_ETRUNC;
 				}
 			}
 			munmap(pending->map_ptr, pending->cmd.msg.hdr.size);
@@ -278,8 +283,9 @@ out:
 }
 
 static int smr_mmap_peer_copy(struct smr_ep *ep, struct smr_cmd *cmd,
-				 struct iovec *iov, size_t iov_count,
-				 size_t *total_len)
+			      enum fi_hmem_iface iface, uint64_t device,
+			      struct iovec *iov, size_t iov_count,
+			      size_t *total_len)
 {
 	char shm_name[SMR_NAME_MAX];
 	void *mapped_ptr;
@@ -309,21 +315,25 @@ static int smr_mmap_peer_copy(struct smr_ep *ep, struct smr_cmd *cmd,
 	}
 
 	if (cmd->msg.hdr.op == ofi_op_read_req) {
-		*total_len = ofi_total_iov_len(iov, iov_count);
-		if (ofi_copy_from_iov(mapped_ptr, *total_len, iov, iov_count, 0)
-		    != *total_len) {
+		*total_len = ofi_copy_from_hmem_iov(mapped_ptr,
+						    cmd->msg.hdr.size, iface,
+						    device, iov, iov_count, 0);
+		if (*total_len != cmd->msg.hdr.size) {
 			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 				"mmap iov copy in error\n");
-			ret = -FI_ETRUNC;
+			ret = (*total_len < 0)
+				? ((int) *total_len) : -FI_ETRUNC;
 			goto munmap;
 		}
 	} else {
-		*total_len = ofi_copy_to_iov(iov, iov_count, 0, mapped_ptr,
-				      cmd->msg.hdr.size);
+		*total_len = ofi_copy_to_hmem_iov(iface, device, iov,
+						  iov_count, 0, mapped_ptr,
+						  cmd->msg.hdr.size);
 		if (*total_len != cmd->msg.hdr.size) {
 			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 				"mmap iov copy out error\n");
-			ret = -FI_ETRUNC;
+			ret = (*total_len < 0)
+				? ((int) *total_len) : -FI_ETRUNC;
 			goto munmap;
 		}
 	}
@@ -336,7 +346,8 @@ unlink_close:
 	return ret;
 }
 
-static int smr_progress_mmap(struct smr_cmd *cmd, struct iovec *iov,
+static int smr_progress_mmap(struct smr_cmd *cmd, enum fi_hmem_iface iface,
+			     uint64_t device, struct iovec *iov,
 			     size_t iov_count, size_t *total_len,
 			     struct smr_ep *ep)
 {
@@ -347,7 +358,8 @@ static int smr_progress_mmap(struct smr_cmd *cmd, struct iovec *iov,
 	peer_smr = smr_peer_region(ep->region, cmd->msg.hdr.id);
 	resp = smr_get_ptr(peer_smr, cmd->msg.hdr.src_data);
 
-	ret = smr_mmap_peer_copy(ep, cmd, iov, iov_count, total_len);
+	ret = smr_mmap_peer_copy(ep, cmd, iface, device,
+				 iov, iov_count, total_len);
 
 	//Status must be set last (signals peer: op done, valid resp entry)
 	resp->status = ret;
@@ -552,7 +564,8 @@ static int smr_progress_msg_common(struct smr_ep *ep, struct smr_cmd *cmd,
 					      &total_len, ep, 0);
 		break;
 	case smr_src_mmap:
-		entry->err = smr_progress_mmap(cmd, entry->iov, entry->iov_count,
+		entry->err = smr_progress_mmap(cmd, entry->iface, entry->device,
+					       entry->iov, entry->iov_count,
 					       &total_len, ep);
 		break;
 	case smr_src_sar:
@@ -743,7 +756,8 @@ static int smr_progress_cmd_rma(struct smr_ep *ep, struct smr_cmd *cmd)
 		err = smr_progress_iov(cmd, iov, iov_count, &total_len, ep, ret);
 		break;
 	case smr_src_mmap:
-		err = smr_progress_mmap(cmd, iov, iov_count, &total_len, ep);
+		err = smr_progress_mmap(cmd, iface, device, iov,
+					iov_count, &total_len, ep);
 		break;
 	case smr_src_sar:
 		if (smr_progress_sar(cmd, NULL, iface, device, iov, iov_count,

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -111,7 +111,7 @@ static int smr_progress_resp_entry(struct smr_ep *ep, struct smr_resp *resp,
 				if (pending->bytes_done != pending->cmd.msg.hdr.size) {
 					FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 						"Incomplete copy from mmapped file\n");
-					*err = -FI_EIO;
+					*err = -FI_ETRUNC;
 				}
 			}
 			munmap(pending->map_ptr, pending->cmd.msg.hdr.size);
@@ -136,7 +136,8 @@ static int smr_progress_resp_entry(struct smr_ep *ep, struct smr_resp *resp,
 		if (pending->bytes_done != pending->cmd.msg.hdr.size) {
 			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 				"Incomplete rma read/fetch buffer copied\n");
-			*err = FI_EIO;
+			*err = (pending->bytes_done < 0)
+				? ((int) pending->bytes_done) : -FI_ETRUNC;
 		}
 		break;
 	default:
@@ -163,7 +164,7 @@ static int smr_progress_resp_entry(struct smr_ep *ep, struct smr_resp *resp,
 	if (peer_smr != ep->region)
 		fastlock_release(&peer_smr->lock);
 
-	return 0;
+	return FI_SUCCESS;
 }
 
 static void smr_progress_resp(struct smr_ep *ep)
@@ -208,9 +209,9 @@ static int smr_progress_inline(struct smr_cmd *cmd, enum fi_hmem_iface iface,
 	if (*total_len != cmd->msg.hdr.size) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"recv truncated");
-		return -FI_EIO;
+		return (*total_len < 0) ? ((int) *total_len) : -FI_ETRUNC;
 	}
-	return 0;
+	return FI_SUCCESS;
 }
 
 static int smr_progress_inject(struct smr_cmd *cmd, enum fi_hmem_iface iface,
@@ -241,7 +242,7 @@ static int smr_progress_inject(struct smr_cmd *cmd, enum fi_hmem_iface iface,
 	if (*total_len != cmd->msg.hdr.size) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"recv truncated");
-		return -FI_EIO;
+		return (*total_len < 0) ? ((int) *total_len) : -FI_ETRUNC;
 	}
 
 	return FI_SUCCESS;
@@ -313,7 +314,7 @@ static int smr_mmap_peer_copy(struct smr_ep *ep, struct smr_cmd *cmd,
 		    != *total_len) {
 			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 				"mmap iov copy in error\n");
-			ret = -FI_EIO;
+			ret = -FI_ETRUNC;
 			goto munmap;
 		}
 	} else {
@@ -322,7 +323,7 @@ static int smr_mmap_peer_copy(struct smr_ep *ep, struct smr_cmd *cmd,
 		if (*total_len != cmd->msg.hdr.size) {
 			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 				"mmap iov copy out error\n");
-			ret = -FI_EIO;
+			ret = -FI_ETRUNC;
 			goto munmap;
 		}
 	}
@@ -473,9 +474,9 @@ static int smr_progress_inline_atomic(struct smr_cmd *cmd, struct fi_ioc *ioc,
 	if (*len != cmd->msg.hdr.size) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"recv truncated");
-		return -FI_EIO;
+		return -FI_ETRUNC;
 	}
-	return 0;
+	return FI_SUCCESS;
 }
 
 static int smr_progress_inject_atomic(struct smr_cmd *cmd, struct fi_ioc *ioc,
@@ -513,7 +514,7 @@ static int smr_progress_inject_atomic(struct smr_cmd *cmd, struct fi_ioc *ioc,
 	if (*len != cmd->msg.hdr.size) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"recv truncated");
-		err = -FI_EIO;
+		err = -FI_ETRUNC;
 	}
 
 out:


### PR DESCRIPTION
Backport #6948, does not include first commit from that as it is not applicable