### PR TITLE
core/fi_peer: Move peer provider defines into new header

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -230,8 +230,9 @@ rdmainclude_HEADERS += \
 	$(top_srcdir)/include/rdma/fi_tagged.h \
 	$(top_srcdir)/include/rdma/fi_trigger.h
 providersinclude_HEADERS += \
-	$(top_srcdir)/include/rdma/providers/fi_prov.h \
-	$(top_srcdir)/include/rdma/providers/fi_log.h
+	$(top_srcdir)/include/rdma/providers/fi_log.h \
+	$(top_srcdir)/include/rdma/providers/fi_peer.h \
+	$(top_srcdir)/include/rdma/providers/fi_prov.h
 
 if HAVE_DIRECT
 nodist_rdmainclude_HEADERS = \

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -53,6 +53,7 @@
 #include <rdma/fi_rma.h>
 #include <rdma/fi_tagged.h>
 #include <rdma/fi_trigger.h>
+#include <rdma/providers/fi_peer.h>
 
 #include <ofi.h>
 #include <ofi_mr.h>

--- a/include/rdma/fi_ext.h
+++ b/include/rdma/fi_ext.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Intel Corporation. All rights reserved.
+ * Copyright (c) 2021-2023 Intel Corporation. All rights reserved.
  * Copyright (c) 2021 Amazon.com, Inc. or its affiliates. All rights reserved.
  * Copyright (c) 2022 DataDirect Networks, Inc. All rights reserved.
  *
@@ -130,167 +130,6 @@ struct fid_mem_monitor {
 
 
 /*
- * Peer provider AV support.
- */
-struct fid_peer_av;
-
-struct fi_ops_av_owner {
-	size_t	size;
-	int	(*query)(struct fid_peer_av *av, struct fi_av_attr *attr);
-	fi_addr_t (*ep_addr)(struct fid_peer_av *av, struct fid_ep *ep);
-};
-
-struct fid_peer_av {
-	struct fid fid;
-	struct fi_ops_av_owner *owner_ops;
-};
-
-struct fi_peer_av_context {
-	size_t size;
-	struct fid_peer_av *av;
-};
-
-
-/*
- * Peer provider AV set support.
- */
-struct fid_peer_av_set;
-
-struct fi_ops_av_set_owner {
-	size_t	size;
-	int	(*members)(struct fid_peer_av_set *av, fi_addr_t *addr,
-			   size_t *count);
-};
-
-struct fid_peer_av_set {
-	struct fid fid;
-	struct fi_ops_av_set_owner *owner_ops;
-};
-
-struct fi_peer_av_set_context {
-	size_t size;
-	struct fi_peer_av_set *av_set;
-};
-
-
-/*
- * Peer provider CQ support.
- */
-struct fid_peer_cq;
-
-struct fi_ops_cq_owner {
-	size_t	size;
-	ssize_t (*write)(struct fid_peer_cq *cq, void *context, uint64_t flags,
-			size_t len, void *buf, uint64_t data, uint64_t tag,
-			fi_addr_t src);
-	ssize_t	(*writeerr)(struct fid_peer_cq *cq,
-			const struct fi_cq_err_entry *err_entry);
-};
-
-struct fid_peer_cq {
-	struct fid fid;
-	struct fi_ops_cq_owner *owner_ops;
-};
-
-struct fi_peer_cq_context {
-	size_t size;
-	struct fid_peer_cq *cq;
-};
-
-
-/*
- * Peer provider domain support.
- */
-struct fi_peer_domain_context {
-	size_t size;
-	struct fid_domain *domain;
-};
-
-
-/*
- * Peer provider EQ support.
- */
-struct fi_peer_eq_context {
-	size_t size;
-	struct fid_eq *eq;
-};
-
-
-/*
- * Peer shared rx context
- */
-struct fid_peer_srx;
-
-/* Castable to dlist_entry */
-struct fi_peer_rx_entry {
-	struct fi_peer_rx_entry *next;
-	struct fi_peer_rx_entry *prev;
-	struct fid_peer_srx *srx;
-	fi_addr_t addr;
-	size_t size;
-	uint64_t tag;
-	uint64_t flags;
-	void *context;
-	size_t count;
-	void **desc;
-	void *peer_context;
-	void *owner_context;
-	struct iovec *iov;
-};
-
-struct fi_ops_srx_owner {
-	size_t	size;
-	int	(*get_msg)(struct fid_peer_srx *srx, fi_addr_t addr,
-			size_t size, struct fi_peer_rx_entry **entry);
-	int	(*get_tag)(struct fid_peer_srx *srx, fi_addr_t addr,
-			uint64_t tag, struct fi_peer_rx_entry **entry);
-	int	(*queue_msg)(struct fi_peer_rx_entry *entry);
-	int	(*queue_tag)(struct fi_peer_rx_entry *entry);
-
-	void	(*free_entry)(struct fi_peer_rx_entry *entry);
-};
-
-struct fi_ops_srx_peer {
-	size_t	size;
-	int	(*start_msg)(struct fi_peer_rx_entry *entry);
-	int	(*start_tag)(struct fi_peer_rx_entry *entry);
-	int	(*discard_msg)(struct fi_peer_rx_entry *entry);
-	int	(*discard_tag)(struct fi_peer_rx_entry *entry);
-};
-
-struct fid_peer_srx {
-	struct fid_ep ep_fid;
-	struct fi_ops_srx_owner *owner_ops;
-	struct fi_ops_srx_peer *peer_ops;
-};
-
-struct fi_peer_srx_context {
-	size_t size;
-	struct fid_peer_srx *srx;
-};
-
-
-/*
- * Peer transfers
- */
-struct fi_peer_transfer_context;
-
-struct fi_ops_transfer_peer {
-	size_t size;
-	ssize_t	(*complete)(struct fid_ep *ep, struct fi_cq_tagged_entry *buf,
-			    fi_addr_t src_addr);
-	ssize_t	(*comperr)(struct fid_ep *ep, struct fi_cq_err_entry *buf);
-};
-
-struct fi_peer_transfer_context {
-	size_t size;
-	struct fi_info *info;
-	struct fid_ep *ep;
-	struct fi_ops_transfer_peer *peer_ops;
-};
-
-
-/*
  * System logging import extension:
  * To use, open logging fid and import.
  */
@@ -335,7 +174,8 @@ static inline int fi_import_log(uint32_t version, uint64_t flags,
 	log_fid->fid.fclass = FI_CLASS_LOG;
 	log_fid->ops->size = sizeof(struct fi_ops_log);
 
-	return fi_import(version, "logging", NULL, 0, flags, &log_fid->fid, log_fid);
+	return fi_import(version, "logging", NULL, 0, flags, &log_fid->fid,
+			 log_fid);
 }
 
 #ifdef __cplusplus

--- a/include/rdma/providers/fi_peer.h
+++ b/include/rdma/providers/fi_peer.h
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2021-2023 Intel Corporation. All rights reserved.
+ * Copyright (c) 2021 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright (c) 2022 DataDirect Networks, Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef FI_PEER_H
+#define FI_PEER_H
+
+#include <stdbool.h>
+#include <rdma/fabric.h>
+#include <rdma/fi_eq.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/providers/fi_prov.h>
+#include <rdma/providers/fi_log.h>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Peer provider AV support.
+ */
+struct fid_peer_av;
+
+struct fi_ops_av_owner {
+	size_t	size;
+	int	(*query)(struct fid_peer_av *av, struct fi_av_attr *attr);
+	fi_addr_t (*ep_addr)(struct fid_peer_av *av, struct fid_ep *ep);
+};
+
+struct fid_peer_av {
+	struct fid fid;
+	struct fi_ops_av_owner *owner_ops;
+};
+
+struct fi_peer_av_context {
+	size_t size;
+	struct fid_peer_av *av;
+};
+
+
+/*
+ * Peer provider AV set support.
+ */
+struct fid_peer_av_set;
+
+struct fi_ops_av_set_owner {
+	size_t	size;
+	int	(*members)(struct fid_peer_av_set *av, fi_addr_t *addr,
+			   size_t *count);
+};
+
+struct fid_peer_av_set {
+	struct fid fid;
+	struct fi_ops_av_set_owner *owner_ops;
+};
+
+struct fi_peer_av_set_context {
+	size_t size;
+	struct fi_peer_av_set *av_set;
+};
+
+
+/*
+ * Peer provider CQ support.
+ */
+struct fid_peer_cq;
+
+struct fi_ops_cq_owner {
+	size_t	size;
+	ssize_t (*write)(struct fid_peer_cq *cq, void *context, uint64_t flags,
+			size_t len, void *buf, uint64_t data, uint64_t tag,
+			fi_addr_t src);
+	ssize_t	(*writeerr)(struct fid_peer_cq *cq,
+			const struct fi_cq_err_entry *err_entry);
+};
+
+struct fid_peer_cq {
+	struct fid fid;
+	struct fi_ops_cq_owner *owner_ops;
+};
+
+struct fi_peer_cq_context {
+	size_t size;
+	struct fid_peer_cq *cq;
+};
+
+
+/*
+ * Peer provider domain support.
+ */
+struct fi_peer_domain_context {
+	size_t size;
+	struct fid_domain *domain;
+};
+
+
+/*
+ * Peer provider EQ support.
+ */
+struct fi_peer_eq_context {
+	size_t size;
+	struct fid_eq *eq;
+};
+
+
+/*
+ * Peer shared rx context
+ */
+struct fid_peer_srx;
+
+/* Castable to dlist_entry */
+struct fi_peer_rx_entry {
+	struct fi_peer_rx_entry *next;
+	struct fi_peer_rx_entry *prev;
+	struct fid_peer_srx *srx;
+	fi_addr_t addr;
+	size_t size;
+	uint64_t tag;
+	uint64_t flags;
+	void *context;
+	size_t count;
+	void **desc;
+	void *peer_context;
+	void *owner_context;
+	struct iovec *iov;
+};
+
+struct fi_ops_srx_owner {
+	size_t	size;
+	int	(*get_msg)(struct fid_peer_srx *srx, fi_addr_t addr,
+			size_t size, struct fi_peer_rx_entry **entry);
+	int	(*get_tag)(struct fid_peer_srx *srx, fi_addr_t addr,
+			uint64_t tag, struct fi_peer_rx_entry **entry);
+	int	(*queue_msg)(struct fi_peer_rx_entry *entry);
+	int	(*queue_tag)(struct fi_peer_rx_entry *entry);
+
+	void	(*free_entry)(struct fi_peer_rx_entry *entry);
+};
+
+struct fi_ops_srx_peer {
+	size_t	size;
+	int	(*start_msg)(struct fi_peer_rx_entry *entry);
+	int	(*start_tag)(struct fi_peer_rx_entry *entry);
+	int	(*discard_msg)(struct fi_peer_rx_entry *entry);
+	int	(*discard_tag)(struct fi_peer_rx_entry *entry);
+};
+
+struct fid_peer_srx {
+	struct fid_ep ep_fid;
+	struct fi_ops_srx_owner *owner_ops;
+	struct fi_ops_srx_peer *peer_ops;
+};
+
+struct fi_peer_srx_context {
+	size_t size;
+	struct fid_peer_srx *srx;
+};
+
+
+/*
+ * Peer transfers
+ */
+struct fi_peer_transfer_context;
+
+struct fi_ops_transfer_peer {
+	size_t size;
+	ssize_t	(*complete)(struct fid_ep *ep, struct fi_cq_tagged_entry *buf,
+			    fi_addr_t src_addr);
+	ssize_t	(*comperr)(struct fid_ep *ep, struct fi_cq_err_entry *buf);
+};
+
+struct fi_peer_transfer_context {
+	size_t size;
+	struct fi_info *info;
+	struct fid_ep *ep;
+	struct fi_ops_transfer_peer *peer_ops;
+};
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FI_PEER_H */

--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -941,6 +941,7 @@
     <ClInclude Include="include\rdma\fi_trigger.h" />
     <ClInclude Include="include\rdma\fi_collective.h" />
     <ClInclude Include="include\rdma\providers\fi_log.h" />
+    <ClInclude Include="include\rdma\providers\fi_peer.h" />
     <ClInclude Include="include\rdma\providers\fi_prov.h" />
     <ClInclude Include="include\uthash.h" />
     <ClInclude Include="include\windows\arpa\inet.h" />

--- a/libfabric.vcxproj.filters
+++ b/libfabric.vcxproj.filters
@@ -809,6 +809,9 @@
     <ClInclude Include="include\rdma\providers\fi_log.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\rdma\providers\fi_peer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="include\rdma\providers\fi_prov.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/man/fi_peer.3.md
+++ b/man/fi_peer.3.md
@@ -27,6 +27,7 @@ struct fid_peer_srx
 ```c
 #include <rdma/fabric.h>
 #include <rdma/fi_ext.h>
+#include <rdma/providers/fi_peer.h>
 
 int fi_export_fid(struct fid *fid, uint64_t flags,
     struct fid **expfid, void *context);

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -51,7 +51,7 @@
 #include <rdma/fi_tagged.h>
 #include <rdma/fi_trigger.h>
 #include <rdma/providers/fi_prov.h>
-#include <rdma/fi_ext.h>
+#include <rdma/providers/fi_peer.h>
 
 #include <ofi.h>
 #include <ofi_enosys.h>

--- a/prov/sm2/src/sm2.h
+++ b/prov/sm2/src/sm2.h
@@ -53,7 +53,7 @@
 #include <rdma/fi_tagged.h>
 #include <rdma/fi_trigger.h>
 #include <rdma/providers/fi_prov.h>
-#include <rdma/fi_ext.h>
+#include <rdma/providers/fi_peer.h>
 
 #include <ofi.h>
 #include <ofi_enosys.h>

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -50,7 +50,7 @@
 #include "ofi_prov.h"
 #include "ofi_perf.h"
 #include "ofi_hmem.h"
-#include "rdma/fi_ext.h"
+#include <rdma/fi_ext.h>
 
 #ifdef HAVE_LIBDL
 #include <dlfcn.h>


### PR DESCRIPTION
The peer provider APIs target provider implementations, not applications.  Move the definitions out of fi_ext.h, which is used by apps, and into include/rdma/providers/fi_peer.h.  This better indicates that the APIs are intended for providers, not applications.