### PR TITLE
prov/tcp: Fixes a possible race condition that can result in use-after-free

### DIFF
--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -166,7 +166,13 @@ enum tcpx_cm_state {
 	/* CM context is freed once connected */
 };
 
+#define OFI_PROV_SPECIFIC_TCP (0x7cb << 16)
+enum {
+	TCPX_CLASS_CM = OFI_PROV_SPECIFIC_TCP,
+};
+
 struct tcpx_cm_context {
+	struct fid		fid;
 	struct fid		*hfid;
 	enum tcpx_cm_state	state;
 	size_t			cm_data_sz;

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -182,7 +182,7 @@ struct tcpx_port_range {
 };
 
 struct tcpx_conn_handle {
-	struct fid		handle;
+	struct fid		fid;
 	struct tcpx_pep		*pep;
 	SOCKET			sock;
 	bool			endian_match;

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -167,7 +167,7 @@ enum tcpx_cm_state {
 };
 
 struct tcpx_cm_context {
-	fid_t			fid;
+	struct fid		*hfid;
 	enum tcpx_cm_state	state;
 	size_t			cm_data_sz;
 	struct tcpx_cm_msg	msg;

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -253,7 +253,11 @@ struct tcpx_ep {
 	int			rx_avail;
 	struct tcpx_rx_ctx	*srx_ctx;
 	enum tcpx_state		state;
-	struct tcpx_cm_context	*cm_ctx;
+	union {
+		struct fid		*fid;
+		struct tcpx_cm_context	*cm_ctx;
+		struct tcpx_conn_handle *handle;
+	};
 
 	/* lock for protecting tx/rx queues, rma list, state*/
 	fastlock_t		lock;

--- a/prov/tcp/src/tcpx_conn_mgr.c
+++ b/prov/tcp/src/tcpx_conn_mgr.c
@@ -53,6 +53,7 @@ struct tcpx_cm_context *tcpx_alloc_cm_ctx(fid_t fid, enum tcpx_cm_state state)
 	if (fid && fid->fclass == FI_CLASS_EP) {
 		ep = container_of(cm_ctx->hfid, struct tcpx_ep,
 				  util_ep.ep_fid.fid);
+		assert(!ep->fid);
 		ep->cm_ctx = cm_ctx;
 	}
 	cm_ctx->state = state;

--- a/prov/tcp/src/tcpx_conn_mgr.c
+++ b/prov/tcp/src/tcpx_conn_mgr.c
@@ -342,7 +342,7 @@ static void tcpx_cm_recv_req(struct util_wait *wait,
 	int ret;
 
 	FI_DBG(&tcpx_prov, FI_LOG_EP_CTRL, "Server receive connect request\n");
-	handle  = container_of(cm_ctx->hfid, struct tcpx_conn_handle, handle);
+	handle  = container_of(cm_ctx->hfid, struct tcpx_conn_handle, fid);
 
 	ret = rx_cm_data(handle->sock, ofi_ctrl_connreq, cm_ctx);
 	if (ret) {
@@ -379,7 +379,7 @@ static void tcpx_cm_recv_req(struct util_wait *wait,
 		goto err3;
 
 	handle->endian_match = (cm_ctx->msg.hdr.conn_data == 1);
-	cm_entry->info->handle = &handle->handle;
+	cm_entry->info->handle = &handle->fid;
 	memcpy(cm_entry->data, cm_ctx->msg.data, cm_ctx->cm_data_sz);
 	cm_ctx->state = TCPX_CM_REQ_RVCD;
 
@@ -482,12 +482,12 @@ static void tcpx_accept(struct util_wait *wait,
 		goto err1;
 	}
 
-	rx_req_cm_ctx = tcpx_alloc_cm_ctx(&handle->handle, TCPX_CM_WAIT_REQ);
+	rx_req_cm_ctx = tcpx_alloc_cm_ctx(&handle->fid, TCPX_CM_WAIT_REQ);
 	if (!rx_req_cm_ctx)
 		goto err2;
 
 	handle->sock = sock;
-	handle->handle.fclass = FI_CLASS_CONNREQ;
+	handle->fid.fclass = FI_CLASS_CONNREQ;
 	handle->pep = pep;
 
 	ret = ofi_wait_add_fd(wait, sock, POLLIN,

--- a/prov/tcp/src/tcpx_conn_mgr.c
+++ b/prov/tcp/src/tcpx_conn_mgr.c
@@ -48,9 +48,9 @@ struct tcpx_cm_context *tcpx_alloc_cm_ctx(fid_t fid, enum tcpx_cm_state state)
 	if (!cm_ctx)
 		return cm_ctx;
 
-	cm_ctx->fid = fid;
+	cm_ctx->hfid = fid;
 	if (fid && fid->fclass == FI_CLASS_EP) {
-		ep = container_of(cm_ctx->fid, struct tcpx_ep,
+		ep = container_of(cm_ctx->hfid, struct tcpx_ep,
 				  util_ep.ep_fid.fid);
 		ep->cm_ctx = cm_ctx;
 	}
@@ -62,8 +62,8 @@ void tcpx_free_cm_ctx(struct tcpx_cm_context *cm_ctx)
 {
 	struct tcpx_ep *ep;
 
-	if (cm_ctx->fid && cm_ctx->fid->fclass == FI_CLASS_EP) {
-		ep = container_of(cm_ctx->fid, struct tcpx_ep,
+	if (cm_ctx->hfid && cm_ctx->hfid->fclass == FI_CLASS_EP) {
+		ep = container_of(cm_ctx->hfid, struct tcpx_ep,
 				  util_ep.ep_fid.fid);
 		ep->cm_ctx = NULL;
 	}
@@ -231,8 +231,8 @@ static void tcpx_cm_recv_resp(struct util_wait *wait,
 	int ret;
 
 	FI_DBG(&tcpx_prov, FI_LOG_EP_CTRL, "Handling accept from server\n");
-	assert(cm_ctx->fid->fclass == FI_CLASS_EP);
-	ep = container_of(cm_ctx->fid, struct tcpx_ep, util_ep.ep_fid.fid);
+	assert(cm_ctx->hfid->fclass == FI_CLASS_EP);
+	ep = container_of(cm_ctx->hfid, struct tcpx_ep, util_ep.ep_fid.fid);
 
 	ret = rx_cm_data(ep->bsock.sock, ofi_ctrl_connresp, cm_ctx);
 	if (ret) {
@@ -258,7 +258,7 @@ static void tcpx_cm_recv_resp(struct util_wait *wait,
 	if (!cm_entry)
 		goto err1;
 
-	cm_entry->fid = cm_ctx->fid;
+	cm_entry->fid = cm_ctx->hfid;
 	memcpy(cm_entry->data, cm_ctx->msg.data, cm_ctx->cm_data_sz);
 
 	ep->hdr_bswap = (cm_ctx->msg.hdr.conn_data == 1) ?
@@ -295,8 +295,8 @@ static void tcpx_cm_send_resp(struct util_wait *wait,
 	int ret;
 
 	FI_DBG(&tcpx_prov, FI_LOG_EP_CTRL, "Send connect (accept) response\n");
-	assert(cm_ctx->fid->fclass == FI_CLASS_EP);
-	ep = container_of(cm_ctx->fid, struct tcpx_ep, util_ep.ep_fid.fid);
+	assert(cm_ctx->hfid->fclass == FI_CLASS_EP);
+	ep = container_of(cm_ctx->hfid, struct tcpx_ep, util_ep.ep_fid.fid);
 
 	ret = tx_cm_data(ep->bsock.sock, ofi_ctrl_connresp, cm_ctx);
 	if (ret) {
@@ -314,7 +314,7 @@ static void tcpx_cm_send_resp(struct util_wait *wait,
 		goto disable;
 	}
 
-	cm_entry.fid =  cm_ctx->fid;
+	cm_entry.fid = cm_ctx->hfid;
 
 	ret = tcpx_ep_enable(ep, &cm_entry, sizeof(cm_entry));
 	if (ret)
@@ -342,7 +342,7 @@ static void tcpx_cm_recv_req(struct util_wait *wait,
 	int ret;
 
 	FI_DBG(&tcpx_prov, FI_LOG_EP_CTRL, "Server receive connect request\n");
-	handle  = container_of(cm_ctx->fid, struct tcpx_conn_handle, handle);
+	handle  = container_of(cm_ctx->hfid, struct tcpx_conn_handle, handle);
 
 	ret = rx_cm_data(handle->sock, ofi_ctrl_connreq, cm_ctx);
 	if (ret) {
@@ -412,7 +412,7 @@ static void tcpx_cm_send_req(struct util_wait *wait,
 	int status, ret = FI_SUCCESS;
 
 	FI_DBG(&tcpx_prov, FI_LOG_EP_CTRL, "client send connreq\n");
-	ep = container_of(cm_ctx->fid, struct tcpx_ep, util_ep.ep_fid.fid);
+	ep = container_of(cm_ctx->hfid, struct tcpx_ep, util_ep.ep_fid.fid);
 
 	len = sizeof(status);
 	ret = getsockopt(ep->bsock.sock, SOL_SOCKET, SO_ERROR,
@@ -463,8 +463,8 @@ static void tcpx_accept(struct util_wait *wait,
 	int ret;
 
 	FI_DBG(&tcpx_prov, FI_LOG_EP_CTRL, "accepting connection\n");
-	assert(cm_ctx->fid->fclass == FI_CLASS_PEP);
-	pep = container_of(cm_ctx->fid, struct tcpx_pep, util_pep.pep_fid.fid);
+	assert(cm_ctx->hfid->fclass == FI_CLASS_PEP);
+	pep = container_of(cm_ctx->hfid, struct tcpx_pep, util_pep.pep_fid.fid);
 
 	sock = accept(pep->sock, NULL, 0);
 	if (sock < 0) {
@@ -510,30 +510,30 @@ static void process_cm_ctx(struct util_wait *wait,
 {
 	switch (cm_ctx->state) {
 	case TCPX_CM_LISTENING:
-		assert(cm_ctx->fid->fclass == FI_CLASS_PEP);
+		assert(cm_ctx->hfid->fclass == FI_CLASS_PEP);
 		tcpx_accept(wait, cm_ctx);
 		break;
 	case TCPX_CM_CONNECTING:
-		assert((cm_ctx->fid->fclass == FI_CLASS_EP) &&
-		       (container_of(cm_ctx->fid, struct tcpx_ep,
+		assert((cm_ctx->hfid->fclass == FI_CLASS_EP) &&
+		       (container_of(cm_ctx->hfid, struct tcpx_ep,
 				     util_ep.ep_fid.fid)->state ==
 							  TCPX_CONNECTING));
 		tcpx_cm_send_req(wait, cm_ctx);
 		break;
 	case TCPX_CM_WAIT_REQ:
-		assert(cm_ctx->fid->fclass == FI_CLASS_CONNREQ);
+		assert(cm_ctx->hfid->fclass == FI_CLASS_CONNREQ);
 		tcpx_cm_recv_req(wait, cm_ctx);
 		break;
 	case TCPX_CM_RESP_READY:
-		assert((cm_ctx->fid->fclass == FI_CLASS_EP) &&
-		       (container_of(cm_ctx->fid, struct tcpx_ep,
+		assert((cm_ctx->hfid->fclass == FI_CLASS_EP) &&
+		       (container_of(cm_ctx->hfid, struct tcpx_ep,
 				     util_ep.ep_fid.fid)->state ==
 							  TCPX_ACCEPTING));
 		tcpx_cm_send_resp(wait, cm_ctx);
 		break;
 	case TCPX_CM_REQ_SENT:
-		assert((cm_ctx->fid->fclass == FI_CLASS_EP) &&
-		       (container_of(cm_ctx->fid, struct tcpx_ep,
+		assert((cm_ctx->hfid->fclass == FI_CLASS_EP) &&
+		       (container_of(cm_ctx->hfid, struct tcpx_ep,
 				     util_ep.ep_fid.fid)->state ==
 							  TCPX_CONNECTING));
 		tcpx_cm_recv_resp(wait, cm_ctx);

--- a/prov/tcp/src/tcpx_conn_mgr.c
+++ b/prov/tcp/src/tcpx_conn_mgr.c
@@ -46,8 +46,9 @@ struct tcpx_cm_context *tcpx_alloc_cm_ctx(fid_t fid, enum tcpx_cm_state state)
 
 	cm_ctx = calloc(1, sizeof(*cm_ctx));
 	if (!cm_ctx)
-		return cm_ctx;
+		return NULL;
 
+	cm_ctx->fid.fclass = TCPX_CLASS_CM;
 	cm_ctx->hfid = fid;
 	if (fid && fid->fclass == FI_CLASS_EP) {
 		ep = container_of(cm_ctx->hfid, struct tcpx_ep,
@@ -62,6 +63,7 @@ void tcpx_free_cm_ctx(struct tcpx_cm_context *cm_ctx)
 {
 	struct tcpx_ep *ep;
 
+	assert(cm_ctx->fid.fclass == TCPX_CLASS_CM);
 	if (cm_ctx->hfid && cm_ctx->hfid->fclass == FI_CLASS_EP) {
 		ep = container_of(cm_ctx->hfid, struct tcpx_ep,
 				  util_ep.ep_fid.fid);
@@ -543,15 +545,11 @@ static void process_cm_ctx(struct util_wait *wait,
 	}
 }
 
-/* The implementation assumes that the EQ does not share a wait set with
- * a CQ.  This is true for internally created wait sets, but not if the
- * application manages the wait set.  To fix, we need to distinguish
- * whether the wait_context references a fid or tcpx_cm_context.
- */
 void tcpx_conn_mgr_run(struct util_eq *eq)
 {
 	struct util_wait_fd *wait_fd;
 	struct tcpx_eq *tcpx_eq;
+	struct fid *fid;
 	struct ofi_epollfds_event events[MAX_POLL_EVENTS];
 	int count, i;
 
@@ -573,7 +571,9 @@ void tcpx_conn_mgr_run(struct util_eq *eq)
 		if (&wait_fd->util_wait.wait_fid.fid == events[i].data.ptr)
 			continue;
 
-		process_cm_ctx(eq->wait, events[i].data.ptr);
+		fid = events[i].data.ptr;
+		if (fid->fclass == TCPX_CLASS_CM)
+			process_cm_ctx(eq->wait, events[i].data.ptr);
 	}
 unlock:
 	fastlock_release(&tcpx_eq->close_lock);

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -996,6 +996,7 @@ int tcpx_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 		goto err2;
 	}
 
+	_pep->cm_ctx.fid.fclass = TCPX_CLASS_CM;
 	_pep->cm_ctx.hfid = &_pep->util_pep.pep_fid.fid;
 	_pep->cm_ctx.state = TCPX_CM_LISTENING;
 	_pep->cm_ctx.cm_data_sz = 0;

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -996,7 +996,7 @@ int tcpx_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 		goto err2;
 	}
 
-	_pep->cm_ctx.fid = &_pep->util_pep.pep_fid.fid;
+	_pep->cm_ctx.hfid = &_pep->util_pep.pep_fid.fid;
 	_pep->cm_ctx.state = TCPX_CM_LISTENING;
 	_pep->cm_ctx.cm_data_sz = 0;
 	_pep->sock = INVALID_SOCKET;

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -177,40 +177,44 @@ free:
 	return ret;
 }
 
-static int tcpx_ep_accept(struct fid_ep *ep, const void *param, size_t paramlen)
+static int
+tcpx_ep_accept(struct fid_ep *fid_ep, const void *param, size_t paramlen)
 {
-	struct tcpx_ep *tcpx_ep = container_of(ep, struct tcpx_ep, util_ep.ep_fid);
+	struct tcpx_ep *ep = container_of(fid_ep, struct tcpx_ep, util_ep.ep_fid);
 	struct tcpx_cm_context *cm_ctx;
+	struct tcpx_conn_handle *handle;
 	int ret;
 
-	if (tcpx_ep->bsock.sock == INVALID_SOCKET ||
-	    tcpx_ep->state != TCPX_RCVD_REQ)
+	handle = ep->handle;
+	if (ep->bsock.sock == INVALID_SOCKET || ep->state != TCPX_RCVD_REQ ||
+	    !handle || (handle->fid.fclass != FI_CLASS_CONNREQ))
 		return -FI_EINVAL;
 
-	cm_ctx = tcpx_alloc_cm_ctx(&tcpx_ep->util_ep.ep_fid.fid,
-				   TCPX_CM_RESP_READY);
+	ep->handle = NULL;
+	cm_ctx = tcpx_alloc_cm_ctx(&ep->util_ep.ep_fid.fid, TCPX_CM_RESP_READY);
 	if (!cm_ctx) {
 		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
 			"cannot allocate memory \n");
 		return -FI_ENOMEM;
 	}
 
-	tcpx_ep->state = TCPX_ACCEPTING;
+	ep->state = TCPX_ACCEPTING;
 
 	if (paramlen) {
 		cm_ctx->cm_data_sz = paramlen;
 		memcpy(cm_ctx->msg.data, param, paramlen);
 	}
 
-	ret = ofi_wait_add_fd(tcpx_ep->util_ep.eq->wait, tcpx_ep->bsock.sock,
+	ret = ofi_wait_add_fd(ep->util_ep.eq->wait, ep->bsock.sock,
 			      POLLOUT, tcpx_eq_wait_try_func, NULL, cm_ctx);
 	if (ret)
 		goto free;
 
+	free(handle);
 	return 0;
 
 free:
-	tcpx_ep->state = TCPX_RCVD_REQ;
+	ep->state = TCPX_RCVD_REQ;
 	tcpx_free_cm_ctx(cm_ctx);
 	return ret;
 }
@@ -549,7 +553,7 @@ static int tcpx_ep_close(struct fid *fid)
 	if (eq)
 		fastlock_release(&eq->close_lock);
 
-	if (ep->cm_ctx)
+	if (ep->fid && ep->fid->fclass == TCPX_CLASS_CM)
 		tcpx_free_cm_ctx(ep->cm_ctx);
 
 	/* Lock not technically needed, since we're freeing the EP.  But it's
@@ -710,10 +714,15 @@ int tcpx_endpoint(struct fid_domain *domain, struct fi_info *info,
 			ep->state = TCPX_RCVD_REQ;
 			handle = container_of(info->handle,
 					      struct tcpx_conn_handle, fid);
+			/* EP now owns socket */
 			ep->bsock.sock = handle->sock;
+			handle->sock = INVALID_SOCKET;
 			ep->hdr_bswap = handle->endian_match ?
 					tcpx_hdr_none : tcpx_hdr_bswap;
-			free(handle);
+			/* Save handle, but we only free if user calls accept.
+			 * Otherwise, user will call reject, which will free it.
+			 */
+			ep->handle = handle;
 
 			ret = tcpx_setup_socket(ep->bsock.sock, info);
 			if (ret)
@@ -891,14 +900,17 @@ static int tcpx_pep_listen(struct fid_pep *pep)
 	return ret;
 }
 
-static int tcpx_pep_reject(struct fid_pep *pep, fid_t handle,
+static int tcpx_pep_reject(struct fid_pep *pep, fid_t fid_handle,
 			   const void *param, size_t paramlen)
 {
 	struct tcpx_cm_msg msg;
-	struct tcpx_conn_handle *conn_handle;
+	struct tcpx_conn_handle *handle;
 	int ret;
 
-	conn_handle = container_of(handle, struct tcpx_conn_handle, fid);
+	handle = container_of(fid_handle, struct tcpx_conn_handle, fid);
+	/* If we created an endpoint, it owns the socket */
+	if (handle->sock == INVALID_SOCKET)
+		goto free;
 
 	memset(&msg.hdr, 0, sizeof(msg.hdr));
 	msg.hdr.version = TCPX_CTRL_HDR_VERSION;
@@ -907,18 +919,19 @@ static int tcpx_pep_reject(struct fid_pep *pep, fid_t handle,
 	if (paramlen)
 		memcpy(&msg.data, param, paramlen);
 
-	ret = ofi_send_socket(conn_handle->sock, &msg,
+	ret = ofi_send_socket(handle->sock, &msg,
 			      sizeof(msg.hdr) + paramlen, MSG_NOSIGNAL);
 	if (ret != sizeof(msg.hdr) + paramlen)
 		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
 			"sending of reject message failed\n");
 
-	ofi_shutdown(conn_handle->sock, SHUT_RDWR);
-	ret = ofi_close_socket(conn_handle->sock);
+	ofi_shutdown(handle->sock, SHUT_RDWR);
+	ret = ofi_close_socket(handle->sock);
 	if (ret)
 		return ret;
 
-	free(conn_handle);
+free:
+	free(handle);
 	return FI_SUCCESS;
 }
 


### PR DESCRIPTION
If an application makes the following calling sequence, use-after-free is possible:

receive a connection request event (info->handle set)
fi_endpoint(... info->handle ...)
fi_close(ep)
fi_reject(info->handle)

This series updates the code to handle that calling sequence.  As part of the changes, it also removes a long-standing limitation where a wait set couldn't be shared between an EQ and CQ.