### PR TITLE
fabtests/multinode: Code cleanup and switch to DELIVERY_COMPLETE barrier

### DIFF
--- a/fabtests/functional/unexpected_msg.c
+++ b/fabtests/functional/unexpected_msg.c
@@ -190,7 +190,7 @@ static int run_test_loop(void)
 		}
 
 		if (i % 100 == 0)
-			printf("PID %d GOOD iter %d/%ld completed\n",
+			printf("PID %d GOOD iter %d/%d completed\n",
 				getpid(), i, opts.iterations);
 	}
 

--- a/fabtests/multinode/src/core.c
+++ b/fabtests/multinode/src/core.c
@@ -188,9 +188,8 @@ static int multi_setup_fabric(int argc, char **argv)
 		FT_ERR("error exchanging rma_iovs\n");
 		goto err;
 	}
-	for (i = 0; i < pm_job.num_ranks; i++) {
+	for (i = 0; i < pm_job.num_ranks; i++)
 		pm_job.multi_iovs[i].addr += (tx_size * pm_job.my_rank);
-	}
 
 	return 0;
 err:
@@ -204,14 +203,13 @@ int multi_msg_recv()
 
 	/* post receives */
 	while (!state.all_recvs_posted && state.rx_window) {
-
 		ret = pattern->next_source(&state.cur_source);
 		if (ret == -FI_ENODATA) {
 			state.all_recvs_posted = true;
 			break;
-		} else if (ret < 0) {
-			return ret;
 		}
+		if (ret < 0)
+			return ret;
 
 		offset = state.recvs_posted % opts.window_size ;
 		assert(rx_ctx_arr[offset].state == OP_DONE);
@@ -236,14 +234,13 @@ int multi_msg_send()
 	fi_addr_t dest;
 
 	while (!state.all_sends_posted && state.tx_window) {
-
 		ret = pattern->next_target(&state.cur_target);
 		if (ret == -FI_ENODATA) {
 			state.all_sends_posted = true;
 			break;
-		} else if (ret < 0) {
-			return ret;
 		}
+		if (ret < 0)
+			return ret;
 
 		offset = state.sends_posted % opts.window_size;
 		assert(tx_ctx_arr[offset].state == OP_DONE);
@@ -295,14 +292,13 @@ int multi_rma_write()
 	int ret, rc;
 
 	while (!state.all_sends_posted && state.tx_window) {
-
 		ret = pattern->next_target(&state.cur_target);
 		if (ret == -FI_ENODATA) {
 			state.all_sends_posted = true;
 			break;
-		} else if (ret < 0) {
-			return ret;
 		}
+		if (ret < 0)
+			return ret;
 
 		snprintf((char*) tx_buf + tx_size * state.cur_target, tx_size,
 		        "Hello World! from %zu to %i on the %zuth iteration, %s test",
@@ -366,8 +362,7 @@ int send_recv_barrier(int sync)
 {
 	int ret, i;
 
-	for(i = 0; i < pm_job.num_ranks; i++) {
-
+	for (i = 0; i < pm_job.num_ranks; i++) {
 		ret = ft_post_rx_buf(ep, opts.transfer_size,
 			     &barrier_rx_ctx[i],
 			     rx_buf, mr_desc, 0);
@@ -411,7 +406,6 @@ static int multi_run_test()
 	int iter;
 
 	for (iter = 0; iter < opts.iterations; iter++) {
-
 		multi_init_state();
 		while (!state.all_completions_done ||
 				!state.all_recvs_posted ||
@@ -466,7 +460,6 @@ int multinode_run_tests(int argc, char **argv)
 	if (ret)
 		return ret;
 
-
 	for (i = 0; i < NUM_TESTS && !ret; i++) {
 		printf("starting %s... ", patterns[i].name);
 		pattern = &patterns[i];
@@ -483,4 +476,3 @@ int multinode_run_tests(int argc, char **argv)
 	ft_free_res();
 	return ft_exit_code(ret);
 }
-

--- a/fabtests/multinode/src/harness.c
+++ b/fabtests/multinode/src/harness.c
@@ -146,14 +146,16 @@ static int pm_init_ranks()
 	size_t send_rank;
 
 	if (pm_job.clients) {
-		for(i = 0; i < pm_job.num_ranks-1; i++) {
+		for (i = 0; i < pm_job.num_ranks-1; i++) {
 			send_rank = i + 1;
-			ret = socket_send(pm_job.clients[i], &send_rank, sizeof(send_rank), 0);
+			ret = socket_send(pm_job.clients[i], &send_rank,
+					  sizeof(send_rank), 0);
 			if (ret < 0)
-				return ret;
+				break;
 		}
 	} else {
-		ret = socket_recv(pm_job.sock, &(pm_job.my_rank), sizeof(pm_job.my_rank), 0);
+		ret = socket_recv(pm_job.sock, &(pm_job.my_rank),
+				  sizeof(pm_job.my_rank), 0);
 	}
 
 	return ret;
@@ -181,8 +183,10 @@ static int server_connect()
 		pm_job.clients[i] = new_sock;
 		FT_DEBUG("connection established\n");
 	}
+
 	ft_close_fd(pm_job.sock);
 	return 0;
+
 err:
 	while (i--) {
 		ft_close_fd(pm_job.clients[i]);
@@ -223,15 +227,15 @@ static int pm_conn_setup()
 		opts.dst_port = opts.src_port;
 		opts.src_addr = NULL;
 		opts.src_port = 0;
-		ret = connect(pm_job.sock, (struct sockaddr *)&pm_job.oob_server_addr,
+		ret = connect(pm_job.sock,
+			      (struct sockaddr *) &pm_job.oob_server_addr,
 			      pm_job.server_addr_len);
 	}
-	if (ret) {
-		FT_ERR("OOB conn failed - %s\n", strerror(errno));
-		return ret;
-	}
 
-	return 0;
+	if (ret)
+		FT_ERR("OOB conn failed - %s\n", strerror(errno));
+
+	return ret;
 }
 
 static void pm_finalize()
@@ -243,9 +247,9 @@ static void pm_finalize()
 		return;
 	}
 
-	for (i = 0; i < pm_job.num_ranks-1; i++) {
+	for (i = 0; i < pm_job.num_ranks-1; i++)
 		ft_close_fd(pm_job.clients[i]);
-	}
+
 	free(pm_job.clients);
 }
 
@@ -332,7 +336,7 @@ int main(int argc, char **argv)
 		FT_ERR("connection setup failed\n");
 		goto err1;
 	}
-	
+
 	ret = pm_init_ranks();
 	if (ret < 0) {
 		FT_ERR("rank initialization failed\n");

--- a/fabtests/multinode/src/pattern.c
+++ b/fabtests/multinode/src/pattern.c
@@ -33,10 +33,12 @@
 #include <core.h>
 #include <shared.h>
 
+
 static int broadcast_gather_next(int *cur)
 {
 	int next;
-	if (pm_job.my_rank) 
+
+	if (pm_job.my_rank)
 		return -FI_ENODATA;
 	next = *cur + 1;
 
@@ -46,47 +48,47 @@ static int broadcast_gather_next(int *cur)
 		next = 1;
 
 	*cur = next;
-	
+
 	return 0;
 }
 
 static int broadcast_gather_current(int *cur)
 {
 	int next;
-	if (!pm_job.my_rank) 
+
+	if (!pm_job.my_rank)
 		return -FI_ENODATA;
-	
+
 	next = *cur + 1;
 
-	if (next > 0)			
+	if (next > 0)
 		return -FI_ENODATA;
 
 	*cur = next;
-	
-	return 0; 
+
+	return 0;
 }
 
 static int ring_next(int *cur)
 {
 	if ((pm_job.my_rank == 0 && pm_job.num_ranks - 1 == *cur) ||
-		(pm_job.my_rank != 0 && pm_job.my_rank - 1   == *cur))
+	    (pm_job.my_rank != 0 && pm_job.my_rank - 1   == *cur))
 		return -FI_ENODATA;
-		
+
 	if (pm_job.my_rank == 0)
 		*cur = pm_job.num_ranks - 1;
-	else 			
+	else
 		*cur = pm_job.my_rank - 1;
-	return 0; 
+	return 0;
 }
 
 static int ring_current(int *cur)
 {
-	if ((pm_job.my_rank + 1) % pm_job.num_ranks == *cur) 
+	if ((pm_job.my_rank + 1) % pm_job.num_ranks == *cur)
 		return -FI_ENODATA;
-	
+
 	*cur = (pm_job.my_rank + 1) % pm_job.num_ranks;
-	return 0; 
-	
+	return 0;
 }
 
 static int mesh_next(int *cur)


### PR DESCRIPTION
Mostly white space cleanup to multinode test.  Converted the 'barrier' implementation to use FI_DELIVERY_COMPLETE for sends, instead of unspecified completion semantics, to ensure that the sends reach the destination.

Also patch to fix a compiler warning in unexpected_msg.