### PR TITLE
prov/hook: Intercept fi_open_ops() to properly handle flow control ops

### DIFF
--- a/include/ofi_hook.h
+++ b/include/ofi_hook.h
@@ -65,6 +65,15 @@ enum ofi_hook_class {
 
 
 /*
+ * Default fi_ops members, can be used to construct custom fi_ops
+ */
+int hook_close(struct fid *fid);
+int hook_bind(struct fid *fid, struct fid *bfid, uint64_t flags);
+int hook_control(struct fid *fid, int command, void *arg);
+int hook_ops_open(struct fid *fid, const char *name,
+		  uint64_t flags, void **ops, void *context);
+
+/*
  * Define hook structs so we can cast from fid to parent using simple cast.
  * This lets us have a single close() call.
  */
@@ -146,10 +155,14 @@ static inline struct fi_provider *hook_to_hprov(const struct fid *fid)
 	return hook_fabric_to_hprov(hook_to_fabric(fid));
 }
 
+struct ofi_ops_flow_ctrl;
+
 struct hook_domain {
 	struct fid_domain domain;
 	struct fid_domain *hdomain;
 	struct hook_fabric *fabric;
+	struct ofi_ops_flow_ctrl *base_ops_flow_ctrl;
+	ssize_t (*base_credit_handler)(struct fid_ep *ep_fid, size_t credits);
 };
 
 int hook_domain(struct fid_fabric *fabric, struct fi_info *info,
@@ -257,6 +270,7 @@ int hook_query_atomic(struct fid_domain *domain, enum fi_datatype datatype,
 		  enum fi_op op, struct fi_atomic_attr *attr, uint64_t flags);
 
 extern struct fi_ops hook_fabric_fid_ops;
+extern struct fi_ops hook_domain_fid_ops;
 extern struct fi_ops_fabric hook_fabric_ops;
 extern struct fi_ops_domain hook_domain_ops;
 extern struct fi_ops_cq hook_cq_ops;


### PR DESCRIPTION
The credit based flow control mechansim uses functions exported via
the fi_open_ops() interface to coordinate between the rxm and verbs
layers. There are two issues when a hook provider sits between rxm
and verbs:

(1) These exported functions expect verbs objects (ep, domain, etc),
but here the hook objects are passed in.

(2) The 'rxm_send_credits' call expects the ep passed in has 'rxm_conn'
as the fid context, but here the fid context contains the hook ep, and
'rxm_conn' resides in the fid context of the hook ep.

To fix these, the hook provider intercepts the flow control functions
and does necessary object mapping.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>