### PR TITLE
prov/rxm: Add disconnect to rxm_av_remove

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -693,6 +693,7 @@ static inline void ofi_cntr_inc(struct util_cntr *cntr)
 
 struct util_av;
 struct util_av_set;
+struct util_peer_addr;
 
 struct util_coll_mc {
 	struct fid_mc		mc_fid;
@@ -749,6 +750,8 @@ struct util_av {
 	size_t			context_offset;
 	struct dlist_entry	ep_list;
 	ofi_mutex_t		ep_list_lock;
+	void (*remove_handler)(struct util_ep *util_ep,
+			       struct util_peer_addr *peer);
 };
 
 #define OFI_AV_DYN_ADDRLEN (1 << 0)
@@ -805,7 +808,9 @@ void util_put_peer(struct util_peer_addr *peer);
 };
 
 int rxm_util_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
-		     struct fid_av **fid_av, void *context, size_t conn_size);
+		     struct fid_av **fid_av, void *context, size_t conn_size,
+		     void (*remove_handler)(struct util_ep *util_ep,
+					    struct util_peer_addr *peer));
 size_t rxm_av_max_peers(struct rxm_av *av);
 void rxm_ref_peer(struct util_peer_addr *peer);
 void *rxm_av_alloc_conn(struct rxm_av *av);

--- a/prov/net/src/xnet_domain.c
+++ b/prov/net/src/xnet_domain.c
@@ -103,7 +103,7 @@ static int xnet_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 			struct fid_av **fid_av, void *context)
 {
 	return rxm_util_av_open(domain_fid, attr, fid_av, context,
-				sizeof(struct xnet_conn));
+				sizeof(struct xnet_conn), NULL);
 }
 
 static int

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -897,6 +897,7 @@ ssize_t rxm_handle_unexp_sar(struct rxm_recv_queue *recv_queue,
 			     struct rxm_recv_entry *recv_entry,
 			     struct rxm_rx_buf *rx_buf);
 int rxm_post_recv(struct rxm_rx_buf *rx_buf);
+void rxm_av_remove_handler(struct util_ep *util_ep, struct util_peer_addr *peer);
 
 static inline void
 rxm_free_rx_buf(struct rxm_rx_buf *rx_buf)

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -1056,3 +1056,18 @@ int rxm_start_listen(struct rxm_ep *ep)
 	}
 	return 0;
 }
+
+void rxm_av_remove_handler(struct util_ep *util_ep, struct util_peer_addr *peer)
+{
+	struct rxm_ep *ep;
+	struct rxm_conn *conn;
+
+	ep = container_of(util_ep, struct rxm_ep, util_ep);
+	ofi_ep_lock_acquire(&ep->util_ep);
+	conn = ofi_idm_lookup(&ep->conn_idx_map, peer->index);
+	if (conn) {
+		rxm_close_conn(conn);
+		rxm_free_conn(conn);
+	}
+	ofi_ep_lock_release(&ep->util_ep);
+}

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -39,6 +39,7 @@
 #include <ofi_coll.h>
 #include "rxm.h"
 
+extern int rxm_av_remove_disc;
 
 static uint64_t rxm_passthru_cntr_read(struct fid_cntr *cntr_fid)
 {
@@ -170,7 +171,9 @@ rxm_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 	    struct fid_av **fid_av, void *context)
 {
 	return rxm_util_av_open(domain_fid, attr, fid_av, context,
-				sizeof(struct rxm_conn));
+				sizeof(struct rxm_conn),
+				rxm_av_remove_disc ? rxm_av_remove_handler
+						   : NULL);
 }
 
 static int

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -57,6 +57,7 @@ size_t rxm_buffer_size = 16384;
 size_t rxm_packet_size;
 
 int rxm_passthru = 0; /* disable by default, need to analyze performance */
+int rxm_av_remove_disc = 0; /* disable by default, disconnect on AV remove */
 int force_auto_progress;
 int rxm_use_write_rndv;
 enum fi_wait_obj def_wait_obj = FI_WAIT_FD, def_tcp_wait_obj = FI_WAIT_UNSPEC;
@@ -723,6 +724,17 @@ RXM_INI
 			"related overhead.  Pass thru is an optimized path "
 			"to the tcp provider, depending on the capabilities "
 			"requested by the application.");
+
+	fi_param_define(&rxm_prov, "av_remove_disc", FI_PARAM_BOOL,
+			"When true, cleanup any underlying resources and "
+			"hidden connection when removing an entry from an "
+			"AV.  This can help save resources on AV entries "
+			"that reference a peer which is no longer active.  "
+			"However, it may abruptly terminate data transfers "
+			"from peers that are active at the time their "
+			"address is removed from the local AV.  "
+			"(default: false)");
+
 	/* passthru supported disabled - to re-enable would need to fix call to
 	 * fi_cq_read to pass in the correct data structure.  However, passthru
 	 * will not be needed at all with in-work tcp changes.
@@ -740,6 +752,7 @@ RXM_INI
 		rxm_cq_eq_fairness = 128;
 	fi_param_get_bool(&rxm_prov, "data_auto_progress", &force_auto_progress);
 	fi_param_get_bool(&rxm_prov, "use_rndv_write", &rxm_use_write_rndv);
+	fi_param_get_bool(&rxm_prov, "av_remove_disc", &rxm_av_remove_disc);
 
 	rxm_get_def_wait();
 


### PR DESCRIPTION
Reduce resource consumption by disconnecting connections to peers on AV remove.  This may abruptly terminate any data transfers in progress.

To enable, set environment variable FI_OFI_RXM_AV_REMOVE_DISC to 1.

Signed-off-by: Chien Tin Tung <chien.tin.tung@intel.com>