### PR TITLE
prov/efa: EFA's CQ_DATA size is now 4 bytes

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_cq.h
+++ b/prov/efa/src/rdm/efa_rdm_cq.h
@@ -41,7 +41,7 @@ typedef struct util_cq efa_rdm_cq;
 /*
  * Control header with completion data. CQ data length is static.
  */
-#define EFA_RDM_CQ_DATA_SIZE (8)
+#define EFA_RDM_CQ_DATA_SIZE (4)
 
 int efa_rdm_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		    struct fid_cq **cq_fid, void *context);


### PR DESCRIPTION
Previously EFA provider supported CQ_DATA size of 8 bytes, but we must change this to 4 bytes to align with rdma-core API for RDMA_WRITE_WITH_IMM which only takes a 4-byte immediate value.