### PR TITLE
efa: Fix markdown formatting in docs

### DIFF
--- a/prov/efa/docs/efa_rdm_protocol_v4.md
+++ b/prov/efa/docs/efa_rdm_protocol_v4.md
@@ -104,7 +104,7 @@ as listed in table 1.1:
 Table: 1.1 A list of subprotocols
 
 | Sub Protocol Name             | Used For  | Defined in |
-|-|-|-|
+|---|---|---|
 | Eager message                 | Two sided | Section 3.2   |
 | Medium message                | Two sided | Section 3.2   |
 | Long-CTS message              | Two sided | Section 3.2   |
@@ -150,44 +150,44 @@ all the packet types in protocol v4 and subprotocol(s) that use it:
 Table: 1.2 A list of packet type IDs
 
 | Packet Type ID  | Nickname          | Full Name                 | Category | Used by                       |
-|-|-|-|-|-|
-| 1               | RTS               | Request To Send           | non-REQ  | Deprecated                    |
-| 2               | CONNACK           | CONNection ACKnowlegement | non-REQ  | Deprecated                    |
-| 3               | CTS               | Clear To Send             | non-REQ  | long-CTS message/read/write |
-| 4               | DATA              | Data                      | non-REQ  | long-CTS message/read/write |
-| 5               | READRSP           | READ ReSPonse             | non-REQ  | emulated short/long-read      |
-| 6               | reserved          | N/A                       | non-REQ  | reserved for internal use      |
-| 7               | EOR               | End Of Read               | non-REQ  | long-read message/write     |
-| 8               | ATOMRSP           | ATOMic ResSPonse          | non-REQ  | emulated write/fetch/compare atomic |
-| 9               | HANDSHAKE         | Handshake                 | non-REQ  | handshake                     |
-| 10              | RECEIPT           | Receipt                   | non-REQ  | delivery complete (DC)         |
-| 64              | EAGER_MSGRTM      | Eager non-tagged Request To Message       | REQ  | eager message |
-| 65              | EAGER_TAGRTM      | Eager tagged Request To Message           | REQ  | eager message |
-| 66              | MEDIUM_MSGRTM     | Medium non-tagged Request To Message      | REQ  | medium message |
-| 67              | MEDIUM_TAGRTM     | Medium tagged Request To Message          | REQ  | medium message |
-| 68              | LONGCTS_MSGRTM    | Long-CTS non-tagged Request To Message    | REQ  | long-CTS message |
-| 69              | LONGCTS_TAGRTM    | Long-CTS tagged Request To Message        | REQ  | long-CTS message |
-| 70              | EAGER_RTW         | Eager Request To Write                    | REQ  | emulated eager write |
-| 71              | LONGCTS_RTW       | Long-CTS Request To Write                 | REQ  | emulated long-CTS write |
-| 72              | SHORT_RTR         | Eager Request To Read                     | REQ  | emulated short read |
-| 73              | LONGCTS_RTR       | Long-CTS Request To Read                  | REQ  | emulated long-CTS read |
-| 74              | WRITE_RTA         | Write Request To Atomic                   | REQ  | emulated write atomic |
-| 75              | FETCH_RTA         | Fetch Request To Atomic                   | REQ  | emulated fetch atomic |
-| 76              | COMPARE_RTA       | Compare Request To Atomic                 | REQ  | emulated compare atomic |
-| 128             | LONGREAD_MSGRTM   | Long-read non-tagged Request To Message   | REQ  | Long-read message |
-| 129             | LONGREAD_TAGRTM   | Long-read tagged Request To Message       | REQ  | Long-read message |
-| 130             | LONGREAD_RTW      | Long-read Request To Write                | REQ  | Long-read message |
-| 131             | reserved          | N/A                                       | N/A  | N/A               |
-| 132             | reserved          | N/A                                       | N/A  | N/A               |
-| 133             | DC_EAGER_MSGRTM   | DC Eager non-tagged Request To Message    | REQ  | DC eager message |
-| 134             | DC_EAGER_TAGRTM   | DC Eager tagged Request To Message        | REQ  | DC eager message |
-| 135             | DC_MEDIUM_MSGRTM  | DC Medium non-tagged Request To Message   | REQ  | DC medium message |
-| 136             | DC_MEDIUM_TAGRTM  | DC Medium tagged Request To Message       | REQ  | DC medium message |
-| 137             | DC_LONGCTS_MSGRTM | DC long-CTS non-tagged Request To Message | REQ  | DC long-CTS message |
-| 138             | DC_LONTCTS_TAGRTM | DC long-CTS tagged Request To Message     | REQ  | DC long-CTS message |
-| 139             | DC_EAGER_RTW      | DC Eager Request To Write                 | REQ  | DC emulated eager write |
-| 140             | DC_LONGCTS_RTW    | DC long-CTS Request To Write              | REQ  | DC emulated long-CTS write |
-| 141             | DC_WRITE_RTA      | DC Write Request To Atomic                | REQ  | DC emulated write atomic |
+|---|---|---|---|---|
+| 1               | `RTS`               | Request To Send           | non-REQ  | Deprecated                    |
+| 2               | `CONNACK`           | CONNection ACKnowlegement | non-REQ  | Deprecated                    |
+| 3               | `CTS`               | Clear To Send             | non-REQ  | long-CTS message/read/write |
+| 4               | `DATA`              | Data                      | non-REQ  | long-CTS message/read/write |
+| 5               | `READRSP`           | READ ReSPonse             | non-REQ  | emulated short/long-read      |
+| 6               | _reserved_          | N/A                       | non-REQ  | reserved for internal use      |
+| 7               | `EOR`               | End Of Read               | non-REQ  | long-read message/write     |
+| 8               | `ATOMRSP`           | ATOMic ResSPonse          | non-REQ  | emulated write/fetch/compare atomic |
+| 9               | `HANDSHAKE`         | Handshake                 | non-REQ  | handshake                     |
+| 10              | `RECEIPT`           | Receipt                   | non-REQ  | delivery complete (DC)         |
+| 64              | `EAGER_MSGRTM`      | Eager non-tagged Request To Message       | REQ  | eager message |
+| 65              | `EAGER_TAGRTM`      | Eager tagged Request To Message           | REQ  | eager message |
+| 66              | `MEDIUM_MSGRTM`     | Medium non-tagged Request To Message      | REQ  | medium message |
+| 67              | `MEDIUM_TAGRTM`     | Medium tagged Request To Message          | REQ  | medium message |
+| 68              | `LONGCTS_MSGRTM`    | Long-CTS non-tagged Request To Message    | REQ  | long-CTS message |
+| 69              | `LONGCTS_TAGRTM`    | Long-CTS tagged Request To Message        | REQ  | long-CTS message |
+| 70              | `EAGER_RTW`         | Eager Request To Write                    | REQ  | emulated eager write |
+| 71              | `LONGCTS_RTW`       | Long-CTS Request To Write                 | REQ  | emulated long-CTS write |
+| 72              | `SHORT_RTR`         | Eager Request To Read                     | REQ  | emulated short read |
+| 73              | `LONGCTS_RTR`       | Long-CTS Request To Read                  | REQ  | emulated long-CTS read |
+| 74              | `WRITE_RTA`         | Write Request To Atomic                   | REQ  | emulated write atomic |
+| 75              | `FETCH_RTA`         | Fetch Request To Atomic                   | REQ  | emulated fetch atomic |
+| 76              | `COMPARE_RTA`       | Compare Request To Atomic                 | REQ  | emulated compare atomic |
+| 128             | `LONGREAD_MSGRTM`   | Long-read non-tagged Request To Message   | REQ  | Long-read message |
+| 129             | `LONGREAD_TAGRTM`   | Long-read tagged Request To Message       | REQ  | Long-read message |
+| 130             | `LONGREAD_RTW`      | Long-read Request To Write                | REQ  | Long-read message |
+| 131             | _reserved_          | N/A                                       | N/A  | N/A               |
+| 132             | _reserved_          | N/A                                       | N/A  | N/A               |
+| 133             | `DC_EAGER_MSGRTM`   | DC Eager non-tagged Request To Message    | REQ  | DC eager message |
+| 134             | `DC_EAGER_TAGRTM`   | DC Eager tagged Request To Message        | REQ  | DC eager message |
+| 135             | `DC_MEDIUM_MSGRTM`  | DC Medium non-tagged Request To Message   | REQ  | DC medium message |
+| 136             | `DC_MEDIUM_TAGRTM`  | DC Medium tagged Request To Message       | REQ  | DC medium message |
+| 137             | `DC_LONGCTS_MSGRTM` | DC long-CTS non-tagged Request To Message | REQ  | DC long-CTS message |
+| 138             | `DC_LONTCTS_TAGRTM` | DC long-CTS tagged Request To Message     | REQ  | DC long-CTS message |
+| 139             | `DC_EAGER_RTW`      | DC Eager Request To Write                 | REQ  | DC emulated eager write |
+| 140             | `DC_LONGCTS_RTW`    | DC long-CTS Request To Write              | REQ  | DC emulated long-CTS write |
+| 141             | `DC_WRITE_RTA`      | DC Write Request To Atomic                | REQ  | DC emulated write atomic |
 
 The packet type ID is included in the 4 byte EFA RDM base header, which every packet must start
 with. The format of the EFA RDM base header is listed in table 1.3:
@@ -195,7 +195,7 @@ with. The format of the EFA RDM base header is listed in table 1.3:
 Table: 1.3 Format of the EFA RDM base header
 
 | Name | Length (bytes) | Type | C language type |
-|-|-|-|-|
+|---|---|---|---|
 | `type`    | 1 | integer | `uint8_t` |
 | `version` | 1 | integer | `uint8_t` |
 | `flags`   | 2 | integer | `uint16_t` |
@@ -212,7 +212,7 @@ Protocol v4 define the following universal flag, which every packet type should 
 Table: 1.4 A list of universal flags
 
 | Bit ID | Value | Name | Description | Used by |
-|-|-|-|-|
+|---|---|---|---|---|
 | 15     | 0x8000 | CONNID_HDR | This packet has "connid" in header | extra request "connid header" (section 4.4) |
 
 Note, the flag `CONNID_HDR` only indicate the presence of connid in the header. The exact location of connid
@@ -240,7 +240,7 @@ format described in the following table 1.5.
 Table: 1.5 Binary format of the EFA RDM raw address
 
 | Name | Lengths (bytes) | Type | C language type | Notes |
-|-|-|-|-|-|
+|---|---|---|---|---|
 | `gid`  | 16 | array   | `uint8_t[16]` | ipv6 format |
 | `qpn`  |  2 | integer | `uint16_t`    | queue pair number |
 | `pad`  |  2 | integer | `uint16_t`    | pad to 4 bytes |
@@ -308,7 +308,7 @@ Currently there are 4 such extra features/requests, as listed in table 2.1:
 Table: 2.1 a list of extra features/requests
 
 | ID | Name              |  Type    | Introduced since | Described in |
-|-|-|-|-|-|
+|---|---|---|---|---|
 | 0  | RDMA read based data transfer    | extra feature | libfabric 1.10.0 | Section 4.1 |
 | 1  | delivery complete                | extra feature | libfabric 1.12.0 | Section 4.2 |
 | 2  | keep packet header length constant | extra request | libfabric 1.13.0 | Section 4.3 |
@@ -368,7 +368,7 @@ The binary format of a HANDSHAKE packet is listed in table 2.2.
 Table: 2.2 binary format of the HANDSHAKE packet
 
 | Name      | Length (bytes) | Type | C language type |
-|-|-|-|-|
+|---|---|---|---|
 | `type`    | 1 | integer | `uint8_t`  |
 | `version` | 1 | integer | `uint8_t`  |
 | `flags`   | 2 | integer | `uint16_t` |
@@ -519,14 +519,14 @@ the same set of flags, which is listed in table 3.1:
 Table: 3.1 A list of REQ packet flags
 
 | Bit Id | Value | Name | Meaning |
-|-|-|-|-|
-|  0     | 0x1    | REQ_OPT_RAW_ADDR_HDR | This REQ packet has the optional raw address header |
-|  1     | 0x2    | REQ_OPT_CQ_DATA_HDR  | This REQ packet has the optional CQ data header |
-|  2     | 0x4    | REQ_MSG              | This REQ packet is used by two-sided communication |
-|  3     | 0x8    | REQ_TAGGED           | This REQ packet is used by tagged two-sided communication |
-|  4     | 0x10   | REQ_RMA              | This REQ packet is used by an emulated RMA (read or write) communication |
-|  5     | 0x20   | REQ_ATOMIC           | This REQ packet is used by an emulated atomic (write,fetch or compare) communication |
-| 15     | 0x8000 | CONNID_HDR           | This REQ packet has the optional connid header |
+|---|---|---|---|
+|  0     | 0x1    | `REQ_OPT_RAW_ADDR_HDR` | This REQ packet has the optional raw address header |
+|  1     | 0x2    | `REQ_OPT_CQ_DATA_HDR`  | This REQ packet has the optional CQ data header |
+|  2     | 0x4    | `REQ_MSG`              | This REQ packet is used by two-sided communication |
+|  3     | 0x8    | `REQ_TAGGED`           | This REQ packet is used by tagged two-sided communication |
+|  4     | 0x10   | `REQ_RMA`              | This REQ packet is used by an emulated RMA (read or write) communication |
+|  5     | 0x20   | `REQ_ATOMIC`           | This REQ packet is used by an emulated atomic (write,fetch or compare) communication |
+| 15     | 0x8000 | `CONNID_HDR`           | This REQ packet has the optional connid header |
 
 Note, the CONNID_HDR flag is an universal flag (table 1.4), and is listed here for completeness.
 
@@ -539,7 +539,7 @@ field of the base header. There are currently 3 REQ optional headers defined:
 Table: 3.2 Format of the REQ optional raw address header
 
 | Field | Type    | Length | C language type |
-|-|-|-|-|
+|---|---|---|---|
 | `size`  | integer | 4      | `uint32` |
 | `addr`  | array   | `size` | `uint8[]` |
 
@@ -591,7 +591,7 @@ The mandatory header of an EAGER_RTM packet is described in table 3.3:
 Table: 3.3 Format of the EAGER_RTM packet
 
 | Name | Length (bytes) | Type | C language type | Notes |
-|-|-|-|-|-|
+|---|---|---|---|---|
 | `type`      | 1 | integer | `uint8_t`  | part of base header |
 | `version`   | 1 | integer | `uint8_t`  | part of base header|
 | `flags`     | 2 | integer | `uint16_t` | part of base header |
@@ -647,14 +647,14 @@ The following diagram illustrates its workflow:
 Table: 3.4 Format of the MEDIUM_RTM packet's mandatory header
 
 | Name | Length (bytes) | Type | C language type | Notes |
-|-|-|-|-|-|
+|---|---|---|---|---|
 | `type`        | 1 | integer | `uint8_t`  | part of base header |
 | `version`     | 1 | integer | `uint8_t`  | part of base header|
 | `flags`       | 2 | integer | `uint16_t` | part of base header |
 | `msg_id`      | 4 | integer | `uint32_t` | message ID |
 | `seg_length` | 8 | integer | `uint64_t` | application data length |
 | `seg_offset` | 8 | integer | `uint64_t` | application data offset |
-| `tag`         | 8 | integer | `uint64_t  | for medium TAGRTM only |
+| `tag`         | 8 | integer | `uint64_t`  | for medium TAGRTM only |
 
 Most of the fields have been introduced and have the same function. The two
 new fields are `seg_length` and `seg_offset`. (`seg` means segment, which
@@ -721,7 +721,7 @@ The format of the LONGCTS_RTM mandatory header is listed in table 3.5:
 Table: 3.5 Format of the LONGCTS_RTM packet's mandatory header
 
 | Name | Length (bytes) | Type | C language type | Notes |
-|-|-|-|-|-|
+|---|---|---|---|---|
 | `type`           | 1 | integer | `uint8_t`  | part of base header |
 | `version`        | 1 | integer | `uint8_t`  | part of base header|
 | `flags`          | 2 | integer | `uint16_t` | part of base header |
@@ -767,7 +767,7 @@ The binary format of a CTS (Clear to Send) packet is listed in table 3.6:
 Table: 3.6 Format a CTS packet
 
 | Name | Length (bytes) | Type | C language type | Notes |
-|-|-|-|-|-|
+|---|---|---|---|---|
 | `type`           | 1 | integer | `uint8_t`  | part of base header |
 | `version`        | 1 | integer | `uint8_t`  | part of base header|
 | `flags`          | 2 | integer | `uint16_t` | part of base header |
@@ -810,7 +810,7 @@ Table 3.7 shows the binary format of DATA packet header:
 Table: 3.7 Format of the DATA packet header
 
 | Name | Length (bytes) | Type | C language type | Notes |
-|-|-|-|-|-|
+|---|---|---|---|---|
 | `type`           | 1 | integer | `uint8_t`  | part of base header |
 | `version`        | 1 | integer | `uint8_t`  | part of base header|
 | `flags`          | 2 | integer | `uint16_t` | part of base header |
@@ -889,7 +889,7 @@ of the EAGER_RTW mandatory header is listed in table 3.8:
 Table: 3.8 Format of the EAGER_RTW packet's mandatory header
 
 | Name | Length (bytes) | Type | C language type | Notes |
-|-|-|-|-|-|
+|---|---|---|---|---|
 | `type`           | 1 | integer | `uint8_t`  | part of base header |
 | `version`        | 1 | integer | `uint8_t`  | part of base header|
 | `flags`          | 2 | integer | `uint16_t` | part of base header |
@@ -914,7 +914,7 @@ LONGCTS_RTM packet. The binary format of the LONGCTS_RTW packet's mandatory head
 Table: 3.9 Format of the LONGCTS_RTW packet's mandatory header
 
 | Name | Length (bytes) | Type | C language type | Notes |
-|-|-|-|-|-|
+|---|---|---|---|---|
 | `type`           | 1 | integer | `uint8_t`  | part of base header |
 | `version`        | 1 | integer | `uint8_t`  | part of base header|
 | `flags`          | 2 | integer | `uint16_t` | part of base header |
@@ -947,7 +947,7 @@ The binary format of a SHORT_RTR mandatory header is listed in the table 3.10:
 Table: 3.10 Format of the SHORT_RTR packet's mandatory header
 
 | Name | Length (bytes) | Type | C language type | Notes |
-|-|-|-|-|-|
+|---|---|---|---|---|
 | `type`           | 1 | integer | `uint8_t`  | part of base header |
 | `version`        | 1 | integer | `uint8_t`  | part of base header|
 | `flags`          | 2 | integer | `uint16_t` | part of base header |
@@ -967,7 +967,7 @@ of the READRSP header is in table 3.11:
 Table: 3.11 Format of the READRSP packet's header
 
 | Name | Length (bytes) | Type | C language type | Notes |
-|-|-|-|-|-|
+|---|---|---|---|---|
 | `type`           | 1 | integer | `uint8_t`  | part of base header |
 | `version`        | 1 | integer | `uint8_t`  | part of base header|
 | `flags`          | 2 | integer | `uint16_t` | part of base header |
@@ -993,7 +993,7 @@ The mandatory header of LONGCTS_RTR packet is listed in table 3.12:
 Table: 3.12 Format of the LONGCTS_RTR packet's mandatory header
 
 | Name | Length (bytes) | Type | C language type | Notes |
-|-|-|-|-|-|
+|---|---|---|---|---|
 | `type`           | 1 | integer | `uint8_t`  | part of base header |
 | `version`        | 1 | integer | `uint8_t`  | part of base header|
 | `flags`          | 2 | integer | `uint16_t` | part of base header |
@@ -1027,7 +1027,7 @@ header:
 Table: 3.13 Format of the WRITE_RTA packet's mandatory header
 
 | Name | Length (bytes) | Type | C language type | Notes |
-|-|-|-|-|-|
+|---|---|---|---|---|
 | `type`           | 1 | integer | `uint8_t`  | part of base header |
 | `version`        | 1 | integer | `uint8_t`  | part of base header|
 | `flags`          | 2 | integer | `uint16_t` | part of base header |
@@ -1059,7 +1059,7 @@ Table 3.14 shows the binary format of the mandatory header of a FETCH_RTA/COMPAR
 Table: 3.14 Format of the FETCH_RTA/COMPARE_RTA packet's mandatory header
 
 | Name | Length (bytes) | Type | C language type | Notes |
-|-|-|-|-|-|
+|---|---|---|---|---|
 | `type`           | 1 | integer | `uint8_t`  | part of base header |
 | `version`        | 1 | integer | `uint8_t`  | part of base header|
 | `flags`          | 2 | integer | `uint16_t` | part of base header |
@@ -1087,7 +1087,7 @@ An ATOMRSP packet consists of two parts: header and application data. Table 3.15
 Table: 3.15 Format of the ATOMRSP packet's header.
 
 | Name | Length (bytes) | Type | C language type | Notes |
-|-|-|-|-|-|
+|---|---|---|---|---|
 | `type`           | 1 | integer | `uint8_t`  | part of base header |
 | `version`        | 1 | integer | `uint8_t`  | part of base header|
 | `flags`          | 2 | integer | `uint16_t` | part of base header |
@@ -1144,7 +1144,7 @@ The binary format of a LONGREAD_RTM packet's mandatory header is listed in table
 Table: 4.1 Format of the LONGREAD_RTM packet's mandatory header
 
 | Name | Length (bytes) | Type | C language type | Notes |
-|-|-|-|-|-|
+|---|---|---|---|---|
 | `type`           | 1 | integer | `uint8_t`  | part of base header |
 | `version`        | 1 | integer | `uint8_t`  | part of base header|
 | `flags`          | 2 | integer | `uint16_t` | part of base header |
@@ -1182,7 +1182,7 @@ The binary format of the EOR packet is listed in table 4.2
 Table: 4.2 Format of the EOR packet
 
 | Name | Length (bytes) | Type | C language type | Notes |
-|-|-|-|-|-|
+|---|---|---|---|---|
 | `type`           | 1 | integer | `uint8_t`  | part of base header |
 | `version`        | 1 | integer | `uint8_t`  | part of base header|
 | `flags`          | 2 | integer | `uint16_t` | part of base header |
@@ -1211,7 +1211,7 @@ in table 4.3.
 Table: 4.3 Format of the LONGREAD_RTW packet's mandatory header
 
 | Name | Length (bytes) | Type | C language type | Notes |
-|-|-|-|-|-|
+|---|---|---|---|---|
 | `type`           | 1 | integer | `uint8_t`  | part of base header |
 | `version`        | 1 | integer | `uint8_t`  | part of base header|
 | `flags`          | 2 | integer | `uint16_t` | part of base header |
@@ -1291,7 +1291,7 @@ Third, the sender/responder will not write a completion until it receives the RE
 The binary format of a RECEIPT packet is as follows:
 
 | Name | Length (bytes) | Type | C language type | Notes |
-|-|-|-|-|-|
+|---|---|---|---|---|
 | `type`           | 1 | integer | `uint8_t`  | part of base header |
 | `version`        | 1 | integer | `uint8_t`  | part of base header|
 | `flags`          | 2 | integer | `uint16_t` | part of base header |


### PR DESCRIPTION
According to at least a couple sites on the Internet and the behavior
of the MacDown rendering engine, table syntax is 3 or more dashes in
the dividing between header and table.

Fix a couple of places where constants with underscores were not
in backticks.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>