### PR TITLE
prov/util: Add logic to detect previous memory patching

### DIFF
--- a/prov/util/src/util_mem_hooks.c
+++ b/prov/util/src/util_mem_hooks.c
@@ -276,6 +276,25 @@ static int ofi_patch_function(struct ofi_intercept *intercept)
 
 	return ofi_apply_patch(intercept);
 }
+
+/*
+ * Check to see if there exists at the specified intercept location the
+ * pattern of bytes used in ofi_patch_function() to patch in our own
+ * monitoring function. These bytes (roughly) represent opcodes to load
+ * a supplied address into a register and execute a jump to that location.
+ * If they do already exist, then we've almost certainly already patched.
+ * Note that we are explicitly ignoring the target address in these checks
+ * as that is a transient value and not invarient as the other values are.
+ */
+static bool ofi_is_function_patched(struct ofi_intercept *intercept)
+{
+	return (
+		(*(unsigned short*)(intercept->orig_func + 0) == 0xbb49) &&
+		(*(unsigned char* )(intercept->orig_func +10) == 0x41  ) &&
+		(*(unsigned char* )(intercept->orig_func +11) == 0xff  ) &&
+		(*(unsigned char* )(intercept->orig_func +12) == 0xe3  )
+	);
+}
 #elif defined(__aarch64__)
 /**
  * @brief Generate a mov immediate instruction
@@ -333,6 +352,27 @@ static int ofi_patch_function(struct ofi_intercept *intercept)
 
 	return ofi_apply_patch(intercept);
 }
+
+/*
+ * Please see comments at other ofi_is_function_patched() function
+ */
+static bool ofi_is_function_patched(struct ofi_intercept *intercept)
+{
+    uint32_t mov_mask=~((0xFFFF << 5) | 0x1F);
+    uint32_t br_mask=~(0x1F << 5);
+    uintptr_t addr = (uintptr_t) intercept->orig_func;
+    /*
+     * Register 15 is used in our patching code, but for checking here let's
+     * ignore the register value and instead focus on the surrounding bytes.
+     */
+    return (
+        ((*(uint32_t *) (addr +  0)) & mov_mask) == mov(0, 3, 0) &&
+        ((*(uint32_t *) (addr +  4)) & mov_mask) == movk(0, 2, 0) &&
+        ((*(uint32_t *) (addr +  8)) & mov_mask) == movk(0, 1, 0) &&
+        ((*(uint32_t *) (addr + 12)) & mov_mask) == movk(0, 0, 0) &&
+        ((*(uint32_t *) (addr + 16)) & br_mask) == br(0)
+	);
+}
 #endif
 
 /*
@@ -362,7 +402,14 @@ static int ofi_intercept_symbol(struct ofi_intercept *intercept)
 
 	intercept->orig_func = func_addr;
 
-	ret = ofi_patch_function(intercept);
+	if (ofi_is_function_patched(intercept)) {
+		FI_DBG(&core_prov, FI_LOG_MR,
+				"function %s is already patched; stopping further patching\n",
+				intercept->symbol);
+		ret = -FI_EALREADY;
+	} else {
+		ret = ofi_patch_function(intercept);
+	}
 
 	if (!ret)
 		dlist_insert_tail(&intercept->entry, &memhooks.intercept_list);
@@ -553,56 +600,25 @@ static int ofi_memhooks_start(struct ofi_mem_monitor *monitor)
 	for (i = 0; i < OFI_INTERCEPT_MAX; ++i)
 		dlist_init(&intercepts[i].dl_intercept_list);
 
-	ret = ofi_intercept_symbol(&intercepts[OFI_INTERCEPT_MMAP]);
-	if (ret) {
-		FI_WARN(&core_prov, FI_LOG_MR,
-		       "intercept mmap failed %d %s\n", ret, fi_strerror(ret));
-		return ret;
-	}
-
-	ret = ofi_intercept_symbol(&intercepts[OFI_INTERCEPT_MUNMAP]);
-	if (ret) {
-		FI_WARN(&core_prov, FI_LOG_MR,
-		       "intercept munmap failed %d %s\n", ret, fi_strerror(ret));
-		return ret;
-	}
-
-	ret = ofi_intercept_symbol(&intercepts[OFI_INTERCEPT_MREMAP]);
-	if (ret) {
-		FI_WARN(&core_prov, FI_LOG_MR,
-		       "intercept mremap failed %d %s\n", ret, fi_strerror(ret));
-		return ret;
-	}
-
-	ret = ofi_intercept_symbol(&intercepts[OFI_INTERCEPT_MADVISE]);
-	if (ret) {
-		FI_WARN(&core_prov, FI_LOG_MR,
-		       "intercept madvise failed %d %s\n", ret, fi_strerror(ret));
-		return ret;
-	}
-
-	ret = ofi_intercept_symbol(&intercepts[OFI_INTERCEPT_SHMAT]);
-	if (ret) {
-		FI_WARN(&core_prov, FI_LOG_MR,
-		       "intercept shmat failed %d %s\n", ret, fi_strerror(ret));
-		return ret;
-	}
-
-	ret = ofi_intercept_symbol(&intercepts[OFI_INTERCEPT_SHMDT]);
-	if (ret) {
-		FI_WARN(&core_prov, FI_LOG_MR,
-		       "intercept shmdt failed %d %s\n", ret, fi_strerror(ret));
-		return ret;
-	}
-
-	ret = ofi_intercept_symbol(&intercepts[OFI_INTERCEPT_BRK]);
-	if (ret) {
-		FI_WARN(&core_prov, FI_LOG_MR,
-		       "intercept brk failed %d %s\n", ret, fi_strerror(ret));
-		return ret;
+	for (i = 0; i < OFI_INTERCEPT_MAX; ++i) {
+		ret = ofi_intercept_symbol(&intercepts[i]);
+		if (ret != 0) {
+			FI_DBG(&core_prov, FI_LOG_MR,
+				"intercept %s failed %d %s\n", intercepts[i].symbol,
+					ret, fi_strerror(ret));
+			goto err_intercept_failed;
+		}
 	}
 
 	return 0;
+
+err_intercept_failed:
+	while (--i >= 0)
+		ofi_remove_patch(&intercepts[i]);
+	memhooks_monitor->subscribe = NULL;
+	memhooks_monitor->unsubscribe = NULL;
+
+	return ret;
 }
 
 static void ofi_memhooks_stop(struct ofi_mem_monitor *monitor)


### PR DESCRIPTION
Currently, we cannot detect if another application patches memory relating to how
we monitor memory registration. This change adds this functionality so that if
another application has patched the memory in the same way we'll detect it before
we patch it (again).

If this happens, the ofi_intercept_symbol() function will return FI_EALREADY
under this condition.

Signed-off-by: Rich Welch <rlwelch@amazon.com>