### PR TITLE
[v1.15.x] core/fabric: Make PSM2 higher default priority

### DIFF
--- a/src/fabric.c
+++ b/src/fabric.c
@@ -411,7 +411,7 @@ static struct fi_provider *ofi_get_hook(const char *name)
 static void ofi_ordered_provs_init(void)
 {
 	char *ordered_prov_names[] = {
-		"efa", "opx", "psm2", "psm", "usnic", "gni", "bgq", "verbs",
+		"efa", "psm2", "opx", "psm", "usnic", "gni", "bgq", "verbs",
 		"netdir", "psm3", "ofi_rxm", "ofi_rxd", "shm",
 		/* Initialize the socket based providers last of the
 		 * standard providers.  This will result in them being


### PR DESCRIPTION
Until the opx provider is ready, psm2 should be
the default provider selected for Omnipath fabrics.

Change ofi_ordered_provs_init() accordingly

Signed-off-by: Tim Thompson <tim.thompson@cornelisnetworks.com>