### PR TITLE
include: Fix compiler warnings for Windows build

### DIFF
--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -177,7 +177,7 @@ ofi_byteq_read(struct ofi_byteq *byteq, void *buf, size_t len)
 
 	if (len < avail) {
 		memcpy(buf, &byteq->data[byteq->head], len);
-		byteq->head += len;
+		byteq->head += (unsigned)len;
 		return len;
 	}
 
@@ -192,7 +192,7 @@ ofi_byteq_write(struct ofi_byteq *byteq, const void *buf, size_t len)
 {
 	assert(len <= ofi_byteq_writeable(byteq));
 	memcpy(&byteq->data[byteq->tail], buf, len);
-	byteq->tail += len;
+	byteq->tail += (unsigned)len;
 }
 
 void ofi_byteq_writev(struct ofi_byteq *byteq, const struct iovec *iov,
@@ -208,7 +208,7 @@ static inline ssize_t ofi_byteq_recv(struct ofi_byteq *byteq, SOCKET sock)
 	ret = ofi_recv_socket(sock, &byteq->data[byteq->tail], avail,
 			      MSG_NOSIGNAL);
 	if (ret > 0)
-		byteq->tail += ret;
+		byteq->tail += (unsigned)ret;
 	return ret;
 }
 
@@ -224,11 +224,11 @@ static inline ssize_t ofi_byteq_send(struct ofi_byteq *byteq, SOCKET sock)
 	assert(avail);
 	ret = ofi_send_socket(sock, &byteq->data[byteq->head], avail,
 			      MSG_NOSIGNAL);
-	if (ret == avail) {
+	if ((size_t) ret == avail) {
 		byteq->head = 0;
 		byteq->tail = 0;
 	} else if (ret > 0) {
-		byteq->head += ret;
+		byteq->head += (unsigned)ret;
 	}
 	return ret;
 }

--- a/include/ofi_signal.h
+++ b/include/ofi_signal.h
@@ -105,7 +105,7 @@ static inline void fd_signal_set(struct fd_signal *signal)
 {
 	char c = 0;
 	bool cas; /* cas result */
-	int write_rc;
+	ssize_t write_rc;
 
 	cas = ofi_atomic_cas_bool_strong32(&signal->state,
 					   OFI_SIGNAL_UNSET,
@@ -136,7 +136,7 @@ static inline void fd_signal_reset(struct fd_signal *signal)
 	char c;
 	bool cas; /* cas result */
 	enum ofi_signal_state state;
-	int read_rc;
+	ssize_t read_rc;
 
 	do {
 		cas = ofi_atomic_cas_bool_weak32(&signal->state,


### PR DESCRIPTION
Build logs are filled with the warning messages since the headers are included
for almost every source file.

windows\osd.h(777,26): warning C4090: 'function': different 'const' qualifiers
windows\osd.h(884,34): warning C4244: 'return': conversion from 'ULONGLONG' to 'long', possible loss of data
windows\osd.h(1039,19): warning C4057: 'function': 'int *' differs in indirection to slightly different base types from 'unsigned int *'
ofi_atom.h(362): warning C4057: 'function': 'volatile long *' differs in indirection to slightly different base types from 'int32_t *'
ofi_signal.h(115,19): warning C4244: '=': conversion from 'ssize_t' to 'int', possible loss of data
ofi_signal.h(147,18): warning C4244: '=': conversion from 'ssize_t' to 'int', possible loss of data
ofi_net.h(180,21): warning C4267: '+=': conversion from 'size_t' to 'unsigned int', possible loss of data
ofi_net.h(195,20): warning C4267: '+=': conversion from 'size_t' to 'unsigned int', possible loss of data
ofi_net.h(211,21): warning C4244: '+=': conversion from 'ssize_t' to 'unsigned int', possible loss of data
ofi_net.h(227,10): warning C4389: '==': signed/unsigned mismatch
ofi_net.h(231,21): warning C4244: '+=': conversion from 'ssize_t' to 'unsigned int', possible loss of data

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>