### PR TITLE
contrib/intel/jenkins: Refactor tests.py to run mpis without shell scripts

### DIFF
--- a/contrib/intel/jenkins/build.py
+++ b/contrib/intel/jenkins/build.py
@@ -18,7 +18,7 @@ def build_libfabric(libfab_install_path, mode):
     if (os.path.exists(libfab_install_path) != True):
         os.makedirs(libfab_install_path)
 
-    config_cmd = ['./configure', '--prefix={}'.format(libfab_install_path)]
+    config_cmd = ['./configure', f'--prefix={libfab_install_path}']
     enable_prov_val = 'yes'
 
     if (mode == 'dbg'):
@@ -27,9 +27,9 @@ def build_libfabric(libfab_install_path, mode):
         enable_prov_val='dl'
 
     for prov in common.enabled_prov_list:
-        config_cmd.append('--enable-{}={}'.format(prov, enable_prov_val))
+        config_cmd.append(f'--enable-{prov}={enable_prov_val}')
     for prov in common.disabled_prov_list:
-         config_cmd.append('--enable-{}=no'.format(prov))
+         config_cmd.append(f'--enable-{prov}=no')
 
     config_cmd.append('--disable-opx') # we do not test opx in intel jenkins ci
     config_cmd.append('--disable-efa') # we do not test efa in intel jenkins ci
@@ -45,14 +45,14 @@ def build_libfabric(libfab_install_path, mode):
 
 def build_fabtests(libfab_install_path, mode):
 
-    os.chdir('{}/fabtests'.format(workspace))
+    os.chdir(f'{workspace}/fabtests')
     if (mode == 'dbg'):
-        config_cmd = ['./configure', '--enable-debug', '--prefix={}' \
-                      .format(libfab_install_path),'--with-libfabric={}' \
-                      .format(libfab_install_path)]
+        config_cmd = ['./configure', '--enable-debug',
+                      f'--prefix={libfab_install_path}',
+                      f'--with-libfabric={libfab_install_path}']
     else:
-        config_cmd = ['./configure', '--prefix={}'.format(libfab_install_path),
-                      '--with-libfabric={}'.format(libfab_install_path)]
+        config_cmd = ['./configure', f'--prefix={libfab_install_path}',
+                      f'--with-libfabric={libfab_install_path}']
 
     common.run_command(['./autogen.sh'])
     common.run_command(config_cmd)
@@ -62,7 +62,7 @@ def build_fabtests(libfab_install_path, mode):
 
 def copy_build_dir(install_path):
     shutil.copytree(ci_site_config.build_dir,
-                    '{}/ci_middlewares'.format(install_path))
+                    f'{install_path}/ci_middlewares')
 
 if __name__ == "__main__":
 #read Jenkins environment variables
@@ -87,12 +87,8 @@ if __name__ == "__main__":
     else:
         ofi_build_mode = 'reg'
 
-    ci_middlewares_install_path = '{installdir}/{jbname}/{bno}' \
-                                .format(installdir=ci_site_config.install_dir, \
-                                jbname=jobname, bno=buildno)
-    install_path = '{installdir}/{jbname}/{bno}/{bmode}' \
-                   .format(installdir=ci_site_config.install_dir,
-                   jbname=jobname, bno=buildno,bmode=ofi_build_mode)
+    ci_middlewares_install_path = f'{ci_site_config.install_dir}/{jobname}/{buildno}'
+    install_path = f'{ci_site_config.install_dir}/{jobname}/{buildno}/{ofi_build_mode}'
 
     p = re.compile('mpi*')
 

--- a/contrib/intel/jenkins/run.py
+++ b/contrib/intel/jenkins/run.py
@@ -121,7 +121,7 @@ def mpich_test_suite(core, hosts, mpi, mode, util):
 
 def osu_benchmark(core, hosts, mpi, mode, util):
 
-    osu_test = tests.MpiTestOSU(jobname=jbname, buildno=bno,
+    osu_test = tests.OSUtests(jobname=jbname, buildno=bno,
                                 testname='osu-benchmarks', core_prov=core,
                                 fabric=fab, mpitype=mpi, hosts=hosts,
                                 ofi_build_mode=mode, util_prov=util)

--- a/contrib/intel/jenkins/run.py
+++ b/contrib/intel/jenkins/run.py
@@ -87,19 +87,19 @@ def ze_fabtests(core, hosts, mode, util):
 
 def intel_mpi_benchmark(core, hosts, mpi, mode, group, util):
 
-    imb_test = tests.MpiTestIMB(jobname=jbname,buildno=bno,
-                                testname='IntelMPIbenchmark', core_prov=core,
-                                fabric=fab, hosts=hosts, mpitype=mpi,
-                                ofi_build_mode=mode, test_group=group,
-                                util_prov=util)
+    imb = tests.IMBtests(jobname=jbname, buildno=bno,
+                         testname='IntelMPIbenchmark', core_prov=core,
+                         fabric=fab, hosts=hosts, mpitype=mpi,
+                         ofi_build_mode=mode, test_group=group,
+                         util_prov=util)
 
     print("-------------------------------------------------------------------")
-    if (imb_test.execute_condn == True):
+    if (imb.execute_condn == True):
         print("Running IMB-tests for {}-{}-{}-{}".format(core, util, fab, mpi))
-        imb_test.execute_cmd()
+        imb.execute_cmd()
     else:
         print("Skipping {} {} as execute condition fails" \
-              .format(mpi.upper(), imb_test.testname))
+              .format(mpi.upper(), impi.testname))
     print("-------------------------------------------------------------------")
 
 def mpich_test_suite(core, hosts, mpi, mode, util):

--- a/contrib/intel/jenkins/run.py
+++ b/contrib/intel/jenkins/run.py
@@ -22,10 +22,10 @@ def fi_info_test(core, hosts, mode, util):
                                     testname='fi_info', core_prov=core,
                                     fabric=fab, hosts=hosts,
                                     ofi_build_mode=mode, util_prov=util)
-    print("-------------------------------------------------------------------")
-    print("Running fi_info test for {}-{}-{}".format(core, util, fab))
+    print('-------------------------------------------------------------------')
+    print(f"Running fi_info test for {core}-{util}-{fab}")
     fi_info_test.execute_cmd()
-    print("-------------------------------------------------------------------")
+    print('-------------------------------------------------------------------')
 
 def fabtests(core, hosts, mode, util):
 
@@ -34,14 +34,13 @@ def fabtests(core, hosts, mode, util):
                                fabric=fab, hosts=hosts, ofi_build_mode=mode,
                                util_prov=util)
 
-    print("-------------------------------------------------------------------")
+    print('-------------------------------------------------------------------')
     if (runfabtest.execute_condn):
-        print("Running Fabtests for {}-{}-{}".format(core, util, fab))
+        print(f"Running Fabtests for {core}-{util}-{fab}")
         runfabtest.execute_cmd()
     else:
-        print("Skipping {} {} as execute condition fails" \
-              .format(core, runfabtest.testname))
-    print("-------------------------------------------------------------------")
+        print(f"Skipping {core} {runfabtest.testname} as execute condition fails")
+    print('-------------------------------------------------------------------')
 
 def shmemtest(core, hosts, mode, util):
 
@@ -50,25 +49,24 @@ def shmemtest(core, hosts, mode, util):
                                    fabric=fab, hosts=hosts,
                                    ofi_build_mode=mode, util_prov=util)
 
-    print("-------------------------------------------------------------------")
+    print('-------------------------------------------------------------------')
     if (runshmemtest.execute_condn):
 #        skip unit because it is failing shmem_team_split_2d
-#        print("running shmem unit test for {}-{}-{}".format(core, util, fab))
+#        print(f"Running shmem unit test for {core}-{util}-{fab}")
 #        runshmemtest.execute_cmd("unit")
-        print("Running shmem PRK test for {}-{}-{}".format(core, util, fab))
+        print(f"Running shmem PRK test for {core}-{util}-{fab}")
         runshmemtest.execute_cmd("prk")
 
-        print("---------------------------------------------------------------")
-        print("Running shmem ISx test for {}-{}-{}".format(core, util, fab))
+        print('--------------------------------------------------------------')
+        print(f"Running shmem ISx test for {core}-{util}-{fab}")
         runshmemtest.execute_cmd("isx")
 
-        print("---------------------------------------------------------------")
-        print("Running shmem uh test for {}-{}-{}".format(core, util, fab))
+        print('---------------------------------------------------------------')
+        print(f"Running shmem uh test for {core}-{util}-{fab}")
         runshmemtest.execute_cmd("uh")
     else:
-        print("Skipping {} {} as execute condition fails"\
-              .format(core, runshmemtest.testname))
-    print("-------------------------------------------------------------------")
+        print(f"Skipping {core} {runshmemtest.testname} as execute condition fails")
+    print('-------------------------------------------------------------------')
 
 def ze_fabtests(core, hosts, mode, util):
     runzefabtests = tests.ZeFabtests(jobname=jbname,buildno=bno,
@@ -76,14 +74,13 @@ def ze_fabtests(core, hosts, mode, util):
                                      fabric=fab, hosts=hosts,
                                      ofi_build_mode=mode, util_prov=util)
 
-    print("-------------------------------------------------------------------")
+    print('-------------------------------------------------------------------')
     if (runzefabtests.execute_condn):
-        print("Running ze tests for {}-{}-{}".format(core, util, fab))
+        print(f"Running ze tests for {core}-{util}-{fab}")
         runzefabtests.execute_cmd()
     else:
-        print("Skipping {} {} as execute condition fails"\
-              .format(core, runzefabtests.testname))
-    print("-------------------------------------------------------------------")
+        print(f"Skipping {core} {runzefabtests.testname} as execute condition fails")
+    print('-------------------------------------------------------------------')
 
 def intel_mpi_benchmark(core, hosts, mpi, mode, group, util):
 
@@ -93,14 +90,13 @@ def intel_mpi_benchmark(core, hosts, mpi, mode, group, util):
                          ofi_build_mode=mode, test_group=group,
                          util_prov=util)
 
-    print("-------------------------------------------------------------------")
+    print('-------------------------------------------------------------------')
     if (imb.execute_condn == True):
-        print("Running IMB-tests for {}-{}-{}-{}".format(core, util, fab, mpi))
+        print(f"Running IMB-tests for {core}-{util}-{fab}-{mpi}")
         imb.execute_cmd()
     else:
-        print("Skipping {} {} as execute condition fails" \
-              .format(mpi.upper(), impi.testname))
-    print("-------------------------------------------------------------------")
+        print(f"Skipping {mpi.upper} {imb.testname} as execute condition fails")
+    print('-------------------------------------------------------------------')
 
 def mpich_test_suite(core, hosts, mpi, mode, util):
 
@@ -109,15 +105,13 @@ def mpich_test_suite(core, hosts, mpi, mode, util):
                                        fabric=fab, mpitype=mpi, hosts=hosts,
                                        ofi_build_mode=mode, util_prov=util)
 
-    print("-------------------------------------------------------------------")
+    print('-------------------------------------------------------------------')
     if (mpich_tests.execute_condn == True):
-        print("Running mpichtestsuite: Spawn Tests " \
-              "for {}-{}-{}-{}".format(core, util, fab, mpi))
+        print(f"Running mpichtestsuite: Spawn Tests for {core}-{util}-{fab}-{mpi}")
         mpich_tests.execute_cmd("spawn")
     else:
-        print("Skipping {} {} as execute condition fails" \
-              .format(mpi.upper(), mpich_tests.testname))
-    print("-------------------------------------------------------------------")
+        print(f"Skipping {mpi.upper()} {mpich_tests.testname} as exec condn fails")
+    print('-------------------------------------------------------------------')
 
 def osu_benchmark(core, hosts, mpi, mode, util):
 
@@ -126,14 +120,13 @@ def osu_benchmark(core, hosts, mpi, mode, util):
                                 fabric=fab, mpitype=mpi, hosts=hosts,
                                 ofi_build_mode=mode, util_prov=util)
 
-    print("-------------------------------------------------------------------")
+    print('-------------------------------------------------------------------')
     if (osu_test.execute_condn == True):
-        print("Running OSU-Test for {}-{}-{}-{}".format(core, util, fab, mpi))
+        print(f"Running OSU-Test for {core}-{util}-{fab}-{mpi}")
         osu_test.execute_cmd()
     else:
-        print("Skipping {} {} as execute condition fails" \
-              .format(mpi.upper(), osu_test.testname))
-    print("-------------------------------------------------------------------")
+        print(f"Skipping {mpi.upper()} {osu_test.testname} as exec condn fails")
+    print('-------------------------------------------------------------------')
 
 def oneccltest(core, hosts, mode, util):
 
@@ -142,20 +135,17 @@ def oneccltest(core, hosts, mode, util):
                                       fabric=fab, hosts=hosts,
                                       ofi_build_mode=mode, util_prov=util)
 
-    print("-------------------------------------------------------------------")
+    print('-------------------------------------------------------------------')
     if (runoneccltest.execute_condn):
-        print("Running oneCCL examples test for {}-{}-{}" \
-              .format(core, util, fab))
+        print(f"Running oneCCL examples test for {core}-{util}-{fab}")
         runoneccltest.execute_cmd("examples")
 
-        print("---------------------------------------------------------------")
-        print("Running oneCCL functional test for {}-{}-{}" \
-              .format(core, util, fab))
+        print('---------------------------------------------------------------')
+        print(f"Running oneCCL functional test for {core}-{util}-{fab}")
         runoneccltest.execute_cmd("functional")
     else:
-        print("Skipping {} as execute condition fails" \
-              .format(runoneccltest.testname))
-    print("-------------------------------------------------------------------")
+        print(f"Skipping {runoneccltest.testname} as execute condition fails")
+    print('-------------------------------------------------------------------')
 
 def oneccltestgpu(core, hosts, mode, util):
 
@@ -164,20 +154,17 @@ def oneccltestgpu(core, hosts, mode, util):
                                          fabric=fab, hosts=hosts,
                                          ofi_build_mode=mode, util_prov=util)
 
-    print("-------------------------------------------------------------------")
+    print('-------------------------------------------------------------------')
     if (runoneccltestgpu.execute_condn):
-        print("Running oneCCL GPU examples test for {}-{}-{}" \
-              .format(core, util, fab))
+        print(f"Running oneCCL GPU examples test for {core}-{util}-{fab}")
         runoneccltestgpu.execute_cmd('examples')
 
-        print("---------------------------------------------------------------")
-        print("Running oneCCL GPU functional test for {}-{}-{}" \
-              .format(core, util, fab))
+        print('---------------------------------------------------------------')
+        print(f"Running oneCCL GPU functional test for {core}-{util}-{fab}")
         runoneccltestgpu.execute_cmd('functional')
     else:
-        print("Skipping {} as execute condition fails" \
-              .format(runoneccltestgpu.testname))
-    print("-------------------------------------------------------------------")
+        print(f"Skipping {runoneccltestgpu.testname} as execute condition fails")
+    print('-------------------------------------------------------------------')
 
 if __name__ == "__main__":
     pass


### PR DESCRIPTION
Mpi's included - [ompi, mpich, impi]
Integrate run_impi.sh into python
Integrate run_mpich.sh into python
Integrate ompi the same way that impi, and mpich are integrated

Change imb, osu, and mpichtestsuite classes to use new mpi classes
Refactor common code into the super class
Change string notation to use newer "f string" notation which is cleaner than the old ".format()" notation