### PR TITLE
prov/efa: Fix a bug in rxr_ep_grow_rx_pkt_pools.

### DIFF
--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1536,22 +1536,26 @@ int rxr_ep_grow_rx_pkt_pools(struct rxr_ep *ep)
 		}
 	}
 
-	assert(ep->rx_unexp_pkt_pool);
-	err = ofi_bufpool_grow(ep->rx_unexp_pkt_pool);
-	if (err) {
-		FI_WARN(&rxr_prov, FI_LOG_CQ,
-			"cannot allocate memory for unexpected packet pool. error: %s\n",
-			strerror(-err));
-		return err;
+	if (ep->rx_unexp_pkt_pool) {
+		assert(ep->rx_unexp_pkt_pool);
+		err = ofi_bufpool_grow(ep->rx_unexp_pkt_pool);
+		if (err) {
+			FI_WARN(&rxr_prov, FI_LOG_CQ,
+				"cannot allocate memory for unexpected packet pool. error: %s\n",
+				strerror(-err));
+			return err;
+		}
 	}
 
-	assert(ep->rx_ooo_pkt_pool);
-	err = ofi_bufpool_grow(ep->rx_ooo_pkt_pool);
-	if (err) {
-		FI_WARN(&rxr_prov, FI_LOG_CQ,
-			"cannot allocate memory for out-of-order packet pool. error: %s\n",
-			strerror(-err));
-		return err;
+	if (ep->rx_ooo_pkt_pool) {
+		assert(ep->rx_ooo_pkt_pool);
+		err = ofi_bufpool_grow(ep->rx_ooo_pkt_pool);
+		if (err) {
+			FI_WARN(&rxr_prov, FI_LOG_CQ,
+				"cannot allocate memory for out-of-order packet pool. error: %s\n",
+				strerror(-err));
+			return err;
+		}
 	}
 
 	if (ep->rx_readcopy_pkt_pool) {


### PR DESCRIPTION
Currently, rxr_ep_grow_rx_pkt_pools unconditionally grows
rx_ooo_pkt_pool and rx_unexp_pkt_pool. This is wrong because
these two pkt pools may not be created if user specifies
FI_EFA_RX_COPY_UNEXP=0 and FI_EFA_RX_COPY_OOO=0.

This patch grows these two pkt pools only when they are created,
in the similar pattern of rx_readcopy_pkt_pool.

Signed-off-by: Shi Jin <sjina@amazon.com>

Test: 
1. Run fabtests with FI_EFA_RX_COPY_UNEXP=0 and FI_EFA_RX_COPY_OOO=0.
2. Run osu micro-benchmarks with FI_EFA_RX_COPY_UNEXP=0 and FI_EFA_RX_COPY_OOO=0.
