### PR TITLE
fabtests/common: add option to configure message sizes 

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -3102,9 +3102,9 @@ void ft_parsecsopts(int op, char *optarg, struct ft_opts *opts)
 		break;
 	case 'S':
 		if (!strncasecmp("all", optarg, 3)) {
-			opts->sizes_enabled = FT_ENABLE_ALL;
+			opts->sizes_enabled = FT_ENABLE_SIZES;
 		} else if (!strncasecmp("r:", optarg, 2)){
-			opts->sizes_enabled = FT_ENABLE_ALL;
+			opts->sizes_enabled = FT_ENABLE_SIZES;
 			ft_parse_opts_range(optarg);
 		} else {
 			opts->options |= FT_OPT_SIZE;

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -82,7 +82,7 @@ extern struct test_size_param *test_size;
 extern unsigned int test_cnt;
 #define TEST_CNT test_cnt
 
-#define FT_ENABLE_ALL		(~0)
+#define FT_ENABLE_SIZES		(~0)
 #define FT_DEFAULT_SIZE		(1 << 0)
 
 enum precision {
@@ -305,7 +305,7 @@ size_t datatype_to_size(enum fi_datatype datatype);
 static inline int ft_use_size(int index, int enable_flags)
 {
 	return test_size[index].size <= fi->ep_attr->max_msg_size &&
-		((enable_flags == FT_ENABLE_ALL) ||
+		((enable_flags == FT_ENABLE_SIZES) ||
 		(enable_flags & test_size[index].enable_flags));
 }
 

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -78,8 +78,8 @@ struct test_size_param {
 	int enable_flags;
 };
 
-extern struct test_size_param test_size[];
-extern const unsigned int test_cnt;
+extern struct test_size_param *test_size;
+extern unsigned int test_cnt;
 #define TEST_CNT test_cnt
 
 #define FT_ENABLE_ALL		(~0)
@@ -508,7 +508,7 @@ void show_perf(char *name, size_t tsize, int iters, struct timespec *start,
 		struct timespec *end, int xfers_per_iter);
 void show_perf_mr(size_t tsize, int iters, struct timespec *start,
 		struct timespec *end, int xfers_per_iter, int argc, char *argv[]);
-
+void ft_parse_opts_range(char *optarg);
 int ft_send_recv_greeting(struct fid_ep *ep);
 int ft_send_greeting(struct fid_ep *ep);
 int ft_recv_greeting(struct fid_ep *ep);

--- a/fabtests/pytest/efa/conftest.py
+++ b/fabtests/pytest/efa/conftest.py
@@ -4,3 +4,8 @@ import pytest
                                         "cuda_to_host", "cuda_to_cuda"])
 def memory_type(request):
     return request.param
+
+@pytest.fixture(scope="module", params=["r:8000,4,9000", 
+                                         "r:0,4,64", "r:4048,4,4148"])
+def message_size_range(request):
+    return request.param

--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -3,13 +3,12 @@ import pytest
 from default.test_rdm import test_rdm_bw_functional
 from default.test_rdm import test_rdm_atomic
 
-
-def run_rdm_test(cmdline_args, executable, iteration_type, completion_type, memory_type):
+def run_rdm_test(cmdline_args, executable, iteration_type, completion_type, memory_type, message_size_range):
     from common import ClientServerTest
     test = ClientServerTest(cmdline_args, executable, iteration_type,
                             completion_type=completion_type,
                             datacheck_type="with_datacheck",
-                            message_size="all",
+                            message_size_range=message_size_range,
                             memory_type=memory_type)
     test.run()
 
@@ -18,18 +17,33 @@ def run_rdm_test(cmdline_args, executable, iteration_type, completion_type, memo
                           pytest.param("standard", marks=pytest.mark.standard)])
 def test_rdm_pingpong(cmdline_args, iteration_type, completion_type, memory_type):
     run_rdm_test(cmdline_args, "fi_rdm_pingpong", iteration_type,
-                 completion_type, memory_type)
+            completion_type, memory_type, "all")
+
+@pytest.mark.functional
+def test_rdm_pingpong_range(cmdline_args, completion_type, memory_type, message_size_range):
+    run_rdm_test(cmdline_args, "fi_rdm_pingpong", "short",
+                 completion_type, memory_type, message_size_range)
 
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
 def test_rdm_tagged_pingpong(cmdline_args, iteration_type, completion_type, memory_type):
     run_rdm_test(cmdline_args, "fi_rdm_tagged_pingpong", iteration_type,
-                 completion_type, memory_type)
+                 completion_type, memory_type, "all")
+
+@pytest.mark.functional
+def test_rdm_tagged_pingpong_range(cmdline_args, completion_type, memory_type, message_size_range):
+    run_rdm_test(cmdline_args, "fi_rdm_tagged_pingpong", "short",
+                 completion_type, memory_type, message_size_range)
 
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
 def test_rdm_tagged_bw(cmdline_args, iteration_type, completion_type, memory_type):
     run_rdm_test(cmdline_args, "fi_rdm_tagged_bw", iteration_type,
-                 completion_type, memory_type)
+                 completion_type, memory_type, "all")
+
+@pytest.mark.functional
+def test_rdm_tagged_bw_range(cmdline_args, completion_type, memory_type, message_size_range):
+    run_rdm_test(cmdline_args, "fi_rdm_tagged_bw", "short",
+                 completion_type, memory_type, message_size_range)

--- a/fabtests/pytest/efa/test_rma_bw.py
+++ b/fabtests/pytest/efa/test_rma_bw.py
@@ -8,6 +8,14 @@ def test_rma_bw(cmdline_args, iteration_type, operation_type, completion_type):
     from common import ClientServerTest
     command = "fi_rma_bw -e rdm"
     command = command + " -o " + operation_type
-    test = ClientServerTest(cmdline_args, command, iteration_type, completion_type, message_size="all")
+    test = ClientServerTest(cmdline_args, command, iteration_type, completion_type, message_size_range="all")
     test.run()
 
+@pytest.mark.functional
+@pytest.mark.parametrize("operation_type", ["read", "writedata", "write"])
+def test_rma_bw_range(cmdline_args, operation_type, completion_type, message_size_range):
+    from common import ClientServerTest
+    command = "fi_rma_bw -e rdm"
+    command = command + " -o " + operation_type
+    test = ClientServerTest(cmdline_args, command, iteration_type="short", completion_type=completion_type, message_size_range=message_size_range)
+    test.run()


### PR DESCRIPTION
The change adds an option to specify a range of messages
to fabtests by using the format 'r:start,increment,end'
to the "-S" option. Prior to this change, we were able to
provide "all" or a specific size to the message size option.

Updates have been made to pytest/efa tests to use this option
for message sizes in the range of 8k-9k with an increment of 4.

Tests were conducted using runfabtests.py to ensure the message
ranges are being processed by pytest (cuda testing is not done).