### PR TITLE
Finish rolling to v1.14.0a1

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -186,7 +186,7 @@ src_libfabric_la_LIBADD =
 src_libfabric_la_DEPENDENCIES = libfabric.map
 
 if !EMBEDDED
-src_libfabric_la_LDFLAGS += -version-info 17:0:16
+src_libfabric_la_LDFLAGS += -version-info 18:0:17
 endif
 src_libfabric_la_LDFLAGS += -export-dynamic \
 			   $(libfabric_version_script)

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -79,7 +79,7 @@ extern "C" {
 #endif
 
 #define FI_MAJOR_VERSION 1
-#define FI_MINOR_VERSION 13
+#define FI_MINOR_VERSION 14
 #define FI_REVISION_VERSION 0
 
 enum {


### PR DESCRIPTION
Update both the shared library version number and the version
reported by fi_version() for the 1.14 series.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>