### PR TITLE
prov/sockets: fix assertion in sock_ep_lookup_conn

### DIFF
--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1829,7 +1829,8 @@ struct sock_conn *sock_ep_lookup_conn(struct sock_ep_attr *attr, fi_addr_t index
 		if (!attr->cmap.table[i].connected)
 			continue;
 
-		if (ofi_equals_sockaddr(&attr->cmap.table[i].addr.sa, &addr->sa)) {
+		if (ofi_equals_sockaddr(&attr->cmap.table[i].addr.sa, &addr->sa) &&
+			attr->cmap.table[i].av_index == idx) {
 			conn = &attr->cmap.table[i];
 			break;
 		}


### PR DESCRIPTION
The addr may collide, e.g. with a dynamic process and the port is being recycled, when, the assertion of matching index won't hold since it may find a previous index. Move the index to the matching condition to prevent this error.

## The error symptom:
```
$ mpirun -n 1 ./th_taskmanager
th_taskmanager: prov/sockets/src/sock_ep.c:1846: sock_ep_lookup_conn: Assertion `conn->av_index == idx' failed.
```
The `th_taskmanager` repeatedly spawns and closes new processes. Eventually one of the processes will reuse a previous port. But the master process still holds all the previous addresses in av table, causing duplicated entries. Because currently, the interface is not connection-based, it is difficult to track the process connections in order to maintain a clean master av table. Luckily, the patch in this PR seems to fix the issue.