### PR TITLE
libfabric.vcxproj: add efa_rdm_peer.c

### DIFF
--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -908,6 +908,7 @@
     <ClCompile Include="prov\efa\src\rxr\rxr_read.c" />
     <ClCompile Include="prov\efa\src\rxr\rxr_rma.c" />
     <ClCompile Include="prov\efa\src\rxr\rxr_prov.c" />
+    <ClCompile Include="prov\efa\src\rxr\efa_rdm_peer.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\fasthash.h" />


### PR DESCRIPTION
Add efa_rdm_peer.c to the list of EFA sources

Signed-off-by: Wei Zhang <wzam@amazon.com>