### PR TITLE
hmem_synpaseai: return 0 for host_register and host_deregister

### DIFF
--- a/src/hmem_synapseai.c
+++ b/src/hmem_synapseai.c
@@ -122,12 +122,12 @@ int synapseai_close_handle(void *ipc_ptr)
 
 int synapseai_host_register(void *ptr, size_t size)
 {
-	return -FI_ENOSYS;
+	return FI_SUCCESS;
 }
 
 int synapseai_host_unregister(void *ptr)
 {
-	return -FI_ENOSYS;
+	return FI_SUCCESS;
 }
 
 int synapseai_get_base_addr(const void *ptr, void **base, size_t *size)


### PR DESCRIPTION
host pointer register and deregister are no-ops for synpase ai. return FI_SUCCESS for them

Signed-off-by: EC2 Default User <ec2-user@ip-172-31-58-230.us-west-2.compute.internal>