### PR TITLE
prov/efa: remove used efa_domain parameter in rxr_op_entry_try_fill_desc

### DIFF
--- a/prov/efa/src/rdm/rxr_op_entry.c
+++ b/prov/efa/src/rdm/rxr_op_entry.c
@@ -267,14 +267,11 @@ void rxr_rx_entry_release(struct rxr_op_entry *rx_entry)
  * memory registration then retry.
  *
  * @param[in,out]	op_entry		contains the inforation of a TX/RX operation
- * @param[in]		efa_domain		where memory regstration function operates from
  * @param[in]		mr_iov_start	the IOV index to start generating descriptors
  * @param[in]		access			the access flag for the memory registation.
  *
  */
-void rxr_op_entry_try_fill_desc(struct rxr_op_entry *op_entry,
-				struct efa_domain *efa_domain,
-				int mr_iov_start, uint64_t access)
+void rxr_op_entry_try_fill_desc(struct rxr_op_entry *op_entry, int mr_iov_start, uint64_t access)
 {
 	int i, err;
 	struct efa_rdm_peer *peer;
@@ -325,7 +322,7 @@ int rxr_tx_entry_prepare_to_be_read(struct rxr_op_entry *tx_entry, struct fi_rma
 {
 	int i;
 
-	rxr_op_entry_try_fill_desc(tx_entry, rxr_ep_domain(tx_entry->ep), 0, FI_REMOTE_READ);
+	rxr_op_entry_try_fill_desc(tx_entry, 0, FI_REMOTE_READ);
 
 	for (i = 0; i < tx_entry->iov_count; ++i) {
 		read_iov[i].addr = (uint64_t)tx_entry->iov[i].iov_base;
@@ -1258,7 +1255,7 @@ int rxr_op_entry_post_remote_read(struct rxr_op_entry *op_entry)
 	assert(op_entry->bytes_read_submitted < op_entry->bytes_read_total_len);
 
 	if (!use_shm) {
-		rxr_op_entry_try_fill_desc(op_entry, rxr_ep_domain(op_entry->ep), 0, FI_RECV);
+		rxr_op_entry_try_fill_desc(op_entry, 0, FI_RECV);
 	}
 
 	max_read_once_len = use_shm ? SIZE_MAX : MIN(rxr_env.efa_read_segment_size, rxr_ep_domain(ep)->device->max_rdma_size);

--- a/prov/efa/src/rdm/rxr_op_entry.h
+++ b/prov/efa/src/rdm/rxr_op_entry.h
@@ -324,9 +324,7 @@ struct rxr_op_entry *rxr_op_entry_of_pkt_entry(struct rxr_pkt_entry *pkt_entry)
  */
 #define RXR_OP_ENTRY_QUEUED_READ 	BIT_ULL(12)
 
-void rxr_op_entry_try_fill_desc(struct rxr_op_entry *op_entry,
-				struct efa_domain *efa_domain,
-				int mr_iov_start, uint64_t access);
+void rxr_op_entry_try_fill_desc(struct rxr_op_entry *op_entry, int mr_iov_start, uint64_t access);
 
 int rxr_tx_entry_prepare_to_be_read(struct rxr_op_entry *tx_entry,
 				    struct fi_rma_iov *read_iov);

--- a/prov/efa/src/rdm/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_misc.c
@@ -306,7 +306,7 @@ void rxr_pkt_handle_readrsp_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_en
 	assert(rx_entry->window >= 0);
 	if (rx_entry->bytes_sent < rx_entry->total_len) {
 		if (efa_is_cache_available(rxr_ep_domain(ep)))
-			rxr_op_entry_try_fill_desc(rx_entry, rxr_ep_domain(ep), 0, FI_SEND);
+			rxr_op_entry_try_fill_desc(rx_entry, 0, FI_SEND);
 
 		rx_entry->state = RXR_TX_SEND;
 		dlist_insert_tail(&rx_entry->entry, &ep->op_entry_longcts_send_list);

--- a/prov/efa/src/rdm/rxr_pkt_type_req.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_req.c
@@ -580,7 +580,7 @@ ssize_t rxr_pkt_init_medium_msgrtm(struct rxr_ep *ep,
 	struct rxr_medium_rtm_base_hdr *rtm_hdr;
 	int ret;
 
-	rxr_op_entry_try_fill_desc(tx_entry, rxr_ep_domain(ep), 0, FI_SEND);
+	rxr_op_entry_try_fill_desc(tx_entry, 0, FI_SEND);
 
 	ret = rxr_pkt_init_rtm(ep, tx_entry, RXR_MEDIUM_MSGRTM_PKT,
 			       tx_entry->bytes_sent, pkt_entry);
@@ -602,7 +602,7 @@ ssize_t rxr_pkt_init_dc_medium_msgrtm(struct rxr_ep *ep,
 
 	tx_entry->rxr_flags |= RXR_TX_ENTRY_DELIVERY_COMPLETE_REQUESTED;
 
-	rxr_op_entry_try_fill_desc(tx_entry, rxr_ep_domain(ep), 0, FI_SEND);
+	rxr_op_entry_try_fill_desc(tx_entry, 0, FI_SEND);
 
 	ret = rxr_pkt_init_rtm(ep, tx_entry, RXR_DC_MEDIUM_MSGRTM_PKT,
 			       tx_entry->bytes_sent, pkt_entry);
@@ -623,7 +623,7 @@ ssize_t rxr_pkt_init_medium_tagrtm(struct rxr_ep *ep,
 	struct rxr_medium_rtm_base_hdr *rtm_hdr;
 	int ret;
 
-	rxr_op_entry_try_fill_desc(tx_entry, rxr_ep_domain(ep), 0, FI_SEND);
+	rxr_op_entry_try_fill_desc(tx_entry, 0, FI_SEND);
 
 	ret = rxr_pkt_init_rtm(ep, tx_entry, RXR_MEDIUM_TAGRTM_PKT,
 			       tx_entry->bytes_sent, pkt_entry);
@@ -647,7 +647,7 @@ ssize_t rxr_pkt_init_dc_medium_tagrtm(struct rxr_ep *ep,
 
 	tx_entry->rxr_flags |= RXR_TX_ENTRY_DELIVERY_COMPLETE_REQUESTED;
 
-	rxr_op_entry_try_fill_desc(tx_entry, rxr_ep_domain(ep), 0, FI_SEND);
+	rxr_op_entry_try_fill_desc(tx_entry, 0, FI_SEND);
 
 	ret = rxr_pkt_init_rtm(ep, tx_entry, RXR_DC_MEDIUM_TAGRTM_PKT,
 			       tx_entry->bytes_sent, pkt_entry);
@@ -888,7 +888,7 @@ void rxr_pkt_handle_longcts_rtm_sent(struct rxr_ep *ep,
 	assert(tx_entry->bytes_sent < tx_entry->total_len);
 
 	if (efa_is_cache_available(rxr_ep_domain(ep)))
-		rxr_op_entry_try_fill_desc(tx_entry, rxr_ep_domain(ep), 0, FI_SEND);
+		rxr_op_entry_try_fill_desc(tx_entry, 0, FI_SEND);
 }
 
 
@@ -1783,7 +1783,7 @@ void rxr_pkt_handle_longcts_rtw_sent(struct rxr_ep *ep,
 	tx_entry->bytes_sent += rxr_pkt_req_data_size(pkt_entry);
 	assert(tx_entry->bytes_sent < tx_entry->total_len);
 	if (efa_is_cache_available(efa_domain))
-		rxr_op_entry_try_fill_desc(tx_entry, rxr_ep_domain(ep), 0, FI_SEND);
+		rxr_op_entry_try_fill_desc(tx_entry, 0, FI_SEND);
 }
 
 /*


### PR DESCRIPTION
Remove unused parameter

Signed-off-by: Wenduo Wang <wenduwan@amazon.com>