### PR TITLE
workflow: Change nroff-elves.yaml from cron job to on-push action

### DIFF
--- a/.github/workflows/nroff-elves.sh
+++ b/.github/workflows/nroff-elves.sh
@@ -47,7 +47,7 @@ done
 git config --global user.name "OFIWG Bot"
 git config --global user.email "ofiwg@lists.openfabrics.org"
 
-branch_name=pr/update-nroff-generated-man-pages
+branch_name=pr/update-nroff-generated-man-pages-$BASE_REF
 git checkout -b $branch_name
 
 set +e

--- a/.github/workflows/nroff-elves.yaml
+++ b/.github/workflows/nroff-elves.yaml
@@ -1,9 +1,10 @@
-name: GitHub Action Schedule
+name: Man Page Converter
 
 on:
-  schedule:
-    - cron: '0 * * * *'
-  workflow_dispatch:
+    push:
+        paths:
+          - 'man/*.md'
+    workflow_dispatch:
 
 jobs:
     nroff-elves-scheduled:
@@ -28,4 +29,4 @@ jobs:
             env:
               GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               REPO: ${{ github.event.repository.full_name }}
-              BASE_REF: ${{ github.event.repository.default_branch }}
+              BASE_REF: ${{ github.ref_name }}


### PR DESCRIPTION
Cron scheduled actions are only triggered from the default branch (main).
Change to push activated action so that the man pages on stable branches
can also be properly updated.

Use a more descriptive name for the action.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>