### PR TITLE
prov/efa: add missing header file to rxr_pkt_entry.c

### DIFF
--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -39,6 +39,7 @@
 #include <ofi_iov.h>
 
 #include "efa.h"
+#include "efa_tp.h"
 #include "rxr.h"
 #include "rxr_msg.h"
 #include "rxr_rma.h"


### PR DESCRIPTION
This patch added "efa_tp.h" to rxr_pkt_entry.c to fix the compilation failure with lttng enabled.

Signed-off-by: Wei Zhang <wzam@amazon.com>