### PR TITLE
prov/efa: Allocate rxr_pkt_entry from two separate ofi_buf_pools

### DIFF
--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -901,6 +901,7 @@
     <ClCompile Include="prov\efa\src\rxr\rxr_msg.c" />
     <ClCompile Include="prov\efa\src\rxr\rxr_pkt_cmd.c" />
     <ClCompile Include="prov\efa\src\rxr\rxr_pkt_entry.c" />
+    <ClCompile Include="prov\efa\src\rxr\rxr_pkt_pool.c" />
     <ClCompile Include="prov\efa\src\rxr\rxr_pkt_type_data.c" />
     <ClCompile Include="prov\efa\src\rxr\rxr_pkt_type_misc.c" />
     <ClCompile Include="prov\efa\src\rxr\rxr_pkt_type_req.c" />
@@ -1022,6 +1023,7 @@
     <ClInclude Include="prov\efa\src\rxr\rxr_msg.h" />
     <ClInclude Include="prov\efa\src\rxr\rxr_pkt_cmd.h" />
     <ClInclude Include="prov\efa\src\rxr\rxr_pkt_entry.h" />
+    <ClInclude Include="prov\efa\src\rxr\rxr_pkt_pool.h" />
     <ClInclude Include="prov\efa\src\rxr\rxr_pkt_type.h" />
     <ClInclude Include="prov\efa\src\rxr\rxr_pkt_type_req.h" />
     <ClInclude Include="prov\efa\src\rxr\rxr_read.h" />

--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -61,6 +61,7 @@ _efa_files = \
 	prov/efa/src/rxr/rxr_pkt_type_data.c \
 	prov/efa/src/rxr/rxr_pkt_type_misc.c \
 	prov/efa/src/rxr/rxr_pkt_cmd.c \
+	prov/efa/src/rxr/rxr_pkt_pool.c \
 	prov/efa/src/rxr/rxr_read.c \
 	prov/efa/src/rxr/rxr_op_entry.c \
 	prov/efa/src/rxr/rxr_atomic.c \
@@ -91,6 +92,7 @@ _efa_headers = \
 	prov/efa/src/rxr/rxr_pkt_type_req.h \
 	prov/efa/src/rxr/rxr_pkt_type_base.h \
 	prov/efa/src/rxr/rxr_pkt_cmd.h \
+	prov/efa/src/rxr/rxr_pkt_pool.h \
 	prov/efa/src/rxr/rxr_read.h \
 	prov/efa/src/rxr/rxr_atomic.h \
 	prov/efa/src/rxr/rxr_op_entry.h \

--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -164,7 +164,7 @@ void efa_rdm_peer_clear(struct rxr_ep *ep, struct rdm_peer *peer)
 		dlist_remove(&peer->rnr_backoff_entry);
 
 #ifdef ENABLE_EFA_POISONING
-	rxr_poison_mem_region((uint32_t *)peer, sizeof(struct rdm_peer));
+	rxr_poison_mem_region(peer, sizeof(struct rdm_peer));
 #endif
 }
 

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -79,12 +79,12 @@ static inline void rxr_poison_mem_region(void *ptr, size_t size)
 		memcpy((uint32_t *)ptr + i, &rxr_poison_value, sizeof(rxr_poison_value));
 }
 
-static inline void rxr_poison_pkt_entry(struct rxr_pkt_entry *pkt_entry, size_t pkt_size)
+static inline void rxr_poison_pkt_entry(struct rxr_pkt_entry *pkt_entry, size_t wiredata_size)
 {
-	rxr_poison_mem_region(pkt_entry->pkt, pkt_size);
+	rxr_poison_mem_region(pkt_entry->wiredata, wiredata_size);
 	/*
-	 * Don't poison pkt_entry->pkt, which is the last element in rxr_pkt_entry
-	 * pkt_entry->pkt is released when the pkt_entry is released
+	 * Don't poison pkt_entry->wiredata, which is the last element in rxr_pkt_entry
+	 * pkt_entry->wiredata is released when the pkt_entry is released
 	 */
 	rxr_poison_mem_region(pkt_entry, sizeof(struct rxr_pkt_entry) - sizeof(char *));
 }

--- a/prov/efa/src/rxr/rxr_cq.c
+++ b/prov/efa/src/rxr/rxr_cq.c
@@ -595,7 +595,7 @@ int rxr_cq_reorder_msg(struct rxr_ep *ep,
 	struct rxr_robuf *robuf;
 	uint32_t msg_id;
 
-	assert(rxr_get_base_hdr(pkt_entry->pkt)->type >= RXR_REQ_PKT_BEGIN);
+	assert(rxr_get_base_hdr(pkt_entry->wiredata)->type >= RXR_REQ_PKT_BEGIN);
 
 	msg_id = rxr_pkt_msg_id(pkt_entry);
 
@@ -642,7 +642,7 @@ int rxr_cq_reorder_msg(struct rxr_ep *ep,
 
 	cur_ooo_entry = *ofi_recvwin_get_msg(robuf, msg_id);
 	if (cur_ooo_entry) {
-		assert(rxr_pkt_type_is_mulreq(rxr_get_base_hdr(cur_ooo_entry->pkt)->type));
+		assert(rxr_pkt_type_is_mulreq(rxr_get_base_hdr(cur_ooo_entry->wiredata)->type));
 		assert(rxr_pkt_msg_id(cur_ooo_entry) == msg_id);
 		assert(rxr_pkt_rtm_total_len(cur_ooo_entry) == rxr_pkt_rtm_total_len(ooo_entry));
 		rxr_pkt_entry_append(cur_ooo_entry, ooo_entry);

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -191,14 +191,14 @@ int rxr_ep_post_user_recv_buf(struct rxr_ep *ep, struct rxr_op_entry *rx_entry, 
 	 *    rx_entry->total_len - sizeof(struct rxr_pkt_entry)
 	 * because the first part of user buffer was used to
 	 * construct pkt_entry. The actual receiving buffer
-	 * posted to device starts from pkt_entry->pkt.
+	 * posted to device starts from pkt_entry->wiredata.
 	 */
 	pkt_entry->pkt_size = rx_entry->iov[0].iov_len - sizeof(struct rxr_pkt_entry);
 
 	pkt_entry->x_entry = rx_entry;
 	rx_entry->state = RXR_RX_MATCHED;
 
-	msg_iov.iov_base = pkt_entry->pkt;
+	msg_iov.iov_base = pkt_entry->wiredata;
 	msg_iov.iov_len = pkt_entry->pkt_size;
 	assert(msg_iov.iov_len <= ep->mtu_size);
 

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -715,7 +715,7 @@ struct rxr_op_entry *rxr_msg_split_rx_entry(struct rxr_ep *ep,
 	uint64_t tag, ignore;
 	struct fi_msg msg = {0};
 
-	assert(rxr_get_base_hdr(pkt_entry->pkt)->type >= RXR_REQ_PKT_BEGIN);
+	assert(rxr_get_base_hdr(pkt_entry->wiredata)->type >= RXR_REQ_PKT_BEGIN);
 
 	if (!consumer_entry) {
 		tag = 0;

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -1139,7 +1139,9 @@ void rxr_pkt_handle_recv_completion(struct rxr_ep *ep,
 	if (pkt_entry->addr == FI_ADDR_NOTAVAIL) {
 		FI_WARN(&rxr_prov, FI_LOG_CQ,
 			"Warning: ignoring a received packet from a removed address. packet type: %" PRIu8
-			", packet flags: %x\n", rxr_get_base_hdr(pkt_entry->pkt)->type, rxr_get_base_hdr(pkt_entry->pkt)->flags);
+			", packet flags: %x\n",
+			rxr_get_base_hdr(pkt_entry->pkt)->type,
+			rxr_get_base_hdr(pkt_entry->pkt)->flags);
 		rxr_pkt_entry_release_rx(ep, pkt_entry);
 		return;
 	}

--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -63,14 +63,14 @@ struct rxr_pkt_entry *rxr_pkt_entry_alloc(struct rxr_ep *ep, struct rxr_pkt_pool
 	memset(pkt_entry, 0, sizeof(*pkt_entry));
 #endif
 
-	pkt_entry->pkt = ofi_buf_alloc_ex(pkt_pool->wiredata_pool, &mr);
-	if (!pkt_entry->pkt) {
+	pkt_entry->wiredata = ofi_buf_alloc_ex(pkt_pool->wiredata_pool, &mr);
+	if (!pkt_entry->wiredata) {
 		ofi_buf_free(pkt_entry);
 		return NULL;
 	}
 
 #ifdef ENABLE_EFA_POISONING
-	memset(pkt_entry->pkt, 0, ep->mtu_size);
+	memset(pkt_entry->wiredata, 0, ep->mtu_size);
 #endif
 
 	dlist_init(&pkt_entry->entry);
@@ -91,7 +91,7 @@ struct rxr_pkt_entry *rxr_pkt_entry_alloc(struct rxr_ep *ep, struct rxr_pkt_pool
 
 void rxr_pkt_entry_release(struct rxr_pkt_entry *pkt_entry)
 {
-	ofi_buf_free(pkt_entry->pkt);
+	ofi_buf_free(pkt_entry->wiredata);
 	ofi_buf_free(pkt_entry);
 }
 
@@ -191,7 +191,7 @@ void rxr_pkt_entry_copy(struct rxr_ep *ep,
 	dest->flags = RXR_PKT_ENTRY_IN_USE;
 	dest->next = NULL;
 	assert(src->pkt_size > 0);
-	memcpy(dest->pkt, src->pkt, src->pkt_size);
+	memcpy(dest->wiredata, src->wiredata, src->pkt_size);
 }
 
 /*
@@ -337,7 +337,7 @@ ssize_t rxr_pkt_entry_sendmsg(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry
 #if ENABLE_DEBUG
 	dlist_insert_tail(&pkt_entry->dbg_entry, &ep->tx_pkt_list);
 #ifdef ENABLE_RXR_PKT_DUMP
-	rxr_pkt_print("Sent", ep, (struct rxr_base_hdr *)pkt_entry->pkt);
+	rxr_pkt_print("Sent", ep, (struct rxr_base_hdr *)pkt_entry->wiredata);
 #endif
 #endif
 	if (pkt_entry->alloc_type == RXR_PKT_FROM_SHM_TX_POOL) {

--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -39,6 +39,7 @@
 #include <ofi_iov.h>
 
 #include "efa.h"
+#include "rxr.h"
 #include "rxr_msg.h"
 #include "rxr_rma.h"
 #include "rxr_op_entry.h"
@@ -47,55 +48,72 @@
 /*
  *   General purpose utility functions
  */
-struct rxr_pkt_entry *rxr_pkt_entry_alloc(struct rxr_ep *ep,
-					  struct ofi_bufpool *pkt_pool,
-					  enum rxr_pkt_entry_alloc_type alloc_type)
+
+struct rxr_pkt_entry *rxr_pkt_entry_alloc(struct rxr_ep *ep, struct rxr_pkt_pool *pkt_pool,
+			enum rxr_pkt_entry_alloc_type alloc_type)
 {
 	struct rxr_pkt_entry *pkt_entry;
 	void *mr = NULL;
 
-	pkt_entry = ofi_buf_alloc_ex(pkt_pool, &mr);
+	pkt_entry = ofi_buf_alloc_ex(pkt_pool->localinfo_pool, &mr);
 	if (!pkt_entry)
 		return NULL;
 
 #ifdef ENABLE_EFA_POISONING
 	memset(pkt_entry, 0, sizeof(*pkt_entry));
 #endif
-	dlist_init(&pkt_entry->entry);
-#if ENABLE_DEBUG
-	dlist_init(&pkt_entry->dbg_entry);
-#endif
-	pkt_entry->mr = (struct fid_mr *) mr;
+
+	pkt_entry->pkt = ofi_buf_alloc_ex(pkt_pool->wiredata_pool, &mr);
+	if (!pkt_entry->pkt) {
+		ofi_buf_free(pkt_entry);
+		return NULL;
+	}
+
 #ifdef ENABLE_EFA_POISONING
 	memset(pkt_entry->pkt, 0, ep->mtu_size);
 #endif
+
+	dlist_init(&pkt_entry->entry);
+
+#if ENABLE_DEBUG
+	dlist_init(&pkt_entry->dbg_entry);
+#endif
+
+	pkt_entry->mr = mr;
 	pkt_entry->alloc_type = alloc_type;
 	pkt_entry->flags = RXR_PKT_ENTRY_IN_USE;
 	pkt_entry->next = NULL;
 	pkt_entry->x_entry = NULL;
+	pkt_entry->send.iov_count = 0; /* rxr_pkt_init methods expect iov_count = 0 */
+
 	return pkt_entry;
+}
+
+void rxr_pkt_entry_release(struct rxr_pkt_entry *pkt_entry)
+{
+	ofi_buf_free(pkt_entry->pkt);
+	ofi_buf_free(pkt_entry);
 }
 
 /**
  * @brief release a TX packet entry
  *
  * @param[in]     ep  the end point
- * @param[in,out] pkt the pkt_entry to be released
+ * @param[in,out] pkt_entry the pkt_entry to be released
  */
-void rxr_pkt_entry_release_tx(struct rxr_ep *ep,
-			      struct rxr_pkt_entry *pkt)
+void rxr_pkt_entry_release_tx(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 {
 	struct rdm_peer *peer;
 
 #if ENABLE_DEBUG
-	dlist_remove(&pkt->dbg_entry);
+	dlist_remove(&pkt_entry->dbg_entry);
 #endif
 	/*
 	 * Decrement rnr_queued_pkts counter and reset backoff for this peer if
 	 * we get a send completion for a retransmitted packet.
 	 */
-	if (OFI_UNLIKELY(pkt->flags & RXR_PKT_ENTRY_RNR_RETRANSMIT)) {
-		peer = rxr_ep_get_peer(ep, pkt->addr);
+	if (OFI_UNLIKELY(pkt_entry->flags & RXR_PKT_ENTRY_RNR_RETRANSMIT)) {
+		peer = rxr_ep_get_peer(ep, pkt_entry->addr);
 		assert(peer);
 		peer->rnr_queued_pkt_cnt--;
 		peer->rnr_backoff_wait_time = 0;
@@ -105,17 +123,13 @@ void rxr_pkt_entry_release_tx(struct rxr_ep *ep,
 		}
 		FI_DBG(&rxr_prov, FI_LOG_EP_DATA,
 		       "reset backoff timer for peer: %" PRIu64 "\n",
-		       pkt->addr);
-	}
-	if (pkt->send) {
-		ofi_buf_free(pkt->send);
-		pkt->send = NULL;
+		       pkt_entry->addr);
 	}
 #ifdef ENABLE_EFA_POISONING
-	rxr_poison_mem_region((uint32_t *)pkt, ep->tx_pkt_pool_entry_sz);
+	rxr_poison_pkt_entry(pkt_entry, ep->mtu_size);
 #endif
-	pkt->flags = 0;
-	ofi_buf_free(pkt);
+	pkt_entry->flags = 0;
+	rxr_pkt_entry_release(pkt_entry);
 }
 
 /*
@@ -150,10 +164,10 @@ void rxr_pkt_entry_release_rx(struct rxr_ep *ep,
 #endif
 #ifdef ENABLE_EFA_POISONING
 	/* the same pool size is used for all types of rx pkt_entries */
-	rxr_poison_mem_region((uint32_t *)pkt_entry, ep->rx_pkt_pool_entry_sz);
+	rxr_poison_pkt_entry(pkt_entry, ep->mtu_size);
 #endif
 	pkt_entry->flags = 0;
-	ofi_buf_free(pkt_entry);
+	rxr_pkt_entry_release(pkt_entry);
 }
 
 void rxr_pkt_entry_copy(struct rxr_ep *ep,
@@ -230,17 +244,17 @@ void rxr_pkt_entry_release_cloned(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_e
 		assert(pkt_entry->alloc_type == RXR_PKT_FROM_OOO_POOL ||
 		       pkt_entry->alloc_type == RXR_PKT_FROM_UNEXP_POOL);
 #ifdef ENABLE_EFA_POISONING
-		rxr_poison_mem_region((uint32_t *)pkt_entry, ep->tx_pkt_pool_entry_sz);
+	rxr_poison_pkt_entry(pkt_entry, ep->mtu_size);
 #endif
 		pkt_entry->flags = 0;
-		ofi_buf_free(pkt_entry);
+		rxr_pkt_entry_release(pkt_entry);
 		next = pkt_entry->next;
 		pkt_entry = next;
 	}
 }
 
 struct rxr_pkt_entry *rxr_pkt_entry_clone(struct rxr_ep *ep,
-					  struct ofi_bufpool *pkt_pool,
+					  struct rxr_pkt_pool *pkt_pool,
 					  enum rxr_pkt_entry_alloc_type alloc_type,
 					  struct rxr_pkt_entry *src)
 {
@@ -362,10 +376,10 @@ ssize_t rxr_pkt_entry_send(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry,
 	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
 	assert(peer);
 
-	if (pkt_entry->send && pkt_entry->send->iov_count > 0) {
-		msg.msg_iov = pkt_entry->send->iov;
-		msg.iov_count = pkt_entry->send->iov_count;
-		msg.desc = pkt_entry->send->desc;
+	if (pkt_entry->send.iov_count > 0) {
+		msg.msg_iov = pkt_entry->send.iov;
+		msg.iov_count = pkt_entry->send.iov_count;
+		msg.desc = pkt_entry->send.desc;
 	} else {
 		iov.iov_base = rxr_pkt_start(pkt_entry);
 		iov.iov_len = pkt_entry->pkt_size;

--- a/prov/efa/src/rxr/rxr_pkt_entry.h
+++ b/prov/efa/src/rxr/rxr_pkt_entry.h
@@ -106,12 +106,12 @@ struct rxr_pkt_entry {
 	struct rxr_pkt_entry *next;
 	struct rxr_pkt_sendv send;
 
-	char *pkt; /* rxr_ctrl_*_pkt, or rxr_data_pkt */
+	char *wiredata; /* rxr_ctrl_*_pkt, or rxr_data_pkt */
 };
 
 static inline void *rxr_pkt_start(struct rxr_pkt_entry *pkt_entry)
 {
-	return pkt_entry->pkt;
+	return pkt_entry->wiredata;
 }
 
 OFI_DECL_RECVWIN_BUF(struct rxr_pkt_entry*, rxr_robuf, uint32_t);

--- a/prov/efa/src/rxr/rxr_pkt_pool.c
+++ b/prov/efa/src/rxr/rxr_pkt_pool.c
@@ -87,7 +87,7 @@ int rxr_pkt_pool_create(struct rxr_ep *ep, size_t size, size_t chunk_cnt,
 	if (ret)
 		return ret;
 
-	struct ofi_bufpool_attr pkt_attr = {
+	struct ofi_bufpool_attr wiredata_attr = {
 		.size = ep->mtu_size,
 		.alignment = RXR_BUF_POOL_ALIGNMENT,
 		.max_cnt = max_cnt,
@@ -98,7 +98,7 @@ int rxr_pkt_pool_create(struct rxr_ep *ep, size_t size, size_t chunk_cnt,
 		.context = rxr_ep_domain(ep),
 		.flags = flags,
 	};
-	ret = ofi_bufpool_create_attr(&pkt_attr, &pool->wiredata_pool);
+	ret = ofi_bufpool_create_attr(&wiredata_attr, &pool->wiredata_pool);
 	if (ret) {
 		ofi_bufpool_destroy(pool->localinfo_pool);
 		return ret;

--- a/prov/efa/src/rxr/rxr_pkt_pool.c
+++ b/prov/efa/src/rxr/rxr_pkt_pool.c
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2019-2022 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "efa.h"
+
+static int rxr_pkt_pool_mr_reg_hndlr(struct ofi_bufpool_region *region)
+{
+	size_t ret;
+	struct fid_mr *mr;
+	struct efa_domain *domain = region->pool->attr.context;
+
+	ret = fi_mr_reg(&domain->util_domain.domain_fid, region->alloc_region,
+			region->pool->alloc_size, FI_SEND | FI_RECV, 0, 0, 0,
+			&mr, NULL);
+
+	region->context = mr;
+	return ret;
+}
+
+static void rxr_pkt_pool_mr_dereg_hndlr(struct ofi_bufpool_region *region)
+{
+	ssize_t ret;
+
+	ret = fi_close((struct fid *)region->context);
+	if (ret)
+		FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,
+			"Unable to deregister memory in a buf pool: %s\n",
+			fi_strerror(-ret));
+}
+
+/*
+ * rxr_pkt_pool_create creates a packet pool. The pool is allowed to grow if
+ * max_cnt is 0 and is fixed size otherwise.
+ *
+ * Important arguments:
+ *      size: packet entry size
+ *      flags: caller can specify OFI_BUFPOOL_HUGEPAGES so the pool
+ *             will be backed by huge pages.
+ * 	    mr: whether memory registration for the wiredata pool is required
+ */
+int rxr_pkt_pool_create(struct rxr_ep *ep, size_t size, size_t chunk_cnt,
+			size_t max_cnt, size_t flags, bool mr,
+			struct rxr_pkt_pool **pkt_pool)
+{
+	int ret;
+	struct rxr_pkt_pool *pool;
+
+	pool = calloc(1, sizeof(**pkt_pool));
+	if (!pool)
+		return -FI_ENOMEM;
+
+	pool->flags = flags;
+
+	ret = ofi_bufpool_create(&pool->localinfo_pool, size,
+				 RXR_BUF_POOL_ALIGNMENT, max_cnt, chunk_cnt,
+				 flags);
+	if (ret)
+		return ret;
+
+	struct ofi_bufpool_attr pkt_attr = {
+		.size = ep->mtu_size,
+		.alignment = RXR_BUF_POOL_ALIGNMENT,
+		.max_cnt = max_cnt,
+		.chunk_cnt = chunk_cnt,
+		.alloc_fn = mr ? rxr_pkt_pool_mr_reg_hndlr : NULL,
+		.free_fn = mr ? rxr_pkt_pool_mr_dereg_hndlr : NULL,
+		.init_fn = NULL,
+		.context = rxr_ep_domain(ep),
+		.flags = flags,
+	};
+	ret = ofi_bufpool_create_attr(&pkt_attr, &pool->wiredata_pool);
+	if (ret) {
+		ofi_bufpool_destroy(pool->localinfo_pool);
+		return ret;
+	}
+
+	*pkt_pool = pool;
+	return 0;
+}
+
+int rxr_pkt_pool_grow(struct rxr_pkt_pool *rxr_pkt_pool)
+{
+	int err;
+
+	err = ofi_bufpool_grow(rxr_pkt_pool->localinfo_pool);
+	if (err)
+		return err;
+
+	err = ofi_bufpool_grow(rxr_pkt_pool->wiredata_pool);
+	if (err)
+		return err;
+
+	return 0;
+}
+
+/*
+ * rxr_pkt_pool_destroy frees the packet pool
+ */
+void rxr_pkt_pool_destroy(struct rxr_pkt_pool *pkt_pool)
+{
+	ofi_bufpool_destroy(pkt_pool->localinfo_pool);
+	ofi_bufpool_destroy(pkt_pool->wiredata_pool);
+
+	free(pkt_pool);
+}

--- a/prov/efa/src/rxr/rxr_pkt_pool.h
+++ b/prov/efa/src/rxr/rxr_pkt_pool.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2019-2022 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _RXR_PKT_POOL_H
+#define _RXR_PKT_POOL_H
+
+#include <stddef.h>
+
+/* Forward declaration to avoid circular dependency */
+struct rxr_ep;
+
+struct rxr_pkt_pool {
+	struct ofi_bufpool *localinfo_pool;
+	struct ofi_bufpool *wiredata_pool;
+
+	int flags;
+};
+
+int rxr_pkt_pool_create(struct rxr_ep *ep, size_t size, size_t chunk_cnt,
+			size_t max_cnt, size_t flags, bool mr,
+			struct rxr_pkt_pool **pkt_pool);
+
+int rxr_pkt_pool_grow(struct rxr_pkt_pool *rxr_pkt_pool);
+
+void rxr_pkt_pool_destroy(struct rxr_pkt_pool *pkt_pool);
+
+#endif

--- a/prov/efa/src/rxr/rxr_pkt_type_data.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_data.c
@@ -46,7 +46,7 @@ int rxr_pkt_init_data(struct rxr_ep *ep,
 	size_t hdr_size;
 	int ret;
 
-	data_hdr = rxr_get_data_hdr(pkt_entry->pkt);
+	data_hdr = rxr_get_data_hdr(pkt_entry->wiredata);
 	data_hdr->type = RXR_DATA_PKT;
 	data_hdr->version = RXR_PROTOCOL_VERSION;
 	data_hdr->flags = 0;
@@ -96,7 +96,7 @@ void rxr_pkt_handle_data_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry
 	struct rxr_op_entry *op_entry;
 	struct rxr_data_hdr *data_hdr;
 
-	data_hdr = rxr_get_data_hdr(pkt_entry->pkt);
+	data_hdr = rxr_get_data_hdr(pkt_entry->wiredata);
 	assert(data_hdr->seg_length > 0);
 
 	op_entry = pkt_entry->x_entry;
@@ -112,7 +112,7 @@ void rxr_pkt_handle_data_send_completion(struct rxr_ep *ep,
 
 	op_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
 	op_entry->bytes_acked +=
-		rxr_get_data_hdr(pkt_entry->pkt)->seg_length;
+		rxr_get_data_hdr(pkt_entry->wiredata)->seg_length;
 
 	if (op_entry->total_len == op_entry->bytes_acked) {
 		if (!(op_entry->rxr_flags & RXR_DELIVERY_COMPLETE_REQUESTED))
@@ -150,7 +150,7 @@ void rxr_pkt_proc_data(struct rxr_ep *ep,
 	ssize_t err;
 
 #if ENABLE_DEBUG
-	int pkt_type = rxr_get_base_hdr(pkt_entry->pkt)->type;
+	int pkt_type = rxr_get_base_hdr(pkt_entry->wiredata)->type;
 
 	assert(pkt_type == RXR_DATA_PKT || pkt_type == RXR_READRSP_PKT);
 #endif
@@ -195,7 +195,7 @@ void rxr_pkt_handle_data_recv(struct rxr_ep *ep,
 	struct rxr_op_entry *op_entry;
 	size_t hdr_size;
 
-	data_hdr = rxr_get_data_hdr(pkt_entry->pkt);
+	data_hdr = rxr_get_data_hdr(pkt_entry->wiredata);
 
 	op_entry = ofi_bufpool_get_ibuf(ep->op_entry_pool,
 					data_hdr->recv_id);
@@ -206,7 +206,7 @@ void rxr_pkt_handle_data_recv(struct rxr_ep *ep,
 
 	rxr_pkt_proc_data(ep, op_entry,
 			  pkt_entry,
-			  pkt_entry->pkt + hdr_size,
+			  pkt_entry->wiredata + hdr_size,
 			  data_hdr->seg_offset,
 			  data_hdr->seg_length);
 }

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -58,7 +58,7 @@ ssize_t rxr_pkt_init_handshake(struct rxr_ep *ep,
 	struct rxr_handshake_hdr *handshake_hdr;
 	struct rxr_handshake_opt_connid_hdr *connid_hdr;
 
-	handshake_hdr = (struct rxr_handshake_hdr *)pkt_entry->pkt;
+	handshake_hdr = (struct rxr_handshake_hdr *)pkt_entry->wiredata;
 	handshake_hdr->type = RXR_HANDSHAKE_PKT;
 	handshake_hdr->version = RXR_PROTOCOL_VERSION;
 	handshake_hdr->flags = 0;
@@ -76,7 +76,7 @@ ssize_t rxr_pkt_init_handshake(struct rxr_ep *ep,
 	 * Always include connid at the end of a handshake packet.
 	 * If peer cannot make use of connid, the connid will be ignored.
 	 */
-	connid_hdr = (struct rxr_handshake_opt_connid_hdr *)(pkt_entry->pkt + pkt_entry->pkt_size);
+	connid_hdr = (struct rxr_handshake_opt_connid_hdr *)(pkt_entry->wiredata + pkt_entry->pkt_size);
 	connid_hdr->connid = rxr_ep_raw_addr(ep)->qkey;
 	handshake_hdr->flags |= RXR_PKT_CONNID_HDR;
 	pkt_entry->pkt_size += sizeof(struct rxr_handshake_opt_connid_hdr);
@@ -177,7 +177,7 @@ void rxr_pkt_handle_handshake_recv(struct rxr_ep *ep,
 	assert(peer);
 	assert(!(peer->flags & RXR_PEER_HANDSHAKE_RECEIVED));
 
-	handshake_pkt = (struct rxr_handshake_hdr *)pkt_entry->pkt;
+	handshake_pkt = (struct rxr_handshake_hdr *)pkt_entry->wiredata;
 
 	/* nextra_p3 is number of members in extra_info plus 3.
 	 * See section 2.1 of protocol v4 document for detail
@@ -200,7 +200,7 @@ ssize_t rxr_pkt_init_cts(struct rxr_ep *ep,
 	struct rxr_cts_hdr *cts_hdr;
 	size_t bytes_left;
 
-	cts_hdr = (struct rxr_cts_hdr *)pkt_entry->pkt;
+	cts_hdr = (struct rxr_cts_hdr *)pkt_entry->wiredata;
 	cts_hdr->type = RXR_CTS_PKT;
 	cts_hdr->version = RXR_PROTOCOL_VERSION;
 	cts_hdr->flags = 0;
@@ -246,7 +246,7 @@ void rxr_pkt_handle_cts_sent(struct rxr_ep *ep,
 	struct rxr_op_entry *op_entry;
 
 	op_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
-	op_entry->window = rxr_get_cts_hdr(pkt_entry->pkt)->recv_length;
+	op_entry->window = rxr_get_cts_hdr(pkt_entry->wiredata)->recv_length;
 }
 
 void rxr_pkt_handle_cts_recv(struct rxr_ep *ep,
@@ -255,7 +255,7 @@ void rxr_pkt_handle_cts_recv(struct rxr_ep *ep,
 	struct rxr_cts_hdr *cts_pkt;
 	struct rxr_op_entry *op_entry;
 
-	cts_pkt = (struct rxr_cts_hdr *)pkt_entry->pkt;
+	cts_pkt = (struct rxr_cts_hdr *)pkt_entry->wiredata;
 	op_entry = ofi_bufpool_get_ibuf(ep->op_entry_pool, cts_pkt->send_id);
 
 	op_entry->rx_id = cts_pkt->recv_id;
@@ -278,7 +278,7 @@ int rxr_pkt_init_readrsp(struct rxr_ep *ep,
 	struct rxr_readrsp_hdr *readrsp_hdr;
 	int ret;
 
-	readrsp_hdr = rxr_get_readrsp_hdr(pkt_entry->pkt);
+	readrsp_hdr = rxr_get_readrsp_hdr(pkt_entry->wiredata);
 	readrsp_hdr->type = RXR_READRSP_PKT;
 	readrsp_hdr->version = RXR_PROTOCOL_VERSION;
 	readrsp_hdr->flags = 0;
@@ -302,7 +302,7 @@ void rxr_pkt_handle_readrsp_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_en
 
 	efa_domain = rxr_ep_domain(ep);
 	rx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
-	data_len = rxr_get_readrsp_hdr(pkt_entry->pkt)->seg_length;
+	data_len = rxr_get_readrsp_hdr(pkt_entry->wiredata)->seg_length;
 	rx_entry->bytes_sent += data_len;
 	rx_entry->window -= data_len;
 	assert(rx_entry->window >= 0);
@@ -327,7 +327,7 @@ void rxr_pkt_handle_readrsp_send_completion(struct rxr_ep *ep,
 	struct rxr_op_entry *rx_entry;
 	struct rxr_readrsp_hdr *readrsp_hdr;
 
-	readrsp_hdr = (struct rxr_readrsp_hdr *)pkt_entry->pkt;
+	readrsp_hdr = (struct rxr_readrsp_hdr *)pkt_entry->wiredata;
 
 	rx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
 	assert(rx_entry->cq_entry.flags & FI_READ);
@@ -343,7 +343,7 @@ void rxr_pkt_handle_readrsp_recv(struct rxr_ep *ep,
 	struct rxr_readrsp_hdr *readrsp_hdr = NULL;
 	struct rxr_op_entry *tx_entry = NULL;
 
-	readrsp_pkt = (struct rxr_readrsp_pkt *)pkt_entry->pkt;
+	readrsp_pkt = (struct rxr_readrsp_pkt *)pkt_entry->wiredata;
 	readrsp_hdr = &readrsp_pkt->hdr;
 	tx_entry = ofi_bufpool_get_ibuf(ep->op_entry_pool, readrsp_hdr->recv_id);
 	assert(tx_entry->cq_entry.flags & FI_READ);
@@ -365,7 +365,7 @@ void rxr_pkt_init_write_context(struct rxr_op_entry *tx_entry,
 	struct rxr_rma_context_pkt *rma_context_pkt;
 
 	pkt_entry->x_entry = (void *)tx_entry;
-	rma_context_pkt = (struct rxr_rma_context_pkt *)pkt_entry->pkt;
+	rma_context_pkt = (struct rxr_rma_context_pkt *)pkt_entry->wiredata;
 	rma_context_pkt->type = RXR_RMA_CONTEXT_PKT;
 	rma_context_pkt->version = RXR_PROTOCOL_VERSION;
 	rma_context_pkt->context_type = RXR_WRITE_CONTEXT;
@@ -383,7 +383,7 @@ void rxr_pkt_init_read_context(struct rxr_ep *rxr_ep,
 	pkt_entry->addr = read_entry->addr;
 	pkt_entry->pkt_size = sizeof(struct rxr_rma_context_pkt);
 
-	ctx_pkt = (struct rxr_rma_context_pkt *)pkt_entry->pkt;
+	ctx_pkt = (struct rxr_rma_context_pkt *)pkt_entry->wiredata;
 	ctx_pkt->type = RXR_RMA_CONTEXT_PKT;
 	ctx_pkt->flags = 0;
 	ctx_pkt->version = RXR_PROTOCOL_VERSION;
@@ -404,7 +404,7 @@ void rxr_pkt_handle_rma_read_completion(struct rxr_ep *ep,
 	size_t data_size;
 	int err;
 
-	rma_context_pkt = (struct rxr_rma_context_pkt *)context_pkt_entry->pkt;
+	rma_context_pkt = (struct rxr_rma_context_pkt *)context_pkt_entry->wiredata;
 	assert(rma_context_pkt->type == RXR_RMA_CONTEXT_PKT);
 	assert(rma_context_pkt->context_type == RXR_READ_CONTEXT);
 
@@ -460,9 +460,9 @@ void rxr_pkt_handle_rma_completion(struct rxr_ep *ep,
 	struct rxr_op_entry *tx_entry = NULL;
 	struct rxr_rma_context_pkt *rma_context_pkt;
 
-	assert(rxr_get_base_hdr(context_pkt_entry->pkt)->version == RXR_PROTOCOL_VERSION);
+	assert(rxr_get_base_hdr(context_pkt_entry->wiredata)->version == RXR_PROTOCOL_VERSION);
 
-	rma_context_pkt = (struct rxr_rma_context_pkt *)context_pkt_entry->pkt;
+	rma_context_pkt = (struct rxr_rma_context_pkt *)context_pkt_entry->wiredata;
 
 	switch (rma_context_pkt->context_type) {
 	case RXR_WRITE_CONTEXT:
@@ -491,7 +491,7 @@ int rxr_pkt_init_eor(struct rxr_ep *ep, struct rxr_op_entry *rx_entry, struct rx
 {
 	struct rxr_eor_hdr *eor_hdr;
 
-	eor_hdr = (struct rxr_eor_hdr *)pkt_entry->pkt;
+	eor_hdr = (struct rxr_eor_hdr *)pkt_entry->wiredata;
 	eor_hdr->type = RXR_EOR_PKT;
 	eor_hdr->version = RXR_PROTOCOL_VERSION;
 	eor_hdr->flags = 0;
@@ -511,7 +511,7 @@ void rxr_pkt_handle_eor_send_completion(struct rxr_ep *ep,
 	struct rxr_op_entry *rx_entry;
 
 	rx_entry = pkt_entry->x_entry;
-	assert(rx_entry && rx_entry->rx_id == rxr_get_eor_hdr(pkt_entry->pkt)->recv_id);
+	assert(rx_entry && rx_entry->rx_id == rxr_get_eor_hdr(pkt_entry->wiredata)->recv_id);
 
 	if (rx_entry->bytes_copied == rx_entry->total_len) {
 		rxr_release_rx_entry(ep, rx_entry);
@@ -535,7 +535,7 @@ void rxr_pkt_handle_eor_recv(struct rxr_ep *ep,
 	assert(peer);
 	peer->num_read_msg_in_flight -= 1;
 
-	eor_hdr = (struct rxr_eor_hdr *)pkt_entry->pkt;
+	eor_hdr = (struct rxr_eor_hdr *)pkt_entry->wiredata;
 
 	/* pre-post buf used here, so can NOT track back to tx_entry with x_entry */
 	tx_entry = ofi_bufpool_get_ibuf(ep->op_entry_pool, eor_hdr->send_id);
@@ -556,7 +556,7 @@ int rxr_pkt_init_receipt(struct rxr_ep *ep, struct rxr_op_entry *rx_entry,
 {
 	struct rxr_receipt_hdr *receipt_hdr;
 
-	receipt_hdr = rxr_get_receipt_hdr(pkt_entry->pkt);
+	receipt_hdr = rxr_get_receipt_hdr(pkt_entry->wiredata);
 	receipt_hdr->type = RXR_RECEIPT_PKT;
 	receipt_hdr->version = RXR_PROTOCOL_VERSION;
 	receipt_hdr->flags = 0;
@@ -602,7 +602,7 @@ int rxr_pkt_init_atomrsp(struct rxr_ep *ep, struct rxr_op_entry *rx_entry,
 	pkt_entry->addr = rx_entry->addr;
 	pkt_entry->x_entry = rx_entry;
 
-	atomrsp_pkt = (struct rxr_atomrsp_pkt *)pkt_entry->pkt;
+	atomrsp_pkt = (struct rxr_atomrsp_pkt *)pkt_entry->wiredata;
 	atomrsp_hdr = &atomrsp_pkt->hdr;
 	atomrsp_hdr->type = RXR_ATOMRSP_PKT;
 	atomrsp_hdr->version = RXR_PROTOCOL_VERSION;
@@ -640,7 +640,7 @@ void rxr_pkt_handle_atomrsp_recv(struct rxr_ep *ep,
 	struct rxr_op_entry *tx_entry = NULL;
 	ssize_t ret;
 
-	atomrsp_pkt = (struct rxr_atomrsp_pkt *)pkt_entry->pkt;
+	atomrsp_pkt = (struct rxr_atomrsp_pkt *)pkt_entry->wiredata;
 	atomrsp_hdr = &atomrsp_pkt->hdr;
 	tx_entry = ofi_bufpool_get_ibuf(ep->op_entry_pool, atomrsp_hdr->recv_id);
 
@@ -667,7 +667,7 @@ void rxr_pkt_handle_receipt_recv(struct rxr_ep *ep,
 	struct rxr_op_entry *tx_entry = NULL;
 	struct rxr_receipt_hdr *receipt_hdr;
 
-	receipt_hdr = rxr_get_receipt_hdr(pkt_entry->pkt);
+	receipt_hdr = rxr_get_receipt_hdr(pkt_entry->wiredata);
 	/* Retrieve the tx_entry that will be written into TX CQ*/
 	tx_entry = ofi_bufpool_get_ibuf(ep->op_entry_pool,
 					receipt_hdr->tx_id);

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -260,6 +260,7 @@ void rxr_pkt_handle_cts_recv(struct rxr_ep *ep,
 
 	op_entry->rx_id = cts_pkt->recv_id;
 	op_entry->window = cts_pkt->recv_length;
+	assert(op_entry->window > 0);
 
 	rxr_pkt_entry_release_rx(ep, pkt_entry);
 

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -107,13 +107,13 @@ size_t rxr_pkt_req_data_offset(struct rxr_pkt_entry *pkt_entry)
 	int pkt_type, read_iov_count;
 	size_t pkt_data_offset;
 
-	pkt_type = rxr_get_base_hdr(pkt_entry->pkt)->type;
+	pkt_type = rxr_get_base_hdr(pkt_entry->wiredata)->type;
 	pkt_data_offset = rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
 	assert(pkt_data_offset > 0);
 
 	if (pkt_type == RXR_RUNTREAD_MSGRTM_PKT ||
 	    pkt_type == RXR_RUNTREAD_TAGRTM_PKT) {
-		read_iov_count = rxr_get_runtread_rtm_base_hdr(pkt_entry->pkt)->read_iov_count;
+		read_iov_count = rxr_get_runtread_rtm_base_hdr(pkt_entry->wiredata)->read_iov_count;
 		pkt_data_offset +=  read_iov_count * sizeof(struct fi_rma_iov);
 	}
 
@@ -159,7 +159,7 @@ void rxr_pkt_init_req_hdr(struct rxr_ep *ep,
 	struct rxr_base_hdr *base_hdr;
 
 	/* init the base header */
-	base_hdr = rxr_get_base_hdr(pkt_entry->pkt);
+	base_hdr = rxr_get_base_hdr(pkt_entry->wiredata);
 	base_hdr->type = pkt_type;
 	base_hdr->version = RXR_PROTOCOL_VERSION;
 	base_hdr->flags = 0;
@@ -221,7 +221,7 @@ void rxr_pkt_init_req_hdr(struct rxr_ep *ep,
 	}
 
 	pkt_entry->addr = tx_entry->addr;
-	assert(opt_hdr - pkt_entry->pkt == rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry));
+	assert(opt_hdr - pkt_entry->wiredata == rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry));
 }
 
 /**
@@ -233,24 +233,24 @@ void rxr_pkt_init_req_hdr(struct rxr_ep *ep,
  */
 uint32_t rxr_pkt_hdr_rma_iov_count(struct rxr_pkt_entry *pkt_entry)
 {
-	int pkt_type = rxr_get_base_hdr(pkt_entry->pkt)->type;
+	int pkt_type = rxr_get_base_hdr(pkt_entry->wiredata)->type;
 
 	if (pkt_type == RXR_EAGER_RTW_PKT ||
 	    pkt_type == RXR_DC_EAGER_RTW_PKT ||
 	    pkt_type == RXR_LONGCTS_RTW_PKT ||
 	    pkt_type == RXR_DC_LONGCTS_RTW_PKT ||
 	    pkt_type == RXR_LONGREAD_RTW_PKT)
-		return rxr_get_rtw_base_hdr(pkt_entry->pkt)->rma_iov_count;
+		return rxr_get_rtw_base_hdr(pkt_entry->wiredata)->rma_iov_count;
 
 	if (pkt_type == RXR_SHORT_RTR_PKT ||
 		 pkt_type == RXR_LONGCTS_RTR_PKT)
-		return rxr_get_rtr_hdr(pkt_entry->pkt)->rma_iov_count;
+		return rxr_get_rtr_hdr(pkt_entry->wiredata)->rma_iov_count;
 
 	if (pkt_type == RXR_WRITE_RTA_PKT ||
 		 pkt_type == RXR_DC_WRITE_RTA_PKT ||
 		 pkt_type == RXR_FETCH_RTA_PKT ||
 		 pkt_type == RXR_COMPARE_RTA_PKT)
-		return rxr_get_rta_hdr(pkt_entry->pkt)->rma_iov_count;
+		return rxr_get_rta_hdr(pkt_entry->wiredata)->rma_iov_count;
 
 	return 0;
 }
@@ -260,7 +260,7 @@ size_t rxr_pkt_req_base_hdr_size(struct rxr_pkt_entry *pkt_entry)
 	struct rxr_base_hdr *base_hdr;
 	uint32_t rma_iov_count;
 
-	base_hdr = rxr_get_base_hdr(pkt_entry->pkt);
+	base_hdr = rxr_get_base_hdr(pkt_entry->wiredata);
 	assert(base_hdr->type >= RXR_REQ_PKT_BEGIN);
 
 	rma_iov_count = rxr_pkt_hdr_rma_iov_count(pkt_entry);
@@ -281,8 +281,8 @@ void *rxr_pkt_req_raw_addr(struct rxr_pkt_entry *pkt_entry)
 	struct rxr_base_hdr *base_hdr;
 	struct rxr_req_opt_raw_addr_hdr *raw_addr_hdr;
 
-	base_hdr = rxr_get_base_hdr(pkt_entry->pkt);
-	opt_hdr = pkt_entry->pkt + rxr_pkt_req_base_hdr_size(pkt_entry);
+	base_hdr = rxr_get_base_hdr(pkt_entry->wiredata);
+	opt_hdr = pkt_entry->wiredata + rxr_pkt_req_base_hdr_size(pkt_entry);
 	if (base_hdr->flags & RXR_REQ_OPT_RAW_ADDR_HDR) {
 		/* For req packet, the optional connid header and the optional
 		 * raw address header are mutually exclusive.
@@ -308,8 +308,8 @@ uint32_t *rxr_pkt_req_connid_ptr(struct rxr_pkt_entry *pkt_entry)
 	struct rxr_base_hdr *base_hdr;
 	struct rxr_req_opt_connid_hdr *connid_hdr;
 
-	base_hdr = rxr_get_base_hdr(pkt_entry->pkt);
-	opt_hdr = pkt_entry->pkt + rxr_pkt_req_base_hdr_size(pkt_entry);
+	base_hdr = rxr_get_base_hdr(pkt_entry->wiredata);
+	opt_hdr = pkt_entry->wiredata + rxr_pkt_req_base_hdr_size(pkt_entry);
 
 	if (base_hdr->flags & RXR_REQ_OPT_RAW_ADDR_HDR) {
 		struct rxr_req_opt_raw_addr_hdr *raw_addr_hdr;
@@ -352,8 +352,8 @@ size_t rxr_pkt_req_hdr_size_from_pkt_entry(struct rxr_pkt_entry *pkt_entry)
 	struct rxr_base_hdr *base_hdr;
 	struct rxr_req_opt_raw_addr_hdr *raw_addr_hdr;
 
-	base_hdr = rxr_get_base_hdr(pkt_entry->pkt);
-	opt_hdr = pkt_entry->pkt + rxr_pkt_req_base_hdr_size(pkt_entry);
+	base_hdr = rxr_get_base_hdr(pkt_entry->wiredata);
+	opt_hdr = pkt_entry->wiredata + rxr_pkt_req_base_hdr_size(pkt_entry);
 
 	/*
 	 * It is not possible to have both optional raw addr header and optional
@@ -373,7 +373,7 @@ size_t rxr_pkt_req_hdr_size_from_pkt_entry(struct rxr_pkt_entry *pkt_entry)
 		opt_hdr += sizeof(struct rxr_req_opt_connid_hdr);
 	}
 
-	return opt_hdr - pkt_entry->pkt;
+	return opt_hdr - pkt_entry->wiredata;
 }
 
 int64_t rxr_pkt_req_cq_data(struct rxr_pkt_entry *pkt_entry)
@@ -383,8 +383,8 @@ int64_t rxr_pkt_req_cq_data(struct rxr_pkt_entry *pkt_entry)
 	struct rxr_req_opt_cq_data_hdr *cq_data_hdr;
 	struct rxr_req_opt_raw_addr_hdr *raw_addr_hdr;
 
-	base_hdr = rxr_get_base_hdr(pkt_entry->pkt);
-	opt_hdr = pkt_entry->pkt + rxr_pkt_req_base_hdr_size(pkt_entry);
+	base_hdr = rxr_get_base_hdr(pkt_entry->wiredata);
+	opt_hdr = pkt_entry->wiredata + rxr_pkt_req_base_hdr_size(pkt_entry);
 	if (base_hdr->flags & RXR_REQ_OPT_RAW_ADDR_HDR) {
 		raw_addr_hdr = (struct rxr_req_opt_raw_addr_hdr *)opt_hdr;
 		opt_hdr += sizeof(struct rxr_req_opt_raw_addr_hdr) + raw_addr_hdr->addr_len;
@@ -484,7 +484,7 @@ int rxr_pkt_init_rtm(struct rxr_ep *ep,
 
 	rxr_pkt_init_req_hdr(ep, tx_entry, pkt_type, pkt_entry);
 
-	rtm_hdr = (struct rxr_rtm_base_hdr *)pkt_entry->pkt;
+	rtm_hdr = (struct rxr_rtm_base_hdr *)pkt_entry->wiredata;
 	rtm_hdr->flags |= RXR_REQ_MSG;
 	rtm_hdr->msg_id = tx_entry->msg_id;
 
@@ -530,7 +530,7 @@ ssize_t rxr_pkt_init_dc_eager_msgrtm(struct rxr_ep *ep,
 	ret = rxr_pkt_init_rtm(ep, tx_entry, RXR_DC_EAGER_MSGRTM_PKT, 0, pkt_entry);
 	if (ret)
 		return ret;
-	dc_eager_msgrtm_hdr = rxr_get_dc_eager_msgrtm_hdr(pkt_entry->pkt);
+	dc_eager_msgrtm_hdr = rxr_get_dc_eager_msgrtm_hdr(pkt_entry->wiredata);
 	dc_eager_msgrtm_hdr->hdr.send_id = tx_entry->tx_id;
 	return 0;
 }
@@ -546,7 +546,7 @@ ssize_t rxr_pkt_init_eager_tagrtm(struct rxr_ep *ep,
 	if (ret)
 		return ret;
 	assert(tx_entry->total_len == rxr_pkt_req_data_size(pkt_entry));
-	base_hdr = rxr_get_base_hdr(pkt_entry->pkt);
+	base_hdr = rxr_get_base_hdr(pkt_entry->wiredata);
 	base_hdr->flags |= RXR_REQ_TAGGED;
 	rxr_pkt_rtm_settag(pkt_entry, tx_entry->tag);
 	return 0;
@@ -564,11 +564,11 @@ ssize_t rxr_pkt_init_dc_eager_tagrtm(struct rxr_ep *ep,
 	ret = rxr_pkt_init_rtm(ep, tx_entry, RXR_DC_EAGER_TAGRTM_PKT, 0, pkt_entry);
 	if (ret)
 		return ret;
-	base_hdr = rxr_get_base_hdr(pkt_entry->pkt);
+	base_hdr = rxr_get_base_hdr(pkt_entry->wiredata);
 	base_hdr->flags |= RXR_REQ_TAGGED;
 	rxr_pkt_rtm_settag(pkt_entry, tx_entry->tag);
 
-	dc_eager_tagrtm_hdr = rxr_get_dc_eager_tagrtm_hdr(pkt_entry->pkt);
+	dc_eager_tagrtm_hdr = rxr_get_dc_eager_tagrtm_hdr(pkt_entry->wiredata);
 	dc_eager_tagrtm_hdr->hdr.send_id = tx_entry->tx_id;
 	return 0;
 }
@@ -589,7 +589,7 @@ ssize_t rxr_pkt_init_medium_msgrtm(struct rxr_ep *ep,
 	if (ret)
 		return ret;
 
-	rtm_hdr = rxr_get_medium_rtm_base_hdr(pkt_entry->pkt);
+	rtm_hdr = rxr_get_medium_rtm_base_hdr(pkt_entry->wiredata);
 	rtm_hdr->msg_length = tx_entry->total_len;
 	rtm_hdr->seg_offset = tx_entry->bytes_sent;
 	return 0;
@@ -613,7 +613,7 @@ ssize_t rxr_pkt_init_dc_medium_msgrtm(struct rxr_ep *ep,
 	if (ret)
 		return ret;
 
-	dc_medium_msgrtm_hdr = rxr_get_dc_medium_msgrtm_hdr(pkt_entry->pkt);
+	dc_medium_msgrtm_hdr = rxr_get_dc_medium_msgrtm_hdr(pkt_entry->wiredata);
 	dc_medium_msgrtm_hdr->hdr.msg_length = tx_entry->total_len;
 	dc_medium_msgrtm_hdr->hdr.seg_offset = tx_entry->bytes_sent;
 	dc_medium_msgrtm_hdr->hdr.send_id = tx_entry->tx_id;
@@ -636,7 +636,7 @@ ssize_t rxr_pkt_init_medium_tagrtm(struct rxr_ep *ep,
 	if (ret)
 		return ret;
 
-	rtm_hdr = rxr_get_medium_rtm_base_hdr(pkt_entry->pkt);
+	rtm_hdr = rxr_get_medium_rtm_base_hdr(pkt_entry->wiredata);
 	rtm_hdr->msg_length = tx_entry->total_len;
 	rtm_hdr->seg_offset = tx_entry->bytes_sent;
 	rtm_hdr->hdr.flags |= RXR_REQ_TAGGED;
@@ -662,7 +662,7 @@ ssize_t rxr_pkt_init_dc_medium_tagrtm(struct rxr_ep *ep,
 	if (ret)
 		return ret;
 
-	dc_medium_tagrtm_hdr = rxr_get_dc_medium_tagrtm_hdr(pkt_entry->pkt);
+	dc_medium_tagrtm_hdr = rxr_get_dc_medium_tagrtm_hdr(pkt_entry->wiredata);
 	dc_medium_tagrtm_hdr->hdr.msg_length = tx_entry->total_len;
 	dc_medium_tagrtm_hdr->hdr.seg_offset = tx_entry->bytes_sent;
 	dc_medium_tagrtm_hdr->hdr.hdr.flags |= RXR_REQ_TAGGED;
@@ -684,7 +684,7 @@ int rxr_pkt_init_longcts_rtm(struct rxr_ep *ep,
 	if (ret)
 		return ret;
 
-	rtm_hdr = rxr_get_longcts_rtm_base_hdr(pkt_entry->pkt);
+	rtm_hdr = rxr_get_longcts_rtm_base_hdr(pkt_entry->wiredata);
 	rtm_hdr->msg_length = tx_entry->total_len;
 	rtm_hdr->send_id = tx_entry->tx_id;
 	rtm_hdr->credit_request = rxr_env.tx_min_credits;
@@ -717,7 +717,7 @@ ssize_t rxr_pkt_init_longcts_tagrtm(struct rxr_ep *ep,
 	if (ret)
 		return ret;
 
-	base_hdr = rxr_get_base_hdr(pkt_entry->pkt);
+	base_hdr = rxr_get_base_hdr(pkt_entry->wiredata);
 	base_hdr->flags |= RXR_REQ_TAGGED;
 	rxr_pkt_rtm_settag(pkt_entry, tx_entry->tag);
 	return 0;
@@ -734,7 +734,7 @@ ssize_t rxr_pkt_init_dc_longcts_tagrtm(struct rxr_ep *ep,
 	ret = rxr_pkt_init_longcts_rtm(ep, tx_entry, RXR_DC_LONGCTS_TAGRTM_PKT, pkt_entry);
 	if (ret)
 		return ret;
-	base_hdr = rxr_get_base_hdr(pkt_entry->pkt);
+	base_hdr = rxr_get_base_hdr(pkt_entry->wiredata);
 	base_hdr->flags |= RXR_REQ_TAGGED;
 	rxr_pkt_rtm_settag(pkt_entry, tx_entry->tag);
 	return 0;
@@ -752,7 +752,7 @@ ssize_t rxr_pkt_init_longread_rtm(struct rxr_ep *ep,
 
 	rxr_pkt_init_req_hdr(ep, tx_entry, pkt_type, pkt_entry);
 
-	rtm_hdr = rxr_get_longread_rtm_base_hdr(pkt_entry->pkt);
+	rtm_hdr = rxr_get_longread_rtm_base_hdr(pkt_entry->wiredata);
 	rtm_hdr->hdr.flags |= RXR_REQ_MSG;
 	rtm_hdr->hdr.msg_id = tx_entry->msg_id;
 	rtm_hdr->msg_length = tx_entry->total_len;
@@ -760,7 +760,7 @@ ssize_t rxr_pkt_init_longread_rtm(struct rxr_ep *ep,
 	rtm_hdr->read_iov_count = tx_entry->iov_count;
 
 	hdr_size = rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
-	read_iov = (struct fi_rma_iov *)(pkt_entry->pkt + hdr_size);
+	read_iov = (struct fi_rma_iov *)(pkt_entry->wiredata + hdr_size);
 	err = rxr_read_init_iov(ep, tx_entry, read_iov);
 	if (OFI_UNLIKELY(err))
 		return err;
@@ -788,7 +788,7 @@ ssize_t rxr_pkt_init_longread_tagrtm(struct rxr_ep *ep,
 	if (err)
 		return err;
 
-	base_hdr = rxr_get_base_hdr(pkt_entry->pkt);
+	base_hdr = rxr_get_base_hdr(pkt_entry->wiredata);
 	base_hdr->flags |= RXR_REQ_TAGGED;
 	rxr_pkt_rtm_settag(pkt_entry, tx_entry->tag);
 	return 0;
@@ -820,7 +820,7 @@ ssize_t rxr_pkt_init_runtread_rtm(struct rxr_ep *ep,
 
 	rxr_pkt_init_req_hdr(ep, tx_entry, pkt_type, pkt_entry);
 
-	rtm_hdr = rxr_get_runtread_rtm_base_hdr(pkt_entry->pkt);
+	rtm_hdr = rxr_get_runtread_rtm_base_hdr(pkt_entry->wiredata);
 	rtm_hdr->hdr.flags |= RXR_REQ_MSG;
 	rtm_hdr->hdr.msg_id = tx_entry->msg_id;
 	rtm_hdr->msg_length = tx_entry->total_len;
@@ -830,7 +830,7 @@ ssize_t rxr_pkt_init_runtread_rtm(struct rxr_ep *ep,
 	rtm_hdr->read_iov_count = tx_entry->iov_count;
 
 	hdr_size = rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
-	read_iov = (struct fi_rma_iov *)(pkt_entry->pkt + hdr_size);
+	read_iov = (struct fi_rma_iov *)(pkt_entry->wiredata + hdr_size);
 	err = rxr_read_init_iov(ep, tx_entry, read_iov);
 	if (OFI_UNLIKELY(err))
 		return err;
@@ -864,7 +864,7 @@ ssize_t rxr_pkt_init_runtread_tagrtm(struct rxr_ep *ep,
 	if (err)
 		return err;
 
-	base_hdr = rxr_get_base_hdr(pkt_entry->pkt);
+	base_hdr = rxr_get_base_hdr(pkt_entry->wiredata);
 	base_hdr->flags |= RXR_REQ_TAGGED;
 	rxr_pkt_rtm_settag(pkt_entry, tx_entry->tag);
 	return 0;
@@ -927,7 +927,7 @@ void rxr_pkt_handle_runtread_rtm_sent(struct rxr_ep *ep,
 	tx_entry->bytes_sent += pkt_data_size;
 	peer->num_runt_bytes_in_flight += pkt_data_size;
 
-	if (rxr_get_runtread_rtm_base_hdr(pkt_entry->pkt)->seg_offset == 0 &&
+	if (rxr_get_runtread_rtm_base_hdr(pkt_entry->wiredata)->seg_offset == 0 &&
 	    tx_entry->total_len > tx_entry->bytes_runt)
 		peer->num_read_msg_in_flight += 1;
 }
@@ -1005,7 +1005,7 @@ size_t rxr_pkt_rtm_total_len(struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_base_hdr *base_hdr;
 
-	base_hdr = rxr_get_base_hdr(pkt_entry->pkt);
+	base_hdr = rxr_get_base_hdr(pkt_entry->wiredata);
 	switch (base_hdr->type) {
 	case RXR_EAGER_MSGRTM_PKT:
 	case RXR_EAGER_TAGRTM_PKT:
@@ -1014,21 +1014,21 @@ size_t rxr_pkt_rtm_total_len(struct rxr_pkt_entry *pkt_entry)
 		return rxr_pkt_req_data_size(pkt_entry);
 	case RXR_MEDIUM_MSGRTM_PKT:
 	case RXR_MEDIUM_TAGRTM_PKT:
-		return rxr_get_medium_rtm_base_hdr(pkt_entry->pkt)->msg_length;
+		return rxr_get_medium_rtm_base_hdr(pkt_entry->wiredata)->msg_length;
 	case RXR_DC_MEDIUM_MSGRTM_PKT:
 	case RXR_DC_MEDIUM_TAGRTM_PKT:
-		return rxr_get_dc_medium_rtm_base_hdr(pkt_entry->pkt)->msg_length;
+		return rxr_get_dc_medium_rtm_base_hdr(pkt_entry->wiredata)->msg_length;
 	case RXR_LONGCTS_MSGRTM_PKT:
 	case RXR_LONGCTS_TAGRTM_PKT:
 	case RXR_DC_LONGCTS_MSGRTM_PKT:
 	case RXR_DC_LONGCTS_TAGRTM_PKT:
-		return rxr_get_longcts_rtm_base_hdr(pkt_entry->pkt)->msg_length;
+		return rxr_get_longcts_rtm_base_hdr(pkt_entry->wiredata)->msg_length;
 	case RXR_LONGREAD_MSGRTM_PKT:
 	case RXR_LONGREAD_TAGRTM_PKT:
-		return rxr_get_longread_rtm_base_hdr(pkt_entry->pkt)->msg_length;
+		return rxr_get_longread_rtm_base_hdr(pkt_entry->wiredata)->msg_length;
 	case RXR_RUNTREAD_MSGRTM_PKT:
 	case RXR_RUNTREAD_TAGRTM_PKT:
-		return rxr_get_runtread_rtm_base_hdr(pkt_entry->pkt)->msg_length;
+		return rxr_get_runtread_rtm_base_hdr(pkt_entry->wiredata)->msg_length;
 	default:
 		assert(0 && "Unknown REQ packet type\n");
 	}
@@ -1058,7 +1058,7 @@ void rxr_pkt_rtm_update_rx_entry(struct rxr_pkt_entry *pkt_entry,
 {
 	struct rxr_base_hdr *base_hdr;
 
-	base_hdr = rxr_get_base_hdr(pkt_entry->pkt);
+	base_hdr = rxr_get_base_hdr(pkt_entry->wiredata);
 	if (base_hdr->flags & RXR_REQ_OPT_CQ_DATA_HDR) {
 		rx_entry->rxr_flags |= RXR_REMOTE_CQ_DATA;
 		rx_entry->cq_entry.flags |= FI_REMOTE_CQ_DATA;
@@ -1194,7 +1194,7 @@ struct rxr_op_entry *rxr_pkt_get_msgrtm_rx_entry(struct rxr_ep *ep,
 			    (size_t) rx_entry->cq_entry.op_context, rx_entry->total_len);
 	}
 
-	pkt_type = rxr_get_base_hdr((*pkt_entry_ptr)->pkt)->type;
+	pkt_type = rxr_get_base_hdr((*pkt_entry_ptr)->wiredata)->type;
 	if (rxr_pkt_type_is_mulreq(pkt_type))
 		rxr_pkt_rx_map_insert(ep, *pkt_entry_ptr, rx_entry);
 
@@ -1233,7 +1233,7 @@ struct rxr_op_entry *rxr_pkt_get_tagrtm_rx_entry(struct rxr_ep *ep,
 			    (size_t) rx_entry->cq_entry.op_context, rx_entry->total_len);
 	}
 
-	pkt_type = rxr_get_base_hdr((*pkt_entry_ptr)->pkt)->type;
+	pkt_type = rxr_get_base_hdr((*pkt_entry_ptr)->wiredata)->type;
 	if (rxr_pkt_type_is_mulreq(pkt_type))
 		rxr_pkt_rx_map_insert(ep, *pkt_entry_ptr, rx_entry);
 
@@ -1247,8 +1247,8 @@ ssize_t rxr_pkt_proc_matched_longread_rtm(struct rxr_ep *ep,
 	struct rxr_longread_rtm_base_hdr *rtm_hdr;
 	struct fi_rma_iov *read_iov;
 
-	rtm_hdr = rxr_get_longread_rtm_base_hdr(pkt_entry->pkt);
-	read_iov = (struct fi_rma_iov *)(pkt_entry->pkt +
+	rtm_hdr = rxr_get_longread_rtm_base_hdr(pkt_entry->wiredata);
+	read_iov = (struct fi_rma_iov *)(pkt_entry->wiredata +
 									rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry));
 
 	rx_entry->tx_id = rtm_hdr->send_id;
@@ -1272,18 +1272,18 @@ ssize_t rxr_pkt_proc_matched_mulreq_rtm(struct rxr_ep *ep,
 	ssize_t ret, err;
 	size_t rx_data_offset, pkt_data_offset, data_size;
 
-	pkt_type = rxr_get_base_hdr(pkt_entry->pkt)->type;
+	pkt_type = rxr_get_base_hdr(pkt_entry->wiredata)->type;
 
 	if (rxr_pkt_type_is_runtread(pkt_type)) {
 		struct rxr_runtread_rtm_base_hdr *runtread_rtm_hdr;
 
-		runtread_rtm_hdr = rxr_get_runtread_rtm_base_hdr(pkt_entry->pkt);
+		runtread_rtm_hdr = rxr_get_runtread_rtm_base_hdr(pkt_entry->wiredata);
 		rx_entry->bytes_runt = runtread_rtm_hdr->runt_length;
 		if (rx_entry->total_len > rx_entry->bytes_runt && !rx_entry->read_entry) {
 			struct fi_rma_iov *read_iov;
 
 			rx_entry->tx_id = runtread_rtm_hdr->send_id;
-			read_iov = (struct fi_rma_iov *)(pkt_entry->pkt + rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry));
+			read_iov = (struct fi_rma_iov *)(pkt_entry->wiredata + rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry));
 			rx_entry->rma_iov_count = runtread_rtm_hdr->read_iov_count;
 			memcpy(rx_entry->rma_iov, read_iov, rx_entry->rma_iov_count * sizeof(struct fi_rma_iov));
 			rxr_tracing(runtread_read_posted, rx_entry->msg_id,
@@ -1298,10 +1298,10 @@ ssize_t rxr_pkt_proc_matched_mulreq_rtm(struct rxr_ep *ep,
 	cur = pkt_entry;
 	while (cur) {
 		pkt_data_offset = rxr_pkt_req_data_offset(cur);
-		pkt_data = cur->pkt + pkt_data_offset;
+		pkt_data = cur->wiredata + pkt_data_offset;
 		data_size = cur->pkt_size - pkt_data_offset;
 
-		rx_data_offset = rxr_pkt_hdr_seg_offset(cur->pkt);
+		rx_data_offset = rxr_pkt_hdr_seg_offset(cur->wiredata);
 
 		/* rxr_pkt_copy_data_to_op_entry() can release rx_entry, so
 		 * bytes_received must be calculated before it.
@@ -1352,7 +1352,7 @@ ssize_t rxr_pkt_proc_matched_eager_rtm(struct rxr_ep *ep,
 	hdr_size = rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
 
 	if (pkt_entry->alloc_type != RXR_PKT_FROM_USER_BUFFER) {
-		data = pkt_entry->pkt + hdr_size;
+		data = pkt_entry->wiredata + hdr_size;
 		data_size = pkt_entry->pkt_size - hdr_size;
 
 		/*
@@ -1382,7 +1382,7 @@ ssize_t rxr_pkt_proc_matched_eager_rtm(struct rxr_ep *ep,
 		 */
 		rx_entry->cq_entry.len = 0;
 	} else {
-		assert(rx_entry->cq_entry.buf == pkt_entry->pkt - sizeof(struct rxr_pkt_entry));
+		assert(rx_entry->cq_entry.buf == pkt_entry->wiredata - sizeof(struct rxr_pkt_entry));
 		rx_entry->cq_entry.len = pkt_entry->pkt_size + sizeof(struct rxr_pkt_entry);
 	}
 
@@ -1422,7 +1422,7 @@ ssize_t rxr_pkt_proc_matched_rtm(struct rxr_ep *ep,
 	if (rx_entry->cq_entry.len > rx_entry->total_len)
 		rx_entry->cq_entry.len = rx_entry->total_len;
 
-	pkt_type = rxr_get_base_hdr(pkt_entry->pkt)->type;
+	pkt_type = rxr_get_base_hdr(pkt_entry->wiredata)->type;
 
 	if (pkt_type > RXR_DC_REQ_PKT_BEGIN &&
 	    pkt_type < RXR_DC_REQ_PKT_END)
@@ -1430,18 +1430,18 @@ ssize_t rxr_pkt_proc_matched_rtm(struct rxr_ep *ep,
 
 	if (pkt_type == RXR_LONGCTS_MSGRTM_PKT ||
 	    pkt_type == RXR_LONGCTS_TAGRTM_PKT)
-		rx_entry->tx_id = rxr_get_longcts_rtm_base_hdr(pkt_entry->pkt)->send_id;
+		rx_entry->tx_id = rxr_get_longcts_rtm_base_hdr(pkt_entry->wiredata)->send_id;
 	else if (pkt_type == RXR_DC_EAGER_MSGRTM_PKT ||
 		 pkt_type == RXR_DC_EAGER_TAGRTM_PKT)
-		rx_entry->tx_id = rxr_get_dc_eager_rtm_base_hdr(pkt_entry->pkt)->send_id;
+		rx_entry->tx_id = rxr_get_dc_eager_rtm_base_hdr(pkt_entry->wiredata)->send_id;
 	else if (pkt_type == RXR_DC_MEDIUM_MSGRTM_PKT ||
 		 pkt_type == RXR_DC_MEDIUM_TAGRTM_PKT)
-		rx_entry->tx_id = rxr_get_dc_medium_rtm_base_hdr(pkt_entry->pkt)->send_id;
+		rx_entry->tx_id = rxr_get_dc_medium_rtm_base_hdr(pkt_entry->wiredata)->send_id;
 	else if (pkt_type == RXR_DC_LONGCTS_MSGRTM_PKT ||
 		 pkt_type == RXR_DC_LONGCTS_TAGRTM_PKT)
-		rx_entry->tx_id = rxr_get_longcts_rtm_base_hdr(pkt_entry->pkt)->send_id;
+		rx_entry->tx_id = rxr_get_longcts_rtm_base_hdr(pkt_entry->wiredata)->send_id;
 
-	rx_entry->msg_id = rxr_get_rtm_base_hdr(pkt_entry->pkt)->msg_id;
+	rx_entry->msg_id = rxr_get_rtm_base_hdr(pkt_entry->wiredata)->msg_id;
 
 	if (pkt_type == RXR_LONGREAD_MSGRTM_PKT || pkt_type == RXR_LONGREAD_TAGRTM_PKT)
 		return rxr_pkt_proc_matched_longread_rtm(ep, rx_entry, pkt_entry);
@@ -1457,7 +1457,7 @@ ssize_t rxr_pkt_proc_matched_rtm(struct rxr_ep *ep,
 	}
 
 	hdr_size = rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
-	data = pkt_entry->pkt + hdr_size;
+	data = pkt_entry->wiredata + hdr_size;
 	data_size = pkt_entry->pkt_size - hdr_size;
 
 	rx_entry->bytes_received += data_size;
@@ -1535,7 +1535,7 @@ ssize_t rxr_pkt_proc_rtm_rta(struct rxr_ep *ep,
 {
 	struct rxr_base_hdr *base_hdr;
 
-	base_hdr = rxr_get_base_hdr(pkt_entry->pkt);
+	base_hdr = rxr_get_base_hdr(pkt_entry->wiredata);
 	assert(base_hdr->type >= RXR_BASELINE_REQ_PKT_BEGIN);
 
 	switch (base_hdr->type) {
@@ -1583,7 +1583,7 @@ void rxr_pkt_handle_rtm_rta_recv(struct rxr_ep *ep,
 	struct rdm_peer *peer;
 	int ret, msg_id;
 
-	base_hdr = rxr_get_base_hdr(pkt_entry->pkt);
+	base_hdr = rxr_get_base_hdr(pkt_entry->wiredata);
 	assert(base_hdr->type >= RXR_BASELINE_REQ_PKT_BEGIN);
 
 	if (rxr_pkt_type_is_mulreq(base_hdr->type)) {
@@ -1683,7 +1683,7 @@ ssize_t rxr_pkt_init_eager_rtw(struct rxr_ep *ep,
 
 	assert(tx_entry->op == ofi_op_write);
 
-	rtw_hdr = (struct rxr_eager_rtw_hdr *)pkt_entry->pkt;
+	rtw_hdr = (struct rxr_eager_rtw_hdr *)pkt_entry->wiredata;
 	rtw_hdr->rma_iov_count = tx_entry->rma_iov_count;
 	rxr_pkt_init_req_hdr(ep, tx_entry, RXR_EAGER_RTW_PKT, pkt_entry);
 	return rxr_pkt_init_rtw_data(ep, tx_entry, pkt_entry, rtw_hdr->rma_iov);
@@ -1699,7 +1699,7 @@ ssize_t rxr_pkt_init_dc_eager_rtw(struct rxr_ep *ep,
 	assert(tx_entry->op == ofi_op_write);
 
 	tx_entry->rxr_flags |= RXR_DELIVERY_COMPLETE_REQUESTED;
-	dc_eager_rtw_hdr = (struct rxr_dc_eager_rtw_hdr *)pkt_entry->pkt;
+	dc_eager_rtw_hdr = (struct rxr_dc_eager_rtw_hdr *)pkt_entry->wiredata;
 	dc_eager_rtw_hdr->rma_iov_count = tx_entry->rma_iov_count;
 	rxr_pkt_init_req_hdr(ep, tx_entry, RXR_DC_EAGER_RTW_PKT, pkt_entry);
 	ret = rxr_pkt_init_rtw_data(ep, tx_entry, pkt_entry,
@@ -1716,7 +1716,7 @@ static inline void rxr_pkt_init_longcts_rtw_hdr(struct rxr_ep *ep,
 	struct rxr_longcts_rtw_hdr *rtw_hdr;
 
 	tx_entry->rxr_flags |= RXR_LONGCTS_PROTOCOL;
-	rtw_hdr = (struct rxr_longcts_rtw_hdr *)pkt_entry->pkt;
+	rtw_hdr = (struct rxr_longcts_rtw_hdr *)pkt_entry->wiredata;
 	rtw_hdr->rma_iov_count = tx_entry->rma_iov_count;
 	rtw_hdr->msg_length = tx_entry->total_len;
 	rtw_hdr->send_id = tx_entry->tx_id;
@@ -1732,7 +1732,7 @@ ssize_t rxr_pkt_init_longcts_rtw(struct rxr_ep *ep,
 
 	assert(tx_entry->op == ofi_op_write);
 
-	rtw_hdr = (struct rxr_longcts_rtw_hdr *)pkt_entry->pkt;
+	rtw_hdr = (struct rxr_longcts_rtw_hdr *)pkt_entry->wiredata;
 	rxr_pkt_init_longcts_rtw_hdr(ep, tx_entry, pkt_entry, RXR_LONGCTS_RTW_PKT);
 	return rxr_pkt_init_rtw_data(ep, tx_entry, pkt_entry, rtw_hdr->rma_iov);
 }
@@ -1746,7 +1746,7 @@ ssize_t rxr_pkt_init_dc_longcts_rtw(struct rxr_ep *ep,
 	assert(tx_entry->op == ofi_op_write);
 
 	tx_entry->rxr_flags |= RXR_DELIVERY_COMPLETE_REQUESTED;
-	rtw_hdr = (struct rxr_longcts_rtw_hdr *)pkt_entry->pkt;
+	rtw_hdr = (struct rxr_longcts_rtw_hdr *)pkt_entry->wiredata;
 	rxr_pkt_init_longcts_rtw_hdr(ep, tx_entry, pkt_entry, RXR_DC_LONGCTS_RTW_PKT);
 	return rxr_pkt_init_rtw_data(ep, tx_entry, pkt_entry, rtw_hdr->rma_iov);
 }
@@ -1763,7 +1763,7 @@ ssize_t rxr_pkt_init_longread_rtw(struct rxr_ep *ep,
 
 	assert(tx_entry->op == ofi_op_write);
 
-	rtw_hdr = (struct rxr_longread_rtw_hdr *)pkt_entry->pkt;
+	rtw_hdr = (struct rxr_longread_rtw_hdr *)pkt_entry->wiredata;
 	rtw_hdr->rma_iov_count = tx_entry->rma_iov_count;
 	rtw_hdr->msg_length = tx_entry->total_len;
 	rtw_hdr->send_id = tx_entry->tx_id;
@@ -1778,7 +1778,7 @@ ssize_t rxr_pkt_init_longread_rtw(struct rxr_ep *ep,
 	}
 
 	hdr_size = rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
-	read_iov = (struct fi_rma_iov *)(pkt_entry->pkt + hdr_size);
+	read_iov = (struct fi_rma_iov *)(pkt_entry->wiredata + hdr_size);
 	err = rxr_read_init_iov(ep, tx_entry, read_iov);
 	if (OFI_UNLIKELY(err))
 		return err;
@@ -1857,7 +1857,7 @@ struct rxr_op_entry *rxr_pkt_alloc_rtw_rx_entry(struct rxr_ep *ep,
 	if (OFI_UNLIKELY(!rx_entry))
 		return NULL;
 
-	base_hdr = rxr_get_base_hdr(pkt_entry->pkt);
+	base_hdr = rxr_get_base_hdr(pkt_entry->wiredata);
 	if (base_hdr->flags & RXR_REQ_OPT_CQ_DATA_HDR) {
 		rx_entry->rxr_flags |= RXR_REMOTE_CQ_DATA;
 		rx_entry->cq_entry.flags |= FI_REMOTE_CQ_DATA;
@@ -1897,7 +1897,7 @@ void rxr_pkt_proc_eager_rtw(struct rxr_ep *ep,
 	rx_entry->total_len = rx_entry->cq_entry.len;
 
 	hdr_size = rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
-	data = pkt_entry->pkt + hdr_size;
+	data = pkt_entry->wiredata + hdr_size;
 	data_size = pkt_entry->pkt_size - hdr_size;
 
 	rx_entry->bytes_received += data_size;
@@ -1935,7 +1935,7 @@ void rxr_pkt_handle_eager_rtw_recv(struct rxr_ep *ep,
 		return;
 	}
 
-	rtw_hdr = (struct rxr_eager_rtw_hdr *)pkt_entry->pkt;
+	rtw_hdr = (struct rxr_eager_rtw_hdr *)pkt_entry->wiredata;
 	rx_entry->iov_count = rtw_hdr->rma_iov_count;
 	rxr_pkt_proc_eager_rtw(ep,
 			       rtw_hdr->rma_iov,
@@ -1959,7 +1959,7 @@ void rxr_pkt_handle_dc_eager_rtw_recv(struct rxr_ep *ep,
 	}
 
 	rx_entry->rxr_flags |= RXR_DELIVERY_COMPLETE_REQUESTED;
-	rtw_hdr = (struct rxr_dc_eager_rtw_hdr *)pkt_entry->pkt;
+	rtw_hdr = (struct rxr_dc_eager_rtw_hdr *)pkt_entry->wiredata;
 	rx_entry->tx_id = rtw_hdr->send_id;
 	rx_entry->iov_count = rtw_hdr->rma_iov_count;
 	rxr_pkt_proc_eager_rtw(ep,
@@ -1987,7 +1987,7 @@ void rxr_pkt_handle_longcts_rtw_recv(struct rxr_ep *ep,
 		return;
 	}
 
-	rtw_hdr = (struct rxr_longcts_rtw_hdr *)pkt_entry->pkt;
+	rtw_hdr = (struct rxr_longcts_rtw_hdr *)pkt_entry->wiredata;
 	tx_id = rtw_hdr->send_id;
 	if (rtw_hdr->type == RXR_DC_LONGCTS_RTW_PKT)
 		rx_entry->rxr_flags |= RXR_DELIVERY_COMPLETE_REQUESTED;
@@ -2009,7 +2009,7 @@ void rxr_pkt_handle_longcts_rtw_recv(struct rxr_ep *ep,
 	rx_entry->total_len = rx_entry->cq_entry.len;
 
 	hdr_size = rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
-	data = pkt_entry->pkt + hdr_size;
+	data = pkt_entry->wiredata + hdr_size;
 	data_size = pkt_entry->pkt_size - hdr_size;
 
 	rx_entry->bytes_received += data_size;
@@ -2065,7 +2065,7 @@ void rxr_pkt_handle_longread_rtw_recv(struct rxr_ep *ep,
 		return;
 	}
 
-	rtw_hdr = (struct rxr_longread_rtw_hdr *)pkt_entry->pkt;
+	rtw_hdr = (struct rxr_longread_rtw_hdr *)pkt_entry->wiredata;
 	rx_entry->iov_count = rtw_hdr->rma_iov_count;
 	err = rxr_rma_verified_copy_iov(ep, rtw_hdr->rma_iov, rtw_hdr->rma_iov_count,
 					FI_REMOTE_WRITE, rx_entry->iov, rx_entry->desc);
@@ -2083,7 +2083,7 @@ void rxr_pkt_handle_longread_rtw_recv(struct rxr_ep *ep,
 	rx_entry->total_len = rx_entry->cq_entry.len;
 
 	hdr_size = rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
-	read_iov = (struct fi_rma_iov *)(pkt_entry->pkt + hdr_size);
+	read_iov = (struct fi_rma_iov *)(pkt_entry->wiredata + hdr_size);
 	rx_entry->addr = pkt_entry->addr;
 	rx_entry->tx_id = rtw_hdr->send_id;
 	rx_entry->rma_iov_count = rtw_hdr->read_iov_count;
@@ -2114,7 +2114,7 @@ void rxr_pkt_init_rtr(struct rxr_ep *ep,
 	int i;
 
 	assert(tx_entry->op == ofi_op_read_req);
-	rtr_hdr = (struct rxr_rtr_hdr *)pkt_entry->pkt;
+	rtr_hdr = (struct rxr_rtr_hdr *)pkt_entry->wiredata;
 	rtr_hdr->rma_iov_count = tx_entry->rma_iov_count;
 	rxr_pkt_init_req_hdr(ep, tx_entry, pkt_type, pkt_entry);
 	rtr_hdr->msg_length = tx_entry->total_len;
@@ -2169,7 +2169,7 @@ void rxr_pkt_handle_rtr_recv(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 	rx_entry->bytes_received = 0;
 	rx_entry->bytes_copied = 0;
 
-	rtr_hdr = (struct rxr_rtr_hdr *)pkt_entry->pkt;
+	rtr_hdr = (struct rxr_rtr_hdr *)pkt_entry->wiredata;
 	rx_entry->tx_id = rtr_hdr->recv_id;
 	rx_entry->window = rtr_hdr->recv_length;
 	rx_entry->iov_count = rtr_hdr->rma_iov_count;
@@ -2213,7 +2213,7 @@ ssize_t rxr_pkt_init_rta(struct rxr_ep *ep, struct rxr_op_entry *tx_entry,
 	ssize_t ret;
 	int i;
 
-	rta_hdr = (struct rxr_rta_hdr *)pkt_entry->pkt;
+	rta_hdr = (struct rxr_rta_hdr *)pkt_entry->wiredata;
 	rta_hdr->msg_id = tx_entry->msg_id;
 	rta_hdr->rma_iov_count = tx_entry->rma_iov_count;
 	rta_hdr->atomic_datatype = tx_entry->atomic_hdr.datatype;
@@ -2229,7 +2229,7 @@ ssize_t rxr_pkt_init_rta(struct rxr_ep *ep, struct rxr_op_entry *tx_entry,
 
 	hdr_size = rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
 
-	data = pkt_entry->pkt + hdr_size;
+	data = pkt_entry->wiredata + hdr_size;
 	ret = efa_copy_from_hmem_iov(tx_entry->desc, data, ep->mtu_size - hdr_size,
 	                             tx_entry->iov, tx_entry->iov_count);
 
@@ -2258,7 +2258,7 @@ ssize_t rxr_pkt_init_dc_write_rta(struct rxr_ep *ep,
 
 	tx_entry->rxr_flags |= RXR_DELIVERY_COMPLETE_REQUESTED;
 	rxr_pkt_init_rta(ep, tx_entry, RXR_DC_WRITE_RTA_PKT, pkt_entry);
-	rta_hdr = rxr_get_rta_hdr(pkt_entry->pkt);
+	rta_hdr = rxr_get_rta_hdr(pkt_entry->wiredata);
 	rta_hdr->send_id = tx_entry->tx_id;
 	return 0;
 }
@@ -2269,7 +2269,7 @@ ssize_t rxr_pkt_init_fetch_rta(struct rxr_ep *ep, struct rxr_op_entry *tx_entry,
 	struct rxr_rta_hdr *rta_hdr;
 
 	rxr_pkt_init_rta(ep, tx_entry, RXR_FETCH_RTA_PKT, pkt_entry);
-	rta_hdr = rxr_get_rta_hdr(pkt_entry->pkt);
+	rta_hdr = rxr_get_rta_hdr(pkt_entry->wiredata);
 	rta_hdr->recv_id = tx_entry->tx_id;
 	return 0;
 }
@@ -2285,13 +2285,13 @@ ssize_t rxr_pkt_init_compare_rta(struct rxr_ep *ep, struct rxr_op_entry *tx_entr
 	/* TODO Add check here to fail if buf size + compare_size > mtu_size - header_size */
 
 	rxr_pkt_init_rta(ep, tx_entry, RXR_COMPARE_RTA_PKT, pkt_entry);
-	rta_hdr = rxr_get_rta_hdr(pkt_entry->pkt);
+	rta_hdr = rxr_get_rta_hdr(pkt_entry->wiredata);
 	rta_hdr->recv_id = tx_entry->tx_id;
 	/* rxr_pkt_init_rta() will copy data from tx_entry->iov to pkt entry
 	 * the following append the data to be compared
 	 */
-	data = pkt_entry->wiredata + pkt_entry->pkt_size;
 
+	data = pkt_entry->wiredata + pkt_entry->pkt_size;
 	ret = efa_copy_from_hmem_iov(tx_entry->atomic_ex.compare_desc, data, ep->mtu_size - pkt_entry->pkt_size,
 	                             tx_entry->atomic_ex.comp_iov, tx_entry->atomic_ex.comp_iov_count);
 
@@ -2347,7 +2347,7 @@ int rxr_pkt_proc_write_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 	size_t dtsize, offset, hdr_size;
 	enum fi_hmem_iface hmem_iface;
 
-	rta_hdr = (struct rxr_rta_hdr *)pkt_entry->pkt;
+	rta_hdr = (struct rxr_rta_hdr *)pkt_entry->wiredata;
 	op = rta_hdr->atomic_op;
 	dt = rta_hdr->atomic_datatype;
 	dtsize = ofi_datatype_size(dt);
@@ -2356,7 +2356,7 @@ int rxr_pkt_proc_write_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 	}
 
 	hdr_size = rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
-	data = pkt_entry->pkt + hdr_size;
+	data = pkt_entry->wiredata + hdr_size;
 	iov_count = rta_hdr->rma_iov_count;
 	rxr_rma_verified_copy_iov(ep, rta_hdr->rma_iov, iov_count, FI_REMOTE_WRITE, iov, desc);
 
@@ -2401,7 +2401,7 @@ struct rxr_op_entry *rxr_pkt_alloc_rta_rx_entry(struct rxr_ep *ep, struct rxr_pk
 		return rx_entry;
 	}
 
-	rta_hdr = (struct rxr_rta_hdr *)pkt_entry->pkt;
+	rta_hdr = (struct rxr_rta_hdr *)pkt_entry->wiredata;
 	rx_entry->atomic_hdr.atomic_op = rta_hdr->atomic_op;
 	rx_entry->atomic_hdr.datatype = rta_hdr->atomic_datatype;
 
@@ -2447,7 +2447,7 @@ int rxr_pkt_proc_dc_write_rta(struct rxr_ep *ep,
 		return -FI_ENOBUFS;
 	}
 
-	rta_hdr = (struct rxr_rta_hdr *)pkt_entry->pkt;
+	rta_hdr = (struct rxr_rta_hdr *)pkt_entry->wiredata;
 	rx_entry->tx_id = rta_hdr->send_id;
 	rx_entry->rxr_flags |= RXR_DELIVERY_COMPLETE_REQUESTED;
 
@@ -2511,7 +2511,7 @@ int rxr_pkt_proc_fetch_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 		return -FI_ENOBUFS;
 	}
 
-	rx_entry->tx_id = rxr_get_rta_hdr(pkt_entry->pkt)->recv_id;
+	rx_entry->tx_id = rxr_get_rta_hdr(pkt_entry->wiredata)->recv_id;
 	op = rx_entry->atomic_hdr.atomic_op;
 	dt = rx_entry->atomic_hdr.datatype;
 	dtsize = ofi_datatype_size(rx_entry->atomic_hdr.datatype);
@@ -2519,7 +2519,7 @@ int rxr_pkt_proc_fetch_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 		return -errno;
 	}
 
-	data = pkt_entry->pkt + rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
+	data = pkt_entry->wiredata + rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
 
 	offset = 0;
 	for (i = 0; i < rx_entry->iov_count; ++i) {
@@ -2587,7 +2587,7 @@ int rxr_pkt_proc_compare_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 		return -FI_ENOBUFS;
 	}
 
-	rx_entry->tx_id = rxr_get_rta_hdr(pkt_entry->pkt)->recv_id;
+	rx_entry->tx_id = rxr_get_rta_hdr(pkt_entry->wiredata)->recv_id;
 	op = rx_entry->atomic_hdr.atomic_op;
 	dt = rx_entry->atomic_hdr.datatype;
 	dtsize = ofi_datatype_size(rx_entry->atomic_hdr.datatype);
@@ -2598,7 +2598,7 @@ int rxr_pkt_proc_compare_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 		return -errno;
 	}
 
-	src_data = pkt_entry->pkt + rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
+	src_data = pkt_entry->wiredata + rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
 	cmp_data = src_data + rx_entry->total_len;
 	offset = 0;
 	for (i = 0; i < rx_entry->iov_count; ++i) {

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -282,7 +282,7 @@ void *rxr_pkt_req_raw_addr(struct rxr_pkt_entry *pkt_entry)
 	struct rxr_req_opt_raw_addr_hdr *raw_addr_hdr;
 
 	base_hdr = rxr_get_base_hdr(pkt_entry->pkt);
-	opt_hdr = (char *)pkt_entry->pkt + rxr_pkt_req_base_hdr_size(pkt_entry);
+	opt_hdr = pkt_entry->pkt + rxr_pkt_req_base_hdr_size(pkt_entry);
 	if (base_hdr->flags & RXR_REQ_OPT_RAW_ADDR_HDR) {
 		/* For req packet, the optional connid header and the optional
 		 * raw address header are mutually exclusive.
@@ -309,7 +309,7 @@ uint32_t *rxr_pkt_req_connid_ptr(struct rxr_pkt_entry *pkt_entry)
 	struct rxr_req_opt_connid_hdr *connid_hdr;
 
 	base_hdr = rxr_get_base_hdr(pkt_entry->pkt);
-	opt_hdr = (char *)pkt_entry->pkt + rxr_pkt_req_base_hdr_size(pkt_entry);
+	opt_hdr = pkt_entry->pkt + rxr_pkt_req_base_hdr_size(pkt_entry);
 
 	if (base_hdr->flags & RXR_REQ_OPT_RAW_ADDR_HDR) {
 		struct rxr_req_opt_raw_addr_hdr *raw_addr_hdr;
@@ -353,7 +353,7 @@ size_t rxr_pkt_req_hdr_size_from_pkt_entry(struct rxr_pkt_entry *pkt_entry)
 	struct rxr_req_opt_raw_addr_hdr *raw_addr_hdr;
 
 	base_hdr = rxr_get_base_hdr(pkt_entry->pkt);
-	opt_hdr = (char *)pkt_entry->pkt + rxr_pkt_req_base_hdr_size(pkt_entry);
+	opt_hdr = pkt_entry->pkt + rxr_pkt_req_base_hdr_size(pkt_entry);
 
 	/*
 	 * It is not possible to have both optional raw addr header and optional
@@ -373,7 +373,7 @@ size_t rxr_pkt_req_hdr_size_from_pkt_entry(struct rxr_pkt_entry *pkt_entry)
 		opt_hdr += sizeof(struct rxr_req_opt_connid_hdr);
 	}
 
-	return opt_hdr - (char *)pkt_entry->pkt;
+	return opt_hdr - pkt_entry->pkt;
 }
 
 int64_t rxr_pkt_req_cq_data(struct rxr_pkt_entry *pkt_entry)
@@ -384,7 +384,7 @@ int64_t rxr_pkt_req_cq_data(struct rxr_pkt_entry *pkt_entry)
 	struct rxr_req_opt_raw_addr_hdr *raw_addr_hdr;
 
 	base_hdr = rxr_get_base_hdr(pkt_entry->pkt);
-	opt_hdr = (char *)pkt_entry->pkt + rxr_pkt_req_base_hdr_size(pkt_entry);
+	opt_hdr = pkt_entry->pkt + rxr_pkt_req_base_hdr_size(pkt_entry);
 	if (base_hdr->flags & RXR_REQ_OPT_RAW_ADDR_HDR) {
 		raw_addr_hdr = (struct rxr_req_opt_raw_addr_hdr *)opt_hdr;
 		opt_hdr += sizeof(struct rxr_req_opt_raw_addr_hdr) + raw_addr_hdr->addr_len;
@@ -760,7 +760,7 @@ ssize_t rxr_pkt_init_longread_rtm(struct rxr_ep *ep,
 	rtm_hdr->read_iov_count = tx_entry->iov_count;
 
 	hdr_size = rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
-	read_iov = (struct fi_rma_iov *)((char *)pkt_entry->pkt + hdr_size);
+	read_iov = (struct fi_rma_iov *)(pkt_entry->pkt + hdr_size);
 	err = rxr_read_init_iov(ep, tx_entry, read_iov);
 	if (OFI_UNLIKELY(err))
 		return err;
@@ -830,7 +830,7 @@ ssize_t rxr_pkt_init_runtread_rtm(struct rxr_ep *ep,
 	rtm_hdr->read_iov_count = tx_entry->iov_count;
 
 	hdr_size = rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
-	read_iov = (struct fi_rma_iov *)((char *)pkt_entry->pkt + hdr_size);
+	read_iov = (struct fi_rma_iov *)(pkt_entry->pkt + hdr_size);
 	err = rxr_read_init_iov(ep, tx_entry, read_iov);
 	if (OFI_UNLIKELY(err))
 		return err;
@@ -1248,7 +1248,8 @@ ssize_t rxr_pkt_proc_matched_longread_rtm(struct rxr_ep *ep,
 	struct fi_rma_iov *read_iov;
 
 	rtm_hdr = rxr_get_longread_rtm_base_hdr(pkt_entry->pkt);
-	read_iov = (struct fi_rma_iov *)((char *)pkt_entry->pkt + rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry));
+	read_iov = (struct fi_rma_iov *)(pkt_entry->pkt +
+									rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry));
 
 	rx_entry->tx_id = rtm_hdr->send_id;
 	rx_entry->rma_iov_count = rtm_hdr->read_iov_count;
@@ -1282,7 +1283,7 @@ ssize_t rxr_pkt_proc_matched_mulreq_rtm(struct rxr_ep *ep,
 			struct fi_rma_iov *read_iov;
 
 			rx_entry->tx_id = runtread_rtm_hdr->send_id;
-			read_iov = (struct fi_rma_iov *)((char *)pkt_entry->pkt + rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry));
+			read_iov = (struct fi_rma_iov *)(pkt_entry->pkt + rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry));
 			rx_entry->rma_iov_count = runtread_rtm_hdr->read_iov_count;
 			memcpy(rx_entry->rma_iov, read_iov, rx_entry->rma_iov_count * sizeof(struct fi_rma_iov));
 			rxr_tracing(runtread_read_posted, rx_entry->msg_id,
@@ -1297,7 +1298,7 @@ ssize_t rxr_pkt_proc_matched_mulreq_rtm(struct rxr_ep *ep,
 	cur = pkt_entry;
 	while (cur) {
 		pkt_data_offset = rxr_pkt_req_data_offset(cur);
-		pkt_data = (char *)cur->pkt + pkt_data_offset;
+		pkt_data = cur->pkt + pkt_data_offset;
 		data_size = cur->pkt_size - pkt_data_offset;
 
 		rx_data_offset = rxr_pkt_hdr_seg_offset(cur->pkt);
@@ -1351,7 +1352,7 @@ ssize_t rxr_pkt_proc_matched_eager_rtm(struct rxr_ep *ep,
 	hdr_size = rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
 
 	if (pkt_entry->alloc_type != RXR_PKT_FROM_USER_BUFFER) {
-		data = (char *)pkt_entry->pkt + hdr_size;
+		data = pkt_entry->pkt + hdr_size;
 		data_size = pkt_entry->pkt_size - hdr_size;
 
 		/*
@@ -1456,7 +1457,7 @@ ssize_t rxr_pkt_proc_matched_rtm(struct rxr_ep *ep,
 	}
 
 	hdr_size = rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
-	data = (char *)pkt_entry->pkt + hdr_size;
+	data = pkt_entry->pkt + hdr_size;
 	data_size = pkt_entry->pkt_size - hdr_size;
 
 	rx_entry->bytes_received += data_size;
@@ -1777,7 +1778,7 @@ ssize_t rxr_pkt_init_longread_rtw(struct rxr_ep *ep,
 	}
 
 	hdr_size = rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
-	read_iov = (struct fi_rma_iov *)((char *)pkt_entry->pkt + hdr_size);
+	read_iov = (struct fi_rma_iov *)(pkt_entry->pkt + hdr_size);
 	err = rxr_read_init_iov(ep, tx_entry, read_iov);
 	if (OFI_UNLIKELY(err))
 		return err;
@@ -1896,7 +1897,7 @@ void rxr_pkt_proc_eager_rtw(struct rxr_ep *ep,
 	rx_entry->total_len = rx_entry->cq_entry.len;
 
 	hdr_size = rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
-	data = (char *)pkt_entry->pkt + hdr_size;
+	data = pkt_entry->pkt + hdr_size;
 	data_size = pkt_entry->pkt_size - hdr_size;
 
 	rx_entry->bytes_received += data_size;
@@ -2008,7 +2009,7 @@ void rxr_pkt_handle_longcts_rtw_recv(struct rxr_ep *ep,
 	rx_entry->total_len = rx_entry->cq_entry.len;
 
 	hdr_size = rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
-	data = (char *)pkt_entry->pkt + hdr_size;
+	data = pkt_entry->pkt + hdr_size;
 	data_size = pkt_entry->pkt_size - hdr_size;
 
 	rx_entry->bytes_received += data_size;
@@ -2082,7 +2083,7 @@ void rxr_pkt_handle_longread_rtw_recv(struct rxr_ep *ep,
 	rx_entry->total_len = rx_entry->cq_entry.len;
 
 	hdr_size = rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
-	read_iov = (struct fi_rma_iov *)((char *)pkt_entry->pkt + hdr_size);
+	read_iov = (struct fi_rma_iov *)(pkt_entry->pkt + hdr_size);
 	rx_entry->addr = pkt_entry->addr;
 	rx_entry->tx_id = rtw_hdr->send_id;
 	rx_entry->rma_iov_count = rtw_hdr->read_iov_count;
@@ -2227,8 +2228,8 @@ ssize_t rxr_pkt_init_rta(struct rxr_ep *ep, struct rxr_op_entry *tx_entry,
 	}
 
 	hdr_size = rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
-	data = (char *)pkt_entry->pkt + hdr_size;
 
+	data = pkt_entry->pkt + hdr_size;
 	ret = efa_copy_from_hmem_iov(tx_entry->desc, data, ep->mtu_size - hdr_size,
 	                             tx_entry->iov, tx_entry->iov_count);
 
@@ -2289,7 +2290,7 @@ ssize_t rxr_pkt_init_compare_rta(struct rxr_ep *ep, struct rxr_op_entry *tx_entr
 	/* rxr_pkt_init_rta() will copy data from tx_entry->iov to pkt entry
 	 * the following append the data to be compared
 	 */
-	data = (char *)pkt_entry->pkt + pkt_entry->pkt_size;
+	data = pkt_entry->wiredata + pkt_entry->pkt_size;
 
 	ret = efa_copy_from_hmem_iov(tx_entry->atomic_ex.compare_desc, data, ep->mtu_size - pkt_entry->pkt_size,
 	                             tx_entry->atomic_ex.comp_iov, tx_entry->atomic_ex.comp_iov_count);
@@ -2355,7 +2356,7 @@ int rxr_pkt_proc_write_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 	}
 
 	hdr_size = rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
-	data = (char *)pkt_entry->pkt + hdr_size;
+	data = pkt_entry->pkt + hdr_size;
 	iov_count = rta_hdr->rma_iov_count;
 	rxr_rma_verified_copy_iov(ep, rta_hdr->rma_iov, iov_count, FI_REMOTE_WRITE, iov, desc);
 
@@ -2518,11 +2519,11 @@ int rxr_pkt_proc_fetch_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 		return -errno;
 	}
 
-	data = (char *)pkt_entry->pkt + rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
+	data = pkt_entry->pkt + rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
 
 	offset = 0;
 	for (i = 0; i < rx_entry->iov_count; ++i) {
-		efa_mr = (struct efa_mr*) ofi_mr_map_get(&ep->util_ep.domain->mr_map, (rxr_get_rta_hdr(pkt_entry->pkt)->rma_iov + i)->key);
+		efa_mr = (struct efa_mr*) ofi_mr_map_get(&ep->util_ep.domain->mr_map, (rxr_get_rta_hdr(pkt_entry->wiredata)->rma_iov + i)->key);
 		hmem_iface = efa_mr->peer.iface;
 		if (hmem_iface == FI_HMEM_SYSTEM) {
 			ofi_atomic_readwrite_handlers[op][dt](rx_entry->iov[i].iov_base,
@@ -2597,11 +2598,11 @@ int rxr_pkt_proc_compare_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 		return -errno;
 	}
 
-	src_data = (char *)pkt_entry->pkt + rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
+	src_data = pkt_entry->pkt + rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
 	cmp_data = src_data + rx_entry->total_len;
 	offset = 0;
 	for (i = 0; i < rx_entry->iov_count; ++i) {
-		efa_mr = (struct efa_mr*) ofi_mr_map_get(&ep->util_ep.domain->mr_map, (rxr_get_rta_hdr(pkt_entry->pkt)->rma_iov + i)->key);
+		efa_mr = (struct efa_mr*) ofi_mr_map_get(&ep->util_ep.domain->mr_map, (rxr_get_rta_hdr(pkt_entry->wiredata)->rma_iov + i)->key);
 		hmem_iface = efa_mr->peer.iface;
 
 		if (hmem_iface == FI_HMEM_SYSTEM) {

--- a/prov/efa/src/rxr/rxr_pkt_type_req.h
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.h
@@ -93,7 +93,7 @@ uint64_t rxr_pkt_rtm_tag(struct rxr_pkt_entry *pkt_entry)
 	 * the last member of header.
 	 */
 	offset = rxr_pkt_req_base_hdr_size(pkt_entry) - sizeof(uint64_t);
-	tagptr = (uint64_t *)((char *)pkt_entry->pkt + offset);
+	tagptr = (uint64_t *)(pkt_entry->pkt + offset);
 	return *tagptr;
 }
 
@@ -105,7 +105,7 @@ void rxr_pkt_rtm_settag(struct rxr_pkt_entry *pkt_entry, uint64_t tag)
 
 	offset = rxr_pkt_req_base_hdr_size(pkt_entry) - sizeof(uint64_t);
 	/* tag is always the last member */
-	tagptr = (uint64_t *)((char *)pkt_entry->pkt + offset);
+	tagptr = (uint64_t *)(pkt_entry->pkt + offset);
 	*tagptr = tag;
 }
 

--- a/prov/efa/src/rxr/rxr_pkt_type_req.h
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.h
@@ -73,7 +73,7 @@ uint32_t rxr_pkt_msg_id(struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_rtm_base_hdr *rtm_hdr;
 
-	rtm_hdr = rxr_get_rtm_base_hdr(pkt_entry->pkt);
+	rtm_hdr = rxr_get_rtm_base_hdr(pkt_entry->wiredata);
 	/* only msg and atomic request has msg_id */
 	assert(rtm_hdr->flags & (RXR_REQ_MSG | RXR_REQ_ATOMIC));
 	return rtm_hdr->msg_id;
@@ -93,7 +93,7 @@ uint64_t rxr_pkt_rtm_tag(struct rxr_pkt_entry *pkt_entry)
 	 * the last member of header.
 	 */
 	offset = rxr_pkt_req_base_hdr_size(pkt_entry) - sizeof(uint64_t);
-	tagptr = (uint64_t *)(pkt_entry->pkt + offset);
+	tagptr = (uint64_t *)(pkt_entry->wiredata + offset);
 	return *tagptr;
 }
 
@@ -105,7 +105,7 @@ void rxr_pkt_rtm_settag(struct rxr_pkt_entry *pkt_entry, uint64_t tag)
 
 	offset = rxr_pkt_req_base_hdr_size(pkt_entry) - sizeof(uint64_t);
 	/* tag is always the last member */
-	tagptr = (uint64_t *)(pkt_entry->pkt + offset);
+	tagptr = (uint64_t *)(pkt_entry->wiredata + offset);
 	*tagptr = tag;
 }
 

--- a/prov/efa/src/rxr/rxr_prov.c
+++ b/prov/efa/src/rxr/rxr_prov.c
@@ -37,10 +37,6 @@
 #include "rxr_env.h"
 #include "efa_prov_info.h"
 
-#ifdef ENABLE_EFA_POISONING
-const uint32_t rxr_poison_value = 0xdeadbeef;
-#endif
-
 static void rxr_fini();
 
 struct fi_provider rxr_prov = {

--- a/prov/efa/src/rxr/rxr_read.c
+++ b/prov/efa/src/rxr/rxr_read.c
@@ -113,7 +113,7 @@ ssize_t rxr_read_prepare_pkt_entry_mr(struct rxr_ep *ep, struct rxr_read_entry *
 	       pkt_entry->alloc_type == RXR_PKT_FROM_UNEXP_POOL ||
 	       pkt_entry->alloc_type == RXR_PKT_FROM_SHM_RX_POOL);
 
-	pkt_offset = (char *)read_entry->rma_iov[0].addr - pkt_entry->pkt;
+	pkt_offset = (char *)read_entry->rma_iov[0].addr - pkt_entry->wiredata;
 	assert(pkt_offset > sizeof(struct rxr_base_hdr));
 
 	pkt_entry_copy = rxr_pkt_entry_clone(ep, ep->rx_readcopy_pkt_pool,
@@ -129,7 +129,7 @@ ssize_t rxr_read_prepare_pkt_entry_mr(struct rxr_ep *ep, struct rxr_read_entry *
 
 	assert(pkt_entry_copy->mr);
 	read_entry->context = pkt_entry_copy;
-	read_entry->rma_iov[0].addr = (uint64_t)pkt_entry_copy->pkt + pkt_offset;
+	read_entry->rma_iov[0].addr = (uint64_t)pkt_entry_copy->wiredata + pkt_offset;
 	read_entry->rma_iov[0].key = fi_mr_key(pkt_entry_copy->mr);
 
 	return 0;

--- a/prov/efa/src/rxr/rxr_read.c
+++ b/prov/efa/src/rxr/rxr_read.c
@@ -113,7 +113,7 @@ ssize_t rxr_read_prepare_pkt_entry_mr(struct rxr_ep *ep, struct rxr_read_entry *
 	       pkt_entry->alloc_type == RXR_PKT_FROM_UNEXP_POOL ||
 	       pkt_entry->alloc_type == RXR_PKT_FROM_SHM_RX_POOL);
 
-	pkt_offset = (char *)read_entry->rma_iov[0].addr - (char *)pkt_entry->pkt;
+	pkt_offset = (char *)read_entry->rma_iov[0].addr - pkt_entry->pkt;
 	assert(pkt_offset > sizeof(struct rxr_base_hdr));
 
 	pkt_entry_copy = rxr_pkt_entry_clone(ep, ep->rx_readcopy_pkt_pool,
@@ -302,7 +302,7 @@ void rxr_read_release_entry(struct rxr_ep *ep, struct rxr_read_entry *read_entry
 	}
 
 #ifdef ENABLE_EFA_POISONING
-	rxr_poison_mem_region((uint32_t *)read_entry, sizeof(struct rxr_read_entry));
+	rxr_poison_mem_region(read_entry, sizeof(struct rxr_read_entry));
 #endif
 	read_entry->state = RXR_RDMA_ENTRY_FREE;
 	ofi_buf_free(read_entry);

--- a/prov/efa/test/efa_unit_test_common.c
+++ b/prov/efa/test/efa_unit_test_common.c
@@ -169,11 +169,11 @@ void efa_unit_test_eager_msgrtm_pkt_construct(struct rxr_pkt_entry *pkt_entry, s
 	base_hdr.hdr.type = RXR_EAGER_MSGRTM_PKT;
 	base_hdr.hdr.flags |= RXR_PKT_CONNID_HDR | RXR_REQ_MSG;
 	base_hdr.hdr.msg_id = attr->msg_id;
-	memcpy(pkt_entry->pkt, &base_hdr, sizeof(struct rxr_eager_msgrtm_hdr));
-	assert_int_equal(rxr_get_base_hdr(pkt_entry->pkt)->type, RXR_EAGER_MSGRTM_PKT);
+	memcpy(pkt_entry->wiredata, &base_hdr, sizeof(struct rxr_eager_msgrtm_hdr));
+	assert_int_equal(rxr_get_base_hdr(pkt_entry->wiredata)->type, RXR_EAGER_MSGRTM_PKT);
 	assert_int_equal(rxr_pkt_req_base_hdr_size(pkt_entry), sizeof(struct rxr_eager_msgrtm_hdr));
 	opt_connid_hdr.connid = attr->connid;
-	memcpy(pkt_entry->pkt + sizeof(struct rxr_eager_msgrtm_hdr), &opt_connid_hdr, sizeof(struct rxr_req_opt_connid_hdr));
+	memcpy(pkt_entry->wiredata + sizeof(struct rxr_eager_msgrtm_hdr), &opt_connid_hdr, sizeof(struct rxr_req_opt_connid_hdr));
 	connid = rxr_pkt_connid_ptr(pkt_entry);
 	assert_int_equal(*connid, attr->connid);
 	pkt_entry->pkt_size = sizeof(base_hdr) + sizeof(opt_connid_hdr);


### PR DESCRIPTION
- rxr_pkt_entry is now allocated from a ofi_buf_pool called local_info_pool
- rxr_pkt_entry->pkt has now been renamed to wiredata and is allocated from a separate ofi_buf_pool
- ep->pkt_sendv_pool has been removed and rxr_pkt_entry->send is allocated from the local_info_pool

Signed-off-by: Sai Sunku <sunkusa@amazon.com>