### PR TITLE
fabtests/sighandler_test: give child more time to handle signal

### DIFF
--- a/fabtests/regression/sighandler_test.c
+++ b/fabtests/regression/sighandler_test.c
@@ -52,7 +52,7 @@ int main(int argc, char **argv)
 	if ((child = fork())) {
 		usleep(500000); /* give child time to finish initialization */
 		kill(child, SIGINT);
-		usleep(100000); /* give child time to handle the signal */
+		usleep(5000000); /* give child time to handle the signal */
 		kill(child, SIGKILL);
 
 		waitpid(child, &status, 0);


### PR DESCRIPTION
This patch gives child more time to handle SIGINT. This allowes 3rd party library signal handler to have enough time to handle the signal.

Signed-off-by: Wei Zhang <wzam@amazon.com>