### PR TITLE
fabtests: Bugfixes to runfabtests.sh and test enabling/disabling

### DIFF
--- a/fabtests/scripts/runfabtests.sh
+++ b/fabtests/scripts/runfabtests.sh
@@ -903,8 +903,8 @@ while true; do
 		-f)
 		    read_exclude_file $2; shift 2 ;;
 		-e)
-		    [[ -z "$input_excludes" ]] && input_excludes=${OPTARG} || \
-		    input_excludes="${input_excludes},${OPTARG}"
+		    [[ -z "$input_excludes" ]] && input_excludes=${2} || \
+		    input_excludes="${input_excludes},${2}"
 		    shift 2 ;;
 		-c)
 		    C_INTERFACE=$2; shift 2 ;;

--- a/fabtests/test_configs/ofi_rxd/ofi_rxd.exclude
+++ b/fabtests/test_configs/ofi_rxd/ofi_rxd.exclude
@@ -21,6 +21,3 @@ shared_ctx
 scalable_ep
 shared_av
 multi_mr
-
-# Exclude because it takes too long
-ubertest

--- a/fabtests/test_configs/sockets/sockets.exclude
+++ b/fabtests/test_configs/sockets/sockets.exclude
@@ -1,4 +1,6 @@
 # Regex patterns of tests to exclude in runfabtests.sh
 
+# Exclude all prefix tests
+-k
 -e dgram
 dgram


### PR DESCRIPTION
runfabtests.sh was not properly using the -e flag and wouldn't exclude user input excludes.
sockets now runs quick tests for ubertest because all has failures. See https://github.com/ofiwg/libfabric/issues/7543
sockets now has FI_MSG_PREFIX tests properly disabled
rxd can now run ubertests
