### PR TITLE
prov/tcp: Acquire ep lock prior to flushing socket in shutdown

### DIFF
--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -355,9 +355,9 @@ static int tcpx_ep_shutdown(struct fid_ep *ep_fid, uint64_t flags)
 	struct tcpx_ep *ep;
 
 	ep = container_of(ep_fid, struct tcpx_ep, util_ep.ep_fid);
-	(void) ofi_bsock_flush(&ep->bsock);
 
 	ofi_mutex_lock(&ep->lock);
+	(void) ofi_bsock_flush(&ep->bsock);
 	tcpx_ep_disable(ep, 0, NULL, 0);
 	ofi_mutex_unlock(&ep->lock);
 


### PR DESCRIPTION
Access to the socket needs to be serialized.  In tcpx_ep_shutdown,
acquire the ep lock prior to flushing the socket to avoid potential
races calling shutdown with progress threads.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>