### PR TITLE
prov/tcp: mark rma read control msg as internal

### DIFF
--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -271,7 +271,8 @@ struct tcpx_fabric {
 	struct util_fabric	util_fabric;
 };
 
-#define TCPX_INTERNAL_MASK	GENMASK_ULL(63, 59)
+#define TCPX_INTERNAL_MASK	GENMASK_ULL(63, 58)
+#define TCPX_NEED_RESP		BIT_ULL(58)
 #define TCPX_NEED_ACK		BIT_ULL(59)
 #define TCPX_INTERNAL_XFER	BIT_ULL(60)
 #define TCPX_NEED_DYN_RBUF 	BIT_ULL(61)
@@ -293,6 +294,9 @@ struct tcpx_xfer_entry {
 	uint32_t		async_index;
 	void			*context;
 	void			*mrecv_msg_start;
+	// for RMA read requests, we need a way to track the request response
+	// so that we don't propagate multiple completions for the same operation
+	struct tcpx_xfer_entry  *resp_entry;
 };
 
 struct tcpx_domain {

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -124,6 +124,11 @@ void tcpx_progress_tx(struct tcpx_ep *ep)
 			 */
 			slist_insert_tail(&tx_entry->entry,
 					  &ep->need_ack_queue);
+		} else if (tx_entry->flags & TCPX_NEED_RESP) {
+			// discard send but enable receive for completeion
+			assert(tx_entry->resp_entry);
+			tx_entry->resp_entry->flags &= ~TCPX_INTERNAL_XFER;
+			tcpx_free_xfer(cq, tx_entry);
 		} else if ((tx_entry->flags & TCPX_ASYNC) &&
 			   (ofi_val32_gt(tx_entry->async_index,
 					 ep->bsock.done_index))) {


### PR DESCRIPTION
Internal messages do not carry op_context and do not generate error messages to the cq.
Since the rma read control message did not have an op_context and was not marked
internal, it was causing a crash in RxM when errors were sent to the cq.