### PR TITLE
[v1.14.x] core+efa: backport bufpool mmap changes

### DIFF
--- a/include/freebsd/osd.h
+++ b/include/freebsd/osd.h
@@ -65,11 +65,6 @@ static inline int ofi_alloc_hugepage_buf(void **memptr, size_t size)
 	return -FI_ENOSYS;
 }
 
-static inline int ofi_free_hugepage_buf(void *memptr, size_t size)
-{
-	return -FI_ENOSYS;
-}
-
 static inline size_t ofi_ifaddr_get_speed(struct ifaddrs *ifa)
 {
 	return 0;

--- a/include/linux/osd.h
+++ b/include/linux/osd.h
@@ -65,18 +65,7 @@ ssize_t ofi_get_hugepage_size(void);
 
 static inline int ofi_alloc_hugepage_buf(void **memptr, size_t size)
 {
-	*memptr = mmap(NULL, size, PROT_READ | PROT_WRITE,
-		       MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB, -1, 0);
-
-	if (*memptr == MAP_FAILED)
-		return -errno;
-
-	return FI_SUCCESS;
-}
-
-static inline int ofi_free_hugepage_buf(void *memptr, size_t size)
-{
-	return munmap(memptr, size);
+	return ofi_mmap_anon_pages(memptr, size, MAP_HUGETLB);
 }
 
 static inline int ofi_hugepage_enabled(void)
@@ -93,7 +82,7 @@ static inline int ofi_hugepage_enabled(void)
 	if (ret)
 		return 0;
 
-	ret = ofi_free_hugepage_buf(buffer, len);
+	ret = ofi_unmap_anon_pages(buffer, len);
 	assert(ret == 0);
 
 	return 1;

--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -289,6 +289,7 @@ enum {
 	OFI_BUFPOOL_INDEXED		= 1 << 1,
 	OFI_BUFPOOL_NO_TRACK		= 1 << 2,
 	OFI_BUFPOOL_HUGEPAGES		= 1 << 3,
+	OFI_BUFPOOL_NONSHARED		= 1 << 4,
 };
 
 struct ofi_bufpool_region;

--- a/include/osx/osd.h
+++ b/include/osx/osd.h
@@ -63,6 +63,10 @@
 #define HOST_NAME_MAX 255
 #endif
 
+#ifndef MAP_ANONYMOUS
+#define MAP_ANONYMOUS MAP_ANON
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -78,11 +82,6 @@ static inline ssize_t ofi_get_hugepage_size(void)
 }
 
 static inline int ofi_alloc_hugepage_buf(void **memptr, size_t size)
-{
-	return -FI_ENOSYS;
-}
-
-static inline int ofi_free_hugepage_buf(void *memptr, size_t size)
 {
 	return -FI_ENOSYS;
 }

--- a/include/unix/osd.h
+++ b/include/unix/osd.h
@@ -90,6 +90,9 @@ struct util_shm
 	size_t		size;
 };
 
+int ofi_mmap_anon_pages(void **memptr, size_t size, int flags);
+int ofi_unmap_anon_pages(void *memptr, size_t size);
+
 static inline int ofi_memalign(void **memptr, size_t alignment, size_t size)
 {
 	return posix_memalign(memptr, alignment, size);

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -682,6 +682,16 @@ static inline char* strsep(char **stringp, const char *delim)
 
 #define __attribute__(x)
 
+static inline int ofi_mmap_anon_pages(void **memptr, size_t size, int flags)
+{
+	return -FI_ENOSYS;
+}
+
+static inline int ofi_unmap_anon_pages(void *memptr, size_t size)
+{
+	return -FI_ENOSYS;
+}
+
 static inline int ofi_memalign(void **memptr, size_t alignment, size_t size)
 {
 	*memptr = _aligned_malloc(size, alignment);
@@ -896,11 +906,6 @@ static inline ssize_t ofi_get_hugepage_size(void)
 }
 
 static inline int ofi_alloc_hugepage_buf(void **memptr, size_t size)
-{
-	return -FI_ENOSYS;
-}
-
-static inline int ofi_free_hugepage_buf(void *memptr, size_t size)
 {
 	return -FI_ENOSYS;
 }

--- a/prov/util/src/util_buf.c
+++ b/prov/util/src/util_buf.c
@@ -54,8 +54,8 @@ static int ofi_bufpool_region_alloc(struct ofi_bufpool_region *buf_region)
 
 	if (pool->attr.flags & OFI_BUFPOOL_HUGEPAGES) {
 		page_size = ofi_get_hugepage_size();
-		if (page_size > 0 && (ssize_t) pool->alloc_size >= page_size) {
-			alloc_size = ofi_get_aligned_size(pool->alloc_size, page_size);
+		if (page_size > 0 && pool->alloc_size >= (size_t) page_size) {
+			alloc_size = ofi_get_aligned_size(pool->alloc_size, (size_t) page_size);
 			ret = ofi_alloc_hugepage_buf((void **) &buf_region->alloc_region,
 					     alloc_size);
 			if (!ret) {
@@ -74,7 +74,10 @@ static int ofi_bufpool_region_alloc(struct ofi_bufpool_region *buf_region)
 
 	if (pool->attr.flags & OFI_BUFPOOL_NONSHARED) {
 		page_size = ofi_get_page_size();
-		pool->alloc_size = ofi_get_aligned_size(pool->alloc_size, page_size);
+		if (page_size < 0) {
+			return -ofi_syserr();
+		}
+		pool->alloc_size = ofi_get_aligned_size(pool->alloc_size, (size_t) page_size);
 		ret = ofi_mmap_anon_pages((void **) &buf_region->alloc_region,
 					     pool->alloc_size, 0);
 		if (!ret) {

--- a/prov/util/src/util_buf.c
+++ b/prov/util/src/util_buf.c
@@ -45,6 +45,75 @@ enum {
 };
 
 
+static int ofi_bufpool_region_alloc(struct ofi_bufpool_region *buf_region)
+{
+	int ret;
+	ssize_t page_size;
+	size_t alloc_size;
+	struct ofi_bufpool *pool = buf_region->pool;
+
+	if (pool->attr.flags & OFI_BUFPOOL_HUGEPAGES) {
+		page_size = ofi_get_hugepage_size();
+		if (page_size > 0 && (ssize_t) pool->alloc_size >= page_size) {
+			alloc_size = ofi_get_aligned_size(pool->alloc_size, page_size);
+			ret = ofi_alloc_hugepage_buf((void **) &buf_region->alloc_region,
+					     alloc_size);
+			if (!ret) {
+				buf_region->flags = OFI_BUFPOOL_HUGEPAGES | OFI_BUFPOOL_NONSHARED;
+				pool->alloc_size = alloc_size;
+				pool->region_size = pool->alloc_size - pool->entry_size;
+				return 0;
+			}
+		}
+		/* If we can't allocate huge pages, fall back to mmap
+		 * for all future attempts.
+		 */
+		pool->attr.flags &= ~OFI_BUFPOOL_HUGEPAGES;
+		pool->attr.flags |= OFI_BUFPOOL_NONSHARED;
+	}
+
+	if (pool->attr.flags & OFI_BUFPOOL_NONSHARED) {
+		page_size = ofi_get_page_size();
+		pool->alloc_size = ofi_get_aligned_size(pool->alloc_size, page_size);
+		ret = ofi_mmap_anon_pages((void **) &buf_region->alloc_region,
+					     pool->alloc_size, 0);
+		if (!ret) {
+			buf_region->flags = OFI_BUFPOOL_NONSHARED;
+			pool->region_size = pool->alloc_size - pool->entry_size;
+			return 0;
+		} else if (ret != -FI_ENOSYS) {
+			return ret;
+		}
+		/* If mmap is not supported, fall back to normal
+		 * allocations for all future attempts.
+		 */
+		pool->attr.flags &= ~OFI_BUFPOOL_NONSHARED;
+		pool->attr.alignment = ofi_get_aligned_size(pool->attr.alignment, page_size);
+	}
+
+	return ofi_memalign((void **) &buf_region->alloc_region,
+				roundup_power_of_two(pool->attr.alignment),
+				pool->alloc_size);
+}
+
+static void ofi_bufpool_region_free(struct ofi_bufpool_region *buf_region)
+{
+	int ret;
+	struct ofi_bufpool *pool = buf_region->pool;
+
+	if (buf_region->flags & (OFI_BUFPOOL_HUGEPAGES | OFI_BUFPOOL_NONSHARED)) {
+		ret = ofi_unmap_anon_pages(buf_region->alloc_region, pool->alloc_size);
+		if (ret) {
+			FI_DBG(&core_prov, FI_LOG_CORE,
+			       "munmap failed: %s\n",
+			       fi_strerror(-ret));
+			assert(0);
+		}
+	} else {
+		ofi_freealign(buf_region->alloc_region);
+	}
+}
+
 int ofi_bufpool_grow(struct ofi_bufpool *pool)
 {
 	struct ofi_bufpool_region *buf_region;
@@ -63,23 +132,7 @@ int ofi_bufpool_grow(struct ofi_bufpool *pool)
 	buf_region->pool = pool;
 	dlist_init(&buf_region->free_list);
 
-	if (pool->attr.flags & OFI_BUFPOOL_HUGEPAGES) {
-		ret = ofi_alloc_hugepage_buf((void **) &buf_region->alloc_region,
-					     pool->alloc_size);
-		/* If we can't allocate huge pages, fall back to normal
-		 * allocations for all future attempts.
-		 */
-		if (ret) {
-			pool->attr.flags &= ~OFI_BUFPOOL_HUGEPAGES;
-			goto retry;
-		}
-		buf_region->flags = OFI_BUFPOOL_HUGEPAGES;
-	} else {
-retry:
-		ret = ofi_memalign((void **) &buf_region->alloc_region,
-				   roundup_power_of_two(pool->attr.alignment),
-				   pool->alloc_size);
-	}
+	ret = ofi_bufpool_region_alloc(buf_region);
 	if (ret) {
 		FI_DBG(&core_prov, FI_LOG_CORE, "Allocation failed: %s\n",
 		       fi_strerror(-ret));
@@ -146,10 +199,7 @@ err3:
 	if (pool->attr.free_fn)
 	    pool->attr.free_fn(buf_region);
 err2:
-	if (buf_region->flags & OFI_BUFPOOL_HUGEPAGES)
-		ofi_free_hugepage_buf(buf_region->alloc_region, pool->alloc_size);
-	else
-		ofi_freealign(buf_region->alloc_region);
+	ofi_bufpool_region_free(buf_region);
 err1:
 	free(buf_region);
 	return ret;
@@ -160,7 +210,6 @@ int ofi_bufpool_create_attr(struct ofi_bufpool_attr *attr,
 {
 	struct ofi_bufpool *pool;
 	size_t entry_sz;
-	ssize_t hp_size;
 
 	pool = calloc(1, sizeof(**buf_pool));
 	if (!pool)
@@ -185,15 +234,6 @@ int ofi_bufpool_create_attr(struct ofi_bufpool_attr *attr,
 		slist_init(&pool->free_list.entries);
 
 	pool->alloc_size = (pool->attr.chunk_cnt + 1) * pool->entry_size;
-	hp_size = ofi_get_hugepage_size();
-	if (hp_size <= 0 || pool->alloc_size < hp_size)
-		pool->attr.flags &= ~OFI_BUFPOOL_HUGEPAGES;
-
-	if (pool->attr.flags & OFI_BUFPOOL_HUGEPAGES) {
-		pool->alloc_size = ofi_get_aligned_size(pool->alloc_size,
-							hp_size);
-	}
-
 	pool->region_size = pool->alloc_size - pool->entry_size;
 
 	*buf_pool = pool;
@@ -203,7 +243,6 @@ int ofi_bufpool_create_attr(struct ofi_bufpool_attr *attr,
 void ofi_bufpool_destroy(struct ofi_bufpool *pool)
 {
 	struct ofi_bufpool_region *buf_region;
-	int ret;
 	size_t i;
 
 	for (i = 0; i < pool->region_cnt; i++) {
@@ -214,19 +253,7 @@ void ofi_bufpool_destroy(struct ofi_bufpool *pool)
 		if (pool->attr.free_fn)
 			pool->attr.free_fn(buf_region);
 
-		if (buf_region->flags & OFI_BUFPOOL_HUGEPAGES) {
-			ret = ofi_free_hugepage_buf(buf_region->alloc_region,
-						    pool->alloc_size);
-			if (ret) {
-				FI_DBG(&core_prov, FI_LOG_CORE,
-				       "Huge page free failed: %s\n",
-				       fi_strerror(-ret));
-				assert(0);
-			}
-		} else {
-			ofi_freealign(buf_region->alloc_region);
-		}
-
+		ofi_bufpool_region_free(buf_region);
 		free(buf_region);
 	}
 	free(pool->region_table);

--- a/src/unix/osd.c
+++ b/src/unix/osd.c
@@ -120,6 +120,24 @@ int fi_wait_cond(pthread_cond_t *cond, pthread_mutex_t *mut, int timeout_ms)
 	return pthread_cond_timedwait(cond, mut, &ts);
 }
 
+int ofi_mmap_anon_pages(void **memptr, size_t size, int flags)
+{
+	*memptr = mmap(NULL, size, PROT_READ | PROT_WRITE,
+		MAP_PRIVATE | MAP_ANONYMOUS | flags, -1, 0);
+	if (OFI_UNLIKELY(*memptr == MAP_FAILED)) {
+		return -errno;
+	}
+	return FI_SUCCESS;
+}
+
+int ofi_unmap_anon_pages(void *memptr, size_t size)
+{
+	if (munmap(memptr, size)) {
+		return -errno;
+	}
+	return FI_SUCCESS;
+}
+
 int ofi_shm_map(struct util_shm *shm, const char *name, size_t size,
 		int readonly, void **mapped)
 {


### PR DESCRIPTION
This set of changes is required to fix an issue involving fork support in the efa provider.

All changes apply cleanly (modulo a bit of context fuzz).  Original reviews:
- https://github.com/ofiwg/libfabric/pull/7547
- https://github.com/ofiwg/libfabric/pull/7558
- https://github.com/ofiwg/libfabric/pull/7570