### PR TITLE
prov/rxm,verbs: Negociate credit based flow control support over CM

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -1064,6 +1064,7 @@ struct ofi_ops_flow_ctrl {
 	int	(*enable)(struct fid_ep *ep);
 	void	(*set_send_handler)(struct fid_domain *domain,
 			ssize_t (*send_handler)(struct fid_ep *ep, uint64_t credits));
+	void	(*disable)(struct fid_ep *ep);
 };
 
 

--- a/prov/hook/src/hook_domain.c
+++ b/prov/hook/src/hook_domain.c
@@ -138,6 +138,13 @@ static int hook_enable_ep_flow_ctrl(struct fid_ep *ep_fid)
 	return ep->domain->base_ops_flow_ctrl->enable(ep->hep);
 }
 
+static void hook_disable_ep_flow_ctrl(struct fid_ep *ep_fid)
+{
+	struct hook_ep *ep = container_of(ep_fid, struct hook_ep, ep);
+
+	return ep->domain->base_ops_flow_ctrl->disable(ep->hep);
+}
+
 static void hook_add_credits(struct fid_ep *ep_fid, size_t credits)
 {
 	struct hook_ep *ep = container_of(ep_fid, struct hook_ep, ep);
@@ -151,6 +158,7 @@ static struct ofi_ops_flow_ctrl hook_ops_flow_ctrl = {
 	.add_credits = hook_add_credits,
 	.enable = hook_enable_ep_flow_ctrl,
 	.set_send_handler = hook_set_send_handler,
+	.disable = hook_disable_ep_flow_ctrl,
 };
 
 static int hook_domain_ops_open(struct fid *fid, const char *name,

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -78,7 +78,8 @@ union rxm_cm_data {
 		uint8_t ctrl_version;
 		uint8_t op_version;
 		uint16_t port;
-		uint8_t padding[2];
+		uint8_t flow_ctrl;
+		uint8_t padding;
 		uint32_t eager_limit;
 		uint32_t rx_size; /* used? */
 		uint64_t client_conn_id;
@@ -87,7 +88,8 @@ union rxm_cm_data {
 	struct _accept {
 		uint64_t server_conn_id;
 		uint32_t rx_size; /* used? */
-		uint32_t align_pad;
+		uint8_t flow_ctrl;
+		uint8_t align_pad[3];
 	} accept;
 
 	struct _reject {
@@ -247,6 +249,7 @@ struct rxm_conn {
 	int remote_index;
 	uint32_t remote_pid;
 	uint8_t flags;
+	uint8_t flow_ctrl;
 
 	struct dlist_entry deferred_entry;
 	struct dlist_entry deferred_tx_queue;

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -59,6 +59,7 @@ static void vrb_set_credit_handler(struct fid_domain *domain_fid,
 static int vrb_enable_ep_flow_ctrl(struct fid_ep *ep_fid)
 {
 	struct vrb_ep *ep = container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
+
 	// only enable if we are not using SRQ
 	if (!ep->srq_ep && ep->ibv_qp && ep->ibv_qp->qp_type == IBV_QPT_RC) {
 		ep->peer_rq_credits = 1;
@@ -68,12 +69,20 @@ static int vrb_enable_ep_flow_ctrl(struct fid_ep *ep_fid)
 	return -FI_ENOSYS;
 }
 
+static void vrb_disable_ep_flow_ctrl(struct fid_ep *ep_fid)
+{
+	struct vrb_ep *ep = container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
+
+	ep->peer_rq_credits = UINT64_MAX;
+}
+
 struct ofi_ops_flow_ctrl vrb_ops_flow_ctrl = {
 	.size = sizeof(struct ofi_ops_flow_ctrl),
 	.set_threshold = vrb_set_threshold,
 	.add_credits = vrb_add_credits,
 	.enable = vrb_enable_ep_flow_ctrl,
 	.set_send_handler = vrb_set_credit_handler,
+	.disable = vrb_disable_ep_flow_ctrl,
 };
 
 static int


### PR DESCRIPTION
Credit based flow control only works when both sides support it.
Exchange the information over the connetion manager and disable
flow control if support is missing from either side.

To help this, add a disable() method to the flow_ctrl_ops. The hook
provider is updated to handle the new method.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>

Fix #6712.