### PR TITLE
fabtests/ubertest: fix ubertest writedata completion check

### DIFF
--- a/fabtests/ubertest/cq.c
+++ b/fabtests/ubertest/cq.c
@@ -71,11 +71,14 @@ bool ft_generates_rx_comp(void)
 	if (test_info.test_class & FI_ATOMIC)
 		return false;
 
-	if ((test_info.test_class & FI_RMA) &&
-	    !is_data_func(test_info.class_function) &&
-	    !(is_msg_func(test_info.class_function) &&
-	      test_info.msg_flags & FI_REMOTE_CQ_DATA))
-		return false;
+	if ((test_info.test_class & FI_RMA)) {
+		if (!is_data_func(test_info.class_function) &&
+		    !(is_msg_func(test_info.class_function) &&
+		      test_info.msg_flags & FI_REMOTE_CQ_DATA))
+			return false;
+		if (!(test_info.mode & FI_RX_CQ_DATA))
+			return true;
+	}
 
 	if (!(test_info.rx_cq_bind_flags & FI_SELECTIVE_COMPLETION))
 		return true;


### PR DESCRIPTION
When using SELECTIVE_COMPLETION with the writedata function,
ubertest was assuming that this should not generate a completion.
This is true only if RX_CQ_DATA is set (where an RMA data operation
consumes a recv buffer - if that buffer was set to be suppressed,
that should not generate a completion).
This adds a check to return true for an RMA with data if that mode bit
is not set. If it is set, we should drop into the regular SELECTIVE_COMPLETION
checks to see if the completion will be suppressed or not.

Signed-off-by: Alexia Ingerson <alexia.ingerson@intel.com>