### PR TITLE
tcp/verbs/shm: Add assert to check source and target RMA msg lengths match

### DIFF
--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -107,6 +107,8 @@ ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 
 	assert(iov_count <= SMR_IOV_LIMIT);
 	assert(rma_count <= SMR_IOV_LIMIT);
+	assert(ofi_total_iov_len(iov, iov_count) ==
+	       ofi_total_rma_iov_len(rma_iov, rma_count));
 
 	domain = container_of(ep->util_ep.domain, struct smr_domain, util_domain);
 

--- a/prov/tcp/src/tcpx_rma.c
+++ b/prov/tcp/src/tcpx_rma.c
@@ -109,6 +109,8 @@ tcpx_rma_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 
 	assert(msg->iov_count <= TCPX_IOV_LIMIT);
 	assert(msg->rma_iov_count <= TCPX_IOV_LIMIT);
+	assert(ofi_total_iov_len(msg->msg_iov, msg->iov_count) ==
+	       ofi_total_rma_iov_len(msg->rma_iov, msg->rma_iov_count));
 
 	send_entry = tcpx_alloc_tx(ep);
 	if (!send_entry)
@@ -200,6 +202,8 @@ tcpx_rma_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 
 	data_len = ofi_total_iov_len(msg->msg_iov, msg->iov_count);
 
+	assert(ofi_total_rma_iov_len(msg->rma_iov, msg->rma_iov_count) ==
+	       data_len);
 	assert(!(flags & FI_INJECT) || (data_len <= TCPX_MAX_INJECT));
 
 	send_entry->hdr.base_hdr.op = ofi_op_write;

--- a/prov/verbs/src/verbs_rma.c
+++ b/prov/verbs/src/verbs_rma.c
@@ -92,6 +92,9 @@ vrb_msg_ep_rma_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 		.wr.rdma.rkey = (uint32_t)msg->rma_iov->key,
 	};
 
+	assert(ofi_total_iov_len(msg->msg_iov, msg->iov_count) ==
+	       ofi_total_rma_iov_len(msg->rma_iov, msg->rma_iov_count));
+
 	if (flags & FI_REMOTE_CQ_DATA) {
 		wr.opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
 		wr.imm_data = htonl((uint32_t)msg->data);
@@ -152,6 +155,9 @@ vrb_msg_ep_rma_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 		.wr.rdma.rkey = (uint32_t)msg->rma_iov->key,
 		.num_sge = msg->iov_count,
 	};
+
+	assert(ofi_total_iov_len(msg->msg_iov, msg->iov_count) ==
+	       ofi_total_rma_iov_len(msg->rma_iov, msg->rma_iov_count));
 
 	vrb_iov_dupa(wr.sg_list, msg->msg_iov, msg->desc, msg->iov_count);
 	return vrb_post_send(ep, &wr, 0);


### PR DESCRIPTION
Verify that the source and target buffer lengths are the same for fi_readmsg and fi_writemsg.

Fixes #7418

Uses asserts only, not run time checks, as these are fast paths.  This change is only to help debug apps.