### PR TITLE
[v1.16.x] fabtests/pytest: retry test when connection issues were encountered

### DIFF
--- a/fabtests/pytest/common.py
+++ b/fabtests/pytest/common.py
@@ -18,6 +18,7 @@ def is_ssh_connection_error(exception):
 
 def has_ssh_connection_err_msg(output):
     err_msgs = ["kex_exchange_identification: Connection closed by remote host",
+                "ssh_exchange_identification: Connection closed by remote host",
                 "ssh_exchange_identification: read: Connection reset by peer",
                 "port 22: Connection refused"]
 

--- a/fabtests/pytest/requirements.txt
+++ b/fabtests/pytest/requirements.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-html
 pyyaml
+retrying


### PR DESCRIPTION
If test failed due to ssh connection issue like "connect reset by peer", this patch will retry the test.