### PR TITLE
contrib/intel/jenkins: Fix shmem summary & add dsa testing back

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -170,7 +170,6 @@ pipeline {
             }
           }
         }
-        /*
         stage ('build-dsa') {
           agent {
             node {
@@ -197,7 +196,6 @@ pipeline {
             }
           }
         }
-        */
       }
     }
     stage('parallel-tests') {
@@ -573,7 +571,6 @@ pipeline {
             }
           }
         }
-        /*
         stage('dsa') {
           agent {
             node {
@@ -595,7 +592,6 @@ pipeline {
             }
           }
         }
-        */
         stage('net') {
           agent { node { label 'cvl' } }
           options { skipDefaultCheckout() }
@@ -766,7 +762,6 @@ pipeline {
           }
         }
       }
-      /*
       node ('dsa') {
         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
           dir ("${env.CI_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}") {
@@ -780,7 +775,6 @@ pipeline {
           }
         }
       }
-      */
       withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
         dir ("${env.CI_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}") {
           deleteDir()

--- a/contrib/intel/jenkins/summary.py
+++ b/contrib/intel/jenkins/summary.py
@@ -329,6 +329,7 @@ class ShmemSummarizer(Summarizer):
                     f"passes {self.passes} do not match log reported passes "\
                     f"{token}"
                 )
+            token = int(failed.split()[1].split('/')[0])
             if self.fails != int(token):
                 self.logger.log(
                     f"fails {self.fails} does not match log fails "\
@@ -615,7 +616,7 @@ def summarize_items(summary_item, logger, log_dir, mode):
         for type in shmem_types:
             ret= ShmemSummarizer(
                 logger, log_dir, f'{type}',
-                f'SHMEM_{type}_shmem{mode}',
+                f'SHMEM_{type}_shmem_{mode}',
                 f'shmem {type} {mode}'
             ).summarize()
         err += ret if ret else 0


### PR DESCRIPTION
Add dsa testing back because the node is back online
Fix a bug where shmem wasn't properly opening files due to missing underscore and improper resetting of a token check.