### PR TITLE
prov/efa: add support for synapseai hmem iface

### DIFF
--- a/prov/efa/configure.m4
+++ b/prov/efa/configure.m4
@@ -100,6 +100,17 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 		[$have_ibv_is_fork_initialized],
 		[Define to 1 if libibverbs has ibv_is_fork_initialized])
 
+	dnl Check for ibv_reg_dmabuf_mr() in libibverbs if built with synapseai support.
+	AS_IF([test $efa_happy -eq 1 && test $have_synapseai -eq 1],[
+		AC_CHECK_DECL([ibv_reg_dmabuf_mr],
+		[],
+		[AC_MSG_ERROR(
+			[ibv_reg_dmabuf_mr is required by synapseai but not available 
+			 in the current rdma-core library. Please build libfabric with
+			 rdma-core >= v34.0])],
+		[[#include <infiniband/verbs.h>]])
+		])
+
 	AS_IF([test "$enable_efa" = "no"], [efa_happy=0])
 
 	AS_IF([test $ac_cv_sizeof_void_p -eq 4],

--- a/prov/efa/src/efa_ep.c
+++ b/prov/efa/src/efa_ep.c
@@ -709,6 +709,9 @@ int efa_ep_open(struct fid_domain *domain_fid, struct fi_info *user_info,
 	} else if (ep->domain->hmem_support_status[FI_HMEM_NEURON].initialized) {
 		/* Neuron requires p2p and supports no other modes. */
 		ep->hmem_p2p_opt = FI_HMEM_P2P_REQUIRED;
+	} else if (ep->domain->hmem_support_status[FI_HMEM_SYNAPSEAI].initialized) {
+		/* SynapseAI requires p2p and supports no other modes. */
+		ep->hmem_p2p_opt = FI_HMEM_P2P_REQUIRED;
 	} else {
 		/* no hmem devices, disable p2p */
 		ep->hmem_p2p_opt = FI_HMEM_P2P_DISABLED;

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -226,7 +226,7 @@ static int efa_mr_hmem_setup(struct efa_mr *efa_mr,
 		efa_mr->peer.iface = FI_HMEM_SYSTEM;
 	}
 
-	/* efa_mr->peer.device is an union. Setting reserved to 0 cleared everything in it (cuda, neuron etc) */
+	/* efa_mr->peer.device is an union. Setting reserved to 0 cleared everything in it (cuda, neuron, synapseai etc) */
 	efa_mr->peer.device.reserved = 0;
 	if (efa_mr->peer.iface == FI_HMEM_CUDA) {
 		err = cuda_dev_register((struct fi_mr_attr *)attr, &efa_mr->peer.device.cuda);
@@ -238,6 +238,8 @@ static int efa_mr_hmem_setup(struct efa_mr *efa_mr,
 		}
 	} else if (attr->iface == FI_HMEM_NEURON) {
 		efa_mr->peer.device.neuron = attr->device.neuron;
+	} else if (attr->iface == FI_HMEM_SYNAPSEAI) {
+		efa_mr->peer.device.synapseai = attr->device.synapseai;
 	}
 
 	return FI_SUCCESS;
@@ -278,6 +280,8 @@ int efa_mr_cache_entry_reg(struct ofi_mr_cache *cache,
 		attr.device.cuda = entry->info.device;
 	else if (attr.iface == FI_HMEM_NEURON)
 		attr.device.neuron = entry->info.device;
+	else if (attr.iface == FI_HMEM_SYNAPSEAI)
+		attr.device.synapseai = entry->info.device;
 
 	ret = efa_mr_reg_impl(efa_mr, 0, (void *)&attr);
 	return ret;
@@ -346,7 +350,7 @@ static int efa_mr_cache_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	struct ofi_mr_info info;
 	int ret;
 
-	if (attr->iface == FI_HMEM_NEURON)
+	if (attr->iface == FI_HMEM_NEURON || attr->iface == FI_HMEM_SYNAPSEAI)
 		flags |= OFI_MR_NOCACHE;
 
 	if (flags & OFI_MR_NOCACHE) {
@@ -482,6 +486,54 @@ struct fi_ops efa_mr_ops = {
 	.ops_open = fi_no_ops_open,
 };
 
+#if HAVE_SYNAPSEAI
+/**
+ * @brief Register a memory buffer with rdma-core api.
+ * 
+ * @param efa_mr the ptr to the efa_mr object
+ * @param mr_attr the ptr to the fi_mr_attr object
+ * @param access the desired memory protection attributes
+ * @return struct ibv_mr* the ptr to the registered MR
+ */
+static struct ibv_mr *efa_mr_reg_ibv_mr(struct efa_mr *efa_mr, struct fi_mr_attr *mr_attr, int access)
+{
+	int dmabuf_fd;
+	int ret;
+	if (efa_mr_is_synapseai(efa_mr)) {
+		ret = synapseai_get_dmabuf_fd((uint64_t) mr_attr->mr_iov->iov_base,
+						(uint64_t) mr_attr->mr_iov->iov_len,
+						&dmabuf_fd);
+		if (ret != FI_SUCCESS) {
+			EFA_WARN(FI_LOG_MR, "Unable to get dmabuf fd for Gaudi device buffer \n");
+			return NULL;
+		}
+		return ibv_reg_dmabuf_mr(efa_mr->domain->ibv_pd, 0,
+					mr_attr->mr_iov->iov_len,
+					(uint64_t)mr_attr->mr_iov->iov_base,
+					dmabuf_fd, access);
+	} else {
+		return ibv_reg_mr(efa_mr->domain->ibv_pd,
+				(void *)mr_attr->mr_iov->iov_base,
+				mr_attr->mr_iov->iov_len, access);
+	}
+}
+#else
+/**
+ * @brief Register a memory buffer with rdma-core api.
+ * 
+ * @param efa_mr the ptr to the efa_mr object
+ * @param mr_attr the ptr to the fi_mr_attr object
+ * @param access the desired memory protection attributes
+ * @return struct ibv_mr* the ptr to the registered MR
+ */
+static struct ibv_mr *efa_mr_reg_ibv_mr(struct efa_mr *efa_mr, struct fi_mr_attr *mr_attr, int access)
+{
+	return ibv_reg_mr(efa_mr->domain->ibv_pd,
+			(void *)mr_attr->mr_iov->iov_base,
+			mr_attr->mr_iov->iov_len, access);
+}
+#endif /* HAVE_SYNAPSEAI */
+
 /*
  * Set core_access to FI_SEND | FI_RECV if not already set,
  * set the fi_ibv_access modes and do real registration (ibv_mr_reg)
@@ -516,9 +568,7 @@ static int efa_mr_reg_impl(struct efa_mr *efa_mr, uint64_t flags, void *attr)
 	if (efa_mr->domain->cache)
 		ofi_mr_cache_flush(efa_mr->domain->cache, false);
 
-	efa_mr->ibv_mr = ibv_reg_mr(efa_mr->domain->ibv_pd, 
-				    (void *)mr_attr->mr_iov->iov_base,
-				    mr_attr->mr_iov->iov_len, fi_ibv_access);
+	efa_mr->ibv_mr = efa_mr_reg_ibv_mr(efa_mr, mr_attr, fi_ibv_access);
 	if (!efa_mr->ibv_mr) {
 		EFA_WARN(FI_LOG_MR, "Unable to register MR: %s\n",
 				fi_strerror(-errno));

--- a/prov/efa/src/efa_mr.h
+++ b/prov/efa/src/efa_mr.h
@@ -47,6 +47,7 @@ struct efa_mr_peer {
 		 */
 		uint64_t        cuda;
 		int             neuron;
+		int             synapseai;
 	} device;
 };
 
@@ -82,7 +83,8 @@ int efa_mr_reg_shm(struct fid_domain *domain_fid, struct iovec *iov,
 static inline bool efa_mr_is_hmem(struct efa_mr *efa_mr)
 {
 	return efa_mr ? (efa_mr->peer.iface == FI_HMEM_CUDA ||
-			 efa_mr->peer.iface == FI_HMEM_NEURON): false;
+			 efa_mr->peer.iface == FI_HMEM_NEURON ||
+			 efa_mr->peer.iface == FI_HMEM_SYNAPSEAI): false;
 }
 
 static inline bool efa_mr_is_cuda(struct efa_mr *efa_mr)
@@ -93,6 +95,11 @@ static inline bool efa_mr_is_cuda(struct efa_mr *efa_mr)
 static inline bool efa_mr_is_neuron(struct efa_mr *efa_mr)
 {
 	return efa_mr ? (efa_mr->peer.iface == FI_HMEM_NEURON) : false;
+}
+
+static inline bool efa_mr_is_synapseai(struct efa_mr *efa_mr)
+{
+	return efa_mr ? (efa_mr->peer.iface == FI_HMEM_SYNAPSEAI) : false;
 }
 
 #endif

--- a/prov/efa/src/efa_prov_info.c
+++ b/prov/efa/src/efa_prov_info.c
@@ -447,12 +447,13 @@ err_free:
 	return ret;
 }
 
-#if HAVE_CUDA || HAVE_NEURON
+#if HAVE_CUDA || HAVE_NEURON || HAVE_SYNAPSEAI
 void efa_prov_info_set_hmem_flags(struct fi_info *prov_info)
 {
 	if (prov_info->ep_attr->type == FI_EP_RDM &&
 	    (ofi_hmem_is_initialized(FI_HMEM_CUDA) ||
-	     ofi_hmem_is_initialized(FI_HMEM_NEURON))) {
+	     ofi_hmem_is_initialized(FI_HMEM_NEURON) ||
+	     ofi_hmem_is_initialized(FI_HMEM_SYNAPSEAI))) {
 		prov_info->caps			|= FI_HMEM;
 		prov_info->tx_attr->caps		|= FI_HMEM;
 		prov_info->rx_attr->caps		|= FI_HMEM;

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -899,8 +899,8 @@ void rxr_ep_set_extra_info(struct rxr_ep *ep)
 }
 
 /*
- * Set the efa_domain hmem_support_status state based on what CUDA/Neuron capabilities
- * are available. Return whether hmem is supported or not.
+ * Set the efa_domain hmem_support_status state based on what device
+ * capabilities are available. Return whether hmem is supported or not.
  *
  * @param[in]	efa_domain efa domain
  * @return 	1 if we have any devices that support hmem, 0 if not, negative
@@ -930,6 +930,13 @@ static int efa_ep_hmem_check(struct efa_domain *efa_domain)
 	else
 		FI_INFO(&rxr_prov, FI_LOG_EP_CTRL,
 			"AWS Neuron peer to peer support is not available.\n");
+
+	if (efa_domain->hmem_support_status[FI_HMEM_SYNAPSEAI].initialized &&
+	    efa_domain->hmem_support_status[FI_HMEM_SYNAPSEAI].p2p_supported)
+		have_hmem = 1;
+	else
+		FI_INFO(&rxr_prov, FI_LOG_EP_CTRL,
+			"AWS SynapseAI peer to peer support is not available, but FI_HMEM was requested.\n");
 
 	if (!have_hmem) {
 		FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,


### PR DESCRIPTION
Use long read for msg and rma operations, regardless of what is
specified by the user for protocol switch over points.
There is no memcpy from host to device for synapseai inside
libfabric.

Signed-off-by: Shi Jin <sjina@amazon.com>

Test info: 
- Run hccl_demo with allreduce, broadcast, reduce
- Run fabtests between synapseai buffer on two dl1 instances.