### PR TITLE
prov/efa: emulated write protocol selection fix

### DIFF
--- a/prov/efa/src/rxr/rxr_pkt_type.h
+++ b/prov/efa/src/rxr/rxr_pkt_type.h
@@ -36,6 +36,10 @@
 
 #include "rdm_proto_v4.h"
 
+#define RXR_PKT_OPT_HDR_FLAGS (RXR_PKT_CONNID_HDR | \
+								RXR_REQ_OPT_RAW_ADDR_HDR_SIZE | \
+								RXR_REQ_OPT_CQ_DATA_HDR)
+
 static inline struct rxr_base_hdr *rxr_get_base_hdr(void *pkt)
 {
 	return (struct rxr_base_hdr *)pkt;
@@ -231,6 +235,29 @@ void rxr_pkt_handle_receipt_send_completion(struct rxr_ep *ep,
 void rxr_pkt_handle_receipt_recv(struct rxr_ep *ep,
 				 struct rxr_pkt_entry *pkt_entry);
 
+/* General packet type helper functions */
+static inline
+int rxr_pkt_type_contains_rma_iov(int pkt_type)
+{
+	switch (pkt_type) {
+		case RXR_EAGER_RTW_PKT:
+		case RXR_DC_EAGER_RTW_PKT:
+		case RXR_LONGCTS_RTW_PKT:
+		case RXR_DC_LONGCTS_RTW_PKT:
+		case RXR_LONGREAD_RTW_PKT:
+		case RXR_SHORT_RTR_PKT:
+		case RXR_LONGCTS_RTR_PKT:
+		case RXR_WRITE_RTA_PKT:
+		case RXR_DC_WRITE_RTA_PKT:
+		case RXR_FETCH_RTA_PKT:
+		case RXR_COMPARE_RTA_PKT:
+			return 1;
+			break;
+		default:
+			return 0;
+			break;
+	}
+}
 #endif
 
 #include "rxr_pkt_type_req.h"

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -317,25 +317,80 @@ int64_t rxr_pkt_req_cq_data(struct rxr_pkt_entry *pkt_entry)
 	return cq_data_hdr->cq_data;
 }
 
-size_t rxr_pkt_req_max_header_size(int pkt_type)
+size_t rxr_pkt_req_calc_data_size(struct rxr_ep *ep,
+				fi_addr_t addr,
+				int pkt_type,
+				uint64_t fi_flags,
+				size_t rma_iov_count)
 {
-	/* max_hdr_size does not include optional connid hdr length because
-	 * it is impossible to have both optional connid hdr and opt_raw_addr_hdr
-	 * in the header, and length of opt raw addr hdr is larger than
-	 * connid hdr (which is confirmed by the following assertion).
-	 */
-	assert(RXR_REQ_OPT_RAW_ADDR_HDR_SIZE >= sizeof(struct rxr_req_opt_connid_hdr));
+	struct rdm_peer *peer;
+	uint16_t header_flags = 0;
 
-	int max_hdr_size = REQ_INF_LIST[pkt_type].base_hdr_size
-		+ RXR_REQ_OPT_RAW_ADDR_HDR_SIZE
-		+ sizeof(struct rxr_req_opt_cq_data_hdr);
+	peer = rxr_ep_get_peer(ep, addr);
+	assert(peer);
 
-	if (pkt_type == RXR_EAGER_RTW_PKT ||
-	    pkt_type == RXR_DC_EAGER_RTW_PKT ||
-	    pkt_type == RXR_LONGCTS_RTW_PKT)
-		max_hdr_size += RXR_IOV_LIMIT * sizeof(struct fi_rma_iov);
+	if (peer->is_local) {
+		assert(ep->use_shm);
+		return rxr_env.shm_max_medium_size;
+	}
 
-	return max_hdr_size;
+	if (rxr_peer_need_raw_addr_hdr(peer))
+		header_flags |= RXR_REQ_OPT_RAW_ADDR_HDR;
+	else if (rxr_peer_need_connid(peer))
+		header_flags |= RXR_PKT_CONNID_HDR;
+
+	if (fi_flags & FI_REMOTE_CQ_DATA)
+		header_flags |= RXR_REQ_OPT_CQ_DATA_HDR;
+
+	return ep->mtu_size - rxr_pkt_req_header_size(pkt_type,
+								header_flags,
+								rma_iov_count);
+}
+
+/**
+ * @brief calculates the exact header size given a REQ packet type, flags, and IOV count.
+ *
+ * @param[in]	pkt_type	packet type
+ * @param[in]	flags	flags from packet
+ * @param[in]	rma_iov_count	number of RMA IOV structures present
+ * @return	The exact size of the packet header
+ */
+inline
+size_t rxr_pkt_req_header_size(int pkt_type, uint16_t flags, size_t rma_iov_count)
+{
+	int hdr_size = REQ_INF_LIST[pkt_type].base_hdr_size;
+
+	if (flags & RXR_REQ_OPT_RAW_ADDR_HDR) {
+		/* It is impossible to have both optional connid hdr and opt_raw_addr_hdr
+		 * in the header, and length of opt raw addr hdr is larger than
+		 * connid hdr (which is confirmed by the following assertion).
+		 */
+		assert(RXR_REQ_OPT_RAW_ADDR_HDR_SIZE >= sizeof(struct rxr_req_opt_connid_hdr));
+		hdr_size += RXR_REQ_OPT_RAW_ADDR_HDR_SIZE;
+	} else if (flags & RXR_PKT_CONNID_HDR) {
+		hdr_size += sizeof(struct rxr_req_opt_connid_hdr);
+	}
+
+	if (flags & RXR_REQ_OPT_CQ_DATA_HDR) {
+		hdr_size += sizeof(struct rxr_req_opt_cq_data_hdr);
+	}
+
+	if (rxr_pkt_type_contains_rma_iov(pkt_type)) {
+		hdr_size += rma_iov_count * sizeof(struct fi_rma_iov);
+	}
+
+	return hdr_size;
+}
+
+/**
+ * @brief calculates the max header size given a REQ packet type
+ *
+ * @param[in]	pkt_type	packet type
+ * @return	The max possible size of the packet header
+ */
+inline size_t rxr_pkt_req_max_header_size(int pkt_type)
+{
+	return rxr_pkt_req_header_size(pkt_type, RXR_PKT_OPT_HDR_FLAGS, RXR_IOV_LIMIT);
 }
 
 size_t rxr_pkt_max_header_size(void)
@@ -353,7 +408,6 @@ size_t rxr_pkt_max_header_size(void)
 	}
 
 	return max_hdr_size;
-
 }
 
 size_t rxr_pkt_req_max_data_size(struct rxr_ep *ep, fi_addr_t addr, int pkt_type)

--- a/prov/efa/src/rxr/rxr_pkt_type_req.h
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.h
@@ -50,6 +50,22 @@ size_t rxr_pkt_req_hdr_size(struct rxr_pkt_entry *pkt_entry);
 
 size_t rxr_pkt_req_base_hdr_size(struct rxr_pkt_entry *pkt_entry);
 
+/*
+ * calculates the data size allowed for a given packet type
+ * Note that there is likely a better name for this as it's purpose is slightly
+ * overlapping with rxr_pkt_req_max_data_size() below. Ideally, we will refactor
+ * this code to be better but that is part of a larger effort.
+ */
+size_t rxr_pkt_req_calc_data_size(struct rxr_ep *ep,
+									fi_addr_t addr,
+									int pkt_type,
+									uint64_t fi_flags,
+									size_t rma_iov_count);
+
+size_t rxr_pkt_req_header_size(int pkt_type,
+								uint16_t flags,
+								size_t rma_iov_count);
+
 size_t rxr_pkt_req_max_header_size(int pkt_type);
 
 size_t rxr_pkt_max_header_size(void);

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -407,7 +407,7 @@ ssize_t rxr_rma_post_write(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry)
 	struct efa_domain *efa_domain;
 	bool delivery_complete_requested;
 	int ctrl_type;
-	size_t max_rtm_data_size;
+	size_t max_eager_rtw_data_size;
 	struct rxr_domain *rxr_domain = rxr_ep_domain(ep);
 
 	efa_domain = container_of(rxr_domain->rdm_domain, struct efa_domain,
@@ -446,17 +446,21 @@ ssize_t rxr_rma_post_write(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry)
 		else if (!rxr_peer_support_delivery_complete(peer))
 			return -FI_EOPNOTSUPP;
 
-		max_rtm_data_size = rxr_pkt_req_max_data_size(ep,
-							      tx_entry->addr,
-							      RXR_DC_EAGER_RTW_PKT);
+		max_eager_rtw_data_size = rxr_pkt_req_calc_data_size(ep,
+									tx_entry->addr,
+									RXR_DC_EAGER_RTW_PKT,
+									tx_entry->fi_flags,
+									tx_entry->rma_iov_count);
 	} else {
-		max_rtm_data_size = rxr_pkt_req_max_data_size(ep,
-							      tx_entry->addr,
-							      RXR_EAGER_RTW_PKT);
+		max_eager_rtw_data_size = rxr_pkt_req_calc_data_size(ep,
+									tx_entry->addr,
+									RXR_EAGER_RTW_PKT,
+									tx_entry->fi_flags,
+									tx_entry->rma_iov_count);
 	}
 
 	/* Inter instance */
-	if (tx_entry->total_len < max_rtm_data_size) {
+	if (tx_entry->total_len <= max_eager_rtw_data_size) {
 		ctrl_type = delivery_complete_requested ?
 			RXR_DC_EAGER_RTW_PKT : RXR_EAGER_RTW_PKT;
 		return rxr_pkt_post_ctrl(ep, RXR_TX_ENTRY, tx_entry, ctrl_type, 0, 0);


### PR DESCRIPTION
The original protocol selection for emulated write used the
maximum possible message header size, which led to situations
where all of the data was sent within the RTW message leading
to assertion errors.

This patch calculates the exact header size instead.

These changes have been tested by verifying broken behavior
pre-patch and correct behavior post-patch using the following
test (and associated parameters) from fabtests:

`./fi_rma_bw -o write -b -p efa -v -S 8872`

Additionally, this patch was verified by running the above test
using all message sizes (`-S all`).

Finally, I wrote a quick bash script that tested every message size
from 8000 to 9001 bytes in increments of 1 byte and verified that
each one succeeded.

Signed-off-by: Matt Koop <mkoop@amazon.com>
Signed-off-by: Rich Welch <rlwelch@amazon.com>