### PR TITLE
prov/rxm: Fix race handling unexpected messages

### DIFF
--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -82,12 +82,21 @@ static int rxm_match_recv_entry_context(struct dlist_entry *item, const void *co
 	return recv_entry->context == context;
 }
 
+static fi_addr_t rxm_get_unexp_addr(struct rxm_unexp_msg *unexp_msg)
+{
+	struct rxm_rx_buf *rx_buf;
+
+	rx_buf = container_of(unexp_msg, struct rxm_rx_buf, unexp_msg);
+	return (unexp_msg->addr != FI_ADDR_UNSPEC) ?
+		unexp_msg->addr : rx_buf->conn->peer->fi_addr;
+}
+
 static int rxm_match_unexp_msg(struct dlist_entry *item, const void *arg)
 {
 	struct rxm_recv_match_attr *attr = (struct rxm_recv_match_attr *)arg;
 	struct rxm_unexp_msg *unexp_msg =
 		container_of(item, struct rxm_unexp_msg, entry);
-	return ofi_match_addr(attr->addr, unexp_msg->addr);
+	return ofi_match_addr(attr->addr, rxm_get_unexp_addr(unexp_msg));
 }
 
 static int rxm_match_unexp_msg_tag(struct dlist_entry *item, const void *arg)
@@ -103,7 +112,7 @@ static int rxm_match_unexp_msg_tag_addr(struct dlist_entry *item, const void *ar
 	struct rxm_recv_match_attr *attr = (struct rxm_recv_match_attr *) arg;
 	struct rxm_unexp_msg *unexp_msg =
 		container_of(item, struct rxm_unexp_msg, entry);
-	return ofi_match_addr(attr->addr, unexp_msg->addr) &&
+	return ofi_match_addr(attr->addr, rxm_get_unexp_addr(unexp_msg)) &&
 		ofi_match_tag(attr->tag, attr->ignore, unexp_msg->tag);
 }
 


### PR DESCRIPTION
If we receive an unexpected message from a peer that we
have not yet inserted into the local AV, no source address
will be available for that message.  Instead the source
address will be set to FI_ADDR_UNSPEC.  Later, after the
address is inserted into the AV, a message may be posted
referencing the source address.  However, no match will
be made, since the source address was not available
when the message was queued.

This problem occurs during MPI start-up in all to all
communication patters.

To provide source address matching in this case, if the
source address saved with the unexpected message is
FI_ADDR_UNSPEC, retrieve the address currently assigned
to the connection that the message arrived on.  Once the
peer's address is inserted into the AV, the connection
will be updated with the correct source address, allowing
a correct match to be made.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>