### PR TITLE
[v1.16.x] prov/efa: Print local/peer addresses for RX write errors

### DIFF
--- a/prov/efa/src/rxr/rxr_cq.c
+++ b/prov/efa/src/rxr/rxr_cq.c
@@ -79,8 +79,12 @@ void rxr_cq_write_rx_error(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,
 	struct dlist_entry *tmp;
 	struct rxr_pkt_entry *pkt_entry;
 	int write_cq_err;
+	char ep_addr_str[OFI_ADDRSTRLEN], peer_addr_str[OFI_ADDRSTRLEN];
+	size_t buflen = 0;
 
 	memset(&err_entry, 0, sizeof(err_entry));
+	memset(&ep_addr_str, 0, sizeof(ep_addr_str));
+	memset(&peer_addr_str, 0, sizeof(peer_addr_str));
 
 	util_cq = ep->util_ep.rx_cq;
 
@@ -133,11 +137,15 @@ void rxr_cq_write_rx_error(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,
 
 	rxr_msg_multi_recv_free_posted_entry(ep, rx_entry);
 
-        FI_WARN(&rxr_prov, FI_LOG_CQ,
-		"rxr_cq_write_rx_error: err: %d, prov_err: %s (%d)\n",
-		err_entry.err, efa_strerror(err_entry.prov_errno),
-		err_entry.prov_errno);
+	buflen = sizeof(ep_addr_str);
+	rxr_ep_raw_addr_str(ep, ep_addr_str, &buflen);
+	buflen = sizeof(peer_addr_str);
+	rxr_peer_raw_addr_str(ep, rx_entry->addr, peer_addr_str, &buflen);
 
+	FI_WARN(&rxr_prov, FI_LOG_CQ,
+		"rxr_cq_write_rx_error: err: %d, prov_err: %s (%d) our address: %s, peer address %s\n",
+		err_entry.err, efa_strerror(err_entry.prov_errno),
+		err_entry.prov_errno, ep_addr_str, peer_addr_str);
 	/*
 	 * TODO: We can't free the rx_entry as we may receive additional
 	 * packets for this entry. Add ref counting so the rx_entry can safely
@@ -183,7 +191,7 @@ void rxr_cq_write_tx_error(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
 	struct rxr_pkt_entry *pkt_entry;
 	int write_cq_err;
 	char ep_addr_str[OFI_ADDRSTRLEN], peer_addr_str[OFI_ADDRSTRLEN];
-	size_t buflen=0;
+	size_t buflen = 0;
 
 	memset(&err_entry, 0, sizeof(err_entry));
 	memset(&ep_addr_str, 0, sizeof(ep_addr_str));


### PR DESCRIPTION
Backporting to `v1.16.x`. Cherry-picked from 51ec51a340f2aca8d408b72351f4676a8a2399a0