### PR TITLE
src/hmem_cuda.c: return FI_ENOSYS for cudaErrorStubLibrary

### DIFF
--- a/src/hmem_cuda.c
+++ b/src/hmem_cuda.c
@@ -431,6 +431,11 @@ static int cuda_hmem_verify_devices(void)
 	case cudaErrorNoDevice:
 		return -FI_ENOSYS;
 
+	case cudaErrorStubLibrary:
+		FI_INFO(&core_prov, FI_LOG_CORE,
+			"CUDA driver is a stub library\n");
+		return -FI_ENOSYS;
+
 	default:
 		FI_WARN(&core_prov, FI_LOG_CORE,
 			"Failed to perform cudaGetDeviceCount: %s:%s\n",


### PR DESCRIPTION
Currently, cuda_hmem_verify_devices() returns FI_ENOSYS
for cudaErrorNoDevice only, and returns FI_EIO for other
cuda error code. However, users may install
cuda with toolkit only and use the stub library libcuda.so to
build libfabric to validate the compilation of cuda build.

In this case it is expected that users will not run libfabric
with cuda support in runtime, and it is not necessary to raise
warning and return `FI_EIO`.

This patch adds an extra case for cudaErrorStubLibrary, and
returns `FI_ENOSYS` with printing messages in the info/debug log
level.

Signed-off-by: Shi Jin <sjina@amazon.com>