### PR TITLE
rxm/tcp: Ensure that connections use the correct source address

### DIFF
--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -830,6 +830,23 @@ int rxm_start_listen(struct rxm_ep *ep)
 		return ret;
 	}
 
+	/* Update src_addr that will be used for active endpoints.
+	 * Zero out the port to avoid address conflicts, as we will
+	 * create multiple msg ep's for a single rdm ep.
+	 */
+	if (ep->msg_info->src_addr) {
+		free(ep->msg_info->src_addr);
+		ep->msg_info->src_addr = NULL;
+		ep->msg_info->src_addrlen = 0;
+	}
+
+	ep->msg_info->src_addr = mem_dup(&ep->addr, addr_len);
+	if (!ep->msg_info->src_addr)
+		return -FI_ENOMEM;
+
+	ep->msg_info->src_addrlen = addr_len;
+	ofi_addr_set_port(ep->msg_info->src_addr, 0);
+
 	if (ep->util_ep.domain->data_progress == FI_PROGRESS_AUTO ||
 	    force_auto_progress) {
 

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -2747,12 +2747,6 @@ static int rxm_open_core_res(struct rxm_ep *ep)
 	if (ret)
 		goto err2;
 
-	/* Zero out the port as we will create multiple MSG EPs for a
-	 * single RXM EP, and we don't want address conflicts.
-	 */
-	if (ep->msg_info->src_addr)
-		ofi_addr_set_port(ep->msg_info->src_addr, 0);
-
 	return 0;
 err2:
 	if (ep->srx_ctx) {

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -731,6 +731,17 @@ int tcpx_endpoint(struct fid_domain *domain, struct fi_info *info,
 			goto err3;
 
 		tcpx_set_zerocopy(ep->bsock.sock);
+
+		if (info->src_addr && (!ofi_is_any_addr(info->src_addr) ||
+					ofi_addr_get_port(info->src_addr))) {
+			ret = bind(ep->bsock.sock, info->src_addr,
+				(socklen_t) info->src_addrlen);
+			if (ret) {
+				FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL, "bind failed\n");
+				ret = -ofi_sockerr();
+				goto err3;
+			}
+		}
 	}
 
 	ret = fastlock_init(&ep->lock);


### PR DESCRIPTION
Should fix #6942

The tcp provider was ignoring the src_addr when creating an active ep.  The result was that the socket would select a src address based on the destination address passed into connect().  This would result in the connection using the wrong src address which would fail tag matching with src addressing.

Modify the rxm provider to reset the src_addr after listening on the passive ep.  This fixes the possibility of using the wrong src_addr in the case where the app calls fi_setname() on the rdm ep.