### PR TITLE
osd-windows/usleep: Modify usleep to sleep rather than spin

### DIFF
--- a/include/windows/unistd.h
+++ b/include/windows/unistd.h
@@ -33,16 +33,9 @@
 #pragma once
 
 #include <windows.h>
+#include <math.h>
 
 static inline void usleep(DWORD waitTime)
 {
-	LARGE_INTEGER perfCnt, start, now;
-
-	QueryPerformanceFrequency(&perfCnt);
-	QueryPerformanceCounter(&start);
-
-	do {
-		QueryPerformanceCounter((LARGE_INTEGER*)&now);
-	} while ((now.QuadPart - start.QuadPart) /
-		(float)perfCnt.QuadPart * 1000 * 1000 < waitTime);
+    Sleep(ceil(waitTime / 1000.0));
 }


### PR DESCRIPTION
Change the implementation of the windows specific implementation of
usleep to actually sleep and guarantee and relinquishment of the
cpu rather than spin.

On-behalf-of: @cmru-ps <dshinaberry@mru.medical.canon>
Signed-off-by: Derek Shinaberry <dshinaberry@mru.medical.canon>