### PR TITLE
prov/efa: Implement RDMA write for EFA

### DIFF
--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -127,7 +127,7 @@ fi_addr_t efa_av_reverse_lookup_dgram(struct efa_av *av, uint16_t ahn, uint16_t 
  * @param[in]	av	address vector
  * @param[in]	ahn	address handle number
  * @param[in]	qpn	QP number
- * @param[in]   pkt_entry	rdm packet entry, used to extract connid
+ * @param[in]   pkt_entry	NULL or rdm packet entry, used to extract connid
  * @return	On success, return fi_addr to the peer who send the packet
  * 		If no such peer exist, return FI_ADDR_NOTAVAIL
  */
@@ -147,6 +147,12 @@ fi_addr_t efa_av_reverse_lookup_rdm(struct efa_av *av, uint16_t ahn, uint16_t qp
 
 	if (OFI_UNLIKELY(!cur_entry))
 		return FI_ADDR_NOTAVAIL;
+
+	if (!pkt_entry) {
+		/* There is no packet entry to extract connid from when we get an
+		   IBV_WC_RECV_RDMA_WITH_IMM completion from rdma-core. */
+		return cur_entry->conn->fi_addr;
+	}
 
 	connid = rxr_pkt_connid_ptr(pkt_entry);
 	if (!connid) {

--- a/prov/efa/src/rdm/rxr_env.c
+++ b/prov/efa/src/rdm/rxr_env.c
@@ -66,6 +66,7 @@ struct rxr_env rxr_env = {
 	.shm_cq_read_size = 50,
 	.efa_max_gdrcopy_msg_size = 32768,
 	.efa_read_segment_size = 1073741824,
+	.efa_write_segment_size = 1073741824, /* need to confirm this constant. */
 	.rnr_retry = 3, /* Setting this value to EFA_RNR_INFINITE_RETRY makes the firmware retry indefinitey */
 };
 

--- a/prov/efa/src/rdm/rxr_env.h
+++ b/prov/efa/src/rdm/rxr_env.h
@@ -69,6 +69,7 @@ struct rxr_env {
 	size_t shm_cq_read_size;
 	size_t efa_max_gdrcopy_msg_size;
 	size_t efa_read_segment_size;
+	size_t efa_write_segment_size;
 	/* If first attempt to send a packet failed,
 	 * this value controls how many times firmware
 	 * retries the send before it report an RNR error

--- a/prov/efa/src/rdm/rxr_ep.h
+++ b/prov/efa/src/rdm/rxr_ep.h
@@ -303,8 +303,10 @@ int rxr_ep_post_user_recv_buf(struct rxr_ep *ep, struct rxr_op_entry *rx_entry,
 
 struct efa_rdm_peer;
 
-int rxr_ep_determine_rdma_support(struct rxr_ep *ep, fi_addr_t addr,
-				  struct efa_rdm_peer *peer);
+int rxr_ep_determine_rdma_read_support(struct rxr_ep *ep, fi_addr_t addr,
+				       struct efa_rdm_peer *peer);
+int rxr_ep_determine_rdma_write_support(struct rxr_ep *ep, fi_addr_t addr,
+					struct efa_rdm_peer *peer);
 
 struct rxr_op_entry *rxr_ep_lookup_mediumrtm_rx_entry(struct rxr_ep *ep,
 						      struct rxr_pkt_entry *pkt_entry);

--- a/prov/efa/src/rdm/rxr_op_entry.h
+++ b/prov/efa/src/rdm/rxr_op_entry.h
@@ -199,6 +199,11 @@ struct rxr_op_entry {
 	uint64_t bytes_read_submitted;
 	uint64_t bytes_read_total_len;
 	uint64_t bytes_read_offset;
+
+	/* counters for rma writes */
+	uint64_t bytes_write_completed;
+	uint64_t bytes_write_submitted;
+	uint64_t bytes_write_total_len;
 };
 
 
@@ -353,7 +358,11 @@ void rxr_op_entry_handle_send_completed(struct rxr_op_entry *op_entry);
 
 int rxr_op_entry_prepare_to_post_read(struct rxr_op_entry *op_entry);
 
+void rxr_op_entry_prepare_to_post_write(struct rxr_op_entry *op_entry);
+
 int rxr_op_entry_post_remote_read(struct rxr_op_entry *op_entry);
+
+int rxr_op_entry_post_remote_write(struct rxr_op_entry *op_entry);
 
 int rxr_op_entry_post_remote_read_or_queue(struct rxr_op_entry *op_entry);
 

--- a/prov/efa/src/rdm/rxr_pkt_entry.c
+++ b/prov/efa/src/rdm/rxr_pkt_entry.c
@@ -508,6 +508,91 @@ int rxr_pkt_entry_read(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry,
 }
 
 /**
+ * @brief post one write request
+ *
+ * This function posts one write request.
+ *
+ * @param[in,out]	ep		endpoint
+ * @param[in]		pkt_entry	write_entry that has information of the write request.
+ * @param[in]		local_buf 	local buffer, where data will be copied from.
+ * @param[in]		len		write size.
+ * @param[in]		desc		memory descriptor of local buffer.
+ * @param[in]		remote_buff	remote buffer, where data will be written to.
+ * @param[in]		remote_key	memory key of remote buffer.
+ * @return	On success, return 0
+ * 		On failure, return a negative error code.
+ */
+int rxr_pkt_entry_write(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry,
+			void *local_buf, size_t len, void *desc,
+			uint64_t remote_buf, size_t remote_key)
+{
+	struct efa_rdm_peer *peer;
+	struct efa_qp *qp;
+	struct efa_conn *conn;
+	struct ibv_sge sge;
+	struct rxr_rma_context_pkt *rma_context_pkt;
+	struct rxr_op_entry *tx_entry;
+	bool self_comm;
+	int err = 0;
+
+	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
+	tx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
+
+	rma_context_pkt = (struct rxr_rma_context_pkt *)pkt_entry->wiredata;
+	rma_context_pkt->seg_size = len;
+
+	if (peer && peer->is_local && ep->use_shm_for_tx) {
+		err = fi_write(ep->shm_ep, local_buf, len, efa_mr_get_shm_desc(desc), peer->shm_fiaddr, remote_buf, remote_key, pkt_entry);
+	} else {
+		assert(((struct efa_mr *)desc)->ibv_mr);
+
+		self_comm = (peer == NULL);
+		if (self_comm)
+			pkt_entry->flags |= RXR_PKT_ENTRY_LOCAL_WRITE;
+
+		qp = ep->base_ep.qp;
+		ibv_wr_start(qp->ibv_qp_ex);
+		qp->ibv_qp_ex->wr_id = (uintptr_t)pkt_entry;
+
+		if (tx_entry->fi_flags & FI_REMOTE_CQ_DATA) {
+			/* assert that we are sending the entire buffer as a
+			   single IOV when immediate data is also included. */
+			assert( len == tx_entry->bytes_write_total_len );
+			ibv_wr_rdma_write_imm(qp->ibv_qp_ex, remote_key,
+				remote_buf, tx_entry->cq_entry.data);
+		} else {
+			ibv_wr_rdma_write(qp->ibv_qp_ex, remote_key, remote_buf);
+		}
+
+		sge.addr = (uint64_t)local_buf;
+		sge.length = len;
+		sge.lkey = ((struct efa_mr *)desc)->ibv_mr->lkey;
+
+		/* As an optimization, we should consider implementing multiple-
+		   iov writes using an IBV wr with multiple sge entries.
+		   For now, each WR contains only one sge. */
+		ibv_wr_set_sge_list(qp->ibv_qp_ex, 1, &sge);
+		if (self_comm) {
+			ibv_wr_set_ud_addr(qp->ibv_qp_ex, ep->base_ep.self_ah,
+					   qp->qp_num, qp->qkey);
+		} else {
+			conn = efa_av_addr_to_conn(ep->base_ep.av, pkt_entry->addr);
+			assert(conn && conn->ep_addr);
+			ibv_wr_set_ud_addr(qp->ibv_qp_ex, conn->ah->ibv_ah,
+					   conn->ep_addr->qpn, conn->ep_addr->qkey);
+		}
+
+		err = ibv_wr_complete(qp->ibv_qp_ex);
+	}
+
+	if (OFI_UNLIKELY(err))
+		return err;
+
+	rxr_ep_record_tx_op_submitted(ep, pkt_entry);
+	return 0;
+}
+
+/**
  * @brief Post a pkt_entry to receive message from EFA device
  *
  * @param[in] ep	rxr endpoint

--- a/prov/efa/src/rdm/rxr_pkt_entry.h
+++ b/prov/efa/src/rdm/rxr_pkt_entry.h
@@ -40,6 +40,8 @@
 #define RXR_PKT_ENTRY_RNR_RETRANSMIT	BIT_ULL(1) /**< this packet entry encountered RNR and is being retransmitted*/
 #define RXR_PKT_ENTRY_LOCAL_READ	BIT_ULL(2) /**< this packet entry is used as context of a local read operation */
 #define RXR_PKT_ENTRY_DC_LONGCTS_DATA	BIT_ULL(3) /**< this DATA packet entry is used by a delivery complete LONGCTS send/write protocol*/
+#define RXR_PKT_ENTRY_LOCAL_WRITE	BIT_ULL(4) /**< this packet entry is used as context of an RDMA Write to self */
+
 
 /**
  * @enum for packet entry allocation type
@@ -294,6 +296,10 @@ ssize_t rxr_pkt_entry_recv(struct rxr_ep *ep,
 ssize_t rxr_pkt_entry_inject(struct rxr_ep *ep,
 			     struct rxr_pkt_entry *pkt_entry,
 			     fi_addr_t addr);
+
+int rxr_pkt_entry_write(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry,
+		       void *local_buf, size_t len, void *desc,
+		       uint64_t remote_buf, size_t remote_key);
 
 struct rxr_pkt_rx_key {
 	uint64_t msg_id;


### PR DESCRIPTION
Implement rxr_op_entry_post_remote_write, which can be used by rxr_rma_writemsg to post writes using rdma-core.

A single FI_WRITE may generate multiple RDMA writes, and completions are tracked in rxr_pkt_handle_write_completion. When the entire write is complete, rxr_pkt_handle_rma_completion is called.