### PR TITLE
util/mr_cache: Add MM valid check to cache find

### DIFF
--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -380,6 +380,7 @@ struct ofi_mr_entry *ofi_mr_cache_find(struct ofi_mr_cache *cache,
 {
 	struct ofi_mr_info info;
 	struct ofi_mr_entry *entry;
+	struct ofi_mem_monitor *monitor;
 
 	assert(attr->iov_count == 1);
 	FI_DBG(cache->domain->prov, FI_LOG_MR, "find %p (len: %zu)\n",
@@ -395,6 +396,12 @@ struct ofi_mr_entry *ofi_mr_cache_find(struct ofi_mr_cache *cache,
 	}
 
 	if (!ofi_iov_within(attr->mr_iov, &entry->info.iov)) {
+		entry = NULL;
+		goto unlock;
+	}
+
+	monitor = cache->monitors[entry->info.iface];
+	if (!monitor->valid(monitor, &entry->info, entry)) {
 		entry = NULL;
 		goto unlock;
 	}


### PR DESCRIPTION
ofi_mr_cache_find can be used to search the MR cache without creating a new entry. ofi_mr_cache_find should only return valid entries, but valid check with the corresponding memory monitor is missing. Add this check.

Signed-off-by: Ian Ziemba <ian.ziemba@hpe.com>