### PR TITLE
prov/net: Fix incorrect disconnect during connection setup

### DIFF
--- a/prov/net/src/xnet_rdm_cm.c
+++ b/prov/net/src/xnet_rdm_cm.c
@@ -367,19 +367,6 @@ struct xnet_ep *xnet_get_ep(struct xnet_rdm *rdm, fi_addr_t addr)
 		conn->ep : NULL;
 }
 
-void xnet_process_connect(struct fi_eq_cm_entry *cm_entry)
-{
-	struct xnet_rdm_cm *msg;
-	struct xnet_conn *conn;
-
-	assert(cm_entry->fid->fclass == XNET_CLASS_CM);
-	conn = cm_entry->fid->context;
-
-	assert(xnet_progress_locked(xnet_rdm2_progress(conn->rdm)));
-	msg = (struct xnet_rdm_cm *) cm_entry->data;
-	conn->remote_pid = ntohl(msg->pid);
-}
-
 static void xnet_process_connreq(struct fi_eq_cm_entry *cm_entry)
 {
 	struct xnet_rdm *rdm;

--- a/prov/net/src/xnet_rdm_cm.c
+++ b/prov/net/src/xnet_rdm_cm.c
@@ -430,7 +430,12 @@ static void xnet_process_connreq(struct fi_eq_cm_entry *cm_entry)
 		break;
 	case XNET_ACCEPTING:
 	case XNET_CONNECTED:
-		if (conn->remote_pid == ntohl(msg->pid)) {
+		/* If we have't set the remote_pid but we're already connected,
+		 * there's a CONNECTED event on the event list queued after this
+		 * CONNREQ event.  The peer has already accepted the current
+		 * connection.
+		 */
+		if (!conn->remote_pid || (conn->remote_pid == ntohl(msg->pid))) {
 			FI_INFO(&xnet_prov, FI_LOG_EP_CTRL,
 				"simultaneous, reject peer\n");
 			goto put;


### PR DESCRIPTION
Yeah, the title doesn't seem to make sense, but it really does...

    For RDM endpoints, when processing a connect request event, we
    see if there's already a connection to the peer.  This is handled
    in xnet_process_connreq().  If we have an active connection (that
    is, there's an ep of state CONNECTED), there are 2 cases that are
    considered.
    
    Case 1 is that the current connection is old and no longer
    usable.  This can happen if the peer disconnects and restarts, and
    is the case for DAOS clients.  We check for this case by comparing
    whether the connection is coming from the same or a different
    remote process ID.
    
    Case 2 is that the current connection is the new connection.  The
    peer has accepted our request for the connection.  And we're simply
    processing the peer's original connection request, which we can
    deduce has been discarded (since the peer accepted out request).
    Case 2 occurs when the remote process ID of the peer matches that
    of the connection.
    
    However, there's a race condition that can occur.  This is when
    the local endpoint has finished connecting, but before the rdm
    CM can process the connect response.  See xnet_req_done().  The
    CONNECTED event, which carries the remote proces ID as part of
    its data, is queued to the EQ (rdm event list).  Then the ep
    state is set to CONNECTED.  Because the rdm cm has direct access
    to the ep state, it can see that the ep state is CONNECTED while
    processing the peer's connect request.  (The connected event is
    queued behind the request on the EQ and has not yet been handled).
    The result is that when handling the connect request, even though
    the local ep is CONNECTED, the process ID will not yet have been
    set.
    
    Add a check for the process ID to be 0, and if not set, then we're
    also in case 2 above.  The new request should be rejected, as the
    peer has already accepted our connection.
    
    This fixes a hang that can occur running MPI as a result of data
    being discarded because of closing the existing connection.