### PR TITLE
fabtests: add missing ft_init calls for hmem init

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -685,7 +685,7 @@ int ft_alloc_active_res(struct fi_info *fi)
 	return 0;
 }
 
-static int ft_init(void)
+int ft_init(void)
 {
 	tx_seq = 0;
 	rx_seq = 0;

--- a/fabtests/functional/rdm_atomic.c
+++ b/fabtests/functional/rdm_atomic.c
@@ -435,6 +435,10 @@ static int init_fabric(void)
 {
 	int ret;
 
+	ret = ft_init();
+	if (ret)
+		return ret;
+
 	ret  = ft_init_oob();
 	if (ret)
 		return ret;

--- a/fabtests/functional/rdm_multi_client.c
+++ b/fabtests/functional/rdm_multi_client.c
@@ -113,10 +113,11 @@ static int run_client(int client_id, bool address_reuse)
 	static size_t size = sizeof(name);
 	int ret;
 
-	tx_seq = 0;
-	rx_seq = 0;
-	tx_cq_cntr = 0;
-	rx_cq_cntr = 0;
+	ret = ft_init();
+	if (ret) {
+		FT_PRINTERR("ft_init", -ret);
+		return ret;
+	}
 
 	ret = ft_init_oob();
 	if (ret) {

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -366,6 +366,7 @@ static inline int ft_use_size(int index, int enable_flags)
 		}							\
 	} while (0)
 
+int ft_init();
 int ft_alloc_bufs();
 int ft_open_fabric_res();
 int ft_getinfo(struct fi_info *hints, struct fi_info **info);


### PR DESCRIPTION
    A couple of fabtests are not calling ft_init, specifically the atomic
    tests and rdm multi client test. Those tests use the general memory
    allocation path and argument parsing so it is possible for them to call
    hmem alloc without calling hmem init. Add calls to ft_init so hmem is
    initialized.

Signed-off-by: Robert Wespetal <wesper@amazon.com>

Test description: Ran efa/tcp fabtests.