### PR TITLE
prov/efa: Add tracepoints to send/recv/read ops

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -62,7 +62,8 @@ _efa_files = \
 	prov/efa/src/rxr/rxr_pkt_cmd.c \
 	prov/efa/src/rxr/rxr_read.c \
 	prov/efa/src/rxr/rxr_op_entry.c \
-	prov/efa/src/rxr/rxr_atomic.c
+	prov/efa/src/rxr/rxr_atomic.c \
+	prov/efa/src/rxr/rxr_tp_def.c
 
 _efa_headers = \
 	prov/efa/src/efa.h \
@@ -90,8 +91,13 @@ _efa_headers = \
 	prov/efa/src/rxr/rxr_read.h \
 	prov/efa/src/rxr/rxr_atomic.h \
 	prov/efa/src/rxr/rxr_op_entry.h \
-	prov/efa/src/rxr/rdm_proto_v4.h
+	prov/efa/src/rxr/rdm_proto_v4.h \
+	prov/efa/src/rxr/rxr_tp_def.h \
+	prov/efa/src/rxr/rxr_tp.h
 
+if HAVE_LTTNG
+efa_LDFLAGS += -llttng-ust
+endif HAVE_LTTNG
 
 if ENABLE_EFA_UNIT_TEST
 noinst_PROGRAMS += prov/efa/test/efa_unit_test

--- a/prov/efa/docs/efa_tracing.txt
+++ b/prov/efa/docs/efa_tracing.txt
@@ -1,0 +1,23 @@
+QUICK INSTRUCTION ABOUT TRACING (DEVELOPMENT)
+
+1. Install lttng according to doc here: https://lttng.org/docs/v2.13/#doc-building-from-source. A couple of notes
+    - Install to a shared location like /fsx
+    - Use --disable-numa if you'd like to skip numactl
+    - Install URCU and LTTNG in same prefix. After install URCU, export PKG_CONFIG_PATH to include its .pc before building LTTNG
+
+2. Build libfabric with LTTNG using --with-lttng=<lttng_prefix>.
+    - This branch will enforce including lttng with a macro of #error, this is temporary to ensure we're indeed tracing
+    - The macro is INCLUDE_LTTNG
+    
+3. Build fabtests as normal.
+
+LIST OF TRACING POINT
+file func [tracepoint(field1, field2, ...., fieldN)]
+rxr_msg.c rxr_msg_generic_send [send_begin(msg_id, context, total_len, msg_context, msg_addr)]
+rxr_msg.c rxr_msg_generic_recv [recv_begin(msg_id, context, total_len, msg_context, msg_addr)]
+rxr_msg.c rxr_msg_proc_unexp_msg_list [msg_match_unexpected(msg_id, context, total_len, msg_addr)]
+rxr_pkt_type_misc.c rxr_pkt_handle_rma_read_completion [read_complete(msg_id, context, total_len, read_entry_context)]
+rxr_pkt_type_req.c rxr_pkt_get_msgrtm_rx_entry [msg_match_expected_nontagged(msg_id, context, total_len)]
+rxr_pkt_type_req.c rxr_pkt_get_tagrtm_rx_entry [msg_match_expected_tagged(msg_id, context, total_len)]
+rxr_pkt_type_req.c rxr_pkt_proc_matched_longread_rtm [longread_read_posted(msg_id, context, total_len)]
+rxr_pkt_type_req.c rxr_pkt_proc_matched_mulreq_rtm [runtread_read_posted(msg_id, context, total_len)]

--- a/prov/efa/src/rxr/rxr_cq.c
+++ b/prov/efa/src/rxr/rxr_cq.c
@@ -44,6 +44,8 @@
 #include "rxr_atomic.h"
 #include "rxr_pkt_cmd.h"
 
+#include "rxr_tp.h"
+
 static const char *rxr_cq_strerror(struct fid_cq *cq_fid, int prov_errno,
 				   const void *err_data, char *buf, size_t len)
 {
@@ -399,6 +401,11 @@ void rxr_cq_write_rx_completion(struct rxr_ep *ep,
 		       rx_entry->addr, rx_entry->rx_id, rx_entry->msg_id,
 		       rx_entry->cq_entry.tag, rx_entry->total_len);
 
+		rxr_tracing(recv_end, 
+			    rx_entry->msg_id, (size_t) rx_entry->cq_entry.op_context, 
+			    rx_entry->total_len, rx_entry->cq_entry.tag, rx_entry->addr);
+
+
 		if (ep->util_ep.caps & FI_SOURCE)
 			ret = ofi_cq_write_src(rx_cq,
 					       rx_entry->cq_entry.op_context,
@@ -750,6 +757,11 @@ void rxr_cq_write_tx_completion(struct rxr_ep *ep,
 		       PRIu64 "\n",
 		       tx_entry->addr, tx_entry->tx_id, tx_entry->msg_id,
 		       tx_entry->cq_entry.tag, tx_entry->total_len);
+
+
+	rxr_tracing(send_end, 
+		    tx_entry->msg_id, (size_t) tx_entry->cq_entry.op_context, 
+		    tx_entry->total_len, tx_entry->cq_entry.tag, tx_entry->addr);
 
 		/* TX completions should not send peer address to util_cq */
 		if (ep->util_ep.caps & FI_SOURCE)

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -39,6 +39,8 @@
 #include "rxr_pkt_type_base.h"
 #include "rxr_read.h"
 
+#include "rxr_tp.h"
+
 /* This file define functons for the following packet type:
  *       HANDSHAKE
  *       CTS
@@ -411,6 +413,9 @@ void rxr_pkt_handle_rma_read_completion(struct rxr_ep *ep,
 			rxr_release_tx_entry(ep, tx_entry);
 		} else if (read_entry->context_type == RXR_READ_CONTEXT_RX_ENTRY) {
 			rx_entry = read_entry->context;
+			rxr_tracing(read_completed, 
+				    rx_entry->msg_id, (size_t) rx_entry->cq_entry.op_context, 
+				    rx_entry->total_len, (size_t) read_entry->context);
 			err = rxr_pkt_post_or_queue(ep, rx_entry, RXR_EOR_PKT, false);
 			if (OFI_UNLIKELY(err)) {
 				FI_WARN(&rxr_prov, FI_LOG_CQ,

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -41,6 +41,8 @@
 #include "rxr_pkt_type_base.h"
 #include "rxr_read.h"
 
+#include "rxr_tp.h"
+
 /*
  * Utility constants and funnctions shared by all REQ packe
  * types.
@@ -1143,6 +1145,8 @@ struct rxr_rx_entry *rxr_pkt_get_msgrtm_rx_entry(struct rxr_ep *ep,
 
 	} else {
 		rx_entry = rxr_pkt_get_rtm_matched_rx_entry(ep, match, *pkt_entry_ptr);
+		rxr_tracing(msg_match_expected_nontagged, rx_entry->msg_id, 
+			    (size_t) rx_entry->cq_entry.op_context, rx_entry->total_len);
 	}
 
 	pkt_type = rxr_get_base_hdr((*pkt_entry_ptr)->pkt)->type;
@@ -1180,6 +1184,8 @@ struct rxr_rx_entry *rxr_pkt_get_tagrtm_rx_entry(struct rxr_ep *ep,
 		}
 	} else {
 		rx_entry = rxr_pkt_get_rtm_matched_rx_entry(ep, match, *pkt_entry_ptr);
+		rxr_tracing(msg_match_expected_tagged, rx_entry->msg_id, 
+			    (size_t) rx_entry->cq_entry.op_context, rx_entry->total_len);
 	}
 
 	pkt_type = rxr_get_base_hdr((*pkt_entry_ptr)->pkt)->type;
@@ -1205,6 +1211,8 @@ ssize_t rxr_pkt_proc_matched_longread_rtm(struct rxr_ep *ep,
 	       rx_entry->rma_iov_count * sizeof(struct fi_rma_iov));
 
 	rxr_pkt_entry_release_rx(ep, pkt_entry);
+	rxr_tracing(longread_read_posted, rx_entry->msg_id, 
+		    (size_t) rx_entry->cq_entry.op_context, rx_entry->total_len);
 	return rxr_read_post_remote_read_or_queue(ep, rx_entry);
 }
 
@@ -1232,6 +1240,8 @@ ssize_t rxr_pkt_proc_matched_mulreq_rtm(struct rxr_ep *ep,
 			read_iov = (struct fi_rma_iov *)((char *)pkt_entry->pkt + rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry));
 			rx_entry->rma_iov_count = runtread_rtm_hdr->read_iov_count;
 			memcpy(rx_entry->rma_iov, read_iov, rx_entry->rma_iov_count * sizeof(struct fi_rma_iov));
+			rxr_tracing(runtread_read_posted, rx_entry->msg_id, 
+				    (size_t) rx_entry->cq_entry.op_context, rx_entry->total_len);
 			err = rxr_read_post_remote_read_or_queue(ep, rx_entry);
 			if (err)
 				return err;

--- a/prov/efa/src/rxr/rxr_tp.h
+++ b/prov/efa/src/rxr/rxr_tp.h
@@ -1,0 +1,13 @@
+#ifndef _EFA_TP_H_
+#define _EFA_TP_H_
+
+#include <config.h>
+
+#if HAVE_LTTNG
+#include "rxr_tp_def.h"
+#define rxr_tracing(tp_name, ...)  lttng_ust_tracepoint(EFA_RDM_TP_PROV, tp_name, __VA_ARGS__)
+#else
+#define rxr_tracing(tp_name, ...)  while (0) {}
+#endif
+
+#endif // _EFA_TP_H_

--- a/prov/efa/src/rxr/rxr_tp_def.c
+++ b/prov/efa/src/rxr/rxr_tp_def.c
@@ -1,0 +1,10 @@
+#define LTTNG_UST_TRACEPOINT_CREATE_PROBES
+#define LTTNG_UST_TRACEPOINT_DEFINE
+
+#include <config.h>
+
+#if HAVE_LTTNG
+
+#include "rxr_tp_def.h"
+
+#endif

--- a/prov/efa/src/rxr/rxr_tp_def.h
+++ b/prov/efa/src/rxr/rxr_tp_def.h
@@ -1,0 +1,194 @@
+#undef LTTNG_UST_TRACEPOINT_PROVIDER
+#define LTTNG_UST_TRACEPOINT_PROVIDER EFA_RDM_TP_PROV
+
+#undef LTTNG_UST_TRACEPOINT_INCLUDE
+#define LTTNG_UST_TRACEPOINT_INCLUDE "rxr/rxr_tp_def.h"
+
+#if !defined(_EFA_TP_DEF_H) || defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
+#define _EFA_TP_DEF_H
+
+#include <lttng/tracepoint.h>
+
+#define EFA_RDM_TP_PROV efa_rdm
+
+#define X_ENTRY_ARGS \
+	int, msg_id, \
+	size_t, ctx, \
+	int, total_len
+
+#define X_ENTRY_FIELDS \
+	lttng_ust_field_integer(int, msg_id, msg_id) \
+	lttng_ust_field_integer_hex(size_t, ctx, ctx) \
+	lttng_ust_field_integer(int, total_len, total_len) 
+
+#define MSG_ARGS \
+	size_t, msg_ctx, \
+	size_t, addr
+
+#define MSG_FIELDS \
+	lttng_ust_field_integer_hex(size_t, msg_ctx, msg_ctx) \
+	lttng_ust_field_integer_hex(size_t, addr, addr)
+
+#define CQ_ENTRY_ARGS \
+	int, tag, \
+	size_t, addr
+
+#define CQ_ENTRY_FIELDS \
+	lttng_ust_field_integer(int, tag, tag) \
+	lttng_ust_field_integer_hex(size_t, addr, addr)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+	EFA_RDM_TP_PROV,
+	send_begin,
+	LTTNG_UST_TP_ARGS(
+		X_ENTRY_ARGS
+	),
+	LTTNG_UST_TP_FIELDS(
+		X_ENTRY_FIELDS  
+	)
+)
+LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_RDM_TP_PROV, send_begin, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+	EFA_RDM_TP_PROV,
+	send_begin_msg_context,
+	LTTNG_UST_TP_ARGS(
+		MSG_ARGS
+	),
+	LTTNG_UST_TP_FIELDS(
+		MSG_FIELDS
+	)
+)
+LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_RDM_TP_PROV, send_begin_msg_context, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+	EFA_RDM_TP_PROV,
+	recv_begin,
+	LTTNG_UST_TP_ARGS(
+		X_ENTRY_ARGS
+	),
+	LTTNG_UST_TP_FIELDS(
+		X_ENTRY_FIELDS
+	)
+)
+LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_RDM_TP_PROV, recv_begin, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+	EFA_RDM_TP_PROV,
+	recv_begin_msg_context,
+	LTTNG_UST_TP_ARGS(
+		MSG_ARGS
+	),
+	LTTNG_UST_TP_FIELDS(
+		MSG_FIELDS
+	)
+)
+LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_RDM_TP_PROV, recv_begin_msg_context, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+	EFA_RDM_TP_PROV,
+	send_end,
+	LTTNG_UST_TP_ARGS(
+		X_ENTRY_ARGS,
+		CQ_ENTRY_ARGS
+	),
+	LTTNG_UST_TP_FIELDS(
+		X_ENTRY_FIELDS
+		CQ_ENTRY_FIELDS
+	)
+)
+LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_RDM_TP_PROV, send_end, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+	EFA_RDM_TP_PROV,
+	recv_end,
+	LTTNG_UST_TP_ARGS(
+		X_ENTRY_ARGS,
+		CQ_ENTRY_ARGS
+	),
+	LTTNG_UST_TP_FIELDS(
+		X_ENTRY_FIELDS
+		CQ_ENTRY_FIELDS
+	)
+)
+LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_RDM_TP_PROV, recv_end, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+	EFA_RDM_TP_PROV,
+	msg_match_unexpected,
+	LTTNG_UST_TP_ARGS(
+		X_ENTRY_ARGS,
+		CQ_ENTRY_ARGS
+	),
+	LTTNG_UST_TP_FIELDS(
+		X_ENTRY_FIELDS
+		CQ_ENTRY_FIELDS
+	)
+)
+LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_RDM_TP_PROV, msg_match_unexpected, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+	EFA_RDM_TP_PROV,
+	msg_match_expected_nontagged,
+	LTTNG_UST_TP_ARGS(
+		X_ENTRY_ARGS
+	),
+	LTTNG_UST_TP_FIELDS(
+		X_ENTRY_FIELDS
+	)
+)
+LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_RDM_TP_PROV, msg_match_expected_nontagged, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+	EFA_RDM_TP_PROV,
+	msg_match_expected_tagged,
+	LTTNG_UST_TP_ARGS(
+		X_ENTRY_ARGS
+	),
+	LTTNG_UST_TP_FIELDS(
+		X_ENTRY_FIELDS
+	)
+)
+LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_RDM_TP_PROV, msg_match_expected_tagged, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+	EFA_RDM_TP_PROV,
+	longread_read_posted,
+	LTTNG_UST_TP_ARGS(
+		X_ENTRY_ARGS
+	),
+	LTTNG_UST_TP_FIELDS(
+		X_ENTRY_FIELDS
+	)
+)
+LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_RDM_TP_PROV, longread_read_posted, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+	EFA_RDM_TP_PROV,
+	runtread_read_posted,
+	LTTNG_UST_TP_ARGS(
+		X_ENTRY_ARGS
+	),
+	LTTNG_UST_TP_FIELDS(
+		X_ENTRY_FIELDS
+	)
+)
+LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_RDM_TP_PROV, runtread_read_posted, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+	EFA_RDM_TP_PROV,
+	read_completed,
+	LTTNG_UST_TP_ARGS(
+		X_ENTRY_ARGS,
+		size_t, context
+	),
+	LTTNG_UST_TP_FIELDS(
+		X_ENTRY_FIELDS
+		lttng_ust_field_integer_hex(size_t, context, context)
+	)
+)
+LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_RDM_TP_PROV, read_end, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
+
+#endif // _EFA_TP_H
+
+#include <lttng/tracepoint-event.h>


### PR DESCRIPTION
This PR adds 9 tracepoints into EFA provider. Detailed tracepoints are listed in its docs `prov/efa/docs/efa_tracing.txt`

Signed-off-by: Tang, Jingyin <jytang@amazon.com>