### PR TITLE
prov/efa: fill tx desc before init rtm pkt.

### DIFF
--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -538,13 +538,13 @@ ssize_t rxr_pkt_init_medium_msgrtm(struct rxr_ep *ep,
 	struct rxr_medium_rtm_base_hdr *rtm_hdr;
 	int ret;
 
+	efa_domain = rxr_ep_domain(ep);
+	rxr_tx_entry_try_fill_desc(tx_entry, efa_domain, 0, FI_SEND);
+
 	ret = rxr_pkt_init_rtm(ep, tx_entry, RXR_MEDIUM_MSGRTM_PKT,
 			       tx_entry->bytes_sent, pkt_entry);
 	if (ret)
 		return ret;
-
-	efa_domain = rxr_ep_domain(ep);
-	rxr_tx_entry_try_fill_desc(tx_entry, efa_domain, 0, FI_SEND);
 
 	rtm_hdr = rxr_get_medium_rtm_base_hdr(pkt_entry->pkt);
 	rtm_hdr->msg_length = tx_entry->total_len;
@@ -561,13 +561,14 @@ ssize_t rxr_pkt_init_dc_medium_msgrtm(struct rxr_ep *ep,
 	int ret;
 
 	tx_entry->rxr_flags |= RXR_DELIVERY_COMPLETE_REQUESTED;
+
+	efa_domain = rxr_ep_domain(ep);
+	rxr_tx_entry_try_fill_desc(tx_entry, efa_domain, 0, FI_SEND);
+
 	ret = rxr_pkt_init_rtm(ep, tx_entry, RXR_DC_MEDIUM_MSGRTM_PKT,
 			       tx_entry->bytes_sent, pkt_entry);
 	if (ret)
 		return ret;
-
-	efa_domain = rxr_ep_domain(ep);
-	rxr_tx_entry_try_fill_desc(tx_entry, efa_domain, 0, FI_SEND);
 
 	dc_medium_msgrtm_hdr = rxr_get_dc_medium_msgrtm_hdr(pkt_entry->pkt);
 	dc_medium_msgrtm_hdr->hdr.msg_length = tx_entry->total_len;
@@ -584,13 +585,13 @@ ssize_t rxr_pkt_init_medium_tagrtm(struct rxr_ep *ep,
 	struct rxr_medium_rtm_base_hdr *rtm_hdr;
 	int ret;
 
+	efa_domain = rxr_ep_domain(ep);
+	rxr_tx_entry_try_fill_desc(tx_entry, efa_domain, 0, FI_SEND);	
+
 	ret = rxr_pkt_init_rtm(ep, tx_entry, RXR_MEDIUM_TAGRTM_PKT,
 			       tx_entry->bytes_sent, pkt_entry);
 	if (ret)
 		return ret;
-
-	efa_domain = rxr_ep_domain(ep);
-	rxr_tx_entry_try_fill_desc(tx_entry, efa_domain, 0, FI_SEND);
 
 	rtm_hdr = rxr_get_medium_rtm_base_hdr(pkt_entry->pkt);
 	rtm_hdr->msg_length = tx_entry->total_len;
@@ -609,13 +610,14 @@ ssize_t rxr_pkt_init_dc_medium_tagrtm(struct rxr_ep *ep,
 	int ret;
 
 	tx_entry->rxr_flags |= RXR_DELIVERY_COMPLETE_REQUESTED;
+
+	efa_domain = rxr_ep_domain(ep);
+	rxr_tx_entry_try_fill_desc(tx_entry, efa_domain, 0, FI_SEND);
+
 	ret = rxr_pkt_init_rtm(ep, tx_entry, RXR_DC_MEDIUM_TAGRTM_PKT,
 			       tx_entry->bytes_sent, pkt_entry);
 	if (ret)
 		return ret;
-
-	efa_domain = rxr_ep_domain(ep);
-	rxr_tx_entry_try_fill_desc(tx_entry, efa_domain, 0, FI_SEND);
 
 	dc_medium_tagrtm_hdr = rxr_get_dc_medium_tagrtm_hdr(pkt_entry->pkt);
 	dc_medium_tagrtm_hdr->hdr.msg_length = tx_entry->total_len;


### PR DESCRIPTION
Currently, the rxr_tx_entry_try_fill_desc is called
before `rxr_pkt_init_rtm` in rxr_pkt_init_*_medium function.
This caused a performance regression because the tx_entry->desc
was not filled before calling rxr_pkt_init_rtm, which makes
rxr_pkt_init_data_from_tx_entry do extra copy.

This patch fixes this issue by calling rxr_tx_entry_try_fill_desc
before rxr_pkt_init_rtm

Signed-off-by: Shi Jin <sjina@amazon.com>