### PR TITLE
prov/util: Free cq->peer_cq on close

### DIFF
--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -362,6 +362,10 @@ static void rxm_ep_txrx_res_close(struct rxm_ep *ep)
 		ofi_bufpool_destroy(ep->tx_pool);
 		ep->tx_pool = NULL;
 	}
+	if (ep->coll_pool) {
+		ofi_bufpool_destroy(ep->coll_pool);
+		ep->coll_pool = NULL;
+	}
 }
 
 static int rxm_setname(fid_t fid, void *addr, size_t addrlen)

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -451,6 +451,7 @@ static void util_peer_cq_cleanup(struct util_cq *cq)
 
 	util_comp_cirq_free(cq->cirq);
 	free(cq->src);
+	fi_close(&cq->peer_cq->fid);
 }
 
 int ofi_cq_cleanup(struct util_cq *cq)


### PR DESCRIPTION
The peer_cq is never freed, resulting in a minor memory leak.

Fixes #8534