### PR TITLE
gh-pages: Add yet another missing link of fi_peer man page

### DIFF
--- a/main/man/index.md
+++ b/main/man/index.md
@@ -33,6 +33,7 @@ main](https://github.com/ofiwg/libfabric/tree/main).
   * [fi_msg(3)](fi_msg.3.html)
   * [fi_mr(3)](fi_mr.3.html)
   * [fi_nic(3)](fi_nic.3.html)
+  * [fi_peer(3)](fi_peer.3.html)
   * [fi_poll(3)](fi_poll.3.html)
   * [fi_provider(3)](fi_provider.3.html)
   * [fi_rma(3)](fi_rma.3.html)


### PR DESCRIPTION
A previous patch (commit efa7f61a51b235a5e08c32ec8d9a209e91be65c3) fixed the man pages for v1.16.0, but the link is still missing from main.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>