### PR TITLE
prov/efa: compare pci bus id in hints

### DIFF
--- a/prov/efa/src/efa_prov_info.c
+++ b/prov/efa/src/efa_prov_info.c
@@ -740,3 +740,23 @@ int efa_prov_info_compare_domain_name(const struct fi_info *hints,
 
        return 0;
 }
+
+/*
+ * @brief Compare the bus id specified via hints and match it with the
+ *		  bus_id in prov_info
+ *
+ * @param[in]  info        info object
+ * @param[in]  hints       hints from user's call to fi_getinfo()
+ *
+ * return      1 - If the bus_id in hints does not match info
+ *             0 - If the bus_id in hints match info, or user did not specify bus ID in hints
+ */
+int efa_prov_info_compare_pci_bus_id(const struct fi_info *hints,
+                                     const struct fi_info *info)
+{
+	if (hints && hints->nic && hints->nic->bus_attr && hints->nic->bus_attr->bus_type == FI_BUS_PCI) {
+		return (hints->nic->bus_attr->attr.pci.bus_id == info->nic->bus_attr->attr.pci.bus_id) ? 0 : 1;
+	}
+
+	return 0;
+}

--- a/prov/efa/src/efa_prov_info.h
+++ b/prov/efa/src/efa_prov_info.h
@@ -48,4 +48,7 @@ int efa_prov_info_compare_src_addr(const char *node, uint64_t flags, const struc
 int efa_prov_info_compare_domain_name(const struct fi_info *hints,
                                       const struct fi_info *info);
 
+int efa_prov_info_compare_pci_bus_id(const struct fi_info *hints,
+                                     const struct fi_info *info);
+
 #endif

--- a/prov/efa/src/efa_user_info.c
+++ b/prov/efa/src/efa_user_info.c
@@ -222,6 +222,10 @@ int efa_user_info_get_dgram(uint32_t version, const char *node, const char *serv
 		if (ret)
 			continue;
 
+		ret = efa_prov_info_compare_pci_bus_id(hints, prov_info_dgram);
+		if (ret)
+			continue;
+
 		EFA_INFO(FI_LOG_FABRIC, "found match for interface %s %s\n",
 			 node, prov_info_dgram->fabric_attr->name);
 		if (hints) {
@@ -494,6 +498,10 @@ int efa_user_info_get_rdm(uint32_t version, const char *node,
 			continue;
 
 		ret = efa_prov_info_compare_domain_name(hints, prov_info_rxr);
+		if (ret)
+			continue;
+
+		ret = efa_prov_info_compare_pci_bus_id(hints, prov_info_rxr);
 		if (ret)
 			continue;
 


### PR DESCRIPTION
If user specified pic bus id in hints, use it to select info.

Signed-off-by: Wei Zhang <wzam@amazon.com>