### PR TITLE
core/ofi_signal: Allow retries in fd_signal_reset

### DIFF
--- a/include/ofi_signal.h
+++ b/include/ofi_signal.h
@@ -137,6 +137,7 @@ static inline void fd_signal_reset(struct fd_signal *signal)
 	bool cas; /* cas result */
 	enum ofi_signal_state state;
 	ssize_t read_rc;
+	int retries = 0;
 
 	do {
 		cas = ofi_atomic_cas_bool_weak32(&signal->state,
@@ -155,10 +156,11 @@ static inline void fd_signal_reset(struct fd_signal *signal)
 			} else {
 				ofi_atomic_set32(&signal->state, OFI_SIGNAL_SET);
 
-				/* Avoid spinning forever in this highly
-				 * unlikely code path.
-				 */
-				break;
+				if (++retries > 256)
+				{
+					/* Avoid spinning forever. */
+					break;
+				}
 			}
 		}
 


### PR DESCRIPTION
Allow upto 256 spinning retries in fd_signal_reset. On Windows the atomic int32_t can be set prior to the byte written to the socket being available to be read.

on-behalf-of: @cmru-ps <dshinaberry@mru.medical.canon>
Signed-off-by: Derek Shinaberry <dshinaberry@mru.medical.canon>