### PR TITLE
fabtests/common: add support for FI_MR_ENDPOINT

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -417,6 +417,16 @@ int ft_reg_mr(struct fi_info *fi, void *buf, size_t size, uint64_t access,
 	if (desc)
 		*desc = fi_mr_desc(*mr);
 
+        if (fi->domain_attr->mr_mode & FI_MR_ENDPOINT) {
+		ret = fi_mr_bind(*mr, &ep->fid, 0);
+		if (ret)
+			return ret;
+
+		ret = fi_mr_enable(*mr);
+		if (ret)
+			return ret;
+	}
+
 	return FI_SUCCESS;
 }
 
@@ -1598,6 +1608,8 @@ static void ft_close_fids(void)
 {
 	FT_CLOSE_FID(mc);
 	FT_CLOSE_FID(alias_ep);
+	if (mr != &no_mr)
+		FT_CLOSE_FID(mr);
 	FT_CLOSE_FID(ep);
 	FT_CLOSE_FID(pep);
 	if (opts.options & FT_OPT_CQ_SHARED) {
@@ -1609,8 +1621,6 @@ static void ft_close_fids(void)
 	FT_CLOSE_FID(rxcntr);
 	FT_CLOSE_FID(txcntr);
 	FT_CLOSE_FID(pollset);
-	if (mr != &no_mr)
-		FT_CLOSE_FID(mr);
 	FT_CLOSE_FID(av);
 	FT_CLOSE_FID(srx);
 	FT_CLOSE_FID(stx);

--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -478,7 +478,7 @@ static void ft_set_tx_rx_sizes(size_t *set_tx, size_t *set_rx)
  * buffer is large enough for a control message used to exchange addressing
  * data.
  */
-static int ft_alloc_msgs(void)
+int ft_alloc_msgs(void)
 {
 	int ret;
 	long alignment = 1;
@@ -623,10 +623,6 @@ int ft_alloc_ep_res(struct fi_info *fi, struct fid_cq **new_txcq,
 		    struct fid_cntr **new_rxcntr)
 {
 	int ret;
-
-	ret = ft_alloc_msgs();
-	if (ret)
-		return ret;
 
 	if (cq_attr.format == FI_CQ_FORMAT_UNSPEC) {
 		if (fi->caps & FI_TAGGED)
@@ -1260,6 +1256,10 @@ int ft_enable_ep_recv(void)
 	int ret;
 
 	ret = ft_enable_ep(ep, eq, av, txcq, rxcq, txcntr, rxcntr);
+	if (ret)
+		return ret;
+
+	ret = ft_alloc_msgs();
 	if (ret)
 		return ret;
 

--- a/fabtests/functional/scalable_ep.c
+++ b/fabtests/functional/scalable_ep.c
@@ -90,7 +90,7 @@ static int alloc_ep_res(struct fid_ep *sep)
 	rx_ep = calloc(ctx_cnt, sizeof *rx_ep);
 	remote_rx_addr = calloc(ctx_cnt, sizeof *remote_rx_addr);
 
-	if (!buf || !txcq_array || !rxcq_array || !tx_ep || !rx_ep || !remote_rx_addr) {
+	if (!txcq_array || !rxcq_array || !tx_ep || !rx_ep || !remote_rx_addr) {
 		perror("malloc");
 		return -1;
 	}
@@ -160,13 +160,6 @@ static int bind_ep_res(void)
 			FT_PRINTERR("fi_enable", ret);
 			return ret;
 		}
-
-		ret = fi_recv(rx_ep[i], rx_buf, MAX(rx_size, FT_MAX_CTRL_MSG),
-			      mr_desc, 0, NULL);
-		if (ret) {
-			FT_PRINTERR("fi_recv", ret);
-			return ret;
-		}
 	}
 
 	ret = fi_enable(sep);
@@ -175,6 +168,18 @@ static int bind_ep_res(void)
 		return ret;
 	}
 
+	ret = ft_alloc_msgs();
+	if (ret)
+		return ret;
+
+	for (i = 0; i < ctx_cnt; i++) {
+		ret = fi_recv(rx_ep[i], rx_buf, MAX(rx_size, FT_MAX_CTRL_MSG),
+			      mr_desc, 0, NULL);
+		if (ret) {
+			FT_PRINTERR("fi_recv", ret);
+			return ret;
+		}
+	}
 	return 0;
 }
 

--- a/fabtests/functional/scalable_ep.c
+++ b/fabtests/functional/scalable_ep.c
@@ -173,6 +173,15 @@ static int bind_ep_res(void)
 		return ret;
 
 	for (i = 0; i < ctx_cnt; i++) {
+		if (fi->domain_attr->mr_mode & FI_MR_ENDPOINT) {
+			ret = fi_mr_bind(mr, &rx_ep[i]->fid, 0);
+			if (ret)
+				return ret;
+
+			ret = fi_mr_enable(mr);
+			if (ret)
+				return ret;
+		}
 		ret = fi_recv(rx_ep[i], rx_buf, MAX(rx_size, FT_MAX_CTRL_MSG),
 			      mr_desc, 0, NULL);
 		if (ret) {

--- a/fabtests/functional/shared_ctx.c
+++ b/fabtests/functional/shared_ctx.c
@@ -298,6 +298,10 @@ static int init_fabric(void)
 	if (ret)
 		return ret;
 
+	ret = ft_alloc_msgs();
+	if (ret)
+		return ret;
+
 	/* Post recv */
 	if (srx)
 		ret = ft_post_rx(srx, MAX(rx_size, FT_MAX_CTRL_MSG), &rx_ctx);

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -409,6 +409,7 @@ int ft_connect_ep(struct fid_ep *ep,
 int ft_alloc_ep_res(struct fi_info *fi, struct fid_cq **new_txcq,
 		    struct fid_cq **new_rxcq, struct fid_cntr **new_txcntr,
 		    struct fid_cntr **new_rxcntr);
+int ft_alloc_msgs(void);
 int ft_alloc_active_res(struct fi_info *fi);
 int ft_enable_ep_recv(void);
 int ft_enable_ep(struct fid_ep *bind_ep, struct fid_eq *bind_eq, struct fid_av *bind_av,

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -282,7 +282,7 @@ extern char default_port[8];
 		.sizes_enabled = FT_DEFAULT_SIZE, \
 		.rma_op = FT_RMA_WRITE, \
 		.oob_port = NULL, \
-		.mr_mode = FI_MR_LOCAL | OFI_MR_BASIC_MAP, \
+		.mr_mode = FI_MR_LOCAL | FI_MR_ENDPOINT | OFI_MR_BASIC_MAP, \
 		.iface = FI_HMEM_SYSTEM, \
 		.device = 0, \
 		.argc = argc, .argv = argv, \

--- a/fabtests/multinode/src/core.c
+++ b/fabtests/multinode/src/core.c
@@ -131,6 +131,10 @@ static int multi_setup_fabric(int argc, char **argv)
 	if (ret)
 		return ret;
 
+	ret = ft_alloc_msgs();
+	if (ret)
+		return ret;
+
 	len = FT_MAX_CTRL_MSG;
 	ret = fi_getname(&ep->fid, (void *) my_name, &len);
 	if (ret) {


### PR DESCRIPTION
FI_MR_ENDPOINT requires binding MRs to endpoints and enabling them once they are bound
to all applicable endpoints. This adds that bind and enable and reorders some of the
resource initialization since MR_ENDPOINT requires the endpoint to be enabled at the
point of binding to the MR.

Signed-off-by: Alexia Ingerson <alexia.ingerson@intel.com>