### PR TITLE
prov/net: RX operations now support io_uring

### DIFF
--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -417,6 +417,7 @@ struct ofi_bsock {
 	size_t zerocopy_size;
 	uint32_t async_index;
 	uint32_t done_index;
+	size_t async_prefetch;
 };
 
 static inline void
@@ -430,6 +431,7 @@ ofi_bsock_init(struct ofi_bsock *bsock, struct ofi_sockapi *sockapi,
 	ofi_byteq_init(&bsock->sq, sbuf_size);
 	ofi_byteq_init(&bsock->rq, rbuf_size);
 	bsock->zerocopy_size = SIZE_MAX;
+	bsock->async_prefetch = false;
 
 	/* first async op will wrap back to 0 as the starting index */
 	bsock->async_index = UINT32_MAX;
@@ -465,6 +467,7 @@ ssize_t ofi_bsock_recvv(struct ofi_bsock *bsock, struct iovec *iov,
 			size_t cnt, size_t *len);
 uint32_t ofi_bsock_async_done(const struct fi_provider *prov,
 			      struct ofi_bsock *bsock);
+void ofi_bsock_prefetch_done(struct ofi_bsock *bsock, size_t len);
 
 
 /*

--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -460,9 +460,9 @@ ssize_t ofi_bsock_flush_sync(struct ofi_bsock *bsock);
 ssize_t ofi_bsock_send(struct ofi_bsock *bsock, const void *buf, size_t *len);
 ssize_t ofi_bsock_sendv(struct ofi_bsock *bsock, const struct iovec *iov,
 			size_t cnt, size_t *len);
-ssize_t ofi_bsock_recv(struct ofi_bsock *bsock, void *buf, size_t len);
+ssize_t ofi_bsock_recv(struct ofi_bsock *bsock, void *buf, size_t *len);
 ssize_t ofi_bsock_recvv(struct ofi_bsock *bsock, struct iovec *iov,
-			size_t cnt);
+			size_t cnt, size_t *len);
 uint32_t ofi_bsock_async_done(const struct fi_provider *prov,
 			      struct ofi_bsock *bsock);
 

--- a/prov/net/src/xnet_ep.c
+++ b/prov/net/src/xnet_ep.c
@@ -324,6 +324,8 @@ static void xnet_ep_flush_all_queues(struct xnet_ep *ep)
 	struct xnet_cq *cq;
 
 	assert(xnet_progress_locked(xnet_ep2_progress(ep)));
+	assert(!ep->bsock.tx_sockctx.uring_sqe_inuse);
+	assert(!ep->bsock.rx_sockctx.uring_sqe_inuse);
 	cq = container_of(ep->util_ep.tx_cq, struct xnet_cq, util_cq);
 	if (ep->cur_tx.entry) {
 		ep->hdr_bswap(ep, &ep->cur_tx.entry->hdr.base_hdr);

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -278,13 +278,14 @@ static ssize_t xnet_recv_msg_data(struct xnet_ep *ep)
 {
 	struct xnet_xfer_entry *rx_entry;
 	ssize_t ret;
+	size_t len;
 
 	assert(xnet_progress_locked(xnet_ep2_progress(ep)));
 	if (!ep->cur_rx.data_left)
 		return FI_SUCCESS;
 
 	rx_entry = ep->cur_rx.entry;
-	ret = ofi_bsock_recvv(&ep->bsock, rx_entry->iov, rx_entry->iov_cnt);
+	ret = ofi_bsock_recvv(&ep->bsock, rx_entry->iov, rx_entry->iov_cnt, &len);
 	if (ret < 0)
 		return ret;
 
@@ -857,7 +858,7 @@ static ssize_t xnet_recv_hdr(struct xnet_ep *ep)
 next_hdr:
 	buf = (uint8_t *) &ep->cur_rx.hdr + ep->cur_rx.hdr_done;
 	len = ep->cur_rx.hdr_len - ep->cur_rx.hdr_done;
-	ret = ofi_bsock_recv(&ep->bsock, buf, len);
+	ret = ofi_bsock_recv(&ep->bsock, buf, &len);
 	if (ret < 0)
 		return ret;
 

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -286,8 +286,13 @@ static ssize_t xnet_recv_msg_data(struct xnet_ep *ep)
 
 	rx_entry = ep->cur_rx.entry;
 	ret = ofi_bsock_recvv(&ep->bsock, rx_entry->iov, rx_entry->iov_cnt, &len);
-	if (ret < 0)
+	if (ret < 0) {
+		if (ret == -OFI_EINPROGRESS_URING) {
+			ep->cur_rx.data_left -= len;
+			assert(ep->cur_rx.data_left);
+		}
 		return ret;
+	}
 
 	ep->cur_rx.data_left -= ret;
 	if (!ep->cur_rx.data_left)
@@ -859,8 +864,11 @@ next_hdr:
 	buf = (uint8_t *) &ep->cur_rx.hdr + ep->cur_rx.hdr_done;
 	len = ep->cur_rx.hdr_len - ep->cur_rx.hdr_done;
 	ret = ofi_bsock_recv(&ep->bsock, buf, &len);
-	if (ret < 0)
+	if (ret < 0) {
+		if (ret == -OFI_EINPROGRESS_URING)
+			ep->cur_rx.hdr_done += len;
 		return ret;
+	}
 
 	ep->cur_rx.hdr_done += ret;
 	if (ep->cur_rx.hdr_done == sizeof(ep->cur_rx.hdr.base_hdr)) {

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -82,12 +82,13 @@ static ssize_t tcpx_recv_msg_data(struct tcpx_ep *ep)
 {
 	struct tcpx_xfer_entry *rx_entry;
 	ssize_t ret;
+	size_t len;
 
 	if (!ep->cur_rx.data_left)
 		return FI_SUCCESS;
 
 	rx_entry = ep->cur_rx.entry;
-	ret = ofi_bsock_recvv(&ep->bsock, rx_entry->iov, rx_entry->iov_cnt);
+	ret = ofi_bsock_recvv(&ep->bsock, rx_entry->iov, rx_entry->iov_cnt, &len);
 	if (ret < 0)
 		return ret;
 
@@ -649,7 +650,7 @@ static ssize_t tcpx_recv_hdr(struct tcpx_ep *ep)
 next_hdr:
 	buf = (uint8_t *) &ep->cur_rx.hdr + ep->cur_rx.hdr_done;
 	len = ep->cur_rx.hdr_len - ep->cur_rx.hdr_done;
-	ret = ofi_bsock_recv(&ep->bsock, buf, len);
+	ret = ofi_bsock_recv(&ep->bsock, buf, &len);
 	if (ret < 0)
 		return ret;
 

--- a/src/common.c
+++ b/src/common.c
@@ -1300,22 +1300,22 @@ ssize_t ofi_bsock_sendv(struct ofi_bsock *bsock, const struct iovec *iov,
 	return ret;
 }
 
-ssize_t ofi_bsock_recv(struct ofi_bsock *bsock, void *buf, size_t len)
+ssize_t ofi_bsock_recv(struct ofi_bsock *bsock, void *buf, size_t *len)
 {
 	size_t bytes, avail;
 	ssize_t ret;
 
-	bytes = ofi_byteq_read(&bsock->rq, buf, len);
+	bytes = ofi_byteq_read(&bsock->rq, buf, *len);
 	if (bytes) {
-		if (bytes == len)
-			return len;
+		if (bytes == *len)
+			return *len;
 
 		buf = (char *) buf + bytes;
-		len -= bytes;
+		*len -= bytes;
 	}
 
 	assert(!ofi_bsock_readable(bsock));
-	if (len < (bsock->rq.size >> 1)) {
+	if (*len < (bsock->rq.size >> 1)) {
 		avail = ofi_byteq_writeable(&bsock->rq);
 		assert(avail);
 		ret = bsock->sockapi->recv(bsock->sockapi, bsock->sock,
@@ -1326,43 +1326,49 @@ ssize_t ofi_bsock_recv(struct ofi_bsock *bsock, void *buf, size_t len)
 
 		ofi_byteq_add(&bsock->rq, (size_t) ret);
 		assert(ofi_bsock_readable(bsock));
-		bytes += ofi_byteq_read(&bsock->rq, buf, len);
+		bytes += ofi_byteq_read(&bsock->rq, buf, *len);
 		return bytes;
 	}
 
-	ret = bsock->sockapi->recv(bsock->sockapi, bsock->sock, buf, len,
+	ret = bsock->sockapi->recv(bsock->sockapi, bsock->sock, buf, *len,
 				   MSG_NOSIGNAL, &bsock->rx_sockctx);
 	if (ret > 0)
 		return bytes + ret;
 
 out:
-	assert(ret != -OFI_EINPROGRESS_URING);
+	if (ret == -OFI_EINPROGRESS_URING) {
+		*len = bytes;
+		return ret;
+	}
 	if (bytes)
 		return bytes;
 	return ret ? -ofi_sockerr(): -FI_ENOTCONN;
 }
 
-ssize_t ofi_bsock_recvv(struct ofi_bsock *bsock, struct iovec *iov, size_t cnt)
+ssize_t ofi_bsock_recvv(struct ofi_bsock *bsock, struct iovec *iov, size_t cnt,
+			size_t *len)
 {
-	size_t len, bytes, avail;
+	size_t bytes, avail;
 	ssize_t ret;
 
-	if (cnt == 1)
-		return ofi_bsock_recv(bsock, iov[0].iov_base, iov[0].iov_len);
+	if (cnt == 1) {
+		*len = iov[0].iov_len;
+		return ofi_bsock_recv(bsock, iov[0].iov_base, len);
+	}
 
-	len = ofi_total_iov_len(iov, cnt);
+	*len = ofi_total_iov_len(iov, cnt);
 	if (ofi_byteq_readable(&bsock->rq)) {
 		bytes = ofi_byteq_readv(&bsock->rq, iov, cnt, 0);
-		if (bytes == len)
-			return len;
+		if (bytes == *len)
+			return *len;
 
-		len -= bytes;
+		*len -= bytes;
 	} else {
 		bytes = 0;
 	}
 
 	assert(!ofi_bsock_readable(bsock));
-	if (len < (bsock->rq.size >> 1)) {
+	if (*len < (bsock->rq.size >> 1)) {
 		avail = ofi_byteq_writeable(&bsock->rq);
 		assert(avail);
 		ret = bsock->sockapi->recv(bsock->sockapi, bsock->sock,
@@ -1388,7 +1394,10 @@ ssize_t ofi_bsock_recvv(struct ofi_bsock *bsock, struct iovec *iov, size_t cnt)
 	if (ret > 0)
 		return ret;
 out:
-	assert(ret != -OFI_EINPROGRESS_URING);
+	if (ret == -OFI_EINPROGRESS_URING) {
+		*len = bytes;
+		return ret;
+	}
 	if (bytes)
 		return bytes;
 	return ret ? -ofi_sockerr(): -FI_ENOTCONN;


### PR DESCRIPTION
This patch adds support of io_uring to RX operations.

 The implementation is still incomplete because of the
 following missing features:
 1. We need a mechanism to cancel all pending io_uring operations
    and wait for them to complete before we can close the ring.
    Pending receive operations would cause the code to fail
    an assertion failure when the endpoint is shut down.
 2. Recv byteq is disabled as we need to agree on a model. I'm not
    sure if recv byteq is useful with io_uring since we can
    pre-post receive buffers.

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>

