### PR TITLE
prov/net: Rework active socket monitoring

### DIFF
--- a/include/ofi_epoll.h
+++ b/include/ofi_epoll.h
@@ -69,14 +69,13 @@ struct ofi_pollfds_work_item {
 	int		fd;
 	uint32_t	events;
 	void		*context;
-	enum ofi_pollfds_ctl type;
+	enum ofi_pollfds_ctl op;
 	struct slist_entry entry;
 };
 
 struct ofi_pollfds_ctx {
 	void		*context;
 	int		index;
-	int		hit_cnt;
 	int		hot_index;
 };
 
@@ -89,7 +88,7 @@ struct ofi_pollfds {
 	struct slist	work_item_list;
 	ofi_mutex_t	lock;
 
-	int		fairness_cntr;
+	bool		enable_hot;
 	int		hot_size;
 	int		hot_nfds;
 	struct pollfd	*hot_fds;
@@ -102,13 +101,16 @@ int ofi_pollfds_add(struct ofi_pollfds *pfds, int fd, uint32_t events,
 int ofi_pollfds_mod(struct ofi_pollfds *pfds, int fd, uint32_t events,
 		    void *context);
 int ofi_pollfds_del(struct ofi_pollfds *pfds, int fd);
+int ofi_pollfds_hotties(struct ofi_pollfds *pfds,
+		        struct ofi_epollfds_event *events, int maxevents);
 int ofi_pollfds_wait(struct ofi_pollfds *pfds,
 		     struct ofi_epollfds_event *events,
 		     int maxevents, int timeout);
 void ofi_pollfds_close(struct ofi_pollfds *pfds);
 
-void ofi_pollfds_coolfd(struct ofi_pollfds *pfds, int fd);
-void ofi_pollfds_heatfd(struct ofi_pollfds *pfds, int fd);
+void ofi_pollfds_hotfd(struct ofi_pollfds *pfds, int fd);
+void ofi_pollfds_check_heat(struct ofi_pollfds *pfds,
+			    bool (*is_hot)(void *context));
 
 /* OS specific */
 struct ofi_pollfds_ctx *ofi_pollfds_get_ctx(struct ofi_pollfds *pfds, int fd);

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -257,24 +257,7 @@ struct xnet_progress {
 	struct slist		event_list;
 	struct ofi_bufpool	*xfer_pool;
 
-	/* epoll works better for apps that wait on the fd,
-	 * but tests show that poll performs better
-	 */
-	bool			use_epoll;
-	union {
-		struct ofi_pollfds *pollfds;
-		ofi_epoll_t	epoll;
-	};
-
-	int (*poll_wait)(struct xnet_progress *progress,
-			struct ofi_epollfds_event *events, int max_events,
-			int timeout);
-	int (*poll_add)(struct xnet_progress *progress, int fd, uint32_t events,
-			void *context);
-	void (*poll_mod)(struct xnet_progress *progress, int fd, uint32_t events,
-			void *context);
-	int (*poll_del)(struct xnet_progress *progress, int fd);
-	void (*poll_close)(struct xnet_progress *progress);
+	struct ofi_pollfds	*pollfds;
 
 	pthread_t		thread;
 	bool			auto_progress;

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -275,7 +275,7 @@ void xnet_run_conn(struct xnet_conn_handle *conn, bool pin, bool pout, bool perr
 void xnet_handle_events(struct xnet_progress *progress);
 
 int xnet_trywait(struct fid_fabric *fid_fabric, struct fid **fids, int count);
-void xnet_update_poll(struct xnet_ep *ep);
+void xnet_update_pollout(struct xnet_ep *ep);
 int xnet_monitor_sock(struct xnet_progress *progress, SOCKET sock,
 		      uint32_t events, struct fid *fid);
 void xnet_halt_sock(struct xnet_progress *progress, SOCKET sock);

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -197,6 +197,7 @@ struct xnet_ep {
 	int			rx_avail;
 	struct xnet_srx		*srx;
 
+	int			progress_cnt;
 	enum xnet_state		state;
 	struct util_peer_addr	*peer;
 	struct xnet_conn_handle *conn;

--- a/prov/net/src/xnet_cm.c
+++ b/prov/net/src/xnet_cm.c
@@ -171,10 +171,10 @@ void xnet_req_done(struct xnet_ep *ep)
 		goto disable;
 	}
 
-	if (xnet_active_wait(ep)) {
+	if (xnet_need_rx(ep)) {
 		progress = xnet_ep2_progress(ep);
-		dlist_insert_tail(&ep->active_entry,
-				  &progress->active_wait_list);
+		dlist_insert_tail(&ep->need_rx_entry,
+				  &progress->rx_poll_list);
 		xnet_signal_progress(progress);
 	}
 	ep->state = XNET_CONNECTED;

--- a/prov/net/src/xnet_cm.c
+++ b/prov/net/src/xnet_cm.c
@@ -276,7 +276,7 @@ void xnet_connect_done(struct xnet_ep *ep)
 		goto disable;
 
 	ep->state = XNET_REQ_SENT;
-	xnet_update_poll(ep);
+	xnet_update_pollout(ep);
 	return;
 
 disable:

--- a/prov/net/src/xnet_cm.c
+++ b/prov/net/src/xnet_cm.c
@@ -128,6 +128,7 @@ int xnet_send_cm_msg(struct xnet_ep *ep)
 	if ((size_t) ret != len)
 		return ofi_sockerr() ? -ofi_sockerr() : -FI_EIO;
 
+	ep->progress_cnt++;
 	return FI_SUCCESS;
 }
 
@@ -153,6 +154,7 @@ void xnet_req_done(struct xnet_ep *ep)
 		goto disable;
 	}
 
+	ep->progress_cnt++;
 	ep->hdr_bswap = (ep->cm_msg->hdr.conn_data == 1) ?
 			xnet_hdr_none : xnet_hdr_bswap;
 

--- a/prov/net/src/xnet_ep.c
+++ b/prov/net/src/xnet_ep.c
@@ -238,9 +238,9 @@ xnet_ep_accept(struct fid_ep *ep_fid, const void *param, size_t paramlen)
 	ofi_genlock_lock(&progress->lock);
 	ret = xnet_monitor_sock(progress, ep->bsock.sock, POLLIN,
 				&ep->util_ep.ep_fid.fid);
-	if (!ret && xnet_active_wait(ep)) {
-		dlist_insert_tail(&ep->active_entry,
-				  &progress->active_wait_list);
+	if (!ret && xnet_need_rx(ep)) {
+		dlist_insert_tail(&ep->need_rx_entry,
+				  &progress->rx_poll_list);
 		xnet_signal_progress(progress);
 	}
 	ofi_genlock_unlock(&progress->lock);
@@ -324,7 +324,7 @@ void xnet_ep_disable(struct xnet_ep *ep, int cm_err, void* err_data,
 		return;
 	};
 
-	dlist_remove_init(&ep->active_entry);
+	dlist_remove_init(&ep->need_rx_entry);
 	xnet_halt_sock(xnet_ep2_progress(ep), ep->bsock.sock);
 
 	ret = ofi_shutdown(ep->bsock.sock, SHUT_RDWR);
@@ -477,7 +477,7 @@ static int xnet_ep_close(struct fid *fid)
 
 	progress = xnet_ep2_progress(ep);
 	ofi_genlock_lock(&progress->lock);
-	dlist_remove_init(&ep->active_entry);
+	dlist_remove_init(&ep->need_rx_entry);
 	xnet_halt_sock(progress, ep->bsock.sock);
 	xnet_ep_flush_all_queues(ep);
 	ofi_genlock_unlock(&progress->lock);
@@ -683,7 +683,7 @@ int xnet_endpoint(struct fid_domain *domain, struct fi_info *info,
 		goto err3;
 	}
 
-	dlist_init(&ep->active_entry);
+	dlist_init(&ep->need_rx_entry);
 	slist_init(&ep->rx_queue);
 	slist_init(&ep->tx_queue);
 	slist_init(&ep->priority_queue);

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -172,7 +172,7 @@ static void xnet_progress_tx(struct xnet_ep *ep)
 	 */
 	(void) ofi_bsock_flush(&ep->bsock);
 update:
-	xnet_update_poll(ep);
+	xnet_update_pollout(ep);
 }
 
 static int xnet_queue_ack(struct xnet_xfer_entry *rx_entry)
@@ -852,7 +852,7 @@ int xnet_trywait(struct fid_fabric *fabric_fid, struct fid **fid, int count)
 	return 0;
 }
 
-void xnet_update_poll(struct xnet_ep *ep)
+void xnet_update_pollout(struct xnet_ep *ep)
 {
 	struct xnet_progress *progress;
 	uint32_t events;

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -71,6 +71,7 @@ static ssize_t xnet_send_msg(struct xnet_ep *ep)
 		len = ret;
 	}
 
+	ep->progress_cnt++;
 	ep->cur_tx.data_left -= len;
 	if (ep->cur_tx.data_left) {
 		ofi_consume_iov(tx_entry->iov, &tx_entry->iov_cnt, len);
@@ -93,6 +94,7 @@ static ssize_t xnet_recv_msg_data(struct xnet_ep *ep)
 	if (ret < 0)
 		return ret;
 
+	ep->progress_cnt++;
 	ep->cur_rx.data_left -= ret;
 	if (!ep->cur_rx.data_left)
 		return FI_SUCCESS;
@@ -634,6 +636,7 @@ next_hdr:
 	if (ret < 0)
 		return ret;
 
+	ep->progress_cnt++;
 	ep->cur_rx.hdr_done += ret;
 	if (ep->cur_rx.hdr_done == sizeof(ep->cur_rx.hdr.base_hdr)) {
 		assert(ep->cur_rx.hdr_len == sizeof(ep->cur_rx.hdr.base_hdr));

--- a/prov/net/src/xnet_rdm_cm.c
+++ b/prov/net/src/xnet_rdm_cm.c
@@ -466,7 +466,7 @@ reject:
 	fi_freeinfo(cm_entry->info);
 }
 
-void xnet_handle_events(struct xnet_progress *progress)
+void xnet_handle_event_list(struct xnet_progress *progress)
 {
 	struct xnet_event *event;
 	struct slist_entry *item;


### PR DESCRIPTION
From the commit message changing pollfds:

    core/pollfds: Add ability to manually select hot/cold sockets
    
    The pollfds implementation maintains 2 arrays of fd's that it
    monitors.  One is the default fd set of all watched fd's.  The
    other is an array of active fd's.  The active fd set is disabled
    by default, but can be enabled through the FI_POLL_FAIRNESS
    variable.  An fd is moved to the active list if it had any events
    on it within the last 'fairness' number of checks.  An fd is
    removed from the active list if no events were reported.
    
    In theory, this sounds like a great idea.  In practice, it does
    not work well with some applications.
    
    The issue is that there are situations where an application is
    only trying to send or receive data from a small number of sockets,
    maybe as few as 1, to the exclusion of all other traffic.  When
    this occurs, sockets that have receive data sitting on them will
    move to the active list and continue to generate events.  But
    because the application isn't trying to receive data from the
    corresponding peers (i.e. no tagged buffers are posted using
    any source or the peer's source address), the sockets will always
    remain on the active list.
    
    The performance of poll depends on the number of sockets passed
    to it and the number of events being reported.  When there are
    many sockets generating events repeatedly, the application
    performance suffers.  This is seen running MPI with a simple
    pingpong test.  As the number of ranks increase, the pingpong
    latency increases dramatically, even though only 2 ranks are
    ever sending data to each other.  The other ranks are waiting in
    the barrier phase, have sent data to the ranks running the pingpong
    test, but the received data is not being handled.  The pending
    data will be ignored until the pingpong ranks move to the barrier
    phase.
    
    Define a mechanism that allows a provider to directly specify if
    a socket should be moved/removed from the active list.
    
    Signed-off-by: Sean Hefty <sean.hefty@intel.com>

This series reworks how sockets are determined to be active and moves the control from the pollfds abstraction to the user.  The net provider is updated to list sockets as active only if it recently sent or received data on that socket.

This series is work in progress, with minimal testing.  Posting the PR for feedback and to share the changes.