### PR TITLE
prov/net: Fixes to provider

### DIFF
--- a/prov/net/src/xnet_rdm_cm.c
+++ b/prov/net/src/xnet_rdm_cm.c
@@ -482,7 +482,7 @@ void xnet_handle_event_list(struct xnet_progress *progress)
 	struct xnet_rdm_cm *msg;
 	struct xnet_conn *conn;
 
-	ofi_genlock_held(&progress->rdm_lock);
+	assert(ofi_genlock_held(&progress->rdm_lock));
 	while (!slist_empty(&progress->event_list)) {
 		item = slist_remove_head(&progress->event_list);
 		event = container_of(item, struct xnet_event, list_entry);


### PR DESCRIPTION
Set a connected endpoint to active if:

- The message queue for the endpoint is currently empty
- We post a tagged message to receive data from its peer
- The connection is not already active

The posting of the message likely indicates that data is
expected from the peer soon.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>