### PR TITLE
prov/efa: pin gdr buffer when gdrcopy is available

### DIFF
--- a/prov/efa/src/rdm/rxr_pkt_type_base.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_base.c
@@ -398,7 +398,6 @@ int rxr_pkt_copy_data_to_cuda(struct rxr_ep *ep,
 	} else {
 		/**
 		 * When CUDA API is available, EFA provider will not use gdrcopy even if gdrcopy is enabled.
-		 * see #efa_mr_use_gdrcopy
 		 */
 		gdrcopy_available = cuda_is_gdrcopy_enabled();
 	}


### PR DESCRIPTION
gdrcopy is found to provide faster memory copy for small data sizes. This change allows gdr memory pinning when gdrcopy is enabled, regardless of FI_HMEM_CUDA_ENABLE_XFER flag.