### PR TITLE
fabtests/fi_rdm_atomic: Fix hmem support

### DIFF
--- a/fabtests/functional/rdm_atomic.c
+++ b/fabtests/functional/rdm_atomic.c
@@ -35,6 +35,7 @@
 #include <rdma/fi_atomic.h>
 
 #include "shared.h"
+#include <hmem.h>
 
 static enum fi_op op_type = FI_MIN;
 static void *result;
@@ -360,11 +361,11 @@ static void free_res(void)
 	FT_CLOSE_FID(mr_result);
 	FT_CLOSE_FID(mr_compare);
 	if (result) {
-		free(result);
+		ft_hmem_free(opts.iface, result);
 		result = NULL;
 	}
 	if (compare) {
-		free(compare);
+		ft_hmem_free(opts.iface, compare);
 		compare = NULL;
 	}
 }
@@ -383,15 +384,15 @@ static int alloc_ep_res(struct fi_info *fi)
 	int ret;
 	int mr_local = !!(fi->domain_attr->mr_mode & FI_MR_LOCAL);
 
-	result = malloc(buf_size);
-	if (!result) {
-		perror("malloc");
+	ret = ft_hmem_alloc(opts.iface, opts.device, &result, buf_size);
+	if (ret) {
+		perror("hmem allocation error");
 		return -1;
 	}
 
-	compare = malloc(buf_size);
-	if (!compare) {
-		perror("malloc");
+	ret = ft_hmem_alloc(opts.iface, opts.device, &compare, buf_size);
+	if (ret) {
+		perror("hmem allocation error");
 		return -1;
 	}
 


### PR DESCRIPTION
Before this patch, alloc_ep_res() would allocate buffers on the host, but ft_reg_mr() uses opt.iface to register the buffers as cuda buffers. This caused the EFA provider to segfault during memory registration. This patch allocates the result/compare buffers on the device, which allows the memory to be successfully registered.

Testing:

Built-in providers:	dmabuf_peer_mem hook_hmem hook_debug perf rstream shm rxd mrail rxm net tcp udp efa verbs sockets 

Ran:
```
fi_rdm_atomic -E.                    # runs successfully
fi_rdm_atomic -D cuda -E      # everything skips - my next change to EFA will provide atomic support for hmem.
```

Signed-off-by: Seth Zegelstein <szegel@amazon.com>