### PR TITLE
man: Update OPX man page with new default settings

### DIFF
--- a/man/fi_opx.7.md
+++ b/man/fi_opx.7.md
@@ -110,7 +110,7 @@ Shared memory is not cleaned up after an application crashes. Use
   will issue PING requests to a remote connection. Reducing this value
   may improve performance at the expense of increased traffic on the OPX 
   fabric.
-  Default setting is 100.
+  Default setting is 500.
 
 *FI_OPX_RELIABILITY_SERVICE_PRE_ACK_RATE*
 : This setting controls how frequently a receiving rank will send ACKs
@@ -121,7 +121,7 @@ Shared memory is not cleaned up after an application crashes. Use
 
   Valid values are 0 (disabled) and powers of 2 in the range of 1-32,768, inclusive.
 
-  Default setting is 0 (disabled).
+  Default setting is 64.
 
 *FI_OPX_HFI_SELECT*
 : Controls how OPX chooses which HFI to use when opening a context.

--- a/man/man7/fi_opx.7
+++ b/man/man7/fi_opx.7
@@ -110,7 +110,7 @@ This setting controls how frequently the reliability/replay function
 will issue PING requests to a remote connection.
 Reducing this value may improve performance at the expense of increased
 traffic on the OPX fabric.
-Default setting is 100.
+Default setting is 500.
 .TP
 .B \f[I]FI_OPX_RELIABILITY_SERVICE_PRE_ACK_RATE\f[R]
 This setting controls how frequently a receiving rank will send ACKs for
@@ -123,7 +123,7 @@ FI_OPX_RELIABILITY_SERVICE_USEC_MAX may improve performance.
 Valid values are 0 (disabled) and powers of 2 in the range of 1\-32,768,
 inclusive.
 .PP
-Default setting is 0 (disabled).
+Default setting is 64.
 .TP
 .B \f[I]FI_OPX_HFI_SELECT\f[R]
 Controls how OPX chooses which HFI to use when opening a context.


### PR DESCRIPTION
Update documentation for new default values for the ENVs:

FI_OPX_RELIABILITY_SERVICE_USEC_MAX: from 100 to 500
FI_OPX_RELIABILITY_SERVICE_PRE_ACK_RATE: from 0 to 64

Signed-off by: Tim Thompson (tim.thompson@cornelisnetworks.com)