### PR TITLE
prov/efa: wait for uncompleted send operations when closing endpoint

### DIFF
--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -767,12 +767,71 @@ static void rxr_ep_free_res(struct rxr_ep *rxr_ep)
 	}
 }
 
+/*
+ * @brief determine whether an endpoint has unfinished send
+ *
+ * Unfinished send includes queued ctrl packets, queued
+ * RNR packets and inflight TX packets.
+ *
+ * @param[in]	rxr_ep	endpoint
+ * @return	a boolean
+ */
+static
+bool rxr_ep_has_unfinished_send(struct rxr_ep *rxr_ep)
+{
+	return !dlist_empty(&rxr_ep->rx_entry_queued_rnr_list) ||
+	       !dlist_empty(&rxr_ep->rx_entry_queued_ctrl_list) ||
+	       !dlist_empty(&rxr_ep->tx_entry_queued_rnr_list) ||
+	       !dlist_empty(&rxr_ep->tx_entry_queued_ctrl_list) ||
+	       (rxr_ep->efa_outstanding_tx_ops > 0) ||
+	       (rxr_ep->shm_outstanding_tx_ops > 0);
+}
+
+/*
+ * @brief wait for send to finish
+ *
+ * Wait for queued packet to be sent, and inflight send to
+ * complete.
+ *
+ * @param[in]	rxr_ep		endpoint
+ * @param[in]	max_wait_time	maximum wait time in second
+ * @return 	Return 0 on success.
+ * 		Return -FI_ETIMEDOUT, if maximum wait time has been reached.
+ */
+static
+int rxr_ep_wait_send(struct rxr_ep *rxr_ep, int max_wait_time)
+{
+	uint64_t begin_time;
+	uint64_t max_wait_time_us = max_wait_time * 1000000;
+	bool finished;
+
+	fastlock_acquire(&rxr_ep->util_ep.lock);
+
+	begin_time = ofi_gettime_us();
+	while (rxr_ep_has_unfinished_send(rxr_ep) &&
+	       (ofi_gettime_us() - begin_time < max_wait_time_us)) {
+		rxr_ep_progress_internal(rxr_ep);
+	}
+
+	finished = rxr_ep_has_unfinished_send(rxr_ep);
+	fastlock_release(&rxr_ep->util_ep.lock);
+
+	return finished ? 0 : -FI_ETIMEDOUT;
+}
+
 static int rxr_ep_close(struct fid *fid)
 {
 	int ret, retv = 0;
+	int finish_send_timeout = 10; // seconds
 	struct rxr_ep *rxr_ep;
 
 	rxr_ep = container_of(fid, struct rxr_ep, util_ep.ep_fid.fid);
+
+	ret = rxr_ep_wait_send(rxr_ep, finish_send_timeout);
+	if (ret == -FI_ETIMEDOUT) {
+		FI_WARN(&rxr_prov, FI_LOG_EP_CTRL, "Unable to finish queued/inflight send in %d seconds\n",
+			finish_send_timeout);
+	}
 
 	ret = fi_close(&rxr_ep->rdm_ep->fid);
 	if (ret) {


### PR DESCRIPTION
This patch added a step to wait for queued/inflight send operations
to finish. This step is necessary because a peer might be waiting
for a packet from the endpoint.

This patch used a maxium wait time and set it to 10 second initially.

Signed-off-by: Wei Zhang <wzam@amazon.com>