### PR TITLE
include/rdma: Simplify version check macros

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -91,14 +91,8 @@ enum {
 #define FI_VERSION(major, minor) (((major) << 16) | (minor))
 #define FI_MAJOR(version)	(version >> 16)
 #define FI_MINOR(version)	(version & 0xFFFF)
-#define FI_VERSION_GE(v1, v2)   ((FI_MAJOR(v1) > FI_MAJOR(v2)) || \
-				 (FI_MAJOR(v1) == FI_MAJOR(v2) && \
-				  FI_MINOR(v1) == FI_MINOR(v2)) || \
-				 (FI_MAJOR(v1) == FI_MAJOR(v2) && \
-				  FI_MINOR(v1) > FI_MINOR(v2)))
-#define FI_VERSION_LT(v1, v2)	((FI_MAJOR(v1) < FI_MAJOR(v2)) || \
-				 (FI_MAJOR(v1) == FI_MAJOR(v2) && \
-				  FI_MINOR(v1) < FI_MINOR(v2)))
+#define FI_VERSION_GE(v1, v2)	(v1 >= v2)
+#define FI_VERSION_LT(v1, v2)	(v1 < v2)
 
 uint32_t fi_version(void);
 


### PR DESCRIPTION
For version check, it is not necessary to check major and minor
separately.  Macros can be simplified to check the whole version
number with >= and < operators.

Signed-off-by: Chien Tin Tung <chien.tin.tung@intel.com>