### PR TITLE
prov/rxm,verbs: Negotiate credit based flow control support over CM

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -1059,9 +1059,9 @@ void *ofi_ns_resolve_name(struct util_ns *ns, const char *server,
 
 struct ofi_ops_flow_ctrl {
 	size_t	size;
-	void	(*set_threshold)(struct fid_ep *ep, uint64_t threshold);
+	bool	(*available)(struct fid_ep *ep);
+	int	(*enable)(struct fid_ep *ep, uint64_t threshold);
 	void	(*add_credits)(struct fid_ep *ep, uint64_t credits);
-	int	(*enable)(struct fid_ep *ep);
 	void	(*set_send_handler)(struct fid_domain *domain,
 			ssize_t (*send_handler)(struct fid_ep *ep, uint64_t credits));
 };

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -71,6 +71,12 @@ enum {
 	RXM_REJECT_EALREADY,
 };
 
+enum {
+	RXM_CM_FLOW_CTRL_LOCAL,
+	RXM_CM_FLOW_CTRL_PEER_ON,
+	RXM_CM_FLOW_CTRL_PEER_OFF,
+};
+
 union rxm_cm_data {
 	struct _connect {
 		uint8_t version;
@@ -78,7 +84,8 @@ union rxm_cm_data {
 		uint8_t ctrl_version;
 		uint8_t op_version;
 		uint16_t port;
-		uint8_t padding[2];
+		uint8_t flow_ctrl;
+		uint8_t padding;
 		uint32_t eager_limit;
 		uint32_t rx_size; /* used? */
 		uint64_t client_conn_id;
@@ -87,7 +94,8 @@ union rxm_cm_data {
 	struct _accept {
 		uint64_t server_conn_id;
 		uint32_t rx_size; /* used? */
-		uint32_t align_pad;
+		uint8_t flow_ctrl;
+		uint8_t align_pad[3];
 	} accept;
 
 	struct _reject {
@@ -247,6 +255,8 @@ struct rxm_conn {
 	int remote_index;
 	uint32_t remote_pid;
 	uint8_t flags;
+	uint8_t flow_ctrl;
+	uint8_t peer_flow_ctrl;
 
 	struct dlist_entry deferred_entry;
 	struct dlist_entry deferred_tx_queue;

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -224,11 +224,7 @@ static int rxm_open_conn(struct rxm_conn *conn, struct fi_info *msg_info)
 		goto err;
 	}
 
-	ret = domain->flow_ctrl_ops->enable(msg_ep);
-	if (!ret) {
-		domain->flow_ctrl_ops->set_threshold(msg_ep,
-					ep->msg_info->rx_attr->size / 2);
-	}
+	conn->flow_ctrl = domain->flow_ctrl_ops->available(msg_ep);
 
 	if (!ep->srx_ctx) {
 		ret = rxm_prepost_recv(ep, msg_ep);
@@ -260,6 +256,9 @@ static int rxm_init_connect_data(struct rxm_conn *conn,
 	cm_data->connect.endianness = ofi_detect_endianness();
 	cm_data->connect.eager_limit = conn->ep->eager_limit;
 	cm_data->connect.rx_size = conn->ep->msg_info->rx_attr->size;
+	cm_data->connect.flow_ctrl = conn->flow_ctrl ?
+						RXM_CM_FLOW_CTRL_PEER_ON :
+						RXM_CM_FLOW_CTRL_PEER_OFF;
 
 	ret = fi_getopt(&conn->ep->msg_pep->fid, FI_OPT_ENDPOINT,
 			FI_OPT_CM_DATA_SIZE, &cm_data_size, &opt_size);
@@ -477,9 +476,32 @@ ssize_t rxm_get_conn(struct rxm_ep *ep, fi_addr_t addr, struct rxm_conn **conn)
 	return ret;
 }
 
+static void rxm_set_peer_flow_ctrl(struct rxm_conn *conn, int cm_flow_ctrl_flag)
+{
+	switch (cm_flow_ctrl_flag) {
+	case RXM_CM_FLOW_CTRL_LOCAL:
+		/*
+		 * For backward compatibility: the flag maps to 0 paddings in
+		 * old protocol. Old protocol doesn't negotiate flow control
+		 * capability. Decision is made locally.
+		 */
+		conn->peer_flow_ctrl = conn->flow_ctrl;
+		break;
+
+	case RXM_CM_FLOW_CTRL_PEER_ON:
+		conn->peer_flow_ctrl = 1;
+		break;
+
+	case RXM_CM_FLOW_CTRL_PEER_OFF:
+		conn->peer_flow_ctrl = 0;
+		break;
+	}
+}
+
 void rxm_process_connect(struct rxm_eq_cm_entry *cm_entry)
 {
 	struct rxm_conn *conn;
+	struct rxm_domain *domain;
 
 	conn = cm_entry->fid->context;
 	FI_DBG(&rxm_prov, FI_LOG_EP_CTRL,
@@ -491,6 +513,14 @@ void rxm_process_connect(struct rxm_eq_cm_entry *cm_entry)
 						    server_conn_id);
 		conn->remote_pid = rxm_peer_pid(cm_entry->data.accept.
 						server_conn_id);
+		rxm_set_peer_flow_ctrl(conn, cm_entry->data.accept.flow_ctrl);
+	}
+
+	if (conn->flow_ctrl & conn->peer_flow_ctrl) {
+		domain = container_of(conn->ep->util_ep.domain,
+				      struct rxm_domain, util_domain);
+		domain->flow_ctrl_ops->enable(conn->msg_ep,
+					      conn->ep->msg_info->rx_attr->size / 2);
 	}
 
 	conn->ep->connecting_cnt--;
@@ -599,7 +629,11 @@ rxm_accept_connreq(struct rxm_conn *conn, struct rxm_eq_cm_entry *cm_entry)
 
 	cm_data.accept.server_conn_id = rxm_conn_id(conn->peer->index);
 	cm_data.accept.rx_size = cm_entry->info->rx_attr->size;
-	cm_data.accept.align_pad = 0;
+	cm_data.accept.flow_ctrl = conn->flow_ctrl ? RXM_CM_FLOW_CTRL_PEER_ON :
+						     RXM_CM_FLOW_CTRL_PEER_OFF;
+	cm_data.accept.align_pad[0] = 0;
+	cm_data.accept.align_pad[1] = 0;
+	cm_data.accept.align_pad[2] = 0;
 
 	ret = fi_accept(conn->msg_ep, &cm_data.accept, sizeof(cm_data.accept));
 	if (ret)
@@ -693,6 +727,8 @@ rxm_process_connreq(struct rxm_ep *ep, struct rxm_eq_cm_entry *cm_entry)
 	ret = rxm_open_conn(conn, cm_entry->info);
 	if (ret)
 		goto free;
+
+	rxm_set_peer_flow_ctrl(conn, cm_entry->data.connect.flow_ctrl);
 
 	ret = rxm_accept_connreq(conn, cm_entry);
 	if (ret)

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -620,9 +620,6 @@ defer:
 	return FI_SUCCESS;
 }
 
-static void rxm_no_set_threshold(struct fid_ep *ep_fid, size_t threshold)
-{ }
-
 static void rxm_no_add_credits(struct fid_ep *ep_fid, size_t credits)
 { }
 
@@ -630,17 +627,22 @@ static void rxm_no_credit_handler(struct fid_domain *domain_fid,
 		ssize_t (*credit_handler)(struct fid_ep *ep, size_t credits))
 { }
 
-static int rxm_no_enable_flow_ctrl(struct fid_ep *ep_fid)
+static int rxm_no_enable_flow_ctrl(struct fid_ep *ep_fid, uint64_t threshold)
 {
 	return -FI_ENOSYS;
 }
 
+static bool rxm_no_flow_ctrl_available(struct fid_ep *ep_fid)
+{
+	return false;
+}
+
 struct ofi_ops_flow_ctrl rxm_no_ops_flow_ctrl = {
 	.size = sizeof(struct ofi_ops_flow_ctrl),
-	.set_threshold = rxm_no_set_threshold,
 	.add_credits = rxm_no_add_credits,
 	.enable = rxm_no_enable_flow_ctrl,
 	.set_send_handler = rxm_no_credit_handler,
+	.available = rxm_no_flow_ctrl_available,
 };
 
 static int rxm_config_flow_ctrl(struct rxm_domain *domain)

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -577,6 +577,7 @@ struct vrb_ep {
 	/* Protected by send CQ lock */
 	uint64_t			sq_credits;
 	uint64_t			peer_rq_credits;
+	uint64_t			saved_peer_rq_credits;
 	struct slist			sq_list;
 	/* Protected by recv CQ lock */
 	int64_t				rq_credits_avail;

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -39,13 +39,6 @@
 #include <malloc.h>
 
 
-
-static void vrb_set_threshold(struct fid_ep *ep_fid, size_t threshold)
-{
-	struct vrb_ep *ep = container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
-	ep->threshold = threshold;
-}
-
 static void vrb_set_credit_handler(struct fid_domain *domain_fid,
 		ssize_t (*credit_handler)(struct fid_ep *ep, size_t credits))
 {
@@ -56,24 +49,62 @@ static void vrb_set_credit_handler(struct fid_domain *domain_fid,
 	domain->send_credits = credit_handler;
 }
 
-static int vrb_enable_ep_flow_ctrl(struct fid_ep *ep_fid)
+static bool vrb_flow_ctrl_available(struct fid_ep *ep_fid)
 {
 	struct vrb_ep *ep = container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
+
 	// only enable if we are not using SRQ
-	if (!ep->srq_ep && ep->ibv_qp && ep->ibv_qp->qp_type == IBV_QPT_RC) {
-		ep->peer_rq_credits = 1;
-		return FI_SUCCESS;
+	return (!ep->srq_ep && ep->ibv_qp && ep->ibv_qp->qp_type == IBV_QPT_RC);
+}
+
+static int vrb_enable_ep_flow_ctrl(struct fid_ep *ep_fid, uint64_t threshold)
+{
+	struct vrb_ep *ep = container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
+	struct vrb_cq *cq = container_of(ep->util_ep.rx_cq, struct vrb_cq, util_cq);
+	struct vrb_domain *domain = vrb_ep_to_domain(ep);
+	uint64_t credits_to_give;
+
+	if (!vrb_flow_ctrl_available(ep_fid))
+		return -FI_ENOSYS;
+
+	ofi_genlock_lock(&cq->util_cq.cq_lock);
+	ep->threshold = threshold;
+
+	/*
+	 * Both sides assume 1 credit to start with. Previously received credits
+	 * from peer should also be added in.
+	 */
+	ep->peer_rq_credits = 1 + ep->saved_peer_rq_credits;
+	ep->saved_peer_rq_credits = 0;
+
+	/*
+	 * Preposted recvs may happen before flow control is enabled.
+	 * Send credit update if needed.
+	 */
+	if (ep->rq_credits_avail >= ep->threshold) {
+		credits_to_give = ep->rq_credits_avail;
+		ep->rq_credits_avail = 0;
+	} else {
+		credits_to_give = 0;
+	}
+	ofi_genlock_unlock(&cq->util_cq.cq_lock);
+
+	if (credits_to_give &&
+	    domain->send_credits(&ep->util_ep.ep_fid, credits_to_give)) {
+		ofi_genlock_lock(&cq->util_cq.cq_lock);
+		ep->rq_credits_avail += credits_to_give;
+		ofi_genlock_unlock(&cq->util_cq.cq_lock);
 	}
 
-	return -FI_ENOSYS;
+	return FI_SUCCESS;
 }
 
 struct ofi_ops_flow_ctrl vrb_ops_flow_ctrl = {
 	.size = sizeof(struct ofi_ops_flow_ctrl),
-	.set_threshold = vrb_set_threshold,
 	.add_credits = vrb_add_credits,
 	.enable = vrb_enable_ep_flow_ctrl,
 	.set_send_handler = vrb_set_credit_handler,
+	.available = vrb_flow_ctrl_available,
 };
 
 static int


### PR DESCRIPTION
Credit based flow control only works when both sides support it.
Exchange the information over the connetion manager and disable
flow control if support is missing from either side.

To help this, a new method 'available()' is added to flow_ctrl_ops and
the hook provider is updated to handle this new method.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>

Fix #6712 
Replace #7480 