### PR TITLE
contrib/intel: remove make distcheck

### DIFF
--- a/contrib/intel/jenkins/build.py
+++ b/contrib/intel/jenkins/build.py
@@ -12,11 +12,6 @@ import common
 import re
 import shutil
 
-def distcheck():
-	cmd = "bash -c \'LDFLAGS=-Wl,--build-id rpmbuild -ta libfabric-*.tar.bz2\'"
-	common.run_command(['make', '-j', 'distcheck'])
-	common.run_command(shlex.split(cmd))
-
 def build_libfabric(libfab_install_path, mode, cluster=None):
 
     if (os.path.exists(libfab_install_path) != True):
@@ -52,8 +47,6 @@ def build_libfabric(libfab_install_path, mode, cluster=None):
     common.run_command(['make','clean'])
     common.run_command(['make', '-j32'])
     common.run_command(['make','install'])
-    if (mode == 'reg'):
-        distcheck()
 
 
 def build_fabtests(libfab_install_path, mode):


### PR DESCRIPTION
make distcheck got added to the github action builds which cover all the providers. Having it here is no longer necessary and consummes a lot of build time.

Signed-off-by: Alexia Ingerson <alexia.ingerson@intel.com>