### PR TITLE
contrib/intel/jenkins: remove cleanup directory deletion

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -132,7 +132,6 @@ pipeline {
             withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
                 dir("${env.WORKSPACE}") {
                     sh "rm -rf '${env.CI_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}/ci_middlewares'"
-                    deleteDir()
                 }
             }
         }


### PR DESCRIPTION
removing this cleanup dir function because if two builds are running and one finishes it
will cause the other one to fail with:
	stale file handle
	file not found
these directories will get deleted during regular jenkins cleanup actions

Signed-off-by: Zach Dworkin <zachary.dworkin@intel.com>