### PR TITLE
coverity: Update notification email

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -78,7 +78,7 @@ jobs:
           tar czvf libfabric.tgz cov-int
           curl \
             --form token=${{ secrets.COVERITY_SCAN_TOKEN }} \
-            --form email=oss@rajachan.com \
+            --form email=ofiwg@lists.openfabrics.org \
             --form file=@libfabric.tgz \
             --form version="main" \
             --form description="`$PWD/install/bin/fi_info -l`" \


### PR DESCRIPTION
Now that Coverity scans have been running relatively well, start sending
nightly reports to the OFIWG devel mailing list. This will mean an
additional email to the list each day, but we will not be spamming users
who will most likely be subscribed to the libfabric-users list.

Signed-off-by: Raghu Raja <raghu@enfabrica.net>