### PR TITLE
prov/shm: change shm lock to mutex and add shared attr

### DIFF
--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -242,7 +242,7 @@ struct smr_region {
 	uint8_t		cma_cap_peer;
 	uint8_t		cma_cap_self;
 	void		*base_addr;
-	fastlock_t	lock; /* lock for shm access
+	pthread_mutex_t	lock; /* lock for shm access
 				 Must hold smr->lock before tx/rx cq locks
 				 in order to progress or post recv */
 	ofi_atomic32_t	signal;

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -161,7 +161,7 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 	peer_id = smr_peer_data(ep->region)[id].addr.id;
 	peer_smr = smr_peer_region(ep->region, id);
 
-	fastlock_acquire(&peer_smr->lock);
+	pthread_mutex_lock(&peer_smr->lock);
 	if (peer_smr->cmd_cnt < 2 || smr_peer_data(ep->region)[id].sar_status) {
 		ret = -FI_EAGAIN;
 		goto unlock_region;
@@ -256,7 +256,7 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 unlock_cq:
 	fastlock_release(&ep->util_ep.tx_cq->cq_lock);
 unlock_region:
-	fastlock_release(&peer_smr->lock);
+	pthread_mutex_unlock(&peer_smr->lock);
 	return ret;
 }
 
@@ -341,7 +341,7 @@ static ssize_t smr_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 	peer_id = smr_peer_data(ep->region)[id].addr.id;
 	peer_smr = smr_peer_region(ep->region, id);
 
-	fastlock_acquire(&peer_smr->lock);
+	pthread_mutex_lock(&peer_smr->lock);
 	if (peer_smr->cmd_cnt < 2 || smr_peer_data(ep->region)[id].sar_status) {
 		ret = -FI_EAGAIN;
 		goto unlock_region;
@@ -378,7 +378,7 @@ static ssize_t smr_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 
 	ofi_ep_tx_cntr_inc_func(&ep->util_ep, ofi_op_atomic);
 unlock_region:
-	fastlock_release(&peer_smr->lock);
+	pthread_mutex_unlock(&peer_smr->lock);
 	return ret;
 }
 

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -203,7 +203,7 @@ static void smr_send_name(struct smr_ep *ep, int64_t id)
 
 	peer_smr = smr_peer_region(ep->region, id);
 
-	fastlock_acquire(&peer_smr->lock);
+	pthread_mutex_lock(&peer_smr->lock);
 
 	if (smr_peer_data(ep->region)[id].name_sent || !peer_smr->cmd_cnt)
 		goto out;
@@ -226,7 +226,7 @@ static void smr_send_name(struct smr_ep *ep, int64_t id)
 	smr_signal(peer_smr);
 
 out:
-	fastlock_release(&peer_smr->lock);
+	pthread_mutex_unlock(&peer_smr->lock);
 }
 
 int64_t smr_verify_peer(struct smr_ep *ep, fi_addr_t fi_addr)

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -173,7 +173,7 @@ static int smr_progress_resp_entry(struct smr_ep *ep, struct smr_resp *resp,
 	//Skip locking on transfers from self since we already have
 	//the ep->region->lock
 	if (peer_smr != ep->region) {
-		if (fastlock_tryacquire(&peer_smr->lock)) {
+		if (pthread_mutex_trylock(&peer_smr->lock)) {
 			smr_signal(ep->region);
 			return -FI_EAGAIN;
 		}
@@ -189,7 +189,7 @@ static int smr_progress_resp_entry(struct smr_ep *ep, struct smr_resp *resp,
 	}
 
 	if (peer_smr != ep->region)
-		fastlock_release(&peer_smr->lock);
+		pthread_mutex_unlock(&peer_smr->lock);
 
 	return FI_SUCCESS;
 }
@@ -200,7 +200,7 @@ static void smr_progress_resp(struct smr_ep *ep)
 	struct smr_tx_entry *pending;
 	int ret;
 
-	fastlock_acquire(&ep->region->lock);
+	pthread_mutex_lock(&ep->region->lock);
 	fastlock_acquire(&ep->util_ep.tx_cq->cq_lock);
 	while (!ofi_cirque_isempty(smr_resp_queue(ep->region)) &&
 	       !ofi_cirque_isfull(ep->util_ep.tx_cq->cirq)) {
@@ -224,7 +224,7 @@ static void smr_progress_resp(struct smr_ep *ep)
 		ofi_cirque_discard(smr_resp_queue(ep->region));
 	}
 	fastlock_release(&ep->util_ep.tx_cq->cq_lock);
-	fastlock_release(&ep->region->lock);
+	pthread_mutex_unlock(&ep->region->lock);
 }
 
 static int smr_progress_inline(struct smr_cmd *cmd, enum fi_hmem_iface iface,
@@ -989,7 +989,7 @@ static void smr_progress_cmd(struct smr_ep *ep)
 	struct smr_cmd *cmd;
 	int ret = 0;
 
-	fastlock_acquire(&ep->region->lock);
+	pthread_mutex_lock(&ep->region->lock);
 	fastlock_acquire(&ep->util_ep.rx_cq->cq_lock);
 
 	while (!ofi_cirque_isempty(smr_cmd_queue(ep->region))) {
@@ -1034,7 +1034,7 @@ static void smr_progress_cmd(struct smr_ep *ep)
 		}
 	}
 	fastlock_release(&ep->util_ep.rx_cq->cq_lock);
-	fastlock_release(&ep->region->lock);
+	pthread_mutex_unlock(&ep->region->lock);
 }
 
 static void smr_progress_sar_list(struct smr_ep *ep)
@@ -1046,7 +1046,7 @@ static void smr_progress_sar_list(struct smr_ep *ep)
 	struct dlist_entry *tmp;
 	int ret;
 
-	fastlock_acquire(&ep->region->lock);
+	pthread_mutex_lock(&ep->region->lock);
 	fastlock_acquire(&ep->util_ep.rx_cq->cq_lock);
 
 	dlist_foreach_container_safe(&ep->sar_list, struct smr_sar_entry,
@@ -1083,7 +1083,7 @@ static void smr_progress_sar_list(struct smr_ep *ep)
 		}
 	}
 	fastlock_release(&ep->util_ep.rx_cq->cq_lock);
-	fastlock_release(&ep->region->lock);
+	pthread_mutex_unlock(&ep->region->lock);
 }
 
 void smr_ep_progress(struct util_ep *util_ep)

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -121,7 +121,7 @@ ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 		    (FI_REMOTE_CQ_DATA | FI_DELIVERY_COMPLETE)) &&
 		     rma_count == 1 && smr_cma_enabled(ep, peer_smr));
 
-	fastlock_acquire(&peer_smr->lock);
+	pthread_mutex_lock(&peer_smr->lock);
 	if (peer_smr->cmd_cnt < cmds ||
 	    smr_peer_data(ep->region)[id].sar_status) {
 		ret = -FI_EAGAIN;
@@ -248,7 +248,7 @@ commit_comp:
 unlock_cq:
 	fastlock_release(&ep->util_ep.tx_cq->cq_lock);
 unlock_region:
-	fastlock_release(&peer_smr->lock);
+	pthread_mutex_unlock(&peer_smr->lock);
 	return ret;
 }
 
@@ -386,7 +386,7 @@ ssize_t smr_generic_rma_inject(struct fid_ep *ep_fid, const void *buf,
 	cmds = 1 + !(domain->fast_rma && !(flags & FI_REMOTE_CQ_DATA) &&
 		     smr_cma_enabled(ep, peer_smr));
 
-	fastlock_acquire(&peer_smr->lock);
+	pthread_mutex_lock(&peer_smr->lock);
 	if (peer_smr->cmd_cnt < cmds ||
 	    smr_peer_data(ep->region)[id].sar_status) {
 		ret = -FI_EAGAIN;
@@ -429,7 +429,7 @@ commit:
 	smr_signal(peer_smr);
 	ofi_ep_tx_cntr_inc_func(&ep->util_ep, ofi_op_write);
 unlock_region:
-	fastlock_release(&peer_smr->lock);
+	pthread_mutex_unlock(&peer_smr->lock);
 	return ret;
 }
 

--- a/prov/util/src/util_shm.c
+++ b/prov/util/src/util_shm.c
@@ -185,6 +185,15 @@ err:
 	return -FI_EBUSY;
 }
 
+static void smr_lock_init(pthread_mutex_t *mutex)
+{
+	pthread_mutexattr_t attr;
+
+	pthread_mutexattr_init(&attr);
+	pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_SHARED);
+	pthread_mutex_init(mutex, &attr);
+}
+
 /* TODO: Determine if aligning SMR data helps performance */
 int smr_create(const struct fi_provider *prov, struct smr_map *map,
 	       const struct smr_attr *attr, struct smr_region *volatile *smr)
@@ -256,7 +265,7 @@ int smr_create(const struct fi_provider *prov, struct smr_map *map,
 	pthread_mutex_unlock(&ep_list_lock);
 
 	*smr = mapped_addr;
-	fastlock_init(&(*smr)->lock);
+	smr_lock_init(&(*smr)->lock);
 	ofi_atomic_initialize32(&(*smr)->signal, 0);
 
 	(*smr)->map = map;


### PR DESCRIPTION
The shm provider currently uses a spin lock by default. However, this
can cause performance issues if a process gets swapped out while holding
the lock and the process swapped in attempts to acquire the same lock.

This also uses a separate lock initialization which sets the PTHREAD_PROCESS_SHARED
attribute field to make sure this lock is shareable between processes, unlike
the default fastlock_init function which makes the lock private.

Signed-off-by: aingerson <alexia.ingerson@intel.com>