### PR TITLE
fabtests/efa: fix runt test

### DIFF
--- a/fabtests/pytest/efa/efa_common.py
+++ b/fabtests/pytest/efa/efa_common.py
@@ -29,7 +29,12 @@ def efa_retrieve_hw_counter_value(hostname, hw_counter_name):
     return: an integer that is sum of all EFA device's counter
     """
     command = "ssh {} cat \"/sys/class/infiniband/*/ports/*/hw_counters/{}\"".format(hostname, hw_counter_name)
-    process = subprocess.run(command, shell=True, check=True, stdout=subprocess.PIPE)
+    try:
+        process = subprocess.run(command, shell=True, check=True, stdout=subprocess.PIPE)
+    except subprocess.CalledProcessError:
+        # this can happen when OS is using older version of EFA kernel module
+        return None
+
     linelist = process.stdout.split()
     sumvalue = 0
     for strvalue in linelist:

--- a/fabtests/pytest/efa/test_runt.py
+++ b/fabtests/pytest/efa/test_runt.py
@@ -33,6 +33,10 @@ def test_runt_read_functional(cmdline_args, cuda_copy_method):
 
     # wrs stands for work requests
     server_read_wrs_before_test = efa_retrieve_hw_counter_value(cmdline_args.server_id, "rdma_read_wrs")
+    if server_read_wrs_before_test is None:
+        pytest.skip("No HW counter support")
+        return
+
     server_read_bytes_before_test = efa_retrieve_hw_counter_value(cmdline_args.server_id, "rdma_read_bytes")
     client_send_bytes_before_test = efa_retrieve_hw_counter_value(cmdline_args.client_id, "send_bytes")
 


### PR DESCRIPTION
Currently, test_runt fails on system with older version of EFA kernel module, which does not support some HW counters.

This patch address the issue by skipping the test under such case.