### PR TITLE
fabtests/efa: add fork-related test

### DIFF
--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -152,7 +152,8 @@ nobase_dist_config_DATA = \
 	pytest/efa/test_multi_recv.py \
 	pytest/efa/test_rnr.py \
 	pytest/efa/test_efa_info.py \
-	pytest/efa/test_runt.py
+	pytest/efa/test_runt.py \
+	pytest/efa/test_fork_support.py
 
 noinst_LTLIBRARIES = libfabtests.la
 

--- a/fabtests/pytest/efa/test_fork_support.py
+++ b/fabtests/pytest/efa/test_fork_support.py
@@ -1,0 +1,21 @@
+import pytest
+
+
+@pytest.mark.functional
+@pytest.mark.parametrize("environment_variable", ["FI_EFA_FORK_SAFE", "RDMAV_FORK_SAFE"])
+def test_fork_support(cmdline_args, completion_type, environment_variable):
+    from common import ClientServerTest
+    import copy
+    cmdline_args_copy = copy.copy(cmdline_args)
+
+    if cmdline_args_copy.environments:
+        cmdline_args_copy.environments += " "
+    else:
+        cmdline_args_copy.environments = ""
+
+    cmdline_args_copy.environments += "{}=1".format(environment_variable)
+    test = ClientServerTest(cmdline_args_copy, "fi_rdm_tagged_bw -K",
+                            completion_type=completion_type,
+                            datacheck_type="with_datacheck")
+    test.run()
+

--- a/fabtests/pytest/efa/test_runt.py
+++ b/fabtests/pytest/efa/test_runt.py
@@ -18,7 +18,7 @@ def test_runt_read_functional(cmdline_args):
     else:
         cmdline_args_copy.environments = ""
 
-    cmdline_args_copy.environments = "FI_EFA_USE_DEVICE_RDMA_READ=1 FI_EFA_RUNT_SIZE=65536 FI_HMEM_CUDA_USE_GDRCOPY=1"
+    cmdline_args_copy.environments += "FI_EFA_USE_DEVICE_RDMA_READ=1 FI_EFA_RUNT_SIZE=65536 FI_HMEM_CUDA_USE_GDRCOPY=1"
 
     # currently, runting read is enabled only if gdrcopy is available.
     # thus skip the test if gdrcopy is not available


### PR DESCRIPTION
Run fi_rdm_tagged_bw with "-K" with environment variables
` FI_EFA_FORK_SAFE=1` and `RDMAV_FORK_SAFE=1`