### PR TITLE
prov/efa: temporarily disable the usage of IBV_INLINE_SEND

### DIFF
--- a/prov/efa/src/efa_msg.c
+++ b/prov/efa/src/efa_msg.c
@@ -342,8 +342,11 @@ static ssize_t efa_post_send(struct efa_ep *ep, const struct fi_msg *msg, uint64
 
 	efa_post_send_sgl(ep, msg, ewr);
 
+	/* TODO: uncomment this code block when the underlying
+	 * issue with INLINE send is fixed.
 	if (len <= ep->domain->ctx->inline_buf_size)
 		wr->send_flags |= IBV_SEND_INLINE;
+	*/
 
 	wr->opcode = IBV_WR_SEND;
 	wr->wr_id = (uintptr_t)msg->context;


### PR DESCRIPTION
We encoutered some issues adding enabling IBV_INLINE_SEND.
Therefore this patch disables the usage of IBV_INLINE_SEND,
it will be reverted once the underlying issue has been fixed.

Signed-off-by: Wei Zhang <wzam@amazon.com>