### PR TITLE
prov/efa: flush MR cache when fork() is called and fork support is ON

### DIFF
--- a/prov/efa/src/efa_domain.h
+++ b/prov/efa/src/efa_domain.h
@@ -52,7 +52,10 @@ struct efa_domain {
 	bool 			mr_local;
 	uint64_t		rdm_mode;
 	size_t			rdm_cq_size;
+	struct dlist_entry	list_entry; /* linked to g_efa_domain_list */
 };
+
+extern struct dlist_entry g_efa_domain_list;
 
 /*
  * efa_is_cache_available() is a check to see whether a memory registration

--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -285,6 +285,7 @@ int efa_prov_initialize(void)
 		goto err_free;
 	}
 
+	dlist_init(&g_efa_domain_list);
 	return 0;
 
 err_free:


### PR DESCRIPTION
When fork support is on, register memory regions was not copied to child processes's memory space.

With MR cache turned on, the registered memory regions remain registered after EFA finished send data from it.

As a result, when both fork support and MR cache are turned on, child processes cannot access some memory they need.

This patch addresses the issue by flush the MR cache when fork is called. Flushing MR cache will cause any memory region that is not actively being used (use_cnt == 0) to be de-registered, therefore they will be copied to child process's memory space

Signed-off-by: Wei Zhang <wzam@amazon.com>