### PR TITLE
[v1.16.x] Revert "hmem_ze: Reverse the order of searching for copy-on…

### DIFF
--- a/src/hmem_ze.c
+++ b/src/hmem_ze.c
@@ -667,7 +667,7 @@ static int ze_hmem_find_copy_only_engine(int device_num, int *ordinal, int *inde
 
 	/* Auto select the first copy-only engine group if possible */
 	j = 0;
-	for (i = cq_grp_count - 1; i >= 0; i--) {
+	for (i = 0; i < cq_grp_count; i++) {
 		if (cq_grp_props[i].flags &
 		    ZE_COMMAND_QUEUE_GROUP_PROPERTY_FLAG_COPY &&
 		    !(cq_grp_props[i].flags &
@@ -678,7 +678,7 @@ static int ze_hmem_find_copy_only_engine(int device_num, int *ordinal, int *inde
 
 out:
 	free(cq_grp_props);
-	*ordinal = (i < 0) ? 0 : i;
+	*ordinal = i == cq_grp_count ? 0 : i;
 	*index = j;
 	return ze_ret;
 }


### PR DESCRIPTION
…ly engine"

This reverts commit 1521915774c3fdf6c23d1cc479f870cf097ba1af.

The original commit was based on the fact that the link copy engine (usually command queue group 2) had much lower submission overhead than the main copy engine (usually command queue group 1). This is no longer the case with the latest oneAPI level-zero library. Now the submission overhead is similar among the command queue groups, and the groups are normally ordered descendently by maximum bandwidth.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>
(cherry picked from commit da714499a4f18e53b7d20286e4a5cc773f1e907a)