### PR TITLE
core/hmem_cuda: adjust FI_HMEM_CUDA_ENABLE_XFER behavior

### DIFF
--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -158,6 +158,18 @@ int cuda_get_handle(void *dev_buf, void **handle);
 int cuda_open_handle(void **handle, uint64_t device, void **ipc_ptr);
 int cuda_close_handle(void *ipc_ptr);
 int cuda_get_base_addr(const void *ptr, void **base, size_t *size);
+
+/*
+ * This enum lists all the possible situations about how
+ * the environment variable FI_HMEM_CUDA_ENABLE_XFER was set.
+ */
+enum cuda_xfer_setting {
+	CUDA_XFER_UNSPECIFIED, /* FI_HMEM_CUDA_ENABLE_XFER was not set */
+	CUDA_XFER_ENABLED, /* FI_HMEM_CUDA_ENABLE_XFER set to 1/true/yes */
+	CUDA_XFER_DISABLED /* FI_HMEM_CUDA_ENABLE_XFER set to 0/false/no */
+};
+
+enum cuda_xfer_setting cuda_get_xfer_setting(void);
 bool cuda_is_ipc_enabled(void);
 int cuda_get_ipc_handle_size(size_t *size);
 bool cuda_is_gdrcopy_enabled(void);


### PR DESCRIPTION
The environment variable FI_HMEM_CUDA_ENABLE_XFER control whether CUDA API can be used to copy data. Currently, its help string states that it default value is true, which means by default a provider is safe to make CUDA calls.

However, by default it is not always safe for a provider to make CUDA calls, and some providers does not make CUDA calls by default. Such provider still need to make CUDA calls when user explictly set this environment variable to true.

This patch used an enum (instead of a boolean) to store the value of the user setting. The enum has three possible values:

    CUDA_XFER_DISABLED means the environment variable is set to 0
    CUDA_XFER_ENABLED means the environment variable is set to 1
    CUDA_XFER_UNSPECIED means the environment variable is not set

It then exposed the value of this setting through a public function, such that provider can access.

It also updated the help string to:
"""
By default, each provider decide whether it will make CUDA calls. """
which better describes current situation.

It is worth noting that this patch did not change the current behavior of any provider because:

Prior to this patch, the value of this environment variable is not accessible to a provider.

Prior to this patch, if the envrionment variable was set to 0, cuda_ops.cudaMemcpy was set to a no-op and cuda_ipc_enabled was set to false. This patch maintained this behavior.

Signed-off-by: Wei Zhang <wzam@amazon.com>