### PR TITLE
prov/shm: Properly chain the original signal handlers

### DIFF
--- a/prov/shm/src/smr_signal.h
+++ b/prov/shm/src/smr_signal.h
@@ -62,11 +62,8 @@ static void smr_handle_signal(int signum, siginfo_t *info, void *ucontext)
 	/* call the original handler */
 	if (old_action[signum].sa_flags & SA_SIGINFO)
 		old_action[signum].sa_sigaction(signum, info, ucontext);
-	else if (old_action[signum].sa_handler == SIG_DFL ||
-		 old_action[signum].sa_handler == SIG_IGN)
-		return;
 	else
-		old_action[signum].sa_handler(signum);
+		raise(signum);
 
 }
 


### PR DESCRIPTION
The shm signal handler cleans up shm allocations and UNIX domain sockets
before handing over to the original signal handler. Previously the orignal
signal handler was not called if it was SIG_DFL.

Change to a simplified logic that covers all scenarios.

Signed-off-by: Andrey Lobanov <andrey.lobanov@intel.com>
Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>

Replaces #7285