### PR TITLE
hmem: disable cuda/ze IPC if p2p is disabled

### DIFF
--- a/src/hmem_cuda.c
+++ b/src/hmem_cuda.c
@@ -582,7 +582,7 @@ int cuda_host_unregister(void *ptr)
 
 bool cuda_is_ipc_enabled(void)
 {
-	return cuda_ipc_enabled;
+	return !ofi_hmem_p2p_disabled() && cuda_ipc_enabled;
 }
 
 #else

--- a/src/hmem_ze.c
+++ b/src/hmem_ze.c
@@ -385,7 +385,7 @@ int ze_hmem_open_shared_handle(int dev_fd, void **handle, int *ze_fd,
 
 bool ze_hmem_p2p_enabled(void)
 {
-	return p2p_enabled;
+	return !ofi_hmem_p2p_disabled() && p2p_enabled;
 }
 
 #else


### PR DESCRIPTION
Use the new FI_HMEM_DISABLE_P2P environment variable to disable cuda/ze IPC
when this option is turned on, and by proxy not use ipc in the shm provider.

Signed-off-by: Robert Wespetal <wesper@amazon.com>