### PR TITLE
[v1.17.x] prov/efa: fix double free in rxr endpoint init

### DIFF
--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -2465,9 +2465,9 @@ static int rxr_ep_setup_device_cq(struct rxr_ep *rxr_ep)
 int rxr_endpoint(struct fid_domain *domain, struct fi_info *info,
 		 struct fid_ep **ep, void *context)
 {
-	struct fi_info *rdm_info;
-	struct efa_domain *efa_domain;
-	struct rxr_ep *rxr_ep;
+	struct fi_info *rdm_info = NULL;
+	struct efa_domain *efa_domain = NULL;
+	struct rxr_ep *rxr_ep = NULL;
 	struct fi_cq_attr cq_attr;
 	int ret, retv;
 
@@ -2536,6 +2536,7 @@ int rxr_endpoint(struct fid_domain *domain, struct fi_info *info,
 	rxr_ep->max_proto_hdr_size = rxr_pkt_max_hdr_size();
 	rxr_ep->mtu_size = rdm_info->ep_attr->max_msg_size;
 	fi_freeinfo(rdm_info);
+	rdm_info = NULL;
 
 	if (rxr_env.mtu_size > 0 && rxr_env.mtu_size < rxr_ep->mtu_size)
 		rxr_ep->mtu_size = rxr_env.mtu_size;
@@ -2640,7 +2641,8 @@ err_close_core_ep:
 		FI_WARN(&rxr_prov, FI_LOG_EP_CTRL, "Unable to close EP: %s\n",
 			fi_strerror(-retv));
 err_free_rdm_info:
-	fi_freeinfo(rdm_info);
+	if (rdm_info)
+		fi_freeinfo(rdm_info);
 err_close_ofi_ep:
 	retv = ofi_endpoint_close(&rxr_ep->util_ep);
 	if (retv)
@@ -2648,7 +2650,8 @@ err_close_ofi_ep:
 			"Unable to close util EP: %s\n",
 			fi_strerror(-retv));
 err_free_ep:
-	free(rxr_ep);
+	if (rxr_ep)
+		free(rxr_ep);
 	return ret;
 }
 


### PR DESCRIPTION
Manually apply a patch to prevent rdm_info from being freed twice. Cherry-picking the fix on main branch results in conflict, and thus we do a simpler fix instead.