### PR TITLE
[v1.16.x] prov/sockets: fix segfault for conn->av_index in sock_av_remove

### DIFF
--- a/prov/sockets/src/sock_av.c
+++ b/prov/sockets/src/sock_av.c
@@ -437,7 +437,7 @@ static int sock_av_remove(struct fid_av *av, fi_addr_t *fi_addr, size_t count,
 		for (i = 0; i < count; i++) {
 			idx = (uint16_t)(fi_addr[i] & sock_ep->attr->av->mask);
 			conn = ofi_idm_lookup(&sock_ep->attr->av_idm, idx);
-			if (conn) {
+			if (conn && conn != SOCK_CM_CONN_IN_PROGRESS) {
 				/* A peer may be using the connection, so leave
 				 * it operational, just dissociate it from AV.
 				 */


### PR DESCRIPTION
Check conn != SOCK_CM_CONN_IN_PROGRESS in addition to conn != NULL, because conn can be partially initialized in sock_ep_get_conn. Acessing SOCK_CM_CONN_IN_PROGRESS->av_index causes a segfault.

Signed-off-by: Wenduo Wang <wenduwan@amazon.com>
(cherry picked from commit bf66b48c133ccd78292b00b7c12123bed1a0d848)