### PR TITLE
fabtests/efa: do not run efa rnr test with strict mode

### DIFF
--- a/fabtests/pytest/efa/test_rnr.py
+++ b/fabtests/pytest/efa/test_rnr.py
@@ -1,4 +1,5 @@
 import pytest
+import copy
 
 @pytest.mark.functional
 def test_rnr_read_cq_error(cmdline_args):
@@ -8,7 +9,13 @@ def test_rnr_read_cq_error(cmdline_args):
         pytest.skip("RNR requires 2 nodes")
         return
 
-    test = ClientServerTest(cmdline_args, "fi_efa_rnr_read_cq_error")
+    # Older efa kernel driver does not support RNR retry capability
+    # and the test will return FI_ENOSYS.
+    # Disable the strict mode for this test explicitly to mark it as skipped
+    # in this case.
+    cmdline_args_copy = copy.copy(cmdline_args)
+    cmdline_args_copy.strict_fabtests_mode = False
+    test = ClientServerTest(cmdline_args_copy, "fi_efa_rnr_read_cq_error")
     test.run()
 
 packet_type_option_map = {
@@ -49,6 +56,12 @@ def test_rnr_queue_resend(cmdline_args, packet_type):
         pytest.skip("RNR test requires 2 nodes")
         return
 
-    test = ClientServerTest(cmdline_args,
+    # Older efa kernel driver does not support RNR retry capability
+    # and the test will return FI_ENOSYS.
+    # Disable the strict mode for this test explicitly to mark it as skipped
+    # in this case.
+    cmdline_args_copy = copy.copy(cmdline_args)
+    cmdline_args_copy.strict_fabtests_mode = False
+    test = ClientServerTest(cmdline_args_copy,
             "fi_efa_rnr_queue_resend " + packet_type_option_map[packet_type])
     test.run()


### PR DESCRIPTION
Older efa kernel driver does not support RNR retry capability
and the test will return FI_ENOSYS. Disable the strict mode for
this test explicitly to mark it as skipped in this case.

Test info

`./runfabtests --strict -b -p <bin_path> efa <server_ip> <client_ip>`

Tested on efa instances that have efa kernel support rnr_retry, `test_rnr*` tests passed

Tested on efa instances that have efa kernel not support rnr_retry, `test_rnr*` tests skipped