### PR TITLE
fabtests/ubertest: Fix tests failing with IPC

### DIFF
--- a/fabtests/ubertest/xfer.c
+++ b/fabtests/ubertest/xfer.c
@@ -662,7 +662,7 @@ static int ft_msg_sync(void)
 	if (ret)
 		return ret;
 
-	msg_iov.iov_base = (void *) buf;
+	msg_iov.iov_base = (void *) ft_tx_ctrl.buf;
 	msg_iov.iov_len = 0;
 
 	msg.msg_iov = &msg_iov;
@@ -689,7 +689,7 @@ static int ft_tmsg_sync(void)
 	if (ret)
 		return ret;
 
-	msg_iov.iov_base = (void *) buf;
+	msg_iov.iov_base = (void *) ft_tx_ctrl.buf;
 	msg_iov.iov_len = 0;
 
 	msg.msg_iov = &msg_iov;


### PR DESCRIPTION
There was a small bug discovered while testing HMEM ZE on
PVC with IPC path. A wrong buffer was used which has been
fixed.

Signed-off-by: Juee Himalbhai Desai <juee.himalbhai.desai@intel.com>