### PR TITLE
core/getinfo: Fix check if provider requires use of shared contexts

### DIFF
--- a/prov/netdir/src/netdir_ep_msg.c
+++ b/prov/netdir/src/netdir_ep_msg.c
@@ -399,7 +399,7 @@ ofi_nd_ep_sendmsg(struct fid_ep *pep, const struct fi_msg *msg, uint64_t flags)
 	entry->seq = InterlockedAdd64(&ep->domain->msg_cnt, 1);
 
 	/* since send operation can't be canceled, set NULL into
-	 * the 1st byte of internal data of context */
+	 * the 1st pointer of internal data of context */
 	if (msg->context)
 		ND_FI_CONTEXT(msg->context) = 0;
 
@@ -554,7 +554,7 @@ static ssize_t ofi_nd_ep_recvmsg(struct fid_ep *pep, const struct fi_msg *msg,
 	for (i = 0; i < msg->iov_count; i++)
 		entry->iov[i] = msg->msg_iov[i];
 
-	/* store allocated entry in 1st byte of internal data of context */
+	/* store allocated entry in 1st pointer of internal data of context */
 	if (msg->context)
 		ND_FI_CONTEXT(msg->context) = entry;
 

--- a/prov/netdir/src/netdir_ep_rma.c
+++ b/prov/netdir/src/netdir_ep_rma.c
@@ -192,7 +192,7 @@ ofi_nd_ep_readmsg(struct fid_ep *pep, const struct fi_msg_rma *msg,
 	main_entry->seq = InterlockedAdd64(&ep->domain->msg_cnt, 1);
 
 	/* since write operation can't be canceled, set NULL into
-	 * the 1st byte of internal data of context */
+	 * the 1st pointer of internal data of context */
 	if (msg->context)
 		ND_FI_CONTEXT(msg->context) = 0;
 
@@ -340,7 +340,7 @@ ofi_nd_ep_writemsg(struct fid_ep *pep, const struct fi_msg_rma *msg,
 		return -FI_EINVAL;
 
 	for (i = 0; i < msg->rma_iov_count; i++) {
-		if (msg->rma_iov[i].len && !msg->rma_iov[i].addr) 
+		if (msg->rma_iov[i].len && !msg->rma_iov[i].addr)
 			return -FI_EINVAL;
 		rma_len += msg->rma_iov[i].len;
 	}
@@ -368,7 +368,7 @@ ofi_nd_ep_writemsg(struct fid_ep *pep, const struct fi_msg_rma *msg,
 	main_entry->seq = InterlockedAdd64(&ep->domain->msg_cnt, 1);
 
 	/* since write operation can't be canceled, set NULL into
-	* the 1st byte of internal data of context */
+	* the 1st pointer of internal data of context */
 	if (msg->context)
 		ND_FI_CONTEXT(msg->context) = 0;
 

--- a/prov/netdir/src/netdir_ep_srx.c
+++ b/prov/netdir/src/netdir_ep_srx.c
@@ -188,7 +188,7 @@ static ssize_t ofi_nd_srx_recvmsg(struct fid_ep *pep, const struct fi_msg *msg,
 		entry->iov[i] = msg->msg_iov[i];
 	}
 
-	/* store allocated entry in 1st byte of internal data of context */
+	/* store allocated entry in 1st pointer of internal data of context */
 	if (msg->context)
 		ND_FI_CONTEXT(msg->context) = entry;
 

--- a/prov/netdir/src/netdir_init.c
+++ b/prov/netdir/src/netdir_init.c
@@ -101,6 +101,7 @@ static int ofi_nd_adapter_cb(const ND2_ADAPTER_INFO *adapter, const char *name)
 		return -FI_ENOMEM;
 
 	info->tx_attr->caps = FI_MSG | FI_SEND;
+	info->tx_attr->mode = FI_CONTEXT;
 	info->tx_attr->comp_order = FI_ORDER_STRICT;
 	info->tx_attr->inject_size = (size_t)gl_data.inline_thr;
 	info->tx_attr->size = (size_t)adapter->MaxTransferLength;
@@ -112,6 +113,7 @@ static int ofi_nd_adapter_cb(const ND2_ADAPTER_INFO *adapter, const char *name)
 	info->tx_attr->msg_order = OFI_ND_MSG_ORDER;
 
 	info->rx_attr->caps = FI_MSG | FI_RECV;
+	info->rx_attr->mode = FI_CONTEXT;
 	info->rx_attr->comp_order = FI_ORDER_STRICT;
 	info->rx_attr->total_buffered_recv = 0;
 	info->rx_attr->size = (size_t)adapter->MaxTransferLength;
@@ -141,6 +143,7 @@ static int ofi_nd_adapter_cb(const ND2_ADAPTER_INFO *adapter, const char *name)
 	info->fabric_attr->prov_version = OFI_VERSION_DEF_PROV;
 
 	info->caps = OFI_ND_EP_CAPS | OFI_ND_DOMAIN_CAPS;
+	info->mode = FI_CONTEXT;
 	info->addr_format = FI_SOCKADDR;
 
 	if (!ofi_nd_util_prov.info) {

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -709,6 +709,11 @@ int ofi_check_ep_attr(const struct util_prov *util_prov, uint32_t api_version,
 				user_attr->tx_ctx_cnt);
 			return -FI_ENODATA;
 		}
+	} else if (!user_attr->tx_ctx_cnt &&
+		   prov_attr->tx_ctx_cnt == FI_SHARED_CONTEXT) {
+		FI_INFO(prov, FI_LOG_CORE,
+			"Provider requires use of shared tx context\n");
+		return -FI_ENODATA;
 	}
 
 	if (user_attr->rx_ctx_cnt > prov_info->domain_attr->max_ep_rx_ctx) {
@@ -726,6 +731,11 @@ int ofi_check_ep_attr(const struct util_prov *util_prov, uint32_t api_version,
 				user_attr->rx_ctx_cnt);
 			return -FI_ENODATA;
 		}
+	} else if (!user_attr->rx_ctx_cnt &&
+		   prov_attr->rx_ctx_cnt == FI_SHARED_CONTEXT) {
+		FI_INFO(prov, FI_LOG_CORE,
+			"Provider requires use of shared rx context\n");
+		return -FI_ENODATA;
 	}
 
 	if (user_info->caps & (FI_RMA | FI_ATOMIC)) {


### PR DESCRIPTION
The tcp provider requires the use of shared contexts in order to
support the FI_TAGGED capability.  By default, if an application
does not specify a tx or rx cxt_cnt, the returned fi_info should
be 1.  Update the checks in ofi_check_ep_attr to see if the user
has specified a tx or rx cxt_cnt.  If no count was specified and
the provider's fi_info structure requires FI_SHARED_CONTEXT, fail
the info match.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>