### PR TITLE
prov/efa: use gdrcopy when it is available

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -291,6 +291,7 @@ struct efa_mr_peer {
 		uint64_t        reserved;
 		int             cuda;
 	} device;
+	uint64_t		gdrcopy_handle;
 };
 
 struct efa_mr {


### PR DESCRIPTION
Currently, efa uses a local read to copy data in bounce buffer
to GPU memory, which is an expensive operation.

This patch uses gdrcopy to do the copy when gdrcopy is
available.

Signed-off-by: Wei Zhang <wzam@amazon.com>