### PR TITLE
prov/tcp,io_uring: Move connect() and CM messages to io_uring

### DIFF
--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -543,6 +543,14 @@ static inline int ofi_bsock_connect(struct ofi_bsock *bsock,
 				       addr, addrlen, &bsock->tx_sockctx);
 }
 
+static inline int ofi_bsock_recv_unbuffered(struct ofi_bsock *bsock, void *buf,
+					    size_t len)
+{
+	assert(!ofi_bsock_readable(bsock));
+	return bsock->sockapi->recv(bsock->sockapi, bsock->sock, buf, len,
+				    MSG_NOSIGNAL, &bsock->rx_sockctx);
+}
+
 int ofi_bsock_flush(struct ofi_bsock *bsock);
 int ofi_bsock_flush_sync(struct ofi_bsock *bsock);
 /* For sends started asynchronously, the return value will be -EINPROGRESS_ASYNC,

--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -149,15 +149,8 @@ typedef struct {
 } ofi_io_uring_cqe_t;
 #endif
 
-enum ofi_sockctx_type {
-	OFI_SOCKCTX_TX,
-	OFI_SOCKCTX_RX,
-	OFI_SOCKCTX_CANCEL,
-};
-
 struct ofi_sockctx {
 	void *context;
-	enum ofi_sockctx_type type;
 	bool uring_sqe_inuse;
 };
 
@@ -183,11 +176,9 @@ struct ofi_sockapi {
 };
 
 static inline void
-ofi_sockctx_init(struct ofi_sockctx *sockctx, enum ofi_sockctx_type type,
-		 void *context)
+ofi_sockctx_init(struct ofi_sockctx *sockctx, void *context)
 {
 	sockctx->context = context;
-	sockctx->type = type;
 	sockctx->uring_sqe_inuse = false;
 }
 
@@ -483,9 +474,9 @@ ofi_bsock_init(struct ofi_bsock *bsock, struct ofi_sockapi *sockapi,
 {
 	bsock->sock = INVALID_SOCKET;
 	bsock->sockapi = sockapi;
-	ofi_sockctx_init(&bsock->tx_sockctx, OFI_SOCKCTX_TX, context);
-	ofi_sockctx_init(&bsock->rx_sockctx, OFI_SOCKCTX_RX, context);
-	ofi_sockctx_init(&bsock->cancel_sockctx, OFI_SOCKCTX_CANCEL, context);
+	ofi_sockctx_init(&bsock->tx_sockctx, context);
+	ofi_sockctx_init(&bsock->rx_sockctx, context);
+	ofi_sockctx_init(&bsock->cancel_sockctx, context);
 	ofi_byteq_init(&bsock->sq, sbuf_size);
 	ofi_byteq_init(&bsock->rq, rbuf_size);
 	bsock->zerocopy_size = SIZE_MAX;

--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -503,6 +503,14 @@ static inline size_t ofi_bsock_tosend(struct ofi_bsock *bsock)
 	return ofi_byteq_readable(&bsock->sq);
 }
 
+static inline int ofi_bsock_connect(struct ofi_bsock *bsock,
+				    const struct sockaddr *addr,
+				    socklen_t addrlen)
+{
+	return bsock->sockapi->connect(bsock->sockapi, bsock->sock,
+				       addr, addrlen, &bsock->tx_sockctx);
+}
+
 int ofi_bsock_flush(struct ofi_bsock *bsock);
 int ofi_bsock_flush_sync(struct ofi_bsock *bsock);
 /* For sends started asynchronously, the return value will be -EINPROGRESS_ASYNC,

--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -479,13 +479,13 @@ struct ofi_bsock {
 
 static inline void
 ofi_bsock_init(struct ofi_bsock *bsock, struct ofi_sockapi *sockapi,
-	       ssize_t sbuf_size, ssize_t rbuf_size)
+	       ssize_t sbuf_size, ssize_t rbuf_size, void *context)
 {
 	bsock->sock = INVALID_SOCKET;
 	bsock->sockapi = sockapi;
-	ofi_sockctx_init(&bsock->tx_sockctx, OFI_SOCKCTX_TX, bsock);
-	ofi_sockctx_init(&bsock->rx_sockctx, OFI_SOCKCTX_RX, bsock);
-	ofi_sockctx_init(&bsock->cancel_sockctx, OFI_SOCKCTX_CANCEL, bsock);
+	ofi_sockctx_init(&bsock->tx_sockctx, OFI_SOCKCTX_TX, context);
+	ofi_sockctx_init(&bsock->rx_sockctx, OFI_SOCKCTX_RX, context);
+	ofi_sockctx_init(&bsock->cancel_sockctx, OFI_SOCKCTX_CANCEL, context);
 	ofi_byteq_init(&bsock->sq, sbuf_size);
 	ofi_byteq_init(&bsock->rq, rbuf_size);
 	bsock->zerocopy_size = SIZE_MAX;

--- a/prov/tcp/src/xnet.h
+++ b/prov/tcp/src/xnet.h
@@ -141,6 +141,7 @@ void xnet_accept_sock(struct xnet_pep *pep);
 void xnet_connect_done(struct xnet_ep *ep);
 void xnet_req_done(struct xnet_ep *ep);
 int xnet_send_cm_msg(struct xnet_ep *ep);
+void xnet_uring_req_done(struct xnet_ep *ep, int res);
 
 /* Inject buffer space is included */
 union xnet_hdrs {

--- a/prov/tcp/src/xnet.h
+++ b/prov/tcp/src/xnet.h
@@ -221,6 +221,7 @@ struct xnet_ep {
 	struct util_peer_addr	*peer;
 	struct xnet_conn_handle *conn;
 	struct xnet_cm_msg	*cm_msg;
+	struct sockaddr		*addr;
 
 	void (*hdr_bswap)(struct xnet_ep *ep, struct xnet_base_hdr *hdr);
 

--- a/prov/tcp/src/xnet_cm.c
+++ b/prov/tcp/src/xnet_cm.c
@@ -177,6 +177,8 @@ void xnet_req_done(struct xnet_ep *ep)
 	ep->state = XNET_CONNECTED;
 	free(ep->cm_msg);
 	ep->cm_msg = NULL;
+	free(ep->addr);
+	ep->addr = NULL;
 	return;
 
 disable:

--- a/prov/tcp/src/xnet_ep.c
+++ b/prov/tcp/src/xnet_ep.c
@@ -650,7 +650,8 @@ int xnet_endpoint(struct fid_domain *domain, struct fi_info *info,
 		goto err1;
 
 	ofi_bsock_init(&ep->bsock, &xnet_ep2_progress(ep)->sockapi,
-		       xnet_staging_sbuf_size, xnet_prefetch_rbuf_size);
+		       xnet_staging_sbuf_size, xnet_prefetch_rbuf_size,
+		       &ep->util_ep.ep_fid);
 	if (info->handle) {
 		if (((fid_t) info->handle)->fclass == FI_CLASS_PEP) {
 			pep = container_of(info->handle, struct xnet_pep,

--- a/prov/tcp/src/xnet_progress.c
+++ b/prov/tcp/src/xnet_progress.c
@@ -927,7 +927,7 @@ static void xnet_progress_cqe(struct xnet_progress *progress,
 	struct xnet_xfer_entry *tx_entry;
 	struct xnet_xfer_entry *rx_entry;
 	struct ofi_sockctx *sockctx;
-	struct ofi_bsock *bsock;
+	struct fid *fid;
 	struct xnet_ep *ep;
 	int ret;
 
@@ -935,16 +935,16 @@ static void xnet_progress_cqe(struct xnet_progress *progress,
 	sockctx = (struct ofi_sockctx *) cqe->user_data;
 	assert(sockctx);
 
-	bsock = (struct ofi_bsock *) sockctx->context;
-	assert(bsock);
+	fid = sockctx->context;
+	assert(fid->fclass == FI_CLASS_EP);
 
-	ep = container_of(bsock, struct xnet_ep, bsock);
+	ep = container_of(fid, struct xnet_ep, util_ep.ep_fid.fid);
 
 	assert(sockctx->uring_sqe_inuse);
 	sockctx->uring_sqe_inuse = false;
 	uring->sockapi->credits++;
 
-	if (sockctx->type == OFI_SOCKCTX_TX) {
+	if (sockctx == &ep->bsock.tx_sockctx) {
 		tx_entry = ep->cur_tx.entry;
 		assert(tx_entry);
 
@@ -961,12 +961,12 @@ static void xnet_progress_cqe(struct xnet_progress *progress,
 				xnet_complete_tx(ep, FI_SUCCESS);
 		}
 		xnet_progress_tx(ep);
-	} else if (sockctx->type == OFI_SOCKCTX_RX) {
-		if (bsock->async_prefetch) {
+	} else if (sockctx == &ep->bsock.rx_sockctx) {
+		if (ep->bsock.async_prefetch) {
 			if (cqe->res > 0)
-				ofi_bsock_prefetch_done(bsock, cqe->res);
+				ofi_bsock_prefetch_done(&ep->bsock, cqe->res);
 			else {
-				bsock->async_prefetch = false;
+				ep->bsock.async_prefetch = false;
 				goto disable_ep;
 			}
 		} else if (cqe->res <= 0 && !OFI_SOCK_TRY_SND_RCV_AGAIN(-cqe->res)) {
@@ -993,7 +993,7 @@ static void xnet_progress_cqe(struct xnet_progress *progress,
 		}
 		xnet_progress_rx(ep);
 	} else {
-		assert(sockctx->type == OFI_SOCKCTX_CANCEL);
+		assert(sockctx == &ep->bsock.cancel_sockctx);
 		/* Nothing to do */
 	}
 	return;

--- a/prov/tcp/src/xnet_progress.c
+++ b/prov/tcp/src/xnet_progress.c
@@ -1005,11 +1005,11 @@ static void xnet_uring_connect_done(struct xnet_ep *ep, int res)
 		goto disable;
 
 	ep->state = XNET_REQ_SENT;
-	ep->pollflags = POLLIN;
-	ret = xnet_monitor_sock(progress, ep->bsock.sock, ep->pollflags,
-				&ep->util_ep.ep_fid.fid);
-	if (ret)
+	ret = ofi_bsock_recv_unbuffered(&ep->bsock, ep->cm_msg,
+					sizeof(ep->cm_msg->hdr));
+	if (ret != -OFI_EINPROGRESS_URING)
 		goto disable;
+
 	xnet_signal_progress(progress);
 	return;
 
@@ -1048,6 +1048,12 @@ static void xnet_progress_cqe(struct xnet_progress *progress,
 		break;
 	case XNET_CONNECTING:
 		xnet_uring_connect_done(ep, cqe->res);
+		break;
+	case XNET_REQ_SENT:
+		if (sockctx == &ep->bsock.rx_sockctx)
+			xnet_uring_req_done(ep, cqe->res);
+		else
+			assert(sockctx == &ep->bsock.cancel_sockctx);
 		break;
 	default:
 		break;

--- a/prov/tcp/src/xnet_progress.c
+++ b/prov/tcp/src/xnet_progress.c
@@ -920,16 +920,76 @@ void xnet_progress_async(struct xnet_ep *ep)
 	}
 }
 
+static void xnet_uring_tx_done(struct xnet_ep *ep, int res)
+{
+	struct xnet_xfer_entry *tx_entry;
+
+	tx_entry = ep->cur_tx.entry;
+	assert(tx_entry);
+
+	if (res < 0) {
+		if (!OFI_SOCK_TRY_SND_RCV_AGAIN(-res))
+			xnet_complete_tx(ep, res);
+	} else {
+		assert(res <= ep->cur_tx.data_left);
+		ep->cur_tx.data_left -= res;
+		if (ep->cur_tx.data_left)
+			ofi_consume_iov(tx_entry->iov, &tx_entry->iov_cnt,
+					res);
+		else
+			xnet_complete_tx(ep, FI_SUCCESS);
+	}
+	xnet_progress_tx(ep);
+}
+
+static void xnet_uring_rx_done(struct xnet_ep *ep, int res)
+{
+	struct xnet_xfer_entry *rx_entry;
+	int ret;
+
+	if (ep->bsock.async_prefetch) {
+		if (res > 0)
+			ofi_bsock_prefetch_done(&ep->bsock, res);
+		else {
+			ep->bsock.async_prefetch = false;
+			goto disable_ep;
+		}
+	} else if (res <= 0 && !OFI_SOCK_TRY_SND_RCV_AGAIN(-res)) {
+		if (ep->cur_rx.entry)
+			xnet_complete_rx(ep, res);
+		else
+			goto disable_ep;
+	} else if (ep->cur_rx.hdr_done < ep->cur_rx.hdr_len) {
+		ep->cur_rx.hdr_done += res;
+		ret = xnet_progress_hdr(ep);
+		if (ret != 0 && !OFI_SOCK_TRY_SND_RCV_AGAIN(-ret))
+			goto disable_ep;
+	} else {
+		rx_entry = ep->cur_rx.entry;
+		assert(rx_entry);
+
+		assert(res <= ep->cur_rx.data_left);
+		ep->cur_rx.data_left -= res;
+		if (ep->cur_rx.data_left)
+			ofi_consume_iov(rx_entry->iov, &rx_entry->iov_cnt,
+					res);
+		else
+			xnet_complete_rx(ep, FI_SUCCESS);
+	}
+	xnet_progress_rx(ep);
+	return;
+
+disable_ep:
+	xnet_ep_disable(ep, 0, NULL, 0);
+}
+
 static void xnet_progress_cqe(struct xnet_progress *progress,
 			      struct xnet_uring *uring,
 			      ofi_io_uring_cqe_t *cqe)
 {
-	struct xnet_xfer_entry *tx_entry;
-	struct xnet_xfer_entry *rx_entry;
 	struct ofi_sockctx *sockctx;
 	struct fid *fid;
 	struct xnet_ep *ep;
-	int ret;
 
 	assert(xnet_io_uring);
 	sockctx = (struct ofi_sockctx *) cqe->user_data;
@@ -937,7 +997,6 @@ static void xnet_progress_cqe(struct xnet_progress *progress,
 
 	fid = sockctx->context;
 	assert(fid->fclass == FI_CLASS_EP);
-
 	ep = container_of(fid, struct xnet_ep, util_ep.ep_fid.fid);
 
 	assert(sockctx->uring_sqe_inuse);
@@ -945,61 +1004,13 @@ static void xnet_progress_cqe(struct xnet_progress *progress,
 	uring->sockapi->credits++;
 
 	if (sockctx == &ep->bsock.tx_sockctx) {
-		tx_entry = ep->cur_tx.entry;
-		assert(tx_entry);
-
-		if (cqe->res < 0) {
-			if (!OFI_SOCK_TRY_SND_RCV_AGAIN(-cqe->res))
-				xnet_complete_tx(ep, cqe->res);
-		} else {
-			assert(cqe->res <= ep->cur_tx.data_left);
-			ep->cur_tx.data_left -= cqe->res;
-			if (ep->cur_tx.data_left)
-				ofi_consume_iov(tx_entry->iov, &tx_entry->iov_cnt,
-						cqe->res);
-			else
-				xnet_complete_tx(ep, FI_SUCCESS);
-		}
-		xnet_progress_tx(ep);
+		xnet_uring_tx_done(ep, cqe->res);
 	} else if (sockctx == &ep->bsock.rx_sockctx) {
-		if (ep->bsock.async_prefetch) {
-			if (cqe->res > 0)
-				ofi_bsock_prefetch_done(&ep->bsock, cqe->res);
-			else {
-				ep->bsock.async_prefetch = false;
-				goto disable_ep;
-			}
-		} else if (cqe->res <= 0 && !OFI_SOCK_TRY_SND_RCV_AGAIN(-cqe->res)) {
-			if (ep->cur_rx.entry)
-				xnet_complete_rx(ep, cqe->res);
-			else
-				goto disable_ep;
-		} else if (ep->cur_rx.hdr_done < ep->cur_rx.hdr_len) {
-			ep->cur_rx.hdr_done += cqe->res;
-			ret = xnet_progress_hdr(ep);
-			if (ret != 0 && !OFI_SOCK_TRY_SND_RCV_AGAIN(-ret))
-				goto disable_ep;
-		} else {
-			rx_entry = ep->cur_rx.entry;
-			assert(rx_entry);
-
-			assert(cqe->res <= ep->cur_rx.data_left);
-			ep->cur_rx.data_left -= cqe->res;
-			if (ep->cur_rx.data_left)
-				ofi_consume_iov(rx_entry->iov, &rx_entry->iov_cnt,
-						cqe->res);
-			else
-				xnet_complete_rx(ep, FI_SUCCESS);
-		}
-		xnet_progress_rx(ep);
+		xnet_uring_rx_done(ep, cqe->res);
 	} else {
 		assert(sockctx == &ep->bsock.cancel_sockctx);
 		/* Nothing to do */
 	}
-	return;
-
-disable_ep:
-	xnet_ep_disable(ep, 0, NULL, 0);
 }
 
 static void xnet_progress_uring(struct xnet_progress *progress,


### PR DESCRIPTION
This PR revisits the existing code for io_uring and starts porting a few CM-related operations associated to the EP. 