### PR TITLE
[v1.13.x] prov/efa: fix rnr deadlock

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -184,6 +184,8 @@ static inline void rxr_poison_mem_region(uint32_t *ptr, size_t size)
  */
 #define RXR_LONGCTS_PROTOCOL BIT_ULL(8)
 
+#define RXR_TX_ENTRY_QUEUED_RNR BIT_ULL(9)
+
 /*
  * OFI flags
  * The 64-bit flag field is used as follows:
@@ -277,8 +279,6 @@ enum rxr_tx_comm_type {
 	RXR_TX_SEND,		/* tx_entry sending data in progress */
 	RXR_TX_QUEUED_SHM_RMA,	/* tx_entry was unable to send RMA operations over shm provider */
 	RXR_TX_QUEUED_CTRL,	/* tx_entry was unable to send ctrl packet */
-	RXR_TX_QUEUED_REQ_RNR,  /* tx_entry RNR sending REQ packet */
-	RXR_TX_QUEUED_DATA_RNR,	/* tx_entry RNR sending data packets */
 };
 
 enum rxr_rx_comm_type {
@@ -515,8 +515,11 @@ struct rxr_tx_entry {
 	/* entry is linked with tx_pending_list in rxr_ep */
 	struct dlist_entry entry;
 
-	/* queued_entry is linked with tx_queued_ctrl_list in rxr_ep */
-	struct dlist_entry queued_entry;
+	/* queued_ctrl_entry is linked with tx_queued_ctrl_list in rxr_ep */
+	struct dlist_entry queued_ctrl_entry;
+
+	/* queued_rnr_entry is linked with tx_queued_rnr_list in rxr_ep */
+	struct dlist_entry queued_rnr_entry;
 
 	/* Queued packets due to TX queue full or RNR backoff */
 	struct dlist_entry queued_pkts;
@@ -676,8 +679,10 @@ struct rxr_ep {
 	struct dlist_entry rx_posted_buf_list;
 	/* list of pre-posted recv buffers for shm */
 	struct dlist_entry rx_posted_buf_shm_list;
-	/* tx entries with queued messages */
-	struct dlist_entry tx_entry_queued_list;
+	/* tx entries with queued ctrl packets */
+	struct dlist_entry tx_entry_queued_ctrl_list;
+	/* tx entries with queued rnr packets */
+	struct dlist_entry tx_entry_queued_rnr_list;
 	/* rx entries with queued messages */
 	struct dlist_entry rx_entry_queued_list;
 	/* tx_entries with data to be sent (large messages) */

--- a/prov/efa/src/rxr/rxr_cq.c
+++ b/prov/efa/src/rxr/rxr_cq.c
@@ -213,15 +213,16 @@ void rxr_cq_write_tx_error(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
 		break;
 	case RXR_TX_QUEUED_CTRL:
 	case RXR_TX_QUEUED_SHM_RMA:
-	case RXR_TX_QUEUED_REQ_RNR:
-	case RXR_TX_QUEUED_DATA_RNR:
-		dlist_remove(&tx_entry->queued_entry);
+		dlist_remove(&tx_entry->queued_ctrl_entry);
 		break;
 	default:
 		FI_WARN(&rxr_prov, FI_LOG_CQ, "tx_entry unknown state %d\n",
 			tx_entry->state);
 		assert(0 && "tx_entry unknown state");
 	}
+
+	if (tx_entry->rxr_flags & RXR_TX_ENTRY_QUEUED_RNR)
+		dlist_remove(&tx_entry->queued_rnr_entry);
 
 	dlist_foreach_container_safe(&tx_entry->queued_pkts,
 				     struct rxr_pkt_entry,

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -471,6 +471,12 @@ void rxr_release_tx_entry(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry)
 		rxr_pkt_entry_release_tx(ep, pkt_entry);
 	}
 
+	if (tx_entry->rxr_flags & RXR_TX_ENTRY_QUEUED_RNR)
+		dlist_remove(&tx_entry->queued_rnr_entry);
+
+	if (tx_entry->state == RXR_TX_QUEUED_CTRL)
+		dlist_remove(&tx_entry->queued_ctrl_entry);
+
 #ifdef ENABLE_EFA_POISONING
 	rxr_poison_mem_region((uint32_t *)tx_entry,
 			      sizeof(struct rxr_tx_entry));
@@ -634,11 +640,20 @@ static void rxr_ep_free_res(struct rxr_ep *rxr_ep)
 		rxr_release_rx_entry(rxr_ep, rx_entry);
 	}
 
-	dlist_foreach_safe(&rxr_ep->tx_entry_queued_list, entry, tmp) {
+	dlist_foreach_safe(&rxr_ep->tx_entry_queued_rnr_list, entry, tmp) {
 		tx_entry = container_of(entry, struct rxr_tx_entry,
-					queued_entry);
+					queued_rnr_entry);
 		FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,
-			"Closing ep with queued tx_entry: %p\n",
+			"Closing ep with queued rnr tx_entry: %p\n",
+			tx_entry);
+		rxr_release_tx_entry(rxr_ep, tx_entry);
+	}
+
+	dlist_foreach_safe(&rxr_ep->tx_entry_queued_ctrl_list, entry, tmp) {
+		tx_entry = container_of(entry, struct rxr_tx_entry,
+					queued_ctrl_entry);
+		FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,
+			"Closing ep with queued ctrl tx_entry: %p\n",
 			tx_entry);
 		rxr_release_tx_entry(rxr_ep, tx_entry);
 	}
@@ -1270,7 +1285,8 @@ int rxr_ep_init(struct rxr_ep *ep)
 	dlist_init(&ep->rx_unexp_tagged_list);
 	dlist_init(&ep->rx_posted_buf_list);
 	dlist_init(&ep->rx_entry_queued_list);
-	dlist_init(&ep->tx_entry_queued_list);
+	dlist_init(&ep->tx_entry_queued_rnr_list);
+	dlist_init(&ep->tx_entry_queued_ctrl_list);
 	dlist_init(&ep->tx_pending_list);
 	dlist_init(&ep->read_pending_list);
 	dlist_init(&ep->peer_backoff_list);
@@ -1884,52 +1900,54 @@ void rxr_ep_progress_internal(struct rxr_ep *ep)
 		rx_entry->state = RXR_RX_RECV;
 	}
 
-	dlist_foreach_container_safe(&ep->tx_entry_queued_list,
+	dlist_foreach_container_safe(&ep->tx_entry_queued_rnr_list,
 				     struct rxr_tx_entry,
-				     tx_entry, queued_entry, tmp) {
+				     tx_entry, queued_rnr_entry, tmp) {
 		peer = rxr_ep_get_peer(ep, tx_entry->addr);
 		assert(peer);
 
 		if (peer->flags & RXR_PEER_IN_BACKOFF)
 			continue;
 
-		/*
-		 * It is possible to receive an RNR after we queue this
-		 * tx_entry if we run out of resources in the medium message
-		 * protocol. Ensure all queued packets are posted before
-		 * continuing to post additional control messages.
-		 */
+		assert(tx_entry->rxr_flags & RXR_TX_ENTRY_QUEUED_RNR);
 		ret = rxr_ep_send_queued_pkts(ep, &tx_entry->queued_pkts);
 		if (ret == -FI_EAGAIN)
 			break;
+
 		if (OFI_UNLIKELY(ret)) {
 			rxr_cq_write_tx_error(ep, tx_entry, -ret, -ret);
 			return;
 		}
 
-		if (tx_entry->state == RXR_TX_QUEUED_CTRL) {
-			ret = rxr_pkt_post_ctrl(ep, RXR_TX_ENTRY, tx_entry,
-						tx_entry->queued_ctrl.type,
-						tx_entry->queued_ctrl.inject);
-			if (ret == -FI_EAGAIN)
-				break;
+		dlist_remove(&tx_entry->queued_rnr_entry);
+		tx_entry->rxr_flags &= ~RXR_TX_ENTRY_QUEUED_RNR;
+	}
 
-			if (OFI_UNLIKELY(ret)) {
-				rxr_cq_write_tx_error(ep, tx_entry, -ret, -ret);
-				return;
-			}
+	dlist_foreach_container_safe(&ep->tx_entry_queued_ctrl_list,
+				     struct rxr_tx_entry,
+				     tx_entry, queued_ctrl_entry, tmp) {
+		peer = rxr_ep_get_peer(ep, tx_entry->addr);
+		assert(peer);
+
+		if (peer->flags & RXR_PEER_IN_BACKOFF)
+			continue;
+
+		assert(tx_entry->state == RXR_TX_QUEUED_CTRL);
+
+		ret = rxr_pkt_post_ctrl(ep, RXR_TX_ENTRY, tx_entry,
+					tx_entry->queued_ctrl.type,
+					tx_entry->queued_ctrl.inject);
+		if (ret == -FI_EAGAIN)
+			break;
+
+		if (OFI_UNLIKELY(ret)) {
+			rxr_cq_write_tx_error(ep, tx_entry, -ret, -ret);
+			return;
 		}
 
-		dlist_remove(&tx_entry->queued_entry);
-
-		if (tx_entry->state == RXR_TX_QUEUED_REQ_RNR ||
-		    tx_entry->state == RXR_TX_QUEUED_CTRL) {
+		dlist_remove(&tx_entry->queued_ctrl_entry);
+		if (tx_entry->state == RXR_TX_QUEUED_CTRL)
 			tx_entry->state = RXR_TX_REQ;
-		} else if (tx_entry->state == RXR_TX_QUEUED_DATA_RNR) {
-			tx_entry->state = RXR_TX_SEND;
-			dlist_insert_tail(&tx_entry->entry,
-					  &ep->tx_pending_list);
-		}
 	}
 
 	/*

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -394,13 +394,12 @@ ssize_t rxr_pkt_post_ctrl_or_queue(struct rxr_ep *ep, int entry_type, void *x_en
 	if (err == -FI_EAGAIN) {
 		if (entry_type == RXR_TX_ENTRY) {
 			tx_entry = (struct rxr_tx_entry *)x_entry;
-			assert(tx_entry->state != RXR_TX_QUEUED_CTRL ||
-			       tx_entry->state != RXR_TX_QUEUED_REQ_RNR);
+			assert(!(tx_entry->rxr_flags & RXR_TX_ENTRY_QUEUED_RNR));
 			tx_entry->state = RXR_TX_QUEUED_CTRL;
 			tx_entry->queued_ctrl.type = ctrl_type;
 			tx_entry->queued_ctrl.inject = inject;
-			dlist_insert_tail(&tx_entry->queued_entry,
-					  &ep->tx_entry_queued_list);
+			dlist_insert_tail(&tx_entry->queued_ctrl_entry,
+					  &ep->tx_entry_queued_ctrl_list);
 		} else {
 			assert(entry_type == RXR_RX_ENTRY);
 			rx_entry = (struct rxr_rx_entry *)x_entry;
@@ -524,6 +523,7 @@ ssize_t rxr_pkt_trigger_handshake(struct rxr_ep *ep,
 	tx_entry->iov_mr_start = 0;
 	tx_entry->iov_offset = 0;
 	tx_entry->fi_flags = RXR_NO_COMPLETION | RXR_NO_COUNTER;
+	tx_entry->rxr_flags = 0;
 
 	dlist_insert_tail(&tx_entry->ep_entry, &ep->tx_entry_list);
 
@@ -765,15 +765,10 @@ void rxr_pkt_handle_send_error(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entr
 			 * application want EFA to manager resource.
 			 */
 			rxr_cq_queue_rnr_pkt(ep, &tx_entry->queued_pkts, pkt_entry);
-			if (tx_entry->state == RXR_TX_SEND) {
-				dlist_remove(&tx_entry->entry);
-				tx_entry->state = RXR_TX_QUEUED_DATA_RNR;
-				dlist_insert_tail(&tx_entry->queued_entry,
-						  &ep->tx_entry_queued_list);
-			} else if (tx_entry->state == RXR_TX_REQ) {
-				tx_entry->state = RXR_TX_QUEUED_REQ_RNR;
-				dlist_insert_tail(&tx_entry->queued_entry,
-						  &ep->tx_entry_queued_list);
+			if (!(tx_entry->rxr_flags & RXR_TX_ENTRY_QUEUED_RNR)) {
+				tx_entry->rxr_flags |= RXR_TX_ENTRY_QUEUED_RNR;
+				dlist_insert_tail(&tx_entry->queued_rnr_entry,
+						  &ep->tx_entry_queued_rnr_list);
 			}
 		} else {
 			rxr_cq_write_tx_error(ep, pkt_entry->x_entry, err, prov_errno);

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -407,8 +407,8 @@ ssize_t rxr_pkt_post_ctrl_or_queue(struct rxr_ep *ep, int entry_type, void *x_en
 			rx_entry->state = RXR_RX_QUEUED_CTRL;
 			rx_entry->queued_ctrl.type = ctrl_type;
 			rx_entry->queued_ctrl.inject = inject;
-			dlist_insert_tail(&rx_entry->queued_entry,
-					  &ep->rx_entry_queued_list);
+			dlist_insert_tail(&rx_entry->queued_ctrl_entry,
+					  &ep->rx_entry_queued_ctrl_list);
 		}
 
 		err = 0;
@@ -792,13 +792,13 @@ void rxr_pkt_handle_send_error(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entr
 			/*
 			 * rx_entry send one ctrl packet at a time, so if we
 			 * received RNR for the packet, the rx_entry must not
-			 * be in ep's rx_queued_entry_list, thus cannot
-			 * be in QUEUED_CTRL state
+			 * be in ep's rx_queued_entry_rnr_list, thus cannot
+			 * have the QUEUED_RNR flag
 			 */
-			assert(rx_entry->state != RXR_RX_QUEUED_CTRL);
-			rx_entry->state = RXR_RX_QUEUED_CTRL;
-			dlist_insert_tail(&rx_entry->queued_entry,
-					  &ep->rx_entry_queued_list);
+			assert(!(rx_entry->rxr_flags & RXR_RX_ENTRY_QUEUED_RNR));
+			rx_entry->rxr_flags |= RXR_RX_ENTRY_QUEUED_RNR;
+			dlist_insert_tail(&rx_entry->queued_rnr_entry,
+					  &ep->rx_entry_queued_rnr_list);
 
 		} else {
 			rxr_cq_write_rx_error(ep, pkt_entry->x_entry, err, prov_errno);


### PR DESCRIPTION
This PR backports the commits in https://github.com/ofiwg/libfabric/pull/6992/commits to v1.13.x branch