### PR TITLE
fabtests/psm3: disable multinode test

### DIFF
--- a/fabtests/test_configs/psm3/psm3.exclude
+++ b/fabtests/test_configs/psm3/psm3.exclude
@@ -18,3 +18,4 @@ multi_recv
 rdm_tagged_peek
 dgram_waitset
 cq_data
+multinode


### PR DESCRIPTION
psm3 is showing transient failures with the multinode test. Will re-enable once issue #8090 is resolved.

Signed-off-by: Alexia Ingerson <alexia.ingerson@intel.com>