### PR TITLE
include/fi_ext: change the peer srx fid to an ep_fid

### DIFF
--- a/include/rdma/fi_ext.h
+++ b/include/rdma/fi_ext.h
@@ -38,6 +38,7 @@
 #include <stdbool.h>
 #include <rdma/fabric.h>
 #include <rdma/fi_eq.h>
+#include <rdma/fi_endpoint.h>
 #include <rdma/providers/fi_prov.h>
 #include <rdma/providers/fi_log.h>
 
@@ -192,7 +193,7 @@ struct fi_ops_srx_peer {
 };
 
 struct fid_peer_srx {
-	struct fid fid;
+	struct fid_ep ep_fid;
 	struct fi_ops_srx_owner *owner_ops;
 	struct fi_ops_srx_peer *peer_ops;
 };

--- a/man/fi_peer.3.md
+++ b/man/fi_peer.3.md
@@ -235,7 +235,7 @@ struct fi_ops_srx_peer {
 };
 
 struct fid_peer_srx {
-    struct fid fid;
+    struct fid_ep ep_fid;
     struct fi_ops_srx_owner *owner_ops;
     struct fi_ops_srx_peer *peer_ops;
 };


### PR DESCRIPTION
This means the ep_fid can be can be passed into the fi_recv APIs in order to post recv messages directly to the SRX.

Signed-off-by: Alexia Ingerson <alexia.ingerson@intel.com>