### PR TITLE
contrib/intel/jenkins: disable failing tests [verbs osu, psm3 ubertest]

### DIFF
--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -139,8 +139,14 @@ class Fabtest(Test):
             else:
                 print("{} Complex test file not found".format(self.core_prov))
 
-        if (self.ofi_build_mode != 'reg' or self.core_prov == 'udp'):
-            opts = "{} -e \'multinode,ubertest\' ".format(opts)
+        if (self.ofi_build_mode != 'reg' or self.core_prov == 'udp' or \
+            self.core_prov == 'psm3'):
+            opts = "{} -e \'ubertest".format(opts)
+
+            if (self.ofi_build_mode != 'reg' or self.core_prov == 'udp'):
+                opts = '{},multinode'.format(opts)
+
+            opts = '{}\''.format(opts)
 
         efile = self.get_exclude_file()
         if efile:

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -552,10 +552,11 @@ class MpiTestOSU(MpiTests):
 
     @property
     def execute_condn(self):
+        return False
         # see disable list for ompi failures
-        return True if ((self.mpi == 'impi' or self.mpi == 'mpich') and \
-                        (self.core_prov == 'verbs')) \
-                    else False
+        #return True if ((self.mpi == 'impi' or self.mpi == 'mpich') and \
+        #                (self.core_prov == 'verbs')) \
+        #            else False
 
     def execute_cmd(self):
         assert(self.osu_mpi_path)


### PR DESCRIPTION
Verbs osu tests are hanging and causing seg faults. Suspected issue is mlnx 5.5 needs to upgrade to mlnx 5.6 for the RDMA core.
psm3 ubertest is failing also due to the suspected 5.5->5.6 issue.
