### PR TITLE
prov/psm3 Added missing reference to neuron_init.

### DIFF
--- a/prov/psm3/Makefile.am
+++ b/prov/psm3/Makefile.am
@@ -45,6 +45,7 @@ common_srcs = \
 	shared/hmem_cuda.c \
 	shared/hmem_cuda_gdrcopy.c \
 	shared/hmem_ze.c \
+	shared/hmem_neuron.c \
 	shared/common.c \
 	shared/enosys.c \
 	shared/rbtree.c \


### PR DESCRIPTION
This fixes an undefined symbol that can result if you build
libpsm3-fi.so from inside prov/psm3.

Signed-off-by: Michael Heinz <michael.heinz@intel.com>