### PR TITLE
fabtests: Enable rdm ep prefix mode test for EFA provider.

### DIFF
--- a/fabtests/test_configs/efa/efa.exclude
+++ b/fabtests/test_configs/efa/efa.exclude
@@ -38,9 +38,6 @@
 # Exclude cq_data test until fi_pool/fi_wait is supported
 cq_data
 
-# Exclude all rdm prefix tests
-rdm.* -k
-
 multi_mr
 rdm_rma_trigger
 


### PR DESCRIPTION
This test suite is excluded in current efa test config,
which causes a gap in the test for cases that FI_MSG_PREFIX
is specified in hints->mode.

Signed-off-by: Shi Jin <sjina@amazon.com>