### PR TITLE
prov/efa: query 128-bytes aligned writing capacity

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-Version @VERSION@
+ Version @VERSION@
 Released on @DATE@
 
 Introduction


### PR DESCRIPTION
Some EFA device may support in-order write for each 128-bytes aligned piece over RDMA write. This PR allows applications to enable this feature via `fi_setopt`.