### PR TITLE
core/peer: New peer provider objects to support collective offload

### DIFF
--- a/include/ofi.h
+++ b/include/ofi.h
@@ -76,6 +76,7 @@ extern "C" {
 #define OFI_GETINFO_INTERNAL	(1ULL << 58)
 #define OFI_CORE_PROV_ONLY	(1ULL << 59)
 #define OFI_GETINFO_HIDDEN	(1ULL << 60)
+#define OFI_OFFLOAD_PROV_ONLY	(1ULL << 61)
 
 #define OFI_ORDER_RAR_SET	(FI_ORDER_RAR | FI_ORDER_RMA_RAR | \
 				 FI_ORDER_ATOMIC_RAR)
@@ -226,6 +227,7 @@ enum ofi_prov_type {
 	OFI_PROV_CORE,
 	OFI_PROV_UTIL,
 	OFI_PROV_HOOK,
+	OFI_PROV_OFFLOAD,
 };
 
 /* Restrict to size of struct fi_provider::context (struct fi_context) */

--- a/include/ofi.h
+++ b/include/ofi.h
@@ -229,11 +229,17 @@ enum ofi_prov_type {
 };
 
 /* Restrict to size of struct fi_provider::context (struct fi_context) */
-struct fi_prov_context {
+struct ofi_prov_context {
 	enum ofi_prov_type type;
-	int disable_logging;
-	int disable_layering;
+	bool disable_logging;
+	bool disable_layering;	/* applies to core providers only */
 };
+
+static inline struct ofi_prov_context *
+ofi_prov_ctx(const struct fi_provider *prov)
+{
+	return (struct ofi_prov_context *) &prov->context;
+}
 
 struct fi_filter {
 	char **names;

--- a/include/ofi_hook.h
+++ b/include/ofi_hook.h
@@ -87,8 +87,8 @@ struct fid_wait *hook_to_hwait(const struct fid_wait *wait);
  * TODO
  * comment from GitHub PR #5052:
  * "another option would be to store the ini/fini calls in a separate structure
- * that we reference from struct fi_prov_context. We could even extend the
- * definition of fi_prov_context with a union that is accessed based on the
+ * that we reference from struct ofi_prov_context. We could even extend the
+ * definition of ofi_prov_context with a union that is accessed based on the
  * prov_type. That might work better if we want to support external hooks,
  * without the external hook provider needing to implement everything"
  */

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -1008,10 +1008,16 @@ void ofi_fabric_remove(struct util_fabric *fabric);
 
 #define OFI_NAME_DELIM	';'
 #define OFI_UTIL_PREFIX "ofi_"
+#define OFI_OFFLOAD_PREFIX "off_"
 
 static inline int ofi_has_util_prefix(const char *str)
 {
 	return !strncasecmp(str, OFI_UTIL_PREFIX, strlen(OFI_UTIL_PREFIX));
+}
+
+static inline int ofi_has_offload_prefix(const char *str)
+{
+	return !strncasecmp(str, OFI_OFFLOAD_PREFIX, strlen(OFI_OFFLOAD_PREFIX));
 }
 
 int ofi_get_core_info(uint32_t version, const char *node, const char *service,

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -165,6 +165,7 @@ typedef struct fid *fid_t;
 #define FI_COMMIT_COMPLETE	(1ULL << 30)
 #define FI_MATCH_COMPLETE	(1ULL << 31)
 
+#define FI_PEER_AV		(1ULL << 39)
 #define FI_PEER_EQ		(1ULL << 40)
 #define FI_AV_USER_ID		(1ULL << 41)
 #define FI_PEER_SRX		(1ULL << 42)

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -165,6 +165,7 @@ typedef struct fid *fid_t;
 #define FI_COMMIT_COMPLETE	(1ULL << 30)
 #define FI_MATCH_COMPLETE	(1ULL << 31)
 
+#define FI_PEER_DOMAIN		(1ULL << 38)
 #define FI_PEER_AV		(1ULL << 39)
 #define FI_PEER_EQ		(1ULL << 40)
 #define FI_AV_USER_ID		(1ULL << 41)

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -165,6 +165,7 @@ typedef struct fid *fid_t;
 #define FI_COMMIT_COMPLETE	(1ULL << 30)
 #define FI_MATCH_COMPLETE	(1ULL << 31)
 
+#define FI_PEER_EQ		(1ULL << 40)
 #define FI_AV_USER_ID		(1ULL << 41)
 #define FI_PEER_SRX		(1ULL << 42)
 #define FI_PEER_CQ		(1ULL << 43)

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -165,6 +165,7 @@ typedef struct fid *fid_t;
 #define FI_COMMIT_COMPLETE	(1ULL << 30)
 #define FI_MATCH_COMPLETE	(1ULL << 31)
 
+#define FI_PEER_TRANSFER	(1ULL << 36)
 #define FI_PEER_DOMAIN		(1ULL << 38)
 #define FI_PEER_AV		(1ULL << 39)
 #define FI_PEER_EQ		(1ULL << 40)
@@ -371,6 +372,7 @@ static inline uint8_t fi_tc_dscp_get(uint32_t tclass)
 #define FI_RESTRICTED_COMP	(1ULL << 53)
 #define FI_CONTEXT2		(1ULL << 52)
 #define FI_BUFFERED_RECV	(1ULL << 51)
+/* #define FI_PEER_TRANSFER	(1ULL << 36) */
 
 struct fi_tx_attr {
 	uint64_t		caps;

--- a/include/rdma/fi_ext.h
+++ b/include/rdma/fi_ext.h
@@ -199,6 +199,15 @@ struct fi_peer_cq_context {
 
 
 /*
+ * Peer provider domain support.
+ */
+struct fi_peer_domain_context {
+	size_t size;
+	struct fid_domain *domain;
+};
+
+
+/*
  * Peer provider EQ support.
  */
 struct fi_peer_eq_context {

--- a/include/rdma/fi_ext.h
+++ b/include/rdma/fi_ext.h
@@ -129,7 +129,9 @@ struct fid_mem_monitor {
 };
 
 
-/* Peer provider CQ support. */
+/*
+ * Peer provider CQ support.
+ */
 struct fid_peer_cq;
 
 struct fi_ops_cq_owner {
@@ -152,7 +154,18 @@ struct fi_peer_cq_context {
 };
 
 
-/* Peer shared rx context */
+/*
+ * Peer provider EQ support.
+ */
+struct fi_peer_eq_context {
+	size_t size;
+	struct fid_eq *eq;
+};
+
+
+/*
+ * Peer shared rx context
+ */
 struct fid_peer_srx;
 
 /* Castable to dlist_entry */
@@ -202,6 +215,7 @@ struct fi_peer_srx_context {
 	size_t size;
 	struct fid_peer_srx *srx;
 };
+
 
 /*
  * System logging import extension:

--- a/include/rdma/fi_ext.h
+++ b/include/rdma/fi_ext.h
@@ -130,6 +130,28 @@ struct fid_mem_monitor {
 
 
 /*
+ * Peer provider AV support.
+ */
+struct fid_peer_av;
+
+struct fi_ops_av_owner {
+	size_t	size;
+	int	(*query)(struct fid_peer_av *av, struct fi_av_attr *attr);
+	fi_addr_t (*ep_addr)(struct fid_peer_av *av, struct fid_ep *ep);
+};
+
+struct fid_peer_av {
+	struct fid fid;
+	struct fi_ops_av_owner *owner_ops;
+};
+
+struct fi_peer_av_context {
+	size_t size;
+	struct fi_peer_av *av;
+};
+
+
+/*
  * Peer provider CQ support.
  */
 struct fid_peer_cq;

--- a/include/rdma/fi_ext.h
+++ b/include/rdma/fi_ext.h
@@ -152,6 +152,28 @@ struct fi_peer_av_context {
 
 
 /*
+ * Peer provider AV set support.
+ */
+struct fid_peer_av_set;
+
+struct fi_ops_av_set_owner {
+	size_t	size;
+	int	(*members)(struct fid_peer_av_set *av, fi_addr_t *addr,
+			   size_t *count);
+};
+
+struct fid_peer_av_set {
+	struct fid fid;
+	struct fi_ops_av_set_owner *owner_ops;
+};
+
+struct fi_peer_av_set_context {
+	size_t size;
+	struct fi_peer_av_set *av_set;
+};
+
+
+/*
  * Peer provider CQ support.
  */
 struct fid_peer_cq;

--- a/include/rdma/fi_ext.h
+++ b/include/rdma/fi_ext.h
@@ -271,6 +271,26 @@ struct fi_peer_srx_context {
 
 
 /*
+ * Peer transfers
+ */
+struct fi_peer_transfer_context;
+
+struct fi_ops_transfer_peer {
+	size_t size;
+	ssize_t	(*complete)(struct fid_ep *ep, struct fi_cq_tagged_entry *buf,
+			fi_addr_t *src_addr);
+	ssize_t	(*comperr)(struct fid_ep *ep, struct fi_cq_err_entry *buf);
+};
+
+struct fi_peer_transfer_context {
+	size_t size;
+	struct fi_info *info;
+	struct fid_ep *ep;
+	struct fi_ops_transfer_peer *peer_ops;
+};
+
+
+/*
  * System logging import extension:
  * To use, open logging fid and import.
  */

--- a/man/fi_peer.3.md
+++ b/man/fi_peer.3.md
@@ -71,6 +71,16 @@ similar, independent from the object being shared.  However, because the goal
 of using peer providers is to avoid overhead, providers must be explicitly
 written to support the peer provider mechanisms.
 
+There are two peer provider models.  In the example listed above, both peers
+are full providers in their own right and usable in a stand-alone fashion.
+In a second model, one of the peers is known as an offload provider.  An
+offload provider implements a subset of the libfabric API and targets the
+use of specific acceleration hardware.  For example, network
+switches may support collective operations, such as barrier or broadcast.  An
+offload provider may be written specifically to leverage this capability;
+however, such a provider is not usable for general purposes.  As a result,
+an offload provider is paired with a main peer provider.
+
 # PEER CQ
 
 The peer CQ defines a mechanism by which a peer provider may insert completions

--- a/man/fi_peer.3.md
+++ b/man/fi_peer.3.md
@@ -85,7 +85,7 @@ an offload provider is paired with a main peer provider.
 
 The peer CQ defines a mechanism by which a peer provider may insert completions
 into the CQ owned by another provider.  This avoids the overhead of the
-libfabric user from needing to access multiple CQs.
+libfabric user needing to access multiple CQs.
 
 To setup a peer CQ, a provider creates a fid_peer_cq object, which links
 back to the provider's actual fid_cq.  The fid_peer_cq object is then
@@ -182,6 +182,32 @@ on the local node.
    set to enosys calls.
 8. Provider B inserts its own callbacks into the peer_cq object.  It
    creates a reference between the peer_cq object and its own cq.
+```
+
+# PEER EQ
+
+The peer EQ defines a mechanism by which a peer provider may insert events
+into the EQ owned by another provider.  This avoids the overhead of the
+libfabric user needing to access multiple EQs.
+
+The setup of a peer EQ is similar to the setup for a peer CQ outline above.
+The owner's EQ object is imported directly into the peer provider.
+
+Peer EQs are configured by the owner calling the peer's fi_eq_open() call.
+The owner passes in the FI_PEER_EQ flag to fi_eq_open().  When
+FI_PEER_EQ is specified, the context parameter passed
+into fi_eq_open() must reference a struct fi_peer_eq_context.  Providers that
+do not support peer EQs must fail the fi_eq_open() call with -FI_EINVAL
+(indicating an invalid flag).  The fid_eq referenced by struct
+fi_peer_eq_context must remain valid until the peer's EQ is closed.
+
+The data structures to support peer EQs are defined as follows:
+
+```c
+struct fi_peer_eq_context {
+    size_t size;
+    struct fid_eq *eq;
+};
 ```
 
 # PEER SRX

--- a/man/fi_peer.3.md
+++ b/man/fi_peer.3.md
@@ -277,6 +277,32 @@ on the local node.
    creates a reference between the peer_cq object and its own cq.
 ```
 
+# PEER DOMAIN
+
+The peer domain allows a provider to access the operations of a domain
+object of its peer.  For example, an offload provider can use a peer
+domain to register memory buffers with the main provider.
+
+The setup of a peer domain is similar to the setup for a peer CQ outline
+above.  The owner's domain object is imported directly into the peer.
+
+Peer domains are configured by the owner calling the peer's fi_domain() call.
+The owner passes in the FI_PEER_DOMAIN flag to fi_domain().  When
+FI_PEER_DOMAIN is specified, the context parameter passed into fi_domain()
+must reference a struct fi_peer_domain_context.  Providers that do not
+support peer domains must fail the fi_domain() call with -FI_EINVAL.  The
+fid_domain referenced by struct fi_peer_domain_context must remain valid
+until the peer's domain is closed.
+
+The data structures to support peer domains are defined as follows:
+
+```c
+struct fi_peer_domain_context {
+	size_t size;
+	struct fid_domain *domain;
+};
+```
+
 # PEER EQ
 
 The peer EQ defines a mechanism by which a peer provider may insert events

--- a/prov/hook/dmabuf_peer_mem/src/hook_dmabuf_peer_mem.c
+++ b/prov/hook/dmabuf_peer_mem/src/hook_dmabuf_peer_mem.c
@@ -352,10 +352,9 @@ static int hook_dmabuf_peer_mem_fabric(struct fi_fabric_attr *attr,
         struct fi_provider *hprov = context;
         struct dmabuf_peer_mem_fabric *fab;
 	extern struct hook_prov_ctx hook_dmabuf_peer_mem_ctx;
-	struct fi_prov_context *ctx = (struct fi_prov_context *)&hprov->context;
 	int fd;
 
-	if (ctx->type != OFI_PROV_CORE) {
+	if (ofi_prov_ctx(hprov)->type != OFI_PROV_CORE) {
 		FI_TRACE(hprov, FI_LOG_FABRIC,
 			 "Skip installing dmabuf_peer_mem hook\n");
 		return -FI_EINVAL;

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -432,6 +432,8 @@ static void ofi_set_prov_type(struct fi_provider *provider)
 		ofi_prov_ctx(provider)->type = OFI_PROV_HOOK;
 	else if (ofi_has_util_prefix(provider->name))
 		ofi_prov_ctx(provider)->type = OFI_PROV_UTIL;
+	else if (ofi_has_offload_prefix(provider->name))
+		ofi_prov_ctx(provider)->type = OFI_PROV_OFFLOAD;
 	else
 		ofi_prov_ctx(provider)->type = OFI_PROV_CORE;
 }
@@ -966,7 +968,6 @@ static void ofi_set_prov_attr(struct fi_fabric_attr *attr,
 		attr->prov_name = ofi_strdup_append(core_name, prov->name);
 		free(core_name);
 	} else {
-		assert(ofi_is_core_prov(prov));
 		attr->prov_name = strdup(prov->name);
 	}
 	attr->prov_version = prov->version;
@@ -1098,6 +1099,10 @@ int DEFAULT_SYMVER_PRE(fi_getinfo)(uint32_t version, const char *node,
 			continue;
 
 		if (prov->hidden && !(flags & OFI_GETINFO_HIDDEN))
+			continue;
+
+		if ((ofi_prov_ctx(prov->provider)->type == OFI_PROV_OFFLOAD) &&
+		    !(flags & OFI_OFFLOAD_PROV_ONLY))
 			continue;
 
 		if (!ofi_layering_ok(prov->provider, prov_vec, count, flags))

--- a/src/log.c
+++ b/src/log.c
@@ -321,11 +321,9 @@ int DEFAULT_SYMVER_PRE(fi_log_enabled)(const struct fi_provider *prov,
 		enum fi_log_level level,
 		enum fi_log_subsys subsys)
 {
-	struct fi_prov_context *ctx;
 	uint64_t flags = 0;
 
-	ctx = (struct fi_prov_context *) &prov->context;
-	if (ctx->disable_logging)
+	if (ofi_prov_ctx(prov)->disable_logging)
 		flags |= FI_LOG_PROV_FILTERED;
 
 	return log_fid.ops->enabled(prov, level, subsys, flags);
@@ -337,11 +335,9 @@ int DEFAULT_SYMVER_PRE(fi_log_ready)(const struct fi_provider *prov,
 		enum fi_log_level level, enum fi_log_subsys subsys,
 		uint64_t *showtime)
 {
-	struct fi_prov_context *ctx;
 	uint64_t flags = 0;
 
-	ctx = (struct fi_prov_context *) &prov->context;
-	if (ctx->disable_logging)
+	if (ofi_prov_ctx(prov)->disable_logging)
 		flags |= FI_LOG_PROV_FILTERED;
 
 	return log_fid.ops->ready(prov, level, subsys, flags, showtime);


### PR DESCRIPTION
This is the first set of changes targeting the support of a provider that only supports collective offloads.  The peer definitions are generic, and not tied specifically to that use case, but should meet it.  The series adds the peer EQ, peer AV, a new peer data transfer flag/mode/feature, and introduces a new type of provider.

The new provider is called (for now) a function provider.  It requires special handling by the libfabric core, as it's not usable stand-alone, nor does it layer over another provider.

The peer eq and av are what one would expect based on the peer cq and srx structures.

The peer data transfer allows the function provider to send and receive data over the main provider's endpoint.  For example, the collective provider send messages between a remote collective provider.  The main provider is responsible for separating that traffic from application traffic.  (For example, by reserving and using a tag bit.)  The main provider must also route completions back to the function provider.

Before the design draft can be considered complete, a peer EP needs to be defined.  This is needed to allow the function provider to transmit peer transfers.  More thought is needed on this, but the definition will be added to this PR once done.