### PR TITLE
prov/efa: split hmem_support_status/mr/fork_support  into seperate header/source files

### DIFF
--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -798,6 +798,7 @@
     <ClCompile Include="prov\efa\src\efa_mr.c" />
     <ClCompile Include="prov\efa\src\efa_msg.c" />
     <ClCompile Include="prov\efa\src\efa_rma.c" />
+    <ClCompile Include="prov\efa\src\efa_fork_support.c" />
     <ClCompile Include="prov\efa\src\rxr\rxr_pkt_type_base.c" />
     <ClCompile Include="prov\efa\src\windows\efawin.c" />
     <ClCompile Include="prov\efa\src\rxr\rxr_atomic.c" />

--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -790,6 +790,7 @@
     <ClCompile Include="prov\efa\src\efa_av.c" />
     <ClCompile Include="prov\efa\src\efa_cm.c" />
     <ClCompile Include="prov\efa\src\efa_cq.c" />
+    <ClCompile Include="prov\efa\src\efa_hmem.c" />
     <ClCompile Include="prov\efa\src\efa_device.c" />
     <ClCompile Include="prov\efa\src\efa_domain.c" />
     <ClCompile Include="prov\efa\src\efa_ep.c" />

--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -32,6 +32,7 @@
 if HAVE_EFA
 _efa_files = \
 	prov/efa/src/efa_device.c \
+	prov/efa/src/efa_hmem.c \
 	prov/efa/src/efa_av.c \
 	prov/efa/src/efa_domain.c \
 	prov/efa/src/efa_cm.c \
@@ -61,6 +62,7 @@ _efa_files = \
 _efa_headers = \
 	prov/efa/src/efa.h \
 	prov/efa/src/efa_device.h \
+	prov/efa/src/efa_hmem.h \
 	prov/efa/src/rxr/rxr.h \
 	prov/efa/src/rxr/rxr_cntr.h \
 	prov/efa/src/rxr/rxr_rma.h \

--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -42,6 +42,7 @@ _efa_files = \
 	prov/efa/src/efa_msg.c \
 	prov/efa/src/efa_mr.c \
 	prov/efa/src/efa_rma.c \
+	prov/efa/src/efa_fork_support.c \
 	prov/efa/src/rxr/rxr_attr.c	\
 	prov/efa/src/rxr/rxr_init.c	\
 	prov/efa/src/rxr/rxr_domain.c	\
@@ -61,8 +62,9 @@ _efa_files = \
 
 _efa_headers = \
 	prov/efa/src/efa.h \
-	prov/efa/src/efa_device.h \
 	prov/efa/src/efa_hmem.h \
+	prov/efa/src/efa_device.h \
+	prov/efa/src/efa_fork_support.h \
 	prov/efa/src/rxr/rxr.h \
 	prov/efa/src/rxr/rxr_cntr.h \
 	prov/efa/src/rxr/rxr_rma.h \

--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -62,6 +62,7 @@ _efa_files = \
 
 _efa_headers = \
 	prov/efa/src/efa.h \
+	prov/efa/src/efa_mr.h \
 	prov/efa/src/efa_hmem.h \
 	prov/efa/src/efa_device.h \
 	prov/efa/src/efa_fork_support.h \

--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -64,6 +64,7 @@
 #include "ofi_util.h"
 #include "ofi_file.h"
 
+#include "efa_fork_support.h"
 #include "efa_device.h"
 #include "efa_hmem.h"
 #include "rxr.h"
@@ -434,17 +435,6 @@ ssize_t efa_post_flush(struct efa_ep *ep, struct ibv_send_wr **bad_wr);
 ssize_t efa_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t count, fi_addr_t *src_addr);
 
 ssize_t efa_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *entry, uint64_t flags);
-
-/*
- * ON will avoid using huge pages for bounce buffers, so that the libibverbs
- * fork support can be used safely.
- */
-enum efa_fork_support_status {
-	EFA_FORK_SUPPORT_OFF = 0,
-	EFA_FORK_SUPPORT_ON,
-	EFA_FORK_SUPPORT_UNNEEDED,
-};
-extern enum efa_fork_support_status efa_fork_status;
 
 static inline
 bool efa_ep_support_rdma_read(struct fid_ep *ep_fid)

--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -65,6 +65,7 @@
 #include "ofi_file.h"
 
 #include "efa_device.h"
+#include "efa_hmem.h"
 #include "rxr.h"
 #define EFA_PROV_NAME "efa"
 
@@ -156,11 +157,6 @@ struct efa_domain_base {
 	enum efa_domain_type	type;
 };
 
-struct efa_hmem_info {
-	bool initialized; 	/* do we support it at all */
-	bool p2p_supported;	/* do we support p2p with this device */
-};
-
 struct efa_domain {
 	struct util_domain	util_domain;
 	enum efa_domain_type	type;
@@ -172,7 +168,7 @@ struct efa_domain {
 	struct ofi_mr_cache	*cache;
 	struct efa_qp		**qp_table;
 	size_t			qp_table_sz_m1;
-	struct efa_hmem_info	hmem_info[OFI_HMEM_MAX];
+	struct efa_hmem_support_status	hmem_support_status[OFI_HMEM_MAX];
 };
 
 /**
@@ -641,7 +637,7 @@ static inline int efa_ep_use_p2p(struct efa_ep *ep, struct efa_mr *efa_mr)
 	if (efa_mr->peer.iface == FI_HMEM_SYSTEM)
 		return 1;
 
-	if (ep->domain->hmem_info[efa_mr->peer.iface].p2p_supported)
+	if (ep->domain->hmem_support_status[efa_mr->peer.iface].p2p_supported)
 		return (ep->hmem_p2p_opt != FI_HMEM_P2P_DISABLED);
 
 	if (ep->hmem_p2p_opt == FI_HMEM_P2P_REQUIRED) {

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -447,135 +447,6 @@ static int efa_mr_cache_init(struct efa_domain *domain, struct fi_info *info)
 	return 0;
 }
 
-static int efa_set_domain_hmem_info_cuda(struct efa_domain *domain)
-{
-#if HAVE_CUDA
-	cudaError_t cuda_ret;
-	void *ptr = NULL;
-	struct ibv_mr *ibv_mr;
-	int ibv_access = IBV_ACCESS_LOCAL_WRITE;
-	size_t len = ofi_get_page_size() * 2;
-	int ret;
-
-	if (!ofi_hmem_is_initialized(FI_HMEM_CUDA)) {
-		EFA_INFO(FI_LOG_DOMAIN,
-		         "FI_HMEM_CUDA is not initialized\n");
-		return 0;
-	}
-
-	if (domain->device->device_caps & EFADV_DEVICE_ATTR_CAPS_RDMA_READ)
-		ibv_access |= IBV_ACCESS_REMOTE_READ;
-
-	domain->hmem_info[FI_HMEM_CUDA].initialized = true;
-
-	cuda_ret = ofi_cudaMalloc(&ptr, len);
-	if (cuda_ret != cudaSuccess) {
-		EFA_WARN(FI_LOG_DOMAIN,
-			 "Failed to allocate CUDA buffer: %s\n",
-			 ofi_cudaGetErrorString(cuda_ret));
-		return -FI_ENOMEM;
-	}
-
-	ibv_mr = ibv_reg_mr(domain->ibv_pd, ptr, len, ibv_access);
-	if (!ibv_mr) {
-		EFA_WARN(FI_LOG_DOMAIN,
-			 "Failed to register CUDA buffer with the EFA device, FI_HMEM transfers that require peer to peer support will fail.\n");
-		ofi_cudaFree(ptr);
-		return 0;
-	}
-
-	ret = ibv_dereg_mr(ibv_mr);
-	ofi_cudaFree(ptr);
-	if (ret) {
-		EFA_WARN(FI_LOG_DOMAIN,
-			 "Failed to deregister CUDA buffer: %s\n",
-			 fi_strerror(-ret));
-		return ret;
-	}
-
-	domain->hmem_info[FI_HMEM_CUDA].p2p_supported = true;
-#endif
-	return 0;
-}
-
-static int efa_set_domain_hmem_info_neuron(struct efa_domain *domain)
-{
-#if HAVE_NEURON
-	struct ibv_mr *ibv_mr;
-	int ibv_access = IBV_ACCESS_LOCAL_WRITE;
-	void *handle;
-	void *ptr = NULL;
-	size_t len = ofi_get_page_size() * 2;
-	int ret;
-
-	if (!ofi_hmem_is_initialized(FI_HMEM_NEURON)) {
-		EFA_INFO(FI_LOG_DOMAIN,
-		         "FI_HMEM_NEURON is not initialized\n");
-		return 0;
-	}
-
-	if (domain->device->device_caps & EFADV_DEVICE_ATTR_CAPS_RDMA_READ) {
-		ibv_access |= IBV_ACCESS_REMOTE_READ;
-	} else {
-		EFA_WARN(FI_LOG_DOMAIN,
-			 "No EFA RDMA read support, transfers using AWS Neuron will fail.\n");
-		return 0;
-	}
-
-	domain->hmem_info[FI_HMEM_NEURON].initialized = true;
-
-	ptr = neuron_alloc(&handle, len);
-	if (!ptr)
-		return -FI_ENOMEM;
-
-	ibv_mr = ibv_reg_mr(domain->ibv_pd, ptr, len, ibv_access);
-	if (!ibv_mr) {
-		EFA_WARN(FI_LOG_DOMAIN,
-			 "Failed to register Neuron buffer with the EFA device, FI_HMEM transfers that require peer to peer support will fail.\n");
-		neuron_free(&handle);
-		return 0;
-	}
-
-	ret = ibv_dereg_mr(ibv_mr);
-	neuron_free(&handle);
-	if (ret) {
-		EFA_WARN(FI_LOG_DOMAIN,
-			 "Failed to deregister Neuron buffer: %s\n",
-			 fi_strerror(-ret));
-		return ret;
-	}
-
-	domain->hmem_info[FI_HMEM_NEURON].p2p_supported = true;
-#endif
-	return 0;
-}
-
-/*
- * Determine whether an HMEM device is initialized, and whether the provider
- * may support p2p transfers for that device. This state is used later when
- * determining how to initiate an HMEM transfer.
- *
- * @param domain efa_domain to run the check/store state
- * @return 0 on success, negative value on an unexpected error
- */
-static int efa_set_domain_hmem_info(struct efa_domain *domain)
-{
-	int ret;
-
-	if (!(domain->info->caps & FI_HMEM))
-		return 0;
-
-	ret = efa_set_domain_hmem_info_cuda(domain);
-	if (ret)
-		return ret;
-
-	ret = efa_set_domain_hmem_info_neuron(domain);
-	if (ret)
-		return ret;
-
-	return 0;
-}
-
 /* @brief Allocate a domain, open the device, and set it up based on the hints.
  *
  * This function creates a domain and uses the info struct to configure the
@@ -683,7 +554,7 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 	}
 
 	if (EFA_EP_TYPE_IS_RDM(info)) {
-		ret = efa_set_domain_hmem_info(domain);
+		ret = efa_hmem_support_status_update_all(domain->hmem_support_status);
 		if (ret) {
 			EFA_WARN(FI_LOG_DOMAIN,
 				 "efa_check_hmem_support failed: %s\n",

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -121,122 +121,6 @@ static struct fi_ops_domain efa_domain_ops = {
 	.query_collective = fi_no_query_collective,
 };
 
-/* @brief Setup the MR cache.
- *
- * This function enables the MR cache using the util MR cache code. Note that
- * if the call to ofi_mr_cache_init fails, we continue but disable the cache.
- *
- * @param efa_domain The EFA domain where cache ops should be set
- * @param info Validated info struct selected by the user
- * @return 0 on success, fi_errno on failure.
- */
-static int efa_mr_cache_init(struct efa_domain *domain, struct fi_info *info)
-{
-	struct ofi_mem_monitor *memory_monitors[OFI_HMEM_MAX] = {
-		[FI_HMEM_SYSTEM] = default_monitor,
-		[FI_HMEM_CUDA] = cuda_monitor,
-	};
-	int ret;
-
-	/* Both Open MPI (and possibly other MPI implementations) and
-	 * Libfabric use the same live binary patching to enable memory
-	 * monitoring, but the patching technique only allows a single
-	 * "winning" patch.  The Libfabric memhooks monitor will not
-	 * overwrite a previous patch, but instead return
-	 * -FI_EALREADY.  There are three cases of concern, and in all
-	 * but one of them, we can avoid changing the default monitor.
-	 *
-	 * (1) Upper layer does not patch, such as Open MPI 4.0 and
-	 * earlier.  In this case, the default monitor will be used,
-	 * as the default monitor is either not the memhooks monitor
-	 * (because the user specified a different monitor) or the
-	 * default monitor is the memhooks monitor, but we were able
-	 * to install the patches.  We will use the default monitor in
-	 * this case.
-	 *
-	 * (2) Upper layer does patch, but does not export a memory
-	 * monitor, such as Open MPI 4.1.0 and 4.1.1.  In this case,
-	 * if the default memory monitor is not memhooks, we will use
-	 * the default monitor.  If the default monitor is memhooks,
-	 * the patch will fail to apply, and we will change the
-	 * requested monitor to UFFD to avoid a broken configuration.
-	 * If the user explicitly requested memhooks, we will return
-	 * an error, as we can not satisfy that request.
-	 *
-	 * (3) Upper layer does patch and exports a memory monitor,
-	 * such as Open MPI 4.1.2 and later.  In this case, the
-	 * default monitor will have been changed from the memhooks
-	 * monitor to the imported monitor, so we will use the
-	 * imported monitor.
-	 *
-	 * The only known cases in which we will not use the default
-	 * monitor are Open MPI 4.1.0/4.1.1.
-	 *
-	 * It is possible that this could be better handled at the
-	 * mem_monitor level in Libfabric, but so far we have not
-	 * reached agreement on how that would work.
-	 */
-	if (default_monitor == memhooks_monitor) {
-		ret = memhooks_monitor->start(memhooks_monitor);
-		if (ret == -FI_EALREADY) {
-			if (cache_params.monitor) {
-				EFA_WARN(FI_LOG_DOMAIN,
-					 "Memhooks monitor requested via FI_MR_CACHE_MONITOR, but memhooks failed to\n"
-					 "install.  No working monitor availale.\n");
-				return -FI_ENOSYS;
-			}
-			EFA_INFO(FI_LOG_DOMAIN,
-				 "Detected potential memhooks monitor conflict. Switching to UFFD.\n");
-			memory_monitors[FI_HMEM_SYSTEM] = uffd_monitor;
-		}
-	} else if (default_monitor == NULL) {
-		/* TODO: Fail if we don't find a system monitor.  This
-		 * is a debatable decision, as the VERBS provider
-		 * falls back to a no-cache mode in this case.  We
-		 * fail the domain creation because the rest of the MR
-		 * code hasn't been audited to deal with a NULL
-		 * monitor.
-		 */
-		EFA_WARN(FI_LOG_DOMAIN,
-			 "No default SYSTEM monitor available.\n");
-		return -FI_ENOSYS;
-	}
-
-	domain->cache = (struct ofi_mr_cache *)calloc(1, sizeof(struct ofi_mr_cache));
-	if (!domain->cache)
-		return -FI_ENOMEM;
-
-	if (!efa_mr_max_cached_count)
-		efa_mr_max_cached_count = info->domain_attr->mr_cnt *
-					  EFA_MR_CACHE_LIMIT_MULT;
-	if (!efa_mr_max_cached_size)
-		efa_mr_max_cached_size = domain->device->ibv_attr.max_mr_size *
-					 EFA_MR_CACHE_LIMIT_MULT;
-	/*
-	 * XXX: we're modifying a global in the util mr cache? do we need an
-	 * API here instead?
-	 */
-	cache_params.max_cnt = efa_mr_max_cached_count;
-	cache_params.max_size = efa_mr_max_cached_size;
-	domain->cache->entry_data_size = sizeof(struct efa_mr);
-	domain->cache->add_region = efa_mr_cache_entry_reg;
-	domain->cache->delete_region = efa_mr_cache_entry_dereg;
-	ret = ofi_mr_cache_init(&domain->util_domain, memory_monitors,
-				domain->cache);
-	if (!ret) {
-		domain->util_domain.domain_fid.mr = &efa_domain_mr_cache_ops;
-		EFA_INFO(FI_LOG_DOMAIN, "EFA MR cache enabled, max_cnt: %zu max_size: %zu\n",
-			 cache_params.max_cnt, cache_params.max_size);
-	} else {
-		EFA_WARN(FI_LOG_DOMAIN, "EFA MR cache init failed: %s\n",
-		         fi_strerror(ret));
-		free(domain->cache);
-		domain->cache = NULL;
-	}
-
-	return 0;
-}
-
 /* @brief Allocate a domain, open the device, and set it up based on the hints.
  *
  * This function creates a domain and uses the info struct to configure the
@@ -356,9 +240,11 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 	 * If FI_MR_LOCAL is set, we do not want to use the MR cache.
 	 */
 	if (!app_mr_local && efa_mr_cache_enable) {
-		ret = efa_mr_cache_init(domain, info);
+		ret = efa_mr_cache_open(&domain->cache, domain);
 		if (ret)
 			goto err_free_info;
+
+		domain->util_domain.domain_fid.mr = &efa_domain_mr_cache_ops;
 	}
 
 	return 0;

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -37,8 +37,6 @@
 #include "efa.h"
 #include "rxr_cntr.h"
 
-enum efa_fork_support_status efa_fork_status = EFA_FORK_SUPPORT_OFF;
-
 static int efa_domain_close(fid_t fid)
 {
 	struct efa_domain *domain;
@@ -101,73 +99,6 @@ static int efa_open_device_by_name(struct efa_domain *domain, const char *name)
 	return 0;
 }
 
-/* @brief Check if rdma-core fork support is enabled and prevent fork
- * support from being enabled later.
- *
- * Register a temporary buffer and call ibv_fork_init() to determine
- * if fork support is enabled. Registering a buffer prevents future
- * calls to ibv_fork_init() from completing successfully.
- *
- * This relies on internal behavior in rdma-core and is a temporary workaround.
- *
- * @param domain_fid domain fid so we can register memory
- * @return 1 if fork support is enabled, 0 otherwise
- */
-static int efa_check_fork_enabled(struct fid_domain *domain_fid)
-{
-	struct fid_mr *mr;
-	char *buf;
-	int ret;
-	long page_size;
-
-	/* If ibv_is_fork_initialized is availble, check if the function
-	 * can exit early.
-	 */
-#if HAVE_IBV_IS_FORK_INITIALIZED == 1
-	enum ibv_fork_status fork_status = ibv_is_fork_initialized();
-
-	/* If fork support is enabled or unneeded, return. */
-	if (fork_status != IBV_FORK_DISABLED)
-		return fork_status == IBV_FORK_ENABLED;
-
-#endif /* HAVE_IBV_IS_FORK_INITIALIZED */
-
-	page_size = ofi_get_page_size();
-	if (page_size <= 0) {
-		EFA_WARN(FI_LOG_DOMAIN, "Unable to determine page size %ld\n",
-			 page_size);
-		return -FI_EINVAL;
-	}
-
-	buf = malloc(page_size);
-	if (!buf)
-		return -FI_ENOMEM;
-
-	ret = fi_mr_reg(domain_fid, buf, page_size,
-			FI_SEND, 0, 0, 0, &mr, NULL);
-	if (ret) {
-		free(buf);
-		return ret;
-	}
-
-	/*
-	 * libibverbs maintains a global variable to determine if any
-	 * registrations have occurred before ibv_fork_init() is called.
-	 * EINVAL is returned if a memory region was registered before
-	 * ibv_fork_init() was called and returns 0 if fork support is
-	 * initialized already.
-	 */
-	ret = ibv_fork_init();
-
-	fi_close(&mr->fid);
-	free(buf);
-
-	if (ret == EINVAL)
-		return 0;
-
-	return 1;
-}
-
 static struct fi_ops efa_fid_ops = {
 	.size = sizeof(struct fi_ops),
 	.close = efa_domain_close,
@@ -189,147 +120,6 @@ static struct fi_ops_domain efa_domain_ops = {
 	.query_atomic = fi_no_query_atomic,
 	.query_collective = fi_no_query_collective,
 };
-
-/* @brief Fork handler that is installed when EFA is loaded
- *
- * We register this fork handler so that users do not inadvertently trip over
- * memory corruption when fork is called. Calling fork() without enabling fork
- * support in rdma-core can cause corruption, even if the registered pages are
- * not used in the child process.
- *
- * It is critical that this fork handler is only installed once an EFA device
- * is present and selected. We don't want this to trigger when Libfabric is not
- * running on an EC2 instance.
- */
-static
-void efa_atfork_callback()
-{
-	static int visited = 0;
-
-	if (visited)
-		return;
-	visited = 1;
-
-	fprintf(stderr,
-		"A process has executed an operation involving a call\n"
-		"to the fork() system call to create a child process.\n"
-		"\n"
-		"As a result, the Libfabric EFA provider is operating in\n"
-		"a condition that could result in memory corruption or\n"
-		"other system errors.\n"
-		"\n"
-		"For the Libfabric EFA provider to work safely when fork()\n"
-		"is called please do one of the following:\n"
-		"1) Set the environment variable:\n"
-		"          FI_EFA_FORK_SAFE=1\n"
-		"and verify you are using rdma-core v31.1 or later.\n"
-		"\n"
-		"OR\n"
-		"2) Use Linux Kernel 5.13+ with rdma-core v35.0+\n"
-		"\n"
-		"Please note that enabling fork support may cause a\n"
-		"small performance impact.\n"
-		"\n"
-		"You may want to check with your application vendor to see\n"
-		"if an application-level alternative (of not using fork)\n"
-		"exists.\n"
-		"\n"
-		"Your job will now abort.\n");
-	abort();
-}
-
-#ifndef _WIN32
-
-/* @brief Check when fork is requested and abort in unsupported cases
- *
- * We check if user or another library asked or enabled fork support and
- * return failure if HUGEPAGES are also enabled as EFA provider does not support this case.
- *
- * In addition, we install a fork handler to ensure that we abort if another
- * library or process initiates a fork and we determined from previous logic
- * that we cannot support that.
- *
- * @param domain_fid domain fid so we can check register memory during initialization.
- * @return error number if we failed to initialize, 0 otherwise
- */
-static
-int efa_initialize_fork_support(struct fid_domain* domain_fid)
-{
-	static int fork_handler_installed = 0;
-	int ret;
-
-	/*
-	 * Call ibv_fork_init if the user asked for fork support.
-	 */
-	if (efa_fork_status == EFA_FORK_SUPPORT_ON) {
-		ret = -ibv_fork_init();
-		if (ret) {
-			EFA_WARN(FI_LOG_DOMAIN,
-				 "Fork support requested but ibv_fork_init failed: %s\n",
-				 strerror(-ret));
-			return ret;
-		}
-	}
-
-	/*
-	 * Run check to see if fork support was enabled by another library. If
-	 * one of the environment variables was set to enable fork support,
-	 * this variable was set to ON during provider init.  Huge pages for
-	 * bounce buffers will not be used if fork support is on.
-	 */
-	if (efa_fork_status == EFA_FORK_SUPPORT_OFF &&
-		efa_check_fork_enabled(domain_fid))
-		efa_fork_status = EFA_FORK_SUPPORT_ON;
-
-	if (efa_fork_status == EFA_FORK_SUPPORT_ON &&
-		getenv("RDMAV_HUGEPAGES_SAFE")) {
-			EFA_WARN(FI_LOG_DOMAIN,
-				 "Using libibverbs fork support and huge pages is not"
-				 " supported by the EFA provider.\n");
-		return -FI_EINVAL;
-	}
-
-	/*
-	 * It'd be better to install this during provider init (since that's
-	 * only invoked once) but we need to do a memory registration for the
-	 * fork check above. This can move to the provider init once that check
-	 * is gone.
-	 */
-	if (!fork_handler_installed && efa_fork_status == EFA_FORK_SUPPORT_OFF) {
-		ret = pthread_atfork(efa_atfork_callback, NULL, NULL);
-		if (ret) {
-			EFA_WARN(FI_LOG_DOMAIN,
-				 "Unable to register atfork callback: %s\n",
-				 strerror(-ret));
-			return ret;
-		}
-		fork_handler_installed = 1;
-	}
-
-	return 0;
-}
-
-#else
-
-/* @brief Check when fork is requested and return failure on Windows
- *
- * We check if fork is requested and return failure as fork is not supported on Windows
- *
- * @param domain_fid domain unused
- * @return error number if fork is requested, 0 otherwise
- */
-static
-int efa_initialize_fork_support(struct fid_domain* domain_fid)
-{
-	if (efa_fork_status == EFA_FORK_SUPPORT_ON) {
-		EFA_WARN(FI_LOG_DOMAIN,
-			 "Using fork support is not supported by the EFA provider on Windows\n");
-		return -FI_EINVAL;
-	}
-	return 0;
-}
-
-#endif
 
 /* @brief Setup the MR cache.
  *
@@ -546,8 +336,7 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 
 	domain->cache = NULL;
 
-	ret = efa_initialize_fork_support(*domain_fid);
-
+	ret = efa_fork_support_enable_if_requested(*domain_fid);
 	if (ret) {
 		EFA_WARN(FI_LOG_DOMAIN, "Failed to initialize fork support %d", ret);
 		goto err_free_info;

--- a/prov/efa/src/efa_ep.c
+++ b/prov/efa/src/efa_ep.c
@@ -701,14 +701,14 @@ int efa_ep_open(struct fid_domain *domain_fid, struct fi_info *info,
 		memcpy(ep->src_addr, info->src_addr, info->src_addrlen);
 	}
 
-	if (ep->domain->hmem_info[FI_HMEM_CUDA].initialized) {
+	if (ep->domain->hmem_support_status[FI_HMEM_CUDA].initialized) {
 		/*
 		 * Set the default to required. NCCL plugin requires p2p, but
 		 * does not call setopt for this option in older NCCL plugin
 		 * versions.
 		 */
 		ep->hmem_p2p_opt = FI_HMEM_P2P_REQUIRED;
-	} else if (ep->domain->hmem_info[FI_HMEM_NEURON].initialized) {
+	} else if (ep->domain->hmem_support_status[FI_HMEM_NEURON].initialized) {
 		/* Neuron requires p2p and supports no other modes. */
 		ep->hmem_p2p_opt = FI_HMEM_P2P_REQUIRED;
 	} else {

--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -78,18 +78,12 @@
 
 #define EFA_NO_DEFAULT -1
 
-#define EFA_DEF_MR_CACHE_ENABLE 1
 
 #ifdef EFA_PERF_ENABLED
 const char *efa_perf_counters_str[] = {
 	EFA_PERF_FOREACH(OFI_STR)
 };
 #endif
-
-int efa_mr_cache_enable		= EFA_DEF_MR_CACHE_ENABLE;
-size_t efa_mr_max_cached_count;
-size_t efa_mr_max_cached_size;
-
 static void efa_addr_to_str(const uint8_t *raw_addr, char *str);
 
 const struct fi_fabric_attr efa_fabric_attr = {

--- a/prov/efa/src/efa_fork_support.c
+++ b/prov/efa/src/efa_fork_support.c
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) 2022 Amazon.com, Inc. or its affiliates. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * OpenIB.org BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "efa.h"
+
+enum efa_fork_support_status g_efa_fork_status = EFA_FORK_SUPPORT_OFF;
+
+/**
+ * @brief initialize g_efa_fork_status based on environment and system statsu
+ *
+ */
+void efa_fork_support_request_initialize()
+{
+	g_efa_fork_status = EFA_FORK_SUPPORT_OFF;
+
+#if HAVE_IBV_IS_FORK_INITIALIZED == 1
+	if (ibv_is_fork_initialized() == IBV_FORK_UNNEEDED) {
+		g_efa_fork_status = EFA_FORK_SUPPORT_UNNEEDED;
+		return;
+	}
+#endif
+	int fork_support_requested = 0;
+
+	fi_param_get_bool(&rxr_prov, "fork_safe", &fork_support_requested);
+
+	/*
+	 * Check if any environment variables which would trigger
+	 * libibverbs' fork support are set. These variables are
+	 * defined by ibv_fork_init(3).
+	 */
+	if (fork_support_requested || getenv("RDMAV_FORK_SAFE") || getenv("IBV_FORK_SAFE"))
+		g_efa_fork_status = EFA_FORK_SUPPORT_ON;
+}
+
+/* @brief Check if rdma-core fork support is enabled and prevent fork
+ * support from being enabled later.
+ *
+ * Register a temporary buffer and call ibv_fork_init() to determine
+ * if fork support is enabled. Registering a buffer prevents future
+ * calls to ibv_fork_init() from completing successfully.
+ *
+ * This relies on internal behavior in rdma-core and is a temporary workaround.
+ *
+ * @param domain_fid domain fid so we can register memory
+ * @return 1 if fork support is enabled, 0 otherwise
+ */
+static int efa_fork_support_is_enabled(struct fid_domain *domain_fid)
+{
+	struct fid_mr *mr;
+	char *buf;
+	int ret;
+	long page_size;
+
+	/* If ibv_is_fork_initialized is availble, check if the function
+	 * can exit early.
+	 */
+#if HAVE_IBV_IS_FORK_INITIALIZED == 1
+	enum ibv_fork_status fork_status = ibv_is_fork_initialized();
+
+	/* If fork support is enabled or unneeded, return. */
+	if (fork_status != IBV_FORK_DISABLED)
+		return fork_status == IBV_FORK_ENABLED;
+
+#endif /* HAVE_IBV_IS_FORK_INITIALIZED */
+
+	page_size = ofi_get_page_size();
+	if (page_size <= 0) {
+		EFA_WARN(FI_LOG_DOMAIN, "Unable to determine page size %ld\n",
+			 page_size);
+		return -FI_EINVAL;
+	}
+
+	buf = malloc(page_size);
+	if (!buf)
+		return -FI_ENOMEM;
+
+	ret = fi_mr_reg(domain_fid, buf, page_size,
+			FI_SEND, 0, 0, 0, &mr, NULL);
+	if (ret) {
+		free(buf);
+		return ret;
+	}
+
+	/*
+	 * libibverbs maintains a global variable to determine if any
+	 * registrations have occurred before ibv_fork_init() is called.
+	 * EINVAL is returned if a memory region was registered before
+	 * ibv_fork_init() was called and returns 0 if fork support is
+	 * initialized already.
+	 */
+	ret = ibv_fork_init();
+
+	fi_close(&mr->fid);
+	free(buf);
+
+	if (ret == EINVAL)
+		return 0;
+
+	return 1;
+}
+
+/* @brief Fork handler that is installed when EFA is loaded
+ *
+ * We register this fork handler so that users do not inadvertently trip over
+ * memory corruption when fork is called. Calling fork() without enabling fork
+ * support in rdma-core can cause corruption, even if the registered pages are
+ * not used in the child process.
+ *
+ * It is critical that this fork handler is only installed once an EFA device
+ * is present and selected. We don't want this to trigger when Libfabric is not
+ * running on an EC2 instance.
+ */
+static
+void efa_atfork_callback()
+{
+	static int visited = 0;
+
+	if (visited)
+		return;
+	visited = 1;
+
+	fprintf(stderr,
+		"A process has executed an operation involving a call\n"
+		"to the fork() system call to create a child process.\n"
+		"\n"
+		"As a result, the Libfabric EFA provider is operating in\n"
+		"a condition that could result in memory corruption or\n"
+		"other system errors.\n"
+		"\n"
+		"For the Libfabric EFA provider to work safely when fork()\n"
+		"is called please do one of the following:\n"
+		"1) Set the environment variable:\n"
+		"          FI_EFA_FORK_SAFE=1\n"
+		"and verify you are using rdma-core v31.1 or later.\n"
+		"\n"
+		"OR\n"
+		"2) Use Linux Kernel 5.13+ with rdma-core v35.0+\n"
+		"\n"
+		"Please note that enabling fork support may cause a\n"
+		"small performance impact.\n"
+		"\n"
+		"You may want to check with your application vendor to see\n"
+		"if an application-level alternative (of not using fork)\n"
+		"exists.\n"
+		"\n"
+		"Your job will now abort.\n");
+	abort();
+}
+
+#ifndef _WIN32
+
+/* @brief Check when fork is requested and abort in unsupported cases
+ *
+ * We check if user or another library asked or enabled fork support and
+ * return failure if HUGEPAGES are also enabled as EFA provider does not support this case.
+ *
+ * In addition, we install a fork handler to ensure that we abort if another
+ * library or process initiates a fork and we determined from previous logic
+ * that we cannot support that.
+ *
+ * @param domain_fid domain fid so we can check register memory during initialization.
+ * @return error number if we failed to initialize, 0 otherwise
+ */
+int efa_fork_support_enable_if_requested(struct fid_domain* domain_fid)
+{
+	static int fork_handler_installed = 0;
+	int ret;
+
+	/*
+	 * Call ibv_fork_init if the user asked for fork support.
+	 */
+	if (g_efa_fork_status == EFA_FORK_SUPPORT_ON) {
+		ret = -ibv_fork_init();
+		if (ret) {
+			EFA_WARN(FI_LOG_DOMAIN,
+				 "Fork support requested but ibv_fork_init failed: %s\n",
+				 strerror(-ret));
+			return ret;
+		}
+	}
+
+	/*
+	 * Run check to see if fork support was enabled by another library. If
+	 * one of the environment variables was set to enable fork support,
+	 * this variable was set to ON during provider init.  Huge pages for
+	 * bounce buffers will not be used if fork support is on.
+	 */
+	if (g_efa_fork_status == EFA_FORK_SUPPORT_OFF && efa_fork_support_is_enabled(domain_fid))
+		g_efa_fork_status = EFA_FORK_SUPPORT_ON;
+
+	if (g_efa_fork_status == EFA_FORK_SUPPORT_ON && getenv("RDMAV_HUGEPAGES_SAFE")) {
+			EFA_WARN(FI_LOG_DOMAIN,
+				 "Using libibverbs fork support and huge pages is not"
+				 " supported by the EFA provider.\n");
+		return -FI_EINVAL;
+	}
+
+	/*
+	 * It'd be better to install this during provider init (since that's
+	 * only invoked once) but we need to do a memory registration for the
+	 * fork check above. This can move to the provider init once that check
+	 * is gone.
+	 */
+	if (!fork_handler_installed && g_efa_fork_status == EFA_FORK_SUPPORT_OFF) {
+		ret = pthread_atfork(efa_atfork_callback, NULL, NULL);
+		if (ret) {
+			EFA_WARN(FI_LOG_DOMAIN,
+				 "Unable to register atfork callback: %s\n",
+				 strerror(-ret));
+			return ret;
+		}
+		fork_handler_installed = 1;
+	}
+
+	return 0;
+}
+
+#else
+
+/* @brief Check when fork is requested and return failure on Windows
+ *
+ * We check if fork is requested and return failure as fork is not supported on Windows
+ *
+ * @param domain_fid domain unused
+ * @return error number if fork is requested, 0 otherwise
+ */
+int efa_fork_support_enable_if_requested(struct domain_fid* domain_fid)
+{
+	if (g_efa_fork_status == EFA_FORK_SUPPORT_ON) {
+		EFA_WARN(FI_LOG_DOMAIN,
+			 "Using fork support is not supported by the EFA provider on Windows\n");
+		return -FI_EINVAL;
+	}
+	return 0;
+}
+
+#endif
+

--- a/prov/efa/src/efa_fork_support.h
+++ b/prov/efa/src/efa_fork_support.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022 Amazon.com, Inc. or its affiliates. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * OpenIB.org BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef EFA_FORK_SUPPORT_H
+#define EFA_FORK_SUPPORT_H
+
+#include <rdma/fabric.h>
+
+/*
+ * ON will avoid using huge pages for bounce buffers, so that the libibverbs
+ * fork support can be used safely.
+ */
+enum efa_fork_support_status {
+	EFA_FORK_SUPPORT_OFF = 0,
+	EFA_FORK_SUPPORT_ON,
+	EFA_FORK_SUPPORT_UNNEEDED,
+};
+extern enum efa_fork_support_status g_efa_fork_status;
+
+int efa_fork_support_enable_if_requested(struct fid_domain *domain_fid);
+
+void efa_fork_support_request_initialize();
+
+#endif

--- a/prov/efa/src/efa_hmem.c
+++ b/prov/efa/src/efa_hmem.c
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2022 Amazon.com, Inc. or its affiliates. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * OpenIB.org BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "efa.h"
+
+/**
+ * @brief determine the support status of cuda memory pointer
+ *
+ * @param	cuda_status[out]	cuda memory support status
+ * @return	0 on success
+ * 		negative libfabric error code on failure
+ */
+static int efa_hmem_support_status_update_cuda(struct efa_hmem_support_status *cuda_status)
+{
+#if HAVE_CUDA
+	cudaError_t cuda_ret;
+	void *ptr = NULL;
+	struct ibv_mr *ibv_mr;
+	int ibv_access = IBV_ACCESS_LOCAL_WRITE;
+	size_t len = ofi_get_page_size() * 2;
+	int ret;
+
+	if (!ofi_hmem_is_initialized(FI_HMEM_CUDA)) {
+		EFA_INFO(FI_LOG_DOMAIN,
+		         "FI_HMEM_CUDA is not initialized\n");
+		return 0;
+	}
+
+	if (efa_device_support_rdma_read())
+		ibv_access |= IBV_ACCESS_REMOTE_READ;
+
+	cuda_status->initialized = true;
+
+	cuda_ret = ofi_cudaMalloc(&ptr, len);
+	if (cuda_ret != cudaSuccess) {
+		EFA_WARN(FI_LOG_DOMAIN,
+			 "Failed to allocate CUDA buffer: %s\n",
+			 ofi_cudaGetErrorString(cuda_ret));
+		return -FI_ENOMEM;
+	}
+
+	ibv_mr = ibv_reg_mr(g_device_list[0].ibv_pd, ptr, len, ibv_access);
+	if (!ibv_mr) {
+		EFA_WARN(FI_LOG_DOMAIN,
+			 "Failed to register CUDA buffer with the EFA device, FI_HMEM transfers that require peer to peer support will fail.\n");
+		ofi_cudaFree(ptr);
+		return 0;
+	}
+
+	ret = ibv_dereg_mr(ibv_mr);
+	ofi_cudaFree(ptr);
+	if (ret) {
+		EFA_WARN(FI_LOG_DOMAIN,
+			 "Failed to deregister CUDA buffer: %s\n",
+			 fi_strerror(-ret));
+		return ret;
+	}
+
+	cuda_status->p2p_supported = true;
+#endif
+	return 0;
+}
+
+/**
+ * @brief determine the support status of neuron memory pointer
+ *
+ * @param	neuron_status[out]	neuron memory support status
+ * @return	0 on success
+ * 		negative libfabric error code on failure
+ */
+static int efa_hmem_support_status_update_neuron(struct efa_hmem_support_status *neuron_status)
+{
+#if HAVE_NEURON
+	struct ibv_mr *ibv_mr;
+	int ibv_access = IBV_ACCESS_LOCAL_WRITE;
+	void *handle;
+	void *ptr = NULL;
+	size_t len = ofi_get_page_size() * 2;
+	int ret;
+
+	if (!ofi_hmem_is_initialized(FI_HMEM_NEURON)) {
+		EFA_INFO(FI_LOG_DOMAIN,
+		         "FI_HMEM_NEURON is not initialized\n");
+		return 0;
+	}
+
+	if (domain->device->device_caps & EFADV_DEVICE_ATTR_CAPS_RDMA_READ) {
+		ibv_access |= IBV_ACCESS_REMOTE_READ;
+	} else {
+		EFA_WARN(FI_LOG_DOMAIN,
+			 "No EFA RDMA read support, transfers using AWS Neuron will fail.\n");
+		return 0;
+	}
+
+	neuron_status->initialized = true;
+
+	ptr = neuron_alloc(&handle, len);
+	if (!ptr)
+		return -FI_ENOMEM;
+
+	ibv_mr = ibv_reg_mr(domain->ibv_pd, ptr, len, ibv_access);
+	if (!ibv_mr) {
+		EFA_WARN(FI_LOG_DOMAIN,
+			 "Failed to register Neuron buffer with the EFA device, FI_HMEM transfers that require peer to peer support will fail.\n");
+		neuron_free(&handle);
+		return 0;
+	}
+
+	ret = ibv_dereg_mr(ibv_mr);
+	neuron_free(&handle);
+	if (ret) {
+		EFA_WARN(FI_LOG_DOMAIN,
+			 "Failed to deregister Neuron buffer: %s\n",
+			 fi_strerror(-ret));
+		return ret;
+	}
+
+	neuron_status->p2p_supported = true;
+#endif
+	return 0;
+}
+
+/**
+ * @brief Determine the support status of all HMEM devices
+ * The support status is used later when
+ * determining how to initiate an HMEM transfer.
+ *
+ * @param 	all_status[out]		an array of struct efa_hmem_support_status,
+ * 					whose size is OFI_HMEM_MAX
+ * @return	0 on success
+ * 		negative libfabric error code on an unexpected error
+ */
+int efa_hmem_support_status_update_all(struct efa_hmem_support_status *all_status)
+{
+	int ret, err;
+
+	if(g_device_cnt <= 0) {
+		return -FI_ENODEV;
+	}
+
+	memset(all_status, 0, OFI_HMEM_MAX * sizeof(struct efa_hmem_support_status));
+
+	ret = 0;
+
+	err = efa_hmem_support_status_update_cuda(&all_status[FI_HMEM_CUDA]);
+	if (err) {
+		ret = err;
+		EFA_WARN(FI_LOG_DOMAIN, "check cuda support status failed! err: %d\n",
+			 err);
+	}
+
+	ret = efa_hmem_support_status_update_neuron(&all_status[FI_HMEM_NEURON]);
+	if (err) {
+		ret = err;
+		EFA_WARN(FI_LOG_DOMAIN, "check neuron support status failed! err: %d\n",
+			 err);
+	}
+
+	return ret;
+}

--- a/prov/efa/src/efa_hmem.h
+++ b/prov/efa/src/efa_hmem.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022 Amazon.com, Inc. or its affiliates. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+#ifndef EFA_HMEM_H
+#define EFA_HMEM_H
+
+struct efa_hmem_support_status {
+	bool initialized; 	/* do we support it at all */
+	bool p2p_supported;	/* do we support p2p with this device */
+};
+
+int efa_hmem_support_status_update_all(struct efa_hmem_support_status *all_status);
+
+#endif

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -85,7 +85,7 @@ static int efa_mr_hmem_setup(struct efa_mr *efa_mr,
 		 * util_domain is at the beginning of both efa_domain and
 		 * rxr_domain.
 		 */
-		if (efa_mr->domain->hmem_info[attr->iface].initialized) {
+		if (efa_mr->domain->hmem_support_status[attr->iface].initialized) {
 			efa_mr->peer.iface = attr->iface;
 		} else {
 			EFA_WARN(FI_LOG_MR,

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -39,6 +39,120 @@ static int efa_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 static int efa_mr_reg_impl(struct efa_mr *efa_mr, uint64_t flags, void *attr);
 static int efa_mr_dereg_impl(struct efa_mr *efa_mr);
 
+/* @brief Setup the MR cache.
+ *
+ * This function enables the MR cache using the util MR cache code.
+ *
+ * @param cache		The ofi_mr_cache that is to be set up.
+ * @param domain	The EFA domain where cache will be used.
+ * @return 0 on success, fi_errno on failure.
+ */
+int efa_mr_cache_open(struct ofi_mr_cache **cache, struct efa_domain *domain)
+{
+	struct ofi_mem_monitor *memory_monitors[OFI_HMEM_MAX] = {
+		[FI_HMEM_SYSTEM] = default_monitor,
+		[FI_HMEM_CUDA] = cuda_monitor,
+	};
+	int err;
+
+	/* Both Open MPI (and possibly other MPI implementations) and
+	 * Libfabric use the same live binary patching to enable memory
+	 * monitoring, but the patching technique only allows a single
+	 * "winning" patch.  The Libfabric memhooks monitor will not
+	 * overwrite a previous patch, but instead return
+	 * -FI_EALREADY.  There are three cases of concern, and in all
+	 * but one of them, we can avoid changing the default monitor.
+	 *
+	 * (1) Upper layer does not patch, such as Open MPI 4.0 and
+	 * earlier.  In this case, the default monitor will be used,
+	 * as the default monitor is either not the memhooks monitor
+	 * (because the user specified a different monitor) or the
+	 * default monitor is the memhooks monitor, but we were able
+	 * to install the patches.  We will use the default monitor in
+	 * this case.
+	 *
+	 * (2) Upper layer does patch, but does not export a memory
+	 * monitor, such as Open MPI 4.1.0 and 4.1.1.  In this case,
+	 * if the default memory monitor is not memhooks, we will use
+	 * the default monitor.  If the default monitor is memhooks,
+	 * the patch will fail to apply, and we will change the
+	 * requested monitor to UFFD to avoid a broken configuration.
+	 * If the user explicitly requested memhooks, we will return
+	 * an error, as we can not satisfy that request.
+	 *
+	 * (3) Upper layer does patch and exports a memory monitor,
+	 * such as Open MPI 4.1.2 and later.  In this case, the
+	 * default monitor will have been changed from the memhooks
+	 * monitor to the imported monitor, so we will use the
+	 * imported monitor.
+	 *
+	 * The only known cases in which we will not use the default
+	 * monitor are Open MPI 4.1.0/4.1.1.
+	 *
+	 * It is possible that this could be better handled at the
+	 * mem_monitor level in Libfabric, but so far we have not
+	 * reached agreement on how that would work.
+	 */
+	if (default_monitor == memhooks_monitor) {
+		err = memhooks_monitor->start(memhooks_monitor);
+		if (err == -FI_EALREADY) {
+			if (cache_params.monitor) {
+				EFA_WARN(FI_LOG_DOMAIN,
+					 "Memhooks monitor requested via FI_MR_CACHE_MONITOR, but memhooks failed to\n"
+					 "install.  No working monitor availale.\n");
+				return -FI_ENOSYS;
+			}
+			EFA_INFO(FI_LOG_DOMAIN,
+				 "Detected potential memhooks monitor conflict. Switching to UFFD.\n");
+			memory_monitors[FI_HMEM_SYSTEM] = uffd_monitor;
+		}
+	} else if (default_monitor == NULL) {
+		/* TODO: Fail if we don't find a system monitor.  This
+		 * is a debatable decision, as the VERBS provider
+		 * falls back to a no-cache mode in this case.  We
+		 * fail the domain creation because the rest of the MR
+		 * code hasn't been audited to deal with a NULL
+		 * monitor.
+		 */
+		EFA_WARN(FI_LOG_DOMAIN,
+			 "No default SYSTEM monitor available.\n");
+		return -FI_ENOSYS;
+	}
+
+	*cache = (struct ofi_mr_cache *)calloc(1, sizeof(struct ofi_mr_cache));
+	if (!*cache)
+		return -FI_ENOMEM;
+
+	if (!efa_mr_max_cached_count)
+		efa_mr_max_cached_count = domain->device->ibv_attr.max_mr *
+					  EFA_MR_CACHE_LIMIT_MULT;
+	if (!efa_mr_max_cached_size)
+		efa_mr_max_cached_size = domain->device->ibv_attr.max_mr_size *
+					 EFA_MR_CACHE_LIMIT_MULT;
+	/*
+	 * XXX: we're modifying a global in the util mr cache? do we need an
+	 * API here instead?
+	 */
+	cache_params.max_cnt = efa_mr_max_cached_count;
+	cache_params.max_size = efa_mr_max_cached_size;
+	(*cache)->entry_data_size = sizeof(struct efa_mr);
+	(*cache)->add_region = efa_mr_cache_entry_reg;
+	(*cache)->delete_region = efa_mr_cache_entry_dereg;
+	err = ofi_mr_cache_init(&domain->util_domain, memory_monitors,
+				*cache);
+	if (err) {
+		EFA_WARN(FI_LOG_DOMAIN, "EFA MR cache init failed: %s\n",
+		         fi_strerror(err));
+		free(*cache);
+		*cache = NULL;
+		return -err;
+	}
+
+	EFA_INFO(FI_LOG_DOMAIN, "EFA MR cache enabled, max_cnt: %zu max_size: %zu\n",
+		 cache_params.max_cnt, cache_params.max_size);
+	return 0;
+}
+
 static int efa_mr_cache_close(fid_t fid)
 {
 	struct efa_mr *efa_mr = container_of(fid, struct efa_mr,

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -39,6 +39,12 @@ static int efa_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 static int efa_mr_reg_impl(struct efa_mr *efa_mr, uint64_t flags, void *attr);
 static int efa_mr_dereg_impl(struct efa_mr *efa_mr);
 
+
+#define EFA_DEF_MR_CACHE_ENABLE 1
+int efa_mr_cache_enable	= EFA_DEF_MR_CACHE_ENABLE;
+size_t efa_mr_max_cached_count;
+size_t efa_mr_max_cached_size;
+
 /* @brief Setup the MR cache.
  *
  * This function enables the MR cache using the util MR cache code.

--- a/prov/efa/src/efa_mr.h
+++ b/prov/efa/src/efa_mr.h
@@ -33,6 +33,8 @@
 #ifndef EFA_MR_H
 #define EFA_MR_H
 
+#include "efa.h"
+
 /*
  * Descriptor returned for FI_HMEM peer memory registrations
  */
@@ -62,6 +64,8 @@ struct efa_mr {
 extern int efa_mr_cache_enable;
 extern size_t efa_mr_max_cached_count;
 extern size_t efa_mr_max_cached_size;
+
+int efa_mr_cache_open(struct ofi_mr_cache **cache, struct efa_domain *domain);
 
 extern struct fi_ops_mr efa_domain_mr_ops;
 extern struct fi_ops_mr efa_domain_mr_cache_ops;

--- a/prov/efa/src/efa_mr.h
+++ b/prov/efa/src/efa_mr.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2022 Amazon.com, Inc. or its affiliates. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef EFA_MR_H
+#define EFA_MR_H
+
+/*
+ * Descriptor returned for FI_HMEM peer memory registrations
+ */
+struct efa_mr_peer {
+	enum fi_hmem_iface      iface;
+	union {
+		uint64_t        reserved;
+		/* this field is gdrcopy handle when gdrcopy is enabled,
+		 * otherwise it is cuda device id.
+		 */
+		uint64_t        cuda;
+		int             neuron;
+	} device;
+};
+
+struct efa_mr {
+	struct fid_mr		mr_fid;
+	struct ibv_mr		*ibv_mr;
+	struct efa_domain	*domain;
+	/* Used only in MR cache */
+	struct ofi_mr_entry	*entry;
+	/* Used only in rdm */
+	struct fid_mr		*shm_mr;
+	struct efa_mr_peer	peer;
+};
+
+extern int efa_mr_cache_enable;
+extern size_t efa_mr_max_cached_count;
+extern size_t efa_mr_max_cached_size;
+
+extern struct fi_ops_mr efa_domain_mr_ops;
+extern struct fi_ops_mr efa_domain_mr_cache_ops;
+
+int efa_mr_cache_entry_reg(struct ofi_mr_cache *cache,
+			   struct ofi_mr_entry *entry);
+
+void efa_mr_cache_entry_dereg(struct ofi_mr_cache *cache,
+			      struct ofi_mr_entry *entry);
+
+int efa_mr_reg_shm(struct fid_domain *domain_fid, struct iovec *iov,
+		   uint64_t access, struct fid_mr **mr_fid);
+
+static inline bool efa_mr_is_hmem(struct efa_mr *efa_mr)
+{
+	return efa_mr ? (efa_mr->peer.iface == FI_HMEM_CUDA ||
+			 efa_mr->peer.iface == FI_HMEM_NEURON): false;
+}
+
+static inline bool efa_mr_is_cuda(struct efa_mr *efa_mr)
+{
+	return efa_mr ? (efa_mr->peer.iface == FI_HMEM_CUDA) : false;
+}
+
+static inline bool efa_mr_is_neuron(struct efa_mr *efa_mr)
+{
+	return efa_mr ? (efa_mr->peer.iface == FI_HMEM_NEURON) : false;
+}
+
+#endif

--- a/prov/efa/src/efa_msg.c
+++ b/prov/efa/src/efa_msg.c
@@ -324,8 +324,8 @@ static bool efa_msg_has_hmem_mr(const struct fi_msg *msg)
 	/* the device only support send up 2 iov, so iov_count cannot be > 2 */
 	assert(msg->iov_count == 1 || msg->iov_count == 2);
 	/* first iov is always on host memory, because it must contain packet header */
-	assert(!efa_ep_is_hmem_mr(msg->desc[0]));
-	return (msg->iov_count == 2) && efa_ep_is_hmem_mr(msg->desc[1]);
+	assert(!efa_mr_is_hmem(msg->desc[0]));
+	return (msg->iov_count == 2) && efa_mr_is_hmem(msg->desc[1]);
 }
 
 static ssize_t efa_post_send(struct efa_ep *ep, const struct fi_msg *msg, uint64_t flags)

--- a/prov/efa/src/rxr/rxr_atomic.c
+++ b/prov/efa/src/rxr/rxr_atomic.c
@@ -137,7 +137,7 @@ ssize_t rxr_atomic_generic_efa(struct rxr_ep *rxr_ep,
 	assert(msg->iov_count <= rxr_ep->tx_iov_limit);
 	efa_perfset_start(rxr_ep, perf_efa_tx);
 
-	if (msg->desc && efa_ep_is_cuda_mr(msg->desc[0]))
+	if (msg->desc && efa_mr_is_cuda(msg->desc[0]))
 		return -FI_ENOSYS;
 
 	ofi_mutex_lock(&rxr_ep->util_ep.lock);

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -970,7 +970,7 @@ void rxr_ep_set_extra_info(struct rxr_ep *ep)
 }
 
 /*
- * Set the efa_domain hmem_info state based on what CUDA/Neuron capabilities
+ * Set the efa_domain hmem_support_status state based on what CUDA/Neuron capabilities
  * are available. Return whether hmem is supported or not.
  *
  * @param[in]	efa_domain efa domain
@@ -988,15 +988,15 @@ static int efa_ep_hmem_check(struct efa_domain *efa_domain)
 	 * TODO: once we support other FI_HMEM p2p modes, check the setopt
 	 * option first. For now, require p2p from at least one device type.
 	 */
-	if (efa_domain->hmem_info[FI_HMEM_CUDA].initialized &&
-	    efa_domain->hmem_info[FI_HMEM_CUDA].p2p_supported)
+	if (efa_domain->hmem_support_status[FI_HMEM_CUDA].initialized &&
+	    efa_domain->hmem_support_status[FI_HMEM_CUDA].p2p_supported)
 		have_hmem = 1;
 	else
 		FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,
 			"NVIDIA GPUDirect support is not available, but FI_HMEM was requested.\n");
 
-	if (efa_domain->hmem_info[FI_HMEM_NEURON].initialized &&
-	    efa_domain->hmem_info[FI_HMEM_NEURON].p2p_supported)
+	if (efa_domain->hmem_support_status[FI_HMEM_NEURON].initialized &&
+	    efa_domain->hmem_support_status[FI_HMEM_NEURON].p2p_supported)
 		have_hmem = 1;
 	else
 		FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,
@@ -1177,9 +1177,9 @@ static ssize_t rxr_ep_cancel(fid_t fid_ep, void *context)
  */
 static int efa_set_fi_hmem_p2p_opt(struct efa_ep *efa_ep, int opt)
 {
-	struct efa_hmem_info *hmem_info;
+	struct efa_hmem_support_status *hmem_support_status;
 
-	hmem_info = efa_ep->domain->hmem_info;
+	hmem_support_status = efa_ep->domain->hmem_support_status;
 
 	switch (opt) {
 	/*
@@ -1190,11 +1190,11 @@ static int efa_set_fi_hmem_p2p_opt(struct efa_ep *efa_ep, int opt)
 	case FI_HMEM_P2P_REQUIRED:
 	case FI_HMEM_P2P_ENABLED:
 	case FI_HMEM_P2P_PREFERRED:
-		if (hmem_info[FI_HMEM_CUDA].initialized &&
-		    hmem_info[FI_HMEM_CUDA].p2p_supported) {
+		if (hmem_support_status[FI_HMEM_CUDA].initialized &&
+		    hmem_support_status[FI_HMEM_CUDA].p2p_supported) {
 			efa_ep->hmem_p2p_opt = opt;
-		} else if (hmem_info[FI_HMEM_NEURON].initialized &&
-			   hmem_info[FI_HMEM_NEURON].p2p_supported) {
+		} else if (hmem_support_status[FI_HMEM_NEURON].initialized &&
+			   hmem_support_status[FI_HMEM_NEURON].p2p_supported) {
 			/*
 			 * Neuron requires p2p support and supports no
 			 * other modes.

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1402,7 +1402,7 @@ int rxr_ep_init(struct rxr_ep *ep)
 	ep->rx_pkt_pool_entry_sz = entry_sz;
 #endif
 
-	if (efa_fork_status == EFA_FORK_SUPPORT_ON) {
+	if (g_efa_fork_status == EFA_FORK_SUPPORT_ON) {
 		/*
 		 * Make sure that no data structures can share the memory pages used
 		 * for this buffer pool.

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -221,7 +221,7 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 		 * Have the remote side issue a read to copy the data instead
 		 * to work around this issue.
 		 */
-		if (tx_entry->total_len > max_rtm_data_size || efa_ep_is_hmem_mr(tx_entry->desc[0]))
+		if (tx_entry->total_len > max_rtm_data_size || efa_mr_is_hmem(tx_entry->desc[0]))
 			/*
 			 * Read message support
 			 * FI_DELIVERY_COMPLETE implicitly.
@@ -236,7 +236,7 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 	ret = efa_ep_use_p2p(efa_ep, tx_entry->desc[0]);
 	if (ret < 0)
 		return ret;
-	if (ret == 1 && efa_ep_is_cuda_mr(tx_entry->desc[0])) {
+	if (ret == 1 && efa_mr_is_cuda(tx_entry->desc[0])) {
 		return rxr_msg_post_cuda_rtm(rxr_ep, tx_entry);
 	}
 
@@ -252,7 +252,7 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 	 * Force the LONGREAD protocol for Neuron buffers, regardless of what
 	 * is specified by the user for protocol switch over points.
 	 */
-	if (efa_ep_is_neuron_mr(tx_entry->desc[0])) {
+	if (efa_mr_is_neuron(tx_entry->desc[0])) {
 		/*
 		 * It is possible for the remote endpoint to support RDMA read,
 		 * but not p2p transfers between efa and neuron. That scenario

--- a/prov/efa/src/rxr/rxr_pkt_type_base.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_base.c
@@ -394,7 +394,7 @@ ssize_t rxr_pkt_copy_data_to_rx_entry(struct rxr_ep *ep,
 	 * copy.
 	 * Other types of device memory (neuron) does not have this limitation.
 	 */
-	if (efa_ep_is_cuda_mr(desc) && !cuda_is_gdrcopy_enabled()) {
+	if (efa_mr_is_cuda(desc) && !cuda_is_gdrcopy_enabled()) {
 		efa_ep = container_of(ep->rdm_ep, struct efa_ep, util_ep.ep_fid);
 		use_p2p = efa_ep_use_p2p(efa_ep, desc);
 		if (use_p2p < 0)
@@ -419,7 +419,7 @@ ssize_t rxr_pkt_copy_data_to_rx_entry(struct rxr_ep *ep,
 		return err;
 	}
 
-	if (efa_ep_is_hmem_mr(desc))
+	if (efa_mr_is_hmem(desc))
 		return rxr_pkt_copy_data_to_hmem(ep, pkt_entry, data, data_size, data_offset);
 
 	assert( !desc || desc->peer.iface == FI_HMEM_SYSTEM);

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -359,7 +359,7 @@ void rxr_pkt_handle_readrsp_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_en
 		 * We currently require EFA RDMA support to enable the FI_HMEM
 		 * devices we support. Emulated read should not be used.
 		 */
-		assert(!efa_ep_is_hmem_mr(tx_entry->desc[0]));
+		assert(!efa_mr_is_hmem(tx_entry->desc[0]));
 
 		if (tx_entry->desc[0] || efa_is_cache_available(efa_domain))
 			rxr_prepare_desc_send(rxr_ep_domain(ep), tx_entry);

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -437,7 +437,7 @@ int rxr_pkt_init_rtm(struct rxr_ep *ep,
 
 	data_size = MIN(tx_entry->total_len - data_offset,
 			ep->mtu_size - rxr_pkt_req_hdr_size(pkt_entry));
-	if (efa_ep_is_cuda_mr(tx_entry->desc[0]) &&
+	if (efa_mr_is_cuda(tx_entry->desc[0]) &&
 	    data_size + data_offset < tx_entry->total_len) {
 		data_size &= ~(CUDA_MEMORY_ALIGNMENT -1);
 	}

--- a/prov/efa/src/rxr/rxr_read.c
+++ b/prov/efa/src/rxr/rxr_read.c
@@ -400,7 +400,7 @@ int rxr_read_post_local_read_or_queue(struct rxr_ep *ep,
 
 	/* setup iov */
 	assert(pkt_entry->x_entry == rx_entry);
-	assert(rx_entry->desc && efa_ep_is_hmem_mr(rx_entry->desc[0]));
+	assert(rx_entry->desc && efa_mr_is_hmem(rx_entry->desc[0]));
 	read_entry->iov_count = rx_entry->iov_count;
 	memset(read_entry->mr, 0, sizeof(*read_entry->mr) * read_entry->iov_count);
 	memcpy(read_entry->iov, rx_entry->iov, rx_entry->iov_count * sizeof(struct iovec));
@@ -414,7 +414,7 @@ int rxr_read_post_local_read_or_queue(struct rxr_ep *ep,
 		return -FI_ETRUNC;
 	}
 
-	assert(efa_ep_is_hmem_mr(read_entry->mr_desc[0]));
+	assert(efa_mr_is_hmem(read_entry->mr_desc[0]));
 	err = ofi_truncate_iov(read_entry->iov, &read_entry->iov_count, data_size + ep->msg_prefix_size);
 
 	if (err) {

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -343,7 +343,7 @@ ssize_t rxr_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uint64_
 		 * so we do not check it here
 		 */
 		use_lower_ep_read = true;
-	} else if (efa_ep_is_neuron_mr(tx_entry->desc[0])) {
+	} else if (efa_mr_is_neuron(tx_entry->desc[0])) {
 		err = rxr_ep_determine_rdma_support(rxr_ep, tx_entry->addr, peer);
 
 		if (err < 0)
@@ -488,7 +488,7 @@ ssize_t rxr_rma_post_write(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry)
 	}
 
 	/* See rxr_msg_post_rtm() */
-	if (efa_ep_is_neuron_mr(tx_entry->desc[0])) {
+	if (efa_mr_is_neuron(tx_entry->desc[0])) {
 		err = rxr_ep_determine_rdma_support(ep, tx_entry->addr, peer);
 
 		if (err < 0)


### PR DESCRIPTION
This patch moved hmem support status checking, fork_support into separate files. Also moved everything related to MR to efa_mr.c/h.