### PR TITLE
prov/efa: Move unit test teardown actions to teardown function

### DIFF
--- a/prov/efa/test/efa_unit_test_av.c
+++ b/prov/efa/test/efa_unit_test_av.c
@@ -1,24 +1,26 @@
 #include "efa_unit_tests.h"
 
-/*
- * Only works on nodes with EFA devices
+/**
+ * @brief Only works on nodes with EFA devices
  * This test calls fi_av_insert() twice with the same raw address,
  * and verifies that returned fi_addr is the same and
  * ibv_create_ah only gets called once.
+ * 
+ * @param[in]	state		struct efa_resource that is managed by the framework
  */
-void test_av_insert_duplicate_raw_addr()
+void test_av_insert_duplicate_raw_addr(struct efa_resource **state)
 {
-	struct efa_resource resource = {0};
+	struct efa_resource *resource = *state;
 	struct efa_ep_addr raw_addr = {0};
 	size_t raw_addr_len = sizeof(struct efa_ep_addr);
 	fi_addr_t addr1, addr2;
 	int err, num_addr;
 
-	err = efa_unit_test_resource_construct(&resource, FI_EP_RDM);
+	err = efa_unit_test_resource_construct(resource, FI_EP_RDM);
 	assert_int_equal(err, 0);
 	g_efa_unit_test_mocks.ibv_create_ah = &efa_mock_ibv_create_ah_check_mock;
 
-	err = fi_getname(&resource.ep->fid, &raw_addr, &raw_addr_len);
+	err = fi_getname(&resource->ep->fid, &raw_addr, &raw_addr_len);
 	assert_int_equal(err, 0);
 	raw_addr.qpn = 1;
 	raw_addr.qkey = 0x1234;
@@ -26,35 +28,35 @@ void test_av_insert_duplicate_raw_addr()
 	/* the following will_return ensures ibv_create_ah is called exactly once */
 	will_return(efa_mock_ibv_create_ah_check_mock, 0);
 
-	num_addr = fi_av_insert(resource.av, &raw_addr, 1, &addr1, 0 /* flags */, NULL /* context */);
+	num_addr = fi_av_insert(resource->av, &raw_addr, 1, &addr1, 0 /* flags */, NULL /* context */);
 	assert_int_equal(num_addr, 1);
 
-	num_addr = fi_av_insert(resource.av, &raw_addr, 1, &addr2, 0 /* flags */, NULL /* context */);
+	num_addr = fi_av_insert(resource->av, &raw_addr, 1, &addr2, 0 /* flags */, NULL /* context */);
 	assert_int_equal(num_addr, 1);
 	assert_int_equal(addr1, addr2);
-
-	efa_unit_test_resource_destruct(&resource);
 }
 
-/*
- * Only works on nodes with EFA devices
+/**
+ * @brief Only works on nodes with EFA devices
  * This test calls fi_av_insert() twice with two difference raw address with same GID,
  * and verifies that returned fi_addr is different and ibv_create_ah only gets called once.
  * this is because libfabric EFA provider has a cache for address handle (AH).
+ * 
+ * @param[in]	state		struct efa_resource that is managed by the framework
  */
-void test_av_insert_duplicate_gid()
+void test_av_insert_duplicate_gid(struct efa_resource **state)
 {
-	struct efa_resource resource = {0};
+	struct efa_resource *resource = *state;
 	struct efa_ep_addr raw_addr = {0};
 	size_t raw_addr_len = sizeof(struct efa_ep_addr);
 	fi_addr_t addr1, addr2;
 	int err, num_addr;
 
-	err = efa_unit_test_resource_construct(&resource, FI_EP_RDM);
+	err = efa_unit_test_resource_construct(resource, FI_EP_RDM);
 	assert_int_equal(err, 0);
 	g_efa_unit_test_mocks.ibv_create_ah = &efa_mock_ibv_create_ah_check_mock;
 
-	err = fi_getname(&resource.ep->fid, &raw_addr, &raw_addr_len);
+	err = fi_getname(&resource->ep->fid, &raw_addr, &raw_addr_len);
 	assert_int_equal(err, 0);
 	raw_addr.qpn = 1;
 	raw_addr.qkey = 0x1234;
@@ -62,15 +64,12 @@ void test_av_insert_duplicate_gid()
 	/* the following will_return ensures ibv_create_ah is called exactly once */
 	will_return(efa_mock_ibv_create_ah_check_mock, 0);
 
-	num_addr = fi_av_insert(resource.av, &raw_addr, 1, &addr1, 0 /* flags */, NULL /* context */);
+	num_addr = fi_av_insert(resource->av, &raw_addr, 1, &addr1, 0 /* flags */, NULL /* context */);
 	assert_int_equal(num_addr, 1);
 
 	raw_addr.qpn = 2;
 	raw_addr.qkey = 0x5678;
-	num_addr = fi_av_insert(resource.av, &raw_addr, 1, &addr2, 0 /* flags */, NULL /* context */);
+	num_addr = fi_av_insert(resource->av, &raw_addr, 1, &addr2, 0 /* flags */, NULL /* context */);
 	assert_int_equal(num_addr, 1);
 	assert_int_not_equal(addr1, addr2);
-
-	efa_unit_test_resource_destruct(&resource);
 }
-

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -1,11 +1,11 @@
 #include "efa_unit_tests.h"
 
-static void check_ep_pkt_pool_flags(struct efa_resource resource, int expected_flags)
+static void check_ep_pkt_pool_flags(struct efa_resource *resource, int expected_flags)
 {
        struct fid_ep *ep;
        struct rxr_ep *rxr_ep;
        int ret;
-       ret = fi_endpoint(resource.domain, resource.info, &ep, NULL);
+       ret = fi_endpoint(resource->domain, resource->info, &ep, NULL);
        assert_int_equal(ret, 0);
        rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid);
        assert_int_equal(rxr_ep->efa_tx_pkt_pool->flags, expected_flags);
@@ -15,13 +15,15 @@ static void check_ep_pkt_pool_flags(struct efa_resource resource, int expected_f
 
 /**
  * @brief Test the pkt pool flags in rxr_ep_init()
+ * 
+ * @param[in]	state		struct efa_resource that is managed by the framework
  */
-void test_rxr_ep_pkt_pool_flags()
+void test_rxr_ep_pkt_pool_flags(struct efa_resource **state)
 {
 	int ret;
-	struct efa_resource resource = {0};
+	struct efa_resource *resource = *state;
 
-	ret = efa_unit_test_resource_construct(&resource, FI_EP_RDM);
+	ret = efa_unit_test_resource_construct(resource, FI_EP_RDM);
 	assert_int_equal(ret, 0);
 
 	g_efa_fork_status = EFA_FORK_SUPPORT_ON;
@@ -32,29 +34,29 @@ void test_rxr_ep_pkt_pool_flags()
 
 	g_efa_fork_status = EFA_FORK_SUPPORT_UNNEEDED;
 	check_ep_pkt_pool_flags(resource, OFI_BUFPOOL_HUGEPAGES);
-
-	efa_unit_test_resource_destruct(&resource);
 }
 
 /**
  * @brief When the buf pool is created with OFI_BUFPOOL_NONSHARED,
  * test if the allocated memory is page aligned.
+ * 
+ * @param[in]	state		struct efa_resource that is managed by the framework
  */
-void test_rxr_ep_pkt_pool_page_alignment()
+void test_rxr_ep_pkt_pool_page_alignment(struct efa_resource **state)
 {
 	int ret;
 	struct ofi_bufpool_region *buf;
 	struct rxr_pkt_entry *pkt_entry;
 	struct fid_ep *ep;
 	struct rxr_ep *rxr_ep;
-	struct efa_resource resource = {0};
+	struct efa_resource *resource = *state;
 
-	ret = efa_unit_test_resource_construct(&resource, FI_EP_RDM);
+	ret = efa_unit_test_resource_construct(resource, FI_EP_RDM);
 	assert_int_equal(ret, 0);
 
 	/* Turn on g_efa_fork_status and open a new rxr endpoint */
 	g_efa_fork_status = EFA_FORK_SUPPORT_ON;
-	ret = fi_endpoint(resource.domain, resource.info, &ep, NULL);
+	ret = fi_endpoint(resource->domain, resource->info, &ep, NULL);
 	assert_int_equal(ret, 0);
 	rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid);
 	assert_int_equal(rxr_ep->efa_rx_pkt_pool->flags, OFI_BUFPOOL_NONSHARED);
@@ -65,7 +67,6 @@ void test_rxr_ep_pkt_pool_page_alignment()
 	rxr_pkt_entry_release(pkt_entry);
 
 	fi_close(&ep->fid);
-	efa_unit_test_resource_destruct(&resource);
 
 	g_efa_fork_status = EFA_FORK_SUPPORT_OFF;
 }
@@ -73,29 +74,31 @@ void test_rxr_ep_pkt_pool_page_alignment()
 /**
  * @brief when delivery complete atomic was used and handshake packet has not been received
  * verify there is no tx entry leak
+ * 
+ * @param[in]	state		struct efa_resource that is managed by the framework
  */
-void test_rxr_ep_dc_atomic_error_handling()
+void test_rxr_ep_dc_atomic_error_handling(struct efa_resource **state)
 {
 	struct rxr_ep *rxr_ep;
 	struct rdm_peer *peer;
 	struct fi_ioc ioc = {0};
 	struct fi_rma_ioc rma_ioc = {0};
 	struct fi_msg_atomic msg = {0};
-	struct efa_resource resource = {0};
+	struct efa_resource *resource = *state;
 	struct efa_ep_addr raw_addr = {0};
 	size_t raw_addr_len = sizeof(struct efa_ep_addr);
 	fi_addr_t peer_addr;
 	int buf[1] = {0}, err, numaddr;
 
-	err = efa_unit_test_resource_construct(&resource, FI_EP_RDM);
+	err = efa_unit_test_resource_construct(resource, FI_EP_RDM);
 	assert_int_equal(err, 0);
 
 	/* create a fake peer */
-	err = fi_getname(&resource.ep->fid, &raw_addr, &raw_addr_len);
+	err = fi_getname(&resource->ep->fid, &raw_addr, &raw_addr_len);
 	assert_int_equal(err, 0);
 	raw_addr.qpn = 1;
 	raw_addr.qkey = 0x1234;
-	numaddr = fi_av_insert(resource.av, &raw_addr, 1, &peer_addr, 0, NULL);
+	numaddr = fi_av_insert(resource->av, &raw_addr, 1, &peer_addr, 0, NULL);
 	assert_int_equal(numaddr, 1);
 
 	msg.addr = peer_addr;
@@ -110,7 +113,7 @@ void test_rxr_ep_dc_atomic_error_handling()
 	msg.datatype = FI_INT32;
 	msg.op = FI_SUM;
 
-	rxr_ep = container_of(resource.ep, struct rxr_ep, util_ep.ep_fid);
+	rxr_ep = container_of(resource->ep, struct rxr_ep, util_ep.ep_fid);
 	rxr_ep->use_shm_for_tx = false;
 	/* set peer->flag to RXR_PEER_REQ_SENT will make rxr_atomic() think
 	 * a REQ packet has been sent to the peer (so no need to send again)
@@ -121,13 +124,11 @@ void test_rxr_ep_dc_atomic_error_handling()
 	peer->is_local = false;
 
 	assert_true(dlist_empty(&rxr_ep->tx_entry_list));
-	err = fi_atomicmsg(resource.ep, &msg, FI_DELIVERY_COMPLETE);
+	err = fi_atomicmsg(resource->ep, &msg, FI_DELIVERY_COMPLETE);
 	/* DC has been reuquested, but ep do not know whether peer supports it, therefore
 	 * -FI_EAGAIN should be returned
 	 */
 	assert_int_equal(err, -FI_EAGAIN);
 	/* make sure there is no leaking of tx_entry */
 	assert_true(dlist_empty(&rxr_ep->tx_entry_list));
-
-	efa_unit_test_resource_destruct(&resource);
 }

--- a/prov/efa/test/efa_unit_test_hmem.c
+++ b/prov/efa/test/efa_unit_test_hmem.c
@@ -8,22 +8,24 @@
  * when HAVE_NEURON=1, will still return 0 but leave
  * efa_hmem_info[FI_HMEM_NEURON].initialized and
  * efa_hmem_info[FI_HMEM_NEURON].p2p_supported_by_device as false.
+ * 
+ * @param[in]	state		struct efa_resource that is managed by the framework
  */
-void test_efa_hmem_info_update_neuron()
+void test_efa_hmem_info_update_neuron(struct efa_resource **state)
 {
         int ret;
-        struct efa_resource resource = {0};
+        struct efa_resource *resource = *state;
         struct efa_domain *efa_domain;
         uint32_t efa_device_caps_orig;
         bool neuron_initialized_orig;
 
-        resource.hints = efa_unit_test_alloc_hints(FI_EP_RDM);
-        assert_non_null(resource.hints);
+        resource->hints = efa_unit_test_alloc_hints(FI_EP_RDM);
+        assert_non_null(resource->hints);
 
-        ret = fi_getinfo(FI_VERSION(1, 14), NULL, NULL, 0ULL, resource.hints, &resource.info);
+        ret = fi_getinfo(FI_VERSION(1, 14), NULL, NULL, 0ULL, resource->hints, &resource->info);
         assert_int_equal(ret, 0);
 
-        ret = fi_fabric(resource.info->fabric_attr, &resource.fabric, NULL);
+        ret = fi_fabric(resource->info->fabric_attr, &resource->fabric, NULL);
         assert_int_equal(ret, 0);
 
         neuron_initialized_orig = hmem_ops[FI_HMEM_NEURON].initialized;
@@ -32,18 +34,17 @@ void test_efa_hmem_info_update_neuron()
         g_device_list[0].device_caps |= EFADV_DEVICE_ATTR_CAPS_RDMA_READ;
         g_efa_unit_test_mocks.neuron_alloc = &efa_mock_neuron_alloc_return_null;
 
-        ret = fi_domain(resource.fabric, resource.info, &resource.domain, NULL);
+        ret = fi_domain(resource->fabric, resource->info, &resource->domain, NULL);
 
         /* recover the modified global variables before doing check */
         hmem_ops[FI_HMEM_NEURON].initialized = neuron_initialized_orig;
         g_device_list[0].device_caps = efa_device_caps_orig;
 
         assert_int_equal(ret, 0);
-        efa_domain = container_of(resource.domain, struct efa_domain,
+        efa_domain = container_of(resource->domain, struct efa_domain,
 				  util_domain.domain_fid.fid);
         assert_false(efa_domain->hmem_info[FI_HMEM_NEURON].initialized);
         assert_false(efa_domain->hmem_info[FI_HMEM_NEURON].p2p_supported_by_device);
-        efa_unit_test_resource_destruct(&resource);
 }
 #else
 void test_efa_hmem_info_update_neuron()

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -1,7 +1,40 @@
 #include "efa_unit_tests.h"
 
-static int efa_unit_test_mocks_reset(void **state)
+// Runs once before all tests
+static int efa_unit_test_mocks_group_setup(struct efa_resource **state)
 {
+	struct efa_resource *resource;
+	resource = calloc(1, sizeof(struct efa_resource));
+	*state = resource;
+
+	return 0;
+}
+
+// Runs once after all tests
+static int efa_unit_test_mocks_group_teardown(struct efa_resource **state)
+{
+	struct efa_resource *resource = *state;
+	free(resource);
+
+	return 0;
+}
+
+// Runs before every test
+static int efa_unit_test_mocks_setup(struct efa_resource **state)
+{
+	// Zero out *resource
+	struct efa_resource *resource = *state;
+	memset(resource, 0, sizeof(struct efa_resource));
+
+	return 0;
+}
+
+// Runs after every test
+static int efa_unit_test_mocks_teardown(struct efa_resource **state)
+{
+	struct efa_resource *resource = *state;
+	efa_unit_test_resource_destruct(resource);
+
 	efa_mock_ibv_send_wr_list_destruct(&g_ibv_send_wr_list);
 
 	g_efa_unit_test_mocks = (struct efa_unit_test_mocks) {
@@ -23,29 +56,29 @@ int main(void)
 	int ret;
 	/* Requires an EFA device to work */
 	const struct CMUnitTest efa_unit_tests[] = {
-		cmocka_unit_test_setup_teardown(test_av_insert_duplicate_raw_addr, efa_unit_test_mocks_reset, NULL),
-		cmocka_unit_test_setup_teardown(test_av_insert_duplicate_gid, efa_unit_test_mocks_reset, NULL),
-		cmocka_unit_test_setup_teardown(test_efa_device_construct_error_handling, efa_unit_test_mocks_reset, NULL),
-		cmocka_unit_test_setup_teardown(test_rxr_ep_pkt_pool_flags, efa_unit_test_mocks_reset, NULL),
-		cmocka_unit_test_setup_teardown(test_rxr_ep_pkt_pool_page_alignment, efa_unit_test_mocks_reset, NULL),
-		cmocka_unit_test_setup_teardown(test_rxr_ep_dc_atomic_error_handling, efa_unit_test_mocks_reset, NULL),
-		cmocka_unit_test_setup_teardown(test_dgram_cq_read_empty_cq, efa_unit_test_mocks_reset, NULL),
-		cmocka_unit_test_setup_teardown(test_dgram_cq_read_bad_wc_status, efa_unit_test_mocks_reset, NULL),
-		cmocka_unit_test_setup_teardown(test_ibv_cq_ex_read_empty_cq, efa_unit_test_mocks_reset, NULL),
-		cmocka_unit_test_setup_teardown(test_ibv_cq_ex_read_failed_poll, efa_unit_test_mocks_reset, NULL),
-		cmocka_unit_test_setup_teardown(test_ibv_cq_ex_read_bad_send_status, efa_unit_test_mocks_reset, NULL),
-		cmocka_unit_test_setup_teardown(test_ibv_cq_ex_read_bad_recv_status, efa_unit_test_mocks_reset, NULL),
-		cmocka_unit_test_setup_teardown(test_ibv_cq_ex_read_recover_forgotten_peer_ah, efa_unit_test_mocks_reset, NULL),
-		cmocka_unit_test_setup_teardown(test_ibv_cq_ex_read_ignore_removed_peer, efa_unit_test_mocks_reset, NULL),
-		cmocka_unit_test_setup_teardown(test_rdm_fallback_to_ibv_create_cq_ex_cq_read_ignore_forgotton_peer, efa_unit_test_mocks_reset, NULL),
-		cmocka_unit_test_setup_teardown(test_info_open_ep_with_wrong_info, efa_unit_test_mocks_reset, NULL),
-		cmocka_unit_test_setup_teardown(test_info_open_ep_with_api_1_1_info, efa_unit_test_mocks_reset, NULL),
-		cmocka_unit_test_setup_teardown(test_efa_hmem_info_update_neuron, efa_unit_test_mocks_reset, NULL),
+		cmocka_unit_test_setup_teardown(test_av_insert_duplicate_raw_addr, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_av_insert_duplicate_gid, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_device_construct_error_handling, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_rxr_ep_pkt_pool_flags, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_rxr_ep_pkt_pool_page_alignment, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_rxr_ep_dc_atomic_error_handling, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_dgram_cq_read_empty_cq, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_dgram_cq_read_bad_wc_status, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_ibv_cq_ex_read_empty_cq, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_ibv_cq_ex_read_failed_poll, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_ibv_cq_ex_read_bad_send_status, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_ibv_cq_ex_read_bad_recv_status, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_ibv_cq_ex_read_recover_forgotten_peer_ah, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_ibv_cq_ex_read_ignore_removed_peer, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_rdm_fallback_to_ibv_create_cq_ex_cq_read_ignore_forgotton_peer, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_info_open_ep_with_wrong_info, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_info_open_ep_with_api_1_1_info, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_hmem_info_update_neuron, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 	};
 
 	cmocka_set_message_output(CM_OUTPUT_XML);
 
-	ret = cmocka_run_group_tests_name("efa unit tests", efa_unit_tests, NULL, NULL);
+	ret = cmocka_run_group_tests_name("efa unit tests", efa_unit_tests, efa_unit_test_mocks_group_setup, efa_unit_test_mocks_group_teardown);
 
 	return ret;
 }


### PR DESCRIPTION
Previously, the teardown actions were part of the unit test code. With this approach, any unrecoverable failure in one test would cause the subsequent unit tests to fail.

This commit moves the teardown actions to a separate function that is executed by the framework even if one unit test fails and allows for subsequent unit tests to run successfully.

Signed-off-by: Sai Sunku <sunkusa@amazon.com>