### PR TITLE
prov/efa: move op_entry flags from rxr.h to rxr_op_entry.h

### DIFF
--- a/prov/efa/src/rdm/rxr.h
+++ b/prov/efa/src/rdm/rxr.h
@@ -135,57 +135,6 @@ static inline void rxr_poison_pkt_entry(struct rxr_pkt_entry *pkt_entry, size_t 
  */
 #define RXR_MAX_NAME_LENGTH	(32)
 
-/*
- * TODO: In future we will send RECV_CANCEL signal to sender,
- * to stop transmitting large message, this flag is also
- * used for fi_discard which has similar behavior.
- */
-#define RXR_RECV_CANCEL		BIT_ULL(3)
-
-/*
- * Flags to tell if the rx_entry is tracking FI_MULTI_RECV buffers
- */
-#define RXR_MULTI_RECV_POSTED	BIT_ULL(4)
-#define RXR_MULTI_RECV_CONSUMER	BIT_ULL(5)
-
-/*
- * Flag to tell if the transmission is using FI_DELIVERY_COMPLETE
- * protocols
- */
-
-#define RXR_DELIVERY_COMPLETE_REQUESTED	BIT_ULL(6)
-
-#define RXR_OP_ENTRY_QUEUED_RNR BIT_ULL(9)
-
-/*
- * Flag to indicate an rx_entry has an EOR
- * in flight (the EOR has been sent or queued,
- * and has not got send completion)
- * hence the rx_entry cannot be released
- */
-#define RXR_EOR_IN_FLIGHT BIT_ULL(10)
-
-/*
- * Flag to indicate a tx_entry has already
- * written an cq error entry for RNR
- */
-#define RXR_TX_ENTRY_WRITTEN_RNR_CQ_ERR_ENTRY BIT_ULL(10)
-
-/*
- * Flag to indicate an op_entry has queued ctrl packet,
- * and is on ep->op_entry_queued_ctrl_list
- */
-#define RXR_OP_ENTRY_QUEUED_CTRL BIT_ULL(11)
-
-/*
- * OFI flags
- * The 64-bit flag field is used as follows:
- * 1-grow up    common (usable with multiple operations)
- * 59-grow down operation specific (used for single call/class)
- * 60 - 63      provider specific
- */
-#define RXR_NO_COMPLETION	BIT_ULL(60)
-#define RXR_NO_COUNTER		BIT_ULL(61)
 
 #define RXR_MTU_MAX_LIMIT	BIT_ULL(15)
 

--- a/prov/efa/src/rdm/rxr_atomic.c
+++ b/prov/efa/src/rdm/rxr_atomic.c
@@ -270,7 +270,7 @@ rxr_atomic_inject(struct fid_ep *ep,
 	msg.data = 0;
 
 	return rxr_atomic_generic_efa(rxr_ep, &msg, NULL, ofi_op_atomic,
-				      FI_INJECT | RXR_NO_COMPLETION);
+				      FI_INJECT | RXR_TX_ENTRY_NO_COMPLETION);
 }
 
 static ssize_t

--- a/prov/efa/src/rdm/rxr_ep.c
+++ b/prov/efa/src/rdm/rxr_ep.c
@@ -522,7 +522,7 @@ static void rxr_ep_free_res(struct rxr_ep *rxr_ep)
 	dlist_foreach_safe(&rxr_ep->rx_entry_list, entry, tmp) {
 		rx_entry = container_of(entry, struct rxr_op_entry,
 					ep_entry);
-		if (!(rx_entry->rxr_flags & RXR_MULTI_RECV_POSTED))
+		if (!(rx_entry->rxr_flags & RXR_RX_ENTRY_MULTI_RECV_POSTED))
 			EFA_WARN(FI_LOG_EP_CTRL,
 				"Closing ep with unreleased rx_entry\n");
 		rxr_rx_entry_release(rx_entry);
@@ -886,9 +886,9 @@ static ssize_t rxr_ep_cancel_recv(struct rxr_ep *ep,
 	}
 
 	rx_entry = container_of(entry, struct rxr_op_entry, entry);
-	rx_entry->rxr_flags |= RXR_RECV_CANCEL;
+	rx_entry->rxr_flags |= RXR_RX_ENTRY_RECV_CANCEL;
 	if (rx_entry->fi_flags & FI_MULTI_RECV &&
-	    rx_entry->rxr_flags & RXR_MULTI_RECV_POSTED) {
+	    rx_entry->rxr_flags & RXR_RX_ENTRY_MULTI_RECV_POSTED) {
 		if (dlist_empty(&rx_entry->multi_recv_consumers)) {
 			/*
 			 * No pending messages for the buffer,
@@ -902,7 +902,7 @@ static ssize_t rxr_ep_cancel_recv(struct rxr_ep *ep,
 			rxr_msg_multi_recv_handle_completion(ep, rx_entry);
 		}
 	} else if (rx_entry->fi_flags & FI_MULTI_RECV &&
-		   rx_entry->rxr_flags & RXR_MULTI_RECV_CONSUMER) {
+		   rx_entry->rxr_flags & RXR_RX_ENTRY_MULTI_RECV_CONSUMER) {
 		rxr_msg_multi_recv_handle_completion(ep, rx_entry);
 	}
 	ofi_mutex_unlock(&ep->base_ep.util_ep.lock);
@@ -919,7 +919,7 @@ static ssize_t rxr_ep_cancel_recv(struct rxr_ep *ep,
 		err_entry.err_data_size = 0;
 	/*
 	 * Other states are currently receiving data. Subsequent messages will
-	 * be sunk (via RXR_RECV_CANCEL flag) and the completion suppressed.
+	 * be sunk (via RXR_RX_ENTRY_RECV_CANCEL flag) and the completion suppressed.
 	 */
 	if (rx_entry->state & (RXR_RX_INIT | RXR_RX_UNEXP | RXR_RX_MATCHED))
 		rxr_rx_entry_release(rx_entry);

--- a/prov/efa/src/rdm/rxr_op_entry.c
+++ b/prov/efa/src/rdm/rxr_op_entry.c
@@ -724,12 +724,12 @@ void rxr_rx_entry_report_completion(struct rxr_op_entry *rx_entry)
 			return;
 		}
 
-		rx_entry->fi_flags |= RXR_NO_COMPLETION;
+		rx_entry->fi_flags |= RXR_TX_ENTRY_NO_COMPLETION;
 		efa_cntr_report_error(&ep->base_ep.util_ep, rx_entry->cq_entry.flags);
 		return;
 	}
 
-	if (!(rx_entry->rxr_flags & RXR_RECV_CANCEL) &&
+	if (!(rx_entry->rxr_flags & RXR_RX_ENTRY_RECV_CANCEL) &&
 	    (ofi_need_completion(rxr_rx_flags(ep), rx_entry->fi_flags) ||
 	     (rx_entry->cq_entry.flags & FI_MULTI_RECV))) {
 		EFA_DBG(FI_LOG_CQ,
@@ -772,7 +772,7 @@ void rxr_rx_entry_report_completion(struct rxr_op_entry *rx_entry)
 			return;
 		}
 
-		rx_entry->fi_flags |= RXR_NO_COMPLETION;
+		rx_entry->fi_flags |= RXR_TX_ENTRY_NO_COMPLETION;
 	}
 
 	efa_cntr_report_rx_completion(&ep->base_ep.util_ep, rx_entry->cq_entry.flags);
@@ -798,7 +798,7 @@ static inline
 bool rxr_tx_entry_should_update_cq(struct rxr_op_entry *tx_entry)
 
 {
-	if (tx_entry->fi_flags & RXR_NO_COMPLETION)
+	if (tx_entry->fi_flags & RXR_TX_ENTRY_NO_COMPLETION)
 		return false;
 
 	/*
@@ -877,7 +877,7 @@ void rxr_tx_entry_report_completion(struct rxr_op_entry *tx_entry)
 	}
 
 	efa_cntr_report_tx_completion(&tx_entry->ep->base_ep.util_ep, tx_entry->cq_entry.flags);
-	tx_entry->fi_flags |= RXR_NO_COMPLETION;
+	tx_entry->fi_flags |= RXR_TX_ENTRY_NO_COMPLETION;
 	return;
 }
 
@@ -931,7 +931,7 @@ void rxr_op_entry_handle_send_completed(struct rxr_op_entry *op_entry)
 		if (op_entry->fi_flags & FI_COMPLETION) {
 			rxr_tx_entry_report_completion(op_entry);
 		} else {
-			if (!(op_entry->fi_flags & RXR_NO_COUNTER))
+			if (!(op_entry->fi_flags & RXR_TX_ENTRY_NO_COUNTER))
 				efa_cntr_report_tx_completion(&ep->base_ep.util_ep, op_entry->cq_entry.flags);
 		}
 
@@ -1042,7 +1042,7 @@ void rxr_op_entry_handle_recv_completed(struct rxr_op_entry *op_entry)
 	 * when inject was used, lower device will not provider send
 	 * completion for the ctrl packet.
 	 */
-	if (op_entry->rxr_flags & RXR_DELIVERY_COMPLETE_REQUESTED) {
+	if (op_entry->rxr_flags & RXR_TX_ENTRY_DELIVERY_COMPLETE_REQUESTED) {
 		assert(op_entry->type == RXR_RX_ENTRY);
 		rx_entry = op_entry; /* Intentionally assigned for easier understanding */
 		peer = rxr_ep_get_peer(rx_entry->ep, rx_entry->addr);
@@ -1070,7 +1070,7 @@ void rxr_op_entry_handle_recv_completed(struct rxr_op_entry *op_entry)
 	 *
 	 * see #rxr_pkt_handle_eor_send_completion
 	 */
-	if (op_entry->rxr_flags & RXR_EOR_IN_FLIGHT) {
+	if (op_entry->rxr_flags & RXR_RX_ENTRY_EOR_IN_FLIGHT) {
 		return;
 	}
 

--- a/prov/efa/src/rdm/rxr_pkt_cmd.c
+++ b/prov/efa/src/rdm/rxr_pkt_cmd.c
@@ -552,7 +552,7 @@ ssize_t rxr_pkt_trigger_handshake(struct rxr_ep *ep,
 	tx_entry->window = 0;
 	tx_entry->rma_iov_count = 0;
 	tx_entry->iov_count = 0;
-	tx_entry->fi_flags = RXR_NO_COMPLETION | RXR_NO_COUNTER;
+	tx_entry->fi_flags = RXR_TX_ENTRY_NO_COMPLETION | RXR_TX_ENTRY_NO_COUNTER;
 	tx_entry->rxr_flags = 0;
 
 	dlist_insert_tail(&tx_entry->ep_entry, &ep->tx_entry_list);

--- a/prov/efa/src/rdm/rxr_pkt_type_base.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_base.c
@@ -536,7 +536,7 @@ ssize_t rxr_pkt_copy_data_to_op_entry(struct rxr_ep *ep,
 	 *
 	 * 3. message size is 0, thus no data to copy.
 	 */
-	if (OFI_UNLIKELY((op_entry->rxr_flags & RXR_RECV_CANCEL)) ||
+	if (OFI_UNLIKELY((op_entry->rxr_flags & RXR_RX_ENTRY_RECV_CANCEL)) ||
 	    OFI_UNLIKELY(data_offset >= op_entry->cq_entry.len) ||
 	    OFI_UNLIKELY(data_size == 0)) {
 		rxr_pkt_handle_data_copied(ep, pkt_entry, data_size);

--- a/prov/efa/src/rdm/rxr_pkt_type_data.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_data.c
@@ -61,7 +61,7 @@ int rxr_pkt_init_data(struct rxr_ep *ep,
 	} else {
 		assert(op_entry->type == RXR_TX_ENTRY);
 		data_hdr->recv_id = op_entry->rx_id;
-		if (op_entry->rxr_flags & RXR_DELIVERY_COMPLETE_REQUESTED)
+		if (op_entry->rxr_flags & RXR_TX_ENTRY_DELIVERY_COMPLETE_REQUESTED)
 			pkt_entry->flags |= RXR_PKT_ENTRY_DC_LONGCTS_DATA;
 	}
 

--- a/prov/efa/src/rdm/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_misc.c
@@ -424,7 +424,7 @@ void rxr_pkt_handle_rma_read_completion(struct rxr_ep *ep,
 				rxr_rx_entry_release(rx_entry);
 			}
 
-			rx_entry->rxr_flags |= RXR_EOR_IN_FLIGHT;
+			rx_entry->rxr_flags |= RXR_RX_ENTRY_EOR_IN_FLIGHT;
 			rx_entry->bytes_received += (read_entry->total_len - rx_entry->bytes_runt);
 			rx_entry->bytes_copied += (read_entry->total_len - rx_entry->bytes_runt);
 			if (rx_entry->bytes_copied == rx_entry->total_len) {
@@ -508,7 +508,7 @@ void rxr_pkt_handle_eor_send_completion(struct rxr_ep *ep,
 	if (rx_entry->bytes_copied == rx_entry->total_len) {
 		rxr_rx_entry_release(rx_entry);
 	} else {
-		rx_entry->rxr_flags &= ~RXR_EOR_IN_FLIGHT;
+		rx_entry->rxr_flags &= ~RXR_RX_ENTRY_EOR_IN_FLIGHT;
 	}
 }
 

--- a/prov/efa/src/rdm/rxr_pkt_type_req.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_req.c
@@ -526,7 +526,7 @@ ssize_t rxr_pkt_init_dc_eager_msgrtm(struct rxr_ep *ep,
 	struct rxr_dc_eager_msgrtm_hdr *dc_eager_msgrtm_hdr;
 	int ret;
 
-	tx_entry->rxr_flags |= RXR_DELIVERY_COMPLETE_REQUESTED;
+	tx_entry->rxr_flags |= RXR_TX_ENTRY_DELIVERY_COMPLETE_REQUESTED;
 	ret = rxr_pkt_init_rtm(ep, tx_entry, RXR_DC_EAGER_MSGRTM_PKT, 0, pkt_entry);
 	if (ret)
 		return ret;
@@ -560,7 +560,7 @@ ssize_t rxr_pkt_init_dc_eager_tagrtm(struct rxr_ep *ep,
 	struct rxr_dc_eager_tagrtm_hdr *dc_eager_tagrtm_hdr;
 	int ret;
 
-	tx_entry->rxr_flags |= RXR_DELIVERY_COMPLETE_REQUESTED;
+	tx_entry->rxr_flags |= RXR_TX_ENTRY_DELIVERY_COMPLETE_REQUESTED;
 	ret = rxr_pkt_init_rtm(ep, tx_entry, RXR_DC_EAGER_TAGRTM_PKT, 0, pkt_entry);
 	if (ret)
 		return ret;
@@ -600,7 +600,7 @@ ssize_t rxr_pkt_init_dc_medium_msgrtm(struct rxr_ep *ep,
 	struct rxr_dc_medium_msgrtm_hdr *dc_medium_msgrtm_hdr;
 	int ret;
 
-	tx_entry->rxr_flags |= RXR_DELIVERY_COMPLETE_REQUESTED;
+	tx_entry->rxr_flags |= RXR_TX_ENTRY_DELIVERY_COMPLETE_REQUESTED;
 
 	rxr_tx_entry_try_fill_desc(tx_entry, rxr_ep_domain(ep), 0, FI_SEND);
 
@@ -645,7 +645,7 @@ ssize_t rxr_pkt_init_dc_medium_tagrtm(struct rxr_ep *ep,
 	struct rxr_dc_medium_tagrtm_hdr *dc_medium_tagrtm_hdr;
 	int ret;
 
-	tx_entry->rxr_flags |= RXR_DELIVERY_COMPLETE_REQUESTED;
+	tx_entry->rxr_flags |= RXR_TX_ENTRY_DELIVERY_COMPLETE_REQUESTED;
 
 	rxr_tx_entry_try_fill_desc(tx_entry, rxr_ep_domain(ep), 0, FI_SEND);
 
@@ -693,7 +693,7 @@ ssize_t rxr_pkt_init_dc_longcts_msgrtm(struct rxr_ep *ep,
 				    struct rxr_op_entry *tx_entry,
 				    struct rxr_pkt_entry *pkt_entry)
 {
-	tx_entry->rxr_flags |= RXR_DELIVERY_COMPLETE_REQUESTED;
+	tx_entry->rxr_flags |= RXR_TX_ENTRY_DELIVERY_COMPLETE_REQUESTED;
 	return rxr_pkt_init_longcts_rtm(ep, tx_entry, RXR_DC_LONGCTS_MSGRTM_PKT, pkt_entry);
 }
 
@@ -721,7 +721,7 @@ ssize_t rxr_pkt_init_dc_longcts_tagrtm(struct rxr_ep *ep,
 	struct rxr_base_hdr *base_hdr;
 	int ret;
 
-	tx_entry->rxr_flags |= RXR_DELIVERY_COMPLETE_REQUESTED;
+	tx_entry->rxr_flags |= RXR_TX_ENTRY_DELIVERY_COMPLETE_REQUESTED;
 	ret = rxr_pkt_init_longcts_rtm(ep, tx_entry, RXR_DC_LONGCTS_TAGRTM_PKT, pkt_entry);
 	if (ret)
 		return ret;
@@ -1056,7 +1056,7 @@ struct rxr_op_entry *rxr_pkt_get_rtm_matched_rx_entry(struct rxr_ep *ep,
 
 	assert(match);
 	rx_entry = container_of(match, struct rxr_op_entry, entry);
-	if (rx_entry->rxr_flags & RXR_MULTI_RECV_POSTED) {
+	if (rx_entry->rxr_flags & RXR_RX_ENTRY_MULTI_RECV_POSTED) {
 		rx_entry = rxr_msg_split_rx_entry(ep, rx_entry, NULL, pkt_entry);
 		if (OFI_UNLIKELY(!rx_entry)) {
 			EFA_WARN(FI_LOG_CQ,
@@ -1406,7 +1406,7 @@ ssize_t rxr_pkt_proc_matched_rtm(struct rxr_ep *ep,
 
 	if (pkt_type > RXR_DC_REQ_PKT_BEGIN &&
 	    pkt_type < RXR_DC_REQ_PKT_END)
-		rx_entry->rxr_flags |= RXR_DELIVERY_COMPLETE_REQUESTED;
+		rx_entry->rxr_flags |= RXR_TX_ENTRY_DELIVERY_COMPLETE_REQUESTED;
 
 	if (pkt_type == RXR_LONGCTS_MSGRTM_PKT ||
 	    pkt_type == RXR_LONGCTS_TAGRTM_PKT)
@@ -1677,7 +1677,7 @@ ssize_t rxr_pkt_init_dc_eager_rtw(struct rxr_ep *ep,
 
 	assert(tx_entry->op == ofi_op_write);
 
-	tx_entry->rxr_flags |= RXR_DELIVERY_COMPLETE_REQUESTED;
+	tx_entry->rxr_flags |= RXR_TX_ENTRY_DELIVERY_COMPLETE_REQUESTED;
 	dc_eager_rtw_hdr = (struct rxr_dc_eager_rtw_hdr *)pkt_entry->wiredata;
 	dc_eager_rtw_hdr->rma_iov_count = tx_entry->rma_iov_count;
 	rxr_pkt_init_req_hdr(ep, tx_entry, RXR_DC_EAGER_RTW_PKT, pkt_entry);
@@ -1723,7 +1723,7 @@ ssize_t rxr_pkt_init_dc_longcts_rtw(struct rxr_ep *ep,
 
 	assert(tx_entry->op == ofi_op_write);
 
-	tx_entry->rxr_flags |= RXR_DELIVERY_COMPLETE_REQUESTED;
+	tx_entry->rxr_flags |= RXR_TX_ENTRY_DELIVERY_COMPLETE_REQUESTED;
 	rtw_hdr = (struct rxr_longcts_rtw_hdr *)pkt_entry->wiredata;
 	rxr_pkt_init_longcts_rtw_hdr(ep, tx_entry, pkt_entry, RXR_DC_LONGCTS_RTW_PKT);
 	return rxr_pkt_init_rtw_data(ep, tx_entry, pkt_entry, rtw_hdr->rma_iov);
@@ -1923,7 +1923,7 @@ void rxr_pkt_handle_dc_eager_rtw_recv(struct rxr_ep *ep,
 		return;
 	}
 
-	rx_entry->rxr_flags |= RXR_DELIVERY_COMPLETE_REQUESTED;
+	rx_entry->rxr_flags |= RXR_TX_ENTRY_DELIVERY_COMPLETE_REQUESTED;
 	rtw_hdr = (struct rxr_dc_eager_rtw_hdr *)pkt_entry->wiredata;
 	rx_entry->tx_id = rtw_hdr->send_id;
 	rx_entry->iov_count = rtw_hdr->rma_iov_count;
@@ -1955,7 +1955,7 @@ void rxr_pkt_handle_longcts_rtw_recv(struct rxr_ep *ep,
 	rtw_hdr = (struct rxr_longcts_rtw_hdr *)pkt_entry->wiredata;
 	tx_id = rtw_hdr->send_id;
 	if (rtw_hdr->type == RXR_DC_LONGCTS_RTW_PKT)
-		rx_entry->rxr_flags |= RXR_DELIVERY_COMPLETE_REQUESTED;
+		rx_entry->rxr_flags |= RXR_TX_ENTRY_DELIVERY_COMPLETE_REQUESTED;
 
 	rx_entry->iov_count = rtw_hdr->rma_iov_count;
 	err = rxr_rma_verified_copy_iov(ep, rtw_hdr->rma_iov, rtw_hdr->rma_iov_count,
@@ -2221,7 +2221,7 @@ ssize_t rxr_pkt_init_dc_write_rta(struct rxr_ep *ep,
 {
 	struct rxr_rta_hdr *rta_hdr;
 
-	tx_entry->rxr_flags |= RXR_DELIVERY_COMPLETE_REQUESTED;
+	tx_entry->rxr_flags |= RXR_TX_ENTRY_DELIVERY_COMPLETE_REQUESTED;
 	rxr_pkt_init_rta(ep, tx_entry, RXR_DC_WRITE_RTA_PKT, pkt_entry);
 	rta_hdr = rxr_get_rta_hdr(pkt_entry->wiredata);
 	rta_hdr->send_id = tx_entry->tx_id;
@@ -2416,7 +2416,7 @@ int rxr_pkt_proc_dc_write_rta(struct rxr_ep *ep,
 
 	rta_hdr = (struct rxr_rta_hdr *)pkt_entry->wiredata;
 	rx_entry->tx_id = rta_hdr->send_id;
-	rx_entry->rxr_flags |= RXR_DELIVERY_COMPLETE_REQUESTED;
+	rx_entry->rxr_flags |= RXR_TX_ENTRY_DELIVERY_COMPLETE_REQUESTED;
 
 	ret = rxr_pkt_proc_write_rta(ep, pkt_entry);
 	if (OFI_UNLIKELY(ret)) {

--- a/prov/efa/src/rdm/rxr_rma.c
+++ b/prov/efa/src/rdm/rxr_rma.c
@@ -507,7 +507,7 @@ ssize_t rxr_rma_inject_write(struct fid_ep *ep, const void *buf, size_t len,
 	msg.rma_iov_count = 1;
 	msg.addr = dest_addr;
 
-	return rxr_rma_writemsg(ep, &msg, FI_INJECT | RXR_NO_COMPLETION);
+	return rxr_rma_writemsg(ep, &msg, FI_INJECT | RXR_TX_ENTRY_NO_COMPLETION);
 }
 
 ssize_t rxr_rma_inject_writedata(struct fid_ep *ep, const void *buf, size_t len,
@@ -539,7 +539,7 @@ ssize_t rxr_rma_inject_writedata(struct fid_ep *ep, const void *buf, size_t len,
 	msg.addr = dest_addr;
 	msg.data = data;
 
-	return rxr_rma_writemsg(ep, &msg, FI_INJECT | RXR_NO_COMPLETION |
+	return rxr_rma_writemsg(ep, &msg, FI_INJECT | RXR_TX_ENTRY_NO_COMPLETION |
 				FI_REMOTE_CQ_DATA);
 }
 


### PR DESCRIPTION
This patch move flags that are only applied to rxr_op_entry from rxr.h to rxr_op_entry.h.

It also rename some flags and added OP/TX/RX_ENTRY to indicate their usage.

Signed-off-by: Wei Zhang <wzam@amazon.com>