### PR TITLE
[v1.15.x] src/hmem_cuda_gdrcopy.c: fix incorrect usage of gdr_copy_from_mapping

### DIFF
--- a/src/hmem_cuda_gdrcopy.c
+++ b/src/hmem_cuda_gdrcopy.c
@@ -269,8 +269,9 @@ void cuda_gdrcopy_impl(uint64_t handle, void *devptr,
 	} else {
 		assert(dir == GDRCOPY_FROM_DEVICE);
 		global_gdrcopy_ops.gdr_copy_from_mapping(gdrcopy->mh,
+							 hostptr,
 							 gdrcopy_user_ptr,
-							 hostptr, len);
+							 len);
 	}
 }
 


### PR DESCRIPTION
cuda_gdrcopy_impl() call gdr_copy_from_mapping() with wrong
sequence of arguments. This patch fixed the issue.

Signed-off-by: Wei Zhang <wzam@amazon.com>
(cherry picked from commit 46d11f17505a8b409804fd039c2782883509f22b)