### PR TITLE
core/net: Expand valid IP address check for sin_zero

### DIFF
--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -525,7 +525,12 @@ static inline void * ofi_get_ipaddr(const struct sockaddr *addr)
 
 static inline bool ofi_valid_dest_ipaddr(const struct sockaddr *addr)
 {
-	return ofi_addr_get_port(addr) && !ofi_is_any_addr(addr);
+	char sin_zero[8] = {0};
+
+	return ofi_addr_get_port(addr) && !ofi_is_any_addr(addr) &&
+	       (addr->sa_family != AF_INET ||
+	         !memcmp(((const struct sockaddr_in *) addr)->sin_zero,
+			 sin_zero, sizeof sin_zero));
 }
 
 static inline bool ofi_equals_ipaddr(const struct sockaddr *addr1,


### PR DESCRIPTION
Reject IP addresses that do not have sin_zero set to 0.  This
will catch malformed IP addresses before they are inserted into
an AV, where sin_zero might contain random/non-zero data.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>