### PR TITLE
prov/shm: fix 0 byte SAR read

### DIFF
--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -437,8 +437,10 @@ static struct smr_sar_entry *smr_progress_sar(struct smr_cmd *cmd,
 		smr_try_progress_from_sar(peer_smr, sar_msg, resp, cmd, iface, device,
 					  sar_iov, iov_count, total_len, &next);
 
-	if (*total_len == cmd->msg.hdr.size)
+	if (*total_len == cmd->msg.hdr.size) {
+		resp->status = FI_SUCCESS;
 		return NULL;
+	}
 
 	sar_entry = ofi_freestack_pop(ep->sar_fs);
 


### PR DESCRIPTION
If a 0 byte SAR read is issued, the resp->status will
never be updated since it only gets updated in the
copy_to/from_sar path (which will never be taken if there
is no data to copy). To fix this, update the resp->status
when first progressing the SAR message if the message is
complete.

Signed-off-by: aingerson <alexia.ingerson@intel.com>

Fixes #7508 