### PR TITLE
prov/efa: Changes to allow efa provider compilation with MSVC - Does not enable efa provider for Windows yet

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -402,14 +402,6 @@ static inline struct efa_av *rxr_ep_av(struct rxr_ep *ep)
 	return container_of(ep->util_ep.av, struct efa_av, util_av);
 }
 
-#define align_down_to_power_of_2(x)		\
-	({					\
-		__typeof__(x) n = (x);		\
-		while (n & (n - 1))		\
-			n = n & (n - 1);	\
-		n;				\
-	})
-
 extern const struct efa_ep_domain efa_rdm_domain;
 extern const struct efa_ep_domain efa_dgrm_domain;
 

--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -271,7 +271,7 @@ fi_addr_t efa_av_reverse_lookup_rdm(struct efa_av *av, uint16_t ahn, uint16_t qp
 
 static inline int efa_av_is_valid_address(struct efa_ep_addr *addr)
 {
-	struct efa_ep_addr all_zeros = {};
+	struct efa_ep_addr all_zeros = { 0 };
 
 	return memcmp(addr->raw, all_zeros.raw, sizeof(addr->raw));
 }
@@ -985,7 +985,7 @@ int efa_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 {
 	struct efa_domain *efa_domain;
 	struct efa_av *av;
-	struct fi_av_attr av_attr;
+	struct fi_av_attr av_attr = { 0 };
 	int i, ret, retv;
 
 	if (!attr)

--- a/prov/efa/src/efa_cm.c
+++ b/prov/efa/src/efa_cm.c
@@ -48,7 +48,7 @@ static int efa_ep_getname(fid_t ep_fid, void *addr, size_t *addrlen)
 {
 	struct efa_ep_addr *ep_addr;
 	struct efa_ep *ep;
-	char str[INET6_ADDRSTRLEN] = {};
+	char str[INET6_ADDRSTRLEN] = { 0 };
 
 	ep = container_of(ep_fid, struct efa_ep, util_ep.ep_fid);
 

--- a/prov/efa/src/efa_ep.c
+++ b/prov/efa/src/efa_ep.c
@@ -82,7 +82,7 @@ static int efa_ep_destroy_qp(struct efa_qp *qp)
 static int efa_ep_modify_qp_state(struct efa_ep *ep, struct efa_qp *qp,
 				  enum ibv_qp_state qp_state, int attr_mask)
 {
-	struct ibv_qp_attr attr = {};
+	struct ibv_qp_attr attr = { 0 };
 
 	attr.qp_state = qp_state;
 
@@ -128,7 +128,7 @@ static int efa_ep_create_qp_ex(struct efa_ep *ep,
 {
 	struct efa_domain *domain;
 	struct efa_qp *qp;
-	struct efadv_qp_init_attr efa_attr = {};
+	struct efadv_qp_init_attr efa_attr = { 0 };
 	int err;
 
 	domain = ep->domain;

--- a/prov/efa/src/efa_ep.c
+++ b/prov/efa/src/efa_ep.c
@@ -41,11 +41,10 @@
 static int efa_generate_rdm_connid()
 {
 	struct timeval tv;
-	struct timezone tz;
 	uint32_t val;
 	int err;
 
-	err = gettimeofday(&tv, &tz);
+	err = gettimeofday(&tv, NULL);
 	if (err) {
 		EFA_WARN(FI_LOG_EP_CTRL, "Cannot gettimeofday, err=%d.\n", err);
 		return 0;

--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -663,7 +663,7 @@ static int efa_get_device_attrs(struct efa_context *ctx, struct fi_info *info)
 static void efa_addr_to_str(const uint8_t *raw_addr, char *str)
 {
 	size_t name_len = strlen(EFA_FABRIC_PREFIX) + INET6_ADDRSTRLEN;
-	char straddr[INET6_ADDRSTRLEN] = {};
+	char straddr[INET6_ADDRSTRLEN] = { 0 };
 
 	if (!inet_ntop(AF_INET6, raw_addr, straddr, INET6_ADDRSTRLEN))
 		return;

--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -610,7 +610,7 @@ static int efa_get_device_attrs(struct efa_context *ctx, struct fi_info *info)
 				info->domain_attr->max_ep_rx_ctx);
 
 	info->tx_attr->iov_limit = efadv_attr.max_sq_sge;
-	info->tx_attr->size = align_down_to_power_of_2(efadv_attr.max_sq_wr);
+	info->tx_attr->size = rounddown_power_of_two(efadv_attr.max_sq_wr);
 	if (info->ep_attr->type == FI_EP_RDM) {
 		info->tx_attr->inject_size = efadv_attr.inline_buf_size;
 	} else if (info->ep_attr->type == FI_EP_DGRAM) {
@@ -625,7 +625,7 @@ static int efa_get_device_attrs(struct efa_context *ctx, struct fi_info *info)
 		info->tx_attr->inject_size = 0;
 	}
 	info->rx_attr->iov_limit = efadv_attr.max_rq_sge;
-	info->rx_attr->size = align_down_to_power_of_2(efadv_attr.max_rq_wr / info->rx_attr->iov_limit);
+	info->rx_attr->size = rounddown_power_of_two(efadv_attr.max_rq_wr / info->rx_attr->iov_limit);
 
 	EFA_DBG(FI_LOG_DOMAIN, "Tx/Rx attribute :\n"
 				"\t info->tx_attr->iov_limit		= %zu\n"

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -880,7 +880,10 @@ fi_addr_t rxr_pkt_insert_addr(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry
 
 	base_hdr = rxr_get_base_hdr(pkt_entry->pkt);
 	if (base_hdr->version < RXR_PROTOCOL_VERSION) {
-		char host_gid[ep->core_addrlen * 3];
+		/* Allocate RXR_MAX_NAME_LENGTH * 3 to allow compilation with MSVC 
+		 * We are calling abort after this, so allocating on stack is fine
+		 */
+		char host_gid[RXR_MAX_NAME_LENGTH * 3];
 		int length = 0;
 
 		for (i = 0; i < ep->core_addrlen; i++)


### PR DESCRIPTION
Following are the changes required to let efa provider compile with Microsoft Visual studio Compiler (MSVC)
- Replaced obsolete timezone parameter from gettimeofday call with NULL.
- Changed {} initialization to {0} as {} is not supported by MSVC
- Converted `align_down_to_power_of_2` macro to an inline function to avoid use of statement expressions.
- Refactored fork support initialization into its own function and calling it only if we are not on Windows.  There is no fork support on Windows.
- Hardcoded length of `host_gid` to `RXR_MAX_NAME_LENGTH` to avoid variable length array.