### PR TITLE
prov/efa: remove usage of SHM_MAX_NAME

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -108,6 +108,8 @@
  * Specific flags and attributes for shm provider
  */
 #define EFA_SHM_MAX_AV_COUNT       (256)
+/* maximum name length for shm endpoint */
+#define EFA_SHM_NAME_MAX	   (256)
 
 extern int efa_mr_cache_enable;
 extern size_t efa_mr_max_cached_count;

--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -36,7 +36,6 @@
 #include <stdio.h>
 
 #include <infiniband/efadv.h>
-#include <ofi_shm.h>
 #include <ofi_enosys.h>
 
 #include "efa.h"
@@ -362,7 +361,7 @@ static
 int efa_conn_rdm_init(struct efa_av *av, struct efa_conn *conn)
 {
 	int err, ret;
-	char smr_name[SMR_NAME_MAX];
+	char smr_name[EFA_SHM_NAME_MAX];
 	struct rxr_ep *rxr_ep;
 	struct rdm_peer *peer;
 

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -37,7 +37,6 @@
 #include "ofi.h"
 #include <ofi_util.h>
 #include <ofi_iov.h>
-#include <ofi_shm.h>
 #include "rxr.h"
 #include "efa.h"
 #include "rxr_msg.h"
@@ -967,7 +966,7 @@ static int rxr_ep_ctrl(struct fid *fid, int command, void *arg)
 {
 	ssize_t ret;
 	struct rxr_ep *ep;
-	char shm_ep_name[SMR_NAME_MAX];
+	char shm_ep_name[EFA_SHM_NAME_MAX];
 
 	switch (command) {
 	case FI_ENABLE:

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -34,7 +34,6 @@
 #include <rdma/fi_errno.h>
 
 #include <ofi_prov.h>
-#include <ofi_shm.h>
 #include "rxr.h"
 #include "efa.h"
 #include "ofi_hmem.h"
@@ -200,9 +199,15 @@ int rxr_raw_addr_to_smr_name(void *ptr, char *smr_name)
 		return -errno;
 	}
 
-	ret = snprintf(smr_name, SMR_NAME_MAX, "%s_%04x_%08x_%04x",
+	ret = snprintf(smr_name, EFA_SHM_NAME_MAX, "%s_%04x_%08x_%04x",
 		       gidstr, raw_addr->qpn, raw_addr->qkey, getuid());
-	return (ret <= 0) ? ret : FI_SUCCESS;
+	if (ret <= 0)
+		return ret;
+
+	if (ret >= EFA_SHM_NAME_MAX)
+		return -FI_EINVAL;
+
+	return FI_SUCCESS;
 }
 
 void rxr_info_to_core_mr_modes(uint32_t version,


### PR DESCRIPTION
Currently, the function rxr_ep_addr_to_shm_name() and its
caller uses SHM_MAX_NAME to define the buffer size for the
shm endpoint name. This is unnecessary because the length
of shm endpoint name can be derived from the name format EFA
used.

This patch remove the usage of SHM_MAX_NAME and the inclusion
of ofi_shm.h in efa.

Signed-off-by: Wei Zhang <wzam@amazon.com>