### PR TITLE
prov/net: remove fd hotlist support

### DIFF
--- a/fabtests/test_configs/net/net.exclude
+++ b/fabtests/test_configs/net/net.exclude
@@ -23,5 +23,18 @@ trigger
 
 # tests assume an unexpected msg queue
 # provider does not queue unexpected msgs
-rdm_tagged_peek
 unexpected_msg
+
+
+# prefix mode not supported
+-k
+
+# shared context tests need to be evaluated for support
+# some subset may be supported, but do not currently work
+shared_ctx
+
+# multi_recv not supported by standard msg endpoints
+multi_recv -e msg
+
+# collective offload not supported
+fi_multinode_coll

--- a/prov/net/src/xnet_cm.c
+++ b/prov/net/src/xnet_cm.c
@@ -273,13 +273,8 @@ void xnet_connect_done(struct xnet_ep *ep)
 
 	ep->state = XNET_REQ_SENT;
 	ep->pollflags = POLLIN;
-	ofi_dynpoll_mod(&progress->allfds, ep->bsock.sock,
+	ofi_dynpoll_mod(&progress->epoll_fd, ep->bsock.sock,
 			ep->pollflags, &ep->util_ep.ep_fid.fid);
-	if (progress->hotfds.type) {
-		assert(!dlist_empty(&ep->hot_entry));
-		ofi_dynpoll_mod(&progress->hotfds, ep->bsock.sock,
-				ep->pollflags, &ep->util_ep.ep_fid.fid);
-	}
 	xnet_signal_progress(progress);
 	return;
 

--- a/prov/net/src/xnet_ep.c
+++ b/prov/net/src/xnet_ep.c
@@ -150,11 +150,6 @@ int xnet_setup_socket(SOCKET sock, struct fi_info *info)
 
 static int xnet_monitor_ep(struct xnet_progress *progress, struct xnet_ep *ep)
 {
-	if (progress->hotfds.type) {
-		assert(dlist_empty(&ep->hot_entry));
-		dlist_insert_tail(&ep->hot_entry, &progress->hot_list);
-	}
-
 	return xnet_monitor_sock(progress, ep->bsock.sock, ep->pollflags,
 				 &ep->util_ep.ep_fid.fid);
 }
@@ -331,7 +326,6 @@ void xnet_ep_disable(struct xnet_ep *ep, int cm_err, void* err_data,
 	};
 
 	dlist_remove_init(&ep->unexp_entry);
-	dlist_remove_init(&ep->hot_entry);
 	xnet_halt_sock(xnet_ep2_progress(ep), ep->bsock.sock);
 
 	ret = ofi_shutdown(ep->bsock.sock, SHUT_RDWR);
@@ -486,7 +480,6 @@ static int xnet_ep_close(struct fid *fid)
 	progress = xnet_ep2_progress(ep);
 	ofi_genlock_lock(&progress->lock);
 	dlist_remove_init(&ep->unexp_entry);
-	dlist_remove_init(&ep->hot_entry);
 	xnet_halt_sock(progress, ep->bsock.sock);
 	xnet_ep_flush_all_queues(ep);
 	ofi_genlock_unlock(&progress->lock);
@@ -693,7 +686,6 @@ int xnet_endpoint(struct fid_domain *domain, struct fi_info *info,
 	}
 
 	dlist_init(&ep->unexp_entry);
-	dlist_init(&ep->hot_entry);
 	slist_init(&ep->rx_queue);
 	slist_init(&ep->tx_queue);
 	slist_init(&ep->priority_queue);

--- a/prov/net/src/xnet_init.c
+++ b/prov/net/src/xnet_init.c
@@ -63,8 +63,6 @@ int xnet_prefetch_rbuf_size = 9000;
 size_t xnet_default_tx_size = 256;
 size_t xnet_default_rx_size = 256;
 size_t xnet_zerocopy_size = SIZE_MAX;
-int xnet_poll_fairness = 0;
-int xnet_poll_cooldown = 0;
 int xnet_disable_autoprog;
 
 
@@ -134,22 +132,6 @@ static void xnet_init_env(void)
 	fi_param_get_int(&xnet_prov, "prefetch_rbuf_size",
 			 &xnet_prefetch_rbuf_size);
 	fi_param_get_size_t(&xnet_prov, "zerocopy_size", &xnet_zerocopy_size);
-
-	fi_param_define(&xnet_prov, "poll_fairness", FI_PARAM_INT,
-			"This counter value balances calling poll() on a list "
-			"of sockets marked as active, versus all sockets being "
-			"monitored.  This variable controls the number of times "
-			"that the active sockets are checked before the full "
-			"set is.  A value of 0 disables the active "
-			"list.  Default (%d)", xnet_poll_fairness);
-	fi_param_get_int(&xnet_prov, "poll_fairness", &xnet_poll_fairness);
-	fi_param_define(&xnet_prov, "poll_cooldown", FI_PARAM_INT,
-			"This value only applies if poll_fairness is active. "
-			"This determines the number of iterations that a socket "
-			"will remain marked as active without receiving data "
-			"before being removed from the active set. "
-			"Default (%d)", xnet_poll_cooldown);
-	fi_param_get_int(&xnet_prov, "poll_cooldown", &xnet_poll_cooldown);
 
 	fi_param_define(&xnet_prov, "disable_auto_progress", FI_PARAM_BOOL,
 			"prevent auto-progress thread from starting");

--- a/prov/net/src/xnet_srx.c
+++ b/prov/net/src/xnet_srx.c
@@ -370,12 +370,9 @@ xnet_srx_tag(struct xnet_srx *srx, struct xnet_xfer_entry *recv_entry)
 		slist_insert_tail(&recv_entry->entry, queue);
 
 		ep = xnet_get_ep(srx->rdm, recv_entry->src_addr);
-		if (ep) {
-			xnet_active_ep(ep);
-			if (xnet_has_unexp(ep)) {
-				assert(!dlist_empty(&ep->unexp_entry));
-				xnet_progress_rx(ep);
-			}
+		if (ep && xnet_has_unexp(ep)) {
+			assert(!dlist_empty(&ep->unexp_entry));
+			xnet_progress_rx(ep);
 		}
 	}
 


### PR DESCRIPTION
the fd hotlist features did not prove to perform noticeably better than epoll alone, so these changes clean up that code