### PR TITLE
prov/efa: fix an error in section ID in efa_rdm_protocol_v4.md

### DIFF
--- a/prov/efa/docs/efa_rdm_protocol_v4.md
+++ b/prov/efa/docs/efa_rdm_protocol_v4.md
@@ -393,7 +393,7 @@ the base header? Given that the sole purpose of the field `maxproto` is to provi
 how many members the `extra_info` array has, the protocol would be much easier to understand if we re-interpret
 the field `maxproto` as `nextra_p3` and allow protocol v4 to have more than 64 extra feature/requests.
 
-### 3.2 handshake sub-protocol and raw address exchange
+### 2.2 handshake sub-protocol and raw address exchange
 
 Another functionality of the handshake sub-protocol is to adjust behavior of including raw address in packet header.
 


### PR DESCRIPTION
In efa_rdm_protocol_v4.md, the ID of section "handshake protocol
and raw address exchange" should be 2.2, but is currently listed
as 3.2.

This patch fixed the issue.

Signed-off-by: Wei Zhang <wzam@amazon.com>