### PR TITLE
contrib/intel/jenkins disable ompi osu tests

### DIFF
--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -586,14 +586,10 @@ class OSUtests(Test):
 
     @property
     def execute_condn(self):
-        # mpich-tcp, ompi-tcp, and net are the only osu test combinations failing
-        return not (
-            (
-                self.core_prov == 'tcp'
-                and (self.mpi_type == 'mpich' or self.mpi_type == 'ompi')
-            )
-            or self.core_prov == 'net'
-        )
+        # mpich-tcp, ompi, and net are the only osu test combinations failing
+        return False if ((self.mpi_type == 'mpich' and self.core_prov == 'tcp') or \
+                          self.mpi_type == 'ompi' or self.core_prov == 'net') \
+                     else True
 
     def osu_cmd(self, test_type, test):
         print(f"Running OSU-{test_type}-{test}")

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -365,6 +365,10 @@ class OMPI:
             opts += f"--mca mtl_ofi_provider_include {self.core_prov} "
             opts += f"--mca btl_ofi_provider_include {self.core_prov} "
         opts += "--mca orte_base_help_aggregate 0 "
+        # This is necessary to prevent verbs from printing warning messages
+        # The test still uses libfabric verbs even when enabled.
+        # if (self.core_prov == 'verbs'):
+        #     opts += "--mca btl_openib_allow_ib 1 "
         opts += "--mca mtl ofi "
         opts += "--mca pml cm -tag-output "
         for key in self.environ:


### PR DESCRIPTION
OMPI OSU was accidentally re-enabled in PR-8108's change of the OSUtests class's execute condition while a known hang issue still occurs. Disabling it again until we fix the problem.

The problem: ompi 4.1.0 with osu tests 5.7 fails verbs-rxm on osu_allgatherv byte transfer 128 with a hang.
I suspect it is a race condition because sometimes the test passes and sometimes not. It will require further debugging.