### PR TITLE
core and prov/shm: Add HMEM IPC Caching Mechanism.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -50,6 +50,7 @@ common_srcs =				\
 	src/hmem_ze.c			\
 	src/hmem_neuron.c		\
 	src/hmem_synapseai.c		\
+	src/hmem_ipc_cache.c	        \
 	src/common.c			\
 	src/enosys.c			\
 	src/rbtree.c			\
@@ -83,6 +84,7 @@ common_srcs =				\
 	prov/util/src/cuda_mem_monitor.c \
 	prov/util/src/rocr_mem_monitor.c \
 	prov/util/src/ze_mem_monitor.c \
+	prov/util/src/cuda_ipc_monitor.c \
 	prov/util/src/util_coll.c
 
 

--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -166,7 +166,22 @@ nobase_dist_config_DATA = \
 	pytest/efa/test_rnr.py \
 	pytest/efa/test_efa_info.py \
 	pytest/efa/test_runt.py \
-	pytest/efa/test_fork_support.py
+	pytest/efa/test_fork_support.py \
+	pytest/shm/conftest.py \
+	pytest/shm/shm_common.py \
+	pytest/shm/test_av.py \
+	pytest/shm/test_cntr.py \
+	pytest/shm/test_cq.py \
+	pytest/shm/test_dom.py \
+	pytest/shm/test_eq.py \
+	pytest/shm/test_getinfo.py \
+	pytest/shm/test_mr.py \
+	pytest/shm/test_multi_recv.py \
+	pytest/shm/test_rdm.py \
+	pytest/shm/test_rma_bw.py \
+	pytest/shm/test_ubertest.py \
+	pytest/shm/test_unexpected_msg.py \
+	pytest/shm/test_sighandler.py
 
 noinst_LTLIBRARIES = libfabtests.la
 

--- a/fabtests/pytest/shm/conftest.py
+++ b/fabtests/pytest/shm/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+@pytest.fixture(scope="module", params=["host_to_host",
+                                        pytest.param("host_to_cuda", marks=pytest.mark.cuda_memory),
+                                        pytest.param("cuda_to_host", marks=pytest.mark.cuda_memory),
+                                        pytest.param("cuda_to_cuda", marks=pytest.mark.cuda_memory)])
+def memory_type(request):
+    return request.param

--- a/fabtests/pytest/shm/shm_common.py
+++ b/fabtests/pytest/shm/shm_common.py
@@ -1,0 +1,11 @@
+def shm_run_client_server_test(cmdline_args, executable, iteration_type,
+                               completion_type, memory_type,
+                               warmup_iteration_type=None):
+    from common import ClientServerTest
+
+    test = ClientServerTest(cmdline_args, executable, iteration_type,
+                            completion_type=completion_type,
+                            datacheck_type="with_datacheck",
+                            memory_type=memory_type,
+                            warmup_iteration_type=warmup_iteration_type)
+    test.run()

--- a/fabtests/pytest/shm/test_av.py
+++ b/fabtests/pytest/shm/test_av.py
@@ -1,0 +1,1 @@
+from default.test_av import test_av_xfer

--- a/fabtests/pytest/shm/test_cntr.py
+++ b/fabtests/pytest/shm/test_cntr.py
@@ -1,0 +1,1 @@
+from default.test_cntr import test_cntr

--- a/fabtests/pytest/shm/test_cq.py
+++ b/fabtests/pytest/shm/test_cq.py
@@ -1,0 +1,1 @@
+from default.test_cq import test_cq

--- a/fabtests/pytest/shm/test_dom.py
+++ b/fabtests/pytest/shm/test_dom.py
@@ -1,0 +1,1 @@
+from default.test_dom import test_dom

--- a/fabtests/pytest/shm/test_eq.py
+++ b/fabtests/pytest/shm/test_eq.py
@@ -1,0 +1,1 @@
+from default.test_eq import test_eq

--- a/fabtests/pytest/shm/test_getinfo.py
+++ b/fabtests/pytest/shm/test_getinfo.py
@@ -1,0 +1,1 @@
+from default.test_getinfo import test_getinfo

--- a/fabtests/pytest/shm/test_mr.py
+++ b/fabtests/pytest/shm/test_mr.py
@@ -1,0 +1,1 @@
+from default.test_mr import test_mr

--- a/fabtests/pytest/shm/test_multi_recv.py
+++ b/fabtests/pytest/shm/test_multi_recv.py
@@ -1,0 +1,1 @@
+from default.test_multi_recv import test_multi_recv

--- a/fabtests/pytest/shm/test_rdm.py
+++ b/fabtests/pytest/shm/test_rdm.py
@@ -1,0 +1,27 @@
+import pytest
+from default.test_rdm import test_rdm, \
+    test_rdm_bw_functional, test_rdm_atomic
+from shm.shm_common import shm_run_client_server_test
+
+@pytest.mark.parametrize("iteration_type",
+                         [pytest.param("short", marks=pytest.mark.short),
+                          pytest.param("standard", marks=pytest.mark.standard)])
+def test_rdm_pingpong(cmdline_args, iteration_type, completion_type, memory_type):
+    shm_run_client_server_test(cmdline_args, "fi_rdm_pingpong", iteration_type,
+                               completion_type, memory_type)
+
+
+@pytest.mark.parametrize("iteration_type",
+                         [pytest.param("short", marks=pytest.mark.short),
+                          pytest.param("standard", marks=pytest.mark.standard)])
+def test_rdm_tagged_pingpong(cmdline_args, iteration_type, completion_type, memory_type):
+    shm_run_client_server_test(cmdline_args, "fi_rdm_tagged_pingpong", iteration_type,
+                               completion_type, memory_type)
+
+
+@pytest.mark.parametrize("iteration_type",
+                         [pytest.param("short", marks=pytest.mark.short),
+                          pytest.param("standard", marks=pytest.mark.standard)])
+def test_rdm_tagged_bw(cmdline_args, iteration_type, completion_type, memory_type):
+    shm_run_client_server_test(cmdline_args, "fi_rdm_tagged_bw", iteration_type,
+                               completion_type, memory_type)

--- a/fabtests/pytest/shm/test_rma_bw.py
+++ b/fabtests/pytest/shm/test_rma_bw.py
@@ -1,0 +1,12 @@
+import pytest
+from shm.shm_common import shm_run_client_server_test
+
+
+@pytest.mark.parametrize("operation_type", ["read", "writedata", "write"])
+@pytest.mark.parametrize("iteration_type",
+                         [pytest.param("short", marks=pytest.mark.short),
+                          pytest.param("standard", marks=pytest.mark.standard)])
+def test_rma_bw(cmdline_args, iteration_type, operation_type, completion_type, memory_type):
+    command = "fi_rma_bw -e rdm"
+    command = command + " -o " + operation_type
+    shm_run_client_server_test(cmdline_args, command, iteration_type, completion_type, memory_type)

--- a/fabtests/pytest/shm/test_sighandler.py
+++ b/fabtests/pytest/shm/test_sighandler.py
@@ -1,0 +1,1 @@
+from default.test_sighandler import test_sighandler

--- a/fabtests/pytest/shm/test_ubertest.py
+++ b/fabtests/pytest/shm/test_ubertest.py
@@ -1,0 +1,1 @@
+from default.test_ubertest import test_ubertest

--- a/fabtests/pytest/shm/test_unexpected_msg.py
+++ b/fabtests/pytest/shm/test_unexpected_msg.py
@@ -1,0 +1,1 @@
+from default.test_unexpected_msg import test_unexpected_msg

--- a/include/ofi.h
+++ b/include/ofi.h
@@ -192,6 +192,11 @@ static inline int ofi_val32_ge(uint32_t x, uint32_t y) {
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 #endif
 
+#ifndef STRINGIFY
+#define __STRINGIFY(expr) #expr
+#define STRINGIFY(expr) __STRINGIFY(expr)
+#endif
+
 #define TAB "    "
 
 #define CASEENUMSTRN(SYM, N) \

--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -128,6 +128,7 @@ struct ofi_hmem_ops {
 	int (*host_unregister)(void *ptr);
 	int (*get_base_addr)(const void *ptr, void **base, size_t *size);
 	bool (*is_ipc_enabled)(void);
+	int (*get_ipc_handle_size)(size_t *size);
 };
 
 extern struct ofi_hmem_ops hmem_ops[];
@@ -154,7 +155,9 @@ int cuda_dev_unregister(uint64_t handle);
 int cuda_get_handle(void *dev_buf, void **handle);
 int cuda_open_handle(void **handle, uint64_t device, void **ipc_ptr);
 int cuda_close_handle(void *ipc_ptr);
+int cuda_get_base_addr(const void *ptr, void **base, size_t *size);
 bool cuda_is_ipc_enabled(void);
+int cuda_get_ipc_handle_size(size_t *size);
 bool cuda_is_gdrcopy_enabled(void);
 
 void cuda_gdrcopy_to_dev(uint64_t handle, void *dev,
@@ -179,6 +182,7 @@ int ze_hmem_open_shared_handle(int dev_fd, void **handle, int *ze_fd,
 			       uint64_t device, void **ipc_ptr);
 int ze_hmem_close_handle(void *ipc_ptr);
 bool ze_hmem_p2p_enabled(void);
+int ze_get_ipc_handle_size(size_t *size);
 int ze_hmem_get_base_addr(const void *ptr, void **base, size_t *size);
 int ze_hmem_get_id(const void *ptr, uint64_t *id);
 int *ze_hmem_get_dev_fds(int *nfds);
@@ -238,6 +242,11 @@ static inline int ofi_hmem_no_close_handle(void *ipc_ptr)
 	return -FI_ENOSYS;
 }
 
+static inline int ofi_hmem_no_get_ipc_handle_size(size_t *size)
+{
+	return -FI_ENOSYS;
+}
+
 static inline int ofi_hmem_register_noop(void *ptr, size_t size)
 {
 	return FI_SUCCESS;
@@ -288,5 +297,6 @@ enum fi_hmem_iface ofi_get_hmem_iface(const void *addr, uint64_t *device,
 int ofi_hmem_host_register(void *ptr, size_t size);
 int ofi_hmem_host_unregister(void *ptr);
 bool ofi_hmem_is_ipc_enabled(enum fi_hmem_iface iface);
+size_t ofi_hmem_get_ipc_handle_size(enum fi_hmem_iface iface);
 
 #endif /* _OFI_HMEM_H_ */

--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -43,6 +43,26 @@
 
 extern bool ofi_hmem_disable_p2p;
 
+#define MAX_IPC_HANDLE_SIZE	64
+
+/*
+ * This structure is part of the
+ * the shm communication protocol
+ * defined in ofi_shm.h.
+ * Please make sure the SMR_VERSION are
+ * bumped and SMR_CMD_SIZE are large
+ * enough, for any changes in this
+ * structure.
+ */
+struct ipc_info {
+	uint64_t	iface;
+	uint64_t	base_address;
+	uint64_t	base_length;
+	uint64_t	device;
+	uint64_t	offset;
+	uint8_t		ipc_handle[MAX_IPC_HANDLE_SIZE];
+};
+
 #if HAVE_CUDA
 
 #include <cuda.h>

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -129,6 +129,15 @@ union ofi_mr_hmem_info {
 	uint64_t ze_id;
 };
 
+struct ofi_mr_entry {
+	struct ofi_mr_info		info;
+	struct ofi_rbnode		*node;
+	int				use_cnt;
+	struct dlist_entry		list_entry;
+	union ofi_mr_hmem_info		hmem_info;
+	uint8_t				data[];
+};
+
 enum fi_mm_state {
 	FI_MM_STATE_UNSPEC = 0,
 	FI_MM_STATE_IDLE,
@@ -159,8 +168,8 @@ struct ofi_mem_monitor {
 	 * pages behind a given virtual address have changed), the buffer needs
 	 * to be re-registered.
 	 */
-	bool (*valid)(struct ofi_mem_monitor *notifier, const void *addr,
-		      size_t len, union ofi_mr_hmem_info *hmem_info);
+	bool (*valid)(struct ofi_mem_monitor *notifier,
+		      const struct ofi_mr_info *info, struct ofi_mr_entry *entry);
 };
 
 void ofi_monitor_init(struct ofi_mem_monitor *monitor);
@@ -183,6 +192,14 @@ void ofi_monitor_unsubscribe(struct ofi_mem_monitor *monitor,
 			     const void *addr, size_t len,
 			     union ofi_mr_hmem_info *hmem_info);
 
+int ofi_monitor_start_no_op(struct ofi_mem_monitor *monitor);
+void ofi_monitor_stop_no_op(struct ofi_mem_monitor *monitor);
+int ofi_monitor_subscribe_no_op(struct ofi_mem_monitor *notifier,
+				 const void *addr, size_t len,
+				 union ofi_mr_hmem_info *hmem_info);
+void ofi_monitor_unsubscribe_no_op(struct ofi_mem_monitor *notifier,
+				    const void *addr, size_t len,
+				    union ofi_mr_hmem_info *hmem_info);
 extern struct ofi_mem_monitor *default_monitor;
 extern struct ofi_mem_monitor *default_cuda_monitor;
 extern struct ofi_mem_monitor *default_rocr_monitor;
@@ -210,6 +227,7 @@ struct ofi_memhooks {
 extern struct ofi_mem_monitor *memhooks_monitor;
 
 extern struct ofi_mem_monitor *cuda_monitor;
+extern struct ofi_mem_monitor *cuda_ipc_monitor;
 extern struct ofi_mem_monitor *rocr_monitor;
 extern struct ofi_mem_monitor *ze_monitor;
 extern struct ofi_mem_monitor *import_monitor;
@@ -286,15 +304,6 @@ struct ofi_mr_cache_params {
 };
 
 extern struct ofi_mr_cache_params	cache_params;
-
-struct ofi_mr_entry {
-	struct ofi_mr_info		info;
-	struct ofi_rbnode		*node;
-	int				use_cnt;
-	struct dlist_entry		list_entry;
-	union ofi_mr_hmem_info		hmem_info;
-	uint8_t				data[];
-};
 
 #define OFI_HMEM_MAX 6
 

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -58,6 +58,8 @@ struct ofi_mr_info {
 	struct iovec iov;
 	enum fi_hmem_iface iface;
 	uint64_t device;
+	void     *ipc_mapped_addr;
+	uint8_t  ipc_handle[MAX_IPC_HANDLE_SIZE];
 };
 
 

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -338,8 +338,21 @@ static inline bool ofi_mr_cache_full(struct ofi_mr_cache *cache)
 
 bool ofi_mr_cache_flush(struct ofi_mr_cache *cache, bool flush_lru);
 
-int ofi_mr_cache_search(struct ofi_mr_cache *cache, const struct fi_mr_attr *attr,
-			struct ofi_mr_entry **entry);
+/**
+ * @brief Given an ofi_mr_info (with an iov range, ipc_info)
+ * If the iov range is already registered and validated by the monitor,
+ * assign the corresponding ofi_mr_entry to entry. Otherwise, register
+ * a new ofi_mr_entry and assign it to entry.
+ *
+ * @param[in] cache     The cache the entry belongs to
+ * @param[in] info      Information about the mr entry to search
+ * @param[out] entry    The registered entry corresponding to the
+ *			region described in info.
+ * @returns On success, returns 0. On failure, returns a negative error code.
+ */
+int ofi_mr_cache_search(struct ofi_mr_cache *cache,
+			 const struct ofi_mr_info *info,
+			 struct ofi_mr_entry **entry);
 
 /**
  * Given an attr (with an iov range), if the iov range is already registered,

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -341,6 +341,12 @@ void ofi_mr_cache_cleanup(struct ofi_mr_cache *cache);
 
 void ofi_mr_cache_notify(struct ofi_mr_cache *cache, const void *addr, size_t len);
 
+int ofi_ipc_cache_open(struct ofi_mr_cache **cache,
+			struct util_domain *domain);
+void ofi_ipc_cache_destroy(struct ofi_mr_cache *cache);
+int  ofi_ipc_cache_search(struct ofi_mr_cache *cache, struct ipc_info *ipc_info,
+			   struct ofi_mr_entry **mr_entry);
+
 static inline bool ofi_mr_cache_full(struct ofi_mr_cache *cache)
 {
 	return (cache->cached_cnt >= cache_params.max_cnt) ||

--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -44,6 +44,7 @@
 #include <ofi_mem.h>
 #include <ofi_rbuf.h>
 #include <ofi_tree.h>
+#include <ofi_hmem.h>
 
 #include <rdma/providers/fi_prov.h>
 
@@ -52,7 +53,7 @@ extern "C" {
 #endif
 
 
-#define SMR_VERSION	2
+#define SMR_VERSION	3
 
 #ifdef HAVE_ATOMICS
 #define SMR_FLAG_ATOMIC	(1 << 0)
@@ -68,7 +69,7 @@ extern "C" {
 
 #define SMR_FLAG_IPC_SOCK (1 << 2)
 
-#define SMR_CMD_SIZE		128	/* align with 64-byte cache line */
+#define SMR_CMD_SIZE		256	/* align with 64-byte cache line */
 
 /* SMR op_src: Specifies data source location */
 enum {
@@ -128,19 +129,6 @@ struct smr_msg_hdr {
 
 #define SMR_MSG_DATA_LEN	(SMR_CMD_SIZE - sizeof(struct smr_msg_hdr))
 
-#define IPC_HANDLE_SIZE		64
-struct smr_ipc_info {
-	uint64_t	iface;
-	union {
-		uint8_t		ipc_handle[IPC_HANDLE_SIZE];
-		struct {
-			uint64_t	device;
-			uint64_t	offset;
-			uint64_t	fd_handle;
-		};
-	};
-};
-
 union smr_cmd_data {
 	uint8_t			msg[SMR_MSG_DATA_LEN];
 	struct {
@@ -151,7 +139,7 @@ union smr_cmd_data {
 	struct {
 		uint64_t	sar;
 	};
-	struct smr_ipc_info	ipc_info;
+	struct ipc_info		ipc_info;
 };
 
 struct smr_cmd_msg {

--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -776,6 +776,7 @@
     <ClCompile Include="prov\util\src\cuda_mem_monitor.c" />
     <ClCompile Include="prov\util\src\rocr_mem_monitor.c" />
     <ClCompile Include="prov\util\src\ze_mem_monitor.c" />
+    <ClCompile Include="prov\util\src\cuda_ipc_monitor.c" />
     <ClCompile Include="src\common.c" />
     <ClCompile Include="src\enosys.c">
       <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Debug-ICC|x64'">4127;869</DisableSpecificWarnings>
@@ -790,6 +791,7 @@
     <ClCompile Include="src\hmem_ze.c" />
     <ClCompile Include="src\hmem_neuron.c" />
     <ClCompile Include="src\hmem_synapseai.c" />
+    <ClCompile Include="src\hmem_ipc_cache.c" />
     <ClCompile Include="src\indexer.c" />
     <ClCompile Include="src\iov.c" />
     <ClCompile Include="src\shared\ofi_str.c" />

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -343,6 +343,7 @@ static int efa_mr_cache_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	struct efa_domain *domain;
 	struct efa_mr *efa_mr;
 	struct ofi_mr_entry *entry;
+	struct ofi_mr_info info;
 	int ret;
 
 	if (attr->iface == FI_HMEM_NEURON)
@@ -362,7 +363,11 @@ static int efa_mr_cache_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	domain = container_of(fid, struct efa_domain,
 			      util_domain.domain_fid.fid);
 
-	ret = ofi_mr_cache_search(domain->cache, attr, &entry);
+	assert(attr->iov_count == 1);
+	info.iov = *attr->mr_iov;
+	info.iface = attr->iface;
+	info.device = attr->device.reserved;
+	ret = ofi_mr_cache_search(domain->cache, &info, &entry);
 	if (OFI_UNLIKELY(ret))
 		return ret;
 

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -62,6 +62,7 @@
 #include <ofi_util.h>
 #include <ofi_atomic.h>
 #include <ofi_iov.h>
+#include <ofi_mr.h>
 
 #ifndef _SMR_H_
 #define _SMR_H_
@@ -211,6 +212,8 @@ struct smr_fabric {
 struct smr_domain {
 	struct util_domain	util_domain;
 	int			fast_rma;
+	/* cache for use with hmem ipc */
+	struct ofi_mr_cache	*ipc_cache;
 };
 
 #define SMR_PREFIX	"fi_shm://"

--- a/prov/util/src/cuda_mem_monitor.c
+++ b/prov/util/src/cuda_mem_monitor.c
@@ -67,8 +67,8 @@ static void cuda_mm_unsubscribe(struct ofi_mem_monitor *monitor,
 }
 
 static bool cuda_mm_valid(struct ofi_mem_monitor *monitor,
-			  const void *addr, size_t len,
-			  union ofi_mr_hmem_info *hmem_info)
+			  const struct ofi_mr_info *info,
+			  struct ofi_mr_entry *entry)
 {
 	uint64_t id;
 	CUresult ret;
@@ -78,20 +78,21 @@ static bool cuda_mm_valid(struct ofi_mem_monitor *monitor,
 	 * buffer ID is associated with this mapping.
 	 */
 	ret = ofi_cuPointerGetAttribute(&id, CU_POINTER_ATTRIBUTE_BUFFER_ID,
-					(CUdeviceptr)addr);
-	if (ret == CUDA_SUCCESS && hmem_info->cuda_id == id) {
+					(CUdeviceptr)entry->info.iov.iov_base);
+	if (ret == CUDA_SUCCESS && entry->hmem_info.cuda_id == id) {
 		FI_DBG(&core_prov, FI_LOG_MR,
 		       "CUDA buffer ID %lu still valid for buffer %p\n",
-		       hmem_info->cuda_id, addr);
+		       entry->hmem_info.cuda_id, entry->info.iov.iov_base);
 		return true;
-	} else if (ret == CUDA_SUCCESS && hmem_info->cuda_id != id) {
+	} else if (ret == CUDA_SUCCESS && entry->hmem_info.cuda_id != id) {
 		FI_DBG(&core_prov, FI_LOG_MR,
 		       "CUDA buffer ID %lu invalid for buffer %p\n",
-		       hmem_info->cuda_id, addr);
+		       entry->hmem_info.cuda_id, entry->info.iov.iov_base);
 	} else {
 		FI_WARN(&core_prov, FI_LOG_MR,
 			"Failed to get CUDA buffer ID for buffer %p len %lu\n"
-			"cuPointerGetAttribute() failed: %s:%s\n", addr, len,
+			"cuPointerGetAttribute() failed: %s:%s\n",
+			entry->info.iov.iov_base, entry->info.iov.iov_len,
 			ofi_cudaGetErrorName(ret), ofi_cudaGetErrorString(ret));
 	}
 
@@ -119,8 +120,8 @@ static void cuda_mm_unsubscribe(struct ofi_mem_monitor *monitor,
 }
 
 static bool cuda_mm_valid(struct ofi_mem_monitor *monitor,
-			  const void *addr, size_t len,
-			  union ofi_mr_hmem_info *hmem_info)
+			  const struct ofi_mr_info *info,
+			  struct ofi_mr_entry *entry)
 {
 	return false;
 }

--- a/prov/util/src/rocr_mem_monitor.c
+++ b/prov/util/src/rocr_mem_monitor.c
@@ -57,8 +57,9 @@ static int rocr_mm_subscribe(struct ofi_mem_monitor *monitor, const void *addr,
 static void rocr_mm_unsubscribe(struct ofi_mem_monitor *monitor,
 				const void *addr, size_t len,
 				union ofi_mr_hmem_info *hmem_info);
-static bool rocr_mm_valid(struct ofi_mem_monitor *monitor, const void *addr,
-			  size_t len, union ofi_mr_hmem_info *hmem_info);
+static bool rocr_mm_valid(struct ofi_mem_monitor *monitor,
+			   const struct ofi_mr_info *info,
+			   struct ofi_mr_entry *entry));
 
 static struct rocr_mm rocr_mm = {
 	.mm = {
@@ -353,8 +354,9 @@ static int rocr_mm_subscribe(struct ofi_mem_monitor *monitor, const void *addr,
 	return ret;
 }
 
-static bool rocr_mm_valid(struct ofi_mem_monitor *monitor, const void *addr,
-			  size_t len, union ofi_mr_hmem_info *hmem_info)
+static bool rocr_mm_valid(struct ofi_mem_monitor *monitor,
+			  const struct ofi_mr_info *info,
+			  struct ofi_mr_entry *entry)
 {
 	/* no-op */
 	return true;
@@ -383,8 +385,9 @@ static void rocr_mm_unsubscribe(struct ofi_mem_monitor *monitor,
 {
 }
 
-static bool rocr_mm_valid(struct ofi_mem_monitor *monitor, const void *addr,
-			  size_t len, union ofi_mr_hmem_info *hmem_info)
+static bool rocr_mm_valid(struct ofi_mem_monitor *monitor,
+			  const struct ofi_mr_info *info,
+			  struct ofi_mr_entry *entry)
 {
 	return false;
 }

--- a/prov/util/src/util_mem_hooks.c
+++ b/prov/util/src/util_mem_hooks.c
@@ -578,8 +578,8 @@ static void ofi_memhooks_unsubscribe(struct ofi_mem_monitor *monitor,
 }
 
 static bool ofi_memhooks_valid(struct ofi_mem_monitor *monitor,
-			       const void *addr, size_t len,
-			       union ofi_mr_hmem_info *hmem_info)
+			       const struct ofi_mr_info *info,
+			       struct ofi_mr_entry *entry)
 {
 	/* no-op */
 	return true;

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -316,29 +316,23 @@ free:
 	return ret;
 }
 
-int ofi_mr_cache_search(struct ofi_mr_cache *cache, const struct fi_mr_attr *attr,
+int ofi_mr_cache_search(struct ofi_mr_cache *cache, const struct ofi_mr_info *info,
 			struct ofi_mr_entry **entry)
 {
-	struct ofi_mr_info info;
 	struct ofi_mem_monitor *monitor;
 	bool flush_lru;
 	int ret;
 
-	monitor = cache->monitors[attr->iface];
+	monitor = cache->monitors[info->iface];
 	if (!monitor) {
 		FI_WARN(&core_prov, FI_LOG_MR,
 			"MR cache disabled for %s memory\n",
-			fi_tostr(&attr->iface, FI_TYPE_HMEM_IFACE));
+			fi_tostr(&info->iface, FI_TYPE_HMEM_IFACE));
 		return -FI_ENOSYS;
 	}
 
-	assert(attr->iov_count == 1);
 	FI_DBG(cache->domain->prov, FI_LOG_MR, "search %p (len: %zu)\n",
-	       attr->mr_iov->iov_base, attr->mr_iov->iov_len);
-
-	info.iov = *attr->mr_iov;
-	info.iface = attr->iface;
-	info.device = attr->device.reserved;
+	       info->iov.iov_base, info->iov.iov_len);
 
 	do {
 		pthread_mutex_lock(&mm_lock);
@@ -350,10 +344,10 @@ int ofi_mr_cache_search(struct ofi_mr_cache *cache, const struct fi_mr_attr *att
 		}
 
 		cache->search_cnt++;
-		*entry = ofi_mr_rbt_find(&cache->tree, &info);
+		*entry = ofi_mr_rbt_find(&cache->tree, info);
 
 		if (*entry &&
-		    ofi_iov_within(attr->mr_iov, &(*entry)->info.iov) &&
+		    ofi_iov_within(&info->iov, &(*entry)->info.iov) &&
 		    monitor->valid(monitor,
 				   (const void *)(*entry)->info.iov.iov_base,
 				   (*entry)->info.iov.iov_len,
@@ -363,11 +357,11 @@ int ofi_mr_cache_search(struct ofi_mr_cache *cache, const struct fi_mr_attr *att
 		/* Purge regions that overlap with new region */
 		while (*entry) {
 			util_mr_uncache_entry(cache, *entry);
-			*entry = ofi_mr_rbt_find(&cache->tree, &info);
+			*entry = ofi_mr_rbt_find(&cache->tree, info);
 		}
 		pthread_mutex_unlock(&mm_lock);
 
-		ret = util_mr_cache_create(cache, &info, entry);
+		ret = util_mr_cache_create(cache, info, entry);
 		if (ret && ret != -FI_EAGAIN) {
 			if (ofi_mr_cache_flush(cache, true))
 				ret = -FI_EAGAIN;

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -348,10 +348,7 @@ int ofi_mr_cache_search(struct ofi_mr_cache *cache, const struct ofi_mr_info *in
 
 		if (*entry &&
 		    ofi_iov_within(&info->iov, &(*entry)->info.iov) &&
-		    monitor->valid(monitor,
-				   (const void *)(*entry)->info.iov.iov_base,
-				   (*entry)->info.iov.iov_len,
-				   &(*entry)->hmem_info))
+		    monitor->valid(monitor, info, *entry))
 			goto hit;
 
 		/* Purge regions that overlap with new region */

--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -273,6 +273,7 @@ vrb_mr_cache_reg(struct vrb_domain *domain, const void *buf, size_t len,
 	struct vrb_mem_desc *md;
 	struct ofi_mr_entry *entry;
 	struct fi_mr_attr attr;
+	struct ofi_mr_info info;
 	struct iovec iov;
 	int ret;
 
@@ -287,10 +288,14 @@ vrb_mr_cache_reg(struct vrb_domain *domain, const void *buf, size_t len,
 	attr.auth_key_size = 0;
 	attr.iface = iface;
 	attr.device.reserved = device;
+	assert(attr.iov_count == 1);
+	info.iov = iov;
+	info.iface = iface;
+	info.device = device;
 
 	ret = (flags & OFI_MR_NOCACHE) ?
 	      ofi_mr_cache_reg(&domain->cache, &attr, &entry) :
-	      ofi_mr_cache_search(&domain->cache, &attr, &entry);
+	      ofi_mr_cache_search(&domain->cache, &info, &entry);
 	if (OFI_UNLIKELY(ret))
 		return ret;
 

--- a/src/hmem_ipc_cache.c
+++ b/src/hmem_ipc_cache.c
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <ofi_mr.h>
+#include <ofi_util.h>
+#include <ofi_hmem.h>
+
+static int ipc_cache_add_region(struct ofi_mr_cache *cache, struct ofi_mr_entry *entry)
+{
+	int ret;
+
+	ret = ofi_hmem_open_handle(entry->info.iface, (void **)&entry->info.ipc_handle,
+				   entry->info.device, &entry->info.ipc_mapped_addr);
+	if (ret == -FI_EALREADY) {
+		/*
+		 * There is a chance we can get the -FI_EALREADY from the
+		 * ofi_hmem_open_handle call. For cuda, the case that this
+		 * can happen is as follows. The sender gets handle from a
+		 * block of memory. Then the sending side frees the memory.
+		 * The sending side then cudaMalloc again and gets the same base
+		 * address. However, it cudaMalloc a block that is larger than
+		 * the one in the cache. The cache will return that memory is not
+		 * found and the ofi_hmem_open_handle will be called again.
+		 * However, that will fail with cudaErrorAlreadyMapped.
+		 * Therefore we need to unmap all overlapping regions and retry.
+		 * ofi_mr_cache_search already move all overlapping regions to
+		 * the dead_region_list via `until_mr_uncache_entry`.
+		 * We need to flush the cache to purge the entries
+		 * and close the handles.
+		 */
+		ofi_mr_cache_flush(cache, false);
+		ret = ofi_hmem_open_handle(entry->info.iface, (void **)&entry->info.ipc_handle,
+						entry->info.device, &entry->info.ipc_mapped_addr);
+	}
+	if (ret) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"Failed to open hmem handle, addr: %p, len: %lu\n",
+			entry->info.iov.iov_base, entry->info.iov.iov_len);
+	}
+	return ret;
+}
+
+static void ipc_cache_delete_region(struct ofi_mr_cache *cache,
+				     struct ofi_mr_entry *entry)
+{
+	ofi_hmem_close_handle(entry->info.iface,
+			      entry->info.ipc_mapped_addr);
+}
+
+/**
+ * @brief Open an ipc cache
+ * 
+ * @param cache[in] the ipc cache
+ * @param domain[in] the domain that the cache is attached to.
+ * @param iface[in] the hmem iface of the ipc
+ * @return int 0 on success, negative value otherwise.
+ */
+int ofi_ipc_cache_open(struct ofi_mr_cache **cache,
+			struct util_domain *domain)
+{
+	struct ofi_mem_monitor *memory_monitors[OFI_HMEM_MAX] = {0};
+	int ret;
+
+	/* no-op when cuda ipc is not enabled */
+	if (!ofi_hmem_is_ipc_enabled(FI_HMEM_CUDA))
+		return FI_SUCCESS;
+
+	memory_monitors[FI_HMEM_CUDA] = cuda_ipc_monitor;
+
+	*cache = calloc(1, sizeof(*(*cache)));
+	if (!*cache) {
+		ret = -FI_ENOMEM;
+		goto out;
+	}
+
+	(*cache)->add_region = ipc_cache_add_region;
+	(*cache)->delete_region = ipc_cache_delete_region;
+	ret = ofi_mr_cache_init(domain, memory_monitors,
+				*cache);
+	if (ret)
+		goto cleanup;
+
+	FI_INFO(&core_prov, FI_LOG_CORE,
+		"ipc cache enabled, max_cnt: %zu max_size: %zu\n",
+		cache_params.max_cnt, cache_params.max_size);
+	return FI_SUCCESS;
+
+cleanup:
+	free(*cache);
+	*cache = NULL;
+out:
+	return ret;
+}
+
+/**
+ * @brief Destroy the ipc cache
+ * 
+ * @param cache the ipc cache
+ */
+void ofi_ipc_cache_destroy(struct ofi_mr_cache *cache)
+{
+	ofi_mr_cache_cleanup(cache);
+	free(cache);
+}
+
+/**
+ * @brief Given ipc_info (with ipc_handle and the iov of the device allocation),
+ * assign the mapped_addr the mapped address of the ipc_handle.
+ * Each (ipc_handle, mapped_addr) pair is stored in ofi_mr_entry.info.ipc_info as
+ * part of each mr entry.
+ * In a cache hit, the mapped_addr is retrieved from the matched mr entry. Otherwise,
+ * the mapped_addr is obtained by opening the ipc handle.
+ * 
+ * @param[in] cache the ipc cache
+ * @param[in] ipc_info the information of the ipc to be mapped.
+ * @param[out] mr_entry the matched mr_entry of the ipc_info and mapped_addr.
+ * @return int 0 on success, negative value otherwise.
+ */
+int ofi_ipc_cache_search(struct ofi_mr_cache *cache, struct ipc_info *ipc_info,
+			  struct ofi_mr_entry **mr_entry)
+{
+	struct ofi_mr_info info;
+	struct ofi_mr_entry *entry;
+	int ret;
+	size_t ipc_handle_size;
+
+	info.iov.iov_base = (void *) (uintptr_t) ipc_info->base_address;
+	info.iov.iov_len = ipc_info->base_length;
+	info.iface = ipc_info->iface;
+
+	ipc_handle_size = ofi_hmem_get_ipc_handle_size(info.iface);
+	assert(ipc_handle_size);
+
+	memcpy(&info.ipc_handle, &ipc_info->ipc_handle, ipc_handle_size);
+
+	ret = ofi_mr_cache_search(cache, &info, &entry);
+	if (ret)
+		goto out;
+
+	*mr_entry = entry;
+out:
+	return ret;
+}
+

--- a/src/hmem_ze.c
+++ b/src/hmem_ze.c
@@ -404,6 +404,12 @@ bool ze_hmem_p2p_enabled(void)
 	return !ofi_hmem_p2p_disabled() && p2p_enabled;
 }
 
+int ze_get_ipc_handle_size(size_t *size)
+{
+	*size = sizeof(ze_ipc_mem_handle_t);
+	return FI_SUCCESS;
+}
+
 #else
 
 static int ze_hmem_init_fds(void)
@@ -989,6 +995,11 @@ int ze_hmem_close_handle(void *ipc_ptr)
 bool ze_hmem_p2p_enabled(void)
 {
 	return false;
+}
+
+int ze_get_ipc_handle_size(size_t *size)
+{
+	return -FI_ENOSYS;
 }
 
 int ze_hmem_get_base_addr(const void *ptr, void **base, size_t *size)


### PR DESCRIPTION
~~This PR is based on the commit https://github.com/ofiwg/libfabric/pull/7848/commits/d34eacd16de58e45bfb256d5ae974c1c22cb8953 in the draft PR https://github.com/ofiwg/libfabric/pull/7848 opened by @amirshehataornl~~


Opening and closing the HMEM IPC handles are expensive operations. They
    should not be performed on every data operation.
    
This patch adds a caching mechanism. On the very first IPC handle open
    call, the address is cached and the mapped memory address is stored. In
    subsequent calls the cache is queried and the mapped address is retrieved.
    
The IPC cache is implemented as an object of ofi_mr_cache, it has the following
    cache attributes:
    
 cache->add_region: open the ipc handle
 cache->delete_region: close the ipc handle
 cache->monitor: a new ipc monitor of type struct ofi_mem_monitor to check whether the
    ipc_handle is stale.
    

