### PR TITLE
[v1.15.x] prov/efa: release tx_entry on error in rxr_atomic_generic_efa()

### DIFF
--- a/prov/efa/src/rxr/rxr_atomic.c
+++ b/prov/efa/src/rxr/rxr_atomic.c
@@ -181,13 +181,17 @@ ssize_t rxr_atomic_generic_efa(struct rxr_ep *rxr_ep,
 		 * support it or not.
 		 */
 		err = rxr_pkt_trigger_handshake(rxr_ep, tx_entry->addr, peer);
-		if (OFI_UNLIKELY(err))
+		if (OFI_UNLIKELY(err)) {
+			rxr_release_tx_entry(rxr_ep, tx_entry);
 			goto out;
+		}
 
 		if (!(peer->flags & RXR_PEER_HANDSHAKE_RECEIVED)) {
+			rxr_release_tx_entry(rxr_ep, tx_entry);
 			err = -FI_EAGAIN;
 			goto out;
 		} else if (!rxr_peer_support_delivery_complete(peer)) {
+			rxr_release_tx_entry(rxr_ep, tx_entry);
 			err = -FI_EOPNOTSUPP;
 			goto out;
 		}


### PR DESCRIPTION
This patch released tx_entry on the error handling path of
rxr_atomic_generic_efa();

Signed-off-by: Wei Zhang <wzam@amazon.com>