### PR TITLE
prov/util: Fix memory access in ip_av_insertsym

### DIFF
--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -799,8 +799,10 @@ static int ip_av_nodesym_getaddr(struct util_av *av, const char *node,
 				"insert\n", node, service);
 
 			ret = getaddrinfo(node, service, &hints, &ai);
-			if (ret)
+			if (ret) {
+				ret = -abs(ret);
 				goto err;
+			}
 
 			memcpy(addr_temp, ai->ai_addr, *addrlen);
 			addr_temp = (char *)addr_temp + *addrlen;


### PR DESCRIPTION
This can occur through the path that calls ip_av_nodesym_getaddr().
If the getaddrinfo call inside that function fails, it can return
a positive error code (from getaddrinfo).  This is treated as a
count value in ip_av_insertsym, which then tries to access the
freed address array.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>