### PR TITLE
fabtests/pytest/efa: Add CUDA Memory Types to Atomic Test

### DIFF
--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -48,12 +48,13 @@ def test_rdm_tagged_bw_range(cmdline_args, completion_type, memory_type, message
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rdm_atomic(cmdline_args, iteration_type, completion_type):
+def test_rdm_atomic(cmdline_args, iteration_type, completion_type, memory_type):
     from common import ClientServerTest
     # the rdm_atomic test's run time has a high variance when running single c6gn instance.
     # the issue is tracked in:  https://github.com/ofiwg/libfabric/issues/7002
     # to mitigate the issue, set the maximum timeout of fi_rdm_atomic to 1800 seconds.
+
     test = ClientServerTest(cmdline_args, "fi_rdm_atomic", iteration_type, completion_type,
-                            timeout=1800)
+                            memory_type=memory_type, timeout=1800)
     test.run()
 


### PR DESCRIPTION
Add hmem atomic tests for CUDA to atomic tests.

Signed-off-by: Seth Zegelstein <szegel@amazon.com>