### PR TITLE
prov/efa: Add unit test for pkt pool flags and page alignment

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -96,9 +96,12 @@ TESTS += prov/efa/test/efa_unit_test
 nodist_prov_efa_test_efa_unit_test_SOURCES = \
 	prov/efa/test/efa_unit_tests.h \
 	prov/efa/test/efa_unit_tests.c \
-	prov/efa/test/rdma_core_mocks.c
+	prov/efa/test/rdma_core_mocks.c \
+	prov/efa/test/efa_unit_test_common.c \
+	prov/efa/test/efa_unit_test_ep.c
 
-efa_CPPFLAGS += -I$(top_srcdir)/prov/efa/test $(cmocka_CPPFLAGS)
+_efa_files += prov/efa/test/efa_unit_test_common.c
+efa_CPPFLAGS += -I$(top_srcdir)/include -I$(top_srcdir)/prov/efa/test $(cmocka_CPPFLAGS)
 
 
 prov_efa_test_efa_unit_test_CPPFLAGS = $(efa_CPPFLAGS)

--- a/prov/efa/test/efa_unit_test_common.c
+++ b/prov/efa/test/efa_unit_test_common.c
@@ -1,0 +1,41 @@
+#include "efa_unit_tests.h"
+
+int efa_unit_test_resource_construct(struct efa_resource* resource)
+{
+	int ret;
+	struct fi_av_attr av_attr = { 0 };
+
+	ret = fi_getinfo(FI_VERSION(1, 14), NULL, NULL, 0ULL, NULL, &resource->info);
+	if (ret)
+		return ret;
+
+	ret = fi_fabric(resource->info->fabric_attr, &resource->fabric, NULL);
+	if (ret) {
+		fi_freeinfo(resource->info);
+		return ret;
+	}
+
+	ret = fi_domain(resource->fabric, resource->info, &resource->domain, NULL);
+	if (ret) {
+		fi_close(&resource->fabric->fid);
+		fi_freeinfo(resource->info);
+		return ret;
+	}
+
+	ret = fi_av_open(resource->domain, &av_attr, &resource->av, NULL);
+	if (ret) {
+		fi_close(&resource->domain->fid);
+		fi_close(&resource->fabric->fid);
+		return ret;
+	}
+
+	return 0;
+}
+
+void efa_unit_test_resource_destroy(struct efa_resource* resource)
+{
+	fi_close(&resource->av->fid);
+	fi_close(&resource->domain->fid);
+	fi_close(&resource->fabric->fid);
+	fi_freeinfo(resource->info);
+}

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -1,0 +1,65 @@
+#include "efa_unit_tests.h"
+
+static void check_ep_pkt_pool_flags(struct efa_resource resource, int expected_flags)
+{
+       struct fid_ep *ep;
+       struct rxr_ep *rxr_ep;
+       int ret;
+       ret = fi_endpoint(resource.domain, resource.info, &ep, NULL);
+       assert_int_equal(ret, 0);
+       rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid);
+       assert_int_equal(rxr_ep->efa_tx_pkt_pool->attr.flags, expected_flags);
+       assert_int_equal(rxr_ep->efa_rx_pkt_pool->attr.flags, expected_flags);
+       fi_close(&ep->fid);
+}
+
+/**
+ * @brief Test the pkt pool flags in rxr_ep_init()
+ */
+void test_rxr_ep_pkt_pool_flags()
+{
+	int ret;
+	struct efa_resource resource = {0};
+	ret = efa_unit_test_resource_construct(&resource);
+	assert_int_equal(ret, 0);
+
+	g_efa_fork_status = EFA_FORK_SUPPORT_ON;
+	check_ep_pkt_pool_flags(resource, OFI_BUFPOOL_NONSHARED);
+
+	g_efa_fork_status = EFA_FORK_SUPPORT_OFF;
+	check_ep_pkt_pool_flags(resource, OFI_BUFPOOL_HUGEPAGES);
+
+	g_efa_fork_status = EFA_FORK_SUPPORT_UNNEEDED;
+	check_ep_pkt_pool_flags(resource, OFI_BUFPOOL_HUGEPAGES);
+
+	efa_unit_test_resource_destroy(&resource);
+}
+
+/**
+ * @brief When the buf pool is created with OFI_BUFPOOL_NONSHARED,
+ * test if the allocated memory is page aligned.
+ */
+void test_rxr_ep_pkt_pool_page_alignment()
+{
+	int ret;
+	struct ofi_bufpool_region *buf;
+	struct fid_ep *ep;
+	struct rxr_ep *rxr_ep;
+	struct efa_resource resource = {0};
+	ret = efa_unit_test_resource_construct(&resource);
+	assert_int_equal(ret, 0);
+
+	g_efa_fork_status = EFA_FORK_SUPPORT_ON;
+	ret = fi_endpoint(resource.domain, resource.info, &ep, NULL);
+	assert_int_equal(ret, 0);
+	rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid);
+	assert_int_equal(rxr_ep->efa_rx_pkt_pool->attr.flags, OFI_BUFPOOL_NONSHARED);
+
+	buf = ofi_buf_alloc(rxr_ep->efa_rx_pkt_pool);
+	assert_non_null(buf);
+	assert_true(((uintptr_t)ofi_buf_region(buf)->alloc_region % ofi_get_page_size()) == 0);
+	ofi_buf_free(buf);
+
+	fi_close(&ep->fid);
+	efa_unit_test_resource_destroy(&resource);
+}

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -6,6 +6,8 @@ int main(void)
 	const struct CMUnitTest efa_unit_tests[] = {
 		cmocka_unit_test(test_duplicate_efa_ah_creation),    /* Requires an EFA device to work */
 		cmocka_unit_test(test_efa_device_construct_error_handling),    /* Requires an EFA device to work */
+		cmocka_unit_test(test_rxr_ep_pkt_pool_flags), /* Requires an EFA device to work */
+		cmocka_unit_test(test_rxr_ep_pkt_pool_page_alignment), /* Requires an EFA device to work */
 	};
 	cmocka_set_message_output(CM_OUTPUT_XML);
 

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -8,9 +8,26 @@
 #include <setjmp.h>
 #include <cmocka.h>
 #include "stdio.h"
+#include "efa.h"
+#include "rxr.h"
+
+struct efa_resource {
+	struct fi_info* info;
+	struct fid_fabric* fabric;
+	struct fid_domain* domain;
+	struct fid_av* av;
+};
 
 void test_duplicate_efa_ah_creation();
 
 void test_efa_device_construct_error_handling();
+
+void test_rxr_ep_pkt_pool_flags();
+
+void test_rxr_ep_pkt_pool_page_alignment();
+
+int efa_unit_test_resource_construct(struct efa_resource* resource);
+
+void efa_unit_test_resource_destroy(struct efa_resource* resource);
 
 #endif


### PR DESCRIPTION
This unit test is introduced to validate the changes in
https://github.com/ofiwg/libfabric/pull/7558

Signed-off-by: Shi Jin <sjina@amazon.com>



Test info

```
(venv) [ec2-user@compute-dy-c5n18xlarge-1 libfabric]$ ./prov/efa/test/efa_unit_test
<?xml version="1.0" encoding="UTF-8" ?>
<testsuites>
  <testsuite name="efa unit tests" time="0.191" tests="4" failures="0" errors="0" skipped="0" >
    <testcase name="test_duplicate_efa_ah_creation" time="0.136" >
    </testcase>
    <testcase name="test_efa_device_construct_error_handling" time="0.000" >
    </testcase>
    <testcase name="test_rxr_ep_pkt_pool_flags" time="0.009" >
    </testcase>
    <testcase name="test_rxr_ep_pkt_pool_page_alignment" time="0.046" >
    </testcase>
  </testsuite>
</testsuites>
```