### PR TITLE
util/fi_info: Fix always displaying verbose output

### DIFF
--- a/util/info.c
+++ b/util/info.c
@@ -330,7 +330,7 @@ static int run(struct fi_info *hints, char *node, char *port, uint64_t flags)
 
 	if (env)
 		ret = print_vars();
-	else if (verbose || info)
+	else if (verbose)
 		ret = print_long_info(info);
 	else if (list_providers)
 		ret = print_providers(info);


### PR DESCRIPTION
Commit 4646751 bad.  Always show everything.  Remove wrong check
to verbose path.  Make good.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>