### PR TITLE
contrib/intel/jenkins: disable opx and efa from build, update opt-out

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -3,7 +3,13 @@ properties([disableConcurrentBuilds(abortPrevious: true)])
 def DO_RUN=1
 
 def skip() {
-    def changes = readFile "${env.WORKSPACE}/commit_id"
+    def file = "${env.WORKSPACE}/commit_id}"
+    if (!fileExists(file)) {
+        echo "CI Run has not rebased with ofiwg/libfabric. Please Rebase."
+        return
+    }
+
+    def changes = readFile file
     def changeStrings = new ArrayList<String>()
 
     for (line in changes.readLines()) {

--- a/contrib/intel/jenkins/build.py
+++ b/contrib/intel/jenkins/build.py
@@ -31,6 +31,9 @@ def build_libfabric(libfab_install_path, mode):
     for prov in common.disabled_prov_list:
          config_cmd.append('--enable-{}=no'.format(prov))
 
+    config_cmd.append('--disable-opx') # we do not test opx in intel jenkins ci
+    config_cmd.append('--disable-efa') # we do not test efa in intel jenkins ci
+
     config_cmd.append('--enable-ze-dlopen')
 
     common.run_command(['./autogen.sh'])

--- a/contrib/intel/jenkins/build.py
+++ b/contrib/intel/jenkins/build.py
@@ -63,8 +63,9 @@ def copy_build_dir(install_path):
 
 def skip(install_path):
     command = [
-                  '{}/skip.sh'.format(ci_site_config.testpath),
-                  '{}'.format(os.environ['WORKSPACE'])
+                  '{}/skip1.sh'.format(ci_site_config.testpath),
+                  '{}'.format(os.environ['WORKSPACE']),
+                  'refs/pull/{}/head'.format(os.environ['CHANGE_ID'])
               ]
     common.run_command(command)
 


### PR DESCRIPTION
Disable opx and efa in the libfabric configure step for all three builds.
Change opt-out feature's comparison branch from ofiwig/libfabric.git HEAD to refs/pr/pr-num/head