### PR TITLE
fabric: Remove FI_PEER_DOMAIN

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -166,7 +166,6 @@ typedef struct fid *fid_t;
 #define FI_MATCH_COMPLETE	(1ULL << 31)
 
 #define FI_PEER_TRANSFER	(1ULL << 36)
-#define FI_PEER_DOMAIN		(1ULL << 38)
 #define FI_AV_USER_ID		(1ULL << 41)
 #define FI_PEER			(1ULL << 43)
 #define FI_XPU_TRIGGER		(1ULL << 44)

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -202,7 +202,6 @@ struct xnet_ep {
 	int			rx_avail;
 	struct xnet_srx		*srx;
 
-	int			hit_cnt;
 	enum xnet_state		state;
 	struct util_peer_addr	*peer;
 	struct xnet_conn_handle *conn;

--- a/prov/net/src/xnet_cm.c
+++ b/prov/net/src/xnet_cm.c
@@ -128,7 +128,6 @@ int xnet_send_cm_msg(struct xnet_ep *ep)
 	if ((size_t) ret != len)
 		return ofi_sockerr() ? -ofi_sockerr() : -FI_EIO;
 
-	ep->hit_cnt++;
 	return FI_SUCCESS;
 }
 
@@ -153,7 +152,6 @@ void xnet_req_done(struct xnet_ep *ep)
 		goto disable;
 	}
 
-	ep->hit_cnt++;
 	if (xnet_trace_msg) {
 		ep->hdr_bswap = (ep->cm_msg->hdr.conn_data == 1) ?
 				xnet_hdr_trace : xnet_hdr_bswap_trace;


### PR DESCRIPTION
The FI_PEER flag is sufficient for allocating peer objects.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>