### PR TITLE
prov/shm: fix FI_INJECT flag support

### DIFF
--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -193,6 +193,7 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 	iface = smr_get_mr_hmem_iface(ep->util_ep.domain, desc, &device);
 
 	total_len = ofi_total_iov_len(iov, iov_count);
+	assert(!(op_flags & FI_INJECT) || total_len <= SMR_INJECT_SIZE);
 
 	cmd = ofi_cirque_next(smr_cmd_queue(peer_smr));
 	smr_generic_format(cmd, peer_id, op, tag, data, op_flags);
@@ -200,7 +201,8 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 	/* Do not inline/inject if IPC is available so device to device
 	 * transfer may occur if possible. */
 	use_ipc = ofi_hmem_is_ipc_enabled(iface) && (iov_count == 1) &&
-		  desc && (smr_get_mr_flags(desc) & FI_HMEM_DEVICE_ONLY);
+		  desc && (smr_get_mr_flags(desc) & FI_HMEM_DEVICE_ONLY) &&
+		  !(op_flags & FI_INJECT);
 
 	if (total_len <= SMR_MSG_DATA_LEN &&
 	    !(op_flags & FI_DELIVERY_COMPLETE) && !use_ipc) {
@@ -217,7 +219,8 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 		}
 		resp = ofi_cirque_next(smr_resp_queue(ep->region));
 		pend = ofi_freestack_pop(ep->pend_fs);
-		if (smr_cma_enabled(ep, peer_smr) && iface == FI_HMEM_SYSTEM) {
+		if (smr_cma_enabled(ep, peer_smr) && iface == FI_HMEM_SYSTEM &&
+		    !(op_flags & FI_INJECT)) {
 			smr_format_iov(cmd, iov, iov_count, total_len, ep->region,
 				       resp);
 		} else {
@@ -238,7 +241,7 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 							     pend, resp);
 				}
 			} else if (total_len <= smr_env.sar_threshold ||
-				   iface != FI_HMEM_SYSTEM) {
+				   iface != FI_HMEM_SYSTEM || op_flags & FI_INJECT) {
 				ret = smr_format_sar(cmd, iface, device, iov,
 						     iov_count, total_len,
 						     ep->region, peer_smr, id,


### PR DESCRIPTION
Most sendmsg or writemsg calls with FI_INJECT should work
fine without issues, but an assert is added to make sure we don't
use the IOV protocol.

There is an issue when using FI_INJECT and FI_DELIVERY_COMPLETE
or with hmem IPC enabled since those protocols default to an asynchronous
data copy initiated by the remote side. In order to avoid this
incompatbility, add checks in the IPC and IOV paths to make sure that if
we do need FI_DELIVERY_COMPLETE support and immediately copy the data from
the user buffer, use the SAR protocol which supports both flags.

Signed-off-by: aingerson <alexia.ingerson@intel.com>

Fixes #7478 