### PR TITLE
common/shared.c: remove extra ft_sync() in ft_exchange_keys()

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -1595,7 +1595,7 @@ int ft_exchange_keys(struct fi_rma_iov *peer_iov)
 	if (ret)
 		return ret;
 
-	return ft_sync();
+	return 0;
 }
 
 static void ft_cleanup_mr_array(struct ft_context *ctx_arr, char **mr_bufs)


### PR DESCRIPTION
Previous commit 4ea2df52e0dd2bdc3b29a627f85d7c17236838ad added a call to ft_sync() to the end of ft_exchange_keys(), which broke the backward compatiblity with previous version of fabtests.

This patch removed it.

Signed-off-by: Wei Zhang <wzam@amazon.com>