### PR TITLE
[1.15.x] contrib/intel: change node name delimiter from - to _

### DIFF
--- a/contrib/intel/jenkins/runtests.py
+++ b/contrib/intel/jenkins/runtests.py
@@ -41,7 +41,7 @@ if (args.imb_grp):
 else:
     imb_group = '1'
 
-node = (os.environ['NODE_NAME']).split('-')[0]
+node = (os.environ['NODE_NAME']).split('_')[0]
 hosts = [node]
 mpilist = ['impi', 'mpich', 'ompi']
 


### PR DESCRIPTION
The Jenkins nodes use the naming convention "node-fabric" Jenkins parses by the '-' and assumes the first element to be the node name to ssh into. This delimiter conflicts with normal node naming convention which uses dashes within the node name. This changes the node/fabric delimiter from - to _ so it doesn't conflict with regular node names.

Note that this will require a momentary down period between naming the nodes and merging the PR.
After this change is merged, PRs will have to rebase on upstream in order to pass.

Cherry-picked from commit cb8dc8cc8a8e0c6d8adf6fd0015b9ed14afe3edb

Signed-off-by: Alexia Ingerson <alexia.ingerson@intel.com>