### PR TITLE
src/hmem_cuda: implement cuda_get_xfer_setting for non cuda build

### DIFF
--- a/src/hmem_cuda.c
+++ b/src/hmem_cuda.c
@@ -839,6 +839,11 @@ int cuda_get_base_addr(const void *ptr, void **base, size_t *size)
 	return -FI_ENOSYS;
 }
 
+enum cuda_xfer_setting cuda_get_xfer_setting(void)
+{
+	return CUDA_XFER_DISABLED;
+}
+
 bool cuda_is_ipc_enabled(void)
 {
 	return false;


### PR DESCRIPTION
Previous commit 148dfd7d7e3a introduced cuda_get_xfer_setting() but did not implement it for non-CUDA build. This patch fixed it.

Signed-off-by: Wei Zhang <wzam@amazon.com>