### PR TITLE
prov/net: Dynamically set the inject message size

### DIFF
--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -418,7 +418,6 @@ static inline struct xnet_progress *xnet_srx2_progress(struct xnet_srx *srx)
 
 struct xnet_cq {
 	struct util_cq		util_cq;
-	struct ofi_bufpool	*xfer_pool;
 };
 
 static inline struct xnet_progress *xnet_cq2_progress(struct xnet_cq *cq)

--- a/prov/net/src/xnet_attr.c
+++ b/prov/net/src/xnet_attr.c
@@ -60,7 +60,7 @@ static struct fi_tx_attr xnet_tx_attr = {
 	.op_flags = XNET_TX_OP_FLAGS,
 	.comp_order = FI_ORDER_STRICT,
 	.msg_order = XNET_MSG_ORDER,
-	.inject_size = XNET_MAX_INJECT,
+	.inject_size = XNET_DEF_INJECT,
 	.size = 1024,
 	.iov_limit = XNET_IOV_LIMIT,
 	.rma_iov_limit = XNET_IOV_LIMIT,
@@ -92,7 +92,7 @@ static struct fi_tx_attr xnet_srx_tx_attr = {
 	.op_flags = XNET_TX_OP_FLAGS,
 	.comp_order = FI_ORDER_NONE,
 	.msg_order = XNET_MSG_ORDER,
-	.inject_size = XNET_MAX_INJECT,
+	.inject_size = XNET_DEF_INJECT,
 	.size = 1024,
 	.iov_limit = XNET_IOV_LIMIT,
 	.rma_iov_limit = XNET_IOV_LIMIT,
@@ -125,7 +125,7 @@ static struct fi_tx_attr xnet_rdm_tx_attr = {
 	.op_flags = XNET_TX_OP_FLAGS,
 	.comp_order = FI_ORDER_STRICT,
 	.msg_order = XNET_MSG_ORDER,
-	.inject_size = XNET_MAX_INJECT,
+	.inject_size = XNET_DEF_INJECT,
 	.size = 65536,
 	.iov_limit = XNET_IOV_LIMIT,
 	.rma_iov_limit = XNET_IOV_LIMIT,
@@ -232,6 +232,14 @@ static struct fi_info xnet_info = {
 	.fabric_attr = &xnet_fabric_attr,
 };
 
+void xnet_init_infos(void)
+{
+	struct fi_info *info;
+
+	for (info = &xnet_info; info; info = info->next) {
+		info->tx_attr->inject_size = xnet_max_inject;
+	}
+}
 
 /* User hints will still override the modified dest_info attributes
  * through ofi_alter_info

--- a/prov/net/src/xnet_init.c
+++ b/prov/net/src/xnet_init.c
@@ -68,6 +68,7 @@ int xnet_trace_msg;
 int xnet_disable_autoprog;
 int xnet_io_uring;
 int xnet_max_saved = 4;
+size_t xnet_max_inject = XNET_DEF_INJECT;
 
 
 static void xnet_init_env(void)
@@ -115,6 +116,12 @@ static void xnet_init_env(void)
 		xnet_default_tx_size = tx_size;
 	if (!fi_param_get_size_t(&xnet_prov, "rx_size", &rx_size))
 		xnet_default_rx_size = rx_size;
+	fi_param_define(&xnet_prov, "max_inject", FI_PARAM_SIZE_T,
+			"maximum size for inject messages.  This also "
+			"includes the maximum size for messages that may "
+			"be buffered at the receiver (default: %zu)",
+			xnet_max_inject);
+	fi_param_get_size_t(&xnet_prov, "max_inject", &xnet_max_inject);
 
 	fi_param_define(&xnet_prov, "max_saved", FI_PARAM_INT,
 			"maximum number of received messages that do not "
@@ -182,5 +189,6 @@ XNET_INI
 	ofi_mem_init();
 #endif
 	xnet_init_env();
+	xnet_init_infos();
 	return &xnet_prov;
 }

--- a/prov/net/src/xnet_msg.c
+++ b/prov/net/src/xnet_msg.c
@@ -89,7 +89,7 @@ static inline void
 xnet_init_tx_inject(struct xnet_xfer_entry *tx_entry, size_t hdr_len,
 		    const void *buf, size_t data_len)
 {
-	assert(data_len <= XNET_MAX_INJECT);
+	assert(data_len <= xnet_max_inject);
 	xnet_init_tx_sizes(tx_entry, hdr_len, data_len);
 
 	tx_entry->iov[0].iov_base = (void *) &tx_entry->hdr;
@@ -103,7 +103,7 @@ static inline void
 xnet_init_tx_buf(struct xnet_xfer_entry *tx_entry, size_t hdr_len,
 		 const void *buf, size_t data_len)
 {
-	if (data_len <= XNET_MAX_INJECT) {
+	if (data_len <= xnet_max_inject) {
 		xnet_init_tx_inject(tx_entry, hdr_len, buf, data_len);
 		return;
 	}
@@ -128,9 +128,9 @@ xnet_init_tx_iov(struct xnet_xfer_entry *tx_entry, size_t hdr_len,
 	xnet_init_tx_sizes(tx_entry, hdr_len, data_len);
 
 	tx_entry->iov[0].iov_base = (void *) &tx_entry->hdr;
-	if (data_len <= XNET_MAX_INJECT) {
+	if (data_len <= xnet_max_inject) {
 		ofi_copy_iov_buf(iov, count, 0, (uint8_t *) &tx_entry->hdr +
-				 hdr_len, XNET_MAX_INJECT, OFI_COPY_IOV_TO_BUF);
+				 hdr_len, xnet_max_inject, OFI_COPY_IOV_TO_BUF);
 		tx_entry->iov[0].iov_len = hdr_len + data_len;
 		tx_entry->iov_cnt = 1;
 	} else {

--- a/prov/net/src/xnet_rma.c
+++ b/prov/net/src/xnet_rma.c
@@ -211,7 +211,7 @@ xnet_rma_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 
 	assert(ofi_total_rma_iov_len(msg->rma_iov, msg->rma_iov_count) ==
 	       data_len);
-	assert(!(flags & FI_INJECT) || (data_len <= XNET_MAX_INJECT));
+	assert(!(flags & FI_INJECT) || (data_len <= xnet_max_inject));
 
 	send_entry->hdr.base_hdr.op = ofi_op_write;
 
@@ -361,7 +361,7 @@ xnet_rma_inject_common(struct fid_ep *ep_fid, const void *buf, size_t len,
 		goto unlock;
 	}
 
-	assert(len <= XNET_MAX_INJECT);
+	assert(len <= xnet_max_inject);
 	offset = sizeof(send_entry->hdr.base_hdr);
 
 	send_entry->hdr.base_hdr.op = ofi_op_write;


### PR DESCRIPTION
This allows for a larger inject size and larger messages to be buffered at the receive side.