### PR TITLE
fabtests/pytest/pytest.ini: adjust default behavior of junit_xml

### DIFF
--- a/fabtests/pytest/pytest.ini
+++ b/fabtests/pytest/pytest.ini
@@ -8,3 +8,8 @@ markers =
     ubertest_all: ubertest tests run will all config
     ubertest_quick: ubertest tests run with quick config
     ubertest_verify: ubertest tests run with verify config
+junit_suite_name = fabtests
+junit_logging = all
+junit_log_passing_tests = true
+junit_duration_report = total
+junit_family = xunit1


### PR DESCRIPTION
This patch set default values for the junit_xml file written by
runfabtests.py, include test_suite name, whether to save log
for passed test.

Signed-off-by: Wei Zhang <wzam@amazon.com>