### PR TITLE
man: Update fi_verbs man page with new runtime parameter

### DIFF
--- a/man/fi_verbs.7.md
+++ b/man/fi_verbs.7.md
@@ -197,6 +197,12 @@ The verbs provider checks for the following environment variables.
 *FI_VERBS_DEVICE_NAME*
 : Specify a specific verbs device to use by name
 
+*FI_VERBS_USE_DMABUF*
+: If supported, try to use ibv_reg_dmabuf_mr first to register dmabuf-based
+  buffers. Set it to "no" to always use ibv_reg_mr which can be helpful for
+  testing the functionality of the dmabuf_peer_mem hooking provider and the
+  corresponding kernel driver. (default: yes)
+
 ### Variables specific to MSG endpoints
 
 *FI_VERBS_IFACE*


### PR DESCRIPTION
Add description of the new environment variable FI_VERBS_USE_DMABUF.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>