### PR TITLE
prov/efa: adjust unexpected packet pool chunk size

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -227,6 +227,7 @@ struct rxr_env {
 	int shm_max_medium_size;
 	int recvwin_size;
 	int ooo_pool_chunk_size;
+	int unexp_pool_chunk_size;
 	int readcopy_pool_size;
 	int atomrsp_pool_size;
 	int cq_size;

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1166,7 +1166,7 @@ int rxr_ep_init(struct rxr_ep *ep)
 	if (rxr_env.rx_copy_unexp) {
 		ret = ofi_bufpool_create(&ep->rx_unexp_pkt_pool, entry_sz,
 					 RXR_BUF_POOL_ALIGNMENT, 0,
-					 rxr_get_rx_pool_chunk_cnt(ep), 0);
+					 rxr_env.unexp_pool_chunk_size, 0);
 
 		if (ret)
 			goto err_free;

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -57,6 +57,7 @@ struct rxr_env rxr_env = {
 	.shm_max_medium_size = 4096,
 	.recvwin_size = RXR_RECVWIN_SIZE,
 	.ooo_pool_chunk_size = 64,
+	.unexp_pool_chunk_size = 1024,
 	.readcopy_pool_size = 256,
 	.atomrsp_pool_size = 1024,
 	.cq_size = RXR_DEF_CQ_SIZE,


### PR DESCRIPTION
Currently, the unexpected packet pool chunk size is the same
with the rx entry pool (8192). Tests have shown that a chunk
size of 1024 can cover majority of use case.

Regression test on 1152 processes also shows that this smaller size
improves the performance of non-blocking collective MPI
benchmarks iallgather, iallgatherv, ialltoall, ialltoallv.

Signed-off-by: Shi Jin <sjina@amazon.com>