### PR TITLE
core/getinfo: Reorder default fi_info list

### DIFF
--- a/include/ofi.h
+++ b/include/ofi.h
@@ -242,18 +242,18 @@ ofi_prov_ctx(const struct fi_provider *prov)
 	return (struct ofi_prov_context *) &prov->context;
 }
 
-struct fi_filter {
+struct ofi_filter {
 	char **names;
-	int negated;
+	bool negated;
 };
 
-extern struct fi_filter prov_log_filter;
+extern struct ofi_filter prov_log_filter;
 extern struct fi_provider core_prov;
 extern const char *log_prefix;
 
-void ofi_create_filter(struct fi_filter *filter, const char *env_name);
-void ofi_free_filter(struct fi_filter *filter);
-int ofi_apply_filter(struct fi_filter *filter, const char *name);
+void ofi_create_filter(struct ofi_filter *filter, const char *env_name);
+void ofi_free_filter(struct ofi_filter *filter);
+int ofi_apply_filter(struct ofi_filter *filter, const char *name);
 
 int ofi_nic_close(struct fid *fid);
 struct fid_nic *ofi_nic_dup(const struct fid_nic *nic);

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -495,7 +495,6 @@ static void ofi_register_provider(struct fi_provider *provider, void *dlhandle)
 	    !strcasecmp(provider->name, "shm") ||
 	    !strcasecmp(provider->name, "efa") ||
 	    !strcasecmp(provider->name, "psm3") ||
-	    !strcasecmp(provider->name, "net") ||
 	    ofi_is_util_prov(provider))
 		ofi_prov_ctx(provider)->disable_layering = true;
 

--- a/src/log.c
+++ b/src/log.c
@@ -84,7 +84,7 @@ enum {
 
 static int log_interval = 2000;
 uint64_t log_mask;
-struct fi_filter prov_log_filter;
+struct ofi_filter prov_log_filter;
 extern struct ofi_common_locks common_locks;
 
 static pid_t pid;
@@ -105,7 +105,7 @@ static int fi_convert_log_str(const char *value)
 
 void fi_log_init(void)
 {
-	struct fi_filter subsys_filter;
+	struct ofi_filter subsys_filter;
 	int level, i;
 	char *levelstr = NULL, *provstr = NULL, *subsysstr = NULL;
 


### PR DESCRIPTION
First patch is a general cleanup of the filtering functionality.

Second removes the restriction to allow the rxm provider to layer over the net provider. net;ofi_rxm is compatible with tcp;ofi_rxm.  This change will allow merging the net and tcp providers back together.

The last patch adds the ability to reorder the fi_info list separately from strict provider ordering.  This allows reporting the net provider's rdm ep support ahead of net;ofi_rxm.