### PR TITLE
prov/shm: Enhanced SHM implementation with DSA offload

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -508,7 +508,7 @@ pipeline {
               (
                 echo `hostname`
                 cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
-                python3.9 runtests.py --prov=shm --test=fabtests --user_env="{'FI_SHM_DISABLE_CMA':1, 'FI_SHM_USE_DSA_IN_SAR':1}"
+                python3.9 runtests.py --prov=shm --test=fabtests --user_env="{'FI_SHM_DISABLE_CMA':1, 'FI_SHM_USE_DSA_SAR':1}"
               )
               """
             }

--- a/include/ofi.h
+++ b/include/ofi.h
@@ -51,7 +51,6 @@
 #include <ofi_file.h>
 #include <ofi_lock.h>
 #include <ofi_atom.h>
-#include <ofi_mem.h>
 #include <ofi_net.h>
 #include <rdma/providers/fi_prov.h>
 #include <rdma/providers/fi_log.h>

--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -39,9 +39,9 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ofi.h>
 #include <ofi_list.h>
 #include <ofi_osd.h>
-
 
 #ifdef INCLUDE_VALGRIND
 #   include <valgrind/memcheck.h>
@@ -200,89 +200,109 @@ void dummy ## name (void) /* work-around global ; scope */
 /*
  * Buffer pool (free stack) template for shared memory regions
  */
-#define SMR_FREESTACK_EMPTY	NULL
+#define SMR_ALIGN_BOUNDARY	64
+#define SMR_FREESTACK_EMPTY	(-1)
 
-#define SMR_FREESTACK_HEADER 					\
-	void		*base_addr;				\
-	size_t		size;					\
-	void		*next;					\
+struct smr_freestack {
+	uint64_t		entry_base_offset;
+	size_t			object_size;
+	size_t			size;
+	int16_t			free;
+	int16_t			top;
+	int16_t 		entry_next[];
+};
 
-#define smr_freestack_isempty(fs)	((fs)->next == SMR_FREESTACK_EMPTY)
-#define smr_freestack_push(fs, local_p)				\
-do {								\
-	void *p = (char **) fs->base_addr +			\
-	    ((char **) ofi_freestack_get_next(local_p) -	\
-		(char **) fs);					\
-	*(void **) ofi_freestack_get_next(local_p) = (fs)->next;\
-	(fs)->next = p;						\
-} while (0)
-#define smr_freestack_pop(fs) smr_freestack_pop_impl(fs, fs->next)
+#define smr_freestack_isempty(fs)	((fs)->top == SMR_FREESTACK_EMPTY)
 
-static inline void* smr_freestack_pop_impl(void *fs, void *next)
+static inline void* smr_freestack_get_entry_from_index(struct smr_freestack *fs,
+		int16_t index)
 {
-	void *local;
-
-	struct _freestack {
-		SMR_FREESTACK_HEADER
-	} *freestack = (struct _freestack*) fs;
-	assert(next != NULL);
-
-	local = (char **) fs + ((char **) next -
-		(char **) freestack->base_addr);
-
-	freestack->next = *((void **)local);
-	ofi_freestack_init_next(local);
-
-	return ofi_freestack_get_user_buf(local);
+	return (void*) (((char *) fs) + fs->entry_base_offset +
+			(fs->object_size * index));
 }
 
-#define SMR_DECLARE_FREESTACK(entrytype, name)			\
-struct name ## _entry {						\
-	void		*next;					\
-	entrytype	buf;					\
-};								\
-struct name {							\
-	SMR_FREESTACK_HEADER					\
-	struct name ## _entry	entry[];			\
-};								\
-								\
-static inline void name ## _init(struct name *fs, size_t size)	\
-{								\
-	ssize_t i;						\
-	assert(size == roundup_power_of_two(size));		\
-	assert(sizeof(fs->entry[0].buf) >= sizeof(void *));	\
-	fs->size = size;					\
-	fs->next = SMR_FREESTACK_EMPTY;				\
-	fs->base_addr = fs;					\
-	for (i = size - 1; i >= 0; i--)				\
-		smr_freestack_push(fs, &fs->entry[i].buf);	\
-}								\
-								\
-static inline struct name * name ## _create(size_t size)	\
-{								\
-	struct name *fs;					\
-	fs = (struct name*) calloc(1, sizeof(*fs) + sizeof(entrytype) *	\
-		    (roundup_power_of_two(size)));		\
-	if (fs)							\
-		name ##_init(fs, roundup_power_of_two(size));	\
-	return fs;						\
-}								\
-								\
-static inline int name ## _index(struct name *fs,		\
-		entrytype *entry)				\
-{								\
-	return (int)((struct name ## _entry *)			\
-			(ofi_freestack_get_next(entry))		\
-			- (struct name ## _entry *)fs->entry);	\
-}								\
-								\
-static inline void name ## _free(struct name *fs)		\
-{								\
-	free(fs);						\
-}								\
-void dummy ## name (void) /* work-around global ; scope */
+static inline long freestack_size(int elem_size, int num_elements)
+{
+	return (sizeof(struct smr_freestack) + sizeof(int16_t) * num_elements +
+			elem_size * num_elements + SMR_ALIGN_BOUNDARY);
+}
 
+/* Push by entry_index */
+static inline void smr_freestack_push_by_index(struct smr_freestack *fs,
+		int16_t entry_index)
+{
+	fs->entry_next[entry_index] = fs->top;
+	fs->top = entry_index;
+	fs->free++;
+}
 
+/* Push by entry_offset */
+static inline void smr_freestack_push_by_offset(struct smr_freestack *fs,
+		uint64_t entry_offset)
+{
+        smr_freestack_push_by_index(fs,
+                        (entry_offset - fs->entry_base_offset) /
+                        fs->object_size);
+}
+
+/* Push by object */
+static inline void smr_freestack_push(struct smr_freestack *fs, void *local_p)
+{
+        smr_freestack_push_by_offset(fs,
+                ((char *) local_p - (char*) fs));
+}
+
+static inline void smr_freestack_init(struct smr_freestack *fs, size_t elem_count,
+		size_t fs_object_size)
+{
+	ssize_t i, next_aligned_addr;
+	assert(elem_count == roundup_power_of_two(elem_count));
+	fs->size = elem_count;
+	fs->object_size = fs_object_size;
+	fs->top = SMR_FREESTACK_EMPTY;
+	fs->entry_base_offset =
+		((char*) &fs->entry_next[0] - (char*) fs) +
+		fs->size * sizeof(fs->top);
+	next_aligned_addr = ofi_get_aligned_size((( (uint64_t) fs) +
+			fs->entry_base_offset), SMR_ALIGN_BOUNDARY);
+	fs->entry_base_offset = next_aligned_addr - ((uint64_t) fs);
+	for (i = elem_count - 1; i >= 0; i--)
+		smr_freestack_push_by_index(fs, i);
+}
+
+static inline struct smr_freestack* smr_freestack_create(size_t elem_count,
+		size_t fs_object_size)
+{
+	struct smr_freestack *fs;
+	fs = (struct smr_freestack*) calloc(1, freestack_size(fs_object_size,
+				roundup_power_of_two(elem_count)));
+	if (fs)
+		smr_freestack_init(fs, elem_count, fs_object_size);
+	return fs;
+}
+
+static inline int smr_freestack_pop_by_index(struct smr_freestack *fs)
+{
+	int entry_index;
+
+	entry_index = fs->top;
+	fs->top = fs->entry_next[entry_index];
+	fs->entry_next[entry_index] = -1;
+	fs->free--;
+
+	return entry_index;
+}
+
+static inline size_t smr_freestack_pop_by_offset(struct smr_freestack *fs)
+{
+	return (size_t) (fs->entry_base_offset +
+		smr_freestack_pop_by_index(fs) * fs->object_size);
+}
+
+static inline void* smr_freestack_pop(struct smr_freestack *fs)
+{
+	return (void *) ( ((char*)fs) + smr_freestack_pop_by_offset(fs) );
+}
 /*
  * Buffer Pool
  */

--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -53,7 +53,7 @@ extern "C" {
 #endif
 
 
-#define SMR_VERSION	3
+#define SMR_VERSION	4
 
 #ifdef HAVE_ATOMICS
 #define SMR_FLAG_ATOMIC	(1 << 0)
@@ -285,8 +285,6 @@ struct smr_sar_msg {
 
 OFI_DECLARE_CIRQUE(struct smr_cmd, smr_cmd_queue);
 OFI_DECLARE_CIRQUE(struct smr_resp, smr_resp_queue);
-SMR_DECLARE_FREESTACK(struct smr_inject_buf, smr_inject_pool);
-SMR_DECLARE_FREESTACK(struct smr_sar_msg, smr_sar_pool);
 
 static inline struct smr_region *smr_peer_region(struct smr_region *smr, int i)
 {
@@ -300,17 +298,17 @@ static inline struct smr_resp_queue *smr_resp_queue(struct smr_region *smr)
 {
 	return (struct smr_resp_queue *) ((char *) smr + smr->resp_queue_offset);
 }
-static inline struct smr_inject_pool *smr_inject_pool(struct smr_region *smr)
+static inline struct smr_freestack *smr_inject_pool(struct smr_region *smr)
 {
-	return (struct smr_inject_pool *) ((char *) smr + smr->inject_pool_offset);
+	return (struct smr_freestack *) ((char *) smr + smr->inject_pool_offset);
 }
 static inline struct smr_peer_data *smr_peer_data(struct smr_region *smr)
 {
 	return (struct smr_peer_data *) ((char *) smr + smr->peer_data_offset);
 }
-static inline struct smr_sar_pool *smr_sar_pool(struct smr_region *smr)
+static inline struct smr_freestack *smr_sar_pool(struct smr_region *smr)
 {
-	return (struct smr_sar_pool *) ((char *) smr + smr->sar_pool_offset);
+	return (struct smr_freestack *) ((char *) smr + smr->sar_pool_offset);
 }
 static inline const char *smr_name(struct smr_region *smr)
 {

--- a/prov/hook/hook_debug/src/hook_debug.c
+++ b/prov/hook/hook_debug/src/hook_debug.c
@@ -33,6 +33,7 @@
 #include <inttypes.h>
 
 #include "ofi.h"
+#include "ofi_mem.h"
 #include "ofi_prov.h"
 #include "ofi_hook.h"
 #include "hook_prov.h"

--- a/prov/opx/src/fi_opx_info.c
+++ b/prov/opx/src/fi_opx_info.c
@@ -32,6 +32,7 @@
  */
 
 #include <ofi.h>
+#include <ofi_mem.h>
 #include "rdma/opx/fi_opx.h"
 #include "rdma/opx/fi_opx_internal.h"
 #include "rdma/opx/fi_opx_hfi1.h"

--- a/prov/opx/src/fi_opx_init.c
+++ b/prov/opx/src/fi_opx_init.c
@@ -31,6 +31,7 @@
  * SOFTWARE.
  */
 #include <ofi.h>
+#include <ofi_mem.h>
 
 #include "rdma/opx/fi_opx.h"
 #include "rdma/opx/fi_opx_internal.h"

--- a/prov/shm/Makefile.include
+++ b/prov/shm/Makefile.include
@@ -14,17 +14,20 @@ _shm_files = \
 	prov/shm/src/smr_init.c		\
 	prov/shm/src/smr_av.c		\
 	prov/shm/src/smr_signal.h	\
-	prov/shm/src/smr.h
+	prov/shm/src/smr.h		\
+	prov/shm/src/smr_dsa.h		\
+	prov/shm/src/smr_dsa.c
+
 
 if HAVE_SHM_DL
 pkglib_LTLIBRARIES += libshm-fi.la
 libshm_fi_la_SOURCES = $(_shm_files) $(common_srcs)
-libshm_fi_la_LIBADD = $(linkback) $(shm_lib_LIBS)
+libshm_fi_la_LIBADD = $(linkback) $(shm_LIBS)
 libshm_fi_la_LDFLAGS = -module -avoid-version -shared -export-dynamic
 libshm_fi_la_DEPENDENCIES = $(linkback)
 else !HAVE_SHM_DL
 src_libfabric_la_SOURCES += $(_shm_files)
-src_libfabric_la_LIBADD += $(shm_lib_LIBS)
+src_libfabric_la_LIBADD += $(shm_LIBS)
 endif !HAVE_SHM_DL
 
 prov_install_man_pages += man/man7/fi_shm.7

--- a/prov/shm/configure.m4
+++ b/prov/shm/configure.m4
@@ -11,6 +11,7 @@ AC_DEFUN([FI_SHM_CONFIGURE],[
 	# Determine if we can support the shm provider
 	shm_happy=0
 	cma_happy=0
+	dsa_happy=0
 	AS_IF([test x"$enable_shm" != x"no"],
 	      [
 	       # check if CMA support are present
@@ -28,7 +29,7 @@ AC_DEFUN([FI_SHM_CONFIGURE],[
 
 	       # look for shm_open in librt if not already present
 	       AS_IF([test $shm_happy -eq 0],
-		     [FI_CHECK_PACKAGE([shm_lib],
+		     [FI_CHECK_PACKAGE([rt],
 				[sys/mman.h],
 				[rt],
 				[shm_open],
@@ -37,6 +38,52 @@ AC_DEFUN([FI_SHM_CONFIGURE],[
 				[],
 				[shm_happy=1],
 				[shm_happy=0])])
+	       shm_LIBS="$rt_LIBS"
+
+	       AC_ARG_WITH([dsa],
+			   [AS_HELP_STRING([--with-dsa=DIR],
+					   [Enable DSA build and fail if not found.
+					    Optional=<Path to where the DSA libraries
+					    and headers are installed.>])])
+
+	       AS_IF([test "x$with_dsa" != "xno"],
+		     [FI_CHECK_PACKAGE([dsa],
+				       [accel-config/libaccel_config.h],
+				       [accel-config],
+				       [accfg_new],
+				       [],
+				       [$with_dsa],
+				       [],
+				       [dsa_happy=1])])
+
+	       AS_IF([test $dsa_happy -eq 1],
+		     [FI_CHECK_PACKAGE([numa],
+				       [numa.h],
+		                       [numa],
+		                       [numa_node_of_cpu],
+		                       [],
+		                       [],
+		                       [],
+		                       [],
+		                       [dsa_happy=0])])
+
+	      AS_IF([test $dsa_happy -eq 1],
+		    [AC_CHECK_HEADER(linux/idxd.h, [], [dsa_happy=0])])
+
+	      AS_IF([test "x$with_dsa" != "xno" && test -n "$with_dsa" && test $dsa_happy -eq 0 ],
+		    [AC_MSG_ERROR([shm DSA support requested but DSA not available.])])
+
+	      AS_IF([test $dsa_happy -eq 1 && test "x$with_dsa" != "xyes"],
+	            [shm_CPPFLAGS="$shm_CPPFLAGS $dsa_CPPFLAGS $numa_LIBS"
+		     shm_LDFLAGS="$shm_LDFLAGS $dsa_LDFLAGS $numa_LIBS"])
+	      shm_LIBS="$shm_LIBS $dsa_LIBS $numa_LIBS"
+
+	      AC_DEFINE_UNQUOTED([SHM_HAVE_DSA],[$dsa_happy],
+				 [Whether DSA support is available])
+
+	      AC_SUBST(shm_CPPFLAGS)
+	      AC_SUBST(shm_LDFLAGS)
+	      AC_SUBST(shm_LIBS)
 	      ])
 
 	AS_IF([test $shm_happy -eq 1 && \

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -315,11 +315,11 @@ void smr_format_pend_resp(struct smr_tx_entry *pend, struct smr_cmd *cmd,
 			  uint64_t op_flags, int64_t id, struct smr_resp *resp);
 void smr_generic_format(struct smr_cmd *cmd, int64_t peer_id, uint32_t op,
 			uint64_t tag, uint64_t data, uint64_t op_flags);
-size_t smr_copy_to_sar(struct smr_sar_msg *sar_msg, struct smr_resp *resp,
-		       struct smr_cmd *cmd, enum fi_hmem_iface,
-		       uint64_t device, const struct iovec *iov, size_t count,
+size_t smr_copy_to_sar(struct smr_freestack *sar_pool, struct smr_resp *resp,
+		       struct smr_cmd *cmd, enum fi_hmem_iface, uint64_t device,
+		       const struct iovec *iov, size_t count,
 		       size_t *bytes_done, int *next);
-size_t smr_copy_from_sar(struct smr_sar_msg *sar_msg, struct smr_resp *resp,
+size_t smr_copy_from_sar(struct smr_freestack *sar_pool, struct smr_resp *resp,
 			 struct smr_cmd *cmd, enum fi_hmem_iface iface,
 			 uint64_t device, const struct iovec *iov, size_t count,
 			 size_t *bytes_done, int *next);

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -70,6 +70,7 @@
 struct smr_env {
 	size_t sar_threshold;
 	int disable_cma;
+	int use_dsa_sar;
 };
 
 extern struct smr_env smr_env;
@@ -286,6 +287,7 @@ struct smr_ep {
 
 	int			ep_idx;
 	struct smr_sock_info	*sock_info;
+	void			*dsa_context;
 };
 
 #define smr_ep_rx_flags(smr_ep) ((smr_ep)->util_ep.rx_op_flags)
@@ -323,6 +325,7 @@ size_t smr_copy_from_sar(struct smr_freestack *sar_pool, struct smr_resp *resp,
 			 struct smr_cmd *cmd, enum fi_hmem_iface iface,
 			 uint64_t device, const struct iovec *iov, size_t count,
 			 size_t *bytes_done, int *next);
+
 int smr_select_proto(bool use_ipc, bool cma_avail, enum fi_hmem_iface iface,
 		     uint32_t op, uint64_t total_len, uint64_t op_flags);
 typedef ssize_t (*smr_proto_func)(struct smr_ep *ep, struct smr_region *peer_smr,

--- a/prov/shm/src/smr_av.c
+++ b/prov/shm/src/smr_av.c
@@ -107,10 +107,14 @@ static int smr_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 			smr_av->used++;
 		}
 
+		assert(smr_av->smr_map->num_peers > 0);
+
 		dlist_foreach(&util_av->ep_list, av_entry) {
 			util_ep = container_of(av_entry, struct util_ep, av_entry);
 			smr_ep = container_of(util_ep, struct smr_ep, util_ep);
 			smr_map_to_endpoint(smr_ep->region, shm_id);
+			smr_ep->region->max_sar_buf_per_peer =
+				SMR_MAX_PEERS / smr_av->smr_map->num_peers;
 		}
 	}
 
@@ -151,6 +155,13 @@ static int smr_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr, size_t count
 			util_ep = container_of(av_entry, struct util_ep, av_entry);
 			smr_ep = container_of(util_ep, struct smr_ep, util_ep);
 			smr_unmap_from_endpoint(smr_ep->region, id);
+			if (smr_av->smr_map->num_peers > 0)
+				smr_ep->region->max_sar_buf_per_peer =
+					SMR_MAX_PEERS /
+					smr_av->smr_map->num_peers;
+			else
+				smr_ep->region->max_sar_buf_per_peer =
+					SMR_BUF_BATCH_MAX;
 		}
 		smr_av->used--;
 	}

--- a/prov/shm/src/smr_dsa.c
+++ b/prov/shm/src/smr_dsa.c
@@ -1,0 +1,838 @@
+/*
+ * Copyright (c) 2022 Intel Corporation. All rights reserved
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+
+#include "smr.h"
+
+#if SHM_HAVE_DSA
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdatomic.h>
+#include <sys/un.h>
+#include <accel-config/libaccel_config.h>
+#include <linux/idxd.h>
+#include <numa.h>
+#include "ofi_shm.h"
+#include "smr_dsa.h"
+
+#define MAX_WQS_PER_EP 4
+#define GENCAP_CACHE_CTRL_MEM 0x4
+#define LIMITED_MSIX_PORTAL_OFFSET 0x1000
+
+#define CMD_CONTEXT_COUNT 32
+
+// Number of DSA descriptors must be large enough to fill the
+// maximum number of SAR buffers.
+#define MAX_CMD_BATCH_SIZE (SMR_BUF_BATCH_MAX + SMR_IOV_LIMIT)
+
+struct dsa_bitmap {
+	int size;
+	atomic_int data;
+};
+
+struct dsa_cmd_context {
+	size_t bytes_in_progress;
+	int index;
+	int batch_size;
+	int dir;
+	uint32_t op;
+	// We keep track of the entry type to know which lock to acquire
+	// when we need to do the updates after completion
+	void *entry_ptr;
+};
+
+struct smr_dsa_context {
+	struct dsa_hw_desc dsa_work_desc[MAX_CMD_BATCH_SIZE *
+					 CMD_CONTEXT_COUNT];
+
+	struct dsa_completion_record dsa_work_comp[MAX_CMD_BATCH_SIZE *
+						   CMD_CONTEXT_COUNT];
+
+	struct dsa_cmd_context dsa_cmd_context[CMD_CONTEXT_COUNT];
+
+	struct dsa_bitmap dsa_bitmap;
+	void *wq_portal[MAX_WQS_PER_EP];
+	int wq_count;
+	int next_wq;
+	int enable_dsa_page_touch;
+
+	unsigned long copy_type_stats[2];
+	unsigned long page_fault_stats[2];
+};
+
+
+static inline unsigned char dsa_enqcmd(struct dsa_hw_desc *desc,
+				       volatile void *reg)
+{
+	unsigned char retry;
+
+	asm volatile(".byte 0xf2, 0x0f, 0x38, 0xf8, 0x02\t\n"
+		     "setz %0\t\n"
+		     : "=r"(retry)
+		     : "a"(reg), "d"(desc));
+	return retry;
+}
+
+static __always_inline void dsa_desc_submit(struct smr_dsa_context *dsa_context,
+					    struct dsa_hw_desc *hw)
+{
+	int enq_status;
+
+	// make sure writes (e.g., comp.status = 0) are ordered wrt to enqcmd
+	{ asm volatile("sfence":::"memory"); }
+
+	do {
+		enq_status = dsa_enqcmd(hw,
+				dsa_context->wq_portal[dsa_context->next_wq]);
+		dsa_context->next_wq = (dsa_context->next_wq + 1) %
+			(dsa_context->wq_count);
+	} while (enq_status);
+}
+
+static int dsa_open_wq(struct accfg_wq *wq)
+{
+	struct accfg_device *dev;
+	int major, minor, fd;
+	char path[1024];
+
+	dev = accfg_wq_get_device(wq);
+	major = accfg_device_get_cdev_major(dev);
+	if (major < 0)
+		return -1;
+	minor = accfg_wq_get_cdev_minor(wq);
+	if (minor < 0)
+		return -1;
+
+	sprintf(path, "/dev/char/%u:%u", major, minor);
+	fd = open(path, O_RDWR);
+	if (fd < 0) {
+		FI_WARN(&smr_prov, FI_LOG_EP_CTRL, "dsa_open_wq error\n");
+		return -1;
+	}
+
+	return fd;
+}
+
+static void *dsa_idxd_wq_mmap(struct accfg_wq *wq)
+{
+	int fd;
+	void *wq_reg;
+
+	fd = dsa_open_wq(wq);
+
+	wq_reg = mmap(NULL, LIMITED_MSIX_PORTAL_OFFSET, PROT_WRITE,
+		      MAP_SHARED | MAP_POPULATE, fd, 0);
+	close(fd);
+
+	if (wq_reg == MAP_FAILED) {
+		FI_WARN(&smr_prov, FI_LOG_EP_CTRL, "d_idxd_wq_mmap error\n");
+		return NULL;
+	}
+
+	return wq_reg;
+}
+
+static void dsa_idxd_wq_unmap(void *wq)
+{
+	munmap(wq, LIMITED_MSIX_PORTAL_OFFSET);
+}
+
+static int dsa_idxd_init_wq_array(int shared, int numa_node,
+				  void **wq_array)
+{
+	static struct accfg_ctx *ctx;
+	struct accfg_wq *wq;
+	void *wq_reg;
+	enum accfg_device_state dstate;
+	enum accfg_wq_state wstate;
+	enum accfg_wq_type type;
+	int mode;
+	int wq_count = 0;
+	struct accfg_device *device;
+
+	if (accfg_new(&ctx) < 0)
+		return 0;
+
+	accfg_device_foreach(ctx, device) {
+		/* Make sure that the device is enabled */
+		dstate = accfg_device_get_state(device);
+		if (dstate != ACCFG_DEVICE_ENABLED)
+			continue;
+
+		/* Make sure cache control is supported for memory operations */
+		if ((accfg_device_get_gen_cap(device) &
+		    GENCAP_CACHE_CTRL_MEM) == 0)
+			continue;
+
+		/* Match the device to the id requested */
+		if (numa_node != -1 &&
+		    accfg_device_get_numa_node(device) != numa_node)
+			continue;
+
+		accfg_wq_foreach(device, wq)
+		{
+			/* Get a workqueue that's enabled */
+			wstate = accfg_wq_get_state(wq);
+			if (wstate != ACCFG_WQ_ENABLED)
+				continue;
+
+			if (accfg_wq_get_max_transfer_size(wq) < SMR_SAR_SIZE)
+				continue;
+
+			/* The wq type should be user */
+			type = accfg_wq_get_type(wq);
+			if (type != ACCFG_WQT_USER)
+				continue;
+
+			/* Make sure the mode is correct */
+			mode = accfg_wq_get_mode(wq);
+			if ((mode == ACCFG_WQ_SHARED && !shared) ||
+			    (mode == ACCFG_WQ_DEDICATED && shared))
+				continue;
+
+			/* This is a candidate wq */
+			FI_DBG(&smr_prov, FI_LOG_EP_CTRL,
+					"DSA WQ: %s\n",
+					accfg_wq_get_devname(wq));
+
+			wq_reg = dsa_idxd_wq_mmap(wq);
+			if (wq_reg == NULL)
+				continue;
+			wq_array[wq_count] = wq_reg;
+			wq_count++;
+			break;
+		}
+
+		if (wq_count >= MAX_WQS_PER_EP)
+			break;
+	}
+
+	accfg_unref(ctx);
+	return wq_count;
+}
+
+static int dsa_bitmap_test_and_set_bit(struct dsa_bitmap *bitmap, int index)
+{
+	assert(index < bitmap->size);
+	return atomic_fetch_or(&bitmap->data, 1ULL << index) & (1ULL << index);
+}
+
+static void dsa_bitmap_clear_bit(struct dsa_bitmap *bitmap, int index)
+{
+	assert(index < bitmap->size);
+	atomic_fetch_and(&bitmap->data, ~(1ULL << index));
+}
+
+static int dsa_bitmap_allocate(struct dsa_bitmap *bitmap, int size)
+{
+	atomic_init(&bitmap->data, 0);
+	bitmap->size = size;
+
+	return 1;
+}
+
+static int dsa_bitmap_test_bit(struct dsa_bitmap *bitmap, int index)
+{
+	assert(index < bitmap->size);
+	return atomic_load(&bitmap->data) & (1ULL << index);
+}
+
+static int dsa_bitmap_is_empty(struct dsa_bitmap *bitmap)
+{
+	return atomic_load(&bitmap->data) == 0;
+}
+
+static struct dsa_cmd_context *
+dsa_allocate_cmd_context(struct smr_dsa_context *smr_dsa_context)
+{
+	struct dsa_cmd_context *dsa_cmd_context;
+	int i;
+
+	for (i = 0; i < CMD_CONTEXT_COUNT; i++) {
+		if (!dsa_bitmap_test_and_set_bit(&smr_dsa_context->dsa_bitmap, i))
+			break;
+	}
+
+	if (i == CMD_CONTEXT_COUNT)
+		return NULL;
+
+	dsa_cmd_context = &smr_dsa_context->dsa_cmd_context[i];
+	memset(dsa_cmd_context, 0, sizeof(*dsa_cmd_context));
+	dsa_cmd_context->index = i;
+
+	return dsa_cmd_context;
+}
+
+static void dsa_free_cmd_context(struct dsa_cmd_context *dsa_cmd_context,
+				 struct smr_dsa_context *smr_dsa_context)
+{
+	dsa_bitmap_clear_bit(&smr_dsa_context->dsa_bitmap,
+			     dsa_cmd_context->index);
+}
+
+static struct dsa_hw_desc *
+dsa_get_work_descriptor_array_ptr(struct dsa_cmd_context *dsa_cmd_context,
+				  struct smr_dsa_context *dsa_context)
+{
+	return &dsa_context->dsa_work_desc[dsa_cmd_context->index *
+					   MAX_CMD_BATCH_SIZE];
+}
+
+static struct dsa_hw_desc *
+dsa_get_free_work_descriptor(struct dsa_cmd_context *dsa_cmd_context,
+			     struct smr_dsa_context *dsa_context)
+{
+	struct dsa_hw_desc *free_desc;
+	struct dsa_completion_record *free_comp;
+
+	free_desc = &dsa_context->dsa_work_desc[dsa_cmd_context->index *
+		MAX_CMD_BATCH_SIZE + dsa_cmd_context->batch_size];
+	free_comp = &dsa_context->dsa_work_comp[dsa_cmd_context->index *
+		MAX_CMD_BATCH_SIZE + dsa_cmd_context->batch_size++];
+
+	memset(free_desc, 0, sizeof(*free_desc));
+	memset(free_comp, 0, sizeof(*free_comp));
+	free_desc->completion_addr = (uintptr_t) free_comp;
+
+	return free_desc;
+}
+
+static struct dsa_completion_record *
+dsa_get_work_completion_array_ptr(struct dsa_cmd_context *dsa_cmd_context,
+				  struct smr_dsa_context *dsa_context)
+{
+	return &dsa_context->dsa_work_comp[dsa_cmd_context->index *
+					   MAX_CMD_BATCH_SIZE];
+}
+
+static struct dsa_cmd_context *dsa_get_cmd_context(struct smr_dsa_context
+						  *dsa_context, int index)
+{
+	if (dsa_bitmap_test_bit(&dsa_context->dsa_bitmap, index))
+		return &dsa_context->dsa_cmd_context[index];
+	return NULL;
+}
+
+static int dsa_is_work_in_progress(struct smr_dsa_context *dsa_context)
+{
+	return !dsa_bitmap_is_empty(&dsa_context->dsa_bitmap);
+}
+
+static void dsa_touch_buffer_pages(struct dsa_hw_desc *desc)
+{
+	size_t i;
+	volatile char *src_addr;
+	volatile char *dst_addr;
+	size_t page_size = ofi_get_page_size();
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-value"
+
+	for (i = 0; i < desc->xfer_size; i += page_size) {
+		src_addr = (char *)desc->src_addr + i;
+		dst_addr = (char *)desc->dst_addr + i;
+
+		*src_addr;
+		*dst_addr = *dst_addr;
+	}
+
+	// Touch last byte in case start of buffer is not aligned to page
+	// boundary
+	src_addr = (char *)desc->src_addr + (desc->xfer_size - 1);
+	dst_addr = (char *)desc->dst_addr + (desc->xfer_size - 1);
+
+	*src_addr;
+	*dst_addr = *dst_addr;
+
+#pragma GCC diagnostic pop
+}
+
+static void dsa_prepare_copy_desc(struct dsa_hw_desc *desc,
+				  uint32_t xfer_size, uint64_t src_addr,
+				  uint64_t dst_addr)
+{
+	desc->opcode = DSA_OPCODE_MEMMOVE;
+	desc->flags = IDXD_OP_FLAG_CRAV | IDXD_OP_FLAG_RCR | IDXD_OP_FLAG_CC;
+	desc->xfer_size = xfer_size;
+	desc->src_addr = src_addr;
+	desc->dst_addr = dst_addr;
+}
+
+static void smr_dsa_copy_sar(struct smr_freestack *sar_pool,
+			struct smr_dsa_context *dsa_context,
+			struct dsa_cmd_context *dsa_cmd_context,
+			struct smr_resp *resp, struct smr_cmd *cmd,
+			const struct iovec *iov, size_t count,
+			size_t *bytes_done, struct smr_region *region)
+{
+	struct smr_sar_buf *smr_sar_buf;
+	size_t remaining_sar_size;
+	size_t remaining_iov_size;
+	size_t iov_len;
+	size_t iov_index = 0;
+	int sar_index = 0;
+	int cmd_index = 0;
+	size_t iov_offset = *bytes_done;
+	size_t sar_offset = 0;
+	size_t cmd_size = 0;
+	char *iov_buf = NULL;
+	char *sar_buf = NULL;
+	struct dsa_hw_desc *desc = NULL;
+	size_t dsa_bytes_pending = 0;
+
+	for (iov_index = 0; iov_index < count; iov_index++) {
+		iov_len = iov[iov_index].iov_len;
+
+		if (iov_offset < iov_len)
+			break;
+		iov_offset -= iov_len;
+	}
+
+	while ((iov_index < count) &&
+	       (sar_index < cmd->msg.data.buf_batch_size) &&
+	       (cmd_index < MAX_CMD_BATCH_SIZE)) {
+		smr_sar_buf = smr_freestack_get_entry_from_index(
+		    sar_pool, cmd->msg.data.sar[sar_index]);
+		iov_len = iov[iov_index].iov_len;
+
+		iov_buf = (char *)iov[iov_index].iov_base + iov_offset;
+		sar_buf = (char *)smr_sar_buf->buf + sar_offset;
+
+		remaining_sar_size = SMR_SAR_SIZE - sar_offset;
+		remaining_iov_size = iov_len - iov_offset;
+		cmd_size = MIN(remaining_iov_size, remaining_sar_size);
+		assert(cmd_size > 0);
+
+		desc = dsa_get_free_work_descriptor(dsa_cmd_context,
+						    dsa_context);
+
+		if (dsa_cmd_context->dir == OFI_COPY_BUF_TO_IOV)
+			dsa_prepare_copy_desc(desc, cmd_size, (uintptr_t)
+					sar_buf, (uintptr_t) iov_buf);
+		else
+			dsa_prepare_copy_desc(desc, cmd_size, (uintptr_t)
+					iov_buf, (uintptr_t) sar_buf);
+
+		dsa_desc_submit(dsa_context, desc);
+
+		cmd_index++;
+		dsa_bytes_pending += cmd_size;
+
+		if (remaining_sar_size > remaining_iov_size) {
+			iov_index++;
+			iov_offset = 0;
+			sar_offset += cmd_size;
+		} else if (remaining_sar_size < remaining_iov_size) {
+			sar_index++;
+			sar_offset = 0;
+			iov_offset += cmd_size;
+		} else {
+			iov_index++;
+			iov_offset = 0;
+			sar_index++;
+			sar_offset = 0;
+		}
+	}
+	assert(dsa_bytes_pending > 0);
+
+	resp->status = SMR_STATUS_BUSY;
+
+	dsa_cmd_context->bytes_in_progress = dsa_bytes_pending;
+	dsa_context->copy_type_stats[dsa_cmd_context->dir]++;
+	dsa_cmd_context->op = cmd->msg.hdr.op;
+
+	smr_signal(region);
+}
+
+static void dsa_handle_page_fault(struct dsa_completion_record *comp)
+{
+	volatile char *fault_addr;
+
+	if (comp->status & DSA_COMP_PAGE_FAULT_NOBOF) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-value"
+		fault_addr = (char *)comp->fault_addr;
+
+		if (comp->status & DSA_COMP_STATUS_WRITE)
+			*fault_addr = *fault_addr;
+		else
+			*fault_addr;
+#pragma GCC diagnostic pop
+	}
+}
+
+static void
+dsa_process_partially_completed_desc(struct smr_dsa_context *dsa_context,
+				     struct dsa_hw_desc *dsa_descriptor)
+{
+	uint32_t new_xfer_size;
+	uint64_t new_src_addr;
+	uint64_t new_dst_addr;
+	uint32_t bytes_completed;
+	struct dsa_completion_record *comp =
+	    (struct dsa_completion_record *)dsa_descriptor->completion_addr;
+
+	dsa_handle_page_fault(comp);
+
+	bytes_completed = comp->bytes_completed;
+
+	// Update descriptor src & dst buffer based on copy direction; see 8.3.4
+	// of DSA spec
+	new_xfer_size = dsa_descriptor->xfer_size - bytes_completed;
+	new_src_addr =
+	    (comp->result ? dsa_descriptor->src_addr
+			  : dsa_descriptor->src_addr + bytes_completed);
+	new_dst_addr =
+	    (comp->result ? dsa_descriptor->dst_addr
+			  : dsa_descriptor->dst_addr + bytes_completed);
+
+	// Reset completion record.
+	memset(comp, 0, sizeof(*comp));
+
+	dsa_prepare_copy_desc(dsa_descriptor, new_xfer_size,
+			       new_src_addr, new_dst_addr);
+
+	if (dsa_context->enable_dsa_page_touch)
+		dsa_touch_buffer_pages(dsa_descriptor);
+
+	dsa_desc_submit(dsa_context, dsa_descriptor);
+}
+
+static void dsa_update_tx_entry(struct smr_region *smr,
+				struct dsa_cmd_context *dsa_cmd_context)
+{
+	struct smr_region *peer_smr;
+	struct smr_resp *resp;
+	struct smr_cmd *cmd;
+	struct smr_tx_entry *tx_entry = dsa_cmd_context->entry_ptr;
+
+	tx_entry->bytes_done += dsa_cmd_context->bytes_in_progress;
+	cmd = &tx_entry->cmd;
+	peer_smr = smr_peer_region(smr, tx_entry->peer_id);
+	resp = smr_get_ptr(smr, cmd->msg.hdr.src_data);
+
+	assert(resp->status == SMR_STATUS_BUSY);
+	resp->status = (dsa_cmd_context->dir == OFI_COPY_IOV_TO_BUF ?
+			SMR_STATUS_SAR_READY : SMR_STATUS_SAR_FREE);
+	smr_signal(peer_smr);
+}
+
+static void dsa_update_sar_entry(struct smr_region *smr,
+				 struct dsa_cmd_context *dsa_cmd_context)
+{
+	struct smr_sar_entry *sar_entry = dsa_cmd_context->entry_ptr;
+	struct smr_region *peer_smr;
+	struct smr_resp *resp;
+	struct smr_cmd *cmd;
+
+	sar_entry->bytes_done += dsa_cmd_context->bytes_in_progress;
+	cmd = &sar_entry->cmd;
+	peer_smr = smr_peer_region(smr, cmd->msg.hdr.id);
+	resp = smr_get_ptr(peer_smr, cmd->msg.hdr.src_data);
+
+	assert(resp->status == SMR_STATUS_BUSY);
+	resp->status = (dsa_cmd_context->dir == OFI_COPY_IOV_TO_BUF ?
+			SMR_STATUS_SAR_READY : SMR_STATUS_SAR_FREE);
+
+	smr_signal(peer_smr);
+}
+
+static void dsa_process_complete_work(struct smr_region *smr,
+				      struct dsa_cmd_context *dsa_cmd_context,
+				      struct smr_dsa_context *dsa_context)
+{
+	if (dsa_cmd_context->op == ofi_op_read_req) {
+		if (dsa_cmd_context->dir == OFI_COPY_BUF_TO_IOV)
+			dsa_update_tx_entry(smr, dsa_cmd_context);
+		else
+			dsa_update_sar_entry(smr, dsa_cmd_context);
+	} else {
+		if (dsa_cmd_context->dir == OFI_COPY_IOV_TO_BUF)
+			dsa_update_tx_entry(smr, dsa_cmd_context);
+		else
+			dsa_update_sar_entry(smr, dsa_cmd_context);
+	}
+
+	dsa_free_cmd_context(dsa_cmd_context, dsa_context);
+}
+
+static inline void
+dsa_page_fault_debug_info(struct dsa_cmd_context *dsa_cmd_context,
+			  struct dsa_completion_record *dsa_work_comp)
+{
+	FI_TRACE(
+		&smr_prov, FI_LOG_EP_CTRL,
+		"handle_page_fault read_fault %d\
+		write_fault %d addr %p dir: %d cmd_idx: %d\n",
+		!(dsa_work_comp->status & DSA_COMP_STATUS_WRITE),
+		dsa_work_comp->status & DSA_COMP_STATUS_WRITE,
+		(void *)dsa_work_comp->fault_addr,
+		dsa_cmd_context->dir, dsa_cmd_context->index);
+}
+
+static bool dsa_check_cmd_status(struct smr_dsa_context *dsa_context,
+				struct dsa_cmd_context *dsa_cmd_context)
+{
+	int i;
+	struct dsa_hw_desc *dsa_work;
+	struct dsa_completion_record *dsa_work_comp;
+	bool dsa_cmd_completed = true;
+	uint8_t status_value = 0;
+	dsa_work = dsa_get_work_descriptor_array_ptr(dsa_cmd_context,
+						     dsa_context);
+	dsa_work_comp =
+	    dsa_get_work_completion_array_ptr(dsa_cmd_context, dsa_context);
+
+	for (i = 0; i < dsa_cmd_context->batch_size; i++) {
+		status_value = dsa_work_comp[i].status & DSA_COMP_STATUS_MASK;
+
+		switch (status_value) {
+		case DSA_COMP_SUCCESS:
+			break;
+		case DSA_COMP_NONE:
+			dsa_cmd_completed = false;
+			break;
+		case DSA_COMP_PAGE_FAULT_NOBOF:
+			dsa_page_fault_debug_info(dsa_cmd_context,
+					&dsa_work_comp[i]);
+			dsa_process_partially_completed_desc(dsa_context,
+					&dsa_work[i]);
+			dsa_context->page_fault_stats[dsa_cmd_context->dir]++;
+			dsa_cmd_completed = false;
+			break;
+		default:
+			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+					"Unhandled status codes: 0x%x\n",
+					status_value);
+			assert(0);
+		}
+	}
+
+	return dsa_cmd_completed;
+}
+
+/* SMR functions */
+void smr_dsa_context_init(struct smr_ep *ep)
+{
+	int i, cpu;
+	int wq_count;
+	struct smr_dsa_context *dsa_context;
+	unsigned int numa_node;
+	int enable_dsa_page_touch = 0;
+
+	cpu = sched_getcpu();
+	numa_node = numa_node_of_cpu(cpu);
+
+	ep->dsa_context = aligned_alloc(sizeof(struct dsa_hw_desc),
+					sizeof(*dsa_context));
+
+	if (!ep->dsa_context) {
+		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+			 "aligned_alloc failed for dsa_context\n");
+		goto alloc_error;
+	}
+
+	dsa_context = ep->dsa_context;
+	memset(dsa_context, 0, sizeof(*dsa_context));
+
+	fi_param_get_bool(&smr_prov, "enable_dsa_page_touch",
+			  &enable_dsa_page_touch);
+
+	wq_count = dsa_idxd_init_wq_array(1, numa_node,
+				      dsa_context->wq_portal);
+
+	if (wq_count == 0) {
+		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+			 "error calling dsa_idxd_init_wq_array()\n");
+		goto wq_get_error;
+	}
+
+	dsa_bitmap_allocate(&dsa_context->dsa_bitmap, CMD_CONTEXT_COUNT);
+
+	for (i = 0; i < CMD_CONTEXT_COUNT; i++)
+		dsa_context->dsa_cmd_context[i].index = -1;
+
+	dsa_context->next_wq = 0;
+	dsa_context->wq_count = wq_count;
+	dsa_context->enable_dsa_page_touch = enable_dsa_page_touch;
+
+	FI_DBG(&smr_prov, FI_LOG_EP_CTRL, "Numa node of endpoint CPU: %d\n",
+			numa_node);
+	return;
+
+wq_get_error:
+	free(dsa_context);
+alloc_error:
+	smr_env.use_dsa_sar = 0;
+}
+
+void smr_dsa_context_cleanup(struct smr_ep *ep)
+{
+	struct smr_dsa_context *dsa_context = ep->dsa_context;
+	int i;
+
+	if (!dsa_context)
+		return;
+
+	FI_WARN(&smr_prov, FI_LOG_EP_CTRL, "Stats:\n\
+		User to Sar Buffer: dsa cmds %ld page faults %ld\n\
+		Sar Buffer to User: dsa cmds %ld page faults %ld\n",
+		dsa_context->copy_type_stats[OFI_COPY_IOV_TO_BUF],
+		dsa_context->page_fault_stats[OFI_COPY_IOV_TO_BUF],
+		dsa_context->copy_type_stats[OFI_COPY_BUF_TO_IOV],
+		dsa_context->page_fault_stats[OFI_COPY_BUF_TO_IOV]);
+
+	if (!dsa_bitmap_is_empty(&dsa_context->dsa_bitmap))
+		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+			"Warning: TBD outstanding DSA commands while "
+			"doing cleanup\n");
+
+	for (i = 0; i < dsa_context->wq_count; i++)
+		dsa_idxd_wq_unmap(dsa_context->wq_portal[i]);
+
+	free(ep->dsa_context);
+}
+
+void smr_dsa_progress(struct smr_ep *ep)
+{
+	int index;
+	struct dsa_cmd_context *dsa_cmd_context;
+	bool dsa_cmd_completed;
+	struct smr_dsa_context *dsa_context = ep->dsa_context;
+
+	if (!dsa_is_work_in_progress(ep->dsa_context))
+		return;
+
+	pthread_spin_lock(&ep->region->lock);
+	for (index = 0; index < CMD_CONTEXT_COUNT; index++) {
+		dsa_cmd_context = dsa_get_cmd_context(dsa_context, index);
+
+		if (!dsa_cmd_context)
+			continue;
+
+		dsa_cmd_completed = dsa_check_cmd_status(dsa_context,
+				dsa_cmd_context);
+
+		if (dsa_cmd_completed)
+			dsa_process_complete_work(ep->region, dsa_cmd_context,
+					      dsa_context);
+	}
+	// Always signal the self to complete dsa, tx or rx.
+	smr_signal(ep->region);
+	pthread_spin_unlock(&ep->region->lock);
+}
+
+size_t smr_dsa_copy_to_sar(struct smr_ep *ep, struct smr_freestack *sar_pool,
+		struct smr_resp *resp, struct smr_cmd *cmd,
+		const struct iovec *iov, size_t count, size_t *bytes_done,
+		void *entry_ptr)
+{
+	struct dsa_cmd_context *dsa_cmd_context;
+
+	assert(smr_env.use_dsa_sar);
+
+	if (resp->status != SMR_STATUS_SAR_FREE)
+		return -FI_EAGAIN;
+
+	dsa_cmd_context = dsa_allocate_cmd_context(ep->dsa_context);
+	if (!dsa_cmd_context)
+		return -FI_ENOMEM;
+
+	dsa_cmd_context->dir = OFI_COPY_IOV_TO_BUF;
+	dsa_cmd_context->entry_ptr = entry_ptr;
+	smr_dsa_copy_sar(sar_pool, ep->dsa_context, dsa_cmd_context, resp,
+			 cmd, iov, count, bytes_done, ep->region);
+
+	return FI_SUCCESS;
+}
+
+size_t smr_dsa_copy_from_sar(struct smr_ep *ep, struct smr_freestack *sar_pool,
+		struct smr_resp *resp, struct smr_cmd *cmd,
+		const struct iovec *iov, size_t count, size_t *bytes_done,
+		void *entry_ptr)
+{
+	struct dsa_cmd_context *dsa_cmd_context;
+
+	assert(smr_env.use_dsa_sar);
+
+	if (resp->status != SMR_STATUS_SAR_READY)
+		return FI_EAGAIN;
+
+	dsa_cmd_context = dsa_allocate_cmd_context(ep->dsa_context);
+	if (!dsa_cmd_context)
+		return -FI_ENOMEM;
+
+	dsa_cmd_context->dir = OFI_COPY_BUF_TO_IOV;
+	dsa_cmd_context->entry_ptr = entry_ptr;
+	smr_dsa_copy_sar(sar_pool, ep->dsa_context, dsa_cmd_context, resp,
+			 cmd, iov, count, bytes_done, ep->region);
+
+	return FI_SUCCESS;
+}
+
+#else
+
+size_t smr_dsa_copy_to_sar(struct smr_ep *ep, struct smr_freestack *sar_pool,
+		struct smr_resp *resp, struct smr_cmd *cmd,
+		const struct iovec *iov, size_t count, size_t *bytes_done,
+		void *entry_ptr)
+{
+	return -FI_ENOSYS;
+}
+
+size_t smr_dsa_copy_from_sar(struct smr_ep *ep, struct smr_freestack *sar_pool,
+		struct smr_resp *resp, struct smr_cmd *cmd,
+		const struct iovec *iov, size_t count, size_t *bytes_done,
+		void *entry_ptr)
+{
+	return -FI_ENOSYS;
+}
+
+void smr_dsa_context_init(struct smr_ep *ep)
+{
+	smr_env.use_dsa_sar = 0;
+	return;
+}
+
+void smr_dsa_context_cleanup(struct smr_ep *ep) {}
+
+void smr_dsa_progress(struct smr_ep *ep) {}
+
+#endif /* SHM_HAVE_DSA */

--- a/prov/shm/src/smr_dsa.h
+++ b/prov/shm/src/smr_dsa.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2022 Intel Corporation. All rights reserved
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _DSA_SHM_H_
+#define _DSA_SHM_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+
+#include <stddef.h>
+#include <stdint.h>
+#include "smr.h"
+
+/* SMR FUNCTIONS FOR DSA SUPPORT */
+size_t smr_dsa_copy_to_sar(struct smr_ep *ep, struct smr_freestack *sar_pool,
+		struct smr_resp *resp, struct smr_cmd *cmd,
+		const struct iovec *iov, size_t count, size_t *bytes_done,
+		void *entry_ptr);
+size_t smr_dsa_copy_from_sar(struct smr_ep *ep, struct smr_freestack *sar_pool,
+		struct smr_resp *resp, struct smr_cmd *cmd,
+		const struct iovec *iov, size_t count, size_t *bytes_done,
+		void *entry_ptr);
+void smr_dsa_context_init(struct smr_ep *ep);
+void smr_dsa_context_cleanup(struct smr_ep *ep);
+void smr_dsa_progress(struct smr_ep *ep);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* _DSA_SHM_H_ */

--- a/prov/shm/src/smr_init.c
+++ b/prov/shm/src/smr_init.c
@@ -35,6 +35,7 @@
 #include <ofi_prov.h>
 #include "smr.h"
 #include "smr_signal.h"
+#include "smr_dsa.h"
 #include <ofi_hmem.h>
 
 struct sigaction *old_action = NULL;
@@ -42,6 +43,7 @@ struct sigaction *old_action = NULL;
 struct smr_env smr_env = {
 	.sar_threshold = SIZE_MAX,
 	.disable_cma = false,
+	.use_dsa_sar = false,
 };
 
 static void smr_init_env(void)
@@ -50,6 +52,7 @@ static void smr_init_env(void)
 	fi_param_get_size_t(&smr_prov, "tx_size", &smr_info.tx_attr->size);
 	fi_param_get_size_t(&smr_prov, "rx_size", &smr_info.rx_attr->size);
 	fi_param_get_bool(&smr_prov, "disable_cma", &smr_env.disable_cma);
+	fi_param_get_bool(&smr_prov, "use_dsa_sar", &smr_env.use_dsa_sar);
 }
 
 static void smr_resolve_addr(const char *node, const char *service,
@@ -210,6 +213,12 @@ SHM_INI
 			 Default: 1024");
 	fi_param_define(&smr_prov, "disable_cma", FI_PARAM_BOOL,
 			"Manually disables CMA. Default: false");
+	fi_param_define(&smr_prov, "use_dsa_sar", FI_PARAM_BOOL,
+			"Enable use of DSA in SAR protocol. Default: false");
+	fi_param_define(&smr_prov, "enable_dsa_page_touch", FI_PARAM_BOOL,
+			"Enable CPU touching of memory pages in DSA command \
+			 descriptor when page fault is reported. \
+			 Default: false");
 
 	smr_init_env();
 

--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -37,6 +37,7 @@
 #include <unistd.h>
 
 #include <ofi_mr.h>
+#include <ofi_mem.h>
 #include <ofi_hmem.h>
 #include <ofi_enosys.h>
 #include <rdma/fi_ext.h>


### PR DESCRIPTION
Add initial DSA implementation to SHM provider. As part of this made other implementation changes: using multiple SAR buffers per copy operation, modifying SMR freestack to use aligned object allocation.