### PR TITLE
fabtests/dgram_pingpong.c: use out-of-band sync

### DIFF
--- a/fabtests/benchmarks/dgram_pingpong.c
+++ b/fabtests/benchmarks/dgram_pingpong.c
@@ -117,6 +117,12 @@ int main(int argc, char **argv)
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
 
+	/*
+	 * Because dgram endpoint is not reliable, we
+	 * must use out-of-band sync
+	 */
+	opts.options |= FT_OPT_OOB_SYNC;
+
 	hints->ep_attr->type = FI_EP_DGRAM;
 	if (opts.options & FT_OPT_SIZE)
 		hints->ep_attr->max_msg_size = opts.transfer_size;


### PR DESCRIPTION
This patch makes dgram_pingpong to always use out-of-band
sync method, because dgram endpoing is unreliable thus cannot
be used for sync.

Signed-off-by: Wei Zhang <wzam@amazon.com>