### PR TITLE
include/ofi_mr.h: remove general MR modes from OFI_MR_MODE_RMA_TARGET

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -85,8 +85,7 @@ check_local_mr:
 	return (info->mode & FI_LOCAL_MR) ? 1 : 0;
 }
 
-#define OFI_MR_MODE_RMA_TARGET (FI_MR_RAW | FI_MR_VIRT_ADDR |			\
-				 FI_MR_PROV_KEY | FI_MR_RMA_EVENT)
+#define OFI_MR_MODE_RMA_TARGET (FI_MR_RAW | FI_MR_RMA_EVENT)
 
 /* If the app sets FI_MR_LOCAL, we ignore FI_LOCAL_MR.  So, if the
  * app doesn't set FI_MR_LOCAL, we need to check for FI_LOCAL_MR.


### PR DESCRIPTION
ofi_cap_mr_mode() will remove OFI_MR_MODE_RMA_TARGET from mr_mode, if application did not ask for RMA target related capability.

However, OFI_MR_MODE_RMA_TARGET contains FI_MR_PROV_KEY and FI_MR_VIRT_ADDR, which are relevent whenever application registers memory, not just RMA.

For example, an application might want to use FI_MR_LOCAL mr mode to manage memory registration by itself. For that, the application need to know whether the provider support FI_MR_PROV_KEY, and act accordingly.

However, currently the FI_MR_PROV_KEY mode will be removed by ofi_cap_mr_mode() because OFI_MR_MODE_RMA_TARGET contains FI_MR_PROV_KEY.

To address the issue, this patch removed FI_MR_PROV_KEY and FI_MR_VIRT_ADDR from OFI_MR_MODE_RMA_TARGET

Signed-off-by: Wei Zhang <wzam@amazon.com>