### PR TITLE
fabtests/efa/test_rdm.py: add cuda tests to rdm tests

### DIFF
--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -4,32 +4,38 @@ from default.test_rdm import test_rdm
 from default.test_rdm import test_rdm_bw_functional
 from default.test_rdm import test_rdm_atomic
 
-def run_rdm_test(cmdline_args, executable, iteration_type, completion_type):
+
+@pytest.fixture(scope="module", params=["host_to_host", "host_to_cuda",
+                                        "cuda_to_host", "cuda_to_cuda"])
+def memory_type(request):
+    return request.param
+
+def run_rdm_test(cmdline_args, executable, iteration_type, completion_type, memory_type):
     from common import ClientServerTest
     test = ClientServerTest(cmdline_args, executable, iteration_type,
                             completion_type=completion_type,
                             datacheck_type="with_datacheck",
-                            message_size="all")
+                            message_size="all",
+                            memory_type=memory_type)
     test.run()
 
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rdm_pingpong(cmdline_args, iteration_type, completion_type):
+def test_rdm_pingpong(cmdline_args, iteration_type, completion_type, memory_type):
     run_rdm_test(cmdline_args, "fi_rdm_pingpong", iteration_type,
-                 completion_type)
+                 completion_type, memory_type)
 
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rdm_tagged_pingpong(cmdline_args, iteration_type, completion_type):
+def test_rdm_tagged_pingpong(cmdline_args, iteration_type, completion_type, memory_type):
     run_rdm_test(cmdline_args, "fi_rdm_tagged_pingpong", iteration_type,
-                 completion_type)
+                 completion_type, memory_type)
 
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rdm_tagged_bw(cmdline_args, iteration_type, completion_type):
+def test_rdm_tagged_bw(cmdline_args, iteration_type, completion_type, memory_type):
     run_rdm_test(cmdline_args, "fi_rdm_tagged_bw", iteration_type,
-                 completion_type)
-
+                 completion_type, memory_type)


### PR DESCRIPTION
This patch introduced a parametrized fixture "memory_type",
which has 4 parameters: host_to_host, host_to_cuda,
cuda_to_host, and cuda_to_cuda.

It then used this fixture as an argument to test on
rdm_pingpoing, rdm_tagged_pingpong, rdm_tagged_bw

Signed-off-by: Wei Zhang <wzam@amazon.com>