### PR TITLE
prov/verbs: Flush and save RX CQEs prior to destroying QP

### DIFF
--- a/prov/verbs/include/fi_verbs.h
+++ b/prov/verbs/include/fi_verbs.h
@@ -864,7 +864,7 @@ int vrb_query_atomic(struct fid_domain *domain_fid, enum fi_datatype datatype,
 			enum fi_op op, struct fi_atomic_attr *attr,
 			uint64_t flags);
 void vrb_set_rnr_timer(struct ibv_qp *qp);
-void vrb_cleanup_cq(struct vrb_ep *cur_ep);
+void vrb_flush_rx_cq(struct vrb_ep *ep);
 int vrb_find_max_inline(struct ibv_pd *pd, struct ibv_context *context,
 			   enum ibv_qp_type qp_type);
 


### PR DESCRIPTION
This patch fixes issue 7837.

Verbs provider is not polling CQ before destroying QP but CQEs
may not be available after a QP is destroyed.  Modify QP
to ERROR state to flush outstanding WRs and poll RX CQ until
RX queue depth entries are retrieved or exceed max retry.
Max retry is calculated based on RX queue depth and some HW
is populating CQEs in chunks of 64.

Current flush SQ code is left intact in favor of polling TX CQ
since it fixes a known issue.

Signed-off-by: Chien Tin Tung <chien.tin.tung@intel.com>