### PR TITLE
ofi_net: add io_uring support and update bsock data structure

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -112,6 +112,10 @@ common_srcs += include/linux/osd.h
 common_srcs += include/unix/osd.h
 endif
 
+if HAVE_LIBURING
+common_srcs += src/iouring.c
+endif
+
 common_hook_srcs =				\
 	prov/hook/src/hook.c			\
 	prov/hook/src/hook_av.c			\

--- a/configure.ac
+++ b/configure.ac
@@ -3,6 +3,7 @@ dnl Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2019-2021 Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2019-2020 Amazon.com, Inc. or its affiliates. All rights reserved.
 dnl (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+dnl Copyright (c) 2022 DataDirect Networks, Inc. All rights reserved.
 dnl
 dnl Process this file with autoconf to produce a configure script.
 
@@ -521,6 +522,36 @@ AC_SEARCH_LIBS([clock_gettime],[rt],
 AC_DEFINE_UNQUOTED(HAVE_CLOCK_GETTIME, [$have_clock_gettime],
        [Define to 1 if clock_gettime is available.])
 AM_CONDITIONAL(HAVE_CLOCK_GETTIME, [test $have_clock_gettime -eq 1])
+
+dnl Check for io_uring runtime libraries
+AC_ARG_WITH([uring],
+	    [AS_HELP_STRING([--with-uring@<:@=DIR@:>@],
+			    [Enable uring support @<:@default=yes@:>@.
+			     Optional=<Path to where liburing is installed.>])])
+
+have_liburing=0
+AS_IF([test x"$with_uring" != x"no"],
+      [FI_CHECK_PACKAGE([uring],
+			[liburing.h],
+			[uring],
+			[io_uring_queue_init],
+			[-luring],
+			[$with_uring],
+			[],
+			[have_liburing=1
+			AC_DEFINE_UNQUOTED([HAVE_LIBURING], [1], [io_uring support])]
+			[],
+			[])],
+      [])
+
+AS_IF([test x"$with_uring" != x"no" && test -n "$with_uring" && test $have_liburing -eq 0],
+	[AC_MSG_ERROR([io_uring support requested but liburing not available.])],
+	[])
+
+AS_IF([test x"$with_uring" != x"yes" && test x"$with_uring" != x"no"],
+	[CPPFLAGS="$CPPFLAGS $uring_CPPFLAGS"
+	 LDFLAGS="$LDFLAGS $uring_LDFLAGS"])
+LIBS="$LIBS $uring_LIBS"
 
 dnl Check for CUDA runtime libraries
 AC_ARG_WITH([cuda],

--- a/configure.ac
+++ b/configure.ac
@@ -547,6 +547,7 @@ AS_IF([test x"$with_uring" != x"no"],
 AS_IF([test x"$with_uring" != x"no" && test -n "$with_uring" && test $have_liburing -eq 0],
 	[AC_MSG_ERROR([io_uring support requested but liburing not available.])],
 	[])
+AM_CONDITIONAL([HAVE_LIBURING], test "$have_liburing" -eq 1)
 
 AS_IF([test x"$with_uring" != x"yes" && test x"$with_uring" != x"no"],
 	[CPPFLAGS="$CPPFLAGS $uring_CPPFLAGS"

--- a/include/freebsd/osd.h
+++ b/include/freebsd/osd.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016 Intel Corp, Inc. All rights reserved.
  * Copyright (c) 2018 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright (c) 2022 DataDirect Networks, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -144,6 +145,38 @@ static inline ssize_t
 ofi_recvmsg_tcp(SOCKET fd, struct msghdr *msg, int flags)
 {
 	return recvmsg(fd, msg, flags);
+}
+
+static inline ssize_t
+ofi_sendv_socket(SOCKET fd, const struct iovec *iov, size_t cnt, int flags)
+{
+       struct msghdr msg;
+
+       msg.msg_control = NULL;
+       msg.msg_controllen = 0;
+       msg.msg_flags = 0;
+       msg.msg_name = NULL;
+       msg.msg_namelen = 0;
+       msg.msg_iov = (struct iovec *) iov;
+       msg.msg_iovlen = cnt;
+
+       return ofi_sendmsg_tcp(fd, &msg, flags);
+}
+
+static inline ssize_t
+ofi_recvv_socket(SOCKET fd, const struct iovec *iov, size_t cnt, int flags)
+{
+       struct msghdr msg;
+
+       msg.msg_control = NULL;
+       msg.msg_controllen = 0;
+       msg.msg_flags = 0;
+       msg.msg_name = NULL;
+       msg.msg_namelen = 0;
+       msg.msg_iov = (struct iovec *) iov;
+       msg.msg_iovlen = cnt;
+
+       return ofi_recvmsg_tcp(fd, &msg, flags);
 }
 
 #endif /* _FREEBSD_OSD_H_ */

--- a/include/linux/osd.h
+++ b/include/linux/osd.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015 Los Alamos Nat. Security, LLC. All rights reserved.
  * Copyright (c) 2018 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright (c) 2022 DataDirect Networks, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -174,6 +175,38 @@ static inline ssize_t
 ofi_recvmsg_tcp(SOCKET fd, struct msghdr *msg, int flags)
 {
 	return recvmsg(fd, msg, flags);
+}
+
+static inline ssize_t
+ofi_sendv_socket(SOCKET fd, const struct iovec *iov, size_t cnt, int flags)
+{
+       struct msghdr msg;
+
+       msg.msg_control = NULL;
+       msg.msg_controllen = 0;
+       msg.msg_flags = 0;
+       msg.msg_name = NULL;
+       msg.msg_namelen = 0;
+       msg.msg_iov = (struct iovec *) iov;
+       msg.msg_iovlen = cnt;
+
+       return ofi_sendmsg_tcp(fd, &msg, flags);
+}
+
+static inline ssize_t
+ofi_recvv_socket(SOCKET fd, const struct iovec *iov, size_t cnt, int flags)
+{
+       struct msghdr msg;
+
+       msg.msg_control = NULL;
+       msg.msg_controllen = 0;
+       msg.msg_flags = 0;
+       msg.msg_name = NULL;
+       msg.msg_namelen = 0;
+       msg.msg_iov = (struct iovec *) iov;
+       msg.msg_iovlen = cnt;
+
+       return ofi_recvmsg_tcp(fd, &msg, flags);
 }
 
 #endif /* _LINUX_OSD_H_ */

--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -315,7 +315,7 @@ static inline size_t ofi_bsock_tosend(struct ofi_bsock *bsock)
 }
 
 ssize_t ofi_bsock_flush(struct ofi_bsock *bsock);
-/* For sends started asynchronously, the return value will be -EINPROGRESS,
+/* For sends started asynchronously, the return value will be -EINPROGRESS_ASYNC,
  * and len will be set to the number of bytes that were queued.
  */
 ssize_t ofi_bsock_send(struct ofi_bsock *bsock, const void *buf, size_t *len);

--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -101,6 +101,11 @@ static inline uint64_t ntohll(uint64_t x) { return x; }
 #endif
 
 
+enum {
+	OFI_EINPROGRESS_ASYNC = 512,	/* Async sockets */
+	OFI_EINPROGRESS_URING = 513,	/* io_uring */
+};
+
 static inline int ofi_recvall_socket(SOCKET sock, void *buf, size_t len)
 {
 	ssize_t ret;

--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -278,19 +278,12 @@ struct ofi_bsock {
 	uint32_t done_index;
 };
 
-static struct ofi_sockapi ofi_bsock_sockapi =
-{
-    .send = ofi_sockapi_send_socket,
-    .sendv = ofi_sockapi_sendv_socket,
-    .recv = ofi_sockapi_recv_socket,
-    .recvv = ofi_sockapi_recvv_socket,
-};
-
 static inline void
-ofi_bsock_init(struct ofi_bsock *bsock, ssize_t sbuf_size, ssize_t rbuf_size)
+ofi_bsock_init(struct ofi_bsock *bsock, struct ofi_sockapi *sockapi,
+	       ssize_t sbuf_size, ssize_t rbuf_size)
 {
 	bsock->sock = INVALID_SOCKET;
-	bsock->sockapi = &ofi_bsock_sockapi;
+	bsock->sockapi = sockapi;
 	ofi_byteq_init(&bsock->sq, sbuf_size);
 	ofi_byteq_init(&bsock->rq, rbuf_size);
 	bsock->zerocopy_size = SIZE_MAX;

--- a/include/osx/osd.h
+++ b/include/osx/osd.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2015 Los Alamos Nat. Security, LLC. All rights reserved.
  * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
  * Copyright (c) 2018 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright (c) 2022 DataDirect Networks, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -156,12 +157,16 @@ ofi_sendto_socket(SOCKET fd, const void *buf, size_t count, int flags,
 	return sendto(fd, buf, len, flags, to, tolen);
 }
 
+ssize_t ofi_sendv_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt,
+			 int flags);
+ssize_t ofi_recvv_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt,
+			 int flags);
 ssize_t ofi_writev_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt);
 ssize_t ofi_readv_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt);
 ssize_t ofi_sendmsg_tcp(SOCKET fd, const struct msghdr *msg, int flags);
 ssize_t ofi_recvmsg_tcp(SOCKET fd, struct msghdr *msg, int flags);
 
-/* 
+/*
  * pthread_spinlock is not available on Mac OS X, the following code
  * used os_unfair_lock to implement pthread_spinlock.
  * os_unfair_lock does not enforce fairness or lock ordering (hence

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2016 Intel Corporation.  All rights reserved.
  * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2018 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright (c) 2022 DataDirect Networks, Inc. All rights reserved.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
@@ -774,6 +775,10 @@ ofi_sendto_socket(SOCKET fd, const void *buf, size_t count, int flags,
 	return sendto(fd, (const char*) buf, len, flags, to, (int) tolen);
 }
 
+ssize_t ofi_sendv_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt,
+			 int flags);
+ssize_t ofi_recvv_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt,
+			 int flags);
 ssize_t ofi_writev_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt);
 ssize_t ofi_readv_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt);
 ssize_t ofi_sendmsg_tcp(SOCKET fd, const struct msghdr *msg, int flags);

--- a/prov/net/src/xnet_ep.c
+++ b/prov/net/src/xnet_ep.c
@@ -43,6 +43,13 @@ extern struct fi_ops_rma xnet_rma_ops;
 extern struct fi_ops_msg xnet_msg_ops;
 extern struct fi_ops_tagged xnet_tagged_ops;
 
+static struct ofi_sockapi xnet_sockapi =
+{
+	.send = ofi_sockapi_send_socket,
+	.sendv = ofi_sockapi_sendv_socket,
+	.recv = ofi_sockapi_recv_socket,
+	.recvv = ofi_sockapi_recvv_socket,
+};
 
 void xnet_hdr_none(struct xnet_base_hdr *hdr)
 {
@@ -622,7 +629,7 @@ int xnet_endpoint(struct fid_domain *domain, struct fi_info *info,
 	if (ret)
 		goto err1;
 
-	ofi_bsock_init(&ep->bsock, xnet_staging_sbuf_size,
+	ofi_bsock_init(&ep->bsock, &xnet_sockapi, xnet_staging_sbuf_size,
 		       xnet_prefetch_rbuf_size);
 	if (info->handle) {
 		if (((fid_t) info->handle)->fclass == FI_CLASS_PEP) {

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -80,10 +80,10 @@ static ssize_t xnet_send_msg(struct xnet_ep *ep)
 	tx_entry = ep->cur_tx.entry;
 	ret = ofi_bsock_sendv(&ep->bsock, tx_entry->iov, tx_entry->iov_cnt,
 			      &len);
-	if (ret < 0 && ret != -FI_EINPROGRESS)
+	if (ret < 0 && ret != -OFI_EINPROGRESS_ASYNC)
 		return ret;
 
-	if (ret == -FI_EINPROGRESS) {
+	if (ret == -OFI_EINPROGRESS_ASYNC) {
 		/* If a transfer generated multiple async sends, we only
 		 * need to track the last async index to know when the entire
 		 * transfer has completed.

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -43,6 +43,13 @@ extern struct fi_ops_rma tcpx_rma_ops;
 extern struct fi_ops_msg tcpx_msg_ops;
 extern struct fi_ops_tagged tcpx_tagged_ops;
 
+static struct ofi_sockapi tcpx_sockapi =
+{
+	.send = ofi_sockapi_send_socket,
+	.sendv = ofi_sockapi_sendv_socket,
+	.recv = ofi_sockapi_recv_socket,
+	.recvv = ofi_sockapi_recvv_socket,
+};
 
 void tcpx_hdr_none(struct tcpx_base_hdr *hdr)
 {
@@ -775,7 +782,7 @@ int tcpx_endpoint(struct fid_domain *domain, struct fi_info *info,
 	if (ret)
 		goto err1;
 
-	ofi_bsock_init(&ep->bsock, tcpx_staging_sbuf_size,
+	ofi_bsock_init(&ep->bsock, &tcpx_sockapi, tcpx_staging_sbuf_size,
 		       tcpx_prefetch_rbuf_size);
 	if (info->handle) {
 		if (((fid_t) info->handle)->fclass == FI_CLASS_PEP) {

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -56,10 +56,10 @@ static ssize_t tcpx_send_msg(struct tcpx_ep *ep)
 	tx_entry = ep->cur_tx.entry;
 	ret = ofi_bsock_sendv(&ep->bsock, tx_entry->iov, tx_entry->iov_cnt,
 			      &len);
-	if (ret < 0 && ret != -FI_EINPROGRESS)
+	if (ret < 0 && ret != -OFI_EINPROGRESS_ASYNC)
 		return ret;
 
-	if (ret == -FI_EINPROGRESS) {
+	if (ret == -OFI_EINPROGRESS_ASYNC) {
 		/* If a transfer generated multiple async sends, we only
 		 * need to track the last async index to know when the entire
 		 * transfer has completed.

--- a/src/common.c
+++ b/src/common.c
@@ -1192,7 +1192,7 @@ ssize_t ofi_bsock_send(struct ofi_bsock *bsock, const void *buf, size_t *len)
 		if (ret >= 0) {
 			bsock->async_index++;
 			*len = ret;
-			return -FI_EINPROGRESS;
+			return -OFI_EINPROGRESS_ASYNC;
 		}
 	} else {
 		ret = bsock->sockapi->send(bsock->sockapi, bsock->sock, buf, *len,
@@ -1243,7 +1243,7 @@ ssize_t ofi_bsock_sendv(struct ofi_bsock *bsock, const struct iovec *iov,
 		if (ret >= 0) {
 			bsock->async_index++;
 			*len = ret;
-			return -FI_EINPROGRESS;
+			return -OFI_EINPROGRESS_ASYNC;
 		}
 	} else {
 		ret = bsock->sockapi->sendv(bsock->sockapi, bsock->sock, iov, cnt,

--- a/src/iouring.c
+++ b/src/iouring.c
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2022 Intel Corporation. All rights reserved.
+ * Copyright (c) 2022 DataDirect Networks, Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "config.h"
+
+#include <liburing.h>
+
+#include <ofi_net.h>
+
+ssize_t ofi_sockapi_send_uring(struct ofi_sockapi *sockapi, SOCKET sock,
+			       const void *buf,  size_t len, int flags, void *ctx)
+{
+	struct io_uring_sqe *sqe;
+
+	/* MSG_NOSIGNAL would return ENOTSUP with io_uring */
+	flags &= ~MSG_NOSIGNAL;
+	/* zero-copy will be implemented later */
+	flags &= ~OFI_ZEROCOPY;
+
+	sqe = io_uring_get_sqe(sockapi->tx_io_uring);
+	if (!sqe)
+		return -FI_EOVERFLOW;
+
+	io_uring_prep_send(sqe, sock, buf, len, flags);
+	io_uring_sqe_set_data(sqe, ctx);
+	return -OFI_EINPROGRESS_URING;
+}
+
+ssize_t ofi_sockapi_sendv_uring(struct ofi_sockapi *sockapi, SOCKET sock,
+				const struct iovec *iov, size_t cnt, int flags,
+				void *ctx)
+{
+	struct io_uring_sqe *sqe;
+
+	/* MSG_NOSIGNAL would return ENOTSUP with io_uring */
+	flags &= ~MSG_NOSIGNAL;
+	/* zero-copy will be implemented later */
+	flags &= ~OFI_ZEROCOPY;
+
+	sqe = io_uring_get_sqe(sockapi->tx_io_uring);
+	if (!sqe)
+		return -FI_EOVERFLOW;
+
+	io_uring_prep_writev(sqe, sock, iov, cnt, flags);
+	io_uring_sqe_set_data(sqe, ctx);
+	return -OFI_EINPROGRESS_URING;
+}
+
+ssize_t ofi_sockapi_recv_uring(struct ofi_sockapi *sockapi, SOCKET sock,
+			       void *buf, size_t len, int flags, void *ctx)
+{
+	struct io_uring_sqe *sqe;
+
+	sqe = io_uring_get_sqe(sockapi->rx_io_uring);
+	if (!sqe)
+		return -FI_EOVERFLOW;
+
+	io_uring_prep_recv(sqe, sock, buf, len, flags);
+	io_uring_sqe_set_data(sqe, ctx);
+	return -OFI_EINPROGRESS_URING;
+}
+
+ssize_t ofi_sockapi_recvv_uring(struct ofi_sockapi *sockapi, SOCKET sock,
+				struct iovec *iov, size_t cnt, int flags,
+				void *ctx)
+{
+	struct io_uring_sqe *sqe;
+
+	sqe = io_uring_get_sqe(sockapi->rx_io_uring);
+	if (!sqe)
+		return -FI_EOVERFLOW;
+
+	io_uring_prep_readv(sqe, sock, iov, cnt, flags);
+	io_uring_sqe_set_data(sqe, ctx);
+	return -OFI_EINPROGRESS_URING;
+}

--- a/src/osx/osd.c
+++ b/src/osx/osd.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020 by Argonne National Laboratory.
+ * Copyright (c) 2022 DataDirect Networks, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -33,7 +34,7 @@
 #include "ofi.h"
 #include "ofi_osd.h"
 
-static ssize_t
+ssize_t
 ofi_sendv_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt, int flags)
 {
 	ssize_t size = 0;
@@ -58,7 +59,7 @@ ofi_sendv_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt, int flags
 	return size;
 }
 
-static ssize_t
+ssize_t
 ofi_recvv_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt, int flags)
 {
 	ssize_t size = 0;

--- a/src/windows/osd.c
+++ b/src/windows/osd.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013-2017 Intel Corporation. All rights reserved.
+ * Copyright (c) 2022 DataDirect Networks, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -505,7 +506,7 @@ void freeifaddrs(struct ifaddrs *ifa)
 	}
 }
 
-static ssize_t
+ssize_t
 ofi_sendv_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt, int flags)
 {
 	ssize_t size = 0, ret;
@@ -530,7 +531,7 @@ ofi_sendv_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt, int flags
 	return size;
 }
 
-static ssize_t
+ssize_t
 ofi_recvv_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt, int flags)
 {
 	ssize_t size = 0, ret;


### PR DESCRIPTION
This PR is an attempt at adding io_uring support to the bsock/byteq datastructures.
To do so, this PR adds a new interface named ofi_sockapi that aims at providing a common interface between io_uring and the traditional sockets.