### PR TITLE
contrib/intel/jenkins: add verbose summary to post stage

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -710,6 +710,9 @@ pipeline {
           }
         }
       }
+      withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
+        sh "python3.7 ${env.WORKSPACE}/${SCRIPT_LOCATION}/summary.py -v --summary_item=all"
+      }
     }
   }
 }


### PR DESCRIPTION
Add a printout of almost every test that passed to the verbose summary in post stage.
Tests that don't have unique names aren't printed.
Sometimes having a list of every test that gets run is better than just having the total number of tests run.

Signed-off-by: Zach Dworkin <zachary.dworkin@intel.com>