### PR TITLE
core/indexer: Fix OFI_IDX_MAX_INDEX off by 1 error

### DIFF
--- a/include/ofi_indexer.h
+++ b/include/ofi_indexer.h
@@ -69,7 +69,7 @@ struct ofi_idx_entry {
 #define OFI_IDX_CHUNK_SIZE (1 << OFI_IDX_OFFSET_BITS)
 #define OFI_IDX_MAX_CHUNKS (1 << OFI_IDX_CHUNK_BITS)
 
-#define OFI_IDX_MAX_INDEX  (OFI_IDX_MAX_CHUNKS * OFI_IDX_CHUNK_SIZE)
+#define OFI_IDX_MAX_INDEX  ((OFI_IDX_MAX_CHUNKS * OFI_IDX_CHUNK_SIZE) - 1)
 
 struct indexer
 {

--- a/src/common.c
+++ b/src/common.c
@@ -1709,7 +1709,10 @@ int ofi_pollfds_create_(struct ofi_pollfds **pfds, enum ofi_lock_type lock_type)
 	if (!*pfds)
 		return -FI_ENOMEM;
 
-	ofi_genlock_init(&(*pfds)->lock, lock_type);
+	ret = ofi_genlock_init(&(*pfds)->lock, lock_type);
+	if (ret)
+		goto err0;
+
 	ofi_genlock_lock(&(*pfds)->lock);
 	ret = ofi_pollfds_grow(*pfds, 63);
 	ofi_genlock_unlock(&(*pfds)->lock);
@@ -1736,6 +1739,7 @@ err2:
 	free((*pfds)->fds);
 err1:
 	ofi_genlock_destroy(&(*pfds)->lock);
+err0:
 	free(*pfds);
 	return ret;
 }


### PR DESCRIPTION
The max index needs to be 1 less, since indices start at 0.

Should fix coverity warning.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>