### PR TITLE
prov/efa: remove releasing of pkt_entry from rxr_cq_handle_rx_completion

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -938,7 +938,6 @@ void rxr_cq_write_rx_completion(struct rxr_ep *ep,
 				struct rxr_rx_entry *rx_entry);
 
 void rxr_cq_handle_rx_completion(struct rxr_ep *ep,
-				 struct rxr_pkt_entry *pkt_entry,
 				 struct rxr_rx_entry *rx_entry);
 
 void rxr_cq_write_tx_completion(struct rxr_ep *ep,

--- a/prov/efa/src/rxr/rxr_cq.c
+++ b/prov/efa/src/rxr/rxr_cq.c
@@ -451,7 +451,6 @@ void rxr_cq_write_rx_completion(struct rxr_ep *ep,
 }
 
 void rxr_cq_handle_rx_completion(struct rxr_ep *ep,
-				 struct rxr_pkt_entry *pkt_entry,
 				 struct rxr_rx_entry *rx_entry)
 {
 	struct rxr_tx_entry *tx_entry = NULL;
@@ -463,7 +462,6 @@ void rxr_cq_handle_rx_completion(struct rxr_ep *ep,
 		if (rx_entry->cq_entry.flags & FI_REMOTE_CQ_DATA)
 			rxr_cq_write_rx_completion(ep, rx_entry);
 
-		rxr_pkt_entry_release_rx(ep, pkt_entry);
 		return;
 	}
 
@@ -507,7 +505,6 @@ void rxr_cq_handle_rx_completion(struct rxr_ep *ep,
 		 * do not call rxr_release_rx_entry here because
 		 * caller will release
 		 */
-		rxr_pkt_entry_release_rx(ep, pkt_entry);
 		return;
 	}
 
@@ -515,7 +512,6 @@ void rxr_cq_handle_rx_completion(struct rxr_ep *ep,
 		rxr_msg_multi_recv_handle_completion(ep, rx_entry);
 
 	rxr_cq_write_rx_completion(ep, rx_entry);
-	rxr_pkt_entry_release_rx(ep, pkt_entry);
 	return;
 }
 

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -635,6 +635,8 @@ void rxr_pkt_handle_data_copied(struct rxr_ep *ep,
 	assert(rx_entry);
 	rx_entry->bytes_copied += data_size;
 
+	rxr_pkt_entry_release_rx(ep, pkt_entry);
+
 	if (rx_entry->total_len == rx_entry->bytes_copied) {
 		if (rx_entry->rxr_flags & RXR_DELIVERY_COMPLETE_REQUESTED) {
 			ret = rxr_pkt_post_ctrl_or_queue(ep,
@@ -653,7 +655,7 @@ void rxr_pkt_handle_data_copied(struct rxr_ep *ep,
 						     rx_entry);
 				return;
 			}
-			rxr_cq_handle_rx_completion(ep, pkt_entry, rx_entry);
+			rxr_cq_handle_rx_completion(ep, rx_entry);
 			rxr_msg_multi_recv_free_posted_entry(ep, rx_entry);
 			/* rx_entry will be released
 			 * when sender receives the
@@ -661,11 +663,9 @@ void rxr_pkt_handle_data_copied(struct rxr_ep *ep,
 			 */
 			return;
 		}
-		rxr_cq_handle_rx_completion(ep, pkt_entry, rx_entry);
+		rxr_cq_handle_rx_completion(ep, rx_entry);
 		rxr_msg_multi_recv_free_posted_entry(ep, rx_entry);
 		rxr_release_rx_entry(ep, rx_entry);
-	} else {
-		rxr_pkt_entry_release_rx(ep, pkt_entry);
 	}
 }
 


### PR DESCRIPTION
Currently, the funciton rxr_cq_handle_rx_completion() takes an RX pkt_entry
as input and release is. This patch simplify the function by removing
the releasing of pkt_entry from it. The caller of this function will
release the RX pkt_entry.

Signed-off-by: Wei Zhang <wzam@amazon.com>