### PR TITLE
prov/verbs: Fix compilation error with anonymous union member initialization

### DIFF
--- a/prov/verbs/src/verbs_dgram_ep_msg.c
+++ b/prov/verbs/src/verbs_dgram_ep_msg.c
@@ -162,9 +162,10 @@ vrb_dgram_ep_senddata(struct fid_ep *ep_fid, const void *buf,
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP(ep, (uintptr_t)context),
 		.opcode = IBV_WR_SEND_WITH_IMM,
-		.imm_data = htonl((uint32_t)data),
 		.send_flags = VERBS_INJECT(ep, len, desc),
 	};
+
+	wr.imm_data = htonl((uint32_t)data);
 
 	if (vrb_dgram_ep_set_addr(ep, dest_addr, &wr))
 		return -FI_ENOENT;
@@ -181,9 +182,10 @@ vrb_dgram_ep_injectdata(struct fid_ep *ep_fid, const void *buf, size_t len,
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_NO_COMP_FLAG,
 		.opcode = IBV_WR_SEND_WITH_IMM,
-		.imm_data = htonl((uint32_t)data),
 		.send_flags = IBV_SEND_INLINE,
 	};
+
+	wr.imm_data = htonl((uint32_t)data);
 
 	if (vrb_dgram_ep_set_addr(ep, dest_addr, &wr))
 		return -FI_ENOENT;

--- a/prov/verbs/src/verbs_msg.c
+++ b/prov/verbs/src/verbs_msg.c
@@ -127,9 +127,10 @@ vrb_msg_ep_senddata(struct fid_ep *ep_fid, const void *buf, size_t len,
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP(ep, (uintptr_t)context),
 		.opcode = IBV_WR_SEND_WITH_IMM,
-		.imm_data = htonl((uint32_t)data),
 		.send_flags = VERBS_INJECT(ep, len, desc),
 	};
+
+	wr.imm_data = htonl((uint32_t)data);
 
 	return vrb_send_buf(ep, &wr, buf, len, desc);
 }
@@ -171,9 +172,10 @@ static ssize_t vrb_msg_ep_injectdata(struct fid_ep *ep_fid, const void *buf, siz
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_NO_COMP_FLAG,
 		.opcode = IBV_WR_SEND_WITH_IMM,
-		.imm_data = htonl((uint32_t)data),
 		.send_flags = IBV_SEND_INLINE,
 	};
+
+	wr.imm_data = htonl((uint32_t)data);
 
 	return vrb_send_buf(ep, &wr, buf, len, NULL);
 }
@@ -283,9 +285,10 @@ vrb_msg_xrc_ep_senddata(struct fid_ep *ep_fid, const void *buf, size_t len,
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP(&ep->base_ep, (uintptr_t)context),
 		.opcode = IBV_WR_SEND_WITH_IMM,
-		.imm_data = htonl((uint32_t)data),
 		.send_flags = VERBS_INJECT(&ep->base_ep, len, desc),
 	};
+
+	wr.imm_data = htonl((uint32_t)data);
 
 	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 
@@ -333,9 +336,10 @@ static ssize_t vrb_msg_xrc_ep_injectdata(struct fid_ep *ep_fid, const void *buf,
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_NO_COMP_FLAG,
 		.opcode = IBV_WR_SEND_WITH_IMM,
-		.imm_data = htonl((uint32_t)data),
 		.send_flags = IBV_SEND_INLINE,
 	};
+
+	wr.imm_data = htonl((uint32_t)data);
 
 	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 

--- a/prov/verbs/src/verbs_rma.c
+++ b/prov/verbs/src/verbs_rma.c
@@ -167,11 +167,12 @@ vrb_msg_ep_rma_writedata(struct fid_ep *ep_fid, const void *buf, size_t len,
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP(ep, (uintptr_t)context),
 		.opcode = IBV_WR_RDMA_WRITE_WITH_IMM,
-		.imm_data = htonl((uint32_t)data),
 		.wr.rdma.remote_addr = addr,
 		.wr.rdma.rkey = (uint32_t)key,
 		.send_flags = VERBS_INJECT(ep, len, desc),
 	};
+
+	wr.imm_data = htonl((uint32_t)data);
 
 	return vrb_send_buf(ep, &wr, buf, len, desc);
 }
@@ -220,11 +221,12 @@ vrb_msg_ep_rma_inject_writedata(struct fid_ep *ep_fid, const void *buf, size_t l
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_NO_COMP_FLAG,
 		.opcode = IBV_WR_RDMA_WRITE_WITH_IMM,
-		.imm_data = htonl((uint32_t)data),
 		.wr.rdma.remote_addr = addr,
 		.wr.rdma.rkey = (uint32_t)key,
 		.send_flags = IBV_SEND_INLINE,
 	};
+
+	wr.imm_data = htonl((uint32_t)data);
 
 	return vrb_send_buf(ep, &wr, buf, len, NULL);
 }
@@ -413,11 +415,12 @@ vrb_msg_xrc_ep_rma_writedata(struct fid_ep *ep_fid, const void *buf,
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP(&ep->base_ep, (uintptr_t)context),
 		.opcode = IBV_WR_RDMA_WRITE_WITH_IMM,
-		.imm_data = htonl((uint32_t)data),
 		.wr.rdma.remote_addr = addr,
 		.wr.rdma.rkey = (uint32_t)key,
 		.send_flags = VERBS_INJECT(&ep->base_ep, len, desc),
 	};
+
+	wr.imm_data = htonl((uint32_t)data);
 
 	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 
@@ -471,11 +474,12 @@ vrb_msg_xrc_ep_rma_inject_writedata(struct fid_ep *ep_fid,
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_NO_COMP_FLAG,
 		.opcode = IBV_WR_RDMA_WRITE_WITH_IMM,
-		.imm_data = htonl((uint32_t)data),
 		.wr.rdma.remote_addr = addr,
 		.wr.rdma.rkey = (uint32_t)key,
 		.send_flags = IBV_SEND_INLINE,
 	};
+
+	wr.imm_data = htonl((uint32_t)data);
 
 	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 


### PR DESCRIPTION
Intel compiler 2018.3.222 generates errors when compiling verbs provider with
rdma-core 34.1:

prov/verbs/src/verbs_rma.c(170): error: a designator for an anonymous union
member can only appear within braces corresponding to that anonymous union
                .imm_data = htonl((uint32_t)data)

It's a compiler specific limitation. Change to use assignment statement for
better compatibility.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>