### PR TITLE
prov/efa: Open extended CQ in rxr_ep

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -122,9 +122,6 @@
 /* maximum name length for shm endpoint */
 #define EFA_SHM_NAME_MAX	   (256)
 
-/* efa_cq->ibv_cq_ex is created by efadv_create_cq */
-#define EFA_CQ_SUPPORT_EFADV_CQ BIT_ULL(0)
-
 extern struct fi_provider efa_prov;
 extern struct util_prov efa_util_prov;
 

--- a/prov/efa/src/efa_cq.c
+++ b/prov/efa/src/efa_cq.c
@@ -36,6 +36,7 @@
 #include "config.h"
 #include <ofi_mem.h>
 #include "efa.h"
+#include "efa_cq.h"
 #include <infiniband/verbs.h>
 
 static inline uint64_t efa_cq_opcode_to_fi_flags(enum ibv_wc_opcode	opcode) {
@@ -251,102 +252,24 @@ static struct fi_ops efa_cq_fi_ops = {
 };
 
 /**
- * @brief Create ibv_cq_ex by calling ibv_create_cq_ex
- *
- * @param[in] cq Pointer to the efa_cq.
- * @param[in] attr Pointer to fi_cq_attr.
- * @param[out] Return pointer to ibv_cq_ex if successful, otherwise NULL
- */
-static inline struct ibv_cq_ex *efa_cq_ibv_create_cq_ex(struct efa_cq *cq, struct fi_cq_attr *attr) {
-	struct ibv_cq_init_attr_ex init_attr_ex = {
-		.cqe = attr->size ? attr->size : EFA_DEF_CQ_SIZE,
-		.cq_context = NULL,
-		.channel = NULL,
-		.comp_vector = 0,
-		/* EFA requires these values for wc_flags and comp_mask.
-		 * See `efa_create_cq_ex` in rdma-core.
-		 */
-		.wc_flags = IBV_WC_STANDARD_FLAGS,
-		.comp_mask = 0,
-	};
-
-	return ibv_create_cq_ex(cq->domain->device->ibv_ctx, &init_attr_ex);
-}
-
-/**
  * @brief Create and set cq->ibv_cq_ex
  *
  * @param[in] cq Pointer to the efa_cq. cq->ibv_cq_ex must be NULL.
  * @param[in] attr Pointer to fi_cq_attr.
  * @param[out] Return code = 0 if successful, or negative otherwise.
  */
-#if HAVE_EFADV_CQ_EX
-static inline int efa_cq_set_ibv_cq_ex(struct efa_cq *cq, struct fi_cq_attr *attr) {
-	struct ibv_cq_init_attr_ex init_attr_ex = {
-		.cqe = attr->size ? attr->size : EFA_DEF_CQ_SIZE,
-		.cq_context = NULL,
-		.channel = NULL,
-		.comp_vector = 0,
-		/* EFA requires these values for wc_flags and comp_mask.
-		 * See `efa_create_cq_ex` in rdma-core.
-		 */
-		.wc_flags = IBV_WC_STANDARD_FLAGS,
-		.comp_mask = 0,
-	};
-
-	struct efadv_cq_init_attr efadv_cq_init_attr = {
-		.comp_mask = 0,
-		.wc_flags = EFADV_WC_EX_WITH_SGID,
-	};
+static inline int efa_cq_set_ibv_cq_ex(struct efa_cq *cq, struct fi_cq_attr *attr)
+{
+	enum ibv_cq_ex_type ibv_cq_ex_type;
 
 	if (cq->ibv_cq_ex) {
 		EFA_WARN(FI_LOG_CQ, "CQ already has attached ibv_cq_ex\n");
 		return -FI_EALREADY;
 	}
 
-	/* To enable additional WC fields, create CQ with efadv_create_cq verb instead. */
-	cq->ibv_cq_ex = efadv_create_cq(cq->domain->device->ibv_ctx,
-						   &init_attr_ex,
-						   &efadv_cq_init_attr,
-						   sizeof(efadv_cq_init_attr));
-
-	if (cq->ibv_cq_ex) {
-		/* Support operations on EFA DV CQ */
-		cq->flags |= EFA_CQ_SUPPORT_EFADV_CQ;
-		return 0;
-	}
-
-	/* This could be due to old EFA kernel module versions */
-	EFA_WARN(FI_LOG_CQ, "Unable to create EFA DV CQ: %s\n", strerror(errno));
-	cq->flags &= ~EFA_CQ_SUPPORT_EFADV_CQ;
-
-	/* Fallback to ibv_create_cq_ex */
-	cq->ibv_cq_ex = efa_cq_ibv_create_cq_ex(cq, attr);
-
-	if (!cq->ibv_cq_ex) {
-		EFA_WARN(FI_LOG_CQ, "Unable to create extended CQ: %s\n", strerror(errno));
-		return -FI_ENOCQ;
-	}
-
-	return 0;
+	return efa_cq_ibv_cq_ex_open(attr, cq->domain->device->ibv_ctx,
+				    &cq->ibv_cq_ex, &ibv_cq_ex_type);
 }
-#else
-static inline int efa_cq_set_ibv_cq_ex(struct efa_cq *cq, struct fi_cq_attr *attr) {
-	if (cq->ibv_cq_ex) {
-		EFA_WARN(FI_LOG_CQ, "CQ already has attached ibv_cq_ex\n");
-		return -FI_EALREADY;
-	}
-
-	cq->ibv_cq_ex = efa_cq_ibv_create_cq_ex(cq, attr);
-
-	if (!cq->ibv_cq_ex) {
-		EFA_WARN(FI_LOG_CQ, "Unable to create extended CQ: %s\n", strerror(errno));
-		return -FI_ENOCQ;
-	}
-
-	return 0;
-}
-#endif
 
 int efa_cq_open(struct fid_domain *domain_fid, struct fi_cq_attr *attr,
 		struct fid_cq **cq_fid, void *context)

--- a/prov/efa/src/efa_cq.h
+++ b/prov/efa/src/efa_cq.h
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2022 Amazon.com, Inc. or its affiliates. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "efa.h"
+
+/**
+ * @brief Create ibv_cq_ex by calling ibv_create_cq_ex
+ *
+ * @param[in] ibv_cq_init_attr_ex Pointer to ibv_cq_init_attr_ex
+ * @param[in] ibv_ctx Pointer to ibv_context
+ * @param[in,out] ibv_cq_ex Pointer to newly created ibv_cq_ex
+ * @param[in,out] ibv_cq_ex_type enum indicating if efadv_create_cq or ibv_create_cq_ex was used
+ * @return Return 0 on success, error code otherwise
+ */
+static inline int efa_cq_ibv_cq_ex_open_with_ibv_create_cq_ex(
+	struct ibv_cq_init_attr_ex *ibv_cq_init_attr_ex,
+	struct ibv_context *ibv_ctx, struct ibv_cq_ex **ibv_cq_ex,
+	enum ibv_cq_ex_type *ibv_cq_ex_type)
+{
+	*ibv_cq_ex = ibv_create_cq_ex(ibv_ctx, ibv_cq_init_attr_ex);
+
+	if (!*ibv_cq_ex) {
+		EFA_WARN(FI_LOG_CQ, "Unable to create extended CQ: %s\n", strerror(errno));
+		return -FI_ENOCQ;
+	}
+
+	*ibv_cq_ex_type = IBV_CQ;
+	return 0;
+}
+
+/**
+ * @brief Create ibv_cq_ex by calling efadv_create_cq or ibv_create_cq_ex
+ *
+ * @param[in] ibv_cq_init_attr_ex Pointer to ibv_cq_init_attr_ex
+ * @param[in] efadv_cq_init_attr_ex Pointer to efadv_cq_init_attr_ex
+ * @param[in] ibv_ctx Pointer to ibv_context
+ * @param[in,out] ibv_cq_ex Pointer to newly created ibv_cq_ex
+ * @param[in,out] ibv_cq_ex_type enum indicating if efadv_create_cq or ibv_create_cq_ex was used
+ * @return Return 0 on success, error code otherwise
+ */
+#if HAVE_EFADV_CQ_EX
+static inline int efa_cq_ibv_cq_ex_open(struct fi_cq_attr *attr,
+					struct ibv_context *ibv_ctx,
+					struct ibv_cq_ex **ibv_cq_ex,
+					enum ibv_cq_ex_type *ibv_cq_ex_type)
+{
+	struct ibv_cq_init_attr_ex init_attr_ex = {
+		.cqe = attr->size ? attr->size : EFA_DEF_CQ_SIZE,
+		.cq_context = NULL,
+		.channel = NULL,
+		.comp_vector = 0,
+		/* EFA requires these values for wc_flags and comp_mask.
+		 * See `efa_create_cq_ex` in rdma-core.
+		 */
+		.wc_flags = IBV_WC_STANDARD_FLAGS,
+		.comp_mask = 0,
+	};
+
+	struct efadv_cq_init_attr efadv_cq_init_attr = {
+		.comp_mask = 0,
+		.wc_flags = EFADV_WC_EX_WITH_SGID,
+	};
+
+	*ibv_cq_ex = efadv_create_cq(ibv_ctx, &init_attr_ex,
+				     &efadv_cq_init_attr,
+				     sizeof(efadv_cq_init_attr));
+
+	if (!*ibv_cq_ex) {
+		/* This could be due to old EFA kernel module versions */
+		/* Fallback to ibv_create_cq_ex */
+		return efa_cq_ibv_cq_ex_open_with_ibv_create_cq_ex(
+			&init_attr_ex, ibv_ctx, ibv_cq_ex, ibv_cq_ex_type);
+	}
+
+	*ibv_cq_ex_type = EFADV_CQ;
+	return 0;
+}
+#else
+static inline int efa_cq_ibv_cq_ex_open(struct fi_cq_attr *attr,
+					struct ibv_context *ibv_ctx,
+					struct ibv_cq_ex **ibv_cq_ex,
+					enum ibv_cq_ex_type *ibv_cq_ex_type)
+{
+	struct ibv_cq_init_attr_ex init_attr_ex = {
+		.cqe = attr->size ? attr->size : EFA_DEF_CQ_SIZE,
+		.cq_context = NULL,
+		.channel = NULL,
+		.comp_vector = 0,
+		/* EFA requires these values for wc_flags and comp_mask.
+		 * See `efa_create_cq_ex` in rdma-core.
+		 */
+		.wc_flags = IBV_WC_STANDARD_FLAGS,
+		.comp_mask = 0,
+	};
+
+	return efa_cq_ibv_cq_ex_open_with_ibv_create_cq_ex(
+		&init_attr_ex, ibv_ctx, ibv_cq_ex, ibv_cq_ex_type);
+}
+#endif

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -209,6 +209,11 @@ static inline void rxr_poison_mem_region(uint32_t *ptr, size_t size)
 
 #define RXR_MTU_MAX_LIMIT	BIT_ULL(15)
 
+enum ibv_cq_ex_type {
+	IBV_CQ,
+	EFADV_CQ
+};
+
 extern struct fi_provider rxr_prov;
 extern struct fi_fabric_attr rxr_fabric_attr;
 extern struct util_prov rxr_util_prov;
@@ -292,6 +297,8 @@ struct rxr_ep {
 	/* core provider fid */
 	struct fid_ep *rdm_ep;
 	struct ibv_cq_ex *ibv_cq_ex;
+
+	enum ibv_cq_ex_type ibv_cq_ex_type;
 
 	/* shm provider fid */
 	bool use_shm_for_tx;

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -38,6 +38,7 @@
 #include <ofi_util.h>
 #include <ofi_iov.h>
 #include "efa.h"
+#include "efa_cq.h"
 #include "rxr_msg.h"
 #include "rxr_rma.h"
 #include "rxr_pkt_cmd.h"
@@ -1840,14 +1841,12 @@ static inline fi_addr_t rdm_ep_determine_peer_address_from_efadv(struct rxr_ep *
 {
 	struct rxr_pkt_entry *pkt_entry;
 	struct efa_ep *efa_ep;
-	struct efa_cq *efa_cq;
 	struct efa_ep_addr efa_ep_addr = {0};
 	fi_addr_t addr;
 	union ibv_gid gid = {0};
 	uint32_t *connid = NULL;
 
-	efa_cq = container_of(ep->rdm_cq, struct efa_cq, util_cq.cq_fid);
-	if (!(efa_cq->flags & EFA_CQ_SUPPORT_EFADV_CQ)) {
+	if (ep->ibv_cq_ex_type != EFADV_CQ) {
 		/* EFA DV CQ is not supported. This could be due to old EFA kernel module versions. */
 		return FI_ADDR_NOTAVAIL;
 	}
@@ -2502,32 +2501,6 @@ int rxr_ep_alloc_app_device_info(struct fi_info **app_device_info,
 }
 
 /**
- * @brief Create ibv_cq_ex by calling ibv_create_cq_ex
- *
- * @param[in] cq Pointer to the efa_cq.
- * @param[in] attr Pointer to fi_cq_attr.
- * @return Return pointer to ibv_cq_ex if successful, otherwise NULL
- */
-static inline struct ibv_cq_ex *rxr_ep_create_ibv_cq_ex(struct rxr_ep *ep, struct fi_cq_attr *attr)
-{
-	struct ibv_cq_init_attr_ex init_attr_ex = {
-		.cqe = attr->size ? attr->size : EFA_DEF_CQ_SIZE,
-		.cq_context = NULL,
-		.channel = NULL,
-		.comp_vector = 0,
-		/* EFA requires these values for wc_flags and comp_mask.
-		 * See `efa_create_cq_ex` in rdma-core.
-		 */
-		.wc_flags = IBV_WC_STANDARD_FLAGS,
-		.comp_mask = 0,
-	};
-
-	struct efa_domain *efa_domain = rxr_ep_domain(ep);
-
-	return ibv_create_cq_ex(efa_domain->device->ibv_ctx, &init_attr_ex);
-}
-
-/**
  * @brief Bind rxr_ep->ibv_cq_ex to efa_ep->scq and efa_ep->rcq
  * 	Will be removed when rxr_ep and efa_ep are fully separated
  *
@@ -2665,11 +2638,11 @@ int rxr_endpoint(struct fid_domain *domain, struct fi_info *info,
 
 	assert(!rxr_ep->ibv_cq_ex);
 
-	rxr_ep->ibv_cq_ex = rxr_ep_create_ibv_cq_ex(rxr_ep, &cq_attr);
+	ret = efa_cq_ibv_cq_ex_open(&cq_attr, efa_domain->device->ibv_ctx,
+				    &rxr_ep->ibv_cq_ex, &rxr_ep->ibv_cq_ex_type);
 
-	if (!rxr_ep->ibv_cq_ex) {
+	if (ret) {
 		EFA_WARN(FI_LOG_CQ, "Unable to create extended CQ: %s\n", strerror(errno));
-		ret = -FI_ENOCQ;
 		goto err_close_shm_ep;
 	}
 


### PR DESCRIPTION
In a previous commit, a new member ibv_cq_ex was added to rxr_ep (https://github.com/ofiwg/libfabric/pull/8035)
But only ibv_create_cq was used to open the CQ

This commit adds support for extended CQ which is created by calling efadv_create_cq

Signed-off-by: Sai Sunku <sunkusa@amazon.com>