### PR TITLE
prov/net: TX operations now support io_uring

### DIFF
--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -154,9 +154,14 @@ struct ofi_sockctx {
 	bool uring_sqe_inuse;
 };
 
+struct ofi_sockapi_uring {
+	ofi_io_uring_t *io_uring;
+	uint64_t credits;
+};
+
 struct ofi_sockapi {
-	ofi_io_uring_t *tx_io_uring;
-	ofi_io_uring_t *rx_io_uring;
+	struct ofi_sockapi_uring tx_uring;
+	struct ofi_sockapi_uring rx_uring;
 
 	ssize_t (*send)(struct ofi_sockapi *sockapi, SOCKET sock, const void *buf,
 			size_t len, int flags, struct ofi_sockctx *ctx);

--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -151,6 +151,7 @@ typedef struct {
 
 struct ofi_sockctx {
 	void *context;
+	bool uring_sqe_inuse;
 };
 
 struct ofi_sockapi {
@@ -173,6 +174,7 @@ static inline void
 ofi_sockctx_init(struct ofi_sockctx *sockctx, void *context)
 {
 	sockctx->context = context;
+	sockctx->uring_sqe_inuse = false;
 }
 
 static inline ssize_t

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -253,7 +253,6 @@ void xnet_freeall_conns(struct xnet_rdm *rdm);
 struct xnet_uring {
 	struct fid fid;
 	ofi_io_uring_t ring;
-	size_t credits;
 };
 
 /* Serialization is handled at the progress instance level, using the

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -808,11 +808,11 @@ static void xnet_run_ep(struct xnet_ep *ep, bool pin, bool pout, bool perr)
 static void xnet_progress_cqe(struct xnet_uring *uring,
 			      ofi_io_uring_cqe_t *cqe)
 {
-	struct ofi_bsock *bsock;
+	struct ofi_sockctx *sockctx;
 
 	assert(xnet_io_uring);
-	bsock = (struct ofi_bsock *) cqe->user_data;
-	assert(bsock);
+	sockctx = (struct ofi_sockctx *) cqe->user_data;
+	assert(sockctx);
 }
 
 static void xnet_progress_uring(struct xnet_uring *uring)

--- a/src/common.c
+++ b/src/common.c
@@ -1153,7 +1153,7 @@ ssize_t ofi_bsock_flush(struct ofi_bsock *bsock)
 	assert(avail);
 	ret = bsock->sockapi->send(bsock->sockapi, bsock->sock,
 				   &bsock->sq.data[bsock->sq.head],
-				   avail, MSG_NOSIGNAL, bsock);
+				   avail, MSG_NOSIGNAL, &bsock->tx_sockctx);
 	if (ret < 0) {
 		if (ret == -OFI_EINPROGRESS_URING)
 		    return ret;
@@ -1219,7 +1219,8 @@ ssize_t ofi_bsock_send(struct ofi_bsock *bsock, const void *buf, size_t *len)
 	assert(!ofi_bsock_tosend(bsock));
 	if (*len > bsock->zerocopy_size) {
 		ret = bsock->sockapi->send(bsock->sockapi, bsock->sock, buf, *len,
-					   MSG_NOSIGNAL | OFI_ZEROCOPY, bsock);
+					   MSG_NOSIGNAL | OFI_ZEROCOPY,
+					   &bsock->tx_sockctx);
 		if (ret >= 0) {
 			bsock->async_index++;
 			*len = ret;
@@ -1227,7 +1228,7 @@ ssize_t ofi_bsock_send(struct ofi_bsock *bsock, const void *buf, size_t *len)
 		}
 	} else {
 		ret = bsock->sockapi->send(bsock->sockapi, bsock->sock, buf, *len,
-					   MSG_NOSIGNAL, bsock);
+					   MSG_NOSIGNAL, &bsock->tx_sockctx);
 	}
 	if (ret < 0) {
 		if (ret == -OFI_EINPROGRESS_URING)
@@ -1273,7 +1274,8 @@ ssize_t ofi_bsock_sendv(struct ofi_bsock *bsock, const struct iovec *iov,
 
 	if (*len > bsock->zerocopy_size) {
 		ret = bsock->sockapi->sendv(bsock->sockapi, bsock->sock, iov, cnt,
-					    MSG_NOSIGNAL | OFI_ZEROCOPY, bsock);
+					    MSG_NOSIGNAL | OFI_ZEROCOPY,
+					    &bsock->tx_sockctx);
 		if (ret >= 0) {
 			bsock->async_index++;
 			*len = ret;
@@ -1281,7 +1283,7 @@ ssize_t ofi_bsock_sendv(struct ofi_bsock *bsock, const struct iovec *iov,
 		}
 	} else {
 		ret = bsock->sockapi->sendv(bsock->sockapi, bsock->sock, iov, cnt,
-					    MSG_NOSIGNAL, bsock);
+					    MSG_NOSIGNAL, &bsock->tx_sockctx);
 	}
 	if (ret < 0) {
 		if (ret == -OFI_EINPROGRESS_URING)
@@ -1318,7 +1320,7 @@ ssize_t ofi_bsock_recv(struct ofi_bsock *bsock, void *buf, size_t len)
 		assert(avail);
 		ret = bsock->sockapi->recv(bsock->sockapi, bsock->sock,
 					   &bsock->rq.data[bsock->rq.tail],
-					   avail, MSG_NOSIGNAL, bsock);
+					   avail, MSG_NOSIGNAL, &bsock->rx_sockctx);
 		if (ret <= 0)
 			goto out;
 
@@ -1329,7 +1331,7 @@ ssize_t ofi_bsock_recv(struct ofi_bsock *bsock, void *buf, size_t len)
 	}
 
 	ret = bsock->sockapi->recv(bsock->sockapi, bsock->sock, buf, len,
-				   MSG_NOSIGNAL, bsock);
+				   MSG_NOSIGNAL, &bsock->rx_sockctx);
 	if (ret > 0)
 		return bytes + ret;
 
@@ -1365,7 +1367,7 @@ ssize_t ofi_bsock_recvv(struct ofi_bsock *bsock, struct iovec *iov, size_t cnt)
 		assert(avail);
 		ret = bsock->sockapi->recv(bsock->sockapi, bsock->sock,
 					   &bsock->rq.data[bsock->rq.tail],
-					   avail, MSG_NOSIGNAL, bsock);
+					   avail, MSG_NOSIGNAL, &bsock->rx_sockctx);
 		if (ret <= 0)
 			goto out;
 
@@ -1382,7 +1384,7 @@ ssize_t ofi_bsock_recvv(struct ofi_bsock *bsock, struct iovec *iov, size_t cnt)
 		return bytes;
 
 	ret = bsock->sockapi->recvv(bsock->sockapi, bsock->sock, iov, cnt,
-				    MSG_NOSIGNAL, bsock);
+				    MSG_NOSIGNAL, &bsock->rx_sockctx);
 	if (ret > 0)
 		return ret;
 out:

--- a/src/iouring.c
+++ b/src/iouring.c
@@ -38,7 +38,8 @@
 #include <ofi_net.h>
 
 ssize_t ofi_sockapi_send_uring(struct ofi_sockapi *sockapi, SOCKET sock,
-			       const void *buf,  size_t len, int flags, void *ctx)
+			       const void *buf,  size_t len, int flags,
+			       struct ofi_sockctx *ctx)
 {
 	struct io_uring_sqe *sqe;
 
@@ -56,7 +57,7 @@ ssize_t ofi_sockapi_send_uring(struct ofi_sockapi *sockapi, SOCKET sock,
 
 ssize_t ofi_sockapi_sendv_uring(struct ofi_sockapi *sockapi, SOCKET sock,
 				const struct iovec *iov, size_t cnt, int flags,
-				void *ctx)
+				struct ofi_sockctx *ctx)
 {
 	struct io_uring_sqe *sqe;
 
@@ -73,7 +74,8 @@ ssize_t ofi_sockapi_sendv_uring(struct ofi_sockapi *sockapi, SOCKET sock,
 }
 
 ssize_t ofi_sockapi_recv_uring(struct ofi_sockapi *sockapi, SOCKET sock,
-			       void *buf, size_t len, int flags, void *ctx)
+			       void *buf, size_t len, int flags,
+			       struct ofi_sockctx *ctx)
 {
 	struct io_uring_sqe *sqe;
 
@@ -88,7 +90,7 @@ ssize_t ofi_sockapi_recv_uring(struct ofi_sockapi *sockapi, SOCKET sock,
 
 ssize_t ofi_sockapi_recvv_uring(struct ofi_sockapi *sockapi, SOCKET sock,
 				struct iovec *iov, size_t cnt, int flags,
-				void *ctx)
+				struct ofi_sockctx *ctx)
 {
 	struct io_uring_sqe *sqe;
 


### PR DESCRIPTION
This PR adds support of io_uring to TX operations.
    
The implementation is still incomplete because of the following missing features:

1. We need a mechanism to cancel all pending io_uring operations
and wait for them to complete before we can close the ring.
Right now, pending operations would cause the code to fail
the assertion failure !ep->cur_tx.uring_busy in
xnet_ep_flush_all_queues().

2. ofi_uring_submit() might return an error or submit fewer
SQs than expected. This is handled using an assertion failure 
right now and we definitely need a better strategy there.
    
