### PR TITLE
prov/efa: request FI_SOURCE capablity for shm provider

### DIFF
--- a/prov/efa/src/efa_shm.c
+++ b/prov/efa/src/efa_shm.c
@@ -103,7 +103,7 @@ void efa_shm_info_initialize(const struct fi_info *app_hints)
 	shm_hints = fi_allocinfo();
 	shm_hints->caps = FI_MSG | FI_TAGGED | FI_RECV | FI_SEND | FI_READ
 			   | FI_WRITE | FI_REMOTE_READ | FI_REMOTE_WRITE
-			   | FI_MULTI_RECV | FI_RMA;
+			   | FI_MULTI_RECV | FI_RMA | FI_SOURCE;
 	shm_hints->domain_attr->av_type = FI_AV_TABLE;
 	shm_hints->domain_attr->mr_mode = FI_MR_VIRT_ADDR;
 	shm_hints->domain_attr->caps |= FI_LOCAL_COMM;


### PR DESCRIPTION
EFA progress engine need CQ entry from shm to have source address, to correctly map CQ from shm proivder to EFA peer, For that, EFA need to request the FI_SOURCE capablity from shm provider.

Signed-off-by: Wei Zhang <wzam@amazon.com>