### PR TITLE
prov/efa: simplify implementation of DC longcts protocol

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -170,18 +170,6 @@ static inline void rxr_poison_pkt_entry(struct rxr_pkt_entry *pkt_entry, size_t 
 
 #define RXR_DELIVERY_COMPLETE_REQUESTED	BIT_ULL(6)
 
-/*
- * Flag to tell if the sender
- * receives the receipt packet for the tx_entry.
- */
-#define RXR_RECEIPT_RECEIVED BIT_ULL(7)
-
-/*
- * Flag to tell that
- * long message protocol is used
- */
-#define RXR_LONGCTS_PROTOCOL BIT_ULL(8)
-
 #define RXR_OP_ENTRY_QUEUED_RNR BIT_ULL(9)
 
 /*

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -861,23 +861,19 @@ void rxr_pkt_handle_send_completion(struct rxr_ep *ep, struct rxr_pkt_entry *pkt
 	case RXR_DC_MEDIUM_TAGRTM_PKT:
 	case RXR_DC_EAGER_RTW_PKT:
 	case RXR_DC_WRITE_RTA_PKT:
-		/* no action to be taken here */
-		/* For non-dc version of the packet types,
-		 * this is the place to write tx completion.
-		 * However, for dc tx completion will always be
+	case RXR_DC_LONGCTS_MSGRTM_PKT:
+	case RXR_DC_LONGCTS_TAGRTM_PKT:
+	case RXR_DC_LONGCTS_RTW_PKT:
+		/* no action to be taken here
+		 * For non-dc version of these packet types,
+		 * this is the place to increase bytes_acked or
+		 * write tx completion.
+		 * For dc, tx completion will always be
 		 * written upon receving the receipt packet
-		 * if not using long message protocols.
 		 * Moreoever, because receipt can arrive
 		 * before send completion, we cannot take
 		 * any action on tx_entry here.
 		 */
-		break;
-	case RXR_DC_LONGCTS_MSGRTM_PKT:
-	case RXR_DC_LONGCTS_TAGRTM_PKT:
-		rxr_pkt_handle_dc_longcts_rtm_send_completion(ep, pkt_entry);
-		break;
-	case RXR_DC_LONGCTS_RTW_PKT:
-		rxr_pkt_handle_dc_longcts_rtw_send_completion(ep, pkt_entry);
 		break;
 	default:
 		FI_WARN(&rxr_prov, FI_LOG_CQ,

--- a/prov/efa/src/rxr/rxr_pkt_entry.h
+++ b/prov/efa/src/rxr/rxr_pkt_entry.h
@@ -40,6 +40,7 @@
 #define RXR_PKT_ENTRY_IN_USE		BIT_ULL(0) /**< this packet entry is being used */
 #define RXR_PKT_ENTRY_RNR_RETRANSMIT	BIT_ULL(1) /**< this packet entry encountered RNR and is being retransmitted*/
 #define RXR_PKT_ENTRY_LOCAL_READ	BIT_ULL(2) /**< this packet entry is used as context of a local read operation */
+#define RXR_PKT_ENTRY_DC_LONGCTS_DATA	BIT_ULL(3) /**< this DATA packet entry is used by a delivery complete LONGCTS send/write protocol*/
 
 /**
  * @enum for packet entry allocation type
@@ -172,7 +173,8 @@ struct rxr_pkt_entry {
 	 * @brief flags indicating the status of the packet entry
 	 * 
 	 * @details
-	 * Possisle flags include  #RXR_PKT_ENTRY_IN_USE #RXR_PKT_ENTRY_RNR_RETRANSMIT and #RXR_PKT_ENTRY_LOCAL_READ
+	 * Possible flags include  #RXR_PKT_ENTRY_IN_USE #RXR_PKT_ENTRY_RNR_RETRANSMIT,
+	 * #RXR_PKT_ENTRY_LOCAL_READ, and #RXR_PKT_ENTRY_DC_LONGCTS_DATA
 	 */
 	uint32_t flags;
 

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -677,21 +677,6 @@ void rxr_pkt_handle_receipt_recv(struct rxr_ep *ep,
 		return;
 	}
 
-	tx_entry->rxr_flags |= RXR_RECEIPT_RECEIVED;
-	if (tx_entry->rxr_flags & RXR_LONGCTS_PROTOCOL) {
-		/*
-		 * For long message protocol, when FI_DELIVERY_COMPLETE
-		 * is requested, we have to write tx completions
-		 * in either rxr_pkt_handle_data_send_completion()
-		 * or rxr_pkt_handle_receipt_recv() depending on which of them
-		 * is called later due to avoid accessing released
-		 * tx_entry.
-		 */
-		if (tx_entry->total_len == tx_entry->bytes_acked)
-			rxr_cq_handle_send_completion(ep, tx_entry);
-	} else {
-		rxr_cq_handle_send_completion(ep, tx_entry);
-	}
-
+	rxr_cq_handle_send_completion(ep, tx_entry);
 	rxr_pkt_entry_release_rx(ep, pkt_entry);
 }

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -679,7 +679,6 @@ int rxr_pkt_init_longcts_rtm(struct rxr_ep *ep,
 	struct rxr_longcts_rtm_base_hdr *rtm_hdr;
 	int ret;
 
-	tx_entry->rxr_flags |= RXR_LONGCTS_PROTOCOL;
 	ret = rxr_pkt_init_rtm(ep, tx_entry, pkt_type, 0, pkt_entry);
 	if (ret)
 		return ret;
@@ -964,18 +963,6 @@ void rxr_pkt_handle_longcts_rtm_send_completion(struct rxr_ep *ep,
 	tx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
 	tx_entry->bytes_acked += rxr_pkt_req_data_size(pkt_entry);
 	if (tx_entry->total_len == tx_entry->bytes_acked)
-		rxr_cq_handle_send_completion(ep, tx_entry);
-}
-
-void rxr_pkt_handle_dc_longcts_rtm_send_completion(struct rxr_ep *ep,
-						struct rxr_pkt_entry *pkt_entry)
-{
-	struct rxr_op_entry *tx_entry;
-
-	tx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
-	tx_entry->bytes_acked += rxr_pkt_req_data_size(pkt_entry);
-	if (tx_entry->total_len == tx_entry->bytes_acked &&
-	    tx_entry->rxr_flags & RXR_RECEIPT_RECEIVED)
 		rxr_cq_handle_send_completion(ep, tx_entry);
 }
 
@@ -1715,7 +1702,6 @@ static inline void rxr_pkt_init_longcts_rtw_hdr(struct rxr_ep *ep,
 {
 	struct rxr_longcts_rtw_hdr *rtw_hdr;
 
-	tx_entry->rxr_flags |= RXR_LONGCTS_PROTOCOL;
 	rtw_hdr = (struct rxr_longcts_rtw_hdr *)pkt_entry->wiredata;
 	rtw_hdr->rma_iov_count = tx_entry->rma_iov_count;
 	rtw_hdr->msg_length = tx_entry->total_len;
@@ -1827,18 +1813,6 @@ void rxr_pkt_handle_longcts_rtw_send_completion(struct rxr_ep *ep,
 	tx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
 	tx_entry->bytes_acked += rxr_pkt_req_data_size(pkt_entry);
 	if (tx_entry->total_len == tx_entry->bytes_acked)
-		rxr_cq_handle_send_completion(ep, tx_entry);
-}
-
-void rxr_pkt_handle_dc_longcts_rtw_send_completion(struct rxr_ep *ep,
-						struct rxr_pkt_entry *pkt_entry)
-{
-	struct rxr_op_entry *tx_entry;
-
-	tx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
-	tx_entry->bytes_acked += rxr_pkt_req_data_size(pkt_entry);
-	if (tx_entry->total_len == tx_entry->bytes_acked &&
-	    tx_entry->rxr_flags & RXR_RECEIPT_RECEIVED)
 		rxr_cq_handle_send_completion(ep, tx_entry);
 }
 

--- a/prov/efa/src/rxr/rxr_pkt_type_req.h
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.h
@@ -262,9 +262,6 @@ void rxr_pkt_handle_medium_rtm_send_completion(struct rxr_ep *ep,
 void rxr_pkt_handle_longcts_rtm_send_completion(struct rxr_ep *ep,
 					     struct rxr_pkt_entry *pkt_entry);
 
-void rxr_pkt_handle_dc_longcts_rtm_send_completion(struct rxr_ep *ep,
-						struct rxr_pkt_entry *pkt_entry);
-
 static inline
 void rxr_pkt_handle_longread_rtm_send_completion(struct rxr_ep *ep,
 					     struct rxr_pkt_entry *pkt_entry)
@@ -353,9 +350,6 @@ void rxr_pkt_handle_eager_rtw_send_completion(struct rxr_ep *ep,
 
 void rxr_pkt_handle_longcts_rtw_send_completion(struct rxr_ep *ep,
 					     struct rxr_pkt_entry *pkt_entry);
-
-void rxr_pkt_handle_dc_longcts_rtw_send_completion(struct rxr_ep *ep,
-						struct rxr_pkt_entry *pkt_entry);
 
 static inline
 void rxr_pkt_handle_longread_rtw_send_completion(struct rxr_ep *ep,


### PR DESCRIPTION
Prior to this patch, the TX entry of a DC longcts
protocol was released when both all DATA packets' send completion have arrived and RECEIPT packet was released.

This is not ideal, because we want to write TX completion as soon as RECEIPT was received.

The current implementation is because of two things:

First, there is no information in the packet
entry can be used to determine whether a DATA packet is used by a DC longcts protocol or a normal longcts protocol,

Second, if a DATA packet is used by a normal longcts protocol, the op_entry's byte_acked must be updated.

Beacuse of 1, we have to update tx_entry->byte_acked when we receive the send completion of a DATA packet, which means the tx_entry must not be released when we received the send completion of the DATA packet.

As a result, we cannot release TX entry when we received the RECEIPT packet.

This patch addressed the issue by introdce a flag

     RXR_PKT_ENTRY_DC_LONGCTS_DATA

and set it in the pkt_entry->flags for DATA packet used by DC longcts protocol.

rxr_pkt_hand_data_send_completion() can check this flag to determine whether a DATA packet is used by a DC longcts protocol, and do not do anything for such a DATA packet.

The function rxr_pkt_handle_receipt_recv() was simplied to just write TX completion.

The two tx_entry flags RXR_LONGCTS_PROTOCOL and RXR_RECEIPT_RECEIVED was removed.

The two functions

    rxr_pkt_handle_dc_longcts_rtw_send_completion()
    rxr_pkt_handle_dc_longcts_rtm_send_completion()

was removed.

Signed-off-by: Wei Zhang <wzam@amazon.com>