### PR TITLE
fabtests: Enhancements to fabtests and rdm_stress specifically

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -159,13 +159,6 @@ struct test_size_param *test_size = def_test_sizes;
 /* range of messages is dynamically allocated */
 struct test_size_param *range_test_size;
 
-int lopt_idx = 0;
-struct option long_opts[] = {
-	{"pin-core", required_argument, NULL, LONG_OPT_PIN_CORE},
-	{"timeout", required_argument, NULL, LONG_OPT_TIMEOUT},
-	{NULL, 0, NULL, 0},
-};
-
 static const char integ_alphabet[] = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 static const int integ_alphabet_length = (sizeof(integ_alphabet)/sizeof(*integ_alphabet)) - 1;
 
@@ -3019,16 +3012,6 @@ void ft_csusage(char *name, char *desc)
 	return;
 }
 
-void ft_longopts_usage()
-{
-	FT_PRINT_OPTS_USAGE("--pin-core <core_list>",
-		"Specify which cores to pin process to using a\n"
-		"a comma-separated list format, e.g.: 0,2-4.\n"
-		"Disabled by default.");
-	FT_PRINT_OPTS_USAGE("--timeout <seconds>",
-		"Overrides default timeout for test specific transfers.");
-}
-
 void ft_parseinfo(int op, char *optarg, struct fi_info *hints,
 		  struct ft_opts *opts)
 {
@@ -3737,6 +3720,29 @@ static int ft_parse_pin_core_opt(char *optarg)
 	return 0;
 }
 
+void ft_longopts_usage()
+{
+	FT_PRINT_OPTS_USAGE("--pin-core <core_list>",
+		"Specify which cores to pin process to using a\n"
+		"a comma-separated list format, e.g.: 0,2-4.\n"
+		"Disabled by default.");
+	FT_PRINT_OPTS_USAGE("--timeout <seconds>",
+		"Overrides default timeout for test specific transfers.");
+	FT_PRINT_OPTS_USAGE("--debug-assert",
+		"Replace asserts with while loops to force process to\n"
+		"spin until a debugger can be attached.");
+}
+
+int debug_assert;
+
+int lopt_idx = 0;
+struct option long_opts[] = {
+	{"pin-core", required_argument, NULL, LONG_OPT_PIN_CORE},
+	{"timeout", required_argument, NULL, LONG_OPT_TIMEOUT},
+	{"debug-assert", no_argument, &debug_assert, LONG_OPT_DEBUG_ASSERT},
+	{NULL, 0, NULL, 0},
+};
+
 int ft_parse_long_opts(int op, char *optarg)
 {
 	switch (op) {
@@ -3744,6 +3750,8 @@ int ft_parse_long_opts(int op, char *optarg)
 		return ft_parse_pin_core_opt(optarg);
 	case LONG_OPT_TIMEOUT:
 		timeout = atoi(optarg);
+		return 0;
+	case LONG_OPT_DEBUG_ASSERT:
 		return 0;
 	default:
 		return EXIT_FAILURE;

--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -162,7 +162,8 @@ struct test_size_param *range_test_size;
 int lopt_idx = 0;
 struct option long_opts[] = {
 	{"pin-core", required_argument, NULL, LONG_OPT_PIN_CORE},
-	{0, 0, 0, 0}
+	{"timeout", required_argument, NULL, LONG_OPT_TIMEOUT},
+	{NULL, 0, NULL, 0},
 };
 
 static const char integ_alphabet[] = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -3020,10 +3021,12 @@ void ft_csusage(char *name, char *desc)
 
 void ft_longopts_usage()
 {
-	FT_PRINT_OPTS_USAGE("--pin-core <core_list>", "specify which cores to pin");
-	FT_PRINT_OPTS_USAGE("", "disabled by default. <core_list> format uses");
-	FT_PRINT_OPTS_USAGE("", "a comma-separated list, like 0,2-4");
-	return;
+	FT_PRINT_OPTS_USAGE("--pin-core <core_list>",
+		"Specify which cores to pin process to using a\n"
+		"a comma-separated list format, e.g.: 0,2-4.\n"
+		"Disabled by default.");
+	FT_PRINT_OPTS_USAGE("--timeout <seconds>",
+		"Overrides default timeout for test specific transfers.");
 }
 
 void ft_parseinfo(int op, char *optarg, struct fi_info *hints,
@@ -3739,6 +3742,9 @@ int ft_parse_long_opts(int op, char *optarg)
 	switch (op) {
 	case LONG_OPT_PIN_CORE:
 		return ft_parse_pin_core_opt(optarg);
+	case LONG_OPT_TIMEOUT:
+		timeout = atoi(optarg);
+		return 0;
 	default:
 		return EXIT_FAILURE;
 	}

--- a/fabtests/functional/rdm_stress.c
+++ b/fabtests/functional/rdm_stress.c
@@ -75,12 +75,9 @@ struct rpc_ctrl {
 	struct fid_mr *mr;
 };
 
+int rpc_timeout = 2000; /* ms */
+
 enum {
-#if ENABLE_DEBUG
-	rpc_timeout = 300000, /* ms */
-#else
-	rpc_timeout = 10000, /* ms */
-#endif
 	rpc_write_key = 189,
 	rpc_read_key = 724,
 	rpc_threads = 32,
@@ -1149,9 +1146,12 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, "u:h" CS_OPTS INFO_OPTS)) != -1) {
+	while ((op = getopt_long(argc, argv, "u:h" CS_OPTS INFO_OPTS,
+				  long_opts, &lopt_idx)) != -1) {
 		switch (op) {
 		default:
+			if (!ft_parse_long_opts(op, optarg))
+				continue;
 			ft_parsecsopts(op, optarg, &opts);
 			ft_parseinfo(op, optarg, hints, &opts);
 			break;
@@ -1161,12 +1161,13 @@ int main(int argc, char **argv)
 		case '?':
 		case 'h':
 			ft_csusage(argv[0], "An RDM endpoint error stress test.");
-			FT_PRINT_OPTS_USAGE("-u <test control file>",
-			"Sample file - fabtests/test_configs/ofi_rxm/stress.json");
+			ft_longopts_usage();
 			return EXIT_FAILURE;
 		}
 	}
 
+	if (timeout >= 0)
+		rpc_timeout = timeout * 1000;
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
 

--- a/fabtests/functional/rdm_stress.c
+++ b/fabtests/functional/rdm_stress.c
@@ -1151,9 +1151,10 @@ int main(int argc, char **argv)
 	opts = INIT_OPTS;
 	opts.options |= FT_OPT_SKIP_MSG_ALLOC | FT_OPT_SKIP_ADDR_EXCH;
 	opts.mr_mode = 0;
-	opts.iterations = 1; // remove
-	opts.num_connections = 1; // 16
+	opts.iterations = 1;
+	opts.num_connections = 16;
 	opts.comp_method = FT_COMP_WAIT_FD;
+	opts.av_size = MAX_RPC_CLIENTS;
 
 	hints = fi_allocinfo();
 	if (!hints)

--- a/fabtests/functional/rdm_stress.c
+++ b/fabtests/functional/rdm_stress.c
@@ -325,7 +325,7 @@ static int rpc_hello(struct rpc_ctrl *ctrl)
 	if (ret)
 		return ret;
 
-	assert(resp.cmd == cmd_hello);
+	ft_assert(resp.cmd == cmd_hello);
 	id_at_server = resp.client_id;
 	printf("(%d-%d) we're friends now\n", myid, id_at_server);
 	return (int) resp.data;
@@ -368,7 +368,7 @@ static int rpc_msg_resp(struct rpc_ctrl *ctrl)
 	if (ret)
 		goto free;
 
-	assert(resp->cmd == cmd_msg);
+	ft_assert(resp->cmd == cmd_msg);
 	ret = ft_check_buf(resp + 1, req->size);
 
 free:
@@ -404,7 +404,7 @@ static int rpc_tag_resp(struct rpc_ctrl *ctrl)
 	if (ret)
 		goto free;
 
-	assert(resp->cmd == cmd_tag);
+	ft_assert(resp->cmd == cmd_tag);
 	ret = ft_check_buf(resp + 1, req->size);
 
 free:
@@ -464,7 +464,7 @@ static int rpc_read_resp(struct rpc_ctrl *ctrl)
 	if (ret)
 		goto close;
 
-	assert(resp.cmd == cmd_read);
+	ft_assert(resp.cmd == cmd_read);
 	ret = ft_check_buf(&req->buf[req->offset], req->size);
 
 close:
@@ -524,7 +524,7 @@ static int rpc_write_resp(struct rpc_ctrl *ctrl)
 	if (ret)
 		goto close;
 
-	assert(resp.cmd == cmd_write);
+	ft_assert(resp.cmd == cmd_write);
 	ret = ft_check_buf(&req->buf[req->offset], req->size);
 
 close:
@@ -685,7 +685,7 @@ static bool add_ctrl(const char *js, int njts, jsmntok_t *jts,
 	size_t len;
 	int i;
 
-	assert(jts[*idx].type == JSMN_OBJECT);
+	ft_assert(jts[*idx].type == JSMN_OBJECT);
 
 	init_rpc_ctrl(ctrl);
 	/* i is indexing # of key:value pairs in JSMN_OBJECT */

--- a/fabtests/functional/rdm_stress.c
+++ b/fabtests/functional/rdm_stress.c
@@ -749,11 +749,15 @@ static int init_ctrls(const char *ctrlfile)
 	int ret = 0;
 
 	ctrl_f = fopen(ctrlfile, "r");
-	if (!ctrl_f)
+	if (!ctrl_f) {
+		FT_PRINTERR("fopen", -errno);
 		return -errno;
+	}
 
-	if (stat(ctrlfile, &sb))
+	if (stat(ctrlfile, &sb)) {
+		FT_PRINTERR("stat", -errno);
 		return -errno;
+	}
 
 	js = malloc(sb.st_size + 1);
 	if (!js) {

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -147,11 +147,6 @@ enum op_state {
 	OP_PENDING
 };
 
-enum {
-	LONG_OPT_PIN_CORE = 1,
-	LONG_OPT_TIMEOUT,
-};
-
 struct ft_context {
 	char *buf;
 	void *desc;
@@ -300,9 +295,6 @@ extern char default_port[8];
 #define FT_RX_MR_KEY 0xFFFF
 #define FT_MSG_MR_ACCESS (FI_SEND | FI_RECV)
 #define FT_RMA_MR_ACCESS (FI_READ | FI_WRITE | FI_REMOTE_READ | FI_REMOTE_WRITE)
-
-extern int lopt_idx;
-extern struct option long_opts[];
 
 int ft_getsrcaddr(char *node, char *service, struct fi_info *hints);
 int ft_read_addr_opts(char **node, char **service, struct fi_info *hints,
@@ -567,8 +559,32 @@ const char *ft_util_name(const char *str, size_t *len);
 const char *ft_core_name(const char *str, size_t *len);
 char **ft_split_and_alloc(const char *s, const char *delim, size_t *count);
 void ft_free_string_array(char **s);
+
+
+enum {
+	LONG_OPT_PIN_CORE = 1,
+	LONG_OPT_TIMEOUT,
+	LONG_OPT_DEBUG_ASSERT,
+};
+
+extern int debug_assert;
+
+extern int lopt_idx;
+extern struct option long_opts[];
 int ft_parse_long_opts(int op, char *optarg);
 void ft_longopts_usage();
+
+#define ft_assert(expr)					\
+	do {						\
+		if (!debug_assert) {			\
+			assert(expr);			\
+		} else {				\
+			if (!(expr))			\
+				FT_WARN("assert (pid %d)", getpid()); \
+			while (!(expr))			\
+				;			\
+		}					\
+	} while (0)
 
 #define FT_PROCESS_QUEUE_ERR(readerr, rd, queue, fn, str)	\
 	do {							\

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -149,6 +149,7 @@ enum op_state {
 
 enum {
 	LONG_OPT_PIN_CORE = 1,
+	LONG_OPT_TIMEOUT,
 };
 
 struct ft_context {

--- a/fabtests/test_configs/ofi_rxm/stress-rd.json
+++ b/fabtests/test_configs/ofi_rxm/stress-rd.json
@@ -26,30 +26,7 @@ This is a sample control file for fi_rdm_stress
 Valid configuration is in the JSON array definition below.
 "
 [
-	{ "op" : "goodbye" },
-	{ "op" : "hello" },
-	{ "op" : "msg_req", "size" : 1000 },
-	{ "op" : "msg_resp" },
-	{ "op" : "tag_req", "size" : 2000 },
-	{ "op" : "tag_resp" },
-	{ "op" : "msg_req", "size" : 1000000 },
-	{ "op" : "msg_resp" },
-	{ "op" : "write_req", "size" : 5600000, "offset" : 12000 },
-	{ "op" : "write_resp" },
-	{ "op" : "read_req", "size" : 64000 },
-	{ "op" : "read_resp" },
-	{ "op" : "tag_req", "size" : 2000000},
-	{ "op" : "tag_resp" },
-	{ "op" : "read_req", "size" : 32000 },
-	{ "op" : "read_resp" },
-	{ "op" : "write_req", "size" : 86000, "offset" : 6000 },
-	{ "op" : "write_resp" },
-	{ "op" : "read_req", "size" : 1000000 },
-	{ "op" : "read_resp" },
-	{ "op" : "write_req", "size" : 56000, "offset" : 12000 },
-	{ "op" : "write_resp" },
-	{ "op" : "sleep", "ms" : 100 },
-	{ "op" : "write_req", "size" : 10000000 },
+	{ "op" : "read_req", "size" : 10000000 },
 	{ "op" : "sleep", "ms" : 1 },
 	{ "op" : "exit" }
 ]

--- a/fabtests/test_configs/ofi_rxm/stress-wr.json
+++ b/fabtests/test_configs/ofi_rxm/stress-wr.json
@@ -26,30 +26,6 @@ This is a sample control file for fi_rdm_stress
 Valid configuration is in the JSON array definition below.
 "
 [
-	{ "op" : "goodbye" },
-	{ "op" : "hello" },
-	{ "op" : "msg_req", "size" : 1000 },
-	{ "op" : "msg_resp" },
-	{ "op" : "tag_req", "size" : 2000 },
-	{ "op" : "tag_resp" },
-	{ "op" : "msg_req", "size" : 1000000 },
-	{ "op" : "msg_resp" },
-	{ "op" : "write_req", "size" : 5600000, "offset" : 12000 },
-	{ "op" : "write_resp" },
-	{ "op" : "read_req", "size" : 64000 },
-	{ "op" : "read_resp" },
-	{ "op" : "tag_req", "size" : 2000000},
-	{ "op" : "tag_resp" },
-	{ "op" : "read_req", "size" : 32000 },
-	{ "op" : "read_resp" },
-	{ "op" : "write_req", "size" : 86000, "offset" : 6000 },
-	{ "op" : "write_resp" },
-	{ "op" : "read_req", "size" : 1000000 },
-	{ "op" : "read_resp" },
-	{ "op" : "write_req", "size" : 56000, "offset" : 12000 },
-	{ "op" : "write_resp" },
-	{ "op" : "sleep", "ms" : 100 },
 	{ "op" : "write_req", "size" : 10000000 },
-	{ "op" : "sleep", "ms" : 1 },
 	{ "op" : "exit" }
 ]

--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -460,7 +460,7 @@ static inline void *ofi_buf_alloc(struct ofi_bufpool *pool)
 	struct ofi_bufpool_hdr *buf_hdr;
 
 	assert(!(pool->attr.flags & OFI_BUFPOOL_INDEXED));
-	if (OFI_UNLIKELY(ofi_bufpool_empty(pool))) {
+	if (ofi_bufpool_empty(pool)) {
 		if (ofi_bufpool_grow(pool))
 			return NULL;
 	}
@@ -477,7 +477,7 @@ static inline void *ofi_buf_alloc_ex(struct ofi_bufpool *pool,
 	void *buf = ofi_buf_alloc(pool);
 
 	assert(context);
-	if (OFI_UNLIKELY(!buf))
+	if (!buf)
 		return NULL;
 
 	*context = ofi_buf_region(buf)->context;
@@ -490,7 +490,7 @@ static inline void *ofi_ibuf_alloc(struct ofi_bufpool *pool)
 	struct ofi_bufpool_region *buf_region;
 
 	assert(pool->attr.flags & OFI_BUFPOOL_INDEXED);
-	if (OFI_UNLIKELY(ofi_ibufpool_empty(pool))) {
+	if (ofi_ibufpool_empty(pool)) {
 		if (ofi_bufpool_grow(pool))
 			return NULL;
 	}

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -95,19 +95,6 @@ extern "C" {
  */
 #define OFI_DOMAIN_SPINLOCK	BIT_ULL(61)
 
-#define OFI_Q_STRERROR(prov, level, subsys, q, q_str, entry, q_strerror)	\
-	FI_LOG(prov, level, subsys, "fi_" q_str "_readerr: err: %s (%d), "	\
-	       "prov_err: %s (%d)\n", strerror((entry)->err), (entry)->err,	\
-	       q_strerror((q), (entry)->prov_errno,				\
-			  (entry)->err_data, NULL, 0),				\
-	       (entry)->prov_errno)
-
-#define OFI_CQ_STRERROR(prov, level, subsys, cq, entry) \
-	OFI_Q_STRERROR(prov, level, subsys, cq, "cq", entry, fi_cq_strerror)
-
-#define OFI_EQ_STRERROR(prov, level, subsys, eq, entry) \
-	OFI_Q_STRERROR(prov, level, subsys, eq, "eq", entry, fi_eq_strerror)
-
 #define OFI_INFO_FIELD(provider, prov_attr, user_attr, prov_str, user_str, type) \
 	do {									\
 		FI_INFO(provider, FI_LOG_CORE, prov_str ": %s\n",		\

--- a/prov/rxm/src/rxm_av.c
+++ b/prov/rxm/src/rxm_av.c
@@ -235,6 +235,7 @@ static int rxm_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr,
 		if (!ofi_atomic_dec32(&av_entry->use_cnt)) {
 			rxm_put_peer_addr(av, fi_addr[i]);
 			HASH_DELETE(hh, av->util_av.hash, av_entry);
+			ofi_ibuf_free(av_entry);
 		}
 	}
 

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -786,8 +786,22 @@ static void rxm_handle_error(struct rxm_ep *ep)
 		return;
 	}
 
-	OFI_EQ_STRERROR(&rxm_prov, FI_LOG_WARN, FI_LOG_EP_CTRL, ep->msg_eq,
-			&entry);
+	if (entry.err == FI_ECONNREFUSED) {
+		FI_LOG_SPARSE(&rxm_prov, FI_LOG_WARN, FI_LOG_CQ,
+			"fi_eq_readerr: err: %s (%d), prov_err: %s (%d)\n",
+			fi_strerror(entry.err), entry.err,
+			fi_eq_strerror(ep->msg_eq, entry.prov_errno,
+					entry.err_data, NULL, 0),
+			entry.prov_errno);
+	} else {
+		FI_WARN(&rxm_prov, FI_LOG_CQ,
+			"fi_eq_readerr: err: %s (%d), prov_err: %s (%d)\n",
+			fi_strerror(entry.err), entry.err,
+			fi_eq_strerror(ep->msg_eq, entry.prov_errno,
+					entry.err_data, NULL, 0),
+			entry.prov_errno);
+	}
+
 	if (!entry.fid || entry.fid->fclass != FI_CLASS_EP)
 		return;
 

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1721,9 +1721,14 @@ void rxm_handle_comp_error(struct rxm_ep *rxm_ep)
 		return;
 	}
 
-	if (err_entry.err != FI_ECANCELED)
-		OFI_CQ_STRERROR(&rxm_prov, FI_LOG_WARN, FI_LOG_CQ,
-				rxm_ep->msg_cq, &err_entry);
+	if (err_entry.err != FI_ECANCELED) {
+		FI_WARN(&rxm_prov, FI_LOG_CQ,
+			"fi_cq_readerr: err: %s (%d), prov_err: %s (%d)\n",
+			fi_strerror(err_entry.err), err_entry.err,
+			fi_cq_strerror(rxm_ep->msg_cq, err_entry.prov_errno,
+					err_entry.err_data, NULL, 0),
+			err_entry.prov_errno);
+	}
 
 	cq = rxm_ep->util_ep.tx_cq;
 	cntr = rxm_ep->util_ep.tx_cntr;


### PR DESCRIPTION
- Add new input control files for rdm_stress
- Add general fabtests timeout command line option, used for rpc timeout
- Update rxm error logging to reduce noise, use sparse logging
- Add debug assert option to convert asserts into busy loops (to attach a debugger)
- Modify rdm_stress to remove AV entries for clients that are not reachable