### PR TITLE
prov/util: Try IPv4 before IPv6 addresses when starting name server

### DIFF
--- a/prov/util/src/util_ns.c
+++ b/prov/util/src/util_ns.c
@@ -122,8 +122,8 @@ static int util_ns_map_del(struct util_ns *ns, void *service_in,
 	int ret = -FI_ENOENT;
 	void *service, *name;
 
-        it = rbtFind(ns->map, service_in);
-        if (it) {
+	it = rbtFind(ns->map, service_in);
+	if (it) {
 		rbtKeyValue(ns->map, it, &service, &name);
 		if (memcmp(name, name_in, ns->name_len))
 			return ret;
@@ -142,7 +142,7 @@ static int util_ns_map_lookup(struct util_ns *ns, void *service_in,
 	RbtIterator it;
 	void *key, *name;
 
-        it = rbtFind(ns->map, service_in);
+	it = rbtFind(ns->map, service_in);
 	if (!it)
 		return -FI_ENOENT;
 
@@ -241,11 +241,11 @@ static void util_ns_close_listen(struct util_ns *ns)
  * on getting an ADDRINUSE error on either bind or listen if another
  * process has started the name server.
  */
-static int util_ns_listen(struct util_ns *ns)
+static int util_ns_listen(struct util_ns *ns, int af)
 {
 	struct addrinfo hints = {
 		.ai_flags = AI_PASSIVE,
-		.ai_family = AF_UNSPEC,
+		.ai_family = af,
 		.ai_socktype = SOCK_STREAM
 	};
 	struct addrinfo *res, *p;
@@ -529,8 +529,16 @@ int ofi_ns_start_server(struct util_ns *ns)
 		goto err1;
 	}
 
-	ret = util_ns_listen(ns);
-	if (ret) {
+	// When using AF_UNSPEC as a hint to getaddrinfo, Linux seems to return IPv4
+	// addresses before IPv6 ones and Windows does the opposite. So, try IPv4
+	// addresses first followed by IPv6 addresses.
+	ret = util_ns_listen(ns, AF_INET);
+	/* EADDRINUSE likely indicates a peer is running the NS */
+	if (ret == -FI_EADDRINUSE) {
+		rbtDelete(ns->map);
+		return 0;
+	} else if (ret) {
+		ret = util_ns_listen(ns, AF_INET6);
 		/* EADDRINUSE likely indicates a peer is running the NS */
 		if (ret == -FI_EADDRINUSE) {
 			rbtDelete(ns->map);


### PR DESCRIPTION
On Windows, getaddrinfo returned IPv6 addresses before IPv4 addresses leading
to the name server being started on an IPv6 address. However, name server
clients were attempting to connect to an IPv4 address for the name server.
Trying IPv4 addresses before IPv6 addresses leads to more deterministic
behavior.

On-behalf-of: @cmru-ps <dshinaberry@mru.medical.canon>
Signed-off-by: Derek Shinaberry <dshinaberry@mru.medical.canon>