### PR TITLE
prov/shm: fix segfault and sigbus error if server is not initialized first

### DIFF
--- a/prov/util/src/util_shm.c
+++ b/prov/util/src/util_shm.c
@@ -381,7 +381,7 @@ int smr_map_to_region(const struct fi_provider *prov, struct smr_peer *peer_buf)
 	if (!peer->pid) {
 		FI_WARN(prov, FI_LOG_AV, "peer not initialized\n");
 		munmap(peer, sizeof(*peer));
-		ret = -FI_EAGAIN;
+		ret = -FI_ENOENT;
 		goto out;
 	}
 


### PR DESCRIPTION
The shm code assumes FI_ENOENT as the error code if the peer is not
initialized. The old code was using FI_ENOENT if the shm region did
not exist but then FI_EAGAIN if the shm existed but the peer has not
finish initializing, causing interpretation errors in the fi_av_insert
path.

Signed-off-by: aingerson <alexia.ingerson@intel.com>