### PR TITLE
prov/efa: fix a bug in setting info->dest_addr and add a test

### DIFF
--- a/fabtests/pytest/efa/efa_common.py
+++ b/fabtests/pytest/efa/efa_common.py
@@ -1,4 +1,4 @@
-
+import subprocess
 
 def efa_run_client_server_test(cmdline_args, executable, iteration_type,
                                completion_type, memory_type, message_size,
@@ -20,7 +20,6 @@ def efa_run_client_server_test(cmdline_args, executable, iteration_type,
     test.run()
 
 def efa_retrieve_hw_counter_value(hostname, hw_counter_name):
-    import subprocess
     """
     retrieve the value of EFA's hardware counter
     hostname: a host that has efa
@@ -42,7 +41,6 @@ def efa_retrieve_hw_counter_value(hostname, hw_counter_name):
     return sumvalue
 
 def has_gdrcopy(hostname):
-    import subprocess
     """
     determine whether a host has gdrcopy installed
     hostname: a host
@@ -51,3 +49,19 @@ def has_gdrcopy(hostname):
     command = "ssh {} /usr/sbin/lsmod | grep gdrdrv".format(hostname)
     process = subprocess.run(command, shell=True, check=False, stdout=subprocess.PIPE)
     return process.returncode == 0
+
+def efa_retrieve_gid(hostname):
+    """
+    return the GID of efa device on a host
+    hostname: a host
+    return: a string if the host has efa device,
+            None otherwise
+    """
+    command = "ssh {} ibv_devinfo  -v | grep GID | awk '{{print $NF}}' | head -n 1".format(hostname)
+    try:
+        process = subprocess.run(command, shell=True, check=True, stdout=subprocess.PIPE)
+    except subprocess.CalledProcessError:
+        # this can happen on instance without EFA device
+        return None
+
+    return process.stdout.decode("utf-8").strip()

--- a/fabtests/pytest/efa/test_efa_info.py
+++ b/fabtests/pytest/efa/test_efa_info.py
@@ -1,7 +1,16 @@
 import pytest
+from common import UnitTest
+from efa_common import efa_retrieve_gid
 
 @pytest.mark.unit
 def test_efa_info(cmdline_args):
-    from common import UnitTest
     test = UnitTest(cmdline_args, "fi_efa_info_test")
+    test.run()
+
+@pytest.mark.unit
+def test_comm_getinfo(cmdline_args):
+    gid = efa_retrieve_gid(cmdline_args.server_id)
+
+    # use GID as source address and dest address
+    test = UnitTest(cmdline_args, f"fi_getinfo_test -s {gid} {gid}")
     test.run()

--- a/fabtests/pytest/efa/test_from_default.py
+++ b/fabtests/pytest/efa/test_from_default.py
@@ -2,7 +2,6 @@ from default.test_cntr import test_cntr
 from default.test_cq import test_cq
 from default.test_dom import test_dom
 from default.test_eq import test_eq
-from default.test_getinfo import test_getinfo
 from default.test_mr import test_mr
 from default.test_recv_cancel import test_recv_cancel
 from default.test_shared_ctx import test_shared_ctx

--- a/prov/efa/src/efa_user_info.c
+++ b/prov/efa/src/efa_user_info.c
@@ -452,7 +452,7 @@ int efa_user_info_get_rdm(uint32_t version, const char *node,
 			goto free_info;
 		}
 
-		ret = efa_user_info_set_dest_addr(node, service, flags, hints, *info);
+		ret = efa_user_info_set_dest_addr(node, service, flags, hints, dupinfo);
 		if (ret)
 			goto free_info;
 


### PR DESCRIPTION
This patch fixed a bug in setting `info->dest_addr` and added a test for the case.