### PR TITLE
prov/shm: write tx err comp to correct cq

### DIFF
--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -239,7 +239,7 @@ static void smr_progress_resp(struct smr_ep *ep)
 			break;
 
 		if (-resp->status) {
-			ret = smr_write_err_comp(ep->util_ep.rx_cq, pending->context,
+			ret = smr_write_err_comp(ep->util_ep.tx_cq, pending->context,
 					 pending->op_flags, pending->cmd.msg.hdr.tag,
 					 -(resp->status));
 		} else {


### PR DESCRIPTION
Outstanding response entries always point to outgoing messages and should always be written to the tx cq.

Signed-off-by: zdworkin <zachary.dworkin@intel.com>