### PR TITLE
fabtests/efa/test_mr: check for specific warning message

### DIFF
--- a/fabtests/pytest/common.py
+++ b/fabtests/pytest/common.py
@@ -129,14 +129,17 @@ def check_returncode_list(returncode_list, strict):
 
 class UnitTest:
 
-    def __init__(self, cmdline_args, base_command, is_negative=False, check_warning=False):
-        if check_warning:
+    def __init__(self, cmdline_args, base_command, is_negative=False, failing_warn_msgs=None):
+        if isinstance(failing_warn_msgs, str):
+            failing_warn_msgs = [failing_warn_msgs]
+
+        if failing_warn_msgs:
             self._cmdline_args = copy.copy(cmdline_args)
             self._cmdline_args.append_environ("FI_LOG_LEVEL=warn")
         else:
             self._cmdline_args = cmdline_args
 
-        self._check_warning = check_warning
+        self._failing_warn_msgs = failing_warn_msgs
         self._base_command = base_command
         self._is_negative = is_negative
         self._command = self._cmdline_args.populate_command(base_command, "host")
@@ -176,8 +179,9 @@ class UnitTest:
         assert not timeout, "timed out"
         check_returncode_list([process.returncode], self._cmdline_args.strict_fabtests_mode)
 
-        if self._check_warning:
-            assert output.find("<warn>") == -1
+        if self._failing_warn_msgs:
+            for msg in self._failing_warn_msgs:
+                assert output.find(msg) == -1
 
 class ClientServerTest:
 

--- a/fabtests/pytest/efa/test_mr.py
+++ b/fabtests/pytest/efa/test_mr.py
@@ -16,5 +16,5 @@ def test_mr_cuda(cmdline_args):
     cmdline_args_copy = copy.copy(cmdline_args)
     cmdline_args_copy.append_environ("FI_EFA_USE_DEVICE_RDMA=1")
 
-    test = UnitTest(cmdline_args_copy, "fi_mr_test -D cuda", check_warning=True)
+    test = UnitTest(cmdline_args_copy, "fi_mr_test -D cuda", failing_warn_msgs=["Unable to add MR to map"] )
     test.run()


### PR DESCRIPTION
Instead of checking for "<warn>", make test_cuda_mr to check for specific message.

Signed-off-by: Wei Zhang <wzam@amazon.com>