### PR TITLE
prov/rxm: Shutdown existing connections if we receive a new request

### DIFF
--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -582,8 +582,9 @@ rxm_process_connreq(struct rxm_ep *ep, struct rxm_eq_cm_entry *cm_entry)
 	case RXM_CM_ACCEPTING:
 	case RXM_CM_CONNECTED:
 		FI_INFO(&rxm_prov, FI_LOG_EP_CTRL,
-			"connection accepting/done, ignoring %p\n", conn);
-		goto put;
+			"old connection accepting/done, replacing %p\n", conn);
+		rxm_close_conn(conn);
+		break;
 	default:
 		assert(0);
 		break;


### PR DESCRIPTION
If we receive a connection request from the same peer address
and we're in the CONNECTED or ACCEPTING state, the new request
likely indicates that the old connection is no longer valid.
(We expect the lower layer to filter out true duplicate
connection requests).  When this occurs, close the older
connection and accept the new request.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>