### PR TITLE
prov/efa: fix the error handling path of efa_mr_reg_impl()

### DIFF
--- a/prov/efa/src/efa_mr.h
+++ b/prov/efa/src/efa_mr.h
@@ -60,6 +60,7 @@ struct efa_mr {
 	/* Used only in rdm */
 	struct fid_mr		*shm_mr;
 	struct efa_mr_peer	peer;
+	bool			inserted_to_mr_map;
 };
 
 extern int efa_mr_cache_enable;


### PR DESCRIPTION
efa_mr_reg_impl() upadte multiple resources. When
one of the resources was failed to be allocated,
the error handling path does not properly deallocate the allocated resources.

This patch address the issue.

Signed-off-by: Wei Zhang <wzam@amazon.com>