### PR TITLE
prov/efa: Adding CMocka Framework for unit testing

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,6 +15,7 @@ AM_CPPFLAGS = \
 
 noinst_LTLIBRARIES =
 lib_LTLIBRARIES =
+check_PROGRAMS =
 
 if EMBEDDED
 noinst_LTLIBRARIES += src/libfabric.la

--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -73,6 +73,26 @@ _efa_headers = \
 	prov/efa/src/rxr/rxr_atomic.h \
 	prov/efa/src/rxr/rdm_proto_v4.h
 
+
+if ENABLE_EFA_UNIT_TEST
+check_PROGRAMS += prov/efa/test/efa_unit_test
+TESTS += prov/efa/test/efa_unit_test
+nodist_prov_efa_test_efa_unit_test_SOURCES = \
+	prov/efa/test/efa_unit_tests.h \
+	prov/efa/test/efa_unit_tests.c \
+	prov/efa/test/rdma_core_mocks.c
+
+efa_CPPFLAGS += -I$(top_srcdir)/prov/efa/test $(cmocka_CPPFLAGS)
+
+
+prov_efa_test_efa_unit_test_CPPFLAGS = $(efa_CPPFLAGS)
+prov_efa_test_efa_unit_test_LDADD = $(cmocka_LIBS) $(linkback)
+prov_efa_test_efa_unit_test_LDFLAGS = $(efa_LDFLAGS) $(cmocka_LDFLAGS) -Wl,--wrap=ibv_create_ah \
+																		-Wl,--wrap=efadv_query_ah
+prov_efa_test_efa_unit_test_LIBS = $(efa_LIBS) $(linkback)
+
+endif ENABLE_EFA_UNIT_TEST
+
 efa_CPPFLAGS += \
 	-I$(top_srcdir)/prov/efa/src/ \
 	-I$(top_srcdir)/prov/efa/src/rxr/

--- a/prov/efa/test/.gitignore
+++ b/prov/efa/test/.gitignore
@@ -1,0 +1,2 @@
+efa_unit_test
+efa_unit_test.trs

--- a/prov/efa/test/README.md
+++ b/prov/efa/test/README.md
@@ -1,0 +1,54 @@
+# EFA unit tests
+
+## How to run
+
+To run efa unit tests, you will need to have cmocka installed.
+Cmocka Mirror: https://cmocka.org/files/
+Install Instructions: https://gitlab.com/cmocka/cmocka/-/blob/master/INSTALL.md
+
+You will need to configure libfabric with ```--enable-efa-unit-test=<path_to_cmocka_install>```.
+
+An example build and run command would look like:
+
+```
+./autogen.sh; ./configure --enable-efa-unit-test=/home/ec2-user/cmocka/install; make check;
+```
+
+## How to write
+
+1. Add unit tests to the bottom of the c source file you wish to test.
+2. Add headers to efa_unit_tests.h for each new unit test.
+3. Create or find an existing cmocka test group in efa_unit_tests.c
+4. Add your new unit test to the cmocka test group.
+
+## Mocking
+
+To mock a function, you will need to add ```-Wl,--wrap=<function to mock>```
+to the Makefile.include as part of efatest_LIBS. Then, after declaring the function,
+you can replace it with __wrap_<function to mock>. If you need to use the original
+function, you can use __real_<function to mock> after declaring it.
+
+### Manipulating mock behavior
+
+You can use the cmocka API to change the behavior of your mock function.
+
+The will_return class of functions will place values onto a stack that can
+be popped within the function with the mock function. You can use this to
+manipulate the function behavior. For example, if you pop the value 'true'
+using
+```
+will_return(mock_function, true)
+```
+
+and add a check in your mock function like so:
+
+```
+int use_real_function = mock_type(bool);
+if (use_real_function)
+	return __real_mock_function(params);
+```
+
+you can use the real function whenever you wish to instead of your custom
+behavior.
+
+See: https://api.cmocka.org/group__cmocka__mock.html for more details

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -1,0 +1,14 @@
+#include "efa_unit_tests.h"
+
+int main(void)
+{
+	int ret;
+	const struct CMUnitTest efa_unit_tests[] = {
+		cmocka_unit_test(test_duplicate_efa_ah_creation)    /* Requires an EFA device to work */
+	};
+	cmocka_set_message_output(CM_OUTPUT_XML);
+
+	ret = cmocka_run_group_tests_name("efa unit tests", efa_unit_tests, NULL, NULL);
+
+	return ret;
+}

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -1,0 +1,14 @@
+#ifndef EFA_UNIT_TESTS_H
+#define EFA_UNIT_TESTS_H
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "stdio.h"
+
+void test_duplicate_efa_ah_creation();
+
+#endif

--- a/prov/efa/test/rdma_core_mocks.c
+++ b/prov/efa/test/rdma_core_mocks.c
@@ -1,0 +1,34 @@
+
+#include <infiniband/efadv.h>
+#include <infiniband/verbs.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+/* Directions For Creating New Mock Function:
+ * 1. Recreate the funciton signature with __wrap_<function>(the_params), and the function
+ *    to the Makefile.include prov_efa_test_efa_unit_test_LDFLAGS list
+ * 2. Check all parameters with check_expected()
+ *   a. This allows test code to optionally check the parameters of the mocked function
+ *      with the family of expect_value() functions.
+ * 3. Make sure to return a casted mock()
+ *   a. This gives the test code control of the return value of the mocked function,
+ *      by calling the will_return() function.  The will_return() function creates a
+ *      stack for each mocked function and returns the top of the stack first.
+*/
+
+struct ibv_ah *__wrap_ibv_create_ah(struct ibv_pd *pd, struct ibv_ah_attr *attr) {
+    check_expected(pd);
+    check_expected(attr);
+    return (struct ibv_ah*) mock();
+}
+
+int __wrap_efadv_query_ah(struct ibv_ah *ibvah, struct efadv_ah_attr *attr, uint32_t inlen) {
+    check_expected(ibvah);
+    check_expected(attr);
+    check_expected(inlen);
+    return (int) mock();
+}


### PR DESCRIPTION
Adding the CMocka framework for unit testing prov/efa.

The unit test I add calls efa_ah_alloc() twice with the same GID, and enforces that the function ibv_create_ah() only gets called once.

Signed-off-by: Seth Zegelstein <szegel@amazon.com>