### PR TITLE
prov/shm: fix user_id support

### DIFF
--- a/prov/shm/src/smr_av.c
+++ b/prov/shm/src/smr_av.c
@@ -103,7 +103,7 @@ static int smr_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 		} else {
 			assert(shm_id >= 0 && shm_id < SMR_MAX_PEERS);
 			if (flags & FI_AV_USER_ID) {
-				assert(fi_addr && fi_addr[i]);
+				assert(fi_addr);
 				smr_av->smr_map->peers[shm_id].fiaddr = fi_addr[i];
 			} else {
 				smr_av->smr_map->peers[shm_id].fiaddr = util_addr;


### PR DESCRIPTION
fi_addr is an array of values, not an array of pointers so assert(fi_addr[i]) would fail if the application passed in an fi_addr of 0

Signed-off-by: Alexia Ingerson <alexia.ingerson@intel.com>