### PR TITLE
prov/verbs: Windows compatibility for vrb_cq_signal

### DIFF
--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -409,7 +409,7 @@ struct vrb_cq {
 	enum fi_wait_obj	wait_obj;
 	enum fi_cq_wait_cond	wait_cond;
 	struct ibv_wc		wc;
-	int			signal_fd[2];
+	struct fd_signal	signal;
 	vrb_cq_read_entry	read_entry;
 	struct slist		saved_wc_list;
 	ofi_atomic32_t		nevents;


### PR DESCRIPTION
Switch to use fd_signal for implementing vrb_cq_signal for Windows compatibility because read/write cannot be used on Windows sockets.

on-behalf-of: @cmru-ps <dshinaberry@mru.medical.canon>
Signed-off-by: Derek Shinaberry <dshinaberry@mru.medical.canon>