### PR TITLE
fabtests/msg_inject: handle the case ft_tsendmsg return -FI_EAGAIN

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -1806,7 +1806,7 @@ static void ft_force_progress(void)
 		fi_cq_read(rxcq, NULL, 0);
 }
 
-static int ft_progress(struct fid_cq *cq, uint64_t total, uint64_t *cq_cntr)
+int ft_progress(struct fid_cq *cq, uint64_t total, uint64_t *cq_cntr)
 {
 	struct fi_cq_err_entry comp;
 	int ret;

--- a/fabtests/functional/msg_inject.c
+++ b/fabtests/functional/msg_inject.c
@@ -52,11 +52,22 @@ static int send_msg(int sendmsg, size_t size)
 	}
 
 	if (sendmsg) {
-		ret = ft_sendmsg(ep, remote_fi_addr, size,
-				&tx_ctx, flag);
-		if (ret) {
-			FT_PRINTERR("ft_sendmsg", ret);
-			return ret;
+		while(1) {
+			ret = ft_sendmsg(ep, remote_fi_addr, size,
+					 &tx_ctx, flag);
+			if (!ret)
+				break;
+
+			if (ret != -FI_EAGAIN) {
+				FT_PRINTERR("ft_sendmsg", ret);
+				return ret;
+			}
+
+			ret = ft_progress(txcq, tx_seq, &tx_cq_cntr);
+			if (ret && ret != -FI_EAGAIN) {
+				FT_ERR("Failed to get send completion");
+				return ret;
+			}
 		}
 	} else {
 		ret = ft_post_tx(ep, remote_fi_addr, size, NO_CQ_DATA, &tx_ctx);

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -459,6 +459,7 @@ int ft_finalize_ep(struct fid_ep *ep);
 
 size_t ft_rx_prefix_size(void);
 size_t ft_tx_prefix_size(void);
+int ft_progress(struct fid_cq *cq, uint64_t total, uint64_t *cq_cntr);
 ssize_t ft_post_rx(struct fid_ep *ep, size_t size, void *ctx);
 ssize_t ft_post_rx_buf(struct fid_ep *ep, size_t size, void *ctx,
 		       void *op_buf, void *op_mr_desc, uint64_t op_tag);

--- a/fabtests/multinode/src/core.c
+++ b/fabtests/multinode/src/core.c
@@ -198,27 +198,6 @@ err:
 	return ft_exit_code(ret);
 }
 
-static int ft_progress(struct fid_cq *cq, uint64_t total, uint64_t *cq_cntr)
-{
-	struct fi_cq_err_entry comp;
-	int ret;
-
-	ret = fi_cq_read(cq, &comp, 1);
-	if (ret > 0)
-		(*cq_cntr)++;
-
-	if (ret >= 0 || ret == -FI_EAGAIN)
-		return 0;
-
-	if (ret == -FI_EAVAIL) {
-		ret = ft_cq_readerr(cq);
-		(*cq_cntr)++;
-	} else {
-		FT_PRINTERR("fi_cq_read/sread", ret);
-	}
-	return ret;
-}
-
 int multi_msg_recv()
 {
 	int ret, offset;


### PR DESCRIPTION
Currently, upon any error return of ft_tsendmsg, the msg_inject test
will fail. However, in case of -FI_EAGAIN, the test should retry the
send.

This patch makes that change to msg_inject.

Signed-off-by: Wei Zhang <wzam@amazon.com>