### PR TITLE
prov/util + most: specify domain lock during initialization

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -531,6 +531,7 @@ int ofi_check_bind_cq_flags(struct util_ep *ep, struct util_cq *cq,
 void ofi_cq_progress(struct util_cq *cq);
 int ofi_cq_cleanup(struct util_cq *cq);
 int ofi_cq_control(struct fid *fid, int command, void *arg);
+
 ssize_t ofi_cq_read(struct fid_cq *cq_fid, void *buf, size_t count);
 ssize_t ofi_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 		fi_addr_t *src_addr);
@@ -541,6 +542,8 @@ ssize_t ofi_cq_sread(struct fid_cq *cq_fid, void *buf, size_t count,
 ssize_t ofi_cq_sreadfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 		fi_addr_t *src_addr, const void *cond, int timeout);
 int ofi_cq_signal(struct fid_cq *cq_fid);
+const char *ofi_cq_strerror(struct fid_cq *cq, int prov_errno,
+			    const void *err_data, char *buf, size_t len);
 
 int ofi_cq_write_overflow(struct util_cq *cq, void *context, uint64_t flags,
 			  size_t len, void *buf, uint64_t data, uint64_t tag,

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -89,12 +89,6 @@ extern "C" {
 /* Memory registration should not be cached */
 #define OFI_MR_NOCACHE		BIT_ULL(60)
 
-/* Provider domain flags
- * SPINLOCK: Use spinlocks for domain and CQ objects.
- *           EP is not included (not needed yet)
- */
-#define OFI_DOMAIN_SPINLOCK	BIT_ULL(61)
-
 #define OFI_INFO_FIELD(provider, prov_attr, user_attr, prov_str, user_str, type) \
 	do {									\
 		FI_INFO(provider, FI_LOG_CORE, prov_str ": %s\n",		\
@@ -221,7 +215,8 @@ struct util_domain {
 };
 
 int ofi_domain_init(struct fid_fabric *fabric_fid, const struct fi_info *info,
-		     struct util_domain *domain, void *context, uint64_t flags);
+		    struct util_domain *domain, void *context,
+		    enum ofi_lock_type lock_type);
 int ofi_domain_bind(struct fid *fid, struct fid *bfid, uint64_t flags);
 int ofi_domain_close(struct util_domain *domain);
 

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -165,7 +165,7 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 					  util_fabric.fabric_fid);
 
 	err = ofi_domain_init(fabric_fid, info, &efa_domain->util_domain,
-			      context, 0);
+			      context, OFI_LOCK_MUTEX);
 	if (err) {
 		ret = err;
 		goto err_free;

--- a/prov/mrail/src/mrail_domain.c
+++ b/prov/mrail/src/mrail_domain.c
@@ -374,7 +374,8 @@ int mrail_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	if (!mrail_domain)
 		return -FI_ENOMEM;
 
-	ret = ofi_domain_init(fabric, info, &mrail_domain->util_domain, context, 0);
+	ret = ofi_domain_init(fabric, info, &mrail_domain->util_domain, context,
+			      OFI_LOCK_MUTEX);
 	if (ret) {
 		free(mrail_domain);
 		return ret;

--- a/prov/psm/src/psmx_domain.c
+++ b/prov/psm/src/psmx_domain.c
@@ -385,7 +385,8 @@ int psmx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		goto err_out;
 	}
 
-	err = ofi_domain_init(fabric, info, &domain_priv->util_domain, context, 0);
+	err = ofi_domain_init(fabric, info, &domain_priv->util_domain, context,
+			      OFI_LOCK_MUTEX);
 	if (err)
 		goto err_out_free_domain;
 

--- a/prov/psm2/src/psmx2_domain.c
+++ b/prov/psm2/src/psmx2_domain.c
@@ -385,7 +385,8 @@ int psmx2_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		       sizeof(psm2_uuid_t));
 	}
 
-	err = ofi_domain_init(fabric, info, &domain_priv->util_domain, context, 0);
+	err = ofi_domain_init(fabric, info, &domain_priv->util_domain, context,
+			      OFI_LOCK_MUTEX);
 	if (err)
 		goto err_out_free_domain;
 

--- a/prov/psm3/src/psmx3_domain.c
+++ b/prov/psm3/src/psmx3_domain.c
@@ -315,7 +315,8 @@ int psmx3_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		goto err_out;
 	}
 
-	err = ofi_domain_init(fabric, info, &domain_priv->util_domain, context, 0);
+	err = ofi_domain_init(fabric, info, &domain_priv->util_domain, context,
+			      OFI_LOCK_MUTEX);
 	if (err)
 		goto err_out_free_domain;
 

--- a/prov/rstream/src/rstream_domain.c
+++ b/prov/rstream/src/rstream_domain.c
@@ -108,7 +108,7 @@ int rstream_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		goto err1;
 
 	ret = ofi_domain_init(fabric, info, &rstream_domain->util_domain,
-			      context, 0);
+			      context, OFI_LOCK_MUTEX);
 	if (ret)
 		goto err1;
 

--- a/prov/rxd/src/rxd_domain.c
+++ b/prov/rxd/src/rxd_domain.c
@@ -137,7 +137,8 @@ int rxd_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	rxd_domain->max_seg_sz = rxd_domain->max_mtu_sz - sizeof(struct rxd_data_pkt) -
 				 dg_info->ep_attr->msg_prefix_size;
 
-	ret = ofi_domain_init(fabric, info, &rxd_domain->util_domain, context, 0);
+	ret = ofi_domain_init(fabric, info, &rxd_domain->util_domain, context,
+			      OFI_LOCK_MUTEX);
 	if (ret) {
 		goto err3;
 	}

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -735,7 +735,8 @@ int rxm_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	if (ret)
 		goto err2;
 
-	ret = ofi_domain_init(fabric, info, &rxm_domain->util_domain, context, 0);
+	ret = ofi_domain_init(fabric, info, &rxm_domain->util_domain, context,
+			      OFI_LOCK_MUTEX);
 	if (ret) {
 		goto err3;
 	}

--- a/prov/shm/src/smr_domain.c
+++ b/prov/shm/src/smr_domain.c
@@ -94,7 +94,7 @@ int smr_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		return -FI_ENOMEM;
 
 	ret = ofi_domain_init(fabric, info, &smr_domain->util_domain, context,
-			      OFI_DOMAIN_SPINLOCK);
+			      OFI_LOCK_SPINLOCK);
 	if (ret) {
 		free(smr_domain);
 		return ret;

--- a/prov/tcp/src/tcpx_domain.c
+++ b/prov/tcp/src/tcpx_domain.c
@@ -120,7 +120,8 @@ int tcpx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	if (!domain)
 		return -FI_ENOMEM;
 
-	ret = ofi_domain_init(fabric, info, &domain->util_domain, context, 0);
+	ret = ofi_domain_init(fabric, info, &domain->util_domain, context,
+			      OFI_LOCK_MUTEX);
 	if (ret)
 		goto err;
 

--- a/prov/udp/src/udpx_domain.c
+++ b/prov/udp/src/udpx_domain.c
@@ -91,7 +91,8 @@ int udpx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	if (!util_domain)
 		return -FI_ENOMEM;
 
-	ret = ofi_domain_init(fabric, info, util_domain, context, 0);
+	ret = ofi_domain_init(fabric, info, util_domain, context,
+			      OFI_LOCK_MUTEX);
 	if (ret) {
 		free(util_domain);
 		return ret;

--- a/prov/util/src/util_domain.c
+++ b/prov/util/src/util_domain.c
@@ -98,16 +98,14 @@ static struct fi_ops_mr util_domain_mr_ops = {
 	.regattr = fi_no_mr_regattr,
 };
 
-static int util_domain_init(struct util_domain *domain,
-			    const struct fi_info *info, uint64_t flags)
+static int
+util_domain_init(struct util_domain *domain, const struct fi_info *info,
+		 enum ofi_lock_type lock_type)
 {
 	int ret;
 
 	ofi_atomic_initialize32(&domain->ref, 0);
-	if (flags & OFI_DOMAIN_SPINLOCK)
-		ret = ofi_genlock_init(&domain->lock, OFI_LOCK_SPINLOCK);
-	else
-		ret = ofi_genlock_init(&domain->lock, OFI_LOCK_MUTEX);
+	ret = ofi_genlock_init(&domain->lock, lock_type);
 	if (ret)
 		return ret;
 
@@ -127,7 +125,8 @@ static int util_domain_init(struct util_domain *domain,
 }
 
 int ofi_domain_init(struct fid_fabric *fabric_fid, const struct fi_info *info,
-		   struct util_domain *domain, void *context, uint64_t flags)
+		    struct util_domain *domain, void *context,
+		    enum ofi_lock_type lock_type)
 {
 	struct util_fabric *fabric;
 	int ret;
@@ -135,7 +134,7 @@ int ofi_domain_init(struct fid_fabric *fabric_fid, const struct fi_info *info,
 	fabric = container_of(fabric_fid, struct util_fabric, fabric_fid);
 	domain->fabric = fabric;
 	domain->prov = fabric->prov;
-	ret = util_domain_init(domain, info, flags);
+	ret = util_domain_init(domain, info, lock_type);
 	if (ret)
 		return ret;
 

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -336,7 +336,8 @@ vrb_domain(struct fid_fabric *fabric, struct fi_info *info,
 	if (!_domain)
 		return -FI_ENOMEM;
 
-	ret = ofi_domain_init(fabric, info, &_domain->util_domain, context, 0);
+	ret = ofi_domain_init(fabric, info, &_domain->util_domain, context,
+			      OFI_LOCK_MUTEX);
 	if (ret)
 		goto err1;
 

--- a/prov/xnet/src/xnet.h
+++ b/prov/xnet/src/xnet.h
@@ -284,6 +284,7 @@ void xnet_close_progress(struct xnet_progress *progress);
 int xnet_start_progress(struct xnet_progress *progress);
 void xnet_stop_progress(struct xnet_progress *progress);
 
+void xnet_progress(struct xnet_progress *progress, bool internal);
 void xnet_run_progress(struct xnet_progress *progress, bool internal);
 void xnet_run_conn(struct xnet_conn_handle *conn, bool pin, bool pout, bool perr);
 void xnet_handle_events(struct xnet_progress *progress);

--- a/prov/xnet/src/xnet_attr.c
+++ b/prov/xnet/src/xnet_attr.c
@@ -39,6 +39,7 @@
 #define XNET_TX_CAPS	 (FI_SEND | FI_WRITE | FI_READ)
 #define XNET_RX_CAPS	 (FI_RECV | FI_REMOTE_READ | 			\
 			  FI_REMOTE_WRITE | FI_RMA_EVENT)
+#define XNET_SRX_CAPS	 (XNET_RX_CAPS | FI_DIRECTED_RECV | FI_SOURCE)
 
 
 #define XNET_MSG_ORDER (OFI_ORDER_RAR_SET | OFI_ORDER_RAW_SET | FI_ORDER_RAS | \
@@ -95,7 +96,7 @@ static struct fi_tx_attr xnet_tx_srx_attr = {
 };
 
 static struct fi_rx_attr xnet_rx_srx_attr = {
-	.caps = XNET_EP_SRX_CAPS | XNET_RX_CAPS,
+	.caps = XNET_EP_SRX_CAPS | XNET_SRX_CAPS,
 	.op_flags = XNET_RX_OP_FLAGS,
 	.comp_order = FI_ORDER_STRICT,
 	.msg_order = XNET_MSG_ORDER,
@@ -176,7 +177,7 @@ static struct fi_fabric_attr xnet_fabric_attr = {
 };
 
 struct fi_info xnet_rdm_info = {
-	.caps = XNET_DOMAIN_CAPS | XNET_EP_SRX_CAPS | XNET_TX_CAPS | XNET_RX_CAPS,
+	.caps = XNET_DOMAIN_CAPS | XNET_EP_SRX_CAPS | XNET_TX_CAPS | XNET_SRX_CAPS,
 	.addr_format = FI_SOCKADDR,
 	.tx_attr = &xnet_tx_srx_attr,
 	.rx_attr = &xnet_rx_srx_attr,
@@ -187,7 +188,7 @@ struct fi_info xnet_rdm_info = {
 
 struct fi_info xnet_srx_info = {
 	.next = &xnet_rdm_info,
-	.caps = XNET_DOMAIN_CAPS | XNET_EP_SRX_CAPS | XNET_TX_CAPS | XNET_RX_CAPS,
+	.caps = XNET_DOMAIN_CAPS | XNET_EP_SRX_CAPS | XNET_TX_CAPS | XNET_SRX_CAPS,
 	.addr_format = FI_SOCKADDR,
 	.tx_attr = &xnet_tx_srx_attr,
 	.rx_attr = &xnet_rx_srx_attr,

--- a/prov/xnet/src/xnet_domain.c
+++ b/prov/xnet/src/xnet_domain.c
@@ -120,7 +120,8 @@ int xnet_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 	if (!domain)
 		return -FI_ENOMEM;
 
-	ret = ofi_domain_init(fabric_fid, info, &domain->util_domain, context, 0);
+	ret = ofi_domain_init(fabric_fid, info, &domain->util_domain, context,
+			      OFI_LOCK_MUTEX);
 	if (ret)
 		goto free;
 


### PR DESCRIPTION
Updates the util code + most providers to specify the desired type of domain lock as part of init.  This replaces the flags parameter to init.  Update the net provider to use the progress lock in place of the cq and domain locks (latter is for memory registration).  This change results in minor changes to util/cq.