### PR TITLE
fabtests: fix return value of rdm_stress client

### DIFF
--- a/fabtests/functional/rdm_stress.c
+++ b/fabtests/functional/rdm_stress.c
@@ -936,6 +936,7 @@ static int run_parent(const char *ctrlfile)
 			}
 
 			clients[myid].pid = ret;
+			ret = 0;
 		}
 	}
 


### PR DESCRIPTION
When `run_parent()` finishes correctly the '`ret`' variable contains a PID of the last forked child. Then this value is passed to `ft_exit_code()` and test exits with an error. '`ret`' should be zeroed to fix this issue.

Signed-off-by: Lukasz Dorau <lukasz.dorau@intel.com>