### PR TITLE
fabtest/efa.exclude: remove msg_inject from exclusion list

### DIFF
--- a/fabtests/test_configs/efa/efa.exclude
+++ b/fabtests/test_configs/efa/efa.exclude
@@ -41,11 +41,6 @@ cq_data
 multi_mr
 rdm_rma_trigger
 
-# fi_msg_inject test does not work with
-# EFA provider on single instance. Temporarily exclude
-# this test while we investigate the root cause
-msg_inject
-
 msg_sockets
 rc_pingpong
 


### PR DESCRIPTION
The test msg_inject does not handle -FI_EAGAIN error code
correctly, which caused EFA provider to fail.

The issue has been fixed by
       #7357
. so this patch enable the test for EFA.


Signed-off-by: Wei Zhang <wzam@amazon.com>