### PR TITLE
fabtests: Add EFA-specific RNR retry test

### DIFF
--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -437,7 +437,8 @@ dummy_man_pages = \
 	man/man1/fi_mr_test.1 \
 	man/man1/fi_bw.1 \
 	man/man1/fi_rdm_multi_client.1 \
-	man/man1/fi_ubertest.1
+	man/man1/fi_ubertest.1 \
+	man/man1/fi_efa_ep_rnr_retry.1
 
 nroff:
 	@for file in $(real_man_pages); do \

--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -445,6 +445,7 @@ nroff:
             perl $(top_srcdir)/config/md2nroff.pl --source=$(top_srcdir)/$$source.md; \
         done
 
+include prov/efa/Makefile.include
 
 man_MANS = $(real_man_pages) $(dummy_man_pages)
 

--- a/fabtests/man/fabtests.7.md
+++ b/fabtests/man/fabtests.7.md
@@ -246,6 +246,19 @@ provider.  Example test configurations are at test_configs.
   values and 2 having 3 possible values, ubertest will execute 576 total
   iterations of each test.
 
+# EFA provider specific tests
+
+Beyond libfabric defined functionalities, EFA provider defines its
+specific features/functionalities. These EFA provider specific fabtests
+show users how to correctly use them.
+
+*fi_efa_ep_rnr_retry*
+: Tests modifying the RNR retry count (rnr_retry) via fi_setopt, and
+  then runs a simple program to test if the error cq entry (with error
+  FI_ENORX) can be written to application, if RNR happens.
+  Use `-R` option to specify RNR retry count. The valid values are 0-7,
+  where 7 indicates infinite retry on firmware.
+
 ### Config file options
 
 The following keys and respective key values may be used in the config file.

--- a/fabtests/man/man1/fi_efa_ep_rnr_retry.1
+++ b/fabtests/man/man1/fi_efa_ep_rnr_retry.1
@@ -1,0 +1,1 @@
+.so man7/fabtests.7

--- a/fabtests/prov/efa/Makefile.include
+++ b/fabtests/prov/efa/Makefile.include
@@ -1,0 +1,36 @@
+#
+# Copyright (c) 2021 Amazon.com, Inc. or its affiliates. All rights reserved.
+#
+# This software is available to you under a choice of one of two
+# licenses.  You may choose to be licensed under the terms of the GNU
+# General Public License (GPL) Version 2, available from the file
+# COPYING in the main directory of this source tree, or the
+# BSD license below:
+#
+#     Redistribution and use in source and binary forms, with or
+#     without modification, are permitted provided that the following
+#     conditions are met:
+#
+#      - Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      - Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials
+#        provided with the distribution.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+bin_PROGRAMS += prov/efa/src/fi_efa_ep_rnr_retry
+
+prov_efa_src_fi_efa_ep_rnr_retry_SOURCES = prov/efa/src/rdm_ep_rnr_retry.c
+prov_efa_src_fi_efa_ep_rnr_retry_LDADD =  libfabtests.la

--- a/fabtests/prov/efa/src/rdm_ep_rnr_retry.c
+++ b/fabtests/prov/efa/src/rdm_ep_rnr_retry.c
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2021, Amazon.com, Inc.  All rights reserved.
+ *
+ * This software is available to you under the BSD license
+ * below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * This program tests the RNR retry counter reset via fi_setopt.
+ * When running the test, use `-R` option to specify RNR retry counter.
+ * The valid values are 0 - 7 (7 inidicates infinite retry on firmware).
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <getopt.h>
+
+#include <shared.h>
+#include <rdma/fi_cm.h>
+#include <rdma/fi_ext.h>
+
+static int poll_rnr_cq_error(void)
+{
+	struct fi_cq_data_entry comp;
+	struct fi_cq_err_entry comp_err;
+	int total_send, expected_rnr_error;
+	int ret, i, cnt, rnr_flag;
+
+	rnr_flag = 0;
+	expected_rnr_error = 1;
+	/*
+	 * In order for the sender to get RNR error, we need to first consume
+	 * all pre-posted receive buffer (in efa provider, fi->rx_attr->size
+	 * receiving buffer are pre-posted) on the receiver side, the subsequent
+	 * sends (expected_rnr_error) will then get RNR errors.
+	 */
+	total_send = fi->rx_attr->size + expected_rnr_error;
+
+	for (i = 0; i < total_send; i++) {
+		do {
+			ret = fi_send(ep, tx_buf, 32, mr_desc, remote_fi_addr, &tx_ctx);
+			if (ret < 0 && ret != -FI_EAGAIN) {
+				FT_PRINTERR("fi_send", -ret);
+				return ret;
+			}
+		} while (ret == -FI_EAGAIN);
+	}
+
+	cnt = total_send;
+	do {
+		ret = fi_cq_read(txcq, &comp, 1);
+		if (ret == 1) {
+			cnt--;
+		} else if (ret == -FI_EAVAIL) {
+			ret = fi_cq_readerr(txcq, &comp_err, FI_SEND);
+			if (ret < 0 && ret != -FI_EAGAIN) {
+				FT_PRINTERR("fi_cq_readerr", -ret);
+				return ret;
+			} else if (ret == 1) {
+				cnt--;
+				if (comp_err.err == FI_ENORX) {
+					rnr_flag = 1;
+					printf("Got RNR error CQ entry as expected: %d, %s\n",
+						comp_err.err, fi_strerror(comp_err.err));
+				} else {
+					printf("Got non-RNR error CQ entry: %d, %s\n",
+						comp_err.err, fi_strerror(comp_err.err));
+					return comp_err.err;
+				}
+			}
+		} else if (ret < 0 && ret != -FI_EAGAIN) {
+			FT_PRINTERR("fi_cq_read", -ret);
+			return ret;
+		}
+	} while (cnt);
+
+	return (rnr_flag) ? 0 : -FI_EINVAL;
+}
+
+static int run(size_t rnr_retry)
+{
+	int ret;
+
+	ret = ft_init();
+	if (ret) {
+		FT_PRINTERR("ft_init", -ret);
+		return ret;
+	}
+
+	ret = ft_init_oob();
+	if (ret) {
+		FT_PRINTERR("ft_init_oob", -ret);
+		return ret;
+	}
+
+	ret = ft_getinfo(hints, &fi);
+	if (ret) {
+		FT_PRINTERR("ft_getinfo", -ret);
+		return ret;
+	}
+
+	ret = ft_open_fabric_res();
+	if (ret) {
+		FT_PRINTERR("ft_open_fabric_res", -ret);
+		return ret;
+	}
+
+	ret = ft_alloc_active_res(fi);
+	if (ret) {
+		FT_PRINTERR("ft_alloc_active_res", -ret);
+		return ret;
+	}
+
+	fprintf(stdout, "Setting RNR retry count to %zu ...\n", rnr_retry);
+	ret = fi_setopt(&ep->fid, FI_OPT_ENDPOINT, FI_OPT_EFA_RNR_RETRY, &rnr_retry, sizeof(rnr_retry));
+	if (ret) {
+		FT_PRINTERR("fi_setopt", -ret);
+		return ret;
+	}
+	fprintf(stdout, "RNR retry count has been set to %zu.\n", rnr_retry);
+
+	ret = ft_enable_ep(ep, eq, av, txcq, rxcq, txcntr, rxcntr);
+	if (ret) {
+		FT_PRINTERR("ft_enable_ep_recv", -ret);
+		return ret;
+	}
+
+	ret = ft_init_av();
+	if (ret) {
+		FT_PRINTERR("ft_init_av", -ret);
+		return ret;
+	}
+	/* client does fi_send and then poll CQ to get error (FI_ENORX) CQ entry */
+	if (opts.dst_addr) {
+		ret = poll_rnr_cq_error();
+		if (ret) {
+			FT_PRINTERR("pingpong", -ret);
+			return ret;
+		}
+	}
+
+	/*
+	 * To get RNR error on the client side, the server should not close its
+	 * endpoint while the client is still sending.
+	 * ft_reset_oob() will re-initialize OOB sync between server and client.
+	 * Calling it here to ensure the client has finished the sending.
+	 * And both server and client are ready to close endpoint and free resources.
+	 */
+	ret = ft_reset_oob();
+	if (ret) {
+		FT_PRINTERR("ft_reset_oob", -ret);
+		return ret;
+	}
+	ret = ft_close_oob();
+	if (ret) {
+		FT_PRINTERR("ft_close_oob", -ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+static void print_opts_usage(char *name, char *desc)
+{
+	ft_usage(name, desc);
+	/* rdm_ep_rnr_retry test usage */
+	FT_PRINT_OPTS_USAGE("-R <number>", "RNR retry count (valid values: 0-7, default: 1)");
+}
+
+int main(int argc, char **argv)
+{
+	int op, ret;
+	size_t rnr_retry;
+
+	rnr_retry = 1;
+	opts = INIT_OPTS;
+	opts.options |= FT_OPT_SIZE;
+
+	hints = fi_allocinfo();
+	if (!hints)
+		return EXIT_FAILURE;
+
+	while ((op = getopt(argc, argv, "R:h" ADDR_OPTS INFO_OPTS CS_OPTS)) != -1) {
+		switch (op) {
+		default:
+			ft_parse_addr_opts(op, optarg, &opts);
+			ft_parseinfo(op, optarg, hints, &opts);
+			ft_parsecsopts(op, optarg, &opts);
+			break;
+		case 'R':
+			rnr_retry = atoi(optarg);
+			if (rnr_retry > 7) {
+				fprintf(stdout, "RNR retry count invalid, it must be 0-7.\n");
+				return EXIT_FAILURE;
+			}
+			break;
+		case '?':
+		case 'h':
+			print_opts_usage(argv[0], "RDM RNR retry counter reset test");
+			return EXIT_FAILURE;
+		}
+	}
+
+	if (optind < argc)
+		opts.dst_addr = argv[optind];
+
+	hints->ep_attr->type = FI_EP_RDM;
+	hints->caps = FI_MSG;
+	hints->mode |= FI_CONTEXT;
+	hints->domain_attr->mr_mode = opts.mr_mode;
+	/*
+	 * FI_RM_DISABLED is required to be set in order for the RNR error CQ entry
+	 * to be written to applications. Otherwise, the packet (failed with RNR error)
+	 * will be queued and resent.
+	 */
+	hints->domain_attr->resource_mgmt = FI_RM_DISABLED;
+
+	ret = run(rnr_retry);
+	if (ret)
+		FT_PRINTERR("run", -ret);
+
+	ft_free_res();
+	return ft_exit_code(ret);
+}

--- a/fabtests/scripts/runfabtests.sh
+++ b/fabtests/scripts/runfabtests.sh
@@ -61,6 +61,7 @@ declare FORK=0
 declare OOB=0
 declare C_ARGS=""
 declare S_ARGS=""
+declare PROVIDER_TESTS=0
 
 declare cur_excludes=""
 declare file_excludes=""
@@ -235,6 +236,10 @@ multinode_tests=(
 	"fi_multinode -C msg"
 	"fi_multinode -C rma"
 	"fi_multinode_coll"
+)
+
+prov_efa_tests=( \
+	"FI_EFA_ENABLE_SHM_TRANSFER=0 fi_efa_ep_rnr_retry -R 0"
 )
 
 function errcho {
@@ -692,6 +697,12 @@ function multinode_test {
 	fi
 }
 
+function prov_efa_test {
+	for test in "${prov_efa_tests[@]}"; do
+		cs_test "$test"
+	done
+}
+
 function set_core_util {
 	prov_arr=$(echo $PROV | tr ";" " ")
 	CORE=""
@@ -777,6 +788,10 @@ function main {
 	esac
 	done
 
+	if [[ $PROVIDER_TESTS -eq 1 ]]; then
+		prov_${PROV}_test
+	fi
+
 	total=$(( $pass_count + $fail_count ))
 
 	print_border
@@ -825,10 +840,11 @@ function usage {
 	errcho -e " -C\tAdditional client test arguments: Parameters to pass to client fabtests"
 	errcho -e " -L\tAdditional server test arguments: Parameters to pass to server fabtests"
 	errcho -e " -b\tenable out-of-band address exchange over the default port"
+	errcho -e " -P\tRun provider specific tests"
 	exit 1
 }
 
-while getopts ":vt:p:g:e:f:c:s:u:T:C:L:NRSbkE:" opt; do
+while getopts ":vt:p:g:e:f:c:s:u:T:C:L:NRSbkPE:" opt; do
 case ${opt} in
 	t) TEST_TYPE=$OPTARG
 	;;
@@ -852,6 +868,8 @@ case ${opt} in
 	T) TIMEOUT_VAL=${OPTARG}
 	;;
 	N) SKIP_NEG+=1
+	;;
+	P) PROVIDER_TESTS=1
 	;;
 	R)
 	;;


### PR DESCRIPTION
This PR adds efa provider specific test `fi_efa_ep_rnr_retry` to test RNR retry count reset via fi_setopt.

It includes the following change  
1. Add efa specific test rdm_ep_rnr_retry.c.
This test resets the RNR retry count via fi_setopt, and then runs a simple program to test if the error cq entry (with error FI_ENORX) can be written to application, if RNR happens. To build the test, also add efa specific Makefile bits in fabtests/prov/efa/Makefile.include, which is included in the top level fabtests/Makefile.am.
2. Update man page for efa specific test
3. Modify runfabtests.sh to run efa provider specific test. Use -P to enable the run.


Testing:
Server:
```
[ec2-user@ip-172-31-41-93 ~]$ FI_EFA_ENABLE_SHM_TRANSFER=0  fi_efa_ep_rnr_retry -p "efa" -R 0  -E
Setting RNR retry count to 0 ...
RNR retry count has been set to 0.
```
Client:
```
[ec2-user@ip-172-31-41-93 ~]$ FI_EFA_ENABLE_SHM_TRANSFER=0  fi_efa_ep_rnr_retry -p "efa" -R 0  -E 127.0.0.1
Setting RNR retry count to 0 ...
RNR retry count has been set to 0.
Got RNR error CQ entry as expected: 269, Receiver not ready, no receive buffers available
```

Run with runfabtests.sh
```
[ec2-user@ip-172-31-41-93 ~]$ /home/ec2-user/libfabric/fabtests/install/bin/runfabtests.sh -E  -vvv -R -f /home/ec2-user/libfabric/fabtests/install/share/fabtests/test_configs/efa/efa.exclude -b -P -t unit efa 172.31.41.93 172.31.41.93
# Test                                                                    Result
# ------------------------------------------------------------------------------
fi_getinfo_test -s 172.31.41.93 172.31.41.93 -p "efa":                      Pass
fi_av_test -g 172.31.41.93 -n 1 -s 172.31.41.93 -p "efa":                 Notrun
fi_dom_test -n 2 -p "efa":                                                  Pass
fi_eq_test -p "efa":                                                        Pass
fi_cq_test -p "efa":                                                        Pass
fi_mr_test -p "efa":                                                        Pass
fi_cntr_test -p "efa":                                                      Pass
fi_dgram g00n13s -p "efa":                                                  Pass
fi_rdm g00n13s -p "efa":                                                    Pass
fi_msg g00n13s -p "efa":                                                Excluded
FI_EFA_ENABLE_SHM_TRANSFER=0 fi_efa_ep_rnr_retry -R 0 -p "efa":             Pass
# ------------------------------------------------------------------------------
# Total Pass                                                 9
# Total Notrun/Excluded                                      2
# Total Fail                                                 0
# Percentage of Pass                                       100
# ------------------------------------------------------------------------------
```



