### PR TITLE
[v1.16.x] prov/efa: add missing efa header

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -75,6 +75,7 @@ _efa_headers = \
 	prov/efa/src/efa_user_info.h \
 	prov/efa/src/efa_prov_info.h \
 	prov/efa/src/efa_fork_support.h \
+	prov/efa/src/efa_cq.h \
 	prov/efa/src/rxr/rxr.h \
 	prov/efa/src/rxr/rxr_env.h \
 	prov/efa/src/rxr/rxr_cntr.h \


### PR DESCRIPTION
Cherry-picked from commit 825dff06ac52825e8c8693ebfd0c07ac9ebb0b3f

Signed-off-by: Alexia Ingerson <alexia.ingerson@intel.com>