### PR TITLE
fabtests/windows: Free hints memory in module that allocated it

### DIFF
--- a/fabtests/functional/av_xfer.c
+++ b/fabtests/functional/av_xfer.c
@@ -112,6 +112,12 @@ static int av_removal_test(void)
 	(void) ft_sync();
 out:
 	fprintf(stdout, "%s\n", ret ? "FAIL" : "PASS");
+	/* After calling fi_dupinfo, libfabric owns all the memory for hints,
+	 * so we want to free it all here with fi_freeinfo rather than letting
+	 * ft_free_res do it under the assumption that parts are owned by the
+	 * application. */
+	fi_freeinfo(hints);
+	hints = NULL;
 	ft_free_res();
 	return ret;
 }
@@ -174,6 +180,12 @@ static int av_reinsert_test(void)
 	(void) ft_sync();
 out:
 	fprintf(stdout, "%s\n", ret ? "FAIL" : "PASS");
+	/* After calling fi_dupinfo, libfabric owns all the memory for hints,
+	 * so we want to free it all here with fi_freeinfo rather than letting
+	 * ft_free_res do it under the assumption that parts are owned by the
+	 * application. */
+	fi_freeinfo(hints);
+	hints = NULL;
 	ft_free_res();
 	return ret;
 }

--- a/fabtests/unit/getinfo_test.c
+++ b/fabtests/unit/getinfo_test.c
@@ -780,6 +780,15 @@ static int getinfo_unit_test(char *node, char *service, uint64_t flags,
 			break;
 	}
 out:
+	/* If init was called, then there is a chance that the hints were
+	 * modified so that the application now owns some of the memory.
+	 * At the moment, only invalid_dom does this and the domain name
+	 * is the only application owned memory. Free the application owned
+	 * memory so that fi_freeinfo only frees memory that it owns. */
+	if (init) {
+		free(test_hints->domain_attr->name);
+		test_hints->domain_attr->name = NULL;
+	}
 	fi_freeinfo(test_hints);
 	fi_freeinfo(info);
 	return ret;


### PR DESCRIPTION
On windows, memory allocated by a module must be freed by that same module
because each module contains its own copy of CRT heap data structures. Any
application owned memory placed into the hints data structure must be freed
by the application before calling fi_freeinfo.

On-behalf-of: @cmru-ps <dshinaberry@mru.medical.canon>
Signed-off-by: Derek Shinaberry <dshinaberry@mru.medical.canon>