### PR TITLE
prov/shm: fix hints->caps = 0 case for FI_MR_HMEM

### DIFF
--- a/prov/shm/src/smr_init.c
+++ b/prov/shm/src/smr_init.c
@@ -168,6 +168,9 @@ static int smr_getinfo(uint32_t version, const char *node, const char *service,
 		if (cur->caps & FI_HMEM) {
 			if (!(mr_mode & FI_MR_HMEM)) {
 				fi_freeinfo(cur);
+				if (!(hints->caps & FI_HMEM))
+					continue;
+
 				FI_INFO(&smr_prov, FI_LOG_CORE,
 					"mr_mode does not match FI_HMEM capability.\n");
 				return -FI_ENODATA;


### PR DESCRIPTION
util_getinfo will return all the util caps if hints->caps is
not set which means shm will interpret this as if the user
requested all the util caps. This will cause a failure with
the MR_HMEM case if MR_HMEM is not set because shm will
think the user needs FI_HMEM which requires FI_MR_HMEM.

This adds a condition to check for no caps set in which case
it will skip the info if we got the HMEM info back but not
return ENODATA since it was not explicitly requested and might
return FI_SUCCESS for the first fi_info.

Signed-off-by: Alexia Ingerson <alexia.ingerson@intel.com>

Fixes #7775 