### PR TITLE
fabtests/common/hmem_neuron.c: Two bug fixes.

### DIFF
--- a/fabtests/common/hmem_neuron.c
+++ b/fabtests/common/hmem_neuron.c
@@ -175,8 +175,10 @@ int ft_neuron_cleanup(void)
 	                             region, entry, tmp)
 		ft_neuron_free_region(region);
 
-	if (neuron_handle)
+	if (neuron_handle) {
 		dlclose(neuron_handle);
+		neuron_handle = NULL;
+	}
 
 	return 0;
 }

--- a/fabtests/common/hmem_neuron.c
+++ b/fabtests/common/hmem_neuron.c
@@ -75,6 +75,7 @@ static struct dlist_entry neuron_alloc_list;
 int ft_neuron_init(void)
 {
 	NRT_STATUS ret;
+	static bool nrt_initialized = false;
 
 	if (neuron_handle)
 		return FI_SUCCESS;
@@ -123,10 +124,13 @@ int ft_neuron_init(void)
 
 	dlist_init(&neuron_alloc_list);
 
-	ret = neuron_ops.nrt_init(NRT_FRAMEWORK_TYPE_NO_FW, "2.0", "");
-	if (ret != NRT_SUCCESS) {
-		FT_ERR("Neuron init failed ret=%d\n", ret);
-		goto err;
+	if (!nrt_initialized) {
+		ret = neuron_ops.nrt_init(NRT_FRAMEWORK_TYPE_NO_FW, "2.0", "");
+		if (ret != NRT_SUCCESS) {
+			FT_ERR("Neuron init failed ret=%d\n", ret);
+			goto err;
+		}
+		nrt_initialized = true;
 	}
 
 	return FI_SUCCESS;


### PR DESCRIPTION
This PR contains two patches that fix the neuron hmem issues in multi client test

1. reset `neuron_handle` to NULL after it's being dlclose() to avoid segfault during multi client test.
2. only call `nrt_init` once so there is no conflict in the neuron resource between the clients.

Test info: Run fabtests on single trn1 instance with -D neuron on both client and server.