### PR TITLE
prov/efa: adopt wide completion APIs in EFA provider

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -193,7 +193,7 @@ struct efa_cq {
 	ofi_spin_t		lock;
 	struct ofi_bufpool	*wce_pool;
 
-	struct ibv_cq		*ibv_cq;
+	struct ibv_cq_ex	*ibv_cq_ex;
 };
 
 struct efa_qp {

--- a/prov/efa/src/efa_ep.c
+++ b/prov/efa/src/efa_ep.c
@@ -436,19 +436,19 @@ static int efa_ep_enable(struct fid_ep *ep_fid)
 	if (ep->scq) {
 		attr_ex.cap.max_send_wr = ep->info->tx_attr->size;
 		attr_ex.cap.max_send_sge = ep->info->tx_attr->iov_limit;
-		attr_ex.send_cq = ep->scq->ibv_cq;
+		attr_ex.send_cq = ibv_cq_ex_to_cq(ep->scq->ibv_cq_ex);
 		ibv_pd = ep->scq->domain->ibv_pd;
 	} else {
-		attr_ex.send_cq = ep->rcq->ibv_cq;
+		attr_ex.send_cq = ibv_cq_ex_to_cq(ep->rcq->ibv_cq_ex);
 		ibv_pd = ep->rcq->domain->ibv_pd;
 	}
 
 	if (ep->rcq) {
 		attr_ex.cap.max_recv_wr = ep->info->rx_attr->size;
 		attr_ex.cap.max_recv_sge = ep->info->rx_attr->iov_limit;
-		attr_ex.recv_cq = ep->rcq->ibv_cq;
+		attr_ex.recv_cq = ibv_cq_ex_to_cq(ep->rcq->ibv_cq_ex);
 	} else {
-		attr_ex.recv_cq = ep->scq->ibv_cq;
+		attr_ex.recv_cq = ibv_cq_ex_to_cq(ep->scq->ibv_cq_ex);
 	}
 
 	attr_ex.cap.max_inline_data = ep->domain->device->efa_attr.inline_buf_size;

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1840,13 +1840,13 @@ static inline void rdm_ep_poll_ibv_cq(struct rxr_ep *ep,
 				/* When no completions are available on the CQ, ENOENT is returned,
 				 * but the CQ remains in a valid state.
 				 */
-				goto end_poll;
+				break;
 		    }
 			/* ret = 0 iff start_poll or next_poll was successful */
 			if (ret < 0)
 				ret = -ret;
 			efa_eq_write_error(&ep->util_ep, ret, ret);
-			goto end_poll;
+			break;
 		}
 
 		if (ret || efa_cq->ibv_cq_ex->status) {
@@ -1862,8 +1862,7 @@ static inline void rdm_ep_poll_ibv_cq(struct rxr_ep *ep,
 				assert(ibv_wc_read_opcode(efa_cq->ibv_cq_ex) == IBV_WC_RECV);
 				rxr_pkt_handle_recv_error(ep, pkt_entry, err, prov_errno);
 			}
-
-			goto end_poll;
+			break;
 		}
 
 		pkt_entry = (void *)(uintptr_t)efa_cq->ibv_cq_ex->wr_id;
@@ -1890,9 +1889,7 @@ static inline void rdm_ep_poll_ibv_cq(struct rxr_ep *ep,
 			assert(0 && "Unhandled cq type");
 		}
 	}
-	goto end_poll;
 
-end_poll:
 	if (should_end_poll)
 		ibv_end_poll(efa_cq->ibv_cq_ex);
 }


### PR DESCRIPTION
In this change we migrate to wide completion APIs to take advantage of additional query capabilities of the extended CQ verbs. Specifically, usage of `ibv_poll_cq` verb is deprecated in favor of `ibv_{start,next,end}_poll` verbs.