### PR TITLE
prov/efa: Do not claim support of 128 bit atomic ints

### DIFF
--- a/prov/efa/src/rxr/rxr_atomic.c
+++ b/prov/efa/src/rxr/rxr_atomic.c
@@ -549,6 +549,12 @@ int rxr_query_atomic(struct fid_domain *domain,
 		return -FI_EINVAL;
 	}
 
+	if ((datatype == FI_INT128) || (datatype == FI_UINT128)) {
+		FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,
+			"128-bit atomic integers not supported\n");
+		return -FI_EOPNOTSUPP;
+	}
+
 	ret = ofi_atomic_valid(&rxr_prov, datatype, op, flags);
 	if (ret || !attr)
 		return ret;


### PR DESCRIPTION
There were additional issues found with memory alignment, specifically in the
SHM provider, so cherry-pick the patch to disable 128 bit atomic support with
EFA.

Original commit message:

Due to the way memory is currently aligned when performing atomic operations,
the EFA provider was segfaulting when atomic operations were performed on 128
bit data types. This is because the compiler optimizes for instructions that
require 16 byte alignment and since we do not (currently) have that, the code
segfaulted.

Eventually we'll need to add support for these types, but for now this change
will explicitly disable support for these types in order to prevent a segfault.

Signed-off-by: Rich Welch <rlwelch@amazon.com>
Signed-off-by: Robert Wespetal <wesper@amazon.com>