### PR TITLE
prov/shm: disable 128-bit atomic support

### DIFF
--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -536,6 +536,12 @@ int smr_query_atomic(struct fid_domain *domain, enum fi_datatype datatype,
 		return -FI_EINVAL;
 	}
 
+	if (datatype >= FI_DATATYPE_LAST) {
+		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+			"128-bit datatypes not supported\n");
+		return -FI_EOPNOTSUPP;
+	}
+
 	ret = ofi_atomic_valid(&smr_prov, datatype, op, flags);
 	if (ret || !attr)
 		return ret;


### PR DESCRIPTION
shm currently does not support 128-bit support because of freestack buffer
alignment issues. Disable until that is fixed.

Signed-off-by: Alexia Ingerson <alexia.ingerson@intel.com>

Fixes #7371 and fixes #7227