### PR TITLE
prov/efa: fix the setting of RXR_EOR_IN_FLIGHT

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -180,9 +180,9 @@ static inline void rxr_poison_mem_region(uint32_t *ptr, size_t size)
 
 /*
  * Flag to indicate an rx_entry has an EOR
- * in flight (the EOR has been sent, but has
- * not got send completion)
- * hence cannot be released
+ * in flight (the EOR has been sent or queued,
+ * and has not got send completion)
+ * hence the rx_entry cannot be released
  */
 #define RXR_EOR_IN_FLIGHT BIT_ULL(10)
 /*

--- a/prov/efa/src/rxr/rxr_pkt_type.h
+++ b/prov/efa/src/rxr/rxr_pkt_type.h
@@ -187,8 +187,10 @@ int rxr_pkt_init_eor(struct rxr_ep *ep,
 		     struct rxr_rx_entry *rx_entry,
 		     struct rxr_pkt_entry *pkt_entry);
 
-
-void rxr_pkt_handle_eor_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
+static inline
+void rxr_pkt_handle_eor_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
+{
+}
 
 void rxr_pkt_handle_eor_send_completion(struct rxr_ep *ep,
 					struct rxr_pkt_entry *pkt_entry);

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -420,6 +420,7 @@ void rxr_pkt_handle_rma_read_completion(struct rxr_ep *ep,
 				rxr_release_rx_entry(ep, rx_entry);
 			}
 
+			rx_entry->rxr_flags |= RXR_EOR_IN_FLIGHT;
 			rx_entry->bytes_received += (read_entry->total_len - rx_entry->bytes_runt);
 			rx_entry->bytes_copied += (read_entry->total_len - rx_entry->bytes_runt);
 			if (rx_entry->bytes_copied == rx_entry->total_len) {
@@ -490,14 +491,6 @@ int rxr_pkt_init_eor(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry, struct rx
 	pkt_entry->addr = rx_entry->addr;
 	pkt_entry->x_entry = rx_entry;
 	return 0;
-}
-
-void rxr_pkt_handle_eor_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
-{
-	struct rxr_rx_entry *rx_entry;
-
-	rx_entry = pkt_entry->x_entry;
-	rx_entry->rxr_flags |= RXR_EOR_IN_FLIGHT;
 }
 
 void rxr_pkt_handle_eor_send_completion(struct rxr_ep *ep,


### PR DESCRIPTION
Currently, RXR_EOR_IN_FLIGHT was set when EOR was sent successfully
which caused the rx_entry to be released when EOR was queued, and
the queued EOR packet cannot be sent successfully.

This patch fixed the issue by setting RXR_EOR_IN_FLIGHT in
rxr_pkt_handle_rma_read_completion().

Signed-off-by: Wei Zhang <wzam@amazon.com>