### PR TITLE
prov/verbs: refine vrb_mr_ofi2ibv_access

### DIFF
--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -151,9 +151,6 @@ vrb_mr_ofi2ibv_access(uint64_t ofi_access, struct vrb_domain *domain)
 			ibv_access |= IBV_ACCESS_REMOTE_WRITE;
 	}
 
-	if (ofi_access & FI_WRITE)
-		ibv_access |= IBV_ACCESS_LOCAL_WRITE;
-
 	if (ofi_access & FI_REMOTE_READ)
 		ibv_access |= IBV_ACCESS_REMOTE_READ;
 


### PR DESCRIPTION
Need not grant IBV_ACCESS_LOCAL_WRITE for FI_WRITE -
FI_WRITE
The memory buffer may be used as the source buffer for RMA write and atomic  operations
on  the  initiator side.  Note that from the viewpoint of the application, the endpoint
is reading from the memory buffer and copying the data onto the network.

It only needs local read permission which is always enabled.

To fix EFAULT failure when fi_mr_regv() a RO buffer.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>