### PR TITLE
prov/efa: remove rxr_rx_entry and rxr_tx_entry macro definitions

### DIFF
--- a/prov/efa/docs/pkt-processing.md
+++ b/prov/efa/docs/pkt-processing.md
@@ -21,16 +21,15 @@ in progress, sends and receives queued due to resource exhaustion, unexpected
 messages, and structures to track out of order packets and remote peer
 capabilities and status.
 
-`rxr_tx_entry` contains information and structures for a send posted either
-directly by the app or indirectly such as an emulated read/write. When the send
-is completed a send completion will be written and the tx_entry will be
-released.
-
-`rxr_rx_entry` contains information and structures for a receive posted by the
-app. This structure is used for tag matching, to queue unexpected messages to
-be matched later, and to keep track of whether long message receives are
-complete. Just like the tx_entry, when done a receive completion is written to
-the app and the rx_entry is freed.
+`rxr_op_entry` contains information and structures used in send/receive operations. 
+It is used in send operation for send posted directly by the app or indirectly 
+by emulated read/write operations. When the send is completed a send completion 
+will be written and the tx_entry will be released.
+It is used in  receive operation for a receive posted by the app. This structure 
+is used for tag matching, to queue unexpected messages to be matched later, and to 
+keep track of whether long message receives are completed. Just like the tx_entry,
+when a receive operation is completed a receive completion is written to the app 
+and the rx_entry is released.
 
 `rxr_ep_progress` is the progress handler we register when the completion queue
 is created and is called via the util completion queue functions. While the EFA

--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -110,8 +110,8 @@ void efa_rdm_peer_init(struct rdm_peer *peer, struct rxr_ep *ep, struct efa_conn
 void efa_rdm_peer_clear(struct rxr_ep *ep, struct rdm_peer *peer)
 {
 	struct dlist_entry *tmp;
-	struct rxr_tx_entry *tx_entry;
-	struct rxr_rx_entry *rx_entry;
+	struct rxr_op_entry *tx_entry;
+	struct rxr_op_entry *rx_entry;
 	struct rxr_pkt_entry *pkt_entry;
 	/*
 	 * TODO: Add support for wait/signal until all pending messages have
@@ -146,13 +146,13 @@ void efa_rdm_peer_clear(struct rxr_ep *ep, struct rdm_peer *peer)
 	}
 
 	dlist_foreach_container_safe(&peer->tx_entry_list,
-				     struct rxr_tx_entry,
+				     struct rxr_op_entry,
 				     tx_entry, peer_entry, tmp) {
 		rxr_release_tx_entry(ep, tx_entry);
 	}
 
 	dlist_foreach_container_safe(&peer->rx_entry_list,
-				     struct rxr_rx_entry,
+				     struct rxr_op_entry,
 				     rx_entry, peer_entry, tmp) {
 		rxr_release_rx_entry(ep, rx_entry);
 	}

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -511,10 +511,10 @@ struct efa_ep_addr *rxr_peer_raw_addr(struct rxr_ep *ep, fi_addr_t addr);
 
 const char *rxr_peer_raw_addr_str(struct rxr_ep *ep, fi_addr_t addr, char *buf, size_t *buflen);
 
-void rxr_tx_entry_init(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry,
+void rxr_tx_entry_init(struct rxr_ep *rxr_ep, struct rxr_op_entry *tx_entry,
 		       const struct fi_msg *msg, uint32_t op, uint64_t flags);
 
-struct rxr_tx_entry *rxr_ep_alloc_tx_entry(struct rxr_ep *rxr_ep,
+struct rxr_op_entry *rxr_ep_alloc_tx_entry(struct rxr_ep *rxr_ep,
 					   const struct fi_msg *msg,
 					   uint32_t op,
 					   uint64_t tag,
@@ -522,11 +522,11 @@ struct rxr_tx_entry *rxr_ep_alloc_tx_entry(struct rxr_ep *rxr_ep,
 
 void rxr_release_tx_entry(struct rxr_ep *ep, struct rxr_op_entry *tx_entry);
 
-struct rxr_rx_entry *rxr_ep_alloc_rx_entry(struct rxr_ep *ep,
+struct rxr_op_entry *rxr_ep_alloc_rx_entry(struct rxr_ep *ep,
 					   fi_addr_t addr, uint32_t op);
 
 static inline void rxr_release_rx_entry(struct rxr_ep *ep,
-					struct rxr_rx_entry *rx_entry)
+					struct rxr_op_entry *rx_entry)
 {
 	struct rxr_pkt_entry *pkt_entry;
 	struct dlist_entry *tmp;
@@ -549,7 +549,7 @@ static inline void rxr_release_rx_entry(struct rxr_ep *ep,
 
 #ifdef ENABLE_EFA_POISONING
 	rxr_poison_mem_region((uint32_t *)rx_entry,
-			      sizeof(struct rxr_rx_entry));
+			      sizeof(struct rxr_op_entry));
 #endif
 	rx_entry->state = RXR_OP_FREE;
 	ofi_buf_free(rx_entry);
@@ -599,7 +599,7 @@ int rxr_endpoint(struct fid_domain *domain, struct fi_info *info,
 void rxr_ep_progress(struct util_ep *util_ep);
 void rxr_ep_progress_internal(struct rxr_ep *rxr_ep);
 
-int rxr_ep_post_user_recv_buf(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,
+int rxr_ep_post_user_recv_buf(struct rxr_ep *ep, struct rxr_op_entry *rx_entry,
 			      uint64_t flags);
 
 int rxr_ep_determine_rdma_support(struct rxr_ep *ep, fi_addr_t addr,
@@ -608,20 +608,20 @@ int rxr_ep_determine_rdma_support(struct rxr_ep *ep, fi_addr_t addr,
 void rxr_convert_desc_for_shm(int numdesc, void **desc);
 
 void rxr_prepare_desc_send(struct efa_domain *efa_domain,
-			   struct rxr_tx_entry *tx_entry);
+			   struct rxr_op_entry *tx_entry);
 
-struct rxr_rx_entry *rxr_ep_lookup_mediumrtm_rx_entry(struct rxr_ep *ep,
+struct rxr_op_entry *rxr_ep_lookup_mediumrtm_rx_entry(struct rxr_ep *ep,
 						      struct rxr_pkt_entry *pkt_entry);
 
 void rxr_ep_record_mediumrtm_rx_entry(struct rxr_ep *ep,
 				      struct rxr_pkt_entry *pkt_entry,
-				      struct rxr_rx_entry *rx_entry);
+				      struct rxr_op_entry *rx_entry);
 
 /* CQ sub-functions */
-void rxr_cq_write_rx_error(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,
+void rxr_cq_write_rx_error(struct rxr_ep *ep, struct rxr_op_entry *rx_entry,
 			   int err, int prov_errno);
 
-void rxr_cq_write_tx_error(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
+void rxr_cq_write_tx_error(struct rxr_ep *ep, struct rxr_op_entry *tx_entry,
 			   int err, int prov_errno);
 
 void rxr_cq_queue_rnr_pkt(struct rxr_ep *ep,
@@ -629,7 +629,7 @@ void rxr_cq_queue_rnr_pkt(struct rxr_ep *ep,
 			  struct rxr_pkt_entry *pkt_entry);
 
 void rxr_cq_write_rx_completion(struct rxr_ep *ep,
-				struct rxr_rx_entry *rx_entry);
+				struct rxr_op_entry *rx_entry);
 
 void rxr_cq_complete_recv(struct rxr_ep *ep,
 			  struct rxr_op_entry *op_entry,

--- a/prov/efa/src/rxr/rxr_atomic.c
+++ b/prov/efa/src/rxr/rxr_atomic.c
@@ -66,13 +66,13 @@ static void rxr_atomic_init_shm_msg(struct fi_msg_atomic *shm_msg,
 }
 
 static
-struct rxr_tx_entry *
+struct rxr_op_entry *
 rxr_atomic_alloc_tx_entry(struct rxr_ep *rxr_ep,
 			  const struct fi_msg_atomic *msg_atomic,
 			  const struct rxr_atomic_ex *atomic_ex,
 			  uint32_t op, uint64_t flags)
 {
-	struct rxr_tx_entry *tx_entry;
+	struct rxr_op_entry *tx_entry;
 	struct fi_msg msg;
 	struct iovec iov[RXR_IOV_LIMIT];
 	size_t datatype_size;
@@ -124,7 +124,7 @@ ssize_t rxr_atomic_generic_efa(struct rxr_ep *rxr_ep,
 			       const struct rxr_atomic_ex *atomic_ex,
 			       uint32_t op, uint64_t flags)
 {
-	struct rxr_tx_entry *tx_entry;
+	struct rxr_op_entry *tx_entry;
 	struct rdm_peer *peer;
 	bool delivery_complete_requested;
 	ssize_t err;

--- a/prov/efa/src/rxr/rxr_cq.c
+++ b/prov/efa/src/rxr/rxr_cq.c
@@ -71,7 +71,7 @@ static const char *rxr_cq_strerror(struct fid_cq *cq_fid, int prov_errno,
  * @param[in]	err		positive libfabric error code
  * @param[in]	prov_errno	positive provider specific error code
  */
-void rxr_cq_write_rx_error(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,
+void rxr_cq_write_rx_error(struct rxr_ep *ep, struct rxr_op_entry *rx_entry,
 			   int err, int prov_errno)
 {
 	struct fi_cq_err_entry err_entry;
@@ -173,7 +173,7 @@ void rxr_cq_write_rx_error(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,
  * @param[in]	err		positive libfabric error code
  * @param[in]	prov_errno	positive EFA provider specific error code
  */
-void rxr_cq_write_tx_error(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
+void rxr_cq_write_tx_error(struct rxr_ep *ep, struct rxr_op_entry *tx_entry,
 			   int err, int prov_errno)
 {
 	struct fi_cq_err_entry err_entry;
@@ -364,7 +364,7 @@ void rxr_cq_queue_rnr_pkt(struct rxr_ep *ep,
 }
 
 void rxr_cq_write_rx_completion(struct rxr_ep *ep,
-				struct rxr_rx_entry *rx_entry)
+				struct rxr_op_entry *rx_entry)
 {
 	struct util_cq *rx_cq = ep->util_ep.rx_cq;
 	int ret = 0;
@@ -729,7 +729,7 @@ void rxr_cq_handle_shm_completion(struct rxr_ep *ep, struct fi_cq_data_entry *cq
 
 static inline
 bool rxr_cq_need_tx_completion(struct rxr_ep *ep,
-			       struct rxr_tx_entry *tx_entry)
+			       struct rxr_op_entry *tx_entry)
 
 {
 	if (tx_entry->fi_flags & RXR_NO_COMPLETION)

--- a/prov/efa/src/rxr/rxr_msg.h
+++ b/prov/efa/src/rxr/rxr_msg.h
@@ -49,31 +49,31 @@ void rxr_msg_construct(struct fi_msg *msg, const struct iovec *iov, void **desc,
 
 
 bool rxr_msg_multi_recv_buffer_available(struct rxr_ep *ep,
-					 struct rxr_rx_entry *rx_entry);
+					 struct rxr_op_entry *rx_entry);
 
 void rxr_msg_multi_recv_handle_completion(struct rxr_ep *ep,
-					  struct rxr_rx_entry *rx_entry);
+					  struct rxr_op_entry *rx_entry);
 
 void rxr_msg_multi_recv_free_posted_entry(struct rxr_ep *ep,
-					  struct rxr_rx_entry *rx_entry);
+					  struct rxr_op_entry *rx_entry);
 
 /**
  * functions to allocate rx_entry for two sided operations
  */
-struct rxr_rx_entry *rxr_msg_alloc_rx_entry(struct rxr_ep *ep,
+struct rxr_op_entry *rxr_msg_alloc_rx_entry(struct rxr_ep *ep,
 					    const struct fi_msg *msg,
 					    uint32_t op, uint64_t flags,
 					    uint64_t tag, uint64_t ignore);
 
-struct rxr_rx_entry *rxr_msg_alloc_unexp_rx_entry_for_msgrtm(struct rxr_ep *ep,
+struct rxr_op_entry *rxr_msg_alloc_unexp_rx_entry_for_msgrtm(struct rxr_ep *ep,
 							     struct rxr_pkt_entry **pkt_entry);
 
-struct rxr_rx_entry *rxr_msg_alloc_unexp_rx_entry_for_tagrtm(struct rxr_ep *ep,
+struct rxr_op_entry *rxr_msg_alloc_unexp_rx_entry_for_tagrtm(struct rxr_ep *ep,
 							     struct rxr_pkt_entry **pkt_entry);
 
-struct rxr_rx_entry *rxr_msg_split_rx_entry(struct rxr_ep *ep,
-					    struct rxr_rx_entry *posted_entry,
-					    struct rxr_rx_entry *consumer_entry,
+struct rxr_op_entry *rxr_msg_split_rx_entry(struct rxr_ep *ep,
+					    struct rxr_op_entry *posted_entry,
+					    struct rxr_op_entry *consumer_entry,
 					    struct rxr_pkt_entry *pkt_entry);
 /*
  * The following 2 OP structures are defined in rxr_msg.c and is
@@ -83,6 +83,6 @@ extern struct fi_ops_msg rxr_ops_msg;
 
 extern struct fi_ops_tagged rxr_ops_tagged;
 
-ssize_t rxr_msg_post_medium_rtm(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry);
+ssize_t rxr_msg_post_medium_rtm(struct rxr_ep *ep, struct rxr_op_entry *tx_entry);
 
-ssize_t rxr_msg_post_medium_rtm_or_queue(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry);
+ssize_t rxr_msg_post_medium_rtm_or_queue(struct rxr_ep *ep, struct rxr_op_entry *tx_entry);

--- a/prov/efa/src/rxr/rxr_op_entry.c
+++ b/prov/efa/src/rxr/rxr_op_entry.c
@@ -82,7 +82,7 @@
  * @param[in]		access		the access flag for the memory registation.
  *
  */
-void rxr_tx_entry_try_fill_desc(struct rxr_tx_entry *tx_entry,
+void rxr_tx_entry_try_fill_desc(struct rxr_op_entry *tx_entry,
 				struct efa_domain *efa_domain,
 				int mr_iov_start, uint64_t access)
 {
@@ -247,7 +247,7 @@ size_t rxr_tx_entry_max_req_data_capacity(struct rxr_ep *ep, struct rxr_op_entry
  * @param[in]		pkt_type	type of REQ packet
  *
  */
-void rxr_tx_entry_set_max_req_data_size(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry, int pkt_type)
+void rxr_tx_entry_set_max_req_data_size(struct rxr_ep *ep, struct rxr_op_entry *tx_entry, int pkt_type)
 {
 	int max_req_data_capacity;
 	int mulreq_total_data_size;

--- a/prov/efa/src/rxr/rxr_op_entry.h
+++ b/prov/efa/src/rxr/rxr_op_entry.h
@@ -195,8 +195,6 @@ struct rxr_op_entry {
 	/* end of TX only variables */
 };
 
-#define rxr_tx_entry rxr_op_entry
-#define rxr_rx_entry rxr_op_entry
 
 #define RXR_GET_X_ENTRY_TYPE(pkt_entry)	\
 	(*((enum rxr_x_entry_type *)	\
@@ -231,7 +229,7 @@ struct rxr_op_entry *rxr_op_entry_of_pkt_entry(struct rxr_pkt_entry *pkt_entry)
 	return (x_entry_type == RXR_TX_ENTRY || x_entry_type == RXR_RX_ENTRY) ? pkt_entry->x_entry : NULL;
 }
 
-void rxr_tx_entry_try_fill_desc(struct rxr_tx_entry *tx_entry,
+void rxr_tx_entry_try_fill_desc(struct rxr_op_entry *tx_entry,
 				struct efa_domain *efa_domain,
 				int mr_iov_start, uint64_t access);
 

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -66,52 +66,52 @@ int rxr_pkt_init_ctrl(struct rxr_ep *rxr_ep, int entry_type, void *x_entry,
 		ret = rxr_pkt_init_cts(rxr_ep, (struct rxr_op_entry *)x_entry, pkt_entry);
 		break;
 	case RXR_EOR_PKT:
-		ret = rxr_pkt_init_eor(rxr_ep, (struct rxr_rx_entry *)x_entry, pkt_entry);
+		ret = rxr_pkt_init_eor(rxr_ep, (struct rxr_op_entry *)x_entry, pkt_entry);
 		break;
 	case RXR_ATOMRSP_PKT:
-		ret = rxr_pkt_init_atomrsp(rxr_ep, (struct rxr_rx_entry *)x_entry, pkt_entry);
+		ret = rxr_pkt_init_atomrsp(rxr_ep, (struct rxr_op_entry *)x_entry, pkt_entry);
 		break;
 	case RXR_RECEIPT_PKT:
-		ret = rxr_pkt_init_receipt(rxr_ep, (struct rxr_rx_entry *)x_entry, pkt_entry);
+		ret = rxr_pkt_init_receipt(rxr_ep, (struct rxr_op_entry *)x_entry, pkt_entry);
 		break;
 	case RXR_EAGER_MSGRTM_PKT:
-		ret = rxr_pkt_init_eager_msgrtm(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
+		ret = rxr_pkt_init_eager_msgrtm(rxr_ep, (struct rxr_op_entry *)x_entry, pkt_entry);
 		break;
 	case RXR_EAGER_TAGRTM_PKT:
-		ret = rxr_pkt_init_eager_tagrtm(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
+		ret = rxr_pkt_init_eager_tagrtm(rxr_ep, (struct rxr_op_entry *)x_entry, pkt_entry);
 		break;
 	case RXR_MEDIUM_MSGRTM_PKT:
-		ret = rxr_pkt_init_medium_msgrtm(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
+		ret = rxr_pkt_init_medium_msgrtm(rxr_ep, (struct rxr_op_entry *)x_entry, pkt_entry);
 		break;
 	case RXR_MEDIUM_TAGRTM_PKT:
-		ret = rxr_pkt_init_medium_tagrtm(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
+		ret = rxr_pkt_init_medium_tagrtm(rxr_ep, (struct rxr_op_entry *)x_entry, pkt_entry);
 		break;
 	case RXR_LONGCTS_MSGRTM_PKT:
-		ret = rxr_pkt_init_longcts_msgrtm(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
+		ret = rxr_pkt_init_longcts_msgrtm(rxr_ep, (struct rxr_op_entry *)x_entry, pkt_entry);
 		break;
 	case RXR_LONGCTS_TAGRTM_PKT:
-		ret = rxr_pkt_init_longcts_tagrtm(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
+		ret = rxr_pkt_init_longcts_tagrtm(rxr_ep, (struct rxr_op_entry *)x_entry, pkt_entry);
 		break;
 	case RXR_LONGREAD_MSGRTM_PKT:
-		ret = rxr_pkt_init_longread_msgrtm(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
+		ret = rxr_pkt_init_longread_msgrtm(rxr_ep, (struct rxr_op_entry *)x_entry, pkt_entry);
 		break;
 	case RXR_LONGREAD_TAGRTM_PKT:
-		ret = rxr_pkt_init_longread_tagrtm(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
+		ret = rxr_pkt_init_longread_tagrtm(rxr_ep, (struct rxr_op_entry *)x_entry, pkt_entry);
 		break;
 	case RXR_RUNTREAD_MSGRTM_PKT:
-		ret = rxr_pkt_init_runtread_msgrtm(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
+		ret = rxr_pkt_init_runtread_msgrtm(rxr_ep, (struct rxr_op_entry *)x_entry, pkt_entry);
 		break;
 	case RXR_RUNTREAD_TAGRTM_PKT:
-		ret = rxr_pkt_init_runtread_tagrtm(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
+		ret = rxr_pkt_init_runtread_tagrtm(rxr_ep, (struct rxr_op_entry *)x_entry, pkt_entry);
 		break;
 	case RXR_EAGER_RTW_PKT:
-		ret = rxr_pkt_init_eager_rtw(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
+		ret = rxr_pkt_init_eager_rtw(rxr_ep, (struct rxr_op_entry *)x_entry, pkt_entry);
 		break;
 	case RXR_LONGCTS_RTW_PKT:
-		ret = rxr_pkt_init_longcts_rtw(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
+		ret = rxr_pkt_init_longcts_rtw(rxr_ep, (struct rxr_op_entry *)x_entry, pkt_entry);
 		break;
 	case RXR_LONGREAD_RTW_PKT:
-		ret = rxr_pkt_init_longread_rtw(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
+		ret = rxr_pkt_init_longread_rtw(rxr_ep, (struct rxr_op_entry *)x_entry, pkt_entry);
 		break;
 	case RXR_SHORT_RTR_PKT:
 		ret = rxr_pkt_init_short_rtr(rxr_ep, (struct rxr_op_entry *)x_entry, pkt_entry);
@@ -120,40 +120,40 @@ int rxr_pkt_init_ctrl(struct rxr_ep *rxr_ep, int entry_type, void *x_entry,
 		ret = rxr_pkt_init_longcts_rtr(rxr_ep, (struct rxr_op_entry *)x_entry, pkt_entry);
 		break;
 	case RXR_WRITE_RTA_PKT:
-		ret = rxr_pkt_init_write_rta(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
+		ret = rxr_pkt_init_write_rta(rxr_ep, (struct rxr_op_entry *)x_entry, pkt_entry);
 		break;
 	case RXR_FETCH_RTA_PKT:
-		ret = rxr_pkt_init_fetch_rta(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
+		ret = rxr_pkt_init_fetch_rta(rxr_ep, (struct rxr_op_entry *)x_entry, pkt_entry);
 		break;
 	case RXR_COMPARE_RTA_PKT:
-		ret = rxr_pkt_init_compare_rta(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
+		ret = rxr_pkt_init_compare_rta(rxr_ep, (struct rxr_op_entry *)x_entry, pkt_entry);
 		break;
 	case RXR_DC_EAGER_MSGRTM_PKT:
-		ret = rxr_pkt_init_dc_eager_msgrtm(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
+		ret = rxr_pkt_init_dc_eager_msgrtm(rxr_ep, (struct rxr_op_entry *)x_entry, pkt_entry);
 		break;
 	case RXR_DC_EAGER_TAGRTM_PKT:
-		ret = rxr_pkt_init_dc_eager_tagrtm(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
+		ret = rxr_pkt_init_dc_eager_tagrtm(rxr_ep, (struct rxr_op_entry *)x_entry, pkt_entry);
 		break;
 	case RXR_DC_MEDIUM_MSGRTM_PKT:
-		ret = rxr_pkt_init_dc_medium_msgrtm(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
+		ret = rxr_pkt_init_dc_medium_msgrtm(rxr_ep, (struct rxr_op_entry *)x_entry, pkt_entry);
 		break;
 	case RXR_DC_MEDIUM_TAGRTM_PKT:
-		ret = rxr_pkt_init_dc_medium_tagrtm(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
+		ret = rxr_pkt_init_dc_medium_tagrtm(rxr_ep, (struct rxr_op_entry *)x_entry, pkt_entry);
 		break;
 	case RXR_DC_LONGCTS_MSGRTM_PKT:
-		ret = rxr_pkt_init_dc_longcts_msgrtm(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
+		ret = rxr_pkt_init_dc_longcts_msgrtm(rxr_ep, (struct rxr_op_entry *)x_entry, pkt_entry);
 		break;
 	case RXR_DC_LONGCTS_TAGRTM_PKT:
-		ret = rxr_pkt_init_dc_longcts_tagrtm(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
+		ret = rxr_pkt_init_dc_longcts_tagrtm(rxr_ep, (struct rxr_op_entry *)x_entry, pkt_entry);
 		break;
 	case RXR_DC_EAGER_RTW_PKT:
-		ret = rxr_pkt_init_dc_eager_rtw(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
+		ret = rxr_pkt_init_dc_eager_rtw(rxr_ep, (struct rxr_op_entry *)x_entry, pkt_entry);
 		break;
 	case RXR_DC_LONGCTS_RTW_PKT:
-		ret = rxr_pkt_init_dc_longcts_rtw(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
+		ret = rxr_pkt_init_dc_longcts_rtw(rxr_ep, (struct rxr_op_entry *)x_entry, pkt_entry);
 		break;
 	case RXR_DC_WRITE_RTA_PKT:
-		ret = rxr_pkt_init_dc_write_rta(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
+		ret = rxr_pkt_init_dc_write_rta(rxr_ep, (struct rxr_op_entry *)x_entry, pkt_entry);
 		break;
 	case RXR_DATA_PKT:
 		ret = rxr_pkt_init_data(rxr_ep, (struct rxr_op_entry *)x_entry, pkt_entry);
@@ -528,7 +528,7 @@ ssize_t rxr_pkt_wait_handshake(struct rxr_ep *ep, fi_addr_t addr, struct rdm_pee
 ssize_t rxr_pkt_trigger_handshake(struct rxr_ep *ep,
 				  fi_addr_t addr, struct rdm_peer *peer)
 {
-	struct rxr_tx_entry *tx_entry;
+	struct rxr_op_entry *tx_entry;
 	ssize_t err;
 
 	if ((peer->flags & RXR_PEER_HANDSHAKE_RECEIVED) ||
@@ -644,8 +644,8 @@ void rxr_pkt_handle_data_copied(struct rxr_ep *ep,
 void rxr_pkt_handle_send_error(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry, int err, int prov_errno)
 {
 	struct rdm_peer *peer;
-	struct rxr_tx_entry *tx_entry;
-	struct rxr_rx_entry *rx_entry;
+	struct rxr_op_entry *tx_entry;
+	struct rxr_op_entry *rx_entry;
 
 	assert(pkt_entry->alloc_type == RXR_PKT_FROM_EFA_TX_POOL ||
 	       pkt_entry->alloc_type == RXR_PKT_FROM_SHM_TX_POOL);
@@ -1131,7 +1131,7 @@ void rxr_pkt_handle_recv_completion(struct rxr_ep *ep,
 	int pkt_type;
 	struct rdm_peer *peer;
 	struct rxr_base_hdr *base_hdr;
-	struct rxr_rx_entry *zcpy_rx_entry = NULL;
+	struct rxr_op_entry *zcpy_rx_entry = NULL;
 
 	base_hdr = rxr_get_base_hdr(pkt_entry->pkt);
 	pkt_type = base_hdr->type;

--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -412,7 +412,7 @@ ssize_t rxr_pkt_entry_inject(struct rxr_ep *ep,
 /*
  * Functions for pkt_rx_map
  */
-struct rxr_rx_entry *rxr_pkt_rx_map_lookup(struct rxr_ep *ep,
+struct rxr_op_entry *rxr_pkt_rx_map_lookup(struct rxr_ep *ep,
 					   struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_pkt_rx_map *entry = NULL;
@@ -427,7 +427,7 @@ struct rxr_rx_entry *rxr_pkt_rx_map_lookup(struct rxr_ep *ep,
 
 void rxr_pkt_rx_map_insert(struct rxr_ep *ep,
 			   struct rxr_pkt_entry *pkt_entry,
-			   struct rxr_rx_entry *rx_entry)
+			   struct rxr_op_entry *rx_entry)
 {
 	struct rxr_pkt_rx_map *entry;
 
@@ -458,7 +458,7 @@ void rxr_pkt_rx_map_insert(struct rxr_ep *ep,
 
 void rxr_pkt_rx_map_remove(struct rxr_ep *ep,
 			   struct rxr_pkt_entry *pkt_entry,
-			   struct rxr_rx_entry *rx_entry)
+			   struct rxr_op_entry *rx_entry)
 {
 	struct rxr_pkt_rx_map *entry;
 	struct rxr_pkt_rx_key key;

--- a/prov/efa/src/rxr/rxr_pkt_entry.h
+++ b/prov/efa/src/rxr/rxr_pkt_entry.h
@@ -136,7 +136,7 @@ OFI_DECLARE_FREESTACK(struct rxr_robuf, rxr_robuf_fs);
 
 struct rxr_ep;
 
-struct rxr_tx_entry;
+struct rxr_op_entry;
 
 struct rxr_pkt_entry *rxr_pkt_entry_init_prefix(struct rxr_ep *ep,
 						const struct fi_msg *posted_buf,

--- a/prov/efa/src/rxr/rxr_pkt_type.h
+++ b/prov/efa/src/rxr/rxr_pkt_type.h
@@ -165,7 +165,7 @@ enum rxr_rma_context_pkt_type {
 	RXR_WRITE_CONTEXT,
 };
 
-void rxr_pkt_init_write_context(struct rxr_tx_entry *tx_entry,
+void rxr_pkt_init_write_context(struct rxr_op_entry *tx_entry,
 				struct rxr_pkt_entry *pkt_entry);
 
 void rxr_pkt_init_read_context(struct rxr_ep *rxr_ep,
@@ -184,7 +184,7 @@ struct rxr_eor_hdr *rxr_get_eor_hdr(void *pkt)
 }
 
 int rxr_pkt_init_eor(struct rxr_ep *ep,
-		     struct rxr_rx_entry *rx_entry,
+		     struct rxr_op_entry *rx_entry,
 		     struct rxr_pkt_entry *pkt_entry);
 
 static inline
@@ -204,7 +204,7 @@ static inline struct rxr_atomrsp_hdr *rxr_get_atomrsp_hdr(void *pkt)
 	return (struct rxr_atomrsp_hdr *)pkt;
 }
 
-int rxr_pkt_init_atomrsp(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,
+int rxr_pkt_init_atomrsp(struct rxr_ep *ep, struct rxr_op_entry *rx_entry,
 			 struct rxr_pkt_entry *pkt_entry);
 
 void rxr_pkt_handle_atomrsp_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
@@ -220,7 +220,7 @@ struct rxr_receipt_hdr *rxr_get_receipt_hdr(void *pkt)
 	return (struct rxr_receipt_hdr *)pkt;
 }
 
-int rxr_pkt_init_receipt(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,
+int rxr_pkt_init_receipt(struct rxr_ep *ep, struct rxr_op_entry *rx_entry,
 			 struct rxr_pkt_entry *pkt_entry);
 
 void rxr_pkt_handle_receipt_sent(struct rxr_ep *ep,

--- a/prov/efa/src/rxr/rxr_pkt_type_base.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_base.c
@@ -253,7 +253,7 @@ int rxr_ep_flush_queued_blocking_copy_to_hmem(struct rxr_ep *ep)
 	size_t i;
 	size_t bytes_copied[RXR_EP_MAX_QUEUED_COPY] = {0};
 	struct efa_mr *desc;
-	struct rxr_rx_entry *rx_entry;
+	struct rxr_op_entry *rx_entry;
 	struct rxr_pkt_entry *pkt_entry;
 	char *data;
 	size_t data_size, data_offset;
@@ -317,7 +317,7 @@ int rxr_pkt_queued_copy_data_to_hmem(struct rxr_ep *ep,
 				     size_t data_size,
 				     size_t data_offset)
 {
-	struct rxr_rx_entry *rx_entry;
+	struct rxr_op_entry *rx_entry;
 
 	assert(ep->queued_copy_num < RXR_EP_MAX_QUEUED_COPY);
 	ep->queued_copy_vec[ep->queued_copy_num].pkt_entry = pkt_entry;
@@ -377,7 +377,7 @@ int rxr_pkt_copy_data_to_cuda(struct rxr_ep *ep,
 			      size_t data_offset)
 {
 	static const int max_gdrcopy_rx_entry_num = 4;
-	struct rxr_rx_entry *rx_entry;
+	struct rxr_op_entry *rx_entry;
 	struct efa_mr *desc;
 	struct efa_ep *efa_ep;
 	int use_p2p, err;

--- a/prov/efa/src/rxr/rxr_pkt_type_base.h
+++ b/prov/efa/src/rxr/rxr_pkt_type_base.h
@@ -46,7 +46,7 @@ int rxr_pkt_init_data_from_op_entry(struct rxr_ep *ep,
 				    size_t data_size);
 
 ssize_t rxr_pkt_copy_data_to_op_entry(struct rxr_ep *ep,
-				      struct rxr_rx_entry *rx_entry,
+				      struct rxr_op_entry *rx_entry,
 				      size_t data_offset,
 				      struct rxr_pkt_entry *pkt_entry,
 				      char *data, size_t data_size);

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -148,7 +148,7 @@ int rxr_pkt_type_readbase_rtm(struct rdm_peer *peer, int op, uint64_t fi_flags, 
 
 
 void rxr_pkt_init_req_hdr(struct rxr_ep *ep,
-			  struct rxr_tx_entry *tx_entry,
+			  struct rxr_op_entry *tx_entry,
 			  int pkt_type,
 			  struct rxr_pkt_entry *pkt_entry)
 {
@@ -436,7 +436,7 @@ size_t rxr_pkt_max_hdr_size(void)
  */
 static inline
 int rxr_pkt_init_rtm(struct rxr_ep *ep,
-		     struct rxr_tx_entry *tx_entry,
+		     struct rxr_op_entry *tx_entry,
 		     int pkt_type, uint64_t data_offset,
 		     struct rxr_pkt_entry *pkt_entry)
 {
@@ -469,7 +469,7 @@ int rxr_pkt_init_rtm(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_eager_msgrtm(struct rxr_ep *ep,
-				  struct rxr_tx_entry *tx_entry,
+				  struct rxr_op_entry *tx_entry,
 				  struct rxr_pkt_entry *pkt_entry)
 {
 	int ret;
@@ -483,7 +483,7 @@ ssize_t rxr_pkt_init_eager_msgrtm(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_dc_eager_msgrtm(struct rxr_ep *ep,
-				     struct rxr_tx_entry *tx_entry,
+				     struct rxr_op_entry *tx_entry,
 				     struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_dc_eager_msgrtm_hdr *dc_eager_msgrtm_hdr;
@@ -499,7 +499,7 @@ ssize_t rxr_pkt_init_dc_eager_msgrtm(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_eager_tagrtm(struct rxr_ep *ep,
-				  struct rxr_tx_entry *tx_entry,
+				  struct rxr_op_entry *tx_entry,
 				  struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_base_hdr *base_hdr;
@@ -516,7 +516,7 @@ ssize_t rxr_pkt_init_eager_tagrtm(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_dc_eager_tagrtm(struct rxr_ep *ep,
-				     struct rxr_tx_entry *tx_entry,
+				     struct rxr_op_entry *tx_entry,
 				     struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_base_hdr *base_hdr;
@@ -537,7 +537,7 @@ ssize_t rxr_pkt_init_dc_eager_tagrtm(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_medium_msgrtm(struct rxr_ep *ep,
-				   struct rxr_tx_entry *tx_entry,
+				   struct rxr_op_entry *tx_entry,
 				   struct rxr_pkt_entry *pkt_entry)
 {
 	struct efa_domain *efa_domain;
@@ -559,7 +559,7 @@ ssize_t rxr_pkt_init_medium_msgrtm(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_dc_medium_msgrtm(struct rxr_ep *ep,
-				      struct rxr_tx_entry *tx_entry,
+				      struct rxr_op_entry *tx_entry,
 				      struct rxr_pkt_entry *pkt_entry)
 {
 	struct efa_domain *efa_domain;
@@ -584,7 +584,7 @@ ssize_t rxr_pkt_init_dc_medium_msgrtm(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_medium_tagrtm(struct rxr_ep *ep,
-				   struct rxr_tx_entry *tx_entry,
+				   struct rxr_op_entry *tx_entry,
 				   struct rxr_pkt_entry *pkt_entry)
 {
 	struct efa_domain *efa_domain;
@@ -608,7 +608,7 @@ ssize_t rxr_pkt_init_medium_tagrtm(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_dc_medium_tagrtm(struct rxr_ep *ep,
-				      struct rxr_tx_entry *tx_entry,
+				      struct rxr_op_entry *tx_entry,
 				      struct rxr_pkt_entry *pkt_entry)
 {
 	struct efa_domain *efa_domain;
@@ -635,7 +635,7 @@ ssize_t rxr_pkt_init_dc_medium_tagrtm(struct rxr_ep *ep,
 }
 
 int rxr_pkt_init_longcts_rtm(struct rxr_ep *ep,
-			     struct rxr_tx_entry *tx_entry,
+			     struct rxr_op_entry *tx_entry,
 			     int pkt_type,
 			     struct rxr_pkt_entry *pkt_entry)
 {
@@ -655,14 +655,14 @@ int rxr_pkt_init_longcts_rtm(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_longcts_msgrtm(struct rxr_ep *ep,
-				 struct rxr_tx_entry *tx_entry,
+				 struct rxr_op_entry *tx_entry,
 				 struct rxr_pkt_entry *pkt_entry)
 {
 	return rxr_pkt_init_longcts_rtm(ep, tx_entry, RXR_LONGCTS_MSGRTM_PKT, pkt_entry);
 }
 
 ssize_t rxr_pkt_init_dc_longcts_msgrtm(struct rxr_ep *ep,
-				    struct rxr_tx_entry *tx_entry,
+				    struct rxr_op_entry *tx_entry,
 				    struct rxr_pkt_entry *pkt_entry)
 {
 	tx_entry->rxr_flags |= RXR_DELIVERY_COMPLETE_REQUESTED;
@@ -670,7 +670,7 @@ ssize_t rxr_pkt_init_dc_longcts_msgrtm(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_longcts_tagrtm(struct rxr_ep *ep,
-				 struct rxr_tx_entry *tx_entry,
+				 struct rxr_op_entry *tx_entry,
 				 struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_base_hdr *base_hdr;
@@ -687,7 +687,7 @@ ssize_t rxr_pkt_init_longcts_tagrtm(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_dc_longcts_tagrtm(struct rxr_ep *ep,
-				    struct rxr_tx_entry *tx_entry,
+				    struct rxr_op_entry *tx_entry,
 				    struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_base_hdr *base_hdr;
@@ -704,7 +704,7 @@ ssize_t rxr_pkt_init_dc_longcts_tagrtm(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_longread_rtm(struct rxr_ep *ep,
-			      struct rxr_tx_entry *tx_entry,
+			      struct rxr_op_entry *tx_entry,
 			      int pkt_type,
 			      struct rxr_pkt_entry *pkt_entry)
 {
@@ -734,14 +734,14 @@ ssize_t rxr_pkt_init_longread_rtm(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_longread_msgrtm(struct rxr_ep *ep,
-				 struct rxr_tx_entry *tx_entry,
+				 struct rxr_op_entry *tx_entry,
 				 struct rxr_pkt_entry *pkt_entry)
 {
 	return rxr_pkt_init_longread_rtm(ep, tx_entry, RXR_LONGREAD_MSGRTM_PKT, pkt_entry);
 }
 
 ssize_t rxr_pkt_init_longread_tagrtm(struct rxr_ep *ep,
-				 struct rxr_tx_entry *tx_entry,
+				 struct rxr_op_entry *tx_entry,
 				 struct rxr_pkt_entry *pkt_entry)
 {
 	ssize_t err;
@@ -769,7 +769,7 @@ ssize_t rxr_pkt_init_longread_tagrtm(struct rxr_ep *ep,
  */
 static
 ssize_t rxr_pkt_init_runtread_rtm(struct rxr_ep *ep,
-				  struct rxr_tx_entry *tx_entry,
+				  struct rxr_op_entry *tx_entry,
 				  int pkt_type,
 				  struct rxr_pkt_entry *pkt_entry)
 {
@@ -810,14 +810,14 @@ ssize_t rxr_pkt_init_runtread_rtm(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_runtread_msgrtm(struct rxr_ep *ep,
-				 struct rxr_tx_entry *tx_entry,
+				 struct rxr_op_entry *tx_entry,
 				 struct rxr_pkt_entry *pkt_entry)
 {
 	return rxr_pkt_init_runtread_rtm(ep, tx_entry, RXR_RUNTREAD_MSGRTM_PKT, pkt_entry);
 }
 
 ssize_t rxr_pkt_init_runtread_tagrtm(struct rxr_ep *ep,
-				 struct rxr_tx_entry *tx_entry,
+				 struct rxr_op_entry *tx_entry,
 				 struct rxr_pkt_entry *pkt_entry)
 {
 	ssize_t err;
@@ -844,20 +844,20 @@ ssize_t rxr_pkt_init_runtread_tagrtm(struct rxr_ep *ep,
 void rxr_pkt_handle_medium_rtm_sent(struct rxr_ep *ep,
 				    struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_tx_entry *tx_entry;
+	struct rxr_op_entry *tx_entry;
 
-	tx_entry = (struct rxr_tx_entry *)pkt_entry->x_entry;
+	tx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
 	tx_entry->bytes_sent += rxr_pkt_req_data_size(pkt_entry);
 }
 
 void rxr_pkt_handle_longcts_rtm_sent(struct rxr_ep *ep,
 				  struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_tx_entry *tx_entry;
+	struct rxr_op_entry *tx_entry;
 	struct efa_domain *efa_domain;
 
 	efa_domain = rxr_ep_domain(ep);
-	tx_entry = (struct rxr_tx_entry *)pkt_entry->x_entry;
+	tx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
 	tx_entry->bytes_sent += rxr_pkt_req_data_size(pkt_entry);
 	assert(tx_entry->bytes_sent < tx_entry->total_len);
 
@@ -880,13 +880,13 @@ void rxr_pkt_handle_runtread_rtm_sent(struct rxr_ep *ep,
 				      struct rxr_pkt_entry *pkt_entry)
 {
 	struct rdm_peer *peer;
-	struct rxr_tx_entry *tx_entry;
+	struct rxr_op_entry *tx_entry;
 	size_t pkt_data_size = rxr_pkt_req_data_size(pkt_entry);
 
 	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
 	assert(peer);
 
-	tx_entry = (struct rxr_tx_entry *)pkt_entry->x_entry;
+	tx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
 	tx_entry->bytes_sent += pkt_data_size;
 	peer->num_runt_bytes_in_flight += pkt_data_size;
 
@@ -901,9 +901,9 @@ void rxr_pkt_handle_runtread_rtm_sent(struct rxr_ep *ep,
 void rxr_pkt_handle_eager_rtm_send_completion(struct rxr_ep *ep,
 					      struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_tx_entry *tx_entry;
+	struct rxr_op_entry *tx_entry;
 
-	tx_entry = (struct rxr_tx_entry *)pkt_entry->x_entry;
+	tx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
 	assert(tx_entry->total_len == rxr_pkt_req_data_size(pkt_entry));
 	rxr_cq_handle_send_completion(ep, tx_entry);
 }
@@ -911,9 +911,9 @@ void rxr_pkt_handle_eager_rtm_send_completion(struct rxr_ep *ep,
 void rxr_pkt_handle_medium_rtm_send_completion(struct rxr_ep *ep,
 					       struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_tx_entry *tx_entry;
+	struct rxr_op_entry *tx_entry;
 
-	tx_entry = (struct rxr_tx_entry *)pkt_entry->x_entry;
+	tx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
 	tx_entry->bytes_acked += rxr_pkt_req_data_size(pkt_entry);
 	if (tx_entry->total_len == tx_entry->bytes_acked)
 		rxr_cq_handle_send_completion(ep, tx_entry);
@@ -922,9 +922,9 @@ void rxr_pkt_handle_medium_rtm_send_completion(struct rxr_ep *ep,
 void rxr_pkt_handle_longcts_rtm_send_completion(struct rxr_ep *ep,
 					     struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_tx_entry *tx_entry;
+	struct rxr_op_entry *tx_entry;
 
-	tx_entry = (struct rxr_tx_entry *)pkt_entry->x_entry;
+	tx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
 	tx_entry->bytes_acked += rxr_pkt_req_data_size(pkt_entry);
 	if (tx_entry->total_len == tx_entry->bytes_acked)
 		rxr_cq_handle_send_completion(ep, tx_entry);
@@ -933,9 +933,9 @@ void rxr_pkt_handle_longcts_rtm_send_completion(struct rxr_ep *ep,
 void rxr_pkt_handle_dc_longcts_rtm_send_completion(struct rxr_ep *ep,
 						struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_tx_entry *tx_entry;
+	struct rxr_op_entry *tx_entry;
 
-	tx_entry = (struct rxr_tx_entry *)pkt_entry->x_entry;
+	tx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
 	tx_entry->bytes_acked += rxr_pkt_req_data_size(pkt_entry);
 	if (tx_entry->total_len == tx_entry->bytes_acked &&
 	    tx_entry->rxr_flags & RXR_RECEIPT_RECEIVED)
@@ -945,11 +945,11 @@ void rxr_pkt_handle_dc_longcts_rtm_send_completion(struct rxr_ep *ep,
 void rxr_pkt_handle_runtread_rtm_send_completion(struct rxr_ep *ep,
 						 struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_tx_entry *tx_entry;
+	struct rxr_op_entry *tx_entry;
 	struct rdm_peer *peer;
 	size_t pkt_data_size;
 
-	tx_entry = (struct rxr_tx_entry *)pkt_entry->x_entry;
+	tx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
 	pkt_data_size = rxr_pkt_req_data_size(pkt_entry);
 	tx_entry->bytes_acked += pkt_data_size;
 
@@ -1017,7 +1017,7 @@ size_t rxr_pkt_rtm_total_len(struct rxr_pkt_entry *pkt_entry)
  * @param rx_entry(input)   rx entry to be updated
  */
 void rxr_pkt_rtm_update_rx_entry(struct rxr_pkt_entry *pkt_entry,
-				 struct rxr_rx_entry *rx_entry)
+				 struct rxr_op_entry *rx_entry)
 {
 	struct rxr_base_hdr *base_hdr;
 
@@ -1035,14 +1035,14 @@ void rxr_pkt_rtm_update_rx_entry(struct rxr_pkt_entry *pkt_entry,
 	rx_entry->cq_entry.tag = rx_entry->tag;
 }
 
-struct rxr_rx_entry *rxr_pkt_get_rtm_matched_rx_entry(struct rxr_ep *ep,
+struct rxr_op_entry *rxr_pkt_get_rtm_matched_rx_entry(struct rxr_ep *ep,
 						      struct dlist_entry *match,
 						      struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_rx_entry *rx_entry;
+	struct rxr_op_entry *rx_entry;
 
 	assert(match);
-	rx_entry = container_of(match, struct rxr_rx_entry, entry);
+	rx_entry = container_of(match, struct rxr_op_entry, entry);
 	if (rx_entry->rxr_flags & RXR_MULTI_RECV_POSTED) {
 		rx_entry = rxr_msg_split_rx_entry(ep, rx_entry, NULL, pkt_entry);
 		if (OFI_UNLIKELY(!rx_entry)) {
@@ -1074,9 +1074,9 @@ static
 int rxr_pkt_rtm_match_recv(struct dlist_entry *item, const void *arg)
 {
 	const struct rxr_pkt_entry *pkt_entry = arg;
-	struct rxr_rx_entry *rx_entry;
+	struct rxr_op_entry *rx_entry;
 
-	rx_entry = container_of(item, struct rxr_rx_entry, entry);
+	rx_entry = container_of(item, struct rxr_op_entry, entry);
 	return ofi_match_addr(rx_entry->addr, pkt_entry->addr);
 }
 
@@ -1084,10 +1084,10 @@ static
 int rxr_pkt_rtm_match_trecv_anyaddr(struct dlist_entry *item, const void *arg)
 {
 	struct rxr_pkt_entry *pkt_entry = (struct rxr_pkt_entry *)arg;
-	struct rxr_rx_entry *rx_entry;
+	struct rxr_op_entry *rx_entry;
 	uint64_t match_tag;
 
-	rx_entry = container_of(item, struct rxr_rx_entry, entry);
+	rx_entry = container_of(item, struct rxr_op_entry, entry);
 	match_tag = rxr_pkt_rtm_tag(pkt_entry);
 
 	return ofi_match_tag(rx_entry->cq_entry.tag, rx_entry->ignore,
@@ -1098,10 +1098,10 @@ static
 int rxr_pkt_rtm_match_trecv(struct dlist_entry *item, const void *arg)
 {
 	struct rxr_pkt_entry *pkt_entry = (struct rxr_pkt_entry *)arg;
-	struct rxr_rx_entry *rx_entry;
+	struct rxr_op_entry *rx_entry;
 	uint64_t match_tag;
 
-	rx_entry = container_of(item, struct rxr_rx_entry, entry);
+	rx_entry = container_of(item, struct rxr_op_entry, entry);
 	match_tag = rxr_pkt_rtm_tag(pkt_entry);
 
 	return ofi_match_addr(rx_entry->addr, pkt_entry->addr) &&
@@ -1109,10 +1109,10 @@ int rxr_pkt_rtm_match_trecv(struct dlist_entry *item, const void *arg)
 }
 
 static
-struct rxr_rx_entry *rxr_pkt_get_msgrtm_rx_entry(struct rxr_ep *ep,
+struct rxr_op_entry *rxr_pkt_get_msgrtm_rx_entry(struct rxr_ep *ep,
 						 struct rxr_pkt_entry **pkt_entry_ptr)
 {
-	struct rxr_rx_entry *rx_entry;
+	struct rxr_op_entry *rx_entry;
 	struct dlist_entry *match;
 	dlist_func_t *match_func;
 	int pkt_type;
@@ -1163,10 +1163,10 @@ struct rxr_rx_entry *rxr_pkt_get_msgrtm_rx_entry(struct rxr_ep *ep,
 }
 
 static
-struct rxr_rx_entry *rxr_pkt_get_tagrtm_rx_entry(struct rxr_ep *ep,
+struct rxr_op_entry *rxr_pkt_get_tagrtm_rx_entry(struct rxr_ep *ep,
 						 struct rxr_pkt_entry **pkt_entry_ptr)
 {
-	struct rxr_rx_entry *rx_entry;
+	struct rxr_op_entry *rx_entry;
 	struct dlist_entry *match;
 	dlist_func_t *match_func;
 	int pkt_type;
@@ -1200,7 +1200,7 @@ struct rxr_rx_entry *rxr_pkt_get_tagrtm_rx_entry(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_proc_matched_longread_rtm(struct rxr_ep *ep,
-				      struct rxr_rx_entry *rx_entry,
+				      struct rxr_op_entry *rx_entry,
 				      struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_longread_rtm_base_hdr *rtm_hdr;
@@ -1219,7 +1219,7 @@ ssize_t rxr_pkt_proc_matched_longread_rtm(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_proc_matched_mulreq_rtm(struct rxr_ep *ep,
-					struct rxr_rx_entry *rx_entry,
+					struct rxr_op_entry *rx_entry,
 					struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_pkt_entry *cur, *nxt;
@@ -1296,7 +1296,7 @@ ssize_t rxr_pkt_proc_matched_mulreq_rtm(struct rxr_ep *ep,
  * 		On failure, return libfabric error code
  */
 ssize_t rxr_pkt_proc_matched_eager_rtm(struct rxr_ep *ep,
-				       struct rxr_rx_entry *rx_entry,
+				       struct rxr_op_entry *rx_entry,
 				       struct rxr_pkt_entry *pkt_entry)
 {
 	int err;
@@ -1349,7 +1349,7 @@ ssize_t rxr_pkt_proc_matched_eager_rtm(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_proc_matched_rtm(struct rxr_ep *ep,
-				 struct rxr_rx_entry *rx_entry,
+				 struct rxr_op_entry *rx_entry,
 				 struct rxr_pkt_entry *pkt_entry)
 {
 	int pkt_type;
@@ -1433,7 +1433,7 @@ ssize_t rxr_pkt_proc_msgrtm(struct rxr_ep *ep,
 			    struct rxr_pkt_entry *pkt_entry)
 {
 	ssize_t err;
-	struct rxr_rx_entry *rx_entry;
+	struct rxr_op_entry *rx_entry;
 
 	rx_entry = rxr_pkt_get_msgrtm_rx_entry(ep, &pkt_entry);
 	if (OFI_UNLIKELY(!rx_entry)) {
@@ -1459,7 +1459,7 @@ ssize_t rxr_pkt_proc_tagrtm(struct rxr_ep *ep,
 			    struct rxr_pkt_entry *pkt_entry)
 {
 	ssize_t err;
-	struct rxr_rx_entry *rx_entry;
+	struct rxr_op_entry *rx_entry;
 
 	rx_entry = rxr_pkt_get_tagrtm_rx_entry(ep, &pkt_entry);
 	if (OFI_UNLIKELY(!rx_entry)) {
@@ -1541,7 +1541,7 @@ void rxr_pkt_handle_rtm_rta_recv(struct rxr_ep *ep,
 	assert(base_hdr->type >= RXR_BASELINE_REQ_PKT_BEGIN);
 
 	if (rxr_pkt_type_is_mulreq(base_hdr->type)) {
-		struct rxr_rx_entry *rx_entry;
+		struct rxr_op_entry *rx_entry;
 		struct rxr_pkt_entry *unexp_pkt_entry;
 
 		rx_entry = rxr_pkt_rx_map_lookup(ep, pkt_entry);
@@ -1610,7 +1610,7 @@ void rxr_pkt_handle_rtm_rta_recv(struct rxr_ep *ep,
  * RTW packet type functions
  */
 int rxr_pkt_init_rtw_data(struct rxr_ep *ep,
-			  struct rxr_tx_entry *tx_entry,
+			  struct rxr_op_entry *tx_entry,
 			  struct rxr_pkt_entry *pkt_entry,
 			  struct efa_rma_iov *rma_iov)
 {
@@ -1630,7 +1630,7 @@ int rxr_pkt_init_rtw_data(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_eager_rtw(struct rxr_ep *ep,
-			       struct rxr_tx_entry *tx_entry,
+			       struct rxr_op_entry *tx_entry,
 			       struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_eager_rtw_hdr *rtw_hdr;
@@ -1644,7 +1644,7 @@ ssize_t rxr_pkt_init_eager_rtw(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_dc_eager_rtw(struct rxr_ep *ep,
-				  struct rxr_tx_entry *tx_entry,
+				  struct rxr_op_entry *tx_entry,
 				  struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_dc_eager_rtw_hdr *dc_eager_rtw_hdr;
@@ -1663,7 +1663,7 @@ ssize_t rxr_pkt_init_dc_eager_rtw(struct rxr_ep *ep,
 }
 
 static inline void rxr_pkt_init_longcts_rtw_hdr(struct rxr_ep *ep,
-					     struct rxr_tx_entry *tx_entry,
+					     struct rxr_op_entry *tx_entry,
 					     struct rxr_pkt_entry *pkt_entry,
 					     int pkt_type)
 {
@@ -1679,7 +1679,7 @@ static inline void rxr_pkt_init_longcts_rtw_hdr(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_longcts_rtw(struct rxr_ep *ep,
-			      struct rxr_tx_entry *tx_entry,
+			      struct rxr_op_entry *tx_entry,
 			      struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_longcts_rtw_hdr *rtw_hdr;
@@ -1692,7 +1692,7 @@ ssize_t rxr_pkt_init_longcts_rtw(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_dc_longcts_rtw(struct rxr_ep *ep,
-				 struct rxr_tx_entry *tx_entry,
+				 struct rxr_op_entry *tx_entry,
 				 struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_longcts_rtw_hdr *rtw_hdr;
@@ -1706,7 +1706,7 @@ ssize_t rxr_pkt_init_dc_longcts_rtw(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_longread_rtw(struct rxr_ep *ep,
-			      struct rxr_tx_entry *tx_entry,
+			      struct rxr_op_entry *tx_entry,
 			      struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_longread_rtw_hdr *rtw_hdr;
@@ -1750,10 +1750,10 @@ ssize_t rxr_pkt_init_longread_rtw(struct rxr_ep *ep,
 void rxr_pkt_handle_longcts_rtw_sent(struct rxr_ep *ep,
 				  struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_tx_entry *tx_entry;
+	struct rxr_op_entry *tx_entry;
 	struct efa_domain *efa_domain = rxr_ep_domain(ep);
 
-	tx_entry = (struct rxr_tx_entry *)pkt_entry->x_entry;
+	tx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
 	tx_entry->bytes_sent += rxr_pkt_req_data_size(pkt_entry);
 	assert(tx_entry->bytes_sent < tx_entry->total_len);
 	if (tx_entry->desc[0] || efa_is_cache_available(efa_domain))
@@ -1766,9 +1766,9 @@ void rxr_pkt_handle_longcts_rtw_sent(struct rxr_ep *ep,
 void rxr_pkt_handle_eager_rtw_send_completion(struct rxr_ep *ep,
 					      struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_tx_entry *tx_entry;
+	struct rxr_op_entry *tx_entry;
 
-	tx_entry = (struct rxr_tx_entry *)pkt_entry->x_entry;
+	tx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
 	assert(tx_entry->total_len == rxr_pkt_req_data_size(pkt_entry));
 	rxr_cq_handle_send_completion(ep, tx_entry);
 }
@@ -1776,9 +1776,9 @@ void rxr_pkt_handle_eager_rtw_send_completion(struct rxr_ep *ep,
 void rxr_pkt_handle_longcts_rtw_send_completion(struct rxr_ep *ep,
 					     struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_tx_entry *tx_entry;
+	struct rxr_op_entry *tx_entry;
 
-	tx_entry = (struct rxr_tx_entry *)pkt_entry->x_entry;
+	tx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
 	tx_entry->bytes_acked += rxr_pkt_req_data_size(pkt_entry);
 	if (tx_entry->total_len == tx_entry->bytes_acked)
 		rxr_cq_handle_send_completion(ep, tx_entry);
@@ -1787,9 +1787,9 @@ void rxr_pkt_handle_longcts_rtw_send_completion(struct rxr_ep *ep,
 void rxr_pkt_handle_dc_longcts_rtw_send_completion(struct rxr_ep *ep,
 						struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_tx_entry *tx_entry;
+	struct rxr_op_entry *tx_entry;
 
-	tx_entry = (struct rxr_tx_entry *)pkt_entry->x_entry;
+	tx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
 	tx_entry->bytes_acked += rxr_pkt_req_data_size(pkt_entry);
 	if (tx_entry->total_len == tx_entry->bytes_acked &&
 	    tx_entry->rxr_flags & RXR_RECEIPT_RECEIVED)
@@ -1801,10 +1801,10 @@ void rxr_pkt_handle_dc_longcts_rtw_send_completion(struct rxr_ep *ep,
  */
 
 static
-struct rxr_rx_entry *rxr_pkt_alloc_rtw_rx_entry(struct rxr_ep *ep,
+struct rxr_op_entry *rxr_pkt_alloc_rtw_rx_entry(struct rxr_ep *ep,
 						struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_rx_entry *rx_entry;
+	struct rxr_op_entry *rx_entry;
 	struct rxr_base_hdr *base_hdr;
 
 	rx_entry = rxr_ep_alloc_rx_entry(ep, pkt_entry->addr, ofi_op_write);
@@ -1827,7 +1827,7 @@ struct rxr_rx_entry *rxr_pkt_alloc_rtw_rx_entry(struct rxr_ep *ep,
 void rxr_pkt_proc_eager_rtw(struct rxr_ep *ep,
 			    struct efa_rma_iov *rma_iov,
 			    size_t rma_iov_count,
-			    struct rxr_rx_entry *rx_entry,
+			    struct rxr_op_entry *rx_entry,
 			    struct rxr_pkt_entry *pkt_entry)
 {
 	ssize_t err;
@@ -1876,7 +1876,7 @@ void rxr_pkt_proc_eager_rtw(struct rxr_ep *ep,
 void rxr_pkt_handle_eager_rtw_recv(struct rxr_ep *ep,
 				   struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_rx_entry *rx_entry;
+	struct rxr_op_entry *rx_entry;
 	struct rxr_eager_rtw_hdr *rtw_hdr;
 
 	rx_entry = rxr_pkt_alloc_rtw_rx_entry(ep, pkt_entry);
@@ -1900,7 +1900,7 @@ void rxr_pkt_handle_eager_rtw_recv(struct rxr_ep *ep,
 void rxr_pkt_handle_dc_eager_rtw_recv(struct rxr_ep *ep,
 				      struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_rx_entry *rx_entry;
+	struct rxr_op_entry *rx_entry;
 	struct rxr_dc_eager_rtw_hdr *rtw_hdr;
 
 	rx_entry = rxr_pkt_alloc_rtw_rx_entry(ep, pkt_entry);
@@ -1925,7 +1925,7 @@ void rxr_pkt_handle_dc_eager_rtw_recv(struct rxr_ep *ep,
 void rxr_pkt_handle_longcts_rtw_recv(struct rxr_ep *ep,
 				  struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_rx_entry *rx_entry;
+	struct rxr_op_entry *rx_entry;
 	struct rxr_longcts_rtw_hdr *rtw_hdr;
 	char *data;
 	size_t hdr_size, data_size;
@@ -2004,7 +2004,7 @@ void rxr_pkt_handle_longcts_rtw_recv(struct rxr_ep *ep,
 void rxr_pkt_handle_longread_rtw_recv(struct rxr_ep *ep,
 				  struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_rx_entry *rx_entry;
+	struct rxr_op_entry *rx_entry;
 	struct rxr_longread_rtw_hdr *rtw_hdr;
 	struct fi_rma_iov *read_iov;
 	size_t hdr_size;
@@ -2157,7 +2157,7 @@ void rxr_pkt_handle_rtr_recv(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 /*
  * RTA packet functions
  */
-ssize_t rxr_pkt_init_rta(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
+ssize_t rxr_pkt_init_rta(struct rxr_ep *ep, struct rxr_op_entry *tx_entry,
 			 int pkt_type, struct rxr_pkt_entry *pkt_entry)
 {
 	struct efa_rma_iov *rma_iov;
@@ -2190,7 +2190,7 @@ ssize_t rxr_pkt_init_rta(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
 	return 0;
 }
 
-ssize_t rxr_pkt_init_write_rta(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
+ssize_t rxr_pkt_init_write_rta(struct rxr_ep *ep, struct rxr_op_entry *tx_entry,
 			    struct rxr_pkt_entry *pkt_entry)
 {
 	rxr_pkt_init_rta(ep, tx_entry, RXR_WRITE_RTA_PKT, pkt_entry);
@@ -2198,7 +2198,7 @@ ssize_t rxr_pkt_init_write_rta(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
 }
 
 ssize_t rxr_pkt_init_dc_write_rta(struct rxr_ep *ep,
-				  struct rxr_tx_entry *tx_entry,
+				  struct rxr_op_entry *tx_entry,
 				  struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_rta_hdr *rta_hdr;
@@ -2210,7 +2210,7 @@ ssize_t rxr_pkt_init_dc_write_rta(struct rxr_ep *ep,
 	return 0;
 }
 
-ssize_t rxr_pkt_init_fetch_rta(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
+ssize_t rxr_pkt_init_fetch_rta(struct rxr_ep *ep, struct rxr_op_entry *tx_entry,
 			      struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_rta_hdr *rta_hdr;
@@ -2221,7 +2221,7 @@ ssize_t rxr_pkt_init_fetch_rta(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
 	return 0;
 }
 
-ssize_t rxr_pkt_init_compare_rta(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
+ssize_t rxr_pkt_init_compare_rta(struct rxr_ep *ep, struct rxr_op_entry *tx_entry,
 				 struct rxr_pkt_entry *pkt_entry)
 {
 	char *data;
@@ -2245,9 +2245,9 @@ ssize_t rxr_pkt_init_compare_rta(struct rxr_ep *ep, struct rxr_tx_entry *tx_entr
 
 void rxr_pkt_handle_write_rta_send_completion(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_tx_entry *tx_entry;
+	struct rxr_op_entry *tx_entry;
 
-	tx_entry = (struct rxr_tx_entry *)pkt_entry->x_entry;
+	tx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
 	rxr_cq_handle_send_completion(ep, tx_entry);
 }
 
@@ -2285,9 +2285,9 @@ int rxr_pkt_proc_write_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 	return 0;
 }
 
-struct rxr_rx_entry *rxr_pkt_alloc_rta_rx_entry(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry, int op)
+struct rxr_op_entry *rxr_pkt_alloc_rta_rx_entry(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry, int op)
 {
-	struct rxr_rx_entry *rx_entry;
+	struct rxr_op_entry *rx_entry;
 	struct rxr_rta_hdr *rta_hdr;
 
 	rx_entry = rxr_ep_alloc_rx_entry(ep, pkt_entry->addr, op);
@@ -2336,7 +2336,7 @@ struct rxr_rx_entry *rxr_pkt_alloc_rta_rx_entry(struct rxr_ep *ep, struct rxr_pk
 int rxr_pkt_proc_dc_write_rta(struct rxr_ep *ep,
 			      struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_rx_entry *rx_entry;
+	struct rxr_op_entry *rx_entry;
 	struct rxr_rta_hdr *rta_hdr;
 	ssize_t err;
 	int ret;
@@ -2374,7 +2374,7 @@ int rxr_pkt_proc_dc_write_rta(struct rxr_ep *ep,
 
 int rxr_pkt_proc_fetch_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_rx_entry *rx_entry;
+	struct rxr_op_entry *rx_entry;
 	char *data;
 	int op, dt, i;
 	size_t offset, dtsize;
@@ -2415,7 +2415,7 @@ int rxr_pkt_proc_fetch_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 
 int rxr_pkt_proc_compare_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_rx_entry *rx_entry;
+	struct rxr_op_entry *rx_entry;
 	char *src_data, *cmp_data;
 	int op, dt, i;
 	size_t offset, dtsize;

--- a/prov/efa/src/rxr/rxr_pkt_type_req.h
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.h
@@ -170,67 +170,67 @@ struct rxr_runtread_rtm_base_hdr *rxr_get_runtread_rtm_base_hdr(void *pkt)
 }
 
 ssize_t rxr_pkt_init_eager_msgrtm(struct rxr_ep *ep,
-				  struct rxr_tx_entry *tx_entry,
+				  struct rxr_op_entry *tx_entry,
 				  struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_dc_eager_msgrtm(struct rxr_ep *ep,
-				     struct rxr_tx_entry *tx_entry,
+				     struct rxr_op_entry *tx_entry,
 				     struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_eager_tagrtm(struct rxr_ep *ep,
-				  struct rxr_tx_entry *tx_entry,
+				  struct rxr_op_entry *tx_entry,
 				  struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_medium_msgrtm(struct rxr_ep *ep,
-				   struct rxr_tx_entry *tx_entry,
+				   struct rxr_op_entry *tx_entry,
 				   struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_dc_eager_tagrtm(struct rxr_ep *ep,
-				     struct rxr_tx_entry *tx_entry,
+				     struct rxr_op_entry *tx_entry,
 				     struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_dc_medium_msgrtm(struct rxr_ep *ep,
-				      struct rxr_tx_entry *tx_entry,
+				      struct rxr_op_entry *tx_entry,
 				      struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_medium_tagrtm(struct rxr_ep *ep,
-				   struct rxr_tx_entry *tx_entry,
+				   struct rxr_op_entry *tx_entry,
 				   struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_dc_medium_tagrtm(struct rxr_ep *ep,
-				      struct rxr_tx_entry *tx_entry,
+				      struct rxr_op_entry *tx_entry,
 				      struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_longcts_msgrtm(struct rxr_ep *ep,
-				 struct rxr_tx_entry *tx_entry,
+				 struct rxr_op_entry *tx_entry,
 				 struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_dc_longcts_msgrtm(struct rxr_ep *ep,
-				    struct rxr_tx_entry *tx_entry,
+				    struct rxr_op_entry *tx_entry,
 				    struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_longcts_tagrtm(struct rxr_ep *ep,
-				 struct rxr_tx_entry *tx_entry,
+				 struct rxr_op_entry *tx_entry,
 				 struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_dc_longcts_tagrtm(struct rxr_ep *ep,
-				    struct rxr_tx_entry *tx_entry,
+				    struct rxr_op_entry *tx_entry,
 				    struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_longread_msgrtm(struct rxr_ep *ep,
-				 struct rxr_tx_entry *tx_entry,
+				 struct rxr_op_entry *tx_entry,
 				 struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_longread_tagrtm(struct rxr_ep *ep,
-				 struct rxr_tx_entry *tx_entry,
+				 struct rxr_op_entry *tx_entry,
 				 struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_runtread_msgrtm(struct rxr_ep *ep,
-				 struct rxr_tx_entry *tx_entry,
+				 struct rxr_op_entry *tx_entry,
 				 struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_runtread_tagrtm(struct rxr_ep *ep,
-				 struct rxr_tx_entry *tx_entry,
+				 struct rxr_op_entry *tx_entry,
 				 struct rxr_pkt_entry *pkt_entry);
 
 static inline
@@ -275,14 +275,14 @@ void rxr_pkt_handle_runtread_rtm_send_completion(struct rxr_ep *ep,
 						 struct rxr_pkt_entry *pkt_entry);
 
 void rxr_pkt_rtm_update_rx_entry(struct rxr_pkt_entry *pkt_entry,
-				 struct rxr_rx_entry *rx_entry);
+				 struct rxr_op_entry *rx_entry);
 
 /*         This function is called by both
  *            rxr_pkt_handle_rtm_recv() and
  *            rxr_msg_handle_unexp_match()
  */
 ssize_t rxr_pkt_proc_matched_rtm(struct rxr_ep *ep,
-				 struct rxr_rx_entry *rx_entry,
+				 struct rxr_op_entry *rx_entry,
 				 struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_proc_rtm_rta(struct rxr_ep *ep,
@@ -312,23 +312,23 @@ struct rxr_dc_eager_rtw_hdr *rxr_get_dc_eager_rtw_hdr(void *pkt)
 }
 
 ssize_t rxr_pkt_init_eager_rtw(struct rxr_ep *ep,
-			       struct rxr_tx_entry *tx_entry,
+			       struct rxr_op_entry *tx_entry,
 			       struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_longcts_rtw(struct rxr_ep *ep,
-			      struct rxr_tx_entry *tx_entry,
+			      struct rxr_op_entry *tx_entry,
 			      struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_longread_rtw(struct rxr_ep *ep,
-			      struct rxr_tx_entry *tx_entry,
+			      struct rxr_op_entry *tx_entry,
 			      struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_dc_eager_rtw(struct rxr_ep *ep,
-				  struct rxr_tx_entry *tx_entry,
+				  struct rxr_op_entry *tx_entry,
 				  struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_dc_longcts_rtw(struct rxr_ep *ep,
-				 struct rxr_tx_entry *tx_entry,
+				 struct rxr_op_entry *tx_entry,
 				 struct rxr_pkt_entry *pkt_entry);
 
 static inline
@@ -400,15 +400,15 @@ struct rxr_rta_hdr *rxr_get_rta_hdr(void *pkt)
 	return (struct rxr_rta_hdr *)pkt;
 }
 
-ssize_t rxr_pkt_init_write_rta(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry, struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_init_write_rta(struct rxr_ep *ep, struct rxr_op_entry *tx_entry, struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_dc_write_rta(struct rxr_ep *ep,
-				  struct rxr_tx_entry *tx_entry,
+				  struct rxr_op_entry *tx_entry,
 				  struct rxr_pkt_entry *pkt_entry);
 
-ssize_t rxr_pkt_init_fetch_rta(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry, struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_init_fetch_rta(struct rxr_ep *ep, struct rxr_op_entry *tx_entry, struct rxr_pkt_entry *pkt_entry);
 
-ssize_t rxr_pkt_init_compare_rta(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry, struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_init_compare_rta(struct rxr_ep *ep, struct rxr_op_entry *tx_entry, struct rxr_pkt_entry *pkt_entry);
 
 static inline
 void rxr_pkt_handle_rta_sent(struct rxr_ep *ep,

--- a/prov/efa/src/rxr/rxr_read.c
+++ b/prov/efa/src/rxr/rxr_read.c
@@ -385,7 +385,7 @@ int rxr_read_post_remote_read_or_queue(struct rxr_ep *ep, struct rxr_op_entry *o
 }
 
 int rxr_read_post_local_read_or_queue(struct rxr_ep *ep,
-				      struct rxr_rx_entry *rx_entry,
+				      struct rxr_op_entry *rx_entry,
 				      size_t data_offset,
 				      struct rxr_pkt_entry *pkt_entry,
 				      char *data, size_t data_size)
@@ -446,7 +446,7 @@ int rxr_read_post_local_read_or_queue(struct rxr_ep *ep,
 }
 
 int rxr_read_init_iov(struct rxr_ep *ep,
-		      struct rxr_tx_entry *tx_entry,
+		      struct rxr_op_entry *tx_entry,
 		      struct fi_rma_iov *read_iov)
 {
 	int i, err;
@@ -712,8 +712,8 @@ int rxr_read_post(struct rxr_ep *ep, struct rxr_read_entry *read_entry)
 void rxr_read_write_error(struct rxr_ep *ep, struct rxr_read_entry *read_entry,
 			  int err, int prov_errno)
 {
-	struct rxr_tx_entry *tx_entry;
-	struct rxr_rx_entry *rx_entry;
+	struct rxr_op_entry *tx_entry;
+	struct rxr_op_entry *rx_entry;
 
 	if (read_entry->context_type == RXR_READ_CONTEXT_TX_ENTRY) {
 		tx_entry = read_entry->context;

--- a/prov/efa/src/rxr/rxr_read.h
+++ b/prov/efa/src/rxr/rxr_read.h
@@ -112,7 +112,7 @@ int rxr_locate_iov_pos(struct iovec *iov, int iov_count, size_t offset,
 		       int *iov_idx, size_t *iov_offset);
 
 int rxr_read_init_iov(struct rxr_ep *ep,
-		      struct rxr_tx_entry *tx_entry,
+		      struct rxr_op_entry *tx_entry,
 		      struct fi_rma_iov *read_iov);
 
 int rxr_read_post(struct rxr_ep *ep, struct rxr_read_entry *read_entry);
@@ -120,7 +120,7 @@ int rxr_read_post(struct rxr_ep *ep, struct rxr_read_entry *read_entry);
 int rxr_read_post_remote_read_or_queue(struct rxr_ep *ep, struct rxr_op_entry *op_entry);
 
 int rxr_read_post_local_read_or_queue(struct rxr_ep *ep,
-				      struct rxr_rx_entry *rx_entry,
+				      struct rxr_op_entry *rx_entry,
 				      size_t data_offset,
 				      struct rxr_pkt_entry *pkt_entry,
 				      char *data, size_t data_size);

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -110,7 +110,7 @@ rxr_rma_alloc_tx_entry(struct rxr_ep *rxr_ep,
 	return tx_entry;
 }
 
-size_t rxr_rma_post_shm_write(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
+size_t rxr_rma_post_shm_write(struct rxr_ep *rxr_ep, struct rxr_op_entry *tx_entry)
 {
 	struct rxr_pkt_entry *pkt_entry;
 	struct fi_msg_rma msg;
@@ -306,7 +306,7 @@ ssize_t rxr_rma_read(struct fid_ep *ep, void *buf, size_t len, void *desc,
 }
 
 /* rma_write functions */
-ssize_t rxr_rma_post_write(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry)
+ssize_t rxr_rma_post_write(struct rxr_ep *ep, struct rxr_op_entry *tx_entry)
 {
 	ssize_t err;
 	struct rdm_peer *peer;
@@ -383,7 +383,7 @@ ssize_t rxr_rma_writemsg(struct fid_ep *ep,
 	ssize_t err;
 	struct rdm_peer *peer;
 	struct rxr_ep *rxr_ep;
-	struct rxr_tx_entry *tx_entry;
+	struct rxr_op_entry *tx_entry;
 
 	FI_DBG(&rxr_prov, FI_LOG_EP_DATA,
 	       "write iov_len %lu flags: %lx\n",


### PR DESCRIPTION
This change removes the rxr_rx_entry and rxr_tx_entry macro definitions and replaces them with rxr_op_entry.

Signed-off-by: Vishwas Dsouza <vidsouza@amazon.com>