### PR TITLE
prov/efa: allow different shm settings between peers

### DIFF
--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -1037,16 +1037,15 @@ int efa_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric_fid,
 		goto err_free_fabric;
 
 	/* Open shm provider's fabric domain */
-	if (rxr_env.enable_shm_transfer) {
+	if (shm_info) {
 		assert(!strcmp(shm_info->fabric_attr->name, "shm"));
 		ret = fi_fabric(shm_info->fabric_attr,
-				    &efa_fabric->shm_fabric, context);
+				&efa_fabric->shm_fabric, context);
 		if (ret)
 			goto err_close_util_fabric;
 	} else {
 		efa_fabric->shm_fabric = NULL;
 	}
-
 
 #ifdef EFA_PERF_ENABLED
 	ret = ofi_perfset_create(&rxr_prov, &efa_fabric->perf_set,

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -314,7 +314,6 @@ static int efa_mr_dereg_impl(struct efa_mr *efa_mr)
 		ret = err;
 	}
 	if (efa_mr->shm_mr) {
-		assert(rxr_env.enable_shm_transfer);
 		err = fi_close(&efa_mr->shm_mr->fid);
 		if (err) {
 			EFA_WARN(FI_LOG_MR,
@@ -419,7 +418,6 @@ static int efa_mr_reg_impl(struct efa_mr *efa_mr, uint64_t flags, void *attr)
 		/* We need to add FI_REMOTE_READ to allow for Read implemented
 		* message protocols.
 		*/
-		assert(rxr_env.enable_shm_transfer);
 		original_access = mr_attr->access;
 		mr_attr->access |= FI_REMOTE_READ;
 		ret = fi_mr_regattr(efa_mr->domain->shm_domain, attr,

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -569,7 +569,7 @@ struct rxr_ep {
 	struct fid_cq *rdm_cq;
 
 	/* shm provider fid */
-	bool use_shm;
+	bool use_shm_for_tx;
 	struct fid_ep *shm_ep;
 	struct fid_cq *shm_cq;
 

--- a/prov/efa/src/rxr/rxr_atomic.c
+++ b/prov/efa/src/rxr/rxr_atomic.c
@@ -242,8 +242,7 @@ rxr_atomic_inject(struct fid_ep *ep,
 	rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid.fid);
 	peer = rxr_ep_get_peer(rxr_ep, dest_addr);
 	assert(peer);
-	if (peer->is_local) {
-		assert(rxr_ep->use_shm);
+	if (peer->is_local && rxr_ep->use_shm_for_tx) {
 		if (!(shm_info->domain_attr->mr_mode & FI_MR_VIRT_ADDR))
 			remote_addr = 0;
 
@@ -291,8 +290,7 @@ rxr_atomic_writemsg(struct fid_ep *ep,
 	rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid.fid);
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
 	assert(peer);
-	if (peer->is_local) {
-		assert(rxr_ep->use_shm);
+	if (peer->is_local && rxr_ep->use_shm_for_tx) {
 		rxr_atomic_init_shm_msg(&shm_msg, msg, rma_iov, shm_desc);
 		shm_msg.addr = peer->shm_fiaddr;
 		return fi_atomicmsg(rxr_ep->shm_ep, &shm_msg, flags);
@@ -371,8 +369,7 @@ rxr_atomic_readwritemsg(struct fid_ep *ep,
 	rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid.fid);
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
 	assert(peer);
-	if (peer->is_local) {
-		assert(rxr_ep->use_shm);
+	if (peer->is_local & rxr_ep->use_shm_for_tx) {
 		rxr_atomic_init_shm_msg(&shm_msg, msg, shm_rma_iov, shm_desc);
 		shm_msg.addr = peer->shm_fiaddr;
 		return fi_fetch_atomicmsg(rxr_ep->shm_ep, &shm_msg,
@@ -460,8 +457,7 @@ rxr_atomic_compwritemsg(struct fid_ep *ep,
 	rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid.fid);
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
 	assert(peer);
-	if (peer->is_local) {
-		assert(rxr_ep->use_shm);
+	if (peer->is_local && rxr_ep->use_shm_for_tx) {
 		rxr_atomic_init_shm_msg(&shm_msg, msg, shm_rma_iov, shm_desc);
 		shm_msg.addr = peer->shm_fiaddr;
 		return fi_compare_atomicmsg(rxr_ep->shm_ep, &shm_msg,

--- a/prov/efa/src/rxr/rxr_cq.c
+++ b/prov/efa/src/rxr/rxr_cq.c
@@ -560,7 +560,7 @@ void rxr_cq_complete_rx(struct rxr_ep *ep,
 		assert(ctrl_type == RXR_RECEIPT_PKT || ctrl_type == RXR_EOR_PKT);
 		peer = rxr_ep_get_peer(ep, rx_entry->addr);
 		assert(peer);
-		inject = peer->is_local;
+		inject = peer->is_local && ep->use_shm_for_tx;
 		err = rxr_pkt_post_ctrl_or_queue(ep,
 						 RXR_RX_ENTRY,
 						 rx_entry,

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -676,7 +676,7 @@ static void rxr_ep_free_res(struct rxr_ep *rxr_ep)
 		ofi_buf_free(pkt);
 	}
 
-	if (rxr_ep->use_shm) {
+	if (rxr_ep->shm_ep) {
 		dlist_foreach_safe(&rxr_ep->rx_posted_buf_shm_list, entry, tmp) {
 			pkt = container_of(entry, struct rxr_pkt_entry, dbg_entry);
 			ofi_buf_free(pkt);
@@ -757,13 +757,11 @@ static void rxr_ep_free_res(struct rxr_ep *rxr_ep)
 	if (rxr_ep->pkt_sendv_pool)
 		ofi_bufpool_destroy(rxr_ep->pkt_sendv_pool);
 
-	if (rxr_ep->use_shm) {
-		if (rxr_ep->shm_rx_pkt_pool)
-			ofi_bufpool_destroy(rxr_ep->shm_rx_pkt_pool);
+	if (rxr_ep->shm_rx_pkt_pool)
+		ofi_bufpool_destroy(rxr_ep->shm_rx_pkt_pool);
 
-		if (rxr_ep->shm_tx_pkt_pool)
-			ofi_bufpool_destroy(rxr_ep->shm_tx_pkt_pool);
-	}
+	if (rxr_ep->shm_tx_pkt_pool)
+		ofi_bufpool_destroy(rxr_ep->shm_tx_pkt_pool);
 }
 
 /*
@@ -828,21 +826,21 @@ static int rxr_ep_close(struct fid *fid)
 		retv = ret;
 	}
 
-	/* Close shm provider's endpoint and cq */
-	if (rxr_ep->use_shm) {
+	if (rxr_ep->shm_ep) {
 		ret = fi_close(&rxr_ep->shm_ep->fid);
 		if (ret) {
 			FI_WARN(&rxr_prov, FI_LOG_EP_CTRL, "Unable to close shm EP\n");
 			retv = ret;
 		}
+	}
 
+	if (rxr_ep->shm_cq) {
 		ret = fi_close(&rxr_ep->shm_cq->fid);
 		if (ret) {
 			FI_WARN(&rxr_prov, FI_LOG_EP_CTRL, "Unable to close shm CQ\n");
 			retv = ret;
 		}
 	}
-
 
 	ret = ofi_endpoint_close(&rxr_ep->util_ep);
 	if (ret) {
@@ -887,7 +885,8 @@ static int rxr_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 			return ret;
 
 		/* Bind shm provider endpoint & shm av */
-		if (rxr_ep->use_shm) {
+		if (rxr_ep->shm_ep) {
+			assert(av->shm_rdm_av);
 			ret = fi_ep_bind(rxr_ep->shm_ep, &av->shm_rdm_av->fid, flags);
 			if (ret)
 				return ret;
@@ -1059,7 +1058,7 @@ static int rxr_ep_ctrl(struct fid *fid, int command, void *arg)
 		 * In this way, each peer is able to open and map to other local peers'
 		 * shared memory region.
 		 */
-		if (ep->use_shm) {
+		if (ep->shm_ep) {
 			shm_ep_name_len = EFA_SHM_NAME_MAX;
 			ret = rxr_raw_addr_to_smr_name(ep->core_addr, shm_ep_name, &shm_ep_name_len);
 			if (ret < 0)
@@ -1069,7 +1068,6 @@ static int rxr_ep_ctrl(struct fid *fid, int command, void *arg)
 			if (ret)
 				goto out;
 		}
-
 out:
 		ofi_mutex_unlock(&ep->util_ep.lock);
 		break;
@@ -1509,7 +1507,7 @@ int rxr_ep_init(struct rxr_ep *ep)
 		goto err_free;
 
 	sendv_pool_size = rxr_get_tx_pool_chunk_cnt(ep);
-	if (ep->use_shm)
+	if (ep->use_shm_for_tx)
 		sendv_pool_size += shm_info->tx_attr->size;
 	ret = ofi_bufpool_create(&ep->pkt_sendv_pool,
 				 sizeof(struct rxr_pkt_sendv),
@@ -1520,7 +1518,7 @@ int rxr_ep_init(struct rxr_ep *ep)
 		goto err_free;
 
 	/* create pkt pool for shm */
-	if (ep->use_shm) {
+	if (ep->use_shm_for_tx) {
 		ret = ofi_bufpool_create(&ep->shm_tx_pkt_pool,
 					 entry_sz,
 					 RXR_BUF_POOL_ALIGNMENT,
@@ -1528,7 +1526,9 @@ int rxr_ep_init(struct rxr_ep *ep)
 					 shm_info->tx_attr->size, 0);
 		if (ret)
 			goto err_free;
+	}
 
+	if (ep->shm_ep) {
 		ret = ofi_bufpool_create(&ep->shm_rx_pkt_pool,
 					 entry_sz,
 					 RXR_BUF_POOL_ALIGNMENT,
@@ -1663,8 +1663,7 @@ int rxr_ep_grow_rx_pkt_pools(struct rxr_ep *ep)
 		return err;
 	}
 
-	if (ep->use_shm) {
-		assert(ep->shm_rx_pkt_pool);
+	if (ep->shm_rx_pkt_pool) {
 		err = ofi_bufpool_grow(ep->shm_rx_pkt_pool);
 		if (err) {
 			FI_WARN(&rxr_prov, FI_LOG_CQ,
@@ -1797,7 +1796,7 @@ void rxr_ep_progress_post_internal_rx_pkts(struct rxr_ep *ep)
 			ep->efa_rx_pkts_to_post = rxr_get_rx_pool_chunk_cnt(ep);
 			ep->available_data_bufs = rxr_get_rx_pool_chunk_cnt(ep);
 
-			if (ep->use_shm) {
+			if (ep->shm_ep) {
 				assert(ep->shm_rx_pkts_posted == 0 && ep->shm_rx_pkts_to_post == 0);
 				ep->shm_rx_pkts_to_post = shm_info->rx_attr->size;
 			}
@@ -1810,7 +1809,7 @@ void rxr_ep_progress_post_internal_rx_pkts(struct rxr_ep *ep)
 
 	ep->efa_rx_pkts_to_post = 0;
 
-	if (ep->use_shm) {
+	if (ep->shm_ep) {
 		err = rxr_ep_bulk_post_internal_rx_pkts(ep, ep->shm_rx_pkts_to_post, SHM_EP);
 		if (err)
 			goto err_exit;
@@ -1834,7 +1833,7 @@ static inline ssize_t rxr_ep_send_queued_pkts(struct rxr_ep *ep,
 
 	dlist_foreach_container_safe(pkts, struct rxr_pkt_entry,
 				     pkt_entry, entry, tmp) {
-		if (ep->use_shm && rxr_ep_get_peer(ep, pkt_entry->addr)->is_local) {
+		if (ep->use_shm_for_tx && rxr_ep_get_peer(ep, pkt_entry->addr)->is_local) {
 			dlist_remove(&pkt_entry->entry);
 			continue;
 		}
@@ -1951,7 +1950,7 @@ static inline void rdm_ep_poll_ibv_cq(struct rxr_ep *ep,
 			pkt_entry->addr = efa_av_reverse_lookup_rdm(efa_av, ibv_wc.slid, ibv_wc.src_qp, pkt_entry);
 			pkt_entry->pkt_size = ibv_wc.byte_len;
 			assert(pkt_entry->pkt_size > 0);
-			rxr_pkt_handle_recv_completion(ep, pkt_entry);
+			rxr_pkt_handle_recv_completion(ep, pkt_entry, EFA_EP);
 #if ENABLE_DEBUG
 			ep->recv_comps++;
 #endif
@@ -2046,7 +2045,7 @@ static inline void rdm_ep_poll_shm_cq(struct rxr_ep *ep,
 			pkt_entry->addr = src_addr;
 			pkt_entry->pkt_size = cq_entry.len;
 			assert(pkt_entry->pkt_size > 0);
-			rxr_pkt_handle_recv_completion(ep, pkt_entry);
+			rxr_pkt_handle_recv_completion(ep, pkt_entry, SHM_EP);
 		} else {
 			FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,
 				"Unhandled cq type\n");
@@ -2070,9 +2069,10 @@ void rxr_ep_progress_internal(struct rxr_ep *ep)
 	// Poll the EFA completion queue
 	rdm_ep_poll_ibv_cq(ep, rxr_env.efa_cq_read_size);
 
-	// Poll the SHM completion queue if enabled
-	if (ep->use_shm)
+	if (ep->shm_cq) {
+		// Poll the SHM completion queue
 		rdm_ep_poll_shm_cq(ep, rxr_env.shm_cq_read_size);
+	}
 
 	rxr_ep_progress_post_internal_rx_pkts(ep);
 
@@ -2349,7 +2349,7 @@ void rxr_ep_progress(struct util_ep *util_ep)
 }
 
 static
-bool rxr_ep_use_shm(struct fi_info *info)
+bool rxr_ep_use_shm_for_tx(struct fi_info *info)
 {
 	/* App provided hints supercede environmental variables.
 	 *
@@ -2431,14 +2431,17 @@ int rxr_endpoint(struct fid_domain *domain, struct fi_info *info,
 	efa_domain = container_of(rxr_domain->rdm_domain, struct efa_domain,
 				  util_domain.domain_fid);
 
-	rxr_ep->use_shm = rxr_ep_use_shm(info);
-	if (rxr_ep->use_shm) {
-		/* Open shm provider's endpoint */
+	if (efa_domain->shm_domain) {
 		assert(!strcmp(shm_info->fabric_attr->name, "shm"));
 		ret = fi_endpoint(efa_domain->shm_domain, shm_info,
 				  &rxr_ep->shm_ep, rxr_ep);
 		if (ret)
 			goto err_close_core_ep;
+
+		rxr_ep->use_shm_for_tx = rxr_ep_use_shm_for_tx(info);
+	} else {
+		rxr_ep->shm_ep = NULL;
+		rxr_ep->use_shm_for_tx = false;
 	}
 
 	rxr_ep->rx_size = info->rx_attr->size;
@@ -2515,8 +2518,8 @@ int rxr_endpoint(struct fid_domain *domain, struct fi_info *info,
 	if (ret)
 		goto err_close_core_cq;
 
-	/* Bind ep with shm provider's cq */
-	if (rxr_ep->use_shm) {
+	if (efa_domain->shm_domain) {
+		/* Bind ep with shm provider's cq */
 		ret = fi_cq_open(efa_domain->shm_domain, &cq_attr,
 				 &rxr_ep->shm_cq, rxr_ep);
 		if (ret)
@@ -2543,7 +2546,7 @@ int rxr_endpoint(struct fid_domain *domain, struct fi_info *info,
 	return 0;
 
 err_close_shm_cq:
-	if (rxr_ep->use_shm && rxr_ep->shm_cq) {
+	if (rxr_ep->shm_cq) {
 		retv = fi_close(&rxr_ep->shm_cq->fid);
 		if (retv)
 			FI_WARN(&rxr_prov, FI_LOG_CQ, "Unable to close shm cq: %s\n",
@@ -2555,7 +2558,7 @@ err_close_core_cq:
 		FI_WARN(&rxr_prov, FI_LOG_CQ, "Unable to close cq: %s\n",
 			fi_strerror(-retv));
 err_close_shm_ep:
-	if (rxr_ep->use_shm && rxr_ep->shm_ep) {
+	if (rxr_ep->shm_ep) {
 		retv = fi_close(&rxr_ep->shm_ep->fid);
 		if (retv)
 			FI_WARN(&rxr_prov, FI_LOG_EP_CTRL, "Unable to close shm EP: %s\n",

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -209,8 +209,7 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 							      tx_entry->fi_flags, 0);
 	}
 
-	if (peer->is_local) {
-		assert(rxr_ep->use_shm);
+	if (peer->is_local && rxr_ep->use_shm_for_tx) {
 		/* intra instance message
 		 *
 		 * Currently the shm provider does not support mixed memory type

--- a/prov/efa/src/rxr/rxr_pkt_cmd.h
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.h
@@ -58,7 +58,8 @@ void rxr_pkt_handle_recv_error(struct rxr_ep *ep,
 			       int err, int prov_errno);
 
 void rxr_pkt_handle_recv_completion(struct rxr_ep *ep,
-				    struct rxr_pkt_entry *pkt_entry);
+				    struct rxr_pkt_entry *pkt_entry,
+				    enum rxr_lower_ep_type lower_ep_type);
 
 ssize_t rxr_pkt_wait_handshake(struct rxr_ep *ep, fi_addr_t addr, struct rdm_peer *peer);
 

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -96,7 +96,7 @@ ssize_t rxr_pkt_post_handshake(struct rxr_ep *ep, struct rdm_peer *peer)
 	ssize_t ret;
 
 	addr = peer->efa_fiaddr;
-	if (peer->is_local)
+	if (peer->is_local && ep->use_shm_for_tx)
 		pkt_entry = rxr_pkt_entry_alloc(ep, ep->shm_tx_pkt_pool, RXR_PKT_FROM_SHM_TX_POOL);
 	else
 		pkt_entry = rxr_pkt_entry_alloc(ep, ep->efa_tx_pkt_pool, RXR_PKT_FROM_EFA_TX_POOL);

--- a/prov/efa/src/rxr/rxr_read.c
+++ b/prov/efa/src/rxr/rxr_read.c
@@ -541,6 +541,7 @@ int rxr_read_post_once(struct rxr_ep *ep, struct rxr_read_entry *read_entry,
 	if (read_entry->lower_ep_type == SHM_EP) {
 		peer = rxr_ep_get_peer(ep, read_entry->addr);
 		assert(peer);
+		assert(peer->is_local && ep->use_shm_for_tx);
 		msg.addr = peer->shm_fiaddr;
 		err = fi_readmsg(ep->shm_ep, &msg, 0);
 	} else {

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -336,8 +336,7 @@ ssize_t rxr_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uint64_
 	}
 
 	use_lower_ep_read = false;
-	if (peer->is_local) {
-		assert(rxr_ep->use_shm);
+	if (peer->is_local && rxr_ep->use_shm_for_tx) {
 		use_lower_ep_read = true;
 	} else if (efa_both_support_rdma_read(rxr_ep, peer)) {
 		/* efa_both_support_rdma_read also check rxr_env.use_device_rdma,


### PR DESCRIPTION
Currently, if two endpoints use different shm settings (one enables
shm, the other disable shm), the communication between them
cannot proceed.

This is because when shm is disabled, an endpoint will not create shm
infrastruction. However,its peer does not know that and will try
to use shm with the endpoint.

This patch addressed the issue by always creating shm infrastructures
(endpoint, domain, CQ), and use it for RX operations.

With this patch, enable_shm_transfer means enable the usage shm for
TX operations.

Signed-off-by: Wei Zhang <wzam@amazon.com>