### PR TITLE
man/cq: Document that cq_read with a count = 0 is valid

### DIFF
--- a/man/fi_cq.3.md
+++ b/man/fi_cq.3.md
@@ -330,7 +330,8 @@ when the CQ was opened.  Multiple completions may be retrieved from a
 CQ in a single call.  The maximum number of entries to return is
 limited to the specified count parameter, with the number of entries
 successfully read from the CQ returned by the call.  (See return
-values section below.)
+values section below.)  A count value of 0 may be used to drive
+progress on associated endpoints when manual progress is enabled.
 
 CQs are optimized to report operations which have completed
 successfully.  Operations which fail are reported 'out of band'.  Such


### PR DESCRIPTION
This is not formally documented, but used by the util providers.
When cq_read is called with a count of 0, this can be used to
drive progress.  Formalize this feature for providers that
need manual progress.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>

Based on inspection, it looks like most providers support this feature as it's part of the util code.