### PR TITLE
prov/efa: only build for linux x86_64 and linux aarch64

### DIFF
--- a/prov/efa/configure.m4
+++ b/prov/efa/configure.m4
@@ -99,6 +99,13 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 
 	AS_IF([test "$enable_efa" = "no"], [efa_happy=0])
 
+	# TODO: fix this once windows is supported
+	AS_IF([test $linux -ne 1 || { test x$host_cpu != xx86_64 && test x$host_cpu != xaarch64 ;}],
+		[
+			AC_MSG_WARN([The EFA provider requires linux x86_64 or linux aarch64.])
+			efa_happy=0
+		])
+
 	AS_IF([test $efa_happy -eq 1 ], [$1], [$2])
 
 	efa_CPPFLAGS="$efa_ibverbs_CPPFLAGS $efadv_CPPFLAGS"


### PR DESCRIPTION
The EFA provider is failing to build for i686 targets, so for now only
build the provider for x86_64 and aarch64.

Note: the EFA device is available on EC2 Windows instances, but the
libfabric provider does not compile there. This will need to be updated
once it does compile.

Signed-off-by: Robert Wespetal <wesper@amazon.com>