### PR TITLE
prov/efa: adjust the sequence of rxr_ep_check_available_data_bufs_timer

### DIFF
--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1821,9 +1821,6 @@ void rxr_ep_progress_internal(struct rxr_ep *ep)
 	struct dlist_entry *tmp;
 	ssize_t ret;
 
-	if (!ep->use_zcpy_rx)
-		rxr_ep_check_available_data_bufs_timer(ep);
-
 	// Poll the EFA completion queue
 	rdm_ep_poll_ibv_cq(ep, rxr_env.efa_cq_read_size);
 
@@ -1835,6 +1832,8 @@ void rxr_ep_progress_internal(struct rxr_ep *ep)
 
 	rxr_ep_check_peer_backoff_timer(ep);
 
+	if (!ep->use_zcpy_rx)
+		rxr_ep_check_available_data_bufs_timer(ep);
 	/*
 	 * Resend handshake packet for any peers where the first
 	 * handshake send failed.


### PR DESCRIPTION
rxr_ep_check_available_data_bufs_timer() checks and updates
ep->available_data_bufs in progress engine, if it has not been updated.

This patch moved it to after rxr_ep_progress_post_internal_rx_pkts(),
because rxr_ep_progress_post_internal_rx_pkts() will update
ep->available_data_bufs.

Signed-off-by: Wei Zhang <wzam@amazon.com>