### PR TITLE
[v1.13.x] prov/efa: set x_entry of longread RTM and longread RTW

### DIFF
--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -582,6 +582,7 @@ ssize_t rxr_pkt_init_read_rtm(struct rxr_ep *ep,
 		return err;
 
 	pkt_entry->pkt_size = hdr_size + tx_entry->iov_count * sizeof(struct fi_rma_iov);
+	pkt_entry->x_entry = tx_entry;
 	return 0;
 }
 
@@ -1479,6 +1480,7 @@ ssize_t rxr_pkt_init_read_rtw(struct rxr_ep *ep,
 		return err;
 
 	pkt_entry->pkt_size = hdr_size + tx_entry->iov_count * sizeof(struct fi_rma_iov);
+	pkt_entry->x_entry = tx_entry;
 	return 0;
 }
 


### PR DESCRIPTION
longread RTM and longread RTW's x_entry was not set, which
can cause the RNR event of these packets not being handled
correctly.

This patch fix the issue.

Signed-off-by: Yehuda Yitschak <yehuday@amazon.com>
Signed-off-by: Wei Zhang <wzam@amazon.com>