### PR TITLE
prov/util: Remove cleanup assertion for import monitor

### DIFF
--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -614,7 +614,6 @@ static void ofi_import_monitor_init(struct ofi_mem_monitor *monitor)
 
 static void ofi_import_monitor_cleanup(struct ofi_mem_monitor *monitor)
 {
-	assert(!impmon.impfid);
 	ofi_monitor_cleanup(monitor);
 }
 


### PR DESCRIPTION
Since cleanup is not a function the user has access to, there's no
guarantee which order cleanup and close will occur. Thus remove the
assertion assuming the impfid is already set to null during cleanup.

Signed-off-by: William Zhang <wilzhang@amazon.com>