### PR TITLE
prov/psm3: avoid bashism in configure

### DIFF
--- a/prov/psm3/configure.ac
+++ b/prov/psm3/configure.ac
@@ -77,7 +77,7 @@ AS_IF([test "x$enable_psm3_sockets" = "xyes"],
 	PSM3_HAL_CNT=$((PSM3_HAL_CNT+1))
 	CPPFLAGS="$CPPFLAGS -DPSM_SOCKETS"
       ])
-PSM3_HAL_INST=${PSM3_HAL_INST:1}
+PSM3_HAL_INST=${PSM3_HAL_INST# }
 
 dnl ------------- HAL Extensions
 AC_ARG_ENABLE([psm3-udp],


### PR DESCRIPTION
Substring substitution is bash extension. Use "remove smallest prefix
pattern" substitution instead.

Reference: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_05_03