### PR TITLE
contrib/intel/jenkins: Fix fi_info test arguments

### DIFF
--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -59,9 +59,9 @@ class FiInfoTest(Test):
     @property
     def options(self):
         if (self.util_prov):
-            opts  = "-f -p {};{}".format(self.core_prov, self.util_prov)
+            opts  = "-f {} -p {};{}".format(self.fabric, self.core_prov, self.util_prov)
         else:
-            opts = "-f -p {}".format(self.core_prov)
+            opts = "-f {} -p {}".format(self.fabric, self.core_prov)
 
         return opts
 


### PR DESCRIPTION
The fi_info test is called with `-f -p <prov>`. There should be
fabric name after the `-f` option.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>