### PR TITLE
.gitignore: add executables under fabtests/prov/efa/src/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,4 +74,5 @@ fabtests/benchmarks/fi_*
 fabtests/functional/fi_*
 fabtests/unit/fi_*
 fabtests/multinode/fi_*
+fabtests/prov/efa/src/fi_efa*
 pingpong/fi_*


### PR DESCRIPTION
This patch added the executables under fabtests/prov/efa/src,
which were generated during compilation, to .gitignore

Signed-off-by: Wei Zhang <wzam@amazon.com>