### PR TITLE
prov/verbs,rxm: Fix hook provider handling in the flow control ops

### DIFF
--- a/include/ofi_hook.h
+++ b/include/ofi_hook.h
@@ -73,6 +73,11 @@ extern struct fi_ops hook_fid_ops;
 struct fid *hook_to_hfid(const struct fid *fid);
 struct fid_wait *hook_to_hwait(const struct fid_wait *wait);
 
+static inline bool is_hook_fid(const struct fid *fid)
+{
+        return (fid->ops == &hook_fid_ops);
+}
+
 /*
  * TODO
  * comment from GitHub PR #5052:

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -37,6 +37,7 @@
 
 #include <ofi_util.h>
 #include <ofi_coll.h>
+#include <ofi_hook.h>
 #include "rxm.h"
 
 int rxm_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
@@ -380,14 +381,19 @@ static struct fi_ops_mr rxm_domain_mr_ops = {
 
 static ssize_t rxm_send_credits(struct fid_ep *ep, size_t credits)
 {
-	struct rxm_conn *rxm_conn = ep->fid.context;
-	struct rxm_ep *rxm_ep = rxm_conn->ep;
+	struct rxm_conn *rxm_conn;
+	struct rxm_ep *rxm_ep;
 	struct rxm_deferred_tx_entry *def_tx_entry;
 	struct rxm_tx_buf *tx_buf;
 	struct iovec iov;
 	struct fi_msg msg;
 	ssize_t ret;
 
+	if (is_hook_fid((fid_t)ep->fid.context))
+		ep = (struct fid_ep *)ep->fid.context;
+
+	rxm_conn = ep->fid.context;
+	rxm_ep = rxm_conn->ep;
 	tx_buf = ofi_buf_alloc(rxm_ep->tx_pool);
 	if (!tx_buf) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_DATA,

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -76,6 +76,7 @@
 #include "ofi_indexer.h"
 #include "ofi_iov.h"
 #include "ofi_hmem.h"
+#include "ofi_hook.h"
 
 #include "ofi_verbs_priv.h"
 

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -39,10 +39,14 @@
 #include <malloc.h>
 
 
-
 static void vrb_set_threshold(struct fid_ep *ep_fid, size_t threshold)
 {
-	struct vrb_ep *ep = container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
+	struct vrb_ep *ep;
+
+	if (is_hook_fid((fid_t)ep_fid))
+		ep_fid = (struct fid_ep *)hook_to_hfid((fid_t)ep_fid);
+
+	ep = container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	ep->threshold = threshold;
 }
 
@@ -51,6 +55,10 @@ static void vrb_set_credit_handler(struct fid_domain *domain_fid,
 {
 	struct vrb_domain *domain;
 
+	if (is_hook_fid((fid_t)domain_fid))
+		domain_fid =
+			(struct fid_domain *)hook_to_hfid((fid_t)domain_fid);
+
 	domain = container_of(domain_fid, struct vrb_domain,
 			      util_domain.domain_fid.fid);
 	domain->send_credits = credit_handler;
@@ -58,7 +66,12 @@ static void vrb_set_credit_handler(struct fid_domain *domain_fid,
 
 static int vrb_enable_ep_flow_ctrl(struct fid_ep *ep_fid)
 {
-	struct vrb_ep *ep = container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
+	struct vrb_ep *ep;
+
+	if (is_hook_fid((fid_t)ep_fid))
+		ep_fid = (struct fid_ep *)hook_to_hfid((fid_t)ep_fid);
+
+	ep = container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	// only enable if we are not using SRQ
 	if (!ep->srq_ep && ep->ibv_qp && ep->ibv_qp->qp_type == IBV_QPT_RC) {
 		ep->peer_rq_credits = 1;

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -43,6 +43,9 @@ void vrb_add_credits(struct fid_ep *ep_fid, size_t credits)
 	struct vrb_ep *ep;
 	struct util_cq *cq;
 
+	if (is_hook_fid((fid_t)ep_fid))
+		ep_fid = (struct fid_ep *)hook_to_hfid((fid_t)ep_fid);
+
 	ep = container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	cq = ep->util_ep.tx_cq;
 


### PR DESCRIPTION
The credit based flow control mechansim uses functions exported via
the fi_open_ops() interface to coordinate between the rxm and verbs
layers. There are two issues when a hook provider sits between rxm
and verbs:

(1) These exported functions expect verbs objects (ep, domain, etc),
but here the hook objects are passed in.

(2) The 'rxm_send_credits' call expects the ep passed in has 'rxm_conn'
as the fid context, but here the fid context contains the hook ep, and
'rxm_conn' resides in the fid context of the hook ep.

To fix these, above functions need to check if the objects are from
the hook provider and adjust the behavior accordingly. In addition, a
utility function 'is_hook_fid' is added to help the checking.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>