### PR TITLE
prov/shm: call original SIG_DFL handler from shm signal handler

### DIFF
--- a/prov/shm/src/smr_signal.h
+++ b/prov/shm/src/smr_signal.h
@@ -62,8 +62,9 @@ static void smr_handle_signal(int signum, siginfo_t *info, void *ucontext)
 	/* call the original handler */
 	if (old_action[signum].sa_flags & SA_SIGINFO)
 		old_action[signum].sa_sigaction(signum, info, ucontext);
-	else if (old_action[signum].sa_handler == SIG_DFL ||
-		 old_action[signum].sa_handler == SIG_IGN)
+	else if (old_action[signum].sa_handler == SIG_DFL)
+		raise(signum);
+	else if (old_action[signum].sa_handler == SIG_IGN)
 		return;
 	else
 		old_action[signum].sa_handler(signum);


### PR DESCRIPTION
Signed-off-by: Andrey Lobanov <andrey.lobanov@intel.com>