### PR TITLE
pytest/efa: handle device differences in test_device_selection

### DIFF
--- a/fabtests/pytest/efa/efa_common.py
+++ b/fabtests/pytest/efa/efa_common.py
@@ -113,3 +113,12 @@ def get_efa_domain_names(server_id):
 
     return efa_domain_names
 
+def get_efa_device_names(server_id):
+    domain_names = get_efa_domain_names(server_id)
+    device_names = set()
+    for domain_name in domain_names:
+        itemlist = domain_name.split("-")
+        assert len(itemlist) == 2
+        assert itemlist[1] in ["rdm", "dgrm"]
+        device_names.add(itemlist[0])
+    return list(device_names)

--- a/fabtests/pytest/efa/test_efa_device_selection.py
+++ b/fabtests/pytest/efa/test_efa_device_selection.py
@@ -1,39 +1,52 @@
+import copy
 import pytest
-
+from efa.efa_common import efa_retrieve_hw_counter_value, get_efa_device_names
+from common import ClientServerTest
 
 # This test must be run in serial mode because it checks the hw counter
 @pytest.mark.serial
 @pytest.mark.functional
 def test_efa_device_selection(cmdline_args):
-    from efa.efa_common import efa_retrieve_hw_counter_value, get_efa_domain_names
-    from common import ClientServerTest
 
     if cmdline_args.server_id == cmdline_args.client_id:
         pytest.skip("EFA device selection test requires 2 nodes")
         return
 
-    efa_domain_names = get_efa_domain_names(cmdline_args.server_id)
+    server_device_names = get_efa_device_names(cmdline_args.server_id)
+    client_device_names = get_efa_device_names(cmdline_args.client_id)
 
-    for efa_domain_name in efa_domain_names:
-        if '-rdm' in efa_domain_name:
-            assert not('-dgrm') in efa_domain_name
-            fabtest_opts = "fi_rdm_pingpong"
-        elif '-dgrm' in efa_domain_name:
-            assert not('-rdm') in efa_domain_name
-            fabtest_opts = "fi_dgram_pingpong -k"
+    server_num_devices = len(server_device_names)
+    client_num_devices = len(server_device_names)
 
-        efa_device_name = efa_domain_name.split('-')[0]
+    for i in range(max(server_num_devices, client_num_devices)):
+        server_device_idx = i % server_num_devices
+        client_device_idx = i % client_num_devices
 
-        server_tx_bytes_before_test = efa_retrieve_hw_counter_value(cmdline_args.server_id, "tx_bytes", efa_device_name)
-        client_tx_bytes_before_test = efa_retrieve_hw_counter_value(cmdline_args.client_id, "tx_bytes", efa_device_name)
+        server_device_name = server_device_names[server_device_idx]
+        client_device_name = client_device_names[client_device_idx]
 
-        executable = "{} -d {}".format(fabtest_opts, efa_domain_name)
-        test = ClientServerTest(cmdline_args, executable, message_size="1000", timeout=300)
-        test.run()
+        for suffix in ["rdm", "dgrm"]:
+            server_tx_bytes_before_test = efa_retrieve_hw_counter_value(cmdline_args.server_id, "tx_bytes", server_device_name)
+            client_tx_bytes_before_test = efa_retrieve_hw_counter_value(cmdline_args.client_id, "tx_bytes", client_device_name)
 
-        server_tx_bytes_after_test = efa_retrieve_hw_counter_value(cmdline_args.server_id, "tx_bytes", efa_device_name)
-        client_tx_bytes_after_test = efa_retrieve_hw_counter_value(cmdline_args.client_id, "tx_bytes", efa_device_name)
+            if suffix == "rdm":
+                command = "fi_rdm_pingpong"
+            else:
+                command = "fi_dgram_pingpong -k" # efa provider requires prefix mode for dgram provider, hence "-k"
 
-        # Verify EFA traffic
-        assert server_tx_bytes_before_test < server_tx_bytes_after_test
-        assert client_tx_bytes_before_test < client_tx_bytes_after_test
+            server_domain_name = server_device_name + "-" + suffix
+            client_domain_name = client_device_name + "-" + suffix
+
+            cmdline_args_copy = copy.copy(cmdline_args)
+            cmdline_args_copy.additional_server_arguments = "-d " + server_domain_name
+            cmdline_args_copy.additional_client_arguments = "-d " + client_domain_name
+
+            test = ClientServerTest(cmdline_args_copy, command, message_size="1000", timeout=300)
+            test.run()
+
+            server_tx_bytes_after_test = efa_retrieve_hw_counter_value(cmdline_args.server_id, "tx_bytes", server_device_name)
+            client_tx_bytes_after_test = efa_retrieve_hw_counter_value(cmdline_args.client_id, "tx_bytes", client_device_name)
+
+            # Verify EFA traffic
+            assert server_tx_bytes_before_test < server_tx_bytes_after_test
+            assert client_tx_bytes_before_test < client_tx_bytes_after_test


### PR DESCRIPTION
The efa_test_device_selection assume both nodes have same device name/numbers, which is not always the case.

This patch addressed the issue.

Signed-off-by: Wei Zhang <wzam@amazon.com>