### PR TITLE
prov/net: Fix loopback receive handling + other updates

### DIFF
--- a/fabtests/functional/loopback.c
+++ b/fabtests/functional/loopback.c
@@ -88,8 +88,9 @@ int main(int argc, char **argv)
 		return EXIT_FAILURE;
 
 	opts.src_addr = "127.0.0.1";
-	hints->caps |= FI_LOCAL_COMM;
+	hints->caps = FI_LOCAL_COMM | FI_MSG | FI_TAGGED;
 	hints->ep_attr->type = FI_EP_RDM;
+	hints->mode = FI_CONTEXT;
 
 	while ((op = getopt(argc, argv, "h" INFO_OPTS)) != -1) {
 		switch (op) {
@@ -103,10 +104,7 @@ int main(int argc, char **argv)
 		}
 	}
 
-	hints->caps = FI_MSG;
-	hints->mode = FI_CONTEXT;
 	hints->domain_attr->mr_mode = opts.mr_mode;
-
 	ret = run();
 
 	ft_free_res();

--- a/fabtests/functional/loopback.c
+++ b/fabtests/functional/loopback.c
@@ -87,6 +87,7 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
+	opts.src_addr = "127.0.0.1";
 	hints->caps |= FI_LOCAL_COMM;
 	hints->ep_attr->type = FI_EP_RDM;
 

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -220,6 +220,8 @@ struct xnet_event {
 
 enum {
 	XNET_CONN_INDEXED = BIT(0),
+	XNET_CONN_TX_LOOPBACK = BIT(1),
+	XNET_CONN_RX_LOOPBACK = BIT(2),
 };
 
 struct xnet_conn {
@@ -228,7 +230,6 @@ struct xnet_conn {
 	struct util_peer_addr	*peer;
 	uint32_t		remote_pid;
 	int			flags;
-	struct dlist_entry	loopback_entry;
 };
 
 struct xnet_rdm {
@@ -238,7 +239,7 @@ struct xnet_rdm {
 	struct xnet_srx		*srx;
 
 	struct index_map	conn_idx_map;
-	struct dlist_entry	loopback_list;
+	struct xnet_conn	*rx_loopback;
 	union ofi_sock_ip	addr;
 };
 
@@ -246,7 +247,7 @@ int xnet_rdm_ep(struct fid_domain *domain, struct fi_info *info,
 		struct fid_ep **ep_fid, void *context);
 ssize_t xnet_get_conn(struct xnet_rdm *rdm, fi_addr_t dest_addr,
 		      struct xnet_conn **conn);
-struct xnet_ep *xnet_get_ep(struct xnet_rdm *rdm, fi_addr_t addr);
+struct xnet_ep *xnet_get_rx_ep(struct xnet_rdm *rdm, fi_addr_t addr);
 void xnet_freeall_conns(struct xnet_rdm *rdm);
 
 struct xnet_uring {

--- a/prov/net/src/xnet_rdm.c
+++ b/prov/net/src/xnet_rdm.c
@@ -775,6 +775,7 @@ static int xnet_rdm_close(struct fid *fid)
 	if (ret) {
 		FI_WARN(&xnet_prov, FI_LOG_EP_CTRL, \
 			"Unable to close passive endpoint\n");
+		ofi_genlock_unlock(&xnet_rdm2_progress(rdm)->rdm_lock);
 		return ret;
 	}
 

--- a/prov/net/src/xnet_rdm.c
+++ b/prov/net/src/xnet_rdm.c
@@ -847,7 +847,6 @@ static int xnet_init_rdm(struct xnet_rdm *rdm, struct fi_info *info)
 		goto err2;
 	}
 
-	dlist_init(&rdm->loopback_list);
 	rdm->srx = container_of(srx, struct xnet_srx, rx_fid);
 	rdm->pep = container_of(pep, struct xnet_pep, util_pep);
 	return 0;

--- a/prov/net/src/xnet_srx.c
+++ b/prov/net/src/xnet_srx.c
@@ -242,7 +242,7 @@ xnet_match_unexp(struct xnet_srx *srx, struct xnet_xfer_entry *recv_entry,
 		if (!queue)
 			return NULL;
 
-		ep = xnet_get_ep(srx->rdm, recv_entry->src_addr);
+		ep = xnet_get_rx_ep(srx->rdm, recv_entry->src_addr);
 		if (!ep || !xnet_has_unexp(ep) ||
 		    !match(&ep->unexp_entry, recv_entry))
 			return NULL;
@@ -372,7 +372,7 @@ xnet_srx_tag(struct xnet_srx *srx, struct xnet_xfer_entry *recv_entry)
 
 		slist_insert_tail(&recv_entry->entry, queue);
 
-		ep = xnet_get_ep(srx->rdm, recv_entry->src_addr);
+		ep = xnet_get_rx_ep(srx->rdm, recv_entry->src_addr);
 		if (ep && xnet_has_unexp(ep)) {
 			assert(!dlist_empty(&ep->unexp_entry));
 			xnet_progress_rx(ep);


### PR DESCRIPTION
prov/net: Release lock in case of error in rdm_close
fabtests/loopback: Update to use loopback IP address, fix setting hints, and use tagged messages