### PR TITLE
fabtests/multinode: add enum to fix magic numbers

### DIFF
--- a/fabtests/multinode/include/core.h
+++ b/fabtests/multinode/include/core.h
@@ -49,6 +49,13 @@ enum multi_xfer{
 	multi_rma,
 };
 
+enum multi_pattern {
+	PATTERN_MESH,
+	PATTERN_RING,
+	PATTERN_GATHER,
+	PATTERN_BROADCAST,
+};
+
 struct multi_xfer_method {
 	char* name;
 	int (*send)();
@@ -69,7 +76,7 @@ struct pm_job_info {
 	size_t		name_len;
 	fi_addr_t	*fi_addrs;
 	enum multi_xfer transfer_method;
-	int 		pattern;
+	enum multi_pattern pattern;
 };
 
 struct multinode_xfer_state {

--- a/fabtests/multinode/src/harness.c
+++ b/fabtests/multinode/src/harness.c
@@ -45,7 +45,7 @@
 #include <core.h>
 struct pm_job_info pm_job;
 
-static int parse_caps(char *caps)
+static enum multi_xfer parse_caps(char *caps)
 {
 	if (strcmp(caps, "msg") == 0) {
 		return multi_msg;
@@ -57,19 +57,19 @@ static int parse_caps(char *caps)
 	}
 }
 
-static int parse_pattern(char *pattern)
+static enum multi_pattern parse_pattern(char *pattern)
 {
 	if (strcmp(pattern, "full_mesh") == 0) {
-		return 0;
+		return PATTERN_MESH;
 	} else if (strcmp(pattern, "ring") == 0) {
-		return 1;
+		return PATTERN_RING;
 	} else if (strcmp(pattern, "gather") == 0) {
-		return 2;
+		return PATTERN_GATHER;
 	} else if (strcmp(pattern, "broadcast") == 0) {
-		return 3;
+		return PATTERN_BROADCAST;
 	} else {
 		printf("Warn: Invalid pattern, defaulting to full_mesh\n");
-		return 0;
+		return PATTERN_MESH;
 	} 
 }
 


### PR DESCRIPTION
Add an enum to set the pattern in a more readable way

Signed-off-by: Alex McKinley <alex.mckinley@intel.com>