### PR TITLE
prov/hook: Enable DL build of hooking providers

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -105,6 +105,18 @@ common_srcs += include/linux/osd.h
 common_srcs += include/unix/osd.h
 endif
 
+common_hook_srcs =				\
+	prov/hook/src/hook.c			\
+	prov/hook/src/hook_av.c			\
+	prov/hook/src/hook_cm.c			\
+	prov/hook/src/hook_cntr.c		\
+	prov/hook/src/hook_cq.c			\
+	prov/hook/src/hook_domain.c		\
+	prov/hook/src/hook_ep.c			\
+	prov/hook/src/hook_eq.c			\
+	prov/hook/src/hook_wait.c		\
+	prov/hook/src/hook_xfer.c
+
 # ensure dl-built providers link back to libfabric
 linkback = src/libfabric.la
 
@@ -169,16 +181,7 @@ src_libfabric_la_SOURCES =			\
 	src/log.c				\
 	src/var.c				\
 	src/abi_1_0.c				\
-	prov/hook/src/hook.c			\
-	prov/hook/src/hook_av.c			\
-	prov/hook/src/hook_cm.c			\
-	prov/hook/src/hook_cntr.c		\
-	prov/hook/src/hook_cq.c			\
-	prov/hook/src/hook_domain.c		\
-	prov/hook/src/hook_ep.c			\
-	prov/hook/src/hook_eq.c			\
-	prov/hook/src/hook_wait.c		\
-	prov/hook/src/hook_xfer.c		\
+	$(common_hook_srcs)			\
 	$(common_srcs)
 
 src_libfabric_la_CPPFLAGS = $(AM_CPPFLAGS)

--- a/include/ofi.h
+++ b/include/ofi.h
@@ -245,17 +245,11 @@ int ofi_nic_close(struct fid *fid);
 struct fid_nic *ofi_nic_dup(const struct fid_nic *nic);
 int ofi_nic_tostr(const struct fid *fid_nic, char *buf, size_t len);
 
-struct fi_provider *ofi_get_hook(const char *name);
-
 void fi_log_init(void);
 void fi_log_fini(void);
 void fi_param_init(void);
 void fi_param_fini(void);
 void fi_param_undefine(const struct fi_provider *provider);
-void ofi_hook_init(void);
-void ofi_hook_fini(void);
-void ofi_hook_install(struct fid_fabric *hfabric, struct fid_fabric **fabric,
-		      struct fi_provider *prov);
 void ofi_remove_comma(char *buffer);
 void ofi_strncatf(char *dest, size_t n, const char *fmt, ...);
 

--- a/include/ofi_prov.h
+++ b/include/ofi_prov.h
@@ -239,7 +239,10 @@ RSTREAM_INI ;
 #  define RSTREAM_INIT NULL
 #endif
 
-#if(HAVE_PERF)
+#if (HAVE_PERF) && (HAVE_PERF_DL)
+#  define HOOK_PERF_INI FI_EXT_INI
+#  define HOOK_PERF_INIT NULL
+#elif (HAVE_PERF)
 #  define HOOK_PERF_INI INI_SIG(fi_hook_perf_ini)
 #  define HOOK_PERF_INIT fi_hook_perf_ini()
 HOOK_PERF_INI ;
@@ -247,7 +250,10 @@ HOOK_PERF_INI ;
 #  define HOOK_PERF_INIT NULL
 #endif
 
-#if(HAVE_HOOK_DEBUG)
+#if (HAVE_HOOK_DEBUG) && (HAVE_HOOK_DEBUG_DL)
+#  define HOOK_DEBUG_INI FI_EXT_INI
+#  define HOOK_DEBUG_INIT NULL
+#elif (HAVE_HOOK_DEBUG)
 #  define HOOK_DEBUG_INI INI_SIG(fi_debug_hook_ini)
 #  define HOOK_DEBUG_INIT fi_debug_hook_ini()
 HOOK_DEBUG_INI ;
@@ -255,7 +261,10 @@ HOOK_DEBUG_INI ;
 #  define HOOK_DEBUG_INIT NULL
 #endif
 
-#if(HAVE_HOOK_HMEM)
+#if (HAVE_HOOK_HMEM) && (HAVE_HOOK_HMEM_DL)
+#  define HOOK_HMEM_INI FI_EXT_INI
+#  define HOOK_HMEM_INIT NULL
+#elif (HAVE_HOOK_HMEM)
 #  define HOOK_HMEM_INI INI_SIG(fi_hook_hmem_ini)
 #  define HOOK_HMEM_INIT fi_hook_hmem_ini()
 HOOK_HMEM_INI ;

--- a/prov/hook/hook_debug/Makefile.include
+++ b/prov/hook/hook_debug/Makefile.include
@@ -1,13 +1,29 @@
 if HAVE_HOOK_DEBUG
+
 _hook_debug_files = \
 	prov/hook/hook_debug/src/hook_debug.c
 
 _hook_debug_headers = \
 	prov/hook/hook_debug/include/hook_debug.h
 
-
+if HAVE_HOOK_DEBUG_DL
+pkglib_LTLIBRARIES += libhook_debug-fi.la
+libhook_debug_fi_la_SOURCES =	$(_hook_debug_files) \
+				$(_hook_debug_headers) \
+				$(common_hook_srcs) \
+				$(common_srcs)
+libhook_debug_fi_la_CPPFLAGS =	$(AM_CPPFLAGS) \
+				-I$(top_srcdir)/prov/hook/include \
+				-I$(top_srcdir)/prov/hook/perf/include \
+				-I$(top_srcdir)/prov/hook/hook_debug/include
+libhook_debug_fi_la_LIBADD =	$(linkback) $(hook_debug_shm_LIBS)
+libhook_debug_fi_la_LDFLAGS =	-module -avoid-version -shared -export-dynamic
+libhook_debug_fi_la_DEPENDENCIES = $(linkback)
+else !HAVE_HOOK_DEBUG_DL
 src_libfabric_la_SOURCES  +=	$(_hook_debug_files) \
 				$(_hook_debug_headers)
 src_libfabric_la_CPPFLAGS +=	-I$(top_srcdir)/prov/hook/hook_debug/include
 src_libfabric_la_LIBADD	  +=	$(hook_debug_shm_LIBS)
+endif !HAVE_HOOK_DEBUG_DL
+
 endif HAVE_HOOK_DEBUG

--- a/prov/hook/hook_debug/configure.m4
+++ b/prov/hook/hook_debug/configure.m4
@@ -12,10 +12,5 @@ AC_DEFUN([FI_HOOK_DEBUG_CONFIGURE],[
     # Determine if we can support the debug hooking provider
     hook_debug_happy=0
     AS_IF([test x"$enable_hook_debug" != x"no"], [hook_debug_happy=1])
-    AS_IF([test x"$hook_debug_dl" = x"1"], [
-	hook_debug_happy=0
-	AC_MSG_ERROR([debug hooking provider cannot be compiled as DL])
-    ])
     AS_IF([test $hook_debug_happy -eq 1], [$1], [$2])
-
 ])

--- a/prov/hook/hook_hmem/Makefile.include
+++ b/prov/hook/hook_hmem/Makefile.include
@@ -1,13 +1,29 @@
 if HAVE_HOOK_HMEM
+
 _hmemhook_files = \
 	prov/hook/hook_hmem/src/hook_hmem.c
 
 _hmemhook_headers = \
 	prov/hook/hook_hmem/include/hook_hmem.h
 
-
+if HAVE_HOOK_HMEM_DL
+pkglib_LTLIBRARIES += libhook_hmem-fi.la
+libhook_hmem_fi_la_SOURCES =	$(_hmemhook_files) \
+				$(_hmemhook_headers) \
+				$(common_hook_srcs) \
+				$(common_srcs)
+libhook_hmem_fi_la_CPPFLAGS =	$(AM_CPPFLAGS) \
+				-I$(top_srcdir)/prov/hook/include \
+				-I$(top_srcdir)/prov/hook/perf/include \
+				-I$(top_srcdir)/prov/hook/hook_hmem/include
+libhook_hmem_fi_la_LIBADD =	$(linkback) $(hook_hmem_shm_LIBS)
+libhook_hmem_fi_la_LDFLAGS =	-module -avoid-version -shared -export-dynamic
+libhook_hmem_fi_la_DEPENDENCIES = $(linkback)
+else !HAVE_HOOK_HMEM_DL
 src_libfabric_la_SOURCES  +=	$(_hmemhook_files) \
 				$(_hmemhook_headers)
 src_libfabric_la_CPPFLAGS +=	-I$(top_srcdir)/prov/hook/hook_hmem/include
 src_libfabric_la_LIBADD	  +=	$(hmemhook_shm_LIBS)
+endif !HAVE_HOOK_HMEM_DL
+
 endif HAVE_HOOK_HMEM

--- a/prov/hook/hook_hmem/configure.m4
+++ b/prov/hook/hook_hmem/configure.m4
@@ -12,9 +12,5 @@ AC_DEFUN([FI_HOOK_HMEM_CONFIGURE],[
     # Determine if we can support the hmem hooking provider
     hook_hmem_happy=0
     AS_IF([test x"$enable_hook_hmem" != x"no"], [hook_hmem_happy=1])
-    AS_IF([test x"$hook_hmem_dl" = x"1"], [
-	hook_hmem_happy=0
-	AC_MSG_ERROR([hmem hooking provider cannot be compiled as DL])
-    ])
     AS_IF([test $hook_hmem_happy -eq 1], [$1], [$2])
 ])

--- a/prov/hook/hook_hmem/src/hook_hmem.c
+++ b/prov/hook/hook_hmem/src/hook_hmem.c
@@ -1912,6 +1912,9 @@ out:
 
 HOOK_HMEM_INI
 {
+#ifdef HAVE_HOOK_HMEM_DL
+	ofi_hmem_init();
+#endif
 	hook_hmem_fabric_ops = hook_fabric_ops;
 	hook_hmem_fabric_ops.domain = hook_hmem_domain;
 

--- a/prov/hook/perf/Makefile.include
+++ b/prov/hook/perf/Makefile.include
@@ -1,13 +1,29 @@
 if HAVE_PERF
+
 _perfhook_files = \
 	prov/hook/perf/src/hook_perf.c
 
 _perfhook_headers = \
 	prov/hook/perf/include/hook_perf.h
 
-
+if HAVE_PERF_DL
+pkglib_LTLIBRARIES += libperf-fi.la
+libperf_fi_la_SOURCES =	$(_perfhook_files) \
+			$(_perfhook_headers) \
+			$(common_hook_srcs) \
+			$(common_srcs)
+libperf_fi_la_CPPFLAGS = $(AM_CPPFLAGS) \
+			 -I$(top_srcdir)/prov/hook/include \
+			 -I$(top_srcdir)/prov/hook/perf/include
+libperf_fi_la_LIBADD = $(linkback) $(perfhook_shm_LIBS)
+libperf_fi_la_LDFLAGS = -module -avoid-version -shared -export-dynamic
+libperf_fi_la_DEPENDENCIES = $(linkback)
+else !HAVE_PERF_DL
 src_libfabric_la_SOURCES  +=	$(_perfhook_files) \
 				$(_perfhook_headers)
-src_libfabric_la_CPPFLAGS +=	-I$(top_srcdir)/prov/hook/perf/include
 src_libfabric_la_LIBADD	  +=	$(perfhook_shm_LIBS)
+endif !HAVE_PERF_DL
+
+src_libfabric_la_CPPFLAGS +=	-I$(top_srcdir)/prov/hook/perf/include
+
 endif HAVE_PERF

--- a/prov/hook/perf/configure.m4
+++ b/prov/hook/perf/configure.m4
@@ -12,10 +12,5 @@ AC_DEFUN([FI_PERF_CONFIGURE],[
     # Determine if we can support the perf hooking provider
     perf_happy=0
     AS_IF([test x"$enable_perf" != x"no"], [perf_happy=1])
-    AS_IF([test x"$perf_dl" = x"1"], [
-	perf_happy=0
-	AC_MSG_ERROR([perf provider cannot be compiled as DL])
-    ])
     AS_IF([test $perf_happy -eq 1], [$1], [$2])
-
 ])


### PR DESCRIPTION
This allows upgrading hooking providers in an existing libfabric
installation, or distributing hooking providers separately

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>