### PR TITLE
[v1.13.x] prov/efa: wait for uncompleted send operations when closing…

### DIFF
--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -809,7 +809,7 @@ int rxr_ep_wait_send(struct rxr_ep *rxr_ep, int max_wait_time)
 		rxr_ep_progress_internal(rxr_ep);
 	}
 
-	finished = rxr_ep_has_unfinished_send(rxr_ep);
+	finished = !rxr_ep_has_unfinished_send(rxr_ep);
 	fastlock_release(&rxr_ep->util_ep.lock);
 
 	return finished ? 0 : -FI_ETIMEDOUT;


### PR DESCRIPTION
… endpoint

This patch added a step to wait for queued/inflight send operations
to finish. This step is necessary because a peer might be waiting
for a packet from the endpoint.

This patch used a maxium wait time and set it to 10 second initially.

(cherry-picked from 7cf9213c4)

Signed-off-by: Wei Zhang <wzam@amazon.com>