### PR TITLE
configure.ac: rewrite ze checks to minimize ZE dl requirements

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -562,49 +562,57 @@ AC_ARG_ENABLE([cuda-dlopen],
     [enable_cuda_dlopen=no])
 
 AC_ARG_WITH([ze],
-	AS_HELP_STRING([--with-ze=DIR], [Provide path to where the ZE
-					 libraries and headers are installed.]),
-	[], [])
+	[AS_HELP_STRING([--with-ze=DIR], [Enable ZE build and fail if not found.
+					  Optional=<Path to where the ZE libraries
+					  and headers are installed.>])])
 
 have_ze=0
-AS_IF([test x"$with_ze" != x"no"],
-      [FI_CHECK_PACKAGE([ze],
-			[level_zero/ze_api.h],
-			[ze_loader],
-			[zeInit],
-			[],
-			[$with_ze],
-			[],
-			[have_ze=1],
-			[], [])],
-      [])
-
-have_drm=0
-AS_IF([test "$have_ze" = "1"],
-      [AC_CHECK_HEADER(drm/i915_drm.h, [have_drm=1], [])]
-      [])
-
-AS_IF([test x"$with_ze" != x"no" && test -n "$with_ze" && test "$have_ze" = "0" ],
-	[AC_MSG_ERROR([ZE support requested but ZE runtime not available.])],
-	[])
-
-AC_DEFINE_UNQUOTED([HAVE_LIBZE], [$have_ze], [ZE support])
-AC_DEFINE_UNQUOTED([HAVE_DRM], [$have_drm], [i915 DRM header])
-
+ze_dlopen=0
 AC_ARG_ENABLE([ze-dlopen],
     [AS_HELP_STRING([--enable-ze-dlopen],
         [Enable dlopen of ZE libraries @<:@default=no@:>@])
     ],
     [
-        AS_IF([test "$freebsd" = "0"], [
-            AC_CHECK_LIB(dl, dlopen, [],
-                [AC_MSG_ERROR([dlopen not found.  libfabric requires libdl.])])
-        ])
-        AC_DEFINE([ENABLE_ZE_DLOPEN], [1], [dlopen ZE libraries])
-    ],
-    [enable_ze_dlopen=no])
+        AS_IF([test x"$with_dlopen" = "no"],
+              [AC_MSG_ERROR([dlopen not found.  libfabric requires libdl.])])
+	ze_dlopen=1
+    ])
 
-AS_IF([test x"$enable_ze_dlopen" != x"yes"], [LIBS="$LIBS $ze_LIBS"])
+AS_IF([test x"$with_ze" != x"no"],
+      [
+	AS_IF([test "$ze_dlopen" != "0"],
+	      [
+		_FI_CHECK_PACKAGE_HEADER([ze],
+				[level_zero/ze_api.h],
+				[$with_ze],
+				[have_ze=1],
+				[AC_MSG_ERROR([ZE headers not found. Cannot enable ZE DL])])
+	      ],
+	      [
+		FI_CHECK_PACKAGE([ze],
+				[level_zero/ze_api.h],
+				[ze_loader],
+				[zeInit],
+				[],
+				[$with_ze],
+				[],
+				[have_ze=1])
+	      ])
+      ])
+
+AC_DEFINE_UNQUOTED([ENABLE_ZE_DLOPEN], [$ze_dlopen], [dlopen ZE libraries])
+
+have_drm=0
+AS_IF([test "$have_ze" = "1"],
+      [AC_CHECK_HEADER(drm/i915_drm.h, [have_drm=1])])
+
+AS_IF([test x"$with_ze" != x"no" && test -n "$with_ze" && test "$have_ze" = "0" ],
+	[AC_MSG_ERROR([ZE support requested but ZE runtime not available.])])
+
+AC_DEFINE_UNQUOTED([HAVE_ZE], [$have_ze], [ZE support])
+AC_DEFINE_UNQUOTED([HAVE_DRM], [$have_drm], [i915 DRM header])
+
+AS_IF([test "$ze_dlopen" != "1"], [LIBS="$LIBS $ze_LIBS"])
 AS_IF([test "$have_ze" = "1" && test x"$with_ze" != x"yes"],
       [CPPFLAGS="$CPPFLAGS $ze_CPPFLAGS"
        LDFLAGS="$LDFLAGS $ze_LDFLAGS"])

--- a/prov/util/src/ze_mem_monitor.c
+++ b/prov/util/src/ze_mem_monitor.c
@@ -32,7 +32,7 @@
 
 #include "ofi_mr.h"
 
-#if HAVE_LIBZE
+#if HAVE_ZE
 
 #include "ofi_hmem.h"
 
@@ -96,7 +96,7 @@ static int ze_monitor_start(struct ofi_mem_monitor *monitor)
 	return -FI_ENOSYS;
 }
 
-#endif /* HAVE_LIBZE */
+#endif /* HAVE_ZE */
 
 void ze_monitor_stop(struct ofi_mem_monitor *monitor)
 {

--- a/src/hmem_ze.c
+++ b/src/hmem_ze.c
@@ -37,7 +37,7 @@
 #include "ofi_hmem.h"
 #include "ofi.h"
 
-#if HAVE_LIBZE
+#if HAVE_ZE
 
 #include <dirent.h>
 #include <level_zero/ze_api.h>
@@ -128,7 +128,7 @@ struct libze_ops {
 					     ze_device_properties_t *pDeviceProperties);
 };
 
-#ifdef ENABLE_ZE_DLOPEN
+#if ENABLE_ZE_DLOPEN
 
 #include <dlfcn.h>
 
@@ -429,7 +429,7 @@ bool ze_hmem_p2p_enabled(void)
 
 static int ze_hmem_dl_init(void)
 {
-#ifdef ENABLE_ZE_DLOPEN
+#if ENABLE_ZE_DLOPEN
 	libze_handle = dlopen("libze_loader.so", RTLD_NOW);
 	if (!libze_handle) {
 		FI_WARN(&core_prov, FI_LOG_CORE,
@@ -574,7 +574,7 @@ err_out:
 
 static void ze_hmem_dl_cleanup(void)
 {
-#ifdef ENABLE_ZE_DLOPEN
+#if ENABLE_ZE_DLOPEN
 	dlclose(libze_handle);
 #endif
 }
@@ -969,4 +969,4 @@ int *ze_hmem_get_dev_fds(int *nfds)
 	return NULL;
 }
 
-#endif /* HAVE_LIBZE */
+#endif /* HAVE_ZE */


### PR DESCRIPTION
Enabling the ZE DL open path only requires having the ZE headers, not the ZE libraries
but the old code was checking for both.

To minimize this requirement, this rewrites the configure code and cleans it up so we
only take one of the two paths - only check for headers with ze_dlopen or check for
headers and the library.

This also fixes an issue where ENABLE_ZE_DLOPEN was only getting defined when enabled
but it is best practice to always set it and check for #if instead of #ifdef

Additionally, the old enable-ze-dlopen check was redundantly checking for libdl when
it was already checked in the beginning as part of the --with-dl check

This also updates the --with-ze help message to better reflect its usage and removes
redundant empty brackets which are not needed.

Signed-off-by: Alexia Ingerson <alexia.ingerson@intel.com>