### PR TITLE
prov/efa: refactor send path/tx_entry init to pass return codes

### DIFF
--- a/prov/efa/src/rxr/rxr_pkt_type_base.h
+++ b/prov/efa/src/rxr/rxr_pkt_type_base.h
@@ -38,11 +38,11 @@
 
 uint32_t *rxr_pkt_connid_ptr(struct rxr_pkt_entry *pkt_entry);
 
-void rxr_pkt_init_data_from_tx_entry(struct rxr_ep *ep,
-				     struct rxr_pkt_entry *pkt_entry,
-				     size_t hdr_size,
-				     struct rxr_tx_entry *tx_entry,
-				     size_t data_offset, size_t data_size);
+int rxr_pkt_init_data_from_tx_entry(struct rxr_ep *ep,
+				    struct rxr_pkt_entry *pkt_entry,
+				    size_t hdr_size,
+				    struct rxr_tx_entry *tx_entry,
+				    size_t data_offset, size_t data_size);
 
 ssize_t rxr_pkt_copy_data_to_rx_entry(struct rxr_ep *ep,
 				      struct rxr_rx_entry *rx_entry,

--- a/prov/efa/src/rxr/rxr_pkt_type_data.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_data.c
@@ -44,6 +44,7 @@ int rxr_pkt_init_data(struct rxr_ep *ep,
 	struct rxr_data_hdr *data_hdr;
 	struct rdm_peer *peer;
 	size_t hdr_size;
+	int ret;
 
 	data_hdr = rxr_get_data_hdr(pkt_entry->pkt);
 	data_hdr->type = RXR_DATA_PKT;
@@ -67,8 +68,11 @@ int rxr_pkt_init_data(struct rxr_ep *ep,
 	data_hdr->seg_length = MIN(tx_entry->total_len - tx_entry->bytes_sent,
 				   ep->max_data_payload_size);
 	data_hdr->seg_length = MIN(data_hdr->seg_length, tx_entry->window);
-	rxr_pkt_init_data_from_tx_entry(ep, pkt_entry, hdr_size,
-					tx_entry, tx_entry->bytes_sent, data_hdr->seg_length);
+	ret = rxr_pkt_init_data_from_tx_entry(ep, pkt_entry, hdr_size,
+					      tx_entry, tx_entry->bytes_sent,
+					      data_hdr->seg_length);
+	if (ret)
+		return ret;
 
 	pkt_entry->x_entry = (void *)tx_entry;
 	pkt_entry->addr = tx_entry->addr;

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -320,6 +320,7 @@ int rxr_pkt_init_readrsp(struct rxr_ep *ep,
 			 struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_readrsp_hdr *readrsp_hdr;
+	int ret;
 
 	readrsp_hdr = rxr_get_readrsp_hdr(pkt_entry->pkt);
 	readrsp_hdr->type = RXR_READRSP_PKT;
@@ -333,9 +334,9 @@ int rxr_pkt_init_readrsp(struct rxr_ep *ep,
 				      tx_entry->total_len);
 
 	pkt_entry->addr = tx_entry->addr;
-	rxr_pkt_init_data_from_tx_entry(ep, pkt_entry, sizeof(struct rxr_readrsp_hdr), 
-					tx_entry, 0, readrsp_hdr->seg_length);
-	return 0;
+	ret = rxr_pkt_init_data_from_tx_entry(ep, pkt_entry, sizeof(struct rxr_readrsp_hdr),
+					      tx_entry, 0, readrsp_hdr->seg_length);
+	return ret;
 }
 
 void rxr_pkt_handle_readrsp_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)


### PR DESCRIPTION
There are scenarios where rxr_pkt_init_data_from_tx_entry can fail, add a
return value.

Signed-off-by: Robert Wespetal <wesper@amazon.com>