### PR TITLE
prov/rxm, util, verbs, efa: add iface initialization checks to MR registration

### DIFF
--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -360,6 +360,12 @@ static int efa_mr_cache_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 		return -FI_EINVAL;
 	}
 
+	if (!ofi_hmem_is_initialized(attr->iface)) {
+		EFA_WARN(FI_LOG_MR,
+			 "Cannot register memory for uninitialized iface\n");
+		return -FI_ENOSYS;
+	}
+
 	domain = container_of(fid, struct efa_domain,
 			      util_domain.domain_fid.fid);
 
@@ -618,6 +624,12 @@ static int efa_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 		EFA_WARN(FI_LOG_MR, "iov count > %d not supported\n",
 			 EFA_MR_IOV_LIMIT);
 		return -FI_EINVAL;
+	}
+
+	if (!ofi_hmem_is_initialized(attr->iface)) {
+		EFA_WARN(FI_LOG_MR,
+			 "Cannot register memory for uninitialized iface\n");
+		return -FI_ENOSYS;
 	}
 
 	domain_fid = container_of(fid, struct fid_domain, fid);

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -420,6 +420,12 @@ static int rxm_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	rxm_domain = container_of(fid, struct rxm_domain,
 				  util_domain.domain_fid.fid);
 
+	if (!ofi_hmem_is_initialized(attr->iface)) {
+		FI_WARN(&rxm_prov, FI_LOG_MR,
+			"Cannot register memory for uninitialized iface\n");
+		return -FI_ENOSYS;
+	}
+
 	rxm_mr = calloc(1, sizeof(*rxm_mr));
 	if (!rxm_mr)
 		return -FI_ENOMEM;

--- a/prov/util/src/util_mr_map.c
+++ b/prov/util/src/util_mr_map.c
@@ -260,6 +260,13 @@ int ofi_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 		return -FI_EINVAL;
 
 	domain = container_of(fid, struct util_domain, domain_fid.fid);
+
+	if (!ofi_hmem_is_initialized(attr->iface)) {
+		FI_WARN(domain->mr_map.prov, FI_LOG_MR,
+			"Cannot register memory for uninitialized iface\n");
+		return -FI_ENOSYS;
+	}
+
 	mr = calloc(1, sizeof(*mr));
 	if (!mr)
 		return -FI_ENOMEM;

--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -120,6 +120,11 @@ int vrb_mr_reg_common(struct vrb_mem_desc *md, int vrb_access, const void *buf,
 		      size_t len, void *context, enum fi_hmem_iface iface,
 		      uint64_t device)
 {
+	if (!ofi_hmem_is_initialized(iface)) {
+		FI_WARN(&vrb_prov, FI_LOG_MR,
+			"Cannot register memory for uninitialized iface\n");
+		return -FI_ENOSYS;
+	}
 	/* ops should be set in special functions */
 	md->mr_fid.fid.fclass = FI_CLASS_MR;
 	md->mr_fid.fid.context = context;


### PR DESCRIPTION
Providers should fail MR registration for ifaces that are not initialized

Fixes #7977 

Signed-off-by: Alexia Ingerson <alexia.ingerson@intel.com>