### PR TITLE
prov/efa: remove redundent call to efa_mr_hmem_setup()

### DIFF
--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -374,10 +374,6 @@ static int efa_mr_cache_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	efa_mr = (struct efa_mr *)entry->data;
 	efa_mr->entry = entry;
 
-	ret = efa_mr_hmem_setup(efa_mr, attr);
-	if (ret)
-		return ret;
-
 	*mr_fid = &efa_mr->mr_fid;
 	return 0;
 }


### PR DESCRIPTION
This patch removed the call to efa_mr_hmem_setup() in
efa_mr_cache_regattr() because efa_mr_cache_regattr() already
called the function indirectly when it called ofi_mr_cache_search()

Signed-off-by: Wei Zhang <wzam@amazon.com>