### PR TITLE
prov/efa: fix the variable usage in efa_hmem_support_status_update_all()

### DIFF
--- a/prov/efa/src/efa_hmem.c
+++ b/prov/efa/src/efa_hmem.c
@@ -178,7 +178,7 @@ int efa_hmem_support_status_update_all(struct efa_hmem_support_status *all_statu
 			 err);
 	}
 
-	ret = efa_hmem_support_status_update_neuron(&all_status[FI_HMEM_NEURON]);
+	err = efa_hmem_support_status_update_neuron(&all_status[FI_HMEM_NEURON]);
 	if (err) {
 		ret = err;
 		EFA_WARN(FI_LOG_DOMAIN, "check neuron support status failed! err: %d\n",


### PR DESCRIPTION
In efa_hmem_support_status_update_all(), the return value of
efa_hmem_support_status_update_neuron() should be saved in err,
not ret. This patch fixed the issue.

Signed-off-by: Wei Zhang <wzam@amazon.com>