### PR TITLE
contrib/intel/jenkins: Correctly set global change_target

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -9,6 +9,7 @@ def check_target() {
   if (changeRequest()) {
     TARGET = env.CHANGE_TARGET
   }
+  return TARGET
 }
 
 def release() {
@@ -48,6 +49,7 @@ def skip() {
     changeStrings.add(line)
   }
 
+  echo "Changeset is: ${changeStrings.toArray()}"
   if (changeStrings.toArray().every { it =~ /(?:fabtests\/pytests|man|prov\/efa|prov\/opx).*$/ }) {
     echo "DONT RUN!"
     return 0
@@ -80,7 +82,7 @@ pipeline {
     stage ('opt-out') {
       steps {
         script {
-          check_target()
+          TARGET=check_target()
         }
         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
           sh """


### PR DESCRIPTION
Have check_target return the target found (default main) instead of setting locally. Print out changeset for debugging purposes