### PR TITLE
[v1.17.x] prov/efa: back port recent changes

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -120,7 +120,8 @@ prov_efa_test_efa_unit_test_CPPFLAGS = $(efa_CPPFLAGS)
 prov_efa_test_efa_unit_test_LDADD = $(cmocka_LIBS) $(linkback)
 prov_efa_test_efa_unit_test_LDFLAGS = $(cmocka_rpath) $(efa_LDFLAGS) $(cmocka_LDFLAGS) \
 					-Wl,--wrap=ibv_create_ah \
-					-Wl,--wrap=efadv_query_device
+					-Wl,--wrap=efadv_query_device \
+					-Wl,--wrap=ofi_copy_from_hmem_iov
 
 if HAVE_EFADV_CQ_EX
 prov_efa_test_efa_unit_test_LDFLAGS += -Wl,--wrap=efadv_create_cq

--- a/prov/efa/src/efa_prov_info.c
+++ b/prov/efa/src/efa_prov_info.c
@@ -740,3 +740,23 @@ int efa_prov_info_compare_domain_name(const struct fi_info *hints,
 
        return 0;
 }
+
+/*
+ * @brief Compare the bus id specified via hints and match it with the
+ *		  bus_id in prov_info
+ *
+ * @param[in]  info        info object
+ * @param[in]  hints       hints from user's call to fi_getinfo()
+ *
+ * return      1 - If the bus_id in hints does not match info
+ *             0 - If the bus_id in hints match info, or user did not specify bus ID in hints
+ */
+int efa_prov_info_compare_pci_bus_id(const struct fi_info *hints,
+                                     const struct fi_info *info)
+{
+	if (hints && hints->nic && hints->nic->bus_attr && hints->nic->bus_attr->bus_type == FI_BUS_PCI) {
+		return (hints->nic->bus_attr->attr.pci.bus_id == info->nic->bus_attr->attr.pci.bus_id) ? 0 : 1;
+	}
+
+	return 0;
+}

--- a/prov/efa/src/efa_prov_info.h
+++ b/prov/efa/src/efa_prov_info.h
@@ -48,4 +48,7 @@ int efa_prov_info_compare_src_addr(const char *node, uint64_t flags, const struc
 int efa_prov_info_compare_domain_name(const struct fi_info *hints,
                                       const struct fi_info *info);
 
+int efa_prov_info_compare_pci_bus_id(const struct fi_info *hints,
+                                     const struct fi_info *info);
+
 #endif

--- a/prov/efa/src/efa_user_info.c
+++ b/prov/efa/src/efa_user_info.c
@@ -222,6 +222,10 @@ int efa_user_info_get_dgram(uint32_t version, const char *node, const char *serv
 		if (ret)
 			continue;
 
+		ret = efa_prov_info_compare_pci_bus_id(hints, prov_info_dgram);
+		if (ret)
+			continue;
+
 		EFA_INFO(FI_LOG_FABRIC, "found match for interface %s %s\n",
 			 node, prov_info_dgram->fabric_attr->name);
 		if (hints) {
@@ -451,6 +455,10 @@ int efa_user_info_get_rdm(uint32_t version, const char *node,
 			continue;
 
 		ret = efa_prov_info_compare_domain_name(hints, prov_info_rxr);
+		if (ret)
+			continue;
+
+		ret = efa_prov_info_compare_pci_bus_id(hints, prov_info_rxr);
 		if (ret)
 			continue;
 

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -130,3 +130,42 @@ void test_rxr_ep_dc_atomic_error_handling()
 
 	efa_unit_test_resource_destruct(&resource);
 }
+
+/**
+ * @brief verify that when shm was used to send a small message (<4k), no copy was performed.
+ *
+ * @param[in]	state		struct efa_resource that is managed by the framework
+ */
+void test_rxr_ep_send_with_shm_no_copy()
+{
+	struct efa_resource resource = {0};
+	struct efa_ep_addr raw_addr = {0};
+	size_t raw_addr_len = sizeof(struct efa_ep_addr);
+	fi_addr_t peer_addr;
+	int num_addr;
+	int buff_len = 8;
+	char buff[8] = {0};
+	int err;
+
+	efa_unit_test_resource_construct(&resource, FI_EP_RDM);
+
+	/* create a fake peer */
+	err = fi_getname(&resource.ep->fid, &raw_addr, &raw_addr_len);
+	assert_int_equal(err, 0);
+	raw_addr.qpn = 1;
+	raw_addr.qkey = 0x1234;
+	num_addr = fi_av_insert(resource.av, &raw_addr, 1, &peer_addr, 0, NULL);
+	assert_int_equal(num_addr, 1);
+
+	g_ofi_copy_from_hmem_iov_call_counter = 0;
+	g_efa_unit_test_mocks.ofi_copy_from_hmem_iov = efa_mock_ofi_copy_from_hmem_iov_inc_counter;
+
+	err = fi_send(resource.ep, buff, buff_len,
+		      NULL /* desc, which is not required by shm */,
+		      peer_addr,
+		      NULL /* context */);
+
+	assert_int_equal(g_ofi_copy_from_hmem_iov_call_counter, 0);
+
+	efa_unit_test_resource_destruct(&resource);
+}

--- a/prov/efa/test/efa_unit_test_mocks.c
+++ b/prov/efa/test/efa_unit_test_mocks.c
@@ -163,6 +163,16 @@ uint32_t efa_mock_ibv_read_vendor_err_return_mock(struct ibv_cq_ex *current)
 	return mock();
 }
 
+int g_ofi_copy_from_hmem_iov_call_counter;
+ssize_t efa_mock_ofi_copy_from_hmem_iov_inc_counter(void *dest, size_t size,
+						    enum fi_hmem_iface hmem_iface, uint64_t device,
+						    const struct iovec *hmem_iov,
+						    size_t hmem_iov_count, uint64_t hmem_iov_offset)
+{
+	g_ofi_copy_from_hmem_iov_call_counter += 1;
+	return __real_ofi_copy_from_hmem_iov(dest, size, hmem_iface, device, hmem_iov, hmem_iov_count, hmem_iov_offset);
+}
+
 struct efa_unit_test_mocks g_efa_unit_test_mocks = {
 	.ibv_create_ah = __real_ibv_create_ah,
 	.efadv_query_device = __real_efadv_query_device,
@@ -172,6 +182,7 @@ struct efa_unit_test_mocks g_efa_unit_test_mocks = {
 #if HAVE_NEURON
 	.neuron_alloc = __real_neuron_alloc,
 #endif
+	.ofi_copy_from_hmem_iov = __real_ofi_copy_from_hmem_iov,
 };
 
 struct ibv_ah *__wrap_ibv_create_ah(struct ibv_pd *pd, struct ibv_ah_attr *attr)
@@ -255,3 +266,11 @@ void *efa_mock_neuron_alloc_return_null(void **handle, size_t size)
 	return NULL;
 }
 #endif
+
+ssize_t __wrap_ofi_copy_from_hmem_iov(void *dest, size_t size,
+				      enum fi_hmem_iface hmem_iface, uint64_t device,
+				      const struct iovec *hmem_iov,
+				      size_t hmem_iov_count, uint64_t hmem_iov_offset)
+{
+	return g_efa_unit_test_mocks.ofi_copy_from_hmem_iov(dest, size, hmem_iface, device, hmem_iov, hmem_iov_count, hmem_iov_offset);
+}

--- a/prov/efa/test/efa_unit_test_mocks.h
+++ b/prov/efa/test/efa_unit_test_mocks.h
@@ -41,6 +41,17 @@ uint32_t efa_mock_ibv_read_opcode_return_mock(struct ibv_cq_ex *current);
 
 uint32_t efa_mock_ibv_read_vendor_err_return_mock(struct ibv_cq_ex *current);
 
+ssize_t __real_ofi_copy_from_hmem_iov(void *dest, size_t size,
+				      enum fi_hmem_iface hmem_iface, uint64_t device,
+				      const struct iovec *hmem_iov,
+				      size_t hmem_iov_count, uint64_t hmem_iov_offset);
+
+extern int g_ofi_copy_from_hmem_iov_call_counter;
+ssize_t efa_mock_ofi_copy_from_hmem_iov_inc_counter(void *dest, size_t size,
+						    enum fi_hmem_iface hmem_iface, uint64_t device,
+						    const struct iovec *hmem_iov,
+						    size_t hmem_iov_count, uint64_t hmem_iov_offset);
+
 struct efa_unit_test_mocks
 {
 	struct ibv_ah *(*ibv_create_ah)(struct ibv_pd *pd, struct ibv_ah_attr *attr);
@@ -58,6 +69,11 @@ struct efa_unit_test_mocks
 #if HAVE_NEURON
 	void *(*neuron_alloc)(void **handle, size_t size);
 #endif
+
+	ssize_t (*ofi_copy_from_hmem_iov)(void *dest, size_t size,
+					  enum fi_hmem_iface hmem_iface, uint64_t device,
+					  const struct iovec *hmem_iov,
+					  size_t hmem_iov_count, uint64_t hmem_iov_offset);
 };
 
 #if HAVE_EFADV_CQ_EX

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -13,6 +13,7 @@ static int efa_unit_test_mocks_reset(void **state)
 #if HAVE_NEURON
 		.neuron_alloc = __real_neuron_alloc,
 #endif
+		.ofi_copy_from_hmem_iov = __real_ofi_copy_from_hmem_iov,
 	};
 
 	return 0;
@@ -29,6 +30,7 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_rxr_ep_pkt_pool_flags, efa_unit_test_mocks_reset, NULL),
 		cmocka_unit_test_setup_teardown(test_rxr_ep_pkt_pool_page_alignment, efa_unit_test_mocks_reset, NULL),
 		cmocka_unit_test_setup_teardown(test_rxr_ep_dc_atomic_error_handling, efa_unit_test_mocks_reset, NULL),
+		cmocka_unit_test_setup_teardown(test_rxr_ep_send_with_shm_no_copy, efa_unit_test_mocks_reset, NULL),
 		cmocka_unit_test_setup_teardown(test_dgram_cq_read_empty_cq, efa_unit_test_mocks_reset, NULL),
 		cmocka_unit_test_setup_teardown(test_dgram_cq_read_bad_wc_status, efa_unit_test_mocks_reset, NULL),
 		cmocka_unit_test_setup_teardown(test_ibv_cq_ex_read_empty_cq, efa_unit_test_mocks_reset, NULL),

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -56,6 +56,7 @@ void test_efa_device_construct_error_handling();
 void test_rxr_ep_pkt_pool_flags();
 void test_rxr_ep_pkt_pool_page_alignment();
 void test_rxr_ep_dc_atomic_error_handling();
+void test_rxr_ep_send_with_shm_no_copy();
 void test_dgram_cq_read_empty_cq();
 void test_dgram_cq_read_bad_wc_status();
 void test_ibv_cq_ex_read_empty_cq();


### PR DESCRIPTION
[prov/efa: compare pci bus id in hints](https://github.com/ofiwg/libfabric/commit/6b9c85df7f008bb8ddbda8bc22e0a31520b09460)

[prov/efa: avoid unnecessary copy when sending data from shm](https://github.com/ofiwg/libfabric/commit/530d9f93a057c8f9c251a41add0539084a5e8721)

[prov/efa: unit test to verify no copy with shm for small host message](https://github.com/ofiwg/libfabric/commit/92734d0bbdca2e601d37c5a37bbda6478a76393b)