### PR TITLE
[v1.16.x] fabtests/pytest: use pytest-xdist to parallelize tests

### DIFF
--- a/fabtests/pytest/conftest.py
+++ b/fabtests/pytest/conftest.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 def get_option_longform(option_name, option_params):
@@ -138,9 +139,15 @@ class CmdlineArgs:
         if host_type == "host":
             return command
 
+        if self.oob_address_exchange:
+            oob_argument = "-E"
+            if "PYTEST_XDIST_WORKER" in os.environ:
+                oob_port = 9228 + int(os.environ["PYTEST_XDIST_WORKER"].replace("gw", ""))
+                oob_argument += "={}".format(oob_port)
+
         if host_type == "server":
             if self.oob_address_exchange:
-                command += " -E"
+                command += " " + oob_argument
             else:
                 command += " -s " + self.server_interface
 
@@ -151,7 +158,7 @@ class CmdlineArgs:
 
         assert host_type == "client"
         if self.oob_address_exchange:
-            command += " -E " + self.server_id
+            command += " " + oob_argument + " " + self.server_id
         else:
             command += " -s " + self.client_interface + " " + self.server_interface
 

--- a/fabtests/pytest/efa/efa_common.py
+++ b/fabtests/pytest/efa/efa_common.py
@@ -4,11 +4,11 @@ def efa_run_client_server_test(cmdline_args, executable, iteration_type,
                                completion_type, memory_type, message_size,
                                warmup_iteration_type=None):
     from common import ClientServerTest
-    # It is observed that cuda tests requires larger time-out limit (~240 secs) to test all
-    # message sizes for libfabric's debug and mem-poisoning builds, on p4d instances.
+    # It is observed that cuda tests requires larger time-out limit to test all
+    # message sizes (especailly when running with multiple workers).
     timeout = None
-    if "cuda" in memory_type and message_size == "all":
-        timeout = 240
+    if "cuda" in memory_type:
+        timeout = max(1000, cmdline_args.timeout)
 
     test = ClientServerTest(cmdline_args, executable, iteration_type,
                             completion_type=completion_type,

--- a/fabtests/pytest/efa/test_dgram.py
+++ b/fabtests/pytest/efa/test_dgram.py
@@ -2,6 +2,8 @@ import pytest
 import copy
 from efa.efa_common import efa_retrieve_hw_counter_value
 
+# this test must be run in serial mode because it check hw counter
+@pytest.mark.serial
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])

--- a/fabtests/pytest/efa/test_runt.py
+++ b/fabtests/pytest/efa/test_runt.py
@@ -1,5 +1,7 @@
 import pytest
 
+# this test must be run in serial mode because it check hw counter
+@pytest.mark.serial
 @pytest.mark.functional
 @pytest.mark.parametrize("cuda_copy_method", ["gdrcopy", "localread"])
 def test_runt_read_functional(cmdline_args, cuda_copy_method):

--- a/fabtests/pytest/options.yaml
+++ b/fabtests/pytest/options.yaml
@@ -70,7 +70,7 @@ ubertest_config_file:
 timeout:
   type: int
   help: "timeout value in seconds"
-  default: 120
+  default: 360
   shortform: -T
 core_list:
   type: str

--- a/fabtests/pytest/pytest.ini
+++ b/fabtests/pytest/pytest.ini
@@ -9,6 +9,7 @@ markers =
     ubertest_quick: ubertest tests run with quick config
     ubertest_verify: ubertest tests run with verify config
     cuda_memory: testing with cuda device memory direct
+    serial : test must be run in serial mode
 junit_suite_name = fabtests
 junit_logging = all
 junit_log_passing_tests = true

--- a/fabtests/pytest/requirements.txt
+++ b/fabtests/pytest/requirements.txt
@@ -1,4 +1,6 @@
 pytest
+pytest-xdist
 pytest-html
 pyyaml
 retrying
+junitparser

--- a/fabtests/scripts/runfabtests.py
+++ b/fabtests/scripts/runfabtests.py
@@ -31,6 +31,10 @@
 # SOFTWARE.
 #
 
+import os
+import pytest
+
+
 def get_option_longform(option_name, option_params):
     '''
         get the long form command line option name of an option
@@ -52,7 +56,10 @@ def get_ubertest_test_type(fabtests_testsets):
 
     return None
 
-def fabtests_testsets_to_pytest_markers(fabtests_testsets):
+def fabtests_testsets_to_pytest_markers(fabtests_testsets, run_mode=None):
+    if run_mode:
+        assert run_mode in ["serial", "parallel"]
+
     test_set = set()
     test_list = fabtests_testsets.split(",")
 
@@ -83,10 +90,16 @@ def fabtests_testsets_to_pytest_markers(fabtests_testsets):
         else:
             markers += " or " + test
 
+    if run_mode:
+        if run_mode == "serial":
+            markers = "(" + markers + ") and (serial)"
+        else:
+            assert run_mode == "parallel"
+            markers = "(" + markers + ") and (not serial)"
+
     return markers
 
 def get_default_exclusion_file(fabtests_args):
-    import os
     test_configs_dir = os.path.abspath(os.path.join(get_pytest_root_dir(), "..", "test_configs"))
     exclusion_file = os.path.join(test_configs_dir, fabtests_args.provider,
                                   fabtests_args.provider + ".exclude")
@@ -96,8 +109,6 @@ def get_default_exclusion_file(fabtests_args):
     return exclusion_file
 
 def get_default_ubertest_config_file(fabtests_args):
-    import os
- 
     test_configs_dir = os.path.abspath(os.path.join(get_pytest_root_dir(), "..", "test_configs"))
     provider = fabtests_args.provider
     if provider.find(";") != -1:
@@ -144,10 +155,12 @@ def add_common_arguments(parser, shared_options):
                                 dest=option_name, type=getattr(builtins, option_type),
                                 help=option_helpmsg, default=option_default)
 
-def fabtests_args_to_pytest_args(fabtests_args, shared_options):
-    import os
-
+def fabtests_args_to_pytest_args(fabtests_args, shared_options, run_mode):
     pytest_args = []
+
+    if run_mode == "parallel":
+        pytest_args.append("-n")
+        pytest_args.append(str(fabtests_args.nworkers))
 
     pytest_args.append("--provider=" + fabtests_args.provider)
     pytest_args.append("--server-id=" + fabtests_args.server_id)
@@ -172,7 +185,7 @@ def fabtests_args_to_pytest_args(fabtests_args, shared_options):
     else:
         pytest_args.append("--tb=no")
 
-    markers = fabtests_testsets_to_pytest_markers(fabtests_args.testsets)
+    markers = fabtests_testsets_to_pytest_markers(fabtests_args.testsets, run_mode)
     pytest_args.append("-m")
     pytest_args.append(markers)
 
@@ -187,8 +200,10 @@ def fabtests_args_to_pytest_args(fabtests_args, shared_options):
 
     if fabtests_args.junit_xml:
         pytest_args.append("--junit-xml")
-        pytest_args.append(os.path.abspath(fabtests_args.junit_xml))
-        pytest_args.append("--self-contained-html")
+        file_name = os.path.abspath(fabtests_args.junit_xml)
+        if run_mode:
+            file_name += "." + run_mode
+        pytest_args.append(file_name)
         if fabtests_args.junit_logging:
             pytest_args.append("-o")
             pytest_args.append("junit_logging=" + fabtests_args.junit_logging)
@@ -229,7 +244,6 @@ def get_pytest_root_dir():
     '''
         find the pytest root directory according the location of runfabtests.py
     '''
-    import os
     import sys
     script_path = os.path.abspath(sys.argv[0])
     script_dir = os.path.dirname(script_path)
@@ -253,8 +267,6 @@ def get_pytest_relative_case_dir(fabtests_args, pytest_root_dir):
     '''
         the directory that contains test cases, relative to pytest_root_dir
     '''
-    import os
-
     # provider's own test directory (if exists) overrides default
     pytest_case_dir = os.path.join(pytest_root_dir, fabtests_args.provider)
     if os.path.exists(pytest_case_dir):
@@ -263,11 +275,32 @@ def get_pytest_relative_case_dir(fabtests_args, pytest_root_dir):
     assert os.path.exists(os.path.join(pytest_root_dir, "default"))
     return "default"
 
+
+def run(fabtests_args, shared_options, run_mode):
+    prev_cwd = os.getcwd()
+    pytest_root_dir = get_pytest_root_dir()
+
+    pytest_args = fabtests_args_to_pytest_args(fabtests_args, shared_options, run_mode)
+    pytest_args.append(get_pytest_relative_case_dir(fabtests_args, pytest_root_dir))
+
+    pytest_command = "cd " + pytest_root_dir + "; pytest"
+    for arg in pytest_args:
+        if arg.find(' ') != -1:
+            arg = "'" + arg + "'"
+        pytest_command += " " + arg
+    print(pytest_command)
+
+    # actually running tests
+
+    os.chdir(pytest_root_dir)
+    status = pytest.main(pytest_args)
+    os.chdir(prev_cwd)
+    return status
+
+
 def main():
-    import os
     import sys
     import yaml
-    import pytest
     import argparse
 
     pytest_root_dir = get_pytest_root_dir()
@@ -299,24 +332,43 @@ def main():
     parser.add_argument("--junit-xml", type=str, help="path to generated junit xml report")
     parser.add_argument("--junit-logging", choices=['no', 'log', 'system-out', 'system-err', 'out-err', 'all'], type=str,
                         help="Write captured log messages to JUnit report")
+    parser.add_argument("--nworkers", type=int, default=8, help="Number of parallel test workers. Defaut is 8.")
 
     add_common_arguments(parser, shared_options)
 
     fabtests_args = parser.parse_args()
-    pytest_args = fabtests_args_to_pytest_args(fabtests_args, shared_options)
+    if fabtests_args.provider != "efa" and fabtests_args.nworkers > 1:
+        print("only efa provider support parallelized tests. Setting nworkers to 1 ....")
+        fabtests_args.nworkers = 1
 
-    os.chdir(pytest_root_dir)
+    if fabtests_args.html:
+        print("html cannot be generated under parallel mode. Setting nworkers to 1 ....")
+        fabtests_args.nworkers = 1
 
-    pytest_args.append(get_pytest_relative_case_dir(fabtests_args, pytest_root_dir))
+    if fabtests_args.nworkers == 1:
+        exit(run(fabtests_args, shared_options, None))
+    else:
+        print("Running parallelable tests in parallel mode")
+        parallel_status = run(fabtests_args, shared_options, "parallel")
 
-    pytest_command = "cd " + pytest_root_dir + "; pytest"
-    for arg in pytest_args:
-        if arg.find(' ') != -1:
-            arg = "'" + arg + "'"
-        pytest_command += " " + arg
-    print(pytest_command)
+        print("Running other tests in serial mode")
+        serial_status = run(fabtests_args, shared_options, "serial")
 
-    # actually running tests
-    exit(pytest.main(pytest_args))
+        if fabtests_args.junit_xml:
+            os.system("junitparser merge {}.parallel {}.serial {}".format(
+                    fabtests_args.junit_xml,
+                    fabtests_args.junit_xml,
+                    fabtests_args.junit_xml)
+                )
+            os.unlink(fabtests_args.junit_xml + ".parallel")
+            os.unlink(fabtests_args.junit_xml + ".serial")
+
+        if parallel_status != 0:
+            exit(parallel_status)
+
+        if serial_status !=0:
+            exit(serial_status)
+
+        exit(0)
 
 main()


### PR DESCRIPTION
Backporting to `v1.16.x` branch

> This patch used the pytest-xdist package to run tests in parallel. Notable changes include:
> 
> 1. This feature is only enabled for EFA provider.
> 
> 2. A new marker "serial" was introduced. Tests that must be run in serial are assigned this marker, and will be run in serial via a separate run.
> 
> 3. Junit parser was used to merge xml report from 2 runs.
> 
> 4. Each xdist worker need to have its own oob port for oob address exchange.
> 
> 5. increased timeout value for individual test because single test can take longer to finish when run in parallel
> 
> Signed-off-by: Wei Zhang <wzam@amazon.com>