### PR TITLE
prov/efa: adopt wide completion APIs in EFA provider

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -97,6 +97,7 @@ nodist_prov_efa_test_efa_unit_test_SOURCES = \
 	prov/efa/test/efa_unit_tests.h \
 	prov/efa/test/efa_unit_tests.c \
 	prov/efa/test/rdma_core_mocks.c \
+	prov/efa/test/efa_unit_test_mocks.c \
 	prov/efa/test/efa_unit_test_common.c \
 	prov/efa/test/efa_unit_test_ep.c
 
@@ -110,7 +111,11 @@ prov_efa_test_efa_unit_test_LDFLAGS = $(cmocka_rpath) $(efa_LDFLAGS) $(cmocka_LD
 					-Wl,--wrap=ibv_create_ah \
 					-Wl,--wrap=ibv_destroy_ah \
 					-Wl,--wrap=efadv_query_ah \
-					-Wl,--wrap=efadv_query_device
+					-Wl,--wrap=efadv_query_device \
+					-Wl,--wrap=rxr_pkt_handle_send_completion \
+					-Wl,--wrap=rxr_pkt_handle_recv_completion \
+					-Wl,--wrap=rxr_pkt_handle_send_error \
+					-Wl,--wrap=rxr_pkt_handle_recv_error
 prov_efa_test_efa_unit_test_LIBS = $(efa_LIBS) $(linkback)
 
 endif ENABLE_EFA_UNIT_TEST

--- a/prov/efa/configure.m4
+++ b/prov/efa/configure.m4
@@ -52,7 +52,7 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 				[efa_happy=1],
 				[
 					efa_happy=0
-					AC_MSG_WARN([The EFA provider requires rdma-core v27 or newer.])
+					AC_MSG_WARN([The EFA provider requires rdma-core v31 or newer.])
 				])
 	      ])
 
@@ -148,6 +148,7 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 						 [
 							#include <stdarg.h>
 							#include <stddef.h>
+							#include <stdint.h>
 							#include <setjmp.h>
 					 	 ])
         if [ test x"$cmocka_dir" != x""]; then

--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -189,11 +189,10 @@ struct efa_cq {
 	struct efa_domain	*domain;
 	size_t			entry_size;
 	efa_cq_read_entry	read_entry;
-	struct slist		wcq;
 	ofi_spin_t		lock;
 	struct ofi_bufpool	*wce_pool;
 
-	struct ibv_cq		*ibv_cq;
+	struct ibv_cq_ex	*ibv_cq_ex;
 };
 
 struct efa_qp {

--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -1094,7 +1094,8 @@ void test_duplicate_efa_ah_creation() {
 	uint8_t gid[EFA_GID_LEN];
 	memset(gid, 7, EFA_GID_LEN);
 
-	will_return(__wrap_efadv_query_device, 0);
+	/* efadv_query_device is only called once during global initialization */
+	will_return_maybe(__wrap_efadv_query_device, 0);
 	ret = efa_unit_test_resource_construct(&resource);
 	assert_int_equal(ret, 0);
 	av = container_of(resource.av, struct efa_av, util_av.av_fid);

--- a/prov/efa/src/efa_ep.c
+++ b/prov/efa/src/efa_ep.c
@@ -436,19 +436,19 @@ static int efa_ep_enable(struct fid_ep *ep_fid)
 	if (ep->scq) {
 		attr_ex.cap.max_send_wr = ep->info->tx_attr->size;
 		attr_ex.cap.max_send_sge = ep->info->tx_attr->iov_limit;
-		attr_ex.send_cq = ep->scq->ibv_cq;
+		attr_ex.send_cq = ibv_cq_ex_to_cq(ep->scq->ibv_cq_ex);
 		ibv_pd = ep->scq->domain->ibv_pd;
 	} else {
-		attr_ex.send_cq = ep->rcq->ibv_cq;
+		attr_ex.send_cq = ibv_cq_ex_to_cq(ep->rcq->ibv_cq_ex);
 		ibv_pd = ep->rcq->domain->ibv_pd;
 	}
 
 	if (ep->rcq) {
 		attr_ex.cap.max_recv_wr = ep->info->rx_attr->size;
 		attr_ex.cap.max_recv_sge = ep->info->rx_attr->iov_limit;
-		attr_ex.recv_cq = ep->rcq->ibv_cq;
+		attr_ex.recv_cq = ibv_cq_ex_to_cq(ep->rcq->ibv_cq_ex);
 	} else {
-		attr_ex.recv_cq = ep->scq->ibv_cq;
+		attr_ex.recv_cq = ibv_cq_ex_to_cq(ep->scq->ibv_cq_ex);
 	}
 
 	attr_ex.cap.max_inline_data = ep->domain->device->efa_attr.inline_buf_size;

--- a/prov/efa/test/README.md
+++ b/prov/efa/test/README.md
@@ -3,15 +3,15 @@
 ## How to run
 
 To run efa unit tests, you will need to have cmocka installed.
-Cmocka Mirror: https://cmocka.org/files/
-Install Instructions: https://gitlab.com/cmocka/cmocka/-/blob/master/INSTALL.md
+* [Cmocka Mirror](https://cmocka.org/files/)
+* [Install Instructions](https://gitlab.com/cmocka/cmocka/-/blob/master/INSTALL.md)
 
-You will need to configure libfabric with ```--enable-efa-unit-test=<path_to_cmocka_install>```.
+You will need to configure libfabric with `--enable-efa-unit-test=<path_to_cmocka_install>`.
 
 An example build and run command would look like:
 
-```
-./autogen.sh; ./configure --enable-efa-unit-test=/home/ec2-user/cmocka/install; make check;
+```bash
+./autogen.sh && ./configure --enable-efa-unit-test=/home/ec2-user/cmocka/install && make check;
 ```
 
 ## How to write
@@ -23,10 +23,15 @@ An example build and run command would look like:
 
 ## Mocking
 
-To mock a function, you will need to add ```-Wl,--wrap=<function to mock>```
+To mock a function, you will need to add `-Wl,--wrap=<function to mock>`
 to the Makefile.include as part of efatest_LIBS. Then, after declaring the function,
-you can replace it with __wrap_<function to mock>. If you need to use the original
-function, you can use __real_<function to mock> after declaring it.
+you can replace it with `__wrap_<function to mock>`. If you need to use the original
+function, you can use `__real_<function to mock>` after declaring it.
+
+### Directions For Creating New Mock Function:
+1. Recreate the funciton signature with `__wrap_<function>(the_params)`, and the function to the **Makefile.include** `prov_efa_test_efa_unit_test_LDFLAGS` list
+1. Check all parameters with `check_expected()`. This allows test code to optionally check the parameters of the mocked function with the family of `expect_value()` functions.
+1. Mock the function return value using `will_return(__wrap_xxx, mocked_val)`. Inside the mocked function, access `mocked_val` using `mock()`. This gives the test code control of the return value of the mocked function. The `will_return()` function creates a stack for each mocked function and returns the top of the stack first.
 
 ### Manipulating mock behavior
 
@@ -36,13 +41,13 @@ The will_return class of functions will place values onto a stack that can
 be popped within the function with the mock function. You can use this to
 manipulate the function behavior. For example, if you pop the value 'true'
 using
-```
+```c
 will_return(mock_function, true)
 ```
 
 and add a check in your mock function like so:
 
-```
+```c
 int use_real_function = mock_type(bool);
 if (use_real_function)
 	return __real_mock_function(params);

--- a/prov/efa/test/efa_unit_test_common.c
+++ b/prov/efa/test/efa_unit_test_common.c
@@ -1,41 +1,79 @@
 #include "efa_unit_tests.h"
 
-int efa_unit_test_resource_construct(struct efa_resource* resource)
+int efa_unit_test_resource_construct(struct efa_resource *resource)
 {
 	int ret;
-	struct fi_av_attr av_attr = { 0 };
+	struct fi_av_attr av_attr = {0};
+	struct fi_cq_attr cq_attr = {0};
 
-	ret = fi_getinfo(FI_VERSION(1, 14), NULL, NULL, 0ULL, NULL, &resource->info);
+	ret = fi_getinfo(FI_VERSION(1, 14), NULL, NULL, 0ULL, resource->hints, &resource->info);
 	if (ret)
-		return ret;
+		goto err;
 
 	ret = fi_fabric(resource->info->fabric_attr, &resource->fabric, NULL);
-	if (ret) {
-		fi_freeinfo(resource->info);
-		return ret;
-	}
+	if (ret)
+		goto err;
 
 	ret = fi_domain(resource->fabric, resource->info, &resource->domain, NULL);
-	if (ret) {
-		fi_close(&resource->fabric->fid);
-		fi_freeinfo(resource->info);
-		return ret;
+	if (ret)
+		goto err;
+
+	ret = fi_endpoint(resource->domain, resource->info, &resource->ep, NULL);
+	if (ret)
+		goto err;
+
+	if (resource->eq_attr) {
+		ret = fi_eq_open(resource->fabric, resource->eq_attr, &resource->eq, NULL);
+		if (ret)
+			goto err;
 	}
 
 	ret = fi_av_open(resource->domain, &av_attr, &resource->av, NULL);
-	if (ret) {
-		fi_close(&resource->domain->fid);
-		fi_close(&resource->fabric->fid);
-		return ret;
-	}
+	if (ret)
+		goto err;
+
+	ret = fi_cq_open(resource->domain, &cq_attr, &resource->cq, NULL);
+	if (ret)
+		goto err;
 
 	return 0;
+err:
+	efa_unit_test_resource_destroy(resource);
+	return ret;
 }
 
-void efa_unit_test_resource_destroy(struct efa_resource* resource)
+/**
+ * @brief Clean up test resources.
+ * Note: Resources should be destroyed in order.
+ * @param[in] resource	struct efa_resource to clean up.
+ */
+void efa_unit_test_resource_destroy(struct efa_resource *resource)
 {
-	fi_close(&resource->av->fid);
-	fi_close(&resource->domain->fid);
-	fi_close(&resource->fabric->fid);
-	fi_freeinfo(resource->info);
+	if (resource->ep) {
+		assert_int_equal(fi_close(&resource->ep->fid), 0);
+	}
+
+	if (resource->eq) {
+		assert_int_equal(fi_close(&resource->eq->fid), 0);
+	}
+
+	if (resource->cq) {
+		assert_int_equal(fi_close(&resource->cq->fid), 0);
+	}
+
+	if (resource->av) {
+		assert_int_equal(fi_close(&resource->av->fid), 0);
+	}
+
+	if (resource->domain) {
+		assert_int_equal(fi_close(&resource->domain->fid), 0);
+	}
+
+	if (resource->fabric) {
+		assert_int_equal(fi_close(&resource->fabric->fid), 0);
+	}
+
+	if (resource->info) {
+		fi_freeinfo(resource->info);
+	}
 }

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -1,4 +1,97 @@
 #include "efa_unit_tests.h"
+#include "efa_unit_test_utils.h"
+
+static void dgram_ep_resource_construct(struct efa_resource *resource)
+{
+	int err;
+	struct efa_ep *efa_ep;
+	struct fi_fabric_attr fabric_attr = {0};
+	struct fi_domain_attr domain_attr = {0};
+	struct fi_ep_attr ep_attr = {0};
+	struct fi_info hints = {0};
+	struct ibv_ah ibv_ah = {0};
+
+	/* Required attributes for EFA DGRAM endpoint */
+	fabric_attr.prov_name = EFA_PROV_NAME;
+	domain_attr.mr_mode |= FI_MR_LOCAL | FI_MR_ALLOCATED;
+	ep_attr.type = FI_EP_DGRAM;
+	hints.mode |= FI_MSG_PREFIX;
+	hints.fabric_attr = &fabric_attr;
+	hints.domain_attr = &domain_attr;
+	hints.ep_attr = &ep_attr;
+	resource->hints = &hints;
+
+	/* efadv_query_device is only called once during global initialization */
+	will_return_maybe(__wrap_efadv_query_device, 0);
+	err = efa_unit_test_resource_construct(resource);
+	assert_int_equal(err, 0);
+
+	/* TX and RX are symmetrical from the progress engine POV. We only test RX. */
+	fi_ep_bind(resource->ep, &resource->cq->fid, FI_RECV);
+	fi_ep_bind(resource->ep, &resource->av->fid, 0);
+
+	efa_ep = container_of(resource->ep, struct efa_ep, util_ep.ep_fid);
+	efa_ep->info->caps &= ~FI_SEND;
+
+	efa_unit_test_ibv_cq_ex_update_func_ptr(efa_ep->rcq->ibv_cq_ex);
+	efa_ep->rcq->ibv_cq_ex->read_opcode = &_read_send_code;
+	efa_ep->rcq->read_entry = &_read_entry;
+
+	expect_any(__wrap_ibv_create_ah, pd);
+	expect_any(__wrap_ibv_create_ah, attr);
+	will_return(__wrap_ibv_create_ah, &ibv_ah);
+
+	err = fi_enable(resource->ep);
+	if (err) {
+		/* Don't leak reource */
+		efa_unit_test_resource_destroy(resource);
+	}
+	assert_int_equal(err, 0);
+}
+
+static void rdm_ep_resource_construct(struct efa_resource *resource)
+{
+	int err;
+	struct rxr_ep *rxr_ep;
+	struct efa_cq *efa_cq;
+	struct fi_fabric_attr fabric_attr = {0};
+	struct fi_domain_attr domain_attr = {0};
+	struct fi_ep_attr ep_attr = {0};
+	struct fi_info hints = {0};
+	struct ibv_ah ibv_ah = {0};
+
+	/* Ask for EFA RDM endpoint */
+	fabric_attr.prov_name = EFA_PROV_NAME;
+	ep_attr.type = FI_EP_RDM;
+	hints.fabric_attr = &fabric_attr;
+	hints.domain_attr = &domain_attr;
+	hints.ep_attr = &ep_attr;
+	resource->hints = &hints;
+
+	/* efadv_query_device is only called once during global initialization */
+	will_return_maybe(__wrap_efadv_query_device, 0);
+	err = efa_unit_test_resource_construct(resource);
+	assert_int_equal(err, 0);
+
+	fi_ep_bind(resource->ep, &resource->av->fid, 0);
+
+	rxr_ep = container_of(resource->ep, struct rxr_ep, util_ep.ep_fid);
+	efa_cq = container_of(rxr_ep->rdm_cq, struct efa_cq, util_cq.cq_fid);
+
+	efa_unit_test_ibv_cq_ex_update_func_ptr(efa_cq->ibv_cq_ex);
+	efa_cq->read_entry = &_read_entry;
+
+	expect_any(__wrap_ibv_create_ah, pd);
+	expect_any(__wrap_ibv_create_ah, attr);
+	will_return(__wrap_ibv_create_ah, &ibv_ah);
+
+	err = fi_enable(resource->ep);
+	if (err) {
+		/* Don't leak reource */
+		efa_unit_test_resource_destroy(resource);
+	}
+	assert_int_equal(err, 0);
+}
 
 static void check_ep_pkt_pool_flags(struct efa_resource resource, int expected_flags)
 {
@@ -20,6 +113,9 @@ void test_rxr_ep_pkt_pool_flags()
 {
 	int ret;
 	struct efa_resource resource = {0};
+
+	/* efadv_query_device is only called once during global initialization */
+	will_return_maybe(__wrap_efadv_query_device, 0);
 	ret = efa_unit_test_resource_construct(&resource);
 	assert_int_equal(ret, 0);
 
@@ -46,9 +142,13 @@ void test_rxr_ep_pkt_pool_page_alignment()
 	struct fid_ep *ep;
 	struct rxr_ep *rxr_ep;
 	struct efa_resource resource = {0};
+
+	/* efadv_query_device is only called once during global initialization */
+	will_return_maybe(__wrap_efadv_query_device, 0);
 	ret = efa_unit_test_resource_construct(&resource);
 	assert_int_equal(ret, 0);
 
+	/* Turn on g_efa_fork_status and open a new rxr endpoint */
 	g_efa_fork_status = EFA_FORK_SUPPORT_ON;
 	ret = fi_endpoint(resource.domain, resource.info, &ep, NULL);
 	assert_int_equal(ret, 0);
@@ -72,7 +172,6 @@ void test_rxr_ep_pkt_pool_page_alignment()
  */
 void test_rxr_ep_dc_atomic_error_handling()
 {
-	struct fid_ep *ep;
 	struct rxr_ep *rxr_ep;
 	struct rdm_peer *peer;
 	struct fi_ioc ioc = {0};
@@ -84,14 +183,7 @@ void test_rxr_ep_dc_atomic_error_handling()
 	fi_addr_t peer_addr;
 	int buf[1] = {0}, err, numaddr;
 
-	err = efa_unit_test_resource_construct(&resource);
-	assert_int_equal(err, 0);
-
-	err = fi_endpoint(resource.domain, resource.info, &ep, NULL);
-	assert_int_equal(err, 0);
-
-	err = fi_ep_bind(ep, &resource.av->fid, 0);
-	assert_int_equal(err, 0);
+	rdm_ep_resource_construct(&resource);
 
 	/* create a fake peer */
 	raw_addr.raw[0] = 0xfe;
@@ -119,7 +211,7 @@ void test_rxr_ep_dc_atomic_error_handling()
 	msg.datatype = FI_INT32;
 	msg.op = FI_SUM;
 
-	rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid);
+	rxr_ep = container_of(resource.ep, struct rxr_ep, util_ep.ep_fid);
 	rxr_ep->use_shm_for_tx = false;
 	/* set peer->flag to RXR_PEER_REQ_SENT will make rxr_atomic() think
 	 * a REQ packet has been sent to the peer (so no need to send again)
@@ -129,7 +221,7 @@ void test_rxr_ep_dc_atomic_error_handling()
 	peer->flags = RXR_PEER_REQ_SENT;
 
 	assert_true(dlist_empty(&rxr_ep->tx_entry_list));
-	err = fi_atomicmsg(ep, &msg, FI_DELIVERY_COMPLETE);
+	err = fi_atomicmsg(resource.ep, &msg, FI_DELIVERY_COMPLETE);
 	/* DC has been reuquested, but ep do not know whether peer supports it, therefore
 	 * -FI_EAGAIN should be returned
 	 */
@@ -137,6 +229,286 @@ void test_rxr_ep_dc_atomic_error_handling()
 	/* make sure there is no leaking of tx_entry */
 	assert_true(dlist_empty(&rxr_ep->tx_entry_list));
 
-	fi_close(&ep->fid);
+	will_return_maybe(__wrap_ibv_destroy_ah, 0);
+	efa_unit_test_resource_destroy(&resource);
+}
+
+/* Verify that DGRAM endpoint progress works with normal work completions */
+void test_dgram_ep_progress_happy()
+{
+	int err;
+	struct efa_ep *efa_ep;
+	struct efa_resource resource = {0};
+
+	dgram_ep_resource_construct(&resource);
+
+	efa_ep = container_of(resource.ep, struct efa_ep, util_ep.ep_fid);
+
+	/* Read 5 entries from CQ and then ENOENT */
+	will_return(_start_poll, 0);
+	will_return_count(_next_poll, 0, 4);
+	will_return(_next_poll, ENOENT);
+	will_return(_end_poll, NULL);
+
+	efa_ep->util_ep.progress(&efa_ep->util_ep);
+
+	/* Error entry will be written to efa_ep->rcq->util_cq.aux_queue */
+	err = !slist_empty(&efa_ep->rcq->util_cq.aux_queue);
+
+	/* Cleanup resource before assertion */
+	will_return_maybe(__wrap_ibv_destroy_ah, 0);
+	efa_unit_test_resource_destroy(&resource);
+
+	assert_int_equal(err, 0);
+}
+
+/* Verify that DGRAM endpoint progress works when CQ is empty */
+void test_dgram_ep_progress_with_empty_cq()
+{
+	int err;
+	struct efa_ep *efa_ep;
+	struct efa_resource resource = {0};
+
+	dgram_ep_resource_construct(&resource);
+
+	efa_ep = container_of(resource.ep, struct efa_ep, util_ep.ep_fid);
+
+	/* Read 5 entries from CQ and then ENOENT */
+	will_return(_start_poll, ENOENT);
+
+	efa_ep->util_ep.progress(&efa_ep->util_ep);
+
+	/* Error entry will be written to efa_ep->rcq->util_cq.aux_queue */
+	err = !slist_empty(&efa_ep->rcq->util_cq.aux_queue);
+
+	/* Cleanup resource before assertion */
+	will_return_maybe(__wrap_ibv_destroy_ah, 0);
+	efa_unit_test_resource_destroy(&resource);
+
+	assert_int_equal(err, 0);
+}
+
+/* Verify that DGRAM endpoint progress works with bad work completion status */
+void test_dgram_ep_progress_encounter_bad_wc_status()
+{
+	int err;
+	struct efa_ep *efa_ep;
+	struct efa_resource resource = {0};
+	struct fi_cq_err_entry err_entry = {0};
+
+	dgram_ep_resource_construct(&resource);
+
+	efa_ep = container_of(resource.ep, struct efa_ep, util_ep.ep_fid);
+
+	/* Read 1 entry from CQ and encounter a bad wc status */
+	will_return(_start_poll, 0);
+	will_return(_end_poll, NULL);
+	efa_ep->rcq->ibv_cq_ex->status = 1;
+
+	efa_ep->util_ep.progress(&efa_ep->util_ep);
+
+	err = ofi_cq_readerr(&efa_ep->rcq->util_cq.cq_fid, &err_entry, 0) != 1;
+
+	/* Cleanup resource before assertion */
+	will_return_maybe(__wrap_ibv_destroy_ah, 0);
+	efa_unit_test_resource_destroy(&resource);
+
+	assert_int_equal(err, 0);
+	assert_int_equal(err_entry.err, EIO);
+	assert_int_equal(err_entry.prov_errno, 1);
+}
+
+/* Verify that RDM endpoint progress works with normal send work completions */
+void test_rdm_ep_progress_send_completion_happy()
+{
+	struct efa_cq *efa_cq;
+	struct rxr_ep *rxr_ep;
+	struct efa_resource resource = {0};
+	struct rxr_pkt_entry entry = {0};
+
+	rdm_ep_resource_construct(&resource);
+
+	rxr_ep = container_of(resource.ep, struct rxr_ep, util_ep.ep_fid);
+	efa_cq = container_of(rxr_ep->rdm_cq, struct efa_cq, util_cq.cq_fid);
+
+	efa_cq->ibv_cq_ex->wr_id = (uint64_t)&entry;
+
+	/* Read 5 entries from CQ and then ENOENT */
+	will_return(_start_poll, 0);
+	will_return_count(_next_poll, 0, 4);
+	will_return(_next_poll, ENOENT);
+	will_return(_end_poll, NULL);
+	will_return_maybe(_read_opcode, IBV_WC_SEND);
+	will_return_count(__wrap_rxr_pkt_handle_send_completion, NULL, 5);
+	expect_value_count(__wrap_rxr_pkt_handle_send_completion, ep, rxr_ep, 5);
+	expect_value_count(__wrap_rxr_pkt_handle_send_completion, pkt_entry, &entry, 5);
+
+	rxr_ep->util_ep.progress(&rxr_ep->util_ep);
+
+	will_return_maybe(__wrap_ibv_destroy_ah, 0);
+	efa_unit_test_resource_destroy(&resource);
+}
+
+/* Verify that RDM endpoint progress works with normal receive completions */
+void test_rdm_ep_progress_recv_completion_happy()
+{
+	struct efa_cq *efa_cq;
+	struct rxr_ep *rxr_ep;
+	struct efa_resource resource = {0};
+	struct rxr_pkt_entry entry = {0};
+
+	rdm_ep_resource_construct(&resource);
+
+	rxr_ep = container_of(resource.ep, struct rxr_ep, util_ep.ep_fid);
+	efa_cq = container_of(rxr_ep->rdm_cq, struct efa_cq, util_cq.cq_fid);
+
+	efa_cq->ibv_cq_ex->wr_id = (uint64_t)&entry;
+
+	/* Read 5 entries from CQ and then ENOENT */
+	will_return(_start_poll, 0);
+	will_return_count(_next_poll, 0, 4);
+	will_return(_next_poll, ENOENT);
+	will_return(_end_poll, NULL);
+	will_return_maybe(_read_opcode, IBV_WC_RECV);
+	will_return_count(__wrap_rxr_pkt_handle_recv_completion, NULL, 5);
+	expect_value_count(__wrap_rxr_pkt_handle_recv_completion, ep, rxr_ep, 5);
+	expect_value_count(__wrap_rxr_pkt_handle_recv_completion, pkt_entry, &entry, 5);
+	expect_value_count(__wrap_rxr_pkt_handle_recv_completion, lower_ep_type, EFA_EP, 5);
+
+	rxr_ep->util_ep.progress(&rxr_ep->util_ep);
+
+	will_return_maybe(__wrap_ibv_destroy_ah, 0);
+	efa_unit_test_resource_destroy(&resource);
+}
+
+/* Verify that RDM endpoint progress works with empty CQ */
+void test_rdm_ep_progress_send_empty_cq()
+{
+	struct efa_cq *efa_cq;
+	struct rxr_ep *rxr_ep;
+	struct efa_resource resource = {0};
+	struct rxr_pkt_entry entry = {0};
+
+	rdm_ep_resource_construct(&resource);
+
+	rxr_ep = container_of(resource.ep, struct rxr_ep, util_ep.ep_fid);
+	efa_cq = container_of(rxr_ep->rdm_cq, struct efa_cq, util_cq.cq_fid);
+
+	efa_cq->ibv_cq_ex->wr_id = (uint64_t)&entry;
+
+	/* Empty CQ */
+	will_return(_start_poll, ENOENT);
+
+	rxr_ep->util_ep.progress(&rxr_ep->util_ep);
+
+	will_return_maybe(__wrap_ibv_destroy_ah, 0);
+	efa_unit_test_resource_destroy(&resource);
+}
+
+/* Verify that RDM endpoint progress works when cq poll returns an unexpected error */
+void test_rdm_ep_progress_failed_poll()
+{
+	int err;
+	struct efa_cq *efa_cq;
+	struct rxr_ep *rxr_ep;
+	struct efa_resource resource = {0};
+	struct fi_eq_attr eq_attr = {0};
+	struct rxr_pkt_entry entry = {0};
+	struct fi_ops_eq fi_ops_eq = {0};
+
+	resource.eq_attr = &eq_attr;
+	rdm_ep_resource_construct(&resource);
+
+	rxr_ep = container_of(resource.ep, struct rxr_ep, util_ep.ep_fid);
+	efa_cq = container_of(rxr_ep->rdm_cq, struct efa_cq, util_cq.cq_fid);
+
+	efa_cq->ibv_cq_ex->wr_id = (uint64_t)&entry;
+	efa_cq->ibv_cq_ex->status = 0;
+
+	/* Bind EQ to the RDM endpoint to write error to */
+	fi_ops_eq.write = &_eq_write_successful;
+	resource.eq->ops = &fi_ops_eq;
+
+	err = fi_ep_bind(&rxr_ep->util_ep.ep_fid, &resource.eq->fid, 0);
+	assert_int_equal(err, 0);
+
+	/* Read 5 entries from CQ and then EFAULT */
+	will_return(_start_poll, 0);
+	will_return_count(_next_poll, 0, 4);
+	will_return(_next_poll, EFAULT);
+	will_return(_end_poll, NULL);
+	will_return_maybe(_read_opcode, IBV_WC_SEND);
+	will_return_count(__wrap_rxr_pkt_handle_send_completion, NULL, 5);
+	expect_value_count(__wrap_rxr_pkt_handle_send_completion, ep, rxr_ep, 5);
+	expect_value_count(__wrap_rxr_pkt_handle_send_completion, pkt_entry, &entry, 5);
+	expect_value(_eq_write_successful, eq, resource.eq);
+
+	rxr_ep->util_ep.progress(&rxr_ep->util_ep);
+
+	will_return(__wrap_ibv_destroy_ah, 0);
+	efa_unit_test_resource_destroy(&resource);
+}
+
+/* Verify that RDM endpoint progress works with with bad send wc status */
+void test_rdm_ep_progress_bad_send_wc_status()
+{
+	struct efa_cq *efa_cq;
+	struct rxr_ep *rxr_ep;
+	struct efa_resource resource = {0};
+	struct rxr_pkt_entry entry = {0};
+
+	rdm_ep_resource_construct(&resource);
+
+	rxr_ep = container_of(resource.ep, struct rxr_ep, util_ep.ep_fid);
+	efa_cq = container_of(rxr_ep->rdm_cq, struct efa_cq, util_cq.cq_fid);
+
+	efa_cq->ibv_cq_ex->wr_id = (uint64_t)&entry;
+	efa_cq->ibv_cq_ex->status = 1;
+
+	/* Read 1 entries with bad wc status */
+	will_return(_start_poll, 0);
+	will_return(_end_poll, NULL);
+	will_return_maybe(_read_opcode, IBV_WC_SEND);
+	will_return(__wrap_rxr_pkt_handle_send_error, NULL);
+	expect_value(__wrap_rxr_pkt_handle_send_error, ep, rxr_ep);
+	expect_value(__wrap_rxr_pkt_handle_send_error, pkt_entry, &entry);
+	expect_any(__wrap_rxr_pkt_handle_send_error, err);
+	expect_any(__wrap_rxr_pkt_handle_send_error, prov_errno);
+
+	rxr_ep->util_ep.progress(&rxr_ep->util_ep);
+
+	will_return_maybe(__wrap_ibv_destroy_ah, 0);
+	efa_unit_test_resource_destroy(&resource);
+}
+
+/* Verify that RDM endpoint progress works with with bad receive wc status */
+void test_rdm_ep_progress_bad_recv_wc_status()
+{
+	struct efa_cq *efa_cq;
+	struct rxr_ep *rxr_ep;
+	struct efa_resource resource = {0};
+	struct rxr_pkt_entry entry = {0};
+
+	rdm_ep_resource_construct(&resource);
+
+	rxr_ep = container_of(resource.ep, struct rxr_ep, util_ep.ep_fid);
+	efa_cq = container_of(rxr_ep->rdm_cq, struct efa_cq, util_cq.cq_fid);
+
+	efa_cq->ibv_cq_ex->wr_id = (uint64_t)&entry;
+	efa_cq->ibv_cq_ex->status = 1;
+
+	/* Read 1 entries with bad wc status */
+	will_return(_start_poll, 0);
+	will_return(_end_poll, NULL);
+	will_return_maybe(_read_opcode, IBV_WC_RECV);
+	will_return(__wrap_rxr_pkt_handle_recv_error, NULL);
+	expect_value(__wrap_rxr_pkt_handle_recv_error, ep, rxr_ep);
+	expect_value(__wrap_rxr_pkt_handle_recv_error, pkt_entry, &entry);
+	expect_any(__wrap_rxr_pkt_handle_recv_error, err);
+	expect_any(__wrap_rxr_pkt_handle_recv_error, prov_errno);
+
+	rxr_ep->util_ep.progress(&rxr_ep->util_ep);
+
+	will_return_maybe(__wrap_ibv_destroy_ah, 0);
 	efa_unit_test_resource_destroy(&resource);
 }

--- a/prov/efa/test/efa_unit_test_mocks.c
+++ b/prov/efa/test/efa_unit_test_mocks.c
@@ -1,0 +1,72 @@
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "efa.h"
+
+void __real_rxr_pkt_handle_send_completion(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
+
+void __wrap_rxr_pkt_handle_send_completion(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
+{
+	check_expected(ep);
+	check_expected(pkt_entry);
+
+	if ((int)mock() == 4242) {
+		__real_rxr_pkt_handle_send_completion(ep, pkt_entry);
+	}
+}
+
+void __real_rxr_pkt_handle_recv_completion(struct rxr_ep *ep,
+										   struct rxr_pkt_entry *pkt_entry,
+										   enum rxr_lower_ep_type lower_ep_type);
+
+void __wrap_rxr_pkt_handle_recv_completion(struct rxr_ep *ep,
+										   struct rxr_pkt_entry *pkt_entry,
+										   enum rxr_lower_ep_type lower_ep_type)
+{
+	check_expected(ep);
+	check_expected(pkt_entry);
+	check_expected(lower_ep_type);
+
+	if ((int)mock() == 4242) {
+		__real_rxr_pkt_handle_recv_completion(ep, pkt_entry, lower_ep_type);
+	}
+};
+
+void __real_rxr_pkt_handle_send_error(struct rxr_ep *ep,
+			       struct rxr_pkt_entry *pkt_entry,
+			       int err, int prov_errno);
+
+void __wrap_rxr_pkt_handle_send_error(struct rxr_ep *ep,
+									  struct rxr_pkt_entry *pkt_entry,
+									  int err, int prov_errno)
+{
+	check_expected(ep);
+	check_expected(pkt_entry);
+	check_expected(err);
+	check_expected(prov_errno);
+
+	if ((int)mock() == 4242) {
+		__real_rxr_pkt_handle_send_error(ep, pkt_entry, err, prov_errno);
+	}
+}
+
+void __real_rxr_pkt_handle_recv_error(struct rxr_ep *ep,
+			       struct rxr_pkt_entry *pkt_entry,
+			       int err, int prov_errno);
+
+void __wrap_rxr_pkt_handle_recv_error(struct rxr_ep *ep,
+			       struct rxr_pkt_entry *pkt_entry,
+			       int err, int prov_errno)
+{
+	check_expected(ep);
+	check_expected(pkt_entry);
+	check_expected(err);
+	check_expected(prov_errno);
+
+	if ((int)mock() == 4242) {
+		__real_rxr_pkt_handle_recv_error(ep, pkt_entry, err, prov_errno);
+	}
+}

--- a/prov/efa/test/efa_unit_test_utils.h
+++ b/prov/efa/test/efa_unit_test_utils.h
@@ -1,0 +1,42 @@
+#include <cmocka.h>
+#include <infiniband/verbs.h>
+#include "efa.h"
+
+/* Mock functions to replace function pointers */
+static int _start_poll(struct ibv_cq_ex *ibvcqx,
+                       struct ibv_poll_cq_attr *attr) { return mock(); }
+static int _next_poll(struct ibv_cq_ex *ibvcqx) { return mock(); }
+static void _end_poll(struct ibv_cq_ex *ibvcqx) { mock(); }
+static uint32_t _read_vendor_err(struct ibv_cq_ex *current) { return 1; }
+static unsigned int _read_wc_flags(struct ibv_cq_ex *current) { return 0; }
+static uint32_t _read_qp_num(struct ibv_cq_ex *current) { return 0; }
+static uint32_t _read_byte_len(struct ibv_cq_ex *current) { return 1; }
+static uint32_t _read_src_qp(struct ibv_cq_ex *current) { return 0; }
+static uint8_t _read_sl(struct ibv_cq_ex *current) { return 0; }
+static uint32_t _read_slid(struct ibv_cq_ex *current) { return 0; }
+static __be32 _read_imm_data(struct ibv_cq_ex *current) { return 0; }
+static enum ibv_wc_opcode _read_send_code(struct ibv_cq_ex *current) { return IBV_WC_SEND; }
+static enum ibv_wc_opcode _read_opcode(struct ibv_cq_ex *current) { return mock(); }
+static void _read_entry(struct efa_wc *wc, int index, void *buf) {}
+static ssize_t _eq_write_successful(struct fid_eq *eq, uint32_t event,
+                                    const void *buf, size_t len, uint64_t flags)
+{
+    check_expected(eq);
+    return len;
+};
+
+static void efa_unit_test_ibv_cq_ex_update_func_ptr(struct ibv_cq_ex *ibv_cq_ex)
+{
+    ibv_cq_ex->start_poll = &_start_poll;
+    ibv_cq_ex->next_poll = &_next_poll;
+    ibv_cq_ex->end_poll = &_end_poll;
+    ibv_cq_ex->read_vendor_err = &_read_vendor_err;
+    ibv_cq_ex->read_wc_flags = &_read_wc_flags;
+    ibv_cq_ex->read_qp_num = &_read_qp_num;
+    ibv_cq_ex->read_byte_len = &_read_byte_len;
+    ibv_cq_ex->read_src_qp = &_read_src_qp;
+    ibv_cq_ex->read_sl = &_read_sl;
+    ibv_cq_ex->read_slid = &_read_slid;
+    ibv_cq_ex->read_imm_data = &_read_imm_data;
+    ibv_cq_ex->read_opcode = &_read_opcode;
+}

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -3,13 +3,24 @@
 int main(void)
 {
 	int ret;
+	/* Requires an EFA device to work */
 	const struct CMUnitTest efa_unit_tests[] = {
-		cmocka_unit_test(test_duplicate_efa_ah_creation),    /* Requires an EFA device to work */
-		cmocka_unit_test(test_efa_device_construct_error_handling),    /* Requires an EFA device to work */
-		cmocka_unit_test(test_rxr_ep_pkt_pool_flags), /* Requires an EFA device to work */
-		cmocka_unit_test(test_rxr_ep_pkt_pool_page_alignment), /* Requires an EFA device to work */
-		cmocka_unit_test(test_rxr_ep_dc_atomic_error_handling), /* Requires an EFA device to work */
+		cmocka_unit_test(test_duplicate_efa_ah_creation),
+		cmocka_unit_test(test_efa_device_construct_error_handling),
+		cmocka_unit_test(test_rxr_ep_pkt_pool_flags),
+		cmocka_unit_test(test_rxr_ep_pkt_pool_page_alignment),
+		cmocka_unit_test(test_rxr_ep_dc_atomic_error_handling),
+		cmocka_unit_test(test_dgram_ep_progress_happy),
+		cmocka_unit_test(test_dgram_ep_progress_with_empty_cq),
+		cmocka_unit_test(test_dgram_ep_progress_encounter_bad_wc_status),
+		cmocka_unit_test(test_rdm_ep_progress_send_completion_happy),
+		cmocka_unit_test(test_rdm_ep_progress_recv_completion_happy),
+		cmocka_unit_test(test_rdm_ep_progress_send_empty_cq),
+		cmocka_unit_test(test_rdm_ep_progress_failed_poll),
+		cmocka_unit_test(test_rdm_ep_progress_bad_send_wc_status),
+		cmocka_unit_test(test_rdm_ep_progress_bad_recv_wc_status),
 	};
+
 	cmocka_set_message_output(CM_OUTPUT_XML);
 
 	ret = cmocka_run_group_tests_name("efa unit tests", efa_unit_tests, NULL, NULL);

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -12,10 +12,15 @@
 #include "rxr.h"
 
 struct efa_resource {
-	struct fi_info* info;
-	struct fid_fabric* fabric;
-	struct fid_domain* domain;
-	struct fid_av* av;
+	struct fi_info *hints;
+	struct fi_info *info;
+	struct fid_fabric *fabric;
+	struct fid_domain *domain;
+	struct fid_ep *ep;
+	struct fi_eq_attr *eq_attr;
+	struct fid_eq *eq;
+	struct fid_av *av;
+	struct fid_cq *cq;
 };
 
 void test_duplicate_efa_ah_creation();
@@ -28,8 +33,22 @@ void test_rxr_ep_pkt_pool_page_alignment();
 
 void test_rxr_ep_dc_atomic_error_handling();
 
-int efa_unit_test_resource_construct(struct efa_resource* resource);
+int efa_unit_test_resource_construct(struct efa_resource *resource);
 
-void efa_unit_test_resource_destroy(struct efa_resource* resource);
+void efa_unit_test_resource_destroy(struct efa_resource *resource);
+
+void test_efa_cq_readerr_happy();
+void test_efa_cq_readerr_sad();
+
+void test_dgram_ep_progress_happy();
+void test_dgram_ep_progress_with_empty_cq();
+void test_dgram_ep_progress_encounter_bad_wc_status();
+
+void test_rdm_ep_progress_send_completion_happy();
+void test_rdm_ep_progress_recv_completion_happy();
+void test_rdm_ep_progress_send_empty_cq();
+void test_rdm_ep_progress_failed_poll();
+void test_rdm_ep_progress_bad_send_wc_status();
+void test_rdm_ep_progress_bad_recv_wc_status();
 
 #endif

--- a/prov/efa/test/rdma_core_mocks.c
+++ b/prov/efa/test/rdma_core_mocks.c
@@ -1,4 +1,3 @@
-
 #include <infiniband/efadv.h>
 #include <infiniband/verbs.h>
 #include <stdlib.h>
@@ -7,18 +6,6 @@
 #include <stddef.h>
 #include <setjmp.h>
 #include <cmocka.h>
-
-/* Directions For Creating New Mock Function:
- * 1. Recreate the funciton signature with __wrap_<function>(the_params), and the function
- *    to the Makefile.include prov_efa_test_efa_unit_test_LDFLAGS list
- * 2. Check all parameters with check_expected()
- *   a. This allows test code to optionally check the parameters of the mocked function
- *      with the family of expect_value() functions.
- * 3. Make sure to return a casted mock()
- *   a. This gives the test code control of the return value of the mocked function,
- *      by calling the will_return() function.  The will_return() function creates a
- *      stack for each mocked function and returns the top of the stack first.
-*/
 
 struct ibv_ah *__wrap_ibv_create_ah(struct ibv_pd *pd, struct ibv_ah_attr *attr) {
     check_expected(pd);
@@ -30,7 +17,11 @@ int __real_ibv_destroy_ah(struct ibv_ah *ibv_ah);
 
 int __wrap_ibv_destroy_ah(struct ibv_ah *ibv_ah)
 {
-	return (ibv_ah->context == NULL) ? 0 : __real_ibv_destroy_ah(ibv_ah);
+	int val = mock();
+	if (val == 4242) {
+		return __real_ibv_destroy_ah(ibv_ah);
+	}
+	return val;
 }
 
 int __wrap_efadv_query_ah(struct ibv_ah *ibvah, struct efadv_ah_attr *attr, uint32_t inlen) {


### PR DESCRIPTION
Migrate efa provider to wide completion APIs. Deprecate ibv_poll_cq
usage in favor of ibv_{start,next,end}_poll verbs.

Signed-off-by: wenduwan <wenduwdan@amazon.com>

In this change we migrate to wide completion APIs to take advantage of additional query capabilities of the extended CQ verbs. Specifically, usage of ibv_poll_cq verb is deprecated in favor of ibv_{start,next,end}_poll verbs.