### PR TITLE
[v1.13.x] prov/efa: update TX counter for inject

### DIFF
--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -335,6 +335,10 @@ ssize_t rxr_pkt_post_ctrl_once(struct rxr_ep *rxr_ep, int entry_type, void *x_en
 		return err;
 	}
 
+	/* If the send (or inject) succeeded, the function rxr_pkt_entry_send
+	 * (or rxr_pkt_entry_inject) will increase the counter in rxr_ep that
+	 * tracks number of outstanding TX ops.
+	 */
 	if (inject)
 		err = rxr_pkt_entry_inject(rxr_ep, pkt_entry, addr);
 	else
@@ -350,7 +354,8 @@ ssize_t rxr_pkt_post_ctrl_once(struct rxr_ep *rxr_ep, int entry_type, void *x_en
 
 	/* If injection succeeded, packet should be considered as sent completed.
 	 * therefore call rxr_pkt_handle_send_completion().
-	 * rxr_pkt_handle_send_completion() will release pkt_entry
+	 * rxr_pkt_handle_send_completion() will release pkt_entry and decrease
+	 * the counter in rxr_ep that tracks number of outstanding TX ops.
 	 */
 	if (inject)
 		rxr_pkt_handle_send_completion(rxr_ep, pkt_entry);


### PR DESCRIPTION
The function rxr_ep_record_tx_op_submitted() should be called for
any TX operations that has successfully submitted to update TX
related counters. However, it is not called for inject operations,
which are also TX operations.

This patch address the issue by calling rxr_ep_record_tx_op_submitted()
in function rxr_pkt_entry_inject().

Signed-off-by: Wei Zhang <wzam@amazon.com>
(cherry picked from commit 0d9b632d3d47a2784c119ff59c453a152760df8c)