### PR TITLE
prov/efa: Adding RPATH to EFA Unit Test Executables

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -88,8 +88,9 @@ efa_CPPFLAGS += -I$(top_srcdir)/prov/efa/test $(cmocka_CPPFLAGS)
 
 prov_efa_test_efa_unit_test_CPPFLAGS = $(efa_CPPFLAGS)
 prov_efa_test_efa_unit_test_LDADD = $(cmocka_LIBS) $(linkback)
-prov_efa_test_efa_unit_test_LDFLAGS = $(efa_LDFLAGS) $(cmocka_LDFLAGS) -Wl,--wrap=ibv_create_ah \
-																		-Wl,--wrap=efadv_query_ah
+prov_efa_test_efa_unit_test_LDFLAGS = $(cmocka_rpath) $(efa_LDFLAGS) $(cmocka_LDFLAGS) \
+                                                                    -Wl,--wrap=ibv_create_ah \
+																	-Wl,--wrap=efadv_query_ah
 prov_efa_test_efa_unit_test_LIBS = $(efa_LIBS) $(linkback)
 
 endif ENABLE_EFA_UNIT_TEST

--- a/prov/efa/configure.m4
+++ b/prov/efa/configure.m4
@@ -111,9 +111,11 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 	efa_CPPFLAGS="$efa_ibverbs_CPPFLAGS $efadv_CPPFLAGS"
 	efa_LDFLAGS="$efa_ibverbs_LDFLAGS $efadv_LDFLAGS"
 	efa_LIBS="$efa_ibverbs_LIBS $efadv_LIBS"
+	cmocka_rpath=""
 	AC_SUBST(efa_CPPFLAGS)
 	AC_SUBST(efa_LDFLAGS)
 	AC_SUBST(efa_LIBS)
+	AC_SUBST(cmocka_rpath)
 
 	AC_ARG_ENABLE([efa-unit-test],
 		[AS_HELP_STRING([--enable-efa-unit-test=CMOCKA_INSTALL_DIR],
@@ -148,6 +150,9 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 							#include <stddef.h>
 							#include <setjmp.h>
 					 	 ])
+        if [ test x"$cmocka_dir" != x""]; then
+            cmocka_rpath+=" -R$cmocka_dir/lib64 "
+        fi
 	else
 		AC_DEFINE([EFA_UNIT_TEST], [0], [EFA unit testing])
 	fi


### PR DESCRIPTION
Sets RPATH when the user specifies a cmocka install directory with the --enable-efa-unit-test argument.

Signed-off-by: Seth Zegelstein <szegel@amazon.com>