### PR TITLE
[v1.16.x] prov/efa: Toggle cuda sync memops via environment variable

### DIFF
--- a/man/fi_efa.7.md
+++ b/man/fi_efa.7.md
@@ -188,6 +188,9 @@ These OFI runtime parameters apply only to the RDM endpoint.
 *FI_EFA_FORK_SAFE*
 : Enable fork() support. This may have a small performance impact and should only be set when required. Applications that require to register regions backed by huge pages and also require fork support are not supported.
 
+*FI_EFA_SET_CUDA_SYNC_MEMOPS*
+: Set CU_POINTER_ATTRIBUTE_SYNC_MEMOPS for cuda ptr. (Default: 1)
+
 # SEE ALSO
 
 [`fabric`(7)](fabric.7.html),

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -229,6 +229,11 @@ static int efa_mr_hmem_setup(struct efa_mr *efa_mr,
 	/* efa_mr->peer.device is an union. Setting reserved to 0 cleared everything in it (cuda, neuron, synapseai etc) */
 	efa_mr->peer.device.reserved = 0;
 	if (efa_mr->peer.iface == FI_HMEM_CUDA) {
+		err = cuda_set_sync_memops(attr->mr_iov->iov_base);
+		if (err) {
+			EFA_WARN(FI_LOG_MR, "unable to set memops for cuda ptr\n");
+			return err;
+		}
 		err = cuda_dev_register((struct fi_mr_attr *)attr, &efa_mr->peer.device.cuda);
 		if (err) {
 			EFA_WARN(FI_LOG_MR,

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -229,10 +229,12 @@ static int efa_mr_hmem_setup(struct efa_mr *efa_mr,
 	/* efa_mr->peer.device is an union. Setting reserved to 0 cleared everything in it (cuda, neuron, synapseai etc) */
 	efa_mr->peer.device.reserved = 0;
 	if (efa_mr->peer.iface == FI_HMEM_CUDA) {
-		err = cuda_set_sync_memops(attr->mr_iov->iov_base);
-		if (err) {
-			EFA_WARN(FI_LOG_MR, "unable to set memops for cuda ptr\n");
-			return err;
+		if (rxr_env.set_cuda_sync_memops) {
+			err = cuda_set_sync_memops(attr->mr_iov->iov_base);
+			if (err) {
+				EFA_WARN(FI_LOG_MR, "unable to set memops for cuda ptr\n");
+				return err;
+			}
 		}
 		err = cuda_dev_register((struct fi_mr_attr *)attr, &efa_mr->peer.device.cuda);
 		if (err) {

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -614,13 +614,6 @@ static int efa_mr_reg_impl(struct efa_mr *efa_mr, uint64_t flags, void *attr)
 			shm_flags |= FI_HMEM_DEVICE_ONLY;
 		}
 
-		if (mr_attr->iface == FI_HMEM_CUDA) {
-			ret = cuda_set_sync_memops(mr_attr->mr_iov->iov_base);
-			if (ret) {
-				EFA_WARN(FI_LOG_MR, "unable to set memops for cuda ptr\n");
-				return ret;
-			}
-		}
 		ret = fi_mr_regattr(efa_mr->domain->shm_domain, attr,
 				    shm_flags, &efa_mr->shm_mr);
 		mr_attr->access = original_access;

--- a/prov/efa/src/rxr/rxr_env.c
+++ b/prov/efa/src/rxr/rxr_env.c
@@ -44,6 +44,7 @@ struct rxr_env rxr_env = {
 	.enable_shm_transfer = 1,
 	.use_device_rdma = 0,
 	.use_zcpy_rx = 1,
+	.set_cuda_sync_memops = 1,
 	.zcpy_rx_seed = 0,
 	.shm_av_size = 128,
 	.shm_max_medium_size = 4096,
@@ -98,6 +99,7 @@ void rxr_env_param_get(void)
 	fi_param_get_int(&rxr_prov, "enable_shm_transfer", &rxr_env.enable_shm_transfer);
 	fi_param_get_int(&rxr_prov, "use_device_rdma", &rxr_env.use_device_rdma);
 	fi_param_get_int(&rxr_prov, "use_zcpy_rx", &rxr_env.use_zcpy_rx);
+	fi_param_get_int(&rxr_prov, "set_cuda_sync_memops", &rxr_env.set_cuda_sync_memops);
 	fi_param_get_int(&rxr_prov, "zcpy_rx_seed", &rxr_env.zcpy_rx_seed);
 	fi_param_get_int(&rxr_prov, "shm_av_size", &rxr_env.shm_av_size);
 	fi_param_get_int(&rxr_prov, "recvwin_size", &rxr_env.recvwin_size);
@@ -159,6 +161,8 @@ void rxr_env_define()
 			"whether to use device's RDMA functionality for one-sided and two-sided transfer.");
 	fi_param_define(&rxr_prov, "use_zcpy_rx", FI_PARAM_INT,
 			"Enables the use of application's receive buffers in place of bounce-buffers when feasible. (Default: 1)");
+	fi_param_define(&rxr_prov, "set_cuda_sync_memops", FI_PARAM_INT,
+			"Set CU_POINTER_ATTRIBUTE_SYNC_MEMOPS for cuda ptr. (Default: 1)");
 	fi_param_define(&rxr_prov, "zcpy_rx_seed", FI_PARAM_INT,
 			"Defines the number of bounce-buffers the provider will prepost during EP initialization.  (Default: 0)");
 	fi_param_define(&rxr_prov, "shm_av_size", FI_PARAM_INT,

--- a/prov/efa/src/rxr/rxr_env.h
+++ b/prov/efa/src/rxr/rxr_env.h
@@ -39,6 +39,7 @@ struct rxr_env {
 	int tx_queue_size;
 	int use_device_rdma;
 	int use_zcpy_rx;
+	int set_cuda_sync_memops;
 	int zcpy_rx_seed;
 	int enable_shm_transfer;
 	int shm_av_size;


### PR DESCRIPTION
This PR backports https://github.com/ofiwg/libfabric/pull/7995 to v1.16.x