### PR TITLE
util/rxm_av: Add option to free resources on AV removal

### DIFF
--- a/include/ofi.h
+++ b/include/ofi.h
@@ -328,6 +328,7 @@ uint8_t ofi_msb(uint64_t num);
 uint8_t ofi_lsb(uint64_t num);
 
 extern size_t ofi_universe_size;
+extern int ofi_av_remove_cleanup;
 
 bool ofi_send_allowed(uint64_t caps);
 bool ofi_recv_allowed(uint64_t caps);

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -694,6 +694,7 @@ static inline void ofi_cntr_inc(struct util_cntr *cntr)
 
 struct util_av;
 struct util_av_set;
+struct util_peer_addr;
 
 struct util_coll_mc {
 	struct fid_mc		mc_fid;
@@ -750,6 +751,8 @@ struct util_av {
 	size_t			context_offset;
 	struct dlist_entry	ep_list;
 	ofi_mutex_t		ep_list_lock;
+	void			(*remove_handler)(struct util_ep *util_ep,
+						  struct util_peer_addr *peer);
 };
 
 #define OFI_AV_DYN_ADDRLEN (1 << 0)
@@ -806,7 +809,9 @@ void util_put_peer(struct util_peer_addr *peer);
 };
 
 int rxm_util_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
-		     struct fid_av **fid_av, void *context, size_t conn_size);
+		     struct fid_av **fid_av, void *context, size_t conn_size,
+		     void (*remove_handler)(struct util_ep *util_ep,
+					    struct util_peer_addr *peer));
 size_t rxm_av_max_peers(struct rxm_av *av);
 void rxm_ref_peer(struct util_peer_addr *peer);
 void *rxm_av_alloc_conn(struct rxm_av *av);

--- a/prov/net/src/xnet_domain.c
+++ b/prov/net/src/xnet_domain.c
@@ -103,7 +103,7 @@ static int xnet_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 			struct fid_av **fid_av, void *context)
 {
 	return rxm_util_av_open(domain_fid, attr, fid_av, context,
-				sizeof(struct xnet_conn));
+				sizeof(struct xnet_conn), NULL);
 }
 
 static int

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -897,6 +897,8 @@ ssize_t rxm_handle_unexp_sar(struct rxm_recv_queue *recv_queue,
 			     struct rxm_recv_entry *recv_entry,
 			     struct rxm_rx_buf *rx_buf);
 int rxm_post_recv(struct rxm_rx_buf *rx_buf);
+void rxm_av_remove_handler(struct util_ep *util_ep,
+			   struct util_peer_addr *peer);
 
 static inline void
 rxm_free_rx_buf(struct rxm_rx_buf *rx_buf)

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -1056,3 +1056,18 @@ int rxm_start_listen(struct rxm_ep *ep)
 	}
 	return 0;
 }
+
+void rxm_av_remove_handler(struct util_ep *util_ep, struct util_peer_addr *peer)
+{
+	struct rxm_ep *ep;
+	struct rxm_conn *conn;
+
+	ep = container_of(util_ep, struct rxm_ep, util_ep);
+	ofi_ep_lock_acquire(&ep->util_ep);
+	conn = ofi_idm_lookup(&ep->conn_idx_map, peer->index);
+	if (conn) {
+		rxm_close_conn(conn);
+		rxm_free_conn(conn);
+	}
+	ofi_ep_lock_release(&ep->util_ep);
+}

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -169,8 +169,9 @@ static int
 rxm_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 	    struct fid_av **fid_av, void *context)
 {
-	return rxm_util_av_open(domain_fid, attr, fid_av, context,
-				sizeof(struct rxm_conn));
+	return rxm_util_av_open(domain_fid, attr, fid_av,
+			context, sizeof(struct rxm_conn),
+			ofi_av_remove_cleanup ? rxm_av_remove_handler : NULL);
 }
 
 static int

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -723,6 +723,7 @@ RXM_INI
 			"related overhead.  Pass thru is an optimized path "
 			"to the tcp provider, depending on the capabilities "
 			"requested by the application.");
+
 	/* passthru supported disabled - to re-enable would need to fix call to
 	 * fi_cq_read to pass in the correct data structure.  However, passthru
 	 * will not be needed at all with in-work tcp changes.

--- a/src/common.c
+++ b/src/common.c
@@ -85,6 +85,7 @@ struct ofi_common_locks common_locks = {
 };
 
 size_t ofi_universe_size = 1024;
+int ofi_av_remove_cleanup;
 
 
 int ofi_genlock_init(struct ofi_genlock *lock,

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -820,6 +820,17 @@ void fi_ini(void)
 			"(default: provider specific)");
 	fi_param_get_size_t(NULL, "universe_size", &ofi_universe_size);
 
+	fi_param_define(NULL, "av_remove_cleanup", FI_PARAM_BOOL,
+			"When true, release any underlying resources, such as "
+			"hidden connections when removing an entry from an "
+			"AV.  This can help save resources on AV entries "
+			"that reference a peer which is no longer active.  "
+			"However, it may abruptly terminate data transfers "
+			"from peers that are active at the time their "
+			"address is removed from the local AV.  "
+			"(default: false)");
+	fi_param_get_bool(NULL, "av_remove_cleanup", &ofi_av_remove_cleanup);
+
 	ofi_load_dl_prov();
 
 	ofi_register_provider(PSM3_INIT, NULL);


### PR DESCRIPTION
When sending or receiving messages, an AV may allocate resources underneath, such as establishing a connection. These connections can persist even if the peer's address is not inserted into the AV or after it's been removed. This can cause use of resources as long as the peer is running, but no longer actively communicating with another peer.

Add the ability to cleanup any underlying resources when removing an address from an AV.  This can free receive buffers, close fd's, etc. to reduce resource utilization.

This capability is disabled by default as it may abruptly terminate communication with a peer if there are data transfers in progress.  To enable, a libfabric wide environment variable must be set.

Signed-off-by: Chien Tin Tung <chien.tin.tung@intel.com>
Signed-off-by: Sean Hefty <sean.hefty@intel.com>