### PR TITLE
prov/rxm, fabtests/ubertest: bug fixes and ubertest updates to validate bug fix

### DIFF
--- a/fabtests/scripts/runfabtests.sh
+++ b/fabtests/scripts/runfabtests.sh
@@ -580,8 +580,10 @@ function complex_test {
 
 	set_cfg_file $config
 	if [[ -z "$COMPLEX_CFG" ]]; then
-		is_excluded "$test" && return
+		return
 	fi
+
+	is_excluded "$test" && return
 
 	start_time=$(date '+%s')
 

--- a/fabtests/test_configs/tcp/all.test
+++ b/fabtests/test_configs/tcp/all.test
@@ -183,3 +183,192 @@
 		FT_FLAG_QUICKTEST,
 	],
 }
+{
+	prov_name: tcp;ofi_rxm,
+	test_type: [
+		FT_TEST_UNIT,
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+	],
+	test_class: [
+		FT_CAP_MSG,
+		FT_CAP_TAGGED,
+	],
+	class_function: [
+		FT_FUNC_SEND,
+		FT_FUNC_SENDV,
+		FT_FUNC_SENDMSG,
+		FT_FUNC_INJECT,
+		FT_FUNC_INJECTDATA,
+		FT_FUNC_SENDDATA,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+		FT_COMP_CNTR,
+	],
+	mr_mode: [],
+	progress: [
+		FI_PROGRESS_MANUAL,
+		FI_PROGRESS_AUTO
+	],
+	test_flags: [
+		FT_FLAG_QUICKTEST
+	],
+},
+{
+	prov_name: tcp;ofi_rxm,
+	test_type: [
+		FT_TEST_UNIT,
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH
+	],
+	test_class: [
+		FT_CAP_RMA,
+	],
+	class_function: [
+		FT_FUNC_WRITE,
+		FT_FUNC_WRITEV,
+		FT_FUNC_WRITEMSG,
+		FT_FUNC_WRITEDATA,
+		FT_FUNC_INJECT_WRITE,
+		FT_FUNC_INJECT_WRITEDATA,
+		FT_FUNC_READ,
+		FT_FUNC_READV,
+		FT_FUNC_READMSG,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	mr_mode: [],
+	progress: [
+		FI_PROGRESS_MANUAL,
+		FI_PROGRESS_AUTO
+	],
+	test_flags: [
+		FT_FLAG_QUICKTEST
+	],
+},
+{
+	prov_name: tcp;ofi_rxm,
+	test_type: [
+		FT_TEST_UNIT,
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH
+	],
+	test_class: [
+		FT_CAP_ATOMIC,
+	],
+	class_function: [
+		FT_FUNC_ATOMIC,
+		FT_FUNC_ATOMICV,
+		FT_FUNC_ATOMICMSG,
+		FT_FUNC_INJECT_ATOMIC,
+		FT_FUNC_FETCH_ATOMIC,
+		FT_FUNC_FETCH_ATOMICV,
+		FT_FUNC_FETCH_ATOMICMSG,
+		FT_FUNC_COMPARE_ATOMIC,
+		FT_FUNC_COMPARE_ATOMICV,
+		FT_FUNC_COMPARE_ATOMICMSG
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	mr_mode: [],
+	progress: [
+		FI_PROGRESS_MANUAL,
+		FI_PROGRESS_AUTO
+	],
+	test_flags: [
+		FT_FLAG_QUICKTEST
+	],
+},
+{
+	prov_name: tcp;ofi_rxm,
+	test_type: [
+		FT_TEST_LATENCY,
+	],
+	test_class: [
+		FT_CAP_TAGGED,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	eq_wait_obj: [
+		FI_WAIT_NONE,
+		FI_WAIT_UNSPEC,
+		FI_WAIT_FD
+	],
+	mr_mode: [],
+	progress: [
+		FI_PROGRESS_MANUAL
+	],
+	test_flags: [
+		FT_FLAG_QUICKTEST
+	],
+},
+{
+	prov_name: tcp;ofi_rxm,
+	test_type: [
+		FT_TEST_LATENCY,
+	],
+	test_class: [
+		FT_CAP_TAGGED,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	cq_wait_obj: [
+		FI_WAIT_NONE,
+		FI_WAIT_UNSPEC,
+		FI_WAIT_FD
+	],
+	mr_mode: [],
+	progress: [
+		FI_PROGRESS_MANUAL
+	],
+	test_flags: [
+		FT_FLAG_QUICKTEST
+	],
+},
+{
+	prov_name: tcp;ofi_rxm,
+	test_type: [
+		FT_TEST_LATENCY,
+	],
+	test_class: [
+		FT_CAP_TAGGED,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	comp_type: [
+		FT_COMP_CNTR,
+	],
+	cntr_wait_obj: [
+		FI_WAIT_NONE,
+		FI_WAIT_UNSPEC,
+		FI_WAIT_FD
+	],
+	mr_mode: [],
+	progress: [
+		FI_PROGRESS_MANUAL
+	],
+	test_flags: [
+		FT_FLAG_QUICKTEST
+	],
+},

--- a/fabtests/test_configs/verbs/all.test
+++ b/fabtests/test_configs/verbs/all.test
@@ -155,3 +155,113 @@
 	mode: [FI_CONTEXT, FI_RX_CQ_DATA],
 	mr_mode: [FI_MR_LOCAL, FI_MR_VIRT_ADDR, FI_MR_ALLOCATED, FI_MR_PROV_KEY],
 },
+#: "Suite of tests for the verbs provider"
+#: "
+# TODO
+#  - Debug WRITEDATA, WRITEMSG, READMSG for RxM before enabling
+#  - Test without FI_MR_LOCAL for RxM
+#  - disable quick test for some configs (takes long time on some fabric)
+#  - Adding more tests results in timeout in runfabtests.sh - fix the script"
+{
+	prov_name: verbs;ofi_rxm,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+	],
+	class_function: [
+		FT_FUNC_SEND,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	eq_wait_obj: [
+		FI_WAIT_NONE,
+	],
+	cq_wait_obj: [
+		FI_WAIT_NONE,
+		FI_WAIT_UNSPEC,
+		FI_WAIT_FD,
+	],
+	test_class: [
+		FT_CAP_MSG,
+	],
+	mr_mode: [FI_MR_LOCAL, FI_MR_VIRT_ADDR, FI_MR_ALLOCATED, FI_MR_PROV_KEY],
+	progress: [FI_PROGRESS_MANUAL, FI_PROGRESS_AUTO],
+},
+{
+	prov_name: verbs;ofi_rxm,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+	],
+	class_function: [
+		FT_FUNC_SEND,
+		FT_FUNC_SENDV,
+		FT_FUNC_SENDDATA,
+		FT_FUNC_INJECT,
+		FT_FUNC_INJECTDATA,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	test_class: [
+		FT_CAP_MSG,
+		FT_CAP_TAGGED,
+	],
+	mr_mode: [FI_MR_LOCAL, FI_MR_VIRT_ADDR, FI_MR_ALLOCATED, FI_MR_PROV_KEY],
+	progress: [FI_PROGRESS_MANUAL, FI_PROGRESS_AUTO],
+},
+{
+	prov_name: verbs;ofi_rxm,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+	],
+	class_function: [
+		FT_FUNC_SENDMSG,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	test_class: [
+		FT_CAP_MSG,
+		FT_CAP_TAGGED,
+	],
+	mr_mode: [FI_MR_LOCAL, FI_MR_VIRT_ADDR, FI_MR_ALLOCATED, FI_MR_PROV_KEY],
+	progress: [FI_PROGRESS_MANUAL, FI_PROGRESS_AUTO],
+	msg_flags: FI_REMOTE_CQ_DATA,
+},
+{
+	prov_name: verbs;ofi_rxm,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+	],
+	class_function: [
+		FT_FUNC_WRITE,
+		FT_FUNC_WRITEV,
+		FT_FUNC_READ,
+		FT_FUNC_READV,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	test_class: [
+		FT_CAP_RMA,
+	],
+	mr_mode: [FI_MR_LOCAL, FI_MR_VIRT_ADDR, FI_MR_ALLOCATED, FI_MR_PROV_KEY],
+	progress: [FI_PROGRESS_MANUAL, FI_PROGRESS_AUTO],
+	test_flags: FT_FLAG_QUICKTEST,
+},

--- a/fabtests/ubertest/config.c
+++ b/fabtests/ubertest/config.c
@@ -878,11 +878,11 @@ void fts_cur_info(struct ft_series *series, struct ft_info *info)
 	} else {
 		if (info->test_class & FI_TAGGED)
 			info->cq_format = FI_CQ_FORMAT_TAGGED;
-		else if (info->test_class & FI_MSG)
-			info->cq_format = FI_CQ_FORMAT_MSG;
 		else if (info->msg_flags & FI_REMOTE_CQ_DATA ||
 		    is_data_func(info->class_function))
 			info->cq_format = FI_CQ_FORMAT_DATA;
+		else if (info->test_class & FI_MSG)
+			info->cq_format = FI_CQ_FORMAT_MSG;
 		else
 			info->cq_format = FI_CQ_FORMAT_CONTEXT;
 	}

--- a/fabtests/ubertest/cq.c
+++ b/fabtests/ubertest/cq.c
@@ -66,49 +66,38 @@ int ft_use_comp_cq(enum ft_comp_type comp_type)
 	return 0;
 }
 
-int ft_generates_rx_comp(void)
+bool ft_generates_rx_comp(void)
 {
-	if (is_data_func(test_info.class_function) ||
-	    (is_msg_func(test_info.class_function) &&
-	    test_info.msg_flags & FI_REMOTE_CQ_DATA))
-		return 1;
+	if (test_info.test_class & FI_ATOMIC)
+		return false;
 
-	if (test_info.test_class & (FI_RMA | FI_ATOMIC))
-		return 0;
+	if ((test_info.test_class & FI_RMA) &&
+	    !is_data_func(test_info.class_function) &&
+	    !(is_msg_func(test_info.class_function) &&
+	      test_info.msg_flags & FI_REMOTE_CQ_DATA))
+		return false;
 
 	if (!(test_info.rx_cq_bind_flags & FI_SELECTIVE_COMPLETION))
-		return 1;
-	if (test_info.rx_op_flags & FI_COMPLETION) {
-		if (is_msg_func(test_info.class_function) &&
-		    !(test_info.msg_flags & FI_COMPLETION))
-			return 0;
-		return 1;
-	}
-	if (is_msg_func(test_info.class_function) &&
-	    test_info.msg_flags & FI_COMPLETION)
-		return 1;
-	return 0;
+		return true;
+
+	if (is_msg_func(test_info.class_function))
+		return test_info.msg_flags & FI_COMPLETION;
+
+	return test_info.rx_op_flags & FI_COMPLETION;
 }
 
-int ft_generates_tx_comp(void)
+bool ft_generates_tx_comp(void)
 {
-	if (!(test_info.tx_cq_bind_flags & FI_SELECTIVE_COMPLETION)) {
-		if (is_inject_func(test_info.class_function))
-			return 0;
-		return 1;
-	}
+	if (is_inject_func(test_info.class_function))
+		return false;
 
-	if (test_info.tx_op_flags & FI_COMPLETION) {
-		if (is_msg_func(test_info.class_function) &&
-		    !(test_info.msg_flags & FI_COMPLETION))
-			return 0;
-		return 1;
-	}
+	if (!(test_info.tx_cq_bind_flags & FI_SELECTIVE_COMPLETION))
+		return true;
 
-	if (test_info.msg_flags & FI_COMPLETION)
-		return 1;
+	if (is_msg_func(test_info.class_function))
+		return test_info.msg_flags & FI_COMPLETION;
 
-	return 0;
+	return test_info.tx_op_flags & FI_COMPLETION;
 }
 
 int ft_check_rx_completion(void)

--- a/fabtests/ubertest/fabtest.h
+++ b/fabtests/ubertest/fabtest.h
@@ -352,8 +352,8 @@ void ft_format_iov(struct iovec *iov, size_t cnt, char *buf, size_t len);
 void ft_format_iocs(struct iovec *iov, size_t *iov_count);
 void ft_next_iov_cnt(struct ft_xcontrol *ctrl, size_t max_iov_cnt);
 int ft_get_ctx(struct ft_xcontrol *ctrl, struct fi_context **ctx);
-int ft_generates_rx_comp();
-int ft_generates_tx_comp();
+bool ft_generates_rx_comp();
+bool ft_generates_tx_comp();
 int ft_check_rx_completion();
 int ft_check_tx_completion();
 

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1542,7 +1542,13 @@ static void rxm_fake_rx_hdr(struct rxm_rx_buf *rx_buf,
 	rx_buf->pkt.hdr.op = ofi_op_tagged;
 	rx_buf->pkt.hdr.tag = entry->tag;
 	rx_buf->pkt.hdr.size = entry->len;
-	rx_buf->pkt.hdr.flags = 0;
+
+	if (entry->flags & FI_REMOTE_CQ_DATA) {
+		rx_buf->pkt.hdr.data = entry->data;
+		rx_buf->pkt.hdr.flags = FI_REMOTE_CQ_DATA;
+	} else {
+		rx_buf->pkt.hdr.flags = 0;
+	}
 }
 
 static ssize_t

--- a/prov/rxm/src/rxm_msg.c
+++ b/prov/rxm/src/rxm_msg.c
@@ -593,7 +593,7 @@ static ssize_t
 rxm_msg_tinject(struct fid_ep *msg_ep, const void *buf, size_t len,
 		bool cq_data, uint64_t data, uint64_t tag)
 {
-	return cq_data ?
+	return !cq_data ?
 		fi_tinject(msg_ep, buf, len, 0, tag) :
 		fi_tinjectdata(msg_ep, buf, len, data, 0, tag);
 }


### PR DESCRIPTION
The separation of the tcp/verbs and ofi_rxm ubertest config files were preventing failing combinations from running. This fixes the coverage gap as well as some bugs in rxm from that gap.