### PR TITLE
prov/efa: Make shm_info created on the fly during domain open 

### DIFF
--- a/prov/efa/src/efa_domain.h
+++ b/prov/efa/src/efa_domain.h
@@ -41,6 +41,7 @@
 
 struct efa_domain {
 	struct util_domain	util_domain;
+	struct fi_info		*shm_info;
 	struct fid_domain	*shm_domain;
 	struct efa_device	*device;
 	struct ibv_pd		*ibv_pd;

--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -120,7 +120,7 @@ int efa_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric_fid,
 {
 	const struct fi_info *info;
 	struct efa_fabric *efa_fabric;
-	int ret = 0, retv;
+	int ret = 0;
 
 	efa_fabric = calloc(1, sizeof(*efa_fabric));
 	if (!efa_fabric)
@@ -135,17 +135,6 @@ int efa_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric_fid,
 
 	if (ret)
 		goto err_free_fabric;
-
-	/* Open shm provider's fabric domain */
-	if (g_shm_info) {
-		assert(!strcmp(g_shm_info->fabric_attr->name, "shm"));
-		ret = fi_fabric(g_shm_info->fabric_attr,
-				&efa_fabric->shm_fabric, context);
-		if (ret)
-			goto err_close_util_fabric;
-	} else {
-		efa_fabric->shm_fabric = NULL;
-	}
 
 #ifdef EFA_PERF_ENABLED
 	ret = ofi_perfset_create(&efa_prov, &efa_fabric->perf_set,
@@ -167,12 +156,6 @@ int efa_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric_fid,
 
 	return 0;
 
-err_close_util_fabric:
-	retv = ofi_fabric_close(&efa_fabric->util_fabric);
-	if (retv)
-		EFA_WARN(FI_LOG_FABRIC,
-			"Unable to close fabric: %s\n",
-			fi_strerror(-retv));
 err_free_fabric:
 	free(efa_fabric);
 

--- a/prov/efa/src/efa_prov.c
+++ b/prov/efa/src/efa_prov.c
@@ -203,8 +203,6 @@ static void efa_prov_finalize(void)
 {
 	efa_util_prov_finalize();
 
-	efa_shm_info_finalize();
-
 	efa_device_list_finalize();
 
 	efa_win_lib_finalize();

--- a/prov/efa/src/efa_shm.h
+++ b/prov/efa/src/efa_shm.h
@@ -34,15 +34,11 @@
 
 #include <rdma/fabric.h>
 
-extern struct fi_info *g_shm_info;
-
 struct efa_ep_addr;
 
 int efa_shm_ep_name_construct(char *smr_name, size_t *smr_name_len, struct efa_ep_addr *raw_addr);
 
-void efa_shm_info_initialize(const struct fi_info *app_hints);
-
-void efa_shm_info_finalize();
+void efa_shm_info_create(const struct fi_info *app_info, struct fi_info **shm_info);
 
 /** maximum name length for shm endpoint */
 #define EFA_SHM_NAME_MAX	   (256)

--- a/prov/efa/src/rdm/rxr_ep.c
+++ b/prov/efa/src/rdm/rxr_ep.c
@@ -1215,8 +1215,8 @@ int rxr_ep_init(struct rxr_ep *ep)
 		ret = rxr_pkt_pool_create(
 			ep,
 			RXR_PKT_FROM_SHM_TX_POOL,
-			g_shm_info->tx_attr->size,
-			g_shm_info->tx_attr->size, /* max count */
+			rxr_ep_domain(ep)->shm_info->tx_attr->size,
+			rxr_ep_domain(ep)->shm_info->tx_attr->size, /* max count */
 			&ep->shm_tx_pkt_pool);
 		if (ret)
 			goto err_free;
@@ -1226,8 +1226,8 @@ int rxr_ep_init(struct rxr_ep *ep)
 		ret = rxr_pkt_pool_create(
 			ep,
 			RXR_PKT_FROM_SHM_RX_POOL,
-			g_shm_info->tx_attr->size,
-			g_shm_info->tx_attr->size, /* max count */
+			rxr_ep_domain(ep)->shm_info->tx_attr->size,
+			rxr_ep_domain(ep)->shm_info->tx_attr->size, /* max count */
 			&ep->shm_rx_pkt_pool);
 		if (ret)
 			goto err_free;
@@ -1483,7 +1483,7 @@ void rxr_ep_progress_post_internal_rx_pkts(struct rxr_ep *ep)
 
 			if (ep->shm_ep) {
 				assert(ep->shm_rx_pkts_posted == 0 && ep->shm_rx_pkts_to_post == 0);
-				ep->shm_rx_pkts_to_post = g_shm_info->rx_attr->size;
+				ep->shm_rx_pkts_to_post = rxr_ep_domain(ep)->shm_info->rx_attr->size;
 			}
 		}
 	}
@@ -2190,8 +2190,8 @@ int rxr_endpoint(struct fid_domain *domain, struct fi_info *info,
 		goto err_free_ep;
 
 	if (efa_domain->shm_domain) {
-		assert(!strcmp(g_shm_info->fabric_attr->name, "shm"));
-		ret = fi_endpoint(efa_domain->shm_domain, g_shm_info,
+		assert(!strcmp(efa_domain->shm_info->fabric_attr->name, "shm"));
+		ret = fi_endpoint(efa_domain->shm_domain, efa_domain->shm_info,
 				  &rxr_ep->shm_ep, rxr_ep);
 		if (ret)
 			goto err_destroy_base_ep;

--- a/prov/efa/src/rdm/rxr_read.c
+++ b/prov/efa/src/rdm/rxr_read.c
@@ -276,7 +276,7 @@ struct rxr_read_entry *rxr_read_alloc_entry(struct rxr_ep *ep, struct rxr_op_ent
 	if (lower_ep_type == SHM_EP) {
 		assert(lower_ep_type == SHM_EP);
 		/* FI_MR_VIRT_ADDR is not being set, use 0-based offset instead. */
-		if (!(g_shm_info->domain_attr->mr_mode & FI_MR_VIRT_ADDR)) {
+		if (!(rxr_ep_domain(ep)->shm_info->domain_attr->mr_mode & FI_MR_VIRT_ADDR)) {
 			for (i = 0; i < read_entry->rma_iov_count; ++i)
 				read_entry->rma_iov[i].addr = 0;
 		}

--- a/prov/efa/src/rdm/rxr_rma.c
+++ b/prov/efa/src/rdm/rxr_rma.c
@@ -128,7 +128,7 @@ size_t rxr_rma_post_shm_write(struct rxr_ep *rxr_ep, struct rxr_op_entry *tx_ent
 	rma_context_pkt->seg_size = tx_entry->bytes_write_total_len;
 
 	/* If no FI_MR_VIRT_ADDR being set, have to use 0-based offset */
-	if (!(g_shm_info->domain_attr->mr_mode & FI_MR_VIRT_ADDR)) {
+	if (!(rxr_ep_domain(rxr_ep)->shm_info->domain_attr->mr_mode & FI_MR_VIRT_ADDR)) {
 		for (i = 0; i < tx_entry->iov_count; i++)
 			tx_entry->rma_iov[i].addr = 0;
 	}

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -76,6 +76,7 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_rdm_fallback_to_ibv_create_cq_ex_cq_read_ignore_forgotton_peer, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_info_open_ep_with_wrong_info, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_info_open_ep_with_api_1_1_info, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_info_check_shm_info, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_hmem_info_update_neuron, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 	};
 

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -73,6 +73,7 @@ void test_rdm_fallback_to_ibv_create_cq_ex_cq_read_ignore_forgotton_peer();
 void test_ibv_cq_ex_read_ignore_removed_peer();
 void test_info_open_ep_with_wrong_info();
 void test_info_open_ep_with_api_1_1_info();
+void test_info_check_shm_info();
 void test_efa_hmem_info_update_neuron();
 
 #endif


### PR DESCRIPTION
Currently, shm info is initialized as a global variable `g_shm_info` once. When applications call `fi_getinfo()` multiple times, `g_shm_info` is only created by the first `fi_getinfo()` and won't be changed by subsequent `fi_getinfo()` calls.
    
This PR addresses this issue by making shm_info created on the fly during efa domain open, based on application info created earlier. A unit test is added to validate the change.