### PR TITLE
prov/net: Process response messages past an unexpected message

### DIFF
--- a/fabtests/functional/loopback.c
+++ b/fabtests/functional/loopback.c
@@ -88,7 +88,7 @@ int main(int argc, char **argv)
 		return EXIT_FAILURE;
 
 	opts.src_addr = "127.0.0.1";
-	hints->caps |= FI_LOCAL_COMM;
+	hints->caps = FI_LOCAL_COMM | FI_MSG | FI_TAGGED;
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->mode = FI_CONTEXT;
 

--- a/fabtests/functional/loopback.c
+++ b/fabtests/functional/loopback.c
@@ -88,7 +88,7 @@ int main(int argc, char **argv)
 		return EXIT_FAILURE;
 
 	opts.src_addr = "127.0.0.1";
-	hints->caps = FI_LOCAL_COMM | FI_MSG | FI_TAGGED;
+	hints->caps |= FI_LOCAL_COMM;
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->mode = FI_CONTEXT;
 

--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -364,6 +364,24 @@ ofi_byteq_read(struct ofi_byteq *byteq, void *buf, size_t len)
 	return avail;
 }
 
+static inline size_t
+ofi_byteq_peek(struct ofi_byteq *byteq, void *buf, size_t len)
+{
+	size_t avail;
+
+	avail = ofi_byteq_readable(byteq);
+	if (!avail)
+		return 0;
+
+	if (len < avail) {
+		memcpy(buf, &byteq->data[byteq->head], len);
+		return len;
+	}
+
+	memcpy(buf, &byteq->data[byteq->head], avail);
+	return avail;
+}
+
 static inline void
 ofi_byteq_write(struct ofi_byteq *byteq, const void *buf, size_t len)
 {
@@ -425,6 +443,7 @@ static inline size_t ofi_bsock_tosend(struct ofi_bsock *bsock)
 
 ssize_t ofi_bsock_flush(struct ofi_bsock *bsock);
 ssize_t ofi_bsock_flush_sync(struct ofi_bsock *bsock);
+
 /* For sends started asynchronously, the return value will be -EINPROGRESS_ASYNC,
  * and len will be set to the number of bytes that were queued.
  */
@@ -434,6 +453,8 @@ ssize_t ofi_bsock_sendv(struct ofi_bsock *bsock, const struct iovec *iov,
 ssize_t ofi_bsock_recv(struct ofi_bsock *bsock, void *buf, size_t len);
 ssize_t ofi_bsock_recvv(struct ofi_bsock *bsock, struct iovec *iov,
 			size_t cnt);
+ssize_t ofi_bsock_peek(struct ofi_bsock *bsock, void *buf, size_t len);
+
 uint32_t ofi_bsock_async_done(const struct fi_provider *prov,
 			      struct ofi_bsock *bsock);
 

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -188,6 +188,7 @@ struct xnet_ep {
 	struct xnet_active_tx	cur_tx;
 	OFI_DBG_VAR(uint8_t, tx_id)
 	OFI_DBG_VAR(uint8_t, rx_id)
+	struct xnet_active_rx	saved_rx;
 
 	struct dlist_entry	unexp_entry;
 	struct slist		rx_queue;

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -137,7 +137,7 @@ void xnet_connect_done(struct xnet_ep *ep);
 void xnet_req_done(struct xnet_ep *ep);
 int xnet_send_cm_msg(struct xnet_ep *ep);
 
-struct xnet_cur_rx {
+struct xnet_active_rx {
 	union {
 		struct xnet_base_hdr	base_hdr;
 		struct xnet_cq_data_hdr cq_data_hdr;
@@ -153,7 +153,7 @@ struct xnet_cur_rx {
 	void			*claim_ctx;
 };
 
-struct xnet_cur_tx {
+struct xnet_active_tx {
 	size_t			data_left;
 	struct xnet_xfer_entry	*entry;
 };
@@ -184,8 +184,8 @@ int xnet_srx_context(struct fid_domain *domain, struct fi_rx_attr *attr,
 struct xnet_ep {
 	struct util_ep		util_ep;
 	struct ofi_bsock	bsock;
-	struct xnet_cur_rx	cur_rx;
-	struct xnet_cur_tx	cur_tx;
+	struct xnet_active_rx	cur_rx;
+	struct xnet_active_tx	cur_tx;
 	OFI_DBG_VAR(uint8_t, tx_id)
 	OFI_DBG_VAR(uint8_t, rx_id)
 

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -85,6 +85,7 @@ extern int xnet_prefetch_rbuf_size;
 extern size_t xnet_default_tx_size;
 extern size_t xnet_default_rx_size;
 extern size_t xnet_zerocopy_size;
+extern int xnet_trace_msg;
 extern int xnet_disable_autoprog;
 extern int xnet_io_uring;
 
@@ -206,7 +207,7 @@ struct xnet_ep {
 	struct xnet_conn_handle *conn;
 	struct xnet_cm_msg	*cm_msg;
 
-	void (*hdr_bswap)(struct xnet_base_hdr *hdr);
+	void (*hdr_bswap)(struct xnet_ep *ep, struct xnet_base_hdr *hdr);
 	void (*report_success)(struct xnet_ep *ep, struct util_cq *cq,
 			       struct xnet_xfer_entry *xfer_entry);
 	short			pollflags;
@@ -499,8 +500,10 @@ void xnet_reset_rx(struct xnet_ep *ep);
 void xnet_progress_rx(struct xnet_ep *ep);
 void xnet_progress_async(struct xnet_ep *ep);
 
-void xnet_hdr_none(struct xnet_base_hdr *hdr);
-void xnet_hdr_bswap(struct xnet_base_hdr *hdr);
+void xnet_hdr_none(struct xnet_ep *ep, struct xnet_base_hdr *hdr);
+void xnet_hdr_bswap(struct xnet_ep *ep, struct xnet_base_hdr *hdr);
+void xnet_hdr_trace(struct xnet_ep *ep, struct xnet_base_hdr *hdr);
+void xnet_hdr_bswap_trace(struct xnet_ep *ep, struct xnet_base_hdr *hdr);
 
 void xnet_tx_queue_insert(struct xnet_ep *ep,
 			  struct xnet_xfer_entry *tx_entry);

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -493,6 +493,7 @@ void xnet_report_cntr_success(struct xnet_ep *ep, struct util_cq *cq,
 			      struct xnet_xfer_entry *xfer_entry);
 void xnet_cntr_incerr(struct xnet_ep *ep, struct xnet_xfer_entry *xfer_entry);
 
+void xnet_update_pollflag(struct xnet_ep *ep, short pollflag, bool set);
 void xnet_reset_rx(struct xnet_ep *ep);
 
 void xnet_progress_rx(struct xnet_ep *ep);

--- a/prov/net/src/xnet_cm.c
+++ b/prov/net/src/xnet_cm.c
@@ -154,8 +154,13 @@ void xnet_req_done(struct xnet_ep *ep)
 	}
 
 	ep->hit_cnt++;
-	ep->hdr_bswap = (ep->cm_msg->hdr.conn_data == 1) ?
-			xnet_hdr_none : xnet_hdr_bswap;
+	if (xnet_trace_msg) {
+		ep->hdr_bswap = (ep->cm_msg->hdr.conn_data == 1) ?
+				xnet_hdr_trace : xnet_hdr_bswap_trace;
+	} else {
+		ep->hdr_bswap = (ep->cm_msg->hdr.conn_data == 1) ?
+				xnet_hdr_none : xnet_hdr_bswap;
+	}
 
 	len = ntohs(ep->cm_msg->hdr.seg_size);
 	cm_entry.fid = &ep->util_ep.ep_fid.fid;

--- a/prov/net/src/xnet_init.c
+++ b/prov/net/src/xnet_init.c
@@ -64,6 +64,7 @@ int xnet_prefetch_rbuf_size = 9000;
 size_t xnet_default_tx_size = 256;
 size_t xnet_default_rx_size = 256;
 size_t xnet_zerocopy_size = SIZE_MAX;
+int xnet_trace_msg;
 int xnet_disable_autoprog;
 int xnet_io_uring;
 
@@ -135,6 +136,10 @@ static void xnet_init_env(void)
 			 &xnet_prefetch_rbuf_size);
 	fi_param_get_size_t(&xnet_prov, "zerocopy_size", &xnet_zerocopy_size);
 
+	fi_param_define(&xnet_prov, "trace_msg", FI_PARAM_BOOL,
+			"Capture and display transport message information "
+			"when FI_LOG_LEVEL=TRACE is specified");
+	fi_param_get_bool(&xnet_prov, "trace_msg", &xnet_trace_msg);
 	fi_param_define(&xnet_prov, "disable_auto_progress", FI_PARAM_BOOL,
 			"prevent auto-progress thread from starting");
 	fi_param_get_bool(&xnet_prov, "disable_auto_progress",

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -460,7 +460,7 @@ static int xnet_handle_ack(struct xnet_ep *ep)
 
 ssize_t xnet_start_recv(struct xnet_ep *ep, struct xnet_xfer_entry *rx_entry)
 {
-	struct xnet_cur_rx *msg = &ep->cur_rx;
+	struct xnet_active_rx *msg = &ep->cur_rx;
 	size_t msg_len;
 	ssize_t ret;
 
@@ -505,7 +505,7 @@ truncate_err:
 static ssize_t xnet_op_msg(struct xnet_ep *ep)
 {
 	struct xnet_xfer_entry *rx_entry;
-	struct xnet_cur_rx *msg = &ep->cur_rx;
+	struct xnet_active_rx *msg = &ep->cur_rx;
 
 	assert(xnet_progress_locked(xnet_ep2_progress(ep)));
 	if (msg->hdr.base_hdr.op_data == XNET_OP_ACK)
@@ -527,7 +527,7 @@ static ssize_t xnet_op_msg(struct xnet_ep *ep)
 static ssize_t xnet_op_tagged(struct xnet_ep *ep)
 {
 	struct xnet_xfer_entry *rx_entry;
-	struct xnet_cur_rx *msg = &ep->cur_rx;
+	struct xnet_active_rx *msg = &ep->cur_rx;
 	uint64_t tag;
 
 	assert(xnet_progress_locked(xnet_ep2_progress(ep)));

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -269,7 +269,7 @@ static void xnet_progress_tx(struct xnet_ep *ep)
 
 		ep->cur_tx.data_left = ep->cur_tx.entry->hdr.base_hdr.size;
 		OFI_DBG_SET(ep->cur_tx.entry->hdr.base_hdr.id, ep->tx_id++);
-		ep->hdr_bswap(&ep->cur_tx.entry->hdr.base_hdr);
+		ep->hdr_bswap(ep, &ep->cur_tx.entry->hdr.base_hdr);
 	}
 
 	/* Buffered data is sent first by xnet_send_msg, but if we don't
@@ -779,7 +779,7 @@ next_hdr:
 		return -FI_EAGAIN;
 	}
 
-	ep->hdr_bswap(&ep->cur_rx.hdr.base_hdr);
+	ep->hdr_bswap(ep, &ep->cur_rx.hdr.base_hdr);
 	assert(ep->cur_rx.hdr.base_hdr.id == ep->rx_id++);
 	if (ep->cur_rx.hdr.base_hdr.op >= ARRAY_SIZE(xnet_start_op)) {
 		FI_WARN(&xnet_prov, FI_LOG_EP_DATA,
@@ -840,7 +840,7 @@ void xnet_tx_queue_insert(struct xnet_ep *ep,
 		ep->cur_tx.entry = tx_entry;
 		ep->cur_tx.data_left = tx_entry->hdr.base_hdr.size;
 		OFI_DBG_SET(tx_entry->hdr.base_hdr.id, ep->tx_id++);
-		ep->hdr_bswap(&tx_entry->hdr.base_hdr);
+		ep->hdr_bswap(ep, &tx_entry->hdr.base_hdr);
 		xnet_progress_tx(ep);
 	} else if (tx_entry->ctrl_flags & XNET_INTERNAL_XFER) {
 		slist_insert_tail(&tx_entry->entry, &ep->priority_queue);

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -63,6 +63,26 @@ static struct ofi_sockapi xnet_sockapi_socket =
 };
 
 
+static bool xnet_have_saved_rx(struct xnet_ep *ep)
+{
+	return ep->saved_rx.hdr_done != 0;
+}
+
+static void xnet_save_rx(struct xnet_ep *ep)
+{
+	assert(ep->cur_rx.hdr_done == ep->cur_rx.hdr_len &&
+	       !ep->cur_rx.claim_ctx);
+	assert(!xnet_have_saved_rx(ep));
+	ep->saved_rx = ep->cur_rx;
+	xnet_reset_rx(ep);
+}
+
+static void xnet_restore_rx(struct xnet_ep *ep)
+{
+	ep->cur_rx = ep->saved_rx;
+	ep->saved_rx.hdr_done = 0;
+}
+
 static void xnet_update_pollflag(struct xnet_ep *ep, short pollflag, bool set)
 {
 	struct xnet_progress *progress;

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -83,6 +83,20 @@ static void xnet_restore_rx(struct xnet_ep *ep)
 	ep->saved_rx.hdr_done = 0;
 }
 
+static int xnet_peek_next_msg(struct xnet_ep *ep, uint8_t *op, uint8_t *op_data)
+{
+	struct xnet_peek_hdr hdr;
+	ssize_t ret;
+
+	ret = ofi_bsock_peek(&ep->bsock, &hdr, sizeof hdr);
+	if (ret != sizeof hdr)
+		return -FI_ENOMSG;
+
+	*op = hdr.op;
+	*op_data = hdr.op_data;
+	return 0;
+}
+
 static void xnet_update_pollflag(struct xnet_ep *ep, short pollflag, bool set)
 {
 	struct xnet_progress *progress;

--- a/prov/net/src/xnet_proto.h
+++ b/prov/net/src/xnet_proto.h
@@ -78,6 +78,15 @@ enum {
 #define XNET_COMMIT_COMPLETE	(1 << 3)
 #define XNET_TAGGED		(1 << 7)
 
+/* Minimal data from base header to identify next message */
+struct xnet_peek_hdr {
+	uint8_t			version;
+	uint8_t			op;
+	uint8_t			flags1;
+	uint8_t			flags2;
+	uint8_t			op_data;
+};
+
 struct xnet_base_hdr {
 	uint8_t			version;
 	uint8_t			op;

--- a/prov/net/src/xnet_rma.c
+++ b/prov/net/src/xnet_rma.c
@@ -127,6 +127,7 @@ xnet_rma_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 	xnet_rma_read_recv_entry_fill(recv_entry, ep, msg, flags);
 
 	slist_insert_tail(&recv_entry->entry, &ep->rma_read_queue);
+	xnet_update_pollflag(ep, POLLIN, true);
 	xnet_tx_queue_insert(ep, send_entry);
 unlock:
 	ofi_genlock_unlock(&xnet_ep2_progress(ep)->lock);

--- a/prov/net/src/xnet_srx.c
+++ b/prov/net/src/xnet_srx.c
@@ -184,7 +184,7 @@ static int xnet_match_rx_tag(struct dlist_entry *item, const void *arg)
 {
 	const struct xnet_xfer_entry *recv_entry = arg;
 	struct xnet_ep *ep;
-	struct xnet_cur_rx *msg;
+	struct xnet_active_rx *msg;
 	uint64_t cur_tag;
 
 	ep = container_of(item, struct xnet_ep, unexp_entry);
@@ -202,7 +202,7 @@ static int xnet_match_claim(struct dlist_entry *item, const void *arg)
 {
 	const struct xnet_xfer_entry *recv_entry = arg;
 	struct xnet_ep *ep;
-	struct xnet_cur_rx *msg;
+	struct xnet_active_rx *msg;
 	uint64_t cur_tag;
 
 	ep = container_of(item, struct xnet_ep, unexp_entry);

--- a/src/common.c
+++ b/src/common.c
@@ -1392,6 +1392,30 @@ out:
 	return ret ? -ofi_sockerr(): -FI_ENOTCONN;
 }
 
+ssize_t ofi_bsock_peek(struct ofi_bsock *bsock, void *buf, size_t len)
+{
+	size_t bytes;
+	ssize_t ret;
+
+	bytes = ofi_byteq_peek(&bsock->rq, buf, len);
+	if (bytes) {
+		if (bytes == len)
+			return len;
+
+		buf = (char *) buf + bytes;
+		len -= bytes;
+	}
+
+	ret = ofi_recv_socket(bsock->sock, buf, len,
+			      MSG_NOSIGNAL | MSG_DONTWAIT | MSG_PEEK);
+	if (ret > 0)
+		return bytes + ret;
+
+	if (bytes)
+		return bytes;
+	return ret ? -ofi_sockerr(): -FI_ENOTCONN;
+}
+
 #ifdef MSG_ZEROCOPY
 uint32_t ofi_bsock_async_done(const struct fi_provider *prov,
 			      struct ofi_bsock *bsock)


### PR DESCRIPTION
    If we're waiting for an ACK or an RMA read response, it may be
    blocked behind a unexpected receive message.  Unfortunately, this
    is a common MPI flow:
    
        for each rank
            RMA read()
        barrier()
    
    The barrier messages may begin to show up from peers before
    the local rank has finished its RMA read operations.  And the
    local rank won't post the receive message for the barrier until
    the RMA read operations have completed.
    
    There seems to be some sort of assumption that RMA read responses
    have a separate from from messages, which is true when using an
    RDMA device.  However, it's not true for tcp streams.  To handle
    this case, we need to look ahead in the tcp stream for the response,
    queuing the barrier message.
    
    To minimize the changes to the provider and avoid re-introducing
    unexpected message buffering at the receiver, we limit peeking
    ahead in the tcp stream to a single 0-byte message (what MPI uses
    for barrier), at least for now.