### PR TITLE
fabtests: Document -C option

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -2878,8 +2878,7 @@ void ft_addr_usage()
 			"synchronization over the, optional, port");
 	FT_PRINT_OPTS_USAGE("-E[=<oob_port>]", "enable out-of-band address exchange only "
 			"over the, optional, port");
-	FT_PRINT_OPTS_USAGE("-C <number>", "number of connections to accept before "
-			"cleaning up a server");
+	FT_PRINT_OPTS_USAGE("-C <number>", "simultaneous connections to server");
 	FT_PRINT_OPTS_USAGE("-F <addr_format>", "Address format (default:FI_FORMAT_UNSPEC)");
 }
 

--- a/fabtests/man/fabtests.7.md
+++ b/fabtests/man/fabtests.7.md
@@ -403,6 +403,10 @@ the list available for that test.
 *-B <src_port>*
 : Specifies the port number of the local endpoint, overriding the default.
 
+*-C <num_connections>*
+: Specifies the number of simultaneous connections or communication
+  endpoints to the server.
+
 *-P <dst_port>*
 : Specifies the port number of the peer endpoint, overriding the default.
 


### PR DESCRIPTION
Update help text for -C option, which is re-used by
fi_rdm_stress, and include in the man page.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>