### PR TITLE
prov/util: fix util cq flags

### DIFF
--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -638,7 +638,7 @@ cleanup:
 }
 
 uint64_t ofi_rx_flags[] = {
-	[ofi_op_msg] = FI_RECV,
+	[ofi_op_msg] = FI_MSG | FI_RECV,
 	[ofi_op_tagged] = FI_RECV | FI_TAGGED,
 	[ofi_op_read_req] = FI_RMA | FI_REMOTE_READ,
 	[ofi_op_read_rsp] = FI_RMA | FI_REMOTE_READ,
@@ -647,7 +647,7 @@ uint64_t ofi_rx_flags[] = {
 	[ofi_op_atomic] = FI_ATOMIC | FI_REMOTE_WRITE,
 	[ofi_op_atomic_fetch] = FI_ATOMIC | FI_REMOTE_READ,
 	[ofi_op_atomic_compare] = FI_ATOMIC | FI_REMOTE_READ,
-	[ofi_op_read_async] = FI_RMA | FI_READ,
+	[ofi_op_read_async] = FI_RMA | FI_REMOTE_READ,
 };
 
 uint64_t ofi_tx_flags[] = {
@@ -660,6 +660,6 @@ uint64_t ofi_tx_flags[] = {
 	[ofi_op_atomic] = FI_ATOMIC | FI_WRITE,
 	[ofi_op_atomic_fetch] = FI_ATOMIC | FI_READ,
 	[ofi_op_atomic_compare] = FI_ATOMIC | FI_READ,
-	[ofi_op_read_async] = FI_RMA | FI_RMA,
+	[ofi_op_read_async] = FI_RMA | FI_READ,
 };
 


### PR DESCRIPTION
msg rx flags should be FI_MSG | FI_RECV, not just FI_RECV
read rx flags should be FI_REMOTE_READ, not FI_READ
read tx flags should be FI_RMA | FI_READ not FI_RMA | FI_RMA

Signed-off-by: aingerson <alexia.ingerson@intel.com>