### PR TITLE
prov/efa: track HMEM device capabilities, use the new p2p option

### DIFF
--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -55,6 +55,8 @@ CUresult ofi_cuPointerGetAttribute(void *data, CUpointer_attribute attribute,
 				   CUdeviceptr ptr);
 cudaError_t ofi_cudaHostRegister(void *ptr, size_t size, unsigned int flags);
 cudaError_t ofi_cudaHostUnregister(void *ptr);
+cudaError_t ofi_cudaMalloc(void **ptr, size_t size);
+cudaError_t ofi_cudaFree(void *ptr);
 
 #endif /* HAVE_LIBCUDA */
 

--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -155,6 +155,11 @@ struct efa_domain_base {
 	enum efa_domain_type	type;
 };
 
+struct efa_hmem_info {
+	bool initialized; 	/* do we support it at all */
+	bool p2p_supported;	/* do we support p2p with this device */
+};
+
 struct efa_domain {
 	struct util_domain	util_domain;
 	enum efa_domain_type	type;
@@ -166,6 +171,7 @@ struct efa_domain {
 	struct ofi_mr_cache	*cache;
 	struct efa_qp		**qp_table;
 	size_t			qp_table_sz_m1;
+	struct efa_hmem_info	hmem_info[OFI_HMEM_MAX];
 };
 
 /**
@@ -321,6 +327,7 @@ struct efa_ep {
 	struct ofi_bufpool	*send_wr_pool;
 	struct ofi_bufpool	*recv_wr_pool;
 	struct ibv_ah		*self_ah;
+	int			hmem_p2p_opt; /* what to do for hmem transfers */
 };
 
 struct efa_send_wr {
@@ -639,6 +646,32 @@ struct rdm_peer *rxr_ep_get_peer(struct rxr_ep *ep, fi_addr_t addr)
 static inline bool efa_ep_is_cuda_mr(struct efa_mr *efa_mr)
 {
 	return efa_mr ? (efa_mr->peer.iface == FI_HMEM_CUDA): false;
+}
+
+/*
+ * @brief: check whether we should use p2p for this transaction
+ *
+ * @param[in]	ep	efa_ep
+ * @param[in]	efa_mr	memory registration struct
+ *
+ * @return: 0 if p2p should not be used, 1 if it should, and negative FI code
+ * if transfer should fail.
+ */
+static inline int efa_ep_use_p2p(struct efa_ep *ep, struct efa_mr *efa_mr)
+{
+	if (!efa_mr)
+		return 0;
+
+	if (ep->domain->hmem_info[efa_mr->peer.iface].p2p_supported)
+		return (ep->hmem_p2p_opt != FI_HMEM_P2P_DISABLED);
+
+	if (ep->hmem_p2p_opt == FI_HMEM_P2P_REQUIRED) {
+		EFA_WARN(FI_LOG_EP_CTRL,
+			 "Peer to peer support is currently required, but not available.");
+		return -FI_ENOSYS;
+	}
+
+	return 0;
 }
 
 /*

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -438,6 +438,13 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 
 	domain->cache = NULL;
 
+	if ((domain->info->caps & FI_HMEM) &&
+	    ofi_hmem_is_initialized(FI_HMEM_CUDA)) {
+		domain->hmem_info[FI_HMEM_CUDA].initialized = true;
+		/* TODO: register a cuda page here instead */
+		domain->hmem_info[FI_HMEM_CUDA].p2p_supported = true;
+	}
+
 	/*
 	 * Call ibv_fork_init if the user asked for fork support.
 	 */

--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -471,67 +471,6 @@ err_free_nic:
 	return ret;
 }
 
-#if HAVE_LIBCUDA
-/*
- * efa_get_gdr_support() checks if the provider can support GPUDirect RDMA. It
- * checks whether the hmem initialization succeeded and also reads from the EFA
- * driver sysfs file "class/infiniband/<device_name>/gdr" to verify the EFA
- * driver was able to successfully load p2p device support.
- *
- * TODO: the gdr sysfs file does not necessarily mean a specific p2p transfer
- * will succeed, more work is needed here.
- *
- * Return value:
- *   return 1 if gdr is supported
- *   return 0 if it is not
- *   return a negative value on error
- */
-static int efa_get_gdr_support(struct efa_context *efa_context)
-{
-	static const int MAX_GDR_SUPPORT_STRLEN = 8;
-	char *gdr_path = NULL;
-	char gdr_support_str[MAX_GDR_SUPPORT_STRLEN];
-	int ret, read_len;
-
-	if (!ofi_hmem_is_initialized(FI_HMEM_CUDA)) {
-		EFA_WARN(FI_LOG_MR,
-		         "FI_HMEM_CUDA is not initialized\n");
-		return 0;
-	}
-
-	ret = asprintf(&gdr_path, "class/infiniband/%s/device/gdr",
-		       efa_context->ibv_ctx->device->name);
-	if (ret < 0) {
-		EFA_INFO_ERRNO(FI_LOG_FABRIC, "asprintf to build sysfs file name failed", ret);
-		goto out;
-	}
-
-	ret = fi_read_file(get_sysfs_path(), gdr_path,
-			   gdr_support_str, MAX_GDR_SUPPORT_STRLEN);
-	if (ret < 0) {
-		if (errno == ENOENT) {
-			/* sysfs file does not exist, gdr is not supported */
-			ret = 0;
-		}
-
-		goto out;
-	}
-
-	if (ret == 0) {
-		EFA_WARN(FI_LOG_FABRIC, "Sysfs file %s is empty\n", gdr_path);
-		ret = -FI_EINVAL;
-		goto out;
-	}
-
-	read_len = MIN(ret, MAX_GDR_SUPPORT_STRLEN);
-	ret = (0 == strncmp(gdr_support_str, "1", read_len));
-
-out:
-	free(gdr_path);
-	return ret;
-}
-#endif
-
 static int efa_get_device_attrs(struct efa_context *ctx, struct fi_info *info)
 {
 	struct efadv_device_attr efadv_attr;
@@ -579,19 +518,12 @@ static int efa_get_device_attrs(struct efa_context *ctx, struct fi_info *info)
 	info->domain_attr->mr_cnt		= base_attr->max_mr;
 
 #if HAVE_LIBCUDA
-	if (info->ep_attr->type == FI_EP_RDM) {
-		ret = efa_get_gdr_support(ctx);
-		if (ret < 0) {
-			EFA_WARN(FI_LOG_FABRIC, "get gdr support failed!\n");
-			return ret;
-		}
-
-		if (ret == 1) {
-			info->caps			|= FI_HMEM;
-			info->tx_attr->caps		|= FI_HMEM;
-			info->rx_attr->caps		|= FI_HMEM;
-			info->domain_attr->mr_mode	|= FI_MR_HMEM;
-		}
+	if (info->ep_attr->type == FI_EP_RDM &&
+	    ofi_hmem_is_initialized(FI_HMEM_CUDA)) {
+		info->caps			|= FI_HMEM;
+		info->tx_attr->caps		|= FI_HMEM;
+		info->rx_attr->caps		|= FI_HMEM;
+		info->domain_attr->mr_mode	|= FI_MR_HMEM;
 	}
 #endif
 

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -81,7 +81,7 @@ static int efa_mr_hmem_setup(struct efa_mr *efa_mr,
 		 * util_domain is at the beginning of both efa_domain and
 		 * rxr_domain.
 		 */
-		if (ofi_hmem_is_initialized(attr->iface)) {
+		if (efa_mr->domain->hmem_info[attr->iface].initialized) {
 			efa_mr->peer.iface = attr->iface;
 		} else {
 			EFA_WARN(FI_LOG_MR,

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -204,7 +204,7 @@ static int efa_mr_cache_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	struct ofi_mr_entry *entry;
 	int ret;
 
-	if (flags & OFI_MR_NOCACHE) {
+	if ((flags & OFI_MR_NOCACHE) || attr->iface != FI_HMEM_SYSTEM) {
 		ret = efa_mr_regattr(fid, attr, flags, mr_fid);
 		return ret;
 	}

--- a/prov/efa/src/rxr/rxr_atomic.c
+++ b/prov/efa/src/rxr/rxr_atomic.c
@@ -136,6 +136,10 @@ ssize_t rxr_atomic_generic_efa(struct rxr_ep *rxr_ep,
 
 	assert(msg->iov_count <= rxr_ep->tx_iov_limit);
 	efa_perfset_start(rxr_ep, perf_efa_tx);
+
+	if (efa_ep_is_cuda_mr(msg->desc[0]))
+		return -FI_ENOSYS;
+
 	fastlock_acquire(&rxr_ep->util_ep.lock);
 
 	if (OFI_UNLIKELY(is_tx_res_full(rxr_ep))) {

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -490,20 +490,6 @@ static int rxr_info_to_rxr(uint32_t version, const struct fi_info *core_info,
 		 * which means FI_MR_HMEM implies FI_MR_LOCAL for cuda buffer
 		 */
 		if (hints->caps & FI_HMEM) {
-
-			if (!efa_device_support_rdma_read()) {
-				FI_WARN(&rxr_prov, FI_LOG_CORE,
-				        "FI_HMEM capability requires RDMA, which this device does not support.\n");
-				return -FI_ENODATA;
-
-			}
-
-			if (!rxr_env.use_device_rdma) {
-				FI_WARN(&rxr_prov, FI_LOG_CORE,
-				        "FI_HMEM capability requires RDMA, which is turned off. You can turn it on by set environment variable FI_EFA_USE_DEVICE_RDMA to 1.\n");
-				return -FI_ENODATA;
-			}
-
 			if (hints->domain_attr &&
 			    !(hints->domain_attr->mr_mode & FI_MR_HMEM)) {
 				FI_WARN(&rxr_prov, FI_LOG_CORE,

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -871,7 +871,8 @@ EFA_INI
 			"Calls to RDMA read is segmented using this value.");
 	fi_param_define(&rxr_prov, "fork_safe", FI_PARAM_BOOL,
 			"Enables fork support and disables internal usage of huge pages. Has no effect on kernels which set copy-on-fork for registered pages, generally 5.13 and later. (Default: false)");
-
+	fi_param_define(&rxr_prov, "hmem_p2p_opt", FI_PARAM_INT,
+			"Change FI_OPT_FI_HMEM_P2P via environment variable instead of setopt. This option has no default, the provider will decide whether to use peer to peer if this variable is not set. This variable will be overriden if an application calls setopt with option FI_OPT_FI_HMEM_P2P.");
 	rxr_init_env();
 
 #if HAVE_EFA_DL

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -122,15 +122,18 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 
 	int tagged;
 	size_t max_rtm_data_size;
-	ssize_t err;
+	ssize_t ret;
 	struct rdm_peer *peer;
 	bool delivery_complete_requested;
 	int ctrl_type;
 	struct efa_domain *efa_domain;
+	struct efa_ep *efa_ep;
 	struct rxr_domain *rxr_domain = rxr_ep_domain(rxr_ep);
 
 	efa_domain = container_of(rxr_domain->rdm_domain, struct efa_domain,
 				  util_domain.domain_fid);
+
+	efa_ep = container_of(rxr_ep->rdm_ep, struct efa_ep, util_ep.ep_fid);
 
 	assert(tx_entry->op == ofi_op_msg || tx_entry->op == ofi_op_tagged);
 	tagged = (tx_entry->op == ofi_op_tagged);
@@ -160,9 +163,9 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 		 * the information whether the peer
 		 * support it or not.
 		 */
-		err = rxr_pkt_trigger_handshake(rxr_ep, tx_entry->addr, peer);
-		if (OFI_UNLIKELY(err))
-			return err;
+		ret = rxr_pkt_trigger_handshake(rxr_ep, tx_entry->addr, peer);
+		if (OFI_UNLIKELY(ret))
+			return ret;
 
 		if (!(peer->flags & RXR_PEER_HANDSHAKE_RECEIVED))
 			return -FI_EAGAIN;
@@ -203,7 +206,10 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 		return rxr_pkt_post_ctrl(rxr_ep, RXR_TX_ENTRY, tx_entry, ctrl_type + tagged, 0, 0);
 	}
 
-	if (efa_ep_is_cuda_mr(tx_entry->desc[0])) {
+	ret = efa_ep_use_p2p(efa_ep, tx_entry->desc[0]);
+	if (ret < 0)
+		return ret;
+	if (ret == 1 && efa_ep_is_cuda_mr(tx_entry->desc[0])) {
 		return rxr_msg_post_cuda_rtm(rxr_ep, tx_entry);
 	}
 
@@ -237,11 +243,11 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 	    efa_both_support_rdma_read(rxr_ep, peer) &&
 	    (tx_entry->desc[0] || efa_is_cache_available(efa_domain))) {
 		/* Read message support FI_DELIVERY_COMPLETE implicitly. */
-		err = rxr_pkt_post_ctrl(rxr_ep, RXR_TX_ENTRY, tx_entry,
+		ret = rxr_pkt_post_ctrl(rxr_ep, RXR_TX_ENTRY, tx_entry,
 					RXR_LONGREAD_MSGRTM_PKT + tagged, 0, 0);
 
-		if (err != -FI_ENOMEM)
-			return err;
+		if (ret != -FI_ENOMEM)
+			return ret;
 
 		/*
 		 * If memory registration failed, we continue here
@@ -249,9 +255,9 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 		 */
 	}
 
-	err = rxr_ep_set_tx_credit_request(rxr_ep, tx_entry);
-	if (OFI_UNLIKELY(err))
-		return err;
+	ret = rxr_ep_set_tx_credit_request(rxr_ep, tx_entry);
+	if (OFI_UNLIKELY(ret))
+		return ret;
 
 	ctrl_type = delivery_complete_requested ? RXR_DC_LONGCTS_MSGRTM_PKT : RXR_LONGCTS_MSGRTM_PKT;
 	tx_entry->rxr_flags |= RXR_LONGCTS_PROTOCOL;

--- a/prov/efa/src/rxr/rxr_pkt_type_base.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_base.c
@@ -96,14 +96,14 @@ uint32_t *rxr_pkt_connid_ptr(struct rxr_pkt_entry *pkt_entry)
  * @param[in]		tx_entry	This function will use iov, iov_count and desc of tx_entry
  * @param[in]		data_offset	offset of the data to be set up. In reference to tx_entry->total_len.
  * @param[in]		data_size	length of the data to be set up. In reference to tx_entry->total_len.
- * @return		no return
+ * @return		0 on success, negative FI code on error
  */
-void rxr_pkt_init_data_from_tx_entry(struct rxr_ep *ep,
-				     struct rxr_pkt_entry *pkt_entry,
-				     size_t hdr_size,
-				     struct rxr_tx_entry *tx_entry,
-				     size_t data_offset,
-				     size_t data_size)
+int rxr_pkt_init_data_from_tx_entry(struct rxr_ep *ep,
+				    struct rxr_pkt_entry *pkt_entry,
+				    size_t hdr_size,
+				    struct rxr_tx_entry *tx_entry,
+				    size_t data_offset,
+				    size_t data_size)
 {
 	int tx_iov_index;
 	char *data;
@@ -118,14 +118,16 @@ void rxr_pkt_init_data_from_tx_entry(struct rxr_ep *ep,
 	 * pkt_entry->send should be allocated successfully
 	 */
 	pkt_entry->send = ofi_buf_alloc(ep->pkt_sendv_pool);
-	if (!pkt_entry->send)
-		FI_WARN(&rxr_prov, FI_LOG_EP_CTRL, "allocate pkt_entry->send failed\n");
 	assert(pkt_entry->send);
+	if (!pkt_entry->send) {
+		FI_WARN(&rxr_prov, FI_LOG_EP_CTRL, "allocate pkt_entry->send failed\n");
+		return -FI_ENOMEM;
+	}
 
 	if (data_size == 0) {
 		pkt_entry->send->iov_count = 0;
 		pkt_entry->pkt_size = hdr_size;
-		return;
+		return 0;
 	}
 
 	rxr_locate_iov_pos(tx_entry->iov, tx_entry->iov_count, data_offset,
@@ -154,7 +156,7 @@ void rxr_pkt_init_data_from_tx_entry(struct rxr_ep *ep,
 		pkt_entry->send->desc[1] = tx_entry->desc[tx_iov_index];
 		pkt_entry->send->iov_count = 2;
 		pkt_entry->pkt_size = hdr_size + data_size;
-		return;
+		return 0;
 	}
 
 	data = pkt_entry->pkt + hdr_size;
@@ -168,6 +170,7 @@ void rxr_pkt_init_data_from_tx_entry(struct rxr_ep *ep,
 	assert(copied == data_size);
 	pkt_entry->send->iov_count = 0;
 	pkt_entry->pkt_size = hdr_size + copied;
+	return 0;
 }
 
 /* @brief return the data size in a packet entry

--- a/prov/efa/src/rxr/rxr_pkt_type_base.h
+++ b/prov/efa/src/rxr/rxr_pkt_type_base.h
@@ -38,11 +38,11 @@
 
 uint32_t *rxr_pkt_connid_ptr(struct rxr_pkt_entry *pkt_entry);
 
-void rxr_pkt_init_data_from_tx_entry(struct rxr_ep *ep,
-				     struct rxr_pkt_entry *pkt_entry,
-				     size_t hdr_size,
-				     struct rxr_tx_entry *tx_entry,
-				     size_t data_offset, size_t data_size);
+int rxr_pkt_init_data_from_tx_entry(struct rxr_ep *ep,
+				    struct rxr_pkt_entry *pkt_entry,
+				    size_t hdr_size,
+				    struct rxr_tx_entry *tx_entry,
+				    size_t data_offset, size_t data_size);
 
 ssize_t rxr_pkt_copy_data_to_rx_entry(struct rxr_ep *ep,
 				      struct rxr_rx_entry *rx_entry,

--- a/prov/efa/src/rxr/rxr_pkt_type_data.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_data.c
@@ -44,6 +44,7 @@ int rxr_pkt_init_data(struct rxr_ep *ep,
 	struct rxr_data_hdr *data_hdr;
 	struct rdm_peer *peer;
 	size_t hdr_size;
+	int ret;
 
 	data_hdr = rxr_get_data_hdr(pkt_entry->pkt);
 	data_hdr->type = RXR_DATA_PKT;
@@ -67,13 +68,14 @@ int rxr_pkt_init_data(struct rxr_ep *ep,
 	data_hdr->seg_length = MIN(tx_entry->total_len - tx_entry->bytes_sent,
 				   ep->max_data_payload_size);
 	data_hdr->seg_length = MIN(data_hdr->seg_length, tx_entry->window);
-	rxr_pkt_init_data_from_tx_entry(ep, pkt_entry, hdr_size,
-					tx_entry, tx_entry->bytes_sent, data_hdr->seg_length);
+	ret = rxr_pkt_init_data_from_tx_entry(ep, pkt_entry, hdr_size,
+					      tx_entry, tx_entry->bytes_sent,
+					      data_hdr->seg_length);
 
 	pkt_entry->x_entry = (void *)tx_entry;
 	pkt_entry->addr = tx_entry->addr;
 
-	return 0;
+	return ret;
 }
 
 void rxr_pkt_handle_data_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -320,6 +320,7 @@ int rxr_pkt_init_readrsp(struct rxr_ep *ep,
 			 struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_readrsp_hdr *readrsp_hdr;
+	int ret;
 
 	readrsp_hdr = rxr_get_readrsp_hdr(pkt_entry->pkt);
 	readrsp_hdr->type = RXR_READRSP_PKT;
@@ -333,9 +334,9 @@ int rxr_pkt_init_readrsp(struct rxr_ep *ep,
 				      tx_entry->total_len);
 
 	pkt_entry->addr = tx_entry->addr;
-	rxr_pkt_init_data_from_tx_entry(ep, pkt_entry, sizeof(struct rxr_readrsp_hdr), 
-					tx_entry, 0, readrsp_hdr->seg_length);
-	return 0;
+	ret = rxr_pkt_init_data_from_tx_entry(ep, pkt_entry, sizeof(struct rxr_readrsp_hdr),
+					      tx_entry, 0, readrsp_hdr->seg_length);
+	return ret;
 }
 
 void rxr_pkt_handle_readrsp_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -377,13 +377,15 @@ size_t rxr_pkt_req_max_data_size(struct rxr_ep *ep, fi_addr_t addr, int pkt_type
  *     init() functions
  */
 static inline
-void rxr_pkt_init_rtm(struct rxr_ep *ep,
-		      struct rxr_tx_entry *tx_entry,
-		      int pkt_type, uint64_t data_offset,
-		      struct rxr_pkt_entry *pkt_entry)
+int rxr_pkt_init_rtm(struct rxr_ep *ep,
+		     struct rxr_tx_entry *tx_entry,
+		     int pkt_type, uint64_t data_offset,
+		     struct rxr_pkt_entry *pkt_entry)
 {
 	size_t data_size;
 	struct rxr_rtm_base_hdr *rtm_hdr;
+	int ret;
+
 	rxr_pkt_init_req_hdr(ep, tx_entry, pkt_type, pkt_entry);
 
 	rtm_hdr = (struct rxr_rtm_base_hdr *)pkt_entry->pkt;
@@ -392,15 +394,19 @@ void rxr_pkt_init_rtm(struct rxr_ep *ep,
 
 	data_size = MIN(tx_entry->total_len - data_offset,
 			ep->mtu_size - rxr_pkt_req_hdr_size(pkt_entry));
-	rxr_pkt_init_data_from_tx_entry(ep, pkt_entry, rxr_pkt_req_hdr_size(pkt_entry),
-					tx_entry, data_offset, data_size);
+	ret = rxr_pkt_init_data_from_tx_entry(ep, pkt_entry, rxr_pkt_req_hdr_size(pkt_entry),
+					      tx_entry, data_offset, data_size);
+	return ret;
 }
 
 ssize_t rxr_pkt_init_eager_msgrtm(struct rxr_ep *ep,
 				  struct rxr_tx_entry *tx_entry,
 				  struct rxr_pkt_entry *pkt_entry)
 {
-	rxr_pkt_init_rtm(ep, tx_entry, RXR_EAGER_MSGRTM_PKT, 0, pkt_entry);
+	int ret;
+	ret = rxr_pkt_init_rtm(ep, tx_entry, RXR_EAGER_MSGRTM_PKT, 0, pkt_entry);
+	if (ret)
+		return ret;
 	assert(tx_entry->total_len == rxr_pkt_req_data_size(pkt_entry));
 	return 0;
 }
@@ -410,8 +416,11 @@ ssize_t rxr_pkt_init_dc_eager_msgrtm(struct rxr_ep *ep,
 				     struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_dc_eager_msgrtm_hdr *dc_eager_msgrtm_hdr;
+	int ret;
 
-	rxr_pkt_init_rtm(ep, tx_entry, RXR_DC_EAGER_MSGRTM_PKT, 0, pkt_entry);
+	ret = rxr_pkt_init_rtm(ep, tx_entry, RXR_DC_EAGER_MSGRTM_PKT, 0, pkt_entry);
+	if (ret)
+		return ret;
 	dc_eager_msgrtm_hdr = rxr_get_dc_eager_msgrtm_hdr(pkt_entry->pkt);
 	dc_eager_msgrtm_hdr->hdr.send_id = tx_entry->tx_id;
 	return 0;
@@ -422,8 +431,11 @@ ssize_t rxr_pkt_init_eager_tagrtm(struct rxr_ep *ep,
 				  struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_base_hdr *base_hdr;
+	int ret;
 
-	rxr_pkt_init_rtm(ep, tx_entry, RXR_EAGER_TAGRTM_PKT, 0, pkt_entry);
+	ret = rxr_pkt_init_rtm(ep, tx_entry, RXR_EAGER_TAGRTM_PKT, 0, pkt_entry);
+	if (ret)
+		return ret;
 	assert(tx_entry->total_len == rxr_pkt_req_data_size(pkt_entry));
 	base_hdr = rxr_get_base_hdr(pkt_entry->pkt);
 	base_hdr->flags |= RXR_REQ_TAGGED;
@@ -437,8 +449,11 @@ ssize_t rxr_pkt_init_dc_eager_tagrtm(struct rxr_ep *ep,
 {
 	struct rxr_base_hdr *base_hdr;
 	struct rxr_dc_eager_tagrtm_hdr *dc_eager_tagrtm_hdr;
+	int ret;
 
-	rxr_pkt_init_rtm(ep, tx_entry, RXR_DC_EAGER_TAGRTM_PKT, 0, pkt_entry);
+	ret = rxr_pkt_init_rtm(ep, tx_entry, RXR_DC_EAGER_TAGRTM_PKT, 0, pkt_entry);
+	if (ret)
+		return ret;
 	base_hdr = rxr_get_base_hdr(pkt_entry->pkt);
 	base_hdr->flags |= RXR_REQ_TAGGED;
 	rxr_pkt_rtm_settag(pkt_entry, tx_entry->tag);
@@ -453,9 +468,12 @@ ssize_t rxr_pkt_init_medium_msgrtm(struct rxr_ep *ep,
 				   struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_medium_rtm_base_hdr *rtm_hdr;
+	int ret;
 
-	rxr_pkt_init_rtm(ep, tx_entry, RXR_MEDIUM_MSGRTM_PKT,
-			 tx_entry->bytes_sent, pkt_entry);
+	ret = rxr_pkt_init_rtm(ep, tx_entry, RXR_MEDIUM_MSGRTM_PKT,
+			       tx_entry->bytes_sent, pkt_entry);
+	if (ret)
+		return ret;
 	rtm_hdr = rxr_get_medium_rtm_base_hdr(pkt_entry->pkt);
 	rtm_hdr->msg_length = tx_entry->total_len;
 	rtm_hdr->seg_offset = tx_entry->bytes_sent;
@@ -467,9 +485,12 @@ ssize_t rxr_pkt_init_dc_medium_msgrtm(struct rxr_ep *ep,
 				      struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_dc_medium_msgrtm_hdr *dc_medium_msgrtm_hdr;
+	int ret;
 
-	rxr_pkt_init_rtm(ep, tx_entry, RXR_DC_MEDIUM_MSGRTM_PKT,
-			 tx_entry->bytes_sent, pkt_entry);
+	ret = rxr_pkt_init_rtm(ep, tx_entry, RXR_DC_MEDIUM_MSGRTM_PKT,
+			       tx_entry->bytes_sent, pkt_entry);
+	if (ret)
+		return ret;
 
 	dc_medium_msgrtm_hdr = rxr_get_dc_medium_msgrtm_hdr(pkt_entry->pkt);
 	dc_medium_msgrtm_hdr->hdr.msg_length = tx_entry->total_len;
@@ -483,9 +504,12 @@ ssize_t rxr_pkt_init_medium_tagrtm(struct rxr_ep *ep,
 				   struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_medium_rtm_base_hdr *rtm_hdr;
+	int ret;
 
-	rxr_pkt_init_rtm(ep, tx_entry, RXR_MEDIUM_TAGRTM_PKT,
-			 tx_entry->bytes_sent, pkt_entry);
+	ret = rxr_pkt_init_rtm(ep, tx_entry, RXR_MEDIUM_TAGRTM_PKT,
+			       tx_entry->bytes_sent, pkt_entry);
+	if (ret)
+		return ret;
 	rtm_hdr = rxr_get_medium_rtm_base_hdr(pkt_entry->pkt);
 	rtm_hdr->msg_length = tx_entry->total_len;
 	rtm_hdr->seg_offset = tx_entry->bytes_sent;
@@ -499,9 +523,12 @@ ssize_t rxr_pkt_init_dc_medium_tagrtm(struct rxr_ep *ep,
 				      struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_dc_medium_tagrtm_hdr *dc_medium_tagrtm_hdr;
+	int ret;
 
-	rxr_pkt_init_rtm(ep, tx_entry, RXR_DC_MEDIUM_TAGRTM_PKT,
-			 tx_entry->bytes_sent, pkt_entry);
+	ret = rxr_pkt_init_rtm(ep, tx_entry, RXR_DC_MEDIUM_TAGRTM_PKT,
+			       tx_entry->bytes_sent, pkt_entry);
+	if (ret)
+		return ret;
 
 	dc_medium_tagrtm_hdr = rxr_get_dc_medium_tagrtm_hdr(pkt_entry->pkt);
 	dc_medium_tagrtm_hdr->hdr.msg_length = tx_entry->total_len;
@@ -512,34 +539,36 @@ ssize_t rxr_pkt_init_dc_medium_tagrtm(struct rxr_ep *ep,
 	return 0;
 }
 
-void rxr_pkt_init_longcts_rtm(struct rxr_ep *ep,
-			   struct rxr_tx_entry *tx_entry,
-			   int pkt_type,
-			   struct rxr_pkt_entry *pkt_entry)
+int rxr_pkt_init_longcts_rtm(struct rxr_ep *ep,
+			     struct rxr_tx_entry *tx_entry,
+			     int pkt_type,
+			     struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_longcts_rtm_base_hdr *rtm_hdr;
+	int ret;
 
-	rxr_pkt_init_rtm(ep, tx_entry, pkt_type, 0, pkt_entry);
+	ret = rxr_pkt_init_rtm(ep, tx_entry, pkt_type, 0, pkt_entry);
+	if (ret)
+		return ret;
 	rtm_hdr = rxr_get_longcts_rtm_base_hdr(pkt_entry->pkt);
 	rtm_hdr->msg_length = tx_entry->total_len;
 	rtm_hdr->send_id = tx_entry->tx_id;
 	rtm_hdr->credit_request = tx_entry->credit_request;
+	return 0;
 }
 
 ssize_t rxr_pkt_init_longcts_msgrtm(struct rxr_ep *ep,
 				 struct rxr_tx_entry *tx_entry,
 				 struct rxr_pkt_entry *pkt_entry)
 {
-	rxr_pkt_init_longcts_rtm(ep, tx_entry, RXR_LONGCTS_MSGRTM_PKT, pkt_entry);
-	return 0;
+	return rxr_pkt_init_longcts_rtm(ep, tx_entry, RXR_LONGCTS_MSGRTM_PKT, pkt_entry);
 }
 
 ssize_t rxr_pkt_init_dc_longcts_msgrtm(struct rxr_ep *ep,
 				    struct rxr_tx_entry *tx_entry,
 				    struct rxr_pkt_entry *pkt_entry)
 {
-	rxr_pkt_init_longcts_rtm(ep, tx_entry, RXR_DC_LONGCTS_MSGRTM_PKT, pkt_entry);
-	return 0;
+	return rxr_pkt_init_longcts_rtm(ep, tx_entry, RXR_DC_LONGCTS_MSGRTM_PKT, pkt_entry);
 }
 
 ssize_t rxr_pkt_init_longcts_tagrtm(struct rxr_ep *ep,
@@ -547,8 +576,11 @@ ssize_t rxr_pkt_init_longcts_tagrtm(struct rxr_ep *ep,
 				 struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_base_hdr *base_hdr;
+	int ret;
 
-	rxr_pkt_init_longcts_rtm(ep, tx_entry, RXR_LONGCTS_TAGRTM_PKT, pkt_entry);
+	ret = rxr_pkt_init_longcts_rtm(ep, tx_entry, RXR_LONGCTS_TAGRTM_PKT, pkt_entry);
+	if (ret)
+		return ret;
 	base_hdr = rxr_get_base_hdr(pkt_entry->pkt);
 	base_hdr->flags |= RXR_REQ_TAGGED;
 	rxr_pkt_rtm_settag(pkt_entry, tx_entry->tag);
@@ -560,8 +592,11 @@ ssize_t rxr_pkt_init_dc_longcts_tagrtm(struct rxr_ep *ep,
 				    struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_base_hdr *base_hdr;
+	int ret;
 
-	rxr_pkt_init_longcts_rtm(ep, tx_entry, RXR_DC_LONGCTS_TAGRTM_PKT, pkt_entry);
+	ret = rxr_pkt_init_longcts_rtm(ep, tx_entry, RXR_DC_LONGCTS_TAGRTM_PKT, pkt_entry);
+	if (ret)
+		return ret;
 	base_hdr = rxr_get_base_hdr(pkt_entry->pkt);
 	base_hdr->flags |= RXR_REQ_TAGGED;
 	rxr_pkt_rtm_settag(pkt_entry, tx_entry->tag);
@@ -1359,12 +1394,12 @@ void rxr_pkt_handle_rtm_rta_recv(struct rxr_ep *ep,
 }
 
 /*
- * RTW pakcet type functions
+ * RTW packet type functions
  */
-void rxr_pkt_init_rtw_data(struct rxr_ep *ep,
-			   struct rxr_tx_entry *tx_entry,
-			   struct rxr_pkt_entry *pkt_entry,
-			   struct efa_rma_iov *rma_iov)
+int rxr_pkt_init_rtw_data(struct rxr_ep *ep,
+			  struct rxr_tx_entry *tx_entry,
+			  struct rxr_pkt_entry *pkt_entry,
+			  struct efa_rma_iov *rma_iov)
 {
 	size_t hdr_size;
 	size_t data_size;
@@ -1378,7 +1413,7 @@ void rxr_pkt_init_rtw_data(struct rxr_ep *ep,
 
 	hdr_size = rxr_pkt_req_hdr_size(pkt_entry);
 	data_size = MIN(ep->mtu_size - hdr_size, tx_entry->total_len);
-	rxr_pkt_init_data_from_tx_entry(ep, pkt_entry, hdr_size, tx_entry, 0, data_size);
+	return rxr_pkt_init_data_from_tx_entry(ep, pkt_entry, hdr_size, tx_entry, 0, data_size);
 }
 
 ssize_t rxr_pkt_init_eager_rtw(struct rxr_ep *ep,
@@ -1392,8 +1427,7 @@ ssize_t rxr_pkt_init_eager_rtw(struct rxr_ep *ep,
 	rtw_hdr = (struct rxr_eager_rtw_hdr *)pkt_entry->pkt;
 	rtw_hdr->rma_iov_count = tx_entry->rma_iov_count;
 	rxr_pkt_init_req_hdr(ep, tx_entry, RXR_EAGER_RTW_PKT, pkt_entry);
-	rxr_pkt_init_rtw_data(ep, tx_entry, pkt_entry, rtw_hdr->rma_iov);
-	return 0;
+	return rxr_pkt_init_rtw_data(ep, tx_entry, pkt_entry, rtw_hdr->rma_iov);
 }
 
 ssize_t rxr_pkt_init_dc_eager_rtw(struct rxr_ep *ep,
@@ -1401,16 +1435,17 @@ ssize_t rxr_pkt_init_dc_eager_rtw(struct rxr_ep *ep,
 				  struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_dc_eager_rtw_hdr *dc_eager_rtw_hdr;
+	int ret;
 
 	assert(tx_entry->op == ofi_op_write);
 
 	dc_eager_rtw_hdr = (struct rxr_dc_eager_rtw_hdr *)pkt_entry->pkt;
 	dc_eager_rtw_hdr->rma_iov_count = tx_entry->rma_iov_count;
 	rxr_pkt_init_req_hdr(ep, tx_entry, RXR_DC_EAGER_RTW_PKT, pkt_entry);
-	rxr_pkt_init_rtw_data(ep, tx_entry, pkt_entry,
-			      dc_eager_rtw_hdr->rma_iov);
+	ret = rxr_pkt_init_rtw_data(ep, tx_entry, pkt_entry,
+				    dc_eager_rtw_hdr->rma_iov);
 	dc_eager_rtw_hdr->send_id = tx_entry->tx_id;
-	return 0;
+	return ret;
 }
 
 static inline void rxr_pkt_init_longcts_rtw_hdr(struct rxr_ep *ep,
@@ -1438,8 +1473,7 @@ ssize_t rxr_pkt_init_longcts_rtw(struct rxr_ep *ep,
 
 	rtw_hdr = (struct rxr_longcts_rtw_hdr *)pkt_entry->pkt;
 	rxr_pkt_init_longcts_rtw_hdr(ep, tx_entry, pkt_entry, RXR_LONGCTS_RTW_PKT);
-	rxr_pkt_init_rtw_data(ep, tx_entry, pkt_entry, rtw_hdr->rma_iov);
-	return 0;
+	return rxr_pkt_init_rtw_data(ep, tx_entry, pkt_entry, rtw_hdr->rma_iov);
 }
 
 ssize_t rxr_pkt_init_dc_longcts_rtw(struct rxr_ep *ep,
@@ -1452,9 +1486,7 @@ ssize_t rxr_pkt_init_dc_longcts_rtw(struct rxr_ep *ep,
 
 	rtw_hdr = (struct rxr_longcts_rtw_hdr *)pkt_entry->pkt;
 	rxr_pkt_init_longcts_rtw_hdr(ep, tx_entry, pkt_entry, RXR_DC_LONGCTS_RTW_PKT);
-	rxr_pkt_init_rtw_data(ep, tx_entry, pkt_entry, rtw_hdr->rma_iov);
-
-	return 0;
+	return rxr_pkt_init_rtw_data(ep, tx_entry, pkt_entry, rtw_hdr->rma_iov);
 }
 
 ssize_t rxr_pkt_init_longread_rtw(struct rxr_ep *ep,

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -341,6 +341,11 @@ ssize_t rxr_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uint64_
 		use_lower_ep_read = true;
 	}
 
+	/*
+	 * Not going to check efa_ep->hmem_p2p_opt here, if the remote side
+	 * gave us a valid MR we should just honor the request even if p2p is
+	 * disabled.
+	 */
 	if (use_lower_ep_read) {
 		err = rxr_read_post_remote_read_or_queue(rxr_ep, RXR_TX_ENTRY, tx_entry);
 		if (OFI_UNLIKELY(err == -FI_ENOBUFS)) {

--- a/src/hmem_cuda.c
+++ b/src/hmem_cuda.c
@@ -139,6 +139,16 @@ static cudaError_t ofi_cudaGetDeviceCount(int *count)
 	return cuda_ops.cudaGetDeviceCount(count);
 }
 
+cudaError_t ofi_cudaMalloc(void **ptr, size_t size)
+{
+	return cuda_ops.cudaMalloc(ptr, size);
+}
+
+cudaError_t ofi_cudaFree(void *ptr)
+{
+	return cuda_ops.cudaFree(ptr);
+}
+
 int cuda_copy_to_dev(uint64_t device, void *dst, const void *src, size_t size)
 {
 	if (hmem_cuda_use_gdrcopy) {


### PR DESCRIPTION
This series uses the new FI_OPT_FI_HMEM_P2P option, adds some state to track whether an FI_HMEM device is initialized, and also makes some changes to fix some FI_HMEM issues as well as allow for CUDA copies when in that mode.