### PR TITLE
prov/net: Updates to socket config and poll behavior

### DIFF
--- a/include/ofi_epoll.h
+++ b/include/ofi_epoll.h
@@ -57,8 +57,6 @@ struct ofi_epollfds_event {
 };
 #endif
 
-extern int ofi_poll_fairness;
-
 enum ofi_pollfds_ctl {
 	POLLFDS_CTL_ADD,
 	POLLFDS_CTL_DEL,

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -84,6 +84,7 @@ extern int xnet_prefetch_rbuf_size;
 extern size_t xnet_default_tx_size;
 extern size_t xnet_default_rx_size;
 extern size_t xnet_zerocopy_size;
+extern int xnet_poll_fairness;
 extern int xnet_disable_autoprog;
 
 struct xnet_xfer_entry;

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -85,6 +85,7 @@ extern size_t xnet_default_tx_size;
 extern size_t xnet_default_rx_size;
 extern size_t xnet_zerocopy_size;
 extern int xnet_poll_fairness;
+extern int xnet_poll_cooldown;
 extern int xnet_disable_autoprog;
 
 struct xnet_xfer_entry;
@@ -295,6 +296,8 @@ struct xnet_progress {
 	struct ofi_dynpoll	hotfds;
 	int			poll_fairness;
 	int			fairness_cntr;
+	int			poll_cooldown;
+	int			cooldown_cntr;
 
 	bool			auto_progress;
 	pthread_t		thread;

--- a/prov/net/src/xnet_init.c
+++ b/prov/net/src/xnet_init.c
@@ -63,6 +63,7 @@ int xnet_prefetch_rbuf_size = 9000;
 size_t xnet_default_tx_size = 256;
 size_t xnet_default_rx_size = 256;
 size_t xnet_zerocopy_size = SIZE_MAX;
+int xnet_poll_fairness = 0;
 int xnet_disable_autoprog;
 
 
@@ -132,6 +133,15 @@ static void xnet_init_env(void)
 	fi_param_get_int(&xnet_prov, "prefetch_rbuf_size",
 			 &xnet_prefetch_rbuf_size);
 	fi_param_get_size_t(&xnet_prov, "zerocopy_size", &xnet_zerocopy_size);
+
+	fi_param_define(&xnet_prov, "poll_fairness", FI_PARAM_INT,
+			"This counter value balances calling poll() on a list "
+			"of sockets marked as active, versus all sockets being "
+			"monitored.  This variable controls the number of times "
+			"that the active sockets are checked before the full "
+			"set is.  A value of 0 disables the active "
+			"list.  Default (%d)", xnet_poll_fairness);
+	fi_param_get_int(&xnet_prov, "poll_fairness", &xnet_poll_fairness);
 
 	fi_param_define(&xnet_prov, "disable_auto_progress", FI_PARAM_BOOL,
 			"prevent auto-progress thread from starting");

--- a/prov/net/src/xnet_init.c
+++ b/prov/net/src/xnet_init.c
@@ -64,6 +64,7 @@ size_t xnet_default_tx_size = 256;
 size_t xnet_default_rx_size = 256;
 size_t xnet_zerocopy_size = SIZE_MAX;
 int xnet_poll_fairness = 0;
+int xnet_poll_cooldown = 0;
 int xnet_disable_autoprog;
 
 
@@ -142,6 +143,13 @@ static void xnet_init_env(void)
 			"set is.  A value of 0 disables the active "
 			"list.  Default (%d)", xnet_poll_fairness);
 	fi_param_get_int(&xnet_prov, "poll_fairness", &xnet_poll_fairness);
+	fi_param_define(&xnet_prov, "poll_cooldown", FI_PARAM_INT,
+			"This value only applies if poll_fairness is active. "
+			"This determines the number of iterations that a socket "
+			"will remain marked as active without receiving data "
+			"before being removed from the active set. "
+			"Default (%d)", xnet_poll_cooldown);
+	fi_param_get_int(&xnet_prov, "poll_cooldown", &xnet_poll_cooldown);
 
 	fi_param_define(&xnet_prov, "disable_auto_progress", FI_PARAM_BOOL,
 			"prevent auto-progress thread from starting");

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -1115,14 +1115,14 @@ int xnet_init_progress(struct xnet_progress *progress, struct fi_info *info)
 	if (ret)
 		goto err2;
 
-	if (ofi_poll_fairness) {
+	if (xnet_poll_fairness) {
 		/* We never block on the hotfds and are serialized by the
 		 * progress lock.  No lock is needed.
 		 */
 		ret = ofi_dynpoll_create(&progress->hotfds, OFI_DYNPOLL_POLL,
 					 OFI_LOCK_NOOP);
 		if (!ret) {
-			progress->poll_fairness = ofi_poll_fairness;
+			progress->poll_fairness = xnet_poll_fairness;
 			progress->fairness_cntr = progress->poll_fairness;
 		}
 	}

--- a/src/common.c
+++ b/src/common.c
@@ -84,7 +84,6 @@ struct ofi_common_locks common_locks = {
 };
 
 size_t ofi_universe_size = 1024;
-int ofi_poll_fairness = 0;
 
 
 int ofi_genlock_init(struct ofi_genlock *lock,

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -827,18 +827,6 @@ void fi_ini(void)
 			"(default: provider specific)");
 	fi_param_get_size_t(NULL, "universe_size", &ofi_universe_size);
 
-	fi_param_define(NULL, "poll_fairness", FI_PARAM_INT,
-			"This counter value controls calling poll() on a list "
-			"of sockets and file descriptors and is most relevant "
-			"when using the tcp provider with the pollfd wait "
-			"object.  The pollfd abstraction maintains a list of "
-			"active or hot fd's that it monitors.  This variable "
-			"controls the number of times that the active fd's "
-			"list is checked relative to the full set of fd's "
-			"being monitored.  A value of 0 disables the active "
-			"list.  Default (%d)", ofi_poll_fairness);
-	fi_param_get_int(NULL, "poll_fairness", &ofi_poll_fairness);
-
 	ofi_load_dl_prov();
 
 	ofi_register_provider(PSM3_INIT, NULL);


### PR DESCRIPTION
Request socket send/receive buffering to 128k as a default.
Convert global ofi_poll_fairness variable to net provider variable.
Use a separate counter from poll fairness to move sockets off the hot set.