### PR TITLE
fabtests/pytest/common.py: retry client process separately in client server tests

### DIFF
--- a/fabtests/pytest/common.py
+++ b/fabtests/pytest/common.py
@@ -1,9 +1,11 @@
-import pytest
+import copy
 import errno
 import os
-import copy
+from subprocess import Popen, TimeoutExpired, run
 from tempfile import NamedTemporaryFile
-from subprocess import run
+from time import sleep
+
+import pytest
 from retrying import retry
 
 
@@ -146,10 +148,6 @@ class UnitTest:
 
     @retry(retry_on_exception=is_ssh_connection_error, stop_max_attempt_number=3, wait_fixed=5000)
     def run(self):
-        import os
-        from tempfile import NamedTemporaryFile
-        from subprocess import Popen, TimeoutExpired
-
         if self._cmdline_args.is_test_excluded(self._base_command, self._is_negative):
             pytest.skip("excluded")
             return
@@ -297,12 +295,7 @@ class ClientServerTest:
 
     @retry(retry_on_exception=is_ssh_connection_error, stop_max_attempt_number=3, wait_fixed=5000)
     def run(self):
-        import os
-        from time import sleep
-        from tempfile import NamedTemporaryFile
-        from subprocess import Popen, TimeoutExpired
-
-        if self._cmdline_args.is_test_excluded(self._server_base_command):
+        if self._server_cmdline_args.is_test_excluded(self._server_base_command):
             pytest.skip("excluded")
             return
 
@@ -374,11 +367,6 @@ class MultinodeTest:
         self._client_command = cmdline_args.populate_command(multinode_command, "client", self._timeout)
 
     def run(self):
-        import os
-        from time import sleep
-        from tempfile import NamedTemporaryFile
-        from subprocess import Popen, TimeoutExpired
-
         if self._cmdline_args.is_test_excluded(self._base_command):
             pytest.skip("excluded")
             return

--- a/fabtests/pytest/common.py
+++ b/fabtests/pytest/common.py
@@ -150,7 +150,6 @@ class UnitTest:
     def run(self):
         if self._cmdline_args.is_test_excluded(self._base_command, self._is_negative):
             pytest.skip("excluded")
-            return
 
         # start running
         outfile = NamedTemporaryFile(prefix="fabtests_server.out.").name
@@ -273,20 +272,16 @@ class ClientServerTest:
         if command_type == "server" and server_memory_type == "cuda":
             if not has_cuda(self._cmdline_args.server_id):
                 pytest.skip("no cuda device")
-                return
             if not has_hmem_support(self._cmdline_args, self._cmdline_args.server_id):
                 pytest.skip("no hmem support")
-                return
 
             return command + " -D cuda"
 
         if command_type == "client" and client_memory_type == "cuda":
             if not has_cuda(self._cmdline_args.client_id):
                 pytest.skip("no cuda device")
-                return
             if not has_hmem_support(self._cmdline_args, self._cmdline_args.client_id):
                 pytest.skip("no hmem support")
-                return
 
             return command + " -D cuda"
 
@@ -297,11 +292,9 @@ class ClientServerTest:
     def run(self):
         if self._server_cmdline_args.is_test_excluded(self._server_base_command):
             pytest.skip("excluded")
-            return
 
         if self._cmdline_args.is_test_excluded(self._client_base_command):
             pytest.skip("excluded")
-            return
 
         # start running
         server_outfile = NamedTemporaryFile(prefix="fabtests_server.out.").name
@@ -369,7 +362,6 @@ class MultinodeTest:
     def run(self):
         if self._cmdline_args.is_test_excluded(self._base_command):
             pytest.skip("excluded")
-            return
 
         server_outfile = NamedTemporaryFile(prefix="fabtests_server.out.").name
 


### PR DESCRIPTION
In client-server tests, SSH connection error will cause both the client and server processes to be terminated and retried. This is inefficient and problematic.
When the server startup is slow, e.g. > 1 second, OOB address exchange will fail due to SSH connection. In this case, restarting both the server and client does not solve the problem. Instead, we only need to retry the client process.