### PR TITLE
prov/tcp: Move progress mgmt to domain

### DIFF
--- a/fabtests/test_configs/psm3/psm3.exclude
+++ b/fabtests/test_configs/psm3/psm3.exclude
@@ -18,3 +18,4 @@ multi_recv
 rdm_tagged_peek
 dgram_waitset
 cq_data
+sighandler

--- a/include/ofi_epoll.h
+++ b/include/ofi_epoll.h
@@ -199,4 +199,18 @@ typedef struct ofi_pollfds *ofi_epoll_t;
 
 #endif /* HAVE_EPOLL */
 
+/* If we HAVE_EPOLL, the values for EPOLLIN and EPOLLOUT are the same as
+ * POLLIN and POLLOUT, at least in the gnu headers.  If we don't have
+ * epoll support, then we're emulating it using poll, in which case the
+ * values are also the same (e.g. OFI_EPOLL_IN == POLLIN).
+ *
+ * This use of this function helps make it clear that we're passing the
+ * correct event values to epoll, versus poll, without actually incurring
+ * the unnecessary overhead of converting the values.
+ */
+static inline uint32_t ofi_poll_to_epoll(uint32_t events)
+{
+	return events;
+}
+
 #endif  /* _OFI_EPOLL_H_ */

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -169,6 +169,16 @@ enum tcpx_cm_state {
 	/* CM context is freed once connected */
 };
 
+enum tcpx_state {
+	TCPX_IDLE,
+	TCPX_CONNECTING,
+	TCPX_RCVD_REQ,
+	TCPX_ACCEPTING,
+	TCPX_CONNECTED,
+	TCPX_DISCONNECTED,
+	TCPX_LISTENING,
+};
+
 #define OFI_PROV_SPECIFIC_TCP (0x7cb << 16)
 enum {
 	TCPX_CLASS_CM = OFI_PROV_SPECIFIC_TCP,
@@ -202,17 +212,10 @@ struct tcpx_pep {
 	struct util_pep 	util_pep;
 	struct fi_info		*info;
 	SOCKET			sock;
-	struct tcpx_cm_context	cm_ctx;
+	enum tcpx_state		state;
 };
 
-enum tcpx_state {
-	TCPX_IDLE,
-	TCPX_CONNECTING,
-	TCPX_RCVD_REQ,
-	TCPX_ACCEPTING,
-	TCPX_CONNECTED,
-	TCPX_DISCONNECTED,
-};
+void tcpx_accept(struct tcpx_pep *pep);
 
 struct tcpx_cur_rx {
 	union {
@@ -305,7 +308,6 @@ void tcpx_stop_progress(struct tcpx_progress *progress);
 
 void tcpx_run_progress(struct tcpx_progress *progress, bool internal);
 void tcpx_run_ep(struct tcpx_ep *ep, bool pin, bool pout, bool perr);
-void tcpx_run_pep(struct tcpx_pep *pep, bool pin, bool pout, bool perr);
 void tcpx_run_conn(struct tcpx_conn_handle *conn, bool pin, bool pout, bool perr);
 
 int tcpx_trywait(struct tcpx_progress *progress);

--- a/prov/tcp/src/tcpx_conn_mgr.c
+++ b/prov/tcp/src/tcpx_conn_mgr.c
@@ -39,105 +39,76 @@
 #include <ofi_util.h>
 
 
-struct tcpx_cm_context *tcpx_alloc_cm_ctx(fid_t fid, enum tcpx_cm_state state)
-{
-	struct tcpx_cm_context *cm_ctx;
-	struct tcpx_ep *ep;
-
-	cm_ctx = calloc(1, sizeof(*cm_ctx));
-	if (!cm_ctx)
-		return NULL;
-
-	cm_ctx->fid.fclass = TCPX_CLASS_CM;
-	cm_ctx->hfid = fid;
-	if (fid && fid->fclass == FI_CLASS_EP) {
-		ep = container_of(cm_ctx->hfid, struct tcpx_ep,
-				  util_ep.ep_fid.fid);
-		assert(!ep->fid);
-		ep->cm_ctx = cm_ctx;
-	}
-	cm_ctx->state = state;
-	return cm_ctx;
-}
-
-void tcpx_free_cm_ctx(struct tcpx_cm_context *cm_ctx)
-{
-	struct tcpx_ep *ep;
-
-	assert(cm_ctx->fid.fclass == TCPX_CLASS_CM);
-	if (cm_ctx->hfid && cm_ctx->hfid->fclass == FI_CLASS_EP) {
-		ep = container_of(cm_ctx->hfid, struct tcpx_ep,
-				  util_ep.ep_fid.fid);
-		ep->cm_ctx = NULL;
-	}
-
-	free(cm_ctx);
-}
+/* Must be castable to struct fi_eq_cm_entry */
+struct tcpx_cm_entry {
+	fid_t			fid;
+	struct fi_info		*info;
+	uint8_t			data[TCPX_MAX_CM_DATA_SIZE];
+};
 
 /* The underlying socket has the POLLIN event set.  The entire
  * CM message should be readable, as it fits within a single MTU
  * and is the first data transferred over the socket.
  */
-static ssize_t rx_cm_data(SOCKET fd, int type, struct tcpx_cm_context *cm_ctx)
+static int
+tcpx_recv_cm_msg(SOCKET sock, struct tcpx_cm_msg *msg, uint8_t exp_msg)
 {
-	size_t data_size = 0;
+	size_t len;
 	ssize_t ret;
 
-	ret = ofi_recv_socket(fd, &cm_ctx->msg.hdr, sizeof(cm_ctx->msg.hdr), 0);
-	if (ret != sizeof(cm_ctx->msg.hdr)) {
+	len = sizeof(msg->hdr);
+	ret = ofi_recv_socket(sock, &msg->hdr, len, 0);
+	if ((size_t) ret != len) {
 		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
 			"Failed to read cm header\n");
 		ret = ofi_sockerr() ? -ofi_sockerr() : -FI_EIO;
-		goto out;
+		goto err;
 	}
 
-	if (cm_ctx->msg.hdr.version != TCPX_CTRL_HDR_VERSION) {
+	if (msg->hdr.version != TCPX_CTRL_HDR_VERSION) {
 		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
 			"cm protocol version mismatch\n");
 		ret = -FI_ENOPROTOOPT;
-		goto out;
+		goto err;
 	}
 
-	if (cm_ctx->msg.hdr.type != type &&
-	    cm_ctx->msg.hdr.type != ofi_ctrl_nack) {
+	if (msg->hdr.type != exp_msg && msg->hdr.type != ofi_ctrl_nack) {
 		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
-			"unexpected cm message type, expected %d or %d got: %d\n",
-			type, ofi_ctrl_nack, cm_ctx->msg.hdr.type);
+			"unexpected message, expected %d or %d got: %d\n",
+			exp_msg, ofi_ctrl_nack, msg->hdr.type);
 		ret = -FI_ECONNREFUSED;
-		goto out;
+		goto err;
 	}
 
-	data_size = ntohs(cm_ctx->msg.hdr.seg_size);
-	if (data_size) {
-		if (data_size > TCPX_MAX_CM_DATA_SIZE)
-			data_size = TCPX_MAX_CM_DATA_SIZE;
+	len = ntohs(msg->hdr.seg_size);
+	if (len) {
+		if (len > TCPX_MAX_CM_DATA_SIZE) {
+			FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
+				"cm data size is too large\n");
+			ret = -FI_ENOPROTOOPT;
+			goto err;
+		}
 
-		ret = ofi_recv_socket(fd, cm_ctx->msg.data, data_size, 0);
-		if ((size_t) ret != data_size) {
+		ret = ofi_recv_socket(sock, msg->data, len, 0);
+		if ((size_t) ret != len) {
 			FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
 				"Failed to read cm data\n");
 			ret = ofi_sockerr() ? -ofi_sockerr() : -FI_EIO;
-			data_size = 0;
-			goto out;
-		}
-
-		if (data_size > TCPX_MAX_CM_DATA_SIZE) {
-			FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
-				"Discarding unexpected cm data\n");
-			ofi_discard_socket(fd, data_size - TCPX_MAX_CM_DATA_SIZE);
+			goto err;
 		}
 	}
 
-	if (cm_ctx->msg.hdr.type == ofi_ctrl_nack) {
+	if (msg->hdr.type == ofi_ctrl_nack) {
 		FI_INFO(&tcpx_prov, FI_LOG_EP_CTRL,
 			"Connection refused from remote\n");
-		ret = -FI_ECONNREFUSED;
-		goto out;
+		return -FI_ECONNREFUSED;
 	}
 
-	ret = 0;
-out:
-	cm_ctx->cm_data_sz = data_size;
+	return 0;
+
+err:
+	/* For any unexpected error, we have no cm data to report */
+	msg->hdr.seg_size = 0;
 	return ret;
 }
 
@@ -146,362 +117,146 @@ out:
  * message as it fits into a single MTU and is the first data
  * transferred over the socket.
  */
-static int tx_cm_data(SOCKET fd, uint8_t type, struct tcpx_cm_context *cm_ctx)
+int tcpx_send_cm_msg(struct tcpx_ep *ep)
 {
+	size_t len;
 	ssize_t ret;
 
-	memset(&cm_ctx->msg.hdr, 0, sizeof(cm_ctx->msg.hdr));
-	cm_ctx->msg.hdr.version = TCPX_CTRL_HDR_VERSION;
-	cm_ctx->msg.hdr.type = type;
-	cm_ctx->msg.hdr.seg_size = htons((uint16_t) cm_ctx->cm_data_sz);
-	cm_ctx->msg.hdr.conn_data = 1; /* tests endianess mismatch at peer */
+	len = sizeof(ep->cm_msg->hdr) + ntohs(ep->cm_msg->hdr.seg_size);
 
-	ret = ofi_send_socket(fd, &cm_ctx->msg, sizeof(cm_ctx->msg.hdr) +
-			      cm_ctx->cm_data_sz, MSG_NOSIGNAL);
-	if ((size_t) ret != sizeof(cm_ctx->msg.hdr) + cm_ctx->cm_data_sz)
+	ret = ofi_send_socket(ep->bsock.sock, ep->cm_msg, len, MSG_NOSIGNAL);
+	if ((size_t) ret != len)
 		return ofi_sockerr() ? -ofi_sockerr() : -FI_EIO;
 
 	return FI_SUCCESS;
 }
 
-static int tcpx_ep_add_fd(struct tcpx_ep *ep)
+void tcpx_req_done(struct tcpx_ep *ep)
 {
-	int ret;
-
-	if (ep->util_ep.rx_cq) {
-		ret = ofi_wait_add_fd(ep->util_ep.rx_cq->wait,
-				      ep->bsock.sock, POLLIN, tcpx_try_func,
-				      (void *) &ep->util_ep,
-				      &ep->util_ep.ep_fid.fid);
-		if (ret) {
-			FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
-				"Failed to add fd to rx_cq\n");
-			return ret;
-		}
-	}
-
-	if (ep->util_ep.tx_cq) {
-		ret = ofi_wait_add_fd(ep->util_ep.tx_cq->wait,
-				      ep->bsock.sock, POLLIN, tcpx_try_func,
-				      (void *) &ep->util_ep,
-				      &ep->util_ep.ep_fid.fid);
-		if (ret) {
-			FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
-				"Failed to add fd to tx_cq\n");
-			return ret;
-		}
-	}
-
-	if (ep->util_ep.rx_cntr) {
-		ret = ofi_wait_add_fd(ep->util_ep.rx_cntr->wait,
-				      ep->bsock.sock, POLLIN, tcpx_try_func,
-				      (void *) &ep->util_ep,
-				      &ep->util_ep.ep_fid.fid);
-		if (ret) {
-			FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
-				"Failed to add fd to rx_cntr\n");
-			return ret;
-		}
-	}
-
-	if (ep->util_ep.tx_cntr) {
-		ret = ofi_wait_add_fd(ep->util_ep.tx_cntr->wait,
-				      ep->bsock.sock, POLLIN, tcpx_try_func,
-				      (void *) &ep->util_ep,
-				      &ep->util_ep.ep_fid.fid);
-		if (ret) {
-			FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
-				"Failed to add fd to tx_cntr\n");
-			return ret;
-		}
-	}
-
-	if (ep->util_ep.wr_cntr) {
-		ret = ofi_wait_add_fd(ep->util_ep.wr_cntr->wait,
-				      ep->bsock.sock, POLLIN, tcpx_try_func,
-				      (void *) &ep->util_ep,
-				      &ep->util_ep.ep_fid.fid);
-		if (ret) {
-			FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
-				"Failed to add fd to wr_cntr\n");
-			return ret;
-		}
-	}
-
-	if (ep->util_ep.rd_cntr) {
-		ret = ofi_wait_add_fd(ep->util_ep.rd_cntr->wait,
-				      ep->bsock.sock, POLLIN, tcpx_try_func,
-				      (void *) &ep->util_ep,
-				      &ep->util_ep.ep_fid.fid);
-		if (ret) {
-			FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
-				"Failed to add fd to rd_cntr\n");
-			return ret;
-		}
-	}
-
-	if (ep->util_ep.rem_wr_cntr) {
-		ret = ofi_wait_add_fd(ep->util_ep.rem_wr_cntr->wait,
-				      ep->bsock.sock, POLLIN, tcpx_try_func,
-				      (void *) &ep->util_ep,
-				      &ep->util_ep.ep_fid.fid);
-		if (ret) {
-			FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
-				"Failed to add fd to rem_wr_cntr\n");
-			return ret;
-		}
-	}
-
-	if (ep->util_ep.rem_rd_cntr) {
-		ret = ofi_wait_add_fd(ep->util_ep.rem_rd_cntr->wait,
-				      ep->bsock.sock, POLLIN, tcpx_try_func,
-				      (void *) &ep->util_ep,
-				      &ep->util_ep.ep_fid.fid);
-		if (ret) {
-			FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
-				"Failed to add fd to rem_rd_cntr\n");
-			return ret;
-		}
-	}
-	return 0;
-}
-
-static int tcpx_ep_enable(struct tcpx_ep *ep,
-			  struct fi_eq_cm_entry *cm_entry,
-			  size_t cm_entry_sz)
-
-{
-	int ret = 0;
-
-	if (!ep->util_ep.rx_cq && !ep->util_ep.tx_cq) {
-		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
-			"ep must be bound to cq's\n");
-		return -FI_ENOCQ;
-	}
-
-	ofi_mutex_lock(&ep->lock);
-	if (ep->state != TCPX_CONNECTING && ep->state != TCPX_ACCEPTING) {
-		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
-			"ep is in invalid state\n");
-		ret = -FI_EINVAL;
-		goto unlock;
-	}
-
-	ep->state = TCPX_CONNECTED;
-	ofi_mutex_unlock(&ep->lock);
-
-	ret = tcpx_ep_add_fd(ep);
-	if (ret)
-		return ret;
-
-	ret = (int) fi_eq_write(&ep->util_ep.eq->eq_fid, FI_CONNECTED, cm_entry,
-				cm_entry_sz, 0);
-	if (ret < 0) {
-		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL, "Error writing to EQ\n");
-		return ret;
-	}
-
-	return 0;
-
-unlock:
-	ofi_mutex_unlock(&ep->lock);
-	return ret;
-}
-
-static void tcpx_cm_recv_resp(struct util_wait *wait,
-			      struct tcpx_cm_context *cm_ctx)
-{
-	struct fi_eq_cm_entry *cm_entry;
-	struct tcpx_ep *ep;
+	struct tcpx_cm_entry cm_entry;
+	uint16_t len;
 	ssize_t ret;
 
-	FI_DBG(&tcpx_prov, FI_LOG_EP_CTRL, "Handling accept from server\n");
-	assert(cm_ctx->hfid->fclass == FI_CLASS_EP);
-	ep = container_of(cm_ctx->hfid, struct tcpx_ep, util_ep.ep_fid.fid);
+	FI_DBG(&tcpx_prov, FI_LOG_EP_CTRL, "connect request done\n");
+	assert(ofi_mutex_held(&tcpx_ep2_progress(ep)->lock));
+	assert(ofi_mutex_held(&ep->lock));
 
-	ret = rx_cm_data(ep->bsock.sock, ofi_ctrl_connresp, cm_ctx);
+	ret = tcpx_recv_cm_msg(ep->bsock.sock, ep->cm_msg, ofi_ctrl_connresp);
 	if (ret) {
 		if (ret == -FI_EAGAIN)
-			return;
+			return; /* This shouldn't happen */
 
 		enum fi_log_level level = (ret == -FI_ECONNREFUSED) ?
 				FI_LOG_INFO : FI_LOG_WARN;
 		FI_LOG(&tcpx_prov, level, FI_LOG_EP_CTRL,
 			"Failed to receive connect response\n");
-		ofi_wait_del_fd(wait, ep->bsock.sock);
-		goto err1;
+		goto disable;
 	}
 
-	ret = ofi_wait_del_fd(wait, ep->bsock.sock);
-	if (ret) {
-		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
-			"Could not remove fd from wait\n");
-		goto err1;
-	}
-
-	cm_entry = calloc(1, sizeof(*cm_entry) + cm_ctx->cm_data_sz);
-	if (!cm_entry) {
-		ret = FI_ENOMEM;
-		goto err1;
-	}
-
-	cm_entry->fid = cm_ctx->hfid;
-	memcpy(cm_entry->data, cm_ctx->msg.data, cm_ctx->cm_data_sz);
-
-	ep->hdr_bswap = (cm_ctx->msg.hdr.conn_data == 1) ?
+	ep->hdr_bswap = (ep->cm_msg->hdr.conn_data == 1) ?
 			tcpx_hdr_none : tcpx_hdr_bswap;
 
-	ret = tcpx_ep_enable(ep, cm_entry,
-			     sizeof(*cm_entry) + cm_ctx->cm_data_sz);
-	if (ret)
-		goto err2;
+	len = ntohs(ep->cm_msg->hdr.seg_size);
+	cm_entry.fid = &ep->util_ep.ep_fid.fid;
+	cm_entry.info = NULL;
+	if (len)
+		memcpy(cm_entry.data, ep->cm_msg->data, len);
 
-	free(cm_entry);
-	tcpx_free_cm_ctx(cm_ctx);
-	return;
-
-err2:
-	free(cm_entry);
-err1:
-	ofi_mutex_lock(&ep->lock);
-	tcpx_ep_disable(ep, -ret, cm_ctx->msg.data, cm_ctx->cm_data_sz);
-	ofi_mutex_unlock(&ep->lock);
-	tcpx_free_cm_ctx(cm_ctx);
-}
-
-int tcpx_eq_wait_try_func(void *arg)
-{
-	return FI_SUCCESS;
-}
-
-static void tcpx_cm_send_resp(struct util_wait *wait,
-			      struct tcpx_cm_context *cm_ctx)
-{
-	struct fi_eq_cm_entry cm_entry = {0};
-	struct tcpx_ep *ep;
-	int ret;
-
-	FI_DBG(&tcpx_prov, FI_LOG_EP_CTRL, "Send connect (accept) response\n");
-	assert(cm_ctx->hfid->fclass == FI_CLASS_EP);
-	ep = container_of(cm_ctx->hfid, struct tcpx_ep, util_ep.ep_fid.fid);
-
-	ret = tx_cm_data(ep->bsock.sock, ofi_ctrl_connresp, cm_ctx);
-	if (ret) {
-		if (ret == -FI_EAGAIN)
-			return;
-		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
-			"Failed to send connect (accept) response\n");
-		goto delfd;
-	}
-
-	ret = ofi_wait_del_fd(wait, ep->bsock.sock);
-	if (ret) {
-		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
-			"Could not remove fd from wait\n");
-		goto disable;
-	}
-
-	cm_entry.fid = cm_ctx->hfid;
-
-	ret = tcpx_ep_enable(ep, &cm_entry, sizeof(cm_entry));
-	if (ret)
-		goto disable;
-
-	FI_DBG(&tcpx_prov, FI_LOG_EP_CTRL, "Connection Accept Successful\n");
-	tcpx_free_cm_ctx(cm_ctx);
-	return;
-
-delfd:
-	ofi_wait_del_fd(wait, ep->bsock.sock);
-disable:
-	ofi_mutex_lock(&ep->lock);
-	tcpx_ep_disable(ep, -ret, NULL, 0);
-	ofi_mutex_unlock(&ep->lock);
-	tcpx_free_cm_ctx(cm_ctx);
-}
-
-static void tcpx_cm_recv_req(struct util_wait *wait,
-			     struct tcpx_cm_context *cm_ctx)
-{
-	struct tcpx_conn_handle *handle;
-	struct fi_eq_cm_entry *cm_entry;
-	socklen_t len;
-	ssize_t ret;
-
-	FI_DBG(&tcpx_prov, FI_LOG_EP_CTRL, "Server receive connect request\n");
-	handle  = container_of(cm_ctx->hfid, struct tcpx_conn_handle, fid);
-
-	ret = rx_cm_data(handle->sock, ofi_ctrl_connreq, cm_ctx);
-	if (ret) {
-		if (ret == -FI_EAGAIN)
-			return;
-		ofi_wait_del_fd(wait, handle->sock);
-		goto err1;
-	}
-
-	ret = ofi_wait_del_fd(wait, handle->sock);
-	if (ret) {
-		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
-			"fd deletion from ofi_wait failed\n");
-		goto err1;
-	}
-
-	cm_entry = calloc(1, sizeof(*cm_entry) + cm_ctx->cm_data_sz);
-	if (!cm_entry)
-		goto err1;
-
-	cm_entry->fid = &handle->pep->util_pep.pep_fid.fid;
-	cm_entry->info = fi_dupinfo(handle->pep->info);
-	if (!cm_entry->info)
-		goto err2;
-
-	cm_entry->info->dest_addrlen = handle->pep->info->src_addrlen;
-	len = (socklen_t) cm_entry->info->dest_addrlen;
-
-	free(cm_entry->info->dest_addr);
-	cm_entry->info->dest_addr = malloc(len);
-	if (!cm_entry->info->dest_addr)
-		goto err3;
-
-	ret = ofi_getpeername(handle->sock, cm_entry->info->dest_addr, &len);
-	if (ret)
-		goto err3;
-
-	handle->endian_match = (cm_ctx->msg.hdr.conn_data == 1);
-	cm_entry->info->handle = &handle->fid;
-	memcpy(cm_entry->data, cm_ctx->msg.data, cm_ctx->cm_data_sz);
-	cm_ctx->state = TCPX_CM_REQ_RVCD;
-
-	ret = (int) fi_eq_write(&handle->pep->util_pep.eq->eq_fid,
-				FI_CONNREQ, cm_entry,
-				sizeof(*cm_entry) + cm_ctx->cm_data_sz, 0);
+	ret = (int) fi_eq_write(&ep->util_ep.eq->eq_fid, FI_CONNECTED, &cm_entry,
+				sizeof(struct fi_eq_cm_entry) + len, 0);
 	if (ret < 0) {
 		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL, "Error writing to EQ\n");
-		goto err3;
+		goto disable;
 	}
 
-	free(cm_entry);
-	tcpx_free_cm_ctx(cm_ctx);
+	if (tcpx_active_wait(ep)) {
+		dlist_insert_tail(&ep->progress_entry,
+				  &tcpx_ep2_progress(ep)->active_wait_list);
+	}
+	ep->state = TCPX_CONNECTED;
+	free(ep->cm_msg);
+	ep->cm_msg = NULL;
 	return;
-err3:
-	fi_freeinfo(cm_entry->info);
-err2:
-	free(cm_entry);
-err1:
-	ofi_close_socket(handle->sock);
-	tcpx_free_cm_ctx(cm_ctx);
-	free(handle);
+
+disable:
+	tcpx_ep_disable(ep, -ret, ep->cm_msg->data,
+			ntohs(ep->cm_msg->hdr.seg_size));
 }
 
-static void tcpx_cm_send_req(struct util_wait *wait,
-			     struct tcpx_cm_context *cm_ctx)
+void tcpx_run_conn(struct tcpx_conn_handle *conn, bool pin, bool pout, bool perr)
 {
-	struct tcpx_ep *ep;
+	struct tcpx_cm_msg msg;
+	struct tcpx_cm_entry cm_entry;
 	socklen_t len;
-	int status, ret = FI_SUCCESS;
+	uint16_t datalen;
+	int ret;
 
-	FI_DBG(&tcpx_prov, FI_LOG_EP_CTRL, "client send connreq\n");
-	ep = container_of(cm_ctx->hfid, struct tcpx_ep, util_ep.ep_fid.fid);
+	FI_DBG(&tcpx_prov, FI_LOG_EP_CTRL, "Receiving connect request\n");
+	assert(ofi_mutex_held(&tcpx_pep2_progress(conn->pep)->lock));
+
+	/* Don't monitor the socket until the user calls fi_accept */
+	tcpx_halt_sock(tcpx_pep2_progress(conn->pep), conn->sock);
+
+	if (perr) {
+		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL, "socket error\n");
+		goto close;
+	}
+
+	ret = tcpx_recv_cm_msg(conn->sock, &msg, ofi_ctrl_connreq);
+	if (ret) {
+		if (ret == -FI_EAGAIN)
+			return;
+		goto close;
+	}
+
+	cm_entry.fid = &conn->pep->util_pep.pep_fid.fid;
+	cm_entry.info = fi_dupinfo(conn->pep->info);
+	if (!cm_entry.info)
+		goto close;
+
+	cm_entry.info->dest_addrlen = conn->pep->info->src_addrlen;
+	len = (socklen_t) cm_entry.info->dest_addrlen;
+
+	free(cm_entry.info->dest_addr);
+	cm_entry.info->dest_addr = malloc(len);
+	if (!cm_entry.info->dest_addr)
+		goto freeinfo;
+
+	ret = ofi_getpeername(conn->sock, cm_entry.info->dest_addr, &len);
+	if (ret)
+		goto freeinfo;
+
+	conn->endian_match = (msg.hdr.conn_data == 1);
+	cm_entry.info->handle = &conn->fid;
+	datalen = ntohs(msg.hdr.seg_size);
+	if (datalen)
+		memcpy(cm_entry.data, msg.data, datalen);
+
+	ret = (int) fi_eq_write(&conn->pep->util_pep.eq->eq_fid,
+				FI_CONNREQ, &cm_entry,
+				sizeof(struct fi_eq_cm_entry) + datalen, 0);
+	if (ret < 0) {
+		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL, "Error writing to EQ\n");
+		goto freeinfo;
+	}
+
+	return;
+
+freeinfo:
+	fi_freeinfo(cm_entry.info);
+close:
+	ofi_close_socket(conn->sock);
+	free(conn);
+}
+
+void tcpx_connect_done(struct tcpx_ep *ep)
+{
+	socklen_t len;
+	int status, ret;
+
+	FI_DBG(&tcpx_prov, FI_LOG_EP_CTRL, "socket connected, sending req\n");
+	assert(ofi_mutex_held(&tcpx_ep2_progress(ep)->lock));
+	assert(ofi_mutex_held(&ep->lock));
 
 	len = sizeof(status);
 	ret = getsockopt(ep->bsock.sock, SOL_SOCKET, SO_ERROR,
@@ -510,46 +265,30 @@ static void tcpx_cm_send_req(struct util_wait *wait,
 		ret = (ret < 0)? -ofi_sockerr() : -status;
 		FI_WARN_SPARSE(&tcpx_prov, FI_LOG_EP_CTRL,
 				"connection failure (sockerr %d)\n", ret);
-		goto delfd;
-	}
-
-	ret = tx_cm_data(ep->bsock.sock, ofi_ctrl_connreq, cm_ctx);
-	if (ret)
-		goto delfd;
-
-	ret = ofi_wait_del_fd(wait, ep->bsock.sock);
-	if (ret) {
-		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
-			"Could not remove fd from wait: %s\n",
-			fi_strerror(-ret));
 		goto disable;
 	}
 
-	cm_ctx->state = TCPX_CM_REQ_SENT;
-	ret = ofi_wait_add_fd(wait, ep->bsock.sock, POLLIN,
-			      tcpx_eq_wait_try_func, NULL, cm_ctx);
+	ret = tcpx_send_cm_msg(ep);
 	if (ret)
 		goto disable;
 
+	ep->state = TCPX_REQ_SENT;
+	tcpx_update_poll(ep);
 	return;
 
-delfd:
-	ofi_wait_del_fd(wait, ep->bsock.sock);
 disable:
-	ofi_mutex_lock(&ep->lock);
 	tcpx_ep_disable(ep, -ret, NULL, 0);
-	ofi_mutex_unlock(&ep->lock);
-	tcpx_free_cm_ctx(cm_ctx);
 }
 
-void tcpx_accept(struct tcpx_pep *pep)
+void tcpx_accept_sock(struct tcpx_pep *pep)
 {
-	struct tcpx_conn_handle *handle;
-	struct tcpx_cm_context *rx_req_cm_ctx;
+	struct tcpx_conn_handle *conn;
 	SOCKET sock;
 	int ret;
 
-	FI_DBG(&tcpx_prov, FI_LOG_EP_CTRL, "accepting connection\n");
+	FI_DBG(&tcpx_prov, FI_LOG_EP_CTRL, "accepting socket\n");
+	assert(ofi_mutex_held(&tcpx_pep2_progress(pep)->lock));
+
 	sock = accept(pep->sock, NULL, 0);
 	if (sock < 0) {
 		if (!OFI_SOCK_TRY_ACCEPT_AGAIN(ofi_sockerr())) {
@@ -559,103 +298,27 @@ void tcpx_accept(struct tcpx_pep *pep)
 		return;
 	}
 
-	handle = calloc(1, sizeof(*handle));
-	if (!handle) {
+	conn = calloc(1, sizeof(*conn));
+	if (!conn) {
 		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
-			"cannot allocate memory \n");
-		goto err1;
+			"cannot allocate memory\n");
+		goto close;
 	}
 
-	rx_req_cm_ctx = tcpx_alloc_cm_ctx(&handle->fid, TCPX_CM_WAIT_REQ);
-	if (!rx_req_cm_ctx)
-		goto err2;
+	conn->sock = sock;
+	conn->fid.fclass = FI_CLASS_CONNREQ;
+	/* TODO: We need to hold a reference on the pep to defer destruction */
+	conn->pep = pep;
 
-	handle->sock = sock;
-	handle->fid.fclass = FI_CLASS_CONNREQ;
-	handle->pep = pep;
-
-	ret = ofi_wait_add_fd(pep->util_pep.eq->wait, sock, POLLIN,
-			      tcpx_eq_wait_try_func,
-			      NULL, (void *) rx_req_cm_ctx);
+	ret = tcpx_monitor_sock(tcpx_pep2_progress(pep), sock, POLLIN,
+				&conn->fid);
 	if (ret)
-		goto err3;
+		goto free;
 
 	return;
-err3:
-	free(rx_req_cm_ctx);
-err2:
-	free(handle);
-err1:
+
+free:
+	free(conn);
+close:
 	ofi_close_socket(sock);
-}
-
-static void process_cm_ctx(struct util_wait *wait,
-			   struct tcpx_cm_context *cm_ctx)
-{
-	switch (cm_ctx->state) {
-	case TCPX_CM_CONNECTING:
-		assert((cm_ctx->hfid->fclass == FI_CLASS_EP) &&
-		       (container_of(cm_ctx->hfid, struct tcpx_ep,
-				     util_ep.ep_fid.fid)->state ==
-							  TCPX_CONNECTING));
-		tcpx_cm_send_req(wait, cm_ctx);
-		break;
-	case TCPX_CM_WAIT_REQ:
-		assert(cm_ctx->hfid->fclass == FI_CLASS_CONNREQ);
-		tcpx_cm_recv_req(wait, cm_ctx);
-		break;
-	case TCPX_CM_RESP_READY:
-		assert((cm_ctx->hfid->fclass == FI_CLASS_EP) &&
-		       (container_of(cm_ctx->hfid, struct tcpx_ep,
-				     util_ep.ep_fid.fid)->state ==
-							  TCPX_ACCEPTING));
-		tcpx_cm_send_resp(wait, cm_ctx);
-		break;
-	case TCPX_CM_REQ_SENT:
-		assert((cm_ctx->hfid->fclass == FI_CLASS_EP) &&
-		       (container_of(cm_ctx->hfid, struct tcpx_ep,
-				     util_ep.ep_fid.fid)->state ==
-							  TCPX_CONNECTING));
-		tcpx_cm_recv_resp(wait, cm_ctx);
-		break;
-	default:
-		break;
-	}
-}
-
-void tcpx_run_conn(struct tcpx_conn_handle *conn, bool pin, bool pout, bool perr)
-{
-	/* TODO: placeholder */
-}
-
-void tcpx_conn_mgr_run(struct util_eq *util_eq)
-{
-	struct util_wait_fd *wait_fd;
-	struct tcpx_eq *eq;
-	struct fid *fid;
-	struct ofi_epollfds_event events[MAX_POLL_EVENTS];
-	int count, i;
-
-	assert(util_eq->wait != NULL);
-	wait_fd = container_of(util_eq->wait, struct util_wait_fd, util_wait);
-
-	eq = container_of(util_eq, struct tcpx_eq, util_eq);
-	ofi_mutex_lock(&eq->close_lock);
-	count = (wait_fd->util_wait.wait_obj == FI_WAIT_FD) ?
-		ofi_epoll_wait(wait_fd->epoll_fd, events, MAX_POLL_EVENTS, 0) :
-		ofi_pollfds_wait(wait_fd->pollfds, events, MAX_POLL_EVENTS, 0);
-	if (count < 0)
-		goto unlock;
-
-	for (i = 0; i < count; i++) {
-		/* skip wake up signals */
-		if (&wait_fd->util_wait.wait_fid.fid == events[i].data.ptr)
-			continue;
-
-		fid = events[i].data.ptr;
-		if (fid->fclass == TCPX_CLASS_CM)
-			process_cm_ctx(util_eq->wait, events[i].data.ptr);
-	}
-unlock:
-	ofi_mutex_unlock(&eq->close_lock);
 }

--- a/prov/tcp/src/tcpx_conn_mgr.c
+++ b/prov/tcp/src/tcpx_conn_mgr.c
@@ -632,6 +632,11 @@ static void process_cm_ctx(struct util_wait *wait,
 	}
 }
 
+void tcpx_run_conn(struct tcpx_conn_handle *conn, bool pin, bool pout, bool perr)
+{
+	/* TODO: placeholder */
+}
+
 void tcpx_conn_mgr_run(struct util_eq *util_eq)
 {
 	struct util_wait_fd *wait_fd;

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -836,6 +836,7 @@ int tcpx_endpoint(struct fid_domain *domain, struct fi_info *info,
 	if (ret)
 		goto err3;
 
+	dlist_init(&ep->progress_entry);
 	slist_init(&ep->rx_queue);
 	slist_init(&ep->tx_queue);
 	slist_init(&ep->priority_queue);

--- a/prov/tcp/src/tcpx_fabric.c
+++ b/prov/tcp/src/tcpx_fabric.c
@@ -47,7 +47,7 @@ struct fi_ops_fabric tcpx_fabric_ops = {
 	.passive_ep = tcpx_passive_ep,
 	.eq_open = tcpx_eq_create,
 	.wait_open = ofi_wait_fd_open,
-	.trywait = ofi_trywait
+	.trywait = tcpx_trywait,
 };
 
 static int tcpx_fabric_close(fid_t fid)

--- a/prov/tcp/src/tcpx_msg.c
+++ b/prov/tcp/src/tcpx_msg.c
@@ -257,14 +257,6 @@ tcpx_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	return FI_SUCCESS;
 }
 
-static inline void
-tcpx_queue_send(struct tcpx_ep *ep, struct tcpx_xfer_entry *tx_entry)
-{
-	ofi_mutex_lock(&ep->lock);
-	tcpx_tx_queue_insert(ep, tx_entry);
-	ofi_mutex_unlock(&ep->lock);
-}
-
 static ssize_t
 tcpx_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t flags)
 {

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -867,10 +867,6 @@ static bool tcpx_active_wait(struct tcpx_ep *ep)
 	       (ep->cur_rx.handler && !ep->cur_rx.entry);
 }
 
-void tcpx_run_pep(struct tcpx_pep *pep, bool pin, bool pout, bool perr)
-{
-}
-
 void tcpx_run_ep(struct tcpx_ep *ep, bool pin, bool pout, bool perr)
 {
 	ofi_mutex_lock(&ep->lock);
@@ -933,7 +929,7 @@ void tcpx_run_progress(struct tcpx_progress *progress, bool internal)
 			ofi_mutex_unlock(&ep->lock);
 			break;
 		case FI_CLASS_PEP:
-			tcpx_run_pep(events[i].data.ptr, pin, pout, perr);
+			tcpx_accept(events[i].data.ptr);
 			break;
 		case TCPX_CLASS_CM:
 			tcpx_run_conn(events[i].data.ptr, pin, pout, perr);

--- a/prov/tcp/src/tcpx_rma.c
+++ b/prov/tcp/src/tcpx_rma.c
@@ -124,10 +124,12 @@ tcpx_rma_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 	tcpx_rma_read_send_entry_fill(send_entry, recv_entry, ep, msg);
 	tcpx_rma_read_recv_entry_fill(recv_entry, ep, msg, flags);
 
+	ofi_mutex_lock(&tcpx_ep2_progress(ep)->lock);
 	ofi_mutex_lock(&ep->lock);
 	slist_insert_tail(&recv_entry->entry, &ep->rma_read_queue);
 	tcpx_tx_queue_insert(ep, send_entry);
 	ofi_mutex_unlock(&ep->lock);
+	ofi_mutex_unlock(&tcpx_ep2_progress(ep)->lock);
 	return FI_SUCCESS;
 }
 
@@ -246,9 +248,7 @@ tcpx_rma_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 	tcpx_set_commit_flags(send_entry, flags);
 	send_entry->context = msg->context;
 
-	ofi_mutex_lock(&ep->lock);
-	tcpx_tx_queue_insert(ep, send_entry);
-	ofi_mutex_unlock(&ep->lock);
+	tcpx_queue_send(ep, send_entry);
 	return FI_SUCCESS;
 }
 
@@ -376,10 +376,7 @@ tcpx_rma_inject_common(struct fid_ep *ep_fid, const void *buf, size_t len,
 	send_entry->iov_cnt = 1;
 
 	send_entry->hdr.base_hdr.size = offset;
-
-	ofi_mutex_lock(&ep->lock);
-	tcpx_tx_queue_insert(ep, send_entry);
-	ofi_mutex_unlock(&ep->lock);
+	tcpx_queue_send(ep, send_entry);
 	return FI_SUCCESS;
 }
 

--- a/prov/util/src/util_wait.c
+++ b/prov/util/src/util_wait.c
@@ -40,17 +40,6 @@
 #include <ofi_epoll.h>
 
 
-static uint32_t ofi_poll_to_epoll(uint32_t events)
-{
-	uint32_t epoll_events = 0;
-
-	if (events & POLLIN)
-		epoll_events |= OFI_EPOLL_IN;
-	if (events & POLLOUT)
-		epoll_events |= OFI_EPOLL_OUT;
-	return epoll_events;
-}
-
 int ofi_trywait(struct fid_fabric *fabric, struct fid **fids, int count)
 {
 	struct util_cq *cq;


### PR DESCRIPTION
Introduce a new progress engine.  The engine/class encapsulate progress
management into a single object.  The engine will allow us to move progress from the
current CQ + counters to a single location.  This will not only simplify the code, but
make it easier to apply future enhancements, such as support for io_uring.  The
progress engine is associated with an open fabric object.

All tcp progress is migrated to the new progress engine.  This includes all connection
management, listening sockets, connecting sockets, and active endpoints.  As a result of
these changes, the progress locking is restructured and simplified.  There's no longer any
need to bounce a socket between different poll sets (EQ and CQ, for example), or add the
socket to multiple poll sets (e.g. Tx and Rx CQs).  Connections should
also be established quicker, since listening sockets are watched even when trying to drive
data progress.  (A future patch will improve this more by allowing tcp to callback into
rxm for faster connection setup).

The expectation is that applications that do not use wait object or blocking calls should
see a slight improvement to stability and performance.  For applications that use wait
objects or blocking calls, stability improvements are expected, but the impact on
performance is unknown as of now.  Blocking calls require spawning a progress thread
to drive progress.  It may be possible to remove the progress thread in certain cases
as a future enhancement, but for now, the thread helps ensure correct behavior prior
to implementing other enhancements.