### PR TITLE
fabtests: Introduce "--pin_core" option

### DIFF
--- a/fabtests/benchmarks/dgram_pingpong.c
+++ b/fabtests/benchmarks/dgram_pingpong.c
@@ -90,13 +90,15 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, "hT:" CS_OPTS INFO_OPTS BENCHMARK_OPTS)) !=
-			-1) {
+	while ((op = getopt_long(argc, argv, "hT:" CS_OPTS INFO_OPTS BENCHMARK_OPTS,
+				 long_opts, &lopt_idx)) != -1) {
 		switch (op) {
 		case 'T':
 			timeout = atoi(optarg);
 			break;
 		default:
+			if (!ft_parse_long_opts(op, optarg))
+				continue;
 			ft_parse_benchmark_opts(op, optarg);
 			ft_parseinfo(op, optarg, hints, &opts);
 			ft_parsecsopts(op, optarg, &opts);
@@ -107,6 +109,7 @@ int main(int argc, char **argv)
 			ft_benchmark_usage();
 			FT_PRINT_OPTS_USAGE("-T <timeout>",
 					"seconds before timeout on receive");
+			ft_longopts_usage();
 			return EXIT_FAILURE;
 		}
 	}

--- a/fabtests/benchmarks/msg_bw.c
+++ b/fabtests/benchmarks/msg_bw.c
@@ -84,10 +84,12 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, "h" CS_OPTS INFO_OPTS
-			    API_OPTS BENCHMARK_OPTS)) != -1) {
+	while ((op = getopt_long(argc, argv, "h" CS_OPTS INFO_OPTS API_OPTS
+				 BENCHMARK_OPTS, long_opts, &lopt_idx)) != -1) {
 		switch (op) {
 		default:
+			if (!ft_parse_long_opts(op, optarg))
+				continue;
 			ft_parse_benchmark_opts(op, optarg);
 			ft_parseinfo(op, optarg, hints, &opts);
 			ft_parsecsopts(op, optarg, &opts);
@@ -97,6 +99,7 @@ int main(int argc, char **argv)
 		case 'h':
 			ft_csusage(argv[0], "Bandwidth test for MSG endpoints.");
 			ft_benchmark_usage();
+			ft_longopts_usage();
 			return EXIT_FAILURE;
 		}
 	}

--- a/fabtests/benchmarks/msg_pingpong.c
+++ b/fabtests/benchmarks/msg_pingpong.c
@@ -84,11 +84,12 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, "h" CS_OPTS INFO_OPTS
-			    API_OPTS BENCHMARK_OPTS)) !=
-			-1) {
+	while ((op = getopt_long(argc, argv, "h" CS_OPTS INFO_OPTS API_OPTS
+				 BENCHMARK_OPTS, long_opts, &lopt_idx)) != -1) {
 		switch (op) {
 		default:
+			if (!ft_parse_long_opts(op, optarg))
+				continue;
 			ft_parse_benchmark_opts(op, optarg);
 			ft_parseinfo(op, optarg, hints, &opts);
 			ft_parsecsopts(op, optarg, &opts);
@@ -98,6 +99,7 @@ int main(int argc, char **argv)
 		case 'h':
 			ft_csusage(argv[0], "Ping pong client and server using message endpoints.");
 			ft_benchmark_usage();
+			ft_longopts_usage();
 			return EXIT_FAILURE;
 		}
 	}

--- a/fabtests/benchmarks/rdm_cntr_pingpong.c
+++ b/fabtests/benchmarks/rdm_cntr_pingpong.c
@@ -78,9 +78,12 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, "h" CS_OPTS INFO_OPTS BENCHMARK_OPTS)) != -1) {
+	while ((op = getopt_long(argc, argv, "h" CS_OPTS INFO_OPTS BENCHMARK_OPTS,
+				 long_opts, &lopt_idx)) != -1) {
 		switch (op) {
 		default:
+			if (!ft_parse_long_opts(op, optarg))
+				continue;
 			ft_parse_benchmark_opts(op, optarg);
 			ft_parseinfo(op, optarg, hints, &opts);
 			ft_parsecsopts(op, optarg, &opts);
@@ -89,6 +92,7 @@ int main(int argc, char **argv)
 		case 'h':
 			ft_csusage(argv[0], "Ping pong client and server using counters.");
 			ft_benchmark_usage();
+			ft_longopts_usage();
 			return EXIT_FAILURE;
 		}
 	}

--- a/fabtests/benchmarks/rdm_pingpong.c
+++ b/fabtests/benchmarks/rdm_pingpong.c
@@ -74,10 +74,12 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, "Uh" CS_OPTS INFO_OPTS BENCHMARK_OPTS)) !=
-			-1) {
+	while ((op = getopt_long(argc, argv, "Uh" CS_OPTS INFO_OPTS BENCHMARK_OPTS,
+				 long_opts, &lopt_idx)) != -1) {
 		switch (op) {
 		default:
+			if (!ft_parse_long_opts(op, optarg))
+				continue;
 			ft_parse_benchmark_opts(op, optarg);
 			ft_parseinfo(op, optarg, hints, &opts);
 			ft_parsecsopts(op, optarg, &opts);
@@ -89,6 +91,7 @@ int main(int argc, char **argv)
 		case 'h':
 			ft_csusage(argv[0], "Ping pong client and server using RDM.");
 			ft_benchmark_usage();
+			ft_longopts_usage();
 			return EXIT_FAILURE;
 		}
 	}

--- a/fabtests/benchmarks/rdm_tagged_bw.c
+++ b/fabtests/benchmarks/rdm_tagged_bw.c
@@ -77,9 +77,12 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, "Uh" CS_OPTS INFO_OPTS BENCHMARK_OPTS)) != -1) {
+	while ((op = getopt_long(argc, argv, "Uh" CS_OPTS INFO_OPTS BENCHMARK_OPTS,
+				 long_opts, &lopt_idx)) != -1) {
 		switch (op) {
 		default:
+			if (!ft_parse_long_opts(op, optarg))
+				continue;
 			ft_parse_benchmark_opts(op, optarg);
 			ft_parseinfo(op, optarg, hints, &opts);
 			ft_parsecsopts(op, optarg, &opts);
@@ -91,6 +94,7 @@ int main(int argc, char **argv)
 		case 'h':
 			ft_csusage(argv[0], "Bandwidth test for RDM endpoints using tagged messages.");
 			ft_benchmark_usage();
+			ft_longopts_usage();
 			return EXIT_FAILURE;
 		}
 	}

--- a/fabtests/benchmarks/rdm_tagged_pingpong.c
+++ b/fabtests/benchmarks/rdm_tagged_pingpong.c
@@ -76,9 +76,12 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, "Uh" CS_OPTS INFO_OPTS BENCHMARK_OPTS)) != -1) {
+	while ((op = getopt_long(argc, argv, "Uh" CS_OPTS INFO_OPTS BENCHMARK_OPTS,
+				 long_opts, &lopt_idx)) != -1) {
 		switch (op) {
 		default:
+			if (!ft_parse_long_opts(op, optarg))
+				continue;
 			ft_parse_benchmark_opts(op, optarg);
 			ft_parseinfo(op, optarg, hints, &opts);
 			ft_parsecsopts(op, optarg, &opts);
@@ -90,6 +93,7 @@ int main(int argc, char **argv)
 		case 'h':
 			ft_csusage(argv[0], "Ping pong client and server using tagged messages.");
 			ft_benchmark_usage();
+			ft_longopts_usage();
 			return EXIT_FAILURE;
 		}
 	}

--- a/fabtests/benchmarks/rma_bw.c
+++ b/fabtests/benchmarks/rma_bw.c
@@ -97,10 +97,12 @@ int main(int argc, char **argv)
 	hints->domain_attr->threading = FI_THREAD_DOMAIN;
 	hints->addr_format = opts.address_format;
 
-	while ((op = getopt(argc, argv, "Uh" CS_OPTS INFO_OPTS API_OPTS
-			    BENCHMARK_OPTS)) != -1) {
+	while ((op = getopt_long(argc, argv, "Uh" CS_OPTS INFO_OPTS API_OPTS
+			    BENCHMARK_OPTS, long_opts, &lopt_idx)) != -1) {
 		switch (op) {
 		default:
+			if (!ft_parse_long_opts(op, optarg))
+				continue;
 			ft_parse_benchmark_opts(op, optarg);
 			ft_parseinfo(op, optarg, hints, &opts);
 			ft_parsecsopts(op, optarg, &opts);
@@ -120,6 +122,7 @@ int main(int argc, char **argv)
 			fprintf(stderr, "Note: read/write bw tests are bidirectional.\n"
 					"      writedata bw test is unidirectional"
 					" from the client side.\n");
+			ft_longopts_usage();
 			return EXIT_FAILURE;
 		}
 	}

--- a/fabtests/fabtests.vcxproj.filters
+++ b/fabtests/fabtests.vcxproj.filters
@@ -227,6 +227,9 @@
     <ClInclude Include="include\windows\unistd.h">
       <Filter>Header Files\osd</Filter>
     </ClInclude>
+    <ClInclude Include="include\windows\sched.h">
+      <Filter>Header Files\osd</Filter>
+    </ClInclude>
     <ClInclude Include="include\windows\sys\socket.h">
       <Filter>Header Files\osd\sys</Filter>
     </ClInclude>

--- a/fabtests/functional/multi_recv.c
+++ b/fabtests/functional/multi_recv.c
@@ -279,9 +279,12 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, "Mhv" CS_OPTS INFO_OPTS)) != -1) {
+	while ((op = getopt_long(argc, argv, "Mhv" CS_OPTS INFO_OPTS,
+				 long_opts, &lopt_idx)) != -1) {
 		switch (op) {
 		default:
+			if (!ft_parse_long_opts(op, optarg))
+				continue;
 			ft_parseinfo(op, optarg, hints, &opts);
 			ft_parsecsopts(op, optarg, &opts);
 			break;
@@ -297,6 +300,7 @@ int main(int argc, char **argv)
 				"Streaming RDM client-server using multi recv buffer.");
 			FT_PRINT_OPTS_USAGE("-M", "enable testing with fi_recvmsg");
 			FT_PRINT_OPTS_USAGE("-v", "Enable data verification");
+			ft_longopts_usage();
 			return EXIT_FAILURE;
 		}
 	}

--- a/fabtests/functional/rdm_atomic.c
+++ b/fabtests/functional/rdm_atomic.c
@@ -503,7 +503,8 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, "ho:Uz:" CS_OPTS INFO_OPTS)) != -1) {
+	while ((op = getopt_long(argc, argv, "ho:Uz:" CS_OPTS INFO_OPTS,
+				 long_opts, &lopt_idx)) != -1) {
 		switch (op) {
 		case 'o':
 			if (!strncasecmp("all", optarg, 3)) {
@@ -533,12 +534,15 @@ int main(int argc, char **argv)
 			}
 			break;
 		default:
+			if (!ft_parse_long_opts(op, optarg))
+				continue;
 			ft_parseinfo(op, optarg, hints, &opts);
 			ft_parsecsopts(op, optarg, &opts);
 			break;
 		case '?':
 		case 'h':
 			print_opts_usage(argv[0]);
+			ft_longopts_usage();
 			return EXIT_FAILURE;
 		}
 	}

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -41,6 +41,7 @@
 #include <sys/uio.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <getopt.h>
 
 #include <rdma/fabric.h>
 #include <rdma/fi_rma.h>
@@ -143,6 +144,10 @@ enum ft_atomic_opcodes {
 enum op_state {
 	OP_DONE = 0,
 	OP_PENDING
+};
+
+enum {
+	LONG_OPT_PIN_CORE = 1,
 };
 
 struct ft_context {
@@ -293,6 +298,9 @@ extern char default_port[8];
 #define FT_RX_MR_KEY 0xFFFF
 #define FT_MSG_MR_ACCESS (FI_SEND | FI_RECV)
 #define FT_RMA_MR_ACCESS (FI_READ | FI_WRITE | FI_REMOTE_READ | FI_REMOTE_WRITE)
+
+extern int lopt_idx;
+extern struct option long_opts[];
 
 int ft_getsrcaddr(char *node, char *service, struct fi_info *hints);
 int ft_read_addr_opts(char **node, char **service, struct fi_info *hints,
@@ -524,6 +532,8 @@ const char *ft_util_name(const char *str, size_t *len);
 const char *ft_core_name(const char *str, size_t *len);
 char **ft_split_and_alloc(const char *s, const char *delim, size_t *count);
 void ft_free_string_array(char **s);
+int ft_parse_long_opts(int op, char *optarg);
+void ft_longopts_usage();
 
 #define FT_PROCESS_QUEUE_ERR(readerr, rd, queue, fn, str)	\
 	do {							\

--- a/fabtests/include/windows/sched.h
+++ b/fabtests/include/windows/sched.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2022 Amazon.com, Inc. or its affiliates. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _WINDOWS_SCHED_H_
+#define _WINDOWS_SCHED_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <windows.h>
+#include <processthreadsapi.h>
+#include "osd.h"
+
+/* Type for array elements in 'cpu_set_t'. */
+typedef unsigned long int __cpu_mask;
+
+/* Size definition for CPU sets. */
+#define __CPU_SETSIZE  1024
+#define __NCPUBITS     (8 * sizeof (__cpu_mask))
+
+/* Data structure to describe CPU mask. */
+typedef struct cpu_set_s
+{
+    __cpu_mask __bits[__CPU_SETSIZE / __NCPUBITS];
+} cpu_set_t;
+
+/* Basic access functions.  */
+#define __CPUELT(cpu)  ((cpu) / __NCPUBITS)
+#define __CPUMASK(cpu) ((__cpu_mask) 1 << ((cpu) % __NCPUBITS))
+
+
+#define CPU_ZERO(cpusetp)	__CPU_ZERO_S(sizeof(cpu_set_t), cpusetp)
+#define CPU_SET(cpu, cpusetp)	__CPU_SET_S(cpu, sizeof(cpu_set_t), cpusetp)
+
+#define __CPU_ZERO_S(setsize, cpusetp)				\
+  do {								\
+	size_t __i;						\
+        size_t __imax = (setsize) / sizeof(__cpu_mask);		\
+        __cpu_mask *__bits = (cpusetp)->__bits;			\
+        for (__i = 0; __i < __imax; ++__i)			\
+		__bits[__i] = 0;				\
+  } while (0)
+
+#define __CPU_SET_S(cpu, setsize, cpusetp) 			\
+  size_t __cpu = (cpu);						\
+  __cpu < 8 * (setsize)						\
+  ? (((__cpu_mask *) ((cpusetp)->__bits))[__CPUELT (__cpu)]	\
+     |= __CPUMASK (__cpu))					\
+  : 0;
+
+
+static inline int sched_setaffinity(pid_t pid, size_t cpusetsize, cpu_set_t *mask)
+{
+	HANDLE process_handle;
+
+	if (cpusetsize == 0 || mask == NULL)
+		return -1;
+
+	process_handle = OpenProcess(PROCESS_ALL_ACCESS, FALSE, pid);
+	if (process_handle == NULL)
+		return -1;
+
+	if (SetProcessAffinityMask(process_handle, *mask->__bits) == 0) {
+		CloseHandle(process_handle);
+		return -1;
+	}
+
+	return 0;
+}
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* _WINDOWS_SCHED_H_ */

--- a/fabtests/pytest/common.py
+++ b/fabtests/pytest/common.py
@@ -103,6 +103,8 @@ class ClientServerTest:
         if iteration_type == "short":
             command += " -I 5"
         elif iteration_type == "standard":
+            if not (self._cmdline_args.core_list is None):
+                command += " --pin-core " + self._cmdline_args.core_list
             pass
         elif iteration_type is None:
             pass

--- a/fabtests/pytest/conftest.py
+++ b/fabtests/pytest/conftest.py
@@ -20,6 +20,7 @@ def pytest_addoption(parser):
                      help="configure option for ubertest tests")
     parser.addoption("--timeout", dest="timeout", default="120",
                      help="timeout value for each test, default to 120 seconds")
+    parser.addoption("--pin-core", dest="core_list", type=str, help="Specify cores to pin when running standard tests. Cores can specified via a comma-delimited list, like 0,2-4")
     parser.addoption("--strict_fabtests_mode", dest="strict_fabtests_more", action="store_true",
                      help="strict mode. -FI_ENODATA and -FI_NOSYS treated as failure instead of skip/notrun") 
     parser.addoption("--additional_server_arguments", dest="additional_server_arguments", type=str,
@@ -73,6 +74,7 @@ class CmdlineArgs:
 
         self.ubertest_config_file = request.config.getoption("--ubertest_config_file")
         self.timeout = int(request.config.getoption("--timeout"))
+        self.core_list = request.config.getoption("--pin-core")
         self.strict_fabtests_mode = request.config.getoption("--strict_fabtests_mode")
         self.additional_server_arguments = request.config.getoption("--additional_server_arguments")
         self.additional_client_arguments = request.config.getoption("--additional_client_arguments")

--- a/fabtests/scripts/runfabtests.py
+++ b/fabtests/scripts/runfabtests.py
@@ -182,6 +182,9 @@ def fabtests_args_to_pytest_args(fabtests_args):
 
     pytest_args.append("--timeout={}".format(fabtests_args.timeout))
 
+    if fabtests_args.core_list:
+        pytest_args.append("--pin-core=" + fabtests_args.core_list)
+
     if fabtests_args.strict:
         pytest_args.append("--strict_fabtests_mode")
 
@@ -266,6 +269,7 @@ def main():
     parser.add_argument("-s", dest="server_interface", type=str, help="server interface")
     parser.add_argument("-u", dest="ubertest_config_file", type=str, help="configure option for ubertest tests")
     parser.add_argument("-T", dest="timeout", type=int, default=120, help="timeout value in seconds")
+    parser.add_argument("--pin-core", dest="core_list", type=str, help="Specify cores to pin when running standard tests. Cores can specified via a comma-delimited list, like 0,2-4")
     parser.add_argument("-S", dest="strict", action="store_true",
                         help="Strict mode: -FI_ENODATA, -FI_ENOSYS errors would be treated as failures"
                              " instead of skipped/notrun")


### PR DESCRIPTION
fabtests define a set of standard tests, which run large iterations. People might want to run them with core pinning to reliably track the performance.

This PR introduces a new option "--pin-core" to these tests, and runfabtests.sh/runfabtests.py scripts. It's disabled by default. To enable core pinning, it's required to provide an argument (core_list) to specify which cores to pin. The
core_list format uses a comma-separated list. e.g., fi_rdm_tagged_bw -p "efa" --pin-core 0,2-4 -E

Commit 1: introduces "--pin-core" option to the tests in standard tests list.
Commit 2: introduces "--pin-core" option to runfabtests.sh script
Commit 3: introduces "--pin-core" option to runfabtests.py and pytest based scripts. 
Commit 4: add header file sched.h to build on Windows