### PR TITLE
fabtests/efa.exclude: temporarily exclude fi_msg_inject

### DIFF
--- a/fabtests/test_configs/efa/efa.exclude
+++ b/fabtests/test_configs/efa/efa.exclude
@@ -41,6 +41,11 @@ cq_data
 multi_mr
 rdm_rma_trigger
 
+# fi_msg_inject test does not work with
+# EFA provider on single instance. Temporarily exclude
+# this test while we investigate the root cause
+msg_inject
+
 msg_sockets
 rc_pingpong
 


### PR DESCRIPTION
EFA does not pass the newly added fi_msg_inject test on single
instance. This patch temporarily excludes this test for EFA to
make CI stable.

Signed-off-by: Wei Zhang <wzam@amazon.com>