### PR TITLE
util/ofi_straddr: Fix truncation of ipv6 addressing

### DIFF
--- a/prov/hook/hook_hmem/src/hook_hmem.c
+++ b/prov/hook/hook_hmem/src/hook_hmem.c
@@ -272,7 +272,7 @@ static int hook_hmem_track_atomic(struct hook_ep *ep, const struct fi_ioc *ioc,
 
 	if (comp_count) {
 		(*hmem_ctx)->comp_desc = calloc(comp_count,
-					sizeof(**(*hmem_ctx)->comp_desc));
+					sizeof(*(*hmem_ctx)->comp_desc));
 		if ((*hmem_ctx)->comp_desc) {
 			ret = -FI_ENOMEM;
 			goto err3;
@@ -293,7 +293,7 @@ static int hook_hmem_track_atomic(struct hook_ep *ep, const struct fi_ioc *ioc,
 
 	if (res_count) {
 		(*hmem_ctx)->res_desc = calloc(res_count,
-					     sizeof(**(*hmem_ctx)->res_desc));
+					     sizeof(*(*hmem_ctx)->res_desc));
 		if (!(*hmem_ctx)->res_desc) {
 			ret = -FI_ENOMEM;
 			goto err4;

--- a/prov/shm/src/smr_av.c
+++ b/prov/shm/src/smr_av.c
@@ -71,8 +71,8 @@ static int smr_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 	smr_av = container_of(util_av, struct smr_av, util_av);
 
 	for (i = 0; i < count; i++, addr = (char *) addr + strlen(addr) + 1) {
+		util_addr = FI_ADDR_NOTAVAIL;
 		if (smr_av->used < SMR_MAX_PEERS) {
-			util_addr = FI_ADDR_NOTAVAIL;
 			ret = smr_map_add(&smr_prov, smr_av->smr_map,
 					  addr, &shm_id);
 			if (!ret) {

--- a/src/common.c
+++ b/src/common.c
@@ -316,9 +316,8 @@ sa_sin:
 			       sizeof(str)))
 			return NULL;
 
-		size = snprintf(buf, MIN(*len, sizeof(str)),
-				"fi_sockaddr_in://%s:%" PRIu16, str,
-				ntohs(sin->sin_port));
+		size = snprintf(buf, *len, "fi_sockaddr_in://%s:%" PRIu16,
+				str, ntohs(sin->sin_port));
 		break;
 	case FI_SOCKADDR_IN6:
 sa_sin6:
@@ -327,9 +326,8 @@ sa_sin6:
 			       sizeof(str)))
 			return NULL;
 
-		size = snprintf(buf, MIN(*len, sizeof(str)),
-				"fi_sockaddr_in6://[%s]:%" PRIu16, str,
-				ntohs(sin6->sin6_port));
+		size = snprintf(buf, *len, "fi_sockaddr_in6://[%s]:%" PRIu16,
+				str, ntohs(sin6->sin6_port));
 		break;
 	case FI_ADDR_EFA:
 		memset(str, 0, sizeof(str));


### PR DESCRIPTION
Fixes #7400.

The sizeof(str) is smaller than what's needed to store an ipv6
address plus the fi_sockaddr_in6:// header.  Remove the
unneeded MIN call and use the user's len value directly.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>