### PR TITLE
prov/tcp + minor adjustments

### DIFF
--- a/prov/hook/hook_hmem/src/hook_hmem.c
+++ b/prov/hook/hook_hmem/src/hook_hmem.c
@@ -1734,7 +1734,7 @@ static int hook_hmem_fabric(struct fi_fabric_attr *attr,
 
 struct hook_prov_ctx hook_hmem_prov_ctx = {
 	.prov = {
-		.version = FI_VERSION(1,0),
+		.version = OFI_VERSION_DEF_PROV,
 		/* We're a pass-through provider
 		   so the fi_version is always the latest */
 		.fi_version = FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION),

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -78,7 +78,7 @@ rxm_ep_rma_common(struct rxm_ep *rxm_ep, const struct fi_msg_rma *msg,
 	ofi_ep_lock_acquire(&rxm_ep->util_ep);
 
 	ret = rxm_get_conn(rxm_ep, msg->addr, &rxm_conn);
-	if (OFI_UNLIKELY(ret))
+	if (ret)
 		goto unlock;
 
 	rma_buf = rxm_get_tx_buf(rxm_ep);
@@ -288,7 +288,7 @@ rxm_ep_rma_inject_common(struct rxm_ep *rxm_ep, const struct fi_msg_rma *msg,
 	ofi_ep_lock_acquire(&rxm_ep->util_ep);
 
 	ret = rxm_get_conn(rxm_ep, msg->addr, &rxm_conn);
-	if (OFI_UNLIKELY(ret))
+	if (ret)
 		goto unlock;
 
 	if ((total_size > rxm_ep->rxm_info->tx_attr->inject_size) ||
@@ -446,7 +446,7 @@ static ssize_t rxm_ep_inject_write(struct fid_ep *ep_fid, const void *buf,
 	ofi_ep_lock_acquire(&rxm_ep->util_ep);
 
 	ret = rxm_get_conn(rxm_ep, dest_addr, &rxm_conn);
-	if (OFI_UNLIKELY(ret))
+	if (ret)
 		goto unlock;
 
 	if (len > rxm_ep->inject_limit || rxm_ep->util_ep.wr_cntr) {
@@ -480,7 +480,7 @@ static ssize_t rxm_ep_inject_writedata(struct fid_ep *ep_fid, const void *buf,
 	ofi_ep_lock_acquire(&rxm_ep->util_ep);
 
 	ret = rxm_get_conn(rxm_ep, dest_addr, &rxm_conn);
-	if (OFI_UNLIKELY(ret))
+	if (ret)
 		goto unlock;
 
 	if (len > rxm_ep->inject_limit || rxm_ep->util_ep.wr_cntr) {

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -159,7 +159,7 @@ static int tcpx_ep_connect(struct fid_ep *ep_fid, const void *addr,
 	cm_ctx = tcpx_alloc_cm_ctx(&ep_fid->fid, TCPX_CM_CONNECTING);
 	if (!cm_ctx) {
 		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
-			"cannot allocate memory \n");
+			"cannot allocate memory\n");
 		return -FI_ENOMEM;
 	}
 
@@ -169,6 +169,8 @@ static int tcpx_ep_connect(struct fid_ep *ep_fid, const void *addr,
 	if (ret && !OFI_SOCK_TRY_CONN_AGAIN(ofi_sockerr())) {
 		ep->state = TCPX_IDLE;
 		ret =  -ofi_sockerr();
+		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
+			"connect failure %d(%s)\n", -ret, fi_strerror(-ret));
 		goto free;
 	}
 


### PR DESCRIPTION
Include IP address as part of addr_list sorting to prioritize ipv4 over ipv6, to make results more consistent.

Update hook_hmem provider version to align with other providers.

Add log message on connect() failures for debug purposes.

Remove use of OFI_UNLIKELY in likely rxm code checks.