### PR TITLE
prov/efa: Remove fi_sendmsg/recvmsg but still use efa_ep's qp and av

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -231,16 +231,6 @@ struct efa_ep {
 	bool			util_ep_initialized;
 };
 
-struct efa_send_wr {
-	struct ibv_send_wr wr;
-	struct ibv_sge sge[];
-};
-
-struct efa_recv_wr {
-	struct ibv_recv_wr wr;
-	struct ibv_sge sge[];
-};
-
 struct efa_av {
 	struct fid_av		*shm_rdm_av;
 	fi_addr_t		shm_rdm_addr_map[EFA_SHM_MAX_AV_COUNT];
@@ -333,7 +323,7 @@ int efa_prov_initialize(void);
 
 void efa_prov_finalize(void);
 
-ssize_t efa_post_flush(struct efa_ep *ep, struct ibv_send_wr **bad_wr);
+ssize_t efa_post_flush(struct efa_ep *ep, struct ibv_send_wr **bad_wr, bool free);
 
 ssize_t efa_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t count, fi_addr_t *src_addr);
 

--- a/prov/efa/src/efa_ep.c
+++ b/prov/efa/src/efa_ep.c
@@ -671,17 +671,18 @@ int efa_ep_open(struct fid_domain *domain_fid, struct fi_info *user_info,
 
 	ep->util_ep_initialized = true;
 
+	/* struct efa_send_wr and efa_recv_wr allocates memory for 2 IOV
+	 * So check with an assert statement that iov_limit is 2 or less
+	 */
+	assert(user_info->tx_attr->iov_limit <= 2);
+
 	ret = ofi_bufpool_create(&ep->send_wr_pool,
-		sizeof(struct efa_send_wr) +
-		user_info->tx_attr->iov_limit * sizeof(struct ibv_sge),
-		16, 0, 1024, 0);
+		sizeof(struct efa_send_wr), 16, 0, 1024, 0);
 	if (ret)
 		goto err_ep_destroy;
 
 	ret = ofi_bufpool_create(&ep->recv_wr_pool,
-		sizeof(struct efa_recv_wr) +
-		user_info->rx_attr->iov_limit * sizeof(struct ibv_sge),
-		16, 0, 1024, 0);
+		sizeof(struct efa_recv_wr), 16, 0, 1024, 0);
 	if (ret)
 		goto err_send_wr_destroy;
 

--- a/prov/efa/src/efa_msg.c
+++ b/prov/efa/src/efa_msg.c
@@ -286,7 +286,6 @@ static void efa_post_send_sgl(struct efa_ep *ep, const struct fi_msg *msg,
 	struct efa_mr *efa_mr;
 	struct ibv_send_wr *wr = &ewr->wr;
 	struct ibv_sge *sge;
-	size_t sgl_idx = 0;
 	uint32_t length;
 	uintptr_t addr;
 	size_t i;
@@ -295,7 +294,7 @@ static void efa_post_send_sgl(struct efa_ep *ep, const struct fi_msg *msg,
 	wr->sg_list = ewr->sge;
 
 	for (i = 0; i < msg->iov_count; i++) {
-		sge = &wr->sg_list[sgl_idx];
+		sge = &wr->sg_list[i];
 		addr = (uintptr_t)msg->msg_iov[i].iov_base;
 		length = msg->msg_iov[i].iov_len;
 
@@ -315,7 +314,6 @@ static void efa_post_send_sgl(struct efa_ep *ep, const struct fi_msg *msg,
 		efa_mr = (struct efa_mr *)msg->desc[i];
 		sge->lkey = efa_mr->ibv_mr->lkey;
 		sge->addr = addr;
-		sgl_idx++;
 	}
 }
 


### PR DESCRIPTION
For SHM EP, use fi_sendv and fi_recvv
For EFA EP
* Allocate ibv_send_wr and ibv_recv_wr in rxr_pkt_entry
* Still use efa_ep->qp, efa_ep->av and efa_ep->xmit_more_wr*
* Directly call efa_post_flush or ibv_post_recv in rxr_pkt_entry.c

Signed-off-by: Sai Sunku <sunkusa@amazon.com>