### PR TITLE
prov/efa: Configurable Eager Max Message Size

### DIFF
--- a/man/fi_efa.7.md
+++ b/man/fi_efa.7.md
@@ -194,6 +194,12 @@ These OFI runtime parameters apply only to the RDM endpoint.
 *FI_EFA_SET_CUDA_SYNC_MEMOPS*
 : Set CU_POINTER_ATTRIBUTE_SYNC_MEMOPS for cuda ptr. (Default: 1)
 
+*FI_EFA_INTER_MIN_READ_MESSAGE_SIZE*
+: The minimum message size in bytes for inter EFA read message protocol. If instance support RDMA read, messages whose size is larger than this value will be sent by read message protocol. (Default 1048576).
+
+*FI_EFA_INTER_MIN_READ_WRITE_SIZE*
+: The mimimum message size for inter EFA write to use read write protocol. If firmware support RDMA read, and FI_EFA_USE_DEVICE_RDMA is 1, write requests whose size is larger than this value will use the read write protocol (Default 65536).
+
 # SEE ALSO
 
 [`fabric`(7)](fabric.7.html),

--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -509,7 +509,7 @@ static inline int efa_ep_use_p2p(struct efa_ep *ep, struct efa_mr *efa_mr)
 	if (efa_mr->peer.iface == FI_HMEM_SYSTEM)
 		return 1;
 
-	if (ep->domain->hmem_support_status[efa_mr->peer.iface].p2p_supported)
+	if (ep->domain->hmem_info[efa_mr->peer.iface].p2p_supported)
 		return (ep->hmem_p2p_opt != FI_HMEM_P2P_DISABLED);
 
 	if (ep->hmem_p2p_opt == FI_HMEM_P2P_REQUIRED) {

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -259,7 +259,7 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 		goto err_free;
 	}
 
-	err = efa_hmem_support_status_update_all(efa_domain->hmem_support_status);
+	err = efa_hmem_info_update_all(efa_domain);
 	if (err) {
 		ret = err;
 		EFA_WARN(FI_LOG_DOMAIN, "Failed to check hmem support status. err: %d", ret);

--- a/prov/efa/src/efa_domain.h
+++ b/prov/efa/src/efa_domain.h
@@ -46,7 +46,7 @@ struct efa_domain {
 	struct ofi_mr_cache	*cache;
 	struct efa_qp		**qp_table;
 	size_t			qp_table_sz_m1;
-	struct efa_hmem_support_status	hmem_support_status[OFI_HMEM_MAX];
+	struct efa_hmem_info	hmem_info[OFI_HMEM_MAX];
 	size_t			mtu_size;
 	size_t			addrlen;
 	bool 			mr_local;

--- a/prov/efa/src/efa_ep.c
+++ b/prov/efa/src/efa_ep.c
@@ -699,17 +699,17 @@ int efa_ep_open(struct fid_domain *domain_fid, struct fi_info *user_info,
 		memcpy(ep->src_addr, user_info->src_addr, user_info->src_addrlen);
 	}
 
-	if (ep->domain->hmem_support_status[FI_HMEM_CUDA].initialized) {
+	if (ep->domain->hmem_info[FI_HMEM_CUDA].initialized) {
 		/*
 		 * Set the default to required. NCCL plugin requires p2p, but
 		 * does not call setopt for this option in older NCCL plugin
 		 * versions.
 		 */
 		ep->hmem_p2p_opt = FI_HMEM_P2P_REQUIRED;
-	} else if (ep->domain->hmem_support_status[FI_HMEM_NEURON].initialized) {
+	} else if (ep->domain->hmem_info[FI_HMEM_NEURON].initialized) {
 		/* Neuron requires p2p and supports no other modes. */
 		ep->hmem_p2p_opt = FI_HMEM_P2P_REQUIRED;
-	} else if (ep->domain->hmem_support_status[FI_HMEM_SYNAPSEAI].initialized) {
+	} else if (ep->domain->hmem_info[FI_HMEM_SYNAPSEAI].initialized) {
 		/* SynapseAI requires p2p and supports no other modes. */
 		ep->hmem_p2p_opt = FI_HMEM_P2P_REQUIRED;
 	} else {

--- a/prov/efa/src/efa_hmem.h
+++ b/prov/efa/src/efa_hmem.h
@@ -34,11 +34,16 @@
 #ifndef EFA_HMEM_H
 #define EFA_HMEM_H
 
-struct efa_hmem_support_status {
+struct efa_hmem_info {
 	bool initialized; 	/* do we support it at all */
 	bool p2p_supported;	/* do we support p2p with this device */
+
+	size_t max_medium_msg_size;
+	size_t runt_size;
+	size_t min_read_msg_size;
+	size_t min_read_write_size;
 };
 
-int efa_hmem_support_status_update_all(struct efa_hmem_support_status *all_status);
+int efa_hmem_info_update_all(struct efa_domain *efa_domain);
 
 #endif

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -208,7 +208,7 @@ static int efa_mr_hmem_setup(struct efa_mr *efa_mr,
 		 * util_domain is at the beginning of both efa_domain and
 		 * rxr_domain.
 		 */
-		if (efa_mr->domain->hmem_support_status[attr->iface].initialized) {
+		if (efa_mr->domain->hmem_info[attr->iface].initialized) {
 			efa_mr->peer.iface = attr->iface;
 		} else {
 			EFA_WARN(FI_LOG_MR,
@@ -518,7 +518,7 @@ struct fi_ops efa_mr_ops = {
 #if HAVE_SYNAPSEAI
 /**
  * @brief Register a memory buffer with rdma-core api.
- * 
+ *
  * @param efa_mr the ptr to the efa_mr object
  * @param mr_attr the ptr to the fi_mr_attr object
  * @param access the desired memory protection attributes
@@ -549,7 +549,7 @@ static struct ibv_mr *efa_mr_reg_ibv_mr(struct efa_mr *efa_mr, struct fi_mr_attr
 #else
 /**
  * @brief Register a memory buffer with rdma-core api.
- * 
+ *
  * @param efa_mr the ptr to the efa_mr object
  * @param mr_attr the ptr to the fi_mr_attr object
  * @param access the desired memory protection attributes

--- a/prov/efa/src/rxr/rxr_env.c
+++ b/prov/efa/src/rxr/rxr_env.c
@@ -66,13 +66,9 @@ struct rxr_env rxr_env = {
 	.rnr_backoff_initial_wait_time = 0, /* 0 is random wait time  */
 	.efa_cq_read_size = 50,
 	.shm_cq_read_size = 50,
-	.efa_max_medium_msg_size = 65536,
-	.efa_min_read_msg_size = 1048576,
 	.efa_max_gdrcopy_msg_size = 32768,
-	.efa_min_read_write_size = 65536,
 	.efa_read_segment_size = 1073741824,
 	.rnr_retry = 3, /* Setting this value to EFA_RNR_INFINITE_RETRY makes the firmware retry indefinitey */
-	.efa_runt_size = 307200,
 };
 
 /* @brief Read and store the FI_EFA_* environment variables.
@@ -134,18 +130,10 @@ void rxr_env_param_get(void)
 			 &rxr_env.efa_cq_read_size);
 	fi_param_get_size_t(&rxr_prov, "shm_cq_read_size",
 			 &rxr_env.shm_cq_read_size);
-	fi_param_get_size_t(&rxr_prov, "inter_max_medium_message_size",
-			    &rxr_env.efa_max_medium_msg_size);
-	fi_param_get_size_t(&rxr_prov, "inter_min_read_message_size",
-			    &rxr_env.efa_min_read_msg_size);
-	fi_param_get_size_t(&rxr_prov, "inter_min_read_write_size",
-			    &rxr_env.efa_min_read_write_size);
 	fi_param_get_size_t(&rxr_prov, "inter_read_segment_size",
 			    &rxr_env.efa_read_segment_size);
 	fi_param_get_size_t(&rxr_prov, "inter_max_gdrcopy_message_size",
 			    &rxr_env.efa_max_gdrcopy_msg_size);
-	fi_param_get_size_t(&rxr_prov, "runt_size",
-			    &rxr_env.efa_runt_size);
 	efa_fork_support_request_initialize();
 }
 
@@ -206,7 +194,7 @@ void rxr_env_define()
 	fi_param_define(&rxr_prov, "inter_max_medium_message_size", FI_PARAM_INT,
 			"The maximum message size for inter EFA medium message protocol (Default 65536).");
 	fi_param_define(&rxr_prov, "inter_min_read_message_size", FI_PARAM_INT,
-			"The minimum message size for inter EFA read message protocol. If instance support RDMA read, messages whose size is larger than this value will be sent by read message protocol (Default 1048576).");
+			"The minimum message size in bytes for inter EFA read message protocol. If instance support RDMA read, messages whose size is larger than this value will be sent by read message protocol (Default 1048576).");
 	fi_param_define(&rxr_prov, "inter_max_gdrcopy_message_size", FI_PARAM_INT,
 			"The maximum message size to use gdrcopy. If instance support gdrcopy, messages whose size is smaller than this value will be sent by eager/longcts protocol (Default 32768).");
 	fi_param_define(&rxr_prov, "inter_min_read_write_size", FI_PARAM_INT,

--- a/prov/efa/src/rxr/rxr_env.h
+++ b/prov/efa/src/rxr/rxr_env.h
@@ -62,12 +62,8 @@ struct rxr_env {
 	int rnr_backoff_initial_wait_time; /* unit is us */
 	size_t efa_cq_read_size;
 	size_t shm_cq_read_size;
-	size_t efa_max_medium_msg_size;
 	size_t efa_max_gdrcopy_msg_size;
-	size_t efa_min_read_msg_size;
-	size_t efa_min_read_write_size;
 	size_t efa_read_segment_size;
-	size_t efa_runt_size;
 	/* If first attempt to send a packet failed,
 	 * this value controls how many times firmware
 	 * retries the send before it report an RNR error

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -918,7 +918,7 @@ void rxr_ep_set_extra_info(struct rxr_ep *ep)
 }
 
 /*
- * Set the efa_domain hmem_support_status state based on what device
+ * Set the efa_domain hmem_info state based on what device
  * capabilities are available. Return whether hmem is supported or not.
  *
  * @param[in]	efa_domain efa domain
@@ -936,22 +936,22 @@ static int efa_ep_hmem_check(struct efa_domain *efa_domain)
 	 * TODO: once we support other FI_HMEM p2p modes, check the setopt
 	 * option first. For now, require p2p from at least one device type.
 	 */
-	if (efa_domain->hmem_support_status[FI_HMEM_CUDA].initialized &&
-	    efa_domain->hmem_support_status[FI_HMEM_CUDA].p2p_supported)
+	if (efa_domain->hmem_info[FI_HMEM_CUDA].initialized &&
+	    efa_domain->hmem_info[FI_HMEM_CUDA].p2p_supported)
 		have_hmem = 1;
 	else
 		FI_INFO(&rxr_prov, FI_LOG_EP_CTRL,
 			"NVIDIA GPUDirect support is not available.\n");
 
-	if (efa_domain->hmem_support_status[FI_HMEM_NEURON].initialized &&
-	    efa_domain->hmem_support_status[FI_HMEM_NEURON].p2p_supported)
+	if (efa_domain->hmem_info[FI_HMEM_NEURON].initialized &&
+	    efa_domain->hmem_info[FI_HMEM_NEURON].p2p_supported)
 		have_hmem = 1;
 	else
 		FI_INFO(&rxr_prov, FI_LOG_EP_CTRL,
 			"AWS Neuron peer to peer support is not available.\n");
 
-	if (efa_domain->hmem_support_status[FI_HMEM_SYNAPSEAI].initialized &&
-	    efa_domain->hmem_support_status[FI_HMEM_SYNAPSEAI].p2p_supported)
+	if (efa_domain->hmem_info[FI_HMEM_SYNAPSEAI].initialized &&
+	    efa_domain->hmem_info[FI_HMEM_SYNAPSEAI].p2p_supported)
 		have_hmem = 1;
 	else
 		FI_INFO(&rxr_prov, FI_LOG_EP_CTRL,
@@ -1129,9 +1129,9 @@ static ssize_t rxr_ep_cancel(fid_t fid_ep, void *context)
  */
 static int efa_set_fi_hmem_p2p_opt(struct efa_ep *efa_ep, int opt)
 {
-	struct efa_hmem_support_status *hmem_support_status;
+	struct efa_hmem_info *hmem_info;
 
-	hmem_support_status = efa_ep->domain->hmem_support_status;
+	hmem_info = efa_ep->domain->hmem_info;
 
 	switch (opt) {
 	/*
@@ -1142,11 +1142,11 @@ static int efa_set_fi_hmem_p2p_opt(struct efa_ep *efa_ep, int opt)
 	case FI_HMEM_P2P_REQUIRED:
 	case FI_HMEM_P2P_ENABLED:
 	case FI_HMEM_P2P_PREFERRED:
-		if (hmem_support_status[FI_HMEM_CUDA].initialized &&
-		    hmem_support_status[FI_HMEM_CUDA].p2p_supported) {
+		if (hmem_info[FI_HMEM_CUDA].initialized &&
+		    hmem_info[FI_HMEM_CUDA].p2p_supported) {
 			efa_ep->hmem_p2p_opt = opt;
-		} else if (hmem_support_status[FI_HMEM_NEURON].initialized &&
-			   hmem_support_status[FI_HMEM_NEURON].p2p_supported) {
+		} else if (hmem_info[FI_HMEM_NEURON].initialized &&
+			   hmem_info[FI_HMEM_NEURON].p2p_supported) {
 			/*
 			 * Neuron requires p2p support and supports no
 			 * other modes.

--- a/prov/efa/src/rxr/rxr_op_entry.c
+++ b/prov/efa/src/rxr/rxr_op_entry.c
@@ -128,6 +128,8 @@ void rxr_tx_entry_try_fill_desc(struct rxr_tx_entry *tx_entry,
  */
 void rxr_tx_entry_set_runt_size(struct rxr_ep *ep, struct rxr_op_entry *tx_entry)
 {
+	int iface;
+	struct efa_hmem_info *hmem_info;
 	struct rdm_peer *peer;
 
 	assert(tx_entry->type == RXR_TX_ENTRY);
@@ -136,8 +138,12 @@ void rxr_tx_entry_set_runt_size(struct rxr_ep *ep, struct rxr_op_entry *tx_entry
 		return;
 
 	peer = rxr_ep_get_peer(ep, tx_entry->addr);
+
+	iface = tx_entry->desc[0] ? ((struct efa_mr*) tx_entry->desc[0])->peer.iface : FI_HMEM_SYSTEM;
+	hmem_info = &rxr_ep_domain(ep)->hmem_info[iface];
+
 	assert(peer);
-	tx_entry->bytes_runt = MIN(rxr_env.efa_runt_size - peer->num_runt_bytes_in_flight, tx_entry->total_len);
+	tx_entry->bytes_runt = MIN(hmem_info->runt_size - peer->num_runt_bytes_in_flight, tx_entry->total_len);
 }
 
 /**

--- a/prov/efa/src/rxr/rxr_pkt_type.h
+++ b/prov/efa/src/rxr/rxr_pkt_type.h
@@ -315,7 +315,7 @@ bool rxr_pkt_type_is_runtread(int pkt_type)
 	return pkt_type == RXR_RUNTREAD_TAGRTM_PKT || pkt_type == RXR_RUNTREAD_MSGRTM_PKT;
 }
 
-int rxr_pkt_type_readbase_rtm(struct rdm_peer *peer, int op, uint64_t fi_flags);
+int rxr_pkt_type_readbase_rtm(struct rdm_peer *peer, int op, uint64_t fi_flags, struct efa_hmem_info *hmem_info);
 
 #endif
 

--- a/prov/efa/test/efa_unit_test_hmem.c
+++ b/prov/efa/test/efa_unit_test_hmem.c
@@ -4,12 +4,12 @@
 #if HAVE_NEURON
 /**
  * @brief Verify when neuron_alloc failed (return null),
- * efa_domain_open, which call efa_hmem_support_status_update_neuron
- * when HAVE_NEURON=1, will still return 0 but leave 
- * hmem_support_status[FI_HMEM_NEURON].initialized and 
- * hmem_support_status[FI_HMEM_NEURON].p2p_supported as false.
+ * efa_domain_open, which call efa_hmem_info_update_neuron
+ * when HAVE_NEURON=1, will still return 0 but leave
+ * efa_hmem_info[FI_HMEM_NEURON].initialized and
+ * efa_hmem_info[FI_HMEM_NEURON].p2p_supported as false.
  */
-void test_efa_hmem_support_status_update_neuron()
+void test_efa_hmem_info_update_neuron()
 {
         int ret;
         struct efa_resource resource = {0};
@@ -41,12 +41,12 @@ void test_efa_hmem_support_status_update_neuron()
         assert_int_equal(ret, 0);
         efa_domain = container_of(resource.domain, struct efa_domain,
 				  util_domain.domain_fid.fid);
-        assert_false(efa_domain->hmem_support_status[FI_HMEM_NEURON].initialized);
-        assert_false(efa_domain->hmem_support_status[FI_HMEM_NEURON].p2p_supported);
+        assert_false(efa_domain->hmem_info[FI_HMEM_NEURON].initialized);
+        assert_false(efa_domain->hmem_info[FI_HMEM_NEURON].p2p_supported);
         efa_unit_test_resource_destruct(&resource);
 }
 #else
-void test_efa_hmem_support_status_update_neuron()
+void test_efa_hmem_info_update_neuron()
 {
         skip();
 }

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -40,7 +40,7 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_rdm_fallback_to_ibv_create_cq_ex_cq_read_ignore_forgotton_peer, efa_unit_test_mocks_reset, NULL),
 		cmocka_unit_test_setup_teardown(test_info_open_ep_with_wrong_info, efa_unit_test_mocks_reset, NULL),
 		cmocka_unit_test_setup_teardown(test_info_open_ep_with_api_1_1_info, efa_unit_test_mocks_reset, NULL),
-		cmocka_unit_test_setup_teardown(test_efa_hmem_support_status_update_neuron, efa_unit_test_mocks_reset, NULL),
+		cmocka_unit_test_setup_teardown(test_efa_hmem_info_update_neuron, efa_unit_test_mocks_reset, NULL),
 	};
 
 	cmocka_set_message_output(CM_OUTPUT_XML);

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -67,6 +67,6 @@ void test_rdm_fallback_to_ibv_create_cq_ex_cq_read_ignore_forgotton_peer();
 void test_ibv_cq_ex_read_ignore_removed_peer();
 void test_info_open_ep_with_wrong_info();
 void test_info_open_ep_with_api_1_1_info();
-void test_efa_hmem_support_status_update_neuron();
+void test_efa_hmem_info_update_neuron();
 
 #endif


### PR DESCRIPTION
Creates a new env variable FI_EFA_MAX_EAGER_MSG_SIZE.
Simplifies code paths for selecting message protocol for send/rma based calls.