### PR TITLE
prov/net: Changes to improve counter support

### DIFF
--- a/include/ofi_lock.h
+++ b/include/ofi_lock.h
@@ -339,10 +339,12 @@ static inline void ofi_nolock_unlock_op(void *nolock)
 	(void) nolock;
 }
 
-/* No way to verify, so return false.  User needs another check. */
+/* No way to verify, so return true to pass all asserts.
+ * User should provide their own checks higher-up.
+ */
 static inline int ofi_nolock_held_op(void *nolock)
 {
-	return 0;
+	return 1;
 }
 
 

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -275,8 +275,8 @@ void xnet_close_progress(struct xnet_progress *progress);
 int xnet_start_progress(struct xnet_progress *progress);
 void xnet_stop_progress(struct xnet_progress *progress);
 
-void xnet_progress(struct xnet_progress *progress, bool internal);
-void xnet_run_progress(struct xnet_progress *progress, bool internal);
+void xnet_progress(struct xnet_progress *progress, bool clear_signal);
+void xnet_run_progress(struct xnet_progress *progress, bool clear_signal);
 void xnet_run_conn(struct xnet_conn_handle *conn, bool pin, bool pout, bool perr);
 void xnet_handle_event_list(struct xnet_progress *progress);
 

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -277,6 +277,7 @@ void xnet_stop_progress(struct xnet_progress *progress);
 
 void xnet_progress(struct xnet_progress *progress, bool clear_signal);
 void xnet_run_progress(struct xnet_progress *progress, bool clear_signal);
+int xnet_progress_wait(struct xnet_progress *progress, int timeout);
 void xnet_run_conn(struct xnet_conn_handle *conn, bool pin, bool pout, bool perr);
 void xnet_handle_event_list(struct xnet_progress *progress);
 

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -329,6 +329,7 @@ struct xnet_xfer_entry {
 	size_t			iov_cnt;
 	struct iovec		iov[XNET_IOV_LIMIT+1];
 	struct xnet_ep		*ep;
+	void			(*cntr_inc)(struct util_ep *ep);
 	uint64_t		tag_seq_no;
 	uint64_t		tag;
 	uint64_t		ignore;
@@ -512,6 +513,7 @@ xnet_free_xfer(struct xnet_ep *ep, struct xnet_xfer_entry *xfer)
 	assert(xnet_progress_locked(xnet_ep2_progress(ep)));
 	xfer->hdr.base_hdr.flags = 0;
 	xfer->cq_flags = 0;
+	xfer->cntr_inc = NULL;
 	xfer->ctrl_flags = 0;
 	xfer->context = 0;
 	ofi_buf_free(xfer);

--- a/prov/net/src/xnet_cq.c
+++ b/prov/net/src/xnet_cq.c
@@ -317,14 +317,11 @@ xnet_get_cntr(struct xnet_ep *ep, struct xnet_xfer_entry *xfer_entry)
 static void
 xnet_cntr_inc(struct xnet_ep *ep, struct xnet_xfer_entry *xfer_entry)
 {
-	struct util_cntr *cntr;
-
 	if (xfer_entry->ctrl_flags & XNET_INTERNAL_XFER)
 		return;
 
-	cntr = xnet_get_cntr(ep, xfer_entry);
-	if (cntr)
-		fi_cntr_add(&cntr->cntr_fid, 1);
+	assert(xfer_entry->cntr_inc);
+	xfer_entry->cntr_inc(&ep->util_ep);
 }
 
 void xnet_report_cntr_success(struct xnet_ep *ep, struct util_cq *cq,
@@ -346,8 +343,6 @@ void xnet_cntr_incerr(struct xnet_ep *ep, struct xnet_xfer_entry *xfer_entry)
 	if (cntr)
 		fi_cntr_adderr(&cntr->cntr_fid, 1);
 }
-
-
 
 static uint64_t xnet_cntr_read(struct fid_cntr *cntr_fid)
 {

--- a/prov/net/src/xnet_msg.c
+++ b/prov/net/src/xnet_msg.c
@@ -177,6 +177,7 @@ xnet_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t flags)
 
 	recv_entry->cq_flags = xnet_rx_completion_flag(ep, flags) |
 			       FI_MSG | FI_RECV;
+	recv_entry->cntr_inc = ofi_ep_rx_cntr_inc;
 	recv_entry->context = msg->context;
 
 	if (!xnet_queue_recv(ep, recv_entry)) {
@@ -211,6 +212,7 @@ xnet_recv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 
 	recv_entry->cq_flags = xnet_rx_completion_flag(ep, 0) |
 			       FI_MSG | FI_RECV;
+	recv_entry->cntr_inc = ofi_ep_rx_cntr_inc;
 	recv_entry->context = context;
 
 	if (!xnet_queue_recv(ep, recv_entry)) {
@@ -245,6 +247,7 @@ xnet_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	memcpy(recv_entry->iov, iov, count * sizeof(*iov));
 	recv_entry->cq_flags = xnet_rx_completion_flag(ep, 0) |
 			       FI_MSG | FI_RECV;
+	recv_entry->cntr_inc = ofi_ep_rx_cntr_inc;
 	recv_entry->context = context;
 
 	if (!xnet_queue_recv(ep, recv_entry)) {
@@ -284,6 +287,7 @@ xnet_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t flags)
 	xnet_init_tx_iov(tx_entry, hdr_len, msg->msg_iov, msg->iov_count);
 	tx_entry->cq_flags = xnet_tx_completion_flag(ep, flags) |
 			     FI_MSG | FI_SEND;
+	tx_entry->cntr_inc = ofi_ep_tx_cntr_inc;
 	xnet_set_ack_flags(tx_entry, flags);
 	tx_entry->context = msg->context;
 
@@ -314,6 +318,7 @@ xnet_send(struct fid_ep *ep_fid, const void *buf, size_t len,
 	tx_entry->context = context;
 	tx_entry->cq_flags = xnet_tx_completion_flag(ep, 0) |
 			     FI_MSG | FI_SEND;
+	tx_entry->cntr_inc = ofi_ep_tx_cntr_inc;
 	xnet_set_ack_flags(tx_entry, ep->util_ep.tx_op_flags);
 
 	xnet_tx_queue_insert(ep, tx_entry);
@@ -343,6 +348,7 @@ xnet_sendv(struct fid_ep *ep_fid, const struct iovec *iov,
 	tx_entry->context = context;
 	tx_entry->cq_flags = xnet_tx_completion_flag(ep, 0) |
 			     FI_MSG | FI_SEND;
+	tx_entry->cntr_inc = ofi_ep_tx_cntr_inc;
 	xnet_set_ack_flags(tx_entry, ep->util_ep.tx_op_flags);
 
 	xnet_tx_queue_insert(ep, tx_entry);
@@ -372,6 +378,7 @@ xnet_inject(struct fid_ep *ep_fid, const void *buf, size_t len,
 	xnet_init_tx_inject(tx_entry, sizeof(tx_entry->hdr.base_hdr), buf, len);
 	tx_entry->ctrl_flags = XNET_INJECT_OP;
 	tx_entry->cq_flags = FI_INJECT | FI_MSG | FI_SEND;
+	tx_entry->cntr_inc = ofi_ep_tx_cntr_inc;
 
 	xnet_tx_queue_insert(ep, tx_entry);
 unlock:
@@ -406,6 +413,7 @@ xnet_senddata(struct fid_ep *ep_fid, const void *buf, size_t len,
 	tx_entry->context = context;
 	tx_entry->cq_flags = xnet_tx_completion_flag(ep, 0) |
 			     FI_MSG | FI_SEND;
+	tx_entry->cntr_inc = ofi_ep_tx_cntr_inc;
 	xnet_set_ack_flags(tx_entry, ep->util_ep.tx_op_flags);
 
 	xnet_tx_queue_insert(ep, tx_entry);
@@ -438,6 +446,7 @@ xnet_injectdata(struct fid_ep *ep_fid, const void *buf, size_t len,
 			    buf, len);
 	tx_entry->ctrl_flags = XNET_INJECT_OP;
 	tx_entry->cq_flags = FI_INJECT | FI_MSG | FI_SEND;
+	tx_entry->cntr_inc = ofi_ep_tx_cntr_inc;
 
 	xnet_tx_queue_insert(ep, tx_entry);
 unlock:
@@ -489,6 +498,7 @@ xnet_tsendmsg(struct fid_ep *fid_ep, const struct fi_msg_tagged *msg,
 	xnet_init_tx_iov(tx_entry, hdr_len, msg->msg_iov, msg->iov_count);
 	tx_entry->cq_flags = xnet_tx_completion_flag(ep, flags) |
 			     FI_TAGGED | FI_SEND;
+	tx_entry->cntr_inc = ofi_ep_tx_cntr_inc;
 	xnet_set_ack_flags(tx_entry, flags);
 	tx_entry->context = msg->context;
 
@@ -521,6 +531,7 @@ xnet_tsend(struct fid_ep *fid_ep, const void *buf, size_t len,
 	tx_entry->context = context;
 	tx_entry->cq_flags = xnet_tx_completion_flag(ep, 0) |
 			     FI_TAGGED | FI_SEND;
+	tx_entry->cntr_inc = ofi_ep_tx_cntr_inc;
 	xnet_set_ack_flags(tx_entry, ep->util_ep.tx_op_flags);
 
 	xnet_tx_queue_insert(ep, tx_entry);
@@ -552,6 +563,7 @@ xnet_tsendv(struct fid_ep *fid_ep, const struct iovec *iov, void **desc,
 	tx_entry->context = context;
 	tx_entry->cq_flags = xnet_tx_completion_flag(ep, 0) |
 			     FI_TAGGED | FI_SEND;
+	tx_entry->cntr_inc = ofi_ep_tx_cntr_inc;
 	xnet_set_ack_flags(tx_entry, ep->util_ep.tx_op_flags);
 
 	xnet_tx_queue_insert(ep, tx_entry);
@@ -583,6 +595,7 @@ xnet_tinject(struct fid_ep *fid_ep, const void *buf, size_t len,
 	xnet_init_tx_inject(tx_entry, sizeof(tx_entry->hdr.tag_hdr), buf, len);
 	tx_entry->ctrl_flags = XNET_INJECT_OP;
 	tx_entry->cq_flags = FI_INJECT | FI_TAGGED | FI_SEND;
+	tx_entry->cntr_inc = ofi_ep_tx_cntr_inc;
 
 	xnet_tx_queue_insert(ep, tx_entry);
 unlock:
@@ -616,6 +629,7 @@ xnet_tsenddata(struct fid_ep *fid_ep, const void *buf, size_t len, void *desc,
 	tx_entry->context = context;
 	tx_entry->cq_flags = xnet_tx_completion_flag(ep, 0) |
 			     FI_TAGGED | FI_SEND;
+	tx_entry->cntr_inc = ofi_ep_tx_cntr_inc;
 	xnet_set_ack_flags(tx_entry, ep->util_ep.tx_op_flags);
 
 	xnet_tx_queue_insert(ep, tx_entry);
@@ -649,6 +663,7 @@ xnet_tinjectdata(struct fid_ep *fid_ep, const void *buf, size_t len,
 			    buf, len);
 	tx_entry->ctrl_flags = XNET_INJECT_OP;
 	tx_entry->cq_flags = FI_INJECT | FI_TAGGED | FI_SEND;
+	tx_entry->cntr_inc = ofi_ep_tx_cntr_inc;
 
 	xnet_tx_queue_insert(ep, tx_entry);
 unlock:

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -366,6 +366,7 @@ static int xnet_alter_mrecv(struct xnet_ep *ep, struct xnet_xfer_entry *xfer,
 
 	recv_entry->ctrl_flags = XNET_MULTI_RECV;
 	recv_entry->cq_flags = FI_MSG | FI_RECV;
+	recv_entry->cntr_inc = ofi_ep_rx_cntr_inc;
 	recv_entry->context = xfer->context;
 
 	recv_entry->iov_cnt = 1;
@@ -392,7 +393,6 @@ static struct xnet_xfer_entry *xnet_get_rx_entry(struct xnet_ep *ep)
 			xfer = container_of(slist_remove_head(&srx->rx_queue),
 					    struct xnet_xfer_entry, entry);
 			xfer->cq_flags |= xnet_rx_completion_flag(ep, 0);
-
 		} else {
 			xfer = NULL;
 		}
@@ -587,6 +587,7 @@ static ssize_t xnet_op_write(struct xnet_ep *ep)
 		rma_iov = (struct ofi_rma_iov *) ((uint8_t *) &rx_entry->hdr +
 			  sizeof(rx_entry->hdr.base_hdr));
 	}
+	rx_entry->cntr_inc = ofi_ep_rem_wr_cntr_inc;
 
 	memcpy(&rx_entry->hdr, &ep->cur_rx.hdr,
 	       (size_t) ep->cur_rx.hdr.base_hdr.hdr_size);

--- a/prov/net/src/xnet_rma.c
+++ b/prov/net/src/xnet_rma.c
@@ -91,6 +91,7 @@ static void xnet_rma_read_recv_entry_fill(struct xnet_xfer_entry *recv_entry,
 	recv_entry->context = msg->context;
 	recv_entry->cq_flags = xnet_tx_completion_flag(ep, flags) |
 			       FI_RMA | FI_READ;
+	recv_entry->cntr_inc = ofi_ep_rd_cntr_inc;
 	recv_entry->ctrl_flags = XNET_INTERNAL_XFER;
 }
 
@@ -249,6 +250,7 @@ xnet_rma_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 
 	send_entry->cq_flags = xnet_tx_completion_flag(ep, flags) |
 			       FI_RMA | FI_WRITE;
+	send_entry->cntr_inc = ofi_ep_wr_cntr_inc;
 	xnet_set_commit_flags(send_entry, flags);
 	send_entry->context = msg->context;
 
@@ -388,6 +390,7 @@ xnet_rma_inject_common(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	send_entry->hdr.base_hdr.size = offset;
 	send_entry->cq_flags = FI_INJECT | FI_WRITE;
+	send_entry->cntr_inc = ofi_ep_wr_cntr_inc;
 	xnet_tx_queue_insert(ep, send_entry);
 unlock:
 	ofi_genlock_unlock(&xnet_ep2_progress(ep)->lock);

--- a/prov/net/src/xnet_srx.c
+++ b/prov/net/src/xnet_srx.c
@@ -68,6 +68,7 @@ xnet_srx_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 
 	recv_entry->ctrl_flags = flags & FI_MULTI_RECV;
 	recv_entry->cq_flags = FI_MSG | FI_RECV;
+	recv_entry->cntr_inc = ofi_ep_rx_cntr_inc;
 	recv_entry->context = msg->context;
 	recv_entry->iov_cnt = msg->iov_count;
 	memcpy(&recv_entry->iov[0], msg->msg_iov,
@@ -97,6 +98,7 @@ xnet_srx_recv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 	}
 
 	recv_entry->cq_flags = FI_MSG | FI_RECV;
+	recv_entry->cntr_inc = ofi_ep_rx_cntr_inc;
 	recv_entry->context = context;
 	recv_entry->iov_cnt = 1;
 	recv_entry->iov[0].iov_base = buf;
@@ -127,6 +129,7 @@ xnet_srx_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	}
 
 	recv_entry->cq_flags = FI_MSG | FI_RECV;
+	recv_entry->cntr_inc = ofi_ep_rx_cntr_inc;
 	recv_entry->context = context;
 	recv_entry->iov_cnt = count;
 	memcpy(&recv_entry->iov[0], iov, count * sizeof(*iov));
@@ -214,6 +217,7 @@ xnet_srx_trecvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
 	recv_entry->ignore = msg->ignore;
 	recv_entry->src_addr = msg->addr;
 	recv_entry->cq_flags = FI_TAGGED | FI_RECV;
+	recv_entry->cntr_inc = ofi_ep_rx_cntr_inc;
 	recv_entry->context = msg->context;
 	recv_entry->iov_cnt = msg->iov_count;
 	memcpy(&recv_entry->iov[0], msg->msg_iov,
@@ -248,6 +252,7 @@ xnet_srx_trecv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 	recv_entry->ignore = ignore;
 	recv_entry->src_addr = src_addr;
 	recv_entry->cq_flags = FI_TAGGED | FI_RECV;
+	recv_entry->cntr_inc = ofi_ep_rx_cntr_inc;
 	recv_entry->context = context;
 	recv_entry->iov_cnt = 1;
 	recv_entry->iov[0].iov_base = buf;
@@ -284,6 +289,7 @@ xnet_srx_trecvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	recv_entry->ignore = ignore;
 	recv_entry->src_addr = src_addr;
 	recv_entry->cq_flags = FI_TAGGED | FI_RECV;
+	recv_entry->cntr_inc = ofi_ep_rx_cntr_inc;
 	recv_entry->context = context;
 	recv_entry->iov_cnt = count;
 	memcpy(&recv_entry->iov[0], iov, count * sizeof(*iov));


### PR DESCRIPTION
Minor change to genlock nolock_held implementation (return true instead of false)

Implement counter calls directly in the net provider.  This removes the requirement to force on the auto-progress thread when blocking counter calls are needed by the app.  Instead, the cntr_wait call can block on the pollfds in the progress object when FI_THREAD_DOMAIN is used.