### PR TITLE
bsock: A couple of changes to the interface and related to async operations

### DIFF
--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -457,9 +457,9 @@ int ofi_bsock_flush_sync(struct ofi_bsock *bsock);
 /* For sends started asynchronously, the return value will be -EINPROGRESS_ASYNC,
  * and len will be set to the number of bytes that were queued.
  */
-ssize_t ofi_bsock_send(struct ofi_bsock *bsock, const void *buf, size_t *len);
-ssize_t ofi_bsock_sendv(struct ofi_bsock *bsock, const struct iovec *iov,
-			size_t cnt, size_t *len);
+int ofi_bsock_send(struct ofi_bsock *bsock, const void *buf, size_t *len);
+int ofi_bsock_sendv(struct ofi_bsock *bsock, const struct iovec *iov,
+		    size_t cnt, size_t *len);
 int ofi_bsock_recv(struct ofi_bsock *bsock, void *buf, size_t *len);
 int ofi_bsock_recvv(struct ofi_bsock *bsock, struct iovec *iov,
 		    size_t cnt, size_t *len);

--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -452,8 +452,8 @@ static inline size_t ofi_bsock_tosend(struct ofi_bsock *bsock)
 	return ofi_byteq_readable(&bsock->sq);
 }
 
-ssize_t ofi_bsock_flush(struct ofi_bsock *bsock);
-ssize_t ofi_bsock_flush_sync(struct ofi_bsock *bsock);
+int ofi_bsock_flush(struct ofi_bsock *bsock);
+int ofi_bsock_flush_sync(struct ofi_bsock *bsock);
 /* For sends started asynchronously, the return value will be -EINPROGRESS_ASYNC,
  * and len will be set to the number of bytes that were queued.
  */

--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -417,6 +417,7 @@ struct ofi_bsock {
 	size_t zerocopy_size;
 	uint32_t async_index;
 	uint32_t done_index;
+	bool async_prefetch;
 };
 
 static inline void
@@ -430,6 +431,7 @@ ofi_bsock_init(struct ofi_bsock *bsock, struct ofi_sockapi *sockapi,
 	ofi_byteq_init(&bsock->sq, sbuf_size);
 	ofi_byteq_init(&bsock->rq, rbuf_size);
 	bsock->zerocopy_size = SIZE_MAX;
+	bsock->async_prefetch = false;
 
 	/* first async op will wrap back to 0 as the starting index */
 	bsock->async_index = UINT32_MAX;
@@ -465,6 +467,7 @@ int ofi_bsock_recvv(struct ofi_bsock *bsock, struct iovec *iov,
 		    size_t cnt, size_t *len);
 uint32_t ofi_bsock_async_done(const struct fi_provider *prov,
 			      struct ofi_bsock *bsock);
+void ofi_bsock_prefetch_done(struct ofi_bsock *bsock, size_t len);
 
 
 /*

--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -460,9 +460,9 @@ ssize_t ofi_bsock_flush_sync(struct ofi_bsock *bsock);
 ssize_t ofi_bsock_send(struct ofi_bsock *bsock, const void *buf, size_t *len);
 ssize_t ofi_bsock_sendv(struct ofi_bsock *bsock, const struct iovec *iov,
 			size_t cnt, size_t *len);
-ssize_t ofi_bsock_recv(struct ofi_bsock *bsock, void *buf, size_t len);
-ssize_t ofi_bsock_recvv(struct ofi_bsock *bsock, struct iovec *iov,
-			size_t cnt);
+int ofi_bsock_recv(struct ofi_bsock *bsock, void *buf, size_t *len);
+int ofi_bsock_recvv(struct ofi_bsock *bsock, struct iovec *iov,
+		    size_t cnt, size_t *len);
 uint32_t ofi_bsock_async_done(const struct fi_provider *prov,
 			      struct ofi_bsock *bsock);
 

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -157,7 +157,7 @@ struct xnet_active_rx {
 	size_t			hdr_done;
 	size_t			data_left;
 	struct xnet_xfer_entry	*entry;
-	ssize_t			(*handler)(struct xnet_ep *ep);
+	int			(*handler)(struct xnet_ep *ep);
 	void			*claim_ctx;
 };
 
@@ -323,7 +323,7 @@ int xnet_init_progress(struct xnet_progress *progress, struct fi_info *info);
 void xnet_close_progress(struct xnet_progress *progress);
 int xnet_start_progress(struct xnet_progress *progress);
 void xnet_stop_progress(struct xnet_progress *progress);
-ssize_t xnet_start_recv(struct xnet_ep *ep, struct xnet_xfer_entry *rx_entry);
+int xnet_start_recv(struct xnet_ep *ep, struct xnet_xfer_entry *rx_entry);
 
 void xnet_progress(struct xnet_progress *progress, bool clear_signal);
 void xnet_run_progress(struct xnet_progress *progress, bool clear_signal);

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -278,21 +278,22 @@ static ssize_t xnet_recv_msg_data(struct xnet_ep *ep)
 {
 	struct xnet_xfer_entry *rx_entry;
 	ssize_t ret;
+	size_t len;
 
 	assert(xnet_progress_locked(xnet_ep2_progress(ep)));
 	if (!ep->cur_rx.data_left)
 		return FI_SUCCESS;
 
 	rx_entry = ep->cur_rx.entry;
-	ret = ofi_bsock_recvv(&ep->bsock, rx_entry->iov, rx_entry->iov_cnt);
+	ret = ofi_bsock_recvv(&ep->bsock, rx_entry->iov, rx_entry->iov_cnt, &len);
 	if (ret < 0)
 		return ret;
 
-	ep->cur_rx.data_left -= ret;
+	ep->cur_rx.data_left -= len;
 	if (!ep->cur_rx.data_left)
 		return FI_SUCCESS;
 
-	ofi_consume_iov(rx_entry->iov, &rx_entry->iov_cnt, ret);
+	ofi_consume_iov(rx_entry->iov, &rx_entry->iov_cnt, len);
 	if (!rx_entry->iov_cnt || !rx_entry->iov[0].iov_len)
 		return -FI_ETRUNC;
 
@@ -857,11 +858,11 @@ static ssize_t xnet_recv_hdr(struct xnet_ep *ep)
 next_hdr:
 	buf = (uint8_t *) &ep->cur_rx.hdr + ep->cur_rx.hdr_done;
 	len = ep->cur_rx.hdr_len - ep->cur_rx.hdr_done;
-	ret = ofi_bsock_recv(&ep->bsock, buf, len);
+	ret = ofi_bsock_recv(&ep->bsock, buf, &len);
 	if (ret < 0)
 		return ret;
 
-	ep->cur_rx.hdr_done += ret;
+	ep->cur_rx.hdr_done += len;
 	if (ep->cur_rx.hdr_done == sizeof(ep->cur_rx.hdr.base_hdr)) {
 		assert(ep->cur_rx.hdr_len == sizeof(ep->cur_rx.hdr.base_hdr));
 

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -262,8 +262,6 @@ static ssize_t xnet_send_msg(struct xnet_ep *ep)
 		 */
 		tx_entry->async_index = ep->bsock.async_index;
 		tx_entry->ctrl_flags |= XNET_ASYNC;
-	} else {
-		len = ret;
 	}
 
 	ep->cur_tx.data_left -= len;

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -223,7 +223,7 @@ struct tcpx_cur_rx {
 	size_t			hdr_done;
 	size_t			data_left;
 	struct tcpx_xfer_entry	*entry;
-	ssize_t			(*handler)(struct tcpx_ep *ep);
+	int			(*handler)(struct tcpx_ep *ep);
 };
 
 struct tcpx_cur_tx {

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -82,20 +82,21 @@ static ssize_t tcpx_recv_msg_data(struct tcpx_ep *ep)
 {
 	struct tcpx_xfer_entry *rx_entry;
 	ssize_t ret;
+	size_t len;
 
 	if (!ep->cur_rx.data_left)
 		return FI_SUCCESS;
 
 	rx_entry = ep->cur_rx.entry;
-	ret = ofi_bsock_recvv(&ep->bsock, rx_entry->iov, rx_entry->iov_cnt);
+	ret = ofi_bsock_recvv(&ep->bsock, rx_entry->iov, rx_entry->iov_cnt, &len);
 	if (ret < 0)
 		return ret;
 
-	ep->cur_rx.data_left -= ret;
+	ep->cur_rx.data_left -= len;
 	if (!ep->cur_rx.data_left)
 		return FI_SUCCESS;
 
-	ofi_consume_iov(rx_entry->iov, &rx_entry->iov_cnt, ret);
+	ofi_consume_iov(rx_entry->iov, &rx_entry->iov_cnt, len);
 	if (!rx_entry->iov_cnt || !rx_entry->iov[0].iov_len)
 		return -FI_ETRUNC;
 
@@ -649,11 +650,11 @@ static ssize_t tcpx_recv_hdr(struct tcpx_ep *ep)
 next_hdr:
 	buf = (uint8_t *) &ep->cur_rx.hdr + ep->cur_rx.hdr_done;
 	len = ep->cur_rx.hdr_len - ep->cur_rx.hdr_done;
-	ret = ofi_bsock_recv(&ep->bsock, buf, len);
+	ret = ofi_bsock_recv(&ep->bsock, buf, &len);
 	if (ret < 0)
 		return ret;
 
-	ep->cur_rx.hdr_done += ret;
+	ep->cur_rx.hdr_done += len;
 	if (ep->cur_rx.hdr_done == sizeof(ep->cur_rx.hdr.base_hdr)) {
 		assert(ep->cur_rx.hdr_len == sizeof(ep->cur_rx.hdr.base_hdr));
 

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -66,8 +66,6 @@ static ssize_t tcpx_send_msg(struct tcpx_ep *ep)
 		 */
 		tx_entry->async_index = ep->bsock.async_index;
 		tx_entry->ctrl_flags |= TCPX_ASYNC;
-	} else {
-		len = ret;
 	}
 
 	ep->cur_tx.data_left -= len;

--- a/src/common.c
+++ b/src/common.c
@@ -1196,22 +1196,25 @@ int ofi_bsock_flush_sync(struct ofi_bsock *bsock)
 	return ofi_bsock_tosend(bsock) ? -FI_EAGAIN : 0;
 }
 
-ssize_t ofi_bsock_send(struct ofi_bsock *bsock, const void *buf, size_t *len)
+int ofi_bsock_send(struct ofi_bsock *bsock, const void *buf, size_t *len)
 {
 	size_t avail;
 	ssize_t ret;
+	int err;
 
 	avail = ofi_bsock_tosend(bsock);
 	if (avail) {
 		if (*len < ofi_byteq_writeable(&bsock->sq)) {
 			ofi_byteq_write(&bsock->sq, buf, *len);
-			ret = ofi_bsock_flush(bsock);
-			return !ret || ret == -FI_EAGAIN ? *len : ret;
+			err = ofi_bsock_flush(bsock);
+			return !err || err == -FI_EAGAIN ? 0 : err;
 		}
 
-		ret = ofi_bsock_flush(bsock);
-		if (ret)
-			return ret;
+		err = ofi_bsock_flush(bsock);
+		if (err) {
+			*len = 0;
+			return err;
+		}
 	}
 
 	assert(!ofi_bsock_tosend(bsock));
@@ -1235,19 +1238,22 @@ ssize_t ofi_bsock_send(struct ofi_bsock *bsock, const void *buf, size_t *len)
 		if (OFI_SOCK_TRY_SND_RCV_AGAIN(ofi_sockerr()) &&
 		    *len < ofi_byteq_writeable(&bsock->sq)) {
 			ofi_byteq_write(&bsock->sq, buf, *len);
-			return *len;
+			return 0;
 		}
+
+		*len = 0;
 		return ofi_sockerr() == EPIPE ? -FI_ENOTCONN : -ofi_sockerr();
 	}
 	*len = ret;
-	return ret;
+	return 0;
 }
 
-ssize_t ofi_bsock_sendv(struct ofi_bsock *bsock, const struct iovec *iov,
-			size_t cnt, size_t *len)
+int ofi_bsock_sendv(struct ofi_bsock *bsock, const struct iovec *iov,
+		    size_t cnt, size_t *len)
 {
 	size_t avail;
 	ssize_t ret;
+	int err;
 
 	if (cnt == 1) {
 		*len = iov[0].iov_len;
@@ -1259,13 +1265,15 @@ ssize_t ofi_bsock_sendv(struct ofi_bsock *bsock, const struct iovec *iov,
 	if (avail) {
 		if (*len < ofi_byteq_writeable(&bsock->sq)) {
 			ofi_byteq_writev(&bsock->sq, iov, cnt);
-			ret = ofi_bsock_flush(bsock);
-			return !ret || ret == -FI_EAGAIN ? *len : ret;
+			err = ofi_bsock_flush(bsock);
+			return !err || err == -FI_EAGAIN ? 0 : err;
 		}
 
-		ret = ofi_bsock_flush(bsock);
-		if (ret)
-			return ret;
+		err = ofi_bsock_flush(bsock);
+		if (err) {
+			*len = 0;
+			return err;
+		}
 	}
 
 	assert(!ofi_bsock_tosend(bsock));
@@ -1290,12 +1298,14 @@ ssize_t ofi_bsock_sendv(struct ofi_bsock *bsock, const struct iovec *iov,
 		if (OFI_SOCK_TRY_SND_RCV_AGAIN(ofi_sockerr()) &&
 		    *len < ofi_byteq_writeable(&bsock->sq)) {
 			ofi_byteq_writev(&bsock->sq, iov, cnt);
-			return *len;
+			return 0;
 		}
+
+		*len = 0;
 		return ofi_sockerr() == EPIPE ? -FI_ENOTCONN : -ofi_sockerr();
 	}
 	*len = ret;
-	return ret;
+	return 0;
 }
 
 int ofi_bsock_recv(struct ofi_bsock *bsock, void *buf, size_t *len)

--- a/src/common.c
+++ b/src/common.c
@@ -1310,7 +1310,7 @@ int ofi_bsock_sendv(struct ofi_bsock *bsock, const struct iovec *iov,
 
 int ofi_bsock_recv(struct ofi_bsock *bsock, void *buf, size_t *len)
 {
-	size_t bytes, avail;
+	size_t bytes, avail = 0;
 	ssize_t ret;
 
 	bytes = ofi_byteq_read(&bsock->rq, buf, *len);
@@ -1348,17 +1348,22 @@ int ofi_bsock_recv(struct ofi_bsock *bsock, void *buf, size_t *len)
 	}
 
 out:
-	assert(ret != -OFI_EINPROGRESS_URING);
 	*len = bytes;
 	if (*len)
 		return 0;
+
+	if (ret == -OFI_EINPROGRESS_URING) {
+		assert(!bsock->async_prefetch);
+		bsock->async_prefetch = avail;
+		return ret;
+	}
 	return ret ? -ofi_sockerr(): -FI_ENOTCONN;
 }
 
 int ofi_bsock_recvv(struct ofi_bsock *bsock, struct iovec *iov, size_t cnt,
 		    size_t *len)
 {
-	size_t bytes, avail;
+	size_t bytes, avail = 0;
 	ssize_t ret;
 
 	if (cnt == 1) {
@@ -1409,11 +1414,26 @@ int ofi_bsock_recvv(struct ofi_bsock *bsock, struct iovec *iov, size_t cnt,
 		return 0;
 	}
 out:
-	assert(ret != -OFI_EINPROGRESS_URING);
 	*len = bytes;
 	if (*len)
 		return 0;
+
+	if (ret == -OFI_EINPROGRESS_URING) {
+		assert(!bsock->async_prefetch);
+		bsock->async_prefetch = avail;
+		return ret;
+	}
 	return ret ? -ofi_sockerr(): -FI_ENOTCONN;
+}
+
+void ofi_bsock_prefetch_done(struct ofi_bsock *bsock, size_t len)
+{
+	assert(ofi_byteq_writeable(&bsock->rq) >= len);
+	assert(bsock->async_prefetch);
+
+	ofi_byteq_add(&bsock->rq, len);
+	assert(ofi_bsock_readable(bsock));
+	bsock->async_prefetch = false;
 }
 
 #ifdef MSG_ZEROCOPY

--- a/src/common.c
+++ b/src/common.c
@@ -1140,7 +1140,7 @@ void ofi_byteq_writev(struct ofi_byteq *byteq, const struct iovec *iov,
 }
 
 
-ssize_t ofi_bsock_flush(struct ofi_bsock *bsock)
+int ofi_bsock_flush(struct ofi_bsock *bsock)
 {
 	size_t avail;
 	ssize_t ret;
@@ -1164,14 +1164,13 @@ ssize_t ofi_bsock_flush(struct ofi_bsock *bsock)
 		if (err == EWOULDBLOCK)
 			return -FI_EAGAIN;
 		return -err;
-	} else {
-		ofi_byteq_consume(&bsock->sq, (size_t) ret);
 	}
 
+	ofi_byteq_consume(&bsock->sq, (size_t) ret);
 	return ofi_bsock_tosend(bsock) ? -FI_EAGAIN : 0;
 }
 
-ssize_t ofi_bsock_flush_sync(struct ofi_bsock *bsock)
+int ofi_bsock_flush_sync(struct ofi_bsock *bsock)
 {
 	size_t avail;
 	ssize_t ret;
@@ -1191,10 +1190,9 @@ ssize_t ofi_bsock_flush_sync(struct ofi_bsock *bsock)
 		if (err == EWOULDBLOCK)
 			return -FI_EAGAIN;
 		return -err;
-	} else {
-		ofi_byteq_consume(&bsock->sq, (size_t) ret);
 	}
 
+	ofi_byteq_consume(&bsock->sq, (size_t) ret);
 	return ofi_bsock_tosend(bsock) ? -FI_EAGAIN : 0;
 }
 


### PR DESCRIPTION
This PR implements a couple of changes to the bsock API in order to support async operations. 
These changes were initially implemented as part of #8262 but I think they deserve their own PR.

The most significant change is the conversion of the return type for the bsock interface. 
The functions now return a int (instead of a size_t) where a value of 0 means success and a value < 0 corresponds to a failure.
The number of bytes received and available for processing is returned in the input/output argument *len.
