### PR TITLE
[v1.16.x] prov/efa: Do not enable rdma_read if rxr_env.use_device_rdm…

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -342,6 +342,9 @@ bool efa_ep_support_rdma_read(struct fid_ep *ep_fid)
 {
 	struct efa_ep *efa_ep;
 
+	if (!rxr_env.use_device_rdma)
+		return 0;
+
 	efa_ep = container_of(ep_fid, struct efa_ep, util_ep.ep_fid);
 	return efa_ep->domain->device->device_caps & EFADV_DEVICE_ATTR_CAPS_RDMA_READ;
 }
@@ -407,9 +410,6 @@ bool rxr_peer_support_delivery_complete(struct rdm_peer *peer)
 static inline
 bool efa_both_support_rdma_read(struct rxr_ep *ep, struct rdm_peer *peer)
 {
-	if (!rxr_env.use_device_rdma)
-		return 0;
-
 	return efa_ep_support_rdma_read(ep->rdm_ep) &&
 	       (peer->is_self || efa_peer_support_rdma_read(peer));
 }


### PR DESCRIPTION
…a is false.

Backport https://github.com/ofiwg/libfabric/pull/8156 to v1.16.x