### PR TITLE
prov/efa: recover unknown peer AH with raw address from efadv

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2020 Amazon.com, Inc. or its affiliates. All rights reserved.
+# Copyright (c) 2018-2022 Amazon.com, Inc. or its affiliates. All rights reserved.
 #
 # This software is available to you under a choice of one of two
 # licenses.  You may choose to be licensed under the terms of the GNU

--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2022 Amazon.com, Inc. or its affiliates. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -243,7 +243,7 @@ struct efa_av {
 	enum fi_av_type		type;
 	/* cur_reverse_av is a map from (ahn + qpn) to current (latest) efa_conn.
 	 * prv_reverse_av is a map from (ahn + qpn + connid) to all previous efa_conns.
-	 * cur_revsere_av is faster to search because its key's size is smaller
+	 * cur_reverse_av is faster to search because its key size is smaller
 	 */
 	struct efa_cur_reverse_av *cur_reverse_av;
 	struct efa_prv_reverse_av *prv_reverse_av;

--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016, Cisco Systems, Inc. All rights reserved.
  * Copyright (c) 2013-2015 Intel Corporation, Inc.  All rights reserved.
- * Copyright (c) 2017-2020 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright (c) 2017-2022 Amazon.com, Inc. or its affiliates. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -240,6 +240,7 @@ fi_addr_t efa_av_reverse_lookup_rdm(struct efa_av *av, uint16_t ahn, uint16_t qp
 	memset(&cur_key, 0, sizeof(cur_key));
 	cur_key.ahn = ahn;
 	cur_key.qpn = qpn;
+
 	HASH_FIND(hh, av->cur_reverse_av, &cur_key, sizeof(cur_key), cur_entry);
 
 	if (OFI_UNLIKELY(!cur_entry))
@@ -675,7 +676,7 @@ void efa_conn_release(struct efa_av *av, struct efa_conn *conn)
  *
  * @param[in]	av	address vector
  * @param[in]	addr	raw address, in the format of gid:qpn:qkey
- * @param[out]	fi_addr pointer the output fi address. This addres is used by fi_send
+ * @param[out]	fi_addr pointer to the output fi address. This address is used by fi_send
  * @param[in]	flags	flags user passed to fi_av_insert.
  * @param[in]	context	context user passed to fi_av_insert
  * @return	0 on success, a negative error code on failure

--- a/prov/efa/src/rxr/rxr_pkt_cmd.h
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020 Amazon.com, Inc. or its affiliates.
+ * Copyright (c) 2019-2022 Amazon.com, Inc. or its affiliates.
  * All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -44,6 +44,8 @@ ssize_t rxr_pkt_post_or_queue(struct rxr_ep *ep, struct rxr_op_entry *op_entry,
 
 ssize_t rxr_pkt_post_req(struct rxr_ep *ep, struct rxr_op_entry *tx_entry,
 			 int req_type, bool inject, uint64_t flags);
+
+fi_addr_t rxr_pkt_determine_addr(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
 
 void rxr_pkt_handle_data_copied(struct rxr_ep *ep,
 				struct rxr_pkt_entry *pkt_entry,

--- a/prov/efa/src/rxr/rxr_pkt_entry.h
+++ b/prov/efa/src/rxr/rxr_pkt_entry.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020 Amazon.com, Inc. or its affiliates.
+ * Copyright (c) 2019-2022 Amazon.com, Inc. or its affiliates.
  * All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -64,7 +64,7 @@ struct rxr_pkt_sendv {
 	void *desc[2];
 };
 
-/* rxr_pkt_entry is used both for sending data to a peer and for receiving dat from a peer.
+/* rxr_pkt_entry is used both for sending data to and receiving data from a peer.
  */
 struct rxr_pkt_entry {
 	/* entry is used for sending only.
@@ -91,11 +91,11 @@ struct rxr_pkt_entry {
 	 * address vector (AV), `lower device will set `addr` to FI_ADDR_NOTAVAIL. This can happen in
 	 * two scenarios:
 	 *
-	 * 1. there has been no prior communication with the peer. In this case, the packet should have
-	 *    peer's raw address in the header, and progress engien will insert the raw address into
-	 *    addres vector, and update `addr`.
+	 * 1. There has been no prior communication with the peer. In this case, the packet should have
+	 *    peer's raw address in the header, and progress engine will insert the raw address into
+	 *    address vector, and update `addr`.
 	 *
-	 * 2. this packet is from a peer whose address has been removed from AV. In this case, the
+	 * 2. This packet is from a peer whose address has been removed from AV. In this case, the
 	 *    recived packet will be ignored because all resources associated with peer has been released.
 	 */
 	fi_addr_t addr;

--- a/prov/efa/src/rxr/rxr_pkt_type.h
+++ b/prov/efa/src/rxr/rxr_pkt_type.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020 Amazon.com, Inc. or its affiliates.
+ * Copyright (c) 2019-2022 Amazon.com, Inc. or its affiliates.
  * All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020 Amazon.com, Inc. or its affiliates.
+ * Copyright (c) 2019-2022 Amazon.com, Inc. or its affiliates.
  * All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -679,4 +679,3 @@ void rxr_pkt_handle_receipt_recv(struct rxr_ep *ep,
 
 	rxr_pkt_entry_release_rx(ep, pkt_entry);
 }
-

--- a/prov/efa/test/efa_unit_test_av.c
+++ b/prov/efa/test/efa_unit_test_av.c
@@ -33,7 +33,6 @@ void test_av_insert_duplicate_raw_addr()
 	assert_int_equal(num_addr, 1);
 	assert_int_equal(addr1, addr2);
 
-	g_efa_unit_test_mocks.ibv_create_ah = __real_ibv_create_ah;
 	efa_unit_test_resource_destruct(&resource);
 }
 
@@ -72,7 +71,6 @@ void test_av_insert_duplicate_gid()
 	assert_int_equal(num_addr, 1);
 	assert_int_not_equal(addr1, addr2);
 
-	g_efa_unit_test_mocks.ibv_create_ah = __real_ibv_create_ah;
 	efa_unit_test_resource_destruct(&resource);
 }
 

--- a/prov/efa/test/efa_unit_test_cq.c
+++ b/prov/efa/test/efa_unit_test_cq.c
@@ -286,4 +286,141 @@ void test_rdm_cq_read_failed_poll()
 	efa_unit_test_resource_destruct(&resource);
 }
 
+#if HAVE_EFADV_CQ_EX
+/**
+ * @brief Construct an RDM endpoint and receive an eager MSG RTM packet.
+ * Simulate EFA device by setting peer AH to unknown and make sure the
+ * endpoint recovers the peer address iff(if and only if) the peer is
+ * inserted to AV.
+ *
+ * @param remove_peer
+ */
+static void test_impl_rdm_cq_read_unknow_peer_ah(bool remove_peer)
+{
+	struct efa_cq *efa_cq;
+	struct rxr_ep *rxr_ep;
+	struct efa_resource resource = {0};
+	struct rxr_pkt_entry *pkt_entry;
+	struct efa_ep_addr raw_addr = {0};
+	size_t raw_addr_len = sizeof(raw_addr);
+	fi_addr_t peer_addr = 0;
+	struct fi_cq_data_entry cq_entry;
+	struct efa_unit_test_eager_rtm_pkt_attr pkt_attr = {0};
+	struct efadv_cq *efadv_cq;
+	struct efa_unit_test_buff recv_buff;
+	int ret;
 
+	efa_unit_test_resource_construct(&resource, FI_EP_RDM);
+
+	rxr_ep = container_of(resource.ep, struct rxr_ep, util_ep.ep_fid);
+	efa_cq = container_of(rxr_ep->rdm_cq, struct efa_cq, util_cq.cq_fid);
+
+	/* Construct a minimal recv buffer */
+	efa_unit_test_buff_construct(&recv_buff, &resource, rxr_ep->min_multi_recv_size);
+
+	/* Create and register a fake peer */
+	ret = fi_getname(&resource.ep->fid, &raw_addr, &raw_addr_len);
+	assert_int_equal(ret, 0);
+	raw_addr.qpn = 0;
+	raw_addr.qkey = 0x1234;
+
+	struct rdm_peer *peer;
+	ret = fi_av_insert(resource.av, &raw_addr, 1, &peer_addr, 0, NULL);
+	assert_int_equal(ret, 1);
+
+	/* Skip handshake */
+	peer = rxr_ep_get_peer(rxr_ep, peer_addr);
+	assert_non_null(peer);
+	peer->flags |= RXR_PEER_HANDSHAKE_SENT;
+
+	/* Setup packet entry */
+	pkt_entry = rxr_pkt_entry_alloc(rxr_ep, rxr_ep->efa_rx_pkt_pool, RXR_PKT_FROM_EFA_RX_POOL);
+	pkt_attr.msg_id = 0;
+	pkt_attr.connid = raw_addr.qkey;
+	/* Packet type must be in [RXR_REQ_PKT_BEGIN, RXR_EXTRA_REQ_PKT_END) */
+	efa_unit_test_eager_msgrtm_pkt_construct(pkt_entry, &pkt_attr);
+
+	/* Setup CQ */
+	efa_cq->ibv_cq_ex->wr_id = (uintptr_t)pkt_entry;
+	efa_cq->ibv_cq_ex->start_poll = &efa_mock_ibv_start_poll_return_mock;
+	efa_cq->ibv_cq_ex->next_poll = &efa_mock_ibv_next_poll_check_function_called_and_return_mock;
+	efa_cq->ibv_cq_ex->end_poll = &efa_mock_ibv_end_poll_check_mock;
+	efa_cq->ibv_cq_ex->read_slid = &efa_mock_ibv_read_slid_return_mock;
+	efa_cq->ibv_cq_ex->read_byte_len = &efa_mock_ibv_read_byte_len_return_mock;
+	efa_cq->ibv_cq_ex->read_opcode = &efa_mock_ibv_read_opcode_return_mock;
+	efa_cq->ibv_cq_ex->read_src_qp = &efa_mock_ibv_read_src_qp_return_mock;
+
+	efadv_cq = efadv_cq_from_ibv_cq_ex(efa_cq->ibv_cq_ex);
+	assert_non_null(efadv_cq);
+	efadv_cq->wc_read_ah = &efa_mock_efadv_wc_read_ah_return_unknown_ah_and_expect_next_poll_and_set_gid;
+
+	/* Return unknown AH from efadv */
+	will_return(efa_mock_efadv_wc_read_ah_return_unknown_ah_and_expect_next_poll_and_set_gid, raw_addr.raw);
+
+	/* Read 1 entry with unknown AH */
+	will_return(efa_mock_ibv_start_poll_return_mock, 0);
+	will_return(efa_mock_ibv_next_poll_check_function_called_and_return_mock, ENOENT);
+	will_return(efa_mock_ibv_end_poll_check_mock, NULL);
+	will_return(efa_mock_ibv_read_slid_return_mock, 0xffff); // slid=0xffff(-1) indicates an unknown AH
+	will_return(efa_mock_ibv_read_byte_len_return_mock, pkt_entry->pkt_size);
+	will_return_maybe(efa_mock_ibv_read_opcode_return_mock, IBV_WC_RECV);
+	will_return_maybe(efa_mock_ibv_read_src_qp_return_mock, raw_addr.qpn);
+
+	/* Post receive buffer */
+	ret = fi_recv(resource.ep, recv_buff.buff, recv_buff.size, fi_mr_desc(recv_buff.mr), peer_addr, NULL /* context */);
+	assert_int_equal(ret, 0);
+
+	if (remove_peer) {
+		ret = fi_av_remove(resource.av, &peer_addr, 1, 0);
+		assert_int_equal(ret, 0);
+	}
+
+	ret = fi_cq_read(resource.cq, &cq_entry, 1);
+
+	if (remove_peer) {
+		/* Ignored WC because the peer is removed */
+		assert_int_equal(ret, -FI_EAGAIN);
+	}
+	else {
+		/* Found 1 matching rx entry */
+		assert_int_equal(ret, 1);
+	}
+
+	efa_unit_test_buff_destruct(&recv_buff);
+	efa_unit_test_resource_destruct(&resource);
+}
+
+/**
+ * @brief Verify that RDM endpoint fi_cq_read recovers unknown peer AH
+ * by querying efadv to get raw address.
+ * A fake peer is registered in AV. The endpoint receives a packet from it,
+ * for which the EFA device returns an unknown AH. The endpoint will retrieve
+ * the peer's raw address using efadv verbs, and recover it's AH using
+ * Raw:QPN:QKey.
+ */
+void test_rdm_cq_read_recover_forgotten_peer_ah()
+{
+	test_impl_rdm_cq_read_unknow_peer_ah(false);
+}
+
+/**
+ * @brief Verify that RDM endpoint progress engine ignores unknown peer AH
+ * if the peer is not registered in AV, e.g. removed.
+ * The endpoint receives a packet from an alien peer, which corresponds to
+ * an unknown AH. The endpoint attempts to look up the AH for the peer but
+ * was rightly unable to, thus ignoring the packet.
+ */
+void test_rdm_cq_read_ignore_removed_peer()
+{
+	test_impl_rdm_cq_read_unknow_peer_ah(true);
+}
+#else
+void test_rdm_cq_read_recover_forgotten_peer_ah()
+{
+	skip();
+}
+void test_rdm_cq_read_ignore_removed_peer()
+{
+	skip();
+}
+#endif

--- a/prov/efa/test/efa_unit_test_device.c
+++ b/prov/efa/test/efa_unit_test_device.c
@@ -28,8 +28,5 @@ void test_efa_device_construct_error_handling()
 	assert_null(efa_device.ibv_ctx);
 	assert_null(efa_device.rdm_info);
 	assert_null(efa_device.dgram_info);
-
-	g_efa_unit_test_mocks.efadv_query_device = &__real_efadv_query_device;
-
 }
 

--- a/prov/efa/test/efa_unit_test_mocks.h
+++ b/prov/efa/test/efa_unit_test_mocks.h
@@ -1,11 +1,15 @@
 #ifndef EFA_UNIT_TEST_RDMA_CORE_MOCKS_H
 #define EFA_UNIT_TEST_RDMA_CORE_MOCKS_H
 
+extern struct efa_unit_test_mocks g_efa_unit_test_mocks;
+
 struct efa_mock_ibv_send_wr_list
 {
 	struct ibv_send_wr *head;
 	struct ibv_send_wr *tail;
 };
+
+void efa_mock_ibv_send_wr_list_destruct(struct efa_mock_ibv_send_wr_list *wr_list);
 
 struct ibv_ah *__real_ibv_create_ah(struct ibv_pd *pd, struct ibv_ah_attr *attr);
 
@@ -45,6 +49,14 @@ struct efa_unit_test_mocks
 				  uint32_t inlen);
 };
 
-extern struct efa_unit_test_mocks g_efa_unit_test_mocks;
+#if HAVE_EFADV_CQ_EX
+uint32_t efa_mock_ibv_read_src_qp_return_mock(struct ibv_cq_ex *current);
+uint32_t efa_mock_ibv_read_byte_len_return_mock(struct ibv_cq_ex *current);
+uint32_t efa_mock_ibv_read_slid_return_mock(struct ibv_cq_ex *current);
+int efa_mock_efadv_wc_read_ah_return_unknown_ah_and_expect_next_poll_and_set_gid(struct efadv_cq *efadv_cq, union ibv_gid *sgid);
+int efa_mock_ibv_start_poll_expect_efadv_wc_read_ah_and_return_mock(struct ibv_cq_ex *ibvcqx,
+																	struct ibv_poll_cq_attr *attr);
+int efa_mock_ibv_next_poll_check_function_called_and_return_mock(struct ibv_cq_ex *ibvcqx);
+#endif
 
 #endif

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -29,6 +29,8 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_rdm_cq_read_failed_poll, efa_unit_test_mocks_reset, NULL),
 		cmocka_unit_test_setup_teardown(test_rdm_cq_read_bad_send_status, efa_unit_test_mocks_reset, NULL),
 		cmocka_unit_test_setup_teardown(test_rdm_cq_read_bad_recv_status, efa_unit_test_mocks_reset, NULL),
+		cmocka_unit_test_setup_teardown(test_rdm_cq_read_recover_forgotten_peer_ah, efa_unit_test_mocks_reset, NULL),
+		cmocka_unit_test_setup_teardown(test_rdm_cq_read_ignore_removed_peer, efa_unit_test_mocks_reset, NULL),
 	};
 
 	cmocka_set_message_output(CM_OUTPUT_XML);

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -1,22 +1,34 @@
 #include "efa_unit_tests.h"
 
+static int efa_unit_test_mocks_reset(void **state)
+{
+	efa_mock_ibv_send_wr_list_destruct(&g_ibv_send_wr_list);
+
+	g_efa_unit_test_mocks = (struct efa_unit_test_mocks) {
+		.ibv_create_ah = __real_ibv_create_ah,
+		.efadv_query_device = __real_efadv_query_device,
+	};
+
+	return 0;
+}
+
 int main(void)
 {
 	int ret;
 	/* Requires an EFA device to work */
 	const struct CMUnitTest efa_unit_tests[] = {
-		cmocka_unit_test(test_av_insert_duplicate_raw_addr),
-		cmocka_unit_test(test_av_insert_duplicate_gid),
-		cmocka_unit_test(test_efa_device_construct_error_handling),
-		cmocka_unit_test(test_rxr_ep_pkt_pool_flags),
-		cmocka_unit_test(test_rxr_ep_pkt_pool_page_alignment),
-		cmocka_unit_test(test_rxr_ep_dc_atomic_error_handling),
-		cmocka_unit_test(test_dgram_cq_read_empty_cq),
-		cmocka_unit_test(test_dgram_cq_read_bad_wc_status),
-		cmocka_unit_test(test_rdm_cq_read_empty_cq),
-		cmocka_unit_test(test_rdm_cq_read_failed_poll),
-		cmocka_unit_test(test_rdm_cq_read_bad_send_status),
-		cmocka_unit_test(test_rdm_cq_read_bad_recv_status),
+		cmocka_unit_test_setup_teardown(test_av_insert_duplicate_raw_addr, efa_unit_test_mocks_reset, NULL),
+		cmocka_unit_test_setup_teardown(test_av_insert_duplicate_gid, efa_unit_test_mocks_reset, NULL),
+		cmocka_unit_test_setup_teardown(test_efa_device_construct_error_handling, efa_unit_test_mocks_reset, NULL),
+		cmocka_unit_test_setup_teardown(test_rxr_ep_pkt_pool_flags, efa_unit_test_mocks_reset, NULL),
+		cmocka_unit_test_setup_teardown(test_rxr_ep_pkt_pool_page_alignment, efa_unit_test_mocks_reset, NULL),
+		cmocka_unit_test_setup_teardown(test_rxr_ep_dc_atomic_error_handling, efa_unit_test_mocks_reset, NULL),
+		cmocka_unit_test_setup_teardown(test_dgram_cq_read_empty_cq, efa_unit_test_mocks_reset, NULL),
+		cmocka_unit_test_setup_teardown(test_dgram_cq_read_bad_wc_status, efa_unit_test_mocks_reset, NULL),
+		cmocka_unit_test_setup_teardown(test_rdm_cq_read_empty_cq, efa_unit_test_mocks_reset, NULL),
+		cmocka_unit_test_setup_teardown(test_rdm_cq_read_failed_poll, efa_unit_test_mocks_reset, NULL),
+		cmocka_unit_test_setup_teardown(test_rdm_cq_read_bad_send_status, efa_unit_test_mocks_reset, NULL),
+		cmocka_unit_test_setup_teardown(test_rdm_cq_read_bad_recv_status, efa_unit_test_mocks_reset, NULL),
 	};
 
 	cmocka_set_message_output(CM_OUTPUT_XML);

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -12,6 +12,9 @@
 #include "rxr.h"
 #include "efa_unit_test_mocks.h"
 
+extern struct efa_mock_ibv_send_wr_list g_ibv_send_wr_list;
+extern struct efa_unit_test_mocks g_efa_unit_test_mocks;
+
 struct efa_resource {
 	struct fi_info *hints;
 	struct fi_info *info;
@@ -33,9 +36,16 @@ struct efa_unit_test_buff {
 	struct fid_mr *mr;
 };
 
+struct efa_unit_test_eager_rtm_pkt_attr {
+	uint32_t msg_id;
+	uint32_t connid;
+};
+
 void efa_unit_test_buff_construct(struct efa_unit_test_buff *buff, struct efa_resource *resource, size_t buff_size);
 
 void efa_unit_test_buff_destruct(struct efa_unit_test_buff *buff);
+
+void efa_unit_test_eager_msgrtm_pkt_construct(struct rxr_pkt_entry *pkt_entry, struct efa_unit_test_eager_rtm_pkt_attr *attr);
 
 /* test cases */
 void test_av_insert_duplicate_raw_addr();

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -60,5 +60,7 @@ void test_rdm_cq_read_empty_cq();
 void test_rdm_cq_read_failed_poll();
 void test_rdm_cq_read_bad_send_status();
 void test_rdm_cq_read_bad_recv_status();
+void test_rdm_cq_read_recover_forgotten_peer_ah();
+void test_rdm_cq_read_ignore_removed_peer();
 
 #endif


### PR DESCRIPTION
It is possible that the EFA device would return an unknown AH(-1) for a known
peer in receive op. This is a bug and could cause the received packet to be
discarded. As a mitigation, the EFA provider attempts to recover the AH if the
node supports extensible CQ. The additional efadv verbs allows the receiver
to retrieve peer raw address. Thereby the provider is able to infer the AH via
Raw Address:QPN:QKey.

Signed-off-by: wenduwan <wenduwan@amazon.com>