### PR TITLE
util/pinpong: add AI_NUMERICSERV definition when it is not defined

### DIFF
--- a/util/pingpong.c
+++ b/util/pingpong.c
@@ -65,6 +65,10 @@
 #define OFI_MR_BASIC_MAP (FI_MR_ALLOCATED | FI_MR_PROV_KEY | FI_MR_VIRT_ADDR)
 #endif
 
+#ifndef AI_NUMERICSERV
+#define AI_NUMERICSERV 0
+#endif
+
 static const uint64_t TAG = 1234;
 
 enum precision {


### PR DESCRIPTION
Older Darwin does not have definition for `AI_NUMERICSERV`, which is used in `util/pingpong.c` (and causes build to fail on 10.6). This PR fixes this error.

It mirrors the fix for `MoarVM` from: https://github.com/macports/macports-ports/pull/14932