### PR TITLE
.github/workflows: temporary workaround for failing ZE build

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -88,10 +88,16 @@ jobs:
         run: |
           echo "Installing Ze SDK"
           sudo apt-get install -y gpg-agent wget
-          wget -qO - https://repositories.intel.com/graphics/intel-graphics.key | sudo apt-key add -
-          sudo apt-add-repository 'deb [arch=amd64] https://repositories.intel.com/graphics/ubuntu focal main'
-          sudo apt-get update
-          sudo apt-get install -y level-zero level-zero-dev
+
+          # Temporary workaround to avoid 1.6.2 (current version in the distro) which is failing to build
+          wget -q https://github.com/oneapi-src/level-zero/releases/download/v1.7.4/level-zero_1.7.4+u18.04_amd64.deb
+          wget -q https://github.com/oneapi-src/level-zero/releases/download/v1.7.4/level-zero-devel_1.7.4+u18.04_amd64.deb
+          sudo apt install ./level-zero_1.7.4+u18.04_amd64.deb ./level-zero-devel_1.7.4+u18.04_amd64.deb
+
+          #wget -qO - https://repositories.intel.com/graphics/intel-graphics.key | sudo apt-key add -
+          #sudo apt-add-repository 'deb [arch=amd64] https://repositories.intel.com/graphics/ubuntu focal main'
+          #sudo apt-get update
+          #sudo apt-get install -y level-zero level-zero-dev
       - uses: actions/checkout@v2
       - name: HMEM Checks
         run: |


### PR DESCRIPTION
The Ubuntu distro ZE version was recently updated from 1.4.1 to 1.6.2 which has
an issue in the headers which prevents compilation and causes CI failures.

The issue has been fixed in 1.7.4 but the distro has not been updated yet. This
is a temporary manual workaround to use 1.7.4 instead of the distro version to
avoid CI failures.

Will be removed when the distro gets updated.

Signed-off-by: Alexia Ingerson <alexia.ingerson@intel.com>