### PR TITLE
[v1.10.x] prov/shm: Fixup progress return values, buffer overrun

### DIFF
--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -106,7 +106,7 @@ static int smr_progress_resp_entry(struct smr_ep *ep, struct smr_resp *resp,
 				if (pending->bytes_done != pending->cmd.msg.hdr.size) {
 					FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 						"Incomplete copy from mmapped file\n");
-					*err = -FI_EIO;
+					*err = -FI_ETRUNC;
 				}
 			}
 			munmap(pending->map_ptr, pending->cmd.msg.hdr.size);
@@ -131,7 +131,8 @@ static int smr_progress_resp_entry(struct smr_ep *ep, struct smr_resp *resp,
 		if (pending->bytes_done != pending->cmd.msg.hdr.size) {
 			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 				"Incomplete rma read/fetch buffer copied\n");
-			*err = FI_EIO;
+			*err = (pending->bytes_done < 0)
+				? ((int) pending->bytes_done) : -FI_ETRUNC;
 		}
 		break;
 	default:
@@ -158,7 +159,7 @@ static int smr_progress_resp_entry(struct smr_ep *ep, struct smr_resp *resp,
 	if (peer_smr != ep->region)
 		fastlock_release(&peer_smr->lock);
 
-	return 0;
+	return FI_SUCCESS;
 }
 
 static void smr_progress_resp(struct smr_ep *ep)
@@ -202,9 +203,9 @@ static int smr_progress_inline(struct smr_cmd *cmd, struct iovec *iov,
 	if (*total_len != cmd->msg.hdr.size) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"recv truncated");
-		return -FI_EIO;
+		return (*total_len < 0) ? ((int) *total_len) : -FI_ETRUNC;
 	}
-	return 0;
+	return FI_SUCCESS;
 }
 
 static int smr_progress_inject(struct smr_cmd *cmd, struct iovec *iov,
@@ -234,7 +235,7 @@ static int smr_progress_inject(struct smr_cmd *cmd, struct iovec *iov,
 	if (*total_len != cmd->msg.hdr.size) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"recv truncated");
-		return -FI_EIO;
+		return (*total_len < 0) ? ((int) *total_len) : -FI_ETRUNC;
 	}
 
 	return FI_SUCCESS;
@@ -327,7 +328,7 @@ static int smr_mmap_peer_copy(struct smr_ep *ep, struct smr_cmd *cmd,
 		    != *total_len) {
 			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 				"mmap iov copy in error\n");
-			ret = -FI_EIO;
+			ret = -FI_ETRUNC;
 			goto munmap;
 		}
 	} else {
@@ -336,7 +337,7 @@ static int smr_mmap_peer_copy(struct smr_ep *ep, struct smr_cmd *cmd,
 		if (*total_len != cmd->msg.hdr.size) {
 			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 				"mmap iov copy out error\n");
-			ret = -FI_EIO;
+			ret = -FI_ETRUNC;
 			goto munmap;
 		}
 	}
@@ -481,9 +482,9 @@ static int smr_progress_inline_atomic(struct smr_cmd *cmd, struct fi_ioc *ioc,
 	if (*len != cmd->msg.hdr.size) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"recv truncated");
-		return -FI_EIO;
+		return -FI_ETRUNC;
 	}
-	return 0;
+	return FI_SUCCESS;
 }
 
 static int smr_progress_inject_atomic(struct smr_cmd *cmd, struct fi_ioc *ioc,
@@ -521,7 +522,7 @@ static int smr_progress_inject_atomic(struct smr_cmd *cmd, struct fi_ioc *ioc,
 	if (*len != cmd->msg.hdr.size) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"recv truncated");
-		err = -FI_EIO;
+		err = -FI_ETRUNC;
 	}
 
 out:

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -99,14 +99,19 @@ static int smr_progress_resp_entry(struct smr_ep *ep, struct smr_resp *resp,
 			break;
 		if (pending->cmd.msg.hdr.op == ofi_op_read_req) {
 			if (!*err) {
-				pending->bytes_done = ofi_copy_to_iov(pending->iov,
-						pending->iov_count, 0,
-						pending->map_ptr,
-						pending->cmd.msg.hdr.size);
+				pending->bytes_done =
+					ofi_copy_to_hmem_iov(pending->iface,
+							     pending->device,
+							     pending->iov,
+							     pending->iov_count,
+							     0, pending->map_ptr,
+							     pending->cmd.msg.hdr.size);
 				if (pending->bytes_done != pending->cmd.msg.hdr.size) {
 					FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 						"Incomplete copy from mmapped file\n");
-					*err = -FI_ETRUNC;
+					*err = (pending->bytes_done < 0)
+						? ((int) pending->bytes_done)
+						: -FI_ETRUNC;
 				}
 			}
 			munmap(pending->map_ptr, pending->cmd.msg.hdr.size);
@@ -291,8 +296,9 @@ out:
 }
 
 static int smr_mmap_peer_copy(struct smr_ep *ep, struct smr_cmd *cmd,
-				 struct iovec *iov, size_t iov_count,
-				 size_t *total_len)
+			      enum fi_hmem_iface iface, uint64_t device,
+			      struct iovec *iov, size_t iov_count,
+			      size_t *total_len)
 {
 	char shm_name[NAME_MAX];
 	void *mapped_ptr;
@@ -323,21 +329,25 @@ static int smr_mmap_peer_copy(struct smr_ep *ep, struct smr_cmd *cmd,
 	}
 
 	if (cmd->msg.hdr.op == ofi_op_read_req) {
-		*total_len = ofi_total_iov_len(iov, iov_count);
-		if (ofi_copy_from_iov(mapped_ptr, *total_len, iov, iov_count, 0)
-		    != *total_len) {
+		*total_len = ofi_copy_from_hmem_iov(mapped_ptr,
+						    cmd->msg.hdr.size, iface,
+						    device, iov, iov_count, 0);
+		if (*total_len != cmd->msg.hdr.size) {
 			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 				"mmap iov copy in error\n");
-			ret = -FI_ETRUNC;
+			ret = (*total_len < 0)
+				? ((int) *total_len) : -FI_ETRUNC;
 			goto munmap;
 		}
 	} else {
-		*total_len = ofi_copy_to_iov(iov, iov_count, 0, mapped_ptr,
-				      cmd->msg.hdr.size);
+		*total_len = ofi_copy_to_hmem_iov(iface, device, iov,
+						  iov_count, 0, mapped_ptr,
+						  cmd->msg.hdr.size);
 		if (*total_len != cmd->msg.hdr.size) {
 			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 				"mmap iov copy out error\n");
-			ret = -FI_ETRUNC;
+			ret = (*total_len < 0)
+				? ((int) *total_len) : -FI_ETRUNC;
 			goto munmap;
 		}
 	}
@@ -350,7 +360,8 @@ unlink_close:
 	return ret;
 }
 
-static int smr_progress_mmap(struct smr_cmd *cmd, struct iovec *iov,
+static int smr_progress_mmap(struct smr_cmd *cmd, enum fi_hmem_iface iface,
+			     uint64_t device, struct iovec *iov,
 			     size_t iov_count, size_t *total_len,
 			     struct smr_ep *ep)
 {
@@ -362,7 +373,8 @@ static int smr_progress_mmap(struct smr_cmd *cmd, struct iovec *iov,
 	peer_smr = smr_peer_region(ep->region, peer_id);
 	resp = smr_get_ptr(peer_smr, cmd->msg.hdr.src_data);
 
-	ret = smr_mmap_peer_copy(ep, cmd, iov, iov_count, total_len);
+	ret = smr_mmap_peer_copy(ep, cmd, iface, device,
+				 iov, iov_count, total_len);
 
 	//Status must be set last (signals peer: op done, valid resp entry)
 	resp->status = ret;
@@ -558,7 +570,8 @@ static int smr_progress_msg_common(struct smr_ep *ep, struct smr_cmd *cmd,
 					      &total_len, ep, 0);
 		break;
 	case smr_src_mmap:
-		entry->err = smr_progress_mmap(cmd, entry->iov, entry->iov_count,
+		entry->err = smr_progress_mmap(cmd, entry->iface, entry->device,
+					       entry->iov, entry->iov_count,
 					       &total_len, ep);
 		break;
 	case smr_src_sar:
@@ -706,7 +719,8 @@ static int smr_progress_cmd_rma(struct smr_ep *ep, struct smr_cmd *cmd)
 		err = smr_progress_iov(cmd, iov, iov_count, &total_len, ep, ret);
 		break;
 	case smr_src_mmap:
-		err = smr_progress_mmap(cmd, iov, iov_count, &total_len, ep);
+		err = smr_progress_mmap(cmd, iface, device, iov,
+					iov_count, &total_len, ep);
 		break;
 	case smr_src_sar:
 		if (smr_progress_sar(cmd, NULL, iov, iov_count, &total_len, ep))


### PR DESCRIPTION
Backport #6948, does not include first commit from that as it is not applicable