### PR TITLE
prov/efa: fix default value for host memory's max_medium_msg_size

### DIFF
--- a/prov/efa/src/efa_hmem.c
+++ b/prov/efa/src/efa_hmem.c
@@ -61,7 +61,7 @@ static int efa_hmem_info_update_system(struct efa_hmem_info *system_info)
 	system_info->runt_size = 0;
 	fi_param_get_size_t(&rxr_prov, "runt_size", &system_info->runt_size);
 
-	system_info->max_medium_msg_size = 0;
+	system_info->max_medium_msg_size = 65536;
 	fi_param_get_size_t(&rxr_prov, "inter_max_medium_message_size", &system_info->max_medium_msg_size);
 
 	system_info->min_read_msg_size = 1048576;


### PR DESCRIPTION
Previous commit wrongly set the max_medium_msg_size to 0 for host memory, which caused medium message protocol not being used. This patch fixed the issue.

Signed-off-by: Wei Zhang <wzam@amazon.com>