### PR TITLE
prov/efa and fabtests/efa: Use shm provider's FI_AV_USER_ID support and add test 

### DIFF
--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -172,6 +172,7 @@ nobase_dist_config_DATA = \
 	pytest/efa/test_runt.py \
 	pytest/efa/test_fork_support.py \
 	pytest/efa/test_mr.py \
+	pytest/efa/test_efa_shm_addr.py \
 	pytest/shm/conftest.py \
 	pytest/shm/shm_common.py \
 	pytest/shm/test_av.py \

--- a/fabtests/pytest/default/test_multinode.py
+++ b/fabtests/pytest/default/test_multinode.py
@@ -1,17 +1,26 @@
 import pytest
+from common import MultinodeTest
+
 
 @pytest.mark.multinode
 @pytest.mark.parametrize("C", ["msg", "rma"])
 def test_multinode(cmdline_args, C):
-    from common import MultinodeTest
-    command = "fi_multinode -C " + C
+
     numproc = 3
-    test = MultinodeTest(cmdline_args, command, 3)
+    client_hostname_list = [cmdline_args.client_id, ] * (numproc - 1)
+    client_base_command = "fi_multinode -C " + C + f" -n {numproc}"
+    server_base_command = client_base_command
+    test = MultinodeTest(cmdline_args, server_base_command, client_base_command,
+                         client_hostname_list, run_client_asynchronously=True)
     test.run()
 
 @pytest.mark.multinode
 def test_multinode_coll(cmdline_args):
-    from common import MultinodeTest
+
     numproc = 3
-    test = MultinodeTest(cmdline_args, "fi_multinode_coll", 3)
+    client_hostname_list = [cmdline_args.client_id, ] * (numproc - 1)
+    client_base_command = "fi_multinode_coll"
+    server_base_command = client_base_command
+    test = MultinodeTest(cmdline_args, server_base_command, client_base_command,
+                         client_hostname_list, run_client_asynchronously=True)
     test.run()

--- a/fabtests/pytest/efa/test_efa_shm_addr.py
+++ b/fabtests/pytest/efa/test_efa_shm_addr.py
@@ -1,0 +1,20 @@
+from common import MultinodeTest
+import pytest
+
+
+@pytest.mark.multinode
+def test_efa_shm_addr(cmdline_args):
+    server_id = cmdline_args.server_id
+    client_id = cmdline_args.client_id
+    if client_id == server_id:
+        pytest.skip("This test requires two nodes")
+    # First start a client on remote host, then start
+    # a client on local host, so the shm fi_addr
+    # inserted for the 2nd client could be different
+    # from its efa fi_addr.
+    client_hostname_list = [client_id, server_id]
+    client_base_command = "fi_rdm"
+    server_base_command = client_base_command + " -C {}".format(len(client_hostname_list))
+    test = MultinodeTest(cmdline_args, server_base_command, client_base_command,
+                         client_hostname_list, run_client_asynchronously=False)
+    test.run()

--- a/prov/efa/src/efa_av.h
+++ b/prov/efa/src/efa_av.h
@@ -88,7 +88,6 @@ struct efa_prv_reverse_av {
 
 struct efa_av {
 	struct fid_av *shm_rdm_av;
-	fi_addr_t shm_rdm_addr_map[EFA_SHM_MAX_AV_COUNT];
 	struct efa_domain *domain;
 	struct efa_base_ep *base_ep;
 	size_t used;

--- a/prov/efa/src/rdm/rxr_ep.c
+++ b/prov/efa/src/rdm/rxr_ep.c
@@ -1721,12 +1721,10 @@ static inline void rdm_ep_poll_shm_cq(struct rxr_ep *ep,
 	struct rxr_pkt_entry *pkt_entry;
 	fi_addr_t src_addr;
 	ssize_t ret;
-	struct efa_av *efa_av;
 	int i;
 
 	VALGRIND_MAKE_MEM_DEFINED(&cq_entry, sizeof(struct fi_cq_data_entry));
 
-	efa_av = ep->base_ep.av;
 	for (i = 0; i < cqe_to_process; i++) {
 		ret = fi_cq_readfrom(ep->shm_cq, &cq_entry, 1, &src_addr);
 
@@ -1757,11 +1755,6 @@ static inline void rdm_ep_poll_shm_cq(struct rxr_ep *ep,
 			return;
 
 		pkt_entry = cq_entry.op_context;
-		if (src_addr != FI_ADDR_UNSPEC) {
-			/* convert SHM address to EFA address */
-			assert(src_addr < EFA_SHM_MAX_AV_COUNT);
-			src_addr = efa_av->shm_rdm_addr_map[src_addr];
-		}
 
 		if (cq_entry.flags & (FI_ATOMIC | FI_REMOTE_CQ_DATA)) {
 			rxr_ep_handle_misc_shm_completion(ep, &cq_entry, src_addr);


### PR DESCRIPTION
This PR makes efa provider use shm provider's FI_AV_USER_ID support so the efa/shm address conversion is not needed in the cq read.

Also add efa specific fabtests item `test_efa_shm_addr` that validate the fi_addr_t returned by efa provider's `fi_cq_readfrom` is correct in the scenario where a non-shm peer is inserted first, and a shm peer is inserted later so
the efa fi_addr and shm fi_addr could differ.
