### PR TITLE
prov/efa: disable IBV_SEND_INLINE to fix performance regression.

### DIFF
--- a/prov/efa/src/efa_msg.c
+++ b/prov/efa/src/efa_msg.c
@@ -351,10 +351,6 @@ static ssize_t efa_post_send(struct efa_ep *ep, const struct fi_msg *msg, uint64
 
 	efa_post_send_sgl(ep, msg, ewr);
 
-	if (len <= ep->domain->ctx->inline_buf_size &&
-	    !efa_msg_has_hmem_mr(msg))
-		wr->send_flags |= IBV_SEND_INLINE;
-
 	wr->opcode = IBV_WR_SEND;
 	wr->wr_id = (uintptr_t)msg->context;
 	wr->wr.ud.ah = conn->ah->ibv_ah;


### PR DESCRIPTION
We have observed that using IBV_SEND_INLINE caused 3% of perf regression
in IMB Bcast from 16 bytes to 1024 bytes. This patch removes such flag
to fix the regression.

Signed-off-by: Shi Jin <sjina@amazon.com>

Test Info: Run IMB Bcast + libfabric with & w/o this patch. This patch improves the perf by >=3%