### PR TITLE
fabtests/pytest/efa: re-enable fi_rdm and fi_av_xfer test

### DIFF
--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -158,6 +158,7 @@ nobase_dist_config_DATA = \
 	pytest/efa/conftest.py \
 	pytest/efa/efa_common.py \
 	pytest/efa/test_from_default.py \
+	pytest/efa/test_av.py \
 	pytest/efa/test_dgram.py \
 	pytest/efa/test_rdm.py \
 	pytest/efa/test_rma_bw.py \

--- a/fabtests/pytest/efa/test_av.py
+++ b/fabtests/pytest/efa/test_av.py
@@ -1,0 +1,7 @@
+import pytest
+
+@pytest.mark.functional
+def test_av_xfer(cmdline_args):
+    from common import ClientServerTest
+    test = ClientServerTest(cmdline_args, "fi_av_xfer -e rdm")
+    test.run()

--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -1,5 +1,6 @@
 import pytest
 
+from default.test_rdm import test_rdm
 from default.test_rdm import test_rdm_bw_functional
 
 @pytest.mark.parametrize("iteration_type",


### PR DESCRIPTION
This patch re-enable the fi_rdm and fi_av_xfer test for EFA provider.