### PR TITLE
prov/efa: Adding some checking around enabled shared memory transfers

### DIFF
--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -840,8 +840,8 @@ static int efa_av_close(struct fid *fid)
 	}
 
 	if (av->ep_type == FI_EP_RDM) {
-		if (rxr_env.enable_shm_transfer && av->shm_rdm_av &&
-		    &av->shm_rdm_av->fid) {
+		if (av->shm_rdm_av) {
+			assert(rxr_env.enable_shm_transfer);
 			ret = fi_close(&av->shm_rdm_av->fid);
 			if (ret) {
 				err = ret;
@@ -939,7 +939,7 @@ int efa_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 		av->ep_type = FI_EP_RDM;
 
 		av_attr = *attr;
-		if (rxr_env.enable_shm_transfer) {
+		if (efa_domain->fab && efa_domain->fab->shm_fabric) {
 			/*
 			 * shm av supports maximum 256 entries
 			 * Reset the count to 128 to reduce memory footprint and satisfy

--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -938,7 +938,7 @@ static int efa_fabric_close(fid_t fid)
 		return ret;
 	}
 
-	if (rxr_env.enable_shm_transfer) {
+	if (efa_fabric->shm_fabric) {
 		ret = fi_close(&efa_fabric->shm_fabric->fid);
 		if (ret) {
 			FI_WARN(&rxr_prov, FI_LOG_FABRIC,
@@ -1006,6 +1006,8 @@ int efa_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric_fid,
 				    &efa_fabric->shm_fabric, context);
 		if (ret)
 			goto err_close_util_fabric;
+	} else {
+		efa_fabric->shm_fabric = NULL;
 	}
 
 

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -243,7 +243,8 @@ static int efa_mr_dereg_impl(struct efa_mr *efa_mr)
 			fi_strerror(-ret));
 		ret = err;
 	}
-	if (rxr_env.enable_shm_transfer && efa_mr->shm_mr) {
+	if (efa_mr->shm_mr) {
+		assert(rxr_env.enable_shm_transfer);
 		err = fi_close(&efa_mr->shm_mr->fid);
 		if (err) {
 			EFA_WARN(FI_LOG_MR,
@@ -339,10 +340,11 @@ static int efa_mr_reg_impl(struct efa_mr *efa_mr, uint64_t flags, void *attr)
 			mr_attr->mr_iov->iov_len);
 		return ret;
 	}
-	if (efa_mr->domain->shm_domain && rxr_env.enable_shm_transfer) {
+	if (efa_mr->domain->shm_domain) {
 		/* We need to add FI_REMOTE_READ to allow for Read implemented
 		* message protocols.
 		*/
+		assert(rxr_env.enable_shm_transfer);
 		original_access = mr_attr->access;
 		mr_attr->access |= FI_REMOTE_READ;
 		ret = fi_mr_regattr(efa_mr->domain->shm_domain, attr,

--- a/prov/efa/src/rxr/rxr_domain.c
+++ b/prov/efa/src/rxr/rxr_domain.c
@@ -190,10 +190,9 @@ int rxr_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 				  	util_domain.domain_fid);
 
 	/* Open shm provider's access domain */
-	if (rxr_env.enable_shm_transfer) {
-		efa_fabric = container_of(fabric, struct efa_fabric,
-					util_fabric.fabric_fid);
-
+	efa_fabric = container_of(fabric, struct efa_fabric,
+							  util_fabric.fabric_fid);
+	if (efa_fabric->shm_fabric) {
 		assert(!strcmp(shm_info->fabric_attr->name, "shm"));
 		ret = fi_domain(efa_fabric->shm_fabric, shm_info,
 				&efa_domain->shm_domain, context);
@@ -229,7 +228,7 @@ int rxr_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	return 0;
 
 err_close_shm_domain:
-	if (rxr_env.enable_shm_transfer) {
+	if (efa_domain->shm_domain) {
 		retv = fi_close(&efa_domain->shm_domain->fid);
 		if (retv)
 			FI_WARN(&rxr_prov, FI_LOG_DOMAIN,


### PR DESCRIPTION
There are currently a couple of places where a global variable is used
to control whether or not shared memory is used for intranode
communnication. This can be dangerous if for some reason this gets
out of sync with the actual underlying structures.

This patch changes things to that we primarily check the underlying
structures, and only set those after checking the global variable
once. There are some occurances where making this change isn't
possible but for the most part this patch makese these checks more
defensive.

Also, in some places the check on the global variable is redundant
and any inconsistency would represent an error state, so these checks
were changes to asserts.

Signed-off-by: Rich Welch <rlwelch@amazon.com>