### PR TITLE
pytest/efa/conftest.py: efa specific fixtures

### DIFF
--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -136,6 +136,7 @@ nobase_dist_config_DATA = \
 	pytest/default/test_shared_ctx.py \
 	pytest/default/test_ubertest.py \
 	pytest/default/test_unexpected_msg.py \
+	pytest/efa/conftest.py \
 	pytest/efa/test_from_default.py \
 	pytest/efa/test_av.py \
 	pytest/efa/test_dgram.py \

--- a/fabtests/pytest/efa/conftest.py
+++ b/fabtests/pytest/efa/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+@pytest.fixture(scope="module", params=["host_to_host", "host_to_cuda",
+                                        "cuda_to_host", "cuda_to_cuda"])
+def memory_type(request):
+    return request.param

--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -4,11 +4,6 @@ from default.test_rdm import test_rdm_bw_functional
 from default.test_rdm import test_rdm_atomic
 
 
-@pytest.fixture(scope="module", params=["host_to_host", "host_to_cuda",
-                                        "cuda_to_host", "cuda_to_cuda"])
-def memory_type(request):
-    return request.param
-
 def run_rdm_test(cmdline_args, executable, iteration_type, completion_type, memory_type):
     from common import ClientServerTest
     test = ClientServerTest(cmdline_args, executable, iteration_type,


### PR DESCRIPTION
This patch introduced a new file: pytest/efa/conftest.py, which
will used to host all efa specific fixtures.

As the first step, the patch moved the memory_type fixture from
pytest/test/test_rdm.py to this file.

Signed-off-by: Wei Zhang <wzam@amazon.com>