### PR TITLE
netdir / fi_endpoint uses maximum values to create queue pair

### DIFF
--- a/prov/netdir/src/netdir.h
+++ b/prov/netdir/src/netdir.h
@@ -51,7 +51,6 @@ extern "C" {
 
 #define ND_MSG_IOV_LIMIT		(256)
 #define ND_MSG_INTERNAL_IOV_LIMIT	(512)
-#define ND_EP_MAX_CM_DATA_SIZE		(256)
 #define OFI_ND_MAX_MR_CNT		(1 << 16)
 
 #define OFI_ND_DOMAIN_CAPS	(FI_LOCAL_COMM | FI_REMOTE_COMM)

--- a/prov/netdir/src/netdir_ep.c
+++ b/prov/netdir/src/netdir_ep.c
@@ -69,7 +69,8 @@ static void ofi_nd_ep_disconnected_free(struct nd_event_base* base);
 static void ofi_nd_ep_disconnected(struct nd_event_base* base, DWORD bytes);
 static void ofi_nd_ep_disconnected_err(struct nd_event_base* base, DWORD bytes, DWORD err);
 static ssize_t ofi_nd_ep_cancel(fid_t fid, void *context);
-
+int ofi_nd_ep_getopt(struct fid* ep, int level, int optname,
+	void* optval, size_t* optlen);
 
 static struct fi_ops ofi_nd_fi_ops = {
 	.size = sizeof(ofi_nd_fi_ops),
@@ -98,7 +99,7 @@ extern struct fi_ops_rma ofi_nd_ep_rma;
 static struct fi_ops_ep ofi_nd_ep_ops = {
 	.size = sizeof(ofi_nd_ep_ops),
 	.cancel = ofi_nd_ep_cancel,
-	.getopt = fi_no_getopt,
+	.getopt = ofi_nd_ep_getopt,
 	.setopt = fi_no_setopt,
 	.tx_ctx = fi_no_tx_ctx,
 	.rx_ctx = fi_no_rx_ctx,
@@ -266,10 +267,10 @@ static int ofi_nd_ep_control(struct fid *fid, int command, void *arg)
 		(IUnknown*)ep->domain->cq,
 		(IUnknown*)ep->domain->cq,
 		ep,
-		ep->domain->ainfo.MaxReceiveQueueDepth,
-		ep->domain->ainfo.MaxInitiatorQueueDepth,
-		ep->domain->ainfo.MaxReceiveSge,
-		ep->domain->ainfo.MaxInitiatorSge,
+		ep->info->rx_attr->size,
+		ep->info->tx_attr->size,
+		ep->info->rx_attr->iov_limit,
+		ep->info->tx_attr->iov_limit,
 		0, (void**)&ep->qp);
 	if (FAILED(hr))
 		return H2F(hr);
@@ -850,5 +851,28 @@ static ssize_t ofi_nd_ep_cancel(fid_t fid, void *context)
 	return ofi_nd_cq_cancel(fid, context);
 }
 
-#endif /* _WIN32 */
+int ofi_nd_ep_getopt(struct fid* fid, int level, int optname,
+	void* optval, size_t* optlen)
+{
+	assert(fid->fclass == FI_CLASS_EP);
+	struct nd_ep* ep = container_of(fid, struct nd_ep, fid.fid);
 
+	assert(level == FI_OPT_ENDPOINT && optname == FI_OPT_CM_DATA_SIZE);
+	assert(optval);
+	assert(optlen);
+
+	if (level != FI_OPT_ENDPOINT || optname != FI_OPT_CM_DATA_SIZE)
+		return -FI_ENOPROTOOPT;
+
+	if (*optlen < sizeof(size_t)) {
+		*optlen = sizeof(size_t);
+		return -FI_ETOOSMALL;
+	}
+
+	*((size_t*)optval) = ep->domain->ainfo.MaxCallerData;
+	*optlen = sizeof(size_t);
+
+	return 0;
+}
+
+#endif /* _WIN32 */

--- a/prov/netdir/src/netdir_ep_srx.c
+++ b/prov/netdir/src/netdir_ep_srx.c
@@ -65,6 +65,8 @@ static ssize_t ofi_nd_no_injectdata(struct fid_ep *ep, const void *buf, size_t l
 				    uint64_t data, fi_addr_t dest_addr);
 static int ofi_nd_srx_close(struct fid *fid);
 static ssize_t ofi_nd_srx_cancel(fid_t fid, void *context);
+extern int ofi_nd_ep_getopt(struct fid* ep, int level, int optname,
+	void* optval, size_t* optlen);
 
 struct fi_ops_msg ofi_nd_srx_msg = {
 	.size = sizeof(ofi_nd_srx_msg),
@@ -96,7 +98,7 @@ static struct fid ofi_nd_fid = {
 static struct fi_ops_ep ofi_nd_ep_ops = {
 	.size = sizeof(ofi_nd_ep_ops),
 	.cancel = ofi_nd_srx_cancel,
-	.getopt = fi_no_getopt,
+	.getopt = ofi_nd_ep_getopt,
 	.setopt = fi_no_setopt,
 	.tx_ctx = fi_no_tx_ctx,
 	.rx_ctx = fi_no_rx_ctx,

--- a/prov/netdir/src/netdir_init.c
+++ b/prov/netdir/src/netdir_init.c
@@ -54,9 +54,14 @@ struct fi_provider ofi_nd_prov = {
 	.cleanup = ofi_nd_fini
 };
 
+static int ofi_nd_alter_defaults(uint32_t version, const struct fi_info *hints,
+		                         const struct fi_info *base_info,
+		                         struct fi_info *dest_info);
+
 struct util_prov ofi_nd_util_prov = {
 	.prov = &ofi_nd_prov,
 	.info = 0,
+    .alter_defaults = &ofi_nd_alter_defaults,
 	.flags = UTIL_RX_SHARED_CTX,
 };
 
@@ -68,6 +73,23 @@ struct gl_data gl_data = {
 	.flow_control_cnt = 1,
 	.total_avail = 64
 };
+
+static size_t nd_default_tx_iov_limit = 8;
+static size_t nd_default_tx_size = 384;
+static size_t nd_default_rx_iov_limit = 8;
+static size_t nd_default_rx_size = 384;
+
+static int ofi_nd_alter_defaults(uint32_t version, const struct fi_info *hints,
+                                 const struct fi_info *base_info,
+                                 struct fi_info *dest_info)
+{
+    dest_info->tx_attr->iov_limit = min(base_info->tx_attr->iov_limit, nd_default_tx_iov_limit);
+    dest_info->tx_attr->size = min(base_info->tx_attr->size, nd_default_tx_size);
+    dest_info->rx_attr->iov_limit = min(base_info->rx_attr->iov_limit, nd_default_rx_iov_limit);
+    dest_info->rx_attr->size = min(base_info->rx_attr->size, nd_default_rx_size);
+
+    return 0;
+}
 
 int ofi_nd_getinfo(uint32_t version, const char *node, const char *service,
 		   uint64_t flags, const struct fi_info *hints,
@@ -107,8 +129,8 @@ static int ofi_nd_adapter_cb(const ND2_ADAPTER_INFO *adapter, const char *name)
 	info->tx_attr->size = (size_t)adapter->MaxInitiatorQueueDepth;
 	/* TODO: if optimization will be needed, we can use adapter->MaxInitiatorSge,
 	 * and use ND SGE to send/write iovecs */
-	info->tx_attr->iov_limit = (size_t)adapter->MaxInitiatorSge;
-	info->tx_attr->rma_iov_limit = (size_t)adapter->MaxInitiatorSge;
+	info->tx_attr->iov_limit = (size_t)min(adapter->MaxInitiatorSge, ND_MSG_IOV_LIMIT);
+    info->tx_attr->rma_iov_limit = 1;
 	info->tx_attr->op_flags = OFI_ND_TX_OP_FLAGS;
 	info->tx_attr->msg_order = OFI_ND_MSG_ORDER;
 
@@ -119,7 +141,7 @@ static int ofi_nd_adapter_cb(const ND2_ADAPTER_INFO *adapter, const char *name)
 	info->rx_attr->size = (size_t)adapter->MaxReceiveQueueDepth;
 	/* TODO: if optimization will be needed, we can use adapter->MaxInitiatorSge,
 	 * and use ND SGE to recv iovecs */
-	info->rx_attr->iov_limit = (size_t)adapter->MaxReceiveSge;
+	info->rx_attr->iov_limit = (size_t)min(adapter->MaxReceiveSge, ND_MSG_IOV_LIMIT);
 	info->rx_attr->msg_order = OFI_ND_MSG_ORDER;
 
 	info->ep_attr->type = FI_EP_MSG;

--- a/prov/netdir/src/netdir_init.c
+++ b/prov/netdir/src/netdir_init.c
@@ -104,11 +104,11 @@ static int ofi_nd_adapter_cb(const ND2_ADAPTER_INFO *adapter, const char *name)
 	info->tx_attr->mode = FI_CONTEXT;
 	info->tx_attr->comp_order = FI_ORDER_STRICT;
 	info->tx_attr->inject_size = (size_t)gl_data.inline_thr;
-	info->tx_attr->size = (size_t)adapter->MaxTransferLength;
+	info->tx_attr->size = (size_t)adapter->MaxInitiatorQueueDepth;
 	/* TODO: if optimization will be needed, we can use adapter->MaxInitiatorSge,
 	 * and use ND SGE to send/write iovecs */
-	info->tx_attr->iov_limit = ND_MSG_IOV_LIMIT;
-	info->tx_attr->rma_iov_limit = ND_MSG_IOV_LIMIT;
+	info->tx_attr->iov_limit = (size_t)adapter->MaxInitiatorSge;
+	info->tx_attr->rma_iov_limit = (size_t)adapter->MaxInitiatorSge;
 	info->tx_attr->op_flags = OFI_ND_TX_OP_FLAGS;
 	info->tx_attr->msg_order = OFI_ND_MSG_ORDER;
 
@@ -116,10 +116,10 @@ static int ofi_nd_adapter_cb(const ND2_ADAPTER_INFO *adapter, const char *name)
 	info->rx_attr->mode = FI_CONTEXT;
 	info->rx_attr->comp_order = FI_ORDER_STRICT;
 	info->rx_attr->total_buffered_recv = 0;
-	info->rx_attr->size = (size_t)adapter->MaxTransferLength;
+	info->rx_attr->size = (size_t)adapter->MaxReceiveQueueDepth;
 	/* TODO: if optimization will be needed, we can use adapter->MaxInitiatorSge,
 	 * and use ND SGE to recv iovecs */
-	info->rx_attr->iov_limit = ND_MSG_IOV_LIMIT;
+	info->rx_attr->iov_limit = (size_t)adapter->MaxReceiveSge;
 	info->rx_attr->msg_order = OFI_ND_MSG_ORDER;
 
 	info->ep_attr->type = FI_EP_MSG;

--- a/prov/netdir/src/netdir_pep.c
+++ b/prov/netdir/src/netdir_pep.c
@@ -57,7 +57,7 @@ static void ofi_nd_pep_connreq_free(nd_event_base *base);
 static void ofi_nd_pep_connreq(nd_event_base *base, DWORD bytes);
 static void ofi_nd_pep_connreq_err(nd_event_base *base, DWORD err,
 				   DWORD bytes);
-static int ofi_nd_pep_getopt(struct fid *ep, int level, int optname,
+extern int ofi_nd_ep_getopt(struct fid *ep, int level, int optname,
 			void *optval, size_t *optlen);
 
 static struct fi_ops ofi_nd_fi_ops = {
@@ -90,7 +90,7 @@ static struct fi_ops_cm ofi_nd_cm_ops = {
 static struct fi_ops_ep ofi_nd_pep_ops = {
 	.size = sizeof(ofi_nd_pep_ops),
 	.cancel = fi_no_cancel,
-	.getopt = ofi_nd_pep_getopt,
+	.getopt = ofi_nd_ep_getopt,
 	.setopt = fi_no_setopt,
 	.tx_ctx = fi_no_tx_ctx,
 	.rx_ctx = fi_no_rx_ctx,
@@ -475,30 +475,6 @@ static int ofi_nd_pep_reject(struct fid_pep *ppep, fid_t handle,
 	ofi_nd_buf_free_nd_connreq(connreq);
 
 	return FI_SUCCESS;
-}
-
-static int ofi_nd_pep_getopt(struct fid *ep, int level, int optname,
-			void *optval, size_t *optlen)
-{
-	OFI_UNUSED(ep);
-
-	assert(level == FI_OPT_ENDPOINT &&
-		optname == FI_OPT_CM_DATA_SIZE);
-	assert(optval);
-	assert(optlen);
-
-	if (level != FI_OPT_ENDPOINT || optname != FI_OPT_CM_DATA_SIZE)
-		return -FI_ENOPROTOOPT;
-
-	if (*optlen < sizeof(size_t)) {
-		*optlen = sizeof(size_t);
-		return -FI_ETOOSMALL;
-	}
-
-	*((size_t *)optval) = ND_EP_MAX_CM_DATA_SIZE;
-	*optlen = sizeof(size_t);
-
-	return 0;
 }
 
 #endif /* _WIN32 */


### PR DESCRIPTION
Addresses issue  #7213.

1 Add netdir provider-wide implementation for fi_getopt.    1.1 Add hooks for common fi_getopt implementation in netdir_ep.c/netdir_pep.c/netdir_ep_srx.c.
    1.2 Move fi_getopt implementation from netdir_pep.c to netdir_ep.c and rename from ofi_nd_pep_getopt to ofi_nd_ep_getopt.
    1.3 Modify fi_getopt implementation to return value from IND2Adapter::Query instead of hard coded value.
2 Modify fi_enable implementation to allow client control of values used when creating a queue pair.
    2.1 Modify tx/rx size/iov_limit values used for fi_getinfo to come from IND2Adapter::Query rather than hard coded values.
    2.2 Modify fi_enable implementation to use tx/rx size/iov_limit values when creating tx/rx queue pair rather than maximum allowed so hints can control the actual values used.