### PR TITLE
prov/shm: Avoid uninitialized variable with invalid atomic parameters

### DIFF
--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -96,6 +96,10 @@ static void smr_format_inject_atomic(struct smr_cmd *cmd,
 
 	switch (cmd->msg.hdr.op) {
 	case ofi_op_atomic:
+		cmd->msg.hdr.size = ofi_copy_from_hmem_iov(tx_buf->data,
+					SMR_INJECT_SIZE, iface, device,
+					iov, count, 0);
+		break;
 	case ofi_op_atomic_fetch:
 		if (cmd->msg.hdr.atomic_op == FI_ATOMIC_READ)
 			cmd->msg.hdr.size = ofi_total_iov_len(resultv, result_count);


### PR DESCRIPTION
Reported by Coverity.  Given invalid combination of
ofi_op_atomic and FI_ATOMIC_READ, it is possible to reach
code that uses uninitialzed result_iov->iov_len.  Separate
code for ofi_ofi_op_atomic case to avoid the issue.

Signed-off-by: Chien Tin Tung <chien.tin.tung@intel.com>