### PR TITLE
contrib/intel/jenkins add net and multinode performance to summary stage

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -416,7 +416,7 @@ pipeline {
             }
           }
         }
-        stage('multinode-tcp-performance') {
+        stage('multinode-performance') {
           agent { node { label 'cvl' } }
           options { skipDefaultCheckout() }
           steps {
@@ -427,6 +427,9 @@ pipeline {
                   (
                       cd ${env.WORKSPACE}/${SCRIPT_LOCATION}/
                       python3.7 runtests.py --prov=tcp --test=multinode
+                      echo "multinode tcp performance completed."
+                      python3.7 runtests.py --prov=net --test=multinode
+                      echo "multinode net performance completed."
                       echo "multinode performance completed."
                   )
                 """
@@ -554,7 +557,7 @@ pipeline {
             }
           }
         }
-        stage('net-fabtests') {
+        stage('net') {
           agent { node { label 'cvl' } }
           options { skipDefaultCheckout() }
           steps {
@@ -621,7 +624,7 @@ pipeline {
             }
           }
         }
-        stage('net-osu') {
+        stage('MPI_net-osu') {
           agent { node { label 'cvl' } }
           options { skipDefaultCheckout() }
           steps {
@@ -635,23 +638,6 @@ pipeline {
                 )
               """
             }
-          }
-        }
-        stage('multinode-net-performance') {
-          agent { node { label 'cvl' } }
-          options { skipDefaultCheckout() }
-          steps {
-              withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH'])
-              {
-                sh """
-                  env
-                  (
-                      cd ${env.WORKSPACE}/${SCRIPT_LOCATION}/
-                      python3.7 runtests.py --prov=net --test=multinode
-                      echo "multinode performance completed."
-                  )
-                """
-              }
           }
         }
       }

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -416,7 +416,7 @@ pipeline {
             }
           }
         }
-        stage('multinode-performance') {
+        stage('multinode_performance') {
           agent { node { label 'cvl' } }
           options { skipDefaultCheckout() }
           steps {

--- a/contrib/intel/jenkins/common.py
+++ b/contrib/intel/jenkins/common.py
@@ -11,13 +11,15 @@ def run_command(command, logdir=None, test_type=None, ofi_build_mode=None):
     stage_name = os.environ['STAGE_NAME']
     if (test_type and ('tcp-rxm' in stage_name)):
         filename = f'{logdir}/MPI_tcp-rxm_{test_type}_{ofi_build_mode}'
+    elif (test_type and ('MPI_net' in stage_name)):
+        filename = f'{logdir}/MPI_net_{test_type}_{ofi_build_mode}'
     elif (test_type and ofi_build_mode):
         filename = f'{logdir}/{stage_name}_{test_type}_{ofi_build_mode}'
     else:
         filename = f'{logdir}/{stage_name}'
     print("filename: ".format(filename))
     if (logdir):
-        f = open(filename,'a')
+        f = open(filename, 'a')
     print(" ".join(command))
     p = subprocess.Popen(command, stdout=subprocess.PIPE, text=True)
     print(p.returncode)

--- a/contrib/intel/jenkins/summary.py
+++ b/contrib/intel/jenkins/summary.py
@@ -398,7 +398,6 @@ if __name__ == "__main__":
     # jobs but with same branch name.
     jobname = os.environ['JOB_NAME']
     buildno = os.environ['BUILD_NUMBER']
-    workspace = os.environ['WORKSPACE']
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--summary_item', help="functional test to summarize",

--- a/contrib/intel/jenkins/summary.py
+++ b/contrib/intel/jenkins/summary.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 import os
 from pickle import FALSE
 import sys
@@ -7,389 +8,469 @@ sys.path.append(os.environ['CI_SITE_CONFIG'])
 
 import ci_site_config
 import argparse
-import subprocess
-import shlex
 import common
-import re
-import shutil
 
 verbose = False
 spacing='\t'
 
-def print_results(stage_name, passes, fails, failed_tests, excludes=None,
-                  excluded_tests=None):
-    total = passes + fails
-    # log was empty or not valid
-    if not total:
+class Summarizer(ABC):
+    @classmethod
+    def __subclasshook__(cls, subclass):
+        return (
+            hasattr(subclass, "print_results")
+            and callable(subclass.print_results)
+            and hasattr(subclass, "check_name")
+            and callable(subclass.check_name)
+            and hasattr(subclass, "check_pass")
+            and callable(subclass.check_pass)
+            and hasattr(subclass, "check_fail")
+            and callable(subclass.check_fail)
+            and hasattr(subclass, "check_exclude")
+            and callable(subclass.check_exclude)
+            and hasattr(subclass, "read_file")
+            and callable(subclass.read_file)
+            and hasattr(subclass, "run")
+            and callable(subclass.run)
+            or NotImplemented
+        )
+
+    @abstractmethod
+    def __init__(self, log_dir, prov, build_mode, file_name, stage_name):
+        self.log_dir = log_dir
+        self.prov = prov
+        self.mode = build_mode
+        self.file_name = file_name
+        self.stage_name = stage_name
+        self.file_path = os.path.join(self.log_dir, self.file_name)
+        self.exists = os.path.exists(self.file_path)
+        self.log = None
+        self.line = ''
+        self.result = ''
+        self.passes = 0
+        self.fails = 0
+        self.failed_tests = []
+        self.excludes = 0
+        self.excluded_tests = []
+        self.test_name_string='no_test'
+
+    def print_results(self):
+        total = self.passes + self.fails
+        # log was empty or not valid
+        if not total:
+            return
+
+        percent = self.passes/total * 100
+        print(f"{spacing}{self.stage_name}: ".ljust(40), end='')
+        print(f"{self.passes}/{total} ".ljust(10), end='')
+        print(f"= {percent:.2f}%".ljust(12), end = '')
+        print("Pass")
+        if self.fails:
+            print(f"{spacing}\tFailed tests: {self.fails}")
+            for test in self.failed_tests:
+                    print(f'{spacing}\t\t{test}')
+        if (verbose):
+            if self.excludes:
+                print(f"{spacing}\tExcluded/Notrun tests: {self.excludes} ")
+                for test in self.excluded_tests:
+                    print(f'{spacing}\t\t{test}')
+
+    def check_name(self):
+        return
+ 
+    def check_pass(self):
         return
 
-    percent = passes/total * 100
-    print(f"{spacing}{stage_name}: ".ljust(40), end='')
-    print(f"{passes}/{total}".ljust(8), end='')
-    print(f"= {percent:.2f}%".ljust(12), end = '')
-    print("Pass")
-    if fails:
-        print(f"{spacing}\tFailed tests: {fails}")
-        for test in failed_tests:
-                print(f'{spacing}\t\t{test}')
-    if (verbose):
-        if excludes:
-            print(f"{spacing}\tExcluded/Notrun tests: {excludes} ")
-            for test in excluded_tests:
-                print(f'{spacing}\t\t{test}')
+    def check_fail(self):
+        if "exiting with" in self.line:
+            self.fails += 1
 
-def summarize_fi_info(log_dir, prov, build_mode):
-    file_name = f'{prov}_fi_info_{build_mode}'
-    if not os.path.exists(f'{log_dir}/{file_name}'):
+    def check_exclude(self):
         return
 
-    log = open(f'{log_dir}/{file_name}', 'r')
-    line = log.readline()
-    passes = 0
-    fails = 0
-    failed_tests = []
-    #check if it failed
-    while line:
-        if "exiting with" in line:
-            fails += 1
-            failed_tests.append(f"fi_info {prov}")
+    def check_line(self):
+        self.check_name()
+        self.check_pass()
+        self.check_fail()
+        self.check_exclude()
 
-        line = log.readline()
+    def read_file(self):
+        self.log = open(self.file_path, 'r')
+        self.line = self.log.readline().lower()
+        while self.line:
+            self.check_line()
+            self.line = self.log.readline().lower()
 
-    if not fails:
-        passes += 1
+        self.log.close()
 
-    print_results(f"{prov} fabtests {build_mode}", passes, fails, failed_tests)
+    def summarize(self):
+        if not self.exists:
+            return 0
 
-    log.close()
-    return int(fails)
+        self.read_file()
+        self.print_results()
+        return int(self.fails)
 
-def summarize_fabtests(log_dir, prov, build_mode=None):
-    file_name = f'{prov}_fabtests_{build_mode}'
-    if not os.path.exists(f'{log_dir}/{file_name}'):
-        return
+class FiInfoSummarizer(Summarizer):
+    def __init__(self, log_dir, prov, build_mode):
+        super().__init__(log_dir, prov, build_mode,
+                         f'{prov}_fi_info_{build_mode}',
+                         f"{prov} fi_info {build_mode}")
 
-    log = open(f'{log_dir}/{file_name}', 'r')
-    line = log.readline()
-    passes = 0
-    fails = 0
-    excludes = 0
-    failed_tests = []
-    excluded_tests = []
-    test_name_string='no_test'
-    while line:
+    def check_fail(self):
+        if "exiting with" in self.line:
+            self.fails += 1
+            self.failed_tests.append(f"fi_info {self.prov}")
+
+    def read_file(self):
+        self.log = open(self.file_name, 'r')
+        line = self.log.readline()
+        while line:
+            self.check_line()
+            line = self.log.readline()
+
+        if not self.fails:
+            self.passes += 1
+
+        self.log.close()
+
+class FabtestsSummarizer(Summarizer):
+    def __init__(self, log_dir, prov, build_mode):
+        super().__init__(log_dir, prov, build_mode,
+                         f'{prov}_fabtests_{mode}',
+                         f"{prov} fabtests {mode}")
+        self.result = ''
+        self.result_line = ''
+
+    def check_name(self):
         # don't double count ubertest output
-        if 'ubertest' in line and 'client_cmd:' in line:
-            while 'name:' not in line: # skip past client output in ubertest
-                line = log.readline()
+        if 'ubertest' in self.line and 'client_cmd:' in self.line:
+            while 'name:' not in self.line: # skip past client output in ubertest
+                self.line = self.log.readline().lower()
 
-        if 'name:' in line:
-            test_name = line.split()[2:]
-            test_name_string = ' '.join(test_name)
+        if 'name:' in self.line:
+            test_name = self.line.split()[2:]
+            self.test_name_string = ' '.join(test_name)
 
-        if 'result:' in line:
-            result_line = line.split()
+    def get_result_line(self):
+        if 'result:' in self.line:
+            self.result_line = self.line.split()
             # lines can look like 'result: Pass' or
             # 'Ending test 1 result: Success'
-            result = (result_line[result_line.index('result:') + 1]).lower()
-            if result == 'pass' or result == 'success':
-                    passes += 1
+            self.result = (self.result_line[self.result_line.index(
+                           'result:') + 1]).lower()
 
-            if result == 'fail':
-                fails += 1
-                if 'ubertest' in test_name_string:
-                    idx = (result_line.index('result:') - 1)
-                    ubertest_number = int((result_line[idx].split(',')[0]))
-                    failed_tests.append(f"{test_name_string}: " \
-                                        f"{ubertest_number}")
-                else:
-                    failed_tests.append(test_name_string)
+    def check_pass(self):
+        self.get_result_line()
+        if self.result == 'pass' or self.result == 'success':
+            self.passes += 1
 
-            if result == 'excluded' or result == 'notrun':
-                excludes += 1
-                excluded_tests.append(test_name_string)
+        self.result = ''
 
-        if "exiting with" in line:
-            fails += 1
-            failed_tests.append(test_name_string)
+    def check_fail(self):
+        self.get_result_line()
+        if self.result == 'fail':
+            self.fails += 1
+            if 'ubertest' in self.test_name_string:
+                idx = (self.result_line.index('result:') - 1)
+                ubertest_number = int((self.result_line[idx].split(',')[0]))
+                self.failed_tests.append(f"{self.test_name_string}: " \
+                                    f"{ubertest_number}")
+            else:
+                self.failed_tests.append(self.test_name_string)
 
-        line = log.readline()
+        if "exiting with" in self.line:
+            self.fails += 1
+            self.failed_tests.append(self.test_name_string)
 
-    print_results(f"{prov} fabtests {build_mode}", passes, fails, failed_tests,
-                  excludes, excluded_tests)
+        self.result = ''
 
-    log.close()
-    return int(fails)
+    def check_exclude(self):
+        self.get_result_line()
+        if self.result == 'excluded' or self.result == 'notrun':
+            self.excludes += 1
+            self.excluded_tests.append(self.test_name_string)
 
-def summarize_ze(log_dir, prov, test_type, build_mode=None):
-    file_name = f'ze-{prov}_{test_type}_{build_mode}'
-    if not os.path.exists(f'{log_dir}/{file_name}'):
-        return
+        self.result = ''
 
-    log = open(f'{log_dir}/{file_name}', 'r')
-    line = log.readline()
-    passes = 0
-    fails = 0
-    excludes = 0
-    failed_tests = []
-    excluded_tests = []
-    test_name_string = 'no_test'
-    while line:
-        if 'name:' in line:
-            test_name = line.split()[2:]
-            test_name_string = ' '.join(test_name)
+class ZeSummarizer(Summarizer):
+    def __init__(self, log_dir, prov, test_type, build_mode):
+        self.test_type = test_type
+        self.result = ''
+        self.result_line = ''
+        super().__init__(log_dir, prov, build_mode,
+                         f'ze-{prov}_{self.test_type}_{build_mode}',
+                         f"ze {prov} {test_type} {build_mode}")
 
-        if 'result:' in line:
-            result_line = line.split()
+    def check_name(self):
+        # don't double count ubertest output
+        if 'ubertest' in self.line and 'client_cmd:' in self.line:
+            while 'name:' not in self.line: # skip past client output in ubertest
+                self.line = self.log.readline().lower()
+
+        if 'name:' in self.line:
+            test_name = self.line.split()[2:]
+            self.test_name_string = ' '.join(test_name)
+
+    def get_result_line(self):
+        if 'result:' in self.line:
+            self.result_line = self.line.split()
             # lines can look like 'result: Pass' or
             # 'Ending test 1 result: Success'
-            result = (result_line[result_line.index('result:') + 1]).lower()
-            if result == 'pass' or result == 'success':
-                    passes += 1
+            self.result = (self.result_line[self.result_line.index(
+                           'result:') + 1]).lower()
 
-            if result == 'fail':
-                fails += 1
-                failed_tests.append(test_name_string)
+    def check_pass(self):
+        self.get_result_line()
+        if self.result == 'pass' or self.result == 'success':
+            self.passes += 1
 
-            if result == 'excluded' or result == 'notrun':
-                excludes += 1
-                excluded_tests.append(test_name_string)
+        self.result = ''
 
-        if "exiting with" in line:
+    def check_fail(self):
+        self.get_result_line()
+        if self.result == 'fail':
             fails += 1
-            failed_tests.append(test_name_string)
+            if 'ubertest' in self.test_name_string:
+                idx = (self.result_line.index('result:') - 1)
+                ubertest_number = int((self.result_line[idx].split(',')[0]))
+                self.failed_tests.append(f"{self.test_name_string}: " \
+                                    f"{ubertest_number}")
+            else:
+                self.failed_tests.append(self.test_name_string)
 
-        line = log.readline()
+        if "exiting with" in self.line:
+            self.fails += 1
+            self.failed_tests.append(self.test_name_string)
 
-    print_results(f"ze {prov} {test_type} {build_mode}", passes, fails,
-                  failed_tests, excludes, excluded_tests)
+        self.result = ''
 
-    log.close()
-    return int(fails)
-
-def summarize_oneccl(log_dir, prov, build_mode=None):
-    if 'GPU' in prov:
-        file_name = f'{prov}_onecclgpu_{build_mode}'
-    else:
-        file_name = f'{prov}_oneccl_{build_mode}'
-
-    if not os.path.exists(f'{log_dir}/{file_name}'):
         return
 
-    log = open(f'{log_dir}/{file_name}', 'r')
-    line = log.readline()
-    passes = 0
-    fails = 0
-    failed_tests = []
-    name = 'no_test'
-    while line:
+    def check_exclude(self):
+        self.get_result_line()
+        if self.result == 'excluded' or self.result == 'notrun':
+            self.excludes += 1
+            self.excluded_tests.append(self.test_name_string)
+        self.result = ''
+
+class OnecclSummarizer(Summarizer):
+    def __init__(self, log_dir, prov, build_mode):
+        super().__init__(log_dir, prov, build_mode,
+                         f'{prov}_onecclgpu_{mode}' if 'GPU' in prov else \
+                         f'{prov}_oneccl_{mode}',
+                         f"{prov} {mode}")
+        self.file_path = os.path.join(self.log_dir, self.file_name)
+        self.exists = os.path.exists(self.file_path)
+        self.name = 'no_test'
+
+    def check_name(self):
         #lines look like path/run_oneccl.sh ..... -test examples ..... test_name
-        if " -test" in line:
-            tokens = line.split()
-            name = f"{tokens[tokens.index('-test') + 1]} " \
+        if " -test" in self.line:
+            tokens = self.line.split()
+            self.name = f"{tokens[tokens.index('-test') + 1]} " \
                    f"{tokens[len(tokens) - 1]}"
 
-        if 'PASSED' in line:
-            passes += 1
+    def check_pass(self):
+        self.passes += 1 if 'passed' in self.line else 0
 
-        if 'FAILED' in line or "exiting with" in line:
-            fails += 1
-            failed_tests.append(name)
+    def check_fail(self):
+        if 'failed' in self.line or "exiting with" in self.line:
+            self.fails += 1
+            self.failed_tests.append(self.name)
 
-        line = log.readline()
+class ShmemSummarizer(Summarizer):
+    def __init__(self, log_dir, prov, build_mode):
+        super().__init__(log_dir, prov, build_mode,
+                         f'SHMEM_{prov}_shmem_{build_mode}',
+                         f"shmem {prov} {build_mode}")
+        if self.prov == 'uh':
+            self.keyphrase = 'summary'
+            # Failed
+        if self.prov == 'isx':
+            self.keyphrase = 'scaling'
+            # Failed
+        if self.prov == 'prk':
+            self.keyphrase = 'solution'
+            # ERROR:
+        self.name = 'no_test'
 
-    print_results(f"{prov} oneccl {build_mode}", passes, fails, failed_tests)
+    def check_uh(self):
+        # (test_002) Running test_shmem_atomics.x: Test all atomics... OK
+        # (test_003) Running test_shmem_barrier.x: Tests barrier ... Failed
+        if "running test_" in self.line:
+            tokens = self.line.split()
+            for token in tokens:
+                if 'test_' in token:
+                    self.name = token
+            if tokens[len(tokens) - 1] == 'ok':
+                self.passes += 1
+            else:
+                self.fails += 1
+                self.failed_tests.append(self.name)
+        # Summary
+        # x/z Passed.
+        # y/z Failed.
+        if self.keyphrase in self.line: #double check
+            passed = self.log.readline().lower()
+            failed = self.log.readline().lower()
+            if self.passes != int(passed.split()[1].split('/')[0]):
+                print(f"passes {self.passes} do not match log reported passes " \
+                        f"{int(passed.split()[1].split('/')[0])}")
+            if self.fails != int(failed.split()[1].split('/')[0]):
+                print(f"fails {self.fails} does not match log fails " \
+                        f"{int(failed.split()[1].split('/')[0])}")
 
-    log.close()
-    return int(fails)
+    def check_prk(self):
+        if self.keyphrase in self.line:
+            self.passes += 1
+        if 'error:' in self.line or "exiting with" in self.line:
+            self.fails += 1
+            self.failed_tests.append(f"{self.prov} {self.passes + self.fails}")
+        if 'test(s)' in self.line:
+            if int(self.line.split()[0]) != self.fails:
+                print(f"fails {self.fails} does not match log reported fails " \
+                    f"{int(self.line.split()[0])}")
 
-def summarize_shmem(log_dir, prov, build_mode=None):
-    file_name = f'SHMEM_{prov}_shmem_{build_mode}'
-    if not os.path.exists(f'{log_dir}/{file_name}'):
-        return
+    def check_isx(self):
+        if self.keyphrase in self.line:
+            self.passes += 1
+        if ('failed' in self.line and 'test(s)' not in self.line) or \
+            "exiting with" in self.line:
+            self.fails += 1
+            self.failed_tests.append(f"{self.prov} {self.passes + self.fails}")
+        if 'test(s)' in self.line:
+            if int(self.line.split()[0]) != self.fails:
+                print(f"fails {self.fails} does not match log reported fails " \
+                        f"{int(self.line.split()[0])}")
 
-    log = open(f'{log_dir}/{file_name}', 'r')
-    line = log.readline()
-    passes = 0
-    fails = 0
-    failed_tests = []
-    total = 0
-    if prov == 'uh':
-        keyphrase = 'Summary'
-        # Failed
-    if prov == 'isx':
-        keyphrase = 'Scaling'
-        # Failed
-    if prov == 'prk':
-        keyphrase = 'Solution'
-        # ERROR:
+    def check_fails(self):
+        if "exiting with" in self.line:
+            self.fails += 1
+            self.failed_tests.append(f"{self.prov} {self.passes + self.fails}")
 
-    name = 'no_test'
-    while line:
-        if prov == 'uh':
-            # (test_002) Running test_shmem_atomics.x: Test all atomics... OK
-            # (test_003) Running test_shmem_barrier.x: Tests barrier ... Failed
-            if "Running test_" in line:
-                tokens = line.split()
-                for token in tokens:
-                    if 'test_' in token:
-                        name = token
-                if tokens[len(tokens) - 1] == 'OK':
-                    passes += 1
-                else:
-                    fails += 1
-                    failed_tests.append(name)
-            # Summary
-            # x/z Passed.
-            # y/z Failed.
-            if 'Summary' in line: #double check
-                passed = log.readline()
-                failed = log.readline()
-                if passes != int(passed.split()[1].split('/')[0]):
-                    print(f"passes {passes} do not match log reported passes " \
-                          f"{int(passed.split()[1].split('/')[0])}")
-                if fails != int(failed.split()[1].split('/')[0]):
-                    print(f"fails {fails} does not match log fails " \
-                          f"{int(failed.split()[1].split('/')[0])}")
+    def check_line(self):
+        if self.prov == 'uh':
+            self.check_uh()
+        if self.prov == 'isx':
+            self.check_isx()
+        if self.prov == 'prk':
+            self.check_prk()
+        self.check_fails()
 
-            if "exiting with" in line:
-                fails += 1
-                failed_tests.append(f"{prov} {passes + fails}")
-        if prov == 'prk':
-            if keyphrase in line:
-                passes += 1
-            if 'ERROR:' in line or "exiting with" in line:
-                fails += 1
-                failed_tests.append(f"{prov} {passes + fails}")
-            if 'test(s)' in line:
-                if int(line.split()[0]) != fails:
-                    print(f"fails {fails} does not match log reported fails " \
-                          f"{int(line.split()[0])}")
-        if prov == 'isx':
-            if keyphrase in line:
-                passes += 1
-            if 'Failed' in line or "exiting with" in line:
-                fails += 1
-                failed_tests.append(f"{prov} {passes + fails}")
-            if 'test(s)' in line:
-                if int(line.split()[0]) != fails:
-                    print(f"fails {fails} does not match log reported fails " \
-                          f"{int(line.split()[0])}")
+class MpichTestSuiteSummarizer(Summarizer):
+    def __init__(self, log_dir, prov, mpi, build_mode):
+        super().__init__(log_dir, prov, build_mode,
+                         f'MPICH testsuite_{prov}_{mpi}_mpichtestsuite_{build_mode}',
+                         f"{prov} {mpi} mpichtestsuite {build_mode}")
 
-        line = log.readline()
+        self.mpi = mpi
+        if self.mpi == 'impi':
+            self.run = 'mpiexec'
+        else:
+            self.run = 'mpirun'
 
-    print_results(f"shmem {prov} {build_mode}", passes, fails, failed_tests)
-
-    log.close()
-    return int(fails)
-
-def summarize_mpichtestsuite(log_dir, prov, mpi, build_mode=None):
-    file_name = f'MPICH testsuite_{prov}_{mpi}_mpichtestsuite_{build_mode}'
-    if not os.path.exists(f'{log_dir}/{file_name}'):
-        return
-
-    log = open(f'{log_dir}/{file_name}', 'r')
-    line = log.readline()
-    passes = 0
-    fails = 0
-    failed_tests = []
-    if mpi == 'impi':
-        run = 'mpiexec'
-    else:
-        run = 'mpirun'
-
-    while line:
-        if run in line:
-            name = line.split()[len(line.split()) - 1].split('/')[1]
+    def check_name(self):
+        if self.run in self.line:
+            self.name = self.line.split()[len(self.line.split()) - 1].split('/')[1]
             #assume pass
-            passes += 1
+            self.passes += 1
 
+    def check_fail(self):
         # Fail cases take away assumed pass
-        if "exiting with" in line:
-            fails += 1
-            passes -= 1
-            failed_tests.append(f'{name}')
+        if "exiting with" in self.line:
+            self.fails += 1
+            self.passes -= 1
+            self.failed_tests.append(f'{self.name}')
             #skip to next test
-            while run not in line:
-                line = log.readline()
-            continue
+            while self.run not in self.line:
+                self.line = self.log.readline().lower()
 
-        line = log.readline()
+class ImbSummarizer(Summarizer):
+    def __init__(self, log_dir, prov, mpi, build_mode):
+        super().__init__(log_dir, prov, build_mode,
+                         f'MPI_{prov}_{mpi}_IMB_{build_mode}',
+                         f"{prov} {mpi} IMB {build_mode}")
 
-    print_results(f"{prov} {mpi} mpichtestsuite {build_mode}", passes, fails,
-                  failed_tests)
+        self.mpi = mpi
+        if self.mpi == 'impi':
+            self.run = 'mpiexec'
+        else:
+            self.run = 'mpirun'
+        self.test_type = ''
 
-    log.close()
-    return int(fails)
+    def check_type(self):
+        if 'part' in self.line:
+            self.test_type = self.line.split()[len(self.line.split()) - 2]
 
-def summarize_imb(log_dir, prov, mpi, build_mode=None):
-    file_name = f'MPI_{prov}_{mpi}_IMB_{build_mode}'
-    if not os.path.exists(f'{log_dir}/{file_name}'):
-        return
+    def check_name(self):
+        if "benchmarking" in self.line:
+            self.name = self.line.split()[len(self.line.split()) - 1]
 
-    log = open(f'{log_dir}/{file_name}', 'r')
-    line = log.readline()
-    passes = 0
-    fails = 0
-    failed_tests = []
-    if mpi == 'impi':
-        run = 'mpiexec'
-    else:
-        run = 'mpirun'
+    def check_pass(self):
+        if "benchmarking" in self.line:
+            self.passes += 1
 
-    while line:
-        if 'part' in line:
-            test_type = line.split()[len(line.split()) - 2]
+    def check_fail(self):
+        if "exiting with" in self.line:
+            self.fails += 1
+            self.failed_tests.append(f"{self.test_type} {self.name}")
+            self.passes -= 1
 
-        if "Benchmarking" in line:
-            name = line.split()[len(line.split()) - 1]
-            passes += 1
+    def check_line(self):
+        self.check_type()
+        self.check_name()
+        self.check_pass()
+        self.check_fail()
+        super().check_exclude()
 
-        if "exiting with" in line:
-            fails += 1
-            failed_tests.append(f"{test_type} {name}")
-            passes -= 1
+class OsuSummarizer(Summarizer):
+    def __init__(self, log_dir, prov, mpi, build_mode):
+        super().__init__(log_dir, prov, build_mode,
+                         f'MPI_{prov}_{mpi}_osu_{build_mode}',
+                         f"{prov} {mpi} OSU {build_mode}")
+        self.mpi = mpi
+        if self.mpi == 'impi':
+            self.run = 'mpiexec'
+        else:
+            self.run = 'mpirun'
 
-        line = log.readline()
+        self.type = ''
+        self.tokens = []
 
-    print_results(f"{prov} {mpi} IMB {build_mode}", passes, fails, failed_tests)
+    def get_tokens(self):
+        if "# osu" in self.line:
+            self.tokens = self.line.split()
+        else:
+            self.tokens = []
 
-    log.close()
-    return int(fails)
+    def check_name(self):
+        if 'osu' in self.tokens:
+            self.name = " ".join(self.tokens[self.tokens.index('osu') + \
+                        1:self.tokens.index('test')])
 
-def summarize_osu(log_dir, prov, mpi, build_mode=None):
-    file_name = f'MPI_{prov}_{mpi}_osu_{build_mode}'
-    if not os.path.exists(f'{log_dir}/{file_name}'):
-        return
+    def check_type(self):
+        if self.tokens:
+            self.test_type = self.tokens[1]
 
-    log = open(f'{log_dir}/{file_name}', 'r')
-    line = log.readline()
-    passes = 0
-    fails = 0
-    failed_tests = []
-    if mpi == 'impi':
-        run = 'mpiexec'
-    else:
-        run = 'mpirun'
+    def check_pass(self):
+        if 'osu' in self.tokens:
+            # Assume pass
+            self.passes += 1
 
-    while line:
-        if "# OSU" in line:
-            tokens = line.split()
-            name = " ".join(tokens[tokens.index('OSU') + 1:tokens.index('Test')])
-            test_type = tokens[1]
-            passes += 1
+    def check_fail(self):
+        if "exiting with" in self.line:
+            self.fails += 1
+            self.failed_tests.append(f"{self.test_type} {self.name}")
+            # Remove assumed pass
+            self.passes -= 1
 
-        if "exiting with" in line:
-            fails += 1
-            failed_tests.append(f"{test_type} {name}")
-            passes -= 1
-
-        line = log.readline()
-
-    print_results(f"{prov} {mpi} OSU {build_mode}", passes, fails, failed_tests)
-
-    log.close()
-    return int(fails)
+    def check_line(self):
+        self.get_tokens()
+        self.check_name()
+        self.check_type()
+        self.check_pass()
+        self.check_fail()
+        super().check_exclude()
 
 if __name__ == "__main__":
 #read Jenkins environment variables
@@ -436,47 +517,49 @@ if __name__ == "__main__":
                 if util:
                     prov = f'{prov}-{util}'
 
-                ret = summarize_fabtests(log_dir, prov, mode)
+                ret = FabtestsSummarizer(log_dir, prov, mode).summarize()
                 err += ret if ret else 0
-                ret = summarize_fi_info(log_dir, prov, mode)
+                ret = FiInfoSummarizer(log_dir, prov, mode).summarize()
                 err += ret if ret else 0
 
-        if summary_item == 'mpichtestsuite' or summary_item == 'all':
+        if summary_item == 'imb' or summary_item == 'all':
             for mpi in mpi_list:
                 for item in ['tcp-rxm', 'verbs-rxm', 'net']:
-                    ret = summarize_imb(log_dir, item, mpi, mode)
+                    ret = ImbSummarizer(log_dir, item, mpi, mode).summarize()
                     err += ret if ret else 0
 
         if summary_item == 'osu' or summary_item == 'all':
             for mpi in mpi_list:
                     for item in ['tcp-rxm', 'verbs-rxm']:
-                        ret = summarize_osu(log_dir, item, mpi, mode)
+                        ret = OsuSummarizer(log_dir, item, mpi,
+                                            mode).summarize()
                         err += ret if ret else 0
 
         if summary_item == 'mpichtestsuite' or summary_item == 'all':
             for mpi in mpi_list:
                     for item in ['tcp-rxm', 'verbs-rxm', 'sockets']:
-                        ret = summarize_mpichtestsuite(log_dir, item, mpi, mode)
+                        ret = MpichTestSuiteSummarizer(log_dir, item,
+                                                       mpi, mode).summarize()
                         err += ret if ret else 0
 
         if summary_item == 'oneccl' or summary_item == 'all':
-            ret = summarize_oneccl(log_dir, 'oneCCL', ofi_build_mode)
+            ret = OnecclSummarizer(log_dir, 'oneCCL', mode).summarize()
             err += ret if ret else 0
-            ret = summarize_oneccl(log_dir, 'oneCCL-GPU', mode)
+            ret = OnecclSummarizer(log_dir, 'oneCCL-GPU', mode).summarize()
             err += ret if ret else 0
 
         if summary_item == 'shmem' or summary_item == 'all':
-            ret = summarize_shmem(log_dir, 'uh', mode)
+            ret = ShmemSummarizer(log_dir, 'uh', mode).summarize()
             err += ret if ret else 0
-            ret = summarize_shmem(log_dir, 'prk', mode)
+            ret = ShmemSummarizer(log_dir, 'prk', mode).summarize()
             err += ret if ret else 0
-            ret = summarize_shmem(log_dir, 'isx', mode)
+            ret = ShmemSummarizer(log_dir, 'isx', mode).summarize()
             err += ret if ret else 0
 
         if summary_item == 'ze' or summary_item == 'all':
             test_types = ['h2d', 'd2d', 'xd2d']
             for type in test_types:
-                ret = summarize_ze(log_dir, 'shm', type, mode)
+                ret = ZeSummarizer(log_dir, 'shm', type, mode).summarize()
                 err += ret if ret else 0
 
     exit(err)

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -275,11 +275,16 @@ class MultinodeTests(Test):
         return True
 
     def execute_cmd(self):
+        if self.util_prov:
+            prov = f"{self.core_prov}-{self.util_prov} "
+        else:
+            prov = self.core_prov
         curdir = os.getcwd()
         os.chdir(self.fabtestconfigpath)
         command = self.cmd + self.options
         outputcmd = shlex.split(command)
-        common.run_command(outputcmd)
+        common.run_command(outputcmd, self.ci_logdir_path, prov,
+                           self.ofi_build_mode)
         os.chdir(curdir)
 
 class ZeFabtests(Test):


### PR DESCRIPTION
Add net provider and multinode performance stage logs to summary.py
They are now included and presented in the same format as the other tests.

The entire summary.py has also been refactored to use python classes. This will help with maintainability and adding future summarizers to it.