### PR TITLE
fabtests/pytest/efa: adjust test case

### DIFF
--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -139,7 +139,6 @@ nobase_dist_config_DATA = \
 	pytest/default/test_unexpected_msg.py \
 	pytest/efa/conftest.py \
 	pytest/efa/test_from_default.py \
-	pytest/efa/test_av.py \
 	pytest/efa/test_dgram.py \
 	pytest/efa/test_rdm.py \
 	pytest/efa/test_rma_bw.py \

--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -143,7 +143,8 @@ nobase_dist_config_DATA = \
 	pytest/efa/test_rdm.py \
 	pytest/efa/test_rma_bw.py \
 	pytest/efa/test_unexpected_msg.py \
-	pytest/efa/test_multi_recv.py
+	pytest/efa/test_multi_recv.py \
+	pytest/efa/test_rnr.py
 
 noinst_LTLIBRARIES = libfabtests.la
 

--- a/fabtests/pytest/efa/test_av.py
+++ b/fabtests/pytest/efa/test_av.py
@@ -1,7 +1,0 @@
-import pytest
-
-@pytest.mark.functional
-def test_av_xfer(cmdline_args):
-    from common import ClientServerTest
-    test = ClientServerTest(cmdline_args, "fi_av_xfer -e rdm")
-    test.run()

--- a/fabtests/pytest/efa/test_rnr.py
+++ b/fabtests/pytest/efa/test_rnr.py
@@ -1,0 +1,54 @@
+import pytest
+
+@pytest.mark.functional
+def test_rnr_read_cq_error(cmdline_args):
+    from common import ClientServerTest
+
+    if cmdline_args.server_id == cmdline_args.client_id:
+        pytest.skip("RNR requires 2 nodes")
+        return
+
+    test = ClientServerTest(cmdline_args, "fi_efa_rnr_read_cq_error")
+    test.run()
+
+packet_type_option_map = {
+    "cts" : "-c 0 -S 1048576",
+    "readrsp" : "-c 0 -o read -S 4",
+    "atomrsp" : "-c 0 -A read -S 4",
+    "receipt" : "-c 0 -U -S 4",
+    "eager_msgrtm" : "-c 1 -S 4",
+    "eager_tagrtm" : "-c 1 -T -S 4",
+    "medium_msgrtm" : "-c 1 -S 16384",
+    "medium_tagrtm" : "-c 1 -T -S 16384",
+    "longcts_msgrtm" : "-c 1 -S 1048576",
+    "longcts_tagrtm" : "-c 1 -T -S 1048576",
+    "eager_rtw" : "-c 1 -o write -S 4",
+    "longcts_rtw" : "-c 1 -o write -S 1048576",
+    "short_rtr" : "-c 1 -o read -S 4",
+    "longcts_rtr" : "-c 1 -o read -S 1048576",
+    "write_rta" : "-c 1 -A write -S 4",
+    "fetch_rta" : "-c 1 -A read -S 4",
+    "compare_rta" : "-c 1 -A cswap -S 4",
+    "dc_eager_msgrtm" : "-c 1 -U -S 4",
+    "dc_eager_tagrtm" : "-c 1 -T -U -S 4",
+    "dc_medium_msgrtm" : "-c 1 -U -S 16384",
+    "dc_medium_tagrtm" : "-c 1 -T -U -S 16384",
+    "dc_longcts_msgrtm" : "-c 1 -U -S 1048576",
+    "dc_longcts_tagrtm" : "-c 1 -T -U -S 1048576",
+    "dc_eager_rtw" : "-c 1 -o write -U -S 4",
+    "dc_longcts_rtw" : "-c 1 -o write -U -S 1048576",
+    "dc_write_rta": "-c 1 -A write -U -S 4"
+}
+
+@pytest.mark.functional
+@pytest.mark.parametrize("packet_type", packet_type_option_map.keys())
+def test_rnr_queue_resend(cmdline_args, packet_type):
+    from common import ClientServerTest
+
+    if cmdline_args.server_id == cmdline_args.client_id:
+        pytest.skip("RNR test requires 2 nodes")
+        return
+
+    test = ClientServerTest(cmdline_args,
+            "fi_efa_rnr_queue_resend " + packet_type_option_map[packet_type])
+    test.run()


### PR DESCRIPTION
Remove av_xfer test temporarily because of hardware issue.

add RNR tests