### PR TITLE
hmem cuda: add stubs for cudaMalloc and cudaFree

### DIFF
--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -57,6 +57,8 @@ CUresult ofi_cuPointerGetAttribute(void *data, CUpointer_attribute attribute,
 				   CUdeviceptr ptr);
 cudaError_t ofi_cudaHostRegister(void *ptr, size_t size, unsigned int flags);
 cudaError_t ofi_cudaHostUnregister(void *ptr);
+cudaError_t ofi_cudaMalloc(void **ptr, size_t size);
+cudaError_t ofi_cudaFree(void *ptr);
 
 #endif /* HAVE_LIBCUDA */
 

--- a/src/hmem_cuda.c
+++ b/src/hmem_cuda.c
@@ -139,6 +139,16 @@ static cudaError_t ofi_cudaGetDeviceCount(int *count)
 	return cuda_ops.cudaGetDeviceCount(count);
 }
 
+cudaError_t ofi_cudaMalloc(void **ptr, size_t size)
+{
+	return cuda_ops.cudaMalloc(ptr, size);
+}
+
+cudaError_t ofi_cudaFree(void *ptr)
+{
+	return cuda_ops.cudaFree(ptr);
+}
+
 int cuda_copy_to_dev(uint64_t device, void *dst, const void *src, size_t size)
 {
 	if (hmem_cuda_use_gdrcopy) {


### PR DESCRIPTION
Expose these functions so providers can try to register CUDA memory to detect
whether the underlying network device supports registering CUDA buffers.

Signed-off-by: Robert Wespetal <wesper@amazon.com>