### PR TITLE
core/strerror: treat negative errnums as positive

### DIFF
--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -325,14 +325,16 @@ static inline int ft_use_size(int index, int enable_flags)
 #define FT_DEBUG(fmt, ...)
 #endif
 
-#define FT_EQ_ERR(eq, entry, buf, len)				\
-	FT_ERR("eq_readerr (Provider errno: %d) : %s",			\
+#define FT_EQ_ERR(eq, entry, buf, len)					\
+	FT_ERR("eq_readerr %d (%s), provider errno: %d (%s)",		\
+		entry.err, fi_strerror(entry.err),			\
 		entry.prov_errno, fi_eq_strerror(eq, entry.prov_errno,	\
 						 entry.err_data,	\
 						 buf, len))		\
 
-#define FT_CQ_ERR(cq, entry, buf, len)				\
-	FT_ERR("cq_readerr (Provider errno: %d) : %s",			\
+#define FT_CQ_ERR(cq, entry, buf, len)					\
+	FT_ERR("cq_readerr %d (%s), provider errno: %d (%s)",		\
+		entry.err, fi_strerror(entry.err),			\
 		entry.prov_errno, fi_cq_strerror(cq, entry.prov_errno,	\
 						 entry.err_data,	\
 						 buf, len))		\

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -1316,6 +1316,9 @@ static const char *const errstr[] = {
 __attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
 const char *DEFAULT_SYMVER_PRE(fi_strerror)(int errnum)
 {
+	if (errnum < 0)
+		errnum = -errnum;
+
 	if (errnum < FI_ERRNO_OFFSET)
 		return strerror(errnum);
 	else if (errnum < FI_ERRNO_MAX)


### PR DESCRIPTION
Patch to update fabtests to print the generic errno values for CQ/EQ errors, rather than just the provider error values.  For grins, updated fi_strerror to handle negative errno values, so the user can pass in either a positive or negative value.