### PR TITLE
contrib/intel/jenkins: Add OneCCL GPU tests to CI

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -383,6 +383,23 @@ pipeline {
                         }
                     }
                 }
+                stage('oneCCL-GPU') {
+                    agent {node {label 'ze'}}
+                    options { skipDefaultCheckout() }
+                    steps {
+                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
+                        {
+                          sh """
+                            env
+                            (
+                                cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                                python3.7 runtests.py --prov=tcp --test=onecclgpu
+                                echo "oneCCL-GPU completed."
+                            )
+                          """
+                        }
+                    }
+                }
                 stage('ze-shm') {
                     agent {node {label 'ze'}}
                     options { skipDefaultCheckout() }

--- a/contrib/intel/jenkins/run.py
+++ b/contrib/intel/jenkins/run.py
@@ -157,5 +157,27 @@ def oneccltest(core, hosts, mode, util):
               .format(runoneccltest.testname))
     print("-------------------------------------------------------------------")
 
+def oneccltestgpu(core, hosts, mode, util):
+
+    runoneccltestgpu = tests.OneCCLTestsGPU(jobname=jbname,buildno=bno,
+                                         testname="oneccl GPU test", core_prov=core,
+                                         fabric=fab, hosts=hosts,
+                                         ofi_build_mode=mode, util_prov=util)
+
+    print("-------------------------------------------------------------------")
+    if (runoneccltestgpu.execute_condn):
+        print("Running oneCCL GPU examples test for {}-{}-{}" \
+              .format(core, util, fab))
+        runoneccltestgpu.execute_cmd('examples')
+
+        print("---------------------------------------------------------------")
+        print("Running oneCCL GPU functional test for {}-{}-{}" \
+              .format(core, util, fab))
+        runoneccltestgpu.execute_cmd('functional')
+    else:
+        print("Skipping {} as execute condition fails" \
+              .format(runoneccltestgpu.testname))
+    print("-------------------------------------------------------------------")
+
 if __name__ == "__main__":
     pass

--- a/contrib/intel/jenkins/runtests.py
+++ b/contrib/intel/jenkins/runtests.py
@@ -15,7 +15,7 @@ parser.add_argument('--ofi_build_mode', help="specify the build configuration", 
                     choices = ['dbg', 'dl'])
 parser.add_argument('--test', help="specify test to execute", \
                     choices = ['all', 'shmem', 'IMB', 'osu', 'oneccl', \
-                               'mpichtestsuite', 'fabtests'])
+                               'mpichtestsuite', 'fabtests', 'onecclgpu'])
 parser.add_argument('--imb_grp', help="IMB test group {1:[MPI1, P2P], \
                     2:[EXT, IO], 3:[NBC, RMA, MT]", choices=['1', '2', '3'])
 parser.add_argument('--device', help="optional gpu device", choices=['ze'])
@@ -69,6 +69,9 @@ if(args_core):
 
             if (run_test == 'all' or run_test == 'oneccl'):
                 run.oneccltest(args_core, hosts, ofi_build_mode, args_util)
+
+            if (run_test == 'all' or run_test == 'onecclgpu'):
+                run.oneccltestgpu(args_core, hosts, ofi_build_mode, args_util)
 
             for mpi in mpilist:
                 if (run_test == 'all' or run_test == 'mpichtestsuite'):

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -651,3 +651,78 @@ class OneCCLTests(Test):
                         outputcmd = shlex.split(command)
                         common.run_command(outputcmd)
 
+class OneCCLTestsGPU(Test):
+
+    def __init__(self, jobname, buildno, testname, core_prov, fabric,
+                 hosts, ofi_build_mode, util_prov=None):
+        super().__init__(jobname, buildno, testname, core_prov, fabric,
+                         hosts, ofi_build_mode, util_prov)
+
+        self.n = 2
+        self.ppn = 4
+        self.oneccl_path = '{}/oneccl_gpu/build'.format(self.ci_middlewares_path)
+
+        self.examples_tests = {
+                                  'sycl_allgatherv_custom_usm_test',
+                                  'sycl_allgatherv_inplace_test',
+                                  'sycl_allgatherv_inplace_usm_test',
+                                  'sycl_allgatherv_test',
+                                  'sycl_allgatherv_usm_test',
+                                  'sycl_allreduce_inplace_usm_test',
+                                  'sycl_allreduce_test',
+                                  'sycl_allreduce_usm_test',
+                                  'sycl_alltoall_test',
+                                  'sycl_alltoall_usm_test',
+                                  'sycl_alltoallv_test',
+                                  'sycl_alltoallv_usm_test',
+                                  'sycl_broadcast_test',
+                                  'sycl_broadcast_usm_test',
+                                  'sycl_reduce_inplace_usm_test',
+                                  'sycl_reduce_scatter_test',
+                                  'sycl_reduce_scatter_usm_test',
+                                  'sycl_reduce_test',
+                                  'sycl_reduce_usm_test'
+                              }
+        self.functional_tests = {
+                                    'allgatherv_test',
+                                    'alltoall_test',
+                                    'alltoallv_test',
+                                    'bcast_test',
+                                    'reduce_scatter_test',
+                                    'reduce_test'
+                                }
+
+    @property
+    def cmd(self):
+        return "{}/run_oneccl_gpu.sh ".format(ci_site_config.testpath)
+
+    def options(self, oneccl_test_gpu):
+        opts = "-n {n} ".format(n=self.n)
+        opts += "-ppn {ppn} ".format(ppn=self.ppn)
+        opts += "-hosts {server},{client} ".format(server=self.server,
+                                                   client=self.client)
+        opts += "-test {test_suite} ".format(test_suite=oneccl_test_gpu)
+        opts += "-libfabric_path={path}/lib " \
+                .format(path=self.libfab_installpath)
+        opts += '-oneccl_root={oneccl_path}' \
+                .format(oneccl_path=self.oneccl_path)
+        return opts
+
+    @property
+    def execute_condn(self):
+        return True
+
+
+    def execute_cmd(self, oneccl_test_gpu):
+        if oneccl_test_gpu == 'examples':
+                for test in self.examples_tests:
+                        command = self.cmd + self.options(oneccl_test_gpu) + \
+                                  " {}".format(test)
+                        outputcmd = shlex.split(command)
+                        common.run_command(outputcmd)
+        elif oneccl_test_gpu == 'functional':
+                for test in self.functional_tests:
+                        command = self.cmd + self.options(oneccl_test_gpu) + \
+                                  " {}".format(test)
+                        outputcmd = shlex.split(command)
+                        common.run_command(outputcmd)


### PR DESCRIPTION
- Add OneCCL examples and functional test suites in GPU mode
to libfabric CI.
- Tests run with tcp provider only. There is an issue with
OFI MPI init hook while running tests with psm3 provider.
This needs to be investigated separately.
- One of the functional tests (allreduce_test) is not added
as it is resulting in a segmentation fault. OneCCL team
needs to be consulted for this issue.
- Takes 1 min 42 secs to complete.

Signed-off-by: Juee Himalbhai Desai <juee.himalbhai.desai@intel.com>