### PR TITLE
fi_tostr: Add missing hmem ifaces.

### DIFF
--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -748,6 +748,7 @@ ofi_tostr_hmem_iface(char *buf, size_t len, enum fi_hmem_iface iface)
 	CASEENUMSTRN(FI_HMEM_CUDA, len);
 	CASEENUMSTRN(FI_HMEM_ROCR, len);
 	CASEENUMSTRN(FI_HMEM_ZE, len);
+	CASEENUMSTRN(FI_HMEM_NEURON, len);
 	default:
 		ofi_strncatf(buf, len, "Unknown");
 		break;

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -749,6 +749,7 @@ ofi_tostr_hmem_iface(char *buf, size_t len, enum fi_hmem_iface iface)
 	CASEENUMSTRN(FI_HMEM_ROCR, len);
 	CASEENUMSTRN(FI_HMEM_ZE, len);
 	CASEENUMSTRN(FI_HMEM_NEURON, len);
+	CASEENUMSTRN(FI_HMEM_SYNAPSEAI, len);
 	default:
 		ofi_strncatf(buf, len, "Unknown");
 		break;


### PR DESCRIPTION
Add missing cases for FI_HMEM_NEURON and FI_HMEM_SYNAPSEAI

Signed-off-by: Shi Jin <sjina@amazon.com>