### PR TITLE
core/bufpool: Convert debug use_cnt to an atomic

### DIFF
--- a/include/ofi_osd.h
+++ b/include/ofi_osd.h
@@ -115,10 +115,12 @@ static inline int ofi_detect_endianness(void)
 #define OFI_DBG_VAR(type, name) type name;
 #define OFI_DBG_SET(name, val) name = val
 #define OFI_DBG_ADD(name, val) name += val
+#define OFI_DBG_CALL(func) func
 #else
 #define OFI_DBG_VAR(type, name)
-#define OFI_DBG_SET(name, val)
-#define OFI_DBG_ADD(name, val)
+#define OFI_DBG_SET(name, val) do {} while (0)
+#define OFI_DBG_ADD(name, val) do {} while (0)
+#define OFI_DBG_CALL(func) do {} while (0)
 #endif
 
 #endif /* _OFI_OSD_H_ */

--- a/prov/util/src/util_buf.c
+++ b/prov/util/src/util_buf.c
@@ -61,6 +61,7 @@ int ofi_bufpool_grow(struct ofi_bufpool *pool)
 		return -FI_ENOMEM;
 
 	buf_region->pool = pool;
+	OFI_DBG_CALL(ofi_atomic_initialize32(&buf_region->use_cnt, 0));
 	dlist_init(&buf_region->free_list);
 
 	if (pool->attr.flags & OFI_BUFPOOL_HUGEPAGES) {
@@ -210,7 +211,7 @@ void ofi_bufpool_destroy(struct ofi_bufpool *pool)
 		buf_region = pool->region_table[i];
 
 		assert((pool->attr.flags & OFI_BUFPOOL_NO_TRACK) ||
-			(buf_region->use_cnt == 0));
+			!ofi_atomic_get32(&buf_region->use_cnt));
 		if (pool->attr.free_fn)
 			pool->attr.free_fn(buf_region);
 


### PR DESCRIPTION
This silences a tsan warning that use_cnt is not thread safe.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>