### PR TITLE
core: Document ZE as oneAPI Level Zero

### DIFF
--- a/man/fi_mr.3.md
+++ b/man/fi_mr.3.md
@@ -633,7 +633,7 @@ requested the FI_HMEM capability.
 : Uses AMD ROCR interfaces such as hsa_memory_allocate and hsa_memory_free.
 
 *FI_HMEM_ZE*
-: Uses Intel L0 ZE interfaces such as zeDriverAllocSharedMem,
+: Uses oneAPI Level Zero interfaces such as zeDriverAllocSharedMem,
   zeDriverFreeMem.
 
 ## device
@@ -833,9 +833,9 @@ configure registration caches.
   unified virtual addressing enabled.
 
 *FI_MR_ZE_CACHE_MONITOR_ENABLED*
-: The ZE cache monitor is responsible for detecting ZE device memory
-  (FI_HMEM_ZE) changes made between the device virtual addresses used by an
-  application and the underlying device physical pages. Valid monitor options
+: The ZE cache monitor is responsible for detecting oneAPI Level Zero device
+  memory (FI_HMEM_ZE) changes made between the device virtual addresses used by
+  an application and the underlying device physical pages. Valid monitor options
   are: 0 or 1.
 
 More direct access to the internal registration cache is possible through the

--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -196,13 +196,13 @@ void ofi_monitors_init(void)
 			" memory caching.");
 	fi_param_define(NULL, "mr_cuda_cache_monitor_enabled", FI_PARAM_BOOL,
 			"Enable or disable the CUDA cache memory monitor."
-			"Monitor is enabled by default.");
+			"Enabled by default.");
 	fi_param_define(NULL, "mr_rocr_cache_monitor_enabled", FI_PARAM_BOOL,
 			"Enable or disable the ROCR cache memory monitor. "
-			"Monitor is enabled by default.");
+			"Enabled by default.");
 	fi_param_define(NULL, "mr_ze_cache_monitor_enabled", FI_PARAM_BOOL,
-			"Enable or disable the ZE cache memory monitor. "
-			"Monitor is enabled by default.");
+			"Enable or disable the oneAPI Level Zero cache memory "
+			"monitor.  Enabled by default.");
 
 	fi_param_get_size_t(NULL, "mr_cache_max_size", &cache_params.max_size);
 	fi_param_get_size_t(NULL, "mr_cache_max_count", &cache_params.max_cnt);


### PR DESCRIPTION
Clarify that ZE refers to oneAPI Level Zero, as ZE by itself
isn't a well known name, like CUDA, or marketed as such.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>