### PR TITLE
[v1.15.x] fi_tostr: add missing hmem iface for neuron

### DIFF
--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -747,6 +747,7 @@ ofi_tostr_hmem_iface(char *buf, size_t len, enum fi_hmem_iface iface)
 	CASEENUMSTRN(FI_HMEM_CUDA, len);
 	CASEENUMSTRN(FI_HMEM_ROCR, len);
 	CASEENUMSTRN(FI_HMEM_ZE, len);
+	CASEENUMSTRN(FI_HMEM_NEURON, len);
 	default:
 		ofi_strncatf(buf, len, "Unknown");
 		break;


### PR DESCRIPTION
Signed-off-by: Shi Jin <sjina@amazon.com>
(cherry picked from commit a4e0bb1dac99b4315d8bcb2f0d77a704ff70d70c)