### PR TITLE
prov/efa: move protocol v4 definition to a separate header file

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -69,7 +69,8 @@ _efa_headers = \
 	prov/efa/src/rxr/rxr_pkt_type_req.h \
 	prov/efa/src/rxr/rxr_pkt_cmd.h \
 	prov/efa/src/rxr/rxr_read.h \
-	prov/efa/src/rxr/rxr_atomic.h
+	prov/efa/src/rxr/rxr_atomic.h \
+	prov/efa/src/rxr/rdm_proto_v4.h
 
 efa_CPPFLAGS += \
 	-I$(top_srcdir)/prov/efa/src/ \

--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -120,18 +120,6 @@ struct efa_fabric {
 	struct util_fabric	util_fabric;
 };
 
-#define EFA_GID_LEN	16
-
-struct efa_ep_addr {
-	uint8_t			raw[EFA_GID_LEN];
-	uint16_t		qpn;
-	uint16_t		pad;
-	uint32_t		qkey;
-	struct efa_ep_addr	*next;
-};
-
-#define EFA_EP_ADDR_LEN sizeof(struct efa_ep_addr)
-
 struct efa_ah {
 	uint8_t		gid[EFA_GID_LEN]; /* efa device GID */
 	struct ibv_ah	*ibv_ah; /* created by ibv_create_ah() using GID */
@@ -610,17 +598,5 @@ static inline bool efa_is_cache_available(struct efa_domain *efa_domain)
 {
 	return efa_domain->cache;
 }
-
-#define RXR_REQ_OPT_HDR_ALIGNMENT 8
-#define RXR_REQ_OPT_RAW_ADDR_HDR_SIZE (((sizeof(struct rxr_req_opt_raw_addr_hdr) + EFA_EP_ADDR_LEN - 1)/RXR_REQ_OPT_HDR_ALIGNMENT + 1) * RXR_REQ_OPT_HDR_ALIGNMENT)
-
-/*
- * Per libfabric standard, the prefix must be a multiple of 8, hence the static assert
- */
-#define RXR_MSG_PREFIX_SIZE (sizeof(struct rxr_pkt_entry) + sizeof(struct rxr_eager_msgrtm_hdr) + RXR_REQ_OPT_RAW_ADDR_HDR_SIZE)
-
-#if defined(static_assert) && defined(__x86_64__)
-static_assert(RXR_MSG_PREFIX_SIZE % 8 == 0, "message prefix size alignment check");
-#endif
 
 #endif /* EFA_H */

--- a/prov/efa/src/rxr/rdm_proto_v4.h
+++ b/prov/efa/src/rxr/rdm_proto_v4.h
@@ -1,0 +1,664 @@
+/*
+ * Copyright (c) 2021 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _RXR_PROTO_V4_H
+#define _RXR_PROTO_V4_H
+
+/*
+ * This header file contains constants, flags and data structures
+ * that are defined in EFA RDM protocol v4. Any change to this
+ * header file can potentially break backward compatibility, thus
+ * need to be reviewed with extra care.
+ *
+ * The section number in this file refers to the sections
+ * in EFA RDM protocol version 4.
+ */
+
+#define RXR_PROTOCOL_VERSION	(4)
+
+/* raw address format. (section 1.4) */
+#define EFA_GID_LEN	16
+
+struct efa_ep_addr {
+	uint8_t			raw[EFA_GID_LEN];
+	uint16_t		qpn;
+	uint16_t		pad;
+	uint32_t		qkey;
+	struct efa_ep_addr	*next;
+};
+
+#define EFA_EP_ADDR_LEN sizeof(struct efa_ep_addr)
+
+/*
+ * Extra Feature/Request Flags (section 2.1)
+ */
+#define RXR_EXTRA_FEATURE_RDMA_READ			BIT_ULL(0)
+#define RXR_EXTRA_FEATURE_DELIVERY_COMPLETE 		BIT_ULL(1)
+#define RXR_EXTRA_REQUEST_CONSTANT_HEADER_LENGTH	BIT_ULL(2)
+#define RXR_NUM_EXTRA_FEATURE_OR_REQUEST		3
+#define RXR_MAX_NUM_EXINFO	(256)
+
+/*
+ * Packet type ID of each packet type (section 1.3)
+ *
+ * Changing packet type ID would break backward compatiblity thus is strictly
+ * prohibited.
+ *
+ * New packet types can be added with introduction of an extra feature
+ * (section 2.1)
+ */
+#define RXR_RETIRED_RTS_PKT		1
+#define RXR_RETIRED_CONNACK_PKT		2
+#define RXR_CTS_PKT			3
+#define RXR_DATA_PKT			4
+#define RXR_READRSP_PKT			5
+#define RXR_RMA_CONTEXT_PKT		6
+#define RXR_EOR_PKT			7
+#define RXR_ATOMRSP_PKT 	        8
+#define RXR_HANDSHAKE_PKT		9
+#define RXR_RECEIPT_PKT 		10
+
+#define RXR_REQ_PKT_BEGIN		64
+#define RXR_BASELINE_REQ_PKT_BEGIN	64
+#define RXR_EAGER_MSGRTM_PKT		64
+#define RXR_EAGER_TAGRTM_PKT		65
+#define RXR_MEDIUM_MSGRTM_PKT		66
+#define RXR_MEDIUM_TAGRTM_PKT		67
+#define RXR_LONGCTS_MSGRTM_PKT		68
+#define RXR_LONGCTS_TAGRTM_PKT		69
+#define RXR_EAGER_RTW_PKT		70
+#define RXR_LONGCTS_RTW_PKT		71
+#define RXR_SHORT_RTR_PKT		72
+#define RXR_LONGCTS_RTR_PKT		73
+#define RXR_WRITE_RTA_PKT		74
+#define RXR_FETCH_RTA_PKT		75
+#define RXR_COMPARE_RTA_PKT		76
+#define RXR_BASELINE_REQ_PKT_END	77
+
+#define RXR_EXTRA_REQ_PKT_BEGIN		128
+#define RXR_LONGREAD_MSGRTM_PKT		128
+#define RXR_LONGREAD_TAGRTM_PKT		129
+#define RXR_LONGREAD_RTW_PKT		130
+#define RXR_READ_RTR_PKT		131
+
+#define RXR_DC_REQ_PKT_BEGIN		132
+#define RXR_DC_EAGER_MSGRTM_PKT 	133
+#define RXR_DC_EAGER_TAGRTM_PKT 	134
+#define RXR_DC_MEDIUM_MSGRTM_PKT 	135
+#define RXR_DC_MEDIUM_TAGRTM_PKT 	136
+#define RXR_DC_LONGCTS_MSGRTM_PKT  	137
+#define RXR_DC_LONGCTS_TAGRTM_PKT  	138
+#define RXR_DC_EAGER_RTW_PKT    	139
+#define RXR_DC_LONGCTS_RTW_PKT     	140
+#define RXR_DC_WRITE_RTA_PKT    	141
+#define RXR_DC_REQ_PKT_END		142
+#define RXR_EXTRA_REQ_PKT_END   	142
+
+/*
+ *  Packet fields common to all rxr packets. The other packet headers below must
+ *  be changed if this is updated.
+ */
+struct rxr_base_hdr {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+};
+
+#if defined(static_assert) && defined(__x86_64__)
+static_assert(sizeof(struct rxr_base_hdr) == 4, "rxr_base_hdr check");
+#endif
+
+struct efa_rma_iov {
+	uint64_t		addr;
+	size_t			len;
+	uint64_t		key;
+};
+
+/*
+ * @breif header format of CTS packet (Packet Type ID 3)
+ *
+ * CTS is used in long-CTS sub-protocols for flow control.
+ *
+ * It is sent from receiver to sender, and contains number of bytes
+ * receiver is ready to receive.
+ *
+ * long-CTS is used not only by two-sided communication but also
+ * by emulated write and emulated read protocols.
+ *
+ * In emulated write, requester is sender, and responder is receiver.
+ *
+ * In emulated read, requester is receiver, and responder is sender.
+ */
+struct rxr_cts_hdr {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+	/* end of rxr_base_hdr */
+	uint8_t pad[4];
+	uint32_t send_id; /* ID of the send opertaion on sender side */
+	uint32_t recv_id; /* ID of the receive operatin on receive side */
+	uint64_t recv_length; /* number of bytes receiver is ready to receive */
+};
+
+#if defined(static_assert) && defined(__x86_64__)
+static_assert(sizeof(struct rxr_cts_hdr) == 24, "rxr_cts_hdr check");
+#endif
+
+/* this flag is to indicated the CTS is the response of a RTR packet */
+#define RXR_CTS_READ_REQ		BIT_ULL(7)
+
+/*
+ * @brief header format of DATA packet header (Packet Type ID 4)
+ *
+ * DATA is used in long-CTS sub-protocols.
+ *
+ * It is sent from sender to receiver, and contains a segment
+ * of application data.
+ *
+ * long-CTS is used not only by two-sided communication but also
+ * by emulated write and emulated read protocols.
+ *
+ * In emulated write, requester is sender, and responder is receiver.
+ *
+ * In emulated read, requester is receiver, and responder is sender.
+ */
+struct rxr_data_hdr {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+	/* end of rxr_base_hdr */
+	uint32_t recv_id; /* ID of the receive operation on receiver */
+	uint64_t seg_length;
+	uint64_t seg_offset;
+};
+
+struct rxr_data_pkt {
+	struct rxr_data_hdr hdr;
+	char data[];
+};
+
+#if defined(static_assert) && defined(__x86_64__)
+static_assert(sizeof(struct rxr_data_hdr) == 24, "rxr_data_hdr check");
+#endif
+
+/*
+ *  @brief READRSP packet header (Packet Type ID 5)
+ *
+ *  READRSP is sent from read responder to read requester, and it contains
+ *  application data.
+ */
+struct rxr_readrsp_hdr {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+	/* end of rxr_base_hdr */
+	uint32_t padding;
+	uint32_t recv_id; /* ID of the receive operation on the read requester, from rtr packet */
+	uint32_t send_id; /* ID of the send operation on the read responder, will be included in CTS packet */
+	uint64_t seg_length;
+};
+
+#if defined(static_assert) && defined(__x86_64__)
+static_assert(sizeof(struct rxr_readrsp_hdr) == sizeof(struct rxr_data_hdr), "rxr_readrsp_hdr check");
+#endif
+
+struct rxr_readrsp_pkt {
+	struct rxr_readrsp_hdr hdr;
+	char data[];
+};
+
+/*
+ * RMA Context pkt (Packe Type ID 6) is a special type
+ * of packet. It is used as the context of an RMA
+ * operatation, thus is not sent over wire. Therefore
+ * its header format is not part of protocol. In doc,
+ * the packet type ID 6 is marked as reserved
+ */
+
+/*
+ * @brief format of the EOR packet. (Packet Type ID 7)
+ *
+ * EOR packet is used in long-read sub-protocols, which is
+ * part of the extra request: RDMA read based data transfer.
+ *
+ * It is sent from receiver to sender, to notify
+ * the finish of data transfer.
+ *
+ * long-read is used not only by two-sided communication but also
+ * by emulated write.
+ *
+ * In emulated write, requester is sender, and responder is receiver.
+ */
+struct rxr_eor_hdr {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+	/* end of rxr_base_hdr */
+	uint32_t send_id; /* ID of the send operation on sender */
+	uint32_t recv_id; /* ID of the receive operation on receiver */
+};
+
+#if defined(static_assert) && defined(__x86_64__)
+static_assert(sizeof(struct rxr_eor_hdr) == 12, "rxr_eor_hdr check");
+#endif
+
+/**
+ * @brief header format of ATOMRSP packet. (Packet Type ID 8)
+ * ATOMRSP packet is used in emulated fetch/compare atomic sub-protocol.
+ * 
+ * It is sent from responder to requester, which contains the response
+ * to a fetch/compare atomic request
+ */
+struct rxr_atomrsp_hdr {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+	/* end of rxr_base_hdr */
+	uint32_t padding;
+	uint32_t reserved;
+	uint32_t recv_id;
+	uint64_t seg_length;
+};
+
+#if defined(static_assert) && defined(__x86_64__)
+static_assert(sizeof(struct rxr_atomrsp_hdr) == 24, "rxr_atomrsp_hdr check");
+#endif
+
+struct rxr_atomrsp_pkt {
+	struct rxr_atomrsp_hdr hdr;
+	char data[];
+};
+
+/**
+ * @breif header format of a HANDSHAKE packet
+ *
+ * HANDSHAKE packet is used in the handshake sub-protocol.
+ *
+ * Upon receiving 1st packet from a peer, an endpoint will
+ * send a HANDSHAKE packet back, which contains its capablity bits
+ */
+struct rxr_handshake_hdr {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+	/* end of rxr_base_hdr */
+	/* nextra_p3 is number of members in extra_info plus 3.
+	 * The "p3" part was introduced for backward compatibility.
+	 * See protocol v4 document section 2.1 for detail.
+	 */
+	uint32_t nextra_p3;
+	uint64_t extra_info[0];
+};
+
+#if defined(static_assert) && defined(__x86_64__)
+static_assert(sizeof(struct rxr_handshake_hdr) == 8, "rxr_handshake_hdr check");
+#endif
+
+/* @brief header format of RECEIPT packet */
+struct rxr_receipt_hdr {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+	/* end of rxr_base_hdr */
+	uint32_t tx_id;
+	uint32_t msg_id;
+	int32_t padding;
+};
+
+/*
+ * The following are REQ packets related constants, flags
+ * and data structures.
+ *
+ * REQ packets can be classifed into 4 categories (section 3.1):
+ *    RTM (Request To Message) is used by message
+ *    RTW (Request To Write) is used by RMA write
+ *    RTR (Request To Read) is used by RMA read
+ *    RTA (Request To Atomic) is used by Atomic
+ */
+
+
+/*
+ * REQ Packets common Header Flags (section 3.1)
+ */
+#define RXR_REQ_OPT_RAW_ADDR_HDR	BIT_ULL(0)
+#define RXR_REQ_OPT_CQ_DATA_HDR		BIT_ULL(1)
+#define RXR_REQ_MSG			BIT_ULL(2)
+#define RXR_REQ_TAGGED			BIT_ULL(3)
+#define RXR_REQ_RMA			BIT_ULL(4)
+#define RXR_REQ_ATOMIC			BIT_ULL(5)
+
+/*
+ * optional headers for REQ packets
+ */
+struct rxr_req_opt_raw_addr_hdr {
+	uint32_t addr_len;
+	char raw_addr[0];
+};
+
+struct rxr_req_opt_cq_data_hdr {
+	int64_t cq_data;
+};
+
+#define RXR_REQ_OPT_HDR_ALIGNMENT 8
+#define RXR_REQ_OPT_RAW_ADDR_HDR_SIZE (((sizeof(struct rxr_req_opt_raw_addr_hdr) + EFA_EP_ADDR_LEN - 1)/RXR_REQ_OPT_HDR_ALIGNMENT + 1) * RXR_REQ_OPT_HDR_ALIGNMENT)
+
+/*
+ * Base header for all RTM packets
+ */
+struct rxr_rtm_base_hdr {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+	uint32_t msg_id;
+};
+
+/**
+ * @brief header format of EAGER_MSGRTM packet (Packet Type ID 64)
+ */
+struct rxr_eager_msgrtm_hdr {
+	struct rxr_rtm_base_hdr hdr;
+};
+
+
+/**
+ * @brief header format of EAGER_TAGRTM packet (Packet Type ID 65)
+ */
+struct rxr_eager_tagrtm_hdr {
+	struct rxr_rtm_base_hdr hdr;
+	uint64_t tag;
+};
+
+struct rxr_medium_rtm_base_hdr {
+	struct rxr_rtm_base_hdr hdr;
+	uint64_t msg_length;
+	uint64_t seg_offset;
+};
+
+/**
+ * @brief header format of MEDIUM_MSGRTM packet (Packet Type ID 66)
+ */
+struct rxr_medium_msgrtm_hdr {
+	struct rxr_medium_rtm_base_hdr hdr;
+};
+
+/**
+ * @brief header format of MEDIUM_TAGRTM packet (Packet Type ID 67)
+ */
+struct rxr_medium_tagrtm_hdr {
+	struct rxr_medium_rtm_base_hdr hdr;
+	uint64_t tag;
+};
+
+struct rxr_longcts_rtm_base_hdr {
+	struct rxr_rtm_base_hdr hdr;
+	uint64_t msg_length;
+	uint32_t send_id;
+	uint32_t credit_request;
+};
+
+/**
+ * @brief header format of LONGCTS_MSGRTM packet (Packet Type ID 68)
+ */
+struct rxr_longcts_msgrtm_hdr {
+	struct rxr_longcts_rtm_base_hdr hdr;
+};
+
+/**
+ * @brief header format of LONGCTS_TAGRTM packet (Packet Type ID 69)
+ */
+struct rxr_longcts_tagrtm_hdr {
+	struct rxr_longcts_rtm_base_hdr hdr;
+	uint64_t tag;
+};
+
+struct rxr_rtw_base_hdr {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+	/* end of rxr_base_hdr */
+	uint32_t rma_iov_count;
+};
+
+/**
+ * @brief header format of EAGER_RTW packet (Packet Type ID 70)
+ */
+struct rxr_eager_rtw_hdr {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+	/* end of rxr_base_hdr */
+	uint32_t rma_iov_count;
+	struct efa_rma_iov rma_iov[0];
+};
+
+/**
+ * @brief header format of LONGCTS_RTW packet (Packet Type ID 71)
+ */
+struct rxr_longcts_rtw_hdr {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+	/* end of rxr_base_hdr */
+	uint32_t rma_iov_count;
+	uint64_t msg_length;
+	uint32_t send_id;
+	uint32_t credit_request;
+	struct efa_rma_iov rma_iov[0];
+};
+
+/*
+ * rxr_rtr_hdr is used by both SHORT_RTR (Packet Type ID 72)
+ * and LONGCTS_RTR (Packet Type ID 73)
+ */
+struct rxr_rtr_hdr {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+	/* end of rxr_base_hdr */
+	uint32_t rma_iov_count;
+	uint64_t msg_length;
+	uint32_t recv_id; /* ID of the receive operation of the read requester, will be included in DATA/READRSP header */
+	uint32_t recv_length; /* number of bytes that the read requester is ready to receive */
+	struct efa_rma_iov rma_iov[0];
+};
+
+/* @brief rxr_rta_hdr are shared by 4 types of RTA:
+ *    WRITE_RTA (Packet Type ID 74),
+ *    FETCH_RTA (Packet Type ID 75),
+ *    COMPARE_RTA (Packet Type ID 76) and
+ *    DC_WRTIE_RTA (Packe Type ID 141)
+ */
+struct rxr_rta_hdr {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+	uint32_t msg_id;
+	/* end of rtm_base_hdr, atomic packet need msg_id for reordering */
+	uint32_t rma_iov_count;
+	uint32_t atomic_datatype;
+	uint32_t atomic_op;
+	union {
+		/* padding is used by WRITE_RTA, align to 8 bytes */
+		uint32_t padding;
+		/* recv_id is used by FETCH_RTA and COMPARE_RTA. It is the ID of the receive operation on atomic requester,
+		 * it will be included in ATOMRSP packet header.
+		 */
+		uint32_t recv_id;
+		/* send_id is used by DC_WRITE_RTA. It is ID of the send operation on the atomic requester.
+		 * It will be included in RECEIPT packet header.
+		 */
+		uint32_t send_id;
+	};
+
+	struct efa_rma_iov rma_iov[0];
+};
+
+/*
+ * Extra request: RDMA read based data transfer (section 4.1)
+ */
+struct rxr_longread_rtm_base_hdr {
+	struct rxr_rtm_base_hdr hdr;
+	uint64_t msg_length;
+	uint32_t send_id;
+	uint32_t read_iov_count;
+};
+
+/**
+ * @brief header format of LONGREAD_MSGRTM (Packet Type ID 128)
+ */
+struct rxr_longread_msgrtm_hdr {
+	struct rxr_longread_rtm_base_hdr hdr;
+};
+
+/**
+ * @brief header format of LONGREAD_MSGRTM (Packet Type ID 129)
+ */
+struct rxr_longread_tagrtm_hdr {
+	struct rxr_longread_rtm_base_hdr hdr;
+	uint64_t tag;
+};
+
+/**
+ * @brief header format of LONGREAD_MSGRTM (Packet Type ID 130)
+ */
+struct rxr_longread_rtw_hdr {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+	/* end of rxr_base_hdr */
+	uint32_t rma_iov_count;
+	uint64_t msg_length;
+	uint32_t send_id;
+	uint32_t read_iov_count;
+	struct efa_rma_iov rma_iov[0];
+};
+
+/*
+ * Extra requester: delivery complete (section 4.2)
+ */
+
+struct rxr_dc_eager_rtm_base_hdr {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+	uint32_t msg_id;
+	uint32_t send_id;
+	uint32_t padding;
+};
+
+/**
+ * @brief header format of a DC_EAGER_MSGRTM packet
+ */
+struct rxr_dc_eager_msgrtm_hdr {
+	struct rxr_dc_eager_rtm_base_hdr hdr;
+};
+
+/**
+ * @brief header format of a DC_EAGER_TAGRTM packet
+ */
+struct rxr_dc_eager_tagrtm_hdr {
+	struct rxr_dc_eager_rtm_base_hdr hdr;
+	uint64_t tag;
+};
+
+struct rxr_dc_medium_rtm_base_hdr {
+	struct rxr_rtm_base_hdr hdr;
+	uint32_t send_id;
+	uint32_t padding;
+	uint64_t msg_length;
+	uint64_t seg_offset;
+};
+
+/**
+ * @brief header format of a DC_MEDIUM_MSGRTM packet
+ */
+struct rxr_dc_medium_msgrtm_hdr {
+	struct rxr_dc_medium_rtm_base_hdr hdr;
+};
+
+/**
+ * @brief header format of a DC_MEDIUM_TAGRTM packet
+ */
+struct rxr_dc_medium_tagrtm_hdr {
+	struct rxr_dc_medium_rtm_base_hdr hdr;
+	uint64_t tag;
+};
+
+/**
+ * @brief header format of a DC_LONGCTS_MSGRTM packet
+ */
+struct rxr_dc_longcts_msgrtm_hdr {
+	struct rxr_longcts_rtm_base_hdr hdr;
+};
+
+/**
+ * @brief header format of a DC_LONGCTS_TAGRTM packet
+ */
+struct rxr_dc_longcts_tagrtm_hdr {
+	struct rxr_longcts_rtm_base_hdr hdr;
+	uint64_t tag;
+};
+
+/**
+ * @brief header format of a DC_EAGER_RTW packet
+ */
+struct rxr_dc_eager_rtw_hdr {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+	/* end of rxr_base_hdr */
+	uint32_t rma_iov_count;
+	/* end of rxr_rtw_base_hdr */
+	uint32_t send_id;
+	uint32_t padding;
+	struct efa_rma_iov rma_iov[0];
+};
+
+/**
+ * @brief header format of a DC_LONGCTS_RTW packet
+ */
+struct rxr_dc_longcts_rtw_hdr {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+	/* end of rxr_base_hdr */
+	uint32_t rma_iov_count;
+	uint64_t msg_length;
+	uint32_t send_id;
+	uint32_t credit_request;
+	struct efa_rma_iov rma_iov[0];
+};
+
+/* DC_WRITE_RTA header format is merged into rxr_rta_hdr */
+
+#endif

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -66,9 +66,6 @@
 #include "rxr_pkt_entry.h"
 #include "rxr_pkt_type.h"
 
-#define RXR_PROTOCOL_VERSION	(4)
-#define RXR_MAX_NUM_EXINFO	(256)
-
 #define RXR_FI_VERSION		OFI_VERSION_LATEST
 
 #define RXR_IOV_LIMIT		(4)

--- a/prov/efa/src/rxr/rxr_pkt_type.h
+++ b/prov/efa/src/rxr/rxr_pkt_type.h
@@ -34,90 +34,7 @@
 #ifndef _RXR_PKT_TYPE_H
 #define _RXR_PKT_TYPE_H
 
-/* This header file contain the ID of all RxR packet types, and
- * the necessary data structures and functions for each packet type
- *
- * RxR packet types can be classified into 3 categories:
- *     data packet, control packet and context packet
- *
- * For each packet type, the following items are needed:
- *
- *   First, each packet type need to define a struct for its header,
- *       and the header must be start with ```struct rxr_base_hdr```.
- *
- *   Second, each control packet type need to define an init()
- *       function and a handle_sent() function. These functions
- *       are called by rxr_pkt_post_ctrl_or_queue().
- *
- *   Finally, each packet type (except context packet) need to
- *     define a handle_recv() functions which is called by
- *     rxr_pkt_handle_recv_completion().
- */
-
-/* ID of each packet type. Changing ID would break inter
- * operability thus is strictly prohibited.
- */
-
-#define RXR_RETIRED_RTS_PKT	1
-#define RXR_RETIRED_CONNACK_PKT	2
-#define RXR_CTS_PKT		3
-#define RXR_DATA_PKT		4
-#define RXR_READRSP_PKT		5
-#define RXR_RMA_CONTEXT_PKT	6
-#define RXR_EOR_PKT		7
-#define RXR_ATOMRSP_PKT         8
-#define RXR_HANDSHAKE_PKT	9
-#define RXR_RECEIPT_PKT 10
-
-#define RXR_REQ_PKT_BEGIN		64
-#define RXR_BASELINE_REQ_PKT_BEGIN	64
-#define RXR_EAGER_MSGRTM_PKT		64
-#define RXR_EAGER_TAGRTM_PKT		65
-#define RXR_MEDIUM_MSGRTM_PKT		66
-#define RXR_MEDIUM_TAGRTM_PKT		67
-#define RXR_LONGCTS_MSGRTM_PKT		68
-#define RXR_LONGCTS_TAGRTM_PKT		69
-#define RXR_EAGER_RTW_PKT		70
-#define RXR_LONGCTS_RTW_PKT		71
-#define RXR_SHORT_RTR_PKT		72
-#define RXR_LONGCTS_RTR_PKT		73
-#define RXR_WRITE_RTA_PKT		74
-#define RXR_FETCH_RTA_PKT		75
-#define RXR_COMPARE_RTA_PKT		76
-#define RXR_BASELINE_REQ_PKT_END	77
-
-#define RXR_EXTRA_REQ_PKT_BEGIN		128
-#define RXR_LONGREAD_MSGRTM_PKT		128
-#define RXR_LONGREAD_TAGRTM_PKT		129
-#define RXR_LONGREAD_RTW_PKT		130
-#define RXR_READ_RTR_PKT		131
-
-#define RXR_DC_REQ_PKT_BEGIN		132
-#define RXR_DC_EAGER_MSGRTM_PKT 	133
-#define RXR_DC_EAGER_TAGRTM_PKT 	134
-#define RXR_DC_MEDIUM_MSGRTM_PKT 	135
-#define RXR_DC_MEDIUM_TAGRTM_PKT 	136
-#define RXR_DC_LONGCTS_MSGRTM_PKT  	137
-#define RXR_DC_LONGCTS_TAGRTM_PKT  	138
-#define RXR_DC_EAGER_RTW_PKT    	139
-#define RXR_DC_LONGCTS_RTW_PKT     	140
-#define RXR_DC_WRITE_RTA_PKT    	141
-#define RXR_DC_REQ_PKT_END		142
-#define RXR_EXTRA_REQ_PKT_END   	142
-
-/*
- *  Packet fields common to all rxr packets. The other packet headers below must
- *  be changed if this is updated.
- */
-struct rxr_base_hdr {
-	uint8_t type;
-	uint8_t version;
-	uint16_t flags;
-};
-
-#if defined(static_assert) && defined(__x86_64__)
-static_assert(sizeof(struct rxr_base_hdr) == 4, "rxr_base_hdr check");
-#endif
+#include "rdm_proto_v4.h"
 
 static inline struct rxr_base_hdr *rxr_get_base_hdr(void *pkt)
 {
@@ -130,27 +47,7 @@ struct rxr_tx_entry;
 struct rxr_rx_entry;
 struct rxr_read_entry;
 
-/*
- *  HANDSHAKE packet header and functions
- *  implementation of the functions are in rxr_pkt_type_misc.c
- */
-struct rxr_handshake_hdr {
-	uint8_t type;
-	uint8_t version;
-	uint16_t flags;
-	/* end of rxr_base_hdr */
-	/* nextra_p3 is number of members in extra_info plus 3.
-	 * The "p3" part was introduced for backward compatibility.
-	 * See protocol v4 document section 2.1 for detail.
-	 */
-	uint32_t nextra_p3;
-	uint64_t extra_info[0];
-};
-
-#if defined(static_assert) && defined(__x86_64__)
-static_assert(sizeof(struct rxr_handshake_hdr) == 8, "rxr_handshake_hdr check");
-#endif
-
+/* HANDSHAKE packet related functions */
 static inline
 struct rxr_handshake_hdr *rxr_get_handshake_hdr(void *pkt)
 {
@@ -168,40 +65,8 @@ void rxr_pkt_post_handshake_or_queue(struct rxr_ep *ep,
 
 void rxr_pkt_handle_handshake_recv(struct rxr_ep *ep,
 				   struct rxr_pkt_entry *pkt_entry);
-/*
- * @breif format of CTS packet header
- *
- * CTS is used in long-CTS sub-protocols for flow control.
- *
- * It is sent from receiver to sender, and contains number of bytes
- * receiver is ready to receive.
- *
- * long-CTS is used not only by two-sided communication but also
- * by emulated write and emulated read protocols.
- *
- * In emulated write, requester is sender, and responder is receiver.
- *
- * In emulated read, requester is receiver, and responder is sender.
- */
-struct rxr_cts_hdr {
-	uint8_t type;
-	uint8_t version;
-	uint16_t flags;
-	/* end of rxr_base_hdr */
-	uint8_t pad[4];
-	uint32_t send_id; /* ID of the send opertaion on sender side */
-	uint32_t recv_id; /* ID of the receive operatin on receive side */
-	uint64_t recv_length; /* number of bytes receiver is ready to receive */
-};
 
-#if defined(static_assert) && defined(__x86_64__)
-static_assert(sizeof(struct rxr_cts_hdr) == 24, "rxr_cts_hdr check");
-#endif
-
-/* this flag is to indicated the CTS is the response of a RTR packet */
-#define RXR_CTS_READ_REQ		BIT_ULL(7)
-#define RXR_CTS_HDR_SIZE		(sizeof(struct rxr_cts_hdr))
-
+/* CTS packet related functions */
 static inline
 struct rxr_cts_hdr *rxr_get_cts_hdr(void *pkt)
 {
@@ -222,42 +87,7 @@ void rxr_pkt_handle_cts_sent(struct rxr_ep *ep,
 void rxr_pkt_handle_cts_recv(struct rxr_ep *ep,
 			     struct rxr_pkt_entry *pkt_entry);
 
-/*
- * @brief format of DATA packet header.
- *
- * DATA is used in long-CTS sub-protocols.
- *
- * It is sent from sender to receiver, and contains a segment
- * of application data.
- *
- * long-CTS is used not only by two-sided communication but also
- * by emulated write and emulated read protocols.
- *
- * In emulated write, requester is sender, and responder is receiver.
- *
- * In emulated read, requester is receiver, and responder is sender.
- */
-struct rxr_data_hdr {
-	uint8_t type;
-	uint8_t version;
-	uint16_t flags;
-	/* end of rxr_base_hdr */
-	uint32_t recv_id; /* ID of the receive operation on receiver */
-	uint64_t seg_length;
-	uint64_t seg_offset;
-};
-
-#if defined(static_assert) && defined(__x86_64__)
-static_assert(sizeof(struct rxr_data_hdr) == 24, "rxr_data_hdr check");
-#endif
-
-#define RXR_DATA_HDR_SIZE		(sizeof(struct rxr_data_hdr))
-
-struct rxr_data_pkt {
-	struct rxr_data_hdr hdr;
-	char data[];
-};
-
+/* DATA packet related functions */
 static inline
 struct rxr_data_pkt *rxr_get_data_pkt(void *pkt)
 {
@@ -281,42 +111,14 @@ void rxr_pkt_proc_data(struct rxr_ep *ep,
 void rxr_pkt_handle_data_send_completion(struct rxr_ep *ep,
 					 struct rxr_pkt_entry *pkt_entry);
 
-
 void rxr_pkt_handle_data_recv(struct rxr_ep *ep,
 			      struct rxr_pkt_entry *pkt_entry);
 
-/*
- *  @brief READRSP packet header
- *
- *  READRSP is sent from read responder to read requester, and it contains
- *  application data.
- */
-struct rxr_readrsp_hdr {
-	uint8_t type;
-	uint8_t version;
-	uint16_t flags;
-	/* end of rxr_base_hdr */
-	uint32_t padding;
-	uint32_t recv_id; /* ID of the receive operation on the read requester, from rtr packet */
-	uint32_t send_id; /* ID of the send operation on the read responder, will be included in CTS packet */
-	uint64_t seg_length;
-};
-
+/* READRSP packet related functions */
 static inline struct rxr_readrsp_hdr *rxr_get_readrsp_hdr(void *pkt)
 {
 	return (struct rxr_readrsp_hdr *)pkt;
 }
-
-#define RXR_READRSP_HDR_SIZE	(sizeof(struct rxr_readrsp_hdr))
-
-#if defined(static_assert) && defined(__x86_64__)
-static_assert(sizeof(struct rxr_readrsp_hdr) == sizeof(struct rxr_data_hdr), "rxr_readrsp_hdr check");
-#endif
-
-struct rxr_readrsp_pkt {
-	struct rxr_readrsp_hdr hdr;
-	char data[];
-};
 
 int rxr_pkt_init_readrsp(struct rxr_ep *ep,
 			 struct rxr_tx_entry *tx_entry,
@@ -363,32 +165,7 @@ void rxr_pkt_init_read_context(struct rxr_ep *rxr_ep,
 void rxr_pkt_handle_rma_completion(struct rxr_ep *ep,
 				   struct rxr_pkt_entry *pkt_entry);
 
-/*
- * @brief format of the EOR packet.
- *
- * EOR packet is used in long-read sub-protocols.
- *
- * It is sent from receiver to sender, to notify
- * the finish of data transfer.
- *
- * long-read is used not only by two-sided communication but also
- * by emulated write.
- *
- * In emulated write, requester is sender, and responder is receiver.
- */
-struct rxr_eor_hdr {
-	uint8_t type;
-	uint8_t version;
-	uint16_t flags;
-	/* end of rxr_base_hdr */
-	uint32_t send_id; /* ID of the send operation on sender */
-	uint32_t recv_id; /* ID of the receive operation on receiver */
-};
-
-#if defined(static_assert) && defined(__x86_64__)
-static_assert(sizeof(struct rxr_eor_hdr) == 12, "rxr_eor_hdr check");
-#endif
-
+/* EOR packet related functions */
 static inline
 struct rxr_eor_hdr *rxr_get_eor_hdr(void *pkt)
 {
@@ -408,52 +185,28 @@ void rxr_pkt_handle_eor_send_completion(struct rxr_ep *ep,
 void rxr_pkt_handle_eor_recv(struct rxr_ep *ep,
 			     struct rxr_pkt_entry *pkt_entry);
 
-/* atomrsp types */
-struct rxr_atomrsp_hdr {
-	uint8_t type;
-	uint8_t version;
-	uint16_t flags;
-	/* end of rxr_base_hdr */
-	uint32_t padding;
-	uint32_t reserved;
-	uint32_t recv_id;
-	uint64_t seg_length;
-};
-
-#if defined(static_assert) && defined(__x86_64__)
-static_assert(sizeof(struct rxr_atomrsp_hdr) == 24, "rxr_atomrsp_hdr check");
-#endif
-
-#define RXR_ATOMRSP_HDR_SIZE	(sizeof(struct rxr_atomrsp_hdr))
-
-struct rxr_atomrsp_pkt {
-	struct rxr_atomrsp_hdr hdr;
-	char data[];
-};
-
+/* ATOMRSP packet related functions */
 static inline struct rxr_atomrsp_hdr *rxr_get_atomrsp_hdr(void *pkt)
 {
 	return (struct rxr_atomrsp_hdr *)pkt;
 }
 
-/* receipt packet headers */
-struct rxr_receipt_hdr {
-	uint8_t type;
-	uint8_t version;
-	uint16_t flags;
-	/* end of rxr_base_hdr */
-	uint32_t tx_id;
-	uint32_t msg_id;
-	int32_t padding;
-};
+int rxr_pkt_init_atomrsp(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,
+			 struct rxr_pkt_entry *pkt_entry);
 
+void rxr_pkt_handle_atomrsp_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
+
+void rxr_pkt_handle_atomrsp_send_completion(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
+
+void rxr_pkt_handle_atomrsp_recv(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
+
+/* RECEIPT packet related functions */
 static inline
 struct rxr_receipt_hdr *rxr_get_receipt_hdr(void *pkt)
 {
 	return (struct rxr_receipt_hdr *)pkt;
 }
 
-/* receipt packet functions: init, handle_sent, handle_send_completion, recv*/
 int rxr_pkt_init_receipt(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,
 			 struct rxr_pkt_entry *pkt_entry);
 
@@ -465,16 +218,6 @@ void rxr_pkt_handle_receipt_send_completion(struct rxr_ep *ep,
 
 void rxr_pkt_handle_receipt_recv(struct rxr_ep *ep,
 				 struct rxr_pkt_entry *pkt_entry);
-
-/* atomrsp functions: init, handle_sent, handle_send_completion, recv */
-int rxr_pkt_init_atomrsp(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,
-			 struct rxr_pkt_entry *pkt_entry);
-
-void rxr_pkt_handle_atomrsp_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
-
-void rxr_pkt_handle_atomrsp_send_completion(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
-
-void rxr_pkt_handle_atomrsp_recv(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
 
 #endif
 

--- a/prov/efa/src/rxr/rxr_pkt_type_data.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_data.c
@@ -221,7 +221,7 @@ ssize_t rxr_pkt_send_data_desc(struct rxr_ep *ep,
 	pkt_entry->send->iov_count = i;
 
 	data_pkt->hdr.seg_length = (uint16_t)payload_size;
-	pkt_entry->pkt_size = payload_size + RXR_DATA_HDR_SIZE;
+	pkt_entry->pkt_size = payload_size + sizeof(struct rxr_data_hdr);
 	pkt_entry->x_entry = tx_entry;
 	pkt_entry->addr = tx_entry->addr;
 

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -312,10 +312,10 @@ int rxr_pkt_init_readrsp(struct rxr_ep *ep,
 	readrsp_hdr->send_id = tx_entry->tx_id;
 	readrsp_hdr->recv_id = tx_entry->rx_id;
 	readrsp_hdr->seg_length = ofi_copy_from_iov(readrsp_pkt->data,
-						    mtu - RXR_READRSP_HDR_SIZE,
+						    mtu - sizeof(struct rxr_readrsp_hdr),
 						    tx_entry->iov,
 						    tx_entry->iov_count, 0);
-	pkt_entry->pkt_size = RXR_READRSP_HDR_SIZE + readrsp_hdr->seg_length;
+	pkt_entry->pkt_size = sizeof(struct rxr_readrsp_hdr) + readrsp_hdr->seg_length;
 	pkt_entry->addr = tx_entry->addr;
 	pkt_entry->x_entry = tx_entry;
 	return 0;
@@ -614,11 +614,11 @@ int rxr_pkt_init_atomrsp(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,
 	atomrsp_hdr->recv_id = rx_entry->tx_id;
 	atomrsp_hdr->seg_length = ofi_total_iov_len(rx_entry->iov, rx_entry->iov_count);
 
-	assert(RXR_ATOMRSP_HDR_SIZE + atomrsp_hdr->seg_length < ep->mtu_size);
+	assert(sizeof(struct rxr_atomrsp_hdr) + atomrsp_hdr->seg_length < ep->mtu_size);
 
 	/* rx_entry->atomrsp_data was filled in rxr_pkt_handle_req_recv() */
-	memcpy((char*)pkt_entry->pkt + RXR_ATOMRSP_HDR_SIZE, rx_entry->atomrsp_data, atomrsp_hdr->seg_length);
-	pkt_entry->pkt_size = RXR_ATOMRSP_HDR_SIZE + atomrsp_hdr->seg_length;
+	memcpy((char*)pkt_entry->pkt + sizeof(struct rxr_atomrsp_hdr), rx_entry->atomrsp_data, atomrsp_hdr->seg_length);
+	pkt_entry->pkt_size = sizeof(struct rxr_atomrsp_hdr) + atomrsp_hdr->seg_length;
 	return 0;
 }
 


### PR DESCRIPTION
This patch moves all constants, flags, and data structures in
protocol v4 to a separate header file rdm_proto_v4.h.

This is to separate protocol definition and implementation.

Signed-off-by: Wei Zhang <wzam@amazon.com>