### PR TITLE
Make FI_WARN_ONCE MSVC compatible and add missing headers

### DIFF
--- a/include/rdma/providers/fi_log.h
+++ b/include/rdma/providers/fi_log.h
@@ -118,16 +118,18 @@ void fi_log(const struct fi_provider *prov, enum fi_log_level level,
 	do {} while (0)
 #endif
 
-#define FI_WARN_ONCE(prov, subsystem, ...) ({				\
-	static int warned;						\
-	if (!warned && fi_log_enabled(prov, FI_LOG_WARN, subsystem)) {	\
-		int saved_errno = errno;				\
-		fi_log(prov, FI_LOG_WARN, subsystem,			\
+#define FI_WARN_ONCE(prov, subsystem, ...)  				\
+	do {								\
+		static int warned = 0;					\
+		if (!warned &&						\
+		    fi_log_enabled(prov, FI_LOG_WARN, subsystem)) {	\
+			int saved_errno = errno;			\
+			fi_log(prov, FI_LOG_WARN, subsystem,		\
 			__func__, __LINE__, __VA_ARGS__);		\
-		warned = 1;						\
-		errno = saved_errno;					\
-	}								\
-})
+			warned = 1;					\
+			errno = saved_errno;				\
+		}							\
+	} while (0)
 
 #ifdef __cplusplus
 }

--- a/include/windows/alloca.h
+++ b/include/windows/alloca.h
@@ -1,0 +1,4 @@
+
+#pragma once
+
+

--- a/include/windows/asm/types.h
+++ b/include/windows/asm/types.h
@@ -1,0 +1,4 @@
+
+#pragma once
+
+

--- a/include/windows/sys/epoll.h
+++ b/include/windows/sys/epoll.h
@@ -1,0 +1,4 @@
+
+#pragma once
+
+


### PR DESCRIPTION

FI_WARN_ONCE macro is changed to avoid statement expression - it is now similar to FI_WARN macro.
The empty header files are needed to compile efa provider with Microsoft Visual studio Compiler (MSVC).