### PR TITLE
fabtests: Update test list for EFA specific RNR test in runfabtests.sh

### DIFF
--- a/fabtests/scripts/runfabtests.sh
+++ b/fabtests/scripts/runfabtests.sh
@@ -239,7 +239,33 @@ multinode_tests=(
 )
 
 prov_efa_tests=( \
-	"fi_efa_ep_rnr_retry -R 0"
+	"fi_efa_rnr_read_cq_error"
+	"fi_efa_rnr_queue_resend -c 0 -S 1048576"
+	"fi_efa_rnr_queue_resend -c 0 -o read -S 4"
+	"fi_efa_rnr_queue_resend -c 0 -A read -S 4"
+	"fi_efa_rnr_queue_resend -c 0 -U -S 4"
+	"fi_efa_rnr_queue_resend -c 1 -S 4"
+	"fi_efa_rnr_queue_resend -c 1 -T -S 4"
+	"fi_efa_rnr_queue_resend -c 1 -S 16384"
+	"fi_efa_rnr_queue_resend -c 1 -T -S 16384"
+	"fi_efa_rnr_queue_resend -c 1 -S 1048576"
+	"fi_efa_rnr_queue_resend -c 1 -T -S 1048576"
+	"fi_efa_rnr_queue_resend -c 1 -o write -S 4"
+	"fi_efa_rnr_queue_resend -c 1 -o write -S 1048576"
+	"fi_efa_rnr_queue_resend -c 1 -o read -S 4"
+	"fi_efa_rnr_queue_resend -c 1 -o read -S 1048576"
+	"fi_efa_rnr_queue_resend -c 1 -A write -S 4"
+	"fi_efa_rnr_queue_resend -c 1 -A read -S 4"
+	"fi_efa_rnr_queue_resend -c 1 -A cswap -S 4"
+	"fi_efa_rnr_queue_resend -c 1 -U -S 4"
+	"fi_efa_rnr_queue_resend -c 1 -T -U -S 4"
+	"fi_efa_rnr_queue_resend -c 1 -U -S 16384"
+	"fi_efa_rnr_queue_resend -c 1 -T -U -S 16384"
+	"fi_efa_rnr_queue_resend -c 1 -U -S 1048576"
+	"fi_efa_rnr_queue_resend -c 1 -T -U -S 1048576"
+	"fi_efa_rnr_queue_resend -c 1 -o write -U -S 4"
+	"fi_efa_rnr_queue_resend -c 1 -o write -U -S 1048576"
+	"fi_efa_rnr_queue_resend -c 1 -A write -U -S 4"
 )
 
 function errcho {


### PR DESCRIPTION
Update test list for EFA provider specific RNR test in runfabtests.sh **after PR#7259 is merged**.


The details are:
(1) check if RNR CQ error entry can be read by application.
"fi_efa_rnr_read_cq_error"

(2) check if RNR queue/re-send logic working correctly for all packet types.
"fi_efa_rnr_queue_resend -c 0 -S 1048576" - CTS, DATA / EOR(RDMA Read)
"fi_efa_rnr_queue_resend -c 0 -o read -S 4" - READRSP
"fi_efa_rnr_queue_resend -c 0 -A read -S 4" - ATOMRSP
"fi_efa_rnr_queue_resend -c 0 -U -S 4" - RECEIPT
"fi_efa_rnr_queue_resend -c 1 -S 4" - EAGER_MSGRTM
"fi_efa_rnr_queue_resend -c 1 -T -S 4" - EAGER_TAGRTM
"fi_efa_rnr_queue_resend -c 1 -S 16384" - MEDIUM_MSGRTM
"fi_efa_rnr_queue_resend -c 1 -T -S 16384" - MEDIUM_TAGRTM
"fi_efa_rnr_queue_resend -c 1 -S 1048576" - LONGCTS_MSGRTM / LONGREAD_MSGRTM (RDMA Read)
"fi_efa_rnr_queue_resend -c 1 -T -S 1048576" - LONGCTS_TAGRTM / LONGREAD_TAGRTM (RDMA Read)
"fi_efa_rnr_queue_resend -c 1 -o write -S 4" - EAGER_RTW
"fi_efa_rnr_queue_resend -c 1 -o write -S 1048576" - LONGCTS_RTW / LONGREAD_RTW (RDMA Read)
"fi_efa_rnr_queue_resend -c 1 -o read -S 4" - SHORT_RTR
"fi_efa_rnr_queue_resend -c 1 -o read -S 1048576" - LONGCTS_RTR
"fi_efa_rnr_queue_resend -c 1 -A write -S 4" - WRITE_RTA
"fi_efa_rnr_queue_resend -c 1 -A read -S 4" - FETCH_RTA
"fi_efa_rnr_queue_resend -c 1 -A cswap -S 4" - COMPARE_RTA
"fi_efa_rnr_queue_resend -c 1 -U -S 4" - DC_EAGER_MSGRTM
"fi_efa_rnr_queue_resend -c 1 -T -U -S 4" - DC_EAGER_TAGRTM
"fi_efa_rnr_queue_resend -c 1 -U -S 16384" - DC_MEDIUM_MSGRTM
"fi_efa_rnr_queue_resend -c 1 -T -U -S 16384" - DC_MEDIUM_TAGRTM
"fi_efa_rnr_queue_resend -c 1 -U -S 1048576" - DC_LONGCTS_MSGRTM
"fi_efa_rnr_queue_resend -c 1 -T -U -S 1048576" - DC_LONGCTS_TAGRTM
"fi_efa_rnr_queue_resend -c 1 -o write -U -S 4" - DC_EAGER_RTW
"fi_efa_rnr_queue_resend -c 1 -o write -U -S 1048576" - DC_LONGCTS_RTW
"fi_efa_rnr_queue_resend -c 1 -A write -U -S 4" - DC_WRITE_RTA

In addition, HANDSHAKE packet's queue/re-send can be easily triggered during
initial ft_sync's ft_rx() on the server side, as the client does not
pre-post internal rx buffers until it polls completion in ft_sync's
ft_tx(). All of the above tests have the sync procedure, so we do not
add a dedicated test to check HANDSHAKE packet.

Signed-off-by: zhngaj <zhngaj@amazon.com>