### PR TITLE
fabtests/conftest.py: fix a bug in preparing ubertest command

### DIFF
--- a/fabtests/pytest/conftest.py
+++ b/fabtests/pytest/conftest.py
@@ -165,8 +165,8 @@ class CmdlineArgs:
 
         assert host_type == "client"
         assert self.ubertest_config_file
-        assert self.client_id
-        return command + " -u " + self.ubertest_config_file + " " + self.client_id
+        assert self.server_id
+        return command + " -u " + self.ubertest_config_file + " " + self.server_id
 
 @pytest.fixture
 def cmdline_args(request):


### PR DESCRIPTION
On client side, populate_ubertest_command() should added
server_id to command line, but it is passing client_id.
This patch fixed the issue.

Signed-off-by: Wei Zhang <wzam@amazon.com>