### PR TITLE
prov/util,tcp,rxm,rxd,netdir,sockets,hook: Fix Windows build warnings

### DIFF
--- a/include/ofi_coll.h
+++ b/include/ofi_coll.h
@@ -192,7 +192,7 @@ ssize_t ofi_ep_broadcast(struct fid_ep *ep, void *buf, size_t count, void *desc,
 			 fi_addr_t coll_addr, fi_addr_t root_addr,
 			 enum fi_datatype datatype, uint64_t flags, void *context);
 
-int ofi_coll_ep_progress(struct fid_ep *ep);
+ssize_t ofi_coll_ep_progress(struct fid_ep *ep);
 
 void ofi_coll_handle_xfer_comp(uint64_t tag, void *ctx);
 

--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -123,7 +123,7 @@ static inline int ofi_sendall_socket(SOCKET sock, const void *buf, size_t len)
 	return (size_t) sent != len;
 }
 
-int ofi_discard_socket(SOCKET sock, size_t len);
+ssize_t ofi_discard_socket(SOCKET sock, size_t len);
 
 /*
  * Byte queue - streaming socket staging buffer

--- a/include/ofi_osd.h
+++ b/include/ofi_osd.h
@@ -85,7 +85,7 @@ enum {
 	OFI_ENDIAN_LITTLE_WORD,	/* Middle-endian, PDP-11 style */
 };
 
-static inline int ofi_detect_endianness(void)
+static inline uint8_t ofi_detect_endianness(void)
 {
 	union {
 		uint8_t data[sizeof(uint32_t)];

--- a/include/windows/dirent.h
+++ b/include/windows/dirent.h
@@ -7,7 +7,7 @@ struct dirent {
 	char	d_name[256];
 };
 
-static inline int scandir(const char *dirp, struct dirent **namelist,
+static inline int scandir(const char *dirp, struct dirent ***namelist,
 	    int (*filter)(const struct dirent *),
 	    int (*compar)(const struct dirent **, const struct dirent **))
 {

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -1039,9 +1039,9 @@ ofi_cpuid(unsigned func, unsigned subfunc, unsigned cpuinfo[4])
 	__cpuidex((int *)cpuinfo, func, subfunc);
 }
 
-#define ofi_clwb(addr) do { _mm_clflush(addr); _mm_sfence(); } while (0)
-#define ofi_clflushopt(addr) do { _mm_clflush(addr); _mm_sfence(); } while (0)
-#define ofi_clflush(addr) _mm_clflush(addr)
+#define ofi_clwb(addr) do { _mm_clflush((void const *)addr); _mm_sfence(); } while (0)
+#define ofi_clflushopt(addr) do { _mm_clflush((void const *)addr); _mm_sfence(); } while (0)
+#define ofi_clflush(addr) _mm_clflush((void const *)addr)
 #define ofi_sfence() _mm_sfence()
 
 #else /* defined(_M_X64) || defined(_M_AMD64) */

--- a/prov/hook/src/hook_domain.c
+++ b/prov/hook/src/hook_domain.c
@@ -135,7 +135,7 @@ static void hook_add_credits(struct fid_ep *ep_fid, size_t credits)
 {
 	struct hook_ep *ep = container_of(ep_fid, struct hook_ep, ep);
 
-	return ep->domain->base_ops_flow_ctrl->add_credits(ep->hep, credits);
+	ep->domain->base_ops_flow_ctrl->add_credits(ep->hep, credits);
 }
 
 static bool hook_flow_ctrl_available(struct fid_ep *ep_fid)

--- a/prov/netdir/src/netdir_buf.h
+++ b/prov/netdir/src/netdir_buf.h
@@ -231,6 +231,7 @@ extern "C" {
 												\
 		LONG dec = InterlockedDecrement(&footer->used);					\
 		assert(dec >= 0);								\
+		OFI_UNUSED(dec); 								\
 	}											\
 												\
 	static inline void ofi_nd_buf_free_##name(type *data)					\

--- a/prov/netdir/src/netdir_cq.c
+++ b/prov/netdir/src/netdir_cq.c
@@ -198,6 +198,7 @@ int ofi_nd_cq_open(struct fid_domain *pdomain, struct fi_cq_attr *attr,
 	struct nd_domain *domain = container_of(pdomain, struct nd_domain, fid);
 	assert(domain->adapter);
 	assert(domain->adapter_file);
+	OFI_UNUSED(domain);
 
 	cq->iocp = CreateIoCompletionPort(INVALID_HANDLE_VALUE, NULL, 0, 0);
 	if (!cq->iocp || cq->iocp == INVALID_HANDLE_VALUE) {
@@ -660,7 +661,7 @@ void ofi_nd_unexp_2_read(nd_cq_entry *entry, void *unexpected)
 	size_t location_cnt = unexp->buf->header.location_cnt;
 	struct nd_msg_location *locations = unexp->buf->received_buf.locations;
 	struct nd_ep *ep = unexp->ep;
-	HRESULT hr;
+	HRESULT hr = 0;
 	size_t i;
 
 	ofi_nd_release_unexp_entry(unexp);

--- a/prov/netdir/src/netdir_ep.c
+++ b/prov/netdir/src/netdir_ep.c
@@ -267,10 +267,10 @@ static int ofi_nd_ep_control(struct fid *fid, int command, void *arg)
 		(IUnknown*)ep->domain->cq,
 		(IUnknown*)ep->domain->cq,
 		ep,
-		ep->info->rx_attr->size,
-		ep->info->tx_attr->size,
-		ep->info->rx_attr->iov_limit,
-		ep->info->tx_attr->iov_limit,
+		(ULONG) ep->info->rx_attr->size,
+		(ULONG) ep->info->tx_attr->size,
+		(ULONG) ep->info->rx_attr->iov_limit,
+		(ULONG) ep->info->tx_attr->iov_limit,
 		0, (void**)&ep->qp);
 	if (FAILED(hr))
 		return H2F(hr);
@@ -335,6 +335,7 @@ static void ofi_nd_ep_completed(nd_event_base *base, DWORD bytes)
 
 	nd_ep_completed *compl = container_of(base, nd_ep_completed, base);
 	assert(compl->connector);
+	OFI_UNUSED(compl);
 
 	base->free(base);
 }

--- a/prov/netdir/src/netdir_ep_rma.c
+++ b/prov/netdir/src/netdir_ep_rma.c
@@ -153,7 +153,7 @@ ofi_nd_ep_readmsg(struct fid_ep *pep, const struct fi_msg_rma *msg,
 		return -FI_EINVAL;
 
 	size_t msg_len = 0, rma_len = 0, i;
-	HRESULT hr;
+	HRESULT hr = 0;
 
 	struct nd_ep *ep = container_of(pep, struct nd_ep, fid);
 
@@ -321,7 +321,7 @@ ofi_nd_ep_writemsg(struct fid_ep *pep, const struct fi_msg_rma *msg,
 		return -FI_EINVAL;
 
 	size_t msg_len = 0, rma_len = 0, i;
-	HRESULT hr;
+	HRESULT hr = 0;
 
 	struct nd_cq_entry *entries[ND_MSG_IOV_LIMIT];
 	struct nd_ep *ep = container_of(pep, struct nd_ep, fid);

--- a/prov/netdir/src/netdir_mr.c
+++ b/prov/netdir/src/netdir_mr.c
@@ -328,6 +328,7 @@ static void ofi_nd_mr_ov_err(struct nd_event_base* base, DWORD bytes,
 
 	struct nd_mr *mr = container_of(ov->fid, struct nd_mr, fid.fid);
 	assert(mr->mr);
+	OFI_UNUSED(mr);
 
 	struct fi_eq_err_entry entry = {
 		.fid = ov->fid,

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -223,7 +223,7 @@ struct rxd_ep {
 /* ensure ep lock is held before this function is called */
 static inline struct rxd_peer *rxd_peer(struct rxd_ep *ep, fi_addr_t rxd_addr)
 {
-	return ofi_idm_lookup(&ep->peers_idm, rxd_addr);
+	return ofi_idm_lookup(&ep->peers_idm, (int) rxd_addr);
 
 }
 static inline struct rxd_domain *rxd_ep_domain(struct rxd_ep *ep)
@@ -429,12 +429,12 @@ int rxd_av_insert_dg_addr(struct rxd_av *av, const void *addr,
 			  void *context);
 
 /* Pkt resource functions */
-int rxd_ep_post_buf(struct rxd_ep *ep);
+ssize_t rxd_ep_post_buf(struct rxd_ep *ep);
 void rxd_ep_send_ack(struct rxd_ep *rxd_ep, fi_addr_t peer);
 struct rxd_pkt_entry *rxd_get_tx_pkt(struct rxd_ep *ep);
 struct rxd_x_entry *rxd_get_tx_entry(struct rxd_ep *ep, uint32_t op);
 struct rxd_x_entry *rxd_get_rx_entry(struct rxd_ep *ep, uint32_t op);
-int rxd_ep_send_pkt(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry);
+ssize_t rxd_ep_send_pkt(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry);
 ssize_t rxd_ep_post_data_pkts(struct rxd_ep *ep, struct rxd_x_entry *tx_entry);
 void rxd_insert_unacked(struct rxd_ep *ep, fi_addr_t peer,
 			struct rxd_pkt_entry *pkt_entry);
@@ -474,8 +474,8 @@ struct rxd_x_entry *rxd_rx_entry_init(struct rxd_ep *ep,
 			uint32_t op, uint32_t flags);
 void rxd_tx_entry_free(struct rxd_ep *ep, struct rxd_x_entry *tx_entry);
 void rxd_rx_entry_free(struct rxd_ep *ep, struct rxd_x_entry *rx_entry);
-int rxd_get_timeout(uint8_t retry_cnt);
-uint64_t rxd_get_retry_time(uint64_t start, uint8_t retry_cnt);
+int rxd_get_timeout(int retry_cnt);
+uint64_t rxd_get_retry_time(uint64_t start, int retry_cnt);
 
 /* Generic message functions */
 ssize_t rxd_ep_generic_recvmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,

--- a/prov/rxd/src/rxd_atomic.c
+++ b/prov/rxd/src/rxd_atomic.c
@@ -59,7 +59,7 @@ static struct rxd_x_entry *rxd_tx_entry_init_atomic(struct rxd_ep *ep, fi_addr_t
 		return NULL;
 
 	if (res_count) {
-		tx_entry->res_count = res_count;
+		tx_entry->res_count = (uint8_t) res_count;
 		memcpy(&tx_entry->res_iov[0], res_iov, sizeof(*res_iov) * res_count);
 	}
 
@@ -71,7 +71,7 @@ static struct rxd_x_entry *rxd_tx_entry_init_atomic(struct rxd_ep *ep, fi_addr_t
 		rxd_init_sar_hdr(&ptr, tx_entry, rma_count);
 	} else {
 		tx_entry->flags |= RXD_INLINE;
-		base_hdr->flags = tx_entry->flags;
+		base_hdr->flags = (uint16_t) tx_entry->flags;
 		tx_entry->num_segs = 1;
 	}
 
@@ -135,7 +135,7 @@ static ssize_t rxd_generic_atomic(struct rxd_ep *rxd_ep,
 		goto out;
 
 	rxd_addr = (intptr_t) ofi_idx_lookup(&(rxd_ep_av(rxd_ep)->fi_addr_idx),
-					     RXD_IDX_OFFSET(addr));
+					     RXD_IDX_OFFSET((int) addr));
 	if (!rxd_addr)
 		goto out;
 	ret = rxd_send_rts_if_needed(rxd_ep, rxd_addr);
@@ -227,7 +227,7 @@ static ssize_t rxd_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 
 	iov.iov_base = (void *) buf;
 	iov.iov_len = count * ofi_datatype_size(datatype);
-	assert(iov.iov_len <= rxd_ep_domain(rxd_ep)->max_inline_atom);
+	assert(iov.iov_len <= (size_t) rxd_ep_domain(rxd_ep)->max_inline_atom);
 
 	rma_iov.addr = addr;
 	rma_iov.len = count * ofi_datatype_size(datatype);
@@ -238,7 +238,7 @@ static ssize_t rxd_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
 	rxd_addr = (intptr_t) ofi_idx_lookup(&(rxd_ep_av(rxd_ep)->fi_addr_idx),
-					     RXD_IDX_OFFSET(addr));
+					     RXD_IDX_OFFSET((int) addr));
 	if (!rxd_addr)
 		goto out;
 

--- a/prov/rxd/src/rxd_av.c
+++ b/prov/rxd/src/rxd_av.c
@@ -45,7 +45,7 @@ static int rxd_tree_compare(struct ofi_rbmap *map, void *key, void *data)
 	memset(addr, 0, len);
 	av = container_of(map, struct rxd_av, rbmap);
 	dg_addr = (intptr_t)ofi_idx_lookup(&av->rxdaddr_dg_idx,
-					   (fi_addr_t) data);
+					   (int)(uintptr_t) data);
 
 	ret = fi_av_lookup(av->dg_av, dg_addr,addr, &len);
 	if (ret)
@@ -110,10 +110,10 @@ static fi_addr_t rxd_av_dg_addr(struct rxd_av *av, fi_addr_t fi_addr)
 {
 	fi_addr_t dg_addr;
 	fi_addr_t rxd_addr = (intptr_t) ofi_idx_lookup(&av->fi_addr_idx,
-					     RXD_IDX_OFFSET(fi_addr));
+					     RXD_IDX_OFFSET((int)fi_addr));
 	if (!rxd_addr)
 		goto err;
-	dg_addr = (intptr_t) ofi_idx_lookup(&av->rxdaddr_dg_idx, rxd_addr);
+	dg_addr = (intptr_t) ofi_idx_lookup(&av->rxdaddr_dg_idx, (int)rxd_addr);
 	if (!dg_addr)
 		goto err;
 
@@ -133,25 +133,26 @@ static int rxd_set_rxd_addr(struct rxd_av *av, fi_addr_t dg_addr, fi_addr_t *add
 
 }
 
-static fi_addr_t rxd_set_fi_addr(struct rxd_av *av, fi_addr_t rxd_addr)
+static int rxd_set_fi_addr(struct rxd_av *av, fi_addr_t rxd_addr)
 {
-	int fi_addr;
+	int idx;
 	fi_addr_t dg_addr;
-	fi_addr = ofi_idx_insert(&(av->fi_addr_idx), (void*)(uintptr_t)rxd_addr);
-	if (fi_addr < 0)
+
+	idx = ofi_idx_insert(&(av->fi_addr_idx), (void*)(uintptr_t)rxd_addr);
+	if (idx < 0)
 		goto nomem1;
 
-	if (ofi_idm_set(&(av->rxdaddr_fi_idm), rxd_addr,
-		        (void*)(uintptr_t) fi_addr) < 0)
+	if (ofi_idm_set(&(av->rxdaddr_fi_idm), (int)rxd_addr,
+		        (void*)(uintptr_t) idx) < 0)
 		goto nomem2;
 
-	return fi_addr;
+	return idx;
 
 nomem2:
-	ofi_idx_remove_ordered(&(av->fi_addr_idx), fi_addr);
+	ofi_idx_remove_ordered(&(av->fi_addr_idx), idx);
 nomem1:
 	dg_addr = (intptr_t) ofi_idx_remove_ordered(&(av->rxdaddr_dg_idx),
-						    rxd_addr);
+						    (int) rxd_addr);
 	fi_av_remove(av->dg_av, &dg_addr, 1, 0);
 
 	return -FI_ENOMEM;
@@ -178,7 +179,7 @@ int rxd_av_insert_dg_addr(struct rxd_av *av, const void *addr,
 			       NULL);
 	if (ret) {
 		assert(ret != -FI_EALREADY);
-		ofi_idx_remove_ordered(&(av->rxdaddr_dg_idx), *rxd_addr);
+		ofi_idx_remove_ordered(&(av->rxdaddr_dg_idx), (int)(*rxd_addr));
 		goto nomem;
 	}
 
@@ -227,9 +228,8 @@ static int rxd_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 				break;
 		}
 
-		util_addr = (intptr_t)ofi_idm_lookup(&av->rxdaddr_fi_idm,
-						     rxd_addr);
-
+		util_addr = (int)(intptr_t) ofi_idm_lookup(&av->rxdaddr_fi_idm,
+							   (int) rxd_addr);
 		if (!util_addr) {
 			util_addr = rxd_set_fi_addr(av, rxd_addr);
 			if (util_addr < 0) {
@@ -302,13 +302,13 @@ static int rxd_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr, size_t count
 	ofi_mutex_lock(&av->util_av.lock);
 	for (i = 0; i < count; i++) {
 		rxd_addr = (intptr_t)ofi_idx_lookup(&av->fi_addr_idx,
-						    RXD_IDX_OFFSET(fi_addr[i]));
+						    (int) RXD_IDX_OFFSET(fi_addr[i]));
 		if (!rxd_addr)
 			goto err;
 
 		ofi_idx_remove_ordered(&(av->fi_addr_idx),
-				       RXD_IDX_OFFSET(fi_addr[i]));
-		ofi_idm_clear(&(av->rxdaddr_fi_idm), rxd_addr);
+				       (int) RXD_IDX_OFFSET(fi_addr[i]));
+		ofi_idm_clear(&(av->rxdaddr_fi_idm), (int) rxd_addr);
 	}
 
 err:
@@ -367,7 +367,7 @@ static int rxd_av_close(struct fid *fid)
 	while ((node = ofi_rbmap_get_root(&av->rbmap))) {
 		rxd_addr = (fi_addr_t) node->data;
 		dg_addr = (intptr_t)ofi_idx_lookup(&av->rxdaddr_dg_idx,
-						   rxd_addr);
+						   (int) rxd_addr);
 
 		ret = fi_av_remove(av->dg_av, &dg_addr, 1, 0);
 		if (ret)
@@ -375,7 +375,7 @@ static int rxd_av_close(struct fid *fid)
 				"failed to remove dg addr: %d (%s)\n",
 				-ret, fi_strerror(-ret));
 
-		ofi_idx_remove_ordered(&(av->rxdaddr_dg_idx), rxd_addr);
+		ofi_idx_remove_ordered(&(av->rxdaddr_dg_idx), (int) rxd_addr);
 		ofi_rbmap_delete(&av->rbmap, node);
 	}
 	ofi_rbmap_cleanup(&av->rbmap);

--- a/prov/rxd/src/rxd_cntr.c
+++ b/prov/rxd/src/rxd_cntr.c
@@ -50,10 +50,10 @@ static int rxd_cntr_wait(struct fid_cntr *cntr_fid, uint64_t threshold, int time
 
 	do {
 		cntr->progress(cntr);
-		if (threshold <= ofi_atomic_get64(&cntr->cnt))
+		if (threshold <= (uint64_t) ofi_atomic_get64(&cntr->cnt))
 			return FI_SUCCESS;
 
-		if (errcnt != ofi_atomic_get64(&cntr->err))
+		if (errcnt != (uint64_t) ofi_atomic_get64(&cntr->err))
 			return -FI_EAVAIL;
 
 		if (ofi_adjust_timeout(endtime, &timeout))

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -134,7 +134,7 @@ out:
 static ssize_t rxd_ep_cancel(fid_t fid, void *context)
 {
 	struct rxd_ep *ep;
-	int ret;
+	ssize_t ret;
 
 	ep = container_of(fid, struct rxd_ep, util_ep.ep_fid);
 
@@ -206,7 +206,7 @@ struct rxd_x_entry *rxd_rx_entry_init(struct rxd_ep *ep,
 	rx_entry->bytes_done = 0;
 	rx_entry->offset = 0;
 	rx_entry->next_seg_no = 0;
-	rx_entry->iov_count = iov_count;
+	rx_entry->iov_count = (uint8_t) iov_count;
 	rx_entry->op = op;
 	rx_entry->ignore = ignore;
 
@@ -223,7 +223,7 @@ struct rxd_x_entry *rxd_rx_entry_init(struct rxd_ep *ep,
 	return rx_entry;
 }
 
-int rxd_ep_post_buf(struct rxd_ep *ep)
+ssize_t rxd_ep_post_buf(struct rxd_ep *ep)
 {
 	struct rxd_pkt_entry *pkt_entry;
 	ssize_t ret;
@@ -250,7 +250,7 @@ int rxd_ep_post_buf(struct rxd_ep *ep)
 static int rxd_ep_enable(struct rxd_ep *ep)
 {
 	size_t i;
-	ssize_t ret;
+	int ret;
 
 	ret = fi_ep_bind(ep->dg_ep, &ep->dg_cq->fid, FI_TRANSMIT | FI_RECV);
 	if (ret)
@@ -265,11 +265,9 @@ static int rxd_ep_enable(struct rxd_ep *ep)
 
 	ofi_mutex_lock(&ep->util_ep.lock);
 	for (i = 0; i < ep->rx_size; i++) {
-		ret = rxd_ep_post_buf(ep);
-		if (ret)
+		if (rxd_ep_post_buf(ep))
 			break;
 	}
-
 	ofi_mutex_unlock(&ep->util_ep.lock);
 	return 0;
 }
@@ -277,12 +275,12 @@ static int rxd_ep_enable(struct rxd_ep *ep)
 /*
  * Exponential back-off starting at 1ms, max 4s.
  */
-int rxd_get_timeout(uint8_t retry_cnt)
+int rxd_get_timeout(int retry_cnt)
 {
 	return MIN(1 << retry_cnt, 4000);
 }
 
-uint64_t rxd_get_retry_time(uint64_t start, uint8_t retry_cnt)
+uint64_t rxd_get_retry_time(uint64_t start, int retry_cnt)
 {
 	return start + rxd_get_timeout(retry_cnt);
 }
@@ -293,8 +291,8 @@ void rxd_init_data_pkt(struct rxd_ep *ep, struct rxd_x_entry *tx_entry,
 	struct rxd_data_pkt *data_pkt = (struct rxd_data_pkt *) (pkt_entry->pkt);
 	uint32_t seg_size;
 
-	seg_size = tx_entry->cq_entry.len - tx_entry->bytes_done;
-	seg_size = MIN(rxd_ep_domain(ep)->max_seg_sz, seg_size);
+	seg_size = (uint32_t) (tx_entry->cq_entry.len - tx_entry->bytes_done);
+	seg_size = (uint32_t) MIN(rxd_ep_domain(ep)->max_seg_sz, seg_size);
 
 	data_pkt->base_hdr.version = RXD_PROTOCOL_VERSION;
 	data_pkt->base_hdr.type = (tx_entry->cq_entry.flags &
@@ -305,7 +303,7 @@ void rxd_init_data_pkt(struct rxd_ep *ep, struct rxd_x_entry *tx_entry,
 	data_pkt->ext_hdr.rx_id = tx_entry->rx_id;
 	data_pkt->ext_hdr.tx_id = tx_entry->tx_id;
 	data_pkt->ext_hdr.seg_no = tx_entry->next_seg_no++;
-	data_pkt->base_hdr.peer = rxd_peer(ep, tx_entry->peer)->peer_addr;
+	data_pkt->base_hdr.peer = (uint32_t) rxd_peer(ep, tx_entry->peer)->peer_addr;
 
 	pkt_entry->pkt_size = ofi_copy_from_iov(data_pkt->msg, seg_size,
 						tx_entry->iov,
@@ -343,7 +341,7 @@ struct rxd_x_entry *rxd_tx_entry_init_common(struct rxd_ep *ep, fi_addr_t addr,
 	tx_entry->bytes_done = 0;
 	tx_entry->offset = 0;
 	tx_entry->next_seg_no = 0;
-	tx_entry->iov_count = iov_count;
+	tx_entry->iov_count = (uint8_t) iov_count;
 	memcpy(&tx_entry->iov[0], iov, sizeof(*iov) * iov_count);
 
 	tx_entry->cq_entry.op_context = context;
@@ -411,20 +409,20 @@ ssize_t rxd_ep_post_data_pkts(struct rxd_ep *ep, struct rxd_x_entry *tx_entry)
 	       rxd_peer(ep, tx_entry->peer)->tx_window;
 }
 
-int rxd_ep_send_pkt(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
+ssize_t rxd_ep_send_pkt(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
 {
-	int ret;
+	ssize_t ret;
 	fi_addr_t dg_addr;
 	pkt_entry->timestamp = ofi_gettime_ms();
 
 	dg_addr = (intptr_t) ofi_idx_lookup(&(rxd_ep_av(ep)->rxdaddr_dg_idx),
-					    pkt_entry->peer);
+					    (int)pkt_entry->peer);
 	ret = fi_send(ep->dg_ep, (const void *) rxd_pkt_start(pkt_entry),
 		      pkt_entry->pkt_size, pkt_entry->desc, dg_addr,
 		      &pkt_entry->context);
 	if (ret) {
 		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "error sending packet: %d (%s)\n",
-			ret, fi_strerror(-ret));
+			(int) ret, fi_strerror((int) -ret));
 		return ret;
 	}
 	pkt_entry->flags |= RXD_PKT_IN_USE;
@@ -487,10 +485,10 @@ void rxd_init_base_hdr(struct rxd_ep *rxd_ep, void **ptr,
 	struct rxd_base_hdr *hdr = (struct rxd_base_hdr *) *ptr;
 
 	hdr->version = RXD_PROTOCOL_VERSION;
-	hdr->type = tx_entry->op;
+	hdr->type = (uint8_t) tx_entry->op;
 	hdr->seq_no = 0;
-	hdr->peer = rxd_peer(rxd_ep, tx_entry->peer)->peer_addr;
-	hdr->flags = tx_entry->flags;
+	hdr->peer = (uint32_t) rxd_peer(rxd_ep, tx_entry->peer)->peer_addr;
+	hdr->flags = (uint16_t) tx_entry->flags;
 
 	*ptr = (char *) (*ptr) + sizeof(*hdr);
 }
@@ -503,7 +501,7 @@ void rxd_init_sar_hdr(void **ptr, struct rxd_x_entry *tx_entry,
 	hdr->size = tx_entry->cq_entry.len;
 	hdr->num_segs = tx_entry->num_segs;
 	hdr->tx_id = tx_entry->tx_id;
-	hdr->iov_count = iov_count;
+	hdr->iov_count = (uint8_t) iov_count;
 
 	*ptr = (char *) (*ptr) + sizeof(*hdr);
 }
@@ -576,7 +574,7 @@ void rxd_ep_send_ack(struct rxd_ep *rxd_ep, fi_addr_t peer)
 
 	ack->base_hdr.version = RXD_PROTOCOL_VERSION;
 	ack->base_hdr.type = RXD_ACK;
-	ack->base_hdr.peer = rxd_peer(rxd_ep, peer)->peer_addr;
+	ack->base_hdr.peer = (uint32_t) rxd_peer(rxd_ep, peer)->peer_addr;
 	ack->base_hdr.seq_no = rxd_peer(rxd_ep, peer)->rx_seq_no;
 	ack->ext_hdr.rx_id = rxd_peer(rxd_ep, peer)->rx_window;
 	rxd_peer(rxd_ep, peer)->last_tx_ack = ack->base_hdr.seq_no;
@@ -920,7 +918,8 @@ static void rxd_progress_pkt_list(struct rxd_ep *ep, struct rxd_peer *peer)
 {
 	struct rxd_pkt_entry *pkt_entry;
 	uint64_t current;
-	int ret, retry = 0;
+	ssize_t ret;
+	int retry = 0;
 
 	current = ofi_gettime_ms();
 	if (peer->retry_cnt > RXD_MAX_PKT_RETRY) {
@@ -931,7 +930,8 @@ static void rxd_progress_pkt_list(struct rxd_ep *ep, struct rxd_peer *peer)
 	dlist_foreach_container(&peer->unacked, struct rxd_pkt_entry,
 				pkt_entry, d_entry) {
 		if (pkt_entry->flags & (RXD_PKT_IN_USE | RXD_PKT_ACKED) ||
-		    current < rxd_get_retry_time(pkt_entry->timestamp, peer->retry_cnt))
+		    current < rxd_get_retry_time(pkt_entry->timestamp,
+						 (uint8_t) peer->retry_cnt))
 			break;
 		retry = 1;
 		ret = rxd_ep_send_pkt(ep, pkt_entry);
@@ -1037,9 +1037,9 @@ static void rxd_pkt_init_fn(struct ofi_bufpool_region *region, void *buf)
 	struct rxd_buf_pool *pool = (struct rxd_buf_pool *) region->pool->attr.context;
 
  	if (pool->type == RXD_BUF_POOL_TX)
-		entry->tx_id = ofi_buf_index(entry);
+		entry->tx_id = (uint16_t) ofi_buf_index(entry);
 	else
-		entry->rx_id = ofi_buf_index(entry);
+		entry->rx_id = (uint16_t) ofi_buf_index(entry);
 }
 
 static void rxd_buf_region_free_fn(struct ofi_bufpool_region *region)
@@ -1160,8 +1160,8 @@ int rxd_create_peer(struct rxd_ep *ep, uint64_t rxd_addr)
 	peer->rx_seq_no = 0;
 	peer->last_rx_ack = 0;
 	peer->last_tx_ack = 0;
-	peer->rx_window = rxd_env.max_unacked;
-	peer->tx_window = rxd_env.max_unacked;
+	peer->rx_window = (uint16_t) rxd_env.max_unacked;
+	peer->tx_window = (uint16_t) rxd_env.max_unacked;
 	peer->unacked_cnt = 0;
 	peer->retry_cnt = 0;
 	peer->active = 0;
@@ -1171,7 +1171,7 @@ int rxd_create_peer(struct rxd_ep *ep, uint64_t rxd_addr)
 	dlist_init(&(peer->rma_rx_list));
 	dlist_init(&(peer->buf_pkts));
 
-	if (ofi_idm_set(&(ep->peers_idm), rxd_addr, peer) < 0)
+	if (ofi_idm_set(&(ep->peers_idm), (int) rxd_addr, peer) < 0)
 		goto err;
 
 	return 0;

--- a/prov/rxd/src/rxd_init.c
+++ b/prov/rxd/src/rxd_init.c
@@ -76,10 +76,10 @@ void rxd_info_to_core_mr_modes(uint32_t version, const struct fi_info *hints,
 	}
 }
 
-int rxd_info_to_core(uint32_t version, const struct fi_info *rxd_info,
+int rxd_info_to_core(uint32_t version, const struct fi_info *rxd_info_in,
 		     const struct fi_info *base_info, struct fi_info *core_info)
 {
-	rxd_info_to_core_mr_modes(version, rxd_info, core_info);
+	rxd_info_to_core_mr_modes(version, rxd_info_in, core_info);
 	core_info->caps = FI_MSG;
 	core_info->mode = FI_LOCAL_MR | FI_CONTEXT | FI_MSG_PREFIX;
 	core_info->ep_attr->type = FI_EP_DGRAM;

--- a/prov/rxd/src/rxd_msg.c
+++ b/prov/rxd/src/rxd_msg.c
@@ -228,7 +228,7 @@ ssize_t rxd_ep_generic_recvmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 	if (rxd_ep->util_ep.caps & FI_DIRECTED_RECV &&
 	    addr != FI_ADDR_UNSPEC) {
 		rxd_addr = (intptr_t) ofi_idx_lookup(&(rxd_ep_av(rxd_ep)->fi_addr_idx),
-						     RXD_IDX_OFFSET(addr));
+						     RXD_IDX_OFFSET((int)addr));
 	}
 
 	if (flags & FI_PEEK) {
@@ -273,7 +273,7 @@ static ssize_t rxd_ep_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 	ep = container_of(ep_fid, struct rxd_ep, util_ep.ep_fid.fid);
 
 	return rxd_ep_generic_recvmsg(ep, msg->msg_iov, msg->iov_count,
-				      msg->addr, 0, ~0, msg->context, RXD_MSG,
+				      msg->addr, 0, ~0ULL, msg->context, RXD_MSG,
 				      rxd_rx_flags(flags | ep->util_ep.rx_msg_flags),
 				      flags);
 }
@@ -289,7 +289,7 @@ static ssize_t rxd_ep_recv(struct fid_ep *ep_fid, void *buf, size_t len, void *d
 	msg_iov.iov_base = buf;
 	msg_iov.iov_len = len;
 
-	return rxd_ep_generic_recvmsg(ep, &msg_iov, 1, src_addr, 0, ~0, context,
+	return rxd_ep_generic_recvmsg(ep, &msg_iov, 1, src_addr, 0, ~0ULL, context,
 				      RXD_MSG, ep->rx_flags, 0);
 }
 
@@ -301,7 +301,7 @@ static ssize_t rxd_ep_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void
 	ep = container_of(ep_fid, struct rxd_ep, util_ep.ep_fid.fid);
 
 	return rxd_ep_generic_recvmsg(ep, iov, count, src_addr,
-				      0, ~0, context, RXD_MSG, ep->rx_flags, 0);
+				      0, ~0ULL, context, RXD_MSG, ep->rx_flags, 0);
 }
 
 static struct rxd_x_entry *rxd_tx_entry_init_msg(struct rxd_ep *ep, fi_addr_t addr,
@@ -335,7 +335,7 @@ static struct rxd_x_entry *rxd_tx_entry_init_msg(struct rxd_ep *ep, fi_addr_t ad
 		rxd_init_sar_hdr(&ptr, tx_entry, 0);
 	} else {
 		tx_entry->flags |= RXD_INLINE;
-		base_hdr->flags = tx_entry->flags;
+		base_hdr->flags = (uint16_t) tx_entry->flags;
 		tx_entry->num_segs = 1;
 	}
 
@@ -359,7 +359,7 @@ ssize_t rxd_ep_generic_inject(struct rxd_ep *rxd_ep, const struct iovec *iov,
 
 	assert(iov_count <= RXD_IOV_LIMIT);
 	assert(ofi_total_iov_len(iov, iov_count) <=
-	       rxd_ep_domain(rxd_ep)->max_inline_msg);
+	       (size_t) rxd_ep_domain(rxd_ep)->max_inline_msg);
 
 	ofi_mutex_lock(&rxd_ep->util_ep.lock);
 
@@ -367,7 +367,7 @@ ssize_t rxd_ep_generic_inject(struct rxd_ep *rxd_ep, const struct iovec *iov,
 		goto out;
 
 	rxd_addr = (intptr_t) ofi_idx_lookup(&(rxd_ep_av(rxd_ep)->fi_addr_idx),
-					     RXD_IDX_OFFSET(addr));
+					     RXD_IDX_OFFSET((int) addr));
 	if (!rxd_addr)
 		goto out;
 
@@ -411,7 +411,7 @@ ssize_t rxd_ep_generic_sendmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 		goto out;
 
 	rxd_addr = (intptr_t) ofi_idx_lookup(&(rxd_ep_av(rxd_ep)->fi_addr_idx),
-					     RXD_IDX_OFFSET(addr));
+					     RXD_IDX_OFFSET((int) addr));
 	if (!rxd_addr)
 		goto out;
 

--- a/prov/rxd/src/rxd_rma.c
+++ b/prov/rxd/src/rxd_rma.c
@@ -69,7 +69,7 @@ static struct rxd_x_entry *rxd_tx_entry_init_rma(struct rxd_ep *ep, fi_addr_t ad
 			rxd_init_sar_hdr(&ptr, tx_entry, rma_count);
 		} else {
 			tx_entry->flags |= RXD_INLINE;
-			base_hdr->flags = tx_entry->flags;
+			base_hdr->flags = (uint16_t) tx_entry->flags;
 			tx_entry->num_segs = 1;
 		}
 		rxd_init_rma_hdr(&ptr, rma_iov, rma_count);
@@ -94,7 +94,7 @@ static ssize_t rxd_generic_write_inject(struct rxd_ep *rxd_ep,
 	ssize_t ret = -FI_EAGAIN;
 
 	assert(iov_count <= RXD_IOV_LIMIT && rma_count <= RXD_IOV_LIMIT);
-	assert(ofi_total_iov_len(iov, iov_count) <= rxd_ep_domain(rxd_ep)->max_inline_rma);
+	assert(ofi_total_iov_len(iov, iov_count) <= (size_t) rxd_ep_domain(rxd_ep)->max_inline_rma);
 
 	ofi_mutex_lock(&rxd_ep->util_ep.lock);
 
@@ -102,7 +102,7 @@ static ssize_t rxd_generic_write_inject(struct rxd_ep *rxd_ep,
 		goto out;
 
 	rxd_addr = (intptr_t) ofi_idx_lookup(&(rxd_ep_av(rxd_ep)->fi_addr_idx),
-					      RXD_IDX_OFFSET(addr));
+					      RXD_IDX_OFFSET((int) addr));
 	if (!rxd_addr)
 		goto out;
 	ret = rxd_send_rts_if_needed(rxd_ep, rxd_addr);
@@ -152,7 +152,7 @@ rxd_generic_rma(struct rxd_ep *rxd_ep, const struct iovec *iov,
 	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
 	rxd_addr = (intptr_t) ofi_idx_lookup(&(rxd_ep_av(rxd_ep)->fi_addr_idx),
-					     RXD_IDX_OFFSET(addr));
+					     RXD_IDX_OFFSET((int) addr));
 	if (!rxd_addr)
 		goto out;
 

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -688,7 +688,7 @@ struct rxm_ep {
 	struct fid_cq 		*msg_cq;
 	uint64_t		msg_cq_last_poll;
 	size_t 			comp_per_progress;
-	int			cq_eq_fairness;
+	size_t			cq_eq_fairness;
 	void			(*handle_comp_error)(struct rxm_ep *ep);
 	ssize_t			(*handle_comp)(struct rxm_ep *ep,
 					       struct fi_cq_tagged_entry *comp);
@@ -933,9 +933,9 @@ rxm_recv_entry_get(struct rxm_ep *rxm_ep, const struct iovec *iov,
 struct rxm_rx_buf *
 rxm_get_unexp_msg(struct rxm_recv_queue *recv_queue, fi_addr_t addr,
 		  uint64_t tag, uint64_t ignore);
-int rxm_handle_unexp_sar(struct rxm_recv_queue *recv_queue,
-			 struct rxm_recv_entry *recv_entry,
-			 struct rxm_rx_buf *rx_buf);
+ssize_t rxm_handle_unexp_sar(struct rxm_recv_queue *recv_queue,
+			     struct rxm_recv_entry *recv_entry,
+			     struct rxm_rx_buf *rx_buf);
 int rxm_post_recv(struct rxm_rx_buf *rx_buf);
 
 static inline void

--- a/prov/rxm/src/rxm_atomic.c
+++ b/prov/rxm/src/rxm_atomic.c
@@ -39,7 +39,7 @@
 static void
 rxm_ep_format_atomic_pkt_hdr(struct rxm_conn *rxm_conn,
 		 struct rxm_tx_buf *tx_buf, size_t data_len,
-		 uint32_t pkt_op, enum fi_datatype datatype,
+		 uint8_t pkt_op, enum fi_datatype datatype,
 		 uint8_t atomic_op, uint64_t flags, uint64_t data,
 		 const struct fi_rma_ioc *rma_ioc, size_t rma_ioc_count)
 {
@@ -52,18 +52,18 @@ rxm_ep_format_atomic_pkt_hdr(struct rxm_conn *rxm_conn,
 	tx_buf->pkt.hdr.op = pkt_op;
 	tx_buf->pkt.hdr.atomic.datatype = datatype;
 	tx_buf->pkt.hdr.atomic.op = atomic_op;
-	tx_buf->pkt.hdr.atomic.ioc_count = rma_ioc_count;
+	tx_buf->pkt.hdr.atomic.ioc_count = (uint8_t) rma_ioc_count;
 	if (rma_ioc_count)
 		memcpy(atomic_hdr->rma_ioc, rma_ioc,
 		       rma_ioc_count * sizeof(struct fi_rma_ioc));
 	tx_buf->flags = flags;
 }
 
-static inline int
+static inline ssize_t
 rxm_ep_send_atomic_req(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 		       struct rxm_tx_buf *tx_buf, uint64_t len)
 {
-	int ret;
+	ssize_t ret;
 
 	/* Atomic request TX completion processing is performed when the
 	 * software generated atomic response message is received. */
@@ -92,16 +92,16 @@ rxm_ep_atomic_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 		const struct fi_msg_atomic *msg, const struct fi_ioc *comparev,
 		void **compare_desc, size_t compare_iov_count,
 		struct fi_ioc *resultv, void **result_desc,
-		size_t result_iov_count, uint32_t op, uint64_t flags)
+		size_t result_iov_count, uint8_t op, uint64_t flags)
 {
 	struct rxm_tx_buf *tx_buf;
 	struct rxm_atomic_hdr *atomic_hdr;
 	struct iovec buf_iov[RXM_IOV_LIMIT];
 	struct iovec cmp_iov[RXM_IOV_LIMIT];
 	enum fi_hmem_iface buf_iface = FI_HMEM_SYSTEM;
-	enum fi_hmem_iface cmp_iface;
+	enum fi_hmem_iface cmp_iface = FI_HMEM_SYSTEM;
 	uint64_t buf_device = 0;
-	uint64_t cmp_device;
+	uint64_t cmp_device = 0;
 	size_t datatype_sz = ofi_datatype_size(msg->datatype);
 	size_t buf_len = 0;
 	size_t cmp_len = 0;
@@ -164,16 +164,16 @@ rxm_ep_atomic_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 
 	ret = ofi_copy_from_hmem_iov(atomic_hdr->data, buf_len, buf_iface,
 				     buf_device, buf_iov, msg->iov_count, 0);
-	assert(ret == buf_len);
+	assert((size_t) ret == buf_len);
 
 	if (cmp_len) {
 		ret = ofi_copy_from_hmem_iov(atomic_hdr->data + buf_len,
 					     cmp_len, cmp_iface, cmp_device,
 					     cmp_iov, compare_iov_count, 0);
-		assert(ret == cmp_len);
+		assert((size_t) ret == cmp_len);
 	}
 
-	tx_buf->atomic_result.count = result_iov_count;
+	tx_buf->atomic_result.count = (uint8_t) result_iov_count;
 	if (resultv) {
 		ofi_ioc_to_iov(resultv, tx_buf->atomic_result.iov,
 			       result_iov_count, datatype_sz);

--- a/prov/rxm/src/rxm_av.c
+++ b/prov/rxm/src/rxm_av.c
@@ -244,7 +244,7 @@ static int rxm_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 		return ret;
 	}
 
-	return av->util_av.eq ? 0 : count;
+	return av->util_av.eq ? 0 : (int) count;
 }
 
 static int rxm_av_insertsym(struct fid_av *av_fid, const char *node,
@@ -280,7 +280,7 @@ static int rxm_av_insertsym(struct fid_av *av_fid, const char *node,
 	}
 
 	free(addr);
-	return av->util_av.eq ? 0 : count;
+	return av->util_av.eq ? 0 : (int) count;
 }
 
 int rxm_av_insertsvc(struct fid_av *av, const char *node, const char *service,

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -729,7 +729,7 @@ rxm_ep_sar_handle_segment_failure(struct rxm_deferred_tx_entry *def_tx_entry,
 			      def_tx_entry->sar_seg.cur_seg_tx_buf);
 	rxm_cq_write_error(def_tx_entry->rxm_ep->util_ep.tx_cq,
 			   def_tx_entry->rxm_ep->util_ep.tx_cntr,
-			   def_tx_entry->sar_seg.app_context, ret);
+			   def_tx_entry->sar_seg.app_context, (int) ret);
 }
 
 /* Returns FI_SUCCESS if the SAR deferred TX queue is empty,
@@ -827,7 +827,7 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 				rxm_cq_write_error(def_tx_entry->rxm_ep->util_ep.rx_cq,
 						   def_tx_entry->rxm_ep->util_ep.rx_cntr,
 						   def_tx_entry->rndv_ack.rx_buf->
-						   recv_entry->context, ret);
+						   recv_entry->context, (int) ret);
 			}
 			if (def_tx_entry->rndv_ack.rx_buf->recv_entry->rndv
 				    .tx_buf->pkt.ctrl_hdr
@@ -851,7 +851,7 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 					return;
 				rxm_cq_write_error(def_tx_entry->rxm_ep->util_ep.tx_cq,
 						   def_tx_entry->rxm_ep->util_ep.tx_cntr,
-						   def_tx_entry->rndv_done.tx_buf, ret);
+						   def_tx_entry->rndv_done.tx_buf, (int) ret);
 			}
 			RXM_UPDATE_STATE(FI_LOG_EP_DATA,
 					 def_tx_entry->rndv_done.tx_buf,
@@ -872,7 +872,7 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 				rxm_cq_write_error(def_tx_entry->rxm_ep->util_ep.rx_cq,
 						   def_tx_entry->rxm_ep->util_ep.rx_cntr,
 						   def_tx_entry->rndv_read.rx_buf->
-							recv_entry->context, ret);
+							recv_entry->context, (int) ret);
 			}
 			break;
 		case RXM_DEFERRED_TX_RNDV_WRITE:
@@ -889,7 +889,7 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 					return;
 				rxm_cq_write_error(def_tx_entry->rxm_ep->util_ep.rx_cq,
 						   def_tx_entry->rxm_ep->util_ep.rx_cntr,
-						   def_tx_entry->rndv_write.tx_buf, ret);
+						   def_tx_entry->rndv_write.tx_buf, (int) ret);
 			}
 			break;
 		case RXM_DEFERRED_TX_SAR_SEG:
@@ -924,7 +924,7 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 						def_tx_entry->rxm_ep->util_ep.rx_cq,
 						def_tx_entry->rxm_ep->util_ep.rx_cntr,
 						def_tx_entry->rndv_read.rx_buf->
-							recv_entry->context, ret);
+							recv_entry->context, (int) ret);
 				}
 				return;
 			}
@@ -1490,7 +1490,7 @@ rxm_prepare_deferred_rndv_read(struct rxm_deferred_tx_entry **def_tx_entry,
 		(*def_tx_entry)->rndv_read.rxm_iov.iov[i] = iov[i];
 		(*def_tx_entry)->rndv_read.rxm_iov.desc[i] = desc[i];
 	}
-	(*def_tx_entry)->rndv_read.rxm_iov.count = count;
+	(*def_tx_entry)->rndv_read.rxm_iov.count = (uint8_t) count;
 
 	return 0;
 }
@@ -1520,7 +1520,7 @@ rxm_prepare_deferred_rndv_write(struct rxm_deferred_tx_entry **def_tx_entry,
 		(*def_tx_entry)->rndv_write.rxm_iov.iov[i] = iov[i];
 		(*def_tx_entry)->rndv_write.rxm_iov.desc[i] = desc[i];
 	}
-	(*def_tx_entry)->rndv_write.rxm_iov.count = count;
+	(*def_tx_entry)->rndv_write.rxm_iov.count = (uint8_t) count;
 
 	return 0;
 }

--- a/prov/rxm/src/rxm_msg.c
+++ b/prov/rxm/src/rxm_msg.c
@@ -41,9 +41,9 @@
 #include "rxm.h"
 
 
-int rxm_handle_unexp_sar(struct rxm_recv_queue *recv_queue,
-			 struct rxm_recv_entry *recv_entry,
-			 struct rxm_rx_buf *rx_buf)
+ssize_t rxm_handle_unexp_sar(struct rxm_recv_queue *recv_queue,
+			     struct rxm_recv_entry *recv_entry,
+			     struct rxm_rx_buf *rx_buf)
 {
 	struct rxm_recv_match_attr match_attr;
 	struct dlist_entry *entry;
@@ -85,7 +85,6 @@ int rxm_handle_unexp_sar(struct rxm_recv_queue *recv_queue,
 			break;
 	}
 	return ret;
-
 }
 
 /*
@@ -104,7 +103,7 @@ rxm_post_mrecv(struct rxm_ep *ep, const struct iovec *iov,
 	struct rxm_recv_entry *recv_entry;
 	struct rxm_rx_buf *rx_buf;
 	struct iovec cur_iov = *iov;
-	int ret;
+	ssize_t ret;
 
 	do {
 		recv_entry = rxm_recv_entry_get(ep, &cur_iov, desc, 1,
@@ -334,7 +333,7 @@ rxm_alloc_rndv_buf(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 		ret = ofi_copy_from_hmem_iov(rxm_pkt_rndv_data(&(*rndv_buf)->pkt),
 					     rxm_ep->buffered_min, iface,
 					     device, iov, count, 0);
-		assert(ret == rxm_ep->buffered_min);
+		assert((size_t) ret == rxm_ep->buffered_min);
 
 		len += rxm_ep->buffered_min;
 	}
@@ -410,8 +409,8 @@ rxm_init_segment(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	} else {
 		tx_buf->pkt.ctrl_hdr.msg_id = *msg_id;
 	}
-	tx_buf->pkt.ctrl_hdr.seg_size = seg_len;
-	tx_buf->pkt.ctrl_hdr.seg_no = seg_no;
+	tx_buf->pkt.ctrl_hdr.seg_size = (uint16_t) seg_len;
+	tx_buf->pkt.ctrl_hdr.seg_no = (uint32_t) seg_no;
 	tx_buf->app_context = app_context;
 	tx_buf->flags = flags;
 	rxm_sar_set_seg_type(&tx_buf->pkt.ctrl_hdr, seg_type);
@@ -449,7 +448,7 @@ rxm_send_segment(struct rxm_ep *rxm_ep,
 
 	ret = ofi_copy_from_hmem_iov(tx_buf->pkt.data, seg_len, iface, device,
 				     iov, count, *iov_offset);
-	assert(ret == seg_len);
+	assert((size_t) ret == seg_len);
 
 	*iov_offset += seg_len;
 
@@ -485,7 +484,7 @@ rxm_send_sar(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 
 	ret = ofi_copy_from_hmem_iov(first_tx_buf->pkt.data, rxm_buffer_size,
 				     iface, device, iov, count, iov_offset);
-	assert(ret == rxm_buffer_size);
+	assert((size_t) ret == rxm_buffer_size);
 
 	iov_offset += rxm_buffer_size;
 
@@ -766,7 +765,7 @@ rxm_send_eager(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 		ret = ofi_copy_from_hmem_iov(eager_buf->pkt.data,
 					     eager_buf->pkt.hdr.size,
 					     iface, device, iov, count, 0);
-		assert(ret == eager_buf->pkt.hdr.size);
+		assert((size_t) ret == eager_buf->pkt.hdr.size);
 
 		ret = fi_send(rxm_conn->msg_ep, &eager_buf->pkt, total_len,
 			      eager_buf->hdr.desc, 0, eager_buf);

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -52,7 +52,7 @@ rxm_ep_rma_reg_iov(struct rxm_ep *rxm_ep, const struct iovec *msg_iov,
 
 		for (i = 0; i < iov_count; i++)
 			desc_storage[i] = fi_mr_desc(rma_buf->rma.mr[i]);
-		rma_buf->rma.count = iov_count;
+		rma_buf->rma.count = (uint8_t) iov_count;
 	} else {
 		for (i = 0; i < iov_count; i++)
 			desc_storage[i] =
@@ -200,7 +200,7 @@ rxm_ep_format_rma_msg(struct rxm_tx_buf *rma_buf,
 	ret = ofi_copy_from_hmem_iov(rma_buf->pkt.data, rma_buf->pkt.hdr.size,
 				     iface, device, orig_msg->msg_iov,
 				     orig_msg->iov_count, 0);
-	assert(ret == rma_buf->pkt.hdr.size);
+	assert((size_t) ret == rma_buf->pkt.hdr.size);
 
 	rxm_iov->iov_base = &rma_buf->pkt.data;
 	rxm_iov->iov_len = rma_buf->pkt.hdr.size;

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -870,8 +870,8 @@ struct sock_pe {
 	ofi_epoll_t epoll_set;
 };
 
-typedef int (*sock_cq_report_fn) (struct sock_cq *cq, fi_addr_t addr,
-				  struct sock_pe_entry *pe_entry);
+typedef ssize_t (*sock_cq_report_fn) (struct sock_cq *cq, fi_addr_t addr,
+				      struct sock_pe_entry *pe_entry);
 
 struct sock_cq_overflow_entry_t {
 	size_t len;
@@ -1061,11 +1061,11 @@ void sock_cq_remove_rx_ctx(struct sock_cq *cq, struct sock_rx_ctx *rx_ctx);
 
 int sock_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 		struct fid_eq **eq, void *context);
-ssize_t sock_eq_report_event(struct sock_eq *sock_eq, uint32_t event,
-			     const void *buf, size_t len, uint64_t flags);
-ssize_t sock_eq_report_error(struct sock_eq *sock_eq, fid_t fid, void *context,
-			     uint64_t data, int err, int prov_errno,
-			     void *err_data, size_t err_data_size);
+int sock_eq_report_event(struct sock_eq *sock_eq, uint32_t event,
+			 const void *buf, size_t len, uint64_t flags);
+int sock_eq_report_error(struct sock_eq *sock_eq, fid_t fid, void *context,
+			 uint64_t data, int err, int prov_errno,
+			 void *err_data, size_t err_data_size);
 int sock_eq_openwait(struct sock_eq *eq, const char *service);
 
 int sock_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
@@ -1200,7 +1200,7 @@ ssize_t sock_ep_tx_atomic(struct fid_ep *ep,
 			  size_t compare_count, struct fi_ioc *resultv,
 			  void **result_desc, size_t result_count, uint64_t flags);
 
-int sock_queue_work(struct sock_domain *dom, struct fi_deferred_work *work);
+ssize_t sock_queue_work(struct sock_domain *dom, struct fi_deferred_work *work);
 ssize_t sock_queue_rma_op(struct fid_ep *ep, const struct fi_msg_rma *msg,
 			  uint64_t flags, enum fi_op_type op_type);
 ssize_t sock_queue_atomic_op(struct fid_ep *ep, const struct fi_msg_atomic *msg,

--- a/prov/sockets/src/sock_atomic.c
+++ b/prov/sockets/src/sock_atomic.c
@@ -148,17 +148,17 @@ ssize_t sock_ep_tx_atomic(struct fid_ep *ep,
 
 	memset(&tx_op, 0, sizeof(tx_op));
 	tx_op.op = SOCK_OP_ATOMIC;
-	tx_op.dest_iov_len = msg->rma_iov_count;
+	tx_op.dest_iov_len = (uint8_t) msg->rma_iov_count;
 	tx_op.atomic.op = msg->op;
 	tx_op.atomic.datatype = msg->datatype;
-	tx_op.atomic.res_iov_len = result_count;
-	tx_op.atomic.cmp_iov_len = compare_count;
+	tx_op.atomic.res_iov_len = (uint8_t) result_count;
+	tx_op.atomic.cmp_iov_len = (uint8_t) compare_count;
 
 	if (flags & FI_INJECT) {
-		tx_op.src_iov_len = src_len;
-		tx_op.atomic.cmp_iov_len = cmp_len;
+		tx_op.src_iov_len = (uint8_t) src_len;
+		tx_op.atomic.cmp_iov_len = (uint8_t) cmp_len;
 	} else {
-		tx_op.src_iov_len = msg->iov_count;
+		tx_op.src_iov_len = (uint8_t) msg->iov_count;
 	}
 
 	sock_tx_ctx_write_op_send(tx_ctx, &tx_op, flags,

--- a/prov/sockets/src/sock_comm.c
+++ b/prov/sockets/src/sock_comm.c
@@ -83,7 +83,7 @@ ssize_t sock_comm_flush(struct sock_pe_entry *pe_entry)
 	if (ret1 > 0)
 		pe_entry->comm_buf.rcnt += ret1;
 
-	if (ret1 == xfer_len && xfer_len < len) {
+	if ((size_t) ret1 == xfer_len && xfer_len < len) {
 		ret2 = sock_comm_send_socket(pe_entry->conn, (char*)pe_entry->comm_buf.buf +
 					     (pe_entry->comm_buf.rcnt & pe_entry->comm_buf.size_mask),
 					     len - xfer_len);
@@ -152,7 +152,7 @@ static ssize_t sock_comm_recv_socket(struct sock_conn *conn,
 
 static void sock_comm_recv_buffer(struct sock_pe_entry *pe_entry)
 {
-	int ret;
+	ssize_t ret;
 	size_t max_read, avail;
 
 	avail = ofi_rbavail(&pe_entry->comm_buf);
@@ -209,7 +209,7 @@ ssize_t sock_comm_peek(struct sock_conn *conn, void *buf, size_t len)
 ssize_t sock_comm_discard(struct sock_pe_entry *pe_entry, size_t len)
 {
 	void *buf;
-	int ret;
+	ssize_t ret;
 
 	buf = malloc(len);
 	if (!buf)

--- a/prov/sockets/src/sock_conn.c
+++ b/prov/sockets/src/sock_conn.c
@@ -275,7 +275,8 @@ static void sock_set_sockopt_reuseaddr(int sock)
 {
 	int optval;
 	optval = 1;
-	if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)))
+	if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR,
+		       (const void *) &optval, sizeof(optval)))
 		SOCK_LOG_ERROR("setsockopt reuseaddr failed\n");
 }
 
@@ -303,7 +304,8 @@ void sock_set_sockopts(int sock, int sock_opts)
 	sock_set_sockopt_reuseaddr(sock);
 	if (sock_opts & SOCK_OPTS_KEEPALIVE)
 		sock_set_sockopt_keepalive(sock);
-	if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, &optval, sizeof(optval)))
+	if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY,
+		       (const void *) &optval, sizeof(optval)))
 		SOCK_LOG_ERROR("setsockopt nodelay failed\n");
 
 	if (sock_opts & SOCK_OPTS_NONBLOCK)
@@ -460,7 +462,7 @@ int sock_conn_listen(struct sock_ep_attr *ep_attr)
 	if (ep_attr->ep_type == FI_EP_MSG)
 		ofi_addr_set_port(&addr.sa, 0);
 
-	ret = bind(listen_fd, &addr.sa, ofi_sizeofaddr(&addr.sa));
+	ret = bind(listen_fd, &addr.sa, (socklen_t) ofi_sizeofaddr(&addr.sa));
 	if (ret) {
 		SOCK_LOG_ERROR("failed to bind listener: %s\n",
 			       strerror(ofi_sockerr()));
@@ -564,7 +566,7 @@ do_connect:
 
 	ofi_straddr_dbg(&sock_prov, FI_LOG_EP_CTRL, "connecting to addr: ",
 			&addr.sa);
-	ret = connect(conn_fd, &addr.sa, ofi_sizeofaddr(&addr.sa));
+	ret = connect(conn_fd, &addr.sa, (socklen_t) ofi_sizeofaddr(&addr.sa));
 	if (ret < 0) {
 		if (OFI_SOCK_TRY_CONN_AGAIN(ofi_sockerr())) {
 			poll_fd.fd = conn_fd;
@@ -626,9 +628,9 @@ out:
 	}
 	new_conn->av_index = (ep_attr->ep_type == FI_EP_MSG) ?
 			     FI_ADDR_NOTAVAIL : index;
-	*conn = ofi_idm_lookup(&ep_attr->av_idm, index);
+	*conn = ofi_idm_lookup(&ep_attr->av_idm, (int) index);
 	if (*conn == SOCK_CM_CONN_IN_PROGRESS) {
-		if (ofi_idm_set(&ep_attr->av_idm, index, new_conn) < 0)
+		if (ofi_idm_set(&ep_attr->av_idm, (int) index, new_conn) < 0)
 			SOCK_LOG_ERROR("ofi_idm_set failed\n");
 		*conn = new_conn;
 	}

--- a/prov/sockets/src/sock_cq.c
+++ b/prov/sockets/src/sock_cq.c
@@ -212,8 +212,8 @@ out:
 	return ret;
 }
 
-static int sock_cq_report_context(struct sock_cq *cq, fi_addr_t addr,
-				  struct sock_pe_entry *pe_entry)
+static ssize_t sock_cq_report_context(struct sock_cq *cq, fi_addr_t addr,
+				      struct sock_pe_entry *pe_entry)
 {
 	struct fi_cq_entry cq_entry;
 	cq_entry.op_context = (void *) (uintptr_t) pe_entry->context;
@@ -229,8 +229,8 @@ static uint64_t sock_cq_sanitize_flags(uint64_t flags)
 				FI_REMOTE_CQ_DATA | FI_MULTI_RECV));
 }
 
-static int sock_cq_report_msg(struct sock_cq *cq, fi_addr_t addr,
-			      struct sock_pe_entry *pe_entry)
+static ssize_t sock_cq_report_msg(struct sock_cq *cq, fi_addr_t addr,
+			          struct sock_pe_entry *pe_entry)
 {
 	struct fi_cq_msg_entry cq_entry;
 	cq_entry.op_context = (void *) (uintptr_t) pe_entry->context;
@@ -239,8 +239,8 @@ static int sock_cq_report_msg(struct sock_cq *cq, fi_addr_t addr,
 	return _sock_cq_write(cq, addr, &cq_entry, sizeof(cq_entry));
 }
 
-static int sock_cq_report_data(struct sock_cq *cq, fi_addr_t addr,
-			       struct sock_pe_entry *pe_entry)
+static ssize_t sock_cq_report_data(struct sock_cq *cq, fi_addr_t addr,
+			           struct sock_pe_entry *pe_entry)
 {
 	struct fi_cq_data_entry cq_entry;
 	cq_entry.op_context = (void *) (uintptr_t) pe_entry->context;
@@ -251,8 +251,8 @@ static int sock_cq_report_data(struct sock_cq *cq, fi_addr_t addr,
 	return _sock_cq_write(cq, addr, &cq_entry, sizeof(cq_entry));
 }
 
-static int sock_cq_report_tagged(struct sock_cq *cq, fi_addr_t addr,
-				 struct sock_pe_entry *pe_entry)
+static ssize_t sock_cq_report_tagged(struct sock_cq *cq, fi_addr_t addr,
+				     struct sock_pe_entry *pe_entry)
 {
 	struct fi_cq_tagged_entry cq_entry;
 	cq_entry.op_context = (void *) (uintptr_t) pe_entry->context;
@@ -333,7 +333,7 @@ static inline ssize_t sock_cq_rbuf_read(struct sock_cq *cq, void *buf,
 static ssize_t sock_cq_sreadfrom(struct fid_cq *cq, void *buf, size_t count,
 			fi_addr_t *src_addr, const void *cond, int timeout)
 {
-	int ret = 0;
+	ssize_t ret = 0;
 	size_t threshold;
 	struct sock_cq *sock_cq;
 	uint64_t start_ms;

--- a/prov/sockets/src/sock_dom.c
+++ b/prov/sockets/src/sock_dom.c
@@ -90,7 +90,7 @@ static int sock_dom_ctrl(struct fid *fid, int command, void *arg)
 	dom = container_of(fid, struct sock_domain, dom_fid.fid);
 	switch (command) {
 	case FI_QUEUE_WORK:
-		return sock_queue_work(dom, arg);
+		return (int) sock_queue_work(dom, arg);
 	default:
 		return -FI_ENOSYS;
 	}

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1137,7 +1137,7 @@ static int sock_ep_tx_ctx(struct fid_ep *ep, int index, struct fi_tx_attr *attr,
 	if (!tx_ctx)
 		return -FI_ENOMEM;
 
-	tx_ctx->tx_id = index;
+	tx_ctx->tx_id = (uint16_t) index;
 	tx_ctx->ep_attr = sock_ep->attr;
 	tx_ctx->domain = sock_ep->attr->domain;
 	if (tx_ctx->rx_ctrl_ctx && tx_ctx->rx_ctrl_ctx->is_ctrl_ctx)
@@ -1183,7 +1183,7 @@ static int sock_ep_rx_ctx(struct fid_ep *ep, int index, struct fi_rx_attr *attr,
 	if (!rx_ctx)
 		return -FI_ENOMEM;
 
-	rx_ctx->rx_id = index;
+	rx_ctx->rx_id = (uint16_t) index;
 	rx_ctx->ep_attr = sock_ep->attr;
 	rx_ctx->domain = sock_ep->attr->domain;
 	rx_ctx->av = sock_ep->attr->av;
@@ -1332,8 +1332,9 @@ static char *sock_get_fabric_name(struct sockaddr *src_addr)
 			continue;
 
 		if (ofi_equals_ipaddr(ifa->ifa_addr, src_addr)) {
-			prefix_len = ofi_mask_addr(&net_in_addr.sa,
-					ifa->ifa_addr, ifa->ifa_netmask);
+			prefix_len = (int) ofi_mask_addr(&net_in_addr.sa,
+							 ifa->ifa_addr,
+							 ifa->ifa_netmask);
 
 			switch (net_in_addr.sa.sa_family) {
 			case AF_INET:
@@ -1805,7 +1806,7 @@ struct sock_conn *sock_ep_lookup_conn(struct sock_ep_attr *attr, fi_addr_t index
 
 	idx = (attr->ep_type == FI_EP_MSG) ? index : index & attr->av->mask;
 
-	conn = ofi_idm_lookup(&attr->av_idm, idx);
+	conn = ofi_idm_lookup(&attr->av_idm, (int) idx);
 	if (conn && conn != SOCK_CM_CONN_IN_PROGRESS) {
 		/* Verify that the existing connection is still usable, and
 		 * that the peer didn't restart.
@@ -1870,7 +1871,7 @@ int sock_ep_get_conn(struct sock_ep_attr *attr, struct sock_tx_ctx *tx_ctx,
 	conn = sock_ep_lookup_conn(attr, av_index, addr);
 	if (!conn) {
 		conn = SOCK_CM_CONN_IN_PROGRESS;
-		if (ofi_idm_set(&attr->av_idm, av_index, conn) < 0)
+		if (ofi_idm_set(&attr->av_idm, (int) av_index, conn) < 0)
 			SOCK_LOG_ERROR("ofi_idm_set failed\n");
 	}
 	ofi_mutex_unlock(&attr->cmap.lock);
@@ -1889,5 +1890,5 @@ int sock_ep_get_conn(struct sock_ep_attr *attr, struct sock_tx_ctx *tx_ctx,
 
 	*pconn = conn;
 	return conn->address_published ?
-	       0 : sock_conn_send_src_addr(attr, tx_ctx, conn);
+	       0 : (int) sock_conn_send_src_addr(attr, tx_ctx, conn);
 }

--- a/prov/sockets/src/sock_eq.c
+++ b/prov/sockets/src/sock_eq.c
@@ -68,7 +68,7 @@ static void sock_eq_clean_err_data_list(struct sock_eq *eq, int free_all)
 static ssize_t sock_eq_sread(struct fid_eq *eq, uint32_t *event, void *buf,
 				size_t len, int timeout, uint64_t flags)
 {
-	int ret;
+	ssize_t ret;
 	struct sock_eq *sock_eq;
 	struct dlist_entry *list;
 	struct sock_eq_entry *entry;
@@ -125,7 +125,7 @@ static ssize_t sock_eq_read(struct fid_eq *eq, uint32_t *event, void *buf,
 static ssize_t sock_eq_readerr(struct fid_eq *eq, struct fi_eq_err_entry *buf,
 			uint64_t flags)
 {
-	int ret;
+	ssize_t ret;
 	struct sock_eq *sock_eq;
 	struct dlist_entry *list;
 	struct sock_eq_entry *entry;
@@ -182,8 +182,8 @@ out:
 	return (ret == 0) ? -FI_EAGAIN : ret;
 }
 
-ssize_t sock_eq_report_event(struct sock_eq *sock_eq, uint32_t event,
-			     const void *buf, size_t len, uint64_t flags)
+int sock_eq_report_event(struct sock_eq *sock_eq, uint32_t event,
+			 const void *buf, size_t len, uint64_t flags)
 {
 	struct sock_eq_entry *entry;
 
@@ -204,9 +204,9 @@ ssize_t sock_eq_report_event(struct sock_eq *sock_eq, uint32_t event,
 	return 0;
 }
 
-ssize_t sock_eq_report_error(struct sock_eq *sock_eq, fid_t fid, void *context,
-			     uint64_t data, int err, int prov_errno,
-			     void *err_data, size_t err_data_size)
+int sock_eq_report_error(struct sock_eq *sock_eq, fid_t fid, void *context,
+			 uint64_t data, int err, int prov_errno,
+			 void *err_data, size_t err_data_size)
 {
 	struct fi_eq_err_entry *err_entry;
 	struct sock_eq_entry *entry;

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -289,7 +289,7 @@ int sock_get_src_addr(union ofi_sock_ip *dest_addr,
 	if (sock < 0)
 		return -ofi_sockerr();
 
-	len = ofi_sizeofaddr(&dest_addr->sa);
+	len = (socklen_t) ofi_sizeofaddr(&dest_addr->sa);
 	ret = connect(sock, &dest_addr->sa, len);
 	if (ret) {
 		SOCK_LOG_DBG("Failed to connect udp socket\n");

--- a/prov/sockets/src/sock_msg.c
+++ b/prov/sockets/src/sock_msg.c
@@ -60,7 +60,7 @@
 ssize_t sock_ep_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 			uint64_t flags)
 {
-	int ret;
+	ssize_t ret;
 	size_t i;
 	struct sock_rx_ctx *rx_ctx;
 	struct sock_rx_entry *rx_entry;
@@ -116,7 +116,7 @@ ssize_t sock_ep_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 		return -FI_ENOMEM;
 
 	rx_entry->rx_op.op = SOCK_OP_RECV;
-	rx_entry->rx_op.dest_iov_len = msg->iov_count;
+	rx_entry->rx_op.dest_iov_len = (uint8_t) msg->iov_count;
 
 	rx_entry->flags = flags;
 	rx_entry->context = (uintptr_t) msg->context;
@@ -178,7 +178,7 @@ static ssize_t sock_ep_recvv(struct fid_ep *ep, const struct iovec *iov,
 ssize_t sock_ep_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 			uint64_t flags)
 {
-	int ret;
+	ssize_t ret;
 	size_t i;
 	uint64_t total_len, op_flags;
 	struct sock_op tx_op;
@@ -245,9 +245,9 @@ ssize_t sock_ep_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 		if (total_len > SOCK_EP_MAX_INJECT_SZ)
 			return -FI_EINVAL;
 
-		tx_op.src_iov_len = total_len;
+		tx_op.src_iov_len = (uint8_t) total_len;
 	} else {
-		tx_op.src_iov_len = msg->iov_count;
+		tx_op.src_iov_len = (uint8_t) msg->iov_count;
 		total_len = msg->iov_count * sizeof(union sock_iov);
 	}
 
@@ -402,7 +402,7 @@ struct fi_ops_msg sock_ep_msg_ops = {
 ssize_t sock_ep_trecvmsg(struct fid_ep *ep,
 			 const struct fi_msg_tagged *msg, uint64_t flags)
 {
-	int ret;
+	ssize_t ret;
 	size_t i;
 	struct sock_rx_ctx *rx_ctx;
 	struct sock_rx_entry *rx_entry;
@@ -460,7 +460,7 @@ ssize_t sock_ep_trecvmsg(struct fid_ep *ep,
 		return -FI_ENOMEM;
 
 	rx_entry->rx_op.op = SOCK_OP_TRECV;
-	rx_entry->rx_op.dest_iov_len = msg->iov_count;
+	rx_entry->rx_op.dest_iov_len = (uint8_t) msg->iov_count;
 
 	rx_entry->flags = flags;
 	rx_entry->context = (uintptr_t) msg->context;
@@ -528,7 +528,7 @@ static ssize_t sock_ep_trecvv(struct fid_ep *ep, const struct iovec *iov,
 ssize_t sock_ep_tsendmsg(struct fid_ep *ep,
 			 const struct fi_msg_tagged *msg, uint64_t flags)
 {
-	int ret;
+	ssize_t ret;
 	size_t i;
 	uint64_t total_len, op_flags;
 	struct sock_op tx_op;
@@ -589,12 +589,12 @@ ssize_t sock_ep_tsendmsg(struct fid_ep *ep,
 		for (i = 0; i < msg->iov_count; i++)
 			total_len += msg->msg_iov[i].iov_len;
 
-		tx_op.src_iov_len = total_len;
+		tx_op.src_iov_len = (uint8_t) total_len;
 		if (total_len > SOCK_EP_MAX_INJECT_SZ)
 			return -FI_EINVAL;
 	} else {
 		total_len = msg->iov_count * sizeof(union sock_iov);
-		tx_op.src_iov_len = msg->iov_count;
+		tx_op.src_iov_len = (uint8_t) msg->iov_count;
 	}
 
 	total_len += sizeof(struct sock_op_tsend);

--- a/prov/sockets/src/sock_rma.c
+++ b/prov/sockets/src/sock_rma.c
@@ -62,7 +62,7 @@
 ssize_t sock_ep_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 			    uint64_t flags)
 {
-	int ret;
+	ssize_t ret;
 	size_t i;
 	struct sock_op tx_op;
 	union sock_iov tx_iov;
@@ -127,8 +127,8 @@ ssize_t sock_ep_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 
 	memset(&tx_op, 0, sizeof(struct sock_op));
 	tx_op.op = SOCK_OP_READ;
-	tx_op.src_iov_len = msg->rma_iov_count;
-	tx_op.dest_iov_len = msg->iov_count;
+	tx_op.src_iov_len = (uint8_t) msg->rma_iov_count;
+	tx_op.dest_iov_len = (uint8_t) msg->iov_count;
 
 	sock_tx_ctx_write_op_send(tx_ctx, &tx_op, flags,
 			(uintptr_t) msg->context, msg->addr,
@@ -222,7 +222,7 @@ static ssize_t sock_ep_rma_readv(struct fid_ep *ep, const struct iovec *iov,
 ssize_t sock_ep_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 			     uint64_t flags)
 {
-	int ret;
+	ssize_t ret;
 	size_t i;
 	struct sock_op tx_op;
 	union sock_iov tx_iov;
@@ -277,7 +277,7 @@ ssize_t sock_ep_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 
 	memset(&tx_op, 0, sizeof(struct sock_op));
 	tx_op.op = SOCK_OP_WRITE;
-	tx_op.dest_iov_len = msg->rma_iov_count;
+	tx_op.dest_iov_len = (uint8_t) msg->rma_iov_count;
 
 	total_len = 0;
 	if (flags & FI_INJECT) {
@@ -287,10 +287,10 @@ ssize_t sock_ep_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 		if (total_len > SOCK_EP_MAX_INJECT_SZ)
 			return -FI_EINVAL;
 
-		tx_op.src_iov_len = total_len;
+		tx_op.src_iov_len = (uint8_t) total_len;
 	} else {
 		total_len += msg->iov_count * sizeof(union sock_iov);
-		tx_op.src_iov_len = msg->iov_count;
+		tx_op.src_iov_len = (uint8_t) msg->iov_count;
 	}
 
 	total_len += (sizeof(struct sock_op_send) +

--- a/prov/sockets/src/sock_trigger.c
+++ b/prov/sockets/src/sock_trigger.c
@@ -263,7 +263,7 @@ ssize_t sock_queue_cntr_op(struct fi_deferred_work *work, uint64_t flags)
 	return 0;
 }
 
-int sock_queue_work(struct sock_domain *dom, struct fi_deferred_work *work)
+ssize_t sock_queue_work(struct sock_domain *dom, struct fi_deferred_work *work)
 {
 	struct sock_triggered_context *ctx;
 	uint64_t flags = SOCK_NO_COMPLETION | SOCK_TRIGGERED_OP | FI_TRIGGER;
@@ -295,12 +295,12 @@ int sock_queue_work(struct sock_domain *dom, struct fi_deferred_work *work)
 		if (work->op.tagged->msg.context != &work->context)
 			return -FI_EINVAL;
 		return sock_ep_trecvmsg(work->op.tagged->ep, &work->op.tagged->msg,
-					  work->op.tagged->flags | flags);
+					work->op.tagged->flags | flags);
 	case FI_OP_TSEND:
 		if (work->op.tagged->msg.context != &work->context)
 			return -FI_EINVAL;
 		return sock_ep_tsendmsg(work->op.tagged->ep, &work->op.tagged->msg,
-					  work->op.tagged->flags | flags);
+					work->op.tagged->flags | flags);
 	case FI_OP_READ:
 		if (work->op.rma->msg.context != &work->context)
 			return -FI_EINVAL;

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -223,7 +223,7 @@ struct tcpx_cur_rx {
 	size_t			hdr_done;
 	size_t			data_left;
 	struct tcpx_xfer_entry	*entry;
-	int			(*handler)(struct tcpx_ep *ep);
+	ssize_t			(*handler)(struct tcpx_ep *ep);
 };
 
 struct tcpx_cur_tx {

--- a/prov/tcp/src/tcpx_rma.c
+++ b/prov/tcp/src/tcpx_rma.c
@@ -61,7 +61,7 @@ static void tcpx_rma_read_send_entry_fill(struct tcpx_xfer_entry *send_entry,
 	rma_iov = (struct ofi_rma_iov *) ((uint8_t *) &send_entry->hdr + offset);
 
 	send_entry->hdr.base_hdr.op = ofi_op_read_req;
-	send_entry->hdr.base_hdr.rma_iov_cnt = msg->rma_iov_count;
+	send_entry->hdr.base_hdr.rma_iov_cnt = (uint8_t) msg->rma_iov_count;
 	memcpy(rma_iov, msg->rma_iov,
 	       msg->rma_iov_count * sizeof(msg->rma_iov[0]));
 
@@ -219,7 +219,7 @@ tcpx_rma_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 	rma_iov = (struct ofi_rma_iov *)((uint8_t *)&send_entry->hdr + offset);
 	memcpy(rma_iov, msg->rma_iov,
 	       msg->rma_iov_count * sizeof(msg->rma_iov[0]));
-	send_entry->hdr.base_hdr.rma_iov_cnt = msg->rma_iov_count;
+	send_entry->hdr.base_hdr.rma_iov_cnt = (uint8_t) msg->rma_iov_count;
 
 	offset += (send_entry->hdr.base_hdr.rma_iov_cnt * sizeof(*rma_iov));
 

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -94,7 +94,7 @@ char *ofi_strdup_append(const char *head, const char *tail)
 int ofi_exclude_prov_name(char **prov_name_list, const char *util_prov_name)
 {
 	char *exclude, *name, *temp;
-	int length;
+	size_t length;
 
 	length = strlen(util_prov_name) + 2;
 	exclude = malloc(length);
@@ -181,7 +181,8 @@ static int ofi_info_to_core(uint32_t version, const struct fi_provider *prov,
 {
 	int ret;
 
-	if (!(*core_hints = fi_allocinfo()))
+	*core_hints = fi_allocinfo();
+	if (!*core_hints)
 		return -FI_ENOMEM;
 
 	ret = info_to_core(version, util_hints, base_attr, *core_hints);
@@ -233,7 +234,8 @@ static int ofi_info_to_util(uint32_t version, const struct fi_provider *prov,
 			    ofi_map_info_t info_to_util,
 			    struct fi_info **util_info)
 {
-	if (!(*util_info = fi_allocinfo()))
+	*util_info = fi_allocinfo();
+	if (!*util_info)
 		return -FI_ENOMEM;
 
 	if (info_to_util(version, core_info, base_info, *util_info))
@@ -364,7 +366,8 @@ int ofi_get_core_info_fabric(const struct fi_provider *prov,
 		return -FI_ENODATA;
 
 	memset(&hints, 0, sizeof hints);
-	if (!(hints.fabric_attr = calloc(1, sizeof(*hints.fabric_attr))))
+	hints.fabric_attr = calloc(1, sizeof(*hints.fabric_attr));
+	if (!hints.fabric_attr)
 		return -FI_ENOMEM;
 
 	hints.fabric_attr->prov_name = strdup(util_attr->prov_name);
@@ -379,7 +382,7 @@ int ofi_get_core_info_fabric(const struct fi_provider *prov,
 
 	hints.fabric_attr->name = util_attr->name;
 	hints.fabric_attr->api_version = util_attr->api_version;
-	hints.mode = ~0;
+	hints.mode = ~0ULL;
 
 	ret = fi_getinfo(util_attr->api_version, NULL, NULL, OFI_CORE_PROV_ONLY,
 	                 &hints, core_info);
@@ -1002,7 +1005,8 @@ int ofi_prov_check_dup_info(const struct util_prov *util_prov,
 	    	if (ret)
 			continue;
 
-		if (!(fi = fi_dupinfo(prov_info))) {
+		fi = fi_dupinfo(prov_info);
+		if (!fi) {
 			ret = -FI_ENOMEM;
 			goto err;
 		}

--- a/prov/util/src/util_buf.c
+++ b/prov/util/src/util_buf.c
@@ -187,7 +187,7 @@ int ofi_bufpool_create_attr(struct ofi_bufpool_attr *attr,
 
 	pool->alloc_size = (pool->attr.chunk_cnt + 1) * pool->entry_size;
 	hp_size = ofi_get_hugepage_size();
-	if (hp_size <= 0 || pool->alloc_size < hp_size)
+	if (hp_size <= 0 || (ssize_t) pool->alloc_size < hp_size)
 		pool->attr.flags &= ~OFI_BUFPOOL_HUGEPAGES;
 
 	if (pool->attr.flags & OFI_BUFPOOL_HUGEPAGES) {

--- a/prov/util/src/util_cntr.c
+++ b/prov/util/src/util_cntr.c
@@ -153,10 +153,10 @@ static int ofi_cntr_wait(struct fid_cntr *cntr_fid, uint64_t threshold, int time
 
 	do {
 		cntr->progress(cntr);
-		if (threshold <= ofi_atomic_get64(&cntr->cnt))
+		if (threshold <= (uint64_t)ofi_atomic_get64(&cntr->cnt))
 			return FI_SUCCESS;
 
-		if (errcnt != ofi_atomic_get64(&cntr->err))
+		if (errcnt != (uint64_t)ofi_atomic_get64(&cntr->err))
 			return -FI_EAVAIL;
 
 		if (ofi_adjust_timeout(endtime, &timeout))

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -63,7 +63,8 @@ int ofi_cq_write_overflow(struct util_cq *cq, void *context, uint64_t flags,
 	FI_DBG(cq->domain->prov, FI_LOG_CQ, "writing to CQ overflow list\n");
 	assert(ofi_cirque_freecnt(cq->cirq) <= 1);
 
-	if (!(entry = calloc(1, sizeof(*entry))))
+	entry = calloc(1, sizeof(*entry));
+	if (!entry)
 		return -FI_ENOMEM;
 
 	entry->comp.op_context = context;
@@ -86,7 +87,8 @@ int ofi_cq_insert_error(struct util_cq *cq,
 
 	assert(ofi_genlock_held(&cq->cq_lock));
 	assert(err_entry->err);
-	if (!(entry = calloc(1, sizeof(*entry))))
+	entry = calloc(1, sizeof(*entry));
+	if (!entry)
 		return -FI_ENOMEM;
 
 	entry->comp = *err_entry;
@@ -350,7 +352,7 @@ ssize_t ofi_cq_sreadfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 {
 	struct util_cq *cq;
 	uint64_t endtime;
-	int ret;
+	ssize_t ret;
 
 	cq = container_of(cq_fid, struct util_cq, cq_fid);
 	assert(cq->wait && cq->internal_wait);

--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -742,7 +742,7 @@ static void ofi_import_monitor_unsubscribe(struct ofi_mem_monitor *notifier,
 					   union ofi_mr_hmem_info *hmem_info)
 {
 	assert(impmon.impfid);
-	return impmon.impfid->export_ops->unsubscribe(impmon.impfid, addr, len);
+	impmon.impfid->export_ops->unsubscribe(impmon.impfid, addr, len);
 }
 
 static bool ofi_import_monitor_valid(struct ofi_mem_monitor *notifier,

--- a/prov/util/src/util_wait.c
+++ b/prov/util/src/util_wait.c
@@ -782,7 +782,7 @@ static int ofi_wait_get_fd(struct util_wait_fd *wait_fd,
 		goto free;
 	}
 
-	fds->events = fid_entry->events;
+	fds->events = (short) fid_entry->events;
 	fid_entry->pollfds.fd = fds;
 	fid_entry->pollfds.nfds = 1;
 	return 0;

--- a/src/common.c
+++ b/src/common.c
@@ -599,7 +599,7 @@ static int ofi_str_to_sib(const char *str, void **addr, size_t *len)
 		return -FI_EINVAL;
 	}
 
-	pkey = strtol(tok, &endptr, 0);
+	pkey = (uint16_t) strtol(tok, &endptr, 0);
 	if (*endptr) {
 		FI_WARN(&core_prov, FI_LOG_CORE,
 			"Invalid pkey in address: %s\n", str);
@@ -613,7 +613,7 @@ static int ofi_str_to_sib(const char *str, void **addr, size_t *len)
 		return -FI_EINVAL;
 	}
 
-	ps = strtol(tok, &endptr, 0);
+	ps = (uint16_t) strtol(tok, &endptr, 0);
 	if (*endptr) {
 		FI_WARN(&core_prov, FI_LOG_CORE,
 			"Invalid port space in address: %s\n", str);
@@ -637,7 +637,7 @@ static int ofi_str_to_sib(const char *str, void **addr, size_t *len)
 	/* Port is optional */
 	tok = strtok_r(NULL, ":", &saveptr);
 	if (tok)
-		port = strtol(tok, &endptr, 0);
+		port = (uint16_t) strtol(tok, &endptr, 0);
 	else
 		port = 0;
 
@@ -1046,7 +1046,7 @@ void ofi_straddr_log_internal(const char *func, int line,
 	}
 }
 
-int ofi_discard_socket(SOCKET sock, size_t len)
+ssize_t ofi_discard_socket(SOCKET sock, size_t len)
 {
 	char buf;
 	ssize_t ret = 0;
@@ -1071,7 +1071,7 @@ size_t ofi_byteq_readv(struct ofi_byteq *byteq, struct iovec *iov,
 	len = ofi_copy_iov_buf(iov, cnt, offset, &byteq->data[byteq->head],
 			       avail, OFI_COPY_BUF_TO_IOV);
 	if (len < avail) {
-		byteq->head += len;
+		byteq->head += (unsigned) len;
 	} else {
 		byteq->head = 0;
 		byteq->tail = 0;
@@ -1094,7 +1094,7 @@ void ofi_byteq_writev(struct ofi_byteq *byteq, const struct iovec *iov,
 	for (i = 0; i < cnt; i++) {
 		memcpy(&byteq->data[byteq->tail], iov[i].iov_base,
 		       iov[i].iov_len);
-		byteq->tail += iov[i].iov_len;
+		byteq->tail += (unsigned) iov[i].iov_len;
 	}
 }
 
@@ -1429,7 +1429,7 @@ void ofi_pollfds_heatfd(struct ofi_pollfds *pfds, int index)
 {
 	struct pollfd *new_fds;
 	struct ofi_pollfds_ctx *ctx;
-	size_t size;
+	int size;
 
 	assert(ofi_poll_fairness);
 	ctx = &pfds->ctx[index];

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -174,7 +174,8 @@ static int ofi_find_name(char **names, const char *name)
 /* matches if names[i] == "xxx;yyy" and name == "xxx" */
 static int ofi_find_layered_name(char **names, const char *name)
 {
-	int i, len;
+	int i;	
+	size_t len;
 
 	len = strlen(name);
 	for (i = 0; names[i]; i++) {
@@ -187,7 +188,8 @@ static int ofi_find_layered_name(char **names, const char *name)
 /* matches if names[i] == "xxx" and name == "xxx;yyy" */
 static int ofi_find_core_name(char **names, const char *name)
 {
-	int i, len;
+	int i;
+	size_t len;
 
 	for (i = 0; names[i]; i++) {
 		len = strlen(names[i]);
@@ -1021,7 +1023,7 @@ static int ofi_layering_ok(const struct fi_provider *provider,
 {
 	char *prov_name;
 	struct ofi_prov *core_ofi_prov;
-	int i;
+	ssize_t i;
 
 	/* Excluded providers must be at the end */
 	for (i = count - 1; i >= 0; i--) {

--- a/src/mem.c
+++ b/src/mem.c
@@ -87,7 +87,7 @@ void ofi_mem_init(void)
 	while (n-- > 0) {
 		if (sscanf(pglist[n]->d_name, "hugepages-%zukB", &hpsize) == 1) {
 			hpsize *= 1024;
-			if (hpsize != page_sizes[OFI_DEF_HUGEPAGE_SIZE])
+			if ((size_t) hpsize != page_sizes[OFI_DEF_HUGEPAGE_SIZE])
 				page_sizes[num_page_sizes++] = hpsize;
 		}
 		free(pglist[n]);

--- a/src/shared/ofi_str.c
+++ b/src/shared/ofi_str.c
@@ -35,6 +35,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <assert.h>
+#include <ctype.h>
 
 #include <rdma/fi_errno.h>
 
@@ -74,11 +75,11 @@ char *strcasestr(const char *haystack, const char *needle)
 		goto out;
 
 	for (i = 0; i < strlen(needle); i++)
-		uneedle[i] = toupper(needle[i]);
+		uneedle[i] = (char) toupper(needle[i]);
 	uneedle[i] = '\0';
 
 	for (i = 0; i < strlen(haystack); i++)
-		uhaystack[i] = toupper(haystack[i]);
+		uhaystack[i] = (char) toupper(haystack[i]);
 	uhaystack[i] = '\0';
 
 	pos = strstr(uhaystack, uneedle);

--- a/src/windows/osd.c
+++ b/src/windows/osd.c
@@ -506,8 +506,8 @@ void freeifaddrs(struct ifaddrs *ifa)
 static ssize_t
 ofi_sendv_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt, int flags)
 {
-	ssize_t size = 0;
-	int ret, i;
+	ssize_t size = 0, ret;
+	int i;
 
 	if (iov_cnt == 1) {
 		return ofi_send_socket(fd, iovec[0].iov_base,
@@ -519,7 +519,7 @@ ofi_sendv_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt, int flags
 				      iovec[i].iov_len, flags);
 		if (ret >= 0) {
 			size += ret;
-			if (ret != iovec[i].iov_len)
+			if ((size_t) ret != iovec[i].iov_len)
 				return size;
 		} else {
 			return size ? size : ret;
@@ -531,8 +531,8 @@ ofi_sendv_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt, int flags
 static ssize_t
 ofi_recvv_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt, int flags)
 {
-	ssize_t size = 0;
-	int ret, i;
+	ssize_t size = 0, ret;
+	int i;
 
 	if (iov_cnt == 1) {
 		return ofi_recv_socket(fd, iovec[0].iov_base,
@@ -544,7 +544,7 @@ ofi_recvv_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt, int flags
 				      iovec[i].iov_len, flags);
 		if (ret >= 0) {
 			size += ret;
-			if (ret != iovec[i].iov_len)
+			if ((size_t) ret != iovec[i].iov_len)
 				return size;
 		} else {
 			return size ? size : ret;
@@ -597,7 +597,7 @@ ssize_t ofi_recvmsg_udp(SOCKET fd, struct msghdr *msg, int flags)
 			return ret;
 	}
 
-	ret = WSARecvMsg(fd, msg, &bytes, NULL, NULL);
+	ret = WSARecvMsg(fd, (LPWSAMSG) msg, &bytes, NULL, NULL);
 	return ret ? ret : bytes;
 }
 
@@ -611,7 +611,7 @@ void ofi_pollfds_do_add(struct ofi_pollfds *pfds,
 	}
 
 	pfds->fds[pfds->nfds].fd = item->fd;
-	pfds->fds[pfds->nfds].events = item->events;
+	pfds->fds[pfds->nfds].events = (SHORT) item->events;
 	pfds->fds[pfds->nfds].revents = 0;
 	pfds->ctx[pfds->nfds].context = item->context;
 	pfds->nfds++;
@@ -625,7 +625,7 @@ int ofi_pollfds_do_mod(struct ofi_pollfds *pfds, int fd, uint32_t events,
 	/* 0 is signaling fd */
 	for (i = 1; i < pfds->nfds; i++) {
 		if (pfds->fds[i].fd == fd) {
-			pfds->fds[i].events = events;
+			pfds->fds[i].events = (SHORT) events;
 			pfds->ctx[i].context = context;
 			return FI_SUCCESS;
 		}

--- a/util/pingpong.c
+++ b/util/pingpong.c
@@ -310,7 +310,7 @@ static int pp_getaddrinfo(char *name, uint16_t port, struct addrinfo **results)
 
 	ret = getaddrinfo(name, port_s, &hints, results);
 	if (ret != 0) {
-		err_msg = gai_strerror(ret);
+		err_msg = (const char *) gai_strerror(ret);
 		PP_ERR("getaddrinfo : %s", err_msg);
 		ret = -EXIT_FAILURE;
 		goto out;
@@ -390,7 +390,7 @@ static int pp_ctrl_init_client(struct ct_pingpong *ct)
 
 		pp_print_addrinfo(rp, "CLIENT: connecting to");
 
-		ret = connect(ct->ctrl_connfd, rp->ai_addr, rp->ai_addrlen);
+		ret = connect(ct->ctrl_connfd, rp->ai_addr, (socklen_t) rp->ai_addrlen);
 		if (ret != -1)
 			break;
 
@@ -606,7 +606,7 @@ static int pp_send_name(struct ct_pingpong *ct, struct fid *endpoint)
 	}
 
 	PP_DEBUG("Sending name length\n");
-	len = htonl(addrlen);
+	len = htonl((uint32_t) addrlen);
 	ret = pp_ctrl_send(ct, (char *) &len, sizeof(len));
 	if (ret < 0)
 		goto fn;
@@ -920,10 +920,10 @@ static int pp_check_buf(void *buf, int size)
 static void eq_readerr(struct fid_eq *eq)
 {
 	struct fi_eq_err_entry eq_err = { 0 };
-	int rd;
+	ssize_t rd;
 
 	rd = fi_eq_readerr(eq, &eq_err, 0);
-	if (rd != sizeof(eq_err)) {
+	if ((size_t) rd != sizeof(eq_err)) {
 		PP_PRINTERR("fi_eq_readerr", rd);
 	} else {
 		PP_ERR("eq_readerr: %s",
@@ -1194,7 +1194,7 @@ static int pp_get_tx_comp(struct ct_pingpong *ct, uint64_t total)
 		int ret, rc;                                                   \
 									       \
 		while (1) {                                                    \
-			ret = post_fn(__VA_ARGS__);                            \
+			ret = (int) post_fn(__VA_ARGS__);                      \
 			if (!ret)                                              \
 				break;                                         \
 									       \
@@ -1234,7 +1234,7 @@ static ssize_t pp_tx(struct ct_pingpong *ct, struct fid_ep *ep, size_t size)
 	ssize_t ret;
 
 	if (pp_check_opts(ct, PP_OPT_VERIFY_DATA | PP_OPT_ACTIVE))
-		pp_fill_buf((char *)ct->tx_buf + ct->tx_prefix_size, size);
+		pp_fill_buf((char *)ct->tx_buf + ct->tx_prefix_size, (int)size);
 
 	ret = pp_post_tx(ct, ep, size + ct->tx_prefix_size, ct->tx_ctx_ptr);
 	if (ret)
@@ -1263,7 +1263,7 @@ static ssize_t pp_inject(struct ct_pingpong *ct, struct fid_ep *ep, size_t size)
 	ssize_t ret;
 
 	if (pp_check_opts(ct, PP_OPT_VERIFY_DATA | PP_OPT_ACTIVE))
-		pp_fill_buf((char *)ct->tx_buf + ct->tx_prefix_size, size);
+		pp_fill_buf((char *)ct->tx_buf + ct->tx_prefix_size, (int)size);
 
 	ret = pp_post_inject(ct, ep, size + ct->tx_prefix_size);
 	if (ret)
@@ -1294,7 +1294,7 @@ static ssize_t pp_rx(struct ct_pingpong *ct, struct fid_ep *ep, size_t size)
 
 	if (pp_check_opts(ct, PP_OPT_VERIFY_DATA | PP_OPT_ACTIVE)) {
 		ret = pp_check_buf((char *)ct->rx_buf + ct->rx_prefix_size,
-				   size);
+				   (int)size);
 		if (ret)
 			return ret;
 	}
@@ -2074,12 +2074,12 @@ static void pp_parse_opts(struct ct_pingpong *ct, int op, char *optarg)
 
 	/* Source Port */
 	case 'B':
-		ct->opts.src_port = parse_ulong(optarg, UINT16_MAX);
+		ct->opts.src_port = (uint16_t) parse_ulong(optarg, UINT16_MAX);
 		break;
 
 	/* Destination Port */
 	case 'P':
-		ct->opts.dst_port = parse_ulong(optarg, UINT16_MAX);
+		ct->opts.dst_port = (uint16_t) parse_ulong(optarg, UINT16_MAX);
 		break;
 
 	case 'm':


### PR DESCRIPTION
A previous patch (commit 0264b9daa153) eliminated a great amount of
warnings caused by headers. However, there are still many warnings
caused by source code of individual providers. That's what this patch
tries to address.

Fix 400+ warnings scattered across 50+ files. Most of the warnings are
either implicit type conversion from larger type size to smaller type
size or comparison between signed & unsigned values.

There are still a few types of warnings being left unhandled:

(1) assignment in condition in 'while ((a = func()) { ... }' structure.
    don't see a good replacement for that. similar complains for 'if'
    statements have been fixed.

(2) windows socket fd type 'SOCKET' is different from 'int'. That requires
    more work to get it right.

(3) structure padding due to alignment specifier.

(4) using enum for bit field base type is non-standard extension.

(5) implicit type conversion from 'int' to 'float' in the atomic macros,
    which are quite complicated to decode.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>