### PR TITLE
fabtests: Fix issues in `has_hmem_support()` 

### DIFF
--- a/fabtests/common/check_hmem.c
+++ b/fabtests/common/check_hmem.c
@@ -35,16 +35,26 @@
 #include <getopt.h>
 #include <shared.h>
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
 	int ret;
+	int op;
 	hints = fi_allocinfo();
 	if (!hints)
 		return EXIT_FAILURE;
-	if (argc == 2) {
-		hints->fabric_attr->prov_name=strdup(argv[1]);
-	} else if (argc > 2) {
-		return EXIT_FAILURE;
+	hints->mode = ~0;
+	hints->domain_attr->mode = ~0;
+	hints->domain_attr->mr_mode = ~(FI_MR_BASIC | FI_MR_SCALABLE);
+	while ((op = getopt(argc, argv, "p:h")) != -1) {
+		switch (op) {
+		case 'p':
+			hints->fabric_attr->prov_name = strdup(optarg);
+			break;
+		case '?':
+		case 'h':
+			FT_PRINT_OPTS_USAGE("-p <provider>", "specific provider name eg shm, efa");
+			return EXIT_FAILURE;
+		}
 	}
 
 	ret = ft_init();

--- a/fabtests/pytest/common.py
+++ b/fabtests/pytest/common.py
@@ -6,9 +6,17 @@ def has_cuda(ip):
     proc = run(["ssh", ip, "nvidia-smi", "-L"])
     return proc.returncode == 0
 
-def has_hmem_support(cmdline_args, host_type, ip):
+def has_hmem_support(cmdline_args, ip):
     from subprocess import run
-    cmd = cmdline_args.populate_command("check_hmem " + cmdline_args.provider, host_type, 10)
+    import os
+    binpath = ""
+    if cmdline_args.binpath:
+        binpath = cmdline_args.binpath
+    cmd = "timeout " + str(cmdline_args.timeout) \
+          + " " + os.path.join(binpath, "check_hmem") \
+          + " " + "-p " + cmdline_args.provider
+    if cmdline_args.environments:
+        cmd = cmdline_args.environments + " " + cmd
     proc = run(["ssh", ip, cmd])
     return proc.returncode == 0
 
@@ -207,7 +215,7 @@ class ClientServerTest:
             if not has_cuda(self._cmdline_args.server_id):
                 pytest.skip("no cuda device")
                 return
-            if not has_hmem_support(self._cmdline_args, "server", self._cmdline_args.server_id):
+            if not has_hmem_support(self._cmdline_args, self._cmdline_args.server_id):
                 pytest.skip("no hmem support")
                 return
 
@@ -217,7 +225,7 @@ class ClientServerTest:
             if not has_cuda(self._cmdline_args.client_id):
                 pytest.skip("no cuda device")
                 return
-            if not has_hmem_support(self._cmdline_args, "client", self._cmdline_args.client_id):
+            if not has_hmem_support(self._cmdline_args, self._cmdline_args.client_id):
                 pytest.skip("no hmem support")
                 return
 


### PR DESCRIPTION
This PR contains two commits to fix issues in `has_hmem_support()` in `fabtests/pytest/common.py`:
