### PR TITLE
workflow: Fix a typo in stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -27,6 +27,6 @@ jobs:
         stale-pr-message: 'This pull request is stale because it has been open 360 days with no activity. Remove stale label or comment, otherwise it will be closed in 7 days.'
         stale-issue-label: 'stale'
         stale-pr-label: 'stale'
-        operations_per_run: 60
+        operations-per-run: 60
         exempt-issue-labels: 'enhancement,high priority'
         exempt-pr-labels: 'work in progress'


### PR DESCRIPTION
Option names use dash instead of underscore.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>