### PR TITLE
core/net: Update to pollfds and hot fd polling

### DIFF
--- a/include/ofi_epoll.h
+++ b/include/ofi_epoll.h
@@ -245,7 +245,8 @@ struct ofi_dynpoll {
 	void	(*close)(struct ofi_dynpoll *dynpoll);
 };
 
-int ofi_dynpoll_create(struct ofi_dynpoll *dynpoll, enum ofi_dynpoll_type type);
+int ofi_dynpoll_create(struct ofi_dynpoll *dynpoll, enum ofi_dynpoll_type type,
+		       enum ofi_lock_type lock_type);
 void ofi_dynpoll_close(struct ofi_dynpoll *dynpoll);
 
 static inline int

--- a/include/ofi_epoll.h
+++ b/include/ofi_epoll.h
@@ -86,9 +86,10 @@ struct ofi_pollfds {
 	struct ofi_pollfds_ctx *ctx;
 	struct fd_signal signal;
 	struct slist	work_item_list;
-	ofi_mutex_t	lock;
+	struct ofi_genlock lock;
 };
 
+int ofi_pollfds_create_(struct ofi_pollfds **pfds, enum ofi_lock_type lock_type);
 int ofi_pollfds_create(struct ofi_pollfds **pfds);
 int ofi_pollfds_grow(struct ofi_pollfds *pfds, int max_size);
 

--- a/include/ofi_epoll.h
+++ b/include/ofi_epoll.h
@@ -87,36 +87,21 @@ struct ofi_pollfds {
 	struct fd_signal signal;
 	struct slist	work_item_list;
 	ofi_mutex_t	lock;
-
-	bool		enable_hot;
-	int		hot_size;
-	int		hot_nfds;
-	struct pollfd	*hot_fds;
 };
 
 int ofi_pollfds_create(struct ofi_pollfds **pfds);
 int ofi_pollfds_grow(struct ofi_pollfds *pfds, int max_size);
 
-/* Adding or modifying an fd to watch for non-zero events automatically
- * adds it to the hot set if enabled.  If events is 0, the fd will be
- * removed from the hot set if present.
- */
 int ofi_pollfds_add(struct ofi_pollfds *pfds, int fd, uint32_t events,
 		    void *context);
 int ofi_pollfds_mod(struct ofi_pollfds *pfds, int fd, uint32_t events,
 		    void *context);
 
 int ofi_pollfds_del(struct ofi_pollfds *pfds, int fd);
-int ofi_pollfds_hotties(struct ofi_pollfds *pfds,
-		        struct ofi_epollfds_event *events, int maxevents);
 int ofi_pollfds_wait(struct ofi_pollfds *pfds,
 		     struct ofi_epollfds_event *events,
 		     int maxevents, int timeout);
 void ofi_pollfds_close(struct ofi_pollfds *pfds);
-
-void ofi_pollfds_hotfd(struct ofi_pollfds *pfds, int fd);
-void ofi_pollfds_check_heat(struct ofi_pollfds *pfds,
-			    bool (*is_hot)(void *context));
 
 /* OS specific */
 struct ofi_pollfds_ctx *ofi_pollfds_get_ctx(struct ofi_pollfds *pfds, int fd);

--- a/include/ofi_epoll.h
+++ b/include/ofi_epoll.h
@@ -87,18 +87,30 @@ struct ofi_pollfds {
 	struct fd_signal signal;
 	struct slist	work_item_list;
 	struct ofi_genlock lock;
+
+	int (*add)(struct ofi_pollfds *pfds, int fd, uint32_t events,
+		   void *context);
+	int (*del)(struct ofi_pollfds *pfds, int fd);
 };
 
 int ofi_pollfds_create_(struct ofi_pollfds **pfds, enum ofi_lock_type lock_type);
 int ofi_pollfds_create(struct ofi_pollfds **pfds);
 int ofi_pollfds_grow(struct ofi_pollfds *pfds, int max_size);
 
-int ofi_pollfds_add(struct ofi_pollfds *pfds, int fd, uint32_t events,
-		    void *context);
+static inline int
+ofi_pollfds_add(struct ofi_pollfds *pfds, int fd, uint32_t events, void *context)
+{
+	return pfds->add(pfds, fd, events, context);
+}
+
 int ofi_pollfds_mod(struct ofi_pollfds *pfds, int fd, uint32_t events,
 		    void *context);
 
-int ofi_pollfds_del(struct ofi_pollfds *pfds, int fd);
+static inline int ofi_pollfds_del(struct ofi_pollfds *pfds, int fd)
+{
+	return pfds->del(pfds, fd);
+}
+
 int ofi_pollfds_wait(struct ofi_pollfds *pfds,
 		     struct ofi_epollfds_event *events,
 		     int maxevents, int timeout);

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -290,7 +290,7 @@ struct xnet_progress {
 	struct slist		event_list;
 	struct ofi_bufpool	*xfer_pool;
 
-	struct ofi_dynpoll	pollfds;
+	struct ofi_dynpoll	allfds;
 	struct ofi_dynpoll	hotfds;
 	int			poll_fairness;
 	int			fairness_cntr;

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -585,6 +585,16 @@ static inline bool xnet_has_unexp(struct xnet_ep *ep)
 	return ep->cur_rx.handler && !ep->cur_rx.entry;
 }
 
+static inline void xnet_active_ep(struct xnet_ep *ep)
+{
+	ep->hit_cnt++;
+	if (ep->is_hot || !xnet_ep2_progress(ep)->poll_fairness)
+		return;
+
+	ofi_pollfds_hotfd(xnet_ep2_progress(ep)->pollfds, ep->bsock.sock);
+	ep->is_hot = true;
+}
+
 #define XNET_WARN_ERR(subsystem, log_str, err) \
 	FI_WARN(&xnet_prov, subsystem, log_str "%s (%d)\n", \
 		fi_strerror((int) -(err)), (int) err)

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -290,8 +290,8 @@ struct xnet_progress {
 	struct slist		event_list;
 	struct ofi_bufpool	*xfer_pool;
 
-	struct ofi_pollfds	*pollfds;
-	struct ofi_pollfds	*hotfds;
+	struct ofi_dynpoll	pollfds;
+	struct ofi_dynpoll	hotfds;
 	int			poll_fairness;
 	int			fairness_cntr;
 
@@ -592,14 +592,14 @@ static inline void xnet_active_ep(struct xnet_ep *ep)
 	struct xnet_progress *progress;
 
 	progress = xnet_ep2_progress(ep);
-	if (!progress->hotfds)
+	if (!progress->hotfds.type)
 		return;
 
 	ep->hit_cnt++;
 	if (!dlist_empty(&ep->hot_entry))
 		return;
 
-	(void) ofi_pollfds_add(progress->hotfds, ep->bsock.sock,
+	(void) ofi_dynpoll_add(&progress->hotfds, ep->bsock.sock,
 			       ep->pollflags, &ep->util_ep.ep_fid.fid);
 	dlist_insert_tail(&ep->hot_entry, &progress->hot_list);
 }

--- a/prov/net/src/xnet_cm.c
+++ b/prov/net/src/xnet_cm.c
@@ -272,10 +272,14 @@ void xnet_connect_done(struct xnet_ep *ep)
 		goto disable;
 
 	ep->state = XNET_REQ_SENT;
-	ep->is_hot = true;
 	ep->pollflags = POLLIN;
 	ofi_pollfds_mod(progress->pollfds, ep->bsock.sock,
 			ep->pollflags, &ep->util_ep.ep_fid.fid);
+	if (progress->hotfds) {
+		assert(!dlist_empty(&ep->hot_entry));
+		ofi_pollfds_mod(progress->hotfds, ep->bsock.sock,
+				ep->pollflags, &ep->util_ep.ep_fid.fid);
+	}
 	xnet_signal_progress(progress);
 	return;
 

--- a/prov/net/src/xnet_cm.c
+++ b/prov/net/src/xnet_cm.c
@@ -273,11 +273,11 @@ void xnet_connect_done(struct xnet_ep *ep)
 
 	ep->state = XNET_REQ_SENT;
 	ep->pollflags = POLLIN;
-	ofi_pollfds_mod(progress->pollfds, ep->bsock.sock,
+	ofi_dynpoll_mod(&progress->pollfds, ep->bsock.sock,
 			ep->pollflags, &ep->util_ep.ep_fid.fid);
-	if (progress->hotfds) {
+	if (progress->hotfds.type) {
 		assert(!dlist_empty(&ep->hot_entry));
-		ofi_pollfds_mod(progress->hotfds, ep->bsock.sock,
+		ofi_dynpoll_mod(&progress->hotfds, ep->bsock.sock,
 				ep->pollflags, &ep->util_ep.ep_fid.fid);
 	}
 	xnet_signal_progress(progress);

--- a/prov/net/src/xnet_cm.c
+++ b/prov/net/src/xnet_cm.c
@@ -273,7 +273,7 @@ void xnet_connect_done(struct xnet_ep *ep)
 
 	ep->state = XNET_REQ_SENT;
 	ep->pollflags = POLLIN;
-	ofi_dynpoll_mod(&progress->pollfds, ep->bsock.sock,
+	ofi_dynpoll_mod(&progress->allfds, ep->bsock.sock,
 			ep->pollflags, &ep->util_ep.ep_fid.fid);
 	if (progress->hotfds.type) {
 		assert(!dlist_empty(&ep->hot_entry));

--- a/prov/net/src/xnet_cq.c
+++ b/prov/net/src/xnet_cq.c
@@ -470,7 +470,7 @@ int xnet_cntr_open(struct fid_domain *fid_domain, struct fi_cntr_attr *attr,
 		    domain->util_domain.threading != FI_THREAD_DOMAIN) {
 			cntr_attr.wait_obj = FI_WAIT_FD;
 		} else {
-			/* We can wait on the progress pollfds */
+			/* We can wait on the progress allfds */
 			cntr_attr.wait_obj = FI_WAIT_NONE;
 		}
 		attr = &cntr_attr;

--- a/prov/net/src/xnet_ep.c
+++ b/prov/net/src/xnet_ep.c
@@ -150,7 +150,7 @@ int xnet_setup_socket(SOCKET sock, struct fi_info *info)
 
 static int xnet_monitor_ep(struct xnet_progress *progress, struct xnet_ep *ep)
 {
-	if (progress->hotfds) {
+	if (progress->hotfds.type) {
 		assert(dlist_empty(&ep->hot_entry));
 		dlist_insert_tail(&ep->hot_entry, &progress->hot_list);
 	}

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -46,16 +46,6 @@
 static ssize_t (*xnet_start_op[ofi_op_write + 1])(struct xnet_ep *ep);
 
 
-static inline void xnet_active_ep(struct xnet_ep *ep)
-{
-	ep->hit_cnt++;
-	if (ep->is_hot || !xnet_ep2_progress(ep)->poll_fairness)
-		return;
-
-	ofi_pollfds_hotfd(xnet_ep2_progress(ep)->pollfds, ep->bsock.sock);
-	ep->is_hot = true;
-}
-
 static void xnet_update_pollflag(struct xnet_ep *ep, short pollflag, bool set)
 {
 	struct xnet_progress *progress;

--- a/prov/net/src/xnet_srx.c
+++ b/prov/net/src/xnet_srx.c
@@ -224,9 +224,12 @@ xnet_srx_tag(struct xnet_srx *srx, struct xnet_xfer_entry *recv_entry)
 		slist_insert_tail(&recv_entry->entry, queue);
 
 		ep = xnet_get_ep(srx->rdm, recv_entry->src_addr);
-		if (ep && xnet_has_unexp(ep)) {
-			assert(!dlist_empty(&ep->unexp_entry));
-			xnet_progress_rx(ep);
+		if (ep) {
+			xnet_active_ep(ep);
+			if (xnet_has_unexp(ep)) {
+				assert(!dlist_empty(&ep->unexp_entry));
+				xnet_progress_rx(ep);
+			}
 		}
 	}
 

--- a/src/common.c
+++ b/src/common.c
@@ -1824,7 +1824,8 @@ void ofi_dynpoll_close(struct ofi_dynpoll *dynpoll)
 	}
 }
 
-int ofi_dynpoll_create(struct ofi_dynpoll *dynpoll, enum ofi_dynpoll_type type)
+int ofi_dynpoll_create(struct ofi_dynpoll *dynpoll, enum ofi_dynpoll_type type,
+		       enum ofi_lock_type lock_type)
 {
 	int ret;
 
@@ -1838,7 +1839,7 @@ int ofi_dynpoll_create(struct ofi_dynpoll *dynpoll, enum ofi_dynpoll_type type)
 		dynpoll->wait = ofi_dynpoll_wait_epoll;
 		break;
 	case OFI_DYNPOLL_POLL:
-		ret = ofi_pollfds_create(&dynpoll->pfds);
+		ret = ofi_pollfds_create_(&dynpoll->pfds, lock_type);
 		dynpoll->add = ofi_dynpoll_add_poll;
 		dynpoll->mod = ofi_dynpoll_mod_poll;
 		dynpoll->del = ofi_dynpoll_del_poll;

--- a/src/unix/osd.c
+++ b/src/unix/osd.c
@@ -322,7 +322,7 @@ struct ofi_pollfds_ctx *ofi_pollfds_get_ctx(struct ofi_pollfds *pfds, int fd)
 {
 	struct ofi_pollfds_ctx *ctx;
 
-	assert(ofi_mutex_held(&pfds->lock));
+	assert(ofi_genlock_held(&pfds->lock));
 	if (fd < 0 || fd >= pfds->size)
 		return NULL;
 
@@ -338,7 +338,7 @@ struct ofi_pollfds_ctx *ofi_pollfds_alloc_ctx(struct ofi_pollfds *pfds, int fd)
 {
 	struct ofi_pollfds_ctx *ctx;
 
-	assert(ofi_mutex_held(&pfds->lock));
+	assert(ofi_genlock_held(&pfds->lock));
 	assert(!ofi_pollfds_get_ctx(pfds, fd));
 	if (fd >= pfds->size) {
 		if (ofi_pollfds_grow(pfds, fd))

--- a/src/windows/osd.c
+++ b/src/windows/osd.c
@@ -609,7 +609,7 @@ struct ofi_pollfds_ctx *ofi_pollfds_get_ctx(struct ofi_pollfds *pfds, int fd)
 	struct ofi_pollfds_ctx *ctx = NULL;
 	int i;
 
-	assert(ofi_mutex_held(&pfds->lock));
+	assert(ofi_genlock_held(&pfds->lock));
 
 	/* 0 is signaling fd */
 	for (i = 1; i < pfds->size; i++) {
@@ -627,7 +627,7 @@ struct ofi_pollfds_ctx *ofi_pollfds_alloc_ctx(struct ofi_pollfds *pfds, int fd)
 	struct ofi_pollfds_ctx *ctx;
 	int i;
 
-	assert(ofi_mutex_held(&pfds->lock));
+	assert(ofi_genlock_held(&pfds->lock));
 	assert(!ofi_pollfds_get_ctx(pfds, fd));
 	/* 0 is signaling fd */
 	for (i = 1; i < pfds->size; i++) {


### PR DESCRIPTION
Moves all hot fd support from the pollfds abstraction directly into the net provider.  Trying to track hot fd's within pollfds does not work and requires the user of the poll set to control which sockets are hot.  The hot support is removed from pollfds.

Adds a new dynamic poll abstraction, which selects between epoll vs poll at run time.

Updates the net provider to maintain separate fd sets for all fd's and hot fd's.

Updates pollfds to allow the user to specify the type of locking to use.  If no lock is required, we optimize the add/del calls to avoid asynchronous processing and memory allocation.