### PR TITLE
prov/efa: allocate ibv_wr for RxR provider in rxr_pkt_entry

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -231,16 +231,6 @@ struct efa_ep {
 	bool			util_ep_initialized;
 };
 
-struct efa_send_wr {
-	struct ibv_send_wr wr;
-	struct ibv_sge sge[];
-};
-
-struct efa_recv_wr {
-	struct ibv_recv_wr wr;
-	struct ibv_sge sge[];
-};
-
 struct efa_av {
 	struct fid_av		*shm_rdm_av;
 	fi_addr_t		shm_rdm_addr_map[EFA_SHM_MAX_AV_COUNT];
@@ -333,7 +323,7 @@ int efa_prov_initialize(void);
 
 void efa_prov_finalize(void);
 
-ssize_t efa_post_flush(struct efa_ep *ep, struct ibv_send_wr **bad_wr);
+ssize_t efa_post_flush(struct efa_ep *ep, struct ibv_send_wr **bad_wr, bool free);
 
 ssize_t efa_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t count, fi_addr_t *src_addr);
 

--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -391,7 +391,7 @@ ssize_t rxr_pkt_entry_send(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry,
 
 	msg.addr = pkt_entry->addr;
 	msg.context = pkt_entry;
-	msg.data = 0;
+	msg.data = (uintptr_t)&pkt_entry->efa_send_wr;
 
 	if (pkt_entry->alloc_type == RXR_PKT_FROM_SHM_TX_POOL) {
 		msg.addr = peer->shm_fiaddr;

--- a/prov/efa/src/rxr/rxr_pkt_entry.h
+++ b/prov/efa/src/rxr/rxr_pkt_entry.h
@@ -53,6 +53,16 @@ enum rxr_pkt_entry_alloc_type {
 	RXR_PKT_FROM_READ_COPY_POOL,  /* packet is allocated from ep->rx_readcopy_pkt_pool */
 };
 
+struct efa_send_wr {
+	struct ibv_send_wr wr;
+	struct ibv_sge sge[];
+};
+
+struct efa_recv_wr {
+	struct ibv_recv_wr wr;
+	struct ibv_sge sge[];
+};
+
 struct rxr_pkt_sendv {
 	/* Because core EP current only support 2 iov,
 	 * and for the sake of code simplicity, we use 2 iov.
@@ -105,6 +115,11 @@ struct rxr_pkt_entry {
 
 	struct rxr_pkt_entry *next;
 	struct rxr_pkt_sendv send;
+
+	union {
+		struct efa_send_wr efa_send_wr;
+		struct efa_recv_wr efa_recv_wr;
+	};
 
 	char *wiredata; /* rxr_ctrl_*_pkt, or rxr_data_pkt */
 };


### PR DESCRIPTION
This commit is part 2 of the endpoint separation
The changes in this commit are temporary and will removed when the endpoints are fully separated

Signed-off-by: Sai Sunku <sunkusa@amazon.com>