### PR TITLE
hmem_ze, fabtests: Increase the number of supported ZE devices

### DIFF
--- a/fabtests/common/hmem_ze.c
+++ b/fabtests/common/hmem_ze.c
@@ -43,7 +43,7 @@
 #include <dlfcn.h>
 #include <level_zero/ze_api.h>
 
-#define ZE_MAX_DEVICES 4
+#define ZE_MAX_DEVICES 8
 
 static ze_context_handle_t context;
 static ze_device_handle_t devices[ZE_MAX_DEVICES];

--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -146,7 +146,7 @@ int cuda_gdrcopy_hmem_cleanup(void);
 int cuda_gdrcopy_dev_register(struct fi_mr_attr *mr_attr, uint64_t *handle);
 int cuda_gdrcopy_dev_unregister(uint64_t handle);
 
-#define ZE_MAX_DEVICES 4
+#define ZE_MAX_DEVICES 8
 int ze_hmem_copy(uint64_t device, void *dst, const void *src, size_t size);
 int ze_hmem_init(void);
 int ze_hmem_cleanup(void);


### PR DESCRIPTION
The previous number is 4. We have already encountered systems with more
devices than that. Increase it to 8.

In the long run, we would want to remove this hard-coded limit.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>