### PR TITLE
fabtests/pytest/conftest.py: changes to running remote commands

### DIFF
--- a/fabtests/pytest/conftest.py
+++ b/fabtests/pytest/conftest.py
@@ -1,5 +1,11 @@
+import builtins
 import os
+import re
+
+import yaml
+
 import pytest
+
 
 def get_option_longform(option_name, option_params):
     '''
@@ -8,8 +14,6 @@ def get_option_longform(option_name, option_params):
     return option_params.get("longform", "--" + option_name.replace("_", "-"))
 
 def pytest_addoption(parser):
-    import yaml, builtins
-
     parser.addoption("--provider", dest="provider", help="libfabric provider")
     parser.addoption("--client-id", dest="client_id", help="client IP address or hostname")
     parser.addoption("--server-id", dest="server_id", help="server IP address or hostname")
@@ -38,8 +42,6 @@ bssh = "ssh -n -o StrictHostKeyChecking=no -o ConnectTimeout=30 -o BatchMode=yes
 class CmdlineArgs:
 
     def __init__(self, request):
-        import yaml
-
         self.provider = request.config.getoption("--provider")
         if self.provider is None:
             raise RuntimeError("Error: libfabric provider is not specified")
@@ -121,13 +123,11 @@ class CmdlineArgs:
         return False
 
     def _add_exclusion_patterns_from_list(self, exclusion_list):
-        import re
         pattern_strs = exclusion_list.split(",")
         for pattern_str in pattern_strs:
             self._exclusion_patterns.append(re.compile(pattern_str))
 
     def _add_exclusion_patterns_from_file(self, exclusion_file):
-        import re
         
         ifs = open(exclusion_file)
         line = ifs.readline()
@@ -201,7 +201,6 @@ def cmdline_args(request):
 
 @pytest.fixture
 def good_address(cmdline_args):
-    import os
 
     if cmdline_args.good_address:
         return cmdline_args.good_address


### PR DESCRIPTION
Neuron runtime runs `lspci` in shell. This is a problem in the current implementation, which runs the remote command in non-interactive mode, e.g. `ssh 1.2.3.4 lspci` produces `sh: lspci: command not found`, because the non-interactive shell has a different environment. The solution is to run the command in interactive mode, i.e. `ssh 1.2.3.4 bash --login -c lspci`.
  However, please note the side effect that we are now locked into `bash`.