### PR TITLE
prov/efa: Get efa provider ready to be compiled for Windows

### DIFF
--- a/prov/efa/src/efa_device.c
+++ b/prov/efa/src/efa_device.c
@@ -49,6 +49,10 @@
 
 #include "efa.h"
 
+#ifdef _WIN32
+#include "efawin.h"
+#endif
+
 static struct efa_context **ctx_list;
 static int dev_cnt;
 
@@ -81,6 +85,32 @@ static int efa_device_close(struct efa_context *ctx)
 	return 0;
 }
 
+#ifndef _WIN32
+
+int efa_lib_init(void)
+{
+	return 0;
+}
+
+#else // _WIN32
+
+int efa_lib_init(void)
+{
+	int ret;
+	/*
+	* On Windows we need to load efawin dll to interact with
+ 	* efa device as there is no built-in verbs integration in the OS.
+	* efawin dll provides all the ibv_* functions on Windows.
+	* efa_load_efawin_lib function will replace stub ibv_* functions with
+	* functions from efawin dll
+	*/
+	ret = efa_load_efawin_lib();
+	
+	return ret;
+}
+
+#endif // _WIN32
+
 int efa_device_init(void)
 {
 	struct ibv_device **device_list;
@@ -88,6 +118,11 @@ int efa_device_init(void)
 	int ret;
 
 	fastlock_init(&pd_list_lock);
+
+	ret = efa_lib_init();
+	if (ret != 0) {
+		return ret;
+	}
 
 	device_list = ibv_get_device_list(&dev_cnt);
 	if (device_list == NULL)
@@ -154,6 +189,20 @@ bool efa_device_support_rdma_read(void)
 #endif
 }
 
+#ifndef _WIN32
+
+void efa_lib_close(void) {
+	// Nothing to do when we are not compiling for Windows
+}
+
+#else // _WIN32
+
+void efa_lib_close(void) {
+	efa_free_efawin_lib();
+}
+
+#endif // _WIN32
+
 void efa_device_free(void)
 {
 	int i;
@@ -164,6 +213,7 @@ void efa_device_free(void)
 	free(pd_list);
 	free(ctx_list);
 	dev_cnt = 0;
+	efa_lib_close();
 	fastlock_destroy(&pd_list_lock);
 }
 

--- a/prov/efa/src/efa_rma.c
+++ b/prov/efa/src/efa_rma.c
@@ -59,7 +59,14 @@ ssize_t efa_rma_post_read(struct efa_ep *ep, const struct fi_msg_rma *msg,
 	struct efa_qp *qp;
 	struct efa_mr *efa_mr;
 	struct efa_conn *conn;
+#ifndef _WIN32
 	struct ibv_sge sge_list[msg->iov_count];
+#else
+	/* MSVC compiler does not support array declarations with runtime size, so hardcode
+	 * the expected iov_limit/max_sq_sge from the lower-level efa provider.
+	 */
+	struct ibv_sge sge_list[EFA_DEV_ATTR_MAX_WR_SGE];
+#endif
 	int i;
 
 	if (OFI_UNLIKELY(msg->iov_count > ep->domain->ctx->max_wr_rdma_sge)) {

--- a/prov/efa/src/windows/README.Efawin
+++ b/prov/efa/src/windows/README.Efawin
@@ -1,0 +1,10 @@
+Efawin headers and loader can be obtained from https://github.com/aws/efawin.
+
+Copy the contents of the folder including subfolders from 
+https://github.com/aws/efawin/tree/v1.0.0/interface
+into the folder containing this file.
+
+Note that Efawin.dll and its dependencies are needed at runtime
+for libfabric's EFA provider to successfully use it.
+Please use https://github.com/aws/efawin/blob/v1.0.0/README.md to prepare
+the necessary dependencies.


### PR DESCRIPTION
This pull request provides an alternate Windows specific implementation for `efa_alloc_fid_nic` function.  It is mostly a copy with some Linux specific paths replaced with Windows specific logic.

This pull request also adds the necessary dependency named efawin to efa provider.   This is required for efa provider to work on Windows. The dependency is done in a similar way to netdir provider where we ask the developer to copy files from an external source.  In this case, the efa provider is taking a dependency on a specific version of efawin when compiling for Windows. The intent is to update the instructions with newer versions as they are tested and proven to be compatible with efa provider.

Note that a different pull request will enable compilation of efa provider on Windows.