### PR TITLE
contrib/intel/jenkins: Update jenkins workspace & globalize py_scripts variable

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -2,6 +2,7 @@
 properties([disableConcurrentBuilds(abortPrevious: true)])
 def DO_RUN=1
 def TARGET="main"
+def SCRIPT_LOCATION="py_scripts/contrib/intel/jenkins"
 def check_target() {
   echo "CHANGE_TARGET = ${env.CHANGE_TARGET}"
   if (changeRequest()) {
@@ -79,31 +80,31 @@ pipeline {
               sh """
                 echo "-----------------------------------------------------"
                 echo "Copy build dirs."
-                python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=builddir
+                python3.7 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=builddir
                 echo "Copy build dirs completed."
                 echo "-----------------------------------------------------"
                 echo "Copy log dirs."
-                python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=logdir
+                python3.7 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=logdir
                 echo "Copy log dirs completed."
                 echo "-----------------------------------------------------"
                 echo "Building libfabric reg."
-                python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=libfabric
+                python3.7 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=libfabric
                 echo "-----------------------------------------------------"
                 echo "Building libfabric dbg."
-                python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=libfabric --ofi_build_mode=dbg
+                python3.7 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=libfabric --ofi_build_mode=dbg
                 echo "-----------------------------------------------------"
                 echo "Building libfabric dl."
-                python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=libfabric --ofi_build_mode=dl
+                python3.7 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=libfabric --ofi_build_mode=dl
                 echo "Libfabric builds completed."
                 echo "-----------------------------------------------------"
                 echo "Building fabtests reg."
-                python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=fabtests
+                python3.7 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=fabtests
                 echo "-----------------------------------------------------"
                 echo "Building fabtests dbg."
-                python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=fabtests --ofi_build_mode=dbg
+                python3.7 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=fabtests --ofi_build_mode=dbg
                 echo "-----------------------------------------------------"
                 echo "Building fabtests dl."
-                python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=fabtests --ofi_build_mode=dl
+                python3.7 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=fabtests --ofi_build_mode=dl
                 echo 'Fabtests builds completed.'
               """
             }
@@ -127,8 +128,8 @@ pipeline {
                     rm -rf ${env.WORKSPACE}/py_scripts && mkdir ${env.WORKSPACE}/py_scripts
                   fi
                   git clone ${env.UPSTREAM} ${env.WORKSPACE}/py_scripts
-                  python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=libfabric --build_cluster='daos'
-                  python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=fabtests
+                  python3.7 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=libfabric --build_cluster='daos'
+                  python3.7 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=fabtests
                 )
               """
             }
@@ -152,9 +153,9 @@ pipeline {
                     rm -rf ${env.WORKSPACE}/py_scripts && mkdir ${env.WORKSPACE}/py_scripts
                   fi
                   git clone ${env.UPSTREAM} ${env.WORKSPACE}/py_scripts
-                  python3.9 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=logdir
-                  python3.9 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=libfabric --build_cluster='dsa'
-                  python3.9 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/build.py --build_item=fabtests
+                  python3.9 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=logdir
+                  python3.9 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=libfabric --build_cluster='dsa'
+                  python3.9 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=fabtests
                 )
               """
             }
@@ -173,7 +174,7 @@ pipeline {
               sh """
                 env
                 (
-                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/${SCRIPT_LOCATION}/
                   python3.7 runtests.py --prov=verbs --util=rxm --test=IMB --imb_grp=1
                   echo "IMB verbs-rxm Group 1 completed."
                   python3.7 runtests.py --prov=verbs --util=rxm --test=IMB --imb_grp=2
@@ -196,7 +197,7 @@ pipeline {
               sh """
                 env
                 (
-                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/${SCRIPT_LOCATION}/
                   python3.7 runtests.py --prov=tcp --util=rxm --test=IMB --imb_grp=2
                   echo "MPI-tcp-rxm-2 completed."
                 )
@@ -212,7 +213,7 @@ pipeline {
               sh """
                 env
                 (
-                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/${SCRIPT_LOCATION}/
                   python3.7 runtests.py --prov=tcp --test=fabtests
                   python3.7 runtests.py --prov=tcp --test=fabtests --ofi_build_mode=dbg
                   python3.7 runtests.py --prov=tcp --test=fabtests --ofi_build_mode=dl
@@ -230,7 +231,7 @@ pipeline {
               sh """
                 env
                 (
-                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/${SCRIPT_LOCATION}/
                   python3.7 runtests.py --prov=verbs --util=rxm --test=fabtests
                   python3.7 runtests.py --prov=verbs --util=rxm --test=fabtests --ofi_build_mode=dbg
                   python3.7 runtests.py --prov=verbs --util=rxm --test=fabtests --ofi_build_mode=dl
@@ -248,7 +249,7 @@ pipeline {
               sh """
                 env
                 (
-                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/${SCRIPT_LOCATION}/
                   python3.7 runtests.py --prov=verbs --util=rxd --test=fabtests
                   python3.7 runtests.py --prov=verbs --util=rxd --test=fabtests --ofi_build_mode=dbg
                   python3.7 runtests.py --prov=verbs --util=rxd --test=fabtests --ofi_build_mode=dl
@@ -266,7 +267,7 @@ pipeline {
               sh """
                 env
                 (
-                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/${SCRIPT_LOCATION}/
                   python3.7 runtests.py --prov=udp --test=fabtests
                   python3.7 runtests.py --prov=udp --test=fabtests --ofi_build_mode=dbg
                   python3.7 runtests.py --prov=udp --test=fabtests --ofi_build_mode=dl
@@ -284,7 +285,7 @@ pipeline {
               sh """
                 env
                 (
-                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/${SCRIPT_LOCATION}/
                   python3.7 runtests.py --prov=shm --test=fabtests
                   python3.7 runtests.py --prov=shm --test=fabtests --ofi_build_mode=dbg
                   python3.7 runtests.py --prov=shm --test=fabtests --ofi_build_mode=dl
@@ -305,7 +306,7 @@ pipeline {
               sh """
                 env
                 (
-                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/${SCRIPT_LOCATION}/
                   python3.7 runtests.py --prov=sockets --test=fabtests
                   python3.7 runtests.py --prov=sockets --test=fabtests --ofi_build_mode=dbg
                   python3.7 runtests.py --prov=sockets --test=fabtests --ofi_build_mode=dl
@@ -325,7 +326,7 @@ pipeline {
                 (
                   export PSM3_IDENTIFY=1
                   export FI_LOG_LEVEL=info
-                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/${SCRIPT_LOCATION}/
                   python3.7 runtests.py --prov=psm3 --test=fabtests
                   python3.7 runtests.py --prov=psm3 --test=fabtests --ofi_build_mode=dbg
                   python3.7 runtests.py --prov=psm3 --test=fabtests --ofi_build_mode=dl
@@ -343,7 +344,7 @@ pipeline {
               sh """
                 env
                 (
-                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/${SCRIPT_LOCATION}/
                   python3.7 runtests.py --prov=tcp --util=rxm --test=IMB --imb_grp=1
                   echo "MPI-tcp-rxm-1 completed."
                 )
@@ -359,7 +360,7 @@ pipeline {
               sh """
                 env
                 (
-                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/${SCRIPT_LOCATION}/
                   python3.7 runtests.py --prov=tcp --util=rxm --test=IMB --imb_grp=3
                   echo "MPI-tcp-rxm-3 completed."
                   python3.7 runtests.py --prov=tcp --util=rxm --test=osu
@@ -377,7 +378,7 @@ pipeline {
               sh """
                 env
                 (
-                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/${SCRIPT_LOCATION}/
                   python3.7 runtests.py --prov=verbs --util=rxm --test=mpichtestsuite
                   echo "verbs-rxm MPICH testsuite completed."
                   python3.7 runtests.py --prov=tcp --util=rxm --test=mpichtestsuite
@@ -400,7 +401,7 @@ pipeline {
               sh """
                 env
                 (
-                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/${SCRIPT_LOCATION}/
                   python3.7 runtests.py --prov=tcp --test=shmem
                   echo "SHMEM tcp completed."
                   python3.7 runtests.py --prov=net --test=shmem
@@ -424,7 +425,7 @@ pipeline {
                 sh """
                   env
                   (
-                      cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                      cd ${env.WORKSPACE}/${SCRIPT_LOCATION}/
                       python3.7 runtests.py --prov=tcp --test=multinode
                       echo "multinode performance completed."
                   )
@@ -440,7 +441,7 @@ pipeline {
               sh """
                 env
                 (
-                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/${SCRIPT_LOCATION}/
                   python3.7 runtests.py --prov=tcp --util=rxm --test=oneccl
                   echo "oneCCL tcp-rxm completed."
                   python3.7 runtests.py --prov=net --test=oneccl
@@ -461,7 +462,7 @@ pipeline {
               sh """
                 env
                 (
-                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/${SCRIPT_LOCATION}/
                   python3.7 runtests.py --prov=tcp --test=onecclgpu
                   echo "oneCCL-GPU tcp completed."
                   python3.7 runtests.py --prov=net --test=onecclgpu
@@ -486,7 +487,7 @@ pipeline {
                 env
                 (
                   echo `hostname`
-                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/${SCRIPT_LOCATION}/
                   python3.7 runtests.py --prov='tcp' --util='rxm' --test=daos
                   echo "daos-tcp test completed."
                 )
@@ -508,7 +509,7 @@ pipeline {
                 env
                 (
                   echo `hostname`
-                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/${SCRIPT_LOCATION}/
                   python3.7 runtests.py --prov='verbs' --util='rxm' --test=daos
                   echo "daos-verbs test completed."
                 )
@@ -530,7 +531,7 @@ pipeline {
               env
               (
                 echo `hostname`
-                cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                cd ${env.WORKSPACE}/${SCRIPT_LOCATION}/
                 python3.9 runtests.py --prov=shm --test=fabtests --user_env="{'FI_SHM_DISABLE_CMA':1, 'FI_SHM_USE_DSA_SAR':1}"
               )
               """
@@ -545,7 +546,7 @@ pipeline {
               sh """
                 env
                 (
-                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/${SCRIPT_LOCATION}/
                   python3.7 runtests.py --prov=net --test=fabtests
                   python3.7 runtests.py --prov=net --test=fabtests --ofi_build_mode=dbg
                   python3.7 runtests.py --prov=net --test=fabtests --ofi_build_mode=dl
@@ -564,7 +565,7 @@ pipeline {
               sh """
                 env
                 (
-                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/${SCRIPT_LOCATION}/
                   python3.7 runtests.py --prov=net --test=IMB --imb_grp=1
                   echo "MPI_net Group 1 completed."
                 )
@@ -580,7 +581,7 @@ pipeline {
               sh """
                 env
                 (
-                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/${SCRIPT_LOCATION}/
                   python3.7 runtests.py --prov=net --test=IMB --imb_grp=2
                   echo "MPI_net Group 2 completed."
                 )
@@ -596,7 +597,7 @@ pipeline {
               sh """
                 env
                 (
-                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/${SCRIPT_LOCATION}/
                   python3.7 runtests.py --prov=net --test=IMB --imb_grp=3
                   echo "MPI_net Group 3 completed."
                 )
@@ -612,7 +613,7 @@ pipeline {
               sh """
                 env
                 (
-                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/${SCRIPT_LOCATION}/
                   python3.7 runtests.py --prov=net --test=osu
                   echo "MPI-net-osu completed."
                 )
@@ -629,7 +630,7 @@ pipeline {
                 sh """
                   env
                   (
-                      cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                      cd ${env.WORKSPACE}/${SCRIPT_LOCATION}/
                       python3.7 runtests.py --prov=net --test=multinode
                       echo "multinode performance completed."
                   )
@@ -646,7 +647,7 @@ pipeline {
           sh """
             env
             (
-              python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/summary.py --summary_item=all
+              python3.7 ${env.WORKSPACE}/${SCRIPT_LOCATION}/summary.py --summary_item=all
             )
           """
         }
@@ -657,7 +658,7 @@ pipeline {
   post {
     always {
       withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
-        sh "python3.7 ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/summary.py --summary_item=all"
+        sh "python3.7 ${env.WORKSPACE}/${SCRIPT_LOCATION}/summary.py --summary_item=all"
       }
     }
     cleanup {

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -38,7 +38,12 @@ def skip() {
 }
 
 pipeline {
-  agent { node { label 'master' } }
+  agent {
+    node {
+      label 'master'
+      customWorkspace "${JENKINS_HOME}/workspace/${JOB_NAME}/${env.BUILD_NUMBER}"
+    }
+  }
   options {
       timestamps()
       timeout(activity: true, time: 1, unit: 'HOURS')
@@ -105,7 +110,12 @@ pipeline {
           }
         }
         stage ('build-daos') {
-          agent {node {label 'daos'}}
+          agent {
+            node {
+              label 'daos'
+              customWorkspace "${JENKINS_HOME}/workspace/${JOB_NAME}/${env.BUILD_NUMBER}"
+            }
+          }
           steps {
             withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
               sh """
@@ -125,7 +135,12 @@ pipeline {
           }
         }
         stage ('build-dsa') {
-          agent {node {label 'dsa'}}
+          agent {
+            node {
+              label 'dsa'
+              customWorkspace "${JENKINS_HOME}/workspace/${JOB_NAME}/${env.BUILD_NUMBER}"
+            }
+          }
           steps {
             withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
               sh """
@@ -151,14 +166,14 @@ pipeline {
       when { equals expected: 1, actual: DO_RUN }
       parallel {
         stage('MPI_verbs-rxm') {
-          agent {node {label 'mlx5'}}
+          agent { node { label 'mlx5' } }
           options { skipDefaultCheckout() }
           steps {
             withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
               sh """
                 env
                 (
-                  cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
                   python3.7 runtests.py --prov=verbs --util=rxm --test=IMB --imb_grp=1
                   echo "IMB verbs-rxm Group 1 completed."
                   python3.7 runtests.py --prov=verbs --util=rxm --test=IMB --imb_grp=2
@@ -174,14 +189,14 @@ pipeline {
           }
         }
         stage('MPI_tcp-rxm-2') {
-          agent {node {label 'cvl'}}
+          agent { node { label 'cvl' } }
           options { skipDefaultCheckout() }
           steps {
             withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
               sh """
                 env
                 (
-                  cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
                   python3.7 runtests.py --prov=tcp --util=rxm --test=IMB --imb_grp=2
                   echo "MPI-tcp-rxm-2 completed."
                 )
@@ -190,14 +205,14 @@ pipeline {
           }
         }
         stage('tcp') {
-          agent {node {label 'cvl'}}
+          agent { node { label 'cvl' } }
           options { skipDefaultCheckout() }
           steps {
             withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
               sh """
                 env
                 (
-                  cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
                   python3.7 runtests.py --prov=tcp --test=fabtests
                   python3.7 runtests.py --prov=tcp --test=fabtests --ofi_build_mode=dbg
                   python3.7 runtests.py --prov=tcp --test=fabtests --ofi_build_mode=dl
@@ -208,14 +223,14 @@ pipeline {
           }
         }
         stage('verbs-rxm') {
-          agent {node {label 'mlx5'}}
+          agent { node { label 'mlx5' } }
           options { skipDefaultCheckout() }
           steps {
             withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
               sh """
                 env
                 (
-                  cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
                   python3.7 runtests.py --prov=verbs --util=rxm --test=fabtests
                   python3.7 runtests.py --prov=verbs --util=rxm --test=fabtests --ofi_build_mode=dbg
                   python3.7 runtests.py --prov=verbs --util=rxm --test=fabtests --ofi_build_mode=dl
@@ -226,14 +241,14 @@ pipeline {
           }
         }
         stage('verbs-rxd') {
-          agent {node {label 'mlx5 && edr'}}
+          agent { node { label 'mlx5 && edr' } }
           options { skipDefaultCheckout() }
           steps {
             withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
               sh """
                 env
                 (
-                  cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
                   python3.7 runtests.py --prov=verbs --util=rxd --test=fabtests
                   python3.7 runtests.py --prov=verbs --util=rxd --test=fabtests --ofi_build_mode=dbg
                   python3.7 runtests.py --prov=verbs --util=rxd --test=fabtests --ofi_build_mode=dl
@@ -244,14 +259,14 @@ pipeline {
           }
         }
         stage('udp') {
-          agent {node {label 'cvl'}}
+          agent { node { label 'cvl' } }
           options { skipDefaultCheckout() }
           steps {
             withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
               sh """
                 env
                 (
-                  cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
                   python3.7 runtests.py --prov=udp --test=fabtests
                   python3.7 runtests.py --prov=udp --test=fabtests --ofi_build_mode=dbg
                   python3.7 runtests.py --prov=udp --test=fabtests --ofi_build_mode=dl
@@ -262,14 +277,14 @@ pipeline {
           }
         }
         stage('shm') {
-          agent {node {label 'cvl'}}
+          agent { node { label 'cvl' } }
           options { skipDefaultCheckout() }
           steps {
             withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
               sh """
                 env
                 (
-                  cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
                   python3.7 runtests.py --prov=shm --test=fabtests
                   python3.7 runtests.py --prov=shm --test=fabtests --ofi_build_mode=dbg
                   python3.7 runtests.py --prov=shm --test=fabtests --ofi_build_mode=dl
@@ -283,14 +298,14 @@ pipeline {
           }
         }
         stage('sockets') {
-          agent {node {label 'cvl'}}
+          agent { node { label 'cvl' } }
           options { skipDefaultCheckout() }
           steps {
             withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
               sh """
                 env
                 (
-                  cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
                   python3.7 runtests.py --prov=sockets --test=fabtests
                   python3.7 runtests.py --prov=sockets --test=fabtests --ofi_build_mode=dbg
                   python3.7 runtests.py --prov=sockets --test=fabtests --ofi_build_mode=dl
@@ -301,7 +316,7 @@ pipeline {
           }
         }
         stage('psm3') {
-        agent {node {label 'mlx5 && edr'}}
+        agent { node { label 'mlx5 && edr' } }
         options { skipDefaultCheckout() }
           steps {
             withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
@@ -310,7 +325,7 @@ pipeline {
                 (
                   export PSM3_IDENTIFY=1
                   export FI_LOG_LEVEL=info
-                  cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
                   python3.7 runtests.py --prov=psm3 --test=fabtests
                   python3.7 runtests.py --prov=psm3 --test=fabtests --ofi_build_mode=dbg
                   python3.7 runtests.py --prov=psm3 --test=fabtests --ofi_build_mode=dl
@@ -321,14 +336,14 @@ pipeline {
           }
         }
         stage('MPI_tcp-rxm-1') {
-          agent {node {label 'cvl'}}
+          agent { node { label 'cvl' } }
           options { skipDefaultCheckout() }
           steps {
             withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
               sh """
                 env
                 (
-                  cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
                   python3.7 runtests.py --prov=tcp --util=rxm --test=IMB --imb_grp=1
                   echo "MPI-tcp-rxm-1 completed."
                 )
@@ -337,14 +352,14 @@ pipeline {
           }
         }
         stage('MPI_tcp-rxm-3') {
-          agent {node {label 'cvl'}}
+          agent { node { label 'cvl' } }
           options { skipDefaultCheckout() }
           steps {
             withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
               sh """
                 env
                 (
-                  cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
                   python3.7 runtests.py --prov=tcp --util=rxm --test=IMB --imb_grp=3
                   echo "MPI-tcp-rxm-3 completed."
                   python3.7 runtests.py --prov=tcp --util=rxm --test=osu
@@ -355,14 +370,14 @@ pipeline {
           }
         }
         stage('MPICH testsuite') {
-          agent {node {label 'mlx5'}}
+          agent { node { label 'mlx5' } }
           options { skipDefaultCheckout() }
           steps {
             withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
               sh """
                 env
                 (
-                  cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
                   python3.7 runtests.py --prov=verbs --util=rxm --test=mpichtestsuite
                   echo "verbs-rxm MPICH testsuite completed."
                   python3.7 runtests.py --prov=tcp --util=rxm --test=mpichtestsuite
@@ -378,14 +393,14 @@ pipeline {
           }
         }
         stage('SHMEM') {
-          agent {node {label 'mlx5'}}
+          agent { node { label 'mlx5' } }
           options { skipDefaultCheckout() }
           steps {
             withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
               sh """
                 env
                 (
-                  cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
                   python3.7 runtests.py --prov=tcp --test=shmem
                   echo "SHMEM tcp completed."
                   python3.7 runtests.py --prov=net --test=shmem
@@ -401,7 +416,7 @@ pipeline {
           }
         }
         stage('multinode-tcp-performance') {
-          agent {node {label 'cvl'}}
+          agent { node { label 'cvl' } }
           options { skipDefaultCheckout() }
           steps {
               withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
@@ -409,7 +424,7 @@ pipeline {
                 sh """
                   env
                   (
-                      cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                      cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
                       python3.7 runtests.py --prov=tcp --test=multinode
                       echo "multinode performance completed."
                   )
@@ -418,14 +433,14 @@ pipeline {
           }
         }
         stage('oneCCL') {
-          agent {node {label 'cvl'}}
+          agent { node { label 'cvl' }  }
           options { skipDefaultCheckout() }
           steps {
             withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
               sh """
                 env
                 (
-                  cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
                   python3.7 runtests.py --prov=tcp --util=rxm --test=oneccl
                   echo "oneCCL tcp-rxm completed."
                   python3.7 runtests.py --prov=net --test=oneccl
@@ -439,14 +454,14 @@ pipeline {
           }
         }
         stage('oneCCL-GPU') {
-          agent {node {label 'ze'}}
+          agent { node {  label 'ze' } }
           options { skipDefaultCheckout() }
           steps {
             withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
               sh """
                 env
                 (
-                  cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
                   python3.7 runtests.py --prov=tcp --test=onecclgpu
                   echo "oneCCL-GPU tcp completed."
                   python3.7 runtests.py --prov=net --test=onecclgpu
@@ -458,7 +473,12 @@ pipeline {
           }
         }
         stage('daos_tcp') {
-          agent {node {label 'daos'}}
+          agent {
+            node {
+              label 'daos'
+              customWorkspace "${JENKINS_HOME}/workspace/${JOB_NAME}/${env.BUILD_NUMBER}"
+            }
+          }
           options { skipDefaultCheckout() }
           steps {
             withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
@@ -475,7 +495,12 @@ pipeline {
           }
         }
         stage('daos_verbs') {
-          agent {node {label 'daos'}}
+          agent {
+            node {
+              label 'daos'
+              customWorkspace "${JENKINS_HOME}/workspace/${JOB_NAME}/${env.BUILD_NUMBER}"
+            }
+          }
           options { skipDefaultCheckout() }
           steps {
             withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
@@ -492,7 +517,12 @@ pipeline {
           }
         }
         stage('dsa') {
-          agent {node {label 'dsa'}}
+          agent {
+            node {
+              label 'dsa'
+              customWorkspace "${JENKINS_HOME}/workspace/${JOB_NAME}/${env.BUILD_NUMBER}"
+            }
+          }
           when { equals expected: 1, actual: DO_RUN }
           steps {
             withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
@@ -508,14 +538,14 @@ pipeline {
           }
         }
         stage('net-fabtests') {
-          agent {node {label 'cvl'}}
+          agent { node { label 'cvl' } }
           options { skipDefaultCheckout() }
           steps {
             withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
               sh """
                 env
                 (
-                  cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
                   python3.7 runtests.py --prov=net --test=fabtests
                   python3.7 runtests.py --prov=net --test=fabtests --ofi_build_mode=dbg
                   python3.7 runtests.py --prov=net --test=fabtests --ofi_build_mode=dl
@@ -527,14 +557,14 @@ pipeline {
         }
         // separate imb tests into 3 stages rather than 1 to hopefully run in parallel
         stage('MPI_net-1') {
-          agent {node {label 'cvl'}}
+          agent { node { label 'cvl' } }
           options { skipDefaultCheckout() }
           steps {
             withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
               sh """
                 env
                 (
-                  cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
                   python3.7 runtests.py --prov=net --test=IMB --imb_grp=1
                   echo "MPI_net Group 1 completed."
                 )
@@ -543,14 +573,14 @@ pipeline {
           }
         }
         stage('MPI_net-2') {
-          agent {node {label 'cvl'}}
+          agent { node { label 'cvl' } }
           options { skipDefaultCheckout() }
           steps {
             withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
               sh """
                 env
                 (
-                  cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
                   python3.7 runtests.py --prov=net --test=IMB --imb_grp=2
                   echo "MPI_net Group 2 completed."
                 )
@@ -559,14 +589,14 @@ pipeline {
           }
         }
         stage('MPI_net-3') {
-          agent {node {label 'cvl'}}
+          agent { node { label 'cvl' } }
           options { skipDefaultCheckout() }
           steps {
             withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
               sh """
                 env
                 (
-                  cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
                   python3.7 runtests.py --prov=net --test=IMB --imb_grp=3
                   echo "MPI_net Group 3 completed."
                 )
@@ -575,14 +605,14 @@ pipeline {
           }
         }
         stage('net-osu') {
-          agent {node {label 'cvl'}}
+          agent { node { label 'cvl' } }
           options { skipDefaultCheckout() }
           steps {
             withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
               sh """
                 env
                 (
-                  cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                  cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
                   python3.7 runtests.py --prov=net --test=osu
                   echo "MPI-net-osu completed."
                 )
@@ -591,7 +621,7 @@ pipeline {
           }
         }
         stage('multinode-net-performance') {
-          agent {node {label 'cvl'}}
+          agent { node { label 'cvl' } }
           options { skipDefaultCheckout() }
           steps {
               withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
@@ -599,7 +629,7 @@ pipeline {
                 sh """
                   env
                   (
-                      cd /opt${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
+                      cd ${env.WORKSPACE}/py_scripts/contrib/intel/jenkins/
                       python3.7 runtests.py --prov=net --test=multinode
                       echo "multinode performance completed."
                   )


### PR DESCRIPTION
Make jenkins checkout to a custom directory. This will fix the problem of two subjobs running together.

The problem this fixes is when Job1 is running and gets aborted by Job2's disableConcurrentBuilds option. Job2 aborts Job1 and causes Job1 to skip straight to the post cleanup stage where it deletes all workspace directories it used. The problem with this is that Job2 and Job1 shared the same workspace directory and so when Job1 deletes the current working directory of Job2, Job2 fails. Jenkins then gets stuck and cannot start a Job3 until the shared workspace directory is removed by hand.

The solution is to separate these workspaces into job_name/build_number. This way Job1 will checkout into Job/1 and therefore cleanup Job/1/* and Job2 will checkout into Job/2 and cleanup Job/2/* and the problem of having to remove directories by hand is eliminated.

There is also a patch that moves the py_scripts/contrib/intel/jenkins string into a global variable so that when developers must replay and replace all of the py_scripts/contrib/intel/jenkins with /contrib/intel/jenkins they can change it in one location instead of 25.