### PR TITLE
prov/efa: initialize efawin library before EFA device on Windows

### DIFF
--- a/prov/efa/src/efa_prov.c
+++ b/prov/efa/src/efa_prov.c
@@ -168,16 +168,16 @@ EFA_INI
 #endif
 	int err;
 
+	err = efa_win_lib_initialize();
+	if (err)
+		goto err_free;
+
 	err = efa_device_list_initialize();
 	if (err)
 		return NULL;
 
 	if (g_device_cnt <= 0)
 		return NULL;
-
-	err = efa_win_lib_initialize();
-	if (err)
-		goto err_free;
 
 	err = efa_util_prov_initialize();
 	if (err)


### PR DESCRIPTION
Fix a latent bug that causes EFA initialization failure on Windows