### PR TITLE
hmem: add support for AWS Trainium to Libfabric and Fabtests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -45,6 +45,7 @@ common_srcs =				\
 	src/hmem_cuda.c			\
 	src/hmem_cuda_gdrcopy.c		\
 	src/hmem_ze.c			\
+	src/hmem_neuron.c		\
 	src/common.c			\
 	src/enosys.c			\
 	src/rbtree.c			\

--- a/configure.ac
+++ b/configure.ac
@@ -609,6 +609,28 @@ AS_IF([test "$have_ze" = "1" && test x"$with_ze" != x"yes"],
       [CPPFLAGS="$CPPFLAGS $ze_CPPFLAGS"
        LDFLAGS="$LDFLAGS $ze_LDFLAGS"])
 
+dnl Check for AWS Neuron runtime library for Neuron device support
+AC_ARG_WITH([neuron],
+	AS_HELP_STRING([--with-neuron=DIR],
+		       [Provide path to where the Neuron headers are installed.]),
+	[], [])
+
+_FI_CHECK_PACKAGE_HEADER([neuron], [nrt/nrt.h], [$with_neuron],
+	[
+		AS_IF([test "$freebsd" = "0"], [
+		    AC_CHECK_LIB(dl, dlopen, [],
+			[AC_MSG_ERROR([dlopen not found.  libfabric requires libdl.])])
+		])
+		AC_DEFINE([HAVE_NEURON], [1], [build with neuron support])
+	],
+	[
+		AS_IF([test x"$with_neuron" != x"no" && test -n "$with_neuron"],
+		      [AC_MSG_ERROR([Neuron support requested but headers are not available.])],
+		      [])
+		AC_DEFINE([HAVE_NEURON], [0], [build with neuron support])
+	]
+)
+
 enable_memhooks=1
 AC_ARG_ENABLE([memhooks-monitor],
               [AS_HELP_STRING([--disable-memhooks-monitor],

--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -120,6 +120,7 @@ libfabtests_la_SOURCES = \
 	common/hmem_rocr.c \
 	common/hmem_ze.c \
 	include/shared.h \
+	include/ft_list.h \
 	include/hmem.h \
 	include/jsmn.h \
 	include/unix/osd.h \

--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -119,6 +119,7 @@ libfabtests_la_SOURCES = \
 	common/hmem_cuda.c \
 	common/hmem_rocr.c \
 	common/hmem_ze.c \
+	common/hmem_neuron.c \
 	include/shared.h \
 	include/ft_list.h \
 	include/hmem.h \

--- a/fabtests/Makefile.win
+++ b/fabtests/Makefile.win
@@ -45,7 +45,8 @@ CFLAGS = $(CFLAGS) /O2 /MT
 
 basedeps = common\hmem.c common\shared.c \
 	common\windows\getopt.c common\windows\osd.c \
-	common\hmem_cuda.c common\hmem_rocr.c common\hmem_ze.c
+	common\hmem_cuda.c common\hmem_rocr.c common\hmem_ze.c \
+	common\hmem_neuron.c
 
 includes = /Iinclude /Iinclude\windows /I..\include /FIft_osd.h \
 	/Iinclude\windows\getopt

--- a/fabtests/common/hmem.c
+++ b/fabtests/common/hmem.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Intel Corporation.  All rights reserved.
+ * Copyright (c) 2021 Amazon.com, Inc. or its affiliates.
  *
  * This software is available to you under the BSD license below:
  *
@@ -83,6 +84,15 @@ static struct ft_hmem_ops hmem_ops[] = {
 		.memset = ft_ze_memset,
 		.copy_to_hmem = ft_ze_copy,
 		.copy_from_hmem = ft_ze_copy,
+	},
+	[FI_HMEM_NEURON] = {
+		.init = ft_neuron_init,
+		.cleanup = ft_neuron_cleanup,
+		.alloc = ft_neuron_alloc,
+		.free = ft_neuron_free,
+		.memset = ft_neuron_memset,
+		.copy_to_hmem = ft_neuron_memcpy_to_hmem,
+		.copy_from_hmem = ft_neuron_memcpy_from_hmem,
 	},
 };
 

--- a/fabtests/common/hmem_neuron.c
+++ b/fabtests/common/hmem_neuron.c
@@ -1,0 +1,360 @@
+/*
+ * (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+ * Copyright (c) 2021 Amazon.com, Inc. or its affiliates.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "hmem.h"
+#include "shared.h"
+
+#ifdef HAVE_NEURON
+
+#include <dlfcn.h>
+#include <ft_list.h>
+
+#include "nrt/nrt.h"
+#include "nrt/nrt_experimental.h"
+
+/* Size of temporary buffer to alloc for memset */
+#define NEURON_MEMSET_BUF_SIZE 65536
+
+struct neuron_ops {
+	NRT_STATUS (*nrt_tensor_allocate)(nrt_tensor_placement_t tensor_placement,
+					  int logical_nc_id, size_t size,
+					  const char *name, nrt_tensor_t **tensor);
+	void (*nrt_tensor_free)(nrt_tensor_t **tensor);
+	void *(*nrt_tensor_get_va)(const nrt_tensor_t *tensor);
+	NRT_STATUS (*nrt_tensor_read)(const nrt_tensor_t *tensor, void *buf, size_t offset, size_t size);
+	NRT_STATUS (*nrt_tensor_write)(nrt_tensor_t *tensor, const void *buf, size_t offset, size_t size);
+	NRT_STATUS (*nrt_init)(nrt_framework_type_t framework, const char *fw_version, const char *fal_version);
+};
+
+static void *neuron_handle = NULL;
+static struct neuron_ops neuron_ops;
+
+/*
+ * List to lookup the handle based on the pointer. Not optimal, but probably
+ * fine for fabtests and this is better than changing the alloc/free functions
+ * to pass a handle and pointer.
+ */
+struct neuron_allocation {
+	nrt_tensor_t *tensor;
+	void *ptr;
+	size_t size;
+	struct dlist_entry entry;
+};
+static struct dlist_entry neuron_alloc_list;
+
+int ft_neuron_init(void)
+{
+	NRT_STATUS ret;
+
+	if (neuron_handle)
+		return FI_SUCCESS;
+
+	neuron_handle = dlopen("libnrt.so", RTLD_NOW);
+	if (!neuron_handle) {
+		FT_ERR("Failed to dlopen libnrt.so\n");
+		return -FI_ENOSYS;
+	}
+
+	neuron_ops.nrt_tensor_allocate = dlsym(neuron_handle, "nrt_tensor_allocate");
+	if (!neuron_ops.nrt_tensor_allocate) {
+		FT_ERR("Failed to find nrt_tensor_allocate\n");
+		goto err;
+	}
+
+	neuron_ops.nrt_tensor_free = dlsym(neuron_handle, "nrt_tensor_free");
+	if (!neuron_ops.nrt_tensor_free) {
+		FT_ERR("Failed to find nrt_tensor_free\n");
+		goto err;
+	}
+
+	neuron_ops.nrt_tensor_get_va = dlsym(neuron_handle, "nrt_tensor_get_va");
+	if (!neuron_ops.nrt_tensor_get_va) {
+		FT_ERR("Failed to find nrt_tensor_get_va\n");
+		goto err;
+	}
+
+	neuron_ops.nrt_tensor_read = dlsym(neuron_handle, "nrt_tensor_read");
+	if (!neuron_ops.nrt_tensor_read) {
+		FT_ERR("Failed to find nrt_tensor_read\n");
+		goto err;
+	}
+
+	neuron_ops.nrt_tensor_write = dlsym(neuron_handle, "nrt_tensor_write");
+	if (!neuron_ops.nrt_tensor_write) {
+		FT_ERR("Failed to find nrt_tensor_write\n");
+		goto err;
+	}
+
+	neuron_ops.nrt_init = dlsym(neuron_handle, "nrt_init");
+	if (!neuron_ops.nrt_init) {
+		FT_ERR("Failed to find nrt_init\n");
+		goto err;
+	}
+
+	dlist_init(&neuron_alloc_list);
+
+	ret = neuron_ops.nrt_init(NRT_FRAMEWORK_TYPE_NO_FW, "2.0", "");
+	if (ret != NRT_SUCCESS) {
+		FT_ERR("Neuron init failed ret=%d\n", ret);
+		goto err;
+	}
+
+	return FI_SUCCESS;
+err:
+	dlclose(neuron_handle);
+	neuron_handle = NULL;
+	return -FI_ENODATA;
+}
+
+static void ft_neuron_free_region(struct neuron_allocation *region)
+{
+	neuron_ops.nrt_tensor_free(&region->tensor);
+	dlist_remove(&region->entry);
+	free(region);
+}
+
+/*
+ * Search for the nrt region given a buffer. Return the offset so we can pass
+ * the offset to read/write corresponding to the offset of the pointer given.
+ */
+static ssize_t ft_neuron_find_region(void *buf, struct neuron_allocation **region)
+{
+	*region = NULL;
+
+	if (!buf)
+		return -1;
+
+	dlist_foreach_container(&neuron_alloc_list, struct neuron_allocation,
+	                        *region, entry)
+		if (buf >= (*region)->ptr &&
+		    (char *)buf < ((char *)(*region)->ptr) + (*region)->size)
+			break;
+
+	if (!(*region))
+		return -1;
+
+	return ((uintptr_t)buf - (uintptr_t)(*region)->ptr);
+}
+
+int ft_neuron_cleanup(void)
+{
+	struct neuron_allocation *region;
+	struct dlist_entry *tmp;
+
+	dlist_foreach_container_safe(&neuron_alloc_list, struct neuron_allocation,
+	                             region, entry, tmp)
+		ft_neuron_free_region(region);
+
+	if (neuron_handle)
+		dlclose(neuron_handle);
+
+	return 0;
+}
+
+int ft_neuron_alloc(uint64_t device, void **buf, size_t size)
+{
+	struct neuron_allocation *region;
+	int page_size;
+	int ret = 0;
+
+	page_size = sysconf(_SC_PAGESIZE);
+	if (page_size == -1) {
+		FT_PRINTERR("failed to get pagesize\n", -errno);
+		return -FI_EINVAL;
+	}
+	size = (size + (page_size - 1)) & ~(page_size - 1);
+
+	region = malloc(sizeof(struct neuron_allocation));
+	if (!region)
+		return -FI_ENOMEM;
+
+	ret = neuron_ops.nrt_tensor_allocate(NRT_TENSOR_PLACEMENT_DEVICE, device,
+	                                     size, "fabtests", &region->tensor);
+	if (ret) {
+		FT_ERR("nrt_tensor_allocate ret=%d\n", ret);
+		free(region);
+		return -FI_ENOMEM;
+	}
+
+	region->ptr = neuron_ops.nrt_tensor_get_va(region->tensor);
+	if (!region->ptr) {
+		FT_ERR("nrt_tensor_get_va failed\n");
+		neuron_ops.nrt_tensor_free(&region->tensor);
+		free(region);
+		return -FI_ENOMEM;
+	}
+
+	region->size = size;
+	*buf = region->ptr;
+	dlist_insert_tail(&region->entry, &neuron_alloc_list);
+
+	return 0;
+}
+
+int ft_neuron_free(void *buf)
+{
+	struct neuron_allocation *region;
+
+	if (!buf)
+		return 0;
+
+	ft_neuron_find_region(buf, &region);
+
+	if (!region)
+		return -FI_EINVAL;
+
+	ft_neuron_free_region(region);
+
+	return 0;
+}
+
+/*
+ * No memset from the neuron API so use write to do it instead. Also not
+ * optimal, but should be good enough for fabtests.
+ */
+int ft_neuron_memset(uint64_t device, void *buf, int value, size_t size)
+{
+	struct neuron_allocation *region;
+	ssize_t offset;
+	size_t mbuf_size, bytes;
+	int *mbuf;
+	int ret;
+
+	offset = ft_neuron_find_region(buf, &region);
+
+	if (!region || offset < 0)
+		return -FI_EINVAL;
+
+	mbuf_size = NEURON_MEMSET_BUF_SIZE;
+	mbuf = malloc(mbuf_size);
+	if (!mbuf)
+		return -FI_ENOMEM;
+
+	memset(mbuf, value, mbuf_size);
+
+	while (size) {
+		bytes = MIN(size, mbuf_size);
+		ret = neuron_ops.nrt_tensor_write(region->tensor, mbuf,
+						  offset, bytes);
+		if (ret) {
+			FT_ERR("nrt_tensor_write failed ret=%d\n", ret);
+			return -FI_EIO;
+		}
+		offset += bytes;
+		size -= bytes;
+	}
+
+	return 0;
+}
+
+int ft_neuron_memcpy_to_hmem(uint64_t device, void *dst, const void *src,
+			     size_t size)
+{
+	struct neuron_allocation *region;
+	ssize_t offset;
+	NRT_STATUS ret;
+
+	offset = ft_neuron_find_region(dst, &region);
+
+	if (!region || offset < 0)
+		return -FI_EINVAL;
+
+	ret = neuron_ops.nrt_tensor_write(region->tensor, src, offset, size);
+	if (ret) {
+		FT_ERR("nrt_tensor_write failed ret=%d\n", ret);
+		return -FI_EIO;
+	}
+
+	return 0;
+}
+
+int ft_neuron_memcpy_from_hmem(uint64_t device, void *dst, const void *src,
+			       size_t size)
+{
+	struct neuron_allocation *region;
+	ssize_t offset;
+	NRT_STATUS ret;
+
+	offset = ft_neuron_find_region((void *)src, &region);
+
+	if (!region || offset < 0)
+		return -FI_EINVAL;
+
+	ret = neuron_ops.nrt_tensor_read(region->tensor, dst, offset, size);
+	if (ret) {
+		FT_ERR("nrt_tensor_read failed ret=%d\n", ret);
+		return -FI_EIO;
+	}
+
+	return 0;
+}
+
+#else
+
+int ft_neuron_init(void)
+{
+	return -FI_ENOSYS;
+}
+
+int ft_neuron_cleanup(void)
+{
+	return -FI_ENOSYS;
+}
+
+int ft_neuron_alloc(uint64_t device, void **buf, size_t size)
+{
+	return -FI_ENOSYS;
+}
+
+int ft_neuron_free(void *buf)
+{
+	return -FI_ENOSYS;
+}
+
+int ft_neuron_memset(uint64_t device, void *buf, int value, size_t size)
+{
+	return -FI_ENOSYS;
+}
+
+int ft_neuron_memcpy_to_hmem(uint64_t device, void *dst, const void *src,
+			     size_t size)
+{
+	return -FI_ENOSYS;
+}
+
+int ft_neuron_memcpy_from_hmem(uint64_t device, void *dst, const void *src,
+			       size_t size)
+{
+	return -FI_ENOSYS;
+}
+#endif /*_HAVE_NEURON_H */

--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -388,6 +388,9 @@ int ft_reg_mr(struct fi_info *fi, void *buf, size_t size, uint64_t access,
 	attr.iface = opts.iface;
 
 	switch (opts.iface) {
+	case FI_HMEM_NEURON:
+		attr.device.neuron = opts.device;
+		break;
 	case FI_HMEM_ZE:
 		attr.device.ze = opts.device;
 		break;
@@ -2905,8 +2908,9 @@ void ft_mcusage(char *name, char *desc)
 	FT_PRINT_OPTS_USAGE("-p <provider>", "specific provider name eg sockets, verbs");
 	FT_PRINT_OPTS_USAGE("-d <domain>", "domain name");
 	FT_PRINT_OPTS_USAGE("-p <provider>", "specific provider name eg sockets, verbs");
-	FT_PRINT_OPTS_USAGE("-D <device_iface>", "Specify device interface: eg ze (default: None). "
-			     "Automatically enables FI_HMEM (-H)");
+	FT_PRINT_OPTS_USAGE("-D <device_iface>", "Specify device interface: "
+			    "e.g. cuda, ze, neuron (default: None). "
+			    "Automatically enables FI_HMEM (-H)");
 	FT_PRINT_OPTS_USAGE("-i <device_id>", "Specify which device to use (default: 0)");
 	FT_PRINT_OPTS_USAGE("-H", "Enable provider FI_HMEM support");
 	FT_PRINT_OPTS_USAGE("-h", "display this help output");
@@ -2923,8 +2927,10 @@ void ft_csusage(char *name, char *desc)
 	FT_PRINT_OPTS_USAGE("-S <size>", "specific transfer size or 'all'");
 	FT_PRINT_OPTS_USAGE("-l", "align transmit and receive buffers to page size");
 	FT_PRINT_OPTS_USAGE("-m", "machine readable output");
-	FT_PRINT_OPTS_USAGE("-D <device_iface>", "Specify device interface: eg cuda, ze(default: None). "
-			     "Automatically enables FI_HMEM (-H)");
+	FT_PRINT_OPTS_USAGE("-D <device_iface>", "Specify device interface: "
+			    "e.g. cuda, ze, neuron (default: None). "
+			    "Automatically enables FI_HMEM (-H)");
+	FT_PRINT_OPTS_USAGE("-i <device_index>", "Index of the device to use");
 	FT_PRINT_OPTS_USAGE("-t <type>", "completion type [queue, counter]");
 	FT_PRINT_OPTS_USAGE("-c <method>", "completion method [spin, sread, fd, yield]");
 	FT_PRINT_OPTS_USAGE("-h", "display this help output");
@@ -3037,6 +3043,8 @@ void ft_parse_hmem_opts(int op, char *optarg, struct ft_opts *opts)
 			opts->iface = FI_HMEM_ZE;
 		else if (!strncasecmp("cuda", optarg, 4))
 			opts->iface = FI_HMEM_CUDA;
+		else if (!strncasecmp("neuron", optarg, 6))
+			opts->iface = FI_HMEM_NEURON;
 		else
 			printf("Unsupported interface\n");
 		opts->options |= FT_OPT_ENABLE_HMEM | FT_OPT_USE_DEVICE;

--- a/fabtests/configure.ac
+++ b/fabtests/configure.ac
@@ -136,6 +136,21 @@ AC_ARG_WITH([rocr],
                              [AC_MSG_ERROR([<hsa/hsa.h> not found])])],
             [])
 
+dnl Check for Neuron support.
+AC_ARG_WITH([neuron],
+            AC_HELP_STRING([--with-neuron=DIR],
+                            [Provide path to where the Neuron development
+                             and runtime libraries are installed.]),
+            [AS_IF([test "$freebsd" == "0"],
+                   [AC_CHECK_LIB(dl, dlopen, [], [AC_MSG_ERROR([dlopen not found.])])],
+                   [])
+             CPPFLAGS="-I$withval/include $CPPFLAGS"
+             AC_CHECK_HEADER([nrt/nrt.h],
+                             [AC_DEFINE([HAVE_NEURON], [1],
+                                        [Define to 1 if you have <nrt/nrt.h>])],
+                             [AC_MSG_ERROR([<nrt/nrt.h> not found])])],
+            [])
+
 dnl Checks for libraries
 AC_CHECK_LIB([fabric], fi_getinfo, [],
     AC_MSG_ERROR([fi_getinfo() not found.  fabtests requires libfabric.]))

--- a/fabtests/fabtests.vcxproj
+++ b/fabtests/fabtests.vcxproj
@@ -194,6 +194,7 @@
     <ClCompile Include="common\hmem_cuda.c" />
     <ClCompile Include="common\hmem_rocr.c" />
     <ClCompile Include="common\hmem_ze.c" />
+    <ClCompile Include="common\hmem_neuron.c" />
     <ClCompile Include="common\shared.c" />
     <ClCompile Include="common\windows\getopt.c" />
     <ClCompile Include="common\windows\osd.c" />

--- a/fabtests/fabtests.vcxproj
+++ b/fabtests/fabtests.vcxproj
@@ -238,6 +238,7 @@
     <ClInclude Include="include\jsmn.h" />
     <ClInclude Include="include\hmem.h" />
     <ClInclude Include="include\shared.h" />
+    <ClInclude Include="include\ft_list.h" />
     <ClInclude Include="include\unit_common.h" />
     <ClInclude Include="include\windows\getopt\getopt.h" />
     <ClInclude Include="include\windows\netdb.h" />

--- a/fabtests/fabtests.vcxproj.filters
+++ b/fabtests/fabtests.vcxproj.filters
@@ -60,6 +60,9 @@
     <ClCompile Include="common\hmem_ze.c">
       <Filter>Source Files\common</Filter>
     </ClCompile>
+    <ClCompile Include="common\hmem_neuron.c">
+      <Filter>Source Files\common</Filter>
+    </ClCompile>
     <ClCompile Include="common\shared.c">
       <Filter>Source Files\common</Filter>
     </ClCompile>

--- a/fabtests/fabtests.vcxproj.filters
+++ b/fabtests/fabtests.vcxproj.filters
@@ -203,6 +203,9 @@
     <ClInclude Include="include\shared.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\ft_list.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="include\unit_common.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/fabtests/include/ft_list.h
+++ b/fabtests/include/ft_list.h
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2021 Amazon.com, Inc. or its affiliates.
+ * Copyright (c) 2011-2015 Intel Corporation.  All rights reserved.
+ * Copyright (c) 2016 Cray Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#ifndef _FT_LIST_H_
+#define _FT_LIST_H_
+
+#include "config.h"
+
+#include <sys/types.h>
+#include <stdlib.h>
+
+/*
+ * Double-linked list
+ */
+struct dlist_entry {
+	struct dlist_entry	*next;
+	struct dlist_entry	*prev;
+};
+
+#define DLIST_INIT(addr) { addr, addr }
+#define DEFINE_LIST(name) struct dlist_entry name = DLIST_INIT(&name)
+
+static inline void dlist_init(struct dlist_entry *head)
+{
+	head->next = head;
+	head->prev = head;
+}
+
+static inline int dlist_empty(struct dlist_entry *head)
+{
+	return head->next == head;
+}
+
+static inline void
+dlist_insert_after(struct dlist_entry *item, struct dlist_entry *head)
+{
+	item->next = head->next;
+	item->prev = head;
+	head->next->prev = item;
+	head->next = item;
+}
+
+static inline void
+dlist_insert_before(struct dlist_entry *item, struct dlist_entry *head)
+{
+	dlist_insert_after(item, head->prev);
+}
+
+#define dlist_insert_head dlist_insert_after
+#define dlist_insert_tail dlist_insert_before
+
+static inline void dlist_remove(struct dlist_entry *item)
+{
+	item->prev->next = item->next;
+	item->next->prev = item->prev;
+}
+
+static inline void dlist_remove_init(struct dlist_entry *item)
+{
+	dlist_remove(item);
+	dlist_init(item);
+}
+
+#define dlist_pop_front(head, type, container, member)			\
+	do {								\
+		container = container_of((head)->next, type, member);	\
+		dlist_remove((head)->next);				\
+	} while (0)
+
+#define dlist_foreach(head, item) 						\
+	for ((item) = (head)->next; (item) != (head); (item) = (item)->next)
+
+#define dlist_foreach_reverse(head, item) 					\
+	for ((item) = (head)->prev; (item) != (head); (item) = (item)->prev
+
+#define dlist_foreach_container(head, type, container, member)			\
+	for ((container) = container_of((head)->next, type, member);		\
+	     &((container)->member) != (head);					\
+	     (container) = container_of((container)->member.next,		\
+					type, member))
+
+#define dlist_foreach_container_reverse(head, type, container, member)		\
+	for ((container) = container_of((head)->prev, type, member);		\
+	     &((container)->member) != (head);					\
+	     (container) = container_of((container)->member.prev,		\
+					type, member))
+
+#define dlist_foreach_safe(head, item, tmp)					\
+	for ((item) = (head)->next, (tmp) = (item)->next; (item) != (head);	\
+             (item) = (tmp), (tmp) = (item)->next)
+
+#define dlist_foreach_reverse_safe(head, item, tmp)				\
+	for ((item) = (head)->prev, (tmp) = (item)->prev; (item) != (head);	\
+             (item) = (tmp), (tmp) = (item)->prev)
+
+#define dlist_foreach_container_safe(head, type, container, member, tmp)	\
+	for ((container) = container_of((head)->next, type, member),		\
+	     (tmp) = (container)->member.next;					\
+	     &((container)->member) != (head);					\
+	     (container) = container_of((tmp), type, member),			\
+	     (tmp) = (container)->member.next)
+
+#define dlist_foreach_container_reverse_safe(head, type, container, member, tmp)\
+	for ((container) = container_of((head)->prev, type, member),		\
+	     (tmp) = (container)->member.prev;					\
+	     &((container)->member) != (head);					\
+	     (container) = container_of((tmp), type, member),			\
+	     (tmp) = (container)->member.prev)
+
+typedef int dlist_func_t(struct dlist_entry *item, const void *arg);
+
+static inline struct dlist_entry *
+dlist_find_first_match(struct dlist_entry *head, dlist_func_t *match,
+		       const void *arg)
+{
+	struct dlist_entry *item;
+
+	dlist_foreach(head, item) {
+		if (match(item, arg))
+			return item;
+	}
+
+	return NULL;
+}
+
+static inline struct dlist_entry *
+dlist_remove_first_match(struct dlist_entry *head, dlist_func_t *match,
+			 const void *arg)
+{
+	struct dlist_entry *item;
+
+	item = dlist_find_first_match(head, match, arg);
+	if (item)
+		dlist_remove(item);
+
+	return item;
+}
+
+static inline void dlist_insert_order(struct dlist_entry *head, dlist_func_t *order,
+				      struct dlist_entry *entry)
+{
+	struct dlist_entry *item;
+
+	item = dlist_find_first_match(head, order, entry);
+	if (item)
+		dlist_insert_before(entry, item);
+	else
+		dlist_insert_tail(entry, head);
+}
+
+/* splices list at the front of the list 'head'
+ *
+ * BEFORE:
+ * head:      HEAD->a->b->c->HEAD
+ * to_splice: HEAD->d->e->HEAD
+ *
+ * AFTER:
+ * head:      HEAD->d->e->a->b->c->HEAD
+ * to_splice: HEAD->HEAD (empty list)
+ */
+static inline void dlist_splice_head(struct dlist_entry *head,
+				     struct dlist_entry *to_splice)
+{
+	if (dlist_empty(to_splice))
+		return;
+
+	/* hook first element of 'head' to last element of 'to_splice' */
+	head->next->prev = to_splice->prev;
+	to_splice->prev->next = head->next;
+
+	/* put first element of 'to_splice' as first element of 'head' */
+	head->next = to_splice->next;
+	head->next->prev = head;
+
+	/* set list to empty */
+	dlist_init(to_splice);
+}
+
+/* splices list at the back of the list 'head'
+ *
+ * BEFORE:
+ * head:      HEAD->a->b->c->HEAD
+ * to_splice: HEAD->d->e->HEAD
+ *
+ * AFTER:
+ * head:      HEAD->a->b->c->d->e->HEAD
+ * to_splice: HEAD->HEAD (empty list)
+ */
+static inline void dlist_splice_tail(struct dlist_entry *head,
+				     struct dlist_entry *to_splice)
+{
+	dlist_splice_head(head->prev, to_splice);
+}
+
+#endif /* _FT_LIST_H */

--- a/fabtests/include/hmem.h
+++ b/fabtests/include/hmem.h
@@ -95,6 +95,14 @@ int ft_rocr_free(void *buf);
 int ft_rocr_memset(uint64_t device, void *buf, int value, size_t size);
 int ft_rocr_memcpy(uint64_t device, void *dst, const void *src, size_t size);
 
+int ft_neuron_init(void);
+int ft_neuron_cleanup(void);
+int ft_neuron_alloc(uint64_t device, void **buf, size_t size);
+int ft_neuron_free(void *buf);
+int ft_neuron_memset(uint64_t device, void *buf, int value, size_t size);
+int ft_neuron_memcpy_to_hmem(uint64_t device, void *dst, const void *src, size_t size);
+int ft_neuron_memcpy_from_hmem(uint64_t device, void *dst, const void *src, size_t size);
+
 int ft_hmem_init(enum fi_hmem_iface iface);
 int ft_hmem_cleanup(enum fi_hmem_iface iface);
 int ft_hmem_alloc(enum fi_hmem_iface iface, uint64_t device, void **buf,

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -40,6 +40,7 @@
 #include <netinet/tcp.h>
 #include <sys/uio.h>
 #include <stdbool.h>
+#include <stdio.h>
 
 #include <rdma/fabric.h>
 #include <rdma/fi_rma.h>

--- a/fabtests/unit/mr_cache_evict.c
+++ b/fabtests/unit/mr_cache_evict.c
@@ -528,6 +528,12 @@ static int mr_cache_test(enum alloc_type type)
 		}
 		break;
 
+	/* Add test case for this once neuron has a memory monitor cache. */
+	case FI_HMEM_NEURON:
+		ret = -FI_ENOSYS;
+		goto cleanup;
+		break;
+
 	default:
 		prime_buf = malloc(mr_buf_size);
 		if (!prime_buf) {

--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -163,6 +163,13 @@ int ze_hmem_get_base_addr(const void *ptr, void **base, size_t *size);
 int ze_hmem_get_id(const void *ptr, uint64_t *id);
 int *ze_hmem_get_dev_fds(int *nfds);
 
+int neuron_copy_to_dev(uint64_t device, void *dev, const void *host, size_t size);
+int neuron_copy_from_dev(uint64_t device, void *host, const void *dev, size_t size);
+int neuron_hmem_init(void);
+int neuron_hmem_cleanup(void);
+void *neuron_alloc(void **handle, size_t size);
+void neuron_free(void **handle);
+
 static inline int ofi_memcpy(uint64_t device, void *dest, const void *src,
 			     size_t size)
 {

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -294,7 +294,7 @@ struct ofi_mr_entry {
 	uint8_t				data[];
 };
 
-#define OFI_HMEM_MAX 4
+#define OFI_HMEM_MAX 5
 
 struct ofi_mr_cache {
 	struct util_domain		*domain;

--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -126,6 +126,7 @@ enum fi_hmem_iface {
 	FI_HMEM_CUDA,
 	FI_HMEM_ROCR,
 	FI_HMEM_ZE,
+	FI_HMEM_NEURON,
 };
 
 struct fi_mr_attr {
@@ -142,6 +143,7 @@ struct fi_mr_attr {
 		uint64_t	reserved;
 		int		cuda;
 		int		ze;
+		int		neuron;
 	} device;
 };
 

--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -773,6 +773,7 @@
     <ClCompile Include="src\hmem_cuda.c" />
     <ClCompile Include="src\hmem_rocr.c" />
     <ClCompile Include="src\hmem_ze.c" />
+    <ClCompile Include="src\hmem_neuron.c" />
     <ClCompile Include="src\indexer.c" />
     <ClCompile Include="src\iov.c" />
     <ClCompile Include="src\shared\ofi_str.c" />

--- a/libfabric.vcxproj.filters
+++ b/libfabric.vcxproj.filters
@@ -147,6 +147,9 @@
     <ClCompile Include="src\hmem_rocr.c">
       <Filter>Source Files\src</Filter>
     </ClCompile>
+    <ClCompile Include="src\hmem_neuron.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
     <ClCompile Include="src\rbtree.c">
       <Filter>Source Files\src</Filter>
     </ClCompile>

--- a/man/fi_mr.3.md
+++ b/man/fi_mr.3.md
@@ -636,6 +636,9 @@ requested the FI_HMEM capability.
 : Uses oneAPI Level Zero interfaces such as zeDriverAllocSharedMem,
   zeDriverFreeMem.
 
+*FI_HMEM_NEURON*
+: Uses the AWS Neuron SDK to support AWS Trainium devices.
+
 ## device
 Reserved 64 bits for device identifier if using non-standard HMEM interface.
 This field is ignore unless the iface field is valid.

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -102,6 +102,13 @@ struct ofi_hmem_ops hmem_ops[] = {
 		.get_base_addr = ze_hmem_get_base_addr,
 		.is_ipc_enabled = ze_hmem_p2p_enabled,
 	},
+	[FI_HMEM_NEURON] = {
+		.initialized = false,
+		.init = neuron_hmem_init,
+		.cleanup = neuron_hmem_cleanup,
+		.copy_to_hmem = neuron_copy_to_dev,
+		.copy_from_hmem = neuron_copy_from_dev,
+	},
 };
 
 static inline int ofi_copy_to_hmem(enum fi_hmem_iface iface, uint64_t device,

--- a/src/hmem_neuron.c
+++ b/src/hmem_neuron.c
@@ -1,0 +1,192 @@
+/*
+ * (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+ * Copyright (c) 2021 Amazon.com, Inc. or its affiliates.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "ofi_hmem.h"
+#include "ofi.h"
+
+#if HAVE_NEURON
+
+#include <dlfcn.h>
+#include "nrt/nrt.h"
+#include "nrt/nrt_experimental.h"
+
+struct neuron_ops {
+	NRT_STATUS (*nrt_tensor_allocate)(nrt_tensor_placement_t tensor_placement,
+					  int logical_nc_id, size_t size,
+					  const char *name, nrt_tensor_t **tensor);
+	void (*nrt_tensor_free)(nrt_tensor_t **tensor);
+	void *(*nrt_tensor_get_va)(const nrt_tensor_t *tensor);
+};
+
+static void *neuron_handle;
+static struct neuron_ops neuron_ops;
+
+static int neuron_dl_init(void)
+{
+	neuron_handle = dlopen("libnrt.so", RTLD_NOW);
+	if (!neuron_handle) {
+		FI_INFO(&core_prov, FI_LOG_CORE,
+			"Failed to dlopen libnrt.so\n");
+		return -FI_ENOSYS;
+	}
+
+	neuron_ops.nrt_tensor_allocate = dlsym(neuron_handle, "nrt_tensor_allocate");
+	if (!neuron_ops.nrt_tensor_allocate) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "Failed to find nrt_tensor_allocate\n");
+		goto err;
+	}
+
+	neuron_ops.nrt_tensor_free = dlsym(neuron_handle, "nrt_tensor_free");
+	if (!neuron_ops.nrt_tensor_free) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "Failed to find nrt_tensor_free\n");
+		goto err;
+	}
+
+	neuron_ops.nrt_tensor_get_va = dlsym(neuron_handle, "nrt_tensor_get_va");
+	if (!neuron_ops.nrt_tensor_get_va) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "Failed to find nrt_tensor_get_va\n");
+		goto err;
+	}
+
+	return FI_SUCCESS;
+err:
+	dlclose(neuron_handle);
+	return -FI_ENODATA;
+}
+
+static int neuron_dl_close(void)
+{
+	dlclose(neuron_handle);
+	return FI_SUCCESS;
+}
+
+int neuron_copy_to_dev(uint64_t device, void *dev, const void *host, size_t size)
+{
+	/*
+	 * Applications will use the neuron runtime to allocate and mmap a
+	 * buffer; Libfabric can access this memory directly.
+	 */
+	memcpy(dev, host, size);
+	return FI_SUCCESS;
+}
+
+int neuron_copy_from_dev(uint64_t device, void *host, const void *dev, size_t size)
+{
+	FI_WARN_ONCE(&core_prov, FI_LOG_CORE,
+		     "Copies from AWS Neuron to host memory are not supported.");
+	return -FI_ENOSYS;
+}
+
+int neuron_hmem_init(void)
+{
+	int ret;
+
+	ret = neuron_dl_init();
+	if (ret)
+		return ret;
+
+	return FI_SUCCESS;
+}
+
+int neuron_hmem_cleanup(void)
+{
+	neuron_dl_close();
+	return FI_SUCCESS;
+}
+
+void *neuron_alloc(void **handle, size_t size)
+{
+	NRT_STATUS ret;
+	nrt_tensor_t **tensor;
+	void *ptr;
+
+	tensor = (nrt_tensor_t **)handle;
+
+	ret = neuron_ops.nrt_tensor_allocate(NRT_TENSOR_PLACEMENT_DEVICE, 0,
+					     size, "libfabric", tensor);
+
+	if (ret != NRT_SUCCESS) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"Failed to allocate nrt tensor: %d\n", ret);
+		return NULL;
+	}
+
+	ptr = neuron_ops.nrt_tensor_get_va(*tensor);
+	if (!ptr)
+		neuron_ops.nrt_tensor_free(tensor);
+
+	return ptr;
+}
+
+void neuron_free(void **handle)
+{
+	neuron_ops.nrt_tensor_free((nrt_tensor_t **)handle);
+}
+
+#else
+
+int neuron_copy_to_dev(uint64_t device, void *dev, const void *host, size_t size)
+{
+	return -FI_ENOSYS;
+}
+
+int neuron_copy_from_dev(uint64_t device, void *host, const void *dev, size_t size)
+{
+	return -FI_ENOSYS;
+}
+
+int neuron_hmem_init(void)
+{
+	return -FI_ENOSYS;
+}
+
+int neuron_hmem_cleanup(void)
+{
+	return -FI_ENOSYS;
+}
+
+void *neuron_alloc(void **handle, size_t size)
+{
+	return NULL;
+}
+
+void neuron_free(void **handle)
+{
+	return;
+}
+
+#endif /* HAVE_NEURON */


### PR DESCRIPTION
Add support for AWS Trainium accelerators available via the trn1 EC2 instance. Changes to support this in the EFA provider will come soon in a separate PR.

https://aws.amazon.com/ec2/instance-types/trn1/

Commits:
```
    fabtests: add AWS Trainium device support
    
    This adds support for AWS Trainium devices to fabtests.
```
```
    fabtests: add ft_list.h dlist implementation
    
    Copy over the doubly linked list implementation from Libfabric.
```
```
    hmem: add support for AWS Trainium devices
    
    Add support for AWS Trainium devices via the AWS Neuron SDK. Writes to
    Trainium will be done via the PCIe BAR and reads from Trainium are not
    supported at this time.
    
    Despite accessing Trainium memory via the BAR, we still dlopen the
    Neuron runtime so that providers allocate a device page and then
    register it with the NIC to detect peer to peer support.
```