### PR TITLE
prov/net: Fixes for rdm ep support

### DIFF
--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -198,7 +198,7 @@ struct xnet_ep {
 	struct xnet_srx		*srx;
 
 	enum xnet_state		state;
-	fi_addr_t		src_addr;
+	struct util_peer_addr	*peer;
 	struct xnet_conn_handle *conn;
 	struct xnet_cm_msg	*cm_msg;
 

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -74,7 +74,8 @@
 
 extern struct fi_provider	xnet_prov;
 extern struct util_prov		xnet_util_prov;
-extern struct fi_info		xnet_info;
+extern struct fi_fabric_attr	xnet_fabric_attr;
+extern struct fi_info		xnet_srx_info;
 extern struct xnet_port_range	xnet_ports;
 
 extern int xnet_nodelay;

--- a/prov/net/src/xnet_domain.c
+++ b/prov/net/src/xnet_domain.c
@@ -33,6 +33,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "ofi_atomic.h"
 #include "xnet.h"
 
 
@@ -105,6 +106,19 @@ static int xnet_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 				sizeof(struct xnet_conn));
 }
 
+static int
+xnet_query_atomic(struct fid_domain *domain, enum fi_datatype datatype,
+		  enum fi_op op, struct fi_atomic_attr *attr, uint64_t flags)
+{
+	int ret;
+
+	ret = ofi_atomic_valid(&xnet_prov, datatype, op, flags);
+	if (ret || !attr)
+		return ret;
+
+	return -FI_EOPNOTSUPP;
+}
+
 static struct fi_ops_domain xnet_domain_ops = {
 	.size = sizeof(struct fi_ops_domain),
 	.av_open = xnet_av_open,
@@ -115,7 +129,7 @@ static struct fi_ops_domain xnet_domain_ops = {
 	.poll_open = fi_poll_create,
 	.stx_ctx = fi_no_stx_context,
 	.srx_ctx = xnet_srx_context,
-	.query_atomic = fi_no_query_atomic,
+	.query_atomic = xnet_query_atomic,
 	.query_collective = fi_no_query_collective,
 };
 

--- a/prov/net/src/xnet_fabric.c
+++ b/prov/net/src/xnet_fabric.c
@@ -85,7 +85,7 @@ int xnet_create_fabric(struct fi_fabric_attr *attr,
 	if (!fabric)
 		return -FI_ENOMEM;
 
-	ret = ofi_fabric_init(&xnet_prov, xnet_info.fabric_attr, attr,
+	ret = ofi_fabric_init(&xnet_prov, &xnet_fabric_attr, attr,
 			      &fabric->util_fabric, context);
 	if (ret)
 		goto free;

--- a/prov/net/src/xnet_init.c
+++ b/prov/net/src/xnet_init.c
@@ -44,7 +44,7 @@ static int xnet_getinfo(uint32_t version, const char *node, const char *service,
 			struct fi_info **info)
 {
 	return ofi_ip_getinfo(&xnet_util_prov, version, node, service, flags,
-			      hints, info);
+			     hints, info);
 }
 
 struct xnet_port_range xnet_ports = {

--- a/prov/net/src/xnet_rdm_cm.c
+++ b/prov/net/src/xnet_rdm_cm.c
@@ -212,7 +212,7 @@ static int xnet_rdm_connect(struct xnet_conn *conn)
 	msg.version = XNET_RDM_VERSION;
 	msg.pid = htonl((uint32_t) getpid());
 	msg.resv = 0;
-	msg.port = htons(ofi_addr_get_port(info->src_addr));
+	msg.port = htons(ofi_addr_get_port(&conn->rdm->addr.sa));
 
 	ret = fi_connect(&conn->ep->util_ep.ep_fid, info->dest_addr,
 			 &msg, sizeof msg);

--- a/prov/net/src/xnet_rdm_cm.c
+++ b/prov/net/src/xnet_rdm_cm.c
@@ -79,6 +79,8 @@ static void xnet_close_conn(struct xnet_conn *conn)
 			event = container_of(item, struct xnet_event, list_entry);
 			free(event);
 		} while (item);
+		if (conn->ep->peer)
+			util_put_peer(conn->ep->peer);
 	}
 
 	conn->ep = NULL;
@@ -170,7 +172,8 @@ static int xnet_open_conn(struct xnet_conn *conn, struct fi_info *info)
 	if (ret)
 		goto err;
 
-	conn->ep->src_addr = conn->peer->index;
+	conn->ep->peer = conn->peer;
+	rxm_ref_peer(conn->peer);
 	ret = fi_enable(&conn->ep->util_ep.ep_fid);
 	if (ret) {
 		XNET_WARN_ERR(FI_LOG_EP_CTRL, "fi_enable", ret);

--- a/prov/net/src/xnet_srx.c
+++ b/prov/net/src/xnet_srx.c
@@ -305,7 +305,7 @@ xnet_match_tag_addr(struct xnet_srx *srx, struct xnet_ep *ep, uint64_t tag)
 	slist_foreach(&srx->tag_queue, item, prev) {
 		rx_entry = container_of(item, struct xnet_xfer_entry, entry);
 		if (ofi_match_tag(rx_entry->tag, rx_entry->ignore, tag) &&
-		    ofi_match_addr(rx_entry->src_addr, ep->src_addr)) {
+		    ofi_match_addr(rx_entry->src_addr, ep->peer->fi_addr)) {
 			slist_remove(&srx->tag_queue, item, prev);
 			return rx_entry;
 		}


### PR DESCRIPTION
Update fi_info attributes reported by net provider for ep, ep with srx, and rdm endpoints.
Fix source address matching for received messages.
Include correct rdm ep port number with CM messages.