### PR TITLE
prov/efa: call fi_setname on shm with actual name length

### DIFF
--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -384,6 +384,7 @@ int efa_conn_rdm_init(struct efa_av *av, struct efa_conn *conn)
 {
 	int err, ret;
 	char smr_name[EFA_SHM_NAME_MAX];
+	size_t smr_name_len;
 	struct rxr_ep *rxr_ep;
 	struct rdm_peer *peer;
 
@@ -406,7 +407,8 @@ int efa_conn_rdm_init(struct efa_av *av, struct efa_conn *conn)
 			return -FI_ENOMEM;
 		}
 
-		err = rxr_raw_addr_to_smr_name(conn->ep_addr, smr_name);
+		smr_name_len = EFA_SHM_NAME_MAX;
+		err = rxr_raw_addr_to_smr_name(conn->ep_addr, smr_name, &smr_name_len);
 		if (err != FI_SUCCESS) {
 			EFA_WARN(FI_LOG_AV,
 				 "rxr_ep_efa_addr_to_str() failed! err=%d\n", err);

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -921,7 +921,8 @@ struct rxr_rx_entry *rxr_ep_split_rx_entry(struct rxr_ep *ep,
 					   struct rxr_rx_entry *posted_entry,
 					   struct rxr_rx_entry *consumer_entry,
 					   struct rxr_pkt_entry *pkt_entry);
-int rxr_raw_addr_to_smr_name(void *addr, char *smr_name);
+
+int rxr_raw_addr_to_smr_name(void *addr, char *smr_name, size_t *smr_name_len);
 
 /* CQ sub-functions */
 void rxr_cq_write_rx_error(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -950,6 +950,7 @@ static int rxr_ep_ctrl(struct fid *fid, int command, void *arg)
 	ssize_t ret;
 	struct rxr_ep *ep;
 	char shm_ep_name[EFA_SHM_NAME_MAX];
+	size_t shm_ep_name_len;
 
 	switch (command) {
 	case FI_ENABLE:
@@ -980,10 +981,11 @@ static int rxr_ep_ctrl(struct fid *fid, int command, void *arg)
 		 * shared memory region.
 		 */
 		if (ep->use_shm) {
-			ret = rxr_raw_addr_to_smr_name(ep->core_addr, shm_ep_name);
+			shm_ep_name_len = EFA_SHM_NAME_MAX;
+			ret = rxr_raw_addr_to_smr_name(ep->core_addr, shm_ep_name, &shm_ep_name_len);
 			if (ret < 0)
 				goto out;
-			fi_setname(&ep->shm_ep->fid, shm_ep_name, sizeof(shm_ep_name));
+			fi_setname(&ep->shm_ep->fid, shm_ep_name, shm_ep_name_len);
 			ret = fi_enable(ep->shm_ep);
 			if (ret)
 				goto out;

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -182,12 +182,15 @@ static void rxr_init_env(void)
  *
  *    fe80::4a5:28ff:fe98:e500_0001_12918366_03e8
  *
- * @param[in]	ptr		pointer to raw address (struct efa_ep_addr)
- * @param[out]	smr_name	an unique name for shm ep
+ * @param[in]		ptr		pointer to raw address (struct efa_ep_addr)
+ * @param[out]		smr_name	an unique name for shm ep
+ * @param[in,out]	smr_name_len    As input, specify size of the "smr_name" buffer.
+ *					As output, specify number of bytes written to the buffer.
+ *
  * @return	0 on success.
  * 		negative error code on failure.
  */
-int rxr_raw_addr_to_smr_name(void *ptr, char *smr_name)
+int rxr_raw_addr_to_smr_name(void *ptr, char *smr_name, size_t *smr_name_len)
 {
 	struct efa_ep_addr *raw_addr;
 	char gidstr[INET6_ADDRSTRLEN] = { 0 };
@@ -199,14 +202,18 @@ int rxr_raw_addr_to_smr_name(void *ptr, char *smr_name)
 		return -errno;
 	}
 
-	ret = snprintf(smr_name, EFA_SHM_NAME_MAX, "%s_%04x_%08x_%04x",
+	ret = snprintf(smr_name, *smr_name_len, "%s_%04x_%08x_%04x",
 		       gidstr, raw_addr->qpn, raw_addr->qkey, getuid());
 	if (ret <= 0)
 		return ret;
 
-	if (ret >= EFA_SHM_NAME_MAX)
+	if (ret >= *smr_name_len)
 		return -FI_EINVAL;
 
+	/* plus 1 here for the ending '\0' character, which was not
+	 * included in ret of snprintf
+	 */
+	*smr_name_len = ret + 1;
 	return FI_SUCCESS;
 }
 

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -204,10 +204,10 @@ int rxr_raw_addr_to_smr_name(void *ptr, char *smr_name, size_t *smr_name_len)
 
 	ret = snprintf(smr_name, *smr_name_len, "%s_%04x_%08x_%04x",
 		       gidstr, raw_addr->qpn, raw_addr->qkey, getuid());
-	if (ret <= 0)
+	if (ret < 0)
 		return ret;
 
-	if (ret >= *smr_name_len)
+	if (ret == 0 || ret >= *smr_name_len)
 		return -FI_EINVAL;
 
 	/* plus 1 here for the ending '\0' character, which was not


### PR DESCRIPTION
Currently, when calling fi_setname on shm provider, the whole buffer
length (EFA_SHM_NAME_MAX) is used as name length. The name for
shm provider is set by function rxr_ep_addr_to_smr_name(), which
did not use the whole buffer.

This patch makes rxr_ep_addr_to_smr_name() to return number of
bytes it wrote, and use it to call fi_setname to be more precise.

Signed-off-by: Wei Zhang <wzam@amazon.com>