### PR TITLE
contrib/intel/jenkins: Add an opt-out feature, tests, and better cleanup

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -325,8 +325,19 @@ pipeline {
     post {
         cleanup {
             withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
+                sh "rm -rf '${env.CI_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}/ci_middlewares'"
+                sh "rm -rf '${env.CI_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}/reg'"
+                sh "rm -rf '${env.CI_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}/dbg'"
+                sh "rm -rf '${env.CI_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}/dl'"
+            }
+        }
+        success {
+            withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
                 dir("${env.WORKSPACE}") {
-                    sh "rm -rf '${env.CI_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}/ci_middlewares'"
+                    deleteDir()
+                }
+                dir("${env.WORKSPACE}@tmp") {
+                    deleteDir()
                 }
             }
         }

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
     agent { node { label 'master' } }
     options {
         timestamps()
-        timeout(activity: true, time: 4, unit: 'HOURS')
+        timeout(activity: true, time: 1, unit: 'HOURS')
     }
     environment {
         JOB_CADENCE = 'PR'

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -1,5 +1,22 @@
 
 properties([disableConcurrentBuilds(abortPrevious: true)])
+def DO_RUN=1
+
+def skip() {
+    def changes = readFile "${env.WORKSPACE}/commit_id"
+    def changeStrings = new ArrayList<String>()
+
+    for (line in changes.readLines()) {
+        changeStrings.add(line)
+    }
+
+    echo "${changeStrings.toArray()}"
+    if (changeStrings.toArray().every { it =~ /(?:fabtests\/pytests|man|prov\/efa|prov\/opx).*$/ }) {
+        echo "DONT RUN!"
+        DO_RUN=0
+    }
+}
+
 
 pipeline {
     agent { node { label 'master' } }
@@ -16,6 +33,15 @@ pipeline {
             steps {
                 withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:PYTHONPATH']) {
                   sh """
+                    echo "${env.WORKSPACE}"
+                    echo "-----------------------------------------------------"
+                    echo "Copy build dirs."
+                    python3.7 contrib/intel/jenkins/build.py --build_item=builddir
+                    echo "Copy build dirs completed."
+                    echo "-----------------------------------------------------"
+
+                    python3.7 contrib/intel/jenkins/build.py --build_item=skip
+
                     echo "-----------------------------------------------------"
                     echo "Building libfabric reg."
                     python3.7 contrib/intel/jenkins/build.py --build_item=libfabric
@@ -37,17 +63,13 @@ pipeline {
                     echo "Building fabtests dl."
                     python3.7 contrib/intel/jenkins/build.py --build_item=fabtests --ofi_build_mode=dl
                     echo 'Fabtests builds completed.'
-
-                    echo "-----------------------------------------------------"
-                    echo "Copy build dirs."
-                    python3.7 contrib/intel/jenkins/build.py --build_item=builddir
-                    echo "Copy build dirs completed."
-                    echo "-----------------------------------------------------"
                   """
                 }
+                skip()
             }
         }
         stage('parallel-tests') {
+            when { equals expected: 1, actual: DO_RUN }
             parallel {
                 stage('MPI-verbs-rxm') {
                     agent {node {label 'mlx5'}}

--- a/contrib/intel/jenkins/build.py
+++ b/contrib/intel/jenkins/build.py
@@ -61,6 +61,13 @@ def copy_build_dir(install_path):
     shutil.copytree(ci_site_config.build_dir,
                     '{}/ci_middlewares'.format(install_path))
 
+def skip(install_path):
+    command = [
+                  '{}/skip.sh'.format(ci_site_config.testpath),
+                  '{}'.format(os.environ['WORKSPACE'])
+              ]
+    common.run_command(command)
+
 if __name__ == "__main__":
 #read Jenkins environment variables
     # In Jenkins,  JOB_NAME  = 'ofi_libfabric/master' vs BRANCH_NAME = 'master'
@@ -72,7 +79,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--build_item', help="build libfabric or fabtests",
-                         choices=['libfabric', 'fabtests', 'builddir'])
+                         choices=['libfabric', 'fabtests', 'builddir', 'skip'])
     parser.add_argument('--ofi_build_mode', help="select buildmode debug or dl", \
                         choices=['dbg', 'dl'])
 
@@ -101,4 +108,7 @@ if __name__ == "__main__":
 
     elif (build_item == 'builddir'):
         copy_build_dir(ci_middlewares_install_path)
+
+    elif (build_item == 'skip'):
+        skip(ci_middlewares_install_path)
 

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -405,8 +405,7 @@ class MpiTestIMB(MpiTests):
                                      'IO'
                                  ],
                              '3':[
-                                     # NBC fails MPI_ALLgather and during collective
-                                     #'NBC',
+                                     'NBC',
                                      'RMA',
                                      'MT'
                                  ]


### PR DESCRIPTION
Add IMB-NBC test back
Add cleanup of the workspace directory on successful only builds
Add an opt-out feature to allow the intel-jenkins-ci to only run for necessary changes