### PR TITLE
netdir / fi_endpoint uses maximum values to create queue pair 

### DIFF
--- a/prov/netdir/src/netdir.h
+++ b/prov/netdir/src/netdir.h
@@ -51,7 +51,6 @@ extern "C" {
 
 #define ND_MSG_IOV_LIMIT		(256)
 #define ND_MSG_INTERNAL_IOV_LIMIT	(512)
-#define ND_EP_MAX_CM_DATA_SIZE		(256)
 #define OFI_ND_MAX_MR_CNT		(1 << 16)
 
 #define OFI_ND_DOMAIN_CAPS	(FI_LOCAL_COMM | FI_REMOTE_COMM)

--- a/prov/netdir/src/netdir_ep_srx.c
+++ b/prov/netdir/src/netdir_ep_srx.c
@@ -65,6 +65,8 @@ static ssize_t ofi_nd_no_injectdata(struct fid_ep *ep, const void *buf, size_t l
 				    uint64_t data, fi_addr_t dest_addr);
 static int ofi_nd_srx_close(struct fid *fid);
 static ssize_t ofi_nd_srx_cancel(fid_t fid, void *context);
+extern int ofi_nd_ep_getopt(struct fid* ep, int level, int optname,
+	void* optval, size_t* optlen);
 
 struct fi_ops_msg ofi_nd_srx_msg = {
 	.size = sizeof(ofi_nd_srx_msg),
@@ -96,7 +98,7 @@ static struct fid ofi_nd_fid = {
 static struct fi_ops_ep ofi_nd_ep_ops = {
 	.size = sizeof(ofi_nd_ep_ops),
 	.cancel = ofi_nd_srx_cancel,
-	.getopt = fi_no_getopt,
+	.getopt = ofi_nd_ep_getopt,
 	.setopt = fi_no_setopt,
 	.tx_ctx = fi_no_tx_ctx,
 	.rx_ctx = fi_no_rx_ctx,

--- a/prov/netdir/src/netdir_pep.c
+++ b/prov/netdir/src/netdir_pep.c
@@ -57,7 +57,7 @@ static void ofi_nd_pep_connreq_free(nd_event_base *base);
 static void ofi_nd_pep_connreq(nd_event_base *base, DWORD bytes);
 static void ofi_nd_pep_connreq_err(nd_event_base *base, DWORD err,
 				   DWORD bytes);
-static int ofi_nd_pep_getopt(struct fid *ep, int level, int optname,
+extern int ofi_nd_ep_getopt(struct fid *ep, int level, int optname,
 			void *optval, size_t *optlen);
 
 static struct fi_ops ofi_nd_fi_ops = {
@@ -90,7 +90,7 @@ static struct fi_ops_cm ofi_nd_cm_ops = {
 static struct fi_ops_ep ofi_nd_pep_ops = {
 	.size = sizeof(ofi_nd_pep_ops),
 	.cancel = fi_no_cancel,
-	.getopt = ofi_nd_pep_getopt,
+	.getopt = ofi_nd_ep_getopt,
 	.setopt = fi_no_setopt,
 	.tx_ctx = fi_no_tx_ctx,
 	.rx_ctx = fi_no_rx_ctx,
@@ -475,30 +475,6 @@ static int ofi_nd_pep_reject(struct fid_pep *ppep, fid_t handle,
 	ofi_nd_buf_free_nd_connreq(connreq);
 
 	return FI_SUCCESS;
-}
-
-static int ofi_nd_pep_getopt(struct fid *ep, int level, int optname,
-			void *optval, size_t *optlen)
-{
-	OFI_UNUSED(ep);
-
-	assert(level == FI_OPT_ENDPOINT &&
-		optname == FI_OPT_CM_DATA_SIZE);
-	assert(optval);
-	assert(optlen);
-
-	if (level != FI_OPT_ENDPOINT || optname != FI_OPT_CM_DATA_SIZE)
-		return -FI_ENOPROTOOPT;
-
-	if (*optlen < sizeof(size_t)) {
-		*optlen = sizeof(size_t);
-		return -FI_ETOOSMALL;
-	}
-
-	*((size_t *)optval) = ND_EP_MAX_CM_DATA_SIZE;
-	*optlen = sizeof(size_t);
-
-	return 0;
 }
 
 #endif /* _WIN32 */


### PR DESCRIPTION
1 Add netdir provider-wide implementation for fi_getopt.
    1.1 Add hooks for common fi_getopt implementation in netdir_ep.c/netdir_pep.c/netdir_ep_srx.c.
    1.2 Move fi_getopt implementation from netdir_pep.c to netdir_ep.c and rename from ofi_nd_pep_getopt to ofi_nd_ep_getopt.
    1.3 Modify fi_getopt implementation to return value from IND2Adapter::Query instead of hard coded value.
2 Modify fi_enable implementation to allow client control of values used when creating a queue pair.
    2.1 Modify tx/rx size/iov_limit values used for fi_getinfo to come from IND2Adapter::Query rather than hard coded values.
    2.2 Modify fi_enable implementation to use tx/rx size/iov_limit values when creating tx/rx queue pair rather than maximum allowed so hints can control the actual values used.

on-behalf-of: @cmru-ps <dshinaberry@mru.medical.canon>
Signed-off-by: Derek Shinaberry <dshinaberry@mru.medical.canon>