### PR TITLE
prov/rxm: Provide quicker response to CM progress

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -629,6 +629,7 @@ struct rxm_ep {
 	struct fi_info 		*rxm_info;
 	struct fi_info 		*msg_info;
 
+	int			connecting_cnt;
 	struct index_map	conn_idx_map;
 	struct dlist_entry	loopback_list;
 	union ofi_sock_ip	addr;

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1889,9 +1889,11 @@ void rxm_ep_do_progress(struct util_ep *util_ep)
 				rxm_cq_write_error_all(rxm_ep, ret);
 		}
 
-		if (ret == -FI_EAGAIN || --rxm_ep->cq_eq_fairness <= 0) {
+		if (ret == -FI_EAGAIN || rxm_ep->connecting_cnt ||
+		    --rxm_ep->cq_eq_fairness <= 0) {
 			rxm_ep->cq_eq_fairness = rxm_cq_eq_fairness;
-			if (rxm_cm_progress_interval) {
+			if (rxm_ep->connecting_cnt == 0 &&
+			    rxm_cm_progress_interval) {
 				timestamp = ofi_gettime_us();
 				if (timestamp - rxm_ep->msg_cq_last_poll >
 				    rxm_cm_progress_interval) {


### PR DESCRIPTION
2 patches which are simple optimizations to avoid calling gettime() when the results will be ignored.

Change to rxm to try to progress connections if there are any active.  This should improve responsiveness to new connections, which should improve the performance of certain MPI applications.

Marking as do not merge until the performance impact can be analyzed.  Changes are based on suggestions from the Intel MPI team, however.