### PR TITLE
contrib/intel/jenkins: Add proper testing for uber,multinode to reduce CI time

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -49,6 +49,47 @@ pipeline {
         }
         stage('parallel-tests') {
             parallel {
+                stage('MPI-verbs-rxm') {
+                    agent {node {label 'mlx5'}}
+                    options { skipDefaultCheckout() }
+                    steps {
+                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
+                        {
+                          sh """
+                            env
+                            (
+                                cd /opt${env.WORKSPACE}/contrib/intel/jenkins/
+                                python3.7 runtests.py --prov=verbs --util=rxm --test=IMB --imb_grp=1
+                                echo "IMB verbs-rxm Group 1 completed."
+                                python3.7 runtests.py --prov=verbs --util=rxm --test=IMB --imb_grp=2
+                                echo "IMB verbs-rxm Group 2 completed."
+                                python3.7 runtests.py --prov=verbs --util=rxm --test=IMB --imb_grp=3
+                                echo "IMB verbs-rxm Group 3 completed."
+                                python3.7 runtests.py --prov=verbs --util=rxm --test=osu
+                                echo "OSU verbs-rxm completed."
+                                echo "MPI-verbs-rxm completed."
+                            )
+                          """
+                        }
+                    }
+                }
+                stage('MPI-tcp-rxm-2') {
+                    agent {node {label 'eth'}}
+                    options { skipDefaultCheckout() }
+                    steps {
+                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
+                        {
+                          sh """
+                            env
+                            (
+                                cd /opt${env.WORKSPACE}/contrib/intel/jenkins/
+                                python3.7 runtests.py --prov=tcp --util=rxm --test=IMB --imb_grp=2
+                                echo "MPI-tcp-rxm-2 completed."
+                            )
+                          """
+                        }
+                    }
+                }
                 stage('tcp') {
                     agent {node {label 'eth'}}
                     options { skipDefaultCheckout() }
@@ -163,30 +204,6 @@ pipeline {
                         }
                     }
                 }
-                stage('MPI-verbs-rxm') {
-                    agent {node {label 'mlx5'}}
-                    options { skipDefaultCheckout() }
-                    steps {
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
-                        {
-                          sh """
-                            env
-                            (
-                                cd /opt${env.WORKSPACE}/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=verbs --util=rxm --test=IMB --imb_grp=1
-                                echo "IMB verbs-rxm Group 1 completed."
-                                python3.7 runtests.py --prov=verbs --util=rxm --test=IMB --imb_grp=2
-                                echo "IMB verbs-rxm Group 2 completed."
-                                python3.7 runtests.py --prov=verbs --util=rxm --test=IMB --imb_grp=3
-                                echo "IMB verbs-rxm Group 3 completed."
-                                python3.7 runtests.py --prov=verbs --util=rxm --test=osu
-                                echo "OSU verbs-rxm completed."
-                                echo "MPI-verbs-rxm completed."
-                            )
-                          """
-                        }
-                    }
-                }
                 stage('MPI-tcp-rxm-1') {
                     agent {node {label 'eth'}}
                     options { skipDefaultCheckout() }
@@ -199,23 +216,6 @@ pipeline {
                                 cd /opt${env.WORKSPACE}/contrib/intel/jenkins/
                                 python3.7 runtests.py --prov=tcp --util=rxm --test=IMB --imb_grp=1
                                 echo "MPI-tcp-rxm-1 completed."
-                            )
-                          """
-                        }
-                    }
-                }
-                stage('MPI-tcp-rxm-2') {
-                    agent {node {label 'eth'}}
-                    options { skipDefaultCheckout() }
-                    steps {
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
-                        {
-                          sh """
-                            env
-                            (
-                                cd /opt${env.WORKSPACE}/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=tcp --util=rxm --test=IMB --imb_grp=2
-                                echo "MPI-tcp-rxm-2 completed."
                             )
                           """
                         }

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -128,8 +128,16 @@ class Fabtest(Test):
         elif not re.match(".*sockets|udp.*", self.core_prov):
             opts = "{} -t all ".format(opts)
 
-        if ((self.ofi_build_mode == 'reg' and self.core_prov == 'udp') or \
-            self.ofi_build_mode != 'reg'):
+        if (self.core_prov == 'sockets' and self.ofi_build_mode == 'reg'):
+            complex_test_file = '{}/share/fabtests/test_configs/{}/quick.test' \
+                                .format(self.libfab_installpath,
+                                self.core_prov)
+            if (os.path.isfile(complex_test_file)):
+                opts = "{} -u {} ".format(opts, complex_test_file)
+            else:
+                print("{} Complex test file not found".format(self.core_prov))
+
+        if (self.ofi_build_mode != 'reg' or self.core_prov == 'udp'):
             opts = "{} -e \'multinode,ubertest\' ".format(opts)
 
         efile = self.get_exclude_file()

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -124,8 +124,8 @@ class Fabtest(Test):
             opts += "-N "
 
         if (self.ofi_build_mode == 'dl'):
-            opts += '-t short'
-        elif not re.match(".*sockets|udp.*", self.core_prov):
+            opts = "{} -t short ".format(opts)
+        else:
             opts = "{} -t all ".format(opts)
 
         if (self.core_prov == 'sockets' and self.ofi_build_mode == 'reg'):


### PR DESCRIPTION
Only run ubertest,multinode on reg builds.
Allow sockets and udp to run -t all via [PR](https://github.com/ofiwg/libfabric/pull/7546)
Make sockets use quick.test for ubertest in ci because all.test is failing
Re-order the Jenkinsfile pipeline to submit slower tests first so nodes have a higher priority to run those tests first. This will decrease overall runtime.