### PR TITLE
prov/efa: simplified emulated read protocol

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -387,10 +387,7 @@ struct rxr_ep {
 #endif
 
 	/* datastructure to maintain rxr send/recv states */
-	struct ofi_bufpool *tx_entry_pool;
-	struct ofi_bufpool *rx_entry_pool;
-	/* datastructure to maintain read response */
-	struct ofi_bufpool *readrsp_tx_entry_pool;
+	struct ofi_bufpool *op_entry_pool;
 	/* data structure to maintain read */
 	struct ofi_bufpool *read_entry_pool;
 	/* data structure to maintain pkt rx map */
@@ -422,8 +419,9 @@ struct rxr_ep {
 	struct dlist_entry rx_entry_queued_ctrl_list;
 	/* rx entries with queued rnr packets */
 	struct dlist_entry rx_entry_queued_rnr_list;
-	/* tx_entries with data to be sent (large messages) */
-	struct dlist_entry tx_pending_list;
+	/* tx/rx_entries used by long CTS msg/write/read protocol
+         * which have data to be sent */
+	struct dlist_entry op_entry_longcts_send_list;
 	/* read entries with data to be read */
 	struct dlist_entry read_pending_list;
 	/* rxr_peer entries that are in backoff due to RNR */
@@ -432,10 +430,11 @@ struct rxr_ep {
 	struct dlist_entry handshake_queued_peer_list;
 
 #if ENABLE_DEBUG
-	/* rx_entries waiting for data to arrive (large messages) */
-	struct dlist_entry rx_pending_list;
-	/* count of rx_pending_list */
-	size_t rx_pending;
+	/* tx/rx_entries waiting to receive data in 
+         * long CTS msg/read/write protocols */
+	struct dlist_entry op_entry_recv_list;
+	/* counter tracking op_entry_recv_list */
+	size_t pending_recv_counter;
 
 	/* rx packets being processed or waiting to be processed */
 	struct dlist_entry rx_pkt_list;
@@ -529,7 +528,7 @@ struct rxr_tx_entry *rxr_ep_alloc_tx_entry(struct rxr_ep *rxr_ep,
 					   uint64_t tag,
 					   uint64_t flags);
 
-void rxr_release_tx_entry(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry);
+void rxr_release_tx_entry(struct rxr_ep *ep, struct rxr_op_entry *tx_entry);
 
 struct rxr_rx_entry *rxr_ep_alloc_rx_entry(struct rxr_ep *ep,
 					   fi_addr_t addr, uint32_t op);
@@ -640,15 +639,15 @@ void rxr_cq_queue_rnr_pkt(struct rxr_ep *ep,
 void rxr_cq_write_rx_completion(struct rxr_ep *ep,
 				struct rxr_rx_entry *rx_entry);
 
-void rxr_cq_complete_rx(struct rxr_ep *ep,
-			struct rxr_rx_entry *rx_entry,
-			bool post_ctrl, int ctrl_type);
+void rxr_cq_complete_recv(struct rxr_ep *ep,
+			  struct rxr_op_entry *op_entry,
+			  bool post_ctrl, int ctrl_type);
 
 void rxr_cq_write_tx_completion(struct rxr_ep *ep,
-				struct rxr_tx_entry *tx_entry);
+				struct rxr_op_entry *tx_entry);
 
-void rxr_cq_handle_tx_completion(struct rxr_ep *ep,
-				 struct rxr_tx_entry *tx_entry);
+void rxr_cq_handle_send_completion(struct rxr_ep *ep,
+				   struct rxr_op_entry *op_entry);
 
 void rxr_cq_handle_shm_completion(struct rxr_ep *ep,
 				  struct fi_cq_data_entry *cq_entry,

--- a/prov/efa/src/rxr/rxr_atomic.c
+++ b/prov/efa/src/rxr/rxr_atomic.c
@@ -82,7 +82,7 @@ rxr_atomic_alloc_tx_entry(struct rxr_ep *rxr_ep,
 		return NULL;
 	}
 
-	tx_entry = ofi_buf_alloc(rxr_ep->tx_entry_pool);
+	tx_entry = ofi_buf_alloc(rxr_ep->op_entry_pool);
 	if (OFI_UNLIKELY(!tx_entry)) {
 		FI_DBG(&rxr_prov, FI_LOG_EP_CTRL, "TX entries exhausted.\n");
 		return NULL;
@@ -219,6 +219,7 @@ ssize_t rxr_atomic_generic_efa(struct rxr_ep *rxr_ep,
 	}
 
 	if (OFI_UNLIKELY(err)) {
+		rxr_ep_progress_internal(rxr_ep);
 		rxr_release_tx_entry(rxr_ep, tx_entry);
 		peer->next_msg_id--;
 	}

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -320,6 +320,7 @@ ssize_t rxr_msg_generic_send(struct fid_ep *ep, const struct fi_msg *msg,
 	tx_entry->msg_id = peer->next_msg_id++;
 	err = rxr_msg_post_rtm(rxr_ep, tx_entry, use_p2p);
 	if (OFI_UNLIKELY(err)) {
+		rxr_ep_progress_internal(rxr_ep);
 		rxr_release_tx_entry(rxr_ep, tx_entry);
 		peer->next_msg_id--;
 	}

--- a/prov/efa/src/rxr/rxr_op_entry.h
+++ b/prov/efa/src/rxr/rxr_op_entry.h
@@ -128,8 +128,6 @@ struct rxr_op_entry {
 
 	size_t rma_iov_count;
 	struct fi_rma_iov rma_iov[RXR_IOV_LIMIT];
-	uint64_t rma_loc_rx_id;
-	uint64_t rma_window;
 
 	struct fi_cq_tagged_entry cq_entry;
 
@@ -164,20 +162,11 @@ struct rxr_op_entry {
 	uint64_t bytes_copied;
 	uint64_t bytes_queued_blocking_copy;
 
-	/* In emulated read protocol, rma_loc_tx_id is the tx_id of
-	 * the tx_entry on the read responder
-	 */
-	uint32_t rma_loc_tx_id;
-	/* In emulated read protocol, rm_initiator_rx_id the rx_id of
-	 * the rx_entry on the read initator.
-	 */
-	uint32_t rma_initiator_rx_id;
-
 	/* linked to peer->rx_unexp_list or peer->rx_unexp_tagged_list */
 	struct dlist_entry peer_unexp_entry;
 #if ENABLE_DEBUG
-	/* linked with rx_pending_list in rxr_ep */
-	struct dlist_entry rx_pending_entry;
+	/* linked with op_entry_recv_list in rxr_ep */
+	struct dlist_entry pending_recv_entry;
 #endif
 
 	size_t efa_outstanding_tx_ops; 

--- a/prov/efa/src/rxr/rxr_pkt_type.h
+++ b/prov/efa/src/rxr/rxr_pkt_type.h
@@ -91,7 +91,7 @@ void rxr_pkt_calc_cts_window_credits(struct rxr_ep *ep, struct rdm_peer *peer,
 				     int *window, int *credits);
 
 ssize_t rxr_pkt_init_cts(struct rxr_ep *ep,
-			 struct rxr_rx_entry *rx_entry,
+			 struct rxr_op_entry *op_entry,
 			 struct rxr_pkt_entry *pkt_entry);
 
 void rxr_pkt_handle_cts_sent(struct rxr_ep *ep,
@@ -107,14 +107,14 @@ struct rxr_data_hdr *rxr_get_data_hdr(void *pkt)
 }
 
 int rxr_pkt_init_data(struct rxr_ep *ep,
-		      struct rxr_tx_entry *tx_entry,
+		      struct rxr_op_entry *op_entry,
 		      struct rxr_pkt_entry *pkt_entry);
 
 void rxr_pkt_handle_data_sent(struct rxr_ep *ep,
 			      struct rxr_pkt_entry *pkt_entry);
 
 void rxr_pkt_proc_data(struct rxr_ep *ep,
-		       struct rxr_rx_entry *rx_entry,
+		       struct rxr_op_entry *op_entry,
 		       struct rxr_pkt_entry *pkt_entry,
 		       char *data, size_t seg_offset,
 		       size_t seg_size);
@@ -132,7 +132,7 @@ static inline struct rxr_readrsp_hdr *rxr_get_readrsp_hdr(void *pkt)
 }
 
 int rxr_pkt_init_readrsp(struct rxr_ep *ep,
-			 struct rxr_tx_entry *tx_entry,
+			 struct rxr_op_entry *tx_entry,
 			 struct rxr_pkt_entry *pkt_entry);
 
 void rxr_pkt_handle_readrsp_sent(struct rxr_ep *ep,

--- a/prov/efa/src/rxr/rxr_pkt_type_base.h
+++ b/prov/efa/src/rxr/rxr_pkt_type_base.h
@@ -38,14 +38,14 @@
 
 uint32_t *rxr_pkt_connid_ptr(struct rxr_pkt_entry *pkt_entry);
 
-int rxr_pkt_init_data_from_tx_entry(struct rxr_ep *ep,
+int rxr_pkt_init_data_from_op_entry(struct rxr_ep *ep,
 				    struct rxr_pkt_entry *pkt_entry,
 				    size_t pkt_data_offset,
-				    struct rxr_tx_entry *tx_entry,
-				    size_t tx_data_offset,
+				    struct rxr_op_entry *op_entry,
+				    size_t op_data_offset,
 				    size_t data_size);
 
-ssize_t rxr_pkt_copy_data_to_rx_entry(struct rxr_ep *ep,
+ssize_t rxr_pkt_copy_data_to_op_entry(struct rxr_ep *ep,
 				      struct rxr_rx_entry *rx_entry,
 				      size_t data_offset,
 				      struct rxr_pkt_entry *pkt_entry,

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -453,7 +453,8 @@ int rxr_pkt_init_rtm(struct rxr_ep *ep,
 			data_size &= ~(CUDA_MEMORY_ALIGNMENT -1);
 	}
 
-	ret = rxr_pkt_init_data_from_tx_entry(ep, pkt_entry, rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry),
+
+	ret = rxr_pkt_init_data_from_op_entry(ep, pkt_entry, rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry),
 					      tx_entry, data_offset, data_size);
 	return ret;
 }
@@ -796,7 +797,7 @@ ssize_t rxr_pkt_init_runtread_rtm(struct rxr_ep *ep,
 	if (tx_entry->max_req_data_size && data_size > tx_entry->max_req_data_size)
 		data_size = tx_entry->max_req_data_size;
 
-	return rxr_pkt_init_data_from_tx_entry(ep, pkt_entry, pkt_data_offset, tx_entry, tx_data_offset, data_size);
+	return rxr_pkt_init_data_from_op_entry(ep, pkt_entry, pkt_data_offset, tx_entry, tx_data_offset, data_size);
 }
 
 ssize_t rxr_pkt_init_runtread_msgrtm(struct rxr_ep *ep,
@@ -895,7 +896,7 @@ void rxr_pkt_handle_eager_rtm_send_completion(struct rxr_ep *ep,
 
 	tx_entry = (struct rxr_tx_entry *)pkt_entry->x_entry;
 	assert(tx_entry->total_len == rxr_pkt_req_data_size(pkt_entry));
-	rxr_cq_handle_tx_completion(ep, tx_entry);
+	rxr_cq_handle_send_completion(ep, tx_entry);
 }
 
 void rxr_pkt_handle_medium_rtm_send_completion(struct rxr_ep *ep,
@@ -906,7 +907,7 @@ void rxr_pkt_handle_medium_rtm_send_completion(struct rxr_ep *ep,
 	tx_entry = (struct rxr_tx_entry *)pkt_entry->x_entry;
 	tx_entry->bytes_acked += rxr_pkt_req_data_size(pkt_entry);
 	if (tx_entry->total_len == tx_entry->bytes_acked)
-		rxr_cq_handle_tx_completion(ep, tx_entry);
+		rxr_cq_handle_send_completion(ep, tx_entry);
 }
 
 void rxr_pkt_handle_longcts_rtm_send_completion(struct rxr_ep *ep,
@@ -917,7 +918,7 @@ void rxr_pkt_handle_longcts_rtm_send_completion(struct rxr_ep *ep,
 	tx_entry = (struct rxr_tx_entry *)pkt_entry->x_entry;
 	tx_entry->bytes_acked += rxr_pkt_req_data_size(pkt_entry);
 	if (tx_entry->total_len == tx_entry->bytes_acked)
-		rxr_cq_handle_tx_completion(ep, tx_entry);
+		rxr_cq_handle_send_completion(ep, tx_entry);
 }
 
 void rxr_pkt_handle_dc_longcts_rtm_send_completion(struct rxr_ep *ep,
@@ -929,7 +930,7 @@ void rxr_pkt_handle_dc_longcts_rtm_send_completion(struct rxr_ep *ep,
 	tx_entry->bytes_acked += rxr_pkt_req_data_size(pkt_entry);
 	if (tx_entry->total_len == tx_entry->bytes_acked &&
 	    tx_entry->rxr_flags & RXR_RECEIPT_RECEIVED)
-		rxr_cq_handle_tx_completion(ep, tx_entry);
+		rxr_cq_handle_send_completion(ep, tx_entry);
 }
 
 void rxr_pkt_handle_runtread_rtm_send_completion(struct rxr_ep *ep,
@@ -948,7 +949,7 @@ void rxr_pkt_handle_runtread_rtm_send_completion(struct rxr_ep *ep,
 	assert(peer->num_runt_bytes_in_flight >= pkt_data_size);
 	peer->num_runt_bytes_in_flight -= pkt_data_size;
 	if (tx_entry->total_len == tx_entry->bytes_acked)
-		rxr_cq_handle_tx_completion(ep, tx_entry);
+		rxr_cq_handle_send_completion(ep, tx_entry);
 }
 
 /*
@@ -1247,7 +1248,7 @@ ssize_t rxr_pkt_proc_matched_mulreq_rtm(struct rxr_ep *ep,
 
 		rx_data_offset = rxr_pkt_hdr_seg_offset(cur->pkt);
 
-		/* rxr_pkt_copy_data_to_rx_entry() can release rx_entry, so
+		/* rxr_pkt_copy_data_to_op_entry() can release rx_entry, so
 		 * bytes_received must be calculated before it.
 		 */
 		rx_entry->bytes_received += data_size;
@@ -1255,13 +1256,13 @@ ssize_t rxr_pkt_proc_matched_mulreq_rtm(struct rxr_ep *ep,
 		if (rxr_op_entry_mulreq_total_data_size(rx_entry, pkt_type) == rx_entry->bytes_received_via_mulreq)
 			rxr_pkt_rx_map_remove(ep, cur, rx_entry);
 
-		/* rxr_pkt_copy_data_to_rx_entry() will release cur, so
+		/* rxr_pkt_copy_data_to_op_entry() will release cur, so
 		 * cur->next must be copied out before it.
 		 */
 		nxt = cur->next;
 		cur->next = NULL;
 
-		err = rxr_pkt_copy_data_to_rx_entry(ep, rx_entry, rx_data_offset, cur, pkt_data, data_size);
+		err = rxr_pkt_copy_data_to_op_entry(ep, rx_entry, rx_data_offset, cur, pkt_data, data_size);
 		if (err) {
 			rxr_pkt_entry_release_rx(ep, cur);
 			ret = err;
@@ -1300,10 +1301,10 @@ ssize_t rxr_pkt_proc_matched_eager_rtm(struct rxr_ep *ep,
 		data_size = pkt_entry->pkt_size - hdr_size;
 
 		/*
-		 * On success, rxr_pkt_copy_data_to_rx_entry will write rx completion,
+		 * On success, rxr_pkt_copy_data_to_op_entry will write rx completion,
 		 * release pkt_entry and rx_entry
 		 */
-		err = rxr_pkt_copy_data_to_rx_entry(ep, rx_entry, 0, pkt_entry, data, data_size);
+		err = rxr_pkt_copy_data_to_op_entry(ep, rx_entry, 0, pkt_entry, data, data_size);
 		if (err)
 			rxr_pkt_entry_release_rx(ep, pkt_entry);
 
@@ -1405,13 +1406,13 @@ ssize_t rxr_pkt_proc_matched_rtm(struct rxr_ep *ep,
 	data_size = pkt_entry->pkt_size - hdr_size;
 
 	rx_entry->bytes_received += data_size;
-	ret = rxr_pkt_copy_data_to_rx_entry(ep, rx_entry, 0, pkt_entry, data, data_size);
+	ret = rxr_pkt_copy_data_to_op_entry(ep, rx_entry, 0, pkt_entry, data, data_size);
 	if (ret) {
 		return ret;
 	}
 #if ENABLE_DEBUG
-	dlist_insert_tail(&rx_entry->rx_pending_entry, &ep->rx_pending_list);
-	ep->rx_pending++;
+	dlist_insert_tail(&rx_entry->pending_recv_entry, &ep->op_entry_recv_list);
+	ep->pending_recv_counter++;
 #endif
 	rx_entry->state = RXR_RX_RECV;
 	ret = rxr_pkt_post_or_queue(ep, rx_entry, RXR_CTS_PKT, 0);
@@ -1616,7 +1617,7 @@ int rxr_pkt_init_rtw_data(struct rxr_ep *ep,
 
 	hdr_size = rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
 	data_size = MIN(ep->mtu_size - hdr_size, tx_entry->total_len);
-	return rxr_pkt_init_data_from_tx_entry(ep, pkt_entry, hdr_size, tx_entry, 0, data_size);
+	return rxr_pkt_init_data_from_op_entry(ep, pkt_entry, hdr_size, tx_entry, 0, data_size);
 }
 
 ssize_t rxr_pkt_init_eager_rtw(struct rxr_ep *ep,
@@ -1760,7 +1761,7 @@ void rxr_pkt_handle_eager_rtw_send_completion(struct rxr_ep *ep,
 
 	tx_entry = (struct rxr_tx_entry *)pkt_entry->x_entry;
 	assert(tx_entry->total_len == rxr_pkt_req_data_size(pkt_entry));
-	rxr_cq_handle_tx_completion(ep, tx_entry);
+	rxr_cq_handle_send_completion(ep, tx_entry);
 }
 
 void rxr_pkt_handle_longcts_rtw_send_completion(struct rxr_ep *ep,
@@ -1771,7 +1772,7 @@ void rxr_pkt_handle_longcts_rtw_send_completion(struct rxr_ep *ep,
 	tx_entry = (struct rxr_tx_entry *)pkt_entry->x_entry;
 	tx_entry->bytes_acked += rxr_pkt_req_data_size(pkt_entry);
 	if (tx_entry->total_len == tx_entry->bytes_acked)
-		rxr_cq_handle_tx_completion(ep, tx_entry);
+		rxr_cq_handle_send_completion(ep, tx_entry);
 }
 
 void rxr_pkt_handle_dc_longcts_rtw_send_completion(struct rxr_ep *ep,
@@ -1783,7 +1784,7 @@ void rxr_pkt_handle_dc_longcts_rtw_send_completion(struct rxr_ep *ep,
 	tx_entry->bytes_acked += rxr_pkt_req_data_size(pkt_entry);
 	if (tx_entry->total_len == tx_entry->bytes_acked &&
 	    tx_entry->rxr_flags & RXR_RECEIPT_RECEIVED)
-		rxr_cq_handle_tx_completion(ep, tx_entry);
+		rxr_cq_handle_send_completion(ep, tx_entry);
 }
 
 /*
@@ -1854,7 +1855,7 @@ void rxr_pkt_proc_eager_rtw(struct rxr_ep *ep,
 		rxr_pkt_entry_release_rx(ep, pkt_entry);
 		rxr_release_rx_entry(ep, rx_entry);
 	} else {
-		err = rxr_pkt_copy_data_to_rx_entry(ep, rx_entry, 0, pkt_entry, data, data_size);
+		err = rxr_pkt_copy_data_to_op_entry(ep, rx_entry, 0, pkt_entry, data, data_size);
 		if (OFI_UNLIKELY(err)) {
 			efa_eq_write_error(&ep->util_ep, FI_EINVAL, FI_EFA_ERR_RX_ENTRY_COPY);
 			rxr_pkt_entry_release_rx(ep, pkt_entry);
@@ -1967,7 +1968,7 @@ void rxr_pkt_handle_longcts_rtw_recv(struct rxr_ep *ep,
 		rxr_pkt_entry_release_rx(ep, pkt_entry);
 		return;
 	} else {
-		err = rxr_pkt_copy_data_to_rx_entry(ep, rx_entry, 0, pkt_entry, data, data_size);
+		err = rxr_pkt_copy_data_to_op_entry(ep, rx_entry, 0, pkt_entry, data, data_size);
 		if (OFI_UNLIKELY(err)) {
 			efa_eq_write_error(&ep->util_ep, FI_EINVAL, FI_EFA_ERR_RX_ENTRY_COPY);
 			rxr_release_rx_entry(ep, rx_entry);
@@ -1978,8 +1979,8 @@ void rxr_pkt_handle_longcts_rtw_recv(struct rxr_ep *ep,
 
 
 #if ENABLE_DEBUG
-	dlist_insert_tail(&rx_entry->rx_pending_entry, &ep->rx_pending_list);
-	ep->rx_pending++;
+	dlist_insert_tail(&rx_entry->pending_recv_entry, &ep->op_entry_recv_list);
+	ep->pending_recv_counter++;
 #endif
 	rx_entry->state = RXR_RX_RECV;
 	rx_entry->tx_id = tx_id;
@@ -2050,7 +2051,7 @@ void rxr_pkt_handle_longread_rtw_recv(struct rxr_ep *ep,
  *     init() functions for RTR packets
  */
 void rxr_pkt_init_rtr(struct rxr_ep *ep,
-		      struct rxr_tx_entry *tx_entry,
+		      struct rxr_op_entry *tx_entry,
 		      int pkt_type, int window,
 		      struct rxr_pkt_entry *pkt_entry)
 {
@@ -2062,7 +2063,7 @@ void rxr_pkt_init_rtr(struct rxr_ep *ep,
 	rtr_hdr->rma_iov_count = tx_entry->rma_iov_count;
 	rxr_pkt_init_req_hdr(ep, tx_entry, pkt_type, pkt_entry);
 	rtr_hdr->msg_length = tx_entry->total_len;
-	rtr_hdr->recv_id = tx_entry->rma_loc_rx_id;
+	rtr_hdr->recv_id = tx_entry->tx_id;
 	rtr_hdr->recv_length = window;
 	for (i = 0; i < tx_entry->rma_iov_count; ++i) {
 		rtr_hdr->rma_iov[i].addr = tx_entry->rma_iov[i].addr;
@@ -2075,7 +2076,7 @@ void rxr_pkt_init_rtr(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_short_rtr(struct rxr_ep *ep,
-			       struct rxr_tx_entry *tx_entry,
+			       struct rxr_op_entry *tx_entry,
 			       struct rxr_pkt_entry *pkt_entry)
 {
 	rxr_pkt_init_rtr(ep, tx_entry, RXR_SHORT_RTR_PKT, tx_entry->total_len, pkt_entry);
@@ -2083,26 +2084,13 @@ ssize_t rxr_pkt_init_short_rtr(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_longcts_rtr(struct rxr_ep *ep,
-			      struct rxr_tx_entry *tx_entry,
+			      struct rxr_op_entry *tx_entry,
 			      struct rxr_pkt_entry *pkt_entry)
 {
-	rxr_pkt_init_rtr(ep, tx_entry, RXR_LONGCTS_RTR_PKT, tx_entry->rma_window, pkt_entry);
+	rxr_pkt_init_rtr(ep, tx_entry, RXR_LONGCTS_RTR_PKT, tx_entry->window, pkt_entry);
 	return 0;
 }
 
-/*
- *     handle_send_completion() funciton for RTR packet
- */
-void rxr_pkt_handle_rtr_send_completion(struct rxr_ep *ep,
-					struct rxr_pkt_entry *pkt_entry)
-{
-	/*
-	 * Unlike other protocol, for emulated read, tx_entry
-	 * is release in rxr_cq_handle_rx_completion().
-	 * therefore there is nothing to be done here.
-	 */
-	return;
-}
 
 /*
  *     handle_recv() functions for RTR packet
@@ -2110,8 +2098,7 @@ void rxr_pkt_handle_rtr_send_completion(struct rxr_ep *ep,
 void rxr_pkt_handle_rtr_recv(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_rtr_hdr *rtr_hdr;
-	struct rxr_rx_entry *rx_entry;
-	struct rxr_tx_entry *tx_entry;
+	struct rxr_op_entry *rx_entry;
 	ssize_t err;
 
 	rx_entry = rxr_ep_alloc_rx_entry(ep, pkt_entry->addr, ofi_op_read_rsp);
@@ -2128,7 +2115,7 @@ void rxr_pkt_handle_rtr_recv(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 	rx_entry->bytes_copied = 0;
 
 	rtr_hdr = (struct rxr_rtr_hdr *)pkt_entry->pkt;
-	rx_entry->rma_initiator_rx_id = rtr_hdr->recv_id;
+	rx_entry->tx_id = rtr_hdr->recv_id;
 	rx_entry->window = rtr_hdr->recv_length;
 	rx_entry->iov_count = rtr_hdr->rma_iov_count;
 	err = rxr_rma_verified_copy_iov(ep, rtr_hdr->rma_iov, rtr_hdr->rma_iov_count,
@@ -2146,26 +2133,15 @@ void rxr_pkt_handle_rtr_recv(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 	rx_entry->cq_entry.buf = rx_entry->iov[0].iov_base;
 	rx_entry->total_len = rx_entry->cq_entry.len;
 
-	tx_entry = rxr_rma_alloc_readrsp_tx_entry(ep, rx_entry);
-	if (OFI_UNLIKELY(!tx_entry)) {
-		FI_WARN(&rxr_prov, FI_LOG_CQ, "Readrsp tx entry exhausted!\n");
-		efa_eq_write_error(&ep->util_ep, FI_ENOBUFS, FI_EFA_ERR_RX_ENTRIES_EXHAUSTED);
-		rxr_release_rx_entry(ep, rx_entry);
-		rxr_pkt_entry_release_rx(ep, pkt_entry);
-		return;
-	}
-
-	err = rxr_pkt_post_or_queue(ep, tx_entry, RXR_READRSP_PKT, 0);
+	err = rxr_pkt_post_or_queue(ep, rx_entry, RXR_READRSP_PKT, 0);
 	if (OFI_UNLIKELY(err)) {
 		FI_WARN(&rxr_prov, FI_LOG_CQ, "Posting of readrsp packet failed! err=%ld\n", err);
 		efa_eq_write_error(&ep->util_ep, FI_EIO, FI_EFA_ERR_PKT_POST);
-		rxr_release_tx_entry(ep, tx_entry);
 		rxr_release_rx_entry(ep, rx_entry);
 		rxr_pkt_entry_release_rx(ep, pkt_entry);
 		return;
 	}
 
-	rx_entry->state = RXR_RX_WAIT_READ_FINISH;
 	rxr_pkt_entry_release_rx(ep, pkt_entry);
 }
 
@@ -2263,7 +2239,7 @@ void rxr_pkt_handle_write_rta_send_completion(struct rxr_ep *ep, struct rxr_pkt_
 	struct rxr_tx_entry *tx_entry;
 
 	tx_entry = (struct rxr_tx_entry *)pkt_entry->x_entry;
-	rxr_cq_handle_tx_completion(ep, tx_entry);
+	rxr_cq_handle_send_completion(ep, tx_entry);
 }
 
 int rxr_pkt_proc_write_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)

--- a/prov/efa/src/rxr/rxr_pkt_type_req.h
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.h
@@ -381,18 +381,16 @@ struct rxr_rtr_hdr *rxr_get_rtr_hdr(void *pkt)
 }
 
 ssize_t rxr_pkt_init_short_rtr(struct rxr_ep *ep,
-			       struct rxr_tx_entry *tx_entry,
+			       struct rxr_op_entry *tx_entry,
 			       struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_longcts_rtr(struct rxr_ep *ep,
-			      struct rxr_tx_entry *tx_entry,
+			      struct rxr_op_entry *tx_entry,
 			      struct rxr_pkt_entry *pkt_entry);
 
 void rxr_pkt_handle_rtr_sent(struct rxr_ep *ep,
 			     struct rxr_pkt_entry *pkt_entry);
 
-void rxr_pkt_handle_rtr_send_completion(struct rxr_ep *ep,
-					struct rxr_pkt_entry *pkt_entry);
 void rxr_pkt_handle_rtr_recv(struct rxr_ep *ep,
 			     struct rxr_pkt_entry *pkt_entry);
 

--- a/prov/efa/src/rxr/rxr_rma.h
+++ b/prov/efa/src/rxr/rxr_rma.h
@@ -43,11 +43,6 @@ int rxr_rma_verified_copy_iov(struct rxr_ep *ep, struct efa_rma_iov *rma,
 			      size_t count, uint32_t flags,
 			      struct iovec *iov, void **desc);
 
-/* read response related functions */
-struct rxr_tx_entry *
-rxr_rma_alloc_readrsp_tx_entry(struct rxr_ep *rxr_ep,
-			       struct rxr_rx_entry *rx_entry);
-
 extern struct fi_ops_rma rxr_ops_rma;
 
 #endif


### PR DESCRIPTION
Code changes:
- Combined the previous tx/rx entry pools to a single entry pool called op_entry_pool.
- Removed unused/redundant variables present in rxr_op_entry.
- Modified dual entries (tx_entry/rx_entry) to op_entry.
- Resolved merge conflicts.
- Adapted naming conventions.

Functional differences:
Prior to this PR, only tx_entry on the responder side could send DATA. Therefore rxr_pkt_init_data, rxr_pkt_handle_data_sent, rxr_pkt_handle_send_completion were using only tx_entry.

Also, only rx_entry on the requestor side could receive DATA and send CTS. Therefore rxr_pkt_handle_data_recv, and rxr_pkt_init_cts, rxr_pkt_handle_cts_sent were using this rx_entry.

With this change, there are only single entries on both ends of the communication - tx_entry on the requestor side and rx_entry on the responder side. In addition to the original functionality of tx_entry on the requestor end and rx_entry on the responder end, the tx_entry on the requestor end can now receive data and send CTS, rx_entry on the responder end can now send DATA. Therefore all above mentioned functions operates on op_entry.