### PR TITLE
[v1.14.x] cherry-picked Fix inline assembly for the Nvidia HPC compilers

### DIFF
--- a/include/ofi_abi.h
+++ b/include/ofi_abi.h
@@ -123,11 +123,11 @@ extern "C" {
 #if HAVE_SYMVER_SUPPORT
 
 #define COMPAT_SYMVER(name, api, ver) \
-	asm(".symver " #name "," #api "@" #ver)
+	asm(".symver " #name "," #api "@" #ver "\n")
 #define DEFAULT_SYMVER(name, api, ver) \
-	asm(".symver " #name "," #api "@@" #ver)
+	asm(".symver " #name "," #api "@@" #ver "\n")
 #define CURRENT_SYMVER(name, api) \
-	asm(".symver " #name "," #api "@@" CURRENT_ABI)
+	asm(".symver " #name "," #api "@@" CURRENT_ABI "\n")
 
 #else
 


### PR DESCRIPTION
Fixes a problem with the Nvidia compiler, which does not emit
separate lines for multiple `asm` inline assembly declarations.

Signed-off-by: Theofilos Manitaras <manitaras@cscs.ch>