### PR TITLE
fabtests/pytest/common.py: Make the ssh error detection more general.

### DIFF
--- a/fabtests/pytest/common.py
+++ b/fabtests/pytest/common.py
@@ -18,10 +18,9 @@ def is_ssh_connection_error(exception):
 
 
 def has_ssh_connection_err_msg(output):
-    err_msgs = ["kex_exchange_identification: Connection closed by remote host",
-                "ssh_exchange_identification: Connection closed by remote host",
-                "ssh_exchange_identification: read: Connection reset by peer",
-                "port 22: Connection refused"]
+    err_msgs = ["Connection closed by remote host",
+                "Connection reset by peer",
+                "Connection refused"]
 
     for msg in err_msgs:
         if output.find(msg) != -1:


### PR DESCRIPTION
When an ssh error happens,
"Connection closed", "Connection refused", "Connection reset" can show up randomly with "ssh_exchange_identification"/"kex_exchange_identification". This patch removes the restrictions of "ssh_exchange_identification"/"kex_exchange_identification" in the err message to make the error detection more robust.

Signed-off-by: Shi Jin <sjina@amazon.com>