### PR TITLE
runfabtests.py: exit with exit code of pytest

### DIFF
--- a/fabtests/scripts/runfabtests.py
+++ b/fabtests/scripts/runfabtests.py
@@ -299,6 +299,6 @@ def main():
     print(pytest_command)
 
     # actually running tests
-    pytest.main(pytest_args)
+    exit(pytest.main(pytest_args))
 
 main()


### PR DESCRIPTION
Currently, runfabtests.py exists with code 0 when
tests has been run succefully, even when some tests
failed.
To address this issue, this patch makes runfabtests.py
to exit with the exit code of pytest.

For reference, pytest return codes are:

  0: All tests were collected and passed successfully
  1: Tests were collected and run but some of the tests failed
  2: Test execution was interrupted by the user
  3: Internal error happened while executing tests
  4: pytest command line usage error
  5: No tests were collected

as documented in

https://docs.pytest.org/en/latest/reference/exit-codes.html

Signed-off-by: Wei Zhang <wzam@amazon.com>