### PR TITLE
prov/efa: return ENOSYS if a CUDA descriptor is used with atomics

### DIFF
--- a/prov/efa/src/rxr/rxr_atomic.c
+++ b/prov/efa/src/rxr/rxr_atomic.c
@@ -136,6 +136,10 @@ ssize_t rxr_atomic_generic_efa(struct rxr_ep *rxr_ep,
 
 	assert(msg->iov_count <= rxr_ep->tx_iov_limit);
 	efa_perfset_start(rxr_ep, perf_efa_tx);
+
+	if (efa_ep_is_cuda_mr(msg->desc[0]))
+		return -FI_ENOSYS;
+
 	fastlock_acquire(&rxr_ep->util_ep.lock);
 
 	if (OFI_UNLIKELY(is_tx_res_full(rxr_ep))) {


### PR DESCRIPTION
The atomics paths do not use hmem copy calls so if HMEM is used with atomics it
will crash. Not really sure how we can handle validation of the RMA iov on the
other side either, so return an error for now.

Signed-off-by: Robert Wespetal <wesper@amazon.com>