### PR TITLE
prov/util: Restructure collective av set creation/destruction

### DIFF
--- a/include/ofi_coll.h
+++ b/include/ofi_coll.h
@@ -38,6 +38,7 @@
 #include <ofi_list.h>
 #include <ofi_atom.h>
 #include <ofi_bitmask.h>
+#include <ofi_util.h>
 
 #define OFI_WORLD_GROUP_ID 0
 #define OFI_MAX_GROUP_ID 256
@@ -59,27 +60,6 @@ static const char * const log_util_coll_op_type[] = {
 	[UTIL_COLL_BROADCAST_OP] = "COLL_BROADCAST",
 	[UTIL_COLL_ALLGATHER_OP] = "COLL_ALLGATHER",
 	[UTIL_COLL_SCATTER_OP] = "COLL_SCATTER"
-};
-
-struct util_coll_mc {
-	struct fid_mc		mc_fid;
-	struct fid_ep		*ep;
-	struct util_av_set	*av_set;
-	uint64_t		local_rank;
-	uint16_t		group_id;
-	uint16_t		seq;
-	ofi_atomic32_t		ref;
-};
-
-struct util_av_set {
-	struct fid_av_set	av_set_fid;
-	struct util_av		*av;
-	fi_addr_t		*fi_addr_array;
-	size_t			fi_addr_count;
-	uint64_t		flags;
-	struct util_coll_mc     coll_mc;
-	ofi_atomic32_t		ref;
-	ofi_mutex_t		lock;
 };
 
 enum coll_work_type {

--- a/include/ofi_coll.h
+++ b/include/ofi_coll.h
@@ -148,8 +148,10 @@ struct util_coll_operation {
 	enum util_coll_op_type		type;
 	uint32_t			cid;
 	void				*context;
+	struct fid_ep			*ep;
 	struct util_coll_mc		*mc;
 	struct dlist_entry		work_queue;
+
 	union {
 		struct join_data	join;
 		struct barrier_data	barrier;

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -707,7 +707,6 @@ struct util_av_set;
 
 struct util_coll_mc {
 	struct fid_mc		mc_fid;
-	struct fid_ep		*ep;
 	struct util_av_set	*av_set;
 	uint64_t		local_rank;
 	uint16_t		group_id;

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -702,6 +702,30 @@ static inline void ofi_cntr_inc(struct util_cntr *cntr)
  * AV / addressing
  */
 
+struct util_av;
+struct util_av_set;
+
+struct util_coll_mc {
+	struct fid_mc		mc_fid;
+	struct fid_ep		*ep;
+	struct util_av_set	*av_set;
+	uint64_t		local_rank;
+	uint16_t		group_id;
+	uint16_t		seq;
+	ofi_atomic32_t		ref;
+};
+
+struct util_av_set {
+	struct fid_av_set	av_set_fid;
+	struct util_av		*av;
+	fi_addr_t		*fi_addr_array;
+	size_t			fi_addr_count;
+	uint64_t		flags;
+	struct util_coll_mc     coll_mc;
+	ofi_atomic32_t		ref;
+	ofi_mutex_t		lock;
+};
+
 struct util_av_entry {
 	ofi_atomic32_t	use_cnt;
 	UT_hash_handle	hh;
@@ -725,7 +749,7 @@ struct util_av {
 	struct util_av_entry	*hash;
 	struct ofi_bufpool	*av_entry_pool;
 
-	struct util_coll_mc	*coll_mc;
+	struct util_av_set	*av_set;
 	void			*context;
 	uint64_t		flags;
 	size_t			addrlen;
@@ -765,7 +789,6 @@ int ofi_av_insert_addr(struct util_av *av, const void *addr, fi_addr_t *fi_addr)
 int ofi_av_remove_addr(struct util_av *av, fi_addr_t fi_addr);
 fi_addr_t ofi_av_lookup_fi_addr_unsafe(struct util_av *av, const void *addr);
 fi_addr_t ofi_av_lookup_fi_addr(struct util_av *av, const void *addr);
-int ofi_av_elements_iter(struct util_av *av, ofi_av_apply_func apply, void *arg);
 int ofi_av_bind(struct fid *av_fid, struct fid *eq_fid, uint64_t flags);
 void ofi_av_write_event(struct util_av *av, uint64_t data,
 			int err, void *context);

--- a/prov/util/src/util_coll.c
+++ b/prov/util/src/util_coll.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2021 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -171,7 +171,7 @@ int ofi_av_set_remove(struct fid_av_set *set, fi_addr_t addr)
 	return -FI_EINVAL;
 }
 
-static inline uint64_t util_coll_form_tag(uint32_t coll_id, uint32_t rank)
+static uint64_t util_coll_form_tag(uint32_t coll_id, uint32_t rank)
 {
 	uint64_t tag;
 	uint64_t src_rank = rank;
@@ -182,29 +182,32 @@ static inline uint64_t util_coll_form_tag(uint32_t coll_id, uint32_t rank)
 	return OFI_COLL_TAG_FLAG | tag;
 }
 
-static inline uint32_t util_coll_get_next_id(struct util_coll_mc *coll_mc)
+static uint32_t util_coll_get_next_id(struct util_coll_mc *coll_mc)
 {
 	uint32_t cid = coll_mc->group_id;
 	return cid << 16 | coll_mc->seq++;
 }
 
-static inline int util_coll_op_create(struct util_coll_operation **coll_op,
-				    struct util_coll_mc *coll_mc,
-				    enum util_coll_op_type type, void *context,
-				    util_coll_comp_fn_t comp_fn)
+static struct util_coll_operation *
+util_coll_op_create(struct fid_ep *ep, struct util_coll_mc *coll_mc,
+		    enum util_coll_op_type type, void *context,
+		    util_coll_comp_fn_t comp_fn)
 {
-	*coll_op = calloc(1, sizeof(**coll_op));
-	if (!(*coll_op))
-		return -FI_ENOMEM;
+	struct util_coll_operation *coll_op;
 
-	(*coll_op)->cid = util_coll_get_next_id(coll_mc);
-	(*coll_op)->mc = coll_mc;
-	(*coll_op)->type = type;
-	(*coll_op)->context = context;
-	(*coll_op)->comp_fn = comp_fn;
-	dlist_init(&(*coll_op)->work_queue);
+	coll_op = calloc(1, sizeof(*coll_op));
+	if (!coll_op)
+		return NULL;
 
-	return FI_SUCCESS;
+	coll_op->ep = ep;
+	coll_op->cid = util_coll_get_next_id(coll_mc);
+	coll_op->mc = coll_mc;
+	coll_op->type = type;
+	coll_op->context = context;
+	coll_op->comp_fn = comp_fn;
+	dlist_init(&coll_op->work_queue);
+
+	return coll_op;
 }
 
 static inline void util_coll_op_log_work(struct util_coll_operation *coll_op)
@@ -214,6 +217,7 @@ static inline void util_coll_op_log_work(struct util_coll_operation *coll_op)
 	struct util_coll_xfer_item *xfer_item;
 	struct dlist_entry *tmp = NULL;
 	size_t count = 0;
+
 	FI_DBG(coll_op->mc->av_set->av->prov, FI_LOG_CQ, "Remaining Work for %s:\n",
 	       log_util_coll_op_type[coll_op->type]);
 	dlist_foreach_container_safe(&coll_op->work_queue, struct util_coll_work_item,
@@ -243,7 +247,6 @@ static inline void util_coll_op_log_work(struct util_coll_operation *coll_op)
 			       xfer_item->tag);
 			break;
 		case UTIL_COLL_REDUCE:
-			//reduce_item = container_of(cur_item, struct util_coll_reduce_item, hdr);
 			FI_DBG(coll_op->mc->av_set->av->prov, FI_LOG_CQ,
 			       "\t%ld: { %p [%s] REDUCTION }\n", count, cur_item,
 			       log_util_coll_state[cur_item->state]);
@@ -269,8 +272,9 @@ static inline void util_coll_op_log_work(struct util_coll_operation *coll_op)
 #endif
 }
 
-static inline void util_coll_op_progress_work(struct util_ep *util_ep,
-				      struct util_coll_operation *coll_op)
+static void
+util_coll_op_progress_work(struct util_ep *util_ep,
+			   struct util_coll_operation *coll_op)
 {
 	struct util_coll_work_item *next_ready = NULL;
 	struct util_coll_work_item *cur_item = NULL;
@@ -278,11 +282,13 @@ static inline void util_coll_op_progress_work(struct util_ep *util_ep,
 	struct dlist_entry *tmp = NULL;
 	int previous_is_head;
 
-	// clean up any completed items while searching for the next ready
-	dlist_foreach_container_safe(&coll_op->work_queue, struct util_coll_work_item,
-				     cur_item, waiting_entry, tmp)
-	{
-		previous_is_head = cur_item->waiting_entry.prev == &cur_item->coll_op->work_queue;
+	/* clean up any completed items while searching for the next ready */
+	dlist_foreach_container_safe(&coll_op->work_queue,
+				     struct util_coll_work_item,
+				     cur_item, waiting_entry, tmp) {
+
+		previous_is_head = (cur_item->waiting_entry.prev ==
+				    &cur_item->coll_op->work_queue);
 		if (!previous_is_head) {
 			prev_item = container_of(cur_item->waiting_entry.prev,
 						 struct util_coll_work_item,
@@ -290,7 +296,9 @@ static inline void util_coll_op_progress_work(struct util_ep *util_ep,
 		}
 
 		if (cur_item->state == UTIL_COLL_COMPLETE) {
-			// if there is work before cur and cur is fencing, we can't complete
+			/* If there is work before cur and cur is fencing,
+			 * we can't complete.
+			 */
 			if (cur_item->fence && !previous_is_head)
 				continue;
 
@@ -299,7 +307,7 @@ static inline void util_coll_op_progress_work(struct util_ep *util_ep,
 			dlist_remove(&cur_item->waiting_entry);
 			free(cur_item);
 
-			// if the work queue is empty, we're done
+			/* if the work queue is empty, we're done */
 			if (dlist_empty(&coll_op->work_queue)) {
 				free(coll_op);
 				return;
@@ -307,14 +315,16 @@ static inline void util_coll_op_progress_work(struct util_ep *util_ep,
 			continue;
 		}
 
-		// we can't progress if prior work is fencing
+		/* we can't progress if prior work is fencing */
 		if (!previous_is_head && prev_item && prev_item->fence) {
 			FI_DBG(coll_op->mc->av_set->av->prov, FI_LOG_CQ,
 			       "%p fenced by: %p \n", cur_item, prev_item);
 			return;
 		}
 
-		// if the current item isn't waiting, it's not the next ready item
+		/* If the current item isn't waiting, it's not the next
+		 * ready item.
+		 */
 		if (cur_item->state != UTIL_COLL_WAITING) {
 			FI_DBG(coll_op->mc->av_set->av->prov, FI_LOG_CQ,
 			       "Work item not waiting: %p [%s]\n", cur_item,
@@ -322,8 +332,8 @@ static inline void util_coll_op_progress_work(struct util_ep *util_ep,
 			continue;
 		}
 
-		FI_DBG(coll_op->mc->av_set->av->prov, FI_LOG_CQ, "Ready item: %p \n",
-		       cur_item);
+		FI_DBG(coll_op->mc->av_set->av->prov, FI_LOG_CQ,
+		       "Ready item: %p \n", cur_item);
 		next_ready = cur_item;
 		break;
 	}
@@ -337,16 +347,16 @@ static inline void util_coll_op_progress_work(struct util_ep *util_ep,
 	slist_insert_tail(&next_ready->ready_entry, &util_ep->coll_ready_queue);
 }
 
-static inline void util_coll_op_bind_work(struct util_coll_operation *coll_op,
-					  struct util_coll_work_item *item)
+static void util_coll_op_bind_work(struct util_coll_operation *coll_op,
+				   struct util_coll_work_item *item)
 {
 	item->coll_op = coll_op;
 	dlist_insert_tail(&item->waiting_entry, &coll_op->work_queue);
 }
 
-static int util_coll_sched_send(struct util_coll_operation *coll_op, uint32_t dest,
-				void *buf, int count, enum fi_datatype datatype,
-				int fence)
+static int
+util_coll_sched_send(struct util_coll_operation *coll_op, uint32_t dest,
+		     void *buf, int count, enum fi_datatype datatype, int fence)
 {
 	struct util_coll_xfer_item *xfer_item;
 
@@ -367,9 +377,9 @@ static int util_coll_sched_send(struct util_coll_operation *coll_op, uint32_t de
 	return FI_SUCCESS;
 }
 
-static int util_coll_sched_recv(struct util_coll_operation *coll_op, uint32_t src,
-				void *buf, int count, enum fi_datatype datatype,
-				int fence)
+static int
+util_coll_sched_recv(struct util_coll_operation *coll_op, uint32_t src,
+		     void *buf, int count, enum fi_datatype datatype, int fence)
 {
 	struct util_coll_xfer_item *xfer_item;
 
@@ -390,9 +400,10 @@ static int util_coll_sched_recv(struct util_coll_operation *coll_op, uint32_t sr
 	return FI_SUCCESS;
 }
 
-static int util_coll_sched_reduce(struct util_coll_operation *coll_op, void *in_buf,
-				  void *inout_buf, int count, enum fi_datatype datatype,
-				  enum fi_op op, int fence)
+static int
+util_coll_sched_reduce(struct util_coll_operation *coll_op, void *in_buf,
+		       void *inout_buf, int count, enum fi_datatype datatype,
+		       enum fi_op op, int fence)
 {
 	struct util_coll_reduce_item *reduce_item;
 
@@ -413,9 +424,10 @@ static int util_coll_sched_reduce(struct util_coll_operation *coll_op, void *in_
 	return FI_SUCCESS;
 }
 
-static int util_coll_sched_copy(struct util_coll_operation *coll_op, void *in_buf,
-				void *out_buf, int count, enum fi_datatype datatype,
-				int fence)
+static int
+util_coll_sched_copy(struct util_coll_operation *coll_op, void *in_buf,
+		     void *out_buf, int count, enum fi_datatype datatype,
+		     int fence)
 {
 	struct util_coll_copy_item *copy_item;
 
@@ -452,9 +464,10 @@ static int util_coll_sched_comp(struct util_coll_operation *coll_op)
 }
 
 /* TODO: when this fails, clean up the already scheduled work in this function */
-static int util_coll_allreduce(struct util_coll_operation *coll_op, const void *send_buf,
-			void *result, void* tmp_buf, int count, enum fi_datatype datatype,
-			enum fi_op op)
+static int
+util_coll_allreduce(struct util_coll_operation *coll_op, const void *send_buf,
+		    void *result, void* tmp_buf, int count,
+		    enum fi_datatype datatype, enum fi_op op)
 {
 	uint64_t rem, pof2, my_new_id;
 	uint64_t local, remote, next_remote;
@@ -470,8 +483,8 @@ static int util_coll_allreduce(struct util_coll_operation *coll_op, const void *
 
 	if (local < 2 * rem) {
 		if (local % 2 == 0) {
-			ret = util_coll_sched_send(coll_op, local + 1, result, count,
-						   datatype, 1);
+			ret = util_coll_sched_send(coll_op, local + 1, result,
+						   count, datatype, 1);
 			if (ret)
 				return ret;
 
@@ -499,34 +512,37 @@ static int util_coll_allreduce(struct util_coll_operation *coll_op, const void *
 			remote = (next_remote < rem) ? next_remote * 2 + 1 :
 				next_remote + rem;
 
-			// receive remote data into tmp buf
-			ret = util_coll_sched_recv(coll_op, remote, tmp_buf, count,
-						   datatype, 0);
+			/* receive remote data into tmp buf */
+			ret = util_coll_sched_recv(coll_op, remote, tmp_buf,
+						   count, datatype, 0);
 			if (ret)
 				return ret;
 
-			// send result buf, which has the current total
-			ret = util_coll_sched_send(coll_op, remote, result, count,
-						   datatype, 1);
+			/* send result buf, which has the current total */
+			ret = util_coll_sched_send(coll_op, remote, result,
+						   count, datatype, 1);
 			if (ret)
 				return ret;
 
 			if (remote < local) {
-				// reduce received remote into result buf
-				ret = util_coll_sched_reduce(coll_op, tmp_buf, result,
-							     count, datatype, op, 1);
+				/* reduce received remote into result buf */
+				ret = util_coll_sched_reduce(coll_op, tmp_buf,
+							     result, count,
+							     datatype, op, 1);
 				if (ret)
 					return ret;
 			} else {
-				// reduce local result into received data
-				ret = util_coll_sched_reduce(coll_op, result, tmp_buf,
-							     count, datatype, op, 1);
+				/* reduce local result into received data */
+				ret = util_coll_sched_reduce(coll_op, result,
+							     tmp_buf, count,
+							     datatype, op, 1);
 				if (ret)
 					return ret;
 
-				// copy total into result
-				ret = util_coll_sched_copy(coll_op, tmp_buf, result,
-							   count, datatype, 1);
+				/* copy total into result */
+				ret = util_coll_sched_copy(coll_op, tmp_buf,
+							   result, count,
+							   datatype, 1);
 				if (ret)
 					return ret;
 			}
@@ -536,13 +552,13 @@ static int util_coll_allreduce(struct util_coll_operation *coll_op, const void *
 
 	if (local < 2 * rem) {
 		if (local % 2) {
-			ret = util_coll_sched_send(coll_op, local - 1, result, count,
-						   datatype, 1);
+			ret = util_coll_sched_send(coll_op, local - 1, result,
+						   count, datatype, 1);
 			if (ret)
 				return ret;
 		} else {
-			ret = util_coll_sched_recv(coll_op, local + 1, result, count,
-						   datatype, 1);
+			ret = util_coll_sched_recv(coll_op, local + 1, result,
+						   count, datatype, 1);
 			if (ret)
 				return ret;
 		}
@@ -550,10 +566,12 @@ static int util_coll_allreduce(struct util_coll_operation *coll_op, const void *
 	return FI_SUCCESS;
 }
 
-static int util_coll_allgather(struct util_coll_operation *coll_op, const void *send_buf,
-			       void *result, int count, enum fi_datatype datatype)
+
+/* allgather implemented using ring algorithm */
+static int
+util_coll_allgather(struct util_coll_operation *coll_op, const void *send_buf,
+		    void *result, int count, enum fi_datatype datatype)
 {
-	// allgather implemented using ring algorithm
 	int64_t ret, i, cur_offset, next_offset;
 	size_t nbytes, numranks;
 	uint64_t local_rank, left_rank, right_rank;
@@ -562,31 +580,31 @@ static int util_coll_allgather(struct util_coll_operation *coll_op, const void *
 	nbytes = ofi_datatype_size(datatype) * count;
 	numranks = coll_op->mc->av_set->fi_addr_count;
 
-	// copy the local value to the appropriate place in result buffer
+	/* copy the local value to the appropriate place in result buffer */
 	ret = util_coll_sched_copy(coll_op, (void *) send_buf,
-				   (char *) result + (local_rank * nbytes), count,
-				   datatype, 1);
+				   (char *) result + (local_rank * nbytes),
+				   count, datatype, 1);
 	if (ret)
 		return ret;
 
-	// send to right, recv from left
+	/* send to right, recv from left */
 	left_rank = (numranks + local_rank - 1) % numranks;
 	right_rank = (local_rank + 1) % numranks;
 
 	cur_offset = local_rank;
 	next_offset = left_rank;
 
-	// fill in result with data going right to left
+	/* fill in result with data going right to left */
 	for (i = 1; i < numranks; i++) {
 		ret = util_coll_sched_send(coll_op, right_rank,
-					   (char *) result + (cur_offset * nbytes), count,
-					   datatype, 0);
+				(char *) result + (cur_offset * nbytes), count,
+				datatype, 0);
 		if (ret)
 			return ret;
 
 		ret = util_coll_sched_recv(coll_op, left_rank,
-					   (char *) result + (next_offset * nbytes),
-					   count, datatype, 1);
+				(char *) result + (next_offset * nbytes),
+				count, datatype, 1);
 		if (ret)
 			return ret;
 
@@ -606,11 +624,12 @@ static size_t util_binomial_tree_values_to_recv(uint64_t rank, size_t numranks)
 	return nvalues;
 }
 
-static int util_coll_scatter(struct util_coll_operation *coll_op, const void *data,
-			     void *result, void **temp, size_t count, uint64_t root,
-			     enum fi_datatype datatype)
+/* Scatter implemented with binomial tree algorithm */
+static int
+util_coll_scatter(struct util_coll_operation *coll_op, const void *data,
+		  void *result, void **temp, size_t count, uint64_t root,
+		  enum fi_datatype datatype)
 {
-	// scatter implemented with binomial tree algorithm
 	uint64_t local_rank, relative_rank;
 	size_t nbytes, numranks, send_cnt, cur_cnt = 0;
 	int ret, mask, remote_rank;
@@ -618,17 +637,21 @@ static int util_coll_scatter(struct util_coll_operation *coll_op, const void *da
 
 	local_rank = coll_op->mc->local_rank;
 	numranks = coll_op->mc->av_set->fi_addr_count;
-	relative_rank = (local_rank >= root) ? local_rank - root : local_rank - root + numranks;
+	relative_rank = (local_rank >= root) ?
+			local_rank - root : local_rank - root + numranks;
 	nbytes = count * ofi_datatype_size(datatype);
 
-	// check if we need to participate
+	/* check if we need to participate */
 	if (count == 0)
 		return FI_SUCCESS;
 
-	// non-root even nodes get a temp buffer for receiving data
-	// these nodes may need to send part of what they receive
+	/* Non-root even nodes get a temp buffer for receiving data.
+	 * These nodes may need to send part of what they receive.
+	 */
 	if (relative_rank && !(relative_rank % 2)) {
-		cur_cnt = count * util_binomial_tree_values_to_recv(relative_rank, numranks);
+		cur_cnt = count *
+			  util_binomial_tree_values_to_recv(relative_rank,
+							    numranks);
 		*temp = malloc(cur_cnt * ofi_datatype_size(datatype));
 		if (!*temp)
 			return -FI_ENOMEM;
@@ -637,23 +660,24 @@ static int util_coll_scatter(struct util_coll_operation *coll_op, const void *da
 	if (local_rank == root) {
 		cur_cnt = count * numranks;
 		if (root != 0) {
-			// if we're root but not rank 0, we need to reorder the send buffer
-			// according to destination rank. if we're rank 3, data intended for
-			// ranks 0-2 will be moved to the end
+			/* If we're root but not rank 0, we need to reorder the
+			 * send buffer according to destination rank.
+			 * E.g. if we're rank 3, data intended for ranks 0-2
+			 * will be moved to the end
+			 */
 			*temp = malloc(cur_cnt * ofi_datatype_size(datatype));
 			if (!*temp)
 				return -FI_ENOMEM;
+
 			ret = util_coll_sched_copy(coll_op,
-						   (char *) data + nbytes * local_rank, *temp,
-						   (numranks - local_rank) * count, datatype,
-						   1);
+				(char *) data + nbytes * local_rank, *temp,
+				(numranks - local_rank) * count, datatype, 1);
 			if (ret)
 				return ret;
 
 			ret = util_coll_sched_copy(coll_op, (char *) data,
-						   (char *) *temp +
-							   (numranks - local_rank) * nbytes,
-						   local_rank * count, datatype, 1);
+				(char *) *temp + (numranks - local_rank) * nbytes,
+				local_rank * count, datatype, 1);
 			if (ret)
 				return ret;
 		}
@@ -668,15 +692,15 @@ static int util_coll_scatter(struct util_coll_operation *coll_op, const void *da
 				remote_rank += numranks;
 
 			if (relative_rank % 2) {
-				// leaf node, we're receiving the actual data
-				ret = util_coll_sched_recv(coll_op, remote_rank, result, count,
-							   datatype, 1);
+				/* leaf node, receive our data */
+				ret = util_coll_sched_recv(coll_op, remote_rank,
+						result, count, datatype, 1);
 				if (ret)
 					return ret;
 			} else {
-				// branch node, we're receiving data which we've got to forward
-				ret = util_coll_sched_recv(coll_op, remote_rank, *temp,
-							   cur_cnt, datatype, 1);
+				/* branch node, receive data to forward */
+				ret = util_coll_sched_recv(coll_op, remote_rank,
+						*temp, cur_cnt, datatype, 1);
 				if (ret)
 					return ret;
 			}
@@ -690,10 +714,11 @@ static int util_coll_scatter(struct util_coll_operation *coll_op, const void *da
 	mask >>= 1;
 	while (mask > 0) {
 		if (relative_rank + mask < numranks) {
-			// to this point, cur_cnt has represented the number of values
-			// to expect to store in our data buf
-			// from here on, cur_cnt is the number of values we have left to
-			// forward from the data buf
+			/* To this point, cur_cnt has represented the number of
+			 * values to expect to store in our data buf.  From here
+			 * on, cur_cnt is the number of values we have left to
+			 * forward from the data buf.
+			 */
 			send_cnt = cur_cnt - count * mask;
 
 			remote_rank = local_rank + mask;
@@ -701,15 +726,14 @@ static int util_coll_scatter(struct util_coll_operation *coll_op, const void *da
 				remote_rank -= numranks;
 
 			FI_DBG(coll_op->mc->av_set->av->prov, FI_LOG_CQ,
-			       "MASK: 0x%0x CUR_CNT: %ld SENDING: %ld TO: %d\n", mask,
-			       cur_cnt, send_cnt, remote_rank);
+			       "MASK: 0x%0x CUR_CNT: %ld SENDING: %ld TO: %d\n",
+			       mask, cur_cnt, send_cnt, remote_rank);
 
 			assert(send_cnt > 0);
 
 			ret = util_coll_sched_send(coll_op, remote_rank,
-							(char *) send_data +
-								nbytes * mask,
-							send_cnt, datatype, 1);
+					(char *) send_data + nbytes * mask,
+					send_cnt, datatype, 1);
 			if (ret)
 				return ret;
 
@@ -721,7 +745,8 @@ static int util_coll_scatter(struct util_coll_operation *coll_op, const void *da
 	if (!(relative_rank % 2)) {
 		// for the root and all even nodes, we've got to copy
 		// our local data to the result buffer
-		ret = util_coll_sched_copy(coll_op, send_data, result, count, datatype, 1);
+		ret = util_coll_sched_copy(coll_op, send_data, result,
+					   count, datatype, 1);
 	}
 
 	return FI_SUCCESS;
@@ -758,11 +783,8 @@ static int ofi_av_set_addr(struct fid_av_set *set, fi_addr_t *coll_addr)
 	return FI_SUCCESS;
 }
 
-/* TODO: Figure out requirements for using collectives.
- * e.g. require local address to be in AV?
- * Determine best way to handle first join request
- */
-static int util_coll_find_local_rank(struct fid_ep *ep, struct util_coll_mc *coll_mc)
+static int
+util_coll_find_local_rank(struct fid_ep *ep, struct util_coll_mc *coll_mc)
 {
 	size_t addrlen;
 	char *addr;
@@ -803,8 +825,9 @@ static int util_coll_find_local_rank(struct fid_ep *ep, struct util_coll_mc *col
 void util_coll_join_comp(struct util_coll_operation *coll_op)
 {
 	struct fi_eq_entry entry;
-	struct util_ep *ep = container_of(coll_op->mc->ep, struct util_ep, ep_fid);
+	struct util_ep *ep;
 
+	ep = container_of(coll_op->ep, struct util_ep, ep_fid);
 	coll_op->data.join.new_mc->seq = 0;
 	coll_op->data.join.new_mc->group_id =
 				ofi_bitmask_get_lsbset(coll_op->data.join.data);
@@ -829,7 +852,7 @@ void util_coll_collective_comp(struct util_coll_operation *coll_op)
 {
 	struct util_ep *ep;
 
-	ep = container_of(coll_op->mc->ep, struct util_ep, ep_fid);
+	ep = container_of(coll_op->ep, struct util_ep, ep_fid);
 
 	if (ofi_cq_write(ep->tx_cq, coll_op->context, FI_COLLECTIVE, 0, 0, 0, 0))
 		FI_WARN(ep->domain->fabric->prov, FI_LOG_DOMAIN,
@@ -868,11 +891,14 @@ static int util_coll_proc_reduce_item(struct util_coll_reduce_item *reduce_item)
 	return FI_SUCCESS;
 }
 
-int util_coll_process_xfer_item(struct util_coll_xfer_item *item) {
-	struct iovec iov;
+int util_coll_process_xfer_item(struct util_coll_xfer_item *item)
+{
+	struct util_coll_operation *coll_op;
 	struct fi_msg_tagged msg;
-	struct util_coll_mc *mc = item->hdr.coll_op->mc;
+	struct iovec iov;
 	int ret;
+
+	coll_op = item->hdr.coll_op;
 
 	msg.msg_iov = &iov;
 	msg.desc = NULL;
@@ -881,26 +907,26 @@ int util_coll_process_xfer_item(struct util_coll_xfer_item *item) {
 	msg.context = item;
 	msg.data = 0;
 	msg.tag = item->tag;
-	msg.addr = mc->av_set->fi_addr_array[item->remote_rank];
+	msg.addr = coll_op->mc->av_set->fi_addr_array[item->remote_rank];
 
 	iov.iov_base = item->buf;
 	iov.iov_len = (item->count * ofi_datatype_size(item->datatype));
 
 	if (item->hdr.type == UTIL_COLL_SEND) {
-		ret = fi_tsendmsg(mc->ep, &msg, FI_COLLECTIVE);
+		ret = fi_tsendmsg(coll_op->ep, &msg, FI_COLLECTIVE);
 		if (!ret)
-			FI_DBG(mc->av_set->av->prov, FI_LOG_CQ,
-			       "%p SEND [0x%02lx] -> [0x%02x] cnt: %d sz: %ld\n", item,
-			       item->hdr.coll_op->mc->local_rank, item->remote_rank,
+			FI_DBG(coll_op->mc->av_set->av->prov, FI_LOG_CQ,
+			       "%p SEND [0x%02lx] -> [0x%02x] cnt: %d sz: %ld\n",
+			       item, coll_op->mc->local_rank, item->remote_rank,
 			       item->count,
 			       item->count * ofi_datatype_size(item->datatype));
 		return ret;
 	} else if (item->hdr.type == UTIL_COLL_RECV) {
-		ret = fi_trecvmsg(mc->ep, &msg, FI_COLLECTIVE);
+		ret = fi_trecvmsg(coll_op->ep, &msg, FI_COLLECTIVE);
 		if (!ret)
-			FI_DBG(mc->av_set->av->prov, FI_LOG_CQ,
-			       "%p RECV [0x%02lx] <- [0x%02x] cnt: %d sz: %ld\n", item,
-			       item->hdr.coll_op->mc->local_rank, item->remote_rank,
+			FI_DBG(coll_op->mc->av_set->av->prov, FI_LOG_CQ,
+			       "%p RECV [0x%02lx] <- [0x%02x] cnt: %d sz: %ld\n",
+			       item, coll_op->mc->local_rank, item->remote_rank,
 			       item->count,
 			       item->count * ofi_datatype_size(item->datatype));
 		return ret;
@@ -928,7 +954,8 @@ int ofi_coll_ep_progress(struct fid_ep *ep)
 		coll_op = work_item->coll_op;
 		switch (work_item->type) {
 		case UTIL_COLL_SEND:
-			xfer_item = container_of(work_item, struct util_coll_xfer_item, hdr);
+			xfer_item = container_of(work_item,
+						struct util_coll_xfer_item, hdr);
 			ret = util_coll_process_xfer_item(xfer_item);
 			if (ret && ret == -FI_EAGAIN) {
 				slist_insert_tail(&work_item->ready_entry,
@@ -937,13 +964,15 @@ int ofi_coll_ep_progress(struct fid_ep *ep)
 			}
 			break;
 		case UTIL_COLL_RECV:
-			xfer_item = container_of(work_item, struct util_coll_xfer_item, hdr);
+			xfer_item = container_of(work_item,
+						struct util_coll_xfer_item, hdr);
 			ret = util_coll_process_xfer_item(xfer_item);
 			if (ret)
 				goto out;
 			break;
 		case UTIL_COLL_REDUCE:
-			reduce_item = container_of(work_item, struct util_coll_reduce_item, hdr);
+			reduce_item = container_of(work_item,
+						struct util_coll_reduce_item, hdr);
 			ret = util_coll_proc_reduce_item(reduce_item);
 			if (ret)
 				goto out;
@@ -951,9 +980,11 @@ int ofi_coll_ep_progress(struct fid_ep *ep)
 			reduce_item->hdr.state = UTIL_COLL_COMPLETE;
 			break;
 		case UTIL_COLL_COPY:
-			copy_item = container_of(work_item, struct util_coll_copy_item, hdr);
+			copy_item = container_of(work_item,
+						struct util_coll_copy_item, hdr);
 			memcpy(copy_item->out_buf, copy_item->in_buf,
-			       copy_item->count * ofi_datatype_size(copy_item->datatype));
+			       copy_item->count *
+			       ofi_datatype_size(copy_item->datatype));
 
 			copy_item->hdr.state = UTIL_COLL_COMPLETE;
 			break;
@@ -978,7 +1009,7 @@ out:
 }
 
 static struct util_coll_mc *
-util_create_coll_mc(struct fid_ep *ep, struct util_av_set *av_set, void *context)
+util_create_coll_mc(struct util_av_set *av_set, void *context)
 {
 	struct util_coll_mc *coll_mc;
 
@@ -993,7 +1024,6 @@ util_create_coll_mc(struct fid_ep *ep, struct util_av_set *av_set, void *context
 
 	ofi_atomic_inc32(&av_set->ref);
 	coll_mc->av_set = av_set;
-	coll_mc->ep = ep;
 
 	return coll_mc;
 }
@@ -1017,10 +1047,8 @@ int ofi_join_collective(struct fid_ep *ep, fi_addr_t coll_addr,
 	} else {
 		coll_mc = (struct util_coll_mc*) ((uintptr_t) coll_addr);
 	}
-	/* TODO: This won't work if there are multiple ep's */
-	coll_mc->ep = ep;
 
-	new_coll_mc = util_create_coll_mc(ep, av_set, context);
+	new_coll_mc = util_create_coll_mc(av_set, context);
 	if (!new_coll_mc)
 		return -FI_ENOMEM;
 
@@ -1028,10 +1056,12 @@ int ofi_join_collective(struct fid_ep *ep, fi_addr_t coll_addr,
 	util_coll_find_local_rank(ep, new_coll_mc);
 	util_coll_find_local_rank(ep, coll_mc);
 
-	ret = util_coll_op_create(&join_op, coll_mc, UTIL_COLL_JOIN_OP, context,
-				util_coll_join_comp);
-	if (ret)
+	join_op = util_coll_op_create(ep, coll_mc, UTIL_COLL_JOIN_OP, context,
+				      util_coll_join_comp);
+	if (!join_op) {
+		ret = -FI_ENOMEM;
 		goto err1;
+	}
 
 	join_op->data.join.new_mc = new_coll_mc;
 
@@ -1201,14 +1231,16 @@ ssize_t ofi_ep_barrier(struct fid_ep *ep, fi_addr_t coll_addr, void *context)
 
 	coll_mc = (struct util_coll_mc*) ((uintptr_t) coll_addr);
 
-	ret = util_coll_op_create(&barrier_op, coll_mc, UTIL_COLL_BARRIER_OP, context,
-			  util_coll_collective_comp);
-	if (ret)
-		return ret;
+	barrier_op = util_coll_op_create(ep, coll_mc, UTIL_COLL_BARRIER_OP,
+					 context, util_coll_collective_comp);
+	if (!barrier_op)
+		return -FI_ENOMEM;
 
 	send = ~barrier_op->mc->local_rank;
-	ret = util_coll_allreduce(barrier_op, &send, &barrier_op->data.barrier.data,
-				  &barrier_op->data.barrier.tmp, 1, FI_UINT64, FI_BAND);
+	ret = util_coll_allreduce(barrier_op, &send,
+				  &barrier_op->data.barrier.data,
+				  &barrier_op->data.barrier.tmp, 1, FI_UINT64,
+				  FI_BAND);
 	if (ret)
 		goto err1;
 
@@ -1225,10 +1257,11 @@ err1:
 	return ret;
 }
 
-ssize_t ofi_ep_allreduce(struct fid_ep *ep, const void *buf, size_t count, void *desc,
-			 void *result, void *result_desc, fi_addr_t coll_addr,
-			 enum fi_datatype datatype, enum fi_op op, uint64_t flags,
-			 void *context)
+ssize_t
+ofi_ep_allreduce(struct fid_ep *ep, const void *buf, size_t count, void *desc,
+		 void *result, void *result_desc, fi_addr_t coll_addr,
+		 enum fi_datatype datatype, enum fi_op op, uint64_t flags,
+		 void *context)
 {
 	struct util_coll_mc *coll_mc;
 	struct util_coll_operation *allreduce_op;
@@ -1236,18 +1269,20 @@ ssize_t ofi_ep_allreduce(struct fid_ep *ep, const void *buf, size_t count, void 
 	int ret;
 
 	coll_mc = (struct util_coll_mc *) ((uintptr_t) coll_addr);
-	ret = util_coll_op_create(&allreduce_op, coll_mc, UTIL_COLL_ALLREDUCE_OP, context,
-				  util_coll_collective_comp);
-	if (ret)
-		return ret;
+	allreduce_op = util_coll_op_create(ep, coll_mc, UTIL_COLL_ALLREDUCE_OP,
+					   context, util_coll_collective_comp);
+	if (!allreduce_op)
+		return -FI_ENOMEM;
 
 
 	allreduce_op->data.allreduce.size = count * ofi_datatype_size(datatype);
-	allreduce_op->data.allreduce.data = calloc(count, ofi_datatype_size(datatype));
+	allreduce_op->data.allreduce.data = calloc(count,
+						ofi_datatype_size(datatype));
 	if (!allreduce_op->data.allreduce.data)
 		goto err1;
 
-	ret = util_coll_allreduce(allreduce_op, buf, result, allreduce_op->data.allreduce.data, count,
+	ret = util_coll_allreduce(allreduce_op, buf, result,
+				  allreduce_op->data.allreduce.data, count,
 				  datatype, op);
 	if (ret)
 		goto err2;
@@ -1277,10 +1312,10 @@ ssize_t ofi_ep_allgather(struct fid_ep *ep, const void *buf, size_t count, void 
 	int ret;
 
 	coll_mc = (struct util_coll_mc *) ((uintptr_t) coll_addr);
-	ret = util_coll_op_create(&allgather_op, coll_mc, UTIL_COLL_ALLGATHER_OP, context,
-				  util_coll_collective_comp);
-	if (ret)
-		return ret;
+	allgather_op = util_coll_op_create(ep, coll_mc, UTIL_COLL_ALLGATHER_OP,
+					   context, util_coll_collective_comp);
+	if (!allgather_op)
+		return -FI_ENOMEM;
 
 	ret = util_coll_allgather(allgather_op, buf, result, count, datatype);
 	if (ret)
@@ -1310,12 +1345,14 @@ ssize_t ofi_ep_scatter(struct fid_ep *ep, const void *buf, size_t count, void *d
 	int ret;
 
 	coll_mc = (struct util_coll_mc *) ((uintptr_t) coll_addr);
-	ret = util_coll_op_create(&scatter_op, coll_mc, UTIL_COLL_SCATTER_OP, context,
-				  util_coll_collective_comp);
-	if (ret)
-		return ret;
+	scatter_op = util_coll_op_create(ep, coll_mc, UTIL_COLL_SCATTER_OP,
+					 context, util_coll_collective_comp);
+	if (!scatter_op)
+		return -FI_ENOMEM;
 
-	ret = util_coll_scatter(scatter_op, buf, result, &scatter_op->data.scatter, count, root_addr, datatype);
+	ret = util_coll_scatter(scatter_op, buf, result,
+				&scatter_op->data.scatter, count,
+				root_addr, datatype);
 	if (ret)
 		goto err;
 
@@ -1342,30 +1379,34 @@ ssize_t ofi_ep_broadcast(struct fid_ep *ep, void *buf, size_t count, void *desc,
 	int ret, chunk_cnt, numranks, local;
 
 	coll_mc = (struct util_coll_mc *) ((uintptr_t) coll_addr);
-	ret = util_coll_op_create(&broadcast_op, coll_mc, UTIL_COLL_BROADCAST_OP, context,
-				  util_coll_collective_comp);
-	if (ret)
-		return ret;
+	broadcast_op = util_coll_op_create(ep, coll_mc, UTIL_COLL_BROADCAST_OP,
+					   context, util_coll_collective_comp);
+	if (!broadcast_op)
+		return -FI_ENOMEM;
 
 	local = broadcast_op->mc->local_rank;
 	numranks = broadcast_op->mc->av_set->fi_addr_count;
 	chunk_cnt = (count + numranks - 1) / numranks;
-	if (chunk_cnt * local > count && chunk_cnt * local - (int) count > chunk_cnt)
+	if (chunk_cnt * local > count &&
+	    chunk_cnt * local - (int) count > chunk_cnt)
 		chunk_cnt = 0;
 
-	broadcast_op->data.broadcast.chunk = malloc(chunk_cnt * ofi_datatype_size(datatype));
+	broadcast_op->data.broadcast.chunk = malloc(chunk_cnt *
+						ofi_datatype_size(datatype));
 	if (!broadcast_op->data.broadcast.chunk) {
 		ret = -FI_ENOMEM;
 		goto err1;
 	}
 
-	ret = util_coll_scatter(broadcast_op, buf, broadcast_op->data.broadcast.chunk,
-				&broadcast_op->data.broadcast.scatter, chunk_cnt,
-				root_addr, datatype);
+	ret = util_coll_scatter(broadcast_op, buf,
+				broadcast_op->data.broadcast.chunk,
+				&broadcast_op->data.broadcast.scatter,
+				chunk_cnt, root_addr, datatype);
 	if (ret)
 		goto err2;
 
-	ret = util_coll_allgather(broadcast_op, broadcast_op->data.broadcast.chunk, buf,
+	ret = util_coll_allgather(broadcast_op,
+				  broadcast_op->data.broadcast.chunk, buf,
 				  chunk_cnt, datatype);
 	if (ret)
 		goto err2;
@@ -1387,21 +1428,27 @@ err1:
 
 void ofi_coll_handle_xfer_comp(uint64_t tag, void *ctx)
 {
+	struct util_coll_operation *coll_op;
 	struct util_ep *util_ep;
-	struct util_coll_xfer_item *xfer_item = (struct util_coll_xfer_item *) ctx;
+	struct util_coll_xfer_item *xfer_item;
+
+	xfer_item = ctx;
 	xfer_item->hdr.state = UTIL_COLL_COMPLETE;
 
-	FI_DBG(xfer_item->hdr.coll_op->mc->av_set->av->prov, FI_LOG_CQ,
-	       "\tXfer complete: { %p %s Remote: 0x%02x Local: 0x%02lx cnt: %d typesize: %ld }\n",
-	       xfer_item, xfer_item->hdr.type == UTIL_COLL_SEND ? "SEND" : "RECV",
-	       xfer_item->remote_rank, xfer_item->hdr.coll_op->mc->local_rank,
+	coll_op = xfer_item->hdr.coll_op;
+	FI_DBG(coll_op->mc->av_set->av->prov, FI_LOG_CQ,
+	       "\tXfer complete: { %p %s Remote: 0x%02x Local: "
+	       "0x%02lx cnt: %d typesize: %ld }\n", xfer_item,
+	       xfer_item->hdr.type == UTIL_COLL_SEND ? "SEND" : "RECV",
+	       xfer_item->remote_rank, coll_op->mc->local_rank,
 	       xfer_item->count, ofi_datatype_size(xfer_item->datatype));
-	util_ep = container_of(xfer_item->hdr.coll_op->mc->ep, struct util_ep, ep_fid);
-	util_coll_op_progress_work(util_ep, xfer_item->hdr.coll_op);
+
+	util_ep = container_of(coll_op->ep, struct util_ep, ep_fid);
+	util_coll_op_progress_work(util_ep, coll_op);
 }
 
 int ofi_query_collective(struct fid_domain *domain, enum fi_collective_op coll,
-				struct fi_collective_attr *attr, uint64_t flags)
+			 struct fi_collective_attr *attr, uint64_t flags)
 {
 	int ret;
 
@@ -1433,14 +1480,15 @@ int ofi_query_collective(struct fid_domain *domain, enum fi_collective_op coll,
 	if (ret)
 		return ret;
 
-	// with the currently implemented software based collective operations
-	// the only restriction is the number of ranks we can address, as limited
-	// by the size of the rank portion of the collective tag, which is 31 bits.
-	// future collectives may impose further restrictions which will need to update
-	// the calculation.  For example, operations which require dedicated space in
-	// the recieve buffer for each rank would limit the number of members by buffer
-	// size and value type (8kB buffer / 64B value = 128 member max).
-	// hardware may impose further restrictions
+	/* with the currently implemented software based collective operations
+	 * the only restriction is the number of ranks we can address, as
+	 * limited by the size of the rank portion of the collective tag, which
+	 * is 31 bits.  Future collectives may impose further restrictions which
+	 * will need to update the calculation.  For example, operations which
+	 * require dedicated space in the recieve buffer for each rank would
+	 * limit the number of members by buffer size and value type
+	 * (8kB buffer / 64B value = 128 member max).
+	 */
 	attr->max_members = ~(0x80000000);
 
 	return FI_SUCCESS;


### PR DESCRIPTION
There is a memory leak of the coll_mc when the parent AV is
destroyed.  To fix the leak, we simplify and restructure the
creation of AV sets.  This may seem like overkill, but is
necessary to fixup object reference counting.

The current code associates a base collective multicast group
(coll_mc) with an AV the first time an AV set is created.  This adds
a coll_mc to the AV, which is what gets leaked.  However, that
coll_mc itself creates an av_set.  Part of the generic creation
of an av_set, a coll_mc is created.  The result is that we have
AV -> coll_mc -> av_set -> coll_mc.  So, there's a double coll_mc
created for the AV.

We can simplify the code by having the AV create an initial av_set
when needed, and let create av_set create the coll_mc.  Then use
that coll_mc and avoid the duplicate coll_mc creation.  This
keeps the av_set to coll_mc objects the same regardless of
whether we allocate them internally or in response to the user
calling fi_av_set().

Finally, to fix the memory leak, when destroying the AV, we just
need to call fi_close() on the av_set.  The resulting code has
common paths for av_set and coll_mc creation/initialization/
destruction.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>