### PR TITLE
fabtests/test_configs/udp Update Exclude File

### DIFF
--- a/fabtests/test_configs/udp/udp.exclude
+++ b/fabtests/test_configs/udp/udp.exclude
@@ -10,6 +10,7 @@ inj_complete -e dgram
 cm_data
 
 # Not supported by ofi_rxd provider
+-k
 scalable_ep
 shared_ctx
 shared_av


### PR DESCRIPTION
Neither udp or rxd use FI_MSG_PREFIX, disable for udp

Signed-off-by: Zach Dworkin <zachary.dworkin@intel.com>