### PR TITLE
gh-pages: Fix indentation of man page index for v1.10.0 to v1.13.1

### DIFF
--- a/v1.10.0/man/index.md
+++ b/v1.10.0/man/index.md
@@ -63,4 +63,4 @@ v1.10.0](https://github.com/ofiwg/libfabric/releases/tag/v1.10.0).
   * [fi_strerror(1)](fi_strerror.1.html)
 
 * Fabtests
- * [fabtests(7)](fabtests.7.html)
+  * [fabtests(7)](fabtests.7.html)

--- a/v1.10.1/man/index.md
+++ b/v1.10.1/man/index.md
@@ -63,4 +63,4 @@ v1.10.1](https://github.com/ofiwg/libfabric/releases/tag/v1.10.1).
   * [fi_strerror(1)](fi_strerror.1.html)
 
 * Fabtests
- * [fabtests(7)](fabtests.7.html)
+  * [fabtests(7)](fabtests.7.html)

--- a/v1.11.0/man/index.md
+++ b/v1.11.0/man/index.md
@@ -63,4 +63,4 @@ v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0).
   * [fi_strerror(1)](fi_strerror.1.html)
 
 * Fabtests
- * [fabtests(7)](fabtests.7.html)
+  * [fabtests(7)](fabtests.7.html)

--- a/v1.11.1/man/index.md
+++ b/v1.11.1/man/index.md
@@ -63,4 +63,4 @@ v1.11.1](https://github.com/ofiwg/libfabric/releases/tag/v1.11.1).
   * [fi_strerror(1)](fi_strerror.1.html)
 
 * Fabtests
- * [fabtests(7)](fabtests.7.html)
+  * [fabtests(7)](fabtests.7.html)

--- a/v1.11.2/man/index.md
+++ b/v1.11.2/man/index.md
@@ -63,4 +63,4 @@ v1.11.2](https://github.com/ofiwg/libfabric/releases/tag/v1.11.2).
   * [fi_strerror(1)](fi_strerror.1.html)
 
 * Fabtests
- * [fabtests(7)](fabtests.7.html)
+  * [fabtests(7)](fabtests.7.html)

--- a/v1.12.0/man/index.md
+++ b/v1.12.0/man/index.md
@@ -64,4 +64,4 @@ v1.12.0](https://github.com/ofiwg/libfabric/releases/tag/v1.12.0).
   * [fi_strerror(1)](fi_strerror.1.html)
 
 * Fabtests
- * [fabtests(7)](fabtests.7.html)
+  * [fabtests(7)](fabtests.7.html)

--- a/v1.12.1/man/index.md
+++ b/v1.12.1/man/index.md
@@ -64,4 +64,4 @@ v1.12.1](https://github.com/ofiwg/libfabric/releases/tag/v1.12.1).
   * [fi_strerror(1)](fi_strerror.1.html)
 
 * Fabtests
- * [fabtests(7)](fabtests.7.html)
+  * [fabtests(7)](fabtests.7.html)

--- a/v1.13.0/man/index.md
+++ b/v1.13.0/man/index.md
@@ -65,4 +65,4 @@ v1.13.0](https://github.com/ofiwg/libfabric/releases/tag/v1.13.0).
   * [fi_strerror(1)](fi_strerror.1.html)
 
 * Fabtests
- * [fabtests(7)](fabtests.7.html)
+  * [fabtests(7)](fabtests.7.html)

--- a/v1.13.1/man/index.md
+++ b/v1.13.1/man/index.md
@@ -65,4 +65,4 @@ v1.13.1](https://github.com/ofiwg/libfabric/releases/tag/v1.13.1).
   * [fi_strerror(1)](fi_strerror.1.html)
 
 * Fabtests
- * [fabtests(7)](fabtests.7.html)
+  * [fabtests(7)](fabtests.7.html)


### PR DESCRIPTION
The entry for fabtests man page was placed at the same level as the category.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>