### PR TITLE
prov/efa: handle queued local read request correctly

### DIFF
--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -2154,9 +2154,12 @@ void rxr_ep_progress_internal(struct rxr_ep *ep)
 	dlist_foreach_container_safe(&ep->read_pending_list, struct rxr_read_entry,
 				     read_entry, pending_entry, tmp) {
 		peer = rxr_ep_get_peer(ep, read_entry->addr);
-		assert(peer);
-
-		if (peer->flags & RXR_PEER_IN_BACKOFF)
+		/*
+		 * Here peer can be NULL, when the read request is a
+		 * local read request. Local read request is used to copy
+		 * data from host memory to device memory on same process.
+		 */
+		if (peer && (peer->flags & RXR_PEER_IN_BACKOFF))
 			continue;
 
 		/*


### PR DESCRIPTION
Progress engine will submit queued read request.

When doing that, it needs to retrieve the peer of the read
to check whether peer is in RNR backoff state.

Local read request (which is used to copy data from host
memory to device memory) does not have a peer, thus
the returned peer pointer would be NULL, therefore
a queued local read requst will cause segfault.

This patch handles that case correctly by not checking
peer state if peer is NULL, it also removed the assertion
of peer not being NULL.

Signed-off-by: Wei Zhang <wzam@amazon.com>