### PR TITLE
fabtests/prov/efa: Make sure trigger_rnr_queue_resend returns 0 on success

### DIFF
--- a/fabtests/prov/efa/src/rdm_rnr_queue_resend.c
+++ b/fabtests/prov/efa/src/rdm_rnr_queue_resend.c
@@ -186,7 +186,7 @@ static int trigger_rnr_queue_resend(enum fi_op atomic_op, void *result, void *co
 				return ret;
 		}
 	}
-	return ret;
+	return 0;
 }
 
 static int rnr_queue_resend_test(int req_pkt, enum fi_op atomic_op)


### PR DESCRIPTION
Resolve compilation warning with trigger_rnr_queue_resend returning uninitialized
ret on success.

Signed-off-by: Chien Tin Tung <chien.tin.tung@intel.com>