### PR TITLE
fabric: Improve log level of provider mismatch

### DIFF
--- a/src/fabric.c
+++ b/src/fabric.c
@@ -1229,7 +1229,8 @@ int DEFAULT_SYMVER_PRE(fi_getinfo)(uint32_t version, const char *node,
 					      hints, &cur);
 		if (ret) {
 			level = ((hints && hints->fabric_attr &&
-				  hints->fabric_attr->prov_name) ?
+				  hints->fabric_attr->prov_name &&
+				  !strcmp(hints->fabric_attr->prov_name, prov->provider->name)) ?
 				 FI_LOG_WARN : FI_LOG_INFO);
 
 			FI_LOG(&core_prov, level, FI_LOG_CORE,


### PR DESCRIPTION
In case a provider returned an error, print a message in WARN level only if the requested provider matches the failed provider.

Signed-off-by: Firas Jahjah <firasj@amazon.com>