### PR TITLE
prov/efa: Ask for remote read in `FI_HMEM_CUDA` init

### DIFF
--- a/prov/efa/src/efa_hmem.c
+++ b/prov/efa/src/efa_hmem.c
@@ -135,7 +135,7 @@ static int efa_domain_hmem_info_init_cuda(struct efa_domain *efa_domain)
 	cudaError_t cuda_ret;
 	void *ptr = NULL;
 	struct ibv_mr *ibv_mr;
-	int ibv_access = IBV_ACCESS_LOCAL_WRITE;
+	int ibv_access = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ;
 	size_t len = ofi_get_page_size() * 2, tmp_value;
 	int ret;
 
@@ -143,9 +143,6 @@ static int efa_domain_hmem_info_init_cuda(struct efa_domain *efa_domain)
 		EFA_INFO(FI_LOG_DOMAIN, "FI_HMEM_CUDA is not initialized\n");
 		return 0;
 	}
-
-	if (efa_device_support_rdma_read())
-		ibv_access |= IBV_ACCESS_REMOTE_READ;
 
 	info->initialized = true;
 


### PR DESCRIPTION
This resolves a corner case where an instance type such as g4dn.metal has P2P support, but not RDMA read support. When calling `ibv_reg_mr()` with only `IBV_ACCESS_LOCAL_WRITE`, it will succeed - causing `efa_hmem_info[FI_HMEM_CUDA].p2p_supported_by_device` to be true; ultimately allowing `efa_mr_reg_impl()` to attempt to register CUDA memory regions.

This is potentially a temporary mitigation; it may be beneficial for performance on g4dn.metal to allow IBV MR registrations - but it's not yet clear why some `ibv_reg_mr()` calls succeed (see CUDA OMB runs) and some fail (CUDA fabtests).

Signed-off-by: Darryl Abbate <drl@amazon.com>