### PR TITLE
contrib/intel/jenkins: remove job middleware builds

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -30,43 +30,12 @@ pipeline {
                 }
             }
         }
-        stage ('build-shmem') {
+        stage ('copy-build-dirs') {
             steps {
-                withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']){
+                withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']) {
                   sh """
-                    python3.7  contrib/intel/jenkins/build.py 'shmem' --ofi_build_mode='dbg'
-                    echo 'shmem benchmarks built successfully'
-                  """
-                }
-            }
-        }
-        stage('build MPICH_bm') {
-            steps {
-                withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']){
-                  sh """
-                    python3.7 contrib/intel/jenkins/build.py 'mpich_benchmarks' --ofi_build_mode='dbg'
-                    echo "mpi benchmarks with mpich - built successfully"
-                  """
-                }
-            }
-        }
-        stage('build IMPI_bm') {
-            steps {
-              withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']){
-                sh """
-                source ${env.CI_IMPI_ONEAPI_ROOT}/env/vars.sh -i_mpi_ofi_internal=0
-                python3.7 contrib/intel/jenkins/build.py 'impi_benchmarks' --ofi_build_mode='dbg'
-                echo 'mpi benchmarks with impi - built successfully'
-                """
-              }
-            }
-        }
-        stage ('build OMPI_bm') {
-            steps {
-                withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']){
-                  sh """
-                    python3.7 contrib/intel/jenkins/build.py 'ompi_benchmarks' --ofi_build_mode='dbg'
-                    echo 'mpi benchmarks with ompi - built successfully'
+                    python3.7 contrib/intel/jenkins/build.py 'builddir' --ofi_build_mode='dbg'
+                    echo "copy build dirs complete"
                   """
                 }
             }
@@ -141,10 +110,8 @@ pipeline {
     post {
         cleanup {
             withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
-                sh "rm -rf '/mpibuilddir/mpich-build-dir/${env.JOB_NAME}/${env.BUILD_NUMBER}'"
-                sh "rm -rf '/mpibuilddir/ompi-build-dir/${env.JOB_NAME}/${env.BUILD_NUMBER}'"
-                sh "rm -rf '/mpibuilddir/mpich-suite-build-dir/${env.JOB_NAME}/${env.BUILD_NUMBER}'"
                 dir("${env.WORKSPACE}") {
+                    sh "rm -rf '${env.CI_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}'"
                     deleteDir()
                 }
             }

--- a/contrib/intel/jenkins/build.py
+++ b/contrib/intel/jenkins/build.py
@@ -34,7 +34,7 @@ def build_libfabric(libfab_install_path, mode):
         common.run_command(['./autogen.sh'])
         common.run_command(shlex.split(" ".join(config_cmd)))
         common.run_command(['make','clean'])
-        common.run_command(['make'])
+        common.run_command(['make', '-j32'])
         common.run_command(['make','install'])
 
 
@@ -52,7 +52,7 @@ def build_fabtests(libfab_install_path, mode):
     common.run_command(['./autogen.sh'])
     common.run_command(config_cmd)
     common.run_command(['make','clean'])
-    common.run_command(['make'])
+    common.run_command(['make', '-j32'])
     common.run_command(['make', 'install'])
 
 

--- a/contrib/intel/jenkins/build.py
+++ b/contrib/intel/jenkins/build.py
@@ -55,175 +55,8 @@ def build_fabtests(libfab_install_path, mode):
     common.run_command(['make', '-j32'])
     common.run_command(['make', 'install'])
 
-
-def build_shmem(shmem_dir, libfab_install_path):
-
-    shmem_tar = ci_site_config.shmem_tar
-    if(os.path.exists(shmem_dir)):
-        os.rmdir(shmem_dir)
-
-    os.makedirs(shmem_dir)
-    os.chdir(shmem_dir)
-
-    os.makedirs('SOS')
-    common.run_command(['tar', '-xf', shmem_tar, '-C', 'SOS', '--strip-components=1'])
-    os.chdir('SOS')
-
-    common.run_command(['./autogen.sh'])
-
-    config_cmd = ['./configure', '--prefix={}'.format(shmem_dir), '--disable-fortran', \
-                  '--enable-remote-virtual-addressing', '--disable-aslr-check', \
-                  '--enable-pmi-simple', '--with-ofi={}'.format(libfab_install_path), \
-                  'LDFLAGS=-fno-pie']
-
-    common.run_command(config_cmd)
-    common.run_command(['make','-j4'])
-    common.run_command(['make', 'check', 'TESTS='])
-    common.run_command(['make', 'install'])
-
-
-def build_ISx(shmem_dir):
-
-    oshcc = '{}/bin/oshcc'.format(shmem_dir)
-    tmp_isx_src = '{}/ISx'.format(ci_site_config.shmem_root)
-    shutil.copytree(tmp_isx_src, '{}/ISx'.format(shmem_dir))
-
-    #os.chdir(shmem_dir)
-    #git_cmd = ['git', 'clone', '--depth', '1', 'https://github.com/ParRes/ISx.git', 'ISx']
-    #common.run_command(git_cmd)
-
-    os.chdir('{}/ISx/SHMEM'.format(shmem_dir))
-    common.run_command(['make', 'CC={}'.format(oshcc), 'LDLIBS=-lm'])
-
-
-def build_PRK(shmem_dir):
-
-    oshcc = '{}/bin/oshcc'.format(shmem_dir)
-    shmem_src = '{}/SOS'.format(shmem_dir)
-    tmp_prk_src = '{}/PRK'.format(ci_site_config.shmem_root)
-    shutil.copytree(tmp_prk_src, '{}/PRK'.format(shmem_dir))
-
-    #os.chdir(shmem_dir)
-    #git_cmd = ['git', 'clone', '--depth', ' 1', 'https://github.com/ParRes/Kernels.git', 'PRK']
-    #common.run_command(git_cmd)
-
-    os.chdir('{}/PRK'.format(shmem_dir))
-    with open('common/make.defs','w') as f:
-        f.write('SHMEMCC={} -std=c99\nSHMEMTOP={}\n'.format(oshcc,shmem_src))
-
-    common.run_command(['make', 'allshmem'])
-
-
-def build_uh(shmem_dir):
-
-    oshcc_bin = "{}/bin".format(shmem_dir)
-    os.environ["PATH"] += os.pathsep + oshcc_bin
-    tmp_uh_src = '{}/tests-uh'.format(ci_site_config.shmem_root)
-    shutil.copytree(tmp_uh_src, '{}/tests-uh'.format(shmem_dir))
-
-    #os.chdir(shmem_dir)
-    #git_cmd = ['git', 'clone', '--depth', '1', 'https://github.com/openshmem-org/tests-uh.git', 'tests-uh']
-    #common.run_command(git_cmd)
-
-    os.chdir('{}/tests-uh'.format(shmem_dir))
-    common.run_command(['make', '-j4', 'C_feature_tests'])
-
-
-def build_mpi(mpi, mpisrc, mpi_install_path, libfab_install_path,  ofi_build_mode):
-
-    build_mpi_path ="/mpibuilddir/{}-build-dir/{}/{}/{}".format(mpi, jobname, buildno, ofi_build_mode)
-    if (os.path.exists(build_mpi_path) == False):
-        os.makedirs(build_mpi_path)
-
-    os.chdir(build_mpi_path)
-    cmd = ["{}/configure".format(mpisrc),
-                    "--disable-oshmem", "--prefix={}".format(mpi_install_path),
-                    "--with-libfabric={}".format(libfab_install_path)]
-
-    if (mpi == 'ompi'):
-        cmd.append("--enable-mpi-fortran=no")
-    elif (mpi == 'mpich'):
-        cmd.append("--enable-fortran=no")
-        cmd.append("--with-device=ch4:ofi")
-        cmd.append("--without-ch4-shmmods")
-
-    configure_cmd = shlex.split(" ".join(cmd))
-    common.run_command(configure_cmd)
-    common.run_command(["make", "clean"])
-    common.run_command(["make", "install", "-j32"])
-
-
-def build_mpich_suite(mpi, mpi_install_path, libfab_install_path, ofi_build_mode):
-
-    mpich_suite_build_path = "/mpibuilddir/mpich-suite-build-dir/{}/{}/{}/mpich" \
-                             .format(jobname, buildno, ofi_build_mode)
-    if (os.path.exists(mpich_suite_build_path) == False):
-        shutil.copytree(ci_site_config.mpich_src, mpich_suite_build_path)
-
-    mpich_suite_path = '{}/test/'.format(mpich_suite_build_path)
-    mpichsuite_installpath= "{}/mpichsuite/test".format(mpi_install_path)
-    pwd = os.getcwd()
-
-    if (mpi == 'impi'):
-        os.chdir("{}/mpi".format(mpich_suite_path))
-        cmd = ["./configure", "--with-mpi={}" \
-               .format(ci_site_config.impi_root)]
-
-        configure_cmd = shlex.split(" ".join(cmd))
-        common.run_command(configure_cmd)
-        common.run_command(["make", "all","-j32"])
-        shutil.copytree(mpich_suite_path, mpichsuite_installpath)
-        common.run_command(["make", "distclean"])
-        os.chdir(pwd)
-
-
-def build_stress_bm(mpi, mpi_install_path, libfab_install_path):
-
-    stress_install_path = "{}/stress".format(mpi_install_path)
-    if (os.path.exists(stress_install_path) == False):
-        os.makedirs(stress_install_path)
-
-    if (mpi == 'impi'):
-        os.environ['LD_LIBRARY_PATH'] = "{}/lib".format(libfab_install_path)
-        mpicc_path = "{}/bin/mpicc".format(ci_site_config.impi_root) 
-    else:
-        os.environ['LD_LIBRARY_PATH'] = ""
-        mpicc_path = "{}/bin/mpicc".format(mpi_install_path)
-
-    cmd=" ".join([mpicc_path, '-lz', "{}/mpi_stress/mpi_stress.c" \
-                 .format(ci_site_config.benchmarks['wfr-mpi-tests']),\
-                  '-o', "{}/mpi_stress".format(stress_install_path)])
-
-    runcmd = shlex.split(cmd)
-    common.run_command(runcmd)
-
-
-def build_osu_bm(mpi, mpi_install_path, libfab_install_path):
-
-    osu_install_path = "{}/osu".format(mpi_install_path)
-    if (os.path.exists(osu_install_path) == False):
-        os.makedirs(osu_install_path)
-    os.chdir(osu_install_path)
-
-    if (mpi == 'impi'):
-        os.environ['CC']="{}/bin/mpicc".format(ci_site_config.impi_root)
-        os.environ['CXX']="{}/bin/mpicxx".format(ci_site_config.impi_root)
-        os.environ['LD_LIBRARY_PATH'] = "{}/lib".format(libfab_install_path)
-
-    else:
-        os.environ['CC']="{}/bin/mpicc".format(mpi_install_path)
-        os.environ['CXX']="{}/bin/mpicxx".format(mpi_install_path)
-        os.environ['LD_LIBRARY_PATH']=""
-
-    os.environ['CFLAGS']="-I{}/util/".format(ci_site_config.benchmarks['osu'])
-    cmd = " ".join(["{}/configure".format(ci_site_config.benchmarks['osu']),
-                    "--prefix={}".format(osu_install_path)])
-
-    configure_cmd = shlex.split(cmd)
-    common.run_command(configure_cmd)
-    common.run_command(["make", "-j4"])
-    common.run_command(["make", "install"])
-
+def copy_build_dir(install_path):
+    shutil.copytree(ci_site_config.build_dir, '{}/ci_middlewares'.format(install_path))
 
 if __name__ == "__main__":
 #read Jenkins environment variables
@@ -236,8 +69,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument("build_item", help="build libfabric or fabtests",
-                         choices=['libfabric','fabtests', 'impi_benchmarks', \
-                        'ompi_benchmarks', 'mpich_benchmarks', 'shmem'])
+                         choices=['libfabric','fabtests', 'builddir'])
     parser.add_argument("--ofi_build_mode", help="select buildmode debug or dl", \
                         choices=['dbg','dl'])
 
@@ -260,28 +92,7 @@ if __name__ == "__main__":
 
     elif (build_item == 'fabtests'):
         build_fabtests(install_path, ofi_build_mode)
-    # if the build_item contains the string 'mpi'
-    elif (p.search(build_item)):
-        mpi = build_item[:-11] #extract the mpitype from '*mpi*_benchmarks' build_item
-        mpi_install_path = "{}/{}".format(install_path, mpi)
 
-        if (os.path.exists(mpi_install_path) == False):
-            os.makedirs(mpi_install_path)
-        if (mpi != 'impi'):
-            mpisrc = ci_site_config.mpich_src if mpi == 'mpich' \
-                     else ci_site_config.ompi_src
-            # only need to build ompi or mpich, impi is available as binary
-            build_mpi(mpi, mpisrc, mpi_install_path, install_path, ofi_build_mode)
+    elif (build_item == 'builddir'):
+        copy_build_dir(install_path)
 
-	    # build mpich_test_suite
-        build_mpich_suite(mpi, mpi_install_path, install_path, ofi_build_mode)
-        # run stress and osu benchmarks for all mpitypes
-        build_stress_bm(mpi, mpi_install_path, install_path)
-        build_osu_bm(mpi, mpi_install_path, install_path)
-    elif (build_item == 'shmem'):
-        # build shmem
-        shmem_dir = "{}/shmem".format(install_path)
-        build_shmem(shmem_dir, install_path)
-        build_ISx(shmem_dir)
-        build_PRK(shmem_dir)
-        build_uh(shmem_dir)

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -36,6 +36,7 @@ class Test:
         self.nw_interface = ci_site_config.interface_map[self.fabric]
         self.libfab_installpath = "{}/{}/{}/{}".format(ci_site_config.install_dir,
                                   self.jobname, self.buildno, self.ofi_build_mode)
+        self.ci_middlewares_path = "{}/ci_middlewares".format(self.libfab_installpath)
 
         self.env = [("FI_VERBS_MR_CACHE_ENABLE", "1"),\
                     ("FI_VERBS_INLINE_SIZE", "256")] \
@@ -173,7 +174,7 @@ class ShmemTest(Test):
         self.n = 4
         # self.ppn - number of processes per node.
         self.ppn = 2
-        self.shmem_dir = "{}/shmem".format(self.libfab_installpath)
+        self.shmem_dir = "{}/shmem".format(self.ci_middlewares_path)
 
     @property
     def cmd(self):
@@ -224,7 +225,7 @@ class MpiTests(Test):
             self.testpath = ci_site_config.mpi_testpath
             return "{}/run_{}.sh ".format(self.testpath,self.mpi)
         elif(self.mpi =="ompi"):
-            self.testpath = "{}/ompi/bin".format(self.libfab_installpath)
+            self.testpath = "{}/ompi/bin".format(self.ci_middlewares_path)
             return "{}/mpirun ".format(self.testpath)
 
     @property
@@ -239,7 +240,7 @@ class MpiTests(Test):
                         ci_site_config.impi_root)
             else:
                 opts = "{} -mpi_root={}/mpich".format(opts,
-                        self.libfab_installpath)
+                        self.ci_middlewares_path)
 
             opts = "{} -libfabric_path={}/lib ".format(opts,
                     self.libfab_installpath)
@@ -379,7 +380,7 @@ class MpichTestSuite(MpiTests):
             super().__init__(jobname, buildno, testname, core_prov, fabric,
 			     mpitype,  hosts, ofi_build_mode, util_prov)
             self.mpichsuitepath =  "{}/{}/mpichsuite/test/mpi/" \
-                                   .format(self.libfab_installpath, self.mpi)
+                                   .format(self.ci_middlewares_path, self.mpi)
             self.pwd = os.getcwd()
 
     def testgroup(self, testgroupname):
@@ -398,7 +399,7 @@ class MpichTestSuite(MpiTests):
             if (self.mpi == "impi"):
                 mpiroot = ci_site_config.impi_root
             else:
-                mpiroot = "{}/mpich".format(self.libfab_installpath)
+                mpiroot = "{}/mpich".format(self.ci_middlewares_path)
             if (self.util_prov):
                 prov = "\"{};{}\"".format(self.core_prov, self.util_prov)
             else:
@@ -468,7 +469,7 @@ class MpiTestOSU(MpiTests):
                               }
 
         self.osu_mpi_path = "{}/{}/osu/libexec/osu-micro-benchmarks/mpi/". \
-                            format(self.libfab_installpath,mpitype)
+                            format(self.ci_middlewares_path, mpitype)
 
     @property
     def execute_condn(self):


### PR DESCRIPTION
add a -j flag to libfabric and fabtests build
change build.py to copy a tree of static prebuilt middlewares to use with ci tests
update jenkinsfile stages to remove middleware builds
remove uneccessary build directions in build.py for removed middleware builds
update file paths with new tree copy location