### PR TITLE
[v1.16.x] contrib/intel/jenkins: Fix typo in change_target

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -4,7 +4,7 @@ def DO_RUN=1
 def TARGET="main"
 
 def check_target() {
-  echo "CHANGE_TARGET = ${env.CHANGE_TARET}"
+  echo "CHANGE_TARGET = ${env.CHANGE_TARGET}"
   if (changeRequest()) {
     TARGET = env.CHANGE_TARGET
   }


### PR DESCRIPTION
This typo fix will make jenkins pull the right repo/branch for its changes comparison instead of defaulting always to main.

Signed-off-by: Zach Dworkin <zachary.dworkin@intel.com>
(cherry picked from commit e621442935cf15628769608bbc89178d486683c8)