### PR TITLE
src/hmem_ze.c: fix ze dlopen path

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -579,35 +579,39 @@ AS_IF([test x"$with_ze" != x"no"],
 			[], [])],
       [])
 
-have_drm=0
-AS_IF([test "$have_ze" = "1"],
-      [AC_CHECK_HEADER(drm/i915_drm.h, [have_drm=1], [])]
-      [])
-
-AS_IF([test x"$with_ze" != x"no" && test -n "$with_ze" && test "$have_ze" = "0" ],
-	[AC_MSG_ERROR([ZE support requested but ZE runtime not available.])],
-	[])
-
-AC_DEFINE_UNQUOTED([HAVE_LIBZE], [$have_ze], [ZE support])
-AC_DEFINE_UNQUOTED([HAVE_DRM], [$have_drm], [i915 DRM header])
-
 AC_ARG_ENABLE([ze-dlopen],
     [AS_HELP_STRING([--enable-ze-dlopen],
         [Enable dlopen of ZE libraries @<:@default=no@:>@])
     ],
     [
         AS_IF([test "$freebsd" = "0"], [
-            AC_CHECK_LIB(dl, dlopen, [],
-                [AC_MSG_ERROR([dlopen not found.  libfabric requires libdl.])])
+            AC_CHECK_LIB(dl, dlopen, [enable_ze_dlopen=1],
+                [AC_MSG_ERROR([dlopen not found.  libfabric requires libdl.])
+		 enable_ze_dlopen=0])
         ])
-        AC_DEFINE([ENABLE_ZE_DLOPEN], [1], [dlopen ZE libraries])
     ],
-    [enable_ze_dlopen=no])
+    [enable_ze_dlopen=0])
 
-AS_IF([test x"$enable_ze_dlopen" != x"yes"], [LIBS="$LIBS $ze_LIBS"])
+AC_DEFINE_UNQUOTED([ENABLE_ZE_DLOPEN], [$enable_ze_dlopen], [dlopen ZE libraries])
+
 AS_IF([test "$have_ze" = "1" && test x"$with_ze" != x"yes"],
       [CPPFLAGS="$CPPFLAGS $ze_CPPFLAGS"
        LDFLAGS="$LDFLAGS $ze_LDFLAGS"])
+
+AS_IF([test "$enable_ze_dlopen" != "1"], [LIBS="$LIBS $ze_LIBS"], [have_ze=1])
+
+AC_DEFINE_UNQUOTED([HAVE_ZE], [$have_ze], [ZE support])
+
+AS_IF([test x"$with_ze" != x"no" && test -n "$with_ze" && test "$have_ze" = "0" ],
+	[AC_MSG_ERROR([ZE support requested but ZE runtime not available.])],
+	[])
+
+have_drm=0
+AS_IF([test "$have_ze" = "1"],
+      [AC_CHECK_HEADER(drm/i915_drm.h, [have_drm=1], [])]
+      [])
+
+AC_DEFINE_UNQUOTED([HAVE_DRM], [$have_drm], [i915 DRM header])
 
 dnl Check for AWS Neuron runtime library for Neuron device support
 AC_ARG_WITH([neuron],

--- a/prov/util/src/ze_mem_monitor.c
+++ b/prov/util/src/ze_mem_monitor.c
@@ -32,7 +32,7 @@
 
 #include "ofi_mr.h"
 
-#if HAVE_LIBZE
+#if HAVE_ZE
 
 #include "ofi_hmem.h"
 
@@ -96,7 +96,7 @@ static int ze_monitor_start(struct ofi_mem_monitor *monitor)
 	return -FI_ENOSYS;
 }
 
-#endif /* HAVE_LIBZE */
+#endif /* HAVE_ZE */
 
 void ze_monitor_stop(struct ofi_mem_monitor *monitor)
 {

--- a/src/hmem_ze.c
+++ b/src/hmem_ze.c
@@ -37,7 +37,7 @@
 #include "ofi_hmem.h"
 #include "ofi.h"
 
-#if HAVE_LIBZE
+#if HAVE_ZE
 
 #include <dirent.h>
 #include <level_zero/ze_api.h>
@@ -128,7 +128,7 @@ struct libze_ops {
 					     ze_device_properties_t *pDeviceProperties);
 };
 
-#ifdef ENABLE_ZE_DLOPEN
+#if ENABLE_ZE_DLOPEN
 
 #include <dlfcn.h>
 
@@ -429,7 +429,7 @@ bool ze_hmem_p2p_enabled(void)
 
 static int ze_hmem_dl_init(void)
 {
-#ifdef ENABLE_ZE_DLOPEN
+#if ENABLE_ZE_DLOPEN
 	libze_handle = dlopen("libze_loader.so", RTLD_NOW);
 	if (!libze_handle) {
 		FI_WARN(&core_prov, FI_LOG_CORE,
@@ -969,4 +969,4 @@ int *ze_hmem_get_dev_fds(int *nfds)
 	return NULL;
 }
 
-#endif /* HAVE_LIBZE */
+#endif /* HAVE_ZE */


### PR DESCRIPTION
When ze dlopen is enabled, the ELSE path was taken instead of properly building ze support

Signed-off-by: Zach Dworkin <zachary.dworkin@intel.com>