### PR TITLE
contrib/intel/jenkins: Force verbs;ofi_rxd and psm3 to run on mlnx+edr

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -187,7 +187,7 @@ pipeline {
                     }
                 }
                 stage('verbs-rxd') {
-                    agent {node {label 'mlx5'}}
+                    agent {node {label 'mlx5 && edr'}}
                     options { skipDefaultCheckout() }
                     steps {
                         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
@@ -263,7 +263,7 @@ pipeline {
                     }
                 }
                 stage('psm3') {
-                    agent {node {label 'mlx5'}}
+                    agent {node {label 'mlx5 && edr'}}
                     options { skipDefaultCheckout() }
                     steps {
                         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])


### PR DESCRIPTION
MLNX+HDR is broken for the multiclient test when using the HDR cards.
This issue needs to get investigated more before allowing these tests to
be run with HDR and EDR

Signed-off-by: Zach Dworkin <zachary.dworkin@intel.com>