### PR TITLE
prov/efa: Clean up efa_hmem_info initialization

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -122,6 +122,11 @@
 /* maximum name length for shm endpoint */
 #define EFA_SHM_NAME_MAX	   (256)
 
+#define EFA_DEFAULT_RUNT_SIZE (307200)
+#define EFA_DEFAULT_INTER_MAX_MEDIUM_MESSAGE_SIZE (65536)
+#define EFA_DEFAULT_INTER_MIN_READ_MESSAGE_SIZE (1048576)
+#define EFA_DEFAULT_INTER_MIN_READ_WRITE_SIZE (65536)
+
 extern struct fi_provider efa_prov;
 extern struct util_prov efa_util_prov;
 

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -259,7 +259,7 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 		goto err_free;
 	}
 
-	err = efa_hmem_info_update_all(efa_domain);
+	err = efa_hmem_info_init_all(efa_domain);
 	if (err) {
 		ret = err;
 		EFA_WARN(FI_LOG_DOMAIN, "Failed to check hmem support status. err: %d", ret);

--- a/prov/efa/src/efa_hmem.h
+++ b/prov/efa/src/efa_hmem.h
@@ -44,6 +44,6 @@ struct efa_hmem_info {
 	size_t min_read_write_size;
 };
 
-int efa_hmem_info_update_all(struct efa_domain *efa_domain);
+int efa_hmem_info_init_all(struct efa_domain *efa_domain);
 
 #endif


### PR DESCRIPTION
This commit:
- Centralizes the protocol variable initialization for the various HMEM interfaces
- Defines `EFA_DEF_XXX` macros for default protocol message sizes, to abstract the hardcoded default values from the core logic
- Changes the "update" nomenclature to "init", which better indicates the intention/behavior of the functions
- Initializes the protocol variables for `FI_HMEM_CUDA` when p2p is unavailable (uses `FI_HMEM_SYSTEM` defaults)
- Adds a missing check for `FI_EFA_MIN_READ_WRITE_SIZE` when initializing the `FI_HMEM_SYNAPSEAI` interface info

Signed-off-by: Darryl Abbate <drl@amazon.com>