### PR TITLE
fabtests/pytest: a series out improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ fabtests/unit/fi_*
 fabtests/multinode/fi_*
 fabtests/prov/efa/src/fi_efa*
 pingpong/fi_*
+
+fabtests/pytest/__pycache__
+fabtests/pytest/*/__pycache__

--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -113,6 +113,7 @@ nobase_dist_config_DATA = \
 	test_configs/efa/efa-neuron.exclude \
 	test_configs/efa/efa.exclude \
 	pytest/pytest.ini \
+	pytest/options.yaml \
 	pytest/conftest.py \
 	pytest/common.py \
 	pytest/default/test_av.py \

--- a/fabtests/pytest/conftest.py
+++ b/fabtests/pytest/conftest.py
@@ -70,7 +70,7 @@ class CmdlineArgs:
         if self.server_interface is None:
             self.server_interface = self.server_id
 
-    def populate_command(self, base_command, host_type):
+    def populate_command(self, base_command, host_type, timeout=None):
         '''
             populate base command with informations in command line: provider, environments, etc
         '''
@@ -79,7 +79,10 @@ class CmdlineArgs:
         if not (self.binpath is None):
             command = self.binpath + "/" + command
 
-        command = "timeout " + str(self.timeout) + " " + command
+        if timeout is None:
+            timeout = self.timeout
+
+        command = "timeout " + str(timeout) + " " + command
 
         # set environment variables if specified
         if not (self.environments is None):

--- a/fabtests/pytest/conftest.py
+++ b/fabtests/pytest/conftest.py
@@ -1,34 +1,35 @@
 import pytest
 
+def get_option_longform(option_name, option_params):
+    '''
+        get the long form command line option name of an option
+    '''
+    return option_params.get("longform", "--" + option_name.replace("_", "-"))
+
 def pytest_addoption(parser):
+    import yaml, builtins
+
     parser.addoption("--provider", dest="provider", help="libfabric provider")
-    parser.addoption("--client_id", dest="client_id", help="client IP address or hostname")
-    parser.addoption("--server_id", dest="server_id", help="server IP address or hostname")
-    parser.addoption("--good_address", dest="good_address",
-                     help="good address from host's perspective (default $GOOD_ADDR)")
-    parser.addoption("--exclusion_list", dest="exclusion_list", help="a list of regex patterns")
-    parser.addoption("--environments", dest="environments",
-                     help="export provided variable name and value to ssh client and server processes.")
-    parser.addoption("--exclusion_file", dest="exclusion_file",
-                     help="a file that contains a list of regex patterns (one per line)")
-    parser.addoption("--exclude_negative_tests", dest="exclude_negative_tests", action="store_true",
-                     help="exclude negative unit tests")
-    parser.addoption("--binpath", dest="binpath", help="path to test bins (default PATH)") 
-    parser.addoption("--client_interface", dest="client_interface", type=str, help="client interface")
-    parser.addoption("--server_interface", dest="server_interface", type=str, help="server interface")
-    parser.addoption("--ubertest_config_file", dest="ubertest_config_file", type=str,
-                     help="configure option for ubertest tests")
-    parser.addoption("--timeout", dest="timeout", default="120",
-                     help="timeout value for each test, default to 120 seconds")
-    parser.addoption("--pin-core", dest="core_list", type=str, help="Specify cores to pin when running standard tests. Cores can specified via a comma-delimited list, like 0,2-4")
-    parser.addoption("--strict_fabtests_mode", dest="strict_fabtests_more", action="store_true",
-                     help="strict mode. -FI_ENODATA and -FI_NOSYS treated as failure instead of skip/notrun") 
-    parser.addoption("--additional_server_arguments", dest="additional_server_arguments", type=str,
-                     help="addtional arguments passed to server programs")
-    parser.addoption("--additional_client_arguments", dest="additional_client_arguments", type=str,
-                     help="addtional arguments passed to client programs")
-    parser.addoption("--oob_address_exchange", dest="oob_address_exchange", action="store_true",
-                     help="use out of band address exchange")
+    parser.addoption("--client-id", dest="client_id", help="client IP address or hostname")
+    parser.addoption("--server-id", dest="server_id", help="server IP address or hostname")
+
+    options = yaml.safe_load(open("options.yaml"))
+    for option_name in options.keys():
+        option_params = options[option_name]
+        option_longform = get_option_longform(option_name, option_params)
+        option_type = option_params["type"]
+        option_helpmsg = option_params["help"]
+        option_default = option_params.get("default")
+        if option_type == "int" and not (option_default is None):
+            option_default = int(option_default)
+
+        if option_type == "bool" or option_type == "boolean":
+            parser.addoption(option_longform, dest=option_name, action="store_true",
+                             help=option_helpmsg, default=option_default)
+        else:
+            assert option_type == "str" or option_type == "int"
+            parser.addoption(option_longform, dest=option_name, type=getattr(builtins, option_type),
+                             help=option_helpmsg, default=option_default)
 
 # base ssh command
 bssh = "ssh -n -o StrictHostKeyChecking=no -o ConnectTimeout=2 -o BatchMode=yes"
@@ -36,49 +37,38 @@ bssh = "ssh -n -o StrictHostKeyChecking=no -o ConnectTimeout=2 -o BatchMode=yes"
 class CmdlineArgs:
 
     def __init__(self, request):
+        import yaml
+
         self.provider = request.config.getoption("--provider")
         if self.provider is None:
             raise RuntimeError("Error: libfabric provider is not specified")
 
-        self.server_id = request.config.getoption("--server_id")
+        self.server_id = request.config.getoption("--server-id")
         if self.server_id is None:
             raise RuntimeError("Error: server is not specified")
 
-        self.client_id = request.config.getoption("--client_id")
+        self.client_id = request.config.getoption("--client-id")
         if self.client_id is None:
             raise RuntimeError("Error: client is not specified")
 
-        self.good_address = request.config.getoption("--good_address")
-        self.environments = request.config.getoption("--environments")
+        options = yaml.safe_load(open("options.yaml"))
+        for option_name in options.keys():
+            option_params = options[option_name]
+            option_longform = get_option_longform(option_name, option_params)
+            setattr(self, option_name, request.config.getoption(option_longform))
 
         self._exclusion_patterns = []
-        exclusion_list = request.config.getoption("--exclusion_list")
-        if exclusion_list:
-            self._add_exclusion_patterns_from_list(exclusion_list)
+        if self.exclusion_list:
+            self._add_exclusion_patterns_from_list(self.exclusion_list)
 
-        exclusion_file = request.config.getoption("--exclusion_file")
-        if exclusion_file:
-            self._add_exclusion_patterns_from_file(exclusion_file)
+        if self.exclusion_file:
+            self._add_exclusion_patterns_from_file(self.exclusion_file)
 
-        self.exclude_negative_tests = request.config.getoption("--exclude_negative_tests")
-
-        self.binpath = request.config.getoption("--binpath")
-
-        self.client_interface = request.config.getoption("--client_interface")
         if self.client_interface is None:
             self.client_interface = self.client_id
 
-        self.server_interface = request.config.getoption("--server_interface")
         if self.server_interface is None:
             self.server_interface = self.server_id
-
-        self.ubertest_config_file = request.config.getoption("--ubertest_config_file")
-        self.timeout = int(request.config.getoption("--timeout"))
-        self.core_list = request.config.getoption("--pin-core")
-        self.strict_fabtests_mode = request.config.getoption("--strict_fabtests_mode")
-        self.additional_server_arguments = request.config.getoption("--additional_server_arguments")
-        self.additional_client_arguments = request.config.getoption("--additional_client_arguments")
-        self.oob_address_exchange = request.config.getoption("--oob_address_exchange")
 
     def populate_command(self, base_command, host_type):
         '''

--- a/fabtests/pytest/default/test_ubertest.py
+++ b/fabtests/pytest/default/test_ubertest.py
@@ -11,8 +11,8 @@ def test_ubertest(cmdline_args, ubertest_test_type):
         pytest.skip("no config file")
         return
 
-    test = ClientServerTest(cmdline_args, "fi_ubertest")
-
     # uber test takes longer to finish, so set a larger timeout
-    test.run(timeout=1000)
+    test = ClientServerTest(cmdline_args, "fi_ubertest", timeout=1000)
+
+    test.run()
  

--- a/fabtests/pytest/options.yaml
+++ b/fabtests/pytest/options.yaml
@@ -1,0 +1,94 @@
+# a list of command line options that are shared by runfabtests.py and libfabric pytest.
+#
+# Each option has a variable name, long form command line argument name (longform).
+# Some options has a short form command line argument name.
+#
+# Variable name is used to access the value of the option from inside python scripts.
+#
+# Longform is used for user to specify the value of the option from command line.
+# By default, an option's longform is:
+#
+#    double dash ("--") + variable_name.replace("_", "-")
+#
+# (The replacement of underscore to dash is to follow linux command's convention.)
+# The default longform can be overriden by explicitly assign a longform for the option.
+#
+# Shortform is supported by runfabtests.py only. An option's shortform is
+#
+#    single dash ("-") + designated character
+# Note that not very option has a short form.
+#
+# The option exlcusion file's variable name is "exclusion_file", its
+# longform is "--exclusion-file", its shortform is "-f". Therefore, user can
+# specify exclusion file via:
+#
+#       runfabtests.py --exclusion-file <path_to_exclusion_file>
+#       runfabtests.py -f <path_to_exclusion_file
+#       pytest --exclusion-file <path_to_exclusion_file>
+#
+#  Developer can access the value of exclusion file via:
+#
+#       args.exlcusion_file in runfabtests.py
+#       cmdline_args.exclusion_file in pytest
+#
+good_address:
+  type: str
+  help: "good address from host's perspective (default $GOOD_ADDR)"
+  shortform: -g
+exclusion_list:
+  type: str
+  help: "comma delimited list of test names/regex patterns for test to be excluded.\nFor example: \"dgram,rma.*write\""
+  shortform: -e
+environments:
+  type: str
+  help: "export provided variable name and value to ssh client and server processes."
+  shortform: -E
+exclusion_file:
+  type: str
+  help: "exclude tests file: File containing list of test names/regex patterns\nto exclude (one per line)"
+  shortform: -f
+exclude_negative_tests:
+  type: boolean
+  help: "whether to exclusion negative unit tests. Default: no"
+  shortform: -N
+binpath:
+  type: str
+  help: "path to test bins (default PATH)"
+  shortform: -p
+client_interface:
+  type: str
+  help: "client interface"
+  shortform: -c
+server_interface:
+  type: str
+  help: "server interface"
+  shortform: -s
+ubertest_config_file:
+  type: str
+  help: "configure option for uber tests"
+  shortform: -u
+timeout:
+  type: int
+  help: "timeout value in seconds"
+  default: 120
+  shortform: -T
+core_list:
+  type: str
+  help: "Specify cores to pin when running standard tests. Cores can specified via a comma-delimited list, like 0,2-4"
+  longform: --pin-core
+strict_fabtests_mode:
+  type: boolean
+  help: "Strict mode: -FI_ENODATA, -FI_ENOSYS errors would be treated as failures\ninstead of skipped/notrun"
+  shortform: -S
+additional_client_arguments:
+  type: str
+  help: "Additional client test arguments: Parameters to pass to client fabtests"
+  shortform: -C
+additional_server_arguments:
+  type: str
+  help: "Additional server test arguments: Parameters to pass to server fabtests"
+  shortform: -L
+oob_address_exchange:
+  type: boolean
+  help: "out-of-band address exchange over the default port"
+  shortform: -b

--- a/fabtests/scripts/runfabtests.py
+++ b/fabtests/scripts/runfabtests.py
@@ -125,21 +125,17 @@ def fabtests_args_to_pytest_args(fabtests_args):
     if fabtests_args.good_address:
         pytest_args.append("--good_address " + fabtests_args.good_address)
 
-    if fabtests_args.verbose_fail_skip_pass:
-        # print extra info for failed/skipped/passed test(s)
-        pytest_args.append("-rA")
-        verbose_fail = True
-    elif fabtests_args.verbose_fail_skip:
-        # print extra info for failed/skipped test(s)
-        pytest_args.append("-rfEsx")
-        verbose_fail = True
-    elif fabtests_args.verbose_fail:
-        pytest_args.append("-rfE")
-        verbose_fail = True
-    else:
-        pytest_args.append("-rN")
-        verbose_fail = False
+    pytest_verbose_options = {
+            0 : "-rN",      # print no extra information
+            1 : "-rfE",     # print extra information for failed test(s)
+            2 : "-rfEsx",   # print extra information for failed/skipped test(s)
+            3 : "-rA",      # print extra information for all test(s) (failed/skipped/passed)
+        }
 
+    print("fabtests_args.verbose: {}".format(fabtests_args.verbose))
+    pytest_args.append(pytest_verbose_options[fabtests_args.verbose])
+
+    verbose_fail = fabtests_args.verbose > 0
     if verbose_fail:
         # Use short python trace back because it show captured stdout of failed tests
         pytest_args.append("--tb=short")
@@ -264,12 +260,11 @@ def main():
     parser.add_argument("client_id", type=str, help="client ip or hostname")
     parser.add_argument("-g", dest="good_address",
                         help="good address from host's perspective (default $GOOD_ADDR)")
-    parser.add_argument("-v", dest="verbose_fail", action="store_true",
-                        help="print extra info for failed test(s)")
-    parser.add_argument("-vv", dest="verbose_fail_skip", action="store_true",
-                        help="print extra info of failed/skipped test(s)")
-    parser.add_argument("-vvv", dest="verbose_fail_skip_pass", action="store_true",
-                        help="print extra info of failed/skipped/passed test(s)")
+    parser.add_argument("-v", dest="verbose", action="count", default=0,
+                        help="verbosity level"
+                             "-v: print extra info for failed test(s)"
+                             "-vv: print extra info of failed/skipped test(s)"
+                             "-vvv: print extra info of failed/skipped/passed test(s)")
     parser.add_argument("-t", dest="testsets", type=str, default="quick",
                         help="test set(s): all,quick,unit,functional,standard,short,ubertest (default quick)")
     parser.add_argument("-E", dest="environments", type=str,

--- a/fabtests/scripts/runfabtests.py
+++ b/fabtests/scripts/runfabtests.py
@@ -214,11 +214,28 @@ def fabtests_args_to_pytest_args(fabtests_args):
     return pytest_args
 
 def get_pytest_root_dir():
+    '''
+        find the pytest root directory according the location of runfabtests.py
+    '''
     import os
     import sys
     script_path = os.path.abspath(sys.argv[0])
-    fabtests_root_dir = os.path.dirname(os.path.dirname(script_path))
-    return os.path.join(fabtests_root_dir, "share", "fabtests", "pytest")
+    script_dir = os.path.dirname(script_path)
+    if os.path.basename(script_dir) == "bin":
+        # runfabtests.py is part of a fabtests installation
+        pytest_root_dir = os.path.abspath(os.path.join(script_dir, "..", "share", "fabtests", "pytest"))
+    elif os.path.basename(script_dir) == "scripts":
+        # runfabtests.py is part of a fabtests source code
+        pytest_root_dir = os.path.abspath(os.path.join(script_dir, "..", "pytest"))
+    else:
+        raise RuntimeError("Error: runfabtests.py is under directory {}, "
+                "which is neither part of fabtests installation "
+                "nor part of fabetsts source code".format(script_dir))
+
+    if not os.path.exists(pytest_root_dir):
+        raise RuntimeError("Deduced pytest root directory {} does not exist!".format(pytest_root_dir))
+
+    return pytest_root_dir
 
 def get_pytest_relative_case_dir(fabtests_args, pytest_root_dir):
     '''


### PR DESCRIPTION
This PR contains several improvement to the pytest framework of libfabric:

`fabtests/runfabtests.py: find pytest root dir when running from source`: this commit allows `runfabtests.py` to be run from inside a source code (prior to this patch, runfabtests.py can only be run from fabtests installation)

`fabtests/runfabtsts.py: use argparser's count action for verbose`: this commit uses python's argparser's count action to implement "-v", "-vv", "-vvv" option, which simplified the code

`fabtests/runfabtests.py,conftests.py: introduce options.yaml`: this commit save command line option's definition in a yaml file, and let runfabtest.py and conftest.py to load options from it. This greatly reduced code duplication, and simplified future work to introduce new options

`.gitignore: add __pycache__ to ignore list` expand ignore list

`fabtests/pytest: fix a bug regarding timeout`: fix a timeout related bug.

