### PR TITLE
core/rxm/verbs: Expand and cleanup log messages

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2016 Intel Corporation, Inc.  All rights reserved.
+ * Copyright (c) 2016-2021 Intel Corporation, Inc.  All rights reserved.
  * Copyright (c) 2019 Amazon.com, Inc. or its affiliates. All rights reserved.
  * (C) Copyright 2020 Hewlett Packard Enterprise Development LP
  *
@@ -132,6 +132,9 @@ extern size_t rxm_packet_size;
 	FI_DBG(&rxm_prov, subsystem, log_str 			\
 	       " (fi_addr: 0x%" PRIx64 " tag: 0x%" PRIx64 ")\n",\
 	       addr, tag)
+#define RXM_WARN_ERR(subsystem, log_str, err) \
+	FI_WARN(&rxm_prov, subsystem, log_str "%s (%d)\n", \
+		fi_strerror((int) -(err)), (int) err)
 
 #define RXM_GET_PROTO_STATE(context)					\
 	(*(enum rxm_proto_state *)					\

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -92,11 +92,14 @@
 
 #define VERBS_PROV_NAME "verbs"
 
-#define VERBS_DBG(subsys, ...) FI_DBG(&vrb_prov, subsys, __VA_ARGS__)
-#define VERBS_INFO(subsys, ...) FI_INFO(&vrb_prov, subsys, __VA_ARGS__)
-#define VERBS_INFO_ERRNO(subsys, fn, errno) VERBS_INFO(subsys, fn ": %s(%d)\n",	\
-		strerror(errno), errno)
-#define VERBS_WARN(subsys, ...) FI_WARN(&vrb_prov, subsys, __VA_ARGS__)
+#define VRB_DBG(subsys, ...) FI_DBG(&vrb_prov, subsys, __VA_ARGS__)
+#define VRB_INFO(subsys, ...) FI_INFO(&vrb_prov, subsys, __VA_ARGS__)
+#define VRB_WARN(subsys, ...) FI_WARN(&vrb_prov, subsys, __VA_ARGS__)
+
+#define VRB_WARN_ERRNO(subsys, fn) \
+	VRB_WARN(subsys, fn ": %s (%d)\n", strerror(errno), errno)
+#define VRB_WARN_ERR(subsys, fn, err) \
+	VRB_WARN(subsys, fn ": %s (%d)\n", fi_strerror((int) -(err)), (int) err)
 
 
 #define VERBS_INJECT_FLAGS(ep, len, flags, desc) \

--- a/prov/verbs/src/verbs_cm.c
+++ b/prov/verbs/src/verbs_cm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2015 Intel Corporation, Inc.  All rights reserved.
+ * Copyright (c) 2013-2021 Intel Corporation, Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -62,7 +62,7 @@ static int vrb_msg_ep_setname(fid_t ep_fid, void *addr, size_t addrlen)
 		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 
 	if (addrlen != ep->info_attr.src_addrlen) {
-		VERBS_INFO(FI_LOG_EP_CTRL,"addrlen expected: %zu, got: %zu.\n",
+		VRB_INFO(FI_LOG_EP_CTRL,"addrlen expected: %zu, got: %zu.\n",
 			   ep->info_attr.src_addrlen, addrlen);
 		return -FI_EINVAL;
 	}
@@ -71,7 +71,7 @@ static int vrb_msg_ep_setname(fid_t ep_fid, void *addr, size_t addrlen)
 
 	ep->info_attr.src_addr = malloc(ep->info_attr.src_addrlen);
 	if (!ep->info_attr.src_addr) {
-		VERBS_WARN(FI_LOG_EP_CTRL, "memory allocation failure\n");
+		VRB_WARN(FI_LOG_EP_CTRL, "memory allocation failure\n");
 		ret = -FI_ENOMEM;
 		goto err1;
 	}
@@ -168,8 +168,10 @@ vrb_msg_ep_connect(struct fid_ep *ep_fid, const void *addr,
 
 	if (!ep->id->qp) {
 		ret = fi_control(&ep_fid->fid, FI_ENABLE, NULL);
-		if (ret)
+		if (ret) {
+			VRB_WARN_ERR(FI_LOG_EP_CTRL, "fi_control", ret);
 			return ret;
+		}
 	}
 
 	if (ep->id->route.addr.src_addr.sa_family == AF_IB)
@@ -194,9 +196,7 @@ vrb_msg_ep_connect(struct fid_ep *ep_fid, const void *addr,
 
 	if (rdma_resolve_route(ep->id, VERBS_RESOLVE_TIMEOUT)) {
 		ret = -errno;
-		FI_WARN(&vrb_prov, FI_LOG_EP_CTRL,
-			"rdma_resolve_route failed: %s (%d)\n",
-			strerror(-ret), -ret);
+		VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "rdma_resolve_route");
 		free(ep->cm_priv_data);
 		ep->cm_priv_data = NULL;
 		return ret;
@@ -219,8 +219,10 @@ vrb_msg_ep_accept(struct fid_ep *ep, const void *param, size_t paramlen)
 
 	if (!_ep->id->qp) {
 		ret = fi_control(&ep->fid, FI_ENABLE, NULL);
-		if (ret)
+		if (ret) {
+			VRB_WARN_ERR(FI_LOG_EP_CTRL, "fi_control", ret);
 			return ret;
+		}
 	}
 
 	cm_hdr = alloca(sizeof(*cm_hdr) + paramlen);
@@ -232,8 +234,10 @@ vrb_msg_ep_accept(struct fid_ep *ep, const void *param, size_t paramlen)
 		conn_param.srq = 1;
 
 	ret = rdma_accept(_ep->id, &conn_param);
-	if (ret)
+	if (ret) {
+		VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "rdma_accept");
 		return -errno;
+	}
 
 	connreq = container_of(_ep->info_attr.handle, struct vrb_connreq, handle);
 	free(connreq);
@@ -250,14 +254,14 @@ static int vrb_msg_alloc_xrc_params(void **adjusted_param,
 	*adjusted_param = NULL;
 
 	if (cm_datalen > VRB_CM_DATA_SIZE) {
-		VERBS_WARN(FI_LOG_EP_CTRL, "XRC CM data overflow %zu\n",
+		VRB_WARN(FI_LOG_EP_CTRL, "XRC CM data overflow %zu\n",
 			   cm_datalen);
 		return -FI_EINVAL;
 	}
 
 	cm_data = malloc(cm_datalen);
 	if (!cm_data) {
-		VERBS_WARN(FI_LOG_EP_CTRL, "Unable to allocate XRC CM data\n");
+		VRB_WARN(FI_LOG_EP_CTRL, "Unable to allocate XRC CM data\n");
 		return -FI_ENOMEM;
 	}
 
@@ -317,6 +321,9 @@ vrb_msg_ep_reject(struct fid_pep *pep, fid_t handle,
 	}
 	fastlock_release(&_pep->eq->lock);
 
+	if (ret)
+		VRB_WARN_ERR(FI_LOG_EP_CTRL, "rdma_reject", ret);
+
 	free(connreq);
 	return ret;
 }
@@ -349,7 +356,7 @@ vrb_msg_xrc_cm_common_verify(struct vrb_xrc_ep *ep, size_t paramlen)
 	int ret;
 
 	if (!vrb_is_xrc_ep(&ep->base_ep)) {
-		VERBS_WARN(FI_LOG_EP_CTRL, "EP is not using XRC\n");
+		VRB_WARN(FI_LOG_EP_CTRL, "EP is not using XRC\n");
 		return -FI_EINVAL;
 	}
 
@@ -398,7 +405,7 @@ vrb_msg_xrc_ep_connect(struct fid_ep *ep, const void *addr,
 
 	xrc_ep->conn_setup = calloc(1, sizeof(*xrc_ep->conn_setup));
 	if (!xrc_ep->conn_setup) {
-		VERBS_WARN(FI_LOG_EP_CTRL,
+		VRB_WARN(FI_LOG_EP_CTRL,
 			   "Unable to allocate connection setup memory\n");
 		free(adjusted_param);
 		free(cm_hdr);
@@ -467,7 +474,7 @@ static int vrb_pep_setname(fid_t pep_fid, void *addr, size_t addrlen)
 	pep = container_of(pep_fid, struct vrb_pep, pep_fid);
 
 	if (pep->src_addrlen && (addrlen != pep->src_addrlen)) {
-		VERBS_INFO(FI_LOG_FABRIC, "addrlen expected: %zu, got: %zu.\n",
+		VRB_INFO(FI_LOG_FABRIC, "addrlen expected: %zu, got: %zu.\n",
 			   pep->src_addrlen, addrlen);
 		return -FI_EINVAL;
 	}
@@ -476,22 +483,19 @@ static int vrb_pep_setname(fid_t pep_fid, void *addr, size_t addrlen)
 	if (pep->bound) {
 		ret = rdma_destroy_id(pep->id);
 		if (ret) {
-			VERBS_INFO(FI_LOG_FABRIC,
-				   "Unable to destroy previous rdma_cm_id\n");
+			VRB_WARN_ERRNO(FI_LOG_FABRIC, "rdma_destroy_id");
 			return -errno;
 		}
 		ret = rdma_create_id(NULL, &pep->id, &pep->pep_fid.fid, RDMA_PS_TCP);
 		if (ret) {
-			VERBS_INFO(FI_LOG_FABRIC,
-				   "Unable to create rdma_cm_id\n");
+			VRB_WARN_ERRNO(FI_LOG_FABRIC, "rdma_cm_id\n");
 			return -errno;
 		}
 	}
 
 	ret = rdma_bind_addr(pep->id, (struct sockaddr *)addr);
 	if (ret) {
-		VERBS_INFO(FI_LOG_FABRIC,
-			   "Unable to bind address to rdma_cm_id\n");
+		VRB_WARN_ERRNO(FI_LOG_FABRIC, "rdma_bind_addr");
 		return -errno;
 	}
 

--- a/prov/verbs/src/verbs_cm_xrc.c
+++ b/prov/verbs/src/verbs_cm_xrc.c
@@ -54,7 +54,7 @@ void vrb_next_xrc_conn_state(struct vrb_xrc_ep *ep)
 		break;
 	default:
 		assert(0);
-		VERBS_WARN(FI_LOG_EP_CTRL, "Unkown XRC connection state %d\n",
+		VRB_WARN(FI_LOG_EP_CTRL, "Unkown XRC connection state %d\n",
 			   ep->conn_state);
 	}
 }
@@ -80,7 +80,7 @@ void vrb_prev_xrc_conn_state(struct vrb_xrc_ep *ep)
 		break;
 	default:
 		assert(0);
-		VERBS_WARN(FI_LOG_EP_CTRL, "Unkown XRC connection state %d\n",
+		VRB_WARN(FI_LOG_EP_CTRL, "Unkown XRC connection state %d\n",
 			   ep->conn_state);
 	}
 }
@@ -109,13 +109,13 @@ int vrb_verify_xrc_cm_data(struct vrb_xrc_cm_data *remote,
 			      int private_data_len)
 {
 	if (sizeof(*remote) > private_data_len) {
-		VERBS_WARN(FI_LOG_EP_CTRL,
+		VRB_WARN(FI_LOG_EP_CTRL,
 			   "XRC MSG EP CM data length mismatch\n");
 		return -FI_EINVAL;
 	}
 
 	if (remote->version != VRB_XRC_VERSION) {
-		VERBS_WARN(FI_LOG_EP_CTRL,
+		VRB_WARN(FI_LOG_EP_CTRL,
 			   "XRC MSG EP connection protocol mismatch "
 			   "(local %"PRIu8", remote %"PRIu8")\n",
 			   VRB_XRC_VERSION, remote->version);
@@ -133,8 +133,8 @@ static void vrb_log_ep_conn(struct vrb_xrc_ep *ep, char *desc)
 	if (!fi_log_enabled(&vrb_prov, FI_LOG_INFO, FI_LOG_EP_CTRL))
 		return;
 
-	VERBS_INFO(FI_LOG_EP_CTRL, "EP %p, %s\n", (void *) ep, desc);
-	VERBS_INFO(FI_LOG_EP_CTRL,
+	VRB_INFO(FI_LOG_EP_CTRL, "EP %p, %s\n", (void *) ep, desc);
+	VRB_INFO(FI_LOG_EP_CTRL,
 		  "EP %p, CM ID %p, TGT CM ID %p, SRQN %d Peer SRQN %d\n",
 		  (void*) ep, (void *) ep->base_ep.id, (void *) ep->tgt_id,
 		  ep->srqn, ep->peer_srqn);
@@ -144,24 +144,24 @@ static void vrb_log_ep_conn(struct vrb_xrc_ep *ep, char *desc)
 		addr = rdma_get_local_addr(ep->base_ep.id);
 		len = sizeof(buf);
 		ofi_straddr(buf, &len, ep->base_ep.info_attr.addr_format, addr);
-		VERBS_INFO(FI_LOG_EP_CTRL, "EP %p src_addr: %s\n",
+		VRB_INFO(FI_LOG_EP_CTRL, "EP %p src_addr: %s\n",
 			   (void *) ep, buf);
 
 		addr = rdma_get_peer_addr(ep->base_ep.id);
 		len = sizeof(buf);
 		ofi_straddr(buf, &len, ep->base_ep.info_attr.addr_format, addr);
-		VERBS_INFO(FI_LOG_EP_CTRL, "EP %p dst_addr: %s\n",
+		VRB_INFO(FI_LOG_EP_CTRL, "EP %p dst_addr: %s\n",
 			   (void *) ep, buf);
 	}
 
 	if (ep->base_ep.ibv_qp) {
-		VERBS_INFO(FI_LOG_EP_CTRL, "EP %p, INI QP Num %d\n",
+		VRB_INFO(FI_LOG_EP_CTRL, "EP %p, INI QP Num %d\n",
 			   (void *) ep, ep->base_ep.ibv_qp->qp_num);
-		VERBS_INFO(FI_LOG_EP_CTRL, "EP %p, Remote TGT QP Num %d\n",
+		VRB_INFO(FI_LOG_EP_CTRL, "EP %p, Remote TGT QP Num %d\n",
 			   (void *) ep, ep->ini_conn->tgt_qpn);
 	}
 	if (ep->tgt_ibv_qp)
-		VERBS_INFO(FI_LOG_EP_CTRL, "EP %p, TGT QP Num %d\n",
+		VRB_INFO(FI_LOG_EP_CTRL, "EP %p, TGT QP Num %d\n",
 			   (void *) ep, ep->tgt_ibv_qp->qp_num);
 }
 
@@ -213,7 +213,7 @@ int vrb_connect_xrc(struct vrb_xrc_ep *ep, struct sockaddr *addr,
 	domain->xrc.lock_acquire(&domain->xrc.ini_lock);
 	ret = vrb_get_shared_ini_conn(ep, &ep->ini_conn);
 	if (ret) {
-		VERBS_WARN(FI_LOG_EP_CTRL,
+		VRB_WARN(FI_LOG_EP_CTRL,
 			   "Get of shared XRC INI connection failed %d\n", ret);
 		if (!reciprocal) {
 			free(ep->conn_setup);
@@ -250,7 +250,7 @@ void vrb_ep_ini_conn_done(struct vrb_xrc_ep *ep, uint32_t tgt_qpn)
 		ep->ini_conn->state = VRB_INI_QP_CONNECTED;
 		ep->ini_conn->tgt_qpn = tgt_qpn;
 		ep->base_ep.id->qp = NULL;
-		VERBS_DBG(FI_LOG_EP_CTRL,
+		VRB_DBG(FI_LOG_EP_CTRL,
 			  "Set INI Conn QP %d remote TGT QP %d\n",
 			  ep->ini_conn->ini_qp->qp_num,
 			  ep->ini_conn->tgt_qpn);
@@ -362,7 +362,7 @@ int vrb_accept_xrc(struct vrb_xrc_ep *ep, int reciprocal,
 	ret = rdma_accept(ep->tgt_id, &conn_param);
 	if (OFI_UNLIKELY(ret)) {
 		ret = -errno;
-		VERBS_WARN(FI_LOG_EP_CTRL,
+		VRB_WARN(FI_LOG_EP_CTRL,
 			   "XRC TGT, rdma_accept error %d\n", ret);
 		vrb_prev_xrc_conn_state(ep);
 		return ret;
@@ -371,7 +371,7 @@ int vrb_accept_xrc(struct vrb_xrc_ep *ep, int reciprocal,
 
 	if (ep->tgt_id->ps == RDMA_PS_UDP &&
 	    vrb_eq_add_sidr_conn(ep, cm_data, paramlen))
-		VERBS_WARN(FI_LOG_EP_CTRL,
+		VRB_WARN(FI_LOG_EP_CTRL,
 			   "SIDR connection accept not added to map\n");
 
 	/* The passive side of the initial shared connection using
@@ -383,7 +383,7 @@ int vrb_accept_xrc(struct vrb_xrc_ep *ep, int reciprocal,
 					 &connect_cm_data,
 					 sizeof(connect_cm_data));
 		if (ret) {
-			VERBS_WARN(FI_LOG_EP_CTRL,
+			VRB_WARN(FI_LOG_EP_CTRL,
 				   "XRC reciprocal connect error %d\n", ret);
 			vrb_prev_xrc_conn_state(ep);
 			ep->tgt_id->qp = NULL;
@@ -404,7 +404,7 @@ int vrb_process_xrc_connreq(struct vrb_ep *ep,
 
 	xrc_ep->conn_setup = calloc(1, sizeof(*xrc_ep->conn_setup));
 	if (!xrc_ep->conn_setup) {
-		VERBS_WARN(FI_LOG_EP_CTRL,
+		VRB_WARN(FI_LOG_EP_CTRL,
 			  "Unable to allocate connection setup memory\n");
 		return -FI_ENOMEM;
 	}

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -180,7 +180,7 @@ vrb_poll_events(struct vrb_cq *_cq, int timeout)
 		rc--;
 	}
 	if (rc) {
-		VERBS_WARN(FI_LOG_CQ, "Unknown poll error: check revents\n");
+		VRB_WARN(FI_LOG_CQ, "Unknown poll error: check revents\n");
 		return -FI_EOTHER;
 	}
 
@@ -377,7 +377,7 @@ int vrb_cq_signal(struct fid_cq *cq)
 	_cq = container_of(cq, struct vrb_cq, util_cq.cq_fid);
 
 	if (write(_cq->signal_fd[1], &data, 1) != 1) {
-		VERBS_WARN(FI_LOG_CQ, "Error signalling CQ\n");
+		VRB_WARN(FI_LOG_CQ, "Error signalling CQ\n");
 		return -errno;
 	}
 
@@ -391,7 +391,7 @@ int vrb_cq_trywait(struct vrb_cq *cq)
 	int ret = -FI_EAGAIN, rc;
 
 	if (!cq->channel) {
-		VERBS_WARN(FI_LOG_CQ, "No wait object object associated with CQ\n");
+		VRB_WARN(FI_LOG_CQ, "No wait object object associated with CQ\n");
 		return -FI_EINVAL;
 	}
 
@@ -411,7 +411,7 @@ int vrb_cq_trywait(struct vrb_cq *cq)
 
 	rc = ibv_req_notify_cq(cq->cq, 0);
 	if (rc) {
-		VERBS_WARN(FI_LOG_CQ, "ibv_req_notify_cq error: %d\n", ret);
+		VRB_WARN(FI_LOG_CQ, "ibv_req_notify_cq error: %d\n", ret);
 		ret = -errno;
 		goto out;
 	}
@@ -599,7 +599,7 @@ int vrb_cq_open(struct fid_domain *domain_fid, struct fi_cq_attr *attr,
 		if (attr->signaling_vector < 0 ||
 		    attr->signaling_vector > domain->verbs->num_comp_vectors)  {
 
-			VERBS_WARN(FI_LOG_CQ,
+			VRB_WARN(FI_LOG_CQ,
 				   "Invalid value for the CQ attribute signaling_vector: %d\n",
 				   attr->signaling_vector);
 			ret = -FI_EINVAL;
@@ -612,7 +612,7 @@ int vrb_cq_open(struct fid_domain *domain_fid, struct fi_cq_attr *attr,
 		cq->channel = ibv_create_comp_channel(domain->verbs);
 		if (!cq->channel) {
 			ret = -errno;
-			VERBS_WARN(FI_LOG_CQ,
+			VRB_WARN(FI_LOG_CQ,
 				   "Unable to create completion channel\n");
 			goto err2;
 		}
@@ -646,14 +646,14 @@ int vrb_cq_open(struct fid_domain *domain_fid, struct fi_cq_attr *attr,
 			       comp_vector);
 	if (!cq->cq) {
 		ret = -errno;
-		VERBS_WARN(FI_LOG_CQ, "Unable to create verbs CQ\n");
+		VRB_WARN(FI_LOG_CQ, "Unable to create verbs CQ\n");
 		goto err4;
 	}
 
 	if (cq->channel) {
 		ret = ibv_req_notify_cq(cq->cq, 0);
 		if (ret) {
-			VERBS_WARN(FI_LOG_CQ,
+			VRB_WARN(FI_LOG_CQ,
 				   "ibv_req_notify_cq failed\n");
 			goto err5;
 		}
@@ -662,7 +662,7 @@ int vrb_cq_open(struct fid_domain *domain_fid, struct fi_cq_attr *attr,
 	ret = ofi_bufpool_create(&cq->wce_pool, sizeof(struct vrb_wc_entry),
 				16, 0, VERBS_WCE_CNT, 0);
 	if (ret) {
-		VERBS_WARN(FI_LOG_CQ, "Failed to create wce_pool\n");
+		VRB_WARN(FI_LOG_CQ, "Failed to create wce_pool\n");
 		goto err5;
 	}
 

--- a/prov/verbs/src/verbs_dgram_av.c
+++ b/prov/verbs/src/verbs_dgram_av.c
@@ -43,12 +43,12 @@ static inline int
 vrb_dgram_verify_av_flags(struct util_av *av, uint64_t flags)
 {
 	if ((av->flags & FI_EVENT) && !av->eq) {
-		VERBS_WARN(FI_LOG_AV, "No EQ bound to AV\n");
+		VRB_WARN(FI_LOG_AV, "No EQ bound to AV\n");
 		return -FI_ENOEQ;
 	}
 
 	if (flags & ~(FI_MORE)) {
-		VERBS_WARN(FI_LOG_AV, "Unsupported flags\n");
+		VRB_WARN(FI_LOG_AV, "Unsupported flags\n");
 		return -FI_ENOEQ;
 	}
 
@@ -79,21 +79,21 @@ vrb_dgram_av_insert_addr(struct vrb_dgram_av *av, const void *addr,
 		ah_attr.grh.sgid_index = vrb_gl_data.gid_idx;
 	} else if (OFI_UNLIKELY(!vrb_dgram_av_is_addr_valid(av, addr))) {
 		ret = -FI_EADDRNOTAVAIL;
-		VERBS_WARN(FI_LOG_AV, "Invalid address\n");
+		VRB_WARN(FI_LOG_AV, "Invalid address\n");
 		goto fn1;
 	}
 
 	av_entry = calloc(1, sizeof(*av_entry));
 	if (OFI_UNLIKELY(!av_entry)) {
 		ret = -FI_ENOMEM;
-		VERBS_WARN(FI_LOG_AV, "Unable to allocate memory for AV entry\n");
+		VRB_WARN(FI_LOG_AV, "Unable to allocate memory for AV entry\n");
 		goto fn1;
 	}
 
 	av_entry->ah = ibv_create_ah(domain->pd, &ah_attr);
 	if (OFI_UNLIKELY(!av_entry->ah)) {
 		ret = -errno;
-		VERBS_WARN(FI_LOG_AV,
+		VRB_WARN(FI_LOG_AV,
 			   "Unable to create Address Handle, errno - %d\n", errno);
 		goto fn2;
 	}
@@ -124,7 +124,7 @@ static int vrb_dgram_av_insert(struct fid_av *av_fid, const void *addr,
 	if (ret)
 		return ret;
 
-	VERBS_DBG(FI_LOG_AV, "Inserting %"PRIu64" addresses\n", count);
+	VRB_DBG(FI_LOG_AV, "Inserting %"PRIu64" addresses\n", count);
 	for (i = 0; i < count; i++) {
 		ret = vrb_dgram_av_insert_addr(
 				av, (struct ofi_ib_ud_ep_name *)addr + i,
@@ -133,7 +133,7 @@ static int vrb_dgram_av_insert(struct fid_av *av_fid, const void *addr,
 			success_cnt++;
 	}
 
-	VERBS_DBG(FI_LOG_AV,
+	VRB_DBG(FI_LOG_AV,
 		  "%d addresses were inserted successfully\n", success_cnt);
 	return success_cnt;
 }
@@ -143,7 +143,7 @@ vrb_dgram_av_remove_addr(struct vrb_dgram_av_entry *av_entry)
 {
 	int ret = ibv_destroy_ah(av_entry->ah);
 	if (ret)
-		VERBS_WARN(FI_LOG_AV,
+		VRB_WARN(FI_LOG_AV,
 			   "AH Destroying failed with status - %d\n",
 			   ret);
 	dlist_remove(&av_entry->list_entry);

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -224,7 +224,7 @@ static int vrb_open_device_by_name(struct vrb_domain *domain, const char *name)
 				      strlen(name) - strlen(verbs_dgram_domain.suffix));
 			break;
 		default:
-			VERBS_WARN(FI_LOG_DOMAIN,
+			VRB_WARN(FI_LOG_DOMAIN,
 				   "Unsupported EP type - %d\n", domain->ep_type);
 			/* Never should go here */
 			assert(0);
@@ -338,13 +338,13 @@ vrb_domain(struct fid_fabric *fabric, struct fi_info *info,
 	ret = ofi_mr_cache_init(&_domain->util_domain, memory_monitors,
 				&_domain->cache);
 	if (ret) {
-		VERBS_INFO(FI_LOG_MR,
+		VRB_INFO(FI_LOG_MR,
 			   "MR cache init failed: %s. MR caching disabled.\n",
 			   fi_strerror(-ret));
 	} else {
 		for (iface = 0; iface < OFI_HMEM_MAX; iface++) {
 			if (_domain->cache.monitors[iface])
-				VERBS_INFO(FI_LOG_MR,
+				VRB_INFO(FI_LOG_MR,
 					   "MR cache enabled for %s memory\n",
 					   fi_tostr(&iface, FI_TYPE_HMEM_IFACE));
 		}
@@ -378,7 +378,7 @@ vrb_domain(struct fid_fabric *fabric, struct fi_info *info,
 		_domain->util_domain.domain_fid.ops = &vrb_msg_domain_ops;
 		break;
 	default:
-		VERBS_INFO(FI_LOG_DOMAIN, "Ivalid EP type is provided, "
+		VRB_INFO(FI_LOG_DOMAIN, "Ivalid EP type is provided, "
 			   "EP type :%d\n", _domain->ep_type);
 		ret = -FI_EINVAL;
 		goto err4;
@@ -389,14 +389,12 @@ vrb_domain(struct fid_fabric *fabric, struct fi_info *info,
 err4:
 	ofi_mr_cache_cleanup(&_domain->cache);
 	if (ibv_dealloc_pd(_domain->pd))
-		VERBS_INFO_ERRNO(FI_LOG_DOMAIN,
-				 "ibv_dealloc_pd", errno);
+		VRB_WARN_ERRNO(FI_LOG_DOMAIN, "ibv_dealloc_pd");
 err3:
 	fi_freeinfo(_domain->info);
 err2:
 	if (ofi_domain_close(&_domain->util_domain))
-		VERBS_INFO(FI_LOG_DOMAIN,
-			   "ofi_domain_close fails");
+		VRB_WARN(FI_LOG_DOMAIN, "ofi_domain_close fails");
 err1:
 	free(_domain);
 	return ret;

--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -63,7 +63,7 @@ static int vrb_create_ini_qp(struct vrb_xrc_ep *ep)
 	ret = rdma_create_qp_ex(ep->base_ep.id, &attr_ex);
 	if (ret) {
 		ret = -errno;
-		VERBS_WARN(FI_LOG_EP_CTRL,
+		VRB_WARN(FI_LOG_EP_CTRL,
 			   "XRC INI QP rdma_create_qp_ex failed %d\n", -ret);
 		return ret;
 	}
@@ -101,7 +101,7 @@ int vrb_get_shared_ini_conn(struct vrb_xrc_ep *ep,
 	*ini_conn = NULL;
 	conn = calloc(1, sizeof(*conn));
 	if (!conn) {
-		VERBS_WARN(FI_LOG_EP_CTRL,
+		VRB_WARN(FI_LOG_EP_CTRL,
 			   "Unable to allocate INI connection memory\n");
 		return -FI_ENOMEM;
 	}
@@ -109,7 +109,7 @@ int vrb_get_shared_ini_conn(struct vrb_xrc_ep *ep,
 	conn->tgt_qpn = VRB_NO_INI_TGT_QPNUM;
 	conn->peer_addr = mem_dup(key.addr, ofi_sizeofaddr(key.addr));
 	if (!conn->peer_addr) {
-		VERBS_WARN(FI_LOG_EP_CTRL,
+		VRB_WARN(FI_LOG_EP_CTRL,
 			   "mem_dup of peer address failed\n");
 		free(conn);
 		return -FI_ENOMEM;
@@ -124,7 +124,7 @@ int vrb_get_shared_ini_conn(struct vrb_xrc_ep *ep,
 			       (void *) &key, (void *) conn, NULL);
 	assert(ret != -FI_EALREADY);
 	if (ret) {
-		VERBS_WARN(FI_LOG_EP_CTRL, "INI QP RBTree insert failed %d\n",
+		VRB_WARN(FI_LOG_EP_CTRL, "INI QP RBTree insert failed %d\n",
 			   ret);
 		goto insert_err;
 	}
@@ -168,7 +168,7 @@ void _vrb_put_shared_ini_conn(struct vrb_xrc_ep *ep)
 	/* Tear down physical INI/TGT when no longer being used */
 	if (!ofi_atomic_dec32(&ini_conn->ref_cnt)) {
 		if (ini_conn->ini_qp && ibv_destroy_qp(ini_conn->ini_qp))
-			VERBS_WARN(FI_LOG_EP_CTRL,
+			VRB_WARN(FI_LOG_EP_CTRL,
 				   "Destroy of XRC physical INI QP failed %d\n",
 				   errno);
 
@@ -245,7 +245,7 @@ void vrb_sched_ini_conn(struct vrb_ini_shared_conn *ini_conn)
 				       RDMA_PS_TCP : RDMA_PS_UDP,
 				       &ep->base_ep.id);
 		if (ret) {
-			VERBS_WARN(FI_LOG_EP_CTRL,
+			VRB_WARN(FI_LOG_EP_CTRL,
 				   "Failed to create active CM ID %d\n",
 				   ret);
 			goto err;
@@ -256,12 +256,12 @@ void vrb_sched_ini_conn(struct vrb_ini_shared_conn *ini_conn)
 
 			if (ep->ini_conn->ini_qp &&
 			    ibv_destroy_qp(ep->ini_conn->ini_qp)) {
-				VERBS_WARN(FI_LOG_EP_CTRL, "Failed to destroy "
+				VRB_WARN(FI_LOG_EP_CTRL, "Failed to destroy "
 					   "physical INI QP %d\n", errno);
 			}
 			ret = vrb_create_ini_qp(ep);
 			if (ret) {
-				VERBS_WARN(FI_LOG_EP_CTRL, "Failed to create "
+				VRB_WARN(FI_LOG_EP_CTRL, "Failed to create "
 					   "physical INI QP %d\n", ret);
 				goto err;
 			}
@@ -270,7 +270,7 @@ void vrb_sched_ini_conn(struct vrb_ini_shared_conn *ini_conn)
 			ep->ini_conn->phys_conn_id = ep->base_ep.id;
 		} else {
 			assert(!ep->base_ep.id->qp);
-			VERBS_DBG(FI_LOG_EP_CTRL, "Sharing XRC INI QPN %d\n",
+			VRB_DBG(FI_LOG_EP_CTRL, "Sharing XRC INI QPN %d\n",
 				  ep->ini_conn->ini_qp->qp_num);
 		}
 
@@ -279,7 +279,7 @@ void vrb_sched_ini_conn(struct vrb_ini_shared_conn *ini_conn)
 		ret = rdma_migrate_id(ep->base_ep.id,
 				      ep->base_ep.eq->channel);
 		if (ret) {
-			VERBS_WARN(FI_LOG_EP_CTRL,
+			VRB_WARN(FI_LOG_EP_CTRL,
 				   "Failed to migrate active CM ID %d\n", ret);
 			goto err;
 		}
@@ -341,7 +341,7 @@ int vrb_process_ini_conn(struct vrb_xrc_ep *ep,int reciprocal,
 	ret = rdma_resolve_route(ep->base_ep.id, VERBS_RESOLVE_TIMEOUT);
 	if (ret) {
 		ret = -errno;
-		VERBS_WARN(FI_LOG_EP_CTRL,
+		VRB_WARN(FI_LOG_EP_CTRL,
 			   "rdma_resolve_route failed %s (%d)\n",
 			   strerror(-ret), -ret);
 		vrb_prev_xrc_conn_state(ep);
@@ -375,7 +375,7 @@ int vrb_ep_create_tgt_qp(struct vrb_xrc_ep *ep, uint32_t tgt_qpn)
 		ep->tgt_ibv_qp = ibv_open_qp(domain->verbs, &open_attr);
 		if (!ep->tgt_ibv_qp) {
 			ret = -errno;
-			VERBS_WARN(FI_LOG_EP_CTRL,
+			VRB_WARN(FI_LOG_EP_CTRL,
 				   "XRC TGT QP ibv_open_qp failed %d\n", -ret);
 			return ret;
 		}
@@ -393,7 +393,7 @@ int vrb_ep_create_tgt_qp(struct vrb_xrc_ep *ep, uint32_t tgt_qpn)
 	attr_ex.xrcd = domain->xrc.xrcd;
 	if (rdma_create_qp_ex(ep->tgt_id, &attr_ex)) {
 		ret = -errno;
-		VERBS_WARN(FI_LOG_EP_CTRL,
+		VRB_WARN(FI_LOG_EP_CTRL,
 			   "Physical XRC TGT QP rdma_create_qp_ex failed %d\n",
 			   -ret);
 		return ret;
@@ -418,7 +418,7 @@ static int vrb_put_tgt_qp(struct vrb_xrc_ep *ep)
 	ret = ibv_destroy_qp(ep->tgt_ibv_qp);
 	if (ret) {
 		ret = -errno;
-		VERBS_WARN(FI_LOG_EP_CTRL,
+		VRB_WARN(FI_LOG_EP_CTRL,
 			   "Close XRC TGT QP ibv_destroy_qp failed %d\n",
 			   -ret);
 		return ret;
@@ -471,7 +471,7 @@ static int vrb_ini_conn_compare(struct ofi_rbmap *map, void *key, void *data)
 			     sizeof(ofi_sin6_addr(_key->addr)));
 		break;
 	default:
-		VERBS_WARN(FI_LOG_FABRIC, "Unsupported address format\n");
+		VRB_WARN(FI_LOG_FABRIC, "Unsupported address format\n");
 		assert(0);
 		return -FI_EINVAL;
 	}
@@ -490,7 +490,7 @@ static int vrb_domain_xrc_validate_hw(struct vrb_domain *domain)
 
 	ret = ibv_query_device(domain->verbs, &attr);
 	if (ret || !(attr.device_cap_flags & IBV_DEVICE_XRC)) {
-		VERBS_INFO(FI_LOG_DOMAIN, "XRC is not supported");
+		VRB_INFO(FI_LOG_DOMAIN, "XRC is not supported");
 		return -FI_EINVAL;
 	}
 	return FI_SUCCESS;
@@ -511,7 +511,7 @@ int vrb_domain_xrc_init(struct vrb_domain *domain)
 		domain->xrc.xrcd_fd = open(vrb_gl_data.msg.xrcd_filename,
 				       O_CREAT, S_IWUSR | S_IRUSR);
 		if (domain->xrc.xrcd_fd < 0) {
-			VERBS_WARN(FI_LOG_DOMAIN,
+			VRB_WARN(FI_LOG_DOMAIN,
 				   "XRCD file open failed %d\n", errno);
 			return -errno;
 		}
@@ -523,14 +523,13 @@ int vrb_domain_xrc_init(struct vrb_domain *domain)
 	domain->xrc.xrcd = ibv_open_xrcd(domain->verbs, &attr);
 	if (!domain->xrc.xrcd) {
 		ret = -errno;
-		VERBS_INFO_ERRNO(FI_LOG_DOMAIN, "ibv_open_xrcd", errno);
+		VRB_WARN_ERRNO(FI_LOG_DOMAIN, "ibv_open_xrcd");
 		goto xrcd_err;
 	}
 
 	domain->xrc.ini_conn_rbmap = ofi_rbmap_create(vrb_ini_conn_compare);
 	if (!domain->xrc.ini_conn_rbmap) {
 		ret = -ENOMEM;
-		VERBS_INFO_ERRNO(FI_LOG_DOMAIN, "XRC INI QP RB Tree", -ret);
 		goto rbmap_err;
 	}
 
@@ -566,13 +565,13 @@ int vrb_domain_xrc_cleanup(struct vrb_domain *domain)
 	assert(domain->xrc.xrcd);
 	/* All endpoint and hence XRC INI QP should be closed */
 	if (!ofi_rbmap_empty(domain->xrc.ini_conn_rbmap)) {
-		VERBS_WARN(FI_LOG_DOMAIN, "XRC domain busy\n");
+		VRB_WARN(FI_LOG_DOMAIN, "XRC domain busy\n");
 		return -FI_EBUSY;
 	}
 
 	ret = ibv_close_xrcd(domain->xrc.xrcd);
 	if (ret) {
-		VERBS_WARN(FI_LOG_DOMAIN, "ibv_close_xrcd failed %d\n", ret);
+		VRB_WARN(FI_LOG_DOMAIN, "ibv_close_xrcd failed %d\n", ret);
 		return -ret;
 	}
 	if (domain->xrc.xrcd_fd >= 0) {

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -101,7 +101,7 @@ void vrb_eq_clear_xrc_conn_tag(struct vrb_xrc_ep *ep)
 	index = ofi_key2idx(&eq->xrc.conn_key_idx,
 			    (uint64_t)ep->conn_setup->conn_tag);
 	if (!ofi_idx_is_valid(eq->xrc.conn_key_map, index))
-	    VERBS_WARN(FI_LOG_EP_CTRL,
+	    VRB_WARN(FI_LOG_EP_CTRL,
 		       "Invalid XRC connection connection tag\n");
 	else
 		ofi_idx_remove(eq->xrc.conn_key_map, index);
@@ -118,16 +118,16 @@ struct vrb_xrc_ep *vrb_eq_xrc_conn_tag2ep(struct vrb_eq *eq,
 	index = ofi_key2idx(&eq->xrc.conn_key_idx, (uint64_t)conn_tag);
 	ep = ofi_idx_lookup(eq->xrc.conn_key_map, index);
 	if (!ep || ep->magic != VERBS_XRC_EP_MAGIC) {
-		VERBS_WARN(FI_LOG_EP_CTRL, "XRC EP is not valid\n");
+		VRB_WARN(FI_LOG_EP_CTRL, "XRC EP is not valid\n");
 		return NULL;
 	}
 	if (!ep->conn_setup) {
-		VERBS_WARN(FI_LOG_EP_CTRL,
+		VRB_WARN(FI_LOG_EP_CTRL,
 			   "Bad state, no connection data\n");
 		return NULL;
 	}
 	if (ep->conn_setup->conn_tag != conn_tag) {
-		VERBS_WARN(FI_LOG_EP_CTRL, "Connection tag mismatch\n");
+		VRB_WARN(FI_LOG_EP_CTRL, "Connection tag mismatch\n");
 		return NULL;
 	}
 
@@ -185,7 +185,7 @@ vrb_eq_cm_getinfo(struct rdma_cm_event *event, struct fi_info *pep_info,
 	int ret = -FI_ENOMEM;
 
 	if (!(hints = fi_dupinfo(pep_info))) {
-		VERBS_WARN(FI_LOG_EP_CTRL, "dupinfo failure\n");
+		VRB_WARN(FI_LOG_EP_CTRL, "dupinfo failure\n");
 		return -FI_ENOMEM;
 	}
 
@@ -200,7 +200,7 @@ vrb_eq_cm_getinfo(struct rdma_cm_event *event, struct fi_info *pep_info,
 			goto err1;
 	} else {
 		if (vrb_pep_dev_domain_match(hints, devname)) {
-			VERBS_WARN(FI_LOG_EQ, "passive endpoint domain: %s does"
+			VRB_WARN(FI_LOG_EQ, "passive endpoint domain: %s does"
 				   " not match device: %s where we got a "
 				   "connection request\n",
 				   hints->domain_attr->name, devname);
@@ -243,7 +243,7 @@ vrb_eq_cm_getinfo(struct rdma_cm_event *event, struct fi_info *pep_info,
 
 	connreq = calloc(1, sizeof *connreq);
 	if (!connreq) {
-		VERBS_WARN(FI_LOG_EP_CTRL,
+		VRB_WARN(FI_LOG_EP_CTRL,
 			   "Unable to allocate connreq memory\n");
 		goto err2;
 	}
@@ -339,7 +339,7 @@ static int vrb_sidr_conn_compare(struct ofi_rbmap *map,
 			     sizeof(ofi_sin6_addr(_key->addr)));
 		break;
 	default:
-		VERBS_WARN(FI_LOG_EP_CTRL, "Unsuuported address format\n");
+		VRB_WARN(FI_LOG_EP_CTRL, "Unsuuported address format\n");
 		assert(0);
 		ret = -FI_EINVAL;
 	}
@@ -385,7 +385,7 @@ int vrb_eq_add_sidr_conn(struct vrb_xrc_ep *ep,
 				 ep->remote_pep_port, ep->recip_accept, &key);
 	ep->accept_param_data = calloc(1, param_len);
 	if (!ep->accept_param_data) {
-		VERBS_WARN(FI_LOG_EP_CTRL,
+		VRB_WARN(FI_LOG_EP_CTRL,
 			   "SIDR alloc conn param memory failure\n");
 		return -FI_ENOMEM;
 	}
@@ -396,7 +396,7 @@ int vrb_eq_add_sidr_conn(struct vrb_xrc_ep *ep,
 			       &key, (void *) ep, &ep->conn_map_node);
 	assert(ret != -FI_EALREADY);
 	if (OFI_UNLIKELY(ret)) {
-		VERBS_WARN(FI_LOG_EP_CTRL,
+		VRB_WARN(FI_LOG_EP_CTRL,
 			   "SIDR conn map entry insert error %d\n", ret);
 		free(ep->accept_param_data);
 		ep->accept_param_data = NULL;
@@ -432,7 +432,7 @@ vrb_eq_accept_recip_conn(struct vrb_xrc_ep *ep,
 	ret = vrb_accept_xrc(ep, VRB_RECIP_CONN, &cm_data,
 				sizeof(cm_data));
 	if (ret) {
-		VERBS_WARN(FI_LOG_EP_CTRL,
+		VRB_WARN(FI_LOG_EP_CTRL,
 			   "Reciprocal XRC Accept failed %d\n", ret);
 		return ret;
 	}
@@ -481,14 +481,14 @@ vrb_eq_xrc_connreq_event(struct vrb_eq *eq, struct fi_eq_cm_entry *entry,
 					     connreq->xrc.port,
 					     connreq->xrc.is_reciprocal);
 		if (ep) {
-			VERBS_DBG(FI_LOG_EP_CTRL,
+			VRB_DBG(FI_LOG_EP_CTRL,
 				  "SIDR %s request retry received\n",
 				  connreq->xrc.is_reciprocal ?
 				  "reciprocal" : "original");
 			ret = vrb_resend_shared_accept_xrc(ep, connreq,
 							      cma_event->id);
 			if (ret)
-				VERBS_WARN(FI_LOG_EP_CTRL,
+				VRB_WARN(FI_LOG_EP_CTRL,
 					   "SIDR accept resend failure %d\n",
 					   -errno);
 			rdma_destroy_id(cma_event->id);
@@ -508,7 +508,7 @@ vrb_eq_xrc_connreq_event(struct vrb_eq *eq, struct fi_eq_cm_entry *entry,
 	 */
 	ep = vrb_eq_xrc_conn_tag2ep(eq, connreq->xrc.conn_tag);
 	if (!ep) {
-		VERBS_WARN(FI_LOG_EP_CTRL,
+		VRB_WARN(FI_LOG_EP_CTRL,
 			   "Reciprocal XRC connection tag 0x%x not found\n",
 			   connreq->xrc.conn_tag);
 		return -FI_EAGAIN;
@@ -524,7 +524,7 @@ vrb_eq_xrc_connreq_event(struct vrb_eq *eq, struct fi_eq_cm_entry *entry,
 
 	ret = rdma_migrate_id(ep->tgt_id, ep->base_ep.eq->channel);
 	if (ret) {
-		VERBS_WARN(FI_LOG_EP_CTRL, "Could not migrate CM ID\n");
+		VRB_WARN(FI_LOG_EP_CTRL, "Could not migrate CM ID\n");
 		goto send_reject;
 	}
 
@@ -538,7 +538,7 @@ vrb_eq_xrc_connreq_event(struct vrb_eq *eq, struct fi_eq_cm_entry *entry,
 
 send_reject:
 	if (rdma_reject(connreq->id, *priv_data, *priv_datalen))
-		VERBS_WARN(FI_LOG_EP_CTRL, "rdma_reject %d\n", -errno);
+		VRB_WARN(FI_LOG_EP_CTRL, "rdma_reject %d\n", -errno);
 
 	return -FI_EAGAIN;
 }
@@ -565,7 +565,7 @@ vrb_eq_xrc_conn_event(struct vrb_xrc_ep *ep,
 	size_t priv_datalen = cma_event->param.conn.private_data_len;
 	int ret;
 
-	VERBS_DBG(FI_LOG_EP_CTRL, "EP %p INITIAL CONNECTION DONE state %d, ps %d\n",
+	VRB_DBG(FI_LOG_EP_CTRL, "EP %p INITIAL CONNECTION DONE state %d, ps %d\n",
 		  ep, ep->conn_state, cma_event->id->ps);
 	vrb_next_xrc_conn_state(ep);
 
@@ -621,14 +621,14 @@ vrb_eq_xrc_recip_conn_event(struct vrb_eq *eq,
 	int ret;
 
 	vrb_next_xrc_conn_state(ep);
-	VERBS_DBG(FI_LOG_EP_CTRL, "EP %p RECIPROCAL CONNECTION DONE state %d\n",
+	VRB_DBG(FI_LOG_EP_CTRL, "EP %p RECIPROCAL CONNECTION DONE state %d\n",
 		  ep, ep->conn_state);
 
 	/* If this is the reciprocal active side notification */
 	if (cma_event->param.conn.private_data) {
 		ret = vrb_eq_set_xrc_info(cma_event, &xrc_info);
 		if (ret) {
-			VERBS_WARN(FI_LOG_EP_CTRL,
+			VRB_WARN(FI_LOG_EP_CTRL,
 				   "Reciprocal connection protocol mismatch\n");
 			eq->err.err = -ret;
 			eq->err.prov_errno = ret;
@@ -665,7 +665,7 @@ vrb_eq_xrc_rej_event(struct vrb_eq *eq, struct rdma_cm_event *cma_event)
 	assert(fastlock_held(&eq->lock));
 	ep = container_of(fid, struct vrb_xrc_ep, base_ep.util_ep.ep_fid);
 	if (ep->magic != VERBS_XRC_EP_MAGIC) {
-		VERBS_WARN(FI_LOG_EP_CTRL,
+		VRB_WARN(FI_LOG_EP_CTRL,
 			   "CM ID context not valid\n");
 		return -FI_EAGAIN;
 	}
@@ -674,7 +674,7 @@ vrb_eq_xrc_rej_event(struct vrb_eq *eq, struct rdma_cm_event *cma_event)
 	if (ep->base_ep.id != cma_event->id ||
 	    (state != VRB_XRC_ORIG_CONNECTING &&
 	     state != VRB_XRC_RECIP_CONNECTING)) {
-		VERBS_WARN(FI_LOG_EP_CTRL,
+		VRB_WARN(FI_LOG_EP_CTRL,
 			   "Stale/invalid CM reject %d received\n", cma_event->status);
 		return -FI_EAGAIN;
 	}
@@ -684,7 +684,7 @@ vrb_eq_xrc_rej_event(struct vrb_eq *eq, struct rdma_cm_event *cma_event)
 	    cma_event->status == VRB_CM_REJ_SIDR_CONSUMER_DEFINED) {
 		if (cma_event->param.conn.private_data_len &&
 		    vrb_eq_set_xrc_info(cma_event, &xrc_info)) {
-			VERBS_WARN(FI_LOG_EP_CTRL,
+			VRB_WARN(FI_LOG_EP_CTRL,
 				   "CM REJ private data not valid\n");
 			return -FI_EAGAIN;
 		}
@@ -693,10 +693,10 @@ vrb_eq_xrc_rej_event(struct vrb_eq *eq, struct rdma_cm_event *cma_event)
 		return FI_SUCCESS;
 	}
 
-	VERBS_WARN(FI_LOG_EP_CTRL, "Non-application generated CM Reject %d\n",
+	VRB_WARN(FI_LOG_EP_CTRL, "Non-application generated CM Reject %d\n",
 		   cma_event->status);
 	if (cma_event->param.conn.private_data_len)
-		VERBS_WARN(FI_LOG_EP_CTRL, "Unexpected CM Reject priv_data\n");
+		VRB_WARN(FI_LOG_EP_CTRL, "Unexpected CM Reject priv_data\n");
 
 	vrb_ep_ini_conn_rejected(ep);
 
@@ -740,7 +740,7 @@ vrb_eq_xrc_cm_err_event(struct vrb_eq *eq,
 	assert(fastlock_held(&eq->lock));
 	ep = container_of(fid, struct vrb_xrc_ep, base_ep.util_ep.ep_fid);
 	if (ep->magic != VERBS_XRC_EP_MAGIC) {
-		VERBS_WARN(FI_LOG_EP_CTRL, "CM ID context invalid\n");
+		VRB_WARN(FI_LOG_EP_CTRL, "CM ID context invalid\n");
 		return -FI_EAGAIN;
 	}
 
@@ -749,7 +749,7 @@ vrb_eq_xrc_cm_err_event(struct vrb_eq *eq,
 	if ((ep->base_ep.id != cma_event->id) &&
 	    (cma_event->event == RDMA_CM_EVENT_CONNECT_ERROR &&
 	     ep->tgt_id != cma_event->id)) {
-		VERBS_WARN(FI_LOG_EP_CTRL, "CM error not valid for EP\n");
+		VRB_WARN(FI_LOG_EP_CTRL, "CM error not valid for EP\n");
 		return -FI_EAGAIN;
 	}
 
@@ -765,7 +765,7 @@ vrb_eq_xrc_cm_err_event(struct vrb_eq *eq,
 		}
 	}
 
-	VERBS_WARN(FI_LOG_EP_CTRL, "CM error event %s, status %d\n",
+	VRB_WARN(FI_LOG_EP_CTRL, "CM error event %s, status %d\n",
 		   rdma_event_str(cma_event->event), cma_event->status);
 	if (ep->base_ep.info_attr.src_addr)
 		ofi_straddr_log(&vrb_prov, FI_LOG_WARN, FI_LOG_EP_CTRL,
@@ -891,7 +891,7 @@ vrb_eq_cm_process_event(struct vrb_eq *eq,
 
 		ret = vrb_eq_cm_getinfo(cma_event, pep->info, &entry->info);
 		if (ret) {
-			VERBS_WARN(FI_LOG_EP_CTRL,
+			VRB_WARN(FI_LOG_EP_CTRL,
 				   "CM getinfo error %d\n", ret);
 			rdma_destroy_id(cma_event->id);
 			eq->err.err = -ret;
@@ -1009,7 +1009,7 @@ xrc_shared_reject:
 		eq->err.err = EADDRNOTAVAIL;
 		goto err;
 	default:
-		VERBS_WARN(FI_LOG_EP_CTRL, "unknown rdmacm event received: %d\n",
+		VRB_WARN(FI_LOG_EP_CTRL, "unknown rdmacm event received: %d\n",
 			   cma_event->event);
 		ret = -FI_EAGAIN;
 		goto ack;
@@ -1293,7 +1293,7 @@ static int vrb_eq_close(fid_t fid)
 	/* TODO: use util code, if possible, and add ref counting */
 
 	if (!ofi_rbmap_empty(&eq->xrc.sidr_conn_rbmap))
-		VERBS_WARN(FI_LOG_EP_CTRL, "SIDR connection RBmap not empty\n");
+		VRB_WARN(FI_LOG_EP_CTRL, "SIDR connection RBmap not empty\n");
 
 	free(eq->err.err_data);
 
@@ -1352,7 +1352,7 @@ int vrb_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 	fastlock_init(&_eq->lock);
 	ret = dlistfd_head_init(&_eq->list_head);
 	if (ret) {
-		VERBS_INFO(FI_LOG_EQ, "Unable to initialize dlistfd\n");
+		VRB_INFO(FI_LOG_EQ, "Unable to initialize dlistfd\n");
 		goto err1;
 	}
 

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -65,7 +65,7 @@
 		OFI_ORDER_WAW_SET | FI_ORDER_WAS | FI_ORDER_SAW | FI_ORDER_SAS )
 
 #define VERBS_INFO_NODE_2_UD_ADDR(sybsys, node, svc, ib_ud_addr)			\
-	VERBS_INFO(sybsys, "'%s:%u' resolved to <gid <interface_id=%"PRIu64		\
+	VRB_INFO(sybsys, "'%s:%u' resolved to <gid <interface_id=%"PRIu64		\
 			   ", subnet_prefix=%"PRIu64">, lid=%d, service = %u>\n",	\
 		   node, svc, be64toh((ib_ud_addr)->gid.global.interface_id),		\
 		   be64toh((ib_ud_addr)->gid.global.subnet_prefix),			\
@@ -183,7 +183,7 @@ int vrb_check_ep_attr(const struct fi_info *hints,
 	case FI_PROTO_IB_UD:
 		break;
 	default:
-		VERBS_INFO(FI_LOG_CORE,
+		VRB_INFO(FI_LOG_CORE,
 			   "Unsupported protocol\n");
 		return -FI_ENODATA;
 	}
@@ -237,7 +237,7 @@ static int vrb_check_hints(uint32_t version, const struct fi_info *hints,
 	uint64_t prov_mode;
 
 	if (hints->caps & ~(info->caps)) {
-		VERBS_INFO(FI_LOG_CORE, "Unsupported capabilities\n");
+		VRB_INFO(FI_LOG_CORE, "Unsupported capabilities\n");
 		OFI_INFO_CHECK(&vrb_prov, info, hints, caps, FI_TYPE_CAPS);
 		return -FI_ENODATA;
 	}
@@ -245,7 +245,7 @@ static int vrb_check_hints(uint32_t version, const struct fi_info *hints,
 	prov_mode = ofi_mr_get_prov_mode(version, hints, info);
 
 	if ((hints->mode & prov_mode) != prov_mode) {
-		VERBS_INFO(FI_LOG_CORE, "needed mode not set\n");
+		VRB_INFO(FI_LOG_CORE, "needed mode not set\n");
 		OFI_INFO_MODE(&vrb_prov, prov_mode, hints->mode);
 		return -FI_ENODATA;
 	}
@@ -260,7 +260,7 @@ static int vrb_check_hints(uint32_t version, const struct fi_info *hints,
 	if (hints->domain_attr) {
 		if (hints->domain_attr->name &&
 		    strcasecmp(hints->domain_attr->name, info->domain_attr->name)) {
-			VERBS_INFO(FI_LOG_CORE, "skipping device %s (want %s)\n",
+			VRB_INFO(FI_LOG_CORE, "skipping device %s (want %s)\n",
 				   info->domain_attr->name, hints->domain_attr->name);
 			return -FI_ENODATA;
 		}
@@ -334,7 +334,7 @@ int vrb_set_rai(uint32_t addr_format, void *src_addr, size_t src_addrlen,
 		}
 		break;
 	default:
-		VERBS_INFO(FI_LOG_FABRIC, "Unknown addr_format\n");
+		VRB_INFO(FI_LOG_FABRIC, "Unknown addr_format\n");
 	}
 
 	if (src_addrlen) {
@@ -400,7 +400,7 @@ static int vrb_rai_to_fi(struct rdma_addrinfo *rai, struct fi_info *fi)
 
 	fi->addr_format = ofi_translate_addr_format(rai->ai_family);
 	if (fi->addr_format == FI_FORMAT_UNSPEC) {
-		VERBS_WARN(FI_LOG_FABRIC, "Unknown address format\n");
+		VRB_WARN(FI_LOG_FABRIC, "Unknown address format\n");
 		return -FI_EINVAL;
 	}
 
@@ -434,13 +434,13 @@ static inline int vrb_get_qp_cap(struct ibv_context *ctx,
 
 	pd = ibv_alloc_pd(ctx);
 	if (!pd) {
-		VERBS_INFO_ERRNO(FI_LOG_FABRIC, "ibv_alloc_pd", errno);
+		VRB_WARN_ERRNO(FI_LOG_FABRIC, "ibv_alloc_pd");
 		return -errno;
 	}
 
 	cq = ibv_create_cq(ctx, 1, NULL, NULL, 0);
 	if (!cq) {
-		VERBS_INFO_ERRNO(FI_LOG_FABRIC, "ibv_create_cq", errno);
+		VRB_WARN_ERRNO(FI_LOG_FABRIC, "ibv_create_cq");
 		ret = -errno;
 		goto err1;
 	}
@@ -476,7 +476,7 @@ static inline int vrb_get_qp_cap(struct ibv_context *ctx,
 
 	qp = ibv_create_qp(pd, &init_attr);
 	if (!qp) {
-		VERBS_INFO_ERRNO(FI_LOG_FABRIC, "ibv_create_qp", errno);
+		VRB_WARN_ERRNO(FI_LOG_FABRIC, "ibv_create_qp");
 		ret = -errno;
 		goto err2;
 	}
@@ -551,8 +551,7 @@ static int vrb_get_device_attrs(struct ibv_context *ctx,
 
 	ret = ibv_query_device(ctx, &device_attr);
 	if (ret) {
-		VERBS_INFO_ERRNO(FI_LOG_FABRIC,
-				 "ibv_query_device", errno);
+		VRB_WARN_ERRNO(FI_LOG_FABRIC, "ibv_query_device");
 		return -errno;
 	}
 
@@ -601,8 +600,7 @@ static int vrb_get_device_attrs(struct ibv_context *ctx,
 	for (port_num = 1; port_num < device_attr.phys_port_cnt + 1; port_num++) {
 		ret = ibv_query_port(ctx, port_num, &port_attr);
 		if (ret) {
-			VERBS_INFO_ERRNO(FI_LOG_FABRIC,
-					 "ibv_query_port", errno);
+			VRB_WARN_ERRNO(FI_LOG_FABRIC, "ibv_query_port");
 			return -errno;
 		}
 		if (port_attr.state == IBV_PORT_ACTIVE)
@@ -614,14 +612,14 @@ static int vrb_get_device_attrs(struct ibv_context *ctx,
 			"active ports\n", dev_name);
 		return -FI_ENODATA;
 	} else {
-		VERBS_INFO(FI_LOG_FABRIC, "device %s: first found active port "
+		VRB_INFO(FI_LOG_FABRIC, "device %s: first found active port "
 			   "is %"PRIu8"\n", dev_name, port_num);
 	}
 
 	if (info->ep_attr->type == FI_EP_DGRAM) {
 		ret = vrb_mtu_type_to_len(port_attr.active_mtu);
 		if (ret < 0) {
-			VERBS_WARN(FI_LOG_FABRIC, "device %s (port: %d) reports"
+			VRB_WARN(FI_LOG_FABRIC, "device %s (port: %d) reports"
 				   " an unrecognized MTU (%d) \n",
 				   dev_name, port_num, port_attr.active_mtu);
 			return ret;
@@ -639,7 +637,7 @@ static int vrb_get_device_attrs(struct ibv_context *ctx,
 		       device_attr.vendor_part_id);
 	if (ret < 0) {
 		info->nic->device_attr->device_id = NULL;
-		VERBS_WARN(FI_LOG_FABRIC,
+		VRB_WARN(FI_LOG_FABRIC,
 			   "Unable to allocate memory for device_attr::device_id\n");
 		return -FI_ENOMEM;
 	}
@@ -648,7 +646,7 @@ static int vrb_get_device_attrs(struct ibv_context *ctx,
 		       device_attr.vendor_id);
 	if (ret < 0) {
 		info->nic->device_attr->vendor_id = NULL;
-		VERBS_WARN(FI_LOG_FABRIC,
+		VRB_WARN(FI_LOG_FABRIC,
 			   "Unable to allocate memory for device_attr::vendor_id\n");
 		return -FI_ENOMEM;
 	}
@@ -657,14 +655,14 @@ static int vrb_get_device_attrs(struct ibv_context *ctx,
 		       device_attr.hw_ver);
 	if (ret < 0) {
 		info->nic->device_attr->device_version = NULL;
-		VERBS_WARN(FI_LOG_FABRIC,
+		VRB_WARN(FI_LOG_FABRIC,
 			   "Unable to allocate memory for device_attr::device_version\n");
 		return -FI_ENOMEM;
 	}
 
         info->nic->device_attr->firmware = strdup(device_attr.fw_ver);
 	if (!info->nic->device_attr->firmware) {
-		VERBS_WARN(FI_LOG_FABRIC,
+		VRB_WARN(FI_LOG_FABRIC,
 			   "Unable to allocate memory for device_attr::firmware\n");
 		return -FI_ENOMEM;
 	}
@@ -678,7 +676,7 @@ static int vrb_get_device_attrs(struct ibv_context *ctx,
 	info->nic->link_attr->network_type =
 		strdup(vrb_link_layer_str(port_attr.link_layer));
 	if (!info->nic->link_attr->network_type) {
-		VERBS_WARN(FI_LOG_FABRIC,
+		VRB_WARN(FI_LOG_FABRIC,
 			   "Unable to allocate memory for link_attr::network_type\n");
 		return -FI_ENOMEM;
 	}
@@ -807,8 +805,7 @@ static int vrb_alloc_info(struct ibv_context *ctx, struct fi_info **info,
 	switch (ctx->device->transport_type) {
 	case IBV_TRANSPORT_IB:
 		if (ibv_query_gid(ctx, 1, vrb_gl_data.gid_idx, &gid)) {
-			VERBS_INFO_ERRNO(FI_LOG_FABRIC,
-					 "ibv_query_gid", errno);
+			VRB_WARN_ERRNO(FI_LOG_FABRIC, "ibv_query_gid");
 			ret = -errno;
 			goto err;
 		}
@@ -852,7 +849,7 @@ static int vrb_alloc_info(struct ibv_context *ctx, struct fi_info **info,
 		fi->domain_attr->cq_data_size = 0;
 		break;
 	default:
-		VERBS_INFO(FI_LOG_CORE, "Unknown transport type\n");
+		VRB_INFO(FI_LOG_CORE, "Unknown transport type\n");
 		ret = -FI_ENODATA;
 		goto err;
 	}
@@ -1124,7 +1121,7 @@ static int vrb_getifaddrs(struct dlist_entry *verbs_devs)
 
 	ret = ofi_getifaddrs(&ifaddr);
 	if (ret) {
-		VERBS_WARN(FI_LOG_FABRIC,
+		VRB_WARN(FI_LOG_FABRIC,
 			   "unable to get interface addresses\n");
 		return ret;
 	}
@@ -1133,7 +1130,7 @@ static int vrb_getifaddrs(struct dlist_entry *verbs_devs)
 	if (iface) {
 		iface_len = strlen(iface);
 		if (iface_len > IFNAMSIZ) {
-			VERBS_INFO(FI_LOG_FABRIC, "iface name: %s, too long "
+			VRB_INFO(FI_LOG_FABRIC, "iface name: %s, too long "
 				   "max: %d\n", iface, IFNAMSIZ);
 
 		}
@@ -1336,7 +1333,7 @@ int vrb_init_info(const struct fi_info **all_infos)
 	*all_infos = NULL;
 
 	if (!vrb_have_device()) {
-		VERBS_INFO(FI_LOG_FABRIC, "no RDMA devices found\n");
+		VRB_INFO(FI_LOG_FABRIC, "no RDMA devices found\n");
 		ret = -FI_ENODATA;
 		goto done;
 	}
@@ -1369,7 +1366,7 @@ int vrb_init_info(const struct fi_info **all_infos)
 
 	ctx_list = rdma_get_devices(&num_devices);
 	if (!num_devices) {
-		VERBS_INFO_ERRNO(FI_LOG_FABRIC, "rdma_get_devices", errno);
+		VRB_WARN_ERRNO(FI_LOG_FABRIC, "rdma_get_devices");
 		ret = -errno;
 		goto done;
 	}
@@ -1630,7 +1627,7 @@ static int vrb_resolve_ib_ud_dest_addr(const char *node, const char *service,
 	if (*dest_addr) {
 		VERBS_INFO_NODE_2_UD_ADDR(FI_LOG_CORE, node, svc, *dest_addr);
 	} else {
-		VERBS_INFO(FI_LOG_CORE,
+		VRB_INFO(FI_LOG_CORE,
 			   "failed to resolve '%s:%u'.\n", node, svc);
 		return -FI_ENODATA;
 	}
@@ -1690,7 +1687,7 @@ static int vrb_handle_ib_ud_addr(const char *node, const char *service,
 	if (!src_addr) {
 		src_addr = calloc(1, sizeof(*src_addr));
 		if (!src_addr) {
-			VERBS_INFO(FI_LOG_CORE,
+			VRB_INFO(FI_LOG_CORE,
 			           "failed to allocate src addr.\n");
 			ret = -FI_ENODATA;
 			goto err;
@@ -1706,7 +1703,7 @@ static int vrb_handle_ib_ud_addr(const char *node, const char *service,
 				}
 			}
 
-			VERBS_INFO(FI_LOG_CORE, "node '%s' service '%s' "
+			VRB_INFO(FI_LOG_CORE, "node '%s' service '%s' "
 				                "converted to <service=%d>\n",
 				   node, service, src_addr->service);
 		}
@@ -1756,7 +1753,7 @@ static int vrb_handle_sock_addr(const char *node, const char *service,
 out:
 	rdma_freeaddrinfo(rai);
 	if (rdma_destroy_id(id))
-		VERBS_INFO_ERRNO(FI_LOG_FABRIC, "rdma_destroy_id", errno);
+		VRB_WARN_ERRNO(FI_LOG_FABRIC, "rdma_destroy_id");
 	return ret;
 }
 
@@ -1779,7 +1776,7 @@ static int vrb_get_match_infos(uint32_t version, const char *node,
 	    hints->ep_attr->type == FI_EP_UNSPEC) {
 		ret_sock_addr = vrb_handle_sock_addr(node, service, flags, hints, info);
 		if (ret_sock_addr) {
-			VERBS_INFO(FI_LOG_FABRIC,
+			VRB_INFO(FI_LOG_FABRIC,
 				   "handling of the socket address fails - %d\n",
 				   ret_sock_addr);
 		} else {
@@ -1792,7 +1789,7 @@ static int vrb_get_match_infos(uint32_t version, const char *node,
 	    hints->ep_attr->type == FI_EP_UNSPEC) {
 		ret_ib_ud_addr = vrb_handle_ib_ud_addr(node, service, flags, info);
 		if (ret_ib_ud_addr)
-			VERBS_INFO(FI_LOG_FABRIC,
+			VRB_INFO(FI_LOG_FABRIC,
 				   "handling of the IB ID address fails - %d\n",
 				   ret_ib_ud_addr);
 	}
@@ -1800,7 +1797,7 @@ static int vrb_get_match_infos(uint32_t version, const char *node,
 	if (ret_sock_addr && ret_ib_ud_addr) {
 		/* neither the sockaddr nor the ib_ud address wasn't
 		 * handled to satisfy the selection procedure */
-		VERBS_INFO(FI_LOG_CORE, "Handling of the addresses fails, "
+		VRB_INFO(FI_LOG_CORE, "Handling of the addresses fails, "
 			   "the getting infos is unsuccessful\n");
 		fi_freeinfo(*info);
 		return -FI_ENODATA;

--- a/src/log.c
+++ b/src/log.c
@@ -179,9 +179,9 @@ void DEFAULT_SYMVER_PRE(fi_log)(const struct fi_provider *prov, enum fi_log_leve
 
 	va_list vargs;
 
-	size = snprintf(buf, sizeof(buf), "%s:%d:%s:%s:%s():%d<%s> ", PACKAGE,
-			pid, prov->name, log_subsys[subsys], func, line,
-			log_levels[level]);
+	size = snprintf(buf, sizeof(buf), "%s:%d:%ld:%s:%s:%s():%d<%s> ",
+			PACKAGE, pid, (unsigned long) time(NULL), prov->name,
+			log_subsys[subsys], func, line, log_levels[level]);
 
 	va_start(vargs, fmt);
 	vsnprintf(buf + size, sizeof(buf) - size, fmt, vargs);


### PR DESCRIPTION
Includes patch to add time stamps (using time()) to all log messages, so that log messages between processes and systems can be coordinated.

Several verbs error messages were converted from INFO to WARN.  Also replaced the prefix for verbs logging for consistency (VERBS -> VRB)

Added a few new messages to rxm, plus a new log macro to simplify the code.

