### PR TITLE
[v1.14.x] prov/efa: flush MR cache when fork() is called and fork support is ON

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -166,7 +166,10 @@ struct efa_domain {
 	struct ofi_mr_cache	*cache;
 	struct efa_qp		**qp_table;
 	size_t			qp_table_sz_m1;
+	struct dlist_entry	list_entry; /* linked to g_efa_domain_list */
 };
+
+extern struct dlist_entry g_efa_domain_list;
 
 /**
  * @brief get a pointer to struct efa_domain from a domain_fid

--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -1131,5 +1131,6 @@ static int efa_init_info(const struct fi_info **all_infos)
 
 int efa_init_prov(void)
 {
+	dlist_init(&g_efa_domain_list);
 	return efa_init_info(&efa_util_prov.info);
 }


### PR DESCRIPTION
When fork support is on, register memory regions was not copied to child processes's memory space.

With MR cache turned on, the registered memory regions remain registered after EFA finished send data from it.

As a result, when both fork support and MR cache are turned on, child processes cannot access some memory they need.

This patch addresses the issue by flush the MR cache when fork is called. Flushing MR cache will cause any memory region that is not actively being used (use_cnt == 0) to be de-registered, therefore they will be copied to child process's memory space

Signed-off-by: Wei Zhang <wzam@amazon.com>

(cherry-picked from 5242e5bf5)