### PR TITLE
prov/efa: rename rdm_peer,efa_peer,rxr_peer to efa_rdm_peer

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -48,6 +48,7 @@ _efa_files = \
 	prov/efa/src/efa_prov_info.c \
 	prov/efa/src/efa_fork_support.c \
 	prov/efa/src/efa_tp_def.c \
+	prov/efa/src/rxr/efa_rdm_peer.c \
 	prov/efa/src/rxr/rxr_prov.c	\
 	prov/efa/src/rxr/rxr_env.c	\
 	prov/efa/src/rxr/rxr_cq.c	\
@@ -81,6 +82,7 @@ _efa_headers = \
 	prov/efa/src/efa_cq.h \
 	prov/efa/src/efa_tp_def.h \
 	prov/efa/src/efa_tp.h \
+	prov/efa/src/rxr/efa_rdm_peer.h \
 	prov/efa/src/rxr/rxr.h \
 	prov/efa/src/rxr/rxr_env.h \
 	prov/efa/src/rxr/rxr_cntr.h \

--- a/prov/efa/src/rxr/efa_rdm_peer.c
+++ b/prov/efa/src/rxr/efa_rdm_peer.c
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2019-2023 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "efa.h"
+
+/**
+ * @brief initialize a rdm peer
+ *
+ * @param[in,out]	peer	rdm peer
+ * @param[in]		ep	rdm endpoint
+ * @param[in]		conn	efa conn object
+ * @relates efa_rdm_peer
+ */
+void efa_rdm_peer_construct(struct efa_rdm_peer *peer, struct rxr_ep *ep, struct efa_conn *conn)
+{
+	memset(peer, 0, sizeof(struct efa_rdm_peer));
+
+	peer->efa_fiaddr = conn->fi_addr;
+	peer->is_self = efa_is_same_addr((struct efa_ep_addr *)ep->core_addr,
+					 conn->ep_addr);
+	peer->num_read_msg_in_flight = 0;
+	peer->num_runt_bytes_in_flight = 0;
+	ofi_recvwin_buf_alloc(&peer->robuf, rxr_env.recvwin_size);
+	dlist_init(&peer->outstanding_tx_pkts);
+	dlist_init(&peer->rx_unexp_list);
+	dlist_init(&peer->rx_unexp_tagged_list);
+	dlist_init(&peer->tx_entry_list);
+	dlist_init(&peer->rx_entry_list);
+}
+
+/**
+ * @brief clear resources accociated with a peer
+ *
+ * release reorder buffer, tx_entry list and rx_entry list of a peer
+ *
+ * @param[in,out]	peer 	rdm peer
+ * @relates efa_rdm_peer
+ */
+void efa_rdm_peer_destruct(struct efa_rdm_peer *peer, struct rxr_ep *ep)
+{
+	struct dlist_entry *tmp;
+	struct rxr_op_entry *tx_entry;
+	struct rxr_op_entry *rx_entry;
+	struct rxr_pkt_entry *pkt_entry;
+	/*
+	 * TODO: Add support for wait/signal until all pending messages have
+	 * been sent/received so we do not attempt to complete a data transfer
+	 * or internal transfer after the EP is shutdown.
+	 */
+	if ((peer->flags & EFA_RDM_PEER_REQ_SENT) &&
+	    !(peer->flags & EFA_RDM_PEER_HANDSHAKE_RECEIVED))
+		FI_WARN_ONCE(&rxr_prov, FI_LOG_EP_CTRL, "Closing EP with unacked CONNREQs in flight\n");
+
+	if (peer->robuf.pending)
+		ofi_recvwin_free(&peer->robuf);
+
+	if (!ep) {
+		/* ep is NULL means the endpoint has been closed.
+		 * In this case there is no need to proceed because
+		 * all the tx_entry, rx_entry, pkt_entry has been released.
+		 */
+		return;
+	}
+
+	/* we cannot release outstanding TX packets because device
+	 * will report completion of these packets later. Setting
+	 * the address to FI_ADDR_NOTAVAIL, so rxr_ep_get_peer()
+	 * will return NULL for the address, so the completion will
+	 * be ignored.
+	 */
+	dlist_foreach_container(&peer->outstanding_tx_pkts,
+				struct rxr_pkt_entry,
+				pkt_entry, entry) {
+		pkt_entry->addr = FI_ADDR_NOTAVAIL;
+	}
+
+	dlist_foreach_container_safe(&peer->tx_entry_list,
+				     struct rxr_op_entry,
+				     tx_entry, peer_entry, tmp) {
+		rxr_release_tx_entry(ep, tx_entry);
+	}
+
+	dlist_foreach_container_safe(&peer->rx_entry_list,
+				     struct rxr_op_entry,
+				     rx_entry, peer_entry, tmp) {
+		rxr_release_rx_entry(ep, rx_entry);
+	}
+
+	if (peer->flags & EFA_RDM_PEER_HANDSHAKE_QUEUED)
+		dlist_remove(&peer->handshake_queued_entry);
+
+	if (peer->flags & EFA_RDM_PEER_IN_BACKOFF)
+		dlist_remove(&peer->rnr_backoff_entry);
+
+#ifdef ENABLE_EFA_POISONING
+	rxr_poison_mem_region(peer, sizeof(struct efa_rdm_peer));
+#endif
+}

--- a/prov/efa/src/rxr/efa_rdm_peer.h
+++ b/prov/efa/src/rxr/efa_rdm_peer.h
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2019-2023 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef EFA_RDM_PEER_H
+#define EFA_RDM_PEER_H
+
+#include "rxr.h"
+
+#define EFA_RDM_PEER_REQ_SENT BIT_ULL(0) /**< A REQ packet has been sent to the peer (peer should send a handshake back) */
+#define EFA_RDM_PEER_HANDSHAKE_SENT BIT_ULL(1) /**< a handshake packet has been sent to the peer */
+#define EFA_RDM_PEER_HANDSHAKE_RECEIVED BIT_ULL(2) /**< a handshaked packet has been received from this peer */
+#define EFA_RDM_PEER_IN_BACKOFF BIT_ULL(3) /**< peer is in backoff mode due to RNR (Endpoint should not send packet to this peer) */
+/**
+ * @details
+ * FI_EAGAIN error was encountered when sending handsahke to this peer,
+ * the peer was put in rxr_ep->handshake_queued_peer_list.
+ * Progress engine will retry sending handshake.
+ */
+#define EFA_RDM_PEER_HANDSHAKE_QUEUED      BIT_ULL(5)
+
+struct efa_rdm_peer {
+	bool is_self;			/**< flag indicating whether the peer is the endpoint itself */
+	bool is_local;			/**< flag indicating wehther the peer is local (on the same instance) */
+	fi_addr_t efa_fiaddr;		/**< libfabric addr from efa provider's perspective */
+	fi_addr_t shm_fiaddr;		/**< libfabric addr from shm provider's perspective */
+	/**
+	 * @brief reorder buffer
+	 * 
+	 * @details temporarily hold packets that are out-of-order, whose msg_id is larger that the one EP is expecting from the peer
+	 */
+	struct rxr_robuf robuf;		
+	uint32_t next_msg_id;		/**< msg_id to be assigned to the next packet sent to the peer. */
+	uint32_t flags;			/**< flags such as #EFA_RDM_PEER_REQ_SENT #EFA_RDM_PEER_HANDSHAKE_SENT #EFA_RDM_PEER_HANDSHAKE_RECEIVED and #EFA_RDM_PEER_IN_BACKOFF */
+	uint32_t nextra_p3;		/**< number of members in extra_info plus 3 (See protocol v4 document section 2.1) */
+	uint64_t extra_info[RXR_MAX_NUM_EXINFO]; /**< the feature/request flag for each version (See protocol v4 document section 2.1)*/
+	size_t efa_outstanding_tx_ops;	/**< tracks outstanding tx ops (send/read) to this peer on EFA device */
+	size_t shm_outstanding_tx_ops;  /**< tracks outstanding tx ops (send/read/write/atomic) to this peer on SHM */
+	struct dlist_entry outstanding_tx_pkts; /**< a list of outstanding pkts sent to the peer */
+	uint64_t rnr_backoff_begin_ts;	/**< timestamp for RNR backoff period begin */
+	uint64_t rnr_backoff_wait_time;	/**< how long the RNR backoff period last */
+	int rnr_queued_pkt_cnt;		/**< queued RNR packet count */
+	struct dlist_entry rnr_backoff_entry;	/**< linked to rxr_ep peer_backoff_list */
+	struct dlist_entry handshake_queued_entry; /**< linked with rxr_ep->handshake_queued_peer_list */
+	struct dlist_entry rx_unexp_list; /**< a list of unexpected untagged rx_entry for this peer */
+	struct dlist_entry rx_unexp_tagged_list; /**< a list of unexpected tagged rx_entry for this peer */
+	struct dlist_entry tx_entry_list; /**< a list of tx_entry related to this peer */
+	struct dlist_entry rx_entry_list; /**< a list of rx_entry relased to this peer */
+
+	/**
+	 * @brief number of bytes that has been sent as part of runting protocols
+	 * @details this value is capped by rxr_env.efa_runt_size
+	 */
+	int64_t num_runt_bytes_in_flight;
+
+	/**
+	 * @brief number of messages that are using read based protocol
+	 */
+	int64_t num_read_msg_in_flight;
+};
+
+static inline
+bool efa_rdm_peer_support_rdma_read(struct efa_rdm_peer *peer)
+{
+	/* RDMA READ is an extra feature defined in version 4 (the base version).
+	 * Because it is an extra feature, an EP will assume the peer does not support
+	 * it before a handshake packet was received.
+	 */
+	return (peer->flags & EFA_RDM_PEER_HANDSHAKE_RECEIVED) &&
+	       (peer->extra_info[0] & RXR_EXTRA_FEATURE_RDMA_READ);
+}
+
+static inline
+bool efa_rdm_peer_support_delivery_complete(struct efa_rdm_peer *peer)
+{
+	/* FI_DELIVERY_COMPLETE is an extra feature defined
+	 * in version 4 (the base version).
+	 * Because it is an extra feature,
+	 * an EP will assume the peer does not support
+	 * it before a handshake packet was received.
+	 */
+	return (peer->flags & EFA_RDM_PEER_HANDSHAKE_RECEIVED) &&
+	       (peer->extra_info[0] & RXR_EXTRA_FEATURE_DELIVERY_COMPLETE);
+}
+
+static inline
+bool efa_both_support_rdma_read(struct rxr_ep *ep, struct efa_rdm_peer *peer)
+{
+	return efa_domain_support_rdma_read(rxr_ep_domain(ep)) &&
+	       (peer->is_self || efa_rdm_peer_support_rdma_read(peer));
+}
+
+/**
+ * @brief determines whether a peer needs the endpoint to include
+ * raw address int the req packet header.
+ *
+ * There are two cases a peer need the raw address in REQ packet header:
+ *
+ * 1. the initial packets to a peer should include the raw address,
+ * because the peer might not have ep's address in its address vector
+ * causing the peer to be unable to send packet back. Normally, after
+ * an endpoint received a hanshake packet from a peer, it can stop
+ * including raw address in packet header.
+ *
+ * 2. If the peer requested to keep the header length constant through
+ * out the communiciton, endpoint will include the raw address in the
+ * header even afer received handshake from a header to conform to the
+ * request. Usually, peer has this request because they are in zero
+ * copy receive mode, which requires the packet header size to remain
+ * the same.
+ *
+ * @params[in]	peer	pointer to rdm_peer
+ * @return	a boolean indicating whether the peer needs the raw address header
+ */
+static inline
+bool efa_rdm_peer_need_raw_addr_hdr(struct efa_rdm_peer *peer)
+{
+	if (OFI_UNLIKELY(!(peer->flags & EFA_RDM_PEER_HANDSHAKE_RECEIVED)))
+		return true;
+
+	return peer->extra_info[0] & RXR_EXTRA_REQUEST_CONSTANT_HEADER_LENGTH;
+}
+
+/**
+ * @brief determines whether a peer needs the endpoint to include
+ * connection ID (connid) in packet header.
+ *
+ * Connection ID is a 4 bytes random integer identifies an endpoint.
+ * Including connection ID in a packet's header allows peer to
+ * identify sender of the packet. It is necessary because device
+ * only report GID+QPN of a received packet, while QPN may be reused
+ * accross device endpoint teardown and initialization.
+ *
+ * EFA uses qkey as connection ID.
+ *
+ * @params[in]	peer	pointer to rdm_peer
+ * @return	a boolean indicating whether the peer needs connection ID
+ */
+static inline
+bool efa_rdm_peer_need_connid(struct efa_rdm_peer *peer)
+{
+	return (peer->flags & EFA_RDM_PEER_HANDSHAKE_RECEIVED) &&
+	       (peer->extra_info[0] & RXR_EXTRA_REQUEST_CONNID_HEADER);
+}
+
+struct efa_conn;
+
+void efa_rdm_peer_construct(struct efa_rdm_peer *peer, struct rxr_ep *ep, struct efa_conn *conn);
+
+void efa_rdm_peer_destruct(struct efa_rdm_peer *peer, struct rxr_ep *ep);
+
+
+
+#endif /* EFA_RDM_PEER_H */

--- a/prov/efa/src/rxr/rxr_atomic.c
+++ b/prov/efa/src/rxr/rxr_atomic.c
@@ -125,7 +125,7 @@ ssize_t rxr_atomic_generic_efa(struct rxr_ep *rxr_ep,
 			       uint32_t op, uint64_t flags)
 {
 	struct rxr_op_entry *tx_entry;
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 	bool delivery_complete_requested;
 	ssize_t err;
 	static int req_pkt_type_list[] = {
@@ -147,7 +147,7 @@ ssize_t rxr_atomic_generic_efa(struct rxr_ep *rxr_ep,
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
 	assert(peer);
 
-	if (peer->flags & RXR_PEER_IN_BACKOFF) {
+	if (peer->flags & EFA_RDM_PEER_IN_BACKOFF) {
 		err = -FI_EAGAIN;
 		goto out;
 	}
@@ -182,11 +182,11 @@ ssize_t rxr_atomic_generic_efa(struct rxr_ep *rxr_ep,
 			goto out;
 		}
 
-		if (!(peer->flags & RXR_PEER_HANDSHAKE_RECEIVED)) {
+		if (!(peer->flags & EFA_RDM_PEER_HANDSHAKE_RECEIVED)) {
 			rxr_release_tx_entry(rxr_ep, tx_entry);
 			err = -FI_EAGAIN;
 			goto out;
-		} else if (!rxr_peer_support_delivery_complete(peer)) {
+		} else if (!efa_rdm_peer_support_delivery_complete(peer)) {
 			rxr_release_tx_entry(rxr_ep, tx_entry);
 			err = -FI_EOPNOTSUPP;
 			goto out;
@@ -238,7 +238,7 @@ rxr_atomic_inject(struct fid_ep *ep,
 	struct fi_msg_atomic msg;
 
 	struct rxr_ep *rxr_ep;
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 
 	rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid.fid);
 	peer = rxr_ep_get_peer(rxr_ep, dest_addr);
@@ -280,7 +280,7 @@ rxr_atomic_writemsg(struct fid_ep *ep,
 {
 	struct fi_msg_atomic shm_msg;
 	struct rxr_ep *rxr_ep;
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 	struct fi_rma_ioc rma_iov[RXR_IOV_LIMIT];
 	void *shm_desc[RXR_IOV_LIMIT];
 
@@ -352,7 +352,7 @@ rxr_atomic_readwritemsg(struct fid_ep *ep,
 			uint64_t flags)
 {
 	struct rxr_ep *rxr_ep;
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 	struct fi_msg_atomic shm_msg;
 	struct fi_rma_ioc shm_rma_iov[RXR_IOV_LIMIT];
 	void *shm_desc[RXR_IOV_LIMIT];
@@ -443,7 +443,7 @@ rxr_atomic_compwritemsg(struct fid_ep *ep,
 			uint64_t flags)
 {
 	struct rxr_ep *rxr_ep;
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 	struct fi_msg_atomic shm_msg;
 	struct fi_rma_ioc shm_rma_iov[RXR_IOV_LIMIT];
 	void *shm_desc[RXR_IOV_LIMIT];

--- a/prov/efa/src/rxr/rxr_cq.c
+++ b/prov/efa/src/rxr/rxr_cq.c
@@ -231,7 +231,7 @@ void rxr_cq_write_tx_error(struct rxr_ep *ep, struct rxr_op_entry *tx_entry,
 	buflen = sizeof(ep_addr_str);
 	rxr_ep_raw_addr_str(ep, ep_addr_str, &buflen);
 	buflen = sizeof(peer_addr_str);
-	rxr_peer_raw_addr_str(ep, tx_entry->addr, peer_addr_str, &buflen);
+	rxr_ep_get_peer_raw_addr_str(ep, tx_entry->addr, peer_addr_str, &buflen);
 
 	FI_WARN(&rxr_prov, FI_LOG_CQ,
 		"rxr_cq_write_tx_error: err: %d, prov_err: %s (%d) our address: %s, peer address %s\n",
@@ -303,7 +303,7 @@ void rxr_cq_queue_rnr_pkt(struct rxr_ep *ep,
 			  struct dlist_entry *list,
 			  struct rxr_pkt_entry *pkt_entry)
 {
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 
 #if ENABLE_DEBUG
 	dlist_remove(&pkt_entry->dbg_entry);
@@ -341,12 +341,12 @@ void rxr_cq_queue_rnr_pkt(struct rxr_ep *ep,
 	 * Otherwise, we need to put the peer in backoff mode and set up backoff
 	 * begin time and wait time.
 	 */
-	if (peer->flags & RXR_PEER_IN_BACKOFF) {
+	if (peer->flags & EFA_RDM_PEER_IN_BACKOFF) {
 		peer->rnr_backoff_begin_ts = ofi_gettime_us();
 		return;
 	}
 
-	peer->flags |= RXR_PEER_IN_BACKOFF;
+	peer->flags |= EFA_RDM_PEER_IN_BACKOFF;
 	dlist_insert_tail(&peer->rnr_backoff_entry,
 			  &ep->peer_backoff_list);
 
@@ -494,7 +494,7 @@ void rxr_cq_complete_recv(struct rxr_ep *ep,
 {
 	struct rxr_op_entry *tx_entry = NULL;
 	struct rxr_op_entry *rx_entry = NULL;
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 	bool inject;
 	int err;
 
@@ -598,7 +598,7 @@ void rxr_cq_complete_recv(struct rxr_ep *ep,
 }
 
 int rxr_cq_reorder_msg(struct rxr_ep *ep,
-		       struct rdm_peer *peer,
+		       struct efa_rdm_peer *peer,
 		       struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_pkt_entry *ooo_entry;
@@ -665,7 +665,7 @@ int rxr_cq_reorder_msg(struct rxr_ep *ep,
 }
 
 void rxr_cq_proc_pending_items_in_recvwin(struct rxr_ep *ep,
-					  struct rdm_peer *peer)
+					  struct efa_rdm_peer *peer)
 {
 	struct rxr_pkt_entry *pending_pkt;
 	int ret = 0;

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -85,7 +85,7 @@ int rxr_msg_select_rtm(struct rxr_ep *rxr_ep, struct rxr_op_entry *tx_entry, int
 	int tagged;
 	int eager_rtm, medium_rtm, longcts_rtm, readbase_rtm, iface;
 	size_t eager_rtm_max_data_size;
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 	struct efa_hmem_info *hmem_info;
 	bool delivery_complete_requested;
 
@@ -168,7 +168,7 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *ep, struct rxr_op_entry *tx_entry, int u
 {
 	ssize_t err;
 	int rtm_type;
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 
 	peer = rxr_ep_get_peer(ep, tx_entry->addr);
 	assert(peer);
@@ -201,7 +201,7 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *ep, struct rxr_op_entry *tx_entry, int u
 	 *
 	 * Check handshake packet from peer to verify support status.
 	 */
-	if (!(peer->flags & RXR_PEER_HANDSHAKE_RECEIVED)) {
+	if (!(peer->flags & EFA_RDM_PEER_HANDSHAKE_RECEIVED)) {
 		err = rxr_pkt_trigger_handshake(ep, tx_entry->addr, peer);
 		if (err)
 			return err;
@@ -222,7 +222,7 @@ ssize_t rxr_msg_generic_send(struct fid_ep *ep, const struct fi_msg *msg,
 	struct rxr_ep *rxr_ep;
 	ssize_t err, ret, use_p2p;
 	struct rxr_op_entry *tx_entry;
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 
 	rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid.fid);
 	assert(msg->iov_count <= rxr_ep->tx_iov_limit);
@@ -238,7 +238,7 @@ ssize_t rxr_msg_generic_send(struct fid_ep *ep, const struct fi_msg *msg,
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
 	assert(peer);
 
-	if (peer->flags & RXR_PEER_IN_BACKOFF) {
+	if (peer->flags & EFA_RDM_PEER_IN_BACKOFF) {
 		err = -FI_EAGAIN;
 		goto out;
 	}
@@ -647,7 +647,7 @@ struct rxr_op_entry *rxr_msg_alloc_rx_entry(struct rxr_ep *ep,
 struct rxr_op_entry *rxr_msg_alloc_unexp_rx_entry_for_msgrtm(struct rxr_ep *ep,
 							     struct rxr_pkt_entry **pkt_entry_ptr)
 {
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 	struct rxr_op_entry *rx_entry;
 	struct rxr_pkt_entry *unexp_pkt_entry;
 
@@ -674,7 +674,7 @@ struct rxr_op_entry *rxr_msg_alloc_unexp_rx_entry_for_msgrtm(struct rxr_ep *ep,
 struct rxr_op_entry *rxr_msg_alloc_unexp_rx_entry_for_tagrtm(struct rxr_ep *ep,
 							     struct rxr_pkt_entry **pkt_entry_ptr)
 {
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 	struct rxr_op_entry *rx_entry;
 	struct rxr_pkt_entry *unexp_pkt_entry;
 
@@ -779,7 +779,7 @@ struct rxr_op_entry *rxr_msg_find_unexp_rx_entry(struct rxr_ep *ep, fi_addr_t ad
 	struct rxr_match_info match_info;
 	struct rxr_op_entry *rx_entry;
 	struct dlist_entry *match;
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 
 	peer = (ep->util_ep.caps & FI_DIRECTED_RECV) ? rxr_ep_get_peer(ep, addr) : NULL;
 

--- a/prov/efa/src/rxr/rxr_op_entry.c
+++ b/prov/efa/src/rxr/rxr_op_entry.c
@@ -130,7 +130,7 @@ void rxr_tx_entry_set_runt_size(struct rxr_ep *ep, struct rxr_op_entry *tx_entry
 {
 	int iface;
 	struct efa_hmem_info *hmem_info;
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 
 	assert(tx_entry->type == RXR_TX_ENTRY);
 
@@ -198,7 +198,7 @@ size_t rxr_op_entry_mulreq_total_data_size(struct rxr_op_entry *op_entry, int pk
  */
 size_t rxr_tx_entry_max_req_data_capacity(struct rxr_ep *ep, struct rxr_op_entry *tx_entry, int pkt_type)
 {
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 	uint16_t header_flags = 0;
 	int max_data_offset;
 
@@ -211,9 +211,9 @@ size_t rxr_tx_entry_max_req_data_capacity(struct rxr_ep *ep, struct rxr_op_entry
 		return rxr_env.shm_max_medium_size;
 	}
 
-	if (rxr_peer_need_raw_addr_hdr(peer))
+	if (efa_rdm_peer_need_raw_addr_hdr(peer))
 		header_flags |= RXR_REQ_OPT_RAW_ADDR_HDR;
-	else if (rxr_peer_need_connid(peer))
+	else if (efa_rdm_peer_need_connid(peer))
 		header_flags |= RXR_PKT_CONNID_HDR;
 
 	if (tx_entry->fi_flags & FI_REMOTE_CQ_DATA)

--- a/prov/efa/src/rxr/rxr_op_entry.h
+++ b/prov/efa/src/rxr/rxr_op_entry.h
@@ -94,7 +94,7 @@ struct rxr_op_entry {
 	enum rxr_x_entry_type type;
 
 	fi_addr_t addr;
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 
 	uint32_t tx_id;
 	uint32_t rx_id;

--- a/prov/efa/src/rxr/rxr_pkt_cmd.h
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.h
@@ -66,10 +66,10 @@ void rxr_pkt_handle_recv_completion(struct rxr_ep *ep,
 				    struct rxr_pkt_entry *pkt_entry,
 				    enum rxr_lower_ep_type lower_ep_type);
 
-ssize_t rxr_pkt_wait_handshake(struct rxr_ep *ep, fi_addr_t addr, struct rdm_peer *peer);
+ssize_t rxr_pkt_wait_handshake(struct rxr_ep *ep, fi_addr_t addr, struct efa_rdm_peer *peer);
 
 ssize_t rxr_pkt_trigger_handshake(struct rxr_ep *ep,
-				  fi_addr_t addr, struct rdm_peer *peer);
+				  fi_addr_t addr, struct efa_rdm_peer *peer);
 
 #if ENABLE_DEBUG
 void rxr_pkt_print(char *prefix,

--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -126,7 +126,7 @@ void rxr_pkt_entry_release(struct rxr_pkt_entry *pkt_entry)
  */
 void rxr_pkt_entry_release_tx(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 {
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 
 #if ENABLE_DEBUG
 	dlist_remove(&pkt_entry->dbg_entry);
@@ -140,9 +140,9 @@ void rxr_pkt_entry_release_tx(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry
 		assert(peer);
 		peer->rnr_queued_pkt_cnt--;
 		peer->rnr_backoff_wait_time = 0;
-		if (peer->flags & RXR_PEER_IN_BACKOFF) {
+		if (peer->flags & EFA_RDM_PEER_IN_BACKOFF) {
 			dlist_remove(&peer->rnr_backoff_entry);
-			peer->flags &= ~RXR_PEER_IN_BACKOFF;
+			peer->flags &= ~EFA_RDM_PEER_IN_BACKOFF;
 		}
 		FI_DBG(&rxr_prov, FI_LOG_EP_DATA,
 		       "reset backoff timer for peer: %" PRIu64 "\n",
@@ -364,7 +364,7 @@ ssize_t rxr_pkt_entry_send(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry,
 			   uint64_t flags)
 {
 	assert(pkt_entry->pkt_size);
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 	struct rxr_pkt_sendv *send = &pkt_entry->send;
 	struct ibv_send_wr *bad_wr, *send_wr = &pkt_entry->send_wr.wr;
 	struct ibv_sge *sge;
@@ -378,7 +378,7 @@ ssize_t rxr_pkt_entry_send(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry,
 
 	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
 	assert(peer);
-	if (peer->flags & RXR_PEER_IN_BACKOFF)
+	if (peer->flags & EFA_RDM_PEER_IN_BACKOFF)
 		return -FI_EAGAIN;
 
 	efa_ep =  container_of(ep->rdm_ep, struct efa_ep, util_ep.ep_fid);
@@ -501,7 +501,7 @@ ssize_t rxr_pkt_entry_inject(struct rxr_ep *ep,
 			     struct rxr_pkt_entry *pkt_entry,
 			     fi_addr_t addr)
 {
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 	ssize_t ret;
 
 	/* currently only EOR packet is injected using shm ep */

--- a/prov/efa/src/rxr/rxr_pkt_type.h
+++ b/prov/efa/src/rxr/rxr_pkt_type.h
@@ -43,7 +43,7 @@ static inline struct rxr_base_hdr *rxr_get_base_hdr(void *pkt)
 }
 
 struct rxr_ep;
-struct rdm_peer;
+struct efa_rdm_peer;
 struct rxr_read_entry;
 
 /* HANDSHAKE packet related functions */
@@ -71,10 +71,10 @@ ssize_t rxr_pkt_init_handshake(struct rxr_ep *ep,
 			       struct rxr_pkt_entry *pkt_entry,
 			       fi_addr_t addr);
 
-ssize_t rxr_pkt_post_handshake(struct rxr_ep *ep, struct rdm_peer *peer);
+ssize_t rxr_pkt_post_handshake(struct rxr_ep *ep, struct efa_rdm_peer *peer);
 
 void rxr_pkt_post_handshake_or_queue(struct rxr_ep *ep,
-				     struct rdm_peer *peer);
+				     struct efa_rdm_peer *peer);
 
 void rxr_pkt_handle_handshake_recv(struct rxr_ep *ep,
 				   struct rxr_pkt_entry *pkt_entry);
@@ -86,7 +86,7 @@ struct rxr_cts_hdr *rxr_get_cts_hdr(void *pkt)
 	return (struct rxr_cts_hdr *)pkt;
 }
 
-void rxr_pkt_calc_cts_window_credits(struct rxr_ep *ep, struct rdm_peer *peer,
+void rxr_pkt_calc_cts_window_credits(struct rxr_ep *ep, struct efa_rdm_peer *peer,
 				     uint64_t size, int request,
 				     int *window, int *credits);
 
@@ -315,7 +315,7 @@ bool rxr_pkt_type_is_runtread(int pkt_type)
 	return pkt_type == RXR_RUNTREAD_TAGRTM_PKT || pkt_type == RXR_RUNTREAD_MSGRTM_PKT;
 }
 
-int rxr_pkt_type_readbase_rtm(struct rdm_peer *peer, int op, uint64_t fi_flags, struct efa_hmem_info *hmem_info);
+int rxr_pkt_type_readbase_rtm(struct efa_rdm_peer *peer, int op, uint64_t fi_flags, struct efa_hmem_info *hmem_info);
 
 #endif
 

--- a/prov/efa/src/rxr/rxr_pkt_type_data.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_data.c
@@ -42,7 +42,7 @@ int rxr_pkt_init_data(struct rxr_ep *ep,
 		      struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_data_hdr *data_hdr;
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 	size_t hdr_size;
 	int ret;
 
@@ -68,7 +68,7 @@ int rxr_pkt_init_data(struct rxr_ep *ep,
 	hdr_size = sizeof(struct rxr_data_hdr);
 	peer = rxr_ep_get_peer(ep, op_entry->addr);
 	assert(peer);
-	if (rxr_peer_need_connid(peer)) {
+	if (efa_rdm_peer_need_connid(peer)) {
 		data_hdr->flags |= RXR_PKT_CONNID_HDR;
 		data_hdr->connid_hdr->connid = rxr_ep_raw_addr(ep)->qkey;
 		hdr_size += sizeof(struct rxr_data_opt_connid_hdr);

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -93,9 +93,9 @@ struct rxr_req_inf REQ_INF_LIST[] = {
 	[RXR_COMPARE_RTA_PKT] = {0, sizeof(struct rxr_rta_hdr), 0},
 };
 
-bool rxr_pkt_req_supported_by_peer(int req_type, struct rdm_peer *peer)
+bool rxr_pkt_req_supported_by_peer(int req_type, struct efa_rdm_peer *peer)
 {
-	assert(peer->flags & RXR_PEER_HANDSHAKE_RECEIVED);
+	assert(peer->flags & EFA_RDM_PEER_HANDSHAKE_RECEIVED);
 
 	int extra_info_id = REQ_INF_LIST[req_type].extra_info_id;
 
@@ -134,7 +134,7 @@ size_t rxr_pkt_req_data_size(struct rxr_pkt_entry *pkt_entry)
  * @param[in] hmem_info	configured protocol limits
  * @return The read-based protocol to use based on inputs.
  */
-int rxr_pkt_type_readbase_rtm(struct rdm_peer *peer, int op, uint64_t fi_flags, struct efa_hmem_info *hmem_info)
+int rxr_pkt_type_readbase_rtm(struct efa_rdm_peer *peer, int op, uint64_t fi_flags, struct efa_hmem_info *hmem_info)
 {
 	assert(op == ofi_op_tagged || op == ofi_op_msg);
 	if (peer->num_read_msg_in_flight == 0 &&
@@ -155,7 +155,7 @@ void rxr_pkt_init_req_hdr(struct rxr_ep *ep,
 			  struct rxr_pkt_entry *pkt_entry)
 {
 	char *opt_hdr;
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 	struct rxr_base_hdr *base_hdr;
 
 	/* init the base header */
@@ -167,14 +167,14 @@ void rxr_pkt_init_req_hdr(struct rxr_ep *ep,
 	peer = rxr_ep_get_peer(ep, tx_entry->addr);
 	assert(peer);
 
-	if (rxr_peer_need_raw_addr_hdr(peer)) {
+	if (efa_rdm_peer_need_raw_addr_hdr(peer)) {
 		/*
 		 * This is the first communication with this peer on this
 		 * endpoint, so send the core's address for this EP in the REQ
 		 * so the remote side can insert it into its address vector.
 		 */
 		base_hdr->flags |= RXR_REQ_OPT_RAW_ADDR_HDR;
-	} else if (rxr_peer_need_connid(peer)) {
+	} else if (efa_rdm_peer_need_connid(peer)) {
 		/*
 		 * After receiving handshake packet, we will know the peer's capability.
 		 *
@@ -895,7 +895,7 @@ void rxr_pkt_handle_longcts_rtm_sent(struct rxr_ep *ep,
 void rxr_pkt_handle_longread_rtm_sent(struct rxr_ep *ep,
 				      struct rxr_pkt_entry *pkt_entry)
 {
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 
 	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
 	assert(peer);
@@ -905,7 +905,7 @@ void rxr_pkt_handle_longread_rtm_sent(struct rxr_ep *ep,
 void rxr_pkt_handle_runtread_rtm_sent(struct rxr_ep *ep,
 				      struct rxr_pkt_entry *pkt_entry)
 {
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 	struct rxr_op_entry *tx_entry;
 	size_t pkt_data_size = rxr_pkt_req_data_size(pkt_entry);
 
@@ -960,7 +960,7 @@ void rxr_pkt_handle_runtread_rtm_send_completion(struct rxr_ep *ep,
 						 struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_op_entry *tx_entry;
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 	size_t pkt_data_size;
 
 	tx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
@@ -1557,7 +1557,7 @@ void rxr_pkt_handle_rtm_rta_recv(struct rxr_ep *ep,
 				 struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_base_hdr *base_hdr;
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 	int ret, msg_id;
 
 	base_hdr = rxr_get_base_hdr(pkt_entry->wiredata);

--- a/prov/efa/src/rxr/rxr_pkt_type_req.h
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.h
@@ -40,7 +40,7 @@
 static_assert(RXR_MSG_PREFIX_SIZE % 8 == 0, "message prefix size alignment check");
 #endif
 
-bool rxr_pkt_req_supported_by_peer(int req_type, struct rdm_peer *peer);
+bool rxr_pkt_req_supported_by_peer(int req_type, struct efa_rdm_peer *peer);
 
 void *rxr_pkt_req_raw_addr(struct rxr_pkt_entry *pkt_entry);
 

--- a/prov/efa/src/rxr/rxr_read.c
+++ b/prov/efa/src/rxr/rxr_read.c
@@ -344,7 +344,7 @@ int rxr_read_post_or_queue(struct rxr_ep *ep, struct rxr_read_entry *read_entry)
  */
 int rxr_read_post_remote_read_or_queue(struct rxr_ep *ep, struct rxr_op_entry *op_entry)
 {
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 	struct rxr_read_entry *read_entry;
 	int lower_ep_type, err;
 
@@ -448,7 +448,7 @@ int rxr_read_init_iov(struct rxr_ep *ep,
 {
 	int i, err;
 	struct fid_mr *mr;
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 
 	peer = rxr_ep_get_peer(ep, tx_entry->addr);
 
@@ -520,7 +520,7 @@ int rxr_read_post_once(struct rxr_ep *ep, struct rxr_read_entry *read_entry,
 	struct iovec iov;
 	struct fi_rma_iov rma_iov;
 	struct rxr_pkt_entry *pkt_entry;
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 	struct efa_ep *efa_ep;
 	bool self_comm;
 	int err = 0;

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -111,7 +111,7 @@ size_t rxr_rma_post_shm_write(struct rxr_ep *rxr_ep, struct rxr_op_entry *tx_ent
 {
 	struct rxr_pkt_entry *pkt_entry;
 	struct fi_msg_rma msg;
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 	int i, err;
 
 	assert(tx_entry->op == ofi_op_write);
@@ -185,7 +185,7 @@ ssize_t rxr_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uint64_
 {
 	ssize_t err;
 	struct rxr_ep *rxr_ep;
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 	struct rxr_op_entry *tx_entry = NULL;
 	bool use_lower_ep_read;
 
@@ -208,7 +208,7 @@ ssize_t rxr_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uint64_
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
 	assert(peer);
 
-	if (peer->flags & RXR_PEER_IN_BACKOFF) {
+	if (peer->flags & EFA_RDM_PEER_IN_BACKOFF) {
 		err = -FI_EAGAIN;
 		goto out;
 	}
@@ -306,7 +306,7 @@ ssize_t rxr_rma_read(struct fid_ep *ep, void *buf, size_t len, void *desc,
 ssize_t rxr_rma_post_write(struct rxr_ep *ep, struct rxr_op_entry *tx_entry)
 {
 	ssize_t err;
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 	bool delivery_complete_requested;
 	int ctrl_type, iface;
 	size_t max_eager_rtw_data_size;
@@ -338,9 +338,9 @@ ssize_t rxr_rma_post_write(struct rxr_ep *ep, struct rxr_op_entry *tx_entry)
 		if (OFI_UNLIKELY(err))
 			return err;
 
-		if (!(peer->flags & RXR_PEER_HANDSHAKE_RECEIVED))
+		if (!(peer->flags & EFA_RDM_PEER_HANDSHAKE_RECEIVED))
 			return -FI_EAGAIN;
-		else if (!rxr_peer_support_delivery_complete(peer))
+		else if (!efa_rdm_peer_support_delivery_complete(peer))
 			return -FI_EOPNOTSUPP;
 
 		max_eager_rtw_data_size = rxr_tx_entry_max_req_data_capacity(ep, tx_entry, RXR_DC_EAGER_RTW_PKT);
@@ -378,7 +378,7 @@ ssize_t rxr_rma_writemsg(struct fid_ep *ep,
 			 uint64_t flags)
 {
 	ssize_t err;
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 	struct rxr_ep *rxr_ep;
 	struct rxr_op_entry *tx_entry;
 
@@ -396,7 +396,7 @@ ssize_t rxr_rma_writemsg(struct fid_ep *ep,
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
 	assert(peer);
 
-	if (peer->flags & RXR_PEER_IN_BACKOFF) {
+	if (peer->flags & EFA_RDM_PEER_IN_BACKOFF) {
 		err = -FI_EAGAIN;
 		goto out;
 	}
@@ -487,7 +487,7 @@ ssize_t rxr_rma_inject_write(struct fid_ep *ep, const void *buf, size_t len,
 	struct iovec iov;
 	struct fi_rma_iov rma_iov;
 	struct rxr_ep *rxr_ep;
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 
 	rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid.fid);
 	peer = rxr_ep_get_peer(rxr_ep, dest_addr);
@@ -518,7 +518,7 @@ ssize_t rxr_rma_inject_writedata(struct fid_ep *ep, const void *buf, size_t len,
 	struct iovec iov;
 	struct fi_rma_iov rma_iov;
 	struct rxr_ep *rxr_ep;
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 
 	rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid.fid);
 	peer = rxr_ep_get_peer(rxr_ep, dest_addr);

--- a/prov/efa/test/efa_unit_test_cq.c
+++ b/prov/efa/test/efa_unit_test_cq.c
@@ -331,14 +331,14 @@ static void test_impl_ibv_cq_ex_read_unknow_peer_ah(struct efa_resource *resourc
 	raw_addr.qpn = 0;
 	raw_addr.qkey = 0x1234;
 
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 	ret = fi_av_insert(resource->av, &raw_addr, 1, &peer_addr, 0, NULL);
 	assert_int_equal(ret, 1);
 
 	/* Skip handshake */
 	peer = rxr_ep_get_peer(rxr_ep, peer_addr);
 	assert_non_null(peer);
-	peer->flags |= RXR_PEER_HANDSHAKE_SENT;
+	peer->flags |= EFA_RDM_PEER_HANDSHAKE_SENT;
 
 	/* Setup packet entry */
 	pkt_entry = rxr_pkt_entry_alloc(rxr_ep, rxr_ep->efa_rx_pkt_pool, RXR_PKT_FROM_EFA_RX_POOL);

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -79,7 +79,7 @@ void test_rxr_ep_pkt_pool_page_alignment(struct efa_resource **state)
 void test_rxr_ep_dc_atomic_error_handling(struct efa_resource **state)
 {
 	struct rxr_ep *rxr_ep;
-	struct rdm_peer *peer;
+	struct efa_rdm_peer *peer;
 	struct fi_ioc ioc = {0};
 	struct fi_rma_ioc rma_ioc = {0};
 	struct fi_msg_atomic msg = {0};
@@ -114,12 +114,12 @@ void test_rxr_ep_dc_atomic_error_handling(struct efa_resource **state)
 
 	rxr_ep = container_of(resource->ep, struct rxr_ep, util_ep.ep_fid);
 	rxr_ep->use_shm_for_tx = false;
-	/* set peer->flag to RXR_PEER_REQ_SENT will make rxr_atomic() think
+	/* set peer->flag to EFA_RDM_PEER_REQ_SENT will make rxr_atomic() think
 	 * a REQ packet has been sent to the peer (so no need to send again)
 	 * handshake has not been received, so we do not know whether the peer support DC
 	 */
 	peer = rxr_ep_get_peer(rxr_ep, peer_addr);
-	peer->flags = RXR_PEER_REQ_SENT;
+	peer->flags = EFA_RDM_PEER_REQ_SENT;
 	peer->is_local = false;
 
 	assert_true(dlist_empty(&rxr_ep->tx_entry_list));


### PR DESCRIPTION
The peer structure has been give different names as:

rdm_peer, efa_peer and rxr_peer,

which caused confusion.

This patch unified the name to efa_rdm_peer

Signed-off-by: Wei Zhang <wzam@amazon.com>