### PR TITLE
prov/efa: fix a bug in rxr_ep_wait_send

### DIFF
--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -814,7 +814,7 @@ int rxr_ep_wait_send(struct rxr_ep *rxr_ep, int max_wait_time)
 		rxr_ep_progress_internal(rxr_ep);
 	}
 
-	finished = rxr_ep_has_unfinished_send(rxr_ep);
+	finished = !rxr_ep_has_unfinished_send(rxr_ep);
 	fastlock_release(&rxr_ep->util_ep.lock);
 
 	return finished ? 0 : -FI_ETIMEDOUT;


### PR DESCRIPTION
In rxr_ep_wait_send(), "finished" should be

    !rxr_ep_has_unfinished_send(rxr_ep)

. However, the "!" was missing, which caused wrong
warning message to printed

This patch fixed the issue

Signed-off-by: Wei Zhang <wzam@amazon.com>