### PR TITLE
contrib/intel/jenkins: add CI support for net provider

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -31,6 +31,7 @@ env:
     --enable-rxm
     --enable-shm
     --enable-tcp
+    --enable-net
     --enable-udp
     --enable-usnic
     --enable-verbs=$PWD/rdma-core/build

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -369,6 +369,8 @@ pipeline {
                   echo "tcp-rxm MPICH testsuite completed."
                   python3.7 runtests.py --prov=sockets --test=mpichtestsuite
                   echo "sockets MPICH testsuite completed."
+                  python3.7 runtests.py --prov=net --test=mpichtestsuite
+                  echo "net MPICH testsuite completed."
                   echo "MPICH testsuite completed."
                 )
               """
@@ -386,6 +388,8 @@ pipeline {
                   cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
                   python3.7 runtests.py --prov=tcp --test=shmem
                   echo "SHMEM tcp completed."
+                  python3.7 runtests.py --prov=net --test=shmem
+                  echo "SHMEM net completed."
                   python3.7 runtests.py --prov=verbs --test=shmem
                   echo "SHMEM verbs completed."
                   python3.7 runtests.py --prov=sockets --test=shmem
@@ -424,6 +428,8 @@ pipeline {
                   cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
                   python3.7 runtests.py --prov=tcp --util=rxm --test=oneccl
                   echo "oneCCL tcp-rxm completed."
+                  python3.7 runtests.py --prov=net --test=oneccl
+                  echo "oneCCL net completed."
                   python3.7 runtests.py --prov=psm3 --test=oneccl
                   echo "oneCCL psm3 completed."
                   echo "OneCCL completed."
@@ -442,6 +448,9 @@ pipeline {
                 (
                   cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
                   python3.7 runtests.py --prov=tcp --test=onecclgpu
+                  echo "oneCCL-GPU tcp completed."
+                  python3.7 runtests.py --prov=net --test=onecclgpu
+                  echo "oneCCL-GPU net completed."
                   echo "oneCCL-GPU completed."
                 )
               """
@@ -514,6 +523,106 @@ pipeline {
             }
           }
         }
+        stage('net-fabtests') {
+          agent {node {label 'cvl'}}
+          options { skipDefaultCheckout() }
+          steps {
+            withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
+              sh """
+                env
+                (
+                  cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  python3.7 runtests.py --prov=net --test=fabtests
+                  python3.7 runtests.py --prov=net --test=fabtests --ofi_build_mode=dbg
+                  python3.7 runtests.py --prov=net --test=fabtests --ofi_build_mode=dl
+                  echo "net completed."
+                )
+              """
+            }
+          }
+        }
+        // separate imb tests into 3 stages rather than 1 to hopefully run in parallel
+        stage('MPI_net-1') {
+          agent {node {label 'cvl'}}
+          options { skipDefaultCheckout() }
+          steps {
+            withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
+              sh """
+                env
+                (
+                  cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  python3.7 runtests.py --prov=net --test=IMB --imb_grp=1
+                  echo "MPI_net Group 1 completed."
+                )
+              """
+            }
+          }
+        }
+        stage('MPI_net-2') {
+          agent {node {label 'cvl'}}
+          options { skipDefaultCheckout() }
+          steps {
+            withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
+              sh """
+                env
+                (
+                  cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  python3.7 runtests.py --prov=net --test=IMB --imb_grp=2
+                  echo "MPI_net Group 2 completed."
+                )
+              """
+            }
+          }
+        }
+        stage('MPI_net-3') {
+          agent {node {label 'cvl'}}
+          options { skipDefaultCheckout() }
+          steps {
+            withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
+              sh """
+                env
+                (
+                  cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  python3.7 runtests.py --prov=net --test=IMB --imb_grp=3
+                  echo "MPI_net Group 3 completed."
+                )
+              """
+            }
+          }
+        }
+        stage('net-osu') {
+          agent {node {label 'cvl'}}
+          options { skipDefaultCheckout() }
+          steps {
+            withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
+              sh """
+                env
+                (
+                  cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  python3.7 runtests.py --prov=net --test=osu
+                  echo "MPI-net-osu completed."
+                )
+              """
+            }
+          }
+        }
+        stage('multinode-net-performance') {
+          agent {node {label 'cvl'}}
+          options { skipDefaultCheckout() }
+          steps {
+              withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
+              {
+                sh """
+                  env
+                  (
+                      cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                      python3.7 runtests.py --prov=net --test=multinode
+                      echo "multinode performance completed."
+                  )
+                """
+              }
+          }
+        }
       }
     }
     stage ('Summary') {
@@ -579,11 +688,11 @@ pipeline {
     success {
       node ('daos') {
         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
-	  dir ("${env.DAOS_CLUSTER_HOME}/avocado") {
+          dir ("${env.DAOS_CLUSTER_HOME}/avocado") {
             deleteDir()
           }
         }
-      } 
+      }
     }
   }
 }

--- a/contrib/intel/jenkins/common.py
+++ b/contrib/intel/jenkins/common.py
@@ -49,6 +49,7 @@ prov_list = [
    Prov('verbs', 'rxm'),
    Prov('sockets', None),
    Prov('tcp', None),
+   Prov('net', None),
    Prov('udp', None),
    Prov('udp', 'rxd'),
    Prov('shm', None),
@@ -56,6 +57,7 @@ prov_list = [
 default_prov_list = [
     'verbs',
     'tcp',
+    'net',
     'sockets',
     'udp',
     'shm',
@@ -63,7 +65,8 @@ default_prov_list = [
 ]
 daos_prov_list = [
     'verbs',
-    'tcp'
+    'tcp',
+    'net'
 ]
 dsa_prov_list = [
     'shm'

--- a/contrib/intel/jenkins/run.py
+++ b/contrib/intel/jenkins/run.py
@@ -199,10 +199,10 @@ def oneccltestgpu(core, hosts, mode, user_env, run_test, util):
 
 def daos_cart_tests(core, hosts, mode, user_env, run_test, util):
 
-    runcarttests = tests.DaosCartTest(jobname=jbname, buildno=bno, 
-                                      testname="Daos Cart Test", core_prov=core, 
-                                      fabric=fab, hosts=hosts, 
-                                      ofi_build_mode=mode, user_env=user_env, 
+    runcarttests = tests.DaosCartTest(jobname=jbname, buildno=bno,
+                                      testname="Daos Cart Test", core_prov=core,
+                                      fabric=fab, hosts=hosts,
+                                      ofi_build_mode=mode, user_env=user_env,
                                       run_test=run_test, util_prov=util)
 
     print('-------------------------------------------------------------------')

--- a/contrib/intel/jenkins/runtests.py
+++ b/contrib/intel/jenkins/runtests.py
@@ -9,7 +9,7 @@ import common
 parser = argparse.ArgumentParser()
 
 parser.add_argument('--prov', help="core provider", choices=['verbs', \
-                     'tcp', 'udp', 'sockets', 'shm', 'psm3'])
+                     'tcp', 'udp', 'sockets', 'shm', 'psm3', 'net'])
 parser.add_argument('--util', help="utility provider", choices=['rxd', 'rxm'])
 parser.add_argument('--ofi_build_mode', help="specify the build configuration", \
                     choices = ['dbg', 'dl'], default='reg')
@@ -48,6 +48,7 @@ else:
 
 node = (os.environ['NODE_NAME']).split('_')[0]
 hosts = [node]
+
 mpilist = ['impi', 'mpich', 'ompi']
 
 #this script is executed from /tmp
@@ -82,6 +83,7 @@ if(args_core):
 
             if (run_test == 'all' or run_test == 'daos'):
                 run.daos_cart_tests(args_core, hosts, ofi_build_mode, user_env, run_test, args_util)
+
             if (run_test == 'all' or run_test == 'multinode'):
                 run.multinodetest(args_core, hosts, ofi_build_mode, user_env, run_test, args_util)
 

--- a/contrib/intel/jenkins/summary.py
+++ b/contrib/intel/jenkins/summary.py
@@ -60,7 +60,7 @@ def summarize_fi_info(log_dir, prov, build_mode):
         passes += 1
 
     print_results(f"{prov} fabtests {build_mode}", passes, fails, failed_tests)
-    
+
     log.close()
     return int(fails)
 
@@ -378,7 +378,7 @@ def summarize_osu(log_dir, prov, mpi, build_mode=None):
             name = " ".join(tokens[tokens.index('OSU') + 1:tokens.index('Test')])
             test_type = tokens[1]
             passes += 1
-        
+
         if "exiting with" in line:
             fails += 1
             failed_tests.append(f"{test_type} {name}")
@@ -387,7 +387,7 @@ def summarize_osu(log_dir, prov, mpi, build_mode=None):
         line = log.readline()
 
     print_results(f"{prov} {mpi} OSU {build_mode}", passes, fails, failed_tests)
-    
+
     log.close()
     return int(fails)
 
@@ -444,7 +444,7 @@ if __name__ == "__main__":
 
         if summary_item == 'mpichtestsuite' or summary_item == 'all':
             for mpi in mpi_list:
-                for item in ['tcp-rxm', 'verbs-rxm']:
+                for item in ['tcp-rxm', 'verbs-rxm', 'net']:
                     ret = summarize_imb(log_dir, item, mpi, mode)
                     err += ret if ret else 0
 

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -396,9 +396,9 @@ class MPICH:
     def env(self):
         cmd = "bash -c \'"
         if (self.util_prov):
-            cmd += f"export FI_PROVIDER={self.core_prov}; "
-        else:
             cmd += f"export FI_PROVIDER={self.core_prov}\\;{self.util_prov}; "
+        else:
+            cmd += f"export FI_PROVIDER={self.core_prov}; "
         cmd += "export I_MPI_FABRICS=ofi; "
         cmd += "export MPIR_CVAR_CH4_OFI_ENABLE_ATOMICS=0; "
         cmd += "export MPIR_CVAR_CH4_OFI_CAPABILITY_SETS_DEBUG=1; "

--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -94,6 +94,8 @@ nobase_dist_config_DATA = \
 	test_configs/osx.exclude \
         test_configs/eq_cq.test \
         test_configs/lat_bw.test \
+	test_configs/net/all.test \
+	test_configs/net/net.exclude \
         test_configs/sockets/all.test \
         test_configs/sockets/quick.test \
 	test_configs/sockets/complete.test \


### PR DESCRIPTION
The intent is to match the current TCP validations and to eventually merge the two.
It is understood that this will increase runtimes.