### PR TITLE
updates to rxd and rxm to set correct domain capabilities

### DIFF
--- a/prov/rxd/src/rxd_init.c
+++ b/prov/rxd/src/rxd_init.c
@@ -104,9 +104,8 @@ int rxd_info_to_rxd(uint32_t version, const struct fi_info *core_info,
 	*info->rx_attr = *rxd_info.rx_attr;
 	*info->ep_attr = *rxd_info.ep_attr;
 	*info->domain_attr = *rxd_info.domain_attr;
-	info->domain_attr->caps = ofi_pick_core_flags(rxd_info.domain_attr->caps,
-						core_info->domain_attr->caps,
-						FI_LOCAL_COMM | FI_REMOTE_COMM);
+	info->domain_attr->caps = rxd_info.domain_attr->caps &
+				  core_info->domain_attr->caps;
 	if (core_info->nic) {
 		info->nic = ofi_nic_dup(core_info->nic);
 		if (!info->nic)

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -227,6 +227,8 @@ int rxm_info_to_rxm(uint32_t version, const struct fi_info *core_info,
 	info->ep_attr->max_order_waw_size = core_info->ep_attr->max_order_waw_size;
 
 	*info->domain_attr = *base_info->domain_attr;
+	info->domain_attr->caps = base_info->domain_attr->caps &
+				  core_info->domain_attr->caps;
 	info->domain_attr->mr_mode |= core_info->domain_attr->mr_mode;
 	info->domain_attr->cq_data_size = MIN(core_info->domain_attr->cq_data_size,
 					      base_info->domain_attr->cq_data_size);


### PR DESCRIPTION
Currently if the core provider supports only FI_LOCAL_COMM domain capabilities rxm would still return FI_LOCAL_COMM | FI_REMOTE_COMM. rxd on the other hand would over ride the is own domain capabilities to only reflect the core provider's capabilites. Changes made to incorporate both the util and core providers. 
ref: https://github.com/ofiwg/libfabric/issues/6881