### PR TITLE
prov/efa: remove unused credit calculation

### DIFF
--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -92,8 +92,6 @@ void efa_rdm_peer_init(struct rdm_peer *peer, struct rxr_ep *ep, struct efa_conn
 					 conn->ep_addr);
 
 	ofi_recvwin_buf_alloc(&peer->robuf, rxr_env.recvwin_size);
-	peer->rx_credits = rxr_env.rx_window_size;
-	peer->tx_credits = rxr_env.tx_max_credits;
 	dlist_init(&peer->outstanding_tx_pkts);
 	dlist_init(&peer->rx_unexp_list);
 	dlist_init(&peer->rx_unexp_tagged_list);

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -110,8 +110,6 @@ static inline void rxr_poison_mem_region(uint32_t *ptr, size_t size)
 #define RXR_RAND_MAX_TIMEOUT		(120)
 
 /* bounds for flow control */
-#define RXR_DEF_MAX_RX_WINDOW		(128)
-#define RXR_DEF_MAX_TX_CREDITS		(64)
 #define RXR_DEF_MIN_TX_CREDITS		(32)
 
 /*
@@ -209,9 +207,7 @@ extern struct fi_fabric_attr rxr_fabric_attr;
 extern struct util_prov rxr_util_prov;
 
 struct rxr_env {
-	int rx_window_size;
 	int tx_min_credits;
-	int tx_max_credits;
 	int tx_queue_size;
 	int use_device_rdma;
 	int use_zcpy_rx;
@@ -313,8 +309,6 @@ struct rdm_peer {
 	size_t efa_outstanding_tx_ops;	/* tracks outstanding tx ops to this peer on EFA device */
 	size_t shm_outstanding_tx_ops;  /* tracks outstanding tx ops to this peer on SHM */
 	struct dlist_entry outstanding_tx_pkts; /* a list of outstanding tx pkts to the peer */
-	uint16_t tx_credits;		/* available send credits */
-	uint16_t rx_credits;		/* available credits to allocate */
 	uint64_t rnr_backoff_begin_ts;	/* timestamp for RNR backoff period begin */
 	uint64_t rnr_backoff_wait_time;	/* how long the RNR backoff period last */
 	int rnr_queued_pkt_cnt;		/* queued RNR packet count */
@@ -380,8 +374,6 @@ struct rxr_rx_entry {
 	uint64_t bytes_copied;
 	uint64_t bytes_queued;
 	int64_t window;
-	uint16_t credit_request;
-	int credit_cts;
 
 	uint64_t total_len;
 
@@ -464,8 +456,6 @@ struct rxr_tx_entry {
 	uint64_t bytes_acked;
 	uint64_t bytes_sent;
 	int64_t window;
-	uint16_t credit_request;
-	uint16_t credit_allocated;
 
 	uint64_t total_len;
 
@@ -738,10 +728,6 @@ struct rxr_ep {
 	 * It exists because posting RX packets by bulk is more efficient.
 	 */
 	size_t efa_rx_pkts_to_post;
-	/* number of buffers available for large messages */
-	size_t available_data_bufs;
-	/* Timestamp of when available_data_bufs was exhausted. */
-	uint64_t available_data_bufs_ts;
 
 	/* number of outstanding tx ops on efa device */
 	size_t efa_outstanding_tx_ops;
@@ -911,9 +897,6 @@ void rxr_ep_progress_internal(struct rxr_ep *rxr_ep);
 
 int rxr_ep_post_user_recv_buf(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,
 			      uint64_t flags);
-
-int rxr_ep_set_tx_credit_request(struct rxr_ep *rxr_ep,
-				 struct rxr_tx_entry *tx_entry);
 
 int rxr_ep_determine_rdma_support(struct rxr_ep *ep, fi_addr_t addr,
 				  struct rdm_peer *peer);

--- a/prov/efa/src/rxr/rxr_cq.c
+++ b/prov/efa/src/rxr/rxr_cq.c
@@ -811,14 +811,8 @@ void rxr_cq_write_tx_completion(struct rxr_ep *ep,
 
 void rxr_cq_handle_tx_completion(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry)
 {
-	struct rdm_peer *peer;
-
 	if (tx_entry->state == RXR_TX_SEND)
 		dlist_remove(&tx_entry->entry);
-
-	peer = rxr_ep_get_peer(ep, tx_entry->addr);
-	assert(peer);
-	peer->tx_credits += tx_entry->credit_allocated;
 
 	if (tx_entry->cq_entry.flags & FI_READ) {
 		/*

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -86,6 +86,15 @@ static void rxr_init_env(void)
 	};
 
 	fi_param_get_int(&rxr_prov, "tx_min_credits", &rxr_env.tx_min_credits);
+	if (rxr_env.tx_min_credits <= 0) {
+		FI_WARN(&rxr_prov, FI_LOG_EP_DATA,
+			"FI_EFA_TX_MIN_CREDITS was set to %d, which is <= 0."
+			"This value will cause EFA communication to deadlock."
+			"To avoid that, the variable was reset to %d\n",
+			rxr_env.tx_min_credits, RXR_DEF_MIN_TX_CREDITS);
+		rxr_env.tx_min_credits = RXR_DEF_MIN_TX_CREDITS;
+	}
+
 	fi_param_get_int(&rxr_prov, "tx_queue_size", &rxr_env.tx_queue_size);
 	fi_param_get_int(&rxr_prov, "enable_shm_transfer", &rxr_env.enable_shm_transfer);
 	fi_param_get_int(&rxr_prov, "use_device_rdma", &rxr_env.use_device_rdma);

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -41,8 +41,6 @@
 struct fi_info *shm_info;
 
 struct rxr_env rxr_env = {
-	.rx_window_size	= RXR_DEF_MAX_RX_WINDOW,
-	.tx_max_credits = RXR_DEF_MAX_TX_CREDITS,
 	.tx_min_credits = RXR_DEF_MIN_TX_CREDITS,
 	.tx_queue_size = 0,
 	.enable_shm_transfer = 1,
@@ -87,8 +85,6 @@ static void rxr_init_env(void)
 		abort();
 	};
 
-	fi_param_get_int(&rxr_prov, "rx_window_size", &rxr_env.rx_window_size);
-	fi_param_get_int(&rxr_prov, "tx_max_credits", &rxr_env.tx_max_credits);
 	fi_param_get_int(&rxr_prov, "tx_min_credits", &rxr_env.tx_min_credits);
 	fi_param_get_int(&rxr_prov, "tx_queue_size", &rxr_env.tx_queue_size);
 	fi_param_get_int(&rxr_prov, "enable_shm_transfer", &rxr_env.enable_shm_transfer);
@@ -746,10 +742,6 @@ struct fi_provider rxr_prov = {
 
 EFA_INI
 {
-	fi_param_define(&rxr_prov, "rx_window_size", FI_PARAM_INT,
-			"Defines the maximum window size that a receiver will return for matched large messages. (Default: 128).");
-	fi_param_define(&rxr_prov, "tx_max_credits", FI_PARAM_INT,
-			"Defines the maximum number of credits a sender requests from a receiver (Default: 64).");
 	fi_param_define(&rxr_prov, "tx_min_credits", FI_PARAM_INT,
 			"Defines the minimum number of credits a sender requests from a receiver (Default: 32).");
 	fi_param_define(&rxr_prov, "tx_queue_size", FI_PARAM_INT,

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -306,10 +306,6 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 		 */
 	}
 
-	ret = rxr_ep_set_tx_credit_request(rxr_ep, tx_entry);
-	if (OFI_UNLIKELY(ret))
-		return ret;
-
 	ctrl_type = delivery_complete_requested ? RXR_DC_LONGCTS_MSGRTM_PKT : RXR_LONGCTS_MSGRTM_PKT;
 	tx_entry->rxr_flags |= RXR_LONGCTS_PROTOCOL;
 	return rxr_pkt_post_ctrl(rxr_ep, RXR_TX_ENTRY, tx_entry,

--- a/prov/efa/src/rxr/rxr_pkt_type_data.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_data.c
@@ -139,7 +139,6 @@ void rxr_pkt_proc_data(struct rxr_ep *ep,
 		       char *data, size_t seg_offset,
 		       size_t seg_size)
 {
-	struct rdm_peer *peer;
 	bool all_received = 0;
 	ssize_t err;
 
@@ -152,14 +151,7 @@ void rxr_pkt_proc_data(struct rxr_ep *ep,
 	assert(rx_entry->bytes_received <= rx_entry->total_len);
 	all_received = (rx_entry->bytes_received == rx_entry->total_len);
 
-	peer = rxr_ep_get_peer(ep, rx_entry->addr);
-	assert(peer);
-	peer->rx_credits += ofi_div_ceil(seg_size, ep->max_data_payload_size);
-
 	rx_entry->window -= seg_size;
-	if (ep->available_data_bufs < rxr_get_rx_pool_chunk_cnt(ep))
-		ep->available_data_bufs++;
-
 #if ENABLE_DEBUG
 	/* rx_entry can be released by rxr_pkt_copy_data_to_rx_entry
 	 * so the call to dlist_remove must happen before

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -211,6 +211,7 @@ ssize_t rxr_pkt_init_cts(struct rxr_ep *ep,
 
 	bytes_left = rx_entry->total_len - rx_entry->bytes_received;
 	cts_hdr->recv_length = MIN(bytes_left, rxr_env.tx_min_credits * ep->max_data_payload_size);
+	assert(cts_hdr->recv_length > 0);
 	pkt_entry->pkt_size = sizeof(struct rxr_cts_hdr);
 
 	/*

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -606,7 +606,7 @@ int rxr_pkt_init_longcts_rtm(struct rxr_ep *ep,
 	rtm_hdr = rxr_get_longcts_rtm_base_hdr(pkt_entry->pkt);
 	rtm_hdr->msg_length = tx_entry->total_len;
 	rtm_hdr->send_id = tx_entry->tx_id;
-	rtm_hdr->credit_request = tx_entry->credit_request;
+	rtm_hdr->credit_request = rxr_env.tx_min_credits;
 	return 0;
 }
 
@@ -1251,8 +1251,6 @@ ssize_t rxr_pkt_proc_matched_rtm(struct rxr_ep *ep,
 	ep->rx_pending++;
 #endif
 	rx_entry->state = RXR_RX_RECV;
-	/* we have noticed using the default value achieve better bandwidth */
-	rx_entry->credit_request = rxr_env.tx_min_credits;
 	ret = rxr_pkt_post_ctrl_or_queue(ep, RXR_RX_ENTRY, rx_entry, RXR_CTS_PKT, 0);
 
 	return ret;
@@ -1502,7 +1500,7 @@ static inline void rxr_pkt_init_longcts_rtw_hdr(struct rxr_ep *ep,
 	rtw_hdr->rma_iov_count = tx_entry->rma_iov_count;
 	rtw_hdr->msg_length = tx_entry->total_len;
 	rtw_hdr->send_id = tx_entry->tx_id;
-	rtw_hdr->credit_request = tx_entry->credit_request;
+	rtw_hdr->credit_request = rxr_env.tx_min_credits;
 	rxr_pkt_init_req_hdr(ep, tx_entry, pkt_type, pkt_entry);
 }
 
@@ -1820,7 +1818,6 @@ void rxr_pkt_handle_longcts_rtw_recv(struct rxr_ep *ep,
 #endif
 	rx_entry->state = RXR_RX_RECV;
 	rx_entry->tx_id = tx_id;
-	rx_entry->credit_request = rxr_env.tx_min_credits;
 	err = rxr_pkt_post_ctrl_or_queue(ep, RXR_RX_ENTRY, rx_entry, RXR_CTS_PKT, 0);
 	if (OFI_UNLIKELY(err)) {
 		FI_WARN(&rxr_prov, FI_LOG_CQ, "Cannot post CTS packet\n");

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -259,6 +259,7 @@ ssize_t rxr_rma_post_efa_emulated_read(struct rxr_ep *ep, struct rxr_tx_entry *t
 	if (tx_entry->total_len < ep->mtu_size - sizeof(struct rxr_readrsp_hdr)) {
 		err = rxr_pkt_post_ctrl(ep, RXR_TX_ENTRY, tx_entry, RXR_SHORT_RTR_PKT, 0, 0);
 	} else {
+		assert(rxr_env.tx_min_credits > 0);
 		rx_entry->window = MIN(tx_entry->total_len,
 				       rxr_env.tx_min_credits * ep->max_data_payload_size);
 		tx_entry->rma_window = rx_entry->window;


### PR DESCRIPTION
The credit calculation in flow control in long-CTS message protocol
is not actually being used because the default tx_min_credits yieds
better bandwidth.

This patch removed it to simplify the code.

Signed-off-by: Wei Zhang <wzam@amazon.com>