### PR TITLE
fabtests: Add cuda_memory marker in pytest

### DIFF
--- a/fabtests/pytest/efa/conftest.py
+++ b/fabtests/pytest/efa/conftest.py
@@ -1,7 +1,9 @@
 import pytest
 
-@pytest.fixture(scope="module", params=["host_to_host", "host_to_cuda",
-                                        "cuda_to_host", "cuda_to_cuda"])
+@pytest.fixture(scope="module", params=["host_to_host",
+                                        pytest.param("host_to_cuda", marks=pytest.mark.cuda_memory),
+                                        pytest.param("cuda_to_host", marks=pytest.mark.cuda_memory),
+                                        pytest.param("cuda_to_cuda", marks=pytest.mark.cuda_memory)])
 def memory_type(request):
     return request.param
 

--- a/fabtests/pytest/pytest.ini
+++ b/fabtests/pytest/pytest.ini
@@ -8,6 +8,7 @@ markers =
     ubertest_all: ubertest tests run will all config
     ubertest_quick: ubertest tests run with quick config
     ubertest_verify: ubertest tests run with verify config
+    cuda_memory: testing with cuda device memory direct
 junit_suite_name = fabtests
 junit_logging = all
 junit_log_passing_tests = true


### PR DESCRIPTION
Add pytest marker to allow tests filtering by cuda memory usage.

Signed-off-by: Michael Margolin <mrgolin@amazon.com>