### PR TITLE
prov/verbs: fail FI_HMEM support if p2p is disabled

### DIFF
--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -731,6 +731,9 @@ static int vrb_have_device(void)
 
 static bool vrb_hmem_supported(const char *dev_name)
 {
+	if (ofi_hmem_p2p_disabled())
+		return false;
+
 	if (vrb_gl_data.peer_mem_support && strstr(dev_name, "mlx"))
 		return true;
 


### PR DESCRIPTION
Fail FI_HMEM support when the FI_HMEM_DISABLE_P2P env is set to true.

Signed-off-by: Robert Wespetal <wesper@amazon.com>