### PR TITLE
fabtest/rdm_stress: Use correct buffer to process recv completion

### DIFF
--- a/fabtests/functional/rdm_stress.c
+++ b/fabtests/functional/rdm_stress.c
@@ -1091,10 +1091,12 @@ static void *process_rpcs(void *context)
 				ret = handle_cq_error();
 			} else if (ret > 0) {
 				ret = 0;
-				if (comp.flags & FI_RECV)
+				if (comp.flags & FI_RECV) {
+					req = comp.op_context;
 					start_rpc(&req->hdr);
-				else
+				} else {
 					complete_rpc(comp.op_context);
+				}
 			}
 		} while (!ret && !(comp.flags & FI_RECV));
 	} while (!ret);


### PR DESCRIPTION
There are multiple server threads posting receives on the same receive
queue. Receive completion polled from one thread doesn't necessarily
match the receive posted in the same thread. Processing the wrong buffer
could lead to various errors including hang and segfault.

The correct buffer is available as the op_context of the completion
event.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>