### PR TITLE
prov/util: Fix fi_addr_array leak in util_av_set_close

### DIFF
--- a/prov/util/src/util_coll.c
+++ b/prov/util/src/util_coll.c
@@ -1095,6 +1095,7 @@ static int util_av_set_close(struct fid *fid)
 	if (ofi_atomic_get32(&av_set->ref) > 0)
 		return -FI_EBUSY;
 
+	free(av_set->fi_addr_array);
 	free(av_set);
 
 	return FI_SUCCESS;


### PR DESCRIPTION
The memory for fi_addr_array is lost when av_set is freed; also free
fi_addr_array.

Signed-off-by: Olivier Serres <oserres@google.com>