### PR TITLE
osd/windows: PTHREAD_MUTEX_INITIALIZER

### DIFF
--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -166,6 +166,8 @@ void ofi_monitor_cleanup(struct ofi_mem_monitor *monitor)
  */
 void ofi_monitors_init(void)
 {
+	pthread_mutex_init(&mm_state_lock, NULL);
+
 	uffd_monitor->init(uffd_monitor);
 	memhooks_monitor->init(memhooks_monitor);
 	cuda_monitor->init(cuda_monitor);


### PR DESCRIPTION
The Windows CRTICAL_SECTION is a structure with six fields. All fields initialized with 0 led to a crash when EnterCriticalSection was called in pthread_mutex_lock. The values used were based on the field values after a call to InitializeCriticalSection except for the final field for spin lock count. I figured that might be system dependent, so I opted to use 0 to disable spin lock attempts altogether.

On-behalf-of: @cmru-ps <dshinaberry@mru.medical.canon>
Signed-off-by: Derek Shinaberry <dshinaberry@mru.medical.canon>