### PR TITLE
contrib/intel/jenkins: Add psm3 provider testing to CI

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -245,6 +245,27 @@ pipeline {
                         }
                     }
                 }
+                stage('psm3') {
+                    agent {node {label 'mlx5'}}
+                    options { skipDefaultCheckout() }
+                    steps {
+                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
+                        {
+                          sh """
+                            env
+                            (
+                                export PSM3_IDENTIFY=1
+                                export FI_LOG_LEVEL=info
+                                cd /opt${env.WORKSPACE}/contrib/intel/jenkins/
+                                python3.7 runtests.py --prov=psm3 --test=fabtests
+                                python3.7 runtests.py --prov=psm3 --test=fabtests --ofi_build_mode=dbg
+                                python3.7 runtests.py --prov=psm3 --test=fabtests --ofi_build_mode=dl
+                                echo "psm3 completed."
+                            )
+                          """
+                        }
+                    }
+                }
                 stage('MPI-tcp-rxm-1') {
                     agent {node {label 'eth'}}
                     options { skipDefaultCheckout() }
@@ -325,7 +346,7 @@ pipeline {
                         }
                     }
                 }
-                stage('oneCCL-tcp-rxm') {
+                stage('oneCCL') {
                     agent {node {label 'eth'}}
                     options { skipDefaultCheckout() }
                     steps {
@@ -337,6 +358,9 @@ pipeline {
                                 cd /opt${env.WORKSPACE}/contrib/intel/jenkins/
                                 python3.7 runtests.py --prov=tcp --util=rxm --test=oneccl
                                 echo "oneCCL tcp-rxm completed."
+                                python3.7 runtests.py --prov=psm3 --test=oneccl
+                                echo "oneCCL psm3 completed."
+                                echo "OneCCL completed."
                             )
                           """
                         }

--- a/contrib/intel/jenkins/common.py
+++ b/contrib/intel/jenkins/common.py
@@ -40,10 +40,10 @@ enabled_prov_list = [
     "tcp",
     "sockets",
     "udp",
-    "shm"
+    "shm",
+    "psm3"
 ]
 disabled_prov_list = [
-    "psm3",
     'usnic',
     'psm',
     'efa',

--- a/contrib/intel/jenkins/common.py
+++ b/contrib/intel/jenkins/common.py
@@ -50,6 +50,7 @@ disabled_prov_list = [
     'perf',
     'rstream',
     'hook_debug',
-    'bgq'
-    'mrail'
+    'bgq',
+    'mrail',
+    'opx'
 ]

--- a/contrib/intel/jenkins/runtests.py
+++ b/contrib/intel/jenkins/runtests.py
@@ -9,7 +9,7 @@ import common
 parser = argparse.ArgumentParser()
 
 parser.add_argument('--prov', help="core provider", choices=['verbs', \
-                     'tcp', 'udp', 'sockets', 'shm'])
+                     'tcp', 'udp', 'sockets', 'shm', 'psm3'])
 parser.add_argument('--util', help="utility provider", choices=['rxd', 'rxm'])
 parser.add_argument('--ofi_build_mode', help="specify the build configuration", \
                     choices = ['dbg', 'dl'])

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -60,6 +60,8 @@ class FiInfoTest(Test):
     def options(self):
         if (self.util_prov):
             opts  = "-f {} -p {};{}".format(self.fabric, self.core_prov, self.util_prov)
+        elif (self.core_prov == 'psm3'):
+            opts = "-p {}".format(self.core_prov)
         else:
             opts = "-f {} -p {}".format(self.fabric, self.core_prov)
 

--- a/fabtests/test_configs/psm3/psm3.exclude
+++ b/fabtests/test_configs/psm3/psm3.exclude
@@ -15,3 +15,6 @@ scalable_ep
 shared_av
 rdm_cntr_pingpong
 multi_recv
+rdm_tagged_peek
+dgram_waitset
+cq_data


### PR DESCRIPTION
- Adding psm3 provider testing to the CI.
- fi_info -f <fabric> option for psm3 results in failure because mlx5 is not considered 
  as a supported fabric name. Hence removed -f option for psm3.
- Three tests are hanging and hence failing for psm3: fi_cq_data, fi_rdm_tagged_peek 
   and fi_dgram_waitset. These tests are added to the exclude file until the bug is resolved.
   An issue is open on github for the same.
- opx provider was built in libfabric but we do not support/test it and hence removed 
  it from the CI build resulting in 6 minutes shorter build time.