### PR TITLE
[v1.15.x] prov/shm: Fix for SAR path

### DIFF
--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -176,7 +176,7 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 	peer_smr = smr_peer_region(ep->region, id);
 
 	pthread_spin_lock(&peer_smr->lock);
-	if (!peer_smr->cmd_cnt || smr_peer_data(ep->region)[peer_id].sar_status) {
+	if (!peer_smr->cmd_cnt || smr_peer_data(ep->region)[id].sar_status) {
 		ret = -FI_EAGAIN;
 		goto unlock_region;
 	}


### PR DESCRIPTION
Fixes incorrect use of "peer_id" to "id" when checking sar_status of local
endpoint; in smr_generic_sendmsg path.

cherry-picked from commit 361f6bec4cb60d65db34c56557012fe5f917253f

Signed-off-by: Jorge Cabrera <jorge.cabrera@intel.com>
Signed-off-by: Alexia Ingerson <alexia.ingerson@intel.com>