### PR TITLE
hmem: add function to get hmem iface initialization status

### DIFF
--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -226,6 +226,7 @@ int ofi_hmem_open_handle(enum fi_hmem_iface iface, void **handle,
 int ofi_hmem_close_handle(enum fi_hmem_iface iface, void *ipc_ptr);
 int ofi_hmem_get_base_addr(enum fi_hmem_iface iface, const void *ptr,
 			   void **base);
+bool ofi_hmem_is_initialized(enum fi_hmem_iface iface);
 
 void ofi_hmem_init(void);
 void ofi_hmem_cleanup(void);

--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -234,7 +234,7 @@ int ofi_monitors_add_cache(struct ofi_mem_monitor **monitors,
 	for (iface = FI_HMEM_SYSTEM; iface < OFI_HMEM_MAX; iface++) {
 		cache->monitors[iface] = NULL;
 
-		if (!hmem_ops[iface].initialized)
+		if (!ofi_hmem_is_initialized(iface))
 			continue;
 
 		monitor = monitors[iface];

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -201,6 +201,11 @@ int ofi_hmem_get_base_addr(enum fi_hmem_iface iface, const void *ptr,
 	return hmem_ops[iface].get_base_addr(ptr, base);
 }
 
+bool ofi_hmem_is_initialized(enum fi_hmem_iface iface)
+{
+	return hmem_ops[iface].initialized;
+}
+
 void ofi_hmem_init(void)
 {
 	int iface, ret;
@@ -228,7 +233,7 @@ void ofi_hmem_cleanup(void)
 	enum fi_hmem_iface iface;
 
 	for (iface = 0; iface < ARRAY_SIZE(hmem_ops); iface++) {
-		if (hmem_ops[iface].initialized)
+		if (ofi_hmem_is_initialized(iface))
 			hmem_ops[iface].cleanup();
 	}
 }
@@ -243,7 +248,7 @@ enum fi_hmem_iface ofi_get_hmem_iface(const void *addr)
 	 */
 	for (iface = ARRAY_SIZE(hmem_ops) - 1; iface > FI_HMEM_SYSTEM;
 	     iface--) {
-		if (hmem_ops[iface].initialized &&
+		if (ofi_hmem_is_initialized(iface) &&
 		    hmem_ops[iface].is_addr_valid(addr))
 			return iface;
 	}
@@ -256,7 +261,7 @@ int ofi_hmem_host_register(void *ptr, size_t size)
 	int iface, ret;
 
 	for (iface = 0; iface < ARRAY_SIZE(hmem_ops); iface++) {
-		if (!hmem_ops[iface].initialized)
+		if (!ofi_hmem_is_initialized(iface))
 			continue;
 
 		ret = hmem_ops[iface].host_register(ptr, size);
@@ -273,7 +278,7 @@ err:
 		fi_strerror(-ret));
 
 	for (iface--; iface >= 0; iface--) {
-		if (!hmem_ops[iface].initialized)
+		if (!ofi_hmem_is_initialized(iface))
 			continue;
 
 		hmem_ops[iface].host_unregister(ptr);
@@ -287,7 +292,7 @@ int ofi_hmem_host_unregister(void *ptr)
 	int iface, ret;
 
 	for (iface = 0; iface < ARRAY_SIZE(hmem_ops); iface++) {
-		if (!hmem_ops[iface].initialized)
+		if (!ofi_hmem_is_initialized(iface))
 			continue;
 
 		ret = hmem_ops[iface].host_unregister(ptr);


### PR DESCRIPTION
Providers can use this to determine if hmem support is enabled for a
particular interface, and fail memory registration calls if it's not
supported.

Signed-off-by: Robert Wespetal <wesper@amazon.com>