### PR TITLE
core/hmem_ops: Rename parameters for consistency

### DIFF
--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -56,7 +56,7 @@ extern bool ofi_hmem_disable_p2p;
  */
 struct ipc_info {
 	uint64_t	iface;
-	uint64_t	base_address;
+	uint64_t	base_addr;
 	uint64_t	base_length;
 	uint64_t	device;
 	uint64_t	offset;
@@ -117,16 +117,17 @@ struct ofi_hmem_ops {
 	int (*init)(void);
 	int (*cleanup)(void);
 	int (*copy_to_hmem)(uint64_t device, void *dest, const void *src,
-			    size_t size);
+			size_t size);
 	int (*copy_from_hmem)(uint64_t device, void *dest, const void *src,
-			      size_t size);
+			size_t size);
 	bool (*is_addr_valid)(const void *addr, uint64_t *device, uint64_t *flags);
-	int (*get_handle)(void *dev_buf, void **handle);
-	int (*open_handle)(void **handle, uint64_t device, void **ipc_ptr);
-	int (*close_handle)(void *ipc_ptr);
-	int (*host_register)(void *ptr, size_t size);
-	int (*host_unregister)(void *ptr);
-	int (*get_base_addr)(const void *ptr, void **base, size_t *size);
+	int (*get_handle)(void *base_addr, void **handle);
+	int (*open_handle)(void **handle, uint64_t device, void **mapped_addr);
+	int (*close_handle)(void *mapped_addr);
+	int (*host_register)(void *addr, size_t size);
+	int (*host_unregister)(void *addr);
+	int (*get_base_addr)(const void *addr, void **base_addr,
+			size_t *base_length);
 	bool (*is_ipc_enabled)(void);
 	int (*get_ipc_handle_size)(size_t *size);
 };
@@ -232,17 +233,18 @@ static inline int ofi_hmem_cleanup_noop(void)
 	return FI_SUCCESS;
 }
 
-static inline int ofi_hmem_no_get_handle(void *dev_buffer, void **handle)
+static inline int ofi_hmem_no_get_handle(void *base_addr, void **handle)
 {
 	return -FI_ENOSYS;
 }
 
-static inline int ofi_hmem_no_open_handle(void **handle, uint64_t device, void **ipc_ptr)
+static inline int
+ofi_hmem_no_open_handle(void **handle, uint64_t device, void **mapped_addr)
 {
 	return -FI_ENOSYS;
 }
 
-static inline int ofi_hmem_no_close_handle(void *ipc_ptr)
+static inline int ofi_hmem_no_close_handle(void *mapped_addr)
 {
 	return -FI_ENOSYS;
 }
@@ -252,17 +254,18 @@ static inline int ofi_hmem_no_get_ipc_handle_size(size_t *size)
 	return -FI_ENOSYS;
 }
 
-static inline int ofi_hmem_host_register_noop(void *ptr, size_t size)
+static inline int ofi_hmem_host_register_noop(void *addr, size_t size)
 {
 	return FI_SUCCESS;
 }
 
-static inline int ofi_hmem_host_unregister_noop(void *ptr)
+static inline int ofi_hmem_host_unregister_noop(void *addr)
 {
 	return FI_SUCCESS;
 }
 
-static inline int ofi_hmem_no_base_addr(const void *ptr, void **base, size_t *size)
+static inline int
+ofi_hmem_no_base_addr(const void *addr, void **base_addr, size_t *base_length)
 {
 	return -FI_ENOSYS;
 }
@@ -287,20 +290,20 @@ ssize_t ofi_copy_to_hmem_iov(enum fi_hmem_iface hmem_iface, uint64_t device,
 			     size_t hmem_iov_count, uint64_t hmem_iov_offset,
 			     const void *src, size_t size);
 
-int ofi_hmem_get_handle(enum fi_hmem_iface iface, void *dev_buf, void **handle);
+int ofi_hmem_get_handle(enum fi_hmem_iface iface, void *base_addr, void **handle);
 int ofi_hmem_open_handle(enum fi_hmem_iface iface, void **handle,
-			 uint64_t device, void **ipc_ptr);
-int ofi_hmem_close_handle(enum fi_hmem_iface iface, void *ipc_ptr);
-int ofi_hmem_get_base_addr(enum fi_hmem_iface iface, const void *ptr,
-			   void **base, size_t *size);
+			 uint64_t device, void **mapped_addr);
+int ofi_hmem_close_handle(enum fi_hmem_iface iface, void *mapped_addr);
+int ofi_hmem_get_base_addr(enum fi_hmem_iface iface, const void *addr,
+			   void **base_addr, size_t *base_length);
 bool ofi_hmem_is_initialized(enum fi_hmem_iface iface);
 
 void ofi_hmem_init(void);
 void ofi_hmem_cleanup(void);
 enum fi_hmem_iface ofi_get_hmem_iface(const void *addr, uint64_t *device,
 				      uint64_t *flags);
-int ofi_hmem_host_register(void *ptr, size_t size);
-int ofi_hmem_host_unregister(void *ptr);
+int ofi_hmem_host_register(void *addr, size_t size);
+int ofi_hmem_host_unregister(void *addr);
 bool ofi_hmem_is_ipc_enabled(enum fi_hmem_iface iface);
 size_t ofi_hmem_get_ipc_handle_size(enum fi_hmem_iface iface);
 

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -1119,12 +1119,10 @@ static int xnet_init_uring(struct xnet_uring *uring, size_t entries,
 	ret = ofi_dynpoll_add(dynpoll,
 			      ofi_uring_get_fd(&uring->ring),
 			      POLLIN, &uring->fid);
-	if (ret) {
-		ofi_uring_destroy(&uring->ring);
-		return ret;
-	}
+	if (ret)
+		(void) ofi_uring_destroy(&uring->ring);
 
-	return 0;
+	return ret;
 }
 
 static void xnet_destroy_uring(struct xnet_uring *uring,

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -408,7 +408,7 @@ static int smr_format_ipc(struct smr_cmd *cmd, void *ptr, size_t len,
 	if (ret)
 		return ret;
 
-	cmd->msg.data.ipc_info.base_address = (uintptr_t) base;
+	cmd->msg.data.ipc_info.base_addr = (uintptr_t) base;
 	cmd->msg.data.ipc_info.offset = (uintptr_t) ptr - (uintptr_t) base;
 
 	return FI_SUCCESS;

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -208,26 +208,26 @@ ssize_t ofi_copy_to_hmem_iov(enum fi_hmem_iface hmem_iface, uint64_t device,
 				     (void *) src, size, OFI_COPY_BUF_TO_IOV);
 }
 
-int ofi_hmem_get_handle(enum fi_hmem_iface iface, void *dev_buf, void **handle)
+int ofi_hmem_get_handle(enum fi_hmem_iface iface, void *base_addr, void **handle)
 {
-	return hmem_ops[iface].get_handle(dev_buf, handle);
+	return hmem_ops[iface].get_handle(base_addr, handle);
 }
 
 int ofi_hmem_open_handle(enum fi_hmem_iface iface, void **handle,
-			 uint64_t device, void **ipc_ptr)
+			 uint64_t device, void **mapped_addr)
 {
-	return hmem_ops[iface].open_handle(handle, device, ipc_ptr);
+	return hmem_ops[iface].open_handle(handle, device, mapped_addr);
 }
 
-int ofi_hmem_close_handle(enum fi_hmem_iface iface, void *ipc_ptr)
+int ofi_hmem_close_handle(enum fi_hmem_iface iface, void *mapped_addr)
 {
-	return hmem_ops[iface].close_handle(ipc_ptr);
+	return hmem_ops[iface].close_handle(mapped_addr);
 }
 
-int ofi_hmem_get_base_addr(enum fi_hmem_iface iface, const void *ptr,
-			   void **base, size_t *size)
+int ofi_hmem_get_base_addr(enum fi_hmem_iface iface, const void *addr,
+			   void **base_addr, size_t *base_length)
 {
-	return hmem_ops[iface].get_base_addr(ptr, base, size);
+	return hmem_ops[iface].get_base_addr(addr, base_addr, base_length);
 }
 
 bool ofi_hmem_is_initialized(enum fi_hmem_iface iface)
@@ -296,7 +296,7 @@ enum fi_hmem_iface ofi_get_hmem_iface(const void *addr, uint64_t *device,
 	return FI_HMEM_SYSTEM;
 }
 
-int ofi_hmem_host_register(void *ptr, size_t size)
+int ofi_hmem_host_register(void *addr, size_t size)
 {
 	int iface, ret;
 
@@ -304,7 +304,7 @@ int ofi_hmem_host_register(void *ptr, size_t size)
 		if (!ofi_hmem_is_initialized(iface))
 			continue;
 
-		ret = hmem_ops[iface].host_register(ptr, size);
+		ret = hmem_ops[iface].host_register(addr, size);
 		if (ret != FI_SUCCESS)
 			goto err;
 	}
@@ -321,13 +321,13 @@ err:
 		if (!ofi_hmem_is_initialized(iface))
 			continue;
 
-		hmem_ops[iface].host_unregister(ptr);
+		hmem_ops[iface].host_unregister(addr);
 	}
 
 	return ret;
 }
 
-int ofi_hmem_host_unregister(void *ptr)
+int ofi_hmem_host_unregister(void *addr)
 {
 	int iface, ret;
 
@@ -335,7 +335,7 @@ int ofi_hmem_host_unregister(void *ptr)
 		if (!ofi_hmem_is_initialized(iface))
 			continue;
 
-		ret = hmem_ops[iface].host_unregister(ptr);
+		ret = hmem_ops[iface].host_unregister(addr);
 		if (ret != FI_SUCCESS)
 			goto err;
 	}

--- a/src/hmem_ipc_cache.c
+++ b/src/hmem_ipc_cache.c
@@ -78,7 +78,7 @@ static void ipc_cache_delete_region(struct ofi_mr_cache *cache,
 
 /**
  * @brief Open an ipc cache
- * 
+ *
  * @param cache[in] the ipc cache
  * @param domain[in] the domain that the cache is attached to.
  * @param iface[in] the hmem iface of the ipc
@@ -123,7 +123,7 @@ out:
 
 /**
  * @brief Destroy the ipc cache
- * 
+ *
  * @param cache the ipc cache
  */
 void ofi_ipc_cache_destroy(struct ofi_mr_cache *cache)
@@ -139,7 +139,7 @@ void ofi_ipc_cache_destroy(struct ofi_mr_cache *cache)
  * part of each mr entry.
  * In a cache hit, the mapped_addr is retrieved from the matched mr entry. Otherwise,
  * the mapped_addr is obtained by opening the ipc handle.
- * 
+ *
  * @param[in] cache the ipc cache
  * @param[in] ipc_info the information of the ipc to be mapped.
  * @param[out] mr_entry the matched mr_entry of the ipc_info and mapped_addr.
@@ -153,7 +153,7 @@ int ofi_ipc_cache_search(struct ofi_mr_cache *cache, struct ipc_info *ipc_info,
 	int ret;
 	size_t ipc_handle_size;
 
-	info.iov.iov_base = (void *) (uintptr_t) ipc_info->base_address;
+	info.iov.iov_base = (void *) (uintptr_t) ipc_info->base_addr;
 	info.iov.iov_len = ipc_info->base_length;
 	info.iface = ipc_info->iface;
 


### PR DESCRIPTION
At least I think this renames the parameters for consistency and to make them easier to understand.  I didn't update the underlying calls, only the hmemops.  Renames are generally

ptr -> addr
ipc_ptr -> mapped_addr
base -> base_addr
dev_buf -> base_addr
size (when referring to base_addr) -> base_length