### PR TITLE
prov/efa: Add `p2p_required_by_impl` to `efa_hmem_info` struct, implement generic p2p opt initialization/validation

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -514,7 +514,7 @@ static inline int efa_ep_use_p2p(struct efa_ep *ep, struct efa_mr *efa_mr)
 	if (efa_mr->peer.iface == FI_HMEM_SYSTEM)
 		return 1;
 
-	if (ep->domain->hmem_info[efa_mr->peer.iface].p2p_supported)
+	if (ep->domain->hmem_info[efa_mr->peer.iface].p2p_supported_by_device)
 		return (ep->hmem_p2p_opt != FI_HMEM_P2P_DISABLED);
 
 	if (ep->hmem_p2p_opt == FI_HMEM_P2P_REQUIRED) {

--- a/prov/efa/src/efa_hmem.h
+++ b/prov/efa/src/efa_hmem.h
@@ -34,8 +34,23 @@
 #ifndef EFA_HMEM_H
 #define EFA_HMEM_H
 
+#define EFA_HMEM_IFACE_FOREACH(var) \
+	for ((var) = 0; (var) < ((sizeof efa_hmem_ifaces) / (sizeof (enum fi_hmem_iface))); ++(var))
+
+#define EFA_HMEM_IFACE_FOREACH_NON_SYSTEM(var) \
+	for ((var) = 1; (var) < ((sizeof efa_hmem_ifaces) / (sizeof (enum fi_hmem_iface))); ++(var))
+
+/* Order matters */
+static const enum fi_hmem_iface efa_hmem_ifaces[] = {
+	FI_HMEM_SYSTEM,	/* Must be first here */
+	FI_HMEM_CUDA,
+	FI_HMEM_NEURON,
+	FI_HMEM_SYNAPSEAI
+};
+
 struct efa_hmem_info {
 	bool initialized; 	/* do we support it at all */
+	bool p2p_disabled_by_user;	/* Did the user disable p2p via FI_OPT_FI_HMEM_P2P? */
 	bool p2p_required_by_impl;	/* Is p2p required for this interface? */
 	bool p2p_supported_by_device;	/* do we support p2p with this device */
 
@@ -45,6 +60,7 @@ struct efa_hmem_info {
 	size_t min_read_write_size;
 };
 
+int efa_hmem_validate_p2p_opt(struct efa_domain *efa_domain, enum fi_hmem_iface iface, int p2p_opt);
 int efa_hmem_info_init_all(struct efa_domain *efa_domain);
 
 #endif

--- a/prov/efa/src/efa_hmem.h
+++ b/prov/efa/src/efa_hmem.h
@@ -36,7 +36,8 @@
 
 struct efa_hmem_info {
 	bool initialized; 	/* do we support it at all */
-	bool p2p_supported;	/* do we support p2p with this device */
+	bool p2p_required_by_impl;	/* Is p2p required for this interface? */
+	bool p2p_supported_by_device;	/* do we support p2p with this device */
 
 	size_t max_medium_msg_size;
 	size_t runt_size;

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1079,10 +1079,10 @@ static int efa_set_fi_hmem_p2p_opt(struct efa_ep *efa_ep, int opt)
 	case FI_HMEM_P2P_ENABLED:
 	case FI_HMEM_P2P_PREFERRED:
 		if (hmem_info[FI_HMEM_CUDA].initialized &&
-		    hmem_info[FI_HMEM_CUDA].p2p_supported) {
+		    hmem_info[FI_HMEM_CUDA].p2p_supported_by_device) {
 			efa_ep->hmem_p2p_opt = opt;
 		} else if (hmem_info[FI_HMEM_NEURON].initialized &&
-			   hmem_info[FI_HMEM_NEURON].p2p_supported) {
+			   hmem_info[FI_HMEM_NEURON].p2p_supported_by_device) {
 			/*
 			 * Neuron requires p2p support and supports no
 			 * other modes.

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1065,44 +1065,26 @@ static ssize_t rxr_ep_cancel(fid_t fid_ep, void *context)
  */
 static int efa_set_fi_hmem_p2p_opt(struct efa_ep *efa_ep, int opt)
 {
-	struct efa_hmem_info *hmem_info;
+	int i, err;
 
-	hmem_info = efa_ep->domain->hmem_info;
-
-	switch (opt) {
 	/*
-	 * TODO: support the other options. We can only support ENABLED
-	 * and PREFERRED when p2p is available. DISABLED is not
-	 * supported yet.
+	 * Check the opt's validity against the first initialized non-system FI_HMEM
+	 * interface
 	 */
-	case FI_HMEM_P2P_REQUIRED:
-	case FI_HMEM_P2P_ENABLED:
-	case FI_HMEM_P2P_PREFERRED:
-		if (hmem_info[FI_HMEM_CUDA].initialized &&
-		    hmem_info[FI_HMEM_CUDA].p2p_supported_by_device) {
-			efa_ep->hmem_p2p_opt = opt;
-		} else if (hmem_info[FI_HMEM_NEURON].initialized &&
-			   hmem_info[FI_HMEM_NEURON].p2p_supported_by_device) {
-			/*
-			 * Neuron requires p2p support and supports no
-			 * other modes.
-			 */
-			if (opt != FI_HMEM_P2P_REQUIRED)
-				return -FI_EOPNOTSUPP;
-			efa_ep->hmem_p2p_opt = FI_HMEM_P2P_REQUIRED;
-		} else {
-			return -FI_EOPNOTSUPP;
+	/*
+	 * TODO this assumes only one non-stantard interface is initialized at a
+	 * time. Refactor to handle multiple initialized interfaces to impose
+	 * tighter restrictions on valid p2p options.
+	 */
+	EFA_HMEM_IFACE_FOREACH_NON_SYSTEM(i) {
+		err = efa_hmem_validate_p2p_opt(efa_ep->domain, efa_hmem_ifaces[i], opt);
+		if (err != -FI_ENODATA) {
+			if (err == FI_SUCCESS)
+				efa_ep->hmem_p2p_opt = opt;
+			return err;
 		}
-
-		break;
-	case FI_HMEM_P2P_DISABLED:
-		return -FI_EOPNOTSUPP;
-		break;
-	default:
-		return -FI_EINVAL;
 	}
-
-	return 0;
+	return -FI_EINVAL;
 }
 
 static int rxr_ep_getopt(fid_t fid, int level, int optname, void *optval,

--- a/prov/efa/test/efa_unit_test_hmem.c
+++ b/prov/efa/test/efa_unit_test_hmem.c
@@ -7,7 +7,7 @@
  * efa_domain_open, which call efa_hmem_info_update_neuron
  * when HAVE_NEURON=1, will still return 0 but leave
  * efa_hmem_info[FI_HMEM_NEURON].initialized and
- * efa_hmem_info[FI_HMEM_NEURON].p2p_supported as false.
+ * efa_hmem_info[FI_HMEM_NEURON].p2p_supported_by_device as false.
  */
 void test_efa_hmem_info_update_neuron()
 {
@@ -42,7 +42,7 @@ void test_efa_hmem_info_update_neuron()
         efa_domain = container_of(resource.domain, struct efa_domain,
 				  util_domain.domain_fid.fid);
         assert_false(efa_domain->hmem_info[FI_HMEM_NEURON].initialized);
-        assert_false(efa_domain->hmem_info[FI_HMEM_NEURON].p2p_supported);
+        assert_false(efa_domain->hmem_info[FI_HMEM_NEURON].p2p_supported_by_device);
         efa_unit_test_resource_destruct(&resource);
 }
 #else


### PR DESCRIPTION
This adds a `p2p_required_by_impl` field to the `efa_hmem_info` struct as a way to track the minimum p2p requirements for each supported `FI_HMEM` interface. Since the p2p requirements of each interface is more-or-less unwritten/institutional knowledge, it should be defined in a single place and queried as needed, instead of hardcoding in various places throughout the codebase or deducing from a combination of other parameters.

The `p2p_required_by_impl` field also offers some dynamic configurability if we choose to utilize it. I.e. if we want to set `p2p_required_by_impl` based on some runtime condition.

As an initial use-case, this PR also adds a function for checking the validity of an endpoint p2p opt against a given HMEM interface in a more generic way (i.e. without the need to hardcode). The benefit is if/when the p2p requirements change for any given HMEM interface, the p2p opt validation will work as intended.