### PR TITLE
core: Reserve CXI provider constants to avoid conflicts

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -215,6 +215,7 @@ enum {
 	FI_ADDR_EFA,
 	FI_ADDR_PSMX3,		/* uint64_t[4] */
 	FI_ADDR_OPX,
+	FI_ADDR_CXI,
 };
 
 #define FI_ADDR_UNSPEC		((uint64_t) -1)
@@ -331,6 +332,7 @@ enum {
 	FI_PROTO_PSMX3,
 	FI_PROTO_RXM_TCP,
 	FI_PROTO_OPX,
+	FI_PROTO_CXI,
 };
 
 enum {

--- a/src/common.c
+++ b/src/common.c
@@ -446,6 +446,10 @@ sa_sin6:
 	case FI_ADDR_STR:
 		size = snprintf(buf, *len, "%s", (const char *) addr);
 		break;
+	case FI_ADDR_CXI:
+		size = snprintf(buf, *len, "fi_addr_cxi://0x%08" PRIx32,
+				*(uint32_t *)addr);
+		break;
 	default:
 		return NULL;
 	}

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -124,6 +124,7 @@ static void ofi_tostr_addr_format(char *buf, size_t len, uint32_t addr_format)
 	CASEENUMSTRN(FI_ADDR_EFA, len);
 	CASEENUMSTRN(FI_ADDR_PSMX3, len);
 	CASEENUMSTRN(FI_ADDR_OPX, len);
+	CASEENUMSTRN(FI_ADDR_CXI, len);
 	default:
 		if (addr_format & FI_PROV_SPECIFIC)
 			ofi_strncatf(buf, len, "Provider specific");
@@ -273,6 +274,7 @@ static void ofi_tostr_protocol(char *buf, size_t len, uint32_t protocol)
 	CASEENUMSTRN(FI_PROTO_PSMX3, len);
 	CASEENUMSTRN(FI_PROTO_RXM_TCP, len);
 	CASEENUMSTRN(FI_PROTO_OPX, len);
+	CASEENUMSTRN(FI_PROTO_CXI, len);
 	default:
 		if (protocol & FI_PROV_SPECIFIC)
 			ofi_strncatf(buf, len, "Provider specific");


### PR DESCRIPTION
Reserve address and protocol constants for the CXI provider
to avoid conflicts in applications that may be using a
pre-upstream release of the provider with other provider
definitions.

Signed-off-by: Steve Welch <welch@hpe.com>