### PR TITLE
prov/rxm: Fix possible leak of stack data in cm_accept

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -87,6 +87,7 @@ union rxm_cm_data {
 	struct _accept {
 		uint64_t server_conn_id;
 		uint32_t rx_size; /* used? */
+		uint32_t align_pad;
 	} accept;
 
 	struct _reject {

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -595,6 +595,7 @@ rxm_accept_connreq(struct rxm_conn *conn, struct rxm_eq_cm_entry *cm_entry)
 
 	cm_data.accept.server_conn_id = conn->peer->index;
 	cm_data.accept.rx_size = cm_entry->info->rx_attr->size;
+	cm_data.accept.align_pad = 0;
 
 	ret = fi_accept(conn->msg_ep, &cm_data.accept, sizeof(cm_data.accept));
 	if (ret)


### PR DESCRIPTION
From valgrind, there's a possible use of uninitialized data passed
to the socket send() call.  This comes from rxm_accept_connreq(),
which uses the cm_data union.  Although all fields of cm_data.accept
are set, the sizeof(cm_data.accept) includes extra padded bytes for
alignment purposes.  Those extra bytes are not set and are handed
through the fi_accept() call, which eventually winds its way through
the tcp provider to a socket send() call.

Fix this by adding an explicit pad field to the structure (to ensure
that 32-bit and 64-bit processors use the same size structure), and
set the padded field to 0.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>