### PR TITLE
prov/shm: refactor and simplify protocol code

### DIFF
--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -78,6 +78,7 @@ enum {
 	smr_src_mmap,	/* mmap-based fallback protocol */
 	smr_src_sar,	/* segmentation fallback protocol */
 	smr_src_ipc,	/* device IPC handle protocol */
+	smr_src_max,
 };
 
 //reserves 0-255 for defined ops and room for new ops
@@ -126,7 +127,6 @@ struct smr_msg_hdr {
 } __attribute__ ((aligned(16)));
 
 #define SMR_MSG_DATA_LEN	(SMR_CMD_SIZE - sizeof(struct smr_msg_hdr))
-#define SMR_COMP_DATA_LEN	(SMR_MSG_DATA_LEN / 2)
 
 #define IPC_HANDLE_SIZE		64
 struct smr_ipc_info {
@@ -147,10 +147,6 @@ union smr_cmd_data {
 		size_t		iov_count;
 		struct iovec	iov[(SMR_MSG_DATA_LEN - sizeof(size_t)) /
 				    sizeof(struct iovec)];
-	};
-	struct {
-		uint8_t		buf[SMR_COMP_DATA_LEN];
-		uint8_t		comp[SMR_COMP_DATA_LEN];
 	};
 	struct {
 		uint64_t	sar;

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -55,35 +55,31 @@ static void smr_generic_atomic_format(struct smr_cmd *cmd, uint8_t datatype,
 
 static void smr_format_inline_atomic(struct smr_cmd *cmd,
 				     enum fi_hmem_iface iface, uint64_t device,
-				     const struct iovec *iov, size_t count,
-				     const struct iovec *compv,
-				     size_t comp_count)
+				     const struct iovec *iov, size_t count)
 {
-	size_t comp_size;
-
 	cmd->msg.hdr.op_src = smr_src_inline;
 
-	switch (cmd->msg.hdr.op) {
-	case ofi_op_atomic:
-	case ofi_op_atomic_fetch:
-		cmd->msg.hdr.size = ofi_copy_from_hmem_iov(cmd->msg.data.msg,
-						SMR_MSG_DATA_LEN, iface, device,
-						iov, count, 0);
-		break;
-	case ofi_op_atomic_compare:
-		cmd->msg.hdr.size = ofi_copy_from_hmem_iov(cmd->msg.data.buf,
-						SMR_MSG_DATA_LEN, iface, device,
-						iov, count, 0);
-		comp_size = ofi_copy_from_hmem_iov(cmd->msg.data.comp,
-						SMR_MSG_DATA_LEN, iface, device,
-						compv, comp_count, 0);
-		if (comp_size != cmd->msg.hdr.size)
-			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-				"atomic and compare buffer size mismatch\n");
-		break;
-	default:
-		break;
-	}
+	cmd->msg.hdr.size = ofi_copy_from_hmem_iov(cmd->msg.data.msg,
+					SMR_MSG_DATA_LEN, iface, device,
+					iov, count, 0);
+}
+
+static void smr_do_atomic_inline(struct smr_ep *ep, struct smr_region *peer_smr,
+			int64_t id, int64_t peer_id, uint32_t op,
+			uint64_t op_flags, enum fi_hmem_iface iface,
+			uint64_t device, uint8_t datatype, uint8_t atomic_op,
+			const struct iovec *iov, size_t iov_count,
+			size_t total_len)
+{
+	struct smr_cmd *cmd;
+
+	cmd = ofi_cirque_next(smr_cmd_queue(peer_smr));
+	smr_generic_format(cmd, peer_id, op, 0, 0, op_flags);
+	smr_generic_atomic_format(cmd, datatype, atomic_op);
+	smr_format_inline_atomic(cmd, iface, device, iov, iov_count);
+
+	ofi_cirque_commit(smr_cmd_queue(peer_smr));
+	peer_smr->cmd_cnt--;
 }
 
 static void smr_format_inject_atomic(struct smr_cmd *cmd,
@@ -123,6 +119,59 @@ static void smr_format_inject_atomic(struct smr_cmd *cmd,
 	}
 }
 
+static ssize_t smr_do_atomic_inject(struct smr_ep *ep, struct smr_region *peer_smr,
+			int64_t id, int64_t peer_id, uint32_t op,
+			uint64_t op_flags, enum fi_hmem_iface iface,
+			uint64_t device, uint8_t datatype, uint8_t atomic_op,
+			const struct iovec *iov, size_t iov_count,
+			const struct iovec *resultv, size_t result_count,
+			const struct iovec *compv, size_t comp_count,
+			size_t total_len, void *context, uint16_t smr_flags)
+{
+	struct smr_cmd *cmd;
+	struct smr_inject_buf *tx_buf;
+	struct smr_tx_entry *pend;
+	struct smr_resp *resp;
+
+	cmd = ofi_cirque_next(smr_cmd_queue(peer_smr));
+	tx_buf = smr_freestack_pop(smr_inject_pool(peer_smr));
+
+	smr_generic_format(cmd, peer_id, op, 0, 0, op_flags);
+	smr_generic_atomic_format(cmd, datatype, atomic_op);
+	smr_format_inject_atomic(cmd, iface, device, iov, iov_count, 
+				 resultv, result_count, compv, comp_count,
+				 peer_smr, tx_buf);
+
+	if (smr_flags & SMR_RMA_REQ || op_flags & FI_DELIVERY_COMPLETE) {
+		if (ofi_cirque_isfull(smr_resp_queue(ep->region))) {
+			smr_freestack_push(smr_inject_pool(peer_smr), tx_buf);
+			return -FI_EAGAIN;
+		}
+		resp = ofi_cirque_next(smr_resp_queue(ep->region));
+		pend = ofi_freestack_pop(ep->pend_fs);
+		smr_format_pend_resp(pend, cmd, context, iface, device, resultv,
+				     result_count, op_flags, id, resp);
+		cmd->msg.hdr.data = smr_get_offset(ep->region, resp);
+		ofi_cirque_commit(smr_resp_queue(ep->region));
+	}
+
+	cmd->msg.hdr.op_flags |= smr_flags;
+	ofi_cirque_commit(smr_cmd_queue(peer_smr));
+	peer_smr->cmd_cnt--;
+
+	return FI_SUCCESS;
+}
+
+static int smr_select_atomic_proto(uint32_t op, uint64_t total_len,
+				   uint64_t op_flags)
+{
+	if (op == ofi_op_atomic_compare || op == ofi_op_atomic_fetch ||
+	    op_flags & FI_DELIVERY_COMPLETE || total_len > SMR_MSG_DATA_LEN)
+		return smr_src_inject;
+
+	return smr_src_inline;
+}
+
 static ssize_t smr_generic_atomic(struct smr_ep *ep,
 			const struct fi_ioc *ioc, void **desc, size_t count,
 			const struct fi_ioc *compare_ioc, void **compare_desc,
@@ -133,19 +182,16 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 			enum fi_op atomic_op, void *context, uint32_t op,
 			uint64_t op_flags)
 {
-	struct smr_region *peer_smr;
-	struct smr_inject_buf *tx_buf;
-	struct smr_tx_entry *pend;
-	struct smr_resp *resp = NULL;
 	struct smr_cmd *cmd;
+	struct smr_region *peer_smr;
 	struct iovec iov[SMR_IOV_LIMIT];
 	struct iovec compare_iov[SMR_IOV_LIMIT];
 	struct iovec result_iov[SMR_IOV_LIMIT];
 	enum fi_hmem_iface iface;
 	uint64_t device;
+	uint16_t smr_flags = 0;
 	int64_t id, peer_id;
-	int err = 0;
-	uint16_t flags = 0;
+	int err = 0, proto;
 	ssize_t ret = 0;
 	size_t total_len;
 
@@ -173,7 +219,6 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 		goto unlock_cq;
 	}
 
-	cmd = ofi_cirque_next(smr_cmd_queue(peer_smr));
 	total_len = ofi_datatype_size(datatype) * ofi_total_ioc_cnt(ioc, count);
 
 	switch (op) {
@@ -187,7 +232,7 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 		assert(result_ioc);
 		ofi_ioc_to_iov(result_ioc, result_iov, result_count,
 			       ofi_datatype_size(datatype));
-		flags |= SMR_RMA_REQ;
+		smr_flags = SMR_RMA_REQ;
 		/* fall through */
 	case ofi_op_atomic:
 		if (atomic_op != FI_ATOMIC_READ) {
@@ -203,45 +248,24 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 
 	iface = smr_get_mr_hmem_iface(ep->util_ep.domain, desc, &device);
 
-	smr_generic_format(cmd, peer_id, op, 0, 0, op_flags);
-	smr_generic_atomic_format(cmd, datatype, atomic_op);
+	proto = smr_select_atomic_proto(op, total_len, op_flags);
 
-	if (total_len <= SMR_MSG_DATA_LEN && !(flags & SMR_RMA_REQ) &&
-	    !(op_flags & FI_DELIVERY_COMPLETE)) {
-		smr_format_inline_atomic(cmd, iface, device, iov, count, compare_iov,
-					 compare_count);
-	} else if (total_len <= SMR_INJECT_SIZE) {
-		tx_buf = smr_freestack_pop(smr_inject_pool(peer_smr));
-		smr_format_inject_atomic(cmd, iface, device, iov, count, result_iov,
-					 result_count, compare_iov, compare_count,
-					 peer_smr, tx_buf);
-		if (flags & SMR_RMA_REQ || op_flags & FI_DELIVERY_COMPLETE) {
-			if (ofi_cirque_isfull(smr_resp_queue(ep->region))) {
-				smr_freestack_push(smr_inject_pool(peer_smr), tx_buf);
-				ret = -FI_EAGAIN;
-				goto unlock_cq;
-			}
-			resp = ofi_cirque_next(smr_resp_queue(ep->region));
-			pend = ofi_freestack_pop(ep->pend_fs);
-			smr_format_pend_resp(pend, cmd, context, iface, device, result_iov,
-					     result_count, id, resp);
-			cmd->msg.hdr.data = smr_get_offset(ep->region, resp);
-			ofi_cirque_commit(smr_resp_queue(ep->region));
-		}
+	if (proto == smr_src_inline) {
+		smr_do_atomic_inline(ep, peer_smr, id, peer_id, ofi_op_atomic,
+			 	     op_flags, iface, device, datatype, atomic_op,
+				     iov, count, total_len);
 	} else {
-		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-			"message too large\n");
-		ret = -FI_EINVAL;
-		goto unlock_cq;
+		ret = smr_do_atomic_inject(ep, peer_smr, id, peer_id, op,
+				op_flags, iface, device, datatype, atomic_op,
+				iov, count, result_iov, result_count,
+				compare_iov, compare_count, total_len, context,
+				smr_flags);
+		if (ret)
+			goto unlock_cq;
 	}
-	cmd->msg.hdr.op_flags |= flags;
 
-	ofi_cirque_commit(smr_cmd_queue(peer_smr));
-	peer_smr->cmd_cnt--;
-
-	if (!resp) {
-		ret = smr_complete_tx(ep, context, op, cmd->msg.hdr.op_flags,
-				      err);
+	if (!(smr_flags & SMR_RMA_REQ) && !(op_flags & FI_DELIVERY_COMPLETE)) {
+		ret = smr_complete_tx(ep, context, op, op_flags, err);
 		if (ret) {
 			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 				"unable to process tx completion\n");
@@ -320,17 +344,14 @@ static ssize_t smr_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 			size_t count, fi_addr_t dest_addr, uint64_t addr,
 			uint64_t key, enum fi_datatype datatype, enum fi_op op)
 {
+	struct smr_cmd *cmd;
 	struct smr_ep *ep;
 	struct smr_region *peer_smr;
-	struct smr_inject_buf *tx_buf;
-	struct smr_cmd *cmd;
 	struct iovec iov;
 	struct fi_rma_ioc rma_ioc;
 	int64_t id, peer_id;
 	ssize_t ret = 0;
 	size_t total_len;
-
-	assert(count <= SMR_INJECT_SIZE);
 
 	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
 
@@ -349,6 +370,7 @@ static ssize_t smr_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 
 	cmd = ofi_cirque_next(smr_cmd_queue(peer_smr));
 	total_len = count * ofi_datatype_size(datatype);
+	assert(total_len <= SMR_INJECT_SIZE);
 
 	iov.iov_base = (void *) buf;
 	iov.iov_len = total_len;
@@ -357,19 +379,19 @@ static ssize_t smr_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 	rma_ioc.count = count;
 	rma_ioc.key = key;
 
-	smr_generic_format(cmd, peer_id, ofi_op_atomic, 0, 0, 0);
-	smr_generic_atomic_format(cmd, datatype, op);
-
 	if (total_len <= SMR_MSG_DATA_LEN) {
-		smr_format_inline_atomic(cmd, FI_HMEM_SYSTEM, 0, &iov, 1, NULL, 0);
+		smr_do_atomic_inline(ep, peer_smr, id, peer_id, ofi_op_atomic,
+			 	     0, FI_HMEM_SYSTEM, 0, datatype, op,
+				     &iov, 1, total_len);
 	} else if (total_len <= SMR_INJECT_SIZE) {
-		tx_buf = smr_freestack_pop(smr_inject_pool(peer_smr));
-		smr_format_inject_atomic(cmd, FI_HMEM_SYSTEM, 0, &iov, 1, NULL,
-					 0, NULL, 0, peer_smr, tx_buf);
+		ret = smr_do_atomic_inject(ep, peer_smr, id, peer_id,
+				ofi_op_atomic, 0, FI_HMEM_SYSTEM, 0, datatype,
+				op, &iov, 1, NULL, 0, NULL, 0, total_len,
+				NULL, 0);
+		if (ret)
+			goto unlock_region;
 	}
 
-	ofi_cirque_commit(smr_cmd_queue(peer_smr));
-	peer_smr->cmd_cnt--;
 	cmd = ofi_cirque_next(smr_cmd_queue(peer_smr));
 	smr_format_rma_ioc(cmd, &rma_ioc, 1);
 	ofi_cirque_commit(smr_cmd_queue(peer_smr));

--- a/prov/shm/src/smr_comp.c
+++ b/prov/shm/src/smr_comp.c
@@ -38,11 +38,11 @@
 #include "smr.h"
 
 int smr_complete_tx(struct smr_ep *ep, void *context, uint32_t op,
-		    uint16_t flags, uint64_t err)
+		    uint64_t flags, uint64_t err)
 {
 	ofi_ep_tx_cntr_inc_func(&ep->util_ep, op);
 
-	if (!err && !(flags & SMR_TX_COMPLETION))
+	if (!err && !(flags & FI_COMPLETION))
 		return 0;
 
 	return ep->tx_comp(ep, context, op, flags, err);

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -158,16 +158,13 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 				   uint32_t op, uint64_t op_flags)
 {
 	struct smr_region *peer_smr;
-	struct smr_inject_buf *tx_buf;
-	struct smr_resp *resp;
-	struct smr_cmd *cmd;
-	struct smr_tx_entry *pend;
 	enum fi_hmem_iface iface;
 	uint64_t device;
 	int64_t id, peer_id;
 	ssize_t ret = 0;
 	size_t total_len;
 	bool use_ipc;
+	int proto;
 
 	assert(iov_count <= SMR_IOV_LIMIT);
 
@@ -195,83 +192,32 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 	total_len = ofi_total_iov_len(iov, iov_count);
 	assert(!(op_flags & FI_INJECT) || total_len <= SMR_INJECT_SIZE);
 
-	cmd = ofi_cirque_next(smr_cmd_queue(peer_smr));
-	smr_generic_format(cmd, peer_id, op, tag, data, op_flags);
-
 	/* Do not inline/inject if IPC is available so device to device
 	 * transfer may occur if possible. */
 	use_ipc = ofi_hmem_is_ipc_enabled(iface) && (iov_count == 1) &&
 		  desc && (smr_get_mr_flags(desc) & FI_HMEM_DEVICE_ONLY) &&
 		  !(op_flags & FI_INJECT);
 
-	if (total_len <= SMR_MSG_DATA_LEN &&
-	    !(op_flags & FI_DELIVERY_COMPLETE) && !use_ipc) {
-		smr_format_inline(cmd, iface, device, iov, iov_count);
-	} else if (total_len <= SMR_INJECT_SIZE &&
-		   !(op_flags & FI_DELIVERY_COMPLETE) &&
-		   !use_ipc) {
-		tx_buf = smr_freestack_pop(smr_inject_pool(peer_smr));
-		smr_format_inject(cmd, iface, device, iov, iov_count, peer_smr, tx_buf);
-	} else {
-		if (ofi_cirque_isfull(smr_resp_queue(ep->region))) {
-			ret = -FI_EAGAIN;
-			goto unlock_cq;
-		}
-		resp = ofi_cirque_next(smr_resp_queue(ep->region));
-		pend = ofi_freestack_pop(ep->pend_fs);
-		if (smr_cma_enabled(ep, peer_smr) && iface == FI_HMEM_SYSTEM &&
-		    !(op_flags & FI_INJECT)) {
-			smr_format_iov(cmd, iov, iov_count, total_len, ep->region,
-				       resp);
-		} else {
-			if (use_ipc && iface == FI_HMEM_ZE &&
-			    smr_ze_ipc_enabled(ep->region, peer_smr)) {
-				ret = smr_format_ze_ipc(ep, id, cmd, iov,
-					device, total_len, ep->region,
-					resp, pend);
-			} else if (use_ipc && iface != FI_HMEM_ZE) {
-				ret = smr_format_ipc(cmd, iov[0].iov_base, total_len,
-						     ep->region, resp, iface);
-				if (ret) {
-					FI_WARN_ONCE(&smr_prov, FI_LOG_EP_CTRL,
-						     "unable to use IPC for msg, fallback to using SAR\n");
-					ret = smr_format_sar(cmd, iface, device, iov,
-							     iov_count, total_len,
-							     ep->region, peer_smr, id,
-							     pend, resp);
-				}
-			} else if (total_len <= smr_env.sar_threshold ||
-				   iface != FI_HMEM_SYSTEM || op_flags & FI_INJECT) {
-				ret = smr_format_sar(cmd, iface, device, iov,
-						     iov_count, total_len,
-						     ep->region, peer_smr, id,
-						     pend, resp);
-			} else {
-				ret = smr_format_mmap(ep, cmd, iov, iov_count,
-						      total_len, pend, resp);
-			}
-			if (ret) {
-				ofi_freestack_push(ep->pend_fs, pend);
-				ret = -FI_EAGAIN;
-				goto unlock_cq;
-			}
-		}
-		smr_format_pend_resp(pend, cmd, context, iface, device, iov,
-				     iov_count, id, resp);
-		ofi_cirque_commit(smr_resp_queue(ep->region));
-		goto commit;
-	}
-	ret = smr_complete_tx(ep, context, op, cmd->msg.hdr.op_flags, 0);
+	proto = smr_select_proto(use_ipc, smr_cma_enabled(ep, peer_smr), iface,
+				 op, total_len, op_flags);
+
+	ret = smr_proto_ops[proto](ep, peer_smr, id, peer_id, op, tag, data, op_flags,
+				   iface, device, iov, iov_count, total_len, context);
+	if (ret)
+		goto unlock_cq;
+
+	smr_signal(peer_smr);
+
+	if (proto != smr_src_inline && proto != smr_src_inject)
+		goto unlock_cq;
+
+	ret = smr_complete_tx(ep, context, op, op_flags, 0);
 	if (ret) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"unable to process tx completion\n");
 		goto unlock_cq;
 	}
 
-commit:
-	ofi_cirque_commit(smr_cmd_queue(peer_smr));
-	peer_smr->cmd_cnt--;
-	smr_signal(peer_smr);
 unlock_cq:
 	ofi_genlock_unlock(&ep->util_ep.tx_cq->cq_lock);
 unlock_region:
@@ -324,11 +270,10 @@ static ssize_t smr_generic_inject(struct fid_ep *ep_fid, const void *buf,
 {
 	struct smr_ep *ep;
 	struct smr_region *peer_smr;
-	struct smr_inject_buf *tx_buf;
-	struct smr_cmd *cmd;
 	int64_t id, peer_id;
 	ssize_t ret = 0;
 	struct iovec msg_iov;
+	int proto;
 
 	assert(len <= SMR_INJECT_SIZE);
 
@@ -350,19 +295,13 @@ static ssize_t smr_generic_inject(struct fid_ep *ep_fid, const void *buf,
 		goto unlock;
 	}
 
-	cmd = ofi_cirque_next(smr_cmd_queue(peer_smr));
-	smr_generic_format(cmd, peer_id, op, tag, data, op_flags);
+	proto = len <= SMR_MSG_DATA_LEN ? smr_src_inline : smr_src_inject;
+	ret = smr_proto_ops[proto](ep, peer_smr, id, peer_id, op, tag, data,
+			op_flags, FI_HMEM_SYSTEM, 0, &msg_iov, 1, len, NULL);
 
-	if (len <= SMR_MSG_DATA_LEN) {
-		smr_format_inline(cmd, FI_HMEM_SYSTEM, 0, &msg_iov, 1);
-	} else {
-		tx_buf = smr_freestack_pop(smr_inject_pool(peer_smr));
-		smr_format_inject(cmd, FI_HMEM_SYSTEM, 0, &msg_iov, 1,
-				  peer_smr, tx_buf);
-	}
+	assert(!ret);
 	ofi_ep_tx_cntr_inc_func(&ep->util_ep, op);
-	peer_smr->cmd_cnt--;
-	ofi_cirque_commit(smr_cmd_queue(peer_smr));
+
 	smr_signal(peer_smr);
 unlock:
 	pthread_spin_unlock(&peer_smr->lock);

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -39,11 +39,18 @@
 #include "smr.h"
 
 
-static void smr_format_rma_iov(struct smr_cmd *cmd, const struct fi_rma_iov *rma_iov,
-			       size_t iov_count)
+static void smr_add_rma_cmd(struct smr_region *peer_smr,
+		const struct fi_rma_iov *rma_iov, size_t iov_count)
 {
+	struct smr_cmd *cmd;
+
+	cmd = ofi_cirque_next(smr_cmd_queue(peer_smr));
+
 	cmd->rma.rma_count = iov_count;
 	memcpy(cmd->rma.rma_iov, rma_iov, sizeof(*rma_iov) * iov_count);
+
+	ofi_cirque_commit(smr_cmd_queue(peer_smr));
+	peer_smr->cmd_cnt--;
 }
 
 static void smr_format_rma_resp(struct smr_cmd *cmd, fi_addr_t peer_id,
@@ -54,13 +61,13 @@ static void smr_format_rma_resp(struct smr_cmd *cmd, fi_addr_t peer_id,
 	cmd->msg.hdr.size = total_len;
 }
 
-ssize_t smr_rma_fast(struct smr_region *peer_smr, struct smr_cmd *cmd,
-		     const struct iovec *iov, size_t iov_count,
-		     const struct fi_rma_iov *rma_iov, size_t rma_count,
-		     void **desc, int peer_id, void *context, uint32_t op,
-		     uint64_t op_flags)
+static ssize_t smr_rma_fast(struct smr_region *peer_smr, const struct iovec *iov,
+			size_t iov_count, const struct fi_rma_iov *rma_iov,
+			size_t rma_count, void **desc, int peer_id, void *context,
+			uint32_t op, uint64_t op_flags)
 {
 	struct iovec cma_iovec[SMR_IOV_LIMIT], rma_iovec[SMR_IOV_LIMIT];
+	struct smr_cmd *cmd;
 	size_t total_len;
 	int ret, i;
 
@@ -78,9 +85,12 @@ ssize_t smr_rma_fast(struct smr_region *peer_smr, struct smr_cmd *cmd,
 	if (ret)
 		return ret;
 
+	cmd = ofi_cirque_next(smr_cmd_queue(peer_smr));
 	smr_format_rma_resp(cmd, peer_id, rma_iov, rma_count, total_len,
 			    (op == ofi_op_write) ? ofi_op_write_async :
 			    ofi_op_read_async, op_flags);
+	ofi_cirque_commit(smr_cmd_queue(peer_smr));
+	peer_smr->cmd_cnt--;
 
 	return 0;
 }
@@ -92,15 +102,10 @@ ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 {
 	struct smr_domain *domain;
 	struct smr_region *peer_smr;
-	struct smr_inject_buf *tx_buf;
-	struct smr_resp *resp;
-	struct smr_cmd *cmd;
-	struct smr_tx_entry *pend;
 	enum fi_hmem_iface iface;
 	uint64_t device;
 	int64_t id, peer_id;
-	int cmds, err = 0, comp = 1;
-	uint16_t comp_flags;
+	int cmds, err = 0, proto = smr_src_inline;
 	ssize_t ret = 0;
 	size_t total_len;
 	bool use_ipc;
@@ -136,14 +141,11 @@ ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 		goto unlock_cq;
 	}
 
-	cmd = ofi_cirque_next(smr_cmd_queue(peer_smr));
-
 	if (cmds == 1) {
-		err = smr_rma_fast(peer_smr, cmd, iov, iov_count, rma_iov,
+		err = smr_rma_fast(peer_smr, iov, iov_count, rma_iov,
 				   rma_count, desc, peer_id,  context, op,
 				   op_flags);
-		comp_flags = cmd->msg.hdr.op_flags;
-		goto commit_comp;
+		goto signal_comp;
 	}
 
 	iface = smr_get_mr_hmem_iface(ep->util_ep.domain, desc, &device);
@@ -157,94 +159,23 @@ ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 		  desc && (smr_get_mr_flags(desc) & FI_HMEM_DEVICE_ONLY) &&
 		  !(op_flags & FI_INJECT);
 
-	smr_generic_format(cmd, peer_id, op, 0, data, op_flags);
-	if (total_len <= SMR_MSG_DATA_LEN && op == ofi_op_write &&
-	    !(op_flags & FI_DELIVERY_COMPLETE) && !use_ipc) {
-		smr_format_inline(cmd, iface, device, iov, iov_count);
-	} else if (total_len <= SMR_INJECT_SIZE &&
-		   !(op_flags & FI_DELIVERY_COMPLETE) && !use_ipc) {
-		tx_buf = smr_freestack_pop(smr_inject_pool(peer_smr));
-		smr_format_inject(cmd, iface, device, iov, iov_count, peer_smr, tx_buf);
-		if (op == ofi_op_read_req) {
-			if (ofi_cirque_isfull(smr_resp_queue(ep->region))) {
-				smr_freestack_push(smr_inject_pool(peer_smr), tx_buf);
-				ret = -FI_EAGAIN;
-				goto unlock_cq;
-			}
-			cmd->msg.hdr.op_flags |= SMR_RMA_REQ;
-			resp = ofi_cirque_next(smr_resp_queue(ep->region));
-			pend = ofi_freestack_pop(ep->pend_fs);
-			smr_format_pend_resp(pend, cmd, context, iface, device, iov,
-					     iov_count, id, resp);
-			cmd->msg.hdr.data = smr_get_offset(ep->region, resp);
-			ofi_cirque_commit(smr_resp_queue(ep->region));
-			comp = 0;
-		}
-	} else {
-		if (ofi_cirque_isfull(smr_resp_queue(ep->region))) {
-			ret = -FI_EAGAIN;
-			goto unlock_cq;
-		}
-		resp = ofi_cirque_next(smr_resp_queue(ep->region));
-		pend = ofi_freestack_pop(ep->pend_fs);
-		if (smr_cma_enabled(ep, peer_smr) && iface == FI_HMEM_SYSTEM &&
-		    !(op_flags & FI_INJECT)) { 
-			smr_format_iov(cmd, iov, iov_count, total_len, ep->region,
-				       resp);
-		} else {
-			if (use_ipc && iface == FI_HMEM_ZE &&
-			    smr_ze_ipc_enabled(ep->region, peer_smr)) {
-				ret = smr_format_ze_ipc(ep, id, cmd, iov,
-					device, total_len, ep->region,
-					resp, pend);
-			} else if (use_ipc && iface != FI_HMEM_ZE) {
-				ret = smr_format_ipc(cmd, iov[0].iov_base, total_len,
-						     ep->region, resp, iface);
-				if (ret) {
-					FI_WARN_ONCE(&smr_prov, FI_LOG_EP_CTRL,
-						     "unable to use IPC for RMA, fallback to using SAR\n");
-					ret = smr_format_sar(cmd, iface, device, iov,
-							     iov_count, total_len,
-							     ep->region, peer_smr, id,
-							     pend, resp);
-				}
-			} else if (total_len <= smr_env.sar_threshold ||
-			    iface != FI_HMEM_SYSTEM || op_flags & FI_INJECT) {
-				ret = smr_format_sar(cmd, iface, device, iov,
-						     iov_count, total_len,
-						     ep->region, peer_smr, id,
-						     pend, resp);
-			} else {
-				ret = smr_format_mmap(ep, cmd, iov, iov_count,
-						      total_len, pend, resp);
-			}
-			if (ret) {
-				ofi_freestack_push(ep->pend_fs, pend);
-				ret = -FI_EAGAIN;
-				goto unlock_cq;
-			}
-		}
-		smr_format_pend_resp(pend, cmd, context, iface, device, iov,
-				     iov_count, id, resp);
-		ofi_cirque_commit(smr_resp_queue(ep->region));
-		comp = 0;
-	}
+	proto = smr_select_proto(use_ipc, smr_cma_enabled(ep, peer_smr), iface,
+				 op, total_len, op_flags);
 
-	comp_flags = cmd->msg.hdr.op_flags;
-	ofi_cirque_commit(smr_cmd_queue(peer_smr));
-	peer_smr->cmd_cnt--;
-	cmd = ofi_cirque_next(smr_cmd_queue(peer_smr));
-	smr_format_rma_iov(cmd, rma_iov, rma_count);
-
-commit_comp:
-	ofi_cirque_commit(smr_cmd_queue(peer_smr));
-	peer_smr->cmd_cnt--;
-	smr_signal(peer_smr);
-
-	if (!comp)
+	ret = smr_proto_ops[proto](ep, peer_smr, id, peer_id, op, 0, data, op_flags,
+				   iface, device, iov, iov_count, total_len, context);
+	if (ret)
 		goto unlock_cq;
 
-	ret = smr_complete_tx(ep, context, op, comp_flags, err);
+	smr_add_rma_cmd(peer_smr, rma_iov, rma_count);
+
+signal_comp:
+	smr_signal(peer_smr);
+
+	if (proto != smr_src_inline && proto != smr_src_inject)
+		goto unlock_cq;
+
+	ret = smr_complete_tx(ep, context, op, op_flags, err);
 	if (ret) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"unable to process tx completion\n");
@@ -369,12 +300,10 @@ ssize_t smr_generic_rma_inject(struct fid_ep *ep_fid, const void *buf,
 	struct smr_ep *ep;
 	struct smr_domain *domain;
 	struct smr_region *peer_smr;
-	struct smr_inject_buf *tx_buf;
-	struct smr_cmd *cmd;
 	struct iovec iov;
 	struct fi_rma_iov rma_iov;
 	int64_t id, peer_id;
-	int cmds;
+	int cmds, proto = smr_src_inline;
 	ssize_t ret = 0;
 
 	assert(len <= SMR_INJECT_SIZE);
@@ -404,33 +333,21 @@ ssize_t smr_generic_rma_inject(struct fid_ep *ep_fid, const void *buf,
 	rma_iov.len = len;
 	rma_iov.key = key;
 
-	cmd = ofi_cirque_next(smr_cmd_queue(peer_smr));
-
 	if (cmds == 1) {
-		ret = smr_rma_fast(peer_smr, cmd, &iov, 1, &rma_iov, 1, NULL,
+		ret = smr_rma_fast(peer_smr, &iov, 1, &rma_iov, 1, NULL,
 				   peer_id, NULL, ofi_op_write, flags);
 		if (ret)
 			goto unlock_region;
-		goto commit;
+		goto signal;
 	}
 
-	smr_generic_format(cmd, peer_id, ofi_op_write, 0, data, flags);
-	if (len <= SMR_MSG_DATA_LEN) {
-		smr_format_inline(cmd, FI_HMEM_SYSTEM, 0, &iov, 1);
-	} else {
-		tx_buf = smr_freestack_pop(smr_inject_pool(peer_smr));
-		smr_format_inject(cmd, FI_HMEM_SYSTEM, 0, &iov, 1,
-				  peer_smr, tx_buf);
-	}
+	proto = len <= SMR_MSG_DATA_LEN ? smr_src_inline : smr_src_inject;
+	ret = smr_proto_ops[proto](ep, peer_smr, id, peer_id, ofi_op_write, 0,
+			data, flags, FI_HMEM_SYSTEM, 0, &iov, 1, len, NULL);
 
-	ofi_cirque_commit(smr_cmd_queue(peer_smr));
-	peer_smr->cmd_cnt--;
-	cmd = ofi_cirque_next(smr_cmd_queue(peer_smr));
-	smr_format_rma_iov(cmd, &rma_iov, 1);
-
-commit:
-	ofi_cirque_commit(smr_cmd_queue(peer_smr));
-	peer_smr->cmd_cnt--;
+	assert(!ret);
+	smr_add_rma_cmd(peer_smr, &rma_iov, 1);
+signal:
 	smr_signal(peer_smr);
 	ofi_ep_tx_cntr_inc_func(&ep->util_ep, ofi_op_write);
 unlock_region:


### PR DESCRIPTION
When the shm provider was first released, it only had
three protocol (inline, inject, iov), making the protocol
selection more or less straightforward. However, as the
provider has developed, three new protocols have been added
(mmap, sar, ipc). The addition of these checks and protocols
has added a lot of complexity to the code, resulting in
very convoluted and hard to follow code with many duplicate
checks.

This patch simplifies all of the protocol code by
isolating each protocol into separate functions, accessible
through an array of function pointers by protocol enum.

These functions are used by the msg, tagged, and rma calls
which all take similar code paths. The atomic calls are
separated since they follow a slightly different pattern
because of the extra atomic/datatype fields.

This patch also makes the following two indirectly related
changes:
- smr_complete_tx now takes in 64bit FI flags instead
of the 16bit SMR flag, saving instructions to convert
from SMR to FI for the completion flags. Add 64bit op
flags to tx_entry to save them for response entry
completions
- Remove redundant atomic fetch/compare inline path and
force all compare and fetch atomics through the inject.
The old code was not using this path anyway because
SMR_RMA_REQ was always set for fetch and compares. Removing
this path simplifies atomic protocol selection as well.

Signed-off-by: aingerson <alexia.ingerson@intel.com>