### PR TITLE
Add Support for ROCR IPC

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -85,6 +85,7 @@ common_srcs =				\
 	prov/util/src/rocr_mem_monitor.c \
 	prov/util/src/ze_mem_monitor.c \
 	prov/util/src/cuda_ipc_monitor.c \
+	prov/util/src/rocr_ipc_monitor.c \
 	prov/coll/src/coll_attr.c	\
 	prov/coll/src/coll_av.c		\
 	prov/coll/src/coll_av_set.c	\

--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -152,6 +152,9 @@ struct name {							\
 typedef void (*name ## _entry_init_func)(entrytype *buf,	\
 					 void *arg);		\
 								\
+typedef void (*name ## _entry_destroy_func)(entrytype *buf,	\
+					 void *arg);		\
+								\
 static inline void						\
 name ## _init(struct name *fs, size_t size,			\
 	      name ## _entry_init_func init, void *arg)		\
@@ -194,8 +197,18 @@ static inline void name ## _free(struct name *fs)		\
 {								\
 	free(fs);						\
 }								\
+static inline void name ## _destroy(struct name *fs,		\
+	size_t size, name ## _entry_destroy_func destroy,	\
+	void *arg)						\
+{								\
+	ssize_t i;						\
+	for (i = size - 1; i >= 0; i--) {			\
+		if (destroy)					\
+			destroy(&fs->entry[i].buf, arg);	\
+	}							\
+	free(fs);						\
+}								\
 void dummy ## name (void) /* work-around global ; scope */
-
 
 /*
  * Buffer pool (free stack) template for shared memory regions

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -229,6 +229,7 @@ extern struct ofi_mem_monitor *memhooks_monitor;
 extern struct ofi_mem_monitor *cuda_monitor;
 extern struct ofi_mem_monitor *cuda_ipc_monitor;
 extern struct ofi_mem_monitor *rocr_monitor;
+extern struct ofi_mem_monitor *rocr_ipc_monitor;
 extern struct ofi_mem_monitor *ze_monitor;
 extern struct ofi_mem_monitor *import_monitor;
 

--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -777,6 +777,7 @@
     <ClCompile Include="prov\util\src\rocr_mem_monitor.c" />
     <ClCompile Include="prov\util\src\ze_mem_monitor.c" />
     <ClCompile Include="prov\util\src\cuda_ipc_monitor.c" />
+    <ClCompile Include="prov\util\src\rocr_ipc_monitor.c" />
     <ClCompile Include="prov\coll\src\coll_attr.c" />
     <ClCompile Include="prov\coll\src\coll_av.c" />
     <ClCompile Include="prov\coll\src\coll_av_set.c" />

--- a/prov/hook/dmabuf_peer_mem/src/hook_dmabuf_peer_mem.c
+++ b/prov/hook/dmabuf_peer_mem/src/hook_dmabuf_peer_mem.c
@@ -144,7 +144,7 @@ static void get_mr_fd(struct dmabuf_peer_mem_mr *mr,
 		 * The region is not covered by any entry in the registry, add a
 		 * new entry to the registry now.
 		 */
-		err = ze_hmem_get_handle(iov->iov_base, &handle);
+		err = ze_hmem_get_handle(iov->iov_base, iov->iov_len, &handle);
 		if (err)
 			goto out_unlock;
 

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -404,6 +404,7 @@ static int smr_format_ipc(struct smr_cmd *cmd, void *ptr, size_t len,
 		return ret;
 
 	ret = ofi_hmem_get_handle(cmd->msg.data.ipc_info.iface, base,
+				   cmd->msg.data.ipc_info.base_length,
 				   (void **)&cmd->msg.data.ipc_info.ipc_handle);
 	if (ret)
 		return ret;

--- a/prov/util/src/rocr_ipc_monitor.c
+++ b/prov/util/src/rocr_ipc_monitor.c
@@ -1,0 +1,69 @@
+/*
+ * (C) Copyright (c) 2022 UT-Battelle, LLC. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "ofi_mr.h"
+
+#if HAVE_ROCR
+
+#include "ofi_hmem.h"
+
+static bool rocr_ipc_monitor_valid(struct ofi_mem_monitor *monitor,
+			const struct ofi_mr_info *info,
+			struct ofi_mr_entry *entry)
+{
+	return (memcmp((void **)&info->ipc_handle,
+		(void **)&entry->info.ipc_handle,
+		sizeof(hsa_amd_ipc_memory_t)) == 0);
+}
+
+#else
+
+static bool rocr_ipc_monitor_valid(struct ofi_mem_monitor *monitor,
+			const struct ofi_mr_info *info,
+			struct ofi_mr_entry *entry)
+{
+	return false;
+}
+
+#endif /* HAVE_ROCR */
+
+static struct ofi_mem_monitor rocr_ipc_monitor_ = {
+	.init = ofi_monitor_init,
+	.cleanup = ofi_monitor_cleanup,
+	.start = ofi_monitor_start_no_op,
+	.stop = ofi_monitor_stop_no_op,
+	.subscribe = ofi_monitor_subscribe_no_op,
+	.unsubscribe = ofi_monitor_unsubscribe_no_op,
+	.valid = rocr_ipc_monitor_valid,
+};
+
+struct ofi_mem_monitor *rocr_ipc_monitor = &rocr_ipc_monitor_;

--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -174,6 +174,7 @@ void ofi_monitors_init(void)
 	cuda_monitor->init(cuda_monitor);
 	cuda_ipc_monitor->init(cuda_ipc_monitor);
 	rocr_monitor->init(rocr_monitor);
+	rocr_ipc_monitor->init(rocr_ipc_monitor);
 	ze_monitor->init(ze_monitor);
 	import_monitor->init(import_monitor);
 

--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -74,7 +74,7 @@ struct ibv_mr *vrb_mr_ibv_reg_dmabuf_mr(struct ibv_pd *pd, const void *buf,
 	if (failover_policy == ALWAYS)
 		goto failover;
 
-	err = ze_hmem_get_handle((void *)buf, &handle);
+	err = ze_hmem_get_handle((void *)buf, len, &handle);
 	if (err)
 		return NULL;
 

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -81,14 +81,14 @@ struct ofi_hmem_ops hmem_ops[] = {
 		.copy_to_hmem = rocr_copy_to_dev,
 		.copy_from_hmem = rocr_copy_from_dev,
 		.is_addr_valid = rocr_is_addr_valid,
-		.get_handle = ofi_hmem_no_get_handle,
-		.open_handle = ofi_hmem_no_open_handle,
-		.close_handle = ofi_hmem_no_close_handle,
+		.get_handle = rocr_get_handle,
+		.open_handle = rocr_open_handle,
+		.close_handle = rocr_close_handle,
 		.host_register = rocr_host_register,
 		.host_unregister = rocr_host_unregister,
 		.get_base_addr = rocr_get_base_addr,
-		.is_ipc_enabled = ofi_hmem_no_is_ipc_enabled,
-		.get_ipc_handle_size = ofi_hmem_no_get_ipc_handle_size,
+		.is_ipc_enabled = rocr_is_ipc_enabled,
+		.get_ipc_handle_size = rocr_get_ipc_handle_size,
 	},
 	[FI_HMEM_ZE] = {
 		.initialized = false,
@@ -203,15 +203,17 @@ ssize_t ofi_copy_to_hmem_iov(enum fi_hmem_iface hmem_iface, uint64_t device,
 				     (void *) src, size, OFI_COPY_BUF_TO_IOV);
 }
 
-int ofi_hmem_get_handle(enum fi_hmem_iface iface, void *base_addr, void **handle)
+int ofi_hmem_get_handle(enum fi_hmem_iface iface, void *base_addr,
+			size_t size, void **handle)
 {
-	return hmem_ops[iface].get_handle(base_addr, handle);
+	return hmem_ops[iface].get_handle(base_addr, size, handle);
 }
 
 int ofi_hmem_open_handle(enum fi_hmem_iface iface, void **handle,
-			 uint64_t device, void **mapped_addr)
+			size_t size, uint64_t device, void **mapped_addr)
 {
-	return hmem_ops[iface].open_handle(handle, device, mapped_addr);
+	return hmem_ops[iface].open_handle(handle, size, device,
+					   mapped_addr);
 }
 
 int ofi_hmem_close_handle(enum fi_hmem_iface iface, void *mapped_addr)

--- a/src/hmem_cuda.c
+++ b/src/hmem_cuda.c
@@ -294,7 +294,7 @@ int cuda_dev_unregister(uint64_t handle)
 	return FI_SUCCESS;
 }
 
-int cuda_get_handle(void *dev_buf, void **handle)
+int cuda_get_handle(void *dev_buf, size_t size, void **handle)
 {
 	cudaError_t cuda_ret;
 
@@ -310,7 +310,8 @@ int cuda_get_handle(void *dev_buf, void **handle)
 	return FI_SUCCESS;
 }
 
-int cuda_open_handle(void **handle, uint64_t device, void **ipc_ptr)
+int cuda_open_handle(void **handle, size_t size, uint64_t device,
+		     void **ipc_ptr)
 {
 	cudaError_t cuda_ret;
 
@@ -819,12 +820,13 @@ int cuda_dev_unregister(uint64_t handle)
 	return FI_SUCCESS;
 }
 
-int cuda_get_handle(void *dev_buf, void **handle)
+int cuda_get_handle(void *dev_buf, size_t size, void **handle)
 {
 	return -FI_ENOSYS;
 }
 
-int cuda_open_handle(void **handle, uint64_t device, void **ipc_ptr)
+int cuda_open_handle(void **handle, size_t size, uint64_t device,
+		     void **ipc_ptr)
 {
 	return -FI_ENOSYS;
 }

--- a/src/hmem_rocr.c
+++ b/src/hmem_rocr.c
@@ -35,15 +35,44 @@
 #endif
 
 #include "ofi_hmem.h"
+#include "ofi_mem.h"
 #include "ofi.h"
 
 #if HAVE_ROCR
 
-#include <hsa/hsa_ext_amd.h>
+#define HSA_MAX_SIGNALS 512
+#define HSA_MAX_STREAMS (HSA_MAX_SIGNALS / MAX_NUM_ASYNC_OP)
+#define D2H_THRESHOLD 16384
+#define H2D_THRESHOLD 1048576
+
+struct ofi_hsa_signal_info {
+	hsa_signal_t sig;
+	void *addr;
+	bool in_use;
+};
+
+struct ofi_hsa_stream {
+	struct ofi_hsa_signal_info *sinfo[MAX_NUM_ASYNC_OP];
+	int num_signals;
+};
+
+OFI_DECLARE_FREESTACK(struct ofi_hsa_stream, rocm_ipc_stream_fs);
+OFI_DECLARE_FREESTACK(struct ofi_hsa_signal_info, rocm_ipc_signal_fs);
+
+static pthread_spinlock_t fs_lock;
+static struct rocm_ipc_stream_fs *ipc_stream_fs;
+static struct rocm_ipc_signal_fs *ipc_signal_fs;
 
 struct hsa_ops {
 	hsa_status_t (*hsa_memory_copy)(void *dst, const void *src,
 					size_t size);
+	hsa_status_t (*hsa_amd_memory_async_copy)(void* dst,
+					hsa_agent_t dst_agent,
+					const void* src,
+					hsa_agent_t src_agent, size_t size,
+					uint32_t num_dep_signals,
+					const hsa_signal_t* dep_signals,
+					hsa_signal_t completion_signal);
 	hsa_status_t (*hsa_amd_pointer_info)(void *ptr,
 					     hsa_amd_pointer_info_t *info,
 					     void *(*alloc)(size_t),
@@ -73,6 +102,17 @@ struct hsa_ops {
 		const hsa_agent_t* mapping_agents,
 		void** mapped_ptr);
 	hsa_status_t (*hsa_amd_ipc_memory_detach)(void* mapped_ptr);
+	void (*hsa_signal_store_screlease)(hsa_signal_t signal,
+					   hsa_signal_value_t value);
+	hsa_signal_value_t (*hsa_signal_load_scacquire)(hsa_signal_t signal);
+	hsa_status_t (*hsa_amd_agents_allow_access)(uint32_t num_agents,
+			const hsa_agent_t* agents,
+			const uint32_t* flags, const void* ptr);
+	hsa_status_t (*hsa_signal_create)(hsa_signal_value_t initial_value,
+			uint32_t num_consumers,
+			const hsa_agent_t *consumers,
+			hsa_signal_t *signal);
+	hsa_status_t (*hsa_signal_destroy)(hsa_signal_t signal);
 };
 
 #if ENABLE_ROCR_DLOPEN
@@ -87,14 +127,22 @@ static struct hsa_ops hsa_ops;
 static struct hsa_ops hsa_ops = {
 	/* mem copy ops */
 	.hsa_memory_copy = hsa_memory_copy,
+	/* Asynchronously copy a block of memory from the location pointed to by
+	 * src on the src_agent to the memory block pointed to by dst on the
+	 * dst_agent. */
+	.hsa_amd_memory_async_copy = hsa_amd_memory_async_copy,
+	/* gets information about the device mem pointer */
 	.hsa_amd_pointer_info = hsa_amd_pointer_info,
+	/* initialize the runt time library */
 	.hsa_init = hsa_init,
 	.hsa_shut_down = hsa_shut_down,
 	.hsa_status_string = hsa_status_string,
+	/* used for memory monitoring */
 	.hsa_amd_dereg_dealloc_cb =
 		hsa_amd_deregister_deallocation_callback,
 	.hsa_amd_reg_dealloc_cb =
 		hsa_amd_register_deallocation_callback,
+	/* memory lock/unlock used for registration */
 	.hsa_amd_memory_lock = hsa_amd_memory_lock,
 	.hsa_amd_memory_unlock = hsa_amd_memory_unlock,
 	.hsa_agent_get_info = hsa_agent_get_info,
@@ -109,9 +157,58 @@ static struct hsa_ops hsa_ops = {
 	 * releases access to shared memory imported with
 	 * hsa_amd_ipc_memory_attach */
 	.hsa_amd_ipc_memory_detach = hsa_amd_ipc_memory_detach,
+	.hsa_signal_store_screlease = hsa_signal_store_screlease,
+	.hsa_signal_load_scacquire = hsa_signal_load_scacquire,
+	.hsa_amd_agents_allow_access = hsa_amd_agents_allow_access,
+	.hsa_signal_create = hsa_signal_create,
+	.hsa_signal_destroy = hsa_signal_destroy,
 };
 
 #endif /* ENABLE_ROCR_DLOPEN */
+
+static hsa_status_t
+ofi_hsa_amd_agents_allow_access(uint32_t num_agents, const hsa_agent_t* agents,
+				const uint32_t* flags, const void* ptr)
+{
+	return hsa_ops.hsa_amd_agents_allow_access(num_agents, agents,
+						   flags, ptr);
+}
+
+static void
+ofi_hsa_signal_store_screlease(hsa_signal_t signal, hsa_signal_value_t value)
+{
+	hsa_ops.hsa_signal_store_screlease(signal, value);
+}
+
+static hsa_signal_value_t ofi_hsa_signal_load_scacquire(hsa_signal_t signal)
+{
+	return hsa_ops.hsa_signal_load_scacquire(signal);
+}
+
+static void ofi_hsa_signal_create(struct ofi_hsa_signal_info *sinfo, void *arg)
+{
+	hsa_status_t hsa_ret;
+
+	if ((hsa_ret = hsa_ops.hsa_signal_create(1, 0, NULL,
+						&sinfo->sig) !=
+		HSA_STATUS_SUCCESS)) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"Failed to perform hsa_signal_create: %s\n",
+			ofi_hsa_status_to_string(hsa_ret));
+	}
+}
+
+static void ofi_hsa_signal_destroy(struct ofi_hsa_signal_info *sinfo, void *arg)
+{
+	hsa_status_t hsa_ret;
+
+	if ((hsa_ret = hsa_ops.hsa_signal_destroy(sinfo->sig) !=
+		HSA_STATUS_SUCCESS)) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"Failed to perform hsa_signal_destroy: %s\n",
+			ofi_hsa_status_to_string(hsa_ret));
+	}
+}
 
 hsa_status_t ofi_hsa_amd_memory_lock(void *host_ptr, size_t size,
 				     hsa_agent_t *agents, int num_agents,
@@ -129,6 +226,18 @@ hsa_status_t ofi_hsa_amd_memory_unlock(void *host_ptr)
 hsa_status_t ofi_hsa_memory_copy(void *dst, const void *src, size_t size)
 {
 	return hsa_ops.hsa_memory_copy(dst, src, size);
+}
+
+hsa_status_t ofi_hsa_amd_memory_async_copy(void* dst, hsa_agent_t dst_agent,
+					const void* src,
+					hsa_agent_t src_agent, size_t size,
+					uint32_t num_dep_signals,
+					const hsa_signal_t* dep_signals,
+					hsa_signal_t completion_signal)
+{
+	return hsa_ops.hsa_amd_memory_async_copy(dst, dst_agent,
+				src, src_agent, size, num_dep_signals,
+				dep_signals, completion_signal);
 }
 
 hsa_status_t ofi_hsa_amd_pointer_info(void *ptr, hsa_amd_pointer_info_t *info,
@@ -286,6 +395,171 @@ int rocr_copy_to_dev(uint64_t device, void *dest, const void *src,
 	return ret;
 }
 
+int rocr_create_async_copy_event(uint64_t device, void **ev)
+{
+	struct ofi_hsa_stream *s;
+
+	pthread_spin_lock(&fs_lock);
+	s = ofi_freestack_pop(ipc_stream_fs);
+	pthread_spin_unlock(&fs_lock);
+	if (!s)
+		return -FI_ENOMEM;
+
+	memset(s, 0, sizeof(*s));
+
+	*ev = s;
+
+	return FI_SUCCESS;
+}
+
+int rocr_free_async_copy_event(uint64_t device, void *ev)
+{
+	struct ofi_hsa_stream *s = ev;
+	int i;
+
+	pthread_spin_lock(&fs_lock);
+	for (i = 0; i < s->num_signals; i++)
+		ofi_freestack_push(ipc_signal_fs, s->sinfo[i]);
+	ofi_freestack_push(ipc_stream_fs, s);
+	pthread_spin_unlock(&fs_lock);
+
+	return FI_SUCCESS;
+}
+
+static int
+rocr_dev_async_copy(void *dst, const void *src, size_t size,
+		    ofi_hmem_async_event_t event)
+{
+	void *src_hsa_ptr;
+	void *dst_hsa_ptr;
+	int ret;
+	hsa_status_t hsa_ret;
+	struct ofi_hsa_stream *s;
+	struct ofi_hsa_signal_info *ipc_signal;
+	/* 0 - source agent
+	 * 1 - destination agent
+	 */
+	hsa_agent_t agents[2];
+	bool src_local, dst_local;
+
+	if (!event)
+		return -FI_EINVAL;
+
+	s = event;
+
+	ret = rocr_host_memory_ptr((void *)src, &src_hsa_ptr, &agents[0],
+				   NULL, NULL, &src_local);
+	if (ret != FI_SUCCESS)
+		return ret;
+
+	ret = rocr_host_memory_ptr(dst, &dst_hsa_ptr, &agents[1], NULL, NULL,
+				   &dst_local);
+	if (ret != FI_SUCCESS)
+		return ret;
+
+	pthread_spin_lock(&fs_lock);
+	s->sinfo[s->num_signals] = ofi_freestack_pop(ipc_signal_fs);
+	pthread_spin_unlock(&fs_lock);
+	ipc_signal = s->sinfo[s->num_signals];
+	ipc_signal->in_use = true;
+
+	s->num_signals++;
+
+	/* device to device */
+	if (!src_local && !dst_local) {
+		hsa_ret = ofi_hsa_amd_agents_allow_access(2, agents, NULL,
+							  dst_hsa_ptr);
+		if (hsa_ret != HSA_STATUS_SUCCESS) {
+			FI_WARN(&core_prov, FI_LOG_CORE,
+			   "Failed to perform hsa_amd_agents_allow_access %s\n",
+			   ofi_hsa_status_to_string(hsa_ret));
+			ret = -FI_EINVAL;
+			goto fail;
+		}
+		ipc_signal->addr = NULL;
+	/* device to host */
+	} else if (!src_local && dst_local) {
+		size_t d2h_thresh;
+
+		if (fi_param_get_size_t(&core_prov, "rocr_d2h_threshold",
+					&d2h_thresh) < 0)
+			d2h_thresh = D2H_THRESHOLD;
+		if (size < d2h_thresh) {
+			memcpy(dst, src, size);
+			ofi_hsa_signal_store_screlease(ipc_signal->sig, 0);
+			ipc_signal->addr = NULL;
+			goto finish;
+		}
+		hsa_ret = ofi_hsa_amd_memory_lock(dst, size, NULL, 0,
+						  &dst_hsa_ptr);
+		if (hsa_ret != HSA_STATUS_SUCCESS) {
+			ret = -FI_EINVAL;
+			goto fail;
+		}
+		ipc_signal->addr = dst;
+		agents[1] = agents[0];
+	}
+
+	ofi_hsa_signal_store_screlease(ipc_signal->sig, 1);
+
+	hsa_ret = ofi_hsa_amd_memory_async_copy(dst_hsa_ptr, agents[1],
+				src_hsa_ptr, agents[0],
+				size, 0, NULL, ipc_signal->sig);
+
+	if (hsa_ret != HSA_STATUS_SUCCESS) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"Failed to perform hsa_amd_memory_async_copy %s\n",
+			ofi_hsa_status_to_string(hsa_ret));
+		ret = -FI_EINVAL;
+		goto fail;
+	}
+
+	return 0;
+
+fail:
+	rocr_free_async_copy_event(0, s);
+finish:
+	return ret;
+}
+
+int rocr_async_copy_to_dev(uint64_t device, void *dst, const void *src,
+			   size_t size, ofi_hmem_async_event_t event)
+{
+	return rocr_dev_async_copy(dst, src, size, event);
+}
+
+int rocr_async_copy_from_dev(uint64_t device, void *dst, const void *src,
+			     size_t size, ofi_hmem_async_event_t event)
+{
+	return rocr_dev_async_copy(dst, src, size, event);
+}
+
+int rocr_async_copy_query(ofi_hmem_async_event_t event)
+{
+	struct ofi_hsa_stream *s = event;
+	hsa_signal_value_t v;
+	int i;
+
+	for (i = 0; i < s->num_signals; i++) {
+		void *addr;
+
+		if (!s->sinfo[i] || !s->sinfo[i]->in_use)
+			continue;
+
+		v = ofi_hsa_signal_load_scacquire(s->sinfo[i]->sig);
+		if (v != 0)
+			return -FI_EBUSY;
+
+		addr = s->sinfo[i]->addr;
+		if (addr)
+			ofi_hsa_amd_memory_unlock(addr);
+
+		s->sinfo[i]->in_use = false;
+	}
+
+	return FI_SUCCESS;
+}
+
 bool rocr_is_addr_valid(const void *addr, uint64_t *device, uint64_t *flags)
 {
 	hsa_amd_pointer_info_t hsa_info = {
@@ -406,6 +680,14 @@ static int rocr_hmem_dl_init(void)
 		goto err;
 	}
 
+	hsa_ops.hsa_amd_memory_async_copy = dlsym(hsa_handle,
+				"hsa_amd_memory_async_copy");
+	if (!hsa_ops.hsa_amd_memory_async_copy) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"Failed to find hsa_amd_memory_async_copy\n");
+		goto err;
+	}
+
 	hsa_ops.hsa_amd_pointer_info = dlsym(hsa_handle,
 					      "hsa_amd_pointer_info");
 	if (!hsa_ops.hsa_amd_pointer_info) {
@@ -497,6 +779,20 @@ static int rocr_hmem_dl_init(void)
 		goto err;
 	}
 
+	hsa_ops.hsa_signal_create = dlsym(hsa_handle, "hsa_signal_create");
+	if (!hsa_ops.hsa_signal_create) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"Failed to find hsa_signal_create\n");
+		goto err;
+	}
+
+	hsa_ops.hsa_signal_destroy = dlsym(hsa_handle, "hsa_signal_destroy");
+	if (!hsa_ops.hsa_signal_destroy) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"Failed to find hsa_signal_destroy\n");
+		goto err;
+	}
+
 	return FI_SUCCESS;
 
 err:
@@ -515,20 +811,52 @@ static void rocr_hmem_dl_cleanup(void)
 #endif
 }
 
+static int rocr_init_async_streams(void)
+{
+	/* did we already initialize? */
+	if (ipc_stream_fs)
+		return 0;
+
+	ipc_stream_fs = rocm_ipc_stream_fs_create(HSA_MAX_STREAMS,
+				NULL, NULL);
+	if (!ipc_stream_fs)
+		return -FI_ENOMEM;
+
+	ipc_signal_fs = rocm_ipc_signal_fs_create(HSA_MAX_SIGNALS,
+				ofi_hsa_signal_create, NULL);
+	if (!ipc_signal_fs)
+		return -FI_ENOMEM;
+
+	ofi_spin_init(&fs_lock);
+
+	return 0;
+}
+
 int rocr_hmem_init(void)
 {
 	hsa_status_t hsa_ret;
 	int ret;
 	int log_level;
 
+	fi_param_define(NULL, "rocr_d2h_threshold", FI_PARAM_SIZE_T,
+		"Threshold for switching to hsa memcpy for device-to-host"
+		"  copies. (Default 16384");
+
 	ret = rocr_hmem_dl_init();
 	if (ret != FI_SUCCESS)
 		return ret;
 
 	hsa_ret = ofi_hsa_init();
-	if (hsa_ret == HSA_STATUS_SUCCESS)
-		return FI_SUCCESS;
+	if (hsa_ret != HSA_STATUS_SUCCESS)
+		goto fail;
 
+	ret = rocr_init_async_streams();
+	if (ret)
+		goto fail;
+
+	return 0;
+
+fail:
 	/* Treat HSA_STATUS_ERROR_OUT_OF_RESOURCES as ROCR not being supported
 	 * instead of an error. This ROCR error is typically returned if no
 	 * devices are supported.
@@ -553,6 +881,13 @@ int rocr_hmem_init(void)
 int rocr_hmem_cleanup(void)
 {
 	hsa_status_t hsa_ret;
+
+	if (ipc_signal_fs)
+		rocm_ipc_signal_fs_destroy(ipc_signal_fs, HSA_MAX_SIGNALS,
+					ofi_hsa_signal_destroy, NULL);
+
+	if (ipc_stream_fs)
+		rocm_ipc_stream_fs_free(ipc_stream_fs);
 
 	hsa_ret = ofi_hsa_shut_down();
 	if (hsa_ret != HSA_STATUS_SUCCESS) {
@@ -663,6 +998,35 @@ int rocr_get_ipc_handle_size(size_t *size)
 }
 
 int rocr_get_base_addr(const void *ptr, void **base, size_t *size)
+{
+	return -FI_ENOSYS;
+}
+
+int rocr_create_async_copy_event(uint64_t device,
+				 ofi_hmem_async_event_t *event)
+{
+	return -FI_ENOSYS;
+}
+
+int rocr_free_async_copy_event(uint64_t device,
+			       ofi_hmem_async_event_t event)
+{
+	return -FI_ENOSYS;
+}
+
+int rocr_async_copy_to_dev(uint64_t device, void *dst, const void *src,
+			   size_t size, ofi_hmem_async_event_t event)
+{
+	return -FI_ENOSYS;
+}
+
+int rocr_async_copy_from_dev(uint64_t device, void *dst, const void *src,
+			     size_t size, ofi_hmem_async_event_t event)
+{
+	return -FI_ENOSYS;
+}
+
+int rocr_async_copy_query(ofi_hmem_async_event_t event)
 {
 	return -FI_ENOSYS;
 }

--- a/src/hmem_ze.c
+++ b/src/hmem_ze.c
@@ -406,7 +406,7 @@ int ze_hmem_get_shared_handle(int dev_fd, void *dev_buf, int *ze_fd,
 	int ret;
 
 	assert(dev_fd != -1);
-	ret = ze_hmem_get_handle(dev_buf, (void **) &ze_handle);
+	ret = ze_hmem_get_handle(dev_buf, 0, (void **) &ze_handle);
 	if (ret)
 		return ret;
 
@@ -443,7 +443,7 @@ int ze_hmem_open_shared_handle(int dev_fd, void **handle, int *ze_fd,
 	*ze_fd = open_fd.fd;
 	memset(&ze_handle, 0, sizeof(ze_handle));
 	memcpy(&ze_handle, &open_fd.fd, sizeof(open_fd.fd));
-	return ze_hmem_open_handle((void **) &ze_handle, device, ipc_ptr);
+	return ze_hmem_open_handle((void **) &ze_handle, 0, device, ipc_ptr);
 }
 
 bool ze_hmem_p2p_enabled(void)
@@ -982,7 +982,7 @@ bool ze_hmem_is_addr_valid(const void *addr, uint64_t *device, uint64_t *flags)
 	return true;
 }
 
-int ze_hmem_get_handle(void *dev_buf, void **handle)
+int ze_hmem_get_handle(void *dev_buf, size_t size, void **handle)
 {
 	ze_result_t ze_ret;
 
@@ -996,7 +996,8 @@ int ze_hmem_get_handle(void *dev_buf, void **handle)
 	return FI_SUCCESS;
 }
 
-int ze_hmem_open_handle(void **handle, uint64_t device, void **ipc_ptr)
+int ze_hmem_open_handle(void **handle, size_t size, uint64_t device,
+			void **ipc_ptr)
 {
 	ze_result_t ze_ret;
 	int dev_id = (int) device;
@@ -1125,12 +1126,13 @@ bool ze_hmem_is_addr_valid(const void *addr, uint64_t *device, uint64_t *flags)
 	return false;
 }
 
-int ze_hmem_get_handle(void *dev_buf, void **handle)
+int ze_hmem_get_handle(void *dev_buf, size_t size, void **handle)
 {
 	return -FI_ENOSYS;
 }
 
-int ze_hmem_open_handle(void **handle, uint64_t device, void **ipc_ptr)
+int ze_hmem_open_handle(void **handle, size_t size, uint64_t device,
+			void **ipc_ptr)
 {
 	return -FI_ENOSYS;
 }


### PR DESCRIPTION
Add the following support:

- Add ROCR IPC for use with SHM provider
- Support Asynchronous ROCR memory copy operations
- improve ROCR device performance by using inline copies instead of asynchronous copies for buffers less than 512KB