### PR TITLE
fabric: Sort DL providers in the same directory

### DIFF
--- a/src/fabric.c
+++ b/src/fabric.c
@@ -624,7 +624,7 @@ static void ofi_ini_dir(const char *dir)
 	char *lib;
 	struct dirent **liblist = NULL;
 
-	n = scandir(dir, &liblist, lib_filter, NULL);
+	n = scandir(dir, &liblist, lib_filter, alphasort);
 	if (n < 0)
 		goto libdl_done;
 


### PR DESCRIPTION
When loading DL providers from a directory, sort the entries in
alphabeta order so that the order of the providers being loaded
can be controlled by tweaking the file names.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>