### PR TITLE
log: remove dependency to config.h from fi_log.h

### DIFF
--- a/include/ofi.h
+++ b/include/ofi.h
@@ -36,7 +36,7 @@
 #ifndef _OFI_H_
 #define _OFI_H_
 
-#include "config.h"
+#include <config.h>
 
 #include <assert.h>
 #include <pthread.h>

--- a/include/rdma/providers/fi_log.h
+++ b/include/rdma/providers/fi_log.h
@@ -35,8 +35,6 @@
 #ifndef FI_LOG_H
 #define FI_LOG_H
 
-#include "config.h"
-
 #include <rdma/fabric.h>
 #include <rdma/providers/fi_prov.h>
 
@@ -106,7 +104,7 @@ void fi_log(const struct fi_provider *prov, enum fi_log_level level,
 #define FI_INFO(prov, subsystem, ...)					\
 	FI_LOG(prov, FI_LOG_INFO, subsystem, __VA_ARGS__)
 
-#if ENABLE_DEBUG
+#if defined(ENABLE_DEBUG) && ENABLE_DEBUG
 #define FI_DBG(prov, subsystem, ...)					\
 	FI_LOG(prov, FI_LOG_DEBUG, subsystem, __VA_ARGS__)
 #define FI_DBG_TRACE(prov, subsystem, ...)				\

--- a/prov/mrail/src/mrail.h
+++ b/prov/mrail/src/mrail.h
@@ -44,7 +44,7 @@
 #include <rdma/fi_eq.h>
 #include <rdma/fi_rma.h>
 #include <rdma/fi_tagged.h>
-#include "rdma/providers/fi_log.h"
+#include <rdma/providers/fi_log.h>
 
 #include <ofi.h>
 #include <ofi_util.h>

--- a/prov/netdir/src/netdir_log.h
+++ b/prov/netdir/src/netdir_log.h
@@ -33,6 +33,8 @@
 #ifndef _FI_NETDIR_LOG_H_
 #define _FI_NETDIR_LOG_H_
 
+#include "config.h"
+
 #include <windows.h>
 
 #include "rdma/providers/fi_log.h"
@@ -120,7 +122,7 @@ ofi_nd_get_last_error_str(HRESULT hr, char *errmsg, SIZE_T max_msg_len)
 	  break
 
 #define ND_FLUSHED 0x10000L	/* undocumented ND error code */
-#define ND_DISCONNECTED 0xc000020C 
+#define ND_DISCONNECTED 0xc000020C
 
 static char *ofi_nd_error_str(HRESULT hr)
 {

--- a/prov/opx/src/test/test_hfi_select.c
+++ b/prov/opx/src/test/test_hfi_select.c
@@ -29,6 +29,9 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
+#include "config.h"
+
 #include <stdio.h>
 #include <stdarg.h>
 #include <check.h>

--- a/prov/rstream/src/rstream.h
+++ b/prov/rstream/src/rstream.h
@@ -47,7 +47,7 @@
 #include <rdma/fi_eq.h>
 #include <rdma/fi_rma.h>
 #include <rdma/fi_tagged.h>
-#include "rdma/providers/fi_log.h"
+#include <rdma/providers/fi_log.h>
 
 #include <ofi.h>
 #include <ofi_util.h>

--- a/prov/sockets/include/sock_util.h
+++ b/prov/sockets/include/sock_util.h
@@ -35,6 +35,8 @@
 #ifndef _SOCK_UTIL_H_
 #define _SOCK_UTIL_H_
 
+#include <config.h>
+
 #include <sys/mman.h>
 #include <rdma/providers/fi_log.h>
 #include "sock.h"

--- a/prov/usnic/src/usdf.h
+++ b/prov/usnic/src/usdf.h
@@ -36,6 +36,8 @@
 #ifndef _USDF_H_
 #define _USDF_H_
 
+#include <config.h>
+
 #include <sys/queue.h>
 #include <pthread.h>
 

--- a/prov/util/src/util_ns.c
+++ b/prov/util/src/util_ns.c
@@ -41,6 +41,8 @@
  * a query to the name server residing on "node".
  */
 
+#include <config.h>
+
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netdb.h>
@@ -112,7 +114,7 @@ err2:
 err1:
 	return ret;
 }
- 
+
 static int util_ns_map_del(struct util_ns *ns, void *service_in,
 			   void *name_in)
 {

--- a/src/perf.c
+++ b/src/perf.c
@@ -30,6 +30,7 @@
  * SOFTWARE.
  */
 
+#include <config.h>
 
 #include <stdio.h>
 #include <string.h>

--- a/src/unix/osd.c
+++ b/src/unix/osd.c
@@ -35,6 +35,8 @@
 #define _GNU_SOURCE
 #endif /* _GNU_SOURCE */
 
+#include "config.h"
+
 #include <stdio.h>
 #include <unistd.h>
 #include <fcntl.h>

--- a/src/windows/osd.c
+++ b/src/windows/osd.c
@@ -30,6 +30,8 @@
  * SOFTWARE.
  */
 
+#include "config.h"
+
 #include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>


### PR DESCRIPTION
Patch a33a3e577("log: Add the provider header files to the
installation") added the header file fi_log.h to the installation.
Problem is that fi_log.h depends on contrib.h, but the application
cannot find it because it's not installed.

The fix implemented in the patch is to remove the inclusion of fi_log.h
and make FI_DBG() usable even if lifbabric is not compiled in debug
mode. Now that applications can import their own logging callbacks,
it makes sense to always intercept FI_LOG_DEBUG log messages anyway.

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>