### PR TITLE
prov/rxm: Fix multi-threaded access to AV structures

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -268,6 +268,7 @@ struct rxm_domain {
 
 int rxm_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 		struct fid_av **fid_av, void *context);
+size_t rxm_av_max_peers(struct rxm_av *av);
 
 struct rxm_mr {
 	struct fid_mr mr_fid;

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -269,6 +269,8 @@ struct rxm_domain {
 int rxm_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 		struct fid_av **fid_av, void *context);
 size_t rxm_av_max_peers(struct rxm_av *av);
+struct rxm_conn *rxm_av_alloc_conn(struct rxm_av *av);
+void rxm_av_free_conn(struct rxm_conn *conn);
 
 struct rxm_mr {
 	struct fid_mr mr_fid;

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -269,6 +269,7 @@ struct rxm_domain {
 int rxm_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 		struct fid_av **fid_av, void *context);
 size_t rxm_av_max_peers(struct rxm_av *av);
+void rxm_ref_peer(struct rxm_peer_addr *peer);
 struct rxm_conn *rxm_av_alloc_conn(struct rxm_av *av);
 void rxm_av_free_conn(struct rxm_conn *conn);
 

--- a/prov/rxm/src/rxm_av.c
+++ b/prov/rxm/src/rxm_av.c
@@ -131,6 +131,13 @@ void rxm_put_peer(struct rxm_peer_addr *peer)
 	fastlock_release(&av->util_av.lock);
 }
 
+void rxm_ref_peer(struct rxm_peer_addr *peer)
+{
+	fastlock_acquire(&peer->av->util_av.lock);
+	peer->refcnt++;
+	fastlock_release(&peer->av->util_av.lock);
+}
+
 static void
 rxm_set_av_context(struct rxm_av *av, fi_addr_t fi_addr,
 		   struct rxm_peer_addr *peer)

--- a/prov/rxm/src/rxm_av.c
+++ b/prov/rxm/src/rxm_av.c
@@ -45,6 +45,24 @@ size_t rxm_av_max_peers(struct rxm_av *av)
 	return cnt;
 }
 
+struct rxm_conn *rxm_av_alloc_conn(struct rxm_av *av)
+{
+	struct rxm_conn *conn;
+	fastlock_acquire(&av->util_av.lock);
+	conn = ofi_buf_alloc(av->conn_pool);
+	fastlock_release(&av->util_av.lock);
+	return conn;
+}
+
+void rxm_av_free_conn(struct rxm_conn *conn)
+{
+	struct rxm_av *av;
+	av = container_of(conn->ep->util_ep.av, struct rxm_av, util_av);
+	fastlock_acquire(&av->util_av.lock);
+	ofi_buf_free(conn);
+	fastlock_release(&av->util_av.lock);
+}
+
 static int rxm_addr_compare(struct ofi_rbmap *map, void *key, void *data)
 {
 	return memcmp(&((struct rxm_peer_addr *) data)->addr, key,

--- a/prov/rxm/src/rxm_av.c
+++ b/prov/rxm/src/rxm_av.c
@@ -35,6 +35,16 @@
 #include "rxm.h"
 
 
+size_t rxm_av_max_peers(struct rxm_av *av)
+{
+	size_t cnt;
+
+	fastlock_acquire(&av->util_av.lock);
+	cnt = av->peer_pool->entry_cnt;
+	fastlock_release(&av->util_av.lock);
+	return cnt;
+}
+
 static int rxm_addr_compare(struct ofi_rbmap *map, void *key, void *data)
 {
 	return memcmp(&((struct rxm_peer_addr *) data)->addr, key,

--- a/prov/rxm/src/rxm_av.c
+++ b/prov/rxm/src/rxm_av.c
@@ -46,6 +46,7 @@ rxm_alloc_peer(struct rxm_av *av, const void *addr)
 {
 	struct rxm_peer_addr *peer;
 
+	assert(fastlock_held(&av->util_av.lock));
 	peer = ofi_ibuf_alloc(av->peer_pool);
 	if (!peer)
 		return NULL;
@@ -66,6 +67,7 @@ rxm_alloc_peer(struct rxm_av *av, const void *addr)
 
 static void rxm_free_peer(struct rxm_peer_addr *peer)
 {
+	assert(fastlock_held(&peer->av->util_av.lock));
 	assert(!peer->refcnt);
 	ofi_rbmap_delete(&peer->av->addr_map, peer->node);
 	ofi_ibuf_free(peer);

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -270,7 +270,7 @@ static void rxm_free_conn(struct rxm_conn *conn)
 	if (conn->flags & RXM_CONN_INDEXED)
 		ofi_idm_clear(&conn->ep->conn_idx_map, conn->peer->index);
 
-	conn->peer->refcnt--;
+	rxm_put_peer(conn->peer);
 	ofi_buf_free(conn);
 }
 

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -271,7 +271,7 @@ static void rxm_free_conn(struct rxm_conn *conn)
 		ofi_idm_clear(&conn->ep->conn_idx_map, conn->peer->index);
 
 	rxm_put_peer(conn->peer);
-	ofi_buf_free(conn);
+	rxm_av_free_conn(conn);
 }
 
 void rxm_freeall_conns(struct rxm_ep *ep)
@@ -315,7 +315,7 @@ rxm_alloc_conn(struct rxm_ep *ep, struct rxm_peer_addr *peer)
 
 	assert(ofi_ep_lock_held(&ep->util_ep));
 	av = container_of(ep->util_ep.av, struct rxm_av, util_av);
-	conn = ofi_buf_alloc(av->conn_pool);
+	conn = rxm_av_alloc_conn(av);
 	if (!conn)
 		return NULL;
 

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -330,7 +330,7 @@ rxm_alloc_conn(struct rxm_ep *ep, struct rxm_peer_addr *peer)
 	dlist_init(&conn->loopback_entry);
 
 	conn->peer = peer;
-	peer->refcnt++;
+	rxm_ref_peer(peer);
 
 	FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "allocated conn %p\n", conn);
 	return conn;

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -279,13 +279,16 @@ void rxm_freeall_conns(struct rxm_ep *ep)
 	struct rxm_conn *conn;
 	struct dlist_entry *tmp;
 	struct rxm_av *av;
-	int i;
+	int i, cnt;
 
 	av = container_of(ep->util_ep.av, struct rxm_av, util_av);
 	ofi_ep_lock_acquire(&ep->util_ep);
 
-	/* We can't have more connections than known peers */
-	for (i = 0; i < av->peer_pool->entry_cnt; i++) {
+	/* We can't have more connections than the current number of
+	 * possible peers.
+	 */
+	cnt = (int) rxm_av_max_peers(av);
+	for (i = 0; i < cnt; i++) {
 		conn = ofi_idm_lookup(&ep->conn_idx_map, i);
 		if (!conn)
 			continue;

--- a/prov/verbs/src/verbs_cm.c
+++ b/prov/verbs/src/verbs_cm.c
@@ -306,12 +306,15 @@ vrb_msg_ep_reject(struct fid_pep *pep, fid_t handle,
 	vrb_msg_ep_prepare_cm_data(param, paramlen, cm_hdr);
 
 	fastlock_acquire(&_pep->eq->lock);
-	if (connreq->is_xrc)
+	if (connreq->is_xrc) {
 		ret = vrb_msg_xrc_ep_reject(connreq, cm_hdr,
 				(uint8_t)(sizeof(*cm_hdr) + paramlen));
-	else
+	} else if (connreq->id) {
 		ret = rdma_reject(connreq->id, cm_hdr,
 			(uint8_t)(sizeof(*cm_hdr) + paramlen)) ? -errno : 0;
+	} else {
+		ret = -FI_EBUSY;
+	}
 	fastlock_release(&_pep->eq->lock);
 
 	free(connreq);

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -1159,7 +1159,12 @@ int vrb_open_ep(struct fid_domain *domain, struct fi_info *info,
 						goto err1;
 				}
 			} else {
+				/* ep now owns this rdma cm id, prevent trying to access
+				 * it outside of ep operations to avoid possible use-after-
+				 * free bugs in case the ep is closed
+				 */
 				ep->id = connreq->id;
+				connreq->id = NULL;
 				ep->ibv_qp = ep->id->qp;
 				ep->id->context = &ep->util_ep.ep_fid.fid;
 			}


### PR DESCRIPTION
Fix for use-after-free in verbs provider handling fi_reject() after calling fi_endpoint() + fi_close(ep)

Added missing AV lock around AV data structures (addr_map, peer_pool, conn_pool) to avoid multi-threaded race issues.  AV problems could occur if there are multiple EPs bound to a single AV.

I am still analyzing serialization of the rxm_peer_addr structure when accessed via the rxm_conn structure.