### PR TITLE
[v1.17.x] prov/efa: Do no ignore hints->domain_attr->name

### DIFF
--- a/prov/efa/src/efa_prov_info.c
+++ b/prov/efa/src/efa_prov_info.c
@@ -722,3 +722,21 @@ int efa_prov_info_compare_src_addr(const char *node, uint64_t flags, const struc
 	return 0;
 }
 
+/*
+ * @brief Compare the domain name specified via hints and match it with the
+ *		  domain name in prov_info
+ *
+ * @param      info[in]        info object
+ * @param      hints[in]       hints from user's call to fi_getinfo()
+ *
+ * return      1 - If the names are different
+ *             0 - No difference, names match.
+ */
+int efa_prov_info_compare_domain_name(const struct fi_info *hints,
+                                      const struct fi_info *info)
+{
+       if (hints && hints->domain_attr && hints->domain_attr->name)
+               return strcmp(info->domain_attr->name, hints->domain_attr->name);
+
+       return 0;
+}

--- a/prov/efa/src/efa_prov_info.h
+++ b/prov/efa/src/efa_prov_info.h
@@ -45,4 +45,7 @@ int efa_prov_info_alloc_for_rxr(struct fi_info **prov_info_rxr,
 int efa_prov_info_compare_src_addr(const char *node, uint64_t flags, const struct fi_info *hints,
 				   const struct fi_info *fi);
 
+int efa_prov_info_compare_domain_name(const struct fi_info *hints,
+                                      const struct fi_info *info);
+
 #endif

--- a/prov/efa/src/efa_user_info.c
+++ b/prov/efa/src/efa_user_info.c
@@ -218,6 +218,10 @@ int efa_user_info_get_dgram(uint32_t version, const char *node, const char *serv
 		if (ret)
 			continue;
 
+		ret = efa_prov_info_compare_domain_name(hints, prov_info_dgram);
+		if (ret)
+			continue;
+
 		EFA_INFO(FI_LOG_FABRIC, "found match for interface %s %s\n",
 			 node, prov_info_dgram->fabric_attr->name);
 		if (hints) {
@@ -443,6 +447,10 @@ int efa_user_info_get_rdm(uint32_t version, const char *node,
 	     prov_info_rxr;
 	     prov_info_rxr = prov_info_rxr->next) {
 		ret = efa_prov_info_compare_src_addr(node, flags, hints, prov_info_rxr);
+		if (ret)
+			continue;
+
+		ret = efa_prov_info_compare_domain_name(hints, prov_info_rxr);
 		if (ret)
 			continue;
 


### PR DESCRIPTION
Back porting to v1.17.x

> Prior to this patch, the provider would ignore the domain name in hints->domain_attr->name even if this was set. This patch fixed this issue.
> 
> Signed-off-by: Vishwas Dsouza <vidsouza@amazon.com>
> (cherry picked from commit 5281cf5dc18daf18414ae27edb49f34427920612)