### PR TITLE
prov/net,uring: cancel outstanding SQEs + various bugfixes 

### DIFF
--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -149,8 +149,14 @@ typedef struct {
 } ofi_io_uring_cqe_t;
 #endif
 
+enum ofi_sockctx_type {
+	OFI_SOCKCTX_TX,
+	OFI_SOCKCTX_RX,
+};
+
 struct ofi_sockctx {
 	void *context;
+	enum ofi_sockctx_type type;
 	bool uring_sqe_inuse;
 };
 
@@ -176,9 +182,11 @@ struct ofi_sockapi {
 };
 
 static inline void
-ofi_sockctx_init(struct ofi_sockctx *sockctx, void *context)
+ofi_sockctx_init(struct ofi_sockctx *sockctx, enum ofi_sockctx_type type,
+		 void *context)
 {
 	sockctx->context = context;
+	sockctx->type = type;
 	sockctx->uring_sqe_inuse = false;
 }
 
@@ -460,8 +468,8 @@ ofi_bsock_init(struct ofi_bsock *bsock, struct ofi_sockapi *sockapi,
 {
 	bsock->sock = INVALID_SOCKET;
 	bsock->sockapi = sockapi;
-	ofi_sockctx_init(&bsock->tx_sockctx, bsock);
-	ofi_sockctx_init(&bsock->rx_sockctx, bsock);
+	ofi_sockctx_init(&bsock->tx_sockctx, OFI_SOCKCTX_TX, bsock);
+	ofi_sockctx_init(&bsock->rx_sockctx, OFI_SOCKCTX_RX, bsock);
 	ofi_byteq_init(&bsock->sq, sbuf_size);
 	ofi_byteq_init(&bsock->rq, rbuf_size);
 	bsock->zerocopy_size = SIZE_MAX;

--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -152,6 +152,7 @@ typedef struct {
 enum ofi_sockctx_type {
 	OFI_SOCKCTX_TX,
 	OFI_SOCKCTX_RX,
+	OFI_SOCKCTX_CANCEL,
 };
 
 struct ofi_sockctx {
@@ -467,6 +468,7 @@ struct ofi_bsock {
 	struct ofi_sockapi *sockapi;
 	struct ofi_sockctx tx_sockctx;
 	struct ofi_sockctx rx_sockctx;
+	struct ofi_sockctx cancel_sockctx;
 	struct ofi_byteq sq;
 	struct ofi_byteq rq;
 	size_t zerocopy_size;
@@ -483,6 +485,7 @@ ofi_bsock_init(struct ofi_bsock *bsock, struct ofi_sockapi *sockapi,
 	bsock->sockapi = sockapi;
 	ofi_sockctx_init(&bsock->tx_sockctx, OFI_SOCKCTX_TX, bsock);
 	ofi_sockctx_init(&bsock->rx_sockctx, OFI_SOCKCTX_RX, bsock);
+	ofi_sockctx_init(&bsock->cancel_sockctx, OFI_SOCKCTX_CANCEL, bsock);
 	ofi_byteq_init(&bsock->sq, sbuf_size);
 	ofi_byteq_init(&bsock->rq, rbuf_size);
 	bsock->zerocopy_size = SIZE_MAX;

--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -276,6 +276,10 @@ ssize_t ofi_sockapi_recvv_uring(struct ofi_sockapi *sockapi, SOCKET sock,
 				struct iovec *iov, size_t cnt, int flags,
 				struct ofi_sockctx *ctx);
 
+int ofi_sockctx_uring_cancel(struct ofi_sockapi_uring *uring,
+			     struct ofi_sockctx *canceled_ctx,
+			     struct ofi_sockctx *ctx);
+
 int ofi_uring_init(ofi_io_uring_t *io_uring, size_t entries);
 int ofi_uring_destroy(ofi_io_uring_t *io_uring);
 
@@ -342,6 +346,15 @@ static inline ssize_t
 ofi_sockapi_recvv_uring(struct ofi_sockapi *sockapi, SOCKET sock,
 			struct iovec *iov, size_t cnt, int flags,
 			struct ofi_sockctx *ctx)
+{
+	return -FI_ENOSYS;
+}
+
+
+static inline int
+ofi_sockctx_uring_cancel(struct ofi_sockapi_uring *uring,
+			 struct ofi_sockctx *canceled_ctx,
+			 struct ofi_sockctx *ctx)
 {
 	return -FI_ENOSYS;
 }

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -338,6 +338,11 @@ int xnet_monitor_sock(struct xnet_progress *progress, SOCKET sock,
 		      uint32_t events, struct fid *fid);
 void xnet_halt_sock(struct xnet_progress *progress, SOCKET sock);
 
+int xnet_uring_cancel(struct xnet_progress *progress,
+		      struct xnet_uring *uring,
+		      struct ofi_sockctx *canceled_ctx,
+		      struct ofi_sockctx *ctx);
+
 static inline int xnet_progress_locked(struct xnet_progress *progress)
 {
 	return ofi_genlock_held(progress->active_lock);

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -263,6 +263,7 @@ void xnet_freeall_conns(struct xnet_rdm *rdm);
 struct xnet_uring {
 	struct fid fid;
 	ofi_io_uring_t ring;
+	struct ofi_sockapi_uring *sockapi;
 };
 
 /* Serialization is handled at the progress instance level, using the

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -923,12 +923,12 @@ static void xnet_progress_cqe(struct xnet_progress *progress,
 
 	assert(sockctx->uring_sqe_inuse);
 	sockctx->uring_sqe_inuse = false;
+	uring->sockapi->credits++;
 
 	if (sockctx->type == OFI_SOCKCTX_TX) {
 		tx_entry = ep->cur_tx.entry;
 		assert(tx_entry);
 
-		progress->sockapi.tx_uring.credits++;
 		if (cqe->res < 0) {
 			if (!OFI_SOCK_TRY_SND_RCV_AGAIN(-cqe->res))
 				xnet_complete_tx(ep, cqe->res);
@@ -945,7 +945,6 @@ static void xnet_progress_cqe(struct xnet_progress *progress,
 	} else {
 		assert(sockctx->type == OFI_SOCKCTX_RX);
 
-		progress->sockapi.rx_uring.credits++;
 		if (bsock->async_prefetch) {
 			if (cqe->res > 0)
 				ofi_bsock_prefetch_done(bsock, cqe->res);

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -923,7 +923,8 @@ static void xnet_progress_cqe(struct xnet_progress *progress,
 
 	assert(sockctx->uring_sqe_inuse);
 	sockctx->uring_sqe_inuse = false;
-	if (&uring->ring == progress->sockapi.tx_uring.io_uring) {
+
+	if (sockctx->type == OFI_SOCKCTX_TX) {
 		tx_entry = ep->cur_tx.entry;
 		assert(tx_entry);
 
@@ -942,7 +943,7 @@ static void xnet_progress_cqe(struct xnet_progress *progress,
 		}
 		xnet_progress_tx(ep);
 	} else {
-		assert(&uring->ring == progress->sockapi.rx_uring.io_uring);
+		assert(sockctx->type == OFI_SOCKCTX_RX);
 
 		progress->sockapi.rx_uring.credits++;
 		if (bsock->async_prefetch) {

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -288,6 +288,7 @@ static int xnet_recv_msg_data(struct xnet_ep *ep)
 		if (ret == -OFI_EINPROGRESS_URING) {
 			ep->cur_rx.data_left -= len;
 			assert(ep->cur_rx.data_left);
+			ofi_consume_iov(rx_entry->iov, &rx_entry->iov_cnt, len);
 		}
 		return ret;
 	}

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -966,6 +966,7 @@ static void xnet_progress_cqe(struct xnet_progress *progress,
 			rx_entry = ep->cur_rx.entry;
 			assert(rx_entry);
 
+			assert(cqe->res <= ep->cur_rx.data_left);
 			ep->cur_rx.data_left -= cqe->res;
 			if (ep->cur_rx.data_left)
 				ofi_consume_iov(rx_entry->iov, &rx_entry->iov_cnt,

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -1180,7 +1180,10 @@ int xnet_progress_wait(struct xnet_progress *progress, int timeout)
 
 	/* We cannot enter blocking if io_uring has entries
 	 * that need submission. */
-	assert(ofi_uring_sq_ready(&progress->tx_uring.ring) == 0);
+	if (xnet_io_uring) {
+		assert(ofi_uring_sq_ready(&progress->tx_uring.ring) == 0);
+		assert(ofi_uring_sq_ready(&progress->rx_uring.ring) == 0);
+	}
 	return ofi_dynpoll_wait(&progress->epoll_fd, &event, 1, timeout);
 }
 

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -1017,7 +1017,7 @@ void xnet_tx_queue_insert(struct xnet_ep *ep,
 		ep->hdr_bswap(ep, &tx_entry->hdr.base_hdr);
 		xnet_progress_tx(ep);
 		if (xnet_io_uring)
-			xnet_progress_uring(progress, &progress->tx_uring);
+			xnet_submit_uring(&progress->tx_uring);
 	} else if (tx_entry->ctrl_flags & XNET_INTERNAL_XFER) {
 		slist_insert_tail(&tx_entry->entry, &ep->priority_queue);
 	} else {
@@ -1114,7 +1114,7 @@ void xnet_progress_unexp(struct xnet_progress *progress)
 		assert(ep->state == XNET_CONNECTED);
 		xnet_progress_rx(ep);
 		if (xnet_io_uring)
-			xnet_progress_uring(progress, &progress->rx_uring);
+			xnet_submit_uring(&progress->rx_uring);
 	}
 }
 

--- a/prov/net/src/xnet_progress.c
+++ b/prov/net/src/xnet_progress.c
@@ -1337,6 +1337,7 @@ static int xnet_init_locks(struct xnet_progress *progress, struct fi_info *info)
 }
 
 static int xnet_init_uring(struct xnet_uring *uring, size_t entries,
+			   struct ofi_sockapi_uring *sockapi,
 			   struct ofi_dynpoll *dynpoll)
 {
 	int ret;
@@ -1346,6 +1347,7 @@ static int xnet_init_uring(struct xnet_uring *uring, size_t entries,
 		return ret;
 
 	uring->fid.fclass = XNET_CLASS_URING;
+	uring->sockapi = sockapi;
 
 	ret = ofi_dynpoll_add(dynpoll,
 			      ofi_uring_get_fd(&uring->ring),
@@ -1411,6 +1413,7 @@ int xnet_init_progress(struct xnet_progress *progress, struct fi_info *info)
 		ret = xnet_init_uring(&progress->tx_uring,
 				      info ? info->tx_attr->size :
 					     xnet_default_tx_size,
+				      &progress->sockapi.tx_uring,
 				      &progress->epoll_fd);
 		if (ret)
 			goto err5;
@@ -1418,6 +1421,7 @@ int xnet_init_progress(struct xnet_progress *progress, struct fi_info *info)
 		ret = xnet_init_uring(&progress->rx_uring,
 				      info ? info->rx_attr->size :
 					     xnet_default_rx_size,
+				      &progress->sockapi.rx_uring,
 				      &progress->epoll_fd);
 		if (ret)
 			goto err6;

--- a/src/common.c
+++ b/src/common.c
@@ -1333,14 +1333,14 @@ int ofi_bsock_recv(struct ofi_bsock *bsock, void *buf, size_t *len)
 
 out:
 	*len = bytes;
-	if (*len)
-		return 0;
-
 	if (ret == -OFI_EINPROGRESS_URING) {
 		assert(!bsock->async_prefetch);
 		bsock->async_prefetch = avail;
 		return ret;
 	}
+	if (*len)
+		return 0;
+
 	return ret;
 }
 
@@ -1399,14 +1399,14 @@ int ofi_bsock_recvv(struct ofi_bsock *bsock, struct iovec *iov, size_t cnt,
 	}
 out:
 	*len = bytes;
-	if (*len)
-		return 0;
-
 	if (ret == -OFI_EINPROGRESS_URING) {
 		assert(!bsock->async_prefetch);
 		bsock->async_prefetch = avail;
 		return ret;
 	}
+	if (*len)
+		return 0;
+
 	return ret;
 }
 


### PR DESCRIPTION
The PR covers the following changes:
- it implements the cancelation of outstanding SQEs when the EP is flushed.
- it fixes a bunch of bugs I found while testing the io_uring support.

With this PR, fabtests reports the same percentage of passed tests whether io_uring is enabled or not (command line `./runfabtests.sh net`).

There is still one test that randomly fails with io_uring, I'm not sure why:
```
$ FI_NET_IO_URING=1 fi_cq_data -e rdm -p "net"   -s 127.0.0.1
Waiting for CQ data from client
remote_cq_data: success
fi_cq_data: prov/net/src/xnet_progress.c:1490: xnet_close_progress: Assertion `slist_empty(&progress->event_list)' failed.
Aborted (core dumped)
```
It looks like the process receives the FI_SHUTDOWN event in the EQ but the application doesn't consume it.