### PR TITLE
fabtests/pytest/common.py: skip neuron to neuron tests on single node

### DIFF
--- a/fabtests/pytest/common.py
+++ b/fabtests/pytest/common.py
@@ -292,6 +292,9 @@ class ClientServerTest:
                 pytest.skip("no cuda device")
             elif host_memory_type == "neuron" and not has_neuron(host_ip):
                 pytest.skip("no neuron device")
+            elif (client_memory_type == server_memory_type == "neuron") and (
+                    self._cmdline_args.server_id == self._cmdline_args.client_id):
+                pytest.skip("Neuron to Neuron tests require 2 nodes")
 
             command = command + " -D " + host_memory_type
 


### PR DESCRIPTION
Because both client and server utilize all Neuron cores, they cannot request -D neuron on the same node. Thus skip those tests.

Signed-off-by: Wenduo Wang <wenduwan@amazon.com>