### PR TITLE
prov/efa: defer memory allocation to 1st call of the progress engine

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -710,13 +710,24 @@ struct rxr_ep {
 	struct dlist_entry rx_entry_list;
 	struct dlist_entry tx_entry_list;
 
-	/* number of posted buffer for shm */
-	size_t posted_bufs_shm;
-	size_t rx_bufs_shm_to_post;
-
-	/* number of posted buffers */
-	size_t posted_bufs_efa;
-	size_t rx_bufs_efa_to_post;
+	/*
+	 * number of posted RX packets for shm
+	 */
+	size_t shm_rx_pkts_posted;
+	/*
+	 * number of RX packets to be posted by progress engine for shm.
+	 * It exists because posting RX packets by bulk is more efficient.
+	 */
+	size_t shm_rx_pkts_to_post;
+	/*
+	 * number of posted RX packets for EFA device
+	 */
+	size_t efa_rx_pkts_posted;
+	/*
+	 * Number of RX packets to be posted by progress engine for EFA device.
+	 * It exists because posting RX packets by bulk is more efficient.
+	 */
+	size_t efa_rx_pkts_to_post;
 	/* number of buffers available for large messages */
 	size_t available_data_bufs;
 	/* Timestamp of when available_data_bufs was exhausted. */
@@ -887,8 +898,8 @@ int rxr_endpoint(struct fid_domain *domain, struct fi_info *info,
 void rxr_ep_progress(struct util_ep *util_ep);
 void rxr_ep_progress_internal(struct rxr_ep *rxr_ep);
 
-int rxr_ep_post_user_buf(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,
-			 uint64_t flags);
+int rxr_ep_post_user_recv_buf(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,
+			      uint64_t flags);
 
 int rxr_ep_set_tx_credit_request(struct rxr_ep *rxr_ep,
 				 struct rxr_tx_entry *tx_entry);

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -871,7 +871,6 @@ static int rxr_ep_ctrl(struct fid *fid, int command, void *arg)
 {
 	ssize_t ret;
 	struct rxr_ep *ep;
-	size_t shm_rx_size;
 	char shm_ep_name[NAME_MAX];
 
 	switch (command) {
@@ -886,13 +885,6 @@ static int rxr_ep_ctrl(struct fid *fid, int command, void *arg)
 		fastlock_acquire(&ep->util_ep.lock);
 
 		rxr_ep_set_features(ep);
-
-		if (!ep->use_zcpy_rx) {
-			ret = rxr_ep_bulk_post_prov_buf(ep, rxr_get_rx_pool_chunk_cnt(ep), EFA_EP);
-			if (OFI_UNLIKELY(ret))
-				goto out;
-			ep->available_data_bufs = rxr_get_rx_pool_chunk_cnt(ep);
-		}
 
 		ep->core_addrlen = RXR_MAX_NAME_LENGTH;
 		ret = fi_getname(&ep->rdm_ep->fid,
@@ -915,14 +907,9 @@ static int rxr_ep_ctrl(struct fid *fid, int command, void *arg)
 				goto out;
 
 			fi_setname(&ep->shm_ep->fid, shm_ep_name, sizeof(shm_ep_name));
-			shm_rx_size = shm_info->rx_attr->size;
 			ret = fi_enable(ep->shm_ep);
 			if (ret)
 				return ret;
-
-			ret = rxr_ep_bulk_post_prov_buf(ep, shm_rx_size, SHM_EP);
-			if (OFI_UNLIKELY(ret))
-				goto out;
 		}
 
 out:
@@ -1170,14 +1157,6 @@ int rxr_ep_init(struct rxr_ep *ep)
 
 		if (ret)
 			goto err_free;
-
-		ret = ofi_bufpool_grow(ep->rx_unexp_pkt_pool);
-		if (ret) {
-			FI_WARN(&rxr_prov, FI_LOG_CQ,
-				"cannot allocate memory for unexpected packet pool. error: %s\n",
-				strerror(-ret));
-			goto err_free;
-		}
 	}
 
 	if (rxr_env.rx_copy_ooo) {
@@ -1188,13 +1167,6 @@ int rxr_ep_init(struct rxr_ep *ep)
 		if (ret)
 			goto err_free;
 
-		ret = ofi_bufpool_grow(ep->rx_ooo_pkt_pool);
-		if (ret) {
-			FI_WARN(&rxr_prov, FI_LOG_CQ,
-				"cannot allocate memory for out-of-order packet pool. error: %s\n",
-				strerror(-ret));
-			goto err_free;
-		}
 	}
 
 	if ((rxr_env.rx_copy_unexp || rxr_env.rx_copy_ooo) &&
@@ -1208,15 +1180,6 @@ int rxr_ep_init(struct rxr_ep *ep)
 
 		if (ret)
 			goto err_free;
-
-		ret = ofi_bufpool_grow(ep->rx_readcopy_pkt_pool);
-		if (ret) {
-			FI_WARN(&rxr_prov, FI_LOG_CQ,
-				"cannot allocate and register memory for readcopy packet pool. error: %s\n",
-				strerror(-ret));
-			goto err_free;
-		}
-
 		ep->rx_readcopy_pkt_pool_used = 0;
 		ep->rx_readcopy_pkt_pool_max_used = 0;
 	}
@@ -1397,6 +1360,73 @@ struct fi_ops_cm rxr_ep_cm = {
 	.join = fi_no_join,
 };
 
+/*
+ * @brief explicitly allocate a chunk of memory for 5 packet pools on RX side:
+ *     efa's receive packet pool (efa_rx_pkt_pool)
+ *     shm's receive packet pool (shm_rx_pkt_pool)
+ *     unexpected packet pool (rx_unexp_pkt_pool),
+ *     out-of-order packet pool (rx_ooo_pkt_pool), and
+ *     local read-copy packet pool (rx_readcopy_pkt_pool).
+ *
+ * @param ep[in]	endpoint
+ * @return		On success, return 0
+ * 			On failure, return a negative error code.
+ */
+int rxr_ep_grow_rx_pkt_pools(struct rxr_ep *ep)
+{
+	int err;
+
+	assert(ep->efa_rx_pkt_pool);
+	err = ofi_bufpool_grow(ep->efa_rx_pkt_pool);
+	if (err) {
+		FI_WARN(&rxr_prov, FI_LOG_CQ,
+			"cannot allocate memory for EFA's RX packet pool. error: %s\n",
+			strerror(-err));
+		return err;
+	}
+
+	if (ep->use_shm) {
+		assert(ep->shm_rx_pkt_pool);
+		err = ofi_bufpool_grow(ep->shm_rx_pkt_pool);
+		if (err) {
+			FI_WARN(&rxr_prov, FI_LOG_CQ,
+				"cannot allocate memory for SHM's RX packet pool. error: %s\n",
+				strerror(-err));
+			return err;
+		}
+	}
+
+	assert(ep->rx_unexp_pkt_pool);
+	err = ofi_bufpool_grow(ep->rx_unexp_pkt_pool);
+	if (err) {
+		FI_WARN(&rxr_prov, FI_LOG_CQ,
+			"cannot allocate memory for unexpected packet pool. error: %s\n",
+			strerror(-err));
+		return err;
+	}
+
+	assert(ep->rx_ooo_pkt_pool);
+	err = ofi_bufpool_grow(ep->rx_ooo_pkt_pool);
+	if (err) {
+		FI_WARN(&rxr_prov, FI_LOG_CQ,
+			"cannot allocate memory for out-of-order packet pool. error: %s\n",
+			strerror(-err));
+		return err;
+	}
+
+	if (ep->rx_readcopy_pkt_pool) {
+		err = ofi_bufpool_grow(ep->rx_readcopy_pkt_pool);
+		if (err) {
+			FI_WARN(&rxr_prov, FI_LOG_CQ,
+				"cannot allocate and register memory for readcopy packet pool. error: %s\n",
+				strerror(-err));
+			return err;
+		}
+	}
+
+	return 0;
+}
+
 /**
  * @brief post internal receive buffers for progress engine.
  *
@@ -1443,6 +1473,52 @@ void rxr_ep_progress_post_prov_buf(struct rxr_ep *ep)
 			ep->rx_bufs_efa_to_post = 1;
 		} else if (ep->posted_bufs_efa > 0 && ep->rx_bufs_efa_to_post > 0){
 			ep->rx_bufs_efa_to_post = 0;
+		}
+	} else {
+		if (ep->posted_bufs_efa == 0 && ep->rx_bufs_efa_to_post == 0) {
+			/* Both posted_bufs_efa and rx_bufs_efa_to_post equal to 0 means
+			 * this is the first call of the progress engine on this endpoint.
+			 *
+			 * In this case, we explictly allocate the 1st chunk of memory
+			 * for unexp/ooo/readcopy RX packet pool.
+			 *
+			 * The reason to explicitly allocate the memory for RX packet
+			 * pool is to improve efficiency.
+			 *
+			 * Without explicit memory allocation, a pkt pools's memory
+			 * is allocated when 1st packet is allocated from it.
+			 * During the computation, different processes got their 1st
+			 * unexp/ooo/read-copy packet at different time. Therefore,
+			 * if we do not explicitly allocate memory at the beginning,
+			 * memory will be allocated at different time.
+			 *
+			 * When one process is allocating memory, other processes
+			 * have to wait. When each process allocate memory at different
+			 * time, the accumulated waiting time became significant.
+			 *
+			 * By explicitly allocating memory at 1st call to progress
+			 * engine, the memory allocation is parallelized.
+			 * (This assumes the 1st call to the progress engine on
+			 * all processes happen at roughly the same time, which
+			 * is a valid assumption according to our knowledge of
+			 * the workflow of most application)
+			 *
+			 * The memory was not allocated during endpoint initialization
+			 * because some applications will initialize some endpoints
+			 * but never uses it, thus allocating memory initialization
+			 * causes waste.
+			 */
+			err = rxr_ep_grow_rx_pkt_pools(ep);
+			if (err)
+				goto err_exit;
+
+			ep->rx_bufs_efa_to_post = rxr_get_rx_pool_chunk_cnt(ep);
+			ep->available_data_bufs = rxr_get_rx_pool_chunk_cnt(ep);
+
+			if (ep->use_shm) {
+				assert(ep->posted_bufs_shm == 0 && ep->rx_bufs_shm_to_post == 0);
+				ep->rx_bufs_shm_to_post = shm_info->rx_attr->size;
+			}
 		}
 	}
 

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -1081,7 +1081,7 @@ ssize_t rxr_msg_generic_recv(struct fid_ep *ep, const struct fi_msg *msg,
 	}
 
 	if (rxr_ep->use_zcpy_rx) {
-		ret = rxr_ep_post_user_buf(rxr_ep, rx_entry, flags);
+		ret = rxr_ep_post_user_recv_buf(rxr_ep, rx_entry, flags);
 		if (ret == -FI_EAGAIN)
 			rxr_ep_progress_internal(rxr_ep);
 	} else if (op == ofi_op_tagged) {

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -1183,9 +1183,9 @@ void rxr_pkt_handle_recv_completion(struct rxr_ep *ep,
 
 	if (peer->is_local) {
 		assert(ep->use_shm);
-		ep->posted_bufs_shm--;
+		ep->shm_rx_pkts_posted--;
 	} else {
-		ep->posted_bufs_efa--;
+		ep->efa_rx_pkts_posted--;
 	}
 
 	if (pkt_entry->alloc_type == RXR_PKT_FROM_USER_BUFFER) {
@@ -1198,7 +1198,7 @@ void rxr_pkt_handle_recv_completion(struct rxr_ep *ep,
 	if (zcpy_rx_entry && pkt_type != RXR_EAGER_MSGRTM_PKT) {
 		/* user buffer was not matched with a message,
 		 * therefore reposting the buffer */
-		rxr_ep_post_user_buf(ep, zcpy_rx_entry, 0);
+		rxr_ep_post_user_recv_buf(ep, zcpy_rx_entry, 0);
 	}
 }
 

--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -137,9 +137,9 @@ void rxr_pkt_entry_release_rx(struct rxr_ep *ep,
 		return;
 
 	if (pkt_entry->alloc_type == RXR_PKT_FROM_EFA_RX_POOL) {
-		ep->rx_bufs_efa_to_post++;
+		ep->efa_rx_pkts_to_post++;
 	} else if (pkt_entry->alloc_type == RXR_PKT_FROM_SHM_RX_POOL) {
-		ep->rx_bufs_shm_to_post++;
+		ep->shm_rx_pkts_to_post++;
 	} else if (pkt_entry->alloc_type == RXR_PKT_FROM_READ_COPY_POOL) {
 		assert(ep->rx_readcopy_pkt_pool_used > 0);
 		ep->rx_readcopy_pkt_pool_used--;

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -195,7 +195,7 @@ void rxr_pkt_calc_cts_window_credits(struct rxr_ep *ep, struct rdm_peer *peer,
 	 * number of credits are allocated to the transfer so the sender can
 	 * make progress.
 	 */
-	*credits = MIN(MIN(ep->available_data_bufs, ep->posted_bufs_efa),
+	*credits = MIN(MIN(ep->available_data_bufs, ep->efa_rx_pkts_posted),
 		       peer->rx_credits);
 	*credits = MIN(request, *credits);
 	*credits = MAX(*credits, rxr_env.tx_min_credits);


### PR DESCRIPTION
 defer memory allocation to 1st call of the progress engine