### PR TITLE
[v1.15.x] prov/efa: flush MR cache when fork() is called and fork support is ON

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -172,7 +172,10 @@ struct efa_domain {
 	struct efa_qp		**qp_table;
 	size_t			qp_table_sz_m1;
 	struct efa_hmem_info	hmem_info[OFI_HMEM_MAX];
+	struct dlist_entry	list_entry; /* linked to g_efa_domain_list */
 };
+
+extern struct dlist_entry g_efa_domain_list;
 
 /**
  * @brief get a pointer to struct efa_domain from a domain_fid

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -42,6 +42,8 @@ struct efa_pd *pd_list = NULL;
 
 enum efa_fork_support_status efa_fork_status = EFA_FORK_SUPPORT_OFF;
 
+struct dlist_entry g_efa_domain_list;
+
 static int efa_domain_close(fid_t fid)
 {
 	struct efa_domain *domain;
@@ -50,6 +52,8 @@ static int efa_domain_close(fid_t fid)
 
 	domain = container_of(fid, struct efa_domain,
 			      util_domain.domain_fid.fid);
+
+	dlist_remove(&domain->list_entry);
 
 	if (efa_is_cache_available(domain)) {
 		ofi_mr_cache_cleanup(domain->cache);
@@ -242,7 +246,7 @@ static struct fi_ops_domain efa_domain_ops = {
  * running on an EC2 instance.
  */
 static
-void efa_atfork_callback()
+void efa_atfork_callback_warn_and_abort()
 {
 	static int visited = 0;
 
@@ -276,6 +280,29 @@ void efa_atfork_callback()
 		"\n"
 		"Your job will now abort.\n");
 	abort();
+}
+
+/**
+ * @brief flush all MR caches
+ *
+ * Going through all domains, and flush the MR caches in them
+ * until all inactive MRs are de-registered.
+ * This makes all memory regions that are not actively used
+ * in data transfer visible to the child process.
+ */
+void efa_atfork_callback_flush_mr_cache()
+{
+	struct dlist_entry *tmp;
+	struct efa_domain *efa_domain;
+	bool flush_lru = true;
+
+	dlist_foreach_container_safe(&g_efa_domain_list,
+				     struct efa_domain,
+				     efa_domain, list_entry, tmp) {
+		if (efa_domain->cache) {
+			while(ofi_mr_cache_flush(efa_domain->cache, flush_lru));
+		}
+	}
 }
 
 #ifndef _WIN32
@@ -335,8 +362,14 @@ int efa_initialize_fork_support(struct fid_domain* domain_fid)
 	 * fork check above. This can move to the provider init once that check
 	 * is gone.
 	 */
-	if (!fork_handler_installed && efa_fork_status == EFA_FORK_SUPPORT_OFF) {
-		ret = pthread_atfork(efa_atfork_callback, NULL, NULL);
+	if (!fork_handler_installed && efa_fork_status != EFA_FORK_SUPPORT_UNNEEDED) {
+		if (efa_fork_status == EFA_FORK_SUPPORT_OFF) {
+			ret = pthread_atfork(efa_atfork_callback_warn_and_abort, NULL, NULL);
+		} else {
+			assert(efa_fork_status == EFA_FORK_SUPPORT_ON);
+			ret = pthread_atfork(efa_atfork_callback_flush_mr_cache, NULL, NULL);
+		}
+
 		if (ret) {
 			EFA_WARN(FI_LOG_DOMAIN,
 				 "Unable to register atfork callback: %s\n",
@@ -659,6 +692,8 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 	if (!domain)
 		return -FI_ENOMEM;
 
+	dlist_init(&domain->list_entry);
+
 	qp_table_size = roundup_power_of_two(info->domain_attr->ep_cnt);
 	domain->qp_table_sz_m1 = qp_table_size - 1;
 	domain->qp_table = calloc(qp_table_size, sizeof(*domain->qp_table));
@@ -741,6 +776,7 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 			goto err_free_info;
 	}
 
+	dlist_insert_tail(&domain->list_entry, &g_efa_domain_list);
 	return 0;
 err_free_info:
 	fi_freeinfo(domain->info);

--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -1162,5 +1162,6 @@ static int efa_init_info(const struct fi_info **all_infos)
 
 int efa_init_prov(void)
 {
+	dlist_init(&g_efa_domain_list);
 	return efa_init_info(&efa_util_prov.info);
 }


### PR DESCRIPTION
When fork support is on, register memory regions was not copied to child processes's memory space.

With MR cache turned on, the registered memory regions remain registered after EFA finished send data from it.

As a result, when both fork support and MR cache are turned on, child processes cannot access some memory they need.

This patch addresses the issue by flush the MR cache when fork is called. Flushing MR cache will cause any memory region that is not actively being used (use_cnt == 0) to be de-registered, therefore they will be copied to child process's memory space

Signed-off-by: Wei Zhang <wzam@amazon.com>

(cherry-picked from 5242e5bf5)