### PR TITLE
prov/efa: fix bugs casued by "op_entry directly post read"

### DIFF
--- a/prov/efa/src/rdm/rxr_op_entry.h
+++ b/prov/efa/src/rdm/rxr_op_entry.h
@@ -131,8 +131,6 @@ struct rxr_op_entry {
 
 	struct fi_cq_tagged_entry cq_entry;
 
-	struct rxr_read_entry *read_entry;
-
 	/* For tx_entry, entry is linked with tx_pending_list in rxr_ep.
 	 * For rx_entry, entry is linked with one of the receive lists: rx_list, rx_tagged_list,
 	 * rx_unexp_list and rxr_unexp_tagged_list in rxr_ep.

--- a/prov/efa/src/rdm/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_misc.c
@@ -416,6 +416,7 @@ void rxr_pkt_handle_rma_read_completion(struct rxr_ep *ep,
 	} else if (x_entry_type == RXR_RX_ENTRY) {
 		rx_entry = context_pkt_entry->x_entry;
 		rx_entry->bytes_read_completed += rma_context_pkt->seg_size;
+		assert(rx_entry->bytes_read_completed <= rx_entry->bytes_read_total_len);
 		if (rx_entry->bytes_read_completed == rx_entry->bytes_read_total_len) {
 			rxr_tracing(read_completed,
 				    rx_entry->msg_id, (size_t) rx_entry->cq_entry.op_context,
@@ -445,7 +446,7 @@ void rxr_pkt_handle_rma_read_completion(struct rxr_ep *ep,
 		read_entry->bytes_finished += rma_context_pkt->seg_size;
 		assert(read_entry->bytes_finished <= read_entry->total_len);
 		if (read_entry->bytes_finished == read_entry->total_len) {
-			assert(read_entry->context_type == RXR_READ_CONTEXT_TX_ENTRY);
+			assert(read_entry->context_type == RXR_READ_CONTEXT_PKT_ENTRY);
 			data_pkt_entry = read_entry->context;
 			data_size = rxr_pkt_data_size(data_pkt_entry);
 			assert(data_size > 0);

--- a/prov/efa/src/rdm/rxr_pkt_type_req.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_req.c
@@ -1260,7 +1260,7 @@ ssize_t rxr_pkt_proc_matched_mulreq_rtm(struct rxr_ep *ep,
 
 		runtread_rtm_hdr = rxr_get_runtread_rtm_base_hdr(pkt_entry->wiredata);
 		rx_entry->bytes_runt = runtread_rtm_hdr->runt_length;
-		if (rx_entry->total_len > rx_entry->bytes_runt && !rx_entry->read_entry) {
+		if (rx_entry->total_len > rx_entry->bytes_runt && rx_entry->bytes_read_total_len == 0) {
 			struct fi_rma_iov *read_iov;
 
 			rx_entry->tx_id = runtread_rtm_hdr->send_id;

--- a/prov/efa/src/rdm/rxr_read.c
+++ b/prov/efa/src/rdm/rxr_read.c
@@ -340,6 +340,7 @@ int rxr_read_post_local_read_or_queue(struct rxr_ep *ep,
 		return -FI_ENOBUFS;
 	}
 
+	read_entry->type = RXR_READ_ENTRY;
 	read_entry->read_id = ofi_buf_index(read_entry);
 	read_entry->lower_ep_type = EFA_EP;
 	read_entry->context_type = RXR_READ_CONTEXT_PKT_ENTRY;


### PR DESCRIPTION
A previous commit db95f071ce2d5253b626e6f05751aec32565da2c introduced a few bugs. This patch fixed them.

Signed-off-by: Wei Zhang <wzam@amazon.com>