### PR TITLE
[v1.15.x] fabtests/runfabtests.py: remove unnecessary good_address ar…

### DIFF
--- a/fabtests/scripts/runfabtests.py
+++ b/fabtests/scripts/runfabtests.py
@@ -156,9 +156,6 @@ def fabtests_args_to_pytest_args(fabtests_args, shared_options):
     # -v make pytest to print 1 line for each test
     pytest_args.append("-v")
 
-    if fabtests_args.good_address:
-        pytest_args.append("--good_address " + fabtests_args.good_address)
-
     pytest_verbose_options = {
             0 : "-rN",      # print no extra information
             1 : "-rfE",     # print extra information for failed test(s)


### PR DESCRIPTION
…gument

good_address is passed to pytest through shared_options, therefore
there is not need to add it to pytest_args separately.

Signed-off-by: Anas Mousa <anasmous@amazon.com>
Signed-off-by: Wei Zhang <wzam@amazon.com>

(cherry-picked from 218a04698)