### PR TITLE
[v1.11.x] util/pingpong.c: fix a bug in pp_alloc_active_res

### DIFF
--- a/util/pingpong.c
+++ b/util/pingpong.c
@@ -1376,6 +1376,11 @@ static int pp_alloc_active_res(struct ct_pingpong *ct, struct fi_info *fi)
 {
 	int ret;
 
+	if (fi->tx_attr->mode & FI_MSG_PREFIX)
+		ct->tx_prefix_size = fi->ep_attr->msg_prefix_size;
+	if (fi->rx_attr->mode & FI_MSG_PREFIX)
+		ct->rx_prefix_size = fi->ep_attr->msg_prefix_size;
+
 	ret = pp_alloc_msgs(ct);
 	if (ret)
 		return ret;
@@ -1410,11 +1415,6 @@ static int pp_alloc_active_res(struct ct_pingpong *ct, struct fi_info *fi)
 			return ret;
 		}
 	}
-
-	if (fi->tx_attr->mode & FI_MSG_PREFIX)
-		ct->tx_prefix_size = fi->ep_attr->msg_prefix_size;
-	if (fi->rx_attr->mode & FI_MSG_PREFIX)
-		ct->rx_prefix_size = fi->ep_attr->msg_prefix_size;
 
 	ret = fi_endpoint(ct->domain, fi, &(ct->ep), NULL);
 	if (ret) {


### PR DESCRIPTION
Currently, pp_alloc_msgs() function includes tx/rx prefix size
in the tx/rx buffer size. However, these two variables are not
assigned the correct msg prefix size before the function call,
which caused a wrong buffer size. This patch makes tx/rx prefix
size assigned correct values before they are used by pp_alloc_msgs().

Signed-off-by: Shi Jin <sjina@amazon.com>
(cherry picked from commit 7aa0d6d5c264821cd1175604aed1ffbcc97519e9)