### PR TITLE
prov/efa: make rxr_ep_alloc_app_device_info() to support older API

### DIFF
--- a/prov/efa/test/efa_unit_test_info.c
+++ b/prov/efa/test/efa_unit_test_info.c
@@ -40,3 +40,61 @@ void test_info_open_ep_with_wrong_info()
 	err = fi_close(&fabric->fid);
 	assert_int_equal(err, 0);
 }
+
+/**
+ * @brief test that we support older version of libfabric API version 1.1
+ */
+void test_info_open_ep_with_api_1_1_info()
+{
+	struct fi_info *hints, *info;
+	struct fid_fabric *fabric = NULL;
+	struct fid_domain *domain = NULL;
+	struct fid_ep *ep = NULL;
+	int err;
+
+	hints = calloc(sizeof(struct fi_info), 1);
+	assert_non_null(hints);
+
+	hints->domain_attr = calloc(sizeof(struct fi_domain_attr), 1);
+	assert_non_null(hints->domain_attr);
+
+	hints->fabric_attr = calloc(sizeof(struct fi_fabric_attr), 1);
+	assert_non_null(hints->fabric_attr);
+
+	hints->ep_attr = calloc(sizeof(struct fi_ep_attr), 1);
+	assert_non_null(hints->ep_attr);
+
+	hints->fabric_attr->prov_name = EFA_PROV_NAME;
+	hints->ep_attr->type = FI_EP_RDM;
+
+	/* in libfabric API < 1.5, domain_attr->mr_mode is an enum with
+	 * two options: FI_MR_BASIC or FI_MR_SCALABLE, (EFA does not support FI_MR_SCALABLE).
+	 *
+	 * Additional information about memory registration is specified as bits in
+	 * "mode". For example, the requirement of local memory registration
+	 * is specified as FI_LOCAL_MR.
+	 */
+	hints->mode = FI_LOCAL_MR;
+	hints->domain_attr->mr_mode = FI_MR_BASIC;
+
+	err = fi_getinfo(FI_VERSION(1, 1), NULL, NULL, 0ULL, hints, &info);
+	assert_int_equal(err, 0);
+
+	err = fi_fabric(info->fabric_attr, &fabric, NULL);
+	assert_int_equal(err, 0);
+
+	err = fi_domain(fabric, info, &domain, NULL);
+	assert_int_equal(err, 0);
+
+	err = fi_endpoint(domain, info, &ep, NULL);
+	assert_int_equal(err, 0);
+
+	err = fi_close(&ep->fid);
+	assert_int_equal(err, 0);
+
+	err = fi_close(&domain->fid);
+	assert_int_equal(err, 0);
+
+	err = fi_close(&fabric->fid);
+	assert_int_equal(err, 0);
+}

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -32,6 +32,7 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_rdm_cq_read_recover_forgotten_peer_ah, efa_unit_test_mocks_reset, NULL),
 		cmocka_unit_test_setup_teardown(test_rdm_cq_read_ignore_removed_peer, efa_unit_test_mocks_reset, NULL),
 		cmocka_unit_test_setup_teardown(test_info_open_ep_with_wrong_info, efa_unit_test_mocks_reset, NULL),
+		cmocka_unit_test_setup_teardown(test_info_open_ep_with_api_1_1_info, efa_unit_test_mocks_reset, NULL),
 	};
 
 	cmocka_set_message_output(CM_OUTPUT_XML);

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -65,5 +65,6 @@ void test_rdm_cq_read_bad_recv_status();
 void test_rdm_cq_read_recover_forgotten_peer_ah();
 void test_rdm_cq_read_ignore_removed_peer();
 void test_info_open_ep_with_wrong_info();
+void test_info_open_ep_with_api_1_1_info();
 
 #endif


### PR DESCRIPTION
Currently, rxr_ep_alloc_app_device_info() only support newer version
of API (>=1.5). This patch makes it to support older version of
API.

Signed-off-by: Wei Zhang <wzam@amazon.com>