### PR TITLE
prov/efa: Fix a bug in data packet send path and some refactors

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -474,7 +474,6 @@ struct rxr_tx_entry {
 	uint64_t fi_flags;
 	uint64_t rxr_flags;
 
-	uint64_t send_flags;
 	size_t iov_count;
 	size_t iov_index;
 	size_t iov_offset;

--- a/prov/efa/src/rxr/rxr_atomic.c
+++ b/prov/efa/src/rxr/rxr_atomic.c
@@ -196,6 +196,7 @@ ssize_t rxr_atomic_generic_efa(struct rxr_ep *rxr_ep,
 		err = rxr_pkt_post_ctrl(rxr_ep, RXR_TX_ENTRY,
 					tx_entry,
 					RXR_DC_WRITE_RTA_PKT,
+					0,
 					0);
 	} else {
 		/*
@@ -206,6 +207,7 @@ ssize_t rxr_atomic_generic_efa(struct rxr_ep *rxr_ep,
 		err = rxr_pkt_post_ctrl(rxr_ep, RXR_TX_ENTRY,
 					tx_entry,
 					req_pkt_type_list[op],
+					0,
 					0);
 	}
 

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -77,7 +77,7 @@ ssize_t rxr_msg_post_cuda_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_ent
 	if (tx_entry->total_len == 0) {
 		pkt_type = delivery_complete_requested ? RXR_DC_EAGER_MSGRTM_PKT : RXR_EAGER_MSGRTM_PKT;
 		return rxr_pkt_post_ctrl(rxr_ep, RXR_TX_ENTRY, tx_entry,
-					 pkt_type + tagged, 0);
+					 pkt_type + tagged, 0, 0);
 	}
 
 	/* Currently cuda data must be sent using read message protocol.
@@ -102,7 +102,7 @@ ssize_t rxr_msg_post_cuda_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_ent
 	}
 
 	return rxr_pkt_post_ctrl(rxr_ep, RXR_TX_ENTRY, tx_entry,
-				 RXR_LONGREAD_MSGRTM_PKT + tagged, 0);
+				 RXR_LONGREAD_MSGRTM_PKT + tagged, 0, 0);
 }
 
 ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
@@ -200,7 +200,7 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 		else
 			ctrl_type = delivery_complete_requested ? RXR_DC_EAGER_MSGRTM_PKT : RXR_EAGER_MSGRTM_PKT;
 
-		return rxr_pkt_post_ctrl(rxr_ep, RXR_TX_ENTRY, tx_entry, ctrl_type + tagged, 0);
+		return rxr_pkt_post_ctrl(rxr_ep, RXR_TX_ENTRY, tx_entry, ctrl_type + tagged, 0, 0);
 	}
 
 	if (efa_ep_is_cuda_mr(tx_entry->desc[0])) {
@@ -212,7 +212,7 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 		ctrl_type = (delivery_complete_requested) ?
 			RXR_DC_EAGER_MSGRTM_PKT : RXR_EAGER_MSGRTM_PKT;
 		return rxr_pkt_post_ctrl(rxr_ep, RXR_TX_ENTRY, tx_entry,
-					 ctrl_type + tagged, 0);
+					 ctrl_type + tagged, 0, 0);
 	}
 
 	if (tx_entry->total_len <= rxr_env.efa_max_medium_msg_size) {
@@ -238,7 +238,7 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 	    (tx_entry->desc[0] || efa_is_cache_available(efa_domain))) {
 		/* Read message support FI_DELIVERY_COMPLETE implicitly. */
 		err = rxr_pkt_post_ctrl(rxr_ep, RXR_TX_ENTRY, tx_entry,
-					RXR_LONGREAD_MSGRTM_PKT + tagged, 0);
+					RXR_LONGREAD_MSGRTM_PKT + tagged, 0, 0);
 
 		if (err != -FI_ENOMEM)
 			return err;
@@ -256,7 +256,7 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 	ctrl_type = delivery_complete_requested ? RXR_DC_LONGCTS_MSGRTM_PKT : RXR_LONGCTS_MSGRTM_PKT;
 	tx_entry->rxr_flags |= RXR_LONGCTS_PROTOCOL;
 	return rxr_pkt_post_ctrl(rxr_ep, RXR_TX_ENTRY, tx_entry,
-				 ctrl_type + tagged, 0);
+				 ctrl_type + tagged, 0, 0);
 }
 
 ssize_t rxr_msg_generic_send(struct fid_ep *ep, const struct fi_msg *msg,

--- a/prov/efa/src/rxr/rxr_pkt_cmd.h
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.h
@@ -37,7 +37,7 @@
 #include "rxr.h"
 
 ssize_t rxr_pkt_post_ctrl(struct rxr_ep *ep, int entry_type, void *x_entry,
-			  int ctrl_type, bool inject);
+			  int ctrl_type, bool inject, uint64_t flags);
 
 ssize_t rxr_pkt_post_ctrl_or_queue(struct rxr_ep *ep, int entry_type, void *x_entry,
 				   int ctrl_type, bool inject);

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -263,7 +263,7 @@ ssize_t rxr_rma_post_efa_emulated_read(struct rxr_ep *ep, struct rxr_tx_entry *t
 	tx_entry->rma_loc_rx_id = rx_entry->rx_id;
 
 	if (tx_entry->total_len < ep->mtu_size - sizeof(struct rxr_readrsp_hdr)) {
-		err = rxr_pkt_post_ctrl(ep, RXR_TX_ENTRY, tx_entry, RXR_SHORT_RTR_PKT, 0);
+		err = rxr_pkt_post_ctrl(ep, RXR_TX_ENTRY, tx_entry, RXR_SHORT_RTR_PKT, 0, 0);
 	} else {
 		peer = rxr_ep_get_peer(ep, tx_entry->addr);
 		assert(peer);
@@ -277,7 +277,7 @@ ssize_t rxr_rma_post_efa_emulated_read(struct rxr_ep *ep, struct rxr_tx_entry *t
 		rx_entry->window = window;
 		rx_entry->credit_cts = credits;
 		tx_entry->rma_window = rx_entry->window;
-		err = rxr_pkt_post_ctrl(ep, RXR_TX_ENTRY, tx_entry, RXR_LONGCTS_RTR_PKT, 0);
+		err = rxr_pkt_post_ctrl(ep, RXR_TX_ENTRY, tx_entry, RXR_LONGCTS_RTR_PKT, 0, 0);
 	}
 
 	if (OFI_UNLIKELY(err)) {
@@ -459,13 +459,13 @@ ssize_t rxr_rma_post_write(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry)
 	if (tx_entry->total_len < max_rtm_data_size) {
 		ctrl_type = delivery_complete_requested ?
 			RXR_DC_EAGER_RTW_PKT : RXR_EAGER_RTW_PKT;
-		return rxr_pkt_post_ctrl(ep, RXR_TX_ENTRY, tx_entry, ctrl_type, 0);
+		return rxr_pkt_post_ctrl(ep, RXR_TX_ENTRY, tx_entry, ctrl_type, 0, 0);
 	}
 
 	if (tx_entry->total_len >= rxr_env.efa_min_read_write_size &&
 	    efa_both_support_rdma_read(ep, peer) &&
 	    (tx_entry->desc[0] || efa_is_cache_available(efa_domain))) {
-		err = rxr_pkt_post_ctrl(ep, RXR_TX_ENTRY, tx_entry, RXR_LONGREAD_RTW_PKT, 0);
+		err = rxr_pkt_post_ctrl(ep, RXR_TX_ENTRY, tx_entry, RXR_LONGREAD_RTW_PKT, 0, 0);
 		if (err != -FI_ENOMEM)
 			return err;
 		/*
@@ -481,7 +481,7 @@ ssize_t rxr_rma_post_write(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry)
 	ctrl_type = delivery_complete_requested ?
 		RXR_DC_LONGCTS_RTW_PKT : RXR_LONGCTS_RTW_PKT;
 	tx_entry->rxr_flags |= RXR_LONGCTS_PROTOCOL;
-	return rxr_pkt_post_ctrl(ep, RXR_TX_ENTRY, tx_entry, ctrl_type, 0);
+	return rxr_pkt_post_ctrl(ep, RXR_TX_ENTRY, tx_entry, ctrl_type, 0, 0);
 }
 
 ssize_t rxr_rma_writemsg(struct fid_ep *ep,


### PR DESCRIPTION
Currently, data packet are sent via `rxr_pkt_post_ctrl`, which call
rxr_pkt_entry_send with flags as 0. This is wrong because data packets
could be sent with FI_MORE to batch several sendings together and
improve performance. This patch fixes this issue and does some refactors:

1. Add flags as an argument of `rxr_pkt_post_ctrl` and let caller specify
the flags like FI_MORE directly.
2. Pass flags to `rxr_pkt_entry_send` correctly inside `rxr_pkt_post_ctrl_once`.
3. Remove the send_flags from `tx_entry`. It's not necessary to bind this flags
with a tx_entry as it's only used to define the additional flags for each pkt
send operations via `rxr_pkt_entry_send()`.


Test:
1. multi-node and single-node fabtests with efa provider
2. OMB pt2pt tests.
3. 32 c5n.18xlarge tests with OMB, IMB, HPCG, Lammps, WRF, OpenFOAM.