### PR TITLE
contrib/intel/jenkins: Make git clone specifiy which branch

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -127,7 +127,8 @@ pipeline {
                   else
                     rm -rf ${env.WORKSPACE}/py_scripts && mkdir ${env.WORKSPACE}/py_scripts
                   fi
-                  git clone ${env.UPSTREAM} ${env.WORKSPACE}/py_scripts
+                  
+                  git clone --branch ${TARGET} ${env.UPSTREAM} ${env.WORKSPACE}/py_scripts
 
                   echo "Copy log dirs."
                   python3.7 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=logdir
@@ -157,7 +158,7 @@ pipeline {
                   else
                     rm -rf ${env.WORKSPACE}/py_scripts && mkdir ${env.WORKSPACE}/py_scripts
                   fi
-                  git clone ${env.UPSTREAM} ${env.WORKSPACE}/py_scripts
+                  git clone --branch ${TARGET} ${env.UPSTREAM} ${env.WORKSPACE}/py_scripts
                   python3.9 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=logdir
                   python3.9 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=libfabric --build_cluster='dsa'
                   python3.9 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=fabtests


### PR DESCRIPTION
In the event where git cloning upstream/main provides newer python files than the Jenkinsfile is expecting. There will be failures when the new python expected the old Jenkinsfile to call something that it didn't. Changing to checkout the same branches python files to avoid this mismatch.

Signed-off-by: Zach Dworkin <zachary.dworkin@intel.com>