### PR TITLE
include/rdma: modify peer_srx API

### DIFF
--- a/include/rdma/fi_ext.h
+++ b/include/rdma/fi_ext.h
@@ -158,33 +158,37 @@ struct fid_peer_srx;
 struct fi_peer_rx_entry {
 	struct fi_peer_rx_entry *next;
 	struct fi_peer_rx_entry *prev;
+	struct fid_peer_srx *srx;
 	fi_addr_t addr;
 	size_t size;
 	uint64_t tag;
+	uint64_t flags;
 	void *context;
 	size_t count;
 	void **desc;
-	struct iovec iov[];
+	void *peer_context;
+	void *owner_context;
+	struct iovec *iov;
 };
 
 struct fi_ops_srx_owner {
 	size_t	size;
-	int	(*get_msg_entry)(struct fid_peer_srx *srx,
-			struct fi_peer_rx_entry *entry);
-	int	(*get_tag_entry)(struct fid_peer_srx *srx,
-			struct fi_peer_rx_entry *entry);
+	int	(*get_msg)(struct fid_peer_srx *srx, fi_addr_t addr,
+			size_t size, struct fi_peer_rx_entry **entry);
+	int	(*get_tag)(struct fid_peer_srx *srx, fi_addr_t addr,
+			uint64_t tag, struct fi_peer_rx_entry **entry);
+	int	(*queue_msg)(struct fi_peer_rx_entry *entry);
+	int	(*queue_tag)(struct fi_peer_rx_entry *entry);
+
+	void	(*free_entry)(struct fi_peer_rx_entry *entry);
 };
 
 struct fi_ops_srx_peer {
 	size_t	size;
-	int	(*start_msg)(struct fid_peer_srx *srx,
-			struct fi_peer_rx_entry *entry);
-	int	(*start_tag)(struct fid_peer_srx *srx,
-			struct fi_peer_rx_entry *entry);
-	int	(*discard_msg)(struct fid_peer_srx *srx,
-			struct fi_peer_rx_entry *entry);
-	int	(*discard_tag)(struct fid_peer_srx *srx,
-			struct fi_peer_rx_entry *entry);
+	int	(*start_msg)(struct fi_peer_rx_entry *entry);
+	int	(*start_tag)(struct fi_peer_rx_entry *entry);
+	int	(*discard_msg)(struct fi_peer_rx_entry *entry);
+	int	(*discard_tag)(struct fi_peer_rx_entry *entry);
 };
 
 struct fid_peer_srx {

--- a/man/fi_peer.3.md
+++ b/man/fi_peer.3.md
@@ -202,33 +202,36 @@ struct fid_peer_srx;
 struct fi_peer_rx_entry {
     struct fi_peer_rx_entry *next;
     struct fi_peer_rx_entry *prev;
+    struct fi_peer_srx *srx;
     fi_addr_t addr;
     size_t size;
     uint64_t tag;
+    uint64_t flags;
     void *context;
     size_t count;
     void **desc;
-    struct iovec iov[];
+    void *peer_context;
+    void *user_context;
+    struct iovec *iov;
 };
 
 struct fi_ops_srx_owner {
     size_t size;
-    int (*get_msg_entry)(struct fid_peer_srx *srx,
-        struct fi_peer_rx_entry *entry);
-    int (*get_tag_entry)(struct fid_peer_srx *srx,
-        struct fi_peer_rx_entry *entry);
+    int (*get_msg)(struct fid_peer_srx *srx, fi_addr_t addr,
+                   size_t size, struct fi_peer_rx_entry **entry);
+    int (*get_tag)(struct fid_peer_srx *srx, fi_addr_t addr,
+                   uint64_t tag, struct fi_peer_rx_entry **entry);
+    int (*queue_msg)(struct fi_peer_rx_entry *entry);
+    int (*queue_tag)(struct fi_peer_rx_entry *entry);
+    void (*free_entry)(struct fi_peer_rx_entry *entry);
 };
 
 struct fi_ops_srx_peer {
     size_t size;
-    int (*start_msg)(struct fid_peer_srx *srx,
-        struct fi_peer_rx_entry *entry);
-    int (*start_tag)(struct fid_peer_srx *srx,
-        struct fi_peer_rx_entry *entry);
-    int (*discard_msg)(struct fid_peer_srx *srx,
-        struct fi_peer_rx_entry *entry);
-    int (*discard_tag)(struct fid_peer_srx *srx,
-        struct fi_peer_rx_entry *entry);
+    int (*start_msg)(struct fid_peer_srx *srx);
+    int (*start_tag)(struct fid_peer_srx *srx);
+    int (*discard_msg)(struct fid_peer_srx *srx);
+    int (*discard_tag)(struct fid_peer_srx *srx);
 };
 
 struct fid_peer_srx {
@@ -248,36 +251,26 @@ to those defined for peer CQs, relative to owner versus peer ops.
 ## fi_ops_srx_owner::get_msg_entry() / get_tag_entry()
 
 These calls are invoked by the peer provider to obtain the receive buffer(s)
-where an incoming message should be placed.  The fi_peer_rx_entry is allocated
-by the peer provider and initialized with information about the received
-message.  If source addressing is required, the addr field will specify the
-source address for the incoming message, otherwise, the source address will
-be set to FI_ADDR_NOTAVAIL.  The size field indicates the received message
-size.  This field is used by the owner when handling multi-receive data
-buffers, but may be ignored otherwise.  The peer provider is responsible
-for checking that an incoming message fits within the provided buffer space.
-The tag field is set for tagged messages.
+where an incoming message should be placed.  The peer provider will pass in
+the relevent fields to request a matching rx_entry from the owner.  If source
+addressing is required, the addr will be passed in; otherwise, the address will
+be set to FI_ADDR_NOT_AVAIL.  The size field indicates the received message size.
+This field is used by the owner when handling multi-received data buffers, but may
+be ignored otherwise.  The peer provider is responsible for checking that an incoming
+message fits within the provided buffer space. The tag parameter is used for tagged
+messages.  An fi_peer_rx_entry is allocated by the owner, whether or not a match was
+found. If a match was found, the owner will return FI_SUCCESS and the rx_entry will
+be filled in with the appropriate receive fields for the peer to process accordingly.
+If no match was found, the owner will return -FI_ENOENT; the rx_entry will still be
+valid but will not match to an existing posted receive. When the peer gets FI_ENOENT,
+it should allocate whatever resources it needs to process the message later
+(on start_msg/tag) and set the rx_entry->user_context appropriately, followed by a
+call to the owner's queue_msg/tag. The get and queue messages should be serialized.
+When the owner gets a matching receive for the queued unexpected message, it will
+call the peer's start function to notify the peer of the updated rx_entry (or the
+peer's discard function if the message is to be discarded)
 (TBD: The peer may need to update the src addr if the remote endpoint is
 inserted into the AV after the message has been received.)
-
-The next, prev, and context fields may be used by the owner while the
-fi_peer_rx_entry is under its control.  On input to the get entry calls,
-the count should be set by the peer to the number of entries in the iov
-array, and desc array if applicable.  When returning the fi_peer_rx_entry
-to the peer, the owner will update the count to the number of iov entries
-containing valid data.  The iov entries will reference the receive
-buffer(s) where the message should be placed.
-
-The get_msg_entry() and get_tag_entry() calls may complete synchronously
-or asynchronously, depending on whether an application buffer is ready to
-receive the incoming data.  A return value of FI_SUCCESS indicates that the
-call has completed synchronously.  In this case, the fi_peer_rx_entry is
-returned to the peer with the iov referencing the receive buffer(s) and
-the context field set to the application's context (to pass to any
-completion).  A return value of -FI_EINPROGRESS indicates that a matching
-receive entry was not found and the request has been queued.  The owner
-will notify the peer when a match has been made or if the message should
-be discarded.
 
 ## fi_ops_srx_peer::start_msg() / start_tag()
 
@@ -332,7 +325,7 @@ where a receive buffer is waiting when the message arrives.
 1. Application calls fi_recv() / fi_trecv() on owner.
 2. Owner queues the receive buffer.
 3. A message is received by the peer provider.
-4. The peer calls owner->get_msg_entry() / get_tag_entry().
+4. The peer calls owner->get_msg() / get_tag().
 5. The owner removes the queued receive buffer and returns it to
    the peer.  The get entry call will complete with FI_SUCCESS.
 ```
@@ -342,15 +335,18 @@ application has posted the matching receive buffer.
 
 ```
 1. A message is received by the peer provider.
-2. The peer calls owner->get_msg_entry() / get_tag_entry().
+2. The peer calls owner->get_msg() / get_tag().
 3. The owner fails to find a matching receive buffer.
-4. The owner queue the peer request on an unexpected/pending list
-   and returns -FI_EINPROGRESS.
+4. The owner allocates a rx_entry with any known fields and returns -FI_ENOENT.
+5. The peer allocates any resources needed to handle the asynchronous processing
+   and sets peer_context accordingly.
+6. The peer calls the peer's queue function and the owner queues the peer request
+   on an unexpected/pending list.
 5. The application calls fi_recv() / fi_trecv() on owner, posting the
    matching receive buffer.
 6. The owner matches the receive with the queued message on the peer.
-7. The owner removes the queued request and calls the peer->start_msg() /
-   start_tag() function.
+7. The owner removes the queued request, fills in the rest of the known fields
+   and calls the peer->start_msg() / start_tag() function.
 ```
 
 # fi_export_fid / fi_import_fid


### PR DESCRIPTION
Add the following fields to the shared receive entry:
- srx pointer to get back to the srx that owns it/is processing a message for it
- owner_context for the owner/allocator to manage resources
- user_context for the user (when the entry represents an incoming message,
not a posted receive)
- flags for a peer to know whether to write completions or not
- change iov[] to iov* - the allocator should be responsible for allocating the
appropriate iov array and can set this pointer to point to where to find the array

Separate the get_msg and get_tagged functions into the following:
- get_msg/get_tagged, queue_msg/queue_tag, free_entry
This allows the peer to allocate and set the rx_entry user_context when an unexpected
message arrives so it has the needed information when the owner calls start after
getting an appropriate posted receive.
Since the owner is always responsible for allocating the rx_entry, free_entry allows
the peer to tell the owner when it is done with the owner's rx_entry

The peer ops remain the same other than removing the srx entry from the parameters
since it is now in the entry.

The flow should be as follows:
On fi_recv:
- owner allocates rx_entry and checks unexpected queue, calling start_msg if a match
is found

On incoming message:
- peer calls get_msg which will always return an rx_entry, whether a match was found
or not - if a match was found, return FI_SUCCESS, if no match, allocate entry and
return FI_ENOENT
- if no match was found, peer allocates any necessary resources for processing the
unexpected message later and saves user_context appropriately. if a match was found,
peer can begin processing the message and complete according the the rx_entry flags

Signed-off-by: Alexia Ingerson <alexia.ingerson@intel.com>