### PR TITLE
prov/rxm: stop growing ep->rx_pool on connection attempt

### DIFF
--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -370,6 +370,7 @@ ofi_bufpool_create(struct ofi_bufpool **buf_pool,
 	return ofi_bufpool_create_attr(&attr, buf_pool);
 }
 
+void ofi_bufpool_reset(struct ofi_bufpool *pool);
 void ofi_bufpool_destroy(struct ofi_bufpool *pool);
 
 int ofi_bufpool_grow(struct ofi_bufpool *pool);

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -87,6 +87,10 @@ static void rxm_close_conn(struct rxm_conn *conn)
 	}
 	fi_close(&conn->msg_ep->fid);
 	rxm_flush_msg_cq(conn->ep);
+
+	if ((!conn->ep->srx_ctx) && (conn->state != RXM_CM_CONNECTED))
+		ofi_bufpool_reset(conn->ep->rx_pool);
+
 	dlist_remove_init(&conn->loopback_entry);
 	conn->msg_ep = NULL;
 


### PR DESCRIPTION
This fixes https://github.com/ofiwg/libfabric/issues/7837

When execute fi_rma_bw -p verbs <server_ip> without
a server instance listening on <server_ip>, it will
rapidly consume memory and MRs.  The cause is on every
connection attempt, rxm_prepost_recv is allocating and
posting RX buffers without freeing the buffers back
to rx_pool after connection failure.  Add ofi_bufpool_reset()
to put all buffers in a pool back to free_list and only
call it if there is no srx_ctx and connection has not been
established.

Signed-off-by: Chien Tin Tung <chien.tin.tung@intel.com>