### PR TITLE
prov/shm: add shared cq, shared rx, av user id support

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -512,6 +512,7 @@ struct util_cq {
 	struct dlist_entry	ep_list;
 	ofi_mutex_t		ep_list_lock;
 	struct ofi_genlock	cq_lock;
+	uint64_t		flags;
 
 	struct util_comp_cirq	*cirq;
 	fi_addr_t		*src;

--- a/man/fi_peer.3.md
+++ b/man/fi_peer.3.md
@@ -477,6 +477,8 @@ where a receive buffer is waiting when the message arrives.
 4. The peer calls owner->get_msg() / get_tag().
 5. The owner removes the queued receive buffer and returns it to
    the peer.  The get entry call will complete with FI_SUCCESS.
+6. When the peer finishes processing the message and completes it on its own
+   CQ, the peer will call free_entry to free the entry with the owner.
 ```
 
 The second case below shows the flow when a message arrives before the
@@ -496,6 +498,8 @@ application has posted the matching receive buffer.
 6. The owner matches the receive with the queued message on the peer.
 7. The owner removes the queued request, fills in the rest of the known fields
    and calls the peer->start_msg() / start_tag() function.
+9. When the peer finishes processing the message and completes it on its own
+   CQ, the peer will call free_entry to free the entry with the owner.
 ```
 
 # fi_export_fid / fi_import_fid

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -154,7 +154,7 @@ typedef int (*smr_rx_comp_func)(struct smr_ep *ep, void *context, uint32_t op,
 		uint16_t flags, size_t len, void *buf, fi_addr_t addr,
 		uint64_t tag, uint64_t data, uint64_t err);
 typedef int (*smr_tx_comp_func)(struct smr_ep *ep, void *context, uint32_t op,
-		uint16_t flags, uint64_t err);
+				uint64_t err);
 
 
 struct smr_match_attr {
@@ -338,9 +338,9 @@ extern smr_proto_func smr_proto_ops[smr_src_max];
 int smr_complete_tx(struct smr_ep *ep, void *context, uint32_t op,
 		uint64_t flags, uint64_t err);
 int smr_tx_comp(struct smr_ep *ep, void *context, uint32_t op,
-		uint16_t flags, uint64_t err);
+		uint64_t err);
 int smr_tx_comp_signal(struct smr_ep *ep, void *context, uint32_t op,
-		uint16_t flags, uint64_t err);
+		       uint64_t err);
 int smr_complete_rx(struct smr_ep *ep, void *context, uint32_t op,
 		uint16_t flags, size_t len, void *buf, int64_t id,
 		uint64_t tag, uint64_t data, uint64_t err);

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -196,13 +196,13 @@ static inline uint64_t smr_get_mr_flags(void **desc)
 	return ((struct ofi_mr *) *desc)->flags;
 }
 
-struct smr_unexp_msg {
+struct smr_cmd_ctx {
 	struct dlist_entry entry;
 	struct smr_cmd cmd;
 };
 
 OFI_DECLARE_FREESTACK(struct smr_rx_entry, smr_recv_fs);
-OFI_DECLARE_FREESTACK(struct smr_unexp_msg, smr_unexp_fs);
+OFI_DECLARE_FREESTACK(struct smr_cmd_ctx, smr_cmd_ctx_fs);
 OFI_DECLARE_FREESTACK(struct smr_tx_entry, smr_pend_fs);
 OFI_DECLARE_FREESTACK(struct smr_sar_entry, smr_sar_fs);
 
@@ -287,7 +287,7 @@ struct smr_ep {
 	struct smr_recv_fs	*recv_fs;
 	struct smr_queue	recv_queue;
 	struct smr_queue	trecv_queue;
-	struct smr_unexp_fs	*unexp_fs;
+	struct smr_cmd_ctx_fs	*cmd_ctx_fs;
 	struct smr_pend_fs	*pend_fs;
 	struct smr_sar_fs	*sar_fs;
 	struct smr_queue	unexp_msg_queue;

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -115,7 +115,7 @@ struct smr_rx_entry {
 	uint64_t		ignore;
 	struct iovec		iov[SMR_IOV_LIMIT];
 	uint32_t		iov_count;
-	uint16_t		flags;
+	uint64_t		flags;
 	uint64_t		err;
 	enum fi_hmem_iface	iface;
 	uint64_t		device;
@@ -150,8 +150,8 @@ struct smr_sar_entry {
 };
 
 struct smr_ep;
-typedef int (*smr_rx_comp_func)(struct smr_ep *ep, void *context, uint32_t op,
-		uint16_t flags, size_t len, void *buf, fi_addr_t addr,
+typedef int (*smr_rx_comp_func)(struct smr_ep *ep, void *context,
+		uint64_t flags, size_t len, void *buf, fi_addr_t addr,
 		uint64_t tag, uint64_t data, uint64_t err);
 typedef int (*smr_tx_comp_func)(struct smr_ep *ep, void *context, uint32_t op,
 				uint64_t err);
@@ -342,22 +342,29 @@ int smr_tx_comp(struct smr_ep *ep, void *context, uint32_t op,
 int smr_tx_comp_signal(struct smr_ep *ep, void *context, uint32_t op,
 		       uint64_t err);
 int smr_complete_rx(struct smr_ep *ep, void *context, uint32_t op,
-		uint16_t flags, size_t len, void *buf, int64_t id,
+		uint64_t flags, size_t len, void *buf, int64_t id,
 		uint64_t tag, uint64_t data, uint64_t err);
-int smr_rx_comp(struct smr_ep *ep, void *context, uint32_t op,
-		uint16_t flags, size_t len, void *buf, fi_addr_t addr,
-		uint64_t tag, uint64_t data, uint64_t err);
-int smr_rx_src_comp(struct smr_ep *ep, void *context, uint32_t op,
-		uint16_t flags, size_t len, void *buf, fi_addr_t addr,
-		uint64_t tag, uint64_t data, uint64_t err);
-int smr_rx_comp_signal(struct smr_ep *ep, void *context, uint32_t op,
-		uint16_t flags, size_t len, void *buf, fi_addr_t addr,
-		uint64_t tag, uint64_t data, uint64_t err);
-int smr_rx_src_comp_signal(struct smr_ep *ep, void *context, uint32_t op,
-		uint16_t flags, size_t len, void *buf, fi_addr_t addr,
-		uint64_t tag, uint64_t data, uint64_t err);
+int smr_rx_comp(struct smr_ep *ep, void *context, uint64_t flags,
+		size_t len, void *buf, fi_addr_t addr, uint64_t tag,
+		uint64_t data, uint64_t err);
+int smr_rx_src_comp(struct smr_ep *ep, void *context, uint64_t flags,
+		    size_t len, void *buf, fi_addr_t addr, uint64_t tag,
+		    uint64_t data, uint64_t err);
+int smr_rx_comp_signal(struct smr_ep *ep, void *context, uint64_t flags,
+		       size_t len, void *buf, fi_addr_t addr, uint64_t tag,
+		       uint64_t data, uint64_t err);
+int smr_rx_src_comp_signal(struct smr_ep *ep, void *context, uint64_t flags,
+			   size_t len, void *buf, fi_addr_t addr, uint64_t tag,
+			   uint64_t data, uint64_t err);
 
-uint64_t smr_rx_cq_flags(uint32_t op, uint16_t op_flags);
+static inline uint64_t smr_rx_cq_flags(uint32_t op, uint64_t rx_flags,
+				       uint16_t op_flags)
+{
+	rx_flags |= ofi_rx_cq_flags(op);
+	if (op_flags & SMR_REMOTE_CQ_DATA)
+		rx_flags |= FI_REMOTE_CQ_DATA;
+	return rx_flags;
+}
 
 void smr_ep_progress(struct util_ep *util_ep);
 

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -110,14 +110,11 @@ int smr_query_atomic(struct fid_domain *domain, enum fi_datatype datatype,
 #define SMR_IOV_LIMIT		4
 
 struct smr_rx_entry {
-	struct dlist_entry	entry;
-	void			*context;
-	int64_t			peer_id;
-	uint64_t		tag;
-	uint64_t		ignore;
+	struct fi_peer_rx_entry	peer_entry;
 	struct iovec		iov[SMR_IOV_LIMIT];
-	uint32_t		iov_count;
-	uint64_t		flags;
+	void			*desc[SMR_IOV_LIMIT];
+	int64_t			peer_id;
+	uint64_t		ignore;
 	uint64_t		err;
 	enum fi_hmem_iface	iface;
 	uint64_t		device;
@@ -142,7 +139,7 @@ struct smr_tx_entry {
 struct smr_sar_entry {
 	struct dlist_entry	entry;
 	struct smr_cmd		cmd;
-	struct smr_rx_entry	rx_entry;
+	struct fi_peer_rx_entry	*rx_entry;
 	size_t			bytes_done;
 	int			next;
 	struct iovec		iov[SMR_IOV_LIMIT];
@@ -161,14 +158,15 @@ typedef int (*smr_rx_comp_func)(struct smr_cq *cq, void *context,
 		fi_addr_t fi_addr, uint64_t tag, uint64_t data);
 
 struct smr_match_attr {
-	int64_t		id;
+	fi_addr_t	id;
 	uint64_t	tag;
 	uint64_t	ignore;
 };
 
-static inline int smr_match_id(int64_t id, int64_t match_id)
+static inline int smr_match_id(fi_addr_t addr, fi_addr_t match_addr)
 {
-	return (id == -1) || (match_id == -1) || (id == match_id);
+	return (addr == FI_ADDR_UNSPEC) || (match_addr == FI_ADDR_UNSPEC) ||
+		(addr == match_addr);
 }
 
 static inline int smr_match_tag(uint64_t tag, uint64_t ignore, uint64_t match_tag)

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -151,16 +151,14 @@ struct smr_sar_entry {
 	uint64_t		device;
 };
 
-struct smr_ep;
-
 struct smr_cq {
 	struct util_cq util_cq;
 	struct fid_peer_cq *peer_cq;
 };
 
-typedef int (*smr_rx_comp_func)(struct smr_ep *ep, void *context,
-		uint64_t flags, size_t len, void *buf, int64_t addr,
-		uint64_t tag, uint64_t data);
+typedef int (*smr_rx_comp_func)(struct smr_cq *cq, void *context,
+		uint64_t flags, size_t len, void *buf,
+		fi_addr_t fi_addr, uint64_t tag, uint64_t data);
 
 struct smr_match_attr {
 	int64_t		id;
@@ -351,11 +349,10 @@ int smr_complete_tx(struct smr_ep *ep, void *context, uint32_t op,
 int smr_complete_rx(struct smr_ep *ep, void *context, uint32_t op,
 		    uint64_t flags, size_t len, void *buf, int64_t id,
 		    uint64_t tag, uint64_t data);
-int smr_rx_comp(struct smr_ep *ep, void *context,
-		uint64_t flags, size_t len, void *buf, int64_t addr,
-		uint64_t tag, uint64_t data);
-int smr_rx_src_comp(struct smr_ep *ep, void *context, uint64_t flags,
-		    size_t len, void *buf, int64_t id, uint64_t tag,
+int smr_rx_comp(struct smr_cq *cq, void *context, uint64_t flags, size_t len,
+		void *buf, fi_addr_t fi_addr, uint64_t tag, uint64_t data);
+int smr_rx_src_comp(struct smr_cq *cq, void *context, uint64_t flags,
+		    size_t len, void *buf, fi_addr_t fi_addr, uint64_t tag,
 		    uint64_t data);
 
 static inline uint64_t smr_rx_cq_flags(uint32_t op, uint64_t rx_flags,

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -152,9 +152,8 @@ struct smr_sar_entry {
 struct smr_ep;
 typedef int (*smr_rx_comp_func)(struct smr_ep *ep, void *context,
 		uint64_t flags, size_t len, void *buf, fi_addr_t addr,
-		uint64_t tag, uint64_t data, uint64_t err);
-typedef int (*smr_tx_comp_func)(struct smr_ep *ep, void *context, uint32_t op,
-				uint64_t err);
+		uint64_t tag, uint64_t data);
+typedef int (*smr_tx_comp_func)(struct smr_ep *ep, void *context, uint32_t op);
 
 
 struct smr_match_attr {
@@ -335,27 +334,27 @@ typedef ssize_t (*smr_proto_func)(struct smr_ep *ep, struct smr_region *peer_smr
 		size_t total_len, void *context);
 extern smr_proto_func smr_proto_ops[smr_src_max];
 
+int smr_write_err_comp(struct util_cq *cq, void *context,
+		       uint64_t flags, uint64_t tag, uint64_t err);
 int smr_complete_tx(struct smr_ep *ep, void *context, uint32_t op,
-		uint64_t flags, uint64_t err);
-int smr_tx_comp(struct smr_ep *ep, void *context, uint32_t op,
-		uint64_t err);
-int smr_tx_comp_signal(struct smr_ep *ep, void *context, uint32_t op,
-		       uint64_t err);
+		    uint64_t flags);
+int smr_tx_comp(struct smr_ep *ep, void *context, uint32_t op);
+int smr_tx_comp_signal(struct smr_ep *ep, void *context, uint32_t op);
 int smr_complete_rx(struct smr_ep *ep, void *context, uint32_t op,
-		uint64_t flags, size_t len, void *buf, int64_t id,
-		uint64_t tag, uint64_t data, uint64_t err);
-int smr_rx_comp(struct smr_ep *ep, void *context, uint64_t flags,
-		size_t len, void *buf, fi_addr_t addr, uint64_t tag,
-		uint64_t data, uint64_t err);
-int smr_rx_src_comp(struct smr_ep *ep, void *context, uint64_t flags,
-		    size_t len, void *buf, fi_addr_t addr, uint64_t tag,
-		    uint64_t data, uint64_t err);
-int smr_rx_comp_signal(struct smr_ep *ep, void *context, uint64_t flags,
-		       size_t len, void *buf, fi_addr_t addr, uint64_t tag,
-		       uint64_t data, uint64_t err);
-int smr_rx_src_comp_signal(struct smr_ep *ep, void *context, uint64_t flags,
-			   size_t len, void *buf, fi_addr_t addr, uint64_t tag,
-			   uint64_t data, uint64_t err);
+		    uint64_t flags, size_t len, void *buf, int64_t id,
+		    uint64_t tag, uint64_t data);
+int smr_rx_comp(struct smr_ep *ep, void *context,
+		uint64_t flags, size_t len, void *buf, fi_addr_t addr,
+		uint64_t tag, uint64_t data);
+int smr_rx_src_comp(struct smr_ep *ep, void *context,
+		uint64_t flags, size_t len, void *buf, fi_addr_t addr,
+		uint64_t tag, uint64_t data);
+int smr_rx_comp_signal(struct smr_ep *ep, void *context,
+		uint64_t flags, size_t len, void *buf, fi_addr_t addr,
+		uint64_t tag, uint64_t data);
+int smr_rx_src_comp_signal(struct smr_ep *ep, void *context,
+		uint64_t flags, size_t len, void *buf, fi_addr_t addr,
+		uint64_t tag, uint64_t data);
 
 static inline uint64_t smr_rx_cq_flags(uint32_t op, uint64_t rx_flags,
 				       uint16_t op_flags)

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -217,12 +217,7 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 		goto unlock_region;
 	}
 
-	ofi_genlock_lock(&ep->util_ep.tx_cq->cq_lock);
-	if (ofi_cirque_isfull(ep->util_ep.tx_cq->cirq)) {
-		ret = -FI_EAGAIN;
-		goto unlock_cq;
-	}
-
+	ofi_spin_lock(&ep->tx_lock);
 	total_len = ofi_datatype_size(datatype) * ofi_total_ioc_cnt(ioc, count);
 
 	switch (op) {
@@ -282,7 +277,7 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 	peer_smr->cmd_cnt--;
 	smr_signal(peer_smr);
 unlock_cq:
-	ofi_genlock_unlock(&ep->util_ep.tx_cq->cq_lock);
+	ofi_spin_unlock(&ep->tx_lock);
 unlock_region:
 	pthread_spin_unlock(&peer_smr->lock);
 	return ret;

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -195,7 +195,7 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 	uint64_t device;
 	uint16_t smr_flags = 0;
 	int64_t id, peer_id;
-	int err = 0, proto;
+	int proto;
 	ssize_t ret = 0;
 	size_t total_len;
 
@@ -269,7 +269,7 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 	}
 
 	if (!(smr_flags & SMR_RMA_REQ) && !(op_flags & FI_DELIVERY_COMPLETE)) {
-		ret = smr_complete_tx(ep, context, op, op_flags, err);
+		ret = smr_complete_tx(ep, context, op, op_flags);
 		if (ret) {
 			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 				"unable to process tx completion\n");

--- a/prov/shm/src/smr_comp.c
+++ b/prov/shm/src/smr_comp.c
@@ -45,7 +45,7 @@ int smr_complete_tx(struct smr_ep *ep, void *context, uint32_t op,
 	if (!err && !(flags & FI_COMPLETION))
 		return 0;
 
-	return ep->tx_comp(ep, context, op, flags, err);
+	return ep->tx_comp(ep, context, op, err);
 }
 
 static int
@@ -100,19 +100,18 @@ smr_write_src_comp(struct util_cq *cq, void *context,
 	}
 }
 
-int smr_tx_comp(struct smr_ep *ep, void *context, uint32_t op,
-		uint16_t flags, uint64_t err)
+int smr_tx_comp(struct smr_ep *ep, void *context, uint32_t op, uint64_t err)
 {
 	return smr_write_comp(ep->util_ep.tx_cq, context,
 			      ofi_tx_cq_flags(op), 0, NULL, 0, 0, err);
 }
 
 int smr_tx_comp_signal(struct smr_ep *ep, void *context, uint32_t op,
-		       uint16_t flags, uint64_t err)
+		       uint64_t err)
 {
 	int ret;
 
-	ret = smr_tx_comp(ep, context, op, flags, err);
+	ret = smr_tx_comp(ep, context, op, err);
 	if (ret)
 		return ret;
 	ep->util_ep.tx_cq->wait->signal(ep->util_ep.tx_cq->wait);

--- a/prov/shm/src/smr_comp.c
+++ b/prov/shm/src/smr_comp.c
@@ -68,6 +68,7 @@ smr_write_comp(struct util_cq *cq, void *context,
 	       uint64_t flags, size_t len, void *buf,
 	       uint64_t tag, uint64_t data, uint64_t err)
 {
+	flags &= ~FI_COMPLETION;
 	if (err)
 		return smr_write_err_comp(cq, context, flags, tag, err);
 
@@ -119,48 +120,46 @@ int smr_tx_comp_signal(struct smr_ep *ep, void *context, uint32_t op,
 }
 
 int smr_complete_rx(struct smr_ep *ep, void *context, uint32_t op,
-		    uint16_t flags, size_t len, void *buf, int64_t id,
+		    uint64_t flags, size_t len, void *buf, int64_t id,
 		    uint64_t tag, uint64_t data, uint64_t err)
 {
 	fi_addr_t fiaddr = FI_ADDR_UNSPEC;
 
 	ofi_ep_rx_cntr_inc_func(&ep->util_ep, op);
 
-	if (!err && !(flags & (SMR_REMOTE_CQ_DATA | SMR_RX_COMPLETION)))
+	if (!err && !(flags & (FI_REMOTE_CQ_DATA | FI_COMPLETION)))
 		return 0;
 
 	if (ep->util_ep.domain->info_domain_caps & FI_SOURCE)
 		fiaddr = ep->region->map->peers[id].fiaddr;
 
-	return ep->rx_comp(ep, context, op, flags, len, buf,
+	return ep->rx_comp(ep, context, flags, len, buf,
 			   fiaddr, tag, data, err);
 }
 
-int smr_rx_comp(struct smr_ep *ep, void *context, uint32_t op,
-		uint16_t flags, size_t len, void *buf, fi_addr_t addr,
-		uint64_t tag, uint64_t data, uint64_t err)
+int smr_rx_comp(struct smr_ep *ep, void *context, uint64_t flags,
+		size_t len, void *buf, fi_addr_t addr, uint64_t tag,
+		uint64_t data, uint64_t err)
 {
-	return smr_write_comp(ep->util_ep.rx_cq, context,
-			      smr_rx_cq_flags(op, flags), len, buf,
-			      tag, data, err);
+	return smr_write_comp(ep->util_ep.rx_cq, context, flags, len,
+			      buf, tag, data, err);
 }
 
-int smr_rx_src_comp(struct smr_ep *ep, void *context, uint32_t op,
-		    uint16_t flags, size_t len, void *buf, fi_addr_t addr,
-		    uint64_t tag, uint64_t data, uint64_t err)
+int smr_rx_src_comp(struct smr_ep *ep, void *context, uint64_t flags,
+		    size_t len, void *buf, fi_addr_t addr, uint64_t tag,
+		    uint64_t data, uint64_t err)
 {
-	return smr_write_src_comp(ep->util_ep.rx_cq, context,
-				  smr_rx_cq_flags(op, flags), len, buf, addr,
-				  tag, data, err);
+	return smr_write_src_comp(ep->util_ep.rx_cq, context, flags, len,
+				  buf, addr, tag, data, err);
 }
 
-int smr_rx_comp_signal(struct smr_ep *ep, void *context, uint32_t op,
-		       uint16_t flags, size_t len, void *buf, fi_addr_t addr,
-		       uint64_t tag, uint64_t data, uint64_t err)
+int smr_rx_comp_signal(struct smr_ep *ep, void *context, uint64_t flags,
+		       size_t len, void *buf, fi_addr_t addr, uint64_t tag,
+		       uint64_t data, uint64_t err)
 {
 	int ret;
 
-	ret = smr_rx_comp(ep, context, op, flags, len, buf, addr, tag,
+	ret = smr_rx_comp(ep, context, flags, len, buf, addr, tag,
 			  data, err);
 	if (ret)
 		return ret;
@@ -168,32 +167,17 @@ int smr_rx_comp_signal(struct smr_ep *ep, void *context, uint32_t op,
 	return 0;
 }
 
-int smr_rx_src_comp_signal(struct smr_ep *ep, void *context, uint32_t op,
-			   uint16_t flags, size_t len, void *buf, fi_addr_t addr,
-			   uint64_t tag, uint64_t data, uint64_t err)
+int smr_rx_src_comp_signal(struct smr_ep *ep, void *context, uint64_t flags,
+			   size_t len, void *buf, fi_addr_t addr, uint64_t tag,
+			   uint64_t data, uint64_t err)
 {
 	int ret;
 
-	ret = smr_rx_src_comp(ep, context, op, flags, len, buf, addr,
-			      tag, data, err);
+	ret = smr_rx_src_comp(ep, context, flags, len, buf, addr, tag, data,
+			      err);
 	if (ret)
 		return ret;
 	ep->util_ep.rx_cq->wait->signal(ep->util_ep.rx_cq->wait);
 	return 0;
 
-}
-
-uint64_t smr_rx_cq_flags(uint32_t op, uint16_t op_flags)
-{
-	uint64_t flags;
-
-	flags = ofi_rx_cq_flags(op);
-
-	if (op_flags & SMR_REMOTE_CQ_DATA)
-		flags |= FI_REMOTE_CQ_DATA;
-
-	if (op_flags & SMR_MULTI_RECV)
-		flags |= FI_MULTI_RECV;
-
-	return flags;
 }

--- a/prov/shm/src/smr_cq.c
+++ b/prov/shm/src/smr_cq.c
@@ -35,10 +35,115 @@
 
 #include "smr.h"
 
+static int smr_peer_cq_close(struct fid *fid)
+{
+	free(container_of(fid, struct fid_peer_cq, fid));
+	return 0;
+}
+
+static int smr_cq_close(struct fid *fid)
+{
+	int ret;
+	struct smr_cq *smr_cq;
+
+	smr_cq = container_of(fid, struct smr_cq, util_cq.cq_fid.fid);
+
+	ret = ofi_cq_cleanup(&smr_cq->util_cq);
+	if (ret)
+		return ret;
+
+	if (!(smr_cq->util_cq.flags & FI_PEER))
+		fi_close(&smr_cq->peer_cq->fid);
+
+	free(smr_cq);
+	return 0;
+}
+
+static struct fi_ops smr_cq_fi_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = smr_cq_close,
+	.bind = fi_no_bind,
+	.control = ofi_cq_control,
+	.ops_open = fi_no_ops_open,
+};
+
+static ssize_t smr_peer_cq_write(struct fid_peer_cq *cq, void *context, uint64_t flags,
+		size_t len, void *buf, uint64_t data, uint64_t tag,
+		fi_addr_t src)
+{
+	struct smr_cq *smr_cq;
+	int ret;
+
+	smr_cq = cq->fid.context;
+
+	if (src == FI_ADDR_NOTAVAIL)
+		ret = ofi_cq_write(&smr_cq->util_cq, context, flags, len,
+				   buf, data, tag);
+	else
+		ret = ofi_cq_write_src(&smr_cq->util_cq, context, flags, len,
+				       buf, data, tag, src);
+
+	if (smr_cq->util_cq.wait)
+		smr_cq->util_cq.wait->signal(smr_cq->util_cq.wait);
+
+	return ret;
+}
+
+static ssize_t smr_peer_cq_writeerr(struct fid_peer_cq *cq,
+				    const struct fi_cq_err_entry *err_entry)
+{
+	return ofi_cq_write_error(&((struct smr_cq *)
+				  (cq->fid.context))->util_cq, err_entry);
+}
+
+static struct fi_ops_cq_owner smr_peer_cq_owner_ops = {
+	.size = sizeof(struct fi_ops_cq_owner),
+	.write = &smr_peer_cq_write,
+	.writeerr = &smr_peer_cq_writeerr,
+};
+
+static struct fi_ops smr_peer_cq_fi_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = smr_peer_cq_close,
+	.bind = fi_no_bind,
+	.control = fi_no_control,
+	.ops_open = fi_no_ops_open,
+};
+
+static int smr_init_peer_cq(struct smr_cq *smr_cq)
+{
+	smr_cq->peer_cq = calloc(1, sizeof(*smr_cq->peer_cq));
+	if (!smr_cq->peer_cq)
+		return -FI_ENOMEM;
+
+	smr_cq->peer_cq->fid.fclass = FI_CLASS_PEER_CQ;
+	smr_cq->peer_cq->fid.context = smr_cq;
+	smr_cq->peer_cq->fid.ops = &smr_peer_cq_fi_ops;
+	smr_cq->peer_cq->owner_ops = &smr_peer_cq_owner_ops;
+
+	return 0;
+}
+
+static ssize_t smr_cq_read(struct fid_cq *cq_fid, void *buf, size_t count)
+{
+	return ofi_cq_readfrom(cq_fid, buf, count, NULL);
+}
+
+static struct fi_ops_cq smr_peer_cq_ops = {
+	.size = sizeof(struct fi_ops_cq),
+	.read = smr_cq_read,
+	.readfrom = fi_no_cq_readfrom,
+	.readerr = fi_no_cq_readerr,
+	.sread = fi_no_cq_sread,
+	.sreadfrom = fi_no_cq_sreadfrom,
+	.signal = fi_no_cq_signal,
+	.strerror = fi_no_cq_strerror,
+};
+
 int smr_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		struct fid_cq **cq_fid, void *context)
 {
-	struct util_cq *util_cq;
+	struct smr_cq *smr_cq;
 	int ret;
 
 	switch (attr->wait_obj) {
@@ -53,19 +158,31 @@ int smr_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		return -FI_ENOSYS;
 	}
 
-	util_cq = calloc(1, sizeof(*util_cq));
-	if (!util_cq)
+	smr_cq = calloc(1, sizeof(*smr_cq));
+	if (!smr_cq)
 		return -FI_ENOMEM;
 
-	ret = ofi_cq_init(&smr_prov, domain, attr, util_cq,
+	ret = ofi_cq_init(&smr_prov, domain, attr, &smr_cq->util_cq,
 			  &ofi_cq_progress, context);
 	if (ret)
 		goto free;
 
-	(*cq_fid) = &util_cq->cq_fid;
+	if (attr->flags & FI_PEER) {
+		smr_cq->peer_cq = ((struct fi_peer_cq_context *) context)->cq;
+		smr_cq->util_cq.cq_fid.ops = &smr_peer_cq_ops;
+	} else {
+		ret = smr_init_peer_cq(smr_cq);
+		if (ret)
+			goto cleanup;
+	}
+
+	smr_cq->util_cq.cq_fid.fid.ops = &smr_cq_fi_ops;
+	(*cq_fid) = &smr_cq->util_cq.cq_fid;
 	return 0;
 
+cleanup:
+	(void) ofi_cq_cleanup(&smr_cq->util_cq);
 free:
-	free(util_cq);
+	free(smr_cq);
 	return ret;
 }

--- a/prov/shm/src/smr_domain.c
+++ b/prov/shm/src/smr_domain.c
@@ -44,7 +44,7 @@ static struct fi_ops_domain smr_domain_ops = {
 	.cntr_open = smr_cntr_open,
 	.poll_open = fi_poll_create,
 	.stx_ctx = fi_no_stx_context,
-	.srx_ctx = fi_no_srx_context,
+	.srx_ctx = smr_srx_context,
 	.query_atomic = smr_query_atomic,
 	.query_collective = fi_no_query_collective,
 };

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -160,10 +160,9 @@ static int smr_ep_cancel_recv(struct smr_ep *ep, struct smr_queue *queue,
 					 context);
 	if (entry) {
 		recv_entry = container_of(entry, struct smr_rx_entry, entry);
-		ret = smr_complete_rx(ep, (void *) recv_entry->context, op,
-				      smr_rx_cq_flags(op, recv_entry->flags, 0),
-				      0, NULL, recv_entry->peer_id,
-				      recv_entry->tag, 0, FI_ECANCELED);
+		ret = smr_write_err_comp(ep->util_ep.rx_cq, recv_entry->context,
+					 smr_rx_cq_flags(op, recv_entry->flags, 0),
+					 recv_entry->tag, FI_ECANCELED);
 		ofi_freestack_push(ep->recv_fs, recv_entry);
 		ret = ret ? ret : 1;
 	}

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -276,9 +276,9 @@ static int smr_match_tagged(struct dlist_entry *item, const void *args)
 static int smr_match_unexp_msg(struct dlist_entry *item, const void *args)
 {
 	struct smr_match_attr *attr = (struct smr_match_attr *)args;
-	struct smr_unexp_msg *unexp_msg;
+	struct smr_cmd_ctx *unexp_msg;
 
-	unexp_msg = container_of(item, struct smr_unexp_msg, entry);
+	unexp_msg = container_of(item, struct smr_cmd_ctx, entry);
 	assert(unexp_msg->cmd.msg.hdr.op == ofi_op_msg);
 	return smr_match_id(unexp_msg->cmd.msg.hdr.id, attr->id);
 }
@@ -286,9 +286,9 @@ static int smr_match_unexp_msg(struct dlist_entry *item, const void *args)
 static int smr_match_unexp_tagged(struct dlist_entry *item, const void *args)
 {
 	struct smr_match_attr *attr = (struct smr_match_attr *)args;
-	struct smr_unexp_msg *unexp_msg;
+	struct smr_cmd_ctx *unexp_msg;
 
-	unexp_msg = container_of(item, struct smr_unexp_msg, entry);
+	unexp_msg = container_of(item, struct smr_cmd_ctx, entry);
 	if (unexp_msg->cmd.msg.hdr.op == ofi_op_msg)
 		return smr_match_id(unexp_msg->cmd.msg.hdr.id, attr->id);
 
@@ -899,7 +899,7 @@ static int smr_ep_close(struct fid *fid)
 		smr_free(ep->region);
 
 	smr_recv_fs_free(ep->recv_fs);
-	smr_unexp_fs_free(ep->unexp_fs);
+	smr_cmd_ctx_fs_free(ep->cmd_ctx_fs);
 	smr_pend_fs_free(ep->pend_fs);
 	smr_sar_fs_free(ep->sar_fs);
 	ofi_spin_destroy(&ep->rx_lock);
@@ -1452,7 +1452,7 @@ int smr_endpoint(struct fid_domain *domain, struct fi_info *info,
 		goto err1;
 
 	ep->recv_fs = smr_recv_fs_create(info->rx_attr->size, NULL, NULL);
-	ep->unexp_fs = smr_unexp_fs_create(info->rx_attr->size, NULL, NULL);
+	ep->cmd_ctx_fs = smr_cmd_ctx_fs_create(info->rx_attr->size, NULL, NULL);
 	ep->pend_fs = smr_pend_fs_create(info->tx_attr->size, NULL, NULL);
 	ep->sar_fs = smr_sar_fs_create(info->rx_attr->size, NULL, NULL);
 	smr_init_queue(&ep->recv_queue, smr_match_msg);

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -149,7 +149,7 @@ static int smr_match_recv_ctx(struct dlist_entry *item, const void *args)
 }
 
 static int smr_ep_cancel_recv(struct smr_ep *ep, struct smr_queue *queue,
-			      void *context)
+			      void *context, uint32_t op)
 {
 	struct smr_rx_entry *recv_entry;
 	struct dlist_entry *entry;
@@ -160,7 +160,7 @@ static int smr_ep_cancel_recv(struct smr_ep *ep, struct smr_queue *queue,
 					 context);
 	if (entry) {
 		recv_entry = container_of(entry, struct smr_rx_entry, entry);
-		ret = smr_complete_rx(ep, (void *) recv_entry->context, ofi_op_msg,
+		ret = smr_complete_rx(ep, (void *) recv_entry->context, op,
 				  recv_entry->flags, 0,
 				  NULL, recv_entry->peer_id,
 				  recv_entry->tag, 0, FI_ECANCELED);
@@ -179,11 +179,11 @@ static ssize_t smr_ep_cancel(fid_t ep_fid, void *context)
 
 	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid);
 
-	ret = smr_ep_cancel_recv(ep, &ep->trecv_queue, context);
+	ret = smr_ep_cancel_recv(ep, &ep->trecv_queue, context, ofi_op_tagged);
 	if (ret)
 		return (ret < 0) ? ret : 0;
 
-	ret = smr_ep_cancel_recv(ep, &ep->recv_queue, context);
+	ret = smr_ep_cancel_recv(ep, &ep->recv_queue, context, ofi_op_msg);
 	return (ret < 0) ? ret : 0;
 }
 

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -161,9 +161,9 @@ static int smr_ep_cancel_recv(struct smr_ep *ep, struct smr_queue *queue,
 	if (entry) {
 		recv_entry = container_of(entry, struct smr_rx_entry, entry);
 		ret = smr_complete_rx(ep, (void *) recv_entry->context, op,
-				  recv_entry->flags, 0,
-				  NULL, recv_entry->peer_id,
-				  recv_entry->tag, 0, FI_ECANCELED);
+				      smr_rx_cq_flags(op, recv_entry->flags, 0),
+				      0, NULL, recv_entry->peer_id,
+				      recv_entry->tag, 0, FI_ECANCELED);
 		ofi_freestack_push(ep->recv_fs, recv_entry);
 		ret = ret ? ret : 1;
 	}

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -69,11 +69,10 @@ static struct smr_rx_entry *smr_get_recv_entry(struct smr_ep *ep,
 	return entry;
 }
 
-ssize_t smr_generic_recv(struct smr_ep *ep, const struct iovec *iov, void **desc,
-			 size_t iov_count, fi_addr_t addr, void *context,
-			 uint64_t tag, uint64_t ignore, uint64_t flags,
-			 struct smr_queue *recv_queue,
-			 struct smr_queue *unexp_queue)
+static ssize_t smr_generic_recv(struct smr_ep *ep, const struct iovec *iov,
+		void **desc, size_t iov_count, fi_addr_t addr, void *context,
+		uint64_t tag, uint64_t ignore, uint64_t flags,
+		struct smr_queue *recv_queue, struct smr_queue *unexp_queue)
 {
 	struct smr_rx_entry *entry;
 	ssize_t ret = -FI_EAGAIN;
@@ -97,7 +96,7 @@ out:
 	return ret;
 }
 
-ssize_t smr_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
+static ssize_t smr_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 		    uint64_t flags)
 {
 	struct smr_ep *ep;
@@ -110,8 +109,9 @@ ssize_t smr_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 				&ep->recv_queue, &ep->unexp_msg_queue);
 }
 
-ssize_t smr_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
-		size_t count, fi_addr_t src_addr, void *context)
+static ssize_t smr_recvv(struct fid_ep *ep_fid, const struct iovec *iov,
+			 void **desc, size_t count, fi_addr_t src_addr,
+			 void *context)
 {
 	struct smr_ep *ep;
 
@@ -122,8 +122,8 @@ ssize_t smr_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 				&ep->unexp_msg_queue);
 }
 
-ssize_t smr_recv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
-		fi_addr_t src_addr, void *context)
+static ssize_t smr_recv(struct fid_ep *ep_fid, void *buf, size_t len,
+			void *desc, fi_addr_t src_addr, void *context)
 {
 	struct iovec iov;
 	struct smr_ep *ep;
@@ -206,8 +206,8 @@ unlock_region:
 	return ret;
 }
 
-ssize_t smr_send(struct fid_ep *ep_fid, const void *buf, size_t len, void *desc,
-		fi_addr_t dest_addr, void *context)
+static ssize_t smr_send(struct fid_ep *ep_fid, const void *buf, size_t len,
+		void *desc, fi_addr_t dest_addr, void *context)
 {
 	struct smr_ep *ep;
 	struct iovec msg_iov;
@@ -222,8 +222,8 @@ ssize_t smr_send(struct fid_ep *ep_fid, const void *buf, size_t len, void *desc,
 }
 
 
-ssize_t smr_sendv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
-		size_t count, fi_addr_t dest_addr, void *context)
+static ssize_t smr_sendv(struct fid_ep *ep_fid, const struct iovec *iov,
+		void **desc, size_t count, fi_addr_t dest_addr, void *context)
 {
 	struct smr_ep *ep;
 
@@ -233,8 +233,8 @@ ssize_t smr_sendv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 				   0, context, ofi_op_msg, smr_ep_tx_flags(ep));
 }
 
-ssize_t smr_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
-		    uint64_t flags)
+static ssize_t smr_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
+			   uint64_t flags)
 {
 	struct smr_ep *ep;
 
@@ -290,16 +290,16 @@ unlock:
 	return ret;
 }
 
-ssize_t smr_inject(struct fid_ep *ep_fid, const void *buf, size_t len,
-		fi_addr_t dest_addr)
+static ssize_t smr_inject(struct fid_ep *ep_fid, const void *buf, size_t len,
+			  fi_addr_t dest_addr)
 {
 	return smr_generic_inject(ep_fid, buf, len, dest_addr, 0, 0,
 				  ofi_op_msg, 0);
 }
 
-ssize_t smr_senddata(struct fid_ep *ep_fid, const void *buf, size_t len,
-		     void *desc, uint64_t data, fi_addr_t dest_addr,
-		     void *context)
+static ssize_t smr_senddata(struct fid_ep *ep_fid, const void *buf, size_t len,
+			    void *desc, uint64_t data, fi_addr_t dest_addr,
+			    void *context)
 {
 	struct smr_ep *ep;
 	struct iovec iov;
@@ -314,8 +314,8 @@ ssize_t smr_senddata(struct fid_ep *ep_fid, const void *buf, size_t len,
 				   FI_REMOTE_CQ_DATA | smr_ep_tx_flags(ep));
 }
 
-ssize_t smr_injectdata(struct fid_ep *ep_fid, const void *buf, size_t len,
-		       uint64_t data, fi_addr_t dest_addr)
+static ssize_t smr_injectdata(struct fid_ep *ep_fid, const void *buf,
+			      size_t len, uint64_t data, fi_addr_t dest_addr)
 {
 	return smr_generic_inject(ep_fid, buf, len, dest_addr, 0, data,
 				  ofi_op_msg, FI_REMOTE_CQ_DATA);
@@ -334,8 +334,9 @@ struct fi_ops_msg smr_msg_ops = {
 	.injectdata = smr_injectdata,
 };
 
-ssize_t smr_trecv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
-	fi_addr_t src_addr, uint64_t tag, uint64_t ignore, void *context)
+static ssize_t smr_trecv(struct fid_ep *ep_fid, void *buf, size_t len,
+			 void *desc, fi_addr_t src_addr, uint64_t tag,
+			 uint64_t ignore, void *context)
 {
 	struct iovec iov;
 	struct smr_ep *ep;
@@ -345,26 +346,26 @@ ssize_t smr_trecv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 	iov.iov_base = buf;
 	iov.iov_len = len;
 
-	return smr_generic_recv(ep, &iov, &desc, 1, src_addr, context, tag, ignore,
-				smr_ep_rx_flags(ep), &ep->trecv_queue,
+	return smr_generic_recv(ep, &iov, &desc, 1, src_addr, context, tag,
+				ignore, smr_ep_rx_flags(ep), &ep->trecv_queue,
 				&ep->unexp_tagged_queue);
 }
 
-ssize_t smr_trecvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
-	size_t count, fi_addr_t src_addr, uint64_t tag, uint64_t ignore,
-	void *context)
+static ssize_t smr_trecvv(struct fid_ep *ep_fid, const struct iovec *iov,
+			  void **desc, size_t count, fi_addr_t src_addr,
+			  uint64_t tag, uint64_t ignore, void *context)
 {
 	struct smr_ep *ep;
 
 	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
 
-	return smr_generic_recv(ep, iov, desc, count, src_addr, context, tag, ignore,
-				smr_ep_rx_flags(ep), &ep->trecv_queue,
+	return smr_generic_recv(ep, iov, desc, count, src_addr, context, tag,
+				ignore, smr_ep_rx_flags(ep), &ep->trecv_queue,
 				&ep->unexp_tagged_queue);
 }
 
-ssize_t smr_trecvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
-	uint64_t flags)
+static ssize_t smr_trecvmsg(struct fid_ep *ep_fid,
+			    const struct fi_msg_tagged *msg, uint64_t flags)
 {
 	struct smr_ep *ep;
 
@@ -376,7 +377,7 @@ ssize_t smr_trecvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
 				&ep->trecv_queue, &ep->unexp_tagged_queue);
 }
 
-ssize_t smr_tsend(struct fid_ep *ep_fid, const void *buf, size_t len,
+static ssize_t smr_tsend(struct fid_ep *ep_fid, const void *buf, size_t len,
 	void *desc, fi_addr_t dest_addr, uint64_t tag, void *context)
 {
 	struct smr_ep *ep;
@@ -392,7 +393,7 @@ ssize_t smr_tsend(struct fid_ep *ep_fid, const void *buf, size_t len,
 				   smr_ep_tx_flags(ep));
 }
 
-ssize_t smr_tsendv(struct fid_ep *ep_fid, const struct iovec *iov,
+static ssize_t smr_tsendv(struct fid_ep *ep_fid, const struct iovec *iov,
 	void **desc, size_t count, fi_addr_t dest_addr, uint64_t tag,
 	void *context)
 {
@@ -405,8 +406,8 @@ ssize_t smr_tsendv(struct fid_ep *ep_fid, const struct iovec *iov,
 				   smr_ep_tx_flags(ep));
 }
 
-ssize_t smr_tsendmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
-	uint64_t flags)
+static ssize_t smr_tsendmsg(struct fid_ep *ep_fid,
+			    const struct fi_msg_tagged *msg, uint64_t flags)
 {
 	struct smr_ep *ep;
 
@@ -414,19 +415,20 @@ ssize_t smr_tsendmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
 
 	return smr_generic_sendmsg(ep, msg->msg_iov, msg->desc, msg->iov_count,
 				   msg->addr, msg->tag, msg->data, msg->context,
-				   ofi_op_tagged, flags | ep->util_ep.tx_msg_flags);
+				   ofi_op_tagged,
+				   flags | ep->util_ep.tx_msg_flags);
 }
 
-ssize_t smr_tinject(struct fid_ep *ep_fid, const void *buf, size_t len,
-		    fi_addr_t dest_addr, uint64_t tag)
+static ssize_t smr_tinject(struct fid_ep *ep_fid, const void *buf, size_t len,
+			   fi_addr_t dest_addr, uint64_t tag)
 {
 	return smr_generic_inject(ep_fid, buf, len, dest_addr, tag, 0,
 				  ofi_op_tagged, 0);
 }
 
-ssize_t smr_tsenddata(struct fid_ep *ep_fid, const void *buf, size_t len,
-		      void *desc, uint64_t data, fi_addr_t dest_addr,
-		      uint64_t tag, void *context)
+static ssize_t smr_tsenddata(struct fid_ep *ep_fid, const void *buf, size_t len,
+			     void *desc, uint64_t data, fi_addr_t dest_addr,
+			     uint64_t tag, void *context)
 {
 	struct smr_ep *ep;
 	struct iovec iov;
@@ -441,8 +443,9 @@ ssize_t smr_tsenddata(struct fid_ep *ep_fid, const void *buf, size_t len,
 				   FI_REMOTE_CQ_DATA | smr_ep_tx_flags(ep));
 }
 
-ssize_t smr_tinjectdata(struct fid_ep *ep_fid, const void *buf, size_t len,
-			uint64_t data, fi_addr_t dest_addr, uint64_t tag)
+static ssize_t smr_tinjectdata(struct fid_ep *ep_fid, const void *buf,
+			       size_t len, uint64_t data, fi_addr_t dest_addr,
+			       uint64_t tag)
 {
 	return smr_generic_inject(ep_fid, buf, len, dest_addr, tag, data,
 				  ofi_op_tagged, FI_REMOTE_CQ_DATA);

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -38,19 +38,6 @@
 #include "ofi_iov.h"
 #include "smr.h"
 
-
-static inline uint16_t smr_convert_rx_flags(uint64_t fi_flags)
-{
-	uint16_t flags = 0;
-
-	if (fi_flags & FI_COMPLETION)
-		flags |= SMR_RX_COMPLETION;
-	if (fi_flags & FI_MULTI_RECV)
-		flags |= SMR_MULTI_RECV;
-
-	return flags;
-}
-
 static struct smr_rx_entry *smr_get_recv_entry(struct smr_ep *ep,
 		const struct iovec *iov, void **desc, size_t count, fi_addr_t addr,
 		void *context, uint64_t tag, uint64_t ignore, uint64_t flags)
@@ -70,7 +57,7 @@ static struct smr_rx_entry *smr_get_recv_entry(struct smr_ep *ep,
 	entry->iov_count = count;
 	entry->context = context;
 	entry->err = 0;
-	entry->flags = smr_convert_rx_flags(flags);
+	entry->flags = flags;
 	entry->peer_id = ep->util_ep.caps & FI_DIRECTED_RECV &&
 				addr != FI_ADDR_UNSPEC ?
 				smr_addr_lookup(ep->util_ep.av, addr) : -1;

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -198,7 +198,7 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 	if (proto != smr_src_inline && proto != smr_src_inject)
 		goto unlock_cq;
 
-	ret = smr_complete_tx(ep, context, op, op_flags, 0);
+	ret = smr_complete_tx(ep, context, op, op_flags);
 	if (ret) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"unable to process tx completion\n");

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -95,7 +95,7 @@ static ssize_t smr_rma_fast(struct smr_region *peer_smr, const struct iovec *iov
 	return 0;
 }
 
-ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
+static ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 	size_t iov_count, const struct fi_rma_iov *rma_iov, size_t rma_count,
 	void **desc, fi_addr_t addr, void *context, uint32_t op, uint64_t data,
 	uint64_t op_flags)
@@ -196,8 +196,9 @@ unlock_region:
 	return ret;
 }
 
-ssize_t smr_read(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
-	fi_addr_t src_addr, uint64_t addr, uint64_t key, void *context)
+static ssize_t smr_read(struct fid_ep *ep_fid, void *buf, size_t len,
+			void *desc, fi_addr_t src_addr, uint64_t addr,
+			uint64_t key, void *context)
 {
 	struct smr_ep *ep;
 	struct iovec msg_iov;
@@ -216,9 +217,9 @@ ssize_t smr_read(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 			       smr_ep_tx_flags(ep));
 }
 
-ssize_t smr_readv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
-	size_t count, fi_addr_t src_addr, uint64_t addr, uint64_t key,
-	void *context)
+static ssize_t smr_readv(struct fid_ep *ep_fid, const struct iovec *iov,
+			 void **desc, size_t count, fi_addr_t src_addr,
+			 uint64_t addr, uint64_t key, void *context)
 {
 	struct smr_ep *ep;
 	struct fi_rma_iov rma_iov;
@@ -234,8 +235,8 @@ ssize_t smr_readv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 			       smr_ep_tx_flags(ep));
 }
 
-ssize_t smr_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
-	uint64_t flags)
+static ssize_t smr_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
+			   uint64_t flags)
 {
 	struct smr_ep *ep;
 
@@ -248,8 +249,9 @@ ssize_t smr_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 			       flags | ep->util_ep.tx_msg_flags);
 }
 
-ssize_t smr_write(struct fid_ep *ep_fid, const void *buf, size_t len, void *desc,
-	fi_addr_t dest_addr, uint64_t addr, uint64_t key, void *context)
+static ssize_t smr_write(struct fid_ep *ep_fid, const void *buf, size_t len,
+			 void *desc, fi_addr_t dest_addr, uint64_t addr,
+			 uint64_t key, void *context)
 {
 	struct smr_ep *ep;
 	struct iovec msg_iov;
@@ -268,9 +270,9 @@ ssize_t smr_write(struct fid_ep *ep_fid, const void *buf, size_t len, void *desc
 			       smr_ep_tx_flags(ep));
 }
 
-ssize_t smr_writev(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
-		size_t count, fi_addr_t dest_addr, uint64_t addr, uint64_t key,
-		void *context)
+static ssize_t smr_writev(struct fid_ep *ep_fid, const struct iovec *iov,
+			  void **desc, size_t count, fi_addr_t dest_addr,
+			  uint64_t addr, uint64_t key, void *context)
 {
 	struct smr_ep *ep;
 	struct fi_rma_iov rma_iov;
@@ -287,8 +289,8 @@ ssize_t smr_writev(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 }
 
 
-ssize_t smr_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
-	uint64_t flags)
+static ssize_t smr_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
+			    uint64_t flags)
 {
 	struct smr_ep *ep;
 
@@ -301,9 +303,9 @@ ssize_t smr_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 			       flags | ep->util_ep.tx_msg_flags);
 }
 
-ssize_t smr_generic_rma_inject(struct fid_ep *ep_fid, const void *buf,
-	size_t len, fi_addr_t dest_addr, uint64_t addr, uint64_t key,
-	uint64_t data, uint64_t flags)
+static ssize_t smr_generic_rma_inject(struct fid_ep *ep_fid, const void *buf,
+		size_t len, fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+		uint64_t data, uint64_t flags)
 {
 	struct smr_ep *ep;
 	struct smr_domain *domain;
@@ -363,9 +365,9 @@ unlock_region:
 	return ret;
 }
 
-ssize_t smr_writedata(struct fid_ep *ep_fid, const void *buf, size_t len,
-		      void *desc, uint64_t data, fi_addr_t dest_addr,
-		      uint64_t addr, uint64_t key, void *context)
+static ssize_t smr_writedata(struct fid_ep *ep_fid, const void *buf, size_t len,
+			     void *desc, uint64_t data, fi_addr_t dest_addr,
+			     uint64_t addr, uint64_t key, void *context)
 {
 	struct smr_ep *ep;
 	struct iovec iov;
@@ -384,16 +386,17 @@ ssize_t smr_writedata(struct fid_ep *ep_fid, const void *buf, size_t len,
 			       FI_REMOTE_CQ_DATA | smr_ep_tx_flags(ep));
 }
 
-ssize_t smr_rma_inject(struct fid_ep *ep_fid, const void *buf,
-	size_t len, fi_addr_t dest_addr, uint64_t addr, uint64_t key)
+static ssize_t smr_rma_inject(struct fid_ep *ep_fid, const void *buf,
+			      size_t len, fi_addr_t dest_addr, uint64_t addr,
+			      uint64_t key)
 {
 	return smr_generic_rma_inject(ep_fid, buf, len, dest_addr, addr, key,
 				      0, 0);
 }
 
-ssize_t smr_inject_writedata(struct fid_ep *ep_fid, const void *buf, size_t len,
-			     uint64_t data, fi_addr_t dest_addr, uint64_t addr,
-			     uint64_t key)
+static ssize_t smr_inject_writedata(struct fid_ep *ep_fid, const void *buf,
+			size_t len, uint64_t data, fi_addr_t dest_addr,
+			uint64_t addr, uint64_t key)
 {
 	return smr_generic_rma_inject(ep_fid, buf, len, dest_addr, addr, key,
 				      data, FI_REMOTE_CQ_DATA);

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -500,6 +500,7 @@ static int fi_cq_init(struct fid_domain *domain, struct fi_cq_attr *attr,
 	if (ret)
 		return ret;
 
+	cq->flags = attr->flags;
 	cq->read_entry = read_entry;
 	cq->cq_fid.fid.fclass = FI_CLASS_CQ;
 	cq->cq_fid.fid.context = context;


### PR DESCRIPTION
Adds shared cq, shared rx, and av user id support to shm which uses it internally with itself as a first step to use shm as a peer provider

This includes the same API change from #7816 for CI purposes but will be removed once that is merged. This PR is mainly for testing purposes but also as an initial request for comment. I am still testing and reviewing and will update it. Adding do not merge label until I've cleaned it up and we've merged #7816