### PR TITLE
src/linux: fixed stringop-truncation in ofi_ifaddr_get_speed

### DIFF
--- a/src/linux/osd.c
+++ b/src/linux/osd.c
@@ -120,8 +120,7 @@ size_t ofi_ifaddr_get_speed(struct ifaddrs *ifa)
 	if (fd < 0)
 		return 0;
 
-	strncpy(ifr.ifr_name, ifa->ifa_name, IF_NAMESIZE);
-	ifr.ifr_name[IF_NAMESIZE - 1] = '\0';
+	strncpy(ifr.ifr_name, ifa->ifa_name, sizeof(ifr.ifr_name) - 1);
 
 	ret = ioctl(fd, SIOCETHTOOL, &ifr);
 	if (ret) {


### PR DESCRIPTION
found using gcc -fsanitize=address.
error: ‘strncpy’ specified bound 16 equals destination size

Signed-off-by: Denis Maryin <denis.maryin@intel.com>