### PR TITLE
prov/efa: Refactor `efa_hmem.c`, tidy Doxygen comments

### DIFF
--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -259,7 +259,7 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 		goto err_free;
 	}
 
-	err = efa_hmem_info_init_all(efa_domain);
+	err = efa_domain_hmem_info_init_all(efa_domain);
 	if (err) {
 		ret = err;
 		EFA_WARN(FI_LOG_DOMAIN, "Failed to check hmem support status. err: %d", ret);

--- a/prov/efa/src/efa_hmem.h
+++ b/prov/efa/src/efa_hmem.h
@@ -60,8 +60,8 @@ struct efa_hmem_info {
 	size_t min_read_write_size;
 };
 
-int efa_hmem_validate_p2p_opt(struct efa_domain *efa_domain, enum fi_hmem_iface iface, int p2p_opt);
-int efa_hmem_info_init_all(struct efa_domain *efa_domain);
+int efa_domain_hmem_validate_p2p_opt(struct efa_domain *efa_domain, enum fi_hmem_iface iface, int p2p_opt);
+int efa_domain_hmem_info_init_all(struct efa_domain *efa_domain);
 
 ssize_t efa_copy_from_hmem_iov(void **desc, char *buff, int buff_size, const struct iovec *hmem_iov, int iov_count);
 ssize_t efa_copy_to_hmem_iov(void **desc, struct iovec *hmem_iov, int iov_count, char *buff, int buff_size);

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1097,7 +1097,7 @@ static int efa_set_fi_hmem_p2p_opt(struct rxr_ep *rxr_ep, int opt)
 	 * tighter restrictions on valid p2p options.
 	 */
 	EFA_HMEM_IFACE_FOREACH_NON_SYSTEM(i) {
-		err = efa_hmem_validate_p2p_opt(rxr_ep_domain(rxr_ep), efa_hmem_ifaces[i], opt);
+		err = efa_domain_hmem_validate_p2p_opt(rxr_ep_domain(rxr_ep), efa_hmem_ifaces[i], opt);
 		if (err == -FI_ENODATA)
 			continue;
 


### PR DESCRIPTION
This is a minor refactor to remove superfluous parameters from the `efa_hmem_info` init functions and reorders them s.t. output params follow any input params.

The motivation is purely for the interface and Doxygen comments to make more sense.

Signed-off-by: Darryl Abbate <drl@amazon.com>