### PR TITLE
prov/tcp: Do not generate error completions for inject msgs

### DIFF
--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -287,11 +287,13 @@ struct tcpx_fabric {
 };
 
 
+/* tcpx_xfer_entry::ctrl_flags */
 #define TCPX_NEED_RESP		BIT(1)
 #define TCPX_NEED_ACK		BIT(2)
 #define TCPX_INTERNAL_XFER	BIT(3)
 #define TCPX_NEED_DYN_RBUF 	BIT(4)
 #define TCPX_ASYNC		BIT(5)
+#define TCPX_INJECT_OP		BIT(6)
 
 struct tcpx_xfer_entry {
 	struct slist_entry	entry;

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -197,8 +197,15 @@ void tcpx_cq_report_error(struct util_cq *cq,
 {
 	struct fi_cq_err_entry err_entry;
 
-	if (xfer_entry->ctrl_flags & TCPX_INTERNAL_XFER)
+	if (xfer_entry->ctrl_flags & (TCPX_INTERNAL_XFER | TCPX_INJECT_OP)) {
+		if (xfer_entry->ctrl_flags & TCPX_INTERNAL_XFER)
+			FI_WARN(&tcpx_prov, FI_LOG_CQ, "internal transfer "
+				"failed (%s)\n", fi_strerror(err));
+		else
+			FI_WARN(&tcpx_prov, FI_LOG_CQ, "inject transfer "
+				"failed (%s)\n", fi_strerror(err));
 		return;
+	}
 
 	err_entry.flags = xfer_entry->cq_flags & ~FI_COMPLETION;
 	if (err_entry.flags & FI_RECV) {

--- a/prov/tcp/src/tcpx_msg.c
+++ b/prov/tcp/src/tcpx_msg.c
@@ -356,8 +356,7 @@ tcpx_inject(struct fid_ep *ep_fid, const void *buf, size_t len,
 		return -FI_EAGAIN;
 
 	tcpx_init_tx_inject(tx_entry, sizeof(tx_entry->hdr.base_hdr), buf, len);
-
-	tx_entry->cq_flags = FI_MSG | FI_SEND; /* set in case of error */
+	tx_entry->ctrl_flags = TCPX_INJECT_OP;
 
 	tcpx_queue_send(ep, tx_entry);
 	return FI_SUCCESS;
@@ -410,8 +409,7 @@ tcpx_injectdata(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	tcpx_init_tx_inject(tx_entry, sizeof(tx_entry->hdr.cq_data_hdr),
 			    buf, len);
-
-	tx_entry->cq_flags = FI_MSG | FI_SEND; /* set in case of error */
+	tx_entry->ctrl_flags = TCPX_INJECT_OP;
 
 	tcpx_queue_send(ep, tx_entry);
 	return FI_SUCCESS;
@@ -535,8 +533,7 @@ tcpx_tinject(struct fid_ep *fid_ep, const void *buf, size_t len,
 	tx_entry->hdr.tag_hdr.tag = tag;
 
 	tcpx_init_tx_inject(tx_entry, sizeof(tx_entry->hdr.tag_hdr), buf, len);
-
-	tx_entry->cq_flags = FI_TAGGED | FI_SEND; /* set in case of error */
+	tx_entry->ctrl_flags = TCPX_INJECT_OP;
 
 	tcpx_queue_send(ep, tx_entry);
 	return FI_SUCCESS;
@@ -588,8 +585,7 @@ tcpx_tinjectdata(struct fid_ep *fid_ep, const void *buf, size_t len,
 
 	tcpx_init_tx_inject(tx_entry, sizeof(tx_entry->hdr.tag_data_hdr),
 			    buf, len);
-
-	tx_entry->cq_flags = FI_TAGGED | FI_SEND; /* set in case of error */
+	tx_entry->ctrl_flags = TCPX_INJECT_OP;
 
 	tcpx_queue_send(ep, tx_entry);
 	return FI_SUCCESS;


### PR DESCRIPTION
Mark inject operations to not generate a completion, even in
the case of failures.  Generating a completion can result in
reporting of a null context to the user, which if they try
to dereference, will result in a segfault.  This is seen with
rxm running MPI apps.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>