### PR TITLE
core: Make output for printing fi_info fields consistent

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -1915,7 +1915,7 @@ static void ofi_tostr_bus_attr(char *buf, size_t len,
 	ofi_strncatf(buf, len, "%sfi_bus_attr:\n", prefix);
 
 	prefix = TAB TAB TAB;
-	ofi_strncatf(buf, len, "%sfi_bus_type: ", prefix);
+	ofi_strncatf(buf, len, "%sbus_type: ", prefix);
 	ofi_tostr_bus_type(buf, len, attr->bus_type);
 	ofi_strncatf(buf, len, "\n");
 
@@ -1961,7 +1961,7 @@ int ofi_nic_tostr(const struct fid *fid_nic, char *buf, size_t len)
 	const struct fid_nic *nic = (const struct fid_nic*) fid_nic;
 
 	assert(fid_nic->fclass == FI_CLASS_NIC);
-	ofi_strncatf(buf, len, "%sfid_nic:\n", TAB);
+	ofi_strncatf(buf, len, "%snic:\n", TAB);
 
 	ofi_tostr_device_attr(buf, len, nic->device_attr);
 	ofi_tostr_bus_attr(buf, len, nic->bus_attr);

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -347,6 +347,7 @@ ofi_tostr_tx_attr(char *buf, size_t len, const struct fi_tx_attr *attr,
 		     attr->iov_limit);
 	ofi_strncatf(buf, len, "%s%srma_iov_limit: %zu\n", prefix, TAB,
 		     attr->rma_iov_limit);
+	ofi_strncatf(buf, len, "%s%stclass: 0x%x\n", prefix, TAB, attr->tclass);
 }
 
 static void
@@ -559,6 +560,7 @@ ofi_tostr_domain_attr(char *buf, size_t len, const struct fi_domain_attr *attr,
 	ofi_strncatf(buf, len, "%s%smax_err_data: %zu\n", prefix, TAB,
 		     attr->max_err_data);
 	ofi_strncatf(buf, len, "%s%smr_cnt: %zu\n", prefix, TAB, attr->mr_cnt);
+	ofi_strncatf(buf, len, "%s%stclass: 0x%x\n", prefix, TAB, attr->tclass);
 }
 
 static void
@@ -611,7 +613,7 @@ static void ofi_tostr_info(char *buf, size_t len, const struct fi_info *info)
 	ofi_tostr_ep_attr(buf, len, info->ep_attr, TAB);
 	ofi_tostr_domain_attr(buf, len, info->domain_attr, TAB);
 	ofi_tostr_fabric_attr(buf, len, info->fabric_attr, TAB);
-	ofi_tostr_fid(TAB "nic_fid: ", buf, len, &info->nic->fid);
+	ofi_tostr_fid(TAB "nic: ", buf, len, &info->nic->fid);
 }
 
 static void ofi_tostr_atomic_type(char *buf, size_t len, enum fi_datatype type)


### PR DESCRIPTION
The fi_info field name is 'nic', not 'nic_fid' or 'fid_nic'.
The string is inconsistent and should match the name of the
field itself.

Update reporting bus_type field from bus_attr to match the
field name, dropping the fi_ prefix.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>