### PR TITLE
prov/tcp: Avoid accessing partially destroyed endpoints

### DIFF
--- a/prov/util/src/util_main.c
+++ b/prov/util/src/util_main.c
@@ -103,9 +103,11 @@ void fid_list_remove(struct dlist_entry *fid_list, ofi_mutex_t *lock,
 	struct fid_list_entry *item;
 	struct dlist_entry *entry;
 
-	ofi_mutex_lock(lock);
+	if (lock)
+		ofi_mutex_lock(lock);
 	entry = dlist_remove_first_match(fid_list, ofi_fid_match, fid);
-	ofi_mutex_unlock(lock);
+	if (lock)
+		ofi_mutex_unlock(lock);
 
 	if (entry) {
 		item = container_of(entry, struct fid_list_entry, entry);


### PR DESCRIPTION
Re-arrange endpoint cleanup code to ensure that progress functions
(e.g. reading from the cq) cannot access an endpoint that is
in the process of being destroyed.  Remove the EP from all
progress related lists or poll sets prior to closing the socket or
freeing internal data structures.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>

This change doesn't fix any known issue; however, there are reports of problems by multi-threaded applications under stress testing where connections are abruptly terminated.  Analyzing whether the current cleanup code can result in problems.