### PR TITLE
[v1.13.x] prov/util: Do not set impmon.impfid to NULL on monitor init

### DIFF
--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -609,7 +609,6 @@ struct ofi_mem_monitor *import_monitor = &impmon.monitor;
 
 static void ofi_import_monitor_init(struct ofi_mem_monitor *monitor)
 {
-	impmon.impfid = NULL;
 	ofi_monitor_init(monitor);
 }
 


### PR DESCRIPTION
The import monitor could have already been imported by the time the
monitors have been initialized. Do not set impmon.impfid to NULL to
avoid this case.

Signed-off-by: William Zhang <wilzhang@amazon.com>
(cherry picked from commit 0b0839e87e106f5fee55e5b3894d7fcafc57ba67)