### PR TITLE
prov/efa: Detect when the user sets the now-deprecated

### DIFF
--- a/man/fi_efa.7.md
+++ b/man/fi_efa.7.md
@@ -165,6 +165,7 @@ These OFI runtime parameters apply only to the RDM endpoint.
 *FI_EFA_SHM_MAX_MEDIUM_SIZE*
 : Defines the switch point between small/medium message and large message. The message
   larger than this switch point will be transferred with large message protocol.
+  NOTE: This parameter is now deprecated.
 
 *FI_EFA_INTER_MAX_MEDIUM_MESSAGE_SIZE*
 : The maximum size for inter EFA messages to be sent by using medium message protocol. Messages which can fit in one packet will be sent as eager message. Messages whose sizes are smaller than this value will be sent using medium message protocol. Other messages will be sent using CTS based long message protocol.

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -86,6 +86,12 @@ static void rxr_init_env(void)
 {
 	int fork_safe = 0;
 
+	if (getenv("FI_EFA_SHM_MAX_MEDIUM_SIZE")) {
+		fprintf(stderr,
+			"FI_EFA_SHM_MAX_MEDIUM_SIZE env variable detected! The use of this variable has been deprecated and as such execution cannot proceed.\n");
+		abort();
+	};
+
 	fi_param_get_int(&rxr_prov, "rx_window_size", &rxr_env.rx_window_size);
 	fi_param_get_int(&rxr_prov, "tx_max_credits", &rxr_env.tx_max_credits);
 	fi_param_get_int(&rxr_prov, "tx_min_credits", &rxr_env.tx_min_credits);


### PR DESCRIPTION
environment variable FI_EFA_SHM_MAX_MEDIUM_SIZE and then if they
have print an error before bailing.

We are now doing this to avoid the case where someone can silently
set this now-deprecated environment variable.

Signed-off-by: Rich Welch <rlwelch@amazon.com>