### PR TITLE
fabtests/pytest/efa: Increase timeout limit for cuda tests

### DIFF
--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -4,11 +4,18 @@ from default.test_rdm import test_rdm_bw_functional
 
 def run_rdm_test(cmdline_args, executable, iteration_type, completion_type, memory_type, message_size):
     from common import ClientServerTest
+    # It is observed that cuda tests requires larger time-out limit (~240 secs) to test all
+    # message sizes for libfabric's debug and mem-poisoning builds, on p4d instances.
+    timeout = None
+    if "cuda" in memory_type and message_size == "all":
+        timeout = 240
+
     test = ClientServerTest(cmdline_args, executable, iteration_type,
                             completion_type=completion_type,
                             datacheck_type="with_datacheck",
                             message_size=message_size,
-                            memory_type=memory_type)
+                            memory_type=memory_type,
+                            timeout=timeout)
     test.run()
 
 @pytest.mark.parametrize("iteration_type",


### PR DESCRIPTION
It is observed that cuda tests requires larger time-out limit (~240 secs)
to test all message sizes for libfabric's debug and mem-poisoning builds, on p4d instances.

Test info: run `runfabtests.py` on 2 c5n and 2 p4n
Signed-off-by: Shi Jin <sjina@amazon.com>