### PR TITLE
[v1.11.x] fabtests/benchmarks: Enable modifying hints->mode by options.

### DIFF
--- a/fabtests/benchmarks/rdm_pingpong.c
+++ b/fabtests/benchmarks/rdm_pingpong.c
@@ -95,7 +95,7 @@ int main(int argc, char **argv)
 
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_MSG;
-	hints->mode = FI_CONTEXT;
+	hints->mode |= FI_CONTEXT;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->domain_attr->threading = FI_THREAD_DOMAIN;
 

--- a/fabtests/benchmarks/rdm_tagged_bw.c
+++ b/fabtests/benchmarks/rdm_tagged_bw.c
@@ -98,7 +98,7 @@ int main(int argc, char **argv)
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->domain_attr->resource_mgmt = FI_RM_ENABLED;
 	hints->caps = FI_TAGGED;
-	hints->mode = FI_CONTEXT;
+	hints->mode |= FI_CONTEXT;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->domain_attr->threading = FI_THREAD_DOMAIN;
 

--- a/fabtests/benchmarks/rdm_tagged_pingpong.c
+++ b/fabtests/benchmarks/rdm_tagged_pingpong.c
@@ -96,7 +96,7 @@ int main(int argc, char **argv)
 
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_TAGGED;
-	hints->mode = FI_CONTEXT;
+	hints->mode |= FI_CONTEXT;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->domain_attr->threading = FI_THREAD_DOMAIN;
 


### PR DESCRIPTION
This PR backports https://github.com/ofiwg/libfabric/pull/7013 to v1.11.x branch