### PR TITLE
Intel/CI: added interface run_command_try and added make distclean for osu bm build

### DIFF
--- a/contrib/intel/jenkins/build.py
+++ b/contrib/intel/jenkins/build.py
@@ -149,7 +149,7 @@ def build_mpi(mpi, mpisrc, mpi_install_path, libfab_install_path,  ofi_build_mod
 
     configure_cmd = shlex.split(" ".join(cmd))
     common.run_command(configure_cmd)
-    common.run_command(["make", "clean"])
+    common.run_command_try(["make", "clean"])
     common.run_command(["make", "install", "-j32"])
 
 
@@ -173,7 +173,7 @@ def build_mpich_suite(mpi, mpi_install_path, libfab_install_path, ofi_build_mode
         common.run_command(configure_cmd)
         common.run_command(["make", "all","-j32"])
         shutil.copytree(mpich_suite_path, mpichsuite_installpath)
-        common.run_command(["make", "distclean"])
+        common.run_command_try(["make", "distclean"])
         os.chdir(pwd)
 
 
@@ -220,8 +220,9 @@ def build_osu_bm(mpi, mpi_install_path, libfab_install_path):
                     "--prefix={}".format(osu_install_path)])
 
     configure_cmd = shlex.split(cmd)
+    common.run_command_try(["make","distclean"])
     common.run_command(configure_cmd)
-    common.run_command(["make", "-j4"])
+    common.run_command(["make", "-j"])
     common.run_command(["make", "install"])
 
 

--- a/contrib/intel/jenkins/common.py
+++ b/contrib/intel/jenkins/common.py
@@ -21,6 +21,21 @@ def run_command(command):
     if (p.returncode != 0):
         print("exiting with " + str(p.poll()))
         sys.exit(p.returncode)
+def run_command_try(command):
+    print(" ".join(command))
+    p = subprocess.Popen(command, stdout=subprocess.PIPE, text=True)
+    print(p.returncode)
+    while True:
+        out = p.stdout.read(1)
+        if (out == "" and p.poll() != None):
+            break
+        if (out != ""):
+            sys.stdout.write(out)
+            sys.stdout.flush()
+    if (p.returncode != 0):
+        print("command didnt succeed" + str(p.poll()))
+        
+
 
 
 Prov = collections.namedtuple('Prov', 'core util')


### PR DESCRIPTION
run_command_try doesnot terminate the command if a failure is returned.
make distclean added to osu bm build to fix build errors with mpich

Signed-off-by: Nikhil Nanal <nikhil.nanal@intel.com>