### PR TITLE
prov/verbs: Store ibv_wr_opcode to use in error cases

### DIFF
--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -620,10 +620,10 @@ struct vrb_ep {
 };
 
 
-enum vrb_op_ctx {
-	VRB_POST_SQ,
-	VRB_POST_RQ,
-	VRB_POST_SRQ,
+enum vrb_op_queue {
+	VRB_OP_SQ,
+	VRB_OP_RQ,
+	VRB_OP_SRQ,
 };
 
 struct vrb_context {
@@ -633,8 +633,11 @@ struct vrb_context {
 		struct vrb_srq_ep	*srx;
 	};
 	void				*user_ctx;
-	enum vrb_op_ctx			op_ctx;
+	enum vrb_op_queue		op_queue;
+	enum ibv_wr_opcode		sq_opcode;
 };
+
+enum ibv_wc_opcode vrb_wr2wc_opcode(enum ibv_wr_opcode wr);
 
 #define VERBS_XRC_EP_MAGIC		0x1F3D5B79
 struct vrb_xrc_ep {

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -37,6 +37,22 @@
 
 #include "fi_verbs.h"
 
+
+enum ibv_wc_opcode vrb_wr2wc_opcode(enum ibv_wr_opcode wr)
+{
+	static enum ibv_wc_opcode wc[] = {
+		[IBV_WR_RDMA_WRITE] = IBV_WC_RDMA_WRITE,
+		[IBV_WR_RDMA_WRITE_WITH_IMM] = IBV_WC_RDMA_WRITE,
+		[IBV_WR_SEND] = IBV_WC_SEND,
+		[IBV_WR_SEND_WITH_IMM] = IBV_WC_SEND,
+		[IBV_WR_RDMA_READ] = IBV_WC_RDMA_READ,
+		[IBV_WR_ATOMIC_CMP_AND_SWP] = IBV_WC_COMP_SWAP,
+		[IBV_WR_ATOMIC_FETCH_AND_ADD] = IBV_WC_FETCH_ADD,
+	};
+
+	return (wr < ARRAY_SIZE(wc)) ? wc[wr] : IBV_WC_SEND;
+}
+
 static void vrb_cq_read_context_entry(struct ibv_wc *wc, void *buf)
 {
 	struct fi_cq_entry *entry = buf;
@@ -239,7 +255,7 @@ int vrb_poll_cq(struct vrb_cq *cq, struct ibv_wc *wc)
 
 		ctx = (struct vrb_context *) (uintptr_t) wc->wr_id;
 		wc->wr_id = (uintptr_t) ctx->user_ctx;
-		if (ctx->op_ctx == VRB_POST_SQ) {
+		if (ctx->op_queue == VRB_OP_SQ) {
 			assert(ctx->ep);
 			assert(!slist_empty(&ctx->ep->sq_list));
 			assert(ctx->ep->sq_list.head == &ctx->entry);
@@ -248,13 +264,11 @@ int vrb_poll_cq(struct vrb_cq *cq, struct ibv_wc *wc)
 			ctx->ep->sq_credits++;
 		}
 
-		if (wc->status) {
-			if (ctx->op_ctx == VRB_POST_SQ)
-				wc->opcode &= ~IBV_WC_RECV;
-			else
-				wc->opcode |= IBV_WC_RECV;
-		}
-		if (ctx->op_ctx == VRB_POST_SRQ) {
+		/* workaround incorrect opcode reported by verbs */
+		wc->opcode = (ctx->op_queue == VRB_OP_SQ) ?
+			     vrb_wr2wc_opcode(ctx->sq_opcode) : IBV_WC_RECV;
+
+		if (ctx->op_queue == VRB_OP_SRQ) {
 			ofi_mutex_lock(&ctx->srx->ctx_lock);
 			ofi_buf_free(ctx);
 			ofi_mutex_unlock(&ctx->srx->ctx_lock);


### PR DESCRIPTION
The full opcode is needed to properly set the completion
flags in the case of an error, when the opcode is not
provided back as part of the completion.

As part of this change, we rename op_ctx to op_queue to
avoid confusion with the opcode, since that field is only
storing which queue the operation was posted to.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>