### PR TITLE
core/hmem: add a new environment variable to disable FI_HMEM p2p

### DIFF
--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -41,6 +41,8 @@
 #include <rdma/fi_domain.h>
 #include <stdbool.h>
 
+extern bool ofi_hmem_disable_p2p;
+
 #if HAVE_LIBCUDA
 
 #include <cuda.h>
@@ -208,6 +210,11 @@ static inline int ofi_hmem_no_base_addr(const void *ptr, void **base)
 static inline bool ofi_hmem_no_is_ipc_enabled(void)
 {
 	return false;
+}
+
+static inline bool ofi_hmem_p2p_disabled(void)
+{
+	return ofi_hmem_disable_p2p;
 }
 
 ssize_t ofi_copy_from_hmem_iov(void *dest, size_t size,

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -538,6 +538,8 @@ The following option levels and option names and parameters are defined.
 	* FI_HMEM_P2P_DISABLED: Peer to peer support should not be used.
 : fi_setopt() will return -FI_EOPNOTSUPP if the mode requested cannot be supported
   by the provider.
+: The FI_HMEM_DISABLE_P2P environment variable discussed in
+  [`fi_mr`(3)](fi_mr.3.html) takes precedence over this setopt option.
 
 ## fi_tc_dscp_set
 

--- a/man/fi_mr.3.md
+++ b/man/fi_mr.3.md
@@ -667,6 +667,13 @@ portable applications target using those interfaces; however, their use
 does carry extra message and memory footprint overhead, making it less
 desirable for highly scalable apps.
 
+There may be cases where device peer to peer support should not be used or
+cannot be used, such as when the PCIe ACS configuration does not permit the
+transfer. The FI_HMEM_DISABLE_P2P environment variable can be set to notify
+Libfabric that peer to peer transactions should not be used. The provider may
+choose to perform a copy instead, or will fail support for FI_HMEM if the
+provider is unable to do that.
+
 # FLAGS
 
 The follow flag may be specified to any memory registration call.

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -40,6 +40,8 @@
 #include "ofi.h"
 #include "ofi_iov.h"
 
+bool ofi_hmem_disable_p2p = false;
+
 struct ofi_hmem_ops hmem_ops[] = {
 	[FI_HMEM_SYSTEM] = {
 		.initialized = true,
@@ -209,6 +211,7 @@ bool ofi_hmem_is_initialized(enum fi_hmem_iface iface)
 void ofi_hmem_init(void)
 {
 	int iface, ret;
+	int disable_p2p = 0;
 
 	for (iface = 0; iface < ARRAY_SIZE(hmem_ops); iface++) {
 		ret = hmem_ops[iface].init();
@@ -225,6 +228,15 @@ void ofi_hmem_init(void)
 		} else {
 			hmem_ops[iface].initialized = true;
 		}
+	}
+
+	fi_param_define(NULL, "hmem_disable_p2p", FI_PARAM_BOOL,
+			"Disable peer to peer support between device memory and"
+			" network devices. (default: no).");
+
+	if (!fi_param_get_bool(NULL, "hmem_disable_p2p", &disable_p2p)) {
+		if (disable_p2p == 1)
+			ofi_hmem_disable_p2p = true;
 	}
 }
 


### PR DESCRIPTION
Add an environment variable that users can set to notify Libfabric that p2p
should not be used. The FI_OPT_FI_HMEM_P2P setopt option provides additional
flexibility over this environment variable.

Signed-off-by: Robert Wespetal <wesper@amazon.com>