### PR TITLE
contrib/intel: fix OneCCL testing

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -490,23 +490,6 @@ pipeline {
             }
           }
         }
-        stage('oneCCL-GPU') {
-          agent { node {  label 'ze' } }
-          options { skipDefaultCheckout() }
-          steps {
-            withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
-              sh """
-                env
-                (
-                  cd ${env.WORKSPACE}/${SCRIPT_LOCATION}/
-                  python3.7 runtests.py --prov=tcp --test=onecclgpu
-                  echo "oneCCL-GPU tcp completed."
-                  echo "oneCCL-GPU completed."
-                )
-              """
-            }
-          }
-        }
         stage('daos_tcp') {
           agent {
             node {

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -482,8 +482,6 @@ pipeline {
                   cd ${env.WORKSPACE}/${SCRIPT_LOCATION}/
                   python3.7 runtests.py --prov=tcp --util=rxm --test=oneccl
                   echo "oneCCL tcp-rxm completed."
-                  python3.7 runtests.py --prov=net --test=oneccl
-                  echo "oneCCL net completed."
                   python3.7 runtests.py --prov=psm3 --test=oneccl
                   echo "oneCCL psm3 completed."
                   echo "OneCCL completed."
@@ -503,8 +501,6 @@ pipeline {
                   cd ${env.WORKSPACE}/${SCRIPT_LOCATION}/
                   python3.7 runtests.py --prov=tcp --test=onecclgpu
                   echo "oneCCL-GPU tcp completed."
-                  python3.7 runtests.py --prov=net --test=onecclgpu
-                  echo "oneCCL-GPU net completed."
                   echo "oneCCL-GPU completed."
                 )
               """

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -815,6 +815,7 @@ class OneCCLTestsGPU(Test):
         opts = f"-n {self.n} "
         opts += f"-ppn {self.ppn} "
         opts += f"-hosts {self.server},{self.client} "
+        opts += f"-prov '{self.core_prov}' "
         opts += f"-test {oneccl_test_gpu} "
         opts += f"-libfabric_path={self.libfab_installpath}/lib "
         opts += f'-oneccl_root={self.oneccl_path}'


### PR DESCRIPTION
Errors in internal scripts weren't catching real failures. CI will fail now until this is merged