### PR TITLE
fabtests/ubertests: Fix string comparison to include length

### DIFF
--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -578,7 +578,8 @@ void ft_longopts_usage();
 
 #define TEST_SET_N_RETURN(str, len, val_str, val, type, data)	\
 	do {							\
-		if (!strncmp(str, val_str, len)) {	\
+		if (len == strlen(val_str) &&			\
+		    !strncmp(str, val_str, len)) {		\
 			*(type *)(data) = val;			\
 			return 0;				\
 		}						\

--- a/fabtests/ubertest/config.c
+++ b/fabtests/ubertest/config.c
@@ -438,7 +438,9 @@ static int ft_parse_key_val(char *config, jsmntok_t *token, char *test_set)
 	}
 
 	for (i = 0; i < sizeof(keys) / sizeof(keys[0]); i++) {
-		if (!strncmp(config + key_token->start, keys[i].str, strlen(keys[i].str))) {
+		if (FT_TOKEN_CHECK(config + key_token->start,
+				   key_token->end - key_token->start,
+				   keys[i].str)) {
 			key = &keys[i];
 			parsed++;
 			break;


### PR DESCRIPTION
When using strncmp with a non-null termianted string,
it may compare unintended characters and return a match.
Compare length of the the two strings before strncmp to
ensure exact match.

Signed-off-by: Chien Tin Tung <chien.tin.tung@intel.com>