### PR TITLE
contrib/intel/jenkins Cancel Stale Builds

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -1,4 +1,6 @@
 
+properties([disableConcurrentBuilds(abortPrevious: true)])
+
 pipeline {
     agent { node { label 'master' } }
     options {


### PR DESCRIPTION
Abort old builds if a new build gets added to the same job's queue
This will remove the need to abort old builds by hand
It will free up resources more quickly when open PRs have multiple changes pushed in quick succession to only test the latest changes

Signed-off-by: Zach Dworkin <zachary.dworkin@intel.com>