### PR TITLE
util/src: fix syntax error

### DIFF
--- a/prov/util/src/rocr_mem_monitor.c
+++ b/prov/util/src/rocr_mem_monitor.c
@@ -59,7 +59,7 @@ static void rocr_mm_unsubscribe(struct ofi_mem_monitor *monitor,
 				union ofi_mr_hmem_info *hmem_info);
 static bool rocr_mm_valid(struct ofi_mem_monitor *monitor,
 			   const struct ofi_mr_info *info,
-			   struct ofi_mr_entry *entry));
+			   struct ofi_mr_entry *entry);
 
 static struct rocr_mm rocr_mm = {
 	.mm = {


### PR DESCRIPTION
Fix syntax error introduced in:
32ead6680c8feb6ee933cf28482a6f3b6bc0a6b8 core and util/prov: introduce cuda ipc monitor

Signed-off-by: Amir Shehata <shehataa@ornl.gov>