### PR TITLE
prov/util,shm: add FI_PEER support to util_cq and update shm to use util FI_PEER support

### DIFF
--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -149,15 +149,6 @@ struct smr_sar_entry {
 	uint64_t		device;
 };
 
-struct smr_cq {
-	struct util_cq util_cq;
-	struct fid_peer_cq *peer_cq;
-};
-
-typedef int (*smr_rx_comp_func)(struct smr_cq *cq, void *context,
-		uint64_t flags, size_t len, void *buf,
-		fi_addr_t fi_addr, uint64_t tag, uint64_t data);
-
 struct smr_match_attr {
 	fi_addr_t	id;
 	uint64_t	tag;
@@ -278,7 +269,7 @@ struct smr_srx_ctx {
 	uint64_t		rx_op_flags;
 	uint64_t		rx_msg_flags;
 
-	struct smr_cq		*cq;
+	struct util_cq		*cq;
 	struct smr_queue	unexp_msg_queue;
 	struct smr_queue	unexp_tagged_queue;
 	struct smr_recv_fs	*recv_fs;
@@ -289,7 +280,6 @@ struct smr_rx_entry *smr_alloc_rx_entry(struct smr_srx_ctx *srx);
 
 struct smr_ep {
 	struct util_ep		util_ep;
-	smr_rx_comp_func	rx_comp;
 	size_t			tx_size;
 	size_t			rx_size;
 	const char		*name;
@@ -376,11 +366,6 @@ int smr_complete_tx(struct smr_ep *ep, void *context, uint32_t op,
 int smr_complete_rx(struct smr_ep *ep, void *context, uint32_t op,
 		    uint64_t flags, size_t len, void *buf, int64_t id,
 		    uint64_t tag, uint64_t data);
-int smr_rx_comp(struct smr_cq *cq, void *context, uint64_t flags, size_t len,
-		void *buf, fi_addr_t fi_addr, uint64_t tag, uint64_t data);
-int smr_rx_src_comp(struct smr_cq *cq, void *context, uint64_t flags,
-		    size_t len, void *buf, fi_addr_t fi_addr, uint64_t tag,
-		    uint64_t data);
 
 static inline uint64_t smr_rx_cq_flags(uint32_t op, uint64_t rx_flags,
 				       uint16_t op_flags)

--- a/prov/shm/src/smr_comp.c
+++ b/prov/shm/src/smr_comp.c
@@ -37,17 +37,6 @@
 #include "ofi_iov.h"
 #include "smr.h"
 
-static int smr_tx_comp(struct smr_ep *ep, void *context, uint32_t op)
-{
-	struct smr_cq *smr_cq;
-
-	smr_cq = container_of(ep->util_ep.tx_cq, struct smr_cq, util_cq);
-
-	return smr_cq->peer_cq->owner_ops->write(smr_cq->peer_cq, context,
-					     ofi_tx_cq_flags(op),
-					     0, NULL, 0, 0, FI_ADDR_NOTAVAIL);
-}
-
 int smr_complete_tx(struct smr_ep *ep, void *context, uint32_t op,
 		    uint64_t flags)
 {
@@ -56,16 +45,15 @@ int smr_complete_tx(struct smr_ep *ep, void *context, uint32_t op,
 	if (!(flags & FI_COMPLETION))
 		return 0;
 
-	return smr_tx_comp(ep, context, op);
+	return ofi_peer_cq_write(ep->util_ep.tx_cq, context,
+				 ofi_tx_cq_flags(op), 0, NULL, 0, 0,
+				 FI_ADDR_NOTAVAIL);
 }
 
 int smr_write_err_comp(struct util_cq *cq, void *context,
 		       uint64_t flags, uint64_t tag, uint64_t err)
 {
 	struct fi_cq_err_entry err_entry;
-	struct smr_cq *smr_cq;
-
-	smr_cq = container_of(cq, struct smr_cq, util_cq);
 
 	memset(&err_entry, 0, sizeof err_entry);
 	err_entry.op_context = context;
@@ -73,27 +61,13 @@ int smr_write_err_comp(struct util_cq *cq, void *context,
 	err_entry.tag = tag;
 	err_entry.err = err;
 	err_entry.prov_errno = -err;
-	return smr_cq->peer_cq->owner_ops->writeerr(smr_cq->peer_cq, &err_entry);
-}
-
-int smr_tx_comp_signal(struct smr_ep *ep, void *context, uint32_t op)
-{
-	int ret;
-
-	ret = smr_tx_comp(ep, context, op);
-	if (ret)
-		return ret;
-
-	ep->util_ep.tx_cq->wait->signal(ep->util_ep.tx_cq->wait);
-	return 0;
+	return ofi_peer_cq_write_error(cq, &err_entry);
 }
 
 int smr_complete_rx(struct smr_ep *ep, void *context, uint32_t op,
 		    uint64_t flags, size_t len, void *buf, int64_t id,
 		    uint64_t tag, uint64_t data)
 {
-	struct smr_cq *cq;
-
 	ofi_ep_rx_cntr_inc_func(&ep->util_ep, op);
 
 	if (!(flags & (FI_REMOTE_CQ_DATA | FI_COMPLETION)))
@@ -101,22 +75,6 @@ int smr_complete_rx(struct smr_ep *ep, void *context, uint32_t op,
 
 	flags &= ~FI_COMPLETION;
 
-	cq = container_of(ep->util_ep.rx_cq, struct smr_cq, util_cq);
-	return ep->rx_comp(cq, context, flags, len, buf,
-			   ep->region->map->peers[id].fiaddr, tag, data);
-}
-
-int smr_rx_comp(struct smr_cq *cq, void *context, uint64_t flags, size_t len,
-		void *buf, fi_addr_t fi_addr, uint64_t tag, uint64_t data)
-{
-	return cq->peer_cq->owner_ops->write(cq->peer_cq, context,
-				flags, len, buf, data,
-				tag, FI_ADDR_NOTAVAIL);
-}
-
-int smr_rx_src_comp(struct smr_cq *cq, void *context, uint64_t flags, size_t len,
-		    void *buf, fi_addr_t fi_addr, uint64_t tag, uint64_t data)
-{
-	return cq->peer_cq->owner_ops->write(cq->peer_cq, context,
-				flags, len, buf, data, tag, fi_addr);
+	return ofi_peer_cq_write(ep->util_ep.rx_cq, context, flags, len, buf,
+				 data, tag, ep->region->map->peers[id].fiaddr);
 }

--- a/prov/shm/src/smr_cq.c
+++ b/prov/shm/src/smr_cq.c
@@ -35,115 +35,10 @@
 
 #include "smr.h"
 
-static int smr_peer_cq_close(struct fid *fid)
-{
-	free(container_of(fid, struct fid_peer_cq, fid));
-	return 0;
-}
-
-static int smr_cq_close(struct fid *fid)
-{
-	int ret;
-	struct smr_cq *smr_cq;
-
-	smr_cq = container_of(fid, struct smr_cq, util_cq.cq_fid.fid);
-
-	ret = ofi_cq_cleanup(&smr_cq->util_cq);
-	if (ret)
-		return ret;
-
-	if (!(smr_cq->util_cq.flags & FI_PEER))
-		fi_close(&smr_cq->peer_cq->fid);
-
-	free(smr_cq);
-	return 0;
-}
-
-static struct fi_ops smr_cq_fi_ops = {
-	.size = sizeof(struct fi_ops),
-	.close = smr_cq_close,
-	.bind = fi_no_bind,
-	.control = ofi_cq_control,
-	.ops_open = fi_no_ops_open,
-};
-
-static ssize_t smr_peer_cq_write(struct fid_peer_cq *cq, void *context, uint64_t flags,
-		size_t len, void *buf, uint64_t data, uint64_t tag,
-		fi_addr_t src)
-{
-	struct smr_cq *smr_cq;
-	int ret;
-
-	smr_cq = cq->fid.context;
-
-	if (src == FI_ADDR_NOTAVAIL)
-		ret = ofi_cq_write(&smr_cq->util_cq, context, flags, len,
-				   buf, data, tag);
-	else
-		ret = ofi_cq_write_src(&smr_cq->util_cq, context, flags, len,
-				       buf, data, tag, src);
-
-	if (smr_cq->util_cq.wait)
-		smr_cq->util_cq.wait->signal(smr_cq->util_cq.wait);
-
-	return ret;
-}
-
-static ssize_t smr_peer_cq_writeerr(struct fid_peer_cq *cq,
-				    const struct fi_cq_err_entry *err_entry)
-{
-	return ofi_cq_write_error(&((struct smr_cq *)
-				  (cq->fid.context))->util_cq, err_entry);
-}
-
-static struct fi_ops_cq_owner smr_peer_cq_owner_ops = {
-	.size = sizeof(struct fi_ops_cq_owner),
-	.write = &smr_peer_cq_write,
-	.writeerr = &smr_peer_cq_writeerr,
-};
-
-static struct fi_ops smr_peer_cq_fi_ops = {
-	.size = sizeof(struct fi_ops),
-	.close = smr_peer_cq_close,
-	.bind = fi_no_bind,
-	.control = fi_no_control,
-	.ops_open = fi_no_ops_open,
-};
-
-static int smr_init_peer_cq(struct smr_cq *smr_cq)
-{
-	smr_cq->peer_cq = calloc(1, sizeof(*smr_cq->peer_cq));
-	if (!smr_cq->peer_cq)
-		return -FI_ENOMEM;
-
-	smr_cq->peer_cq->fid.fclass = FI_CLASS_PEER_CQ;
-	smr_cq->peer_cq->fid.context = smr_cq;
-	smr_cq->peer_cq->fid.ops = &smr_peer_cq_fi_ops;
-	smr_cq->peer_cq->owner_ops = &smr_peer_cq_owner_ops;
-
-	return 0;
-}
-
-static ssize_t smr_cq_read(struct fid_cq *cq_fid, void *buf, size_t count)
-{
-	return ofi_cq_readfrom(cq_fid, buf, count, NULL);
-}
-
-static struct fi_ops_cq smr_peer_cq_ops = {
-	.size = sizeof(struct fi_ops_cq),
-	.read = smr_cq_read,
-	.readfrom = fi_no_cq_readfrom,
-	.readerr = fi_no_cq_readerr,
-	.sread = fi_no_cq_sread,
-	.sreadfrom = fi_no_cq_sreadfrom,
-	.signal = fi_no_cq_signal,
-	.strerror = fi_no_cq_strerror,
-};
-
 int smr_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		struct fid_cq **cq_fid, void *context)
 {
-	struct smr_cq *smr_cq;
+	struct util_cq *cq;
 	int ret;
 
 	switch (attr->wait_obj) {
@@ -158,31 +53,16 @@ int smr_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		return -FI_ENOSYS;
 	}
 
-	smr_cq = calloc(1, sizeof(*smr_cq));
-	if (!smr_cq)
+	cq = calloc(1, sizeof(*cq));
+	if (!cq)
 		return -FI_ENOMEM;
 
-	ret = ofi_cq_init(&smr_prov, domain, attr, &smr_cq->util_cq,
-			  &ofi_cq_progress, context);
+	ret = ofi_cq_init(&smr_prov, domain, attr, cq, &ofi_cq_progress,
+			  context);
 	if (ret)
-		goto free;
+		return ret;
 
-	if (attr->flags & FI_PEER) {
-		smr_cq->peer_cq = ((struct fi_peer_cq_context *) context)->cq;
-		smr_cq->util_cq.cq_fid.ops = &smr_peer_cq_ops;
-	} else {
-		ret = smr_init_peer_cq(smr_cq);
-		if (ret)
-			goto cleanup;
-	}
+	(*cq_fid) = &cq->cq_fid;
 
-	smr_cq->util_cq.cq_fid.fid.ops = &smr_cq_fi_ops;
-	(*cq_fid) = &smr_cq->util_cq.cq_fid;
-	return 0;
-
-cleanup:
-	(void) ofi_cq_cleanup(&smr_cq->util_cq);
-free:
-	free(smr_cq);
-	return ret;
+	return FI_SUCCESS;
 }

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -42,7 +42,7 @@
 /* While the CQ is full, we continue to add new entries to the auxiliary
  * queue.
  */
-static void ofi_cq_insert_aux(struct util_cq *cq,
+static void util_cq_insert_aux(struct util_cq *cq,
 			      struct util_cq_aux_entry *entry)
 {
 	assert(ofi_genlock_held(&cq->cq_lock));
@@ -77,12 +77,12 @@ int ofi_cq_write_overflow(struct util_cq *cq, void *context, uint64_t flags,
 	entry->comp.err = 0;
 	entry->src = src;
 
-	ofi_cq_insert_aux(cq, entry);
+	util_cq_insert_aux(cq, entry);
 	return 0;
 }
 
-int ofi_cq_insert_error(struct util_cq *cq,
-			const struct fi_cq_err_entry *err_entry)
+static int util_cq_insert_error(struct util_cq *cq,
+				const struct fi_cq_err_entry *err_entry)
 {
 	struct util_cq_aux_entry *entry;
 
@@ -93,20 +93,22 @@ int ofi_cq_insert_error(struct util_cq *cq,
 		return -FI_ENOMEM;
 
 	entry->comp = *err_entry;
-	ofi_cq_insert_aux(cq, entry);
+	util_cq_insert_aux(cq, entry);
 	return 0;
 }
 
 int ofi_cq_write_error(struct util_cq *cq,
 		       const struct fi_cq_err_entry *err_entry)
 {
+	int ret;
+
 	ofi_genlock_lock(&cq->cq_lock);
-	ofi_cq_insert_error(cq, err_entry);
+	ret = util_cq_insert_error(cq, err_entry);
 	ofi_genlock_unlock(&cq->cq_lock);
 
 	if (cq->wait)
 		cq->wait->signal(cq->wait);
-	return 0;
+	return ret;
 }
 
 int ofi_cq_write_error_peek(struct util_cq *cq, uint64_t tag, void *context)
@@ -138,6 +140,38 @@ int ofi_cq_write_error_trunc(struct util_cq *cq, void *context, uint64_t flags,
 	};
 	return ofi_cq_write_error(cq, &err_entry);
 }
+
+int ofi_peer_cq_write_error_peek(struct util_cq *cq, uint64_t tag,
+				 void *context)
+{
+	struct fi_cq_err_entry err_entry = {
+		.op_context	= context,
+		.flags		= FI_TAGGED | FI_RECV,
+		.tag		= tag,
+		.err		= FI_ENOMSG,
+		.prov_errno	= -FI_ENOMSG,
+	};
+	return ofi_peer_cq_write_error(cq, &err_entry);
+}
+
+int ofi_peer_cq_write_error_trunc(struct util_cq *cq, void *context,
+				  uint64_t flags, size_t len, void *buf,
+				  uint64_t data, uint64_t tag, size_t olen)
+{
+	struct fi_cq_err_entry err_entry = {
+		.op_context	= context,
+		.flags		= flags,
+		.len		= len,
+		.buf		= buf,
+		.data		= data,
+		.tag		= tag,
+		.olen		= olen,
+		.err		= FI_ETRUNC,
+		.prov_errno	= -FI_ETRUNC,
+	};
+	return ofi_peer_cq_write_error(cq, &err_entry);
+}
+
 
 int ofi_check_cq_attr(const struct fi_provider *prov,
 		      const struct fi_cq_attr *attr)
@@ -404,19 +438,28 @@ static struct fi_ops_cq util_cq_ops = {
 	.strerror = ofi_cq_strerror,
 };
 
-int ofi_cq_cleanup(struct util_cq *cq)
+static void util_peer_cq_cleanup(struct util_cq *cq)
 {
 	struct util_cq_aux_entry *err;
 	struct slist_entry *entry;
-
-	if (ofi_atomic_get32(&cq->ref))
-		return -FI_EBUSY;
 
 	while (!slist_empty(&cq->aux_queue)) {
 		entry = slist_remove_head(&cq->aux_queue);
 		err = container_of(entry, struct util_cq_aux_entry, list_entry);
 		free(err);
 	}
+
+	util_comp_cirq_free(cq->cirq);
+	free(cq->src);
+}
+
+int ofi_cq_cleanup(struct util_cq *cq)
+{
+	if (ofi_atomic_get32(&cq->ref))
+		return -FI_EBUSY;
+
+	if (!(cq->flags & FI_PEER))
+		util_peer_cq_cleanup(cq);
 
 	if (cq->wait) {
 		fi_poll_del(&cq->wait->pollset->poll_fid,
@@ -425,11 +468,9 @@ int ofi_cq_cleanup(struct util_cq *cq)
 			fi_close(&cq->wait->wait_fid.fid);
 	}
 
-	ofi_atomic_dec32(&cq->domain->ref);
-	util_comp_cirq_free(cq->cirq);
 	ofi_genlock_destroy(&cq->cq_lock);
 	ofi_mutex_destroy(&cq->ep_list_lock);
-	free(cq->src);
+	ofi_atomic_dec32(&cq->domain->ref);
 	return 0;
 }
 
@@ -471,68 +512,6 @@ static struct fi_ops util_cq_fi_ops = {
 	.ops_open = fi_no_ops_open,
 };
 
-static int fi_cq_init(struct fid_domain *domain, struct fi_cq_attr *attr,
-		      fi_cq_read_func read_entry, struct util_cq *cq,
-		      void *context)
-{
-	struct fi_wait_attr wait_attr;
-	enum ofi_lock_type lock_type;
-	struct fid_wait *wait;
-	int ret;
-
-	cq->domain = container_of(domain, struct util_domain, domain_fid);
-	ofi_atomic_initialize32(&cq->ref, 0);
-	ofi_atomic_initialize32(&cq->wakeup, 0);
-	dlist_init(&cq->ep_list);
-	ofi_mutex_init(&cq->ep_list_lock);
-
-	if (cq->domain->threading == FI_THREAD_COMPLETION ||
-	    cq->domain->threading == FI_THREAD_DOMAIN)
-		lock_type = OFI_LOCK_NOOP;
-	else
-		lock_type = cq->domain->lock.lock_type;
-	ret = ofi_genlock_init(&cq->cq_lock, lock_type);
-	slist_init(&cq->aux_queue);
-	if (ret)
-		return ret;
-
-	cq->flags = attr->flags;
-	cq->read_entry = read_entry;
-	cq->cq_fid.fid.fclass = FI_CLASS_CQ;
-	cq->cq_fid.fid.context = context;
-
-	switch (attr->wait_obj) {
-	case FI_WAIT_NONE:
-		wait = NULL;
-		break;
-	case FI_WAIT_UNSPEC:
-	case FI_WAIT_FD:
-	case FI_WAIT_POLLFD:
-	case FI_WAIT_MUTEX_COND:
-	case FI_WAIT_YIELD:
-		memset(&wait_attr, 0, sizeof wait_attr);
-		wait_attr.wait_obj = attr->wait_obj;
-		cq->internal_wait = 1;
-		ret = fi_wait_open(&cq->domain->fabric->fabric_fid,
-				   &wait_attr, &wait);
-		if (ret)
-			return ret;
-		break;
-	case FI_WAIT_SET:
-		wait = attr->wait_set;
-		break;
-	default:
-		assert(0);
-		return -FI_EINVAL;
-	}
-
-	if (wait)
-		cq->wait = container_of(wait, struct util_wait, wait_fid);
-
-	ofi_atomic_inc32(&cq->domain->ref);
-	return 0;
-}
-
 int ofi_check_bind_cq_flags(struct util_ep *ep, struct util_cq *cq,
 			    uint64_t flags)
 {
@@ -570,11 +549,179 @@ void ofi_cq_progress(struct util_cq *cq)
 	ofi_mutex_unlock(&cq->ep_list_lock);
 }
 
+static ssize_t util_peer_cq_write(struct fid_peer_cq *cq, void *context,
+		uint64_t flags, size_t len, void *buf, uint64_t data,
+		uint64_t tag, fi_addr_t src)
+{
+	struct util_cq *util_cq = cq->fid.context;
+	int ret;
+
+	util_cq = cq->fid.context;
+
+	ofi_genlock_lock(&util_cq->cq_lock);
+	if (ofi_cirque_freecnt(util_cq->cirq) > 1) {
+		ofi_cq_write_entry(util_cq, context, flags, len, buf, data,
+				     tag);
+		ret = 0;
+	} else {
+		ret = ofi_cq_write_overflow(util_cq, context, flags, len, buf,
+					      data, tag, FI_ADDR_NOTAVAIL);
+	}
+	ofi_genlock_unlock(&util_cq->cq_lock);
+
+	if (util_cq->wait)
+		util_cq->wait->signal(util_cq->wait);
+
+	return ret;
+}
+
+static ssize_t util_peer_cq_write_src(struct fid_peer_cq *cq, void *context,
+		uint64_t flags, size_t len, void *buf, uint64_t data,
+		uint64_t tag, fi_addr_t src)
+{
+	struct util_cq *util_cq = cq->fid.context;
+	int ret;
+
+	ofi_genlock_lock(&util_cq->cq_lock);
+	if (ofi_cirque_freecnt(util_cq->cirq) > 1) {
+		ofi_cq_write_src_entry(util_cq, context, flags, len, buf, data,
+				       tag, src);
+		ret = 0;
+	} else {
+		ret = ofi_cq_write_overflow(util_cq, context, flags, len, buf,
+					      data, tag, src);
+	}
+	ofi_genlock_unlock(&util_cq->cq_lock);
+
+	if (util_cq->wait)
+		util_cq->wait->signal(util_cq->wait);
+
+	return ret;
+}
+
+static ssize_t util_peer_cq_writeerr(struct fid_peer_cq *cq,
+				     const struct fi_cq_err_entry *err_entry)
+{
+	struct util_cq *util_cq = cq->fid.context;
+	int ret;
+
+	ofi_genlock_lock(&util_cq->cq_lock);
+	ret = util_cq_insert_error(util_cq, err_entry);
+	ofi_genlock_unlock(&util_cq->cq_lock);
+
+	if (util_cq->wait)
+		util_cq->wait->signal(util_cq->wait);
+
+	return ret;
+}
+
+static struct fi_ops_cq_owner util_peer_cq_owner_ops = {
+	.size = sizeof(struct fi_ops_cq_owner),
+	.write = &util_peer_cq_write,
+	.writeerr = &util_peer_cq_writeerr,
+};
+
+static struct fi_ops_cq_owner util_peer_cq_src_owner_ops = {
+	.size = sizeof(struct fi_ops_cq_owner),
+	.write = &util_peer_cq_write_src,
+	.writeerr = &util_peer_cq_writeerr,
+};
+
+static ssize_t util_cq_read(struct fid_cq *cq_fid, void *buf, size_t count)
+{
+       return ofi_cq_readfrom(cq_fid, buf, count, NULL);
+}
+
+static struct fi_ops_cq util_peer_cq_ops = {
+       .size = sizeof(struct fi_ops_cq),
+       .read = util_cq_read,
+       .readfrom = fi_no_cq_readfrom,
+       .readerr = fi_no_cq_readerr,
+       .sread = fi_no_cq_sread,
+       .sreadfrom = fi_no_cq_sreadfrom,
+       .signal = fi_no_cq_signal,
+       .strerror = fi_no_cq_strerror,
+};
+
+static int util_peer_cq_close(struct fid *fid)
+{
+       free(container_of(fid, struct fid_peer_cq, fid));
+       return 0;
+}
+
+static struct fi_ops util_peer_cq_fi_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = util_peer_cq_close,
+	.bind = fi_no_bind,
+	.control = fi_no_control,
+	.ops_open = fi_no_ops_open,
+};
+
+static int util_init_peer_cq(struct util_cq *cq, struct fi_cq_attr *attr)
+{
+	int ret;
+
+	cq->peer_cq = calloc(1, sizeof(*cq->peer_cq));
+	if (!cq->peer_cq)
+		return -FI_ENOMEM;
+
+	slist_init(&cq->aux_queue);
+
+	switch (attr->format) {
+	case FI_CQ_FORMAT_UNSPEC:
+	case FI_CQ_FORMAT_CONTEXT:
+		cq->read_entry = util_cq_read_ctx;
+		break;
+	case FI_CQ_FORMAT_MSG:
+		cq->read_entry = util_cq_read_msg;
+		break;
+	case FI_CQ_FORMAT_DATA:
+		cq->read_entry = util_cq_read_data;
+		break;
+	case FI_CQ_FORMAT_TAGGED:
+		cq->read_entry = util_cq_read_tagged;
+		break;
+	default:
+		assert(0);
+		ret = -FI_EINVAL;
+		goto free;
+	}
+
+	cq->cirq = util_comp_cirq_create(attr->size == 0 ? UTIL_DEF_CQ_SIZE : attr->size);
+	if (!cq->cirq) {
+		ret = -FI_ENOMEM;
+		goto free;
+	}
+
+	if (cq->domain->info_domain_caps & FI_SOURCE) {
+		cq->src = calloc(cq->cirq->size, sizeof(*cq->src));
+		if (!cq->src) {
+			util_comp_cirq_free(cq->cirq);
+			ret = -FI_ENOMEM;
+			goto free;
+		}
+		cq->peer_cq->owner_ops = &util_peer_cq_src_owner_ops;
+	} else {
+		cq->peer_cq->owner_ops = &util_peer_cq_owner_ops;
+	}
+
+	cq->peer_cq->fid.fclass = FI_CLASS_PEER_CQ;
+	cq->peer_cq->fid.context = cq;
+	cq->peer_cq->fid.ops = &util_peer_cq_fi_ops;
+
+	return FI_SUCCESS;
+free:
+	free(cq->peer_cq);
+	return ret;
+}
+
 int ofi_cq_init(const struct fi_provider *prov, struct fid_domain *domain,
 		 struct fi_cq_attr *attr, struct util_cq *cq,
 		 ofi_cq_progress_func progress, void *context)
 {
-	fi_cq_read_func read_func;
+	struct fi_wait_attr wait_attr;
+	struct fid_wait *wait;
+	enum ofi_lock_type lock_type;
 	int ret;
 
 	assert(progress);
@@ -586,54 +733,84 @@ int ofi_cq_init(const struct fi_provider *prov, struct fid_domain *domain,
 	cq->cq_fid.ops = &util_cq_ops;
 	cq->progress = progress;
 
-	switch (attr->format) {
-	case FI_CQ_FORMAT_UNSPEC:
-	case FI_CQ_FORMAT_CONTEXT:
-		read_func = util_cq_read_ctx;
-		break;
-	case FI_CQ_FORMAT_MSG:
-		read_func = util_cq_read_msg;
-		break;
-	case FI_CQ_FORMAT_DATA:
-		read_func = util_cq_read_data;
-		break;
-	case FI_CQ_FORMAT_TAGGED:
-		read_func = util_cq_read_tagged;
-		break;
-	default:
-		assert(0);
-		return -FI_EINVAL;
-	}
-
-	ret = fi_cq_init(domain, attr, read_func, cq, context);
+	cq->domain = container_of(domain, struct util_domain, domain_fid);
+	ofi_atomic_initialize32(&cq->ref, 0);
+	ofi_atomic_initialize32(&cq->wakeup, 0);
+	dlist_init(&cq->ep_list);
+	ret = ofi_mutex_init(&cq->ep_list_lock);
 	if (ret)
 		return ret;
 
-	/* CQ must be fully operational before adding to wait set */
-	if (cq->wait) {
-		ret = fi_poll_add(&cq->wait->pollset->poll_fid,
-				  &cq->cq_fid.fid, 0);
+	if (cq->domain->threading == FI_THREAD_COMPLETION ||
+	    cq->domain->threading == FI_THREAD_DOMAIN)
+		lock_type = OFI_LOCK_NOOP;
+	else
+		lock_type = cq->domain->lock.lock_type;
+
+	ret = ofi_genlock_init(&cq->cq_lock, lock_type);
+	if (ret)
+		goto destroy1;
+
+	cq->flags = attr->flags;
+	cq->cq_fid.fid.fclass = FI_CLASS_CQ;
+	cq->cq_fid.fid.context = context;
+
+	if (attr->flags & FI_PEER) {
+		cq->peer_cq = ((struct fi_peer_cq_context *) context)->cq;
+		cq->cq_fid.ops = &util_peer_cq_ops;
+	} else {
+		ret = util_init_peer_cq(cq, attr);
 		if (ret)
-			goto cleanup;
+			goto destroy2;
 	}
 
-	cq->cirq = util_comp_cirq_create(attr->size == 0 ? UTIL_DEF_CQ_SIZE : attr->size);
-	if (!cq->cirq) {
-		ret = -FI_ENOMEM;
+	switch (attr->wait_obj) {
+	case FI_WAIT_NONE:
+		wait = NULL;
+		break;
+	case FI_WAIT_UNSPEC:
+	case FI_WAIT_FD:
+	case FI_WAIT_POLLFD:
+	case FI_WAIT_MUTEX_COND:
+	case FI_WAIT_YIELD:
+		memset(&wait_attr, 0, sizeof wait_attr);
+		wait_attr.wait_obj = attr->wait_obj;
+		cq->internal_wait = 1;
+		ret = fi_wait_open(&cq->domain->fabric->fabric_fid,
+				   &wait_attr, &wait);
+		if (ret)
+			goto cleanup;
+		break;
+	case FI_WAIT_SET:
+		wait = attr->wait_set;
+		break;
+	default:
+		assert(0);
 		goto cleanup;
 	}
 
-	if (cq->domain->info_domain_caps & FI_SOURCE) {
-		cq->src = calloc(cq->cirq->size, sizeof *cq->src);
-		if (!cq->src) {
-			ret = -FI_ENOMEM;
+	/* CQ must be fully operational before adding to wait set */
+	if (wait) {
+		cq->wait = container_of(wait, struct util_wait, wait_fid);
+		ret = fi_poll_add(&cq->wait->pollset->poll_fid,
+				  &cq->cq_fid.fid, 0);
+		if (ret) {
+			if (cq->internal_wait) {
+				fi_close(&cq->wait->wait_fid.fid);
+				cq->wait = NULL;
+			}
 			goto cleanup;
 		}
 	}
+	ofi_atomic_inc32(&cq->domain->ref);
 	return 0;
 
 cleanup:
-	(void) ofi_cq_cleanup(cq);
+	util_peer_cq_cleanup(cq);
+destroy2:
+	ofi_genlock_destroy(&cq->cq_lock);
+destroy1:
+	ofi_mutex_destroy(&cq->ep_list_lock);
 	return ret;
 }
 


### PR DESCRIPTION
Moves FI_PEER support to util_cq so that any provider using the util_cq to read and write entries can leverage support to be either an owner or peer
Modifies providers using util_cq to streamline CQ functionality and isolate FI_SOURCE/signal optimizations to fewer places