### PR TITLE
hmem, prov/shm: Generic HMEM IPC protocol using get/open/close_handle, implemented those funcs for CUDA

### DIFF
--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -103,6 +103,7 @@ struct ofi_hmem_ops {
 	int (*host_register)(void *ptr, size_t size);
 	int (*host_unregister)(void *ptr);
 	int (*get_base_addr)(const void *ptr, void **base);
+	bool (*is_ipc_enabled)(void);
 };
 
 extern struct ofi_hmem_ops hmem_ops[];
@@ -200,6 +201,11 @@ static inline int ofi_hmem_no_base_addr(const void *ptr, void **base)
 	return -FI_ENOSYS;
 }
 
+static inline bool ofi_hmem_no_is_ipc_enabled(void)
+{
+	return false;
+}
+
 ssize_t ofi_copy_from_hmem_iov(void *dest, size_t size,
 			       enum fi_hmem_iface hmem_iface, uint64_t device,
 			       const struct iovec *hmem_iov,
@@ -222,5 +228,6 @@ void ofi_hmem_cleanup(void);
 enum fi_hmem_iface ofi_get_hmem_iface(const void *addr);
 int ofi_hmem_host_register(void *ptr, size_t size);
 int ofi_hmem_host_unregister(void *ptr);
+bool ofi_hmem_is_ipc_enabled(enum fi_hmem_iface iface);
 
 #endif /* _OFI_HMEM_H_ */

--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -127,6 +127,10 @@ int cuda_host_register(void *ptr, size_t size);
 int cuda_host_unregister(void *ptr);
 int cuda_dev_register(struct fi_mr_attr *mr_attr, uint64_t *handle);
 int cuda_dev_unregister(uint64_t handle);
+int cuda_get_handle(void *dev_buf, void **handle);
+int cuda_open_handle(void **handle, uint64_t device, void **ipc_ptr);
+int cuda_close_handle(void *ipc_ptr);
+bool cuda_is_ipc_enabled(void);
 
 void cuda_gdrcopy_to_dev(uint64_t handle, void *dev,
 			 const void *host, size_t size);

--- a/man/fabric.7.md
+++ b/man/fabric.7.md
@@ -281,6 +281,7 @@ application, with the -e or --env command line option.
 
 # NOTES
 
+## System Calls
 Because libfabric is designed to provide applications direct access to
 fabric hardware, there are limits on how libfabric resources may be used
 in conjunction with system calls.  These limitations are notable for
@@ -296,6 +297,25 @@ portability across providers.
   network.  For example, data buffers that have been registered with a
   fabric domain may not be available in a child process because of copy
   on write restrictions.
+
+## CUDA deadlock
+In some cases, calls to `cudaMemcpy` within libfabric may result in a
+deadlock. This typically occurs when a CUDA kernel blocks until a
+`cudaMemcpy` on the host completes.  To avoid this deadlock,
+`cudaMemcpy` may be disabled by setting
+`FI_HMEM_CUDA_ENABLE_XFER=0`. If this environment variable is set and
+there is a call to `cudaMemcpy` with libfabric, a warning will be
+emitted and no copy will occur. Note that not all providers support
+this option.
+
+Another mechanism which can be used to avoid deadlock is Nvidia's
+gdrcopy. Using gdrcopy requires an external library and kernel module
+available at https://github.com/NVIDIA/gdrcopy. Libfabric must be
+configured with gdrcopy support using the `--with-gdrcopy` option, and
+be run with `FI_HMEM_CUDA_USE_GDRCOPY=1`. This may be used in
+conjunction with the above option to provide a method for copying
+to/from CUDA device memory when `cudaMemcpy` cannot be used. Again,
+this may not be supported by all providers.
 
 # ABI CHANGES
 

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -326,6 +326,9 @@ int smr_format_ze_ipc(struct smr_ep *ep, int64_t id, struct smr_cmd *cmd,
 		      const struct iovec *iov, uint64_t device,
 		      size_t total_len, struct smr_region *smr,
 		      struct smr_resp *resp, struct smr_tx_entry *pend);
+int smr_format_ipc(struct smr_cmd *cmd, void *ptr,
+                   size_t len, struct smr_region *smr,
+                   struct smr_resp *resp, enum fi_hmem_iface iface);
 int smr_format_mmap(struct smr_ep *ep, struct smr_cmd *cmd,
 		    const struct iovec *iov, size_t count, size_t total_len,
 		    struct smr_tx_entry *pend, struct smr_resp *resp);

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -391,6 +391,19 @@ int smr_format_ze_ipc(struct smr_ep *ep, int64_t id, struct smr_cmd *cmd,
 	return FI_SUCCESS;
 }
 
+int smr_format_ipc(struct smr_cmd *cmd, void *ptr,
+                   size_t len, struct smr_region *smr,
+                   struct smr_resp *resp, enum fi_hmem_iface iface)
+{
+    cmd->msg.hdr.op_src = smr_src_ipc;
+    cmd->msg.hdr.src_data = smr_get_offset(smr, resp);
+    cmd->msg.hdr.size = len;
+    cmd->msg.data.ipc_info.iface = iface;
+
+    return ofi_hmem_get_handle(cmd->msg.data.ipc_info.iface, ptr,
+                               (void **)&cmd->msg.data.ipc_info.ipc_handle);
+}
+
 int smr_format_mmap(struct smr_ep *ep, struct smr_cmd *cmd,
 		    const struct iovec *iov, size_t count, size_t total_len,
 		    struct smr_tx_entry *pend, struct smr_resp *resp)

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -80,7 +80,8 @@ static int smr_progress_resp_entry(struct smr_ep *ep, struct smr_resp *resp,
 	case smr_src_iov:
 		break;
 	case smr_src_ipc:
-		close(pending->fd);
+		if (pending->iface == FI_HMEM_ZE)
+			close(pending->fd);
 		break;
 	case smr_src_sar:
 		sar_msg = smr_get_ptr(peer_smr, pending->cmd.msg.data.sar);

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013-2021 Intel Corporation. All rights reserved
+ * (C) Copyright 2021 Amazon.com, Inc. or its affiliates.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -103,6 +104,7 @@ ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 	uint16_t comp_flags;
 	ssize_t ret = 0;
 	size_t total_len;
+	bool use_ipc;
 
 	assert(iov_count <= SMR_IOV_LIMIT);
 	assert(rma_count <= SMR_IOV_LIMIT);
@@ -147,12 +149,17 @@ ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 
 	total_len = ofi_total_iov_len(iov, iov_count);
 
+	/* Do not inline/inject if IPC is available so device to device
+	 * transfer may occur if possible. */
+	use_ipc = ofi_hmem_is_ipc_enabled(iface) && (iov_count == 1) &&
+		  desc && (smr_get_mr_flags(desc) & FI_HMEM_DEVICE_ONLY);
+
 	smr_generic_format(cmd, peer_id, op, 0, data, op_flags);
 	if (total_len <= SMR_MSG_DATA_LEN && op == ofi_op_write &&
-	    !(op_flags & FI_DELIVERY_COMPLETE)) {
+	    !(op_flags & FI_DELIVERY_COMPLETE) && !use_ipc) {
 		smr_format_inline(cmd, iface, device, iov, iov_count);
 	} else if (total_len <= SMR_INJECT_SIZE &&
-		   !(op_flags & FI_DELIVERY_COMPLETE)) {
+		   !(op_flags & FI_DELIVERY_COMPLETE) && !use_ipc) {
 		tx_buf = smr_freestack_pop(smr_inject_pool(peer_smr));
 		smr_format_inject(cmd, iface, device, iov, iov_count, peer_smr, tx_buf);
 		if (op == ofi_op_read_req) {
@@ -181,13 +188,14 @@ ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 			smr_format_iov(cmd, iov, iov_count, total_len, ep->region,
 				       resp);
 		} else {
-			if (iface == FI_HMEM_ZE &&
-			    (smr_get_mr_flags(desc) & FI_HMEM_DEVICE_ONLY) &&
-			    iov_count == 1 &&
+			if (use_ipc && iface == FI_HMEM_ZE &&
 			    smr_ze_ipc_enabled(ep->region, peer_smr)) {
 				ret = smr_format_ze_ipc(ep, id, cmd, iov,
 					device, total_len, ep->region,
 					resp, pend);
+			} else if (use_ipc && iface != FI_HMEM_ZE) {
+				ret = smr_format_ipc(cmd, iov[0].iov_base, total_len,
+						     ep->region, resp, iface);
 			} else if (total_len <= smr_env.sar_threshold ||
 			    iface != FI_HMEM_SYSTEM) {
 				if (!peer_smr->sar_cnt) {

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -52,6 +52,7 @@ struct ofi_hmem_ops hmem_ops[] = {
 		.host_register = ofi_hmem_register_noop,
 		.host_unregister = ofi_hmem_host_unregister_noop,
 		.get_base_addr = ofi_hmem_no_base_addr,
+		.is_ipc_enabled = ofi_hmem_no_is_ipc_enabled,
 	},
 	[FI_HMEM_CUDA] = {
 		.initialized = false,
@@ -66,6 +67,7 @@ struct ofi_hmem_ops hmem_ops[] = {
 		.host_register = cuda_host_register,
 		.host_unregister = cuda_host_unregister,
 		.get_base_addr = ofi_hmem_no_base_addr,
+		.is_ipc_enabled = ofi_hmem_no_is_ipc_enabled,
 	},
 	[FI_HMEM_ROCR] = {
 		.initialized = false,
@@ -80,6 +82,7 @@ struct ofi_hmem_ops hmem_ops[] = {
 		.host_register = rocr_host_register,
 		.host_unregister = rocr_host_unregister,
 		.get_base_addr = ofi_hmem_no_base_addr,
+		.is_ipc_enabled = ofi_hmem_no_is_ipc_enabled,
 	},
 	[FI_HMEM_ZE] = {
 		.initialized = false,
@@ -94,6 +97,7 @@ struct ofi_hmem_ops hmem_ops[] = {
 		.host_register = ofi_hmem_register_noop,
 		.host_unregister = ofi_hmem_host_unregister_noop,
 		.get_base_addr = ze_hmem_get_base_addr,
+		.is_ipc_enabled = ze_hmem_p2p_enabled,
 	},
 };
 
@@ -299,4 +303,9 @@ err:
 		fi_strerror(-ret));
 
 	return ret;
+}
+
+bool ofi_hmem_is_ipc_enabled(enum fi_hmem_iface iface)
+{
+	return hmem_ops[iface].is_ipc_enabled();
 }

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -1,6 +1,7 @@
 /*
  * (C) Copyright 2020 Hewlett Packard Enterprise Development LP
  * (C) Copyright 2020-2021 Intel Corporation. All rights reserved.
+ * (C) Copyright 2021 Amazon.com, Inc. or its affiliates.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -61,13 +62,13 @@ struct ofi_hmem_ops hmem_ops[] = {
 		.copy_to_hmem = cuda_copy_to_dev,
 		.copy_from_hmem = cuda_copy_from_dev,
 		.is_addr_valid = cuda_is_addr_valid,
-		.get_handle = ofi_hmem_no_get_handle,
-		.open_handle = ofi_hmem_no_open_handle,
-		.close_handle = ofi_hmem_no_close_handle,
+		.get_handle = cuda_get_handle,
+		.open_handle = cuda_open_handle,
+		.close_handle = cuda_close_handle,
 		.host_register = cuda_host_register,
 		.host_unregister = cuda_host_unregister,
 		.get_base_addr = ofi_hmem_no_base_addr,
-		.is_ipc_enabled = ofi_hmem_no_is_ipc_enabled,
+		.is_ipc_enabled = cuda_is_ipc_enabled,
 	},
 	[FI_HMEM_ROCR] = {
 		.initialized = false,

--- a/src/hmem_cuda.c
+++ b/src/hmem_cuda.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2021 Amazon.com, Inc. or its affiliates.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -43,8 +44,10 @@
 #include <cuda_runtime.h>
 
 struct cuda_ops {
-	cudaError_t (*cudaMemcpy)(void *dst, const void *src, size_t count,
+	cudaError_t (*cudaMemcpy)(void *dst, const void *src, size_t size,
 				  enum cudaMemcpyKind kind);
+	cudaError_t (*cudaFree)(void* ptr);
+	cudaError_t (*cudaMalloc)(void** ptr, size_t size);
 	const char *(*cudaGetErrorName)(cudaError_t error);
 	const char *(*cudaGetErrorString)(cudaError_t error);
 	CUresult (*cuPointerGetAttribute)(void *data,
@@ -54,9 +57,21 @@ struct cuda_ops {
 					unsigned int flags);
 	cudaError_t (*cudaHostUnregister)(void *ptr);
 	cudaError_t (*cudaGetDeviceCount)(int *count);
+	cudaError_t (*cudaGetDevice)(int *device);
+	cudaError_t (*cudaSetDevice)(int device);
+	cudaError_t (*cudaIpcOpenMemHandle)(void **devptr,
+					    cudaIpcMemHandle_t handle,
+					    unsigned int flags);
+	cudaError_t (*cudaIpcGetMemHandle)(cudaIpcMemHandle_t *handle,
+					   void *devptr);
+	cudaError_t (*cudaIpcCloseMemHandle)(void *devptr);
 };
 
-static int hmem_cuda_use_gdrcopy;
+static bool hmem_cuda_use_gdrcopy;
+static bool cuda_ipc_enabled;
+
+static cudaError_t cuda_disabled_cudaMemcpy(void *dst, const void *src,
+					    size_t size, enum cudaMemcpyKind kind);
 
 #ifdef ENABLE_CUDA_DLOPEN
 
@@ -70,20 +85,27 @@ static struct cuda_ops cuda_ops;
 
 static struct cuda_ops cuda_ops = {
 	.cudaMemcpy = cudaMemcpy,
+	.cudaFree = cudaFree,
+	.cudaMalloc = cudaMalloc,
 	.cudaGetErrorName = cudaGetErrorName,
 	.cudaGetErrorString = cudaGetErrorString,
 	.cuPointerGetAttribute = cuPointerGetAttribute,
 	.cudaHostRegister = cudaHostRegister,
 	.cudaHostUnregister = cudaHostUnregister,
 	.cudaGetDeviceCount = cudaGetDeviceCount,
+	.cudaGetDevice = cudaGetDevice,
+	.cudaSetDevice = cudaSetDevice,
+	.cudaIpcOpenMemHandle = cudaIpcOpenMemHandle,
+	.cudaIpcGetMemHandle = cudaIpcGetMemHandle,
+	.cudaIpcCloseMemHandle = cudaIpcCloseMemHandle
 };
 
 #endif /* ENABLE_CUDA_DLOPEN */
 
-cudaError_t ofi_cudaMemcpy(void *dst, const void *src, size_t count,
+cudaError_t ofi_cudaMemcpy(void *dst, const void *src, size_t size,
 			   enum cudaMemcpyKind kind)
 {
-	return cuda_ops.cudaMemcpy(dst, src, count, kind);
+	return cuda_ops.cudaMemcpy(dst, src, size, kind);
 }
 
 const char *ofi_cudaGetErrorName(cudaError_t error)
@@ -117,16 +139,16 @@ static cudaError_t ofi_cudaGetDeviceCount(int *count)
 	return cuda_ops.cudaGetDeviceCount(count);
 }
 
-int cuda_copy_to_dev(uint64_t device, void *dev, const void *host, size_t size)
+int cuda_copy_to_dev(uint64_t device, void *dst, const void *src, size_t size)
 {
 	if (hmem_cuda_use_gdrcopy) {
-		cuda_gdrcopy_to_dev(device, dev, host, size);
+		cuda_gdrcopy_to_dev(device, dst, src, size);
 		return FI_SUCCESS;
 	}
 
 	cudaError_t cuda_ret;
 
-	cuda_ret = ofi_cudaMemcpy(dev, host, size, cudaMemcpyHostToDevice);
+	cuda_ret = ofi_cudaMemcpy(dst, src, size, cudaMemcpyDefault);
 	if (cuda_ret == cudaSuccess)
 		return 0;
 
@@ -138,16 +160,16 @@ int cuda_copy_to_dev(uint64_t device, void *dev, const void *host, size_t size)
 	return -FI_EIO;
 }
 
-int cuda_copy_from_dev(uint64_t device, void *host, const void *dev, size_t size)
+int cuda_copy_from_dev(uint64_t device, void *dst, const void *src, size_t size)
 {
 	if (hmem_cuda_use_gdrcopy) {
-		cuda_gdrcopy_from_dev(device, host, dev, size);
+		cuda_gdrcopy_from_dev(device, dst, src, size);
 		return FI_SUCCESS;
 	}
 
 	cudaError_t cuda_ret;
 
-	cuda_ret = ofi_cudaMemcpy(host, dev, size, cudaMemcpyDeviceToHost);
+	cuda_ret = ofi_cudaMemcpy(dst, src, size, cudaMemcpyDefault);
 	if (cuda_ret == cudaSuccess)
 		return 0;
 
@@ -176,6 +198,70 @@ int cuda_dev_unregister(uint64_t handle)
 	return FI_SUCCESS;
 }
 
+int cuda_get_handle(void *dev_buf, void **handle)
+{
+	cudaError_t cuda_ret;
+
+	cuda_ret = cuda_ops.cudaIpcGetMemHandle((cudaIpcMemHandle_t *)handle,
+						dev_buf);
+
+	if (cuda_ret == cudaSuccess)
+		return FI_SUCCESS;
+
+	FI_WARN(&core_prov, FI_LOG_CORE,
+			"Failed to perform cudaIpcGetMemHandle: %s:%s\n",
+			ofi_cudaGetErrorName(cuda_ret),
+			ofi_cudaGetErrorString(cuda_ret));
+
+	return -FI_EINVAL;
+}
+
+int cuda_open_handle(void **handle, uint64_t device, void **ipc_ptr)
+{
+	cudaError_t cuda_ret;
+
+	cuda_ret = cuda_ops.cudaIpcOpenMemHandle(ipc_ptr,
+						 *(cudaIpcMemHandle_t *)handle,
+						 cudaIpcMemLazyEnablePeerAccess);
+
+	if (cuda_ret == cudaSuccess)
+		return FI_SUCCESS;
+
+	FI_WARN(&core_prov, FI_LOG_CORE,
+		"Failed to perform cudaIpcOpenMemHandle: %s:%s\n",
+		ofi_cudaGetErrorName(cuda_ret),
+		ofi_cudaGetErrorString(cuda_ret));
+
+	return -FI_EINVAL;
+}
+
+int cuda_close_handle(void *ipc_ptr)
+{
+	cudaError_t cuda_ret;
+
+	cuda_ret = cuda_ops.cudaIpcCloseMemHandle(ipc_ptr);
+
+	if (cuda_ret == cudaSuccess)
+		return FI_SUCCESS;
+
+	FI_WARN(&core_prov, FI_LOG_CORE,
+		"Failed to perform cudaIpcCloseMemHandle: %s:%s\n",
+		ofi_cudaGetErrorName(cuda_ret),
+		ofi_cudaGetErrorString(cuda_ret));
+
+	return -FI_EINVAL;
+}
+
+static cudaError_t cuda_disabled_cudaMemcpy(void *dst, const void *src,
+					    size_t size, enum cudaMemcpyKind kind)
+{
+	FI_WARN(&core_prov, FI_LOG_CORE,
+		"cudaMemcpy was called but FI_HMEM_CUDA_ENABLE_XFER = 0, "
+		"no copy will occur to prevent deadlock.");
+
+	return cudaErrorInvalidValue;
+}
+
 static int cuda_hmem_dl_init(void)
 {
 #ifdef ENABLE_CUDA_DLOPEN
@@ -199,6 +285,18 @@ static int cuda_hmem_dl_init(void)
 	cuda_ops.cudaMemcpy = dlsym(cudart_handle, "cudaMemcpy");
 	if (!cuda_ops.cudaMemcpy) {
 		FI_WARN(&core_prov, FI_LOG_CORE, "Failed to find cudaMemcpy\n");
+		goto err_dlclose_cuda;
+	}
+
+	cuda_ops.cudaFree = dlsym(cudart_handle, "cudaFree");
+	if (!cuda_ops.cudaFree) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "Failed to find cudaFree\n");
+		goto err_dlclose_cuda;
+	}
+
+	cuda_ops.cudaMalloc = dlsym(cudart_handle, "cudaMalloc");
+	if (!cuda_ops.cudaMalloc) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "Failed to find cudaMalloc\n");
 		goto err_dlclose_cuda;
 	}
 
@@ -245,6 +343,46 @@ static int cuda_hmem_dl_init(void)
 	if (!cuda_ops.cudaGetDeviceCount) {
 		FI_WARN(&core_prov, FI_LOG_CORE,
 			"Failed to find cudaGetDeviceCount\n");
+		goto err_dlclose_cuda;
+	}
+
+	cuda_ops.cudaGetDevice = dlsym(cudart_handle,
+					    "cudaGetDevice");
+	if (!cuda_ops.cudaGetDevice) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"Failed to find cudaGetDevice\n");
+		goto err_dlclose_cuda;
+	}
+
+	cuda_ops.cudaSetDevice = dlsym(cudart_handle,
+					    "cudaSetDevice");
+	if (!cuda_ops.cudaSetDevice) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"Failed to find cudaSetDevice\n");
+		goto err_dlclose_cuda;
+	}
+
+	cuda_ops.cudaIpcOpenMemHandle = dlsym(cudart_handle,
+					    "cudaIpcOpenMemHandle");
+	if (!cuda_ops.cudaIpcOpenMemHandle) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"Failed to find cudaIpcOpenMemHandle\n");
+		goto err_dlclose_cuda;
+	}
+
+	cuda_ops.cudaIpcGetMemHandle = dlsym(cudart_handle,
+					    "cudaIpcGetMemHandle");
+	if (!cuda_ops.cudaIpcGetMemHandle) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"Failed to find cudaIpcGetMemHandle\n");
+		goto err_dlclose_cuda;
+	}
+
+	cuda_ops.cudaIpcCloseMemHandle = dlsym(cudart_handle,
+					    "cudaIpcCloseMemHandle");
+	if (!cuda_ops.cudaIpcCloseMemHandle) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"Failed to find cudaIpcCloseMemHandle\n");
 		goto err_dlclose_cuda;
 	}
 
@@ -301,6 +439,21 @@ int cuda_hmem_init(void)
 {
 	int ret;
 	int gdrcopy_ret;
+	bool cuda_enable_xfer;
+	int devices, dev_id, orig_dev_id;
+	void *ptr;
+	cudaIpcMemHandle_t handle;
+	cudaError_t err;
+
+	fi_param_define(NULL, "hmem_cuda_use_gdrcopy", FI_PARAM_BOOL,
+			"Use gdrcopy to copy data to/from CUDA GPU memory. "
+			"If libfabric is not compiled with gdrcopy support, "
+			"this variable is not checked. (default: true)");
+	fi_param_define(NULL, "hmem_cuda_enable_xfer", FI_PARAM_BOOL,
+			"Enable use of CUDA APIs for copying data to/from CUDA "
+			"GPU memory. This should be disabled if CUDA "
+			"operations on the default stream would result in a "
+			"deadlock in the application. (default: true)");
 
 	ret = cuda_hmem_dl_init();
 	if (ret != FI_SUCCESS)
@@ -310,18 +463,82 @@ int cuda_hmem_init(void)
 	if (ret != FI_SUCCESS)
 		goto dl_cleanup;
 
-	gdrcopy_ret = cuda_gdrcopy_hmem_init();
-	if (gdrcopy_ret == FI_SUCCESS) {
-		hmem_cuda_use_gdrcopy = 1;
-		fi_param_define(NULL, "hmem_cuda_use_gdrcopy", FI_PARAM_BOOL,
-				"Use gdrcopy to copy data to/from GPU memory");
-		fi_param_get_bool(NULL, "hmem_cuda_use_gdrcopy",
-				  &hmem_cuda_use_gdrcopy);
-	} else {
-		hmem_cuda_use_gdrcopy = 0;
-		if (gdrcopy_ret != -FI_ENOSYS)
-			FI_WARN(&core_prov, FI_LOG_CORE,
-				"gdrcopy initialization failed! gdrcopy will not be used.\n");
+	fi_param_get_bool(NULL, "hmem_cuda_use_gdrcopy",
+			  &ret);
+	hmem_cuda_use_gdrcopy = (ret != 0);
+	if (hmem_cuda_use_gdrcopy) {
+		gdrcopy_ret = cuda_gdrcopy_hmem_init();
+		if (gdrcopy_ret != FI_SUCCESS) {
+			hmem_cuda_use_gdrcopy = false;
+			if (gdrcopy_ret != -FI_ENOSYS)
+				FI_WARN(&core_prov, FI_LOG_CORE,
+					"gdrcopy initialization failed! "
+					"gdrcopy will not be used.\n");
+		}
+	}
+
+	ret = 1;
+	fi_param_get_bool(NULL, "hmem_cuda_enable_xfer", &ret);
+	cuda_enable_xfer = (ret != 0);
+
+	if (!cuda_enable_xfer)
+		cuda_ops.cudaMemcpy = cuda_disabled_cudaMemcpy;
+
+	/*
+	 * CUDA IPC is only enabled if gdrcopy is not in use and
+	 * cudaMemcpy can be used.
+	 */
+	cuda_ipc_enabled = !hmem_cuda_use_gdrcopy && cuda_enable_xfer;
+
+	ret = FI_SUCCESS;
+
+	/*
+	 * If IPC may be enabled, loop over each device and ensure it
+	 * supports IPC. If any device lacks IPC support, set
+	 * cuda_ipc_enabled to false.
+	 */
+	if (cuda_ipc_enabled) {
+		cuda_ops.cudaGetDevice(&orig_dev_id);
+		cuda_ops.cudaGetDeviceCount(&devices);
+		for (dev_id = 0; dev_id < devices; ++dev_id) {
+
+			cuda_ops.cudaSetDevice(dev_id);
+
+			/* CUDA runtime and driver APIs do not expose IPC support
+			 * directly in the device properties, so try using IPC and
+			 * see if it errors out. Checking if unified memory is
+			 * supported is not sufficient as Tegra devices support
+			 * unified memory, but not IPC.
+			 */
+
+			err = cuda_ops.cudaMalloc(&ptr, 1);
+			if (err != cudaSuccess) {
+				FI_INFO(&core_prov, FI_LOG_CORE,
+					"Could not allocate memory on CUDA device %d\n",
+					dev_id);
+				cuda_ipc_enabled = false;
+				ret = -FI_EINVAL;
+				break;
+			}
+
+			err = cuda_ops.cudaIpcGetMemHandle(&handle, ptr);
+			cuda_ops.cudaFree(&ptr);
+
+			if (err != cudaSuccess) {
+				FI_INFO(&core_prov, FI_LOG_CORE,
+					"Could not get IPC handle on CUDA device %d,"
+					"disabling CUDA IPC\n",
+					dev_id);
+				cuda_ipc_enabled = false;
+				ret = -FI_EINVAL;
+				break;
+			}
+		}
+
+		cuda_ops.cudaSetDevice(orig_dev_id);
+
+		if (ret != FI_SUCCESS)
+			goto dl_cleanup;
 	}
 
 	return ret;
@@ -418,6 +635,11 @@ int cuda_host_unregister(void *ptr)
 	return -FI_EIO;
 }
 
+bool cuda_is_ipc_enabled(void)
+{
+	return cuda_ipc_enabled;
+}
+
 #else
 
 int cuda_copy_to_dev(uint64_t device, void *dev, const void *host, size_t size)
@@ -463,6 +685,26 @@ int cuda_dev_register(struct fi_mr_attr *mr_attr, uint64_t *handle)
 int cuda_dev_unregister(uint64_t handle)
 {
 	return FI_SUCCESS;
+}
+
+int cuda_get_handle(void *dev_buf, void **handle)
+{
+	return -FI_ENOSYS;
+}
+
+int cuda_open_handle(void **handle, uint64_t device, void **ipc_ptr)
+{
+	return -FI_ENOSYS;
+}
+
+int cuda_close_handle(void *ipc_ptr)
+{
+	return -FI_ENOSYS;
+}
+
+bool cuda_is_ipc_enabled(void)
+{
+	return false;
 }
 
 #endif /* HAVE_LIBCUDA */


### PR DESCRIPTION
This PR:
 - Adds a new function to the HMEM interface - `is_ipc_enabled`
 - introduces an HMEM IPC protocol into the shm provider based on the `get/open/close_handle` and `is_ipc_enabled` functions in the hmem interface. This uses the existing `smr_progress_ipc` function used by Ze, but as it is not based on dma-buf there is a new `smr_format_ipc` function added.
 - Implements the necessary functions for IPC in the CUDA HMEM interface

The cuda `get/open_handle` functions have a very high overhead, about 750us total, so IPC handle caching would be a very useful addition in the future.