### PR TITLE
prov/opx: Disable if no compiler atomics

### DIFF
--- a/prov/opx/configure.m4
+++ b/prov/opx/configure.m4
@@ -117,6 +117,11 @@ AC_DEFUN([FI_OPX_CONFIGURE],[
 		   	[],
 		   	[opx_happy=0])
 
+               AC_CHECK_DECL([HAVE_ATOMICS],
+                             [],
+                             [cc_version=`$CC --version | head -n1`
+                              AC_MSG_WARN(["$cc_version" doesn't support native atomics.  Disabling OPX provider.])
+                              opx_happy=0])
 	])
 
 	AS_IF([test $opx_happy -eq 1], [$1], [$2])


### PR DESCRIPTION
C11 atomics are required to build the OPX provider.

Signed-off-by: Ken Raffenetti <raffenet@mcs.anl.gov>