### PR TITLE
ofi_hmem: new rdma flush function + prov/efa: Emulated Atomic Support for Cuda Devices

### DIFF
--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -171,6 +171,7 @@ int cuda_gdrcopy_hmem_cleanup(void);
 int cuda_gdrcopy_dev_register(struct fi_mr_attr *mr_attr, uint64_t *handle);
 int cuda_gdrcopy_dev_unregister(uint64_t handle);
 int cuda_set_sync_memops(void *ptr);
+int cuda_flush_rdma_operations(void);
 
 #define ZE_MAX_DEVICES 8
 int ze_hmem_copy(uint64_t device, void *dst, const void *src, size_t size);

--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -290,6 +290,18 @@ ssize_t ofi_copy_to_hmem_iov(enum fi_hmem_iface hmem_iface, uint64_t device,
 			     size_t hmem_iov_count, uint64_t hmem_iov_offset,
 			     const void *src, size_t size);
 
+static inline int ofi_copy_to_hmem(enum fi_hmem_iface iface, uint64_t device,
+				   void *dest, const void *src, size_t size)
+{
+	return hmem_ops[iface].copy_to_hmem(device, dest, src, size);
+}
+
+static inline int ofi_copy_from_hmem(enum fi_hmem_iface iface, uint64_t device,
+				     void *dest, const void *src, size_t size)
+{
+	return hmem_ops[iface].copy_from_hmem(device, dest, src, size);
+}
+
 int ofi_hmem_get_handle(enum fi_hmem_iface iface, void *base_addr, void **handle);
 int ofi_hmem_open_handle(enum fi_hmem_iface iface, void **handle,
 			 uint64_t device, void **mapped_addr);

--- a/prov/efa/src/rxr/rxr_atomic.c
+++ b/prov/efa/src/rxr/rxr_atomic.c
@@ -137,9 +137,6 @@ ssize_t rxr_atomic_generic_efa(struct rxr_ep *rxr_ep,
 	assert(msg->iov_count <= rxr_ep->tx_iov_limit);
 	efa_perfset_start(rxr_ep, perf_efa_tx);
 
-	if (msg->desc && efa_mr_is_cuda(msg->desc[0]))
-		return -FI_ENOSYS;
-
 	ofi_mutex_lock(&rxr_ep->util_ep.lock);
 
 	if (OFI_UNLIKELY(is_tx_res_full(rxr_ep))) {
@@ -383,6 +380,8 @@ rxr_atomic_readwritemsg(struct fid_ep *ep,
 
 	ofi_ioc_to_iov(resultv, atomic_ex.resp_iov, result_count, datatype_size);
 	atomic_ex.resp_iov_count = result_count;
+	atomic_ex.result_desc = *result_desc;
+	atomic_ex.compare_desc = NULL;
 	return rxr_atomic_generic_efa(rxr_ep, msg, &atomic_ex, ofi_op_atomic_fetch, flags);
 }
 
@@ -475,6 +474,8 @@ rxr_atomic_compwritemsg(struct fid_ep *ep,
 
 	ofi_ioc_to_iov(comparev, atomic_ex.comp_iov, compare_count, datatype_size);
 	atomic_ex.comp_iov_count = compare_count;
+	atomic_ex.compare_desc = *compare_desc;
+	atomic_ex.result_desc = *result_desc;
 
 	return rxr_atomic_generic_efa(rxr_ep, msg, &atomic_ex, ofi_op_atomic_compare, flags);
 }

--- a/prov/efa/src/rxr/rxr_op_entry.h
+++ b/prov/efa/src/rxr/rxr_op_entry.h
@@ -80,6 +80,8 @@ struct rxr_atomic_ex {
 	int resp_iov_count;
 	struct iovec comp_iov[RXR_IOV_LIMIT];
 	int comp_iov_count;
+	void *result_desc;
+	void *compare_desc;
 };
 
 enum rxr_cuda_copy_method {
@@ -166,7 +168,7 @@ struct rxr_op_entry {
 	struct dlist_entry pending_recv_entry;
 #endif
 
-	size_t efa_outstanding_tx_ops; 
+	size_t efa_outstanding_tx_ops;
 	size_t shm_outstanding_tx_ops;
 
 	/*

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -209,10 +209,10 @@ ssize_t rxr_pkt_init_cts(struct rxr_ep *ep,
 		cts_hdr->flags |= RXR_CTS_READ_REQ;
 
 	/* CTS is sent by different communication protocols.
-	 * CTS is sent using tx_entry in the emulated longcts read 
-	 * protocol. The emulated longcts write and the longcts 
+	 * CTS is sent using tx_entry in the emulated longcts read
+	 * protocol. The emulated longcts write and the longcts
 	 * message protocols sends CTS using rx_entry.
-	 * This check ensures appropriate tx_id and rx_id are 
+	 * This check ensures appropriate tx_id and rx_id are
 	 * assigned for the respective protocols */
 	if (op_entry->type == RXR_TX_ENTRY){
 		cts_hdr->send_id = op_entry->rx_id;
@@ -419,8 +419,8 @@ void rxr_pkt_handle_rma_read_completion(struct rxr_ep *ep,
 			rxr_release_tx_entry(ep, tx_entry);
 		} else if (read_entry->context_type == RXR_READ_CONTEXT_RX_ENTRY) {
 			rx_entry = read_entry->context;
-			rxr_tracing(read_completed, 
-				    rx_entry->msg_id, (size_t) rx_entry->cq_entry.op_context, 
+			rxr_tracing(read_completed,
+				    rx_entry->msg_id, (size_t) rx_entry->cq_entry.op_context,
 				    rx_entry->total_len, (size_t) read_entry->context);
 			err = rxr_pkt_post_or_queue(ep, rx_entry, RXR_EOR_PKT, false);
 			if (OFI_UNLIKELY(err)) {
@@ -624,7 +624,7 @@ void rxr_pkt_handle_atomrsp_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_en
 void rxr_pkt_handle_atomrsp_send_completion(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_op_entry *rx_entry;
-	
+
 	rx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
 	ofi_buf_free(rx_entry->atomrsp_data);
 	rx_entry->atomrsp_data = NULL;
@@ -637,15 +637,23 @@ void rxr_pkt_handle_atomrsp_recv(struct rxr_ep *ep,
 	struct rxr_atomrsp_pkt *atomrsp_pkt = NULL;
 	struct rxr_atomrsp_hdr *atomrsp_hdr = NULL;
 	struct rxr_op_entry *tx_entry = NULL;
+	uint64_t device;
+	enum fi_hmem_iface hmem_iface;
 
 	atomrsp_pkt = (struct rxr_atomrsp_pkt *)pkt_entry->pkt;
 	atomrsp_hdr = &atomrsp_pkt->hdr;
 	tx_entry = ofi_bufpool_get_ibuf(ep->op_entry_pool, atomrsp_hdr->recv_id);
 
-	ofi_copy_to_iov(tx_entry->atomic_ex.resp_iov,
-			tx_entry->atomic_ex.resp_iov_count,
-			0, atomrsp_pkt->data,
-			atomrsp_hdr->seg_length);
+    hmem_iface = ((struct efa_mr*) tx_entry->atomic_ex.result_desc)->peer.iface;
+    device = ((struct efa_mr*) tx_entry->atomic_ex.result_desc)->peer.device.reserved;
+
+	ofi_copy_to_hmem_iov(hmem_iface, device, tx_entry->atomic_ex.resp_iov,
+	                     tx_entry->atomic_ex.resp_iov_count, 0,
+	                     atomrsp_pkt->data, atomrsp_hdr->seg_length);
+
+
+	if (hmem_iface == FI_HMEM_CUDA)
+		cuda_flush_rdma_operations();
 
 	if (tx_entry->fi_flags & FI_COMPLETION)
 		rxr_cq_write_tx_completion(ep, tx_entry);

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -131,18 +131,6 @@ struct ofi_hmem_ops hmem_ops[] = {
 	},
 };
 
-static inline int ofi_copy_to_hmem(enum fi_hmem_iface iface, uint64_t device,
-				   void *dest, const void *src, size_t size)
-{
-	return hmem_ops[iface].copy_to_hmem(device, dest, src, size);
-}
-
-static inline int ofi_copy_from_hmem(enum fi_hmem_iface iface, uint64_t device,
-				     void *dest, const void *src, size_t size)
-{
-	return hmem_ops[iface].copy_from_hmem(device, dest, src, size);
-}
-
 static ssize_t ofi_copy_hmem_iov_buf(enum fi_hmem_iface hmem_iface, uint64_t device,
 				     const struct iovec *hmem_iov,
 				     size_t hmem_iov_count,

--- a/src/hmem_cuda.c
+++ b/src/hmem_cuda.c
@@ -56,7 +56,7 @@ struct cuda_ops {
 	CUresult (*cuPointerGetAttribute)(void *data,
 					  CUpointer_attribute attribute,
 					  CUdeviceptr ptr);
-	CUresult (*cuPointerSetAttribute)(void *data,
+	CUresult (*cuPointerSetAttribute)(const void *data,
 					  CUpointer_attribute attribute,
 					  CUdeviceptr ptr);
 	CUresult (*cuMemGetAddressRange)( CUdeviceptr* pbase,

--- a/src/hmem_cuda.c
+++ b/src/hmem_cuda.c
@@ -760,6 +760,12 @@ bool cuda_is_gdrcopy_enabled(void)
 	return hmem_cuda_use_gdrcopy;
 }
 
+int cuda_flush_rdma_operations(void)
+{
+	return cudaDeviceFlushGPUDirectRDMAWrites(cudaFlushGPUDirectRDMAWritesTargetCurrentDevice,
+	                                          cudaFlushGPUDirectRDMAWritesToOwner);
+}
+
 #else
 
 int cuda_copy_to_dev(uint64_t device, void *dev, const void *host, size_t size)
@@ -845,5 +851,10 @@ bool cuda_is_gdrcopy_enabled(void)
 int cuda_set_sync_memops(void *ptr)
 {
         return FI_SUCCESS;
+}
+
+int cuda_flush_rdma_operations(void)
+{
+	return -FI_ENOSYS;
 }
 #endif /* HAVE_CUDA */


### PR DESCRIPTION
Small change to ofi_hmem.h/cuda_hmem.c to add rdma flush function

Lots of changes to prov/efa to add emulated atomic support for CUDA devices.
1. Added result + fetch memory descriptors to rxr_atomic_ex
2. Switched every memcpy to be ofi_hmem memcpy
3. On the target side, added ofi_hmem memcpy's around emulated atomic impl functions, and performed them on host memory.

Testing:
```
fi_rdm_atomic -D cuda -p efa -E  # passes, and exits cleanly
fi_rdm_atomic -p efa -E                # passes, and exits cleanly
```