### PR TITLE
hmem: Introduce FI_HMEM_SYNAPSEAI API to libfabric

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -47,6 +47,7 @@ common_srcs =				\
 	src/hmem_cuda_gdrcopy.c		\
 	src/hmem_ze.c			\
 	src/hmem_neuron.c		\
+	src/hmem_synapseai.c		\
 	src/common.c			\
 	src/enosys.c			\
 	src/rbtree.c			\

--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -170,6 +170,22 @@ int neuron_hmem_cleanup(void);
 void *neuron_alloc(void **handle, size_t size);
 void neuron_free(void **handle);
 
+int synapseai_init(void);
+int synapseai_cleanup(void);
+int synapseai_copy_to_hmem(uint64_t device, void *dest, const void *src,
+                           size_t size);
+int synapseai_copy_from_hmem(uint64_t device, void *dest, const void *src,
+                             size_t size);
+bool synapseai_is_addr_valid(const void *addr, uint64_t *device,
+                             uint64_t *flags);
+int synapseai_get_handle(void *dev_buf, void **handle);
+int synapseai_open_handle(void **handle, uint64_t device, void **ipc_ptr);
+int synapseai_close_handle(void *ipc_ptr);
+int synapseai_host_register(void *ptr, size_t size);
+int synapseai_host_unregister(void *ptr);
+int synapseai_get_base_addr(const void *ptr, void **base, size_t *size);
+bool synapseai_is_ipc_enabled(void);
+
 static inline int ofi_memcpy(uint64_t device, void *dest, const void *src,
 			     size_t size)
 {

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -294,7 +294,7 @@ struct ofi_mr_entry {
 	uint8_t				data[];
 };
 
-#define OFI_HMEM_MAX 5
+#define OFI_HMEM_MAX 6
 
 struct ofi_mr_cache {
 	struct util_domain		*domain;

--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -127,6 +127,7 @@ enum fi_hmem_iface {
 	FI_HMEM_ROCR,
 	FI_HMEM_ZE,
 	FI_HMEM_NEURON,
+	FI_HMEM_SYNAPSEAI,
 };
 
 struct fi_mr_attr {
@@ -144,6 +145,7 @@ struct fi_mr_attr {
 		int		cuda;
 		int		ze;
 		int		neuron;
+		int		synapseai;
 	} device;
 };
 

--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -774,6 +774,7 @@
     <ClCompile Include="src\hmem_rocr.c" />
     <ClCompile Include="src\hmem_ze.c" />
     <ClCompile Include="src\hmem_neuron.c" />
+    <ClCompile Include="src\hmem_synapseai.c" />
     <ClCompile Include="src\indexer.c" />
     <ClCompile Include="src\iov.c" />
     <ClCompile Include="src\shared\ofi_str.c" />

--- a/libfabric.vcxproj.filters
+++ b/libfabric.vcxproj.filters
@@ -150,6 +150,9 @@
     <ClCompile Include="src\hmem_neuron.c">
       <Filter>Source Files\src</Filter>
     </ClCompile>
+    <ClCompile Include="src\hmem_synapseai.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
     <ClCompile Include="src\rbtree.c">
       <Filter>Source Files\src</Filter>
     </ClCompile>

--- a/man/fi_mr.3.md
+++ b/man/fi_mr.3.md
@@ -639,6 +639,9 @@ requested the FI_HMEM capability.
 *FI_HMEM_NEURON*
 : Uses the AWS Neuron SDK to support AWS Trainium devices.
 
+*FI_HMEM_SYNAPSEAI*
+: Uses the SynapseAI API to support Habana Gaudi devices.
+
 ## device
 Reserved 64 bits for device identifier if using non-standard HMEM interface.
 This field is ignore unless the iface field is valid.
@@ -651,6 +654,9 @@ This field is ignore unless the iface field is valid.
 
 *neuron*
 : For FI_HMEM_NEURON, the device identifier for AWS Trainium devices.
+
+*synapseai*
+: For FI_HMEM_SYNAPSEAI, the device identifier for Habana Gaudi hardware.
 
 # NOTES
 

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -109,6 +109,20 @@ struct ofi_hmem_ops hmem_ops[] = {
 		.copy_to_hmem = neuron_copy_to_dev,
 		.copy_from_hmem = neuron_copy_from_dev,
 	},
+	[FI_HMEM_SYNAPSEAI] = {
+		.initialized = false,
+		.init = synapseai_init,
+		.cleanup = synapseai_cleanup,
+		.copy_to_hmem = synapseai_copy_to_hmem,
+		.copy_from_hmem = synapseai_copy_from_hmem,
+		.get_handle = synapseai_get_handle,
+		.open_handle = synapseai_open_handle,
+		.close_handle = synapseai_close_handle,
+		.host_register = synapseai_host_register,
+		.host_unregister = synapseai_host_unregister,
+		.get_base_addr = synapseai_get_base_addr,
+		.is_ipc_enabled = synapseai_is_ipc_enabled,
+	},
 };
 
 static inline int ofi_copy_to_hmem(enum fi_hmem_iface iface, uint64_t device,

--- a/src/hmem_synapseai.c
+++ b/src/hmem_synapseai.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2022 Amazon.com, Inc. or its affiliates.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "ofi_hmem.h"
+#include "ofi.h"
+
+int synapseai_init(void)
+{
+	return -FI_ENOSYS;
+}
+
+int synapseai_cleanup(void)
+{
+	return -FI_ENOSYS;
+}
+
+int synapseai_copy_to_hmem(uint64_t device, void *dest, const void *src,
+                           size_t size)
+{
+	return -FI_ENOSYS;
+}
+
+int synapseai_copy_from_hmem(uint64_t device, void *dest, const void *src,
+                             size_t size)
+{
+	return -FI_ENOSYS;
+}
+
+bool synapseai_is_addr_valid(const void *addr, uint64_t *device,
+                             uint64_t *flags)
+{
+	return false;
+}
+
+int synapseai_get_handle(void *dev_buf, void **handle)
+{
+	return -FI_ENOSYS;
+}
+
+int synapseai_open_handle(void **handle, uint64_t device, void **ipc_ptr)
+{
+	return -FI_ENOSYS;
+}
+
+int synapseai_close_handle(void *ipc_ptr)
+{
+	return -FI_ENOSYS;
+}
+
+int synapseai_host_register(void *ptr, size_t size)
+{
+	return -FI_ENOSYS;
+}
+
+int synapseai_host_unregister(void *ptr)
+{
+	return -FI_ENOSYS;
+}
+
+int synapseai_get_base_addr(const void *ptr, void **base, size_t *size)
+{
+	return -FI_ENOSYS;
+}
+
+bool synapseai_is_ipc_enabled(void)
+{
+	return false;
+}


### PR DESCRIPTION
This PR adds a new hmem iface `FI_HMEM_SYNAPSEAI` for Habana Gaudi devices.

As an initialization step, this PR only defines dummy `hmem_ops` api functions for `FI_HMEM_SYNAPSEAI` which return `FI_ENOSYS` before real implementations.

Signed-off-by: Shi Jin <sjina@amazon.com>