### PR TITLE
contrib/intel/jenkins: Re-enable ze-shm stage

### DIFF
--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -249,14 +249,13 @@ class ZeFabtests(Test):
     def options(self):
         opts = f"-p {self.fabtestpath} "
         opts += f"-B {self.fabtestpath} "
+        opts += "-t h2d,d2d " #xd2d is failing
         opts += f"{self.server} {self.client} "
         return opts
 
     @property
     def execute_condn(self):
-        #disabled for failures we are investigating
-        return False
-#        return True if (self.core_prov == 'shm') else False
+        return True if (self.core_prov == 'shm') else False
 
     def execute_cmd(self):
         curdir = os.getcwd()


### PR DESCRIPTION
Add the ze-shm stage back to the CI and disable the actual failing test, (xd2d: cross device to device), rather than the whole stage

Signed-off-by: Zach Dworkin <zachary.dworkin@intel.com>