### PR TITLE
core,efa: set CU_POINTER_ATTRIBUTE_SYNC_MEMOPS pointer attribute

### DIFF
--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -168,6 +168,7 @@ int cuda_gdrcopy_hmem_init(void);
 int cuda_gdrcopy_hmem_cleanup(void);
 int cuda_gdrcopy_dev_register(struct fi_mr_attr *mr_attr, uint64_t *handle);
 int cuda_gdrcopy_dev_unregister(uint64_t handle);
+int cuda_set_sync_memops(void *ptr);
 
 #define ZE_MAX_DEVICES 8
 int ze_hmem_copy(uint64_t device, void *dst, const void *src, size_t size);

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -558,6 +558,13 @@ static int efa_mr_reg_impl(struct efa_mr *efa_mr, uint64_t flags, void *attr)
 			shm_flags |= FI_HMEM_DEVICE_ONLY;
 		}
 
+		if (mr_attr->iface == FI_HMEM_CUDA) {
+			ret = cuda_set_sync_memops(mr_attr->mr_iov->iov_base);
+			if (ret) {
+				EFA_WARN(FI_LOG_MR, "unable to set memops for cuda ptr\n");
+				return ret;
+			}
+		}
 		ret = fi_mr_regattr(efa_mr->domain->shm_domain, attr,
 				    shm_flags, &efa_mr->shm_mr);
 		mr_attr->access = original_access;


### PR DESCRIPTION
This PR introduced an utility function to set CU_POINTER_ATTRIBUTE_SYNC_MEMOPS, then let EFA to use the function to set