### PR TITLE
prov/psm3 Add missing references to synapseai.

### DIFF
--- a/prov/psm3/Makefile.am
+++ b/prov/psm3/Makefile.am
@@ -46,6 +46,7 @@ common_srcs = \
 	shared/hmem_cuda_gdrcopy.c \
 	shared/hmem_ze.c \
 	shared/hmem_neuron.c \
+	shared/hmem_synapseai.c \
 	shared/common.c \
 	shared/enosys.c \
 	shared/rbtree.c \


### PR DESCRIPTION
Fixes an issue where building libpsm3-fi.so can lead to undefined symbols in the library.

Signed-off-by: Michael Heinz <michael.heinz@intel.com>