### PR TITLE
fabtests/multinode_coll: Fix memory leaks

### DIFF
--- a/fabtests/multinode/src/core_coll.c
+++ b/fabtests/multinode/src/core_coll.c
@@ -379,8 +379,10 @@ static int broadcast_test_run()
 		return -FI_ENOMEM;
 
 	data = malloc(data_cnt * sizeof(*data));
-	if (!data)
+	if (!data) {
+		free(result);
 		return -FI_ENOMEM;
+	}
 
 	for (i = 0; i < pm_job.num_ranks; ++i) {
 		data[i] = pm_job.num_ranks - 1 - i;


### PR DESCRIPTION
Free the following arrays even in case of success:

- all_gather_test_run: result, expect_result
- scatter_test_run: data

Added a test for allocation failure in all_gather_test_run
Free result if the data allocation fails in broadcast_test_run

Signed-off-by: Olivier Serres <oserres@google.com>