### PR TITLE
prov/rxm: Correcting the setting of conn_id in rx pkt control header

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1538,7 +1538,7 @@ static void rxm_fake_rx_hdr(struct rxm_rx_buf *rx_buf,
 	OFI_DBG_SET(rx_buf->pkt.hdr.version, OFI_OP_VERSION);
 	OFI_DBG_SET(rx_buf->pkt.ctrl_hdr.version, RXM_CTRL_VERSION);
 	rx_buf->pkt.ctrl_hdr.type = rxm_ctrl_eager;
-	rx_buf->pkt.ctrl_hdr.conn_id = conn->remote_index;
+	rx_buf->pkt.ctrl_hdr.conn_id = conn->peer->index;
 	rx_buf->pkt.hdr.op = ofi_op_tagged;
 	rx_buf->pkt.hdr.tag = entry->tag;
 	rx_buf->pkt.hdr.size = entry->len;


### PR DESCRIPTION
In the rxm_fake_rx_hdr function the rx_buf->pkt.ctrl_hdr.conn_id was
being incorrectly set to conn->remote_index. Since this interface is used
by the receiving side to support tcp optimizations for small messages
this value should be updated with the peer->index. The peer->index
is used to fetch the appropriate connection. Using the remote index
causes the connection lookup to fail.

This patch provides fix for PR 6682.

Signed-off-by: Nikhil Nanal<nikhil.nanal@intel.com>