### PR TITLE
prov/efa: FI_HMEM caps refactoring

### DIFF
--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -487,6 +487,80 @@ static int efa_mr_cache_init(struct efa_domain *domain, struct fi_info *info)
 	return 0;
 }
 
+
+static int efa_set_domain_hmem_info_cuda(struct efa_domain *domain)
+{
+#if HAVE_LIBCUDA
+	cudaError_t cuda_ret;
+	void *ptr = NULL;
+	struct ibv_mr *ibv_mr;
+	int ibv_access = IBV_ACCESS_LOCAL_WRITE;
+	size_t len = ofi_get_page_size() * 2;
+	int ret;
+
+	if (!ofi_hmem_is_initialized(FI_HMEM_CUDA)) {
+		EFA_INFO(FI_LOG_DOMAIN,
+		         "FI_HMEM_CUDA is not initialized\n");
+		return 0;
+	}
+
+	if (domain->ctx->device_caps & EFADV_DEVICE_ATTR_CAPS_RDMA_READ)
+		ibv_access |= IBV_ACCESS_REMOTE_READ;
+
+	domain->hmem_info[FI_HMEM_CUDA].initialized = true;
+
+	cuda_ret = ofi_cudaMalloc(&ptr, len);
+	if (cuda_ret != cudaSuccess) {
+		EFA_WARN(FI_LOG_DOMAIN,
+			 "Failed to allocate CUDA buffer: %s\n",
+			 ofi_cudaGetErrorString(cuda_ret));
+		return -FI_ENOMEM;
+	}
+
+	ibv_mr = ibv_reg_mr(domain->ibv_pd, ptr, len, ibv_access);
+	if (!ibv_mr) {
+		EFA_WARN(FI_LOG_DOMAIN,
+			 "Failed to register CUDA buffer with the EFA device, FI_HMEM transfers that require peer to peer support will fail.\n");
+		ofi_cudaFree(ptr);
+		return 0;
+	}
+
+	ret = ibv_dereg_mr(ibv_mr);
+	ofi_cudaFree(ptr);
+	if (ret) {
+		EFA_WARN(FI_LOG_DOMAIN,
+			 "Failed to deregister CUDA buffer: %s\n",
+			 fi_strerror(-ret));
+		return ret;
+	}
+
+	domain->hmem_info[FI_HMEM_CUDA].p2p_supported = true;
+#endif
+	return 0;
+}
+
+/*
+ * Determine whether an HMEM device is initialized, and whether the provider
+ * may support p2p transfers for that device. This state is used later when
+ * determining how to initiate an HMEM transfer.
+ *
+ * @param domain efa_domain to run the check/store state
+ * @return 0 on success, negative value on an unexpected error
+ */
+static int efa_set_domain_hmem_info(struct efa_domain *domain)
+{
+	int ret;
+
+	if (!(domain->info->caps & FI_HMEM))
+		return 0;
+
+	ret = efa_set_domain_hmem_info_cuda(domain);
+	if (ret)
+		return ret;
+
+	return 0;
+}
+
 /* @brief Allocate a domain, open the device, and set it up based on the hints.
  *
  * This function creates a domain and uses the info struct to configure the
@@ -593,11 +667,14 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 		goto err_free_info;
 	}
 
-	if ((domain->info->caps & FI_HMEM) &&
-	    ofi_hmem_is_initialized(FI_HMEM_CUDA)) {
-		domain->hmem_info[FI_HMEM_CUDA].initialized = true;
-		/* TODO: register a cuda page here instead */
-		domain->hmem_info[FI_HMEM_CUDA].p2p_supported = true;
+	if (EFA_EP_TYPE_IS_RDM(info)) {
+		ret = efa_set_domain_hmem_info(domain);
+		if (ret) {
+			EFA_WARN(FI_LOG_DOMAIN,
+				 "efa_check_hmem_support failed: %s\n",
+				 fi_strerror(-ret));
+			goto err_free_info;
+		}
 	}
 
 	/*

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -593,6 +593,13 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 		goto err_free_info;
 	}
 
+	if ((domain->info->caps & FI_HMEM) &&
+	    ofi_hmem_is_initialized(FI_HMEM_CUDA)) {
+		domain->hmem_info[FI_HMEM_CUDA].initialized = true;
+		/* TODO: register a cuda page here instead */
+		domain->hmem_info[FI_HMEM_CUDA].p2p_supported = true;
+	}
+
 	/*
 	 * If FI_MR_LOCAL is set, we do not want to use the MR cache.
 	 */

--- a/prov/efa/src/efa_ep.c
+++ b/prov/efa/src/efa_ep.c
@@ -701,6 +701,18 @@ int efa_ep_open(struct fid_domain *domain_fid, struct fi_info *info,
 		memcpy(ep->src_addr, info->src_addr, info->src_addrlen);
 	}
 
+	if (ep->domain->hmem_info[FI_HMEM_CUDA].initialized) {
+		/*
+		 * Set the default to required. NCCL plugin requires p2p, but
+		 * does not call setopt for this option in older NCCL plugin
+		 * versions.
+		 */
+		ep->hmem_p2p_opt = FI_HMEM_P2P_REQUIRED;
+	} else {
+		/* no hmem devices, disable p2p */
+		ep->hmem_p2p_opt = FI_HMEM_P2P_DISABLED;
+	}
+
 	*ep_fid = &ep->util_ep.ep_fid;
 	(*ep_fid)->fid.fclass = FI_CLASS_EP;
 	(*ep_fid)->fid.context = context;

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -81,7 +81,7 @@ static int efa_mr_hmem_setup(struct efa_mr *efa_mr,
 		 * util_domain is at the beginning of both efa_domain and
 		 * rxr_domain.
 		 */
-		if (ofi_hmem_is_initialized(attr->iface)) {
+		if (efa_mr->domain->hmem_info[attr->iface].initialized) {
 			efa_mr->peer.iface = attr->iface;
 		} else {
 			EFA_WARN(FI_LOG_MR,

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -949,13 +949,29 @@ static int rxr_ep_ctrl(struct fid *fid, int command, void *arg)
 {
 	ssize_t ret;
 	struct rxr_ep *ep;
+	struct rxr_domain *rxr_domain;
+	struct efa_domain *efa_domain;
 	char shm_ep_name[EFA_SHM_NAME_MAX];
 	size_t shm_ep_name_len;
 
 	switch (command) {
 	case FI_ENABLE:
-		/* Enable core endpoints & post recv buff */
 		ep = container_of(fid, struct rxr_ep, util_ep.ep_fid.fid);
+		rxr_domain = rxr_ep_domain(ep);
+		efa_domain = container_of(rxr_domain->rdm_domain, struct efa_domain,
+					  util_domain.domain_fid);
+
+		/*
+		 * TODO: once we support other FI_HMEM p2p modes, check the
+		 * setopt option first.
+		 */
+		if ((efa_domain->util_domain.info_domain_caps & FI_HMEM) &&
+		    (!efa_domain->hmem_info[FI_HMEM_CUDA].initialized ||
+		     !efa_domain->hmem_info[FI_HMEM_CUDA].p2p_supported)) {
+			FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,
+				"NVIDIA GPUDirect support is not available, but FI_HMEM was requested.\n");
+			return -FI_EOPNOTSUPP;
+		}
 
 		ret = fi_enable(ep->rdm_ep);
 		if (ret)
@@ -1319,6 +1335,7 @@ int rxr_ep_init(struct rxr_ep *ep)
 		hp_pool_flag = 0;
 	else
 		hp_pool_flag = OFI_BUFPOOL_HUGEPAGES;
+
 
 	ret = rxr_create_pkt_pool(ep, entry_sz, rxr_get_tx_pool_chunk_cnt(ep),
 				  hp_pool_flag,

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -882,7 +882,6 @@ EFA_INI
 			"Calls to RDMA read is segmented using this value.");
 	fi_param_define(&rxr_prov, "fork_safe", FI_PARAM_BOOL,
 			"Enables fork support and disables internal usage of huge pages. Has no effect on kernels which set copy-on-fork for registered pages, generally 5.13 and later. (Default: false)");
-
 	rxr_init_env();
 
 #if HAVE_EFA_DL

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -502,6 +502,7 @@ static int rxr_info_to_rxr(uint32_t version, const struct fi_info *core_info,
 					"FI_HMEM capability currently requires peer to peer support, which is disabled.\n");
 				return -FI_ENODATA;
 			}
+			//TODO: remove the rdma checks once FI_HMEM w/o p2p is supported
 			if (!efa_device_support_rdma_read()) {
 				FI_WARN(&rxr_prov, FI_LOG_CORE,
 				        "FI_HMEM capability requires RDMA, which this device does not support.\n");

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -122,7 +122,7 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 
 	int tagged;
 	size_t max_rtm_data_size;
-	ssize_t err;
+	ssize_t ret;
 	struct rdm_peer *peer;
 	bool delivery_complete_requested;
 	int ctrl_type;
@@ -160,9 +160,9 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 		 * the information whether the peer
 		 * support it or not.
 		 */
-		err = rxr_pkt_trigger_handshake(rxr_ep, tx_entry->addr, peer);
-		if (OFI_UNLIKELY(err))
-			return err;
+		ret = rxr_pkt_trigger_handshake(rxr_ep, tx_entry->addr, peer);
+		if (OFI_UNLIKELY(ret))
+			return ret;
 
 		if (!(peer->flags & RXR_PEER_HANDSHAKE_RECEIVED))
 			return -FI_EAGAIN;
@@ -239,11 +239,11 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 	    efa_both_support_rdma_read(rxr_ep, peer) &&
 	    (tx_entry->desc[0] || efa_is_cache_available(efa_domain))) {
 		/* Read message support FI_DELIVERY_COMPLETE implicitly. */
-		err = rxr_pkt_post_ctrl(rxr_ep, RXR_TX_ENTRY, tx_entry,
+		ret = rxr_pkt_post_ctrl(rxr_ep, RXR_TX_ENTRY, tx_entry,
 					RXR_LONGREAD_MSGRTM_PKT + tagged, 0, 0);
 
-		if (err != -FI_ENOMEM)
-			return err;
+		if (ret != -FI_ENOMEM)
+			return ret;
 
 		/*
 		 * If memory registration failed, we continue here
@@ -251,9 +251,9 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 		 */
 	}
 
-	err = rxr_ep_set_tx_credit_request(rxr_ep, tx_entry);
-	if (OFI_UNLIKELY(err))
-		return err;
+	ret = rxr_ep_set_tx_credit_request(rxr_ep, tx_entry);
+	if (OFI_UNLIKELY(ret))
+		return ret;
 
 	ctrl_type = delivery_complete_requested ? RXR_DC_LONGCTS_MSGRTM_PKT : RXR_LONGCTS_MSGRTM_PKT;
 	tx_entry->rxr_flags |= RXR_LONGCTS_PROTOCOL;

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -341,6 +341,11 @@ ssize_t rxr_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uint64_
 		use_lower_ep_read = true;
 	}
 
+	/*
+	 * Not going to check efa_ep->hmem_p2p_opt here, if the remote side
+	 * gave us a valid MR we should just honor the request even if p2p is
+	 * disabled.
+	 */
 	if (use_lower_ep_read) {
 		err = rxr_read_post_remote_read_or_queue(rxr_ep, RXR_TX_ENTRY, tx_entry);
 		if (OFI_UNLIKELY(err == -FI_ENOBUFS)) {


### PR DESCRIPTION
A handful of patches to start on properly handling FI_HMEM support when peer to peer support is unavailable, and to deal with the deprecation of the gdr sysfs flag in the EFA kernel driver.

We still require RDMA and NVIDIA GPUDirect support for FI_HMEM at this time.

```
prov/efa: change FI_HMEM cap reporting behavior around p2p support
prov/efa: add copy paths for hmem when p2p is disabled
prov/efa: add state to track FI_HMEM support
prov/efa: rename err to ret in rxr_msg_post_rtm
```

Test description: Tested NCCL allreduce perf and MPI ring_c on two p4d.24xlarge instances. Still trying to test this on p3dn.