### PR TITLE
core/pollfds: Use a compact pollfd array

### DIFF
--- a/include/ofi_epoll.h
+++ b/include/ofi_epoll.h
@@ -75,6 +75,7 @@ struct ofi_pollfds_work_item {
 
 struct ofi_pollfds_ctx {
 	void		*context;
+	int		index;
 	int		hit_cnt;
 	int		hot_index;
 };
@@ -110,12 +111,8 @@ void ofi_pollfds_coolfd(struct ofi_pollfds *pfds, int fd);
 void ofi_pollfds_heatfd(struct ofi_pollfds *pfds, int fd);
 
 /* OS specific */
-void ofi_pollfds_do_add(struct ofi_pollfds *pfds,
-			struct ofi_pollfds_work_item *item);
-int ofi_pollfds_do_mod(struct ofi_pollfds *pfds, int fd, uint32_t events,
-		       void *context);
-void ofi_pollfds_do_del(struct ofi_pollfds *pfds,
-			struct ofi_pollfds_work_item *item);
+struct ofi_pollfds_ctx *ofi_pollfds_get_ctx(struct ofi_pollfds *pfds, int fd);
+struct ofi_pollfds_ctx *ofi_pollfds_alloc_ctx(struct ofi_pollfds *pfds, int fd);
 
 
 #ifdef HAVE_EPOLL

--- a/include/ofi_epoll.h
+++ b/include/ofi_epoll.h
@@ -106,8 +106,8 @@ int ofi_pollfds_wait(struct ofi_pollfds *pfds,
 		     int maxevents, int timeout);
 void ofi_pollfds_close(struct ofi_pollfds *pfds);
 
-void ofi_pollfds_coolfd(struct ofi_pollfds *pfds, int index);
-void ofi_pollfds_heatfd(struct ofi_pollfds *pfds, int index);
+void ofi_pollfds_coolfd(struct ofi_pollfds *pfds, int fd);
+void ofi_pollfds_heatfd(struct ofi_pollfds *pfds, int fd);
 
 /* OS specific */
 void ofi_pollfds_do_add(struct ofi_pollfds *pfds,

--- a/src/common.c
+++ b/src/common.c
@@ -1413,7 +1413,7 @@ int ofi_pollfds_grow(struct ofi_pollfds *pfds, int max_size)
 	}
 
 	while (pfds->size < size) {
-		ctx[pfds->size].hot_index = INVALID_SOCKET;
+		ctx[pfds->size].hot_index = -1;
 		fds[pfds->size++].fd = INVALID_SOCKET;
 	}
 
@@ -1459,7 +1459,7 @@ void ofi_pollfds_heatfd(struct ofi_pollfds *pfds, int index)
 
 	assert(ofi_poll_fairness);
 	ctx = &pfds->ctx[index];
-	assert(ctx->hot_index == INVALID_SOCKET);
+	assert(ctx->hot_index == -1);
 
 	if (pfds->hot_nfds >= pfds->hot_size) {
 		size = pfds->hot_size + 8;
@@ -1495,7 +1495,7 @@ void ofi_pollfds_coolfd(struct ofi_pollfds *pfds, int index)
 
 	assert(ofi_poll_fairness);
 	ctx = &pfds->ctx[index];
-	assert(ctx->hot_index != INVALID_SOCKET);
+	assert(ctx->hot_index >= 0);
 	assert(pfds->hot_nfds);
 
 	if (ctx->hot_index < pfds->hot_nfds - 1) {
@@ -1508,7 +1508,7 @@ void ofi_pollfds_coolfd(struct ofi_pollfds *pfds, int index)
 
 	OFI_DBG_SET(pfds->hot_fds[pfds->hot_nfds].fd, INVALID_SOCKET);
 	pfds->hot_nfds--;
-	ctx->hot_index = INVALID_SOCKET;
+	ctx->hot_index = -1;
 	ctx->hit_cnt = 0;
 }
 
@@ -1656,10 +1656,10 @@ static void ofi_pollfds_adjust_temp(struct ofi_pollfds *pfds, int index)
 
 	if (pfd->revents || ctx->hit_cnt || (pfd->events & POLLOUT)) {
 		ctx->hit_cnt = 0;
-		if (ctx->hot_index == INVALID_SOCKET)
+		if (ctx->hot_index == -1)
 			ofi_pollfds_heatfd(pfds, index);
 
-	} else if (ctx->hot_index != INVALID_SOCKET) {
+	} else if (ctx->hot_index != -1) {
 		ofi_pollfds_coolfd(pfds, index);
 	}
 }

--- a/src/unix/osd.c
+++ b/src/unix/osd.c
@@ -358,8 +358,7 @@ void ofi_pollfds_do_del(struct ofi_pollfds *pfds,
 	pfds->fds[item->fd].events = 0;
 	pfds->fds[item->fd].revents = 0;
 
-	if (pfds->ctx[item->fd].hot_index != INVALID_SOCKET &&
-	    ofi_poll_fairness)
+	if (pfds->ctx[item->fd].hot_index >= 0 && ofi_poll_fairness)
 		ofi_pollfds_coolfd(pfds, item->fd);
 
 	while (pfds->nfds && pfds->fds[pfds->nfds - 1].fd == INVALID_SOCKET)


### PR DESCRIPTION
   
    The mdtest benchmark is showing significant performance regressions
    as a result of commit 7ec82992.  That commit replaced a compact
    pollfd array, where all entries are valid, with a sparsely filled
    array.  This removed a linear search through the array in order
    to update events.
    
    Rather than revert the above commit, we separate the pollfd
    context array and pollfd array.  The fd may still be used to
    directly index into the context array.  The context structure is
    updated to store the corresponding index where the fd is located
    in the pollfd array.  This avoids the linear search while
    maintaining a compact array.
    
    As a result of these changes, it becomes possible to support
    the hot fd array on windows.  Add that as part of this change in
    order to align the unix and windows implementations closer.
    
    Signed-off-by: Sean Hefty <sean.hefty@intel.com>