### PR TITLE
core: Fix altering of MR mode with FI_MR_UNSPEC

### DIFF
--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -1143,7 +1143,7 @@ static void fi_alter_domain_attr(struct fi_domain_attr *attr,
 {
 	int hints_mr_mode;
 
-	hints_mr_mode = hints ? hints->mr_mode : 0;
+	hints_mr_mode = hints ? hints->mr_mode : FI_MR_UNSPEC;
 	if (hints_mr_mode & (FI_MR_BASIC | FI_MR_SCALABLE)) {
 		attr->mr_mode = hints_mr_mode;
 	} else if (FI_VERSION_LT(api_version, FI_VERSION(1, 5))) {
@@ -1151,12 +1151,12 @@ static void fi_alter_domain_attr(struct fi_domain_attr *attr,
 				FI_MR_BASIC : FI_MR_SCALABLE;
 	} else {
 		attr->mr_mode &= ~(FI_MR_BASIC | FI_MR_SCALABLE);
-
-		if (hints &&
-		    ((hints_mr_mode & attr->mr_mode) != attr->mr_mode)) {
+		if (hints_mr_mode == FI_MR_UNSPEC)
 			attr->mr_mode = ofi_cap_mr_mode(info_caps,
-						attr->mr_mode & hints_mr_mode);
-		}
+							attr->mr_mode);
+		else
+			attr->mr_mode = ofi_cap_mr_mode(info_caps,
+							attr->mr_mode & hints_mr_mode);
 	}
 
 	attr->caps = ofi_get_caps(info_caps, hints ? hints->caps : 0, attr->caps);


### PR DESCRIPTION
Prior to this change, if the hints had FI_MR_UNSPEC set for domain
attribute mr_mode field, fi_alter_domain_attr() would AND the provider
mr_mode bits against FI_MR_UNSPEC thus zeroing the returned mr_mode
bits.

FI_MR_UNSPEC may be used to indicate support for any registration mode.
If FI_MR_UNSPEC is set, instead of zeroing provider returned mr_mode
bits, set the mr_mode bits based on requested capabilities and default
provider mr_mode bits.

Signed-off-by: Ian Ziemba <ian.ziemba@hpe.com>