### PR TITLE
Reduce log messages

### DIFF
--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -611,7 +611,7 @@ static int vrb_get_device_attrs(struct ibv_context *ctx,
 	}
 
 	if (port_num == device_attr.phys_port_cnt + 1) {
-		FI_WARN(&vrb_prov, FI_LOG_FABRIC, "device %s: there are no "
+		FI_INFO(&vrb_prov, FI_LOG_FABRIC, "device %s: there are no "
 			"active ports\n", dev_name);
 		return -FI_ENODATA;
 	} else {

--- a/src/common.c
+++ b/src/common.c
@@ -1389,8 +1389,10 @@ uint32_t ofi_bsock_async_done(const struct fi_provider *prov,
 		FI_WARN(prov, FI_LOG_EP_DATA,
 			"Zerocopy data was copied\n");
 disable:
-		FI_WARN(prov, FI_LOG_EP_DATA, "disabling zerocopy\n");
-		bsock->zerocopy_size = SIZE_MAX;
+		if (bsock->zerocopy_size != SIZE_MAX) {
+			FI_WARN(prov, FI_LOG_EP_DATA, "disabling zerocopy\n");
+			bsock->zerocopy_size = SIZE_MAX;
+		}
 	}
 	return bsock->done_index;
 }


### PR DESCRIPTION
I also wonder if it should enter ofi_bsock_async_done() at all, when zerocopy was never enabled.