### PR TITLE
fabtests/hmem_cuda: used device allocated host buff to fill device buf

### DIFF
--- a/fabtests/include/hmem.h
+++ b/fabtests/include/hmem.h
@@ -78,10 +78,15 @@ static inline int ft_host_memcpy(uint64_t device, void *dst, const void *src,
 	return FI_SUCCESS;
 }
 
+int ft_default_alloc_host(void **buf, size_t size);
+int ft_default_free_host(void *buf);
+
 int ft_cuda_init(void);
 int ft_cuda_cleanup(void);
 int ft_cuda_alloc(uint64_t device, void **buf, size_t size);
+int ft_cuda_alloc_host(void **buf, size_t size);
 int ft_cuda_free(void *buf);
+int ft_cuda_free_host(void *buf);
 int ft_cuda_memset(uint64_t device, void *buf, int value, size_t size);
 int ft_cuda_copy_to_hmem(uint64_t device, void *dst, const void *src,
 			 size_t size);
@@ -107,7 +112,9 @@ int ft_hmem_init(enum fi_hmem_iface iface);
 int ft_hmem_cleanup(enum fi_hmem_iface iface);
 int ft_hmem_alloc(enum fi_hmem_iface iface, uint64_t device, void **buf,
 		  size_t size);
+int ft_hmem_alloc_host(enum fi_hmem_iface iface, void **buf, size_t size);
 int ft_hmem_free(enum fi_hmem_iface iface, void *buf);
+int ft_hmem_free_host(enum fi_hmem_iface iface, void *buf);
 int ft_hmem_memset(enum fi_hmem_iface iface, uint64_t device, void *buf,
 		   int value, size_t size);
 int ft_hmem_copy_to(enum fi_hmem_iface iface, uint64_t device, void *dst,


### PR DESCRIPTION
ft_fill_buf() is used to fill send buffer for data verification.
When the send buffer is on device, ft_fill_buf() will
allocate a host buffer using malloc(), stage the allocated
buffer, then copy data from host buffer to device buffer.

For CUDA, cudaMemcpy() was used to copy data from host buffer
to device buffer.

Accordig to cuda document:

https://docs.nvidia.com/cuda/cuda-runtime-api/api-sync-behavior.html

When host buffer is pageable, cudaMemcpy() "will return once the
pageable buffer has been copied to the staging memory for
DMA transfer to device memory, but the DMA to final destination may
not have completed".

Hence, ft_fill_buff() can cause data corruption on cuda device.

This patch introduced a function ft_hmem_alloc_host(), which will
allocate a host buffer suitable to be used by ft_fill_buff, and
let ft_fill_buff() to use it.

Currently, this function call cudaMallocHost() to allocated a pinned
host buffer for cuda. For other types of devices, this function
call fi_host_alloc(), which is original behavior.

Signed-off-by: Wei Zhang <wzam@amazon.com>