### PR TITLE
prov/efa: update references to efadv_wc_read_sgid

### DIFF
--- a/prov/efa/configure.m4
+++ b/prov/efa/configure.m4
@@ -134,6 +134,17 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 			[efadv_support_extended_cq=0])
 	      ])
 
+	# efadv_wc_read_sgid is a static inline function, which is
+	# required to use extended CQ for recovering peer address.
+	# Extended CQ should be disabled if it is not available.
+	AS_IF([test $efadv_support_extended_cq -eq 1],
+		[AC_EGREP_HEADER(
+			[int efadv_wc_read_sgid],
+			[infiniband/efadv.h],
+			[],
+			[efadv_support_extended_cq=0])
+		])
+
 	AS_IF([test $efadv_support_extended_cq -eq 1],
 		[AC_DEFINE([HAVE_EFADV_CQ_EX], [1], [EFA device support extensible CQ])],
 		[AC_DEFINE([HAVE_EFADV_CQ_EX], [0], [EFA device does not support extensible CQ])]

--- a/prov/efa/src/efa_cq.c
+++ b/prov/efa/src/efa_cq.c
@@ -271,7 +271,7 @@ static inline int efa_cq_set_ibv_cq_ex(struct efa_cq *cq, struct fi_cq_attr *att
 	};
 	struct efadv_cq_init_attr efadv_cq_init_attr = {
 		.comp_mask = 0,
-		.wc_flags = EFADV_WC_EX_WITH_AH,
+		.wc_flags = EFADV_WC_EX_WITH_SGID,
 	};
 
 	if (cq->ibv_cq_ex) {

--- a/prov/efa/test/efa_unit_test_cq.c
+++ b/prov/efa/test/efa_unit_test_cq.c
@@ -343,10 +343,10 @@ static void test_impl_rdm_cq_read_unknow_peer_ah(bool remove_peer)
 
 	efadv_cq = efadv_cq_from_ibv_cq_ex(efa_cq->ibv_cq_ex);
 	assert_non_null(efadv_cq);
-	efadv_cq->wc_read_ah = &efa_mock_efadv_wc_read_ah_return_unknown_ah_and_expect_next_poll_and_set_gid;
+	efadv_cq->wc_read_sgid = &efa_mock_efadv_wc_read_sgid_return_zero_code_and_expect_next_poll_and_set_gid;
 
 	/* Return unknown AH from efadv */
-	will_return(efa_mock_efadv_wc_read_ah_return_unknown_ah_and_expect_next_poll_and_set_gid, raw_addr.raw);
+	will_return(efa_mock_efadv_wc_read_sgid_return_zero_code_and_expect_next_poll_and_set_gid, raw_addr.raw);
 
 	/* Read 1 entry with unknown AH */
 	will_return(efa_mock_ibv_start_poll_return_mock, 0);

--- a/prov/efa/test/efa_unit_test_mocks.c
+++ b/prov/efa/test/efa_unit_test_mocks.c
@@ -194,13 +194,13 @@ uint32_t efa_mock_ibv_read_slid_return_mock(struct ibv_cq_ex *current)
 	return mock();
 }
 
-int efa_mock_efadv_wc_read_ah_return_unknown_ah_and_expect_next_poll_and_set_gid(struct efadv_cq *efadv_cq, union ibv_gid *sgid)
+int efa_mock_efadv_wc_read_sgid_return_zero_code_and_expect_next_poll_and_set_gid(struct efadv_cq *efadv_cq, union ibv_gid *sgid)
 {
 	/* Make sure this mock is always called before ibv_next_poll */
 	expect_function_call(efa_mock_ibv_next_poll_check_function_called_and_return_mock);
 	memcpy(sgid->raw, (uint8_t *)mock(), sizeof(sgid->raw));
-	/* Must return a negative value for unknown AH */
-	return -ENOENT;
+	/* Must return 0 for unknown AH */
+	return 0;
 };
 
 int efa_mock_ibv_next_poll_check_function_called_and_return_mock(struct ibv_cq_ex *ibvcqx)

--- a/prov/efa/test/efa_unit_test_mocks.h
+++ b/prov/efa/test/efa_unit_test_mocks.h
@@ -53,7 +53,7 @@ struct efa_unit_test_mocks
 uint32_t efa_mock_ibv_read_src_qp_return_mock(struct ibv_cq_ex *current);
 uint32_t efa_mock_ibv_read_byte_len_return_mock(struct ibv_cq_ex *current);
 uint32_t efa_mock_ibv_read_slid_return_mock(struct ibv_cq_ex *current);
-int efa_mock_efadv_wc_read_ah_return_unknown_ah_and_expect_next_poll_and_set_gid(struct efadv_cq *efadv_cq, union ibv_gid *sgid);
+int efa_mock_efadv_wc_read_sgid_return_zero_code_and_expect_next_poll_and_set_gid(struct efadv_cq *efadv_cq, union ibv_gid *sgid);
 int efa_mock_ibv_start_poll_expect_efadv_wc_read_ah_and_return_mock(struct ibv_cq_ex *ibvcqx,
 																	struct ibv_poll_cq_attr *attr);
 int efa_mock_ibv_next_poll_check_function_called_and_return_mock(struct ibv_cq_ex *ibvcqx);


### PR DESCRIPTION
`efadv_wc_read_ah` is renamed to `efadv_wc_read_sgid` in rdma-core.
The new function does not return peer AH but instead 0(success) or
negative(peer AH is known).

Signed-off-by: Wenduo Wang <wenduwan@amazon.com>