### PR TITLE
Revert buffer pool flag changes

### DIFF
--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -312,7 +312,6 @@ enum {
 	OFI_BUFPOOL_NO_TRACK		= 1 << 2,
 	OFI_BUFPOOL_HUGEPAGES		= 1 << 3,
 	OFI_BUFPOOL_NONSHARED		= 1 << 4,
-	OFI_BUFPOOL_HMEM_COPY		= 1 << 5,
 };
 
 struct ofi_bufpool_region;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -253,7 +253,6 @@ static void rxm_recv_queue_close(struct rxm_recv_queue *recv_queue)
 static int rxm_ep_create_pools(struct rxm_ep *rxm_ep)
 {
 	struct ofi_bufpool_attr attr = {0};
-	bool hmem_enabled = !!(rxm_ep->util_ep.caps & FI_HMEM);
 	int ret;
 
 	attr.size = rxm_buffer_size + sizeof(struct rxm_rx_buf);
@@ -264,8 +263,6 @@ static int rxm_ep_create_pools(struct rxm_ep *rxm_ep)
 	attr.init_fn = rxm_init_rx_buf;
 	attr.context = rxm_ep;
 	attr.flags = OFI_BUFPOOL_NO_TRACK;
-	if (hmem_enabled)
-		attr.flags |= OFI_BUFPOOL_HMEM_COPY;
 
 	ret = ofi_bufpool_create_attr(&attr, &rxm_ep->rx_pool);
 	if (ret) {
@@ -303,10 +300,6 @@ static int rxm_multi_recv_pool_init(struct rxm_ep *rxm_ep)
 		.context	= rxm_ep,
 		.flags		= OFI_BUFPOOL_NO_TRACK,
 	};
-	bool hmem_enabled = !!(rxm_ep->util_ep.caps & FI_HMEM);
-
-	if (hmem_enabled)
-		attr.flags |= OFI_BUFPOOL_HMEM_COPY;
 
 	return ofi_bufpool_create_attr(&attr, &rxm_ep->multi_recv_pool);
 }


### PR DESCRIPTION
It turns out rxm already uses attrs.alloc_fn/free_fn to handle host registration. Out of the three commits from PR #8137, revert the two commits related to the new flag and keep only the hmem_ze change.