### PR TITLE
contrib/intel/jenkins: source env/vars.sh Jenkinsfile

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -52,12 +52,13 @@ pipeline {
         }
         stage('build IMPI_bm') {
             steps {
-                withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']){
-                  sh """
-                    python3.7 contrib/intel/jenkins/build.py 'impi_benchmarks' --ofi_build_mode='dbg'
-                    echo 'mpi benchmarks with impi - built successfully'
-                  """
-                }
+              withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']){
+                sh """
+                source ${env.CI_IMPI_ONEAPI_ROOT}/env/vars.sh -i_mpi_ofi_internal=0
+                python3.7 contrib/intel/jenkins/build.py 'impi_benchmarks' --ofi_build_mode='dbg'
+                echo 'mpi benchmarks with impi - built successfully'
+                """
+              }
             }
         }
         stage ('build OMPI_bm') {

--- a/contrib/intel/jenkins/build.py
+++ b/contrib/intel/jenkins/build.py
@@ -156,7 +156,7 @@ def build_mpi(mpi, mpisrc, mpi_install_path, libfab_install_path,  ofi_build_mod
 def build_mpich_suite(mpi, mpi_install_path, libfab_install_path, ofi_build_mode):
 
     mpich_suite_build_path = "/mpibuilddir/mpich-suite-build-dir/{}/{}/{}/mpich" \
-                             .format(jobname, buildno, ofi_build_mode);
+                             .format(jobname, buildno, ofi_build_mode)
     if (os.path.exists(mpich_suite_build_path) == False):
         shutil.copytree(ci_site_config.mpich_src, mpich_suite_build_path)
 


### PR DESCRIPTION
source env/vars.sh before building IMPI

Signed-off-by: Zach Dworkin <zachary.dworkin@intel.com>