### PR TITLE
core/log,common: move log_prefix to common.c

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -2272,3 +2272,6 @@ size_t ofi_vrb_speed(uint8_t speed, uint8_t width)
 
 	return width_val * speed_val;
 }
+
+/* log_prefix is used by fi_log and by prov/util */
+const char *log_prefix = "";

--- a/src/log.c
+++ b/src/log.c
@@ -81,7 +81,6 @@ enum {
 static int log_interval = 2000;
 uint64_t log_mask;
 struct fi_filter prov_log_filter;
-const char *log_prefix = "";
 
 static pid_t pid;
 


### PR DESCRIPTION
Previous commit introduced a global variable log_prefix to src/log.c,
and log_prefix is accessed by prov/util/src/util_attr.c

However, src/log.c is not part of common_srcs, thus the variable
in it is not available to dso build of provider.

This patch addresses the issue by move log_prefix to src/common.c.

Signed-off-by: Wei Zhang <wzam@amazon.com>