### PR TITLE
prov/efa/Makefile.include: Add efa-unit-tests to install bin directory

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -77,6 +77,7 @@ _efa_headers = \
 
 if ENABLE_EFA_UNIT_TEST
 check_PROGRAMS += prov/efa/test/efa_unit_test
+bin_PROGRAMS += prov/efa/test/efa_unit_test
 TESTS += prov/efa/test/efa_unit_test
 nodist_prov_efa_test_efa_unit_test_SOURCES = \
 	prov/efa/test/efa_unit_tests.h \


### PR DESCRIPTION
Add EFA Unit Test to install directory.

Signed-off-by: Seth Zegelstein <szegel@amazon.com>