### PR TITLE
core + prov/efa: Request page alignment for buffer pools

### DIFF
--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -289,6 +289,7 @@ enum {
 	OFI_BUFPOOL_INDEXED		= 1 << 1,
 	OFI_BUFPOOL_NO_TRACK		= 1 << 2,
 	OFI_BUFPOOL_HUGEPAGES		= 1 << 3,
+	OFI_BUFPOOL_PAGE_ALIGNED	= 1 << 4,
 };
 
 struct ofi_bufpool_region;


### PR DESCRIPTION
This lets us safely use MADV_DONTFORK without worrying about the buffer sharing a page with an unrelated allocation.  

We also have to make the allocation size aligned to avoid the same page sharing issue at the end of the buffer.

