### PR TITLE
prov/tcp: Rename variables to remove tcpx_ prefix

### DIFF
--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -367,7 +367,7 @@ int tcpx_update_epoll(struct tcpx_ep *ep);
 void tcpx_hdr_none(struct tcpx_base_hdr *hdr);
 void tcpx_hdr_bswap(struct tcpx_base_hdr *hdr);
 
-void tcpx_tx_queue_insert(struct tcpx_ep *tcpx_ep,
+void tcpx_tx_queue_insert(struct tcpx_ep *ep,
 			  struct tcpx_xfer_entry *tx_entry);
 
 void tcpx_conn_mgr_run(struct util_eq *eq);
@@ -375,11 +375,11 @@ int tcpx_eq_wait_try_func(void *arg);
 int tcpx_eq_create(struct fid_fabric *fabric_fid, struct fi_eq_attr *attr,
 		   struct fid_eq **eq_fid, void *context);
 
-int tcpx_op_invalid(struct tcpx_ep *tcpx_ep);
-int tcpx_op_msg(struct tcpx_ep *tcpx_ep);
-int tcpx_op_read_req(struct tcpx_ep *tcpx_ep);
-int tcpx_op_write(struct tcpx_ep *tcpx_ep);
-int tcpx_op_read_rsp(struct tcpx_ep *tcpx_ep);
+int tcpx_op_invalid(struct tcpx_ep *ep);
+int tcpx_op_msg(struct tcpx_ep *ep);
+int tcpx_op_read_req(struct tcpx_ep *ep);
+int tcpx_op_write(struct tcpx_ep *ep);
+int tcpx_op_read_rsp(struct tcpx_ep *ep);
 
 
 static inline void

--- a/prov/tcp/src/tcpx_domain.c
+++ b/prov/tcp/src/tcpx_domain.c
@@ -66,7 +66,7 @@ static struct fi_ops fi_ops_srx_ctx = {
 };
 
 static int tcpx_srx_ctx(struct fid_domain *domain, struct fi_rx_attr *attr,
-		 struct fid_ep **rx_ep, void *context)
+			struct fid_ep **rx_ep, void *context)
 {
 	struct tcpx_rx_ctx *srx_ctx;
 	int ret = FI_SUCCESS;
@@ -141,17 +141,17 @@ static int tcpx_set_ops(struct fid *fid, const char *name,
 
 static int tcpx_domain_close(fid_t fid)
 {
-	struct tcpx_domain *tcpx_domain;
+	struct tcpx_domain *domain;
 	int ret;
 
-	tcpx_domain = container_of(fid, struct tcpx_domain,
-				   util_domain.domain_fid.fid);
+	domain = container_of(fid, struct tcpx_domain,
+			      util_domain.domain_fid.fid);
 
-	ret = ofi_domain_close(&tcpx_domain->util_domain);
+	ret = ofi_domain_close(&domain->util_domain);
 	if (ret)
 		return ret;
 
-	free(tcpx_domain);
+	free(domain);
 	return FI_SUCCESS;
 }
 
@@ -173,30 +173,30 @@ static struct fi_ops_mr tcpx_domain_fi_ops_mr = {
 };
 
 int tcpx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
-		     struct fid_domain **domain, void *context)
+		     struct fid_domain **domain_fid, void *context)
 {
-	struct tcpx_domain *tcpx_domain;
+	struct tcpx_domain *domain;
 	int ret;
 
 	ret = ofi_prov_check_info(&tcpx_util_prov, fabric->api_version, info);
 	if (ret)
 		return ret;
 
-	tcpx_domain = calloc(1, sizeof(*tcpx_domain));
-	if (!tcpx_domain)
+	domain = calloc(1, sizeof(*domain));
+	if (!domain)
 		return -FI_ENOMEM;
 
-	ret = ofi_domain_init(fabric, info, &tcpx_domain->util_domain, context);
+	ret = ofi_domain_init(fabric, info, &domain->util_domain, context);
 	if (ret)
 		goto err;
 
-	*domain = &tcpx_domain->util_domain.domain_fid;
-	(*domain)->fid.ops = &tcpx_domain_fi_ops;
-	(*domain)->ops = &tcpx_domain_ops;
-	(*domain)->mr = &tcpx_domain_fi_ops_mr;
+	domain->util_domain.domain_fid.fid.ops = &tcpx_domain_fi_ops;
+	domain->util_domain.domain_fid.ops = &tcpx_domain_ops;
+	domain->util_domain.domain_fid.mr = &tcpx_domain_fi_ops_mr;
+	*domain_fid = &domain->util_domain.domain_fid;
 
 	return FI_SUCCESS;
 err:
-	free(tcpx_domain);
+	free(domain);
 	return ret;
 }

--- a/prov/tcp/src/tcpx_fabric.c
+++ b/prov/tcp/src/tcpx_fabric.c
@@ -53,16 +53,16 @@ struct fi_ops_fabric tcpx_fabric_ops = {
 static int tcpx_fabric_close(fid_t fid)
 {
 	int ret;
-	struct tcpx_fabric *tcpx_fabric;
+	struct tcpx_fabric *fabric;
 
-	tcpx_fabric = container_of(fid, struct tcpx_fabric,
-				   util_fabric.fabric_fid.fid);
+	fabric = container_of(fid, struct tcpx_fabric,
+			      util_fabric.fabric_fid.fid);
 
-	ret = ofi_fabric_close(&tcpx_fabric->util_fabric);
+	ret = ofi_fabric_close(&fabric->util_fabric);
 	if (ret)
 		return ret;
 
-	free(tcpx_fabric);
+	free(fabric);
 	return 0;
 }
 
@@ -74,26 +74,26 @@ struct fi_ops tcpx_fabric_fi_ops = {
 	.ops_open = fi_no_ops_open,
 };
 
-int tcpx_create_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
-		       void *context)
+int tcpx_create_fabric(struct fi_fabric_attr *attr,
+		       struct fid_fabric **fabric_fid, void *context)
 {
-	struct tcpx_fabric *tcpx_fabric;
+	struct tcpx_fabric *fabric;
 	int ret;
 
-	tcpx_fabric = calloc(1, sizeof(*tcpx_fabric));
-	if (!tcpx_fabric)
+	fabric = calloc(1, sizeof(*fabric));
+	if (!fabric)
 		return -FI_ENOMEM;
 
 	ret = ofi_fabric_init(&tcpx_prov, tcpx_info.fabric_attr, attr,
-			      &tcpx_fabric->util_fabric, context);
+			      &fabric->util_fabric, context);
 	if (ret) {
-		free(tcpx_fabric);
+		free(fabric);
 		return ret;
 	}
 
-	*fabric = &tcpx_fabric->util_fabric.fabric_fid;
-	(*fabric)->fid.ops = &tcpx_fabric_fi_ops;
-	(*fabric)->ops = &tcpx_fabric_ops;
+	fabric->util_fabric.fabric_fid.fid.ops = &tcpx_fabric_fi_ops;
+	fabric->util_fabric.fabric_fid.ops = &tcpx_fabric_ops;
+	*fabric_fid = &fabric->util_fabric.fabric_fid;
 
 	return 0;
 }

--- a/prov/tcp/src/tcpx_rma.c
+++ b/prov/tcp/src/tcpx_rma.c
@@ -51,7 +51,7 @@
 
 static void tcpx_rma_read_send_entry_fill(struct tcpx_xfer_entry *send_entry,
 					  struct tcpx_xfer_entry *recv_entry,
-					  struct tcpx_ep *tcpx_ep,
+					  struct tcpx_ep *ep,
 					  const struct fi_msg_rma *msg)
 {
 	struct ofi_rma_iov *rma_iov;
@@ -79,7 +79,7 @@ static void tcpx_rma_read_send_entry_fill(struct tcpx_xfer_entry *send_entry,
 }
 
 static void tcpx_rma_read_recv_entry_fill(struct tcpx_xfer_entry *recv_entry,
-					  struct tcpx_ep *tcpx_ep,
+					  struct tcpx_ep *ep,
 					  const struct fi_msg_rma *msg,
 					  uint64_t flags)
 {
@@ -87,49 +87,51 @@ static void tcpx_rma_read_recv_entry_fill(struct tcpx_xfer_entry *recv_entry,
 	       msg->iov_count * sizeof(struct iovec));
 
 	recv_entry->iov_cnt = msg->iov_count;
-	recv_entry->ep = tcpx_ep;
+	recv_entry->ep = ep;
 	recv_entry->context = msg->context;
-	recv_entry->cq_flags = tcpx_tx_completion_flag(tcpx_ep, flags) |
+	recv_entry->cq_flags = tcpx_tx_completion_flag(ep, flags) |
 			       FI_RMA | FI_READ;
 	recv_entry->ctrl_flags = TCPX_INTERNAL_XFER;
 }
 
-static ssize_t tcpx_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
-				uint64_t flags)
+static ssize_t
+tcpx_rma_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
+		 uint64_t flags)
 {
-	struct tcpx_ep *tcpx_ep;
-	struct tcpx_cq *tcpx_cq;
+	struct tcpx_ep *ep;
+	struct tcpx_cq *cq;
 	struct tcpx_xfer_entry *send_entry;
 	struct tcpx_xfer_entry *recv_entry;
 
-	tcpx_ep = container_of(ep, struct tcpx_ep, util_ep.ep_fid);
-	tcpx_cq = container_of(tcpx_ep->util_ep.tx_cq, struct tcpx_cq,
+	ep = container_of(ep_fid, struct tcpx_ep, util_ep.ep_fid);
+	cq = container_of(ep->util_ep.tx_cq, struct tcpx_cq,
 			       util_cq);
 
 	assert(msg->iov_count <= TCPX_IOV_LIMIT);
 	assert(msg->rma_iov_count <= TCPX_IOV_LIMIT);
 
-	send_entry = tcpx_alloc_tx(tcpx_ep);
+	send_entry = tcpx_alloc_tx(ep);
 	if (!send_entry)
 		return -FI_EAGAIN;
 
-	recv_entry = tcpx_alloc_xfer(tcpx_cq);
+	recv_entry = tcpx_alloc_xfer(cq);
 	if (!recv_entry) {
-		tcpx_free_xfer(tcpx_cq, send_entry);
+		tcpx_free_xfer(cq, send_entry);
 		return -FI_EAGAIN;
 	}
-	tcpx_rma_read_send_entry_fill(send_entry, recv_entry, tcpx_ep, msg);
-	tcpx_rma_read_recv_entry_fill(recv_entry, tcpx_ep, msg, flags);
+	tcpx_rma_read_send_entry_fill(send_entry, recv_entry, ep, msg);
+	tcpx_rma_read_recv_entry_fill(recv_entry, ep, msg, flags);
 
-	fastlock_acquire(&tcpx_ep->lock);
-	slist_insert_tail(&recv_entry->entry, &tcpx_ep->rma_read_queue);
-	tcpx_tx_queue_insert(tcpx_ep, send_entry);
-	fastlock_release(&tcpx_ep->lock);
+	fastlock_acquire(&ep->lock);
+	slist_insert_tail(&recv_entry->entry, &ep->rma_read_queue);
+	tcpx_tx_queue_insert(ep, send_entry);
+	fastlock_release(&ep->lock);
 	return FI_SUCCESS;
 }
 
-static ssize_t tcpx_rma_read(struct fid_ep *ep, void *buf, size_t len, void *desc,
-			     fi_addr_t src_addr, uint64_t addr, uint64_t key, void *context)
+static ssize_t
+tcpx_rma_read(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
+	      fi_addr_t src_addr, uint64_t addr, uint64_t key, void *context)
 {
 	struct iovec msg_iov = {
 		.iov_base = (void *)buf,
@@ -151,12 +153,13 @@ static ssize_t tcpx_rma_read(struct fid_ep *ep, void *buf, size_t len, void *des
 		.data = 0,
 	};
 
-	return tcpx_rma_readmsg(ep, &msg, 0);
+	return tcpx_rma_readmsg(ep_fid, &msg, 0);
 }
 
-static ssize_t tcpx_rma_readv(struct fid_ep *ep, const struct iovec *iov, void **desc,
-			      size_t count, fi_addr_t src_addr, uint64_t addr, uint64_t key,
-			      void *context)
+static ssize_t
+tcpx_rma_readv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
+	       size_t count, fi_addr_t src_addr, uint64_t addr, uint64_t key,
+	       void *context)
 {
 	struct fi_rma_iov rma_iov = {
 		.addr = addr,
@@ -174,20 +177,21 @@ static ssize_t tcpx_rma_readv(struct fid_ep *ep, const struct iovec *iov, void *
 		.data = 0,
 	};
 
-	return tcpx_rma_readmsg(ep, &msg, 0);
+	return tcpx_rma_readmsg(ep_fid, &msg, 0);
 }
 
-static ssize_t tcpx_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
-				 uint64_t flags)
+static ssize_t
+tcpx_rma_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
+		 uint64_t flags)
 {
-	struct tcpx_ep *tcpx_ep;
+	struct tcpx_ep *ep;
 	struct tcpx_xfer_entry *send_entry;
 	struct ofi_rma_iov *rma_iov;
 	uint64_t data_len;
 	size_t offset;
 
-	tcpx_ep = container_of(ep, struct tcpx_ep, util_ep.ep_fid);
-	send_entry = tcpx_alloc_tx(tcpx_ep);
+	ep = container_of(ep_fid, struct tcpx_ep, util_ep.ep_fid);
+	send_entry = tcpx_alloc_tx(ep);
 	if (!send_entry)
 		return -FI_EAGAIN;
 
@@ -233,19 +237,20 @@ static ssize_t tcpx_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg
 	send_entry->iov[0].iov_base = (void *) &send_entry->hdr;
 	send_entry->iov[0].iov_len = offset;
 
-	send_entry->cq_flags = tcpx_tx_completion_flag(tcpx_ep, flags) |
+	send_entry->cq_flags = tcpx_tx_completion_flag(ep, flags) |
 			       FI_RMA | FI_WRITE;
 	tcpx_set_commit_flags(send_entry, flags);
 	send_entry->context = msg->context;
 
-	fastlock_acquire(&tcpx_ep->lock);
-	tcpx_tx_queue_insert(tcpx_ep, send_entry);
-	fastlock_release(&tcpx_ep->lock);
+	fastlock_acquire(&ep->lock);
+	tcpx_tx_queue_insert(ep, send_entry);
+	fastlock_release(&ep->lock);
 	return FI_SUCCESS;
 }
 
-static ssize_t tcpx_rma_write(struct fid_ep *ep, const void *buf, size_t len, void *desc,
-			      fi_addr_t dest_addr, uint64_t addr, uint64_t key, void *context)
+static ssize_t
+tcpx_rma_write(struct fid_ep *ep_fid, const void *buf, size_t len, void *desc,
+	       fi_addr_t dest_addr, uint64_t addr, uint64_t key, void *context)
 {
 	struct iovec msg_iov = {
 		.iov_base = (void *)buf,
@@ -267,12 +272,13 @@ static ssize_t tcpx_rma_write(struct fid_ep *ep, const void *buf, size_t len, vo
 		.data = 0,
 	};
 
-	return tcpx_rma_writemsg(ep, &msg, 0);
+	return tcpx_rma_writemsg(ep_fid, &msg, 0);
 }
 
-static ssize_t tcpx_rma_writev(struct fid_ep *ep, const struct iovec *iov, void **desc,
-			       size_t count, fi_addr_t dest_addr, uint64_t addr, uint64_t key,
-			       void *context)
+static ssize_t
+tcpx_rma_writev(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
+		size_t count, fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+		void *context)
 {
 	struct fi_rma_iov rma_iov = {
 		.addr = addr,
@@ -290,13 +296,14 @@ static ssize_t tcpx_rma_writev(struct fid_ep *ep, const struct iovec *iov, void 
 		.data = 0,
 	};
 
-	return tcpx_rma_writemsg(ep, &msg, 0);
+	return tcpx_rma_writemsg(ep_fid, &msg, 0);
 }
 
 
-static ssize_t tcpx_rma_writedata(struct fid_ep *ep, const void *buf, size_t len, void *desc,
-				  uint64_t data, fi_addr_t dest_addr, uint64_t addr, uint64_t key,
-				  void *context)
+static ssize_t
+tcpx_rma_writedata(struct fid_ep *ep_fid, const void *buf, size_t len,
+		   void *desc, uint64_t data, fi_addr_t dest_addr,
+		   uint64_t addr, uint64_t key, void *context)
 {
 	struct iovec msg_iov = {
 		.iov_base = (void *)buf,
@@ -318,22 +325,22 @@ static ssize_t tcpx_rma_writedata(struct fid_ep *ep, const void *buf, size_t len
 		.data = data,
 	};
 
-	return tcpx_rma_writemsg(ep, &msg, FI_REMOTE_CQ_DATA);
+	return tcpx_rma_writemsg(ep_fid, &msg, FI_REMOTE_CQ_DATA);
 }
 
-static ssize_t tcpx_rma_inject_common(struct fid_ep *ep, const void *buf,
-				      size_t len, uint64_t data,
-				      fi_addr_t dest_addr, uint64_t addr,
-				      uint64_t key, uint64_t flags)
+static ssize_t
+tcpx_rma_inject_common(struct fid_ep *ep_fid, const void *buf, size_t len,
+		       uint64_t data, fi_addr_t dest_addr, uint64_t addr,
+		       uint64_t key, uint64_t flags)
 {
-	struct tcpx_ep *tcpx_ep;
+	struct tcpx_ep *ep;
 	struct tcpx_xfer_entry *send_entry;
 	struct ofi_rma_iov *rma_iov;
 	uint64_t *cq_data;
 	size_t offset;
 
-	tcpx_ep = container_of(ep, struct tcpx_ep, util_ep.ep_fid);
-	send_entry = tcpx_alloc_tx(tcpx_ep);
+	ep = container_of(ep_fid, struct tcpx_ep, util_ep.ep_fid);
+	send_entry = tcpx_alloc_tx(ep);
 	if (!send_entry)
 		return -FI_EAGAIN;
 
@@ -366,26 +373,27 @@ static ssize_t tcpx_rma_inject_common(struct fid_ep *ep, const void *buf,
 
 	send_entry->hdr.base_hdr.size = offset;
 
-	fastlock_acquire(&tcpx_ep->lock);
-	tcpx_tx_queue_insert(tcpx_ep, send_entry);
-	fastlock_release(&tcpx_ep->lock);
+	fastlock_acquire(&ep->lock);
+	tcpx_tx_queue_insert(ep, send_entry);
+	fastlock_release(&ep->lock);
 	return FI_SUCCESS;
 }
 
-static ssize_t tcpx_rma_inject(struct fid_ep *ep, const void *buf, size_t len,
-			       fi_addr_t dest_addr, uint64_t addr, uint64_t key)
+static ssize_t
+tcpx_rma_inject(struct fid_ep *ep_fid, const void *buf, size_t len,
+		fi_addr_t dest_addr, uint64_t addr, uint64_t key)
 {
-	return tcpx_rma_inject_common(ep, buf, len, 0 ,dest_addr,
+	return tcpx_rma_inject_common(ep_fid, buf, len, 0 ,dest_addr,
 				      addr, key, FI_INJECT);
 }
 
 static ssize_t
-tcpx_rma_injectdata(struct fid_ep *ep, const void *buf, size_t len,
+tcpx_rma_injectdata(struct fid_ep *ep_fid, const void *buf, size_t len,
 		    uint64_t data, fi_addr_t dest_addr, uint64_t addr,
 		    uint64_t key)
 {
-	return tcpx_rma_inject_common(ep, buf, len, data, dest_addr, addr, key,
-				      FI_INJECT | FI_REMOTE_CQ_DATA);
+	return tcpx_rma_inject_common(ep_fid, buf, len, data, dest_addr, addr,
+				      key, FI_INJECT | FI_REMOTE_CQ_DATA);
 }
 
 struct fi_ops_rma tcpx_rma_ops = {

--- a/prov/tcp/src/tcpx_shared_ctx.c
+++ b/prov/tcp/src/tcpx_shared_ctx.c
@@ -39,14 +39,15 @@
 #include <ofi_iov.h>
 
 
-static ssize_t tcpx_srx_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
-				uint64_t flags)
+static ssize_t
+tcpx_srx_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
+		 uint64_t flags)
 {
 	struct tcpx_xfer_entry *recv_entry;
 	struct tcpx_rx_ctx *srx_ctx;
 	ssize_t ret = FI_SUCCESS;
 
-	srx_ctx = container_of(ep, struct tcpx_rx_ctx, rx_fid);
+	srx_ctx = container_of(ep_fid, struct tcpx_rx_ctx, rx_fid);
 	assert(msg->iov_count <= TCPX_IOV_LIMIT);
 
 	fastlock_acquire(&srx_ctx->lock);
@@ -68,14 +69,15 @@ unlock:
 	return ret;
 }
 
-static ssize_t tcpx_srx_recv(struct fid_ep *ep, void *buf, size_t len, void *desc,
-			     fi_addr_t src_addr, void *context)
+static ssize_t
+tcpx_srx_recv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
+	      fi_addr_t src_addr, void *context)
 {
 	struct tcpx_xfer_entry *recv_entry;
 	struct tcpx_rx_ctx *srx_ctx;
 	ssize_t ret = FI_SUCCESS;
 
-	srx_ctx = container_of(ep, struct tcpx_rx_ctx, rx_fid);
+	srx_ctx = container_of(ep_fid, struct tcpx_rx_ctx, rx_fid);
 
 	fastlock_acquire(&srx_ctx->lock);
 	recv_entry = ofi_buf_alloc(srx_ctx->buf_pool);
@@ -96,14 +98,15 @@ unlock:
 	return ret;
 }
 
-static ssize_t tcpx_srx_recvv(struct fid_ep *ep, const struct iovec *iov, void **desc,
-			      size_t count, fi_addr_t src_addr, void *context)
+static ssize_t
+tcpx_srx_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
+	       size_t count, fi_addr_t src_addr, void *context)
 {
 	struct tcpx_xfer_entry *recv_entry;
 	struct tcpx_rx_ctx *srx_ctx;
 	ssize_t ret = FI_SUCCESS;
 
-	srx_ctx = container_of(ep, struct tcpx_rx_ctx, rx_fid);
+	srx_ctx = container_of(ep_fid, struct tcpx_rx_ctx, rx_fid);
 	assert(count <= TCPX_IOV_LIMIT);
 
 	fastlock_acquire(&srx_ctx->lock);


### PR DESCRIPTION
This patch renames variables that contain the prefix
tcpx_ to drop the prefix.  Doing so makes the code easier
to read.  Some reformating of white space is impacted
for code consistency.

No functional changes.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>