### PR TITLE
[v1.13.x] prov/efa: copy unexpected messages out of pre-posted shm buffers

### DIFF
--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -180,16 +180,33 @@ void rxr_pkt_entry_copy(struct rxr_ep *ep,
 }
 
 /*
- * Create a new rx_entry for an unexpected message. Store the packet for later
- * processing and put the rx_entry on the appropriate unexpected list.
+ * Handle copying or updating the metadata for an unexpected packet.
+ *
+ * Packets from the EFA RX pool will be copied into a separate buffer not
+ * registered with the device (if this option is enabled) so that we can repost
+ * the registered buffer again to keep the EFA RX queue full. Packets from the
+ * SHM RX pool will also be copied to reuse the unexpected message pool.
+ *
+ * @param[in]     ep  the end point
+ * @param[in,out] pkt_entry_ptr unexpected packet, if this packet is copied to
+ *                a new memory region this pointer will be updated.
+ *
+ * @return	  struct rxr_pkt_entry of the updated or copied packet, NULL on
+ * 		  allocation failure.
  */
 struct rxr_pkt_entry *rxr_pkt_get_unexp(struct rxr_ep *ep,
 					struct rxr_pkt_entry **pkt_entry_ptr)
 {
 	struct rxr_pkt_entry *unexp_pkt_entry;
+	enum rxr_pkt_entry_alloc_type type;
 
-	if (rxr_env.rx_copy_unexp && (*pkt_entry_ptr)->alloc_type == RXR_PKT_FROM_EFA_RX_POOL) {
-		unexp_pkt_entry = rxr_pkt_entry_clone(ep, ep->rx_unexp_pkt_pool, RXR_PKT_FROM_UNEXP_POOL, *pkt_entry_ptr);
+	type = (*pkt_entry_ptr)->alloc_type;
+
+	if (rxr_env.rx_copy_unexp && (type == RXR_PKT_FROM_EFA_RX_POOL ||
+				      type == RXR_PKT_FROM_SHM_RX_POOL)) {
+		unexp_pkt_entry = rxr_pkt_entry_clone(ep, ep->rx_unexp_pkt_pool,
+						      RXR_PKT_FROM_UNEXP_POOL,
+						      *pkt_entry_ptr);
 		if (OFI_UNLIKELY(!unexp_pkt_entry)) {
 			FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,
 				"Unable to allocate rx_pkt_entry for unexp msg\n");

--- a/prov/efa/src/rxr/rxr_pkt_entry.h
+++ b/prov/efa/src/rxr/rxr_pkt_entry.h
@@ -42,13 +42,13 @@
 
 /* pkt_entry_alloc_type indicate where the packet entry is allocated from */
 enum rxr_pkt_entry_alloc_type {
-	RXR_PKT_FROM_EFA_TX_POOL = 1, /* packet is allcoated from ep->efa_tx_pkt_pool */
+	RXR_PKT_FROM_EFA_TX_POOL = 1, /* packet is allocated from ep->efa_tx_pkt_pool */
 	RXR_PKT_FROM_EFA_RX_POOL,     /* packet is allocated from ep->efa_rx_pkt_pool */
 	RXR_PKT_FROM_SHM_TX_POOL,     /* packet is allocated from ep->shm_tx_pkt_pool */
 	RXR_PKT_FROM_SHM_RX_POOL,     /* packet is allocated from ep->shm_rx_pkt_pool */
 	RXR_PKT_FROM_UNEXP_POOL,      /* packet is allocated from ep->rx_unexp_pkt_pool */
 	RXR_PKT_FROM_OOO_POOL,	      /* packet is allocated from ep->rx_ooo_pkt_pool */
-	RXR_PKT_FROM_USER_BUFFER,     /* packet is from user proivded buffer */
+	RXR_PKT_FROM_USER_BUFFER,     /* packet is from user provided buffer */
 	RXR_PKT_FROM_READ_COPY_POOL,  /* packet is allocated from ep->rx_readcopy_pkt_pool */
 };
 


### PR DESCRIPTION
Copy unexpected messages out of the pre-posted buffer pool for the SHM
provider. Certain workloads can exhaust the SHM receive pool size of 1k on
unexpected messages which can cause application hangs.

This approach incurs an additional memory copy for SHM unexpected
messages, since SHM doesn't require memory to be registered, however,
this will potentially utilize less memory depending on the workload.

Signed-off-by: Robert Wespetal <wesper@amazon.com>
(cherry picked from commit d9a805b67f1f7b8899f49f944b298d4ebf8d8cb5)