### PR TITLE
contrib/intel/jenkins: Update summary delimiter for post processing

### DIFF
--- a/contrib/intel/jenkins/summary.py
+++ b/contrib/intel/jenkins/summary.py
@@ -104,11 +104,11 @@ class Summarizer(ABC):
             self.logger.log(
                 f"{self.stage_name}: ", lpad=1, ljust=40, end_delimiter = ''
             )
-        self.logger.log(f"{self.passes}/{total} ", ljust=10, end_delimiter = '')
-        self.logger.log(f"= {percent:.2f}% ", ljust=12, end_delimiter = '')
+        self.logger.log(f"{self.passes}:{total} ", ljust=10, end_delimiter = '')
+        self.logger.log(f": {percent:.2f}% : ", ljust=12, end_delimiter = '')
         self.logger.log("Pass", end_delimiter = '')
         if (self.excludes > 0):
-            self.logger.log(f"  |  {self.excludes:3.0f} Excluded/Notrun")
+            self.logger.log(f"  :  {self.excludes:3.0f} : Excluded/Notrun")
         else:
             self.logger.log("")
 

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -660,7 +660,8 @@ class MpichTestSuite(Test):
 
     @property
     def execute_condn(self):
-        return (self.mpi_type == 'mpich' and self.core_prov == 'verbs')
+        return (self.mpi_type == 'impi' or \
+               (self.mpi_type == 'mpich' and self.core_prov == 'verbs'))
 
     def execute_cmd(self, testgroupname):
         print("Running Tests: " + testgroupname)


### PR DESCRIPTION
Make non verbose summary use ':' as a delimiter for post processing in excel
Add impi back as a valid test case for mpichtestsuite