### PR TITLE
prov/efa: Directly use ibv_cq_ex in rxr_ep 

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -291,7 +291,7 @@ struct rxr_ep {
 
 	/* core provider fid */
 	struct fid_ep *rdm_ep;
-	struct fid_cq *rdm_cq;
+	struct ibv_cq_ex *ibv_cq_ex;
 
 	/* shm provider fid */
 	bool use_shm_for_tx;


### PR DESCRIPTION
rxr_ep now has a new member ibv_cq_ex which is polled directly in
rxr_ep_progress_internal

Signed-off-by: Sai Sunku <sunkusa@amazon.com>
