### PR TITLE
[v1.16.x] util,verbs: FI_SOCKADDR includes support of FI_SOCKADDR_IB

### DIFF
--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -771,7 +771,7 @@ static int vrb_alloc_info(struct ibv_context *ctx, struct fi_info **info,
 		fi->caps = VERBS_MSG_CAPS;
 		*(fi->tx_attr) = verbs_tx_attr;
 		*(fi->rx_attr) = verbs_rx_attr;
-		fi->addr_format = FI_SOCKADDR;
+		fi->addr_format = FI_SOCKADDR_IB;
 		break;
 	case FI_EP_DGRAM:
 		fi->caps = VERBS_DGRAM_CAPS;


### PR DESCRIPTION
According to libfabric's man pages (fi_verbs.7), MSG EPs in the verbs  provider support FI_SOCKADDR, FI_SOCKADDR_IN, FI_SOCKADDR_IN6 and FI_SOCKADDR_IB.

Since commit fb758f5d7("prov/verbs: set and check address format correctly"), the verbs provider sets fi->addr_format = FI_SOCKADDR for MSG EPs.

The problem is that applications requesting FI_SOCKADDR_IB get FI_ENODATA in fi_getinfo() because ofi_valid_addr_format() only expects FI_SOCKADDR, FI_SOCKADDR_IN and FI_SOCKADDR_IN6 but not FI_SOCKADDR_IB when the provider format is FI_SOCKADDR.

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>