### PR TITLE
[v1.15.x] prov/efa: Decouple device from fabric id

### DIFF
--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -145,7 +145,8 @@ nobase_dist_config_DATA = \
 	pytest/efa/test_rma_bw.py \
 	pytest/efa/test_unexpected_msg.py \
 	pytest/efa/test_multi_recv.py \
-	pytest/efa/test_rnr.py
+	pytest/efa/test_rnr.py \
+	pytest/efa/test_efa_info.py
 
 noinst_LTLIBRARIES = libfabtests.la
 

--- a/fabtests/prov/efa/Makefile.include
+++ b/fabtests/prov/efa/Makefile.include
@@ -31,7 +31,8 @@
 #
 
 bin_PROGRAMS += prov/efa/src/fi_efa_rnr_read_cq_error \
-		prov/efa/src/fi_efa_rnr_queue_resend
+		prov/efa/src/fi_efa_rnr_queue_resend \
+		prov/efa/src/fi_efa_info_test
 
 efa_rnr_srcs = \
 	prov/efa/src/efa_rnr_shared.h \
@@ -47,3 +48,6 @@ prov_efa_src_fi_efa_rnr_queue_resend_SOURCES = \
 	$(efa_rnr_srcs)
 prov_efa_src_fi_efa_rnr_queue_resend_LDADD = libfabtests.la
 
+prov_efa_src_fi_efa_info_test_SOURCES = \
+	prov/efa/src/efa_info_test.c
+prov_efa_src_fi_efa_info_test_LDADD = libfabtests.la

--- a/fabtests/prov/efa/src/efa_info_test.c
+++ b/fabtests/prov/efa/src/efa_info_test.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2022, Amazon.com, Inc.  All rights reserved.
+ *
+ * This software is available to you under the BSD license
+ * below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * This test ensures that the fabric id we get from the efa provider will
+ * always be "efa".
+ *
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <getopt.h>
+#include <shared.h>
+
+int main(int argc, char **argv)
+{
+	int ret;
+	hints = fi_allocinfo();
+	if (!hints)
+		return EXIT_FAILURE;
+	hints->fabric_attr->prov_name=strdup("efa");
+	ret = ft_init();
+	if (ret) {
+		FT_PRINTERR("ft_init", -ret);
+		goto out;
+	}
+	ret = ft_getinfo(hints, &fi);
+	if (ret) {
+		FT_PRINTERR("ft_getinfo", -ret);
+		goto out;
+	}
+	while (NULL != fi) {
+		if (0 != strcmp(fi->fabric_attr->name, "efa")) {
+			ret = EXIT_FAILURE;
+			goto out;
+		}
+		fi = fi->next;
+	}
+
+out:
+	fi_freeinfo(hints);
+	fi_freeinfo(fi);
+	return ft_exit_code(ret);
+}

--- a/fabtests/pytest/efa/test_efa_info.py
+++ b/fabtests/pytest/efa/test_efa_info.py
@@ -1,0 +1,7 @@
+import pytest
+
+@pytest.mark.unit
+def test_efa_info(cmdline_args):
+    from common import UnitTest
+    test = UnitTest(cmdline_args, "fi_efa_info_test")
+    test.run()

--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -57,7 +57,7 @@
 #endif
 
 #define EFA_FABRIC_PREFIX "EFA-"
-
+#define EFA_FABRIC_NAME "efa"
 #define EFA_DOMAIN_CAPS (FI_LOCAL_COMM | FI_REMOTE_COMM)
 
 #define EFA_RDM_TX_CAPS (OFI_TX_MSG_CAPS)
@@ -776,14 +776,15 @@ static int efa_alloc_info(struct efa_context *ctx, struct fi_info **info,
 		goto err_free_info;
 	}
 
-	name_len = strlen(EFA_FABRIC_PREFIX) + INET6_ADDRSTRLEN;
+	name_len = strlen(EFA_FABRIC_NAME);
 
 	fi->fabric_attr->name = calloc(1, name_len + 1);
 	if (!fi->fabric_attr->name) {
 		ret = -FI_ENOMEM;
 		goto err_free_info;
 	}
-	efa_addr_to_str(gid.raw, fi->fabric_attr->name);
+
+	strcpy(fi->fabric_attr->name, EFA_FABRIC_NAME);
 
 	name_len = strlen(ctx->ibv_ctx->device->name) + strlen(ep_dom->suffix);
 	fi->domain_attr->name = malloc(name_len + 1);


### PR DESCRIPTION
Previously we used our device GID as fabric id, which
is not an appropriate coupling. Since our GID does not
contain information to indicate connectivity, we use a
static/constant fabric id instead.

Signed-off-by: William Zhang <wilzhang@amazon.com>
(cherry picked from commit cf35e27d62d6c0cfe037b339ab7497e845ca1d4f)