### PR TITLE
prov/util: rename internal bitmask struct to include ofi prefix

### DIFF
--- a/include/ofi_bitmask.h
+++ b/include/ofi_bitmask.h
@@ -40,12 +40,12 @@
 #include <assert.h>
 #include <string.h>
 
-struct bitmask {
+struct ofi_bitmask {
 	size_t size;
 	uint8_t *bytes;
 };
 
-static inline int ofi_bitmask_create(struct bitmask *mask, size_t size)
+static inline int ofi_bitmask_create(struct ofi_bitmask *mask, size_t size)
 {
 	size_t byte_size = size / 8;
 	if (byte_size % 8)
@@ -60,35 +60,35 @@ static inline int ofi_bitmask_create(struct bitmask *mask, size_t size)
 	return FI_SUCCESS;
 }
 
-static inline void ofi_bitmask_free(struct bitmask *mask)
+static inline void ofi_bitmask_free(struct ofi_bitmask *mask)
 {
 	free(mask->bytes);
 	mask->bytes = NULL;
 }
 
-static inline size_t ofi_bitmask_bytesize(struct bitmask *mask)
+static inline size_t ofi_bitmask_bytesize(struct ofi_bitmask *mask)
 {
 	return (mask->size % 8) ? (mask->size / 8 + 1) : (mask->size / 8);
 }
 
-static inline void ofi_bitmask_unset(struct bitmask *mask, size_t idx)
+static inline void ofi_bitmask_unset(struct ofi_bitmask *mask, size_t idx)
 {
 	assert(idx <= mask->size);
 	mask->bytes[idx / 8] &= ~(0x01 << (idx % 8));
 }
 
-static inline void ofi_bitmask_set(struct bitmask *mask, size_t idx)
+static inline void ofi_bitmask_set(struct ofi_bitmask *mask, size_t idx)
 {
 	assert(idx <= mask->size);
 	mask->bytes[idx / 8] |= (0x01 << (idx % 8));
 }
 
-static inline void ofi_bitmask_set_all(struct bitmask *mask)
+static inline void ofi_bitmask_set_all(struct ofi_bitmask *mask)
 {
 	memset(mask->bytes, 0xff, ofi_bitmask_bytesize(mask));
 }
 
-static inline size_t ofi_bitmask_get_lsbset(struct bitmask mask)
+static inline size_t ofi_bitmask_get_lsbset(struct ofi_bitmask mask)
 {
 	size_t cur;
 	uint8_t tmp;

--- a/include/ofi_coll.h
+++ b/include/ofi_coll.h
@@ -121,8 +121,8 @@ struct util_coll_reduce_item {
 
 struct join_data {
 	struct util_coll_mc *new_mc;
-	struct bitmask data;
-	struct bitmask tmp;
+	struct ofi_bitmask data;
+	struct ofi_bitmask tmp;
 };
 
 struct barrier_data {

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -304,7 +304,7 @@ struct util_ep {
 	ofi_mutex_lock_t	lock_acquire;
 	ofi_mutex_unlock_t	lock_release;
 
-	struct bitmask		*coll_cid_mask;
+	struct ofi_bitmask	*coll_cid_mask;
 	struct slist		coll_ready_queue;
 };
 

--- a/prov/util/src/util_ep.c
+++ b/prov/util/src/util_ep.c
@@ -191,7 +191,7 @@ int ofi_ep_bind(struct util_ep *util_ep, struct fid *fid, uint64_t flags)
 	return -FI_EINVAL;
 }
 
-static inline int util_coll_init_cid_mask(struct bitmask *mask)
+static inline int util_coll_init_cid_mask(struct ofi_bitmask *mask)
 {
 	int err = ofi_bitmask_create(mask, OFI_MAX_GROUP_ID);
 	if (err)


### PR DESCRIPTION
The numa.h header also defines a struct bitmask. When using the numa.h header, these definitions conflict.

Add the ofi_ internal function prefix to make it unique and adhere to the naming convention.

Signed-off-by: Alexia Ingerson <alexia.ingerson@intel.com>