### PR TITLE
fabtests: Add component tests for dmabuf RDMA

### DIFF
--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -69,6 +69,15 @@ bin_PROGRAMS = \
 	regression/sighandler_test \
 	common/check_hmem
 
+if HAVE_LIBZE_DEVEL
+bin_PROGRAMS += \
+	component/dmabuf-rdma/rdmabw-xe \
+	component/dmabuf-rdma/fi-rdmabw-xe \
+	component/dmabuf-rdma/mr-reg-xe \
+	component/dmabuf-rdma/fi-mr-reg-xe \
+	component/dmabuf-rdma/memcopy-xe
+endif HAVE_LIBZE_DEVEL
+
 dist_bin_SCRIPTS = \
 	scripts/runfabtests.sh \
 	scripts/runfabtests.py \
@@ -446,6 +455,76 @@ component_sock_test_LDADD = libfabtests.la
 
 component_sock_test_CFLAGS = \
 	$(AM_CFLAGS)
+
+if HAVE_LIBZE_DEVEL
+component_dmabuf_rdma_rdmabw_xe_SOURCES = \
+	component/dmabuf-rdma/rdmabw-xe.c \
+	component/dmabuf-rdma/util.c \
+	component/dmabuf-rdma/util.h \
+	component/dmabuf-rdma/xe.c \
+	component/dmabuf-rdma/xe.h \
+	component/dmabuf-rdma/dmabuf_reg.c \
+	component/dmabuf-rdma/dmabuf_reg.h
+
+component_dmabuf_rdma_rdmabw_xe_LDADD = libfabtests.la
+
+component_dmabuf_rdma_rdmabw_xe_CFLAGS = \
+	$(AM_CFLAGS) \
+	-I$(srcdir)/component/dmabuf-rdma
+
+component_dmabuf_rdma_fi_rdmabw_xe_SOURCES = \
+	component/dmabuf-rdma/fi-rdmabw-xe.c \
+	component/dmabuf-rdma/util.c \
+	component/dmabuf-rdma/util.h \
+	component/dmabuf-rdma/xe.c \
+	component/dmabuf-rdma/xe.h \
+	component/dmabuf-rdma/dmabuf_reg.c \
+	component/dmabuf-rdma/dmabuf_reg.h
+
+component_dmabuf_rdma_fi_rdmabw_xe_LDADD = libfabtests.la
+
+component_dmabuf_rdma_fi_rdmabw_xe_CFLAGS = \
+	$(AM_CFLAGS) \
+	-I$(srcdir)/component/dmabuf-rdma
+
+component_dmabuf_rdma_mr_reg_xe_SOURCES = \
+	component/dmabuf-rdma/mr-reg-xe.c \
+	component/dmabuf-rdma/util.h \
+	component/dmabuf-rdma/xe.c \
+	component/dmabuf-rdma/xe.h \
+	component/dmabuf-rdma/dmabuf_reg.c \
+	component/dmabuf-rdma/dmabuf_reg.h
+
+component_dmabuf_rdma_mr_reg_xe_LDADD = libfabtests.la
+
+component_dmabuf_rdma_mr_reg_xe_CFLAGS = \
+	$(AM_CFLAGS) \
+	-I$(srcdir)/component/dmabuf-rdma
+
+component_dmabuf_rdma_fi_mr_reg_xe_SOURCES = \
+	component/dmabuf-rdma/fi-mr-reg-xe.c \
+	component/dmabuf-rdma/util.h \
+	component/dmabuf-rdma/xe.c \
+	component/dmabuf-rdma/xe.h \
+	component/dmabuf-rdma/dmabuf_reg.c \
+	component/dmabuf-rdma/dmabuf_reg.h
+
+component_dmabuf_rdma_fi_mr_reg_xe_LDADD = libfabtests.la
+
+component_dmabuf_rdma_fi_mr_reg_xe_CFLAGS = \
+	$(AM_CFLAGS) \
+	-I$(srcdir)/component/dmabuf-rdma
+
+component_dmabuf_rdma_memcopy_xe_SOURCES = \
+	component/dmabuf-rdma/memcopy-xe.c \
+	component/dmabuf-rdma/util.c \
+	component/dmabuf-rdma/util.h
+
+component_dmabuf_rdma_memcopy_xe_LDADD = libfabtests.la
+
+component_dmabuf_rdma_memcopy_xe_CFLAGS = \
+	$(AM_CFLAGS)
+endif HAVE_LIBZE_DEVEL
 
 regression_sighandler_test_SOURCES = \
 	regression/sighandler_test.c

--- a/fabtests/component/dmabuf-rdma/dmabuf_reg.c
+++ b/fabtests/component/dmabuf-rdma/dmabuf_reg.c
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2021-2022 Intel Corporation.  All rights reserved.
+ *
+ * This software is available to you under the BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ * dmabuf registry for peer-memory access.
+ *
+ * The dmabuf registry is a database of known dmabuf based allocations
+ * maintained by the "dmabuf_peer_mem" kernel module. The module provides a
+ * ib-peer-memory client that plugs into the RDMA stack of MOFED installation.
+ * It allows buffer allocated on the device memory be registered via the
+ * regular ibv_reg_mr() call.
+ *
+ * The "dmabuf_peer_mem" kernel module is not needed if the RDMA stack has
+ * native dmabuf support and the buffer is registered with the newer
+ * ibv_reg_dmabuf_mr() call.
+ *
+ * The code here is for explicitly accesing the dmabuf registry upon buffer
+ * allocation. It is not needed for libfabric based applications when the
+ * "dmabuf_peer_mem" hooking provider is enabled (by setting the environment
+ * variable FI_HOOK=dmabuf_peer_mem).
+ */
+
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include "dmabuf_reg.h"
+
+static char *dmabuf_reg_dev_name = "/dev/" DMABUF_REG_DEV_NAME;
+static int dmabuf_reg_fd = -1;
+
+int dmabuf_reg_open(void)
+{
+	int fd;
+
+	fd = open(dmabuf_reg_dev_name, 0);
+	if (fd < 0) {
+		perror(dmabuf_reg_dev_name);
+		return fd;
+	}
+
+	dmabuf_reg_fd = fd;
+	return 0;
+}
+
+void dmabuf_reg_close(void)
+{
+	if (dmabuf_reg_fd >= 0)
+		close(dmabuf_reg_fd);
+}
+
+int dmabuf_reg_add(uint64_t base, uint64_t size, int fd)
+{
+	struct dmabuf_reg_param args = {
+		.op = DMABUF_REG_ADD,
+		.base = base,
+		.size = size,
+		.fd = fd,
+	};
+	int err;
+
+	err = ioctl(dmabuf_reg_fd, DMABUF_REG_IOCTL, &args);
+	if (err)
+		perror(__func__);
+
+	return err;
+}
+
+void dmabuf_reg_remove(uint64_t addr)
+{
+	struct dmabuf_reg_param args = {
+		.op = DMABUF_REG_REMOVE_ADDR,
+		.base = addr,
+	};
+	int err;
+
+	err = ioctl(dmabuf_reg_fd, DMABUF_REG_IOCTL, &args);
+	if (err)
+		perror(__func__);
+}
+

--- a/fabtests/component/dmabuf-rdma/dmabuf_reg.h
+++ b/fabtests/component/dmabuf-rdma/dmabuf_reg.h
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: GPL-2.0 OR Linux-OpenIB */
+/*
+ * Copyright (c) 2021 Intel Corporation. All rights reserved.
+ */
+
+#ifndef __LINUX_DMABUF_REG_H__
+#define __LINUX_DMABUF_REG_H__
+
+#ifdef __KERNEL__
+#include <linux/types.h>
+#else
+#include <stdint.h>
+#endif
+
+#define DMABUF_REG_DEV_NAME	"dmabuf_reg"
+#define DMABUF_REG_IOCTL	1
+
+enum {
+	DMABUF_REG_ADD,
+	DMABUF_REG_REMOVE_ADDR,
+	DMABUF_REG_REMOVE_FD,
+	DMABUF_REG_QUERY,
+};
+
+struct dmabuf_reg_param {
+	uint64_t base;
+	uint64_t size;
+	uint32_t fd;
+	uint32_t op;
+};
+
+#endif /* __LINUX_DMABUF_REG_H__ */

--- a/fabtests/component/dmabuf-rdma/fi-mr-reg-xe.c
+++ b/fabtests/component/dmabuf-rdma/fi-mr-reg-xe.c
@@ -1,0 +1,275 @@
+/*
+ * Copyright (c) 2021-2022 Intel Corporation.  All rights reserved.
+ *
+ * This software is available to you under the BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ *	fi-mr-reg-xe.c
+ *
+ *	This is simple libfabric memory registration test for buffers allocated
+ *	via oneAPI L0 functions.
+ *
+ *	Register memory allocted with malloc():
+ *
+ *	    ./fi-mr-reg-xe -m malloc
+ *
+ *	Register memory allocated with zeMemAllocHost():
+ *
+ *	    ./fi-mr-reg-xe -m host
+ *
+ *	Register memory allocated with zeMemAllocDevice() on device 0
+ *
+ *	    ./fi-mr-reg-xe -m device -d 0
+ *
+ *	For more options:
+ *
+ *	    ./fi-mr-reg-xe -h
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <string.h>
+#include <rdma/fabric.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_endpoint.h>
+#include "util.h"
+#include "xe.h"
+
+static int	ep_type = FI_EP_RDM;
+static char	*prov_name;
+static char	*domain_name;
+
+static struct fi_info		*fi;
+static struct fid_fabric	*fabric;
+static struct fid_eq		*eq;
+static struct fid_domain	*domain;
+static struct fid_ep		*ep;
+static struct fid_av		*av;
+static struct fid_cq		*cq;
+static struct fid_mr		*mr;
+
+static void	*buf;
+static size_t	buf_size = 65536;
+static int 	buf_location = MALLOC;
+
+static void init_buf(void)
+{
+	int page_size = sysconf(_SC_PAGESIZE);
+
+	buf = xe_alloc_buf(page_size, buf_size, buf_location, 0, NULL);
+	if (!buf) {
+		fprintf(stderr, "Couldn't allocate work buf.\n");
+		exit(-1);
+	}
+}
+
+static void free_buf(void)
+{
+	xe_free_buf(buf, buf_location);
+}
+
+static void init_ofi(void)
+{
+	struct fi_info *hints;
+	struct fi_cq_attr cq_attr = {};
+	struct fi_av_attr av_attr = {};
+	struct fi_eq_attr eq_attr = {};
+	int version;
+
+	EXIT_ON_NULL((hints = fi_allocinfo()));
+
+	hints->caps = FI_HMEM;
+	hints->ep_attr->type = ep_type;
+	if (prov_name)
+		hints->fabric_attr->prov_name = strdup(prov_name);
+	hints->domain_attr->mr_mode = (FI_MR_ALLOCATED | FI_MR_PROV_KEY |
+				       FI_MR_VIRT_ADDR | FI_MR_LOCAL |
+				       FI_MR_HMEM | FI_MR_ENDPOINT);
+	if (domain_name)
+		hints->domain_attr->name = strdup(domain_name);
+
+	version = FI_VERSION(1, 12);
+
+	if (ep_type == FI_EP_RDM)
+		EXIT_ON_ERROR(fi_getinfo(version, NULL, NULL, 0, hints, &fi));
+	else
+		EXIT_ON_ERROR(fi_getinfo(version, "localhost", "12345", 0,
+					 hints, &fi));
+
+	fi_freeinfo(hints);
+
+	printf("Using OFI device: %s (%s)\n", fi->fabric_attr->prov_name,
+		fi->domain_attr->name);
+
+	EXIT_ON_ERROR(fi_fabric(fi->fabric_attr, &fabric, NULL));
+	EXIT_ON_ERROR(fi_domain(fabric, fi, &domain, NULL));
+	EXIT_ON_ERROR(fi_endpoint(domain, fi, &ep, NULL));
+	EXIT_ON_ERROR(fi_cq_open(domain, &cq_attr, &cq, NULL));
+	if (ep_type == FI_EP_RDM) {
+		EXIT_ON_ERROR(fi_av_open(domain, &av_attr, &av, NULL));
+		EXIT_ON_ERROR(fi_ep_bind(ep, (fid_t)av, 0));
+	} else {
+		EXIT_ON_ERROR(fi_eq_open(fabric, &eq_attr, &eq, NULL));
+		EXIT_ON_ERROR(fi_ep_bind(ep, (fid_t)eq, 0));
+	}
+	EXIT_ON_ERROR(fi_ep_bind(ep, (fid_t)cq, (FI_TRANSMIT | FI_RECV |
+						 FI_SELECTIVE_COMPLETION)));
+	EXIT_ON_ERROR(fi_enable(ep));
+}
+
+void reg_mr(void)
+{
+	struct iovec iov = {
+		.iov_base = buf,
+		.iov_len = buf_size,
+	};
+	struct fi_mr_attr mr_attr = {
+		.mr_iov = &iov,
+		.iov_count = 1,
+		.access = FI_REMOTE_READ | FI_REMOTE_WRITE,
+		.requested_key = 1,
+		.iface = buf_location == MALLOC ? FI_HMEM_SYSTEM : FI_HMEM_ZE,
+		.device.ze = xe_get_dev_num(0),
+	};
+
+	CHECK_ERROR(fi_mr_regattr(domain, &mr_attr, 0, &mr));
+
+	if (fi->domain_attr->mr_mode & FI_MR_ENDPOINT) {
+		CHECK_ERROR(fi_mr_bind(mr, (fid_t)ep, 0));
+		CHECK_ERROR(fi_mr_enable(mr));
+	}
+
+	printf("mr %p, buf %p, rkey 0x%lx, len %zd\n",
+		mr, buf, fi_mr_key(mr), buf_size);
+
+err_out:
+	return;
+}
+
+void dereg_mr(void)
+{
+	if (mr)
+		fi_close((fid_t)mr);
+}
+
+static void finalize_ofi(void)
+{
+	fi_close((fid_t)ep);
+	if (ep_type == FI_EP_RDM)
+		fi_close((fid_t)av);
+	fi_close((fid_t)cq);
+	fi_close((fid_t)domain);
+	if (ep_type == FI_EP_MSG)
+		fi_close((fid_t)eq);
+	fi_close((fid_t)fabric);
+	fi_freeinfo(fi);
+}
+
+static void usage(char *prog)
+{
+	printf("Usage: %s [options]\n", prog);
+	printf("Options:\n");
+	printf("\t-m <location>    Where to allocate the buffer, can be 'malloc', 'host', 'device' or 'shared', default: malloc\n");
+	printf("\t-d <x>[.<y>]     Use the GPU device <x>, optionally subdevice <y>, default: 0\n");
+	printf("\t-e <ep_type>     Set the endpoint type, can be 'rdm' or 'msg', default: rdm\n");
+	printf("\t-p <prov_name>   Use the OFI provider named as <prov_name>, default: the first one\n");
+	printf("\t-D <domain_name> Open OFI domain named as <domain_name>, default: automatic\n");
+	printf("\t-S <size>        Set the buffer size, default: 65536\n");
+	printf("\t-R               Enable dmabuf_reg (plug-in for MOFED peer-memory)\n");
+	printf("\t-h               Print this message\n");
+}
+
+int main(int argc, char *argv[])
+{
+	char *gpu_dev_nums = NULL;
+	int c;
+
+	while ((c = getopt(argc, argv, "d:D:e:p:m:RS:h")) != -1) {
+		switch (c) {
+		case 'd':
+			gpu_dev_nums = strdup(optarg);
+			break;
+		case 'D':
+			domain_name = strdup(optarg);
+			break;
+		case 'e':
+			if (!strcmp(optarg, "rdm"))
+				ep_type = FI_EP_RDM;
+			else if (!strcmp(optarg, "msg"))
+				ep_type = FI_EP_MSG;
+			else
+				printf("Invalid ep type %s, use default\n", optarg);
+			break;
+		case 'p':
+			prov_name = strdup(optarg);
+			break;
+		case 'm':
+			if (!strcmp(optarg, "malloc"))
+				buf_location = MALLOC;
+			else if (!strcmp(optarg, "host"))
+				buf_location = HOST;
+			else if (!strcmp(optarg, "device"))
+				buf_location = DEVICE;
+			else if (!strcmp(optarg, "shared"))
+				buf_location = SHARED;
+			else
+				printf("Invalid buffer location %s, use default\n", optarg);
+			break;
+		case 'R':
+			use_dmabuf_reg = 1;
+			break;
+		case 'S':
+			buf_size = atoi(optarg);
+			break;
+		default:
+			usage(argv[0]);
+			exit(-1);
+			break;
+		}
+	}
+
+	if (use_dmabuf_reg)
+		dmabuf_reg_open();
+
+	if (buf_location != MALLOC)
+		xe_init(gpu_dev_nums, 0);
+
+	init_buf();
+	init_ofi();
+	reg_mr();
+
+	dereg_mr();
+	finalize_ofi();
+	free_buf();
+
+	if (use_dmabuf_reg)
+		dmabuf_reg_close();
+
+	return 0;
+}
+

--- a/fabtests/component/dmabuf-rdma/fi-rdmabw-xe.c
+++ b/fabtests/component/dmabuf-rdma/fi-rdmabw-xe.c
@@ -1,0 +1,1132 @@
+/*
+ * Copyright (c) 2021-2022 Intel Corporation.  All rights reserved.
+ *
+ * This software is available to you under the BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ *	fi-rdmabw-xe.c
+ *
+ *	This is a libfabric veriosn of the RDMA bandwidth test with buffers
+ *	allocated via oneAPI L0 functions. Kernel and user space RDMA/dma-buf
+ *	support is required (kernel 5.12 or later, rdma-core v34 and later,
+ *	or MOFED 5.5 and later).
+ *
+ * 	Examples of running the test on a single node:
+ *
+ *	RDMA write host memory --> device memory:
+ *
+ *	    ./fi-rdmabw-xe -m device -d 0 &
+ *	    sleep 1 &&
+ *	    ./fi-rdmabw-xe -m host -t write localhost
+ *
+ *	RDMA read host memory <-- device memory:
+ *
+ *	    ./fi-rdmabw-xe -m device -d 0 &
+ *	    sleep 1 &&
+ *	    ./fi-rdmabw-xe -m host -t read localhost
+ *
+ *	RDMA write between memory on the same device:
+ *
+ *	    ./fi-rdmabw-xe -m device -d 0 &
+ *	    sleep 1 &&
+ *	    ./fi-rdmabw-xe -m device -d 0 -t write localhost
+ *
+ *	RDMA write test between memory on different devices:
+ *
+ *	    ./fi-rdmabw-xe -m device -d 0 &
+ *	    sleep 1 &&
+ *	    ./fi-rdmabw-xe -m device -d 1 -t write localhost
+ *
+ *	RDMA write test between memory on different devices, use specified
+ *	network interface (as OFI domain name):
+ *
+ *	    ./fi-rdmabw-xe -m device -d 0 -D mlx5_0 &
+ *	    sleep 1 &&
+ *	    ./fi-rdmabw-xe -m device -d 1 -D mlx5_1 -t write localhost
+ *
+ *	For more options:
+ *
+ *	    ./fi-rdmabw-xe -h
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include <arpa/inet.h>
+#include <rdma/fabric.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_cm.h>
+#include <rdma/fi_tagged.h>
+#include <rdma/fi_rma.h>
+#include <rdma/fi_atomic.h>
+#include <rdma/fi_errno.h>
+#include <level_zero/ze_api.h>
+#include "util.h"
+#include "xe.h"
+
+#define MAX_SIZE	(4*1024*1024)
+#define MIN_PROXY_BLOCK	(131072)
+#define TX_DEPTH	(128)
+#define RX_DEPTH	(1)
+#define MAX_NICS	(4)
+
+enum test_type {
+	READ,
+	WRITE,
+	SEND,
+	RECV, /* internal use only */
+};
+
+static struct business_card {
+	int num_nics;
+	int num_gpus;
+	struct {
+		struct {
+			uint64_t	one;
+			uint64_t	two;
+			uint64_t	three;
+			uint64_t	four;
+		} ep_name;
+	} nics[MAX_NICS];
+	struct {
+		uint64_t	addr;
+		uint64_t	rkeys[MAX_NICS];
+	} bufs[MAX_GPUS];
+} me, peer;
+
+static char			*server_name;
+static char			*prov_name;
+static char			*domain_names;
+static int			client;
+static int			ep_type = FI_EP_RDM;
+
+struct nic {
+	struct fi_info		*fi, *fi_pep;
+	struct fid_fabric	*fabric;
+	struct fid_eq		*eq;
+	struct fid_domain	*domain;
+	struct fid_pep		*pep;
+	struct fid_ep		*ep;
+	struct fid_av		*av;
+	struct fid_cq		*cq;
+	fi_addr_t		peer_addr;
+};
+
+static struct nic 		nics[MAX_NICS];
+static int			num_nics;
+
+struct buf {
+	struct xe_buf		xe_buf;
+	struct fid_mr		*mrs[MAX_NICS];
+};
+
+static int			num_gpus;
+static struct buf		bufs[MAX_GPUS];
+static struct buf		proxy_buf;
+static int			buf_location = MALLOC;
+
+static int			use_proxy;
+static int			proxy_block = MAX_SIZE;
+static int			use_sync_ofi;
+static int			verify;
+
+static void init_buf(size_t buf_size, char c)
+{
+	int page_size = sysconf(_SC_PAGESIZE);
+	int i;
+	void *buf;
+
+	for (i = 0; i < num_gpus; i++) {
+		buf = xe_alloc_buf(page_size, buf_size, buf_location, i,
+				   &bufs[i].xe_buf);
+		if (!buf) {
+			fprintf(stderr, "Couldn't allocate work buf.\n");
+			exit(-1);
+		}
+
+		xe_set_buf(buf, c, buf_size, buf_location, i);
+	}
+
+	if (buf_location == DEVICE && use_proxy) {
+		if (!xe_alloc_buf(page_size, buf_size, HOST, 0,
+				  &proxy_buf.xe_buf)) {
+			fprintf(stderr, "Couldn't allocate proxy buf.\n");
+			exit(-1);
+		}
+	}
+}
+
+static void check_buf(size_t size, char c, int gpu)
+{
+	unsigned long mismatches = 0;
+	int i;
+	char *bounce_buf;
+
+	bounce_buf = malloc(size);
+	if (!bounce_buf) {
+		perror("malloc bounce buffer");
+		return;
+	}
+
+	xe_copy_buf(bounce_buf, bufs[gpu].xe_buf.buf, size, gpu);
+
+	for (i = 0; i < size; i++)
+		if (bounce_buf[i] != c) {
+			mismatches++;
+			if (mismatches < 10)
+			printf("value at [%d] is '%c'(0x%02x), expecting '%c'(0x%02x)\n",
+				i, bounce_buf[i], bounce_buf[i], c, c);
+		}
+
+	free(bounce_buf);
+
+	if (mismatches)
+		printf("%lu mismatches found\n", mismatches);
+	else
+		printf("all %lu bytes are correct.\n", size);
+}
+
+static void free_buf(void)
+{
+	int i;
+
+	for (i = 0; i < num_gpus; i++)
+		xe_free_buf(bufs[i].xe_buf.buf, bufs[i].xe_buf.location);
+
+	if (use_proxy)
+		xe_free_buf(proxy_buf.xe_buf.buf, proxy_buf.xe_buf.location);
+}
+
+/*
+ * Fabric setup & tear-down
+ */
+
+static int wait_conn_req(struct fid_eq *eq, struct fi_info **fi)
+{
+	struct fi_eq_cm_entry entry;
+	struct fi_eq_err_entry err_entry;
+	uint32_t event;
+	ssize_t ret;
+
+	ret = fi_eq_sread(eq, &event, &entry, sizeof(entry), -1, 0);
+	if (ret != sizeof entry) {
+		printf("%s: fi_eq_sread returned %ld, expecting %ld\n",
+			__func__, ret, sizeof(entry));
+		if (ret == -FI_EAVAIL) {
+			fi_eq_readerr(eq, &err_entry, 0);
+			printf("%s: error %d prov_errno %d\n", __func__,
+				err_entry.err, err_entry.prov_errno);
+		}
+		return (int) ret;
+	}
+
+	*fi = entry.info;
+	if (event != FI_CONNREQ) {
+		printf("%s: unexpected CM event %d\n", __func__, event);
+		return -FI_EOTHER;
+	}
+
+	return 0;
+}
+
+static int wait_connected(struct fid_ep *ep, struct fid_eq *eq)
+{
+	struct fi_eq_cm_entry entry;
+	struct fi_eq_err_entry err_entry;
+	uint32_t event;
+	ssize_t ret;
+
+	ret = fi_eq_sread(eq, &event, &entry, sizeof(entry), -1, 0);
+	if (ret != sizeof(entry)) {
+		printf("%s: fi_eq_sread returns %ld, expecting %ld\n",
+			__func__, ret, sizeof(entry));
+		if (ret == -FI_EAVAIL) {
+			fi_eq_readerr(eq, &err_entry, 0);
+			printf("%s: error %d prov_errno %d\n", __func__,
+				err_entry.err, err_entry.prov_errno);
+		}
+		return (int)ret;
+	}
+
+	if (event != FI_CONNECTED || entry.fid != &ep->fid) {
+		printf("%s: unexpected CM event %d fid %p (ep %p)\n",
+			__func__, event, entry.fid, ep);
+		return -FI_EOTHER;
+	}
+
+	return 0;
+}
+
+static int init_nic(int nic, char *domain_name, char *server_name, int port,
+		    int test_type)
+{
+	struct fi_info *fi, *fi_pep = NULL;
+	struct fid_fabric *fabric;
+	struct fid_eq *eq = NULL;
+	struct fid_domain *domain;
+	struct fid_pep *pep = NULL;
+	struct fid_ep *ep;
+	struct fid_av *av;
+	struct fid_cq *cq;
+	struct fid_mr *mr = NULL;
+	struct fi_info *hints;
+	struct fi_cq_attr cq_attr = { .format = FI_CQ_FORMAT_CONTEXT };
+	struct fi_av_attr av_attr = {};
+	struct fi_mr_attr mr_attr = {};
+	struct fi_eq_attr eq_attr = { .wait_obj = FI_WAIT_UNSPEC };
+	struct iovec iov;
+	int version;
+	char port_name[16];
+	int i;
+
+	EXIT_ON_NULL((hints = fi_allocinfo()));
+
+	hints->ep_attr->type = ep_type;
+	hints->ep_attr->tx_ctx_cnt = 1;
+	hints->ep_attr->rx_ctx_cnt = 1;
+	if (prov_name)
+		hints->fabric_attr->prov_name = strdup(prov_name);
+	hints->caps = FI_MSG | FI_RMA | FI_HMEM;
+	hints->domain_attr->control_progress = FI_PROGRESS_MANUAL;
+	hints->domain_attr->data_progress = FI_PROGRESS_MANUAL;
+	hints->domain_attr->mr_mode = FI_MR_ALLOCATED | FI_MR_PROV_KEY |
+				      FI_MR_VIRT_ADDR | FI_MR_LOCAL |
+				      FI_MR_HMEM | FI_MR_ENDPOINT;
+	if (domain_name)
+		hints->domain_attr->name = strdup(domain_name);
+
+	sprintf(port_name, "%d", port);
+	version = FI_VERSION(1, 12);
+	if (ep_type == FI_EP_MSG) {
+		if (client)
+			EXIT_ON_ERROR(fi_getinfo(version, server_name,
+						 port_name, 0, hints, &fi));
+		else
+			EXIT_ON_ERROR(fi_getinfo(version, server_name,
+						 port_name, FI_SOURCE, hints,
+						 &fi));
+	} else {
+		EXIT_ON_ERROR(fi_getinfo(version, NULL, NULL, 0, hints, &fi));
+	}
+
+	fi_freeinfo(hints);
+
+	if (ep_type == FI_EP_RDM || client)
+		printf("Using OFI device: %s (%s)\n",
+			fi->fabric_attr->prov_name, fi->domain_attr->name);
+
+	EXIT_ON_ERROR(fi_fabric(fi->fabric_attr, &fabric, NULL));
+	if (ep_type == FI_EP_MSG) {
+		EXIT_ON_ERROR(fi_eq_open(fabric, &eq_attr, &eq, NULL));
+		if (!client) {
+			fi_pep = fi;
+			EXIT_ON_ERROR(fi_passive_ep(fabric, fi_pep, &pep, NULL));
+			EXIT_ON_ERROR(fi_pep_bind(pep, (fid_t)eq, 0));
+			EXIT_ON_ERROR(fi_listen(pep));
+			EXIT_ON_ERROR(wait_conn_req(eq, &fi));
+			printf("Using OFI device: %s (%s)\n",
+				fi_pep->fabric_attr->prov_name,
+				fi->domain_attr->name);
+		}
+	}
+	EXIT_ON_ERROR(fi_domain(fabric, fi, &domain, NULL));
+	EXIT_ON_ERROR(fi_endpoint(domain, fi, &ep, NULL));
+	EXIT_ON_ERROR(fi_cq_open(domain, &cq_attr, &cq, NULL));
+	if (ep_type == FI_EP_RDM) {
+		EXIT_ON_ERROR(fi_av_open(domain, &av_attr, &av, NULL));
+		EXIT_ON_ERROR(fi_ep_bind(ep, (fid_t)av, 0));
+	} else {
+		EXIT_ON_ERROR(fi_ep_bind(ep, (fid_t)eq, 0));
+	}
+	EXIT_ON_ERROR(fi_ep_bind(ep, (fid_t)cq,
+		    (FI_TRANSMIT | FI_RECV | FI_SELECTIVE_COMPLETION)));
+	EXIT_ON_ERROR(fi_enable(ep));
+
+	if (ep_type == FI_EP_MSG) {
+		if (client)
+			EXIT_ON_ERROR(fi_connect(ep, fi->dest_addr, NULL, 0));
+		else
+			EXIT_ON_ERROR(fi_accept(ep, NULL, 0));
+		EXIT_ON_ERROR(wait_connected(ep, eq));
+	}
+
+	if (test_type == SEND &&
+	    !(fi->domain_attr->mr_mode & (FI_MR_HMEM | FI_MR_LOCAL))) {
+		printf("Local MR registration skipped.\n");
+		goto done;
+	}
+
+	for (i = 0; i < num_gpus; i++) {
+		iov.iov_base = bufs[i].xe_buf.buf;
+		iov.iov_len = MAX_SIZE;
+		mr_attr.mr_iov = &iov;
+		mr_attr.iov_count = 1;
+		mr_attr.access = FI_REMOTE_READ | FI_REMOTE_WRITE;
+		mr_attr.requested_key = 1;
+		mr_attr.iface = bufs[i].xe_buf.location == MALLOC ?
+					FI_HMEM_SYSTEM : FI_HMEM_ZE;
+		mr_attr.device.ze = xe_get_dev_num(i);
+		EXIT_ON_ERROR(fi_mr_regattr(domain, &mr_attr, 0, &mr));
+
+		if (fi->domain_attr->mr_mode & FI_MR_ENDPOINT) {
+			EXIT_ON_ERROR(fi_mr_bind(mr, (fid_t)ep, 0));
+			EXIT_ON_ERROR(fi_mr_enable(mr));
+		}
+
+		bufs[i].mrs[nic] = mr;
+	}
+
+	if (buf_location == DEVICE && use_proxy) {
+		iov.iov_base = proxy_buf.xe_buf.buf;
+		iov.iov_len = MAX_SIZE;
+		mr_attr.mr_iov = &iov;
+		mr_attr.iov_count = 1;
+		mr_attr.access = FI_REMOTE_READ | FI_REMOTE_WRITE;
+		mr_attr.requested_key = 1;
+		mr_attr.iface = FI_HMEM_ZE;
+		mr_attr.device.ze = xe_get_dev_num(i);
+		EXIT_ON_ERROR(fi_mr_regattr(domain, &mr_attr, 0, &mr));
+
+		if (fi->domain_attr->mr_mode & FI_MR_ENDPOINT) {
+			EXIT_ON_ERROR(fi_mr_bind(mr, (fid_t)ep, 0));
+			EXIT_ON_ERROR(fi_mr_enable(mr));
+		}
+
+		proxy_buf.mrs[nic] = mr;
+	}
+
+done:
+	nics[nic].fi = fi;
+	nics[nic].fi_pep = fi_pep;
+	nics[nic].fabric = fabric;
+	nics[nic].eq = eq;
+	nics[nic].domain = domain;
+	nics[nic].pep = pep;
+	nics[nic].ep = ep;
+	nics[nic].av = av;
+	nics[nic].cq = cq;
+	return 0;
+}
+
+static void show_business_card(struct business_card *bc, char *name)
+{
+	int i, j;
+
+	printf("%s:\tnum_nics %d num_gpus %d ", name, bc->num_nics,
+		bc->num_gpus);
+	for (i = 0; i < bc->num_nics; i++) {
+		printf("[NIC %d] %lx:%lx:%lx:%lx ", i,
+			bc->nics[i].ep_name.one, bc->nics[i].ep_name.two,
+			bc->nics[i].ep_name.three, bc->nics[i].ep_name.four);
+	}
+	for (i = 0; i < bc->num_gpus; i++) {
+		printf("[BUF %d] addr %lx rkeys (", i, bc->bufs[i].addr);
+		for (j = 0; j < bc->num_nics; j++)
+			printf("%lx ", bc->bufs[i].rkeys[j]);
+		printf(") ");
+	}
+	printf("\n");
+
+}
+
+static void init_ofi(int sockfd, char *server_name, int port, int test_type)
+{
+	int i, j;
+	int err;
+	size_t len;
+	char *domain_name;
+
+	num_nics = 0;
+	if (domain_names) {
+		domain_name = strtok(domain_names, ",");
+		while (domain_name && num_nics < MAX_NICS) {
+			err = init_nic(num_nics, domain_name, server_name,
+				       port, test_type);
+			if (err)
+				return;
+			num_nics++;
+			domain_name = strtok(NULL, ",");
+		}
+	} else {
+		err = init_nic(num_nics, NULL, server_name, port, test_type);
+		if (err)
+			return;
+		num_nics++;
+	}
+
+	for (i = 0; i < num_gpus; i++) {
+		me.bufs[i].addr = (uint64_t)bufs[i].xe_buf.buf;
+		for (j = 0; j < num_nics; j++) {
+			len = sizeof(me.nics[j].ep_name);
+			EXIT_ON_ERROR(fi_getname((fid_t)nics[j].ep,
+						 &me.nics[j].ep_name, &len));
+			me.bufs[i].rkeys[j]= bufs[i].mrs[j] ?
+						fi_mr_key(bufs[i].mrs[j]) : 0;
+		}
+	}
+	me.num_nics = num_nics;
+	me.num_gpus = num_gpus;
+
+	show_business_card(&me, "Me");
+
+	EXIT_ON_ERROR(exchange_info(sockfd, sizeof(me), &me, &peer));
+
+	if (!(nics[0].fi->domain_attr->mr_mode & FI_MR_VIRT_ADDR)) {
+		for (i = 0; i < num_gpus; i++)
+			peer.bufs[i].addr = 0;
+	}
+
+	show_business_card(&peer, "Peer");
+
+	if (me.num_nics != peer.num_nics) {
+		printf("The number of network devices doesn't match. Exiting\n");
+		exit(-1);
+	}
+
+	if (ep_type == FI_EP_MSG)
+		return;
+
+	for (i = 0; i < num_nics; i++) {
+		EXIT_ON_NEG_ERROR(fi_av_insert(nics[i].av, &peer.nics[i].ep_name,
+					       1, &nics[i].peer_addr, 0, NULL));
+	}
+
+	return;
+}
+
+static void finalize_ofi(void)
+{
+	int i, j;
+
+	for (i = 0; i < num_nics; i++) {
+		if (buf_location == DEVICE && use_proxy && proxy_buf.mrs[i])
+			fi_close((fid_t)proxy_buf.mrs[i]);
+		for (j = 0; j < num_gpus ; j++)
+			if (bufs[j].mrs[i])
+				fi_close((fid_t)bufs[j].mrs[i]);
+		fi_close((fid_t)nics[i].ep);
+		if (ep_type == FI_EP_RDM)
+			fi_close((fid_t)nics[i].av);
+		fi_close((fid_t)nics[i].cq);
+		fi_close((fid_t)nics[i].domain);
+		if (ep_type == FI_EP_MSG && !client)
+			fi_close((fid_t)nics[i].pep);
+		if (ep_type == FI_EP_MSG)
+			fi_close((fid_t)nics[i].eq);
+		fi_close((fid_t)nics[i].fabric);
+		fi_freeinfo(nics[i].fi);
+		if (ep_type == FI_EP_MSG && !client)
+			fi_freeinfo(nics[i].fi_pep);
+	}
+}
+
+/*
+ * Test routines
+ */
+
+static int post_rdma(int nic, int gpu, int rgpu, int test_type, size_t size,
+		     int idx, int signaled)
+{
+	struct iovec iov;
+	void *desc = fi_mr_desc(bufs[gpu].mrs[nic]);
+	struct fi_rma_iov rma_iov;
+	struct fi_msg_rma msg;
+	int err;
+
+	iov.iov_base = (char *)bufs[gpu].xe_buf.buf + idx * size;
+	iov.iov_len = size;
+	rma_iov.addr = peer.bufs[rgpu].addr + idx * size;
+	rma_iov.len = size;
+	rma_iov.key = peer.bufs[rgpu].rkeys[nic];
+	msg.msg_iov = &iov;
+	msg.desc = &desc;
+	msg.iov_count = 1;
+	msg.addr = nics[nic].peer_addr;
+	msg.rma_iov = &rma_iov;
+	msg.rma_iov_count = 1;
+	msg.context = NULL;
+	msg.data = 0;
+
+try_again:
+	if (test_type == READ)
+		err = fi_readmsg(nics[nic].ep, &msg,
+				 signaled ? FI_COMPLETION : 0);
+	else
+		err = fi_writemsg(nics[nic].ep, &msg,
+				  signaled ? FI_COMPLETION : 0);
+
+	if (err == -FI_EAGAIN) {
+		fi_cq_read(nics[nic].cq, NULL, 0);
+		goto try_again;
+	}
+
+	return err;
+}
+
+static int post_proxy_write(int nic, int gpu, int rgpu, size_t size, int idx,
+			    int signaled)
+{
+	uintptr_t offset = idx * size;
+	struct iovec iov;
+	void *desc = fi_mr_desc(proxy_buf.mrs[nic]);
+	struct fi_rma_iov rma_iov;
+	struct fi_msg_rma msg;
+	size_t sent, block_size = proxy_block;
+	int flags = 0;
+	int ret;
+
+	iov.iov_base = (char *)proxy_buf.xe_buf.buf + offset;
+	iov.iov_len = proxy_block;
+	rma_iov.addr = peer.bufs[rgpu].addr + offset;
+	rma_iov.len = proxy_block;
+	rma_iov.key = peer.bufs[rgpu].rkeys[nic];
+	msg.msg_iov = &iov;
+	msg.desc = &desc;
+	msg.iov_count = 1;
+	msg.addr = nics[nic].peer_addr;
+	msg.rma_iov = &rma_iov;
+	msg.rma_iov_count = 1;
+	msg.context = NULL;
+	msg.data = 0;
+
+	for (sent = 0; sent < size;) {
+		if (block_size >= size - sent) {
+			block_size = size - sent;
+			iov.iov_len = block_size;
+			rma_iov.len = block_size;
+			flags = signaled ? FI_COMPLETION : 0;
+		}
+
+		xe_copy_buf((char *)proxy_buf.xe_buf.buf + offset + sent,
+			    (char *)bufs[gpu].xe_buf.buf + offset + sent,
+			    block_size, gpu);
+
+try_again:
+		ret = fi_writemsg(nics[nic].ep, &msg, flags);
+		if (ret == -FI_EAGAIN) {
+			fi_cq_read(nics[nic].cq, NULL, 0);
+			goto try_again;
+		} else if (ret) {
+			break;
+		}
+
+		sent += block_size;
+		iov.iov_base = (char *)iov.iov_base + block_size;
+		rma_iov.addr += block_size;
+	}
+
+	return ret;
+}
+
+static int post_proxy_send(int nic, int gpu, size_t size, int idx, int signaled)
+{
+	uintptr_t offset = idx * size;
+	struct iovec iov;
+	void *desc = proxy_buf.mrs[nic] ? fi_mr_desc(proxy_buf.mrs[nic]) : NULL;
+	struct fi_msg msg;
+	size_t sent, block_size = proxy_block;
+	int flags = 0;
+	int ret;
+
+	iov.iov_base = (char *)proxy_buf.xe_buf.buf + offset;
+	iov.iov_len = proxy_block;
+	msg.msg_iov = &iov;
+	msg.desc = proxy_buf.mrs[nic] ? &desc : NULL;
+	msg.iov_count = 1;
+	msg.addr = nics[nic].peer_addr;
+	msg.context = NULL;
+	msg.data = 0;
+
+	for (sent = 0; sent < size;) {
+		if (block_size >= size - sent) {
+			block_size = size - sent;
+			iov.iov_len = block_size;
+			flags = signaled ? FI_COMPLETION : 0;
+		}
+
+		xe_copy_buf((char *)proxy_buf.xe_buf.buf + offset + sent,
+			    (char *)bufs[gpu].xe_buf.buf + offset + sent,
+			    block_size, gpu);
+
+try_again:
+		ret = fi_sendmsg(nics[nic].ep, &msg, flags);
+		if (ret == -FI_EAGAIN) {
+			fi_cq_read(nics[nic].cq, NULL, 0);
+			goto try_again;
+		} else if (ret) {
+			break;
+		}
+
+		sent += block_size;
+		iov.iov_base = (char *)iov.iov_base + block_size;
+	}
+
+	return ret;
+}
+
+static int post_send(int nic, int gpu, size_t size, int idx, int signaled)
+{
+	struct iovec iov;
+	void *desc = bufs[gpu].mrs[nic] ? fi_mr_desc(bufs[gpu].mrs[nic]) : NULL;
+	struct fi_msg msg;
+	int ret;
+
+	iov.iov_base = (char *)bufs[gpu].xe_buf.buf + idx * size;
+	iov.iov_len = size;
+	msg.msg_iov = &iov;
+	msg.desc = bufs[gpu].mrs[nic] ? &desc : NULL;
+	msg.iov_count = 1;
+	msg.addr = nics[nic].peer_addr;
+	msg.context = NULL;
+	msg.data = 0;
+
+try_again:
+	ret = fi_sendmsg(nics[nic].ep, &msg, signaled ? FI_COMPLETION : 0);
+	if (ret == -FI_EAGAIN) {
+		fi_cq_read(nics[nic].cq, NULL, 0);
+		goto try_again;
+	}
+	return ret;
+}
+
+static int post_recv(int nic, int gpu, size_t size, int idx)
+{
+	struct iovec iov;
+	void *desc = bufs[gpu].mrs[nic] ? fi_mr_desc(bufs[gpu].mrs[nic]) : NULL;
+	struct fi_msg msg;
+	int ret;
+
+	iov.iov_base = (char *)bufs[gpu].xe_buf.buf + idx * size;
+	iov.iov_len = size;
+	msg.msg_iov = &iov;
+	msg.desc = bufs[gpu].mrs[nic] ? &desc : NULL;
+	msg.iov_count = 1;
+	msg.addr = nics[nic].peer_addr;
+	msg.context = NULL;
+	msg.data = 0;
+
+try_again:
+	ret = fi_recvmsg(nics[nic].ep, &msg, FI_COMPLETION);
+	if (ret == -FI_EAGAIN) {
+		fi_cq_read(nics[nic].cq, NULL, 0);
+		goto try_again;
+	}
+	return ret;
+}
+
+static inline void wait_completion(int n)
+{
+	struct fi_cq_entry wc[16];
+	struct fi_cq_err_entry error;
+	int ret, completed = 0;
+	int i;
+
+	while (completed < n) {
+		for (i = 0; i < num_nics; i++) {
+			ret = fi_cq_read(nics[i].cq, wc, 16);
+			if (ret == -FI_EAGAIN)
+				continue;
+			if (ret < 0) {
+				fi_cq_readerr(nics[i].cq, &error, 0);
+				fprintf(stderr,
+					"Completion with error: %s (err %d prov_errno %d).\n",
+					fi_strerror(error.err), error.err,
+					error.prov_errno);
+				return;
+			}
+			completed += ret;
+		}
+	}
+}
+
+static void sync_ofi(size_t size)
+{
+	int i;
+
+	for (i = 0; i < num_nics; i++) {
+		EXIT_ON_ERROR(post_recv(i, 0, size, 0));
+		EXIT_ON_ERROR(post_send(i, 0, size, 0, 1));
+	}
+
+	wait_completion(num_nics * 2);
+	return;
+}
+
+static void sync_send(size_t size)
+{
+	int i;
+
+	for (i = 0; i < num_nics; i++)
+		EXIT_ON_ERROR(post_send(i, 0, size, 0, 1));
+	wait_completion(num_nics);
+	return;
+}
+
+static void sync_recv(size_t size)
+{
+	int i;
+
+	for (i = 0; i < num_nics; i++)
+		EXIT_ON_ERROR(post_recv(i, 0, size, 0));
+	wait_completion(num_nics);
+	return;
+}
+
+int run_test(int test_type, int size, int iters, int batch, int output_result)
+{
+	int i, j, completed, pending;
+	int n, n0;
+	double t1, t2;
+	struct fi_cq_entry wc[16];
+	struct fi_cq_err_entry error;
+	int signaled;
+	int nic, gpu, rgpu;
+
+	t1 = when();
+	for (i = completed = pending = 0; i < iters || completed < iters;) {
+		while (i < iters && pending < TX_DEPTH) {
+			nic = i % num_nics;
+			gpu = i % num_gpus;
+			rgpu = i % peer.num_gpus;
+			signaled = ((i / num_nics) % batch) == batch -1 ||
+				   i >= iters - num_nics;
+			switch (test_type) {
+			case WRITE:
+				if (buf_location == DEVICE && use_proxy)
+					CHECK_ERROR(post_proxy_write(nic, gpu,
+								     rgpu, size,
+								     i % batch,
+								     signaled));
+				else
+					CHECK_ERROR(post_rdma(nic, gpu, rgpu,
+							      test_type, size,
+							      i % batch,
+							      signaled));
+				break;
+			case READ:
+				CHECK_ERROR(post_rdma(nic, gpu, rgpu,
+						      test_type, size,
+						      i % batch, signaled));
+				break;
+			case SEND:
+				if (buf_location == DEVICE && use_proxy)
+					CHECK_ERROR(post_proxy_send(nic, gpu,
+								    size,
+								    i % batch,
+								    signaled));
+				else
+					CHECK_ERROR(post_send(nic, gpu, size,
+							      i % batch, signaled));
+				break;
+			case RECV:
+				CHECK_ERROR(post_recv(nic, gpu, size, i % batch));
+				break;
+			}
+			nic = (nic + 1) % num_nics;
+			pending++;
+			i++;
+		}
+		do {
+			n0 = 0;
+			for (j = 0; j < num_nics; j++) {
+				n = fi_cq_read(nics[j].cq, wc, 16);
+				if (n == -FI_EAGAIN) {
+					continue;
+				} else if (n < 0) {
+					fi_cq_readerr(nics[j].cq, &error, 0);
+					fprintf(stderr,
+						"Completion with error: %s (err %d prov_errno %d).\n",
+						fi_strerror(error.err),
+						error.err, error.prov_errno);
+					return -1;
+				} else {
+					pending -= n * batch;
+					completed += n * batch;
+					n0 += n;
+				}
+			}
+		} while (n0 > 0);
+	}
+
+	if (test_type == SEND)
+		sync_recv(4);
+
+	if (test_type == RECV)
+		sync_send(4);
+
+	t2 = when();
+
+	if (test_type == RECV)
+		return 0;
+
+	if (output_result)
+		printf("%10d (x %4d) %10.2lf us %12.2lf MB/s\n", size, iters,
+		       (t2 - t1), (long)size * iters / (t2 - t1));
+
+	return 0;
+
+err_out:
+	printf("%10d aborted due to fail to post read request\n", size);
+	return -1;
+}
+
+static void usage(char *prog)
+{
+	printf("Usage: %s [options][server_name]\n", prog);
+	printf("Options:\n");
+	printf("\t-m <location>    Where to allocate the buffer, can be 'malloc', 'host', 'device' or 'shared', default: malloc\n");
+	printf("\t-d <gpu_devs>    Use the GPU device(s) specified as comma separated list of <dev>[.<subdev>], default: 0\n");
+	printf("\t-e <ep_type>     Set the endpoint type, can be 'rdm' or 'msg', default: rdm\n");
+	printf("\t-p <prov_name>   Use the OFI provider named as <prov_name>, default: the first one\n");
+	printf("\t-D <domain_names> Open OFI domain(s) specified as comma separated list of <domain_name>, default: automatic\n");
+	printf("\t-n <iters>       Set the number of iterations for each message size, default: 1000\n");
+	printf("\t-S <size>        Set the message size to test (0: all, -1: none), default: 0\n");
+	printf("\t-t <test_type>   Type of test to perform, can be 'read', 'write', or 'send', default: read\n");
+	printf("\t-P               Proxy device buffer through host buffer (for write and send only), default: off\n");
+	printf("\t-B <block_size>  Set the block size for proxying, default: maximum message size\n");
+	printf("\t-r               Reverse the direction of data movement (server initates RDMA ops)\n");
+	printf("\t-R               Enable dmabuf_reg (plug-in for MOFED peer-memory)\n");
+	printf("\t-s               Sync with send/recv at the end\n");
+	printf("\t-v               Verify the data (for read test only)\n");
+	printf("\t-h               Print this message\n");
+}
+
+static inline int string_to_location(char *s, int default_loc)
+{
+	int loc;
+
+	if (strcasecmp(s, "malloc") == 0)
+		loc = MALLOC;
+	else if (strcasecmp(s, "host") == 0)
+		loc = HOST;
+	else if (strcasecmp(s, "device") == 0)
+		loc = DEVICE;
+	else if (strcasecmp(s, "shared") == 0)
+		loc = SHARED;
+	else
+		loc = default_loc;
+
+	return loc;
+}
+
+void parse_buf_location(char *string, int *loc1, int *loc2, int default_loc)
+{
+	char *s;
+
+	s = strtok(string, ":");
+	if (s) {
+		*loc1 = string_to_location(s, default_loc);
+		s = strtok(NULL, ":");
+		if (s)
+			*loc2 = string_to_location(s, default_loc);
+		else
+			*loc2 = *loc1;
+	} else {
+		*loc1 = *loc2 = default_loc;
+	}
+}
+
+int main(int argc, char *argv[])
+{
+	char *gpu_dev_nums = NULL;
+	int enable_multi_gpu;
+	unsigned int port = 12345;
+	int test_type = READ;
+	int iters = 1000;
+	int batch = 1; /* was 16. however, when > 1, for large messages, rxd
+			* hangs and rxm gets i/o error (err=5, prov_errno=10)
+			*/
+	int reverse = 0;
+	int sockfd;
+	int size;
+	int c;
+	int initiator;
+	int msg_size = 0;
+	int err = 0;
+	int rank;
+	char *s;
+	int loc1 = MALLOC, loc2 = MALLOC;
+
+	while ((c = getopt(argc, argv, "d:D:e:p:m:n:t:gPB:rRsS:hv")) != -1) {
+		switch (c) {
+		case 'd':
+			gpu_dev_nums = strdup(optarg);
+			break;
+		case 'D':
+			domain_names = strdup(optarg);
+			break;
+		case 'e':
+			if (strcasecmp(optarg, "rdm") == 0)
+				ep_type = FI_EP_RDM;
+			else if (strcasecmp(optarg, "msg") == 0)
+				ep_type = FI_EP_MSG;
+			break;
+		case 'p':
+			prov_name = strdup(optarg);
+			break;
+		case 'm':
+			parse_buf_location(optarg, &loc1, &loc2, MALLOC);
+			break;
+		case 'n':
+			iters = atoi(optarg);
+			break;
+		case 't':
+			if (strcasecmp(optarg, "read") == 0)
+				test_type = READ;
+			else if (strcasecmp(optarg, "write") == 0)
+				test_type = WRITE;
+			else if (strcasecmp(optarg, "send") == 0)
+				test_type = SEND;
+			break;
+		case 'P':
+			use_proxy = 1;
+			break;
+		case 'B':
+			proxy_block = atoi(optarg);
+			if (proxy_block < MIN_PROXY_BLOCK) {
+				fprintf(stderr,
+					"Block size too small, adjusted to %d\n",
+					MIN_PROXY_BLOCK);
+				proxy_block = MIN_PROXY_BLOCK;
+			}
+			break;
+		case 'r':
+			reverse = 1;
+			break;
+		case 'R':
+			use_dmabuf_reg = 1;
+			break;
+		case 's':
+			use_sync_ofi = 1;
+			break;
+		case 'S':
+			msg_size = atoi(optarg);
+			break;
+		case 'v':
+			verify = 1;
+			break;
+		default:
+			usage(argv[0]);
+			exit(-1);
+			break;
+		}
+	}
+
+	if (argc > optind) {
+		client = 1;
+		server_name = strdup(argv[optind]);
+	}
+
+	/*
+	 * If started by a job launcher, perform pair-wise test.
+	 */
+	s = getenv("PMI_RANK");
+	if (s) {
+		rank = atoi(s);
+		client = rank % 2;
+		port += rank >> 1;
+		if (!client && server_name) {
+			free(server_name);
+			server_name = NULL;
+		}
+	}
+
+	buf_location = client ? loc2 : loc1;
+
+	sockfd = connect_tcp(server_name, port);
+	if (sockfd < 0) {
+		fprintf(stderr, "Cannot create socket connection\n");
+		exit(-1);
+	}
+
+	initiator = (!reverse && server_name) || (reverse && !server_name);
+
+	if (use_dmabuf_reg)
+		dmabuf_reg_open();
+
+	/* multi-GPU test doesn't make sense if buffers are on the host */
+	enable_multi_gpu = buf_location != MALLOC && buf_location != HOST;
+	num_gpus = xe_init(gpu_dev_nums, enable_multi_gpu);
+
+	init_buf(MAX_SIZE * batch, initiator ? 'A' : 'a');
+	init_ofi(sockfd, server_name, port + 1000, test_type);
+
+	sync_tcp(sockfd);
+	printf("Warming up ...\n");
+	if (initiator) {
+		run_test(test_type, 1, 16, 1, 0);
+		sync_send(4);
+	} else {
+		if (test_type == SEND)
+			run_test(RECV, 1, 16, 1, 0);
+		sync_recv(4);
+	}
+
+	sync_tcp(sockfd);
+	printf("Start test ...\n");
+	for (size = 1; size <= MAX_SIZE && !err; size <<= 1) {
+		if (msg_size < 0)
+			break;
+		else if (msg_size > 0)
+			size = msg_size;
+		if (initiator) {
+			err = run_test(test_type, size, iters, batch, 1);
+			sync_send(4);
+		} else {
+			if (test_type == SEND)
+				err = run_test(RECV, size, iters, 1, 1);
+			sync_recv(4);
+		}
+		sync_tcp(sockfd);
+		if (verify) {
+			if (test_type == READ)
+				check_buf(size, 'a', 0);
+			else
+				check_buf(size, 'A', 0);
+		}
+		if (msg_size)
+			break;
+	}
+	sync_tcp(sockfd);
+
+	if (use_sync_ofi)
+		sync_ofi(4);
+
+	finalize_ofi();
+	free_buf();
+
+	if (use_dmabuf_reg)
+		dmabuf_reg_close();
+
+	close(sockfd);
+
+	return 0;
+}
+

--- a/fabtests/component/dmabuf-rdma/memcopy-xe.c
+++ b/fabtests/component/dmabuf-rdma/memcopy-xe.c
@@ -1,0 +1,662 @@
+/*
+ * Copyright (c) 2021-2022 Intel Corporation.  All rights reserved.
+ *
+ * This software is available to you under the BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ *	memcopy-xe.c
+ *
+ *	This is a memory copy bandwidth test with buffers allocated via oneAPI L0
+ *	functions.
+ *
+ *	Copy using memcpy() between buffers allocated with malloc():
+ *
+ *	    ./memcopy-xe -c memcpy M M
+ *
+ *	Copy using memcpy between buffers allocated with zeMemAllocHost():
+ *
+ *	    ./memcopy-xe -c memcpy H H
+ *
+ *	Copy using GPU between buffers allocated with zeMemAllocDevice():
+ *
+ *	    ./memcopy-xe -c cmdq D D
+ *
+ *	Copy using GPU from buffer allocated with zeMemAllocDevice() to buffer
+ *	allcated with zeMemAllocHost():
+ *
+ *	    ./memcopy-xe -c cmdq D H
+ *
+ *	Copy using GPU between buffers allocated with zeMemAllocDevice(), with
+ *	cached command list:
+ *
+ *	    ./memcopy-xe -c cmdq -C D D
+ *
+ *	Copy using GPU between buffers allocated with zeMemAllocDevice(), with
+ *	immediate command list:
+ *
+ *	    ./memcopy-xe -c cmdq -i D D
+ *
+ *	Copy using GPU between buffers allocated with zeMemAllocDevice(), using
+ *	specified device (src=dst=0):
+ *
+ *	    ./memcopy-xe -c cmdq -d 0 D D
+ *
+ *	Copy using GPU between buffers allocated with zeMemAllocDevice(), using
+ *	specified device (src=0, dst=1):
+ *
+ *	    ./memcopy-xe -c cmdq -d 0 -D 1 D D
+ *
+ *	Copy using GPU between buffers allocated with zeMemAllocDevice(), using
+ *	specified command queue group:
+ *
+ *	    ./memcopy-xe -c cmdq -G 2 D D
+ *
+ *	Copy using GPU between buffers allocated with zeMemAllocDevice(), using
+ *	specified devices, command queue group and engine index:
+ *
+ *	    ./memcopy-xe -c cmdq -d 0 -D 1 -G 2 -I 1 D D
+ *
+ *	Copy using GPU between buffers allocated with zeMemAllocDevice(), using
+ *	specified devices, 2nd device's command queue group and engine index:
+ *
+ *	    ./memcopy-xe -c cmdq -d 0 -D 1 -r -G 2 -I 1 D D
+ *
+ *	Copy using mmap + memcpy between buffers allocated with zeMemAllocDevice(),
+ *	mmap() is called before each memcpy():
+ *
+ *	    ./memcopy-xe -c mmap D D
+ *
+ *	Copy using mmap + memcpy between buffers allocated with zeMemAllocDevice(),
+ *	mmap() is called once (cached):
+ *
+ *	    ./memcopy-xe -c mmap -C D D
+ *
+ *	For more options:
+ *
+ *	    ./memcopy-xe -h
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <signal.h>
+#include <setjmp.h>
+#include <level_zero/ze_api.h>
+#include "util.h"
+
+#define MALLOC	0
+#define HOST	1
+#define DEVICE	2
+#define SHARED	3
+
+struct my_buf {
+	int where;
+	void *buf;
+	size_t size;
+	int fd;
+	void *map;
+	size_t map_size;
+};
+
+const size_t gpu_page_size = 65536;
+static int iterations = 1000;
+
+#define CMDQ		0
+#define MEMCPY		1
+#define MMAP		2
+
+static ze_result_t (*zexDriverImportExternalPointer)(ze_driver_handle_t drv,
+						     void *ptr, size_t len);
+static ze_result_t (*zexDriverReleaseImportedPointer)(ze_driver_handle_t drv,
+						      void *ptr);
+
+static int copy_method = CMDQ;
+static int use_imm_cmdl = 0;
+static int cache_cmdl = 0;
+static int cache_mmap = 0;
+static int mmap_all = 1;
+static int reverse = 0;
+static int import = 0;
+static unsigned int card_num = 0;
+static unsigned int card_num2 = 0xFF;
+static unsigned int ordinal = 0;
+static unsigned int engine_index = 0;
+
+#define MAX_MSG_SIZE	(64*1024*1024)
+
+static jmp_buf env;
+
+void segv_handler(int signum)
+{
+	printf("Segmentation fault caught while accessing device buffer\n");
+	longjmp(env, 1);
+}
+
+static struct {
+	ze_driver_handle_t	drv;
+	ze_context_handle_t	ctxt;
+	ze_device_handle_t	dev;
+	ze_device_handle_t	dev2;
+	ze_command_queue_handle_t cmdq;
+	ze_command_list_handle_t cmdl;
+} gpu;
+
+void show_device_properties(ze_device_properties_t *props)
+{
+	printf("vendor_id: 0x%x, device_id: 0x%x, name: %s, type: 0x%x, flags: 0x%x\n",
+		props->vendorId, props->deviceId, props->name, props->type,
+		props->flags);
+
+	printf("\tsubdevice_id: 0x%x, core_clock: %d, max_mem_alloc: %ld, "
+	       "max_hw_ctxts: %d, threads_per_EU: %d, slices: %d\n",
+		props->subdeviceId, props->coreClockRate,
+		props->maxMemAllocSize, props->maxHardwareContexts,
+		props->numThreadsPerEU, props->numSlices);
+}
+
+void show_cmdq_group_info(ze_device_handle_t dev)
+{
+	ze_command_queue_group_properties_t *props;
+	uint32_t cnt = 0;
+	int i;
+
+	EXIT_ON_ERROR(zeDeviceGetCommandQueueGroupProperties(dev, &cnt, NULL));
+
+	props = calloc(cnt, sizeof(ze_command_queue_group_properties_t));
+	if (!props) {
+		printf("Error: cannot allocate memory for cmdq_group_properties\n");
+		exit(-1);
+	}
+
+	EXIT_ON_ERROR(zeDeviceGetCommandQueueGroupProperties(dev, &cnt, props));
+
+	printf("\tcommand queue groups: ");
+
+	for(i = 0; i < cnt; ++i)
+		printf("%d:[%s%s]x%d%s", i,
+			(props[i].flags & ZE_COMMAND_QUEUE_GROUP_PROPERTY_FLAG_COMPUTE) ? "comp," : "",
+			(props[i].flags & ZE_COMMAND_QUEUE_GROUP_PROPERTY_FLAG_COPY) ? "copy" : "",
+			props[i].numQueues, i < cnt -1 ? ", " : "\n");
+}
+
+void init_gpu(void)
+{
+	uint32_t count;
+	ze_device_handle_t *all_devices;
+	ze_device_properties_t device_properties;
+	ze_context_desc_t ctxt_desc = {};
+	ze_command_queue_desc_t cq_desc = {
+		.stype = ZE_STRUCTURE_TYPE_COMMAND_QUEUE_DESC,
+		.ordinal = ordinal,
+		.index = engine_index,
+		.flags = 0,
+		.mode = use_imm_cmdl ? ZE_COMMAND_QUEUE_MODE_SYNCHRONOUS :
+				       ZE_COMMAND_QUEUE_MODE_DEFAULT,
+		.priority = ZE_COMMAND_QUEUE_PRIORITY_NORMAL,
+	};
+	ze_command_list_desc_t cl_desc = {
+		.stype = ZE_STRUCTURE_TYPE_COMMAND_LIST_DESC,
+		.commandQueueGroupOrdinal = ordinal,
+		.flags = 0,
+	};
+	ze_bool_t succ;
+	ze_device_handle_t cmdq_dev;
+
+	EXIT_ON_ERROR(zeInit(ZE_INIT_FLAG_GPU_ONLY));
+
+	/* get the first driver */
+	count = 1;
+	EXIT_ON_ERROR(zeDriverGet(&count, &gpu.drv));
+
+	if (import) {
+		EXIT_ON_ERROR(zeDriverGetExtensionFunctionAddress(
+				gpu.drv,
+				"zexDriverImportExternalPointer",
+				(void *)&zexDriverImportExternalPointer));
+		EXIT_ON_ERROR(zeDriverGetExtensionFunctionAddress(
+				gpu.drv,
+				"zexDriverReleaseImportedPointer",
+				(void *)&zexDriverReleaseImportedPointer));
+	}
+
+	/* get the number of GPU devices */
+	count = 0;
+	EXIT_ON_ERROR(zeDeviceGet(gpu.drv, &count, NULL));
+	printf("Total number of devices: %d\n", count);
+
+	if (card_num >= count || card_num2 >= count) {
+		printf("Error: card number exeeds available devices (%d)\n",
+			count);
+		exit(-1);
+	}
+
+	/* get GPU devices */
+	all_devices = calloc(count, sizeof(*all_devices));
+	if (!all_devices) {
+		printf("Error: cannot allocate memory for all_devices\n");
+		exit(-1);
+	}
+
+	EXIT_ON_ERROR(zeDeviceGet(gpu.drv, &count, all_devices));
+	gpu.dev = all_devices[card_num];
+	gpu.dev2 = all_devices[card_num2];
+
+	printf("Use device %d: %p, ", card_num, gpu.dev);
+	zeDeviceGetProperties(gpu.dev, &device_properties);
+	show_device_properties(&device_properties);
+	show_cmdq_group_info(gpu.dev);
+
+	if (card_num2 != card_num) {
+		printf("Use device %d: %p, ", card_num2, gpu.dev2);
+		zeDeviceGetProperties(gpu.dev2, &device_properties);
+		show_device_properties(&device_properties);
+		show_cmdq_group_info(gpu.dev2);
+	}
+
+	/* check peer access capability */
+	EXIT_ON_ERROR(zeDeviceCanAccessPeer(gpu.dev, gpu.dev2, &succ));
+	printf("Peer access from device %d to device %d is %s\n",
+		card_num, card_num2, succ ? "supported" : "unsupported");
+
+	/* create a context */
+	EXIT_ON_ERROR(zeContextCreate(gpu.drv, &ctxt_desc, &gpu.ctxt));
+
+	/* create command queue and commad list */
+	cmdq_dev = reverse ? gpu.dev2 : gpu.dev;
+	if (use_imm_cmdl) {
+		EXIT_ON_ERROR(zeCommandListCreateImmediate(gpu.ctxt, cmdq_dev,
+							   &cq_desc,
+							   &gpu.cmdl));
+	} else {
+		EXIT_ON_ERROR(zeCommandQueueCreate(gpu.ctxt, cmdq_dev,
+						   &cq_desc, &gpu.cmdq));
+		EXIT_ON_ERROR(zeCommandListCreate(gpu.ctxt, cmdq_dev,
+						  &cl_desc, &gpu.cmdl));
+	}
+}
+
+void finalize_gpu(void)
+{
+	EXIT_ON_ERROR(zeCommandListDestroy(gpu.cmdl));
+	if (!use_imm_cmdl)
+		EXIT_ON_ERROR(zeCommandQueueDestroy(gpu.cmdq));
+}
+
+int get_buf_fd(void *buf)
+{
+	ze_ipc_mem_handle_t ipc;
+
+	memset(&ipc, 0, sizeof(ipc));
+	EXIT_ON_ERROR((zeMemGetIpcHandle(gpu.ctxt, buf, &ipc)));
+
+	return (int)*(uint64_t *)&ipc;
+}
+
+void alloc_buffer(struct my_buf *buf, size_t size, ze_device_handle_t dev)
+{
+	ze_device_mem_alloc_desc_t dev_desc = {};
+	ze_host_mem_alloc_desc_t host_desc = {};
+
+	switch (buf->where) {
+	  case MALLOC:
+		EXIT_ON_ERROR(posix_memalign(&buf->buf, 4096, size));
+		if (import)
+			EXIT_ON_ERROR((*zexDriverImportExternalPointer)(gpu.drv,
+									buf->buf,
+									size));
+		break;
+	  case HOST:
+		EXIT_ON_ERROR(zeMemAllocHost(gpu.ctxt, &host_desc, size, 4096,
+					     &buf->buf));
+		break;
+	  case DEVICE:
+		EXIT_ON_ERROR(zeMemAllocDevice(gpu.ctxt, &dev_desc, size, 4096,
+					       dev, &buf->buf));
+		break;
+	  default:
+		EXIT_ON_ERROR(zeMemAllocShared(gpu.ctxt, &dev_desc, &host_desc,
+					       size, 4096, dev, &buf->buf));
+		break;
+	}
+
+	buf->size = size;
+	buf->fd = -1;
+	buf->map = NULL;
+	buf->map_size = (size + 4095) & ~4095UL;
+
+	if (buf->where == MALLOC)
+		return;
+
+	buf->fd = get_buf_fd(buf->buf);
+
+	if (cache_mmap && copy_method == MMAP &&
+	    (buf->where == DEVICE || mmap_all)) {
+		buf->map = mmap(NULL, buf->map_size, PROT_READ | PROT_WRITE,
+				MAP_PRIVATE, buf->fd, 0);
+		if (buf->map == MAP_FAILED) {
+			perror("mmap");
+			exit(-1);
+		}
+	}
+}
+
+void free_buffer(struct my_buf *buf)
+{
+	if (buf->map)
+		munmap(buf->map, buf->map_size);
+
+	if (buf->fd != -1)
+		close(buf->fd);
+
+	if (buf->where == MALLOC && import)
+		EXIT_ON_ERROR((*zexDriverReleaseImportedPointer)(gpu.drv,
+								 buf->buf));
+
+	if (buf->where == MALLOC)
+		free(buf->buf);
+	else
+		EXIT_ON_ERROR(zeMemFree(gpu.ctxt, buf->buf));
+}
+
+void *get_buf_ptr(struct my_buf *buf, size_t size)
+{
+	if (buf->map)
+		return buf->map;
+
+	if (copy_method == MMAP && buf->where != MALLOC) {
+		buf->map = mmap(NULL, buf->map_size, PROT_READ | PROT_WRITE,
+				MAP_PRIVATE, buf->fd, 0);
+		if (buf->map == MAP_FAILED) {
+			perror("mmap");
+			exit(-1);
+		}
+		return buf->map;
+	}
+
+	return buf->buf;
+}
+
+void put_buf_ptr(struct my_buf *buf)
+{
+	if (!cache_mmap && copy_method == MMAP && buf->where != MALLOC) {
+		munmap(buf->map, buf->map_size);
+		buf->map = NULL;
+	}
+}
+
+void copy_buffer(struct my_buf *src_buf, struct my_buf *dst_buf, size_t size)
+{
+	if (copy_method == MEMCPY) {
+		memcpy(dst_buf->buf, src_buf->buf, size);
+	} else if (copy_method == MMAP) {
+		memcpy(get_buf_ptr(dst_buf, size),
+		       get_buf_ptr(src_buf, size), size);
+		put_buf_ptr(src_buf);
+		put_buf_ptr(dst_buf);
+	} else if (copy_method == CMDQ) {
+		if (use_imm_cmdl) {
+			EXIT_ON_ERROR(zeCommandListAppendMemoryCopy(
+						gpu.cmdl, dst_buf->buf,
+						src_buf->buf, size, NULL, 0,
+						NULL));
+			EXIT_ON_ERROR(zeCommandListReset(gpu.cmdl));
+		} else {
+			if (!cache_cmdl) {
+				EXIT_ON_ERROR(zeCommandListAppendMemoryCopy(
+						gpu.cmdl, dst_buf->buf,
+						src_buf->buf, size, NULL, 0,
+						NULL));
+				EXIT_ON_ERROR(zeCommandListClose(gpu.cmdl));
+			}
+			EXIT_ON_ERROR(zeCommandQueueExecuteCommandLists(
+						gpu.cmdq, 1, &gpu.cmdl, NULL));
+			EXIT_ON_ERROR(zeCommandQueueSynchronize(
+						gpu.cmdq, UINT32_MAX));
+			if (!cache_cmdl)
+				EXIT_ON_ERROR(zeCommandListReset(gpu.cmdl));
+		}
+	}
+}
+
+void fill_buffer(struct my_buf *buf, char c, size_t size)
+{
+	void *mapped;
+
+	if (buf->where != DEVICE) {
+		memset(buf->buf, c, size);
+	} else {
+		mapped = mmap(NULL, buf->map_size, PROT_READ | PROT_WRITE,
+			      MAP_PRIVATE, buf->fd, 0);
+		if (mapped == MAP_FAILED) {
+			perror("mmap");
+			exit(-1);
+		}
+		memset(mapped, c, size);
+		munmap(mapped, buf->map_size);
+	}
+}
+
+void check_buffer(struct my_buf *buf, char c, size_t size)
+{
+	char *p;
+	int i;
+	size_t errors = 0;
+
+	if (buf->where != DEVICE) {
+		p = buf->buf;
+		for (i = 0; i< size; i++)
+			if (p[i] != c) errors++;
+	} else {
+		p = mmap(NULL, buf->map_size, PROT_READ | PROT_WRITE,
+			 MAP_PRIVATE, buf->fd, 0);
+		if (p == MAP_FAILED) {
+			perror("mmap");
+			exit(-1);
+		}
+		for (i = 0; i< size; i++)
+			if (p[i] != c) errors++;
+		munmap(p, buf->map_size);
+	}
+
+	printf("%zd errors found\n", errors);
+}
+
+int str_to_location(char *s)
+{
+	if (!strncasecmp(s, "m", 1))
+		return MALLOC;
+	else if (!strncasecmp(s, "h", 1))
+		return HOST;
+	else if (!strncasecmp(s, "d", 1))
+		return DEVICE;
+	else
+		return SHARED;
+}
+
+char *location_to_str(int location)
+{
+	if (location == MALLOC)
+		return "Host Memory (malloc)";
+	else if (location == HOST)
+		return "Host Memory (ze)";
+	else if (location == DEVICE)
+		return "Device Memory";
+	else
+		return "Shared Memory";
+}
+
+void run_test(struct my_buf *src_buf, struct my_buf *dst_buf)
+{
+	size_t size;
+	int i;
+	double t1, t2;
+
+	signal(SIGSEGV, segv_handler);
+
+	if (setjmp(env))
+		return;
+
+	fill_buffer(src_buf, 'a', MAX_MSG_SIZE);
+	for (size = 1; size <= MAX_MSG_SIZE; size <<= 1) {
+		if (cache_cmdl && copy_method == CMDQ && !use_imm_cmdl) {
+			EXIT_ON_ERROR(zeCommandListAppendMemoryCopy(
+						gpu.cmdl, dst_buf->buf,
+						src_buf->buf, size, NULL, 0,
+						NULL));
+			EXIT_ON_ERROR(zeCommandListClose(gpu.cmdl));
+		}
+
+		t1 = when();
+		for (i = 0; i < iterations; i++)
+			copy_buffer(src_buf, dst_buf, size);
+		t2 = when();
+
+		if (cache_cmdl && copy_method == CMDQ && !use_imm_cmdl)
+			EXIT_ON_ERROR(zeCommandListReset(gpu.cmdl));
+
+		printf("%8ld (x%d):%12.2lfus%12.2lfMB/s\n", size, iterations,
+			t2 - t1, size * iterations / ((t2-t1)));
+	}
+	printf("Verifying data ......\n");
+	check_buffer(dst_buf, 'a', MAX_MSG_SIZE);
+}
+
+void usage(char *prog_name)
+{
+	printf("Usage: %s [<options>] <src> <dst>\n", prog_name);
+	printf("Options:\n");
+	printf("\t-n <iterations>     number of iterations to perform copy operation for each message size\n");
+	printf("\t-c <copy-method>    method used for copy operations, can be 'cmdq' (default), 'memcpy', 'mmap', and 'mmap-device'\n");
+	printf("\t-C                  cache the command list, or cache mmap\n");
+	printf("\t-i                  use immediate command list\n");
+	printf("\t-d <device>         device to use (default: 0)\n");
+	printf("\t-D <device2>        second device to use (default: the same as the first device)\n");
+	printf("\t-G <ordinal>        command queue group ordinal (default: 0)\n");
+	printf("\t-I <index>          engine index within the command queue group (default: 0)\n");
+	printf("\t-r                  reverse the direction by creating command queue on the device with the destination buffer\n");
+	printf("\t-M                  import malloc'ed buffer into L0 before the copy\n");
+	printf("\t<src>               location of source buffer -- 'M':malloc, 'H':host, 'D':device, 'S':shared\n");
+	printf("\t<dst>               location of destination buffer -- 'M':malloc, 'H':host, 'D':device, 'S':shared\n");
+	exit(1);
+}
+
+int main(int argc, char **argv)
+{
+	struct my_buf src_buf = {};
+	struct my_buf dst_buf = {};
+	int c;
+
+	while ((c = getopt(argc, argv, "n:c:Cid:D:G:I:rMh")) != -1)
+	{
+		switch (c) {
+		case 'n':
+			iterations = atoi(optarg);
+			break;
+		case 'c':
+			if (!strcasecmp(optarg, "cmdq"))
+				copy_method = CMDQ;
+			else if (!strcasecmp(optarg, "memcpy"))
+				copy_method = MEMCPY;
+			else if (!strcasecmp(optarg, "mmap"))
+				copy_method = MMAP, mmap_all = 1;
+			else if (!strcasecmp(optarg, "mmap-device"))
+				copy_method = MMAP, mmap_all = 0;
+			else
+				printf("Invalid copy method '%s', using default (cmdq).\n",
+					optarg);
+			break;
+		case 'C':
+			cache_cmdl = cache_mmap = 1;
+			break;
+		case 'i':
+			use_imm_cmdl = 1;
+			break;
+		case 'd':
+			card_num = atoi(optarg);
+			break;
+		case 'D':
+			card_num2 = atoi(optarg);
+			break;
+		case 'G':
+			ordinal = atoi(optarg);
+			break;
+		case 'I':
+			engine_index = atoi(optarg);
+			break;
+		case 'r':
+			reverse = 1;
+			break;
+		case 'M':
+			import = 1;
+			break;
+		default:
+			usage(argv[0]);
+			break;
+		}
+	}
+
+	if (argc < optind + 2)
+		usage(argv[0]);
+
+	src_buf.where = str_to_location(argv[optind]);
+	dst_buf.where = str_to_location(argv[optind + 1]);
+
+	if (card_num2 == 0xFF || src_buf.where == HOST || dst_buf.where == HOST)
+		card_num2 = card_num;
+
+	init_gpu();
+
+	alloc_buffer(&src_buf, MAX_MSG_SIZE, gpu.dev);
+	alloc_buffer(&dst_buf, MAX_MSG_SIZE, gpu.dev2);
+
+	printf("Copy from %s to %s, ",
+		location_to_str(src_buf.where), location_to_str(dst_buf.where));
+
+	if (copy_method == MEMCPY)
+		printf("using memcpy\n");
+	else if (copy_method == MMAP)
+		printf("using mmap (%s) on %s\n",
+			cache_mmap ? "cached" : "non-cached",
+			mmap_all ? "all memory except malloc" : "device memory");
+	else
+		printf("using %s command list (%s)\n",
+			use_imm_cmdl ? "immediate" : "regular",
+			cache_cmdl ? "cached" : "non-cached");
+
+	printf("Import external pointers: %s\n", import ? "yes" : "no");
+
+	run_test(&src_buf, &dst_buf);
+
+	free_buffer(&src_buf);
+	free_buffer(&dst_buf);
+
+	finalize_gpu();
+	return 0;
+}
+

--- a/fabtests/component/dmabuf-rdma/mr-reg-xe.c
+++ b/fabtests/component/dmabuf-rdma/mr-reg-xe.c
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2021-2022 Intel Corporation.  All rights reserved.
+ *
+ * This software is available to you under the BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ *	mr-reg-xe.c
+ *
+ *	This is a simple test that checks if memory registration is working
+ *	correctly. Kernel and user space RDMA/dma-buf support is required
+ *	(kernel 5.12 and later, rdma-core v34 nad later, or MOFED 5.5 and
+ *	later).
+ *
+ *	Register memory allocted with malloc():
+ *
+ *	    ./mr-reg-xe -m malloc
+ *
+ *	Register memory allocated with zeMemAllocHost():
+ *
+ *	    ./mr-reg-xe -m host
+ *
+ *	Register memory allocated with zeMemAllocDevice() on device 0
+ *
+ *	    ./mr-reg-xe -m device -d 0
+ *
+ *	For more options:
+ *
+ *	    ./mr-reg-xe -h
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <string.h>
+#include <infiniband/verbs.h>
+#include "util.h"
+#include "xe.h"
+
+static struct ibv_device	**dev_list;
+static struct ibv_device	*dev;
+static struct ibv_context	*context;
+static struct ibv_pd		*pd;
+static struct ibv_mr		*mr;
+
+void		*buf;
+static int	buf_fd;
+static size_t	buf_size = 65536;
+static int	buf_location = MALLOC;
+
+static void init_buf(void)
+{
+	int page_size = sysconf(_SC_PAGESIZE);
+
+	buf = xe_alloc_buf(page_size, buf_size, buf_location, 0, NULL);
+	if (!buf) {
+		fprintf(stderr, "Couldn't allocate work buf.\n");
+		exit(-1);
+	}
+}
+
+static void free_buf(void)
+{
+	xe_free_buf(buf, buf_location);
+}
+
+static void free_ib(void)
+{
+	ibv_dealloc_pd(pd);
+	ibv_close_device(context);
+	ibv_free_device_list(dev_list);
+}
+
+static int init_ib(void)
+{
+	dev_list = ibv_get_device_list(NULL);
+	if (!dev_list) {
+		perror("Failed to get IB devices list");
+		return -ENODEV;
+	}
+
+	dev = *dev_list;
+	if (!dev) {
+		fprintf(stderr, "No IB devices found\n");
+		return -ENODEV;
+	}
+
+	printf("Using IB device %s\n", ibv_get_device_name(dev));
+	CHECK_NULL((context = ibv_open_device(dev)));
+	CHECK_NULL((pd = ibv_alloc_pd(context)));
+	return 0;
+
+err_out:
+	return -1;
+}
+
+static int reg_mr(void)
+{
+	int mr_access_flags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ |
+			      IBV_ACCESS_REMOTE_WRITE;
+
+	if (use_dmabuf_reg || buf_location == MALLOC) {
+		printf("Calling ibv_reg_mr(buf=%p, size=%zd)\n", buf, buf_size);
+		CHECK_NULL((mr = ibv_reg_mr(pd, buf, buf_size, mr_access_flags)));
+	} else {
+		buf_fd = xe_get_buf_fd(buf);
+		printf("Calling ibv_reg_dmabuf_mr(buf=%p, size=%zd, fd=%d)\n",
+			buf, buf_size, buf_fd);
+		CHECK_NULL((mr = ibv_reg_dmabuf_mr(pd, 0, buf_size,
+						   (uint64_t)buf, buf_fd,
+						   mr_access_flags)));
+	}
+
+	printf("%s: mr %p\n", __func__, mr);
+	return 0;
+
+err_out:
+	return -1;
+}
+
+static void dereg_mr(void)
+{
+	if (mr)
+		ibv_dereg_mr(mr);
+}
+
+static void usage(char *prog)
+{
+	printf("Usage: %s [options]\n", prog);
+	printf("Options:\n");
+	printf("\t-m <location>    Where to allocate the buffer, can be 'malloc', 'host','device' or 'shared', default: malloc\n");
+	printf("\t-d <card_num>    Use the GPU device specified by <card_num>, default: 0\n");
+	printf("\t-S <buf_size>    Set the size of the buffer to allocate, default: 65536\n");
+	printf("\t-R               Use dmabuf_reg (plug-in for MOFED peer-mem)\n");
+	printf("\t-h               Print this message\n");
+}
+
+int main(int argc, char *argv[])
+{
+	char *gpu_dev_nums = NULL;
+	int c;
+
+	while ((c = getopt(argc, argv, "d:m:RS:h")) != -1) {
+		switch (c) {
+		case 'd':
+			gpu_dev_nums = strdup(optarg);
+			break;
+		case 'm':
+			if (strcasecmp(optarg, "malloc") == 0)
+				buf_location = MALLOC ;
+			else if (strcasecmp(optarg, "host") == 0)
+				buf_location = HOST;
+			else if (strcasecmp(optarg, "device") == 0)
+				buf_location = DEVICE;
+			else if (strcasecmp(optarg, "shared") == 0)
+				buf_location = SHARED;
+			break;
+		case 'R':
+			use_dmabuf_reg = 1;
+			break;
+		case 'S':
+			buf_size = atol(optarg);
+			break;
+		default:
+			usage(argv[0]);
+			exit(-1);
+			break;
+		}
+	}
+
+	if (use_dmabuf_reg)
+		dmabuf_reg_open();
+
+	if (buf_location != MALLOC)
+		xe_init(gpu_dev_nums, 0);
+
+	init_buf();
+	init_ib();
+	reg_mr();
+
+	dereg_mr();
+	free_ib();
+	free_buf();
+
+	if (use_dmabuf_reg)
+		dmabuf_reg_close();
+
+	return 0;
+}
+

--- a/fabtests/component/dmabuf-rdma/rdmabw-xe.c
+++ b/fabtests/component/dmabuf-rdma/rdmabw-xe.c
@@ -1,0 +1,877 @@
+/*
+ * Copyright (c) 2021-2022 Intel Corporation.  All rights reserved.
+ *
+ * This software is available to you under the BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ *	rdmabw-xe.c
+ *
+ *	This is a IB Verbs RDMA bandwidth test with buffers allocated via
+ *	oneAPI L0 functions. Kernel and user space RDMA/dma-buf support is
+ *	required (kernel 5.12 and later, rdma-core v34 and later, or MOFED
+ *	5.5 and later).
+ *
+ *	Examples of running the test on a single node:
+ *
+ *	RDMA write host memory --> device memory:
+ *
+ *	    ./rdmabw-xe -m device -d 0 &
+ *	    sleep 1 &&
+ *	    ./rdmabw-xe -m host -t write localhost
+ *
+ *	RDMA read host memory <-- device memory:
+ *
+ *	    ./rdmabw-xe -m device -d 0 &
+ *	    sleep 1 &&
+ *	    ./rdmabw-xe -m host -t read localhost
+ *
+ *	RDMA write between memory on the same device:
+ *
+ *	    ./rdmabw-xe -m device -d 0 &
+ *	    sleep 1 &&
+ *	    ./rdmabw-xe -m device -d 0 -t write localhost
+ *
+ *	RDMA write between memory on different devices:
+ *
+ *	    ./rdmabw-xe -m device -d 0 &
+ *	    sleep 1 &&
+ *	    ./rdmabw-xe -m device -d 1 -t write localhost
+ *
+ *	RDMA write between memory on different devices, use specified IB device:
+ *
+ *	    ./rdmabw-xe -m device -d 0 -D mlx5_0 &
+ *	    sleep 1 &&
+ *	    ./rdmabw-xe -m device -d 1 -D mlx5_1 -t write localhost
+ *
+ *	For more options:
+ *
+ *	    ./rdmabw-xe -h
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <string.h>
+#include <arpa/inet.h>
+#include <infiniband/verbs.h>
+#include <level_zero/ze_api.h>
+#include "util.h"
+#include "xe.h"
+
+#define MAX_SIZE	(4*1024*1024)
+#define MIN_PROXY_BLOCK	(131072)
+#define TX_DEPTH	(128)
+#define RX_DEPTH	(1)
+#define MAX_NICS	(4)
+
+enum test_type {
+	READ,
+	WRITE
+};
+
+static struct business_card {
+	int	num_nics;
+	int	num_gpus;
+	struct {
+		int		lid;
+		int		qpn;
+		int		psn;
+		union ibv_gid	gid;
+	} nics[MAX_NICS];
+	struct {
+		uint64_t	addr;
+		uint64_t	rkeys[MAX_NICS];
+	} bufs[MAX_GPUS];
+} me, peer;
+
+struct nic {
+	struct ibv_device	*dev;
+	struct ibv_context	*context;
+	struct ibv_pd		*pd;
+	struct ibv_cq		*cq;
+	struct ibv_qp		*qp;
+	int			lid;
+	union ibv_gid		gid;
+};
+
+static struct ibv_device	**dev_list;
+static struct nic		nics[MAX_NICS];
+static int			num_nics;
+static int			gid_idx = -1;
+static int			mtu = IBV_MTU_4096;
+
+struct buf {
+	struct xe_buf		xe_buf;
+	struct ibv_mr		*mrs[MAX_NICS];
+};
+
+static int			num_gpus;
+static struct buf		bufs[MAX_GPUS];
+static struct buf		proxy_buf;
+static int			buf_location = MALLOC;
+static int			use_proxy;
+static int			proxy_block = MAX_SIZE;
+static int			use_sync_ib;
+static int			use_inline_send;
+static int			use_odp;
+static int			verify;
+
+static void init_buf(size_t buf_size, char c)
+{
+	int page_size = sysconf(_SC_PAGESIZE);
+	int i;
+	void *buf;
+
+	for (i = 0; i < num_gpus; i++) {
+		buf = xe_alloc_buf(page_size, buf_size, buf_location, i,
+				   &bufs[i].xe_buf);
+		if (!buf) {
+			fprintf(stderr, "Couldn't allocate work buf.\n");
+			exit(-1);
+		}
+		xe_set_buf(buf, c, buf_size, buf_location, i);
+	}
+
+	if (buf_location == DEVICE && use_proxy) {
+		if (!xe_alloc_buf(page_size, buf_size, HOST, 0, &proxy_buf.xe_buf)) {
+			fprintf(stderr, "Couldn't allocate proxy buf.\n");
+			exit(-1);
+		}
+	}
+}
+
+static void check_buf(size_t size, char c, int gpu)
+{
+	unsigned long mismatches = 0;
+	int i;
+	char *bounce_buf;
+
+	bounce_buf = malloc(size);
+	if (!bounce_buf) {
+		perror("malloc bounce buffer");
+		return;
+	}
+
+	xe_copy_buf(bounce_buf, bufs[gpu].xe_buf.buf, size, gpu);
+
+	for (i = 0; i < size; i++)
+		if (bounce_buf[i] != c) {
+			mismatches++;
+			if (mismatches < 10)
+			printf("value at [%d] is '%c'(0x%02x), expecting '%c'(0x%02x)\n",
+				i, bounce_buf[i], bounce_buf[i], c, c);
+		}
+
+	free(bounce_buf);
+
+	if (mismatches)
+		printf("%lu mismatches found\n", mismatches);
+	else
+		printf("all %lu bytes are correct.\n", size);
+}
+
+static void free_buf(void)
+{
+	int i;
+
+	for (i = 0; i < num_gpus; i++)
+		xe_free_buf(bufs[i].xe_buf.buf, bufs[i].xe_buf.location);
+
+	if (use_proxy)
+		xe_free_buf(proxy_buf.xe_buf.buf, proxy_buf.xe_buf.location);
+}
+
+/*
+ * Fabric setup & tear-down
+ */
+
+static int connect_ib(int port, struct business_card *dest)
+{
+	struct ibv_qp_attr qp_attr = {};
+	int qp_rtr_flags, qp_rts_flags;
+	int i;
+
+	/* set up pair-wise connection, not all-to-all connection */
+
+	for (i = 0; i < num_nics; i++) {
+		qp_attr.qp_state		= IBV_QPS_RTR;
+		qp_attr.path_mtu		= mtu;
+		qp_attr.dest_qp_num		= dest->nics[i].qpn;
+		qp_attr.rq_psn			= dest->nics[i].psn;
+		qp_attr.max_dest_rd_atomic	= 16;
+		qp_attr.min_rnr_timer		= 12;
+		qp_attr.ah_attr.is_global	= 0;
+		qp_attr.ah_attr.dlid		= dest->nics[i].lid;
+		qp_attr.ah_attr.sl		= 0;
+		qp_attr.ah_attr.src_path_bits	= 0;
+		qp_attr.ah_attr.port_num	= port;
+
+		if (dest->nics[i].gid.global.interface_id) {
+			qp_attr.ah_attr.is_global	= 1;
+			qp_attr.ah_attr.grh.hop_limit	= 1;
+			qp_attr.ah_attr.grh.dgid	= dest->nics[i].gid;
+			qp_attr.ah_attr.grh.sgid_index	= gid_idx;
+		}
+
+		qp_rtr_flags = IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU |
+			       IBV_QP_DEST_QPN | IBV_QP_RQ_PSN |
+			       IBV_QP_MAX_DEST_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER;
+
+		CHECK_ERROR(ibv_modify_qp(nics[i].qp, &qp_attr, qp_rtr_flags));
+
+		qp_attr.qp_state = IBV_QPS_RTS;
+		qp_attr.timeout	= 14;
+		qp_attr.retry_cnt = 7;
+		qp_attr.rnr_retry = 7;
+		qp_attr.sq_psn = 0;
+		qp_attr.max_rd_atomic = 16;
+
+		qp_rts_flags = IBV_QP_STATE | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT |
+			       IBV_QP_RNR_RETRY | IBV_QP_SQ_PSN |
+			       IBV_QP_MAX_QP_RD_ATOMIC;
+
+		CHECK_ERROR(ibv_modify_qp(nics[i].qp, &qp_attr, qp_rts_flags));
+	}
+	return 0;
+
+err_out:
+	return -1;
+}
+
+static void free_ib(void)
+{
+	int i, j;
+
+	for (i = 0; i < num_nics; i++) {
+		if (nics[i].qp)
+			ibv_destroy_qp(nics[i].qp);
+		if (nics[i].cq)
+			ibv_destroy_cq(nics[i].cq);
+		if (use_proxy && proxy_buf.mrs[i])
+			ibv_dereg_mr(proxy_buf.mrs[i]);
+		for (j = 0; j < num_gpus; j++)
+			if (bufs[j].mrs[i])
+				ibv_dereg_mr(bufs[j].mrs[i]);
+		ibv_dealloc_pd(nics[i].pd);
+		ibv_close_device(nics[i].context);
+	}
+	ibv_free_device_list(dev_list);
+}
+
+static struct ibv_mr *reg_mr(struct ibv_pd *pd, void *buf, uint64_t size,
+			     void *base, int where)
+{
+	int mr_access_flags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ |
+			      IBV_ACCESS_REMOTE_WRITE;
+	int odp_flag = use_odp ? IBV_ACCESS_ON_DEMAND : 0;
+
+	if (where == MALLOC || use_dmabuf_reg)
+		return ibv_reg_mr(pd, buf, size, mr_access_flags | odp_flag);
+	else
+		return ibv_reg_dmabuf_mr(pd,
+					 (uint64_t)((char *)buf - (char *)base),
+					 size, (uint64_t)buf, /* iova */
+					 xe_get_buf_fd(buf), mr_access_flags);
+}
+
+static int init_nic(int nic, char *ibdev_name, int ib_port)
+{
+	int qp_init_flags = IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT |
+			    IBV_QP_ACCESS_FLAGS;
+	struct ibv_qp_attr qp_attr = {};
+	struct ibv_qp_init_attr qp_init_attr = {};
+	struct ibv_port_attr port_attr;
+	struct ibv_device **p;
+	struct ibv_device *dev = NULL;
+	struct ibv_context *context = NULL;
+	struct ibv_pd *pd = NULL;
+	struct ibv_cq *cq = NULL;
+	struct ibv_qp *qp = NULL;
+	int i;
+
+	p = dev_list;
+	dev = *p;
+	while (*p && ibdev_name) {
+		dev = *p;
+		if (!strcasecmp(ibdev_name, ibv_get_device_name(dev)))
+			break;
+		dev = NULL;
+		p++;
+	}
+	if (!dev) {
+		fprintf(stderr, "IB devices %s not found\n", ibdev_name);
+		return -ENODEV;
+	}
+
+	printf("Using IB device %s\n", ibv_get_device_name(dev));
+
+	/* open dev, pd, mr, cq */
+	CHECK_NULL((context = ibv_open_device(dev)));
+	CHECK_NULL((pd = ibv_alloc_pd(context)));
+	for (i = 0; i < num_gpus; i++)
+		CHECK_NULL((bufs[i].mrs[nic] =
+				reg_mr(pd, bufs[i].xe_buf.buf,
+				       bufs[i].xe_buf.size,
+				       bufs[i].xe_buf.base,
+				       bufs[i].xe_buf.location)));
+	if (proxy_buf.xe_buf.buf)
+		CHECK_NULL((proxy_buf.mrs[nic] =
+				reg_mr(pd, proxy_buf.xe_buf.buf,
+				       proxy_buf.xe_buf.size,
+				       proxy_buf.xe_buf.base,
+				       proxy_buf.xe_buf.location)));
+	CHECK_NULL((cq = ibv_create_cq(context, TX_DEPTH + RX_DEPTH, NULL,
+				       NULL, 0)));
+
+	/* create & initialize qp */
+	qp_init_attr.send_cq = cq;
+	qp_init_attr.recv_cq = cq;
+	qp_init_attr.cap.max_send_wr = TX_DEPTH * (MAX_SIZE / MIN_PROXY_BLOCK);
+	qp_init_attr.cap.max_recv_wr = RX_DEPTH;
+	qp_init_attr.cap.max_send_sge = 1;
+	qp_init_attr.cap.max_recv_sge = 1;
+	qp_init_attr.qp_type = IBV_QPT_RC;
+	CHECK_NULL((qp = ibv_create_qp(pd, &qp_init_attr)));
+
+	qp_attr.qp_state = IBV_QPS_INIT;
+	qp_attr.pkey_index = 0;
+	qp_attr.port_num = ib_port;
+	qp_attr.qp_access_flags = IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_WRITE;
+	CHECK_ERROR(ibv_modify_qp(qp, &qp_attr, qp_init_flags));
+
+	nics[nic].dev = dev;
+	nics[nic].context = context;
+	nics[nic].pd = pd;
+	nics[nic].qp = qp;
+	nics[nic].cq = cq;
+
+	CHECK_ERROR(ibv_query_port(context, ib_port, &port_attr));
+	nics[nic].lid = port_attr.lid;
+
+	if (gid_idx >= 0)
+		CHECK_ERROR(ibv_query_gid(context, ib_port, gid_idx, &nics[nic].gid));
+	else
+		memset(&nics[nic].gid, 0, sizeof nics[nic].gid);
+
+	return 0;
+
+err_out:
+	return -1;
+}
+
+static void show_business_card(struct business_card *bc, char *name)
+{
+	char gid[33];
+	int i, j;
+
+	printf("%s:\tnum_nics %d num_gpus %d ", name, bc->num_nics, bc->num_gpus);
+	for (i = 0; i < bc->num_nics; i++) {
+		inet_ntop(AF_INET6, &bc->nics[i].gid, gid, sizeof gid);
+		printf("[NIC %d] lid 0x%04x qpn 0x%06x gid %s ",
+			i, bc->nics[i].lid, bc->nics[i].qpn, gid);
+	}
+	for (i = 0; i < bc->num_gpus; i++) {
+		printf("[BUF %d] addr %lx rkeys (", i, bc->bufs[i].addr);
+		for (j = 0; j < bc->num_nics; j++)
+			printf("%lx ", bc->bufs[i].rkeys[j]);
+		printf(") ");
+	}
+	printf("\n");
+}
+
+static void init_ib(char *ibdev_names, int sockfd)
+{
+	int ib_port = 1;
+	char *ibdev_name;
+	int i, j;
+
+	dev_list = ibv_get_device_list(NULL);
+	if (!dev_list) {
+		perror("Failed to get IB devices list");
+		exit(-1);
+	}
+
+	if (!*dev_list) {
+		fprintf(stderr, "No IB devices found\n");
+		exit(-1);
+	}
+
+	num_nics = 0;
+	if (ibdev_names) {
+		ibdev_name = strtok(ibdev_names, ",");
+		while (ibdev_name && num_nics < MAX_NICS) {
+			EXIT_ON_ERROR(init_nic(num_nics, ibdev_name, ib_port));
+			num_nics++;
+			ibdev_name = strtok(NULL, ",");
+		}
+	} else {
+		EXIT_ON_ERROR(init_nic(0, NULL, ib_port));
+		num_nics++;
+	}
+
+	for (i = 0; i < num_nics; i++) {
+		memcpy(&me.nics[i].gid, &nics[i].gid, sizeof(nics[i].gid));
+		me.nics[i].lid = nics[i].lid;
+		me.nics[i].qpn = nics[i].qp->qp_num;
+		me.nics[i].psn = 0;
+	}
+	for (i = 0; i < num_gpus; i++) {
+		me.bufs[i].addr = (uint64_t)bufs[i].xe_buf.buf;
+		for (j = 0; j < num_nics; j++)
+			me.bufs[i].rkeys[j] = bufs[i].mrs[j]->rkey;
+	}
+	me.num_nics = num_nics;
+	me.num_gpus = num_gpus;
+
+	show_business_card(&me, "Me");
+
+	EXIT_ON_ERROR(exchange_info(sockfd, sizeof(me), &me, &peer));
+
+	show_business_card(&peer, "Peer");
+
+	if (me.num_nics != peer.num_nics) {
+		printf("The number of IB devices doesn't match. Exiting\n");
+		exit(-1);
+	}
+
+	EXIT_ON_ERROR(connect_ib(ib_port, &peer));
+}
+
+/*
+ * Test routines
+ */
+
+static int post_rdma(int nic, int gpu, int rgpu, int test_type, size_t size,
+		     int idx, int signaled)
+{
+	struct ibv_sge list = {
+		.addr = (uintptr_t)bufs[gpu].xe_buf.buf + idx * size,
+		.length = size,
+		.lkey = bufs[gpu].mrs[nic]->lkey
+	};
+	struct ibv_send_wr wr = {
+		.sg_list = &list,
+		.num_sge = 1,
+		.opcode = test_type == READ ? IBV_WR_RDMA_READ :
+					      IBV_WR_RDMA_WRITE,
+		.send_flags = signaled ? IBV_SEND_SIGNALED : 0,
+		.wr = {
+		  .rdma = {
+		    .remote_addr = peer.bufs[rgpu].addr + idx * size,
+		    .rkey = peer.bufs[rgpu].rkeys[nic],
+		  }
+		}
+	};
+	struct ibv_send_wr *bad_wr;
+
+	return ibv_post_send(nics[nic].qp, &wr, &bad_wr);
+}
+
+static int post_proxy_write(int nic, int gpu, int rgpu, size_t size, int idx,
+			    int signaled)
+{
+	uintptr_t offset = idx * size;
+	struct ibv_sge list = {
+		.addr = (uintptr_t)proxy_buf.xe_buf.buf + offset,
+		.length = proxy_block,
+		.lkey = proxy_buf.mrs[nic]->lkey
+	};
+	struct ibv_send_wr wr = {
+		.sg_list = &list,
+		.num_sge = 1,
+		.opcode = IBV_WR_RDMA_WRITE,
+		.wr = {
+		  .rdma = {
+		    .remote_addr = peer.bufs[rgpu].addr + offset,
+		    .rkey = peer.bufs[rgpu].rkeys[nic],
+		  }
+		}
+	};
+	struct ibv_send_wr *bad_wr;
+	size_t sent, block_size = proxy_block;
+	int ret;
+
+	for (sent = 0; sent < size;) {
+		if (block_size >= size - sent) {
+			block_size = size - sent;
+			list.length = block_size;
+			wr.send_flags = signaled ? IBV_SEND_SIGNALED : 0;
+		}
+
+		xe_copy_buf((char *)proxy_buf.xe_buf.buf + offset + sent,
+			    (char *)bufs[gpu].xe_buf.buf + offset + sent,
+			    block_size, gpu);
+
+		ret = ibv_post_send(nics[nic].qp, &wr, &bad_wr);
+		if (ret)
+			break;
+
+		sent += block_size;
+		list.addr += block_size;
+		wr.wr.rdma.remote_addr += block_size;
+	}
+
+	return ret;
+}
+
+static int post_send(int nic, int gpu, size_t size, int idx, int signaled)
+{
+	struct ibv_sge list = {
+		.addr = (uintptr_t)bufs[gpu].xe_buf.buf + idx * size,
+		.length = size,
+		.lkey = bufs[gpu].mrs[nic]->lkey
+	};
+	struct ibv_send_wr wr = {
+		.sg_list = &list,
+		.num_sge = 1,
+		.opcode = IBV_WR_SEND,
+		.send_flags = (signaled ? IBV_SEND_SIGNALED : 0) |
+			      (use_inline_send ? IBV_SEND_INLINE : 0)
+	};
+	struct ibv_send_wr *bad_wr;
+
+	printf("%s: size %ld, signaled %d, inline_send %d\n", __func__,
+		size, signaled, use_inline_send);
+	return ibv_post_send(nics[nic].qp, &wr, &bad_wr);
+}
+
+static int post_recv(int nic, int gpu, size_t size, int idx)
+{
+	struct ibv_sge list = {
+		.addr = (uintptr_t)bufs[gpu].xe_buf.buf + idx * size,
+		.length = size,
+		.lkey = bufs[gpu].mrs[nic]->lkey
+	};
+	struct ibv_recv_wr wr = {
+		.sg_list = &list,
+		.num_sge = 1,
+	};
+	struct ibv_recv_wr *bad_wr;
+
+	printf("%s: size %ld\n", __func__, size);
+	return ibv_post_recv(nics[nic].qp, &wr, &bad_wr);
+}
+
+void check_completions(struct ibv_wc *wc, int n)
+{
+	int i;
+	static uint64_t errcnt = 0;
+
+	for (i = 0; i < n; i++) {
+		if (wc->status != IBV_WC_SUCCESS) {
+			fprintf(stderr,
+				"Completion with error: %s. [total %ld]\n",
+				ibv_wc_status_str(wc->status), ++errcnt);
+			exit(-1);
+		}
+		wc++;
+	}
+}
+
+static void sync_ib(size_t size)
+{
+	int n, i;
+	int pending = 2 * num_nics;
+	struct ibv_wc wc[2];
+
+	for (i = 0; i < num_nics; i++) {
+		CHECK_ERROR(post_recv(i, 0, size, 0));
+		CHECK_ERROR(post_send(i, 0, size, 0, 1));
+	}
+
+	while (pending > 0) {
+		for (i = 0; i < num_nics; i++) {
+			n = ibv_poll_cq(nics[i].cq, 2, wc);
+			if (n < 0) {
+				fprintf(stderr, "poll CQ failed %d\n", n);
+				return;
+			} else if (n > 0) {
+				printf("%s: n %d, pending %d\n", __func__, n,
+					pending);
+				check_completions(wc, n);
+				pending -= n;
+			}
+		}
+	}
+
+err_out:
+	return;
+}
+
+void run_rdma_test(int test_type, int size, int iters, int batch,
+		   int output_result)
+{
+	int i, j, completed, pending;
+	int n, n0;
+	double t1, t2;
+	struct ibv_wc wc[16];
+	int signaled;
+	int nic, gpu, rgpu;
+
+	t1 = when();
+	for (i = completed = pending = 0; i < iters || completed < iters;) {
+		while (i < iters && pending < TX_DEPTH) {
+			nic = i % num_nics;
+			gpu = i % num_gpus;
+			rgpu = i % peer.num_gpus;
+			signaled = ((i / num_nics) % batch) == batch -1 ||
+				   i >= iters - num_nics;
+			if (use_proxy && test_type == WRITE)
+				CHECK_ERROR(post_proxy_write(nic, gpu, rgpu,
+							     size, i % batch,
+							     signaled));
+			else
+				CHECK_ERROR(post_rdma(nic, gpu, rgpu, test_type,
+						      size, i % batch,
+						      signaled));
+			pending++;
+			i++;
+		}
+		do {
+			n0 = 0;
+			for (j = 0; j < num_nics; j++) {
+				n = ibv_poll_cq(nics[j].cq, 16, wc);
+				if (n < 0) {
+					fprintf(stderr, "poll CQ failed %d\n", n);
+					return;
+				} else {
+					check_completions(wc, n);
+					pending -= n * batch;
+					completed += n * batch;
+					n0 += n;
+				}
+			}
+		} while (n0 > 0);
+	}
+	t2 = when();
+
+	if (output_result)
+		printf("%10d (x %4d) %10.2lf us %12.2lf MB/s\n", size, iters,
+		       (t2 - t1), (long)size * iters / (t2 - t1));
+
+	return;
+
+err_out:
+	printf("%10d aborted due to fail to post read request\n", size);
+}
+
+static void usage(char *prog_name)
+{
+	printf("Usage: %s [options][server_name]\n", prog_name);
+	printf("Options:\n");
+	printf("\t-m <location>    Where to allocate the buffer, can be 'host','device' or 'shared', default: host\n");
+	printf("\t-d <gpu_devs>    Use the GPU devices specified as comma separated list of <dev>[.<subdev>], default: 0\n");
+	printf("\t-D <ibdev_names> Use the IB devices named comma separated list of <ibdev_name>, default: the first one\n");
+	printf("\t-g <gid_index>   Specify local port gid index, default: unused\n");
+	printf("\t-M <mtu>         Set the MTU, default: 4096\n");
+	printf("\t-n <iters>       Set the number of iterations for each message size, default: 1000\n");
+	printf("\t-b <batch>       Generate completion for every <batch> iterations (default: 16)\n");
+	printf("\t-S <size>        Set the message size to test (0: all, -1: none), default: 0\n");
+	printf("\t-t <test_type>   Type of test to perform, can be 'read' or 'write', default: read\n");
+	printf("\t-P               Proxy device buffer through host buffer (for write only), default: off\n");
+	printf("\t-B <block_size>  Set the block size for proxying, default: maximum message size\n");
+	printf("\t-O               Use on-demand paging flag (host memory only)\n");
+	printf("\t-r               Reverse the direction of data movement (server initates RDMA ops)\n");
+	printf("\t-R               Enable dmabuf_reg (plug-in for MOFED peer-memory)\n");
+	printf("\t-s               Sync with send/recv at the end\n");
+	printf("\t-i               Use inline send\n");
+	printf("\t-v               Verify the data (for read test only)\n");
+	printf("\t-2               Run test in both direction\n");
+	printf("\t-h               Print this message\n");
+}
+
+int main(int argc, char *argv[])
+{
+	char *server_name = NULL;
+	char *ibdev_names = NULL;
+	char *gpu_dev_nums = NULL;
+	int enable_multi_gpu;
+	unsigned int port = 12345;
+	int test_type = READ;
+	int iters = 1000;
+	int batch = 16;
+	int reverse = 0;
+	int sockfd;
+	int size;
+	int c;
+	int initiator;
+	int bidir = 0;
+	int msg_size = 0;
+
+	while ((c = getopt(argc, argv, "b:d:D:g:m:M:n:t:PB:OrRsS:ihv2")) != -1) {
+		switch (c) {
+		case 'b':
+			batch = atoi(optarg);
+			break;
+		case 'd':
+			gpu_dev_nums = strdup(optarg);
+			break;
+		case 'D':
+			ibdev_names = strdup(optarg);
+			break;
+		case 'g':
+			gid_idx = atoi(optarg);
+			break;
+		case 'm':
+			if (strcasecmp(optarg, "malloc") == 0)
+				buf_location = MALLOC;
+			else if (strcasecmp(optarg, "host") == 0)
+				buf_location = HOST;
+			else if (strcasecmp(optarg, "device") == 0)
+				buf_location = DEVICE;
+			else
+				buf_location = SHARED;
+			break;
+		case 'M':
+			if (strcmp(optarg, "256") == 0)
+				mtu = IBV_MTU_256;
+			else if (strcmp(optarg, "512") == 0)
+				mtu = IBV_MTU_512;
+			else if (strcmp(optarg, "1024") == 0)
+				mtu = IBV_MTU_1024;
+			else if (strcmp(optarg, "2048") == 0)
+				mtu = IBV_MTU_2048;
+			else if (strcmp(optarg, "4096") == 0)
+				mtu = IBV_MTU_4096;
+			else
+				printf("invalid mtu: %s, ignored. "
+				       "valid values are: 256, 512, 1024, 2048, 4096\n",
+				       optarg);
+			break;
+		case 'n':
+			iters = atoi(optarg);
+			break;
+		case 't':
+			if (strcasecmp(optarg, "read") == 0)
+				test_type = READ;
+			else if (strcasecmp(optarg, "write") == 0)
+				test_type = WRITE;
+			break;
+		case 'P':
+			use_proxy = 1;
+			break;
+		case 'B':
+			proxy_block = atoi(optarg);
+			if (proxy_block < MIN_PROXY_BLOCK) {
+				fprintf(stderr,
+					"Block size too small, adjusted to %d\n",
+					MIN_PROXY_BLOCK);
+				proxy_block = MIN_PROXY_BLOCK;
+			}
+			break;
+		case 'O':
+			use_odp = 1;
+			break;
+		case 'r':
+			reverse = 1;
+			break;
+		case 'R':
+			use_dmabuf_reg = 1;
+			break;
+		case 's':
+			use_sync_ib = 1;
+			break;
+		case 'S':
+			msg_size = atoi(optarg);
+			break;
+		case 'i':
+			use_inline_send = 1;
+			break;
+		case 'v':
+			verify = 1;
+			break;
+		case '2':
+			bidir = 1;
+			break;
+		default:
+			usage(argv[0]);
+			exit(-1);
+			break;
+		}
+	}
+
+	if (argc > optind)
+		server_name = strdup(argv[optind]);
+
+	sockfd = connect_tcp(server_name, port);
+	if (sockfd < 0) {
+		fprintf(stderr, "Cannot create socket connection\n");
+		exit(-1);
+	}
+
+	initiator = (!reverse && server_name) || (reverse && !server_name);
+
+	if (use_dmabuf_reg && dmabuf_reg_open())
+		exit(-1);
+
+	/* multi-GPU test doesn't make sense if buffers are on the host */
+	enable_multi_gpu = buf_location != MALLOC && buf_location != HOST;
+	num_gpus = xe_init(gpu_dev_nums, enable_multi_gpu);
+
+	init_buf(MAX_SIZE * batch, initiator ? 'A' : 'a');
+	init_ib(ibdev_names, sockfd);
+
+	sync_tcp(sockfd);
+	printf("Warming up ...\n");
+	if (initiator || bidir)
+		run_rdma_test(test_type, 1, 16, 1, 0);
+
+	sync_tcp(sockfd);
+	printf("Start RDMA test ...\n");
+	for (size = 1; size <= MAX_SIZE; size <<= 1) {
+		if (msg_size < 0)
+			break;
+		else if (msg_size > 0)
+			size = msg_size;
+		if (initiator || bidir)
+			run_rdma_test(test_type, size, iters, batch, 1);
+		sync_tcp(sockfd);
+		if (verify) {
+			if (test_type == READ)
+				check_buf(size, 'a', 0);
+			else
+				check_buf(size, 'A', 0);
+		}
+		if (msg_size)
+			break;
+	}
+	sync_tcp(sockfd);
+
+	if (use_sync_ib)
+		sync_ib(4);
+
+	free_ib();
+	free_buf();
+
+	if (use_dmabuf_reg)
+		dmabuf_reg_close();
+
+	close(sockfd);
+
+	return 0;
+}
+

--- a/fabtests/component/dmabuf-rdma/util.c
+++ b/fabtests/component/dmabuf-rdma/util.c
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2021-2022 Intel Corporation.  All rights reserved.
+ *
+ * This software is available to you under the BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <netdb.h>
+#include <arpa/inet.h>
+
+double when(void)
+{
+	struct timeval tv;
+	static struct timeval tv0;
+	static int first = 1;
+	int err;
+
+	err = gettimeofday(&tv, NULL);
+	if (err) {
+		perror("gettimeofday");
+		return 0;
+	}
+
+	if (first) {
+		tv0 = tv;
+		first = 0;
+	}
+	return (double)(tv.tv_sec - tv0.tv_sec) * 1.0e6 +
+	       (double)(tv.tv_usec - tv0.tv_usec);
+}
+
+int connect_tcp(char *host, int port)
+{
+	struct sockaddr_in sin;
+	struct hostent *addr;
+	int sockfd, newsockfd;
+	socklen_t clen;
+
+	memset(&sin, 0, sizeof(sin));
+
+	if ((sockfd = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+		perror("socket");
+		exit(-1);
+	}
+
+	if (host) {
+		if (atoi(host) > 0) {
+			sin.sin_family = AF_INET;
+			sin.sin_addr.s_addr = inet_addr(host);
+		} else {
+			if ((addr = gethostbyname(host)) == NULL){
+				printf("invalid hostname '%s'\n", host);
+				exit(-1);
+			}
+			sin.sin_family = addr->h_addrtype;
+			memcpy(&sin.sin_addr.s_addr, addr->h_addr, addr->h_length);
+		}
+		sin.sin_port = htons(port);
+		if(connect(sockfd, (struct sockaddr *) &sin, sizeof(sin)) < 0){
+			perror("connect");
+			exit(-1);
+		}
+		return sockfd;
+	} else {
+		int one = 1;
+		if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(int))) {
+			perror("setsockopt");
+			exit(-1);
+		}
+		memset(&sin, 0, sizeof(sin));
+		sin.sin_family = AF_INET;
+		sin.sin_addr.s_addr = htonl(INADDR_ANY);
+		sin.sin_port = htons(port);
+		if (bind(sockfd, (struct sockaddr *) &sin, sizeof(sin)) < 0){
+			perror("bind");
+			exit(-1);
+		}
+
+		listen(sockfd, 5);
+		clen = sizeof(sin);
+		newsockfd = accept(sockfd, (struct sockaddr *) &sin, &clen);
+		if(newsockfd < 0) {
+			perror("accept");
+			exit(-1);
+		}
+
+		close(sockfd);
+		return newsockfd;
+	}
+}
+
+void sync_tcp(int sockfd)
+{
+	int dummy1, dummy2;
+
+	(void)! write(sockfd, &dummy1, sizeof dummy1);
+	(void)! read(sockfd, &dummy2, sizeof dummy2);
+}
+
+int exchange_info(int sockfd, size_t size, void *me, void *peer)
+{
+	if (write(sockfd, me, size) != size) {
+		fprintf(stderr, "Failed to send local info\n");
+		return -1;
+	}
+
+	if (read(sockfd, peer, size) != size) {
+		fprintf(stderr, "Failed to read peer info\n");
+		return -1;
+	}
+
+	return 0;
+}
+

--- a/fabtests/component/dmabuf-rdma/util.h
+++ b/fabtests/component/dmabuf-rdma/util.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2021-2022 Intel Corporation.  All rights reserved.
+ *
+ * This software is available to you under the BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _DMABUF_RDMA_TESTS_UTIL_H_
+#define _DMABUF_RDMA_TESTS_UTIL_H_
+
+#define EXIT_ON_ERROR(stmt) \
+	do { \
+		int err = (stmt); \
+		if (err) { \
+			perror(#stmt); \
+			printf("%s returned error %d\n", #stmt, (err)); \
+			exit(err); \
+		} \
+	} while (0)
+
+#define CHECK_ERROR(stmt) \
+	do { \
+		int err = (stmt); \
+		if (err) { \
+			perror(#stmt); \
+			printf("%s returned error %d\n", #stmt, (err)); \
+			goto err_out; \
+		} \
+	} while (0)
+
+#define EXIT_ON_NEG_ERROR(stmt) \
+	do { \
+		int err = (stmt); \
+		if (err < 0) { \
+			perror(#stmt); \
+			printf("%s returned error %d\n", #stmt, (err)); \
+			exit(err); \
+		} \
+	} while (0)
+
+#define CHECK_NEG_ERROR(stmt) \
+	do { \
+		int err = (stmt); \
+		if (err < 0) { \
+			perror(#stmt); \
+			printf("%s returned error %d\n", #stmt, (err)); \
+			goto err_out; \
+		} \
+	} while (0)
+
+#define EXIT_ON_NULL(stmt) \
+	do { \
+		if (!(stmt)) { \
+			perror(#stmt); \
+			printf("%s returned NULL\n", #stmt); \
+			exit(-1); \
+		} \
+	} while (0)
+
+#define CHECK_NULL(stmt) \
+	do { \
+		if (!(stmt)) { \
+			perror(#stmt); \
+			printf("%s returned NULL\n", #stmt); \
+			goto err_out; \
+		} \
+	} while (0)
+
+/*
+ * Get the wall time since the first call (in microsecodns).
+ * Can be used for performance calculation.
+ */
+double	when(void);
+
+/*
+ * Set up tcp connection for OOB communication, the side with NULL host is the
+ * server. Return socked fd.
+ */
+int	connect_tcp(char *host, int port);
+
+/*
+ * Perform a bi-directional send/recv over the socket. Can be used
+ * as a barrier.
+ */
+void	sync_tcp(int sockfd);
+
+/*
+ * Exchange information over the socket. Can be used as a barrier.
+ */
+int	exchange_info(int sockfd, size_t size, void *me, void *peer);
+
+#endif /* _DMABUF_RDMA_TESTS_UTIL_H_ */
+

--- a/fabtests/component/dmabuf-rdma/xe.c
+++ b/fabtests/component/dmabuf-rdma/xe.c
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) 2021-2022 Intel Corporation.  All rights reserved.
+ *
+ * This software is available to you under the BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <string.h>
+#include <level_zero/ze_api.h>
+#include "util.h"
+#include "xe.h"
+
+/*
+ * Memory allocation & copy routines using oneAPI L0
+ */
+
+#define MAX_GPUS	(8)
+
+extern int buf_location;
+
+struct gpu {
+	int dev_num;
+	int subdev_num;
+	ze_device_handle_t device;
+	ze_command_list_handle_t cmdl;
+};
+
+int use_dmabuf_reg;
+
+static int num_gpus;
+static struct gpu gpus[MAX_GPUS];
+static ze_driver_handle_t gpu_driver;
+static ze_context_handle_t gpu_context;
+
+static int init_gpu(int gpu, int dev_num, int subdev_num)
+{
+	uint32_t count;
+	ze_device_handle_t *devices;
+	ze_device_handle_t device;
+	ze_command_queue_desc_t cq_desc = {
+	    .stype = ZE_STRUCTURE_TYPE_COMMAND_QUEUE_DESC,
+	    .ordinal = 0,
+	    .index = 0,
+	    .flags = 0,
+	    .mode = ZE_COMMAND_QUEUE_MODE_SYNCHRONOUS,
+	    .priority = ZE_COMMAND_QUEUE_PRIORITY_NORMAL,
+	};
+	ze_command_list_handle_t cmdl;
+
+	count = 0;
+	EXIT_ON_ERROR(zeDeviceGet(gpu_driver, &count, NULL));
+
+	if (count < dev_num + 1) {
+		fprintf(stderr, "GPU device %d does't exist\n", dev_num);
+		goto err_out;
+	}
+
+	devices = calloc(count, sizeof(*devices));
+	if (!devices) {
+		perror("calloc");
+		goto err_out;
+	}
+
+	EXIT_ON_ERROR(zeDeviceGet(gpu_driver, &count, devices));
+	device = devices[dev_num];
+	free(devices);
+
+	if (subdev_num >= 0) {
+		count = 0;
+		EXIT_ON_ERROR(zeDeviceGetSubDevices(device, &count, NULL));
+
+		if (count < subdev_num + 1) {
+			fprintf(stderr, "GPU subdevice %d.%d does't exist\n",
+				dev_num, subdev_num);
+			goto err_out;
+		}
+
+		devices = calloc(count, sizeof(*devices));
+		if (!devices) {
+			perror("calloc");
+			goto err_out;
+		}
+
+		EXIT_ON_ERROR(zeDeviceGetSubDevices(device, &count, devices));
+		device = devices[subdev_num];
+		free(devices);
+
+		printf("using GPU subdevice %d.%d: %p (total %d)\n", dev_num,
+			subdev_num, device, count);
+	} else {
+		printf("using GPU device %d: %p (total %d)\n", dev_num,
+			device, count);
+	}
+
+	EXIT_ON_ERROR(zeCommandListCreateImmediate(gpu_context, device,
+						   &cq_desc, &cmdl));
+
+	gpus[gpu].dev_num = dev_num;
+	gpus[gpu].subdev_num = subdev_num;
+	gpus[gpu].device = device;
+	gpus[gpu].cmdl = cmdl;
+	return 0;
+
+err_out:
+	return -1;
+}
+
+int xe_init(char *gpu_dev_nums, int enable_multi_gpu)
+{
+	uint32_t count;
+	ze_context_desc_t ctxt_desc = {};
+	char *gpu_dev_num;
+	char *s;
+	int dev_num, subdev_num;
+
+	EXIT_ON_ERROR(zeInit(ZE_INIT_FLAG_GPU_ONLY));
+
+	count = 1;
+	EXIT_ON_ERROR(zeDriverGet(&count, &gpu_driver));
+	printf("Using first driver: %p (total >= %d)\n", gpu_driver, count);
+
+	EXIT_ON_ERROR(zeContextCreate(gpu_driver, &ctxt_desc, &gpu_context));
+
+	num_gpus = 0;
+	if (gpu_dev_nums) {
+		gpu_dev_num = strtok(gpu_dev_nums, ",");
+		while (gpu_dev_num && num_gpus < MAX_GPUS) {
+			dev_num = 0;
+			subdev_num = -1;
+			dev_num = atoi(gpu_dev_num);
+			s = strchr(gpu_dev_num, '.');
+			if (s)
+				subdev_num = atoi(s + 1);
+			gpu_dev_num = strtok(NULL, ",");
+
+			if (init_gpu(num_gpus, dev_num, subdev_num) < 0)
+				continue;
+
+			num_gpus++;
+
+			if (!enable_multi_gpu)
+				break;
+		}
+	} else {
+		if (!init_gpu(0, 0, -1))
+			num_gpus++;
+	}
+
+	return num_gpus;
+}
+
+int xe_get_dev_num(int i)
+{
+	if (i < 0 || i >= num_gpus)
+		return -1;
+
+	return gpus[i].dev_num;
+}
+
+void xe_show_buf(struct xe_buf *buf)
+{
+	printf("Allocation: buf %p alloc_base %p alloc_size %ld offset 0x%lx type %d device %p\n",
+		buf->buf, buf->base, buf->size, buf->offset, buf->type, buf->dev);
+}
+
+int xe_get_buf_fd(void *buf)
+{
+	ze_ipc_mem_handle_t ipc;
+
+	memset(&ipc, 0, sizeof(ipc));
+	CHECK_ERROR((zeMemGetIpcHandle(gpu_context, buf, &ipc)));
+
+	return (int)*(uint64_t *)&ipc;
+
+err_out:
+	return -1;
+}
+
+void *xe_alloc_buf(size_t page_size, size_t size, int where, int gpu,
+		   struct xe_buf *xe_buf)
+{
+	void *buf = NULL;
+	ze_device_mem_alloc_desc_t dev_desc = {};
+	ze_host_mem_alloc_desc_t host_desc = {};
+	ze_memory_allocation_properties_t alloc_props = { .type = -1};
+	ze_device_handle_t alloc_dev = 0;
+	void *alloc_base;
+	size_t alloc_size;
+
+	switch (where) {
+	  case MALLOC:
+		posix_memalign(&buf, page_size, size);
+		alloc_base = buf;
+		alloc_size = size;
+		break;
+	  case HOST:
+		EXIT_ON_ERROR(zeMemAllocHost(gpu_context, &host_desc, size,
+					     page_size, &buf));
+		break;
+	  case DEVICE:
+		EXIT_ON_ERROR(zeMemAllocDevice(gpu_context, &dev_desc, size,
+					       page_size, gpus[gpu].device, &buf));
+		break;
+	  default:
+		EXIT_ON_ERROR(zeMemAllocShared(gpu_context, &dev_desc,
+					       &host_desc, size, page_size,
+					       gpus[gpu].device, &buf));
+		break;
+	}
+
+	if (where != MALLOC) {
+		EXIT_ON_ERROR(zeMemGetAllocProperties(gpu_context, buf,
+						      &alloc_props, &alloc_dev));
+		EXIT_ON_ERROR(zeMemGetAddressRange(gpu_context, buf, &alloc_base,
+						   &alloc_size));
+		if (use_dmabuf_reg)
+			EXIT_ON_ERROR(dmabuf_reg_add((uintptr_t)alloc_base,
+						     alloc_size,
+						     xe_get_buf_fd(buf)));
+	}
+
+	if (xe_buf) {
+		xe_buf->buf = buf;
+		xe_buf->base = alloc_base;
+		xe_buf->size = alloc_size;
+		xe_buf->offset = (char *)buf - (char *)alloc_base;
+		xe_buf->type = alloc_props.type;
+		xe_buf->dev = alloc_dev;
+		xe_buf->location = where;
+		xe_show_buf(xe_buf);
+	}
+	return buf;
+}
+
+void xe_free_buf(void *buf, int where)
+{
+	if (where == MALLOC) {
+		free(buf);
+	} else {
+		if (use_dmabuf_reg)
+			dmabuf_reg_remove((uint64_t)buf);
+		CHECK_ERROR(zeMemFree(gpu_context, buf));
+	}
+err_out:
+	return;
+}
+
+void xe_set_buf(void *buf, char c, size_t size, int location, int gpu)
+{
+	if (location == MALLOC) {
+		memset(buf, c, size);
+	} else {
+		EXIT_ON_ERROR(zeCommandListAppendMemoryFill(gpus[gpu].cmdl, buf,
+							    &c, 1, size, NULL,
+							    0, NULL));
+		EXIT_ON_ERROR(zeCommandListReset(gpus[gpu].cmdl));
+	}
+}
+
+void xe_copy_buf(void *dst, void *src, size_t size, int gpu)
+{
+	EXIT_ON_ERROR(zeCommandListAppendMemoryCopy(gpus[gpu].cmdl, dst, src,
+						    size, NULL, 0, NULL));
+	EXIT_ON_ERROR(zeCommandListReset(gpus[gpu].cmdl));
+}

--- a/fabtests/component/dmabuf-rdma/xe.h
+++ b/fabtests/component/dmabuf-rdma/xe.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2021-2022 Intel Corporation.  All rights reserved.
+ *
+ * This software is available to you under the BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _DMABUF_RDMA_TESTS_XE_H_
+#define _DMABUF_RDMA_TESTS_XE_H_
+
+#include <stdint.h>
+#include "level_zero/ze_api.h"
+
+#define MAX_GPUS	(8)
+
+/*
+ * Buffer location and method of allocation
+ */
+enum {
+	MALLOC,	/* Host memory allocated via malloc and alike */
+	HOST,	/* Host memory allocated via zeMemAllocHost */
+	DEVICE,	/* Device memory allocated via zeMemAllocDevice */
+	SHARED	/* Shared memory allocated via zeMemAllocShared */
+};
+
+/*
+ * All information related to a buffer allocated via oneAPI L0 API.
+ */
+struct xe_buf {
+	void			*buf;
+	void			*base;
+	uint64_t		offset;
+	size_t			size;
+	ze_device_handle_t	dev;
+	ze_memory_type_t	type;
+	int			location;
+};
+
+/*
+ * Initialize GPU devices specified in the string of comma separated numbers.
+ * Returns the number of GPU device successfully initialized.
+ */
+int	xe_init(char *gpu_dev_nums, int enable_multi_gpu);
+
+/*
+ * Get the device number for the ith successfully initialized GPU.
+ */
+int	xe_get_dev_num(int i);
+
+/*
+ * Alloctaed a buffer from specified location, on the speficied GPU if
+ * applicable. The xe_buf output is optional, can pass in NULL if the
+ * information is not needed.
+ */
+void	*xe_alloc_buf(size_t page_size, size_t size, int where, int gpu,
+		      struct xe_buf *xe_buf);
+
+/*
+ * Get the dma-buf fd associated with the buffer allocated with the oneAPI L0
+ * functions. Return -1 if it's not a dma-buf object.
+ */
+int	xe_get_buf_fd(void *buf);
+
+/*
+ * Show the fields of the xe_buf structure.
+ */
+void	xe_show_buf(struct xe_buf *buf);
+
+/*
+ * Free the buffer allocated with xe_alloc_buf.
+ */
+void	xe_free_buf(void *buf, int where);
+
+/*
+ * Like memset(). Use oneAPI L0 to access device memory.
+ */
+void	xe_set_buf(void *buf, char c, size_t size, int location, int gpu);
+
+/*
+ * Like memcpy(). Use oneAPI L0 to access device memory.
+ */
+void	xe_copy_buf(void *dst, void *src, size_t size, int gpu);
+
+
+/*
+ * Registry for MOFED peer-mem plug-in
+ */
+int	dmabuf_reg_open(void);
+void	dmabuf_reg_close(void);
+int	dmabuf_reg_add(uint64_t base, uint64_t size, int fd);
+void	dmabuf_reg_remove(uint64_t addr);
+
+extern int	use_dmabuf_reg;
+
+#endif /* _DMABUF_RDMA_TESTS_XE_H_ */
+

--- a/fabtests/configure.ac
+++ b/fabtests/configure.ac
@@ -184,6 +184,13 @@ AS_IF([test x"$with_ze" != x"no" && test -n "$with_ze" && test "$have_ze" = "0" 
 
 AC_DEFINE_UNQUOTED([HAVE_LIBZE], [$have_ze], [ZE support])
 
+dnl Checks for presence of ZE library. Needed for building dmabuf rdma component tests.
+have_ze_devel=0
+AS_IF([test "$have_ze" = "1"],
+      [AC_CHECK_LIB(ze_loader, zeInit, [have_ze_devel=1])],
+      [])
+AM_CONDITIONAL([HAVE_LIBZE_DEVEL], [test $have_ze_devel -eq 1])
+
 AC_MSG_CHECKING([for fi_trywait support])
 AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <rdma/fi_eq.h>]],
 	       [[fi_trywait(NULL, NULL, 0);]])],

--- a/fabtests/man/fabtests.7.md
+++ b/fabtests/man/fabtests.7.md
@@ -32,7 +32,7 @@ restricted to verifying a single endpoint type.  These tests typically
 include the endpoint type as part of the test name, such as dgram, msg, or
 rdm.
 
-# Functional
+## Functional
 
 These tests are a mix of very basic functionality tests that show major
 features of libfabric.
@@ -156,7 +156,7 @@ features of libfabric.
 : Tests a persistent server communicating with multiple clients, one at a
   time, in sequence.
 
-# Benchmarks
+## Benchmarks
 
 The client and the server exchange messages in either a ping-pong manner,
 for pingpong named tests, or transfer messages one-way, for bw named tests.
@@ -191,7 +191,7 @@ given provider or system may achieve.
 *fi_rma_bw*
 : An RMA read and write bandwidth test for reliable (MSG and RDM) endpoints.
 
-# Unit
+## Unit
 
 These are simple one-sided unit tests that validate basic behavior of the API.
 Because these are single system tests that do not perform data transfers their
@@ -221,7 +221,7 @@ testing scope is limited.
 *fi_mr_cache_evict*
 : Tests provider MR cache eviction capabilities.
 
-# Multinode
+## Multinode
 
 This test runs a series of tests over multiple formats and patterns to help
 validate at scale. The patterns are an all to all, one to all, all to one and
@@ -230,7 +230,7 @@ atomics, and tagged messages. Currently, there is no option to run these
 capabilities and patterns independently, however the test is short enough to be
 all run at once.
 
-# Ubertest
+## Ubertest
 
 This is a comprehensive latency, bandwidth, and functionality test that can
 handle a variety of test configurations.  The test is able to run a large
@@ -257,17 +257,58 @@ specific features/functionalities. These EFA provider specific fabtests
 show users how to correctly use them.
 
 *fi_efa_rnr_read_cq_error*
-  This test modifies the RNR retry count (rnr_retry) to 0 via
+: This test modifies the RNR retry count (rnr_retry) to 0 via
   fi_setopt, and then runs a simple program to test if the error cq entry
   (with error FI_ENORX) can be read by the application, if RNR happens.
 
 *fi_efa_rnr_queue_resend*
-  This test modifies the RNR retry count (rnr_retry) to 0 via fi_setopt,
+: This test modifies the RNR retry count (rnr_retry) to 0 via fi_setopt,
   and then tests RNR queue/re-send logic for different packet types.
   To run the test, one needs to use `-c` option to specify the category
   of packet types.
 
-### Config file options
+## Component tests
+
+These stand-alone tests don't test libfabric functionalities. Instead,
+they test some components that libfabric depend on. They are not called
+by runfabtests.sh, either, and don't follow the fabtests coventions for
+naming, config file, and command line options.
+
+### Dmabuf RDMA tests
+
+These tests check the functionality or performance of dmabuf based GPU
+RDMA mechanism. They use oneAPI level-zero API to allocate buffer from
+device memory, get dmabuf handle, and perform some device memory related
+operations. Run with the *-h* option to see all available options for
+each of the tests.
+
+*rdmabw-xe*
+: This Verbs test measures the bandwidth of RDMA operations. It runs in
+  client-server mode. It has options to choose buffer location, test type
+  (write, read, send/recv), device unit(s), NIC unit(s), message size, and
+  the number of iterations per message size.
+
+*fi-rdmabw-xe*
+: This test is similar to *rdmabw-xe*, but uses libfabric instead of Verbs.
+
+*mr-reg-xe*
+: This Verbs test tries to register a buffer with the RDMA NIC.
+
+*fi-mr-reg-xe*
+: This test is similar to *mr-reg-xe*, but uses libfabric instead of Verbs.
+
+*memcopy-xe*
+: This test measures the performance of memory copy operations between
+  buffers. It has options for buffer locations, as well as memory copying
+  methods to use (memcpy, mmap + memcpy, copy with device command queue, etc).
+
+### Other component tests
+
+*sock_test*
+: This client-server test establishes socket connections and tests the
+  functionality of select/poll/epoll with different set sizes.
+
+## Config file options
 
 The following keys and respective key values may be used in the config file.
 


### PR DESCRIPTION
These are a mix of OFI, verbs, and oneAPI level-zero tests. They are
intended for validating basic functionality of dmabuf based RDMA.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>