### PR TITLE
contrib/intel: re-enable cross device testing

### DIFF
--- a/contrib/intel/jenkins/run.py
+++ b/contrib/intel/jenkins/run.py
@@ -102,9 +102,8 @@ def ze_fabtests(core, hosts, mode, user_env, run_test, util):
         runzefabtests.execute_cmd('h2d')
         print(f"Running ze d2d tests for {core}-{util}-{fab}")
         runzefabtests.execute_cmd('d2d')
-        # xd2d tests are failing
-        # print(f"Running ze xd2d tests for {core}-{util}-{fab}")
-        # runzefabtests.execute_cmd('xd2d')
+        print(f"Running ze xd2d tests for {core}-{util}-{fab}")
+        runzefabtests.execute_cmd('xd2d')
     else:
         print(f"Skipping {core} {runzefabtests.testname} as execute condition fails")
     print('-------------------------------------------------------------------')

--- a/contrib/intel/jenkins/summary.py
+++ b/contrib/intel/jenkins/summary.py
@@ -475,7 +475,7 @@ if __name__ == "__main__":
             err += ret if ret else 0
 
         if summary_item == 'ze' or summary_item == 'all':
-            test_types = ['h2d', 'd2d'] #, 'xd2d']
+            test_types = ['h2d', 'd2d', 'xd2d']
             for type in test_types:
                 ret = summarize_ze(log_dir, 'shm', type, mode)
                 err += ret if ret else 0


### PR DESCRIPTION
Cross device testing was disabled because of unknown failures. This was probably due to the same configuration issue that was causing failures in the h->d and d->d testing.

Signed-off-by: Alexia Ingerson <alexia.ingerson@intel.com>