### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/prov/psm3/Makefile.include
+++ b/prov/psm3/Makefile.include
@@ -270,11 +270,12 @@ _psm3_LIBS = prov/psm3/psm3/libpsm3i.la
 
 BUILT_SOURCES = prov/psm3/src/psm3_src_chksum.h
 CLEANFILES = prov/psm3/src/psm3_src_chksum.h
+DATE_FMT = +%Y-%m-%dT%H:%M:%S
 prov/psm3/src/psm3_src_chksum.h: Makefile $(chksum_srcs)
 	$(AM_V_GEN) chksum=`for file in $(chksum_srcs); do cat $(top_srcdir)/$$file; done | sha1sum | cut -d' ' -f 1`; \
 	if ! grep -q $$chksum prov/psm3/src/psm3_src_chksum.h 2>/dev/null; then \
 		echo "#define PSMX3_SRC_CHECKSUM \"$$chksum\"" > prov/psm3/src/psm3_src_chksum.h; \
-		echo "#define PSMX3_BUILD_TIMESTAMP \"`date`\"" >> prov/psm3/src/psm3_src_chksum.h; \
+		echo "#define PSMX3_BUILD_TIMESTAMP \"`if test -z "$(SOURCE_DATE_EPOCH)" ; then date "$(DATE_FMT)" ; else date -u -d "@$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u "$(DATE_FMT)" ; fi`\"" >> prov/psm3/src/psm3_src_chksum.h; \
 	fi
 
 endif HAVE_PSM3_SRC


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH` in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

This date call works with various `date` command implementations.
Also consistently use ISO 8601 date format to be understood everywhere and to be independent of locales.
Also use UTC to be independent of timezone.