### PR TITLE
configure.ac: cleanup device configure checks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -697,52 +697,55 @@ AH_BOTTOM([
 
 #gdrcopy related configs
 AC_ARG_WITH([gdrcopy],
-	    [AS_HELP_STRING([--with-gdrcopy=DIR],
-			    [Provide path to where the gdrcopy development
-			    and runtime libraries are installed.])],
-	    [], [])
-
-AS_IF([test -n "$with_gdrcopy" && test x"$with_gdrcopy" != x"no" && test "$have_cuda" = "0"],
-	[AC_MSG_ERROR([gdrcopy is requested but cuda is not requested or cuda runtime is not available.])],
-	[])
+	[AS_HELP_STRING([--with-gdrcopy=DIR], [Enable gdrcopy build and fail if not found.
+					       Optional=<Path to where the gdrcopy development
+					       and runtime libraries are installed.>])])
 
 have_gdrcopy=0
-AS_IF([test "$have_cuda" = "1" && test x"$with_gdrcopy" != x"no"],
-	[AS_IF([test x"$with_gdrcopy" = x"yes"],[gdrcopy_dir=""],[gdrcopy_dir=$with_gdrcopy])
-	 FI_CHECK_PACKAGE([gdrcopy],
-			  [gdrapi.h],
-			  [gdrapi],
-			  [gdr_open],
-			  [],
-			  [$gdrcopy_dir],
-			  [],
-			  [have_gdrcopy=1],
-			  [],
-			  [])],
-	[])
-
-AS_IF([test x"$with_gdrcopy" != x"no" && test -n "$with_gdrcopy" && test "$have_gdrcopy" = "0" ],
-	[AC_MSG_ERROR([gdrcopy support requested but gdrcopy development library is not available.])],
-	[])
-
-AC_DEFINE_UNQUOTED([HAVE_GDRCOPY], [$have_gdrcopy], [Whether we have gdrcopy development library or not])
-
+gdrcopy_dlopen=0
 AC_ARG_ENABLE([gdrcopy-dlopen],
     [AS_HELP_STRING([--enable-gdrcopy-dlopen],
         [Enable dlopen of gdrcopy libraries @<:@default=no@:>@])
     ],
     [
-        AS_IF([test "$freebsd" = "0"], [
-            AC_CHECK_LIB(dl, dlopen, [],
-                [AC_MSG_ERROR([dlopen not found.  libfabric requires libdl.])])
-        ])
-        AC_DEFINE([ENABLE_GDRCOPY_DLOPEN], [1], [dlopen CUDA libraries])
-    ],
-    [enable_gdrcopy_dlopen=no])
+        AS_IF([test x"$with_dlopen" = "no"],
+              [AC_MSG_ERROR([dlopen not found.  libfabric requires libdl.])])
+	gdrcopy_dlopen=1
+    ])
 
-CPPFLAGS="$CPPFLAGS $gdrcopy_CPPFLAGS"
-LDFLAGS="$LDFLAGS $gdrcopy_LDFLAGS"
-AS_IF([test x"$enable_gdrcopy_dlopen" != x"yes"], [LIBS="$LIBS $gdrcopy_LIBS"])
+AS_IF([test "$have_cuda" = 1 && test x"$with_gdrcopy" != x"no"],
+      [
+	AS_IF([test "$gdrcopy_dlopen" != "0"],
+	      [
+		_FI_CHECK_PACKAGE_HEADER([gdrcopy],
+				[gdrapi.h],
+				[$with_gdrcopy],
+				[have_gdrcopy=1],
+				[AC_MSG_ERROR([gdrcopy headers not found. Cannot enable gdrcopy DL])])
+	      ],
+	      [
+		FI_CHECK_PACKAGE([gdrcopy],
+				 [gdrapi.h],
+				 [gdrapi],
+				 [gdr_open],
+				 [],
+				 [$with_gdrcopy],
+				 [],
+				 [have_gdrcopy=1])
+	      ])
+      ])
+
+AC_DEFINE_UNQUOTED([ENABLE_GDRCOPY_DLOPEN], [$gdrcopy_dlopen], [dlopen gdrcopy libraries])
+
+AS_IF([test x"$with_gdrcopy" != x"no" && test -n "$with_gdrcopy" && test "$have_gdrcopy" = "0" ],
+	[AC_MSG_ERROR([gdrcopy support requested but gdrcopy runtime not available.])])
+
+AC_DEFINE_UNQUOTED([HAVE_GDRCOPY], [$have_gdrcopy], [gdrcopy support])
+
+AS_IF([test "$gdrcopy_dlopen" != "1"], [LIBS="$LIBS $gdrcopy_LIBS"])
+AS_IF([test "$have_gdrcopy" = "1" && test x"$with_gdrcopy" != x"yes"],
+      [CPPFLAGS="$CPPFLAGS $gdrcopy_CPPFLAGS"
+       LDFLAGS="$LDFLAGS $gdrcopy_LDFLAGS"])
 #end gdrcopy configures
 
 dnl Check for ROCR runtime libraries.

--- a/configure.ac
+++ b/configure.ac
@@ -738,38 +738,55 @@ AS_IF([test x"$enable_gdrcopy_dlopen" != x"yes"], [LIBS="$LIBS $gdrcopy_LIBS"])
 
 dnl Check for ROCR runtime libraries.
 AC_ARG_WITH([rocr],
-	    [AS_HELP_STRING([--with-rocr=DIR],
-			    [Provide path to where the ROCR/HSA development
-			    and runtime libraries are installed.])],
-	    [], [])
+	[AS_HELP_STRING([--with-rocr=DIR], [Enable ROCR/HSA build and fail if not found.
+					    Optional=<Path to where the ROCR/HSA libraries
+					    and headers are installed.>])])
 
+have_rocr=0
+rocr_dlopen=0
 AC_ARG_ENABLE([rocr-dlopen],
     [AS_HELP_STRING([--enable-rocr-dlopen],
         [Enable dlopen of ROCR libraries @<:@default=no@:>@])
     ],
     [
-        AS_IF([test "$freebsd" = "0"], [
-            AC_CHECK_LIB(dl, dlopen, [],
-                [AC_MSG_ERROR([dlopen not found.  libfabric requires libdl.])])
-        ])
-        AC_DEFINE([ENABLE_ROCR_DLOPEN], [1], [dlopen ROCR libraries])
-    ],
-    [enable_rocr_dlopen=no])
+        AS_IF([test x"$with_dlopen" = "no"],
+              [AC_MSG_ERROR([dlopen not found.  libfabric requires libdl.])])
+	rocr_dlopen=1
+    ])
 
-FI_CHECK_PACKAGE([rocr],
-		 [hsa/hsa_ext_amd.h],
-		 [hsa-runtime64],
-		 [hsa_amd_pointer_info],
-		 [],
-		 [$with_rocr],
-		 [$with_rocr/lib],
-		 [AC_DEFINE([HAVE_ROCR], [1], [ROCR HSA support])],
-		 [], [])
+AS_IF([test x"$with_rocr" != x"no"],
+      [
+	AS_IF([test "$rocr_dlopen" != "0"],
+	      [
+		_FI_CHECK_PACKAGE_HEADER([rocr],
+				[hsa/hsa_ext_amd.h],
+				[$with_rocr],
+				[have_rocr=1],
+				[AC_MSG_ERROR([ROCR headers not found. Cannot enable ROCR DL])])
+	      ],
+	      [
+		FI_CHECK_PACKAGE([rocr],
+				 [hsa/hsa_ext_amd.h],
+				 [hsa-runtime64],
+				 [hsa_amd_pointer_info],
+				 [],
+				 [$with_rocr],
+				 [$with_rocr/lib],
+				 [have_rocr=1])
+	      ])
+      ])
 
-CPPFLAGS="$CPPFLAGS $rocr_CPPFLAGS"
-LDFLAGS="$LDFLAGS $rocr_LDFLAGS"
+AC_DEFINE_UNQUOTED([ENABLE_ROCR_DLOPEN], [$rocr_dlopen], [dlopen ROCR libraries])
 
-AS_IF([test x"$enable_rocr_dlopen" != x"yes"], [LIBS="$LIBS $rocr_LIBS"])
+AS_IF([test x"$with_rocr" != x"no" && test -n "$with_rocr" && test "$have_rocr" = "0" ],
+	[AC_MSG_ERROR([ROCR support requested but ROCR runtime not available.])])
+
+AC_DEFINE_UNQUOTED([HAVE_ROCR], [$have_rocr], [ROCR support])
+
+AS_IF([test "$rocr_dlopen" != "1"], [LIBS="$LIBS $rocr_LIBS"])
+AS_IF([test "$have_rocr" = "1" && test x"$with_rocr" != x"yes"],
+      [CPPFLAGS="$CPPFLAGS $rocr_CPPFLAGS"
+       LDFLAGS="$LDFLAGS $rocr_LDFLAGS"])
 
 AC_CHECK_SIZEOF([void *])
 

--- a/configure.ac
+++ b/configure.ac
@@ -522,44 +522,58 @@ AC_DEFINE_UNQUOTED(HAVE_CLOCK_GETTIME, [$have_clock_gettime],
        [Define to 1 if clock_gettime is available.])
 AM_CONDITIONAL(HAVE_CLOCK_GETTIME, [test $have_clock_gettime -eq 1])
 
-dnl Check for CUDA runtime libraries.
+dnl Check for CUDA runtime libraries
 AC_ARG_WITH([cuda],
-	    [AS_HELP_STRING([--with-cuda=DIR],
-			    [Provide path to where the CUDA development
-			    and runtime libraries are installed.])],
-	    [], [])
+	[AS_HELP_STRING([--with-cuda=DIR],
+			[Enable CUDA build and fail if not found.
+			 Optional=<Path to where the CUDA libraries
+			 and headers are installed.>])])
 
-have_libcuda=0
-AS_IF([test x"$with_cuda" != x"no"],
-	    [FI_CHECK_PACKAGE([cuda],
-			      [cuda_runtime.h],
-			      [cudart],
-			      [cudaMemcpy],
-			      [-lcuda],
-			      [$with_cuda],
-			      [],
-			      [have_libcuda=1],
-			      [],
-			      [])],
-	    [])
-
-AS_IF([test x"$with_cuda" != x"no" && test -n "$with_cuda" && test "$have_libcuda" = "0" ],
-	[AC_MSG_ERROR([CUDA support requested but CUDA runtime not available.])],
-	[])
-AC_DEFINE_UNQUOTED([HAVE_LIBCUDA], [$have_libcuda], [Whether we have CUDA runtime or not])
-
+have_cuda=0
+cuda_dlopen=0
 AC_ARG_ENABLE([cuda-dlopen],
     [AS_HELP_STRING([--enable-cuda-dlopen],
         [Enable dlopen of CUDA libraries @<:@default=no@:>@])
     ],
     [
-        AS_IF([test "$freebsd" = "0"], [
-            AC_CHECK_LIB(dl, dlopen, [],
-                [AC_MSG_ERROR([dlopen not found.  libfabric requires libdl.])])
-        ])
-        AC_DEFINE([ENABLE_CUDA_DLOPEN], [1], [dlopen CUDA libraries])
-    ],
-    [enable_cuda_dlopen=no])
+        AS_IF([test x"$with_dlopen" = "no"],
+              [AC_MSG_ERROR([dlopen not found.  libfabric requires libdl.])])
+	cuda_dlopen=1
+    ])
+
+AS_IF([test x"$with_cuda" != x"no"],
+      [
+	AS_IF([test "$cuda_dlopen" != "0"],
+	      [
+		_FI_CHECK_PACKAGE_HEADER([cuda],
+				[cuda_runtime.h],
+				[$with_cuda],
+				[have_cuda=1],
+				[AC_MSG_ERROR([CUDA headers not found. Cannot enable CUDA DL])])
+	      ],
+	      [
+		FI_CHECK_PACKAGE([cuda],
+				 [cuda_runtime.h],
+				 [cudart],
+				 [cudaMemcpy],
+				 [-lcuda],
+				 [$with_cuda],
+				 [],
+				 [have_cuda=1])
+	      ])
+      ])
+
+AC_DEFINE_UNQUOTED([ENABLE_CUDA_DLOPEN], [$cuda_dlopen], [dlopen CUDA libraries])
+
+AS_IF([test x"$with_cuda" != x"no" && test -n "$with_cuda" && test "$have_cuda" = "0" ],
+	[AC_MSG_ERROR([CUDA support requested but CUDA runtime not available.])])
+
+AC_DEFINE_UNQUOTED([HAVE_CUDA], [$have_cuda], [CUDA support])
+
+AS_IF([test "$cuda_dlopen" != "1"], [LIBS="$LIBS $cuda_LIBS"])
+AS_IF([test "$have_cuda" = "1" && test x"$with_cuda" != x"yes"],
+      [CPPFLAGS="$CPPFLAGS $cuda_CPPFLAGS"
+       LDFLAGS="$LDFLAGS $cuda_LDFLAGS"])
 
 AC_ARG_WITH([ze],
 	[AS_HELP_STRING([--with-ze=DIR], [Enable ZE build and fail if not found.
@@ -681,11 +695,6 @@ AH_BOTTOM([
 #endif
 ])
 
-CPPFLAGS="$CPPFLAGS $cuda_CPPFLAGS"
-LDFLAGS="$LDFLAGS $cuda_LDFLAGS"
-
-AS_IF([test x"$enable_cuda_dlopen" != x"yes"], [LIBS="$LIBS $cuda_LIBS"])
-
 #gdrcopy related configs
 AC_ARG_WITH([gdrcopy],
 	    [AS_HELP_STRING([--with-gdrcopy=DIR],
@@ -693,12 +702,12 @@ AC_ARG_WITH([gdrcopy],
 			    and runtime libraries are installed.])],
 	    [], [])
 
-AS_IF([test -n "$with_gdrcopy" && test x"$with_gdrcopy" != x"no" && test "$have_libcuda" = "0"],
+AS_IF([test -n "$with_gdrcopy" && test x"$with_gdrcopy" != x"no" && test "$have_cuda" = "0"],
 	[AC_MSG_ERROR([gdrcopy is requested but cuda is not requested or cuda runtime is not available.])],
 	[])
 
 have_gdrcopy=0
-AS_IF([test "$have_libcuda" = "1" && test x"$with_gdrcopy" != x"no"],
+AS_IF([test "$have_cuda" = "1" && test x"$with_gdrcopy" != x"no"],
 	[AS_IF([test x"$with_gdrcopy" = x"yes"],[gdrcopy_dir=""],[gdrcopy_dir=$with_gdrcopy])
 	 FI_CHECK_PACKAGE([gdrcopy],
 			  [gdrapi.h],

--- a/configure.ac
+++ b/configure.ac
@@ -632,26 +632,25 @@ AS_IF([test "$have_ze" = "1" && test x"$with_ze" != x"yes"],
        LDFLAGS="$LDFLAGS $ze_LDFLAGS"])
 
 dnl Check for AWS Neuron runtime library for Neuron device support
+have_neuron=0
 AC_ARG_WITH([neuron],
 	AS_HELP_STRING([--with-neuron=DIR],
-		       [Provide path to where the Neuron headers are installed.]),
-	[], [])
+		       [Enable Neuron build and fail if not found.
+			Optional=<Path to where the Neuron libraries
+			and headers are installed.>]))
 
 _FI_CHECK_PACKAGE_HEADER([neuron], [nrt/nrt.h], [$with_neuron],
 	[
-		AS_IF([test "$freebsd" = "0"], [
-		    AC_CHECK_LIB(dl, dlopen, [],
+		AS_IF([test x"$with_dlopen" = "no"],
 			[AC_MSG_ERROR([dlopen not found.  libfabric requires libdl.])])
-		])
-		AC_DEFINE([HAVE_NEURON], [1], [build with neuron support])
+		have_neuron=1
 	],
-	[
-		AS_IF([test x"$with_neuron" != x"no" && test -n "$with_neuron"],
-		      [AC_MSG_ERROR([Neuron support requested but headers are not available.])],
-		      [])
-		AC_DEFINE([HAVE_NEURON], [0], [build with neuron support])
-	]
 )
+
+AS_IF([test x"$with_neuron" != x"no" && test -n "$with_neuron" && test "$have_neuron" = "0" ],
+	[AC_MSG_ERROR([Neuron support requested but headers are not available.])])
+
+AC_DEFINE_UNQUOTED([HAVE_NEURON], [$have_neuron], [Build with Neuron support])
 
 enable_memhooks=1
 AC_ARG_ENABLE([memhooks-monitor],

--- a/include/ofi_cuda.h
+++ b/include/ofi_cuda.h
@@ -36,7 +36,7 @@
 
 #ifndef _OFI_CUDA_H_
 #define _OFI_CUDA_H_
-#if HAVE_LIBCUDA
+#if HAVE_CUDA
 
 #include <cuda.h>
 #include <cuda_runtime.h>
@@ -107,5 +107,5 @@ ofi_copy_to_cuda_iov(const struct iovec *iov, size_t iov_count, uint64_t iov_off
 	}
 }
 
-#endif /* HAVE_LIBCUDA */
+#endif /* HAVE_CUDA */
 #endif /* _OFI_CUDA_H_ */

--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -62,7 +62,7 @@ cudaError_t ofi_cudaFree(void *ptr);
 
 #endif /* HAVE_LIBCUDA */
 
-#ifdef HAVE_ROCR
+#if HAVE_ROCR
 
 #include <hsa/hsa_ext_amd.h>
 

--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -43,7 +43,7 @@
 
 extern bool ofi_hmem_disable_p2p;
 
-#if HAVE_LIBCUDA
+#if HAVE_CUDA
 
 #include <cuda.h>
 #include <cuda_runtime.h>
@@ -60,7 +60,7 @@ cudaError_t ofi_cudaHostUnregister(void *ptr);
 cudaError_t ofi_cudaMalloc(void **ptr, size_t size);
 cudaError_t ofi_cudaFree(void *ptr);
 
-#endif /* HAVE_LIBCUDA */
+#endif /* HAVE_CUDA */
 
 #if HAVE_ROCR
 

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -489,7 +489,7 @@ static int efa_mr_cache_init(struct efa_domain *domain, struct fi_info *info)
 
 static int efa_set_domain_hmem_info_cuda(struct efa_domain *domain)
 {
-#if HAVE_LIBCUDA
+#if HAVE_CUDA
 	cudaError_t cuda_ret;
 	void *ptr = NULL;
 	struct ibv_mr *ibv_mr;

--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -615,7 +615,7 @@ static int efa_get_device_attrs(struct efa_context *ctx, struct fi_info *info)
 	info->domain_attr->resource_mgmt	= FI_RM_DISABLED;
 	info->domain_attr->mr_cnt		= base_attr->max_mr;
 
-#if HAVE_LIBCUDA || HAVE_NEURON
+#if HAVE_CUDA || HAVE_NEURON
 	if (info->ep_attr->type == FI_EP_RDM &&
 	    (ofi_hmem_is_initialized(FI_HMEM_CUDA) ||
 	     ofi_hmem_is_initialized(FI_HMEM_NEURON))) {

--- a/prov/efa/src/rxr/rxr_attr.c
+++ b/prov/efa/src/rxr/rxr_attr.c
@@ -37,7 +37,7 @@
 const uint32_t rxr_poison_value = 0xdeadbeef;
 #endif
 
-#if HAVE_LIBCUDA || HAVE_NEURON
+#if HAVE_CUDA || HAVE_NEURON
 #define EFA_HMEM_CAP FI_HMEM
 #else
 #define EFA_HMEM_CAP 0

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -242,7 +242,7 @@ void rxr_info_to_core_mr_modes(uint32_t version,
 					hints->domain_attr->mr_mode & OFI_MR_BASIC_MAP;
 			core_info->addr_format = hints->addr_format;
 		}
-#if HAVE_LIBCUDA || HAVE_NEURON
+#if HAVE_CUDA || HAVE_NEURON
 		core_info->domain_attr->mr_mode |= FI_MR_HMEM;
 #endif
 	}
@@ -488,7 +488,7 @@ static int rxr_info_to_rxr(uint32_t version, const struct fi_info *core_info,
 		}
 
 
-#if HAVE_LIBCUDA || HAVE_NEURON
+#if HAVE_CUDA || HAVE_NEURON
 		/* If the application requires HMEM support, we will add
 		 * FI_MR_HMEM to mr_mode, because we need application to
 		 * provide descriptor for cuda or neuron buffer. Note we did

--- a/prov/psm3/configure.m4
+++ b/prov/psm3/configure.m4
@@ -138,6 +138,8 @@ ifelse('
 			])
 		CFLAGS=$save_CFLAGS
 
+		have_libcuda=0
+		AS_IF([test $have_cuda -eq 1 && test $cuda_dlopen -eq 1], [have_libcuda=1])
 		AS_IF([test $have_libcuda -eq 1],
 		      [psm3_CPPFLAGS="$psm3_CPPFLAGS -DPSM_CUDA -DNVIDIA_GPU_DIRECT"])
 		AC_DEFINE_UNQUOTED([PSM3_CUDA], [$have_libcuda], [Whether we have CUDA runtime or not])

--- a/prov/util/src/cuda_mem_monitor.c
+++ b/prov/util/src/cuda_mem_monitor.c
@@ -32,7 +32,7 @@
 
 #include "ofi_mr.h"
 
-#if HAVE_LIBCUDA
+#if HAVE_CUDA
 
 #include "ofi_hmem.h"
 
@@ -130,7 +130,7 @@ static int cuda_monitor_start(struct ofi_mem_monitor *monitor)
 	return -FI_ENOSYS;
 }
 
-#endif /* HAVE_LIBCUDA */
+#endif /* HAVE_CUDA */
 
 void cuda_monitor_stop(struct ofi_mem_monitor *monitor)
 {

--- a/prov/util/src/rocr_mem_monitor.c
+++ b/prov/util/src/rocr_mem_monitor.c
@@ -33,7 +33,7 @@
 
 #include "ofi_mr.h"
 
-#ifdef HAVE_ROCR
+#if HAVE_ROCR
 
 #include "ofi_tree.h"
 #include "ofi_iov.h"

--- a/src/hmem_cuda.c
+++ b/src/hmem_cuda.c
@@ -38,7 +38,7 @@
 #include "ofi_hmem.h"
 #include "ofi.h"
 
-#if HAVE_LIBCUDA
+#if HAVE_CUDA
 
 #include <cuda.h>
 #include <cuda_runtime.h>
@@ -73,7 +73,7 @@ static bool cuda_ipc_enabled;
 static cudaError_t cuda_disabled_cudaMemcpy(void *dst, const void *src,
 					    size_t size, enum cudaMemcpyKind kind);
 
-#ifdef ENABLE_CUDA_DLOPEN
+#if ENABLE_CUDA_DLOPEN
 
 #include <dlfcn.h>
 
@@ -274,7 +274,7 @@ static cudaError_t cuda_disabled_cudaMemcpy(void *dst, const void *src,
 
 static int cuda_hmem_dl_init(void)
 {
-#ifdef ENABLE_CUDA_DLOPEN
+#if ENABLE_CUDA_DLOPEN
 	/* Assume failure to dlopen CUDA runtime is caused by the library not
 	 * being found. Thus, CUDA is not supported.
 	 */
@@ -411,7 +411,7 @@ err_dlclose_cudart:
 
 static void cuda_hmem_dl_cleanup(void)
 {
-#ifdef ENABLE_CUDA_DLOPEN
+#if ENABLE_CUDA_DLOPEN
 	dlclose(cuda_handle);
 	dlclose(cudart_handle);
 #endif
@@ -686,4 +686,4 @@ bool cuda_is_gdrcopy_enabled(void)
 	return false;
 }
 
-#endif /* HAVE_LIBCUDA */
+#endif /* HAVE_CUDA */

--- a/src/hmem_cuda_gdrcopy.c
+++ b/src/hmem_cuda_gdrcopy.c
@@ -73,7 +73,7 @@ enum gdrcopy_dir {
 static gdr_t global_gdr;
 static pthread_spinlock_t global_gdr_lock;
 
-#ifdef ENABLE_GDRCOPY_DLOPEN
+#if ENABLE_GDRCOPY_DLOPEN
 
 #include <dlfcn.h>
 

--- a/src/hmem_rocr.c
+++ b/src/hmem_rocr.c
@@ -37,7 +37,7 @@
 #include "ofi_hmem.h"
 #include "ofi.h"
 
-#ifdef HAVE_ROCR
+#if HAVE_ROCR
 
 #include <hsa/hsa_ext_amd.h>
 
@@ -67,7 +67,7 @@ struct rocr_ops {
 					   void *value);
 };
 
-#ifdef ENABLE_ROCR_DLOPEN
+#if ENABLE_ROCR_DLOPEN
 
 #include <dlfcn.h>
 
@@ -277,7 +277,7 @@ bool rocr_is_addr_valid(const void *addr, uint64_t *device, uint64_t *flags)
 
 static int rocr_hmem_dl_init(void)
 {
-#ifdef ENABLE_ROCR_DLOPEN
+#if ENABLE_ROCR_DLOPEN
 	/* Assume if dlopen fails, the ROCR library could not be found. Do not
 	 * treat this as an error.
 	 */
@@ -375,7 +375,7 @@ err:
 
 static void rocr_hmem_dl_cleanup(void)
 {
-#ifdef ENABLE_ROCR_DLOPEN
+#if ENABLE_ROCR_DLOPEN
 	dlclose(rocr_handle);
 #endif
 }


### PR DESCRIPTION
Cleanup cuda, rocr, gdrcopy, and neuron config checks to minimize DL dependencies, make consistent defines, and make more readable.