### PR TITLE
prov/util (all) - initial set of patches to allow providers to set lock type

### DIFF
--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -242,7 +242,7 @@ struct smr_region {
 	uint8_t		cma_cap_peer;
 	uint8_t		cma_cap_self;
 	void		*base_addr;
-	pthread_mutex_t	lock; /* lock for shm access
+	pthread_spinlock_t	lock; /* lock for shm access
 				 Must hold smr->lock before tx/rx cq locks
 				 in order to progress or post recv */
 	ofi_atomic32_t	signal;

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -89,6 +89,12 @@ extern "C" {
 /* Memory registration should not be cached */
 #define OFI_MR_NOCACHE		BIT_ULL(60)
 
+/* Provider domain flags
+ * SPINLOCK: Use spinlocks for domain and CQ objects.
+ *           EP is not included (not needed yet)
+ */
+#define OFI_DOMAIN_SPINLOCK	BIT_ULL(61)
+
 #define OFI_Q_STRERROR(prov, level, subsys, q, q_str, entry, q_strerror)	\
 	FI_LOG(prov, level, subsys, "fi_" q_str "_readerr: err: %s (%d), "	\
 	       "prov_err: %s (%d)\n", strerror((entry)->err), (entry)->err,	\
@@ -228,7 +234,7 @@ struct util_domain {
 };
 
 int ofi_domain_init(struct fid_fabric *fabric_fid, const struct fi_info *info,
-		     struct util_domain *domain, void *context);
+		     struct util_domain *domain, void *context, uint64_t flags);
 int ofi_domain_bind(struct fid *fid, struct fid *bfid, uint64_t flags);
 int ofi_domain_close(struct util_domain *domain);
 

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -211,7 +211,8 @@ struct util_domain {
 	struct dlist_entry	list_entry;
 	struct util_fabric	*fabric;
 	struct util_eq		*eq;
-	ofi_mutex_t		lock;
+
+	struct ofi_genlock	lock;
 	ofi_atomic32_t		ref;
 	const struct fi_provider *prov;
 

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -668,7 +668,7 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 	}
 
 	ret = ofi_domain_init(fabric_fid, info, &domain->util_domain,
-			      context);
+			      context, 0);
 	if (ret)
 		goto err_free_qp_table;
 

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -1019,22 +1019,22 @@ static inline uint64_t is_rx_res_full(struct rxr_ep *ep)
 
 static inline void rxr_rm_rx_cq_check(struct rxr_ep *ep, struct util_cq *rx_cq)
 {
-	ofi_mutex_lock(&rx_cq->cq_lock);
+	ofi_genlock_lock(&rx_cq->cq_lock);
 	if (ofi_cirque_isfull(rx_cq->cirq))
 		ep->rm_full |= RXR_RM_RX_CQ_FULL;
 	else
 		ep->rm_full &= ~RXR_RM_RX_CQ_FULL;
-	ofi_mutex_unlock(&rx_cq->cq_lock);
+	ofi_genlock_unlock(&rx_cq->cq_lock);
 }
 
 static inline void rxr_rm_tx_cq_check(struct rxr_ep *ep, struct util_cq *tx_cq)
 {
-	ofi_mutex_lock(&tx_cq->cq_lock);
+	ofi_genlock_lock(&tx_cq->cq_lock);
 	if (ofi_cirque_isfull(tx_cq->cirq))
 		ep->rm_full |= RXR_RM_TX_CQ_FULL;
 	else
 		ep->rm_full &= ~RXR_RM_TX_CQ_FULL;
-	ofi_mutex_unlock(&tx_cq->cq_lock);
+	ofi_genlock_unlock(&tx_cq->cq_lock);
 }
 
 #endif

--- a/prov/efa/src/rxr/rxr_domain.c
+++ b/prov/efa/src/rxr/rxr_domain.c
@@ -211,7 +211,7 @@ int rxr_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	rxr_domain->cq_size = MAX(info->rx_attr->size + info->tx_attr->size,
 				  rxr_env.cq_size);
 
-	ret = ofi_domain_init(fabric, info, &rxr_domain->util_domain, context);
+	ret = ofi_domain_init(fabric, info, &rxr_domain->util_domain, context, 0);
 	if (ret)
 		goto err_close_shm_domain;
 

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -55,14 +55,14 @@ int rxr_rma_verified_copy_iov(struct rxr_ep *ep, struct efa_rma_iov *rma,
 	efa_ep = container_of(ep->rdm_ep, struct efa_ep, util_ep.ep_fid);
 
 	for (i = 0; i < count; i++) {
-		ofi_mutex_lock(&efa_ep->domain->util_domain.lock);
+		ofi_genlock_lock(&efa_ep->domain->util_domain.lock);
 		ret = ofi_mr_map_verify(&efa_ep->domain->util_domain.mr_map,
 					(uintptr_t *)(&rma[i].addr),
 					rma[i].len, rma[i].key, flags,
 					&context);
 		efa_mr = context;
 		desc[i] = fi_mr_desc(&efa_mr->mr_fid);
-		ofi_mutex_unlock(&efa_ep->domain->util_domain.lock);
+		ofi_genlock_unlock(&efa_ep->domain->util_domain.lock);
 		if (ret) {
 			FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,
 				"MR verification failed (%s), addr: %lx key: %ld\n",

--- a/prov/mrail/src/mrail_domain.c
+++ b/prov/mrail/src/mrail_domain.c
@@ -374,7 +374,7 @@ int mrail_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	if (!mrail_domain)
 		return -FI_ENOMEM;
 
-	ret = ofi_domain_init(fabric, info, &mrail_domain->util_domain, context);
+	ret = ofi_domain_init(fabric, info, &mrail_domain->util_domain, context, 0);
 	if (ret) {
 		free(mrail_domain);
 		return ret;

--- a/prov/psm/src/psmx_domain.c
+++ b/prov/psm/src/psmx_domain.c
@@ -385,7 +385,7 @@ int psmx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		goto err_out;
 	}
 
-	err = ofi_domain_init(fabric, info, &domain_priv->util_domain, context);
+	err = ofi_domain_init(fabric, info, &domain_priv->util_domain, context, 0);
 	if (err)
 		goto err_out_free_domain;
 

--- a/prov/psm2/src/psmx2_domain.c
+++ b/prov/psm2/src/psmx2_domain.c
@@ -385,7 +385,7 @@ int psmx2_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		       sizeof(psm2_uuid_t));
 	}
 
-	err = ofi_domain_init(fabric, info, &domain_priv->util_domain, context);
+	err = ofi_domain_init(fabric, info, &domain_priv->util_domain, context, 0);
 	if (err)
 		goto err_out_free_domain;
 

--- a/prov/psm3/src/psmx3_domain.c
+++ b/prov/psm3/src/psmx3_domain.c
@@ -323,7 +323,7 @@ int psmx3_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		goto err_out;
 	}
 
-	err = ofi_domain_init(fabric, info, &domain_priv->util_domain, context);
+	err = ofi_domain_init(fabric, info, &domain_priv->util_domain, context, 0);
 	if (err)
 		goto err_out_free_domain;
 

--- a/prov/rstream/src/rstream_domain.c
+++ b/prov/rstream/src/rstream_domain.c
@@ -108,7 +108,7 @@ int rstream_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		goto err1;
 
 	ret = ofi_domain_init(fabric, info, &rstream_domain->util_domain,
-		context);
+			      context, 0);
 	if (ret)
 		goto err1;
 

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -1254,7 +1254,7 @@ ssize_t rxd_cq_sreadfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 		}
 
 		ep_retry = -1;
-		cq->cq_mutex_lock(&cq->ep_list_lock);
+		ofi_mutex_lock(&cq->ep_list_lock);
 		dlist_foreach_container(&cq->ep_list, struct fid_list_entry,
 					fid_entry, entry) {
 			ep = container_of(fid_entry->fid, struct rxd_ep,
@@ -1264,7 +1264,7 @@ ssize_t rxd_cq_sreadfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 			ep_retry = ep_retry == -1 ? ep->next_retry :
 					MIN(ep_retry, ep->next_retry);
 		}
-		cq->cq_mutex_unlock(&cq->ep_list_lock);
+		ofi_mutex_unlock(&cq->ep_list_lock);
 
 		ret = fi_wait(&cq->wait->wait_fid, ep_retry == -1 ?
 			      timeout : rxd_get_timeout(ep_retry));

--- a/prov/rxd/src/rxd_domain.c
+++ b/prov/rxd/src/rxd_domain.c
@@ -137,7 +137,7 @@ int rxd_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	rxd_domain->max_seg_sz = rxd_domain->max_mtu_sz - sizeof(struct rxd_data_pkt) -
 				 dg_info->ep_attr->msg_prefix_size;
 
-	ret = ofi_domain_init(fabric, info, &rxd_domain->util_domain, context);
+	ret = ofi_domain_init(fabric, info, &rxd_domain->util_domain, context, 0);
 	if (ret) {
 		goto err3;
 	}

--- a/prov/rxd/src/rxd_domain.c
+++ b/prov/rxd/src/rxd_domain.c
@@ -91,10 +91,10 @@ int rxd_mr_verify(struct rxd_domain *rxd_domain, ssize_t len,
 {
 	int ret;
 
-	ofi_mutex_lock(&rxd_domain->util_domain.lock);
+	ofi_genlock_lock(&rxd_domain->util_domain.lock);
 	ret = ofi_mr_map_verify(&rxd_domain->mr_map, io_addr, len,
 				key, access, NULL);
-	ofi_mutex_unlock(&rxd_domain->util_domain.lock);
+	ofi_genlock_unlock(&rxd_domain->util_domain.lock);
 	return ret;
 }
 

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -221,10 +221,10 @@ static struct fi_ops_domain rxm_domain_ops = {
 
 static void rxm_mr_remove_map_entry(struct rxm_mr *mr)
 {
-	ofi_mutex_lock(&mr->domain->util_domain.lock);
+	ofi_genlock_lock(&mr->domain->util_domain.lock);
 	(void) ofi_mr_map_remove(&mr->domain->util_domain.mr_map,
 				 mr->mr_fid.key);
-	ofi_mutex_unlock(&mr->domain->util_domain.lock);
+	ofi_genlock_unlock(&mr->domain->util_domain.lock);
 }
 
 static int rxm_mr_add_map_entry(struct util_domain *domain,
@@ -236,7 +236,7 @@ static int rxm_mr_add_map_entry(struct util_domain *domain,
 
 	msg_attr->requested_key = rxm_mr->mr_fid.key;
 
-	ofi_mutex_lock(&domain->lock);
+	ofi_genlock_lock(&domain->lock);
 	ret = ofi_mr_map_insert(&domain->mr_map, msg_attr, &temp_key, rxm_mr);
 	if (OFI_UNLIKELY(ret)) {
 		FI_WARN(&rxm_prov, FI_LOG_DOMAIN,
@@ -245,7 +245,7 @@ static int rxm_mr_add_map_entry(struct util_domain *domain,
 	} else {
 		assert(rxm_mr->mr_fid.key == temp_key);
 	}
-	ofi_mutex_unlock(&domain->lock);
+	ofi_genlock_unlock(&domain->lock);
 
 	return ret;
 }
@@ -254,9 +254,9 @@ struct rxm_mr *rxm_mr_get_map_entry(struct rxm_domain *domain, uint64_t key)
 {
 	struct rxm_mr *mr;
 
-	ofi_mutex_lock(&domain->util_domain.lock);
+	ofi_genlock_lock(&domain->util_domain.lock);
 	mr = ofi_mr_map_get(&domain->util_domain.mr_map, key);
-	ofi_mutex_unlock(&domain->util_domain.lock);
+	ofi_genlock_unlock(&domain->util_domain.lock);
 
 	return mr;
 }

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -725,7 +725,7 @@ int rxm_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	if (ret)
 		goto err2;
 
-	ret = ofi_domain_init(fabric, info, &rxm_domain->util_domain, context);
+	ret = ofi_domain_init(fabric, info, &rxm_domain->util_domain, context, 0);
 	if (ret) {
 		goto err3;
 	}

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -161,7 +161,7 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 	peer_id = smr_peer_data(ep->region)[id].addr.id;
 	peer_smr = smr_peer_region(ep->region, id);
 
-	pthread_mutex_lock(&peer_smr->lock);
+	pthread_spin_lock(&peer_smr->lock);
 	if (peer_smr->cmd_cnt < 2 || smr_peer_data(ep->region)[id].sar_status) {
 		ret = -FI_EAGAIN;
 		goto unlock_region;
@@ -256,7 +256,7 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 unlock_cq:
 	ofi_genlock_unlock(&ep->util_ep.tx_cq->cq_lock);
 unlock_region:
-	pthread_mutex_unlock(&peer_smr->lock);
+	pthread_spin_unlock(&peer_smr->lock);
 	return ret;
 }
 
@@ -341,7 +341,7 @@ static ssize_t smr_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 	peer_id = smr_peer_data(ep->region)[id].addr.id;
 	peer_smr = smr_peer_region(ep->region, id);
 
-	pthread_mutex_lock(&peer_smr->lock);
+	pthread_spin_lock(&peer_smr->lock);
 	if (peer_smr->cmd_cnt < 2 || smr_peer_data(ep->region)[id].sar_status) {
 		ret = -FI_EAGAIN;
 		goto unlock_region;
@@ -378,7 +378,7 @@ static ssize_t smr_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 
 	ofi_ep_tx_cntr_inc_func(&ep->util_ep, ofi_op_atomic);
 unlock_region:
-	pthread_mutex_unlock(&peer_smr->lock);
+	pthread_spin_unlock(&peer_smr->lock);
 	return ret;
 }
 

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -167,7 +167,7 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 		goto unlock_region;
 	}
 
-	ofi_mutex_lock(&ep->util_ep.tx_cq->cq_lock);
+	ofi_genlock_lock(&ep->util_ep.tx_cq->cq_lock);
 	if (ofi_cirque_isfull(ep->util_ep.tx_cq->cirq)) {
 		ret = -FI_EAGAIN;
 		goto unlock_cq;
@@ -254,7 +254,7 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 	peer_smr->cmd_cnt--;
 	smr_signal(peer_smr);
 unlock_cq:
-	ofi_mutex_unlock(&ep->util_ep.tx_cq->cq_lock);
+	ofi_genlock_unlock(&ep->util_ep.tx_cq->cq_lock);
 unlock_region:
 	pthread_mutex_unlock(&peer_smr->lock);
 	return ret;

--- a/prov/shm/src/smr_domain.c
+++ b/prov/shm/src/smr_domain.c
@@ -99,6 +99,7 @@ int smr_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		return ret;
 	}
 
+	smr_domain->util_domain.threading = FI_THREAD_SAFE;
 	smr_fabric = container_of(fabric, struct smr_fabric, util_fabric.fabric_fid);
 	ofi_mutex_lock(&smr_fabric->util_fabric.lock);
 	smr_domain->fast_rma = smr_fast_rma_enabled(info->domain_attr->mr_mode,

--- a/prov/shm/src/smr_domain.c
+++ b/prov/shm/src/smr_domain.c
@@ -93,7 +93,8 @@ int smr_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	if (!smr_domain)
 		return -FI_ENOMEM;
 
-	ret = ofi_domain_init(fabric, info, &smr_domain->util_domain, context, 0);
+	ret = ofi_domain_init(fabric, info, &smr_domain->util_domain, context,
+			      OFI_DOMAIN_SPINLOCK);
 	if (ret) {
 		free(smr_domain);
 		return ret;

--- a/prov/shm/src/smr_domain.c
+++ b/prov/shm/src/smr_domain.c
@@ -93,7 +93,7 @@ int smr_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	if (!smr_domain)
 		return -FI_ENOMEM;
 
-	ret = ofi_domain_init(fabric, info, &smr_domain->util_domain, context);
+	ret = ofi_domain_init(fabric, info, &smr_domain->util_domain, context, 0);
 	if (ret) {
 		free(smr_domain);
 		return ret;

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -152,7 +152,7 @@ static int smr_ep_cancel_recv(struct smr_ep *ep, struct smr_queue *queue,
 	struct dlist_entry *entry;
 	int ret = 0;
 
-	ofi_mutex_lock(&ep->util_ep.rx_cq->cq_lock);
+	ofi_genlock_lock(&ep->util_ep.rx_cq->cq_lock);
 	entry = dlist_remove_first_match(&queue->list, smr_match_recv_ctx,
 					 context);
 	if (entry) {
@@ -165,7 +165,7 @@ static int smr_ep_cancel_recv(struct smr_ep *ep, struct smr_queue *queue,
 		ret = ret ? ret : 1;
 	}
 
-	ofi_mutex_unlock(&ep->util_ep.rx_cq->cq_lock);
+	ofi_genlock_unlock(&ep->util_ep.rx_cq->cq_lock);
 	return ret;
 }
 

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -203,7 +203,7 @@ static void smr_send_name(struct smr_ep *ep, int64_t id)
 
 	peer_smr = smr_peer_region(ep->region, id);
 
-	pthread_mutex_lock(&peer_smr->lock);
+	pthread_spin_lock(&peer_smr->lock);
 
 	if (smr_peer_data(ep->region)[id].name_sent || !peer_smr->cmd_cnt)
 		goto out;
@@ -226,7 +226,7 @@ static void smr_send_name(struct smr_ep *ep, int64_t id)
 	smr_signal(peer_smr);
 
 out:
-	pthread_mutex_unlock(&peer_smr->lock);
+	pthread_spin_unlock(&peer_smr->lock);
 }
 
 int64_t smr_verify_peer(struct smr_ep *ep, fi_addr_t fi_addr)

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -96,7 +96,7 @@ ssize_t smr_generic_recv(struct smr_ep *ep, const struct iovec *iov, void **desc
 	assert(!(flags & FI_MULTI_RECV) || iov_count == 1);
 
 	pthread_mutex_lock(&ep->region->lock);
-	ofi_mutex_lock(&ep->util_ep.rx_cq->cq_lock);
+	ofi_genlock_lock(&ep->util_ep.rx_cq->cq_lock);
 
 	entry = smr_get_recv_entry(ep, iov, desc, iov_count, addr, context, tag,
 				   ignore, flags);
@@ -106,7 +106,7 @@ ssize_t smr_generic_recv(struct smr_ep *ep, const struct iovec *iov, void **desc
 	dlist_insert_tail(&entry->entry, &recv_queue->list);
 	ret = smr_progress_unexp_queue(ep, entry, unexp_queue);
 out:
-	ofi_mutex_unlock(&ep->util_ep.rx_cq->cq_lock);
+	ofi_genlock_unlock(&ep->util_ep.rx_cq->cq_lock);
 	pthread_mutex_unlock(&ep->region->lock);
 	return ret;
 }
@@ -184,7 +184,7 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 		goto unlock_region;
 	}
 
-	ofi_mutex_lock(&ep->util_ep.tx_cq->cq_lock);
+	ofi_genlock_lock(&ep->util_ep.tx_cq->cq_lock);
 	if (ofi_cirque_isfull(ep->util_ep.tx_cq->cirq)) {
 		ret = -FI_EAGAIN;
 		goto unlock_cq;
@@ -270,7 +270,7 @@ commit:
 	peer_smr->cmd_cnt--;
 	smr_signal(peer_smr);
 unlock_cq:
-	ofi_mutex_unlock(&ep->util_ep.tx_cq->cq_lock);
+	ofi_genlock_unlock(&ep->util_ep.tx_cq->cq_lock);
 unlock_region:
 	pthread_mutex_unlock(&peer_smr->lock);
 	return ret;

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -95,7 +95,7 @@ ssize_t smr_generic_recv(struct smr_ep *ep, const struct iovec *iov, void **desc
 	assert(iov_count <= SMR_IOV_LIMIT);
 	assert(!(flags & FI_MULTI_RECV) || iov_count == 1);
 
-	pthread_mutex_lock(&ep->region->lock);
+	pthread_spin_lock(&ep->region->lock);
 	ofi_genlock_lock(&ep->util_ep.rx_cq->cq_lock);
 
 	entry = smr_get_recv_entry(ep, iov, desc, iov_count, addr, context, tag,
@@ -107,7 +107,7 @@ ssize_t smr_generic_recv(struct smr_ep *ep, const struct iovec *iov, void **desc
 	ret = smr_progress_unexp_queue(ep, entry, unexp_queue);
 out:
 	ofi_genlock_unlock(&ep->util_ep.rx_cq->cq_lock);
-	pthread_mutex_unlock(&ep->region->lock);
+	pthread_spin_unlock(&ep->region->lock);
 	return ret;
 }
 
@@ -178,7 +178,7 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 	peer_id = smr_peer_data(ep->region)[id].addr.id;
 	peer_smr = smr_peer_region(ep->region, id);
 
-	pthread_mutex_lock(&peer_smr->lock);
+	pthread_spin_lock(&peer_smr->lock);
 	if (!peer_smr->cmd_cnt || smr_peer_data(ep->region)[peer_id].sar_status) {
 		ret = -FI_EAGAIN;
 		goto unlock_region;
@@ -272,7 +272,7 @@ commit:
 unlock_cq:
 	ofi_genlock_unlock(&ep->util_ep.tx_cq->cq_lock);
 unlock_region:
-	pthread_mutex_unlock(&peer_smr->lock);
+	pthread_spin_unlock(&peer_smr->lock);
 	return ret;
 }
 
@@ -341,7 +341,7 @@ static ssize_t smr_generic_inject(struct fid_ep *ep_fid, const void *buf,
 	peer_id = smr_peer_data(ep->region)[id].addr.id;
 	peer_smr = smr_peer_region(ep->region, id);
 
-	pthread_mutex_lock(&peer_smr->lock);
+	pthread_spin_lock(&peer_smr->lock);
 	if (!peer_smr->cmd_cnt || smr_peer_data(ep->region)[id].sar_status) {
 		ret = -FI_EAGAIN;
 		goto unlock;
@@ -362,7 +362,7 @@ static ssize_t smr_generic_inject(struct fid_ep *ep_fid, const void *buf,
 	ofi_cirque_commit(smr_cmd_queue(peer_smr));
 	smr_signal(peer_smr);
 unlock:
-	pthread_mutex_unlock(&peer_smr->lock);
+	pthread_spin_unlock(&peer_smr->lock);
 
 	return ret;
 }

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -832,7 +832,7 @@ static int smr_progress_cmd_rma(struct smr_ep *ep, struct smr_cmd *cmd)
 	ep->region->cmd_cnt++;
 	rma_cmd = ofi_cirque_head(smr_cmd_queue(ep->region));
 
-	ofi_mutex_lock(&domain->util_domain.lock);
+	ofi_genlock_lock(&domain->util_domain.lock);
 	for (iov_count = 0; iov_count < rma_cmd->rma.rma_count; iov_count++) {
 		ret = ofi_mr_map_verify(&domain->util_domain.mr_map,
 				(uintptr_t *) &(rma_cmd->rma.rma_iov[iov_count].addr),
@@ -852,7 +852,7 @@ static int smr_progress_cmd_rma(struct smr_ep *ep, struct smr_cmd *cmd)
 			assert(mr->iface == iface && mr->device == device);
 		}
 	}
-	ofi_mutex_unlock(&domain->util_domain.lock);
+	ofi_genlock_unlock(&domain->util_domain.lock);
 
 	ofi_cirque_discard(smr_cmd_queue(ep->region));
 	if (ret) {

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -201,7 +201,7 @@ static void smr_progress_resp(struct smr_ep *ep)
 	int ret;
 
 	pthread_mutex_lock(&ep->region->lock);
-	ofi_mutex_lock(&ep->util_ep.tx_cq->cq_lock);
+	ofi_genlock_lock(&ep->util_ep.tx_cq->cq_lock);
 	while (!ofi_cirque_isempty(smr_resp_queue(ep->region)) &&
 	       !ofi_cirque_isfull(ep->util_ep.tx_cq->cirq)) {
 		resp = ofi_cirque_head(smr_resp_queue(ep->region));
@@ -223,7 +223,7 @@ static void smr_progress_resp(struct smr_ep *ep)
 		ofi_freestack_push(ep->pend_fs, pending);
 		ofi_cirque_discard(smr_resp_queue(ep->region));
 	}
-	ofi_mutex_unlock(&ep->util_ep.tx_cq->cq_lock);
+	ofi_genlock_unlock(&ep->util_ep.tx_cq->cq_lock);
 	pthread_mutex_unlock(&ep->region->lock);
 }
 
@@ -990,7 +990,7 @@ static void smr_progress_cmd(struct smr_ep *ep)
 	int ret = 0;
 
 	pthread_mutex_lock(&ep->region->lock);
-	ofi_mutex_lock(&ep->util_ep.rx_cq->cq_lock);
+	ofi_genlock_lock(&ep->util_ep.rx_cq->cq_lock);
 
 	while (!ofi_cirque_isempty(smr_cmd_queue(ep->region))) {
 		cmd = ofi_cirque_head(smr_cmd_queue(ep->region));
@@ -1033,7 +1033,7 @@ static void smr_progress_cmd(struct smr_ep *ep)
 			break;
 		}
 	}
-	ofi_mutex_unlock(&ep->util_ep.rx_cq->cq_lock);
+	ofi_genlock_unlock(&ep->util_ep.rx_cq->cq_lock);
 	pthread_mutex_unlock(&ep->region->lock);
 }
 
@@ -1047,7 +1047,7 @@ static void smr_progress_sar_list(struct smr_ep *ep)
 	int ret;
 
 	pthread_mutex_lock(&ep->region->lock);
-	ofi_mutex_lock(&ep->util_ep.rx_cq->cq_lock);
+	ofi_genlock_lock(&ep->util_ep.rx_cq->cq_lock);
 
 	dlist_foreach_container_safe(&ep->sar_list, struct smr_sar_entry,
 				     sar_entry, entry, tmp) {
@@ -1082,7 +1082,7 @@ static void smr_progress_sar_list(struct smr_ep *ep)
 			ofi_freestack_push(ep->sar_fs, sar_entry);
 		}
 	}
-	ofi_mutex_unlock(&ep->util_ep.rx_cq->cq_lock);
+	ofi_genlock_unlock(&ep->util_ep.rx_cq->cq_lock);
 	pthread_mutex_unlock(&ep->region->lock);
 }
 

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -128,7 +128,7 @@ ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 		goto unlock_region;
 	}
 
-	ofi_mutex_lock(&ep->util_ep.tx_cq->cq_lock);
+	ofi_genlock_lock(&ep->util_ep.tx_cq->cq_lock);
 	if (ofi_cirque_isfull(ep->util_ep.tx_cq->cirq)) {
 		ret = -FI_EAGAIN;
 		goto unlock_cq;
@@ -246,7 +246,7 @@ commit_comp:
 	}
 
 unlock_cq:
-	ofi_mutex_unlock(&ep->util_ep.tx_cq->cq_lock);
+	ofi_genlock_unlock(&ep->util_ep.tx_cq->cq_lock);
 unlock_region:
 	pthread_mutex_unlock(&peer_smr->lock);
 	return ret;

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -121,7 +121,7 @@ ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 		    (FI_REMOTE_CQ_DATA | FI_DELIVERY_COMPLETE)) &&
 		     rma_count == 1 && smr_cma_enabled(ep, peer_smr));
 
-	pthread_mutex_lock(&peer_smr->lock);
+	pthread_spin_lock(&peer_smr->lock);
 	if (peer_smr->cmd_cnt < cmds ||
 	    smr_peer_data(ep->region)[id].sar_status) {
 		ret = -FI_EAGAIN;
@@ -248,7 +248,7 @@ commit_comp:
 unlock_cq:
 	ofi_genlock_unlock(&ep->util_ep.tx_cq->cq_lock);
 unlock_region:
-	pthread_mutex_unlock(&peer_smr->lock);
+	pthread_spin_unlock(&peer_smr->lock);
 	return ret;
 }
 
@@ -386,7 +386,7 @@ ssize_t smr_generic_rma_inject(struct fid_ep *ep_fid, const void *buf,
 	cmds = 1 + !(domain->fast_rma && !(flags & FI_REMOTE_CQ_DATA) &&
 		     smr_cma_enabled(ep, peer_smr));
 
-	pthread_mutex_lock(&peer_smr->lock);
+	pthread_spin_lock(&peer_smr->lock);
 	if (peer_smr->cmd_cnt < cmds ||
 	    smr_peer_data(ep->region)[id].sar_status) {
 		ret = -FI_EAGAIN;
@@ -429,7 +429,7 @@ commit:
 	smr_signal(peer_smr);
 	ofi_ep_tx_cntr_inc_func(&ep->util_ep, ofi_op_write);
 unlock_region:
-	pthread_mutex_unlock(&peer_smr->lock);
+	pthread_spin_unlock(&peer_smr->lock);
 	return ret;
 }
 

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -445,9 +445,9 @@ tcpx_alloc_xfer(struct tcpx_cq *cq)
 {
 	struct tcpx_xfer_entry *xfer;
 
-	cq->util_cq.cq_mutex_lock(&cq->util_cq.cq_lock);
+	ofi_genlock_lock(&cq->util_cq.cq_lock);
 	xfer = ofi_buf_alloc(cq->xfer_pool);
-	cq->util_cq.cq_mutex_unlock(&cq->util_cq.cq_lock);
+	ofi_genlock_unlock(&cq->util_cq.cq_lock);
 
 	return xfer;
 }
@@ -460,9 +460,9 @@ tcpx_free_xfer(struct tcpx_cq *cq, struct tcpx_xfer_entry *xfer)
 	xfer->ctrl_flags = 0;
 	xfer->context = 0;
 
-	cq->util_cq.cq_mutex_lock(&cq->util_cq.cq_lock);
+	ofi_genlock_lock(&cq->util_cq.cq_lock);
 	ofi_buf_free(xfer);
-	cq->util_cq.cq_mutex_unlock(&cq->util_cq.cq_lock);
+	ofi_genlock_unlock(&cq->util_cq.cq_lock);
 }
 
 static inline struct tcpx_xfer_entry *

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -113,9 +113,9 @@ void tcpx_progress(struct dlist_entry *ep_list, struct util_wait *wait)
 
 void tcpx_cq_progress(struct util_cq *cq)
 {
-	cq->cq_mutex_lock(&cq->ep_list_lock);
+	ofi_mutex_lock(&cq->ep_list_lock);
 	tcpx_progress(&cq->ep_list, cq->wait);
-	cq->cq_mutex_unlock(&cq->ep_list_lock);
+	ofi_mutex_unlock(&cq->ep_list_lock);
 }
 
 static int tcpx_cq_close(struct fid *fid)

--- a/prov/tcp/src/tcpx_domain.c
+++ b/prov/tcp/src/tcpx_domain.c
@@ -120,7 +120,7 @@ int tcpx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	if (!domain)
 		return -FI_ENOMEM;
 
-	ret = ofi_domain_init(fabric, info, &domain->util_domain, context);
+	ret = ofi_domain_init(fabric, info, &domain->util_domain, context, 0);
 	if (ret)
 		goto err;
 

--- a/prov/udp/src/udpx_domain.c
+++ b/prov/udp/src/udpx_domain.c
@@ -91,7 +91,7 @@ int udpx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	if (!util_domain)
 		return -FI_ENOMEM;
 
-	ret = ofi_domain_init(fabric, info, util_domain, context);
+	ret = ofi_domain_init(fabric, info, util_domain, context, 0);
 	if (ret) {
 		free(util_domain);
 		return ret;

--- a/prov/udp/src/udpx_ep.c
+++ b/prov/udp/src/udpx_ep.c
@@ -285,7 +285,7 @@ static void udpx_ep_progress(struct util_ep *util_ep)
 	hdr.msg_controllen = 0;
 	hdr.msg_flags = 0;
 
-	ofi_mutex_lock(&ep->util_ep.rx_cq->cq_lock);
+	ofi_genlock_lock(&ep->util_ep.rx_cq->cq_lock);
 	if (ofi_cirque_isempty(ep->rxq))
 		goto out;
 
@@ -299,7 +299,7 @@ static void udpx_ep_progress(struct util_ep *util_ep)
 		ofi_cirque_discard(ep->rxq);
 	}
 out:
-	ofi_mutex_unlock(&ep->util_ep.rx_cq->cq_lock);
+	ofi_genlock_unlock(&ep->util_ep.rx_cq->cq_lock);
 }
 
 static ssize_t udpx_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
@@ -310,7 +310,7 @@ static ssize_t udpx_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 	ssize_t ret;
 
 	ep = container_of(ep_fid, struct udpx_ep, util_ep.ep_fid.fid);
-	ofi_mutex_lock(&ep->util_ep.rx_cq->cq_lock);
+	ofi_genlock_lock(&ep->util_ep.rx_cq->cq_lock);
 	if (ofi_cirque_isfull(ep->rxq)) {
 		ret = -FI_EAGAIN;
 		goto out;
@@ -327,7 +327,7 @@ static ssize_t udpx_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 	ofi_cirque_commit(ep->rxq);
 	ret = 0;
 out:
-	ofi_mutex_unlock(&ep->util_ep.rx_cq->cq_lock);
+	ofi_genlock_unlock(&ep->util_ep.rx_cq->cq_lock);
 	return ret;
 }
 
@@ -351,7 +351,7 @@ static ssize_t udpx_recv(struct fid_ep *ep_fid, void *buf, size_t len,
 	ssize_t ret;
 
 	ep = container_of(ep_fid, struct udpx_ep, util_ep.ep_fid.fid);
-	ofi_mutex_lock(&ep->util_ep.rx_cq->cq_lock);
+	ofi_genlock_lock(&ep->util_ep.rx_cq->cq_lock);
 	if (ofi_cirque_isfull(ep->rxq)) {
 		ret = -FI_EAGAIN;
 		goto out;
@@ -367,7 +367,7 @@ static ssize_t udpx_recv(struct fid_ep *ep_fid, void *buf, size_t len,
 	ofi_cirque_commit(ep->rxq);
 	ret = 0;
 out:
-	ofi_mutex_unlock(&ep->util_ep.rx_cq->cq_lock);
+	ofi_genlock_unlock(&ep->util_ep.rx_cq->cq_lock);
 	return ret;
 }
 
@@ -392,7 +392,7 @@ static ssize_t udpx_sendto(struct udpx_ep *ep, const void *buf, size_t len,
 {
 	ssize_t ret;
 
-	ofi_mutex_lock(&ep->util_ep.tx_cq->cq_lock);
+	ofi_genlock_lock(&ep->util_ep.tx_cq->cq_lock);
 	if (ofi_cirque_isfull(ep->util_ep.tx_cq->cirq)) {
 		ret = -FI_EAGAIN;
 		goto out;
@@ -407,7 +407,7 @@ static ssize_t udpx_sendto(struct udpx_ep *ep, const void *buf, size_t len,
 		ret = -errno;
 	}
 out:
-	ofi_mutex_unlock(&ep->util_ep.tx_cq->cq_lock);
+	ofi_genlock_unlock(&ep->util_ep.tx_cq->cq_lock);
 	return ret;
 }
 
@@ -448,7 +448,7 @@ static ssize_t udpx_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 	hdr.msg_controllen = 0;
 	hdr.msg_flags = 0;
 
-	ofi_mutex_lock(&ep->util_ep.tx_cq->cq_lock);
+	ofi_genlock_lock(&ep->util_ep.tx_cq->cq_lock);
 	if (ofi_cirque_isfull(ep->util_ep.tx_cq->cirq)) {
 		ret = -FI_EAGAIN;
 		goto out;
@@ -462,7 +462,7 @@ static ssize_t udpx_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 		ret = -errno;
 	}
 out:
-	ofi_mutex_unlock(&ep->util_ep.tx_cq->cq_lock);
+	ofi_genlock_unlock(&ep->util_ep.tx_cq->cq_lock);
 	return ret;
 }
 

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -486,9 +486,12 @@ static int fi_cq_init(struct fid_domain *domain, struct fi_cq_attr *attr,
 	ofi_atomic_initialize32(&cq->signaled, 0);
 	dlist_init(&cq->ep_list);
 	ofi_mutex_init(&cq->ep_list_lock);
-	if (cq->domain->threading == FI_THREAD_COMPLETION ||
-	    (cq->domain->threading == FI_THREAD_DOMAIN)) {
+	if (cq->domain->lock.lock_type == OFI_LOCK_NONE ||
+	    cq->domain->threading == FI_THREAD_COMPLETION ||
+	    cq->domain->threading == FI_THREAD_DOMAIN) {
 		ret = ofi_genlock_init(&cq->cq_lock, OFI_LOCK_NONE);
+	} else if (cq->domain->lock.lock_type == OFI_LOCK_SPINLOCK) {
+		ret = ofi_genlock_init(&cq->cq_lock, OFI_LOCK_SPINLOCK);
 	} else {
 		ret = ofi_genlock_init(&cq->cq_lock, OFI_LOCK_MUTEX);
 	}

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -59,7 +59,7 @@ int ofi_cq_write_overflow(struct util_cq *cq, void *context, uint64_t flags,
 {
 	struct util_cq_aux_entry *entry;
 
-	assert(ofi_mutex_held(&cq->cq_lock));
+	assert(ofi_genlock_held(&cq->cq_lock));
 	FI_DBG(cq->domain->prov, FI_LOG_CQ, "writing to CQ overflow list\n");
 	assert(ofi_cirque_freecnt(cq->cirq) <= 1);
 
@@ -84,7 +84,7 @@ int ofi_cq_insert_error(struct util_cq *cq,
 {
 	struct util_cq_aux_entry *entry;
 
-	assert(ofi_mutex_held(&cq->cq_lock));
+	assert(ofi_genlock_held(&cq->cq_lock));
 	assert(err_entry->err);
 	if (!(entry = calloc(1, sizeof(*entry))))
 		return -FI_ENOMEM;
@@ -97,9 +97,9 @@ int ofi_cq_insert_error(struct util_cq *cq,
 int ofi_cq_write_error(struct util_cq *cq,
 		       const struct fi_cq_err_entry *err_entry)
 {
-	cq->cq_mutex_lock(&cq->cq_lock);
+	ofi_genlock_lock(&cq->cq_lock);
 	ofi_cq_insert_error(cq, err_entry);
-	cq->cq_mutex_unlock(&cq->cq_lock);
+	ofi_genlock_unlock(&cq->cq_lock);
 
 	if (cq->wait)
 		cq->wait->signal(cq->wait);
@@ -224,11 +224,11 @@ ssize_t ofi_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 
 	cq = container_of(cq_fid, struct util_cq, cq_fid);
 
-	cq->cq_mutex_lock(&cq->cq_lock);
+	ofi_genlock_lock(&cq->cq_lock);
 	if (ofi_cirque_isempty(cq->cirq) || !count) {
-		cq->cq_mutex_unlock(&cq->cq_lock);
+		ofi_genlock_unlock(&cq->cq_lock);
 		cq->progress(cq);
-		cq->cq_mutex_lock(&cq->cq_lock);
+		ofi_genlock_lock(&cq->cq_lock);
 		if (ofi_cirque_isempty(cq->cirq)) {
 			i = -FI_EAGAIN;
 			goto out;
@@ -274,7 +274,7 @@ ssize_t ofi_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 		}
 	}
 out:
-	cq->cq_mutex_unlock(&cq->cq_lock);
+	ofi_genlock_unlock(&cq->cq_lock);
 	return i;
 }
 
@@ -296,7 +296,7 @@ ssize_t ofi_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *buf,
 	cq = container_of(cq_fid, struct util_cq, cq_fid);
 	api_version = cq->domain->fabric->fabric_fid.api_version;
 
-	cq->cq_mutex_lock(&cq->cq_lock);
+	ofi_genlock_lock(&cq->cq_lock);
 	if (ofi_cirque_isempty(cq->cirq) ||
 	    !(ofi_cirque_head(cq->cirq)->flags & UTIL_FLAG_AUX)) {
 		ret = -FI_EAGAIN;
@@ -341,7 +341,7 @@ ssize_t ofi_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *buf,
 
 	ret = 1;
 unlock:
-	cq->cq_mutex_unlock(&cq->cq_lock);
+	ofi_genlock_unlock(&cq->cq_lock);
 	return ret;
 }
 
@@ -429,7 +429,7 @@ int ofi_cq_cleanup(struct util_cq *cq)
 
 	ofi_atomic_dec32(&cq->domain->ref);
 	util_comp_cirq_free(cq->cirq);
-	ofi_mutex_destroy(&cq->cq_lock);
+	ofi_genlock_destroy(&cq->cq_lock);
 	ofi_mutex_destroy(&cq->ep_list_lock);
 	free(cq->src);
 	return 0;
@@ -486,18 +486,17 @@ static int fi_cq_init(struct fid_domain *domain, struct fi_cq_attr *attr,
 	ofi_atomic_initialize32(&cq->signaled, 0);
 	dlist_init(&cq->ep_list);
 	ofi_mutex_init(&cq->ep_list_lock);
-	ofi_mutex_init(&cq->cq_lock);
 	if (cq->domain->threading == FI_THREAD_COMPLETION ||
 	    (cq->domain->threading == FI_THREAD_DOMAIN)) {
-		cq->cq_mutex_lock = ofi_mutex_lock_noop;
-		cq->cq_mutex_unlock = ofi_mutex_unlock_noop;
+		ret = ofi_genlock_init(&cq->cq_lock, OFI_LOCK_NONE);
 	} else {
-		cq->cq_mutex_lock = ofi_mutex_lock_op;
-		cq->cq_mutex_unlock = ofi_mutex_unlock_op;
+		ret = ofi_genlock_init(&cq->cq_lock, OFI_LOCK_MUTEX);
 	}
 	slist_init(&cq->aux_queue);
-	cq->read_entry = read_entry;
+	if (ret)
+		return ret;
 
+	cq->read_entry = read_entry;
 	cq->cq_fid.fid.fclass = FI_CLASS_CQ;
 	cq->cq_fid.fid.context = context;
 
@@ -560,14 +559,14 @@ void ofi_cq_progress(struct util_cq *cq)
 	struct fid_list_entry *fid_entry;
 	struct dlist_entry *item;
 
-	cq->cq_mutex_lock(&cq->ep_list_lock);
+	ofi_mutex_lock(&cq->ep_list_lock);
 	dlist_foreach(&cq->ep_list, item) {
 		fid_entry = container_of(item, struct fid_list_entry, entry);
 		ep = container_of(fid_entry->fid, struct util_ep, ep_fid.fid);
 		ep->progress(ep);
 
 	}
-	cq->cq_mutex_unlock(&cq->ep_list_lock);
+	ofi_mutex_unlock(&cq->ep_list_lock);
 }
 
 int ofi_cq_init(const struct fi_provider *prov, struct fid_domain *domain,

--- a/prov/util/src/util_domain.c
+++ b/prov/util/src/util_domain.c
@@ -86,7 +86,7 @@ int ofi_domain_close(struct util_domain *domain)
 	ofi_mutex_unlock(&domain->fabric->lock);
 
 	free(domain->name);
-	ofi_mutex_destroy(&domain->lock);
+	ofi_genlock_destroy(&domain->lock);
 	ofi_atomic_dec32(&domain->fabric->ref);
 	return 0;
 }
@@ -101,17 +101,26 @@ static struct fi_ops_mr util_domain_mr_ops = {
 static int util_domain_init(struct util_domain *domain,
 			    const struct fi_info *info)
 {
+	int ret;
+
 	ofi_atomic_initialize32(&domain->ref, 0);
-	ofi_mutex_init(&domain->lock);
+	ret = ofi_genlock_init(&domain->lock, OFI_LOCK_MUTEX);
+	if (ret)
+		return ret;
+
 	domain->info_domain_caps = info->caps | info->domain_attr->caps;
 	domain->info_domain_mode = info->mode | info->domain_attr->mode;
 	domain->mr_mode = info->domain_attr->mr_mode;
 	domain->addr_format = info->addr_format;
 	domain->av_type = info->domain_attr->av_type;
-	domain->name = strdup(info->domain_attr->name);
 	domain->threading = info->domain_attr->threading;
 	domain->data_progress = info->domain_attr->data_progress;
-	return domain->name ? 0 : -FI_ENOMEM;
+	domain->name = strdup(info->domain_attr->name);
+	if (!domain->name) {
+		ofi_genlock_destroy(&domain->lock);
+		return -FI_ENOMEM;
+	}
+	return 0;
 }
 
 int ofi_domain_init(struct fid_fabric *fabric_fid, const struct fi_info *info,

--- a/prov/util/src/util_mr_map.c
+++ b/prov/util/src/util_mr_map.c
@@ -200,9 +200,9 @@ int ofi_mr_close(struct fid *fid)
 
 	mr = container_of(fid, struct ofi_mr, mr_fid.fid);
 
-	ofi_mutex_lock(&mr->domain->lock);
+	ofi_genlock_lock(&mr->domain->lock);
 	ret = ofi_mr_map_remove(&mr->domain->mr_map, mr->key);
-	ofi_mutex_unlock(&mr->domain->lock);
+	ofi_genlock_unlock(&mr->domain->lock);
 	if (ret)
 		return ret;
 
@@ -277,7 +277,7 @@ int ofi_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 		return -FI_ENOSYS;
 	}
 
-	ofi_mutex_lock(&domain->lock);
+	ofi_genlock_lock(&domain->lock);
 
 	mr->mr_fid.fid.fclass = FI_CLASS_MR;
 	mr->mr_fid.fid.context = attr->context;
@@ -300,7 +300,7 @@ int ofi_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	ofi_atomic_inc32(&domain->ref);
 
 out:
-	ofi_mutex_unlock(&domain->lock);
+	ofi_genlock_unlock(&domain->lock);
 	return ret;
 }
 
@@ -342,9 +342,9 @@ int ofi_mr_verify(struct ofi_mr_map *map, ssize_t len,
 	int ret;
 
 	domain = container_of(map, struct util_domain, mr_map);
-	ofi_mutex_lock(&domain->lock);
+	ofi_genlock_lock(&domain->lock);
 	ret = ofi_mr_map_verify(&domain->mr_map, addr, len,
 				key, access, NULL);
-	ofi_mutex_unlock(&domain->lock);
+	ofi_genlock_unlock(&domain->lock);
 	return ret;
 }

--- a/prov/util/src/util_shm.c
+++ b/prov/util/src/util_shm.c
@@ -185,13 +185,9 @@ err:
 	return -FI_EBUSY;
 }
 
-static void smr_lock_init(pthread_mutex_t *mutex)
+static void smr_lock_init(pthread_spinlock_t *lock)
 {
-	pthread_mutexattr_t attr;
-
-	pthread_mutexattr_init(&attr);
-	pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_SHARED);
-	pthread_mutex_init(mutex, &attr);
+	pthread_spin_init(lock, PTHREAD_PROCESS_SHARED);
 }
 
 /* TODO: Determine if aligning SMR data helps performance */

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -305,7 +305,7 @@ vrb_domain(struct fid_fabric *fabric, struct fi_info *info,
 	if (!_domain)
 		return -FI_ENOMEM;
 
-	ret = ofi_domain_init(fabric, info, &_domain->util_domain, context);
+	ret = ofi_domain_init(fabric, info, &_domain->util_domain, context, 0);
 	if (ret)
 		goto err1;
 


### PR DESCRIPTION
This series will allow a provider to indicate if a domain should use a mutex or spinlock for its base lock.  So far only the util domain is updated.  Next is to add the CQ, though some preliminary changes are included to make this straightforward.  The shm provider can then be updated to request the use of a spinlock over a mutex to avoid nesting a mutex inside of a spinlock.

Because the code updates the ofi_domain_init() call, most of the providers are touched, but only to pass in a 0 flag to that call.