### PR TITLE
include,src/hmem: Define missing neuron hmem ops function pointers

### DIFF
--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -206,6 +206,8 @@ int ze_hmem_host_unregister(void *ptr);
 
 int neuron_copy_to_dev(uint64_t device, void *dev, const void *host, size_t size);
 int neuron_copy_from_dev(uint64_t device, void *host, const void *dev, size_t size);
+int neuron_host_register(void *ptr, size_t size);
+int neuron_host_unregister(void *ptr);
 int neuron_hmem_init(void);
 int neuron_hmem_cleanup(void);
 void *neuron_alloc(void **handle, size_t size);

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -112,6 +112,13 @@ struct ofi_hmem_ops hmem_ops[] = {
 		.cleanup = neuron_hmem_cleanup,
 		.copy_to_hmem = neuron_copy_to_dev,
 		.copy_from_hmem = neuron_copy_from_dev,
+		.get_handle = ofi_hmem_no_get_handle,
+		.open_handle = ofi_hmem_no_open_handle,
+		.close_handle = ofi_hmem_no_close_handle,
+		.host_register = neuron_host_register,
+		.host_unregister = neuron_host_unregister,
+		.get_base_addr = ofi_hmem_no_base_addr,
+		.is_ipc_enabled = ofi_hmem_no_is_ipc_enabled,
 		.get_ipc_handle_size = ofi_hmem_no_get_ipc_handle_size,
 	},
 	[FI_HMEM_SYNAPSEAI] = {

--- a/src/hmem_neuron.c
+++ b/src/hmem_neuron.c
@@ -122,6 +122,16 @@ int neuron_copy_from_dev(uint64_t device, void *host, const void *dev, size_t si
 	return -FI_ENOSYS;
 }
 
+int neuron_host_register(void *ptr, size_t size)
+{
+	return FI_SUCCESS;
+}
+
+int neuron_host_unregister(void *ptr)
+{
+	return FI_SUCCESS;
+}
+
 int neuron_hmem_init(void)
 {
 	int ret;
@@ -176,6 +186,16 @@ int neuron_copy_to_dev(uint64_t device, void *dev, const void *host, size_t size
 }
 
 int neuron_copy_from_dev(uint64_t device, void *host, const void *dev, size_t size)
+{
+	return -FI_ENOSYS;
+}
+
+int neuron_host_register(void *ptr, size_t size)
+{
+	return -FI_ENOSYS;
+}
+
+int neuron_host_unregister(void *ptr)
 {
 	return -FI_ENOSYS;
 }


### PR DESCRIPTION
Neuron hmem iface is missing ops function pointers, which caused segfault on trn1 hosts.
The function pointers are used in `ofi_hmem_host_register` by SHM provider etc.

This problem was not revealed in AWS CI because it does not test on trn1 hosts, thus the
Neuron code path was not activated.