### PR TITLE
prov/efa: validate ep->util_ep before closing in efa_ep_destroy()

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -101,7 +101,8 @@ nodist_prov_efa_test_efa_unit_test_SOURCES = \
 	prov/efa/test/efa_unit_test_ep.c \
 	prov/efa/test/efa_unit_test_av.c \
 	prov/efa/test/efa_unit_test_cq.c \
-	prov/efa/test/efa_unit_test_device.c
+	prov/efa/test/efa_unit_test_device.c \
+	prov/efa/test/efa_unit_test_info.c
 
 efa_CPPFLAGS += -I$(top_srcdir)/include -I$(top_srcdir)/prov/efa/test $(cmocka_CPPFLAGS)
 

--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -221,6 +221,7 @@ struct efa_ep {
 	struct ofi_bufpool	*recv_wr_pool;
 	struct ibv_ah		*self_ah;
 	int			hmem_p2p_opt; /* what to do for hmem transfers */
+	bool			util_ep_initialized;
 };
 
 struct efa_send_wr {

--- a/prov/efa/test/efa_unit_test_common.c
+++ b/prov/efa/test/efa_unit_test_common.c
@@ -1,7 +1,6 @@
 #include "efa_unit_tests.h"
 #include "rxr_pkt_type_base.h"
 
-static
 struct fi_info *efa_unit_test_alloc_hints(enum fi_ep_type ep_type)
 {
 	struct fi_info *hints;

--- a/prov/efa/test/efa_unit_test_info.c
+++ b/prov/efa/test/efa_unit_test_info.c
@@ -1,0 +1,42 @@
+#include "efa_unit_tests.h"
+
+/**
+ * @brief test that when a wrong fi_info was used to open resource, the error is handled
+ * gracefully
+ */
+void test_info_open_ep_with_wrong_info()
+{
+	struct fi_info *hints, *info;
+	struct fid_fabric *fabric = NULL;
+	struct fid_domain *domain = NULL;
+	struct fid_ep *ep = NULL;
+	int err;
+
+	hints = efa_unit_test_alloc_hints(FI_EP_DGRAM);
+
+	err = fi_getinfo(FI_VERSION(1, 14), NULL, NULL, 0ULL, hints, &info);
+	assert_int_equal(err, 0);
+
+	/* dgram endpoint require FI_MSG_PREFIX */
+	assert_int_equal(info->mode, FI_MSG_PREFIX);
+
+	/* make the info wrong by setting the mode to 0 */
+	info->mode = 0;
+
+	err = fi_fabric(info->fabric_attr, &fabric, NULL);
+	assert_int_equal(err, 0);
+
+	err = fi_domain(fabric, info, &domain, NULL);
+	assert_int_equal(err, 0);
+
+	/* because of the error in the info object, fi_endpoint() should fail with -FI_ENODATA */
+	err = fi_endpoint(domain, info, &ep, NULL);
+	assert_int_equal(err, -FI_ENODATA);
+	assert_null(ep);
+
+	err = fi_close(&domain->fid);
+	assert_int_equal(err, 0);
+
+	err = fi_close(&fabric->fid);
+	assert_int_equal(err, 0);
+}

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -31,6 +31,7 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_rdm_cq_read_bad_recv_status, efa_unit_test_mocks_reset, NULL),
 		cmocka_unit_test_setup_teardown(test_rdm_cq_read_recover_forgotten_peer_ah, efa_unit_test_mocks_reset, NULL),
 		cmocka_unit_test_setup_teardown(test_rdm_cq_read_ignore_removed_peer, efa_unit_test_mocks_reset, NULL),
+		cmocka_unit_test_setup_teardown(test_info_open_ep_with_wrong_info, efa_unit_test_mocks_reset, NULL),
 	};
 
 	cmocka_set_message_output(CM_OUTPUT_XML);

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -26,6 +26,8 @@ struct efa_resource {
 	struct fid_cq *cq;
 };
 
+struct fi_info *efa_unit_test_alloc_hints(enum fi_ep_type ep_type);
+
 int efa_unit_test_resource_construct(struct efa_resource *resource, enum fi_ep_type ep_type);
 
 void efa_unit_test_resource_destruct(struct efa_resource *resource);
@@ -62,5 +64,6 @@ void test_rdm_cq_read_bad_send_status();
 void test_rdm_cq_read_bad_recv_status();
 void test_rdm_cq_read_recover_forgotten_peer_ah();
 void test_rdm_cq_read_ignore_removed_peer();
+void test_info_open_ep_with_wrong_info();
 
 #endif


### PR DESCRIPTION
In efa_ep_destroy(), ofi_endpoint_close() was called on
ep->util_ep unconditionally, even when ep->util_ep has not
been initialized.

This patch check whether ep->util_ep is initialized before
close it

Signed-off-by: Wei Zhang <wzam@amazon.com>