### PR TITLE
[v1.15.x] man: add description of `neuron`.

### DIFF
--- a/man/fi_mr.3.md
+++ b/man/fi_mr.3.md
@@ -649,6 +649,9 @@ This field is ignore unless the iface field is valid.
 *ze*
 : For FI_HMEM_ZE, this is equivalent to the ze_device_handle_t index (int).
 
+*neuron*
+: For FI_HMEM_NEURON, the device identifier for AWS Trainium devices.
+
 # NOTES
 
 Direct access to an application's memory by a remote peer requires that


### PR DESCRIPTION
Add a missing bullet for `neuron` in `fi_mr_attr.device`.

Signed-off-by: Shi Jin <sjina@amazon.com>
(cherry picked from commit ca26217201afe12066eafe1c368022efd88edb40)