### PR TITLE
prov/efa: use shm's inject write when possible

### DIFF
--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -631,6 +631,13 @@ ssize_t rxr_rma_inject_write(struct fid_ep *ep, const void *buf, size_t len,
 	struct fi_msg_rma msg;
 	struct iovec iov;
 	struct fi_rma_iov rma_iov;
+	struct rxr_ep *rxr_ep;
+	struct rdm_peer *peer;
+
+	rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid.fid);
+	peer = rxr_ep_get_peer(rxr_ep, dest_addr);
+	if (peer->is_local)
+		return fi_inject_write(rxr_ep->shm_ep, buf, len, peer->shm_fiaddr, addr, key);
 
 	iov.iov_base = (void *)buf;
 	iov.iov_len = len;
@@ -655,6 +662,13 @@ ssize_t rxr_rma_inject_writedata(struct fid_ep *ep, const void *buf, size_t len,
 	struct fi_msg_rma msg;
 	struct iovec iov;
 	struct fi_rma_iov rma_iov;
+	struct rxr_ep *rxr_ep;
+	struct rdm_peer *peer;
+
+	rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid.fid);
+	peer = rxr_ep_get_peer(rxr_ep, dest_addr);
+	if (peer->is_local)
+		return fi_inject_writedata(rxr_ep->shm_ep, buf, len, data, peer->shm_fiaddr, addr, key);
 
 	iov.iov_base = (void *)buf;
 	iov.iov_len = len;


### PR DESCRIPTION
EFA provider uses shm provider's write to implement
intra-node write.

Currently, EFA provider always calls shm's fi_writemsg()
to post intranode write request. For fi_writemsg(),
shm provider will write a completion entry. To process shm's
completion entry, EFA needs to create a tx_entry and a
pkt_entry when posting the write request, and use the packet
entry as context.

When application uses inject write, it does not require a completion.
Currently, EFA implement intra-node inject write by deserting the
completion from the shm provider (RXR_NO_COMPLETION flag).

However, it is more efficient to use shm's inject write in this case,
which elliminates the allocation of tx_entry and pkt_entry.
Meanwhile, if shm provider does not need to write completion,
it can chose a more effective communication protocol.

Hence, this patch makes EFA provider to use shm's provider's inject
write directly when possible.

Signed-off-by: Wei Zhang <wzam@amazon.com>