### PR TITLE
contrib/intel/jenkins: Interface Selection, tcp-osu-impi enabled, code cleanup

### DIFF
--- a/contrib/intel/jenkins/common.py
+++ b/contrib/intel/jenkins/common.py
@@ -4,8 +4,7 @@ import subprocess
 import sys
 
 def get_node_name(host, interface):
-   # This is the pattern we follow in SFS team cluster
-   return "%s-%s" % (host, interface)
+   return '%s-%s' % (host, interface)
 
 def run_command(command):
     print(" ".join(command))
@@ -13,9 +12,9 @@ def run_command(command):
     print(p.returncode)
     while True:
         out = p.stdout.read(1)
-        if (out == "" and p.poll() != None):
+        if (out == '' and p.poll() != None):
             break
-        if (out != ""):
+        if (out != ''):
             sys.stdout.write(out)
             sys.stdout.flush()
     if (p.returncode != 0):
@@ -25,23 +24,23 @@ def run_command(command):
 
 Prov = collections.namedtuple('Prov', 'core util')
 prov_list = [
-   Prov("psm3", None),
-   Prov("verbs", None),
-   Prov("verbs", "rxd"),
-   Prov("verbs", "rxm"),
-   Prov("sockets", None),
-   Prov("tcp", None),
-   Prov("udp", None),
-   Prov("udp", "rxd"),
-   Prov("shm", None),
+   Prov('psm3', None),
+   Prov('verbs', None),
+   Prov('verbs', 'rxd'),
+   Prov('verbs', 'rxm'),
+   Prov('sockets', None),
+   Prov('tcp', None),
+   Prov('udp', None),
+   Prov('udp', 'rxd'),
+   Prov('shm', None),
 ]
 enabled_prov_list = [
-    "verbs",
-    "tcp",
-    "sockets",
-    "udp",
-    "shm",
-    "psm3"
+    'verbs',
+    'tcp',
+    'sockets',
+    'udp',
+    'shm',
+    'psm3'
 ]
 disabled_prov_list = [
     'usnic',

--- a/contrib/intel/jenkins/run.py
+++ b/contrib/intel/jenkins/run.py
@@ -94,8 +94,7 @@ def intel_mpi_benchmark(core, hosts, mpi, mode, group, util):
                                 util_prov=util)
 
     print("-------------------------------------------------------------------")
-    if (imb_test.execute_condn == True and \
-        imb_test.mpi_gen_execute_condn == True):
+    if (imb_test.execute_condn == True):
         print("Running IMB-tests for {}-{}-{}-{}".format(core, util, fab, mpi))
         imb_test.execute_cmd()
     else:
@@ -111,8 +110,7 @@ def mpich_test_suite(core, hosts, mpi, mode, util):
                                        ofi_build_mode=mode, util_prov=util)
 
     print("-------------------------------------------------------------------")
-    if (mpich_tests.execute_condn == True and \
-        mpich_tests.mpi_gen_execute_condn == True):
+    if (mpich_tests.execute_condn == True):
         print("Running mpichtestsuite: Spawn Tests " \
               "for {}-{}-{}-{}".format(core, util, fab, mpi))
         mpich_tests.execute_cmd("spawn")
@@ -129,8 +127,7 @@ def osu_benchmark(core, hosts, mpi, mode, util):
                                 ofi_build_mode=mode, util_prov=util)
 
     print("-------------------------------------------------------------------")
-    if (osu_test.execute_condn == True and \
-        osu_test.mpi_gen_execute_condn == True):
+    if (osu_test.execute_condn == True):
         print("Running OSU-Test for {}-{}-{}-{}".format(core, util, fab, mpi))
         osu_test.execute_cmd()
     else:

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -330,10 +330,6 @@ class MpiTests(Test):
                 opts = "{} -x {}={} ".format(opts,key,val)
         return opts
 
-    @property
-    def mpi_gen_execute_condn(self):
-        return True if (self.mpi == 'impi' or self.mpi == 'mpich') \
-                    else False
 
 class IMBtests:
     def __init__(self, test_name, core_prov, util_prov):

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -114,7 +114,7 @@ class Fabtest(Test):
     @property
     def options(self):
         opts = "-T 300 -vvv -p {} -S ".format(self.fabtestpath)
-        if (self.core_prov == 'verbs' and self.nw_interface):
+        if (self.core_prov != 'shm' and self.nw_interface):
             opts = "{} -s {} ".format(opts, common.get_node_name(self.server,
                     self.nw_interface)) # include common.py
             opts = "{} -c {} ".format(opts, common.get_node_name(self.client,
@@ -285,7 +285,10 @@ class MpiTests(Test):
         if (self.mpi == 'impi' or self.mpi == 'mpich'):
             opts = "-n {} ".format(self.n)
             opts += "-ppn {} ".format(self.ppn)
-            opts += "-hosts {},{} ".format(self.server,self.client)
+            opts += "-hosts {},{} ".format(common.get_node_name(self.server,
+                                           self.nw_interface),
+                                           common.get_node_name(self.client,
+                                           self.nw_interface))
 
             if (self.mpi == 'impi'):
                 opts = "{} -mpi_root={} ".format(opts,
@@ -308,7 +311,8 @@ class MpiTests(Test):
 
         elif (self.mpi == 'ompi'):
             opts = "-np {} ".format(self.n)
-            hosts = ','.join([':'.join([host,str(self.ppn)]) \
+            hosts = ','.join([':'.join([common.get_node_name(host, \
+                             self.nw_interface), str(self.ppn)]) \
                     for host in self.hosts])
 
             opts = "{} --host {} ".format(opts, hosts)
@@ -465,7 +469,10 @@ class MpichTestSuite(MpiTests):
                 os.environ['MPIEXEC_TIMEOUT']=timeout
 
             opts = "-n {np} ".format(np=nprocs)
-            opts += "-hosts {s},{c} ".format(s=self.server, c=self.client)
+            opts += "-hosts {s},{c} ".format(s=common.get_node_name(\
+                                             self.server, self.nw_interface), \
+                                             c=common.get_node_name(\
+                                             self.client, self.nw_interface))
             opts += "-mpi_root={mpiroot} ".format(mpiroot=mpiroot)
             opts += "-libfabric_path={installpath}/lib " \
                     .format(installpath=self.libfab_installpath)

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -541,10 +541,10 @@ class MpiTestOSU(MpiTests):
 
     @property
     def execute_condn(self):
-        # see disable list for ompi failures
-        return True if ((self.mpi == 'impi' or self.mpi == 'mpich') and \
-                        (self.core_prov == 'verbs')) \
-                    else False
+        # mpich-tcp and ompi-tcp are the only osu test combinations failing
+        return False if ((self.mpi == 'mpich' and self.core_prov == 'tcp') or \
+                          self.mpi == 'ompi') \
+                    else True
 
     def execute_cmd(self):
         assert(self.osu_mpi_path)


### PR DESCRIPTION
All tests that need to select an interface (every provider except shm) now explicitly select their interface.
This will allow us to know exactly what tests are doing when they run.

common.py has been refactored to follow other py files' style.

OSU tcp tests have been re-enabled for impi since they are now passing.

The general execute condition is being removed because it created a redundant check.

As usual - the ci will be aborted and replayed removing the py_scripts file path from the Jenkinsfile to ensure the changed scripts are being used.