### PR TITLE
prov/util: Fix MR mode bit check for ver 1.5 and greater

### DIFF
--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -540,7 +540,8 @@ int ofi_check_mr_mode(const struct fi_provider *prov, uint32_t api_version,
 				goto out;
 		} else {
 			prov_mode = ofi_cap_mr_mode(user_info->caps, prov_mode);
-			if ((user_mode & prov_mode) != prov_mode)
+			if (user_mode != FI_MR_UNSPEC &&
+			    (user_mode & prov_mode) != prov_mode)
 				goto out;
 		}
 	}


### PR DESCRIPTION
Client can set hints mr_mode bits to FI_MR_UNSPEC to
indicate support for any registration mode.

Signed-off-by: Steve Welch <welch@hpe.com>