### PR TITLE
prov/net: First set of patches to improve unexpected msg handling

### DIFF
--- a/include/ofi_epoll.h
+++ b/include/ofi_epoll.h
@@ -96,10 +96,16 @@ struct ofi_pollfds {
 
 int ofi_pollfds_create(struct ofi_pollfds **pfds);
 int ofi_pollfds_grow(struct ofi_pollfds *pfds, int max_size);
+
+/* Adding or modifying an fd to watch for non-zero events automatically
+ * adds it to the hot set if enabled.  If events is 0, the fd will be
+ * removed from the hot set if present.
+ */
 int ofi_pollfds_add(struct ofi_pollfds *pfds, int fd, uint32_t events,
 		    void *context);
 int ofi_pollfds_mod(struct ofi_pollfds *pfds, int fd, uint32_t events,
 		    void *context);
+
 int ofi_pollfds_del(struct ofi_pollfds *pfds, int fd);
 int ofi_pollfds_hotties(struct ofi_pollfds *pfds,
 		        struct ofi_epollfds_event *events, int maxevents);

--- a/include/ofi_indexer.h
+++ b/include/ofi_indexer.h
@@ -179,8 +179,10 @@ ofi_array_init(struct ofi_dyn_arr *arr, size_t item_size,
 }
 
 int ofi_array_grow(struct ofi_dyn_arr *arr, int index);
-void ofi_array_iter(struct ofi_dyn_arr *arr,
-		    void (*callback)(struct ofi_dyn_arr *arr, void *item));
+/* Returning non-zero from callback breaks iteration */
+void ofi_array_iter(struct ofi_dyn_arr *arr, void *context,
+		    int (*callback)(struct ofi_dyn_arr *arr, void *item,
+				    void *context));
 void ofi_array_destroy(struct ofi_dyn_arr *arr);
 
 static inline char *ofi_array_chunk(struct ofi_dyn_arr *arr, int index)

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -204,7 +204,7 @@ struct xnet_ep {
 	void (*hdr_bswap)(struct xnet_base_hdr *hdr);
 	void (*report_success)(struct xnet_ep *ep, struct util_cq *cq,
 			       struct xnet_xfer_entry *xfer_entry);
-	bool			pollout_set;
+	short			pollflags;
 	bool			is_active;
 };
 
@@ -310,7 +310,6 @@ void xnet_progress_unexp(struct xnet_progress *progress,
 			   struct dlist_entry *list);
 
 int xnet_trywait(struct fid_fabric *fid_fabric, struct fid **fids, int count);
-void xnet_update_pollout(struct xnet_ep *ep);
 int xnet_monitor_sock(struct xnet_progress *progress, SOCKET sock,
 		      uint32_t events, struct fid *fid);
 void xnet_halt_sock(struct xnet_progress *progress, SOCKET sock);

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -513,12 +513,9 @@ xnet_tx_completion_flag(struct xnet_ep *ep, uint64_t op_flags)
 }
 
 static inline uint64_t
-xnet_rx_completion_flag(struct xnet_ep *ep, uint64_t op_flags)
+xnet_rx_completion_flag(struct xnet_ep *ep)
 {
-	/* Generate a completion if op flags indicate or we generate
-	 * completions by default
-	 */
-	return (ep->util_ep.rx_op_flags | op_flags) & FI_COMPLETION;
+	return ep->util_ep.rx_op_flags & FI_COMPLETION;
 }
 
 static inline struct xnet_xfer_entry *

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -277,7 +277,8 @@ struct xnet_progress {
 	struct ofi_genlock	rdm_lock;
 	struct ofi_genlock	*active_lock;
 
-	struct dlist_entry	need_rx_list;
+	struct dlist_entry	need_msg_list;
+	struct dlist_entry	need_tag_list;
 	struct fd_signal	signal;
 
 	struct slist		event_list;

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -277,8 +277,7 @@ struct xnet_progress {
 	struct ofi_genlock	rdm_lock;
 	struct ofi_genlock	*active_lock;
 
-	struct dlist_entry	rx_wait_list;
-	struct dlist_entry	rx_poll_list;
+	struct dlist_entry	need_rx_list;
 	struct fd_signal	signal;
 
 	struct slist		event_list;

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -290,6 +290,7 @@ struct xnet_progress {
 	struct ofi_bufpool	*xfer_pool;
 
 	struct ofi_pollfds	*pollfds;
+	int			poll_fairness;
 	int			fairness_cntr;
 
 	bool			auto_progress;

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -88,6 +88,7 @@ extern int xnet_disable_autoprog;
 
 struct xnet_xfer_entry;
 struct xnet_ep;
+struct xnet_rdm;
 struct xnet_progress;
 struct xnet_domain;
 
@@ -156,7 +157,6 @@ struct xnet_cur_tx {
 struct xnet_srx {
 	struct fid_ep		rx_fid;
 	struct xnet_domain	*domain;
-	struct xnet_cq		*cq;
 	struct slist		rx_queue;
 	struct slist		tag_queue;
 	struct ofi_dyn_arr	src_tag_queues;
@@ -168,6 +168,10 @@ struct xnet_srx {
 	struct ofi_bufpool	*buf_pool;
 	uint64_t		op_flags;
 	size_t			min_multi_recv_size;
+
+	/* Internal use when srx is part of rdm endpoint */
+	struct xnet_rdm		*rdm;
+	struct xnet_cq		*cq;
 };
 
 int xnet_srx_context(struct fid_domain *domain, struct fi_rx_attr *attr,
@@ -239,6 +243,7 @@ int xnet_rdm_ep(struct fid_domain *domain, struct fi_info *info,
 		struct fid_ep **ep_fid, void *context);
 ssize_t xnet_get_conn(struct xnet_rdm *rdm, fi_addr_t dest_addr,
 		      struct xnet_conn **conn);
+struct xnet_ep *xnet_get_ep(struct xnet_rdm *rdm, fi_addr_t addr);
 void xnet_freeall_conns(struct xnet_rdm *rdm);
 
 /* Serialization is handled at the progress instance level, using the
@@ -301,6 +306,8 @@ void xnet_run_progress(struct xnet_progress *progress, bool clear_signal);
 int xnet_progress_wait(struct xnet_progress *progress, int timeout);
 void xnet_run_conn(struct xnet_conn_handle *conn, bool pin, bool pout, bool perr);
 void xnet_handle_event_list(struct xnet_progress *progress);
+void xnet_progress_unexp(struct xnet_progress *progress,
+			   struct dlist_entry *list);
 
 int xnet_trywait(struct fid_fabric *fid_fabric, struct fid **fids, int count);
 void xnet_update_pollout(struct xnet_ep *ep);

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -568,9 +568,7 @@ xnet_alloc_tx(struct xnet_ep *ep)
 	return xfer;
 }
 
-/* If we've buffered receive data, it counts the same as if a POLLIN
- * event were set, and we need to process the data.
- * We also need to progress receives in the case where we're waiting
+/* We need to progress receives in the case where we're waiting
  * on the application to post a buffer to consume a receive
  * that we've already read from the kernel.  If the message is
  * of length 0, there's no additional data to read, so calling
@@ -579,8 +577,7 @@ xnet_alloc_tx(struct xnet_ep *ep)
 static inline bool xnet_need_rx(struct xnet_ep *ep)
 {
 	assert(xnet_progress_locked(xnet_ep2_progress(ep)));
-	return ofi_bsock_readable(&ep->bsock) ||
-	       (ep->cur_rx.handler && !ep->cur_rx.entry);
+	return ep->cur_rx.handler && !ep->cur_rx.entry;
 }
 
 #define XNET_WARN_ERR(subsystem, log_str, err) \

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -185,7 +185,7 @@ struct xnet_ep {
 	OFI_DBG_VAR(uint8_t, tx_id)
 	OFI_DBG_VAR(uint8_t, rx_id)
 
-	struct dlist_entry	need_rx_entry; /* protected by progress->lock */
+	struct dlist_entry	unexp_entry;
 	struct slist		rx_queue;
 	struct slist		tx_queue;
 	struct slist		priority_queue;
@@ -282,8 +282,8 @@ struct xnet_progress {
 	struct ofi_genlock	rdm_lock;
 	struct ofi_genlock	*active_lock;
 
-	struct dlist_entry	need_msg_list;
-	struct dlist_entry	need_tag_list;
+	struct dlist_entry	unexp_msg_list;
+	struct dlist_entry	unexp_tag_list;
 	struct fd_signal	signal;
 
 	struct slist		event_list;
@@ -579,7 +579,7 @@ xnet_alloc_tx(struct xnet_ep *ep)
  * of length 0, there's no additional data to read, so calling
  * poll without forcing progress can result in application hangs.
  */
-static inline bool xnet_need_rx(struct xnet_ep *ep)
+static inline bool xnet_has_unexp(struct xnet_ep *ep)
 {
 	assert(xnet_progress_locked(xnet_ep2_progress(ep)));
 	return ep->cur_rx.handler && !ep->cur_rx.entry;

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -205,7 +205,7 @@ struct xnet_ep {
 	void (*report_success)(struct xnet_ep *ep, struct util_cq *cq,
 			       struct xnet_xfer_entry *xfer_entry);
 	short			pollflags;
-	bool			is_active;
+	bool			is_hot;
 };
 
 struct xnet_event {

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -195,7 +195,7 @@ struct xnet_ep {
 	int			rx_avail;
 	struct xnet_srx		*srx;
 
-	int			progress_cnt;
+	int			hit_cnt;
 	enum xnet_state		state;
 	struct util_peer_addr	*peer;
 	struct xnet_conn_handle *conn;

--- a/prov/net/src/xnet_cm.c
+++ b/prov/net/src/xnet_cm.c
@@ -134,7 +134,6 @@ int xnet_send_cm_msg(struct xnet_ep *ep)
 
 void xnet_req_done(struct xnet_ep *ep)
 {
-	struct xnet_progress *progress;
 	struct xnet_cm_entry cm_entry;
 	uint16_t len;
 	ssize_t ret;
@@ -171,12 +170,7 @@ void xnet_req_done(struct xnet_ep *ep)
 		goto disable;
 	}
 
-	if (xnet_need_rx(ep)) {
-		progress = xnet_ep2_progress(ep);
-		dlist_insert_tail(&ep->need_rx_entry,
-				  &progress->need_rx_list);
-		xnet_signal_progress(progress);
-	}
+	assert(!ofi_bsock_readable(&ep->bsock) && !ep->cur_rx.handler);
 	ep->state = XNET_CONNECTED;
 	free(ep->cm_msg);
 	ep->cm_msg = NULL;

--- a/prov/net/src/xnet_cm.c
+++ b/prov/net/src/xnet_cm.c
@@ -128,7 +128,7 @@ int xnet_send_cm_msg(struct xnet_ep *ep)
 	if ((size_t) ret != len)
 		return ofi_sockerr() ? -ofi_sockerr() : -FI_EIO;
 
-	ep->progress_cnt++;
+	ep->hit_cnt++;
 	return FI_SUCCESS;
 }
 
@@ -153,7 +153,7 @@ void xnet_req_done(struct xnet_ep *ep)
 		goto disable;
 	}
 
-	ep->progress_cnt++;
+	ep->hit_cnt++;
 	ep->hdr_bswap = (ep->cm_msg->hdr.conn_data == 1) ?
 			xnet_hdr_none : xnet_hdr_bswap;
 

--- a/prov/net/src/xnet_cm.c
+++ b/prov/net/src/xnet_cm.c
@@ -272,6 +272,7 @@ void xnet_connect_done(struct xnet_ep *ep)
 		goto disable;
 
 	ep->state = XNET_REQ_SENT;
+	ep->is_hot = true;
 	ep->pollflags = POLLIN;
 	ofi_pollfds_mod(progress->pollfds, ep->bsock.sock,
 			ep->pollflags, &ep->util_ep.ep_fid.fid);

--- a/prov/net/src/xnet_cm.c
+++ b/prov/net/src/xnet_cm.c
@@ -174,7 +174,7 @@ void xnet_req_done(struct xnet_ep *ep)
 	if (xnet_need_rx(ep)) {
 		progress = xnet_ep2_progress(ep);
 		dlist_insert_tail(&ep->need_rx_entry,
-				  &progress->rx_poll_list);
+				  &progress->need_rx_list);
 		xnet_signal_progress(progress);
 	}
 	ep->state = XNET_CONNECTED;

--- a/prov/net/src/xnet_ep.c
+++ b/prov/net/src/xnet_ep.c
@@ -180,10 +180,10 @@ static int xnet_ep_connect(struct fid_ep *ep_fid, const void *addr,
 		return ret;
 	}
 
-	ep->pollout_set = true;
 	progress = xnet_ep2_progress(ep);
 	ofi_genlock_lock(&progress->lock);
-	ret = xnet_monitor_sock(progress, ep->bsock.sock, POLLOUT,
+	ep->pollflags = POLLOUT;
+	ret = xnet_monitor_sock(progress, ep->bsock.sock, ep->pollflags,
 				&ep->util_ep.ep_fid.fid);
 	ofi_genlock_unlock(&progress->lock);
 	if (ret)
@@ -237,7 +237,8 @@ xnet_ep_accept(struct fid_ep *ep_fid, const void *param, size_t paramlen)
 
 	progress = xnet_ep2_progress(ep);
 	ofi_genlock_lock(&progress->lock);
-	ret = xnet_monitor_sock(progress, ep->bsock.sock, POLLIN,
+	ep->pollflags = POLLIN;
+	ret = xnet_monitor_sock(progress, ep->bsock.sock, ep->pollflags,
 				&ep->util_ep.ep_fid.fid);
 	ofi_genlock_unlock(&progress->lock);
 	if (ret)

--- a/prov/net/src/xnet_ep.c
+++ b/prov/net/src/xnet_ep.c
@@ -233,16 +233,12 @@ xnet_ep_accept(struct fid_ep *ep_fid, const void *param, size_t paramlen)
 	free(ep->cm_msg);
 	ep->cm_msg = NULL;
 	ep->state = XNET_CONNECTED;
+	assert(!ofi_bsock_readable(&ep->bsock) && !ep->cur_rx.handler);
 
 	progress = xnet_ep2_progress(ep);
 	ofi_genlock_lock(&progress->lock);
 	ret = xnet_monitor_sock(progress, ep->bsock.sock, POLLIN,
 				&ep->util_ep.ep_fid.fid);
-	if (!ret && xnet_need_rx(ep)) {
-		dlist_insert_tail(&ep->need_rx_entry,
-				  &progress->need_rx_list);
-		xnet_signal_progress(progress);
-	}
 	ofi_genlock_unlock(&progress->lock);
 	if (ret)
 		return ret;

--- a/prov/net/src/xnet_ep.c
+++ b/prov/net/src/xnet_ep.c
@@ -182,6 +182,7 @@ static int xnet_ep_connect(struct fid_ep *ep_fid, const void *addr,
 
 	progress = xnet_ep2_progress(ep);
 	ofi_genlock_lock(&progress->lock);
+	ep->is_hot = true;
 	ep->pollflags = POLLOUT;
 	ret = xnet_monitor_sock(progress, ep->bsock.sock, ep->pollflags,
 				&ep->util_ep.ep_fid.fid);
@@ -237,6 +238,7 @@ xnet_ep_accept(struct fid_ep *ep_fid, const void *param, size_t paramlen)
 
 	progress = xnet_ep2_progress(ep);
 	ofi_genlock_lock(&progress->lock);
+	ep->is_hot = true;
 	ep->pollflags = POLLIN;
 	ret = xnet_monitor_sock(progress, ep->bsock.sock, ep->pollflags,
 				&ep->util_ep.ep_fid.fid);

--- a/prov/net/src/xnet_ep.c
+++ b/prov/net/src/xnet_ep.c
@@ -240,7 +240,7 @@ xnet_ep_accept(struct fid_ep *ep_fid, const void *param, size_t paramlen)
 				&ep->util_ep.ep_fid.fid);
 	if (!ret && xnet_need_rx(ep)) {
 		dlist_insert_tail(&ep->need_rx_entry,
-				  &progress->rx_poll_list);
+				  &progress->need_rx_list);
 		xnet_signal_progress(progress);
 	}
 	ofi_genlock_unlock(&progress->lock);

--- a/prov/net/src/xnet_ep.c
+++ b/prov/net/src/xnet_ep.c
@@ -323,7 +323,7 @@ void xnet_ep_disable(struct xnet_ep *ep, int cm_err, void* err_data,
 		return;
 	};
 
-	dlist_remove_init(&ep->need_rx_entry);
+	dlist_remove_init(&ep->unexp_entry);
 	xnet_halt_sock(xnet_ep2_progress(ep), ep->bsock.sock);
 
 	ret = ofi_shutdown(ep->bsock.sock, SHUT_RDWR);
@@ -476,7 +476,7 @@ static int xnet_ep_close(struct fid *fid)
 
 	progress = xnet_ep2_progress(ep);
 	ofi_genlock_lock(&progress->lock);
-	dlist_remove_init(&ep->need_rx_entry);
+	dlist_remove_init(&ep->unexp_entry);
 	xnet_halt_sock(progress, ep->bsock.sock);
 	xnet_ep_flush_all_queues(ep);
 	ofi_genlock_unlock(&progress->lock);
@@ -682,7 +682,7 @@ int xnet_endpoint(struct fid_domain *domain, struct fi_info *info,
 		goto err3;
 	}
 
-	dlist_init(&ep->need_rx_entry);
+	dlist_init(&ep->unexp_entry);
 	slist_init(&ep->rx_queue);
 	slist_init(&ep->tx_queue);
 	slist_init(&ep->priority_queue);

--- a/prov/net/src/xnet_msg.c
+++ b/prov/net/src/xnet_msg.c
@@ -150,8 +150,8 @@ xnet_queue_recv(struct xnet_ep *ep, struct xnet_xfer_entry *recv_entry)
 		slist_insert_tail(&recv_entry->entry, &ep->rx_queue);
 		ep->rx_avail--;
 
-		if (xnet_need_rx(ep)) {
-			assert(!dlist_empty(&ep->need_rx_entry));
+		if (xnet_has_unexp(ep)) {
+			assert(!dlist_empty(&ep->unexp_entry));
 			xnet_progress_rx(ep);
 		}
 	}

--- a/prov/net/src/xnet_msg.c
+++ b/prov/net/src/xnet_msg.c
@@ -175,8 +175,7 @@ xnet_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t flags)
 	memcpy(&recv_entry->iov[0], &msg->msg_iov[0],
 	       msg->iov_count * sizeof(struct iovec));
 
-	recv_entry->cq_flags = xnet_rx_completion_flag(ep, flags) |
-			       FI_MSG | FI_RECV;
+	recv_entry->cq_flags = (flags & FI_COMPLETION) | FI_MSG | FI_RECV;
 	recv_entry->cntr_inc = ofi_ep_rx_cntr_inc;
 	recv_entry->context = msg->context;
 
@@ -210,8 +209,7 @@ xnet_recv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 	recv_entry->iov[0].iov_base = buf;
 	recv_entry->iov[0].iov_len = len;
 
-	recv_entry->cq_flags = xnet_rx_completion_flag(ep, 0) |
-			       FI_MSG | FI_RECV;
+	recv_entry->cq_flags = FI_MSG | FI_RECV;
 	recv_entry->cntr_inc = ofi_ep_rx_cntr_inc;
 	recv_entry->context = context;
 
@@ -245,8 +243,7 @@ xnet_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 
 	recv_entry->iov_cnt = count;
 	memcpy(recv_entry->iov, iov, count * sizeof(*iov));
-	recv_entry->cq_flags = xnet_rx_completion_flag(ep, 0) |
-			       FI_MSG | FI_RECV;
+	recv_entry->cq_flags = FI_MSG | FI_RECV;
 	recv_entry->cntr_inc = ofi_ep_rx_cntr_inc;
 	recv_entry->context = context;
 

--- a/prov/net/src/xnet_msg.c
+++ b/prov/net/src/xnet_msg.c
@@ -149,6 +149,11 @@ xnet_queue_recv(struct xnet_ep *ep, struct xnet_xfer_entry *recv_entry)
 	if (ret) {
 		slist_insert_tail(&recv_entry->entry, &ep->rx_queue);
 		ep->rx_avail--;
+
+		if (xnet_need_rx(ep)) {
+			assert(!dlist_empty(&ep->need_rx_entry));
+			xnet_progress_rx(ep);
+		}
 	}
 	return ret;
 }

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -49,7 +49,7 @@ static ssize_t (*xnet_start_op[ofi_op_write + 1])(struct xnet_ep *ep);
 
 static inline void xnet_active_ep(struct xnet_ep *ep)
 {
-	ep->progress_cnt++;
+	ep->hit_cnt++;
 	if (ep->is_active || !ofi_poll_fairness)
 		return;
 
@@ -785,8 +785,8 @@ static bool xnet_is_active(void *ctx)
 
 	/* If we're connecting, keep the socket as hot until the connection
 	 * completes.  (Note that the disconnecting path removes the socket
-	 * from the hot set).  We don't reset the progress_cnt values in the
-	 * connecting case, so that they remain set after the connection
+	 * from the hot set).  We don't reset the hit_cnt value in the
+	 * connecting case, so it remain set after the connection
 	 * completes.  This ensures that we get at least 1 pass through the
 	 * fairness counter where the new connection is considered hot before
 	 * we remove it.
@@ -794,8 +794,8 @@ static bool xnet_is_active(void *ctx)
 	if (ep->state != XNET_CONNECTED)
 		return true;
 
-	if (ep->progress_cnt) {
-		ep->progress_cnt = 0;
+	if (ep->hit_cnt) {
+		ep->hit_cnt = 0;
 		return true;
 	}
 

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -841,8 +841,8 @@ xnet_handle_events(struct xnet_progress *progress,
 	xnet_handle_event_list(progress);
 }
 
-static void
-xnet_progress_need_rx(struct xnet_progress *progress, struct dlist_entry *list)
+void xnet_progress_unexp(struct xnet_progress *progress,
+			 struct dlist_entry *list)
 {
 	struct dlist_entry *item, *tmp;
 	struct xnet_ep *ep;
@@ -866,8 +866,8 @@ void xnet_run_progress(struct xnet_progress *progress, bool clear_signal)
 
 	assert(ofi_genlock_held(progress->active_lock));
 	if (!progress->fairness_cntr) {
-		xnet_progress_need_rx(progress, &progress->need_msg_list);
-		xnet_progress_need_rx(progress, &progress->need_tag_list);
+		xnet_progress_unexp(progress, &progress->need_msg_list);
+		xnet_progress_unexp(progress, &progress->need_tag_list);
 	}
 
 	if (progress->fairness_cntr) {

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -387,7 +387,6 @@ static struct xnet_xfer_entry *xnet_get_rx_entry(struct xnet_ep *ep)
 		if (!slist_empty(&srx->rx_queue)) {
 			xfer = container_of(slist_remove_head(&srx->rx_queue),
 					    struct xnet_xfer_entry, entry);
-			xfer->cq_flags |= xnet_rx_completion_flag(ep, 0);
 		} else {
 			xfer = NULL;
 		}
@@ -446,6 +445,7 @@ static ssize_t xnet_op_msg(struct xnet_ep *ep)
 		return -FI_EAGAIN;
 	}
 
+	rx_entry->cq_flags |= xnet_rx_completion_flag(ep);
 	memcpy(&rx_entry->hdr, &msg->hdr,
 	       (size_t) msg->hdr.base_hdr.hdr_size);
 	rx_entry->ep = ep;
@@ -499,7 +499,7 @@ static ssize_t xnet_op_tagged(struct xnet_ep *ep)
 		return -FI_EAGAIN;
 	}
 
-	rx_entry->cq_flags |= xnet_rx_completion_flag(ep, 0);
+	rx_entry->cq_flags |= xnet_rx_completion_flag(ep);
 	memcpy(&rx_entry->hdr, &msg->hdr,
 	       (size_t) msg->hdr.base_hdr.hdr_size);
 	rx_entry->ep = ep;

--- a/prov/net/src/xnet_rdm.c
+++ b/prov/net/src/xnet_rdm.c
@@ -704,6 +704,8 @@ static int xnet_enable_rdm(struct xnet_rdm *rdm)
 
 	(void) fi_ep_bind(&rdm->srx->rx_fid, &rdm->util_ep.rx_cq->cq_fid.fid,
 			  FI_RECV);
+	(void) fi_ep_bind(&rdm->srx->rx_fid, &rdm->util_ep.ep_fid.fid,
+			  FI_TAGGED | FI_MSG);
 	progress = xnet_rdm2_progress(rdm);
 	ofi_genlock_lock(&progress->rdm_lock);
 

--- a/prov/net/src/xnet_rdm_cm.c
+++ b/prov/net/src/xnet_rdm_cm.c
@@ -355,6 +355,18 @@ ssize_t xnet_get_conn(struct xnet_rdm *rdm, fi_addr_t addr,
 	return 0;
 }
 
+struct xnet_ep *xnet_get_ep(struct xnet_rdm *rdm, fi_addr_t addr)
+{
+	struct util_peer_addr **peer;
+	struct xnet_conn *conn;
+
+	assert(xnet_progress_locked(xnet_rdm2_progress(rdm)));
+	peer = ofi_av_addr_context(rdm->util_ep.av, addr);
+	conn = ofi_idm_lookup(&rdm->conn_idx_map, (*peer)->index);
+	return conn && conn->ep && (conn->ep->state == XNET_CONNECTED) ?
+		conn->ep : NULL;
+}
+
 void xnet_process_connect(struct fi_eq_cm_entry *cm_entry)
 {
 	struct xnet_rdm_cm *msg;

--- a/prov/net/src/xnet_srx.c
+++ b/prov/net/src/xnet_srx.c
@@ -458,14 +458,15 @@ static void xnet_srx_cleanup(struct xnet_srx *srx, struct slist *queue)
 	}
 }
 
-static void xnet_srx_cleanup_arr(struct ofi_dyn_arr *arr, void *list)
+static int
+xnet_srx_cleanup_arr(struct ofi_dyn_arr *arr, void *list, void *context)
 {
-	struct xnet_srx *srx;
+	struct xnet_srx *srx = context;
 	struct slist *queue = list;
 
-	srx = container_of(arr, struct xnet_srx, src_tag_queues);
 	if (!slist_empty(queue))
 		xnet_srx_cleanup(srx, queue);
+	return 0;
 }
 
 static int xnet_srx_close(struct fid *fid)
@@ -476,7 +477,7 @@ static int xnet_srx_close(struct fid *fid)
 
 	xnet_srx_cleanup(srx, &srx->rx_queue);
 	xnet_srx_cleanup(srx, &srx->tag_queue);
-	ofi_array_iter(&srx->src_tag_queues, xnet_srx_cleanup_arr);
+	ofi_array_iter(&srx->src_tag_queues, srx, xnet_srx_cleanup_arr);
 	ofi_array_destroy(&srx->src_tag_queues);
 
 	if (srx->cq)

--- a/prov/net/src/xnet_srx.c
+++ b/prov/net/src/xnet_srx.c
@@ -59,9 +59,8 @@ xnet_srx_msg(struct xnet_srx *srx, struct xnet_xfer_entry *recv_entry)
 	slist_insert_tail(&recv_entry->entry, &srx->rx_queue);
 
 	if (!dlist_empty(&progress->unexp_msg_list)) {
-		dlist_pop_front(&progress->unexp_msg_list, struct xnet_ep,
-				ep, unexp_entry);
-		dlist_init(&ep->unexp_entry);
+		ep = container_of(progress->unexp_msg_list.next,
+				  struct xnet_ep, unexp_entry);
 		xnet_progress_rx(ep);
 	}
 }

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -257,17 +257,22 @@ nomem:
 	return -1;
 }
 
-void ofi_array_iter(struct ofi_dyn_arr *arr,
-		    void (*callback)(struct ofi_dyn_arr *arr, void *item))
+void ofi_array_iter(struct ofi_dyn_arr *arr, void *context,
+		    int (*callback)(struct ofi_dyn_arr *arr, void *item,
+				    void *context))
 {
-	int c, i;
+	int ret, c, i;
 
 	for (c = 0; c < OFI_IDX_MAX_CHUNKS; c++) {
 		if (!arr->chunk[c])
 			continue;
 
-		for (i = 0; i < OFI_IDX_CHUNK_SIZE; i++)
-			callback(arr, ofi_array_item(arr, arr->chunk[c], i));
+		for (i = 0; i < OFI_IDX_CHUNK_SIZE; i++) {
+			ret = callback(arr, ofi_array_item(arr, arr->chunk[c], i),
+				       context);
+			if (ret)
+				return;
+		}
 	}
 }
 


### PR DESCRIPTION
The objective of this series is to process unexpected messages as soon as the receive buffers for them are posted.  The changes are limited to source-targeted tagged receives.

The follow-on objective to these changes is to remove 'connections that need a receive buffer posted in order to proceed' from the general progress engine.  For example, remove the underlying sockets from monitored poll sets and as part of normal progress.  Progress would then resume once the receive buffer had been posted.