### PR TITLE
[v1.17.x] prov/net: Add save and restart look-ahead message processing

### DIFF
--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -85,6 +85,7 @@ extern int xnet_prefetch_rbuf_size;
 extern size_t xnet_default_tx_size;
 extern size_t xnet_default_rx_size;
 extern size_t xnet_zerocopy_size;
+extern int xnet_trace_msg;
 extern int xnet_disable_autoprog;
 extern int xnet_io_uring;
 
@@ -205,7 +206,7 @@ struct xnet_ep {
 	struct xnet_conn_handle *conn;
 	struct xnet_cm_msg	*cm_msg;
 
-	void (*hdr_bswap)(struct xnet_base_hdr *hdr);
+	void (*hdr_bswap)(struct xnet_ep *ep, struct xnet_base_hdr *hdr);
 	void (*report_success)(struct xnet_ep *ep, struct util_cq *cq,
 			       struct xnet_xfer_entry *xfer_entry);
 	short			pollflags;
@@ -497,8 +498,10 @@ void xnet_reset_rx(struct xnet_ep *ep);
 void xnet_progress_rx(struct xnet_ep *ep);
 void xnet_progress_async(struct xnet_ep *ep);
 
-void xnet_hdr_none(struct xnet_base_hdr *hdr);
-void xnet_hdr_bswap(struct xnet_base_hdr *hdr);
+void xnet_hdr_none(struct xnet_ep *ep, struct xnet_base_hdr *hdr);
+void xnet_hdr_bswap(struct xnet_ep *ep, struct xnet_base_hdr *hdr);
+void xnet_hdr_trace(struct xnet_ep *ep, struct xnet_base_hdr *hdr);
+void xnet_hdr_bswap_trace(struct xnet_ep *ep, struct xnet_base_hdr *hdr);
 
 void xnet_tx_queue_insert(struct xnet_ep *ep,
 			  struct xnet_xfer_entry *tx_entry);

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -138,7 +138,7 @@ void xnet_connect_done(struct xnet_ep *ep);
 void xnet_req_done(struct xnet_ep *ep);
 int xnet_send_cm_msg(struct xnet_ep *ep);
 
-struct xnet_cur_rx {
+struct xnet_active_rx {
 	union {
 		struct xnet_base_hdr	base_hdr;
 		struct xnet_cq_data_hdr cq_data_hdr;
@@ -154,7 +154,7 @@ struct xnet_cur_rx {
 	void			*claim_ctx;
 };
 
-struct xnet_cur_tx {
+struct xnet_active_tx {
 	size_t			data_left;
 	struct xnet_xfer_entry	*entry;
 };
@@ -185,8 +185,8 @@ int xnet_srx_context(struct fid_domain *domain, struct fi_rx_attr *attr,
 struct xnet_ep {
 	struct util_ep		util_ep;
 	struct ofi_bsock	bsock;
-	struct xnet_cur_rx	cur_rx;
-	struct xnet_cur_tx	cur_tx;
+	struct xnet_active_rx	cur_rx;
+	struct xnet_active_tx	cur_tx;
 	OFI_DBG_VAR(uint8_t, tx_id)
 	OFI_DBG_VAR(uint8_t, rx_id)
 

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -321,8 +321,7 @@ void xnet_run_progress(struct xnet_progress *progress, bool clear_signal);
 int xnet_progress_wait(struct xnet_progress *progress, int timeout);
 void xnet_run_conn(struct xnet_conn_handle *conn, bool pin, bool pout, bool perr);
 void xnet_handle_event_list(struct xnet_progress *progress);
-void xnet_progress_unexp(struct xnet_progress *progress,
-			   struct dlist_entry *list);
+void xnet_progress_unexp(struct xnet_progress *progress);
 
 int xnet_trywait(struct fid_fabric *fid_fabric, struct fid **fids, int count);
 int xnet_monitor_sock(struct xnet_progress *progress, SOCKET sock,

--- a/prov/net/src/xnet_cm.c
+++ b/prov/net/src/xnet_cm.c
@@ -154,8 +154,13 @@ void xnet_req_done(struct xnet_ep *ep)
 	}
 
 	ep->hit_cnt++;
-	ep->hdr_bswap = (ep->cm_msg->hdr.conn_data == 1) ?
-			xnet_hdr_none : xnet_hdr_bswap;
+	if (xnet_trace_msg) {
+		ep->hdr_bswap = (ep->cm_msg->hdr.conn_data == 1) ?
+				xnet_hdr_trace : xnet_hdr_bswap_trace;
+	} else {
+		ep->hdr_bswap = (ep->cm_msg->hdr.conn_data == 1) ?
+				xnet_hdr_none : xnet_hdr_bswap;
+	}
 
 	len = ntohs(ep->cm_msg->hdr.seg_size);
 	cm_entry.fid = &ep->util_ep.ep_fid.fid;

--- a/prov/net/src/xnet_init.c
+++ b/prov/net/src/xnet_init.c
@@ -64,6 +64,7 @@ int xnet_prefetch_rbuf_size = 9000;
 size_t xnet_default_tx_size = 256;
 size_t xnet_default_rx_size = 256;
 size_t xnet_zerocopy_size = SIZE_MAX;
+int xnet_trace_msg;
 int xnet_disable_autoprog;
 int xnet_io_uring;
 
@@ -135,6 +136,10 @@ static void xnet_init_env(void)
 			 &xnet_prefetch_rbuf_size);
 	fi_param_get_size_t(&xnet_prov, "zerocopy_size", &xnet_zerocopy_size);
 
+	fi_param_define(&xnet_prov, "trace_msg", FI_PARAM_BOOL,
+			"Capture and display transport message information "
+			"when FI_LOG_LEVEL=TRACE is specified");
+	fi_param_get_bool(&xnet_prov, "trace_msg", &xnet_trace_msg);
 	fi_param_define(&xnet_prov, "disable_auto_progress", FI_PARAM_BOOL,
 			"prevent auto-progress thread from starting");
 	fi_param_get_bool(&xnet_prov, "disable_auto_progress",

--- a/prov/net/src/xnet_pep.c
+++ b/prov/net/src/xnet_pep.c
@@ -271,7 +271,7 @@ static int xnet_pep_reject(struct fid_pep *pep, fid_t fid_handle,
 	ssize_t size_ret;
 	int ret;
 
-	FI_DBG(&xnet_prov, FI_LOG_EP_CTRL, "rejecting connection");
+	FI_DBG(&xnet_prov, FI_LOG_EP_CTRL, "rejecting connection\n");
 	conn = container_of(fid_handle, struct xnet_conn_handle, fid);
 	/* If we created an endpoint, it owns the socket */
 	if (conn->sock == INVALID_SOCKET)

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -460,7 +460,7 @@ static int xnet_handle_ack(struct xnet_ep *ep)
 
 ssize_t xnet_start_recv(struct xnet_ep *ep, struct xnet_xfer_entry *rx_entry)
 {
-	struct xnet_cur_rx *msg = &ep->cur_rx;
+	struct xnet_active_rx *msg = &ep->cur_rx;
 	size_t msg_len;
 	ssize_t ret;
 
@@ -505,7 +505,7 @@ truncate_err:
 static ssize_t xnet_op_msg(struct xnet_ep *ep)
 {
 	struct xnet_xfer_entry *rx_entry;
-	struct xnet_cur_rx *msg = &ep->cur_rx;
+	struct xnet_active_rx *msg = &ep->cur_rx;
 
 	assert(xnet_progress_locked(xnet_ep2_progress(ep)));
 	if (msg->hdr.base_hdr.op_data == XNET_OP_ACK)
@@ -527,7 +527,7 @@ static ssize_t xnet_op_msg(struct xnet_ep *ep)
 static ssize_t xnet_op_tagged(struct xnet_ep *ep)
 {
 	struct xnet_xfer_entry *rx_entry;
-	struct xnet_cur_rx *msg = &ep->cur_rx;
+	struct xnet_active_rx *msg = &ep->cur_rx;
 	uint64_t tag;
 
 	assert(xnet_progress_locked(xnet_ep2_progress(ep)));

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -879,14 +879,13 @@ xnet_handle_events(struct xnet_progress *progress,
 	xnet_handle_event_list(progress);
 }
 
-void xnet_progress_unexp(struct xnet_progress *progress,
-			 struct dlist_entry *list)
+void xnet_progress_unexp(struct xnet_progress *progress)
 {
 	struct dlist_entry *item, *tmp;
 	struct xnet_ep *ep;
 
 	assert(ofi_genlock_held(progress->active_lock));
-	dlist_foreach_safe(list, item, tmp) {
+	dlist_foreach_safe(&progress->unexp_tag_list, item, tmp) {
 		ep = container_of(item, struct xnet_ep, unexp_entry);
 		assert(xnet_has_unexp(ep));
 		assert(ep->state == XNET_CONNECTED);

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -204,7 +204,7 @@ static void xnet_progress_tx(struct xnet_ep *ep)
 
 		ep->cur_tx.data_left = ep->cur_tx.entry->hdr.base_hdr.size;
 		OFI_DBG_SET(ep->cur_tx.entry->hdr.base_hdr.id, ep->tx_id++);
-		ep->hdr_bswap(&ep->cur_tx.entry->hdr.base_hdr);
+		ep->hdr_bswap(ep, &ep->cur_tx.entry->hdr.base_hdr);
 	}
 
 	/* Buffered data is sent first by xnet_send_msg, but if we don't
@@ -704,7 +704,7 @@ next_hdr:
 		return -FI_EAGAIN;
 	}
 
-	ep->hdr_bswap(&ep->cur_rx.hdr.base_hdr);
+	ep->hdr_bswap(ep, &ep->cur_rx.hdr.base_hdr);
 	assert(ep->cur_rx.hdr.base_hdr.id == ep->rx_id++);
 	if (ep->cur_rx.hdr.base_hdr.op >= ARRAY_SIZE(xnet_start_op)) {
 		FI_WARN(&xnet_prov, FI_LOG_EP_DATA,
@@ -765,7 +765,7 @@ void xnet_tx_queue_insert(struct xnet_ep *ep,
 		ep->cur_tx.entry = tx_entry;
 		ep->cur_tx.data_left = tx_entry->hdr.base_hdr.size;
 		OFI_DBG_SET(tx_entry->hdr.base_hdr.id, ep->tx_id++);
-		ep->hdr_bswap(&tx_entry->hdr.base_hdr);
+		ep->hdr_bswap(ep, &tx_entry->hdr.base_hdr);
 		xnet_progress_tx(ep);
 	} else if (tx_entry->ctrl_flags & XNET_INTERNAL_XFER) {
 		slist_insert_tail(&tx_entry->entry, &ep->priority_queue);

--- a/prov/net/src/xnet_srx.c
+++ b/prov/net/src/xnet_srx.c
@@ -184,7 +184,7 @@ static int xnet_match_rx_tag(struct dlist_entry *item, const void *arg)
 {
 	const struct xnet_xfer_entry *recv_entry = arg;
 	struct xnet_ep *ep;
-	struct xnet_cur_rx *msg;
+	struct xnet_active_rx *msg;
 	uint64_t cur_tag;
 
 	ep = container_of(item, struct xnet_ep, unexp_entry);
@@ -202,7 +202,7 @@ static int xnet_match_claim(struct dlist_entry *item, const void *arg)
 {
 	const struct xnet_xfer_entry *recv_entry = arg;
 	struct xnet_ep *ep;
-	struct xnet_cur_rx *msg;
+	struct xnet_active_rx *msg;
 	uint64_t cur_tag;
 
 	ep = container_of(item, struct xnet_ep, unexp_entry);

--- a/prov/net/src/xnet_srx.c
+++ b/prov/net/src/xnet_srx.c
@@ -359,7 +359,7 @@ xnet_srx_tag(struct xnet_srx *srx, struct xnet_xfer_entry *recv_entry)
 
 		/* The message could match any endpoint waiting. */
 		if (!dlist_empty(&progress->unexp_tag_list))
-			xnet_progress_unexp(progress, &progress->unexp_tag_list);
+			xnet_progress_unexp(progress);
 	} else {
 		queue = ofi_array_at(&srx->src_tag_queues, recv_entry->src_addr);
 		if (!queue)

--- a/prov/net/src/xnet_srx.c
+++ b/prov/net/src/xnet_srx.c
@@ -267,14 +267,18 @@ xnet_srx_claim(struct xnet_srx *srx, struct xnet_xfer_entry *recv_entry,
 	if (flags & FI_DISCARD) {
 		msg_len = ep->cur_rx.hdr.base_hdr.size -
 			  ep->cur_rx.hdr.base_hdr.hdr_size;
-		recv_entry->user_buf = calloc(1, msg_len);
-		if (!recv_entry->user_buf)
-			return -FI_ENOMEM;
+		if (msg_len) {
+			recv_entry->user_buf = calloc(1, msg_len);
+			if (!recv_entry->user_buf)
+				return -FI_ENOMEM;
 
-		recv_entry->iov[0].iov_base = recv_entry->user_buf;
-		recv_entry->iov[0].iov_len = msg_len;
-		recv_entry->iov_cnt = 1;
-		recv_entry->ctrl_flags |= XNET_FREE_BUF;
+			recv_entry->iov[0].iov_base = recv_entry->user_buf;
+			recv_entry->iov[0].iov_len = msg_len;
+			recv_entry->iov_cnt = 1;
+			recv_entry->ctrl_flags |= XNET_FREE_BUF;
+		} else {
+			recv_entry->iov_cnt = 0;
+		}
 	}
 
 	ret = xnet_start_recv(ep, recv_entry);


### PR DESCRIPTION
Enhancements to support MPI RMA / barrier hangs.  See commit messages for details.