### PR TITLE
Revert "prov/efa: temporarily disable the usage of IBV_INLINE_SEND"

### DIFF
--- a/prov/efa/src/efa_msg.c
+++ b/prov/efa/src/efa_msg.c
@@ -342,11 +342,8 @@ static ssize_t efa_post_send(struct efa_ep *ep, const struct fi_msg *msg, uint64
 
 	efa_post_send_sgl(ep, msg, ewr);
 
-	/* TODO: uncomment this code block when the underlying
-	 * issue with INLINE send is fixed.
 	if (len <= ep->domain->ctx->inline_buf_size)
 		wr->send_flags |= IBV_SEND_INLINE;
-	*/
 
 	wr->opcode = IBV_WR_SEND;
 	wr->wr_id = (uintptr_t)msg->context;


### PR DESCRIPTION
This reverts commit 67179fe0d78f4dd7ef31349d5ee27807b3219870.
The commit was added because of some underlying issue with device.
The issue has been fixed, so revert the commit

Signed-off-by: Wei Zhang <wzam@amazon.com>