### PR TITLE
CI/Jenkins: changed build code for shmem tests due to git clone issues

### DIFF
--- a/contrib/intel/jenkins/build.py
+++ b/contrib/intel/jenkins/build.py
@@ -10,6 +10,7 @@ import subprocess
 import shlex
 import common
 import re
+import shutil
 
 def build_libfabric(libfab_install_path, mode):
 
@@ -87,12 +88,13 @@ def build_shmem(shmem_dir, libfab_install_path):
 def build_ISx(shmem_dir):
     
     oshcc = '{}/bin/oshcc'.format(shmem_dir)
+    tmp_isx_src = '{}/ISx'.format(ci_site_config.shmem_root)
+    shutil.copytree(tmp_isx_src, '{}/ISx'.format(shmem_dir)) 
+    #os.chdir(shmem_dir)
+    #git_cmd = ['git', 'clone', '--depth', '1', 'https://github.com/ParRes/ISx.git', 'ISx']
     
-    os.chdir(shmem_dir)
-    git_cmd = ['git', 'clone', '--depth', '1', 'https://github.com/ParRes/ISx.git', 'ISx']
-    
-    common.run_command(git_cmd) 
-    os.chdir('ISx/SHMEM')
+    #common.run_command(git_cmd) 
+    os.chdir('{}/ISx/SHMEM'.format(shmem_dir))
     common.run_command(['make', 'CC={}'.format(oshcc), 'LDLIBS=-lm']) 
                   
     
@@ -100,10 +102,12 @@ def build_PRK(shmem_dir):
     
     oshcc = '{}/bin/oshcc'.format(shmem_dir)
     shmem_src = '{}/SOS'.format(shmem_dir)
-    os.chdir(shmem_dir)
-    git_cmd = ['git', 'clone', '--depth', ' 1', 'https://github.com/ParRes/Kernels.git', 'PRK']
-    common.run_command(git_cmd)
-    os.chdir('PRK')
+    tmp_prk_src = '{}/PRK'.format(ci_site_config.shmem_root)
+    shutil.copytree(tmp_prk_src, '{}/PRK'.format(shmem_dir))
+    #os.chdir(shmem_dir)
+    #git_cmd = ['git', 'clone', '--depth', ' 1', 'https://github.com/ParRes/Kernels.git', 'PRK']
+    #common.run_command(git_cmd)
+    os.chdir('{}/PRK'.format(shmem_dir))
     with open('common/make.defs','w') as f:
         f.write('SHMEMCC={} -std=c99\nSHMEMTOP={}\n'.format(oshcc,shmem_src))
 
@@ -112,12 +116,12 @@ def build_PRK(shmem_dir):
 def build_uh(shmem_dir):
     oshcc_bin = "{}/bin".format(shmem_dir)
     os.environ["PATH"] += os.pathsep + oshcc_bin
-   
-   
-    os.chdir(shmem_dir) 
-    git_cmd = ['git', 'clone', '--depth', '1', 'https://github.com/openshmem-org/tests-uh.git', 'tests-uh'] 
-    common.run_command(git_cmd)
-    os.chdir('tests-uh')
+    tmp_uh_src = '{}/tests-uh'.format(ci_site_config.shmem_root)
+    shutil.copytree(tmp_uh_src, '{}/tests-uh'.format(shmem_dir))
+    #os.chdir(shmem_dir) 
+    #git_cmd = ['git', 'clone', '--depth', '1', 'https://github.com/openshmem-org/tests-uh.git', 'tests-uh'] 
+    #common.run_command(git_cmd)
+    os.chdir('{}/tests-uh'.format(shmem_dir))
     common.run_command(['make', '-j4', 'C_feature_tests'])
     
 


### PR DESCRIPTION
Changed the shmem build to source the ISx, PRK and uh from
prefetched repositories instead of attempting to clone run time.
This is done since shmem build is throwing https errors while
cloning these repos on the fly. This also saves build time.

cherry-picked from main 7257067798e52dd57451594b1243201c5eb3ace0

Signed-off-by: Nikhil Nanal <nikhil.nanal@intel.com>