### PR TITLE
prov/net (mostly): Allow saving a small number of out-of-order messages

### DIFF
--- a/fabtests/functional/rdm_tagged_peek.c
+++ b/fabtests/functional/rdm_tagged_peek.c
@@ -38,6 +38,10 @@
 
 #include <shared.h>
 
+
+#define BASE_TAG 0x900d
+#define SEND_CNT 10
+
 static struct fi_context fi_context;
 
 static int wait_for_send_comp(int count)
@@ -59,12 +63,12 @@ static int wait_for_send_comp(int count)
 
 static int trecv_op(uint64_t tag, uint64_t flags, bool ignore_nomsg)
 {
-	int ret;
 	struct fi_cq_tagged_entry comp;
 	struct fi_msg_tagged msg = {0};
 	struct fi_cq_err_entry cq_err;
 	struct iovec iov;
 	void *desc;
+	int ret;
 
 	if (!(flags & (FI_PEEK | FI_DISCARD))) {
 		iov.iov_base = buf;
@@ -87,107 +91,221 @@ static int trecv_op(uint64_t tag, uint64_t flags, bool ignore_nomsg)
 		}
 
 		ret = fi_cq_sread(rxcq, &comp, 1, NULL, -1);
-		if (ret != 1) {
-			if (ret == -FI_EAVAIL) {
-				ret = fi_cq_readerr(rxcq, &cq_err, 0);
-				if (ret < 0)
-					FT_PRINTERR("fi_cq_readerr", ret);
-				else
-					ret = -cq_err.err;
-			} else {
-				FT_PRINTERR("fi_cq_sread", ret);
-			}
+		if (ret == 1) {
+			ret = 0;
+			break;
 		}
-	} while (ignore_nomsg && ret == -FI_ENOMSG);
 
+		if (ret == -FI_EAVAIL) {
+			ret = fi_cq_readerr(rxcq, &cq_err, 0);
+			if (ret < 0)
+				FT_PRINTERR("fi_cq_readerr", ret);
+			else
+				ret = -cq_err.err;
+		} else {
+			FT_PRINTERR("fi_cq_sread", ret);
+		}
+	} while (ret == -FI_ENOMSG && ignore_nomsg);
+
+	if (!ret && msg.msg_iov && ((tag & BASE_TAG) == BASE_TAG))
+		ret = ft_check_buf(iov.iov_base, iov.iov_len);
+
+	return ret;
+}
+
+static int test_bad(void)
+{
+	int ret;
+
+	printf("Peek for a bad msg\n");
+	ret = trecv_op(0xbad, FI_PEEK, false);
+	if (ret != -FI_ENOMSG) {
+		FT_PRINTERR("FI_PEEK - bad msg", ret);
+		return ret;
+	}
+
+	printf("Peek w/ claim for a bad msg\n");
+	ret = trecv_op(0xbad, FI_PEEK | FI_CLAIM, false);
+	if (ret != -FI_ENOMSG) {
+		FT_PRINTERR("FI_PEEK - claim bad msg", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int test_peek(void)
+{
+	int ret;
+
+	printf("Peek msg 1\n");
+	ret = trecv_op(BASE_TAG + 1, FI_PEEK, true);
+	if (ret) {
+		FT_PRINTERR("FI_PEEK", ret);
+		return ret;
+	}
+
+	printf("Receive msg 1\n");
+	ret = trecv_op(BASE_TAG + 1, 0, false);
+	if (ret) {
+		FT_PRINTERR("Receive after peek", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int test_claim(void)
+{
+	int ret;
+
+	printf("Peek w/ claim msg 2\n");
+	ret = trecv_op(BASE_TAG + 2, FI_PEEK | FI_CLAIM, true);
+	if (ret) {
+		FT_PRINTERR("FI_PEEK | FI_CLAIM", ret);
+		return ret;
+	}
+
+	printf("Receive claimed msg 2\n");
+	ret = trecv_op(BASE_TAG + 2, FI_CLAIM, false);
+	if (ret) {
+		FT_PRINTERR("FI_CLAIM", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int test_discard(void)
+{
+	int ret;
+
+	printf("Peek & discard msg 3\n");
+	ret = trecv_op(BASE_TAG + 3, FI_PEEK | FI_DISCARD, true);
+	if (ret) {
+		FT_PRINTERR("FI_PEEK | FI_DISCARD", ret);
+		return ret;
+	}
+
+	printf("Checking to see if msg 3 was discarded\n");
+	ret = trecv_op(BASE_TAG + 3, FI_PEEK, false);
+	if (ret != -FI_ENOMSG) {
+		FT_PRINTERR("FI_PEEK", ret);
+		return ret;
+	}
+
+	printf("Peek w/ claim msg 4\n");
+	ret = trecv_op(BASE_TAG + 4, FI_PEEK | FI_CLAIM, true);
+	if (ret) {
+		FT_PRINTERR("FI_DISCARD", ret);
+		return ret;
+	}
+
+	printf("Claim and discard msg 4\n");
+	ret = trecv_op(BASE_TAG + 4, FI_CLAIM | FI_DISCARD, false);
+	if (ret) {
+		FT_PRINTERR("FI_CLAIM", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int test_ordered(void)
+{
+	int i, ret;
+
+	for (i = 5; i <= 6; i++) {
+		printf("Receive msg %d\n", i);
+		ret = trecv_op(BASE_TAG + i, 0, false);
+		if (ret) {
+			FT_PRINTERR("trecv", ret);
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+static int test_ooo(void)
+{
+	int i, ret;
+
+	for (i = SEND_CNT; i >= 7; i--) {
+		printf("Receive msg %d\n", i);
+		ret = trecv_op(BASE_TAG + i, 0, false);
+		if (ret) {
+			FT_PRINTERR("trecv", ret);
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+static int do_recvs(void)
+{
+	int ret;
+
+	ret = test_bad();
+	if (ret)
+		return ret;
+
+	ret = test_peek();
+	if (ret)
+		return ret;
+
+	ret = test_claim();
+	if (ret)
+		return ret;
+
+	ret = test_discard();
+	if (ret)
+		return ret;
+
+	ret = test_ordered();
+	if (ret)
+		return ret;
+
+	ret = test_ooo();
+	if (ret)
+		return ret;
+
+	return 0;
+}
+
+static int do_sends(void)
+{
+	int i, ret;
+
+	printf("Sending %d tagged messages\n", SEND_CNT);
+	(void) ft_fill_buf(tx_buf, tx_size);
+
+	for (i = 1; i <= SEND_CNT; i++) {
+		ret = fi_tsend(ep, tx_buf, tx_size, mr_desc,
+				remote_fi_addr, BASE_TAG + i,
+				&tx_ctx_arr[i].context);
+		if (ret)
+			return ret;
+	}
+
+	printf("Waiting for messages to complete\n");
+	ret = wait_for_send_comp(SEND_CNT);
 	return ret;
 }
 
 static int run(void)
 {
-	int i, ret;
+	int ret;
 
 	ret = ft_init_fabric();
 	if (ret)
 		return ret;
 
 	if (opts.dst_addr) {
-		printf("Searching for a bad msg\n");
-		ret = trecv_op(0xbad, FI_PEEK, false);
-		if (ret != -FI_ENOMSG) {
-			FT_PRINTERR("FI_PEEK", ret);
+		ret = do_recvs();
+		if (ret)
 			return ret;
-		}
-
-		printf("Searching for a bad msg with claim\n");
-		ret = trecv_op(0xbad, FI_PEEK | FI_CLAIM, false);
-		if (ret != -FI_ENOMSG) {
-			FT_PRINTERR("FI_PEEK", ret);
-			return ret;
-		}
-
-		printf("Searching for first msg\n");
-		ret = trecv_op(0x900d, FI_PEEK, true);
-		if (ret != 1) {
-			FT_PRINTERR("FI_PEEK", ret);
-			return ret;
-		}
-
-		printf("Receiving first msg\n");
-		ret = trecv_op(0x900d, 0, false);
-		if (ret != 1) {
-			FT_PRINTERR("Receive after peek", ret);
-			return ret;
-		}
-
-		printf("Searching for second msg to claim\n");
-		ret = trecv_op(0x900d + 1, FI_PEEK | FI_CLAIM, true);
-		if (ret != 1) {
-			FT_PRINTERR("FI_PEEK | FI_CLAIM", ret);
-			return ret;
-		}
-
-		printf("Receiving second msg\n");
-		ret = trecv_op(0x900d + 1, FI_CLAIM, false);
-		if (ret != 1) {
-			FT_PRINTERR("FI_CLAIM", ret);
-			return ret;
-		}
-
-		printf("Searching for third msg to peek and discard\n");
-		ret = trecv_op(0x900d + 2, FI_PEEK | FI_DISCARD, true);
-		if (ret != 1) {
-			FT_PRINTERR("FI_PEEK | FI_DISCARD", ret);
-			return ret;
-		}
-
-		printf("Checking to see if third msg was discarded\n");
-		ret = trecv_op(0x900d + 2, FI_PEEK, false);
-		if (ret != -FI_ENOMSG) {
-			FT_PRINTERR("FI_PEEK", ret);
-			return ret;
-		}
-
-		printf("Searching for fourth msg to claim and discard\n");
-		ret = trecv_op(0x900d + 3, FI_PEEK | FI_CLAIM, true);
-		if (ret != 1) {
-			FT_PRINTERR("FI_DISCARD", ret);
-			return ret;
-		}
-
-		printf("Discarding fourth msg\n");
-		ret = trecv_op(0x900d + 3, FI_CLAIM | FI_DISCARD, false);
-		if (ret != 1) {
-			FT_PRINTERR("FI_CLAIM", ret);
-			return ret;
-		}
-
-		printf("Retrieving fifth message\n");
-		ret = trecv_op(0x900d + 4, 0, false);
-		if (ret != 1) {
-			FT_PRINTERR("Receive after peek", ret);
-			return ret;
-		}
 
 		/* sync with sender before ft_finalize, since we sent
 		 * and received messages outside of the sequence numbers
@@ -202,21 +320,12 @@ static int run(void)
 		if (ret)
 			return ret;
 	} else {
-		printf("Sending five tagged messages\n");
-		for(i = 0; i < 5; i++) {
-			ret = fi_tsend(ep, tx_buf, tx_size, mr_desc,
-				       remote_fi_addr, 0x900d+i,
-				       &tx_ctx_arr[i].context);
-			if (ret)
-				return ret;
-		}
-		printf("Waiting for messages to complete\n");
-		ret = wait_for_send_comp(5);
+		ret = do_sends();
 		if (ret)
 			return ret;
 
 		ret = trecv_op(0xabc, 0, false);
-		if (ret != 1) {
+		if (ret) {
 			FT_PRINTERR("Receive sync", ret);
 			return ret;
 		}
@@ -232,8 +341,9 @@ int main(int argc, char **argv)
 
 	opts = INIT_OPTS;
 	opts.options |= FT_OPT_SIZE;
+	opts.transfer_size = 64;  /* Don't expect receiver buffering */
 	opts.comp_method = FT_COMP_SREAD;
-	opts.window_size = 5;
+	opts.window_size = SEND_CNT;
 
 	hints = fi_allocinfo();
 	if (!hints) {

--- a/man/fi_peer.3.md
+++ b/man/fi_peer.3.md
@@ -10,8 +10,17 @@ tagline: Libfabric Programmer's Manual
 fi_export_fid / fi_import_fid
 : Share a fabric object between different providers or resources
 
+struct fid_peer_av
+: An address vector sharable between independent providers
+
+struct fid_peer_av_set
+: An AV set sharable between independent providers
+
 struct fid_peer_cq
 : A completion queue that may be shared between independent providers
+
+struct fid_peer_srx
+: A shared receive context that may be shared between independent providers
 
 # SYNOPSIS
 
@@ -40,6 +49,11 @@ int fi_import_fid(struct fid *fid, struct fid *expfid, uint64_t flags);
 : User defined context that will be associated with a fabric object.
 
 # DESCRIPTION
+
+NOTICE: The peer APIs describe by this man page are developmental and may
+change between libfabric versions.  The data structures and API definitions
+should not be considered stable between versions.  Providers being used
+as peers must target the same libfabric version.
 
 Functions defined in this man page are typically used by providers to
 communicate with other providers, known as peer providers, or by other

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -138,12 +138,13 @@ void xnet_connect_done(struct xnet_ep *ep);
 void xnet_req_done(struct xnet_ep *ep);
 int xnet_send_cm_msg(struct xnet_ep *ep);
 
+/* Inject buffer space is included */
 union xnet_hdrs {
 	struct xnet_base_hdr	base_hdr;
 	struct xnet_cq_data_hdr cq_data_hdr;
 	struct xnet_tag_data_hdr tag_data_hdr;
 	struct xnet_tag_hdr	tag_hdr;
-	uint8_t			max_hdr[XNET_MAX_HDR];
+	uint8_t			max_hdr[XNET_MAX_HDR + XNET_MAX_INJECT];
 };
 
 struct xnet_active_rx {

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -88,6 +88,7 @@ extern size_t xnet_zerocopy_size;
 extern int xnet_trace_msg;
 extern int xnet_disable_autoprog;
 extern int xnet_io_uring;
+extern int xnet_max_saved;
 
 struct xnet_xfer_entry;
 struct xnet_ep;
@@ -192,7 +193,6 @@ struct xnet_ep {
 	struct xnet_active_tx	cur_tx;
 	OFI_DBG_VAR(uint8_t, tx_id)
 	OFI_DBG_VAR(uint8_t, rx_id)
-	struct xnet_active_rx	saved_rx;
 
 	struct dlist_entry	unexp_entry;
 	struct dlist_entry	saved_entry;
@@ -202,6 +202,8 @@ struct xnet_ep {
 	struct slist		need_ack_queue;
 	struct slist		async_queue;
 	struct slist		rma_read_queue;
+	struct slist		saved_queue;
+	int			saved_cnt;
 	int			rx_avail;
 	struct xnet_srx		*srx;
 
@@ -363,6 +365,8 @@ static inline void xnet_signal_progress(struct xnet_progress *progress)
 #define XNET_ASYNC		BIT(5)
 #define XNET_INJECT_OP		BIT(6)
 #define XNET_FREE_BUF		BIT(7)
+#define XNET_SAVED_XFER		BIT(8)
+#define XNET_COPY_RECV		BIT(9)
 #define XNET_MULTI_RECV		FI_MULTI_RECV /* BIT(16) */
 
 struct xnet_xfer_entry {
@@ -613,14 +617,9 @@ static inline bool xnet_has_unexp(struct xnet_ep *ep)
 	return ep->cur_rx.handler && !ep->cur_rx.entry;
 }
 
-static inline bool xnet_has_saved_rx(struct xnet_ep *ep)
-{
-	assert(xnet_progress_locked(xnet_ep2_progress(ep)));
-	return ep->saved_rx.hdr_done != 0;
-}
-
-void xnet_complete_saved(struct xnet_ep *ep, struct xnet_xfer_entry *rx_entry);
-void xnet_clear_saved_rx(struct xnet_ep *ep);
+void xnet_recv_saved(struct xnet_xfer_entry *saved_entry,
+		     struct xnet_xfer_entry *rx_entry);
+void xnet_complete_saved(struct xnet_xfer_entry *saved_entry);
 
 #define XNET_WARN_ERR(subsystem, log_str, err) \
 	FI_WARN(&xnet_prov, subsystem, log_str "%s (%d)\n", \

--- a/prov/net/src/xnet_ep.c
+++ b/prov/net/src/xnet_ep.c
@@ -338,6 +338,8 @@ static void xnet_ep_flush_all_queues(struct xnet_ep *ep)
 	xnet_ep_flush_queue(ep, &ep->rma_read_queue, cq);
 	xnet_ep_flush_queue(ep, &ep->need_ack_queue, cq);
 	xnet_ep_flush_queue(ep, &ep->async_queue, cq);
+	xnet_ep_flush_queue(ep, &ep->saved_queue, cq);
+	ep->saved_cnt = 0;
 
 	cq = container_of(ep->util_ep.rx_cq, struct xnet_cq, util_cq);
 	if (ep->cur_rx.entry) {
@@ -367,9 +369,8 @@ void xnet_ep_disable(struct xnet_ep *ep, int cm_err, void* err_data,
 		return;
 	};
 
-	if (xnet_has_saved_rx(ep))
-		xnet_clear_saved_rx(ep);
 	dlist_remove_init(&ep->unexp_entry);
+	dlist_remove_init(&ep->saved_entry);
 	xnet_halt_sock(xnet_ep2_progress(ep), ep->bsock.sock);
 
 	ret = ofi_shutdown(ep->bsock.sock, SHUT_RDWR);
@@ -524,6 +525,7 @@ static int xnet_ep_close(struct fid *fid)
 	progress = xnet_ep2_progress(ep);
 	ofi_genlock_lock(&progress->lock);
 	dlist_remove_init(&ep->unexp_entry);
+	dlist_remove_init(&ep->saved_entry);
 	xnet_halt_sock(progress, ep->bsock.sock);
 	xnet_ep_flush_all_queues(ep);
 	ofi_genlock_unlock(&progress->lock);
@@ -736,12 +738,14 @@ int xnet_endpoint(struct fid_domain *domain, struct fi_info *info,
 	}
 
 	dlist_init(&ep->unexp_entry);
+	dlist_init(&ep->saved_entry);
 	slist_init(&ep->rx_queue);
 	slist_init(&ep->tx_queue);
 	slist_init(&ep->priority_queue);
 	slist_init(&ep->rma_read_queue);
 	slist_init(&ep->need_ack_queue);
 	slist_init(&ep->async_queue);
+	slist_init(&ep->saved_queue);
 
 	if (info->ep_attr->rx_ctx_cnt != FI_SHARED_CONTEXT)
 		ep->rx_avail = (int) info->rx_attr->size;

--- a/prov/net/src/xnet_init.c
+++ b/prov/net/src/xnet_init.c
@@ -67,6 +67,7 @@ size_t xnet_zerocopy_size = SIZE_MAX;
 int xnet_trace_msg;
 int xnet_disable_autoprog;
 int xnet_io_uring;
+int xnet_max_saved = 4;
 
 
 static void xnet_init_env(void)
@@ -115,8 +116,18 @@ static void xnet_init_env(void)
 	if (!fi_param_get_size_t(&xnet_prov, "rx_size", &rx_size))
 		xnet_default_rx_size = rx_size;
 
+	fi_param_define(&xnet_prov, "max_saved", FI_PARAM_INT,
+			"maximum number of received messages that do not "
+			"have a posted application buffer that will be "
+			"queued by the provider.  A larger value increases "
+			"memory and processing overhead, negatively "
+			"impacting performance, but may be required by some "
+			"applications to prevent hangs. (default: %d)",
+			xnet_max_saved);
+	fi_param_get_int(&xnet_prov, "max_saved", &xnet_max_saved);
 	fi_param_define(&xnet_prov, "nodelay", FI_PARAM_BOOL,
-			"overrides default TCP_NODELAY socket setting");
+			"overrides default TCP_NODELAY socket setting "
+			"(default %d)", xnet_nodelay);
 	fi_param_get_bool(&xnet_prov, "nodelay", &xnet_nodelay);
 
 	fi_param_define(&xnet_prov, "staging_sbuf_size", FI_PARAM_INT,


### PR DESCRIPTION
man/peer: Clearly indicates that peer APIs are not stable (from v1.17.x)
prov/net: Fix inject support (from v1.17.x)
fabtests/tagged_peek: Restructure and expand test coverage
prov/net: Allow saving multiple small messages to support OOO messages