### PR TITLE
fabtests/functional/rdma_atomic: Fix fi_rdma_atomic for hmem

### DIFF
--- a/fabtests/functional/rdm_atomic.c
+++ b/fabtests/functional/rdm_atomic.c
@@ -424,10 +424,6 @@ static int run(void)
 	if (ret)
 		return ret;
 
-	ret = alloc_ep_res(fi);
-	if (ret)
-		return ret;
-
 	ret = ft_exchange_keys(&remote);
 	if (ret)
 		goto out;


### PR DESCRIPTION
When running fabtests with -D cuda, alloc_ep_res calls malloc, and then ft_reg_mr with a opts.iface set to cuda HMEM.  This caused a seg fault in the EFA provider when trying to register a system buffer as a cuda buffer. The alloc_ep_res function doesn't seem to be required for the test, so I am removing it to fix the test. 

I haven't fully implemented EFA atomic support for HMEM, but from the debugger this fix seems to push me down the correct path.  I tested this on EFA without hmem and it seems to work as expected.

Putting up this PR early for feedback on approach.

Signed-off-by: Seth Zegelstein <szegel@amazon.com>