### PR TITLE
util: Free CQ aux entry memory leak

### DIFF
--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -260,6 +260,7 @@ ssize_t ofi_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 				src_addr[i] = aux_entry->src;
 			cq->read_entry(&buf, &aux_entry->comp);
 			slist_remove_head(&cq->aux_queue);
+			free(aux_entry);
 
 			if (slist_empty(&cq->aux_queue)) {
 				ofi_cirque_discard(cq->cirq);


### PR DESCRIPTION
In ofi_cq_readfrom, aux entries are removed from the aux queue but were
never freed.

ofi_cq_readerr does not have this issue.

Signed-off-by: Ian Ziemba <ian.ziemba@hpe.com>