### PR TITLE
prov/efa: use hmem device info from the MR cache info

### DIFF
--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -131,12 +131,16 @@ int efa_mr_cache_entry_reg(struct ofi_mr_cache *cache,
 	efa_mr->mr_fid.fid.context = NULL;
 
 	attr.mr_iov = &entry->info.iov;
+	/* ofi_mr_info only stores one iov */
 	attr.iov_count = 1;
 	attr.access = access;
 	attr.offset = 0;
 	attr.requested_key = 0;
 	attr.context = NULL;
-	attr.iface = FI_HMEM_SYSTEM;
+	attr.iface = entry->info.iface;
+
+	if (attr.iface == FI_HMEM_CUDA)
+		attr.device.cuda = entry->info.device;
 
 	ret = efa_mr_reg_impl(efa_mr, 0, (void *)&attr);
 	return ret;


### PR DESCRIPTION
Use the hmem device information in the MR cache registration handler, instead
of assuming FI_HMEM_SYSTEM.

Our only (known) user, the OFI NCCL plugin, disables the cache as EFA turns off
the cache if FI_MR_LOCAL is set, so it is not affected by this bug.

Signed-off-by: Robert Wespetal <wesper@amazon.com>

Test description: Combined this with the WIP PR for EFA FI_HMEM changes, ran some MPI CUDA collectives, and it works/I see the CUDA monitor being used.