### PR TITLE
util: 1 coverity and 1 build warning fix

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -164,11 +164,15 @@ struct ofi_common_locks {
 typedef int (*ofi_map_info_t)(uint32_t version, const struct fi_info *src_info,
 			      const struct fi_info *base_info,
 			      struct fi_info *dest_info);
+typedef void (*ofi_alter_info_t)(uint32_t version,
+				 const struct fi_info *hints,
+				 const struct fi_info *base_info,
+				 struct fi_info *dest_info);
 
 struct util_prov {
 	const struct fi_provider	*prov;
 	const struct fi_info		*info;
-	ofi_map_info_t			alter_defaults;
+	ofi_alter_info_t		alter_defaults;
 	const int			flags;
 };
 

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -161,14 +161,14 @@ struct ofi_common_locks {
 /*
  * Provider details
  */
-typedef int (*ofi_alter_info_t)(uint32_t version, const struct fi_info *src_info,
-				const struct fi_info *base_info,
-				struct fi_info *dest_info);
+typedef int (*ofi_map_info_t)(uint32_t version, const struct fi_info *src_info,
+			      const struct fi_info *base_info,
+			      struct fi_info *dest_info);
 
 struct util_prov {
 	const struct fi_provider	*prov;
 	const struct fi_info		*info;
-	ofi_alter_info_t		alter_defaults;
+	ofi_map_info_t			alter_defaults;
 	const int			flags;
 };
 
@@ -980,12 +980,12 @@ int ofi_get_core_info(uint32_t version, const char *node, const char *service,
 		      uint64_t flags, const struct util_prov *util_prov,
 		      const struct fi_info *util_hints,
 		      const struct fi_info *base_attr,
-		      ofi_alter_info_t info_to_core,
+		      ofi_map_info_t info_to_core,
 		      struct fi_info **core_info);
 int ofix_getinfo(uint32_t version, const char *node, const char *service,
 		 uint64_t flags, const struct util_prov *util_prov,
-		 const struct fi_info *hints, ofi_alter_info_t info_to_core,
-		 ofi_alter_info_t info_to_util, struct fi_info **info);
+		 const struct fi_info *hints, ofi_map_info_t info_to_core,
+		 ofi_map_info_t info_to_util, struct fi_info **info);
 int ofi_get_core_info_fabric(const struct fi_provider *prov,
 			     const struct fi_fabric_attr *util_attr,
 			     struct fi_info **core_info);

--- a/prov/netdir/src/netdir_init.c
+++ b/prov/netdir/src/netdir_init.c
@@ -54,9 +54,9 @@ struct fi_provider ofi_nd_prov = {
 	.cleanup = ofi_nd_fini
 };
 
-static int ofi_nd_alter_defaults(uint32_t version, const struct fi_info *hints,
-		                         const struct fi_info *base_info,
-		                         struct fi_info *dest_info);
+static void ofi_nd_alter_defaults(uint32_t version, const struct fi_info *hints,
+				  const struct fi_info *base_info,
+				  struct fi_info *dest_info);
 
 struct util_prov ofi_nd_util_prov = {
 	.prov = &ofi_nd_prov,
@@ -79,9 +79,9 @@ static size_t nd_default_tx_size = 384;
 static size_t nd_default_rx_iov_limit = 8;
 static size_t nd_default_rx_size = 384;
 
-static int ofi_nd_alter_defaults(uint32_t version, const struct fi_info *hints,
-                                 const struct fi_info *base_info,
-                                 struct fi_info *dest_info)
+static void ofi_nd_alter_defaults(uint32_t version, const struct fi_info *hints,
+				  const struct fi_info *base_info,
+				  struct fi_info *dest_info)
 {
     dest_info->tx_attr->iov_limit = min(base_info->tx_attr->iov_limit,
     					nd_default_tx_iov_limit);
@@ -91,8 +91,6 @@ static int ofi_nd_alter_defaults(uint32_t version, const struct fi_info *hints,
     					nd_default_rx_iov_limit);
     dest_info->rx_attr->size = min(base_info->rx_attr->size,
     				   nd_default_rx_size);
-
-    return 0;
 }
 
 int ofi_nd_getinfo(uint32_t version, const char *node, const char *service,

--- a/prov/tcp/src/tcpx_attr.c
+++ b/prov/tcp/src/tcpx_attr.c
@@ -167,7 +167,7 @@ struct fi_info tcpx_info = {
 /* User hints will still override the modified dest_info attributes
  * through ofi_alter_info
  */
-static int
+static void
 tcpx_alter_defaults(uint32_t version, const struct fi_info *hints,
 		    const struct fi_info *base_info,
 		    struct fi_info *dest_info)
@@ -177,7 +177,6 @@ tcpx_alter_defaults(uint32_t version, const struct fi_info *hints,
 	    hints && hints->ep_attr &&
 	    (hints->ep_attr->rx_ctx_cnt != FI_SHARED_CONTEXT))
 		dest_info->rx_attr->size = tcpx_default_rx_size;
-	return 0;
 }
 
 

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -1008,9 +1008,8 @@ int ofi_prov_check_dup_info(const struct util_prov *util_prov,
 		}
 
 		if (util_prov->alter_defaults) {
-			ret = util_prov->alter_defaults(api_version, user_info,
-							prov_info, fi);
-			assert(ret == FI_SUCCESS);
+			util_prov->alter_defaults(api_version, user_info,
+						  prov_info, fi);
 		}
 
 		if (!*info)

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -176,7 +176,7 @@ static int ofi_set_prov_name(const struct fi_provider *prov,
 static int ofi_info_to_core(uint32_t version, const struct fi_provider *prov,
 			    const struct fi_info *util_hints,
 			    const struct fi_info *base_attr,
-			    ofi_alter_info_t info_to_core,
+			    ofi_map_info_t info_to_core,
 			    struct fi_info **core_hints)
 {
 	int ret;
@@ -228,8 +228,9 @@ err:
 }
 
 static int ofi_info_to_util(uint32_t version, const struct fi_provider *prov,
-			    struct fi_info *core_info, const struct fi_info *base_info,
-			    ofi_alter_info_t info_to_util,
+			    struct fi_info *core_info,
+			    const struct fi_info *base_info,
+			    ofi_map_info_t info_to_util,
 			    struct fi_info **util_info)
 {
 	if (!(*util_info = fi_allocinfo()))
@@ -284,7 +285,7 @@ int ofi_get_core_info(uint32_t version, const char *node, const char *service,
 		      uint64_t flags, const struct util_prov *util_prov,
 		      const struct fi_info *util_hints,
 		      const struct fi_info *base_attr,
-		      ofi_alter_info_t info_to_core, struct fi_info **core_info)
+		      ofi_map_info_t info_to_core, struct fi_info **core_info)
 {
 	struct fi_info *core_hints = NULL;
 	int ret;
@@ -307,8 +308,8 @@ int ofi_get_core_info(uint32_t version, const char *node, const char *service,
 
 int ofix_getinfo(uint32_t version, const char *node, const char *service,
 		 uint64_t flags, const struct util_prov *util_prov,
-		 const struct fi_info *hints, ofi_alter_info_t info_to_core,
-		 ofi_alter_info_t info_to_util, struct fi_info **info)
+		 const struct fi_info *hints, ofi_map_info_t info_to_core,
+		 ofi_map_info_t info_to_util, struct fi_info **info)
 {
 	struct fi_info *core_info, *base_info, *util_info, *cur, *tail;
 	int ret = -FI_ENODATA;

--- a/prov/util/src/util_coll.c
+++ b/prov/util/src/util_coll.c
@@ -1274,12 +1274,13 @@ ofi_ep_allreduce(struct fid_ep *ep, const void *buf, size_t count, void *desc,
 	if (!allreduce_op)
 		return -FI_ENOMEM;
 
-
 	allreduce_op->data.allreduce.size = count * ofi_datatype_size(datatype);
 	allreduce_op->data.allreduce.data = calloc(count,
 						ofi_datatype_size(datatype));
-	if (!allreduce_op->data.allreduce.data)
+	if (!allreduce_op->data.allreduce.data) {
+		ret = -FI_ENOMEM;
 		goto err1;
+	}
 
 	ret = util_coll_allreduce(allreduce_op, buf, result,
 				  allreduce_op->data.allreduce.data, count,
@@ -1295,6 +1296,7 @@ ofi_ep_allreduce(struct fid_ep *ep, const void *buf, size_t count, void *desc,
 	util_coll_op_progress_work(util_ep, allreduce_op);
 
 	return FI_SUCCESS;
+
 err2:
 	free(allreduce_op->data.allreduce.data);
 err1:


### PR DESCRIPTION
Restructuring of ofi_alter_info_t callback handlers, plus fix for using an uninitialized variable in an error path.