### PR TITLE
contrib/intel/jenkins: enable verbs mpich and impi osu tests

### DIFF
--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -550,10 +550,10 @@ class MpiTestOSU(MpiTests):
 
     @property
     def execute_condn(self):
-        return False
-        # see disable list for mpich, impi, ompi failures
-        #return True if (self.mpi == 'impi' or self.mpi == 'mpich') \
-        #            else False
+        # see disable list for ompi failures
+        return True if ((self.mpi == 'impi' or self.mpi == 'mpich') and \
+                        (self.core_prov == 'verbs')) \
+                    else False
 
     def execute_cmd(self):
         assert(self.osu_mpi_path)


### PR DESCRIPTION
Enable mpich and impi osu tests for verbs

Signed-off-by: Zach Dworkin <zachary.dworkin@intel.com>