### PR TITLE
include <assert.h> instead of <cassert> in C file

### DIFF
--- a/prov/netdir/src/netdir_ndinit.c
+++ b/prov/netdir/src/netdir_ndinit.c
@@ -36,7 +36,7 @@
 #include <guiddef.h>
 
 #include <ws2spi.h>
-#include <cassert>
+#include <assert.h>
 #include "ndspi.h"
 
 #include "netdir.h"


### PR DESCRIPTION
Standard C++ headers are only to be used for compiling C++

Fixes #7041

Signed-off-by: Casey Carter <cacarter@microsoft.com>