### PR TITLE
prov/efa: set domain_fid to NULL on error.

### DIFF
--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -290,6 +290,7 @@ err_free:
 	}
 
 	efa_domain = NULL;
+	*domain_fid = NULL;
 	return ret;
 }
 


### PR DESCRIPTION
This patch fix a bug in the error handling path of efa_domain_open().
which is that output domain_fid was not set to back to NULL.

Signed-off-by: Wei Zhang <wzam@amazon.com>