### PR TITLE
fabtests/pytest: add possible ssh connection error message

### DIFF
--- a/fabtests/pytest/common.py
+++ b/fabtests/pytest/common.py
@@ -18,6 +18,7 @@ def is_ssh_connection_error(exception):
 
 def has_ssh_connection_err_msg(output):
     err_msgs = ["kex_exchange_identification: Connection closed by remote host",
+                "ssh_exchange_identification: Connection closed by remote host",
                 "ssh_exchange_identification: read: Connection reset by peer",
                 "port 22: Connection refused"]
 


### PR DESCRIPTION
Add "ssh_exchange_identification: Connection closed by remote host" as an error message that is considered ssh connection issue.

Signed-off-by: Wei Zhang <wzam@amazon.com>