### PR TITLE
fi_errno.h: define new RNR error FI_ENORX 

### DIFF
--- a/include/rdma/fi_errno.h
+++ b/include/rdma/fi_errno.h
@@ -193,6 +193,7 @@ enum {
 	FI_ENOKEY        = 266, /* Required key not available */
 	FI_ENOAV	 = 267, /* Missing or unavailable address vector */
 	FI_EOVERRUN	 = 268, /* Queue has been overrun */
+	FI_ENORX	 = 269, /* Receiver not ready, no receive buffers available */
 	FI_ERRNO_MAX
 };
 

--- a/man/fi_domain.3.md
+++ b/man/fi_domain.3.md
@@ -446,8 +446,10 @@ transfer operation.
   seen by the initiator of a request.  For FI_EP_DGRAM endpoints, if the target EP
   queues are unable to accept incoming messages, received messages will
   be dropped.  For reliable endpoints, if RM is disabled, the transmit
-  operation will complete in error.  If RM is enabled, the provider will
-  internally retry the operation.
+  operation will complete in error. A provider may choose to return an error
+  completion with the error code FI_ENORX for that transmit operation so that
+  it can be retried. If RM is enabled, the provider will internally retry the
+  operation.
 
 *Rx Buffer Overrun*
 : This refers to buffers posted to receive incoming tagged or untagged messages,

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -1304,6 +1304,7 @@ static const char *const errstr[] = {
 	[FI_ENOKEY - FI_ERRNO_OFFSET] = "Required key not available",
 	[FI_ENOAV - FI_ERRNO_OFFSET] = "Missing or unavailable address vector",
 	[FI_EOVERRUN - FI_ERRNO_OFFSET] = "Queue has been overrun",
+	[FI_ENORX - FI_ERRNO_OFFSET] = "Receiver not ready, no receive buffers available",
 };
 
 __attribute__((visibility ("default"),EXTERNALLY_VISIBLE))


### PR DESCRIPTION
Add a new error code for receiver not ready errors and update the man page discussing this error.