### PR TITLE
fabtests/sighandler_test: set caps and mode

### DIFF
--- a/fabtests/regression/sighandler_test.c
+++ b/fabtests/regression/sighandler_test.c
@@ -78,6 +78,8 @@ int main(int argc, char **argv)
 				return EXIT_FAILURE;
 			}
 		}
+		hints->caps = FI_MSG;
+		hints->mode = FI_CONTEXT;
 		if (ft_init_fabric()) {
 			ft_freehints(hints);
 			exit(EXIT_FAILURE);


### PR DESCRIPTION
The test waits for the provider to complete initialization which includes posting
a receive buffer using fi_recv. This ensures the provider anticipates the fi_recv
call and sets the mode bit to support more providers.

Signed-off-by: Alexia Ingerson <alexia.ingerson@intel.com>