### PR TITLE
contrib/intel/jenkins: Add functional summary stage to CI

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -56,11 +56,11 @@ pipeline {
                     check_target()
                 }
                 withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
-                  sh """
-                    mkdir ${env.WORKSPACE}/py_scripts
-                    git clone ${env.UPSTREAM} ${env.WORKSPACE}/py_scripts
-                    ${env.SKIP_PATH}/skip.sh ${env.WORKSPACE} ${TARGET}
-                  """
+                  	sh """
+                  		mkdir ${env.WORKSPACE}/py_scripts
+                    	git clone ${env.UPSTREAM} ${env.WORKSPACE}/py_scripts
+                    	${env.SKIP_PATH}/skip.sh ${env.WORKSPACE} ${TARGET}
+                  	"""
                 }
                 script {
                     DO_RUN=skip()

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -427,6 +427,19 @@ pipeline {
                 }
             }
         }
+				stage ('Summary') {
+						when { equals expected: 1, actual: DO_RUN }
+						steps {
+								withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
+										sh """
+												env
+												(
+														python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/summary.py --summary_item=all
+												)
+										"""
+								}
+						}
+				}
     }
 
     post {

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
     }
 
     stages {
-        stage ('opt-out') {
+				stage ('opt-out') {
             steps {
                 script {
                     check_target()
@@ -71,43 +71,44 @@ pipeline {
             when { equals expected: 1, actual: DO_RUN }
             steps {
                 withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
-                  sh """
-		    env(
-                    echo "-----------------------------------------------------"
-                    echo "Copy build dirs."
-                    python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=builddir
-                    echo "Copy build dirs completed."
-                    echo "-----------------------------------------------------"
+										sh """
+												env
+												(
+														echo "-----------------------------------------------------"
+														echo "Copy build dirs."
+														python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=builddir
+														echo "Copy build dirs completed."
+														echo "-----------------------------------------------------"
 
-		    echo "-----------------------------------------------------"
-                    echo "Copy log dirs."
-                    python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=logdir
-                    echo "Copy log dirs completed."
-                    echo "-----------------------------------------------------"
+														echo "-----------------------------------------------------"
+														echo "Copy log dirs."
+														python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=logdir
+														echo "Copy log dirs completed."
+														echo "-----------------------------------------------------" 
 
-                    echo "-----------------------------------------------------"
-                    echo "Building libfabric reg."
-                    python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=libfabric
-                    echo "-----------------------------------------------------"
-                    echo "Building libfabric dbg."
-                    python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=libfabric --ofi_build_mode=dbg
-                    echo "-----------------------------------------------------"
-                    echo "Building libfabric dl."
-                    python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=libfabric --ofi_build_mode=dl
-                    echo "Libfabric builds completed."
+														echo "-----------------------------------------------------"
+														echo "Building libfabric reg."
+														python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=libfabric
+														echo "-----------------------------------------------------"
+														echo "Building libfabric dbg."
+														python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=libfabric --ofi_build_mode=dbg
+														echo "-----------------------------------------------------"
+														echo "Building libfabric dl."
+														python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=libfabric --ofi_build_mode=dl
+														echo "Libfabric builds completed."
 
-                    echo "-----------------------------------------------------"
-                    echo "Building fabtests reg."
-                    python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=fabtests
-                    echo "-----------------------------------------------------"
-                    echo "Building fabtests dbg."
-                    python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=fabtests --ofi_build_mode=dbg
-                    echo "-----------------------------------------------------"
-                    echo "Building fabtests dl."
-                    python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=fabtests --ofi_build_mode=dl
-                    echo 'Fabtests builds completed.'
-		    )
-                  """
+														echo "-----------------------------------------------------"
+														echo "Building fabtests reg."
+														python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=fabtests
+														echo "-----------------------------------------------------"
+														echo "Building fabtests dbg."
+														python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=fabtests --ofi_build_mode=dbg
+														echo "-----------------------------------------------------"
+														echo "Building fabtests dl."
+														python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=fabtests --ofi_build_mode=dl
+														echo 'Fabtests builds completed.'
+												)
+										"""
                 }
             }
         }
@@ -120,21 +121,21 @@ pipeline {
                     steps {
                         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
                         {
-                          sh """
-                            env
-                            (
-                                cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=verbs --util=rxm --test=IMB --imb_grp=1
-                                echo "IMB verbs-rxm Group 1 completed."
-                                python3.7 runtests.py --prov=verbs --util=rxm --test=IMB --imb_grp=2
-                                echo "IMB verbs-rxm Group 2 completed."
-                                python3.7 runtests.py --prov=verbs --util=rxm --test=IMB --imb_grp=3
-                                echo "IMB verbs-rxm Group 3 completed."
-                                python3.7 runtests.py --prov=verbs --util=rxm --test=osu
-                                echo "OSU verbs-rxm completed."
-                                echo "MPI-verbs-rxm completed."
-                            )
-                          """
+														sh """
+																env
+																(
+																		cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+																		python3.7 runtests.py --prov=verbs --util=rxm --test=IMB --imb_grp=1
+																		echo "IMB verbs-rxm Group 1 completed."
+																		python3.7 runtests.py --prov=verbs --util=rxm --test=IMB --imb_grp=2
+																		echo "IMB verbs-rxm Group 2 completed."
+																		python3.7 runtests.py --prov=verbs --util=rxm --test=IMB --imb_grp=3
+																		echo "IMB verbs-rxm Group 3 completed."
+																		python3.7 runtests.py --prov=verbs --util=rxm --test=osu
+																		echo "OSU verbs-rxm completed."
+																		echo "MPI-verbs-rxm completed."
+																)
+														"""
                         }
                     }
                 }
@@ -144,14 +145,14 @@ pipeline {
                     steps {
                         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
                         {
-                          sh """
-                            env
-                            (
-                                cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=tcp --util=rxm --test=IMB --imb_grp=2
-                                echo "MPI-tcp-rxm-2 completed."
-                            )
-                          """
+														sh """
+																env
+																(
+																		cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+																		python3.7 runtests.py --prov=tcp --util=rxm --test=IMB --imb_grp=2
+																		echo "MPI-tcp-rxm-2 completed."
+																)
+														"""
                         }
                     }
                 }
@@ -161,16 +162,16 @@ pipeline {
                     steps {
                         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
                         {
-                          sh """
-                            env
-                            (
-                                cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=tcp --test=fabtests
-                                python3.7 runtests.py --prov=tcp --test=fabtests --ofi_build_mode=dbg
-                                python3.7 runtests.py --prov=tcp --test=fabtests --ofi_build_mode=dl
-                                echo "tcp completed."
-                            )
-                          """
+														sh """
+																env
+																(
+																		cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+																		python3.7 runtests.py --prov=tcp --test=fabtests
+																		python3.7 runtests.py --prov=tcp --test=fabtests --ofi_build_mode=dbg
+																		python3.7 runtests.py --prov=tcp --test=fabtests --ofi_build_mode=dl
+																		echo "tcp completed."
+																)
+														"""
                         }
                     }
                 }
@@ -180,16 +181,16 @@ pipeline {
                     steps {
                         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
                         {
-                          sh """
-                            env
-                            (
-                                cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=verbs --util=rxm --test=fabtests
-                                python3.7 runtests.py --prov=verbs --util=rxm --test=fabtests --ofi_build_mode=dbg
-                                python3.7 runtests.py --prov=verbs --util=rxm --test=fabtests --ofi_build_mode=dl
-                                echo "verbs-rxm completed."
-                            )
-                          """
+														sh """
+																env
+																(
+																		cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+																		python3.7 runtests.py --prov=verbs --util=rxm --test=fabtests
+																		python3.7 runtests.py --prov=verbs --util=rxm --test=fabtests --ofi_build_mode=dbg
+																		python3.7 runtests.py --prov=verbs --util=rxm --test=fabtests --ofi_build_mode=dl
+																		echo "verbs-rxm completed."
+																)
+														"""
                         }
                     }
                 }
@@ -199,16 +200,16 @@ pipeline {
                     steps {
                         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
                         {
-                          sh """
-                            env
-                            (
-                                cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=verbs --util=rxd --test=fabtests
-                                python3.7 runtests.py --prov=verbs --util=rxd --test=fabtests --ofi_build_mode=dbg
-                                python3.7 runtests.py --prov=verbs --util=rxd --test=fabtests --ofi_build_mode=dl
-                                echo "verbs-rxd completed."
-                            )
-                          """
+														sh """
+																env
+																(
+																		cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+																		python3.7 runtests.py --prov=verbs --util=rxd --test=fabtests
+																		python3.7 runtests.py --prov=verbs --util=rxd --test=fabtests --ofi_build_mode=dbg
+																		python3.7 runtests.py --prov=verbs --util=rxd --test=fabtests --ofi_build_mode=dl
+																		echo "verbs-rxd completed."
+																)
+														"""
                         }
                     }
                 }
@@ -218,16 +219,16 @@ pipeline {
                     steps {
                         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
                         {
-                          sh """
-                            env
-                            (
-                                cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=udp --test=fabtests
-                                python3.7 runtests.py --prov=udp --test=fabtests --ofi_build_mode=dbg
-                                python3.7 runtests.py --prov=udp --test=fabtests --ofi_build_mode=dl
-                                echo "udp completed."
-                            )
-                          """
+														sh """
+																env
+																(
+																		cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+																		python3.7 runtests.py --prov=udp --test=fabtests
+																		python3.7 runtests.py --prov=udp --test=fabtests --ofi_build_mode=dbg
+																		python3.7 runtests.py --prov=udp --test=fabtests --ofi_build_mode=dl
+																		echo "udp completed."
+																)
+														"""
                         }
                     }
                 }
@@ -237,16 +238,16 @@ pipeline {
                     steps {
                         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
                         {
-                          sh """
-                            env
-                            (
-                                cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=shm --test=fabtests
-                                python3.7 runtests.py --prov=shm --test=fabtests --ofi_build_mode=dbg
-                                python3.7 runtests.py --prov=shm --test=fabtests --ofi_build_mode=dl
-                                echo "shm completed."
-                            )
-                          """
+														sh """
+																env
+																(
+																		cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+																		python3.7 runtests.py --prov=shm --test=fabtests
+																		python3.7 runtests.py --prov=shm --test=fabtests --ofi_build_mode=dbg
+																		python3.7 runtests.py --prov=shm --test=fabtests --ofi_build_mode=dl
+																		echo "shm completed."
+																)
+														"""
                         }
                     }
                 }
@@ -256,16 +257,16 @@ pipeline {
                     steps {
                         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
                         {
-                          sh """
-                            env
-                            (
-                                cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=sockets --test=fabtests
-                                python3.7 runtests.py --prov=sockets --test=fabtests --ofi_build_mode=dbg
-                                python3.7 runtests.py --prov=sockets --test=fabtests --ofi_build_mode=dl
-                                echo "sockets completed."
-                            )
-                          """
+														sh """
+																env
+																(
+																		cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+																		python3.7 runtests.py --prov=sockets --test=fabtests
+																		python3.7 runtests.py --prov=sockets --test=fabtests --ofi_build_mode=dbg
+																		python3.7 runtests.py --prov=sockets --test=fabtests --ofi_build_mode=dl
+																		echo "sockets completed."
+																)
+                          	"""
                         }
                     }
                 }
@@ -275,18 +276,18 @@ pipeline {
                     steps {
                         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
                         {
-                          sh """
-                            env
-                            (
-                                export PSM3_IDENTIFY=1
-                                export FI_LOG_LEVEL=info
-                                cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=psm3 --test=fabtests
-                                python3.7 runtests.py --prov=psm3 --test=fabtests --ofi_build_mode=dbg
-                                python3.7 runtests.py --prov=psm3 --test=fabtests --ofi_build_mode=dl
-                                echo "psm3 completed."
-                            )
-                          """
+														sh """
+																env
+																(
+																		export PSM3_IDENTIFY=1
+																		export FI_LOG_LEVEL=info
+																		cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+																		python3.7 runtests.py --prov=psm3 --test=fabtests
+																		python3.7 runtests.py --prov=psm3 --test=fabtests --ofi_build_mode=dbg
+																		python3.7 runtests.py --prov=psm3 --test=fabtests --ofi_build_mode=dl
+																		echo "psm3 completed."
+																)
+														"""
                         }
                     }
                 }
@@ -296,14 +297,14 @@ pipeline {
                     steps {
                         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
                         {
-                          sh """
-                            env
-                            (
-                                cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=tcp --util=rxm --test=IMB --imb_grp=1
-                                echo "MPI-tcp-rxm-1 completed."
-                            )
-                          """
+														sh """
+																env
+																(
+																		cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+																		python3.7 runtests.py --prov=tcp --util=rxm --test=IMB --imb_grp=1
+																		echo "MPI-tcp-rxm-1 completed."
+																)
+														"""
                         }
                     }
                 }
@@ -313,16 +314,16 @@ pipeline {
                     steps {
                         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
                         {
-                          sh """
-                            env
-                            (
-                                cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=tcp --util=rxm --test=IMB --imb_grp=3
-                                echo "MPI-tcp-rxm-3 completed."
-                                python3.7 runtests.py --prov=tcp --util=rxm --test=osu
-                                echo "OSU verbs-rxm completed."
-                            )
-                          """
+														sh """
+																env
+																(
+																		cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+																		python3.7 runtests.py --prov=tcp --util=rxm --test=IMB --imb_grp=3
+																		echo "MPI-tcp-rxm-3 completed."
+																		python3.7 runtests.py --prov=tcp --util=rxm --test=osu
+																		echo "OSU verbs-rxm completed."
+																)
+														"""
                         }
                     }
                 }
@@ -332,19 +333,19 @@ pipeline {
                     steps {
                         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
                         {
-                          sh """
-                            env
-                            (
-                                cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=verbs --util=rxm --test=mpichtestsuite
-                                echo "verbs-rxm MPICH testsuite completed."
-                                python3.7 runtests.py --prov=tcp --util=rxm --test=mpichtestsuite
-                                echo "tcp-rxm MPICH testsuite completed."
-                                python3.7 runtests.py --prov=sockets --test=mpichtestsuite
-                                echo "sockets MPICH testsuite completed."
-                                echo "MPICH testsuite completed."
-                            )
-                          """
+														sh """
+																env
+																(
+																		cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+																		python3.7 runtests.py --prov=verbs --util=rxm --test=mpichtestsuite
+																		echo "verbs-rxm MPICH testsuite completed."
+																		python3.7 runtests.py --prov=tcp --util=rxm --test=mpichtestsuite
+																		echo "tcp-rxm MPICH testsuite completed."
+																		python3.7 runtests.py --prov=sockets --test=mpichtestsuite
+																		echo "sockets MPICH testsuite completed."
+																		echo "MPICH testsuite completed."
+																)
+														"""
                         }
                     }
                 }
@@ -354,19 +355,19 @@ pipeline {
                     steps {
                         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
                         {
-                          sh """
-                            env
-                            (
-                                cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=tcp --test=shmem
-                                echo "SHMEM tcp completed."
-                                python3.7 runtests.py --prov=verbs --test=shmem
-                                echo "SHMEM verbs completed."
-                                python3.7 runtests.py --prov=sockets --test=shmem
-                                echo "SHMEM sockets completed."
-                                echo "SHMEM completed."
-                            )
-                          """
+														sh """
+																env
+																(
+																		cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+																		python3.7 runtests.py --prov=tcp --test=shmem
+																		echo "SHMEM tcp completed."
+																		python3.7 runtests.py --prov=verbs --test=shmem
+																		echo "SHMEM verbs completed."
+																		python3.7 runtests.py --prov=sockets --test=shmem
+																		echo "SHMEM sockets completed."
+																		echo "SHMEM completed."
+																)
+														"""
                         }
                     }
                 }
@@ -376,17 +377,17 @@ pipeline {
                     steps {
                         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
                         {
-                          sh """
-                            env
-                            (
-                                cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=tcp --util=rxm --test=oneccl
-                                echo "oneCCL tcp-rxm completed."
-                                python3.7 runtests.py --prov=psm3 --test=oneccl
-                                echo "oneCCL psm3 completed."
-                                echo "OneCCL completed."
-                            )
-                          """
+														sh """
+																env
+																(
+																		cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+																		python3.7 runtests.py --prov=tcp --util=rxm --test=oneccl
+																		echo "oneCCL tcp-rxm completed."
+																		python3.7 runtests.py --prov=psm3 --test=oneccl
+																		echo "oneCCL psm3 completed."
+																		echo "OneCCL completed."
+																)
+														"""
                         }
                     }
                 }
@@ -396,14 +397,14 @@ pipeline {
                     steps {
                         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
                         {
-                          sh """
-                            env
-                            (
-                                cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=tcp --test=onecclgpu
-                                echo "oneCCL-GPU completed."
-                            )
-                          """
+														sh """
+																env
+																(
+																		cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+																		python3.7 runtests.py --prov=tcp --test=onecclgpu
+																		echo "oneCCL-GPU completed."
+																)
+														"""
                         }
                     }
                 }
@@ -413,14 +414,14 @@ pipeline {
                     steps {
                         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
                         {
-                          sh """
-                            env
-                            (
-                                cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
-                                python3.7 runtests.py --prov=shm --device='ze'
-                                echo "ze-shm completed."
-                            )
-                          """
+														sh """
+																env
+																(
+																		cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+																		python3.7 runtests.py --prov=shm --device='ze'
+																		echo "ze-shm completed."
+																)
+														"""
                         }
                     }
                 }
@@ -429,25 +430,24 @@ pipeline {
     }
 
     post {
-        cleanup {
-            withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
-                sh "rm -rf '${env.CI_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}/ci_middlewares'"
-                sh "rm -rf '${env.CI_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}/reg'"
-                sh "rm -rf '${env.CI_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}/dbg'"
-                sh "rm -rf '${env.CI_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}/dl'"
-                sh "rm -rf '${env.WORKSPACE}/py_scripts'"
-            }
-        }
-        success {
-            withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
-                dir("${env.WORKSPACE}") {
-                    deleteDir()
-                }
-                dir("${env.WORKSPACE}@tmp") {
-                    deleteDir()
-                }
-            }
-        }
+				always {
+						withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
+								sh "python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/summary.py --summary_item=all"
+						}
+				}
+				cleanup {
+						withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
+								dir ("${env.CI_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}"){
+										deleteDir()
+								}
+								dir("${env.WORKSPACE}") {
+										deleteDir()
+								}
+								dir("${env.WORKSPACE}@tmp") {
+										deleteDir()
+								}
+						}
+				}
     }
 }
 

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -114,7 +114,7 @@ pipeline {
         stage('parallel-tests') {
             when { equals expected: 1, actual: DO_RUN }
             parallel {
-                stage('MPI-verbs-rxm') {
+                stage('MPI_verbs-rxm') {
                     agent {node {label 'mlx5'}}
                     options { skipDefaultCheckout() }
                     steps {
@@ -138,7 +138,7 @@ pipeline {
                         }
                     }
                 }
-                stage('MPI-tcp-rxm-2') {
+                stage('MPI_tcp-rxm-2') {
                     agent {node {label 'cvl'}}
                     options { skipDefaultCheckout() }
                     steps {
@@ -290,7 +290,7 @@ pipeline {
                         }
                     }
                 }
-                stage('MPI-tcp-rxm-1') {
+                stage('MPI_tcp-rxm-1') {
                     agent {node {label 'cvl'}}
                     options { skipDefaultCheckout() }
                     steps {
@@ -307,7 +307,7 @@ pipeline {
                         }
                     }
                 }
-                stage('MPI-tcp-rxm-3') {
+                stage('MPI_tcp-rxm-3') {
                     agent {node {label 'cvl'}}
                     options { skipDefaultCheckout() }
                     steps {

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -4,463 +4,446 @@ def DO_RUN=1
 def TARGET="main"
 
 def check_target() {
-    echo "CHANGE_TARGET = ${env.CHANGE_TARET}"
-    if (changeRequest()) {
-        TARGET = env.CHANGE_TARGET
-    }
+  echo "CHANGE_TARGET = ${env.CHANGE_TARET}"
+  if (changeRequest()) {
+    TARGET = env.CHANGE_TARGET
+  }
 }
 
 def skip() {
-    def file = "${env.WORKSPACE}/commit_id"
-    if (!fileExists(file)) {
-        echo "CI Run has not rebased with ofiwg/libfabric. Please Rebase."
-        return 1
-    }
-
-    def changes = readFile file
-    def changeStrings = new ArrayList<String>()
-
-    for (line in changes.readLines()) {
-        changeStrings.add(line)
-    }
-
-    echo "${changeStrings.toArray()}"
-    if (changeStrings.toArray().every { it =~ /(?:fabtests\/pytests|man|prov\/efa|prov\/opx).*$/ }) {
-        echo "DONT RUN!"
-        return 0
-    }
-
-    if (changeStrings.isEmpty()) {
-        echo "DONT RUN!"
-        return 0
-    }
-
+  def file = "${env.WORKSPACE}/commit_id"
+  if (!fileExists(file)) {
+    echo "CI Run has not rebased with ofiwg/libfabric. Please Rebase."
     return 1
+  }
+
+  def changes = readFile file
+  def changeStrings = new ArrayList<String>()
+
+  for (line in changes.readLines()) {
+    changeStrings.add(line)
+  }
+
+  echo "${changeStrings.toArray()}"
+  if (changeStrings.toArray().every { it =~ /(?:fabtests\/pytests|man|prov\/efa|prov\/opx).*$/ }) {
+    echo "DONT RUN!"
+    return 0
+  }
+
+  if (changeStrings.isEmpty()) {
+    echo "DONT RUN!"
+    return 0
+  }
+
+  return 1
 }
 
-
 pipeline {
-    agent { node { label 'master' } }
-    options {
-        timestamps()
-        timeout(activity: true, time: 1, unit: 'HOURS')
-    }
-    environment {
-        JOB_CADENCE = 'PR'
-    }
+  agent { node { label 'master' } }
+  options {
+      timestamps()
+      timeout(activity: true, time: 1, unit: 'HOURS')
+  }
+  environment {
+      JOB_CADENCE = 'PR'
+  }
 
-    stages {
-				stage ('opt-out') {
+  stages {
+    stage ('opt-out') {
+      steps {
+        script {
+          check_target()
+        }
+        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
+          sh """
+           mkdir ${env.WORKSPACE}/py_scripts
+            git clone ${env.UPSTREAM} ${env.WORKSPACE}/py_scripts
+            ${env.SKIP_PATH}/skip.sh ${env.WORKSPACE} ${TARGET}
+          """
+        }
+        script {
+          DO_RUN=skip()
+        }
+      }
+    }
+    stage ('build') {
+      when { equals expected: 1, actual: DO_RUN }
+      steps {
+        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
+          sh """
+            env
+            (
+              echo "-----------------------------------------------------"
+              echo "Copy build dirs."
+              python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=builddir
+              echo "Copy build dirs completed."
+              echo "-----------------------------------------------------"
+
+              echo "-----------------------------------------------------"
+              echo "Copy log dirs."
+              python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=logdir
+              echo "Copy log dirs completed."
+              echo "-----------------------------------------------------" 
+
+              echo "-----------------------------------------------------"
+              echo "Building libfabric reg."
+              python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=libfabric
+              echo "-----------------------------------------------------"
+              echo "Building libfabric dbg."
+              python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=libfabric --ofi_build_mode=dbg
+              echo "-----------------------------------------------------"
+              echo "Building libfabric dl."
+              python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=libfabric --ofi_build_mode=dl
+              echo "Libfabric builds completed."
+
+              echo "-----------------------------------------------------"
+              echo "Building fabtests reg."
+              python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=fabtests
+              echo "-----------------------------------------------------"
+              echo "Building fabtests dbg."
+              python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=fabtests --ofi_build_mode=dbg
+              echo "-----------------------------------------------------"
+              echo "Building fabtests dl."
+              python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=fabtests --ofi_build_mode=dl
+              echo 'Fabtests builds completed.'
+            )
+          """
+        }
+      }
+    }
+    stage('parallel-tests') {
+        when { equals expected: 1, actual: DO_RUN }
+        parallel {
+          stage('MPI_verbs-rxm') {
+            agent {node {label 'mlx5'}}
+            options { skipDefaultCheckout() }
             steps {
-                script {
-                    check_target()
-                }
-                withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
-                  	sh """
-                  		mkdir ${env.WORKSPACE}/py_scripts
-                    	git clone ${env.UPSTREAM} ${env.WORKSPACE}/py_scripts
-                    	${env.SKIP_PATH}/skip.sh ${env.WORKSPACE} ${TARGET}
-                  	"""
-                }
-                script {
-                    DO_RUN=skip()
-                }
+              withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
+                sh """
+                  env
+                  (
+                    cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                    python3.7 runtests.py --prov=verbs --util=rxm --test=IMB --imb_grp=1
+                    echo "IMB verbs-rxm Group 1 completed."
+                    python3.7 runtests.py --prov=verbs --util=rxm --test=IMB --imb_grp=2
+                    echo "IMB verbs-rxm Group 2 completed."
+                    python3.7 runtests.py --prov=verbs --util=rxm --test=IMB --imb_grp=3
+                    echo "IMB verbs-rxm Group 3 completed."
+                    python3.7 runtests.py --prov=verbs --util=rxm --test=osu
+                    echo "OSU verbs-rxm completed."
+                    echo "MPI-verbs-rxm completed."
+                  )
+                """
+              }
             }
-        }
-        stage ('build') {
-            when { equals expected: 1, actual: DO_RUN }
+          }
+          stage('MPI_tcp-rxm-2') {
+            agent {node {label 'cvl'}}
+            options { skipDefaultCheckout() }
             steps {
-                withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
-										sh """
-												env
-												(
-														echo "-----------------------------------------------------"
-														echo "Copy build dirs."
-														python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=builddir
-														echo "Copy build dirs completed."
-														echo "-----------------------------------------------------"
-
-														echo "-----------------------------------------------------"
-														echo "Copy log dirs."
-														python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=logdir
-														echo "Copy log dirs completed."
-														echo "-----------------------------------------------------" 
-
-														echo "-----------------------------------------------------"
-														echo "Building libfabric reg."
-														python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=libfabric
-														echo "-----------------------------------------------------"
-														echo "Building libfabric dbg."
-														python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=libfabric --ofi_build_mode=dbg
-														echo "-----------------------------------------------------"
-														echo "Building libfabric dl."
-														python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=libfabric --ofi_build_mode=dl
-														echo "Libfabric builds completed."
-
-														echo "-----------------------------------------------------"
-														echo "Building fabtests reg."
-														python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=fabtests
-														echo "-----------------------------------------------------"
-														echo "Building fabtests dbg."
-														python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=fabtests --ofi_build_mode=dbg
-														echo "-----------------------------------------------------"
-														echo "Building fabtests dl."
-														python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=fabtests --ofi_build_mode=dl
-														echo 'Fabtests builds completed.'
-												)
-										"""
-                }
+              withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
+                sh """
+                  env
+                  (
+                    cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                    python3.7 runtests.py --prov=tcp --util=rxm --test=IMB --imb_grp=2
+                    echo "MPI-tcp-rxm-2 completed."
+                  )
+                """
+              }
             }
-        }
-        stage('parallel-tests') {
-            when { equals expected: 1, actual: DO_RUN }
-            parallel {
-                stage('MPI_verbs-rxm') {
-                    agent {node {label 'mlx5'}}
-                    options { skipDefaultCheckout() }
-                    steps {
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
-                        {
-														sh """
-																env
-																(
-																		cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
-																		python3.7 runtests.py --prov=verbs --util=rxm --test=IMB --imb_grp=1
-																		echo "IMB verbs-rxm Group 1 completed."
-																		python3.7 runtests.py --prov=verbs --util=rxm --test=IMB --imb_grp=2
-																		echo "IMB verbs-rxm Group 2 completed."
-																		python3.7 runtests.py --prov=verbs --util=rxm --test=IMB --imb_grp=3
-																		echo "IMB verbs-rxm Group 3 completed."
-																		python3.7 runtests.py --prov=verbs --util=rxm --test=osu
-																		echo "OSU verbs-rxm completed."
-																		echo "MPI-verbs-rxm completed."
-																)
-														"""
-                        }
-                    }
-                }
-                stage('MPI_tcp-rxm-2') {
-                    agent {node {label 'cvl'}}
-                    options { skipDefaultCheckout() }
-                    steps {
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
-                        {
-														sh """
-																env
-																(
-																		cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
-																		python3.7 runtests.py --prov=tcp --util=rxm --test=IMB --imb_grp=2
-																		echo "MPI-tcp-rxm-2 completed."
-																)
-														"""
-                        }
-                    }
-                }
-                stage('tcp') {
-                    agent {node {label 'cvl'}}
-                    options { skipDefaultCheckout() }
-                    steps {
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
-                        {
-														sh """
-																env
-																(
-																		cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
-																		python3.7 runtests.py --prov=tcp --test=fabtests
-																		python3.7 runtests.py --prov=tcp --test=fabtests --ofi_build_mode=dbg
-																		python3.7 runtests.py --prov=tcp --test=fabtests --ofi_build_mode=dl
-																		echo "tcp completed."
-																)
-														"""
-                        }
-                    }
-                }
-                stage('verbs-rxm') {
-                    agent {node {label 'mlx5'}}
-                    options { skipDefaultCheckout() }
-                    steps {
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
-                        {
-														sh """
-																env
-																(
-																		cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
-																		python3.7 runtests.py --prov=verbs --util=rxm --test=fabtests
-																		python3.7 runtests.py --prov=verbs --util=rxm --test=fabtests --ofi_build_mode=dbg
-																		python3.7 runtests.py --prov=verbs --util=rxm --test=fabtests --ofi_build_mode=dl
-																		echo "verbs-rxm completed."
-																)
-														"""
-                        }
-                    }
-                }
-                stage('verbs-rxd') {
-                    agent {node {label 'mlx5 && edr'}}
-                    options { skipDefaultCheckout() }
-                    steps {
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
-                        {
-														sh """
-																env
-																(
-																		cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
-																		python3.7 runtests.py --prov=verbs --util=rxd --test=fabtests
-																		python3.7 runtests.py --prov=verbs --util=rxd --test=fabtests --ofi_build_mode=dbg
-																		python3.7 runtests.py --prov=verbs --util=rxd --test=fabtests --ofi_build_mode=dl
-																		echo "verbs-rxd completed."
-																)
-														"""
-                        }
-                    }
-                }
-                stage('udp') {
-                    agent {node {label 'cvl'}}
-                    options { skipDefaultCheckout() }
-                    steps {
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
-                        {
-														sh """
-																env
-																(
-																		cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
-																		python3.7 runtests.py --prov=udp --test=fabtests
-																		python3.7 runtests.py --prov=udp --test=fabtests --ofi_build_mode=dbg
-																		python3.7 runtests.py --prov=udp --test=fabtests --ofi_build_mode=dl
-																		echo "udp completed."
-																)
-														"""
-                        }
-                    }
-                }
-                stage('shm') {
-                    agent {node {label 'cvl'}}
-                    options { skipDefaultCheckout() }
-                    steps {
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
-                        {
-														sh """
-																env
-																(
-																		cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
-																		python3.7 runtests.py --prov=shm --test=fabtests
-																		python3.7 runtests.py --prov=shm --test=fabtests --ofi_build_mode=dbg
-																		python3.7 runtests.py --prov=shm --test=fabtests --ofi_build_mode=dl
-																		echo "shm completed."
-																)
-														"""
-                        }
-                    }
-                }
-                stage('sockets') {
-                    agent {node {label 'cvl'}}
-                    options { skipDefaultCheckout() }
-                    steps {
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
-                        {
-														sh """
-																env
-																(
-																		cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
-																		python3.7 runtests.py --prov=sockets --test=fabtests
-																		python3.7 runtests.py --prov=sockets --test=fabtests --ofi_build_mode=dbg
-																		python3.7 runtests.py --prov=sockets --test=fabtests --ofi_build_mode=dl
-																		echo "sockets completed."
-																)
-                          	"""
-                        }
-                    }
-                }
-                stage('psm3') {
-                    agent {node {label 'mlx5 && edr'}}
-                    options { skipDefaultCheckout() }
-                    steps {
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
-                        {
-														sh """
-																env
-																(
-																		export PSM3_IDENTIFY=1
-																		export FI_LOG_LEVEL=info
-																		cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
-																		python3.7 runtests.py --prov=psm3 --test=fabtests
-																		python3.7 runtests.py --prov=psm3 --test=fabtests --ofi_build_mode=dbg
-																		python3.7 runtests.py --prov=psm3 --test=fabtests --ofi_build_mode=dl
-																		echo "psm3 completed."
-																)
-														"""
-                        }
-                    }
-                }
-                stage('MPI_tcp-rxm-1') {
-                    agent {node {label 'cvl'}}
-                    options { skipDefaultCheckout() }
-                    steps {
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
-                        {
-														sh """
-																env
-																(
-																		cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
-																		python3.7 runtests.py --prov=tcp --util=rxm --test=IMB --imb_grp=1
-																		echo "MPI-tcp-rxm-1 completed."
-																)
-														"""
-                        }
-                    }
-                }
-                stage('MPI_tcp-rxm-3') {
-                    agent {node {label 'cvl'}}
-                    options { skipDefaultCheckout() }
-                    steps {
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
-                        {
-														sh """
-																env
-																(
-																		cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
-																		python3.7 runtests.py --prov=tcp --util=rxm --test=IMB --imb_grp=3
-																		echo "MPI-tcp-rxm-3 completed."
-																		python3.7 runtests.py --prov=tcp --util=rxm --test=osu
-																		echo "OSU verbs-rxm completed."
-																)
-														"""
-                        }
-                    }
-                }
-                stage('MPICH testsuite') {
-                    agent {node {label 'mlx5'}}
-                    options { skipDefaultCheckout() }
-                    steps {
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
-                        {
-														sh """
-																env
-																(
-																		cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
-																		python3.7 runtests.py --prov=verbs --util=rxm --test=mpichtestsuite
-																		echo "verbs-rxm MPICH testsuite completed."
-																		python3.7 runtests.py --prov=tcp --util=rxm --test=mpichtestsuite
-																		echo "tcp-rxm MPICH testsuite completed."
-																		python3.7 runtests.py --prov=sockets --test=mpichtestsuite
-																		echo "sockets MPICH testsuite completed."
-																		echo "MPICH testsuite completed."
-																)
-														"""
-                        }
-                    }
-                }
-                stage('SHMEM') {
-                    agent {node {label 'mlx5'}}
-                    options { skipDefaultCheckout() }
-                    steps {
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
-                        {
-														sh """
-																env
-																(
-																		cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
-																		python3.7 runtests.py --prov=tcp --test=shmem
-																		echo "SHMEM tcp completed."
-																		python3.7 runtests.py --prov=verbs --test=shmem
-																		echo "SHMEM verbs completed."
-																		python3.7 runtests.py --prov=sockets --test=shmem
-																		echo "SHMEM sockets completed."
-																		echo "SHMEM completed."
-																)
-														"""
-                        }
-                    }
-                }
-                stage('oneCCL') {
-                    agent {node {label 'cvl'}}
-                    options { skipDefaultCheckout() }
-                    steps {
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
-                        {
-														sh """
-																env
-																(
-																		cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
-																		python3.7 runtests.py --prov=tcp --util=rxm --test=oneccl
-																		echo "oneCCL tcp-rxm completed."
-																		python3.7 runtests.py --prov=psm3 --test=oneccl
-																		echo "oneCCL psm3 completed."
-																		echo "OneCCL completed."
-																)
-														"""
-                        }
-                    }
-                }
-                stage('oneCCL-GPU') {
-                    agent {node {label 'ze'}}
-                    options { skipDefaultCheckout() }
-                    steps {
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
-                        {
-														sh """
-																env
-																(
-																		cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
-																		python3.7 runtests.py --prov=tcp --test=onecclgpu
-																		echo "oneCCL-GPU completed."
-																)
-														"""
-                        }
-                    }
-                }
-                stage('ze-shm') {
-                    agent {node {label 'ze'}}
-                    options { skipDefaultCheckout() }
-                    steps {
-                        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
-                        {
-														sh """
-																env
-																(
-																		cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
-																		python3.7 runtests.py --prov=shm --device='ze'
-																		echo "ze-shm completed."
-																)
-														"""
-                        }
-                    }
-                }
+          }
+          stage('tcp') {
+            agent {node {label 'cvl'}}
+            options { skipDefaultCheckout() }
+            steps {
+              withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
+                sh """
+                  env
+                  (
+                    cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                    python3.7 runtests.py --prov=tcp --test=fabtests
+                    python3.7 runtests.py --prov=tcp --test=fabtests --ofi_build_mode=dbg
+                    python3.7 runtests.py --prov=tcp --test=fabtests --ofi_build_mode=dl
+                    echo "tcp completed."
+                  )
+                """
+              }
             }
+          }
+          stage('verbs-rxm') {
+            agent {node {label 'mlx5'}}
+            options { skipDefaultCheckout() }
+            steps {
+              withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
+                sh """
+                  env
+                  (
+                    cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                    python3.7 runtests.py --prov=verbs --util=rxm --test=fabtests
+                    python3.7 runtests.py --prov=verbs --util=rxm --test=fabtests --ofi_build_mode=dbg
+                    python3.7 runtests.py --prov=verbs --util=rxm --test=fabtests --ofi_build_mode=dl
+                    echo "verbs-rxm completed."
+                  )
+                """
+              }
+            }
+          }
+          stage('verbs-rxd') {
+            agent {node {label 'mlx5 && edr'}}
+            options { skipDefaultCheckout() }
+            steps {
+              withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
+                sh """
+                  env
+                  (
+                    cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                    python3.7 runtests.py --prov=verbs --util=rxd --test=fabtests
+                    python3.7 runtests.py --prov=verbs --util=rxd --test=fabtests --ofi_build_mode=dbg
+                    python3.7 runtests.py --prov=verbs --util=rxd --test=fabtests --ofi_build_mode=dl
+                    echo "verbs-rxd completed."
+                  )
+                """
+              }
+            }
+          }
+          stage('udp') {
+            agent {node {label 'cvl'}}
+            options { skipDefaultCheckout() }
+            steps {
+              withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
+                sh """
+                  env
+                  (
+                    cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                    python3.7 runtests.py --prov=udp --test=fabtests
+                    python3.7 runtests.py --prov=udp --test=fabtests --ofi_build_mode=dbg
+                    python3.7 runtests.py --prov=udp --test=fabtests --ofi_build_mode=dl
+                    echo "udp completed."
+                  )
+                """
+              }
+            }
+          }
+          stage('shm') {
+            agent {node {label 'cvl'}}
+            options { skipDefaultCheckout() }
+            steps {
+              withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
+                sh """
+                  env
+                  (
+                    cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                    python3.7 runtests.py --prov=shm --test=fabtests
+                    python3.7 runtests.py --prov=shm --test=fabtests --ofi_build_mode=dbg
+                    python3.7 runtests.py --prov=shm --test=fabtests --ofi_build_mode=dl
+                    echo "shm completed."
+                  )
+                """
+              }
+            }
+          }
+          stage('sockets') {
+            agent {node {label 'cvl'}}
+            options { skipDefaultCheckout() }
+            steps {
+              withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
+                sh """
+                  env
+                  (
+                    cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                    python3.7 runtests.py --prov=sockets --test=fabtests
+                    python3.7 runtests.py --prov=sockets --test=fabtests --ofi_build_mode=dbg
+                    python3.7 runtests.py --prov=sockets --test=fabtests --ofi_build_mode=dl
+                    echo "sockets completed."
+                  )
+                """
+              }
+            }
+          }
+          stage('psm3') {
+          agent {node {label 'mlx5 && edr'}}
+          options { skipDefaultCheckout() }
+          steps {
+            withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
+              sh """
+                env
+                (
+                  export PSM3_IDENTIFY=1
+                  export FI_LOG_LEVEL=info
+                  cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  python3.7 runtests.py --prov=psm3 --test=fabtests
+                  python3.7 runtests.py --prov=psm3 --test=fabtests --ofi_build_mode=dbg
+                  python3.7 runtests.py --prov=psm3 --test=fabtests --ofi_build_mode=dl
+                  echo "psm3 completed."
+                )
+              """
+            }
+          }
         }
-				stage ('Summary') {
-						when { equals expected: 1, actual: DO_RUN }
-						steps {
-								withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
-										sh """
-												env
-												(
-														python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/summary.py --summary_item=all
-												)
-										"""
-								}
-						}
-				}
+        stage('MPI_tcp-rxm-1') {
+          agent {node {label 'cvl'}}
+          options { skipDefaultCheckout() }
+          steps {
+            withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
+              sh """
+                env
+                (
+                  cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  python3.7 runtests.py --prov=tcp --util=rxm --test=IMB --imb_grp=1
+                  echo "MPI-tcp-rxm-1 completed."
+                )
+              """
+            }
+          }
+        }
+        stage('MPI_tcp-rxm-3') {
+          agent {node {label 'cvl'}}
+          options { skipDefaultCheckout() }
+          steps {
+            withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
+              sh """
+                env
+                (
+                  cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  python3.7 runtests.py --prov=tcp --util=rxm --test=IMB --imb_grp=3
+                  echo "MPI-tcp-rxm-3 completed."
+                  python3.7 runtests.py --prov=tcp --util=rxm --test=osu
+                  echo "OSU verbs-rxm completed."
+                )
+              """
+            }
+          }
+        }
+        stage('MPICH testsuite') {
+          agent {node {label 'mlx5'}}
+          options { skipDefaultCheckout() }
+          steps {
+            withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
+              sh """
+                env
+                (
+                  cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  python3.7 runtests.py --prov=verbs --util=rxm --test=mpichtestsuite
+                  echo "verbs-rxm MPICH testsuite completed."
+                  python3.7 runtests.py --prov=tcp --util=rxm --test=mpichtestsuite
+                  echo "tcp-rxm MPICH testsuite completed."
+                  python3.7 runtests.py --prov=sockets --test=mpichtestsuite
+                  echo "sockets MPICH testsuite completed."
+                  echo "MPICH testsuite completed."
+                )
+              """
+            }
+          }
+        }
+        stage('SHMEM') {
+          agent {node {label 'mlx5'}}
+          options { skipDefaultCheckout() }
+          steps {
+            withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
+              sh """
+                env
+                (
+                  cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  python3.7 runtests.py --prov=tcp --test=shmem
+                  echo "SHMEM tcp completed."
+                  python3.7 runtests.py --prov=verbs --test=shmem
+                  echo "SHMEM verbs completed."
+                  python3.7 runtests.py --prov=sockets --test=shmem
+                  echo "SHMEM sockets completed."
+                  echo "SHMEM completed."
+                )
+              """
+            }
+          }
+        }
+        stage('oneCCL') {
+          agent {node {label 'cvl'}}
+          options { skipDefaultCheckout() }
+          steps {
+            withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
+              sh """
+                env
+                (
+                  cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  python3.7 runtests.py --prov=tcp --util=rxm --test=oneccl
+                  echo "oneCCL tcp-rxm completed."
+                  python3.7 runtests.py --prov=psm3 --test=oneccl
+                  echo "oneCCL psm3 completed."
+                  echo "OneCCL completed."
+                )
+              """
+            }
+          }
+        }
+        stage('oneCCL-GPU') {
+          agent {node {label 'ze'}}
+          options { skipDefaultCheckout() }
+          steps {
+            withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
+              sh """
+                env
+                (
+                  cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  python3.7 runtests.py --prov=tcp --test=onecclgpu
+                  echo "oneCCL-GPU completed."
+                )
+              """
+            }
+          }
+        }
+        stage('ze-shm') {
+          agent {node {label 'ze'}}
+          options { skipDefaultCheckout() }
+          steps {
+            withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
+              sh """
+                env
+                (
+                  cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  python3.7 runtests.py --prov=shm --device='ze'
+                  echo "ze-shm completed."
+                )
+              """
+            }
+          }
+        }
+      }
     }
+    stage ('Summary') {
+      when { equals expected: 1, actual: DO_RUN }
+      steps {
+        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
+          sh """
+            env
+            (
+              python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/summary.py --summary_item=all
+            )
+          """
+        }
+      }
+    }
+  }
 
-    post {
-				always {
-						withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
-								sh "python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/summary.py --summary_item=all"
-						}
-				}
-				cleanup {
-						withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
-								dir ("${env.CI_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}"){
-										deleteDir()
-								}
-								dir("${env.WORKSPACE}") {
-										deleteDir()
-								}
-								dir("${env.WORKSPACE}@tmp") {
-										deleteDir()
-								}
-						}
-				}
+  post {
+    always {
+      withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
+        sh "python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/summary.py --summary_item=all"
+      }
     }
+    cleanup {
+      withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
+        dir ("${env.CI_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}"){
+          deleteDir()
+        }
+        dir("${env.WORKSPACE}") {
+          deleteDir()
+        }
+        dir("${env.WORKSPACE}@tmp") {
+          deleteDir()
+        }
+      }
+    }
+  }
 }
 

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -72,10 +72,17 @@ pipeline {
             steps {
                 withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
                   sh """
+		    env(
                     echo "-----------------------------------------------------"
                     echo "Copy build dirs."
                     python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=builddir
                     echo "Copy build dirs completed."
+                    echo "-----------------------------------------------------"
+
+		    echo "-----------------------------------------------------"
+                    echo "Copy log dirs."
+                    python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=logdir
+                    echo "Copy log dirs completed."
                     echo "-----------------------------------------------------"
 
                     echo "-----------------------------------------------------"
@@ -99,7 +106,7 @@ pipeline {
                     echo "Building fabtests dl."
                     python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=fabtests --ofi_build_mode=dl
                     echo 'Fabtests builds completed.'
-
+		    )
                   """
                 }
             }

--- a/contrib/intel/jenkins/build.py
+++ b/contrib/intel/jenkins/build.py
@@ -64,6 +64,10 @@ def copy_build_dir(install_path):
     shutil.copytree(ci_site_config.build_dir,
                     f'{install_path}/ci_middlewares')
 
+def log_dir(install_path):
+    if (os.path.exists(f'{install_path}/log_dir') != True):
+         os.makedirs(f'{install_path}/log_dir')
+
 if __name__ == "__main__":
 #read Jenkins environment variables
     # In Jenkins,  JOB_NAME  = 'ofi_libfabric/master' vs BRANCH_NAME = 'master'
@@ -75,7 +79,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--build_item', help="build libfabric or fabtests",
-                         choices=['libfabric', 'fabtests', 'builddir'])
+                         choices=['libfabric', 'fabtests', 'builddir', 'logdir'])
     parser.add_argument('--ofi_build_mode', help="select buildmode debug or dl", \
                         choices=['dbg', 'dl'])
 
@@ -87,17 +91,19 @@ if __name__ == "__main__":
     else:
         ofi_build_mode = 'reg'
 
-    ci_middlewares_install_path = f'{ci_site_config.install_dir}/{jobname}/{buildno}'
-    install_path = f'{ci_site_config.install_dir}/{jobname}/{buildno}/{ofi_build_mode}'
+    install_path = f'{ci_site_config.install_dir}/{jobname}/{buildno}'
+    libfab_install_path = f'{ci_site_config.install_dir}/{jobname}/{buildno}/{ofi_build_mode}'
 
     p = re.compile('mpi*')
 
     if (build_item == 'libfabric'):
-        build_libfabric(install_path, ofi_build_mode)
+        build_libfabric(libfab_install_path, ofi_build_mode)
 
     elif (build_item == 'fabtests'):
-        build_fabtests(install_path, ofi_build_mode)
+        build_fabtests(libfab_install_path, ofi_build_mode)
 
     elif (build_item == 'builddir'):
-        copy_build_dir(ci_middlewares_install_path)
+        copy_build_dir(install_path)
 
+    elif (build_item == 'logdir'):
+        log_dir(install_path)

--- a/contrib/intel/jenkins/common.py
+++ b/contrib/intel/jenkins/common.py
@@ -10,7 +10,7 @@ def get_node_name(host, interface):
 def run_command(command, logdir=None, test_type=None, ofi_build_mode=None):
     stage_name = os.environ['STAGE_NAME']
     if (test_type and ('tcp-rxm' in stage_name)):
-        filename = f'{logdir}/MPI-tcp-rxm_{test_type}_{ofi_build_mode}'
+        filename = f'{logdir}/MPI_tcp-rxm_{test_type}_{ofi_build_mode}'
     elif (test_type and ofi_build_mode):
         filename = f'{logdir}/{stage_name}_{test_type}_{ofi_build_mode}'
     else:
@@ -21,6 +21,8 @@ def run_command(command, logdir=None, test_type=None, ofi_build_mode=None):
     print(" ".join(command))
     p = subprocess.Popen(command, stdout=subprocess.PIPE, text=True)
     print(p.returncode)
+    if (logdir):
+        f.write(" ".join(command) + '\n')
     while True:
         out = p.stdout.read(1)
         if (logdir):

--- a/contrib/intel/jenkins/common.py
+++ b/contrib/intel/jenkins/common.py
@@ -2,16 +2,24 @@ import collections
 import ci_site_config
 import subprocess
 import sys
+import os
 
 def get_node_name(host, interface):
    return '%s-%s' % (host, interface)
 
-def run_command(command):
+def run_command(command, logdir=None, ofi_build_mode=None):
+    stage_name = os.environ['STAGE_NAME']
+    filename = f'{logdir}/{stage_name}'
+    print("filename: ".format(filename))
+    if (logdir):
+        f = open(filename,'a')
     print(" ".join(command))
     p = subprocess.Popen(command, stdout=subprocess.PIPE, text=True)
     print(p.returncode)
     while True:
         out = p.stdout.read(1)
+        if (logdir):
+            f.write(out)
         if (out == '' and p.poll() != None):
             break
         if (out != ''):
@@ -19,7 +27,11 @@ def run_command(command):
             sys.stdout.flush()
     if (p.returncode != 0):
         print("exiting with " + str(p.poll()))
+        if (logdir):
+            close(f)
         sys.exit(p.returncode)
+    if (logdir):
+        f.close()
 
 
 Prov = collections.namedtuple('Prov', 'core util')

--- a/contrib/intel/jenkins/common.py
+++ b/contrib/intel/jenkins/common.py
@@ -7,9 +7,14 @@ import os
 def get_node_name(host, interface):
    return '%s-%s' % (host, interface)
 
-def run_command(command, logdir=None, ofi_build_mode=None):
+def run_command(command, logdir=None, test_type=None, ofi_build_mode=None):
     stage_name = os.environ['STAGE_NAME']
-    filename = f'{logdir}/{stage_name}'
+    if (test_type and ('tcp-rxm' in stage_name)):
+        filename = f'{logdir}/MPI-tcp-rxm_{test_type}_{ofi_build_mode}'
+    elif (test_type and ofi_build_mode):
+        filename = f'{logdir}/{stage_name}_{test_type}_{ofi_build_mode}'
+    else:
+        filename = f'{logdir}/{stage_name}'
     print("filename: ".format(filename))
     if (logdir):
         f = open(filename,'a')
@@ -28,7 +33,7 @@ def run_command(command, logdir=None, ofi_build_mode=None):
     if (p.returncode != 0):
         print("exiting with " + str(p.poll()))
         if (logdir):
-            close(f)
+            f.close()
         sys.exit(p.returncode)
     if (logdir):
         f.close()

--- a/contrib/intel/jenkins/run.py
+++ b/contrib/intel/jenkins/run.py
@@ -16,23 +16,23 @@ fab = os.environ['FABRIC']#args.fabric
 jbname = os.environ['JOB_NAME']#args.jobname
 bno = os.environ['BUILD_NUMBER']#args.buildno
 
-def fi_info_test(core, hosts, mode, user_env, util):
+def fi_info_test(core, hosts, mode, user_env, run_test, util):
 
     fi_info_test = tests.FiInfoTest(jobname=jbname,buildno=bno,
                                     testname='fi_info', core_prov=core,
                                     fabric=fab, hosts=hosts, ofi_build_mode=mode,
-                                    user_env=user_env, util_prov=util)
+                                    user_env=user_env, run_test=run_test, util_prov=util)
     print('-------------------------------------------------------------------')
     print(f"Running fi_info test for {core}-{util}-{fab}")
     fi_info_test.execute_cmd()
     print('-------------------------------------------------------------------')
 
-def fabtests(core, hosts, mode, user_env, util):
+def fabtests(core, hosts, mode, user_env, run_test, util):
 
     runfabtest = tests.Fabtest(jobname=jbname,buildno=bno,
                                testname='runfabtests', core_prov=core,
                                fabric=fab, hosts=hosts, ofi_build_mode=mode,
-                               user_env=user_env, util_prov=util)
+                               user_env=user_env, run_test=run_test, util_prov=util)
 
     print('-------------------------------------------------------------------')
     if (runfabtest.execute_condn):
@@ -42,12 +42,12 @@ def fabtests(core, hosts, mode, user_env, util):
         print(f"Skipping {core} {runfabtest.testname} as execute condition fails")
     print('-------------------------------------------------------------------')
 
-def shmemtest(core, hosts, mode, user_env, util):
+def shmemtest(core, hosts, mode, user_env, run_test, util):
 
     runshmemtest = tests.ShmemTest(jobname=jbname,buildno=bno,
                                    testname="shmem test", core_prov=core,
                                    fabric=fab, hosts=hosts,
-                                   ofi_build_mode=mode, user_env=user_env, util_prov=util)
+                                   ofi_build_mode=mode, user_env=user_env, run_test=run_test, util_prov=util)
 
     print('-------------------------------------------------------------------')
     if (runshmemtest.execute_condn):
@@ -68,12 +68,12 @@ def shmemtest(core, hosts, mode, user_env, util):
         print(f"Skipping {core} {runshmemtest.testname} as execute condition fails")
     print('-------------------------------------------------------------------')
 
-def ze_fabtests(core, hosts, mode, user_env, util):
+def ze_fabtests(core, hosts, mode, user_env, run_test, util):
     runzefabtests = tests.ZeFabtests(jobname=jbname,buildno=bno,
                                      testname="ze test", core_prov=core,
                                      fabric=fab, hosts=hosts,
                                      ofi_build_mode=mode, user_env=user_env,
-                                     util_prov=util)
+                                     run_test=run_test, util_prov=util)
 
     print('-------------------------------------------------------------------')
     if (runzefabtests.execute_condn):
@@ -83,13 +83,13 @@ def ze_fabtests(core, hosts, mode, user_env, util):
         print(f"Skipping {core} {runzefabtests.testname} as execute condition fails")
     print('-------------------------------------------------------------------')
 
-def intel_mpi_benchmark(core, hosts, mpi, mode, group, user_env, util):
+def intel_mpi_benchmark(core, hosts, mpi, mode, group, user_env, run_test, util):
 
     imb = tests.IMBtests(jobname=jbname, buildno=bno,
                          testname='IntelMPIbenchmark', core_prov=core,
                          fabric=fab, hosts=hosts, mpitype=mpi,
-                         ofi_build_mode=mode, user_env=user_env, test_group=group,
-                         util_prov=util)
+                         ofi_build_mode=mode, user_env=user_env, run_test=run_test,
+                         test_group=group, util_prov=util)
 
     print('-------------------------------------------------------------------')
     if (imb.execute_condn == True):
@@ -99,13 +99,13 @@ def intel_mpi_benchmark(core, hosts, mpi, mode, group, user_env, util):
         print(f"Skipping {mpi.upper} {imb.testname} as execute condition fails")
     print('-------------------------------------------------------------------')
 
-def mpich_test_suite(core, hosts, mpi, mode, user_env, util):
+def mpich_test_suite(core, hosts, mpi, mode, user_env, run_test, util):
 
     mpich_tests = tests.MpichTestSuite(jobname=jbname,buildno=bno,
                                        testname="MpichTestSuite",core_prov=core,
                                        fabric=fab, mpitype=mpi, hosts=hosts,
                                        ofi_build_mode=mode, user_env=user_env,
-                                       util_prov=util)
+                                       run_test=run_test, util_prov=util)
 
     print('-------------------------------------------------------------------')
     if (mpich_tests.execute_condn == True):
@@ -115,13 +115,13 @@ def mpich_test_suite(core, hosts, mpi, mode, user_env, util):
         print(f"Skipping {mpi.upper()} {mpich_tests.testname} as exec condn fails")
     print('-------------------------------------------------------------------')
 
-def osu_benchmark(core, hosts, mpi, mode, user_env, util):
+def osu_benchmark(core, hosts, mpi, mode, user_env, run_test, util):
 
     osu_test = tests.OSUtests(jobname=jbname, buildno=bno,
                                 testname='osu-benchmarks', core_prov=core,
                                 fabric=fab, mpitype=mpi, hosts=hosts,
                                 ofi_build_mode=mode, user_env=user_env,
-                                util_prov=util)
+                                run_test=run_test, util_prov=util)
 
     print('-------------------------------------------------------------------')
     if (osu_test.execute_condn == True):
@@ -131,13 +131,13 @@ def osu_benchmark(core, hosts, mpi, mode, user_env, util):
         print(f"Skipping {mpi.upper()} {osu_test.testname} as exec condn fails")
     print('-------------------------------------------------------------------')
 
-def oneccltest(core, hosts, mode, user_env, util):
+def oneccltest(core, hosts, mode, user_env, run_test, util):
 
     runoneccltest = tests.OneCCLTests(jobname=jbname,buildno=bno,
                                       testname="oneccl test", core_prov=core,
                                       fabric=fab, hosts=hosts,
                                       ofi_build_mode=mode, user_env=user_env,
-                                      util_prov=util)
+                                      run_test=run_test, util_prov=util)
 
     print('-------------------------------------------------------------------')
     if (runoneccltest.execute_condn):
@@ -151,13 +151,13 @@ def oneccltest(core, hosts, mode, user_env, util):
         print(f"Skipping {runoneccltest.testname} as execute condition fails")
     print('-------------------------------------------------------------------')
 
-def oneccltestgpu(core, hosts, mode, user_env, util):
+def oneccltestgpu(core, hosts, mode, user_env, run_test, util):
 
     runoneccltestgpu = tests.OneCCLTestsGPU(jobname=jbname,buildno=bno,
                                          testname="oneccl GPU test", core_prov=core,
                                          fabric=fab, hosts=hosts,
                                          ofi_build_mode=mode, user_env=user_env,
-                                         util_prov=util)
+                                         run_test=run_test, util_prov=util)
 
     print('-------------------------------------------------------------------')
     if (runoneccltestgpu.execute_condn):

--- a/contrib/intel/jenkins/run.py
+++ b/contrib/intel/jenkins/run.py
@@ -77,8 +77,13 @@ def ze_fabtests(core, hosts, mode, user_env, run_test, util):
 
     print('-------------------------------------------------------------------')
     if (runzefabtests.execute_condn):
-        print(f"Running ze tests for {core}-{util}-{fab}")
-        runzefabtests.execute_cmd()
+        print(f"Running ze h2d tests for {core}-{util}-{fab}")
+        runzefabtests.execute_cmd('h2d')
+        print(f"Running ze d2d tests for {core}-{util}-{fab}")
+        runzefabtests.execute_cmd('d2d')
+        # xd2d tests are failing
+        # print(f"Running ze xd2d tests for {core}-{util}-{fab}")
+        # runzefabtests.execute_cmd('xd2d')
     else:
         print(f"Skipping {core} {runzefabtests.testname} as execute condition fails")
     print('-------------------------------------------------------------------')

--- a/contrib/intel/jenkins/runtests.py
+++ b/contrib/intel/jenkins/runtests.py
@@ -15,7 +15,8 @@ parser.add_argument('--ofi_build_mode', help="specify the build configuration", 
                     choices = ['dbg', 'dl'], default='reg')
 parser.add_argument('--test', help="specify test to execute", \
                     choices = ['all', 'shmem', 'IMB', 'osu', 'oneccl', \
-                               'mpichtestsuite', 'fabtests', 'onecclgpu'])
+                               'mpichtestsuite', 'fabtests', 'onecclgpu', \
+                               'fi_info'])
 parser.add_argument('--imb_grp', help="IMB test group {1:[MPI1, P2P], \
                     2:[EXT, IO], 3:[NBC, RMA, MT]", choices=['1', '2', '3'])
 parser.add_argument('--device', help="optional gpu device", choices=['ze'])
@@ -62,9 +63,11 @@ if(args_core):
         hosts.append(host)
 
         if (args.device != 'ze'):
-            if (run_test == 'all' or run_test == 'fabtests'):
+            if (run_test == 'all' or run_test == 'fi_info'):
                 run.fi_info_test(args_core, hosts, ofi_build_mode, user_env, run_test,
                                  util=args.util)
+
+            if (run_test == 'all' or run_test == 'fabtests'):
                 run.fabtests(args_core, hosts, ofi_build_mode, user_env, run_test, args_util)
 
             if (run_test == 'all' or run_test == 'shmem'):

--- a/contrib/intel/jenkins/runtests.py
+++ b/contrib/intel/jenkins/runtests.py
@@ -63,32 +63,32 @@ if(args_core):
 
         if (args.device != 'ze'):
             if (run_test == 'all' or run_test == 'fabtests'):
-                run.fi_info_test(args_core, hosts, ofi_build_mode, user_env,
+                run.fi_info_test(args_core, hosts, ofi_build_mode, user_env, run_test,
                                  util=args.util)
-                run.fabtests(args_core, hosts, ofi_build_mode, user_env, args_util)
+                run.fabtests(args_core, hosts, ofi_build_mode, user_env, run_test, args_util)
 
             if (run_test == 'all' or run_test == 'shmem'):
-                run.shmemtest(args_core, hosts, ofi_build_mode, user_env, args_util)
+                run.shmemtest(args_core, hosts, ofi_build_mode, user_env, run_test, args_util)
 
             if (run_test == 'all' or run_test == 'oneccl'):
-                run.oneccltest(args_core, hosts, ofi_build_mode, user_env, args_util)
+                run.oneccltest(args_core, hosts, ofi_build_mode, user_env, run_test, args_util)
 
             if (run_test == 'all' or run_test == 'onecclgpu'):
-                run.oneccltestgpu(args_core, hosts, ofi_build_mode, user_env, args_util)
+                run.oneccltestgpu(args_core, hosts, ofi_build_mode, user_env, run_test, args_util)
 
             for mpi in mpilist:
                 if (run_test == 'all' or run_test == 'mpichtestsuite'):
                     run.mpich_test_suite(args_core, hosts, mpi,
-                                         ofi_build_mode, user_env, args_util)
+                                         ofi_build_mode, user_env, run_test, args_util)
                 if (run_test == 'all' or run_test == 'IMB'):
                     run.intel_mpi_benchmark(args_core, hosts, mpi,
                                             ofi_build_mode, imb_group,
-                                            user_env, args_util)
+                                            user_env, run_test, args_util)
                 if (run_test == 'all' or run_test == 'osu'):
                     run.osu_benchmark(args_core, hosts, mpi,
-                                      ofi_build_mode, user_env, args_util)
+                                      ofi_build_mode, user_env, run_test, args_util)
         else:
-            run.ze_fabtests(args_core, hosts, ofi_build_mode, user_env, args_util)
+            run.ze_fabtests(args_core, hosts, ofi_build_mode, user_env, run_test, args_util)
 
 else:
     print("Error : Specify a core provider to run tests")

--- a/contrib/intel/jenkins/runtests.py
+++ b/contrib/intel/jenkins/runtests.py
@@ -12,7 +12,7 @@ parser.add_argument('--prov', help="core provider", choices=['verbs', \
                      'tcp', 'udp', 'sockets', 'shm', 'psm3'])
 parser.add_argument('--util', help="utility provider", choices=['rxd', 'rxm'])
 parser.add_argument('--ofi_build_mode', help="specify the build configuration", \
-                    choices = ['dbg', 'dl'])
+                    choices = ['dbg', 'dl'], default='reg')
 parser.add_argument('--test', help="specify test to execute", \
                     choices = ['all', 'shmem', 'IMB', 'osu', 'oneccl', \
                                'mpichtestsuite', 'fabtests', 'onecclgpu'])

--- a/contrib/intel/jenkins/summary.py
+++ b/contrib/intel/jenkins/summary.py
@@ -87,6 +87,42 @@ def summarize_fabtests(log_dir, prov, build_mode=None):
 
     log.close()
 
+def summarize_oneccl(log_dir, prov, build_mode=None):
+    if 'GPU' in prov:
+        file_name = f'{prov}_onecclgpu_{build_mode}'
+    else:
+        file_name = f'{prov}_oneccl_{build_mode}'
+
+    if not os.path.exists(f'{log_dir}/{file_name}'):
+        return
+
+    log = open(f'{log_dir}/{file_name}', 'r')
+    line = log.readline()
+    passes = 0
+    fails = 0
+    failed_tests = []
+    name = 'no_test'
+    while line:
+        #lines look like path/run_oneccl.sh ..... -test examples ..... test_name
+        if " -test" in line:
+            tokens = line.split()
+            name = f"{tokens[tokens.index('-test') + 1]} " \
+                   f"{tokens[len(tokens) - 1]}"
+
+        if 'PASSED' in line:
+            passes += 1
+
+        if 'FAILED' in line or "exiting with" in line:
+            fails += 1
+            failed_tests.append(name)
+
+        line = log.readline()
+
+    print_results(f"{prov} oneccl {build_mode}", passes, fails, failed_tests, \
+                  excludes=0, excluded_tests=[])
+
+    log.close()
+
 
 if __name__ == "__main__":
 #read Jenkins environment variables

--- a/contrib/intel/jenkins/summary.py
+++ b/contrib/intel/jenkins/summary.py
@@ -1,0 +1,133 @@
+import os
+from pickle import FALSE
+import sys
+
+# add jenkins config location to PATH
+sys.path.append(os.environ['CI_SITE_CONFIG'])
+
+import ci_site_config
+import argparse
+import subprocess
+import shlex
+import common
+import re
+import shutil
+
+verbose = False
+
+def print_results(stage_name, passes, fails, failed_tests, excludes,
+                  excluded_tests):
+    total = passes + fails
+    percent = passes/total * 100
+    print(f"{stage_name}: {passes}/{total} = {percent:.2f} % Pass")
+    if fails:
+        print(f"\tFailed tests: {fails}")
+        for test in failed_tests:
+                print(f'\t\t{test}')
+    if (verbose):
+        if excludes:
+            print(f"\tExcluded/Notrun tests: {excludes} ")
+            for test in excluded_tests:
+                print(f'\t\t{test}')
+
+
+def summarize_fabtests(log_dir, prov, build_mode=None):
+    file_name = f'{prov}_fabtests_{build_mode}'
+    if not os.path.exists(f'{log_dir}/{file_name}'):
+        return
+
+    log = open(f'{log_dir}/{file_name}', 'r')
+    line = log.readline()
+    passes = 0
+    fails = 0
+    excludes = 0
+    failed_tests = []
+    excluded_tests = []
+    test_name_string='no_test'
+    while line:
+        # don't double count ubertest output
+        if 'ubertest' in line and 'client_cmd:' in line:
+            while 'name:' not in line: # skip past client output in ubertest
+                line = log.readline()
+
+        if 'name:' in line:
+            test_name = line.split()[2:]
+            test_name_string = ' '.join(test_name)
+
+        if 'result:' in line:
+            result_line = line.split()
+            # lines can look like 'result: Pass' or
+            # 'Ending test 1 result: Success'
+            result = (result_line[result_line.index('result:') + 1]).lower()
+            if result == 'pass' or result == 'success':
+                    passes += 1
+
+            if result == 'fail':
+                fails += 1
+                if 'ubertest' in test_name_string:
+                    idx = (result_line.index('result:') - 1)
+                    ubertest_number = int((result_line[idx].split(',')[0]))
+                    failed_tests.append(f"{test_name_string}: " \
+                                        f"{ubertest_number}")
+                else:
+                    failed_tests.append(test_name_string)
+
+            if result == 'excluded' or result == 'notrun':
+                excludes += 1
+                excluded_tests.append(test_name_string)
+
+        if "exiting with" in line:
+            fails += 1
+            failed_tests.append(test_name_string)
+
+        line = log.readline()
+
+    print_results(f"{prov} fabtests {build_mode}", passes, fails, failed_tests,
+                  excludes, excluded_tests)
+
+    log.close()
+
+
+if __name__ == "__main__":
+#read Jenkins environment variables
+    # In Jenkins,  JOB_NAME  = 'ofi_libfabric/master' vs BRANCH_NAME = 'master'
+    # job name is better to use to distinguish between builds of different
+    # jobs but with same branch name.
+    jobname = os.environ['JOB_NAME']
+    buildno = os.environ['BUILD_NUMBER']
+    workspace = os.environ['WORKSPACE']
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--summary_item', help="functional test to summarize",
+                         choices=['fabtests', 'impi', 'ompi', 'mpichtestsuite'])
+    parser.add_argument('--ofi_build_mode', help="select buildmode debug or dl",
+                        choices=['dbg', 'dl'])
+    parser.add_argument('-v', help="Verbose mode. Print excluded tests", \
+                        action='store_true')
+
+    args = parser.parse_args()
+    verbose = args.v
+
+    args = parser.parse_args()
+    summary_item = args.summary_item
+
+    if (args.ofi_build_mode):
+        ofi_build_mode = args.ofi_build_mode
+    else:
+        ofi_build_mode = 'reg'
+
+    log_dir = f'{ci_site_config.install_dir}/{jobname}/{buildno}/log_dir'
+
+    if summary_item == 'fabtests':
+        for prov,util in common.prov_list:
+            if util:
+                prov = f'{prov}-{util}'
+
+            summarize_fabtests(log_dir, prov, ofi_build_mode)
+
+    if summary_item == 'impi':
+        print('impi')
+    if summary_item == 'ompi':
+        print('ompi')
+    if summary_item == 'mpichtestsuite':
+        print('mpichtestsuite')

--- a/contrib/intel/jenkins/summary.py
+++ b/contrib/intel/jenkins/summary.py
@@ -241,6 +241,41 @@ def summarize_mpichtestsuite(log_dir, prov, mpi, build_mode=None):
 
     log.close()
 
+def summarize_imb(log_dir, prov, mpi, build_mode=None):
+    file_name = f'MPI_{prov}_{mpi}_IMB_{build_mode}'
+    if not os.path.exists(f'{log_dir}/{file_name}'):
+        return
+
+    log = open(f'{log_dir}/{file_name}', 'r')
+    line = log.readline()
+    passes = 0
+    fails = 0
+    failed_tests = []
+    if mpi == 'impi':
+        run = 'mpiexec'
+    else:
+        run = 'mpirun'
+
+    while line:
+        if 'part' in line:
+            test_type = line.split()[len(line.split()) - 2]
+
+        if "Benchmarking" in line:
+            name = line.split()[len(line.split()) - 1]
+            passes += 1
+
+        if "exiting with" in line:
+            fails += 1
+            failed_tests.append(f"{test_type} {name}")
+            passes -= 1
+
+        line = log.readline()
+
+    print_results(f"{prov} {mpi} IMB {build_mode}", passes, fails, \
+                  failed_tests, excludes=0, excluded_tests=[])
+
+    log.close()
+
 
 if __name__ == "__main__":
 #read Jenkins environment variables

--- a/contrib/intel/jenkins/summary.py
+++ b/contrib/intel/jenkins/summary.py
@@ -273,9 +273,41 @@ def summarize_imb(log_dir, prov, mpi, build_mode=None):
 
     print_results(f"{prov} {mpi} IMB {build_mode}", passes, fails, \
                   failed_tests, excludes=0, excluded_tests=[])
-
     log.close()
 
+def summarize_osu(log_dir, prov, mpi, build_mode=None):
+    file_name = f'MPI_{prov}_{mpi}_osu_{build_mode}'
+    if not os.path.exists(f'{log_dir}/{file_name}'):
+        return
+
+    log = open(f'{log_dir}/{file_name}', 'r')
+    line = log.readline()
+    passes = 0
+    fails = 0
+    failed_tests = []
+    if mpi == 'impi':
+        run = 'mpiexec'
+    else:
+        run = 'mpirun'
+
+    while line:
+        if "# OSU" in line:
+            tokens = line.split()
+            name = " ".join(tokens[tokens.index('OSU') + 1:tokens.index('Test')])
+            test_type = tokens[1]
+            passes += 1
+        
+        if "exiting with" in line:
+            fails += 1
+            failed_tests.append(f"{test_type} {name}")
+            passes -= 1
+
+        line = log.readline()
+
+    print_results(f"{prov} {mpi} OSU {build_mode}", passes, fails, failed_tests, \
+                    excludes=0, excluded_tests=[])
+    
+    log.close()
 
 if __name__ == "__main__":
 #read Jenkins environment variables

--- a/contrib/intel/jenkins/summary.py
+++ b/contrib/intel/jenkins/summary.py
@@ -15,8 +15,8 @@ import shutil
 
 verbose = False
 
-def print_results(stage_name, passes, fails, failed_tests, excludes,
-                  excluded_tests):
+def print_results(stage_name, passes, fails, failed_tests, excludes=None,
+                  excluded_tests=None):
     total = passes + fails
     percent = passes/total * 100
     print(f"{stage_name}: {passes}/{total} = {percent:.2f} % Pass")
@@ -30,6 +30,30 @@ def print_results(stage_name, passes, fails, failed_tests, excludes,
             for test in excluded_tests:
                 print(f'\t\t{test}')
 
+def summarize_fi_info(log_dir, prov, build_mode):
+    file_name = f'{prov}_fi_info_{build_mode}'
+    if not os.path.exists(f'{log_dir}/{file_name}'):
+        return
+
+    log = open(f'{log_dir}/{file_name}', 'r')
+    line = log.readline()
+    passes = 0
+    fails = 0
+    failed_tests = []
+    #check if it failed
+    while line:
+        if "exiting with" in line:
+            fails += 1
+            failed_tests.append(f"fi_info {prov}")
+
+        line = log.readline()
+
+    if not fails:
+        passes += 1
+
+    print_results(f"{prov} fabtests {build_mode}", passes, fails, failed_tests)
+    
+    log.close()
 
 def summarize_fabtests(log_dir, prov, build_mode=None):
     file_name = f'{prov}_fabtests_{build_mode}'
@@ -118,8 +142,7 @@ def summarize_oneccl(log_dir, prov, build_mode=None):
 
         line = log.readline()
 
-    print_results(f"{prov} oneccl {build_mode}", passes, fails, failed_tests, \
-                  excludes=0, excluded_tests=[])
+    print_results(f"{prov} oneccl {build_mode}", passes, fails, failed_tests)
 
     log.close()
 
@@ -198,8 +221,7 @@ def summarize_shmem(log_dir, prov, build_mode=None):
 
         line = log.readline()
 
-    print_results(f"shmem {prov} {build_mode}", passes, fails, failed_tests, \
-                    excludes=0, excluded_tests=[])
+    print_results(f"shmem {prov} {build_mode}", passes, fails, failed_tests)
 
     log.close()
 
@@ -237,7 +259,7 @@ def summarize_mpichtestsuite(log_dir, prov, mpi, build_mode=None):
         line = log.readline()
 
     print_results(f"{prov} {mpi} mpichtestsuite {build_mode}", passes, fails,
-                  failed_tests, excludes=0, excluded_tests=[])
+                  failed_tests)
 
     log.close()
 
@@ -271,8 +293,8 @@ def summarize_imb(log_dir, prov, mpi, build_mode=None):
 
         line = log.readline()
 
-    print_results(f"{prov} {mpi} IMB {build_mode}", passes, fails, \
-                  failed_tests, excludes=0, excluded_tests=[])
+    print_results(f"{prov} {mpi} IMB {build_mode}", passes, fails, failed_tests)
+
     log.close()
 
 def summarize_osu(log_dir, prov, mpi, build_mode=None):
@@ -304,8 +326,7 @@ def summarize_osu(log_dir, prov, mpi, build_mode=None):
 
         line = log.readline()
 
-    print_results(f"{prov} {mpi} OSU {build_mode}", passes, fails, failed_tests, \
-                    excludes=0, excluded_tests=[])
+    print_results(f"{prov} {mpi} OSU {build_mode}", passes, fails, failed_tests)
     
     log.close()
 

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -250,11 +250,10 @@ class ZeFabtests(Test):
     def cmd(self):
         return f'{self.zefabtest_script_path}/runfabtests_ze.sh '
 
-    @property
-    def options(self):
+    def options(self, test_name):
         opts = f"-p {self.fabtestpath} "
         opts += f"-B {self.fabtestpath} "
-        opts += "-t h2d,d2d " #xd2d is failing
+        opts += f"-t {test_name} "
         opts += f"{self.server} {self.client} "
         return opts
 
@@ -262,13 +261,13 @@ class ZeFabtests(Test):
     def execute_condn(self):
         return True if (self.core_prov == 'shm') else False
 
-    def execute_cmd(self):
+    def execute_cmd(self, test_name):
         curdir = os.getcwd()
         os.chdir(self.fabtestconfigpath)
-        command = self.cmd + self.options
+        command = self.cmd + self.options(test_name)
         outputcmd = shlex.split(command)
-        common.run_command(outputcmd, self.ci_logdir_path, self.run_test,
-                           self.ofi_build_mode)
+        common.run_command(outputcmd, self.ci_logdir_path,
+                           f'{test_name}', self.ofi_build_mode)
         os.chdir(curdir)
 
 

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -231,7 +231,8 @@ class ShmemTest(Test):
     def execute_cmd(self, shmem_testname):
         command = self.cmd + self.options(shmem_testname)
         outputcmd = shlex.split(command)
-        common.run_command(outputcmd, self.ci_logdir_path, self.run_test,
+        common.run_command(outputcmd, self.ci_logdir_path,
+                           f'{shmem_testname}_{self.run_test}',
                            self.ofi_build_mode)
 
 class ZeFabtests(Test):
@@ -514,7 +515,8 @@ class IMBtests(Test):
                 outputcmd = shlex.split(self.mpi.env + self.mpi.cmd + \
                                         self.imb_cmd(test_type) + '\'')
                 common.run_command(outputcmd, self.ci_logdir_path,
-                                   self.run_test, self.ofi_build_mode)
+                                   f'{self.mpi_type}_{self.run_test}',
+                                   self.ofi_build_mode)
 
 
 class OSUtests(Test):
@@ -564,7 +566,8 @@ class OSUtests(Test):
                     outputcmd = shlex.split(self.mpi.env + self.mpi.cmd + \
                                             osu_command + '\'')
                     common.run_command(outputcmd, self.ci_logdir_path,
-                                       self.run_test, self.ofi_build_mode)
+                                       f'{self.mpi_type}_{self.run_test}',
+                                       self.ofi_build_mode)
 
                 if (test == 'osu_latency_mp' and self.core_prov == 'verbs'):
                     self.env.pop('IBV_FORK_SAFE')
@@ -624,8 +627,15 @@ class MpichTestSuite(Test):
             self.set_options(nprocs, timeout=time)
             testcmd = f'./{testname}'
             outputcmd = shlex.split(self.mpi.env + self.mpi.cmd + testcmd + '\'')
-            common.run_command(outputcmd, self.ci_logdir_path, self.run_test,
-                               self.ofi_build_mode)
+            if self.util_prov:
+                util_prov = self.util_prov.strip('ofi_')
+                log_file_name = f'{self.core_prov}-{util_prov}_' \
+                                f'{self.mpi_type}_{self.run_test}'
+            else:
+                log_file_name = f'{self.core_prov}_{self.mpi_type}_{self.run_test}'
+
+            common.run_command(outputcmd, self.ci_logdir_path, log_file_name,
+                                self.ofi_build_mode)
         os.chdir(self.pwd)
 
 

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -36,6 +36,9 @@ class Test:
         self.ci_middlewares_path = f'{ci_site_config.install_dir}/'\
                                    f'{self.jobname}/{self.buildno}/'\
                                    'ci_middlewares'
+        self.ci_logdir_path = f'{ci_site_config.install_dir}/'\
+                                   f'{self.jobname}/{self.buildno}/'\
+                                   'log_dir'
         self.env = eval(user_env)
 
         self.mpi = ''
@@ -83,7 +86,7 @@ class FiInfoTest(Test):
     def execute_cmd(self):
         command = self.cmd + self.options
         outputcmd = shlex.split(command)
-        common.run_command(outputcmd)
+        common.run_command(outputcmd, self.ci_logdir_path)
 
 
 class Fabtest(Test):
@@ -177,7 +180,7 @@ class Fabtest(Test):
         os.chdir(self.fabtestconfigpath)
         command = self.cmd + self.options
         outputcmd = shlex.split(command)
-        common.run_command(outputcmd)
+        common.run_command(outputcmd, self.ci_logdir_path)
         os.chdir(curdir)
 
 


### PR DESCRIPTION
This commit adds a functional summary to the CI.
A new directory (log_dir) is being made to store all the logs for each stage.
These patches add a functional summary stage to the pipeline and to the post stage in the Jenkinsfile.
The pipeline stage is only viewable on passed pipelines. This is because jenkins skips future stages if earlier stages failed. So, this stage is just to provide a clear place to look on passed pipelines for the functional summary.
The functional summary will still be provided in the post stage inside of the always{} clause incase of a test failure where the summary will still provide a list of passed and failed tests during the entire run.
The stages that get summarized in these patches are:
fabtests (tcp, verbs-rxm, verbs-rxd, shm, udp, sockets, psm3) [reg, dl, dbg build modes]
fabtests_ze (shm, h2d, d2d) [reg]
shmem (uh, prk, isx) [reg]
verbs-rxm impi IMB [reg]
verbs-rxm mpich IMB [reg]
verbs-rxm impi osu [reg]
verbs-rxm mpich osu [reg]
tcp-rxm impi IMB [reg]
tcp-rxm impi osu [reg]
verbs-rxm mpich mpichtestsuite [reg]
verbs-rxm impi mpichtestsuite [reg]
tcp impi mpichtestsuite [reg]
sockets impi mpichtestsuite [reg]
oneccl [reg]
oneccl gpu [reg]
These combinations are all of the ones that currently get run in the Jenkinsfile however the summarizer has the capability to summarize additional combinations once they get re-enabled.

There are also some miscellaneous changes like:
common.run_command has been made versatile to accommodate new log filenames.
Separating the ze-shm stage into three log files the same way that shmem is for easier summarizing.
Changes to the cleanup path in the Jenkinsfile to always cleanup everything created per run.
This is because jenkins doesn't cleanup the ofi-libfabric workspace and only cleans up its checkout workspace.
This makes the space that the libfabric builds, the middlewares directory, and the logs directory take up get freed
at the end of the run.
If there was a failure general user's do not care about having the build artifacts because they
can be easily remade.
And in the case of developers re-enabling failing tests, they already build these things by hand
and use jenkins to test if its working via automation.
TLDR: It is no longer necessary to keep the build artifacts post run