### PR TITLE
fabtests/rdm_stress: Add support for inject operations

### DIFF
--- a/fabtests/test_configs/ofi_rxm/stress.json
+++ b/fabtests/test_configs/ofi_rxm/stress.json
@@ -9,6 +9,7 @@ This is a sample control file for fi_rdm_stress
 	* hello - initiate a conversation
 	* goodbye - hang up nicely
 	* msg_req - send request for a message
+	* msg_inject_req - send request for a message using inject
 	* msg_resp - receive response to message request
 	* tag_req - send request for a tagged message
 	* tag_resp - receive response to tagged message request
@@ -31,6 +32,8 @@ Valid configuration is in the JSON array definition below.
 	{ "op" : "tag_req", "size" : 2000 },
 	{ "op" : "tag_resp" },
 	{ "op" : "msg_req", "size" : 1000000 },
+	{ "op" : "msg_resp" },
+	{ "op" : "msg_inject_req", "size" : 32 },
 	{ "op" : "msg_resp" },
 	{ "op" : "write_req", "size" : 5600000, "offset" : 12000 },
 	{ "op" : "write_resp" },


### PR DESCRIPTION
Add use of fi_inject() to the server.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>