### PR TITLE
core: Define XPU triggering capability

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -166,6 +166,7 @@ typedef struct fid *fid_t;
 #define FI_COMMIT_COMPLETE	(1ULL << 30)
 #define FI_MATCH_COMPLETE	(1ULL << 31)
 
+#define FI_XPU			(1ULL << 45)
 #define FI_HMEM_DEVICE_ONLY	(1ULL << 46)
 #define FI_HMEM			(1ULL << 47)
 #define FI_VARIABLE_MSG		(1ULL << 48)

--- a/include/rdma/fi_endpoint.h
+++ b/include/rdma/fi_endpoint.h
@@ -66,6 +66,7 @@ enum {
 	FI_OPT_RECV_BUF_SIZE,
 	FI_OPT_TX_SIZE,
 	FI_OPT_RX_SIZE,
+	FI_OPT_XPU_TRIGGER,		/* struct fi_trigger_xpu */
 };
 
 struct fi_ops_ep {

--- a/include/rdma/fi_trigger.h
+++ b/include/rdma/fi_trigger.h
@@ -45,6 +45,7 @@ extern "C" {
 
 enum fi_trigger_event {
 	FI_TRIGGER_THRESHOLD,
+	FI_TRIGGER_XPU,
 };
 
 enum fi_op_type {
@@ -64,6 +65,30 @@ enum fi_op_type {
 struct fi_trigger_threshold {
 	struct fid_cntr		*cntr;
 	size_t			threshold;
+};
+
+struct fi_trigger_var {
+	enum fi_datatype	datatype;
+	int			count;
+	void			*addr;
+	union {
+		uint8_t		val8;
+		uint16_t	val16;
+		uint32_t	val32;
+		uint64_t	val64;
+		uint8_t		*data;
+	} value;
+};
+
+struct fi_trigger_xpu {
+	int			count;
+	enum fi_hmem_iface	iface;
+	union {
+		uint64_t	reserved;
+		int		cuda;
+		int		ze;
+	} device;
+	struct fi_trigger_var	*var;
 };
 
 struct fi_op_msg {
@@ -121,6 +146,7 @@ struct fi_triggered_context {
 	enum fi_trigger_event			event_type;
 	union {
 		struct fi_trigger_threshold	threshold;
+		struct fi_trigger_xpu		xpu;
 		void				*internal[3];
 	} trigger;
 };
@@ -130,6 +156,7 @@ struct fi_triggered_context2 {
 	enum fi_trigger_event			event_type;
 	union {
 		struct fi_trigger_threshold	threshold;
+		struct fi_trigger_xpu		xpu;
 		void				*internal[7];
 	} trigger;
 };

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -520,6 +520,22 @@ The following option levels and option names and parameters are defined.
   that applications that want to override the default MIN_MULTI_RECV
   value set this option before enabling the corresponding endpoint.
 
+- *FI_OPT_XPU_TRIGGER - struct fi_trigger_xpu \**
+: This option only applies to the fi_getopt() call.  It is used to query
+  the maximum number of variables required to support XPU
+  triggered operations, along with the size of each variable.
+
+  The user provides a filled out struct fi_trigger_xpu on input.  The iface
+  and device fields should reference an HMEM domain.  If the provider does not
+  support XPU triggered operations from the given device, fi_getopt() will
+  return -FI_EOPNOTSUPP.  On input, var should reference an array of
+  struct fi_trigger_var data structures, with count set to the size of the
+  referenced array.  If count is 0, the var field will be ignored, and the
+  provider will return the number of fi_trigger_var structures needed.  If
+  count is > 0, the provider will set count to the needed value, and for
+  each fi_trigger_var available, set the datatype and count of the variable
+  used for the trigger.
+
 ## fi_tc_dscp_set
 
 This call converts a DSCP defined value into a libfabric traffic class value.
@@ -890,7 +906,7 @@ capability bits from the fi_info structure will be used.
 The following capabilities apply to the transmit attributes: FI_MSG,
 FI_RMA, FI_TAGGED, FI_ATOMIC, FI_READ, FI_WRITE, FI_SEND, FI_HMEM,
 FI_TRIGGER, FI_FENCE, FI_MULTICAST, FI_RMA_PMEM, FI_NAMED_RX_CTX,
-and FI_COLLECTIVE.
+FI_COLLECTIVE, and FI_XPU.
 
 Many applications will be able to ignore this field and rely solely
 on the fi_info::caps field.  Use of this field provides fine grained
@@ -1198,8 +1214,8 @@ capability bits from the fi_info structure will be used.
 The following capabilities apply to the receive attributes: FI_MSG,
 FI_RMA, FI_TAGGED, FI_ATOMIC, FI_REMOTE_READ, FI_REMOTE_WRITE, FI_RECV,
 FI_HMEM, FI_TRIGGER, FI_RMA_PMEM, FI_DIRECTED_RECV, FI_VARIABLE_MSG,
-FI_MULTI_RECV, FI_SOURCE, FI_RMA_EVENT, FI_SOURCE_ERR, and
-FI_COLLECTIVE.
+FI_MULTI_RECV, FI_SOURCE, FI_RMA_EVENT, FI_SOURCE_ERR, FI_COLLECTIVE,
+and FI_XPU.
 
 Many applications will be able to ignore this field and rely solely
 on the fi_info::caps field.  Use of this field provides fine grained

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -412,7 +412,7 @@ additional optimizations.
 *FI_TRIGGER*
 : Indicates that the endpoint should support triggered operations.
   Endpoints support this capability must meet the usage model as
-  described by fi_trigger.3.
+  described by [`fi_trigger`(3)](fi_trigger.3.html).
 
 *FI_VARIABLE_MSG*
 
@@ -428,6 +428,12 @@ additional optimizations.
 : Indicates that the user requires an endpoint capable of initiating
   writes against remote memory regions.  This flag requires that FI_RMA
   and/or FI_ATOMIC be set.
+
+*FI_XPU*
+: Specifies that the endpoint should support transfers that may be initiated
+  from heterogenous computation devices, such as GPUs.  This flag requires
+  that FI_TRIGGER be set.  For additional details on XPU triggers see
+  [`fi_trigger`(3)](fi_trigger.3.html).
 
 Capabilities may be grouped into three general categories: primary,
 secondary, and primary modifiers.  Primary capabilities must explicitly
@@ -445,7 +451,8 @@ may optionally report non-selected secondary capabilities if doing so
 would not compromise performance or security.
 
 Primary capabilities: FI_MSG, FI_RMA, FI_TAGGED, FI_ATOMIC, FI_MULTICAST,
-FI_NAMED_RX_CTX, FI_DIRECTED_RECV, FI_VARIABLE_MSG, FI_HMEM, FI_COLLECTIVE
+FI_NAMED_RX_CTX, FI_DIRECTED_RECV, FI_VARIABLE_MSG, FI_HMEM, FI_COLLECTIVE,
+FI_XPU
 
 Primary modifiers: FI_READ, FI_WRITE, FI_RECV, FI_SEND,
 FI_REMOTE_READ, FI_REMOTE_WRITE
@@ -752,3 +759,4 @@ Multiple threads may call
 [`fi_endpoint`(3)](fi_endpoint.3.html),
 [`fi_domain`(3)](fi_domain.3.html),
 [`fi_nic`(3)](fi_nic.3.html)
+[`fi_trigger`(3)](fi_trigger.3.html)

--- a/man/fi_trigger.3.md
+++ b/man/fi_trigger.3.md
@@ -19,13 +19,15 @@ fi_trigger - Triggered operations
 
 Triggered operations allow an application to queue a data transfer
 request that is deferred until a specified condition is met.  A typical
-use is to send a message only after receiving all input data.
+use is to send a message only after receiving all input data.  Triggered
+operations can help reduce the latency needed to initiate a transfer by
+removing the need to return control back to an application prior to
+the data transfer starting.
 
-A triggered operation may be requested by specifying the FI_TRIGGER
-flag as part of the operation.  Alternatively, an endpoint alias may
-be created and configured with the FI_TRIGGER flag.  Such an endpoint
-is referred to as a trigger-able endpoint.  All data transfer
-operations on a trigger-able endpoint are deferred.
+An endpoint must be created with the FI_TRIGGER capability in order
+for triggered operations to be specified.  A triggered operation is
+requested by specifying the FI_TRIGGER flag as part of the operation.
+Such an endpoint is referred to as a trigger-able endpoint.
 
 Any data transfer operation is potentially trigger-able, subject to
 provider constraints.  Trigger-able endpoints are initialized such that
@@ -51,18 +53,20 @@ is described below.
 
 ```c
 struct fi_triggered_context {
-	enum fi_trigger_event         event_type;   /* trigger type */
+	enum fi_trigger_event event_type;   /* trigger type */
 	union {
 		struct fi_trigger_threshold threshold;
-		void                        *internal[3]; /* reserved */
+		struct fi_trigger_xpu xpu;
+		void *internal[3]; /* reserved */
 	} trigger;
 };
 
 struct fi_triggered_context2 {
-	enum fi_trigger_event         event_type;   /* trigger type */
+	enum fi_trigger_event event_type;   /* trigger type */
 	union {
 		struct fi_trigger_threshold threshold;
-		void                        *internal[7]; /* reserved */
+		struct fi_trigger_xpu xpu;
+		void *internal[7]; /* reserved */
 	} trigger;
 };
 ```
@@ -71,15 +75,20 @@ The triggered context indicates the type of event assigned to the
 trigger, along with a union of trigger details that is based on the
 event type.
 
-## TRIGGER EVENTS
+# COMPLETION BASED TRIGGERS
 
-The following trigger events are defined.
+Completion based triggers defer a data transfer until one or more
+related data transfers complete.  For example, a send operation may
+be deferred until a receive operation completes, indicating that the
+data to be transferred is now available.
+
+The following trigger event related to completion based transfers
+is defined.
 
 *FI_TRIGGER_THRESHOLD*
 : This indicates that the data transfer operation will be deferred
   until an event counter crosses an application specified threshold
-  value.  The threshold is specified using struct
-  fi_trigger_threshold:
+  value.  The threshold is specified using struct fi_trigger_threshold:
 
 ```c
 struct fi_trigger_threshold {
@@ -93,6 +102,124 @@ struct fi_trigger_threshold {
   greater than 1.  If two triggered operations have the same threshold,
   they will be triggered in the order in which they were submitted to
   the endpoint.
+
+# XPU TRIGGERS
+
+XPU based triggers work in conjunction with heterogenous memory (FI_HMEM
+capability).  XPU triggers define a split execution model for specifying
+a data transfer separately from initiating the transfer.  Unlike completion
+triggers, the user controls the timing of when the transfer starts by
+writing data into a trigger variable location.
+
+XPU transfers allow the requesting and triggering to occur on separate
+computational domains.  For example, a process running on the host CPU can
+setup a data transfer, with a compute kernel running on a GPU signaling
+the start of the transfer.  XPU refers to a CPU, GPU, FPGA, or other
+acceleration device with some level of computational ability.
+
+Endpoints must be created with both the FI_TRIGGER and FI_XPU capabilities
+to use XPU triggers.  XPU triggered enabled endpoints only support XPU
+triggered operations.  The behavior of mixing XPU triggered operations with
+normal data transfers or non-XPU triggered operations is not defined by
+the API and subject to provider support and implementation.
+
+The use of XPU triggers requires coordination between the fabric provider,
+application, and submitting XPU.  The result is that hardware
+implementation details need to be conveyed across the computational domains.
+The XPU trigger API abstracts those details.  When submitting a XPU trigger
+operation, the user identifies the XPU where the triggering will
+occur.  The triggering XPU must match with the location of the local memory
+regions.  For example, if triggering will be done by a GPU kernel, the
+type of GPU and its local identifier are given.  As output, the fabric
+provider will return a list of variables and corresponding values.
+The XPU signals that the data transfer is safe to initiate by writing
+the given values to the specified variable locations.  The number of
+variables and their sizes are provider specific.
+
+XPU trigger operations are submitted using the FI_TRIGGER flag with
+struct fi_triggered_context or struct fi_triggered_context2, as
+required by the provider.  The trigger event_type is:
+
+*FI_TRIGGER_XPU*
+: Indicates that the data transfer operation will be deferred until
+  the user writes provider specified data to provider indicated
+  memory locations.  The user indicates which device will initiate
+  the write.  The struct fi_trigger_xpu is used to convey both
+  input and output data regarding the signaling of the trigger.
+
+```c
+struct fi_trigger_var {
+	enum fi_datatype datatype;
+	int count;
+	void *addr;
+	union {
+		uint8_t val8;
+		uint16_t val16;
+		uint32_t val32;
+		uint64_t val64;
+		uint8_t *data;
+	} value;
+};
+
+struct fi_trigger_xpu {
+	int count;
+	enum fi_hmem_iface iface;
+	union {
+		uint64_t reserved;
+		int cuda;
+		int ze;
+	} device;
+	struct fi_trigger_var *var;
+};
+```
+
+On input to a triggered operation, the iface field indicates the software
+interface that will be used to write the variables.  The device union
+specifies the device identifier.  For valid iface and device values, see
+[`fi_mr`(3)](fi_mr.3.html).  The iface and device must match with the
+iface and device of any local HMEM memory regions.  Count should be set
+to the number of fi_trigger_var structures available, with the var field
+pointing to an array of struct fi_trigger_var.  The user is responsible for
+ensuring that there are sufficient fi_trigger_var structures available and of
+an appropriate size.  The count and size of fi_trigger_var structures
+can be obtained by calling fi_getopt() on the endpoint with the
+FI_OPT_XPU_TRIGGER option.  See [`fi_endpoint`(3)](fi_endpoint.3.html)
+for details.
+
+Each fi_trigger_var structure referenced should have the datatype
+and count fields initialized to the number of values referenced by the
+struct fi_trigger_val.  If the count is 1, one of the val fields will be used
+to return the necessary data (val8, val16, etc.).  If count > 1, the data
+field will return all necessary data used to signal the trigger.  The data
+field must reference a buffer large enough to hold the returned bytes.
+
+On output, the provider will set the fi_trigger_xpu count to the number of
+fi_trigger_var variables that must be signaled.  Count will be less than or
+equal to the input value.  The provider will initialize each valid
+fi_trigger_var entry with information needed to signal the trigger.  The
+datatype indicates the size of the data that must be written.  Valid datatype
+values are FI_UINT8, FI_UINT16, FI_UINT32, and FI_UINT64.  For signal
+variables <= 64 bits, the count field will be 1.  If a trigger requires writing
+more than 64-bits, the datatype field will be set to FI_UINT8, with count set
+to the number of bytes that must be written.  The data that must be written
+to signal the start of an operation is returned through either the value
+union val fields or data array.
+
+Users signal the start of a transfer by writing the returned data to the
+given memory address.  The write must occur from the specified input XPU
+location (based on the iface and device fields).  If a transfer cannot
+be initiated for some reason, such as an error occurring before the
+transfer can start, the triggered operation should
+be canceled to release any allocated resources.  If multiple variables are
+specified, they must be updated in order.
+
+Note that the provider will not modify the fi_trigger_xpu or fi_trigger_var
+structures after returning from the data transfer call.
+
+In order to support multiple provider implementations, users should trigger
+data transfer operations in the same order that they are queued and should
+serialize the writing of triggers that reference the same endpoint.  Providers
+may return the same trigger variable for multiple data transfer requests.
 
 # DEFERRED WORK QUEUES
 
@@ -187,5 +314,6 @@ provider, it will fail the operation with -FI_ENOSYS.
 
 [`fi_getinfo`(3)](fi_getinfo.3.html),
 [`fi_endpoint`(3)](fi_endpoint.3.html),
+[`fi_mr`(3)](fi_mr.3.html),
 [`fi_alias`(3)](fi_alias.3.html),
 [`fi_cntr`(3)](fi_cntr.3.html)


### PR DESCRIPTION
Many HPC and AI applications use GPUs or other accelerator devices
to perform computation work.  FI_HMEM support allows a NIC
provider to send and receive data stored on a GPU.  However,
the data transfer itself must still be initiated by the host
CPU.  This introduces delays from the time the data is ready to
be transfered until the network transfer is initiated.  Once
the GPU is done processing the data, it must signal the CPU
that the processing is complete, and then the CPU can request
the network transfer.

This patch introduces a new type of triggered operation, called
an XPU trigger.  An XPU trigger works as follows:

1. An endpoint is created with XPU triggering support.  By
default, all data transfers posted to the endpoint follow
the XPU triggering model.

2. The host CPU makes a data transfer call (e.g. fi_write)
with the FI_TRIGGER flag set.  The triggering event is
FI_TRIGGER_XPU.

3. A provider responds to the data transfer call by queuing
the transfer, but will not initiate the transfer until a
provider specified signal is set.  The signal may be signaled
by a device, such as a GPU or FPGA, referred to as an XPU.

4. Once an XPU writes the signal, the provider will initiate
the data transfer.

Details and restrictions are defined as part of the man
page updates.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>