### PR TITLE
[v1.15.x] configure: Check for alternative path of i915_drm.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -617,14 +617,19 @@ AS_IF([test x"$with_ze" != x"no"],
 AC_DEFINE_UNQUOTED([ENABLE_ZE_DLOPEN], [$ze_dlopen], [dlopen ZE libraries])
 
 have_drm=0
+have_libdrm=0
 AS_IF([test "$have_ze" = "1"],
-      [AC_CHECK_HEADER(drm/i915_drm.h, [have_drm=1])])
+      [AC_CHECK_HEADER(drm/i915_drm.h,
+		       [have_drm=1],
+		       [AC_CHECK_HEADER(libdrm/i915_drm.h,
+					[have_libdrm=1])])])
 
 AS_IF([test x"$with_ze" != x"no" && test -n "$with_ze" && test "$have_ze" = "0" ],
 	[AC_MSG_ERROR([ZE support requested but ZE runtime not available.])])
 
 AC_DEFINE_UNQUOTED([HAVE_ZE], [$have_ze], [ZE support])
 AC_DEFINE_UNQUOTED([HAVE_DRM], [$have_drm], [i915 DRM header])
+AC_DEFINE_UNQUOTED([HAVE_LIBDRM], [$have_libdrm], [i915 DRM header])
 
 AS_IF([test "$ze_dlopen" != "1"], [LIBS="$LIBS $ze_LIBS"])
 AS_IF([test "$have_ze" = "1" && test x"$with_ze" != x"yes"],

--- a/src/hmem_ze.c
+++ b/src/hmem_ze.c
@@ -309,8 +309,14 @@ ze_result_t ofi_zeDeviceGetProperties(ze_device_handle_t hDevice,
 	return (*libze_ops.zeDeviceGetProperties)(hDevice, pDeviceProperties);
 }
 
+#if HAVE_DRM || HAVE_LIBDRM
+
 #if HAVE_DRM
 #include <drm/i915_drm.h>
+#else
+#include <libdrm/i915_drm.h>
+#endif
+
 #include <sys/ioctl.h>
 #include <stdio.h>
 
@@ -427,7 +433,7 @@ bool ze_hmem_p2p_enabled(void)
 	return false;
 }
 
-#endif //HAVE_DRM
+#endif //HAVE_DRM || HAVE_LIBDRM
 
 static int ze_hmem_dl_init(void)
 {


### PR DESCRIPTION
The header 'i195_drm.h' could be under either '/usr/include/drm' or
'/usr/include/libdrm' depending on the system and the package it is
installed from.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>

Cherry-picked from commit 4749c3215aae90f374094cb1430306cea19a4137