### PR TITLE
fi_endpoint: add a parameter to allow FI_HMEM p2p configuration

### DIFF
--- a/include/rdma/fi_endpoint.h
+++ b/include/rdma/fi_endpoint.h
@@ -66,6 +66,18 @@ enum {
 	FI_OPT_RECV_BUF_SIZE,
 	FI_OPT_TX_SIZE,
 	FI_OPT_RX_SIZE,
+	FI_OPT_FI_HMEM_P2P,		/* int */
+};
+
+/*
+ * Parameters for FI_OPT_HMEM_P2P to allow endpoint control over peer to peer
+ * support and FI_HMEM.
+ */
+enum {
+	FI_HMEM_P2P_ENABLED,	/* Provider decides when to use P2P, default. */
+	FI_HMEM_P2P_REQUIRED,	/* Must use P2P for all transfers */
+	FI_HMEM_P2P_PREFERRED,	/* Should use P2P for all transfers if available */
+	FI_HMEM_P2P_DISABLED	/* Do not use P2P */
 };
 
 struct fi_ops_ep {

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -520,6 +520,25 @@ The following option levels and option names and parameters are defined.
   that applications that want to override the default MIN_MULTI_RECV
   value set this option before enabling the corresponding endpoint.
 
+- *FI_OPT_FI_HMEM_P2P - int*
+: Defines how the provider should handle peer to peer FI_HMEM transfers for
+  this endpoint. By default, the provider will chose whether to use peer to peer
+  support based on the type of transfer (FI_HMEM_P2P_ENABLED). Valid values
+  defined in fi_endpoint.h are:
+	* FI_HMEM_P2P_ENABLED: Peer to peer support may be used by the provider
+	  to handle FI_HMEM transfers, and which transfers are initiated using
+	  peer to peer is subject to the provider implementation.
+	* FI_HMEM_P2P_REQUIRED: Peer to peer support must be used for
+	  transfers, transfers that cannot be performed using p2p will be
+	  reported as failing.
+	* FI_HMEM_P2P_PREFERRED: Peer to peer support should be used by the
+	  provider for all transfers if available, but the provider may choose
+	  to copy the data to initiate the transfer if peer to peer support is
+	  unavailable.
+	* FI_HMEM_P2P_DISABLED: Peer to peer support should not be used.
+: fi_setopt() will return -FI_EOPNOTSUPP if the mode requested cannot be supported
+  by the provider.
+
 ## fi_tc_dscp_set
 
 This call converts a DSCP defined value into a libfabric traffic class value.


### PR DESCRIPTION
Certain Libfabric applications (such as Open MPI) prefer that FI_HMEM transfers
should be attempted via other means if peer to peer device transfer support is
unavailable. Other applications (such as NVIDIA OFI NCCL plugin) only want
FI_HMEM transfers to occur via peer to peer transactions. Add a new endpoint
setopt option that allows applications to state this after selecting a provider
with FI_HMEM support.

Signed-off-by: Robert Wespetal <wesper@amazon.com>