### PR TITLE
[v1.13.x] prov/efa: Allow apps to reset RNR retry counter

### DIFF
--- a/include/rdma/fi_ext.h
+++ b/include/rdma/fi_ext.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Intel Corporation. All rights reserved.
+ * Copyright (c) 2021 Amazon.com, Inc. or its affiliates. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -41,6 +42,24 @@
 extern "C" {
 #endif
 
+/*
+ * Each provider can define provider-specific values by
+ * choosing an unique 11-bit (since the most significant
+ * bit must be 1) provider-specific code to avoid
+ * overlapping with other providers. E.g.,
+ *
+ * #define FI_PROV_SPECIFIC_XXX    (FI_PROV_SPECIFIC | 0xabc << 20)
+ * enum {
+ *        FI_PROV_XXX_VALUE        (1U | FI_PROV_SPECIFIC_XXX)
+ * }
+ */
+
+#define FI_PROV_SPECIFIC_EFA   (FI_PROV_SPECIFIC | 0xefa << 20)
+
+/* EFA options */
+enum {
+       FI_OPT_EFA_RNR_RETRY = (1U | FI_PROV_SPECIFIC_EFA),
+};
 
 struct fi_fid_export {
 	struct fid **fid;

--- a/include/rdma/fi_ext.h
+++ b/include/rdma/fi_ext.h
@@ -33,6 +33,7 @@
 #ifndef FI_EXT_H
 #define FI_EXT_H
 
+#include <stdbool.h>
 #include <rdma/fabric.h>
 
 

--- a/man/fi_efa.7.md
+++ b/man/fi_efa.7.md
@@ -82,6 +82,14 @@ No support for counters for the DGRAM endpoint.
 
 No support for inject.
 
+# PROVIDER SPECIFIC ENDPOINT LEVEL OPTION
+
+*FI_OPT_EFA_RNR_RETRY*
+: Defines the number of RNR retry. The application can use it to reset RNR retry
+  counter via the call to fi_setopt. Note that this option must be set before
+  the endpoint is enabled. Otherwise, the call will fail. Also note that this
+  option only applies to RDM endpoint.
+
 # RUNTIME PARAMETERS
 
 *FI_EFA_TX_SIZE*

--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -317,6 +317,7 @@ struct efa_ep {
 	struct efa_cq		*scq;
 	struct efa_av		*av;
 	struct fi_info		*info;
+	size_t			rnr_retry;
 	void			*src_addr;
 	struct ibv_send_wr	xmit_more_wr_head;
 	struct ibv_send_wr	*xmit_more_wr_tail;

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -49,6 +49,7 @@
 #include <rdma/fi_rma.h>
 #include <rdma/fi_tagged.h>
 #include <rdma/fi_trigger.h>
+#include <rdma/fi_ext.h>
 
 #include <ofi.h>
 #include <ofi_iov.h>

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1042,14 +1042,29 @@ static ssize_t rxr_ep_cancel(fid_t fid_ep, void *context)
 static int rxr_ep_getopt(fid_t fid, int level, int optname, void *optval,
 			 size_t *optlen)
 {
-	struct rxr_ep *rxr_ep = container_of(fid, struct rxr_ep,
-					     util_ep.ep_fid.fid);
+	struct rxr_ep *rxr_ep;
+	struct efa_ep *efa_ep;
 
-	if (level != FI_OPT_ENDPOINT || optname != FI_OPT_MIN_MULTI_RECV)
+	rxr_ep = container_of(fid, struct rxr_ep, util_ep.ep_fid.fid);
+	efa_ep = container_of(rxr_ep->rdm_ep, struct efa_ep, util_ep.ep_fid);
+
+	if (level != FI_OPT_ENDPOINT)
 		return -FI_ENOPROTOOPT;
 
-	*(size_t *)optval = rxr_ep->min_multi_recv_size;
-	*optlen = sizeof(size_t);
+	switch (optname) {
+	case FI_OPT_MIN_MULTI_RECV:
+		*(size_t *)optval = rxr_ep->min_multi_recv_size;
+		*optlen = sizeof(size_t);
+		break;
+	case FI_OPT_EFA_RNR_RETRY:
+		*(size_t *)optval = efa_ep->rnr_retry;
+		*optlen = sizeof(size_t);
+		break;
+	default:
+		FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,
+			"Unknown endpoint option %s\n", __func__);
+		return -FI_ENOPROTOOPT;
+	}
 
 	return FI_SUCCESS;
 }
@@ -1057,16 +1072,46 @@ static int rxr_ep_getopt(fid_t fid, int level, int optname, void *optval,
 static int rxr_ep_setopt(fid_t fid, int level, int optname,
 			 const void *optval, size_t optlen)
 {
-	struct rxr_ep *rxr_ep = container_of(fid, struct rxr_ep,
-					     util_ep.ep_fid.fid);
+	struct rxr_ep *rxr_ep;
+	struct efa_ep *efa_ep;
 
-	if (level != FI_OPT_ENDPOINT || optname != FI_OPT_MIN_MULTI_RECV)
+	rxr_ep = container_of(fid, struct rxr_ep, util_ep.ep_fid.fid);
+	efa_ep = container_of(rxr_ep->rdm_ep, struct efa_ep, util_ep.ep_fid);
+
+	if (level != FI_OPT_ENDPOINT)
 		return -FI_ENOPROTOOPT;
 
 	if (optlen < sizeof(size_t))
 		return -FI_EINVAL;
 
-	rxr_ep->min_multi_recv_size = *(size_t *)optval;
+	switch (optname) {
+	case FI_OPT_MIN_MULTI_RECV:
+		rxr_ep->min_multi_recv_size = *(size_t *)optval;
+		break;
+	case FI_OPT_EFA_RNR_RETRY:
+		/*
+		 * Application is required to call to fi_setopt before EP
+		 * enabled. If it's calling to fi_setopt after EP enabled,
+		 * fail the call.
+		 *
+		 * efa_ep->qp will be NULL before EP enabled, use it to check
+		 * if the call to fi_setopt is before or after EP enabled for
+		 * convience, instead of calling to ibv_query_qp
+		 */
+		if (!efa_ep->qp) {
+			efa_ep->rnr_retry = *(size_t *)optval;
+		} else {
+			FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,
+				"The option FI_OPT_EFA_RNR_RETRY is required \
+				to be set before EP enabled %s\n", __func__);
+			return -FI_EINVAL;
+		}
+		break;
+	default:
+		FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,
+			"Unknown endpoint option %s\n", __func__);
+		return -FI_ENOPROTOOPT;
+	}
 
 	return FI_SUCCESS;
 }


### PR DESCRIPTION
This patch adds a mechanism to allow apps to reset
RNR retry counter before EP enablement via fi_setopt.

Need to rebase after #7072 is merged 