### PR TITLE
contrib/intel/jenkins: make skip.sh default to upstream/main

### DIFF
--- a/contrib/intel/jenkins/build.py
+++ b/contrib/intel/jenkins/build.py
@@ -68,7 +68,7 @@ def skip(install_path):
     if os.getenv('CHANGE_TARGET') is not None:
         change_target = os.environ['CHANGE_TARGET']
     else:
-        change_target = os.environ['GIT_BRANCH']
+        change_target = 'main'
 
     command = [
                   '{}/skip.sh'.format(ci_site_config.testpath),


### PR DESCRIPTION
make skip.sh default to use upstream/main instead of upstream/GIT_BRANCH

upstream/GIT_BRANCH fills GIT_BRANCH with the user's branch name which doesnt match with anything
in private jobs