### PR TITLE
prov/rxm: Add hmem initialization for DL build

### DIFF
--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -427,6 +427,7 @@ static int rxm_getinfo(uint32_t version, const char *node, const char *service,
 static void rxm_fini(void)
 {
 #if HAVE_RXM_DL
+	ofi_hmem_fini();
 	ofi_mem_fini();
 #endif
 }
@@ -584,6 +585,7 @@ RXM_INI
 
 #if HAVE_RXM_DL
 	ofi_mem_init();
+	ofi_hmem_init();
 #endif
 
 	return &rxm_prov;


### PR DESCRIPTION
The rxm provider uses hmem ops for buffer copying, etc. When built
as a DL provider, ofi_hmem_init()/ofi_hmem_fini() should be called.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>