### PR TITLE
fabtests/efa.exclude: exclude msg_sockets instead of msg

### DIFF
--- a/fabtests/test_configs/efa/efa.exclude
+++ b/fabtests/test_configs/efa/efa.exclude
@@ -41,8 +41,7 @@ cq_data
 multi_mr
 rdm_rma_trigger
 
-# Exclude all MSG tests
-msg
+msg_sockets
 rc_pingpong
 
 # Exclude all polling tests


### PR DESCRIPTION
The exclusion of "msg" was intented to exclude tests
using msg endpoint, but it accidently excluded test
"fi_unexpected_msg", which is a valid test EFA's rdm endpoint

This patch fixed the issue by excluding "msg_sockets" instead
of "msg", which excluded the test fi_msg_sockets.

With this change, tests that uses msg endpoint will be run,
and EFA provider will return FI_ENODATA, and these tests
will be marked as "notrun".

Signed-off-by: Wei Zhang <wzam@amazon.com>