### PR TITLE
prov/efa: Add more warning message when the peer cannot be found for a received packet

### DIFF
--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -1047,7 +1047,9 @@ void rxr_pkt_handle_recv_completion(struct rxr_ep *ep,
 			 * Application called fi_av_remove() to remove the address
 			 * from address vector. In this case, this packet should be ignored.
 			 */
-			FI_WARN(&rxr_prov, FI_LOG_CQ, "Warning: ignoring a received packet from a removed address\n");
+			FI_WARN(&rxr_prov, FI_LOG_CQ,
+				"Warning: ignoring a received packet from a removed address. packet type: %" PRIu8
+				", packet flags: %x\n", rxr_get_base_hdr(pkt_entry->pkt)->type, rxr_get_base_hdr(pkt_entry->pkt)->flags);
 			rxr_pkt_entry_release_rx(ep, pkt_entry);
 			return;
 		}


### PR DESCRIPTION
This PR contains two commits:
- add the packet type and flags into the warning messages a receiving packet from a removed address is ignored
- adds warning message that contains the ahn and qpn if they cannot be found in the reverse av table.