### PR TITLE
contrib/intel/jenkins: Succeed on opt-out path in daos summary stage

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -732,7 +732,11 @@ pipeline {
     success {
       node ('daos') {
         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
-          sh "python3.7 ${env.WORKSPACE}/${SCRIPT_LOCATION}/summary.py -v --summary_item=daos"
+            sh """
+              if [[ ${DO_RUN} -eq 1 ]]; then
+                python3.7 ${env.WORKSPACE}/${SCRIPT_LOCATION}/summary.py -v --summary_item=daos
+              fi
+            """
           dir ("${env.DAOS_CLUSTER_HOME}/avocado") {
             deleteDir()
           }


### PR DESCRIPTION
Summary.py does not exist on the daos cluster if the opt-out path was taken. Check to see if opt-out path was taken since the 'when' clause cannot be applied here.

Signed-off-by: Zach Dworkin <zachary.dworkin@intel.com>