### PR TITLE
fabtests/runfabtests.cmd: Rewrite to be more like runfabtests.sh

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -53,10 +53,50 @@ before_test:
   - cd fabtests
   - msbuild fabtests.sln
 
-test_script:
-  - set PATH=%CD%\x64\%CONFIGURATION%;%PATH%
-  - set FI_PROVIDER=sockets
-  - scripts\runfabtests.cmd
+for:
+-
+  matrix:
+    only:
+      - image: Visual Studio 2017
+        configuration: Debug-v140
+      - image: Visual Studio 2017
+        configuration: Release-v140
+
+  test_script:
+    - scripts\runfabtests.cmd -v -v -v -p %CD%\x64\%CONFIGURATION% -t unit sockets
+
+-
+  matrix:
+    only:
+      - image: Visual Studio 2017
+        configuration: Debug-v141
+      - image: Visual Studio 2017
+        configuration: Release-v141
+
+  test_script:
+    - scripts\runfabtests.cmd -v -v -v -p %CD%\x64\%CONFIGURATION% -t functional sockets
+
+-
+  matrix:
+    only:
+      - image: Visual Studio 2019
+        configuration: Debug-v141
+      - image: Visual Studio 2019
+        configuration: Release-v141
+
+  test_script:
+    - scripts\runfabtests.cmd -v -v -v -p %CD%\x64\%CONFIGURATION% -C "-I 10" -L "-I 10" -t standard sockets
+
+-
+  matrix:
+    only:
+      - image: Visual Studio 2019
+        configuration: Debug-v142
+      - image: Visual Studio 2019
+        configuration: Release-v142
+
+  test_script:
+    - scripts\runfabtests.cmd -v -v -v -p %CD%\x64\%CONFIGURATION% -C "-I 10" -L "-I 10" -t multinode sockets
 
 skip_commits:
   files:

--- a/fabtests/functional/rdm_multi_client.c
+++ b/fabtests/functional/rdm_multi_client.c
@@ -221,13 +221,17 @@ int main(int argc, char **argv)
 
 	if (opts.dst_addr) {
 		for (i = 0; i < opts.num_connections; i++) {
-			save = fi_dupinfo(hints);
 			printf("Starting client: %d\n", i);
 			ret = run_client(i, address_reuse);
 			if (ret) {
 				FT_PRINTERR("run_client", -ret);
 				goto out;
 			}
+			// Reuse hints for each iteration without using fi_dupinfo
+			// because that would complicate memory ownership between the
+			// application and the library, which Windows doesn't like.
+			save = hints;
+			hints = NULL;
 			ft_free_res();
 			hints = save;
 		}

--- a/fabtests/functional/unexpected_msg.c
+++ b/fabtests/functional/unexpected_msg.c
@@ -50,7 +50,6 @@
 
 
 static size_t concurrent_msgs = 5;
-static size_t num_iters = 600;
 static bool send_data = false;
 
 
@@ -129,7 +128,7 @@ static int run_test_loop(void)
 	char *op_buf;
 	int i, j;
 
-	for (i = 0; i < num_iters; i++) {
+	for (i = 0; i < opts.iterations; i++) {
 		for (j = 0; j < concurrent_msgs; j++) {
 			op_buf = get_tx_buf(j);
 			if (ft_check_opts(FT_OPT_VERIFY_DATA)) {
@@ -192,7 +191,7 @@ static int run_test_loop(void)
 
 		if (i % 100 == 0)
 			printf("PID %d GOOD iter %d/%ld completed\n",
-				getpid(), i, num_iters);
+				getpid(), i, opts.iterations);
 	}
 
 	(void) ft_sync();
@@ -223,6 +222,7 @@ int main(int argc, char **argv)
 	int ret;
 
 	opts = INIT_OPTS;
+	opts.iterations = 600; // Change default from 1000.
 	opts.options |= FT_OPT_OOB_CTRL | FT_OPT_SKIP_MSG_ALLOC;
 	opts.mr_mode = FI_MR_LOCAL | FI_MR_ALLOCATED;
 


### PR DESCRIPTION
Brings a significant amount of the functionality of runfabtests.sh to
runfabtests.cmd in order to run tests on the verbs provider on windows
in a similar fashion to linux.

On-behalf-of: @cmru-ps <dshinaberry@mru.medical.canon>
Signed-off-by: Derek Shinaberry <dshinaberry@mru.medical.canon>