### PR TITLE
fabtests/pytest/efa: extend cuda client server test timeout

### DIFF
--- a/fabtests/pytest/efa/efa_common.py
+++ b/fabtests/pytest/efa/efa_common.py
@@ -10,7 +10,7 @@ def efa_run_client_server_test(cmdline_args, executable, iteration_type,
     # message sizes (especailly when running with multiple workers).
     timeout = None
     if "cuda" in memory_type:
-        timeout = max(1000, cmdline_args.timeout)
+        timeout = max(2000, cmdline_args.timeout)
 
     test = ClientServerTest(cmdline_args, executable, iteration_type,
                             completion_type=completion_type,


### PR DESCRIPTION
Double cuda client-server test timeout to reduce noise.

Signed-off-by: Wenduo Wang <wenduwan@amazon.com>