### PR TITLE
fabtests: Add sockets.exclude to Makefile.am

### DIFF
--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -81,6 +81,7 @@ nobase_dist_config_DATA = \
         test_configs/sockets/quick.test \
 	test_configs/sockets/complete.test \
 	test_configs/sockets/verify.test \
+	test_configs/sockets/sockets.exclude \
         test_configs/udp/all.test \
         test_configs/udp/lat_bw.test \
         test_configs/udp/quick.test \


### PR DESCRIPTION
Add sockets.exclude to Makefile.am. It is missing in the install location

Signed-off-by: Zach Dworkin <zachary.dworkin@intel.com>