### PR TITLE
[v1.13.x] prov/rxm: Handle connection failures from verbs

### DIFF
--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -626,11 +626,15 @@ static void rxm_handle_error(struct rxm_ep *ep)
 		return;
 	}
 
+	OFI_EQ_STRERROR(&rxm_prov, FI_LOG_WARN, FI_LOG_EP_CTRL, ep->msg_eq,
+			&entry);
+	if (!entry.fid || entry.fid->fclass != FI_CLASS_EP)
+		return;
+
 	if (entry.err == ECONNREFUSED) {
 		rxm_process_reject(entry.fid->context, &entry);
 	} else {
-		OFI_EQ_STRERROR(&rxm_prov, FI_LOG_WARN, FI_LOG_EP_CTRL,
-				ep->msg_eq, &entry);
+		rxm_process_shutdown(entry.fid->context);
 	}
 }
 


### PR DESCRIPTION
If we receive a connection failure from verbs, reset
the conn object, so that a subsequent attempt can try
again.


Signed-off-by: Sean Hefty <sean.hefty@intel.com>