### PR TITLE
src/log: add utility provider log suffix to make logs easier to read

### DIFF
--- a/include/ofi.h
+++ b/include/ofi.h
@@ -236,6 +236,7 @@ struct fi_filter {
 
 extern struct fi_filter prov_log_filter;
 extern struct fi_provider core_prov;
+extern const char *log_prefix;
 
 void ofi_create_filter(struct fi_filter *filter, const char *env_name);
 void ofi_free_filter(struct fi_filter *filter);

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -295,12 +295,12 @@ int ofi_get_core_info(uint32_t version, const char *node, const char *service,
 	if (ret)
 		return ret;
 
-	FI_DBG(util_prov->prov, FI_LOG_CORE, "--- Begin ofi_get_core_info ---\n");
+	log_prefix = util_prov->prov->name;
 
 	ret = fi_getinfo(version, node, service, flags | OFI_CORE_PROV_ONLY,
 			 core_hints, core_info);
 
-	FI_DBG(util_prov->prov, FI_LOG_CORE, "--- End ofi_get_core_info ---\n");
+	log_prefix = "";
 
 	fi_freeinfo(core_hints);
 	return ret;

--- a/src/log.c
+++ b/src/log.c
@@ -81,6 +81,7 @@ enum {
 static int log_interval = 2000;
 uint64_t log_mask;
 struct fi_filter prov_log_filter;
+const char *log_prefix = "";
 
 static pid_t pid;
 
@@ -179,9 +180,10 @@ void DEFAULT_SYMVER_PRE(fi_log)(const struct fi_provider *prov, enum fi_log_leve
 
 	va_list vargs;
 
-	size = snprintf(buf, sizeof(buf), "%s:%d:%ld:%s:%s:%s():%d<%s> ",
-			PACKAGE, pid, (unsigned long) time(NULL), prov->name,
-			log_subsys[subsys], func, line, log_levels[level]);
+	size = snprintf(buf, sizeof(buf), "%s:%d:%ld:%s:%s:%s:%s():%d<%s> ",
+			PACKAGE, pid, (unsigned long) time(NULL), log_prefix,
+			prov->name, log_subsys[subsys], func, line,
+			log_levels[level]);
 
 	va_start(vargs, fmt);
 	vsnprintf(buf + size, sizeof(buf) - size, fmt, vargs);


### PR DESCRIPTION
Utility providers have to call fi_getinfo again to get core providers
resulting in deceptive and confusing log lines where a core provider
might return FI_ENODATA for a utility provider but FI_SUCCESS for the
app. Extra log levels were added that say Begin/End ofi_get_core_info
to make this clearer but these debug-only (not info) logs can get lost
among the hundreds of lines of output.

To make it easier to distinguish between log lines with and without a
core provider, specifically during fi_getinfo, add a log_prefix to the
log output which clarifies that the log line was outputed as part of
the layered fi_getinfo call

For example, the following log line sees changes as such:
libfabric:53685:1643663041:verbs:fabric:vrb_get_matching_info():1514<info> checking domain: #1 mlx5_0
libfabric:53685:1643663041:ofi_rxm:verbs:fabric:vrb_get_matching_info():1514<info> checking domain: #1 mlx5_0

Signed-off-by: aingerson <alexia.ingerson@intel.com>