### PR TITLE
print ofi_mr_map_remove return correctly upon failure

### DIFF
--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -433,7 +433,7 @@ static int efa_mr_dereg_impl(struct efa_mr *efa_mr)
 	if (err) {
 		EFA_WARN(FI_LOG_MR,
 			"Unable to remove MR entry from util map (%s)\n",
-			fi_strerror(-ret));
+			fi_strerror(-err));
 		ret = err;
 	}
 	if (efa_mr->shm_mr) {


### PR DESCRIPTION
When ofi_mr_map_remove returns a failure return code, that code is not
the one that is included in the debug message.  This makes it so that
the returned code is logged.

Signed-off-by: Ryan Hankins <rqh@amazon.com>