### PR TITLE
prov/efa: add AWS Trainium device support

### DIFF
--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -109,6 +109,7 @@ nobase_dist_config_DATA = \
 	test_configs/shm/shm.exclude \
 	test_configs/shm/quick.test \
 	test_configs/shm/verify.test \
+	test_configs/efa/efa-neuron.exclude \
 	test_configs/efa/efa.exclude
 
 noinst_LTLIBRARIES = libfabtests.la

--- a/fabtests/test_configs/efa/efa-neuron.exclude
+++ b/fabtests/test_configs/efa/efa-neuron.exclude
@@ -1,0 +1,94 @@
+#
+# Copyright (c) 2021-2019 Amazon.com, Inc. or its affiliates. All rights reserved.
+#
+# This software is available to you under a choice of one of two
+# licenses.  You may choose to be licensed under the terms of the GNU
+# General Public License (GPL) Version 2, available from the file
+# COPYING in the main directory of this source tree, or the
+# BSD license below:
+#
+#     Redistribution and use in source and binary forms, with or
+#     without modification, are permitted provided that the following
+#     conditions are met:
+#
+#      - Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      - Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials
+#        provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Regex patterns of tests to exclude in runfabtests.sh
+
+# Exclude cq_data test until fi_pool/fi_wait is supported
+cq_data
+
+multi_mr
+rdm_rma_trigger
+
+# Exclude all MSG tests
+msg
+rc_pingpong
+
+# Exclude all polling tests
+poll
+
+# Exclude inj complete
+inj_complete
+
+# Exclude trigger ops
+trigger
+
+# Connection manager isn't supported
+cm_data
+
+# Shared context isn't supported
+shared_ctx
+
+# Scalable EP isn't supported
+scalable_ep
+
+# This test requires passive EP
+cmatose
+
+# shared AV isn't supported
+shared_av
+
+# wait isn't supported
+dgram_waitset
+
+# Remove this once ubertest supports setting MR modes
+ubertest
+
+# Not useful on efa rdm ep
+pd_test
+
+# Test requires sread support
+rdm_tagged_peek
+
+# fail on timeout - cannot be supported
+dgram_bw
+
+# Multinode tests failing with an unsupported address format
+multinode
+
+# FI_HMEM and atomics not supported with EFA
+rdm_atomic
+
+fi_rdm$
+fi_rdm -U$

--- a/man/fi_efa.7.md
+++ b/man/fi_efa.7.md
@@ -82,6 +82,11 @@ No support for counters for the DGRAM endpoint.
 
 No support for inject.
 
+When using FI_HMEM for either CUDA and Neuron buffers, the provider requires
+peer to peer transaction support between the EFA and the FI_HMEM device.
+Therefore, the FI_HMEM_P2P_DISABLED option is not supported by the EFA
+provider.
+
 # PROVIDER SPECIFIC ENDPOINT LEVEL OPTION
 
 *FI_OPT_EFA_RNR_RETRY*

--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -296,6 +296,7 @@ struct efa_mr_peer {
 	union {
 		uint64_t        reserved;
 		int             cuda;
+		int             neuron;
 	} device;
 };
 
@@ -637,12 +638,18 @@ struct rdm_peer *rxr_ep_get_peer(struct rxr_ep *ep, fi_addr_t addr)
 
 static inline bool efa_ep_is_hmem_mr(struct efa_mr *efa_mr)
 {
-	return efa_mr ? (efa_mr->peer.iface == FI_HMEM_CUDA): false;
+	return efa_mr ? (efa_mr->peer.iface == FI_HMEM_CUDA ||
+			 efa_mr->peer.iface == FI_HMEM_NEURON): false;
 }
 
 static inline bool efa_ep_is_cuda_mr(struct efa_mr *efa_mr)
 {
 	return efa_mr ? (efa_mr->peer.iface == FI_HMEM_CUDA) : false;
+}
+
+static inline bool efa_ep_is_neuron_mr(struct efa_mr *efa_mr)
+{
+	return efa_mr ? (efa_mr->peer.iface == FI_HMEM_NEURON) : false;
 }
 
 /*

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -487,7 +487,6 @@ static int efa_mr_cache_init(struct efa_domain *domain, struct fi_info *info)
 	return 0;
 }
 
-
 static int efa_set_domain_hmem_info_cuda(struct efa_domain *domain)
 {
 #if HAVE_LIBCUDA
@@ -539,6 +538,58 @@ static int efa_set_domain_hmem_info_cuda(struct efa_domain *domain)
 	return 0;
 }
 
+static int efa_set_domain_hmem_info_neuron(struct efa_domain *domain)
+{
+#if HAVE_NEURON
+	struct ibv_mr *ibv_mr;
+	int ibv_access = IBV_ACCESS_LOCAL_WRITE;
+	void *handle;
+	void *ptr = NULL;
+	size_t len = ofi_get_page_size() * 2;
+	int ret;
+
+	if (!ofi_hmem_is_initialized(FI_HMEM_NEURON)) {
+		EFA_INFO(FI_LOG_DOMAIN,
+		         "FI_HMEM_NEURON is not initialized\n");
+		return 0;
+	}
+
+	if (domain->ctx->device_caps & EFADV_DEVICE_ATTR_CAPS_RDMA_READ) {
+		ibv_access |= IBV_ACCESS_REMOTE_READ;
+	} else {
+		EFA_WARN(FI_LOG_DOMAIN,
+			 "No EFA RDMA read support, transfers using AWS Neuron will fail.\n");
+		return 0;
+	}
+
+	domain->hmem_info[FI_HMEM_NEURON].initialized = true;
+
+	ptr = neuron_alloc(&handle, len);
+	if (!ptr)
+		return -FI_ENOMEM;
+
+	ibv_mr = ibv_reg_mr(domain->ibv_pd, ptr, len, ibv_access);
+	if (!ibv_mr) {
+		EFA_WARN(FI_LOG_DOMAIN,
+			 "Failed to register Neuron buffer with the EFA device, FI_HMEM transfers that require peer to peer support will fail.\n");
+		neuron_free(&handle);
+		return 0;
+	}
+
+	ret = ibv_dereg_mr(ibv_mr);
+	neuron_free(&handle);
+	if (ret) {
+		EFA_WARN(FI_LOG_DOMAIN,
+			 "Failed to deregister Neuron buffer: %s\n",
+			 fi_strerror(-ret));
+		return ret;
+	}
+
+	domain->hmem_info[FI_HMEM_NEURON].p2p_supported = true;
+#endif
+	return 0;
+}
+
 /*
  * Determine whether an HMEM device is initialized, and whether the provider
  * may support p2p transfers for that device. This state is used later when
@@ -555,6 +606,10 @@ static int efa_set_domain_hmem_info(struct efa_domain *domain)
 		return 0;
 
 	ret = efa_set_domain_hmem_info_cuda(domain);
+	if (ret)
+		return ret;
+
+	ret = efa_set_domain_hmem_info_neuron(domain);
 	if (ret)
 		return ret;
 

--- a/prov/efa/src/efa_ep.c
+++ b/prov/efa/src/efa_ep.c
@@ -708,6 +708,9 @@ int efa_ep_open(struct fid_domain *domain_fid, struct fi_info *info,
 		 * versions.
 		 */
 		ep->hmem_p2p_opt = FI_HMEM_P2P_REQUIRED;
+	} else if (ep->domain->hmem_info[FI_HMEM_NEURON].initialized) {
+		/* Neuron requires p2p and supports no other modes. */
+		ep->hmem_p2p_opt = FI_HMEM_P2P_REQUIRED;
 	} else {
 		/* no hmem devices, disable p2p */
 		ep->hmem_p2p_opt = FI_HMEM_P2P_DISABLED;

--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -615,9 +615,10 @@ static int efa_get_device_attrs(struct efa_context *ctx, struct fi_info *info)
 	info->domain_attr->resource_mgmt	= FI_RM_DISABLED;
 	info->domain_attr->mr_cnt		= base_attr->max_mr;
 
-#if HAVE_LIBCUDA
+#if HAVE_LIBCUDA || HAVE_NEURON
 	if (info->ep_attr->type == FI_EP_RDM &&
-	    ofi_hmem_is_initialized(FI_HMEM_CUDA)) {
+	    (ofi_hmem_is_initialized(FI_HMEM_CUDA) ||
+	     ofi_hmem_is_initialized(FI_HMEM_NEURON))) {
 		info->caps			|= FI_HMEM;
 		info->tx_attr->caps		|= FI_HMEM;
 		info->rx_attr->caps		|= FI_HMEM;

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -104,6 +104,8 @@ static int efa_mr_hmem_setup(struct efa_mr *efa_mr,
 
 	if (efa_mr->peer.iface == FI_HMEM_CUDA)
 		efa_mr->peer.device.cuda = attr->device.cuda;
+	else if (attr->iface == FI_HMEM_NEURON)
+		efa_mr->peer.device.neuron = attr->device.neuron;
 
 	return FI_SUCCESS;
 }
@@ -141,6 +143,8 @@ int efa_mr_cache_entry_reg(struct ofi_mr_cache *cache,
 
 	if (attr.iface == FI_HMEM_CUDA)
 		attr.device.cuda = entry->info.device;
+	else if (attr.iface == FI_HMEM_NEURON)
+		attr.device.neuron = entry->info.device;
 
 	ret = efa_mr_reg_impl(efa_mr, 0, (void *)&attr);
 	return ret;

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -895,6 +895,9 @@ int rxr_ep_post_user_recv_buf(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,
 int rxr_ep_set_tx_credit_request(struct rxr_ep *rxr_ep,
 				 struct rxr_tx_entry *tx_entry);
 
+int rxr_ep_determine_rdma_support(struct rxr_ep *ep, fi_addr_t addr,
+				  struct rdm_peer *peer);
+
 int rxr_ep_tx_init_mr_desc(struct rxr_domain *rxr_domain,
 			   struct rxr_tx_entry *tx_entry,
 			   int mr_iov_start, uint64_t access);

--- a/prov/efa/src/rxr/rxr_attr.c
+++ b/prov/efa/src/rxr/rxr_attr.c
@@ -37,7 +37,7 @@
 const uint32_t rxr_poison_value = 0xdeadbeef;
 #endif
 
-#if HAVE_LIBCUDA
+#if HAVE_LIBCUDA || HAVE_NEURON
 #define EFA_HMEM_CAP FI_HMEM
 #else
 #define EFA_HMEM_CAP 0

--- a/prov/efa/src/rxr/rxr_domain.c
+++ b/prov/efa/src/rxr/rxr_domain.c
@@ -97,6 +97,9 @@ int rxr_mr_regattr(struct fid *domain_fid, const struct fi_mr_attr *attr,
 	rxr_domain = container_of(domain_fid, struct rxr_domain,
 				  util_domain.domain_fid.fid);
 
+	if (attr->iface == FI_HMEM_NEURON)
+		flags |= OFI_MR_NOCACHE;
+
 	ret = fi_mr_regattr(rxr_domain->rdm_domain, attr, flags, mr);
 	if (ret) {
 		FI_WARN(&rxr_prov, FI_LOG_MR,
@@ -120,6 +123,7 @@ int rxr_mr_regv(struct fid *domain_fid, const struct iovec *iov,
 	attr.requested_key = requested_key;
 	attr.context = context;
 	attr.iface = FI_HMEM_SYSTEM;
+
 	return rxr_mr_regattr(domain_fid, &attr, flags, mr_fid);
 }
 

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -224,6 +224,30 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 					 ctrl_type + tagged, 0, 0);
 	}
 
+	/*
+	 * Force the LONGREAD protocol for Neuron buffers, regardless of what
+	 * is specified by the user for protocol switch over points.
+	 */
+	if (efa_ep_is_neuron_mr(tx_entry->desc[0])) {
+		/*
+		 * It is possible for the remote endpoint to support RDMA read,
+		 * but not p2p transfers between efa and neuron. That scenario
+		 * will cause a fatal error; if we want to catch this we will
+		 * need to extend the handshake packet to report device p2p
+		 * support.
+		 */
+		ret = rxr_ep_determine_rdma_support(rxr_ep, tx_entry->addr, peer);
+		if (ret < 0)
+			return ret;
+
+		if (ret != 1)
+			return -FI_EOPNOTSUPP;
+
+		ret = rxr_pkt_post_ctrl(rxr_ep, RXR_TX_ENTRY, tx_entry,
+					RXR_LONGREAD_MSGRTM_PKT + tagged, 0, 0);
+		return ret;
+	}
+
 	if (tx_entry->total_len <= rxr_env.efa_max_medium_msg_size) {
 		/* we do not check the return value of rxr_ep_init_mr_desc()
 		 * because medium message works even if MR registration failed


### PR DESCRIPTION
Add support to the EFA provider for AWS Trainium device buffers. RDMA
support and EFA/Trainium peer to peer transactions are required for
Libfabric to support FI_HMEM with Trainium.

Due to the way Libfabric interacts with Trainium buffers, we will force
the LONGREAD protocol for any messages larger than the EFA device MTU
size, so also add a function to check for that.

Test description: Ran fabtests on two trn1 instances. 
