### PR TITLE
include/ofi.h Avoid implicit casting when calling ofi_get_page_start

### DIFF
--- a/include/ofi.h
+++ b/include/ofi.h
@@ -302,7 +302,7 @@ static inline void *ofi_get_page_end(const void *addr, size_t page_size)
 static inline size_t
 ofi_get_page_bytes(const void *addr, size_t len, size_t page_size)
 {
-	char *start = ofi_get_page_start(addr, page_size);
+	char *start = (char *)ofi_get_page_start(addr, page_size);
 	char *end = (char *)ofi_get_page_start((const char*)addr + len - 1, page_size)
 		    + page_size;
 	size_t result = end - start;


### PR DESCRIPTION
Signed-off-by: William Zhang <wilzhang@amazon.com>