### PR TITLE
prov/efa: fix bug in error handling in efa_device_construct()

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -104,8 +104,9 @@ efa_CPPFLAGS += -I$(top_srcdir)/prov/efa/test $(cmocka_CPPFLAGS)
 prov_efa_test_efa_unit_test_CPPFLAGS = $(efa_CPPFLAGS)
 prov_efa_test_efa_unit_test_LDADD = $(cmocka_LIBS) $(linkback)
 prov_efa_test_efa_unit_test_LDFLAGS = $(cmocka_rpath) $(efa_LDFLAGS) $(cmocka_LDFLAGS) \
-                                                                    -Wl,--wrap=ibv_create_ah \
-																	-Wl,--wrap=efadv_query_ah
+					-Wl,--wrap=ibv_create_ah \
+					-Wl,--wrap=efadv_query_ah \
+					-Wl,--wrap=efadv_query_device
 prov_efa_test_efa_unit_test_LIBS = $(efa_LIBS) $(linkback)
 
 endif ENABLE_EFA_UNIT_TEST

--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -1148,6 +1148,7 @@ void test_duplicate_efa_ah_creation() {
 	uint8_t gid[EFA_GID_LEN];
 	memset(gid, 7, EFA_GID_LEN);
 
+	will_return(__wrap_efadv_query_device, 0);
 	resource = create_efa_resource();
 	assert_non_null(resource);
 	av = container_of(resource->av, struct efa_av, util_av.av_fid);

--- a/prov/efa/src/efa_device.c
+++ b/prov/efa/src/efa_device.c
@@ -148,12 +148,17 @@ static int efa_device_construct(struct efa_device *efa_device,
 
 err_close:
 	ibv_close_device(efa_device->ibv_ctx);
+	efa_device->ibv_ctx = NULL;
 
-	if (efa_device->rdm_info)
+	if (efa_device->rdm_info) {
 		fi_freeinfo(efa_device->rdm_info);
+		efa_device->rdm_info = NULL;
+	}
 
-	if (efa_device->dgram_info)
+	if (efa_device->dgram_info) {
 		fi_freeinfo(efa_device->dgram_info);
+		efa_device->dgram_info = NULL;
+	}
 
 	return err;
 }

--- a/prov/efa/src/efa_device.c
+++ b/prov/efa/src/efa_device.c
@@ -503,3 +503,33 @@ int efa_device_get_pci_attr(struct efa_device *device,
 }
 
 #endif // _WIN32
+
+#if EFA_UNIT_TEST
+
+#include "efa_unit_tests.h"
+
+/*
+ * test the error handling path of efa_device_construct()
+ */
+void test_efa_device_construct_error_handling()
+{
+	int ibv_err = 4242;
+	struct ibv_device **ibv_device_list;
+	struct efa_device efa_device = {0};
+
+	ibv_device_list = ibv_get_device_list(&g_device_cnt);
+	if (ibv_device_list == NULL) {
+		skip();
+		return;
+	}
+
+	will_return(__wrap_efadv_query_device, ibv_err);
+	efa_device_construct(&efa_device, 0, ibv_device_list[0]);
+
+	/* when error happend, resources in efa_device should be NULL */
+	assert_null(efa_device.ibv_ctx);
+	assert_null(efa_device.rdm_info);
+	assert_null(efa_device.dgram_info);
+}
+
+#endif

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -4,7 +4,8 @@ int main(void)
 {
 	int ret;
 	const struct CMUnitTest efa_unit_tests[] = {
-		cmocka_unit_test(test_duplicate_efa_ah_creation)    /* Requires an EFA device to work */
+		cmocka_unit_test(test_duplicate_efa_ah_creation),    /* Requires an EFA device to work */
+		cmocka_unit_test(test_efa_device_construct_error_handling),    /* Requires an EFA device to work */
 	};
 	cmocka_set_message_output(CM_OUTPUT_XML);
 

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -11,4 +11,6 @@
 
 void test_duplicate_efa_ah_creation();
 
+void test_efa_device_construct_error_handling();
+
 #endif

--- a/prov/efa/test/rdma_core_mocks.c
+++ b/prov/efa/test/rdma_core_mocks.c
@@ -32,3 +32,18 @@ int __wrap_efadv_query_ah(struct ibv_ah *ibvah, struct efadv_ah_attr *attr, uint
     check_expected(inlen);
     return (int) mock();
 }
+
+int __real_efadv_query_device(struct ibv_context *ibvctx, struct efadv_device_attr *attr,
+			     uint32_t inlen);
+
+int __wrap_efadv_query_device(struct ibv_context *ibvctx, struct efadv_device_attr *attr,
+			     uint32_t inlen)
+{
+	int retval;
+
+	retval = mock();
+	/* Expected return value being 0 means we want this function to work as expected
+	 * hence call the real function in this case
+	 */
+	return (retval == 0) ? __real_efadv_query_device(ibvctx, attr, inlen) : retval;
+}


### PR DESCRIPTION
In function efa_device_construct()'s error handling path, resources
(like ibv_ctx) were released, but the pointer was not reset to NULL,
which can caused double free. This patch addressed the issue.

Signed-off-by: Wei Zhang <wzam@amazon.com>