### PR TITLE
prov/efa: Do not fail domain open when neuron_alloc failed.

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -104,7 +104,8 @@ nodist_prov_efa_test_efa_unit_test_SOURCES = \
 	prov/efa/test/efa_unit_test_av.c \
 	prov/efa/test/efa_unit_test_cq.c \
 	prov/efa/test/efa_unit_test_device.c \
-	prov/efa/test/efa_unit_test_info.c
+	prov/efa/test/efa_unit_test_info.c \
+	prov/efa/test/efa_unit_test_hmem.c
 
 efa_CPPFLAGS += -I$(top_srcdir)/include -I$(top_srcdir)/prov/efa/test $(cmocka_CPPFLAGS)
 
@@ -117,6 +118,10 @@ prov_efa_test_efa_unit_test_LDFLAGS = $(cmocka_rpath) $(efa_LDFLAGS) $(cmocka_LD
 if HAVE_EFADV_CQ_EX
 prov_efa_test_efa_unit_test_LDFLAGS += -Wl,--wrap=efadv_create_cq
 endif HAVE_EFADV_CQ_EX
+
+if HAVE_NEURON
+prov_efa_test_efa_unit_test_LDFLAGS += -Wl,--wrap=neuron_alloc
+endif HAVE_NEURON
 
 prov_efa_test_efa_unit_test_LIBS = $(efa_LIBS) $(linkback)
 

--- a/prov/efa/configure.m4
+++ b/prov/efa/configure.m4
@@ -203,6 +203,7 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 	fi
 
 	AM_CONDITIONAL([ENABLE_EFA_UNIT_TEST], [ test x"$enable_efa_unit_test" != x"" && test x"$enable_efa_unit_test" != x"no" ])
+	AM_CONDITIONAL([HAVE_NEURON], [ test "$have_neuron" = "1" ])
 ])
 
 dnl

--- a/prov/efa/test/efa_unit_test_hmem.c
+++ b/prov/efa/test/efa_unit_test_hmem.c
@@ -1,0 +1,53 @@
+#include "efa_unit_tests.h"
+
+
+#if HAVE_NEURON
+/**
+ * @brief Verify when neuron_alloc failed (return null),
+ * efa_domain_open, which call efa_hmem_support_status_update_neuron
+ * when HAVE_NEURON=1, will still return 0 but leave 
+ * hmem_support_status[FI_HMEM_NEURON].initialized and 
+ * hmem_support_status[FI_HMEM_NEURON].p2p_supported as false.
+ */
+void test_efa_hmem_support_status_update_neuron()
+{
+        int ret;
+        struct efa_resource resource = {0};
+        struct efa_domain *efa_domain;
+        uint32_t efa_device_caps_orig;
+        bool neuron_initialized_orig;
+
+        resource.hints = efa_unit_test_alloc_hints(FI_EP_RDM);
+        assert_non_null(resource.hints);
+
+        ret = fi_getinfo(FI_VERSION(1, 14), NULL, NULL, 0ULL, resource.hints, &resource.info);
+        assert_int_equal(ret, 0);
+
+        ret = fi_fabric(resource.info->fabric_attr, &resource.fabric, NULL);
+        assert_int_equal(ret, 0);
+
+        neuron_initialized_orig = hmem_ops[FI_HMEM_NEURON].initialized;
+        hmem_ops[FI_HMEM_NEURON].initialized = true;
+        efa_device_caps_orig = g_device_list[0].device_caps;
+        g_device_list[0].device_caps |= EFADV_DEVICE_ATTR_CAPS_RDMA_READ;
+        g_efa_unit_test_mocks.neuron_alloc = &efa_mock_neuron_alloc_return_null;
+
+        ret = fi_domain(resource.fabric, resource.info, &resource.domain, NULL);
+
+        /* recover the modified global variables before doing check */
+        hmem_ops[FI_HMEM_NEURON].initialized = neuron_initialized_orig;
+        g_device_list[0].device_caps = efa_device_caps_orig;
+
+        assert_int_equal(ret, 0);
+        efa_domain = container_of(resource.domain, struct efa_domain,
+				  util_domain.domain_fid.fid);
+        assert_false(efa_domain->hmem_support_status[FI_HMEM_NEURON].initialized);
+        assert_false(efa_domain->hmem_support_status[FI_HMEM_NEURON].p2p_supported);
+        efa_unit_test_resource_destruct(&resource);
+}
+#else
+void test_efa_hmem_support_status_update_neuron()
+{
+        skip();
+}
+#endif /* HAVE_NEURON */

--- a/prov/efa/test/efa_unit_test_mocks.c
+++ b/prov/efa/test/efa_unit_test_mocks.c
@@ -169,6 +169,9 @@ struct efa_unit_test_mocks g_efa_unit_test_mocks = {
 #if HAVE_EFADV_CQ_EX
 	.efadv_create_cq = __real_efadv_create_cq,
 #endif
+#if HAVE_NEURON
+	.neuron_alloc = __real_neuron_alloc,
+#endif
 };
 
 struct ibv_ah *__wrap_ibv_create_ah(struct ibv_pd *pd, struct ibv_ah_attr *attr)
@@ -237,6 +240,18 @@ struct ibv_cq_ex *efa_mock_efadv_create_cq_set_eopnotsupp_and_return_null(struct
 {
 	function_called();
 	errno = EOPNOTSUPP;
+	return NULL;
+}
+#endif
+
+#if HAVE_NEURON
+void *__wrap_neuron_alloc(void **handle, size_t size)
+{
+	return g_efa_unit_test_mocks.neuron_alloc(handle, size);
+}
+
+void *efa_mock_neuron_alloc_return_null(void **handle, size_t size)
+{
 	return NULL;
 }
 #endif

--- a/prov/efa/test/efa_unit_test_mocks.h
+++ b/prov/efa/test/efa_unit_test_mocks.h
@@ -54,6 +54,10 @@ struct efa_unit_test_mocks
 										 struct efadv_cq_init_attr *efa_attr,
 										 uint32_t inlen);
 #endif
+
+#if HAVE_NEURON
+	void *(*neuron_alloc)(void **handle, size_t size);
+#endif
 };
 
 #if HAVE_EFADV_CQ_EX
@@ -76,6 +80,11 @@ struct ibv_cq_ex *efa_mock_efadv_create_cq_set_eopnotsupp_and_return_null(struct
 																		  struct ibv_cq_init_attr_ex *attr_ex,
 																		  struct efadv_cq_init_attr *efa_attr,
 																		  uint32_t inlen);
+#endif
+
+#if HAVE_NEURON
+void *__real_neuron_alloc(void **handle, size_t size);
+void *efa_mock_neuron_alloc_return_null(void **handle, size_t size);
 #endif
 
 #endif

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -10,6 +10,9 @@ static int efa_unit_test_mocks_reset(void **state)
 #if HAVE_EFADV_CQ_EX
 		.efadv_create_cq = __real_efadv_create_cq,
 #endif
+#if HAVE_NEURON
+		.neuron_alloc = __real_neuron_alloc,
+#endif
 	};
 
 	return 0;
@@ -37,6 +40,7 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_rdm_fallback_to_ibv_create_cq_ex_cq_read_ignore_forgotton_peer, efa_unit_test_mocks_reset, NULL),
 		cmocka_unit_test_setup_teardown(test_info_open_ep_with_wrong_info, efa_unit_test_mocks_reset, NULL),
 		cmocka_unit_test_setup_teardown(test_info_open_ep_with_api_1_1_info, efa_unit_test_mocks_reset, NULL),
+		cmocka_unit_test_setup_teardown(test_efa_hmem_support_status_update_neuron, efa_unit_test_mocks_reset, NULL),
 	};
 
 	cmocka_set_message_output(CM_OUTPUT_XML);

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -67,5 +67,6 @@ void test_rdm_fallback_to_ibv_create_cq_ex_cq_read_ignore_forgotton_peer();
 void test_rdm_cq_read_ignore_removed_peer();
 void test_info_open_ep_with_wrong_info();
 void test_info_open_ep_with_api_1_1_info();
+void test_efa_hmem_support_status_update_neuron();
 
 #endif


### PR DESCRIPTION
neuron_alloc will fail if application did not call nrt_init,
which is ok if it's not running neuron workloads. libfabric
will move on and leave neuron_status->initialized as false.

Also add a unit test for this fix