### PR TITLE
contrib/intel/jenkins: remove opx & efa from ci builds, update opt-out feature

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -3,7 +3,13 @@ properties([disableConcurrentBuilds(abortPrevious: true)])
 def DO_RUN=1
 
 def skip() {
-    def changes = readFile "${env.WORKSPACE}/commit_id"
+    def file = "${env.WORKSPACE}/commit_id"
+    if (!fileExists(file)) {
+        echo "CI Run has not rebased with ofiwg/libfabric. Please Rebase."
+        return 1
+    }
+
+    def changes = readFile file
     def changeStrings = new ArrayList<String>()
 
     for (line in changes.readLines()) {
@@ -13,8 +19,10 @@ def skip() {
     echo "${changeStrings.toArray()}"
     if (changeStrings.toArray().every { it =~ /(?:fabtests\/pytests|man|prov\/efa|prov\/opx).*$/ }) {
         echo "DONT RUN!"
-        DO_RUN=0
+        return 0
     }
+
+    return 1
 }
 
 
@@ -29,18 +37,29 @@ pipeline {
     }
 
     stages {
-        stage ('build') {
+        stage ('opt-out') {
             steps {
-                withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:PYTHONPATH']) {
+                withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
                   sh """
-                    echo "${env.WORKSPACE}"
+                    python3.7 contrib/intel/jenkins/build.py --build_item=skip
+
+                  """
+                }
+                script {
+                    DO_RUN=skip()
+                }
+            }
+        }
+        stage ('build') {
+            when { equals expected: 1, actual: DO_RUN }
+            steps {
+                withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
+                  sh """
                     echo "-----------------------------------------------------"
                     echo "Copy build dirs."
                     python3.7 contrib/intel/jenkins/build.py --build_item=builddir
                     echo "Copy build dirs completed."
                     echo "-----------------------------------------------------"
-
-                    python3.7 contrib/intel/jenkins/build.py --build_item=skip
 
                     echo "-----------------------------------------------------"
                     echo "Building libfabric reg."
@@ -63,9 +82,9 @@ pipeline {
                     echo "Building fabtests dl."
                     python3.7 contrib/intel/jenkins/build.py --build_item=fabtests --ofi_build_mode=dl
                     echo 'Fabtests builds completed.'
+
                   """
                 }
-                skip()
             }
         }
         stage('parallel-tests') {
@@ -365,3 +384,4 @@ pipeline {
         }
     }
 }
+

--- a/contrib/intel/jenkins/build.py
+++ b/contrib/intel/jenkins/build.py
@@ -65,9 +65,15 @@ def copy_build_dir(install_path):
                     '{}/ci_middlewares'.format(install_path))
 
 def skip(install_path):
+    if os.getenv('CHANGE_TARGET') is not None:
+        change_target = os.environ['CHANGE_TARGET']
+    else:
+        change_target = os.environ['GIT_BRANCH']
+
     command = [
                   '{}/skip.sh'.format(ci_site_config.testpath),
-                  '{}'.format(os.environ['WORKSPACE'])
+                  '{}'.format(os.environ['WORKSPACE']),
+                  '{}'.format(change_target)
               ]
     common.run_command(command)
 

--- a/contrib/intel/jenkins/build.py
+++ b/contrib/intel/jenkins/build.py
@@ -31,6 +31,9 @@ def build_libfabric(libfab_install_path, mode):
     for prov in common.disabled_prov_list:
          config_cmd.append('--enable-{}=no'.format(prov))
 
+    config_cmd.append('--disable-opx') # we do not test opx in intel jenkins ci
+    config_cmd.append('--disable-efa') # we do not test efa in intel jenkins ci
+
     config_cmd.append('--enable-ze-dlopen')
 
     common.run_command(['./autogen.sh'])


### PR DESCRIPTION
remove opx and efa from ci builds
move opt-out feature to its own stage to be able to opt out of everything
update the skip.sh script to allow PRs to push to any ofiwg/libfabric branch