### PR TITLE
prov/efa: Refactor the req header size functions

### DIFF
--- a/prov/efa/src/efa_prov_info.c
+++ b/prov/efa/src/efa_prov_info.c
@@ -414,7 +414,7 @@ static int efa_prov_info_set_nic_attr(struct fi_info *prov_info, struct efa_devi
 		goto err_free;
 	}
 
-	link_attr->mtu = device->ibv_port_attr.max_msg_sz - rxr_pkt_max_header_size();
+	link_attr->mtu = device->ibv_port_attr.max_msg_sz - rxr_pkt_max_hdr_size();
 	link_attr->speed = ofi_vrb_speed(device->ibv_port_attr.active_speed,
 	                                 device->ibv_port_attr.active_width);
 
@@ -651,10 +651,10 @@ int efa_prov_info_alloc_for_rxr(struct fi_info **prov_info_rxr_ptr,
 		else
 			min_pkt_size = device->rdm_info->ep_attr->max_msg_size;
 
-		if (min_pkt_size < rxr_pkt_max_header_size()) {
+		if (min_pkt_size < rxr_pkt_max_hdr_size()) {
 			prov_info_rxr->tx_attr->inject_size = 0;
 		} else {
-			prov_info_rxr->tx_attr->inject_size = min_pkt_size - rxr_pkt_max_header_size();
+			prov_info_rxr->tx_attr->inject_size = min_pkt_size - rxr_pkt_max_hdr_size();
 		}
 
 		/*

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -2595,7 +2595,7 @@ int rxr_endpoint(struct fid_domain *domain, struct fi_info *info,
 	rxr_ep->core_inject_size = rdm_info->tx_attr->inject_size;
 	rxr_ep->max_msg_size = info->ep_attr->max_msg_size;
 	rxr_ep->msg_prefix_size = info->ep_attr->msg_prefix_size;
-	rxr_ep->max_proto_hdr_size = rxr_pkt_max_header_size();
+	rxr_ep->max_proto_hdr_size = rxr_pkt_max_hdr_size();
 	rxr_ep->mtu_size = rdm_info->ep_attr->max_msg_size;
 	fi_freeinfo(rdm_info);
 

--- a/prov/efa/src/rxr/rxr_op_entry.c
+++ b/prov/efa/src/rxr/rxr_op_entry.c
@@ -213,8 +213,8 @@ size_t rxr_tx_entry_max_req_data_capacity(struct rxr_ep *ep, struct rxr_op_entry
 	if (tx_entry->fi_flags & FI_REMOTE_CQ_DATA)
 		header_flags |= RXR_REQ_OPT_CQ_DATA_HDR;
 
-	max_data_offset = rxr_pkt_req_header_size(pkt_type, header_flags,
-						  tx_entry->rma_iov_count);
+	max_data_offset = rxr_pkt_req_hdr_size(pkt_type, header_flags,
+					       tx_entry->rma_iov_count);
 
 	if (rxr_pkt_type_is_runtread(pkt_type)) {
 		max_data_offset += tx_entry->iov_count * sizeof(struct fi_rma_iov);

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -327,7 +327,7 @@ size_t rxr_pkt_req_hdr_size_from_pkt_entry(struct rxr_pkt_entry *pkt_entry)
 
 	base_hdr = rxr_get_base_hdr(pkt_entry->pkt);
 	rma_iov_count = rxr_pkt_hdr_rma_iov_count(pkt_entry);
-	return rxr_pkt_req_header_size(base_hdr->type, base_hdr->flags, rma_iov_count);
+	return rxr_pkt_req_hdr_size(base_hdr->type, base_hdr->flags, rma_iov_count);
 }
 
 int64_t rxr_pkt_req_cq_data(struct rxr_pkt_entry *pkt_entry)
@@ -358,7 +358,7 @@ int64_t rxr_pkt_req_cq_data(struct rxr_pkt_entry *pkt_entry)
  * @return	The exact size of the packet header
  */
 inline
-size_t rxr_pkt_req_header_size(int pkt_type, uint16_t flags, size_t rma_iov_count)
+size_t rxr_pkt_req_hdr_size(int pkt_type, uint16_t flags, size_t rma_iov_count)
 {
 	int hdr_size = REQ_INF_LIST[pkt_type].base_hdr_size;
 
@@ -390,7 +390,7 @@ size_t rxr_pkt_req_header_size(int pkt_type, uint16_t flags, size_t rma_iov_coun
  * @param[in]	pkt_type	packet type
  * @return	The max possible size of the packet header
  */
-inline size_t rxr_pkt_req_max_header_size(int pkt_type)
+inline size_t rxr_pkt_req_max_hdr_size(int pkt_type)
 {
 	/* To calculate max REQ reader size, we should include all possible REQ opt header flags.
 	 * However, because the optional connid header and optional raw address header cannot
@@ -399,17 +399,17 @@ inline size_t rxr_pkt_req_max_header_size(int pkt_type)
 	 */
 	uint16_t header_flags = RXR_REQ_OPT_RAW_ADDR_HDR_SIZE | RXR_REQ_OPT_CQ_DATA_HDR;
 
-	return rxr_pkt_req_header_size(pkt_type, header_flags, RXR_IOV_LIMIT);
+	return rxr_pkt_req_hdr_size(pkt_type, header_flags, RXR_IOV_LIMIT);
 }
 
-size_t rxr_pkt_max_header_size(void)
+size_t rxr_pkt_max_hdr_size(void)
 {
 	size_t max_hdr_size = 0;
 	size_t pkt_type = RXR_REQ_PKT_BEGIN;
 
 	while (pkt_type < RXR_EXTRA_REQ_PKT_END) {
 		max_hdr_size = MAX(max_hdr_size,
-				rxr_pkt_req_max_header_size(pkt_type));
+				rxr_pkt_req_max_hdr_size(pkt_type));
 		if (pkt_type == RXR_BASELINE_REQ_PKT_END)
 			pkt_type = RXR_EXTRA_REQ_PKT_BEGIN;
 		else

--- a/prov/efa/src/rxr/rxr_pkt_type_req.h
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.h
@@ -54,13 +54,13 @@ size_t rxr_pkt_req_base_hdr_size(struct rxr_pkt_entry *pkt_entry);
 
 size_t rxr_pkt_req_data_size(struct rxr_pkt_entry *pkt_entry);
 
-size_t rxr_pkt_req_header_size(int pkt_type, uint16_t flags, size_t rma_iov_count);
+size_t rxr_pkt_req_hdr_size(int pkt_type, uint16_t flags, size_t rma_iov_count);
 
 uint32_t rxr_pkt_hdr_rma_iov_count(struct rxr_pkt_entry *pkt_entry);
 
-size_t rxr_pkt_req_max_header_size(int pkt_type);
+size_t rxr_pkt_req_max_hdr_size(int pkt_type);
 
-size_t rxr_pkt_max_header_size(void);
+size_t rxr_pkt_max_hdr_size(void);
 
 static inline
 struct rxr_rtm_base_hdr *rxr_get_rtm_base_hdr(void *pkt)

--- a/prov/efa/src/rxr/rxr_pkt_type_req.h
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.h
@@ -48,7 +48,7 @@ int64_t rxr_pkt_req_cq_data(struct rxr_pkt_entry *pkt_entry);
 
 uint32_t *rxr_pkt_req_connid_ptr(struct rxr_pkt_entry *pkt_entry);
 
-size_t rxr_pkt_req_hdr_size(struct rxr_pkt_entry *pkt_entry);
+size_t rxr_pkt_req_hdr_size_from_pkt_entry(struct rxr_pkt_entry *pkt_entry);
 
 size_t rxr_pkt_req_base_hdr_size(struct rxr_pkt_entry *pkt_entry);
 

--- a/prov/efa/src/rxr/rxr_pkt_type_req.h
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.h
@@ -56,6 +56,8 @@ size_t rxr_pkt_req_data_size(struct rxr_pkt_entry *pkt_entry);
 
 size_t rxr_pkt_req_header_size(int pkt_type, uint16_t flags, size_t rma_iov_count);
 
+uint32_t rxr_pkt_hdr_rma_iov_count(struct rxr_pkt_entry *pkt_entry);
+
 size_t rxr_pkt_req_max_header_size(int pkt_type);
 
 size_t rxr_pkt_max_header_size(void);


### PR DESCRIPTION
Currently, both `rxr_pkt_req_hdr_size` and `rxr_pkt_req_header_size` in `rxr_pkt_type_req.c`  calculate the header size of REQ packets and have considerable code duplication. This PR did some refactors in `rxr_pkt_type_req.c` to remove the code duplication and rename the functions to make them more intuitive.