### PR TITLE
.github/workflows: update MacOS version

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -123,7 +123,7 @@ jobs:
           name: config.log
           path: config.log
   macos:
-    runs-on: macos-10.15
+    runs-on: macos-12
     steps:
       - name: Install dependencies (Mac OS)
         run: |


### PR DESCRIPTION
Support for MacOS 10.15 is being deprecated in December 2022. Update to MacOS 12

Signed-off-by: Alexia Ingerson <alexia.ingerson@intel.com>