### PR TITLE
prov/efa: enable using shm via CUDA IPC.

### DIFF
--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -536,7 +536,6 @@ static int efa_mr_reg_impl(struct efa_mr *efa_mr, uint64_t flags, void *attr)
 	assert(efa_mr->mr_fid.key != FI_KEY_NOTAVAIL);
 
 	mr_attr->requested_key = efa_mr->mr_fid.key;
-	mr_attr->device.reserved = efa_mr->peer.device.reserved;
 
 	ofi_genlock_lock(&efa_mr->domain->util_domain.lock);
 	ret = ofi_mr_map_insert(&efa_mr->domain->util_domain.mr_map, attr,

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -2414,26 +2414,6 @@ bool rxr_ep_use_shm_for_tx(struct fi_info *info)
 	    && !(info->caps & FI_LOCAL_COMM))
 		return 0;
 
-	/*
-	 * Currently, shm provider uses the SAR protocol for cuda
-	 * memory buffer, whose performance is worse than using EFA device.
-	 *
-	 * To address this issue, shm usage is disabled if application
-	 * requested the FI_HMEM capablity.
-	 *
-	 * This is not ideal, because host memory commuications are
-	 * also going through device.
-	 *
-	 * The long term fix is make shm provider to support cuda
-	 * buffers through cuda IPC. Once that is implemented, the
-	 * following two lines need to be removed.
-	 *
-	 * In addition, AWS Neuron is currently not supported by the SHM
-	 * provider.
-	 */
-	if (info && (info->caps & FI_HMEM))
-		return 0;
-
 	return rxr_env.enable_shm_transfer;
 }
 

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -230,7 +230,16 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *ep, struct rxr_op_entry *tx_entry, int u
 	assert(rtm_type >= RXR_REQ_PKT_BEGIN);
 
 	if (peer->is_local && ep->use_shm_for_tx) {
-		/* we know shm's capablity, so no need to check handshake */
+		/*
+		 * We know shm's capablity, so no need to check handshake.
+		 * AWS Neuron is currently not supported by the SHM provider.
+		 */
+
+		if (efa_mr_is_neuron(tx_entry->desc[0])) {
+			FI_WARN(&rxr_prov, FI_LOG_CQ,
+			"AWS Neuron is currently not supported by the SHM provider\n");
+			return -FI_EINVAL;
+		}
 		return rxr_pkt_post_req(ep, tx_entry, rtm_type, 0, 0);
 	}
 


### PR DESCRIPTION
This PR enables using shm for CUDA hmem. It cannot be merged before https://github.com/ofiwg/libfabric/pull/7893 is merged.