### PR TITLE
core + prov/rxm: skip calling gettime when result is ignored

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1891,11 +1891,15 @@ void rxm_ep_do_progress(struct util_ep *util_ep)
 
 		if (ret == -FI_EAGAIN || --rxm_ep->cq_eq_fairness <= 0) {
 			rxm_ep->cq_eq_fairness = rxm_cq_eq_fairness;
-			timestamp = ofi_gettime_us();
-			if (timestamp - rxm_ep->msg_cq_last_poll >
-				rxm_cm_progress_interval) {
-				rxm_ep->msg_cq_last_poll = timestamp;
-				rxm_conn_progress(rxm_ep);
+			if (rxm_cm_progress_interval) {
+				timestamp = ofi_gettime_us();
+				if (timestamp - rxm_ep->msg_cq_last_poll >
+				    rxm_cm_progress_interval) {
+					rxm_ep->msg_cq_last_poll = timestamp;
+					rxm_conn_progress(rxm_ep);
+				}
+			} else {
+					rxm_conn_progress(rxm_ep);
 			}
 		}
 	} while ((ret > 0) && (++comp_read < rxm_ep->comp_per_progress));

--- a/src/common.c
+++ b/src/common.c
@@ -1473,7 +1473,7 @@ int ofi_pollfds_wait(struct ofi_pollfds *pfds,
 {
 	int i, ret;
 	int found = 0;
-	uint64_t start = (timeout >= 0) ? ofi_gettime_ms() : 0;
+	uint64_t start = (timeout > 0) ? ofi_gettime_ms() : 0;
 
 	fastlock_acquire(&pfds->lock);
 	if (!slist_empty(&pfds->work_item_list))


### PR DESCRIPTION
Extracting 2 commits from #7112, which should be safe to merge immediately.