### PR TITLE
common: add IFF_RUNNING check to indicate iface is up and running

### DIFF
--- a/include/windows/ifaddrs.h
+++ b/include/windows/ifaddrs.h
@@ -15,6 +15,11 @@
 
 #include <Winsock2.h>
 
+/* IFF_RUNNING is not defined, reset it by IFF_UP */
+#ifndef IFF_RUNNING
+#define IFF_RUNNING IFF_UP
+#endif
+
 /* here is minimal subset of ifaddr API required for sockets & UDP
    providers */
 struct ifaddrs {

--- a/src/common.c
+++ b/src/common.c
@@ -2077,6 +2077,7 @@ void ofi_get_list_of_addr(const struct fi_provider *prov, const char *env_name,
 	for (ifa = ifaddrs; ifa != NULL; ifa = ifa->ifa_next) {
 		if (ifa->ifa_addr == NULL ||
 			!(ifa->ifa_flags & IFF_UP) ||
+			!(ifa->ifa_flags & IFF_RUNNING) ||
 			(ifa->ifa_flags & IFF_LOOPBACK) ||
 			((ifa->ifa_addr->sa_family != AF_INET) &&
 			(ifa->ifa_addr->sa_family != AF_INET6)))


### PR DESCRIPTION
Add checking for ifa_flags for IFF_RUNNING flag to filter out the interface, which is down and not running. In WinOS, there is not definition of IFF_RUNNING, reset it by IFF_UP.

Signed-off-by: Nikita Gusev <nikita.gusev@intel.com>