### PR TITLE
prov/efa: Check FI_HMEM_CUDA_ENABLE_XFER per domain

### DIFF
--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -197,6 +197,8 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 		return -FI_EINVAL;
 	}
 
+	// Check the value of environment variable FI_HMEM_CUDA_ENABLE_XFER
+	efa_domain->cuda_xfer_setting = cuda_get_xfer_setting();
 
 	efa_domain->mr_local = ofi_mr_local(info);
 	if (EFA_EP_TYPE_IS_DGRAM(info) && !efa_domain->mr_local) {

--- a/prov/efa/src/efa_domain.h
+++ b/prov/efa/src/efa_domain.h
@@ -54,6 +54,7 @@ struct efa_domain {
 	bool 			mr_local;
 	uint64_t		rdm_mode;
 	size_t			rdm_cq_size;
+	enum cuda_xfer_setting  cuda_xfer_setting;
 	struct dlist_entry	list_entry; /* linked to g_efa_domain_list */
 };
 

--- a/prov/efa/src/efa_hmem.c
+++ b/prov/efa/src/efa_hmem.c
@@ -156,7 +156,7 @@ static int efa_domain_hmem_info_init_cuda(struct efa_domain *efa_domain)
 	 * Require p2p for FI_HMEM_CUDA unless the user exlipictly enables
 	 * FI_HMEM_CUDA_ENABLE_XFER
 	 */
-	info->p2p_required_by_impl = cuda_get_xfer_setting() != CUDA_XFER_ENABLED;
+	info->p2p_required_by_impl = efa_domain->cuda_xfer_setting != CUDA_XFER_ENABLED;
 
 	ibv_mr = ibv_reg_mr(g_device_list[0].ibv_pd, ptr, len, ibv_access);
 	if (!ibv_mr) {

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -210,7 +210,7 @@ static struct fi_ops efa_mr_cache_ops = {
 static inline
 bool efa_mr_use_gdrcopy(struct efa_mr *efa_mr)
 {
-	return efa_mr->peer.iface == FI_HMEM_CUDA && cuda_get_xfer_setting()!=CUDA_XFER_ENABLED && cuda_is_gdrcopy_enabled();
+	return efa_mr->peer.iface == FI_HMEM_CUDA && efa_mr->domain->cuda_xfer_setting != CUDA_XFER_ENABLED && cuda_is_gdrcopy_enabled();
 }
 
 /*


### PR DESCRIPTION
Prior to this change FI_HMEM_CUDA_ENABLE_XFER was checked only once when the provider is initialized. Due to this different plugins/libraries setting up the environment for various applications cannot modify the value of this environment variable.

This patch provides this possibility by checking the value of FI_HMEM_CUDA_ENABLE_XFER once per domain.