### PR TITLE
contrib/intel/jenkins: Bugfixes to Jenkinsfile opt-out process

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -87,7 +87,7 @@ pipeline {
         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
           sh """
             mkdir ${env.WORKSPACE}/py_scripts
-            git clone ${env.UPSTREAM} ${env.WORKSPACE}/py_scripts
+            git clone --branch ${TARGET} ${env.UPSTREAM} ${env.WORKSPACE}/py_scripts
             ${env.SKIP_PATH}/skip.sh ${env.WORKSPACE} ${TARGET}
             ${env.SKIP_PATH}/release.sh ${env.WORKSPACE} ${TARGET}
           """

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -9,7 +9,12 @@ def check_target() {
   if (changeRequest()) {
     TARGET = env.CHANGE_TARGET
   }
-  return TARGET
+
+  if (TARGET) {
+    return TARGET
+  }
+
+  return "main"
 }
 
 def release() {


### PR DESCRIPTION
Add --branch option to the upstream git clone step to correctly clone the target branch
Make it impossible for check_target to return null