### PR TITLE
[v1.15.x] psm3: Remove bashisms from psm3 provider build 

### DIFF
--- a/prov/psm3/configure.ac
+++ b/prov/psm3/configure.ac
@@ -77,7 +77,7 @@ AS_IF([test "x$enable_psm3_sockets" = "xyes"],
 	PSM3_HAL_CNT=$((PSM3_HAL_CNT+1))
 	CPPFLAGS="$CPPFLAGS -DPSM_SOCKETS"
       ])
-PSM3_HAL_INST=${PSM3_HAL_INST:1}
+PSM3_HAL_INST=${PSM3_HAL_INST# }
 
 dnl ------------- HAL Extensions
 AC_ARG_ENABLE([psm3-udp],

--- a/prov/psm3/configure.ac
+++ b/prov/psm3/configure.ac
@@ -762,9 +762,11 @@ AC_SUBST(PSM3_HAL_INST)
 
 AM_COND_IF([HAVE_PSM3_SRC],
 	   [
-		PSM3_IEFS_VERSION="${RELEASE_TAG:-$(git describe --dirty --always --abbrev=8 --broken --tags 2>/dev/null \
-			|| git describe --dirty --always --abbrev=8 --broken 2>/dev/null || echo 'unknown commit')}"
-		PSM3_IEFS_VERSION=${PSM3_IEFS_VERSION//./_}
+		PSM3_IEFS_VERSION="${RELEASE_TAG}"
+		AS_IF([test -z "${PSM3_IEFS_VERSION}"], [
+			PSM3_IEFS_VERSION="$(git describe --dirty --always --abbrev=8 --broken --tags 2>/dev/null \
+				|| git describe --dirty --always --abbrev=8 --broken 2>/dev/null || echo 'unknown commit')"])
+		PSM3_IEFS_VERSION=$(echo "${PSM3_IEFS_VERSION}" | tr '.' '_')
 		PSM3_GIT_HASH="$(git log --oneline --format='%H' -1)"
 		RPM_RELEASE=$(echo "${PSM3_IEFS_VERSION}" | cut -d'_' -f5)
 		RELEASE_VER=$(echo "${PSM3_IEFS_VERSION}" | cut -d'_' -f1-4 | sed 's/_/./g')


### PR DESCRIPTION
Fixes: https://github.com/ofiwg/libfabric/issues/7901
