### PR TITLE
contrib/intel: add ability to set specific environment variables per test

### DIFF
--- a/contrib/intel/jenkins/run.py
+++ b/contrib/intel/jenkins/run.py
@@ -16,23 +16,23 @@ fab = os.environ['FABRIC']#args.fabric
 jbname = os.environ['JOB_NAME']#args.jobname
 bno = os.environ['BUILD_NUMBER']#args.buildno
 
-def fi_info_test(core, hosts, mode, util):
+def fi_info_test(core, hosts, mode, user_env, util):
 
     fi_info_test = tests.FiInfoTest(jobname=jbname,buildno=bno,
                                     testname='fi_info', core_prov=core,
-                                    fabric=fab, hosts=hosts,
-                                    ofi_build_mode=mode, util_prov=util)
+                                    fabric=fab, hosts=hosts, ofi_build_mode=mode,
+                                    user_env=user_env, util_prov=util)
     print('-------------------------------------------------------------------')
     print(f"Running fi_info test for {core}-{util}-{fab}")
     fi_info_test.execute_cmd()
     print('-------------------------------------------------------------------')
 
-def fabtests(core, hosts, mode, util):
+def fabtests(core, hosts, mode, user_env, util):
 
     runfabtest = tests.Fabtest(jobname=jbname,buildno=bno,
                                testname='runfabtests', core_prov=core,
                                fabric=fab, hosts=hosts, ofi_build_mode=mode,
-                               util_prov=util)
+                               user_env=user_env, util_prov=util)
 
     print('-------------------------------------------------------------------')
     if (runfabtest.execute_condn):
@@ -42,12 +42,12 @@ def fabtests(core, hosts, mode, util):
         print(f"Skipping {core} {runfabtest.testname} as execute condition fails")
     print('-------------------------------------------------------------------')
 
-def shmemtest(core, hosts, mode, util):
+def shmemtest(core, hosts, mode, user_env, util):
 
     runshmemtest = tests.ShmemTest(jobname=jbname,buildno=bno,
                                    testname="shmem test", core_prov=core,
                                    fabric=fab, hosts=hosts,
-                                   ofi_build_mode=mode, util_prov=util)
+                                   ofi_build_mode=mode, user_env=user_env, util_prov=util)
 
     print('-------------------------------------------------------------------')
     if (runshmemtest.execute_condn):
@@ -68,11 +68,12 @@ def shmemtest(core, hosts, mode, util):
         print(f"Skipping {core} {runshmemtest.testname} as execute condition fails")
     print('-------------------------------------------------------------------')
 
-def ze_fabtests(core, hosts, mode, util):
+def ze_fabtests(core, hosts, mode, user_env, util):
     runzefabtests = tests.ZeFabtests(jobname=jbname,buildno=bno,
                                      testname="ze test", core_prov=core,
                                      fabric=fab, hosts=hosts,
-                                     ofi_build_mode=mode, util_prov=util)
+                                     ofi_build_mode=mode, user_env=user_env,
+                                     util_prov=util)
 
     print('-------------------------------------------------------------------')
     if (runzefabtests.execute_condn):
@@ -82,12 +83,12 @@ def ze_fabtests(core, hosts, mode, util):
         print(f"Skipping {core} {runzefabtests.testname} as execute condition fails")
     print('-------------------------------------------------------------------')
 
-def intel_mpi_benchmark(core, hosts, mpi, mode, group, util):
+def intel_mpi_benchmark(core, hosts, mpi, mode, group, user_env, util):
 
     imb = tests.IMBtests(jobname=jbname, buildno=bno,
                          testname='IntelMPIbenchmark', core_prov=core,
                          fabric=fab, hosts=hosts, mpitype=mpi,
-                         ofi_build_mode=mode, test_group=group,
+                         ofi_build_mode=mode, user_env=user_env, test_group=group,
                          util_prov=util)
 
     print('-------------------------------------------------------------------')
@@ -98,12 +99,13 @@ def intel_mpi_benchmark(core, hosts, mpi, mode, group, util):
         print(f"Skipping {mpi.upper} {imb.testname} as execute condition fails")
     print('-------------------------------------------------------------------')
 
-def mpich_test_suite(core, hosts, mpi, mode, util):
+def mpich_test_suite(core, hosts, mpi, mode, user_env, util):
 
     mpich_tests = tests.MpichTestSuite(jobname=jbname,buildno=bno,
                                        testname="MpichTestSuite",core_prov=core,
                                        fabric=fab, mpitype=mpi, hosts=hosts,
-                                       ofi_build_mode=mode, util_prov=util)
+                                       ofi_build_mode=mode, user_env=user_env,
+                                       util_prov=util)
 
     print('-------------------------------------------------------------------')
     if (mpich_tests.execute_condn == True):
@@ -113,12 +115,13 @@ def mpich_test_suite(core, hosts, mpi, mode, util):
         print(f"Skipping {mpi.upper()} {mpich_tests.testname} as exec condn fails")
     print('-------------------------------------------------------------------')
 
-def osu_benchmark(core, hosts, mpi, mode, util):
+def osu_benchmark(core, hosts, mpi, mode, user_env, util):
 
     osu_test = tests.OSUtests(jobname=jbname, buildno=bno,
                                 testname='osu-benchmarks', core_prov=core,
                                 fabric=fab, mpitype=mpi, hosts=hosts,
-                                ofi_build_mode=mode, util_prov=util)
+                                ofi_build_mode=mode, user_env=user_env,
+                                util_prov=util)
 
     print('-------------------------------------------------------------------')
     if (osu_test.execute_condn == True):
@@ -128,12 +131,13 @@ def osu_benchmark(core, hosts, mpi, mode, util):
         print(f"Skipping {mpi.upper()} {osu_test.testname} as exec condn fails")
     print('-------------------------------------------------------------------')
 
-def oneccltest(core, hosts, mode, util):
+def oneccltest(core, hosts, mode, user_env, util):
 
     runoneccltest = tests.OneCCLTests(jobname=jbname,buildno=bno,
                                       testname="oneccl test", core_prov=core,
                                       fabric=fab, hosts=hosts,
-                                      ofi_build_mode=mode, util_prov=util)
+                                      ofi_build_mode=mode, user_env=user_env,
+                                      util_prov=util)
 
     print('-------------------------------------------------------------------')
     if (runoneccltest.execute_condn):
@@ -147,12 +151,13 @@ def oneccltest(core, hosts, mode, util):
         print(f"Skipping {runoneccltest.testname} as execute condition fails")
     print('-------------------------------------------------------------------')
 
-def oneccltestgpu(core, hosts, mode, util):
+def oneccltestgpu(core, hosts, mode, user_env, util):
 
     runoneccltestgpu = tests.OneCCLTestsGPU(jobname=jbname,buildno=bno,
                                          testname="oneccl GPU test", core_prov=core,
                                          fabric=fab, hosts=hosts,
-                                         ofi_build_mode=mode, util_prov=util)
+                                         ofi_build_mode=mode, user_env=user_env,
+                                         util_prov=util)
 
     print('-------------------------------------------------------------------')
     if (runoneccltestgpu.execute_condn):

--- a/contrib/intel/jenkins/runtests.py
+++ b/contrib/intel/jenkins/runtests.py
@@ -19,12 +19,15 @@ parser.add_argument('--test', help="specify test to execute", \
 parser.add_argument('--imb_grp', help="IMB test group {1:[MPI1, P2P], \
                     2:[EXT, IO], 3:[NBC, RMA, MT]", choices=['1', '2', '3'])
 parser.add_argument('--device', help="optional gpu device", choices=['ze'])
+parser.add_argument('--user_env', help="Run with additional environment variables", \
+                    default='{}')
 
 args = parser.parse_args()
 args_core = args.prov
 
 args_util = args.util
 args_device = args.device
+user_env = args.user_env
 
 if (args.ofi_build_mode):
     ofi_build_mode = args.ofi_build_mode
@@ -60,32 +63,32 @@ if(args_core):
 
         if (args.device != 'ze'):
             if (run_test == 'all' or run_test == 'fabtests'):
-                run.fi_info_test(args_core, hosts, ofi_build_mode,
+                run.fi_info_test(args_core, hosts, ofi_build_mode, user_env,
                                  util=args.util)
-                run.fabtests(args_core, hosts, ofi_build_mode, args_util)
+                run.fabtests(args_core, hosts, ofi_build_mode, user_env, args_util)
 
             if (run_test == 'all' or run_test == 'shmem'):
-                run.shmemtest(args_core, hosts, ofi_build_mode, args_util)
+                run.shmemtest(args_core, hosts, ofi_build_mode, user_env, args_util)
 
             if (run_test == 'all' or run_test == 'oneccl'):
-                run.oneccltest(args_core, hosts, ofi_build_mode, args_util)
+                run.oneccltest(args_core, hosts, ofi_build_mode, user_env, args_util)
 
             if (run_test == 'all' or run_test == 'onecclgpu'):
-                run.oneccltestgpu(args_core, hosts, ofi_build_mode, args_util)
+                run.oneccltestgpu(args_core, hosts, ofi_build_mode, user_env, args_util)
 
             for mpi in mpilist:
                 if (run_test == 'all' or run_test == 'mpichtestsuite'):
                     run.mpich_test_suite(args_core, hosts, mpi,
-                                         ofi_build_mode, args_util)
+                                         ofi_build_mode, user_env, args_util)
                 if (run_test == 'all' or run_test == 'IMB'):
                     run.intel_mpi_benchmark(args_core, hosts, mpi,
                                             ofi_build_mode, imb_group,
-                                            args_util)
+                                            user_env, args_util)
                 if (run_test == 'all' or run_test == 'osu'):
                     run.osu_benchmark(args_core, hosts, mpi,
-                                      ofi_build_mode, args_util)
+                                      ofi_build_mode, user_env, args_util)
         else:
-            run.ze_fabtests(args_core, hosts, ofi_build_mode, args_util)
+            run.ze_fabtests(args_core, hosts, ofi_build_mode, user_env, args_util)
 
 else:
     print("Error : Specify a core provider to run tests")


### PR DESCRIPTION
Allow setting of environment variables per test run. This is specified through the
runtests.py arg --user_env with a string formatted as a dictionary. For example:

runtests.py --prov=shm --test=fabtests --slurm --user_env="{'FI_SHM_DISABLE_CMA':1,'FI_LOG_LEVEL'='info'}"

This lets us test certain runtime parameters for certain cases only.

This also removes the hard coded verbs variables because FI_VERBS_MR_CACHE_ENABLE was deprecated and
FI_VERBS_INLINE_SIZE is already defaulted to 256 bytes so setting it is redundant.

Signed-off-by: Alexia Ingerson <alexia.ingerson@intel.com>