### PR TITLE
log: Logging functions can be imported with fi_import_fid()

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -36,8 +36,10 @@ else !HAVE_LD_VERSION_SCRIPT
 endif !HAVE_LD_VERSION_SCRIPT
 
 rdmaincludedir = $(includedir)/rdma
+providersincludedir = $(rdmaincludedir)/providers
 
 rdmainclude_HEADERS =
+providersinclude_HEADERS =
 
 # internal utility functions shared by in-tree providers:
 common_srcs =				\
@@ -209,6 +211,9 @@ rdmainclude_HEADERS += \
 	$(top_srcdir)/include/rdma/fi_errno.h \
 	$(top_srcdir)/include/rdma/fi_tagged.h \
 	$(top_srcdir)/include/rdma/fi_trigger.h
+providersinclude_HEADERS += \
+	$(top_srcdir)/include/rdma/providers/fi_prov.h \
+	$(top_srcdir)/include/rdma/providers/fi_log.h
 
 if HAVE_DIRECT
 nodist_rdmainclude_HEADERS = \

--- a/include/ofi.h
+++ b/include/ofi.h
@@ -415,6 +415,8 @@ size_t ofi_vrb_speed(uint8_t speed, uint8_t width);
 
 int ofi_open_log(uint32_t version, void *attr, size_t attr_len,
 		 uint64_t flags, struct fid **fid, void *context);
+void ofi_tostr_log_level(char *buf, size_t len, enum fi_log_level level);
+void ofi_tostr_log_subsys(char *buf, size_t len, enum fi_log_subsys subsys);
 
 #ifdef __cplusplus
 }

--- a/include/ofi.h
+++ b/include/ofi.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2013-2018 Intel Corporation. All rights reserved.
  * Copyright (c) 2016-2018 Cisco Systems, Inc. All rights reserved.
  * Copyright (c) 2019 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright (c) 2022 DataDirect Networks, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -411,6 +412,9 @@ static inline uint32_t ofi_xorshift_random_r(uint32_t *seed)
 uint32_t ofi_generate_seed(void);
 
 size_t ofi_vrb_speed(uint8_t speed, uint8_t width);
+
+int ofi_open_log(uint32_t version, void *attr, size_t attr_len,
+		 uint64_t flags, struct fid **fid, void *context);
 
 #ifdef __cplusplus
 }

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -44,12 +44,16 @@
 #ifdef __GNUC__
 #define FI_DEPRECATED_FUNC __attribute__((deprecated))
 #define FI_DEPRECATED_FIELD __attribute__((deprecated))
+#define FI_FORMAT_PRINTF(string, first) \
+	__attribute__ ((__format__ (__printf__, (string), (first))))
 #elif defined(_MSC_VER)
 #define FI_DEPRECATED_FUNC __declspec(deprecated)
 #define FI_DEPRECATED_FIELD
+#define FI_FORMAT_PRINTF(string, first)
 #else
 #define FI_DEPRECATED_FUNC
 #define FI_DEPRECATED_FIELD
+#define FI_FORMAT_PRINTF(string, first)
 #endif
 
 #if defined(__GNUC__) && !defined(__clang__)

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2013-2017 Intel Corporation. All rights reserved.
  * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
  * (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+ * Copyright (c) 2022 DataDirect Networks, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -738,6 +739,8 @@ enum fi_type {
 	FI_TYPE_COLLECTIVE_OP,
 	FI_TYPE_HMEM_IFACE,
 	FI_TYPE_CQ_FORMAT,
+	FI_TYPE_LOG_LEVEL,
+	FI_TYPE_LOG_SUBSYS,
 };
 
 char *fi_tostr(const void *data, enum fi_type datatype);

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -531,6 +531,7 @@ enum {
 	FI_CLASS_MEM_MONITOR,
 	FI_CLASS_PEER_CQ,
 	FI_CLASS_PEER_SRX,
+	FI_CLASS_LOG,
 };
 
 struct fi_eq_attr;

--- a/include/rdma/fi_ext.h
+++ b/include/rdma/fi_ext.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021 Intel Corporation. All rights reserved.
  * Copyright (c) 2021 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright (c) 2022 DataDirect Networks, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -37,6 +38,8 @@
 #include <stdbool.h>
 #include <rdma/fabric.h>
 #include <rdma/fi_eq.h>
+#include <rdma/providers/fi_prov.h>
+#include <rdma/providers/fi_log.h>
 
 
 #ifdef __cplusplus
@@ -195,6 +198,28 @@ struct fi_peer_srx_context {
 	struct fid_peer_srx *srx;
 };
 
+/*
+ * System logging import extension:
+ * To use, open logging fid and import.
+ */
+
+#define FI_LOG_PROV_FILTERED (1ULL << 0) /* Filter provider */
+
+struct fi_ops_log {
+	size_t size;
+	int (*enabled)(const struct fi_provider *prov, enum fi_log_level level,
+		       enum fi_log_subsys subsys, uint64_t flags);
+	int (*ready)(const struct fi_provider *prov, enum fi_log_level level,
+		     enum fi_log_subsys subsys, uint64_t flags, uint64_t *showtime);
+	void (*log)(const struct fi_provider *prov, enum fi_log_level level,
+		    enum fi_log_subsys subsys, const char *func, int line,
+		    const char *msg);
+};
+
+struct fid_logging {
+	struct fid          fid;
+	struct fi_ops_log   *ops;
+};
 
 #ifdef __cplusplus
 }

--- a/include/rdma/fi_ext.h
+++ b/include/rdma/fi_ext.h
@@ -221,6 +221,31 @@ struct fid_logging {
 	struct fi_ops_log   *ops;
 };
 
+static inline int fi_import(uint32_t version, const char *name, void *attr,
+			    size_t attr_len, uint64_t flags, struct fid *fid,
+			    void *context)
+{
+	struct fid *open_fid;
+	int ret;
+
+	ret = fi_open(version, name, attr, attr_len, flags, &open_fid, context);
+	if (ret != FI_SUCCESS)
+	    return ret;
+
+	ret = fi_import_fid(open_fid, fid, flags);
+	fi_close(open_fid);
+	return ret;
+}
+
+static inline int fi_import_log(uint32_t version, uint64_t flags,
+				struct fid_logging *log_fid)
+{
+	log_fid->fid.fclass = FI_CLASS_LOG;
+	log_fid->ops->size = sizeof(struct fi_ops_log);
+
+	return fi_import(version, "logging", NULL, 0, flags, &log_fid->fid, log_fid);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/rdma/providers/fi_log.h
+++ b/include/rdma/providers/fi_log.h
@@ -72,7 +72,7 @@ int fi_log_ready(const struct fi_provider *prov, enum fi_log_level level,
 		 enum fi_log_subsys subsys, uint64_t *showtime);
 void fi_log(const struct fi_provider *prov, enum fi_log_level level,
 	    enum fi_log_subsys subsys, const char *func, int line,
-	    const char *fmt, ...) __attribute__ ((__format__ (__printf__, 6, 7)));
+	    const char *fmt, ...) FI_FORMAT_PRINTF(6, 7);
 
 #define FI_LOG(prov, level, subsystem, ...)				\
 	do {								\

--- a/man/fi_fabric.3.md
+++ b/man/fi_fabric.3.md
@@ -171,6 +171,12 @@ datatype or field value.
 *FI_TYPE_CQ_FORMAT*
 : enum fi_cq_format
 
+*FI_TYPE_LOG_LEVEL*
+: enum fi_log_level
+
+*FI_TYPE_LOG_SUBSYS*
+: enum fi_log_subsys
+
 fi_tostr() will return a pointer to an internal libfabric buffer that
 should not be modified, and will be overwritten the next time
 fi_tostr() is invoked.  fi_tostr() is not thread safe.

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -174,7 +174,7 @@ static int ofi_find_name(char **names, const char *name)
 /* matches if names[i] == "xxx;yyy" and name == "xxx" */
 static int ofi_find_layered_name(char **names, const char *name)
 {
-	int i;	
+	int i;
 	size_t len;
 
 	len = strlen(name);
@@ -1372,6 +1372,9 @@ int DEFAULT_SYMVER_PRE(fi_open)(uint32_t version, const char *name,
 	if (!strcasecmp("mr_cache", name))
 		return ofi_open_mr_cache(version, attr, attr_len,
 					 flags, fid, context);
+	if (!strcasecmp("logging", name))
+		return ofi_open_log(version, attr, attr_len,
+				    flags, fid, context);
 
 	return -FI_ENOSYS;
 }

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014-2017 Intel Corp., Inc.  All rights reserved.
  * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2022 DataDirect Networks, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -867,6 +868,12 @@ char *DEFAULT_SYMVER_PRE(fi_tostr_r)(char *buf, size_t len,
 		break;
 	case FI_TYPE_CQ_FORMAT:
 		ofi_tostr_cq_format(buf, len, *enumval);
+		break;
+	case FI_TYPE_LOG_LEVEL:
+		ofi_tostr_log_level(buf, len, *enumval);
+		break;
+	case FI_TYPE_LOG_SUBSYS:
+		ofi_tostr_log_subsys(buf, len, *enumval);
 		break;
 	default:
 		ofi_strncatf(buf, len, "Unknown type");

--- a/src/log.c
+++ b/src/log.c
@@ -293,6 +293,22 @@ unlock:
 	return ret;
 }
 
+void ofi_tostr_log_level(char *buf, size_t len, enum fi_log_level level)
+{
+    if (level >= FI_LOG_MAX)
+	ofi_strncatf(buf, len, "Unknown");
+    else
+	ofi_strncatf(buf, len, log_levels[level]);
+}
+
+void ofi_tostr_log_subsys(char *buf, size_t len, enum fi_log_subsys subsys)
+{
+    if (subsys >= FI_LOG_SUBSYS_MAX)
+	ofi_strncatf(buf, len, "Unknown");
+    else
+	ofi_strncatf(buf, len, log_subsys[subsys]);
+}
+
 void fi_log_fini(void)
 {
 	ofi_free_filter(&prov_log_filter);


### PR DESCRIPTION
This PR allows for an application to override the logging functions using fi_open()/fi_import_fid()

Fixes #6525