### PR TITLE
fabtests: Add verbs presence check for component tests

### DIFF
--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -70,10 +70,13 @@ bin_PROGRAMS = \
 	common/check_hmem
 
 if HAVE_LIBZE_DEVEL
+if HAVE_VERBS_DEVEL
 bin_PROGRAMS += \
 	component/dmabuf-rdma/rdmabw-xe \
+	component/dmabuf-rdma/mr-reg-xe
+endif HAVE_VERBS_DEVEL
+bin_PROGRAMS += \
 	component/dmabuf-rdma/fi-rdmabw-xe \
-	component/dmabuf-rdma/mr-reg-xe \
 	component/dmabuf-rdma/fi-mr-reg-xe \
 	component/dmabuf-rdma/memcopy-xe
 endif HAVE_LIBZE_DEVEL
@@ -457,6 +460,7 @@ component_sock_test_CFLAGS = \
 	$(AM_CFLAGS)
 
 if HAVE_LIBZE_DEVEL
+if HAVE_VERBS_DEVEL
 component_dmabuf_rdma_rdmabw_xe_SOURCES = \
 	component/dmabuf-rdma/rdmabw-xe.c \
 	component/dmabuf-rdma/util.c \
@@ -472,6 +476,21 @@ component_dmabuf_rdma_rdmabw_xe_CFLAGS = \
 	$(AM_CFLAGS) \
 	-I$(srcdir)/component/dmabuf-rdma
 
+component_dmabuf_rdma_mr_reg_xe_SOURCES = \
+	component/dmabuf-rdma/mr-reg-xe.c \
+	component/dmabuf-rdma/util.h \
+	component/dmabuf-rdma/xe.c \
+	component/dmabuf-rdma/xe.h \
+	component/dmabuf-rdma/dmabuf_reg.c \
+	component/dmabuf-rdma/dmabuf_reg.h
+
+component_dmabuf_rdma_mr_reg_xe_LDADD = libfabtests.la
+
+component_dmabuf_rdma_mr_reg_xe_CFLAGS = \
+	$(AM_CFLAGS) \
+	-I$(srcdir)/component/dmabuf-rdma
+endif HAVE_VERBS_DEVEL
+
 component_dmabuf_rdma_fi_rdmabw_xe_SOURCES = \
 	component/dmabuf-rdma/fi-rdmabw-xe.c \
 	component/dmabuf-rdma/util.c \
@@ -484,20 +503,6 @@ component_dmabuf_rdma_fi_rdmabw_xe_SOURCES = \
 component_dmabuf_rdma_fi_rdmabw_xe_LDADD = libfabtests.la
 
 component_dmabuf_rdma_fi_rdmabw_xe_CFLAGS = \
-	$(AM_CFLAGS) \
-	-I$(srcdir)/component/dmabuf-rdma
-
-component_dmabuf_rdma_mr_reg_xe_SOURCES = \
-	component/dmabuf-rdma/mr-reg-xe.c \
-	component/dmabuf-rdma/util.h \
-	component/dmabuf-rdma/xe.c \
-	component/dmabuf-rdma/xe.h \
-	component/dmabuf-rdma/dmabuf_reg.c \
-	component/dmabuf-rdma/dmabuf_reg.h
-
-component_dmabuf_rdma_mr_reg_xe_LDADD = libfabtests.la
-
-component_dmabuf_rdma_mr_reg_xe_CFLAGS = \
 	$(AM_CFLAGS) \
 	-I$(srcdir)/component/dmabuf-rdma
 

--- a/fabtests/configure.ac
+++ b/fabtests/configure.ac
@@ -191,6 +191,12 @@ AS_IF([test "$have_ze" = "1"],
       [])
 AM_CONDITIONAL([HAVE_LIBZE_DEVEL], [test $have_ze_devel -eq 1])
 
+dnl Checks for presence of Verbs. Needed for building dmabuf rdma component tests.
+have_verbs_devel=0
+AC_CHECK_HEADER([infiniband/verbs.h],
+		[AC_CHECK_LIB(ibverbs, ibv_open_device, [have_verbs_devel=1])])
+AM_CONDITIONAL([HAVE_VERBS_DEVEL], [test $have_verbs_devel -eq 1])
+
 AC_MSG_CHECKING([for fi_trywait support])
 AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <rdma/fi_eq.h>]],
 	       [[fi_trywait(NULL, NULL, 0);]])],


### PR DESCRIPTION
Two of the dmabuf rdma component tests depend on verbs.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>