### PR TITLE
prov/shm: Store IPC availability in smr_domain

### DIFF
--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -190,6 +190,7 @@ struct smr_domain {
 	/* cache for use with hmem ipc */
 	struct ofi_mr_cache	*ipc_cache;
 	struct fid_peer_srx	*srx;
+	bool			hmem_is_ipc_enabled[OFI_HMEM_MAX];
 };
 
 #define SMR_PREFIX	"fi_shm://"

--- a/prov/shm/src/smr_domain.c
+++ b/prov/shm/src/smr_domain.c
@@ -117,6 +117,13 @@ int smr_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		return ret;
 	}
 
+	/* Store is_ipc_enabled values of ofi_hmem_ops structure
+	 * in an array in smr_domain. These values will be used
+	 * later when messages are sent, like in smr_generic_sendmsg()
+	 * and smr_generic_rma() */
+	for (int i = 0; i < OFI_HMEM_MAX; i++)
+		smr_domain->hmem_is_ipc_enabled[i] = ofi_hmem_is_ipc_enabled(i);
+
 	*domain = &smr_domain->util_domain.domain_fid;
 	(*domain)->fid.ops = &smr_domain_fi_ops;
 	(*domain)->ops = &smr_domain_ops;

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -172,9 +172,9 @@ static ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 	 * transfer may occur if possible. */
 	if (iov_count == 1 && desc && desc[0]) {
 		smr_desc = (struct ofi_mr *) *desc;
-		use_ipc = ofi_hmem_is_ipc_enabled(((struct ofi_mr *) *desc)->iface) &&
-				smr_desc->flags & FI_HMEM_DEVICE_ONLY &&
-				!(op_flags & FI_INJECT);
+		use_ipc = domain->hmem_is_ipc_enabled[((struct ofi_mr *) *desc)->iface] &&
+			  smr_desc->flags & FI_HMEM_DEVICE_ONLY &&
+			  !(op_flags & FI_INJECT);
 	}
 	proto = smr_select_proto(use_ipc, smr_cma_enabled(ep, peer_smr), op,
 				 total_len, op_flags);


### PR DESCRIPTION
This patch serves as a prerequisite to an upcoming patch. The logic of the function cuda_is_ipc_enabled() will be changed to fetch the value of an environment variable. With that change the calls to ofi_hmem_is_ipc_enabled() in smr_generic_rma() and smr_generic_sendmsg() will be costly.

This patch eliminates this problem by storing the values IPC availbility in smr_ep structure.