### PR TITLE
[v1.17.x] prov/net: Fix inject support

### DIFF
--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -138,12 +138,13 @@ void xnet_connect_done(struct xnet_ep *ep);
 void xnet_req_done(struct xnet_ep *ep);
 int xnet_send_cm_msg(struct xnet_ep *ep);
 
+/* Inject buffer space is included */
 union xnet_hdrs {
 	struct xnet_base_hdr	base_hdr;
 	struct xnet_cq_data_hdr cq_data_hdr;
 	struct xnet_tag_data_hdr tag_data_hdr;
 	struct xnet_tag_hdr	tag_hdr;
-	uint8_t			max_hdr[XNET_MAX_HDR];
+	uint8_t			max_hdr[XNET_MAX_HDR + XNET_MAX_INJECT];
 };
 
 struct xnet_active_rx {


### PR DESCRIPTION
Commit 3ae11c498f350e3532d0c6268ca217903b3e5f0e broke inject support by removing the buffering provided for inject.  Add the inject buffer size back into the hdr size.