### PR TITLE
prov/efa:  test and fix atomic tx entry leak

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -108,6 +108,7 @@ prov_efa_test_efa_unit_test_CPPFLAGS = $(efa_CPPFLAGS)
 prov_efa_test_efa_unit_test_LDADD = $(cmocka_LIBS) $(linkback)
 prov_efa_test_efa_unit_test_LDFLAGS = $(cmocka_rpath) $(efa_LDFLAGS) $(cmocka_LDFLAGS) \
 					-Wl,--wrap=ibv_create_ah \
+					-Wl,--wrap=ibv_destroy_ah \
 					-Wl,--wrap=efadv_query_ah \
 					-Wl,--wrap=efadv_query_device
 prov_efa_test_efa_unit_test_LIBS = $(efa_LIBS) $(linkback)

--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -554,7 +554,7 @@ struct efa_conn *efa_conn_alloc(struct efa_av *av, struct efa_ep_addr *raw_addr,
 		memset(context, 0, sizeof(int));
 
 	if (!efa_av_is_valid_address(raw_addr)) {
-		EFA_WARN(FI_LOG_AV, "Failed to insert bad addr");
+		EFA_WARN(FI_LOG_AV, "Failed to insert bad addr\n");
 		errno = FI_EINVAL;
 		return NULL;
 	}

--- a/prov/efa/src/rxr/rxr_atomic.c
+++ b/prov/efa/src/rxr/rxr_atomic.c
@@ -180,13 +180,17 @@ ssize_t rxr_atomic_generic_efa(struct rxr_ep *rxr_ep,
 		 * support it or not.
 		 */
 		err = rxr_pkt_trigger_handshake(rxr_ep, tx_entry->addr, peer);
-		if (OFI_UNLIKELY(err))
+		if (OFI_UNLIKELY(err)) {
+			rxr_release_tx_entry(rxr_ep, tx_entry);
 			goto out;
+		}
 
 		if (!(peer->flags & RXR_PEER_HANDSHAKE_RECEIVED)) {
+			rxr_release_tx_entry(rxr_ep, tx_entry);
 			err = -FI_EAGAIN;
 			goto out;
 		} else if (!rxr_peer_support_delivery_complete(peer)) {
+			rxr_release_tx_entry(rxr_ep, tx_entry);
 			err = -FI_EOPNOTSUPP;
 			goto out;
 		}

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -65,3 +65,78 @@ void test_rxr_ep_pkt_pool_page_alignment()
 
 	g_efa_fork_status = EFA_FORK_SUPPORT_OFF;
 }
+
+/**
+ * @brief when delivery complete atomic was used and handshake packet has not been received
+ * verify there is no tx entry leak
+ */
+void test_rxr_ep_dc_atomic_error_handling()
+{
+	struct fid_ep *ep;
+	struct rxr_ep *rxr_ep;
+	struct rdm_peer *peer;
+	struct fi_ioc ioc = {0};
+	struct fi_rma_ioc rma_ioc = {0};
+	struct fi_msg_atomic msg = {0};
+	struct efa_resource resource = {0};
+	struct efa_ep_addr raw_addr = {0};
+	struct ibv_ah ibv_ah = {0};
+	fi_addr_t peer_addr;
+	int buf[1] = {0}, err, numaddr;
+
+	err = efa_unit_test_resource_construct(&resource);
+	assert_int_equal(err, 0);
+
+	err = fi_endpoint(resource.domain, resource.info, &ep, NULL);
+	assert_int_equal(err, 0);
+
+	err = fi_ep_bind(ep, &resource.av->fid, 0);
+	assert_int_equal(err, 0);
+
+	/* create a fake peer */
+	raw_addr.raw[0] = 0xfe;
+	raw_addr.qpn = 1;
+	raw_addr.qkey = 0x1234;
+	expect_any(__wrap_ibv_create_ah, pd);
+	expect_any(__wrap_ibv_create_ah, attr);
+	will_return(__wrap_ibv_create_ah, &ibv_ah);
+	expect_any(__wrap_efadv_query_ah, ibvah);
+	expect_any(__wrap_efadv_query_ah, attr);
+	expect_any(__wrap_efadv_query_ah, inlen);
+	will_return(__wrap_efadv_query_ah, 0);
+	numaddr = fi_av_insert(resource.av, &raw_addr, 1, &peer_addr, 0, NULL);
+	assert_int_equal(numaddr, 1);
+
+	msg.addr = peer_addr;
+
+	ioc.addr = buf;
+	ioc.count = 1;
+	msg.msg_iov = &ioc;
+	msg.iov_count = 1;
+
+	msg.rma_iov = &rma_ioc;
+	msg.rma_iov_count = 1;
+	msg.datatype = FI_INT32;
+	msg.op = FI_SUM;
+
+	rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid);
+	rxr_ep->use_shm_for_tx = false;
+	/* set peer->flag to RXR_PEER_REQ_SENT will make rxr_atomic() think
+	 * a REQ packet has been sent to the peer (so no need to send again)
+	 * handshake has not been received, so we do not know whether the peer support DC
+	 */
+	peer = rxr_ep_get_peer(rxr_ep, peer_addr);
+	peer->flags = RXR_PEER_REQ_SENT;
+
+	assert_true(dlist_empty(&rxr_ep->tx_entry_list));
+	err = fi_atomicmsg(ep, &msg, FI_DELIVERY_COMPLETE);
+	/* DC has been reuquested, but ep do not know whether peer supports it, therefore
+	 * -FI_EAGAIN should be returned
+	 */
+	assert_int_equal(err, -FI_EAGAIN);
+	/* make sure there is no leaking of tx_entry */
+	assert_true(dlist_empty(&rxr_ep->tx_entry_list));
+
+	fi_close(&ep->fid);
+	efa_unit_test_resource_destroy(&resource);
+}

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -62,4 +62,6 @@ void test_rxr_ep_pkt_pool_page_alignment()
 
 	fi_close(&ep->fid);
 	efa_unit_test_resource_destroy(&resource);
+
+	g_efa_fork_status = EFA_FORK_SUPPORT_OFF;
 }

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -8,6 +8,7 @@ int main(void)
 		cmocka_unit_test(test_efa_device_construct_error_handling),    /* Requires an EFA device to work */
 		cmocka_unit_test(test_rxr_ep_pkt_pool_flags), /* Requires an EFA device to work */
 		cmocka_unit_test(test_rxr_ep_pkt_pool_page_alignment), /* Requires an EFA device to work */
+		cmocka_unit_test(test_rxr_ep_dc_atomic_error_handling), /* Requires an EFA device to work */
 	};
 	cmocka_set_message_output(CM_OUTPUT_XML);
 

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -26,6 +26,8 @@ void test_rxr_ep_pkt_pool_flags();
 
 void test_rxr_ep_pkt_pool_page_alignment();
 
+void test_rxr_ep_dc_atomic_error_handling();
+
 int efa_unit_test_resource_construct(struct efa_resource* resource);
 
 void efa_unit_test_resource_destroy(struct efa_resource* resource);

--- a/prov/efa/test/rdma_core_mocks.c
+++ b/prov/efa/test/rdma_core_mocks.c
@@ -26,6 +26,13 @@ struct ibv_ah *__wrap_ibv_create_ah(struct ibv_pd *pd, struct ibv_ah_attr *attr)
     return (struct ibv_ah*) mock();
 }
 
+int __real_ibv_destroy_ah(struct ibv_ah *ibv_ah);
+
+int __wrap_ibv_destroy_ah(struct ibv_ah *ibv_ah)
+{
+	return (ibv_ah->context == NULL) ? 0 : __real_ibv_destroy_ah(ibv_ah);
+}
+
 int __wrap_efadv_query_ah(struct ibv_ah *ibvah, struct efadv_ah_attr *attr, uint32_t inlen) {
     check_expected(ibvah);
     check_expected(attr);


### PR DESCRIPTION
Added a unit test to reproduce a memory leak in DC atomic, and included a bug fix for it.