### PR TITLE
Exclude OPX from build if older hfi1_user.h version

### DIFF
--- a/prov/opx/configure.m4
+++ b/prov/opx/configure.m4
@@ -120,13 +120,26 @@ AC_DEFUN([FI_OPX_CONFIGURE],[
 		    [],
 		    [],
 		    [opx_happy=0])
-
-               AC_CHECK_DECL([HAVE_ATOMICS],
-                             [],
-                             [cc_version=`$CC --version | head -n1`
-                              AC_MSG_WARN(["$cc_version" doesn't support native atomics.  Disabling OPX provider.])
-                              opx_happy=0])
-	])
+		AS_IF([test $opx_happy -eq 1],[
+			AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+				[[#include <rdma/hfi/hfi1_user.h>]],
+				[[
+					#if HFI1_USER_SWMAJOR != 6
+					#error "incorrect version of hfi1_user.h"
+					#endif
+				]])],
+				[AC_MSG_NOTICE([hfi1_user.h version 6.x found... yes])],
+				[
+				AC_MSG_NOTICE([hfi1_user.h version 6.x found... no])
+				opx_happy=0
+				])
+		])
+		AC_CHECK_DECL([HAVE_ATOMICS],
+			[],
+			[cc_version=`$CC --version | head -n1`
+			AC_MSG_WARN(["$cc_version" doesn't support native atomics.  Disabling OPX provider.])
+			opx_happy=0])
+		])
 
 	AS_IF([test $opx_happy -eq 1], [$1], [$2])
 ])


### PR DESCRIPTION
OPX will not compile if the system's hfi1_user.h is older than version 6; for now, exclude OPX from build if that header's macro HFI1_USER_SWMAJOR != 6.