### PR TITLE
prov/efa: do not use shm with a peer that uses EFA

### DIFF
--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1951,7 +1951,7 @@ static inline void rdm_ep_poll_ibv_cq(struct rxr_ep *ep,
 			pkt_entry->addr = efa_av_reverse_lookup_rdm(efa_av, ibv_wc.slid, ibv_wc.src_qp, pkt_entry);
 			pkt_entry->pkt_size = ibv_wc.byte_len;
 			assert(pkt_entry->pkt_size > 0);
-			rxr_pkt_handle_recv_completion(ep, pkt_entry);
+			rxr_pkt_handle_recv_completion(ep, pkt_entry, EFA_EP);
 #if ENABLE_DEBUG
 			ep->recv_comps++;
 #endif
@@ -2046,7 +2046,7 @@ static inline void rdm_ep_poll_shm_cq(struct rxr_ep *ep,
 			pkt_entry->addr = src_addr;
 			pkt_entry->pkt_size = cq_entry.len;
 			assert(pkt_entry->pkt_size > 0);
-			rxr_pkt_handle_recv_completion(ep, pkt_entry);
+			rxr_pkt_handle_recv_completion(ep, pkt_entry, SHM_EP);
 		} else {
 			FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,
 				"Unhandled cq type\n");

--- a/prov/efa/src/rxr/rxr_pkt_cmd.h
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.h
@@ -58,7 +58,8 @@ void rxr_pkt_handle_recv_error(struct rxr_ep *ep,
 			       int err, int prov_errno);
 
 void rxr_pkt_handle_recv_completion(struct rxr_ep *ep,
-				    struct rxr_pkt_entry *pkt_entry);
+				    struct rxr_pkt_entry *pkt_entry,
+				    enum rxr_lower_ep_type lower_ep_type);
 
 ssize_t rxr_pkt_wait_handshake(struct rxr_ep *ep, fi_addr_t addr, struct rdm_peer *peer);
 


### PR DESCRIPTION
This patch makes an endpoint to not use shm when a peer
is on same instance but chose to use EFA to communicate,
because the peer might not enable shm transfer.

Signed-off-by: Wei Zhang <wzam@amazon.com>