### PR TITLE
prov/shm: remove extraneous ofi_cirque_next() call

### DIFF
--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -367,7 +367,6 @@ static ssize_t smr_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 		goto unlock_region;
 	}
 
-	cmd = ofi_cirque_next(smr_cmd_queue(peer_smr));
 	total_len = count * ofi_datatype_size(datatype);
 	assert(total_len <= SMR_INJECT_SIZE);
 


### PR DESCRIPTION
In smr_atomic_inject() there was an extraneous ofi_cirque_next() call. This didn't cause an issue because ofi_cirque_next() would return the same entry for multiple calls as long as there was no commit function call in between.

Signed-off-by: Amir Shehata <shehataa@ornl.gov>