### PR TITLE
contrib/intel/jenkins: update mpich_build configure

### DIFF
--- a/contrib/intel/jenkins/build.py
+++ b/contrib/intel/jenkins/build.py
@@ -145,7 +145,7 @@ def build_mpi(mpi, mpisrc, mpi_install_path, libfab_install_path,  ofi_build_mod
     elif (mpi == 'mpich'):
         cmd.append("--enable-fortran=no")
         cmd.append("--with-device=ch4:ofi")
-        cmd.append("--enable-ch4-direct=netmod")
+        cmd.append("--without-ch4-shmmods")
 
     configure_cmd = shlex.split(" ".join(cmd))
     common.run_command(configure_cmd)


### PR DESCRIPTION
replace deprecated MPICH config option

Signed-off-by: Zach Dworkin <zachary.dworkin@intel.com>