### PR TITLE
core: Abstract ofi_wait_cond call

### DIFF
--- a/include/ofi_lock.h
+++ b/include/ofi_lock.h
@@ -279,6 +279,13 @@ static inline void ofi_mutex_unlock_noop(ofi_mutex_t *lock)
 	lock->in_use = 0;
 }
 
+static inline int
+ofi_pthread_wait_cond(pthread_cond_t *cond, ofi_mutex_t *lock, int timeout_ms)
+{
+	assert(lock->is_initialized);
+	return ofi_wait_cond(cond, &lock->impl, timeout_ms);
+}
+
 #else /* !ENABLE_DEBUG */
 
 #  define ofi_mutex_t ofi_mutex_t_
@@ -298,6 +305,9 @@ static inline void ofi_mutex_unlock_noop(ofi_mutex_t *lock)
 {
 	(void) lock;
 }
+
+#define ofi_pthread_wait_cond(cond, mut, timeout_ms) \
+	ofi_wait_cond(cond, mut, timeout_ms)
 
 #endif
 


### PR DESCRIPTION
ofi_wait_cond is an abstraction based on the OS, however it
takes as input the raw mutex.  Abstract ofi_wait_cond, so that
callers can use the ofi_mutex_t instead, which differs based on
release vs debug build.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>