### PR TITLE
contrib/intel/jenkins: disable ze-shm stage while we investigate failures

### DIFF
--- a/contrib/intel/jenkins/run.py
+++ b/contrib/intel/jenkins/run.py
@@ -82,7 +82,7 @@ def ze_fabtests(core, hosts, mode, util):
         runzefabtests.execute_cmd()
     else:
         print("Skipping {} {} as execute condition fails"\
-              .format(core, runfabzetests.testname))
+              .format(core, runzefabtests.testname))
     print("-------------------------------------------------------------------")
 
 def intel_mpi_benchmark(core, hosts, mpi, mode, group, util):

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -250,7 +250,9 @@ class ZeFabtests(Test):
 
     @property
     def execute_condn(self):
-        return True if (self.core_prov == 'shm') else False
+        #disabled for failures we are investigating
+        return False
+#        return True if (self.core_prov == 'shm') else False
 
     def execute_cmd(self):
         curdir = os.getcwd()


### PR DESCRIPTION
contrib/intel/jenkins: disable ze-shm stage while we investigate failures

Signed-off-by: Zach Dworkin <zachary.dworkin@intel.com>