### PR TITLE
psm3: Remove bashisms from psm3 provider build

### DIFF
--- a/prov/psm3/configure.ac
+++ b/prov/psm3/configure.ac
@@ -74,7 +74,7 @@ AS_IF([test "x$enable_psm3_sockets" = "xyes"],
         PSM3_HAL_CNT=$((PSM3_HAL_CNT+1))
         CPPFLAGS="$CPPFLAGS -DPSM_SOCKETS"
       ])
-PSM3_HAL_INST=${PSM3_HAL_INST:1}
+PSM3_HAL_INST=${PSM3_HAL_INST# }
 
 dnl ------------- HAL Extensions
 AC_ARG_ENABLE([psm3-udp],


### PR DESCRIPTION
Fixes: https://github.com/ofiwg/libfabric/issues/7901
Signed-off-by: Adam Goldman <adam.goldman@intel.com>