### PR TITLE
prov/efa: Initialize attr in efa_mr_cache_entry_reg.

### DIFF
--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -256,7 +256,7 @@ int efa_mr_cache_entry_reg(struct ofi_mr_cache *cache,
 	 * Issue: https://github.com/ofiwg/libfabric/issues/5677
 	 */
 	uint64_t access = FI_SEND | FI_RECV | FI_REMOTE_READ | FI_REMOTE_WRITE;
-	struct fi_mr_attr attr;
+	struct fi_mr_attr attr = {0};
 	struct efa_mr *efa_mr = (struct efa_mr *)entry->data;
 
 	efa_mr->domain = container_of(cache->domain, struct efa_domain,


### PR DESCRIPTION
The local variable attr is not initialized to {0},
which could cause attr.device has unexpected value
and make hmem_ops have wrong device input.

Signed-off-by: Shi Jin <sjina@amazon.com>