### PR TITLE
prov/efa: fail FI_HMEM support when p2p is disabled

### DIFF
--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -490,7 +490,11 @@ static int rxr_info_to_rxr(uint32_t version, const struct fi_info *core_info,
 		 * which means FI_MR_HMEM implies FI_MR_LOCAL for cuda buffer
 		 */
 		if (hints->caps & FI_HMEM) {
-
+			if (ofi_hmem_p2p_disabled()) {
+				FI_WARN(&rxr_prov, FI_LOG_CORE,
+					"FI_HMEM capability currently requires peer to peer support, which is disabled.\n");
+				return -FI_ENODATA;
+			}
 			if (!efa_device_support_rdma_read()) {
 				FI_WARN(&rxr_prov, FI_LOG_CORE,
 				        "FI_HMEM capability requires RDMA, which this device does not support.\n");


### PR DESCRIPTION
Fail FI_HMEM support when the FI_HMEM_DISABLE_P2P env is set to true. A future patch series will add support to the EFA provider so that it can fallback to copies.

Signed-off-by: Robert Wespetal <wesper@amazon.com>