### PR TITLE
[v1.15.x] hmem_neuron.c: Use nrt_memcpy_to_device to copy from host to dev

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ v1.15.2, Fri Aug 19, 2022
 
 - Fix incorrect cleanup on gdrcopy initialization success
 - Change the neuron library file name
+- Use neuron's memcpy API to copy from host to device.
 - Fix signaling race in pollfds abstraction
 - Check correct number of events in pollfds abstraction
 - Fix locking in pollfds reading event contexts


### PR DESCRIPTION
This PR backports https://github.com/ofiwg/libfabric/pull/7952 to v1.15.x, and updates `NEWS.md`.