### PR TITLE
prov/efa: allow EFA SHM RX pkt pool to grow for unexp msgs

### DIFF
--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1395,8 +1395,7 @@ int rxr_ep_init(struct rxr_ep *ep)
 		ret = ofi_bufpool_create(&ep->shm_rx_pkt_pool,
 					 entry_sz,
 					 RXR_BUF_POOL_ALIGNMENT,
-					 shm_info->rx_attr->size,
-					 shm_info->rx_attr->size, 0);
+					 0, shm_info->rx_attr->size, 0);
 		if (ret)
 			goto err_free;
 

--- a/prov/efa/src/rxr/rxr_pkt_entry.h
+++ b/prov/efa/src/rxr/rxr_pkt_entry.h
@@ -42,14 +42,17 @@
 
 /* pkt_entry_alloc_type indicate where the packet entry is allocated from */
 enum rxr_pkt_entry_alloc_type {
-	RXR_PKT_FROM_EFA_TX_POOL = 1, /* packet is allcoated from ep->efa_tx_pkt_pool */
+	RXR_PKT_FROM_EFA_TX_POOL = 1, /* packet is allocated from ep->efa_tx_pkt_pool */
 	RXR_PKT_FROM_EFA_RX_POOL,     /* packet is allocated from ep->efa_rx_pkt_pool */
 	RXR_PKT_FROM_SHM_TX_POOL,     /* packet is allocated from ep->shm_tx_pkt_pool */
 	RXR_PKT_FROM_SHM_RX_POOL,     /* packet is allocated from ep->shm_rx_pkt_pool */
 	RXR_PKT_FROM_UNEXP_POOL,      /* packet is allocated from ep->rx_unexp_pkt_pool */
 	RXR_PKT_FROM_OOO_POOL,	      /* packet is allocated from ep->rx_ooo_pkt_pool */
-	RXR_PKT_FROM_USER_BUFFER,     /* packet is from user proivded buffer */
+	RXR_PKT_FROM_USER_BUFFER,     /* packet is from user provided buffer */
 	RXR_PKT_FROM_READ_COPY_POOL,  /* packet is allocated from ep->rx_readcopy_pkt_pool */
+	RXR_PKT_FROM_SHM_RX_POOL_UNEXP, /* from ep->shm_rx_pkt_pool, separate
+					 * type to avoid reposting to shm on
+					 * free */
 };
 
 struct rxr_pkt_sendv {


### PR DESCRIPTION
Currently the SHM RX packet pool is a fixed size based on the RX queue
size of SHM (1k). This can be exhausted by unexpected messages and cause
applications to hang when the RX queue is exhausted.

We had a similar bug with the EFA queues and added a copy out mechanism
to keep the RX queues hydrated. SHM is a bit different in that we do not
need to register the RX buffers, so this patch instead allows the SHM RX
packet pool to grow, and changes the type of the packet. Unexpected
messages will stay in the same buffer until processed, but the SHM RX
pool can now grow to keep 1k buffers posted with SHM. This will lead to
increased memory usage when unexpected messages are received over SHM,
but will avoid an extra memcpy.

Signed-off-by: Robert Wespetal <wesper@amazon.com>

Test description: Ran extended internal tests against this PR and 128 node LAMMPS benchmark no longer hangs.