### PR TITLE
prov/util: Add max_array_size to track/check array overflow

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -714,6 +714,7 @@ struct util_av_set {
 	struct util_coll_mc     coll_mc;
 	ofi_atomic32_t		ref;
 	ofi_mutex_t		lock;
+	size_t			max_array_size;
 };
 
 struct util_av_entry {


### PR DESCRIPTION
Add max_array_size in "struct util_av_set" for tracking address array size, and add checkes on array overflow.

Signed-off-by: Peinan Zhang <peinan.zhang@intel.com>