### PR TITLE
[v1.13.x] prov/rxm: Correcting setting of conn_id in rx pkt control hdr

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1540,7 +1540,7 @@ static void rxm_fake_rx_hdr(struct rxm_rx_buf *rx_buf,
 	OFI_DBG_SET(rx_buf->pkt.hdr.version, OFI_OP_VERSION);
 	OFI_DBG_SET(rx_buf->pkt.ctrl_hdr.version, RXM_CTRL_VERSION);
 	rx_buf->pkt.ctrl_hdr.type = rxm_ctrl_eager;
-	rx_buf->pkt.ctrl_hdr.conn_id = cm_handle->remote_key;
+	rx_buf->pkt.ctrl_hdr.conn_id = cm_handle->key;
 	rx_buf->pkt.hdr.op = ofi_op_tagged;
 	rx_buf->pkt.hdr.tag = entry->tag;
 	rx_buf->pkt.hdr.size = entry->len;


### PR DESCRIPTION
In the rxm_fake_rx_hdr function the rx_buf->pkt.ctrl_hdr.conn_id was
being incorrectly set to cm_handle->remote_key.Since this interface
is used by the receiving side to support tcp optimizations for small
messages this value should be updated with the cm_handle->key.In this
function the (local)key should be used to fetch the connections. Using
the remote index causes the connection lookup to fail sometimes.

This change is similar to the changes in the main branch,
commit id: 4de6fef248f8191d5a34a07554ee28b0c09ad231

Signed-off-by: Nikhil Nanal <nikhil.nanal@intel.com>