### PR TITLE
prov/efa: Fix memory leak in efa_device_init by device_list

### DIFF
--- a/prov/efa/src/efa_device.c
+++ b/prov/efa/src/efa_device.c
@@ -90,8 +90,12 @@ int efa_device_init(void)
 	fastlock_init(&pd_list_lock);
 
 	device_list = ibv_get_device_list(&dev_cnt);
-	if (dev_cnt <= 0)
-		return -ENODEV;
+	if (device_list == NULL)
+		return -ENOMEM;
+	if (dev_cnt <= 0) {
+		ret = -ENODEV;
+		goto err_free_dev_list;
+	}
 
 	ctx_list = calloc(dev_cnt, sizeof(*ctx_list));
 	if (!ctx_list) {


### PR DESCRIPTION
Even when the number of ibv devices is 0, the NULL terminated device_list is
returned and needs to be free with ibv_free_device_list to not leak
memory.

The efa_device_init function is changed to:
- return -ENOMEM if ibv_get_device_list didn't have enough memory to
allocate the list.
- Free the device list and return -ENODEV if there is 0 device
available.

Signed-off-by: Olivier Serres <oserres@google.com>