### PR TITLE
prov/shm: disable FI_ATOMIC when FI_HMEM is requested

### DIFF
--- a/prov/shm/src/smr_attr.c
+++ b/prov/shm/src/smr_attr.c
@@ -36,6 +36,8 @@
 #define SMR_RX_CAPS (FI_SOURCE | FI_RMA_EVENT | OFI_RX_MSG_CAPS | FI_TAGGED | \
 		     OFI_RX_RMA_CAPS | FI_ATOMICS | FI_DIRECTED_RECV | \
 		     FI_MULTI_RECV)
+#define SMR_HMEM_TX_CAPS ((SMR_TX_CAPS | FI_HMEM) & ~FI_ATOMICS)
+#define SMR_HMEM_RX_CAPS ((SMR_RX_CAPS | FI_HMEM) & ~FI_ATOMICS)
 #define SMR_TX_OP_FLAGS (FI_COMPLETION | FI_INJECT_COMPLETE | \
 			 FI_TRANSMIT_COMPLETE | FI_DELIVERY_COMPLETE)
 #define SMR_RX_OP_FLAGS (FI_COMPLETION | FI_MULTI_RECV)
@@ -61,7 +63,7 @@ struct fi_rx_attr smr_rx_attr = {
 };
 
 struct fi_tx_attr smr_hmem_tx_attr = {
-	.caps = SMR_TX_CAPS | FI_HMEM,
+	.caps = SMR_HMEM_TX_CAPS,
 	.op_flags = SMR_TX_OP_FLAGS,
 	.comp_order = FI_ORDER_NONE,
 	.msg_order = SMR_RMA_ORDER | FI_ORDER_SAS,
@@ -72,7 +74,7 @@ struct fi_tx_attr smr_hmem_tx_attr = {
 };
 
 struct fi_rx_attr smr_hmem_rx_attr = {
-	.caps = SMR_RX_CAPS | FI_HMEM,
+	.caps = SMR_HMEM_RX_CAPS,
 	.op_flags = SMR_RX_OP_FLAGS,
 	.comp_order = FI_ORDER_STRICT,
 	.msg_order = SMR_RMA_ORDER | FI_ORDER_SAS,
@@ -119,7 +121,7 @@ struct fi_fabric_attr smr_fabric_attr = {
 };
 
 struct fi_info smr_hmem_info = {
-	.caps = SMR_TX_CAPS | SMR_RX_CAPS | FI_HMEM | FI_MULTI_RECV,
+	.caps = SMR_HMEM_TX_CAPS | SMR_HMEM_RX_CAPS | FI_MULTI_RECV,
 	.addr_format = FI_ADDR_STR,
 	.tx_attr = &smr_hmem_tx_attr,
 	.rx_attr = &smr_hmem_rx_attr,


### PR DESCRIPTION
HMEM atomics are not supported. Remove this from the hmem info

Signed-off-by: Alexia Ingerson <alexia.ingerson@intel.com>