### PR TITLE
fabtests/pytest,scripts: add neuron memory types to test suites

### DIFF
--- a/fabtests/pytest/common.py
+++ b/fabtests/pytest/common.py
@@ -6,8 +6,9 @@ from subprocess import Popen, TimeoutExpired, run
 from tempfile import NamedTemporaryFile
 from time import sleep
 
-import pytest
 from retrying import retry
+
+import pytest
 
 SERVER_RESTART_DELAY_MS = 10_1000
 CLIENT_RETRY_INTERVAL_MS = 1_000

--- a/fabtests/pytest/efa/conftest.py
+++ b/fabtests/pytest/efa/conftest.py
@@ -1,9 +1,13 @@
 import pytest
 
+
 @pytest.fixture(scope="module", params=["host_to_host",
                                         pytest.param("host_to_cuda", marks=pytest.mark.cuda_memory),
                                         pytest.param("cuda_to_host", marks=pytest.mark.cuda_memory),
-                                        pytest.param("cuda_to_cuda", marks=pytest.mark.cuda_memory)])
+                                        pytest.param("cuda_to_cuda", marks=pytest.mark.cuda_memory),
+                                        pytest.param("neuron_to_neuron", marks=pytest.mark.neuron_memory),
+                                        pytest.param("neuron_to_host", marks=pytest.mark.neuron_memory),
+                                        pytest.param("host_to_neuron", marks=pytest.mark.neuron_memory)])
 def memory_type(request):
     return request.param
 

--- a/fabtests/pytest/efa/test_mr.py
+++ b/fabtests/pytest/efa/test_mr.py
@@ -11,12 +11,25 @@ def test_mr_host(cmdline_args):
 
 
 @pytest.mark.unit
-def test_mr_cuda(cmdline_args):
-    if not has_cuda(cmdline_args.server_id):
+@pytest.mark.parametrize(
+    "hmem_type",
+    [
+        pytest.param("cuda", marks=pytest.mark.cuda_memory),
+        pytest.param("neuron", marks=pytest.mark.neuron_memory),
+    ],
+)
+def test_mr_hmem(cmdline_args, hmem_type):
+    if hmem_type == "cuda" and not has_cuda(cmdline_args.server_id):
         pytest.skip("no cuda device")
+    if hmem_type == "neuron" and not has_neuron(cmdline_args.server_id):
+        pytest.skip("no neuron device")
 
     cmdline_args_copy = copy.copy(cmdline_args)
     cmdline_args_copy.append_environ("FI_EFA_USE_DEVICE_RDMA=1")
 
-    test = UnitTest(cmdline_args_copy, "fi_mr_test -D cuda", failing_warn_msgs=["Unable to add MR to map"] )
+    test = UnitTest(
+        cmdline_args_copy,
+        f"fi_mr_test -D {hmem_type}",
+        failing_warn_msgs=["Unable to add MR to map"],
+    )
     test.run()

--- a/fabtests/pytest/efa/test_mr.py
+++ b/fabtests/pytest/efa/test_mr.py
@@ -1,6 +1,8 @@
-import pytest
 import copy
-from common import UnitTest, has_cuda
+
+import pytest
+from common import UnitTest, has_cuda, has_neuron
+
 
 @pytest.mark.unit
 def test_mr_host(cmdline_args):

--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -45,7 +45,12 @@ def test_rdm_tagged_bw_range(cmdline_args, completion_type, memory_type, message
                           pytest.param("standard", marks=pytest.mark.standard)])
 def test_rdm_atomic(cmdline_args, iteration_type, completion_type, memory_type):
     from copy import copy
+
     from common import ClientServerTest
+
+    if "neuron" in memory_type:
+        pytest.skip("Neuron does not fully support atomics")
+
     # the rdm_atomic test's run time has a high variance when running single c6gn instance.
     # the issue is tracked in:  https://github.com/ofiwg/libfabric/issues/7002
     # to mitigate the issue, set the maximum timeout of fi_rdm_atomic to 1800 seconds.

--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -1,19 +1,18 @@
+from default.test_rdm import test_rdm, test_rdm_bw_functional
+from efa.efa_common import efa_run_client_server_test
+
 import pytest
 
-from default.test_rdm import test_rdm
-from default.test_rdm import test_rdm_bw_functional
 
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
 def test_rdm_pingpong(cmdline_args, iteration_type, completion_type, memory_type):
-    from efa.efa_common import efa_run_client_server_test
     efa_run_client_server_test(cmdline_args, "fi_rdm_pingpong", iteration_type,
                                completion_type, memory_type, "all")
 
 @pytest.mark.functional
 def test_rdm_pingpong_range(cmdline_args, completion_type, memory_type, message_size):
-    from efa.efa_common import efa_run_client_server_test
     efa_run_client_server_test(cmdline_args, "fi_rdm_pingpong", "short",
                                completion_type, memory_type, message_size)
 
@@ -21,13 +20,11 @@ def test_rdm_pingpong_range(cmdline_args, completion_type, memory_type, message_
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
 def test_rdm_tagged_pingpong(cmdline_args, iteration_type, completion_type, memory_type):
-    from efa.efa_common import efa_run_client_server_test
     efa_run_client_server_test(cmdline_args, "fi_rdm_tagged_pingpong", iteration_type,
                                completion_type, memory_type, "all")
 
 @pytest.mark.functional
 def test_rdm_tagged_pingpong_range(cmdline_args, completion_type, memory_type, message_size):
-    from efa.efa_common import efa_run_client_server_test
     efa_run_client_server_test(cmdline_args, "fi_rdm_tagged_pingpong", "short",
                                completion_type, memory_type, message_size)
 
@@ -35,13 +32,11 @@ def test_rdm_tagged_pingpong_range(cmdline_args, completion_type, memory_type, m
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
 def test_rdm_tagged_bw(cmdline_args, iteration_type, completion_type, memory_type):
-    from efa.efa_common import efa_run_client_server_test
     efa_run_client_server_test(cmdline_args, "fi_rdm_tagged_bw", iteration_type,
                                completion_type, memory_type, "all")
 
 @pytest.mark.functional
 def test_rdm_tagged_bw_range(cmdline_args, completion_type, memory_type, message_size):
-    from efa.efa_common import efa_run_client_server_test
     efa_run_client_server_test(cmdline_args, "fi_rdm_tagged_bw", "short",
                                completion_type, memory_type, message_size)
 

--- a/fabtests/pytest/efa/test_runt.py
+++ b/fabtests/pytest/efa/test_runt.py
@@ -17,31 +17,26 @@ def test_runt_read_functional(cmdline_args, cuda_copy_method):
     if cmdline_args.server_id == cmdline_args.client_id:
         pytest.skip("no runting for intra-node communication")
 
-    cmdline_args_copy = copy.copy(cmdline_args)
-
-    cmdline_args_copy.append_environ("FI_EFA_USE_DEVICE_RDMA=1")
-    cmdline_args_copy.append_environ("FI_EFA_RUNT_SIZE=65536")
+    cmdline_args.append_environ("FI_EFA_RUNT_SIZE=65536")
 
     if cuda_copy_method == "gdrcopy":
         if not has_gdrcopy(cmdline_args.server_id) or not has_gdrcopy(cmdline_args.client_id):
             pytest.skip("No gdrcopy")
-            return
 
-        cmdline_args_copy.append_environ("FI_HMEM_CUDA_USE_GDRCOPY=1")
+        cmdline_args.append_environ("FI_HMEM_CUDA_USE_GDRCOPY=1")
     else:
-        cmdline_args_copy.append_environ("FI_HMEM_CUDA_USE_GDRCOPY=0")
+        cmdline_args.append_environ("FI_HMEM_CUDA_USE_GDRCOPY=0")
 
     # wrs stands for work requests
     server_read_wrs_before_test = efa_retrieve_hw_counter_value(cmdline_args.server_id, "rdma_read_wrs")
     if server_read_wrs_before_test is None:
         pytest.skip("No HW counter support")
-        return
 
     server_read_bytes_before_test = efa_retrieve_hw_counter_value(cmdline_args.server_id, "rdma_read_bytes")
     client_send_bytes_before_test = efa_retrieve_hw_counter_value(cmdline_args.client_id, "send_bytes")
 
     # currently runting read is only used on cuda memory, hence set the memory_type to "cuda_to_cuda"
-    efa_run_client_server_test(cmdline_args_copy,
+    efa_run_client_server_test(cmdline_args,
                                "fi_rdm_tagged_bw",
                                iteration_type="1",
                                completion_type="transmit_complete",

--- a/fabtests/pytest/efa/test_runt.py
+++ b/fabtests/pytest/efa/test_runt.py
@@ -1,4 +1,8 @@
+from efa.efa_common import (efa_retrieve_hw_counter_value,
+                            efa_run_client_server_test, has_gdrcopy)
+
 import pytest
+
 
 # this test must be run in serial mode because it check hw counter
 @pytest.mark.serial
@@ -10,10 +14,6 @@ def test_runt_read_functional(cmdline_args, cuda_copy_method):
     64 KB of the message will be transfered using EFA device's send capability
     The remainer will be tranfered using EFA device's RDMA read capability
     """
-
-    import copy
-    from efa.efa_common import efa_run_client_server_test, efa_retrieve_hw_counter_value, has_gdrcopy
-
     if cmdline_args.server_id == cmdline_args.client_id:
         pytest.skip("no runting for intra-node communication")
 

--- a/fabtests/pytest/pytest.ini
+++ b/fabtests/pytest/pytest.ini
@@ -1,15 +1,16 @@
 [pytest]
 markers =
-    unit : single instance unit test
-    functional : runs on two instances, not performance related
-    short : short communcation tests, usually 5 iterations
-    standard : longer communcation tests
+    unit: single instance unit test
+    functional: runs on two instances, not performance related
+    short: short communcation tests, usually 5 iterations
+    standard: longer communcation tests
     multinode: testing the multi node functionality
     ubertest_all: ubertest tests run will all config
     ubertest_quick: ubertest tests run with quick config
     ubertest_verify: ubertest tests run with verify config
     cuda_memory: testing with cuda device memory direct
-    serial : test must be run in serial mode
+    neuron_memory: testing with neuron device memory
+    serial: test must be run in serial mode
 junit_suite_name = fabtests
 junit_logging = all
 junit_log_passing_tests = true

--- a/fabtests/pytest/shm/conftest.py
+++ b/fabtests/pytest/shm/conftest.py
@@ -1,8 +1,12 @@
 import pytest
 
+
 @pytest.fixture(scope="module", params=["host_to_host",
                                         pytest.param("host_to_cuda", marks=pytest.mark.cuda_memory),
                                         pytest.param("cuda_to_host", marks=pytest.mark.cuda_memory),
-                                        pytest.param("cuda_to_cuda", marks=pytest.mark.cuda_memory)])
+                                        pytest.param("cuda_to_cuda", marks=pytest.mark.cuda_memory),
+                                        pytest.param("neuron_to_neuron", marks=pytest.mark.neuron_memory),
+                                        pytest.param("neuron_to_host", marks=pytest.mark.neuron_memory),
+                                        pytest.param("host_to_neuron", marks=pytest.mark.neuron_memory)])
 def memory_type(request):
     return request.param

--- a/fabtests/scripts/runfabtests.py
+++ b/fabtests/scripts/runfabtests.py
@@ -31,7 +31,13 @@
 # SOFTWARE.
 #
 
+import argparse
+import builtins
 import os
+import sys
+
+import yaml
+
 import pytest
 
 
@@ -128,8 +134,6 @@ def get_default_ubertest_config_file(fabtests_args):
     return cfg_file
 
 def add_common_arguments(parser, shared_options):
-    import builtins
-
     for option_name in shared_options.keys():
         option_params = shared_options[option_name]
         option_longform = get_option_longform(option_name, option_params)
@@ -244,7 +248,6 @@ def get_pytest_root_dir():
     '''
         find the pytest root directory according the location of runfabtests.py
     '''
-    import sys
     script_path = os.path.abspath(sys.argv[0])
     script_dir = os.path.dirname(script_path)
     if os.path.basename(script_dir) == "bin":
@@ -299,10 +302,6 @@ def run(fabtests_args, shared_options, run_mode):
 
 
 def main():
-    import sys
-    import yaml
-    import argparse
-
     pytest_root_dir = get_pytest_root_dir()
 
     # pytest/options.yaml contains the definition of a list of options that are

--- a/fabtests/scripts/runfabtests.py
+++ b/fabtests/scripts/runfabtests.py
@@ -227,10 +227,10 @@ def fabtests_args_to_pytest_args(fabtests_args, shared_options, run_mode):
 
         if option_type == "bool" or option_type == "boolean":
             assert option_value
-            pytest_args.append(get_option_longform(option_name, option_params))
+            pytest_args.append(option_longform)
         else:
             assert option_type == "str" or option_type == "int"
-            pytest_args.append(get_option_longform(option_name, option_params) + "=" + str(option_value))
+            pytest_args.append(option_longform + "=" + str(option_value))
 
     if not hasattr(fabtests_args, "exclusion_file") or not fabtests_args.exclusion_file:
         default_exclusion_file = get_default_exclusion_file(fabtests_args)

--- a/fabtests/scripts/runfabtests.py
+++ b/fabtests/scripts/runfabtests.py
@@ -319,7 +319,7 @@ def main():
     parser.add_argument("server_id", type=str, help="server ip or hostname")
     parser.add_argument("client_id", type=str, help="client ip or hostname")
     parser.add_argument("-t", dest="testsets", type=str, default="quick",
-                        help="test set(s): all,quick,unit,functional,standard,short,ubertest (default quick)")
+                        help="test set(s): all,quick,unit,functional,standard,short,ubertest,cuda_memory,neuron_memory (default quick)")
     parser.add_argument("-v", dest="verbose", action="count", default=0,
                         help="verbosity level"
                              "-v: print extra info for failed test(s)"


### PR DESCRIPTION
Introduce Neuron memory types to test suites. Notably we omitted rdm atomic - Neuron does not currently support atomic ops so we skip those tests
Also included are cosmetic changes that I stumped upon while making the changes.