### PR TITLE
[v1.13.x] prov/efa: fix a bug that caused unnecessary copy

### DIFF
--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -336,7 +336,7 @@ void rxr_pkt_req_data_from_tx(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry
 	 *    1st iov for header.
 	 */
 	if ((!pkt_entry->mr || tx_entry->desc[tx_iov_index]) &&
-	    (tx_iov_offset + data_size < tx_entry->iov[tx_iov_index].iov_len)) {
+	    (tx_iov_offset + data_size <= tx_entry->iov[tx_iov_index].iov_len)) {
 
 		assert(ep->core_iov_limit >= 2);
 		pkt_entry->send->iov[0].iov_base = pkt_entry->pkt;


### PR DESCRIPTION
The function rxr_pkt_req_data_from_tx() prepares a REQ packet
to be sent. It can either use the application's sending
buffer directly, or copy data from application's buffer to
packet entry.

Using application's sending buffer is preferred but certain
conditions must be met.

One of the conditions is the application's data must be
in one IOV. This is because EFA device supports sending 2 IOV
at a time, and EFA provider uses 1 IOV for packet header.

The bug is with the checking of this condition, the checking
should have been

   "offset + total_data_size <= iov_length",

but is currently.

   "offset + total_data_size < iov_length"

Which caused unnecessary copy.

This patch fixed the issue.

Signed-off-by: Wei Zhang <wzam@amazon.com>
(cherry picked from commit a1d272ecbce24ffcf63b0a72edde9e46a6ae38d8)