### PR TITLE
prov/net: Fix possible crash handling FI_DISCARD

### DIFF
--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -553,7 +553,7 @@ xnet_free_xfer(struct xnet_progress *progress, struct xnet_xfer_entry *xfer)
 {
 	assert(xnet_progress_locked(progress));
 	if (xfer->ctrl_flags & XNET_FREE_BUF)
-		free(xfer->iov[0].iov_base);
+		free(xfer->user_buf);
 
 	ofi_buf_free(xfer);
 }

--- a/prov/net/src/xnet_srx.c
+++ b/prov/net/src/xnet_srx.c
@@ -405,6 +405,12 @@ xnet_srx_trecvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
 	recv_entry->src_addr = msg->addr;
 	recv_entry->cq_flags = (flags & FI_COMPLETION) | FI_TAGGED | FI_RECV;
 	recv_entry->context = msg->context;
+	recv_entry->iov_cnt = msg->iov_count;
+	if (msg->iov_count) {
+		recv_entry->user_buf = msg->msg_iov[0].iov_base;
+		memcpy(&recv_entry->iov[0], msg->msg_iov,
+		       msg->iov_count * sizeof(*msg->msg_iov));
+	}
 
 	if (flags & FI_PEEK) {
 		ret = xnet_srx_peek(srx, recv_entry, flags);
@@ -413,19 +419,12 @@ xnet_srx_trecvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
 		goto unlock;
 	}
 
+	recv_entry->cntr_inc = ofi_ep_rx_cntr_inc;
 	if (flags & FI_CLAIM) {
 		ret = xnet_srx_claim(srx, recv_entry, flags);
 		if (ret)
 			xnet_free_xfer(xnet_srx2_progress(srx), recv_entry);
 		goto unlock;
-	}
-
-	recv_entry->cntr_inc = ofi_ep_rx_cntr_inc;
-	recv_entry->iov_cnt = msg->iov_count;
-	if (msg->iov_count) {
-		recv_entry->user_buf = msg->msg_iov[0].iov_base;
-		memcpy(&recv_entry->iov[0], msg->msg_iov,
-		       msg->iov_count * sizeof(*msg->msg_iov));
 	}
 
 	ret = xnet_srx_tag(srx, recv_entry);

--- a/prov/net/src/xnet_srx.c
+++ b/prov/net/src/xnet_srx.c
@@ -278,6 +278,7 @@ xnet_srx_claim(struct xnet_srx *srx, struct xnet_xfer_entry *recv_entry,
 
 		recv_entry->iov[0].iov_base = recv_entry->user_buf;
 		recv_entry->iov[0].iov_len = msg_len;
+		recv_entry->iov_cnt = 1;
 		recv_entry->ctrl_flags |= XNET_FREE_BUF;
 	}
 

--- a/prov/net/src/xnet_srx.c
+++ b/prov/net/src/xnet_srx.c
@@ -272,9 +272,11 @@ xnet_srx_claim(struct xnet_srx *srx, struct xnet_xfer_entry *recv_entry,
 	if (flags & FI_DISCARD) {
 		msg_len = ep->cur_rx.hdr.base_hdr.size -
 			  ep->cur_rx.hdr.base_hdr.hdr_size;
-		recv_entry->iov[0].iov_base = calloc(1, msg_len);
-		if (!recv_entry->iov[0].iov_base)
+		recv_entry->user_buf = calloc(1, msg_len);
+		if (!recv_entry->user_buf)
 			return -FI_ENOMEM;
+
+		recv_entry->iov[0].iov_base = recv_entry->user_buf;
 		recv_entry->iov[0].iov_len = msg_len;
 		recv_entry->ctrl_flags |= XNET_FREE_BUF;
 	}


### PR DESCRIPTION
We need to allocate an internal buffer to receive a discarded message.  Once the message has been received, we can free the buffer.  The buffer is stored in the recv_entry iov[0] as iov_base.  The iov_base is freed later.  However, as part of the receive handling, the iov_base can be updated.  This is done to handle partial receives, where we need to wait for additional data to arrive from the peer before receiving more data.

To fix, we need to record the address of the allocation in a separate location, so we can free it later.  Use the existing user_buf pointer for this, which is used in other places to track the start of the buffer.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>