### PR TITLE
prov/opx: Do not return opx as a provider on systems without hardware

### DIFF
--- a/prov/opx/include/opa_service.h
+++ b/prov/opx/include/opa_service.h
@@ -271,4 +271,7 @@ int64_t opx_hfi_sysfs_unit_read_node_s64(uint32_t unit);
 
 int opx_hfi_cmd_wait_for_packet(int fd);
 
+/* returns number of hfi1_* devs in /dev */
+int opx_hfi_get_hfi1_count();
+
 #endif /* OPA_SERVICE_H */

--- a/prov/opx/src/fi_opx_init.c
+++ b/prov/opx/src/fi_opx_init.c
@@ -37,6 +37,7 @@
 #include "rdma/opx/fi_opx_hfi1.h"
 #include "rdma/opx/fi_opx_domain.h"
 #include "ofi_prov.h"
+#include "opa_service.h"
 
 #include "rdma/opx/fi_opx_addr.h"
 
@@ -367,6 +368,9 @@ static int fi_opx_getinfo(uint32_t version, const char *node,
 	struct fi_info *fi = NULL;
 
 	*info = NULL;
+	fi_opx_count = opx_hfi_get_hfi1_count();
+	FI_LOG(fi_opx_global.prov, FI_LOG_DEBUG, FI_LOG_FABRIC,
+			"Detected %d hfi1(s) in the system\n", fi_opx_count);	
 
 	if (!fi_opx_count) {
 		return -FI_ENODATA;

--- a/prov/opx/src/fi_opx_service.c
+++ b/prov/opx/src/fi_opx_service.c
@@ -809,3 +809,26 @@ int opx_hfi_cmd_wait_for_packet(int fd)
 
 	return ret;
 }
+
+/* 
+ * A fast check to count the number of hfi1 devs.
+ * Device(s) may not be usable, more checking is needed
+ * returns number of hfi1 devices found in /dev (0 means none)
+ */
+int opx_hfi_get_hfi1_count() {
+	struct stat st;
+	int ret;
+	char hfi1_pathname[256];
+	int hfi1_count = 0;
+
+	for (int i = 0; i < FI_OPX_MAX_HFIS; i++) {
+		snprintf(hfi1_pathname, sizeof(hfi1_pathname), "%s_%u", 
+			OPX_DEVICE_PATH, i);
+		ret = stat(hfi1_pathname, &st);
+		if (!ret) {
+			//TODO add additional check opx_hfi_get_unit_active
+			hfi1_count++;
+		}
+	}
+	return hfi1_count;
+}


### PR DESCRIPTION
Fix bug in opx provider where it was returning itself as
a provider choice on systems with no Omnipath hardware.

ofiwg/libfabric Github Issue #7715

Signed-off-by: Tim Thompson <tim.thompson@cornelisnetworks.com>