### PR TITLE
contrib/intel: Add OneCCL tests to CI

### DIFF
--- a/contrib/intel/jenkins/run.py
+++ b/contrib/intel/jenkins/run.py
@@ -110,5 +110,24 @@ def osu_benchmark(core, hosts, mpi, mode, util=None):
     print("----------------------------------------------------------------------------------------\n")
 
 
+#OneCCL examples and functional tests
+def oneccltest(core, hosts, mode, util=None):
+
+    runoneccltest = tests.OneCCLTests(jobname=jbname,buildno=bno, \
+                    testname="oneccl test", core_prov=core, fabric=fab, \
+                    hosts=hosts, ofi_build_mode=mode, util_prov=util)
+    if (runoneccltest.execute_condn):
+        print("running oneCCL examples test for {}-{}-{}" \
+              .format(core, util, fab))
+        runoneccltest.execute_cmd("examples")
+        print("running oneCCL functional test for {}-{}-{}" \
+              .format(core, util, fab))
+        runoneccltest.execute_cmd("functional")
+    else:
+        print("skipping {} as execute condition fails" \
+              .format(runoneccltest.testname))
+    print("----------------------------------------------------------------------------------------\n")
+
+
 if __name__ == "__main__":
     pass

--- a/contrib/intel/jenkins/runtests.py
+++ b/contrib/intel/jenkins/runtests.py
@@ -14,7 +14,7 @@ parser.add_argument("--util", help="utility provider", choices=["rxd", "rxm"])
 parser.add_argument("--ofi_build_mode", help="specify the build configuration", \
                     choices = ["dbg", "dl"])
 parser.add_argument("--test", help="specify test to execute", \
-                    choices = ["all", "unit", "shmem", "mpi"])
+                    choices = ["all", "unit", "shmem", "mpi", "oneccl"])
 
 args = parser.parse_args()
 args_core = args.prov
@@ -60,6 +60,9 @@ if(args_core):
         if (run_test == 'all' or run_test == 'shmem'):
             run.shmemtest(args_core, hosts, ofi_build_mode)
 
+        if (run_test == 'all' or run_test == 'oneccl'):
+            run.oneccltest(args_core, hosts, ofi_build_mode)
+
         if (run_test == 'all' or run_test == 'all'):
             for mpi in mpilist:
                 run.mpich_test_suite(args_core, hosts, mpi, ofi_build_mode)
@@ -72,6 +75,9 @@ if(args_core):
 
         if (run_test == 'all' or run_test == 'shmem'):
             run.shmemtest(args_core, hosts, ofi_build_mode, util=args_util)
+
+        if (run_test == 'all' or run_test == 'oneccl'):
+            run.oneccltest(args_core, hosts, ofi_build_mode, util=args_util)
 
         if (run_test == 'all' or run_test == 'all'):
             for mpi in mpilist:

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -500,3 +500,72 @@ class MpiTestOSU(MpiTests):
                     command = launcher + osu_cmd
                     outputcmd = shlex.split(command)
                     common.run_command(outputcmd)
+
+class OneCCLTests(Test):
+
+    def __init__(self, jobname, buildno, testname, core_prov, fabric,
+                 hosts, ofi_build_mode, util_prov=None):
+        super().__init__(jobname, buildno, testname, core_prov, fabric,
+                         hosts, ofi_build_mode, util_prov)
+
+        self.n = 2
+        self.ppn = 1
+        self.oneccl_path = "{}/oneccl/build".format(ci_site_config.build_dir)
+
+        self.examples_tests = {'allgatherv',
+                               'allreduce',
+                               'alltoallv',
+                               'broadcast',
+                               'communicator',
+                               'cpu_allgatherv_test',
+                               'cpu_allreduce_bf16_test',
+                               'cpu_allreduce_test',
+                               'custom_allreduce',
+                               'datatype',
+                               'external_kvs',
+                               'priority_allreduce',
+                               'reduce',
+                               'reduce_scatter',
+                               'unordered_allreduce'
+                              }
+        self.functional_tests = {'allgatherv_test',
+                                 'allreduce_test',
+                                 'alltoall_test',
+                                 'alltoallv_test',
+                                 'bcast_test',
+                                 'reduce_scatter_test',
+                                 'reduce_test'
+                                }
+
+    @property
+    def cmd(self):
+        return "{}/run_oneccl.sh ".format(ci_site_config.mpi_testpath)
+
+    def options(self, oneccl_test):
+        opts = "-n {n} -ppn {ppn} -hosts {server},{client} -prov '{provider}' \
+        -test {test_suite} -libfabric_path={path}/lib \
+        -oneccl_root={oneccl_path}" \
+        .format(n=self.n, ppn=self.ppn, server=self.server, \
+        client=self.client, provider=self.core_prov, test_suite=oneccl_test, \
+        path=self.libfab_installpath, oneccl_path=self.oneccl_path)
+        return opts
+
+    @property
+    def execute_condn(self):
+        return True if (self.core_prov == "tcp") else False
+
+
+    def execute_cmd(self, oneccl_test):
+        if oneccl_test == "examples":
+                for test in self.examples_tests:
+                        command = self.cmd + self.options(oneccl_test) + \
+                                  " {}".format(test)
+                        outputcmd = shlex.split(command)
+                        common.run_command(outputcmd)
+        elif oneccl_test == "functional":
+                for test in self.functional_tests:
+                        command = self.cmd + self.options(oneccl_test) + \
+                                  " {}".format(test)
+                        outputcmd = shlex.split(command)
+                        common.run_command(outputcmd)
+


### PR DESCRIPTION
Two sets of OneCCL tests, examples and functional, have been
added to the Intel CI. OneCCL has been built in CPU only mode 
currently.

The test output is too wordy and hence will not be printed
on the console. It is being redirected to /dev/null and the
return code is used to determine if test has passed. OneCCL
team will be adding a new non-verbose option to the tests
for reducing output.

The time taken by a complete CI run is about  23 minutes after
these changes.

Signed-off-by: Juee Himalbhai Desai <juee.himalbhai.desai@intel.com>