### PR TITLE
source/ofi_hmem: Make Copy Utils Public + Warning Cleanup + New HMEM Utility Method

### DIFF
--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -290,6 +290,18 @@ ssize_t ofi_copy_to_hmem_iov(enum fi_hmem_iface hmem_iface, uint64_t device,
 			     size_t hmem_iov_count, uint64_t hmem_iov_offset,
 			     const void *src, size_t size);
 
+static inline int ofi_copy_to_hmem(enum fi_hmem_iface iface, uint64_t device,
+				   void *dest, const void *src, size_t size)
+{
+	return hmem_ops[iface].copy_to_hmem(device, dest, src, size);
+}
+
+static inline int ofi_copy_from_hmem(enum fi_hmem_iface iface, uint64_t device,
+				     void *dest, const void *src, size_t size)
+{
+	return hmem_ops[iface].copy_from_hmem(device, dest, src, size);
+}
+
 int ofi_hmem_get_handle(enum fi_hmem_iface iface, void *base_addr, void **handle);
 int ofi_hmem_open_handle(enum fi_hmem_iface iface, void **handle,
 			 uint64_t device, void **mapped_addr);

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -131,18 +131,6 @@ struct ofi_hmem_ops hmem_ops[] = {
 	},
 };
 
-static inline int ofi_copy_to_hmem(enum fi_hmem_iface iface, uint64_t device,
-				   void *dest, const void *src, size_t size)
-{
-	return hmem_ops[iface].copy_to_hmem(device, dest, src, size);
-}
-
-static inline int ofi_copy_from_hmem(enum fi_hmem_iface iface, uint64_t device,
-				     void *dest, const void *src, size_t size)
-{
-	return hmem_ops[iface].copy_from_hmem(device, dest, src, size);
-}
-
 static ssize_t ofi_copy_hmem_iov_buf(enum fi_hmem_iface hmem_iface, uint64_t device,
 				     const struct iovec *hmem_iov,
 				     size_t hmem_iov_count,

--- a/src/hmem_cuda.c
+++ b/src/hmem_cuda.c
@@ -56,7 +56,7 @@ struct cuda_ops {
 	CUresult (*cuPointerGetAttribute)(void *data,
 					  CUpointer_attribute attribute,
 					  CUdeviceptr ptr);
-	CUresult (*cuPointerSetAttribute)(void *data,
+	CUresult (*cuPointerSetAttribute)(const void *data,
 					  CUpointer_attribute attribute,
 					  CUdeviceptr ptr);
 	CUresult (*cuMemGetAddressRange)( CUdeviceptr* pbase,


### PR DESCRIPTION
    Added const to data parameter of cuPointerSetAttribute function pointer to
    remove compiler warning.

    Move implementation of ofi_copy_to_hmem() and ofi_copy_from_hmem() from
    source to header.

Add New HMEM Utility Method.