### PR TITLE
src/hmem_cuda: Allow CUDA IPC when P2P disabled

### DIFF
--- a/src/hmem_cuda.c
+++ b/src/hmem_cuda.c
@@ -758,7 +758,7 @@ enum cuda_xfer_setting cuda_get_xfer_setting(void)
 
 bool cuda_is_ipc_enabled(void)
 {
-	return !ofi_hmem_p2p_disabled() && cuda_ipc_enabled;
+	return cuda_ipc_enabled;
 }
 
 int cuda_get_ipc_handle_size(size_t *size)


### PR DESCRIPTION
This effectively defers any limitation(s) on CUDA IPC to the initialization of `cuda_ipc_enabled`, which in turn depends on the status of `FI_HMEM_CUDA_ENABLE_XFER`

Signed-off-by: Darryl Abbate <drl@amazon.com>