### PR TITLE
prov/tcp: Wake-up threads blocked on CQ to update their poll events

### DIFF
--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -812,7 +812,7 @@ int tcpx_try_func(void *util_ep)
 void tcpx_tx_queue_insert(struct tcpx_ep *ep,
 			  struct tcpx_xfer_entry *tx_entry)
 {
-	struct util_wait *wait = ep->util_ep.tx_cq->wait;
+	struct util_wait *rx_wait, *tx_wait;
 
 	if (!ep->cur_tx.entry) {
 		ep->cur_tx.entry = tx_entry;
@@ -821,8 +821,17 @@ void tcpx_tx_queue_insert(struct tcpx_ep *ep,
 		ep->hdr_bswap(&tx_entry->hdr.base_hdr);
 		tcpx_progress_tx(ep);
 
-		if (!ep->cur_tx.entry && wait)
-			wait->signal(wait);
+		/* Wake-up blocked threads if they need to add POLLOUT to
+		 * their events to monitor for this socket.
+		 */
+		tx_wait = ep->util_ep.tx_cq->wait;
+		rx_wait = ep->util_ep.rx_cq->wait;
+		if (ep->cur_tx.entry) {
+			if (tx_wait)
+				tx_wait->signal(tx_wait);
+			if (rx_wait && rx_wait != tx_wait)
+				rx_wait->signal(rx_wait);
+		}
 	} else if (tx_entry->ctrl_flags & TCPX_INTERNAL_XFER) {
 		slist_insert_tail(&tx_entry->entry, &ep->priority_queue);
 	} else {


### PR DESCRIPTION
Commit 45dce66 incorrectly negated a check that is used to signal
any threads waiting on a cq to wake up.  Without this signal,
applications can hang, as reported in issue 7443.  The situation is
as follows:

A thread waits for completions on the CQ. At the time that the thread
blocks, the socket has no outgoing transfers, so the thread calls
poll looking for a POLLIN event.

Another thread tries to send a large transfer. A portion of the data
is accepted by the socket. The rest of the transfer is queued on the ep.
That thread returns.  Additional messages may be posted to the ep, but
since there's already an active transfer, those messages simply get
queued on the tx_queue.

Note that the thread that was blocked on the CQ is still blocked waiting
for a POLLIN event.  However, it should be waiting for POLLOUT | POLLIN.
The signal in this case isn't trying to drive progress, like the original
commit suggests, but is needed to update the poll call.

Reverse the check, so that blocked threads wake up and can update their
poll event status.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>