### PR TITLE
prov/efa: multi_recv test case and bug fix

### DIFF
--- a/fabtests/pytest/efa/test_multi_recv.py
+++ b/fabtests/pytest/efa/test_multi_recv.py
@@ -3,7 +3,11 @@ import pytest
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_multi_recv(cmdline_args, iteration_type):
+@pytest.mark.parametrize("message_size", ["1024", "8192"])
+def test_multi_recv(cmdline_args, iteration_type, message_size):
     from common import ClientServerTest
-    test = ClientServerTest(cmdline_args, "fi_multi_recv -e rdm", iteration_type)
+    test = ClientServerTest(cmdline_args,
+            "fi_multi_recv -e rdm",
+            iteration_type,
+            message_size=message_size)
     test.run()

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -962,8 +962,9 @@ void rxr_cq_queue_rnr_pkt(struct rxr_ep *ep,
 void rxr_cq_write_rx_completion(struct rxr_ep *ep,
 				struct rxr_rx_entry *rx_entry);
 
-void rxr_cq_handle_rx_completion(struct rxr_ep *ep,
-				 struct rxr_rx_entry *rx_entry);
+void rxr_cq_complete_rx(struct rxr_ep *ep,
+			struct rxr_rx_entry *rx_entry,
+			bool post_ctrl, int ctrl_type);
 
 void rxr_cq_write_tx_completion(struct rxr_ep *ep,
 				struct rxr_tx_entry *tx_entry);

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -472,7 +472,11 @@ void rxr_pkt_handle_rma_read_completion(struct rxr_ep *ep,
 		} else if (read_entry->context_type == RXR_READ_CONTEXT_RX_ENTRY) {
 			rx_entry = read_entry->context;
 			if (rx_entry->op == ofi_op_msg || rx_entry->op == ofi_op_tagged) {
+				if (rx_entry->fi_flags & FI_MULTI_RECV)
+					rxr_msg_multi_recv_handle_completion(ep, rx_entry);
+
 				rxr_cq_write_rx_completion(ep, rx_entry);
+				rxr_msg_multi_recv_free_posted_entry(ep, rx_entry);
 			} else {
 				assert(rx_entry->op == ofi_op_write);
 				if (rx_entry->cq_entry.flags & FI_REMOTE_CQ_DATA)

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -451,9 +451,7 @@ void rxr_pkt_handle_rma_read_completion(struct rxr_ep *ep,
 	struct rxr_pkt_entry *pkt_entry;
 	struct rxr_read_entry *read_entry;
 	struct rxr_rma_context_pkt *rma_context_pkt;
-	int inject;
 	size_t data_size;
-	ssize_t ret;
 
 	rma_context_pkt = (struct rxr_rma_context_pkt *)context_pkt_entry->pkt;
 	assert(rma_context_pkt->type == RXR_RMA_CONTEXT_PKT);
@@ -471,24 +469,7 @@ void rxr_pkt_handle_rma_read_completion(struct rxr_ep *ep,
 			rxr_release_tx_entry(ep, tx_entry);
 		} else if (read_entry->context_type == RXR_READ_CONTEXT_RX_ENTRY) {
 			rx_entry = read_entry->context;
-			if (rx_entry->op == ofi_op_msg || rx_entry->op == ofi_op_tagged) {
-				if (rx_entry->fi_flags & FI_MULTI_RECV)
-					rxr_msg_multi_recv_handle_completion(ep, rx_entry);
-
-				rxr_cq_write_rx_completion(ep, rx_entry);
-				rxr_msg_multi_recv_free_posted_entry(ep, rx_entry);
-			} else {
-				assert(rx_entry->op == ofi_op_write);
-				if (rx_entry->cq_entry.flags & FI_REMOTE_CQ_DATA)
-					rxr_cq_write_rx_completion(ep, rx_entry);
-			}
-
-			inject = (read_entry->lower_ep_type == SHM_EP);
-			ret = rxr_pkt_post_ctrl_or_queue(ep, RXR_RX_ENTRY, rx_entry, RXR_EOR_PKT, inject);
-			if (OFI_UNLIKELY(ret)) {
-				rxr_cq_write_rx_error(ep, rx_entry, -ret, -ret);
-				rxr_release_rx_entry(ep, rx_entry);
-			}
+			rxr_cq_complete_rx(ep, rx_entry, true, RXR_EOR_PKT);
 		} else {
 			assert(read_entry->context_type == RXR_READ_CONTEXT_PKT_ENTRY);
 			pkt_entry = read_entry->context;


### PR DESCRIPTION
The PR contains 2 commits that are related to multi-recv:

1st commit added test case that test multi_recv of 8k message, which exposed a bug in EFA's implementation of multi reccv.

2nd commit fixed the bug.

Signed-off-by: Wei Zhang <wzam@amazon.com>