### PR TITLE
fabtests: Build verbs related tests on windows

### DIFF
--- a/fabtests/Makefile.win
+++ b/fabtests/Makefile.win
@@ -49,7 +49,7 @@ basedeps = common\hmem.c common\shared.c \
 	common\hmem_neuron.c
 
 includes = /Iinclude /Iinclude\windows /I..\include /FIft_osd.h \
-	/Iinclude\windows\getopt
+	/Iinclude\windows\getopt /Imultinode\include
 defines = /DGETOPT_STATIC
 libs = ..\$(arch)\$(config)\libfabric.lib Ws2_32.lib
 
@@ -57,7 +57,7 @@ CFLAGS = $(CFLAGS) $(includes) $(defines)
 
 #all: complex functional
 
-all: benchmarks functional unit
+all: benchmarks functional unit multinode
 
 {benchmarks}.c{$(outdir)}.exe:
 	if not exist $(@D) mkdir $(@D)
@@ -72,15 +72,24 @@ all: benchmarks functional unit
 	$(CC) /Fe$@ $** $(baseincludes) $(CFLAGS) $(libs)
 
 
-benchmarks: $(outdir)\msg_pingpong.exe $(outdir)\rdm_cntr_pingpong.exe \
-	$(outdir)\rdm_pingpong.exe $(outdir)\rdm_tagged_pingpong.exe
+benchmarks: $(outdir)\dgram_pingpong.exe $(outdir)\msg_bw.exe \
+	$(outdir)\msg_pingpong.exe $(outdir)\rdm_cntr_pingpong.exe \
+	$(outdir)\rdm_pingpong.exe $(outdir)\rdm_tagged_bw.exe \
+	$(outdir)\rdm_tagged_pingpong.exe $(outdir)\rma_bw.exe 
 
-functional: $(outdir)\cq_data.exe $(outdir)\dgram.exe $(outdir)\dgram_waitset.exe $(outdir)\msg.exe \
-	$(outdir)\msg_epoll.exe $(outdir)\msg_sockets.exe \
-	$(outdir)\poll.exe $(outdir)\rdm.exe $(outdir)\rdm_rma_event.exe $(outdir)\rdm_rma_trigger.exe \
-	$(outdir)\rdm_tagged_peek.exe $(outdir)\scalable_ep.exe $(outdir)\msg_inject.exe $(outdir)\bw.exe
+functional: $(outdir)\av_xfer.exe $(outdir)\bw.exe $(outdir)\cm_data.exe $(outdir)\cq_data.exe \
+	$(outdir)\dgram.exe $(outdir)\dgram_waitset.exe $(outdir)\msg.exe $(outdir)\msg_epoll.exe \
+	$(outdir)\msg_inject.exe $(outdir)\msg_sockets.exe $(outdir)\multi_mr.exe \
+	$(outdir)\multi_ep.exe $(outdir)\multi_recv.exe $(outdir)\poll.exe $(outdir)\rdm.exe \
+	$(outdir)\rdm_atomic.exe $(outdir)\rdm_multi_client.exe $(outdir)\rdm_rma_event.exe \
+	$(outdir)\rdm_rma_trigger.exe $(outdir)\rdm_shared_av.exe $(outdir)\rdm_tagged_peek.exe \
+	$(outdir)\recv_cancel.exe $(outdir)\scalable_ep.exe $(outdir)\shared_ctx.exe \
+	$(outdir)\unexpected_msg.exe
 
-unit: $(outdir)\av_test.exe $(outdir)\dom_test.exe $(outdir)\eq_test.exe
+unit: $(outdir)\av_test.exe $(outdir)\cntr_test.exe $(outdir)\cq_test.exe $(outdir)\dom_test.exe \
+	$(outdir)\eq_test.exe $(outdir)\getinfo_test.exe $(outdir)\mr_test.exe
+
+multinode: $(outdir)\multinode.exe $(outdir)\multinode_coll.exe
 
 complex: $(outdir)\complex.exe
 
@@ -88,14 +97,28 @@ clean:
 	if exist $(outdir) rmdir /s /q $(outdir)
 	del *.obj
 
+$(outdir)\dgram_pingpong.exe: {benchmarks}dgram_pingpong.c $(basedeps) {benchmarks}benchmark_shared.c
+
+$(outdir)\msg_bw.exe: {benchmarks}msg_bw.c $(basedeps) {benchmarks}benchmark_shared.c
+
 $(outdir)\msg_pingpong.exe: {benchmarks}msg_pingpong.c $(basedeps) {benchmarks}benchmark_shared.c
 
 $(outdir)\rdm_cntr_pingpong.exe: {benchmarks}rdm_cntr_pingpong.c $(basedeps) {benchmarks}benchmark_shared.c
 
 $(outdir)\rdm_pingpong.exe: {benchmarks}rdm_pingpong.c $(basedeps) {benchmarks}benchmark_shared.c
 
+$(outdir)\rdm_tagged_bw.exe: {benchmarks}rdm_tagged_bw.c $(basedeps) {benchmarks}benchmark_shared.c
+
 $(outdir)\rdm_tagged_pingpong.exe: {benchmarks}rdm_tagged_pingpong.c $(basedeps) {benchmarks}benchmark_shared.c
 
+$(outdir)\rma_bw.exe: {benchmarks}rma_bw.c $(basedeps) {benchmarks}benchmark_shared.c
+
+
+$(outdir)\av_xfer.exe: {functional}av_xfer.c $(basedeps)
+
+$(outdir)\bw.exe: {functional}bw.c $(basedeps)
+
+$(outdir)\cm_data.exe: {functional}cm_data.c $(basedeps)
 
 $(outdir)\cq_data.exe: {functional}cq_data.c $(basedeps)
 
@@ -107,29 +130,64 @@ $(outdir)\msg.exe: {functional}msg.c $(basedeps)
 
 $(outdir)\msg_epoll.exe: {functional}msg_epoll.c $(basedeps)
 
+$(outdir)\msg_inject.exe: {functional}msg_inject.c $(basedeps)
+
 $(outdir)\msg_sockets.exe: {functional}msg_sockets.c $(basedeps)
+
+$(outdir)\multi_mr.exe: {functional}multi_mr.c $(basedeps)
+
+$(outdir)\multi_ep.exe: {functional}multi_ep.c $(basedeps)
+
+$(outdir)\multi_recv.exe: {functional}multi_recv.c $(basedeps)
 
 $(outdir)\poll.exe: {functional}poll.c $(basedeps)
 
 $(outdir)\rdm.exe: {functional}rdm.c $(basedeps)
 
+$(outdir)\rdm_atomic.exe: {functional}rdm_atomic.c $(basedeps)
+
+$(outdir)\rdm_multi_client.exe: {functional}rdm_multi_client.c $(basedeps)
+
 $(outdir)\rdm_rma_event.exe: {functional}rdm_rma_event.c $(basedeps)
 
 $(outdir)\rdm_rma_trigger.exe: {functional}rdm_rma_trigger.c $(basedeps)
 
+$(outdir)\rdm_shared_av.exe: {functional}rdm_shared_av.c $(basedeps)
+
 $(outdir)\rdm_tagged_peek.exe: {functional}rdm_tagged_peek.c $(basedeps)
+
+$(outdir)\recv_cancel.exe: {functional}recv_cancel.c $(basedeps)
 
 $(outdir)\scalable_ep.exe: {functional}scalable_ep.c $(basedeps)
 
-$(outdir)\msg_inject.exe: {functional}msg_inject.c $(basedeps)
+$(outdir)\shared_ctx.exe: {functional}shared_ctx.c $(basedeps)
 
-$(outdir)\bw.exe: {functional}bw.c $(basedeps)
+$(outdir)\unexpected_msg.exe: {functional}unexpected_msg.c $(basedeps)
+
 
 $(outdir)\av_test.exe: {unit}av_test.c $(basedeps) {unit}common.c
+
+$(outdir)\cntr_test.exe: {unit}cntr_test.c $(basedeps) {unit}common.c
+
+$(outdir)\cq_test.exe: {unit}cq_test.c $(basedeps) {unit}common.c
 
 $(outdir)\dom_test.exe: {unit}dom_test.c $(basedeps) {unit}common.c
 
 $(outdir)\eq_test.exe: {unit}eq_test.c $(basedeps) {unit}common.c
+
+$(outdir)\getinfo_test.exe: {unit}getinfo_test.c $(basedeps) {unit}common.c
+
+$(outdir)\mr_test.exe: {unit}mr_test.c $(basedeps) {unit}common.c
+
+
+$(outdir)\multinode.exe: {multinode\src}harness.c $(basedeps) {multinode\src}core.c {multinode\src}pattern.c
+	if not exist $(@D) mkdir $(@D)
+	$(CC) /Fe$@ $** $(baseincludes) $(CFLAGS) $(libs)
+
+$(outdir)\multinode_coll.exe: {multinode\src}harness.c $(basedeps) {multinode\src}core_coll.c
+	if not exist $(@D) mkdir $(@D)
+	$(CC) /Fe$@ $** $(baseincludes) $(CFLAGS) $(libs)
+
 
 $(outdir)\complex.exe: {complex}ft_comm.c {complex}ft_comp.c {complex}ft_config.c {complex}ft_domain.c {complex}ft_endpoint.c {complex}ft_main.c {complex}ft_msg.c {complex}ft_test.c $(basedeps)
 	if not exist $(@D) mkdir $(@D)

--- a/fabtests/fabtests.vcxproj
+++ b/fabtests/fabtests.vcxproj
@@ -59,7 +59,8 @@
     <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
-  </PropertyGroup>  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Efa-v142|x64'" Label="Configuration">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Efa-v142|x64'" Label="Configuration">
     <ConfigurationType>Makefile</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
@@ -198,6 +199,21 @@
     <ClCompile Include="common\shared.c" />
     <ClCompile Include="common\windows\getopt.c" />
     <ClCompile Include="common\windows\osd.c" />
+    <ClCompile Include="functional\av_xfer.c" />
+    <ClCompile Include="functional\cm_data.c" />
+    <ClCompile Include="functional\multi_ep.c" />
+    <ClCompile Include="functional\multi_mr.c" />
+    <ClCompile Include="functional\multi_recv.c" />
+    <ClCompile Include="functional\rdm_atomic.c" />
+    <ClCompile Include="functional\rdm_multi_client.c" />
+    <ClCompile Include="functional\rdm_shared_av.c" />
+    <ClCompile Include="functional\recv_cancel.c" />
+    <ClCompile Include="functional\shared_ctx.c" />
+    <ClCompile Include="functional\unexpected_msg.c" />
+    <ClCompile Include="multinode\src\core.c" />
+    <ClCompile Include="multinode\src\core_coll.c" />
+    <ClCompile Include="multinode\src\harness.c" />
+    <ClCompile Include="multinode\src\pattern.c" />
     <ClCompile Include="ubertest\connect.c" />
     <ClCompile Include="ubertest\cq.c" />
     <ClCompile Include="ubertest\config.c" />
@@ -234,6 +250,11 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="benchmarks\benchmark_shared.h" />
+    <ClInclude Include="include\windows\arpa\inet.h" />
+    <ClInclude Include="include\windows\sched.h" />
+    <ClInclude Include="multinode\include\coll_test.h" />
+    <ClInclude Include="multinode\include\core.h" />
+    <ClInclude Include="multinode\include\pattern.h" />
     <ClInclude Include="ubertest\fabtest.h" />
     <ClInclude Include="include\ft_osd.h" />
     <ClInclude Include="include\jsmn.h" />

--- a/fabtests/fabtests.vcxproj.filters
+++ b/fabtests/fabtests.vcxproj.filters
@@ -43,11 +43,17 @@
     <Filter Include="Source Files\benchmarks">
       <UniqueIdentifier>{f1716194-5311-4a40-a1f3-d4e96c93639f}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\multinode">
+      <UniqueIdentifier>{2faeae3a-fc2b-4642-9c33-68f5266ca3b5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\multinode\include">
+      <UniqueIdentifier>{160442e0-a8e7-4bed-b61e-d884d32cc76d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\osd\arpa">
+      <UniqueIdentifier>{51950ad3-b2bf-429c-8552-df4962b4164b}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="common\jsmn.c">
-      <Filter>Source Files\common</Filter>
-    </ClCompile>
     <ClCompile Include="common\hmem.c">
       <Filter>Source Files\common</Filter>
     </ClCompile>
@@ -103,9 +109,6 @@
       <Filter>Source Files\functional</Filter>
     </ClCompile>
     <ClCompile Include="functional\scalable_ep.c">
-      <Filter>Source Files\functional</Filter>
-    </ClCompile>
-    <ClCompile Include="functional\inj_complete.c">
       <Filter>Source Files\functional</Filter>
     </ClCompile>
     <ClCompile Include="ubertest\connect.c">
@@ -195,6 +198,57 @@
     <ClCompile Include="unit\cntr_test.c">
       <Filter>Source Files\unit</Filter>
     </ClCompile>
+    <ClCompile Include="functional\av_xfer.c">
+      <Filter>Source Files\functional</Filter>
+    </ClCompile>
+    <ClCompile Include="functional\cm_data.c">
+      <Filter>Source Files\functional</Filter>
+    </ClCompile>
+    <ClCompile Include="functional\multi_mr.c">
+      <Filter>Source Files\functional</Filter>
+    </ClCompile>
+    <ClCompile Include="functional\rdm_multi_client.c">
+      <Filter>Source Files\functional</Filter>
+    </ClCompile>
+    <ClCompile Include="functional\rdm_shared_av.c">
+      <Filter>Source Files\functional</Filter>
+    </ClCompile>
+    <ClCompile Include="functional\recv_cancel.c">
+      <Filter>Source Files\functional</Filter>
+    </ClCompile>
+    <ClCompile Include="functional\shared_ctx.c">
+      <Filter>Source Files\functional</Filter>
+    </ClCompile>
+    <ClCompile Include="functional\unexpected_msg.c">
+      <Filter>Source Files\functional</Filter>
+    </ClCompile>
+    <ClCompile Include="functional\bw.c">
+      <Filter>Source Files\functional</Filter>
+    </ClCompile>
+    <ClCompile Include="functional\msg_inject.c">
+      <Filter>Source Files\functional</Filter>
+    </ClCompile>
+    <ClCompile Include="functional\multi_recv.c">
+      <Filter>Source Files\functional</Filter>
+    </ClCompile>
+    <ClCompile Include="functional\rdm_atomic.c">
+      <Filter>Source Files\functional</Filter>
+    </ClCompile>
+    <ClCompile Include="multinode\src\core.c">
+      <Filter>Source Files\multinode</Filter>
+    </ClCompile>
+    <ClCompile Include="multinode\src\core_coll.c">
+      <Filter>Source Files\multinode</Filter>
+    </ClCompile>
+    <ClCompile Include="multinode\src\harness.c">
+      <Filter>Source Files\multinode</Filter>
+    </ClCompile>
+    <ClCompile Include="multinode\src\pattern.c">
+      <Filter>Source Files\multinode</Filter>
+    </ClCompile>
+    <ClCompile Include="functional\multi_ep.c">
+      <Filter>Source Files\functional</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\jsmn.h">
@@ -227,9 +281,6 @@
     <ClInclude Include="include\windows\unistd.h">
       <Filter>Header Files\osd</Filter>
     </ClInclude>
-    <ClInclude Include="include\windows\sched.h">
-      <Filter>Header Files\osd</Filter>
-    </ClInclude>
     <ClInclude Include="include\windows\sys\socket.h">
       <Filter>Header Files\osd\sys</Filter>
     </ClInclude>
@@ -253,6 +304,21 @@
     </ClInclude>
     <ClInclude Include="include\ft_osd.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\windows\sched.h">
+      <Filter>Header Files\osd</Filter>
+    </ClInclude>
+    <ClInclude Include="multinode\include\coll_test.h">
+      <Filter>Source Files\multinode\include</Filter>
+    </ClInclude>
+    <ClInclude Include="multinode\include\core.h">
+      <Filter>Source Files\multinode\include</Filter>
+    </ClInclude>
+    <ClInclude Include="multinode\include\pattern.h">
+      <Filter>Source Files\multinode\include</Filter>
+    </ClInclude>
+    <ClInclude Include="include\windows\arpa\inet.h">
+      <Filter>Header Files\osd\arpa</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/fabtests/include/windows/arpa/inet.h
+++ b/fabtests/include/windows/arpa/inet.h
@@ -1,0 +1,4 @@
+
+#pragma once
+
+

--- a/fabtests/include/windows/osd.h
+++ b/fabtests/include/windows/osd.h
@@ -46,6 +46,7 @@ struct iovec
 #define strdup _strdup
 #define strcasecmp _stricmp
 #define strncasecmp _strnicmp
+#define alloca _alloca
 #define SHUT_RDWR SD_BOTH
 #define CLOCK_MONOTONIC	1
 

--- a/fabtests/include/windows/sched.h
+++ b/fabtests/include/windows/sched.h
@@ -98,6 +98,12 @@ static inline int sched_setaffinity(pid_t pid, size_t cpusetsize, cpu_set_t *mas
 	return 0;
 }
 
+static inline int sched_yield(void)
+{
+	(void) SwitchToThread();
+	return 0;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/fabtests/include/windows/unistd.h
+++ b/fabtests/include/windows/unistd.h
@@ -1,3 +1,10 @@
 #pragma once
 
+#include <math.h>
+
 #define sleep(x) Sleep(x * 1000)
+
+static inline void usleep(DWORD waitTime)
+{
+    Sleep(ceil(waitTime/1000.0));
+}


### PR DESCRIPTION
- Adds most of the tests handled by linux to the msvc project files
- Adds build commands to the windows nmake makefile
- Add/Modify windows specific include files to provide declarations/definitions
  used by the newly built tests

On-behalf-of: @cmru-ps <dshinaberry@mru.medical.canon>
Signed-off-by: Derek Shinaberry <dshinaberry@mru.medical.canon>