### PR TITLE
Fix inline assembly for the Nvidia HPC compilers

### DIFF
--- a/include/ofi_abi.h
+++ b/include/ofi_abi.h
@@ -123,11 +123,11 @@ extern "C" {
 #if HAVE_SYMVER_SUPPORT
 
 #define COMPAT_SYMVER(name, api, ver) \
-	asm(".symver " #name "," #api "@" #ver)
+	asm(".symver " #name "," #api "@" #ver "\n")
 #define DEFAULT_SYMVER(name, api, ver) \
-	asm(".symver " #name "," #api "@@" #ver)
+	asm(".symver " #name "," #api "@@" #ver "\n")
 #define CURRENT_SYMVER(name, api) \
-	asm(".symver " #name "," #api "@@" CURRENT_ABI)
+	asm(".symver " #name "," #api "@@" CURRENT_ABI "\n")
 
 #else
 


### PR DESCRIPTION
Signed-off-by: Theofilos Manitaras <manitaras@cscs.ch>

This PR fixes a problem with the inline assembly when using the Nvidia HPC compilers. The error is the following:

```
<inline asm>:1:64: error: unknown token in expression
.symver fi_freeinfo_,fi_freeinfo@@FABRIC_1.3.symver fi_getinfo_,fi_getinfo@@FABRIC_1.3.symver fi_dupinfo_,fi_dupinfo@@FABRIC_1.3.symver fi_fabric_,fi_fabric@@FABRIC_1.1.symver fi_version_,fi_version@@FABRIC_1.0.symver fi_open_,fi_open@@FABRIC_1.5.symver fi_strerror_,fi_strerror@@FABRIC_1.0
```

So the Nvidia compiler does not produce separate lines for each `asm` use.

The error can be easily reproduced using just a single two line source code `test.c`:

```
__asm__(".symver foo,foo@VER_1");
__asm__(".symver bar,bar@VER_2");
```
```
$ nvc -c test.c
<inline asm>:1:33: error: unknown token in expression
.symver foo,foo@VER_1.symver bar,bar@VER_2

```
                                                           
