### PR TITLE
core: Fix ofi_init race condition

### DIFF
--- a/src/var.c
+++ b/src/var.c
@@ -43,7 +43,6 @@
 #include "ofi_list.h"
 
 
-extern int ofi_init;
 extern void fi_ini(void);
 
 struct fi_param_entry {
@@ -87,8 +86,7 @@ int DEFAULT_SYMVER_PRE(fi_getparams)(struct fi_param **params, int *count)
 	int cnt, i;
 	char *tmp;
 
-	if (!ofi_init)
-		fi_ini();
+	fi_ini();
 
 	for (entry = param_list.next, cnt = 0; entry != &param_list;
 	     entry = entry->next)


### PR DESCRIPTION
The ofi_init is set to true when the initialization is complete. However,
if it is tested without holding the associated lock, it has a potential
race conditions (e.g. the compiler could reorder the stores in fi_ini
setting ofi_init before the initialization is fully complete, and even
when the compiler doesn't reorder thing, on some architectures the CPU
could).

This can be solved in two ways; putting a memory barrier before ofi_init
= 1 or holding the mutex.
The barrier solution  is error prone if we ever change the code to put
back ofi_init = 0 and harder for tools to validate.

This fix makes sure the mutex is held while considering ofi_init. This
is done in two ways:
- if the test was made to call fi_ini, then simply call fi_ini as the
test is performed there, and the function while immediately return if
the initialization is done.
- for the destructor fi_fini, hold the mutex and set back ofi_init to 0.

Signed-off-by: Olivier Serres <oserres@google.com>