### PR TITLE
contrib/intel/jenkins: Add excluded tests back to psm3 stage

### DIFF
--- a/fabtests/test_configs/psm3/psm3.exclude
+++ b/fabtests/test_configs/psm3/psm3.exclude
@@ -15,7 +15,5 @@ scalable_ep
 shared_av
 rdm_cntr_pingpong
 multi_recv
-rdm_tagged_peek
 dgram_waitset
-cq_data
 multinode


### PR DESCRIPTION
fi_rdm_tagged_peek and fi_cq_data tests were disabled for the CI because of race condition in psm3. 
Issue has been fixed in the latest psm3 release (11.4) and has been verified manually and by CI.
Github issue: https://github.com/ofiwg/libfabric/issues/7550