### PR TITLE
prov/efa: Check FI_EFA_USE_DEVICE_RDMA per domain

### DIFF
--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -197,6 +197,8 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 		return -FI_EINVAL;
 	}
 
+	/* Check the value of environment variable FI_EFA_USE_DEVICE_RDMA */
+	efa_domain->use_device_rdma = rxr_env_get_use_device_rdma();
 
 	efa_domain->mr_local = ofi_mr_local(info);
 	if (EFA_EP_TYPE_IS_DGRAM(info) && !efa_domain->mr_local) {

--- a/prov/efa/src/efa_domain.h
+++ b/prov/efa/src/efa_domain.h
@@ -54,6 +54,7 @@ struct efa_domain {
 	bool 			mr_local;
 	uint64_t		rdm_mode;
 	size_t			rdm_cq_size;
+	int	                use_device_rdma;
 	struct dlist_entry	list_entry; /* linked to g_efa_domain_list */
 };
 
@@ -119,7 +120,7 @@ bool efa_domain_support_rnr_retry_modify(struct efa_domain *domain)
 static inline
 bool efa_domain_support_rdma_read(struct efa_domain *domain)
 {
-	if (!rxr_env.use_device_rdma)
+	if (!domain->use_device_rdma)
 		return 0;
 
 	return domain->device->device_caps & EFADV_DEVICE_ATTR_CAPS_RDMA_READ;

--- a/prov/efa/src/efa_user_info.c
+++ b/prov/efa/src/efa_user_info.c
@@ -358,7 +358,7 @@ int efa_user_info_alter_rxr(struct fi_info *info, const struct fi_info *hints)
 					return -FI_ENODATA;
 				}
 
-				if (!rxr_env.use_device_rdma) {
+				if (!rxr_env_get_use_device_rdma()) {
 					EFA_WARN(FI_LOG_CORE,
 						"FI_HMEM capability requires RDMA, which is turned off. "
 						"You can turn it on by setting environment variable "

--- a/prov/efa/src/rdm/rxr_env.h
+++ b/prov/efa/src/rdm/rxr_env.h
@@ -43,7 +43,6 @@
 struct rxr_env {
 	int tx_min_credits;
 	int tx_queue_size;
-	int use_device_rdma;
 	int use_zcpy_rx;
 	int set_cuda_sync_memops;
 	int zcpy_rx_seed;
@@ -86,5 +85,7 @@ struct rxr_env {
 extern struct rxr_env rxr_env;
 
 void rxr_env_initialize();
+
+int rxr_env_get_use_device_rdma();
 
 #endif

--- a/prov/efa/src/rdm/rxr_rma.c
+++ b/prov/efa/src/rdm/rxr_rma.c
@@ -223,7 +223,7 @@ ssize_t rxr_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uint64_
 	if (peer->is_local && rxr_ep->use_shm_for_tx) {
 		use_lower_ep_read = true;
 	} else if (efa_both_support_rdma_read(rxr_ep, peer)) {
-		/* efa_both_support_rdma_read also check rxr_env.use_device_rdma,
+		/* efa_both_support_rdma_read also check domain.use_device_rdma,
 		 * so we do not check it here
 		 */
 		use_lower_ep_read = true;


### PR DESCRIPTION
Prior to this change FI_EFA_USE_DEVICE_RDMA was checked only once when the provider is initialized. Due to this different plugins/libraries setting up the environment for various applications cannot modify the value of this environment variable.

This patch provides this possibility by checking the value of FI_EFA_USE_DEVICE_RDMA once per domain.