### PR TITLE
prov/efa: remove unused credit based flow control

### DIFF
--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -92,8 +92,6 @@ void efa_rdm_peer_init(struct rdm_peer *peer, struct rxr_ep *ep, struct efa_conn
 					 conn->ep_addr);
 
 	ofi_recvwin_buf_alloc(&peer->robuf, rxr_env.recvwin_size);
-	peer->rx_credits = rxr_env.rx_window_size;
-	peer->tx_credits = rxr_env.tx_max_credits;
 	dlist_init(&peer->outstanding_tx_pkts);
 	dlist_init(&peer->rx_unexp_list);
 	dlist_init(&peer->rx_unexp_tagged_list);

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -313,8 +313,6 @@ struct rdm_peer {
 	size_t efa_outstanding_tx_ops;	/* tracks outstanding tx ops to this peer on EFA device */
 	size_t shm_outstanding_tx_ops;  /* tracks outstanding tx ops to this peer on SHM */
 	struct dlist_entry outstanding_tx_pkts; /* a list of outstanding tx pkts to the peer */
-	uint16_t tx_credits;		/* available send credits */
-	uint16_t rx_credits;		/* available credits to allocate */
 	uint64_t rnr_backoff_begin_ts;	/* timestamp for RNR backoff period begin */
 	uint64_t rnr_backoff_wait_time;	/* how long the RNR backoff period last */
 	int rnr_queued_pkt_cnt;		/* queued RNR packet count */
@@ -379,8 +377,6 @@ struct rxr_rx_entry {
 	uint64_t bytes_received;
 	uint64_t bytes_copied;
 	int64_t window;
-	uint16_t credit_request;
-	int credit_cts;
 
 	uint64_t total_len;
 
@@ -463,8 +459,6 @@ struct rxr_tx_entry {
 	uint64_t bytes_acked;
 	uint64_t bytes_sent;
 	int64_t window;
-	uint16_t credit_request;
-	uint16_t credit_allocated;
 
 	uint64_t total_len;
 
@@ -721,10 +715,6 @@ struct rxr_ep {
 	 * It exists because posting RX packets by bulk is more efficient.
 	 */
 	size_t efa_rx_pkts_to_post;
-	/* number of buffers available for large messages */
-	size_t available_data_bufs;
-	/* Timestamp of when available_data_bufs was exhausted. */
-	uint64_t available_data_bufs_ts;
 
 	/* number of outstanding tx ops on efa device */
 	size_t efa_outstanding_tx_ops;
@@ -891,9 +881,6 @@ void rxr_ep_progress_internal(struct rxr_ep *rxr_ep);
 
 int rxr_ep_post_user_recv_buf(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,
 			      uint64_t flags);
-
-int rxr_ep_set_tx_credit_request(struct rxr_ep *rxr_ep,
-				 struct rxr_tx_entry *tx_entry);
 
 int rxr_ep_tx_init_mr_desc(struct rxr_domain *rxr_domain,
 			   struct rxr_tx_entry *tx_entry,

--- a/prov/efa/src/rxr/rxr_cq.c
+++ b/prov/efa/src/rxr/rxr_cq.c
@@ -744,14 +744,8 @@ void rxr_cq_write_tx_completion(struct rxr_ep *ep,
 
 void rxr_cq_handle_tx_completion(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry)
 {
-	struct rdm_peer *peer;
-
 	if (tx_entry->state == RXR_TX_SEND)
 		dlist_remove(&tx_entry->entry);
-
-	peer = rxr_ep_get_peer(ep, tx_entry->addr);
-	assert(peer);
-	peer->tx_credits += tx_entry->credit_allocated;
 
 	if (tx_entry->cq_entry.flags & FI_READ) {
 		/*

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -578,35 +578,6 @@ void rxr_prepare_desc_send(struct rxr_domain *rxr_domain,
 }
 
 /* Generic send */
-int rxr_ep_set_tx_credit_request(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
-{
-	struct rdm_peer *peer;
-	int outstanding;
-
-	peer = rxr_ep_get_peer(rxr_ep, tx_entry->addr);
-	assert(peer);
-
-	/*
-	 * Divy up available credits to outstanding transfers and request the
-	 * minimum of that and the amount required to finish the current long
-	 * message.
-	 */
-	outstanding = peer->efa_outstanding_tx_ops + 1;
-	tx_entry->credit_request = MIN(ofi_div_ceil(peer->tx_credits, outstanding),
-				       ofi_div_ceil(tx_entry->total_len,
-						    rxr_ep->max_data_payload_size));
-	tx_entry->credit_request = MAX(tx_entry->credit_request,
-				       rxr_env.tx_min_credits);
-	if (peer->tx_credits >= tx_entry->credit_request)
-		peer->tx_credits -= tx_entry->credit_request;
-
-	/* Queue this REQ for later if there are too many outstanding packets */
-	if (!tx_entry->credit_request)
-		return -FI_EAGAIN;
-
-	return 0;
-}
-
 static void rxr_ep_free_res(struct rxr_ep *rxr_ep)
 {
 	struct dlist_entry *entry, *tmp;
@@ -1641,7 +1612,6 @@ void rxr_ep_progress_post_internal_rx_pkts(struct rxr_ep *ep)
 				goto err_exit;
 
 			ep->efa_rx_pkts_to_post = rxr_get_rx_pool_chunk_cnt(ep);
-			ep->available_data_bufs = rxr_get_rx_pool_chunk_cnt(ep);
 
 			if (ep->use_shm) {
 				assert(ep->shm_rx_pkts_posted == 0 && ep->shm_rx_pkts_to_post == 0);
@@ -1702,20 +1672,6 @@ static inline int rxr_ep_send_queued_pkts(struct rxr_ep *ep,
 		}
 	}
 	return 0;
-}
-
-static inline void rxr_ep_check_available_data_bufs_timer(struct rxr_ep *ep)
-{
-	if (OFI_LIKELY(ep->available_data_bufs != 0))
-		return;
-
-	if (ofi_gettime_us() - ep->available_data_bufs_ts >=
-	    RXR_AVAILABLE_DATA_BUFS_TIMEOUT) {
-		ep->available_data_bufs = rxr_get_rx_pool_chunk_cnt(ep);
-		ep->available_data_bufs_ts = 0;
-		FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,
-			"Reset available buffers for large message receives\n");
-	}
 }
 
 static inline void rxr_ep_check_peer_backoff_timer(struct rxr_ep *ep)
@@ -1923,9 +1879,6 @@ void rxr_ep_progress_internal(struct rxr_ep *ep)
 	rxr_ep_progress_post_internal_rx_pkts(ep);
 
 	rxr_ep_check_peer_backoff_timer(ep);
-
-	if (!ep->use_zcpy_rx)
-		rxr_ep_check_available_data_bufs_timer(ep);
 	/*
 	 * Resend handshake packet for any peers where the first
 	 * handshake send failed.
@@ -2343,7 +2296,6 @@ int rxr_endpoint(struct fid_domain *domain, struct fi_info *info,
 	rxr_ep->efa_rx_pkts_to_post = 0;
 	rxr_ep->efa_outstanding_tx_ops = 0;
 	rxr_ep->shm_outstanding_tx_ops = 0;
-	rxr_ep->available_data_bufs_ts = 0;
 
 	ret = fi_cq_open(rxr_domain->rdm_domain, &cq_attr,
 			 &rxr_ep->rdm_cq, rxr_ep);

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -249,10 +249,6 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 		 */
 	}
 
-	err = rxr_ep_set_tx_credit_request(rxr_ep, tx_entry);
-	if (OFI_UNLIKELY(err))
-		return err;
-
 	ctrl_type = delivery_complete_requested ? RXR_DC_LONGCTS_MSGRTM_PKT : RXR_LONGCTS_MSGRTM_PKT;
 	tx_entry->rxr_flags |= RXR_LONGCTS_PROTOCOL;
 	return rxr_pkt_post_ctrl(rxr_ep, RXR_TX_ENTRY, tx_entry,

--- a/prov/efa/src/rxr/rxr_pkt_type_data.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_data.c
@@ -135,7 +135,6 @@ void rxr_pkt_proc_data(struct rxr_ep *ep,
 		       char *data, size_t seg_offset,
 		       size_t seg_size)
 {
-	struct rdm_peer *peer;
 	bool all_received = 0;
 	ssize_t err;
 
@@ -148,14 +147,7 @@ void rxr_pkt_proc_data(struct rxr_ep *ep,
 	assert(rx_entry->bytes_received <= rx_entry->total_len);
 	all_received = (rx_entry->bytes_received == rx_entry->total_len);
 
-	peer = rxr_ep_get_peer(ep, rx_entry->addr);
-	assert(peer);
-	peer->rx_credits += ofi_div_ceil(seg_size, ep->max_data_payload_size);
-
 	rx_entry->window -= seg_size;
-	if (ep->available_data_bufs < rxr_get_rx_pool_chunk_cnt(ep))
-		ep->available_data_bufs++;
-
 #if ENABLE_DEBUG
 	/* rx_entry can be released by rxr_pkt_copy_data_to_rx_entry
 	 * so the call to dlist_remove must happen before

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -523,7 +523,6 @@ void rxr_pkt_init_longcts_rtm(struct rxr_ep *ep,
 	rtm_hdr = rxr_get_longcts_rtm_base_hdr(pkt_entry->pkt);
 	rtm_hdr->msg_length = tx_entry->total_len;
 	rtm_hdr->send_id = tx_entry->tx_id;
-	rtm_hdr->credit_request = tx_entry->credit_request;
 }
 
 ssize_t rxr_pkt_init_longcts_msgrtm(struct rxr_ep *ep,
@@ -1153,8 +1152,6 @@ ssize_t rxr_pkt_proc_matched_rtm(struct rxr_ep *ep,
 	ep->rx_pending++;
 #endif
 	rx_entry->state = RXR_RX_RECV;
-	/* we have noticed using the default value achieve better bandwidth */
-	rx_entry->credit_request = rxr_env.tx_min_credits;
 	ret = rxr_pkt_post_ctrl_or_queue(ep, RXR_RX_ENTRY, rx_entry, RXR_CTS_PKT, 0);
 
 	return ret;
@@ -1424,7 +1421,7 @@ static inline void rxr_pkt_init_longcts_rtw_hdr(struct rxr_ep *ep,
 	rtw_hdr->rma_iov_count = tx_entry->rma_iov_count;
 	rtw_hdr->msg_length = tx_entry->total_len;
 	rtw_hdr->send_id = tx_entry->tx_id;
-	rtw_hdr->credit_request = tx_entry->credit_request;
+	rtw_hdr->credit_request = rxr_env.tx_min_credits;
 	rxr_pkt_init_req_hdr(ep, tx_entry, pkt_type, pkt_entry);
 }
 
@@ -1744,7 +1741,6 @@ void rxr_pkt_handle_longcts_rtw_recv(struct rxr_ep *ep,
 #endif
 	rx_entry->state = RXR_RX_RECV;
 	rx_entry->tx_id = tx_id;
-	rx_entry->credit_request = rxr_env.tx_min_credits;
 	err = rxr_pkt_post_ctrl_or_queue(ep, RXR_RX_ENTRY, rx_entry, RXR_CTS_PKT, 0);
 	if (OFI_UNLIKELY(err)) {
 		FI_WARN(&rxr_prov, FI_LOG_CQ, "Cannot post CTS packet\n");

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -199,8 +199,7 @@ size_t rxr_rma_post_shm_write(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_ent
 /* rma_read functions */
 ssize_t rxr_rma_post_efa_emulated_read(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry)
 {
-	int err, window, credits;
-	struct rdm_peer *peer;
+	int err;
 	struct rxr_rx_entry *rx_entry;
 
 	/* create a rx_entry to receve data
@@ -234,16 +233,6 @@ ssize_t rxr_rma_post_efa_emulated_read(struct rxr_ep *ep, struct rxr_tx_entry *t
 	 * meanwhile set rx_entry->state to RXR_RX_RECV so that
 	 * this rx_entry is ready to receive.
 	 */
-
-	/* But if there is no available buffer, we do not even proceed.
-	 * call rxr_ep_progress_internal() might release some buffer
-	 */
-	if (ep->available_data_bufs == 0) {
-		rxr_release_rx_entry(ep, rx_entry);
-		rxr_ep_progress_internal(ep);
-		return -FI_EAGAIN;
-	}
-
 	rx_entry->state = RXR_RX_RECV;
 	/* rma_loc_tx_id is used in rxr_cq_handle_rx_completion()
 	 * to locate the tx_entry for tx completion.
@@ -265,17 +254,8 @@ ssize_t rxr_rma_post_efa_emulated_read(struct rxr_ep *ep, struct rxr_tx_entry *t
 	if (tx_entry->total_len < ep->mtu_size - sizeof(struct rxr_readrsp_hdr)) {
 		err = rxr_pkt_post_ctrl(ep, RXR_TX_ENTRY, tx_entry, RXR_SHORT_RTR_PKT, 0, 0);
 	} else {
-		peer = rxr_ep_get_peer(ep, tx_entry->addr);
-		assert(peer);
-
-		rxr_pkt_calc_cts_window_credits(ep, peer,
-						tx_entry->total_len,
-						tx_entry->credit_request,
-						&window,
-						&credits);
-
-		rx_entry->window = window;
-		rx_entry->credit_cts = credits;
+		rx_entry->window = MIN(tx_entry->total_len,
+				       rxr_env.tx_min_credits * ep->max_data_payload_size);
 		tx_entry->rma_window = rx_entry->window;
 		err = rxr_pkt_post_ctrl(ep, RXR_TX_ENTRY, tx_entry, RXR_LONGCTS_RTR_PKT, 0, 0);
 	}
@@ -349,10 +329,6 @@ ssize_t rxr_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uint64_
 			goto out;
 		}
 	} else {
-		err = rxr_ep_set_tx_credit_request(rxr_ep, tx_entry);
-		if (OFI_UNLIKELY(err))
-			goto out;
-
 		err = rxr_rma_post_efa_emulated_read(rxr_ep, tx_entry);
 	}
 
@@ -473,10 +449,6 @@ ssize_t rxr_rma_post_write(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry)
 		 * message protocol
 		 */
 	}
-
-	err = rxr_ep_set_tx_credit_request(ep, tx_entry);
-	if (OFI_UNLIKELY(err))
-		return err;
 
 	ctrl_type = delivery_complete_requested ?
 		RXR_DC_LONGCTS_RTW_PKT : RXR_LONGCTS_RTW_PKT;


### PR DESCRIPTION
The credit based flow control in long-CTS message protocol is not
actually used because the default tx_min_credits will yied better
bandwidth. This patch removed it to simplify the code.

Signed-off-by: Wei Zhang <wzam@amazon.com>