### PR TITLE
prov/net: RX operations now support io_uring

### DIFF
--- a/prov/net/src/xnet_ep.c
+++ b/prov/net/src/xnet_ep.c
@@ -324,6 +324,8 @@ static void xnet_ep_flush_all_queues(struct xnet_ep *ep)
 	struct xnet_cq *cq;
 
 	assert(xnet_progress_locked(xnet_ep2_progress(ep)));
+	assert(!ep->bsock.tx_sockctx.uring_sqe_inuse);
+	assert(!ep->bsock.rx_sockctx.uring_sqe_inuse);
 	cq = container_of(ep->util_ep.tx_cq, struct xnet_cq, util_cq);
 	if (ep->cur_tx.entry) {
 		ep->hdr_bswap(ep, &ep->cur_tx.entry->hdr.base_hdr);

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -742,6 +742,36 @@ static int xnet_op_read_rsp(struct xnet_ep *ep)
 	return xnet_recv_msg_data(ep);
 }
 
+static int xnet_progress_hdr(struct xnet_ep *ep)
+{
+	if (ep->cur_rx.hdr_done == sizeof(ep->cur_rx.hdr.base_hdr)) {
+		assert(ep->cur_rx.hdr_len == sizeof(ep->cur_rx.hdr.base_hdr));
+
+		if (ep->cur_rx.hdr.base_hdr.hdr_size > XNET_MAX_HDR) {
+			FI_WARN(&xnet_prov, FI_LOG_EP_DATA,
+				"Payload offset is too large\n");
+			return -FI_EIO;
+		}
+		ep->cur_rx.hdr_len = (size_t) ep->cur_rx.hdr.base_hdr.hdr_size;
+	}
+
+	if (ep->cur_rx.hdr_done < ep->cur_rx.hdr_len)
+		return -FI_EAGAIN;
+
+	ep->hdr_bswap(ep, &ep->cur_rx.hdr.base_hdr);
+	assert(ep->cur_rx.hdr.base_hdr.id == ep->rx_id++);
+	if (ep->cur_rx.hdr.base_hdr.op >= ARRAY_SIZE(xnet_start_op)) {
+		FI_WARN(&xnet_prov, FI_LOG_EP_DATA,
+			"Received invalid opcode\n");
+		return -FI_EIO;
+	}
+
+	ep->cur_rx.data_left = ep->cur_rx.hdr.base_hdr.size -
+			       ep->cur_rx.hdr.base_hdr.hdr_size;
+	ep->cur_rx.handler = xnet_start_op[ep->cur_rx.hdr.base_hdr.op];
+	return FI_SUCCESS;
+}
+
 static int xnet_recv_hdr(struct xnet_ep *ep)
 {
 	size_t len;
@@ -762,33 +792,16 @@ next_hdr:
 	}
 
 	ep->cur_rx.hdr_done += len;
-	if (ep->cur_rx.hdr_done == sizeof(ep->cur_rx.hdr.base_hdr)) {
-		assert(ep->cur_rx.hdr_len == sizeof(ep->cur_rx.hdr.base_hdr));
 
-		if (ep->cur_rx.hdr.base_hdr.hdr_size > XNET_MAX_HDR) {
-			FI_WARN(&xnet_prov, FI_LOG_EP_DATA,
-				"Payload offset is too large\n");
-			return -FI_EIO;
-		}
-		ep->cur_rx.hdr_len = (size_t) ep->cur_rx.hdr.base_hdr.hdr_size;
-		if (ep->cur_rx.hdr_done < ep->cur_rx.hdr_len)
+	ret = xnet_progress_hdr(ep);
+	if (ret) {
+		if (ret == -FI_EAGAIN &&
+		    ep->cur_rx.hdr_done == sizeof(ep->cur_rx.hdr.base_hdr)) {
 			goto next_hdr;
+		}
 
-	} else if (ep->cur_rx.hdr_done < ep->cur_rx.hdr_len) {
-		return -FI_EAGAIN;
+		return ret;
 	}
-
-	ep->hdr_bswap(ep, &ep->cur_rx.hdr.base_hdr);
-	assert(ep->cur_rx.hdr.base_hdr.id == ep->rx_id++);
-	if (ep->cur_rx.hdr.base_hdr.op >= ARRAY_SIZE(xnet_start_op)) {
-		FI_WARN(&xnet_prov, FI_LOG_EP_DATA,
-			"Received invalid opcode\n");
-		return -FI_EIO;
-	}
-
-	ep->cur_rx.data_left = ep->cur_rx.hdr.base_hdr.size -
-			       ep->cur_rx.hdr.base_hdr.hdr_size;
-	ep->cur_rx.handler = xnet_start_op[ep->cur_rx.hdr.base_hdr.op];
 
 	return ep->cur_rx.handler(ep);
 }

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -409,46 +409,6 @@ static int xnet_queue_ack(struct xnet_xfer_entry *rx_entry)
 	return FI_SUCCESS;
 }
 
-static int xnet_process_recv(struct xnet_ep *ep)
-{
-	struct xnet_progress *progress;
-	struct xnet_xfer_entry *rx_entry;
-	int ret;
-
-	progress = xnet_ep2_progress(ep);
-	assert(xnet_progress_locked(progress));
-	rx_entry = ep->cur_rx.entry;
-	ret = xnet_recv_msg_data(ep);
-	if (ret) {
-		if (OFI_SOCK_TRY_SND_RCV_AGAIN(-ret))
-			return ret;
-
-		goto err;
-	}
-
-	if (rx_entry->hdr.base_hdr.flags & XNET_DELIVERY_COMPLETE) {
-		ret = xnet_queue_ack(rx_entry);
-		if (ret)
-			goto err;
-	}
-
-	if (!(rx_entry->ctrl_flags & XNET_SAVED_XFER)) {
-		ep->report_success(ep, ep->util_ep.rx_cq, rx_entry);
-		xnet_free_xfer(progress, rx_entry);
-	}
-	xnet_reset_rx(ep);
-	return 0;
-
-err:
-	FI_WARN(&xnet_prov, FI_LOG_EP_DATA,
-		"msg recv failed ret = %d (%s)\n", ret, fi_strerror(-ret));
-	xnet_cntr_incerr(ep, rx_entry);
-	xnet_cq_report_error(rx_entry->ep->util_ep.rx_cq, rx_entry, -ret);
-	xnet_free_xfer(progress, rx_entry);
-	xnet_reset_rx(ep);
-	return ret;
-}
-
 static void xnet_pmem_commit(struct xnet_xfer_entry *rx_entry)
 {
 	struct ofi_rma_iov *rma_iov;
@@ -471,75 +431,6 @@ static void xnet_pmem_commit(struct xnet_xfer_entry *rx_entry)
 		(*ofi_pmem_commit)((const void *) (uintptr_t) rma_iov[i].addr,
 				   rma_iov[i].len);
 	}
-}
-
-static int xnet_process_remote_write(struct xnet_ep *ep)
-{
-	struct xnet_xfer_entry *rx_entry;
-	int ret;
-
-	assert(xnet_progress_locked(xnet_ep2_progress(ep)));
-	rx_entry = ep->cur_rx.entry;
-	ret = xnet_recv_msg_data(ep);
-	if (ret) {
-		if (OFI_SOCK_TRY_SND_RCV_AGAIN(-ret))
-			return ret;
-
-		goto err;
-	}
-
-	if (rx_entry->hdr.base_hdr.flags &
-	    (XNET_DELIVERY_COMPLETE | XNET_COMMIT_COMPLETE)) {
-
-		if (rx_entry->hdr.base_hdr.flags & XNET_COMMIT_COMPLETE)
-			xnet_pmem_commit(rx_entry);
-
-		ret = xnet_queue_ack(rx_entry);
-		if (ret)
-			goto err;
-	}
-
-	ep->report_success(ep, ep->util_ep.rx_cq, rx_entry);
-	xnet_free_xfer(xnet_ep2_progress(ep), rx_entry);
-	xnet_reset_rx(ep);
-	return FI_SUCCESS;
-
-err:
-	FI_WARN(&xnet_prov, FI_LOG_DOMAIN, "remote write failed %d\n", ret);
-	xnet_cntr_incerr(ep, rx_entry);
-	xnet_cq_report_error(rx_entry->ep->util_ep.rx_cq, rx_entry, -ret);
-	xnet_free_xfer(xnet_ep2_progress(ep), rx_entry);
-	xnet_reset_rx(ep);
-	return ret;
-}
-
-static int xnet_process_remote_read(struct xnet_ep *ep)
-{
-	struct xnet_xfer_entry *rx_entry;
-	struct xnet_cq *cq;
-	int ret;
-
-	assert(xnet_progress_locked(xnet_ep2_progress(ep)));
-	rx_entry = ep->cur_rx.entry;
-	cq = container_of(ep->util_ep.tx_cq, struct xnet_cq, util_cq);
-
-	ret = xnet_recv_msg_data(ep);
-	if (OFI_SOCK_TRY_SND_RCV_AGAIN(-ret))
-		return ret;
-
-	if (ret) {
-		FI_WARN(&xnet_prov, FI_LOG_DOMAIN,
-			"msg recv Failed ret = %d\n", ret);
-		xnet_cntr_incerr(ep, rx_entry);
-		xnet_cq_report_error(&cq->util_cq, rx_entry, -ret);
-	} else {
-		ep->report_success(ep, &cq->util_cq, rx_entry);
-	}
-
-	slist_remove_head(&rx_entry->ep->rma_read_queue);
-	xnet_free_xfer(xnet_ep2_progress(ep), rx_entry);
-	xnet_reset_rx(ep);
-	return ret;
 }
 
 static int xnet_alter_mrecv(struct xnet_ep *ep, struct xnet_xfer_entry *xfer,
@@ -662,8 +553,8 @@ int xnet_start_recv(struct xnet_ep *ep, struct xnet_xfer_entry *rx_entry)
 		goto truncate_err;
 
 	ep->cur_rx.entry = rx_entry;
-	ep->cur_rx.handler = xnet_process_recv;
-	return xnet_process_recv(ep);
+	ep->cur_rx.handler = xnet_recv_msg_data;
+	return xnet_recv_msg_data(ep);
 
 truncate_err:
 	FI_WARN(&xnet_prov, FI_LOG_EP_DATA,
@@ -826,8 +717,8 @@ static int xnet_op_write(struct xnet_ep *ep)
 	}
 
 	ep->cur_rx.entry = rx_entry;
-	ep->cur_rx.handler = xnet_process_remote_write;
-	return xnet_process_remote_write(ep);
+	ep->cur_rx.handler = xnet_recv_msg_data;
+	return xnet_recv_msg_data(ep);
 }
 
 static int xnet_op_read_rsp(struct xnet_ep *ep)
@@ -847,8 +738,8 @@ static int xnet_op_read_rsp(struct xnet_ep *ep)
 	rx_entry->hdr.base_hdr.op_data = 0;
 
 	ep->cur_rx.entry = rx_entry;
-	ep->cur_rx.handler = xnet_process_remote_read;
-	return xnet_process_remote_read(ep);
+	ep->cur_rx.handler = xnet_recv_msg_data;
+	return xnet_recv_msg_data(ep);
 }
 
 static int xnet_recv_hdr(struct xnet_ep *ep)
@@ -902,6 +793,50 @@ next_hdr:
 	return ep->cur_rx.handler(ep);
 }
 
+static void xnet_complete_rx(struct xnet_ep *ep, ssize_t ret)
+{
+	struct xnet_xfer_entry *rx_entry;
+	struct util_cq *cq;
+
+	rx_entry = ep->cur_rx.entry;
+	assert(rx_entry);
+
+	if (ep->rma_read_queue.head == &rx_entry->entry) {
+		slist_remove_head(&rx_entry->ep->rma_read_queue);
+		cq = ep->util_ep.tx_cq;
+	} else {
+		cq = ep->util_ep.rx_cq;
+	}
+
+	if (ret)
+		goto cq_error;
+
+	if (rx_entry->hdr.base_hdr.flags & XNET_COMMIT_COMPLETE)
+		xnet_pmem_commit(rx_entry);
+	if (rx_entry->hdr.base_hdr.flags &
+	    (XNET_DELIVERY_COMPLETE | XNET_COMMIT_COMPLETE)) {
+		ret = xnet_queue_ack(rx_entry);
+		if (ret)
+			goto cq_error;
+	}
+
+	if (!(rx_entry->ctrl_flags & XNET_SAVED_XFER)) {
+		ep->report_success(ep, cq, rx_entry);
+		xnet_free_xfer(xnet_ep2_progress(ep), rx_entry);
+	}
+	xnet_reset_rx(ep);
+	return;
+
+cq_error:
+	FI_WARN(&xnet_prov, FI_LOG_EP_DATA,
+		"msg recv failed ret = %zd (%s)\n", ret, fi_strerror((int)-ret));
+	xnet_cntr_incerr(ep, rx_entry);
+	xnet_cq_report_error(cq, rx_entry, (int) -ret);
+	xnet_free_xfer(xnet_ep2_progress(ep), rx_entry);
+	xnet_reset_rx(ep);
+	xnet_ep_disable(ep, 0, NULL, 0);
+}
+
 void xnet_progress_rx(struct xnet_ep *ep)
 {
 	int ret;
@@ -914,10 +849,15 @@ void xnet_progress_rx(struct xnet_ep *ep)
 			ret = ep->cur_rx.handler(ep);
 		}
 
-	} while (!ret && ofi_bsock_readable(&ep->bsock));
+		if (OFI_SOCK_TRY_SND_RCV_AGAIN(-ret))
+			return;
 
-	if (ret && !OFI_SOCK_TRY_SND_RCV_AGAIN(-ret))
-		xnet_ep_disable(ep, 0, NULL, 0);
+		if (ep->cur_rx.entry)
+			xnet_complete_rx(ep, ret);
+		else if (ret)
+			xnet_ep_disable(ep, 0, NULL, 0);
+
+	} while (!ret && ofi_bsock_readable(&ep->bsock));
 }
 
 void xnet_progress_async(struct xnet_ep *ep)

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -50,8 +50,8 @@ static struct ofi_sockapi xnet_sockapi_uring =
 {
 	.send = ofi_sockapi_send_uring,
 	.sendv = ofi_sockapi_sendv_uring,
-	.recv = ofi_sockapi_recv_socket,
-	.recvv = ofi_sockapi_recvv_socket,
+	.recv = ofi_sockapi_recv_uring,
+	.recvv = ofi_sockapi_recvv_uring,
 };
 
 static struct ofi_sockapi xnet_sockapi_socket =
@@ -862,8 +862,9 @@ void xnet_progress_rx(struct xnet_ep *ep)
 			ret = ep->cur_rx.handler(ep);
 		}
 
-		if (OFI_SOCK_TRY_SND_RCV_AGAIN(-ret))
-			return;
+		if (OFI_SOCK_TRY_SND_RCV_AGAIN(-ret) ||
+		    ret == -OFI_EINPROGRESS_URING)
+			break;
 
 		if (ep->cur_rx.entry)
 			xnet_complete_rx(ep, ret);
@@ -871,6 +872,13 @@ void xnet_progress_rx(struct xnet_ep *ep)
 			xnet_ep_disable(ep, 0, NULL, 0);
 
 	} while (!ret && ofi_bsock_readable(&ep->bsock));
+
+	if (xnet_io_uring) {
+		if (ret == -OFI_EINPROGRESS_URING)
+			xnet_update_pollflag(ep, POLLIN, false);
+		else if (!ret || OFI_SOCK_TRY_SND_RCV_AGAIN(-ret))
+			xnet_update_pollflag(ep, POLLIN, true);
+	}
 }
 
 void xnet_progress_async(struct xnet_ep *ep)
@@ -897,9 +905,11 @@ static void xnet_progress_cqe(struct xnet_progress *progress,
 			      ofi_io_uring_cqe_t *cqe)
 {
 	struct xnet_xfer_entry *tx_entry;
+	struct xnet_xfer_entry *rx_entry;
 	struct ofi_sockctx *sockctx;
 	struct ofi_bsock *bsock;
 	struct xnet_ep *ep;
+	int ret;
 
 	assert(xnet_io_uring);
 	sockctx = (struct ofi_sockctx *) cqe->user_data;
@@ -932,7 +942,37 @@ static void xnet_progress_cqe(struct xnet_progress *progress,
 		xnet_progress_tx(ep);
 	} else {
 		assert(&uring->ring == progress->sockapi.rx_uring.io_uring);
+
 		progress->sockapi.rx_uring.credits++;
+		if (bsock->async_prefetch) {
+			if (cqe->res > 0)
+				ofi_bsock_prefetch_done(bsock, cqe->res);
+			else {
+				bsock->async_prefetch = false;
+				xnet_ep_disable(ep, 0, NULL, 0);
+			}
+		} else if (cqe->res <= 0 && !OFI_SOCK_TRY_SND_RCV_AGAIN(-cqe->res)) {
+			if (ep->cur_rx.entry)
+				xnet_complete_rx(ep, cqe->res);
+			else
+				xnet_ep_disable(ep, 0, NULL, 0);
+		} else if (ep->cur_rx.hdr_done < ep->cur_rx.hdr_len) {
+			ep->cur_rx.hdr_done += cqe->res;
+			ret = xnet_progress_hdr(ep);
+			if (ret != 0 && !OFI_SOCK_TRY_SND_RCV_AGAIN(-ret))
+				xnet_ep_disable(ep, 0, NULL, 0);
+		} else {
+			rx_entry = ep->cur_rx.entry;
+			assert(rx_entry);
+
+			ep->cur_rx.data_left -= cqe->res;
+			if (ep->cur_rx.data_left)
+				ofi_consume_iov(rx_entry->iov, &rx_entry->iov_cnt,
+						cqe->res);
+			else
+				xnet_complete_rx(ep, FI_SUCCESS);
+		}
+		xnet_progress_rx(ep);
 	}
 }
 
@@ -1051,8 +1091,10 @@ xnet_handle_events(struct xnet_progress *progress,
 	}
 
 	xnet_handle_event_list(progress);
-	if (xnet_io_uring)
+	if (xnet_io_uring) {
 		xnet_submit_uring(&progress->tx_uring);
+		xnet_submit_uring(&progress->rx_uring);
+	}
 }
 
 void xnet_progress_unexp(struct xnet_progress *progress)
@@ -1066,6 +1108,8 @@ void xnet_progress_unexp(struct xnet_progress *progress)
 		assert(xnet_has_unexp(ep));
 		assert(ep->state == XNET_CONNECTED);
 		xnet_progress_rx(ep);
+		if (xnet_io_uring)
+			xnet_progress_uring(progress, &progress->rx_uring);
 	}
 }
 


### PR DESCRIPTION
This patch adds support of io_uring to RX operations.

The implementation is still incomplete because we need a mechanism
to cancel all pending io_uring operations and wait for them to
complete before we can close the ring. Pending receive operations
would cause the code to fail an assertion failure when the endpoint
is shut down.