### PR TITLE
prov/tcp: Cleanup reporting of CQ flags and optimize RMA handling

### DIFF
--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -290,7 +290,7 @@ struct tcpx_xfer_entry {
 	size_t			iov_cnt;
 	struct iovec		iov[TCPX_IOV_LIMIT+1];
 	struct tcpx_ep		*ep;
-	uint64_t		flags;
+	uint64_t		cq_flags;
 	uint32_t		ctrl_flags;
 	uint32_t		async_index;
 	void			*context;
@@ -401,6 +401,24 @@ tcpx_set_commit_flags(struct tcpx_xfer_entry *xfer, uint64_t flags)
 	}
 }
 
+static inline uint64_t
+tcpx_tx_completion_flag(struct tcpx_ep *ep, uint64_t op_flags)
+{
+	/* Generate a completion if op flags indicate or we generate
+	 * completions by default
+	 */
+	return (ep->util_ep.tx_op_flags | op_flags) & FI_COMPLETION;
+}
+
+static inline uint64_t
+tcpx_rx_completion_flag(struct tcpx_ep *ep, uint64_t op_flags)
+{
+	/* Generate a completion if op flags indicate or we generate
+	 * completions by default
+	 */
+	return (ep->util_ep.rx_op_flags | op_flags) & FI_COMPLETION;
+}
+
 static inline struct tcpx_xfer_entry *
 tcpx_alloc_xfer(struct tcpx_cq *cq)
 {
@@ -417,7 +435,7 @@ static inline void
 tcpx_free_xfer(struct tcpx_cq *cq, struct tcpx_xfer_entry *xfer)
 {
 	xfer->hdr.base_hdr.flags = 0;
-	xfer->flags = 0;
+	xfer->cq_flags = 0;
 	xfer->ctrl_flags = 0;
 	xfer->context = 0;
 

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -157,10 +157,10 @@ void tcpx_cq_report_success(struct util_cq *cq,
 	size_t len;
 
 	if (!(xfer_entry->flags & FI_COMPLETION) ||
-	    (xfer_entry->flags & TCPX_INTERNAL_XFER))
+	    (xfer_entry->ctrl_flags & TCPX_INTERNAL_XFER))
 		return;
 
-	flags = xfer_entry->flags & ~TCPX_INTERNAL_MASK;
+	flags = xfer_entry->flags & ~FI_COMPLETION;
 	if (flags & FI_RECV) {
 		len = xfer_entry->hdr.base_hdr.size -
 		      xfer_entry->hdr.base_hdr.hdr_size;
@@ -188,10 +188,10 @@ void tcpx_cq_report_error(struct util_cq *cq,
 {
 	struct fi_cq_err_entry err_entry;
 
-	if (xfer_entry->flags & TCPX_INTERNAL_XFER)
+	if (xfer_entry->ctrl_flags & TCPX_INTERNAL_XFER)
 		return;
 
-	err_entry.flags = xfer_entry->flags & ~TCPX_INTERNAL_MASK;
+	err_entry.flags = xfer_entry->flags & ~FI_COMPLETION;
 	if (err_entry.flags & FI_RECV) {
 		tcpx_get_cq_info(xfer_entry, &err_entry.flags, &err_entry.data,
 				 &err_entry.tag);

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -412,7 +412,7 @@ static struct tcpx_xfer_entry *tcpx_get_rx_entry(struct tcpx_ep *ep)
 		if (!slist_empty(&srx->rx_queue)) {
 			xfer = container_of(slist_remove_head(&srx->rx_queue),
 					    struct tcpx_xfer_entry, entry);
-			xfer->flags |= ep->util_ep.rx_op_flags & FI_COMPLETION;
+			xfer->cq_flags |= tcpx_rx_completion_flag(ep, 0);
 		} else {
 			xfer = NULL;
 		}
@@ -565,10 +565,9 @@ int tcpx_op_write(struct tcpx_ep *ep)
 	if (!rx_entry)
 		return -FI_ENOMEM;
 
-	rx_entry->flags = 0;
 	if (ep->cur_rx.hdr.base_hdr.flags & TCPX_REMOTE_CQ_DATA) {
-		rx_entry->flags = (FI_COMPLETION | FI_REMOTE_WRITE |
-				   FI_REMOTE_CQ_DATA);
+		rx_entry->cq_flags = (FI_COMPLETION | FI_REMOTE_WRITE |
+				      FI_REMOTE_CQ_DATA);
 	} else {
 		rx_entry->ctrl_flags = TCPX_INTERNAL_XFER;
 	}

--- a/prov/tcp/src/tcpx_rma.c
+++ b/prov/tcp/src/tcpx_rma.c
@@ -74,7 +74,7 @@ static void tcpx_rma_read_send_entry_fill(struct tcpx_xfer_entry *send_entry,
 	send_entry->iov[0].iov_len = offset;
 	send_entry->iov_cnt = 1;
 	send_entry->context = msg->context;
-	send_entry->flags = TCPX_NEED_RESP;
+	send_entry->ctrl_flags = TCPX_NEED_RESP;
 	send_entry->resp_entry = recv_entry;
 }
 
@@ -89,8 +89,9 @@ static void tcpx_rma_read_recv_entry_fill(struct tcpx_xfer_entry *recv_entry,
 	recv_entry->iov_cnt = msg->iov_count;
 	recv_entry->ep = tcpx_ep;
 	recv_entry->context = msg->context;
-	recv_entry->flags = ((tcpx_ep->util_ep.tx_op_flags & FI_COMPLETION) |
-			     flags | FI_RMA | FI_READ) | TCPX_INTERNAL_XFER;
+	recv_entry->flags = (tcpx_ep->util_ep.tx_op_flags & FI_COMPLETION) |
+			    flags | FI_RMA | FI_READ;
+	recv_entry->ctrl_flags = TCPX_INTERNAL_XFER;
 }
 
 static ssize_t tcpx_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,

--- a/prov/tcp/src/tcpx_rma.c
+++ b/prov/tcp/src/tcpx_rma.c
@@ -89,8 +89,8 @@ static void tcpx_rma_read_recv_entry_fill(struct tcpx_xfer_entry *recv_entry,
 	recv_entry->iov_cnt = msg->iov_count;
 	recv_entry->ep = tcpx_ep;
 	recv_entry->context = msg->context;
-	recv_entry->flags = (tcpx_ep->util_ep.tx_op_flags & FI_COMPLETION) |
-			    flags | FI_RMA | FI_READ;
+	recv_entry->cq_flags = tcpx_tx_completion_flag(tcpx_ep, flags) |
+			       FI_RMA | FI_READ;
 	recv_entry->ctrl_flags = TCPX_INTERNAL_XFER;
 }
 
@@ -233,8 +233,8 @@ static ssize_t tcpx_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg
 	send_entry->iov[0].iov_base = (void *) &send_entry->hdr;
 	send_entry->iov[0].iov_len = offset;
 
-	send_entry->flags = (tcpx_ep->util_ep.tx_op_flags & FI_COMPLETION) |
-			     flags | FI_RMA | FI_WRITE;
+	send_entry->cq_flags = tcpx_tx_completion_flag(tcpx_ep, flags) |
+			       FI_RMA | FI_WRITE;
 	tcpx_set_commit_flags(send_entry, flags);
 	send_entry->context = msg->context;
 

--- a/prov/tcp/src/tcpx_shared_ctx.c
+++ b/prov/tcp/src/tcpx_shared_ctx.c
@@ -56,7 +56,7 @@ static ssize_t tcpx_srx_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 		goto unlock;
 	}
 
-	recv_entry->flags = flags | FI_MSG | FI_RECV;
+	recv_entry->cq_flags = FI_MSG | FI_RECV;
 	recv_entry->context = msg->context;
 	recv_entry->iov_cnt = msg->iov_count;
 	memcpy(&recv_entry->iov[0], msg->msg_iov,
@@ -84,7 +84,7 @@ static ssize_t tcpx_srx_recv(struct fid_ep *ep, void *buf, size_t len, void *des
 		goto unlock;
 	}
 
-	recv_entry->flags = FI_MSG | FI_RECV;
+	recv_entry->cq_flags = FI_MSG | FI_RECV;
 	recv_entry->context = context;
 	recv_entry->iov_cnt = 1;
 	recv_entry->iov[0].iov_base = buf;
@@ -113,7 +113,7 @@ static ssize_t tcpx_srx_recvv(struct fid_ep *ep, const struct iovec *iov, void *
 		goto unlock;
 	}
 
-	recv_entry->flags = FI_MSG | FI_RECV;
+	recv_entry->cq_flags = FI_MSG | FI_RECV;
 	recv_entry->context = context;
 	recv_entry->iov_cnt = count;
 	memcpy(&recv_entry->iov[0], iov, count * sizeof(*iov));


### PR DESCRIPTION
Separate CQ flags and control flags associated with data transfers into different separate fields.  Limit CQ flags to those flags defined as part of completion data.

Minor optimization to RMA receive handling to combine checks and loops.