### PR TITLE
[v1.15.x] hmem_neuron: change the neuron library file name.

### DIFF
--- a/src/hmem_neuron.c
+++ b/src/hmem_neuron.c
@@ -57,7 +57,7 @@ static struct neuron_ops neuron_ops;
 
 static int neuron_dl_init(void)
 {
-	neuron_handle = dlopen("libnrt.so", RTLD_NOW);
+	neuron_handle = dlopen("libnrt.so.1", RTLD_NOW);
 	if (!neuron_handle) {
 		FI_INFO(&core_prov, FI_LOG_CORE,
 			"Failed to dlopen libnrt.so\n");


### PR DESCRIPTION
Currently, libfabric tries to dlopen libnrt.so, which may not
be always on the LD_LIBRARY_PATH during runtime. Change it
to libnrt.so.1 which is in application's RPATH.

Signed-off-by: Shi Jin <sjina@amazon.com>
(cherry picked from commit 9dccd723e20534c398db854670b9eef2c2590d20)


Backport of https://github.com/ofiwg/libfabric/pull/7821