### PR TITLE
contrib/intel/jenkins: Catch potential release package make issues

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -3,7 +3,7 @@ properties([disableConcurrentBuilds(abortPrevious: true)])
 def DO_RUN=1
 def TARGET="main"
 def check_target() {
-  echo "CHANGE_TARGET = ${env.CHANGE_TARET}"
+  echo "CHANGE_TARGET = ${env.CHANGE_TARGET}"
   if (changeRequest()) {
     TARGET = env.CHANGE_TARGET
   }

--- a/contrib/intel/jenkins/build.py
+++ b/contrib/intel/jenkins/build.py
@@ -12,6 +12,10 @@ import common
 import re
 import shutil
 
+def distcheck():
+	cmd = "bash -c \'LDFLAGS=-Wl,--build-id rpmbuild -ta libfabric-*.tar.bz2\'"
+	common.run_command(['make', '-j', 'distcheck'])
+	common.run_command(shlex.split(cmd))
 
 def build_libfabric(libfab_install_path, mode, cluster=None):
 
@@ -36,11 +40,14 @@ def build_libfabric(libfab_install_path, mode, cluster=None):
 
     if (cluster != 'daos'):
         config_cmd.append('--enable-ze-dlopen')
+
     common.run_command(['./autogen.sh'])
     common.run_command(shlex.split(" ".join(config_cmd)))
     common.run_command(['make','clean'])
     common.run_command(['make', '-j32'])
     common.run_command(['make','install'])
+    if (mode == 'reg'):
+        distcheck()
 
 
 def build_fabtests(libfab_install_path, mode):

--- a/prov/verbs/Makefile.include
+++ b/prov/verbs/Makefile.include
@@ -15,7 +15,8 @@ _verbs_files =							\
 	prov/verbs/src/verbs_rma.c				\
 	prov/verbs/src/verbs_dgram_ep_msg.c			\
 	prov/verbs/src/verbs_dgram_av.c				\
-	prov/verbs/include/ofi_verbs_priv.h
+	prov/verbs/include/ofi_verbs_priv.h			\
+	prov/verbs/include/linux/verbs_osd.h
 
 if HAVE_VERBS_DL
 pkglib_LTLIBRARIES += libverbs-fi.la


### PR DESCRIPTION
Add make distcheck and rpmbuild to jenkins for regular build.
We need to catch problems where a release package does not include all necessary files because of potential missing updates to makefile.includes.

Signed-off-by: Zach Dworkin <zachary.dworkin@intel.com>