### PR TITLE
[v1.9.x] Add check for python in runfabtests.sh

### DIFF
--- a/fabtests/scripts/runfabtests.sh
+++ b/fabtests/scripts/runfabtests.sh
@@ -73,12 +73,19 @@ declare -i pass_count=0
 declare -i fail_count=0
 declare -i total_failures=0
 
-if [[ "$(uname)" == "FreeBSD" ]]; then
-    declare -ri FI_ENODATA=$(python -c 'import errno; print(errno.ENOMSG)')
-else
-    declare -ri FI_ENODATA=$(python -c 'import errno; print(errno.ENODATA)')
+python=$(which python3 2>/dev/null) || python=$(which python2 2>/dev/null)
+
+if [ $? -ne 0 ]; then
+	echo "Unable to find python dependency, exiting..."
+	exit 1
 fi
-declare -ri FI_ENOSYS=$(python -c 'import errno; print(errno.ENOSYS)')
+
+if [[ "$(uname)" == "FreeBSD" ]]; then
+    declare -ri FI_ENODATA=$($python -c 'import errno; print(errno.ENOMSG)')
+else
+    declare -ri FI_ENODATA=$($python -c 'import errno; print(errno.ENODATA)')
+fi
+declare -ri FI_ENOSYS=$($python -c 'import errno; print(errno.ENOSYS)')
 
 neg_unit_tests=(
 	"fi_dgram g00n13s"

--- a/fabtests/scripts/runfabtests.sh
+++ b/fabtests/scripts/runfabtests.sh
@@ -73,7 +73,7 @@ declare -i pass_count=0
 declare -i fail_count=0
 declare -i total_failures=0
 
-python=$(which python3 2>/dev/null) || python=$(which python2 2>/dev/null)
+python=$(which python3 2>/dev/null) || python=$(which python2 2>/dev/null) || python=$(which python 2>/dev/null)
 
 if [ $? -ne 0 ]; then
 	echo "Unable to find python dependency, exiting..."


### PR DESCRIPTION
This PR backports https://github.com/ofiwg/libfabric/pull/6052 and https://github.com/ofiwg/libfabric/pull/6054 to v1.9.x branch. It adds a check for the availability of python command (and its variants: python2, python3) before running tests. This will guarantee the error code will not mess up when the default `python` command is not available on the system.