### PR TITLE
prov/shm: Fix check for FI_MR_HMEM mr_mode

### DIFF
--- a/prov/shm/src/smr_attr.c
+++ b/prov/shm/src/smr_attr.c
@@ -115,6 +115,26 @@ struct fi_domain_attr smr_domain_attr = {
 	.caps = FI_LOCAL_COMM,
 };
 
+struct fi_domain_attr smr_hmem_domain_attr = {
+	.name = "shm",
+	.threading = FI_THREAD_SAFE,
+	.control_progress = FI_PROGRESS_AUTO,
+	.data_progress = FI_PROGRESS_MANUAL,
+	.resource_mgmt = FI_RM_ENABLED,
+	.av_type = FI_AV_UNSPEC,
+	.mr_mode = FI_MR_HMEM,
+	.mr_key_size = sizeof_field(struct fi_rma_iov, key),
+	.cq_data_size = sizeof_field(struct smr_msg_hdr, data),
+	.cq_cnt = (1 << 10),
+	.ep_cnt = SMR_MAX_PEERS,
+	.tx_ctx_cnt = (1 << 10),
+	.rx_ctx_cnt = (1 << 10),
+	.max_ep_tx_ctx = 1,
+	.max_ep_rx_ctx = 1,
+	.mr_iov_limit = SMR_IOV_LIMIT,
+	.caps = FI_LOCAL_COMM,
+};
+
 struct fi_fabric_attr smr_fabric_attr = {
 	.name = "shm",
 	.prov_version = OFI_VERSION_DEF_PROV
@@ -126,7 +146,7 @@ struct fi_info smr_hmem_info = {
 	.tx_attr = &smr_hmem_tx_attr,
 	.rx_attr = &smr_hmem_rx_attr,
 	.ep_attr = &smr_ep_attr,
-	.domain_attr = &smr_domain_attr,
+	.domain_attr = &smr_hmem_domain_attr,
 	.fabric_attr = &smr_fabric_attr
 };
 

--- a/prov/shm/src/smr_init.c
+++ b/prov/shm/src/smr_init.c
@@ -130,7 +130,7 @@ static int smr_getinfo(uint32_t version, const char *node, const char *service,
 	int ret;
 
 	mr_mode = hints && hints->domain_attr ? hints->domain_attr->mr_mode :
-						FI_MR_VIRT_ADDR | FI_MR_HMEM;
+						FI_MR_VIRT_ADDR;
 	msg_order = hints && hints->tx_attr ? hints->tx_attr->msg_order : 0;
 	fast_rma = smr_fast_rma_enabled(mr_mode, msg_order);
 
@@ -159,22 +159,11 @@ static int smr_getinfo(uint32_t version, const char *node, const char *service,
 						 &cur->src_addrlen);
 		}
 		if (fast_rma) {
-			cur->domain_attr->mr_mode = FI_MR_VIRT_ADDR;
+			cur->domain_attr->mr_mode |= FI_MR_VIRT_ADDR;
 			cur->tx_attr->msg_order = FI_ORDER_SAS;
 			cur->ep_attr->max_order_raw_size = 0;
 			cur->ep_attr->max_order_waw_size = 0;
 			cur->ep_attr->max_order_war_size = 0;
-		}
-		if (cur->caps & FI_HMEM) {
-			if (!(mr_mode & FI_MR_HMEM)) {
-				fi_freeinfo(cur);
-				FI_INFO(&smr_prov, FI_LOG_CORE,
-					"mr_mode does not match FI_HMEM capability.\n");
-				return -FI_ENODATA;
-			}
-			cur->domain_attr->mr_mode |= FI_MR_HMEM;
-		} else {
-			cur->domain_attr->mr_mode &= ~FI_MR_HMEM;
 		}
 	}
 	return 0;


### PR DESCRIPTION
In smr_getinfo, we perform a post-getinfo check that the FI_MR_HMEM
mr_mode bit is set correctly if FI_HMEM has been requested.  However,
there may be valid fi_info structures to return.  By failing
the smr_getinfo call, we leak those structures and fail to return
them as valid.

To fix this we add a domain_attr to pair with the FI_HMEM info
structures, so that util_getinfo can handle the filtering.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>