### PR TITLE
[v1.15.x] prov/tcp: Fix assertion failure in CQ progress function

### DIFF
--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -276,8 +276,8 @@ static void tcpx_ep_flush_all_queues(struct tcpx_ep *ep)
 		tcpx_cq_report_error(&cq->util_cq, ep->cur_rx.entry,
 				     FI_ECANCELED);
 		tcpx_free_xfer(cq, ep->cur_rx.entry);
-		tcpx_reset_rx(ep);
 	}
+	tcpx_reset_rx(ep);
 	tcpx_ep_flush_queue(&ep->rx_queue, cq);
 	ofi_bsock_discard(&ep->bsock);
 }


### PR DESCRIPTION
The TCP provider sometimes fails the following assertion:
prov/tcp/src/tcpx_cq.c:69: tcpx_cq_progress: Assertion `ep->state == TCPX_CONNECTED' failed.

tcpx_cq_progress() expects data to be received from a connected endpoint
if 'ep->cur_rx.handler != NULL' and 'ep->cur_rx.entry == NULL'.

However, GDB gives a clear evidence that the EP is disconnected but 'cur_rx'
was not correctly reset:

(gdb) print ep->state
$1 = TCPX_DISCONNECTED
(gdb) print ep->cur_rx->entry
$2 = (struct tcpx_xfer_entry *) 0x0
(gdb) print ep->cur_rx->handler
$3 = (int (*)(struct tcpx_ep *)) 0x7ffff7ecce20 <tcpx_op_msg>

The problem occurs because tcpx_ep_flush_all_queues() resets 'cur_rx'
only if 'cur_rx.entry != NULL'. However, cur_rx.entry may be NULL,
but cur_rx.handler may contain a valid pointer according to GDB.

The fix is to always call tcpx_reset_rx() when flushing the EP's
queues, which will ensure that cur_rx.handler and cur_rx.entry
will be always NULL after the endpoint is disconnected.

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>