### PR TITLE
prov/efa: bugfix: Never set a negative inject size

### DIFF
--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -407,7 +407,12 @@ static int rxr_info_to_rxr(uint32_t version, const struct fi_info *core_info,
 	else
 		min_pkt_size = core_info->ep_attr->max_msg_size;
 
-	info->tx_attr->inject_size = min_pkt_size - rxr_pkt_max_header_size();
+	if (min_pkt_size < rxr_pkt_max_header_size()) {
+		info->tx_attr->inject_size = 0;
+	} else {
+		info->tx_attr->inject_size = min_pkt_size - rxr_pkt_max_header_size();
+	}
+
 	rxr_info.tx_attr->inject_size = info->tx_attr->inject_size;
 
 	info->addr_format = core_info->addr_format;


### PR DESCRIPTION
If our max message size was set low enough, we could attempt to set a
size_t to a negative value, causing segfaults.

Signed-off-by: William Zhang <wilzhang@amazon.com>