### PR TITLE
prov/rxm: Add PID to CM messages

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -96,6 +96,20 @@ union rxm_cm_data {
 	} reject;
 };
 
+static inline uint64_t rxm_conn_id(int peer_index)
+{
+	return (((uint64_t) getpid()) << 32) | ((uint32_t) peer_index);
+}
+
+static inline int rxm_peer_index(uint64_t conn_id)
+{
+	return (int) conn_id;
+}
+
+static inline uint32_t rxm_peer_pid(uint64_t conn_id)
+{
+	return (uint32_t) (conn_id >> 32);
+}
 
 extern size_t rxm_buffer_size;
 extern size_t rxm_packet_size;
@@ -231,6 +245,7 @@ struct rxm_conn {
 	 * the peer_addr.
 	 */
 	int remote_index;
+	uint32_t remote_pid;
 	uint8_t flags;
 
 	struct dlist_entry deferred_entry;


### PR DESCRIPTION
There are 2 situations where we can receive a connection request
from a peer where we already have a connection that's active.

In one case, the connection may be an older connection to the
same node, but to a client that's no longer running.  In this case,
the old connection needs to be closed and the new connection
accepted.  This is the behavior of the current code.  The code
was structured this way to handle a situation where a client
crashed and was restarted, with the new client choosing the same
network address.  Unless the old connection discarded and the new
request accepted, the re-started client would not be able to
communicate with a running server.

In the second case, the connection may have just been created,
with the request being for a simultaneous connection.  This
occurs frequently during MPI startup when all to all communication
is needed.  Although rxm has code to detect simultaneous
connections, the order of CM events as seen by one node may differ
from those seen by another node.  Long story short, one rank may
detect the simultaneous connection request, accepting one, while
rejecting or discarding the other.  But the peer may see that it's
connection request was accepted, transition into a connected state,
then get the connection request from the peer (which the peer has
already decided to discard).  Because transfers may already be
active on the newly formed connection, tearing it down would result
in communication failures.  This has been seen to result in MPI
hanging, since messages have now been lost.

To distinguish between these 2 cases, which require separate
handling, we add a process ID to the CM protocol.  In order to
maintain backwards compatilibity, the PID is added into the
server and client conn_id.  (This means that rxm can now only support
4 billion peers, instead of whatever 2^64 is.)  Existing rxm
implementation will simply reflect the conn_id value back, so we
can mask off the upper bits to convert the conn_id back into an
index.  New implementations of rxm will write their PID into the
upper bits.  If the PID isn't set, the existing behavior will be
used, as we can't distinguish between the above 2 cases.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>