### PR TITLE
core/peers: Peer provider support part 2

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -160,7 +160,8 @@ typedef struct fid *fid_t;
 #define FI_COMMIT_COMPLETE	(1ULL << 30)
 #define FI_MATCH_COMPLETE	(1ULL << 31)
 
-#define FI_PEER_IMPORT		(1ULL << 43)
+#define FI_PEER_SRX		(1ULL << 42)
+#define FI_PEER_CQ		(1ULL << 43)
 #define FI_XPU_TRIGGER		(1ULL << 44)
 #define FI_HMEM_HOST_ALLOC	(1ULL << 45)
 #define FI_HMEM_DEVICE_ONLY	(1ULL << 46)

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -160,6 +160,7 @@ typedef struct fid *fid_t;
 #define FI_COMMIT_COMPLETE	(1ULL << 30)
 #define FI_MATCH_COMPLETE	(1ULL << 31)
 
+#define FI_AV_USER_ID		(1ULL << 41)
 #define FI_PEER_SRX		(1ULL << 42)
 #define FI_PEER_CQ		(1ULL << 43)
 #define FI_XPU_TRIGGER		(1ULL << 44)

--- a/include/rdma/fi_ext.h
+++ b/include/rdma/fi_ext.h
@@ -137,16 +137,9 @@ struct fi_ops_cq_owner {
 			const struct fi_cq_err_entry *err_entry);
 };
 
-struct fi_ops_cq_peer {
-	size_t	size;
-	void	(*progress)(struct fid_peer_cq *cq);
-
-};
-
 struct fid_peer_cq {
 	struct fid fid;
 	struct fi_ops_cq_owner *owner_ops;
-	struct fi_ops_cq_peer *peer_ops;
 };
 
 struct fi_peer_cq_context {

--- a/man/fi_av.3.md
+++ b/man/fi_av.3.md
@@ -88,6 +88,8 @@ const char * fi_av_straddr(struct fid_av *av, const void *addr,
 *fi_addr*
 : For insert, a reference to an array where returned fabric addresses
   will be written.  For remove, one or more fabric addresses to remove.
+  If FI_AV_USER_ID is requested, also used as input into insert calls
+  to assign the user ID with the added address.
 
 *count*
 : Number of addresses to insert/remove from an AV.
@@ -97,9 +99,21 @@ const char * fi_av_straddr(struct fid_av *av, const void *addr,
 
 # DESCRIPTION
 
-Address vectors are used to map higher level addresses, which may be
+Address vectors are used to map higher-level addresses, which may be
 more natural for an application to use, into fabric specific
-addresses.  The mapping of addresses is fabric and provider specific,
+addresses.  For example, an endpoint may be associated with a
+struct sockaddr_in address, indicating the endpoint is reachable using
+a TCP port number over an IPv4 address.  This may hold even if the
+endpoint communicates using a proprietary network protocol.  The
+purpose of the AV is to associate a higher-level address with
+a simpler, more efficient value that can be used by the libfabric API in a
+fabric agnostic way.  The mapped address is of type fi_addr_t and is
+returned through an AV insertion call.  The fi_addr_t is designed such
+that it may be a simple index into an array, a pointer to a structure,
+or a compact network address that may be placed directly into protocol
+headers.
+
+The process of mapping an address is fabric and provider specific,
 but may involve lengthy address resolution and fabric management
 protocols.  AV operations are synchronous by default, but may be set
 to operate asynchronously by specifying the FI_EVENT flag to
@@ -337,6 +351,11 @@ determine what the next assigned index will be.
   written to the corresponding array location.  Successful insertions
   will be updated to 0.  Failures will contain a fabric errno code.
 
+- *FI_AV_USER_ID*
+: This flag associates a user-assigned identifier with each AV entry
+  that is returned with any completion entry in place of the AV's address.
+  See the user ID section below.
+
 ## fi_av_insertsvc
 
 The fi_av_insertsvc call behaves similar to fi_av_insert, but allows the
@@ -448,6 +467,37 @@ Specifically, a provider may begin resolving inserted addresses as
 soon as they have been added to an AV, even if asynchronous operation
 has been specified.  Similarly, a provider may lazily release
 resources from removed entries.
+
+# USER IDENTIFIERS FOR ADDRESSES
+
+As described above, endpoint addresses that are inserted into an AV are
+mapped to an fi_addr_t value.  The fi_addr_t is used in data transfer APIs
+to specify the destination of an outbound transfer, in receive APIs to
+indicate the source for an inbound transfer, and also in completion events
+to report the source address of inbound transfers.  The FI_AV_USER_ID
+capability bit and flag provide a mechanism by which the fi_addr_t value
+reported by a completion event is replaced with a user-specified value
+instead.  This is useful for applications that need to map the source
+address to their own data structure.
+
+Support for FI_AV_USER_ID is provider specific, as it may not be feasible
+for a provider to implement this support without significant overhead.
+For example, some providers may need to add a reverse lookup mechanism.
+This feature may be unavailable if shared AVs are requested, or
+negatively impact the per process memory footprint if implemented.  For
+providers that do not support FI_AV_USER_ID, users may be able to trade
+off lookup processing with protocol overhead, by carrying source
+identification within a message header.
+
+User-specified fi_addr_t values are provided as part of address insertion
+(e.g. fi_av_insert) through the fi_addr parameter.  The fi_addr parameter
+acts as input/output in this case.  When the FI_AV_USER_ID flag is passed
+to any of the insert calls, the caller must specify an fi_addr_t identifier
+value to associate with each address.  The provider will record that
+identifier and use it where required as part of any completion event.  Note
+that the output from the AV insertion call is unchanged.  The provider will
+return an fi_addr_t value that maps to each address, and that value must be
+used for all data transfer operations.
 
 # RETURN VALUES
 

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -263,6 +263,12 @@ additional optimizations.
   FI_WRITE, FI_REMOTE_READ, and FI_REMOTE_WRITE flags to restrict the
   types of atomic operations supported by an endpoint.
 
+*FI_AV_USER_ID*
+: Requests that the provider support the association of a user specified
+  identifier with each address vector (AV) address.  User identifiers are
+  returned with completion data in place of the AV address.  See [`fi_av`(3)]
+  (fi_av.3.html) for more details.
+
 *FI_COLLECTIVE*
 : Requests support for collective operations.  Endpoints that support
   this capability support the collective operations defined in

--- a/man/fi_peer.3.md
+++ b/man/fi_peer.3.md
@@ -187,6 +187,12 @@ Peer SRXs are configured by the owner calling the peer's fi_srx_context()
 call with the FI_PEER_SRX flag set.  The context parameter passed to
 fi_srx_context() must be a struct fi_peer_srx_context.
 
+The owner provider initializes all elements of the fid_peer_srx and
+referenced structures (fi_ops_srx_owner and fi_ops_srx_peer), with the
+exception of the fi_ops_srx_peer callback functions.  Those must be
+initialized by the peer provider prior to returning from the fi_srx_contex()
+call and are used by the owner to control peer actions.
+
 The data structures to support peer SRXs are defined as follows:
 
 ```

--- a/man/fi_peer.3.md
+++ b/man/fi_peer.3.md
@@ -85,8 +85,8 @@ the fid_peer_cq is known as the owner, with the other provider referred to
 as the peer.  An owner may setup peer relationships with multiple providers.
 
 Peer CQs are configured by the owner calling the peer's fi_cq_open() call.
-The owner passes in the FI_PEER_IMPORT flag to fi_cq_open().  When
-FI_PEER_IMPORT is specified, the context parameter passed
+The owner passes in the FI_PEER_CQ flag to fi_cq_open().  When
+FI_PEER_CQ is specified, the context parameter passed
 into fi_cq_open() must reference a struct fi_peer_cq_context.  Providers that
 do not support peer CQs must fail the fi_cq_open() call with -FI_EINVAL
 (indicating an invalid flag).  The fid_peer_cq referenced by struct
@@ -183,7 +183,7 @@ on the local node.
 4. Provider A takes these steps:
    allocate peer_cq and reference cq_a
    set peer_cq_context->cq = peer_cq
-   set attr_b.flags |= FI_PEER_IMPORT
+   set attr_b.flags |= FI_PEER_CQ
    fi_cq_open(domain_b, attr_b, &cq_b, peer_cq_context)
 5. Provider B allocates a cq, but configures it such that all completions
    are written to the peer_cq.  The cq ops to read from the cq are
@@ -202,7 +202,7 @@ message ordering.
 The setup of a peer SRX is similar to the setup for a peer CQ outlined above.
 A fid_peer_srx object links the owner of the SRX with the peer provider.
 Peer SRXs are configured by the owner calling the peer's fi_srx_context()
-call with the FI_IMPORT_PEER flag set.  The context parameter passed to
+call with the FI_PEER_SRX flag set.  The context parameter passed to
 fi_srx_context() must be a struct fi_peer_srx_context.
 
 The data structures to support peer SRXs are defined as follows:
@@ -325,7 +325,7 @@ on the local node.
 4. Provider A takes these steps:
    allocate peer_srx and reference srx_a
    set peer_srx_context->srx = peer_srx
-   set attr_b.flags |= FI_PEER_IMPORT
+   set attr_b.flags |= FI_PEER_SRX
    fi_srx_context(domain_b, attr_b, &srx_b, peer_srx_context)
 5. Provider B allocates an srx, but configures it such that all receive
    buffers are obtained from the peer_srx.  The srx ops to post receives are


### PR DESCRIPTION
There are 2 patches in this PR.  The first patch replaces the FI_IMPORT_PEER flag with 2 flags: FI_PEER_CQ and FI_PEER_SRX.  The new flags are defined such that these could also be used as capability bits.  However, I didn't document them as capability bits at the moment.  I want to see if that would actually be needed.

The second patch introduces a new feature to the AV, FI_AV_USER_ID.  This allows the user to assign a user-specified id or context with an address.  That id is returned as part of any completion in place of the AV defined fi_addr_t value.  Besides the addition of the new flag, the AV APIs are unchanged, though the use of the flag does modify the behavior of the AV insert calls.