### PR TITLE
prov/efa: fix the memcpy size in rxr_pkt_entry_copy

### DIFF
--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -176,7 +176,8 @@ void rxr_pkt_entry_copy(struct rxr_ep *ep,
 	dest->addr = src->addr;
 	dest->flags = RXR_PKT_ENTRY_IN_USE;
 	dest->next = NULL;
-	memcpy(dest->pkt, src->pkt, ep->mtu_size);
+	assert(src->pkt_size > 0);
+	memcpy(dest->pkt, src->pkt, src->pkt_size);
 }
 
 /*


### PR DESCRIPTION
Currently, rxr_pkt_entry_copy will copy the whole
packet entry, which is unnecessary because only
the first pkt_entry->pkt_size contains data.
This patch fixed the issue.

Signed-off-by: Wei Zhang <wzam@amazon.com>