### PR TITLE
prov/net: Fix memory leaks with RDM

### DIFF
--- a/prov/net/src/xnet_rdm.c
+++ b/prov/net/src/xnet_rdm.c
@@ -849,6 +849,7 @@ static int xnet_init_rdm(struct xnet_rdm *rdm, struct fi_info *info)
 
 	rdm->srx = container_of(srx, struct xnet_srx, rx_fid);
 	rdm->pep = container_of(pep, struct xnet_pep, util_pep);
+	fi_freeinfo(msg_info);
 	return 0;
 
 err2:

--- a/prov/net/src/xnet_rdm_cm.c
+++ b/prov/net/src/xnet_rdm_cm.c
@@ -477,6 +477,7 @@ accept:
 	if (ret)
 		goto close;
 
+	fi_freeinfo(cm_entry->info);
 	return;
 
 close:


### PR DESCRIPTION
Running fabtests with ASAN has revealed 2 memory leaks with RDM. When a new endpoint (active or passive) is created, the fi_info object is duplicated and can be deleted by the caller.

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>