### PR TITLE
contrib/intel: replace '-' delimiter with '_'

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -450,7 +450,7 @@ pipeline {
                 env
                 (
                   echo `hostname`
-		  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
                   python3.7 runtests.py --prov='verbs' --util='rxm' --test=daos
                   echo "daos-verbs test completed."
                 )

--- a/contrib/intel/jenkins/runtests.py
+++ b/contrib/intel/jenkins/runtests.py
@@ -46,7 +46,7 @@ if (args.imb_grp):
 else:
     imb_group = '1'
 
-node = (os.environ['NODE_NAME']).split('-')[0]
+node = (os.environ['NODE_NAME']).split('_')[0]
 hosts = [node]
 mpilist = ['impi', 'mpich', 'ompi']
 

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -151,7 +151,7 @@ class Fabtest(Test):
                 print(f"{self.core_prov} Complex test file not found")
 
         if (self.ofi_build_mode != 'reg' or self.core_prov == 'udp'):
-            opts += "-e \'ubertest,multinode\'"
+            opts += "-e \'ubertest,multinode\' "
 
         efile = self.get_exclude_file()
         if efile:


### PR DESCRIPTION
The Jenkins nodes use the naming convention "node-fabric"
Jenkins parses by the '-' and assumes the first element to be the
node name to ssh into. This delimiter conflicts with normal node
naming convention which uses dashes within the node name.
This changes the node/fabric delimiter from - to _ so it doesn't
conflict with regular node names.

Note that this will require a momentary down period between naming
the nodes and merging the PR.
After this change is merged, PRs will have to rebase on upstream
in order to pass.

Verified this works with a single pair of renamed nodes as well as with the daos testing.

Also includes 2 unrelated minor fixes.