### PR TITLE
prov/efa: disable 32 bit builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -746,6 +746,8 @@ LDFLAGS="$LDFLAGS $rocr_LDFLAGS"
 
 AS_IF([test x"$enable_rocr_dlopen" != x"yes"], [LIBS="$LIBS $rocr_LIBS"])
 
+AC_CHECK_SIZEOF([void *])
+
 dnl Provider-specific checks
 FI_PROVIDER_INIT
 FI_PROVIDER_SETUP([psm])

--- a/prov/efa/configure.m4
+++ b/prov/efa/configure.m4
@@ -99,6 +99,12 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 
 	AS_IF([test "$enable_efa" = "no"], [efa_happy=0])
 
+	AS_IF([test $ac_cv_sizeof_void_p -eq 4],
+		[
+			efa_happy=0
+			AC_MSG_WARN([The EFA provider is not supported on 32-bit systems.])
+		])
+
 	AS_IF([test $efa_happy -eq 1 ], [$1], [$2])
 
 	efa_CPPFLAGS="$efa_ibverbs_CPPFLAGS $efadv_CPPFLAGS"


### PR DESCRIPTION
Two commits, one to configure.ac and one for EFA to disable 32 bit builds.

```
c22618979 prov/efa: disable build on 32-bit systems
d098dbe5d configure.ac: check size of void*
```

Test description: Dusted off a c1 instance and verified the EFA provider is disabled on a 32 bit system.
