### PR TITLE
fabric: Add ofi_hook_dmabuf_peer_mem to the ordered provider list

### DIFF
--- a/src/fabric.c
+++ b/src/fabric.c
@@ -424,6 +424,7 @@ static void ofi_ordered_provs_init(void)
 		 * doesn't matter
 		 */
 		"ofi_hook_perf", "ofi_hook_debug", "ofi_hook_noop", "ofi_hook_hmem",
+		"ofi_hook_dmabuf_peer_mem",
 	};
 	struct ofi_prov *prov;
 	int num_provs, i;


### PR DESCRIPTION
Functionality-wise it doesn't matter since the provider will always
be added when ofi_register_provider() is called and the ordering
doesn't affect hooking providers. However, all other providers are
in the list so it makes sense to keep it this way.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>