### PR TITLE
prov/efa: fix a bug rxr_pkt_req_hdr_size()

### DIFF
--- a/prov/efa/src/rxr/rxr_op_entry.c
+++ b/prov/efa/src/rxr/rxr_op_entry.c
@@ -199,7 +199,6 @@ size_t rxr_op_entry_mulreq_total_data_size(struct rxr_op_entry *op_entry, int pk
 size_t rxr_tx_entry_max_req_data_capacity(struct rxr_ep *ep, struct rxr_op_entry *tx_entry, int pkt_type)
 {
 	struct rdm_peer *peer;
-	uint16_t header_flags = 0;
 	int max_data_offset;
 
 	assert(pkt_type >= RXR_REQ_PKT_BEGIN);
@@ -211,16 +210,7 @@ size_t rxr_tx_entry_max_req_data_capacity(struct rxr_ep *ep, struct rxr_op_entry
 		return rxr_env.shm_max_medium_size;
 	}
 
-	if (rxr_peer_need_raw_addr_hdr(peer))
-		header_flags |= RXR_REQ_OPT_RAW_ADDR_HDR;
-	else if (rxr_peer_need_connid(peer))
-		header_flags |= RXR_PKT_CONNID_HDR;
-
-	if (tx_entry->fi_flags & FI_REMOTE_CQ_DATA)
-		header_flags |= RXR_REQ_OPT_CQ_DATA_HDR;
-
-	max_data_offset = rxr_pkt_req_hdr_size(pkt_type, header_flags,
-					       tx_entry->rma_iov_count);
+	max_data_offset = rxr_pkt_req_max_hdr_size(pkt_type);
 
 	if (rxr_pkt_type_is_runtread(pkt_type)) {
 		max_data_offset += tx_entry->iov_count * sizeof(struct fi_rma_iov);

--- a/prov/efa/src/rxr/rxr_pkt_type_req.h
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.h
@@ -48,13 +48,11 @@ int64_t rxr_pkt_req_cq_data(struct rxr_pkt_entry *pkt_entry);
 
 uint32_t *rxr_pkt_req_connid_ptr(struct rxr_pkt_entry *pkt_entry);
 
-size_t rxr_pkt_req_hdr_size_from_pkt_entry(struct rxr_pkt_entry *pkt_entry);
-
 size_t rxr_pkt_req_base_hdr_size(struct rxr_pkt_entry *pkt_entry);
 
 size_t rxr_pkt_req_data_size(struct rxr_pkt_entry *pkt_entry);
 
-size_t rxr_pkt_req_hdr_size(int pkt_type, uint16_t flags, size_t rma_iov_count);
+size_t rxr_pkt_req_hdr_size(struct rxr_pkt_entry *pkt_entry);
 
 uint32_t rxr_pkt_hdr_rma_iov_count(struct rxr_pkt_entry *pkt_entry);
 


### PR DESCRIPTION
rxr_pkt_req_hdr_size() calculates the exact header size of a REQ packet.

Prior to this patch, it assumes the opt raw headersize to be a constant: RXR_REQ_OPT_RAW_HDR_SIZE. The assumption is wrong because this header size is a variable and is stored in as "addr_len" in rxr_req_opt_raw_hdr.

This patch addressed the issue by:

1. merging rxr_pkt_req_hdr_size_from_entry() into rxr_pkt_req_hdr_size(). The new function takes rxr_pkt_entry as input and load correct opt raw address header size from pkt entry's header

2. Re implement rxr_pkt_req_max_hdr_size() such that it does not call rxr_pkt_req_hdr_size().

3. Re implement rxr_op_entry_max_data_capacity that it call rxr_pkt_max_hdr_size() instead of rxr_pkt_req_hdr_size().

Signed-off-by: Wei Zhang <wzam@amazon.com>