### PR TITLE
core (+ most providers): Replace spin locks with mutex

### DIFF
--- a/docs/providers
+++ b/docs/providers
@@ -99,7 +99,7 @@ htonll() / ntohll()
 sizeof_field()
 MIN / MAX - simple (i.e. potentially unsafe) min/max macros
 roundup_power_of_two()
-fastlock_t - lock object (spinlock or mutex based on availability)
+ofi_spin_t - lock object (spinlock or mutex based on availability)
 atomic operations - implementation based on availability
 fi_read_file() - read a value from a file
 fi_poll_fd() - call poll() on an fd

--- a/docs/providers
+++ b/docs/providers
@@ -103,7 +103,7 @@ ofi_spin_t - lock object (spinlock or mutex based on availability)
 atomic operations - implementation based on availability
 fi_read_file() - read a value from a file
 fi_poll_fd() - call poll() on an fd
-fi_wait_cond() - wait on a mutex
+ofi_wait_cond() - wait on a mutex
 fi_datatype_size() - return size of an atomic datatype
 fi_[capability]_allowed() - routines to check caps bits
 ofi_gettime_ns() - return current time in nanoseconds

--- a/include/ofi_atom.h
+++ b/include/ofi_atom.h
@@ -255,7 +255,7 @@ typedef atomic_long	ofi_atomic_int64_t;
 
 #define OFI_ATOMIC_DEFINE(radix)								\
 	typedef	struct {									\
-		fastlock_t lock;								\
+		ofi_spin_t lock;								\
 		int##radix##_t val;								\
 		ATOMIC_DEF_INIT;								\
 	} ofi_atomic##radix##_t;								\
@@ -265,9 +265,9 @@ typedef atomic_long	ofi_atomic_int64_t;
 	{											\
 		int##radix##_t v = 0;								\
 		ATOMIC_IS_INITIALIZED(atomic);							\
-		fastlock_acquire(&atomic->lock);						\
+		ofi_spin_lock(&atomic->lock);						\
 		v = ++(atomic->val);								\
-		fastlock_release(&atomic->lock);						\
+		ofi_spin_unlock(&atomic->lock);						\
 		return v;									\
 	}											\
 	static inline										\
@@ -275,9 +275,9 @@ typedef atomic_long	ofi_atomic_int64_t;
 	{											\
 		int##radix##_t v = 0;								\
 		ATOMIC_IS_INITIALIZED(atomic);							\
-		fastlock_acquire(&atomic->lock);						\
+		ofi_spin_lock(&atomic->lock);						\
 		v = --(atomic->val);								\
-		fastlock_release(&atomic->lock);						\
+		ofi_spin_unlock(&atomic->lock);						\
 		return v;									\
 	}											\
 	static inline										\
@@ -285,9 +285,9 @@ typedef atomic_long	ofi_atomic_int64_t;
 					     int##radix##_t value)				\
 	{											\
 		ATOMIC_IS_INITIALIZED(atomic);							\
-		fastlock_acquire(&atomic->lock);						\
+		ofi_spin_lock(&atomic->lock);						\
 		atomic->val = value;								\
-		fastlock_release(&atomic->lock);						\
+		ofi_spin_unlock(&atomic->lock);						\
 		return value;									\
 	}											\
 	static inline int##radix##_t ofi_atomic_get##radix(ofi_atomic##radix##_t *atomic)	\
@@ -299,7 +299,7 @@ typedef atomic_long	ofi_atomic_int64_t;
 	void ofi_atomic_initialize##radix(ofi_atomic##radix##_t *atomic,			\
 					  int##radix##_t value)					\
 	{											\
-		fastlock_init(&atomic->lock);							\
+		ofi_spin_init(&atomic->lock);							\
 		atomic->val = value;								\
 		ATOMIC_INIT(atomic);								\
 	}											\
@@ -309,10 +309,10 @@ typedef atomic_long	ofi_atomic_int64_t;
 	{											\
 		int##radix##_t v;								\
 		ATOMIC_IS_INITIALIZED(atomic);							\
-		fastlock_acquire(&atomic->lock);						\
+		ofi_spin_lock(&atomic->lock);						\
 		atomic->val += val;								\
 		v = atomic->val;								\
-		fastlock_release(&atomic->lock);						\
+		ofi_spin_unlock(&atomic->lock);						\
 		return v;									\
 	}											\
 	static inline										\
@@ -321,10 +321,10 @@ typedef atomic_long	ofi_atomic_int64_t;
 	{											\
 		int##radix##_t v;								\
 		ATOMIC_IS_INITIALIZED(atomic);							\
-		fastlock_acquire(&atomic->lock);						\
+		ofi_spin_lock(&atomic->lock);						\
 		atomic->val -= val;								\
 		v = atomic->val;								\
-		fastlock_release(&atomic->lock);						\
+		ofi_spin_unlock(&atomic->lock);						\
 		return v;									\
 	}											\
 	static inline										\
@@ -334,12 +334,12 @@ typedef atomic_long	ofi_atomic_int64_t;
 	{											\
 		bool ret = false;								\
 		ATOMIC_IS_INITIALIZED(atomic);							\
-		fastlock_acquire(&atomic->lock);						\
+		ofi_spin_lock(&atomic->lock);						\
 		if (atomic->val == expected) {							\
 			atomic->val = desired;							\
 			ret = true;								\
 		}										\
-		fastlock_release(&atomic->lock);						\
+		ofi_spin_unlock(&atomic->lock);						\
 		return ret;									\
 	}											\
 	static inline										\

--- a/include/ofi_coll.h
+++ b/include/ofi_coll.h
@@ -79,7 +79,7 @@ struct util_av_set {
 	uint64_t		flags;
 	struct util_coll_mc     coll_mc;
 	ofi_atomic32_t		ref;
-	fastlock_t		lock;
+	ofi_spin_t		lock;
 };
 
 enum coll_work_type {

--- a/include/ofi_coll.h
+++ b/include/ofi_coll.h
@@ -79,7 +79,7 @@ struct util_av_set {
 	uint64_t		flags;
 	struct util_coll_mc     coll_mc;
 	ofi_atomic32_t		ref;
-	ofi_spin_t		lock;
+	ofi_mutex_t		lock;
 };
 
 enum coll_work_type {

--- a/include/ofi_epoll.h
+++ b/include/ofi_epoll.h
@@ -78,7 +78,7 @@ struct ofi_pollfds {
 	void		**context;
 	struct fd_signal signal;
 	struct slist	work_item_list;
-	fastlock_t	lock;
+	ofi_spin_t	lock;
 };
 
 int ofi_pollfds_create(struct ofi_pollfds **pfds);

--- a/include/ofi_epoll.h
+++ b/include/ofi_epoll.h
@@ -78,7 +78,7 @@ struct ofi_pollfds {
 	void		**context;
 	struct fd_signal signal;
 	struct slist	work_item_list;
-	ofi_spin_t	lock;
+	ofi_mutex_t	lock;
 };
 
 int ofi_pollfds_create(struct ofi_pollfds **pfds);

--- a/include/ofi_list.h
+++ b/include/ofi_list.h
@@ -239,12 +239,12 @@ static inline void dlist_splice_tail(struct dlist_entry *head,
  */
 struct dlist_ts {
 	struct dlist_entry	head;
-	fastlock_t		lock;
+	ofi_spin_t		lock;
 };
 
 static inline void dlist_ts_init(struct dlist_ts *list)
 {
-	fastlock_init(&list->lock);
+	ofi_spin_init(&list->lock);
 	dlist_init(&list->head);
 }
 
@@ -257,9 +257,9 @@ static inline void
 dlist_ts_insert_after(struct dlist_ts *list, struct dlist_entry *item,
 		      struct dlist_entry *head)
 {
-	fastlock_acquire(&list->lock);
+	ofi_spin_lock(&list->lock);
 	dlist_insert_after(item, head);
-	fastlock_release(&list->lock);
+	ofi_spin_unlock(&list->lock);
 }
 
 static inline void
@@ -275,68 +275,68 @@ dlist_ts_insert_before(struct dlist_ts *list, struct dlist_entry *item,
 static inline void
 dlist_ts_remove(struct dlist_ts *list, struct dlist_entry *item)
 {
-	fastlock_acquire(&list->lock);
+	ofi_spin_lock(&list->lock);
 	dlist_remove(item);
-	fastlock_release(&list->lock);
+	ofi_spin_unlock(&list->lock);
 }
 
 #define dlist_ts_pop_front(list, type, container, member)		\
 	do {								\
-		fastlock_acquire(&(list)->lock);			\
+		ofi_spin_lock(&(list)->lock);			\
 		if (dlist_ts_empty(list)) {				\
 			container = NULL;				\
 		} else {						\
 			dlist_pop_front(&(list)->head, type,		\
 					container, member);		\
 		}							\
-		fastlock_release(&(list)->lock);			\
+		ofi_spin_unlock(&(list)->lock);			\
 	} while (0)
 
 #define dlist_ts_foreach_end(list)				\
-		fastlock_release(&(list)->lock);		\
+		ofi_spin_unlock(&(list)->lock);		\
 	} while (0)
 
 #define dlist_ts_foreach(list, head, item)			\
 	{							\
-		fastlock_acquire(&(list)->lock);		\
+		ofi_spin_lock(&(list)->lock);		\
 		dlist_foreach(list, head, item)
 
 #define dlist_ts_foreach_reverse(list, head, item)		\
 	{							\
-		fastlock_acquire(&(list)->lock);		\
+		ofi_spin_lock(&(list)->lock);		\
 		dlist_foreach_reverse(list, head, item)
 
 #define dlist_ts_foreach_container(list, head, type, container, member)		\
 	{									\
-		fastlock_acquire(&(list)->lock);				\
+		ofi_spin_lock(&(list)->lock);				\
 		dlist_foreach_container(type, container, member)
 
 #define dlist_ts_foreach_container_reverse(list, head, type, container, member)\
 	{									\
-		fastlock_acquire(&(list)->lock);				\
+		ofi_spin_lock(&(list)->lock);				\
 		dlist_foreach_container_reverse(type, container, member)
 
 #define dlist_ts_foreach_safe(list, head, item, tmp)				\
 	{									\
-		fastlock_acquire(&(list)->lock);				\
+		ofi_spin_lock(&(list)->lock);				\
 		dlist_foreach_safe(head, item, tmp)
 
 #define dlist_ts_foreach_reverse_safe(list, head, item, tmp)			\
 	{									\
-		fastlock_acquire(&(list)->lock);				\
+		ofi_spin_lock(&(list)->lock);				\
 		dlist_foreach_reverse_safe(head, item, tmp)
 
 #define dlist_ts_foreach_container_safe(list, head, type, container,	\
 					member, tmp)			\
 	{								\
-		fastlock_acquire(&(list)->lock);			\
+		ofi_spin_lock(&(list)->lock);			\
 		dlist_foreach_container_safe(head, type, container,	\
 					     member, tmp)
 
 #define dlist_ts_foreach_container_reverse_safe(list, head, type, container,\
 					member, tmp)				\
 	{									\
-		fastlock_acquire(&(list)->lock);				\
+		ofi_spin_lock(&(list)->lock);				\
 		dlist_foreach_container_reverse_safe(head, type, container,	\
 					     member, tmp)
 
@@ -346,9 +346,9 @@ dlist_ts_find_first_match(struct dlist_ts *list, struct dlist_entry *head,
 {
 	struct dlist_entry *item;
 
-	fastlock_acquire(&list->lock);
+	ofi_spin_lock(&list->lock);
 	item = dlist_find_first_match(head, match, arg);
-	fastlock_release(&list->lock);
+	ofi_spin_unlock(&list->lock);
 
 	return item;
 }
@@ -359,18 +359,18 @@ dlist_ts_remove_first_match(struct dlist_ts *list, struct dlist_entry *head,
 {
 	struct dlist_entry *item;
 
-	fastlock_acquire(&list->lock);
+	ofi_spin_lock(&list->lock);
 	item = dlist_remove_first_match(head, match, arg);
-	fastlock_release(&list->lock);
+	ofi_spin_unlock(&list->lock);
 
 	return item;
 }
 
 #define dlist_ts_splice_head(list, head, to_splice)	\
 	{						\
-		fastlock_acquire(&(list)->lock);	\
+		ofi_spin_lock(&(list)->lock);	\
 		dlist_splice_head(head, to_splice);	\
-		fastlock_release(&list->lock);		\
+		ofi_spin_unlock(&list->lock);		\
 	} while(0)
 
 #define dlist_ts_splice_tail(list, head, to_splice)		\

--- a/include/ofi_lock.h
+++ b/include/ofi_lock.h
@@ -138,6 +138,19 @@ static inline int fastlock_held(fastlock_t *lock)
 	return lock->in_use;
 }
 
+static inline void ofi_fastlock_acquire_noop(fastlock_t *lock)
+{
+	/* These non-op routines must be used only by single-threaded code*/
+	assert(!lock->in_use);
+	lock->in_use = 1;
+}
+
+static inline void ofi_fastlock_release_noop(fastlock_t *lock)
+{
+	assert(lock->in_use);
+	lock->in_use = 0;
+}
+
 #else /* !ENABLE_DEBUG */
 
 #  define fastlock_t fastlock_t_
@@ -148,6 +161,16 @@ static inline int fastlock_held(fastlock_t *lock)
 #  define fastlock_release(lock) fastlock_release_(lock)
 #  define fastlock_held(lock) true
 
+static inline void ofi_fastlock_acquire_noop(fastlock_t *lock)
+{
+	(void) lock;
+}
+
+static inline void ofi_fastlock_release_noop(fastlock_t *lock)
+{
+	(void) lock;
+}
+
 #endif
 
 typedef void(*ofi_fastlock_acquire_t)(fastlock_t *lock);
@@ -157,28 +180,10 @@ static inline void ofi_fastlock_acquire(fastlock_t *lock)
 {
 	fastlock_acquire(lock);
 }
+
 static inline void ofi_fastlock_release(fastlock_t *lock)
 {
 	fastlock_release(lock);
-}
-static inline void ofi_fastlock_acquire_noop(fastlock_t *lock)
-{
-#if ENABLE_DEBUG
-	/* These non-op routines must be used only by a single-threaded code*/
-	assert(!lock->in_use);
-	lock->in_use = 1;
-#else
-	(void) lock;
-#endif
-}
-static inline void ofi_fastlock_release_noop(fastlock_t *lock)
-{
-#if ENABLE_DEBUG
-	assert(lock->in_use);
-	lock->in_use = 0;
-#else
-	(void) lock;
-#endif
 }
 
 #ifdef __cplusplus

--- a/include/ofi_lock.h
+++ b/include/ofi_lock.h
@@ -48,7 +48,7 @@ extern "C" {
 #endif
 
 
-int fi_wait_cond(pthread_cond_t *cond, pthread_mutex_t *mut, int timeout_ms);
+int ofi_wait_cond(pthread_cond_t *cond, pthread_mutex_t *mut, int timeout_ms);
 
 
 #if PT_LOCK_SPIN == 1

--- a/include/ofi_lock.h
+++ b/include/ofi_lock.h
@@ -53,99 +53,99 @@ int fi_wait_cond(pthread_cond_t *cond, pthread_mutex_t *mut, int timeout_ms);
 
 #if PT_LOCK_SPIN == 1
 
-#define fastlock_t_ pthread_spinlock_t
-#define fastlock_init_(lock) pthread_spin_init(lock, PTHREAD_PROCESS_PRIVATE)
-#define fastlock_destroy_(lock) pthread_spin_destroy(lock)
-#define fastlock_acquire_(lock) pthread_spin_lock(lock)
-#define fastlock_tryacquire_(lock) pthread_spin_trylock(lock)
-#define fastlock_release_(lock) pthread_spin_unlock(lock)
+#define ofi_spin_t_ pthread_spinlock_t
+#define ofi_spin_init_(lock) pthread_spin_init(lock, PTHREAD_PROCESS_PRIVATE)
+#define ofi_spin_destroy_(lock) pthread_spin_destroy(lock)
+#define ofi_spin_lock_(lock) pthread_spin_lock(lock)
+#define ofi_spin_trylock_(lock) pthread_spin_trylock(lock)
+#define ofi_spin_unlock_(lock) pthread_spin_unlock(lock)
 
 #else
 
-#define fastlock_t_ pthread_mutex_t
-#define fastlock_init_(lock) pthread_mutex_init(lock, NULL)
-#define fastlock_destroy_(lock) pthread_mutex_destroy(lock)
-#define fastlock_acquire_(lock) pthread_mutex_lock(lock)
-#define fastlock_tryacquire_(lock) pthread_mutex_trylock(lock)
-#define fastlock_release_(lock) pthread_mutex_unlock(lock)
+#define ofi_spin_t_ pthread_mutex_t
+#define ofi_spin_init_(lock) pthread_mutex_init(lock, NULL)
+#define ofi_spin_destroy_(lock) pthread_mutex_destroy(lock)
+#define ofi_spin_lock_(lock) pthread_mutex_lock(lock)
+#define ofi_spin_trylock_(lock) pthread_mutex_trylock(lock)
+#define ofi_spin_unlock_(lock) pthread_mutex_unlock(lock)
 
 #endif /* PT_LOCK_SPIN */
 
 #if ENABLE_DEBUG
 
 typedef struct {
-	fastlock_t_ impl;
+	ofi_spin_t_ impl;
 	int is_initialized;
 	int in_use;
-} fastlock_t;
+} ofi_spin_t;
 
-static inline int fastlock_init(fastlock_t *lock)
+static inline int ofi_spin_init(ofi_spin_t *lock)
 {
 	int ret;
 
-	ret = fastlock_init_(&lock->impl);
+	ret = ofi_spin_init_(&lock->impl);
 	lock->is_initialized = !ret;
 	lock->in_use = 0;
 
 	return ret;
 }
 
-static inline void fastlock_destroy(fastlock_t *lock)
+static inline void ofi_spin_destroy(ofi_spin_t *lock)
 {
 	int ret;
 
 	assert(lock->is_initialized);
 	lock->is_initialized = 0;
-	ret = fastlock_destroy_(&lock->impl);
+	ret = ofi_spin_destroy_(&lock->impl);
 	assert(!ret);
 }
 
-static inline void fastlock_acquire(fastlock_t *lock)
+static inline void ofi_spin_lock(ofi_spin_t *lock)
 {
 	int ret;
 
 	assert(lock->is_initialized);
-	ret = fastlock_acquire_(&lock->impl);
+	ret = ofi_spin_lock_(&lock->impl);
 	assert(!ret);
 	lock->in_use++;
 }
 
-static inline int fastlock_tryacquire(fastlock_t *lock)
+static inline int ofi_spin_trylock(ofi_spin_t *lock)
 {
 	int ret;
 
 	assert(lock->is_initialized);
-	ret = fastlock_tryacquire_(&lock->impl);
+	ret = ofi_spin_trylock_(&lock->impl);
 	if (!ret)
 		lock->in_use++;
 
 	return ret;
 }
 
-static inline void fastlock_release(fastlock_t *lock)
+static inline void ofi_spin_unlock(ofi_spin_t *lock)
 {
 	int ret;
 
 	assert(lock->in_use);
 	assert(lock->is_initialized);
 	lock->in_use--;
-	ret = fastlock_release_(&lock->impl);
+	ret = ofi_spin_unlock_(&lock->impl);
 	assert(!ret);
 }
 
-static inline int fastlock_held(fastlock_t *lock)
+static inline int ofi_spin_held(ofi_spin_t *lock)
 {
 	return lock->in_use;
 }
 
-static inline void ofi_fastlock_acquire_noop(fastlock_t *lock)
+static inline void ofi_spin_lock_noop(ofi_spin_t *lock)
 {
 	/* These non-op routines must be used only by single-threaded code*/
 	assert(!lock->in_use);
 	lock->in_use = 1;
 }
 
-static inline void ofi_fastlock_release_noop(fastlock_t *lock)
+static inline void ofi_spin_unlock_noop(ofi_spin_t *lock)
 {
 	assert(lock->in_use);
 	lock->in_use = 0;
@@ -153,37 +153,37 @@ static inline void ofi_fastlock_release_noop(fastlock_t *lock)
 
 #else /* !ENABLE_DEBUG */
 
-#  define fastlock_t fastlock_t_
-#  define fastlock_init(lock) fastlock_init_(lock)
-#  define fastlock_destroy(lock) fastlock_destroy_(lock)
-#  define fastlock_acquire(lock) fastlock_acquire_(lock)
-#  define fastlock_tryacquire(lock) fastlock_tryacquire_(lock)
-#  define fastlock_release(lock) fastlock_release_(lock)
-#  define fastlock_held(lock) true
+#  define ofi_spin_t ofi_spin_t_
+#  define ofi_spin_init(lock) ofi_spin_init_(lock)
+#  define ofi_spin_destroy(lock) ofi_spin_destroy_(lock)
+#  define ofi_spin_lock(lock) ofi_spin_lock_(lock)
+#  define ofi_spin_trylock(lock) ofi_spin_trylock_(lock)
+#  define ofi_spin_unlock(lock) ofi_spin_unlock_(lock)
+#  define ofi_spin_held(lock) true
 
-static inline void ofi_fastlock_acquire_noop(fastlock_t *lock)
+static inline void ofi_spin_lock_noop(ofi_spin_t *lock)
 {
 	(void) lock;
 }
 
-static inline void ofi_fastlock_release_noop(fastlock_t *lock)
+static inline void ofi_spin_unlock_noop(ofi_spin_t *lock)
 {
 	(void) lock;
 }
 
 #endif
 
-typedef void(*ofi_fastlock_acquire_t)(fastlock_t *lock);
-typedef void(*ofi_fastlock_release_t)(fastlock_t *lock);
+typedef void(*ofi_spin_lock_t)(ofi_spin_t *lock);
+typedef void(*ofi_spin_unlock_t)(ofi_spin_t *lock);
 
-static inline void ofi_fastlock_acquire(fastlock_t *lock)
+static inline void ofi_spin_lock_op(ofi_spin_t *lock)
 {
-	fastlock_acquire(lock);
+	ofi_spin_lock(lock);
 }
 
-static inline void ofi_fastlock_release(fastlock_t *lock)
+static inline void ofi_spin_unlock_op(ofi_spin_t *lock)
 {
-	fastlock_release(lock);
+	ofi_spin_unlock(lock);
 }
 
 

--- a/include/ofi_lock.h
+++ b/include/ofi_lock.h
@@ -186,6 +186,130 @@ static inline void ofi_fastlock_release(fastlock_t *lock)
 	fastlock_release(lock);
 }
 
+
+#define ofi_mutex_t_ pthread_mutex_t
+#define ofi_mutex_init_(lock) pthread_mutex_init(lock, NULL)
+#define ofi_mutex_destroy_(lock) pthread_mutex_destroy(lock)
+#define ofi_mutex_lock_(lock) pthread_mutex_lock(lock)
+#define ofi_mutex_trylock_(lock) pthread_mutex_trylock(lock)
+#define ofi_mutex_unlock_(lock) pthread_mutex_unlock(lock)
+
+#if ENABLE_DEBUG
+
+typedef struct {
+	ofi_mutex_t_ impl;
+	int is_initialized;
+	int in_use;
+} ofi_mutex_t;
+
+static inline int ofi_mutex_init(ofi_mutex_t *lock)
+{
+	int ret;
+
+	ret = ofi_mutex_init_(&lock->impl);
+	lock->is_initialized = !ret;
+	lock->in_use = 0;
+
+	return ret;
+}
+
+static inline void ofi_mutex_destroy(ofi_mutex_t *lock)
+{
+	int ret;
+
+	assert(lock->is_initialized);
+	lock->is_initialized = 0;
+	ret = ofi_mutex_destroy_(&lock->impl);
+	assert(!ret);
+}
+
+static inline void ofi_mutex_lock(ofi_mutex_t *lock)
+{
+	int ret;
+
+	assert(lock->is_initialized);
+	ret = ofi_mutex_lock_(&lock->impl);
+	assert(!ret);
+	lock->in_use++;
+}
+
+static inline int ofi_mutex_trylock(ofi_mutex_t *lock)
+{
+	int ret;
+
+	assert(lock->is_initialized);
+	ret = ofi_mutex_trylock_(&lock->impl);
+	if (!ret)
+		lock->in_use++;
+
+	return ret;
+}
+
+static inline void ofi_mutex_unlock(ofi_mutex_t *lock)
+{
+	int ret;
+
+	assert(lock->in_use);
+	assert(lock->is_initialized);
+	lock->in_use--;
+	ret = ofi_mutex_unlock_(&lock->impl);
+	assert(!ret);
+}
+
+static inline int ofi_mutex_held(ofi_mutex_t *lock)
+{
+	return lock->in_use;
+}
+
+static inline void ofi_mutex_lock_noop(ofi_mutex_t *lock)
+{
+	/* These non-op routines must be used only by single-threaded code*/
+	assert(!lock->in_use);
+	lock->in_use = 1;
+}
+
+static inline void ofi_mutex_unlock_noop(ofi_mutex_t *lock)
+{
+	assert(lock->in_use);
+	lock->in_use = 0;
+}
+
+#else /* !ENABLE_DEBUG */
+
+#  define ofi_mutex_t ofi_mutex_t_
+#  define ofi_mutex_init(lock) ofi_mutex_init_(lock)
+#  define ofi_mutex_destroy(lock) ofi_mutex_destroy_(lock)
+#  define ofi_mutex_lock(lock) ofi_mutex_lock_(lock)
+#  define ofi_mutex_trylock(lock) ofi_mutex_trylock_(lock)
+#  define ofi_mutex_unlock(lock) ofi_mutex_unlock_(lock)
+#  define ofi_mutex_held(lock) true
+
+static inline void ofi_mutex_lock_noop(ofi_mutex_t *lock)
+{
+	(void) lock;
+}
+
+static inline void ofi_mutex_unlock_noop(ofi_mutex_t *lock)
+{
+	(void) lock;
+}
+
+#endif
+
+typedef void(*ofi_mutex_lock_t)(ofi_mutex_t *lock);
+typedef void(*ofi_mutex_unlock_t)(ofi_mutex_t *lock);
+
+static inline void ofi_mutex_lock_op(ofi_mutex_t *lock)
+{
+	ofi_mutex_lock(lock);
+}
+
+static inline void ofi_mutex_unlock_op(ofi_mutex_t *lock)
+{
+	ofi_mutex_unlock(lock);
+}
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -228,7 +228,7 @@ struct smr_peer {
 #define SMR_MAX_PEERS	256
 
 struct smr_map {
-	fastlock_t		lock;
+	ofi_spin_t		lock;
 	int64_t			cur_id;
 	struct ofi_rbmap	rbmap;
 	struct smr_peer		peers[SMR_MAX_PEERS];

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -184,7 +184,7 @@ struct util_fabric_info {
 struct util_fabric {
 	struct fid_fabric	fabric_fid;
 	struct dlist_entry	list_entry;
-	ofi_spin_t		lock;
+	ofi_mutex_t		lock;
 	ofi_atomic32_t		ref;
 	const char		*name;
 	const struct fi_provider *prov;
@@ -207,7 +207,7 @@ struct util_domain {
 	struct dlist_entry	list_entry;
 	struct util_fabric	*fabric;
 	struct util_eq		*eq;
-	ofi_spin_t		lock;
+	ofi_mutex_t		lock;
 	ofi_atomic32_t		ref;
 	const struct fi_provider *prov;
 
@@ -308,7 +308,7 @@ struct util_ep {
 	uint64_t		flags;
 	ofi_ep_progress_func	progress;
 	ofi_spin_t		lock;
-	ofi_spin_lock_t	lock_acquire;
+	ofi_spin_lock_t		lock_acquire;
 	ofi_spin_unlock_t	lock_release;
 
 	struct bitmask		*coll_cid_mask;
@@ -429,7 +429,7 @@ struct util_wait {
 	fi_wait_try_func	wait_try;
 
 	struct dlist_entry	fid_list;
-	ofi_spin_t		lock;
+	ofi_mutex_t		lock;
 };
 
 int ofi_wait_init(struct util_fabric *fabric, struct fi_wait_attr *attr,
@@ -482,7 +482,7 @@ int ofi_wait_del_fid(struct util_wait *wait, fid_t fid);
 struct util_wait_yield {
 	struct util_wait	util_wait;
 	int			signal;
-	ofi_spin_t		signal_lock;
+	ofi_mutex_t		signal_lock;
 };
 
 int ofi_wait_yield_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
@@ -721,7 +721,7 @@ struct util_av {
 	struct util_domain	*domain;
 	struct util_eq		*eq;
 	ofi_atomic32_t		ref;
-	ofi_spin_t		lock;
+	ofi_mutex_t		lock;
 	const struct fi_provider *prov;
 
 	struct util_av_entry	*hash;
@@ -816,7 +816,7 @@ struct util_poll {
 	struct fid_poll		poll_fid;
 	struct util_domain	*domain;
 	struct dlist_entry	fid_list;
-	ofi_spin_t		lock;
+	ofi_mutex_t		lock;
 	ofi_atomic32_t		ref;
 	const struct fi_provider *prov;
 };
@@ -833,7 +833,7 @@ struct util_eq {
 	struct fid_eq		eq_fid;
 	struct util_fabric	*fabric;
 	struct util_wait	*wait;
-	ofi_spin_t		lock;
+	ofi_mutex_t		lock;
 	ofi_atomic32_t		ref;
 	const struct fi_provider *prov;
 

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -517,9 +517,11 @@ struct util_cq {
 	struct util_wait	*wait;
 	ofi_atomic32_t		ref;
 	struct dlist_entry	ep_list;
-	ofi_spin_t		ep_list_lock;
+	ofi_mutex_t		ep_list_lock;
 	ofi_spin_t		cq_lock;
-	ofi_spin_lock_t	cq_fastlock_acquire;
+	ofi_mutex_lock_t	cq_mutex_lock;
+	ofi_mutex_unlock_t	cq_mutex_unlock;
+	ofi_spin_lock_t		cq_fastlock_acquire;
 	ofi_spin_unlock_t	cq_fastlock_release;
 
 	struct util_comp_cirq	*cirq;
@@ -668,7 +670,7 @@ struct util_cntr {
 	uint64_t		checkpoint_err;
 
 	struct dlist_entry	ep_list;
-	ofi_spin_t		ep_list_lock;
+	ofi_mutex_t		ep_list_lock;
 
 	int			internal_wait;
 	ofi_cntr_progress_func	progress;
@@ -735,7 +737,7 @@ struct util_av {
 	 */
 	size_t			context_offset;
 	struct dlist_entry	ep_list;
-	ofi_spin_t		ep_list_lock;
+	ofi_mutex_t		ep_list_lock;
 };
 
 struct util_av_attr {

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -307,9 +307,9 @@ struct util_ep {
 	uint64_t		caps;
 	uint64_t		flags;
 	ofi_ep_progress_func	progress;
-	ofi_spin_t		lock;
-	ofi_spin_lock_t		lock_acquire;
-	ofi_spin_unlock_t	lock_release;
+	ofi_mutex_t		lock;
+	ofi_mutex_lock_t	lock_acquire;
+	ofi_mutex_unlock_t	lock_release;
 
 	struct bitmask		*coll_cid_mask;
 	struct slist		coll_ready_queue;
@@ -345,8 +345,8 @@ static inline void ofi_ep_lock_release(struct util_ep *ep)
 
 static inline bool ofi_ep_lock_held(struct util_ep *ep)
 {
-	return (ep->lock_acquire == ofi_spin_lock_noop) ||
-		ofi_spin_held(&ep->lock);
+	return (ep->lock_acquire == ofi_mutex_lock_noop) ||
+		ofi_mutex_held(&ep->lock);
 }
 
 static inline void ofi_ep_tx_cntr_inc(struct util_ep *ep)

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -518,11 +518,9 @@ struct util_cq {
 	ofi_atomic32_t		ref;
 	struct dlist_entry	ep_list;
 	ofi_mutex_t		ep_list_lock;
-	ofi_spin_t		cq_lock;
+	ofi_mutex_t		cq_lock;
 	ofi_mutex_lock_t	cq_mutex_lock;
 	ofi_mutex_unlock_t	cq_mutex_unlock;
-	ofi_spin_lock_t		cq_fastlock_acquire;
-	ofi_spin_unlock_t	cq_fastlock_release;
 
 	struct util_comp_cirq	*cirq;
 	fi_addr_t		*src;
@@ -592,7 +590,7 @@ ofi_cq_write(struct util_cq *cq, void *context, uint64_t flags, size_t len,
 {
 	int ret;
 
-	cq->cq_fastlock_acquire(&cq->cq_lock);
+	cq->cq_mutex_lock(&cq->cq_lock);
 	if (ofi_cirque_freecnt(cq->cirq) > 1) {
 		ofi_cq_write_entry(cq, context, flags, len, buf, data, tag);
 		ret = 0;
@@ -600,7 +598,7 @@ ofi_cq_write(struct util_cq *cq, void *context, uint64_t flags, size_t len,
 		ret = ofi_cq_write_overflow(cq, context, flags, len,
 					    buf, data, tag, FI_ADDR_NOTAVAIL);
 	}
-	cq->cq_fastlock_release(&cq->cq_lock);
+	cq->cq_mutex_unlock(&cq->cq_lock);
 	return ret;
 }
 
@@ -610,7 +608,7 @@ ofi_cq_write_src(struct util_cq *cq, void *context, uint64_t flags, size_t len,
 {
 	int ret;
 
-	cq->cq_fastlock_acquire(&cq->cq_lock);
+	cq->cq_mutex_lock(&cq->cq_lock);
 	if (ofi_cirque_freecnt(cq->cirq) > 1) {
 		ofi_cq_write_src_entry(cq, context, flags, len, buf, data,
 				       tag, src);
@@ -619,7 +617,7 @@ ofi_cq_write_src(struct util_cq *cq, void *context, uint64_t flags, size_t len,
 		ret = ofi_cq_write_overflow(cq, context, flags, len,
 					    buf, data, tag, src);
 	}
-	cq->cq_fastlock_release(&cq->cq_lock);
+	cq->cq_mutex_unlock(&cq->cq_lock);
 	return ret;
 }
 

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -935,13 +935,9 @@ struct fid_list_entry {
 	struct fid		*fid;
 };
 
-int fid_list_insert(struct dlist_entry *fid_list, ofi_spin_t *lock,
+int fid_list_insert(struct dlist_entry *fid_list, ofi_mutex_t *lock,
 		    struct fid *fid);
-void fid_list_remove(struct dlist_entry *fid_list, ofi_spin_t *lock,
-		     struct fid *fid);
-int fid_list_insert_m(struct dlist_entry *fid_list, ofi_mutex_t *lock,
-		    struct fid *fid);
-void fid_list_remove_m(struct dlist_entry *fid_list, ofi_mutex_t *lock,
+void fid_list_remove(struct dlist_entry *fid_list, ofi_mutex_t *lock,
 		     struct fid *fid);
 
 

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -937,6 +937,11 @@ int fid_list_insert(struct dlist_entry *fid_list, ofi_spin_t *lock,
 		    struct fid *fid);
 void fid_list_remove(struct dlist_entry *fid_list, ofi_spin_t *lock,
 		     struct fid *fid);
+int fid_list_insert_m(struct dlist_entry *fid_list, ofi_mutex_t *lock,
+		    struct fid *fid);
+void fid_list_remove_m(struct dlist_entry *fid_list, ofi_mutex_t *lock,
+		     struct fid *fid);
+
 
 void ofi_fabric_insert(struct util_fabric *fabric);
 void ofi_fabric_remove(struct util_fabric *fabric);

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -824,7 +824,7 @@ static inline int ofi_syserr(void)
 	return winerr2bsderr(GetLastError());
 }
 
-static inline int fi_wait_cond(pthread_cond_t *cond, pthread_mutex_t *mut, int timeout_ms)
+static inline int ofi_wait_cond(pthread_cond_t *cond, pthread_mutex_t *mut, int timeout_ms)
 {
 	return !SleepConditionVariableCS(cond, mut, (DWORD)timeout_ms);
 }

--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -253,7 +253,7 @@ struct efa_cq {
 	size_t			entry_size;
 	efa_cq_read_entry	read_entry;
 	struct slist		wcq;
-	fastlock_t		lock;
+	ofi_spin_t		lock;
 	struct ofi_bufpool	*wce_pool;
 
 	struct ibv_cq		*ibv_cq;
@@ -412,7 +412,7 @@ extern struct fi_ops_rma efa_ep_rma_ops;
 ssize_t efa_rma_post_read(struct efa_ep *ep, const struct fi_msg_rma *msg,
 			  uint64_t flags, bool self_comm);
 
-extern fastlock_t pd_list_lock;
+extern ofi_spin_t pd_list_lock;
 // This list has the same indicies as ctx_list.
 extern struct efa_pd *pd_list;
 

--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -692,7 +692,7 @@ int efa_av_insert_one(struct efa_av *av, struct efa_ep_addr *addr,
 	if (av->ep_type == FI_EP_DGRAM)
 		addr->qkey = EFA_DGRAM_CONNID;
 
-	fastlock_acquire(&av->util_av.lock);
+	ofi_spin_lock(&av->util_av.lock);
 	memset(raw_gid_str, 0, sizeof(raw_gid_str));
 	if (!inet_ntop(AF_INET6, addr->raw, raw_gid_str, INET6_ADDRSTRLEN)) {
 		EFA_WARN(FI_LOG_AV, "cannot convert address to string. errno: %d", errno);
@@ -728,7 +728,7 @@ int efa_av_insert_one(struct efa_av *av, struct efa_ep_addr *addr,
 		 raw_gid_str, addr->qpn, addr->qkey, *fi_addr);
 	ret = 0;
 out:
-	fastlock_release(&av->util_av.lock);
+	ofi_spin_unlock(&av->util_av.lock);
 	return ret;
 }
 
@@ -848,7 +848,7 @@ static int efa_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr,
 	if (av->type != FI_AV_MAP && av->type != FI_AV_TABLE)
 		return -FI_EINVAL;
 
-	fastlock_acquire(&av->util_av.lock);
+	ofi_spin_lock(&av->util_av.lock);
 	for (i = 0; i < count; i++) {
 		conn = efa_av_addr_to_conn(av, fi_addr[i]);
 		if (!conn) {
@@ -868,7 +868,7 @@ static int efa_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr,
 		}
 	}
 
-	fastlock_release(&av->util_av.lock);
+	ofi_spin_unlock(&av->util_av.lock);
 	return err;
 }
 
@@ -893,7 +893,7 @@ static void efa_av_close_reverse_av(struct efa_av *av)
 	struct efa_cur_reverse_av *cur_entry, *curtmp;
 	struct efa_prv_reverse_av *prv_entry, *prvtmp;
 
-	fastlock_acquire(&av->util_av.lock);
+	ofi_spin_lock(&av->util_av.lock);
 
 	HASH_ITER(hh, av->cur_reverse_av, cur_entry, curtmp) {
 		efa_conn_release(av, cur_entry->conn);
@@ -903,7 +903,7 @@ static void efa_av_close_reverse_av(struct efa_av *av)
 		efa_conn_release(av, prv_entry->conn);
 	}
 
-	fastlock_release(&av->util_av.lock);
+	ofi_spin_unlock(&av->util_av.lock);
 }
 
 static int efa_av_close(struct fid *fid)

--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -692,7 +692,7 @@ int efa_av_insert_one(struct efa_av *av, struct efa_ep_addr *addr,
 	if (av->ep_type == FI_EP_DGRAM)
 		addr->qkey = EFA_DGRAM_CONNID;
 
-	ofi_spin_lock(&av->util_av.lock);
+	ofi_mutex_lock(&av->util_av.lock);
 	memset(raw_gid_str, 0, sizeof(raw_gid_str));
 	if (!inet_ntop(AF_INET6, addr->raw, raw_gid_str, INET6_ADDRSTRLEN)) {
 		EFA_WARN(FI_LOG_AV, "cannot convert address to string. errno: %d", errno);
@@ -728,7 +728,7 @@ int efa_av_insert_one(struct efa_av *av, struct efa_ep_addr *addr,
 		 raw_gid_str, addr->qpn, addr->qkey, *fi_addr);
 	ret = 0;
 out:
-	ofi_spin_unlock(&av->util_av.lock);
+	ofi_mutex_unlock(&av->util_av.lock);
 	return ret;
 }
 
@@ -848,7 +848,7 @@ static int efa_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr,
 	if (av->type != FI_AV_MAP && av->type != FI_AV_TABLE)
 		return -FI_EINVAL;
 
-	ofi_spin_lock(&av->util_av.lock);
+	ofi_mutex_lock(&av->util_av.lock);
 	for (i = 0; i < count; i++) {
 		conn = efa_av_addr_to_conn(av, fi_addr[i]);
 		if (!conn) {
@@ -868,7 +868,7 @@ static int efa_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr,
 		}
 	}
 
-	ofi_spin_unlock(&av->util_av.lock);
+	ofi_mutex_unlock(&av->util_av.lock);
 	return err;
 }
 
@@ -893,7 +893,7 @@ static void efa_av_close_reverse_av(struct efa_av *av)
 	struct efa_cur_reverse_av *cur_entry, *curtmp;
 	struct efa_prv_reverse_av *prv_entry, *prvtmp;
 
-	ofi_spin_lock(&av->util_av.lock);
+	ofi_mutex_lock(&av->util_av.lock);
 
 	HASH_ITER(hh, av->cur_reverse_av, cur_entry, curtmp) {
 		efa_conn_release(av, cur_entry->conn);
@@ -903,7 +903,7 @@ static void efa_av_close_reverse_av(struct efa_av *av)
 		efa_conn_release(av, prv_entry->conn);
 	}
 
-	ofi_spin_unlock(&av->util_av.lock);
+	ofi_mutex_unlock(&av->util_av.lock);
 }
 
 static int efa_av_close(struct fid *fid)

--- a/prov/efa/src/efa_device.c
+++ b/prov/efa/src/efa_device.c
@@ -105,7 +105,7 @@ int efa_lib_init(void)
 	* functions from efawin dll
 	*/
 	ret = efa_load_efawin_lib();
-	
+
 	return ret;
 }
 
@@ -117,7 +117,7 @@ int efa_device_init(void)
 	int ctx_idx;
 	int ret;
 
-	fastlock_init(&pd_list_lock);
+	ofi_spin_init(&pd_list_lock);
 
 	ret = efa_lib_init();
 	if (ret != 0) {
@@ -214,7 +214,7 @@ void efa_device_free(void)
 	free(ctx_list);
 	dev_cnt = 0;
 	efa_lib_close();
-	fastlock_destroy(&pd_list_lock);
+	ofi_spin_destroy(&pd_list_lock);
 }
 
 struct efa_context **efa_device_get_context_list(int *num_ctx)

--- a/prov/efa/src/efa_ep.c
+++ b/prov/efa/src/efa_ep.c
@@ -593,7 +593,7 @@ void efa_ep_progress(struct util_ep *ep)
 	rcq = efa_ep->rcq;
 	scq = efa_ep->scq;
 
-	fastlock_acquire(&ep->lock);
+	ofi_spin_lock(&ep->lock);
 
 	if (rcq)
 		efa_ep_progress_internal(efa_ep, rcq);
@@ -601,7 +601,7 @@ void efa_ep_progress(struct util_ep *ep)
 	if (scq && scq != rcq)
 		efa_ep_progress_internal(efa_ep, scq);
 
-	fastlock_release(&ep->lock);
+	ofi_spin_unlock(&ep->lock);
 }
 
 static struct fi_ops_atomic efa_ep_atomic_ops = {

--- a/prov/efa/src/efa_ep.c
+++ b/prov/efa/src/efa_ep.c
@@ -593,7 +593,7 @@ void efa_ep_progress(struct util_ep *ep)
 	rcq = efa_ep->rcq;
 	scq = efa_ep->scq;
 
-	ofi_spin_lock(&ep->lock);
+	ofi_mutex_lock(&ep->lock);
 
 	if (rcq)
 		efa_ep_progress_internal(efa_ep, rcq);
@@ -601,7 +601,7 @@ void efa_ep_progress(struct util_ep *ep)
 	if (scq && scq != rcq)
 		efa_ep_progress_internal(efa_ep, scq);
 
-	ofi_spin_unlock(&ep->lock);
+	ofi_mutex_unlock(&ep->lock);
 }
 
 static struct fi_ops_atomic efa_ep_atomic_ops = {

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -1015,22 +1015,22 @@ static inline uint64_t is_rx_res_full(struct rxr_ep *ep)
 
 static inline void rxr_rm_rx_cq_check(struct rxr_ep *ep, struct util_cq *rx_cq)
 {
-	ofi_spin_lock(&rx_cq->cq_lock);
+	ofi_mutex_lock(&rx_cq->cq_lock);
 	if (ofi_cirque_isfull(rx_cq->cirq))
 		ep->rm_full |= RXR_RM_RX_CQ_FULL;
 	else
 		ep->rm_full &= ~RXR_RM_RX_CQ_FULL;
-	ofi_spin_unlock(&rx_cq->cq_lock);
+	ofi_mutex_unlock(&rx_cq->cq_lock);
 }
 
 static inline void rxr_rm_tx_cq_check(struct rxr_ep *ep, struct util_cq *tx_cq)
 {
-	ofi_spin_lock(&tx_cq->cq_lock);
+	ofi_mutex_lock(&tx_cq->cq_lock);
 	if (ofi_cirque_isfull(tx_cq->cirq))
 		ep->rm_full |= RXR_RM_TX_CQ_FULL;
 	else
 		ep->rm_full &= ~RXR_RM_TX_CQ_FULL;
-	ofi_spin_unlock(&tx_cq->cq_lock);
+	ofi_mutex_unlock(&tx_cq->cq_lock);
 }
 
 #endif

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -1015,22 +1015,22 @@ static inline uint64_t is_rx_res_full(struct rxr_ep *ep)
 
 static inline void rxr_rm_rx_cq_check(struct rxr_ep *ep, struct util_cq *rx_cq)
 {
-	fastlock_acquire(&rx_cq->cq_lock);
+	ofi_spin_lock(&rx_cq->cq_lock);
 	if (ofi_cirque_isfull(rx_cq->cirq))
 		ep->rm_full |= RXR_RM_RX_CQ_FULL;
 	else
 		ep->rm_full &= ~RXR_RM_RX_CQ_FULL;
-	fastlock_release(&rx_cq->cq_lock);
+	ofi_spin_unlock(&rx_cq->cq_lock);
 }
 
 static inline void rxr_rm_tx_cq_check(struct rxr_ep *ep, struct util_cq *tx_cq)
 {
-	fastlock_acquire(&tx_cq->cq_lock);
+	ofi_spin_lock(&tx_cq->cq_lock);
 	if (ofi_cirque_isfull(tx_cq->cirq))
 		ep->rm_full |= RXR_RM_TX_CQ_FULL;
 	else
 		ep->rm_full &= ~RXR_RM_TX_CQ_FULL;
-	fastlock_release(&tx_cq->cq_lock);
+	ofi_spin_unlock(&tx_cq->cq_lock);
 }
 
 #endif

--- a/prov/efa/src/rxr/rxr_atomic.c
+++ b/prov/efa/src/rxr/rxr_atomic.c
@@ -140,7 +140,7 @@ ssize_t rxr_atomic_generic_efa(struct rxr_ep *rxr_ep,
 	if (efa_ep_is_cuda_mr(msg->desc[0]))
 		return -FI_ENOSYS;
 
-	fastlock_acquire(&rxr_ep->util_ep.lock);
+	ofi_spin_lock(&rxr_ep->util_ep.lock);
 
 	if (OFI_UNLIKELY(is_tx_res_full(rxr_ep))) {
 		err = -FI_EAGAIN;
@@ -221,7 +221,7 @@ ssize_t rxr_atomic_generic_efa(struct rxr_ep *rxr_ep,
 	}
 
 out:
-	fastlock_release(&rxr_ep->util_ep.lock);
+	ofi_spin_unlock(&rxr_ep->util_ep.lock);
 	efa_perfset_end(rxr_ep, perf_efa_tx);
 	return err;
 }
@@ -495,7 +495,7 @@ rxr_atomic_compwritev(struct fid_ep *ep,
 	rma_ioc.key = rma_key;
 
 	msg.msg_iov = iov;
-	msg.iov_count = count; 
+	msg.iov_count = count;
 	msg.desc = desc;
 	msg.addr = dest_addr;
 	msg.rma_iov = &rma_ioc;

--- a/prov/efa/src/rxr/rxr_atomic.c
+++ b/prov/efa/src/rxr/rxr_atomic.c
@@ -140,7 +140,7 @@ ssize_t rxr_atomic_generic_efa(struct rxr_ep *rxr_ep,
 	if (efa_ep_is_cuda_mr(msg->desc[0]))
 		return -FI_ENOSYS;
 
-	ofi_spin_lock(&rxr_ep->util_ep.lock);
+	ofi_mutex_lock(&rxr_ep->util_ep.lock);
 
 	if (OFI_UNLIKELY(is_tx_res_full(rxr_ep))) {
 		err = -FI_EAGAIN;
@@ -221,7 +221,7 @@ ssize_t rxr_atomic_generic_efa(struct rxr_ep *rxr_ep,
 	}
 
 out:
-	ofi_spin_unlock(&rxr_ep->util_ep.lock);
+	ofi_mutex_unlock(&rxr_ep->util_ep.lock);
 	efa_perfset_end(rxr_ep, perf_efa_tx);
 	return err;
 }

--- a/prov/efa/src/rxr/rxr_cq.c
+++ b/prov/efa/src/rxr/rxr_cq.c
@@ -55,7 +55,7 @@ static const char *rxr_cq_strerror(struct fid_cq *cq_fid, int prov_errno,
 
 	cq = container_of(cq_fid, struct util_cq, cq_fid);
 
-	fastlock_acquire(&cq->ep_list_lock);
+	ofi_spin_lock(&cq->ep_list_lock);
 	assert(!dlist_empty(&cq->ep_list));
 	fid_entry = container_of(cq->ep_list.next,
 				 struct fid_list_entry, entry);
@@ -63,7 +63,7 @@ static const char *rxr_cq_strerror(struct fid_cq *cq_fid, int prov_errno,
 	ep = container_of(util_ep, struct rxr_ep, util_ep);
 
 	str = fi_cq_strerror(ep->rdm_cq, prov_errno, err_data, buf, len);
-	fastlock_release(&cq->ep_list_lock);
+	ofi_spin_unlock(&cq->ep_list_lock);
 	return str;
 }
 

--- a/prov/efa/src/rxr/rxr_cq.c
+++ b/prov/efa/src/rxr/rxr_cq.c
@@ -55,7 +55,7 @@ static const char *rxr_cq_strerror(struct fid_cq *cq_fid, int prov_errno,
 
 	cq = container_of(cq_fid, struct util_cq, cq_fid);
 
-	ofi_spin_lock(&cq->ep_list_lock);
+	ofi_mutex_lock(&cq->ep_list_lock);
 	assert(!dlist_empty(&cq->ep_list));
 	fid_entry = container_of(cq->ep_list.next,
 				 struct fid_list_entry, entry);
@@ -63,7 +63,7 @@ static const char *rxr_cq_strerror(struct fid_cq *cq_fid, int prov_errno,
 	ep = container_of(util_ep, struct rxr_ep, util_ep);
 
 	str = fi_cq_strerror(ep->rdm_cq, prov_errno, err_data, buf, len);
-	ofi_spin_unlock(&cq->ep_list_lock);
+	ofi_mutex_unlock(&cq->ep_list_lock);
 	return str;
 }
 

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -111,7 +111,7 @@ struct rxr_rx_entry *rxr_ep_alloc_rx_entry(struct rxr_ep *ep, fi_addr_t addr, ui
 		 */
 		assert(op == ofi_op_msg || op == ofi_op_tagged);
 		rx_entry->peer = NULL;
-	} 
+	}
 
 	rx_entry->op = op;
 	switch (op) {
@@ -798,13 +798,13 @@ bool rxr_ep_has_unfinished_send(struct rxr_ep *rxr_ep)
 static inline
 void rxr_ep_wait_send(struct rxr_ep *rxr_ep)
 {
-	fastlock_acquire(&rxr_ep->util_ep.lock);
+	ofi_spin_lock(&rxr_ep->util_ep.lock);
 
 	while (rxr_ep_has_unfinished_send(rxr_ep)) {
 		rxr_ep_progress_internal(rxr_ep);
 	}
 
-	fastlock_release(&rxr_ep->util_ep.lock);
+	ofi_spin_unlock(&rxr_ep->util_ep.lock);
 }
 
 static int rxr_ep_close(struct fid *fid)
@@ -961,7 +961,7 @@ static int rxr_ep_ctrl(struct fid *fid, int command, void *arg)
 		if (ret)
 			return ret;
 
-		fastlock_acquire(&ep->util_ep.lock);
+		ofi_spin_lock(&ep->util_ep.lock);
 
 		rxr_ep_set_extra_info(ep);
 
@@ -992,7 +992,7 @@ static int rxr_ep_ctrl(struct fid *fid, int command, void *arg)
 		}
 
 out:
-		fastlock_release(&ep->util_ep.lock);
+		ofi_spin_unlock(&ep->util_ep.lock);
 		break;
 	default:
 		ret = -FI_ENOSYS;
@@ -1029,12 +1029,12 @@ static ssize_t rxr_ep_cancel_recv(struct rxr_ep *ep,
 	struct fi_cq_err_entry err_entry;
 	uint32_t api_version;
 
-	fastlock_acquire(&ep->util_ep.lock);
+	ofi_spin_lock(&ep->util_ep.lock);
 	entry = dlist_remove_first_match(recv_list,
 					 &rxr_ep_cancel_match_recv,
 					 context);
 	if (!entry) {
-		fastlock_release(&ep->util_ep.lock);
+		ofi_spin_unlock(&ep->util_ep.lock);
 		return 0;
 	}
 
@@ -1058,7 +1058,7 @@ static ssize_t rxr_ep_cancel_recv(struct rxr_ep *ep,
 		   rx_entry->rxr_flags & RXR_MULTI_RECV_CONSUMER) {
 		rxr_msg_multi_recv_handle_completion(ep, rx_entry);
 	}
-	fastlock_release(&ep->util_ep.lock);
+	ofi_spin_unlock(&ep->util_ep.lock);
 	memset(&err_entry, 0, sizeof(err_entry));
 	err_entry.op_context = rx_entry->cq_entry.op_context;
 	err_entry.flags |= rx_entry->cq_entry.flags;
@@ -2199,9 +2199,9 @@ void rxr_ep_progress(struct util_ep *util_ep)
 
 	ep = container_of(util_ep, struct rxr_ep, util_ep);
 
-	fastlock_acquire(&ep->util_ep.lock);
+	ofi_spin_lock(&ep->util_ep.lock);
 	rxr_ep_progress_internal(ep);
-	fastlock_release(&ep->util_ep.lock);
+	ofi_spin_unlock(&ep->util_ep.lock);
 }
 
 static

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -798,13 +798,13 @@ bool rxr_ep_has_unfinished_send(struct rxr_ep *rxr_ep)
 static inline
 void rxr_ep_wait_send(struct rxr_ep *rxr_ep)
 {
-	ofi_spin_lock(&rxr_ep->util_ep.lock);
+	ofi_mutex_lock(&rxr_ep->util_ep.lock);
 
 	while (rxr_ep_has_unfinished_send(rxr_ep)) {
 		rxr_ep_progress_internal(rxr_ep);
 	}
 
-	ofi_spin_unlock(&rxr_ep->util_ep.lock);
+	ofi_mutex_unlock(&rxr_ep->util_ep.lock);
 }
 
 static int rxr_ep_close(struct fid *fid)
@@ -961,7 +961,7 @@ static int rxr_ep_ctrl(struct fid *fid, int command, void *arg)
 		if (ret)
 			return ret;
 
-		ofi_spin_lock(&ep->util_ep.lock);
+		ofi_mutex_lock(&ep->util_ep.lock);
 
 		rxr_ep_set_extra_info(ep);
 
@@ -992,7 +992,7 @@ static int rxr_ep_ctrl(struct fid *fid, int command, void *arg)
 		}
 
 out:
-		ofi_spin_unlock(&ep->util_ep.lock);
+		ofi_mutex_unlock(&ep->util_ep.lock);
 		break;
 	default:
 		ret = -FI_ENOSYS;
@@ -1029,12 +1029,12 @@ static ssize_t rxr_ep_cancel_recv(struct rxr_ep *ep,
 	struct fi_cq_err_entry err_entry;
 	uint32_t api_version;
 
-	ofi_spin_lock(&ep->util_ep.lock);
+	ofi_mutex_lock(&ep->util_ep.lock);
 	entry = dlist_remove_first_match(recv_list,
 					 &rxr_ep_cancel_match_recv,
 					 context);
 	if (!entry) {
-		ofi_spin_unlock(&ep->util_ep.lock);
+		ofi_mutex_unlock(&ep->util_ep.lock);
 		return 0;
 	}
 
@@ -1058,7 +1058,7 @@ static ssize_t rxr_ep_cancel_recv(struct rxr_ep *ep,
 		   rx_entry->rxr_flags & RXR_MULTI_RECV_CONSUMER) {
 		rxr_msg_multi_recv_handle_completion(ep, rx_entry);
 	}
-	ofi_spin_unlock(&ep->util_ep.lock);
+	ofi_mutex_unlock(&ep->util_ep.lock);
 	memset(&err_entry, 0, sizeof(err_entry));
 	err_entry.op_context = rx_entry->cq_entry.op_context;
 	err_entry.flags |= rx_entry->cq_entry.flags;
@@ -2199,9 +2199,9 @@ void rxr_ep_progress(struct util_ep *util_ep)
 
 	ep = container_of(util_ep, struct rxr_ep, util_ep);
 
-	ofi_spin_lock(&ep->util_ep.lock);
+	ofi_mutex_lock(&ep->util_ep.lock);
 	rxr_ep_progress_internal(ep);
-	ofi_spin_unlock(&ep->util_ep.lock);
+	ofi_mutex_unlock(&ep->util_ep.lock);
 }
 
 static

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -278,7 +278,7 @@ ssize_t rxr_msg_generic_send(struct fid_ep *ep, const struct fi_msg *msg,
 	assert(msg->iov_count <= rxr_ep->tx_iov_limit);
 
 	efa_perfset_start(rxr_ep, perf_efa_tx);
-	ofi_spin_lock(&rxr_ep->util_ep.lock);
+	ofi_mutex_lock(&rxr_ep->util_ep.lock);
 
 	if (OFI_UNLIKELY(is_tx_res_full(rxr_ep))) {
 		err = -FI_EAGAIN;
@@ -311,7 +311,7 @@ ssize_t rxr_msg_generic_send(struct fid_ep *ep, const struct fi_msg *msg,
 	}
 
 out:
-	ofi_spin_unlock(&rxr_ep->util_ep.lock);
+	ofi_mutex_unlock(&rxr_ep->util_ep.lock);
 	efa_perfset_end(rxr_ep, perf_efa_tx);
 	return err;
 }
@@ -1051,7 +1051,7 @@ ssize_t rxr_msg_generic_recv(struct fid_ep *ep, const struct fi_msg *msg,
 		rx_op_flags &= ~FI_COMPLETION;
 	flags = flags | rx_op_flags;
 
-	ofi_spin_lock(&rxr_ep->util_ep.lock);
+	ofi_mutex_lock(&rxr_ep->util_ep.lock);
 	if (OFI_UNLIKELY(is_rx_res_full(rxr_ep))) {
 		ret = -FI_EAGAIN;
 		goto out;
@@ -1093,7 +1093,7 @@ ssize_t rxr_msg_generic_recv(struct fid_ep *ep, const struct fi_msg *msg,
 	}
 
 out:
-	ofi_spin_unlock(&rxr_ep->util_ep.lock);
+	ofi_mutex_unlock(&rxr_ep->util_ep.lock);
 
 	efa_perfset_end(rxr_ep, perf_efa_recv);
 	return ret;
@@ -1131,7 +1131,7 @@ ssize_t rxr_msg_claim_trecv(struct fid_ep *ep_fid,
 	struct fi_context *context;
 
 	ep = container_of(ep_fid, struct rxr_ep, util_ep.ep_fid.fid);
-	ofi_spin_lock(&ep->util_ep.lock);
+	ofi_mutex_lock(&ep->util_ep.lock);
 
 	context = (struct fi_context *)msg->context;
 	rx_entry = (struct rxr_rx_entry *)context->internal[0];
@@ -1155,7 +1155,7 @@ ssize_t rxr_msg_claim_trecv(struct fid_ep *ep_fid,
 					 msg->addr, ofi_op_tagged, flags);
 
 out:
-	ofi_spin_unlock(&ep->util_ep.lock);
+	ofi_mutex_unlock(&ep->util_ep.lock);
 	return ret;
 }
 
@@ -1175,7 +1175,7 @@ ssize_t rxr_msg_peek_trecv(struct fid_ep *ep_fid,
 
 	ep = container_of(ep_fid, struct rxr_ep, util_ep.ep_fid.fid);
 
-	ofi_spin_lock(&ep->util_ep.lock);
+	ofi_mutex_lock(&ep->util_ep.lock);
 
 	rxr_ep_progress_internal(ep);
 
@@ -1229,7 +1229,7 @@ ssize_t rxr_msg_peek_trecv(struct fid_ep *ep_fid,
 				   rx_entry->cq_entry.data, tag);
 	rxr_rm_rx_cq_check(ep, ep->util_ep.rx_cq);
 out:
-	ofi_spin_unlock(&ep->util_ep.lock);
+	ofi_mutex_unlock(&ep->util_ep.lock);
 	return ret;
 }
 

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -55,14 +55,14 @@ int rxr_rma_verified_copy_iov(struct rxr_ep *ep, struct efa_rma_iov *rma,
 	efa_ep = container_of(ep->rdm_ep, struct efa_ep, util_ep.ep_fid);
 
 	for (i = 0; i < count; i++) {
-		fastlock_acquire(&efa_ep->domain->util_domain.lock);
+		ofi_spin_lock(&efa_ep->domain->util_domain.lock);
 		ret = ofi_mr_map_verify(&efa_ep->domain->util_domain.mr_map,
 					(uintptr_t *)(&rma[i].addr),
 					rma[i].len, rma[i].key, flags,
 					&context);
 		efa_mr = context;
 		desc[i] = fi_mr_desc(&efa_mr->mr_fid);
-		fastlock_release(&efa_ep->domain->util_domain.lock);
+		ofi_spin_unlock(&efa_ep->domain->util_domain.lock);
 		if (ret) {
 			FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,
 				"MR verification failed (%s), addr: %lx key: %ld\n",
@@ -308,7 +308,7 @@ ssize_t rxr_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uint64_
 	assert(msg->iov_count <= rxr_ep->tx_iov_limit);
 
 	efa_perfset_start(rxr_ep, perf_efa_tx);
-	fastlock_acquire(&rxr_ep->util_ep.lock);
+	ofi_spin_lock(&rxr_ep->util_ep.lock);
 
 	if (OFI_UNLIKELY(is_tx_res_full(rxr_ep))) {
 		err = -FI_EAGAIN;
@@ -360,7 +360,7 @@ out:
 	if (OFI_UNLIKELY(err && tx_entry))
 		rxr_release_tx_entry(rxr_ep, tx_entry);
 
-	fastlock_release(&rxr_ep->util_ep.lock);
+	ofi_spin_unlock(&rxr_ep->util_ep.lock);
 	efa_perfset_end(rxr_ep, perf_efa_tx);
 	return err;
 }
@@ -506,7 +506,7 @@ ssize_t rxr_rma_writemsg(struct fid_ep *ep,
 	assert(msg->iov_count <= rxr_ep->tx_iov_limit);
 
 	efa_perfset_start(rxr_ep, perf_efa_tx);
-	fastlock_acquire(&rxr_ep->util_ep.lock);
+	ofi_spin_lock(&rxr_ep->util_ep.lock);
 
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
 	assert(peer);
@@ -528,7 +528,7 @@ ssize_t rxr_rma_writemsg(struct fid_ep *ep,
 		rxr_release_tx_entry(rxr_ep, tx_entry);
 	}
 out:
-	fastlock_release(&rxr_ep->util_ep.lock);
+	ofi_spin_unlock(&rxr_ep->util_ep.lock);
 	efa_perfset_end(rxr_ep, perf_efa_tx);
 	return err;
 }

--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -388,7 +388,7 @@ struct gnix_fid_domain {
 	struct dlist_entry nic_list;
 	struct gnix_fid_fabric *fabric;
 	struct gnix_cm_nic *cm_nic;
-	fastlock_t cm_nic_lock;
+	ofi_spin_t cm_nic_lock;
 	uint32_t cdm_id_seed;
 	uint32_t addr_format;
 	/* user tunable parameters accessed via open_ops functions */
@@ -403,7 +403,7 @@ struct gnix_fid_domain {
 	gnix_mr_cache_attr_t mr_cache_attr;
 	struct gnix_mr_cache_info *mr_cache_info;
 	struct gnix_mr_ops *mr_ops;
-	fastlock_t mr_cache_lock;
+	ofi_spin_t mr_cache_lock;
 	int mr_cache_type;
 	/* flag to indicate that memory registration is initialized and should not
 	 * be changed at this point.
@@ -439,7 +439,7 @@ struct gnix_fid_pep {
 	struct fi_info *info;
 	struct gnix_fid_eq *eq;
 	struct gnix_ep_name src_addr;
-	fastlock_t lock;
+	ofi_spin_t lock;
 	int listen_fd;
 	int backlog;
 	int bound;
@@ -479,7 +479,7 @@ struct gnix_int_tx_ptrs {
 struct gnix_int_tx_pool {
 	bool enabled;
 	int nbufs;
-	fastlock_t lock;
+	ofi_spin_t lock;
 	struct slist sl;
 	struct slist bl;
 };
@@ -524,7 +524,7 @@ struct gnix_fid_ep {
 	struct gnix_fid_stx *stx_ctx;
 	struct gnix_cm_nic *cm_nic;
 	struct gnix_nic *nic;
-	fastlock_t vc_lock;
+	ofi_spin_t vc_lock;
 	/* used for unexpected receives */
 	struct gnix_tag_storage unexp_recv_queue;
 	/* used for posted receives */
@@ -629,7 +629,7 @@ struct gnix_fid_sep {
 	struct gnix_cm_nic *cm_nic;
 	struct gnix_fid_av *av;
 	struct gnix_ep_name my_name;
-	fastlock_t sep_lock;
+	ofi_spin_t sep_lock;
 	struct gnix_reference ref_cnt;
 	struct gnix_auth_key *auth_key;
 };

--- a/prov/gni/include/gnix_auth_key.h
+++ b/prov/gni/include/gnix_auth_key.h
@@ -63,7 +63,7 @@
  * @var user        bitmap for detecting user key usage
  */
 struct gnix_auth_key {
-	fastlock_t lock;
+	ofi_spin_t lock;
 	struct gnix_auth_key_attr attr;
 	int enabled;
 	uint8_t ptag;

--- a/prov/gni/include/gnix_bitmap.h
+++ b/prov/gni/include/gnix_bitmap.h
@@ -32,7 +32,7 @@ typedef uint64_t gnix_bitmap_value_t;
 typedef atomic_uint_fast64_t gnix_bitmap_block_t;
 #else
 typedef struct atomic_uint64_t {
-	fastlock_t lock;
+	ofi_spin_t lock;
 	gnix_bitmap_value_t val;
 } gnix_bitmap_block_t;
 #endif
@@ -191,7 +191,7 @@ int _gnix_bitmap_empty(gnix_bitmap_t *bitmap);
 
 /**
  * Helper function for determining the size of array needed to support
- * 'x' number of bits for an externally provided buffer address 
+ * 'x' number of bits for an externally provided buffer address
  * @param   nbits  number of bits requested for the bitmap
  */
 __attribute__((unused))

--- a/prov/gni/include/gnix_buddy_allocator.h
+++ b/prov/gni/include/gnix_buddy_allocator.h
@@ -132,7 +132,7 @@ typedef struct gnix_buddy_alloc_handle {
 
 	gnix_bitmap_t bitmap;
 
-	fastlock_t lock;
+	ofi_spin_t lock;
 } gnix_buddy_alloc_handle_t;
 
 /**

--- a/prov/gni/include/gnix_cm_nic.h
+++ b/prov/gni/include/gnix_cm_nic.h
@@ -73,7 +73,7 @@ struct gnix_cm_nic {
 	struct gnix_dgram_hndl *dgram_hndl;
 	struct gnix_fid_domain *domain;
 	struct gnix_hashtable *addr_to_ep_ht;
-	fastlock_t wq_lock;
+	ofi_spin_t wq_lock;
 	struct dlist_entry cm_nic_wq;
 	struct gnix_reference ref_cnt;
 	enum fi_progress ctrl_progress;

--- a/prov/gni/include/gnix_cntr.h
+++ b/prov/gni/include/gnix_cntr.h
@@ -50,7 +50,7 @@ struct gnix_fid_cntr {
 	ofi_atomic32_t cnt_err;
 	struct gnix_reference ref_cnt;
 	struct dlist_entry trigger_list;
-	fastlock_t trigger_lock;
+	ofi_spin_t trigger_lock;
 	struct gnix_prog_set pset;
 	bool requires_lock;
 };

--- a/prov/gni/include/gnix_cq.h
+++ b/prov/gni/include/gnix_cq.h
@@ -69,7 +69,7 @@ struct gnix_fid_cq {
 
 	struct fid_wait *wait;
 
-	fastlock_t lock;
+	ofi_spin_t lock;
 	struct gnix_reference ref_cnt;
 
 	struct gnix_prog_set pset;

--- a/prov/gni/include/gnix_datagram.h
+++ b/prov/gni/include/gnix_datagram.h
@@ -125,7 +125,7 @@ struct gnix_dgram_hndl {
 	bool (*timeout_needed)(void *);
 	void (*timeout_progress)(void *);
 	void *timeout_data;
-	fastlock_t lock;
+	ofi_spin_t lock;
 	pthread_t progress_thread;
 	int n_dgrams;
 	int n_wc_dgrams;

--- a/prov/gni/include/gnix_ep.h
+++ b/prov/gni/include/gnix_ep.h
@@ -190,11 +190,11 @@ static inline struct slist_entry
 {
 	struct slist_entry *e;
 
-	fastlock_acquire(&ep->int_tx_pool.lock);
+	ofi_spin_lock(&ep->int_tx_pool.lock);
 
 	e = slist_remove_head(&ep->int_tx_pool.sl);
 
-	fastlock_release(&ep->int_tx_pool.lock);
+	ofi_spin_unlock(&ep->int_tx_pool.lock);
 
 	if (e == NULL) {
 		int ret;
@@ -203,9 +203,9 @@ static inline struct slist_entry
 		if (ret != FI_SUCCESS)
 			return NULL;
 
-		fastlock_acquire(&ep->int_tx_pool.lock);
+		ofi_spin_lock(&ep->int_tx_pool.lock);
 		e = slist_remove_head(&ep->int_tx_pool.sl);
-		fastlock_release(&ep->int_tx_pool.lock);
+		ofi_spin_unlock(&ep->int_tx_pool.lock);
 	}
 
 	return e;
@@ -219,14 +219,14 @@ static inline gni_mem_handle_t _gnix_ep_get_int_tx_mdh(void *e)
 static inline void _gnix_ep_release_int_tx_buf(struct gnix_fid_ep *ep,
 					       struct slist_entry *e)
 {
-	fastlock_acquire(&ep->int_tx_pool.lock);
+	ofi_spin_lock(&ep->int_tx_pool.lock);
 
 	GNIX_DEBUG(FI_LOG_EP_DATA, "sl.head = %p, sl.tail = %p\n",
 		   ep->int_tx_pool.sl.head, ep->int_tx_pool.sl.tail);
 
 	slist_insert_head(e, &ep->int_tx_pool.sl);
 
-	fastlock_release(&ep->int_tx_pool.lock);
+	ofi_spin_unlock(&ep->int_tx_pool.lock);
 }
 
 static inline struct gnix_fab_req *

--- a/prov/gni/include/gnix_eq.h
+++ b/prov/gni/include/gnix_eq.h
@@ -91,7 +91,7 @@ struct gnix_fid_eq {
 
 	struct fid_wait *wait;
 
-	fastlock_t lock;
+	ofi_spin_t lock;
 	struct gnix_reference ref_cnt;
 
 	rwlock_t poll_obj_lock;

--- a/prov/gni/include/gnix_freelist.h
+++ b/prov/gni/include/gnix_freelist.h
@@ -63,7 +63,7 @@ struct gnix_freelist {
 	int elem_size;
 	int offset;
 	int ts;
-	fastlock_t lock;
+	ofi_spin_t lock;
 };
 
 /** Initializes a gnix_freelist
@@ -122,7 +122,7 @@ static inline int _gnix_fl_alloc(struct dlist_entry **e, struct gnix_freelist *f
     assert(fl);
 
     if (fl->ts)
-	    fastlock_acquire(&fl->lock);
+	    ofi_spin_lock(&fl->lock);
 
     if (dlist_empty(&fl->freelist)) {
 
@@ -158,7 +158,7 @@ static inline int _gnix_fl_alloc(struct dlist_entry **e, struct gnix_freelist *f
     *e = de;
 err:
     if (fl->ts)
-        fastlock_release(&fl->lock);
+        ofi_spin_unlock(&fl->lock);
     return ret;
 }
 
@@ -176,11 +176,11 @@ static inline void _gnix_fl_free(struct dlist_entry *e, struct gnix_freelist *fl
     e->next = NULL;  /* keep slist implementation happy */
 
     if (fl->ts)
-        fastlock_acquire(&fl->lock);
+        ofi_spin_lock(&fl->lock);
     dlist_init(e);
     dlist_insert_head(e, &fl->freelist);
     if (fl->ts)
-        fastlock_release(&fl->lock);
+        ofi_spin_unlock(&fl->lock);
 }
 
 

--- a/prov/gni/include/gnix_mbox_allocator.h
+++ b/prov/gni/include/gnix_mbox_allocator.h
@@ -106,7 +106,7 @@ struct gnix_slab {
  */
 struct gnix_mbox_alloc_handle {
 	struct gnix_nic *nic_handle;
-	fastlock_t lock;
+	ofi_spin_t lock;
 	gni_cq_handle_t cq_handle;
 
 	size_t last_offset;

--- a/prov/gni/include/gnix_mr.h
+++ b/prov/gni/include/gnix_mr.h
@@ -72,7 +72,7 @@ struct gnix_mr_cache_info {
 	struct gnix_fid_domain *domain;
 	struct gnix_auth_key *auth_key;
 
-	fastlock_t mr_cache_lock;
+	ofi_spin_t mr_cache_lock;
 	int inuse;
 };
 
@@ -207,14 +207,14 @@ int _gnix_close_cache(struct gnix_fid_domain *domain,
 int _gnix_flush_registration_cache(struct gnix_fid_domain *domain);
 
 
-/** 
+/**
  * used for internal registrations,
  *
  * @param fid  endpoint fid
  * @param buf            buffer to register
  * @param len            length of buffer to register
  * @param access         access permissions
- * @param offset         registration offset 
+ * @param offset         registration offset
  * @param requested_key  key requested for new registration
  * @param flags          registration flags
  * @param mr_o           pointer to returned registration
@@ -223,7 +223,7 @@ int _gnix_flush_registration_cache(struct gnix_fid_domain *domain);
  * @param reserved       1 if provider registration, 0 otherwise
  *
  * @note  Set reserved to 0 for a user registration
- * @note  Set reserved to 1 for a provider registration 
+ * @note  Set reserved to 1 for a provider registration
  */
 int _gnix_mr_reg(struct fid *fid, const void *buf, size_t len,
 			  uint64_t access, uint64_t offset,

--- a/prov/gni/include/gnix_mr_notifier.h
+++ b/prov/gni/include/gnix_mr_notifier.h
@@ -67,7 +67,7 @@ typedef volatile uint64_t kdreg_user_delta_t;
 struct gnix_mr_notifier {
 	int fd;
 	kdreg_user_delta_t *cntr;
-	fastlock_t lock;
+	ofi_spin_t lock;
 	int ref_cnt;
 };
 

--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -171,7 +171,7 @@ struct gnix_nic {
 	struct dlist_entry gnix_nic_list; /* global NIC list */
 	struct dlist_entry ptag_nic_list; /* global PTAG NIC list */
 	struct dlist_entry gnix_nic_prog_list; /* temporary list for nic progression */
-	fastlock_t lock;
+	ofi_spin_t lock;
 	uint32_t allocd_gni_res;
 	gni_cdm_handle_t gni_cdm_hndl;
 	uint32_t	 gni_cdm_modes;
@@ -181,11 +181,11 @@ struct gnix_nic {
 	gni_cq_handle_t tx_cq;
 	gni_cq_handle_t tx_cq_blk;
 	pthread_t progress_thread;
-	fastlock_t tx_desc_lock;
+	ofi_spin_t tx_desc_lock;
 	struct dlist_entry tx_desc_active_list;
 	struct dlist_entry tx_desc_free_list;
 	struct gnix_tx_descriptor *tx_desc_base;
-	fastlock_t prog_vcs_lock;
+	ofi_spin_t prog_vcs_lock;
 	struct dlist_entry prog_vcs;
 	/* note this free list will be initialized for thread safe */
 	struct gnix_freelist vc_freelist;
@@ -194,7 +194,7 @@ struct gnix_nic {
 	uint32_t device_id;
 	uint32_t device_addr;
 	int max_tx_desc_id;
-	fastlock_t vc_id_lock;
+	ofi_spin_t vc_id_lock;
 	void **vc_id_table;
 	int vc_id_table_capacity;
 	int vc_id_table_count;

--- a/prov/gni/include/gnix_smrn.h
+++ b/prov/gni/include/gnix_smrn.h
@@ -46,14 +46,14 @@
  *                  if reading or writing while setting up or tearing down)
  */
 struct gnix_smrn {
-	fastlock_t lock;
+	ofi_spin_t lock;
 	struct gnix_mr_notifier *notifier;
 	struct dlist_entry rq_head;
 	int references;
 };
 
 struct gnix_smrn_rq {
-	fastlock_t lock;
+	ofi_spin_t lock;
 	struct dlist_entry list;
 	struct dlist_entry entry;
 };

--- a/prov/gni/include/gnix_tags.h
+++ b/prov/gni/include/gnix_tags.h
@@ -129,20 +129,20 @@
  *
  * On receipt of a message:
  *
- * fastlock_acquire(&ep->tag_lock);
+ * ofi_spin_lock(&ep->tag_lock);
  * req = _gnix_remove_by_tag(&ep->posted_recvs, msg->tag, 0);
  * if (!req)
  *     _gnix_insert_by_tag(&ep->unexpected_recvs, msg->tag, msg->req);
- * fastlock_release(&ep->tag_lock);
+ * ofi_spin_unlock(&ep->tag_lock);
  *
  * On post of receive:
  *
- * fastlock_acquire(&ep->tag_lock);
+ * ofi_spin_lock(&ep->tag_lock);
  * tag_req = _gnix_remove_by_tag(&ep->unexpected_recvs,
  *           req->tag, req->ignore);
  * if (!tag_req)
  *     _gnix_insert_by_tag(&ep->posted_recvs, tag, req);
- * fastlock_release(&ep->tag_lock);
+ * ofi_spin_unlock(&ep->tag_lock);
  *
  */
 

--- a/prov/gni/include/gnix_util.h
+++ b/prov/gni/include/gnix_util.h
@@ -266,14 +266,14 @@ static inline void _gnix_ref_init(
 	} while (0)
 
 #define COND_ACQUIRE(cond, lock) \
-	__COND_FUNC((cond), (lock), fastlock_acquire)
+	__COND_FUNC((cond), (lock), ofi_spin_lock)
 #define COND_READ_ACQUIRE(cond, lock) \
 	__COND_FUNC((cond), (lock), rwlock_rdlock)
 #define COND_WRITE_ACQUIRE(cond, lock) \
 	__COND_FUNC((cond), (lock), rwlock_wrlock)
 
 #define COND_RELEASE(cond, lock) \
-	__COND_FUNC((cond), (lock), fastlock_release)
+	__COND_FUNC((cond), (lock), ofi_spin_unlock)
 #define COND_RW_RELEASE(cond, lock) \
 	__COND_FUNC((cond), (lock), rwlock_unlock)
 #ifdef __GNUC__

--- a/prov/gni/include/gnix_xpmem.h
+++ b/prov/gni/include/gnix_xpmem.h
@@ -45,7 +45,7 @@ typedef int64_t xpmem_segid_t;
 struct gnix_xpmem_handle {
 	struct gnix_reference ref_cnt;
 	struct gnix_hashtable *apid_ht;
-	fastlock_t lock;
+	ofi_spin_t lock;
 };
 
 struct gnix_xpmem_access_handle {

--- a/prov/gni/src/gnix_bitmap.c
+++ b/prov/gni/src/gnix_bitmap.c
@@ -29,7 +29,7 @@
 
 static inline void __gnix_init_block(gnix_bitmap_block_t *block)
 {
-	fastlock_init(&block->lock);
+	ofi_spin_init(&block->lock);
 	block->val = 0llu;
 }
 
@@ -38,9 +38,9 @@ static inline void __gnix_set_block(gnix_bitmap_t *bitmap, int index,
 {
 	gnix_bitmap_block_t *block = &bitmap->arr[index];
 
-	fastlock_acquire(&block->lock);
+	ofi_spin_lock(&block->lock);
 	block->val = value;
-	fastlock_release(&block->lock);
+	ofi_spin_unlock(&block->lock);
 }
 
 static inline uint64_t __gnix_load_block(gnix_bitmap_t *bitmap, int index)
@@ -48,9 +48,9 @@ static inline uint64_t __gnix_load_block(gnix_bitmap_t *bitmap, int index)
 	gnix_bitmap_block_t *block = &bitmap->arr[index];
 	uint64_t ret;
 
-	fastlock_acquire(&block->lock);
+	ofi_spin_lock(&block->lock);
 	ret = block->val;
-	fastlock_release(&block->lock);
+	ofi_spin_unlock(&block->lock);
 
 	return ret;
 }
@@ -60,10 +60,10 @@ static inline uint64_t __gnix_set_bit(gnix_bitmap_t *bitmap, int bit)
 	gnix_bitmap_block_t *block = &bitmap->arr[GNIX_BUCKET_INDEX(bit)];
 	uint64_t ret;
 
-	fastlock_acquire(&block->lock);
+	ofi_spin_lock(&block->lock);
 	ret = block->val;
 	block->val |= GNIX_BIT_VALUE(bit);
-	fastlock_release(&block->lock);
+	ofi_spin_unlock(&block->lock);
 
 	return ret;
 }
@@ -73,10 +73,10 @@ static inline uint64_t __gnix_clear_bit(gnix_bitmap_t *bitmap, int bit)
 	gnix_bitmap_block_t *block = &bitmap->arr[GNIX_BUCKET_INDEX(bit)];
 	uint64_t ret;
 
-	fastlock_acquire(&block->lock);
+	ofi_spin_lock(&block->lock);
 	ret = block->val;
 	block->val &= ~GNIX_BIT_VALUE(bit);
-	fastlock_release(&block->lock);
+	ofi_spin_unlock(&block->lock);
 
 	return ret;
 }
@@ -86,9 +86,9 @@ static inline int __gnix_test_bit(gnix_bitmap_t *bitmap, int bit)
 	gnix_bitmap_block_t *block = &bitmap->arr[GNIX_BUCKET_INDEX(bit)];
 	int ret;
 
-	fastlock_acquire(&block->lock);
+	ofi_spin_lock(&block->lock);
 	ret = (block->val & GNIX_BIT_VALUE(bit)) != 0;
-	fastlock_release(&block->lock);
+	ofi_spin_unlock(&block->lock);
 
 	return ret;
 }

--- a/prov/gni/src/gnix_cntr.c
+++ b/prov/gni/src/gnix_cntr.c
@@ -465,7 +465,7 @@ DIRECT_FN int gnix_cntr_open(struct fid_domain *domain,
 	_gnix_prog_init(&cntr_priv->pset);
 
 	dlist_init(&cntr_priv->trigger_list);
-	fastlock_init(&cntr_priv->trigger_lock);
+	ofi_spin_init(&cntr_priv->trigger_lock);
 
 	ret = gnix_cntr_set_wait(cntr_priv);
 	if (ret)

--- a/prov/gni/src/gnix_cq.c
+++ b/prov/gni/src/gnix_cq.c
@@ -402,7 +402,7 @@ static void __cq_destruct(void *obj)
 	_gnix_queue_destroy(cq->events);
 	_gnix_queue_destroy(cq->errors);
 
-	fastlock_destroy(&cq->lock);
+	ofi_spin_destroy(&cq->lock);
 	free(cq->cq_fid.ops);
 	free(cq->cq_fid.fid.ops);
 	free(cq);
@@ -708,7 +708,7 @@ DIRECT_FN int gnix_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	 */
 	cq_priv->entry_size = format_sizes[cq_priv->attr.format];
 
-	fastlock_init(&cq_priv->lock);
+	ofi_spin_init(&cq_priv->lock);
 	ret = gnix_cq_set_wait(cq_priv);
 	if (ret)
 		goto free_cq_priv;
@@ -732,7 +732,7 @@ free_gnix_queue:
 	_gnix_queue_destroy(cq_priv->events);
 free_cq_priv:
 	_gnix_ref_put(cq_priv->domain);
-	fastlock_destroy(&cq_priv->lock);
+	ofi_spin_destroy(&cq_priv->lock);
 	free(cq_priv);
 free_fi_cq_ops:
 	free(fi_cq_ops);

--- a/prov/gni/src/gnix_datagram.c
+++ b/prov/gni/src/gnix_datagram.c
@@ -243,7 +243,7 @@ int _gnix_dgram_alloc(struct gnix_dgram_hndl *hndl, enum gnix_dgram_type type,
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
-	fastlock_acquire(&hndl->lock);
+	ofi_spin_lock(&hndl->lock);
 
 	if (type == GNIX_DGRAM_WC) {
 		the_free_list = &hndl->wc_dgram_free_list;
@@ -265,7 +265,7 @@ int _gnix_dgram_alloc(struct gnix_dgram_hndl *hndl, enum gnix_dgram_type type,
 
 	}
 
-	fastlock_release(&hndl->lock);
+	ofi_spin_unlock(&hndl->lock);
 
 	if (d != NULL) {
 		d->r_index_in_buf = 0;
@@ -295,11 +295,11 @@ int _gnix_dgram_free(struct gnix_datagram *d)
 		}
 	}
 
-	fastlock_acquire(&d->d_hndl->lock);
+	ofi_spin_lock(&d->d_hndl->lock);
 	dlist_remove_init(&d->list);
 	d->state = GNIX_DGRAM_STATE_FREE;
 	dlist_insert_head(&d->list, d->free_list_head);
-	fastlock_release(&d->d_hndl->lock);
+	ofi_spin_unlock(&d->d_hndl->lock);
 	return ret;
 }
 
@@ -604,7 +604,7 @@ int _gnix_dgram_hndl_alloc(struct gnix_cm_nic *cm_nic,
 
 	the_hndl->n_dgrams = fabric->n_bnd_dgrams;
 	the_hndl->n_wc_dgrams = fabric->n_wc_dgrams;
-	fastlock_init(&the_hndl->lock);
+	ofi_spin_init(&the_hndl->lock);
 
 	n_dgrams_tot = the_hndl->n_dgrams + the_hndl->n_wc_dgrams;
 

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -933,9 +933,9 @@ static int __gnix_auth_key_set_val(
 	/* if the limits have already been set, and the user is
 	 * trying to modify it, kick it back */
 	if (opt == GNIX_USER_KEY_LIMIT || opt == GNIX_PROV_KEY_LIMIT) {
-		fastlock_acquire(&info->lock);
+		ofi_spin_lock(&info->lock);
 		if (info->enabled) {
-			fastlock_release(&info->lock);
+			ofi_spin_unlock(&info->lock);
 			GNIX_INFO(FI_LOG_FABRIC, "authorization key already "
 				"enabled and cannot be modified\n");
 			return -FI_EAGAIN;
@@ -951,7 +951,7 @@ static int __gnix_auth_key_set_val(
 			ret = -FI_EINVAL;
 		} else
 			info->attr.user_key_limit = v;
-		fastlock_release(&info->lock);
+		ofi_spin_unlock(&info->lock);
 		break;
 	case GNIX_PROV_KEY_LIMIT:
 		v = *(int *) val;
@@ -961,7 +961,7 @@ static int __gnix_auth_key_set_val(
 			ret = -FI_EINVAL;
 		}
 		info->attr.prov_key_limit = v;
-		fastlock_release(&info->lock);
+		ofi_spin_unlock(&info->lock);
 		break;
 	case GNIX_TOTAL_KEYS_NEEDED:
 		GNIX_WARN(FI_LOG_FABRIC,

--- a/prov/gni/src/gnix_freelist.c
+++ b/prov/gni/src/gnix_freelist.c
@@ -135,7 +135,7 @@ int _gnix_fl_init_ts(int elem_size, int offset, int init_size,
 			     fl);
 	if (ret == FI_SUCCESS) {
 		fl->ts = 1;
-		fastlock_init(&fl->lock);
+		ofi_spin_init(&fl->lock);
 	}
 
 	return ret;
@@ -155,7 +155,7 @@ void _gnix_fl_destroy(struct gnix_freelist *fl)
 	}
 
 	if (fl->ts)
-		fastlock_destroy(&fl->lock);
+		ofi_spin_destroy(&fl->lock);
 }
 
 

--- a/prov/gni/src/gnix_init.c
+++ b/prov/gni/src/gnix_init.c
@@ -56,7 +56,7 @@ __thread uint32_t gnix_debug_tid = ~(uint32_t) 0;
 ofi_atomic32_t gnix_debug_next_tid;
 #endif
 
-extern fastlock_t __gnix_alps_lock;
+extern ofi_spin_t __gnix_alps_lock;
 
 /**
  * Helper for static computation of GNI CRC updating an intermediate crc
@@ -153,7 +153,7 @@ void _gnix_init(void)
 	static int called=0;
 
 	if (called==0) {
-		fastlock_init(&__gnix_alps_lock);
+		ofi_spin_init(&__gnix_alps_lock);
 
 		if (sizeof(struct gnix_mr_key) != sizeof(uint64_t)) {
 			GNIX_FATAL(FI_LOG_FABRIC,

--- a/prov/gni/src/gnix_mbox_allocator.c
+++ b/prov/gni/src/gnix_mbox_allocator.c
@@ -629,7 +629,7 @@ int _gnix_mbox_allocator_create(struct gnix_nic *nic,
 	handle->mpmmap = mpmmap;
 	handle->nic_handle = nic;
 	handle->cq_handle = cq_handle;
-	fastlock_init(&handle->lock);
+	ofi_spin_init(&handle->lock);
 
 	ret = __open_huge_page(handle);
 	if (ret == FI_SUCCESS) {
@@ -727,7 +727,7 @@ int _gnix_mbox_allocator_destroy(struct gnix_mbox_alloc_handle *alloc_handle)
 			  error);
 	}
 
-	fastlock_destroy(&alloc_handle->lock);
+	ofi_spin_destroy(&alloc_handle->lock);
 
 	free(alloc_handle);
 
@@ -749,7 +749,7 @@ int _gnix_mbox_alloc(struct gnix_mbox_alloc_handle *alloc_handle,
 		goto err;
 	}
 
-	fastlock_acquire(&alloc_handle->lock);
+	ofi_spin_lock(&alloc_handle->lock);
 	position = __find_free(alloc_handle, &slab);
 	if (position < 0) {
 		GNIX_DEBUG(FI_LOG_EP_CTRL, "Creating new slab.\n");
@@ -768,7 +768,7 @@ int _gnix_mbox_alloc(struct gnix_mbox_alloc_handle *alloc_handle,
 	if (ret)
 		GNIX_WARN(FI_LOG_EP_CTRL, "Creating mbox failed.\n");
 
-	fastlock_release(&alloc_handle->lock);
+	ofi_spin_unlock(&alloc_handle->lock);
 err:
 	return ret;
 }
@@ -777,7 +777,7 @@ int _gnix_mbox_free(struct gnix_mbox *ptr)
 {
 	size_t position;
 	int ret;
-	fastlock_t *lock;
+	ofi_spin_t *lock;
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
@@ -787,19 +787,19 @@ int _gnix_mbox_free(struct gnix_mbox *ptr)
 	}
 
 	lock = &ptr->slab->allocator->lock;
-	fastlock_acquire(lock);
+	ofi_spin_lock(lock);
 	position = ptr->offset / ptr->slab->allocator->mbox_size;
 
 	ret = _gnix_test_and_clear_bit(ptr->slab->used, position);
 	if (ret != 1) {
 		GNIX_WARN(FI_LOG_EP_CTRL,
 			  "Bit already cleared while freeing mbox.\n");
-		fastlock_release(lock);
+		ofi_spin_unlock(lock);
 		return -FI_EINVAL;
 	}
 
 	free(ptr);
-	fastlock_release(lock);
+	ofi_spin_unlock(lock);
 
 	return FI_SUCCESS;
 }

--- a/prov/gni/src/gnix_mr_cache.c
+++ b/prov/gni/src/gnix_mr_cache.c
@@ -1048,7 +1048,7 @@ int _gnix_mr_cache_init(
 
 	dlist_init(&cache_p->rq.list);
 	dlist_init(&cache_p->rq.entry);
-	fastlock_init(&cache_p->rq.lock);
+	ofi_spin_init(&cache_p->rq.lock);
 
 	*cache = cache_p;
 

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -729,7 +729,7 @@ static int __gnix_nic_tx_freelist_init(struct gnix_nic *nic, int n_descs)
 	nic->max_tx_desc_id = n_descs - 1;
 	nic->tx_desc_base = desc_base;
 
-	fastlock_init(&nic->tx_desc_lock);
+	ofi_spin_init(&nic->tx_desc_lock);
 
 	return ret;
 
@@ -746,7 +746,7 @@ static void __gnix_nic_tx_freelist_destroy(struct gnix_nic *nic)
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
 	free(nic->tx_desc_base);
-	fastlock_destroy(&nic->tx_desc_lock);
+	ofi_spin_destroy(&nic->tx_desc_lock);
 }
 
 /*
@@ -1173,7 +1173,7 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 				  "alloc_bitmap returned %d\n", ret);
 			goto err1;
 		}
-		fastlock_init(&nic->vc_id_lock);
+		ofi_spin_init(&nic->vc_id_lock);
 
 		/*
 		 * initialize free list for VC's
@@ -1207,14 +1207,14 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 			goto err1;
 		}
 
-		fastlock_init(&nic->lock);
+		ofi_spin_init(&nic->lock);
 
 		ret = __gnix_nic_tx_freelist_init(nic,
 						  domain->params.tx_cq_size);
 		if (ret != FI_SUCCESS)
 			goto err1;
 
-		fastlock_init(&nic->prog_vcs_lock);
+		ofi_spin_init(&nic->prog_vcs_lock);
 		dlist_init(&nic->prog_vcs);
 
 		_gnix_ref_init(&nic->ref_cnt, 1, __nic_destruct);

--- a/prov/gni/src/gnix_sep.c
+++ b/prov/gni/src/gnix_sep.c
@@ -164,7 +164,7 @@ static int gnix_sep_tx_ctx(struct fid_ep *sep, int index,
 	 * allocated
 	 */
 
-	fastlock_acquire(&sep_priv->sep_lock);
+	ofi_spin_lock(&sep_priv->sep_lock);
 
 	if (sep_priv->tx_ep_table[index] != NULL) {
 		ret = -FI_EBUSY;
@@ -243,7 +243,7 @@ static int gnix_sep_tx_ctx(struct fid_ep *sep, int index,
 		attr->op_flags = tx_priv->op_flags;
 	}
 err:
-	fastlock_release(&sep_priv->sep_lock);
+	ofi_spin_unlock(&sep_priv->sep_lock);
 
 	return ret;
 }
@@ -293,7 +293,7 @@ static int gnix_sep_rx_ctx(struct fid_ep *sep, int index,
 	 * allocated
 	 */
 
-	fastlock_acquire(&sep_priv->sep_lock);
+	ofi_spin_lock(&sep_priv->sep_lock);
 
 	if (sep_priv->rx_ep_table[index] != NULL) {
 		ret = -FI_EBUSY;
@@ -370,7 +370,7 @@ static int gnix_sep_rx_ctx(struct fid_ep *sep, int index,
 		attr->op_flags = rx_priv->op_flags;
 	}
 err:
-	fastlock_release(&sep_priv->sep_lock);
+	ofi_spin_unlock(&sep_priv->sep_lock);
 
 	return ret;
 }
@@ -790,7 +790,7 @@ int gnix_sep_open(struct fid_domain *domain, struct fi_info *info,
 	sep_priv->my_name.rx_ctx_cnt = info->ep_attr->rx_ctx_cnt;
 	sep_priv->my_name.name_type = name_type;
 
-	fastlock_init(&sep_priv->sep_lock);
+	ofi_spin_init(&sep_priv->sep_lock);
 	_gnix_ref_get(domain_priv);
 
 	*sep = &sep_priv->ep_fid;

--- a/prov/gni/src/gnix_smrn.c
+++ b/prov/gni/src/gnix_smrn.c
@@ -39,7 +39,7 @@ int _gnix_smrn_init(void)
 {
 	int ret;
 
-	fastlock_init(&global_smrn.lock);
+	ofi_spin_init(&global_smrn.lock);
 	global_smrn.references = 0;
 	dlist_init(&global_smrn.rq_head);
 
@@ -53,13 +53,13 @@ int _gnix_smrn_open(struct gnix_smrn **smrn)
 	struct gnix_smrn *tmp = &global_smrn;
 	int ret = FI_SUCCESS;
 
-	fastlock_acquire(&tmp->lock);
+	ofi_spin_lock(&tmp->lock);
 	if (tmp->references == 0)
 		ret = _gnix_notifier_open(&tmp->notifier);
 
 	if (!ret)
 		tmp->references += 1;
-	fastlock_release(&tmp->lock);
+	ofi_spin_unlock(&tmp->lock);
 
 	if (!ret)
 		*smrn = tmp;
@@ -71,7 +71,7 @@ int _gnix_smrn_close(struct gnix_smrn *smrn)
 {
 	int ret = FI_SUCCESS;
 
-	fastlock_acquire(&smrn->lock);
+	ofi_spin_lock(&smrn->lock);
 	if (smrn->references == 0)
 		ret = -FI_EINVAL;
 
@@ -80,7 +80,7 @@ int _gnix_smrn_close(struct gnix_smrn *smrn)
 
 	if (!ret)
 		smrn->references -= 1;
-	fastlock_release(&smrn->lock);
+	ofi_spin_unlock(&smrn->lock);
 
 	return ret;
 }
@@ -145,9 +145,9 @@ static void __gnix_smrn_read_events(struct gnix_smrn *smrn)
 			context, context->rq, context->cookie);
 
 		rq = context->rq;
-		fastlock_acquire(&rq->lock);
+		ofi_spin_lock(&rq->lock);
 		dlist_insert_tail(&context->entry, &rq->list);
-		fastlock_release(&rq->lock);
+		ofi_spin_unlock(&rq->lock);
 	} while (ret == len);
 }
 
@@ -162,14 +162,14 @@ int _gnix_smrn_get_event(struct gnix_smrn *smrn,
 
 	__gnix_smrn_read_events(smrn);
 
-	fastlock_acquire(&rq->lock);
+	ofi_spin_lock(&rq->lock);
 	if (!dlist_empty(&rq->list)) {
 		dlist_pop_front(&rq->list, struct gnix_smrn_context,
 			*context, entry);
 		ret = FI_SUCCESS;
 	} else
 		ret = -FI_EAGAIN;
-	fastlock_release(&rq->lock);
+	ofi_spin_unlock(&rq->lock);
 
 	return ret;
 }

--- a/prov/gni/src/gnix_trigger.c
+++ b/prov/gni/src/gnix_trigger.c
@@ -66,7 +66,7 @@ int _gnix_trigger_queue_req(struct gnix_fab_req *req)
 		  "Queueing triggered op: %p\n",
 		  req);
 
-	fastlock_acquire(&cntr->trigger_lock);
+	ofi_spin_lock(&cntr->trigger_lock);
 	if (dlist_empty(&cntr->trigger_list)) {
 		dlist_init(&req->dlist);
 		dlist_insert_head(&req->dlist, &cntr->trigger_list);
@@ -88,7 +88,7 @@ int _gnix_trigger_queue_req(struct gnix_fab_req *req)
 		dlist_init(&req->dlist);
 		dlist_insert_before(&req->dlist, &r->dlist);
 	}
-	fastlock_release(&cntr->trigger_lock);
+	ofi_spin_unlock(&cntr->trigger_lock);
 
 	return FI_SUCCESS;
 }
@@ -106,7 +106,7 @@ void _gnix_trigger_check_cntr(struct gnix_fid_cntr *cntr)
 
 	 count = ofi_atomic_get32(&cntr->cnt);
 
-	fastlock_acquire(&cntr->trigger_lock);
+	ofi_spin_lock(&cntr->trigger_lock);
 	dlist_for_each_safe(&cntr->trigger_list, req, req2, dlist) {
 		trigger_context = (struct fi_triggered_context *)
 					req->user_context;
@@ -124,5 +124,5 @@ void _gnix_trigger_check_cntr(struct gnix_fid_cntr *cntr)
 			break;
 		}
 	}
-	fastlock_release(&cntr->trigger_lock);
+	ofi_spin_unlock(&cntr->trigger_lock);
 }

--- a/prov/gni/src/gnix_util.c
+++ b/prov/gni/src/gnix_util.c
@@ -103,7 +103,7 @@ static int *gnix_app_totalPes;
 static int *gnix_app_nodePes;
 static int *gnix_app_peCpus;
 
-fastlock_t __gnix_alps_lock;
+ofi_spin_t __gnix_alps_lock;
 
 int _gnix_get_cq_limit(void)
 {
@@ -255,14 +255,14 @@ static int __gnix_alps_init(void)
 	alpsAppLLIGni_t *rdmacred_rsp = NULL;
 	alpsAppGni_t *rdmacred_buf = NULL;
 
-	fastlock_acquire(&__gnix_alps_lock);
+	ofi_spin_lock(&__gnix_alps_lock);
 	/* lli_lock doesn't return anything useful */
 	ret = alps_app_lli_lock();
 
 	if (alps_init) {
 		/* alps lli lock protects alps_init for now */
 		alps_app_lli_unlock();
-		fastlock_release(&__gnix_alps_lock);
+		ofi_spin_unlock(&__gnix_alps_lock);
 		return ret;
 	}
 
@@ -389,7 +389,7 @@ static int __gnix_alps_init(void)
 	ret = 0;
 err:
 	alps_app_lli_unlock();
-	fastlock_release(&__gnix_alps_lock);
+	ofi_spin_unlock(&__gnix_alps_lock);
 	if (rdmacred_rsp != NULL) {
 		free(rdmacred_rsp);
 	}

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -1026,9 +1026,9 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 		 * cm_nic's work queue, progress the cm_nic.
 		 */
 
-		fastlock_acquire(&cm_nic->wq_lock);
+		ofi_spin_lock(&cm_nic->wq_lock);
 		dlist_insert_before(&work_req->list, &cm_nic->cm_nic_wq);
-		fastlock_release(&cm_nic->wq_lock);
+		ofi_spin_unlock(&cm_nic->wq_lock);
 	} else {
 
 		/*
@@ -1718,9 +1718,9 @@ int _gnix_vc_connect(struct gnix_vc *vc)
 	 * cm_nic's work queue, progress the cm_nic.
 	 */
 
-	fastlock_acquire(&cm_nic->wq_lock);
+	ofi_spin_lock(&cm_nic->wq_lock);
 	dlist_insert_before(&work_req->list, &cm_nic->cm_nic_wq);
-	fastlock_release(&cm_nic->wq_lock);
+	ofi_spin_unlock(&cm_nic->wq_lock);
 
 	return ret;
 }

--- a/prov/gni/src/gnix_xpmem.c
+++ b/prov/gni/src/gnix_xpmem.c
@@ -262,7 +262,7 @@ int _gnix_xpmem_handle_create(struct gnix_fid_domain *dom,
 
 	_gnix_ref_init(&hndl->ref_cnt, 1,
 			__xpmem_hndl_destruct);
-	fastlock_init(&hndl->lock);
+	ofi_spin_init(&hndl->lock);
 
 	/*
 	 * initialize xpmem_apid_t key'd hash table for
@@ -337,7 +337,7 @@ int _gnix_xpmem_access_hndl_get(struct gnix_xpmem_handle *xp_hndl,
 	 *  - if not in the hash, create and insert
 	 */
 
-	fastlock_acquire(&xp_hndl->lock);
+	ofi_spin_lock(&xp_hndl->lock);
 
 	entry = _gnix_ht_lookup(xp_hndl->apid_ht,
 			      (gnix_ht_key_t)peer_apid);
@@ -393,7 +393,7 @@ int _gnix_xpmem_access_hndl_get(struct gnix_xpmem_handle *xp_hndl,
 	}
 
 exit_w_lock:
-	fastlock_release(&xp_hndl->lock);
+	ofi_spin_unlock(&xp_hndl->lock);
 	return ret;
 
 }
@@ -418,7 +418,7 @@ int _gnix_xpmem_access_hndl_put(struct gnix_xpmem_access_handle *access_hndl)
 		return -FI_EINVAL;
 	}
 
-	fastlock_acquire(&xp_hndl->lock);
+	ofi_spin_lock(&xp_hndl->lock);
 
 	ret = _gnix_mr_cache_deregister(entry->mr_cache,
 					access_hndl);
@@ -426,7 +426,7 @@ int _gnix_xpmem_access_hndl_put(struct gnix_xpmem_access_handle *access_hndl)
 		GNIX_WARN(FI_LOG_EP_DATA, "_gnix_mr_cache_deregister returned %s\n",
 			  fi_strerror(-ret));
 
-	fastlock_release(&xp_hndl->lock);
+	ofi_spin_unlock(&xp_hndl->lock);
 
 	return ret;
 }

--- a/prov/gni/test/av.c
+++ b/prov/gni/test/av.c
@@ -424,10 +424,10 @@ static pthread_barrier_t mtbar;
  * fat lock when calling them */
 #define USE_LOCK
 #ifdef USE_LOCK
-static fastlock_t my_big_lock;
-#define init_av_lock() fastlock_init(&my_big_lock)
-#define av_lock() fastlock_acquire(&my_big_lock)
-#define av_unlock() fastlock_release(&my_big_lock)
+static ofi_spin_t my_big_lock;
+#define init_av_lock() ofi_spin_init(&my_big_lock)
+#define av_lock() ofi_spin_lock(&my_big_lock)
+#define av_unlock() ofi_spin_unlock(&my_big_lock)
 #else
 #define init_av_lock()
 #define av_lock()

--- a/prov/gni/test/bitmap.c
+++ b/prov/gni/test/bitmap.c
@@ -61,9 +61,9 @@ static inline void __gnix_set_block(gnix_bitmap_t *bitmap, int index,
 {
 	gnix_bitmap_block_t *block = &bitmap->arr[index];
 
-	fastlock_acquire(&block->lock);
+	ofi_spin_lock(&block->lock);
 	block->val = value;
-	fastlock_release(&block->lock);
+	ofi_spin_unlock(&block->lock);
 }
 
 static inline uint64_t __gnix_load_block(gnix_bitmap_t *bitmap, int index)
@@ -71,9 +71,9 @@ static inline uint64_t __gnix_load_block(gnix_bitmap_t *bitmap, int index)
 	gnix_bitmap_block_t *block = &bitmap->arr[index];
 	uint64_t ret;
 
-	fastlock_acquire(&block->lock);
+	ofi_spin_lock(&block->lock);
 	ret = block->val;
-	fastlock_release(&block->lock);
+	ofi_spin_unlock(&block->lock);
 
 	return ret;
 }

--- a/prov/gni/test/smrn.c
+++ b/prov/gni/test/smrn.c
@@ -73,7 +73,7 @@ static void smrn_setup(void)
 		rqs[i] = calloc(1, sizeof(*rqs[i]));
 		cr_assert_neq(rqs[i], NULL);
 
-		fastlock_init(&rqs[i]->lock);
+		ofi_spin_init(&rqs[i]->lock);
 		dlist_init(&rqs[i]->list);
 		dlist_init(&rqs[i]->entry);
 	}

--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -228,7 +228,7 @@ struct psmx_unexp {
 };
 
 struct psmx_req_queue {
-	fastlock_t	lock;
+	ofi_spin_t	lock;
 	struct slist	list;
 };
 
@@ -264,7 +264,7 @@ struct psmx_fid_domain {
 	uint64_t		caps;
 
 	enum fi_mr_mode		mr_mode;
-	fastlock_t		mr_lock;
+	ofi_spin_t		mr_lock;
 	uint64_t		mr_reserved_key;
 	RbtHandle		mr_map;
 
@@ -292,7 +292,7 @@ struct psmx_fid_domain {
 	/* lock to prevent the sequence of psm_mq_ipeek and psm_mq_test be
 	 * interleaved in a multithreaded environment.
 	 */
-	fastlock_t		poll_lock;
+	ofi_spin_t		poll_lock;
 
 	int			progress_thread_enabled;
 	pthread_t		progress_thread;
@@ -330,7 +330,7 @@ struct psmx_fid_cq {
 	size_t				event_count;
 	struct slist			event_queue;
 	struct slist			free_list;
-	fastlock_t			lock;
+	ofi_spin_t			lock;
 	struct psmx_cq_event		*pending_error;
 	struct util_wait		*wait;
 	int				wait_cond;

--- a/prov/psm/src/psmx_atomic.c
+++ b/prov/psm/src/psmx_atomic.c
@@ -49,16 +49,16 @@
  *	args[1].u64	req
  */
 
-static fastlock_t psmx_atomic_lock;
+static ofi_spin_t psmx_atomic_lock;
 
 void psmx_atomic_init(void)
 {
-	fastlock_init(&psmx_atomic_lock);
+	ofi_spin_init(&psmx_atomic_lock);
 }
 
 void psmx_atomic_fini(void)
 {
-	fastlock_destroy(&psmx_atomic_lock);
+	ofi_spin_destroy(&psmx_atomic_lock);
 }
 
 #define CASE_INT_TYPE(FUNC,...) \
@@ -119,10 +119,10 @@ void psmx_atomic_fini(void)
 			int i; \
 			TYPE *d = (dst); \
 			TYPE *r = (res); \
-			fastlock_acquire(&psmx_atomic_lock); \
+			ofi_spin_lock(&psmx_atomic_lock); \
 			for (i=0; i<(cnt); i++) \
 				r[i] = d[i]; \
-			fastlock_release(&psmx_atomic_lock); \
+			ofi_spin_unlock(&psmx_atomic_lock); \
 		} while (0)
 
 #define PSMX_ATOMIC_WRITE(dst,src,cnt,OP,TYPE) \
@@ -130,10 +130,10 @@ void psmx_atomic_fini(void)
 			int i; \
 			TYPE *d = (dst); \
 			TYPE *s = (src); \
-			fastlock_acquire(&psmx_atomic_lock); \
+			ofi_spin_lock(&psmx_atomic_lock); \
 			for (i=0; i<cnt; i++) \
 				OP(d[i],s[i]); \
-			fastlock_release(&psmx_atomic_lock); \
+			ofi_spin_unlock(&psmx_atomic_lock); \
 		} while (0)
 
 #define PSMX_ATOMIC_READWRITE(dst,src,res,cnt,OP,TYPE) \
@@ -142,12 +142,12 @@ void psmx_atomic_fini(void)
 			TYPE *d = (dst); \
 			TYPE *s = (src); \
 			TYPE *r = (res); \
-			fastlock_acquire(&psmx_atomic_lock); \
+			ofi_spin_lock(&psmx_atomic_lock); \
 			for (i=0; i<(cnt); i++) {\
 				r[i] = d[i]; \
 				OP(d[i],s[i]); \
 			} \
-			fastlock_release(&psmx_atomic_lock); \
+			ofi_spin_unlock(&psmx_atomic_lock); \
 		} while (0)
 
 #define PSMX_ATOMIC_CSWAP(dst,src,cmp,res,cnt,CMP_OP,TYPE) \
@@ -157,13 +157,13 @@ void psmx_atomic_fini(void)
 			TYPE *s = (src); \
 			TYPE *c = (cmp); \
 			TYPE *r = (res); \
-			fastlock_acquire(&psmx_atomic_lock); \
+			ofi_spin_lock(&psmx_atomic_lock); \
 			for (i=0; i<(cnt); i++) { \
 				r[i] = d[i]; \
 				if (c[i] CMP_OP d[i]) \
 					d[i] = s[i]; \
 			} \
-			fastlock_release(&psmx_atomic_lock); \
+			ofi_spin_unlock(&psmx_atomic_lock); \
 		} while (0)
 
 #define PSMX_ATOMIC_MSWAP(dst,src,cmp,res,cnt,TYPE) \
@@ -173,12 +173,12 @@ void psmx_atomic_fini(void)
 			TYPE *s = (src); \
 			TYPE *c = (cmp); \
 			TYPE *r = (res); \
-			fastlock_acquire(&psmx_atomic_lock); \
+			ofi_spin_lock(&psmx_atomic_lock); \
 			for (i=0; i<(cnt); i++) { \
 				r[i] = d[i]; \
 				d[i] = (s[i] & c[i]) | (d[i] & ~c[i]); \
 			} \
-			fastlock_release(&psmx_atomic_lock); \
+			ofi_spin_unlock(&psmx_atomic_lock); \
 		} while (0)
 
 static int psmx_atomic_do_write(void *dest, void *src,

--- a/prov/psm/src/psmx_cntr.c
+++ b/prov/psm/src/psmx_cntr.c
@@ -174,9 +174,9 @@ void psmx_cntr_check_trigger(struct psmx_fid_cntr *cntr)
 		cntr->trigger = trigger->next;
 
 		if (domain->am_initialized) {
-			fastlock_acquire(&domain->trigger_queue.lock);
+			ofi_spin_lock(&domain->trigger_queue.lock);
 			slist_insert_tail(&trigger->list_entry, &domain->trigger_queue.list);
-			fastlock_release(&domain->trigger_queue.lock);
+			ofi_spin_unlock(&domain->trigger_queue.lock);
 		} else {
 			psmx_process_trigger(domain, trigger);
 		}

--- a/prov/psm/src/psmx_domain.c
+++ b/prov/psm/src/psmx_domain.c
@@ -195,9 +195,9 @@ static int psmx_domain_close(fid_t fid)
 	if (domain->am_initialized)
 		psmx_am_fini(domain);
 
-	fastlock_destroy(&domain->poll_lock);
+	ofi_spin_destroy(&domain->poll_lock);
 	rbtDelete(domain->mr_map);
-	fastlock_destroy(&domain->mr_lock);
+	ofi_spin_destroy(&domain->mr_lock);
 
 #if 0
 	/* AM messages could arrive after MQ is finalized, causing segfault
@@ -294,10 +294,10 @@ static int psmx_domain_init(struct psmx_fid_domain *domain,
 		goto err_out_close_ep;
 	}
 
-	err = fastlock_init(&domain->mr_lock);
+	err = ofi_spin_init(&domain->mr_lock);
 	if (err) {
 		FI_WARN(&psmx_prov, FI_LOG_CORE,
-			"fastlock_init(mr_lock) returns %d\n", err);
+			"ofi_spin_init(mr_lock) returns %d\n", err);
 		goto err_out_finalize_mq;
 	}
 
@@ -310,10 +310,10 @@ static int psmx_domain_init(struct psmx_fid_domain *domain,
 
 	domain->mr_reserved_key = 1;
 
-	err = fastlock_init(&domain->poll_lock);
+	err = ofi_spin_init(&domain->poll_lock);
 	if (err) {
 		FI_WARN(&psmx_prov, FI_LOG_CORE,
-			"fastlock_init(poll_lock) returns %d\n", err);
+			"ofi_spin_init(poll_lock) returns %d\n", err);
 		goto err_out_delete_mr_map;
 	}
 
@@ -335,13 +335,13 @@ static int psmx_domain_init(struct psmx_fid_domain *domain,
 
 err_out_reset_active_domain:
 	fabric->active_domain = NULL;
-	fastlock_destroy(&domain->poll_lock);
+	ofi_spin_destroy(&domain->poll_lock);
 
 err_out_delete_mr_map:
 	rbtDelete(domain->mr_map);
 
 err_out_destroy_mr_lock:
-	fastlock_destroy(&domain->mr_lock);
+	ofi_spin_destroy(&domain->mr_lock);
 
 err_out_finalize_mq:
 	psm_mq_finalize(domain->psm_mq);

--- a/prov/psm/src/psmx_mr.c
+++ b/prov/psm/src/psmx_mr.c
@@ -37,14 +37,14 @@ struct psmx_fid_mr *psmx_mr_get(struct psmx_fid_domain *domain, uint64_t key)
 	RbtIterator it;
 	struct psmx_fid_mr *mr = NULL;
 
-	fastlock_acquire(&domain->mr_lock);
+	ofi_spin_lock(&domain->mr_lock);
 	it = rbtFind(domain->mr_map, (void *)key);
 	if (!it)
 		goto exit;
 
 	rbtKeyValue(domain->mr_map, it, (void **)&key, (void **)&mr);
 exit:
-	fastlock_release(&domain->mr_lock);
+	ofi_spin_unlock(&domain->mr_lock);
 	return mr;
 }
 
@@ -52,11 +52,11 @@ static inline void psmx_mr_release_key(struct psmx_fid_domain *domain, uint64_t 
 {
 	RbtIterator it;
 
-	fastlock_acquire(&domain->mr_lock);
+	ofi_spin_lock(&domain->mr_lock);
 	it = rbtFind(domain->mr_map, (void *)key);
 	if (it)
 		rbtErase(domain->mr_map, it);
-	fastlock_release(&domain->mr_lock);
+	ofi_spin_unlock(&domain->mr_lock);
 }
 
 static int psmx_mr_reserve_key(struct psmx_fid_domain *domain,
@@ -69,7 +69,7 @@ static int psmx_mr_reserve_key(struct psmx_fid_domain *domain,
 	int try_count;
 	int err = -FI_ENOKEY;
 
-	fastlock_acquire(&domain->mr_lock);
+	ofi_spin_lock(&domain->mr_lock);
 
 	if (domain->mr_mode == FI_MR_BASIC) {
 		key = domain->mr_reserved_key;
@@ -91,7 +91,7 @@ static int psmx_mr_reserve_key(struct psmx_fid_domain *domain,
 		}
 	}
 
-	fastlock_release(&domain->mr_lock);
+	ofi_spin_unlock(&domain->mr_lock);
 
 	return err;
 }

--- a/prov/psm/src/psmx_rma.c
+++ b/prov/psm/src/psmx_rma.c
@@ -35,9 +35,9 @@
 static inline void psmx_am_enqueue_rma(struct psmx_fid_domain *domain,
 				       struct psmx_am_request *req)
 {
-	fastlock_acquire(&domain->rma_queue.lock);
+	ofi_spin_lock(&domain->rma_queue.lock);
 	slist_insert_tail(&req->list_entry, &domain->rma_queue.list);
-	fastlock_release(&domain->rma_queue.lock);
+	ofi_spin_unlock(&domain->rma_queue.lock);
 }
 
 /* RMA protocol:

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -458,7 +458,7 @@ struct psmx2_sendv_reply {
 };
 
 struct psmx2_req_queue {
-	fastlock_t	lock;
+	ofi_spin_t	lock;
 	struct slist	list;
 };
 
@@ -479,7 +479,7 @@ struct psmx2_fid_fabric {
 	struct util_ns		name_server;
 
 	/* list of all opened domains */
-	fastlock_t		domain_lock;
+	ofi_spin_t		domain_lock;
 	struct dlist_entry	domain_list;
 };
 
@@ -511,16 +511,16 @@ struct psmx2_trx_ctxt {
 
 	/* request pool for RMA/atomic ops */
 	struct ofi_bufpool	*am_req_pool;
-	fastlock_t		am_req_pool_lock;
+	ofi_spin_t		am_req_pool_lock;
 
 	/* lock to prevent the sequence of psm2_mq_ipeek and psm2_mq_test be
 	 * interleaved in a multithreaded environment.
 	 */
-	fastlock_t		poll_lock;
+	ofi_spin_t		poll_lock;
 
 	/* list of peers connected to this tx/rx context */
 	struct dlist_entry	peer_list;
-	fastlock_t		peer_lock;
+	ofi_spin_t		peer_lock;
 
 	/* number of pathes this tx/rx context can be polled. this include
 	 * CQs and counters, as well as domain->trx_ctxt_list.
@@ -533,9 +533,9 @@ struct psmx2_trx_ctxt {
 	struct dlist_entry	entry;
 };
 
-typedef void	(*psmx2_lock_fn_t) (fastlock_t *lock, int lock_level);
-typedef int	(*psmx2_trylock_fn_t) (fastlock_t *lock, int lock_level);
-typedef void	(*psmx2_unlock_fn_t) (fastlock_t *lock, int lock_level);
+typedef void	(*psmx2_lock_fn_t) (ofi_spin_t *lock, int lock_level);
+typedef int	(*psmx2_trylock_fn_t) (ofi_spin_t *lock, int lock_level);
+typedef void	(*psmx2_unlock_fn_t) (ofi_spin_t *lock, int lock_level);
 
 struct psmx2_fid_domain {
 	struct util_domain	util_domain;
@@ -545,16 +545,16 @@ struct psmx2_fid_domain {
 	psm2_uuid_t		uuid;
 
 	enum fi_mr_mode		mr_mode;
-	fastlock_t		mr_lock;
+	ofi_spin_t		mr_lock;
 	uint64_t		mr_reserved_key;
 	RbtHandle		mr_map;
 
 	/* list of hw contexts opened for this domain */
-	fastlock_t		trx_ctxt_lock;
+	ofi_spin_t		trx_ctxt_lock;
 	struct dlist_entry	trx_ctxt_list;
 
 	ofi_atomic32_t		sep_cnt;
-	fastlock_t		sep_lock;
+	ofi_spin_t		sep_lock;
 	struct dlist_entry	sep_list;
 
 	int			progress_thread_enabled;
@@ -659,7 +659,7 @@ struct psmx2_fid_cq {
 	size_t				event_count;
 	struct slist			event_queue;
 	struct slist			free_list;
-	fastlock_t			lock;
+	ofi_spin_t			lock;
 	struct psmx2_cq_event		*pending_error;
 	struct util_wait		*wait;
 	int				wait_cond;
@@ -686,7 +686,7 @@ struct psmx2_fid_cntr {
 	int			wait_is_local;
 	struct util_wait	*wait;
 	struct psmx2_trigger	*trigger;
-	fastlock_t		trigger_lock;
+	ofi_spin_t		trigger_lock;
 };
 
 #define PSMX2_AV_DEFAULT_SIZE	64
@@ -731,7 +731,7 @@ struct psmx2_fid_av {
 	uint64_t		flags;
 	size_t			addrlen;
 	size_t			count;
-	fastlock_t		lock;
+	ofi_spin_t		lock;
 	struct psmx2_trx_ctxt	*av_map_trx_ctxt;
 	struct util_shm		shm;
 	struct psmx2_av_hdr	*hdr;	/* shared AV header */
@@ -889,51 +889,51 @@ extern struct psmx2_fid_fabric	*psmx2_active_fabric;
  *     1 -- lock needed if there is more than one thread (including internal threads)
  *     2 -- lock needed if more then one thread accesses the same psm2 ep
  */
-static inline void psmx2_lock(fastlock_t *lock, int lock_level)
+static inline void psmx2_lock(ofi_spin_t *lock, int lock_level)
 {
 	if (psmx2_env.lock_level >= lock_level)
-		fastlock_acquire(lock);
+		ofi_spin_lock(lock);
 }
 
-static inline int psmx2_trylock(fastlock_t *lock, int lock_level)
+static inline int psmx2_trylock(ofi_spin_t *lock, int lock_level)
 {
 	if (psmx2_env.lock_level >= lock_level)
-		return fastlock_tryacquire(lock);
+		return ofi_spin_trylock(lock);
 	else
 		return 0;
 }
 
-static inline void psmx2_unlock(fastlock_t *lock, int lock_level)
+static inline void psmx2_unlock(ofi_spin_t *lock, int lock_level)
 {
 	if (psmx2_env.lock_level >= lock_level)
-		fastlock_release(lock);
+		ofi_spin_unlock(lock);
 }
 
 /* Specialized lock functions used based on FI_THREAD model */
 
-static inline void psmx2_lock_disabled(fastlock_t *lock, int lock_level)
+static inline void psmx2_lock_disabled(ofi_spin_t *lock, int lock_level)
 {
 	return;
 }
 
-static inline int psmx2_trylock_disabled(fastlock_t *lock, int lock_level)
+static inline int psmx2_trylock_disabled(ofi_spin_t *lock, int lock_level)
 {
 	return 0;
 }
 
-static inline void psmx2_lock_enabled(fastlock_t *lock, int lock_level)
+static inline void psmx2_lock_enabled(ofi_spin_t *lock, int lock_level)
 {
-	fastlock_acquire(lock);
+	ofi_spin_lock(lock);
 }
 
-static inline void psmx2_unlock_enabled(fastlock_t *lock, int lock_level)
+static inline void psmx2_unlock_enabled(ofi_spin_t *lock, int lock_level)
 {
-	fastlock_release(lock);
+	ofi_spin_unlock(lock);
 }
 
-static inline int psmx2_trylock_enabled(fastlock_t *lock, int lock_level)
+static inline int psmx2_trylock_enabled(ofi_spin_t *lock, int lock_level)
 {
-	return fastlock_tryacquire(lock);
+	return ofi_spin_trylock(lock);
 }
 
 int	psmx2_init_prov_info(const struct fi_info *hints, struct fi_info **info);

--- a/prov/psm2/src/psmx2_atomic.c
+++ b/prov/psm2/src/psmx2_atomic.c
@@ -50,16 +50,16 @@
  *	args[1].u64	req
  */
 
-static fastlock_t psmx2_atomic_lock;
+static ofi_spin_t psmx2_atomic_lock;
 
 void psmx2_atomic_global_init(void)
 {
-	fastlock_init(&psmx2_atomic_lock);
+	ofi_spin_init(&psmx2_atomic_lock);
 }
 
 void psmx2_atomic_global_fini(void)
 {
-	fastlock_destroy(&psmx2_atomic_lock);
+	ofi_spin_destroy(&psmx2_atomic_lock);
 }
 
 static inline void psmx2_ioc_read(const struct fi_ioc *ioc, size_t count,

--- a/prov/psm2/src/psmx2_av.c
+++ b/prov/psm2/src/psmx2_av.c
@@ -954,7 +954,7 @@ static int psmx2_av_close(fid_t fid)
 
 	av = container_of(fid, struct psmx2_fid_av, av.fid);
 	psmx2_domain_release(av->domain);
-	fastlock_destroy(&av->lock);
+	ofi_spin_destroy(&av->lock);
 
 	if (av->type == FI_AV_MAP)
 		goto out;
@@ -1151,7 +1151,7 @@ int psmx2_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 	}
 
 init_lock:
-	fastlock_init(&av_priv->lock);
+	ofi_spin_init(&av_priv->lock);
 
 	psmx2_domain_acquire(domain_priv);
 

--- a/prov/psm2/src/psmx2_cntr.c
+++ b/prov/psm2/src/psmx2_cntr.c
@@ -287,7 +287,7 @@ static int psmx2_cntr_close(fid_t fid)
 			fi_close((fid_t)cntr->wait);
 	}
 
-	fastlock_destroy(&cntr->trigger_lock);
+	ofi_spin_destroy(&cntr->trigger_lock);
 	psmx2_domain_release(cntr->domain);
 	free(cntr);
 
@@ -426,7 +426,7 @@ int psmx2_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 	ofi_atomic_initialize64(&cntr_priv->error_counter, 0);
 
 	slist_init(&cntr_priv->poll_list);
-	fastlock_init(&cntr_priv->trigger_lock);
+	ofi_spin_init(&cntr_priv->trigger_lock);
 
 	if (wait)
 		fi_poll_add(&cntr_priv->wait->pollset->poll_fid,

--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -961,7 +961,7 @@ static inline int psmx2_cq_any_complete(struct psmx2_fid_cq *poll_cq,
 
 		if (event == event_in) {
 			if (src_addr) {
-				src_addr[*read_count] = 
+				src_addr[*read_count] =
 					psmx2_av_translate_source(av, source, source_sep_id);
 				if (src_addr[*read_count] == FI_ADDR_NOTAVAIL) {
 					event = psmx2_cq_alloc_event(comp_cq);
@@ -1831,7 +1831,7 @@ static int psmx2_cq_close(fid_t fid)
 		free(item);
 	}
 
-	fastlock_destroy(&cq->lock);
+	ofi_spin_destroy(&cq->lock);
 
 	if (cq->wait) {
 		fi_poll_del(&cq->wait->pollset->poll_fid, &cq->cq.fid, 0);
@@ -2004,7 +2004,7 @@ int psmx2_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	slist_init(&cq_priv->poll_list);
 	slist_init(&cq_priv->event_queue);
 	slist_init(&cq_priv->free_list);
-	fastlock_init(&cq_priv->lock);
+	ofi_spin_init(&cq_priv->lock);
 
 #define PSMX2_FREE_LIST_SIZE	64
 	for (i=0; i<PSMX2_FREE_LIST_SIZE; i++) {

--- a/prov/psm2/src/psmx2_domain.c
+++ b/prov/psm2/src/psmx2_domain.c
@@ -190,8 +190,8 @@ static int psmx2_domain_close(fid_t fid)
 	if (domain->progress_thread_enabled)
 		psmx2_domain_stop_progress(domain);
 
-	fastlock_destroy(&domain->sep_lock);
-	fastlock_destroy(&domain->mr_lock);
+	ofi_spin_destroy(&domain->sep_lock);
+	ofi_spin_destroy(&domain->mr_lock);
 	rbtDelete(domain->mr_map);
 
 	psmx2_lock(&domain->fabric->domain_lock, 1);
@@ -206,13 +206,13 @@ static int psmx2_domain_close(fid_t fid)
 static int psmx2_domain_get_val(struct fid *fid, int var, void *val)
 {
 	struct psmx2_fid_domain *domain;
- 
+
 	if (!val)
 		return -FI_EINVAL;
 
 	domain = container_of(fid, struct psmx2_fid_domain,
 			      util_domain.domain_fid.fid);
- 
+
 	switch (var) {
 	case FI_PSM2_DISCONNECT:
 		*(uint32_t *)val = domain->params.disconnect;
@@ -226,13 +226,13 @@ static int psmx2_domain_get_val(struct fid *fid, int var, void *val)
 static int psmx2_domain_set_val(struct fid *fid, int var, void *val)
 {
 	struct psmx2_fid_domain *domain;
- 
+
 	if (!val)
 		return -FI_EINVAL;
 
 	domain = container_of(fid, struct psmx2_fid_domain,
 			      util_domain.domain_fid.fid);
- 
+
 	switch (var) {
 	case FI_PSM2_DISCONNECT:
 		domain->params.disconnect = *(uint32_t *)val;
@@ -308,10 +308,10 @@ static int psmx2_domain_init(struct psmx2_fid_domain *domain,
 {
 	int err;
 
-	err = fastlock_init(&domain->mr_lock);
+	err = ofi_spin_init(&domain->mr_lock);
 	if (err) {
 		FI_WARN(&psmx2_prov, FI_LOG_CORE,
-			"fastlock_init(mr_lock) returns %d\n", err);
+			"ofi_spin_init(mr_lock) returns %d\n", err);
 		goto err_out;
 	}
 
@@ -326,10 +326,10 @@ static int psmx2_domain_init(struct psmx2_fid_domain *domain,
 	domain->max_atomic_size = INT_MAX;
 
 	ofi_atomic_initialize32(&domain->sep_cnt, 0);
-	fastlock_init(&domain->sep_lock);
+	ofi_spin_init(&domain->sep_lock);
 	dlist_init(&domain->sep_list);
 	dlist_init(&domain->trx_ctxt_list);
-	fastlock_init(&domain->trx_ctxt_lock);
+	ofi_spin_init(&domain->trx_ctxt_lock);
 
 	if (domain->progress_thread_enabled)
 		psmx2_domain_start_progress(domain);
@@ -337,7 +337,7 @@ static int psmx2_domain_init(struct psmx2_fid_domain *domain,
 	return 0;
 
 err_out_destroy_mr_lock:
-	fastlock_destroy(&domain->mr_lock);
+	ofi_spin_destroy(&domain->mr_lock);
 
 err_out:
 	return err;

--- a/prov/psm2/src/psmx2_fabric.c
+++ b/prov/psm2/src/psmx2_fabric.c
@@ -53,7 +53,7 @@ static int psmx2_fabric_close(fid_t fid)
 	if (psmx2_env.name_server)
 		ofi_ns_stop_server(&fabric->name_server);
 
-	fastlock_destroy(&fabric->domain_lock);
+	ofi_spin_destroy(&fabric->domain_lock);
 	assert(fabric == psmx2_active_fabric);
 	psmx2_active_fabric = NULL;
 	free(fabric);
@@ -102,7 +102,7 @@ int psmx2_fabric(struct fi_fabric_attr *attr,
 	if (!fabric_priv)
 		return -FI_ENOMEM;
 
-	fastlock_init(&fabric_priv->domain_lock);
+	ofi_spin_init(&fabric_priv->domain_lock);
 	dlist_init(&fabric_priv->domain_list);
 
 	if (psmx2_env.name_server) {

--- a/prov/psm2/src/psmx2_trx_ctxt.c
+++ b/prov/psm2/src/psmx2_trx_ctxt.c
@@ -225,9 +225,9 @@ void psmx2_trx_ctxt_free(struct psmx2_trx_ctxt *trx_ctxt, int usage_flags)
 		psm2_ep_close(trx_ctxt->psm2_ep, PSM2_EP_CLOSE_FORCE, 0);
 
 	ofi_bufpool_destroy(trx_ctxt->am_req_pool);
-	fastlock_destroy(&trx_ctxt->am_req_pool_lock);
-	fastlock_destroy(&trx_ctxt->poll_lock);
-	fastlock_destroy(&trx_ctxt->peer_lock);
+	ofi_spin_destroy(&trx_ctxt->am_req_pool_lock);
+	ofi_spin_destroy(&trx_ctxt->poll_lock);
+	ofi_spin_destroy(&trx_ctxt->peer_lock);
 
 	if (!ofi_atomic_dec32(&trx_ctxt->poll_refcnt))
 		free(trx_ctxt);
@@ -341,13 +341,13 @@ struct psmx2_trx_ctxt *psmx2_trx_ctxt_alloc(struct psmx2_fid_domain *domain,
 	}
 
 #if !HAVE_PSM2_MQ_FP_MSG
-	fastlock_init(&trx_ctxt->rma_queue.lock);
+	ofi_spin_init(&trx_ctxt->rma_queue.lock);
 	slist_init(&trx_ctxt->rma_queue.list);
 #endif
-	fastlock_init(&trx_ctxt->peer_lock);
-	fastlock_init(&trx_ctxt->poll_lock);
-	fastlock_init(&trx_ctxt->am_req_pool_lock);
-	fastlock_init(&trx_ctxt->trigger_queue.lock);
+	ofi_spin_init(&trx_ctxt->peer_lock);
+	ofi_spin_init(&trx_ctxt->poll_lock);
+	ofi_spin_init(&trx_ctxt->am_req_pool_lock);
+	ofi_spin_init(&trx_ctxt->trigger_queue.lock);
 	dlist_init(&trx_ctxt->peer_list);
 	slist_init(&trx_ctxt->trigger_queue.list);
 	trx_ctxt->id = psmx2_trx_ctxt_cnt++;

--- a/prov/psm2/src/version.h
+++ b/prov/psm2/src/version.h
@@ -171,14 +171,14 @@ struct psmx2_context {
 
 #define PSMX2_EP_DECL_OP_CONTEXT \
 	struct slist	free_context_list; \
-	fastlock_t	context_lock;
+	ofi_spin_t	context_lock;
 
 #define PSMX2_EP_INIT_OP_CONTEXT(ep) \
 	do { \
 		struct psmx2_context *item; \
 		int i; \
 		slist_init(&(ep)->free_context_list); \
-		fastlock_init(&(ep)->context_lock); \
+		ofi_spin_init(&(ep)->context_lock); \
 		for (i = 0; i < 64; i++) { \
 			item = calloc(1, sizeof(*item)); \
 			if (!item) { \
@@ -198,7 +198,7 @@ struct psmx2_context {
 			item = container_of(entry, struct psmx2_context, list_entry); \
 			free(item); \
 		} \
-		fastlock_destroy(&(ep)->context_lock); \
+		ofi_spin_destroy(&(ep)->context_lock); \
 	} while (0)
 
 #define PSMX2_EP_GET_OP_CONTEXT(ep, ctx) \

--- a/prov/psm3/src/psmx3_atomic.c
+++ b/prov/psm3/src/psmx3_atomic.c
@@ -50,16 +50,16 @@
  *	args[1].u64	req
  */
 
-static fastlock_t psmx3_atomic_lock;
+static ofi_spin_t psmx3_atomic_lock;
 
 void psmx3_atomic_global_init(void)
 {
-	fastlock_init(&psmx3_atomic_lock);
+	ofi_spin_init(&psmx3_atomic_lock);
 }
 
 void psmx3_atomic_global_fini(void)
 {
-	fastlock_destroy(&psmx3_atomic_lock);
+	ofi_spin_destroy(&psmx3_atomic_lock);
 }
 
 static inline void psmx3_ioc_read(const struct fi_ioc *ioc, size_t count,

--- a/prov/psm3/src/psmx3_av.c
+++ b/prov/psm3/src/psmx3_av.c
@@ -959,7 +959,7 @@ static int psmx3_av_close(fid_t fid)
 
 	av = container_of(fid, struct psmx3_fid_av, av.fid);
 	psmx3_domain_release(av->domain);
-	fastlock_destroy(&av->lock);
+	ofi_spin_destroy(&av->lock);
 
 	if (av->type == FI_AV_MAP)
 		goto out;
@@ -1156,7 +1156,7 @@ int psmx3_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 	}
 
 init_lock:
-	fastlock_init(&av_priv->lock);
+	ofi_spin_init(&av_priv->lock);
 
 	psmx3_domain_acquire(domain_priv);
 

--- a/prov/psm3/src/psmx3_cntr.c
+++ b/prov/psm3/src/psmx3_cntr.c
@@ -287,7 +287,7 @@ static int psmx3_cntr_close(fid_t fid)
 			fi_close((fid_t)cntr->wait);
 	}
 
-	fastlock_destroy(&cntr->trigger_lock);
+	ofi_spin_destroy(&cntr->trigger_lock);
 	psmx3_domain_release(cntr->domain);
 	free(cntr);
 
@@ -426,7 +426,7 @@ int psmx3_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 	ofi_atomic_initialize64(&cntr_priv->error_counter, 0);
 
 	slist_init(&cntr_priv->poll_list);
-	fastlock_init(&cntr_priv->trigger_lock);
+	ofi_spin_init(&cntr_priv->trigger_lock);
 
 	if (wait)
 		fi_poll_add(&cntr_priv->wait->pollset->poll_fid,

--- a/prov/psm3/src/psmx3_cq.c
+++ b/prov/psm3/src/psmx3_cq.c
@@ -1105,7 +1105,7 @@ static int psmx3_cq_close(fid_t fid)
 		free(item);
 	}
 
-	fastlock_destroy(&cq->lock);
+	ofi_spin_destroy(&cq->lock);
 
 	if (cq->wait) {
 		fi_poll_del(&cq->wait->pollset->poll_fid, &cq->cq.fid, 0);
@@ -1278,7 +1278,7 @@ int psmx3_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	slist_init(&cq_priv->poll_list);
 	slist_init(&cq_priv->event_queue);
 	slist_init(&cq_priv->free_list);
-	fastlock_init(&cq_priv->lock);
+	ofi_spin_init(&cq_priv->lock);
 
 #define PSMX3_FREE_LIST_SIZE	64
 	for (i=0; i<PSMX3_FREE_LIST_SIZE; i++) {

--- a/prov/psm3/src/psmx3_domain.c
+++ b/prov/psm3/src/psmx3_domain.c
@@ -190,8 +190,8 @@ static int psmx3_domain_close(fid_t fid)
 	if (domain->progress_thread_enabled)
 		psmx3_domain_stop_progress(domain);
 
-	fastlock_destroy(&domain->sep_lock);
-	fastlock_destroy(&domain->mr_lock);
+	ofi_spin_destroy(&domain->sep_lock);
+	ofi_spin_destroy(&domain->mr_lock);
 	rbtDelete(domain->mr_map);
 
 	psmx3_lock(&domain->fabric->domain_lock, 1);
@@ -259,10 +259,10 @@ static int psmx3_domain_init(struct psmx3_fid_domain *domain,
 {
 	int err;
 
-	err = fastlock_init(&domain->mr_lock);
+	err = ofi_spin_init(&domain->mr_lock);
 	if (err) {
 		FI_WARN(&psmx3_prov, FI_LOG_CORE,
-			"fastlock_init(mr_lock) returns %d\n", err);
+			"ofi_spin_init(mr_lock) returns %d\n", err);
 		goto err_out;
 	}
 
@@ -277,10 +277,10 @@ static int psmx3_domain_init(struct psmx3_fid_domain *domain,
 	domain->max_atomic_size = INT_MAX;
 
 	ofi_atomic_initialize32(&domain->sep_cnt, 0);
-	fastlock_init(&domain->sep_lock);
+	ofi_spin_init(&domain->sep_lock);
 	dlist_init(&domain->sep_list);
 	dlist_init(&domain->trx_ctxt_list);
-	fastlock_init(&domain->trx_ctxt_lock);
+	ofi_spin_init(&domain->trx_ctxt_lock);
 
 	if (domain->progress_thread_enabled)
 		psmx3_domain_start_progress(domain);
@@ -288,7 +288,7 @@ static int psmx3_domain_init(struct psmx3_fid_domain *domain,
 	return 0;
 
 err_out_destroy_mr_lock:
-	fastlock_destroy(&domain->mr_lock);
+	ofi_spin_destroy(&domain->mr_lock);
 
 err_out:
 	return err;

--- a/prov/psm3/src/psmx3_fabric.c
+++ b/prov/psm3/src/psmx3_fabric.c
@@ -53,7 +53,7 @@ static int psmx3_fabric_close(fid_t fid)
 	if (psmx3_env.name_server)
 		ofi_ns_stop_server(&fabric->name_server);
 
-	fastlock_destroy(&fabric->domain_lock);
+	ofi_spin_destroy(&fabric->domain_lock);
 	assert(fabric == psmx3_active_fabric);
 	psmx3_active_fabric = NULL;
 	free(fabric);
@@ -101,7 +101,7 @@ int psmx3_fabric(struct fi_fabric_attr *attr,
 	if (!fabric_priv)
 		return -FI_ENOMEM;
 
-	fastlock_init(&fabric_priv->domain_lock);
+	ofi_spin_init(&fabric_priv->domain_lock);
 	dlist_init(&fabric_priv->domain_list);
 
 	psmx3_get_uuid(fabric_priv->uuid);

--- a/prov/psm3/src/psmx3_trx_ctxt.c
+++ b/prov/psm3/src/psmx3_trx_ctxt.c
@@ -225,9 +225,9 @@ void psmx3_trx_ctxt_free(struct psmx3_trx_ctxt *trx_ctxt, int usage_flags)
 		psm2_ep_close(trx_ctxt->psm2_ep, PSM2_EP_CLOSE_FORCE, 0);
 
 	ofi_bufpool_destroy(trx_ctxt->am_req_pool);
-	fastlock_destroy(&trx_ctxt->am_req_pool_lock);
-	fastlock_destroy(&trx_ctxt->poll_lock);
-	fastlock_destroy(&trx_ctxt->peer_lock);
+	ofi_spin_destroy(&trx_ctxt->am_req_pool_lock);
+	ofi_spin_destroy(&trx_ctxt->poll_lock);
+	ofi_spin_destroy(&trx_ctxt->peer_lock);
 
 	if (!ofi_atomic_dec32(&trx_ctxt->poll_refcnt))
 		free(trx_ctxt);
@@ -333,10 +333,10 @@ struct psmx3_trx_ctxt *psmx3_trx_ctxt_alloc(struct psmx3_fid_domain *domain,
 		goto err_out_close_ep;
 	}
 
-	fastlock_init(&trx_ctxt->peer_lock);
-	fastlock_init(&trx_ctxt->poll_lock);
-	fastlock_init(&trx_ctxt->am_req_pool_lock);
-	fastlock_init(&trx_ctxt->trigger_queue.lock);
+	ofi_spin_init(&trx_ctxt->peer_lock);
+	ofi_spin_init(&trx_ctxt->poll_lock);
+	ofi_spin_init(&trx_ctxt->am_req_pool_lock);
+	ofi_spin_init(&trx_ctxt->trigger_queue.lock);
 	dlist_init(&trx_ctxt->peer_list);
 	slist_init(&trx_ctxt->trigger_queue.list);
 	trx_ctxt->id = psmx3_trx_ctxt_cnt++;

--- a/prov/psm3/src/version.h
+++ b/prov/psm3/src/version.h
@@ -107,14 +107,14 @@ struct psmx3_context {
 
 #define PSMX3_EP_DECL_OP_CONTEXT \
 	struct slist	free_context_list; \
-	fastlock_t	context_lock;
+	ofi_spin_t	context_lock;
 
 #define PSMX3_EP_INIT_OP_CONTEXT(ep) \
 	do { \
 		struct psmx3_context *item; \
 		int i; \
 		slist_init(&(ep)->free_context_list); \
-		fastlock_init(&(ep)->context_lock); \
+		ofi_spin_init(&(ep)->context_lock); \
 		for (i = 0; i < 64; i++) { \
 			item = calloc(1, sizeof(*item)); \
 			if (!item) { \
@@ -134,7 +134,7 @@ struct psmx3_context {
 			item = container_of(entry, struct psmx3_context, list_entry); \
 			free(item); \
 		} \
-		fastlock_destroy(&(ep)->context_lock); \
+		ofi_spin_destroy(&(ep)->context_lock); \
 	} while (0)
 
 #define PSMX3_EP_GET_OP_CONTEXT(ep, ctx) \

--- a/prov/rstream/src/rstream.h
+++ b/prov/rstream/src/rstream.h
@@ -180,7 +180,7 @@ struct rstream_ep {
 	ofi_spin_t send_lock;
 	ofi_spin_t recv_lock;
 	/* must take send/recv lock before cq_lock */
-	ofi_spin_t cq_lock;
+	ofi_mutex_t cq_lock;
 };
 
 struct rstream_pep {

--- a/prov/rstream/src/rstream.h
+++ b/prov/rstream/src/rstream.h
@@ -177,10 +177,10 @@ struct rstream_ep {
 	uint32_t rx_ctx_index;
 	struct rstream_tx_ctx_fs *tx_ctxs;
 	struct rstream_cq_data rx_cq_data;
-	fastlock_t send_lock;
-	fastlock_t recv_lock;
+	ofi_spin_t send_lock;
+	ofi_spin_t recv_lock;
 	/* must take send/recv lock before cq_lock */
-	fastlock_t cq_lock;
+	ofi_spin_t cq_lock;
 };
 
 struct rstream_pep {

--- a/prov/rstream/src/rstream.h
+++ b/prov/rstream/src/rstream.h
@@ -177,8 +177,8 @@ struct rstream_ep {
 	uint32_t rx_ctx_index;
 	struct rstream_tx_ctx_fs *tx_ctxs;
 	struct rstream_cq_data rx_cq_data;
-	ofi_spin_t send_lock;
-	ofi_spin_t recv_lock;
+	ofi_mutex_t send_lock;
+	ofi_mutex_t recv_lock;
 	/* must take send/recv lock before cq_lock */
 	ofi_mutex_t cq_lock;
 };

--- a/prov/rstream/src/rstream_ep.c
+++ b/prov/rstream/src/rstream_ep.c
@@ -56,9 +56,9 @@ static int rstream_ep_close(fid_t fid)
 
 	rstream_tx_ctx_fs_free(rstream_ep->tx_ctxs);
 
-	fastlock_destroy(&rstream_ep->send_lock);
-	fastlock_destroy(&rstream_ep->recv_lock);
-	fastlock_destroy(&rstream_ep->cq_lock);
+	ofi_spin_destroy(&rstream_ep->send_lock);
+	ofi_spin_destroy(&rstream_ep->recv_lock);
+	ofi_spin_destroy(&rstream_ep->cq_lock);
 	free(rstream_ep->rx_ctxs);
 	free(rstream_ep);
 	return 0;
@@ -289,9 +289,9 @@ int rstream_ep_open(struct fid_domain *domain, struct fi_info *info,
 	(*ep_fid)->ops = &rstream_ops_ep;
 	(*ep_fid)->cm = &rstream_ops_cm;
 	(*ep_fid)->msg = &rstream_ops_msg;
-	fastlock_init(&rstream_ep->send_lock);
-	fastlock_init(&rstream_ep->recv_lock);
-	fastlock_init(&rstream_ep->cq_lock);
+	ofi_spin_init(&rstream_ep->send_lock);
+	ofi_spin_init(&rstream_ep->recv_lock);
+	ofi_spin_init(&rstream_ep->cq_lock);
 	return 0;
 
 err1:

--- a/prov/rstream/src/rstream_ep.c
+++ b/prov/rstream/src/rstream_ep.c
@@ -58,7 +58,7 @@ static int rstream_ep_close(fid_t fid)
 
 	ofi_spin_destroy(&rstream_ep->send_lock);
 	ofi_spin_destroy(&rstream_ep->recv_lock);
-	ofi_spin_destroy(&rstream_ep->cq_lock);
+	ofi_mutex_destroy(&rstream_ep->cq_lock);
 	free(rstream_ep->rx_ctxs);
 	free(rstream_ep);
 	return 0;
@@ -291,7 +291,7 @@ int rstream_ep_open(struct fid_domain *domain, struct fi_info *info,
 	(*ep_fid)->msg = &rstream_ops_msg;
 	ofi_spin_init(&rstream_ep->send_lock);
 	ofi_spin_init(&rstream_ep->recv_lock);
-	ofi_spin_init(&rstream_ep->cq_lock);
+	ofi_mutex_init(&rstream_ep->cq_lock);
 	return 0;
 
 err1:

--- a/prov/rstream/src/rstream_ep.c
+++ b/prov/rstream/src/rstream_ep.c
@@ -56,8 +56,8 @@ static int rstream_ep_close(fid_t fid)
 
 	rstream_tx_ctx_fs_free(rstream_ep->tx_ctxs);
 
-	ofi_spin_destroy(&rstream_ep->send_lock);
-	ofi_spin_destroy(&rstream_ep->recv_lock);
+	ofi_mutex_destroy(&rstream_ep->send_lock);
+	ofi_mutex_destroy(&rstream_ep->recv_lock);
 	ofi_mutex_destroy(&rstream_ep->cq_lock);
 	free(rstream_ep->rx_ctxs);
 	free(rstream_ep);
@@ -289,8 +289,8 @@ int rstream_ep_open(struct fid_domain *domain, struct fi_info *info,
 	(*ep_fid)->ops = &rstream_ops_ep;
 	(*ep_fid)->cm = &rstream_ops_cm;
 	(*ep_fid)->msg = &rstream_ops_msg;
-	ofi_spin_init(&rstream_ep->send_lock);
-	ofi_spin_init(&rstream_ep->recv_lock);
+	ofi_mutex_init(&rstream_ep->send_lock);
+	ofi_mutex_init(&rstream_ep->recv_lock);
 	ofi_mutex_init(&rstream_ep->cq_lock);
 	return 0;
 

--- a/prov/rstream/src/rstream_msg.c
+++ b/prov/rstream/src/rstream_msg.c
@@ -411,7 +411,7 @@ ssize_t rstream_process_cq(struct rstream_ep *ep, enum rstream_msg_type type)
 	enum rstream_msg_type comp_type;
 	int len;
 
-	fastlock_acquire(&ep->cq_lock);
+	ofi_spin_lock(&ep->cq_lock);
 	do {
 		ret = rstream_check_cq(ep, &cq_entry);
 		if (ret == 1) {
@@ -445,7 +445,7 @@ ssize_t rstream_process_cq(struct rstream_ep *ep, enum rstream_msg_type type)
 		!found_msg_type) || (found_msg_type && ret > 0));
 
 	ret = rstream_update_target(ep, rx_completions, 0);
-	fastlock_release(&ep->cq_lock);
+	ofi_spin_unlock(&ep->cq_lock);
 	if (ret)
 		return ret;
 
@@ -454,7 +454,7 @@ ssize_t rstream_process_cq(struct rstream_ep *ep, enum rstream_msg_type type)
 	else
 		return -FI_EAGAIN;
 out:
-	fastlock_release(&ep->cq_lock);
+	ofi_spin_unlock(&ep->cq_lock);
 	return ret;
 }
 
@@ -510,14 +510,14 @@ static ssize_t rstream_send(struct fid_ep *ep_fid, const void *buf, size_t len,
 	uint32_t curr_avail_len = len;
 	void *ctx;
 
-	fastlock_acquire(&ep->send_lock);
+	ofi_spin_lock(&ep->send_lock);
 	do {
 		ret = rstream_can_send(ep);
 		if (ret < 0) {
 			if (ret < 0 && ret != -FI_EAGAIN) {
 				goto err;
 			} else {
-				fastlock_release(&ep->send_lock);
+				ofi_spin_unlock(&ep->send_lock);
 				return ((sent_len) ? sent_len : ret);
 			}
 		}
@@ -556,11 +556,11 @@ static ssize_t rstream_send(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	} while(curr_avail_len); /* circle buffer rollover requires two loops */
 
-	fastlock_release(&ep->send_lock);
+	ofi_spin_unlock(&ep->send_lock);
 	return sent_len;
 
 err:
-	fastlock_release(&ep->send_lock);
+	ofi_spin_unlock(&ep->send_lock);
 	return ret;
 }
 
@@ -578,9 +578,9 @@ static ssize_t rstream_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 		util_ep.ep_fid);
 
 	if (flags == FI_PEEK) {
-		fastlock_acquire(&ep->send_lock);
+		ofi_spin_lock(&ep->send_lock);
 		ret = rstream_can_send(ep);
-		fastlock_release(&ep->send_lock);
+		ofi_spin_unlock(&ep->send_lock);
 		return ret;
 	} else {
 		return -FI_ENOSYS;
@@ -649,14 +649,14 @@ static ssize_t rstream_recv(struct fid_ep *ep_fid, void *buf, size_t len,
 	uint32_t copy_out_len = 0;
 	ssize_t ret;
 
-	fastlock_acquire(&ep->recv_lock);
+	ofi_spin_lock(&ep->recv_lock);
 
 	copy_out_len = rstream_copy_out_chunk(ep, buf, len);
 
 	if ((len - copy_out_len)) {
 		ret = rstream_process_cq(ep, RSTREAM_RX_MSG_COMP);
 		if(ret < 0 && ret != -FI_EAGAIN) {
-			fastlock_release(&ep->recv_lock);
+			ofi_spin_unlock(&ep->recv_lock);
 			return ret;
 		}
 
@@ -664,10 +664,10 @@ static ssize_t rstream_recv(struct fid_ep *ep_fid, void *buf, size_t len,
 			((char *)buf + copy_out_len), (len - copy_out_len));
 	}
 
-	fastlock_acquire(&ep->send_lock);
+	ofi_spin_lock(&ep->send_lock);
 	ret = rstream_update_target(ep, 0, copy_out_len);
-	fastlock_release(&ep->send_lock);
-	fastlock_release(&ep->recv_lock);
+	ofi_spin_unlock(&ep->send_lock);
+	ofi_spin_unlock(&ep->recv_lock);
 	if(ret < 0 && ret != -FI_EAGAIN) {
 		return ret;
 	}
@@ -696,32 +696,32 @@ static ssize_t rstream_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 		util_ep.ep_fid);
 
 	if (flags == FI_PEEK) {
-		fastlock_acquire(&ep->recv_lock);
+		ofi_spin_lock(&ep->recv_lock);
 		if (!ep->local_mr.rx.avail_size) {
 			ret = rstream_process_cq(ep, RSTREAM_RX_MSG_COMP);
 			if (ret < 0) {
-				fastlock_release(&ep->recv_lock);
+				ofi_spin_unlock(&ep->recv_lock);
 				return ret;
 			}
 		}
-		fastlock_release(&ep->recv_lock);
+		ofi_spin_unlock(&ep->recv_lock);
 
-		fastlock_acquire(&ep->send_lock);
+		ofi_spin_lock(&ep->send_lock);
 		if (rstream_target_rx_full(ep)) {
 			ret = rstream_process_cq(ep, RSTREAM_RX_MSG_COMP);
 			if (ret < 0) {
-				fastlock_release(&ep->send_lock);
+				ofi_spin_unlock(&ep->send_lock);
 				return ret;
 			}
 		}
 
 		if (!ep->qp_win.ctrl_credits) {
 			ret = rstream_process_cq(ep, RSTREAM_TX_MSG_COMP);
-			fastlock_release(&ep->send_lock);
+			ofi_spin_unlock(&ep->send_lock);
 			return ret;
 		}
 
-		fastlock_release(&ep->send_lock);
+		ofi_spin_unlock(&ep->send_lock);
 		return 0;
 	} else {
 		return -FI_ENOSYS;

--- a/prov/rstream/src/rstream_msg.c
+++ b/prov/rstream/src/rstream_msg.c
@@ -411,7 +411,7 @@ ssize_t rstream_process_cq(struct rstream_ep *ep, enum rstream_msg_type type)
 	enum rstream_msg_type comp_type;
 	int len;
 
-	ofi_spin_lock(&ep->cq_lock);
+	ofi_mutex_lock(&ep->cq_lock);
 	do {
 		ret = rstream_check_cq(ep, &cq_entry);
 		if (ret == 1) {
@@ -445,7 +445,7 @@ ssize_t rstream_process_cq(struct rstream_ep *ep, enum rstream_msg_type type)
 		!found_msg_type) || (found_msg_type && ret > 0));
 
 	ret = rstream_update_target(ep, rx_completions, 0);
-	ofi_spin_unlock(&ep->cq_lock);
+	ofi_mutex_unlock(&ep->cq_lock);
 	if (ret)
 		return ret;
 
@@ -454,7 +454,7 @@ ssize_t rstream_process_cq(struct rstream_ep *ep, enum rstream_msg_type type)
 	else
 		return -FI_EAGAIN;
 out:
-	ofi_spin_unlock(&ep->cq_lock);
+	ofi_mutex_unlock(&ep->cq_lock);
 	return ret;
 }
 

--- a/prov/rstream/src/rstream_msg.c
+++ b/prov/rstream/src/rstream_msg.c
@@ -510,14 +510,14 @@ static ssize_t rstream_send(struct fid_ep *ep_fid, const void *buf, size_t len,
 	uint32_t curr_avail_len = len;
 	void *ctx;
 
-	ofi_spin_lock(&ep->send_lock);
+	ofi_mutex_lock(&ep->send_lock);
 	do {
 		ret = rstream_can_send(ep);
 		if (ret < 0) {
 			if (ret < 0 && ret != -FI_EAGAIN) {
 				goto err;
 			} else {
-				ofi_spin_unlock(&ep->send_lock);
+				ofi_mutex_unlock(&ep->send_lock);
 				return ((sent_len) ? sent_len : ret);
 			}
 		}
@@ -556,11 +556,11 @@ static ssize_t rstream_send(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	} while(curr_avail_len); /* circle buffer rollover requires two loops */
 
-	ofi_spin_unlock(&ep->send_lock);
+	ofi_mutex_unlock(&ep->send_lock);
 	return sent_len;
 
 err:
-	ofi_spin_unlock(&ep->send_lock);
+	ofi_mutex_unlock(&ep->send_lock);
 	return ret;
 }
 
@@ -578,9 +578,9 @@ static ssize_t rstream_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 		util_ep.ep_fid);
 
 	if (flags == FI_PEEK) {
-		ofi_spin_lock(&ep->send_lock);
+		ofi_mutex_lock(&ep->send_lock);
 		ret = rstream_can_send(ep);
-		ofi_spin_unlock(&ep->send_lock);
+		ofi_mutex_unlock(&ep->send_lock);
 		return ret;
 	} else {
 		return -FI_ENOSYS;
@@ -649,14 +649,14 @@ static ssize_t rstream_recv(struct fid_ep *ep_fid, void *buf, size_t len,
 	uint32_t copy_out_len = 0;
 	ssize_t ret;
 
-	ofi_spin_lock(&ep->recv_lock);
+	ofi_mutex_lock(&ep->recv_lock);
 
 	copy_out_len = rstream_copy_out_chunk(ep, buf, len);
 
 	if ((len - copy_out_len)) {
 		ret = rstream_process_cq(ep, RSTREAM_RX_MSG_COMP);
 		if(ret < 0 && ret != -FI_EAGAIN) {
-			ofi_spin_unlock(&ep->recv_lock);
+			ofi_mutex_unlock(&ep->recv_lock);
 			return ret;
 		}
 
@@ -664,10 +664,10 @@ static ssize_t rstream_recv(struct fid_ep *ep_fid, void *buf, size_t len,
 			((char *)buf + copy_out_len), (len - copy_out_len));
 	}
 
-	ofi_spin_lock(&ep->send_lock);
+	ofi_mutex_lock(&ep->send_lock);
 	ret = rstream_update_target(ep, 0, copy_out_len);
-	ofi_spin_unlock(&ep->send_lock);
-	ofi_spin_unlock(&ep->recv_lock);
+	ofi_mutex_unlock(&ep->send_lock);
+	ofi_mutex_unlock(&ep->recv_lock);
 	if(ret < 0 && ret != -FI_EAGAIN) {
 		return ret;
 	}
@@ -696,32 +696,32 @@ static ssize_t rstream_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 		util_ep.ep_fid);
 
 	if (flags == FI_PEEK) {
-		ofi_spin_lock(&ep->recv_lock);
+		ofi_mutex_lock(&ep->recv_lock);
 		if (!ep->local_mr.rx.avail_size) {
 			ret = rstream_process_cq(ep, RSTREAM_RX_MSG_COMP);
 			if (ret < 0) {
-				ofi_spin_unlock(&ep->recv_lock);
+				ofi_mutex_unlock(&ep->recv_lock);
 				return ret;
 			}
 		}
-		ofi_spin_unlock(&ep->recv_lock);
+		ofi_mutex_unlock(&ep->recv_lock);
 
-		ofi_spin_lock(&ep->send_lock);
+		ofi_mutex_lock(&ep->send_lock);
 		if (rstream_target_rx_full(ep)) {
 			ret = rstream_process_cq(ep, RSTREAM_RX_MSG_COMP);
 			if (ret < 0) {
-				ofi_spin_unlock(&ep->send_lock);
+				ofi_mutex_unlock(&ep->send_lock);
 				return ret;
 			}
 		}
 
 		if (!ep->qp_win.ctrl_credits) {
 			ret = rstream_process_cq(ep, RSTREAM_TX_MSG_COMP);
-			ofi_spin_unlock(&ep->send_lock);
+			ofi_mutex_unlock(&ep->send_lock);
 			return ret;
 		}
 
-		ofi_spin_unlock(&ep->send_lock);
+		ofi_mutex_unlock(&ep->send_lock);
 		return 0;
 	} else {
 		return -FI_ENOSYS;

--- a/prov/rxd/src/rxd_atomic.c
+++ b/prov/rxd/src/rxd_atomic.c
@@ -129,7 +129,7 @@ static ssize_t rxd_generic_atomic(struct rxd_ep *rxd_ep,
 	ofi_ioc_to_iov(compare_ioc, comp_iov, compare_count, ofi_datatype_size(datatype));
 	ofi_rma_ioc_to_iov(rma_ioc, rma_iov, rma_count, ofi_datatype_size(datatype));
 
-	fastlock_acquire(&rxd_ep->util_ep.lock);
+	ofi_spin_lock(&rxd_ep->util_ep.lock);
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
@@ -152,7 +152,7 @@ static ssize_t rxd_generic_atomic(struct rxd_ep *rxd_ep,
 		(void) rxd_start_xfer(rxd_ep, tx_entry);
 
 out:
-	fastlock_release(&rxd_ep->util_ep.lock);
+	ofi_spin_unlock(&rxd_ep->util_ep.lock);
 	return ret;
 }
 
@@ -233,7 +233,7 @@ static ssize_t rxd_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 	rma_iov.len = count * ofi_datatype_size(datatype);
 	rma_iov.key = key;
 
-	fastlock_acquire(&rxd_ep->util_ep.lock);
+	ofi_spin_lock(&rxd_ep->util_ep.lock);
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
@@ -257,7 +257,7 @@ static ssize_t rxd_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 
 	(void) rxd_start_xfer(rxd_ep, tx_entry);
 out:
-	fastlock_release(&rxd_ep->util_ep.lock);
+	ofi_spin_unlock(&rxd_ep->util_ep.lock);
 	return ret;
 }
 

--- a/prov/rxd/src/rxd_atomic.c
+++ b/prov/rxd/src/rxd_atomic.c
@@ -129,7 +129,7 @@ static ssize_t rxd_generic_atomic(struct rxd_ep *rxd_ep,
 	ofi_ioc_to_iov(compare_ioc, comp_iov, compare_count, ofi_datatype_size(datatype));
 	ofi_rma_ioc_to_iov(rma_ioc, rma_iov, rma_count, ofi_datatype_size(datatype));
 
-	ofi_spin_lock(&rxd_ep->util_ep.lock);
+	ofi_mutex_lock(&rxd_ep->util_ep.lock);
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
@@ -152,7 +152,7 @@ static ssize_t rxd_generic_atomic(struct rxd_ep *rxd_ep,
 		(void) rxd_start_xfer(rxd_ep, tx_entry);
 
 out:
-	ofi_spin_unlock(&rxd_ep->util_ep.lock);
+	ofi_mutex_unlock(&rxd_ep->util_ep.lock);
 	return ret;
 }
 
@@ -233,7 +233,7 @@ static ssize_t rxd_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 	rma_iov.len = count * ofi_datatype_size(datatype);
 	rma_iov.key = key;
 
-	ofi_spin_lock(&rxd_ep->util_ep.lock);
+	ofi_mutex_lock(&rxd_ep->util_ep.lock);
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
@@ -257,7 +257,7 @@ static ssize_t rxd_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 
 	(void) rxd_start_xfer(rxd_ep, tx_entry);
 out:
-	ofi_spin_unlock(&rxd_ep->util_ep.lock);
+	ofi_mutex_unlock(&rxd_ep->util_ep.lock);
 	return ret;
 }
 

--- a/prov/rxd/src/rxd_av.c
+++ b/prov/rxd/src/rxd_av.c
@@ -208,7 +208,7 @@ static int rxd_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 		memset(sync_err, 0, sizeof(*sync_err) * count);
 	}
 
-	ofi_spin_lock(&av->util_av.lock);
+	ofi_mutex_lock(&av->util_av.lock);
 	if (!av->dg_addrlen) {
 		ret = rxd_av_set_addrlen(av, addr);
 		if (ret)
@@ -257,7 +257,7 @@ static int rxd_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 	}
 out:
 	av->dg_av_used += success_cnt;
-	ofi_spin_unlock(&av->util_av.lock);
+	ofi_mutex_unlock(&av->util_av.lock);
 
 	for (; i < count; i++) {
 		if (fi_addr)
@@ -299,7 +299,7 @@ static int rxd_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr, size_t count
 	struct rxd_av *av;
 
 	av = container_of(av_fid, struct rxd_av, util_av.av_fid);
-	ofi_spin_lock(&av->util_av.lock);
+	ofi_mutex_lock(&av->util_av.lock);
 	for (i = 0; i < count; i++) {
 		rxd_addr = (intptr_t)ofi_idx_lookup(&av->fi_addr_idx,
 						    RXD_IDX_OFFSET(fi_addr[i]));
@@ -315,7 +315,7 @@ err:
 	if (ret)
 		FI_WARN(&rxd_prov, FI_LOG_AV, "Unable to remove address from AV\n");
 
-	ofi_spin_unlock(&av->util_av.lock);
+	ofi_mutex_unlock(&av->util_av.lock);
 	return ret;
 }
 

--- a/prov/rxd/src/rxd_av.c
+++ b/prov/rxd/src/rxd_av.c
@@ -208,7 +208,7 @@ static int rxd_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 		memset(sync_err, 0, sizeof(*sync_err) * count);
 	}
 
-	fastlock_acquire(&av->util_av.lock);
+	ofi_spin_lock(&av->util_av.lock);
 	if (!av->dg_addrlen) {
 		ret = rxd_av_set_addrlen(av, addr);
 		if (ret)
@@ -257,7 +257,7 @@ static int rxd_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 	}
 out:
 	av->dg_av_used += success_cnt;
-	fastlock_release(&av->util_av.lock);
+	ofi_spin_unlock(&av->util_av.lock);
 
 	for (; i < count; i++) {
 		if (fi_addr)
@@ -299,7 +299,7 @@ static int rxd_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr, size_t count
 	struct rxd_av *av;
 
 	av = container_of(av_fid, struct rxd_av, util_av.av_fid);
-	fastlock_acquire(&av->util_av.lock);
+	ofi_spin_lock(&av->util_av.lock);
 	for (i = 0; i < count; i++) {
 		rxd_addr = (intptr_t)ofi_idx_lookup(&av->fi_addr_idx,
 						    RXD_IDX_OFFSET(fi_addr[i]));
@@ -315,7 +315,7 @@ err:
 	if (ret)
 		FI_WARN(&rxd_prov, FI_LOG_AV, "Unable to remove address from AV\n");
 
-	fastlock_release(&av->util_av.lock);
+	ofi_spin_unlock(&av->util_av.lock);
 	return ret;
 }
 

--- a/prov/rxd/src/rxd_cntr.c
+++ b/prov/rxd/src/rxd_cntr.c
@@ -60,7 +60,7 @@ static int rxd_cntr_wait(struct fid_cntr *cntr_fid, uint64_t threshold, int time
 			return -FI_ETIMEDOUT;
 
 		ep_retry = -1;
-		ofi_spin_lock(&cntr->ep_list_lock);
+		ofi_mutex_lock(&cntr->ep_list_lock);
 		dlist_foreach_container(&cntr->ep_list, struct fid_list_entry,
 					fid_entry, entry) {
 			ep = container_of(fid_entry->fid, struct rxd_ep,
@@ -70,7 +70,7 @@ static int rxd_cntr_wait(struct fid_cntr *cntr_fid, uint64_t threshold, int time
 			ep_retry = ep_retry == -1 ? ep->next_retry :
 					MIN(ep_retry, ep->next_retry);
 		}
-		ofi_spin_unlock(&cntr->ep_list_lock);
+		ofi_mutex_unlock(&cntr->ep_list_lock);
 
 		ret = fi_wait(&cntr->wait->wait_fid, ep_retry == -1 ?
 			      timeout : rxd_get_timeout(ep_retry));

--- a/prov/rxd/src/rxd_cntr.c
+++ b/prov/rxd/src/rxd_cntr.c
@@ -60,7 +60,7 @@ static int rxd_cntr_wait(struct fid_cntr *cntr_fid, uint64_t threshold, int time
 			return -FI_ETIMEDOUT;
 
 		ep_retry = -1;
-		fastlock_acquire(&cntr->ep_list_lock);
+		ofi_spin_lock(&cntr->ep_list_lock);
 		dlist_foreach_container(&cntr->ep_list, struct fid_list_entry,
 					fid_entry, entry) {
 			ep = container_of(fid_entry->fid, struct rxd_ep,
@@ -70,7 +70,7 @@ static int rxd_cntr_wait(struct fid_cntr *cntr_fid, uint64_t threshold, int time
 			ep_retry = ep_retry == -1 ? ep->next_retry :
 					MIN(ep_retry, ep->next_retry);
 		}
-		fastlock_release(&cntr->ep_list_lock);
+		ofi_spin_unlock(&cntr->ep_list_lock);
 
 		ret = fi_wait(&cntr->wait->wait_fid, ep_retry == -1 ?
 			      timeout : rxd_get_timeout(ep_retry));

--- a/prov/rxd/src/rxd_domain.c
+++ b/prov/rxd/src/rxd_domain.c
@@ -91,10 +91,10 @@ int rxd_mr_verify(struct rxd_domain *rxd_domain, ssize_t len,
 {
 	int ret;
 
-	ofi_spin_lock(&rxd_domain->util_domain.lock);
+	ofi_mutex_lock(&rxd_domain->util_domain.lock);
 	ret = ofi_mr_map_verify(&rxd_domain->mr_map, io_addr, len,
 				key, access, NULL);
-	ofi_spin_unlock(&rxd_domain->util_domain.lock);
+	ofi_mutex_unlock(&rxd_domain->util_domain.lock);
 	return ret;
 }
 

--- a/prov/rxd/src/rxd_domain.c
+++ b/prov/rxd/src/rxd_domain.c
@@ -91,10 +91,10 @@ int rxd_mr_verify(struct rxd_domain *rxd_domain, ssize_t len,
 {
 	int ret;
 
-	fastlock_acquire(&rxd_domain->util_domain.lock);
+	ofi_spin_lock(&rxd_domain->util_domain.lock);
 	ret = ofi_mr_map_verify(&rxd_domain->mr_map, io_addr, len,
 				key, access, NULL);
-	fastlock_release(&rxd_domain->util_domain.lock);
+	ofi_spin_unlock(&rxd_domain->util_domain.lock);
 	return ret;
 }
 

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -107,7 +107,7 @@ static ssize_t rxd_ep_cancel_recv(struct rxd_ep *ep, struct dlist_entry *list,
 	struct fi_cq_err_entry err_entry;
 	int ret = 0;
 
-	ofi_spin_lock(&ep->util_ep.lock);
+	ofi_mutex_lock(&ep->util_ep.lock);
 
 	entry = dlist_remove_first_match(list, &rxd_match_ctx, context);
 	if (!entry)
@@ -127,7 +127,7 @@ static ssize_t rxd_ep_cancel_recv(struct rxd_ep *ep, struct dlist_entry *list,
 	rxd_rx_entry_free(ep, rx_entry);
 	ret = 1;
 out:
-	ofi_spin_unlock(&ep->util_ep.lock);
+	ofi_mutex_unlock(&ep->util_ep.lock);
 	return ret;
 }
 
@@ -263,14 +263,14 @@ static int rxd_ep_enable(struct rxd_ep *ep)
 	ep->tx_flags = rxd_tx_flags(ep->util_ep.tx_op_flags);
 	ep->rx_flags = rxd_rx_flags(ep->util_ep.rx_op_flags);
 
-	ofi_spin_lock(&ep->util_ep.lock);
+	ofi_mutex_lock(&ep->util_ep.lock);
 	for (i = 0; i < ep->rx_size; i++) {
 		ret = rxd_ep_post_buf(ep);
 		if (ret)
 			break;
 	}
 
-	ofi_spin_unlock(&ep->util_ep.lock);
+	ofi_mutex_unlock(&ep->util_ep.lock);
 	return 0;
 }
 
@@ -957,7 +957,7 @@ void rxd_ep_progress(struct util_ep *util_ep)
 
 	ep = container_of(util_ep, struct rxd_ep, util_ep);
 
-	ofi_spin_lock(&ep->util_ep.lock);
+	ofi_mutex_lock(&ep->util_ep.lock);
 	for(ret = 1, i = 0;
 	    ret > 0 && (!rxd_env.spin_count || i < rxd_env.spin_count);
 	    i++) {
@@ -992,7 +992,7 @@ void rxd_ep_progress(struct util_ep *util_ep)
 	}
 
 out:
-	ofi_spin_unlock(&ep->util_ep.lock);
+	ofi_mutex_unlock(&ep->util_ep.lock);
 }
 
 static int rxd_buf_region_alloc_fn(struct ofi_bufpool_region *region)

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -107,7 +107,7 @@ static ssize_t rxd_ep_cancel_recv(struct rxd_ep *ep, struct dlist_entry *list,
 	struct fi_cq_err_entry err_entry;
 	int ret = 0;
 
-	fastlock_acquire(&ep->util_ep.lock);
+	ofi_spin_lock(&ep->util_ep.lock);
 
 	entry = dlist_remove_first_match(list, &rxd_match_ctx, context);
 	if (!entry)
@@ -127,7 +127,7 @@ static ssize_t rxd_ep_cancel_recv(struct rxd_ep *ep, struct dlist_entry *list,
 	rxd_rx_entry_free(ep, rx_entry);
 	ret = 1;
 out:
-	fastlock_release(&ep->util_ep.lock);
+	ofi_spin_unlock(&ep->util_ep.lock);
 	return ret;
 }
 
@@ -263,14 +263,14 @@ static int rxd_ep_enable(struct rxd_ep *ep)
 	ep->tx_flags = rxd_tx_flags(ep->util_ep.tx_op_flags);
 	ep->rx_flags = rxd_rx_flags(ep->util_ep.rx_op_flags);
 
-	fastlock_acquire(&ep->util_ep.lock);
+	ofi_spin_lock(&ep->util_ep.lock);
 	for (i = 0; i < ep->rx_size; i++) {
 		ret = rxd_ep_post_buf(ep);
 		if (ret)
 			break;
 	}
 
-	fastlock_release(&ep->util_ep.lock);
+	ofi_spin_unlock(&ep->util_ep.lock);
 	return 0;
 }
 
@@ -957,7 +957,7 @@ void rxd_ep_progress(struct util_ep *util_ep)
 
 	ep = container_of(util_ep, struct rxd_ep, util_ep);
 
-	fastlock_acquire(&ep->util_ep.lock);
+	ofi_spin_lock(&ep->util_ep.lock);
 	for(ret = 1, i = 0;
 	    ret > 0 && (!rxd_env.spin_count || i < rxd_env.spin_count);
 	    i++) {
@@ -992,7 +992,7 @@ void rxd_ep_progress(struct util_ep *util_ep)
 	}
 
 out:
-	fastlock_release(&ep->util_ep.lock);
+	ofi_spin_unlock(&ep->util_ep.lock);
 }
 
 static int rxd_buf_region_alloc_fn(struct ofi_bufpool_region *region)

--- a/prov/rxd/src/rxd_msg.c
+++ b/prov/rxd/src/rxd_msg.c
@@ -144,7 +144,7 @@ static int rxd_ep_discard_recv(struct rxd_ep *rxd_ep, void *context,
 	seq += unexp_msg->sar_hdr ? unexp_msg->sar_hdr->num_segs : 1;
 
 	rxd_peer(rxd_ep, unexp_msg->base_hdr->peer)->rx_seq_no =
-			MAX(seq, rxd_peer(rxd_ep, 
+			MAX(seq, rxd_peer(rxd_ep,
 				 unexp_msg->base_hdr->peer)->rx_seq_no);
 	rxd_ep_send_ack(rxd_ep, unexp_msg->base_hdr->peer);
 
@@ -164,9 +164,9 @@ static int rxd_peek_recv(struct rxd_ep *rxd_ep, fi_addr_t addr, uint64_t tag,
 {
 	struct rxd_unexp_msg *unexp_msg;
 
-	fastlock_release(&rxd_ep->util_ep.lock);
+	ofi_spin_unlock(&rxd_ep->util_ep.lock);
 	rxd_ep_progress(&rxd_ep->util_ep);
-	fastlock_acquire(&rxd_ep->util_ep.lock);
+	ofi_spin_lock(&rxd_ep->util_ep.lock);
 
 	unexp_msg = rxd_ep_check_unexp_list(unexp_list, addr, tag, ignore);
 	if (!unexp_msg) {
@@ -204,13 +204,13 @@ ssize_t rxd_ep_generic_recvmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 	struct rxd_unexp_msg *unexp_msg;
 	fi_addr_t rxd_addr = RXD_ADDR_INVALID;
 
-	
+
 	assert(iov_count <= RXD_IOV_LIMIT);
 	assert(!(rxd_flags & RXD_MULTI_RECV) || iov_count == 1);
 	assert(!(flags & FI_PEEK) || op == RXD_TAGGED);
 
 
-	fastlock_acquire(&rxd_ep->util_ep.lock);
+	ofi_spin_lock(&rxd_ep->util_ep.lock);
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.rx_cq->cirq)) {
 		ret = -FI_EAGAIN;
@@ -224,10 +224,10 @@ ssize_t rxd_ep_generic_recvmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 		unexp_list = &rxd_ep->unexp_list;
 		rx_list = &rxd_ep->rx_list;
 	}
-	
+
 	if (rxd_ep->util_ep.caps & FI_DIRECTED_RECV &&
 	    addr != FI_ADDR_UNSPEC) {
-		rxd_addr = (intptr_t) ofi_idx_lookup(&(rxd_ep_av(rxd_ep)->fi_addr_idx), 
+		rxd_addr = (intptr_t) ofi_idx_lookup(&(rxd_ep_av(rxd_ep)->fi_addr_idx),
 						     RXD_IDX_OFFSET(addr));
 	}
 
@@ -237,7 +237,7 @@ ssize_t rxd_ep_generic_recvmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 		goto out;
 	}
 	if (!(flags & FI_DISCARD)) {
-		
+
 		rx_entry = rxd_rx_entry_init(rxd_ep, iov, iov_count, tag, ignore,
 					     context, rxd_addr, op, rxd_flags);
 		if (!rx_entry) {
@@ -261,7 +261,7 @@ ssize_t rxd_ep_generic_recvmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 	ret = rxd_ep_discard_recv(rxd_ep, context, unexp_msg);
 
 out:
-	fastlock_release(&rxd_ep->util_ep.lock);
+	ofi_spin_unlock(&rxd_ep->util_ep.lock);
 	return ret;
 }
 
@@ -361,12 +361,12 @@ ssize_t rxd_ep_generic_inject(struct rxd_ep *rxd_ep, const struct iovec *iov,
 	assert(ofi_total_iov_len(iov, iov_count) <=
 	       rxd_ep_domain(rxd_ep)->max_inline_msg);
 
-	fastlock_acquire(&rxd_ep->util_ep.lock);
+	ofi_spin_lock(&rxd_ep->util_ep.lock);
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
-	
-	rxd_addr = (intptr_t) ofi_idx_lookup(&(rxd_ep_av(rxd_ep)->fi_addr_idx), 
+
+	rxd_addr = (intptr_t) ofi_idx_lookup(&(rxd_ep_av(rxd_ep)->fi_addr_idx),
 					     RXD_IDX_OFFSET(addr));
 	if (!rxd_addr)
 		goto out;
@@ -386,7 +386,7 @@ ssize_t rxd_ep_generic_inject(struct rxd_ep *rxd_ep, const struct iovec *iov,
 		(void) rxd_start_xfer(rxd_ep, tx_entry);
 
 out:
-	fastlock_release(&rxd_ep->util_ep.lock);
+	ofi_spin_unlock(&rxd_ep->util_ep.lock);
 	return ret;
 }
 
@@ -405,16 +405,16 @@ ssize_t rxd_ep_generic_sendmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 		return rxd_ep_generic_inject(rxd_ep, iov, iov_count, addr, tag, 0,
 					     op, rxd_flags);
 
-	fastlock_acquire(&rxd_ep->util_ep.lock);
+	ofi_spin_lock(&rxd_ep->util_ep.lock);
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
-	
-	rxd_addr = (intptr_t) ofi_idx_lookup(&(rxd_ep_av(rxd_ep)->fi_addr_idx), 
+
+	rxd_addr = (intptr_t) ofi_idx_lookup(&(rxd_ep_av(rxd_ep)->fi_addr_idx),
 					     RXD_IDX_OFFSET(addr));
 	if (!rxd_addr)
 		goto out;
-	
+
 	ret = rxd_send_rts_if_needed(rxd_ep, rxd_addr);
 	if (ret)
 		goto out;
@@ -433,7 +433,7 @@ ssize_t rxd_ep_generic_sendmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 
 	ret = 0;
 out:
-	fastlock_release(&rxd_ep->util_ep.lock);
+	ofi_spin_unlock(&rxd_ep->util_ep.lock);
 	return ret;
 }
 
@@ -459,7 +459,7 @@ static ssize_t rxd_ep_sendv(struct fid_ep *ep_fid, const struct iovec *iov, void
 	ep = container_of(ep_fid, struct rxd_ep, util_ep.ep_fid.fid);
 
 	return rxd_ep_generic_sendmsg(ep, iov, count, dest_addr, 0,
-				      0, context, RXD_MSG, 
+				      0, context, RXD_MSG,
 				      ep->tx_flags);
 }
 

--- a/prov/rxd/src/rxd_msg.c
+++ b/prov/rxd/src/rxd_msg.c
@@ -164,9 +164,9 @@ static int rxd_peek_recv(struct rxd_ep *rxd_ep, fi_addr_t addr, uint64_t tag,
 {
 	struct rxd_unexp_msg *unexp_msg;
 
-	ofi_spin_unlock(&rxd_ep->util_ep.lock);
+	ofi_mutex_unlock(&rxd_ep->util_ep.lock);
 	rxd_ep_progress(&rxd_ep->util_ep);
-	ofi_spin_lock(&rxd_ep->util_ep.lock);
+	ofi_mutex_lock(&rxd_ep->util_ep.lock);
 
 	unexp_msg = rxd_ep_check_unexp_list(unexp_list, addr, tag, ignore);
 	if (!unexp_msg) {
@@ -210,7 +210,7 @@ ssize_t rxd_ep_generic_recvmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 	assert(!(flags & FI_PEEK) || op == RXD_TAGGED);
 
 
-	ofi_spin_lock(&rxd_ep->util_ep.lock);
+	ofi_mutex_lock(&rxd_ep->util_ep.lock);
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.rx_cq->cirq)) {
 		ret = -FI_EAGAIN;
@@ -261,7 +261,7 @@ ssize_t rxd_ep_generic_recvmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 	ret = rxd_ep_discard_recv(rxd_ep, context, unexp_msg);
 
 out:
-	ofi_spin_unlock(&rxd_ep->util_ep.lock);
+	ofi_mutex_unlock(&rxd_ep->util_ep.lock);
 	return ret;
 }
 
@@ -361,7 +361,7 @@ ssize_t rxd_ep_generic_inject(struct rxd_ep *rxd_ep, const struct iovec *iov,
 	assert(ofi_total_iov_len(iov, iov_count) <=
 	       rxd_ep_domain(rxd_ep)->max_inline_msg);
 
-	ofi_spin_lock(&rxd_ep->util_ep.lock);
+	ofi_mutex_lock(&rxd_ep->util_ep.lock);
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
@@ -386,7 +386,7 @@ ssize_t rxd_ep_generic_inject(struct rxd_ep *rxd_ep, const struct iovec *iov,
 		(void) rxd_start_xfer(rxd_ep, tx_entry);
 
 out:
-	ofi_spin_unlock(&rxd_ep->util_ep.lock);
+	ofi_mutex_unlock(&rxd_ep->util_ep.lock);
 	return ret;
 }
 
@@ -405,7 +405,7 @@ ssize_t rxd_ep_generic_sendmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 		return rxd_ep_generic_inject(rxd_ep, iov, iov_count, addr, tag, 0,
 					     op, rxd_flags);
 
-	ofi_spin_lock(&rxd_ep->util_ep.lock);
+	ofi_mutex_lock(&rxd_ep->util_ep.lock);
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
@@ -433,7 +433,7 @@ ssize_t rxd_ep_generic_sendmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 
 	ret = 0;
 out:
-	ofi_spin_unlock(&rxd_ep->util_ep.lock);
+	ofi_mutex_unlock(&rxd_ep->util_ep.lock);
 	return ret;
 }
 

--- a/prov/rxd/src/rxd_rma.c
+++ b/prov/rxd/src/rxd_rma.c
@@ -96,7 +96,7 @@ static ssize_t rxd_generic_write_inject(struct rxd_ep *rxd_ep,
 	assert(iov_count <= RXD_IOV_LIMIT && rma_count <= RXD_IOV_LIMIT);
 	assert(ofi_total_iov_len(iov, iov_count) <= rxd_ep_domain(rxd_ep)->max_inline_rma);
 
-	fastlock_acquire(&rxd_ep->util_ep.lock);
+	ofi_spin_lock(&rxd_ep->util_ep.lock);
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
@@ -126,7 +126,7 @@ static ssize_t rxd_generic_write_inject(struct rxd_ep *rxd_ep,
 	ret = 0;
 
 out:
-	fastlock_release(&rxd_ep->util_ep.lock);
+	ofi_spin_unlock(&rxd_ep->util_ep.lock);
 	return ret;
 }
 
@@ -147,7 +147,7 @@ rxd_generic_rma(struct rxd_ep *rxd_ep, const struct iovec *iov,
 
 	assert(iov_count <= RXD_IOV_LIMIT && rma_count <= RXD_IOV_LIMIT);
 
-	fastlock_acquire(&rxd_ep->util_ep.lock);
+	ofi_spin_lock(&rxd_ep->util_ep.lock);
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
@@ -177,7 +177,7 @@ rxd_generic_rma(struct rxd_ep *rxd_ep, const struct iovec *iov,
 	ret = 0;
 
 out:
-	fastlock_release(&rxd_ep->util_ep.lock);
+	ofi_spin_unlock(&rxd_ep->util_ep.lock);
 	return ret;
 }
 

--- a/prov/rxd/src/rxd_rma.c
+++ b/prov/rxd/src/rxd_rma.c
@@ -96,7 +96,7 @@ static ssize_t rxd_generic_write_inject(struct rxd_ep *rxd_ep,
 	assert(iov_count <= RXD_IOV_LIMIT && rma_count <= RXD_IOV_LIMIT);
 	assert(ofi_total_iov_len(iov, iov_count) <= rxd_ep_domain(rxd_ep)->max_inline_rma);
 
-	ofi_spin_lock(&rxd_ep->util_ep.lock);
+	ofi_mutex_lock(&rxd_ep->util_ep.lock);
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
@@ -126,7 +126,7 @@ static ssize_t rxd_generic_write_inject(struct rxd_ep *rxd_ep,
 	ret = 0;
 
 out:
-	ofi_spin_unlock(&rxd_ep->util_ep.lock);
+	ofi_mutex_unlock(&rxd_ep->util_ep.lock);
 	return ret;
 }
 
@@ -147,7 +147,7 @@ rxd_generic_rma(struct rxd_ep *rxd_ep, const struct iovec *iov,
 
 	assert(iov_count <= RXD_IOV_LIMIT && rma_count <= RXD_IOV_LIMIT);
 
-	ofi_spin_lock(&rxd_ep->util_ep.lock);
+	ofi_mutex_lock(&rxd_ep->util_ep.lock);
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
@@ -177,7 +177,7 @@ rxd_generic_rma(struct rxd_ep *rxd_ep, const struct iovec *iov,
 	ret = 0;
 
 out:
-	ofi_spin_unlock(&rxd_ep->util_ep.lock);
+	ofi_mutex_unlock(&rxd_ep->util_ep.lock);
 	return ret;
 }
 

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -256,7 +256,7 @@ struct rxm_domain {
 	bool passthru;
 	struct ofi_ops_flow_ctrl *flow_ctrl_ops;
 	struct ofi_bufpool *amo_bufpool;
-	fastlock_t amo_bufpool_lock;
+	ofi_spin_t amo_bufpool_lock;
 };
 
 
@@ -301,7 +301,7 @@ struct rxm_mr {
 	struct rxm_domain *domain;
 	enum fi_hmem_iface iface;
 	uint64_t device;
-	fastlock_t amo_lock;
+	ofi_spin_t amo_lock;
 };
 
 static inline enum fi_hmem_iface

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -256,7 +256,7 @@ struct rxm_domain {
 	bool passthru;
 	struct ofi_ops_flow_ctrl *flow_ctrl_ops;
 	struct ofi_bufpool *amo_bufpool;
-	ofi_spin_t amo_bufpool_lock;
+	ofi_mutex_t amo_bufpool_lock;
 };
 
 
@@ -301,7 +301,7 @@ struct rxm_mr {
 	struct rxm_domain *domain;
 	enum fi_hmem_iface iface;
 	uint64_t device;
-	ofi_spin_t amo_lock;
+	ofi_mutex_t amo_lock;
 };
 
 static inline enum fi_hmem_iface

--- a/prov/rxm/src/rxm_av.c
+++ b/prov/rxm/src/rxm_av.c
@@ -39,18 +39,18 @@ size_t rxm_av_max_peers(struct rxm_av *av)
 {
 	size_t cnt;
 
-	fastlock_acquire(&av->util_av.lock);
+	ofi_spin_lock(&av->util_av.lock);
 	cnt = av->peer_pool->entry_cnt;
-	fastlock_release(&av->util_av.lock);
+	ofi_spin_unlock(&av->util_av.lock);
 	return cnt;
 }
 
 struct rxm_conn *rxm_av_alloc_conn(struct rxm_av *av)
 {
 	struct rxm_conn *conn;
-	fastlock_acquire(&av->util_av.lock);
+	ofi_spin_lock(&av->util_av.lock);
 	conn = ofi_buf_alloc(av->conn_pool);
-	fastlock_release(&av->util_av.lock);
+	ofi_spin_unlock(&av->util_av.lock);
 	return conn;
 }
 
@@ -58,9 +58,9 @@ void rxm_av_free_conn(struct rxm_conn *conn)
 {
 	struct rxm_av *av;
 	av = container_of(conn->ep->util_ep.av, struct rxm_av, util_av);
-	fastlock_acquire(&av->util_av.lock);
+	ofi_spin_lock(&av->util_av.lock);
 	ofi_buf_free(conn);
-	fastlock_release(&av->util_av.lock);
+	ofi_spin_unlock(&av->util_av.lock);
 }
 
 static int rxm_addr_compare(struct ofi_rbmap *map, void *key, void *data)
@@ -74,7 +74,7 @@ rxm_alloc_peer(struct rxm_av *av, const void *addr)
 {
 	struct rxm_peer_addr *peer;
 
-	assert(fastlock_held(&av->util_av.lock));
+	assert(ofi_spin_held(&av->util_av.lock));
 	peer = ofi_ibuf_alloc(av->peer_pool);
 	if (!peer)
 		return NULL;
@@ -95,7 +95,7 @@ rxm_alloc_peer(struct rxm_av *av, const void *addr)
 
 static void rxm_free_peer(struct rxm_peer_addr *peer)
 {
-	assert(fastlock_held(&peer->av->util_av.lock));
+	assert(ofi_spin_held(&peer->av->util_av.lock));
 	assert(!peer->refcnt);
 	ofi_rbmap_delete(&peer->av->addr_map, peer->node);
 	ofi_ibuf_free(peer);
@@ -107,7 +107,7 @@ rxm_get_peer(struct rxm_av *av, const void *addr)
 	struct rxm_peer_addr *peer;
 	struct ofi_rbnode *node;
 
-	fastlock_acquire(&av->util_av.lock);
+	ofi_spin_lock(&av->util_av.lock);
 	node = ofi_rbmap_find(&av->addr_map, (void *) addr);
 	if (node) {
 		peer = node->data;
@@ -116,7 +116,7 @@ rxm_get_peer(struct rxm_av *av, const void *addr)
 		peer = rxm_alloc_peer(av, addr);
 	}
 
-	fastlock_release(&av->util_av.lock);
+	ofi_spin_unlock(&av->util_av.lock);
 	return peer;
 }
 
@@ -125,17 +125,17 @@ void rxm_put_peer(struct rxm_peer_addr *peer)
 	struct rxm_av *av;
 
 	av = peer->av;
-	fastlock_acquire(&av->util_av.lock);
+	ofi_spin_lock(&av->util_av.lock);
 	if (--peer->refcnt == 0)
 		rxm_free_peer(peer);
-	fastlock_release(&av->util_av.lock);
+	ofi_spin_unlock(&av->util_av.lock);
 }
 
 void rxm_ref_peer(struct rxm_peer_addr *peer)
 {
-	fastlock_acquire(&peer->av->util_av.lock);
+	ofi_spin_lock(&peer->av->util_av.lock);
 	peer->refcnt++;
-	fastlock_release(&peer->av->util_av.lock);
+	ofi_spin_unlock(&peer->av->util_av.lock);
 }
 
 static void
@@ -153,13 +153,13 @@ rxm_put_peer_addr(struct rxm_av *av, fi_addr_t fi_addr)
 {
 	struct rxm_peer_addr **peer;
 
-	fastlock_acquire(&av->util_av.lock);
+	ofi_spin_lock(&av->util_av.lock);
 	peer = ofi_av_addr_context(&av->util_av, fi_addr);
 	if (--(*peer)->refcnt == 0)
 		rxm_free_peer(*peer);
 
 	rxm_set_av_context(av, fi_addr, NULL);
-	fastlock_release(&av->util_av.lock);
+	ofi_spin_unlock(&av->util_av.lock);
 }
 
 static int

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1117,14 +1117,14 @@ static int rxm_do_device_mem_atomic(struct rxm_mr *dev_mr, uint8_t op,
 		.iov_len = amo_op_size,
 	};
 
-	fastlock_acquire(&dom->amo_bufpool_lock);
+	ofi_spin_lock(&dom->amo_bufpool_lock);
 	tx_buf = ofi_buf_alloc(dom->amo_bufpool);
-	fastlock_release(&dom->amo_bufpool_lock);
+	ofi_spin_unlock(&dom->amo_bufpool_lock);
 
 	if (!tx_buf)
 		return -FI_ENOMEM;
 
-	fastlock_acquire(&dev_mr->amo_lock);
+	ofi_spin_lock(&dev_mr->amo_lock);
 	ret = ofi_copy_from_hmem_iov(tx_buf, amo_op_size, dev_mr->iface, 0,
 				    &iov, 1, 0);
 	assert(ret == amo_op_size);
@@ -1136,11 +1136,11 @@ static int rxm_do_device_mem_atomic(struct rxm_mr *dev_mr, uint8_t op,
 				   amo_op_size);
 	assert(ret == amo_op_size);
 
-	fastlock_release(&dev_mr->amo_lock);
+	ofi_spin_unlock(&dev_mr->amo_lock);
 
-	fastlock_acquire(&dom->amo_bufpool_lock);
+	ofi_spin_lock(&dom->amo_bufpool_lock);
 	ofi_buf_free(tx_buf);
-	fastlock_release(&dom->amo_bufpool_lock);
+	ofi_spin_unlock(&dom->amo_bufpool_lock);
 
 	return FI_SUCCESS;
 }

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1117,14 +1117,14 @@ static int rxm_do_device_mem_atomic(struct rxm_mr *dev_mr, uint8_t op,
 		.iov_len = amo_op_size,
 	};
 
-	ofi_spin_lock(&dom->amo_bufpool_lock);
+	ofi_mutex_lock(&dom->amo_bufpool_lock);
 	tx_buf = ofi_buf_alloc(dom->amo_bufpool);
-	ofi_spin_unlock(&dom->amo_bufpool_lock);
+	ofi_mutex_unlock(&dom->amo_bufpool_lock);
 
 	if (!tx_buf)
 		return -FI_ENOMEM;
 
-	ofi_spin_lock(&dev_mr->amo_lock);
+	ofi_mutex_lock(&dev_mr->amo_lock);
 	ret = ofi_copy_from_hmem_iov(tx_buf, amo_op_size, dev_mr->iface, 0,
 				    &iov, 1, 0);
 	assert(ret == amo_op_size);
@@ -1136,11 +1136,11 @@ static int rxm_do_device_mem_atomic(struct rxm_mr *dev_mr, uint8_t op,
 				   amo_op_size);
 	assert(ret == amo_op_size);
 
-	ofi_spin_unlock(&dev_mr->amo_lock);
+	ofi_mutex_unlock(&dev_mr->amo_lock);
 
-	ofi_spin_lock(&dom->amo_bufpool_lock);
+	ofi_mutex_lock(&dom->amo_bufpool_lock);
 	ofi_buf_free(tx_buf);
-	ofi_spin_unlock(&dom->amo_bufpool_lock);
+	ofi_mutex_unlock(&dom->amo_bufpool_lock);
 
 	return FI_SUCCESS;
 }

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -221,10 +221,10 @@ static struct fi_ops_domain rxm_domain_ops = {
 
 static void rxm_mr_remove_map_entry(struct rxm_mr *mr)
 {
-	fastlock_acquire(&mr->domain->util_domain.lock);
+	ofi_spin_lock(&mr->domain->util_domain.lock);
 	(void) ofi_mr_map_remove(&mr->domain->util_domain.mr_map,
 				 mr->mr_fid.key);
-	fastlock_release(&mr->domain->util_domain.lock);
+	ofi_spin_unlock(&mr->domain->util_domain.lock);
 }
 
 static int rxm_mr_add_map_entry(struct util_domain *domain,
@@ -236,7 +236,7 @@ static int rxm_mr_add_map_entry(struct util_domain *domain,
 
 	msg_attr->requested_key = rxm_mr->mr_fid.key;
 
-	fastlock_acquire(&domain->lock);
+	ofi_spin_lock(&domain->lock);
 	ret = ofi_mr_map_insert(&domain->mr_map, msg_attr, &temp_key, rxm_mr);
 	if (OFI_UNLIKELY(ret)) {
 		FI_WARN(&rxm_prov, FI_LOG_DOMAIN,
@@ -245,7 +245,7 @@ static int rxm_mr_add_map_entry(struct util_domain *domain,
 	} else {
 		assert(rxm_mr->mr_fid.key == temp_key);
 	}
-	fastlock_release(&domain->lock);
+	ofi_spin_unlock(&domain->lock);
 
 	return ret;
 }
@@ -254,9 +254,9 @@ struct rxm_mr *rxm_mr_get_map_entry(struct rxm_domain *domain, uint64_t key)
 {
 	struct rxm_mr *mr;
 
-	fastlock_acquire(&domain->util_domain.lock);
+	ofi_spin_lock(&domain->util_domain.lock);
 	mr = ofi_mr_map_get(&domain->util_domain.mr_map, key);
-	fastlock_release(&domain->util_domain.lock);
+	ofi_spin_unlock(&domain->util_domain.lock);
 
 	return mr;
 }
@@ -268,7 +268,7 @@ static int rxm_domain_close(fid_t fid)
 
 	rxm_domain = container_of(fid, struct rxm_domain, util_domain.domain_fid.fid);
 
-	fastlock_destroy(&rxm_domain->amo_bufpool_lock);
+	ofi_spin_destroy(&rxm_domain->amo_bufpool_lock);
 	ofi_bufpool_destroy(rxm_domain->amo_bufpool);
 
 	ret = fi_close(&rxm_domain->msg_domain->fid);
@@ -432,7 +432,7 @@ static int rxm_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 		goto err;
 	}
 	rxm_mr_init(rxm_mr, rxm_domain, attr->context);
-	fastlock_init(&rxm_mr->amo_lock);
+	ofi_spin_init(&rxm_mr->amo_lock);
 	rxm_mr->iface = msg_attr.iface;
 	rxm_mr->device = msg_attr.device.reserved;
 	*mr = &rxm_mr->mr_fid;
@@ -748,7 +748,7 @@ int rxm_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	if (ret)
 		goto err3;
 
-	fastlock_init(&rxm_domain->amo_bufpool_lock);
+	ofi_spin_init(&rxm_domain->amo_bufpool_lock);
 
 	rxm_domain->passthru = rxm_passthru_info(info);
 	if (rxm_domain->passthru)
@@ -765,7 +765,7 @@ int rxm_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	fi_freeinfo(msg_info);
 	return 0;
 err4:
-	fastlock_destroy(&rxm_domain->amo_bufpool_lock);
+	ofi_spin_destroy(&rxm_domain->amo_bufpool_lock);
 	ofi_bufpool_destroy(rxm_domain->amo_bufpool);
 err3:
 	fi_close(&rxm_domain->msg_domain->fid);

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -645,7 +645,7 @@ struct rxm_tx_buf *rxm_get_tx_buf(struct rxm_ep *ep)
 {
 	struct rxm_tx_buf *buf;
 
-	assert(fastlock_held(&ep->util_ep.lock));
+	assert(ofi_spin_held(&ep->util_ep.lock));
 	if (!ep->tx_credit)
 		return NULL;
 
@@ -659,7 +659,7 @@ struct rxm_tx_buf *rxm_get_tx_buf(struct rxm_ep *ep)
 
 void rxm_free_rx_buf(struct rxm_ep *ep, struct rxm_tx_buf *buf)
 {
-	assert(fastlock_held(&ep->util_ep.lock));
+	assert(ofi_spin_held(&ep->util_ep.lock));
 	assert(buf->user_tx);
 	OFI_DBG_SET(buf->user_tx, false);
 	ep->tx_credit++;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -645,7 +645,7 @@ struct rxm_tx_buf *rxm_get_tx_buf(struct rxm_ep *ep)
 {
 	struct rxm_tx_buf *buf;
 
-	assert(ofi_spin_held(&ep->util_ep.lock));
+	assert(ofi_mutex_held(&ep->util_ep.lock));
 	if (!ep->tx_credit)
 		return NULL;
 
@@ -659,7 +659,7 @@ struct rxm_tx_buf *rxm_get_tx_buf(struct rxm_ep *ep)
 
 void rxm_free_rx_buf(struct rxm_ep *ep, struct rxm_tx_buf *buf)
 {
-	assert(ofi_spin_held(&ep->util_ep.lock));
+	assert(ofi_mutex_held(&ep->util_ep.lock));
 	assert(buf->user_tx);
 	OFI_DBG_SET(buf->user_tx, false);
 	ep->tx_credit++;

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -167,7 +167,7 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 		goto unlock_region;
 	}
 
-	fastlock_acquire(&ep->util_ep.tx_cq->cq_lock);
+	ofi_spin_lock(&ep->util_ep.tx_cq->cq_lock);
 	if (ofi_cirque_isfull(ep->util_ep.tx_cq->cirq)) {
 		ret = -FI_EAGAIN;
 		goto unlock_cq;
@@ -254,7 +254,7 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 	peer_smr->cmd_cnt--;
 	smr_signal(peer_smr);
 unlock_cq:
-	fastlock_release(&ep->util_ep.tx_cq->cq_lock);
+	ofi_spin_unlock(&ep->util_ep.tx_cq->cq_lock);
 unlock_region:
 	pthread_mutex_unlock(&peer_smr->lock);
 	return ret;

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -167,7 +167,7 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 		goto unlock_region;
 	}
 
-	ofi_spin_lock(&ep->util_ep.tx_cq->cq_lock);
+	ofi_mutex_lock(&ep->util_ep.tx_cq->cq_lock);
 	if (ofi_cirque_isfull(ep->util_ep.tx_cq->cirq)) {
 		ret = -FI_EAGAIN;
 		goto unlock_cq;
@@ -254,7 +254,7 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 	peer_smr->cmd_cnt--;
 	smr_signal(peer_smr);
 unlock_cq:
-	ofi_spin_unlock(&ep->util_ep.tx_cq->cq_lock);
+	ofi_mutex_unlock(&ep->util_ep.tx_cq->cq_lock);
 unlock_region:
 	pthread_mutex_unlock(&peer_smr->lock);
 	return ret;

--- a/prov/shm/src/smr_av.c
+++ b/prov/shm/src/smr_av.c
@@ -76,10 +76,10 @@ static int smr_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 			ret = smr_map_add(&smr_prov, smr_av->smr_map,
 					  addr, &shm_id);
 			if (!ret) {
-				fastlock_acquire(&util_av->lock);
+				ofi_spin_lock(&util_av->lock);
 				ret = ofi_av_insert_addr(util_av, &shm_id,
 							 &util_addr);
-				fastlock_release(&util_av->lock);
+				ofi_spin_unlock(&util_av->lock);
 			}
 		} else {
 			FI_WARN(&smr_prov, FI_LOG_AV,
@@ -132,7 +132,7 @@ static int smr_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr, size_t count
 	util_av = container_of(av_fid, struct util_av, av_fid);
 	smr_av = container_of(util_av, struct smr_av, util_av);
 
-	fastlock_acquire(&util_av->lock);
+	ofi_spin_lock(&util_av->lock);
 	for (i = 0; i < count; i++) {
 		id = smr_addr_lookup(util_av, fi_addr[i]);
 		ret = ofi_av_remove_addr(util_av, fi_addr[i]);
@@ -151,7 +151,7 @@ static int smr_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr, size_t count
 		smr_av->used--;
 	}
 
-	fastlock_release(&util_av->lock);
+	ofi_spin_unlock(&util_av->lock);
 	return ret;
 }
 

--- a/prov/shm/src/smr_av.c
+++ b/prov/shm/src/smr_av.c
@@ -76,10 +76,10 @@ static int smr_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 			ret = smr_map_add(&smr_prov, smr_av->smr_map,
 					  addr, &shm_id);
 			if (!ret) {
-				ofi_spin_lock(&util_av->lock);
+				ofi_mutex_lock(&util_av->lock);
 				ret = ofi_av_insert_addr(util_av, &shm_id,
 							 &util_addr);
-				ofi_spin_unlock(&util_av->lock);
+				ofi_mutex_unlock(&util_av->lock);
 			}
 		} else {
 			FI_WARN(&smr_prov, FI_LOG_AV,
@@ -132,7 +132,7 @@ static int smr_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr, size_t count
 	util_av = container_of(av_fid, struct util_av, av_fid);
 	smr_av = container_of(util_av, struct smr_av, util_av);
 
-	ofi_spin_lock(&util_av->lock);
+	ofi_mutex_lock(&util_av->lock);
 	for (i = 0; i < count; i++) {
 		id = smr_addr_lookup(util_av, fi_addr[i]);
 		ret = ofi_av_remove_addr(util_av, fi_addr[i]);
@@ -151,7 +151,7 @@ static int smr_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr, size_t count
 		smr_av->used--;
 	}
 
-	ofi_spin_unlock(&util_av->lock);
+	ofi_mutex_unlock(&util_av->lock);
 	return ret;
 }
 

--- a/prov/shm/src/smr_domain.c
+++ b/prov/shm/src/smr_domain.c
@@ -100,10 +100,10 @@ int smr_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	}
 
 	smr_fabric = container_of(fabric, struct smr_fabric, util_fabric.fabric_fid);
-	ofi_spin_lock(&smr_fabric->util_fabric.lock);
+	ofi_mutex_lock(&smr_fabric->util_fabric.lock);
 	smr_domain->fast_rma = smr_fast_rma_enabled(info->domain_attr->mr_mode,
 						    info->tx_attr->msg_order);
-	ofi_spin_unlock(&smr_fabric->util_fabric.lock);
+	ofi_mutex_unlock(&smr_fabric->util_fabric.lock);
 
 	*domain = &smr_domain->util_domain.domain_fid;
 	(*domain)->fid.ops = &smr_domain_fi_ops;

--- a/prov/shm/src/smr_domain.c
+++ b/prov/shm/src/smr_domain.c
@@ -100,10 +100,10 @@ int smr_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	}
 
 	smr_fabric = container_of(fabric, struct smr_fabric, util_fabric.fabric_fid);
-	fastlock_acquire(&smr_fabric->util_fabric.lock);
+	ofi_spin_lock(&smr_fabric->util_fabric.lock);
 	smr_domain->fast_rma = smr_fast_rma_enabled(info->domain_attr->mr_mode,
 						    info->tx_attr->msg_order);
-	fastlock_release(&smr_fabric->util_fabric.lock);
+	ofi_spin_unlock(&smr_fabric->util_fabric.lock);
 
 	*domain = &smr_domain->util_domain.domain_fid;
 	(*domain)->fid.ops = &smr_domain_fi_ops;

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -152,7 +152,7 @@ static int smr_ep_cancel_recv(struct smr_ep *ep, struct smr_queue *queue,
 	struct dlist_entry *entry;
 	int ret = 0;
 
-	ofi_spin_lock(&ep->util_ep.rx_cq->cq_lock);
+	ofi_mutex_lock(&ep->util_ep.rx_cq->cq_lock);
 	entry = dlist_remove_first_match(&queue->list, smr_match_recv_ctx,
 					 context);
 	if (entry) {
@@ -165,7 +165,7 @@ static int smr_ep_cancel_recv(struct smr_ep *ep, struct smr_queue *queue,
 		ret = ret ? ret : 1;
 	}
 
-	ofi_spin_unlock(&ep->util_ep.rx_cq->cq_lock);
+	ofi_mutex_unlock(&ep->util_ep.rx_cq->cq_lock);
 	return ret;
 }
 

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -662,7 +662,7 @@ static int smr_ep_bind_cq(struct smr_ep *ep, struct util_cq *cq, uint64_t flags)
 			return ret;
 	}
 
-	ret = fid_list_insert(&cq->ep_list,
+	ret = fid_list_insert_m(&cq->ep_list,
 			      &cq->ep_list_lock,
 			      &ep->util_ep.ep_fid.fid);
 

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -662,7 +662,7 @@ static int smr_ep_bind_cq(struct smr_ep *ep, struct util_cq *cq, uint64_t flags)
 			return ret;
 	}
 
-	ret = fid_list_insert_m(&cq->ep_list,
+	ret = fid_list_insert(&cq->ep_list,
 			      &cq->ep_list_lock,
 			      &ep->util_ep.ep_fid.fid);
 

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -152,7 +152,7 @@ static int smr_ep_cancel_recv(struct smr_ep *ep, struct smr_queue *queue,
 	struct dlist_entry *entry;
 	int ret = 0;
 
-	fastlock_acquire(&ep->util_ep.rx_cq->cq_lock);
+	ofi_spin_lock(&ep->util_ep.rx_cq->cq_lock);
 	entry = dlist_remove_first_match(&queue->list, smr_match_recv_ctx,
 					 context);
 	if (entry) {
@@ -165,7 +165,7 @@ static int smr_ep_cancel_recv(struct smr_ep *ep, struct smr_queue *queue,
 		ret = ret ? ret : 1;
 	}
 
-	fastlock_release(&ep->util_ep.rx_cq->cq_lock);
+	ofi_spin_unlock(&ep->util_ep.rx_cq->cq_lock);
 	return ret;
 }
 

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -96,7 +96,7 @@ ssize_t smr_generic_recv(struct smr_ep *ep, const struct iovec *iov, void **desc
 	assert(!(flags & FI_MULTI_RECV) || iov_count == 1);
 
 	pthread_mutex_lock(&ep->region->lock);
-	fastlock_acquire(&ep->util_ep.rx_cq->cq_lock);
+	ofi_spin_lock(&ep->util_ep.rx_cq->cq_lock);
 
 	entry = smr_get_recv_entry(ep, iov, desc, iov_count, addr, context, tag,
 				   ignore, flags);
@@ -106,7 +106,7 @@ ssize_t smr_generic_recv(struct smr_ep *ep, const struct iovec *iov, void **desc
 	dlist_insert_tail(&entry->entry, &recv_queue->list);
 	ret = smr_progress_unexp_queue(ep, entry, unexp_queue);
 out:
-	fastlock_release(&ep->util_ep.rx_cq->cq_lock);
+	ofi_spin_unlock(&ep->util_ep.rx_cq->cq_lock);
 	pthread_mutex_unlock(&ep->region->lock);
 	return ret;
 }
@@ -184,7 +184,7 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 		goto unlock_region;
 	}
 
-	fastlock_acquire(&ep->util_ep.tx_cq->cq_lock);
+	ofi_spin_lock(&ep->util_ep.tx_cq->cq_lock);
 	if (ofi_cirque_isfull(ep->util_ep.tx_cq->cirq)) {
 		ret = -FI_EAGAIN;
 		goto unlock_cq;
@@ -270,7 +270,7 @@ commit:
 	peer_smr->cmd_cnt--;
 	smr_signal(peer_smr);
 unlock_cq:
-	fastlock_release(&ep->util_ep.tx_cq->cq_lock);
+	ofi_spin_unlock(&ep->util_ep.tx_cq->cq_lock);
 unlock_region:
 	pthread_mutex_unlock(&peer_smr->lock);
 	return ret;

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -832,7 +832,7 @@ static int smr_progress_cmd_rma(struct smr_ep *ep, struct smr_cmd *cmd)
 	ep->region->cmd_cnt++;
 	rma_cmd = ofi_cirque_head(smr_cmd_queue(ep->region));
 
-	ofi_spin_lock(&domain->util_domain.lock);
+	ofi_mutex_lock(&domain->util_domain.lock);
 	for (iov_count = 0; iov_count < rma_cmd->rma.rma_count; iov_count++) {
 		ret = ofi_mr_map_verify(&domain->util_domain.mr_map,
 				(uintptr_t *) &(rma_cmd->rma.rma_iov[iov_count].addr),
@@ -852,7 +852,7 @@ static int smr_progress_cmd_rma(struct smr_ep *ep, struct smr_cmd *cmd)
 			assert(mr->iface == iface && mr->device == device);
 		}
 	}
-	ofi_spin_unlock(&domain->util_domain.lock);
+	ofi_mutex_unlock(&domain->util_domain.lock);
 
 	ofi_cirque_discard(smr_cmd_queue(ep->region));
 	if (ret) {

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -201,7 +201,7 @@ static void smr_progress_resp(struct smr_ep *ep)
 	int ret;
 
 	pthread_mutex_lock(&ep->region->lock);
-	ofi_spin_lock(&ep->util_ep.tx_cq->cq_lock);
+	ofi_mutex_lock(&ep->util_ep.tx_cq->cq_lock);
 	while (!ofi_cirque_isempty(smr_resp_queue(ep->region)) &&
 	       !ofi_cirque_isfull(ep->util_ep.tx_cq->cirq)) {
 		resp = ofi_cirque_head(smr_resp_queue(ep->region));
@@ -223,7 +223,7 @@ static void smr_progress_resp(struct smr_ep *ep)
 		ofi_freestack_push(ep->pend_fs, pending);
 		ofi_cirque_discard(smr_resp_queue(ep->region));
 	}
-	ofi_spin_unlock(&ep->util_ep.tx_cq->cq_lock);
+	ofi_mutex_unlock(&ep->util_ep.tx_cq->cq_lock);
 	pthread_mutex_unlock(&ep->region->lock);
 }
 
@@ -990,7 +990,7 @@ static void smr_progress_cmd(struct smr_ep *ep)
 	int ret = 0;
 
 	pthread_mutex_lock(&ep->region->lock);
-	ofi_spin_lock(&ep->util_ep.rx_cq->cq_lock);
+	ofi_mutex_lock(&ep->util_ep.rx_cq->cq_lock);
 
 	while (!ofi_cirque_isempty(smr_cmd_queue(ep->region))) {
 		cmd = ofi_cirque_head(smr_cmd_queue(ep->region));
@@ -1033,7 +1033,7 @@ static void smr_progress_cmd(struct smr_ep *ep)
 			break;
 		}
 	}
-	ofi_spin_unlock(&ep->util_ep.rx_cq->cq_lock);
+	ofi_mutex_unlock(&ep->util_ep.rx_cq->cq_lock);
 	pthread_mutex_unlock(&ep->region->lock);
 }
 
@@ -1047,7 +1047,7 @@ static void smr_progress_sar_list(struct smr_ep *ep)
 	int ret;
 
 	pthread_mutex_lock(&ep->region->lock);
-	ofi_spin_lock(&ep->util_ep.rx_cq->cq_lock);
+	ofi_mutex_lock(&ep->util_ep.rx_cq->cq_lock);
 
 	dlist_foreach_container_safe(&ep->sar_list, struct smr_sar_entry,
 				     sar_entry, entry, tmp) {
@@ -1082,7 +1082,7 @@ static void smr_progress_sar_list(struct smr_ep *ep)
 			ofi_freestack_push(ep->sar_fs, sar_entry);
 		}
 	}
-	ofi_spin_unlock(&ep->util_ep.rx_cq->cq_lock);
+	ofi_mutex_unlock(&ep->util_ep.rx_cq->cq_lock);
 	pthread_mutex_unlock(&ep->region->lock);
 }
 

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -201,7 +201,7 @@ static void smr_progress_resp(struct smr_ep *ep)
 	int ret;
 
 	pthread_mutex_lock(&ep->region->lock);
-	fastlock_acquire(&ep->util_ep.tx_cq->cq_lock);
+	ofi_spin_lock(&ep->util_ep.tx_cq->cq_lock);
 	while (!ofi_cirque_isempty(smr_resp_queue(ep->region)) &&
 	       !ofi_cirque_isfull(ep->util_ep.tx_cq->cirq)) {
 		resp = ofi_cirque_head(smr_resp_queue(ep->region));
@@ -223,7 +223,7 @@ static void smr_progress_resp(struct smr_ep *ep)
 		ofi_freestack_push(ep->pend_fs, pending);
 		ofi_cirque_discard(smr_resp_queue(ep->region));
 	}
-	fastlock_release(&ep->util_ep.tx_cq->cq_lock);
+	ofi_spin_unlock(&ep->util_ep.tx_cq->cq_lock);
 	pthread_mutex_unlock(&ep->region->lock);
 }
 
@@ -832,7 +832,7 @@ static int smr_progress_cmd_rma(struct smr_ep *ep, struct smr_cmd *cmd)
 	ep->region->cmd_cnt++;
 	rma_cmd = ofi_cirque_head(smr_cmd_queue(ep->region));
 
-	fastlock_acquire(&domain->util_domain.lock);
+	ofi_spin_lock(&domain->util_domain.lock);
 	for (iov_count = 0; iov_count < rma_cmd->rma.rma_count; iov_count++) {
 		ret = ofi_mr_map_verify(&domain->util_domain.mr_map,
 				(uintptr_t *) &(rma_cmd->rma.rma_iov[iov_count].addr),
@@ -852,7 +852,7 @@ static int smr_progress_cmd_rma(struct smr_ep *ep, struct smr_cmd *cmd)
 			assert(mr->iface == iface && mr->device == device);
 		}
 	}
-	fastlock_release(&domain->util_domain.lock);
+	ofi_spin_unlock(&domain->util_domain.lock);
 
 	ofi_cirque_discard(smr_cmd_queue(ep->region));
 	if (ret) {
@@ -990,7 +990,7 @@ static void smr_progress_cmd(struct smr_ep *ep)
 	int ret = 0;
 
 	pthread_mutex_lock(&ep->region->lock);
-	fastlock_acquire(&ep->util_ep.rx_cq->cq_lock);
+	ofi_spin_lock(&ep->util_ep.rx_cq->cq_lock);
 
 	while (!ofi_cirque_isempty(smr_cmd_queue(ep->region))) {
 		cmd = ofi_cirque_head(smr_cmd_queue(ep->region));
@@ -1033,7 +1033,7 @@ static void smr_progress_cmd(struct smr_ep *ep)
 			break;
 		}
 	}
-	fastlock_release(&ep->util_ep.rx_cq->cq_lock);
+	ofi_spin_unlock(&ep->util_ep.rx_cq->cq_lock);
 	pthread_mutex_unlock(&ep->region->lock);
 }
 
@@ -1047,7 +1047,7 @@ static void smr_progress_sar_list(struct smr_ep *ep)
 	int ret;
 
 	pthread_mutex_lock(&ep->region->lock);
-	fastlock_acquire(&ep->util_ep.rx_cq->cq_lock);
+	ofi_spin_lock(&ep->util_ep.rx_cq->cq_lock);
 
 	dlist_foreach_container_safe(&ep->sar_list, struct smr_sar_entry,
 				     sar_entry, entry, tmp) {
@@ -1082,7 +1082,7 @@ static void smr_progress_sar_list(struct smr_ep *ep)
 			ofi_freestack_push(ep->sar_fs, sar_entry);
 		}
 	}
-	fastlock_release(&ep->util_ep.rx_cq->cq_lock);
+	ofi_spin_unlock(&ep->util_ep.rx_cq->cq_lock);
 	pthread_mutex_unlock(&ep->region->lock);
 }
 

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -128,7 +128,7 @@ ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 		goto unlock_region;
 	}
 
-	fastlock_acquire(&ep->util_ep.tx_cq->cq_lock);
+	ofi_spin_lock(&ep->util_ep.tx_cq->cq_lock);
 	if (ofi_cirque_isfull(ep->util_ep.tx_cq->cirq)) {
 		ret = -FI_EAGAIN;
 		goto unlock_cq;
@@ -246,7 +246,7 @@ commit_comp:
 	}
 
 unlock_cq:
-	fastlock_release(&ep->util_ep.tx_cq->cq_lock);
+	ofi_spin_unlock(&ep->util_ep.tx_cq->cq_lock);
 unlock_region:
 	pthread_mutex_unlock(&peer_smr->lock);
 	return ret;

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -128,7 +128,7 @@ ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 		goto unlock_region;
 	}
 
-	ofi_spin_lock(&ep->util_ep.tx_cq->cq_lock);
+	ofi_mutex_lock(&ep->util_ep.tx_cq->cq_lock);
 	if (ofi_cirque_isfull(ep->util_ep.tx_cq->cirq)) {
 		ret = -FI_EAGAIN;
 		goto unlock_cq;
@@ -246,7 +246,7 @@ commit_comp:
 	}
 
 unlock_cq:
-	ofi_spin_unlock(&ep->util_ep.tx_cq->cq_lock);
+	ofi_mutex_unlock(&ep->util_ep.tx_cq->cq_lock);
 unlock_region:
 	pthread_mutex_unlock(&peer_smr->lock);
 	return ret;

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -179,7 +179,7 @@ struct sock_fabric {
 #endif
 	struct dlist_entry service_list;
 	struct dlist_entry fab_list_entry;
-	ofi_spin_t lock;
+	ofi_mutex_t lock;
 };
 
 struct sock_conn {
@@ -201,13 +201,13 @@ struct sock_conn_map {
 	int epoll_size;
 	int used;
 	int size;
-	ofi_spin_t lock;
+	ofi_mutex_t lock;
 };
 
 struct sock_conn_listener {
 	ofi_epoll_t epollfd;
 	struct fd_signal signal;
-	ofi_spin_t signal_lock; /* acquire before map lock */
+	ofi_mutex_t signal_lock; /* acquire before map lock */
 	pthread_t listener_thread;
 	int do_listen;
 	bool removed_from_epollfd;
@@ -227,7 +227,7 @@ struct sock_domain {
 	struct fi_info		info;
 	struct fid_domain	dom_fid;
 	struct sock_fabric	*fab;
-	ofi_spin_t		lock;
+	ofi_mutex_t		lock;
 	ofi_atomic32_t		ref;
 
 	struct sock_eq		*eq;
@@ -316,9 +316,9 @@ struct sock_cntr {
 
 	struct dlist_entry	rx_list;
 	struct dlist_entry	tx_list;
-	ofi_spin_t		list_lock;
+	ofi_mutex_t		list_lock;
 
-	ofi_spin_t		trigger_lock;
+	ofi_mutex_t		trigger_lock;
 	struct dlist_entry	trigger_list;
 
 	struct fid_wait		*waitset;
@@ -362,8 +362,8 @@ struct sock_av {
 	struct util_shm shm;
 	int    shared;
 	struct dlist_entry ep_list;
-	ofi_spin_t list_lock;
-	ofi_spin_t table_lock;
+	ofi_mutex_t list_lock;
+	ofi_mutex_t table_lock;
 };
 
 struct sock_fid_list {
@@ -484,7 +484,7 @@ struct sock_eq {
 	struct dlistfd_head list;
 	struct dlistfd_head err_list;
 	struct dlist_entry err_data_list;
-	ofi_spin_t lock;
+	ofi_mutex_t lock;
 
 	struct fid_wait *waitset;
 	int signal;
@@ -525,7 +525,7 @@ struct sock_pep_cm_entry {
 
 struct sock_ep_cm_entry {
 	int sock;
-	ofi_spin_t lock;
+	ofi_mutex_t lock;
 	enum sock_cm_state state;
 };
 
@@ -572,7 +572,7 @@ struct sock_ep_attr {
 	int is_enabled;
 	struct sock_ep_cm_entry cm;
 	struct sock_conn_handle conn_handle;
-	ofi_spin_t lock;
+	ofi_mutex_t lock;
 
 	struct index_map av_idm;
 	struct sock_conn_map cmap;
@@ -654,7 +654,7 @@ struct sock_rx_ctx {
 	struct dlist_entry rx_entry_list;
 	struct dlist_entry rx_buffered_list;
 	struct dlist_entry ep_list;
-	ofi_spin_t lock;
+	ofi_mutex_t lock;
 
 	struct dlist_entry *progress_start;
 
@@ -671,7 +671,7 @@ struct sock_tx_ctx {
 	size_t fclass;
 
 	struct ofi_ringbuf rb;
-	ofi_spin_t rb_lock;
+	ofi_mutex_t rb_lock;
 
 	uint16_t tx_id;
 	uint8_t enabled;
@@ -695,7 +695,7 @@ struct sock_tx_ctx {
 	struct dlist_entry ep_list;
 
 	struct fi_tx_attr attr;
-	ofi_spin_t lock;
+	ofi_mutex_t lock;
 };
 
 struct sock_msg_hdr {
@@ -847,8 +847,8 @@ struct sock_pe {
 	struct sock_domain *domain;
 	int num_free_entries;
 	struct sock_pe_entry pe_table[SOCK_PE_MAX_ENTRIES];
-	ofi_spin_t lock;
-	ofi_spin_t signal_lock;
+	ofi_mutex_t lock;
+	ofi_mutex_t signal_lock;
 	pthread_mutex_t list_lock;
 	int wcnt, rcnt;
 	int signal_fds[2];

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -179,7 +179,7 @@ struct sock_fabric {
 #endif
 	struct dlist_entry service_list;
 	struct dlist_entry fab_list_entry;
-	fastlock_t lock;
+	ofi_spin_t lock;
 };
 
 struct sock_conn {
@@ -201,13 +201,13 @@ struct sock_conn_map {
 	int epoll_size;
 	int used;
 	int size;
-	fastlock_t lock;
+	ofi_spin_t lock;
 };
 
 struct sock_conn_listener {
 	ofi_epoll_t epollfd;
 	struct fd_signal signal;
-	fastlock_t signal_lock; /* acquire before map lock */
+	ofi_spin_t signal_lock; /* acquire before map lock */
 	pthread_t listener_thread;
 	int do_listen;
 	bool removed_from_epollfd;
@@ -227,7 +227,7 @@ struct sock_domain {
 	struct fi_info		info;
 	struct fid_domain	dom_fid;
 	struct sock_fabric	*fab;
-	fastlock_t		lock;
+	ofi_spin_t		lock;
 	ofi_atomic32_t		ref;
 
 	struct sock_eq		*eq;
@@ -316,9 +316,9 @@ struct sock_cntr {
 
 	struct dlist_entry	rx_list;
 	struct dlist_entry	tx_list;
-	fastlock_t		list_lock;
+	ofi_spin_t		list_lock;
 
-	fastlock_t		trigger_lock;
+	ofi_spin_t		trigger_lock;
 	struct dlist_entry	trigger_list;
 
 	struct fid_wait		*waitset;
@@ -362,8 +362,8 @@ struct sock_av {
 	struct util_shm shm;
 	int    shared;
 	struct dlist_entry ep_list;
-	fastlock_t list_lock;
-	fastlock_t table_lock;
+	ofi_spin_t list_lock;
+	ofi_spin_t table_lock;
 };
 
 struct sock_fid_list {
@@ -484,7 +484,7 @@ struct sock_eq {
 	struct dlistfd_head list;
 	struct dlistfd_head err_list;
 	struct dlist_entry err_data_list;
-	fastlock_t lock;
+	ofi_spin_t lock;
 
 	struct fid_wait *waitset;
 	int signal;
@@ -525,7 +525,7 @@ struct sock_pep_cm_entry {
 
 struct sock_ep_cm_entry {
 	int sock;
-	fastlock_t lock;
+	ofi_spin_t lock;
 	enum sock_cm_state state;
 };
 
@@ -572,7 +572,7 @@ struct sock_ep_attr {
 	int is_enabled;
 	struct sock_ep_cm_entry cm;
 	struct sock_conn_handle conn_handle;
-	fastlock_t lock;
+	ofi_spin_t lock;
 
 	struct index_map av_idm;
 	struct sock_conn_map cmap;
@@ -654,7 +654,7 @@ struct sock_rx_ctx {
 	struct dlist_entry rx_entry_list;
 	struct dlist_entry rx_buffered_list;
 	struct dlist_entry ep_list;
-	fastlock_t lock;
+	ofi_spin_t lock;
 
 	struct dlist_entry *progress_start;
 
@@ -671,7 +671,7 @@ struct sock_tx_ctx {
 	size_t fclass;
 
 	struct ofi_ringbuf rb;
-	fastlock_t rb_lock;
+	ofi_spin_t rb_lock;
 
 	uint16_t tx_id;
 	uint8_t enabled;
@@ -695,7 +695,7 @@ struct sock_tx_ctx {
 	struct dlist_entry ep_list;
 
 	struct fi_tx_attr attr;
-	fastlock_t lock;
+	ofi_spin_t lock;
 };
 
 struct sock_msg_hdr {
@@ -847,8 +847,8 @@ struct sock_pe {
 	struct sock_domain *domain;
 	int num_free_entries;
 	struct sock_pe_entry pe_table[SOCK_PE_MAX_ENTRIES];
-	fastlock_t lock;
-	fastlock_t signal_lock;
+	ofi_spin_t lock;
+	ofi_spin_t signal_lock;
 	pthread_mutex_t list_lock;
 	int wcnt, rcnt;
 	int signal_fds[2];

--- a/prov/sockets/src/sock_av.c
+++ b/prov/sockets/src/sock_av.c
@@ -68,7 +68,7 @@ int sock_av_get_addr_index(struct sock_av *av, union ofi_sock_ip *addr)
 	int i;
 	struct sock_av_addr *av_addr;
 
-	fastlock_acquire(&av->table_lock);
+	ofi_spin_lock(&av->table_lock);
 	for (i = 0; i < (int)av->table_hdr->size; i++) {
 		av_addr = &av->table[i];
 		if (!av_addr->valid)
@@ -76,11 +76,11 @@ int sock_av_get_addr_index(struct sock_av *av, union ofi_sock_ip *addr)
 
 		 if (ofi_equals_sockaddr((const struct sockaddr *) addr,
 					 (const struct sockaddr *) &av_addr->addr)) {
-			fastlock_release(&av->table_lock);
+			ofi_spin_unlock(&av->table_lock);
 			return i;
 		 }
 	}
-	fastlock_release(&av->table_lock);
+	ofi_spin_unlock(&av->table_lock);
 	SOCK_LOG_DBG("failed to get index in AV\n");
 	return -1;
 }
@@ -95,11 +95,11 @@ int sock_av_compare_addr(struct sock_av *av,
 	index1 = ((uint64_t)addr1 & av->mask);
 	index2 = ((uint64_t)addr2 & av->mask);
 
-	fastlock_acquire(&av->table_lock);
+	ofi_spin_lock(&av->table_lock);
 	if (index1 >= (int)av->table_hdr->size || index1 < 0 ||
 	    index2 >= (int)av->table_hdr->size || index2 < 0) {
 		SOCK_LOG_ERROR("requested rank is larger than av table\n");
-		fastlock_release(&av->table_lock);
+		ofi_spin_unlock(&av->table_lock);
 		return -1;
 	}
 
@@ -108,7 +108,7 @@ int sock_av_compare_addr(struct sock_av *av,
 
 	/* Return 0 if the addresses match */
 	ret = !ofi_equals_sockaddr(&av_addr1->addr.sa, &av_addr2->addr.sa);
-	fastlock_release(&av->table_lock);
+	ofi_spin_unlock(&av->table_lock);
 	return ret;
 }
 
@@ -287,9 +287,9 @@ static int sock_av_insert(struct fid_av *av, const void *addr, size_t count,
 
 	_av = container_of(av, struct sock_av, av_fid);
 
-	fastlock_acquire(&_av->table_lock);
+	ofi_spin_lock(&_av->table_lock);
 	ret = sock_check_table_in(_av, addr, fi_addr, count, flags, context);
-	fastlock_release(&_av->table_lock);
+	ofi_spin_unlock(&_av->table_lock);
 	return ret;
 }
 
@@ -303,16 +303,16 @@ static int sock_av_lookup(struct fid_av *av, fi_addr_t fi_addr, void *addr,
 	_av = container_of(av, struct sock_av, av_fid);
 	index = ((uint64_t)fi_addr & _av->mask);
 
-	fastlock_acquire(&_av->table_lock);
+	ofi_spin_lock(&_av->table_lock);
 	if (index >= (int)_av->table_hdr->size || index < 0) {
 		SOCK_LOG_ERROR("requested address not inserted\n");
-		fastlock_release(&_av->table_lock);
+		ofi_spin_unlock(&_av->table_lock);
 		return -EINVAL;
 	}
 
 	av_addr = &_av->table[index];
 	memcpy(addr, &av_addr->addr, MIN(*addrlen, (size_t)_av->addrlen));
-	fastlock_release(&_av->table_lock);
+	ofi_spin_unlock(&_av->table_lock);
 	*addrlen = _av->addrlen;
 	return 0;
 }
@@ -342,10 +342,10 @@ static int _sock_av_insertsvc(struct fid_av *av, const char *node,
 		return -ret;
 	}
 
-	fastlock_acquire(&_av->table_lock);
+	ofi_spin_lock(&_av->table_lock);
 	ret = sock_check_table_in(_av, result->ai_addr,
 				  fi_addr, 1, flags, context);
-	fastlock_release(&_av->table_lock);
+	ofi_spin_unlock(&_av->table_lock);
 	freeaddrinfo(result);
 	return ret;
 }
@@ -429,11 +429,11 @@ static int sock_av_remove(struct fid_av *av, fi_addr_t *fi_addr, size_t count,
 	uint16_t idx;
 
 	_av = container_of(av, struct sock_av, av_fid);
-	fastlock_acquire(&_av->list_lock);
+	ofi_spin_lock(&_av->list_lock);
 	dlist_foreach(&_av->ep_list, item) {
 		fid_entry = container_of(item, struct fid_list_entry, entry);
 		sock_ep = container_of(fid_entry->fid, struct sock_ep, ep.fid);
-		fastlock_acquire(&sock_ep->attr->cmap.lock);
+		ofi_spin_lock(&sock_ep->attr->cmap.lock);
 		for (i = 0; i < count; i++) {
 			idx = fi_addr[i] & sock_ep->attr->av->mask;
 			conn = ofi_idm_lookup(&sock_ep->attr->av_idm, idx);
@@ -446,16 +446,16 @@ static int sock_av_remove(struct fid_av *av, fi_addr_t *fi_addr, size_t count,
 				ofi_idm_clear(&sock_ep->attr->av_idm, idx);
 			}
 		}
-		fastlock_release(&sock_ep->attr->cmap.lock);
+		ofi_spin_unlock(&sock_ep->attr->cmap.lock);
 	}
-	fastlock_release(&_av->list_lock);
+	ofi_spin_unlock(&_av->list_lock);
 
-	fastlock_acquire(&_av->table_lock);
+	ofi_spin_lock(&_av->table_lock);
 	for (i = 0; i < count; i++) {
 		av_addr = &_av->table[fi_addr[i]];
 		av_addr->valid = 0;
 	}
-	fastlock_release(&_av->table_lock);
+	ofi_spin_unlock(&_av->table_lock);
 
 	return 0;
 }
@@ -510,8 +510,8 @@ static int sock_av_close(struct fid *fid)
 	}
 
 	ofi_atomic_dec32(&av->domain->ref);
-	fastlock_destroy(&av->list_lock);
-	fastlock_destroy(&av->table_lock);
+	ofi_spin_destroy(&av->list_lock);
+	ofi_spin_destroy(&av->table_lock);
 	free(av);
 	return 0;
 }
@@ -659,8 +659,8 @@ int sock_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 		goto err2;
 	}
 	dlist_init(&_av->ep_list);
-	fastlock_init(&_av->list_lock);
-	fastlock_init(&_av->table_lock);
+	ofi_spin_init(&_av->list_lock);
+	ofi_spin_init(&_av->table_lock);
 	_av->rx_ctx_bits = attr->rx_ctx_bits;
 	_av->mask = attr->rx_ctx_bits ?
 		((uint64_t)1 << (64 - attr->rx_ctx_bits)) - 1 : ~0;

--- a/prov/sockets/src/sock_av.c
+++ b/prov/sockets/src/sock_av.c
@@ -68,7 +68,7 @@ int sock_av_get_addr_index(struct sock_av *av, union ofi_sock_ip *addr)
 	int i;
 	struct sock_av_addr *av_addr;
 
-	ofi_spin_lock(&av->table_lock);
+	ofi_mutex_lock(&av->table_lock);
 	for (i = 0; i < (int)av->table_hdr->size; i++) {
 		av_addr = &av->table[i];
 		if (!av_addr->valid)
@@ -76,11 +76,11 @@ int sock_av_get_addr_index(struct sock_av *av, union ofi_sock_ip *addr)
 
 		 if (ofi_equals_sockaddr((const struct sockaddr *) addr,
 					 (const struct sockaddr *) &av_addr->addr)) {
-			ofi_spin_unlock(&av->table_lock);
+			ofi_mutex_unlock(&av->table_lock);
 			return i;
 		 }
 	}
-	ofi_spin_unlock(&av->table_lock);
+	ofi_mutex_unlock(&av->table_lock);
 	SOCK_LOG_DBG("failed to get index in AV\n");
 	return -1;
 }
@@ -95,11 +95,11 @@ int sock_av_compare_addr(struct sock_av *av,
 	index1 = ((uint64_t)addr1 & av->mask);
 	index2 = ((uint64_t)addr2 & av->mask);
 
-	ofi_spin_lock(&av->table_lock);
+	ofi_mutex_lock(&av->table_lock);
 	if (index1 >= (int)av->table_hdr->size || index1 < 0 ||
 	    index2 >= (int)av->table_hdr->size || index2 < 0) {
 		SOCK_LOG_ERROR("requested rank is larger than av table\n");
-		ofi_spin_unlock(&av->table_lock);
+		ofi_mutex_unlock(&av->table_lock);
 		return -1;
 	}
 
@@ -108,7 +108,7 @@ int sock_av_compare_addr(struct sock_av *av,
 
 	/* Return 0 if the addresses match */
 	ret = !ofi_equals_sockaddr(&av_addr1->addr.sa, &av_addr2->addr.sa);
-	ofi_spin_unlock(&av->table_lock);
+	ofi_mutex_unlock(&av->table_lock);
 	return ret;
 }
 
@@ -287,9 +287,9 @@ static int sock_av_insert(struct fid_av *av, const void *addr, size_t count,
 
 	_av = container_of(av, struct sock_av, av_fid);
 
-	ofi_spin_lock(&_av->table_lock);
+	ofi_mutex_lock(&_av->table_lock);
 	ret = sock_check_table_in(_av, addr, fi_addr, count, flags, context);
-	ofi_spin_unlock(&_av->table_lock);
+	ofi_mutex_unlock(&_av->table_lock);
 	return ret;
 }
 
@@ -303,16 +303,16 @@ static int sock_av_lookup(struct fid_av *av, fi_addr_t fi_addr, void *addr,
 	_av = container_of(av, struct sock_av, av_fid);
 	index = ((uint64_t)fi_addr & _av->mask);
 
-	ofi_spin_lock(&_av->table_lock);
+	ofi_mutex_lock(&_av->table_lock);
 	if (index >= (int)_av->table_hdr->size || index < 0) {
 		SOCK_LOG_ERROR("requested address not inserted\n");
-		ofi_spin_unlock(&_av->table_lock);
+		ofi_mutex_unlock(&_av->table_lock);
 		return -EINVAL;
 	}
 
 	av_addr = &_av->table[index];
 	memcpy(addr, &av_addr->addr, MIN(*addrlen, (size_t)_av->addrlen));
-	ofi_spin_unlock(&_av->table_lock);
+	ofi_mutex_unlock(&_av->table_lock);
 	*addrlen = _av->addrlen;
 	return 0;
 }
@@ -342,10 +342,10 @@ static int _sock_av_insertsvc(struct fid_av *av, const char *node,
 		return -ret;
 	}
 
-	ofi_spin_lock(&_av->table_lock);
+	ofi_mutex_lock(&_av->table_lock);
 	ret = sock_check_table_in(_av, result->ai_addr,
 				  fi_addr, 1, flags, context);
-	ofi_spin_unlock(&_av->table_lock);
+	ofi_mutex_unlock(&_av->table_lock);
 	freeaddrinfo(result);
 	return ret;
 }
@@ -429,11 +429,11 @@ static int sock_av_remove(struct fid_av *av, fi_addr_t *fi_addr, size_t count,
 	uint16_t idx;
 
 	_av = container_of(av, struct sock_av, av_fid);
-	ofi_spin_lock(&_av->list_lock);
+	ofi_mutex_lock(&_av->list_lock);
 	dlist_foreach(&_av->ep_list, item) {
 		fid_entry = container_of(item, struct fid_list_entry, entry);
 		sock_ep = container_of(fid_entry->fid, struct sock_ep, ep.fid);
-		ofi_spin_lock(&sock_ep->attr->cmap.lock);
+		ofi_mutex_lock(&sock_ep->attr->cmap.lock);
 		for (i = 0; i < count; i++) {
 			idx = fi_addr[i] & sock_ep->attr->av->mask;
 			conn = ofi_idm_lookup(&sock_ep->attr->av_idm, idx);
@@ -446,16 +446,16 @@ static int sock_av_remove(struct fid_av *av, fi_addr_t *fi_addr, size_t count,
 				ofi_idm_clear(&sock_ep->attr->av_idm, idx);
 			}
 		}
-		ofi_spin_unlock(&sock_ep->attr->cmap.lock);
+		ofi_mutex_unlock(&sock_ep->attr->cmap.lock);
 	}
-	ofi_spin_unlock(&_av->list_lock);
+	ofi_mutex_unlock(&_av->list_lock);
 
-	ofi_spin_lock(&_av->table_lock);
+	ofi_mutex_lock(&_av->table_lock);
 	for (i = 0; i < count; i++) {
 		av_addr = &_av->table[fi_addr[i]];
 		av_addr->valid = 0;
 	}
-	ofi_spin_unlock(&_av->table_lock);
+	ofi_mutex_unlock(&_av->table_lock);
 
 	return 0;
 }
@@ -510,8 +510,8 @@ static int sock_av_close(struct fid *fid)
 	}
 
 	ofi_atomic_dec32(&av->domain->ref);
-	ofi_spin_destroy(&av->list_lock);
-	ofi_spin_destroy(&av->table_lock);
+	ofi_mutex_destroy(&av->list_lock);
+	ofi_mutex_destroy(&av->table_lock);
 	free(av);
 	return 0;
 }
@@ -659,8 +659,8 @@ int sock_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 		goto err2;
 	}
 	dlist_init(&_av->ep_list);
-	ofi_spin_init(&_av->list_lock);
-	ofi_spin_init(&_av->table_lock);
+	ofi_mutex_init(&_av->list_lock);
+	ofi_mutex_init(&_av->table_lock);
 	_av->rx_ctx_bits = attr->rx_ctx_bits;
 	_av->mask = attr->rx_ctx_bits ?
 		((uint64_t)1 << (64 - attr->rx_ctx_bits)) - 1 : ~0;

--- a/prov/sockets/src/sock_cntr.c
+++ b/prov/sockets/src/sock_cntr.c
@@ -100,7 +100,7 @@ int sock_cntr_progress(struct sock_cntr *cntr)
 	if (cntr->domain->progress_mode == FI_PROGRESS_AUTO)
 		return 0;
 
-	fastlock_acquire(&cntr->list_lock);
+	ofi_spin_lock(&cntr->list_lock);
 	for (entry = cntr->tx_list.next; entry != &cntr->tx_list;
 	     entry = entry->next) {
 		fid_entry = container_of(entry, struct fid_list_entry, entry);
@@ -121,7 +121,7 @@ int sock_cntr_progress(struct sock_cntr *cntr)
 			sock_pe_progress_ep_rx(cntr->domain->pe, rx_ctx->ep_attr);
 	}
 
-	fastlock_release(&cntr->list_lock);
+	ofi_spin_unlock(&cntr->list_lock);
 	return 0;
 }
 
@@ -132,7 +132,7 @@ void sock_cntr_check_trigger_list(struct sock_cntr *cntr)
 	struct dlist_entry *entry;
 	int ret = 0;
 
-	fastlock_acquire(&cntr->trigger_lock);
+	ofi_spin_lock(&cntr->trigger_lock);
 	for (entry = cntr->trigger_list.next;
 	     entry != &cntr->trigger_list;) {
 
@@ -207,7 +207,7 @@ void sock_cntr_check_trigger_list(struct sock_cntr *cntr)
 			break;
 		}
 	}
-	fastlock_release(&cntr->trigger_lock);
+	ofi_spin_unlock(&cntr->trigger_lock);
 }
 
 static uint64_t sock_cntr_read(struct fid_cntr *fid_cntr)
@@ -437,8 +437,8 @@ static int sock_cntr_close(struct fid *fid)
 	pthread_mutex_unlock(&cntr->mut);
 
 	pthread_mutex_destroy(&cntr->mut);
-	fastlock_destroy(&cntr->list_lock);
-	fastlock_destroy(&cntr->trigger_lock);
+	ofi_spin_destroy(&cntr->list_lock);
+	ofi_spin_destroy(&cntr->trigger_lock);
 
 	pthread_cond_destroy(&cntr->cond);
 	ofi_atomic_dec32(&cntr->domain->ref);
@@ -571,7 +571,7 @@ int sock_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 	}
 
 	pthread_mutex_init(&_cntr->mut, NULL);
-	fastlock_init(&_cntr->list_lock);
+	ofi_spin_init(&_cntr->list_lock);
 
 	ofi_atomic_initialize32(&_cntr->ref, 0);
 	ofi_atomic_initialize32(&_cntr->err_cnt, 0);
@@ -584,7 +584,7 @@ int sock_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 	dlist_init(&_cntr->rx_list);
 
 	dlist_init(&_cntr->trigger_list);
-	fastlock_init(&_cntr->trigger_lock);
+	ofi_spin_init(&_cntr->trigger_lock);
 
 	_cntr->cntr_fid.fid.fclass = FI_CLASS_CNTR;
 	_cntr->cntr_fid.fid.context = context;

--- a/prov/sockets/src/sock_cntr.c
+++ b/prov/sockets/src/sock_cntr.c
@@ -57,7 +57,7 @@ void sock_cntr_add_tx_ctx(struct sock_cntr *cntr, struct sock_tx_ctx *tx_ctx)
 {
 	int ret;
 	struct fid *fid = &tx_ctx->fid.ctx.fid;
-	ret = fid_list_insert_m(&cntr->tx_list, &cntr->list_lock, fid);
+	ret = fid_list_insert(&cntr->tx_list, &cntr->list_lock, fid);
 	if (ret)
 		SOCK_LOG_ERROR("Error in adding ctx to progress list\n");
 	else
@@ -67,7 +67,7 @@ void sock_cntr_add_tx_ctx(struct sock_cntr *cntr, struct sock_tx_ctx *tx_ctx)
 void sock_cntr_remove_tx_ctx(struct sock_cntr *cntr, struct sock_tx_ctx *tx_ctx)
 {
 	struct fid *fid = &tx_ctx->fid.ctx.fid;
-	fid_list_remove_m(&cntr->tx_list, &cntr->list_lock, fid);
+	fid_list_remove(&cntr->tx_list, &cntr->list_lock, fid);
 	ofi_atomic_dec32(&cntr->ref);
 }
 
@@ -75,7 +75,7 @@ void sock_cntr_add_rx_ctx(struct sock_cntr *cntr, struct sock_rx_ctx *rx_ctx)
 {
 	int ret;
 	struct fid *fid = &rx_ctx->ctx.fid;
-	ret = fid_list_insert_m(&cntr->rx_list, &cntr->list_lock, fid);
+	ret = fid_list_insert(&cntr->rx_list, &cntr->list_lock, fid);
 	if (ret)
 		SOCK_LOG_ERROR("Error in adding ctx to progress list\n");
 	else
@@ -85,7 +85,7 @@ void sock_cntr_add_rx_ctx(struct sock_cntr *cntr, struct sock_rx_ctx *rx_ctx)
 void sock_cntr_remove_rx_ctx(struct sock_cntr *cntr, struct sock_rx_ctx *rx_ctx)
 {
 	struct fid *fid = &rx_ctx->ctx.fid;
-	fid_list_remove_m(&cntr->rx_list, &cntr->list_lock, fid);
+	fid_list_remove(&cntr->rx_list, &cntr->list_lock, fid);
 	ofi_atomic_dec32(&cntr->ref);
 }
 

--- a/prov/sockets/src/sock_cntr.c
+++ b/prov/sockets/src/sock_cntr.c
@@ -338,7 +338,7 @@ static int sock_cntr_wait(struct fid_cntr *fid_cntr, uint64_t threshold,
 			ret = sock_cntr_progress(cntr);
 			pthread_mutex_lock(&cntr->mut);
 		} else {
-			ret = fi_wait_cond(&cntr->cond, &cntr->mut, remaining_ms);
+			ret = ofi_wait_cond(&cntr->cond, &cntr->mut, remaining_ms);
 		}
 
 		uint64_t curr_ms = ofi_gettime_ms();

--- a/prov/sockets/src/sock_conn.c
+++ b/prov/sockets/src/sock_conn.c
@@ -114,7 +114,7 @@ int sock_conn_map_init(struct sock_ep *ep, int init_size)
 		goto err2;
 	}
 
-	ofi_spin_init(&map->lock);
+	ofi_mutex_init(&map->lock);
 	map->used = 0;
 	map->size = init_size;
 	map->epoll_size = init_size;
@@ -160,7 +160,7 @@ void sock_conn_map_destroy(struct sock_ep_attr *ep_attr)
 	cmap->epoll_size = 0;
 	cmap->used = cmap->size = 0;
 	ofi_epoll_close(cmap->epoll_set);
-	ofi_spin_destroy(&cmap->lock);
+	ofi_mutex_destroy(&cmap->lock);
 }
 
 void sock_conn_release_entry(struct sock_conn_map *map, struct sock_conn *conn)
@@ -299,9 +299,9 @@ int sock_conn_stop_listener_thread(struct sock_conn_listener *conn_listener)
 {
 	conn_listener->do_listen = 0;
 
-	ofi_spin_lock(&conn_listener->signal_lock);
+	ofi_mutex_lock(&conn_listener->signal_lock);
 	fd_signal_set(&conn_listener->signal);
-	ofi_spin_unlock(&conn_listener->signal_lock);
+	ofi_mutex_unlock(&conn_listener->signal_lock);
 
 	if (conn_listener->listener_thread &&
 	    pthread_join(conn_listener->listener_thread, NULL)) {
@@ -310,7 +310,7 @@ int sock_conn_stop_listener_thread(struct sock_conn_listener *conn_listener)
 
 	fd_signal_free(&conn_listener->signal);
 	ofi_epoll_close(conn_listener->epollfd);
-	ofi_spin_destroy(&conn_listener->signal_lock);
+	ofi_mutex_destroy(&conn_listener->signal_lock);
 
 	return 0;
 }
@@ -333,7 +333,7 @@ static void *sock_conn_listener_thread(void *arg)
 			continue;
 		}
 
-		ofi_spin_lock(&conn_listener->signal_lock);
+		ofi_mutex_lock(&conn_listener->signal_lock);
 		if (conn_listener->removed_from_epollfd) {
 			/* The epoll set changed between calling wait and wait
 			 * returning.  Get an updated set of events to avoid
@@ -366,13 +366,13 @@ static void *sock_conn_listener_thread(void *arg)
 			}
 
 			ep_attr = container_of(conn_handle, struct sock_ep_attr, conn_handle);
-			ofi_spin_lock(&ep_attr->cmap.lock);
+			ofi_mutex_lock(&ep_attr->cmap.lock);
 			sock_conn_map_insert(ep_attr, &remote, conn_fd, 1);
-			ofi_spin_unlock(&ep_attr->cmap.lock);
+			ofi_mutex_unlock(&ep_attr->cmap.lock);
 			sock_pe_signal(ep_attr->domain->pe);
 		}
 skip:
-		ofi_spin_unlock(&conn_listener->signal_lock);
+		ofi_mutex_unlock(&conn_listener->signal_lock);
 	}
 
 	return NULL;
@@ -382,7 +382,7 @@ int sock_conn_start_listener_thread(struct sock_conn_listener *conn_listener)
 {
 	int ret;
 
-	ofi_spin_init(&conn_listener->signal_lock);
+	ofi_mutex_init(&conn_listener->signal_lock);
 
 	ret = ofi_epoll_create(&conn_listener->epollfd);
 	if (ret < 0) {
@@ -420,7 +420,7 @@ err3:
 err2:
 	ofi_epoll_close(conn_listener->epollfd);
 err1:
-	ofi_spin_destroy(&conn_listener->signal_lock);
+	ofi_mutex_destroy(&conn_listener->signal_lock);
 	return ret;
 }
 
@@ -476,11 +476,11 @@ int sock_conn_listen(struct sock_ep_attr *ep_attr)
 	conn_handle->sock = listen_fd;
 	conn_handle->do_listen = 1;
 
-	ofi_spin_lock(&ep_attr->domain->conn_listener.signal_lock);
+	ofi_mutex_lock(&ep_attr->domain->conn_listener.signal_lock);
 	ret = ofi_epoll_add(ep_attr->domain->conn_listener.epollfd,
 	                   conn_handle->sock, OFI_EPOLL_IN, conn_handle);
 	fd_signal_set(&ep_attr->domain->conn_listener.signal);
-	ofi_spin_unlock(&ep_attr->domain->conn_listener.signal_lock);
+	ofi_mutex_unlock(&ep_attr->domain->conn_listener.signal_lock);
 	if (ret) {
 		SOCK_LOG_ERROR("failed to add fd to pollset: %d\n", ret);
 		goto err;
@@ -515,15 +515,15 @@ int sock_ep_connect(struct sock_ep_attr *ep_attr, fi_addr_t index,
 		addr = *ep_attr->dest_addr;
 		ofi_addr_set_port(&addr.sa, ep_attr->msg_dest_port);
 	} else {
-		ofi_spin_lock(&ep_attr->av->table_lock);
+		ofi_mutex_lock(&ep_attr->av->table_lock);
 		addr = ep_attr->av->table[index].addr;
-		ofi_spin_unlock(&ep_attr->av->table_lock);
+		ofi_mutex_unlock(&ep_attr->av->table_lock);
 	}
 
 do_connect:
-	ofi_spin_lock(&ep_attr->cmap.lock);
+	ofi_mutex_lock(&ep_attr->cmap.lock);
 	*conn = sock_ep_lookup_conn(ep_attr, index, &addr);
-	ofi_spin_unlock(&ep_attr->cmap.lock);
+	ofi_mutex_unlock(&ep_attr->cmap.lock);
 
 	if (*conn != SOCK_CM_CONN_IN_PROGRESS)
 		return FI_SUCCESS;
@@ -600,10 +600,10 @@ retry:
         goto do_connect;
 
 out:
-	ofi_spin_lock(&ep_attr->cmap.lock);
+	ofi_mutex_lock(&ep_attr->cmap.lock);
 	new_conn = sock_conn_map_insert(ep_attr, &addr, conn_fd, 0);
 	if (!new_conn) {
-		ofi_spin_unlock(&ep_attr->cmap.lock);
+		ofi_mutex_unlock(&ep_attr->cmap.lock);
 		goto err;
 	}
 	new_conn->av_index = (ep_attr->ep_type == FI_EP_MSG) ?
@@ -614,7 +614,7 @@ out:
 			SOCK_LOG_ERROR("ofi_idm_set failed\n");
 		*conn = new_conn;
 	}
-	ofi_spin_unlock(&ep_attr->cmap.lock);
+	ofi_mutex_unlock(&ep_attr->cmap.lock);
 	return FI_SUCCESS;
 
 err:

--- a/prov/sockets/src/sock_conn.c
+++ b/prov/sockets/src/sock_conn.c
@@ -114,7 +114,7 @@ int sock_conn_map_init(struct sock_ep *ep, int init_size)
 		goto err2;
 	}
 
-	fastlock_init(&map->lock);
+	ofi_spin_init(&map->lock);
 	map->used = 0;
 	map->size = init_size;
 	map->epoll_size = init_size;
@@ -160,7 +160,7 @@ void sock_conn_map_destroy(struct sock_ep_attr *ep_attr)
 	cmap->epoll_size = 0;
 	cmap->used = cmap->size = 0;
 	ofi_epoll_close(cmap->epoll_set);
-	fastlock_destroy(&cmap->lock);
+	ofi_spin_destroy(&cmap->lock);
 }
 
 void sock_conn_release_entry(struct sock_conn_map *map, struct sock_conn *conn)
@@ -299,9 +299,9 @@ int sock_conn_stop_listener_thread(struct sock_conn_listener *conn_listener)
 {
 	conn_listener->do_listen = 0;
 
-	fastlock_acquire(&conn_listener->signal_lock);
+	ofi_spin_lock(&conn_listener->signal_lock);
 	fd_signal_set(&conn_listener->signal);
-	fastlock_release(&conn_listener->signal_lock);
+	ofi_spin_unlock(&conn_listener->signal_lock);
 
 	if (conn_listener->listener_thread &&
 	    pthread_join(conn_listener->listener_thread, NULL)) {
@@ -310,7 +310,7 @@ int sock_conn_stop_listener_thread(struct sock_conn_listener *conn_listener)
 
 	fd_signal_free(&conn_listener->signal);
 	ofi_epoll_close(conn_listener->epollfd);
-	fastlock_destroy(&conn_listener->signal_lock);
+	ofi_spin_destroy(&conn_listener->signal_lock);
 
 	return 0;
 }
@@ -333,7 +333,7 @@ static void *sock_conn_listener_thread(void *arg)
 			continue;
 		}
 
-		fastlock_acquire(&conn_listener->signal_lock);
+		ofi_spin_lock(&conn_listener->signal_lock);
 		if (conn_listener->removed_from_epollfd) {
 			/* The epoll set changed between calling wait and wait
 			 * returning.  Get an updated set of events to avoid
@@ -366,13 +366,13 @@ static void *sock_conn_listener_thread(void *arg)
 			}
 
 			ep_attr = container_of(conn_handle, struct sock_ep_attr, conn_handle);
-			fastlock_acquire(&ep_attr->cmap.lock);
+			ofi_spin_lock(&ep_attr->cmap.lock);
 			sock_conn_map_insert(ep_attr, &remote, conn_fd, 1);
-			fastlock_release(&ep_attr->cmap.lock);
+			ofi_spin_unlock(&ep_attr->cmap.lock);
 			sock_pe_signal(ep_attr->domain->pe);
 		}
 skip:
-		fastlock_release(&conn_listener->signal_lock);
+		ofi_spin_unlock(&conn_listener->signal_lock);
 	}
 
 	return NULL;
@@ -382,7 +382,7 @@ int sock_conn_start_listener_thread(struct sock_conn_listener *conn_listener)
 {
 	int ret;
 
-	fastlock_init(&conn_listener->signal_lock);
+	ofi_spin_init(&conn_listener->signal_lock);
 
 	ret = ofi_epoll_create(&conn_listener->epollfd);
 	if (ret < 0) {
@@ -420,7 +420,7 @@ err3:
 err2:
 	ofi_epoll_close(conn_listener->epollfd);
 err1:
-	fastlock_destroy(&conn_listener->signal_lock);
+	ofi_spin_destroy(&conn_listener->signal_lock);
 	return ret;
 }
 
@@ -476,11 +476,11 @@ int sock_conn_listen(struct sock_ep_attr *ep_attr)
 	conn_handle->sock = listen_fd;
 	conn_handle->do_listen = 1;
 
-	fastlock_acquire(&ep_attr->domain->conn_listener.signal_lock);
+	ofi_spin_lock(&ep_attr->domain->conn_listener.signal_lock);
 	ret = ofi_epoll_add(ep_attr->domain->conn_listener.epollfd,
 	                   conn_handle->sock, OFI_EPOLL_IN, conn_handle);
 	fd_signal_set(&ep_attr->domain->conn_listener.signal);
-	fastlock_release(&ep_attr->domain->conn_listener.signal_lock);
+	ofi_spin_unlock(&ep_attr->domain->conn_listener.signal_lock);
 	if (ret) {
 		SOCK_LOG_ERROR("failed to add fd to pollset: %d\n", ret);
 		goto err;
@@ -515,15 +515,15 @@ int sock_ep_connect(struct sock_ep_attr *ep_attr, fi_addr_t index,
 		addr = *ep_attr->dest_addr;
 		ofi_addr_set_port(&addr.sa, ep_attr->msg_dest_port);
 	} else {
-		fastlock_acquire(&ep_attr->av->table_lock);
+		ofi_spin_lock(&ep_attr->av->table_lock);
 		addr = ep_attr->av->table[index].addr;
-		fastlock_release(&ep_attr->av->table_lock);
+		ofi_spin_unlock(&ep_attr->av->table_lock);
 	}
 
 do_connect:
-	fastlock_acquire(&ep_attr->cmap.lock);
+	ofi_spin_lock(&ep_attr->cmap.lock);
 	*conn = sock_ep_lookup_conn(ep_attr, index, &addr);
-	fastlock_release(&ep_attr->cmap.lock);
+	ofi_spin_unlock(&ep_attr->cmap.lock);
 
 	if (*conn != SOCK_CM_CONN_IN_PROGRESS)
 		return FI_SUCCESS;
@@ -600,10 +600,10 @@ retry:
         goto do_connect;
 
 out:
-	fastlock_acquire(&ep_attr->cmap.lock);
+	ofi_spin_lock(&ep_attr->cmap.lock);
 	new_conn = sock_conn_map_insert(ep_attr, &addr, conn_fd, 0);
 	if (!new_conn) {
-		fastlock_release(&ep_attr->cmap.lock);
+		ofi_spin_unlock(&ep_attr->cmap.lock);
 		goto err;
 	}
 	new_conn->av_index = (ep_attr->ep_type == FI_EP_MSG) ?
@@ -614,7 +614,7 @@ out:
 			SOCK_LOG_ERROR("ofi_idm_set failed\n");
 		*conn = new_conn;
 	}
-	fastlock_release(&ep_attr->cmap.lock);
+	ofi_spin_unlock(&ep_attr->cmap.lock);
 	return FI_SUCCESS;
 
 err:

--- a/prov/sockets/src/sock_ctx.c
+++ b/prov/sockets/src/sock_ctx.c
@@ -59,7 +59,7 @@ struct sock_rx_ctx *sock_rx_ctx_alloc(const struct fi_rx_attr *attr,
 
 	rx_ctx->progress_start = &rx_ctx->rx_buffered_list;
 
-	ofi_spin_init(&rx_ctx->lock);
+	ofi_mutex_init(&rx_ctx->lock);
 
 	rx_ctx->ctx.fid.fclass = FI_CLASS_RX_CTX;
 	rx_ctx->ctx.fid.context = context;
@@ -80,7 +80,7 @@ void sock_rx_ctx_free(struct sock_rx_ctx *rx_ctx)
 		free(rx_buffered);
 	}
 
-	ofi_spin_destroy(&rx_ctx->lock);
+	ofi_mutex_destroy(&rx_ctx->lock);
 	free(rx_ctx->rx_entry_pool);
 	free(rx_ctx);
 }
@@ -107,8 +107,8 @@ static struct sock_tx_ctx *sock_tx_context_alloc(const struct fi_tx_attr *attr,
 	dlist_init(&tx_ctx->pe_entry_list);
 	dlist_init(&tx_ctx->ep_list);
 
-	ofi_spin_init(&tx_ctx->rb_lock);
-	ofi_spin_init(&tx_ctx->lock);
+	ofi_mutex_init(&tx_ctx->rb_lock);
+	ofi_mutex_init(&tx_ctx->lock);
 
 	switch (fclass) {
 	case FI_CLASS_TX_CTX:
@@ -156,8 +156,8 @@ struct sock_tx_ctx *sock_stx_ctx_alloc(const struct fi_tx_attr *attr,
 
 void sock_tx_ctx_free(struct sock_tx_ctx *tx_ctx)
 {
-	ofi_spin_destroy(&tx_ctx->rb_lock);
-	ofi_spin_destroy(&tx_ctx->lock);
+	ofi_mutex_destroy(&tx_ctx->rb_lock);
+	ofi_mutex_destroy(&tx_ctx->lock);
 
 	if (!tx_ctx->use_shared) {
 		ofi_rbfree(&tx_ctx->rb);
@@ -168,7 +168,7 @@ void sock_tx_ctx_free(struct sock_tx_ctx *tx_ctx)
 
 void sock_tx_ctx_start(struct sock_tx_ctx *tx_ctx)
 {
-	ofi_spin_lock(&tx_ctx->rb_lock);
+	ofi_mutex_lock(&tx_ctx->rb_lock);
 }
 
 void sock_tx_ctx_write(struct sock_tx_ctx *tx_ctx, const void *buf, size_t len)
@@ -180,13 +180,13 @@ void sock_tx_ctx_commit(struct sock_tx_ctx *tx_ctx)
 {
 	ofi_rbcommit(&tx_ctx->rb);
 	sock_pe_signal(tx_ctx->domain->pe);
-	ofi_spin_unlock(&tx_ctx->rb_lock);
+	ofi_mutex_unlock(&tx_ctx->rb_lock);
 }
 
 void sock_tx_ctx_abort(struct sock_tx_ctx *tx_ctx)
 {
 	ofi_rbabort(&tx_ctx->rb);
-	ofi_spin_unlock(&tx_ctx->rb_lock);
+	ofi_mutex_unlock(&tx_ctx->rb_lock);
 }
 
 void sock_tx_ctx_write_op_send(struct sock_tx_ctx *tx_ctx,

--- a/prov/sockets/src/sock_ctx.c
+++ b/prov/sockets/src/sock_ctx.c
@@ -59,7 +59,7 @@ struct sock_rx_ctx *sock_rx_ctx_alloc(const struct fi_rx_attr *attr,
 
 	rx_ctx->progress_start = &rx_ctx->rx_buffered_list;
 
-	fastlock_init(&rx_ctx->lock);
+	ofi_spin_init(&rx_ctx->lock);
 
 	rx_ctx->ctx.fid.fclass = FI_CLASS_RX_CTX;
 	rx_ctx->ctx.fid.context = context;
@@ -80,7 +80,7 @@ void sock_rx_ctx_free(struct sock_rx_ctx *rx_ctx)
 		free(rx_buffered);
 	}
 
-	fastlock_destroy(&rx_ctx->lock);
+	ofi_spin_destroy(&rx_ctx->lock);
 	free(rx_ctx->rx_entry_pool);
 	free(rx_ctx);
 }
@@ -107,8 +107,8 @@ static struct sock_tx_ctx *sock_tx_context_alloc(const struct fi_tx_attr *attr,
 	dlist_init(&tx_ctx->pe_entry_list);
 	dlist_init(&tx_ctx->ep_list);
 
-	fastlock_init(&tx_ctx->rb_lock);
-	fastlock_init(&tx_ctx->lock);
+	ofi_spin_init(&tx_ctx->rb_lock);
+	ofi_spin_init(&tx_ctx->lock);
 
 	switch (fclass) {
 	case FI_CLASS_TX_CTX:
@@ -156,8 +156,8 @@ struct sock_tx_ctx *sock_stx_ctx_alloc(const struct fi_tx_attr *attr,
 
 void sock_tx_ctx_free(struct sock_tx_ctx *tx_ctx)
 {
-	fastlock_destroy(&tx_ctx->rb_lock);
-	fastlock_destroy(&tx_ctx->lock);
+	ofi_spin_destroy(&tx_ctx->rb_lock);
+	ofi_spin_destroy(&tx_ctx->lock);
 
 	if (!tx_ctx->use_shared) {
 		ofi_rbfree(&tx_ctx->rb);
@@ -168,7 +168,7 @@ void sock_tx_ctx_free(struct sock_tx_ctx *tx_ctx)
 
 void sock_tx_ctx_start(struct sock_tx_ctx *tx_ctx)
 {
-	fastlock_acquire(&tx_ctx->rb_lock);
+	ofi_spin_lock(&tx_ctx->rb_lock);
 }
 
 void sock_tx_ctx_write(struct sock_tx_ctx *tx_ctx, const void *buf, size_t len)
@@ -180,13 +180,13 @@ void sock_tx_ctx_commit(struct sock_tx_ctx *tx_ctx)
 {
 	ofi_rbcommit(&tx_ctx->rb);
 	sock_pe_signal(tx_ctx->domain->pe);
-	fastlock_release(&tx_ctx->rb_lock);
+	ofi_spin_unlock(&tx_ctx->rb_lock);
 }
 
 void sock_tx_ctx_abort(struct sock_tx_ctx *tx_ctx)
 {
 	ofi_rbabort(&tx_ctx->rb);
-	fastlock_release(&tx_ctx->rb_lock);
+	ofi_spin_unlock(&tx_ctx->rb_lock);
 }
 
 void sock_tx_ctx_write_op_send(struct sock_tx_ctx *tx_ctx,

--- a/prov/sockets/src/sock_dom.c
+++ b/prov/sockets/src/sock_dom.c
@@ -58,7 +58,7 @@ static int sock_dom_close(struct fid *fid)
 	sock_ep_cm_stop_thread(&dom->cm_head);
 
 	sock_pe_finalize(dom->pe);
-	ofi_spin_destroy(&dom->lock);
+	ofi_mutex_destroy(&dom->lock);
 	ofi_mr_map_close(&dom->mr_map);
 	sock_dom_remove_from_list(dom);
 	free(dom);
@@ -162,7 +162,7 @@ int sock_domain(struct fid_fabric *fabric, struct fi_info *info,
 	if (!sock_domain)
 		return -FI_ENOMEM;
 
-	ofi_spin_init(&sock_domain->lock);
+	ofi_mutex_init(&sock_domain->lock);
 	ofi_atomic_initialize32(&sock_domain->ref, 0);
 
 	sock_domain->info = *info;
@@ -211,7 +211,7 @@ err3:
 err2:
 	sock_pe_finalize(sock_domain->pe);
 err1:
-	ofi_spin_destroy(&sock_domain->lock);
+	ofi_mutex_destroy(&sock_domain->lock);
 	free(sock_domain);
 	return -FI_EINVAL;
 }

--- a/prov/sockets/src/sock_dom.c
+++ b/prov/sockets/src/sock_dom.c
@@ -58,7 +58,7 @@ static int sock_dom_close(struct fid *fid)
 	sock_ep_cm_stop_thread(&dom->cm_head);
 
 	sock_pe_finalize(dom->pe);
-	fastlock_destroy(&dom->lock);
+	ofi_spin_destroy(&dom->lock);
 	ofi_mr_map_close(&dom->mr_map);
 	sock_dom_remove_from_list(dom);
 	free(dom);
@@ -162,7 +162,7 @@ int sock_domain(struct fid_fabric *fabric, struct fi_info *info,
 	if (!sock_domain)
 		return -FI_ENOMEM;
 
-	fastlock_init(&sock_domain->lock);
+	ofi_spin_init(&sock_domain->lock);
 	ofi_atomic_initialize32(&sock_domain->ref, 0);
 
 	sock_domain->info = *info;
@@ -211,7 +211,7 @@ err3:
 err2:
 	sock_pe_finalize(sock_domain->pe);
 err1:
-	fastlock_destroy(&sock_domain->lock);
+	ofi_spin_destroy(&sock_domain->lock);
 	free(sock_domain);
 	return -FI_EINVAL;
 }

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -452,7 +452,7 @@ static ssize_t sock_rx_ctx_cancel(struct sock_rx_ctx *rx_ctx, void *context)
 	struct sock_rx_entry *rx_entry;
 	struct sock_pe_entry pe_entry;
 
-	fastlock_acquire(&rx_ctx->lock);
+	ofi_spin_lock(&rx_ctx->lock);
 	for (entry = rx_ctx->rx_entry_list.next;
 	     entry != &rx_ctx->rx_entry_list; entry = entry->next) {
 
@@ -486,7 +486,7 @@ static ssize_t sock_rx_ctx_cancel(struct sock_rx_ctx *rx_ctx, void *context)
 			break;
 		}
 	}
-	fastlock_release(&rx_ctx->lock);
+	ofi_spin_unlock(&rx_ctx->lock);
 	return ret;
 }
 
@@ -572,9 +572,9 @@ static ssize_t sock_tx_size_left(struct fid_ep *ep)
 	if (!tx_ctx->enabled)
 		return -FI_EOPBADSTATE;
 
-	fastlock_acquire(&tx_ctx->rb_lock);
+	ofi_spin_lock(&tx_ctx->rb_lock);
 	num_left = ofi_rbavail(&tx_ctx->rb)/SOCK_EP_TX_ENTRY_SZ;
-	fastlock_release(&tx_ctx->rb_lock);
+	ofi_spin_unlock(&tx_ctx->rb_lock);
 	return num_left;
 }
 
@@ -658,47 +658,47 @@ static int sock_ep_close(struct fid *fid)
 			ofi_atomic_dec32(&sock_ep->attr->av->ref);
 	}
 	if (sock_ep->attr->av) {
-		fastlock_acquire(&sock_ep->attr->av->list_lock);
+		ofi_spin_lock(&sock_ep->attr->av->list_lock);
 		fid_list_remove(&sock_ep->attr->av->ep_list,
 				&sock_ep->attr->lock, &sock_ep->ep.fid);
-		fastlock_release(&sock_ep->attr->av->list_lock);
+		ofi_spin_unlock(&sock_ep->attr->av->list_lock);
 	}
 
 	pthread_mutex_lock(&sock_ep->attr->domain->pe->list_lock);
 	if (sock_ep->attr->tx_shared) {
-		fastlock_acquire(&sock_ep->attr->tx_ctx->lock);
+		ofi_spin_lock(&sock_ep->attr->tx_ctx->lock);
 		dlist_remove(&sock_ep->attr->tx_ctx_entry);
-		fastlock_release(&sock_ep->attr->tx_ctx->lock);
+		ofi_spin_unlock(&sock_ep->attr->tx_ctx->lock);
 	}
 
 	if (sock_ep->attr->rx_shared) {
-		fastlock_acquire(&sock_ep->attr->rx_ctx->lock);
+		ofi_spin_lock(&sock_ep->attr->rx_ctx->lock);
 		dlist_remove(&sock_ep->attr->rx_ctx_entry);
-		fastlock_release(&sock_ep->attr->rx_ctx->lock);
+		ofi_spin_unlock(&sock_ep->attr->rx_ctx->lock);
 	}
 	pthread_mutex_unlock(&sock_ep->attr->domain->pe->list_lock);
 
 	if (sock_ep->attr->conn_handle.do_listen) {
-		fastlock_acquire(&sock_ep->attr->domain->conn_listener.signal_lock);
+		ofi_spin_lock(&sock_ep->attr->domain->conn_listener.signal_lock);
 		ofi_epoll_del(sock_ep->attr->domain->conn_listener.epollfd,
 		             sock_ep->attr->conn_handle.sock);
 		sock_ep->attr->domain->conn_listener.removed_from_epollfd = true;
-		fastlock_release(&sock_ep->attr->domain->conn_listener.signal_lock);
+		ofi_spin_unlock(&sock_ep->attr->domain->conn_listener.signal_lock);
 		ofi_close_socket(sock_ep->attr->conn_handle.sock);
 		sock_ep->attr->conn_handle.do_listen = 0;
 	}
 
-	fastlock_destroy(&sock_ep->attr->cm.lock);
+	ofi_spin_destroy(&sock_ep->attr->cm.lock);
 
 	if (sock_ep->attr->eq) {
-		fastlock_acquire(&sock_ep->attr->eq->lock);
+		ofi_spin_lock(&sock_ep->attr->eq->lock);
 		sock_ep_clear_eq_list(&sock_ep->attr->eq->list,
 				      &sock_ep->ep);
 		/* Any err_data if present would be freed by
 		 * sock_eq_clean_err_data_list when EQ is closed */
 		sock_ep_clear_eq_list(&sock_ep->attr->eq->err_list,
 				      &sock_ep->ep);
-		fastlock_release(&sock_ep->attr->eq->lock);
+		ofi_spin_unlock(&sock_ep->attr->eq->lock);
 	}
 
 	if (sock_ep->attr->fclass != FI_CLASS_SEP) {
@@ -725,13 +725,13 @@ static int sock_ep_close(struct fid *fid)
 	if (sock_ep->attr->dest_addr)
 		free(sock_ep->attr->dest_addr);
 
-	fastlock_acquire(&sock_ep->attr->domain->pe->lock);
+	ofi_spin_lock(&sock_ep->attr->domain->pe->lock);
 	ofi_idm_reset(&sock_ep->attr->av_idm, NULL);
 	sock_conn_map_destroy(sock_ep->attr);
-	fastlock_release(&sock_ep->attr->domain->pe->lock);
+	ofi_spin_unlock(&sock_ep->attr->domain->pe->lock);
 
 	ofi_atomic_dec32(&sock_ep->attr->domain->ref);
-	fastlock_destroy(&sock_ep->attr->lock);
+	ofi_spin_destroy(&sock_ep->attr->lock);
 	free(sock_ep->attr);
 	free(sock_ep);
 	return 0;
@@ -866,21 +866,21 @@ static int sock_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 			if (ep->attr->rx_array[i])
 				ep->attr->rx_array[i]->av = av;
 		}
-		fastlock_acquire(&av->list_lock);
+		ofi_spin_lock(&av->list_lock);
 		ret = fid_list_insert(&av->ep_list, &ep->attr->lock, &ep->ep.fid);
 		if (ret) {
 			SOCK_LOG_ERROR("Error in adding fid in the EP list\n");
-			fastlock_release(&av->list_lock);
+			ofi_spin_unlock(&av->list_lock);
 			return ret;
 		}
-		fastlock_release(&av->list_lock);
+		ofi_spin_unlock(&av->list_lock);
 		break;
 
 	case FI_CLASS_STX_CTX:
 		tx_ctx = container_of(bfid, struct sock_tx_ctx, fid.stx.fid);
-		fastlock_acquire(&tx_ctx->lock);
+		ofi_spin_lock(&tx_ctx->lock);
 		dlist_insert_tail(&ep->attr->tx_ctx_entry, &tx_ctx->ep_list);
-		fastlock_release(&tx_ctx->lock);
+		ofi_spin_unlock(&tx_ctx->lock);
 
 		ep->attr->tx_ctx->use_shared = 1;
 		ep->attr->tx_ctx->stx_ctx = tx_ctx;
@@ -888,9 +888,9 @@ static int sock_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 
 	case FI_CLASS_SRX_CTX:
 		rx_ctx = container_of(bfid, struct sock_rx_ctx, ctx);
-		fastlock_acquire(&rx_ctx->lock);
+		ofi_spin_lock(&rx_ctx->lock);
 		dlist_insert_tail(&ep->attr->rx_ctx_entry, &rx_ctx->ep_list);
-		fastlock_release(&rx_ctx->lock);
+		ofi_spin_unlock(&rx_ctx->lock);
 
 		ep->attr->rx_ctx->use_shared = 1;
 		ep->attr->rx_ctx->srx_ctx = rx_ctx;
@@ -1698,7 +1698,7 @@ int sock_alloc_endpoint(struct fid_domain *domain, struct fi_info *info,
 	ofi_atomic_initialize32(&sock_ep->attr->ref, 0);
 	ofi_atomic_initialize32(&sock_ep->attr->num_tx_ctx, 0);
 	ofi_atomic_initialize32(&sock_ep->attr->num_rx_ctx, 0);
-	fastlock_init(&sock_ep->attr->lock);
+	ofi_spin_init(&sock_ep->attr->lock);
 
 	if (sock_ep->attr->ep_attr.tx_ctx_cnt == FI_SHARED_CONTEXT)
 		sock_ep->attr->tx_shared = 1;
@@ -1762,7 +1762,7 @@ int sock_alloc_endpoint(struct fid_domain *domain, struct fi_info *info,
 	memcpy(&sock_ep->attr->info, info, sizeof(struct fi_info));
 
 	sock_ep->attr->domain = sock_dom;
-	fastlock_init(&sock_ep->attr->cm.lock);
+	ofi_spin_init(&sock_ep->attr->cm.lock);
 
 	if (sock_conn_map_init(sock_ep, sock_cm_def_map_sz)) {
 		SOCK_LOG_ERROR("failed to init connection map\n");
@@ -1858,19 +1858,19 @@ int sock_ep_get_conn(struct sock_ep_attr *attr, struct sock_tx_ctx *tx_ctx,
 	if (attr->ep_type == FI_EP_MSG)
 		addr = attr->dest_addr;
 	else {
-		fastlock_acquire(&attr->av->table_lock);
+		ofi_spin_lock(&attr->av->table_lock);
 		addr = &attr->av->table[av_index].addr;
-		fastlock_release(&attr->av->table_lock);
+		ofi_spin_unlock(&attr->av->table_lock);
 	}
 
-	fastlock_acquire(&attr->cmap.lock);
+	ofi_spin_lock(&attr->cmap.lock);
 	conn = sock_ep_lookup_conn(attr, av_index, addr);
 	if (!conn) {
 		conn = SOCK_CM_CONN_IN_PROGRESS;
 		if (ofi_idm_set(&attr->av_idm, av_index, conn) < 0)
 			SOCK_LOG_ERROR("ofi_idm_set failed\n");
 	}
-	fastlock_release(&attr->cmap.lock);
+	ofi_spin_unlock(&attr->cmap.lock);
 
 	if (conn == SOCK_CM_CONN_IN_PROGRESS)
 		ret = sock_ep_connect(attr, av_index, &conn);

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -659,7 +659,7 @@ static int sock_ep_close(struct fid *fid)
 	}
 	if (sock_ep->attr->av) {
 		ofi_mutex_lock(&sock_ep->attr->av->list_lock);
-		fid_list_remove_m(&sock_ep->attr->av->ep_list,
+		fid_list_remove(&sock_ep->attr->av->ep_list,
 				&sock_ep->attr->lock, &sock_ep->ep.fid);
 		ofi_mutex_unlock(&sock_ep->attr->av->list_lock);
 	}
@@ -867,7 +867,7 @@ static int sock_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 				ep->attr->rx_array[i]->av = av;
 		}
 		ofi_mutex_lock(&av->list_lock);
-		ret = fid_list_insert_m(&av->ep_list, &ep->attr->lock, &ep->ep.fid);
+		ret = fid_list_insert(&av->ep_list, &ep->attr->lock, &ep->ep.fid);
 		if (ret) {
 			SOCK_LOG_ERROR("Error in adding fid in the EP list\n");
 			ofi_mutex_unlock(&av->list_lock);

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -283,7 +283,7 @@ static void sock_ep_cm_shutdown_report(struct sock_ep *ep, int send_shutdown)
 	struct sock_conn_hdr msg = {0};
 	enum sock_cm_state old_state;
 
-	ofi_spin_lock(&ep->attr->cm.lock);
+	ofi_mutex_lock(&ep->attr->cm.lock);
 	old_state = ep->attr->cm.state;
 	switch (ep->attr->cm.state) {
 	case SOCK_CM_STATE_REQUESTED:
@@ -298,7 +298,7 @@ static void sock_ep_cm_shutdown_report(struct sock_ep *ep, int send_shutdown)
 		assert(0);
 		break;
 	}
-	ofi_spin_unlock(&ep->attr->cm.lock);
+	ofi_mutex_unlock(&ep->attr->cm.lock);
 
 	switch (old_state) {
 	case SOCK_CM_STATE_CONNECTED:
@@ -348,12 +348,12 @@ static void sock_ep_cm_report_connect_fail(struct sock_ep *ep,
 {
 	int do_report = 0;
 
-	ofi_spin_lock(&ep->attr->cm.lock);
+	ofi_mutex_lock(&ep->attr->cm.lock);
 	if (ep->attr->cm.state == SOCK_CM_STATE_REQUESTED) {
 		do_report = 1;
 		ep->attr->cm.state = SOCK_CM_STATE_DISCONNECTED;
 	}
-	ofi_spin_unlock(&ep->attr->cm.lock);
+	ofi_mutex_unlock(&ep->attr->cm.lock);
 
 	if (do_report) {
 		SOCK_LOG_DBG("reporting FI_REJECT\n");

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -1279,7 +1279,7 @@ void sock_ep_cm_wait_handle_finalized(struct sock_ep_cm_head *cm_head,
 
 	pthread_mutex_lock(&handle->finalized_mutex);
 	while (handle->state != SOCK_CONN_HANDLE_FINALIZED)
-		fi_wait_cond(&handle->finalized_cond,
+		ofi_wait_cond(&handle->finalized_cond,
 				&handle->finalized_mutex, -1);
 	pthread_mutex_unlock(&handle->finalized_mutex);
 }

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -283,7 +283,7 @@ static void sock_ep_cm_shutdown_report(struct sock_ep *ep, int send_shutdown)
 	struct sock_conn_hdr msg = {0};
 	enum sock_cm_state old_state;
 
-	fastlock_acquire(&ep->attr->cm.lock);
+	ofi_spin_lock(&ep->attr->cm.lock);
 	old_state = ep->attr->cm.state;
 	switch (ep->attr->cm.state) {
 	case SOCK_CM_STATE_REQUESTED:
@@ -298,7 +298,7 @@ static void sock_ep_cm_shutdown_report(struct sock_ep *ep, int send_shutdown)
 		assert(0);
 		break;
 	}
-	fastlock_release(&ep->attr->cm.lock);
+	ofi_spin_unlock(&ep->attr->cm.lock);
 
 	switch (old_state) {
 	case SOCK_CM_STATE_CONNECTED:
@@ -348,12 +348,12 @@ static void sock_ep_cm_report_connect_fail(struct sock_ep *ep,
 {
 	int do_report = 0;
 
-	fastlock_acquire(&ep->attr->cm.lock);
+	ofi_spin_lock(&ep->attr->cm.lock);
 	if (ep->attr->cm.state == SOCK_CM_STATE_REQUESTED) {
 		do_report = 1;
 		ep->attr->cm.state = SOCK_CM_STATE_DISCONNECTED;
 	}
-	fastlock_release(&ep->attr->cm.lock);
+	ofi_spin_unlock(&ep->attr->cm.lock);
 
 	if (do_report) {
 		SOCK_LOG_DBG("reporting FI_REJECT\n");

--- a/prov/sockets/src/sock_eq.c
+++ b/prov/sockets/src/sock_eq.c
@@ -92,7 +92,7 @@ static ssize_t sock_eq_sread(struct fid_eq *eq, uint32_t *event, void *buf,
 				-FI_EAGAIN : ret;
 	}
 
-	ofi_spin_lock(&sock_eq->lock);
+	ofi_mutex_lock(&sock_eq->lock);
 	list = sock_eq->list.list.next;
 	entry = container_of(list, struct sock_eq_entry, entry);
 
@@ -111,7 +111,7 @@ static ssize_t sock_eq_sread(struct fid_eq *eq, uint32_t *event, void *buf,
 	}
 
 out:
-	ofi_spin_unlock(&sock_eq->lock);
+	ofi_mutex_unlock(&sock_eq->lock);
 	return (ret == 0 || ret == -FI_ETIMEDOUT) ? -FI_EAGAIN : ret;
 }
 
@@ -136,7 +136,7 @@ static ssize_t sock_eq_readerr(struct fid_eq *eq, struct fi_eq_err_entry *buf,
 	uint32_t api_version;
 
 	sock_eq = container_of(eq, struct sock_eq, eq);
-	ofi_spin_lock(&sock_eq->lock);
+	ofi_mutex_lock(&sock_eq->lock);
 	if (dlistfd_empty(&sock_eq->err_list)) {
 		ret = -FI_EAGAIN;
 		goto out;
@@ -178,7 +178,7 @@ static ssize_t sock_eq_readerr(struct fid_eq *eq, struct fi_eq_err_entry *buf,
 	}
 
 out:
-	ofi_spin_unlock(&sock_eq->lock);
+	ofi_mutex_unlock(&sock_eq->lock);
 	return (ret == 0) ? -FI_EAGAIN : ret;
 }
 
@@ -196,11 +196,11 @@ ssize_t sock_eq_report_event(struct sock_eq *sock_eq, uint32_t event,
 	entry->flags = flags;
 	memcpy(entry->event, buf, len);
 
-	ofi_spin_lock(&sock_eq->lock);
+	ofi_mutex_lock(&sock_eq->lock);
 	dlistfd_insert_tail(&entry->entry, &sock_eq->list);
 	if (sock_eq->signal)
 		sock_wait_signal(sock_eq->waitset);
-	ofi_spin_unlock(&sock_eq->lock);
+	ofi_mutex_unlock(&sock_eq->lock);
 	return 0;
 }
 
@@ -241,12 +241,12 @@ ssize_t sock_eq_report_error(struct sock_eq *sock_eq, fid_t fid, void *context,
 					&sock_eq->err_data_list);
 	}
 
-	ofi_spin_lock(&sock_eq->lock);
+	ofi_mutex_lock(&sock_eq->lock);
 	dlistfd_insert_tail(&entry->entry, &sock_eq->err_list);
 	dlistfd_signal(&sock_eq->list);
 	if (sock_eq->signal)
 		sock_wait_signal(sock_eq->waitset);
-	ofi_spin_unlock(&sock_eq->lock);
+	ofi_mutex_unlock(&sock_eq->lock);
 	return 0;
 }
 
@@ -291,7 +291,7 @@ static int sock_eq_fi_close(struct fid *fid)
 
 	dlistfd_head_free(&sock_eq->list);
 	dlistfd_head_free(&sock_eq->err_list);
-	ofi_spin_destroy(&sock_eq->lock);
+	ofi_mutex_destroy(&sock_eq->lock);
 	ofi_atomic_dec32(&sock_eq->sock_fab->ref);
 
 	if (sock_eq->signal && sock_eq->attr.wait_obj == FI_WAIT_MUTEX_COND)
@@ -404,7 +404,7 @@ int sock_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 	if (ret)
 		goto err2;
 
-	ofi_spin_init(&sock_eq->lock);
+	ofi_mutex_init(&sock_eq->lock);
 	ofi_atomic_inc32(&sock_eq->sock_fab->ref);
 
 	switch (sock_eq->attr.wait_obj) {

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -68,14 +68,14 @@ int sock_keepalive_probes = INT_MAX;
 
 static struct dlist_entry sock_fab_list;
 static struct dlist_entry sock_dom_list;
-static ofi_spin_t sock_list_lock;
+static ofi_mutex_t sock_list_lock;
 static int read_default_params;
 
 void sock_dom_add_to_list(struct sock_domain *domain)
 {
-	ofi_spin_lock(&sock_list_lock);
+	ofi_mutex_lock(&sock_list_lock);
 	dlist_insert_tail(&domain->dom_list_entry, &sock_dom_list);
-	ofi_spin_unlock(&sock_list_lock);
+	ofi_mutex_unlock(&sock_list_lock);
 }
 
 static inline int sock_dom_check_list_internal(struct sock_domain *domain)
@@ -95,32 +95,32 @@ static inline int sock_dom_check_list_internal(struct sock_domain *domain)
 int sock_dom_check_list(struct sock_domain *domain)
 {
 	int found;
-	ofi_spin_lock(&sock_list_lock);
+	ofi_mutex_lock(&sock_list_lock);
 	found = sock_dom_check_list_internal(domain);
-	ofi_spin_unlock(&sock_list_lock);
+	ofi_mutex_unlock(&sock_list_lock);
 	return found;
 }
 
 void sock_dom_remove_from_list(struct sock_domain *domain)
 {
-	ofi_spin_lock(&sock_list_lock);
+	ofi_mutex_lock(&sock_list_lock);
 	if (sock_dom_check_list_internal(domain))
 		dlist_remove(&domain->dom_list_entry);
 
-	ofi_spin_unlock(&sock_list_lock);
+	ofi_mutex_unlock(&sock_list_lock);
 }
 
 struct sock_domain *sock_dom_list_head(void)
 {
 	struct sock_domain *domain;
-	ofi_spin_lock(&sock_list_lock);
+	ofi_mutex_lock(&sock_list_lock);
 	if (dlist_empty(&sock_dom_list)) {
 		domain = NULL;
 	} else {
 		domain = container_of(sock_dom_list.next,
 				      struct sock_domain, dom_list_entry);
 	}
-	ofi_spin_unlock(&sock_list_lock);
+	ofi_mutex_unlock(&sock_list_lock);
 	return domain;
 }
 
@@ -141,9 +141,9 @@ int sock_dom_check_manual_progress(struct sock_fabric *fabric)
 
 void sock_fab_add_to_list(struct sock_fabric *fabric)
 {
-	ofi_spin_lock(&sock_list_lock);
+	ofi_mutex_lock(&sock_list_lock);
 	dlist_insert_tail(&fabric->fab_list_entry, &sock_fab_list);
-	ofi_spin_unlock(&sock_list_lock);
+	ofi_mutex_unlock(&sock_list_lock);
 }
 
 static inline int sock_fab_check_list_internal(struct sock_fabric *fabric)
@@ -163,32 +163,32 @@ static inline int sock_fab_check_list_internal(struct sock_fabric *fabric)
 int sock_fab_check_list(struct sock_fabric *fabric)
 {
 	int found;
-	ofi_spin_lock(&sock_list_lock);
+	ofi_mutex_lock(&sock_list_lock);
 	found = sock_fab_check_list_internal(fabric);
-	ofi_spin_unlock(&sock_list_lock);
+	ofi_mutex_unlock(&sock_list_lock);
 	return found;
 }
 
 void sock_fab_remove_from_list(struct sock_fabric *fabric)
 {
-	ofi_spin_lock(&sock_list_lock);
+	ofi_mutex_lock(&sock_list_lock);
 	if (sock_fab_check_list_internal(fabric))
 		dlist_remove(&fabric->fab_list_entry);
 
-	ofi_spin_unlock(&sock_list_lock);
+	ofi_mutex_unlock(&sock_list_lock);
 }
 
 struct sock_fabric *sock_fab_list_head(void)
 {
 	struct sock_fabric *fabric;
-	ofi_spin_lock(&sock_list_lock);
+	ofi_mutex_lock(&sock_list_lock);
 	if (dlist_empty(&sock_fab_list)) {
 		fabric = NULL;
 	} else {
 		fabric = container_of(sock_fab_list.next,
 				      struct sock_fabric, fab_list_entry);
 	}
-	ofi_spin_unlock(&sock_list_lock);
+	ofi_mutex_unlock(&sock_list_lock);
 	return fabric;
 }
 
@@ -215,7 +215,7 @@ static int sock_fabric_close(fid_t fid)
 		return -FI_EBUSY;
 
 	sock_fab_remove_from_list(fab);
-	ofi_spin_destroy(&fab->lock);
+	ofi_mutex_destroy(&fab->lock);
 	free(fab);
 	return 0;
 }
@@ -261,7 +261,7 @@ static int sock_fabric(struct fi_fabric_attr *attr,
 
 	sock_read_default_params();
 
-	ofi_spin_init(&fab->lock);
+	ofi_mutex_init(&fab->lock);
 	dlist_init(&fab->service_list);
 
 	fab->fab_fid.fid.fclass = FI_CLASS_FABRIC;
@@ -318,7 +318,7 @@ static int sock_getinfo(uint32_t version, const char *node, const char *service,
 
 static void fi_sockets_fini(void)
 {
-	ofi_spin_destroy(&sock_list_lock);
+	ofi_mutex_destroy(&sock_list_lock);
 }
 
 struct fi_provider sock_prov = {
@@ -382,7 +382,7 @@ SOCKETS_INI
 	fi_param_define(&sock_prov, "iface", FI_PARAM_STRING,
 			"Specify interface name");
 
-	ofi_spin_init(&sock_list_lock);
+	ofi_mutex_init(&sock_list_lock);
 	dlist_init(&sock_fab_list);
 	dlist_init(&sock_dom_list);
 #if ENABLE_DEBUG

--- a/prov/sockets/src/sock_mr.c
+++ b/prov/sockets/src/sock_mr.c
@@ -52,12 +52,12 @@ static int sock_mr_close(struct fid *fid)
 	mr = container_of(fid, struct sock_mr, mr_fid.fid);
 	dom = mr->domain;
 
-	ofi_spin_lock(&dom->lock);
+	ofi_mutex_lock(&dom->lock);
 	err = ofi_mr_map_remove(&dom->mr_map, mr->key);
 	if (err != 0)
 		SOCK_LOG_ERROR("MR Erase error %d \n", err);
 
-	ofi_spin_unlock(&dom->lock);
+	ofi_mutex_unlock(&dom->lock);
 	ofi_atomic_dec32(&dom->ref);
 	free(mr);
 	return 0;
@@ -109,7 +109,7 @@ struct sock_mr *sock_mr_verify_key(struct sock_domain *domain, uint64_t key,
 	int err = 0;
 	struct sock_mr *mr;
 
-	ofi_spin_lock(&domain->lock);
+	ofi_mutex_lock(&domain->lock);
 
 	err = ofi_mr_map_verify(&domain->mr_map, buf, len, key, access, (void **)&mr);
 	if (err != 0) {
@@ -117,7 +117,7 @@ struct sock_mr *sock_mr_verify_key(struct sock_domain *domain, uint64_t key,
 		mr = NULL;
 	}
 
-	ofi_spin_unlock(&domain->lock);
+	ofi_mutex_unlock(&domain->lock);
 	return mr;
 }
 
@@ -152,7 +152,7 @@ static int sock_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 
 	ofi_mr_update_attr(dom->fab->fab_fid.api_version, dom->info.caps,
 			   attr, &cur_abi_attr);
-	ofi_spin_lock(&dom->lock);
+	ofi_mutex_lock(&dom->lock);
 
 	_mr->mr_fid.fid.fclass = FI_CLASS_MR;
 	_mr->mr_fid.fid.context = attr->context;
@@ -167,7 +167,7 @@ static int sock_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 
 	_mr->mr_fid.key = _mr->key = key;
 	_mr->mr_fid.mem_desc = (void *) (uintptr_t) key;
-	ofi_spin_unlock(&dom->lock);
+	ofi_mutex_unlock(&dom->lock);
 
 	*mr = &_mr->mr_fid;
 	ofi_atomic_inc32(&dom->ref);
@@ -182,7 +182,7 @@ static int sock_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	return 0;
 
 err:
-	ofi_spin_unlock(&dom->lock);
+	ofi_mutex_unlock(&dom->lock);
 	free(_mr);
 	return ret;
 }

--- a/prov/sockets/src/sock_mr.c
+++ b/prov/sockets/src/sock_mr.c
@@ -52,12 +52,12 @@ static int sock_mr_close(struct fid *fid)
 	mr = container_of(fid, struct sock_mr, mr_fid.fid);
 	dom = mr->domain;
 
-	fastlock_acquire(&dom->lock);
+	ofi_spin_lock(&dom->lock);
 	err = ofi_mr_map_remove(&dom->mr_map, mr->key);
 	if (err != 0)
 		SOCK_LOG_ERROR("MR Erase error %d \n", err);
 
-	fastlock_release(&dom->lock);
+	ofi_spin_unlock(&dom->lock);
 	ofi_atomic_dec32(&dom->ref);
 	free(mr);
 	return 0;
@@ -109,7 +109,7 @@ struct sock_mr *sock_mr_verify_key(struct sock_domain *domain, uint64_t key,
 	int err = 0;
 	struct sock_mr *mr;
 
-	fastlock_acquire(&domain->lock);
+	ofi_spin_lock(&domain->lock);
 
 	err = ofi_mr_map_verify(&domain->mr_map, buf, len, key, access, (void **)&mr);
 	if (err != 0) {
@@ -117,7 +117,7 @@ struct sock_mr *sock_mr_verify_key(struct sock_domain *domain, uint64_t key,
 		mr = NULL;
 	}
 
-	fastlock_release(&domain->lock);
+	ofi_spin_unlock(&domain->lock);
 	return mr;
 }
 
@@ -152,7 +152,7 @@ static int sock_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 
 	ofi_mr_update_attr(dom->fab->fab_fid.api_version, dom->info.caps,
 			   attr, &cur_abi_attr);
-	fastlock_acquire(&dom->lock);
+	ofi_spin_lock(&dom->lock);
 
 	_mr->mr_fid.fid.fclass = FI_CLASS_MR;
 	_mr->mr_fid.fid.context = attr->context;
@@ -167,7 +167,7 @@ static int sock_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 
 	_mr->mr_fid.key = _mr->key = key;
 	_mr->mr_fid.mem_desc = (void *) (uintptr_t) key;
-	fastlock_release(&dom->lock);
+	ofi_spin_unlock(&dom->lock);
 
 	*mr = &_mr->mr_fid;
 	ofi_atomic_inc32(&dom->ref);
@@ -182,7 +182,7 @@ static int sock_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	return 0;
 
 err:
-	fastlock_release(&dom->lock);
+	ofi_spin_unlock(&dom->lock);
 	free(_mr);
 	return ret;
 }

--- a/prov/sockets/src/sock_msg.c
+++ b/prov/sockets/src/sock_msg.c
@@ -109,9 +109,9 @@ ssize_t sock_ep_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 					  msg->msg_iov, msg->iov_count);
 	}
 
-	ofi_spin_lock(&rx_ctx->lock);
+	ofi_mutex_lock(&rx_ctx->lock);
 	rx_entry = sock_rx_new_entry(rx_ctx);
-	ofi_spin_unlock(&rx_ctx->lock);
+	ofi_mutex_unlock(&rx_ctx->lock);
 	if (!rx_entry)
 		return -FI_ENOMEM;
 
@@ -133,10 +133,10 @@ ssize_t sock_ep_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 	}
 
 	SOCK_LOG_DBG("New rx_entry: %p (ctx: %p)\n", rx_entry, rx_ctx);
-	ofi_spin_lock(&rx_ctx->lock);
+	ofi_mutex_lock(&rx_ctx->lock);
 	dlist_insert_tail(&rx_entry->entry, &rx_ctx->rx_entry_list);
 	rx_ctx->progress_start = &rx_ctx->rx_buffered_list;
-	ofi_spin_unlock(&rx_ctx->lock);
+	ofi_mutex_unlock(&rx_ctx->lock);
 	return 0;
 }
 
@@ -453,9 +453,9 @@ ssize_t sock_ep_trecvmsg(struct fid_ep *ep,
 					  msg->msg_iov, msg->iov_count);
 	}
 
-	ofi_spin_lock(&rx_ctx->lock);
+	ofi_mutex_lock(&rx_ctx->lock);
 	rx_entry = sock_rx_new_entry(rx_ctx);
-	ofi_spin_unlock(&rx_ctx->lock);
+	ofi_mutex_unlock(&rx_ctx->lock);
 	if (!rx_entry)
 		return -FI_ENOMEM;
 
@@ -477,11 +477,11 @@ ssize_t sock_ep_trecvmsg(struct fid_ep *ep,
 		rx_entry->total_len += rx_entry->iov[i].iov.len;
 	}
 
-	ofi_spin_lock(&rx_ctx->lock);
+	ofi_mutex_lock(&rx_ctx->lock);
 	SOCK_LOG_DBG("New rx_entry: %p (ctx: %p)\n", rx_entry, rx_ctx);
 	dlist_insert_tail(&rx_entry->entry, &rx_ctx->rx_entry_list);
 	rx_ctx->progress_start = &rx_ctx->rx_buffered_list;
-	ofi_spin_unlock(&rx_ctx->lock);
+	ofi_mutex_unlock(&rx_ctx->lock);
 	return 0;
 }
 

--- a/prov/sockets/src/sock_msg.c
+++ b/prov/sockets/src/sock_msg.c
@@ -109,9 +109,9 @@ ssize_t sock_ep_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 					  msg->msg_iov, msg->iov_count);
 	}
 
-	fastlock_acquire(&rx_ctx->lock);
+	ofi_spin_lock(&rx_ctx->lock);
 	rx_entry = sock_rx_new_entry(rx_ctx);
-	fastlock_release(&rx_ctx->lock);
+	ofi_spin_unlock(&rx_ctx->lock);
 	if (!rx_entry)
 		return -FI_ENOMEM;
 
@@ -133,10 +133,10 @@ ssize_t sock_ep_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 	}
 
 	SOCK_LOG_DBG("New rx_entry: %p (ctx: %p)\n", rx_entry, rx_ctx);
-	fastlock_acquire(&rx_ctx->lock);
+	ofi_spin_lock(&rx_ctx->lock);
 	dlist_insert_tail(&rx_entry->entry, &rx_ctx->rx_entry_list);
 	rx_ctx->progress_start = &rx_ctx->rx_buffered_list;
-	fastlock_release(&rx_ctx->lock);
+	ofi_spin_unlock(&rx_ctx->lock);
 	return 0;
 }
 
@@ -453,9 +453,9 @@ ssize_t sock_ep_trecvmsg(struct fid_ep *ep,
 					  msg->msg_iov, msg->iov_count);
 	}
 
-	fastlock_acquire(&rx_ctx->lock);
+	ofi_spin_lock(&rx_ctx->lock);
 	rx_entry = sock_rx_new_entry(rx_ctx);
-	fastlock_release(&rx_ctx->lock);
+	ofi_spin_unlock(&rx_ctx->lock);
 	if (!rx_entry)
 		return -FI_ENOMEM;
 
@@ -477,11 +477,11 @@ ssize_t sock_ep_trecvmsg(struct fid_ep *ep,
 		rx_entry->total_len += rx_entry->iov[i].iov.len;
 	}
 
-	fastlock_acquire(&rx_ctx->lock);
+	ofi_spin_lock(&rx_ctx->lock);
 	SOCK_LOG_DBG("New rx_entry: %p (ctx: %p)\n", rx_entry, rx_ctx);
 	dlist_insert_tail(&rx_entry->entry, &rx_ctx->rx_entry_list);
 	rx_ctx->progress_start = &rx_ctx->rx_buffered_list;
-	fastlock_release(&rx_ctx->lock);
+	ofi_spin_unlock(&rx_ctx->lock);
 	return 0;
 }
 

--- a/prov/sockets/src/sock_poll.c
+++ b/prov/sockets/src/sock_poll.c
@@ -154,13 +154,13 @@ static int sock_poll_poll(struct fid_poll *pollset, void **context, int count)
 
 		case FI_CLASS_EQ:
 			eq = container_of(list_item->fid, struct sock_eq, eq);
-			fastlock_acquire(&eq->lock);
+			ofi_spin_lock(&eq->lock);
 			if (!dlistfd_empty(&eq->list) ||
 				!dlistfd_empty(&eq->err_list)) {
 				*context++ = eq->eq.fid.context;
 				ret_count++;
 			}
-			fastlock_release(&eq->lock);
+			ofi_spin_unlock(&eq->lock);
 			break;
 
 		default:

--- a/prov/sockets/src/sock_poll.c
+++ b/prov/sockets/src/sock_poll.c
@@ -154,13 +154,13 @@ static int sock_poll_poll(struct fid_poll *pollset, void **context, int count)
 
 		case FI_CLASS_EQ:
 			eq = container_of(list_item->fid, struct sock_eq, eq);
-			ofi_spin_lock(&eq->lock);
+			ofi_mutex_lock(&eq->lock);
 			if (!dlistfd_empty(&eq->list) ||
 				!dlistfd_empty(&eq->err_list)) {
 				*context++ = eq->eq.fid.context;
 				ret_count++;
 			}
-			ofi_spin_unlock(&eq->lock);
+			ofi_mutex_unlock(&eq->lock);
 			break;
 
 		default:

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -319,10 +319,10 @@ static void sock_pe_report_mr_completion(struct sock_domain *domain,
 	struct sock_mr *mr;
 
 	for (i = 0; i < pe_entry->msg_hdr.dest_iov_len; i++) {
-		ofi_spin_lock(&domain->lock);
+		ofi_mutex_lock(&domain->lock);
 		mr = ofi_mr_map_get(&domain->mr_map,
 				    pe_entry->pe.rx.rx_iov[i].iov.key);
-		ofi_spin_unlock(&domain->lock);
+		ofi_mutex_unlock(&domain->lock);
 		if (!mr || (!mr->cq && !mr->cntr))
 			continue;
 
@@ -1035,10 +1035,10 @@ sock_pe_process_rx_tatomic(struct sock_pe *pe, struct sock_rx_ctx *rx_ctx,
 	pe_entry->tag = pe_entry->pe.rx.rx_iov[0].ioc.key;
 	pe_entry->data_len = entry_len;
 
-	ofi_spin_lock(&rx_ctx->lock);
+	ofi_mutex_lock(&rx_ctx->lock);
 	rx_entry = sock_rx_new_buffered_entry(rx_ctx, entry_len);
 	if (!rx_entry) {
-		ofi_spin_unlock(&rx_ctx->lock);
+		ofi_mutex_unlock(&rx_ctx->lock);
 		return -FI_ENOMEM;
 	}
 
@@ -1060,7 +1060,7 @@ sock_pe_process_rx_tatomic(struct sock_pe *pe, struct sock_rx_ctx *rx_ctx,
 	pe_entry->pe.rx.rx_entry = rx_entry;
 
 	sock_pe_progress_buffered_rx(rx_ctx, true);
-	ofi_spin_unlock(&rx_ctx->lock);
+	ofi_mutex_unlock(&rx_ctx->lock);
 
 	pe_entry->is_complete = 1;
 
@@ -1076,7 +1076,7 @@ ssize_t sock_rx_peek_recv(struct sock_rx_ctx *rx_ctx, fi_addr_t addr,
 	struct sock_rx_entry *rx_buffered;
 	struct sock_pe_entry pe_entry;
 
-	ofi_spin_lock(&rx_ctx->lock);
+	ofi_mutex_lock(&rx_ctx->lock);
 	rx_buffered = sock_rx_get_buffered_entry(rx_ctx,
 					(rx_ctx->attr.caps & FI_DIRECTED_RECV) ?
 						 addr : FI_ADDR_UNSPEC,
@@ -1106,7 +1106,7 @@ ssize_t sock_rx_peek_recv(struct sock_rx_ctx *rx_ctx, fi_addr_t addr,
 		sock_cq_report_error(rx_ctx->comp.recv_cq, &pe_entry, 0,
 				     FI_ENOMSG, -FI_ENOMSG, NULL, 0);
 	}
-	ofi_spin_unlock(&rx_ctx->lock);
+	ofi_mutex_unlock(&rx_ctx->lock);
 	return 0;
 }
 
@@ -1121,7 +1121,7 @@ ssize_t sock_rx_claim_recv(struct sock_rx_ctx *rx_ctx, void *context,
 	struct sock_pe_entry pe_entry;
 	struct sock_rx_entry *rx_buffered = NULL;
 
-	ofi_spin_lock(&rx_ctx->lock);
+	ofi_mutex_lock(&rx_ctx->lock);
 	for (entry = rx_ctx->rx_buffered_list.next;
 	     entry != &rx_ctx->rx_buffered_list; entry = entry->next) {
 		rx_buffered = container_of(entry, struct sock_rx_entry, entry);
@@ -1175,7 +1175,7 @@ ssize_t sock_rx_claim_recv(struct sock_rx_ctx *rx_ctx, void *context,
 		ret = -FI_ENOMSG;
 	}
 
-	ofi_spin_unlock(&rx_ctx->lock);
+	ofi_mutex_unlock(&rx_ctx->lock);
 	return ret;
 }
 
@@ -1347,7 +1347,7 @@ static int sock_pe_process_rx_send(struct sock_pe *pe,
 
 	data_len = pe_entry->msg_hdr.msg_len - len;
 	if (pe_entry->done_len == len && !pe_entry->pe.rx.rx_entry) {
-		ofi_spin_lock(&rx_ctx->lock);
+		ofi_mutex_lock(&rx_ctx->lock);
 		rx_ctx->progress_start = &rx_ctx->rx_buffered_list;
 		sock_pe_progress_buffered_rx(rx_ctx, false);
 
@@ -1361,7 +1361,7 @@ static int sock_pe_process_rx_send(struct sock_pe *pe,
 
 			rx_entry = sock_rx_new_buffered_entry(rx_ctx, data_len);
 			if (!rx_entry) {
-				ofi_spin_unlock(&rx_ctx->lock);
+				ofi_mutex_unlock(&rx_ctx->lock);
 				return -FI_ENOMEM;
 			}
 
@@ -1377,7 +1377,7 @@ static int sock_pe_process_rx_send(struct sock_pe *pe,
 			if (pe_entry->msg_hdr.op_type == SOCK_OP_TSEND)
 				rx_entry->is_tagged = 1;
 		}
-		ofi_spin_unlock(&rx_ctx->lock);
+		ofi_mutex_unlock(&rx_ctx->lock);
 		pe_entry->context = rx_entry->context;
 		pe_entry->pe.rx.rx_entry = rx_entry;
 	}
@@ -1426,7 +1426,7 @@ static int sock_pe_process_rx_send(struct sock_pe *pe,
 		pe_entry->flags |= FI_REMOTE_CQ_DATA;
 	pe_entry->flags &= ~FI_MULTI_RECV;
 
-	ofi_spin_lock(&rx_ctx->lock);
+	ofi_mutex_lock(&rx_ctx->lock);
 	if (rx_entry->flags & FI_MULTI_RECV) {
 		if (sock_rx_avail_len(rx_entry) < rx_ctx->min_multi_recv) {
 			pe_entry->flags |= FI_MULTI_RECV;
@@ -1437,7 +1437,7 @@ static int sock_pe_process_rx_send(struct sock_pe *pe,
 			dlist_remove(&rx_entry->entry);
 	}
 	rx_entry->is_busy = 0;
-	ofi_spin_unlock(&rx_ctx->lock);
+	ofi_mutex_unlock(&rx_ctx->lock);
 
 	/* report error, if any */
 	if (rem) {
@@ -1460,10 +1460,10 @@ out:
 	if (!rx_entry->is_buffered &&
 	    (!(rx_entry->flags & FI_MULTI_RECV) ||
 	     (pe_entry->flags & FI_MULTI_RECV))) {
-		ofi_spin_lock(&rx_ctx->lock);
+		ofi_mutex_lock(&rx_ctx->lock);
 		sock_rx_release_entry(rx_entry);
 		rx_ctx->num_left++;
-		ofi_spin_unlock(&rx_ctx->lock);
+		ofi_mutex_unlock(&rx_ctx->lock);
 	}
 	return ret;
 }
@@ -1498,13 +1498,13 @@ static int sock_pe_process_rx_conn_msg(struct sock_pe *pe,
 
 	index = (ep_attr->ep_type == FI_EP_MSG) ? 0 : sock_av_get_addr_index(ep_attr->av, addr);
 	if (index != -1) {
-		ofi_spin_lock(&map->lock);
+		ofi_mutex_lock(&map->lock);
 		conn = sock_ep_lookup_conn(ep_attr, index, addr);
 		if (conn == NULL || conn == SOCK_CM_CONN_IN_PROGRESS) {
 			if (ofi_idm_set(&ep_attr->av_idm, index, pe_entry->conn) < 0)
 				SOCK_LOG_ERROR("ofi_idm_set failed\n");
 		}
-		ofi_spin_unlock(&map->lock);
+		ofi_mutex_unlock(&map->lock);
 	}
 	pe_entry->conn->av_index = (ep_attr->ep_type == FI_EP_MSG || index == -1) ?
 		FI_ADDR_NOTAVAIL : index;
@@ -1950,9 +1950,9 @@ static int sock_pe_progress_tx_entry(struct sock_pe *pe,
 		ofi_straddr_log(&sock_prov, FI_LOG_WARN, FI_LOG_EP_DATA,
 				"Peer disconnected: removing fd from pollset",
 				&pe_entry->conn->addr.sa);
-		ofi_spin_lock(&pe_entry->ep_attr->cmap.lock);
+		ofi_mutex_lock(&pe_entry->ep_attr->cmap.lock);
 		sock_ep_remove_conn(pe_entry->ep_attr, pe_entry->conn);
-		ofi_spin_unlock(&pe_entry->ep_attr->cmap.lock);
+		ofi_mutex_unlock(&pe_entry->ep_attr->cmap.lock);
 
 		sock_pe_report_tx_error(pe_entry, 0, FI_EIO);
 		pe_entry->is_complete = 1;
@@ -2028,9 +2028,9 @@ static int sock_pe_progress_rx_pe_entry(struct sock_pe *pe,
 		ofi_straddr_log(&sock_prov, FI_LOG_WARN, FI_LOG_EP_DATA,
 				"Peer disconnected: removing fd from pollset",
 				&pe_entry->conn->addr.sa);
-		ofi_spin_lock(&pe_entry->ep_attr->cmap.lock);
+		ofi_mutex_lock(&pe_entry->ep_attr->cmap.lock);
 		sock_ep_remove_conn(pe_entry->ep_attr, pe_entry->conn);
-		ofi_spin_unlock(&pe_entry->ep_attr->cmap.lock);
+		ofi_mutex_unlock(&pe_entry->ep_attr->cmap.lock);
 
 		if (pe_entry->pe.rx.header_read)
 			sock_pe_report_rx_error(pe_entry, 0, FI_EIO);
@@ -2286,30 +2286,30 @@ void sock_pe_signal(struct sock_pe *pe)
 	if (pe->domain->progress_mode != FI_PROGRESS_AUTO)
 		return;
 
-	ofi_spin_lock(&pe->signal_lock);
+	ofi_mutex_lock(&pe->signal_lock);
 	if (pe->wcnt == pe->rcnt) {
 		if (ofi_write_socket(pe->signal_fds[SOCK_SIGNAL_WR_FD], &c, 1) != 1)
 			SOCK_LOG_ERROR("Failed to signal\n");
 		else
 			pe->wcnt++;
 	}
-	ofi_spin_unlock(&pe->signal_lock);
+	ofi_mutex_unlock(&pe->signal_lock);
 }
 
 void sock_pe_poll_add(struct sock_pe *pe, int fd)
 {
-        ofi_spin_lock(&pe->signal_lock);
+        ofi_mutex_lock(&pe->signal_lock);
         if (ofi_epoll_add(pe->epoll_set, fd, OFI_EPOLL_IN, NULL))
 			SOCK_LOG_ERROR("failed to add to epoll set: %d\n", fd);
-        ofi_spin_unlock(&pe->signal_lock);
+        ofi_mutex_unlock(&pe->signal_lock);
 }
 
 void sock_pe_poll_del(struct sock_pe *pe, int fd)
 {
-        ofi_spin_lock(&pe->signal_lock);
+        ofi_mutex_lock(&pe->signal_lock);
         if (ofi_epoll_del(pe->epoll_set, fd))
 			SOCK_LOG_DBG("failed to del from epoll set: %d\n", fd);
-        ofi_spin_unlock(&pe->signal_lock);
+        ofi_mutex_unlock(&pe->signal_lock);
 }
 
 void sock_pe_add_tx_ctx(struct sock_pe *pe, struct sock_tx_ctx *ctx)
@@ -2396,7 +2396,7 @@ static int sock_pe_progress_rx_ep(struct sock_pe *pe,
 		return num_fds;
 	}
 
-	ofi_spin_lock(&map->lock);
+	ofi_mutex_lock(&map->lock);
 	for (i = 0; i < num_fds; i++) {
 		conn = map->epoll_events[i].data.ptr;
 		if (!conn)
@@ -2407,7 +2407,7 @@ static int sock_pe_progress_rx_ep(struct sock_pe *pe,
 
 		sock_pe_new_rx_entry(pe, rx_ctx, ep_attr, conn);
 	}
-	ofi_spin_unlock(&map->lock);
+	ofi_mutex_unlock(&map->lock);
 
 	return 0;
 }
@@ -2419,11 +2419,11 @@ int sock_pe_progress_rx_ctx(struct sock_pe *pe, struct sock_rx_ctx *rx_ctx)
 	struct dlist_entry *entry;
 	struct sock_pe_entry *pe_entry;
 
-	ofi_spin_lock(&pe->lock);
+	ofi_mutex_lock(&pe->lock);
 
-	ofi_spin_lock(&rx_ctx->lock);
+	ofi_mutex_lock(&rx_ctx->lock);
 	sock_pe_progress_buffered_rx(rx_ctx, true);
-	ofi_spin_unlock(&rx_ctx->lock);
+	ofi_mutex_unlock(&rx_ctx->lock);
 
 	/* check for incoming data */
 	if (rx_ctx->ctx.fid.fclass == FI_CLASS_SRX_CTX) {
@@ -2453,7 +2453,7 @@ int sock_pe_progress_rx_ctx(struct sock_pe *pe, struct sock_rx_ctx *rx_ctx)
 out:
 	if (ret < 0)
 		SOCK_LOG_ERROR("failed to progress RX ctx\n");
-	ofi_spin_unlock(&pe->lock);
+	ofi_mutex_unlock(&pe->lock);
 	return ret;
 }
 
@@ -2523,7 +2523,7 @@ int sock_pe_progress_tx_ctx(struct sock_pe *pe, struct sock_tx_ctx *tx_ctx)
 	struct dlist_entry *entry;
 	struct sock_pe_entry *pe_entry;
 
-	ofi_spin_lock(&pe->lock);
+	ofi_mutex_lock(&pe->lock);
 
 	/* progress tx_ctx in PE table */
 	for (entry = tx_ctx->pe_entry_list.next;
@@ -2538,11 +2538,11 @@ int sock_pe_progress_tx_ctx(struct sock_pe *pe, struct sock_tx_ctx *tx_ctx)
 		}
 	}
 
-	ofi_spin_lock(&tx_ctx->rb_lock);
+	ofi_mutex_lock(&tx_ctx->rb_lock);
 	if (!ofi_rbempty(&tx_ctx->rb) && !dlist_empty(&pe->free_list)) {
 		ret = sock_pe_new_tx_entry(pe, tx_ctx);
 	}
-	ofi_spin_unlock(&tx_ctx->rb_lock);
+	ofi_mutex_unlock(&tx_ctx->rb_lock);
 	if (ret < 0)
 		goto out;
 
@@ -2550,7 +2550,7 @@ int sock_pe_progress_tx_ctx(struct sock_pe *pe, struct sock_tx_ctx *tx_ctx)
 out:
 	if (ret < 0)
 		SOCK_LOG_ERROR("failed to progress TX ctx\n");
-	ofi_spin_unlock(&pe->lock);
+	ofi_mutex_unlock(&pe->lock);
 	return ret;
 }
 
@@ -2603,14 +2603,14 @@ static void sock_pe_wait(struct sock_pe *pe)
 	if (ret < 0)
 		SOCK_LOG_ERROR("poll failed : %s\n", strerror(ofi_sockerr()));
 
-	ofi_spin_lock(&pe->signal_lock);
+	ofi_mutex_lock(&pe->signal_lock);
 	if (pe->rcnt != pe->wcnt) {
 		if (ofi_read_socket(pe->signal_fds[SOCK_SIGNAL_RD_FD], &tmp, 1) == 1)
 			pe->rcnt++;
 		else
 			SOCK_LOG_ERROR("Invalid signal\n");
 	}
-	ofi_spin_unlock(&pe->signal_lock);
+	ofi_mutex_unlock(&pe->signal_lock);
 	pe->waittime = ofi_gettime_ms();
 }
 
@@ -2714,8 +2714,8 @@ struct sock_pe *sock_pe_init(struct sock_domain *domain)
 	sock_pe_init_table(pe);
 	dlist_init(&pe->tx_list);
 	dlist_init(&pe->rx_list);
-	ofi_spin_init(&pe->lock);
-	ofi_spin_init(&pe->signal_lock);
+	ofi_mutex_init(&pe->lock);
+	ofi_mutex_init(&pe->signal_lock);
 	pthread_mutex_init(&pe->list_lock, NULL);
 	pe->domain = domain;
 
@@ -2769,7 +2769,7 @@ err3:
 err2:
 	ofi_bufpool_destroy(pe->pe_rx_pool);
 err1:
-	ofi_spin_destroy(&pe->lock);
+	ofi_mutex_destroy(&pe->lock);
 	free(pe);
 	return NULL;
 }
@@ -2807,8 +2807,8 @@ void sock_pe_finalize(struct sock_pe *pe)
 	}
 
 	sock_pe_free_util_pool(pe);
-	ofi_spin_destroy(&pe->lock);
-	ofi_spin_destroy(&pe->signal_lock);
+	ofi_mutex_destroy(&pe->lock);
+	ofi_mutex_destroy(&pe->signal_lock);
 	pthread_mutex_destroy(&pe->list_lock);
 	ofi_epoll_close(pe->epoll_set);
 	free(pe);

--- a/prov/sockets/src/sock_trigger.c
+++ b/prov/sockets/src/sock_trigger.c
@@ -82,9 +82,9 @@ ssize_t sock_queue_rma_op(struct fid_ep *ep, const struct fi_msg_rma *msg,
 	trigger->ep = ep;
 	trigger->flags = flags;
 
-	fastlock_acquire(&cntr->trigger_lock);
+	ofi_spin_lock(&cntr->trigger_lock);
 	dlist_insert_tail(&trigger->entry, &cntr->trigger_list);
-	fastlock_release(&cntr->trigger_lock);
+	ofi_spin_unlock(&cntr->trigger_lock);
 	sock_cntr_check_trigger_list(cntr);
 	return 0;
 }
@@ -124,9 +124,9 @@ ssize_t sock_queue_msg_op(struct fid_ep *ep, const struct fi_msg *msg,
 	trigger->ep = ep;
 	trigger->flags = flags;
 
-	fastlock_acquire(&cntr->trigger_lock);
+	ofi_spin_lock(&cntr->trigger_lock);
 	dlist_insert_tail(&trigger->entry, &cntr->trigger_list);
-	fastlock_release(&cntr->trigger_lock);
+	ofi_spin_unlock(&cntr->trigger_lock);
 	sock_cntr_check_trigger_list(cntr);
 	return 0;
 }
@@ -166,9 +166,9 @@ ssize_t sock_queue_tmsg_op(struct fid_ep *ep, const struct fi_msg_tagged *msg,
 	trigger->ep = ep;
 	trigger->flags = flags;
 
-	fastlock_acquire(&cntr->trigger_lock);
+	ofi_spin_lock(&cntr->trigger_lock);
 	dlist_insert_tail(&trigger->entry, &cntr->trigger_list);
-	fastlock_release(&cntr->trigger_lock);
+	ofi_spin_unlock(&cntr->trigger_lock);
 	sock_cntr_check_trigger_list(cntr);
 	return 0;
 }
@@ -226,9 +226,9 @@ ssize_t sock_queue_atomic_op(struct fid_ep *ep, const struct fi_msg_atomic *msg,
 	trigger->ep = ep;
 	trigger->flags = flags;
 
-	fastlock_acquire(&cntr->trigger_lock);
+	ofi_spin_lock(&cntr->trigger_lock);
 	dlist_insert_tail(&trigger->entry, &cntr->trigger_list);
-	fastlock_release(&cntr->trigger_lock);
+	ofi_spin_unlock(&cntr->trigger_lock);
 	sock_cntr_check_trigger_list(cntr);
 	return 0;
 }
@@ -256,9 +256,9 @@ ssize_t sock_queue_cntr_op(struct fi_deferred_work *work, uint64_t flags)
 	trigger->threshold = work->threshold;
 	trigger->flags = flags;
 
-	fastlock_acquire(&cntr->trigger_lock);
+	ofi_spin_lock(&cntr->trigger_lock);
 	dlist_insert_tail(&trigger->entry, &cntr->trigger_list);
-	fastlock_release(&cntr->trigger_lock);
+	ofi_spin_unlock(&cntr->trigger_lock);
 	sock_cntr_check_trigger_list(cntr);
 	return 0;
 }

--- a/prov/sockets/src/sock_trigger.c
+++ b/prov/sockets/src/sock_trigger.c
@@ -82,9 +82,9 @@ ssize_t sock_queue_rma_op(struct fid_ep *ep, const struct fi_msg_rma *msg,
 	trigger->ep = ep;
 	trigger->flags = flags;
 
-	ofi_spin_lock(&cntr->trigger_lock);
+	ofi_mutex_lock(&cntr->trigger_lock);
 	dlist_insert_tail(&trigger->entry, &cntr->trigger_list);
-	ofi_spin_unlock(&cntr->trigger_lock);
+	ofi_mutex_unlock(&cntr->trigger_lock);
 	sock_cntr_check_trigger_list(cntr);
 	return 0;
 }
@@ -124,9 +124,9 @@ ssize_t sock_queue_msg_op(struct fid_ep *ep, const struct fi_msg *msg,
 	trigger->ep = ep;
 	trigger->flags = flags;
 
-	ofi_spin_lock(&cntr->trigger_lock);
+	ofi_mutex_lock(&cntr->trigger_lock);
 	dlist_insert_tail(&trigger->entry, &cntr->trigger_list);
-	ofi_spin_unlock(&cntr->trigger_lock);
+	ofi_mutex_unlock(&cntr->trigger_lock);
 	sock_cntr_check_trigger_list(cntr);
 	return 0;
 }
@@ -166,9 +166,9 @@ ssize_t sock_queue_tmsg_op(struct fid_ep *ep, const struct fi_msg_tagged *msg,
 	trigger->ep = ep;
 	trigger->flags = flags;
 
-	ofi_spin_lock(&cntr->trigger_lock);
+	ofi_mutex_lock(&cntr->trigger_lock);
 	dlist_insert_tail(&trigger->entry, &cntr->trigger_list);
-	ofi_spin_unlock(&cntr->trigger_lock);
+	ofi_mutex_unlock(&cntr->trigger_lock);
 	sock_cntr_check_trigger_list(cntr);
 	return 0;
 }
@@ -226,9 +226,9 @@ ssize_t sock_queue_atomic_op(struct fid_ep *ep, const struct fi_msg_atomic *msg,
 	trigger->ep = ep;
 	trigger->flags = flags;
 
-	ofi_spin_lock(&cntr->trigger_lock);
+	ofi_mutex_lock(&cntr->trigger_lock);
 	dlist_insert_tail(&trigger->entry, &cntr->trigger_list);
-	ofi_spin_unlock(&cntr->trigger_lock);
+	ofi_mutex_unlock(&cntr->trigger_lock);
 	sock_cntr_check_trigger_list(cntr);
 	return 0;
 }
@@ -256,9 +256,9 @@ ssize_t sock_queue_cntr_op(struct fi_deferred_work *work, uint64_t flags)
 	trigger->threshold = work->threshold;
 	trigger->flags = flags;
 
-	ofi_spin_lock(&cntr->trigger_lock);
+	ofi_mutex_lock(&cntr->trigger_lock);
 	dlist_insert_tail(&trigger->entry, &cntr->trigger_list);
-	ofi_spin_unlock(&cntr->trigger_lock);
+	ofi_mutex_unlock(&cntr->trigger_lock);
 	sock_cntr_check_trigger_list(cntr);
 	return 0;
 }

--- a/prov/sockets/src/sock_wait.c
+++ b/prov/sockets/src/sock_wait.c
@@ -173,7 +173,7 @@ static int sock_wait_wait(struct fid_wait *wait_fid, int timeout)
 		break;
 
 	case FI_WAIT_MUTEX_COND:
-		err = fi_wait_cond(&wait->wobj.mutex_cond.cond,
+		err = ofi_wait_cond(&wait->wobj.mutex_cond.cond,
 				   &wait->wobj.mutex_cond.mutex, timeout);
 		break;
 

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -242,7 +242,7 @@ struct tcpx_rx_ctx {
 
 	struct ofi_bufpool	*buf_pool;
 	uint64_t		op_flags;
-	ofi_spin_t		lock;
+	ofi_mutex_t		lock;
 };
 
 int tcpx_srx_context(struct fid_domain *domain, struct fi_rx_attr *attr,
@@ -274,7 +274,7 @@ struct tcpx_ep {
 	};
 
 	/* lock for protecting tx/rx queues, rma list, state*/
-	ofi_spin_t		lock;
+	ofi_mutex_t		lock;
 	void (*hdr_bswap)(struct tcpx_base_hdr *hdr);
 	void (*report_success)(struct tcpx_ep *ep, struct util_cq *cq,
 			       struct tcpx_xfer_entry *xfer_entry);
@@ -345,7 +345,7 @@ struct tcpx_eq {
 	  The following lock avoids race between ep close
 	  and connection management code.
 	 */
-	ofi_spin_t		close_lock;
+	ofi_mutex_t		close_lock;
 };
 
 int tcpx_create_fabric(struct fi_fabric_attr *attr,
@@ -485,9 +485,9 @@ tcpx_free_rx(struct tcpx_xfer_entry *xfer)
 
 	if (xfer->ep->srx_ctx) {
 		srx = xfer->ep->srx_ctx;
-		ofi_spin_lock(&srx->lock);
+		ofi_mutex_lock(&srx->lock);
 		ofi_buf_free(xfer);
-		ofi_spin_unlock(&srx->lock);
+		ofi_mutex_unlock(&srx->lock);
 	} else {
 		cq = container_of(xfer->ep->util_ep.rx_cq,
 				  struct tcpx_cq, util_cq);

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -242,7 +242,7 @@ struct tcpx_rx_ctx {
 
 	struct ofi_bufpool	*buf_pool;
 	uint64_t		op_flags;
-	fastlock_t		lock;
+	ofi_spin_t		lock;
 };
 
 int tcpx_srx_context(struct fid_domain *domain, struct fi_rx_attr *attr,
@@ -274,7 +274,7 @@ struct tcpx_ep {
 	};
 
 	/* lock for protecting tx/rx queues, rma list, state*/
-	fastlock_t		lock;
+	ofi_spin_t		lock;
 	void (*hdr_bswap)(struct tcpx_base_hdr *hdr);
 	void (*report_success)(struct tcpx_ep *ep, struct util_cq *cq,
 			       struct tcpx_xfer_entry *xfer_entry);
@@ -345,7 +345,7 @@ struct tcpx_eq {
 	  The following lock avoids race between ep close
 	  and connection management code.
 	 */
-	fastlock_t		close_lock;
+	ofi_spin_t		close_lock;
 };
 
 int tcpx_create_fabric(struct fi_fabric_attr *attr,
@@ -485,9 +485,9 @@ tcpx_free_rx(struct tcpx_xfer_entry *xfer)
 
 	if (xfer->ep->srx_ctx) {
 		srx = xfer->ep->srx_ctx;
-		fastlock_acquire(&srx->lock);
+		ofi_spin_lock(&srx->lock);
 		ofi_buf_free(xfer);
-		fastlock_release(&srx->lock);
+		ofi_spin_unlock(&srx->lock);
 	} else {
 		cq = container_of(xfer->ep->util_ep.rx_cq,
 				  struct tcpx_cq, util_cq);

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -443,9 +443,9 @@ tcpx_alloc_xfer(struct tcpx_cq *cq)
 {
 	struct tcpx_xfer_entry *xfer;
 
-	cq->util_cq.cq_fastlock_acquire(&cq->util_cq.cq_lock);
+	cq->util_cq.cq_mutex_lock(&cq->util_cq.cq_lock);
 	xfer = ofi_buf_alloc(cq->xfer_pool);
-	cq->util_cq.cq_fastlock_release(&cq->util_cq.cq_lock);
+	cq->util_cq.cq_mutex_unlock(&cq->util_cq.cq_lock);
 
 	return xfer;
 }
@@ -458,9 +458,9 @@ tcpx_free_xfer(struct tcpx_cq *cq, struct tcpx_xfer_entry *xfer)
 	xfer->ctrl_flags = 0;
 	xfer->context = 0;
 
-	cq->util_cq.cq_fastlock_acquire(&cq->util_cq.cq_lock);
+	cq->util_cq.cq_mutex_lock(&cq->util_cq.cq_lock);
 	ofi_buf_free(xfer);
-	cq->util_cq.cq_fastlock_release(&cq->util_cq.cq_lock);
+	cq->util_cq.cq_mutex_unlock(&cq->util_cq.cq_lock);
 }
 
 static inline struct tcpx_xfer_entry *

--- a/prov/tcp/src/tcpx_conn_mgr.c
+++ b/prov/tcp/src/tcpx_conn_mgr.c
@@ -280,7 +280,7 @@ static int tcpx_ep_enable(struct tcpx_ep *ep,
 		return -FI_ENOCQ;
 	}
 
-	ofi_spin_lock(&ep->lock);
+	ofi_mutex_lock(&ep->lock);
 	if (ep->state != TCPX_CONNECTING && ep->state != TCPX_ACCEPTING) {
 		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
 			"ep is in invalid state\n");
@@ -289,7 +289,7 @@ static int tcpx_ep_enable(struct tcpx_ep *ep,
 	}
 
 	ep->state = TCPX_CONNECTED;
-	ofi_spin_unlock(&ep->lock);
+	ofi_mutex_unlock(&ep->lock);
 
 	ret = tcpx_ep_add_fd(ep);
 	if (ret)
@@ -305,7 +305,7 @@ static int tcpx_ep_enable(struct tcpx_ep *ep,
 	return 0;
 
 unlock:
-	ofi_spin_unlock(&ep->lock);
+	ofi_mutex_unlock(&ep->lock);
 	return ret;
 }
 
@@ -362,9 +362,9 @@ static void tcpx_cm_recv_resp(struct util_wait *wait,
 err2:
 	free(cm_entry);
 err1:
-	ofi_spin_lock(&ep->lock);
+	ofi_mutex_lock(&ep->lock);
 	tcpx_ep_disable(ep, -ret);
-	ofi_spin_unlock(&ep->lock);
+	ofi_mutex_unlock(&ep->lock);
 	tcpx_free_cm_ctx(cm_ctx);
 }
 
@@ -413,9 +413,9 @@ static void tcpx_cm_send_resp(struct util_wait *wait,
 delfd:
 	ofi_wait_del_fd(wait, ep->bsock.sock);
 disable:
-	ofi_spin_lock(&ep->lock);
+	ofi_mutex_lock(&ep->lock);
 	tcpx_ep_disable(ep, -ret);
-	ofi_spin_unlock(&ep->lock);
+	ofi_mutex_unlock(&ep->lock);
 	tcpx_free_cm_ctx(cm_ctx);
 }
 
@@ -533,9 +533,9 @@ static void tcpx_cm_send_req(struct util_wait *wait,
 delfd:
 	ofi_wait_del_fd(wait, ep->bsock.sock);
 disable:
-	ofi_spin_lock(&ep->lock);
+	ofi_mutex_lock(&ep->lock);
 	tcpx_ep_disable(ep, -ret);
-	ofi_spin_unlock(&ep->lock);
+	ofi_mutex_unlock(&ep->lock);
 	tcpx_free_cm_ctx(cm_ctx);
 }
 
@@ -641,7 +641,7 @@ void tcpx_conn_mgr_run(struct util_eq *util_eq)
 	wait_fd = container_of(util_eq->wait, struct util_wait_fd, util_wait);
 
 	eq = container_of(util_eq, struct tcpx_eq, util_eq);
-	ofi_spin_lock(&eq->close_lock);
+	ofi_mutex_lock(&eq->close_lock);
 	count = (wait_fd->util_wait.wait_obj == FI_WAIT_FD) ?
 		ofi_epoll_wait(wait_fd->epoll_fd, events, MAX_POLL_EVENTS, 0) :
 		ofi_pollfds_wait(wait_fd->pollfds, events, MAX_POLL_EVENTS, 0);
@@ -658,5 +658,5 @@ void tcpx_conn_mgr_run(struct util_eq *util_eq)
 			process_cm_ctx(util_eq->wait, events[i].data.ptr);
 	}
 unlock:
-	ofi_spin_unlock(&eq->close_lock);
+	ofi_mutex_unlock(&eq->close_lock);
 }

--- a/prov/tcp/src/tcpx_conn_mgr.c
+++ b/prov/tcp/src/tcpx_conn_mgr.c
@@ -280,7 +280,7 @@ static int tcpx_ep_enable(struct tcpx_ep *ep,
 		return -FI_ENOCQ;
 	}
 
-	fastlock_acquire(&ep->lock);
+	ofi_spin_lock(&ep->lock);
 	if (ep->state != TCPX_CONNECTING && ep->state != TCPX_ACCEPTING) {
 		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
 			"ep is in invalid state\n");
@@ -289,7 +289,7 @@ static int tcpx_ep_enable(struct tcpx_ep *ep,
 	}
 
 	ep->state = TCPX_CONNECTED;
-	fastlock_release(&ep->lock);
+	ofi_spin_unlock(&ep->lock);
 
 	ret = tcpx_ep_add_fd(ep);
 	if (ret)
@@ -305,7 +305,7 @@ static int tcpx_ep_enable(struct tcpx_ep *ep,
 	return 0;
 
 unlock:
-	fastlock_release(&ep->lock);
+	ofi_spin_unlock(&ep->lock);
 	return ret;
 }
 
@@ -362,9 +362,9 @@ static void tcpx_cm_recv_resp(struct util_wait *wait,
 err2:
 	free(cm_entry);
 err1:
-	fastlock_acquire(&ep->lock);
+	ofi_spin_lock(&ep->lock);
 	tcpx_ep_disable(ep, -ret);
-	fastlock_release(&ep->lock);
+	ofi_spin_unlock(&ep->lock);
 	tcpx_free_cm_ctx(cm_ctx);
 }
 
@@ -413,9 +413,9 @@ static void tcpx_cm_send_resp(struct util_wait *wait,
 delfd:
 	ofi_wait_del_fd(wait, ep->bsock.sock);
 disable:
-	fastlock_acquire(&ep->lock);
+	ofi_spin_lock(&ep->lock);
 	tcpx_ep_disable(ep, -ret);
-	fastlock_release(&ep->lock);
+	ofi_spin_unlock(&ep->lock);
 	tcpx_free_cm_ctx(cm_ctx);
 }
 
@@ -533,9 +533,9 @@ static void tcpx_cm_send_req(struct util_wait *wait,
 delfd:
 	ofi_wait_del_fd(wait, ep->bsock.sock);
 disable:
-	fastlock_acquire(&ep->lock);
+	ofi_spin_lock(&ep->lock);
 	tcpx_ep_disable(ep, -ret);
-	fastlock_release(&ep->lock);
+	ofi_spin_unlock(&ep->lock);
 	tcpx_free_cm_ctx(cm_ctx);
 }
 
@@ -641,7 +641,7 @@ void tcpx_conn_mgr_run(struct util_eq *util_eq)
 	wait_fd = container_of(util_eq->wait, struct util_wait_fd, util_wait);
 
 	eq = container_of(util_eq, struct tcpx_eq, util_eq);
-	fastlock_acquire(&eq->close_lock);
+	ofi_spin_lock(&eq->close_lock);
 	count = (wait_fd->util_wait.wait_obj == FI_WAIT_FD) ?
 		ofi_epoll_wait(wait_fd->epoll_fd, events, MAX_POLL_EVENTS, 0) :
 		ofi_pollfds_wait(wait_fd->pollfds, events, MAX_POLL_EVENTS, 0);
@@ -658,5 +658,5 @@ void tcpx_conn_mgr_run(struct util_eq *util_eq)
 			process_cm_ctx(util_eq->wait, events[i].data.ptr);
 	}
 unlock:
-	fastlock_release(&eq->close_lock);
+	ofi_spin_unlock(&eq->close_lock);
 }

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -113,9 +113,9 @@ void tcpx_progress(struct dlist_entry *ep_list, struct util_wait *wait)
 
 void tcpx_cq_progress(struct util_cq *cq)
 {
-	cq->cq_fastlock_acquire(&cq->ep_list_lock);
+	cq->cq_mutex_lock(&cq->ep_list_lock);
 	tcpx_progress(&cq->ep_list, cq->wait);
-	cq->cq_fastlock_release(&cq->ep_list_lock);
+	cq->cq_mutex_unlock(&cq->ep_list_lock);
 }
 
 static int tcpx_cq_close(struct fid *fid)
@@ -301,9 +301,9 @@ free_cq:
 
 void tcpx_cntr_progress(struct util_cntr *cntr)
 {
-	ofi_spin_lock(&cntr->ep_list_lock);
+	ofi_mutex_lock(&cntr->ep_list_lock);
 	tcpx_progress(&cntr->ep_list, cntr->wait);
-	ofi_spin_unlock(&cntr->ep_list_lock);
+	ofi_mutex_unlock(&cntr->ep_list_lock);
 }
 
 static struct util_cntr *

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -59,7 +59,7 @@ void tcpx_progress(struct dlist_entry *ep_list, struct util_wait *wait)
 		ep = container_of(fid_entry->fid, struct tcpx_ep,
 				  util_ep.ep_fid.fid);
 
-		fastlock_acquire(&ep->lock);
+		ofi_spin_lock(&ep->lock);
 		/* We need to progress receives in the case where we're waiting
 		 * on the application to post a buffer to consume a receive
 		 * that we've already read from the kernel.  If the message is
@@ -73,7 +73,7 @@ void tcpx_progress(struct dlist_entry *ep_list, struct util_wait *wait)
 		}
 
 		(void) tcpx_update_epoll(ep);
-		fastlock_release(&ep->lock);
+		ofi_spin_unlock(&ep->lock);
 	}
 
 	if (wait_fd->util_wait.wait_obj == FI_WAIT_FD) {
@@ -100,14 +100,14 @@ void tcpx_progress(struct dlist_entry *ep_list, struct util_wait *wait)
 		}
 
 		ep = container_of(fid, struct tcpx_ep, util_ep.ep_fid.fid);
-		fastlock_acquire(&ep->lock);
+		ofi_spin_lock(&ep->lock);
 		if (events[i].events & errevent)
 			tcpx_progress_async(ep);
 		if (events[i].events & inevent)
 			tcpx_progress_rx(ep);
 		if (events[i].events & outevent)
 			tcpx_progress_tx(ep);
-		fastlock_release(&ep->lock);
+		ofi_spin_unlock(&ep->lock);
 	}
 }
 
@@ -301,9 +301,9 @@ free_cq:
 
 void tcpx_cntr_progress(struct util_cntr *cntr)
 {
-	fastlock_acquire(&cntr->ep_list_lock);
+	ofi_spin_lock(&cntr->ep_list_lock);
 	tcpx_progress(&cntr->ep_list, cntr->wait);
-	fastlock_release(&cntr->ep_list_lock);
+	ofi_spin_unlock(&cntr->ep_list_lock);
 }
 
 static struct util_cntr *

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -59,7 +59,7 @@ void tcpx_progress(struct dlist_entry *ep_list, struct util_wait *wait)
 		ep = container_of(fid_entry->fid, struct tcpx_ep,
 				  util_ep.ep_fid.fid);
 
-		ofi_spin_lock(&ep->lock);
+		ofi_mutex_lock(&ep->lock);
 		/* We need to progress receives in the case where we're waiting
 		 * on the application to post a buffer to consume a receive
 		 * that we've already read from the kernel.  If the message is
@@ -73,7 +73,7 @@ void tcpx_progress(struct dlist_entry *ep_list, struct util_wait *wait)
 		}
 
 		(void) tcpx_update_epoll(ep);
-		ofi_spin_unlock(&ep->lock);
+		ofi_mutex_unlock(&ep->lock);
 	}
 
 	if (wait_fd->util_wait.wait_obj == FI_WAIT_FD) {
@@ -100,14 +100,14 @@ void tcpx_progress(struct dlist_entry *ep_list, struct util_wait *wait)
 		}
 
 		ep = container_of(fid, struct tcpx_ep, util_ep.ep_fid.fid);
-		ofi_spin_lock(&ep->lock);
+		ofi_mutex_lock(&ep->lock);
 		if (events[i].events & errevent)
 			tcpx_progress_async(ep);
 		if (events[i].events & inevent)
 			tcpx_progress_rx(ep);
 		if (events[i].events & outevent)
 			tcpx_progress_tx(ep);
-		ofi_spin_unlock(&ep->lock);
+		ofi_mutex_unlock(&ep->lock);
 	}
 }
 

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -185,9 +185,9 @@ static int tcpx_ep_connect(struct fid_ep *ep_fid, const void *addr,
 	return 0;
 
 disable:
-	fastlock_acquire(&ep->lock);
+	ofi_spin_lock(&ep->lock);
 	tcpx_ep_disable(ep, -ret);
-	fastlock_release(&ep->lock);
+	ofi_spin_unlock(&ep->lock);
 free:
 	tcpx_free_cm_ctx(cm_ctx);
 	return ret;
@@ -255,7 +255,7 @@ static void tcpx_ep_flush_all_queues(struct tcpx_ep *ep)
 {
 	struct tcpx_cq *cq;
 
-	assert(fastlock_held(&ep->lock));
+	assert(ofi_spin_held(&ep->lock));
 	cq = container_of(ep->util_ep.tx_cq, struct tcpx_cq, util_cq);
 	if (ep->cur_tx.entry) {
 		ep->hdr_bswap(&ep->cur_tx.entry->hdr.base_hdr);
@@ -289,7 +289,7 @@ void tcpx_ep_disable(struct tcpx_ep *ep, int cm_err)
 	struct fi_eq_err_entry err_entry = {0};
 	int ret;
 
-	assert(fastlock_held(&ep->lock));
+	assert(ofi_spin_held(&ep->lock));
 	switch (ep->state) {
 	case TCPX_RCVD_REQ:
 		break;
@@ -349,9 +349,9 @@ static int tcpx_ep_shutdown(struct fid_ep *ep_fid, uint64_t flags)
 	ep = container_of(ep_fid, struct tcpx_ep, util_ep.ep_fid);
 	(void) ofi_bsock_flush(&ep->bsock);
 
-	fastlock_acquire(&ep->lock);
+	ofi_spin_lock(&ep->lock);
 	tcpx_ep_disable(ep, 0);
-	fastlock_release(&ep->lock);
+	ofi_spin_unlock(&ep->lock);
 
 	return FI_SUCCESS;
 }
@@ -500,7 +500,7 @@ static void tcpx_ep_cancel_rx(struct tcpx_ep *ep, void *context)
 	struct tcpx_xfer_entry *xfer_entry;
 	struct tcpx_cq *cq;
 
-	assert(fastlock_held(&ep->lock));
+	assert(ofi_spin_held(&ep->lock));
 
 	/* To cancel an active receive, we would need to flush the socket of
 	 * all data associated with that message.  Since some of that data
@@ -538,9 +538,9 @@ static ssize_t tcpx_ep_cancel(fid_t fid, void *context)
 
 	ep = container_of(fid, struct tcpx_ep, util_ep.ep_fid.fid);
 
-	fastlock_acquire(&ep->lock);
+	ofi_spin_lock(&ep->lock);
 	tcpx_ep_cancel_rx(ep, context);
-	fastlock_release(&ep->lock);
+	ofi_spin_unlock(&ep->lock);
 
 	return 0;
 }
@@ -583,7 +583,7 @@ static int tcpx_ep_close(struct fid *fid)
 
 	/* eq->close_lock protects from processing stale connection events */
 	if (eq)
-		fastlock_acquire(&eq->close_lock);
+		ofi_spin_lock(&eq->close_lock);
 
 	tcpx_ep_del_fd(ep);
 
@@ -591,7 +591,7 @@ static int tcpx_ep_close(struct fid *fid)
 		ofi_wait_del_fd(ep->util_ep.eq->wait, ep->bsock.sock);
 
 	if (eq)
-		fastlock_release(&eq->close_lock);
+		ofi_spin_unlock(&eq->close_lock);
 
 	if (ep->fid && ep->fid->fclass == TCPX_CLASS_CM)
 		tcpx_free_cm_ctx(ep->cm_ctx);
@@ -599,9 +599,9 @@ static int tcpx_ep_close(struct fid *fid)
 	/* Lock not technically needed, since we're freeing the EP.  But it's
 	 * harmless to acquire and silences static code analysis tools.
 	 */
-	fastlock_acquire(&ep->lock);
+	ofi_spin_lock(&ep->lock);
 	tcpx_ep_flush_all_queues(ep);
-	fastlock_release(&ep->lock);
+	ofi_spin_unlock(&ep->lock);
 
 	if (eq) {
 		ofi_eq_remove_fid_events(ep->util_ep.eq,
@@ -609,7 +609,7 @@ static int tcpx_ep_close(struct fid *fid)
 	}
 	ofi_close_socket(ep->bsock.sock);
 	ofi_endpoint_close(&ep->util_ep);
-	fastlock_destroy(&ep->lock);
+	ofi_spin_destroy(&ep->lock);
 
 	free(ep);
 	return 0;
@@ -813,7 +813,7 @@ int tcpx_endpoint(struct fid_domain *domain, struct fi_info *info,
 		}
 	}
 
-	ret = fastlock_init(&ep->lock);
+	ret = ofi_spin_init(&ep->lock);
 	if (ret)
 		goto err3;
 

--- a/prov/tcp/src/tcpx_eq.c
+++ b/prov/tcp/src/tcpx_eq.c
@@ -58,7 +58,7 @@ static int tcpx_eq_close(struct fid *fid)
 
 	eq = container_of(fid, struct tcpx_eq, util_eq.eq_fid.fid);
 
-	fastlock_destroy(&eq->close_lock);
+	ofi_spin_destroy(&eq->close_lock);
 	free(eq);
 	return 0;
 }
@@ -99,7 +99,7 @@ int tcpx_eq_create(struct fid_fabric *fabric_fid, struct fi_eq_attr *attr,
 		goto err1;
 	}
 
-	ret = fastlock_init(&eq->close_lock);
+	ret = ofi_spin_init(&eq->close_lock);
 	if (ret)
 		goto err2;
 
@@ -122,7 +122,7 @@ int tcpx_eq_create(struct fid_fabric *fabric_fid, struct fi_eq_attr *attr,
 	*eq_fid = &eq->util_eq.eq_fid;
 	return 0;
 err3:
-	fastlock_destroy(&eq->close_lock);
+	ofi_spin_destroy(&eq->close_lock);
 err2:
 	ofi_eq_cleanup(&eq->util_eq.eq_fid.fid);
 err1:

--- a/prov/tcp/src/tcpx_eq.c
+++ b/prov/tcp/src/tcpx_eq.c
@@ -58,7 +58,7 @@ static int tcpx_eq_close(struct fid *fid)
 
 	eq = container_of(fid, struct tcpx_eq, util_eq.eq_fid.fid);
 
-	ofi_spin_destroy(&eq->close_lock);
+	ofi_mutex_destroy(&eq->close_lock);
 	free(eq);
 	return 0;
 }
@@ -99,7 +99,7 @@ int tcpx_eq_create(struct fid_fabric *fabric_fid, struct fi_eq_attr *attr,
 		goto err1;
 	}
 
-	ret = ofi_spin_init(&eq->close_lock);
+	ret = ofi_mutex_init(&eq->close_lock);
 	if (ret)
 		goto err2;
 
@@ -122,7 +122,7 @@ int tcpx_eq_create(struct fid_fabric *fabric_fid, struct fi_eq_attr *attr,
 	*eq_fid = &eq->util_eq.eq_fid;
 	return 0;
 err3:
-	ofi_spin_destroy(&eq->close_lock);
+	ofi_mutex_destroy(&eq->close_lock);
 err2:
 	ofi_eq_cleanup(&eq->util_eq.eq_fid.fid);
 err1:

--- a/prov/tcp/src/tcpx_msg.c
+++ b/prov/tcp/src/tcpx_msg.c
@@ -161,13 +161,13 @@ tcpx_queue_recv(struct tcpx_ep *ep, struct tcpx_xfer_entry *recv_entry)
 {
 	bool ret;
 
-	ofi_spin_lock(&ep->lock);
+	ofi_mutex_lock(&ep->lock);
 	ret = ep->rx_avail;
 	if (ret) {
 		slist_insert_tail(&recv_entry->entry, &ep->rx_queue);
 		ep->rx_avail--;
 	}
-	ofi_spin_unlock(&ep->lock);
+	ofi_mutex_unlock(&ep->lock);
 	return ret;
 }
 
@@ -260,9 +260,9 @@ tcpx_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 static inline void
 tcpx_queue_send(struct tcpx_ep *ep, struct tcpx_xfer_entry *tx_entry)
 {
-	ofi_spin_lock(&ep->lock);
+	ofi_mutex_lock(&ep->lock);
 	tcpx_tx_queue_insert(ep, tx_entry);
-	ofi_spin_unlock(&ep->lock);
+	ofi_mutex_unlock(&ep->lock);
 }
 
 static ssize_t

--- a/prov/tcp/src/tcpx_msg.c
+++ b/prov/tcp/src/tcpx_msg.c
@@ -161,13 +161,13 @@ tcpx_queue_recv(struct tcpx_ep *ep, struct tcpx_xfer_entry *recv_entry)
 {
 	bool ret;
 
-	fastlock_acquire(&ep->lock);
+	ofi_spin_lock(&ep->lock);
 	ret = ep->rx_avail;
 	if (ret) {
 		slist_insert_tail(&recv_entry->entry, &ep->rx_queue);
 		ep->rx_avail--;
 	}
-	fastlock_release(&ep->lock);
+	ofi_spin_unlock(&ep->lock);
 	return ret;
 }
 
@@ -260,9 +260,9 @@ tcpx_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 static inline void
 tcpx_queue_send(struct tcpx_ep *ep, struct tcpx_xfer_entry *tx_entry)
 {
-	fastlock_acquire(&ep->lock);
+	ofi_spin_lock(&ep->lock);
 	tcpx_tx_queue_insert(ep, tx_entry);
-	fastlock_release(&ep->lock);
+	ofi_spin_unlock(&ep->lock);
 }
 
 static ssize_t

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -108,7 +108,7 @@ void tcpx_progress_tx(struct tcpx_ep *ep)
 	struct tcpx_cq *cq;
 	int ret;
 
-	assert(fastlock_held(&ep->lock));
+	assert(ofi_spin_held(&ep->lock));
 	while (ep->cur_tx.entry) {
 		ret = tcpx_send_msg(ep);
 		if (OFI_SOCK_TRY_SND_RCV_AGAIN(-ret))
@@ -381,7 +381,7 @@ static struct tcpx_xfer_entry *tcpx_get_rx_entry(struct tcpx_ep *ep)
 
 	if (ep->srx_ctx) {
 		srx = ep->srx_ctx;
-		fastlock_acquire(&srx->lock);
+		ofi_spin_lock(&srx->lock);
 		if (!slist_empty(&srx->rx_queue)) {
 			xfer = container_of(slist_remove_head(&srx->rx_queue),
 					    struct tcpx_xfer_entry, entry);
@@ -389,9 +389,9 @@ static struct tcpx_xfer_entry *tcpx_get_rx_entry(struct tcpx_ep *ep)
 		} else {
 			xfer = NULL;
 		}
-		fastlock_release(&ep->srx_ctx->lock);
+		ofi_spin_unlock(&ep->srx_ctx->lock);
 	} else {
-		assert(fastlock_held(&ep->lock));
+		assert(ofi_spin_held(&ep->lock));
 		if (!slist_empty(&ep->rx_queue)) {
 			xfer = container_of(slist_remove_head(&ep->rx_queue),
 					    struct tcpx_xfer_entry, entry);
@@ -692,7 +692,7 @@ void tcpx_progress_rx(struct tcpx_ep *ep)
 {
 	int ret;
 
-	assert(fastlock_held(&ep->lock));
+	assert(ofi_spin_held(&ep->lock));
 	do {
 		if (ep->cur_rx.hdr_done < ep->cur_rx.hdr_len) {
 			ret = tcpx_recv_hdr(ep);
@@ -734,7 +734,7 @@ static int tcpx_mod_epoll(struct tcpx_ep *ep, struct util_wait_fd *wait_fd)
 	uint32_t events;
 	int ret;
 
-	assert(fastlock_held(&ep->lock));
+	assert(ofi_spin_held(&ep->lock));
 	if (ep->pollout_set) {
 		events = (wait_fd->util_wait.wait_obj == FI_WAIT_FD) ?
 			 (OFI_EPOLL_IN | OFI_EPOLL_OUT) : (POLLIN | POLLOUT);
@@ -771,7 +771,7 @@ int tcpx_update_epoll(struct tcpx_ep *ep)
 	struct util_wait_fd *rx_wait, *tx_wait;
 	int ret;
 
-	assert(fastlock_held(&ep->lock));
+	assert(ofi_spin_held(&ep->lock));
 	if ((tcpx_tx_pending(ep) && ep->pollout_set) ||
 	    (!tcpx_tx_pending(ep) && !ep->pollout_set))
 		return FI_SUCCESS;
@@ -799,13 +799,13 @@ int tcpx_try_func(void *util_ep)
 	int ret;
 
 	ep = container_of(util_ep, struct tcpx_ep, util_ep);
-	fastlock_acquire(&ep->lock);
+	ofi_spin_lock(&ep->lock);
 	if (ofi_bsock_readable(&ep->bsock)) {
 		ret = -FI_EAGAIN;
 	} else {
 		ret = tcpx_update_epoll(ep);
 	}
-	fastlock_release(&ep->lock);
+	ofi_spin_unlock(&ep->lock);
 	return ret;
 }
 

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -108,7 +108,7 @@ void tcpx_progress_tx(struct tcpx_ep *ep)
 	struct tcpx_cq *cq;
 	int ret;
 
-	assert(ofi_spin_held(&ep->lock));
+	assert(ofi_mutex_held(&ep->lock));
 	while (ep->cur_tx.entry) {
 		ret = tcpx_send_msg(ep);
 		if (OFI_SOCK_TRY_SND_RCV_AGAIN(-ret))
@@ -381,7 +381,7 @@ static struct tcpx_xfer_entry *tcpx_get_rx_entry(struct tcpx_ep *ep)
 
 	if (ep->srx_ctx) {
 		srx = ep->srx_ctx;
-		ofi_spin_lock(&srx->lock);
+		ofi_mutex_lock(&srx->lock);
 		if (!slist_empty(&srx->rx_queue)) {
 			xfer = container_of(slist_remove_head(&srx->rx_queue),
 					    struct tcpx_xfer_entry, entry);
@@ -389,9 +389,9 @@ static struct tcpx_xfer_entry *tcpx_get_rx_entry(struct tcpx_ep *ep)
 		} else {
 			xfer = NULL;
 		}
-		ofi_spin_unlock(&ep->srx_ctx->lock);
+		ofi_mutex_unlock(&ep->srx_ctx->lock);
 	} else {
-		assert(ofi_spin_held(&ep->lock));
+		assert(ofi_mutex_held(&ep->lock));
 		if (!slist_empty(&ep->rx_queue)) {
 			xfer = container_of(slist_remove_head(&ep->rx_queue),
 					    struct tcpx_xfer_entry, entry);
@@ -692,7 +692,7 @@ void tcpx_progress_rx(struct tcpx_ep *ep)
 {
 	int ret;
 
-	assert(ofi_spin_held(&ep->lock));
+	assert(ofi_mutex_held(&ep->lock));
 	do {
 		if (ep->cur_rx.hdr_done < ep->cur_rx.hdr_len) {
 			ret = tcpx_recv_hdr(ep);
@@ -734,7 +734,7 @@ static int tcpx_mod_epoll(struct tcpx_ep *ep, struct util_wait_fd *wait_fd)
 	uint32_t events;
 	int ret;
 
-	assert(ofi_spin_held(&ep->lock));
+	assert(ofi_mutex_held(&ep->lock));
 	if (ep->pollout_set) {
 		events = (wait_fd->util_wait.wait_obj == FI_WAIT_FD) ?
 			 (OFI_EPOLL_IN | OFI_EPOLL_OUT) : (POLLIN | POLLOUT);
@@ -771,7 +771,7 @@ int tcpx_update_epoll(struct tcpx_ep *ep)
 	struct util_wait_fd *rx_wait, *tx_wait;
 	int ret;
 
-	assert(ofi_spin_held(&ep->lock));
+	assert(ofi_mutex_held(&ep->lock));
 	if ((tcpx_tx_pending(ep) && ep->pollout_set) ||
 	    (!tcpx_tx_pending(ep) && !ep->pollout_set))
 		return FI_SUCCESS;
@@ -799,13 +799,13 @@ int tcpx_try_func(void *util_ep)
 	int ret;
 
 	ep = container_of(util_ep, struct tcpx_ep, util_ep);
-	ofi_spin_lock(&ep->lock);
+	ofi_mutex_lock(&ep->lock);
 	if (ofi_bsock_readable(&ep->bsock)) {
 		ret = -FI_EAGAIN;
 	} else {
 		ret = tcpx_update_epoll(ep);
 	}
-	ofi_spin_unlock(&ep->lock);
+	ofi_mutex_unlock(&ep->lock);
 	return ret;
 }
 

--- a/prov/tcp/src/tcpx_rma.c
+++ b/prov/tcp/src/tcpx_rma.c
@@ -122,10 +122,10 @@ tcpx_rma_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 	tcpx_rma_read_send_entry_fill(send_entry, recv_entry, ep, msg);
 	tcpx_rma_read_recv_entry_fill(recv_entry, ep, msg, flags);
 
-	ofi_spin_lock(&ep->lock);
+	ofi_mutex_lock(&ep->lock);
 	slist_insert_tail(&recv_entry->entry, &ep->rma_read_queue);
 	tcpx_tx_queue_insert(ep, send_entry);
-	ofi_spin_unlock(&ep->lock);
+	ofi_mutex_unlock(&ep->lock);
 	return FI_SUCCESS;
 }
 
@@ -242,9 +242,9 @@ tcpx_rma_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 	tcpx_set_commit_flags(send_entry, flags);
 	send_entry->context = msg->context;
 
-	ofi_spin_lock(&ep->lock);
+	ofi_mutex_lock(&ep->lock);
 	tcpx_tx_queue_insert(ep, send_entry);
-	ofi_spin_unlock(&ep->lock);
+	ofi_mutex_unlock(&ep->lock);
 	return FI_SUCCESS;
 }
 
@@ -373,9 +373,9 @@ tcpx_rma_inject_common(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	send_entry->hdr.base_hdr.size = offset;
 
-	ofi_spin_lock(&ep->lock);
+	ofi_mutex_lock(&ep->lock);
 	tcpx_tx_queue_insert(ep, send_entry);
-	ofi_spin_unlock(&ep->lock);
+	ofi_mutex_unlock(&ep->lock);
 	return FI_SUCCESS;
 }
 

--- a/prov/tcp/src/tcpx_rma.c
+++ b/prov/tcp/src/tcpx_rma.c
@@ -122,10 +122,10 @@ tcpx_rma_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 	tcpx_rma_read_send_entry_fill(send_entry, recv_entry, ep, msg);
 	tcpx_rma_read_recv_entry_fill(recv_entry, ep, msg, flags);
 
-	fastlock_acquire(&ep->lock);
+	ofi_spin_lock(&ep->lock);
 	slist_insert_tail(&recv_entry->entry, &ep->rma_read_queue);
 	tcpx_tx_queue_insert(ep, send_entry);
-	fastlock_release(&ep->lock);
+	ofi_spin_unlock(&ep->lock);
 	return FI_SUCCESS;
 }
 
@@ -242,9 +242,9 @@ tcpx_rma_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 	tcpx_set_commit_flags(send_entry, flags);
 	send_entry->context = msg->context;
 
-	fastlock_acquire(&ep->lock);
+	ofi_spin_lock(&ep->lock);
 	tcpx_tx_queue_insert(ep, send_entry);
-	fastlock_release(&ep->lock);
+	ofi_spin_unlock(&ep->lock);
 	return FI_SUCCESS;
 }
 
@@ -373,9 +373,9 @@ tcpx_rma_inject_common(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	send_entry->hdr.base_hdr.size = offset;
 
-	fastlock_acquire(&ep->lock);
+	ofi_spin_lock(&ep->lock);
 	tcpx_tx_queue_insert(ep, send_entry);
-	fastlock_release(&ep->lock);
+	ofi_spin_unlock(&ep->lock);
 	return FI_SUCCESS;
 }
 

--- a/prov/tcp/src/tcpx_shared_ctx.c
+++ b/prov/tcp/src/tcpx_shared_ctx.c
@@ -50,7 +50,7 @@ tcpx_srx_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 	srx = container_of(ep_fid, struct tcpx_rx_ctx, rx_fid);
 	assert(msg->iov_count <= TCPX_IOV_LIMIT);
 
-	fastlock_acquire(&srx->lock);
+	ofi_spin_lock(&srx->lock);
 	recv_entry = ofi_buf_alloc(srx->buf_pool);
 	if (!recv_entry) {
 		ret = -FI_EAGAIN;
@@ -65,7 +65,7 @@ tcpx_srx_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 
 	slist_insert_tail(&recv_entry->entry, &srx->rx_queue);
 unlock:
-	fastlock_release(&srx->lock);
+	ofi_spin_unlock(&srx->lock);
 	return ret;
 }
 
@@ -79,7 +79,7 @@ tcpx_srx_recv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 
 	srx = container_of(ep_fid, struct tcpx_rx_ctx, rx_fid);
 
-	fastlock_acquire(&srx->lock);
+	ofi_spin_lock(&srx->lock);
 	recv_entry = ofi_buf_alloc(srx->buf_pool);
 	if (!recv_entry) {
 		ret = -FI_EAGAIN;
@@ -94,7 +94,7 @@ tcpx_srx_recv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 
 	slist_insert_tail(&recv_entry->entry, &srx->rx_queue);
 unlock:
-	fastlock_release(&srx->lock);
+	ofi_spin_unlock(&srx->lock);
 	return ret;
 }
 
@@ -109,7 +109,7 @@ tcpx_srx_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	srx = container_of(ep_fid, struct tcpx_rx_ctx, rx_fid);
 	assert(count <= TCPX_IOV_LIMIT);
 
-	fastlock_acquire(&srx->lock);
+	ofi_spin_lock(&srx->lock);
 	recv_entry = ofi_buf_alloc(srx->buf_pool);
 	if (!recv_entry) {
 		ret = -FI_EAGAIN;
@@ -123,7 +123,7 @@ tcpx_srx_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 
 	slist_insert_tail(&recv_entry->entry, &srx->rx_queue);
 unlock:
-	fastlock_release(&srx->lock);
+	ofi_spin_unlock(&srx->lock);
 	return ret;
 }
 
@@ -169,7 +169,7 @@ tcpx_srx_trecvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
 	if (flags & FI_PEEK)
 		return tcpx_srx_peek(srx, msg, flags);
 
-	fastlock_acquire(&srx->lock);
+	ofi_spin_lock(&srx->lock);
 	recv_entry = ofi_buf_alloc(srx->buf_pool);
 	if (!recv_entry) {
 		ret = -FI_EAGAIN;
@@ -187,7 +187,7 @@ tcpx_srx_trecvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
 
 	slist_insert_tail(&recv_entry->entry, &srx->tag_queue);
 unlock:
-	fastlock_release(&srx->lock);
+	ofi_spin_unlock(&srx->lock);
 	return ret;
 }
 
@@ -201,7 +201,7 @@ tcpx_srx_trecv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 
 	srx = container_of(ep_fid, struct tcpx_rx_ctx, rx_fid);
 
-	fastlock_acquire(&srx->lock);
+	ofi_spin_lock(&srx->lock);
 	recv_entry = ofi_buf_alloc(srx->buf_pool);
 	if (!recv_entry) {
 		ret = -FI_EAGAIN;
@@ -219,7 +219,7 @@ tcpx_srx_trecv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 
 	slist_insert_tail(&recv_entry->entry, &srx->tag_queue);
 unlock:
-	fastlock_release(&srx->lock);
+	ofi_spin_unlock(&srx->lock);
 	return ret;
 }
 
@@ -235,7 +235,7 @@ tcpx_srx_trecvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	srx = container_of(ep_fid, struct tcpx_rx_ctx, rx_fid);
 	assert(count <= TCPX_IOV_LIMIT);
 
-	fastlock_acquire(&srx->lock);
+	ofi_spin_lock(&srx->lock);
 	recv_entry = ofi_buf_alloc(srx->buf_pool);
 	if (!recv_entry) {
 		ret = -FI_EAGAIN;
@@ -252,7 +252,7 @@ tcpx_srx_trecvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 
 	slist_insert_tail(&recv_entry->entry, &srx->tag_queue);
 unlock:
-	fastlock_release(&srx->lock);
+	ofi_spin_unlock(&srx->lock);
 	return ret;
 }
 
@@ -275,16 +275,16 @@ tcpx_match_tag(struct tcpx_rx_ctx *srx, struct tcpx_ep *ep, uint64_t tag)
 	struct tcpx_xfer_entry *rx_entry;
 	struct slist_entry *item, *prev;
 
-	fastlock_acquire(&srx->lock);
+	ofi_spin_lock(&srx->lock);
 	slist_foreach(&srx->tag_queue, item, prev) {
 		rx_entry = container_of(item, struct tcpx_xfer_entry, entry);
 		if (ofi_match_tag(rx_entry->tag, rx_entry->ignore, tag)) {
 			slist_remove(&srx->tag_queue, item, prev);
-			fastlock_release(&srx->lock);
+			ofi_spin_unlock(&srx->lock);
 			return rx_entry;
 		}
 	}
-	fastlock_release(&srx->lock);
+	ofi_spin_unlock(&srx->lock);
 
 	return NULL;
 }
@@ -295,17 +295,17 @@ tcpx_match_tag_addr(struct tcpx_rx_ctx *srx, struct tcpx_ep *ep, uint64_t tag)
 	struct tcpx_xfer_entry *rx_entry;
 	struct slist_entry *item, *prev;
 
-	fastlock_acquire(&srx->lock);
+	ofi_spin_lock(&srx->lock);
 	slist_foreach(&srx->tag_queue, item, prev) {
 		rx_entry = container_of(item, struct tcpx_xfer_entry, entry);
 		if (ofi_match_tag(rx_entry->tag, rx_entry->ignore, tag) &&
 		    ofi_match_addr(rx_entry->src_addr, ep->src_addr)) {
 			slist_remove(&srx->tag_queue, item, prev);
-			fastlock_release(&srx->lock);
+			ofi_spin_unlock(&srx->lock);
 			return rx_entry;
 		}
 	}
-	fastlock_release(&srx->lock);
+	ofi_spin_unlock(&srx->lock);
 
 	return NULL;
 }
@@ -316,7 +316,7 @@ tcpx_srx_cancel_rx(struct tcpx_rx_ctx *srx, struct slist *queue, void *context)
 	struct slist_entry *cur, *prev;
 	struct tcpx_xfer_entry *xfer_entry;
 
-	assert(fastlock_held(&srx->lock));
+	assert(ofi_spin_held(&srx->lock));
 
 	slist_foreach(queue, cur, prev) {
 		xfer_entry = container_of(cur, struct tcpx_xfer_entry, entry);
@@ -338,10 +338,10 @@ static ssize_t tcpx_srx_cancel(fid_t fid, void *context)
 
 	srx = container_of(fid, struct tcpx_rx_ctx, rx_fid.fid);
 
-	fastlock_acquire(&srx->lock);
+	ofi_spin_lock(&srx->lock);
 	if (!tcpx_srx_cancel_rx(srx, &srx->tag_queue, context))
 		tcpx_srx_cancel_rx(srx, &srx->rx_queue, context);
-	fastlock_release(&srx->lock);
+	ofi_spin_unlock(&srx->lock);
 
 	return 0;
 }
@@ -401,7 +401,7 @@ static int tcpx_srx_close(struct fid *fid)
 	if (srx->cq)
 		ofi_atomic_dec32(&srx->cq->util_cq.ref);
 	ofi_bufpool_destroy(srx->buf_pool);
-	fastlock_destroy(&srx->lock);
+	ofi_spin_destroy(&srx->lock);
 	free(srx);
 	return FI_SUCCESS;
 }
@@ -434,7 +434,7 @@ int tcpx_srx_context(struct fid_domain *domain, struct fi_rx_attr *attr,
 	slist_init(&srx->rx_queue);
 	slist_init(&srx->tag_queue);
 
-	ret = fastlock_init(&srx->lock);
+	ret = ofi_spin_init(&srx->lock);
 	if (ret)
 		goto err1;
 
@@ -450,7 +450,7 @@ int tcpx_srx_context(struct fid_domain *domain, struct fi_rx_attr *attr,
 	*rx_ep = &srx->rx_fid;
 	return FI_SUCCESS;
 err2:
-	fastlock_destroy(&srx->lock);
+	ofi_spin_destroy(&srx->lock);
 err1:
 	free(srx);
 	return ret;

--- a/prov/udp/src/udpx_ep.c
+++ b/prov/udp/src/udpx_ep.c
@@ -285,7 +285,7 @@ static void udpx_ep_progress(struct util_ep *util_ep)
 	hdr.msg_controllen = 0;
 	hdr.msg_flags = 0;
 
-	ofi_spin_lock(&ep->util_ep.rx_cq->cq_lock);
+	ofi_mutex_lock(&ep->util_ep.rx_cq->cq_lock);
 	if (ofi_cirque_isempty(ep->rxq))
 		goto out;
 
@@ -299,7 +299,7 @@ static void udpx_ep_progress(struct util_ep *util_ep)
 		ofi_cirque_discard(ep->rxq);
 	}
 out:
-	ofi_spin_unlock(&ep->util_ep.rx_cq->cq_lock);
+	ofi_mutex_unlock(&ep->util_ep.rx_cq->cq_lock);
 }
 
 static ssize_t udpx_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
@@ -310,7 +310,7 @@ static ssize_t udpx_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 	ssize_t ret;
 
 	ep = container_of(ep_fid, struct udpx_ep, util_ep.ep_fid.fid);
-	ofi_spin_lock(&ep->util_ep.rx_cq->cq_lock);
+	ofi_mutex_lock(&ep->util_ep.rx_cq->cq_lock);
 	if (ofi_cirque_isfull(ep->rxq)) {
 		ret = -FI_EAGAIN;
 		goto out;
@@ -327,7 +327,7 @@ static ssize_t udpx_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 	ofi_cirque_commit(ep->rxq);
 	ret = 0;
 out:
-	ofi_spin_unlock(&ep->util_ep.rx_cq->cq_lock);
+	ofi_mutex_unlock(&ep->util_ep.rx_cq->cq_lock);
 	return ret;
 }
 
@@ -351,7 +351,7 @@ static ssize_t udpx_recv(struct fid_ep *ep_fid, void *buf, size_t len,
 	ssize_t ret;
 
 	ep = container_of(ep_fid, struct udpx_ep, util_ep.ep_fid.fid);
-	ofi_spin_lock(&ep->util_ep.rx_cq->cq_lock);
+	ofi_mutex_lock(&ep->util_ep.rx_cq->cq_lock);
 	if (ofi_cirque_isfull(ep->rxq)) {
 		ret = -FI_EAGAIN;
 		goto out;
@@ -367,7 +367,7 @@ static ssize_t udpx_recv(struct fid_ep *ep_fid, void *buf, size_t len,
 	ofi_cirque_commit(ep->rxq);
 	ret = 0;
 out:
-	ofi_spin_unlock(&ep->util_ep.rx_cq->cq_lock);
+	ofi_mutex_unlock(&ep->util_ep.rx_cq->cq_lock);
 	return ret;
 }
 
@@ -392,7 +392,7 @@ static ssize_t udpx_sendto(struct udpx_ep *ep, const void *buf, size_t len,
 {
 	ssize_t ret;
 
-	ofi_spin_lock(&ep->util_ep.tx_cq->cq_lock);
+	ofi_mutex_lock(&ep->util_ep.tx_cq->cq_lock);
 	if (ofi_cirque_isfull(ep->util_ep.tx_cq->cirq)) {
 		ret = -FI_EAGAIN;
 		goto out;
@@ -407,7 +407,7 @@ static ssize_t udpx_sendto(struct udpx_ep *ep, const void *buf, size_t len,
 		ret = -errno;
 	}
 out:
-	ofi_spin_unlock(&ep->util_ep.tx_cq->cq_lock);
+	ofi_mutex_unlock(&ep->util_ep.tx_cq->cq_lock);
 	return ret;
 }
 
@@ -448,7 +448,7 @@ static ssize_t udpx_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 	hdr.msg_controllen = 0;
 	hdr.msg_flags = 0;
 
-	ofi_spin_lock(&ep->util_ep.tx_cq->cq_lock);
+	ofi_mutex_lock(&ep->util_ep.tx_cq->cq_lock);
 	if (ofi_cirque_isfull(ep->util_ep.tx_cq->cirq)) {
 		ret = -FI_EAGAIN;
 		goto out;
@@ -462,7 +462,7 @@ static ssize_t udpx_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 		ret = -errno;
 	}
 out:
-	ofi_spin_unlock(&ep->util_ep.tx_cq->cq_lock);
+	ofi_mutex_unlock(&ep->util_ep.tx_cq->cq_lock);
 	return ret;
 }
 

--- a/prov/udp/src/udpx_ep.c
+++ b/prov/udp/src/udpx_ep.c
@@ -285,7 +285,7 @@ static void udpx_ep_progress(struct util_ep *util_ep)
 	hdr.msg_controllen = 0;
 	hdr.msg_flags = 0;
 
-	fastlock_acquire(&ep->util_ep.rx_cq->cq_lock);
+	ofi_spin_lock(&ep->util_ep.rx_cq->cq_lock);
 	if (ofi_cirque_isempty(ep->rxq))
 		goto out;
 
@@ -299,7 +299,7 @@ static void udpx_ep_progress(struct util_ep *util_ep)
 		ofi_cirque_discard(ep->rxq);
 	}
 out:
-	fastlock_release(&ep->util_ep.rx_cq->cq_lock);
+	ofi_spin_unlock(&ep->util_ep.rx_cq->cq_lock);
 }
 
 static ssize_t udpx_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
@@ -310,7 +310,7 @@ static ssize_t udpx_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 	ssize_t ret;
 
 	ep = container_of(ep_fid, struct udpx_ep, util_ep.ep_fid.fid);
-	fastlock_acquire(&ep->util_ep.rx_cq->cq_lock);
+	ofi_spin_lock(&ep->util_ep.rx_cq->cq_lock);
 	if (ofi_cirque_isfull(ep->rxq)) {
 		ret = -FI_EAGAIN;
 		goto out;
@@ -327,7 +327,7 @@ static ssize_t udpx_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 	ofi_cirque_commit(ep->rxq);
 	ret = 0;
 out:
-	fastlock_release(&ep->util_ep.rx_cq->cq_lock);
+	ofi_spin_unlock(&ep->util_ep.rx_cq->cq_lock);
 	return ret;
 }
 
@@ -351,7 +351,7 @@ static ssize_t udpx_recv(struct fid_ep *ep_fid, void *buf, size_t len,
 	ssize_t ret;
 
 	ep = container_of(ep_fid, struct udpx_ep, util_ep.ep_fid.fid);
-	fastlock_acquire(&ep->util_ep.rx_cq->cq_lock);
+	ofi_spin_lock(&ep->util_ep.rx_cq->cq_lock);
 	if (ofi_cirque_isfull(ep->rxq)) {
 		ret = -FI_EAGAIN;
 		goto out;
@@ -367,7 +367,7 @@ static ssize_t udpx_recv(struct fid_ep *ep_fid, void *buf, size_t len,
 	ofi_cirque_commit(ep->rxq);
 	ret = 0;
 out:
-	fastlock_release(&ep->util_ep.rx_cq->cq_lock);
+	ofi_spin_unlock(&ep->util_ep.rx_cq->cq_lock);
 	return ret;
 }
 
@@ -392,7 +392,7 @@ static ssize_t udpx_sendto(struct udpx_ep *ep, const void *buf, size_t len,
 {
 	ssize_t ret;
 
-	fastlock_acquire(&ep->util_ep.tx_cq->cq_lock);
+	ofi_spin_lock(&ep->util_ep.tx_cq->cq_lock);
 	if (ofi_cirque_isfull(ep->util_ep.tx_cq->cirq)) {
 		ret = -FI_EAGAIN;
 		goto out;
@@ -407,7 +407,7 @@ static ssize_t udpx_sendto(struct udpx_ep *ep, const void *buf, size_t len,
 		ret = -errno;
 	}
 out:
-	fastlock_release(&ep->util_ep.tx_cq->cq_lock);
+	ofi_spin_unlock(&ep->util_ep.tx_cq->cq_lock);
 	return ret;
 }
 
@@ -448,7 +448,7 @@ static ssize_t udpx_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 	hdr.msg_controllen = 0;
 	hdr.msg_flags = 0;
 
-	fastlock_acquire(&ep->util_ep.tx_cq->cq_lock);
+	ofi_spin_lock(&ep->util_ep.tx_cq->cq_lock);
 	if (ofi_cirque_isfull(ep->util_ep.tx_cq->cirq)) {
 		ret = -FI_EAGAIN;
 		goto out;
@@ -462,7 +462,7 @@ static ssize_t udpx_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 		ret = -errno;
 	}
 out:
-	fastlock_release(&ep->util_ep.tx_cq->cq_lock);
+	ofi_spin_unlock(&ep->util_ep.tx_cq->cq_lock);
 	return ret;
 }
 

--- a/prov/udp/src/udpx_ep.c
+++ b/prov/udp/src/udpx_ep.c
@@ -563,7 +563,7 @@ static int udpx_ep_close(struct fid *fid)
 					    struct util_wait_fd, util_wait);
 			ofi_epoll_del(wait->epoll_fd, (int)ep->sock);
 		}
-		fid_list_remove(&ep->util_ep.rx_cq->ep_list,
+		fid_list_remove_m(&ep->util_ep.rx_cq->ep_list,
 				&ep->util_ep.rx_cq->ep_list_lock,
 				&ep->util_ep.ep_fid.fid);
 	}
@@ -614,7 +614,7 @@ static int udpx_ep_bind_cq(struct udpx_ep *ep, struct util_cq *cq,
 				udpx_rx_src_comp : udpx_rx_comp;
 		}
 
-		ret = fid_list_insert(&cq->ep_list,
+		ret = fid_list_insert_m(&cq->ep_list,
 				      &cq->ep_list_lock,
 				      &ep->util_ep.ep_fid.fid);
 		if (ret)

--- a/prov/udp/src/udpx_ep.c
+++ b/prov/udp/src/udpx_ep.c
@@ -563,7 +563,7 @@ static int udpx_ep_close(struct fid *fid)
 					    struct util_wait_fd, util_wait);
 			ofi_epoll_del(wait->epoll_fd, (int)ep->sock);
 		}
-		fid_list_remove_m(&ep->util_ep.rx_cq->ep_list,
+		fid_list_remove(&ep->util_ep.rx_cq->ep_list,
 				&ep->util_ep.rx_cq->ep_list_lock,
 				&ep->util_ep.ep_fid.fid);
 	}
@@ -614,7 +614,7 @@ static int udpx_ep_bind_cq(struct udpx_ep *ep, struct util_cq *cq,
 				udpx_rx_src_comp : udpx_rx_comp;
 		}
 
-		ret = fid_list_insert_m(&cq->ep_list,
+		ret = fid_list_insert(&cq->ep_list,
 				      &cq->ep_list_lock,
 				      &ep->util_ep.ep_fid.fid);
 		if (ret)

--- a/prov/usnic/src/usdf_cq.c
+++ b/prov/usnic/src/usdf_cq.c
@@ -749,7 +749,7 @@ static int usdf_cq_unbind_wait(struct usdf_cq *cq)
 		return ret;
 	}
 
-	fid_list_remove_m(&wait_priv->list, &wait_priv->lock, &cq->cq_fid.fid);
+	fid_list_remove(&wait_priv->list, &wait_priv->lock, &cq->cq_fid.fid);
 
 	ofi_atomic_dec32(&wait_priv->wait_refcnt);
 
@@ -1177,7 +1177,7 @@ static int usdf_cq_bind_wait(struct usdf_cq *cq)
 	 */
 	wait_priv = wait_ftou(cq->cq_attr.wait_set);
 
-	ret = fid_list_insert_m(&wait_priv->list, &wait_priv->lock,
+	ret = fid_list_insert(&wait_priv->list, &wait_priv->lock,
 			&cq->cq_fid.fid);
 	if (ret) {
 		USDF_WARN_SYS(CQ,
@@ -1198,7 +1198,7 @@ static int usdf_cq_bind_wait(struct usdf_cq *cq)
 	return ret;
 
 err:
-	fid_list_remove_m(&wait_priv->list, &wait_priv->lock, &cq->cq_fid.fid);
+	fid_list_remove(&wait_priv->list, &wait_priv->lock, &cq->cq_fid.fid);
 	return ret;
 }
 

--- a/prov/usnic/src/usdf_cq.c
+++ b/prov/usnic/src/usdf_cq.c
@@ -749,7 +749,7 @@ static int usdf_cq_unbind_wait(struct usdf_cq *cq)
 		return ret;
 	}
 
-	fid_list_remove(&wait_priv->list, &wait_priv->lock, &cq->cq_fid.fid);
+	fid_list_remove_m(&wait_priv->list, &wait_priv->lock, &cq->cq_fid.fid);
 
 	ofi_atomic_dec32(&wait_priv->wait_refcnt);
 
@@ -1177,7 +1177,7 @@ static int usdf_cq_bind_wait(struct usdf_cq *cq)
 	 */
 	wait_priv = wait_ftou(cq->cq_attr.wait_set);
 
-	ret = fid_list_insert(&wait_priv->list, &wait_priv->lock,
+	ret = fid_list_insert_m(&wait_priv->list, &wait_priv->lock,
 			&cq->cq_fid.fid);
 	if (ret) {
 		USDF_WARN_SYS(CQ,
@@ -1198,7 +1198,7 @@ static int usdf_cq_bind_wait(struct usdf_cq *cq)
 	return ret;
 
 err:
-	fid_list_remove(&wait_priv->list, &wait_priv->lock, &cq->cq_fid.fid);
+	fid_list_remove_m(&wait_priv->list, &wait_priv->lock, &cq->cq_fid.fid);
 	return ret;
 }
 

--- a/prov/usnic/src/usdf_eq.c
+++ b/prov/usnic/src/usdf_eq.c
@@ -442,7 +442,7 @@ static int usdf_eq_bind_wait(struct usdf_eq *eq)
 
 	wait_priv = wait_ftou(eq->eq_attr.wait_set);
 
-	ret = fid_list_insert(&wait_priv->list, &wait_priv->lock,
+	ret = fid_list_insert_m(&wait_priv->list, &wait_priv->lock,
 			&eq->eq_fid.fid);
 	if (ret) {
 		USDF_WARN_SYS(EQ,
@@ -462,7 +462,7 @@ static int usdf_eq_bind_wait(struct usdf_eq *eq)
 	return ret;
 
 err:
-	fid_list_remove(&wait_priv->list, &wait_priv->lock, &eq->eq_fid.fid);
+	fid_list_remove_m(&wait_priv->list, &wait_priv->lock, &eq->eq_fid.fid);
 	return ret;
 }
 
@@ -485,7 +485,7 @@ static int usdf_eq_unbind_wait(struct usdf_eq *eq)
 		return ret;
 	}
 
-	fid_list_remove(&wait_priv->list, &wait_priv->lock, &eq->eq_fid.fid);
+	fid_list_remove_m(&wait_priv->list, &wait_priv->lock, &eq->eq_fid.fid);
 
 	ofi_atomic_dec32(&wait_priv->wait_refcnt);
 

--- a/prov/usnic/src/usdf_eq.c
+++ b/prov/usnic/src/usdf_eq.c
@@ -442,7 +442,7 @@ static int usdf_eq_bind_wait(struct usdf_eq *eq)
 
 	wait_priv = wait_ftou(eq->eq_attr.wait_set);
 
-	ret = fid_list_insert_m(&wait_priv->list, &wait_priv->lock,
+	ret = fid_list_insert(&wait_priv->list, &wait_priv->lock,
 			&eq->eq_fid.fid);
 	if (ret) {
 		USDF_WARN_SYS(EQ,
@@ -462,7 +462,7 @@ static int usdf_eq_bind_wait(struct usdf_eq *eq)
 	return ret;
 
 err:
-	fid_list_remove_m(&wait_priv->list, &wait_priv->lock, &eq->eq_fid.fid);
+	fid_list_remove(&wait_priv->list, &wait_priv->lock, &eq->eq_fid.fid);
 	return ret;
 }
 
@@ -485,7 +485,7 @@ static int usdf_eq_unbind_wait(struct usdf_eq *eq)
 		return ret;
 	}
 
-	fid_list_remove_m(&wait_priv->list, &wait_priv->lock, &eq->eq_fid.fid);
+	fid_list_remove(&wait_priv->list, &wait_priv->lock, &eq->eq_fid.fid);
 
 	ofi_atomic_dec32(&wait_priv->wait_refcnt);
 

--- a/prov/usnic/src/usdf_poll.c
+++ b/prov/usnic/src/usdf_poll.c
@@ -59,7 +59,7 @@ static int usdf_poll_poll(struct fid_poll *fps, void **context, int count)
 
 	ps = poll_ftou(fps);
 
-	fastlock_acquire(&ps->lock);
+	ofi_spin_lock(&ps->lock);
 
 	dlist_foreach(&ps->list, item) {
 		entry = container_of(item, struct fid_list_entry, entry);
@@ -86,7 +86,7 @@ static int usdf_poll_poll(struct fid_poll *fps, void **context, int count)
 		}
 	}
 
-	fastlock_release(&ps->lock);
+	ofi_spin_unlock(&ps->lock);
 
 	return copied;
 }
@@ -220,7 +220,7 @@ static int usdf_poll_close(struct fid *fps)
 	}
 
 	ofi_atomic_dec32(&ps->poll_domain->dom_refcnt);
-	fastlock_destroy(&ps->lock);
+	ofi_spin_destroy(&ps->lock);
 	free(ps);
 
 	return ret;
@@ -267,7 +267,7 @@ int usdf_poll_open(struct fid_domain *fdom, struct fi_poll_attr *attr,
 
 	dlist_init(&ps->list);
 	ofi_atomic_initialize32(&ps->poll_refcnt, 0);
-	fastlock_init(&ps->lock);
+	ofi_spin_init(&ps->lock);
 
 	ps->poll_fid.fid.ops = &usdf_poll_fi_ops;
 	ps->poll_fid.fid.fclass = FI_CLASS_POLL;

--- a/prov/usnic/src/usdf_poll.c
+++ b/prov/usnic/src/usdf_poll.c
@@ -115,7 +115,7 @@ static int usdf_poll_add(struct fid_poll *fps, struct fid *event_fid,
 		return -FI_EINVAL;
 	}
 
-	ret = fid_list_insert_m(&ps->list, &ps->lock, event_fid);
+	ret = fid_list_insert(&ps->list, &ps->lock, event_fid);
 	if (ret)
 		return ret;
 
@@ -152,7 +152,7 @@ static int usdf_poll_del(struct fid_poll *fps, struct fid *event_fid,
 		return -FI_EINVAL;
 	}
 
-	fid_list_remove_m(&ps->list, &ps->lock, event_fid);
+	fid_list_remove(&ps->list, &ps->lock, event_fid);
 
 	cq = cq_fidtou(event_fid);
 	ret = ofi_atomic_dec32(&cq->cq_refcnt);

--- a/prov/usnic/src/usdf_poll.h
+++ b/prov/usnic/src/usdf_poll.h
@@ -44,7 +44,7 @@ struct usdf_poll {
 	struct usdf_domain	*poll_domain;
 
 	ofi_atomic32_t		poll_refcnt;
-	ofi_spin_t		lock;
+	ofi_mutex_t		lock;
 	struct dlist_entry	list;
 };
 

--- a/prov/usnic/src/usdf_poll.h
+++ b/prov/usnic/src/usdf_poll.h
@@ -44,7 +44,7 @@ struct usdf_poll {
 	struct usdf_domain	*poll_domain;
 
 	ofi_atomic32_t		poll_refcnt;
-	fastlock_t		lock;
+	ofi_spin_t		lock;
 	struct dlist_entry	list;
 };
 

--- a/prov/usnic/src/usdf_wait.c
+++ b/prov/usnic/src/usdf_wait.c
@@ -217,7 +217,7 @@ int usdf_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
 	wait_priv->object.epfd = epfd;
 
 	ofi_atomic_initialize32(&wait_priv->wait_refcnt, 0);
-	fastlock_init(&wait_priv->lock);
+	ofi_spin_init(&wait_priv->lock);
 	dlist_init(&wait_priv->list);
 
 	ofi_atomic_inc32(&wait_priv->wait_fabric->fab_refcnt);

--- a/prov/usnic/src/usdf_wait.c
+++ b/prov/usnic/src/usdf_wait.c
@@ -217,7 +217,7 @@ int usdf_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
 	wait_priv->object.epfd = epfd;
 
 	ofi_atomic_initialize32(&wait_priv->wait_refcnt, 0);
-	ofi_spin_init(&wait_priv->lock);
+	ofi_mutex_init(&wait_priv->lock);
 	dlist_init(&wait_priv->list);
 
 	ofi_atomic_inc32(&wait_priv->wait_fabric->fab_refcnt);

--- a/prov/usnic/src/usdf_wait.h
+++ b/prov/usnic/src/usdf_wait.h
@@ -51,7 +51,7 @@ struct usdf_wait {
 
 	ofi_atomic32_t		wait_refcnt;
 
-	ofi_spin_t		lock;
+	ofi_mutex_t		lock;
 	struct dlist_entry	list;
 };
 

--- a/prov/usnic/src/usdf_wait.h
+++ b/prov/usnic/src/usdf_wait.h
@@ -51,7 +51,7 @@ struct usdf_wait {
 
 	ofi_atomic32_t		wait_refcnt;
 
-	fastlock_t		lock;
+	ofi_spin_t		lock;
 	struct dlist_entry	list;
 };
 

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -410,7 +410,7 @@ int ofi_av_close_lightweight(struct util_av *av)
 	if (av->eq)
 		ofi_atomic_dec32(&av->eq->ref);
 
-	ofi_spin_destroy(&av->ep_list_lock);
+	ofi_mutex_destroy(&av->ep_list_lock);
 
 	ofi_atomic_dec32(&av->domain->ref);
 	ofi_spin_destroy(&av->lock);
@@ -537,7 +537,7 @@ int ofi_av_init_lightweight(struct util_domain *domain, const struct fi_av_attr 
 	 */
 	av->context = context;
 	av->domain = domain;
-	ofi_spin_init(&av->ep_list_lock);
+	ofi_mutex_init(&av->ep_list_lock);
 	dlist_init(&av->ep_list);
 	ofi_atomic_inc32(&domain->ref);
 	return 0;

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -286,7 +286,7 @@ int ofi_av_insert_addr(struct util_av *av, const void *addr, fi_addr_t *fi_addr)
 {
 	struct util_av_entry *entry = NULL;
 
-	assert(fastlock_held(&av->lock));
+	assert(ofi_spin_held(&av->lock));
 	HASH_FIND(hh, av->hash, addr, av->addrlen, entry);
 	if (entry) {
 		if (fi_addr)
@@ -328,7 +328,7 @@ int ofi_av_remove_addr(struct util_av *av, fi_addr_t fi_addr)
 {
 	struct util_av_entry *av_entry;
 
-	assert(fastlock_held(&av->lock));
+	assert(ofi_spin_held(&av->lock));
 	av_entry = ofi_bufpool_get_ibuf(av->av_entry_pool, fi_addr);
 	if (!av_entry)
 		return -FI_ENOENT;
@@ -352,9 +352,9 @@ fi_addr_t ofi_av_lookup_fi_addr_unsafe(struct util_av *av, const void *addr)
 fi_addr_t ofi_av_lookup_fi_addr(struct util_av *av, const void *addr)
 {
 	fi_addr_t fi_addr;
-	fastlock_acquire(&av->lock);
+	ofi_spin_lock(&av->lock);
 	fi_addr = ofi_av_lookup_fi_addr_unsafe(av, addr);
-	fastlock_release(&av->lock);
+	ofi_spin_unlock(&av->lock);
 	return fi_addr;
 }
 
@@ -410,10 +410,10 @@ int ofi_av_close_lightweight(struct util_av *av)
 	if (av->eq)
 		ofi_atomic_dec32(&av->eq->ref);
 
-	fastlock_destroy(&av->ep_list_lock);
+	ofi_spin_destroy(&av->ep_list_lock);
 
 	ofi_atomic_dec32(&av->domain->ref);
-	fastlock_destroy(&av->lock);
+	ofi_spin_destroy(&av->lock);
 
 	return 0;
 }
@@ -528,7 +528,7 @@ int ofi_av_init_lightweight(struct util_domain *domain, const struct fi_av_attr 
 
 	av->prov = domain->prov;
 	ofi_atomic_initialize32(&av->ref, 0);
-	fastlock_init(&av->lock);
+	ofi_spin_init(&av->lock);
 	av->av_fid.fid.fclass = FI_CLASS_AV;
 	/*
 	 * ops set by provider
@@ -537,7 +537,7 @@ int ofi_av_init_lightweight(struct util_domain *domain, const struct fi_av_attr 
 	 */
 	av->context = context;
 	av->domain = domain;
-	fastlock_init(&av->ep_list_lock);
+	ofi_spin_init(&av->ep_list_lock);
 	dlist_init(&av->ep_list);
 	ofi_atomic_inc32(&domain->ref);
 	return 0;
@@ -603,9 +603,9 @@ static int ip_av_insert_addr(struct util_av *av, const void *addr,
 	int ret;
 
 	if (ofi_valid_dest_ipaddr(addr)) {
-		fastlock_acquire(&av->lock);
+		ofi_spin_lock(&av->lock);
 		ret = ofi_av_insert_addr(av, addr, fi_addr);
-		fastlock_release(&av->lock);
+		ofi_spin_unlock(&av->lock);
 	} else {
 		ret = -FI_EADDRNOTAVAIL;
 		if (fi_addr)
@@ -893,9 +893,9 @@ int ofi_ip_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr,
 	 * Thus, we walk through the array backwards.
 	 */
 	for (i = count - 1; i >= 0; i--) {
-		fastlock_acquire(&av->lock);
+		ofi_spin_lock(&av->lock);
 		ret = ofi_av_remove_addr(av, fi_addr[i]);
-		fastlock_release(&av->lock);
+		ofi_spin_unlock(&av->lock);
 		if (ret) {
 			FI_WARN(av->prov, FI_LOG_AV,
 				"removal of fi_addr %"PRIu64" failed\n",

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -286,7 +286,7 @@ int ofi_av_insert_addr(struct util_av *av, const void *addr, fi_addr_t *fi_addr)
 {
 	struct util_av_entry *entry = NULL;
 
-	assert(ofi_spin_held(&av->lock));
+	assert(ofi_mutex_held(&av->lock));
 	HASH_FIND(hh, av->hash, addr, av->addrlen, entry);
 	if (entry) {
 		if (fi_addr)
@@ -328,7 +328,7 @@ int ofi_av_remove_addr(struct util_av *av, fi_addr_t fi_addr)
 {
 	struct util_av_entry *av_entry;
 
-	assert(ofi_spin_held(&av->lock));
+	assert(ofi_mutex_held(&av->lock));
 	av_entry = ofi_bufpool_get_ibuf(av->av_entry_pool, fi_addr);
 	if (!av_entry)
 		return -FI_ENOENT;
@@ -352,9 +352,9 @@ fi_addr_t ofi_av_lookup_fi_addr_unsafe(struct util_av *av, const void *addr)
 fi_addr_t ofi_av_lookup_fi_addr(struct util_av *av, const void *addr)
 {
 	fi_addr_t fi_addr;
-	ofi_spin_lock(&av->lock);
+	ofi_mutex_lock(&av->lock);
 	fi_addr = ofi_av_lookup_fi_addr_unsafe(av, addr);
-	ofi_spin_unlock(&av->lock);
+	ofi_mutex_unlock(&av->lock);
 	return fi_addr;
 }
 
@@ -413,7 +413,7 @@ int ofi_av_close_lightweight(struct util_av *av)
 	ofi_mutex_destroy(&av->ep_list_lock);
 
 	ofi_atomic_dec32(&av->domain->ref);
-	ofi_spin_destroy(&av->lock);
+	ofi_mutex_destroy(&av->lock);
 
 	return 0;
 }
@@ -528,7 +528,7 @@ int ofi_av_init_lightweight(struct util_domain *domain, const struct fi_av_attr 
 
 	av->prov = domain->prov;
 	ofi_atomic_initialize32(&av->ref, 0);
-	ofi_spin_init(&av->lock);
+	ofi_mutex_init(&av->lock);
 	av->av_fid.fid.fclass = FI_CLASS_AV;
 	/*
 	 * ops set by provider
@@ -603,9 +603,9 @@ static int ip_av_insert_addr(struct util_av *av, const void *addr,
 	int ret;
 
 	if (ofi_valid_dest_ipaddr(addr)) {
-		ofi_spin_lock(&av->lock);
+		ofi_mutex_lock(&av->lock);
 		ret = ofi_av_insert_addr(av, addr, fi_addr);
-		ofi_spin_unlock(&av->lock);
+		ofi_mutex_unlock(&av->lock);
 	} else {
 		ret = -FI_EADDRNOTAVAIL;
 		if (fi_addr)
@@ -893,9 +893,9 @@ int ofi_ip_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr,
 	 * Thus, we walk through the array backwards.
 	 */
 	for (i = count - 1; i >= 0; i--) {
-		ofi_spin_lock(&av->lock);
+		ofi_mutex_lock(&av->lock);
 		ret = ofi_av_remove_addr(av, fi_addr[i]);
-		ofi_spin_unlock(&av->lock);
+		ofi_mutex_unlock(&av->lock);
 		if (ret) {
 			FI_WARN(av->prov, FI_LOG_AV,
 				"removal of fi_addr %"PRIu64" failed\n",

--- a/prov/util/src/util_cntr.c
+++ b/prov/util/src/util_cntr.c
@@ -217,7 +217,7 @@ int ofi_cntr_cleanup(struct util_cntr *cntr)
 	}
 
 	ofi_atomic_dec32(&cntr->domain->ref);
-	ofi_spin_destroy(&cntr->ep_list_lock);
+	ofi_mutex_destroy(&cntr->ep_list_lock);
 	return 0;
 }
 
@@ -240,13 +240,13 @@ void ofi_cntr_progress(struct util_cntr *cntr)
 	struct fid_list_entry *fid_entry;
 	struct dlist_entry *item;
 
-	ofi_spin_lock(&cntr->ep_list_lock);
+	ofi_mutex_lock(&cntr->ep_list_lock);
 	dlist_foreach(&cntr->ep_list, item) {
 		fid_entry = container_of(item, struct fid_list_entry, entry);
 		ep = container_of(fid_entry->fid, struct util_ep, ep_fid.fid);
 		ep->progress(ep);
 	}
-	ofi_spin_unlock(&cntr->ep_list_lock);
+	ofi_mutex_unlock(&cntr->ep_list_lock);
 }
 
 static struct fi_ops util_cntr_fi_ops = {
@@ -308,7 +308,7 @@ int ofi_cntr_init(const struct fi_provider *prov, struct fid_domain *domain,
 		return -FI_EINVAL;
 	}
 
-	ofi_spin_init(&cntr->ep_list_lock);
+	ofi_mutex_init(&cntr->ep_list_lock);
 	ofi_atomic_inc32(&cntr->domain->ref);
 
 	/* CNTR must be fully operational before adding to wait set */

--- a/prov/util/src/util_coll.c
+++ b/prov/util/src/util_coll.c
@@ -1121,7 +1121,7 @@ static inline int util_av_set_init(struct util_av_set *av_set,
 	av_set->av_set_fid.fid.ops = &util_av_set_fi_ops;
 	av_set->av = util_av;
 	ofi_atomic_initialize32(&av_set->ref, 0);
-	ret = ofi_spin_init(&av_set->lock);
+	ret = ofi_mutex_init(&av_set->lock);
 
 	return ret;
 }
@@ -1164,7 +1164,7 @@ static int util_coll_av_init(struct util_av *av)
 	return FI_SUCCESS;
 
 err4:
-	ofi_spin_destroy(&coll_mc->av_set->lock);
+	ofi_mutex_destroy(&coll_mc->av_set->lock);
 err3:
 	free(coll_mc->av_set->fi_addr_array);
 err2:
@@ -1214,7 +1214,7 @@ int ofi_av_set(struct fid_av *av, struct fi_av_set_attr *attr,
 	(*av_set_fid) = &av_set->av_set_fid;
 	return FI_SUCCESS;
 err2:
-	ofi_spin_destroy(&av_set->lock);
+	ofi_mutex_destroy(&av_set->lock);
 err1:
 	free(av_set);
 	return ret;

--- a/prov/util/src/util_coll.c
+++ b/prov/util/src/util_coll.c
@@ -1121,7 +1121,7 @@ static inline int util_av_set_init(struct util_av_set *av_set,
 	av_set->av_set_fid.fid.ops = &util_av_set_fi_ops;
 	av_set->av = util_av;
 	ofi_atomic_initialize32(&av_set->ref, 0);
-	ret = fastlock_init(&av_set->lock);
+	ret = ofi_spin_init(&av_set->lock);
 
 	return ret;
 }
@@ -1164,7 +1164,7 @@ static int util_coll_av_init(struct util_av *av)
 	return FI_SUCCESS;
 
 err4:
-	fastlock_destroy(&coll_mc->av_set->lock);
+	ofi_spin_destroy(&coll_mc->av_set->lock);
 err3:
 	free(coll_mc->av_set->fi_addr_array);
 err2:
@@ -1214,7 +1214,7 @@ int ofi_av_set(struct fid_av *av, struct fi_av_set_attr *attr,
 	(*av_set_fid) = &av_set->av_set_fid;
 	return FI_SUCCESS;
 err2:
-	fastlock_destroy(&av_set->lock);
+	ofi_spin_destroy(&av_set->lock);
 err1:
 	free(av_set);
 	return ret;

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -59,7 +59,7 @@ int ofi_cq_write_overflow(struct util_cq *cq, void *context, uint64_t flags,
 {
 	struct util_cq_aux_entry *entry;
 
-	assert(ofi_spin_held(&cq->cq_lock));
+	assert(ofi_mutex_held(&cq->cq_lock));
 	FI_DBG(cq->domain->prov, FI_LOG_CQ, "writing to CQ overflow list\n");
 	assert(ofi_cirque_freecnt(cq->cirq) <= 1);
 
@@ -84,7 +84,7 @@ int ofi_cq_insert_error(struct util_cq *cq,
 {
 	struct util_cq_aux_entry *entry;
 
-	assert(ofi_spin_held(&cq->cq_lock));
+	assert(ofi_mutex_held(&cq->cq_lock));
 	assert(err_entry->err);
 	if (!(entry = calloc(1, sizeof(*entry))))
 		return -FI_ENOMEM;
@@ -97,9 +97,9 @@ int ofi_cq_insert_error(struct util_cq *cq,
 int ofi_cq_write_error(struct util_cq *cq,
 		       const struct fi_cq_err_entry *err_entry)
 {
-	cq->cq_fastlock_acquire(&cq->cq_lock);
+	cq->cq_mutex_lock(&cq->cq_lock);
 	ofi_cq_insert_error(cq, err_entry);
-	cq->cq_fastlock_release(&cq->cq_lock);
+	cq->cq_mutex_unlock(&cq->cq_lock);
 
 	if (cq->wait)
 		cq->wait->signal(cq->wait);
@@ -224,11 +224,11 @@ ssize_t ofi_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 
 	cq = container_of(cq_fid, struct util_cq, cq_fid);
 
-	cq->cq_fastlock_acquire(&cq->cq_lock);
+	cq->cq_mutex_lock(&cq->cq_lock);
 	if (ofi_cirque_isempty(cq->cirq) || !count) {
-		cq->cq_fastlock_release(&cq->cq_lock);
+		cq->cq_mutex_unlock(&cq->cq_lock);
 		cq->progress(cq);
-		cq->cq_fastlock_acquire(&cq->cq_lock);
+		cq->cq_mutex_lock(&cq->cq_lock);
 		if (ofi_cirque_isempty(cq->cirq)) {
 			i = -FI_EAGAIN;
 			goto out;
@@ -274,7 +274,7 @@ ssize_t ofi_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 		}
 	}
 out:
-	cq->cq_fastlock_release(&cq->cq_lock);
+	cq->cq_mutex_unlock(&cq->cq_lock);
 	return i;
 }
 
@@ -296,7 +296,7 @@ ssize_t ofi_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *buf,
 	cq = container_of(cq_fid, struct util_cq, cq_fid);
 	api_version = cq->domain->fabric->fabric_fid.api_version;
 
-	cq->cq_fastlock_acquire(&cq->cq_lock);
+	cq->cq_mutex_lock(&cq->cq_lock);
 	if (ofi_cirque_isempty(cq->cirq) ||
 	    !(ofi_cirque_head(cq->cirq)->flags & UTIL_FLAG_AUX)) {
 		ret = -FI_EAGAIN;
@@ -341,7 +341,7 @@ ssize_t ofi_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *buf,
 
 	ret = 1;
 unlock:
-	cq->cq_fastlock_release(&cq->cq_lock);
+	cq->cq_mutex_unlock(&cq->cq_lock);
 	return ret;
 }
 
@@ -429,7 +429,7 @@ int ofi_cq_cleanup(struct util_cq *cq)
 
 	ofi_atomic_dec32(&cq->domain->ref);
 	util_comp_cirq_free(cq->cirq);
-	ofi_spin_destroy(&cq->cq_lock);
+	ofi_mutex_destroy(&cq->cq_lock);
 	ofi_mutex_destroy(&cq->ep_list_lock);
 	free(cq->src);
 	return 0;
@@ -486,16 +486,12 @@ static int fi_cq_init(struct fid_domain *domain, struct fi_cq_attr *attr,
 	ofi_atomic_initialize32(&cq->signaled, 0);
 	dlist_init(&cq->ep_list);
 	ofi_mutex_init(&cq->ep_list_lock);
-	ofi_spin_init(&cq->cq_lock);
+	ofi_mutex_init(&cq->cq_lock);
 	if (cq->domain->threading == FI_THREAD_COMPLETION ||
 	    (cq->domain->threading == FI_THREAD_DOMAIN)) {
-		cq->cq_fastlock_acquire = ofi_spin_lock_noop;
-		cq->cq_fastlock_release = ofi_spin_unlock_noop;
 		cq->cq_mutex_lock = ofi_mutex_lock_noop;
 		cq->cq_mutex_unlock = ofi_mutex_unlock_noop;
 	} else {
-		cq->cq_fastlock_acquire = ofi_spin_lock_op;
-		cq->cq_fastlock_release = ofi_spin_unlock_op;
 		cq->cq_mutex_lock = ofi_mutex_lock_op;
 		cq->cq_mutex_unlock = ofi_mutex_unlock_op;
 	}

--- a/prov/util/src/util_domain.c
+++ b/prov/util/src/util_domain.c
@@ -81,12 +81,12 @@ int ofi_domain_close(struct util_domain *domain)
 	if (domain->mr_map.rbtree)
 		ofi_mr_map_close(&domain->mr_map);
 
-	ofi_spin_lock(&domain->fabric->lock);
+	ofi_mutex_lock(&domain->fabric->lock);
 	dlist_remove(&domain->list_entry);
-	ofi_spin_unlock(&domain->fabric->lock);
+	ofi_mutex_unlock(&domain->fabric->lock);
 
 	free(domain->name);
-	ofi_spin_destroy(&domain->lock);
+	ofi_mutex_destroy(&domain->lock);
 	ofi_atomic_dec32(&domain->fabric->ref);
 	return 0;
 }
@@ -102,7 +102,7 @@ static int util_domain_init(struct util_domain *domain,
 			    const struct fi_info *info)
 {
 	ofi_atomic_initialize32(&domain->ref, 0);
-	ofi_spin_init(&domain->lock);
+	ofi_mutex_init(&domain->lock);
 	domain->info_domain_caps = info->caps | info->domain_attr->caps;
 	domain->info_domain_mode = info->mode | info->domain_attr->mode;
 	domain->mr_mode = info->domain_attr->mr_mode;
@@ -141,9 +141,9 @@ int ofi_domain_init(struct fid_fabric *fabric_fid, const struct fi_info *info,
 		return ret;
 	}
 
-	ofi_spin_lock(&fabric->lock);
+	ofi_mutex_lock(&fabric->lock);
 	dlist_insert_tail(&domain->list_entry, &fabric->domain_list);
-	ofi_spin_unlock(&fabric->lock);
+	ofi_mutex_unlock(&fabric->lock);
 
 	ofi_atomic_inc32(&fabric->ref);
 	return 0;

--- a/prov/util/src/util_ep.c
+++ b/prov/util/src/util_ep.c
@@ -92,9 +92,9 @@ int ofi_ep_bind_av(struct util_ep *util_ep, struct util_av *av)
 	util_ep->av = av;
 	ofi_atomic_inc32(&av->ref);
 
-	fastlock_acquire(&av->ep_list_lock);
+	ofi_spin_lock(&av->ep_list_lock);
 	dlist_insert_tail(&util_ep->av_entry, &av->ep_list);
-	fastlock_release(&av->ep_list_lock);
+	ofi_spin_unlock(&av->ep_list_lock);
 
 	return 0;
 }
@@ -247,13 +247,13 @@ int ofi_endpoint_init(struct fid_domain *domain, const struct util_prov *util_pr
 	ofi_atomic_inc32(&util_domain->ref);
 	if (util_domain->eq)
 		ofi_ep_bind_eq(ep, util_domain->eq);
-	fastlock_init(&ep->lock);
+	ofi_spin_init(&ep->lock);
 	if (ep->domain->threading != FI_THREAD_SAFE) {
-		ep->lock_acquire = ofi_fastlock_acquire_noop;
-		ep->lock_release = ofi_fastlock_release_noop;
+		ep->lock_acquire = ofi_spin_lock_noop;
+		ep->lock_release = ofi_spin_unlock_noop;
 	} else {
-		ep->lock_acquire = ofi_fastlock_acquire;
-		ep->lock_release = ofi_fastlock_release;
+		ep->lock_acquire = ofi_spin_lock_op;
+		ep->lock_release = ofi_spin_unlock_op;
 	}
 	if (ep->caps & FI_COLLECTIVE) {
 		ep->coll_cid_mask = calloc(1, sizeof(*ep->coll_cid_mask));
@@ -326,9 +326,9 @@ int ofi_endpoint_close(struct util_ep *util_ep)
 	}
 
 	if (util_ep->av) {
-		fastlock_acquire(&util_ep->av->ep_list_lock);
+		ofi_spin_lock(&util_ep->av->ep_list_lock);
 		dlist_remove(&util_ep->av_entry);
-		fastlock_release(&util_ep->av->ep_list_lock);
+		ofi_spin_unlock(&util_ep->av->ep_list_lock);
 
 		ofi_atomic_dec32(&util_ep->av->ref);
 	}
@@ -341,6 +341,6 @@ int ofi_endpoint_close(struct util_ep *util_ep)
 	if (util_ep->eq)
 		ofi_atomic_dec32(&util_ep->eq->ref);
 	ofi_atomic_dec32(&util_ep->domain->ref);
-	fastlock_destroy(&util_ep->lock);
+	ofi_spin_destroy(&util_ep->lock);
 	return 0;
 }

--- a/prov/util/src/util_ep.c
+++ b/prov/util/src/util_ep.c
@@ -247,13 +247,13 @@ int ofi_endpoint_init(struct fid_domain *domain, const struct util_prov *util_pr
 	ofi_atomic_inc32(&util_domain->ref);
 	if (util_domain->eq)
 		ofi_ep_bind_eq(ep, util_domain->eq);
-	ofi_spin_init(&ep->lock);
+	ofi_mutex_init(&ep->lock);
 	if (ep->domain->threading != FI_THREAD_SAFE) {
-		ep->lock_acquire = ofi_spin_lock_noop;
-		ep->lock_release = ofi_spin_unlock_noop;
+		ep->lock_acquire = ofi_mutex_lock_noop;
+		ep->lock_release = ofi_mutex_unlock_noop;
 	} else {
-		ep->lock_acquire = ofi_spin_lock_op;
-		ep->lock_release = ofi_spin_unlock_op;
+		ep->lock_acquire = ofi_mutex_lock_op;
+		ep->lock_release = ofi_mutex_unlock_op;
 	}
 	if (ep->caps & FI_COLLECTIVE) {
 		ep->coll_cid_mask = calloc(1, sizeof(*ep->coll_cid_mask));
@@ -341,6 +341,6 @@ int ofi_endpoint_close(struct util_ep *util_ep)
 	if (util_ep->eq)
 		ofi_atomic_dec32(&util_ep->eq->ref);
 	ofi_atomic_dec32(&util_ep->domain->ref);
-	ofi_spin_destroy(&util_ep->lock);
+	ofi_mutex_destroy(&util_ep->lock);
 	return 0;
 }

--- a/prov/util/src/util_ep.c
+++ b/prov/util/src/util_ep.c
@@ -64,7 +64,7 @@ int ofi_ep_bind_cq(struct util_ep *ep, struct util_cq *cq, uint64_t flags)
 	}
 
 	if (flags & (FI_TRANSMIT | FI_RECV)) {
-		return fid_list_insert_m(&cq->ep_list,
+		return fid_list_insert(&cq->ep_list,
 				       &cq->ep_list_lock,
 				       &ep->ep_fid.fid);
 	}
@@ -157,7 +157,7 @@ int ofi_ep_bind_cntr(struct util_ep *ep, struct util_cntr *cntr, uint64_t flags)
 
 	ep->flags |= OFI_CNTR_ENABLED;
 
-	return fid_list_insert_m(&cntr->ep_list, &cntr->ep_list_lock,
+	return fid_list_insert(&cntr->ep_list, &cntr->ep_list_lock,
 			       &ep->ep_fid.fid);
 }
 
@@ -270,56 +270,56 @@ int ofi_endpoint_init(struct fid_domain *domain, const struct util_prov *util_pr
 int ofi_endpoint_close(struct util_ep *util_ep)
 {
 	if (util_ep->tx_cq) {
-		fid_list_remove_m(&util_ep->tx_cq->ep_list,
+		fid_list_remove(&util_ep->tx_cq->ep_list,
 				&util_ep->tx_cq->ep_list_lock,
 				&util_ep->ep_fid.fid);
 		ofi_atomic_dec32(&util_ep->tx_cq->ref);
 	}
 
 	if (util_ep->rx_cq) {
-		fid_list_remove_m(&util_ep->rx_cq->ep_list,
+		fid_list_remove(&util_ep->rx_cq->ep_list,
 				&util_ep->rx_cq->ep_list_lock,
 				&util_ep->ep_fid.fid);
 		ofi_atomic_dec32(&util_ep->rx_cq->ref);
 	}
 
 	if (util_ep->rx_cntr) {
-		fid_list_remove_m(&util_ep->rx_cntr->ep_list,
+		fid_list_remove(&util_ep->rx_cntr->ep_list,
 				&util_ep->rx_cntr->ep_list_lock,
 				&util_ep->ep_fid.fid);
 		ofi_atomic_dec32(&util_ep->rx_cntr->ref);
 	}
 
 	if (util_ep->tx_cntr) {
-		fid_list_remove_m(&util_ep->tx_cntr->ep_list,
+		fid_list_remove(&util_ep->tx_cntr->ep_list,
 				&util_ep->tx_cntr->ep_list_lock,
 				&util_ep->ep_fid.fid);
 		ofi_atomic_dec32(&util_ep->tx_cntr->ref);
 	}
 
 	if (util_ep->rd_cntr) {
-		fid_list_remove_m(&util_ep->rd_cntr->ep_list,
+		fid_list_remove(&util_ep->rd_cntr->ep_list,
 				&util_ep->rd_cntr->ep_list_lock,
 				&util_ep->ep_fid.fid);
 		ofi_atomic_dec32(&util_ep->rd_cntr->ref);
 	}
 
 	if (util_ep->wr_cntr) {
-		fid_list_remove_m(&util_ep->wr_cntr->ep_list,
+		fid_list_remove(&util_ep->wr_cntr->ep_list,
 				&util_ep->wr_cntr->ep_list_lock,
 				&util_ep->ep_fid.fid);
 		ofi_atomic_dec32(&util_ep->wr_cntr->ref);
 	}
 
 	if (util_ep->rem_rd_cntr) {
-		fid_list_remove_m(&util_ep->rem_rd_cntr->ep_list,
+		fid_list_remove(&util_ep->rem_rd_cntr->ep_list,
 				&util_ep->rem_rd_cntr->ep_list_lock,
 				&util_ep->ep_fid.fid);
 		ofi_atomic_dec32(&util_ep->rem_rd_cntr->ref);
 	}
 
 	if (util_ep->rem_wr_cntr) {
-		fid_list_remove_m(&util_ep->rem_wr_cntr->ep_list,
+		fid_list_remove(&util_ep->rem_wr_cntr->ep_list,
 				&util_ep->rem_wr_cntr->ep_list_lock,
 				&util_ep->ep_fid.fid);
 		ofi_atomic_dec32(&util_ep->rem_wr_cntr->ref);

--- a/prov/util/src/util_eq.c
+++ b/prov/util/src/util_eq.c
@@ -83,7 +83,7 @@ ssize_t ofi_eq_read(struct fid_eq *eq_fid, uint32_t *event,
 
 	eq = container_of(eq_fid, struct util_eq, eq_fid);
 
-	ofi_spin_lock(&eq->lock);
+	ofi_mutex_lock(&eq->lock);
 	if (slist_empty(&eq->list)) {
 		ret = -FI_EAGAIN;
 		goto out;
@@ -127,7 +127,7 @@ ssize_t ofi_eq_read(struct fid_eq *eq_fid, uint32_t *event,
 		free(entry);
 	}
 out:
-	ofi_spin_unlock(&eq->lock);
+	ofi_mutex_unlock(&eq->lock);
 	return ret;
 }
 
@@ -154,9 +154,9 @@ ssize_t ofi_eq_write(struct fid_eq *eq_fid, uint32_t event,
 	entry->err = !!(flags & UTIL_FLAG_ERROR);
 	memcpy(entry->data, buf, len);
 
-	ofi_spin_lock(&eq->lock);
+	ofi_mutex_lock(&eq->lock);
 	slist_insert_tail(&entry->entry, &eq->list);
-	ofi_spin_unlock(&eq->lock);
+	ofi_mutex_unlock(&eq->lock);
 
 	if (eq->wait)
 		eq->wait->signal(eq->wait);
@@ -243,7 +243,7 @@ int ofi_eq_cleanup(struct fid *fid)
 	}
 
 	free(eq->saved_err_data);
-	ofi_spin_destroy(&eq->lock);
+	ofi_mutex_destroy(&eq->lock);
 	ofi_atomic_dec32(&eq->fabric->ref);
 	return 0;
 }
@@ -289,7 +289,7 @@ static int util_eq_init(struct fid_fabric *fabric, struct util_eq *eq,
 
 	ofi_atomic_initialize32(&eq->ref, 0);
 	slist_init(&eq->list);
-	ofi_spin_init(&eq->lock);
+	ofi_mutex_init(&eq->lock);
 
 	switch (attr->wait_obj) {
 	case FI_WAIT_NONE:
@@ -344,7 +344,7 @@ void ofi_eq_remove_fid_events(struct util_eq *eq, fid_t fid)
 	struct util_event *event;
 	struct fi_eq_cm_entry *cm_entry;
 
-	ofi_spin_lock(&eq->lock);
+	ofi_mutex_lock(&eq->lock);
 	while((entry =
 	      slist_remove_first_match(&eq->list, ofi_eq_match_fid_event,
 				       fid))) {
@@ -361,7 +361,7 @@ void ofi_eq_remove_fid_events(struct util_eq *eq, fid_t fid)
 		}
 		free(event);
 	}
-	ofi_spin_unlock(&eq->lock);
+	ofi_mutex_unlock(&eq->lock);
 }
 
 static int util_verify_eq_attr(const struct fi_provider *prov,

--- a/prov/util/src/util_eq.c
+++ b/prov/util/src/util_eq.c
@@ -83,7 +83,7 @@ ssize_t ofi_eq_read(struct fid_eq *eq_fid, uint32_t *event,
 
 	eq = container_of(eq_fid, struct util_eq, eq_fid);
 
-	fastlock_acquire(&eq->lock);
+	ofi_spin_lock(&eq->lock);
 	if (slist_empty(&eq->list)) {
 		ret = -FI_EAGAIN;
 		goto out;
@@ -127,7 +127,7 @@ ssize_t ofi_eq_read(struct fid_eq *eq_fid, uint32_t *event,
 		free(entry);
 	}
 out:
-	fastlock_release(&eq->lock);
+	ofi_spin_unlock(&eq->lock);
 	return ret;
 }
 
@@ -154,9 +154,9 @@ ssize_t ofi_eq_write(struct fid_eq *eq_fid, uint32_t event,
 	entry->err = !!(flags & UTIL_FLAG_ERROR);
 	memcpy(entry->data, buf, len);
 
-	fastlock_acquire(&eq->lock);
+	ofi_spin_lock(&eq->lock);
 	slist_insert_tail(&entry->entry, &eq->list);
-	fastlock_release(&eq->lock);
+	ofi_spin_unlock(&eq->lock);
 
 	if (eq->wait)
 		eq->wait->signal(eq->wait);
@@ -243,7 +243,7 @@ int ofi_eq_cleanup(struct fid *fid)
 	}
 
 	free(eq->saved_err_data);
-	fastlock_destroy(&eq->lock);
+	ofi_spin_destroy(&eq->lock);
 	ofi_atomic_dec32(&eq->fabric->ref);
 	return 0;
 }
@@ -289,7 +289,7 @@ static int util_eq_init(struct fid_fabric *fabric, struct util_eq *eq,
 
 	ofi_atomic_initialize32(&eq->ref, 0);
 	slist_init(&eq->list);
-	fastlock_init(&eq->lock);
+	ofi_spin_init(&eq->lock);
 
 	switch (attr->wait_obj) {
 	case FI_WAIT_NONE:
@@ -344,7 +344,7 @@ void ofi_eq_remove_fid_events(struct util_eq *eq, fid_t fid)
 	struct util_event *event;
 	struct fi_eq_cm_entry *cm_entry;
 
-	fastlock_acquire(&eq->lock);
+	ofi_spin_lock(&eq->lock);
 	while((entry =
 	      slist_remove_first_match(&eq->list, ofi_eq_match_fid_event,
 				       fid))) {
@@ -361,7 +361,7 @@ void ofi_eq_remove_fid_events(struct util_eq *eq, fid_t fid)
 		}
 		free(event);
 	}
-	fastlock_release(&eq->lock);
+	ofi_spin_unlock(&eq->lock);
 }
 
 static int util_verify_eq_attr(const struct fi_provider *prov,

--- a/prov/util/src/util_fabric.c
+++ b/prov/util/src/util_fabric.c
@@ -43,7 +43,7 @@ int ofi_fabric_close(struct util_fabric *fabric)
 
 	ofi_fabric_remove(fabric);
 	free((char *)fabric->name);
-	ofi_spin_destroy(&fabric->lock);
+	ofi_mutex_destroy(&fabric->lock);
 	return 0;
 }
 
@@ -61,7 +61,7 @@ int ofi_fabric_init(const struct fi_provider *prov,
 	fabric->prov = prov;
 	ofi_atomic_initialize32(&fabric->ref, 0);
 	dlist_init(&fabric->domain_list);
-	ofi_spin_init(&fabric->lock);
+	ofi_mutex_init(&fabric->lock);
 	fabric->name = strdup(user_attr->name);
 	if (!fabric->name)
 		return -FI_ENOMEM;

--- a/prov/util/src/util_fabric.c
+++ b/prov/util/src/util_fabric.c
@@ -43,7 +43,7 @@ int ofi_fabric_close(struct util_fabric *fabric)
 
 	ofi_fabric_remove(fabric);
 	free((char *)fabric->name);
-	fastlock_destroy(&fabric->lock);
+	ofi_spin_destroy(&fabric->lock);
 	return 0;
 }
 
@@ -61,7 +61,7 @@ int ofi_fabric_init(const struct fi_provider *prov,
 	fabric->prov = prov;
 	ofi_atomic_initialize32(&fabric->ref, 0);
 	dlist_init(&fabric->domain_list);
-	fastlock_init(&fabric->lock);
+	ofi_spin_init(&fabric->lock);
 	fabric->name = strdup(user_attr->name);
 	if (!fabric->name)
 		return -FI_ENOMEM;

--- a/prov/util/src/util_main.c
+++ b/prov/util/src/util_main.c
@@ -214,7 +214,7 @@ int util_getinfo(const struct util_prov *util_prov, uint32_t version,
 			FI_DBG(prov, FI_LOG_CORE, "Found opened fabric\n");
 			(*info)->fabric_attr->fabric = &fabric->fabric_fid;
 
-			ofi_spin_lock(&fabric->lock);
+			ofi_mutex_lock(&fabric->lock);
 			item = dlist_find_first_match(&fabric->domain_list,
 						      util_find_domain, *info);
 			if (item) {
@@ -225,7 +225,7 @@ int util_getinfo(const struct util_prov *util_prov, uint32_t version,
 				(*info)->domain_attr->domain =
 						&domain->domain_fid;
 			}
-			ofi_spin_unlock(&fabric->lock);
+			ofi_mutex_unlock(&fabric->lock);
 
 		}
 		pthread_mutex_unlock(&common_locks.util_fabric_lock);

--- a/prov/util/src/util_main.c
+++ b/prov/util/src/util_main.c
@@ -72,14 +72,14 @@ static int ofi_fid_match(struct dlist_entry *entry, const void *fid)
 	return (item->fid == fid);
 }
 
-int fid_list_insert(struct dlist_entry *fid_list, fastlock_t *lock,
+int fid_list_insert(struct dlist_entry *fid_list, ofi_spin_t *lock,
 		    struct fid *fid)
 {
 	int ret = 0;
 	struct dlist_entry *entry;
 	struct fid_list_entry *item;
 
-	fastlock_acquire(lock);
+	ofi_spin_lock(lock);
 	entry = dlist_find_first_match(fid_list, ofi_fid_match, fid);
 	if (entry)
 		goto out;
@@ -93,19 +93,19 @@ int fid_list_insert(struct dlist_entry *fid_list, fastlock_t *lock,
 	item->fid = fid;
 	dlist_insert_tail(&item->entry, fid_list);
 out:
-	fastlock_release(lock);
+	ofi_spin_unlock(lock);
 	return ret;
 }
 
-void fid_list_remove(struct dlist_entry *fid_list, fastlock_t *lock,
+void fid_list_remove(struct dlist_entry *fid_list, ofi_spin_t *lock,
 		     struct fid *fid)
 {
 	struct fid_list_entry *item;
 	struct dlist_entry *entry;
 
-	fastlock_acquire(lock);
+	ofi_spin_lock(lock);
 	entry = dlist_remove_first_match(fid_list, ofi_fid_match, fid);
-	fastlock_release(lock);
+	ofi_spin_unlock(lock);
 
 	if (entry) {
 		item = container_of(entry, struct fid_list_entry, entry);
@@ -173,7 +173,7 @@ int util_getinfo(const struct util_prov *util_prov, uint32_t version,
 			FI_DBG(prov, FI_LOG_CORE, "Found opened fabric\n");
 			(*info)->fabric_attr->fabric = &fabric->fabric_fid;
 
-			fastlock_acquire(&fabric->lock);
+			ofi_spin_lock(&fabric->lock);
 			item = dlist_find_first_match(&fabric->domain_list,
 						      util_find_domain, *info);
 			if (item) {
@@ -184,7 +184,7 @@ int util_getinfo(const struct util_prov *util_prov, uint32_t version,
 				(*info)->domain_attr->domain =
 						&domain->domain_fid;
 			}
-			fastlock_release(&fabric->lock);
+			ofi_spin_unlock(&fabric->lock);
 
 		}
 		pthread_mutex_unlock(&common_locks.util_fabric_lock);

--- a/prov/util/src/util_main.c
+++ b/prov/util/src/util_main.c
@@ -72,48 +72,7 @@ static int ofi_fid_match(struct dlist_entry *entry, const void *fid)
 	return (item->fid == fid);
 }
 
-int fid_list_insert(struct dlist_entry *fid_list, ofi_spin_t *lock,
-		    struct fid *fid)
-{
-	int ret = 0;
-	struct dlist_entry *entry;
-	struct fid_list_entry *item;
-
-	ofi_spin_lock(lock);
-	entry = dlist_find_first_match(fid_list, ofi_fid_match, fid);
-	if (entry)
-		goto out;
-
-	item = calloc(1, sizeof(*item));
-	if (!item) {
-		ret = -FI_ENOMEM;
-		goto out;
-	}
-
-	item->fid = fid;
-	dlist_insert_tail(&item->entry, fid_list);
-out:
-	ofi_spin_unlock(lock);
-	return ret;
-}
-
-void fid_list_remove(struct dlist_entry *fid_list, ofi_spin_t *lock,
-		     struct fid *fid)
-{
-	struct fid_list_entry *item;
-	struct dlist_entry *entry;
-
-	ofi_spin_lock(lock);
-	entry = dlist_remove_first_match(fid_list, ofi_fid_match, fid);
-	ofi_spin_unlock(lock);
-
-	if (entry) {
-		item = container_of(entry, struct fid_list_entry, entry);
-		free(item);
-	}
-}
-
-int fid_list_insert_m(struct dlist_entry *fid_list, ofi_mutex_t *lock,
+int fid_list_insert(struct dlist_entry *fid_list, ofi_mutex_t *lock,
 		    struct fid *fid)
 {
 	int ret = 0;
@@ -138,7 +97,7 @@ out:
 	return ret;
 }
 
-void fid_list_remove_m(struct dlist_entry *fid_list, ofi_mutex_t *lock,
+void fid_list_remove(struct dlist_entry *fid_list, ofi_mutex_t *lock,
 		     struct fid *fid)
 {
 	struct fid_list_entry *item;

--- a/prov/util/src/util_mr_map.c
+++ b/prov/util/src/util_mr_map.c
@@ -200,9 +200,9 @@ int ofi_mr_close(struct fid *fid)
 
 	mr = container_of(fid, struct ofi_mr, mr_fid.fid);
 
-	ofi_spin_lock(&mr->domain->lock);
+	ofi_mutex_lock(&mr->domain->lock);
 	ret = ofi_mr_map_remove(&mr->domain->mr_map, mr->key);
-	ofi_spin_unlock(&mr->domain->lock);
+	ofi_mutex_unlock(&mr->domain->lock);
 	if (ret)
 		return ret;
 
@@ -277,7 +277,7 @@ int ofi_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 		return -FI_ENOSYS;
 	}
 
-	ofi_spin_lock(&domain->lock);
+	ofi_mutex_lock(&domain->lock);
 
 	mr->mr_fid.fid.fclass = FI_CLASS_MR;
 	mr->mr_fid.fid.context = attr->context;
@@ -300,7 +300,7 @@ int ofi_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	ofi_atomic_inc32(&domain->ref);
 
 out:
-	ofi_spin_unlock(&domain->lock);
+	ofi_mutex_unlock(&domain->lock);
 	return ret;
 }
 
@@ -342,9 +342,9 @@ int ofi_mr_verify(struct ofi_mr_map *map, ssize_t len,
 	int ret;
 
 	domain = container_of(map, struct util_domain, mr_map);
-	ofi_spin_lock(&domain->lock);
+	ofi_mutex_lock(&domain->lock);
 	ret = ofi_mr_map_verify(&domain->mr_map, addr, len,
 				key, access, NULL);
-	ofi_spin_unlock(&domain->lock);
+	ofi_mutex_unlock(&domain->lock);
 	return ret;
 }

--- a/prov/util/src/util_mr_map.c
+++ b/prov/util/src/util_mr_map.c
@@ -200,9 +200,9 @@ int ofi_mr_close(struct fid *fid)
 
 	mr = container_of(fid, struct ofi_mr, mr_fid.fid);
 
-	fastlock_acquire(&mr->domain->lock);
+	ofi_spin_lock(&mr->domain->lock);
 	ret = ofi_mr_map_remove(&mr->domain->mr_map, mr->key);
-	fastlock_release(&mr->domain->lock);
+	ofi_spin_unlock(&mr->domain->lock);
 	if (ret)
 		return ret;
 
@@ -277,7 +277,7 @@ int ofi_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 		return -FI_ENOSYS;
 	}
 
-	fastlock_acquire(&domain->lock);
+	ofi_spin_lock(&domain->lock);
 
 	mr->mr_fid.fid.fclass = FI_CLASS_MR;
 	mr->mr_fid.fid.context = attr->context;
@@ -300,7 +300,7 @@ int ofi_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	ofi_atomic_inc32(&domain->ref);
 
 out:
-	fastlock_release(&domain->lock);
+	ofi_spin_unlock(&domain->lock);
 	return ret;
 }
 
@@ -342,9 +342,9 @@ int ofi_mr_verify(struct ofi_mr_map *map, ssize_t len,
 	int ret;
 
 	domain = container_of(map, struct util_domain, mr_map);
-	fastlock_acquire(&domain->lock);
+	ofi_spin_lock(&domain->lock);
 	ret = ofi_mr_map_verify(&domain->mr_map, addr, len,
 				key, access, NULL);
-	fastlock_release(&domain->lock);
+	ofi_spin_unlock(&domain->lock);
 	return ret;
 }

--- a/prov/util/src/util_poll.c
+++ b/prov/util/src/util_poll.c
@@ -85,7 +85,7 @@ static int util_poll_run(struct fid_poll *poll_fid, void **context, int count)
 
 	pollset = container_of(poll_fid, struct util_poll, poll_fid.fid);
 
-	fastlock_acquire(&pollset->lock);
+	ofi_spin_lock(&pollset->lock);
 	dlist_foreach(&pollset->fid_list, item) {
 		fid_entry = container_of(item, struct fid_list_entry, entry);
 		switch (fid_entry->fid->fclass) {
@@ -127,7 +127,7 @@ static int util_poll_run(struct fid_poll *poll_fid, void **context, int count)
 		else if (ret < 0 && ret != -FI_EAGAIN)
 			err = (int) ret;
 	}
-	fastlock_release(&pollset->lock);
+	ofi_spin_unlock(&pollset->lock);
 	return i ? i : err;
 }
 
@@ -142,7 +142,7 @@ static int util_poll_close(struct fid *fid)
 	if (pollset->domain)
 		ofi_atomic_dec32(&pollset->domain->ref);
 
-	fastlock_destroy(&pollset->lock);
+	ofi_spin_destroy(&pollset->lock);
 
 	free(pollset);
 	return 0;
@@ -191,7 +191,7 @@ int fi_poll_create_(const struct fi_provider *prov, struct fid_domain *domain,
 	pollset->prov = prov;
 	ofi_atomic_initialize32(&pollset->ref, 0);
 	dlist_init(&pollset->fid_list);
-	fastlock_init(&pollset->lock);
+	ofi_spin_init(&pollset->lock);
 
 	pollset->poll_fid.fid.fclass = FI_CLASS_POLL;
 	pollset->poll_fid.fid.ops = &util_poll_fi_ops;

--- a/prov/util/src/util_poll.c
+++ b/prov/util/src/util_poll.c
@@ -58,7 +58,7 @@ static int util_poll_add(struct fid_poll *poll_fid, struct fid *event_fid,
 		return -FI_EINVAL;
 	}
 
-	return fid_list_insert_m(&pollset->fid_list, &pollset->lock, event_fid);
+	return fid_list_insert(&pollset->fid_list, &pollset->lock, event_fid);
 }
 
 static int util_poll_del(struct fid_poll *poll_fid, struct fid *event_fid,
@@ -67,7 +67,7 @@ static int util_poll_del(struct fid_poll *poll_fid, struct fid *event_fid,
 	struct util_poll *pollset;
 
 	pollset = container_of(poll_fid, struct util_poll, poll_fid);
-	fid_list_remove_m(&pollset->fid_list, &pollset->lock, event_fid);
+	fid_list_remove(&pollset->fid_list, &pollset->lock, event_fid);
 	return 0;
 }
 

--- a/prov/util/src/util_poll.c
+++ b/prov/util/src/util_poll.c
@@ -58,7 +58,7 @@ static int util_poll_add(struct fid_poll *poll_fid, struct fid *event_fid,
 		return -FI_EINVAL;
 	}
 
-	return fid_list_insert(&pollset->fid_list, &pollset->lock, event_fid);
+	return fid_list_insert_m(&pollset->fid_list, &pollset->lock, event_fid);
 }
 
 static int util_poll_del(struct fid_poll *poll_fid, struct fid *event_fid,
@@ -67,7 +67,7 @@ static int util_poll_del(struct fid_poll *poll_fid, struct fid *event_fid,
 	struct util_poll *pollset;
 
 	pollset = container_of(poll_fid, struct util_poll, poll_fid);
-	fid_list_remove(&pollset->fid_list, &pollset->lock, event_fid);
+	fid_list_remove_m(&pollset->fid_list, &pollset->lock, event_fid);
 	return 0;
 }
 
@@ -85,7 +85,7 @@ static int util_poll_run(struct fid_poll *poll_fid, void **context, int count)
 
 	pollset = container_of(poll_fid, struct util_poll, poll_fid.fid);
 
-	ofi_spin_lock(&pollset->lock);
+	ofi_mutex_lock(&pollset->lock);
 	dlist_foreach(&pollset->fid_list, item) {
 		fid_entry = container_of(item, struct fid_list_entry, entry);
 		switch (fid_entry->fid->fclass) {
@@ -127,7 +127,7 @@ static int util_poll_run(struct fid_poll *poll_fid, void **context, int count)
 		else if (ret < 0 && ret != -FI_EAGAIN)
 			err = (int) ret;
 	}
-	ofi_spin_unlock(&pollset->lock);
+	ofi_mutex_unlock(&pollset->lock);
 	return i ? i : err;
 }
 
@@ -142,7 +142,7 @@ static int util_poll_close(struct fid *fid)
 	if (pollset->domain)
 		ofi_atomic_dec32(&pollset->domain->ref);
 
-	ofi_spin_destroy(&pollset->lock);
+	ofi_mutex_destroy(&pollset->lock);
 
 	free(pollset);
 	return 0;
@@ -191,7 +191,7 @@ int fi_poll_create_(const struct fi_provider *prov, struct fid_domain *domain,
 	pollset->prov = prov;
 	ofi_atomic_initialize32(&pollset->ref, 0);
 	dlist_init(&pollset->fid_list);
-	ofi_spin_init(&pollset->lock);
+	ofi_mutex_init(&pollset->lock);
 
 	pollset->poll_fid.fid.fclass = FI_CLASS_POLL;
 	pollset->poll_fid.fid.ops = &util_poll_fi_ops;

--- a/prov/util/src/util_wait.c
+++ b/prov/util/src/util_wait.c
@@ -129,7 +129,7 @@ int fi_wait_cleanup(struct util_wait *wait)
 		free(fid_entry);
 	}
 
-	ofi_spin_destroy(&wait->lock);
+	ofi_mutex_destroy(&wait->lock);
 	ofi_atomic_dec32(&wait->fabric->ref);
 	return 0;
 }
@@ -166,7 +166,7 @@ int ofi_wait_init(struct util_fabric *fabric, struct fi_wait_attr *attr,
 		return ret;
 
 	wait->pollset = container_of(poll_fid, struct util_poll, poll_fid);
-	ofi_spin_init(&wait->lock);
+	ofi_mutex_init(&wait->lock);
 	dlist_init(&wait->fid_list);
 	wait->fabric = fabric;
 	ofi_atomic_inc32(&fabric->ref);
@@ -213,7 +213,7 @@ int ofi_wait_del_fd(struct util_wait *wait, int fd)
 	int ret = 0;
 
 	wait_fd = container_of(wait, struct util_wait_fd, util_wait);
-	ofi_spin_lock(&wait->lock);
+	ofi_mutex_lock(&wait->lock);
 	entry = dlist_find_first_match(&wait_fd->fd_list, ofi_wait_match_fd, &fd);
 	if (!entry) {
 		FI_INFO(wait->prov, FI_LOG_FABRIC,
@@ -231,7 +231,7 @@ int ofi_wait_del_fd(struct util_wait *wait, int fd)
 	ofi_wait_fdset_del(wait_fd, fd_entry->fd);
 	free(fd_entry);
 out:
-	ofi_spin_unlock(&wait->lock);
+	ofi_mutex_unlock(&wait->lock);
 	return ret;
 }
 
@@ -244,7 +244,7 @@ int ofi_wait_add_fd(struct util_wait *wait, int fd, uint32_t events,
 	int ret = 0;
 
 	wait_fd = container_of(wait, struct util_wait_fd, util_wait);
-	ofi_spin_lock(&wait->lock);
+	ofi_mutex_lock(&wait->lock);
 	entry = dlist_find_first_match(&wait_fd->fd_list, ofi_wait_match_fd, &fd);
 	if (entry) {
 		FI_DBG(wait->prov, FI_LOG_EP_CTRL,
@@ -276,7 +276,7 @@ int ofi_wait_add_fd(struct util_wait *wait, int fd, uint32_t events,
 
 	dlist_insert_tail(&fd_entry->entry, &wait_fd->fd_list);
 out:
-	ofi_spin_unlock(&wait->lock);
+	ofi_mutex_unlock(&wait->lock);
 	return ret;
 }
 
@@ -352,7 +352,7 @@ static int util_wait_fd_try(struct util_wait *wait)
 
 	wait_fd = container_of(wait, struct util_wait_fd, util_wait);
 	fd_signal_reset(&wait_fd->signal);
-	ofi_spin_lock(&wait->lock);
+	ofi_mutex_lock(&wait->lock);
 	dlist_foreach_container(&wait_fd->fd_list, struct ofi_wait_fd_entry,
 				fd_entry, entry) {
 		ret = fd_entry->wait_try(fd_entry->arg);
@@ -373,12 +373,12 @@ static int util_wait_fd_try(struct util_wait *wait)
 			goto release;
 	}
 
-	ofi_spin_unlock(&wait->lock);
+	ofi_mutex_unlock(&wait->lock);
 	ret = fi_poll(&wait->pollset->poll_fid, &context, 1);
 	return (ret > 0) ? -FI_EAGAIN : (ret == -FI_EAGAIN) ? FI_SUCCESS : ret;
 
 release:
-	ofi_spin_unlock(&wait->lock);
+	ofi_mutex_unlock(&wait->lock);
 	return ret;
 }
 
@@ -438,7 +438,7 @@ static int util_wait_fd_control(struct fid *fid, int command, void *arg)
 		}
 
 		pollfd = arg;
-		ofi_spin_lock(&wait->util_wait.lock);
+		ofi_mutex_lock(&wait->util_wait.lock);
 		if (pollfd->nfds >= wait->pollfds->nfds) {
 			memcpy(pollfd->fd, &wait->pollfds->fds[0],
 			       wait->pollfds->nfds * sizeof(*wait->pollfds->fds));
@@ -448,7 +448,7 @@ static int util_wait_fd_control(struct fid *fid, int command, void *arg)
 		}
 		pollfd->change_index = wait->change_index;
 		pollfd->nfds = wait->pollfds->nfds;
-		ofi_spin_unlock(&wait->util_wait.lock);
+		ofi_mutex_unlock(&wait->util_wait.lock);
 		break;
 	case FI_GETWAITOBJ:
 		*(enum fi_wait_obj *) arg = wait->util_wait.wait_obj;
@@ -471,14 +471,14 @@ static int util_wait_fd_close(struct fid *fid)
 
 	wait = container_of(fid, struct util_wait_fd, util_wait.wait_fid.fid);
 
-	ofi_spin_lock(&wait->util_wait.lock);
+	ofi_mutex_lock(&wait->util_wait.lock);
 	while (!dlist_empty(&wait->fd_list)) {
 		dlist_pop_front(&wait->fd_list, struct ofi_wait_fd_entry,
 				fd_entry, entry);
 		ofi_wait_fdset_del(wait, fd_entry->fd);
 		free(fd_entry);
 	}
-	ofi_spin_unlock(&wait->util_wait.lock);
+	ofi_mutex_unlock(&wait->util_wait.lock);
 
 	ret = fi_wait_cleanup(&wait->util_wait);
 	if (ret)
@@ -595,9 +595,9 @@ static void util_wait_yield_signal(struct util_wait *util_wait)
 
 	wait_yield = container_of(util_wait, struct util_wait_yield, util_wait);
 
-	ofi_spin_lock(&wait_yield->signal_lock);
+	ofi_mutex_lock(&wait_yield->signal_lock);
 	wait_yield->signal = 1;
-	ofi_spin_unlock(&wait_yield->signal_lock);
+	ofi_mutex_unlock(&wait_yield->signal_lock);
 }
 
 static int util_wait_yield_run(struct fid_wait *wait_fid, int timeout)
@@ -608,23 +608,23 @@ static int util_wait_yield_run(struct fid_wait *wait_fid, int timeout)
 
 	wait = container_of(wait_fid, struct util_wait_yield, util_wait.wait_fid);
 	while (!wait->signal) {
-		ofi_spin_lock(&wait->util_wait.lock);
+		ofi_mutex_lock(&wait->util_wait.lock);
 		dlist_foreach_container(&wait->util_wait.fid_list,
 					struct ofi_wait_fid_entry,
 					fid_entry, entry) {
 			ret = fid_entry->wait_try(fid_entry->fid);
 			if (ret) {
-				ofi_spin_unlock(&wait->util_wait.lock);
+				ofi_mutex_unlock(&wait->util_wait.lock);
 				return ret;
 			}
 		}
-		ofi_spin_unlock(&wait->util_wait.lock);
+		ofi_mutex_unlock(&wait->util_wait.lock);
 		sched_yield();
 	}
 
-	ofi_spin_lock(&wait->signal_lock);
+	ofi_mutex_lock(&wait->signal_lock);
 	wait->signal = 0;
-	ofi_spin_unlock(&wait->signal_lock);
+	ofi_mutex_unlock(&wait->signal_lock);
 
 	return FI_SUCCESS;
 }
@@ -639,7 +639,7 @@ static int util_wait_yield_close(struct fid *fid)
 	if (ret)
 		return ret;
 
-	ofi_spin_destroy(&wait->signal_lock);
+	ofi_mutex_destroy(&wait->signal_lock);
 	free(wait);
 	return 0;
 }
@@ -707,7 +707,7 @@ int ofi_wait_yield_open(struct fid_fabric *fabric_fid, struct fi_wait_attr *attr
 	wait->util_wait.wait_fid.fid.ops = &util_wait_yield_fi_ops;
 	wait->util_wait.wait_fid.ops = &util_wait_yield_ops;
 
-	ofi_spin_init(&wait->signal_lock);
+	ofi_mutex_init(&wait->signal_lock);
 
 	*waitset = &wait->util_wait.wait_fid;
 
@@ -731,7 +731,7 @@ int ofi_wait_del_fid(struct util_wait *wait, fid_t fid)
 	size_t i;
 	int ret = 0;
 
-	ofi_spin_lock(&wait->lock);
+	ofi_mutex_lock(&wait->lock);
 	entry = dlist_find_first_match(&wait->fid_list,
 				       ofi_wait_match_fid, fid);
 	if (!entry) {
@@ -761,7 +761,7 @@ int ofi_wait_del_fid(struct util_wait *wait, fid_t fid)
 	free(fid_entry->pollfds.fd);
 	free(fid_entry);
 out:
-	ofi_spin_unlock(&wait->lock);
+	ofi_mutex_unlock(&wait->lock);
 	return ret;
 }
 
@@ -840,7 +840,7 @@ int ofi_wait_add_fid(struct util_wait *wait, fid_t fid, uint32_t events,
 	struct dlist_entry *entry;
 	int ret = 0;
 
-	ofi_spin_lock(&wait->lock);
+	ofi_mutex_lock(&wait->lock);
 	entry = dlist_find_first_match(&wait->fid_list,
 				       ofi_wait_match_fid, fid);
 	if (entry) {
@@ -872,6 +872,6 @@ int ofi_wait_add_fid(struct util_wait *wait, fid_t fid, uint32_t events,
 	}
 	dlist_insert_tail(&fid_entry->entry, &wait->fid_list);
 out:
-	ofi_spin_unlock(&wait->lock);
+	ofi_mutex_unlock(&wait->lock);
 	return ret;
 }

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -284,7 +284,7 @@ typedef int (*vrb_trywait_func)(struct fid *fid);
 struct vrb_eq {
 	struct fid_eq		eq_fid;
 	struct vrb_fabric	*fab;
-	ofi_spin_t		lock;
+	ofi_mutex_t		lock;
 	struct dlistfd_head	list_head;
 	struct rdma_event_channel *channel;
 	uint64_t		flags;
@@ -381,9 +381,9 @@ struct vrb_domain {
 		 * physical XRC INI connection to the associated node. The
 		 * map and XRC INI connection object state information are
 		 * protected via the ini_lock. */
-		ofi_spin_t		ini_lock;
-		ofi_spin_lock_t	lock_acquire;
-		ofi_spin_unlock_t	lock_release;
+		ofi_mutex_t		ini_lock;
+		ofi_mutex_lock_t	lock_acquire;
+		ofi_mutex_unlock_t	lock_release;
 		struct ofi_rbmap	*ini_conn_rbmap;
 	} xrc;
 
@@ -417,7 +417,7 @@ struct vrb_cq {
 
 	struct {
 		/* The list of XRC SRQ contexts associated with this CQ */
-		ofi_spin_t		srq_list_lock;
+		ofi_mutex_t		srq_list_lock;
 		struct dlist_entry	srq_list;
 	} xrc;
 
@@ -468,12 +468,12 @@ struct vrb_srq_ep {
 	struct ibv_srq		*srq;
 	struct vrb_domain	*domain;
 	struct ofi_bufpool	*ctx_pool;
-	ofi_spin_t		ctx_lock;
+	ofi_mutex_t		ctx_lock;
 
 	/* For XRC SRQ only */
 	struct {
 		/* XRC SRQ is not created until endpoint enable */
-		ofi_spin_t		prepost_lock;
+		ofi_mutex_t		prepost_lock;
 		struct slist		prepost_list;
 		uint32_t		max_recv_wr;
 		uint32_t		max_sge;

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -284,7 +284,7 @@ typedef int (*vrb_trywait_func)(struct fid *fid);
 struct vrb_eq {
 	struct fid_eq		eq_fid;
 	struct vrb_fabric	*fab;
-	fastlock_t		lock;
+	ofi_spin_t		lock;
 	struct dlistfd_head	list_head;
 	struct rdma_event_channel *channel;
 	uint64_t		flags;
@@ -381,9 +381,9 @@ struct vrb_domain {
 		 * physical XRC INI connection to the associated node. The
 		 * map and XRC INI connection object state information are
 		 * protected via the ini_lock. */
-		fastlock_t		ini_lock;
-		ofi_fastlock_acquire_t	lock_acquire;
-		ofi_fastlock_release_t	lock_release;
+		ofi_spin_t		ini_lock;
+		ofi_spin_lock_t	lock_acquire;
+		ofi_spin_unlock_t	lock_release;
 		struct ofi_rbmap	*ini_conn_rbmap;
 	} xrc;
 
@@ -417,7 +417,7 @@ struct vrb_cq {
 
 	struct {
 		/* The list of XRC SRQ contexts associated with this CQ */
-		fastlock_t		srq_list_lock;
+		ofi_spin_t		srq_list_lock;
 		struct dlist_entry	srq_list;
 	} xrc;
 
@@ -468,12 +468,12 @@ struct vrb_srq_ep {
 	struct ibv_srq		*srq;
 	struct vrb_domain	*domain;
 	struct ofi_bufpool	*ctx_pool;
-	fastlock_t		ctx_lock;
+	ofi_spin_t		ctx_lock;
 
 	/* For XRC SRQ only */
 	struct {
 		/* XRC SRQ is not created until endpoint enable */
-		fastlock_t		prepost_lock;
+		ofi_spin_t		prepost_lock;
 		struct slist		prepost_list;
 		uint32_t		max_recv_wr;
 		uint32_t		max_sge;

--- a/prov/verbs/src/verbs_cm.c
+++ b/prov/verbs/src/verbs_cm.c
@@ -309,7 +309,7 @@ vrb_msg_ep_reject(struct fid_pep *pep, fid_t handle,
 	cm_hdr = alloca(sizeof(*cm_hdr) + paramlen);
 	vrb_msg_ep_prepare_cm_data(param, paramlen, cm_hdr);
 
-	ofi_spin_lock(&_pep->eq->lock);
+	ofi_mutex_lock(&_pep->eq->lock);
 	if (connreq->is_xrc) {
 		ret = vrb_msg_xrc_ep_reject(connreq, cm_hdr,
 				(uint8_t)(sizeof(*cm_hdr) + paramlen));
@@ -319,7 +319,7 @@ vrb_msg_ep_reject(struct fid_pep *pep, fid_t handle,
 	} else {
 		ret = -FI_EBUSY;
 	}
-	ofi_spin_unlock(&_pep->eq->lock);
+	ofi_mutex_unlock(&_pep->eq->lock);
 
 	if (ret)
 		VRB_WARN_ERR(FI_LOG_EP_CTRL, "rdma_reject", ret);
@@ -413,9 +413,9 @@ vrb_msg_xrc_ep_connect(struct fid_ep *ep, const void *addr,
 	}
 	xrc_ep->conn_setup->conn_tag = VERBS_CONN_TAG_INVALID;
 
-	ofi_spin_lock(&xrc_ep->base_ep.eq->lock);
+	ofi_mutex_lock(&xrc_ep->base_ep.eq->lock);
 	ret = vrb_connect_xrc(xrc_ep, NULL, 0, adjusted_param, paramlen);
-	ofi_spin_unlock(&xrc_ep->base_ep.eq->lock);
+	ofi_mutex_unlock(&xrc_ep->base_ep.eq->lock);
 
 	free(adjusted_param);
 	free(cm_hdr);
@@ -445,9 +445,9 @@ vrb_msg_xrc_ep_accept(struct fid_ep *ep, const void *param, size_t paramlen)
 	if (ret)
 		return ret;
 
-	ofi_spin_lock(&xrc_ep->base_ep.eq->lock);
+	ofi_mutex_lock(&xrc_ep->base_ep.eq->lock);
 	ret = vrb_accept_xrc(xrc_ep, 0, adjusted_param, paramlen);
-	ofi_spin_unlock(&xrc_ep->base_ep.eq->lock);
+	ofi_mutex_unlock(&xrc_ep->base_ep.eq->lock);
 
 	free(adjusted_param);
 	return ret;

--- a/prov/verbs/src/verbs_cm.c
+++ b/prov/verbs/src/verbs_cm.c
@@ -309,7 +309,7 @@ vrb_msg_ep_reject(struct fid_pep *pep, fid_t handle,
 	cm_hdr = alloca(sizeof(*cm_hdr) + paramlen);
 	vrb_msg_ep_prepare_cm_data(param, paramlen, cm_hdr);
 
-	fastlock_acquire(&_pep->eq->lock);
+	ofi_spin_lock(&_pep->eq->lock);
 	if (connreq->is_xrc) {
 		ret = vrb_msg_xrc_ep_reject(connreq, cm_hdr,
 				(uint8_t)(sizeof(*cm_hdr) + paramlen));
@@ -319,7 +319,7 @@ vrb_msg_ep_reject(struct fid_pep *pep, fid_t handle,
 	} else {
 		ret = -FI_EBUSY;
 	}
-	fastlock_release(&_pep->eq->lock);
+	ofi_spin_unlock(&_pep->eq->lock);
 
 	if (ret)
 		VRB_WARN_ERR(FI_LOG_EP_CTRL, "rdma_reject", ret);
@@ -413,9 +413,9 @@ vrb_msg_xrc_ep_connect(struct fid_ep *ep, const void *addr,
 	}
 	xrc_ep->conn_setup->conn_tag = VERBS_CONN_TAG_INVALID;
 
-	fastlock_acquire(&xrc_ep->base_ep.eq->lock);
+	ofi_spin_lock(&xrc_ep->base_ep.eq->lock);
 	ret = vrb_connect_xrc(xrc_ep, NULL, 0, adjusted_param, paramlen);
-	fastlock_release(&xrc_ep->base_ep.eq->lock);
+	ofi_spin_unlock(&xrc_ep->base_ep.eq->lock);
 
 	free(adjusted_param);
 	free(cm_hdr);
@@ -445,9 +445,9 @@ vrb_msg_xrc_ep_accept(struct fid_ep *ep, const void *param, size_t paramlen)
 	if (ret)
 		return ret;
 
-	fastlock_acquire(&xrc_ep->base_ep.eq->lock);
+	ofi_spin_lock(&xrc_ep->base_ep.eq->lock);
 	ret = vrb_accept_xrc(xrc_ep, 0, adjusted_param, paramlen);
-	fastlock_release(&xrc_ep->base_ep.eq->lock);
+	ofi_spin_unlock(&xrc_ep->base_ep.eq->lock);
 
 	free(adjusted_param);
 	return ret;

--- a/prov/verbs/src/verbs_cm_xrc.c
+++ b/prov/verbs/src/verbs_cm_xrc.c
@@ -167,7 +167,7 @@ static void vrb_log_ep_conn(struct vrb_xrc_ep *ep, char *desc)
 
 void vrb_free_xrc_conn_setup(struct vrb_xrc_ep *ep, int disconnect)
 {
-	assert(ofi_spin_held(&ep->base_ep.eq->lock));
+	assert(ofi_mutex_held(&ep->base_ep.eq->lock));
 	assert(ep->conn_setup);
 
 	/* If a disconnect is requested then the XRC bidirectional connection
@@ -207,7 +207,7 @@ int vrb_connect_xrc(struct vrb_xrc_ep *ep, struct sockaddr *addr,
 	struct vrb_domain *domain = vrb_ep_to_domain(&ep->base_ep);
 	int ret;
 
-	assert(ofi_spin_held(&ep->base_ep.eq->lock));
+	assert(ofi_mutex_held(&ep->base_ep.eq->lock));
 	assert(!ep->base_ep.id && !ep->base_ep.ibv_qp && !ep->ini_conn);
 
 	domain->xrc.lock_acquire(&domain->xrc.ini_lock);
@@ -235,7 +235,7 @@ void vrb_ep_ini_conn_done(struct vrb_xrc_ep *ep, uint32_t tgt_qpn)
 {
 	struct vrb_domain *domain = vrb_ep_to_domain(&ep->base_ep);
 
-	assert(ofi_spin_held(&ep->base_ep.eq->lock));
+	assert(ofi_mutex_held(&ep->base_ep.eq->lock));
 	assert(ep->base_ep.id && ep->ini_conn);
 
 	domain->xrc.lock_acquire(&domain->xrc.ini_lock);
@@ -263,7 +263,7 @@ void vrb_ep_ini_conn_done(struct vrb_xrc_ep *ep, uint32_t tgt_qpn)
 
 void vrb_ep_ini_conn_rejected(struct vrb_xrc_ep *ep)
 {
-	assert(ofi_spin_held(&ep->base_ep.eq->lock));
+	assert(ofi_mutex_held(&ep->base_ep.eq->lock));
 	assert(ep->base_ep.id && ep->ini_conn);
 
 	vrb_log_ep_conn(ep, "INI Connection Rejected");
@@ -288,7 +288,7 @@ int vrb_resend_shared_accept_xrc(struct vrb_xrc_ep *ep,
 	struct rdma_conn_param conn_param = { 0 };
 	struct vrb_xrc_cm_data *cm_data = ep->accept_param_data;
 
-	assert(ofi_spin_held(&ep->base_ep.eq->lock));
+	assert(ofi_mutex_held(&ep->base_ep.eq->lock));
 	assert(cm_data && ep->tgt_ibv_qp);
 	assert(ep->tgt_ibv_qp->qp_num == connreq->xrc.tgt_qpn);
 	assert(ep->peer_srqn == connreq->xrc.peer_srqn);
@@ -320,7 +320,7 @@ int vrb_accept_xrc(struct vrb_xrc_ep *ep, int reciprocal,
 	struct vrb_xrc_cm_data connect_cm_data;
 	int ret;
 
-	assert(ofi_spin_held(&ep->base_ep.eq->lock));
+	assert(ofi_mutex_held(&ep->base_ep.eq->lock));
 	addr = rdma_get_local_addr(ep->tgt_id);
 	if (addr)
 		ofi_straddr_dbg(&vrb_prov, FI_LOG_CORE, "src_addr", addr);

--- a/prov/verbs/src/verbs_cm_xrc.c
+++ b/prov/verbs/src/verbs_cm_xrc.c
@@ -167,7 +167,7 @@ static void vrb_log_ep_conn(struct vrb_xrc_ep *ep, char *desc)
 
 void vrb_free_xrc_conn_setup(struct vrb_xrc_ep *ep, int disconnect)
 {
-	assert(fastlock_held(&ep->base_ep.eq->lock));
+	assert(ofi_spin_held(&ep->base_ep.eq->lock));
 	assert(ep->conn_setup);
 
 	/* If a disconnect is requested then the XRC bidirectional connection
@@ -207,7 +207,7 @@ int vrb_connect_xrc(struct vrb_xrc_ep *ep, struct sockaddr *addr,
 	struct vrb_domain *domain = vrb_ep_to_domain(&ep->base_ep);
 	int ret;
 
-	assert(fastlock_held(&ep->base_ep.eq->lock));
+	assert(ofi_spin_held(&ep->base_ep.eq->lock));
 	assert(!ep->base_ep.id && !ep->base_ep.ibv_qp && !ep->ini_conn);
 
 	domain->xrc.lock_acquire(&domain->xrc.ini_lock);
@@ -235,7 +235,7 @@ void vrb_ep_ini_conn_done(struct vrb_xrc_ep *ep, uint32_t tgt_qpn)
 {
 	struct vrb_domain *domain = vrb_ep_to_domain(&ep->base_ep);
 
-	assert(fastlock_held(&ep->base_ep.eq->lock));
+	assert(ofi_spin_held(&ep->base_ep.eq->lock));
 	assert(ep->base_ep.id && ep->ini_conn);
 
 	domain->xrc.lock_acquire(&domain->xrc.ini_lock);
@@ -263,7 +263,7 @@ void vrb_ep_ini_conn_done(struct vrb_xrc_ep *ep, uint32_t tgt_qpn)
 
 void vrb_ep_ini_conn_rejected(struct vrb_xrc_ep *ep)
 {
-	assert(fastlock_held(&ep->base_ep.eq->lock));
+	assert(ofi_spin_held(&ep->base_ep.eq->lock));
 	assert(ep->base_ep.id && ep->ini_conn);
 
 	vrb_log_ep_conn(ep, "INI Connection Rejected");
@@ -288,7 +288,7 @@ int vrb_resend_shared_accept_xrc(struct vrb_xrc_ep *ep,
 	struct rdma_conn_param conn_param = { 0 };
 	struct vrb_xrc_cm_data *cm_data = ep->accept_param_data;
 
-	assert(fastlock_held(&ep->base_ep.eq->lock));
+	assert(ofi_spin_held(&ep->base_ep.eq->lock));
 	assert(cm_data && ep->tgt_ibv_qp);
 	assert(ep->tgt_ibv_qp->qp_num == connreq->xrc.tgt_qpn);
 	assert(ep->peer_srqn == connreq->xrc.peer_srqn);
@@ -320,7 +320,7 @@ int vrb_accept_xrc(struct vrb_xrc_ep *ep, int reciprocal,
 	struct vrb_xrc_cm_data connect_cm_data;
 	int ret;
 
-	assert(fastlock_held(&ep->base_ep.eq->lock));
+	assert(ofi_spin_held(&ep->base_ep.eq->lock));
 	addr = rdma_get_local_addr(ep->tgt_id);
 	if (addr)
 		ofi_straddr_dbg(&vrb_prov, FI_LOG_CORE, "src_addr", addr);

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -103,7 +103,7 @@ vrb_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *entry,
 
 	cq = container_of(cq_fid, struct vrb_cq, util_cq.cq_fid);
 
-	cq->util_cq.cq_fastlock_acquire(&cq->util_cq.cq_lock);
+	cq->util_cq.cq_mutex_lock(&cq->util_cq.cq_lock);
 	if (slist_empty(&cq->saved_wc_list))
 		goto err;
 
@@ -114,7 +114,7 @@ vrb_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *entry,
 	api_version = cq->util_cq.domain->fabric->fabric_fid.api_version;
 
 	slist_entry = slist_remove_head(&cq->saved_wc_list);
-	cq->util_cq.cq_fastlock_release(&cq->util_cq.cq_lock);
+	cq->util_cq.cq_mutex_unlock(&cq->util_cq.cq_lock);
 
 	wce = container_of(slist_entry, struct vrb_wc_entry, entry);
 
@@ -141,7 +141,7 @@ vrb_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *entry,
 	ofi_buf_free(wce);
 	return 1;
 err:
-	cq->util_cq.cq_fastlock_release(&cq->util_cq.cq_lock);
+	cq->util_cq.cq_mutex_unlock(&cq->util_cq.cq_lock);
 	return -FI_EAGAIN;
 }
 
@@ -231,7 +231,7 @@ int vrb_poll_cq(struct vrb_cq *cq, struct ibv_wc *wc)
 	struct vrb_context *ctx;
 	int ret;
 
-	assert(ofi_spin_held(&cq->util_cq.cq_lock));
+	assert(ofi_mutex_held(&cq->util_cq.cq_lock));
 	do {
 		ret = ibv_poll_cq(cq->cq, 1, wc);
 		if (ret <= 0)
@@ -267,7 +267,7 @@ int vrb_save_wc(struct vrb_cq *cq, struct ibv_wc *wc)
 {
 	struct vrb_wc_entry *wce;
 
-	assert(ofi_spin_held(&cq->util_cq.cq_lock));
+	assert(ofi_mutex_held(&cq->util_cq.cq_lock));
 	wce = ofi_buf_alloc(cq->wce_pool);
 	if (!wce) {
 		FI_WARN(&vrb_prov, FI_LOG_CQ,
@@ -285,7 +285,7 @@ static void vrb_flush_cq(struct vrb_cq *cq)
 	struct ibv_wc wc;
 	ssize_t ret;
 
-	cq->util_cq.cq_fastlock_acquire(&cq->util_cq.cq_lock);
+	cq->util_cq.cq_mutex_lock(&cq->util_cq.cq_lock);
 	while (1) {
 		ret = vrb_poll_cq(cq, &wc);
 		if (ret <= 0)
@@ -294,7 +294,7 @@ static void vrb_flush_cq(struct vrb_cq *cq)
 		vrb_save_wc(cq, &wc);
 	};
 
-	cq->util_cq.cq_fastlock_release(&cq->util_cq.cq_lock);
+	cq->util_cq.cq_mutex_unlock(&cq->util_cq.cq_lock);
 }
 
 void vrb_cleanup_cq(struct vrb_ep *ep)
@@ -319,7 +319,7 @@ static ssize_t vrb_cq_read(struct fid_cq *cq_fid, void *buf, size_t count)
 
 	cq = container_of(cq_fid, struct vrb_cq, util_cq.cq_fid);
 
-	cq->util_cq.cq_fastlock_acquire(&cq->util_cq.cq_lock);
+	cq->util_cq.cq_mutex_lock(&cq->util_cq.cq_lock);
 
 	for (i = 0; i < count; i++) {
 		if (!slist_empty(&cq->saved_wc_list)) {
@@ -343,7 +343,7 @@ static ssize_t vrb_cq_read(struct fid_cq *cq_fid, void *buf, size_t count)
 		if (wc.status) {
 			wce = ofi_buf_alloc(cq->wce_pool);
 			if (!wce) {
-				cq->util_cq.cq_fastlock_release(&cq->util_cq.cq_lock);
+				cq->util_cq.cq_mutex_unlock(&cq->util_cq.cq_lock);
 				return -FI_ENOMEM;
 			}
 			memset(wce, 0, sizeof(*wce));
@@ -356,7 +356,7 @@ static ssize_t vrb_cq_read(struct fid_cq *cq_fid, void *buf, size_t count)
 		cq->read_entry(&wc, (char *)buf + i * cq->entry_size);
 	}
 
-	cq->util_cq.cq_fastlock_release(&cq->util_cq.cq_lock);
+	cq->util_cq.cq_mutex_unlock(&cq->util_cq.cq_lock);
 	return i ? i : (ret < 0 ? ret : -FI_EAGAIN);
 }
 
@@ -395,7 +395,7 @@ int vrb_cq_trywait(struct vrb_cq *cq)
 		return -FI_EINVAL;
 	}
 
-	cq->util_cq.cq_fastlock_acquire(&cq->util_cq.cq_lock);
+	cq->util_cq.cq_mutex_lock(&cq->util_cq.cq_lock);
 	if (!slist_empty(&cq->saved_wc_list))
 		goto out;
 
@@ -427,7 +427,7 @@ int vrb_cq_trywait(struct vrb_cq *cq)
 
 	ret = FI_SUCCESS;
 out:
-	cq->util_cq.cq_fastlock_release(&cq->util_cq.cq_lock);
+	cq->util_cq.cq_mutex_unlock(&cq->util_cq.cq_lock);
 	return ret;
 }
 
@@ -510,13 +510,13 @@ static int vrb_cq_close(fid_t fid)
 	}
 	ofi_mutex_unlock(&cq->xrc.srq_list_lock);
 
-	cq->util_cq.cq_fastlock_acquire(&cq->util_cq.cq_lock);
+	cq->util_cq.cq_mutex_lock(&cq->util_cq.cq_lock);
 	while (!slist_empty(&cq->saved_wc_list)) {
 		entry = slist_remove_head(&cq->saved_wc_list);
 		wce = container_of(entry, struct vrb_wc_entry, entry);
 		ofi_buf_free(wce);
 	}
-	cq->util_cq.cq_fastlock_release(&cq->util_cq.cq_lock);
+	cq->util_cq.cq_mutex_unlock(&cq->util_cq.cq_lock);
 
 	ofi_bufpool_destroy(cq->wce_pool);
 	ofi_bufpool_destroy(cq->ctx_pool);

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -231,7 +231,7 @@ int vrb_poll_cq(struct vrb_cq *cq, struct ibv_wc *wc)
 	struct vrb_context *ctx;
 	int ret;
 
-	assert(fastlock_held(&cq->util_cq.cq_lock));
+	assert(ofi_spin_held(&cq->util_cq.cq_lock));
 	do {
 		ret = ibv_poll_cq(cq->cq, 1, wc);
 		if (ret <= 0)
@@ -251,9 +251,9 @@ int vrb_poll_cq(struct vrb_cq *cq, struct ibv_wc *wc)
 				wc->opcode &= ~IBV_WC_RECV;
 		}
 		if (ctx->srx) {
-			fastlock_acquire(&ctx->srx->ctx_lock);
+			ofi_spin_lock(&ctx->srx->ctx_lock);
 			ofi_buf_free(ctx);
-			fastlock_release(&ctx->srx->ctx_lock);
+			ofi_spin_unlock(&ctx->srx->ctx_lock);
 		} else {
 			ofi_buf_free(ctx);
 		}
@@ -267,7 +267,7 @@ int vrb_save_wc(struct vrb_cq *cq, struct ibv_wc *wc)
 {
 	struct vrb_wc_entry *wce;
 
-	assert(fastlock_held(&cq->util_cq.cq_lock));
+	assert(ofi_spin_held(&cq->util_cq.cq_lock));
 	wce = ofi_buf_alloc(cq->wce_pool);
 	if (!wce) {
 		FI_WARN(&vrb_prov, FI_LOG_CQ,
@@ -499,16 +499,16 @@ static int vrb_cq_close(fid_t fid)
 	/* Since an RX CQ and SRX context can be destroyed in any order,
 	 * and the XRC SRQ references the RX CQ, we must destroy any
 	 * XRC SRQ using this CQ before destroying the CQ. */
-	fastlock_acquire(&cq->xrc.srq_list_lock);
+	ofi_spin_lock(&cq->xrc.srq_list_lock);
 	dlist_foreach_container_safe(&cq->xrc.srq_list, struct vrb_srq_ep,
 				     srq_ep, xrc.srq_entry, srq_ep_temp) {
 		ret = vrb_xrc_close_srq(srq_ep);
 		if (ret) {
-			fastlock_release(&cq->xrc.srq_list_lock);
+			ofi_spin_unlock(&cq->xrc.srq_list_lock);
 			return -ret;
 		}
 	}
-	fastlock_release(&cq->xrc.srq_list_lock);
+	ofi_spin_unlock(&cq->xrc.srq_list_lock);
 
 	cq->util_cq.cq_fastlock_acquire(&cq->util_cq.cq_lock);
 	while (!slist_empty(&cq->saved_wc_list)) {
@@ -539,7 +539,7 @@ static int vrb_cq_close(fid_t fid)
 	if (cq->channel)
 		ibv_destroy_comp_channel(cq->channel);
 
-	fastlock_destroy(&cq->xrc.srq_list_lock);
+	ofi_spin_destroy(&cq->xrc.srq_list_lock);
 	free(cq);
 	return 0;
 }
@@ -699,7 +699,7 @@ int vrb_cq_open(struct fid_domain *domain_fid, struct fi_cq_attr *attr,
 
 	slist_init(&cq->saved_wc_list);
 	dlist_init(&cq->xrc.srq_list);
-	fastlock_init(&cq->xrc.srq_list_lock);
+	ofi_spin_init(&cq->xrc.srq_list_lock);
 
 	ofi_atomic_initialize32(&cq->nevents, 0);
 

--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -89,7 +89,7 @@ int vrb_get_shared_ini_conn(struct vrb_xrc_ep *ep,
 	struct ofi_rbnode *node;
 	int ret;
 
-	assert(ofi_spin_held(&domain->xrc.ini_lock));
+	assert(ofi_mutex_held(&domain->xrc.ini_lock));
 	vrb_set_ini_conn_key(ep, &key);
 	node = ofi_rbmap_find(domain->xrc.ini_conn_rbmap, &key);
 	if (node) {
@@ -143,7 +143,7 @@ void _vrb_put_shared_ini_conn(struct vrb_xrc_ep *ep)
 	struct vrb_ini_shared_conn *ini_conn;
 	struct vrb_ini_conn_key key;
 
-	assert(ofi_spin_held(&domain->xrc.ini_lock));
+	assert(ofi_mutex_held(&domain->xrc.ini_lock));
 	if (!ep->ini_conn)
 		return;
 
@@ -194,7 +194,7 @@ void vrb_put_shared_ini_conn(struct vrb_xrc_ep *ep)
 void vrb_add_pending_ini_conn(struct vrb_xrc_ep *ep, int reciprocal,
 			      void *conn_param, size_t conn_paramlen)
 {
-	assert(ofi_spin_held(&vrb_ep_to_domain(&ep->base_ep)->xrc.ini_lock));
+	assert(ofi_mutex_held(&vrb_ep_to_domain(&ep->base_ep)->xrc.ini_lock));
 
 	ep->conn_setup->pending_recip = reciprocal;
 	ep->conn_setup->pending_paramlen = MIN(conn_paramlen,
@@ -432,7 +432,7 @@ static int vrb_put_tgt_qp(struct vrb_xrc_ep *ep)
 
 int vrb_ep_destroy_xrc_qp(struct vrb_xrc_ep *ep)
 {
-	assert(ofi_spin_held(&ep->base_ep.eq->lock));
+	assert(ofi_mutex_held(&ep->base_ep.eq->lock));
 	vrb_put_shared_ini_conn(ep);
 
 	if (ep->base_ep.id) {
@@ -533,13 +533,13 @@ int vrb_domain_xrc_init(struct vrb_domain *domain)
 		goto rbmap_err;
 	}
 
-	ofi_spin_init(&domain->xrc.ini_lock);
+	ofi_mutex_init(&domain->xrc.ini_lock);
 	if (domain->util_domain.threading == FI_THREAD_DOMAIN) {
-		domain->xrc.lock_acquire = ofi_spin_lock_noop;
-		domain->xrc.lock_release = ofi_spin_unlock_noop;
+		domain->xrc.lock_acquire = ofi_mutex_lock_noop;
+		domain->xrc.lock_release = ofi_mutex_unlock_noop;
 	} else {
-		domain->xrc.lock_acquire = ofi_spin_lock_op;
-		domain->xrc.lock_release = ofi_spin_unlock_op;
+		domain->xrc.lock_acquire = ofi_mutex_lock_op;
+		domain->xrc.lock_release = ofi_mutex_unlock_op;
 	}
 	domain->ext_flags |= VRB_USE_XRC;
 	return FI_SUCCESS;
@@ -580,7 +580,7 @@ int vrb_domain_xrc_cleanup(struct vrb_domain *domain)
 	}
 
 	ofi_rbmap_destroy(domain->xrc.ini_conn_rbmap);
-	ofi_spin_destroy(&domain->xrc.ini_lock);
+	ofi_mutex_destroy(&domain->xrc.ini_lock);
 #endif /* VERBS_HAVE_XRC */
 	return 0;
 }

--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -89,7 +89,7 @@ int vrb_get_shared_ini_conn(struct vrb_xrc_ep *ep,
 	struct ofi_rbnode *node;
 	int ret;
 
-	assert(fastlock_held(&domain->xrc.ini_lock));
+	assert(ofi_spin_held(&domain->xrc.ini_lock));
 	vrb_set_ini_conn_key(ep, &key);
 	node = ofi_rbmap_find(domain->xrc.ini_conn_rbmap, &key);
 	if (node) {
@@ -143,7 +143,7 @@ void _vrb_put_shared_ini_conn(struct vrb_xrc_ep *ep)
 	struct vrb_ini_shared_conn *ini_conn;
 	struct vrb_ini_conn_key key;
 
-	assert(fastlock_held(&domain->xrc.ini_lock));
+	assert(ofi_spin_held(&domain->xrc.ini_lock));
 	if (!ep->ini_conn)
 		return;
 
@@ -194,7 +194,7 @@ void vrb_put_shared_ini_conn(struct vrb_xrc_ep *ep)
 void vrb_add_pending_ini_conn(struct vrb_xrc_ep *ep, int reciprocal,
 			      void *conn_param, size_t conn_paramlen)
 {
-	assert(fastlock_held(&vrb_ep_to_domain(&ep->base_ep)->xrc.ini_lock));
+	assert(ofi_spin_held(&vrb_ep_to_domain(&ep->base_ep)->xrc.ini_lock));
 
 	ep->conn_setup->pending_recip = reciprocal;
 	ep->conn_setup->pending_paramlen = MIN(conn_paramlen,
@@ -432,7 +432,7 @@ static int vrb_put_tgt_qp(struct vrb_xrc_ep *ep)
 
 int vrb_ep_destroy_xrc_qp(struct vrb_xrc_ep *ep)
 {
-	assert(fastlock_held(&ep->base_ep.eq->lock));
+	assert(ofi_spin_held(&ep->base_ep.eq->lock));
 	vrb_put_shared_ini_conn(ep);
 
 	if (ep->base_ep.id) {
@@ -533,13 +533,13 @@ int vrb_domain_xrc_init(struct vrb_domain *domain)
 		goto rbmap_err;
 	}
 
-	fastlock_init(&domain->xrc.ini_lock);
+	ofi_spin_init(&domain->xrc.ini_lock);
 	if (domain->util_domain.threading == FI_THREAD_DOMAIN) {
-		domain->xrc.lock_acquire = ofi_fastlock_acquire_noop;
-		domain->xrc.lock_release = ofi_fastlock_release_noop;
+		domain->xrc.lock_acquire = ofi_spin_lock_noop;
+		domain->xrc.lock_release = ofi_spin_unlock_noop;
 	} else {
-		domain->xrc.lock_acquire = ofi_fastlock_acquire;
-		domain->xrc.lock_release = ofi_fastlock_release;
+		domain->xrc.lock_acquire = ofi_spin_lock_op;
+		domain->xrc.lock_release = ofi_spin_unlock_op;
 	}
 	domain->ext_flags |= VRB_USE_XRC;
 	return FI_SUCCESS;
@@ -580,7 +580,7 @@ int vrb_domain_xrc_cleanup(struct vrb_domain *domain)
 	}
 
 	ofi_rbmap_destroy(domain->xrc.ini_conn_rbmap);
-	fastlock_destroy(&domain->xrc.ini_lock);
+	ofi_spin_destroy(&domain->xrc.ini_lock);
 #endif /* VERBS_HAVE_XRC */
 	return 0;
 }

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -437,7 +437,7 @@ static void vrb_ep_xrc_close(struct vrb_ep *ep)
 	struct vrb_xrc_ep *xrc_ep = container_of(ep, struct vrb_xrc_ep,
 						 base_ep);
 
-	assert(ofi_spin_held(&ep->eq->lock));
+	assert(ofi_mutex_held(&ep->eq->lock));
 	if (xrc_ep->conn_setup)
 		vrb_free_xrc_conn_setup(xrc_ep, 0);
 
@@ -457,7 +457,7 @@ static int vrb_ep_close(fid_t fid)
 	switch (ep->util_ep.type) {
 	case FI_EP_MSG:
 		if (ep->eq) {
-			ofi_spin_lock(&ep->eq->lock);
+			ofi_mutex_lock(&ep->eq->lock);
 			if (ep->eq->err.err && ep->eq->err.fid == fid) {
 				if (ep->eq->err.err_data) {
 					free(ep->eq->err.err_data);
@@ -476,7 +476,7 @@ static int vrb_ep_close(fid_t fid)
 			rdma_destroy_ep(ep->id);
 
 		if (ep->eq)
-			ofi_spin_unlock(&ep->eq->lock);
+			ofi_mutex_unlock(&ep->eq->lock);
 		vrb_cleanup_cq(ep);
 		break;
 	case FI_EP_DGRAM:
@@ -560,12 +560,12 @@ static int vrb_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 		ep->eq = container_of(bfid, struct vrb_eq, eq_fid.fid);
 
 		/* Make sure EQ channel is not polled during migrate */
-		ofi_spin_lock(&ep->eq->lock);
+		ofi_mutex_lock(&ep->eq->lock);
 		if (vrb_is_xrc_ep(ep))
 			ret = vrb_ep_xrc_set_tgt_chan(ep);
 		else
 			ret = rdma_migrate_id(ep->id, ep->eq->channel);
-		ofi_spin_unlock(&ep->eq->lock);
+		ofi_mutex_unlock(&ep->eq->lock);
 		if (ret) {
 			VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "rdma_migrate_id");
 			return -errno;
@@ -685,7 +685,7 @@ static int vrb_process_xrc_preposted(struct vrb_srq_ep *srq_ep)
 	struct slist_entry *entry;
 	int ret;
 
-	assert(ofi_spin_held(&srq_ep->xrc.prepost_lock));
+	assert(ofi_mutex_held(&srq_ep->xrc.prepost_lock));
 	/* The pre-post SRQ function ops have been replaced so the
 	 * posting here results in adding the RX entries to the SRQ */
 	while (!slist_empty(&srq_ep->xrc.prepost_list)) {
@@ -720,14 +720,14 @@ static int vrb_ep_enable_xrc(struct vrb_ep *ep)
 	dlist_init(&xrc_ep->ini_conn_entry);
 	xrc_ep->conn_state = VRB_XRC_UNCONNECTED;
 
-	ofi_spin_lock(&srq_ep->xrc.prepost_lock);
+	ofi_mutex_lock(&srq_ep->xrc.prepost_lock);
 	if (srq_ep->srq) {
 		/*
 		 * Multiple endpoints bound to the same XRC SRX context have
 		 * the restriction that they must be bound to the same RX CQ
 		 */
 		if (!srq_ep->xrc.cq || srq_ep->xrc.cq != cq) {
-			ofi_spin_unlock(&srq_ep->xrc.prepost_lock);
+			ofi_mutex_unlock(&srq_ep->xrc.prepost_lock);
 			VRB_WARN(FI_LOG_EP_CTRL, "SRX_CTX/CQ mismatch\n");
 			return -FI_EINVAL;
 		}
@@ -761,11 +761,11 @@ static int vrb_ep_enable_xrc(struct vrb_ep *ep)
 	}
 	/* The RX CQ maintains a list of all the XRC SRQs that were created
 	 * using it as the CQ */
-	cq->util_cq.cq_fastlock_acquire(&cq->xrc.srq_list_lock);
+	ofi_mutex_lock(&cq->xrc.srq_list_lock);
 	dlist_insert_tail(&srq_ep->xrc.srq_entry, &cq->xrc.srq_list);
 	srq_ep->xrc.cq = cq;
 	cq->credits -= srq_ep->xrc.max_recv_wr;
-	cq->util_cq.cq_fastlock_release(&cq->xrc.srq_list_lock);
+	ofi_mutex_unlock(&cq->xrc.srq_list_lock);
 
 	ibv_get_srq_num(srq_ep->srq, &xrc_ep->srqn);
 
@@ -773,7 +773,7 @@ static int vrb_ep_enable_xrc(struct vrb_ep *ep)
 	srq_ep->ep_fid.msg = &vrb_srq_msg_ops;
 	ret = vrb_process_xrc_preposted(srq_ep);
 done:
-	ofi_spin_unlock(&srq_ep->xrc.prepost_lock);
+	ofi_mutex_unlock(&srq_ep->xrc.prepost_lock);
 
 	return ret;
 #else /* VERBS_HAVE_XRC */
@@ -1457,7 +1457,7 @@ ssize_t vrb_post_srq(struct vrb_srq_ep *ep, struct ibv_recv_wr *wr)
 	struct ibv_recv_wr *bad_wr;
 	int ret;
 
-	ofi_spin_lock(&ep->ctx_lock);
+	ofi_mutex_lock(&ep->ctx_lock);
 	ctx = ofi_buf_alloc(ep->ctx_pool);
 	if (!ctx)
 		goto unlock;
@@ -1471,13 +1471,13 @@ ssize_t vrb_post_srq(struct vrb_srq_ep *ep, struct ibv_recv_wr *wr)
 	wr->wr_id = (uintptr_t) ctx->user_ctx;
 	if (ret)
 		goto freebuf;
-	ofi_spin_unlock(&ep->ctx_lock);
+	ofi_mutex_unlock(&ep->ctx_lock);
 	return 0;
 
 freebuf:
 	ofi_buf_free(ctx);
 unlock:
-	ofi_spin_unlock(&ep->ctx_lock);
+	ofi_mutex_unlock(&ep->ctx_lock);
 	return -FI_EAGAIN;
 }
 
@@ -1555,12 +1555,12 @@ vrb_xrc_srq_ep_prepost_recv(struct fid_ep *ep_fid, void *buf, size_t len,
 	struct vrb_xrc_srx_prepost *recv;
 	ssize_t ret;
 
-	ofi_spin_lock(&ep->xrc.prepost_lock);
+	ofi_mutex_lock(&ep->xrc.prepost_lock);
 
 	/* Handle race that can occur when SRQ is created and pre-post
 	 * receive message function is swapped out. */
 	if (ep->srq) {
-		ofi_spin_unlock(&ep->xrc.prepost_lock);
+		ofi_mutex_unlock(&ep->xrc.prepost_lock);
 		return vrb_convert_ret(fi_recv(ep_fid, buf, len, desc,
 						 src_addr, context));
 	}
@@ -1586,7 +1586,7 @@ vrb_xrc_srq_ep_prepost_recv(struct fid_ep *ep_fid, void *buf, size_t len,
 	slist_insert_tail(&recv->prepost_entry, &ep->xrc.prepost_list);
 	ret = FI_SUCCESS;
 done:
-	ofi_spin_unlock(&ep->xrc.prepost_lock);
+	ofi_mutex_unlock(&ep->xrc.prepost_lock);
 	return ret;
 }
 
@@ -1620,7 +1620,7 @@ int vrb_xrc_close_srq(struct vrb_srq_ep *srq_ep)
 {
 	int ret;
 
-	assert(ofi_spin_held(&srq_ep->xrc.cq->xrc.srq_list_lock));
+	assert(ofi_mutex_held(&srq_ep->xrc.cq->xrc.srq_list_lock));
 	assert(srq_ep->domain->ext_flags & VRB_USE_XRC);
 	if (!srq_ep->xrc.cq || !srq_ep->srq)
 		return FI_SUCCESS;
@@ -1648,13 +1648,13 @@ static int vrb_srq_close(fid_t fid)
 
 	if (srq_ep->domain->ext_flags & VRB_USE_XRC) {
 		if (cq) {
-			ofi_spin_lock(&cq->xrc.srq_list_lock);
+			ofi_mutex_lock(&cq->xrc.srq_list_lock);
 			ret = vrb_xrc_close_srq(srq_ep);
-			ofi_spin_unlock(&cq->xrc.srq_list_lock);
+			ofi_mutex_unlock(&cq->xrc.srq_list_lock);
 			if (ret)
 				goto err;
 		}
-		ofi_spin_destroy(&srq_ep->xrc.prepost_lock);
+		ofi_mutex_destroy(&srq_ep->xrc.prepost_lock);
 	} else {
 		ret = ibv_destroy_srq(srq_ep->srq);
 		if (ret)
@@ -1662,7 +1662,7 @@ static int vrb_srq_close(fid_t fid)
 	}
 
 	ofi_bufpool_destroy(srq_ep->ctx_pool);
-	ofi_spin_destroy(&srq_ep->ctx_lock);
+	ofi_mutex_destroy(&srq_ep->ctx_lock);
 	free(srq_ep);
 	return FI_SUCCESS;
 
@@ -1694,7 +1694,7 @@ int vrb_srq_context(struct fid_domain *domain, struct fi_rx_attr *attr,
 	if (!srq_ep)
 		return -FI_ENOMEM;
 
-	ofi_spin_init(&srq_ep->ctx_lock);
+	ofi_mutex_init(&srq_ep->ctx_lock);
 	ret = ofi_bufpool_create(&srq_ep->ctx_pool, sizeof(struct fi_context),
 				 16, attr->size, 1024, OFI_BUFPOOL_NO_TRACK);
 	if (ret)
@@ -1715,7 +1715,7 @@ int vrb_srq_context(struct fid_domain *domain, struct fi_rx_attr *attr,
 	/* XRC SRQ creation is delayed until the first endpoint it is bound
 	 * to is enabled.*/
 	if (dom->ext_flags & VRB_USE_XRC) {
-		ofi_spin_init(&srq_ep->xrc.prepost_lock);
+		ofi_mutex_init(&srq_ep->xrc.prepost_lock);
 		slist_init(&srq_ep->xrc.prepost_list);
 		dlist_init(&srq_ep->xrc.srq_entry);
 		srq_ep->xrc.max_recv_wr = attr->size;
@@ -1742,7 +1742,7 @@ done:
 free_bufs:
 	ofi_bufpool_destroy(srq_ep->ctx_pool);
 free_ep:
-	ofi_spin_destroy(&srq_ep->ctx_lock);
+	ofi_mutex_destroy(&srq_ep->ctx_lock);
 	free(srq_ep);
 	return ret;
 }

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -64,7 +64,7 @@ vrb_eq_readerr(struct fid_eq *eq, struct fi_eq_err_entry *entry,
 	struct vrb_eq *_eq =
 		container_of(eq, struct vrb_eq, eq_fid.fid);
 	ssize_t rd = -FI_EAGAIN;
-	ofi_spin_lock(&_eq->lock);
+	ofi_mutex_lock(&_eq->lock);
 	if (!_eq->err.err)
 		goto unlock;
 
@@ -72,7 +72,7 @@ vrb_eq_readerr(struct fid_eq *eq, struct fi_eq_err_entry *entry,
 				flags, &_eq->err, entry);
 	rd = sizeof(*entry);
 unlock:
-	ofi_spin_unlock(&_eq->lock);
+	ofi_mutex_unlock(&_eq->lock);
 	return rd;
 }
 
@@ -80,7 +80,7 @@ void vrb_eq_set_xrc_conn_tag(struct vrb_xrc_ep *ep)
 {
 	struct vrb_eq *eq = ep->base_ep.eq;
 
-	assert(ofi_spin_held(&eq->lock));
+	assert(ofi_mutex_held(&eq->lock));
 	assert(ep->conn_setup);
 	assert(ep->conn_setup->conn_tag == VERBS_CONN_TAG_INVALID);
 	ep->conn_setup->conn_tag =
@@ -93,7 +93,7 @@ void vrb_eq_clear_xrc_conn_tag(struct vrb_xrc_ep *ep)
 	struct vrb_eq *eq = ep->base_ep.eq;
 	int index;
 
-	assert(ofi_spin_held(&eq->lock));
+	assert(ofi_mutex_held(&eq->lock));
 	assert(ep->conn_setup);
 	if (ep->conn_setup->conn_tag == VERBS_CONN_TAG_INVALID)
 		return;
@@ -114,7 +114,7 @@ struct vrb_xrc_ep *vrb_eq_xrc_conn_tag2ep(struct vrb_eq *eq,
 	struct vrb_xrc_ep *ep;
 	int index;
 
-	assert(ofi_spin_held(&eq->lock));
+	assert(ofi_mutex_held(&eq->lock));
 	index = ofi_key2idx(&eq->xrc.conn_key_idx, (uint64_t)conn_tag);
 	ep = ofi_idx_lookup(eq->xrc.conn_key_map, index);
 	if (!ep || ep->magic != VERBS_XRC_EP_MAGIC) {
@@ -361,7 +361,7 @@ struct vrb_xrc_ep *vrb_eq_get_sidr_conn(struct vrb_eq *eq,
 	struct ofi_rbnode *node;
 	struct vrb_sidr_conn_key key;
 
-	assert(ofi_spin_held(&eq->lock));
+	assert(ofi_mutex_held(&eq->lock));
 	vrb_set_sidr_conn_key(peer, pep_port, recip, &key);
 	node = ofi_rbmap_find(&eq->xrc.sidr_conn_rbmap, &key);
 	if (OFI_LIKELY(!node))
@@ -376,7 +376,7 @@ int vrb_eq_add_sidr_conn(struct vrb_xrc_ep *ep,
 	int ret;
 	struct vrb_sidr_conn_key key;
 
-	assert(ofi_spin_held(&ep->base_ep.eq->lock));
+	assert(ofi_mutex_held(&ep->base_ep.eq->lock));
 	assert(!ep->accept_param_data);
 	assert(param_len);
 	assert(ep->tgt_id && ep->tgt_id->ps == RDMA_PS_UDP);
@@ -408,7 +408,7 @@ int vrb_eq_add_sidr_conn(struct vrb_xrc_ep *ep,
 
 void vrb_eq_remove_sidr_conn(struct vrb_xrc_ep *ep)
 {
-	assert(ofi_spin_held(&ep->base_ep.eq->lock));
+	assert(ofi_mutex_held(&ep->base_ep.eq->lock));
 	assert(ep->conn_map_node);
 
 	ofi_rbmap_delete(&ep->base_ep.eq->xrc.sidr_conn_rbmap,
@@ -662,7 +662,7 @@ vrb_eq_xrc_rej_event(struct vrb_eq *eq, struct rdma_cm_event *cma_event)
 	struct vrb_xrc_conn_info xrc_info;
 	enum vrb_xrc_ep_conn_state state;
 
-	assert(ofi_spin_held(&eq->lock));
+	assert(ofi_mutex_held(&eq->lock));
 	ep = container_of(fid, struct vrb_xrc_ep, base_ep.util_ep.ep_fid);
 	if (ep->magic != VERBS_XRC_EP_MAGIC) {
 		VRB_WARN(FI_LOG_EP_CTRL,
@@ -707,7 +707,7 @@ static int
 vrb_eq_xrc_connect_retry(struct vrb_xrc_ep *ep,
 			 struct rdma_cm_event *cma_event, int *acked)
 {
-	assert(ofi_spin_held(&ep->base_ep.eq->lock));
+	assert(ofi_mutex_held(&ep->base_ep.eq->lock));
 
 	if (ep->base_ep.info_attr.src_addr)
 		ofi_straddr_dbg(&vrb_prov, FI_LOG_EP_CTRL,
@@ -737,7 +737,7 @@ vrb_eq_xrc_cm_err_event(struct vrb_eq *eq,
 	fid_t fid = cma_event->id->context;
 	int ret;
 
-	assert(ofi_spin_held(&eq->lock));
+	assert(ofi_mutex_held(&eq->lock));
 	ep = container_of(fid, struct vrb_xrc_ep, base_ep.util_ep.ep_fid);
 	if (ep->magic != VERBS_XRC_EP_MAGIC) {
 		VRB_WARN(FI_LOG_EP_CTRL, "CM ID context invalid\n");
@@ -789,7 +789,7 @@ vrb_eq_xrc_connected_event(struct vrb_eq *eq,
 
 	ep = container_of(fid, struct vrb_xrc_ep, base_ep.util_ep.ep_fid);
 
-	assert(ofi_spin_held(&eq->lock));
+	assert(ofi_mutex_held(&eq->lock));
 	assert(ep->conn_state == VRB_XRC_ORIG_CONNECTING ||
 	       ep->conn_state == VRB_XRC_RECIP_CONNECTING);
 
@@ -816,7 +816,7 @@ vrb_eq_xrc_timewait_event(struct vrb_eq *eq,
 	struct vrb_xrc_ep *ep = container_of(fid, struct vrb_xrc_ep,
 						base_ep.util_ep.ep_fid);
 
-	assert(ofi_spin_held(&eq->lock));
+	assert(ofi_mutex_held(&eq->lock));
 	assert(ep->magic == VERBS_XRC_EP_MAGIC);
 	assert(ep->conn_setup);
 
@@ -843,7 +843,7 @@ vrb_eq_xrc_disconnect_event(struct vrb_eq *eq,
 	struct vrb_xrc_ep *ep = container_of(fid, struct vrb_xrc_ep,
 					     base_ep.util_ep.ep_fid);
 
-	assert(ofi_spin_held(&eq->lock));
+	assert(ofi_mutex_held(&eq->lock));
 	assert(ep->magic == VERBS_XRC_EP_MAGIC);
 
 	if (ep->conn_setup && cma_event->id == ep->base_ep.id) {
@@ -1036,9 +1036,9 @@ ack:
 int vrb_eq_trywait(struct vrb_eq *eq)
 {
 	int ret;
-	ofi_spin_lock(&eq->lock);
+	ofi_mutex_lock(&eq->lock);
 	ret = dlistfd_empty(&eq->list_head);
-	ofi_spin_unlock(&eq->lock);
+	ofi_mutex_unlock(&eq->lock);
 	return ret ? 0 : -FI_EAGAIN;
 }
 
@@ -1067,7 +1067,7 @@ void vrb_eq_remove_events(struct vrb_eq *eq, struct fid *fid)
 	struct dlist_entry *item;
 	struct vrb_eq_entry *entry;
 
-	assert(ofi_spin_held(&eq->lock));
+	assert(ofi_mutex_held(&eq->lock));
 	while ((item =
 		dlistfd_remove_first_match(&eq->list_head,
 					   vrb_eq_match_event, fid))) {
@@ -1103,9 +1103,9 @@ ssize_t vrb_eq_write_event(struct vrb_eq *eq, uint32_t event,
 	if (!entry)
 		return -FI_ENOMEM;
 
-	ofi_spin_lock(&eq->lock);
+	ofi_mutex_lock(&eq->lock);
 	dlistfd_insert_tail(&entry->item, &eq->list_head);
-	ofi_spin_unlock(&eq->lock);
+	ofi_mutex_unlock(&eq->lock);
 
 	return len;
 }
@@ -1128,7 +1128,7 @@ static size_t vrb_eq_read_event(struct vrb_eq *eq, uint32_t *event,
 	struct vrb_eq_entry *entry;
 	ssize_t ret = 0;
 
-	ofi_spin_lock(&eq->lock);
+	ofi_mutex_lock(&eq->lock);
 
 	if (eq->err.err) {
 		ret = -FI_EAVAIL;
@@ -1154,7 +1154,7 @@ static size_t vrb_eq_read_event(struct vrb_eq *eq, uint32_t *event,
 	}
 
 out:
-	ofi_spin_unlock(&eq->lock);
+	ofi_mutex_unlock(&eq->lock);
 	return ret;
 }
 
@@ -1176,17 +1176,17 @@ vrb_eq_read(struct fid_eq *eq_fid, uint32_t *event,
 
 	if (eq->channel) {
 next_event:
-		ofi_spin_lock(&eq->lock);
+		ofi_mutex_lock(&eq->lock);
 		ret = rdma_get_cm_event(eq->channel, &cma_event);
 		if (ret) {
-			ofi_spin_unlock(&eq->lock);
+			ofi_mutex_unlock(&eq->lock);
 			return -errno;
 		}
 
 		ret = vrb_eq_cm_process_event(eq, cma_event, event,
 						 (struct fi_eq_cm_entry *)buf,
 						 len);
-		ofi_spin_unlock(&eq->lock);
+		ofi_mutex_unlock(&eq->lock);
 		/* If the CM event was handled internally (e.g. XRC), continue
 		 * to process events. */
 		if (ret == -FI_EAGAIN)
@@ -1314,7 +1314,7 @@ static int vrb_eq_close(fid_t fid)
 	ofi_rbmap_cleanup(&eq->xrc.sidr_conn_rbmap);
 	ofi_idx_reset(eq->xrc.conn_key_map);
 	free(eq->xrc.conn_key_map);
-	ofi_spin_destroy(&eq->lock);
+	ofi_mutex_destroy(&eq->lock);
 	free(eq);
 
 	return 0;
@@ -1349,7 +1349,7 @@ int vrb_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 	}
 	ofi_rbmap_init(&_eq->xrc.sidr_conn_rbmap, vrb_sidr_conn_compare);
 
-	ofi_spin_init(&_eq->lock);
+	ofi_mutex_init(&_eq->lock);
 	ret = dlistfd_head_init(&_eq->list_head);
 	if (ret) {
 		VRB_INFO(FI_LOG_EQ, "Unable to initialize dlistfd\n");
@@ -1411,7 +1411,7 @@ err3:
 err2:
 	dlistfd_head_free(&_eq->list_head);
 err1:
-	ofi_spin_destroy(&_eq->lock);
+	ofi_mutex_destroy(&_eq->lock);
 	free(_eq->xrc.conn_key_map);
 err0:
 	free(_eq);

--- a/src/common.c
+++ b/src/common.c
@@ -1358,7 +1358,7 @@ int ofi_pollfds_create(struct ofi_pollfds **pfds)
 	(*pfds)->fds[(*pfds)->nfds].events = POLLIN;
 	(*pfds)->context[(*pfds)->nfds++] = NULL;
 	slist_init(&(*pfds)->work_item_list);
-	ofi_spin_init(&(*pfds)->lock);
+	ofi_mutex_init(&(*pfds)->lock);
 	return FI_SUCCESS;
 err2:
 	free((*pfds)->fds);
@@ -1380,10 +1380,10 @@ static int ofi_pollfds_ctl(struct ofi_pollfds *pfds, enum ofi_pollfds_ctl op,
 	item->events = events;
 	item->context = context;
 	item->type = op;
-	ofi_spin_lock(&pfds->lock);
+	ofi_mutex_lock(&pfds->lock);
 	slist_insert_tail(&item->entry, &pfds->work_item_list);
 	fd_signal_set(&pfds->signal);
-	ofi_spin_unlock(&pfds->lock);
+	ofi_mutex_unlock(&pfds->lock);
 	return 0;
 }
 
@@ -1418,7 +1418,7 @@ int ofi_pollfds_mod(struct ofi_pollfds *pfds, int fd, uint32_t events,
 	struct ofi_pollfds_work_item *item;
 	int ret;
 
-	ofi_spin_lock(&pfds->lock);
+	ofi_mutex_lock(&pfds->lock);
 	ret = ofi_pollfds_do_mod(pfds, fd, events, context);
 	if (!ret)
 		goto signal;
@@ -1434,7 +1434,7 @@ int ofi_pollfds_mod(struct ofi_pollfds *pfds, int fd, uint32_t events,
 
 signal:
 	fd_signal_set(&pfds->signal);
-	ofi_spin_unlock(&pfds->lock);
+	ofi_mutex_unlock(&pfds->lock);
 	return 0;
 }
 
@@ -1475,10 +1475,10 @@ int ofi_pollfds_wait(struct ofi_pollfds *pfds,
 	int found = 0;
 	uint64_t start = (timeout > 0) ? ofi_gettime_ms() : 0;
 
-	ofi_spin_lock(&pfds->lock);
+	ofi_mutex_lock(&pfds->lock);
 	if (!slist_empty(&pfds->work_item_list))
 		ofi_pollfds_process_work(pfds);
-	ofi_spin_unlock(&pfds->lock);
+	ofi_mutex_unlock(&pfds->lock);
 
 	do {
 		ret = poll(pfds->fds, pfds->nfds, timeout);
@@ -1487,10 +1487,10 @@ int ofi_pollfds_wait(struct ofi_pollfds *pfds,
 		else if (ret == 0)
 			return 0;
 
-		ofi_spin_lock(&pfds->lock);
+		ofi_mutex_lock(&pfds->lock);
 		if (!slist_empty(&pfds->work_item_list))
 			ofi_pollfds_process_work(pfds);
-		ofi_spin_unlock(&pfds->lock);
+		ofi_mutex_unlock(&pfds->lock);
 
 		if (pfds->fds[0].revents) {
 			fd_signal_reset(&pfds->signal);
@@ -1528,7 +1528,7 @@ void ofi_pollfds_close(struct ofi_pollfds *pfds)
 					    entry);
 			free(item);
 		}
-		ofi_spin_destroy(&pfds->lock);
+		ofi_mutex_destroy(&pfds->lock);
 		fd_signal_free(&pfds->signal);
 		free(pfds->fds);
 		free(pfds);

--- a/src/unix/osd.c
+++ b/src/unix/osd.c
@@ -106,7 +106,7 @@ int fi_fd_block(int fd)
 	return 0;
 }
 
-int fi_wait_cond(pthread_cond_t *cond, pthread_mutex_t *mut, int timeout_ms)
+int ofi_wait_cond(pthread_cond_t *cond, pthread_mutex_t *mut, int timeout_ms)
 {
 	uint64_t t;
 	struct timespec ts;


### PR DESCRIPTION
PR is updated to manually replace most uses of spin lock with mutex.  Fastlock abstraction is replaced with ofi_spin_t and ofi_mutex_t abstractions instead.  The typedef allows us to keep the debug validation checks that we currently have.

The current code uses spin locks throughout.  However, as pointed out in issue #7053, the result can be a lack of fairness resulting in very low performance.  Additionally, if the thread holding the lock is swapped out, then another thread that tries to acquire the lock will spin on the CPU for their entire time quantum, resulting in 100% CPU utilization for that core without any work being done.  Because the locks are held during progress, it's is common for the calling thread to make kernel calls (e.g. tcp provider), register memory (efa/verbs), or allocate memory.  All of these can take significant time and result in the thread sleeping.  Unlike the kernel, there's no way for a user space thread to avoid being swapped out while holding the lock.

Modern mutex implementations already spin for a brief period of time before putting the thread to sleep.

Opening PR with changes and will discuss in the Nov. 30th OFIWG.

Note that many HPC apps are single threaded, which the code already optimizes for by using no-op locking routines.  These changes are not expected to impact those applications negatively.