### PR TITLE
prov/shm: move shm signal handlers initialization to EP

### DIFF
--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -199,6 +199,8 @@ struct smr_peer_data {
 
 extern struct dlist_entry ep_name_list;
 extern pthread_mutex_t ep_list_lock;
+extern struct dlist_entry sock_name_list;
+extern pthread_mutex_t sock_list_lock;
 
 struct smr_region;
 

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -234,9 +234,6 @@ static inline void *smr_get_ptr(void *base, uint64_t offset)
 	return (char *) base + (uintptr_t) offset;
 }
 
-extern struct dlist_entry sock_name_list;
-extern pthread_mutex_t sock_list_lock;
-
 struct smr_sock_name {
 	char name[SMR_SOCK_NAME_MAX];
 	struct dlist_entry entry;

--- a/prov/shm/src/smr_init.c
+++ b/prov/shm/src/smr_init.c
@@ -37,7 +37,8 @@
 #include "smr_signal.h"
 #include <ofi_hmem.h>
 
-extern struct sigaction *old_action;
+struct sigaction *old_action = NULL;
+
 struct smr_env smr_env = {
 	.sar_threshold = SIZE_MAX,
 	.disable_cma = false,
@@ -226,13 +227,6 @@ SHM_INI
 	old_action = calloc(SIGRTMIN, sizeof(*old_action));
 	if (!old_action)
 		return NULL;
-	/* Signal handlers to cleanup tmpfs files on an unclean shutdown */
-	assert(SIGBUS < SIGRTMIN && SIGSEGV < SIGRTMIN
-	       && SIGTERM < SIGRTMIN && SIGINT < SIGRTMIN);
-	smr_reg_sig_hander(SIGBUS);
-	smr_reg_sig_hander(SIGSEGV);
-	smr_reg_sig_hander(SIGTERM);
-	smr_reg_sig_hander(SIGINT);
 
 	return &smr_prov;
 }

--- a/prov/shm/src/smr_signal.h
+++ b/prov/shm/src/smr_signal.h
@@ -36,8 +36,9 @@
 #define _SMR_SIGNAL_H_
 #include <signal.h>
 #include <ofi_shm.h>
+#include "smr.h"
 
-struct sigaction *old_action;
+extern struct sigaction *old_action;
 
 static void smr_handle_signal(int signum, siginfo_t *info, void *ucontext)
 {
@@ -67,7 +68,7 @@ static void smr_handle_signal(int signum, siginfo_t *info, void *ucontext)
 
 }
 
-static void smr_reg_sig_hander(int signum)
+static inline void smr_reg_sig_handler(int signum)
 {
 	struct sigaction action;
 	int ret;


### PR DESCRIPTION
Currently, any use of libfabric will cause shm to add its
signal handlers, even if shm is not being used.

This moves the signal handler initialization to fi_endpoint so
we only add them if they are needed.

The old_action free is kept in the shm FINI call since we need
to wait for all EPs to be closed.

This also fixes a typo in the function smr_reg_sig_handler and
fixes some function and variable definition inconsistencies.

Signed-off-by: Alexia Ingerson <alexia.ingerson@intel.com>