### PR TITLE
prov/opx: Correctly disable OPX if unsupported.

### DIFF
--- a/prov/opx/configure.m4
+++ b/prov/opx/configure.m4
@@ -44,7 +44,13 @@ AC_DEFUN([FI_OPX_CONFIGURE],[
 	opx_happy=0
 	opx_direct=0
 
-	AS_IF([test x"$enable_opx" != x"no"],[
+
+	dnl OPX hardware is not supported for MacOS or FreeBSD,
+	dnl and is not supported for non-x86 processors.
+	AS_IF([test "x$macos" = "x1"],[opx_happy=0],
+		[test "x$freebsd" = "x1"],[opx_happy=0],
+		[test x$host_cpu != xx86_64],[opx_happy=0],
+		[test x"$enable_opx" != x"no"],[
 
 		AC_MSG_CHECKING([for opx provider])
 
@@ -91,6 +97,7 @@ AC_DEFUN([FI_OPX_CONFIGURE],[
 		AC_SUBST(opx_reliability, [$OPX_RELIABILITY])
 		AC_DEFINE_UNQUOTED(OPX_RELIABILITY, [$OPX_RELIABILITY], [fabric direct reliability])
 
+		opx_happy=1
 		FI_CHECK_PACKAGE([opx_uuid],
 			[uuid/uuid.h],
 		   	[uuid],
@@ -98,12 +105,18 @@ AC_DEFUN([FI_OPX_CONFIGURE],[
 		   	[],
 		   	[],
 		   	[],
-		   	[opx_happy=1],
+		   	[],
+		   	[opx_happy=0])
+		FI_CHECK_PACKAGE([opx_numa],
+			[numa.h],
+		   	[numa],
+		   	[numa_node_of_cpu],
+		   	[],
+		   	[],
+		   	[],
+		   	[],
 		   	[opx_happy=0])
 
-		dnl OPX hardware is not available for MacOS or FreeBSD.
-		AS_IF([test "x$macos" = "x1"],[opx_happy=0],[])
-		AS_IF([test "x$freebsd" = "x1"],[opx_happy=0],[])
 	])
 
 	AS_IF([test $opx_happy -eq 1], [$1], [$2])


### PR DESCRIPTION
Fixes issues #7573 and #7567 

Disables building OPX if building on a non-x86 machine even if it is running Linux, or if libnuma is not installed.

This should capture all missed dependencies. I went and did an ldd of fi_getinfo and got the list of libraries it depended on and I did not find any more lurking surprises.