### PR TITLE
core/hmem_cuda: fix the default value of hmem_cuda_use_gdrcopy

### DIFF
--- a/src/hmem_cuda.c
+++ b/src/hmem_cuda.c
@@ -469,6 +469,7 @@ int cuda_hmem_init(void)
 	if (ret != FI_SUCCESS)
 		goto dl_cleanup;
 
+	ret = 1;
 	fi_param_get_bool(NULL, "hmem_cuda_use_gdrcopy",
 			  &ret);
 	hmem_cuda_use_gdrcopy = (ret != 0);


### PR DESCRIPTION
According its defintion, the default value of hmem_cuda_use_gdrcopy
should be 1, but the default value was not set in current code.

This patch fix the issue.

Signed-off-by: Wei Zhang <wzam@amazon.com>