### PR TITLE
fabtests/common: close mr before closing ep for FI_MR_ENDPOINT only

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -1617,8 +1617,12 @@ static void ft_close_fids(void)
 {
 	FT_CLOSE_FID(mc);
 	FT_CLOSE_FID(alias_ep);
-	if (mr != &no_mr)
-		FT_CLOSE_FID(mr);
+	if (fi && fi->domain_attr->mr_mode & FI_MR_ENDPOINT) {
+		if (mr != &no_mr) {
+			FT_CLOSE_FID(mr);
+			mr = &no_mr;
+		}
+	}
 	FT_CLOSE_FID(ep);
 	FT_CLOSE_FID(pep);
 	if (opts.options & FT_OPT_CQ_SHARED) {
@@ -1630,6 +1634,8 @@ static void ft_close_fids(void)
 	FT_CLOSE_FID(rxcntr);
 	FT_CLOSE_FID(txcntr);
 	FT_CLOSE_FID(pollset);
+	if (mr != &no_mr)
+		FT_CLOSE_FID(mr);
 	FT_CLOSE_FID(av);
 	FT_CLOSE_FID(srx);
 	FT_CLOSE_FID(stx);


### PR DESCRIPTION
In commit 1b12e5caa, mr close is moved before the ep close unconditionally. For non-FI_MR_ENDPOINT case, it is not safe to close mr before closing ep as the mr may still be used during ep finalization. This patch makes ft_free_res close mr before closing ep only when mr mode is FI_MR_ENDPOINT.

Signed-off-by: Shi Jin <sjina@amazon.com>