### PR TITLE
fabtests: update .gitignore + fabtests/efa: Add new protocol decision test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,8 @@ fabtests.spec
 fabtests/config
 fabtests/ubertest/fabtest
 fabtests/ubertest/fi_ubertest
-
+fabtests/common/check_hmem
+fabtests/regression/sighandler_test
 fabtests/benchmarks/fi_*
 fabtests/component/sock_test
 fabtests/functional/fi_*

--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -169,6 +169,7 @@ nobase_dist_config_DATA = \
 	pytest/efa/test_multi_recv.py \
 	pytest/efa/test_rnr.py \
 	pytest/efa/test_efa_info.py \
+	pytest/efa/test_efa_protocol_selection.py \
 	pytest/efa/test_runt.py \
 	pytest/efa/test_fork_support.py \
 	pytest/efa/test_mr.py \

--- a/fabtests/pytest/efa/test_efa_protocol_selection.py
+++ b/fabtests/pytest/efa/test_efa_protocol_selection.py
@@ -1,0 +1,54 @@
+import pytest
+
+
+# TODO Expand this test to run on all memory types (and rename)
+@pytest.mark.serial
+@pytest.mark.functional
+@pytest.mark.parametrize("fabtest_name,cntrl_env_var", [("fi_rdm_tagged_bw", "FI_EFA_INTER_MIN_READ_MESSAGE_SIZE"), ("fi_rma_bw", "FI_EFA_INTER_MIN_READ_WRITE_SIZE")])
+def test_transfer_with_read_protocol_cuda(cmdline_args, fabtest_name, cntrl_env_var):
+    """
+    Verify that the read protocol is used for a 1024 byte message when the env variable
+    switches are set to force the read protocol at 1000 bytes.
+    """
+    import copy
+    from common import has_cuda, has_hmem_support
+    from efa.efa_common import efa_run_client_server_test, efa_retrieve_hw_counter_value
+
+    if cmdline_args.server_id == cmdline_args.client_id:
+        pytest.skip("No read for intra-node communication")
+
+    if (not has_hmem_support(cmdline_args, cmdline_args.client_id) or
+        not has_hmem_support(cmdline_args, cmdline_args.server_id)):
+        pytest.skip("Client and server both need hmem support for RDMA Read test")
+
+    if not has_cuda(cmdline_args.client_id) or not has_cuda(cmdline_args.server_id):
+        pytest.skip("Client and server both need a Cuda device")
+
+    message_size = 1024
+
+    cmdline_args_copy = copy.copy(cmdline_args)
+    cmdline_args_copy.append_environ("FI_EFA_USE_DEVICE_RDMA=1")
+    cmdline_args_copy.append_environ(f"{cntrl_env_var}=1000")
+    cmdline_args_copy.append_environ("FI_EFA_RUNT_SIZE=0")
+
+    # wrs stands for work requests
+    server_read_wrs_before_test = efa_retrieve_hw_counter_value(cmdline_args.server_id, "rdma_read_wrs")
+    if server_read_wrs_before_test is None:
+        pytest.skip("No HW counter support")
+        return
+    server_read_bytes_before_test = efa_retrieve_hw_counter_value(cmdline_args.server_id, "rdma_read_bytes")
+
+    efa_run_client_server_test(cmdline_args_copy,
+                               fabtest_name,
+                               iteration_type="1",
+                               completion_type="transmit_complete",
+                               memory_type="cuda_to_cuda",
+                               message_size=message_size,
+                               warmup_iteration_type="0")
+
+    server_read_wrs_after_test = efa_retrieve_hw_counter_value(cmdline_args.server_id, "rdma_read_wrs")
+    server_read_bytes_after_test = efa_retrieve_hw_counter_value(cmdline_args.server_id, "rdma_read_bytes")
+
+    # Check that the READ protocol was the only protocol used.
+    assert server_read_bytes_after_test - server_read_bytes_before_test == message_size
+    assert server_read_wrs_after_test == server_read_wrs_before_test + 1


### PR DESCRIPTION
Adds fabtest executables to .gitignore.

Adds a new EFA test to make sure that READ protocol is used when environmental controls are set.