### PR TITLE
[v1.16.x] prov/rxm: Always use rendezvous protocol for ZE device memory send

### DIFF
--- a/prov/rxm/src/rxm_msg.c
+++ b/prov/rxm/src/rxm_msg.c
@@ -799,6 +799,10 @@ rxm_send_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 		(data_len > rxm_ep->rxm_info->tx_attr->inject_size)) ||
 	       (data_len <= rxm_ep->rxm_info->tx_attr->inject_size));
 
+	iface = rxm_mr_desc_to_hmem_iface_dev(desc, count, &device);
+	if (iface == FI_HMEM_ZE)
+		goto rndv_send;
+
 	if (data_len <= rxm_ep->eager_limit) {
 		ret = rxm_send_eager(rxm_ep, rxm_conn, iov, desc, count,
 				     context, data, flags, tag, op,
@@ -808,8 +812,7 @@ rxm_send_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 				   context, data, flags, tag, op, data_len,
 				   rxm_ep_sar_calc_segs_cnt(rxm_ep, data_len));
 	} else {
-		iface = rxm_mr_desc_to_hmem_iface_dev(desc, count, &device);
-
+rndv_send:
 		ret = rxm_alloc_rndv_buf(rxm_ep, rxm_conn, context,
 					 (uint8_t) count, iov, desc,
 					 data_len, data, flags, tag, op,


### PR DESCRIPTION
Bounce buffer copy overhead is high for ZE device memory. The rendezvous protocol takes advantage of GPU RDMA and performs better even for small messages.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>
(cherry picked from commit 7efb4f8715f062a10b421672057b8d38dbde534e)