### PR TITLE
man/guide: Add user-guide to man pages

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -278,9 +278,14 @@ real_man_pages = \
         man/man3/fi_trigger.3 \
         man/man3/fi_version.3 \
         man/man7/fabric.7 \
+        man/man7/fi_arch.7 \
+        man/man7/fi_direct.7 \
+        man/man7/fi_guide.7 \
 	man/man7/fi_hook.7 \
+        man/man7/fi_intro.7 \
         man/man7/fi_provider.7 \
-        man/man7/fi_direct.7
+        man/man7/fi_setup.7
+
 
 dummy_man_pages = \
         man/man3/fi_accept.3 \

--- a/man/fabric.7.md
+++ b/man/fabric.7.md
@@ -16,7 +16,8 @@ fabric \- Fabric Interface Library
 ```
 
 Libfabric is a high-performance fabric software library designed to
-provide low-latency interfaces to fabric hardware.
+provide low-latency interfaces to fabric hardware.  For an in-depth
+discussion of the motivation and design see [`fi_guide`(7)](fi_guide.7.html).
 
 # OVERVIEW
 

--- a/man/fi_arch.7.md
+++ b/man/fi_arch.7.md
@@ -1,0 +1,558 @@
+---
+layout: page
+title: fi_arch(7)
+tagline: Libfabric Programmer's Guide - Architecture
+---
+{% include JB/setup %}
+
+# NAME
+
+fi_arch \- libfabric architecture
+
+# OVERVIEW
+
+Libfabric APIs define application facing communication semantics without
+mandating the underlying implementation or wire protocols. It is architected
+such that applications can have direct access to network hardware without
+operating system intervention, but does not mandate such an implementation.
+The APIs have been defined specifically to allow multiple implementations.
+
+The following diagram highlights the general architecture of the interfaces
+exposed by libfabric.
+
+```
+                 Applications and Middleware
+       [MPI]   [SHMEM]   [PGAS]   [Storage]   [Other]
+
+--------------------- libfabric API ---------------------
+
+/  Core  \ + /Communication\ + /  Data  \ + <Completion>
+\Services/   \    Setup    /   \Transfer/
+
+----------------- libfabric Provider API ----------------
+
+                    libfabric providers
+   [TCP]   [UDP]   [Verbs]    [EFA]    [SHM]   [Other]
+
+---------------------------------------------------------
+
+     Low-level network hardware and software interfaces
+```
+Details of each libfabric component is described below.
+
+## Core Services
+
+libfabric can be divided between the libfabric core and providers.  The
+core defines defines the APIs that applications use and implements what is
+referred to as discovery services.  Discovery services are responsible
+for identifying what hardware is available in the system, platform features,
+operating system features, associated communication and computational
+libraries, and so forth.  Providers are optimized implementations of the
+libfabric API.  One of the goals of the libfabric core is to link upper
+level applications and middleware with specific providers best suited for
+their needs.
+
+From the viewpoint of an application, the core libfabric services are
+accessed primarily by the fi_getinfo() API.  See
+[`fi_getinfo`(3)](fi_getinfo.3.html).
+
+## Providers
+
+Unlike many libraries, the libfabric core does not implement most of the APIs
+called by its users.  Instead, that responsibility instead falls to what
+libfabric calls providers.  The bulk of the libfabric API is implemented by each
+provider.  When an application calls a libfabric API, that function call is
+routed directly into a specific provider.  This is done using function
+pointers associated with specific libfabric defined objects.  The object
+model is describe in more detail below.
+
+The benefit of this approach is that each provider can optimize the libfabric
+defined communication semantics according to their available network hardware,
+operating system, platform, and network protocol features.
+
+In general, each provider focuses on supporting the libfabric API over a
+specific lower-level communication API or NIC.  See
+[`fi_provider`(7)](fi_provider.7.html) for a discussion on the different
+types of providers available and the provider architecture.
+
+## Communication Setup
+
+At a high-level, communication via libfabric may be either connection-
+oriented or connectionless.  This is similar to choosing between using TCP
+or UDP sockets, though libfabric supports reliable-connectionless
+communication semantics.  Communication between two processes occurs over
+a construct known as an endpoint.  Conceptually, an endpoint is equivalent
+to a socket in the socket API world.
+
+Specific APIs and libfabric objects are designed to manage and setup
+communication between nodes.  It includes calls for connection management (CM),
+as well as functionality used to address connection-less endpoints.
+
+The CM APIs are modeled after APIs used to connect
+TCP sockets: connect(), bind(), listen(), and accept().  A main difference
+is that libfabric calls are designed to always operate asynchronously.
+CM APIs are discussed in [`fi_cm`(3)](fi_cm.3.html).
+
+For performance and scalability reasons discussed in the
+[`fi_intro`(7)](fi_intro.7.html) page, connection-less endpoints use a unique
+model to setup communication.  These are based on a concept referred to as
+address vectors, where the term vector means table or array.  Address vectors
+are discussed in detail later, but target applications needing to talk with
+potentially thousands to millions of peers.
+
+## Data Transfer Services
+
+libfabric provides several data transfer semantics to meet different
+application requirements.  There are five basic sets of data transfer APIs:
+messages, tagged messages, RMA, atomics, and collectives.
+
+*Messages*
+: Message APIs expose the ability to send and receive data with message
+  boundaries being maintained.  Message transfers act as FIFOs, with sent
+  messages matched with receive buffers in the order that messages are
+  received at the target.  The message APIs are modeled after socket APIs,
+  such as send(). sendto(), sendmsg(), recv(), recvmsg(), etc.  For more
+  information see [`fi_msg`(3)](fi_msg.3.html).
+
+*Tagged Messages*
+: Tagged messages are similar to messages APIs, with the exception of how
+  messages are matched at the receiver.  Tagged messages maintain message
+  boundaries, same as the message API.  The tag matching APIs differ from
+  the message APIs in that received messages are directed into buffers
+  based on small steering tags that are specified and carried in the sent
+  message.  All message buffers, posted to send or receive data,
+  are associated with a tag value.  Sent messages are matched with buffers
+  at the receiver that have the same tag.  For more information, see
+  [`fi_tagged`(3)](fi_tagged.3.html).
+
+*RMA*
+: RMA stands for remote memory access. RMA transfers allow an application
+  to write data directly into a specific memory location in a target process
+  or to read memory from a specific address at the target process and
+  return the data into a local buffer.  RMA is also known as RDMA (remote
+  direct memory access); however, RDMA originally defined a specific
+  transport implementation of RMA.  For more information, see
+  [`fi_rma`(3)](fi_rma.3.html).
+
+*Atomics*
+: Atomic operations add arithmetic operations to RMA transfers.  Atomics
+  permit direct access and manipulation of memory on the target process.
+  libfabric defines a wide range of arithmetic operations that may be
+  invoked as part of a data transfer operation.  For more information,
+  see [`fi_atomic`(3)](fi_atomic.3.html).
+
+*Collectives*
+: The above data transfer APIs perform point-to-point communication.
+  Data transfers occur between exactly one initiator and one target.
+  Collective operations are coordinated atomic operations among an
+  arbitrarily large number of peers.  For more information, see
+  [`fi_collective`(3)](fi_collective.3.html).
+
+## Memory Registration
+
+One of the objective of libfabric is to allow network hardware direct
+access to application data buffers.  This is accomplished through an
+operation known as memory registration.
+
+In order for a NIC to read or write application memory directly, it must
+access the physical memory pages that back the application's address space.
+Modern operating systems employ page files that swap out virtual pages from
+one process with the virtual pages from another.  As a result, a physical
+memory page may map to different virtual addresses depending on when it
+is accessed.  Furthermore, when a virtual page is swapped in, it may be
+mapped to a new physical page.  If a NIC attempts to read or write
+application memory without being linked into the virtual address manager,
+it could access the wrong data, possibly corrupting an application's memory.
+Memory registration can be used to avoid this situation from occurring.
+For example, registered pages can be marked such that the operating system
+locks the virtual to physical mapping, avoiding any possibility of the
+virtual page being paged out or remapped.
+
+Memory registration is also the security mechanism used to grant a remote
+peer access to local memory buffers.  Registered memory regions associate
+memory buffers with permissions granted for access by fabric resources.
+A memory buffer must be registered before it can be used as the target
+of an RMA or atomic data transfer.  Memory registration provides a simple
+protection mechanism.  (Advanced scalable networks employ other mechanisms,
+which are considered out of scope for the purposes of this discussion.)
+After a memory buffer has been registered, that registration request
+(buffer's address, buffer length, and access permission) is given a
+registration key.  Peers that issue RMA or atomic operations against that
+memory buffer must provide this key as part of their operation.  This helps
+protects against unintentional accesses to the region.
+
+## Completion Services
+
+libfabric data transfers operate asynchronously. Completion services are
+used to report the results of submitted data transfer operations.
+Completions may be reported using the cleverly named completions queues,
+which provide details about the operation that completed. Or, completions
+may be reported using completion counters that simply return the number
+of operations that have completed.
+
+Completion services are designed with high-performance, low-latency in mind.
+The calls map directly into the providers, and data structures are defined
+to minimize memory writes and cache impact.  Completion services do not have
+corresponding socket APIs.  However, for Windows developers, they are similar
+to IO completion ports.
+
+# Object Model
+
+libfabric follows an object-oriented design model.  Although the interfaces
+are written in C, the structures and implementation have a C++ feel to them.
+The following diagram shows a high-level view of notable libfabric objects
+and object dependencies.
+
+```
+/ Passive \ ---> <Fabric> <--- /Event\
+\Endpoints/         ^          \Queue/
+                    |
+  /Address\ ---> <Domain> <--- /Completion\
+  \Vector /       ^  ^         \  Queue   /
+                  |  |
+      /Memory\ ---    --- / Active \
+      \Region/            \Endpoint/
+
+```
+
+*Fabric*
+: A fabric represents a collection of hardware and software resources that
+  access a single physical or virtual network.  For example, a fabric may
+  be a single network subnet or cluster.  All network ports on a system that
+  can communicate with each other through the fabric belong to the same
+  fabric. A fabric shares network addresses and can span multiple providers.
+  Fabrics are the top level object from which other objects are allocated.
+
+*Domain*
+: A domain represents a logical connection into a fabric.  In the simplest
+  case, a domain may correspond to a physical or virtual NIC; however a domain
+  could include multiple NICs (in the case of a multi-rail provider), or no
+  NIC at all (in the case of shared memory).  A domain defines the boundary
+  within which other resources may be associated.  Active endpoints and
+  completion queues must be part of the same domain in order to be related
+  to each other.
+
+*Passive Endpoint*
+: Passive endpoints are used by connection-oriented protocols to listen for
+  incoming connection requests. Passive endpoints often map to software
+  constructs and may span multiple domains.  They are best represented by
+  a listening socket.
+
+*Event Queues*
+: Event queues (EQs) are used to collect and report the completion of
+  asynchronous operations and events. Event queues handle _control_ events,
+  that is, operations which are not directly associated with data transfer
+  operations. The reason for separating control events from data transfer
+  events is for performance reasons.  Event queues are often implemented
+  entirely in software using operating system constructs.  Control events
+  usually occur during an application's initialization phase, or at a rate
+  that's several orders of magnitude smaller than data transfer events.
+  Event queues are most commonly used by connection-oriented protocols for
+  notification of connection request or established events.
+
+*Active Endpoint*
+: Active endpoints are data transfer communication portals.  They are
+  conceptually similar to a TCP or UDP socket.  Active endpoints are used to
+  perform data transfers.  Active endpoints implement the network protocol.
+
+*Completion Queue*
+: Completion queues (CQs) are high-performance queues used to report the
+  completion of data transfer operations.  Unlike event queues, completion
+  queues are often fully or partially implemented in hardware.  Completion
+  queue interfaces are designed to minimize software overhead.
+
+*Memory Region*
+: Memory regions describe application’s local memory buffers. In order for
+  fabric resources to access application memory, the application must first
+  grant permission to the fabric provider by constructing a memory region.
+  Memory regions are required for specific types of data transfer operations,
+  such as RMA and atomic operations.
+
+*Address Vectors*
+: Address vectors are used by connection-less endpoints. They map higher level
+  addresses, such as IP addresses or hostnames, which may be more natural for
+  an application to use, into fabric specific addresses. The use of address
+  vectors allows providers to reduce the amount of memory required to
+  maintain large address look-up tables, and eliminate expensive address
+  resolution and look-up methods during data transfer operations.
+
+# Communication Model
+
+Endpoints represent communication portals, and all data transfer operations
+are initiated on endpoints. libfabric defines the conceptual model for how
+endpoints are exposed to applications.  It supports three main communication
+endpoint types.  The endpoint names are borrowed from socket API naming.
+
+*FI_EP_MSG*
+: Reliable-connected
+
+*FI_EP_DGRAM*
+: Unreliable datagram
+
+*FI_EP_RDM*
+: Reliable-unconnected
+
+Communication setup is based on whether the endpoint is connected or
+unconnected.  Reliability is a feature of the endpoint's data transfer
+protocol.
+
+## Connected Communications
+
+The following diagram highlights the general usage behind connection-oriented
+communication. Connected communication is based on the flow used to connect
+TCP sockets, with improved asynchronous support.
+
+```
+         1 listen()              2 connect()
+             |                      |
+         /Passive \  <---(3)--- / Active \
+         \Endpoint/             \Endpoint/
+         /                               \
+        / (4 CONNREQ)                     \
+/Event\                                     /Event\
+\Queue/                                     \Queue/
+                                           /
+         5 accept()         (8 CONNECTED) /
+             |                           /
+         / Active \  ------(6)--------->
+         \Endpoint/  <-----(7)----------
+         /
+        / (9 CONNECTED)
+/Event\
+\Queue/
+
+```
+Connections require the use of both passive and active endpoints.
+In order to establish a connection, an application must first create a
+passive endpoint and associate it with an event queue. The event queue
+will be used to report the connection management events. The application
+then calls listen on the passive endpoint. A single passive endpoint can
+be used to form multiple connections.
+
+The connecting peer allocates an active endpoint, which is also
+associated with an event queue. Connect is called on the active
+endpoint, which results in sending a connection request (CONNREQ)
+message to the passive endpoint. The CONNREQ event is inserted into
+the passive endpoint’s event queue, where the listening application can
+process it.
+
+Upon processing the CONNREQ, the listening application will allocate
+an active endpoint to use with the connection. The active endpoint is
+bound with an event queue. Although the diagram shows the use of a
+separate event queue, the active endpoint may use the same event queue
+as used by the passive endpoint. Accept is called on the active endpoint
+to finish forming the connection. It should be noted that the OFI accept
+call is different than the accept call used by sockets. The differences
+result from OFI supporting process direct I/O.
+
+libfabric does not define the connection establishment protocol, but
+does support a traditional three-way handshake used by many technologies.
+After calling accept, a response is sent to the connecting active endpoint.
+That response generates a CONNECTED event on the remote event queue. If a
+three-way handshake is used, the remote endpoint will generate an
+acknowledgment message that will generate a CONNECTED event for the accepting
+endpoint. Regardless of the connection protocol, both the active and passive
+sides of the connection will receive a CONNECTED event that signals that the
+connection has been established.
+
+## Connectionless Communications
+
+Connectionless communication allows data transfers between active endpoints
+without going through a connection setup process. The diagram below shows
+the basic components needed to setup connection-less communication.
+Connectionless communication setup differs from UDP sockets in that it
+requires that the remote addresses be stored with libfabric.
+
+```
+  1 insert_addr()              2 send()
+         |                        |
+     /Address\ <--3 lookup--> / Active \
+     \Vector /                \Endpoint/
+
+```
+libfabric requires the addresses of peer endpoints be inserted into a local
+addressing table, or address vector, before data transfers can be initiated
+against the remote endpoint. Address vectors abstract fabric specific
+addressing requirements and avoid long queuing delays on data transfers
+when address resolution is needed. For example, IP addresses may need to be
+resolved into Ethernet MAC addresses. Address vectors allow this resolution
+to occur during application initialization time. libfabric does not define
+how an address vector be implemented, only its conceptual model.
+
+All connection-less endpoints that transfer data must be associated with an
+address vector.
+
+# Endpoints
+
+At a low-level, endpoints are usually associated with a transmit context, or
+queue, and a receive context, or queue.  Although the terms transmit and
+receive queues are easier to understand, libfabric uses the terminology
+context, since queue like behavior of acting as a FIFO (first-in, first-out)
+is not guaranteed.  Transmit and receive contexts may be implemented using
+hardware queues mapped directly into the process’s address space.  An endpoint
+may be configured only to transmit or receive data.  Data transfer requests
+are converted by the underlying provider into commands that are inserted into
+hardware transmit and/or receive contexts.
+
+Endpoints are also associated with completion queues. Completion queues are
+used to report the completion of asynchronous data transfer operations.
+
+## Shared Contexts
+
+An advanced usage model allows for sharing resources among multiple endpoints.
+The most common form of sharing is having multiple connected endpoints
+make use of a single receive context.  This can reduce receive side buffering
+requirements, allowing the number of connected endpoints that an application
+can manage to scale to larger numbers.
+
+# Data Transfers
+
+Obviously, a primary goal of network communication is to transfer data between
+processes running on different systems. In a similar way that the socket API
+defines different data transfer semantics for TCP versus UDP sockets, that is,
+streaming versus datagram messages, libfabric defines different types of data
+transfers. However, unlike sockets, libfabric allows different semantics over
+a single endpoint, even when communicating with the same peer.
+
+libfabric uses separate API sets for the different data transfer semantics;
+although, there are strong similarities between the API sets.  The differences
+are the result of the parameters needed to invoke each type of data transfer.
+
+## Message transfers
+
+Message transfers are most similar to UDP datagram transfers, except that
+transfers may be sent and received reliably.  Message transfers may also be
+gigabytes in size, depending on the provider implementation.  The sender
+requests that data be transferred as a single transport operation to a peer.
+Even if the data is referenced using an I/O vector, it is treated as a single
+logical unit or message.  The data is placed into a waiting receive buffer
+at the peer, with the receive buffer usually chosen using FIFO ordering.
+Note that even though receive buffers are selected using FIFO ordering, the
+received messages may complete out of order.  This can occur as a result of
+data between and within messages taking different paths through the network,
+handling lost or retransmitted packets, etc.
+
+Message transfers are usually invoked using API calls that contain the string
+"send" or "recv".  As a result they may be referred to simply as sent or
+received messages.
+
+Message transfers involve the target process posting memory buffers to the
+receive (Rx) context of its endpoint.  When a message arrives from the network,
+a receive buffer is removed from the Rx context, and the data is copied from
+the network into the receive buffer.  Messages are matched with posted receives
+in the order that they are received.  Note that this may differ from the order
+that messages are sent, depending on the transmit side's ordering semantics.
+
+Conceptually, on the transmit side, messages are posted to a transmit (Tx)
+context.  The network processes messages from the Tx context, packetizing
+the data into outbound messages.  Although many implementations process the
+Tx context in order (i.e. the Tx context is a true queue), ordering guarantees
+specified through the libfabric API determine the actual processing order.  As
+a general rule, the more relaxed an application is on its message and data
+ordering, the more optimizations the networking software and hardware can
+leverage, providing better performance.
+
+## Tagged messages
+
+Tagged messages are similar to message transfers except that the messages
+carry one additional piece of information, a message tag.  Tags are application
+defined values that are part of the message transfer protocol and are used to
+route packets at the receiver.  At a high level, they are roughly similar to
+message ids.  The difference is that tag values are set by the application,
+may be any value, and duplicate tag values are allowed.
+
+Each sent message carries a single tag value, which is used to select a receive
+buffer into which the data is copied.  On the receiving side, message buffers
+are also marked with a tag.  Messages that arrive from the network search
+through the posted receive messages until a matching tag is found.
+
+Tags are often used to identify virtual communication groups or roles.
+In practice, message tags are typically divided into fields.  For example, the
+upper 16 bits of the tag may indicate a virtual group, with the lower 16 bits
+identifying the message purpose.  The tag message interface in libfabric is
+designed around this usage model.  Each sent message carries exactly one tag
+value, specified through the API.  At the receiver, buffers are associated
+with both a tag value and a mask.  The mask is used as part of the buffer
+matching process.  The mask is applied against the received tag value carried
+in the sent message prior to checking the tag against the receive buffer.  For
+example, the mask may indicate to ignore the lower 16-bits of a tag.  If
+the resulting values match, then the tags are said to match.  The received
+data is then placed into the matched buffer.
+
+For performance reasons, the mask is specified as 'ignore' bits. Although
+this is backwards from how many developers think of a mask (where the bits
+that are valid would be set to 1), the definition ends up mapping well with
+applications.  The actual operation performed when matching tags is:
+
+```
+send_tag | ignore == recv_tag | ignore
+
+/* this is equivalent to:
+ * send_tag & ~ignore == recv_tag & ~ignore
+ */
+```
+
+Tagged messages are equivalent of message transfers if a single tag value is
+used.  But tagged messages require that the receiver perform a matching
+operation at the target, which can impact performance versus untagged messages.
+
+## RMA
+
+RMA operations are architected such that they can require no processing by the
+CPU at the RMA target.  NICs which offload transport functionality can perform
+RMA operations without impacting host processing.  RMA write operations transmit
+data from the initiator to the target.  The memory location where the data
+should be written is carried within the transport message itself, with
+verification checks at the target to prevent invalid access.
+
+RMA read operations fetch data from the target system and transfer it back to
+the initiator of the request, where it is placed into memory.  This too can be
+done without involving the host processor at the target system when the NIC
+supports transport offloading.
+
+The advantage of RMA operations is that they decouple the processing of the
+peers.  Data can be placed or fetched whenever the initiator is ready without
+necessarily impacting the peer process.
+
+Because RMA operations allow a peer to directly access the memory of a process,
+additional protection mechanisms are used to prevent unintentional or unwanted
+access.  RMA memory that is updated by a write operation or is fetched by a read
+operation must be registered for access with the correct permissions specified.
+
+## Atomic operations
+
+Atomic transfers are used to read and update data located in remote memory
+regions in an atomic fashion. Conceptually, they are similar to local atomic
+operations of a similar nature (e.g. atomic increment, compare and swap, etc.).
+The benefit of atomic operations is they enable offloading basic arithmetic
+capabilities onto a NIC.  Unlike other data transfer operations, which merely
+need to transfer bytes of data, atomics require knowledge of the format of
+the data being accessed.
+
+A single atomic function operates across an array of data, applying an atomic
+operation to each entry.  The atomicity of an operation is limited to a single
+data type or entry, however, not across the entire array.  libfabric defines a
+wide variety of atomic operations across all common data types.  However
+support for a given operation is dependent on the provider implementation.
+
+## Collective operations
+
+In general, collective operations can be thought of as coordinated atomic
+operations between a set of peer endpoints, almost like a multicast
+atomic request.  A single collective operation can result in data being
+collected from multiple peers, combined using a set of atomic primitives,
+and the results distributed to all peers.   A collective operation is a
+group communication exchange.  It involves multiple peers exchanging data
+with other peers participating in the collective call.  Collective operations
+require close coordination by all participating members, and
+collective calls can strain the fabric, as well as local and remote data
+buffers.
+
+Collective operations are an area of heavy research, with dedicated libraries
+focused almost exclusively on implementing collective operations efficiently.
+Such libraries are a specific target of libfabric.  The main object of
+the libfabric collection APIs is to expose network acceleration features
+for implementing collectives to higher-level libraries and applications.
+It is recommended that applications needing collective communication target
+higher-level libraries, such as MPI, instead of using libfabric collective
+APIs for that purpose.

--- a/man/fi_cm.3.md
+++ b/man/fi_cm.3.md
@@ -88,8 +88,8 @@ Active or passive endpoint to get/set address.
 
 # DESCRIPTION
 
-Connection management functions are used to connect an 
-connection-oriented endpoint to a peer endpoint.
+Connection management functions are used to connect an
+connection-oriented (FI_EP_MSG) endpoint to a listening peer.
 
 ## fi_listen
 
@@ -195,7 +195,7 @@ peer endpoint address, respectively.  On input, the addrlen parameter should
 indicate the size of the addr buffer.  If the actual address is larger than
 what can fit into the buffer, it will be truncated and -FI_ETOOSMALL will
 be returned.  On output, addrlen is set to the size of the buffer needed
-to store the address, which may be larger than the input value.  
+to store the address, which may be larger than the input value.
 
 fi_getname is not guaranteed to return a valid source address until after the
 specified endpoint has been enabled or has had an address assigned.  An

--- a/man/fi_collective.3.md
+++ b/man/fi_collective.3.md
@@ -146,13 +146,7 @@ int fi_query_collective(struct fid_domain *domain,
   ignored if the operation will not generate a successful completion, unless
   an op flag specifies the context parameter be used for required input.
 
-# DESCRIPTION (EXPERIMENTAL APIs)
-
-The collective APIs are new to the 1.9 libfabric release.  Although, efforts
-have been made to design the APIs such that they align well with applications
-and are implementable by the providers, the APIs should be considered
-experimental and may be subject to change in future versions of the
-library until the experimental tag has been removed.
+# DESCRIPTION
 
 In general collective operations can be thought of as coordinated atomic
 operations between a set of peer endpoints.  Readers should refer to the

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -50,8 +50,16 @@ struct fi_info *fi_dupinfo(const struct fi_info *info);
 
 # DESCRIPTION
 
+The fi_getinfo() call is used to discover what communication features are
+available in the system, as well as how they might best be used by an
+application.  The call is loosely modeled on getaddrinfo().  fi_getinfo()
+permits an application to exchange information between an application and
+the libfabric providers regarding its required set of communication.
+It provides the ability to access complex network details, balanced between
+being expressive but also simple to use.
+
 fi_getinfo returns information about available fabric services for reaching
-specified node or service, subject to any provided hints.  Callers
+a specified node or service, subject to any provided hints.  Callers
 may specify NULL for node, service, and hints in order to retrieve
 information about what providers are available and their optimal usage
 models.  If no matching fabric information is available, info will

--- a/man/fi_guide.7.md
+++ b/man/fi_guide.7.md
@@ -1,0 +1,36 @@
+---
+layout: page
+title: fi_guide(7)
+tagline: Libfabric Programmer's Guide
+---
+{% include JB/setup %}
+
+# NAME
+
+fi_guide \- libfabric programmer's guide
+
+# OVERVIEW
+
+libfabric is a communication library framework designed to meet the
+performance and scalability requirements of high-performance computing (HPC)
+applications.  libfabric defines communication interfaces that enable a
+tight semantic map between applications and underlying network services.
+Specifically, libfabric software interfaces have been co-designed with
+network hardware providers and application developers, with a focus on
+the needs of HPC users.
+
+This guide describes the libfabric architecture and interfaces.  Due to
+the length of the guide, it has been broken into multiple pages.  These
+sections are:
+
+*Introduction [`fi_intro`(7)](fi_intro.7.html)*
+: This section provides insight into the motivation for the libfabric
+  design and underlying networking features that are being exposed through
+  the API.
+
+*Architecture [`fi_arch`(7)](fi_arch.7.html)*
+: This describes the exposed architecture of libfabric, including the
+  object-model and their related operations
+
+*Setup [`fi_setup`(7)](fi_setup.7.html)*
+: This provides basic bootstrapping and setup for using the libfabric API.

--- a/man/fi_intro.7.md
+++ b/man/fi_intro.7.md
@@ -1,0 +1,1203 @@
+---
+layout: page
+title: fi_intro(7)
+tagline: Libfabric Programmer's Guide - Introduction
+---
+{% include JB/setup %}
+
+# NAME
+
+fi_intro \- libfabric introduction
+
+# OVERVIEW
+
+This introduction is part of the libfabric's programmer's guide.  See
+[`fi_guide`(7)](fi_guide.7.html).  This section provides insight
+into the motivation for the libfabric design and underlying networking
+features that are being exposed through the API.
+
+# Review of Sockets Communication
+
+The sockets API is a widely used networking API.  This guide assumes that a
+reader has a working knowledge of programming to sockets.  It makes reference
+to socket based communications throughout in an effort to help explain
+libfabric concepts and how they relate or differ from the socket API. To be
+clear, the intent of this guide is not to criticize the socket API, but
+reference sockets as a starting point in order to explain certain network
+features or limitations.  The following sections provide a high-level overview
+of socket semantics for reference.
+
+## Connected (TCP) Communication
+
+The most widely used type of socket is SOCK_STREAM.  This sort of socket
+usually runs over TCP/IP, and as a result is often referred to as a 'TCP'
+socket.  TCP sockets are connection-oriented, requiring an explicit
+connection setup before data transfers can occur.  A single TCP socket can only
+transfer data to a single peer socket.  Communicating with multiple peers
+requires the use of one socket per peer.
+
+Applications using TCP sockets are typically labeled as either a client or
+server.  Server applications listen for connection requests, and accept them
+when they occur.  Clients, on the other hand, initiate connections to the
+server.  In socket API terms, a server calls listen(), and the client calls
+connect().  After a connection has been established, data transfers between
+a client and server are similar.  The following code segments highlight the
+general flow for a sample client and server.  Error handling and some
+subtleties of the socket API are omitted for brevity.
+
+```
+/* Example server code flow to initiate listen */
+struct addrinfo *ai, hints;
+int listen_fd;
+
+memset(&hints, 0, sizeof hints);
+hints.ai_socktype = SOCK_STREAM;
+hints.ai_flags = AI_PASSIVE;
+getaddrinfo(NULL, "7471", &hints, &ai);
+
+listen_fd = socket(ai->ai_family, SOCK_STREAM, 0);
+bind(listen_fd, ai->ai_addr, ai->ai_addrlen);
+freeaddrinfo(ai);
+
+fcntl(listen_fd, F_SETFL, O_NONBLOCK);
+listen(listen_fd, 128);
+```
+
+In this example, the server will listen for connection requests on port 7471
+across all addresses in the system.  The call to getaddrinfo() is used to form
+the local socket address.  The node parameter is set to NULL, which result in
+a wild card IP address being returned.  The port is hard-coded to 7471.  The
+AI_PASSIVE flag signifies that the address will be used by the listening side
+of the connection.  That is, the address information should be relative to the
+local node.
+
+This example will work with both IPv4 and IPv6.  The getaddrinfo() call
+abstracts the address format away from the server, improving its portability.
+Using the data returned by getaddrinfo(), the server allocates a socket of
+type SOCK_STREAM, and binds the socket to port 7471.
+
+In practice, most enterprise-level applications make use of non-blocking
+sockets.  This is needed for a single application thread to manage multiple
+socket connections.  The fcntl() command sets the listening socket to
+non-blocking mode.  This will affect how the server processes connection
+requests (shown below).  Finally, the server starts listening for connection
+requests by calling listen.  Until listen is called, connection requests
+that arrive at the server will be rejected by the operating system.
+
+```
+/* Example client code flow to start connection */
+struct addrinfo *ai, hints;
+int client_fd;
+
+memset(&hints, 0, sizeof hints);
+hints.ai_socktype = SOCK_STREAM;
+getaddrinfo("10.31.20.04", "7471", &hints, &ai);
+
+client_fd = socket(ai->ai_family, SOCK_STREAM, 0);
+fcntl(client_fd, F_SETFL, O_NONBLOCK);
+
+connect(client_fd, ai->ai_addr, ai->ai_addrlen);
+freeaddrinfo(ai);
+```
+
+Similar to the server, the client makes use of getaddrinfo().  Since the
+AI_PASSIVE flag is not specified, the given address is treated as that of
+the destination.  The client expects to reach the server at IP address
+10.31.20.04, port 7471.  For this example the address is hard-coded into
+the client.  More typically, the address will be given to the client via
+the command line, through a configuration file, or from a service.
+Often the port number will be well-known, and the client will find the
+server by name, with DNS (domain name service) providing the name to address
+resolution.  Fortunately, the getaddrinfo call can be used to convert
+host names into IP addresses.
+
+Whether the client is given the server's network address directly or a name
+which must be translated into the network address, the mechanism used to
+provide this information to the client varies widely.  A simple mechanism
+that is commonly used is for users to provide the server's address using a
+command line option.  The problem of telling applications where its peers are
+located increases significantly for applications that communicate with hundreds
+to millions of peer processes, often requiring a separate, dedicated
+application to solve.  For a typical client-server socket application, this
+is not an issue, so we will defer more discussion until later.
+
+Using the getaddrinfo() results, the client opens a socket, configures it for
+non-blocking mode, and initiates the connection request.  At this point, the
+network stack has sent a request to the server to establish the connection.
+Because the socket has been set to non-blocking, the connect call will return
+immediately and not wait for the connection to be established.  As a result
+any attempt to send data at this point will likely fail.
+
+```
+/* Example server code flow to accept a connection */
+struct pollfd fds;
+int server_fd;
+
+fds.fd = listen_fd;
+fds.events = POLLIN;
+
+poll(&fds, -1);
+
+server_fd = accept(listen_fd, NULL, 0);
+fcntl(server_fd, F_SETFL, O_NONBLOCK);
+```
+
+Applications that use non-blocking sockets use select(), poll(), or an
+equivalent such as epoll() to receive notification of when a socket
+is ready to send or receive data.  In this case, the server wishes to
+know when the listening socket has a connection request to process.
+It adds the listening socket to a poll set, then waits until a connection
+request arrives (i.e. POLLIN is true).  The poll() call blocks until POLLIN
+is set on the socket.  POLLIN indicates that the socket has data to accept.
+Since this is a listening socket, the data is a connection request.  The
+server accepts the request by calling accept().  That returns a new socket
+to the server, which is ready for data transfers.  Finally, the server sets
+the new socket to non-blocking mode.
+
+```
+/* Example client code flow to establish a connection */
+struct pollfd fds;
+int err;
+socklen_t len;
+
+fds.fd = client_fd;
+fds.events = POLLOUT;
+
+poll(&fds, -1);
+
+len = sizeof err;
+getsockopt(client_fd, SOL_SOCKET, SO_ERROR, &err, &len);
+```
+
+The client is notified that its connection request has completed when its
+connecting socket is 'ready to send data' (i.e. POLLOUT is true).  The poll()
+call blocks until POLLOUT is set on the socket, indicating the connection
+attempt is done.  Note that the connection request may have completed with
+an error, and the client still needs to check if the connection attempt was
+successful.  That is not conveyed to the application by the poll() call.
+The getsockopt() call is used to retrieve the result of the connection attempt.
+If err in this example is set to 0, then the connection attempt succeeded.
+The socket is now ready to send and receive data.
+
+After a connection has been established, the process of sending or receiving
+data is the same for both the client and server.  The examples below differ
+only by name of the socket variable used by the client or server application.
+
+```
+/* Example of client sending data to server */
+struct pollfd fds;
+size_t offset, size, ret;
+char buf[4096];
+
+fds.fd = client_fd;
+fds.events = POLLOUT;
+
+size = sizeof(buf);
+for (offset = 0; offset < size; ) {
+    poll(&fds, -1);
+
+    ret = send(client_fd, buf + offset, size - offset, 0);
+    offset += ret;
+}
+```
+
+Network communication involves buffering of data at both the sending and
+receiving sides of the connection. TCP uses a credit based scheme to manage
+flow control to ensure that there is sufficient buffer space at the receive
+side of a connection to accept incoming data.  This flow control is hidden
+from the application by the socket API.  As a result, stream based sockets
+may not transfer all the data that the application requests to send as part
+of a single operation.
+
+In this example, the client maintains an offset into the buffer that it
+wishes to send.  As data is accepted by the network, the offset increases.
+The client then waits until the network is ready to accept more data before
+attempting another transfer.  The poll() operation supports this.  When the
+client socket is ready for data, it sets POLLOUT to true.  This indicates
+that send will transfer some additional amount of data.  The client issues
+a send() request for the remaining amount of buffer that it wishes to transfer.
+If send() transfers less data than requested, the client updates the offset,
+waits for the network to become ready, then tries again.
+
+```
+/* Example of server receiving data from client */
+struct pollfd fds;
+size_t offset, size, ret;
+char buf[4096];
+
+fds.fd = server_fd;
+fds.events = POLLIN;
+
+size = sizeof(buf);
+for (offset = 0; offset < size; ) {
+    poll(&fds, -1);
+
+    ret = recv(client_fd, buf + offset, size - offset, 0);
+    offset += ret;
+}
+```
+
+The flow for receiving data is similar to that used to send it.  Because of
+the streaming nature of the socket, there is no guarantee that the receiver
+will obtain all of the available data as part of a single call.  The server
+instead must wait until the socket is ready to receive data (POLLIN), before
+calling receive to obtain what data is available.  In this example, the
+server knows to expect exactly 4 KB of data from the client.  More generally,
+a client and server will exchange communication protocol headers at the start
+of all messages, and the header will include the size of the message.
+
+It is worth noting that the previous two examples are written so that they
+are simple to understand.  They are poorly constructed when considering
+performance.  In both cases, the application always precedes a data transfer
+call (send or recv) with poll().  The impact is even if the network is ready
+to transfer data or has data queued for receiving, the application will always
+experience the latency and processing overhead of poll().  A better approach
+is to call send() or recv() prior to entering the for() loops, and only enter
+the loops if needed.
+
+## Connection-less (UDP) Communication
+
+As mentioned, TCP sockets are connection-oriented.  They may be used to
+communicate between exactly 2 processes.  For parallel applications that need
+to communicate with thousands peer processes, the overhead of managing this
+many simultaneous sockets can be significant, to the point where the
+application performance may decrease as more processes are added.
+
+To support communicating with a large number of peers, or for applications
+that do not need the overhead of reliable communication, sockets offers
+another commonly used socket option, SOCK_DGRAM.  Datagrams are unreliable,
+connectionless messages.  The most common type of SOCK_DGRAM socket runs
+over UDP/IP.  As a result, datagram sockets are often referred to as UDP
+sockets.
+
+UDP sockets use the same socket API as that described above for TCP
+sockets; however, the communication behavior differs.  First, an application
+using UDP sockets does not need to connect to a peer prior to sending
+it a message.  The destination address is specified as part of the send
+operation.  A second major difference is that the message is not guaranteed
+to arrive at the peer.  Network congestion in switches, routers, or the
+remote NIC can discard the message, and no attempt will be made to resend
+the message.  The sender will not be notified that the message either arrived
+or was dropped.  Another difference between TCP and UDP sockets is the
+maximum size of the transfer that is allowed.  UDP sockets limit messages to
+at most 64k, though in practice, applications use a much smaller size, usually
+aligned to the network MTU size (for example, 1500 bytes).
+
+Most use of UDP sockets replace the socket send() / recv() calls with sendto()
+and recvfrom().
+
+```
+/* Example send to peer at given IP address and UDP port */
+struct addrinfo *ai, hints;
+
+memset(&hints, 0, sizeof hints);
+hints.ai_socktype = SOCK_DGRAM;
+getaddrinfo("10.31.20.04", "7471", &hints, &ai);
+
+ret = sendto(client_fd, buf, size, 0, ai->ai_addr, ai->ai_addrlen);
+```
+
+In the above example, we use getadddrinfo() to convert the given IP address
+and UDP port number into a sockaddr.  That is passed into the sendto() call
+in order to specify the destination of the message.  Note the similarities
+between this flow and the TCP socket flow.  The recvfrom() call allows us
+to receive the address of the sender of a message.  Note that unlike streaming
+sockets, the entire message is accepted by the network on success.  All
+contents of the buf parameter, specified by the size parameter, have been
+queued by the network layer.
+
+Although not shown, the application could call poll() or an equivalent
+prior to calling sendto() to ensure that the socket is ready to accept new
+data.  Similarly, poll() may be used prior to calling recvfrom() to check
+if there is data ready to be read from the socket.
+
+```
+/* Example receive a message from a peer */
+struct sockaddr_in addr;
+socklen_t addrlen;
+
+addrlen = sizeof(addr);
+ret = recvfrom(client_fd, buf, size, 0, &addr, &addrlen);
+```
+
+This example will receive any incoming message from any peer.  The address
+of the peer will be provided in the addr parameter.  In this case, we only
+provide enough space to record and IPv4 address (limited by our use of
+struct sockaddr_in).  Supporting an IPv6 address would simply require passing
+in a larger address buffer (mapped to struct sockaddr_in6 for example).
+
+## Advantages
+
+The socket API has two significant advantages.  First, it is available on a
+wide variety of operating systems and platforms, and works over the vast
+majority of available networking hardware.  It can even work for communication
+between processes on the same system without any network hardware.  It is
+easily the de-facto networking API.  This by itself makes it appealing to use.
+
+The second key advantage is that it is relatively easy to program to.  The
+importance of this should not be overlooked.  Networking APIs that offer
+access to higher performing features, but are difficult to program to correctly
+or well, often result in lower application performance.  This is not unlike
+coding an application in a higher-level language such as C or C++, versus
+assembly.  Although writing directly to assembly language offers the _promise_
+of being better performing, for the vast majority of developers, their
+applications will perform better if written in C or C++, and using an
+optimized compiler.  Applications should have a clear need for high-performance
+networking before selecting an alternative API to sockets.
+
+## Disadvantages
+
+When considering the problems with the socket API as it pertains to
+high-performance networking, we limit our discussion to the two most common
+sockets types: streaming (TCP) and datagram (UDP).
+
+Most applications require that network data be sent reliably.  This invariably
+means using a connection-oriented TCP socket.  TCP sockets transfer data as a
+stream of bytes.  However, many applications operate on messages.  The result is
+that applications often insert headers that are simply used to convert
+application message to / from a byte stream.  These headers consume additional
+network bandwidth and processing.  The streaming nature of the interface also
+results in the application using loops as shown in the examples above to send
+and receive larger messages.  The complexity of those loops can be significant
+if the application is managing sockets to hundreds or thousands of peers.
+
+Another issue highlighted by the above examples deals with the asynchronous
+nature of network traffic.  When using a reliable transport, it is not enough
+to place an application's data onto the network.  If the network is busy, it
+could drop the packet, or the data could become corrupted during a transfer.
+The data must be kept until it has been acknowledged by the peer, so that it
+can be resent if needed.  The socket API is defined such that the application
+owns the contents of its memory buffers after a socket call returns.
+
+As an example, if we examine the socket send() call, once send() returns the
+application is free to modify its buffer.  The network implementation has a
+couple of options.  One option is for the send call to place the data directly
+onto the network.  The call must then block before returning to the user until
+the peer acknowledges that it received the data, at which point send() can
+return.  The obvious problem with this approach is that the application is
+blocked in the send() call until the network stack at the peer can process
+the data and generate an acknowledgment.  This can be a significant amount
+of time where the application is blocked and unable to process other work,
+such as responding to messages from other clients.  Such an approach is not
+feasible.
+
+A better option is for the send() call to copy the application's data into an
+internal buffer.  The data transfer is then issued out of that buffer, which
+allows retrying the operation in case of a failure.  The send() call in this
+case is not blocked, but all data that passes through the network will result
+in a memory copy to a local buffer, even in the absence of any errors.
+
+Allowing immediate re-use of a data buffer is a feature of the socket API that
+keeps it simple and easy to program to.  However, such a feature can potentially
+have a negative impact on network performance.  For network or memory limited
+applications, or even applications concerned about power consumption, an
+alternative API may be attractive.
+
+A slightly more hidden problem occurs in the socket APIs designed for UDP
+sockets.  This problem is an inefficiency in the implementation as a result
+of the API design being designed for ease of use.  In order for the
+application to send data to a peer, it needs to provide the IP address
+and UDP port number of the peer.  That involves passing a sockaddr structure
+to the sendto() and recvfrom() calls.  However, IP addresses are a higher-
+level network layer address.  In order to transfer data between systems,
+low-level link layer addresses are needed, for example Ethernet addresses.
+The network layer must map IP addresses to Ethernet addresses on every send
+operation.  When scaled to thousands of peers, that overhead on every send
+call can be significant.
+
+Finally, because the socket API is often considered in conjunction with TCP
+and UDP protocols, it is intentionally detached from the underlying
+network hardware implementation, including NICs, switches, and routers.
+Access to available network features is therefore constrained by what the
+API can support.
+
+It is worth noting here, that some operating systems support enhanced
+APIs that may be used to interact with TCP and UDP sockets.  For example,
+Linux supports an interface known as io_uring, and Windows has an
+asynchronous socket API.  Those APIs can help alleviate some of the
+problems described above.  However, an application will still be restricted
+by the features that the TCP an UDP protocols provide.
+
+# High-Performance Networking
+
+By analyzing the socket API in the context of high-performance networking,
+we can start to see some features that are desirable for a network API.
+
+## Avoiding Memory Copies
+
+The socket API implementation usually results in data copies occurring at
+both the sender and the receiver.  This is a trade-off between keeping the
+interface easy to use, versus providing reliability.  Ideally, all memory
+copies would be avoided when transferring data over the network.  There are
+techniques and APIs that can be used to avoid memory copies, but in practice,
+the cost of avoiding a copy can often be more than the copy itself, in
+particular for small transfers (measured in bytes, versus kilobytes or more).
+
+To avoid a memory copy at the sender, we need to place the application data
+directly onto the network.  If we also want to avoid blocking the sending
+application, we need some way for the network layer to communicate with the
+application when the buffer is safe to re-use.  This would allow the original
+buffer to be re-used in case the data needs to be re-transmitted.  This leads
+us to crafting a network interface that behaves asynchronously.  The
+application will need to issue a request, then receive some sort of
+notification when the request has completed.
+
+Avoiding a memory copy at the receiver is more challenging.  When data arrives
+from the network, it needs to land into an available memory buffer, or it will
+be dropped, resulting in the sender re-transmitting the data.  If we use socket
+recv() semantics, the only way to avoid a copy at the receiver is for the recv()
+to be called before the send().  Recv() would then need to block until the data
+has arrived.  Not only does this block the receiver, it is impractical to use
+outside of an application with a simple request-reply protocol.
+
+Instead, what is needed is a way for the receiving application to provide one
+or more buffers to the network for received data to land.  The network then
+needs to notify the application when data is available.  This sort of mechanism
+works well if the receiver does not care where in its memory space the data is
+located; it only needs to be able to process the incoming message.
+
+As an alternative, it is possible to reverse this flow, and have the network
+layer hand its buffer to the application.  The application would then be
+responsible for returning the buffer to the network layer when it is done
+with its processing.  While this approach can avoid memory copies, it suffers
+from a few drawbacks.  First, the network layer does not know what size of
+messages to expect, which can lead to inefficient memory use.  Second, many
+would consider this a more difficult programming model to use.  And finally,
+the network buffers would need to be mapped into the application process'
+memory space, which negatively impacts performance.
+
+In addition to processing messages, some applications want to receive data and
+store it in a specific location in memory.  For example, a database may want
+to merge received data records into an existing table.  In such cases, even
+if data arriving from the network goes directly into an application's receive
+buffers, it may still need to be copied into its final location.  It would be
+ideal if the network supported placing data that arrives from the network into
+a specific memory buffer, with the buffer determined based on the contents
+of the data.
+
+### Network Buffers
+
+Based on the problems described above, we can start to see that avoiding
+memory copies depends upon the ownership of the memory buffers used for
+network traffic.  With socket based transports, the network buffers are
+owned and managed by the networking stack.  This is usually handled by
+the operating system kernel.  However, this results in the data 'bouncing'
+between the application buffers and the network buffers.  By putting the
+application in control of managing the network buffers, we can avoid
+this overhead.  The cost for doing so is additional complexity in
+the application.
+
+Note that even though we want the application to own the network buffers,
+we would still like to avoid the situation where the application
+implements a complex network protocol.  The trade-off is that the
+app provides the data buffers to the network stack, but the network
+stack continues to handle things like flow control, reliability,
+and segmentation and reassembly.
+
+### Resource Management
+
+We define resource management to mean properly allocating network resources
+in order to avoid overrunning data buffers or queues.  Flow control is a
+common aspect of resource management.  Without proper flow control, a
+sender can overrun a slow or busy receiver.  This can result in dropped
+packets, re-transmissions, and increased network congestion.  Significant
+research and development has gone into implementing flow control algorithms.
+Because of its complexity, it is not something that an application developer
+should need to deal with.  That said, there are some applications where
+flow control simply falls out of the network protocol.  For example, a
+request-reply protocol naturally has flow control built in.
+
+For our purposes, we expand the definition of resource management beyond
+flow control.  Flow control typically only deals with available network
+buffering at a peer.  We also want to be concerned about having available
+space in outbound data transfer queues.  That is, as we issue commands to
+the local NIC to send data, that those commands can be queued at the NIC.
+When we consider reliability, this means tracking outstanding requests
+until they have been acknowledged.  Resource management will need to
+ensure that we do not overflow that request queue.
+
+Additionally, supporting asynchronous operations (described in detail
+below) will introduce potential new queues.  Those queues also must not overflow.
+
+## Asynchronous Operations
+
+Arguably, the key feature of achieving high-performance is supporting
+asynchronous operations, or the ability to overlap different communication and
+communication with computation.  The socket API supports asynchronous
+transfers with its non-blocking mode.  However, because the API itself
+operates synchronously, the result is additional data copies.  For an
+API to be asynchronous, an application needs to be able to submit work,
+then later receive some sort of notification that the work is done.
+In order to avoid extra memory copies, the application must agree not
+to modify its data buffers until the operation completes.
+
+There are two main ways to notify an application that it is safe to
+re-use its data buffers.  One mechanism is for the network layer to
+invoke some sort of callback or send a signal to the application that
+the request is done.  Some asynchronous APIs use this mechanism.  The
+drawback of this approach is that signals interrupt an application's
+processing.  This can negatively impact the CPU caches, plus requires
+interrupt processing.  Additionally, it is often difficult to develop
+an application that can handle processing a signal that can occur at anytime.
+
+An alternative mechanism for supporting asynchronous operations is to
+write events into some sort of completion queue when an operation completes.
+This provides a way to indicate to an application when a data transfer has
+completed, plus gives the application control over when and how to process
+completed requests.  For example, it can process requests in batches to
+improve code locality and performance.
+
+### Interrupts and Signals
+
+Interrupts are a natural extension to supporting asynchronous operations.
+However, when dealing with an asynchronous API, they can negatively impact
+performance.  Interrupts, even when directed to a kernel agent, can
+interfere with application processing.
+
+If an application has an asynchronous interface with completed operations
+written into a completion queue, it is often sufficient for the application
+to simply check the queue for events.  As long as the application has other
+work to perform, there is no need for it to block.  This alleviates the
+need for interrupt generation.  A NIC merely needs to write an entry into
+the completion queue and update a tail pointer to signal that a request is
+done.
+
+If we follow this argument, then it can be beneficial to give the application
+control over when interrupts should occur and when to write events to some
+sort of wait object.  By having the application notify the network layer
+that it will wait until a completion occurs, we can better manage the
+number and type of interrupts that are generated.
+
+### Event Queues
+
+As outlined above, there are performance advantages to having an API that
+reports completions or provides other types of notification using an event
+queue.  A very simple type of event queue merely tracks completed operations.
+As data is received or a send completes, an entry is written into the event queue.
+
+## Direct Hardware Access
+
+When discussing the network layer, most software implementations refer to
+kernel modules responsible for implementing the necessary transport and
+network protocols.  However, if we want network latency to approach
+sub-microsecond speeds, then we need to remove as much software between
+the application and its access to the hardware as possible.  One way to
+do this is for the application to have direct access to the network interface
+controller's command queues.  Similarly, the NIC requires direct access to
+the application's data buffers and control structures, such as the above
+mentioned completion queues.
+
+Note that when we speak about an application having direct access to network
+hardware, we're referring to the application process.  Naturally, an application
+developer is highly unlikely to code for a specific hardware NIC.  That work
+would be left to some sort of network library specifically targeting the NIC.
+The actual network layer, which implements the network transport, could be
+part of the network library or offloaded onto the NIC's hardware or firmware.
+
+### Kernel Bypass
+
+Kernel bypass is a feature that allows the application to avoid calling into
+the kernel for data transfer operations.  This is possible when it has direct
+access to the NIC hardware.  Complete kernel bypass is impractical because of
+security concerns and resource management constraints.  However, it is possible
+to avoid kernel calls for what are called 'fast-path' operations, such as
+send or receive.
+
+For security and stability reasons, operating system kernels cannot rely on
+data that comes from user space applications.  As a result, even a simple
+kernel call often requires acquiring and releasing locks, coupled with
+data verification checks.  If we can limit the effects of a poorly written
+or malicious application to its own process space, we can avoid the overhead
+that comes with kernel validation without impacting system stability.
+
+### Direct Data Placement
+
+Direct data placement means avoiding data copies when sending and receiving
+data, plus placing received data into the correct memory buffer where needed.
+On a broader scale, it is part of having direct hardware access, with the
+application and NIC communicating directly with shared memory buffers and
+queues.
+
+Direct data placement is often thought of by those familiar with RDMA -
+remote direct memory access.  RDMA is a technique that allows reading and
+writing memory that belongs to a peer process that is running on a node
+across the network.  Advanced RDMA hardware is capable of accessing the
+target memory buffers without involving the execution of the peer process.
+RDMA relies on offloading the network transport onto the NIC in order
+to avoid interrupting the target process.
+
+The main advantages of supporting direct data placement is avoiding
+memory copies and minimizing processing overhead.
+
+# Designing Interfaces for Performance
+
+We want to design a network interface that can meet the requirements outlined
+above.  Moreover, we also want to take into account the performance of the
+interface itself.  It is often not obvious how an interface can adversely
+affect performance, versus performance being a result of the underlying
+implementation.  The following sections describe how interface choices
+can impact performance.  Of course, when we begin defining the actual
+APIs that an application will use, we will need to trade off raw performance
+for ease of use where it makes sense.
+
+When considering performance goals for an API, we need to take into account
+the target application use cases.  For the purposes of this discussion, we
+want to consider applications that communicate with thousands to millions of
+peer processes.  Data transfers will include millions of small messages per
+second per peer, and large transfers that may be up to gigabytes of data.
+At such extreme scales, even small optimizations are measurable, in terms
+of both performance and power.  If we have a million peers sending a millions
+messages per second, eliminating even a single instruction from the code path
+quickly multiplies to saving billions of instructions per second from the
+overall execution, when viewing the operation of the entire application.
+
+We once again refer to the socket API as part of this discussion in order
+to illustrate how an API can affect performance.
+
+```
+/* Notable socket function prototypes */
+/* "control" functions */
+int socket(int domain, int type, int protocol);
+int bind(int socket, const struct sockaddr *addr, socklen_t addrlen);
+int listen(int socket, int backlog);
+int accept(int socket, struct sockaddr *addr, socklen_t *addrlen);
+int connect(int socket, const struct sockaddr *addr, socklen_t addrlen);
+int shutdown(int socket, int how);
+int close(int socket);
+
+/* "fast path" data operations - send only (receive calls not shown) */
+ssize_t send(int socket, const void *buf, size_t len, int flags);
+ssize_t sendto(int socket, const void *buf, size_t len, int flags,
+    const struct sockaddr *dest_addr, socklen_t addrlen);
+ssize_t sendmsg(int socket, const struct msghdr *msg, int flags);
+ssize_t write(int socket, const void *buf, size_t count);
+ssize_t writev(int socket, const struct iovec *iov, int iovcnt);
+
+/* "indirect" data operations */
+int poll(struct pollfd *fds, nfds_t nfds, int timeout);
+int select(int nfds, fd_set *readfds, fd_set *writefds,
+    fd_set *exceptfds, struct timeval *timeout);
+```
+
+Examining this list, there are a couple of features to note.  First, there
+are multiple calls that can be used to send data, as well as multiple calls
+that can be used to wait for a non-blocking socket to become ready.  This
+will be discussed in more detail further on.  Second, the operations have
+been split into different groups (terminology is ours).  Control operations
+are those functions that an application seldom invokes during execution.
+They often only occur as part of initialization.
+
+Data operations, on the other hand, may be called hundreds to millions of
+times during an application's lifetime.  They deal directly or indirectly
+with transferring or receiving data over the network.  Data operations
+can be split into two groups.  Fast path calls interact with the network
+stack to immediately send or receive data.  In order to achieve high
+bandwidth and low latency, those operations need to be as fast as possible.
+Non-fast path operations that still deal with data transfers are those calls,
+that while still frequently called by the application, are not as
+performance critical.  For example, the select() and poll() calls are
+used to block an application thread until a socket becomes ready.
+Because those calls suspend the thread execution, performance is a
+lesser concern.  (Performance of those operations is still of a concern,
+but the cost of executing the operating system scheduler often swamps
+any but the most substantial performance gains.)
+
+## Call Setup Costs
+
+The amount of work that an application needs to perform before issuing
+a data transfer operation can affect performance, especially message rates.
+Obviously, the more parameters an application must push on the stack
+to call a function increases its instruction count.  However, replacing
+stack variables with a single data structure does not help to
+reduce the setup costs.
+
+Suppose that an application wishes to send a single data buffer of a
+given size to a peer.  If we examine the socket API, the best fit for
+such an operation is the write() call.  That call takes only those
+values which are necessary to perform the data transfer.  The send()
+call is a close second, and send() is a more natural function name for
+network communication, but send() requires one extra argument over write().
+Other functions are even worse in terms of setup costs.  The sendmsg()
+function, for example, requires that the application format a data structure,
+the address of which is passed into the call.  This requires significantly
+more instructions from the application if done for every data transfer.
+
+Even though all other send functions can be replaced by sendmsg(), it
+is useful to have multiple ways for the application to issue send requests.
+Not only are the other calls easier to read and use (which lower software
+maintenance costs), but they can also improve performance.
+
+## Branches and Loops
+
+When designing an API, developers rarely consider how the API impacts
+the underlying implementation.  However, the selection of API parameters
+can require that the underlying implementation add branches or use control
+loops.  Consider the difference between the write() and writev() calls.
+The latter passes in an array of I/O vectors, which may be processed
+using a loop such as this:
+
+```
+/* Sample implementation for processing an array */
+for (i = 0; i < iovcnt; i++) {
+    ...
+}
+```
+
+In order to process the iovec array, the natural software construct
+would be to use a loop to iterate over the entries.  Loops result in
+additional processing.  Typically, a loop requires initializing a
+loop control variable (e.g. i = 0), adds ALU operations (e.g. i++),
+and a comparison (e.g. i < iovcnt).  This overhead is necessary to
+handle an arbitrary number of iovec entries.  If the common case is
+that the application wants to send a single data buffer, write()
+is a better option.
+
+In addition to control loops, an API can result in the implementation
+needing branches.  Branches can change the execution flow of a program,
+impacting processor pipe-lining techniques.  Processor branch
+prediction helps alleviate this issue.  However, while branch
+prediction can be correct nearly 100% of the time while running a
+micro-benchmark, such as a network bandwidth or latency test, with
+more realistic network traffic, the impact can become measurable.
+
+We can easily see how an API can introduce branches into the code flow
+if we examine the send() call.  Send() takes an extra flags parameter
+over the write() call.  This allows the application to modify the behavior
+of send().  From the viewpoint of implementing send(), the flags parameter
+must be checked.  In the best case, this adds one additional check
+(flags are non-zero).  In the worst case, every valid flag may need
+a separate check, resulting in potentially dozens of checks.
+
+Overall, the sockets API is well designed considering these performance
+implications.  It provides complex calls where they are needed, with
+simpler functions available that can avoid some of the overhead inherent
+in other calls.
+
+## Command Formatting
+
+The ultimate objective of invoking a network function is to transfer
+or receive data from the network.  In this section, we're dropping to
+the very bottom of the software stack to the component responsible for
+directly accessing the hardware.  This is usually referred to as the
+network driver, and its implementation is often tied to a specific
+piece of hardware, or a series of NICs by a single hardware vendor.
+
+In order to signal a NIC that it should read a memory buffer and copy
+that data onto the network, the software driver usually needs to write
+some sort of command to the NIC.  To limit hardware complexity and
+cost, a NIC may only support a couple of command formats.  This differs
+from the software interfaces that we've been discussing, where we
+can have different APIs of varying complexity in order to reduce overhead.
+There can be significant costs associated with formatting the command
+and posting it to the hardware.
+
+With a standard NIC, the command is formatted by a kernel driver.
+That driver sits at the bottom of the network stack servicing
+requests from multiple applications.  It must typically format
+each command only after a request has passed through the network
+stack.
+
+With devices that are directly accessible by a single application,
+there are opportunities to use pre-formatted command structures.
+The more of the command that can be initialized prior to the application
+submitting a network request, the more streamlined the process, and the
+better the performance.
+
+As an example, a NIC needs to have the destination address as part of
+a send operation.  If an application is sending to a single peer, that
+information can be cached and be part of a pre-formatted network header.
+This is only possible if the NIC driver knows that the destination will not
+change between sends.  The closer that the driver can be to the application,
+the greater the chance for optimization.  An optimal approach is for the
+driver to be part of a library that executes entirely within the application
+ process space.
+
+## Memory Footprint
+
+Memory footprint concerns are most notable among high-performance
+computing (HPC) applications that communicate with thousands of peers.
+Excessive memory consumption impacts application scalability, limiting
+the number of peers that can operate in parallel to solve problems.
+There is often a trade-off between minimizing the memory footprint
+needed for network communication, application performance, and ease
+of use of the network interface.
+
+As we discussed with the socket API semantics, part of the ease of using
+sockets comes from the network layering copying the user's buffer into an
+internal buffer belonging to the network stack.  The amount of internal
+buffering that's made available to the application directly correlates
+with the bandwidth that an application can achieve.  In general, larger
+internal buffering increases network performance, with a cost of increasing
+the memory footprint consumed by the application.  This memory footprint
+exists independent of the amount of memory allocated directly by the
+application.  Eliminating network buffering not only helps with performance,
+but also scalability, by reducing the memory footprint needed to support
+the application.
+
+While network memory buffering increases as an application scales, it can
+often be configured to a fixed size.  The amount of buffering needed is
+dependent on the number of active communication streams being used at
+any one time.  That number is often significantly lower than the total
+number of peers that an application may need to communicate with.  The
+amount of memory required to _address_ the peers, however, usually has
+a linear relationship with the total number of peers.
+
+With the socket API, each peer is identified using a struct sockaddr.
+If we consider a UDP based socket application using IPv4 addresses, a
+peer is identified by the following address.
+
+```
+/* IPv4 socket address - with typedefs removed */
+struct sockaddr_in {
+    uint16_t sin_family; /* AF_INET */
+    uint16_t sin_port;
+    struct {
+        uint32_t sin_addr;
+    } in_addr;
+};
+```
+
+In total, the application requires 8-bytes of addressing for each peer.
+If the app communicates with a million peers, that explodes to roughly
+8 MB of memory space that is consumed just to maintain the address list.
+If IPv6 addressing is needed, then the requirement increases by a factor of 4.
+
+Luckily, there are some tricks that can be used to help reduce the
+addressing memory footprint, though doing so will introduce more instructions
+into code path to access the network stack.  For instance, we can notice that
+all addresses in the above example have the same sin_family value (AF_INET).
+There's no need to store that for each address.  This potentially shrinks each
+address from 8 bytes to 6.  (We may be left with unaligned data, but that's a
+trade-off to reducing the memory consumption).  Depending on how the addresses
+are assigned, further reduction may be possible.  For example, if the
+application uses the same set of port addresses at each node, then we
+can eliminate storing the port, and instead calculate it from some base
+value.  This type of trick can be applied to the IP portion of the address
+if the app is lucky enough to run across sequential IP addresses.
+
+The main issue with this sort of address reduction is that it is difficult
+to achieve.  It requires that each application check for and handle address
+compression, exposing the application to the addressing format used by the
+networking stack.  It should be kept in mind that TCP/IP and UDP/IP addresses
+are logical addresses, not physical.  When running over Ethernet, the
+addresses that appear at the link layer are MAC addresses, not IP addresses.
+The IP to MAC address association is managed by the network software.  We
+would like to provide addressing that is simple for an application to use,
+but at the same time can provide a minimal memory footprint.
+
+## Communication Resources
+
+We need to take a brief detour in the discussion in order to delve deeper
+into the network problem and solution space.  Instead of continuing to
+think of a socket as a single entity, with both send and receive capabilities,
+we want to consider its components separately. A network socket can be viewed
+as three basic constructs: a transport level address, a send or transmit
+queue, and a receive queue.  Because our discussion will begin to pivot
+away from pure socket semantics, we will refer to our network 'socket'
+as an endpoint.
+
+In order to reduce an application's memory footprint, we need to consider
+features that fall outside of the socket API.  So far, much of the discussion
+has been around sending data to a peer.  We now want to focus on the best
+mechanisms for receiving data.
+
+With sockets, when an app has data to receive (indicated, for example, by a
+POLLIN event), we call recv().  The network stack copies the receive data
+into its buffer and returns.  If we want to avoid the data copy on the receive
+side, we need a way for the application to post its buffers to the network
+stack _before_ data arrives.
+
+Arguably, a natural way of extending the socket API to support this feature
+is to have each call to recv() simply post the buffer to the network layer.
+As data is received, the receive buffers are removed in the order that they
+were posted.  Data is copied into the posted buffer and returned to the user.
+It would be noted that the size of the posted receive buffer may be larger
+(or smaller) than the amount of data received.  If the available buffer space
+is larger, hypothetically, the network layer could wait a short amount of
+time to see if more data arrives.  If nothing more arrives, the receive
+completes with the buffer returned to the application.
+
+This raises an issue regarding how to handle buffering on the receive side.
+So far, with sockets we've mostly considered a streaming protocol.  However,
+many applications deal with messages which end up being layered over the
+data stream.  If they send an 8 KB message, they want the receiver to receive
+an 8 KB message.  Message boundaries need to be maintained.
+
+If an application sends and receives a fixed sized message, buffer allocation
+becomes trivial.  The app can post X number of buffers each of an optimal size.
+However, if there is a wide mix in message sizes, difficulties arise.  It is not
+uncommon for an app to have 80% of its messages be a couple hundred of bytes or
+less, but 80% of the total data that it sends to be in large transfers that are,
+say, a megabyte or more.  Pre-posting receive buffers in such a situation
+is challenging.
+
+A commonly used technique used to handle this situation is to implement one
+application level protocol for smaller messages, and use a separate protocol
+for transfers that are larger than some given threshold.  This would allow an
+application to post a bunch of smaller messages, say 4 KB, to receive data.
+For transfers that are larger than 4 KB, a different communication protocol
+is used, possibly over a different socket or endpoint.
+
+### Shared Receive Queues
+
+If an application pre-posts receive buffers to a network queue, it needs to
+balance the size of each buffer posted, the number of buffers that are posted
+to each queue, and the number of queues that are in use.  With a socket like
+approach, each socket would maintain an independent receive queue where data
+is placed.  If an application is using 1000 endpoints and posts 100 buffers,
+each 4 KB, that results in 400 MB of memory space being consumed to receive
+data.  (We can start to realize that by eliminating memory copies, one of
+the trade offs is increased memory consumption.)  While 400 MB seems like a
+lot of memory, there is less than half a megabyte allocated to a single
+receive queue.  At today's networking speeds, that amount of space can be
+consumed within milliseconds.  The result is that if only a few endpoints
+are in use, the application will experience long delays where flow control
+will kick in and back the transfers off.
+
+There are a couple of observations that we can make here.  The first is that
+in order to achieve high scalability, we need to move away from a
+connection-oriented protocol, such as streaming sockets.  Secondly, we need
+to reduce the number of receive queues that an application uses.
+
+A shared receive queue is a network queue that can receive data for many
+different endpoints at once.  With shared receive queues, we no longer
+associate a receive queue with a specific transport address.  Instead
+network data will target a specific endpoint address.  As data arrives,
+the endpoint will remove an entry from the shared receive queue, place
+the data into the application's posted buffer, and return it to the user.
+Shared receive queues can greatly reduce the amount of buffer space needed
+by an applications.  In the previous example, if a shared receive queue
+were used, the app could post 10 times the number of buffers (1000 total),
+yet still consume 100 times less memory (4 MB total).  This is far more
+scalable.  The drawback is that the application must now be aware of
+receive queues and shared receive queues, rather than considering the
+network only at the level of a socket.
+
+### Multi-Receive Buffers
+
+Shared receive queues greatly improve application scalability; however,
+it still results in some inefficiencies as defined so far.  We've only
+considered the case of posting a series of fixed sized memory buffers
+to the receive queue.  As mentioned, determining the size of each
+buffer is challenging.  Transfers larger than the fixed size require
+using some other protocol in order to complete.  If transfers are
+typically much smaller than the fixed size, then the extra buffer
+space goes unused.
+
+Again referring to our example, if the application posts 1000 buffers,
+then it can only receive 1000 messages before the queue is emptied.
+At data rates measured in millions of messages per second, this will
+introduce stalls in the data stream.  An obvious solution is to increase
+the number of buffers posted.  The problem is dealing with variable sized
+messages, including some which are only a couple hundred bytes in length.
+For example, if the average message size in our case is 256 bytes or less,
+then even though we've allocated 4 MB of buffer space, we only make use of
+6% of that space.  The rest is wasted in order to handle messages which
+may only occasionally be up to 4 KB.
+
+A second optimization that we can make is to fill up each posted receive
+buffer as messages arrive.  So, instead of a 4 KB buffer being removed
+from use as soon as a single 256 byte message arrives, it can instead
+receive up to 16, 256 byte, messages.  We refer to such a feature as
+'multi-receive' buffers.
+
+With multi-receive buffers, instead of posting a bunch of smaller buffers,
+we instead post a single larger buffer, say the entire 4 MB, at once.
+As data is received, it is placed into the posted buffer.  Unlike TCP
+streams, we still maintain message boundaries.  The advantages here are
+twofold.  Not only is memory used more efficiently, allowing us to receive
+more smaller messages at once and larger messages overall, but we reduce
+the number of function calls that the application must make to maintain
+its supply of available receive buffers.
+
+When combined with shared receive queues, multi-receive buffers
+help support optimal receive side buffering and processing.  The
+main drawback to supporting multi-receive buffers are that the
+application will not necessarily know up front how many messages
+may be associated with a single posted memory buffer.  This is
+rarely a problem for applications.
+
+## Optimal Hardware Allocation
+
+As part of scalability considerations, we not only need to consider the
+processing and memory resources of the host system, but also the allocation
+and use of the NIC hardware.  We've referred to network endpoints as
+combination of transport addressing, transmit queues, and receive queues.
+The latter two queues are often implemented as hardware command queues.
+Command queues are used to signal the NIC to perform some sort of work.
+A transmit queue indicates that the NIC should transfer data.  A transmit
+command often contains information such as the address of the buffer to
+transmit, the length of the buffer, and destination addressing data.
+The actual format and data contents vary based on the hardware implementation.
+
+NICs have limited resources.  Only the most scalable, high-performance
+applications likely need to be concerned with utilizing NIC hardware optimally.
+ However, such applications are an important and specific focus of libfabric.
+ Managing NIC resources is often handled by a resource manager application,
+ which is responsible for allocating systems to competing applications,
+ among other activities.
+
+Supporting applications that wish to make optimal use of hardware requires
+that hardware related abstractions be exposed to the application.  Such
+abstractions cannot require a specific hardware implementation, and care
+must be taken to ensure that the resulting API is still usable by developers
+unfamiliar with dealing with such low level details.  Exposing concepts such
+as shared receive queues is an example of giving an application more control
+over how hardware resources are used.
+
+### Sharing Command Queues
+
+By exposing the transmit and receive queues to the application, we open the
+possibility for the application that makes use of multiple endpoints to
+determine how those queues might be shared.  We talked about the benefits
+of sharing a receive queue among endpoints.  The benefits of sharing transmit
+queues are not as obvious.
+
+An application that uses more addressable endpoints than there are transmit
+queues will need to share transmit queues among the endpoints.  By controlling
+which endpoint uses which transmit queue, the application can prioritize traffic.
+A transmit queue can also be configured to optimize for a specific type of
+data transfer, such as large transfers only.
+
+From the perspective of a software API, sharing transmit or receive queues
+implies exposing those constructs to the application, and allowing them to be
+associated with different endpoint addresses.
+
+### Multiple Queues
+
+The opposite of a shared command queue are endpoints that have multiple queues.
+An application that can take advantage of multiple transmit or receive queues
+can increase parallel handling of messages without synchronization constraints.
+Being able to use multiple command queues through a single endpoint has
+advantages  over using multiple endpoints.  Multiple endpoints require
+separate addresses, which increases memory use.  A single endpoint with
+multiple queues can continue to expose a single address, while taking
+full advantage of available NIC resources.
+
+## Progress Model Considerations
+
+One aspect of the sockets programming interface that developers often
+don't consider is the location of the protocol implementation.  This is
+usually managed by the operating system kernel.  The network stack is
+responsible for handling flow control messages, timing out transfers,
+re-transmitting unacknowledged transfers, processing received data,
+and sending acknowledgments.  This processing requires that the network
+stack consume CPU cycles.  Portions of that processing can be done within
+the context of the application thread, but much must be handled by kernel
+threads dedicated to network processing.
+
+By moving the network processing directly into the application process,
+we need to be concerned with how network communication makes forward progress.
+For example, how and when are acknowledgments sent?  How are timeouts and
+message re-transmissions handled?  The progress model defines this behavior,
+and it depends on how much of the network processing has been offloaded
+onto the NIC.
+
+More generally, progress is the ability of the underlying network
+implementation to complete processing of an asynchronous request.  In
+many cases, the processing of an asynchronous request requires the use
+of the host processor.  For performance reasons, it may be undesirable
+for the provider to allocate a thread for this purpose, which will compete
+with the application thread(s).  We can avoid thread context switches if
+the application thread can be used to make forward progress on requests --
+check for acknowledgments, retry timed out operations, etc.  Doing so
+requires that the application periodically call into the network stack.
+
+## Ordering
+
+Network ordering is a complex subject.  With TCP sockets, data is sent and
+received in the same order.  Buffers are re-usable by the application
+immediately upon returning from a function call.  As a result, ordering is
+simple to understand and use.  UDP sockets complicate things slightly.  With
+UDP sockets, messages may be received out of order from how they were sent.
+In practice, this often doesn't occur, particularly, if the application only
+communicates over a local area network, such as Ethernet.
+
+With our evolving network API, there are situations where exposing different
+order semantics can improve performance.  These details will be discussed
+further below.
+
+### Messages
+
+UDP sockets allow messages to arrive out of order because each message is
+routed from the sender to the receiver independently.  This allows packets
+to take different network paths, to avoid congestion or take advantage of
+multiple network links for improved bandwidth.  We would like to take advantage
+of the same features in those cases where the application doesn't care in
+which order messages arrive.
+
+Unlike UDP sockets, however, our definition of message ordering is more subtle.
+UDP messages are small, MTU sized packets.  In our case, messages may be
+gigabytes in size.  We define message ordering to indicate whether the start
+of each message is processed in order or out of order.  This is related to,
+but separate from the order of how the message payload is received.
+
+An example will help clarify this distinction.  Suppose that an application
+has posted two messages to its receive queue.  The first receive points to a
+4 KB buffer.  The second receive points to a 64 KB buffer.  The sender will
+transmit a 4 KB message followed by a 64 KB message.  If messages are processed
+in order, then the 4 KB send will match with the 4 KB received, and the 64 KB
+send will match with the 64 KB receive.  However, if messages can be processed
+out of order, then the sends and receives can mismatch, resulting in the 64 KB
+send being truncated.
+
+In this example, we're not concerned with what order the data is received in.
+The 64 KB send could be broken in 64 1-KB transfers that take different
+routes to the destination.  So, bytes 2k-3k could be received before bytes
+1k-2k.  Message ordering is not concerned with ordering _within_ a message,
+only _between_ messages.  With ordered messages, the messages themselves
+need to be processed in order.
+
+The more relaxed message ordering can be the more optimizations that the
+network stack can use to transfer the data.  However, the application must
+be aware of message ordering semantics, and be able to select the desired
+semantic for its needs.  For the purposes of this section, messages refers
+to transport level operations, which includes RDMA and similar operations
+(some of which have not yet been discussed).
+
+### Data
+
+Data ordering refers to the receiving and placement of data both
+_within and between_ messages.  Data ordering is most important
+to messages that can update the same target memory buffer.  For
+example, imagine an application that writes a series of database
+records directly into a peer memory location.  Data ordering,
+combined with message ordering, ensures that the data from the
+second write updates memory after the first write completes.
+The result is that the memory location will contain the records
+carried in the second write.
+
+Enforcing data ordering between messages requires that the messages
+themselves be ordered.  Data ordering can also apply within a single
+message, though this level of ordering is usually less important to
+applications.  Intra-message data ordering indicates that the data for a
+single message is received in order.  Some applications use this feature
+to 'spin' reading the last byte of a receive buffer.  Once the byte changes,
+the application knows that the operation has completed and all earlier
+data has been received.  (Note that while such behavior is interesting
+for benchmark purposes, using such a feature in this way is strongly
+discouraged.  It is not portable between networks or platforms.)
+
+### Completions
+
+Completion ordering refers to the sequence that asynchronous operations
+report their completion to the application.  Typically, unreliable data
+transfer will naturally complete in the order that they are submitted
+to a transmit queue.  Each operation is transmitted to the network,
+with the completion occurring immediately after.  For reliable data
+transfers, an operation cannot complete until it has been acknowledged
+by the peer.  Since ack packets can be lost or possibly take different
+paths through the network, operations can be marked as completed out of
+order.  Out of order acks is more likely if messages can be processed
+out of order.
+
+Asynchronous interfaces require that the application track their
+outstanding requests.  Handling out of order completions can increase
+application complexity, but it does allow for optimizing network
+utilization.
+
+# lifabric Architecture
+
+Libfabric is well architected to support the previously discussed features.
+For further information on the libfabric architecture, see
+the next programmer's guide section: [`fi_arch`(7)](fi_arch.7.html).

--- a/man/fi_provider.7.md
+++ b/man/fi_provider.7.md
@@ -11,64 +11,61 @@ fi_provider \- Fabric Interface Providers
 
 # OVERVIEW
 
-Conceptually, a fabric provider may be viewed as a local hardware NIC
-driver, though a provider is not limited by this definition.  The
-first component of libfabric is a general purpose framework that is
-capable of handling different types of fabric hardware.  All fabric
-hardware devices and their software drivers are required to support
-this framework.  Devices and the drivers that plug into the libfabric
-framework are referred to as fabric providers, or simply providers.
+See [`fi_arch`(7)](fi_arch.7.html) for a brief description of how
+providers fit into the libfabric architecture.
 
-This distribution of libfabric contains the following providers
-(although more may be available via run-time plug-ins):
+Conceptually, a fabric provider implements and maps the libfabric
+API over lower-level network software and/or hardware.  Most application
+calls into the libfabric API go directly into a provider's implementation
+of that API.
 
-## Core providers
+Libfabric providers are grouped into different type: core, utility,
+hooking, and offload.  These are describe in more detail below.  The
+following diagram illustrates the architecture between the provider
+types.
 
-*GNI*
-: A provider for the Aries interconnect in Cray XC(TM) systems
-  utilizing the user-space *Generic Networking Interface*.  See
-  [`fi_gni`(7)](fi_gni.7.html) for more information.
+```
+---------------------------- libfabric API ----------------------------
+  [core]   provider|<- [hooking provider]
+[services]   API   |  --- libfabric API ---
+                   |<- [utility provider]
+                   |  ---------------- libfabric API ------------------
+                   |<-  [core provider] <-peer API-> [offload provider]
 
-*PSM*
-: High-speed InfiniBand networking from Intel.  See
-  [`fi_psm`(7)](fi_psm.7.html) for more information.
+```
+All providers plug into libfabric using an exported provider API.  libfabric
+supports both internal providers, which ship with the library for user
+convenience, as well as external providers.  External provider libraries
+must be in the library search path, end with the suffix "-fi", and export
+the function fi_prov_ini().
 
-*PSM2*
-: High-speed Omni-Path networking from Intel.  See
-  [`fi_psm2`(7)](fi_psm2.7.html) for more information.
+Once registered with the libfabric core, a provider will be reported to
+applications as part of the discovery process.  Hooking and utility providers
+will intercept libfabric calls from the application to perform some task
+before calling through to the next provider.  If there's no need to intercept
+a specific API call, the application will call directly to the core provider.
+Where possible provider to provider communication is done using the libfabric
+APIs itself, including the use of provider specific extensions to reduce
+call overhead.
 
-*PSM3*
-: High-speed Ethernet networking from Intel.  See
-  [`fi_psm3`(7)](fi_psm3.7.html) for more information.
+libfabric defines a set of APIs that specifically target providers that may
+be used as peers.  These APIs are oddly enough called peer APIs.  Peer APIs
+are technically part of the external libfabric API, but are not designed for
+direct use by applications and are not considered stable for API backwards
+compatibility.
 
-*OPX*
-: High-speed Omni-Path networking from Cornelis Networks.  See
-  [`fi_opx`(7)](fi_opx.7.html) for more information.
+# Core Providers
 
-*Sockets*
-: A general purpose provider that can be used on any network that
-  supports TCP/UDP sockets.  This provider is not intended to provide
-  performance improvements over regular TCP/UDP sockets, but rather to
-  allow developers to write, test, and debug application code even on
-  platforms that do not have high-speed networking.
-  See [`fi_sockets`(7)](fi_sockets.7.html) for more information.
+Core providers are stand-alone providers that usually target a specific
+class of networking devices.  That is, a specific NIC, class of network
+hardware, or lower-level software interface.  The core providers
+are usually what most application developers are concerned with.  Core
+providers may only support libfabric features and interfaces that map
+efficiently to the underlying hardware or network protocols.
 
-*usNIC*
-: Ultra low latency Ethernet networking over Cisco userspace VIC
-  adapters.
-  See [`fi_usnic`(7)](fi_usnic.7.html) for more information.
-
-*Verbs*
-: This provider uses the Linux Verbs API for network transport.
-  Application performance is, obviously expected to be similar to that
-  of the native Linux Verbs API.  Analogous to the Sockets provider,
-  the Verbs provider is intended to enable developers to write, test,
-  and debug application code on platforms that only have Linux
-  Verbs-based networking.
-  See [`fi_verbs`(7)](fi_verbs.7.html) for more information.
-
-*Blue Gene/Q*
-: See [`fi_bgq`(7)](fi_bgq.7.html) for more information.
+The following core providers are built into libfabric by default, assuming
+all build pre-requisites are met.  That is, necessary libraries are installed,
+operating system support is available, etc.  This list is not exhaustive.
 
 *EFA*
 : A provider for the [Amazon EC2 Elastic Fabric Adapter
@@ -76,169 +73,86 @@ This distribution of libfabric contains the following providers
   hardware interface for inter-instance communication on EC2.
   See [`fi_efa`(7)](fi_efa.7.html) for more information.
 
+*GNI*
+: A provider for the Aries interconnect in Cray XC(TM) systems
+  utilizing the user-space *Generic Networking Interface*.  See
+  [`fi_gni`(7)](fi_gni.7.html) for more information.
+
+*OPX*
+: Supports Omni-Path networking from Cornelis Networks.  See
+  [`fi_opx`(7)](fi_opx.7.html) for more information.
+
+*PSM2*
+: Older provider for Omni-Path networks.  See
+  [`fi_psm2`(7)](fi_psm2.7.html) for more information.
+
+*PSM3*
+: Provider for Ethernet networking from Intel.  See
+  [`fi_psm3`(7)](fi_psm3.7.html) for more information.
+
 *SHM*
-: A provider for intranode communication using shared memory.
-  The provider makes use of the Linux kernel feature Cross Memory
-  Attach (CMA) which allows processes to have full access to another
-  process' address space.
-  See [`fi_shm`(7)](fi_shm.7.html) for more information. 
+: A provider for intra-node communication using shared memory.
+  See [`fi_shm`(7)](fi_shm.7.html) for more information.
 
-## Utility providers
+*TCP*
+: A provider which runs over the TCP/IP protocol and is available on
+  multiple operating systems.  This provider enables develop of libfabric
+  applications on most platforms.
+  See [`fi_tcp`(7)](fi_tcp.7.html) for more information
 
-*RxM*
-: The RxM provider (ofi_rxm) is an utility provider that supports RDM
-  endpoints emulated over MSG endpoints of a core provider.
-  See [`fi_rxm`(7)](fi_rxm.7.html) for more information.
+*UDP*
+: A provider which runs over the UDP/IP protocol and is available on
+  multiple operating systems.  This provider enables develop of libfabric
+  applications on most platforms.
+  See [`fi_udp`(7)](fi_udp.7.html) for more information
 
-*RxD*
-: The RxD provider (ofi_rxd) is a utility provider that supports RDM
-  endpoints emulated over DGRAM endpoints of a core provider.
-  See [`fi_rxd`(7)](fi_rxd.7.html) for more information.
+*Verbs*
+: This provider targets RDMA NICs for both Linux and Windows platforms.
+  See [`fi_verbs`(7)](fi_verbs.7.html) for more information.
 
-## Special providers
+# Utility Providers
 
-*Hook*
-: The hook provider is a special type of provider that can layer over any
-  other provider, unless FI_FABRIC_DIRECT is used.  The hook provider is
-  always available, but has no impact unless enabled.  When enabled, the
-  hook provider will intercept all calls to the underlying core or utility
-  provider(s).  The hook provider is useful for capturing performance data
-  or providing debugging information, even in release builds of the library.
-  See [`fi_hook`(7)](fi_hook.7.html) for more information.
-
-# CORE VERSUS UTILITY PROVIDERS
-
-Core providers implement the libfabric interfaces directly over low-level
-hardware and software interfaces.  They are designed to support a
-specific class of hardware, and may be limited to supporting a single
-NIC.  Core providers often only support libfabric features and interfaces
-that map efficiently to their underlying hardware.
-
+Utility providers are named with a starting prefix of "ofi_".
 Utility providers are distinct from core providers in that they are not
 associated with specific classes of devices.  They instead work with
-core providers to expand their features, and interact with core providers
-through libfabric interfaces internally.  Utility providers are often used
-to support a specific endpoint type over a simpler endpoint type.  For
-example, the RXD provider implements reliability over unreliable datagram
-endpoints. The utility providers will not layer over the sockets provider
-unless it is explicitly requested.
+core providers to expand their features and interact with core providers
+through libfabric interfaces internally.  Utility providers are used
+to support a specific endpoint type over a simpler endpoint type.
 
-Utility providers show up as a component in the core provider's component
-list.  See [`fi_fabric`(3)](fi_fabric.3.html).  Utility providers are
+Utility providers show up as part of the return's provider's name.
+See [`fi_fabric`(3)](fi_fabric.3.html).  Utility providers are
 enabled automatically for core providers that do not support the feature
 set requested by an application.
 
-# PROVIDER REQUIREMENTS
+*RxM*
+: Implements RDM endpoint semantics over MSG endpoints.
+  See [`fi_rxm`(7)](fi_rxm.7.html) for more information.
 
-Libfabric provides a general framework for supporting multiple types
-of fabric objects and their related interfaces.  Fabric providers have
-a large amount of flexibility in selecting which components they are
-able and willing to support, based on specific hardware constraints.
-Provider developers should refer to docs/provider for information on
-functionality supplied by the framework to assist in provider
-implementation.  To assist in the development of applications,
-libfabric specifies the
-following requirements that must be met by any fabric provider, if
-requested by an application.
+*RxD*
+: Implements RDM endpoint semantis over DGRAM endpoints.
+  See [`fi_rxd`(7)](fi_rxd.7.html) for more information.
 
-Note that the instantiation of a specific fabric object is subject
-to application configuration parameters and need not meet these requirements.
+# Hooking Providers
 
-* A fabric provider must support at least one endpoint type.
-* All endpoints must support the message queue data transfer
-  interface (fi_ops_msg).
-* An endpoint that advertises support for a specific endpoint
-  capability must support the corresponding data transfer interface.
-  * FI_ATOMIC - fi_ops_atomic
-  * FI_RMA - fi_ops_rma
-  * FI_TAGGED - fi_ops_tagged
-* Endpoints must support all transmit and receive operations for any
-  data transfer interface that they support.
-  * Exception: If an operation is only usable for an operation that
-    the provider does not support, and support for that operation is
-    conveyed using some other mechanism, the operation may return
-    - FI_ENOSYS.  For example, if the provider does not support
-    injected data, it can set the attribute inject_size = 0, and fail
-    all fi_inject operations.
-  * The framework supplies wrappers around the 'msg' operations that
-    can be used.  For example, the framework implements the sendv()
-    msg operation by calling sendmsg().  Providers may reference the
-    general operation, and supply on the sendmsg() implementation.
-* Providers must set all operations to an implementation.  Function
-  pointers may not be left NULL or uninitialized.  The framework supplies
-  empty functions that return -FI_ENOSYS which can be used for this
-  purpose.
-* Endpoints must support the CM interface as follows:
-  * FI_EP_MSG endpoints must support all CM operations.
-  * FI_EP_DGRAM endpoints must support CM getname and setname.
-  * FI_EP_RDM endpoints must support CM getname and setname.
-* Providers that support connectionless endpoints must support all AV
-  operations (fi_ops_av).
-* Providers that support memory registration, must support all MR operations
-  (fi_ops_mr).
-* Providers should support both completion queues and counters.
-  * If FI_RMA_EVENT is not supported, counter support is limited to local
-    events only.
-  * Completion queues must support the FI_CQ_FORMAT_CONTEXT and
-    FI_CQ_FORMAT_MSG.
-  * Providers that support FI_REMOTE_CQ_DATA shall support FI_CQ_FORMAT_DATA.
-  * Providers that support FI_TAGGED shall support FI_CQ_FORMAT_TAGGED.
-* A provider is expected to be forward compatible, and must be able to
-  be compiled against expanded `fi_xxx_ops` structures that define new
-  functions added after the provider was written.  Any unknown
-  functions must be set to NULL.
-* Providers shall document in their man page which features they support,
-  and any missing requirements. 
+Hooking providers are mostly used for debugging purposes.  Since
+hooking providers are built and included in release versions of
+libfabric, they are always available and have no impact on performance
+unless enabled.  Hooking providers can layer over all other providers
+and intercept, or hook, their calls in order to perform some dedicated
+task, such as gathering performance data on call paths or providing
+debug output.
 
-Future versions of libfabric will automatically enable a more complete
-set of features for providers that focus their implementation on a
-narrow subset of libfabric capabilities.
+See [`fi_hook`(7)](fi_hook.7.html) for more information.
 
-# LOGGING INTERFACE
+# Offload Providers
 
-Logging is performed using the FI_ERR, FI_LOG, and FI_DEBUG macros.
-
-## DEFINITIONS
-
-```c
-#define FI_ERR(prov_name, subsystem, ...)
-
-#define FI_LOG(prov_name, prov, level, subsystem, ...)
-
-#define FI_DEBUG(prov_name, subsystem, ...)
-```
-
-## ARGUMENTS
-*prov_name*
-: String representing the provider name.
-
-*prov*
-: Provider context structure.
-
-*level*
-: Log level associated with log statement.
-
-*subsystem*
-: Subsystem being logged from.
-
-## DESCRIPTION
-*FI_ERR*
-: Always logged.
-
-*FI_LOG*
-: Logged if the intended provider, log level, and subsystem parameters match
-  the user supplied values.
-
-*FI_DEBUG*
-: Logged if configured with the --enable-debug flag.
+Offload providers start with the naming prefix "off_".  An offload provider
+is meant to be paired with other core and/or utility providers.
+An offload provider is intended to accelerate specific types of communication,
+generally by taking advantage of network services that have been offloaded
+into hardware, though actual hardware offload support is not a requirement.
 
 # SEE ALSO
 
-[`fi_gni`(7)](fi_gni.7.html),
-[`fi_hook`(7)](fi_hook.7.html),
-[`fi_psm`(7)](fi_psm.7.html),
-[`fi_sockets`(7)](fi_sockets.7.html),
-[`fi_usnic`(7)](fi_usnic.7.html),
-[`fi_verbs`(7)](fi_verbs.7.html),
-[`fi_bgq`(7)](fi_bgq.7.html),
-[`fi_opx`(7)](fi_opx.7.html),
+[`fabric`(7)](fabric.7.html)
+[`fi_provider`(3)](fi_provider.3.html)

--- a/man/fi_setup.7.md
+++ b/man/fi_setup.7.md
@@ -1,0 +1,1173 @@
+---
+layout: page
+title: fi_setup(7)
+tagline: Libfabric Programmer's Guide - Setup
+---
+{% include JB/setup %}
+
+# NAME
+
+fi_setup \- libfabric setup and initialization
+
+# OVERVIEW
+
+A full description of the libfabric API is documented in the relevant man pages.
+This section provides an introduction to select interfaces, including how they
+may be used.  It does not attempt to capture all subtleties or use cases,
+nor describe all possible data structures or fields.  However, it is useful
+for new developers trying to kick-start using libfabric.
+
+# fi_getinfo()
+
+The fi_getinfo() call is one of the first calls that applications invoke.
+It is designed to be easy to use for simple applications, but extensible
+enough to configure a network for optimal performance.  It serves several
+purposes. First, it abstracts away network implementation and addressing
+details.  Second, it allows an application to specify which features they
+require of the network.  Last, it provides a mechanism for a provider to
+report how an application can use the network in order to achieve the best
+performance.  fi_getinfo() is loosely based on the getaddrinfo() call.
+
+```
+/* API prototypes */
+struct fi_info *fi_allocinfo(void);
+
+int fi_getinfo(int version, const char *node, const char *service,
+    uint64_t flags, struct fi_info *hints, struct fi_info **info);
+```
+
+```
+/* Sample initialization code flow */
+struct fi_info *hints, *info;
+
+hints = fi_allocinfo();
+
+/* hints will point to a cleared fi_info structure
+ * Initialize hints here to request specific network capabilities
+ */
+
+fi_getinfo(FI_VERSION(1, 16), NULL, NULL, 0, hints, &info);
+fi_freeinfo(hints);
+
+/* Use the returned info structure to allocate fabric resources */
+```
+
+The hints parameter is the key for requesting fabric services.  The
+fi_info structure contains several data fields, plus pointers to a wide
+variety of attributes.  The fi_allocinfo() call simplifies the creation
+of an fi_info structure and is strongly recommended for use.  In this
+example, the application is merely attempting to get a list of what
+providers are available in the system and the features that they support.
+Note that the API is designed to be extensible.  Versioning information is
+provided as part of the fi_getinfo() call.  The version is used by libfabric
+to determine what API features the application is aware of.  In this case,
+the application indicates that it can properly handle any feature that was
+defined for the 1.16 release (or earlier).
+
+Applications should _always_ hard code the version that they are written
+for into the fi_getinfo() call.  This ensures that newer versions of libfabric
+will provide backwards compatibility with that used by the application.
+Newer versions of libfabric must support applications that were compiled
+against an older version of the library.  It must also support applications
+written against header files from an older library version, but re-compiled
+against newer header files.  Among other things, the version parameter allows
+libfabric to determine if an application is aware of new fields that may have
+been added to structures, or if the data in those fields may be uninitialized.
+
+Typically, an application will initialize the hints parameter to list the
+features that it will use.
+
+```
+/* Taking a peek at the contents of fi_info */
+struct fi_info {
+    struct fi_info *next;
+    uint64_t caps;
+    uint64_t mode;
+    uint32_t addr_format;
+    size_t src_addrlen;
+    size_t dest_addrlen;
+    void *src_addr;
+    void *dest_addr;
+    fid_t handle;
+    struct fi_tx_attr *tx_attr;
+    struct fi_rx_attr *rx_attr;
+    struct fi_ep_attr *ep_attr;
+    struct fi_domain_attr *domain_attr;
+    struct fi_fabric_attr *fabric_attr;
+    struct fid_nic *nic;
+};
+```
+
+The fi_info structure references several different attributes, which correspond
+to the different libfabric objects that an application allocates.  For basic
+applications, modifying or accessing most attribute fields are unnecessary.
+Many applications will only need to deal with a few fields of fi_info, most
+notably the endpoint type, capability (caps) bits, and mode bits.  These are
+defined in more detail below.
+
+On success, the fi_getinfo() function returns a linked list of fi_info
+structures.  Each entry in the list will meet the conditions specified
+through the hints parameter.  The returned entries may come from different
+network providers, or may differ in the returned attributes.  For example,
+if hints does not specify a particular endpoint type, there may be an entry
+for each of the three endpoint types.  As a general rule, libfabric attempts
+to return the list of fi_info structures in order from most desirable to least.
+High-performance network providers are listed before more generic providers.
+
+## Capabilities (fi_info::caps)
+
+The fi_info caps field is used to specify the features and services that the
+application requires of the network.  This field is a bit-mask of desired
+capabilities.  There are capability bits for each of the data transfer services
+previously mentioned: FI_MSG, FI_TAGGED, FI_RMA, FI_ATOMIC, and FI_COLLECTIVE.
+Applications should set each bit for each set of operations that it will use.
+These bits are often the only caps bits set by an application.
+
+Capabilities are grouped into three general categories: primary, secondary,
+and primary modifiers.  Primary capabilities must explicitly be requested
+by an application, and a provider must enable support for only those primary
+capabilities which were selected.  This is required for both performance and
+security reasons.  Primary modifiers are used to limit a primary capability,
+such as restricting an endpoint to being send-only.
+
+Secondary capabilities may optionally be requested by an application.  If
+requested, a provider must support a capability if it is asked for or fail
+the fi_getinfo request.  A provider may optionally report non-requested
+secondary capabilities if doing so would not compromise performance or
+security.  That is, a provider may grant an application a secondary capability,
+whether the application.  The most commonly accessed secondary capability bits
+indicate if provider communication is restricted to the local node Ifor example,
+the shared memory provider only supports local communication) and/or remote
+nodes (which can be the case for NICs that lack loopback support).  Other
+secondary capability bits mostly deal with features targeting highly-scalable
+applications, but may not be commonly supported across multiple providers.
+
+Because different providers support different sets of capabilities, applications
+that desire optimal network performance may need to code for a capability being
+either present or absent.  When present, such capabilities can offer a
+scalability or performance boost.  When absent, an application may prefer to
+adjust its protocol or implementation to work around the network limitations.
+Although providers can often emulate features, doing so can impact overall
+performance, including the performance of data transfers that otherwise appear
+unrelated to the feature in use.  For example, if a provider needs to insert
+protocol headers into the message stream in order to implement a given
+capability, the insertion of that header could negatively impact the
+performance of all transfers. By exposing such limitations to the application,
+the application developer has better control over how to best emulate the
+feature or work around its absence.
+
+It is recommended that applications code for only those capabilities required
+to achieve the best performance.  If a capability would have little to no
+effect on overall performance, developers should avoid using such features as
+part of an initial implementation.  This will allow the application to work
+well across the widest variety of hardware.  Application optimizations can
+then add support for less common features.  To see which features are supported
+by which providers, see the libfabric
+[Provider Feature Maxtrix](https://github.com/ofiwg/libfabric/wiki/Provider-Feature-Matrix)
+for the relevant release.
+
+## Mode Bits (fi_info::mode)
+
+Where capability bits represent features desired by applications, mode bits
+correspond to behavior needed by the provider.  That is, capability bits are top
+down requests, whereas mode bits are bottom up restrictions.  Mode bits are set
+by the provider to request that the application use the API in a specific way
+in order to achieve optimal performance.  Mode bits often imply that the
+additional work to implement certain communication semantics needed by the
+application will be less if implemented by the applicaiton than forcing that
+same implementation down into the provider.  Mode bits arise as a result of
+hardware implementation restrictions.
+
+An application developer decides which mode bits they want to or can easily
+support as part of their development process.  Each mode bit describes a
+particular behavior that the application must follow to use various interfaces.
+Applications set the mode bits that they support when calling fi_getinfo().
+If a provider requires a mode bit that isn't set, that provider will be skipped
+by fi_getinfo().  If a provider does not need a mode bit that is set, it will
+respond to the fi_getinfo() call, with the mode bit cleared.  This indicates
+that the application does not need to perform the action required by the
+mode bit.
+
+One of common mode bit needed by providers is FI_CONTEXT (and FI_CONTEXT2).
+This mode bit requires that applications pass in a libfabric defined data
+structure (struct fi_context) into any data transfer function.  That
+structure must remain valid and unused by the application until the data
+transfer operation completes.  The purpose behind this mode bit is that the
+struct fi_context provides "scratch" space that the provider can use to
+track the request.  For example, it may need to insert the request into a
+linked list while it is pending, or track the number of times that an
+outbound transfer has been retried.  Since many applications already track
+outstanding operations with their own data structure, by embedding the
+struct fi_context into that same structure, overall performance can be
+improved.  This avoids the provider needing to allocate and free internal
+structures for each request.
+
+Continuing with this example, if an application does not already track
+outstanding requests, then it would leave the FI_CONTEXT mode bit unset.
+This would indicate that the provider needs to get and release its own
+structure for tracking purposes.  In this case, the costs would essentially
+be the same whether it were done by the application or provider.
+
+For the broadest support of different network technologies, applications
+should attempt to support as many mode bits as feasible.  It is recommended
+that providers support applications that cannot support any mode bits, with
+as small an impact as possible.  However, implementation of mode bit avoidance
+in the provider can still impact performance, even when the mode bit is
+disabled.  As a result, some providers may always require specific mode bits
+be set.
+
+# FIDs (fid_t)
+
+FID stands for fabric identifier.  It is the base object type assigned to all
+libfabric API objects.  All fabric resources are represented by a fid structure,
+and all fid's are derived from a base fid type.  In object-oriented terms, a
+fid would be the parent class.  The contents of a fid are visible to the
+application.
+
+```
+/* Base FID definition */
+enum {
+    FI_CLASS_UNSPEC,
+    FI_CLASS_FABRIC,
+    FI_CLASS_DOMAIN,
+    ...
+};
+
+struct fi_ops {
+    size_t size;
+    int (*close)(struct fid *fid);
+    ...
+};
+
+/* All fabric interface descriptors must start with this structure */
+struct fid {
+    size_t fclass;
+    void *context;
+    struct fi_ops *ops;
+};
+
+```
+
+The fid structure is designed as a trade-off between minimizing memory
+footprint versus software overhead.  Each fid is identified as a specific
+object class, which helps with debugging.  Examples are given above
+(e.g. FI_CLASS_FABRIC).  The context field is an application defined data
+value, assigned to an object during its creation.  The use of the context
+field is application specific, but it is meant to be read by applications.
+Applications often set context to a corresponding structure that it's
+allocated.  The context field is the only field that applications are
+recommended to access directly.  Access to other fields should be done
+using defined function calls (for example, the close() operation).
+
+The ops field points to a set of function pointers.  The fi_ops structure
+defines the operations that apply to that class.  The size field in the
+fi_ops structure is used for extensibility, and allows the fi_ops structure
+to grow in a backward compatible manner as new operations are added.  The
+fid deliberately points to the fi_ops structure, rather than embedding the
+operations directly.  This allows multiple fids to point to the same set
+of ops, which minimizes the memory footprint of each fid. (Internally,
+providers usually set ops to a static data structure, with the fid structure
+dynamically allocated.)
+
+Although it's possible for applications to access function pointers directly,
+it is strongly recommended that the static inline functions defined in the
+man pages be used instead.  This is required by applications that may be built
+using the FABRIC_DIRECT library feature.  (FABRIC_DIRECT is a compile time
+option that allows for highly optimized builds by tightly coupling an
+application with a specific provider.)
+
+Other OFI classes are derived from this structure, adding their own set of operations.
+
+```
+/* Example of deriving a new class for a fabric object */
+struct fi_ops_fabric {
+    size_t size;
+    int (*domain)(struct fid_fabric *fabric, struct fi_info *info,
+        struct fid_domain **dom, void *context);
+    ...
+};
+
+struct fid_fabric {
+    struct fid fid;
+    struct fi_ops_fabric *ops;
+};
+```
+
+Other fid classes follow a similar pattern as that shown for fid_fabric.  The
+base fid structure is followed by zero or more pointers to operation sets.
+
+# Fabric (fid_fabric)
+
+The top-level object that applications open is the fabric identifier.  The
+fabric can mostly be viewed as a container object by applications, though
+it does identify which provider(s) applications use.
+
+Opening a fabric is usually a straightforward call after calling fi_getinfo().
+
+```
+int fi_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric, void *context);
+```
+
+The fabric attributes can be directly accessed from struct fi_info.  The newly
+opened fabric is returned through the 'fabric' parameter.  The 'context'
+parameter appears in many operations.  It is a user-specified value that is
+associated with the fabric.  It may be used to point to an application specific
+structure and is retrievable from struct fid_fabric.
+
+## Attributes (fi_fabric_attr)
+
+The fabric attributes are straightforward.
+
+```
+struct fi_fabric_attr {
+    struct fid_fabric *fabric;
+    char *name;
+    char *prov_name;
+    uint32_t prov_version;
+    uint32_t api_version;
+};
+```
+
+The only field that applications are likely to use directly is the prov_name.
+This is a string value that can be used by hints to select a specific provider
+for use.  On most systems, there will be multiple providers available.  Only
+one is likely to represent the high-performance network attached to the system.
+Others are generic providers that may be available on any system, such as the
+TCP socket and UDP providers.
+
+The fabric field is used to help applications manage opened fabric resources.
+If an application has already opened a fabric that can support the returned
+fi_info structure, this will be set to that fabric.
+
+# Domains (fid_domain)
+
+Domains frequently map to a specific local network interface adapter.  A domain
+may either refer to the entire NIC, a port on a multi-port NIC, a virtual
+device exposed by a NIC, multiple NICs being used in a multi-rail fashion,
+and so forth.  Although it's convenient to think of a domain as referring to
+a NIC, such an association isn't expected by libfabric.  From the viewpoint
+of the application, a domain identifies a set of resources that may be used
+together.
+
+Similar to a fabric, opening a domain is straightforward after calling fi_getinfo().
+
+```
+int fi_domain(struct fid_fabric *fabric, struct fi_info *info,
+    struct fid_domain **domain, void *context);
+```
+
+The fi_info structure returned from fi_getinfo() can be passed directly to
+fi_domain() to open a new domain.
+
+## Attributes (fi_domain_attr)
+
+One of the goals of a domain is to define the relationship between data
+transfer services (endpoints) and completion services (completion queues
+and counters).  Many of the domain attributes describe that relationship
+and its impact to the application.
+
+```
+struct fi_domain_attr {
+    struct fid_domain *domain;
+    char *name;
+    enum fi_threading threading;
+    enum fi_progress control_progress;
+    enum fi_progress data_progress;
+    enum fi_resource_mgmt resource_mgmt;
+    enum fi_av_type av_type;
+    enum fi_mr_mode mr_mode;
+    size_t mr_key_size;
+    size_t cq_data_size;
+    size_t cq_cnt;
+    size_t ep_cnt;
+    size_t tx_ctx_cnt;
+    size_t rx_ctx_cnt;
+    ...
+```
+
+Full details of the domain attributes and their meaning are in the fi_domain
+man page.  Information on select attributes and their impact to the application
+are described below.
+
+## Threading (fi_threading)
+
+libfabric defines a unique threading model.  The libfabric design is heavily
+influenced by object-oriented programming concepts.  A multi-threaded
+application must determine how libfabric objects (domains, endpoints,
+completion queues, etc.) will be allocated among its threads, or if any
+thread can access any object.  For example, an application may spawn a new
+thread to handle each new connected endpoint.  The domain threading field
+provides a mechanism for an application to identify which objects may be
+accessed simultaneously by different threads.  This in turn allows a provider
+to optimize or, in some cases, eliminate internal synchronization and locking
+around those objects.
+
+Threading defines where providers could optimize synchronization primitives.
+However, providers may still implement more serialization than is needed
+by the application.  (This is usually a result of keeping the provider
+implementation simpler).
+
+It is recommended that applications target either FI_THREAD_SAFE (full thread
+safety implemented by the provider) or FI_THREAD_DOMAIN (objects associated
+with a single domain will only be accessed by a single thread).
+
+## Progress (fi_progress)
+
+Progress models are a result of using the host processor in order to perform
+some portion of the transport protocol.  In order to simplify development,
+libfabric defines two progress models: automatic or manual.  It does not
+attempt to identify which specific interface features may be offloaded, or
+what operations require additional processing by the application's thread.
+
+Automatic progress means that an operation initiated by the application will
+eventually complete, even if the application makes no further calls into the
+libfabric API.  The operation is either offloaded entirely onto hardware,
+the provider uses an internal thread, or the operating system kernel may
+perform the task.  The use of automatic progress may increase system overhead
+and latency in the latter two cases.  For control operations, such as
+connection setup, this is usually acceptable.  However, the impact to data
+ transfers may be measurable, especially if internal threads are required
+ to provide automatic progress.
+
+The manual progress model can avoid this overhead for providers that do not
+offload all transport features into hardware.  With manual progress the
+provider implementation will handle transport operations as part of specific
+libfabric functions.  For example, a call to fi_cq_read() which retrieves an
+array completed operations may also be responsible for sending ack messages
+to notify peers that a message has been received.  Since reading the
+completion queue is part of the normal operation of an application, there is
+minimal impact to the application and additional threads are avoided.
+
+Applications need to take care when using manual progress, particularly if
+they link into libfabric multiple times through different code paths or library
+dependencies.  If application threads are used to drive progress, such as
+responding to received data with ACKs, then it is critical that the application
+thread call into libfabric in a timely manner.
+
+## Memory Registration (fid_mr)
+
+RMA, atomic, and collective operations can read and write memory that is owned
+by a peer process, and neither require the involvement of the target processor.
+Because the memory can be modified over the network, an application must opt
+into exposing its memory to peers.  This is handled by the memory registration
+process.  Registered memory regions associate memory buffers with permissions
+granted for access by fabric resources. A memory buffer must be registered
+before it can be used as the target of a remote RMA, atomic, or collective
+data transfer.  Additionally, a fabric provider may require that data buffers
+be registered before being used even in the case of local transfers.  The latter
+is necessary to ensure that the virtual to physical page mappings do not change
+while network hardware is performing the transfer.
+
+In order to handle diverse hardware requirements, there are a set of mr_mode
+bits associated with memory registration.  The mr_mode bits behave similar to
+fi_info mode bits.  Applications indicate which types of restrictions they
+can support, and the providers clear those bits which aren't needed.
+
+For hardware that requires memory registration, managing registration is
+critical to achieving good performance and scalability.  The act of registering
+memory is costly and should be avoided on a per data transfer basis.
+libfabric has extensive internal support for managing memory registration,
+hiding registration from user application, caching registration to reduce per
+transfer overhead, and detecting when cached registrations are no longer valid.
+It is recommended that applications that are not natively designed to account
+for registering memory to make use of libfabric's registration cache.  This
+can be done by simply not setting the relevant mr_mode bits.
+
+### Memory Region APIs
+
+The following APIs highlight how to allocate and access a registered memory
+region.  Note that this is not a complete list of memory region (MR) calls,
+and for full details on each API, readers should refer directly to the fi_mr
+man page.
+
+```
+int fi_mr_reg(struct fid_domain *domain, const void *buf, size_t len,
+    uint64_t access, uint64_t offset, uint64_t requested_key, uint64_t flags,
+    struct fid_mr **mr, void *context);
+
+void * fi_mr_desc(struct fid_mr *mr);
+uint64_t fi_mr_key(struct fid_mr *mr);
+```
+
+By default, memory regions are associated with a domain.  A MR is accessible
+by any endpoint that is opened on that domain.  A region starts at the address
+specified by 'buf', and is 'len' bytes long.  The 'access' parameter are
+permission flags that are OR'ed together.  The permissions indicate which
+type of operations may be invoked against the region (e.g. FI_READ, FI_WRITE,
+FI_REMOTE_READ, FI_REMOTE_WRITE).  The 'buf' parameter typically references
+allocated virtual memory.
+
+A MR is associated with local and remote protection keys.  The local key is
+referred to as a memory descriptor and may be retrieved by calling fi_mr_desc().
+This call is only needed if the FI_MR_LOCAL mr_mode bit has been set.  The
+memory descriptor is passed directly into data transfer operations, for example:
+
+```
+/* fi_mr_desc() example using fi_send() */
+fi_send(ep, buf, len, fi_mr_desc(mr), 0, NULL);
+```
+
+The remote key, or simply MR key, is used by the peer when targeting the MR
+with an RMA or atomic operation.   In many cases, the key will need to be sent
+in a separate message to the initiating peer.  libfabric API uses a 64-bit key
+where one is used.  The actual key size used by a provider is part of its domain
+attributes  Support for larger key sizes, as required by some providers, is
+conveyed through an mr_mode bit, and requires the use of extended MR API calls
+that map the larger size to a 64-bit value.
+
+# Endpoints
+
+Endpoints are transport level communication portals.  Opening an endpoint is
+trivial after calling fi_getinfo().
+
+## Active (fid_ep)
+
+Active endpoints may be connection-oriented or connection-less.  They are
+considered active as they may be used to perform data transfers.  All data
+transfer interfaces – messages (fi_msg), tagged messages (fi_tagged),
+RMA (fi_rma), atomics (fi_atomic), and collectives (fi_collective) – are
+associated with active endpoints.  Though an individual endpoint may not
+be enabled to use all data transfers.  In standard configurations, an
+active endpoint has one transmit and one receive queue.  In general,
+operations that generate traffic on the fabric are posted to the transmit
+queue. This includes all RMA and atomic operations, along with sent messages
+and sent tagged messages. Operations that post buffers for receiving incoming
+data are submitted to the receive queue.
+
+Active endpoints are created in the disabled state.  The endpoint must first
+be configured prior to it being enabled.  Endpoints must transition into
+an enabled state before accepting data transfer operations, including posting
+of receive buffers. The fi_enable() call is used to transition an active endpoint
+into an enabled state. The fi_connect() and fi_accept() calls will also
+transition an endpoint into the enabled state, if it is not already enabled.
+
+```
+int fi_endpoint(struct fid_domain *domain, struct fi_info *info,
+    struct fid_ep **ep, void *context);
+```
+
+### Enabling (fi_enable)
+
+In order to transition an endpoint into an enabled state, it must be bound to
+one or more fabric resources.  This includes binding the endpoint to a
+completion queue and event queue.  Unconnected endpoints must also be bound to
+an address vector.
+
+```
+/* Example to enable an unconnected endpoint */
+
+/* Allocate an address vector and associated it with the endpoint */
+fi_av_open(domain, &av_attr, &av, NULL);
+fi_ep_bind(ep, &av->fid, 0);
+
+/* Allocate and associate completion queues with the endpoint */
+fi_cq_open(domain, &cq_attr, &cq, NULL);
+fi_ep_bind(ep, &cq->fid, FI_TRANSMIT | FI_RECV);
+
+fi_enable(ep);
+```
+
+In the above example, we allocate an AV and CQ.  The attributes for the AV
+and CQ are omitted (additional discussion below).  Those are then associated
+with the endpoint through the fi_ep_bind() call.  After all necessary resources
+have been assigned to the endpoint, we enable it.  Enabling the endpoint
+indicates to the provider that it should allocate any hardware and software
+resources and complete the initialization for the endpoint.  (If the endpoint
+is not bound to all necessary resources, the fi_enable() call will fail.)
+
+The fi_enable() call is always called for unconnected endpoints.  Connected
+endpoints may be able to skip calling fi_enable(), since fi_connect() and
+fi_accept() will enable the endpoint automatically.  However, applications
+may still call fi_enable() prior to calling fi_connect() or fi_accept().
+Doing so allows the application to post receive buffers to the endpoint,
+which ensures that they are available to receive data in the case the peer
+endpoint sends messages immediately after it establishes the connection.
+
+## Passive (fid_pep)
+
+Passive endpoints are used to listen for incoming connection requests.
+Passive endpoints are of type FI_EP_MSG, and may not perform any data transfers.
+An application wishing to create a passive endpoint typically calls fi_getinfo()
+using the FI_SOURCE flag, often only specifying a 'service' address.  The
+service address corresponds to a TCP port number.
+
+Passive endpoints are associated with event queues.  Event queues report
+connection requests from peers.  Unlike active endpoints, passive endpoints are
+not associated with a domain.  This allows an application to listen for
+connection requests across multiple domains, though still restricted to a
+single provider.
+
+```
+/* Example passive endpoint listen */
+fi_passive_ep(fabric, info, &pep, NULL);
+
+fi_eq_open(fabric, &eq_attr, &eq, NULL);
+fi_pep_bind(pep, &eq->fid, 0);
+
+fi_listen(pep);
+```
+
+A passive endpoint must be bound to an event queue before calling listen.
+This ensures that connection requests can be reported to the application.
+To accept new connections, the application waits for a request, allocates a
+new active endpoint for it, and accepts the request.
+
+```
+/* Example accepting a new connection */
+
+/* Wait for a CONNREQ event */
+fi_eq_sread(eq, &event, &cm_entry, sizeof cm_entry, -1, 0);
+assert(event == FI_CONNREQ);
+
+/* Allocate a new endpoint for the connection */
+if (!cm_entry.info->domain_attr->domain)
+    fi_domain(fabric, cm_entry.info, &domain, NULL);
+fi_endpoint(domain, cm_entry.info, &ep, NULL);
+
+fi_ep_bind(ep, &eq->fid, 0);
+fi_cq_open(domain, &cq_attr, &cq, NULL);
+fi_ep_bind(ep, &cq->fid, FI_TRANSMIT | FI_RECV);
+
+fi_enable(ep);
+fi_recv(ep, rx_buf, len, NULL, 0, NULL);
+
+fi_accept(ep, NULL, 0);
+fi_eq_sread(eq, &event, &cm_entry, sizeof cm_entry, -1, 0);
+assert(event == FI_CONNECTED);
+```
+
+The connection request event (FI_CONNREQ) includes information about the
+type of endpoint to allocate, including default attributes to use.  If a
+domain has not already been opened for the endpoint, one must be opened.
+Then the endpoint and related resources can be allocated.  Unlike the
+unconnected endpoint example above, a connected endpoint does not have an AV,
+but does need to be bound to an event queue.  In this case, we use the same
+EQ as the listening endpoint.  Once the other EP resources (e.g. CQ) have
+been allocated and bound, the EP can be enabled.
+
+To accept the connection, the application calls fi_accept().  Note that because
+of thread synchronization issues, it is possible for the active endpoint to
+receive data even before fi_accept() can return.  The posting of receive
+buffers prior to calling fi_accept() handles this condition, which avoids
+network flow control issues occurring immediately after connecting.
+
+The fi_eq_sread() calls are blocking (synchronous) read calls to the event
+queue.  These calls wait until an event occurs, which in this case are
+connection request and establishment events.
+
+## EP Attributes (fi_ep_attr)
+
+The properties of an endpoint are specified using endpoint attributes.
+These are attributes for the endpoint as a whole.  There are additional
+attributes specifically related to the transmit and receive contexts
+underpinning the endpoint (details below).
+
+```
+struct fi_ep_attr {
+    enum fi_ep_type type;
+    uint32_t        protocol;
+    uint32_t        protocol_version;
+    size_t          max_msg_size;
+    ...
+};
+```
+
+A full description of each field is available in the fi_endpoint man page,
+with selected details listed below.
+
+### Endpoint Type (fi_ep_type)
+
+This indicates the type of endpoint: reliable datagram (FI_EP_RDM),
+reliable-connected (FI_EP_MSG), or unreliable datagram (FI_EP_DGRAM).
+Nearly all applications will want to specify the endpoint type as a hint
+passed into fi_getinfo, as most applications will only be coded to support
+a single endpoint type.
+
+### Maximum Message Size (max_msg_size)
+
+This size is the maximum size for any data transfer operation that goes over
+the endpoint. For unreliable datagram endpoints, this is often the MTU of the
+underlying network. For reliable endpoints, this value is often a restriction
+of the underlying transport protocol.  A common minimum maximum message size
+is 2GB, though some providers support an arbitrarily large size.  Applications
+that require transfers larger than the maximum reported size are required to
+break up a single, large transfer into multiple operations.
+
+Providers expose their hardware or network limits to the applications, rather
+than segmenting large transfers internally, in order to minimize completion
+overhead. For example, for a provider to support large message segmentation
+internally, it would need to emulate all completion mechanisms (queues and
+counters) in software, even if transfers that are larger than the transport
+supported maximum were never used.
+
+### Message Order Size (max_order_xxx_size)
+
+These fields specify data ordering.   They define the delivery order of
+transport data into target memory for RMA and atomic operations.  Data
+ordering requires message ordering.  If message ordering is not specified,
+these fields do not apply.
+
+For example, suppose that an application issues two RMA write operations to
+the same target memory location.  (The application may be writing a time stamp
+value every time a local condition is met, for instance).  Message ordering
+indicates that the first write as initiated by the sender is the first write
+processed by the receiver.  Data ordering indicates whether the _data_ from
+the first write updates memory before the second write updates memory.
+
+The max_order_xxx_size fields indicate how large a message may be while still
+achieving data ordering.  If a field is 0, then no data ordering is guaranteed.
+If a field is the same as the max_msg_size, then data order is guaranteed for
+all messages.
+
+Providers may support data ordering up to max_msg_size for back to back operations
+that are the same.  For example, an RMA write followed by an RMA write may have data
+ordering regardless of the size of the data transfer (max_order_waw_size =
+max_msg_size).  Mixed operations, such as a read followed by a write, are often
+restricted.  This is because RMA read operations may require acknowledgments from
+the _initiator_, which impacts the re-transmission protocol.
+
+For example, consider an RMA read followed by a write.  The target will process
+the read request, retrieve the data, and send a reply.  While that is occurring,
+a write is received that wants to update the same memory location accessed
+by the read. If the target processes the write, it will overwrite the memory
+used by the read. If the read response is lost, and the read is retried, the
+target will be unable to re-send the data. To handle this, the target either
+needs to: defer handling the write until it receives an acknowledgment for
+the read response, buffer the read response so it can be re-transmitted, or
+indicate that data ordering is not guaranteed.
+
+Because the read or write operation may be gigabytes in size, deferring the
+write may add significant latency, and buffering the read response may be
+impractical. The max_order_xxx_size fields indicate how large back to back
+operations may be with ordering still maintained. In many cases, read after
+write and write and read ordering may be significantly limited, but still
+usable for implementing specific algorithms, such as a global locking mechanism.
+
+## Rx/Tx Context Attributes (fi_rx_attr / fi_tx_attr)
+
+The endpoint attributes define the overall abilities for the endpoint;
+however, attributes that apply specifically to receive or transmit contexts
+are defined by struct fi_rx_attr and fi_tx_attr, respectively:
+
+```
+struct fi_rx_attr {
+    uint64_t caps;
+    uint64_t mode;
+    uint64_t op_flags;
+    uint64_t msg_order;
+    uint64_t comp_order;
+    ...
+};
+
+struct fi_tx_attr {
+    uint64_t caps;
+    uint64_t mode;
+    uint64_t op_flags;
+    uint64_t msg_order;
+    uint64_t comp_order;
+    size_t inject_size;
+    ...
+};
+```
+
+Rx/Tx context capabilities must be a subset of the endpoint capabilities. For
+many applications, the default attributes returned by the provider will be
+sufficient, with the application only needing to specify endpoint attributes.
+
+Both context attributes include an op_flags field. This field is used by
+applications to specify the default operation flags to use with any call.
+For example, by setting the transmit context’s op_flags to FI_INJECT, the
+application has indicated to the provider that all transmit operations should
+assume ‘inject’ behavior is desired.  I.e. the buffer provided to the call
+must be returned to the application upon return from the function.  The
+op_flags applies to all operations that do not provide flags as part of
+the call (e.g. fi_sendmsg).  One use of op_flags is to specify the
+default completion semantic desired (discussed next) by the application.  By
+setting the default op_flags at initialization time, we can avoid passing the
+flags as arguments into some data transfer calls, avoid parsing the flags, and
+can prepare submitted commands ahead of time.
+
+It should be noted that some attributes are dependent upon the peer endpoint
+having supporting attributes in order to achieve correct application behavior.
+For example, message order must be the compatible between the initiator’s
+transmit attributes and the target’s receive attributes. Any mismatch may
+result in incorrect behavior that could be difficult to debug.
+
+# Completions
+
+Data transfer operations complete asynchronously. Libfabric defines two
+mechanism by which an application can be notified that an operation has
+completed: completion queues and counters.  Regardless of which mechanism
+is used to notify the application that an operation is done, developers
+must be aware of what a completion indicates.
+
+In all cases, a completion indicates that it is safe to reuse the buffer(s)
+associated with the data transfer. This completion mode is referred to as
+_inject_ complete and corresponds to the operational flags FI_INJECT_COMPLETE.
+However, a completion may also guarantee stronger semantics.
+
+Although libfabric does not define an implementation, a provider can meet the
+requirement for inject complete by copying the application’s buffer into a
+network buffer before generating the completion. Even if the transmit
+operation is lost and must be retried, the provider can resend the
+original data from the copied location. For large transfers, a provider
+may not mark a request as inject complete until the data has been
+acknowledged by the target. Applications, however, should only infer that
+it is safe to reuse their data buffer for an inject complete operation.
+
+Transmit complete is a completion mode that provides slightly stronger
+guarantees to the application. The meaning of transmit complete depends
+on whether the endpoint is reliable or unreliable. For an unreliable
+endpoint (FI_EP_DGRAM), a transmit completion indicates that the request
+has been delivered to the network. That is, the message has been delivered at
+least as far as hardware queues on the local NIC. For reliable endpoints,
+a transmit complete occurs when the request has reached the target
+endpoint. Typically, this indicates that the target has acked the
+request. Transmit complete maps to the operation flag FI_TRANSMIT_COMPLETE.
+
+A third completion mode is defined to provide guarantees beyond transmit
+complete. With transmit complete, an application knows that the message is
+no longer dependent on the local NIC or network (e.g. switches). However,
+the data may be buffered at the remote NIC and has not necessarily been
+written to the target memory. As a result, data sent in the request may
+not be visible to all processes. The third completion mode is delivery
+complete.
+
+Delivery complete indicates that the results of the operation are available
+to all processes on the fabric. The distinction between transmit and delivery
+complete is subtle, but important. It often deals with _when_ the target
+endpoint generates an acknowledgment to a message. For providers that offload
+transport protocol to the NIC, support for transmit complete is common.
+Delivery complete guarantees are more easily met by providers that implement
+portions of their protocol on the host processor. Delivery complete
+corresponds to the FI_DELIVERY_COMPLETE operation flag.
+
+Applications can request a default completion mode when opening an endpoint
+by setting one of the above mentioned complete flags as an op_flags for the
+context’s attributes. However, it is usually recommended that application
+use the provider’s default flags for best performance, and amend its protocol
+to achieve its completion semantics. For example, many applications will
+perform a ‘finalize’ or ‘commit’ procedure as part of their operation,
+which synchronizes the processing of all peers and guarantees that all
+previously sent data has been received.
+
+A full discussion of completion semantics is given in the fi_cq man page.
+
+## CQs (fid_cq)
+
+Completion queues often map directly to provider hardware mechanisms, and
+libfabric is designed around minimizing the software impact of accessing
+those mechanisms. Unlike other objects discussed so far (fabrics, domains,
+endpoints), completion queues are not part of the fi_info structure or
+involved with the fi_getinfo() call.
+
+All active endpoints must be bound with one or more completion queues.
+This is true even if completions will be suppressed by the application
+(e.g. using the FI_SELECTIVE_COMPLETION flag). Completion queues are
+needed to report operations that complete in error and help drive progress
+in the case of manual progress.
+
+CQs are allocated separately from endpoints and are associated with endpoints
+through the fi_ep_bind() function.
+
+## CQ Format (fi_cq_format)
+
+In order to minimize the amount of data that a provider must report, the
+type of completion data written back to the application is select-able.
+This limits the number of bytes the provider writes to memory, and allows
+necessary completion data to fit into a compact structure. Each CQ format
+ maps to a specific completion structure. Developers should analyze each
+ structure, select the smallest structure that contains all of the data
+ it requires, and specify the corresponding enum value as the CQ format.
+
+For example, if an application only needs to know which request completed,
+along with the size of a received message, it can select the following:
+
+```
+cq_attr->format = FI_CQ_FORMAT_MSG;
+
+struct fi_cq_msg_entry {
+    void      *op_context;
+    uint64_t  flags;
+    size_t    len;
+};
+```
+
+Once the format has been selected, the underlying provider will assume that
+read operations against the CQ will pass in an array of the corresponding
+structure.  The CQ data formats are designed such that a structure that
+reports more information can be cast to one that reports less.
+
+## Reading Completions (fi_cq_read)
+
+Completions may be read from a CQ by using one of the non-blocking calls,
+fi_cq_read / fi_cq_readfrom, or one of the blocking calls, fi_cq_sread /
+fi_cq_sreadfrom. Regardless of which call is used, applications pass in
+an array of completion structures based on the selected CQ format. The
+CQ interfaces are optimized for batch completion processing, allowing the
+application to retrieve multiple completions from a single read call.
+The difference between the read and readfrom calls is that readfrom
+returns source addressing data, if available. The readfrom derivative
+of the calls is only useful for unconnected endpoints, and only if the
+corresponding endpoint has been configured with the FI_SOURCE capability.
+
+FI_SOURCE requires that the provider use the source address available
+in the raw completion data, such as the packet's source address, to retrieve
+a matching entry in the endpoint’s address vector. Applications that carry
+some sort of source identifier as part of their data packets can avoid
+ the overhead associated with using FI_SOURCE.
+
+### Retrieving Errors
+
+Because the selected completion structure is insufficient to report all
+data necessary to debug or handle an operation that completes in error,
+failed operations are reported using a separate fi_cq_readerr() function.
+This call takes as input a CQ error entry structure, which allows the provider
+to report more information regarding the reason for the failure.
+
+```
+/* read error prototype */
+fi_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf, uint64_t flags);
+
+/* error data structure */
+struct fi_cq_err_entry {
+    void      *op_context;
+    uint64_t  flags;
+    size_t    len;
+    void      *buf;
+    uint64_t  data;
+    uint64_t  tag;
+    size_t    olen;
+    int       err;
+    int       prov_errno;
+    void      *err_data;
+    size_t    err_data_size;
+};
+
+/* Sample error handling */
+struct fi_cq_msg_entry entry;
+struct fi_cq_err_entry err_entry;
+int ret;
+
+ret = fi_cq_read(cq, &entry, 1);
+if (ret == -FI_EAVAIL)
+    ret = fi_cq_readerr(cq, &err_entry, 0);
+```
+
+As illustrated, if an error entry has been inserted into the completion
+ queue, then attempting to read the CQ will result in the read call
+ returning -FI_EAVAIL (error available).  This indicates that the application
+ must use the fi_cq_readerr() call to remove the failed operation's
+ completion information before other completions can be reaped from the CQ.
+
+A fabric error code regarding the failure is reported as the err field
+in the fi_cq_err_entry structure.  A provider specific error code is also
+available through the prov_errno field.  This field can be decoded into a
+displayable string using the fi_cq_strerror() routine. The err_data
+field is provider specific data that assists the provider in decoding
+the reason for the failure.
+
+# Address Vectors (fid_av)
+
+A primary goal of address vectors is to allow applications to communicate with
+thousands to millions of peers while minimizing the amount of data needed to
+store peer addressing information. It pushes fabric specific addressing details
+away from the application to the provider. This allows the provider to optimize
+how it converts addresses into routing data, and enables data compression
+techniques that may be difficult for an application to achieve without being
+aware of low-level fabric addressing details. For example, providers may be able
+to algorithmically calculate addressing components, rather than storing the data
+locally. Additionally, providers can communicate with resource management
+entities or fabric manager agents to obtain quality of service or other
+information about the fabric, in order to improve network utilization.
+
+An equally important objective is ensuring that the resulting interfaces,
+particularly data transfer operations, are fast and easy to use. Conceptually,
+an address vector converts an endpoint address into an fi_addr_t. The fi_addr_t
+(fabric interface address datatype) is a 64-bit value that is used in all
+‘fast-path’ operations – data transfers and completions.
+
+Address vectors are associated with domain objects. This allows providers to
+implement portions of an address vector, such as quality of service mappings,
+in hardware.
+
+## AV Type (fi_av_type)
+
+There are two types of address vectors. The type refers to the format of the
+returned fi_addr_t values for addresses that are inserted into the AV. With
+type FI_AV_TABLE, returned addresses are simple indices, and developers may
+think of the AV as an array of addresses. Each address that is inserted into
+the AV is mapped to the index of the next free array slot. The advantage of
+FI_AV_TABLE is that applications can refer to peers using a simple index,
+eliminating an application’s need to store any addressing data. I.e. the
+application can generate the fi_addr_t values themselves.  This type maps
+well to applications, such as MPI, where a peer is referenced by rank.
+
+The second type is FI_AV_MAP. This type does not define any specific format
+for the fi_addr_t value. Applications that use type map are required to provide
+the correct fi_addr_t for a given peer when issuing a data transfer operation.
+The advantage of FI_AV_MAP is that a provider can use the fi_addr_t to encode
+the target’s address, which avoids retrieving the data from memory. As a simple
+example, consider a fabric that uses TCP/IPv4 based addressing. An fi_addr_t
+is large enough to contain the address, which allows a provider to copy the
+data from the fi_addr_t directly into an outgoing packet.
+
+## Sharing AVs Between Processes
+
+Large scale parallel programs typically run with multiple processes allocated
+on each node. Because these processes communicate with the same set of peers,
+the addressing data needed by each process is the same. Libfabric defines a
+mechanism by which processes running on the same node may share their address
+vectors. This allows a system to maintain a single copy of addressing data,
+rather than one copy per process.
+
+Although libfabric does not require any implementation for how an address
+vector is shared, the interfaces map well to using shared memory. Address
+vectors which will be shared are given an application specific name. How an
+application selects a name that avoid conflicts with unrelated processes,
+or how it communicates the name with peer processes is outside the scope of
+libfabric.
+
+In addition to having a name, a shared AV also has a base map address --
+map_addr. Use of map_addr is only important for address vectors that are of
+type FI_AV_MAP, and allows applications to share fi_addr_t values. From the
+viewpoint of the application, the map_addr is the base value for all fi_addr_t
+values. A common use for map_addr is for the process that creates the initial
+address vector to request a value from the provider, exchange the returned
+map_addr with its peers, and for the peers to open the shared AV using the
+same map_addr. This allows the fi_addr_t values to be stored in shared
+memory that is accessible by all peers.
+
+# Using Native Wait Objects: TryWait
+
+There is an important difference between using libfabric completion objects,
+versus sockets, that may not be obvious from the discussions so far. With
+sockets, the object that is signaled is the same object that abstracts the
+queues, namely the file descriptor. When data is received on a socket, that
+data is placed in a queue associated directly with the fd. Reading from the
+fd retrieves that data. If an application wishes to block until data arrives
+on a socket, it calls select() or poll() on the fd. The fd is signaled when
+a message is received, which releases the blocked thread, allowing it to
+read the fd.
+
+By associating the wait object with the underlying data queue, applications
+are exposed to an interface that is easy to use and race free. If data is
+available to read from the socket at the time select() or poll() is called,
+those calls simply return that the fd is readable.
+
+There are a couple of significant disadvantages to this approach, which have
+been discussed previously, but from different perspectives. The first is that
+every socket must be associated with its own fd. There is no way to share a
+wait object among multiple sockets. (This is a main reason for the development
+of epoll semantics). The second is that the queue is maintained in the kernel,
+so that the select() and poll() calls can check them.
+
+Libfabric allows for the separation of the wait object from the data queues.
+For applications that use libfabric interfaces to wait for events, such as
+fi_cq_sread, this separation is mostly hidden from the application. The
+exception is that applications may receive a signal, but no events are retrieved
+when a queue is read.  This separation allows the queues to reside in the
+application's memory space, while wait objects may still use kernel components.
+A reason for the latter is that wait objects may be signaled as part of
+system interrupt processing, which would go through a kernel driver.
+
+Applications that want to use native wait objects (e.g. file descriptors)
+directly in operating system calls must perform an additional step in their
+processing. In order to handle race conditions that can occur between inserting
+an event into a completion or event object and signaling the corresponding wait
+object, libfabric defines an ‘fi_trywait()’ function. The fi_trywait
+implementation is responsible for handling potential race conditions which could
+result in an application either losing events or hanging. The following example
+demonstrates the use of fi_trywait().
+
+```
+/* Get the native wait object -- an fd in this case */
+fi_control(&cq->fid, FI_GETWAIT, (void *) &fd);
+FD_ZERO(&fds);
+FD_SET(fd, &fds);
+
+while (1) {
+    ret = fi_trywait(fabric, &cq->fid, 1);
+    if (ret == FI_SUCCESS) {
+        /* It’s safe to block on the fd */
+        select(fd + 1, &fds, NULL, &fds, &timeout);
+    } else if (ret == -FI_EAGAIN) {
+        /* Read and process all completions from the CQ */
+        do {
+            ret = fi_cq_read(cq, &comp, 1);
+        } while (ret > 0);
+    } else {
+        /* something really bad happened */
+    }
+}
+```
+
+In this example, the application has allocated a CQ with an fd as its wait
+object. It calls select() on the fd. Before calling select(), the application
+must call fi_trywait() successfully (return code of FI_SUCCESS). Success
+indicates that a blocking operation can now be invoked on the native wait
+object without fear of the application hanging or events being lost. If
+fi_trywait() returns –FI_EAGAIN, it usually indicates that there are queued
+events to process.
+
+# Environment Variables
+
+Environment variables are used by providers to configure internal options
+for optimal performance or memory consumption.  Libfabric provides an interface
+for querying which environment variables are usable, along with an application
+to display the information to a command window.  Although environment variables
+are usually configured by an administrator, an application can query for
+variables programmatically.
+
+```
+/* APIs to query for supported environment variables */
+enum fi_param_type {
+    FI_PARAM_STRING,
+    FI_PARAM_INT,
+    FI_PARAM_BOOL,
+    FI_PARAM_SIZE_T,
+};
+
+struct fi_param {
+    /* The name of the environment variable */
+    const char *name;
+    /* What type of value it stores */
+    enum fi_param_type type;
+    /* A description of how the variable is used */
+    const char *help_string;
+    /* The current value of the variable */
+    const char *value;
+};
+
+int fi_getparams(struct fi_param **params, int *count);
+void fi_freeparams(struct fi_param *params);
+```
+
+The modification of environment variables is typically a tuning activity done
+on larger clusters.  However there are a few values that are useful for
+developers.  These can be seen by executing the fi_info command.
+
+```
+$ fi_info -e
+# FI_LOG_LEVEL: String
+# Specify logging level: warn, trace, info, debug (default: warn)
+
+# FI_LOG_PROV: String
+# Specify specific provider to log (default: all)
+
+# FI_PROVIDER: String
+# Only use specified provider (default: all available)
+```
+
+The fi_info application, which ships with libfabric, can be used to list all
+environment variables for all providers.  The '-e' option will list all
+variables, and the '-g' option can be used to filter the output to only
+those variables with a matching substring.  Variables are documented directly
+in code with the description available as the help_string output.
+
+The FI_LOG_LEVEL can be used to increase the debug output from libfabric and
+the providers.  Note that in the release build of libfabric, debug output from
+data path operations (transmit, receive, and completion processing) may not
+be available.  The FI_PROVIDER variable can be used to enable or disable
+specific providers.  This is useful to ensure that a given provider will be
+used.

--- a/man/fi_tagged.3.md
+++ b/man/fi_tagged.3.md
@@ -112,6 +112,10 @@ tag with the ignored bits masked out.  This can be stated as:
 
 ```c
 send_tag & ~ignore == recv_tag & ~ignore
+
+or
+
+send_tag | ignore == recv_tag | ignore
 ```
 
 In general, message tags are checked against receive buffers in the

--- a/man/man7/fi_arch.7
+++ b/man/man7/fi_arch.7
@@ -1,0 +1,1 @@
+update me

--- a/man/man7/fi_guide.7
+++ b/man/man7/fi_guide.7
@@ -1,0 +1,1 @@
+update me

--- a/man/man7/fi_intro.7
+++ b/man/man7/fi_intro.7
@@ -1,0 +1,1 @@
+update me

--- a/man/man7/fi_setup.7
+++ b/man/man7/fi_setup.7
@@ -1,0 +1,1 @@
+update me


### PR DESCRIPTION
Relocate and update the ofi-guide from the adjacent git repo to integrate with the libfabric man pages.  This will make it easier to keep it in sync with API updates and avoid duplicate text between the guide and other man pages.

Update man pages to align with guide, expanding descriptions as needed, with appropriate references between man pages. Remove duplicate and outdated text.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>