### PR TITLE
src/hmem_neuron.c Change print to to reflect libnrt.so.1

### DIFF
--- a/fabtests/common/hmem_neuron.c
+++ b/fabtests/common/hmem_neuron.c
@@ -80,9 +80,9 @@ int ft_neuron_init(void)
 	if (neuron_handle)
 		return FI_SUCCESS;
 
-	neuron_handle = dlopen("libnrt.so", RTLD_NOW);
+	neuron_handle = dlopen("libnrt.so.1", RTLD_NOW);
 	if (!neuron_handle) {
-		FT_ERR("Failed to dlopen libnrt.so\n");
+		FT_ERR("Failed to dlopen libnrt.so.1\n");
 		return -FI_ENOSYS;
 	}
 

--- a/src/hmem_neuron.c
+++ b/src/hmem_neuron.c
@@ -60,7 +60,7 @@ static int neuron_dl_init(void)
 	neuron_handle = dlopen("libnrt.so.1", RTLD_NOW);
 	if (!neuron_handle) {
 		FI_INFO(&core_prov, FI_LOG_CORE,
-			"Failed to dlopen libnrt.so\n");
+			"Failed to dlopen libnrt.so.1\n");
 		return -FI_ENOSYS;
 	}
 


### PR DESCRIPTION
Also changes fabtests to open libnrt.so.1 instead of libnrt.so

Signed-off-by: William Zhang <wilzhang@amazon.com>