### PR TITLE
fabtests: Use hint to disable shm for fi_efa_ep_rnr_retry

### DIFF
--- a/fabtests/prov/efa/src/rdm_ep_rnr_retry.c
+++ b/fabtests/prov/efa/src/rdm_ep_rnr_retry.c
@@ -226,6 +226,13 @@ int main(int argc, char **argv)
 
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_MSG;
+	/*
+	 * RNR error is generated from EFA device, so disable shm transfer by
+	 * setting FI_REMOTE_COMM and unsetting FI_LOCAL_COMM in order to ensure
+	 * EFA device is being used when running this test on a single node.
+	 */
+	hints->caps |= FI_REMOTE_COMM;
+	hints->caps &= ~FI_LOCAL_COMM;
 	hints->mode |= FI_CONTEXT;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	/*

--- a/fabtests/scripts/runfabtests.sh
+++ b/fabtests/scripts/runfabtests.sh
@@ -239,7 +239,7 @@ multinode_tests=(
 )
 
 prov_efa_tests=( \
-	"FI_EFA_ENABLE_SHM_TRANSFER=0 fi_efa_ep_rnr_retry -R 0"
+	"fi_efa_ep_rnr_retry -R 0"
 )
 
 function errcho {


### PR DESCRIPTION
RNR error is generated from efa device, to make sure the test
can be running on a single node, shm transfer needs to be disabled.
An environment variable (FI_EFA_ENABLE_SHM_TRANSFER=0) was used
in runfabtests.sh before.

To make this test self-contained, this patch removes the environment
variable and uses hint to disable shm by setting FI_REMOTE_COMM
and unsetting FI_LOCAL_COMM.

Signed-off-by: Jie Zhang <zhngaj@amazon.com>