### PR TITLE
prov/efa: Introduce rxr_env.enable_eager_message

### DIFF
--- a/man/fi_efa.7.md
+++ b/man/fi_efa.7.md
@@ -174,6 +174,9 @@ These OFI runtime parameters apply only to the RDM endpoint.
   [`ptrace protection`](https://wiki.ubuntu.com/SecurityTeam/Roadmap/KernelHardening#ptrace_Protection)
   is turned on. You can turn it off to enable shm transfer.
 
+*FI_EFA_ENABLE_EAGER_MESSAGE*
+: Enable eager message protocol (default: 1).
+
 *FI_EFA_SHM_AV_SIZE*
 : Defines the maximum number of entries in SHM provider's address vector.
 

--- a/prov/efa/src/rxr/rxr_env.c
+++ b/prov/efa/src/rxr/rxr_env.c
@@ -42,6 +42,7 @@ struct rxr_env rxr_env = {
 	.tx_min_credits = RXR_DEF_MIN_TX_CREDITS,
 	.tx_queue_size = 0,
 	.enable_shm_transfer = 1,
+	.enable_eager_message = 1,
 	.use_device_rdma = 0,
 	.use_zcpy_rx = 1,
 	.zcpy_rx_seed = 0,
@@ -96,6 +97,7 @@ void rxr_env_param_get(void)
 
 	fi_param_get_int(&rxr_prov, "tx_queue_size", &rxr_env.tx_queue_size);
 	fi_param_get_int(&rxr_prov, "enable_shm_transfer", &rxr_env.enable_shm_transfer);
+	fi_param_get_int(&rxr_prov, "enable_eager_message", &rxr_env.enable_eager_message);
 	fi_param_get_int(&rxr_prov, "use_device_rdma", &rxr_env.use_device_rdma);
 	fi_param_get_int(&rxr_prov, "use_zcpy_rx", &rxr_env.use_zcpy_rx);
 	fi_param_get_int(&rxr_prov, "zcpy_rx_seed", &rxr_env.zcpy_rx_seed);
@@ -155,6 +157,8 @@ void rxr_env_define()
 			"Defines the maximum number of unacknowledged sends with the NIC.");
 	fi_param_define(&rxr_prov, "enable_shm_transfer", FI_PARAM_INT,
 			"Enable using SHM provider to perform TX operations between processes on the same system. (Default: 1)");
+	fi_param_define(&rxr_prov, "enable_eager_message", FI_PARAM_INT,
+			"Enable eager message protocol (Default: 1).");
 	fi_param_define(&rxr_prov, "use_device_rdma", FI_PARAM_INT,
 			"whether to use device's RDMA functionality for one-sided and two-sided transfer.");
 	fi_param_define(&rxr_prov, "use_zcpy_rx", FI_PARAM_INT,

--- a/prov/efa/src/rxr/rxr_env.h
+++ b/prov/efa/src/rxr/rxr_env.h
@@ -41,6 +41,7 @@ struct rxr_env {
 	int use_zcpy_rx;
 	int zcpy_rx_seed;
 	int enable_shm_transfer;
+	int enable_eager_message;
 	int shm_av_size;
 	int shm_max_medium_size;
 	int recvwin_size;

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -88,7 +88,7 @@ int rxr_msg_select_rtm_for_hmem(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_e
 
 	readbase_rtm = rxr_pkt_type_readbase_rtm(peer, tx_entry->op, tx_entry->fi_flags);
 
-	return (tx_entry->total_len <= eager_rtm_max_msg_size) ? eager_rtm : readbase_rtm;
+	return (rxr_env.enable_eager_message && tx_entry->total_len <= eager_rtm_max_msg_size) ? eager_rtm : readbase_rtm;
 }
 
 /**
@@ -172,7 +172,7 @@ int rxr_msg_select_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry, int
 
 	eager_rtm_max_data_size = rxr_tx_entry_max_req_data_capacity(rxr_ep, tx_entry, eager_rtm);
 
-	if (tx_entry->total_len <= eager_rtm_max_data_size)
+	if (rxr_env.enable_eager_message && tx_entry->total_len <= eager_rtm_max_data_size)
 		return eager_rtm;
 
 	if (tx_entry->total_len <= rxr_env.efa_max_medium_msg_size)

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -447,7 +447,7 @@ ssize_t rxr_rma_post_write(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry)
 	}
 
 	/* Inter instance */
-	if (tx_entry->total_len <= max_eager_rtw_data_size) {
+	if (rxr_env.enable_eager_message && tx_entry->total_len <= max_eager_rtw_data_size) {
 		ctrl_type = delivery_complete_requested ?
 			RXR_DC_EAGER_RTW_PKT : RXR_EAGER_RTW_PKT;
 		return rxr_pkt_post_req(ep, tx_entry, ctrl_type, 0, 0);


### PR DESCRIPTION
Currently, there is no way to disable eager message
protocol when message size is < eager_rtm_max_data_size.

This pathc introduces rxr_env.enable_eager_message, which
defines whether eager message protocol is
enabled. It has a default value as 1 and can be
overriden by specifying the FI_EFA_ENABLE_EAGER_MESSAGE
environment variable.

Signed-off-by: Shi Jin <sjina@amazon.com>