### PR TITLE
Add Support for XPMEM

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -181,6 +181,7 @@ src_libfabric_la_SOURCES =			\
 	include/ofi_proto.h			\
 	include/ofi_recvwin.h			\
 	include/ofi_rbuf.h			\
+	include/ofi_shm_p2p.h			\
 	include/ofi_signal.h			\
 	include/ofi_epoll.h			\
 	include/ofi_tree.h			\

--- a/Makefile.am
+++ b/Makefile.am
@@ -163,6 +163,7 @@ util_fi_pingpong_LDADD = $(linkback)
 nodist_src_libfabric_la_SOURCES =
 src_libfabric_la_SOURCES =			\
 	include/ofi_hmem.h			\
+	include/ofi_cma.h			\
 	include/ofi.h				\
 	include/ofi_abi.h			\
 	include/ofi_atom.h			\

--- a/Makefile.am
+++ b/Makefile.am
@@ -51,6 +51,8 @@ common_srcs =				\
 	src/hmem_neuron.c		\
 	src/hmem_synapseai.c		\
 	src/hmem_ipc_cache.c	        \
+	src/xpmem.c			\
+	src/xpmem_cache.c		\
 	src/common.c			\
 	src/enosys.c			\
 	src/rbtree.c			\
@@ -86,6 +88,7 @@ common_srcs =				\
 	prov/util/src/ze_mem_monitor.c \
 	prov/util/src/cuda_ipc_monitor.c \
 	prov/util/src/rocr_ipc_monitor.c \
+	prov/util/src/xpmem_monitor.c	\
 	prov/coll/src/coll_attr.c	\
 	prov/coll/src/coll_av.c		\
 	prov/coll/src/coll_av_set.c	\
@@ -164,6 +167,7 @@ nodist_src_libfabric_la_SOURCES =
 src_libfabric_la_SOURCES =			\
 	include/ofi_hmem.h			\
 	include/ofi_cma.h			\
+	include/ofi_xpmem.h			\
 	include/ofi.h				\
 	include/ofi_abi.h			\
 	include/ofi_atom.h			\

--- a/configure.ac
+++ b/configure.ac
@@ -398,6 +398,33 @@ AM_CONDITIONAL([EMBEDDED], [test x"$enable_embedded" = x"yes"])
 
 AM_CONDITIONAL(HAVE_LD_VERSION_SCRIPT, test "$ac_cv_version_script" = "yes")
 
+xpmem_happy=0
+AC_ARG_ENABLE([xpmem],
+	      [AS_HELP_STRING([--enable-xpmem@<:@=yes|no|PATH@:>@],
+			      [Enable xpmem (gni and shm providers) @<:@default=yes@:>@
+			      (yes: enable xpmem; no: disable xpmem;
+			      PATH: enable xpmem and use xpmem installed under PATH)])],
+	      )	
+
+FI_CHECK_PACKAGE([xpmem],
+		 [xpmem.h],
+		 [xpmem],
+		 [xpmem_make],
+		 [],
+		 [$enable_xpmem],
+		 [$enable_xpmem/lib64],
+		 [xpmem_happy=1])
+
+AS_IF([test x"$enable_xpmem" != x"no" && test -n "$enable_xpmem" && test "$xpmem_happy" = "0" ],
+	[AC_MSG_ERROR([XPMEM support requested but XPMEM runtime not available.])])
+
+AC_DEFINE_UNQUOTED([HAVE_XPMEM], [$xpmem_happy],
+	  	   [XPMEM support availability])
+
+LIBS="$LIBS $xpmem_LIBS"
+CPPFLAGS="$CPPFLAGS $xpmem_CPPFLAGS"
+LDFLAGS="$LDFLAGS $xpmem_LDFLAGS"
+
 dnl Disable symbol versioning when -ipo is in CFLAGS or ipo is disabled by icc.
 dnl The gcc equivalent ipo (-fwhole-program) seems to work fine.
 AS_CASE([$CFLAGS],

--- a/include/ofi.h
+++ b/include/ofi.h
@@ -268,7 +268,7 @@ void ofi_dump_sysconfig(void);
 
 const char *ofi_hex_str(const uint8_t *data, size_t len);
 
-#define MAX_IPC_HANDLE_SIZE	64
+#define MAX_MR_HANDLE_SIZE	64
 
 /*
  * This structure is part of the
@@ -285,7 +285,7 @@ struct ipc_info {
 	uint64_t	base_length;
 	uint64_t	device;
 	uint64_t	offset;
-	uint8_t		ipc_handle[MAX_IPC_HANDLE_SIZE];
+	uint8_t		ipc_handle[MAX_MR_HANDLE_SIZE];
 };
 
 static inline uint64_t roundup_power_of_two(uint64_t n)

--- a/include/ofi_cma.h
+++ b/include/ofi_cma.h
@@ -1,0 +1,72 @@
+/*
+ * (C) Copyright 2023 UT-Battelle, LLC. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef OFI_CMA_H
+#define OFI_CMA_H
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+
+#include <ofi.h>
+#include <ofi_iov.h>
+
+static inline int cma_copy(struct iovec *local, unsigned long local_cnt,
+			   struct iovec *remote, unsigned long remote_cnt,
+			   size_t total, pid_t pid, bool write,
+			   void *user_data)
+{
+	ssize_t ret;
+
+	while (1) {
+		if (write)
+			ret = ofi_process_vm_writev(pid, local, local_cnt, remote,
+						    remote_cnt, 0);
+		else
+			ret = ofi_process_vm_readv(pid, local, local_cnt, remote,
+						   remote_cnt, 0);
+		if (ret < 0) {
+			FI_WARN(&core_prov, FI_LOG_CORE,
+				"CMA error %d\n", errno);
+			return -FI_EIO;
+		}
+
+		total -= ret;
+		if (!total)
+			return FI_SUCCESS;
+
+		ofi_consume_iov(local, &local_cnt, (size_t) ret);
+		ofi_consume_iov(remote, &remote_cnt, (size_t) ret);
+	}
+}
+
+#endif /* OFI_CMA_H */

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -58,8 +58,8 @@ struct ofi_mr_info {
 	uint64_t device;
 
 	uint64_t peer_id;
-	void     *ipc_mapped_addr;
-	uint8_t  ipc_handle[MAX_IPC_HANDLE_SIZE];
+	void     *mapped_addr;
+	uint8_t  handle[MAX_MR_HANDLE_SIZE];
 };
 
 

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -232,6 +232,7 @@ extern struct ofi_mem_monitor *rocr_monitor;
 extern struct ofi_mem_monitor *rocr_ipc_monitor;
 extern struct ofi_mem_monitor *ze_monitor;
 extern struct ofi_mem_monitor *import_monitor;
+extern struct ofi_mem_monitor *xpmem_monitor;
 
 /*
  * Used to store registered memory regions into a lookup map.  This

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -329,6 +329,7 @@ extern struct ofi_mr_cache_params	cache_params;
 
 struct ofi_mr_cache {
 	struct util_domain		*domain;
+	const struct fi_provider	*prov;
 	struct ofi_mem_monitor		*monitors[OFI_HMEM_MAX];
 	struct dlist_entry		notify_entries[OFI_HMEM_MAX];
 	size_t				entry_data_size;

--- a/include/ofi_shm_p2p.h
+++ b/include/ofi_shm_p2p.h
@@ -35,6 +35,7 @@
 #endif
 
 #include <ofi_cma.h>
+#include <ofi_xpmem.h>
 #include <ofi.h>
 #include <ofi_iov.h>
 
@@ -77,9 +78,9 @@ ofi_shm_p2p_no_copy(struct iovec *local, unsigned long local_cnt,
 static struct ofi_shm_p2p_ops p2p_ops[] = {
 	[FI_SHM_P2P_XPMEM] = {
 		.initialized = false,
-		.init = ofi_shm_p2p_no_init,
-		.cleanup = ofi_shm_p2p_no_cleanup,
-		.copy = ofi_shm_p2p_no_copy,
+		.init = xpmem_init,
+		.cleanup = xpmem_cleanup,
+		.copy = xpmem_copy,
 	},
 	[FI_SHM_P2P_CMA] = {
 		.initialized = false,

--- a/include/ofi_shm_p2p.h
+++ b/include/ofi_shm_p2p.h
@@ -1,0 +1,132 @@
+/*
+ * (C) Copyright 2023 UT-Battelle, LLC. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <ofi.h>
+#include <ofi_iov.h>
+
+#ifndef _OFI_SHM_P2P_H_
+#define _OFI_SHM_P2P_H_
+
+enum ofi_shm_p2p_type {
+	FI_SHM_P2P_XPMEM,
+	FI_SHM_P2P_CMA,
+	FI_SHM_P2P_DSA,
+};
+
+struct ofi_shm_p2p_ops {
+	bool initialized;
+	int (*init)(void);
+	int (*cleanup)(void);
+	int (*copy)(struct iovec *local, unsigned long local_cnt,
+		    struct iovec *remote, unsigned long remote_cnt,
+		    size_t total, pid_t pid, bool write, void *user_data);
+};
+
+static inline int ofi_shm_p2p_no_init(void)
+{
+	return FI_SUCCESS;
+}
+
+static inline int ofi_shm_p2p_no_cleanup(void)
+{
+	return FI_SUCCESS;
+}
+
+static inline int
+ofi_shm_p2p_no_copy(struct iovec *local, unsigned long local_cnt,
+		    struct iovec *remote, unsigned long remote_cnt,
+		    size_t total, pid_t pid, bool write, void *user_data)
+{
+	return -FI_ENOSYS;
+}
+
+static struct ofi_shm_p2p_ops p2p_ops[] = {
+	[FI_SHM_P2P_XPMEM] = {
+		.initialized = false,
+		.init = ofi_shm_p2p_no_init,
+		.cleanup = ofi_shm_p2p_no_cleanup,
+		.copy = ofi_shm_p2p_no_copy,
+	},
+	[FI_SHM_P2P_CMA] = {
+		.initialized = false,
+		.init = ofi_shm_p2p_no_init,
+		.cleanup = ofi_shm_p2p_no_cleanup,
+		.copy = ofi_shm_p2p_no_copy,
+	},
+	[FI_SHM_P2P_DSA] = {
+		.initialized = false,
+		.init = ofi_shm_p2p_no_init,
+		.cleanup = ofi_shm_p2p_no_cleanup,
+		.copy = ofi_shm_p2p_no_copy,
+	},
+};
+
+static inline void ofi_shm_p2p_init(void)
+{
+	int rc;
+	enum ofi_shm_p2p_type p2p_type;
+
+	for (p2p_type = 0; p2p_type < ARRAY_SIZE(p2p_ops); p2p_type++) {
+		rc = p2p_ops[p2p_type].init();
+		if (!rc)
+			p2p_ops[p2p_type].initialized = true;
+	}
+}
+
+static inline void ofi_shm_p2p_cleanup(void)
+{
+	int rc;
+	enum ofi_shm_p2p_type p2p_type;
+
+	for (p2p_type = 0; p2p_type < ARRAY_SIZE(p2p_ops); p2p_type++) {
+		rc = p2p_ops[p2p_type].cleanup();
+		if (!rc)
+			p2p_ops[p2p_type].initialized = false;
+	}
+}
+
+static inline int
+ofi_shm_p2p_copy(enum ofi_shm_p2p_type p2p_type, struct iovec *local,
+		 unsigned long local_cnt, struct iovec *remote,
+		 unsigned long remote_cnt, size_t total, int64_t id,
+		 bool write, void *user_data)
+{
+	return p2p_ops[p2p_type].copy(local, local_cnt, remote,
+				      remote_cnt, total, id, write, user_data);
+}
+
+#endif /* _OFI_SHM_P2P_H_ */
+

--- a/include/ofi_shm_p2p.h
+++ b/include/ofi_shm_p2p.h
@@ -34,6 +34,7 @@
 #include <config.h>
 #endif
 
+#include <ofi_cma.h>
 #include <ofi.h>
 #include <ofi_iov.h>
 
@@ -84,7 +85,7 @@ static struct ofi_shm_p2p_ops p2p_ops[] = {
 		.initialized = false,
 		.init = ofi_shm_p2p_no_init,
 		.cleanup = ofi_shm_p2p_no_cleanup,
-		.copy = ofi_shm_p2p_no_copy,
+		.copy = cma_copy,
 	},
 	[FI_SHM_P2P_DSA] = {
 		.initialized = false,

--- a/include/ofi_xpmem.h
+++ b/include/ofi_xpmem.h
@@ -1,0 +1,91 @@
+/*
+ * (C) Copyright 2023 UT-Battelle, LLC. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef OFI_XPMEM_H
+#define OFI_XPMEM_H
+
+#include <ofi_mr.h>
+#include <ofi_util.h>
+
+#if HAVE_XPMEM
+#include <xpmem.h>
+#else
+/* define XPMEM specific types to allow the code to
+ * compile on different platforms and to allow smr_region to compile
+ * without xpmem available.
+ */
+typedef int64_t xpmem_apid_t;
+typedef int64_t xpmem_segid_t;
+#endif /* HAVE_XPMEM */
+
+struct xpmem_client {
+	uint8_t cap;
+	xpmem_apid_t apid;
+	uintptr_t addr_max;
+};
+
+struct xpmem_pinfo {
+	/* XPMEM segment id for this process */
+	xpmem_segid_t seg_id;
+	/* maximum attachment address for this process. attempts to attach
+	 * past this value may fail. */
+	uintptr_t address_max;
+};
+
+struct xpmem {
+	struct xpmem_pinfo pinfo;
+	/* maximum size that will be used with a single memcpy call.
+	 * On some systems we see better peformance if we chunk the
+	 * copy into multiple memcpy calls. */
+	uint64_t memcpy_chunk_size;
+};
+
+extern struct xpmem *xpmem;
+
+int ofi_xpmem_cache_search(struct ofi_mr_cache *cache,
+			   struct iovec *iov, uint64_t peer_id,
+			   struct ofi_mr_entry **mr_entry,
+			   struct xpmem_client *xpmem);
+
+int ofi_xpmem_cache_open(struct ofi_mr_cache **cache);
+void ofi_xpmem_cache_destroy(struct ofi_mr_cache *cache);
+
+int xpmem_init(void);
+int xpmem_cleanup(void);
+int xpmem_copy(struct iovec *local, unsigned long local_cnt,
+	       struct iovec *remote, unsigned long remote_cnt,
+	       size_t total, pid_t pid, bool write, void *user_data);
+int ofi_xpmem_enable(struct xpmem_pinfo *peer,
+		     struct xpmem_client *xpmem);
+void ofi_xpmem_release(struct xpmem_client *xpmem);
+
+#endif /* OFI_XPMEM_H */

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -749,6 +749,26 @@ ofi_send_socket(SOCKET fd, const void *buf, size_t count, int flags)
 	return (ssize_t) send(fd, (const char*) buf, len, flags);
 }
 
+static inline ssize_t ofi_process_vm_readv(pid_t pid,
+			const struct iovec *local_iov,
+			unsigned long liovcnt,
+			const struct iovec *remote_iov,
+			unsigned long riovcnt,
+			unsigned long flags)
+{
+	return -FI_ENOSYS;
+}
+
+static inline size_t ofi_process_vm_writev(pid_t pid,
+			 const struct iovec *local_iov,
+			 unsigned long liovcnt,
+			 const struct iovec *remote_iov,
+			 unsigned long riovcnt,
+			 unsigned long flags)
+{
+	return -FI_ENOSYS;
+}
+
 static inline ssize_t ofi_read_socket(SOCKET fd, void *buf, size_t count)
 {
 	return ofi_recv_socket(fd, buf, count, 0);

--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -769,6 +769,7 @@
     <ClCompile Include="prov\util\src\ze_mem_monitor.c" />
     <ClCompile Include="prov\util\src\cuda_ipc_monitor.c" />
     <ClCompile Include="prov\util\src\rocr_ipc_monitor.c" />
+    <ClCompile Include="prov\util\src\xpmem_monitor.c" />
     <ClCompile Include="prov\coll\src\coll_attr.c" />
     <ClCompile Include="prov\coll\src\coll_av.c" />
     <ClCompile Include="prov\coll\src\coll_av_set.c" />
@@ -795,6 +796,8 @@
     <ClCompile Include="src\hmem_neuron.c" />
     <ClCompile Include="src\hmem_synapseai.c" />
     <ClCompile Include="src\hmem_ipc_cache.c" />
+    <ClCompile Include="src\xpmem_cache.c" />
+    <ClCompile Include="src\xpmem.c" />
     <ClCompile Include="src\indexer.c" />
     <ClCompile Include="src\iov.c" />
     <ClCompile Include="src\ofi_str.c" />

--- a/man/fi_shm.7.md
+++ b/man/fi_shm.7.md
@@ -168,6 +168,19 @@ The *shm* provider checks for the following environment variables:
   page fault is reported, so that there is valid address translation for the
   remaining addresses in the command. This minimizes DSA page faults. Default
   false
+
+*FI_SHM_USE_XPMEM*
+ : SHM can use SAR, CMA or XPMEM for host memory transfer. If
+   FI_SHM_USE_XPMEM is set to 1, the provider will select XPMEM over CMA if
+   XPMEM is available.  Otherwise, if neither CMA nor XPMEM are available
+   SHM shall default to the SAR protocol. Default 0
+
+*FI_XPMEM_MEMCPY_CHUNKSIZE*
+ :  The maximum size which will be used with a single memcpy call. XPMEM
+    copy performance improves when buffers are divided into smaller
+    chunks. This environment variable is provided to fine tune performance
+    on different systems. Default 262144
+
 # SEE ALSO
 
 [`fabric`(7)](fabric.7.html),

--- a/prov/gni/configure.m4
+++ b/prov/gni/configure.m4
@@ -59,14 +59,8 @@ AC_DEFUN([FI_GNI_CONFIGURE],[
 	gnitest_CPPFLAGS=
 	gnitest_LDFLAGS=
         gnitest_LIBS=
-        xpmem_happy=0
         kdreg_happy=0
 
-
-        AC_ARG_ENABLE([xpmem],
-                      [AS_HELP_STRING([--enable-xpmem],
-                                      [Enable xpmem (gni provider) @<:@default=yes@:>@])],
-                      )
 
         AC_ARG_ENABLE([ugni-static],
                       [AS_HELP_STRING([--enable-ugni-static],
@@ -110,17 +104,6 @@ AC_DEFUN([FI_GNI_CONFIGURE],[
                                   gni_LDFLAGS="$CRAY_UDREG_LIBS $gni_LDFLAGS"
                                  ],
                                  [udreg_lib_happy=0])
-               AS_IF([test x"$enable_xpmem" != x"no"],
-                     [FI_PKG_CHECK_MODULES([CRAY_XPMEM], [cray-xpmem],
-                                 [AC_DEFINE_UNQUOTED([HAVE_XPMEM], [1], [Define to 1 if xpmem available])
-                                  gni_CPPFLAGS="$CRAY_XPMEM_CFLAGS $gni_CPPFLAGS"
-                                  gni_LDFLAGS="$CRAY_XPMEM_LIBS $gni_LDFLAGS"
-                                 ],
-                                 [xpmem_happy=0])
-                      ],
-                      [AC_DEFINE_UNQUOTED([HAVE_XPMEM], [0], [Define to 1 if xpmem available])
-                      ])
-
 
                CPPFLAGS_SAVE=$CPPFLAGS
                CPPFLAGS="$gni_CPPFLAGS $CPPFLAGS"

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -304,13 +304,13 @@ static inline uint64_t smr_rx_cq_flags(uint32_t op, uint64_t rx_flags,
 
 void smr_ep_progress(struct util_ep *util_ep);
 
-static inline bool smr_cma_enabled(struct smr_ep *ep,
+static inline bool smr_vma_enabled(struct smr_ep *ep,
 				   struct smr_region *peer_smr)
 {
 	if (ep->region == peer_smr)
-		return ep->region->cma_cap_self == SMR_CMA_CAP_ON;
+		return ep->region->cma_cap_self == SMR_VMA_CAP_ON;
 	else
-		return ep->region->cma_cap_peer == SMR_CMA_CAP_ON;
+		return ep->region->cma_cap_peer == SMR_VMA_CAP_ON;
 }
 
 static inline bool smr_ze_ipc_enabled(struct smr_region *smr,

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -55,6 +55,7 @@
 
 #include <ofi.h>
 #include <ofi_enosys.h>
+#include <ofi_shm_p2p.h>
 #include <ofi_rbuf.h>
 #include <ofi_list.h>
 #include <ofi_signal.h>
@@ -75,6 +76,7 @@ struct smr_env {
 	int disable_cma;
 	int use_dsa_sar;
 	size_t max_gdrcopy_size;
+	int use_xpmem;
 };
 
 extern struct smr_env smr_env;
@@ -228,6 +230,7 @@ struct smr_ep {
 	struct dlist_entry	ipc_cpy_pend_list;
 
 	int			ep_idx;
+	enum ofi_shm_p2p_type	p2p_type;
 	struct smr_sock_info	*sock_info;
 	void			*dsa_context;
 	void 			(*smr_progress_ipc_list)(struct smr_ep *ep);
@@ -308,9 +311,11 @@ static inline bool smr_vma_enabled(struct smr_ep *ep,
 				   struct smr_region *peer_smr)
 {
 	if (ep->region == peer_smr)
-		return ep->region->cma_cap_self == SMR_VMA_CAP_ON;
+		return (ep->region->cma_cap_self == SMR_VMA_CAP_ON ||
+			ep->region->xpmem_cap_self == SMR_VMA_CAP_ON);
 	else
-		return ep->region->cma_cap_peer == SMR_VMA_CAP_ON;
+		return (ep->region->cma_cap_peer == SMR_VMA_CAP_ON ||
+			peer_smr->xpmem_cap_self == SMR_VMA_CAP_ON);
 }
 
 static inline bool smr_ze_ipc_enabled(struct smr_region *smr,

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -320,35 +320,6 @@ static inline bool smr_ze_ipc_enabled(struct smr_region *smr,
 	       (peer_smr->flags & SMR_FLAG_IPC_SOCK);
 }
 
-static inline int smr_cma_loop(pid_t pid, struct iovec *local,
-			unsigned long local_cnt, struct iovec *remote,
-			unsigned long remote_cnt, unsigned long flags,
-			size_t total, bool write)
-{
-	ssize_t ret;
-
-	while (1) {
-		if (write)
-			ret = ofi_process_vm_writev(pid, local, local_cnt, remote,
-						    remote_cnt, flags);
-		else
-			ret = ofi_process_vm_readv(pid, local, local_cnt, remote,
-						   remote_cnt, flags);
-		if (ret < 0) {
-			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-				"CMA error %d\n", errno);
-			return -FI_EIO;
-		}
-
-		total -= ret;
-		if (!total)
-			return FI_SUCCESS;
-
-		ofi_consume_iov(local, &local_cnt, (size_t) ret);
-		ofi_consume_iov(remote, &remote_cnt, (size_t) ret);
-	}
-}
-
 static inline struct smr_inject_buf *
 smr_get_txbuf(struct smr_region *smr)
 {

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -1341,8 +1341,8 @@ static int smr_ep_ctrl(struct fid *fid, int command, void *arg)
 			return ret;
 
 		if (ep->util_ep.caps & FI_HMEM || smr_env.disable_cma) {
-			ep->region->cma_cap_peer = SMR_CMA_CAP_OFF;
-			ep->region->cma_cap_self = SMR_CMA_CAP_OFF;
+			ep->region->cma_cap_peer = SMR_VMA_CAP_OFF;
+			ep->region->cma_cap_self = SMR_VMA_CAP_OFF;
 			if (ep->util_ep.caps & FI_HMEM) {
 				if (ze_hmem_p2p_enabled())
 					smr_init_ipc_socket(ep);

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -42,6 +42,7 @@
 #include "smr_signal.h"
 #include "smr.h"
 #include "smr_dsa.h"
+#include "ofi_xpmem.h"
 
 extern struct fi_ops_msg smr_msg_ops, smr_no_recv_msg_ops;
 extern struct fi_ops_tagged smr_tag_ops, smr_no_recv_tag_ops;
@@ -573,7 +574,7 @@ static int smr_format_sar(struct smr_ep *ep, struct smr_cmd *cmd,
 }
 
 int smr_select_proto(void **desc, size_t iov_count,
-                     bool cma_avail, uint32_t op, uint64_t total_len,
+                     bool vma_avail, uint32_t op, uint64_t total_len,
 		     uint64_t op_flags)
 {
 	struct ofi_mr *smr_desc;
@@ -599,7 +600,7 @@ int smr_select_proto(void **desc, size_t iov_count,
 	if (op == ofi_op_read_req) {
 		if (use_ipc)
 			return smr_src_ipc;
-		if (cma_avail && FI_HMEM_SYSTEM == iface)
+		if (vma_avail && FI_HMEM_SYSTEM == iface)
 			return smr_src_iov;
 		return smr_src_sar;
 	}
@@ -618,7 +619,7 @@ int smr_select_proto(void **desc, size_t iov_count,
 	if (use_ipc)
 		return smr_src_ipc;
 
-	if (total_len > SMR_INJECT_SIZE && cma_avail)
+	if (total_len > SMR_INJECT_SIZE && vma_avail)
 		return smr_src_iov;
 
 	if (op_flags & FI_DELIVERY_COMPLETE)
@@ -1387,6 +1388,13 @@ static int smr_ep_ctrl(struct fid *fid, int command, void *arg)
 		if (smr_env.use_dsa_sar)
 			smr_dsa_context_init(ep);
 
+		/* if XPMEM is on after exchanging peer info, then set the
+		 * endpoint p2p to XPMEM so it can be used on the fast
+		 * path
+		 */
+		if (ep->region->xpmem_cap_self == SMR_VMA_CAP_ON)
+			ep->p2p_type = FI_SHM_P2P_XPMEM;
+
 		break;
 	default:
 		return -FI_ENOSYS;
@@ -1506,6 +1514,9 @@ int smr_endpoint(struct fid_domain *domain, struct fi_info *info,
 	ep->util_ep.ep_fid.atomic = &smr_atomic_ops;
 
 	*ep_fid = &ep->util_ep.ep_fid;
+
+	/* default to CMA for p2p */
+	ep->p2p_type = FI_SHM_P2P_CMA;
 	return 0;
 ep:
 	ofi_endpoint_close(&ep->util_ep);

--- a/prov/shm/src/smr_init.c
+++ b/prov/shm/src/smr_init.c
@@ -45,6 +45,7 @@ struct smr_env smr_env = {
 	.disable_cma = false,
 	.use_dsa_sar = false,
 	.max_gdrcopy_size = 3072,
+	.use_xpmem = false,
 };
 
 static void smr_init_env(void)
@@ -54,6 +55,7 @@ static void smr_init_env(void)
 	fi_param_get_size_t(&smr_prov, "rx_size", &smr_info.rx_attr->size);
 	fi_param_get_bool(&smr_prov, "disable_cma", &smr_env.disable_cma);
 	fi_param_get_bool(&smr_prov, "use_dsa_sar", &smr_env.use_dsa_sar);
+	fi_param_get_bool(&smr_prov, "use_xpmem", &smr_env.use_xpmem);
 }
 
 static void smr_resolve_addr(const char *node, const char *service,
@@ -220,6 +222,9 @@ SHM_INI
 			"Enable CPU touching of memory pages in DSA command \
 			 descriptor when page fault is reported. \
 			 Default: false");
+	fi_param_define(&smr_prov, "use_xpmem", FI_PARAM_BOOL,
+			"Enable XPMEM over CMA when possible "
+			"(default: false)");
 
 	smr_init_env();
 

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -111,7 +111,7 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 	total_len = ofi_total_iov_len(iov, iov_count);
 	assert(!(op_flags & FI_INJECT) || total_len <= SMR_INJECT_SIZE);
 
-	proto = smr_select_proto(desc, iov_count, smr_cma_enabled(ep, peer_smr),
+	proto = smr_select_proto(desc, iov_count, smr_vma_enabled(ep, peer_smr),
 	                         op, total_len, op_flags);
 
 	ret = smr_proto_ops[proto](ep, peer_smr, id, peer_id, op, tag, data, op_flags,

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -308,8 +308,8 @@ static int smr_progress_iov(struct smr_cmd *cmd, struct iovec *iov,
 			    size_t iov_count, size_t *total_len,
 			    struct smr_ep *ep, int err)
 {
-	enum ofi_shm_p2p_type p2p_type = FI_SHM_P2P_CMA;
 	struct smr_region *peer_smr;
+	struct xpmem_client *xpmem;
 	struct smr_resp *resp;
 	int ret;
 
@@ -321,10 +321,12 @@ static int smr_progress_iov(struct smr_cmd *cmd, struct iovec *iov,
 		goto out;
 	}
 
-	ret = ofi_shm_p2p_copy(p2p_type, iov, iov_count, cmd->msg.data.iov,
+	xpmem = &smr_peer_data(ep->region)[cmd->msg.hdr.id].xpmem;
+
+	ret = ofi_shm_p2p_copy(ep->p2p_type, iov, iov_count, cmd->msg.data.iov,
 			       cmd->msg.data.iov_count, cmd->msg.hdr.size,
 			       peer_smr->pid, cmd->msg.hdr.op == ofi_op_read_req,
-			       NULL);
+			       xpmem);
 	if (!ret)
 		*total_len = cmd->msg.hdr.size;
 

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -38,6 +38,7 @@
 #include "ofi_hmem.h"
 #include "ofi_atom.h"
 #include "ofi_mr.h"
+#include "ofi_shm_p2p.h"
 #include "smr.h"
 #include "smr_dsa.h"
 
@@ -307,6 +308,7 @@ static int smr_progress_iov(struct smr_cmd *cmd, struct iovec *iov,
 			    size_t iov_count, size_t *total_len,
 			    struct smr_ep *ep, int err)
 {
+	enum ofi_shm_p2p_type p2p_type = FI_SHM_P2P_CMA;
 	struct smr_region *peer_smr;
 	struct smr_resp *resp;
 	int ret;
@@ -319,9 +321,10 @@ static int smr_progress_iov(struct smr_cmd *cmd, struct iovec *iov,
 		goto out;
 	}
 
-	ret = smr_cma_loop(peer_smr->pid, iov, iov_count, cmd->msg.data.iov,
-			   cmd->msg.data.iov_count, 0, cmd->msg.hdr.size,
-			   cmd->msg.hdr.op == ofi_op_read_req);
+	ret = ofi_shm_p2p_copy(p2p_type, iov, iov_count, cmd->msg.data.iov,
+			       cmd->msg.data.iov_count, cmd->msg.hdr.size,
+			       peer_smr->pid, cmd->msg.hdr.op == ofi_op_read_req,
+			       NULL);
 	if (!ret)
 		*total_len = cmd->msg.hdr.size;
 

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -565,7 +565,7 @@ static struct smr_pend_entry *smr_progress_ipc(struct smr_cmd *cmd,
 	if (cmd->msg.data.ipc_info.iface == FI_HMEM_ZE)
 		ptr = (char *) base + (uintptr_t) cmd->msg.data.ipc_info.offset;
 	else
-		ptr = (char *) (uintptr_t) mr_entry->info.ipc_mapped_addr +
+		ptr = (char *) (uintptr_t) mr_entry->info.mapped_addr +
 		      (uintptr_t) cmd->msg.data.ipc_info.offset;
 
 	if (cmd->msg.data.ipc_info.iface == FI_HMEM_ROCR) {

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -125,7 +125,7 @@ static ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 
 	cmds = 1 + !(domain->fast_rma && !(op_flags &
 		    (FI_REMOTE_CQ_DATA | FI_DELIVERY_COMPLETE)) &&
-		     rma_count == 1 && smr_cma_enabled(ep, peer_smr));
+		     rma_count == 1 && smr_vma_enabled(ep, peer_smr));
 
 	if (smr_peer_data(ep->region)[id].sar_status)
 		return -FI_EAGAIN;
@@ -167,7 +167,7 @@ static ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 	total_len = ofi_total_iov_len(iov, iov_count);
 	assert(!(op_flags & FI_INJECT) || total_len <= SMR_INJECT_SIZE);
 
-	proto = smr_select_proto(desc, iov_count, smr_cma_enabled(ep, peer_smr),
+	proto = smr_select_proto(desc, iov_count, smr_vma_enabled(ep, peer_smr),
 	                         op, total_len, op_flags);
 
 	ret = smr_proto_ops[proto](ep, peer_smr, id, peer_id, op, 0, data,
@@ -329,7 +329,7 @@ static ssize_t smr_generic_rma_inject(struct fid_ep *ep_fid, const void *buf,
 	peer_smr = smr_peer_region(ep->region, id);
 
 	cmds = 1 + !(domain->fast_rma && !(flags & FI_REMOTE_CQ_DATA) &&
-		     smr_cma_enabled(ep, peer_smr));
+		     smr_vma_enabled(ep, peer_smr));
 
 	if (smr_peer_data(ep->region)[id].sar_status)
 		return -FI_EAGAIN;

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -55,13 +55,14 @@ static void smr_format_rma_resp(struct smr_cmd *cmd, fi_addr_t peer_id,
 	cmd->msg.hdr.size = total_len;
 }
 
-static ssize_t smr_rma_fast(struct smr_region *peer_smr, const struct iovec *iov,
-			size_t iov_count, const struct fi_rma_iov *rma_iov,
-			size_t rma_count, void **desc, int peer_id, void *context,
+static ssize_t smr_rma_fast(struct smr_ep *ep, struct smr_region *peer_smr,
+			const struct iovec *iov, size_t iov_count,
+			const struct fi_rma_iov *rma_iov, size_t rma_count,
+			void **desc, int peer_id, int id, void *context,
 			uint32_t op, uint64_t op_flags)
 {
-	struct iovec cma_iovec[SMR_IOV_LIMIT], rma_iovec[SMR_IOV_LIMIT];
-	enum ofi_shm_p2p_type p2p_type = FI_SHM_P2P_CMA;
+	struct iovec vma_iovec[SMR_IOV_LIMIT], rma_iovec[SMR_IOV_LIMIT];
+	struct xpmem_client *xpmem;
 	struct smr_cmd_entry *ce;
 	size_t total_len;
 	int ret, i;
@@ -71,7 +72,7 @@ static ssize_t smr_rma_fast(struct smr_region *peer_smr, const struct iovec *iov
 	if (ret == -FI_ENOENT)
 		return -FI_EAGAIN;
 
-	memcpy(cma_iovec, iov, sizeof(*iov) * iov_count);
+	memcpy(vma_iovec, iov, sizeof(*iov) * iov_count);
 	for (i = 0; i < rma_count; i++) {
 		rma_iovec[i].iov_base = (void *) rma_iov[i].addr;
 		rma_iovec[i].iov_len = rma_iov[i].len;
@@ -79,9 +80,11 @@ static ssize_t smr_rma_fast(struct smr_region *peer_smr, const struct iovec *iov
 
 	total_len = ofi_total_iov_len(iov, iov_count);
 
-	ret = ofi_shm_p2p_copy(p2p_type, rma_iovec, iov_count,
+	xpmem = &smr_peer_data(ep->region)[id].xpmem;
+
+	ret = ofi_shm_p2p_copy(ep->p2p_type, vma_iovec, iov_count,
 			       rma_iovec, rma_count, total_len, peer_smr->pid,
-			       op == ofi_op_write, NULL);
+			       op == ofi_op_write, xpmem);
 
 	if (ret) {
 		smr_cmd_queue_discard(ce, pos);
@@ -133,8 +136,8 @@ static ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 	ofi_spin_lock(&ep->tx_lock);
 
 	if (cmds == 1) {
-		err = smr_rma_fast(peer_smr, iov, iov_count, rma_iov,
-				   rma_count, desc, peer_id,  context, op,
+		err = smr_rma_fast(ep, peer_smr, iov, iov_count, rma_iov,
+				   rma_count, desc, peer_id, id, context, op,
 				   op_flags);
 		if (err) {
 			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
@@ -341,8 +344,8 @@ static ssize_t smr_generic_rma_inject(struct fid_ep *ep_fid, const void *buf,
 	rma_iov.key = key;
 
 	if (cmds == 1) {
-		ret = smr_rma_fast(peer_smr, &iov, 1, &rma_iov, 1, NULL,
-				   peer_id, NULL, ofi_op_write, flags);
+		ret = smr_rma_fast(ep, peer_smr, &iov, 1, &rma_iov, 1, NULL,
+				   peer_id, id, NULL, ofi_op_write, flags);
 		goto out;
 	}
 

--- a/prov/shm/src/smr_util.c
+++ b/prov/shm/src/smr_util.c
@@ -71,7 +71,7 @@ void smr_cma_check(struct smr_region *smr, struct smr_region *peer_smr)
 	int remote_pid;
 	int ret;
 
-	if (smr != peer_smr && peer_smr->cma_cap_peer != SMR_CMA_CAP_NA) {
+	if (smr != peer_smr && peer_smr->cma_cap_peer != SMR_VMA_CAP_NA) {
 		smr->cma_cap_peer = peer_smr->cma_cap_peer;
 		return;
 	}
@@ -86,9 +86,9 @@ void smr_cma_check(struct smr_region *smr, struct smr_region *peer_smr)
 	assert(remote_pid == peer_smr->pid);
 
 	if (smr == peer_smr) {
-		smr->cma_cap_self = (ret == -1) ? SMR_CMA_CAP_OFF : SMR_CMA_CAP_ON;
+		smr->cma_cap_self = (ret == -1) ? SMR_VMA_CAP_OFF : SMR_VMA_CAP_ON;
 	} else {
-		smr->cma_cap_peer = (ret == -1) ? SMR_CMA_CAP_OFF : SMR_CMA_CAP_ON;
+		smr->cma_cap_peer = (ret == -1) ? SMR_VMA_CAP_OFF : SMR_VMA_CAP_ON;
 		peer_smr->cma_cap_peer = smr->cma_cap_peer;
 	}
 }
@@ -282,8 +282,8 @@ int smr_create(const struct fi_provider *prov, struct smr_map *map,
 	(*smr)->flags |= SMR_FLAG_DEBUG;
 #endif
 
-	(*smr)->cma_cap_peer = SMR_CMA_CAP_NA;
-	(*smr)->cma_cap_self = SMR_CMA_CAP_NA;
+	(*smr)->cma_cap_peer = SMR_VMA_CAP_NA;
+	(*smr)->cma_cap_self = SMR_VMA_CAP_NA;
 	(*smr)->base_addr = *smr;
 
 	(*smr)->total_size = total_size;
@@ -463,8 +463,8 @@ void smr_map_to_endpoint(struct smr_region *region, int64_t id)
 
 	peer_smr = smr_peer_region(region, id);
 
-	if ((region != peer_smr && region->cma_cap_peer == SMR_CMA_CAP_NA) ||
-	    (region == peer_smr && region->cma_cap_self == SMR_CMA_CAP_NA))
+	if ((region != peer_smr && region->cma_cap_peer == SMR_VMA_CAP_NA) ||
+	    (region == peer_smr && region->cma_cap_self == SMR_VMA_CAP_NA))
 		smr_cma_check(region, peer_smr);
 }
 

--- a/prov/shm/src/smr_util.c
+++ b/prov/shm/src/smr_util.c
@@ -40,8 +40,10 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <stdio.h>
+#include <ofi_xpmem.h>
 
 #include "smr_util.h"
+#include "smr.h"
 
 struct dlist_entry ep_name_list;
 DEFINE_LIST(ep_name_list);
@@ -284,6 +286,13 @@ int smr_create(const struct fi_provider *prov, struct smr_map *map,
 
 	(*smr)->cma_cap_peer = SMR_VMA_CAP_NA;
 	(*smr)->cma_cap_self = SMR_VMA_CAP_NA;
+
+	(*smr)->xpmem_cap_self = SMR_VMA_CAP_OFF;
+	if (xpmem && smr_env.use_xpmem) {
+		(*smr)->xpmem_cap_self = SMR_VMA_CAP_ON;
+		(*smr)->xpmem_self = xpmem->pinfo;
+	}
+
 	(*smr)->base_addr = *smr;
 
 	(*smr)->total_size = total_size;
@@ -306,6 +315,7 @@ int smr_create(const struct fi_provider *prov, struct smr_map *map,
 		smr_peer_addr_init(&smr_peer_data(*smr)[i].addr);
 		smr_peer_data(*smr)[i].sar_status = 0;
 		smr_peer_data(*smr)[i].name_sent = 0;
+		smr_peer_data(*smr)[i].xpmem.cap = SMR_VMA_CAP_OFF;
 	}
 
 	strncpy((char *) smr_name(*smr), attr->name, total_size - name_offset);
@@ -449,6 +459,7 @@ out:
 
 void smr_map_to_endpoint(struct smr_region *region, int64_t id)
 {
+	int ret;
 	struct smr_region *peer_smr;
 	struct smr_peer_data *local_peers;
 
@@ -466,6 +477,24 @@ void smr_map_to_endpoint(struct smr_region *region, int64_t id)
 	if ((region != peer_smr && region->cma_cap_peer == SMR_VMA_CAP_NA) ||
 	    (region == peer_smr && region->cma_cap_self == SMR_VMA_CAP_NA))
 		smr_cma_check(region, peer_smr);
+
+	/* enable xpmem locally if the peer also has it enabled */
+	if (peer_smr->xpmem_cap_self == SMR_VMA_CAP_ON &&
+	    region->xpmem_cap_self == SMR_VMA_CAP_ON) {
+		ret = ofi_xpmem_enable(&peer_smr->xpmem_self,
+				       &local_peers[id].xpmem);
+		if (ret) {
+			local_peers[id].xpmem.cap = SMR_VMA_CAP_OFF;
+			region->xpmem_cap_self = SMR_VMA_CAP_OFF;
+			return;
+		}
+		local_peers[id].xpmem.cap = SMR_VMA_CAP_ON;
+		local_peers[id].xpmem.addr_max = peer_smr->xpmem_self.address_max;
+	} else {
+		local_peers[id].xpmem.cap = SMR_VMA_CAP_OFF;
+	}
+
+	return;
 }
 
 void smr_unmap_from_endpoint(struct smr_region *region, int64_t id)
@@ -486,6 +515,8 @@ void smr_unmap_from_endpoint(struct smr_region *region, int64_t id)
 
 	peer_peers[peer_id].addr.id = -1;
 	peer_peers[peer_id].name_sent = 0;
+
+	ofi_xpmem_release(&local_peers[peer_id].xpmem);
 }
 
 void smr_exchange_all_peers(struct smr_region *region)

--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -84,11 +84,12 @@ enum {
 #define SMR_RX_COMPLETION	(1 << 3)
 #define SMR_MULTI_RECV		(1 << 4)
 
-/* CMA capability */
+/* CMA/XPMEM capability. Generic acronym used:
+ * VMA: Virtual Memory Address */
 enum {
-	SMR_CMA_CAP_NA,
-	SMR_CMA_CAP_ON,
-	SMR_CMA_CAP_OFF,
+	SMR_VMA_CAP_NA,
+	SMR_VMA_CAP_ON,
+	SMR_VMA_CAP_OFF,
 };
 
 /*

--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -39,6 +39,7 @@
 #include <stddef.h>
 #include <sys/un.h>
 
+#include <ofi_xpmem.h>
 #include <ofi_atom.h>
 #include <ofi_proto.h>
 #include <ofi_mem.h>
@@ -53,8 +54,7 @@
 extern "C" {
 #endif
 
-
-#define SMR_VERSION	5
+#define SMR_VERSION	6
 
 #define SMR_FLAG_ATOMIC	(1 << 0)
 #define SMR_FLAG_DEBUG	(1 << 1)
@@ -178,6 +178,7 @@ struct smr_peer_data {
 	struct smr_addr		addr;
 	uint32_t		sar_status;
 	uint32_t		name_sent;
+	struct xpmem_client 	xpmem;
 };
 
 extern struct dlist_entry ep_name_list;
@@ -225,6 +226,9 @@ struct smr_region {
 	uint8_t		cma_cap_peer;
 	uint8_t		cma_cap_self;
 	uint32_t	max_sar_buf_per_peer;
+	uint8_t		xpmem_cap_self;
+	struct xpmem_pinfo xpmem_self;
+	struct xpmem_pinfo xpmem_peer;
 	void		*base_addr;
 	pthread_spinlock_t	lock; /* lock for shm access
 				 if both ep->tx_lock and this lock need to

--- a/prov/util/src/cuda_ipc_monitor.c
+++ b/prov/util/src/cuda_ipc_monitor.c
@@ -40,8 +40,8 @@ static bool cuda_ipc_monitor_valid(struct ofi_mem_monitor *monitor,
 			const struct ofi_mr_info *info,
 			struct ofi_mr_entry *entry)
 {
-	return (memcmp((void **)&info->ipc_handle,
-		(void **)&entry->info.ipc_handle,
+	return (memcmp((void **)&info->handle,
+		(void **)&entry->info.handle,
 		sizeof(cudaIpcMemHandle_t)) == 0);
 }
 

--- a/prov/util/src/rocr_ipc_monitor.c
+++ b/prov/util/src/rocr_ipc_monitor.c
@@ -40,8 +40,8 @@ static bool rocr_ipc_monitor_valid(struct ofi_mem_monitor *monitor,
 			const struct ofi_mr_info *info,
 			struct ofi_mr_entry *entry)
 {
-	return (memcmp((void **)&info->ipc_handle,
-		(void **)&entry->info.ipc_handle,
+	return (memcmp((void **)&info->handle,
+		(void **)&entry->info.handle,
 		sizeof(hsa_amd_ipc_memory_t)) == 0);
 }
 

--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -175,6 +175,7 @@ void ofi_monitors_init(void)
 	cuda_ipc_monitor->init(cuda_ipc_monitor);
 	rocr_monitor->init(rocr_monitor);
 	rocr_ipc_monitor->init(rocr_ipc_monitor);
+	xpmem_monitor->init(xpmem_monitor);
 	ze_monitor->init(ze_monitor);
 	import_monitor->init(import_monitor);
 

--- a/prov/util/src/xpmem_monitor.c
+++ b/prov/util/src/xpmem_monitor.c
@@ -1,0 +1,64 @@
+/*
+ * (C) Copyright (c) 2022 UT-Battelle, LLC. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "ofi_mr.h"
+
+#if HAVE_XPMEM
+
+static bool xpmem_monitor_valid(struct ofi_mem_monitor *monitor,
+			const struct ofi_mr_info *info,
+			struct ofi_mr_entry *entry)
+{
+	return true;
+}
+
+#else
+
+static bool xpmem_monitor_valid(struct ofi_mem_monitor *monitor,
+			const struct ofi_mr_info *info,
+			struct ofi_mr_entry *entry)
+{
+	return false;
+}
+
+#endif /* HAVE_XPMEM */
+static struct ofi_mem_monitor xpmem_monitor_ = {
+	.init = ofi_monitor_init,
+	.cleanup = ofi_monitor_cleanup,
+	.start = ofi_monitor_start_no_op,
+	.stop = ofi_monitor_stop_no_op,
+	.subscribe = ofi_monitor_subscribe_no_op,
+	.unsubscribe = ofi_monitor_unsubscribe_no_op,
+	.valid = xpmem_monitor_valid,
+};
+
+struct ofi_mem_monitor *xpmem_monitor = &xpmem_monitor_;

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -50,6 +50,7 @@
 #include "ofi_prov.h"
 #include "ofi_perf.h"
 #include "ofi_hmem.h"
+#include <ofi_shm_p2p.h>
 #include <rdma/fi_ext.h>
 
 #ifdef HAVE_LIBDL
@@ -847,6 +848,7 @@ void fi_ini(void)
 	ofi_hook_init();
 	ofi_hmem_init();
 	ofi_monitors_init();
+	ofi_shm_p2p_init();
 
 	fi_param_define(NULL, "provider", FI_PARAM_STRING,
 			"Only use specified provider (default: all available)");
@@ -939,6 +941,7 @@ FI_DESTRUCTOR(fi_fini(void))
 	ofi_free_filter(&prov_filter);
 	ofi_monitors_cleanup();
 	ofi_hmem_cleanup();
+	ofi_shm_p2p_cleanup();
 	ofi_hook_fini();
 	ofi_mem_fini();
 	fi_log_fini();

--- a/src/hmem_ipc_cache.c
+++ b/src/hmem_ipc_cache.c
@@ -38,9 +38,9 @@ static int ipc_cache_add_region(struct ofi_mr_cache *cache, struct ofi_mr_entry 
 {
 	int ret;
 
-	ret = ofi_hmem_open_handle(entry->info.iface, (void **)&entry->info.ipc_handle,
+	ret = ofi_hmem_open_handle(entry->info.iface, (void **)&entry->info.handle,
 				   entry->info.iov.iov_len, entry->info.device,
-				   &entry->info.ipc_mapped_addr);
+				   &entry->info.mapped_addr);
 	if (ret == -FI_EALREADY) {
 		/*
 		 * There is a chance we can get the -FI_EALREADY from the
@@ -59,9 +59,9 @@ static int ipc_cache_add_region(struct ofi_mr_cache *cache, struct ofi_mr_entry 
 		 * and close the handles.
 		 */
 		ofi_mr_cache_flush(cache, false);
-		ret = ofi_hmem_open_handle(entry->info.iface, (void **)&entry->info.ipc_handle,
+		ret = ofi_hmem_open_handle(entry->info.iface, (void **)&entry->info.handle,
 						entry->info.iov.iov_len, entry->info.device,
-						&entry->info.ipc_mapped_addr);
+						&entry->info.mapped_addr);
 	}
 	if (ret) {
 		FI_WARN(&core_prov, FI_LOG_CORE,
@@ -75,7 +75,7 @@ static void ipc_cache_delete_region(struct ofi_mr_cache *cache,
 				     struct ofi_mr_entry *entry)
 {
 	ofi_hmem_close_handle(entry->info.iface,
-			      entry->info.ipc_mapped_addr);
+			      entry->info.mapped_addr);
 }
 
 /**
@@ -136,9 +136,9 @@ void ofi_ipc_cache_destroy(struct ofi_mr_cache *cache)
 }
 
 /**
- * @brief Given ipc_info (with ipc_handle and the iov of the device allocation),
- * assign the mapped_addr the mapped address of the ipc_handle.
- * Each (ipc_handle, mapped_addr) pair is stored in ofi_mr_entry.info.ipc_info as
+ * @brief Given ipc_info (with handle and the iov of the device allocation),
+ * assign the mapped_addr the mapped address of the handle.
+ * Each (handle, mapped_addr) pair is stored in ofi_mr_entry.info.ipc_info as
  * part of each mr entry.
  * In a cache hit, the mapped_addr is retrieved from the matched mr entry. Otherwise,
  * the mapped_addr is obtained by opening the ipc handle.
@@ -165,7 +165,7 @@ int ofi_ipc_cache_search(struct ofi_mr_cache *cache, uint64_t peer_id,
 	ipc_handle_size = ofi_hmem_get_ipc_handle_size(info.iface);
 	assert(ipc_handle_size);
 
-	memcpy(&info.ipc_handle, &ipc_info->ipc_handle, ipc_handle_size);
+	memcpy(&info.handle, &ipc_info->ipc_handle, ipc_handle_size);
 
 	ret = ofi_mr_cache_search(cache, &info, &entry);
 	if (ret)

--- a/src/xpmem.c
+++ b/src/xpmem.c
@@ -1,0 +1,253 @@
+/*
+ * (C) Copyright 2023 UT-Battelle, LLC. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <rdma/fi_errno.h>
+#include <ofi_xpmem.h>
+#include <ofi_mem.h>
+#include <ofi_mr.h>
+#include <ofi.h>
+#include <stdio.h>
+
+#define XPMEM_DEFAULT_MEMCPY_CHUNK_SIZE 262144
+struct xpmem *xpmem = NULL;
+
+#if HAVE_XPMEM
+/* global cache for use with xpmem */
+static struct ofi_mr_cache *xpmem_cache;
+
+int xpmem_init(void)
+{
+	/* Any attachment that goes past the Linux TASK_SIZE will always
+	 * fail. To prevent this we need to determine the value of
+	 * TASK_SIZE. On x86_64 the value was hard-coded in sm to be
+	 * 0x7ffffffffffful but this approach does not work with AARCH64
+	 * (and possibly other architectures). Since there is really no
+	 * way to directly determine the value we can (in all cases?) look
+	 * through the mapping for this process to determine what the
+	 * largest address is.  This should be the top of the stack. No
+	 * heap allocations should be larger than this value.  Since the
+	 * largest address may differ between processes the value must be
+	 * shared as part of the modex and stored in the endpoint. */
+	int ret = 0;
+	char buffer[1024];
+	uintptr_t address_max = 0;
+	FILE *fh;
+	uintptr_t low, high;
+	char *tmp;
+
+	fi_param_define(&core_prov, "xpmem_memcpy_chunksize", FI_PARAM_SIZE_T,
+			"Maximum size used for a single memcpy call. "
+			"(default: %d)", XPMEM_DEFAULT_MEMCPY_CHUNK_SIZE);
+
+	xpmem = calloc(sizeof(*xpmem), 1);
+	if (!xpmem)
+		return -FI_ENOMEM;
+
+	fh = fopen("/proc/self/maps", "r");
+	if (NULL == fh) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+				"could not open /proc/self/maps for reading");
+		ret = -FI_EIO;
+		goto fail;
+	}
+
+	while (fgets(buffer, sizeof(buffer), fh)) {
+		/* each line of /proc/self/maps starts with low-high in
+		 * hexidecimal (without a 0x) */
+		low = strtoul(buffer, &tmp, 16);
+		high = strtoul(tmp + 1, NULL, 16);
+		if (address_max < high)
+			address_max = high;
+	}
+	fclose(fh);
+
+	if (address_max == 0) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"could not determine the address max");
+		ret = -FI_EIO;
+		goto fail;
+	}
+
+	/* save the calcuated maximum */
+	xpmem->pinfo.address_max = address_max - 1;
+
+	/* export the process virtual address space for use with xpmem */
+	xpmem->pinfo.seg_id = xpmem_make(0, XPMEM_MAXADDR_SIZE, XPMEM_PERMIT_MODE,
+					 (void *) 0666);
+	if (xpmem->pinfo.seg_id == -1) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"Failed to export process virtual address space for use with xpmem\n");
+		ret = -FI_ENODATA;
+		goto fail;
+	}
+
+	ret = fi_param_get_size_t(&core_prov, "xpmem_memcpy_chunksize",
+				  &xpmem->memcpy_chunk_size);
+	if (ret)
+		xpmem->memcpy_chunk_size = XPMEM_DEFAULT_MEMCPY_CHUNK_SIZE;
+
+	ret = ofi_xpmem_cache_open(&xpmem_cache);
+	if (ret)
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"could not open xpmem cache");
+
+	return ret;
+
+fail:
+	free(xpmem);
+	xpmem = NULL;
+	return ret;
+}
+
+int xpmem_cleanup(void)
+{
+	int ret = 0;
+
+	if (xpmem_cache)
+		ofi_xpmem_cache_destroy(xpmem_cache);
+
+	if (xpmem)
+		ret = xpmem_remove(xpmem->pinfo.seg_id);
+
+	return (ret) ? -FI_EINVAL : ret;
+}
+
+static inline void xpmem_memcpy(void *dst, void *src, size_t size)
+{
+	size_t copy_size;
+
+	while (size > 0) {
+		copy_size = MIN(size, xpmem->memcpy_chunk_size);
+		memcpy(dst, src, copy_size);
+		dst = (void *) ((uintptr_t) dst + copy_size);
+		src = (void *) ((uintptr_t) src + copy_size);
+		size -= copy_size;
+	}
+}
+
+int xpmem_copy(struct iovec *local, unsigned long local_cnt,
+	       struct iovec *remote, unsigned long remote_cnt,
+	       size_t total, pid_t pid, bool write, void *user_data)
+{
+	int ret, i;
+	struct iovec iov;
+	uint64_t offset, copy_len;
+	void *mapped_addr;
+	struct ofi_mr_entry *mr_entry;
+	long page_size = ofi_get_page_size();
+
+	assert(local_cnt == remote_cnt);
+
+	for (i = 0; i < remote_cnt; i++) {
+		iov.iov_base = (void *) ofi_get_page_start(remote[i].iov_base,
+							   page_size);
+		iov.iov_len =
+			(uintptr_t) ofi_get_page_end(remote[i].iov_base +
+					remote[i].iov_len, page_size) -
+					(uintptr_t)iov.iov_base;
+		offset = (uintptr_t)((uintptr_t) remote[i].iov_base -
+				     (uintptr_t) iov.iov_base);
+
+		ret = ofi_xpmem_cache_search(xpmem_cache, &iov, pid, &mr_entry,
+					     (struct xpmem_client *)user_data);
+		if (ret)
+			return ret;
+
+		mapped_addr = (char*) (uintptr_t)mr_entry->info.mapped_addr +
+				offset;
+
+		copy_len = (local[i].iov_len <= iov.iov_len - offset) ?
+				local[i].iov_len : iov.iov_len - offset;
+
+		if (write)
+			xpmem_memcpy(mapped_addr, local[i].iov_base,
+				     copy_len);
+		else
+			xpmem_memcpy(local[i].iov_base, mapped_addr,
+				     copy_len);
+
+		ofi_mr_cache_delete(xpmem_cache, mr_entry);
+	}
+
+	return 0;
+}
+
+int ofi_xpmem_enable(struct xpmem_pinfo *peer,
+		     struct xpmem_client *xpmem)
+{
+	xpmem->apid = xpmem_get(peer->seg_id,
+				XPMEM_RDWR, XPMEM_PERMIT_MODE, (void *) 0666);
+	if (xpmem->apid == -1)
+		return -FI_ENOSYS;
+
+	return FI_SUCCESS;
+}
+
+void ofi_xpmem_release(struct xpmem_client *xpmem)
+{
+	xpmem_release(xpmem->apid);
+}
+
+#else
+
+int xpmem_init(void)
+{
+	return -FI_ENOSYS;
+}
+
+int xpmem_cleanup(void)
+{
+	return -FI_ENOSYS;
+}
+
+int xpmem_copy(struct iovec *local, unsigned long local_cnt,
+	       struct iovec *remote, unsigned long remote_cnt,
+	       size_t total, pid_t pid, bool write, void *user_data)
+{
+	return -FI_ENOSYS;
+}
+
+int ofi_xpmem_enable(struct xpmem_pinfo *peer,
+		     struct xpmem_client *xpmem)
+{
+	return -FI_ENOSYS;
+}
+
+void ofi_xpmem_release(struct xpmem_client *xpmem)
+{
+}
+
+#endif /* HAVE_XPMEM */

--- a/src/xpmem_cache.c
+++ b/src/xpmem_cache.c
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif /* HAVE_CONFIG_H */
+
+#include <ofi_xpmem.h>
+
+#if HAVE_XPMEM
+static int xpmem_cache_add_region(struct ofi_mr_cache *cache, struct ofi_mr_entry *entry)
+{
+	struct xpmem_addr *xpmem_addr = (struct xpmem_addr *) entry->info.handle;
+
+	entry->info.mapped_addr = xpmem_attach(*xpmem_addr,
+					       entry->info.iov.iov_len, NULL);
+	if (entry->info.mapped_addr == (void *) -1)
+		return -FI_EIO;
+
+	return FI_SUCCESS;
+}
+
+static void xpmem_cache_delete_region(struct ofi_mr_cache *cache,
+				     struct ofi_mr_entry *entry)
+{
+	xpmem_detach(entry->info.mapped_addr);
+}
+
+/**
+ * @brief Open an xpmem cache
+ *
+ * @param cache[in] the xpmem cache
+ * @return int 0 on success, negative value otherwise.
+ */
+int ofi_xpmem_cache_open(struct ofi_mr_cache **cache)
+{
+	struct ofi_mem_monitor *memory_monitors[OFI_HMEM_MAX] = {0};
+	int ret;
+
+	memory_monitors[FI_HMEM_SYSTEM] = xpmem_monitor;
+
+	*cache = calloc(1, sizeof(*(*cache)));
+	if (!*cache) {
+		ret = -FI_ENOMEM;
+		goto out;
+	}
+
+	(*cache)->add_region = xpmem_cache_add_region;
+	(*cache)->delete_region = xpmem_cache_delete_region;
+	ret = ofi_mr_cache_init(NULL, memory_monitors,
+				*cache);
+	if (ret)
+		goto cleanup;
+
+	FI_INFO(&core_prov, FI_LOG_CORE,
+		"xpmem cache enabled, max_cnt: %zu max_size: %zu\n",
+		cache_params.max_cnt, cache_params.max_size);
+	return FI_SUCCESS;
+
+cleanup:
+	free(*cache);
+	*cache = NULL;
+out:
+	return ret;
+}
+
+/**
+ * @brief Destroy the xpmem cache
+ *
+ * @param cache the xpmem cache
+ */
+void ofi_xpmem_cache_destroy(struct ofi_mr_cache *cache)
+{
+	ofi_mr_cache_cleanup(cache);
+	free(cache);
+}
+
+/**
+ * @brief Given the remote address exposed by XPMEM and the peer id,
+ * search to see if we have already cached the address returned by
+ * xpmem_attach(). If not, then trigger an xpmem_attach() operation (done
+ * through the cache mechanism) and cache the mapped address.
+ *
+ * @param[in] cache the xpmem cache
+ * @param[in] iov the remote address to be XPMEM attached if necessary.
+ * @param[in] peer_id ID of the peer
+ * @param[out] mr_entry the matched mr_entry of the XPMEM mapped_addr.
+ * @return int 0 on success, negative value otherwise.
+ */
+int ofi_xpmem_cache_search(struct ofi_mr_cache *cache, struct iovec *iov,
+			   uint64_t peer_id, struct ofi_mr_entry **mr_entry,
+			   struct xpmem_client *xpmem)
+{
+	int ret;
+	struct ofi_mr_info info;
+	struct ofi_mr_entry *entry;
+	struct xpmem_addr xpmem_addr;
+
+	xpmem_addr.apid = xpmem->apid;
+	xpmem_addr.offset = (uintptr_t)iov->iov_base;
+	memcpy(&info.iov, iov, sizeof(*iov));
+	info.iface = FI_HMEM_SYSTEM;
+	info.peer_id = peer_id;
+
+	memcpy(&info.handle, &xpmem_addr, sizeof(xpmem_addr));
+
+	ret = ofi_mr_cache_search(cache, &info, &entry);
+	if (ret)
+		goto out;
+
+	*mr_entry = entry;
+out:
+	return ret;
+}
+
+#else
+
+int ofi_xpmem_cache_search(struct ofi_mr_cache *cache, struct iovec *iov,
+			   uint64_t peer_id, struct ofi_mr_entry **mr_entry,
+			   struct xpmem_client *xpmem)
+{
+	return -FI_ENOSYS;
+}
+
+int ofi_xpmem_cache_open(struct ofi_mr_cache **cache)
+{
+	*cache = NULL;
+	return FI_SUCCESS;
+}
+
+void ofi_xpmem_cache_destroy(struct ofi_mr_cache *cache)
+{
+}
+
+#endif /* HAVE_XPMEM */


### PR DESCRIPTION
Add support for XPMEM the same way as other HMEM entries.
XPMEM makes use of the IPC caching to avoid repeated calls to xpmem_attach()/xpmem_detach()