### PR TITLE
prov/hook_dmabuf: Cast away ioctl return

### DIFF
--- a/prov/hook/dmabuf_peer_mem/src/hook_dmabuf_peer_mem.c
+++ b/prov/hook/dmabuf_peer_mem/src/hook_dmabuf_peer_mem.c
@@ -67,7 +67,7 @@ static void dmabuf_reg_remove(int reg_fd, uint32_t fd)
 		.fd = fd,
 	};
 
-	ioctl(reg_fd, DMABUF_REG_IOCTL, &args);
+	(void) ioctl(reg_fd, DMABUF_REG_IOCTL, &args);
 }
 
 /*


### PR DESCRIPTION
Indicate that we don't care about the return value from ioctl
by casting the result to (void).  This addresses a coverity
report.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>