### PR TITLE
core: Fix build warnings, mostly around printf format specifiers, in several areas

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -119,10 +119,18 @@ extern "C" {
 	OFI_INFO_FIELD(provider, prov->field, user->field, "Supported",	\
 		      "Requested", type)
 
-#define OFI_INFO_CHECK_VAL(provider, prov, user, field)				\
+#define OFI_INFO_CHECK_SIZE(provider, prov, user, field)			\
 	do {									\
 		FI_INFO(provider, FI_LOG_CORE, "Supported: %zd\n", prov->field);\
 		FI_INFO(provider, FI_LOG_CORE, "Requested: %zd\n", user->field);\
+	} while (0)
+
+#define OFI_INFO_CHECK_U64(provider, prov, user, field)			\
+	do {								\
+		FI_INFO(provider, FI_LOG_CORE,				\
+			"Supported: %" PRIu64 "\n", prov->field);	\
+		FI_INFO(provider, FI_LOG_CORE,				\
+			"Requested: %" PRIu64 "\n", user->field);	\
 	} while (0)
 
 #define OFI_INFO_MODE(provider, prov_mode, user_mode)				\

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -101,41 +101,40 @@ extern "C" {
 #define OFI_EQ_STRERROR(prov, level, subsys, eq, entry) \
 	OFI_Q_STRERROR(prov, level, subsys, eq, "eq", entry, fi_eq_strerror)
 
-#define FI_INFO_FIELD(provider, prov_attr, user_attr, prov_str, user_str, type)	\
-	do {										\
-		FI_INFO(provider, FI_LOG_CORE, prov_str ": %s\n",			\
-				fi_tostr(&prov_attr, type));				\
-		FI_INFO(provider, FI_LOG_CORE, user_str ": %s\n",			\
-				fi_tostr(&user_attr, type));				\
+#define OFI_INFO_FIELD(provider, prov_attr, user_attr, prov_str, user_str, type) \
+	do {									\
+		FI_INFO(provider, FI_LOG_CORE, prov_str ": %s\n",		\
+				fi_tostr(&prov_attr, type));			\
+		FI_INFO(provider, FI_LOG_CORE, user_str ": %s\n",		\
+				fi_tostr(&user_attr, type));			\
 	} while (0)
 
-#define FI_INFO_STRING(provider, prov_attr, user_attr, prov_str, user_str)	\
+#define OFI_INFO_STR(provider, prov_attr, user_attr, prov_str, user_str)	\
 	do {									\
 		FI_INFO(provider, FI_LOG_CORE, prov_str ": %s\n", prov_attr);	\
 		FI_INFO(provider, FI_LOG_CORE, user_str ": %s\n", user_attr);	\
 	} while (0)
 
-#define FI_INFO_CHECK(provider, prov, user, field, type)		\
-	FI_INFO_FIELD(provider, prov->field, user->field, "Supported",	\
+#define OFI_INFO_CHECK(provider, prov, user, field, type)		\
+	OFI_INFO_FIELD(provider, prov->field, user->field, "Supported",	\
 		      "Requested", type)
 
-#define FI_INFO_CHECK_VAL(provider, prov, user, field)					\
-	do {										\
-		FI_INFO(provider, FI_LOG_CORE, "Supported: %zd\n", prov->field);	\
-		FI_INFO(provider, FI_LOG_CORE, "Requested: %zd\n", user->field);	\
+#define OFI_INFO_CHECK_VAL(provider, prov, user, field)				\
+	do {									\
+		FI_INFO(provider, FI_LOG_CORE, "Supported: %zd\n", prov->field);\
+		FI_INFO(provider, FI_LOG_CORE, "Requested: %zd\n", user->field);\
 	} while (0)
 
-#define FI_INFO_MODE(provider, prov_mode, user_mode)				\
-	FI_INFO_FIELD(provider, prov_mode, user_mode, "Expected", "Given",	\
+#define OFI_INFO_MODE(provider, prov_mode, user_mode)				\
+	OFI_INFO_FIELD(provider, prov_mode, user_mode, "Expected", "Given",	\
 		      FI_TYPE_MODE)
 
-#define FI_INFO_MR_MODE(provider, prov_mode, user_mode)			\
-	FI_INFO_FIELD(provider, prov_mode, user_mode, "Expected", "Given",	\
+#define OFI_INFO_MR_MODE(provider, prov_mode, user_mode)			\
+	OFI_INFO_FIELD(provider, prov_mode, user_mode, "Expected", "Given",	\
 		      FI_TYPE_MR_MODE)
 
-#define FI_INFO_NAME(provider, prov, user)				\
-	FI_INFO_STRING(provider, prov->name, user->name, "Supported",	\
-		       "Requested")
+#define OFI_INFO_NAME(provider, prov, user)				\
+	OFI_INFO_STR(provider, prov->name, user->name, "Supported", "Requested")
 
 #define ofi_after_eq(a,b)	((long)((a) - (b)) >= 0)
 #define ofi_before(a,b)		((long)((a) - (b)) < 0)

--- a/include/windows/sched.h
+++ b/include/windows/sched.h
@@ -1,0 +1,13 @@
+
+#pragma once
+
+
+#include "osd.h"
+#include <processthreadsapi.h>
+
+
+static inline int sched_yield(void)
+{
+	(void) SwitchToThread();
+	return 0;
+}

--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -766,6 +766,7 @@
     <ClInclude Include="include\windows\osd.h" />
     <ClInclude Include="include\windows\poll.h" />
     <ClInclude Include="include\windows\pthread.h" />
+    <ClInclude Include="include\windows\sched.h" />
     <ClInclude Include="include\windows\sys\ipc.h" />
     <ClInclude Include="include\windows\sys\mman.h" />
     <ClInclude Include="include\windows\sys\param.h" />

--- a/libfabric.vcxproj.filters
+++ b/libfabric.vcxproj.filters
@@ -623,6 +623,9 @@
     <ClInclude Include="include\windows\pthread.h">
       <Filter>Header Files\windows</Filter>
     </ClInclude>
+    <ClInclude Include="include\windows\sched.h">
+      <Filter>Header Files\windows</Filter>
+    </ClInclude>
     <ClInclude Include="include\windows\unistd.h">
       <Filter>Header Files\windows</Filter>
     </ClInclude>

--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -187,7 +187,7 @@ static int efa_check_hints(uint32_t version, const struct fi_info *hints,
 
 	if (hints->caps & ~(info->caps)) {
 		EFA_INFO(FI_LOG_CORE, "Unsupported capabilities\n");
-		FI_INFO_CHECK(&efa_prov, info, hints, caps, FI_TYPE_CAPS);
+		OFI_INFO_CHECK(&efa_prov, info, hints, caps, FI_TYPE_CAPS);
 		return -FI_ENODATA;
 	}
 
@@ -195,7 +195,7 @@ static int efa_check_hints(uint32_t version, const struct fi_info *hints,
 
 	if ((hints->mode & prov_mode) != prov_mode) {
 		EFA_INFO(FI_LOG_CORE, "Required hints mode bits not set\n");
-		FI_INFO_MODE(&efa_prov, prov_mode, hints->mode);
+		OFI_INFO_MODE(&efa_prov, prov_mode, hints->mode);
 		return -FI_ENODATA;
 	}
 

--- a/prov/psm2/src/psmx2_attr.c
+++ b/prov/psm2/src/psmx2_attr.c
@@ -177,14 +177,14 @@ int psmx2_init_prov_info(const struct fi_info *hints, struct fi_info **info)
 	if (hints->fabric_attr && hints->fabric_attr->name &&
 	    strcasecmp(hints->fabric_attr->name, fabric_attr->name)) {
 		FI_INFO(&psmx2_prov, FI_LOG_CORE, "Unknown fabric name\n");
-		FI_INFO_NAME(&psmx2_prov, fabric_attr, hints->fabric_attr);
+		OFI_INFO_NAME(&psmx2_prov, fabric_attr, hints->fabric_attr);
 		return -FI_ENODATA;
 	}
 
 	if (hints->domain_attr && hints->domain_attr->name &&
 	    strncasecmp(hints->domain_attr->name, domain_attr->name, strlen(PSMX2_DOMAIN_NAME))) {
 		FI_INFO(&psmx2_prov, FI_LOG_CORE, "Unknown domain name\n");
-		FI_INFO_NAME(&psmx2_prov, domain_attr, hints->domain_attr);
+		OFI_INFO_NAME(&psmx2_prov, domain_attr, hints->domain_attr);
 		return -FI_ENODATA;
 	}
 
@@ -230,7 +230,7 @@ int psmx2_init_prov_info(const struct fi_info *hints, struct fi_info **info)
 
 	if ((hints->caps & PSMX2_CAPS) != hints->caps) {
 		FI_INFO(&psmx2_prov, FI_LOG_CORE, "caps not supported\n");
-		FI_INFO_CHECK(&psmx2_prov, prov_info, hints, caps, FI_TYPE_CAPS);
+		OFI_INFO_CHECK(&psmx2_prov, prov_info, hints, caps, FI_TYPE_CAPS);
 		return -FI_ENODATA;
 	}
 

--- a/prov/psm3/src/psmx3_attr.c
+++ b/prov/psm3/src/psmx3_attr.c
@@ -335,7 +335,7 @@ int psmx3_init_prov_info(const struct fi_info *hints, struct fi_info **info)
 	if (hints->fabric_attr && hints->fabric_attr->name &&
 	    strcasecmp(hints->fabric_attr->name, fabric_attr->name)) {
 		FI_INFO(&psmx3_prov, FI_LOG_CORE, "Unknown fabric name\n");
-		FI_INFO_NAME(&psmx3_prov, fabric_attr, hints->fabric_attr);
+		OFI_INFO_NAME(&psmx3_prov, fabric_attr, hints->fabric_attr);
 		return -FI_ENODATA;
 	}
 
@@ -389,7 +389,7 @@ int psmx3_init_prov_info(const struct fi_info *hints, struct fi_info **info)
 
 	if ((hints->caps & prov_info->caps) != hints->caps) {
 		FI_INFO(&psmx3_prov, FI_LOG_CORE, "caps not supported\n");
-		FI_INFO_CHECK(&psmx3_prov, prov_info, hints, caps, FI_TYPE_CAPS);
+		OFI_INFO_CHECK(&psmx3_prov, prov_info, hints, caps, FI_TYPE_CAPS);
 		return -FI_ENODATA;
 	}
 

--- a/prov/psm3/src/psmx3_init.c
+++ b/prov/psm3/src/psmx3_init.c
@@ -449,7 +449,7 @@ static void psmx3_update_hfi_nic_info(struct fi_info *info)
 
 		args[0].unit = unit;
 		if ((PSM2_OK != psm2_info_query(PSM2_INFO_QUERY_UNIT_SYS_PATH,
-			sys_dev_path, 2, args)) || 
+			sys_dev_path, 2, args)) ||
 			(asprintf(&path, "%s/%s", sys_dev_path, "device") < 0))
 		{
 			FI_WARN(&psmx3_prov, FI_LOG_CORE,
@@ -519,7 +519,7 @@ static int psmx3_getinfo(uint32_t api_version, const char *node,
 	if (hints && hints->domain_attr && hints->domain_attr->name &&
 		NULL == strcasestr(psmx3_hfi_info.default_domain_name, hints->domain_attr->name)) {
 		FI_INFO(&psmx3_prov, FI_LOG_CORE, "Unknown domain name\n");
-		FI_INFO_STRING(&psmx3_prov, psmx3_hfi_info.default_domain_name,
+		OFI_INFO_STR(&psmx3_prov, psmx3_hfi_info.default_domain_name,
 					   hints->domain_attr->name, "Supported", "Requested");
 		goto err_out;
 	}

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -589,7 +589,7 @@ int ofi_check_domain_attr(const struct fi_provider *prov, uint32_t api_version,
 
 	if (user_attr->cq_data_size > prov_attr->cq_data_size) {
 		FI_INFO(prov, FI_LOG_CORE, "CQ data size too large\n");
-		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr, cq_data_size);
+		OFI_INFO_CHECK_SIZE(prov, prov_attr, user_attr, cq_data_size);
 		return -FI_ENODATA;
 	}
 
@@ -598,12 +598,12 @@ int ofi_check_domain_attr(const struct fi_provider *prov, uint32_t api_version,
 
 	if (user_attr->max_ep_stx_ctx > prov_attr->max_ep_stx_ctx) {
 		FI_INFO(prov, FI_LOG_CORE, "max_ep_stx_ctx greater than supported\n");
-		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr, max_ep_stx_ctx);
+		OFI_INFO_CHECK_SIZE(prov, prov_attr, user_attr, max_ep_stx_ctx);
 	}
 
 	if (user_attr->max_ep_srx_ctx > prov_attr->max_ep_srx_ctx) {
 		FI_INFO(prov, FI_LOG_CORE, "max_ep_srx_ctx greater than supported\n");
-		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr, max_ep_srx_ctx);
+		OFI_INFO_CHECK_SIZE(prov, prov_attr, user_attr, max_ep_srx_ctx);
 	}
 
 	/* following checks only apply to api 1.5 and beyond */
@@ -617,7 +617,7 @@ int ofi_check_domain_attr(const struct fi_provider *prov, uint32_t api_version,
 
 	if (user_attr->mr_iov_limit > prov_attr->mr_iov_limit) {
 		FI_INFO(prov, FI_LOG_CORE, "MR iov limit too large\n");
-		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr, mr_iov_limit);
+		OFI_INFO_CHECK_SIZE(prov, prov_attr, user_attr, mr_iov_limit);
 		return -FI_ENODATA;
 	}
 
@@ -635,13 +635,13 @@ int ofi_check_domain_attr(const struct fi_provider *prov, uint32_t api_version,
 
 	if (user_attr->max_err_data > prov_attr->max_err_data) {
 		FI_INFO(prov, FI_LOG_CORE, "Max err data too large\n");
-		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr, max_err_data);
+		OFI_INFO_CHECK_SIZE(prov, prov_attr, user_attr, max_err_data);
 		return -FI_ENODATA;
 	}
 
 	if (user_attr->mr_cnt > prov_attr->mr_cnt) {
 		FI_INFO(prov, FI_LOG_CORE, "MR count too large\n");
-		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr, mr_cnt);
+		OFI_INFO_CHECK_SIZE(prov, prov_attr, user_attr, mr_cnt);
 		return -FI_ENODATA;
 	}
 
@@ -690,7 +690,7 @@ int ofi_check_ep_attr(const struct util_prov *util_prov, uint32_t api_version,
 
 	if (user_attr->max_msg_size > prov_attr->max_msg_size) {
 		FI_INFO(prov, FI_LOG_CORE, "Max message size too large\n");
-		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr, max_msg_size);
+		OFI_INFO_CHECK_SIZE(prov, prov_attr, user_attr, max_msg_size);
 		return -FI_ENODATA;
 	}
 
@@ -733,8 +733,8 @@ int ofi_check_ep_attr(const struct util_prov *util_prov, uint32_t api_version,
 		    prov_attr->max_order_raw_size) {
 			FI_INFO(prov, FI_LOG_CORE,
 				"Max order RAW size exceeds supported size\n");
-			OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr,
-					  max_order_raw_size);
+			OFI_INFO_CHECK_SIZE(prov, prov_attr, user_attr,
+					    max_order_raw_size);
 			return -FI_ENODATA;
 		}
 
@@ -742,8 +742,8 @@ int ofi_check_ep_attr(const struct util_prov *util_prov, uint32_t api_version,
 		    prov_attr->max_order_war_size) {
 			FI_INFO(prov, FI_LOG_CORE,
 				"Max order WAR size exceeds supported size\n");
-			OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr,
-					  max_order_war_size);
+			OFI_INFO_CHECK_SIZE(prov, prov_attr, user_attr,
+					    max_order_war_size);
 			return -FI_ENODATA;
 		}
 
@@ -751,8 +751,8 @@ int ofi_check_ep_attr(const struct util_prov *util_prov, uint32_t api_version,
 		    prov_attr->max_order_waw_size) {
 			FI_INFO(prov, FI_LOG_CORE,
 				"Max order WAW size exceeds supported size\n");
-			OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr,
-					  max_order_waw_size);
+			OFI_INFO_CHECK_SIZE(prov, prov_attr, user_attr,
+					    max_order_waw_size);
 			return -FI_ENODATA;
 		}
 	}
@@ -760,7 +760,7 @@ int ofi_check_ep_attr(const struct util_prov *util_prov, uint32_t api_version,
 	if (user_attr->auth_key_size &&
 	    (user_attr->auth_key_size != prov_attr->auth_key_size)) {
 		FI_INFO(prov, FI_LOG_CORE, "Unsupported authentication size.");
-		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr, auth_key_size);
+		OFI_INFO_CHECK_SIZE(prov, prov_attr, user_attr, auth_key_size);
 		return -FI_ENODATA;
 	}
 
@@ -768,7 +768,7 @@ int ofi_check_ep_attr(const struct util_prov *util_prov, uint32_t api_version,
 	    ofi_max_tag(user_attr->mem_tag_format) >
 		    ofi_max_tag(prov_attr->mem_tag_format)) {
 		FI_INFO(prov, FI_LOG_CORE, "Tag size exceeds supported size\n");
-		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr, mem_tag_format);
+		OFI_INFO_CHECK_U64(prov, prov_attr, user_attr, mem_tag_format);
 		return -FI_ENODATA;
 	}
 
@@ -821,20 +821,20 @@ int ofi_check_rx_attr(const struct fi_provider *prov,
 
 	if (user_attr->total_buffered_recv > prov_attr->total_buffered_recv) {
 		FI_INFO(prov, FI_LOG_CORE, "total_buffered_recv too large\n");
-		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr,
-				  total_buffered_recv);
+		OFI_INFO_CHECK_SIZE(prov, prov_attr, user_attr,
+				    total_buffered_recv);
 		return -FI_ENODATA;
 	}
 
 	if (user_attr->size > prov_attr->size) {
 		FI_INFO(prov, FI_LOG_CORE, "size is greater than supported\n");
-		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr, size);
+		OFI_INFO_CHECK_SIZE(prov, prov_attr, user_attr, size);
 		return -FI_ENODATA;
 	}
 
 	if (user_attr->iov_limit > prov_attr->iov_limit) {
 		FI_INFO(prov, FI_LOG_CORE, "iov_limit too large\n");
-		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr, iov_limit);
+		OFI_INFO_CHECK_SIZE(prov, prov_attr, user_attr, iov_limit);
 		return -FI_ENODATA;
 	}
 
@@ -843,8 +843,8 @@ int ofi_check_rx_attr(const struct fi_provider *prov,
 		/* Just log a notification, but ignore the value */
 		FI_INFO(prov, FI_LOG_CORE,
 			"Total buffered recv size exceeds supported size\n");
-		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr,
-				  total_buffered_recv);
+		OFI_INFO_CHECK_SIZE(prov, prov_attr, user_attr,
+				    total_buffered_recv);
 	}
 
 	return 0;
@@ -919,25 +919,25 @@ int ofi_check_tx_attr(const struct fi_provider *prov,
 
 	if (user_attr->inject_size > prov_attr->inject_size) {
 		FI_INFO(prov, FI_LOG_CORE, "inject_size too large\n");
-		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr, inject_size);
+		OFI_INFO_CHECK_SIZE(prov, prov_attr, user_attr, inject_size);
 		return -FI_ENODATA;
 	}
 
 	if (user_attr->size > prov_attr->size) {
 		FI_INFO(prov, FI_LOG_CORE, "size is greater than supported\n");
-		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr, size);
+		OFI_INFO_CHECK_SIZE(prov, prov_attr, user_attr, size);
 		return -FI_ENODATA;
 	}
 
 	if (user_attr->iov_limit > prov_attr->iov_limit) {
 		FI_INFO(prov, FI_LOG_CORE, "iov_limit too large\n");
-		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr, iov_limit);
+		OFI_INFO_CHECK_SIZE(prov, prov_attr, user_attr, iov_limit);
 		return -FI_ENODATA;
 	}
 
 	if (user_attr->rma_iov_limit > prov_attr->rma_iov_limit) {
 		FI_INFO(prov, FI_LOG_CORE, "rma_iov_limit too large\n");
-		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr, rma_iov_limit);
+		OFI_INFO_CHECK_SIZE(prov, prov_attr, user_attr, rma_iov_limit);
 		return -FI_ENODATA;
 	}
 

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -544,7 +544,7 @@ int ofi_check_mr_mode(const struct fi_provider *prov, uint32_t api_version,
 out:
 	if (ret) {
 		FI_INFO(prov, FI_LOG_CORE, "Invalid memory registration mode\n");
-		FI_INFO_MR_MODE(prov, prov_mode, user_mode);
+		OFI_INFO_MR_MODE(prov, prov_mode, user_mode);
 	}
 
 	return ret;
@@ -589,7 +589,7 @@ int ofi_check_domain_attr(const struct fi_provider *prov, uint32_t api_version,
 
 	if (user_attr->cq_data_size > prov_attr->cq_data_size) {
 		FI_INFO(prov, FI_LOG_CORE, "CQ data size too large\n");
-		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr, cq_data_size);
+		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr, cq_data_size);
 		return -FI_ENODATA;
 	}
 
@@ -598,12 +598,12 @@ int ofi_check_domain_attr(const struct fi_provider *prov, uint32_t api_version,
 
 	if (user_attr->max_ep_stx_ctx > prov_attr->max_ep_stx_ctx) {
 		FI_INFO(prov, FI_LOG_CORE, "max_ep_stx_ctx greater than supported\n");
-		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr, max_ep_stx_ctx);
+		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr, max_ep_stx_ctx);
 	}
 
 	if (user_attr->max_ep_srx_ctx > prov_attr->max_ep_srx_ctx) {
 		FI_INFO(prov, FI_LOG_CORE, "max_ep_srx_ctx greater than supported\n");
-		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr, max_ep_srx_ctx);
+		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr, max_ep_srx_ctx);
 	}
 
 	/* following checks only apply to api 1.5 and beyond */
@@ -617,31 +617,31 @@ int ofi_check_domain_attr(const struct fi_provider *prov, uint32_t api_version,
 
 	if (user_attr->mr_iov_limit > prov_attr->mr_iov_limit) {
 		FI_INFO(prov, FI_LOG_CORE, "MR iov limit too large\n");
-		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr, mr_iov_limit);
+		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr, mr_iov_limit);
 		return -FI_ENODATA;
 	}
 
 	if (user_attr->caps & ~(prov_attr->caps)) {
 		FI_INFO(prov, FI_LOG_CORE, "Requested domain caps not supported\n");
-		FI_INFO_CHECK(prov, prov_attr, user_attr, caps, FI_TYPE_CAPS);
+		OFI_INFO_CHECK(prov, prov_attr, user_attr, caps, FI_TYPE_CAPS);
 		return -FI_ENODATA;
 	}
 
 	if ((user_attr->mode & prov_attr->mode) != prov_attr->mode) {
 		FI_INFO(prov, FI_LOG_CORE, "Required domain mode missing\n");
-		FI_INFO_MODE(prov, prov_attr->mode, user_attr->mode);
+		OFI_INFO_MODE(prov, prov_attr->mode, user_attr->mode);
 		return -FI_ENODATA;
 	}
 
 	if (user_attr->max_err_data > prov_attr->max_err_data) {
 		FI_INFO(prov, FI_LOG_CORE, "Max err data too large\n");
-		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr, max_err_data);
+		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr, max_err_data);
 		return -FI_ENODATA;
 	}
 
 	if (user_attr->mr_cnt > prov_attr->mr_cnt) {
 		FI_INFO(prov, FI_LOG_CORE, "MR count too large\n");
-		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr, mr_cnt);
+		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr, mr_cnt);
 		return -FI_ENODATA;
 	}
 
@@ -656,7 +656,7 @@ int ofi_check_ep_type(const struct fi_provider *prov,
 	    (prov_attr->type != FI_EP_UNSPEC) &&
 	    (user_attr->type != prov_attr->type)) {
 		FI_INFO(prov, FI_LOG_CORE, "unsupported endpoint type\n");
-		FI_INFO_CHECK(prov, prov_attr, user_attr, type, FI_TYPE_EP_TYPE);
+		OFI_INFO_CHECK(prov, prov_attr, user_attr, type, FI_TYPE_EP_TYPE);
 		return -FI_ENODATA;
 	}
 	return 0;
@@ -678,7 +678,7 @@ int ofi_check_ep_attr(const struct util_prov *util_prov, uint32_t api_version,
 	if ((user_attr->protocol != FI_PROTO_UNSPEC) &&
 	    (user_attr->protocol != prov_attr->protocol)) {
 		FI_INFO(prov, FI_LOG_CORE, "Unsupported protocol\n");
-		FI_INFO_CHECK(prov, prov_attr, user_attr, protocol, FI_TYPE_PROTOCOL);
+		OFI_INFO_CHECK(prov, prov_attr, user_attr, protocol, FI_TYPE_PROTOCOL);
 		return -FI_ENODATA;
 	}
 
@@ -690,7 +690,7 @@ int ofi_check_ep_attr(const struct util_prov *util_prov, uint32_t api_version,
 
 	if (user_attr->max_msg_size > prov_attr->max_msg_size) {
 		FI_INFO(prov, FI_LOG_CORE, "Max message size too large\n");
-		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr, max_msg_size);
+		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr, max_msg_size);
 		return -FI_ENODATA;
 	}
 
@@ -733,7 +733,7 @@ int ofi_check_ep_attr(const struct util_prov *util_prov, uint32_t api_version,
 		    prov_attr->max_order_raw_size) {
 			FI_INFO(prov, FI_LOG_CORE,
 				"Max order RAW size exceeds supported size\n");
-			FI_INFO_CHECK_VAL(prov, prov_attr, user_attr,
+			OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr,
 					  max_order_raw_size);
 			return -FI_ENODATA;
 		}
@@ -742,7 +742,7 @@ int ofi_check_ep_attr(const struct util_prov *util_prov, uint32_t api_version,
 		    prov_attr->max_order_war_size) {
 			FI_INFO(prov, FI_LOG_CORE,
 				"Max order WAR size exceeds supported size\n");
-			FI_INFO_CHECK_VAL(prov, prov_attr, user_attr,
+			OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr,
 					  max_order_war_size);
 			return -FI_ENODATA;
 		}
@@ -751,7 +751,7 @@ int ofi_check_ep_attr(const struct util_prov *util_prov, uint32_t api_version,
 		    prov_attr->max_order_waw_size) {
 			FI_INFO(prov, FI_LOG_CORE,
 				"Max order WAW size exceeds supported size\n");
-			FI_INFO_CHECK_VAL(prov, prov_attr, user_attr,
+			OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr,
 					  max_order_waw_size);
 			return -FI_ENODATA;
 		}
@@ -760,7 +760,7 @@ int ofi_check_ep_attr(const struct util_prov *util_prov, uint32_t api_version,
 	if (user_attr->auth_key_size &&
 	    (user_attr->auth_key_size != prov_attr->auth_key_size)) {
 		FI_INFO(prov, FI_LOG_CORE, "Unsupported authentication size.");
-		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr, auth_key_size);
+		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr, auth_key_size);
 		return -FI_ENODATA;
 	}
 
@@ -768,7 +768,7 @@ int ofi_check_ep_attr(const struct util_prov *util_prov, uint32_t api_version,
 	    ofi_max_tag(user_attr->mem_tag_format) >
 		    ofi_max_tag(prov_attr->mem_tag_format)) {
 		FI_INFO(prov, FI_LOG_CORE, "Tag size exceeds supported size\n");
-		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr, mem_tag_format);
+		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr, mem_tag_format);
 		return -FI_ENODATA;
 	}
 
@@ -787,54 +787,54 @@ int ofi_check_rx_attr(const struct fi_provider *prov,
 
 	if ((user_attr->caps & ~OFI_IGNORED_RX_CAPS) & ~(prov_attr->caps)) {
 		FI_INFO(prov, FI_LOG_CORE, "caps not supported\n");
-		FI_INFO_CHECK(prov, prov_attr, user_attr, caps, FI_TYPE_CAPS);
+		OFI_INFO_CHECK(prov, prov_attr, user_attr, caps, FI_TYPE_CAPS);
 		return -FI_ENODATA;
 	}
 
 	info_mode = user_attr->mode ? user_attr->mode : info_mode;
 	if ((info_mode & prov_attr->mode) != prov_attr->mode) {
 		FI_INFO(prov, FI_LOG_CORE, "needed mode not set\n");
-		FI_INFO_MODE(prov, prov_attr->mode, user_attr->mode);
+		OFI_INFO_MODE(prov, prov_attr->mode, user_attr->mode);
 		return -FI_ENODATA;
 	}
 
 	if (user_attr->op_flags & ~(prov_attr->op_flags)) {
 		FI_INFO(prov, FI_LOG_CORE, "op_flags not supported\n");
-		FI_INFO_CHECK(prov, prov_attr, user_attr, op_flags,
+		OFI_INFO_CHECK(prov, prov_attr, user_attr, op_flags,
 			     FI_TYPE_OP_FLAGS);
 		return -FI_ENODATA;
 	}
 
 	if (user_attr->msg_order & ~(prov_attr->msg_order)) {
 		FI_INFO(prov, FI_LOG_CORE, "msg_order not supported\n");
-		FI_INFO_CHECK(prov, prov_attr, user_attr, msg_order,
+		OFI_INFO_CHECK(prov, prov_attr, user_attr, msg_order,
 			     FI_TYPE_MSG_ORDER);
 		return -FI_ENODATA;
 	}
 
 	if (user_attr->comp_order & ~(prov_attr->comp_order)) {
 		FI_INFO(prov, FI_LOG_CORE, "comp_order not supported\n");
-		FI_INFO_CHECK(prov, prov_attr, user_attr, comp_order,
+		OFI_INFO_CHECK(prov, prov_attr, user_attr, comp_order,
 			     FI_TYPE_MSG_ORDER);
 		return -FI_ENODATA;
 	}
 
 	if (user_attr->total_buffered_recv > prov_attr->total_buffered_recv) {
 		FI_INFO(prov, FI_LOG_CORE, "total_buffered_recv too large\n");
-		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr,
+		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr,
 				  total_buffered_recv);
 		return -FI_ENODATA;
 	}
 
 	if (user_attr->size > prov_attr->size) {
 		FI_INFO(prov, FI_LOG_CORE, "size is greater than supported\n");
-		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr, size);
+		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr, size);
 		return -FI_ENODATA;
 	}
 
 	if (user_attr->iov_limit > prov_attr->iov_limit) {
 		FI_INFO(prov, FI_LOG_CORE, "iov_limit too large\n");
-		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr, iov_limit);
+		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr, iov_limit);
 		return -FI_ENODATA;
 	}
 
@@ -843,7 +843,7 @@ int ofi_check_rx_attr(const struct fi_provider *prov,
 		/* Just log a notification, but ignore the value */
 		FI_INFO(prov, FI_LOG_CORE,
 			"Total buffered recv size exceeds supported size\n");
-		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr,
+		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr,
 				  total_buffered_recv);
 	}
 
@@ -868,7 +868,7 @@ int ofi_check_attr_subset(const struct fi_provider *prov,
 	if (~expanded_caps & requested_caps) {
 		FI_INFO(prov, FI_LOG_CORE,
 			"requested caps not subset of base endpoint caps\n");
-		FI_INFO_FIELD(prov, expanded_caps, requested_caps,
+		OFI_INFO_FIELD(prov, expanded_caps, requested_caps,
 			"Supported", "Requested", FI_TYPE_CAPS);
 		return -FI_ENODATA;
 	}
@@ -885,59 +885,59 @@ int ofi_check_tx_attr(const struct fi_provider *prov,
 
 	if ((user_attr->caps & ~OFI_IGNORED_TX_CAPS) & ~(prov_attr->caps)) {
 		FI_INFO(prov, FI_LOG_CORE, "caps not supported\n");
-		FI_INFO_CHECK(prov, prov_attr, user_attr, caps, FI_TYPE_CAPS);
+		OFI_INFO_CHECK(prov, prov_attr, user_attr, caps, FI_TYPE_CAPS);
 		return -FI_ENODATA;
 	}
 
 	info_mode = user_attr->mode ? user_attr->mode : info_mode;
 	if ((info_mode & prov_attr->mode) != prov_attr->mode) {
 		FI_INFO(prov, FI_LOG_CORE, "needed mode not set\n");
-		FI_INFO_MODE(prov, prov_attr->mode, user_attr->mode);
+		OFI_INFO_MODE(prov, prov_attr->mode, user_attr->mode);
 		return -FI_ENODATA;
 	}
 
 	if (user_attr->op_flags & ~(prov_attr->op_flags)) {
 		FI_INFO(prov, FI_LOG_CORE, "op_flags not supported\n");
-		FI_INFO_CHECK(prov, prov_attr, user_attr, op_flags,
+		OFI_INFO_CHECK(prov, prov_attr, user_attr, op_flags,
 			     FI_TYPE_OP_FLAGS);
 		return -FI_ENODATA;
 	}
 
 	if (user_attr->msg_order & ~(prov_attr->msg_order)) {
 		FI_INFO(prov, FI_LOG_CORE, "msg_order not supported\n");
-		FI_INFO_CHECK(prov, prov_attr, user_attr, msg_order,
+		OFI_INFO_CHECK(prov, prov_attr, user_attr, msg_order,
 			     FI_TYPE_MSG_ORDER);
 		return -FI_ENODATA;
 	}
 
 	if (user_attr->comp_order & ~(prov_attr->comp_order)) {
 		FI_INFO(prov, FI_LOG_CORE, "comp_order not supported\n");
-		FI_INFO_CHECK(prov, prov_attr, user_attr, comp_order,
+		OFI_INFO_CHECK(prov, prov_attr, user_attr, comp_order,
 			     FI_TYPE_MSG_ORDER);
 		return -FI_ENODATA;
 	}
 
 	if (user_attr->inject_size > prov_attr->inject_size) {
 		FI_INFO(prov, FI_LOG_CORE, "inject_size too large\n");
-		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr, inject_size);
+		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr, inject_size);
 		return -FI_ENODATA;
 	}
 
 	if (user_attr->size > prov_attr->size) {
 		FI_INFO(prov, FI_LOG_CORE, "size is greater than supported\n");
-		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr, size);
+		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr, size);
 		return -FI_ENODATA;
 	}
 
 	if (user_attr->iov_limit > prov_attr->iov_limit) {
 		FI_INFO(prov, FI_LOG_CORE, "iov_limit too large\n");
-		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr, iov_limit);
+		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr, iov_limit);
 		return -FI_ENODATA;
 	}
 
 	if (user_attr->rma_iov_limit > prov_attr->rma_iov_limit) {
 		FI_INFO(prov, FI_LOG_CORE, "rma_iov_limit too large\n");
-		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr, rma_iov_limit);
+		OFI_INFO_CHECK_VAL(prov, prov_attr, user_attr, rma_iov_limit);
 		return -FI_ENODATA;
 	}
 
@@ -1039,7 +1039,7 @@ int ofi_check_info(const struct util_prov *util_prov,
 
 	if (user_info->caps & ~(prov_info->caps)) {
 		FI_INFO(prov, FI_LOG_CORE, "Unsupported capabilities\n");
-		FI_INFO_CHECK(prov, prov_info, user_info, caps, FI_TYPE_CAPS);
+		OFI_INFO_CHECK(prov, prov_info, user_info, caps, FI_TYPE_CAPS);
 		return -FI_ENODATA;
 	}
 
@@ -1047,14 +1047,14 @@ int ofi_check_info(const struct util_prov *util_prov,
 
 	if ((user_info->mode & prov_mode) != prov_mode) {
 		FI_INFO(prov, FI_LOG_CORE, "needed mode not set\n");
-		FI_INFO_MODE(prov, prov_mode, user_info->mode);
+		OFI_INFO_MODE(prov, prov_mode, user_info->mode);
 		return -FI_ENODATA;
 	}
 
 	if (!fi_valid_addr_format(prov_info->addr_format,
 				  user_info->addr_format)) {
 		FI_INFO(prov, FI_LOG_CORE, "address format not supported\n");
-		FI_INFO_CHECK(prov, prov_info, user_info, addr_format,
+		OFI_INFO_CHECK(prov, prov_info, user_info, addr_format,
 			      FI_TYPE_ADDR_FORMAT);
 		return -FI_ENODATA;
 	}

--- a/prov/util/src/util_wait.c
+++ b/prov/util/src/util_wait.c
@@ -33,6 +33,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/time.h>
+#include <sched.h>
 
 #include <ofi_enosys.h>
 #include <ofi_util.h>
@@ -618,7 +619,7 @@ static int util_wait_yield_run(struct fid_wait *wait_fid, int timeout)
 			}
 		}
 		fastlock_release(&wait->util_wait.lock);
-		pthread_yield();
+		sched_yield();
 	}
 
 	fastlock_acquire(&wait->signal_lock);

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -747,8 +747,7 @@ static int vrb_ep_enable_xrc(struct vrb_ep *ep)
 
 	if (cq->credits < srq_ep->xrc.max_recv_wr) {
 		VERBS_WARN(FI_LOG_EP_CTRL,
-			   "CQ credits %" PRId64 " insufficient\n",
-			   cq->credits);
+			   "CQ credits %zd insufficient\n", cq->credits);
 		ret = -FI_EINVAL;
 		goto done;
 	}

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -238,7 +238,7 @@ static int vrb_check_hints(uint32_t version, const struct fi_info *hints,
 
 	if (hints->caps & ~(info->caps)) {
 		VERBS_INFO(FI_LOG_CORE, "Unsupported capabilities\n");
-		FI_INFO_CHECK(&vrb_prov, info, hints, caps, FI_TYPE_CAPS);
+		OFI_INFO_CHECK(&vrb_prov, info, hints, caps, FI_TYPE_CAPS);
 		return -FI_ENODATA;
 	}
 
@@ -246,7 +246,7 @@ static int vrb_check_hints(uint32_t version, const struct fi_info *hints,
 
 	if ((hints->mode & prov_mode) != prov_mode) {
 		VERBS_INFO(FI_LOG_CORE, "needed mode not set\n");
-		FI_INFO_MODE(&vrb_prov, prov_mode, hints->mode);
+		OFI_INFO_MODE(&vrb_prov, prov_mode, hints->mode);
 		return -FI_ENODATA;
 	}
 


### PR DESCRIPTION
Changes made in response to a build log provided by redhat.

- Renamed some internal macros to use the OFI prefix.  Impacts several providers.
- Created new macro to separate use of size_t fields from u64, in order that correct printf format specifier is used.
- Replaced deprecated pthread_yield call with sched_yield
- Fixed casting of ints to pointers of different sizes in shm util code.