### PR TITLE
prov/efa: Fail unit test early if resource struct fails

### DIFF
--- a/prov/efa/test/efa_unit_test_av.c
+++ b/prov/efa/test/efa_unit_test_av.c
@@ -16,8 +16,7 @@ void test_av_insert_duplicate_raw_addr(struct efa_resource **state)
 	fi_addr_t addr1, addr2;
 	int err, num_addr;
 
-	err = efa_unit_test_resource_construct(resource, FI_EP_RDM);
-	assert_int_equal(err, 0);
+	efa_unit_test_resource_construct(resource, FI_EP_RDM);
 	g_efa_unit_test_mocks.ibv_create_ah = &efa_mock_ibv_create_ah_check_mock;
 
 	err = fi_getname(&resource->ep->fid, &raw_addr, &raw_addr_len);
@@ -52,8 +51,7 @@ void test_av_insert_duplicate_gid(struct efa_resource **state)
 	fi_addr_t addr1, addr2;
 	int err, num_addr;
 
-	err = efa_unit_test_resource_construct(resource, FI_EP_RDM);
-	assert_int_equal(err, 0);
+	efa_unit_test_resource_construct(resource, FI_EP_RDM);
 	g_efa_unit_test_mocks.ibv_create_ah = &efa_mock_ibv_create_ah_check_mock;
 
 	err = fi_getname(&resource->ep->fid, &raw_addr, &raw_addr_len);

--- a/prov/efa/test/efa_unit_test_common.c
+++ b/prov/efa/test/efa_unit_test_common.c
@@ -38,7 +38,7 @@ struct fi_info *efa_unit_test_alloc_hints(enum fi_ep_type ep_type)
 	return hints;
 }
 
-int efa_unit_test_resource_construct(struct efa_resource *resource, enum fi_ep_type ep_type)
+void efa_unit_test_resource_construct(struct efa_resource *resource, enum fi_ep_type ep_type)
 {
 	int ret = 0;
 	struct fi_av_attr av_attr = {0};
@@ -87,11 +87,13 @@ int efa_unit_test_resource_construct(struct efa_resource *resource, enum fi_ep_t
 	if (ret)
 		goto err;
 
-	assert_int_equal(ret, 0);
-	return 0;
+	return;
+
 err:
 	efa_unit_test_resource_destruct(resource);
-	return ret;
+
+	/* Fail test early if the resource struct fails to initialize */
+	assert_int_equal(ret, 0);
 }
 
 /**

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -20,11 +20,9 @@ static void check_ep_pkt_pool_flags(struct efa_resource *resource, int expected_
  */
 void test_rxr_ep_pkt_pool_flags(struct efa_resource **state)
 {
-	int ret;
 	struct efa_resource *resource = *state;
 
-	ret = efa_unit_test_resource_construct(resource, FI_EP_RDM);
-	assert_int_equal(ret, 0);
+	efa_unit_test_resource_construct(resource, FI_EP_RDM);
 
 	g_efa_fork_status = EFA_FORK_SUPPORT_ON;
 	check_ep_pkt_pool_flags(resource, OFI_BUFPOOL_NONSHARED);
@@ -50,8 +48,7 @@ void test_rxr_ep_pkt_pool_page_alignment(struct efa_resource **state)
 	struct rxr_ep *rxr_ep;
 	struct efa_resource *resource = *state;
 
-	ret = efa_unit_test_resource_construct(resource, FI_EP_RDM);
-	assert_int_equal(ret, 0);
+	efa_unit_test_resource_construct(resource, FI_EP_RDM);
 
 	/* Turn on g_efa_fork_status and open a new rxr endpoint */
 	g_efa_fork_status = EFA_FORK_SUPPORT_ON;
@@ -89,8 +86,7 @@ void test_rxr_ep_dc_atomic_error_handling(struct efa_resource **state)
 	fi_addr_t peer_addr;
 	int buf[1] = {0}, err, numaddr;
 
-	err = efa_unit_test_resource_construct(resource, FI_EP_RDM);
-	assert_int_equal(err, 0);
+	efa_unit_test_resource_construct(resource, FI_EP_RDM);
 
 	/* create a fake peer */
 	err = fi_getname(&resource->ep->fid, &raw_addr, &raw_addr_len);

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -1,6 +1,6 @@
 #include "efa_unit_tests.h"
 
-// Runs once before all tests
+/* Runs once before all tests */
 static int efa_unit_test_mocks_group_setup(void **state)
 {
 	struct efa_resource *resource;
@@ -10,7 +10,7 @@ static int efa_unit_test_mocks_group_setup(void **state)
 	return 0;
 }
 
-// Runs once after all tests
+/* Runs once after all tests */
 static int efa_unit_test_mocks_group_teardown(void **state)
 {
 	struct efa_resource *resource = *state;
@@ -19,17 +19,17 @@ static int efa_unit_test_mocks_group_teardown(void **state)
 	return 0;
 }
 
-// Runs before every test
+/* Runs before every test */
 static int efa_unit_test_mocks_setup(void **state)
 {
-	// Zero out *resource
+	/* Zero out *resource */
 	struct efa_resource *resource = *state;
 	memset(resource, 0, sizeof(struct efa_resource));
 
 	return 0;
 }
 
-// Runs after every test
+/* Runs after every test */
 static int efa_unit_test_mocks_teardown(void **state)
 {
 	struct efa_resource *resource = *state;

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -28,7 +28,7 @@ struct efa_resource {
 
 struct fi_info *efa_unit_test_alloc_hints(enum fi_ep_type ep_type);
 
-int efa_unit_test_resource_construct(struct efa_resource *resource, enum fi_ep_type ep_type);
+void efa_unit_test_resource_construct(struct efa_resource *resource, enum fi_ep_type ep_type);
 
 void efa_unit_test_resource_destruct(struct efa_resource *resource);
 


### PR DESCRIPTION
No point in continuing the test or checking the return value in the test body

Signed-off-by: Sai Sunku <sunkusa@amazon.com>