### PR TITLE
prov/rxm: Cast bit-field to avoid signed behavior on windows

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -442,7 +442,7 @@ union rxm_sar_ctrl_data {
 static inline enum rxm_sar_seg_type
 rxm_sar_get_seg_type(struct ofi_ctrl_hdr *ctrl_hdr)
 {
-	return ((union rxm_sar_ctrl_data *)&(ctrl_hdr->ctrl_data))->seg_type;
+	return (uint8_t)((union rxm_sar_ctrl_data *)&(ctrl_hdr->ctrl_data))->seg_type & 0x3;
 }
 
 static inline void


### PR DESCRIPTION
The windows msvc compiler interprets a 2-bit wide bit field enum as a signed
value. Explicitly cast to unsigned and mask off any remaining sign bits to
obtain behavior from msvc that is equivalent to gcc.

On-behalf-of: https://github.com/cmru-ps <dshinaberry@mru.medical.canon>
Signed-off-by: Derek Shinaberry <dshinaberry@mru.medical.canon>