### PR TITLE
prov/shm: Enable CMA Protocol with FI_HMEM and additional refactorings

### DIFF
--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -246,7 +246,6 @@ struct smr_region {
 				    Might not always be paired consistently with
 				    cmd alloc/free depending on protocol
 				    (Ex. unexpected messages, RMA requests) */
-	size_t		sar_cnt;
 
 	/* offsets from start of smr_region */
 	size_t		cmd_queue_offset;

--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -183,7 +183,7 @@ struct smr_addr {
 
 struct smr_peer_data {
 	struct smr_addr		addr;
-	uint32_t		sar_status;
+	uint32_t		status;
 	uint32_t		name_sent;
 };
 

--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -169,7 +169,7 @@ struct smr_cmd {
 
 #define SMR_INJECT_SIZE		4096
 #define SMR_COMP_INJECT_SIZE	(SMR_INJECT_SIZE / 2)
-#define SMR_SAR_SIZE		32768
+#define SMR_IFB_SIZE		32768
 
 #define SMR_DIR "/dev/shm/"
 #define SMR_NAME_MAX	256
@@ -230,7 +230,7 @@ struct smr_region {
 	int		pid;
 	uint8_t		cma_cap_peer;
 	uint8_t		cma_cap_self;
-	uint32_t	max_sar_buf_per_peer;
+	uint32_t	max_ifb_per_peer;
 	void		*base_addr;
 	pthread_spinlock_t	lock; /* lock for shm access
 				 Must hold smr->lock before tx/rx cq locks
@@ -251,7 +251,7 @@ struct smr_region {
 	size_t		cmd_queue_offset;
 	size_t		resp_queue_offset;
 	size_t		inject_pool_offset;
-	size_t		sar_pool_offset;
+	size_t		ifb_pool_offset;
 	size_t		peer_data_offset;
 	size_t		name_offset;
 	size_t		sock_name_offset;
@@ -277,12 +277,12 @@ enum smr_status {
 	SMR_STATUS_BUSY = FI_EBUSY, 	/* busy */
 
 	SMR_STATUS_OFFSET = 1024, 	/* Beginning of shm-specific codes */
-	SMR_STATUS_SAR_FREE, 		/* buffer can be used */
-	SMR_STATUS_SAR_READY, 		/* buffer has data in it */
+	SMR_STATUS_IFB_FREE, 		/* buffer can be used */
+	SMR_STATUS_IFB_READY, 		/* buffer has data in it */
 };
 
-struct smr_sar_buf {
-	uint8_t		buf[SMR_SAR_SIZE];
+struct smr_in_flight_buf {
+	uint8_t		buf[SMR_IFB_SIZE];
 };
 
 OFI_DECLARE_CIRQUE(struct smr_cmd, smr_cmd_queue);
@@ -308,10 +308,11 @@ static inline struct smr_peer_data *smr_peer_data(struct smr_region *smr)
 {
 	return (struct smr_peer_data *) ((char *) smr + smr->peer_data_offset);
 }
-static inline struct smr_freestack *smr_sar_pool(struct smr_region *smr)
+static inline struct smr_freestack *smr_ifb_pool(struct smr_region *smr)
 {
-	return (struct smr_freestack *) ((char *) smr + smr->sar_pool_offset);
+	return (struct smr_freestack *) ((char *) smr + smr->ifb_pool_offset);
 }
+
 static inline const char *smr_name(struct smr_region *smr)
 {
 	return (const char *) smr + smr->name_offset;
@@ -335,7 +336,7 @@ struct smr_attr {
 
 size_t smr_calculate_size_offsets(size_t tx_count, size_t rx_count,
 				  size_t *cmd_offset, size_t *resp_offset,
-				  size_t *inject_offset, size_t *sar_offset,
+				  size_t *inject_offset, size_t *ifb_offset,
 				  size_t *peer_offset, size_t *name_offset,
 				  size_t *sock_offset);
 void	smr_cma_check(struct smr_region *region, struct smr_region *peer_region);

--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -67,7 +67,8 @@ extern "C" {
 #define SMR_FLAG_DEBUG	(0 << 1)
 #endif
 
-#define SMR_FLAG_IPC_SOCK (1 << 2)
+#define SMR_FLAG_IPC_SOCK	(1 << 2)
+#define SMR_FLAG_IPC_ENABLED	(1 << 3)
 
 #define SMR_CMD_SIZE		256	/* align with 64-byte cache line */
 

--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -53,7 +53,7 @@ extern "C" {
 #endif
 
 
-#define SMR_VERSION	4
+#define SMR_VERSION	5
 
 #ifdef HAVE_ATOMICS
 #define SMR_FLAG_ATOMIC	(1 << 0)
@@ -137,6 +137,7 @@ union smr_cmd_data {
 		size_t		iov_count;
 		struct iovec	iov[(SMR_MSG_DATA_LEN - sizeof(size_t)) /
 				    sizeof(struct iovec)];
+		int16_t		ipc_ifb;
 	};
 	struct {
 		uint32_t	buf_batch_size;
@@ -280,6 +281,7 @@ enum smr_status {
 	SMR_STATUS_OFFSET = 1024, 	/* Beginning of shm-specific codes */
 	SMR_STATUS_IFB_FREE, 		/* buffer can be used */
 	SMR_STATUS_IFB_READY, 		/* buffer has data in it */
+	SMR_STATUS_IPC,
 };
 
 struct smr_in_flight_buf {

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -216,8 +216,9 @@ struct smr_domain {
 #define SMR_RMA_ORDER (OFI_ORDER_RAR_SET | OFI_ORDER_RAW_SET | FI_ORDER_RAS |	\
 		       OFI_ORDER_WAR_SET | OFI_ORDER_WAW_SET | FI_ORDER_WAS |	\
 		       FI_ORDER_SAR | FI_ORDER_SAW)
-#define smr_fast_rma_enabled(mode, order) ((mode & FI_MR_VIRT_ADDR) && \
-			!(order & SMR_RMA_ORDER))
+#define smr_fast_rma_enabled(mode, order) ((mode & (FI_MR_VIRT_ADDR) &&	\
+					   !(mode & FI_MR_HMEM)) &&	\
+					   !(order & SMR_RMA_ORDER))
 
 static inline uint64_t smr_get_offset(void *base, void *addr)
 {
@@ -336,6 +337,10 @@ void smr_format_pend_resp(struct smr_progress_entry *pend, struct smr_cmd *cmd,
 			  void *context, enum fi_hmem_iface iface, uint64_t device,
 			  const struct iovec *iov, uint32_t iov_count,
 			  uint64_t op_flags, int64_t id, struct smr_resp *resp);
+int smr_format_ipc_info(struct smr_ep *ep, struct ipc_info *ipc_info,
+			int64_t id, const struct iovec *iov,
+			enum fi_hmem_iface iface, uint64_t device,
+			struct smr_progress_entry *pend);
 void smr_generic_format(struct smr_cmd *cmd, int64_t peer_id, uint32_t op,
 			uint64_t tag, uint64_t data, uint64_t op_flags);
 size_t smr_copy_to_sar(struct smr_freestack *sar_pool, struct smr_resp *resp,

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -142,7 +142,6 @@ struct smr_sar_entry {
 	struct smr_cmd		cmd;
 	struct fi_peer_rx_entry	*rx_entry;
 	size_t			bytes_done;
-	int			next;
 	struct iovec		iov[SMR_IOV_LIMIT];
 	size_t			iov_count;
 	enum fi_hmem_iface	iface;
@@ -354,11 +353,11 @@ void smr_generic_format(struct smr_cmd *cmd, int64_t peer_id, uint32_t op,
 size_t smr_copy_to_sar(struct smr_freestack *sar_pool, struct smr_resp *resp,
 		       struct smr_cmd *cmd, enum fi_hmem_iface, uint64_t device,
 		       const struct iovec *iov, size_t count,
-		       size_t *bytes_done, int *next);
+		       size_t *bytes_done);
 size_t smr_copy_from_sar(struct smr_freestack *sar_pool, struct smr_resp *resp,
 			 struct smr_cmd *cmd, enum fi_hmem_iface iface,
 			 uint64_t device, const struct iovec *iov, size_t count,
-			 size_t *bytes_done, int *next);
+			 size_t *bytes_done);
 
 int smr_select_proto(bool use_ipc, bool cma_avail, enum fi_hmem_iface iface,
 		     uint32_t op, uint64_t total_len, uint64_t op_flags);

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -347,8 +347,9 @@ size_t smr_copy_from_sar(struct smr_freestack *sar_pool, struct smr_resp *resp,
 			 uint64_t device, const struct iovec *iov, size_t count,
 			 size_t *bytes_done);
 
-int smr_select_proto(bool use_ipc, bool cma_avail, enum fi_hmem_iface iface,
-		     uint32_t op, uint64_t total_len, uint64_t op_flags);
+int smr_select_proto(struct smr_ep *ep, struct smr_region *peer_smr,
+		     enum fi_hmem_iface iface, void **desc, uint32_t op,
+		     size_t iov_count, size_t total_len, uint64_t op_flags);
 typedef ssize_t (*smr_proto_func)(struct smr_ep *ep, struct smr_region *peer_smr,
 		int64_t id, int64_t peer_id, uint32_t op, uint64_t tag,
 		uint64_t data, uint64_t op_flags, enum fi_hmem_iface iface,

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -291,7 +291,7 @@ struct smr_ep {
 	struct smr_pend_fs	*tx_pend_fs;
 	struct smr_pend_fs	*rx_pend_fs;
 
-	struct dlist_entry	sar_list;
+	struct dlist_entry	in_flight_list;
 
 	int			ep_idx;
 	struct smr_sock_info	*sock_info;

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -406,6 +406,13 @@ static inline bool smr_ze_ipc_enabled(struct smr_region *smr,
 	       (peer_smr->flags & SMR_FLAG_IPC_SOCK);
 }
 
+static inline bool smr_ipc_enabled(struct smr_region *smr,
+				   struct smr_region *peer_smr)
+{
+	return (smr->flags & SMR_FLAG_IPC_ENABLED) &&
+	       (peer_smr->flags & SMR_FLAG_IPC_ENABLED);
+}
+
 static inline int smr_cma_loop(pid_t pid, struct iovec *local,
 			unsigned long local_cnt, struct iovec *remote,
 			unsigned long remote_cnt, unsigned long flags,

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -134,7 +134,7 @@ static ssize_t smr_do_atomic_inject(struct smr_ep *ep, struct smr_region *peer_s
 {
 	struct smr_cmd *cmd;
 	struct smr_inject_buf *tx_buf;
-	struct smr_tx_entry *pend;
+	struct smr_progress_entry *pend;
 	struct smr_resp *resp;
 
 	cmd = ofi_cirque_next(smr_cmd_queue(peer_smr));
@@ -152,7 +152,7 @@ static ssize_t smr_do_atomic_inject(struct smr_ep *ep, struct smr_region *peer_s
 			return -FI_EAGAIN;
 		}
 		resp = ofi_cirque_next(smr_resp_queue(ep->region));
-		pend = ofi_freestack_pop(ep->pend_fs);
+		pend = ofi_freestack_pop(ep->tx_pend_fs);
 		smr_format_pend_resp(pend, cmd, context, iface, device, resultv,
 				     result_count, op_flags, id, resp);
 		cmd->msg.hdr.data = smr_get_offset(ep->region, resp);

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -212,7 +212,7 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 	peer_smr = smr_peer_region(ep->region, id);
 
 	pthread_spin_lock(&peer_smr->lock);
-	if (peer_smr->cmd_cnt < 2 || smr_peer_data(ep->region)[id].sar_status) {
+	if (peer_smr->cmd_cnt < 2 || smr_peer_data(ep->region)[id].status) {
 		ret = -FI_EAGAIN;
 		goto unlock_region;
 	}
@@ -362,7 +362,7 @@ static ssize_t smr_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 	peer_smr = smr_peer_region(ep->region, id);
 
 	pthread_spin_lock(&peer_smr->lock);
-	if (peer_smr->cmd_cnt < 2 || smr_peer_data(ep->region)[id].sar_status) {
+	if (peer_smr->cmd_cnt < 2 || smr_peer_data(ep->region)[id].status) {
 		ret = -FI_EAGAIN;
 		goto unlock_region;
 	}

--- a/prov/shm/src/smr_av.c
+++ b/prov/shm/src/smr_av.c
@@ -118,7 +118,7 @@ static int smr_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 			util_ep = container_of(av_entry, struct util_ep, av_entry);
 			smr_ep = container_of(util_ep, struct smr_ep, util_ep);
 			smr_map_to_endpoint(smr_ep->region, shm_id);
-			smr_ep->region->max_sar_buf_per_peer =
+			smr_ep->region->max_ifb_per_peer =
 				SMR_MAX_PEERS / smr_av->smr_map->num_peers;
 		}
 	}
@@ -161,11 +161,11 @@ static int smr_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr, size_t count
 			smr_ep = container_of(util_ep, struct smr_ep, util_ep);
 			smr_unmap_from_endpoint(smr_ep->region, id);
 			if (smr_av->smr_map->num_peers > 0)
-				smr_ep->region->max_sar_buf_per_peer =
+				smr_ep->region->max_ifb_per_peer =
 					SMR_MAX_PEERS /
 					smr_av->smr_map->num_peers;
 			else
-				smr_ep->region->max_sar_buf_per_peer =
+				smr_ep->region->max_ifb_per_peer =
 					SMR_BUF_BATCH_MAX;
 		}
 		smr_av->used--;

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -610,7 +610,7 @@ static int smr_format_sar(struct smr_ep *ep, struct smr_cmd *cmd,
 	}
 
 	peer_smr->sar_cnt--;
-	smr_peer_data(smr)[id].sar_status = SMR_STATUS_SAR_READY;
+	smr_peer_data(smr)[id].status = SMR_STATUS_SAR_READY;
 
 	return 0;
 }

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -306,7 +306,7 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 	peer_smr = smr_peer_region(ep->region, id);
 
 	pthread_spin_lock(&peer_smr->lock);
-	if (!peer_smr->cmd_cnt || smr_peer_data(ep->region)[id].sar_status) {
+	if (!peer_smr->cmd_cnt || smr_peer_data(ep->region)[id].status) {
 		ret = -FI_EAGAIN;
 		goto unlock_region;
 	}
@@ -414,7 +414,7 @@ static ssize_t smr_generic_inject(struct fid_ep *ep_fid, const void *buf,
 	peer_smr = smr_peer_region(ep->region, id);
 
 	pthread_spin_lock(&peer_smr->lock);
-	if (!peer_smr->cmd_cnt || smr_peer_data(ep->region)[id].sar_status) {
+	if (!peer_smr->cmd_cnt || smr_peer_data(ep->region)[id].status) {
 		ret = -FI_EAGAIN;
 		goto unlock;
 	}

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -293,7 +293,6 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 	int64_t id, peer_id;
 	ssize_t ret = 0;
 	size_t total_len;
-	bool use_ipc;
 	int proto;
 
 	assert(iov_count <= SMR_IOV_LIMIT);
@@ -317,15 +316,8 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 	total_len = ofi_total_iov_len(iov, iov_count);
 	assert(!(op_flags & FI_INJECT) || total_len <= SMR_INJECT_SIZE);
 
-	/* Do not inline/inject if IPC is available so device to device
-	 * transfer may occur if possible. */
-	use_ipc = ofi_hmem_is_ipc_enabled(iface) &&
-		  smr_ipc_enabled(ep->region, peer_smr) && (iov_count == 1) &&
-		  desc && (smr_get_mr_flags(desc) & FI_HMEM_DEVICE_ONLY) &&
-		  !(op_flags & FI_INJECT);
-
-	proto = smr_select_proto(use_ipc, smr_cma_enabled(ep, peer_smr), iface,
-				 op, total_len, op_flags);
+	proto = smr_select_proto(ep, peer_smr, iface, desc, op, iov_count,
+				 total_len, op_flags);
 
 	ret = smr_proto_ops[proto](ep, peer_smr, id, peer_id, op, tag, data, op_flags,
 				   iface, device, iov, iov_count, total_len, context);

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -319,7 +319,8 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 
 	/* Do not inline/inject if IPC is available so device to device
 	 * transfer may occur if possible. */
-	use_ipc = ofi_hmem_is_ipc_enabled(iface) && (iov_count == 1) &&
+	use_ipc = ofi_hmem_is_ipc_enabled(iface) &&
+		  smr_ipc_enabled(ep->region, peer_smr) && (iov_count == 1) &&
 		  desc && (smr_get_mr_flags(desc) & FI_HMEM_DEVICE_ONLY) &&
 		  !(op_flags & FI_INJECT);
 

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -212,7 +212,8 @@ static int smr_progress_resp_entry(struct smr_ep *ep, struct smr_resp *resp,
 					pending->cmd.msg.data.sar[i]);
 		}
 		peer_smr->sar_cnt++;
-		smr_peer_data(ep->region)[pending->peer_id].sar_status = 0;
+		smr_peer_data(ep->region)[pending->peer_id].status =
+							SMR_STATUS_SUCCESS;
 	}
 
 	if (peer_smr != ep->region)

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -164,7 +164,8 @@ static ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 
 	/* Do not inline/inject if IPC is available so device to device
 	 * transfer may occur if possible. */
-	use_ipc = ofi_hmem_is_ipc_enabled(iface) && (iov_count == 1) &&
+	use_ipc = ofi_hmem_is_ipc_enabled(iface) &&
+		  smr_ipc_enabled(ep->region, peer_smr) && (iov_count == 1) &&
 		  desc && (smr_get_mr_flags(desc) & FI_HMEM_DEVICE_ONLY) &&
 		  !(op_flags & FI_INJECT);
 

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -130,7 +130,7 @@ static ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 
 	pthread_spin_lock(&peer_smr->lock);
 	if (peer_smr->cmd_cnt < cmds ||
-	    smr_peer_data(ep->region)[id].sar_status) {
+	    smr_peer_data(ep->region)[id].status) {
 		ret = -FI_EAGAIN;
 		goto unlock_region;
 	}
@@ -332,7 +332,7 @@ static ssize_t smr_generic_rma_inject(struct fid_ep *ep_fid, const void *buf,
 
 	pthread_spin_lock(&peer_smr->lock);
 	if (peer_smr->cmd_cnt < cmds ||
-	    smr_peer_data(ep->region)[id].sar_status) {
+	    smr_peer_data(ep->region)[id].status) {
 		ret = -FI_EAGAIN;
 		goto unlock_region;
 	}

--- a/prov/util/src/util_shm.c
+++ b/prov/util/src/util_shm.c
@@ -268,6 +268,7 @@ int smr_create(const struct fi_provider *prov, struct smr_map *map,
 	(*smr)->map = map;
 	(*smr)->version = SMR_VERSION;
 	(*smr)->flags = SMR_FLAG_ATOMIC | SMR_FLAG_DEBUG;
+	(*smr)->flags |= ofi_hmem_p2p_disabled() ? 0 : SMR_FLAG_IPC_ENABLED;
 	(*smr)->cma_cap_peer = SMR_CMA_CAP_NA;
 	(*smr)->cma_cap_self = SMR_CMA_CAP_NA;
 	(*smr)->base_addr = *smr;

--- a/prov/util/src/util_shm.c
+++ b/prov/util/src/util_shm.c
@@ -293,7 +293,7 @@ int smr_create(const struct fi_provider *prov, struct smr_map *map,
 			sizeof(struct smr_sar_buf));
 	for (i = 0; i < SMR_MAX_PEERS; i++) {
 		smr_peer_addr_init(&smr_peer_data(*smr)[i].addr);
-		smr_peer_data(*smr)[i].sar_status = 0;
+		smr_peer_data(*smr)[i].status = SMR_STATUS_SUCCESS;
 		smr_peer_data(*smr)[i].name_sent = 0;
 	}
 

--- a/prov/util/src/util_shm.c
+++ b/prov/util/src/util_shm.c
@@ -281,8 +281,6 @@ int smr_create(const struct fi_provider *prov, struct smr_map *map,
 	(*smr)->name_offset = name_offset;
 	(*smr)->sock_name_offset = sock_name_offset;
 	(*smr)->cmd_cnt = rx_size;
-	/* Limit of 1 outstanding SAR message per peer */
-	(*smr)->sar_cnt = SMR_MAX_PEERS;
 	(*smr)->max_sar_buf_per_peer = SMR_BUF_BATCH_MAX;
 
 	smr_cmd_queue_init(smr_cmd_queue(*smr), rx_size);


### PR DESCRIPTION
The goal of these patches is to enable CMA (Cross Memory Attach) protocol with H->H transfers when FI_HMEM is enabled. The previous way of doing this was defaulting to SAR (Segmentation and Reassembly) protocol because if FI_HMEM is enabled the sender cannot be sure that the destination buffer is not a device buffer. If it was a device buffer it would error out because that memory access operation is not allowed.

Now H->H becomes possible again and a new protocol for doing H->D and D->H transfers exists. In order to create this new protocol: sar buffers, statusses, and progress_entry needed to be repurposed. They have now become ifbs (in flight buffers:  which can be used for both SAR and storing ipc information), new statusses, and a merged sar_entry and tx_entry. The sar_entry and tx_entry merged into a progress_entry because they are both used for in pending operations and it simplifies the use for this new protocol, SAR, and the DSA (Data Streaming Accelerator) paths. [The peer_id has been renamed to send_id to make it clear that it is only applicable for the sender]

The use of the IFB is necessary because if the sender sends its H buffer to a destination that is a D buffer, the reciever can utilize the IFB to save ipc information to give back to the sender so that the sender can resend the message with device operations.

The select protocol function has also been simplified because of these changes and the addition of an ipc_enabled flag.

[H=Host, D=Device, CMA=Cross Memory Attach, SAR=Segmentation and Reassembly, DSA=Data Streaming Accelerator]