### PR TITLE
prov/sockets: retry setting conn->av_index

### DIFF
--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -1328,8 +1328,17 @@ static int sock_pe_process_rx_send(struct sock_pe *pe,
 	len = sizeof(struct sock_msg_hdr);
 
 	if (pe_entry->addr == FI_ADDR_NOTAVAIL &&
-	    pe_entry->ep_attr->ep_type == FI_EP_RDM && pe_entry->ep_attr->av)
+	    pe_entry->ep_attr->ep_type == FI_EP_RDM && pe_entry->ep_attr->av) {
+		if (pe_entry->conn->av_index == FI_ADDR_NOTAVAIL) {
+			/* this may happen when connection message comes in
+			 * before fi_av_insert. Let's try setting
+			 * conn->av_index now. */
+			pe_entry->conn->av_index =
+			    sock_av_get_addr_index(pe_entry->ep_attr->av,
+						   &(pe_entry->conn->addr));
+		}
 		pe_entry->addr = pe_entry->conn->av_index;
+	}
 
 	if (pe_entry->msg_hdr.op_type == SOCK_OP_TSEND) {
 		if (sock_pe_recv_field(pe_entry, &pe_entry->tag,


### PR DESCRIPTION
This is a back port of #8259 to v1.17.x.

When we make dynamic connections, it is possible for a connect message to arrive before the receiver issue fi_av_insert. This result in conn->av_index being set to FI_ADDR_NOTAVAIL, and leading to future message mismatch.

Retry setting the av_index fixes the issue. It works because the matching will always happen after the receiver issues fi_av_insert or it has to be a wild card receive.
