### PR TITLE
prov/net: fix error path in xnet_enable_rdm

### DIFF
--- a/prov/net/src/xnet_rdm.c
+++ b/prov/net/src/xnet_rdm.c
@@ -711,7 +711,7 @@ static int xnet_enable_rdm(struct xnet_rdm *rdm)
 
 	ret = xnet_listen(rdm->pep, progress);
 	if (ret)
-		return ret;
+		goto unlock;
 
 	/* TODO: Move updating the src_addr to pep_listen(). */
 	len = sizeof(rdm->addr);


### PR DESCRIPTION
If xnet_listen fails (happens 100% of the time on a system with no network interface but lo), the progress lock is not released which causes a deadlock when fi_close is called later on the endpoint.

Signed-off-by: Nicolas Morey-Chaisemartin <nmoreychaisemartin@suse.com>