### PR TITLE
prov/efa: add efa_ep_is_hmem_mr function     

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -635,9 +635,14 @@ struct rdm_peer *rxr_ep_get_peer(struct rxr_ep *ep, fi_addr_t addr)
 	return av_entry->conn.ep_addr ? &av_entry->conn.rdm_peer : NULL;
 }
 
-static inline bool efa_ep_is_cuda_mr(struct efa_mr *efa_mr)
+static inline bool efa_ep_is_hmem_mr(struct efa_mr *efa_mr)
 {
 	return efa_mr ? (efa_mr->peer.iface == FI_HMEM_CUDA): false;
+}
+
+static inline bool efa_ep_is_cuda_mr(struct efa_mr *efa_mr)
+{
+	return efa_mr ? (efa_mr->peer.iface == FI_HMEM_CUDA) : false;
 }
 
 /*

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -188,15 +188,16 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 		assert(rxr_ep->use_shm);
 		/* intra instance message
 		 *
-		 * Currently shm proivder does not support mixed memory type iov
-		 * (it will crash), which will happen is eager message protocol
-		 * is used for cuda buffer. An GitHub issue has been opened
-		 * regarding this
+		 * Currently the shm provider does not support mixed memory type
+		 * iov (it will crash), which will happen if the eager message
+		 * protocol is used for FI_HMEM enabled buffers. An GitHub
+		 * issue has been opened regarding this:
 		 *     https://github.com/ofiwg/libfabric/issues/6639
-		 * Before it is addressed, we use read message protocol for
-		 * all cuda messages
+		 *
+		 * Have the remote side issue a read to copy the data instead
+		 * to work around this issue.
 		 */
-		if (tx_entry->total_len > max_rtm_data_size || efa_ep_is_cuda_mr(tx_entry->desc[0]))
+		if (tx_entry->total_len > max_rtm_data_size || efa_ep_is_hmem_mr(tx_entry->desc[0]))
 			/*
 			 * Read message support
 			 * FI_DELIVERY_COMPLETE implicitly.

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -355,7 +355,12 @@ void rxr_pkt_handle_readrsp_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_en
 	tx_entry->window -= data_len;
 	assert(tx_entry->window >= 0);
 	if (tx_entry->bytes_sent < tx_entry->total_len) {
-		assert(!efa_ep_is_cuda_mr(tx_entry->desc[0]));
+		/*
+		 * We currently require EFA RDMA support to enable the FI_HMEM
+		 * devices we support. Emulated read should not be used.
+		 */
+		assert(!efa_ep_is_hmem_mr(tx_entry->desc[0]));
+
 		if (tx_entry->desc[0] || efa_is_cache_available(efa_domain))
 			rxr_prepare_desc_send(rxr_ep_domain(ep), tx_entry);
 

--- a/prov/efa/src/rxr/rxr_read.c
+++ b/prov/efa/src/rxr/rxr_read.c
@@ -400,7 +400,7 @@ int rxr_read_post_local_read_or_queue(struct rxr_ep *ep,
 
 	/* setup iov */
 	assert(pkt_entry->x_entry == rx_entry);
-	assert(rx_entry->desc && efa_ep_is_cuda_mr(rx_entry->desc[0]));
+	assert(rx_entry->desc && efa_ep_is_hmem_mr(rx_entry->desc[0]));
 	read_entry->iov_count = rx_entry->iov_count;
 	memset(read_entry->mr, 0, sizeof(*read_entry->mr) * read_entry->iov_count);
 	memcpy(read_entry->iov, rx_entry->iov, rx_entry->iov_count * sizeof(struct iovec));
@@ -414,8 +414,9 @@ int rxr_read_post_local_read_or_queue(struct rxr_ep *ep,
 		return -FI_ETRUNC;
 	}
 
-	assert(efa_ep_is_cuda_mr(read_entry->mr_desc[0]));
+	assert(efa_ep_is_hmem_mr(read_entry->mr_desc[0]));
 	err = ofi_truncate_iov(read_entry->iov, &read_entry->iov_count, data_size + ep->msg_prefix_size);
+
 	if (err) {
 		FI_WARN(&rxr_prov, FI_LOG_CQ,
 			"data_offset %ld data_size %ld out of range\n",


### PR DESCRIPTION
    Add a new function called efa_ep_is_hmem_mr to be used for paths where
    we want a general HMEM check. CUDA still has a couple of special cases
    until we support CUDA IPC.