### PR TITLE
contrib/intel: Remove older HW from per PR CI

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -3,93 +3,90 @@ pipeline {
     agent any
     options {
         timestamps()
-        timeout(activity: true, time: 4, unit: 'HOURS')    
+        timeout(activity: true, time: 4, unit: 'HOURS')
     }
     environment {
         JOB_CADENCE = 'PR'
     }
 
     stages {
-        stage ('fetch-opa-psm2')  {
-             steps {
-                 withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']) { 
-                     dir('opa-psm2-lib') {
-
-                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', \
-                        branches: [[name: '*/master']], \
-                        doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], \
-                        userRemoteConfigs: [[url: 'https://github.com/intel/opa-psm2.git']]]                        
-                      }
-                 }
-             }
-        }
-        
         stage ('build-libfabric') {
             steps {
-                withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']) { 
-                sh """ 
+                withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']) {
+                sh """
                   python3.7 contrib/intel/jenkins/build.py 'libfabric' --ofi_build_mode='dbg'
-                  echo "libfabric build completed"  
+                  python3.7 contrib/intel/jenkins/build.py 'libfabric'
+                  python3.7 contrib/intel/jenkins/build.py 'libfabric' --ofi_build_mode='dl'
+                  echo "libfabric build completed"
                  """
                 }
             }
         }
         stage('build-fabtests') {
             steps {
-                withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']) { 
+                withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']) {
                 sh """
-                python3.7 contrib/intel/jenkins/build.py 'fabtests' --ofi_build_mode='dbg'              
-                echo 'fabtests build completed' 
+                python3.7 contrib/intel/jenkins/build.py 'fabtests' --ofi_build_mode='dbg'
+                python3.7 contrib/intel/jenkins/build.py 'fabtests'
+                python3.7 contrib/intel/jenkins/build.py 'fabtests' --ofi_build_mode='dl'
+                echo 'fabtests build completed'
                 """
                 }
             }
         }
-        
-        stage ('build-shmem') {
-            steps {
-              withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']){
-                sh """
-                python3.7  contrib/intel/jenkins/build.py 'shmem' --ofi_build_mode='dbg'
-                echo 'shmem benchmarks built successfully'
-                """
-              }
-            }
-        }
-        stage('build MPICH_bm') {
-            steps {
-              withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']){
-                sh """
-                python3.7 contrib/intel/jenkins/build.py 'mpich_benchmarks' --ofi_build_mode='dbg'
-                echo "mpi benchmarks with mpich - built successfully"
-                """
-              }
-            }
-        }
-        stage('build IMPI_bm') {
-            steps {
-              withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']){
-                sh """
-                python3.7 contrib/intel/jenkins/build.py 'impi_benchmarks' --ofi_build_mode='dbg'
-                echo 'mpi benchmarks with impi - built successfully'
-                """
-              }
-            }
-        }  
 
-        stage ('build OMPI_bm') {
-            steps {
-              withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']){
-                sh """
-                python3.7 contrib/intel/jenkins/build.py 'ompi_benchmarks' --ofi_build_mode='dbg'
-                echo 'mpi benchmarks with ompi - built successfully'
-                """
-              }
+        stage('parallel-build') {
+          parallel {
+            stage ('build-SHMEM') {
+                steps {
+                  withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']){
+                    sh """
+                    python3.7  contrib/intel/jenkins/build.py 'shmem' --ofi_build_mode='dbg'
+                    python3.7  contrib/intel/jenkins/build.py 'shmem'
+                    echo 'shmem benchmarks built successfully'
+                    """
+                  }
+                }
             }
+            stage('build-MPICH') {
+                steps {
+                  withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']){
+                    sh """
+                    python3.7 contrib/intel/jenkins/build.py 'mpich_benchmarks' --ofi_build_mode='dbg'
+                    python3.7 contrib/intel/jenkins/build.py 'mpich_benchmarks'
+                    echo "mpi benchmarks with mpich - built successfully"
+                    """
+                  }
+                }
+            }
+            stage('build-IMPI') {
+                steps {
+                  withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']){
+                    sh """
+                    python3.7 contrib/intel/jenkins/build.py 'impi_benchmarks' --ofi_build_mode='dbg'
+                    python3.7 contrib/intel/jenkins/build.py 'impi_benchmarks'
+                    echo 'mpi benchmarks with impi - built successfully'
+                    """
+                  }
+                }
+            }
+            stage ('build-OMPI') {
+                steps {
+                  withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']){
+                    sh """
+                    python3.7 contrib/intel/jenkins/build.py 'ompi_benchmarks' --ofi_build_mode='dbg'
+                    python3.7 contrib/intel/jenkins/build.py 'ompi_benchmarks'
+                    echo 'mpi benchmarks with ompi - built successfully'
+                    """
+                  }
+                }
+            }
+          }
         }
-    
+
         stage('parallel-tests') {
-            parallel { 
-                 stage('eth-tcp-dbg') {
+            parallel {
+                stage('tcp') {
                     agent {node {label 'eth'}}
                     steps{
                         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
@@ -98,13 +95,16 @@ pipeline {
                             env
                             (
                                 cd  ${env.WORKSPACE}/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=tcp --ofi_build_mode='dbg'
+                                python3.7 runtests.py --prov=tcp --ofi_build_mode='dbg' --test_mode='unit'
+                                python3.7 runtests.py --prov=tcp --test_mode='unit'
+                                python3.7 runtests.py --prov=tcp --test_mode='mpi'
+                                python3.7 runtests.py --prov=sockets --test_mode='unit'
                             )
                           """
                         }
                      }
-                 }
-                 stage('eth-udp-shm-dbg') {
+                }
+                stage('udp') {
                      agent {node {label 'eth'}}
                      steps{
                         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
@@ -113,60 +113,30 @@ pipeline {
                             env
                             (
                                 cd  ${env.WORKSPACE}/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=udp --ofi_build_mode='dbg'
-                                python3.7 runtests.py --prov=udp --util=rxd --ofi_build_mode='dbg'
-                                python3.7 runtests.py --prov=shm --ofi_build_mode='dbg'
+                                python3.7 runtests.py --prov=udp --ofi_build_mode='dbg' --test_mode='unit'
+                                python3.7 runtests.py --prov=udp --test_mode='unit'
                             )
                           """
                         }
                      }
-
-                 }
-                 stage('hfi1-psm2-verbs-dbg') {
-                     agent {node {label 'hfi1'}}
+                }
+                stage('shm') {
+                     agent {node {label 'eth'}}
                      steps{
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
+                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
+                        {
                           sh """
                             env
                             (
-                                cd ${env.WORKSPACE}/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=psm2 --ofi_build_mode='dbg'
-                                python3.7 runtests.py --prov=verbs --ofi_build_mode='dbg'
+                                cd  ${env.WORKSPACE}/contrib/intel/jenkins/
+                                python3.7 runtests.py --prov=shm --ofi_build_mode='dbg' --test_mode='unit'
+                                python3.7 runtests.py --prov=shm --test_mode='unit'
                             )
-                         """
+                          """
                         }
                      }
-                 }
-                
-                 stage('hfi1-verbs_rxd-dbg') {
-                    agent {node {label 'hfi1'}}
-                     steps{
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
-                          sh """
-                            env
-                            (
-                                cd ${env.WORKSPACE}/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=verbs --util=rxd --ofi_build_mode='dbg'
-                            )
-                         """
-                        }
-                     }
-                 }
-                 stage('hfi1-verbs_rxm-dbg') {
-                     agent {node {label 'hfi1'}}
-                     steps{
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
-                          sh """
-                            env
-                            (
-                                cd ${env.WORKSPACE}/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=verbs --util=rxm --ofi_build_mode='dbg'
-                            )
-                         """
-                        }
-                     }
-                 }
-                 stage('mlx5-verbs_rxm-dbg') {
+                }
+                stage('verbs-rc') {
                      agent {node {label 'mlx5'}}
                      steps{
                         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
@@ -174,14 +144,15 @@ pipeline {
                             env
                             (
                                 cd ${env.WORKSPACE}/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=verbs --ofi_build_mode='dbg'
-                                python3.7 runtests.py --prov=verbs --util=rxm --ofi_build_mode='dbg'
+                                python3.7 runtests.py --prov=verbs --ofi_build_mode='dbg' --test_mode='unit'
+                                python3.7 runtests.py --prov=verbs --test_mode='unit'
+                                python3.7 runtests.py --prov=verbs --test_mode='mpi'
                             )
-                          """
+                         """
                         }
                      }
-                 }
-                 stage('mlx5-verbs_rxd-dbg') {
+                }
+                stage('verbs-ud') {
                      agent {node {label 'mlx5'}}
                      steps{
                         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
@@ -189,28 +160,26 @@ pipeline {
                             env
                             (
                                 cd ${env.WORKSPACE}/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=verbs --util=rxd --ofi_build_mode='dbg'
+                                python3.7 runtests.py --prov=verbs --util=rxd --ofi_build_mode='dbg' --test_mode='unit'
                             )
-                          """
+                         """
                         }
                      }
-                 }     
-            } 
-   }        
+                }
+            }
+      }
+    }
 
-  }
- 
-  post {
-    cleanup {
-        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
+    post {
+        cleanup {
+          withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
             sh "rm -rf '/mpibuilddir/mpich-build-dir/${env.JOB_NAME}/${env.BUILD_NUMBER}'"
             sh "rm -rf '/mpibuilddir/ompi-build-dir/${env.JOB_NAME}/${env.BUILD_NUMBER}'"
             sh "rm -rf '/mpibuilddir/mpich-suite-build-dir/${env.JOB_NAME}/${env.BUILD_NUMBER}'"
-	    dir("${env.WORKSPACE}"){
-                deleteDir()
+	          dir("${env.WORKSPACE}") {
+              deleteDir()
             }
+          }
         }
-    }  
-  }
-  
+    }
 }

--- a/contrib/intel/jenkins/Jenkinsfile.daily
+++ b/contrib/intel/jenkins/Jenkinsfile.daily
@@ -2,52 +2,38 @@
 pipeline {
     agent any
     options {
-    timestamps()             
+    timestamps()
     timeout(activity: true, time: 4, unit: 'HOURS')
     }
     environment {
         JOB_CADENCE = 'daily'
-    }    
-    stages {
-        stage ('fetch-opa-psm2')  {
-             steps {
-                 withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']) { 
-                     dir('opa-psm2-lib') {
+    }
 
-                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', \
-                        branches: [[name: '*/master']], \
-                        doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], \
-                        userRemoteConfigs: [[url: 'https://github.com/intel/opa-psm2.git']]]                        
-                      }
-                 }
-             }
-        }
-        
+    stages {
         stage ('build-libfabric') {
             steps {
-                withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']) { 
+                withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']) {
                 sh """
                   python3.7 contrib/intel/jenkins/build.py 'libfabric'
                   python3.7 contrib/intel/jenkins/build.py 'libfabric' --ofi_build_mode='dbg'
                   python3.7 contrib/intel/jenkins/build.py 'libfabric' --ofi_build_mode='dl'
-                  echo "libfabric build completed"  
+                  echo "libfabric build completed"
                  """
                 }
             }
         }
         stage('build-fabtests') {
             steps {
-                withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']) { 
+                withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']) {
                 sh """
                 python3.7 contrib/intel/jenkins/build.py 'fabtests'
                 python3.7 contrib/intel/jenkins/build.py 'fabtests' --ofi_build_mode='dbg'
-                python3.7 contrib/intel/jenkins/build.py 'fabtests' --ofi_build_mode='dl'              
-                echo 'fabtests build completed' 
+                python3.7 contrib/intel/jenkins/build.py 'fabtests' --ofi_build_mode='dl'
+                echo 'fabtests build completed'
                 """
                 }
             }
         }
-        
         stage ('build-shmem') {
             steps {
               withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']) {
@@ -59,49 +45,47 @@ pipeline {
                 """
                 }
               }
-          }
-  
+        }
         stage ('build OMPI_bm') {
               steps {
               withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']) {
                   sh """
-                  python3.7 contrib/intel/jenkins/build.py 'ompi_benchmarks' 
-                  python3.7 contrib/intel/jenkins/build.py 'ompi_benchmarks' --ofi_build_mode='dbg' 
+                  python3.7 contrib/intel/jenkins/build.py 'ompi_benchmarks'
+                  python3.7 contrib/intel/jenkins/build.py 'ompi_benchmarks' --ofi_build_mode='dbg'
                   python3.7 contrib/intel/jenkins/build.py 'ompi_benchmarks' --ofi_build_mode='dl'
                   echo 'mpi benchmarks with ompi - built successfully'
                  """
                 }
               }
-          }
-    
-    stage('build IMPI_bm') {
-        steps {
-          withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']) {
-                sh """
-                python3.7 contrib/intel/jenkins/build.py 'impi_benchmarks'
-                python3.7 contrib/intel/jenkins/build.py 'impi_benchmarks' --ofi_build_mode='dbg'
-                python3.7 contrib/intel/jenkins/build.py 'impi_benchmarks' --ofi_build_mode='dl'
-                echo 'mpi benchmarks with impi - built successfully'
-                """
-            }
-          }
-      }  
-    
-    stage('build MPICH_bm') {
-        steps {
-          withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']) {
-                sh """
-                python3.7 contrib/intel/jenkins/build.py 'mpich_benchmarks'
-                python3.7 contrib/intel/jenkins/build.py 'mpich_benchmarks' --ofi_build_mode='dbg'
-                python3.7 contrib/intel/jenkins/build.py 'mpich_benchmarks' --ofi_build_mode='dl'
-                echo "mpi benchmarks with mpich - built successfully"
-                """
-              }
-            }
         }
-   stage('parallel-tests') {
+        stage('build IMPI_bm') {
+            steps {
+              withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']) {
+                    sh """
+                    python3.7 contrib/intel/jenkins/build.py 'impi_benchmarks'
+                    python3.7 contrib/intel/jenkins/build.py 'impi_benchmarks' --ofi_build_mode='dbg'
+                    python3.7 contrib/intel/jenkins/build.py 'impi_benchmarks' --ofi_build_mode='dl'
+                    echo 'mpi benchmarks with impi - built successfully'
+                    """
+                }
+              }
+        }
+        stage('build MPICH_bm') {
+              steps {
+                withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']) {
+                      sh """
+                      python3.7 contrib/intel/jenkins/build.py 'mpich_benchmarks'
+                      python3.7 contrib/intel/jenkins/build.py 'mpich_benchmarks' --ofi_build_mode='dbg'
+                      python3.7 contrib/intel/jenkins/build.py 'mpich_benchmarks' --ofi_build_mode='dl'
+                      echo "mpi benchmarks with mpich - built successfully"
+                      """
+                    }
+                  }
+        }
+
+        stage('parallel-tests') {
             parallel {
-                stage('eth-sockets') {
+                stage('sockets') {
                      agent {node {label 'eth'}}
                      steps{
                         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
@@ -109,14 +93,14 @@ pipeline {
                           sh """
                             env
                             (
-                                cd  ${env.WORKSPACE}/contrib/intel/jenkins/ 
-                                python3.7 runtests.py --prov=sockets               
-                            )                              
+                                cd  ${env.WORKSPACE}/contrib/intel/jenkins/
+                                python3.7 runtests.py --prov=sockets
+                            )
                           """
                         }
                      }
-                 }
-                 stage('eth-tcp') {
+                }
+                stage('tcp') {
                      agent {node {label 'eth'}}
                      steps{
                         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
@@ -124,14 +108,15 @@ pipeline {
                           sh """
                             env
                             (
-                                cd  ${env.WORKSPACE}/contrib/intel/jenkins/ 
-                                python3.7 runtests.py --prov=tcp              
-                            )                              
+                                cd  ${env.WORKSPACE}/contrib/intel/jenkins/
+                                python3.7 runtests.py --prov=tcp --test_mode='unit'
+                                python3.7 runtests.py --prov=tcp --test_mode='mpi'
+                            )
                           """
                         }
                      }
-                 } 
-                 stage('eth-udp-rxd-shm') {
+                }
+                stage('udp') {
                      agent {node {label 'eth'}}
                      steps{
                         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
@@ -139,215 +124,59 @@ pipeline {
                           sh """
                             env
                             (
-                                cd  ${env.WORKSPACE}/contrib/intel/jenkins/ 
-                                python3.7 runtests.py --prov=udp 
-                                python3.7 runtests.py --prov=udp --util=rxd
-                                python3.7 runtests.py --prov=shm               
-                            )                              
+                                cd  ${env.WORKSPACE}/contrib/intel/jenkins/
+                                python3.7 runtests.py --prov=udp --test_mode='unit'
+                            )
                           """
                         }
                      }
-                 }
-                 stage('hfi1-psm2-verbs') {
-                     agent {node {label 'hfi1'}}
+                }
+                stage('shm') {
+                     agent {node {label 'eth'}}
                      steps{
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
+                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
+                        {
                           sh """
                             env
                             (
-                                cd ${env.WORKSPACE}/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=psm2
-                                python3.7 runtests.py --prov=verbs                   
+                                cd  ${env.WORKSPACE}/contrib/intel/jenkins/
+                                python3.7 runtests.py --prov=shm --test_mode='unit'
                             )
                           """
-                        } 
-                     }       
-       
-                 }
-                 stage('hfi1-verbs-rxm') {
-                     agent {node {label 'hfi1'}}
+                        }
+                     }
+                }
+                stage('verbs-rc') {
+                     agent {node {label 'mlx5'}}
                      steps{
                         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
                           sh """
                             env
                             (
                                 cd ${env.WORKSPACE}/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=verbs --util=rxm              
+                                python3.7 runtests.py --prov=verbs --test_mode='unit'
+                                python3.7 runtests.py --prov=verbs --test_mode='mpi'
                             )
                           """
-                        } 
-                     }       
-       
-                 }
-                 stage('hfi1-verbs-rxd') {
-                     agent {node {label 'hfi1'}}
+                        }
+                     }
+                }
+                stage('verbs-ud') {
+                     agent {node {label 'mlx5'}}
                      steps{
                         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
                           sh """
                             env
                             (
                                 cd ${env.WORKSPACE}/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=verbs --util=rxd
-                      
+                                python3.7 runtests.py --prov=verbs --util=rxd --test_mode='unit'
+                                python3.7 runtests.py --prov=verbs --util=rxd --test_mode='mpi'
                             )
                           """
-                        } 
-                     }       
-       
-                 }
-                 stage('mlx5-verbs-rxm') {
-                     agent {node {label 'mlx5'}}
-                     steps{
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
-                          sh """
-                            env
-                            (                            
-                                cd ${env.WORKSPACE}/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=verbs
-                                python3.7 runtests.py --prov=verbs --util=rxm                   
- 
-                            )  
-                          """
-                        } 
-                     }       
-       
-                 }
-                  stage('mlx5-verbs-rxd') {
-                     agent {node {label 'mlx5'}}
-                     steps{
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
-                          sh """
-                            env
-                            (                            
-                                cd ${env.WORKSPACE}/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=verbs --util=rxd
-                            )  
-                          """
-                        } 
-                     }       
-       
-                 }
-                 stage('eth-sockets-dbg') {
-                     agent {node {label 'eth'}}
-                     steps{
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
-                        {
-                          sh """
-                            env
-                            ( 
-                               cd  ${env.WORKSPACE}/contrib/intel/jenkins/
-                               python3.7 runtests.py --prov=sockets --ofi_build_mode='dbg'               
-                            )  
-                          """
-                        } 
-                     }       
-                 }
-                 stage('eth-tcp-dbg') {
-                     agent {node {label 'eth'}}
-                     steps{
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
-                        {
-                          sh """
-                            env
-                            ( 
-                                cd  ${env.WORKSPACE}/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=tcp --ofi_build_mode='dbg'
-                            )  
-                          """
-                        } 
-                     }       
-                 }
-                 stage('eth-udp-rxd-shm-dbg') {
-                     agent {node {label 'eth'}}
-                     steps{
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
-                        {
-                          sh """
-                            env
-                            ( 
-                                cd  ${env.WORKSPACE}/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=udp --ofi_build_mode='dbg'
-                                python3.7 runtests.py --prov=udp --util=rxd --ofi_build_mode='dbg'
-                                python3.7 runtests.py --prov=shm --ofi_build_mode='dbg'
-                            )  
-                          """
-                        } 
-                     }       
-       
-                 }
-                 stage('hfi1-psm2-verbs-dbg') {
-                     agent {node {label 'hfi1'}}
-                     steps{
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
-                          sh """
-                            env 
-                            (
-                                cd ${env.WORKSPACE}/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=psm2 --ofi_build_mode='dbg'
-                                python3.7 runtests.py --prov=verbs --ofi_build_mode='dbg'                   
-                            ) 
-                         """
-                        } 
-                     }        
-                 }
-                 stage('hfi1-verbs_rxd-dbg') {
-                     agent {node {label 'hfi1'}}
-                     steps{
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
-                          sh """
-                            env 
-                            (
-                                cd ${env.WORKSPACE}/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=verbs --util=rxd --ofi_build_mode='dbg'                  
-                            ) 
-                         """
-                        } 
-                     }       
-                 }
-                 stage('hfi1-verbs_rxm-dbg') {
-                     agent {node {label 'hfi1'}}
-                     steps{
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
-                          sh """
-                            env 
-                            (
-                                cd ${env.WORKSPACE}/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=verbs --util=rxm --ofi_build_mode='dbg'                  
-                            ) 
-                         """
-                        } 
-                     }       
-                 }
-                 stage('mlx5-verbs_rxm-dbg') {
-                     agent {node {label 'mlx5'}}
-                     steps{
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
-                          sh """
-                            env
-                            (
-                                cd ${env.WORKSPACE}/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=verbs --ofi_build_mode='dbg'
-                                python3.7 runtests.py --prov=verbs --util=rxm --ofi_build_mode='dbg'           
-                            ) 
-                          """
-                        } 
-                     }       
-                 }
-                 stage('mlx5-verbs_rxd-dbg') {
-                     agent {node {label 'mlx5'}}
-                     steps{
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
-                          sh """
-                            env
-                            (
-                                cd ${env.WORKSPACE}/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=verbs --util=rxd --ofi_build_mode='dbg'                  
-                            ) 
-                          """
-                        } 
-                     }       
-                 }
-                 stage('eth-sockets-dl') {
+                        }
+                     }
+                }
+                stage('sockets-dbg') {
                      agent {node {label 'eth'}}
                      steps{
                         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
@@ -356,13 +185,13 @@ pipeline {
                             env
                             (
                                 cd  ${env.WORKSPACE}/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=sockets --ofi_build_mode='dl'               
-                            )  
+                                python3.7 runtests.py --prov=sockets --ofi_build_mode='dbg'
+                            )
                           """
-                        } 
-                     }       
-                 }
-                 stage('eth-tcp-dl') {
+                        }
+                     }
+                }
+                stage('tcp-dbg') {
                      agent {node {label 'eth'}}
                      steps{
                         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
@@ -371,14 +200,105 @@ pipeline {
                             env
                             (
                                 cd  ${env.WORKSPACE}/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=tcp --ofi_build_mode='dl'
-                            )  
+                                python3.7 runtests.py --prov=tcp --ofi_build_mode='dbg' --test_mode='unit'
+                                python3.7 runtests.py --prov=tcp --ofi_build_mode='dbg' --test_mode='mpi'
+                            )
+                          """
+                        }
+                     }
+                }
+                stage('udp-dbg') {
+                     agent {node {label 'eth'}}
+                     steps{
+                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
+                        {
+                          sh """
+                            env
+                            (
+                                cd  ${env.WORKSPACE}/contrib/intel/jenkins/
+                                python3.7 runtests.py --prov=udp --ofi_build_mode='dbg' --test_mode='unit'
+                            )
+                          """
+                        }
+                     }
+                }
+                stage('shm-dbg') {
+                     agent {node {label 'eth'}}
+                     steps{
+                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
+                        {
+                          sh """
+                            env
+                            (
+                                cd  ${env.WORKSPACE}/contrib/intel/jenkins/
+                                python3.7 runtests.py --prov=shm --ofi_build_mode='dbg' --test_mode='unit'
+                            )
+                          """
+                        }
+                     }
+                }
+                stage('verbs-rc-dbg') {
+                     agent {node {label 'mlx5'}}
+                     steps{
+                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
+                          sh """
+                            env
+                            (
+                                cd ${env.WORKSPACE}/contrib/intel/jenkins/
+                                python3.7 runtests.py --prov=verbs --ofi_build_mode='dbg' --test_mode='unit'
+                                python3.7 runtests.py --prov=verbs --ofi_build_mode='dbg' --test_mode='mpi'
+                            )
+                          """
+                        }
+                     }
+                }
+                stage('verbs-ud-dbg') {
+                     agent {node {label 'mlx5'}}
+                     steps{
+                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
+                          sh """
+                            env
+                            (
+                                cd ${env.WORKSPACE}/contrib/intel/jenkins/
+                                python3.7 runtests.py --prov=verbs --util=rxd --ofi_build_mode='dbg' --test_mode='unit'
+                                python3.7 runtests.py --prov=verbs --util=rxd --ofi_build_mode='dbg' --test_mode='mpi'
+                            )
+                          """
+                        }
+                     }
+                }
+                stage('sockets-dl') {
+                     agent {node {label 'eth'}}
+                     steps{
+                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
+                        {
+                          sh """
+                            env
+                            (
+                                cd  ${env.WORKSPACE}/contrib/intel/jenkins/
+                                python3.7 runtests.py --prov=sockets --ofi_build_mode='dl'
+                            )
+                          """
+                        }
+                     }
+                }
+                stage('tcp-dl') {
+                     agent {node {label 'eth'}}
+                     steps{
+                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
+                        {
+                          sh """
+                            env
+                            (
+                                cd  ${env.WORKSPACE}/contrib/intel/jenkins/
+                                python3.7 runtests.py --prov=tcp --ofi_build_mode='dl' --test_mode='unit'
+                                python3.7 runtests.py --prov=tcp --ofi_build_mode='dl' --test_mode='mpi'
+                            )
                            """
-                        } 
-                     }       
-       
-                 }
-                 stage('eth-udp-rxd-shm-dl') {
+                        }
+                     }
+                }
+                stage('udp-dl') {
                     agent {node {label 'eth'}}
                     steps{
                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
@@ -387,115 +307,79 @@ pipeline {
                             env
                             (
                                 cd  ${env.WORKSPACE}/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=udp --ofi_build_mode='dl'
-                                python3.7 runtests.py --prov=udp --util=rxd --ofi_build_mode='dl'
-                                python3.7 runtests.py --prov=shm --ofi_build_mode='dl'
-                            )  
+                                python3.7 runtests.py --prov=udp --ofi_build_mode='dl' --test_mode='unit'
+                            )
                         """
-                        } 
-                     }       
-       
-                 }
-        
-                 stage('hfi1-psm2-verbs-dl') {
-                     agent {node {label 'hfi1'}}
-                     steps{
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
-                          sh """
-                            env
-                            ( 
-                                cd ${env.WORKSPACE}/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=psm2 --ofi_build_mode='dl'
-                                python3.7 runtests.py --prov=verbs --ofi_build_mode='dl'                   
-                            ) 
-                         """
-                        } 
-                     }       
-                 }
-                  stage('hfi1-verbs_rxd-dl') {
-                     agent {node {label 'hfi1'}}
-                     steps{
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
-                          sh """
-                            env
-                            ( 
-                                cd ${env.WORKSPACE}/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=verbs --util=rxd --ofi_build_mode='dl'                   
-                            ) 
-                         """
-                        } 
-                     }       
-                 }
-                 stage('hfi1-verbs_rxm-dl') {
-                     agent {node {label 'hfi1'}}
-                     steps{
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
-                          sh """
-                            env
-                            ( 
-                                cd ${env.WORKSPACE}/contrib/intel/jenkins/ 
-                                python3.7 runtests.py --prov=verbs --util=rxm --ofi_build_mode='dl'                   
-                            ) 
-                         """
-                        } 
-                     }       
-                 }
-
-                 stage('mlx5-verbs_rxm-dl') {
-                     agent {node {label 'mlx5'}}
-                     steps{
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
-                          sh """
-                            env
-                            (                           
-                                cd ${env.WORKSPACE}/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=verbs --ofi_build_mode='dl'
-                                python3.7 runtests.py --prov=verbs --util=rxm --ofi_build_mode='dl'                   
-                            )  
-                         """
-                        } 
-                     }       
-       
-                 }   
-                 stage('mlx5-verbs_rxd-dl') {
-                     agent {node {label 'mlx5'}}
-                     steps{
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
-                          sh """
-                            env
-                            (                           
-                                cd ${env.WORKSPACE}/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=verbs --util=rxd --ofi_build_mode='dl'                   
-                            )  
-                         """
-                        } 
+                        }
                      }
                 }
-            } 
-
-   }        
-
-  }
-  
-  post {
-    failure {
-                 mail from: 'notification@jenkins-ci.org', 
-                 to: "${env.mailrecepient}",
-                 subject: "${env.JOB_NAME} - Build # ${env.BUILD_NUMBER} - ${currentBuild.result}!",
-                 body: " Check console output at ${env.BUILD_URL} to view the results."
-
-            }
-    cleanup {
-        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
-            sh "rm -rf '/mpibuilddir/mpich-build-dir/${env.JOB_NAME}/${env.BUILD_NUMBER}'"
-            sh "rm -rf '/mpibuilddir/ompi-build-dir/${env.JOB_NAME}/${env.BUILD_NUMBER}'"
-            sh "rm -rf '/mpibuilddir/mpich-suite-build-dir/${env.JOB_NAME}/${env.BUILD_NUMBER}'"
-            dir("${env.WORKSPACE}"){
-                deleteDir()
+                stage('shm-dl') {
+                     agent {node {label 'eth'}}
+                     steps{
+                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
+                        {
+                          sh """
+                            env
+                            (
+                                cd  ${env.WORKSPACE}/contrib/intel/jenkins/
+                                python3.7 runtests.py --prov=shm --ofi_build_mode='dl' --test_mode='unit'
+                            )
+                          """
+                        }
+                     }
+                }
+                stage('verbs-rc-dl') {
+                     agent {node {label 'mlx5'}}
+                     steps{
+                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
+                          sh """
+                            env
+                            (
+                                cd ${env.WORKSPACE}/contrib/intel/jenkins/
+                                python3.7 runtests.py --prov=verbs --ofi_build_mode='dl' --test_mode='unit'
+                                python3.7 runtests.py --prov=verbs --ofi_build_mode='dl' --test_mode='mpi'
+                            )
+                         """
+                        }
+                     }
+                }
+                stage('verbs-ud-dl') {
+                     agent {node {label 'mlx5'}}
+                     steps{
+                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
+                          sh """
+                            env
+                            (
+                                cd ${env.WORKSPACE}/contrib/intel/jenkins/
+                                python3.7 runtests.py --prov=verbs --util=rxd --ofi_build_mode='dl' --test_mode='unit'
+                                python3.7 runtests.py --prov=verbs --util=rxd --ofi_build_mode='dl' --test_mode='mpi'
+                            )
+                         """
+                        }
+                     }
+                }
             }
         }
     }
-  }
 
+    post {
+      failure {
+                  mail from: 'notification@jenkins-ci.org',
+                  to: "${env.mailrecepient}",
+                  subject: "${env.JOB_NAME} - Build # ${env.BUILD_NUMBER} - ${currentBuild.result}!",
+                  body: " Check console output at ${env.BUILD_URL} to view the results."
+
+              }
+      cleanup {
+          withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
+              sh "rm -rf '/mpibuilddir/mpich-build-dir/${env.JOB_NAME}/${env.BUILD_NUMBER}'"
+              sh "rm -rf '/mpibuilddir/ompi-build-dir/${env.JOB_NAME}/${env.BUILD_NUMBER}'"
+              sh "rm -rf '/mpibuilddir/mpich-suite-build-dir/${env.JOB_NAME}/${env.BUILD_NUMBER}'"
+              dir("${env.WORKSPACE}"){
+                  deleteDir()
+              }
+          }
+      }
+    }
 }
 

--- a/contrib/intel/jenkins/build.py
+++ b/contrib/intel/jenkins/build.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-# add jenkins config location to PATH 
+# add jenkins config location to PATH
 sys.path.append(os.environ['CI_SITE_CONFIG'])
 
 import ci_site_config
@@ -15,24 +15,21 @@ import shutil
 def build_libfabric(libfab_install_path, mode):
 
         if (os.path.exists(libfab_install_path) != True):
-            os.makedirs(libfab_install_path)  
+            os.makedirs(libfab_install_path)
 
         config_cmd = ['./configure', '--prefix={}'.format(libfab_install_path)]
         enable_prov_val = 'yes'
 
         if (mode == 'dbg'):
-            config_cmd.append('--enable-debug')                     
+            config_cmd.append('--enable-debug')
         elif (mode == 'dl'):
             enable_prov_val='dl'
-                   
+
         for prov in common.enabled_prov_list:
             config_cmd.append('--enable-{}={}'.format(prov, enable_prov_val))
         for prov in common.disabled_prov_list:
              config_cmd.append('--enable-{}=no'.format(prov))
-       
-        config_cmd.append('--with-psm2-src={}/opa-psm2-lib'.format(workspace))   
-  
-           
+
         common.run_command(['./autogen.sh'])
         common.run_command(shlex.split(" ".join(config_cmd)))
         common.run_command(['make','clean'])
@@ -41,12 +38,12 @@ def build_libfabric(libfab_install_path, mode):
 
 
 def build_fabtests(libfab_install_path, mode):
-       
+
     os.chdir('{}/fabtests'.format(workspace))
-    if (mode == 'dbg'):   
+    if (mode == 'dbg'):
         config_cmd = ['./configure', '--enable-debug', '--prefix={}' \
                       .format(libfab_install_path),'--with-libfabric={}' \
-                      .format(libfab_install_path)] 
+                      .format(libfab_install_path)]
     else:
         config_cmd = ['./configure', '--prefix={}'.format(libfab_install_path),
                 '--with-libfabric={}'.format(libfab_install_path)]
@@ -63,10 +60,10 @@ def build_shmem(shmem_dir, libfab_install_path):
     shmem_tar = ci_site_config.shmem_tar
     if(os.path.exists(shmem_dir)):
         os.rmdir(shmem_dir)
-    
+
     os.makedirs(shmem_dir)
     os.chdir(shmem_dir)
-    
+
     os.makedirs('SOS')
     common.run_command(['tar', '-xf', shmem_tar, '-C', 'SOS', '--strip-components=1'])
     os.chdir('SOS')
@@ -79,27 +76,27 @@ def build_shmem(shmem_dir, libfab_install_path):
                   'LDFLAGS=-fno-pie']
 
     common.run_command(config_cmd)
-   
+
     common.run_command(['make','-j4'])
     common.run_command(['make', 'check', 'TESTS='])
     common.run_command(['make', 'install'])
 
 
 def build_ISx(shmem_dir):
-    
+
     oshcc = '{}/bin/oshcc'.format(shmem_dir)
     tmp_isx_src = '{}/ISx'.format(ci_site_config.shmem_root)
-    shutil.copytree(tmp_isx_src, '{}/ISx'.format(shmem_dir)) 
+    shutil.copytree(tmp_isx_src, '{}/ISx'.format(shmem_dir))
     #os.chdir(shmem_dir)
     #git_cmd = ['git', 'clone', '--depth', '1', 'https://github.com/ParRes/ISx.git', 'ISx']
-    
-    #common.run_command(git_cmd) 
+
+    #common.run_command(git_cmd)
     os.chdir('{}/ISx/SHMEM'.format(shmem_dir))
-    common.run_command(['make', 'CC={}'.format(oshcc), 'LDLIBS=-lm']) 
-                  
-    
+    common.run_command(['make', 'CC={}'.format(oshcc), 'LDLIBS=-lm'])
+
+
 def build_PRK(shmem_dir):
-    
+
     oshcc = '{}/bin/oshcc'.format(shmem_dir)
     shmem_src = '{}/SOS'.format(shmem_dir)
     tmp_prk_src = '{}/PRK'.format(ci_site_config.shmem_root)
@@ -118,15 +115,15 @@ def build_uh(shmem_dir):
     os.environ["PATH"] += os.pathsep + oshcc_bin
     tmp_uh_src = '{}/tests-uh'.format(ci_site_config.shmem_root)
     shutil.copytree(tmp_uh_src, '{}/tests-uh'.format(shmem_dir))
-    #os.chdir(shmem_dir) 
-    #git_cmd = ['git', 'clone', '--depth', '1', 'https://github.com/openshmem-org/tests-uh.git', 'tests-uh'] 
+    #os.chdir(shmem_dir)
+    #git_cmd = ['git', 'clone', '--depth', '1', 'https://github.com/openshmem-org/tests-uh.git', 'tests-uh']
     #common.run_command(git_cmd)
     os.chdir('{}/tests-uh'.format(shmem_dir))
     common.run_command(['make', '-j4', 'C_feature_tests'])
-    
+
 
 def build_mpi(mpi, mpisrc, mpi_install_path, libfab_install_path,  ofi_build_mode):
-   
+
     build_mpi_path ="/mpibuilddir/{}-build-dir/{}/{}/{}".format(mpi, jobname, buildno, ofi_build_mode)
     if (os.path.exists(build_mpi_path) == False):
         os.makedirs(build_mpi_path)
@@ -142,7 +139,7 @@ def build_mpi(mpi, mpisrc, mpi_install_path, libfab_install_path,  ofi_build_mod
         cmd.append("--enable-fortran=no")
         cmd.append("--with-device=ch4:ofi")
         cmd.append("--enable-ch4-direct=netmod")
-        
+
     configure_cmd = shlex.split(" ".join(cmd))
     common.run_command(configure_cmd)
     common.run_command(["make", "clean"])
@@ -159,7 +156,7 @@ def build_mpich_suite(mpi, mpi_install_path, libfab_install_path, ofi_build_mode
     mpichsuite_installpath= "{}/mpichsuite/test".format(mpi_install_path)
     pwd = os.getcwd()
     if (mpi == 'impi'):
-        os.chdir("{}/mpi".format(mpich_suite_path)) 
+        os.chdir("{}/mpi".format(mpich_suite_path))
         cmd = ["./configure", "--with-mpi={}/intel64" \
                .format(ci_site_config.impi_root)]
 
@@ -173,14 +170,14 @@ def build_mpich_suite(mpi, mpi_install_path, libfab_install_path, ofi_build_mode
 
 
 def build_stress_bm(mpi, mpi_install_path, libfab_install_path):
-    
+
     stress_install_path = "{}/stress".format(mpi_install_path)
     if (os.path.exists(stress_install_path) == False):
         os.makedirs(stress_install_path)
-     
+
     if (mpi == 'impi'):
         os.environ['LD_LIBRARY_PATH'] = "{}/lib".format(libfab_install_path)
-        mpicc_path = "{}/intel64/bin/mpicc".format(ci_site_config.impi_root) 
+        mpicc_path = "{}/intel64/bin/mpicc".format(ci_site_config.impi_root)
     else:
         os.environ['LD_LIBRARY_PATH'] = ""
         mpicc_path = "{}/bin/mpicc".format(mpi_install_path)
@@ -191,32 +188,32 @@ def build_stress_bm(mpi, mpi_install_path, libfab_install_path):
 
     runcmd = shlex.split(cmd)
     common.run_command(runcmd)
- 
+
 
 def build_osu_bm(mpi, mpi_install_path, libfab_install_path):
-    
+
     osu_install_path = "{}/osu".format(mpi_install_path)
     if (os.path.exists(osu_install_path) == False):
         os.makedirs(osu_install_path)
     os.chdir(osu_install_path)
-    
+
     if (mpi == 'impi'):
         os.environ['CC']="{}/intel64/bin/mpicc".format(ci_site_config.impi_root)
         os.environ['CXX']="{}/intel64/bin/mpicxx".format(ci_site_config.impi_root)
         os.environ['LD_LIBRARY_PATH'] = "{}/lib".format(libfab_install_path)
 
-    else: 
+    else:
         os.environ['CC']="{}/bin/mpicc".format(mpi_install_path)
         os.environ['CXX']="{}/bin/mpicxx".format(mpi_install_path)
         os.environ['LD_LIBRARY_PATH']=""
 
-    
+
     os.environ['CFLAGS']="-I{}/util/".format(ci_site_config.benchmarks['osu'])
     cmd = " ".join(["{}/configure".format(ci_site_config.benchmarks['osu']),
                     "--prefix={}".format(osu_install_path)])
-   
-    configure_cmd = shlex.split(cmd) 
-    
+
+    configure_cmd = shlex.split(cmd)
+
     common.run_command(configure_cmd)
     common.run_command(["make", "-j4"])
     common.run_command(["make", "install"])
@@ -224,14 +221,12 @@ def build_osu_bm(mpi, mpi_install_path, libfab_install_path):
 
 if __name__ == "__main__":
 #read Jenkins environment variables
-    # In Jenkins,  JOB_NAME  = 'ofi_libfabric/master' vs BRANCH_NAME = 'master' 
+    # In Jenkins,  JOB_NAME  = 'ofi_libfabric/master' vs BRANCH_NAME = 'master'
     # job name is better to use to distinguish between builds of different
     # jobs but with same branch name.
     jobname = os.environ['JOB_NAME']
     buildno = os.environ['BUILD_NUMBER']
     workspace = os.environ['WORKSPACE']
-
-
 
     parser = argparse.ArgumentParser()
     parser.add_argument("build_item", help="build libfabric or fabtests",
@@ -248,8 +243,6 @@ if __name__ == "__main__":
     else:
         ofi_build_mode = 'reg'
 
-
-
     install_path = "{installdir}/{jbname}/{bno}/{bmode}" \
                      .format(installdir=ci_site_config.install_dir,
                             jbname=jobname, bno=buildno,bmode=ofi_build_mode)
@@ -261,19 +254,19 @@ if __name__ == "__main__":
 
     elif (build_item == 'fabtests'):
         build_fabtests(install_path, ofi_build_mode)
-   #if the build_item contains the string 'mpi'   
+   #if the build_item contains the string 'mpi'
     elif (p.search(build_item)):
         mpi = build_item[:-11] #extract the mpitype from '*mpi*_benchmarks' build_item
-        mpi_install_path = "{}/{}".format(install_path, mpi) 
-    
+        mpi_install_path = "{}/{}".format(install_path, mpi)
+
         if (os.path.exists(mpi_install_path) == False):
-            os.makedirs(mpi_install_path) 
+            os.makedirs(mpi_install_path)
         if (mpi != 'impi'):
             mpisrc = ci_site_config.mpich_src if mpi == 'mpich' \
                      else ci_site_config.ompi_src
             # only need to build ompi or mpich, impi is available as binary
             build_mpi(mpi, mpisrc, mpi_install_path, install_path, ofi_build_mode)
-        
+
 	# build mpich_test_suite
         build_mpich_suite(mpi, mpi_install_path, install_path, ofi_build_mode)
         # run stress and osu benchmarks for all mpitypes
@@ -286,6 +279,6 @@ if __name__ == "__main__":
         build_ISx(shmem_dir)
         build_PRK(shmem_dir)
         build_uh(shmem_dir)
-    
+
 
 

--- a/contrib/intel/jenkins/run.py
+++ b/contrib/intel/jenkins/run.py
@@ -34,30 +34,22 @@ def fabtests(core, hosts, mode, util=None):
                  testname="runfabtests", core_prov=core, fabric=fab,\
                  hosts=hosts, ofi_build_mode=mode, util_prov=util)
 
-    if (runfabtest.execute_condn):
-        print("running fabtests for {}-{}-{}".format(core, util, fab))
-        runfabtest.execute_cmd()
-    else:
-        print("skipping {} as execute condition fails"\
-              .format(runfabtest.testname))
+    print("running fabtests for {}-{}-{}".format(core, util, fab))
+    runfabtest.execute_cmd()
     print("----------------------------------------------------------------------------------------\n")
 
 def shmemtest(core, hosts, mode, util=None):
     runshmemtest = tests.ShmemTest(jobname=jbname,buildno=bno,\
                  testname="shmem test", core_prov=core, fabric=fab,\
                  hosts=hosts, ofi_build_mode=mode, util_prov=util)
-    if (runshmemtest.execute_condn):
-        print("running shmem unit test for {}-{}-{}".format(core, util, fab))
-        runshmemtest.execute_cmd("unit")
-        print("running shmem PRK test for {}-{}-{}".format(core, util, fab))
-        runshmemtest.execute_cmd("prk")
-        print("running shmem ISx test for {}-{}-{}".format(core, util, fab))
-        runshmemtest.execute_cmd("isx")
-        print("running shmem uh test for {}-{}-{}".format(core, util, fab))
-        runshmemtest.execute_cmd("uh")
-    else:
-        print("skipping {} as execute condition fails"\
-              .format(runshmemtest.testname))
+    print("running shmem unit test for {}-{}-{}".format(core, util, fab))
+    runshmemtest.execute_cmd("unit")
+    print("running shmem PRK test for {}-{}-{}".format(core, util, fab))
+    runshmemtest.execute_cmd("prk")
+    print("running shmem ISx test for {}-{}-{}".format(core, util, fab))
+    runshmemtest.execute_cmd("isx")
+    print("running shmem uh test for {}-{}-{}".format(core, util, fab))
+    runshmemtest.execute_cmd("uh")
     print("----------------------------------------------------------------------------------------\n")
 
 
@@ -68,12 +60,12 @@ def intel_mpi_benchmark(core, hosts, mpi, mode, util=None):
                testname="IntelMPIbenchmark",core_prov=core, fabric=fab,\
                hosts=hosts, mpitype=mpi, ofi_build_mode=mode, util_prov=util)
 
-    if (imb_test.execute_condn == True  and imb_test.mpi_gen_execute_condn == True):
+    if (imb_test.execute_condn == True):
         print("running imb-tests for {}-{}-{}-{}".format(core, util, fab, mpi))
         imb_test.execute_cmd()
     else:
         print("skipping {} as execute condition fails"\
-                    .format(imb_test.testname))
+                .format(imb_test.testname))
     print("----------------------------------------------------------------------------------------\n")
 
 #mpich_test_suite
@@ -82,8 +74,7 @@ def mpich_test_suite(core, hosts, mpi, mode, util=None):
                   testname="MpichTestSuite",core_prov=core, fabric=fab,\
                   mpitype=mpi, hosts=hosts, ofi_build_mode=mode, \
                   util_prov=util)
-    if (mpich_tests.execute_condn == True and \
-        mpich_tests.mpi_gen_execute_condn == True):
+    if (mpich_tests.execute_condn == True):
         print("Running mpich test suite: Spawn coll, comm, dt Tests for {}-{}-{}-{}".format(core, util, fab, mpi))
         os.environ["MPITEST_RETURN_WITH_CODE"] = "1"
         mpich_tests.execute_cmd("spawn")
@@ -96,7 +87,7 @@ def osu_benchmark(core, hosts, mpi, mode, util=None):
                testname="osu-benchmarks",core_prov=core, fabric=fab, mpitype=mpi, \
                hosts=hosts, ofi_build_mode=mode, util_prov=util)
 
-    if (osu_test.execute_condn == True and osu_test.mpi_gen_execute_condn == True):
+    if (osu_test.execute_condn == True):
         print("running osu-test for {}-{}-{}-{}".format(core, util, fab, mpi))
         osu_test.execute_cmd()
     else:

--- a/contrib/intel/jenkins/runtests.py
+++ b/contrib/intel/jenkins/runtests.py
@@ -8,11 +8,13 @@ import common
 
 parser = argparse.ArgumentParser()
 
-parser.add_argument("--prov", help="core provider", choices=["psm2", "verbs", \
+parser.add_argument("--prov", help="core provider", choices=["verbs", \
                      "tcp", "udp", "sockets", "shm"])
 parser.add_argument("--util", help="utility provider", choices=["rxd", "rxm"])
 parser.add_argument("--ofi_build_mode", help="specify the build configuration", \
                      choices = ["dbg", "dl"])
+parser.add_argument("--test_mode", help="specify tests to execute", \
+                    choices = ["all", "unit", "shmem", "mpi"])
 
 args = parser.parse_args()
 args_core = args.prov
@@ -23,6 +25,11 @@ if (args.ofi_build_mode):
     ofi_build_mode = args.ofi_build_mode
 else:
     ofi_build_mode='reg'
+
+if (args.test_mode):
+    test_mode = args.test_mode
+else:
+    test_mode = 'all'
 
 node = (os.environ['NODE_NAME']).split('-')[0]
 hosts = [node]
@@ -46,25 +53,34 @@ if(args_core):
         hosts.append(host)
 
     if (args_util == None):
-        run.fi_info_test(args_core, hosts, ofi_build_mode)
-        run.fabtests(args_core, hosts, ofi_build_mode)
-        run.shmemtest(args_core, hosts, ofi_build_mode)
-        for mpi in mpilist:
-            run.mpich_test_suite(args_core, hosts, mpi, ofi_build_mode)
-            run.intel_mpi_benchmark(args_core, hosts, mpi, ofi_build_mode)
-            run.osu_benchmark(args_core, hosts, mpi, ofi_build_mode)
-    else:
-        run.fi_info_test(args_core, hosts, ofi_build_mode, util=args_util)
-        run.fabtests(args_core, hosts, ofi_build_mode, util=args_util)
-        run.shmemtest(args_core, hosts, ofi_build_mode, util=args_util)
-        for mpi in mpilist:
-            run.mpich_test_suite(args_core, hosts, mpi, ofi_build_mode, \
-                                 util=args_util)
+        if (test_mode == 'all' or test_mode == 'unit'):
+            run.fi_info_test(args_core, hosts, ofi_build_mode)
+            run.fabtests(args_core, hosts, ofi_build_mode)
 
-            run.intel_mpi_benchmark(args_core, hosts, mpi, ofi_build_mode, \
+        if (test_mode == 'all' or test_mode == 'shmem'):
+            run.shmemtest(args_core, hosts, ofi_build_mode)
+
+        if (test_mode == 'all' or test_mode == 'mpi'):
+            for mpi in mpilist:
+                run.mpich_test_suite(args_core, hosts, mpi, ofi_build_mode)
+                run.intel_mpi_benchmark(args_core, hosts, mpi, ofi_build_mode)
+                run.osu_benchmark(args_core, hosts, mpi, ofi_build_mode)
+    else:
+        if (test_mode == 'all' or test_mode == 'unit'):
+            run.fi_info_test(args_core, hosts, ofi_build_mode, util=args_util)
+            run.fabtests(args_core, hosts, ofi_build_mode, util=args_util)
+
+        if (test_mode == 'all' or test_mode == 'shmem'):
+            run.shmemtest(args_core, hosts, ofi_build_mode, util=args_util)
+
+        if (test_mode == 'all' or test_mode == 'mpi'):
+            for mpi in mpilist:
+                run.mpich_test_suite(args_core, hosts, mpi, ofi_build_mode, \
                                     util=args_util)
-            run.osu_benchmark(args_core, hosts, mpi, ofi_build_mode, \
-                                             util=args_util)
+                run.intel_mpi_benchmark(args_core, hosts, mpi, ofi_build_mode, \
+                                        util=args_util)
+                run.osu_benchmark(args_core, hosts, mpi, ofi_build_mode, \
+                                                util=args_util)
 else:
     print("Error : Specify a core provider to run tests")
 

--- a/fabtests/test_configs/verbs/verbs.exclude
+++ b/fabtests/test_configs/verbs/verbs.exclude
@@ -3,7 +3,6 @@
 # Exclude all prefix tests
 -k
 
-rdm
 dgram
 
 trigger
@@ -17,3 +16,6 @@ multi_recv
 recv_cancel
 unexpected_msg
 inj_complete
+rdm_rma_event
+trigger
+shared_av


### PR DESCRIPTION
Remove psm2 and hfi1 from CI.  The HW and related architecture has
been branch to a separate start-up.

This modifies the per PR CI to exclude older HW, but expands the CI coverage in other areas.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>