### PR TITLE
prov/efa: Remove redundant variable "lower_efa_prov".

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -418,6 +418,9 @@ int efa_cq_open(struct fid_domain *domain_fid, struct fi_cq_attr *attr,
 		struct fid_cq **cq_fid, void *context);
 int efa_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric_fid,
 	       void *context);
+int efa_getinfo(uint32_t version, const char *node, const char *service,
+		uint64_t flags, const struct fi_info *hints, struct fi_info **info);
+void efa_finalize_prov(void);
 
 /* AV sub-functions */
 int efa_av_insert_one(struct efa_av *av, struct efa_ep_addr *addr,
@@ -434,7 +437,7 @@ fi_addr_t efa_ahn_qpn_to_addr(struct efa_av *av, uint16_t ahn, uint16_t qpn);
 
 struct rdm_peer *efa_ahn_qpn_to_peer(struct efa_av *av, uint16_t ahn, uint16_t qpn);
 
-struct fi_provider *init_lower_efa_prov();
+int efa_init_prov(void);
 
 ssize_t efa_post_flush(struct efa_ep *ep, struct ibv_send_wr **bad_wr);
 

--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -1041,7 +1041,7 @@ err_free_fabric:
 	return ret;
 }
 
-static void fi_efa_fini(void)
+void efa_finalize_prov(void)
 {
 	struct efa_context **ctx_list;
 	int num_devices;
@@ -1063,7 +1063,7 @@ struct fi_provider efa_prov = {
 	.fi_version = OFI_VERSION_LATEST,
 	.getinfo = efa_getinfo,
 	.fabric = efa_fabric,
-	.cleanup = fi_efa_fini
+	.cleanup = efa_finalize_prov
 };
 
 struct util_prov efa_util_prov = {
@@ -1120,10 +1120,7 @@ static int efa_init_info(const struct fi_info **all_infos)
 	return retv;
 }
 
-struct fi_provider *init_lower_efa_prov()
+int efa_init_prov(void)
 {
-	if (efa_init_info(&efa_util_prov.info))
-		return NULL;
-
-	return &efa_prov;
+	return efa_init_info(&efa_util_prov.info);
 }

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -201,7 +201,6 @@ static inline void rxr_poison_mem_region(uint32_t *ptr, size_t size)
 
 extern struct fi_info *shm_info;
 
-extern struct fi_provider *lower_efa_prov;
 extern struct fi_provider rxr_prov;
 extern struct fi_info rxr_info;
 extern struct rxr_env rxr_env;


### PR DESCRIPTION
Since the efa_fabric and rxr_fabric functionality was squashed a while back,
this variable was redundant and added to unnecessary code complexity.

This change simplifies the code by removing this variable and replacing
with existing functionality as needed. Going forward this will make the code
easier to understand and maintain.

Signed-off-by: Rich Welch <rlwelch@amazon.com>