### PR TITLE
[v1.14.x] fabtests: disable inject when FI_HMEM is enabled

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -88,10 +88,16 @@ jobs:
         run: |
           echo "Installing Ze SDK"
           sudo apt-get install -y gpg-agent wget
-          wget -qO - https://repositories.intel.com/graphics/intel-graphics.key | sudo apt-key add -
-          sudo apt-add-repository 'deb [arch=amd64] https://repositories.intel.com/graphics/ubuntu focal main'
-          sudo apt-get update
-          sudo apt-get install -y level-zero level-zero-dev
+
+          # Temporary workaround to avoid 1.6.2 (current version in the distro) which is failing to build
+          wget -q https://github.com/oneapi-src/level-zero/releases/download/v1.7.4/level-zero_1.7.4+u18.04_amd64.deb
+          wget -q https://github.com/oneapi-src/level-zero/releases/download/v1.7.4/level-zero-devel_1.7.4+u18.04_amd64.deb
+          sudo apt install ./level-zero_1.7.4+u18.04_amd64.deb ./level-zero-devel_1.7.4+u18.04_amd64.deb
+
+          #wget -qO - https://repositories.intel.com/graphics/intel-graphics.key | sudo apt-key add -
+          #sudo apt-add-repository 'deb [arch=amd64] https://repositories.intel.com/graphics/ubuntu focal main'
+          #sudo apt-get update
+          #sudo apt-get install -y level-zero level-zero-dev
       - uses: actions/checkout@v2
       - name: HMEM Checks
         run: |

--- a/fabtests/benchmarks/benchmark_shared.c
+++ b/fabtests/benchmarks/benchmark_shared.c
@@ -86,6 +86,9 @@ int pingpong(void)
 	inject_size = inject_size_set ?
 			hints->tx_attr->inject_size : fi->tx_attr->inject_size;
 
+	if (opts.options & FT_OPT_ENABLE_HMEM)
+		inject_size = 0;
+
 	ret = ft_sync();
 	if (ret)
 		return ret;
@@ -161,6 +164,9 @@ int bandwidth(void)
 
 	inject_size = inject_size_set ?
 			hints->tx_attr->inject_size : fi->tx_attr->inject_size;
+
+	if (opts.options & FT_OPT_ENABLE_HMEM)
+		inject_size = 0;
 
 	ret = ft_sync();
 	if (ret)
@@ -252,6 +258,9 @@ int bandwidth_rma(enum ft_rma_opcodes rma_op, struct fi_rma_iov *remote)
 
 	inject_size = inject_size_set ?
 			hints->tx_attr->inject_size: fi->tx_attr->inject_size;
+
+	if (opts.options & FT_OPT_ENABLE_HMEM)
+		inject_size = 0;
 
 	ret = ft_sync();
 	if (ret)


### PR DESCRIPTION
This PR is a backport of https://github.com/ofiwg/libfabric/pull/7334/commits/65fa2adcb3ff1d70b54d2f593b53a68edc869a1d to v1.14.x branch 