### PR TITLE
prov/psm3: fail FI_HMEM support if p2p is disabled

### DIFF
--- a/prov/psm3/src/psmx3_attr.c
+++ b/prov/psm3/src/psmx3_attr.c
@@ -286,7 +286,8 @@ static long get_psm3_env(const char *var, int default_value) {
 #endif
 static uint64_t psmx3_check_fi_hmem_cap(void) {
 #ifdef PSM_CUDA
-	if (get_psm3_env("PSM3_CUDA", 0) || get_psm3_env("PSM3_GPUDIRECT", 0))
+	if ((get_psm3_env("PSM3_CUDA", 0) || get_psm3_env("PSM3_GPUDIRECT", 0)) &&
+	    !ofi_hmem_p2p_disabled())
 		return FI_HMEM;
 #endif
 	return 0;


### PR DESCRIPTION
Fail FI_HMEM support when the FI_HMEM_DISABLE_P2P env is set to true.

Signed-off-by: Robert Wespetal <wesper@amazon.com>