### PR TITLE
prov/efa: a unit test bug fix and handle the case when EFA DV CQ is not supported

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -113,6 +113,11 @@ prov_efa_test_efa_unit_test_LDADD = $(cmocka_LIBS) $(linkback)
 prov_efa_test_efa_unit_test_LDFLAGS = $(cmocka_rpath) $(efa_LDFLAGS) $(cmocka_LDFLAGS) \
 					-Wl,--wrap=ibv_create_ah \
 					-Wl,--wrap=efadv_query_device
+
+if HAVE_EFADV_CQ_EX
+prov_efa_test_efa_unit_test_LDFLAGS += -Wl,--wrap=efadv_create_cq
+endif HAVE_EFADV_CQ_EX
+
 prov_efa_test_efa_unit_test_LIBS = $(efa_LIBS) $(linkback)
 
 endif ENABLE_EFA_UNIT_TEST

--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -122,6 +122,9 @@
 /* maximum name length for shm endpoint */
 #define EFA_SHM_NAME_MAX	   (256)
 
+/* efa_cq->ibv_cq_ex is created by efadv_create_cq */
+#define EFA_CQ_SUPPORT_EFADV_CQ BIT_ULL(0)
+
 extern struct fi_provider efa_prov;
 extern struct util_prov efa_util_prov;
 
@@ -192,6 +195,7 @@ struct efa_cq {
 	efa_cq_read_entry	read_entry;
 	ofi_spin_t		lock;
 	struct ofi_bufpool	*wce_pool;
+	uint32_t	flags; /* User defined capability mask */
 
 	struct ibv_cq_ex	*ibv_cq_ex;
 };

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1815,11 +1815,17 @@ static inline fi_addr_t rdm_ep_determine_peer_address_from_efadv(struct rxr_ep *
 {
 	struct rxr_pkt_entry *pkt_entry;
 	struct efa_ep *efa_ep;
+	struct efa_cq *efa_cq;
 	struct efa_ep_addr efa_ep_addr = {0};
 	fi_addr_t addr;
 	union ibv_gid gid = {0};
 	uint32_t *connid = NULL;
 
+	efa_cq = container_of(ep->rdm_cq, struct efa_cq, util_cq.cq_fid);
+	if (!(efa_cq->flags & EFA_CQ_SUPPORT_EFADV_CQ)) {
+		/* EFA DV CQ is not supported. This could be due to old EFA kernel module versions. */
+		return FI_ADDR_NOTAVAIL;
+	}
 
 	/* Attempt to read sgid from EFA firmware */
 	if (efadv_wc_read_sgid(efadv_cq_from_ibv_cq_ex(ibv_cqx), &gid) < 0) {

--- a/prov/efa/test/efa_unit_test_common.c
+++ b/prov/efa/test/efa_unit_test_common.c
@@ -138,7 +138,7 @@ void efa_unit_test_buff_construct(struct efa_unit_test_buff *buff, struct efa_re
 	assert_non_null(buff->buff);
 
 	buff->size = buff_size;
-	err = fi_mr_reg(resource->domain, buff, buff_size, FI_SEND | FI_RECV,
+	err = fi_mr_reg(resource->domain, buff->buff, buff_size, FI_SEND | FI_RECV,
 			0 /*offset*/, 0 /*requested_key*/, 0 /*flags*/, &buff->mr, NULL);
 	assert_int_equal(err, 0);
 }

--- a/prov/efa/test/efa_unit_test_mocks.h
+++ b/prov/efa/test/efa_unit_test_mocks.h
@@ -46,10 +46,21 @@ struct efa_unit_test_mocks
 	struct ibv_ah *(*ibv_create_ah)(struct ibv_pd *pd, struct ibv_ah_attr *attr);
 
 	int (*efadv_query_device)(struct ibv_context *ibvctx, struct efadv_device_attr *attr,
-				  uint32_t inlen);
+							  uint32_t inlen);
+#if HAVE_EFADV_CQ_EX
+
+	struct ibv_cq_ex *(*efadv_create_cq)(struct ibv_context *ibvctx,
+										 struct ibv_cq_init_attr_ex *attr_ex,
+										 struct efadv_cq_init_attr *efa_attr,
+										 uint32_t inlen);
+#endif
 };
 
 #if HAVE_EFADV_CQ_EX
+struct ibv_cq_ex *__real_efadv_create_cq(struct ibv_context *ibvctx,
+											struct ibv_cq_init_attr_ex *attr_ex,
+											struct efadv_cq_init_attr *efa_attr,
+											uint32_t inlen);
 uint32_t efa_mock_ibv_read_src_qp_return_mock(struct ibv_cq_ex *current);
 uint32_t efa_mock_ibv_read_byte_len_return_mock(struct ibv_cq_ex *current);
 uint32_t efa_mock_ibv_read_slid_return_mock(struct ibv_cq_ex *current);
@@ -57,6 +68,14 @@ int efa_mock_efadv_wc_read_sgid_return_zero_code_and_expect_next_poll_and_set_gi
 int efa_mock_ibv_start_poll_expect_efadv_wc_read_ah_and_return_mock(struct ibv_cq_ex *ibvcqx,
 																	struct ibv_poll_cq_attr *attr);
 int efa_mock_ibv_next_poll_check_function_called_and_return_mock(struct ibv_cq_ex *ibvcqx);
+struct ibv_cq_ex *efa_mock_efadv_create_cq_with_ibv_create_cq_ex(struct ibv_context *ibvctx,
+																 struct ibv_cq_init_attr_ex *attr_ex,
+																 struct efadv_cq_init_attr *efa_attr,
+																 uint32_t inlen);
+struct ibv_cq_ex *efa_mock_efadv_create_cq_set_eopnotsupp_and_return_null(struct ibv_context *ibvctx,
+																		  struct ibv_cq_init_attr_ex *attr_ex,
+																		  struct efadv_cq_init_attr *efa_attr,
+																		  uint32_t inlen);
 #endif
 
 #endif

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -7,6 +7,9 @@ static int efa_unit_test_mocks_reset(void **state)
 	g_efa_unit_test_mocks = (struct efa_unit_test_mocks) {
 		.ibv_create_ah = __real_ibv_create_ah,
 		.efadv_query_device = __real_efadv_query_device,
+#if HAVE_EFADV_CQ_EX
+		.efadv_create_cq = __real_efadv_create_cq,
+#endif
 	};
 
 	return 0;
@@ -31,6 +34,7 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_rdm_cq_read_bad_recv_status, efa_unit_test_mocks_reset, NULL),
 		cmocka_unit_test_setup_teardown(test_rdm_cq_read_recover_forgotten_peer_ah, efa_unit_test_mocks_reset, NULL),
 		cmocka_unit_test_setup_teardown(test_rdm_cq_read_ignore_removed_peer, efa_unit_test_mocks_reset, NULL),
+		cmocka_unit_test_setup_teardown(test_rdm_fallback_to_ibv_create_cq_ex_cq_read_ignore_forgotton_peer, efa_unit_test_mocks_reset, NULL),
 		cmocka_unit_test_setup_teardown(test_info_open_ep_with_wrong_info, efa_unit_test_mocks_reset, NULL),
 		cmocka_unit_test_setup_teardown(test_info_open_ep_with_api_1_1_info, efa_unit_test_mocks_reset, NULL),
 	};

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -63,6 +63,7 @@ void test_rdm_cq_read_failed_poll();
 void test_rdm_cq_read_bad_send_status();
 void test_rdm_cq_read_bad_recv_status();
 void test_rdm_cq_read_recover_forgotten_peer_ah();
+void test_rdm_fallback_to_ibv_create_cq_ex_cq_read_ignore_forgotton_peer();
 void test_rdm_cq_read_ignore_removed_peer();
 void test_info_open_ep_with_wrong_info();
 void test_info_open_ep_with_api_1_1_info();


### PR DESCRIPTION
- Unit test buffer construction used the wrong buffer address, which caused `Bad address` error from `fi_mr_reg` at large buffer sizes, e.g. 8800 bytes. This is a subtle bug and we did not notice it for 4096 bytes.
- The recent change to query peer address from EFA device did not account for the case when EFA DV CQ is not supported in the kernel, which will cause `efadv_create_cq` to fail. In this change we add the handling logic to fallback to `ibv_create_cq_ex` if `efadv_create_cq` fails(for any reason). We use a bit mask to indicate whether the `efa_cq->ibv_cq_ex` is created with `efadv_create_cq` or `ibv_create_cq_ex`, and thereby decide if we should try to query peer address from EFA device.