### PR TITLE
prov/verbs_nd: Various fixes for test failures and minor feature additions

### DIFF
--- a/prov/verbs/src/windows/verbs_nd_ov.c
+++ b/prov/verbs/src/windows/verbs_nd_ov.c
@@ -40,11 +40,12 @@ void CALLBACK nd_io_cb(DWORD error, DWORD bytes, LPOVERLAPPED ov)
 	struct nd_event_base *base;
 
 	assert(ov);
+	base = container_of(ov, struct nd_event_base, ov);
+	ofi_mutex_lock(&base->lock);
 
 	VRB_DBG(FI_LOG_EP_CTRL, "IO callback: error: %s, bytes: %d, ov: %p\n",
 		ofi_nd_error_str(error), bytes, ov);
 
-	base = container_of(ov, struct nd_event_base, ov);
 	if (error) {
 		assert(base->error_cb);
 		base->error_cb(base, bytes, error);
@@ -52,9 +53,52 @@ void CALLBACK nd_io_cb(DWORD error, DWORD bytes, LPOVERLAPPED ov)
 		assert(base->event_cb);
 		base->event_cb(base, bytes);
 	}
+
+	assert(base->cb_pending);
+	--base->cb_pending;
+	ofi_mutex_unlock(&base->lock);
+	pthread_cond_broadcast(&base->cond);
 }
 
-void nd_get_read_limits(IND2Connector *connector, struct nd_cm_event *entry_nd)
+HRESULT nd_cancel_pending(struct nd_event_base *event, IND2Overlapped *ov)
+{
+	HRESULT hr;
+
+	ofi_mutex_lock(&event->lock);
+	if (event->cb_pending) {
+		hr = ov->lpVtbl->CancelOverlappedRequests(ov);
+		if (FAILED(hr)) {
+			errno = hresult2fi(hr);
+			ofi_mutex_unlock(&event->lock);
+			return errno;
+		}
+
+		while (event->cb_pending) {
+			ofi_pthread_wait_cond(&event->cond, &event->lock,
+					      INFINITE);
+		}
+	}
+	ofi_mutex_unlock(&event->lock);
+
+	return 0;
+}
+
+struct nd_cm_event *nd_allocate_cm_event(struct rdma_cm_id *id,
+					 enum rdma_cm_event_type type)
+{
+	struct nd_cm_event *cm_event;
+
+	// TODO: Find an alternative to memory allocation in
+	// asynchronous completion routines
+	cm_event = calloc(1, sizeof(*cm_event));
+	assert(cm_event);
+	cm_event->event.id = id;
+	cm_event->event.event = type;
+
+	return cm_event;
+}
+
+void nd_get_read_limits(IND2Connector *connector, struct nd_cm_event *event)
 {
 	ULONG in = 0;
 	ULONG out = 0;
@@ -66,13 +110,12 @@ void nd_get_read_limits(IND2Connector *connector, struct nd_cm_event *entry_nd)
 	       hr);
 
 	assert(in <= 255);
-	entry_nd->event.param.conn.responder_resources = (uint8_t)in;
+	event->event.param.conn.responder_resources = (uint8_t)in;
 	assert(out <= 255);
-	entry_nd->event.param.conn.initiator_depth = (uint8_t)out;
+	event->event.param.conn.initiator_depth = (uint8_t)out;
 }
 
-void nd_get_connection_data(IND2Connector *connector,
-			    struct nd_cm_event *entry_nd)
+void nd_get_connection_data(IND2Connector *connector, struct nd_cm_event *event)
 {
 	ULONG len = 0;
 	HRESULT hr;
@@ -84,13 +127,13 @@ void nd_get_connection_data(IND2Connector *connector,
 	       FI_LOG_EP_CTRL, "IND2Connector::GetPrivateData: hr=0x%08lx\n",
 	       hr);
 
-	entry_nd->event.param.conn.private_data_len = (uint8_t)len;
+	event->event.param.conn.private_data_len = (uint8_t)len;
 	if (len) {
-		entry_nd->event.param.conn.private_data = malloc(len);
-		if (entry_nd->event.param.conn.private_data) {
+		event->event.param.conn.private_data = malloc(len);
+		if (event->event.param.conn.private_data) {
 			hr = connector->lpVtbl->GetPrivateData(
 				connector,
-				(void *)entry_nd->event.param.conn.private_data,
+				(void *)event->event.param.conn.private_data,
 				&len);
 			FI_LOG(&vrb_prov,
 			       FAILED(hr) ? FI_LOG_WARN : FI_LOG_DEBUG,
@@ -98,20 +141,31 @@ void nd_get_connection_data(IND2Connector *connector,
 			       "IND2Connector::GetPrivateData: hr=0x%08lx\n",
 			       hr);
 		} else {
-			entry_nd->event.param.conn.private_data_len = 0;
+			event->event.param.conn.private_data_len = 0;
 			VRB_WARN(
 				FI_LOG_EP_CTRL,
 				"Failed to allocate memory for connection data.\n");
 		}
 	} else {
-		entry_nd->event.param.conn.private_data = NULL;
+		event->event.param.conn.private_data = NULL;
 	}
+}
+
+static void nd_insert_cm_event(struct rdma_event_channel *channel,
+			       struct nd_cm_event *event)
+{
+	struct nd_event_channel *ch_nd;
+
+	ch_nd = container_of(channel, struct nd_event_channel, channel);
+	VRB_DBG(FI_LOG_EQ, "EQ SET event:%p %p %d\n", event->event.id,
+		event->event.listen_id, event->event.event);
+	dlistfd_insert_tail(&event->entry, &ch_nd->q);
 }
 
 // Used in conjunction with IND2Listener::GetConnectionRequest()
 void nd_cm_connreq_event(struct nd_event_base *base, DWORD bytes)
 {
-	struct nd_cm_event *entry_nd;
+	struct nd_cm_event *cm_event;
 	struct nd_cm_listen_event *event;
 	IND2Connector *connector;
 	struct rdma_cm_id *id;
@@ -120,14 +174,8 @@ void nd_cm_connreq_event(struct nd_event_base *base, DWORD bytes)
 	struct nd_cm_id *listen_id_nd;
 	ULONG len;
 	HRESULT hr;
-	struct nd_event_channel *ch_nd;
 
 	VRB_TRACE(FI_LOG_FABRIC, "\n");
-
-    // TODO: Find an alternative to memory allocation in
-    // asynchronous completion routines
-	entry_nd = calloc(1, sizeof(*entry_nd));
-	assert(entry_nd);
 
 	event = container_of(base, struct nd_cm_listen_event, base);
 	connector = event->connector;
@@ -143,13 +191,11 @@ void nd_cm_connreq_event(struct nd_event_base *base, DWORD bytes)
 	id_nd->peer_event.connector = listen_id_nd->peer_event.connector;
 	id_nd->listen_event.connector = listen_id_nd->listen_event.connector;
 
-	entry_nd->event.id = id;
-	entry_nd->event.listen_id = event->listen_id;
-	entry_nd->event.event = RDMA_CM_EVENT_CONNECT_REQUEST;
-	entry_nd->event.status = 0;
+	cm_event = nd_allocate_cm_event(id, RDMA_CM_EVENT_CONNECT_REQUEST);
+	cm_event->event.listen_id = event->listen_id;
 
-	nd_get_read_limits(connector, entry_nd);
-	nd_get_connection_data(connector, entry_nd);
+	nd_get_read_limits(connector, cm_event);
+	nd_get_connection_data(connector, cm_event);
 
 	len = sizeof(id->route.addr.src_addr);
 	hr = connector->lpVtbl->GetLocalAddress(connector,
@@ -165,16 +211,15 @@ void nd_cm_connreq_event(struct nd_event_base *base, DWORD bytes)
 	       FI_LOG_EP_CTRL, "IND2Connector::GetPeerAddress: hr=0x%08lx\n",
 	       hr);
 
-	ch_nd = container_of(id->channel, struct nd_event_channel, channel);
-	dlistfd_insert_tail(&entry_nd->entry, &ch_nd->q);
-	VRB_DBG(FI_LOG_EQ, "EQ SET event:%p %p %d\n", entry_nd->event.id,
-		entry_nd->event.listen_id, entry_nd->event.event);
+	nd_insert_cm_event(id->channel, cm_event);
 
 	// Need to obtain a new connector for the listening id.
 	ret = rdma_bind_addr(&listen_id_nd->id,
 			     &listen_id_nd->id.route.addr.src_addr);
 	assert(!ret);
 
+	ofi_mutex_lock(&listen_id_nd->listen_event.base.lock);
+	++listen_id_nd->listen_event.base.cb_pending;
 	hr = listen_id_nd->listener->lpVtbl->GetConnectionRequest(
 		listen_id_nd->listener, (IUnknown *)listen_id_nd->connector,
 		&listen_id_nd->listen_event.base.ov);
@@ -182,37 +227,28 @@ void nd_cm_connreq_event(struct nd_event_base *base, DWORD bytes)
 	       FI_LOG_EP_CTRL,
 	       "IND2Listener::GetConnectionRequest: hr=0x%08lx; ov=%p\n", hr,
 	       &listen_id_nd->listen_event.base.ov);
+	if (FAILED(hr))
+		--listen_id_nd->listen_event.base.cb_pending;
+	ofi_mutex_unlock(&listen_id_nd->listen_event.base.lock);
 }
 
 void nd_cm_connreq_error(struct nd_event_base *base, DWORD bytes, DWORD error)
 {
 	struct nd_cm_listen_event *event;
-	struct nd_cm_event *entry_nd;
-	struct nd_event_channel *ch_nd;
+	struct nd_cm_event *cm_event;
 
 	VRB_TRACE(FI_LOG_FABRIC, "\n");
 
 	if (error == ND_CANCELED)
 		return;
 
-    // TODO: Find an alternative to memory allocation in
-    // asynchronous completion routines
-	entry_nd = calloc(1, sizeof(*entry_nd));
-	assert(entry_nd);
-
 	event = container_of(base, struct nd_cm_listen_event, base);
-	entry_nd->event.id = event->listen_id;
-	entry_nd->event.listen_id = event->listen_id;
-	entry_nd->event.event = RDMA_CM_EVENT_CONNECT_ERROR;
-	entry_nd->event.status = error;
-	entry_nd->event.param.conn.private_data_len = 0;
-	entry_nd->event.param.conn.private_data = NULL;
+	cm_event = nd_allocate_cm_event(event->listen_id,
+					RDMA_CM_EVENT_CONNECT_ERROR);
+	cm_event->event.listen_id = event->listen_id;
+	cm_event->event.status = error;
 
-	ch_nd = container_of(event->listen_id->channel, struct nd_event_channel,
-			     channel);
-	dlistfd_insert_tail(&entry_nd->entry, &ch_nd->q);
-	VRB_DBG(FI_LOG_EQ, "EQ SET event:%p %p %d\n", entry_nd->event.id,
-		entry_nd->event.listen_id, entry_nd->event.event);
+	nd_insert_cm_event(event->listen_id->channel, cm_event);
 }
 
 // Used in conjunction with
@@ -229,7 +265,7 @@ static void nd_handle_cm_connect(IND2Connector *connector,
 	struct nd_cm_event tmp_event = { 0 };
 
 	id_nd = container_of(id, struct nd_cm_id, id);
-	id_nd->connect_event.state = ND_CM_COMPLETE;
+	id_nd->connect_event.type = ND_CM_COMPLETE;
 
 	nd_get_read_limits(connector, &tmp_event);
 	id_nd->connect_event.param.responder_resources =
@@ -243,56 +279,57 @@ static void nd_handle_cm_connect(IND2Connector *connector,
 	id_nd->connect_event.param.private_data =
 		tmp_event.event.param.conn.private_data;
 
+	ofi_mutex_lock(&id_nd->connect_event.base.lock);
+	++id_nd->connect_event.base.cb_pending;
 	hr = connector->lpVtbl->CompleteConnect(connector,
 						&id_nd->connect_event.base.ov);
 	FI_LOG(&vrb_prov, FAILED(hr) ? FI_LOG_WARN : FI_LOG_DEBUG,
 	       FI_LOG_EP_CTRL,
 	       "IND2Connector::CompleteConnect: hr=0x%08lx; ov=%p\n", hr,
 	       &id_nd->connect_event.base.ov);
+	if (FAILED(hr))
+		--id_nd->connect_event.base.cb_pending;
+	ofi_mutex_unlock(&id_nd->connect_event.base.lock);
 }
 
-struct nd_cm_event *nd_allocate_cm_event(struct rdma_cm_id *id,
-					 enum nd_cm_state state)
+static void nd_notify_disconnect(struct rdma_cm_id *id,
+				 IND2Connector *connector)
 {
-	struct nd_cm_event *cm_event;
+	HRESULT hr;
+	struct nd_cm_id *id_nd = container_of(id, struct nd_cm_id, id);
+	id_nd->peer_event.type = ND_CM_DISCONNECTED;
 
-    // TODO: Find an alternative to memory allocation in
-    // asynchronous completion routines
-	cm_event = calloc(1, sizeof(*cm_event));
-	assert(cm_event);
-	cm_event->event.id = id;
-	cm_event->event.listen_id = NULL;
-	cm_event->event.event = state;
-	cm_event->event.status = 0;
-
-	return cm_event;
+	ofi_mutex_lock(&id_nd->peer_event.base.lock);
+	++id_nd->peer_event.base.cb_pending;
+	hr = connector->lpVtbl->NotifyDisconnect(connector,
+						 &id_nd->peer_event.base.ov);
+	FI_LOG(&vrb_prov, FAILED(hr) ? FI_LOG_WARN : FI_LOG_DEBUG,
+	       FI_LOG_EP_CTRL,
+	       "IND2Connector::NotifyDisconnect: hr=0x%08lx; ov=%p\n", hr,
+	       &id_nd->peer_event.base.ov);
+	if (FAILED(hr))
+		--id_nd->peer_event.base.cb_pending;
+	ofi_mutex_unlock(&id_nd->peer_event.base.lock);
 }
 
 void nd_cm_connect_ack(struct nd_event_base *base, DWORD bytes)
 {
 	struct nd_cm_connect_event *event;
-	HRESULT hr;
 	IND2Connector *connector;
 	struct rdma_cm_id *id;
-	struct nd_cm_id *id_nd;
 	IND2QueuePair *qp;
 	struct nd_cm_event *cm_event = NULL;
-	struct nd_event_channel *ch_nd;
 
 	VRB_TRACE(FI_LOG_FABRIC, "\n");
 
 	event = container_of(base, struct nd_cm_connect_event, base);
-	ch_nd = container_of(event->channel, struct nd_event_channel, channel);
 	connector = event->connector;
 	id = event->id;
 	qp = event->qp;
 
-	switch (event->state) {
+	switch (event->type) {
 	case ND_CM_CONNECT:
 		nd_handle_cm_connect(connector, id, qp);
-		// Intentional fall through.
-
-	case ND_CM_DISCONNECT:
 		return;
 
 	case ND_CM_COMPLETE:
@@ -306,85 +343,72 @@ void nd_cm_connect_ack(struct nd_event_base *base, DWORD bytes)
 			event->param.private_data_len;
 		cm_event->event.param.conn.private_data =
 			event->param.private_data;
-		// Intentional fall through.
-
-	case ND_CM_ACCEPT:
-		// If we fell through from above, then we need to allocate the cm_event.
-		if (!cm_event)
-			cm_event = nd_allocate_cm_event(
-				id, RDMA_CM_EVENT_ESTABLISHED);
-
-		id_nd = container_of(id, struct nd_cm_id, id);
-		id_nd->peer_event.state = ND_CM_DISCONNECTED;
-
-		hr = connector->lpVtbl->NotifyDisconnect(
-			connector, &id_nd->peer_event.base.ov);
-		FI_LOG(&vrb_prov, FAILED(hr) ? FI_LOG_WARN : FI_LOG_DEBUG,
-		       FI_LOG_EP_CTRL,
-		       "IND2Connector::NotifyDisconnect: hr=0x%08lx; ov=%p\n",
-		       hr, &id_nd->peer_event.base.ov);
+		nd_insert_cm_event(event->channel, cm_event);
+		nd_notify_disconnect(id, connector);
 		break;
 
+	case ND_CM_ACCEPT:
+		cm_event = nd_allocate_cm_event(id, RDMA_CM_EVENT_ESTABLISHED);
+		nd_insert_cm_event(event->channel, cm_event);
+		nd_notify_disconnect(id, connector);
+		break;
+
+	case ND_CM_DISCONNECT:
 	case ND_CM_DISCONNECTED:
 		cm_event = nd_allocate_cm_event(id, RDMA_CM_EVENT_DISCONNECTED);
+		nd_insert_cm_event(event->channel, cm_event);
 		break;
 
 	default:
 		break;
 	}
-
-	dlistfd_insert_tail(&cm_event->entry, &ch_nd->q);
-	VRB_DBG(FI_LOG_EQ, "EQ SET event:%p %p %d\n", cm_event->event.id,
-		cm_event->event.listen_id, cm_event->event.event);
 }
 
 void nd_cm_connect_nack(struct nd_event_base *base, DWORD bytes, DWORD error)
 {
 	struct nd_cm_connect_event *event;
-	struct nd_cm_event *entry_nd;
+	struct nd_cm_event *cm_event = NULL;
 	HRESULT hr;
-	struct nd_event_channel *ch_nd;
 
 	VRB_TRACE(FI_LOG_FABRIC, "\n");
 
 	event = container_of(base, struct nd_cm_connect_event, base);
 
-	if (error == ND_CANCELED) {
+	if (error == ND_CANCELED)
 		return;
-	} else if ((event->state == ND_CM_DISCONNECTED) &&
-		   (error == ND_DISCONNECTED)) {
+
+	if ((event->type == ND_CM_DISCONNECTED) && (error == ND_DISCONNECTED)) {
 		nd_cm_connect_ack(base, bytes);
 		return;
 	}
 
-    // TODO: Find an alternative to memory allocation in
-    // asynchronous completion routines
-	entry_nd = calloc(1, sizeof(*entry_nd));
-	assert(entry_nd);
+	switch (event->type) {
+	case ND_CM_CONNECT:
+	case ND_CM_ACCEPT:
+		cm_event = nd_allocate_cm_event(event->id,
+						RDMA_CM_EVENT_REJECTED);
+		cm_event->event.status = ECONNREFUSED;
 
-	entry_nd->event.id = event->id;
-	entry_nd->event.listen_id = NULL;
-
-	if ((event->state == ND_CM_CONNECT) || (event->state == ND_CM_ACCEPT)) {
-		entry_nd->event.event = RDMA_CM_EVENT_REJECTED;
-		entry_nd->event.status = ECONNREFUSED;
-
-		nd_get_read_limits(event->connector, entry_nd);
+		nd_get_read_limits(event->connector, cm_event);
 
 		hr = event->qp->lpVtbl->Flush(event->qp);
 		FI_LOG(&vrb_prov, FAILED(hr) ? FI_LOG_WARN : FI_LOG_DEBUG,
 		       FI_LOG_EP_CTRL, "IND2QueuePair::Flush: hr=0x%08lx\n",
 		       hr);
-	} else if ((event->state == ND_CM_COMPLETE) ||
-		   (event->state == ND_CM_DISCONNECT)) {
-		entry_nd->event.event = RDMA_CM_EVENT_CONNECT_ERROR;
-		entry_nd->event.status = error;
-	}
+		nd_insert_cm_event(event->channel, cm_event);
+		break;
 
-	ch_nd = container_of(event->channel, struct nd_event_channel, channel);
-	dlistfd_insert_tail(&entry_nd->entry, &ch_nd->q);
-	VRB_DBG(FI_LOG_EQ, "EQ SET event:%p %p %d\n", entry_nd->event.id,
-		entry_nd->event.listen_id, entry_nd->event.event);
+	case ND_CM_COMPLETE:
+	case ND_CM_DISCONNECT:
+		cm_event = nd_allocate_cm_event(event->id,
+						RDMA_CM_EVENT_CONNECT_ERROR);
+		cm_event->event.status = error;
+		nd_insert_cm_event(event->channel, cm_event);
+		break;
+
+	default:
+		break;
+	}
 }
 
 // Used in conjunction with IND2CompletionQueue::Notify
@@ -399,30 +423,18 @@ void nd_cq_notify_event(struct nd_event_base *base, DWORD bytes)
 	ch_nd = container_of(cq_nd->cq.channel, struct nd_comp_channel,
 			     channel);
 
-	ofi_mutex_lock(&cq_nd->lock);
-	if (cq_nd->notify_pending) {
-		ofi_mutex_lock(&ch_nd->q_lock);
-		dlistfd_insert_tail(&cq_nd->entry, &ch_nd->q);
-		ofi_mutex_unlock(&ch_nd->q_lock);
-		cq_nd->notify_pending = false;
-	}
-	ofi_mutex_unlock(&cq_nd->lock);
+	ofi_mutex_lock(&ch_nd->q_lock);
+	dlistfd_insert_tail(&cq_nd->entry, &ch_nd->q);
+	ofi_mutex_unlock(&ch_nd->q_lock);
 }
 
 void nd_cq_notify_error(struct nd_event_base *base, DWORD bytes, DWORD error)
 {
-	struct nd_cq *cq_nd;
-
 	VRB_TRACE(FI_LOG_FABRIC, "\n");
 
 	if (error == ND_CANCELED) {
 		nd_cq_notify_event(base, bytes);
 	} else {
-		cq_nd = container_of(base, struct nd_cq, notification);
-		ofi_mutex_lock(&cq_nd->lock);
-		cq_nd->notify_pending = false;
-		ofi_mutex_unlock(&cq_nd->lock);
-
 		VRB_WARN(FI_LOG_CQ, "Unknown error: %s, bytes %d, ov: %p\n",
 			 ofi_nd_error_str(error), bytes, base);
 	}


### PR DESCRIPTION
- Move checking of pending asynchronous callbacks into the overlapped structure
  and add locking to prevent race conditions between rdma/ibv functions and
  asynchronous completion callbacks.

- Add support to ibv_post_send for opcodes IBV_WR_RDMA_READ/WRITE.

- Improve disconnect handling by better distinguishing between host initiated
  disconnect and peer initiated disconnect and removing some race conditions.

On-behalf-of: @cmru-ps <dshinaberry@mru.medical.canon>
Signed-off-by: Derek Shinaberry <dshinaberry@mru.medical.canon>