### PR TITLE
[v1.17.x] prov/net: Eliminate build warning due to partial io_uring support

### DIFF
--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -812,7 +812,8 @@ static void xnet_progress_cqe(struct xnet_uring *uring,
 
 	assert(xnet_io_uring);
 	bsock = (struct ofi_bsock *) cqe->user_data;
-	assert(bsock);
+	if (!bsock)
+		FI_WARN(&xnet_prov, FI_LOG_EP_DATA, "io_uring error\n");
 }
 
 static void xnet_progress_uring(struct xnet_uring *uring)


### PR DESCRIPTION
io_uring implementation is proceding in mainline, but disabled in release branch.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>