### PR TITLE
fabtests/pytest/efa: remove fi_rdm test for a hardware issue.

### DIFF
--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -1,6 +1,5 @@
 import pytest
 
-from default.test_rdm import test_rdm
 from default.test_rdm import test_rdm_bw_functional
 from default.test_rdm import test_rdm_atomic
 


### PR DESCRIPTION
There is an ongoing hardware issue that will cause fi_rdm test
to fail. This patch remove the test for now to mitigate it.

Signed-off-by: Wei Zhang <wzam@amazon.com>