### PR TITLE
collective: Rework the fi_barrier change

### DIFF
--- a/fabtests/multinode/src/core_coll.c
+++ b/fabtests/multinode/src/core_coll.c
@@ -206,7 +206,7 @@ static int barrier_test_run()
 	}
 
 	coll_addr = fi_mc_addr(coll_mc);
-	err = fi_barrier(ep, coll_addr, 0, &done_flag);
+	err = fi_barrier(ep, coll_addr, &done_flag);
 	if (err) {
 		FT_DEBUG("collective barrier failed: %d (%s)\n", err, fi_strerror(err));
 		return err;

--- a/include/ofi_coll.h
+++ b/include/ofi_coll.h
@@ -172,8 +172,7 @@ int ofi_join_collective(struct fid_ep *ep, fi_addr_t coll_addr,
 int ofi_av_set(struct fid_av *av, struct fi_av_set_attr *attr,
 	       struct fid_av_set **av_set_fid, void *context);
 
-ssize_t ofi_ep_barrier(struct fid_ep *ep, fi_addr_t coll_addr, uint64_t flags,
-		       void *context);
+ssize_t ofi_ep_barrier(struct fid_ep *ep, fi_addr_t coll_addr, void *context);
 
 ssize_t ofi_ep_allreduce(struct fid_ep *ep, const void *buf, size_t count, void *desc,
 			 void *result, void *result_desc, fi_addr_t coll_addr,

--- a/include/ofi_enosys.h
+++ b/include/ofi_enosys.h
@@ -502,8 +502,9 @@ static struct fi_ops_collective X = {
 	.msg = fi_coll_no_msg,
 };
 */
-ssize_t fi_coll_no_barrier(struct fid_ep *ep, fi_addr_t coll_addr,
-			   uint64_t flags, void *context);
+ssize_t fi_coll_no_barrier(struct fid_ep *ep, fi_addr_t coll_addr, void *context);
+ssize_t fi_coll_no_barrier2(struct fid_ep *ep, fi_addr_t coll_addr, uint64_t flags,
+			    void *context);
 ssize_t fi_coll_no_broadcast(struct fid_ep *ep, void *buf, size_t count, void *desc,
 			     fi_addr_t coll_addr, fi_addr_t root_addr,
 			     enum fi_datatype datatype, uint64_t flags, void *context);

--- a/include/rdma/fi_collective.h
+++ b/include/rdma/fi_collective.h
@@ -92,8 +92,7 @@ struct fi_msg_collective {
 struct fi_ops_collective {
 	size_t	size;
 
-	ssize_t	(*barrier)(struct fid_ep *ep, fi_addr_t coll_addr, uint64_t flags,
-			void *context);
+	ssize_t	(*barrier)(struct fid_ep *ep, fi_addr_t coll_addr, void *context);
 	ssize_t	(*broadcast)(struct fid_ep *ep,
 			void *buf, size_t count, void *desc,
 			fi_addr_t coll_addr, fi_addr_t root_addr,
@@ -135,6 +134,8 @@ struct fi_ops_collective {
 			const struct fi_msg_collective *msg,
 			struct fi_ioc *resultv, void **result_desc,
 			size_t result_count, uint64_t flags);
+	ssize_t	(*barrier2)(struct fid_ep *ep, fi_addr_t coll_addr, uint64_t flags,
+			void *context);
 };
 
 
@@ -201,9 +202,20 @@ fi_join_collective(struct fid_ep *ep, fi_addr_t coll_addr,
 }
 
 static inline ssize_t
-fi_barrier(struct fid_ep *ep, fi_addr_t coll_addr, uint64_t flags, void *context)
+fi_barrier(struct fid_ep *ep, fi_addr_t coll_addr, void *context)
 {
-	return ep->collective->barrier(ep, coll_addr, flags, context);
+	return ep->collective->barrier(ep, coll_addr, context);
+}
+
+static inline ssize_t
+fi_barrier2(struct fid_ep *ep, fi_addr_t coll_addr, uint64_t flags, void *context)
+{
+	if (!flags)
+		return fi_barrier(ep, coll_addr, context);
+
+	return FI_CHECK_OP(ep->collective, struct fi_ops_collective, barrier2) ?
+		ep->collective->barrier2(ep, coll_addr, flags, context) :
+		-FI_ENOSYS;
 }
 
 static inline ssize_t

--- a/man/fi_collective.3.md
+++ b/man/fi_collective.3.md
@@ -10,7 +10,7 @@ tagline: Libfabric Programmer's Manual
 fi_join_collective
 : Operation where a subset of peers join a new collective group.
 
-fi_barrier
+fi_barrier / fi_barrier2
 : Collective operation that does not complete until all peers have entered
   the barrier call.
 
@@ -57,6 +57,9 @@ int fi_join_collective(struct fid_ep *ep, fi_addr_t coll_addr,
 	uint64_t flags, struct fid_mc **mc, void *context);
 
 ssize_t fi_barrier(struct fid_ep *ep, fi_addr_t coll_addr,
+	void *context);
+
+ssize_t fi_barrier2(struct fid_ep *ep, fi_addr_t coll_addr,
 	uint64_t flags, void *context);
 
 ssize_t fi_broadcast(struct fid_ep *ep, void *buf, size_t count, void *desc,
@@ -251,6 +254,11 @@ does not result in any data being transferred at the application level.  A
 barrier does not complete locally until all peers have invoked the barrier
 call.  This signifies to the local application that work by peers that
 completed prior to them calling barrier has finished.
+
+## Barrier (fi_barrier2)
+
+The fi_barrier2 operations is the same as fi_barrier, but with an extra
+parameter to pass in operation flags.
 
 ## Broadcast (fi_broadcast)
 

--- a/prov/util/src/util_coll.c
+++ b/prov/util/src/util_coll.c
@@ -1244,7 +1244,7 @@ int ofi_av_set(struct fid_av *av_fid, struct fi_av_set_attr *attr,
 }
 
 ssize_t ofi_ep_barrier(struct fid_ep *ep, fi_addr_t coll_addr,
-		       uint64_t flags, void *context)
+		       void *context)
 {
 	struct util_coll_mc *coll_mc;
 	struct util_coll_operation *barrier_op;

--- a/src/enosys.c
+++ b/src/enosys.c
@@ -645,9 +645,17 @@ int fi_no_av_set_addr(struct fid_av_set *set, fi_addr_t *coll_addr)
 }
 
 ssize_t fi_coll_no_barrier(struct fid_ep *ep, fi_addr_t coll_addr,
-			   uint64_t flags, void *context)
+			   void *context)
 {
 	return -FI_ENOSYS;
+}
+ssize_t fi_coll_no_barrier2(struct fid_ep *ep, fi_addr_t coll_addr,
+			   uint64_t flags, void *context)
+{
+	if (flags)
+		return -FI_ENOSYS;
+
+	return fi_barrier(ep, coll_addr, context);
 }
 ssize_t fi_coll_no_broadcast(struct fid_ep *ep, void *buf, size_t count, void *desc,
 			     fi_addr_t coll_addr, fi_addr_t root_addr,


### PR DESCRIPTION
Changes introduced by commit d634fb7adc9e27e149ae0480e768d9744faae891 may break upper layer library build. Rework the changes to maintain API compatibility.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>