### PR TITLE
prov/verbs: Format fi_fabric_attr reported through FI_CONNREQ event

### DIFF
--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -215,23 +215,25 @@ vrb_eq_cm_getinfo(struct rdma_cm_event *event, struct fi_info *pep_info,
 	}
 
 	ret = vrb_get_matching_info(hints->fabric_attr->api_version, hints,
-				       info, vrb_util_prov.info, 0);
+				    info, vrb_util_prov.info, 0);
 	if (ret)
 		goto err1;
 
-	assert(!(*info)->dest_addr);
-
 	ofi_alter_info(*info, hints, hints->fabric_attr->api_version);
 	vrb_alter_info(hints, *info);
+	(*info)->fabric_attr->api_version = pep_info->fabric_attr->api_version;
+	(*info)->fabric_attr->prov_name = strdup(pep_info->fabric_attr->prov_name);
+	if (!(*info)->fabric_attr->prov_name)
+		goto err2;
 
 	free((*info)->src_addr);
-
 	(*info)->src_addrlen = ofi_sizeofaddr(rdma_get_local_addr(event->id));
 	(*info)->src_addr = malloc((*info)->src_addrlen);
 	if (!((*info)->src_addr))
 		goto err2;
 	memcpy((*info)->src_addr, rdma_get_local_addr(event->id), (*info)->src_addrlen);
 
+	assert(!(*info)->dest_addr);
 	(*info)->dest_addrlen = ofi_sizeofaddr(rdma_get_peer_addr(event->id));
 	(*info)->dest_addr = malloc((*info)->dest_addrlen);
 	if (!((*info)->dest_addr))


### PR DESCRIPTION
Not all fields in the fi_fabric_attr are set when reporting an
fi_info structure as part of an FI_CONNREQ event.  Specifically,
the prov_name and api_version are left unset.  These are usually
set by the core when fi_getinfo is called, but that path is not
taken for CM events.

Copy the values from the passive ep.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>