### PR TITLE
fabtests/multinode_coll: Add test with start_addr != 0 and stride != 1

### DIFF
--- a/fabtests/multinode/src/core_coll.c
+++ b/fabtests/multinode/src/core_coll.c
@@ -59,6 +59,20 @@ fi_addr_t world_addr;
 fi_addr_t coll_addr;
 struct fid_mc *coll_mc;
 
+// For the verification
+struct fi_av_set_attr av_set_attr;
+
+static bool is_my_rank_participating()
+{
+	size_t rank = pm_job.my_rank;
+	if (rank < av_set_attr.start_addr)
+		return false;
+	if (rank > av_set_attr.end_addr)
+		return false;
+	if ((rank - av_set_attr.start_addr) % av_set_attr.stride != 0)
+		return false;
+	return true;
+}
 
 static int wait_for_event(uint32_t event)
 {
@@ -119,15 +133,17 @@ static int wait_for_comp(void *ctx)
 	return err;
 }
 
-static int coll_setup()
+static int coll_setup_w_start_addr_stride(int start_addr, int stride)
 {
 	int err;
-	struct fi_av_set_attr av_set_attr;
 
-	av_set_attr.count = pm_job.num_ranks;
-	av_set_attr.start_addr = 0;
+	av_set_attr.count = 0;
+	av_set_attr.start_addr = start_addr;
 	av_set_attr.end_addr = pm_job.num_ranks - 1;
-	av_set_attr.stride = 1;
+	av_set_attr.stride = stride;
+
+	if (!is_my_rank_participating())
+		return FI_SUCCESS;
 
 	err = fi_av_set(av, &av_set_attr, &av_set, NULL);
 	if (err) {
@@ -150,8 +166,20 @@ static int coll_setup()
 	return wait_for_event(FI_JOIN_COMPLETE);
 }
 
+static int coll_setup()
+{
+	return coll_setup_w_start_addr_stride(/*start_addr=*/0, /*stride=*/1);
+}
+
+static int coll_setup_w_stride()
+{
+	return coll_setup_w_start_addr_stride(/*start_addr=*/1, /*stride=*/2);
+}
+
 static void coll_teardown()
 {
+	if (!is_my_rank_participating())
+		return;
 	fi_close(&coll_mc->fid);
 	fi_close(&av_set->fid);
 }
@@ -193,10 +221,18 @@ static int sum_all_reduce_test_run()
 	uint64_t done_flag;
 	uint64_t result = 0;
 	uint64_t expect_result = 0;
-	uint64_t data = pm_job.my_rank;
+	uint64_t data;
+	const uint64_t base_data_value = 1234; /* any arbitrary value != 0 */
 	size_t count = 1;
 	uint64_t i;
 	struct fi_collective_attr attr;
+
+	if (!is_my_rank_participating())
+		return FI_SUCCESS;
+
+	// Set to rank + base_data_value to make the participation of rank 0
+	// verifiable
+	data = base_data_value + pm_job.my_rank;
 
 	attr.op = FI_SUM;
 	attr.datatype = FI_UINT64;
@@ -208,8 +244,10 @@ static int sum_all_reduce_test_run()
 		return err;
 	}
 
-	for (i = 0; i < pm_job.num_ranks; i++) {
-		expect_result += i;
+	for (i = av_set_attr.start_addr;
+	     i <= av_set_attr.end_addr;
+	     i += av_set_attr.stride) {
+		expect_result += base_data_value + i;
 	}
 
 	coll_addr = fi_mc_addr(coll_mc);
@@ -431,6 +469,12 @@ struct coll_test tests[] = {
 	{
 		.name = "sum_all_reduce_test",
 		.setup = coll_setup,
+		.run = sum_all_reduce_test_run,
+		.teardown = coll_teardown
+	},
+	{
+		.name = "sum_all_reduce_w_stride_test",
+		.setup = coll_setup_w_stride,
 		.run = sum_all_reduce_test_run,
 		.teardown = coll_teardown
 	},


### PR DESCRIPTION
Add a test case for when av_set_attr.start_addr != 0 and
av_set_attr.stride != 1.

It runs an extra test with sum_all_reduce_test_run targetting half of
the ranks.

The test is now using data offseted by base_data_value to be able to
check if rank 0 takes part or not in the collective.

Signed-off-by: Olivier Serres <oserres@google.com>