### PR TITLE
fabtests/ubertest: fix data validation with device memory

### DIFF
--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -411,6 +411,8 @@ int ft_alloc_ep_res(struct fi_info *fi, struct fid_cq **new_txcq,
 		    struct fid_cq **new_rxcq, struct fid_cntr **new_txcntr,
 		    struct fid_cntr **new_rxcntr);
 int ft_alloc_msgs(void);
+int ft_alloc_host_tx_buf(size_t size);
+void ft_free_host_tx_buf(void);
 int ft_alloc_active_res(struct fi_info *fi);
 int ft_enable_ep_recv(void);
 int ft_enable_ep(struct fid_ep *bind_ep, struct fid_eq *bind_eq, struct fid_av *bind_av,

--- a/fabtests/ubertest/domain.c
+++ b/fabtests/ubertest/domain.c
@@ -311,6 +311,10 @@ static int ft_setup_bufs(void)
 	if (ret)
 		return ret;
 
+	ret = ft_alloc_host_tx_buf(ft_ctrl.size_array[ft_ctrl.size_cnt - 1]);
+	if (ret)
+		return ret;
+
 	ret = ft_setup_mr_control(&ft_mr_ctrl);
 	if (ret)
 		return ret;

--- a/fabtests/ubertest/test_ctrl.c
+++ b/fabtests/ubertest/test_ctrl.c
@@ -979,6 +979,7 @@ void ft_cleanup(void)
 	FT_CLOSE_FID(ft_atom_ctrl.comp_mr);
 	ft_cleanup_xcontrol(&ft_rx_ctrl);
 	ft_cleanup_xcontrol(&ft_tx_ctrl);
+	ft_free_host_tx_buf();
 	ft_cleanup_mr_control(&ft_mr_ctrl);
 	ft_cleanup_atomic_control(&ft_atom_ctrl);
 	ft_free_res();


### PR DESCRIPTION
Need to allocate host buffer for filling data. Separate function in common code in order to call it from ubertest.

Signed-off-by: Alexia Ingerson <alexia.ingerson@intel.com>