### PR TITLE
net: Fix for multi-recv. core: fix iface strcmp. fabtest: Fix multi-recv test

### DIFF
--- a/fabtests/functional/multi_recv.c
+++ b/fabtests/functional/multi_recv.c
@@ -275,7 +275,7 @@ static int run(void)
 	ret = run_test();
 
 	rx_seq++;
-	ft_finalize();
+	ft_sync();
 
 	return ret;
 }

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -360,6 +360,7 @@ struct xnet_xfer_entry {
 		struct xnet_tag_hdr	tag_hdr;
 		uint8_t		       	max_hdr[XNET_MAX_HDR + XNET_MAX_INJECT];
 	} hdr;
+	void			*user_buf;
 	size_t			iov_cnt;
 	struct iovec		iov[XNET_IOV_LIMIT+1];
 	struct xnet_ep		*ep;
@@ -547,6 +548,7 @@ xnet_free_xfer(struct xnet_ep *ep, struct xnet_xfer_entry *xfer)
 	xfer->cntr_inc = NULL;
 	xfer->ctrl_flags = 0;
 	xfer->context = 0;
+	xfer->user_buf = NULL;
 	ofi_buf_free(xfer);
 }
 

--- a/prov/net/src/xnet_attr.c
+++ b/prov/net/src/xnet_attr.c
@@ -53,6 +53,7 @@
 	 FI_DELIVERY_COMPLETE | FI_COMMIT_COMPLETE | FI_COMPLETION)
 
 #define XNET_RX_OP_FLAGS (FI_COMPLETION)
+#define XNET_SRX_OP_FLAGS (FI_COMPLETION | FI_MULTI_RECV)
 
 static struct fi_tx_attr xnet_tx_attr = {
 	.caps = XNET_EP_CAPS | XNET_TX_CAPS,
@@ -99,7 +100,7 @@ static struct fi_tx_attr xnet_srx_tx_attr = {
 
 static struct fi_rx_attr xnet_srx_rx_attr = {
 	.caps = XNET_SRX_EP_CAPS | XNET_SRX_CAPS,
-	.op_flags = XNET_RX_OP_FLAGS,
+	.op_flags = XNET_SRX_OP_FLAGS,
 	.comp_order = FI_ORDER_NONE,
 	.msg_order = XNET_MSG_ORDER,
 	.total_buffered_recv = 0,
@@ -132,7 +133,7 @@ static struct fi_tx_attr xnet_rdm_tx_attr = {
 
 static struct fi_rx_attr xnet_rdm_rx_attr = {
 	.caps = XNET_RDM_EP_CAPS | XNET_SRX_CAPS,
-	.op_flags = XNET_RX_OP_FLAGS,
+	.op_flags = XNET_SRX_OP_FLAGS,
 	.comp_order = FI_ORDER_STRICT,
 	.msg_order = XNET_MSG_ORDER,
 	.total_buffered_recv = 0,

--- a/prov/net/src/xnet_cq.c
+++ b/prov/net/src/xnet_cq.c
@@ -151,8 +151,8 @@ void xnet_report_success(struct xnet_ep *ep, struct util_cq *cq,
 		tag = 0;
 	}
 
-	ofi_cq_write(cq, xfer_entry->context,
-		     flags, len, NULL, data, tag);
+	ofi_cq_write(cq, xfer_entry->context, flags, len,
+		     xfer_entry->user_buf, data, tag);
 	if (cq->wait)
 		cq->wait->signal(cq->wait);
 }

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -381,7 +381,7 @@ static int xnet_alter_mrecv(struct xnet_ep *ep, struct xnet_xfer_entry *xfer,
 	}
 
 	left = xfer->iov[0].iov_len - msg_len;
-	if (!xfer->iov_cnt || (left <= ep->srx->min_multi_recv_size))
+	if (!xfer->iov_cnt || (left < ep->srx->min_multi_recv_size))
 		goto complete;
 
 	/* If we can't repost the remaining buffer, return it to the user. */

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -395,7 +395,8 @@ static int xnet_alter_mrecv(struct xnet_ep *ep, struct xnet_xfer_entry *xfer,
 	recv_entry->context = xfer->context;
 
 	recv_entry->iov_cnt = 1;
-	recv_entry->iov[0].iov_base = (char *) xfer->iov[0].iov_base + msg_len;
+	recv_entry->user_buf =  (char *) xfer->iov[0].iov_base + msg_len;
+	recv_entry->iov[0].iov_base = recv_entry->user_buf;
 	recv_entry->iov[0].iov_len = left;
 
 	slist_insert_head(&recv_entry->entry, &ep->srx->rx_queue);

--- a/prov/net/src/xnet_srx.c
+++ b/prov/net/src/xnet_srx.c
@@ -118,6 +118,7 @@ xnet_srx_recv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 		goto unlock;
 	}
 
+	recv_entry->ctrl_flags = srx->op_flags & FI_MULTI_RECV;
 	recv_entry->cq_flags = FI_MSG | FI_RECV;
 	recv_entry->cntr_inc = ofi_ep_rx_cntr_inc;
 	recv_entry->context = context;
@@ -150,6 +151,7 @@ xnet_srx_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 		goto unlock;
 	}
 
+	recv_entry->ctrl_flags = srx->op_flags & FI_MULTI_RECV;
 	recv_entry->cq_flags = FI_MSG | FI_RECV;
 	recv_entry->cntr_inc = ofi_ep_rx_cntr_inc;
 	recv_entry->context = context;
@@ -609,7 +611,7 @@ int xnet_srx_context(struct fid_domain *domain, struct fi_rx_attr *attr,
 	ofi_atomic_inc32(&srx->domain->util_domain.ref);
 	srx->match_tag_rx = (attr->caps & FI_DIRECTED_RECV) ?
 			    xnet_match_tag_addr : xnet_match_tag;
-	srx->op_flags = attr->op_flags;
+	srx->op_flags = attr->op_flags & FI_MULTI_RECV;
 	srx->min_multi_recv_size = XNET_MIN_MULTI_RECV;
 	*rx_ep = &srx->rx_fid;
 	return FI_SUCCESS;

--- a/prov/net/src/xnet_srx.c
+++ b/prov/net/src/xnet_srx.c
@@ -89,8 +89,11 @@ xnet_srx_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 	recv_entry->cntr_inc = ofi_ep_rx_cntr_inc;
 	recv_entry->context = msg->context;
 	recv_entry->iov_cnt = msg->iov_count;
-	memcpy(&recv_entry->iov[0], msg->msg_iov,
-	       msg->iov_count * sizeof(*msg->msg_iov));
+	if (msg->iov_count) {
+		recv_entry->user_buf = msg->msg_iov[0].iov_base;
+		memcpy(&recv_entry->iov[0], msg->msg_iov,
+		       msg->iov_count * sizeof(*msg->msg_iov));
+	}
 
 	xnet_srx_msg(srx, recv_entry);
 unlock:
@@ -119,6 +122,7 @@ xnet_srx_recv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 	recv_entry->cntr_inc = ofi_ep_rx_cntr_inc;
 	recv_entry->context = context;
 	recv_entry->iov_cnt = 1;
+	recv_entry->user_buf = buf;
 	recv_entry->iov[0].iov_base = buf;
 	recv_entry->iov[0].iov_len = len;
 
@@ -150,7 +154,10 @@ xnet_srx_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	recv_entry->cntr_inc = ofi_ep_rx_cntr_inc;
 	recv_entry->context = context;
 	recv_entry->iov_cnt = count;
-	memcpy(&recv_entry->iov[0], iov, count * sizeof(*iov));
+	if (count) {
+		recv_entry->user_buf = iov[0].iov_base;
+		memcpy(&recv_entry->iov[0], iov, count * sizeof(*iov));
+	}
 
 	xnet_srx_msg(srx, recv_entry);
 unlock:
@@ -266,9 +273,13 @@ xnet_srx_trecvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
 	recv_entry->cq_flags = FI_TAGGED | FI_RECV;
 	recv_entry->cntr_inc = ofi_ep_rx_cntr_inc;
 	recv_entry->context = msg->context;
+
 	recv_entry->iov_cnt = msg->iov_count;
-	memcpy(&recv_entry->iov[0], msg->msg_iov,
-	       msg->iov_count * sizeof(*msg->msg_iov));
+	if (msg->iov_count) {
+		recv_entry->user_buf = msg->msg_iov[0].iov_base;
+		memcpy(&recv_entry->iov[0], msg->msg_iov,
+		       msg->iov_count * sizeof(*msg->msg_iov));
+	}
 
 	ret = xnet_srx_tag(srx, recv_entry);
 	if (ret)
@@ -301,6 +312,7 @@ xnet_srx_trecv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 	recv_entry->cq_flags = FI_TAGGED | FI_RECV;
 	recv_entry->cntr_inc = ofi_ep_rx_cntr_inc;
 	recv_entry->context = context;
+	recv_entry->user_buf = buf;
 	recv_entry->iov_cnt = 1;
 	recv_entry->iov[0].iov_base = buf;
 	recv_entry->iov[0].iov_len = len;
@@ -338,8 +350,12 @@ xnet_srx_trecvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	recv_entry->cq_flags = FI_TAGGED | FI_RECV;
 	recv_entry->cntr_inc = ofi_ep_rx_cntr_inc;
 	recv_entry->context = context;
+
 	recv_entry->iov_cnt = count;
-	memcpy(&recv_entry->iov[0], iov, count * sizeof(*iov));
+	if (count) {
+		recv_entry->user_buf = iov[0].iov_base;
+		memcpy(&recv_entry->iov[0], iov, count * sizeof(*iov));
+	}
 
 	ret = xnet_srx_tag(srx, recv_entry);
 	if (ret)

--- a/src/common.c
+++ b/src/common.c
@@ -2002,10 +2002,8 @@ void ofi_get_list_of_addr(const struct fi_provider *prov, const char *env_name,
 
 	if (iface) {
 		for (ifa = ifaddrs; ifa != NULL; ifa = ifa->ifa_next) {
-			if (strncmp(iface, ifa->ifa_name,
-					strlen(iface)) == 0) {
+			if (!strncmp(iface, ifa->ifa_name, strlen(iface) + 1))
 				break;
-			}
 		}
 		if (ifa == NULL) {
 			FI_INFO(prov, FI_LOG_CORE,
@@ -2021,7 +2019,7 @@ void ofi_get_list_of_addr(const struct fi_provider *prov, const char *env_name,
 			((ifa->ifa_addr->sa_family != AF_INET) &&
 			(ifa->ifa_addr->sa_family != AF_INET6)))
 			continue;
-		if (iface && strncmp(iface, ifa->ifa_name, strlen(iface)) != 0) {
+		if (iface && strncmp(iface, ifa->ifa_name, strlen(iface) + 1)) {
 			FI_DBG(prov, FI_LOG_CORE,
 				"Skip (%s) interface\n", ifa->ifa_name);
 			continue;


### PR DESCRIPTION
core: Fix NIC interface name checks to be exact match, versus prefix match
prov/net: Fix support for FI_MULTI_RECV
fabtests/multi_recv: Fix crash in cleanup and add buffer validation