### PR TITLE
[v1.15.x] prov/hook/dmabuf_peer_mem: Set iface when auto-detect succeeds

### DIFF
--- a/prov/hook/dmabuf_peer_mem/src/hook_dmabuf_peer_mem.c
+++ b/prov/hook/dmabuf_peer_mem/src/hook_dmabuf_peer_mem.c
@@ -259,6 +259,9 @@ static int hook_dmabuf_peer_mem_mr_regattr(struct fid *fid,
 
 	get_mr_fd(mymr, attr->iov_count, attr->mr_iov);
 
+	if (mymr->fd != -1 && attr->iface == FI_HMEM_SYSTEM)
+		((struct fi_mr_attr *)attr)->iface = FI_HMEM_ZE;
+
 	ret = fi_mr_regattr(dom->hdomain, attr, flags, &mymr->mr_hook.hmr);
 	if (ret) {
 		release_mr_fd(mymr);


### PR DESCRIPTION
When the hooking provider detects valid dmabuf based buffer, set the iface to FI_HMEM_ZE. This allows HMEM buffer copy routines to work properly.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>

Cherry-picked from commit 10a8e25cfa8b8f38ea059c08f6bde6f84384f1ac.