### PR TITLE
include/rdma: New options to fi_getopts for EFA

### DIFF
--- a/include/rdma/fi_ext.h
+++ b/include/rdma/fi_ext.h
@@ -70,6 +70,9 @@ extern "C" {
 /* negative options are provider specific */
 enum {
        FI_OPT_EFA_RNR_RETRY = -FI_PROV_SPECIFIC_EFA,
+       FI_OPT_EFA_EMULATED_READ,       /* bool */
+       FI_OPT_EFA_EMULATED_WRITE,      /* bool */
+       FI_OPT_EFA_EMULATED_ATOMICS,    /* bool */
 };
 
 struct fi_fid_export {

--- a/man/fi_efa.7.md
+++ b/man/fi_efa.7.md
@@ -97,6 +97,12 @@ provider for AWS Neuron or Habana SynapseAI.
   the endpoint is enabled. Otherwise, the call will fail. Also note that this
   option only applies to RDM endpoint.
 
+*FI_OPT_EFA_EMULATED_READ, FI_OPT_EFA_EMULATED_WRITE, FI_OPT_EFA_EMULATED_ATOMICS - bool*
+: These options only apply to the fi_getopt() call.
+  They are used to query the EFA provider to determine if the endpoint is
+  emulating Read, Write, and Atomic operations (return value is true), or if
+  these operations are assisted by hardware support (return value is false).
+
 # RUNTIME PARAMETERS
 
 *FI_EFA_TX_SIZE*

--- a/prov/efa/src/rdm/rxr_ep.c
+++ b/prov/efa/src/rdm/rxr_ep.c
@@ -976,6 +976,15 @@ static int rxr_ep_getopt(fid_t fid, int level, int optname, void *optval,
 		*(int *)optval = rxr_ep->hmem_p2p_opt;
 		*optlen = sizeof(int);
 		break;
+	case FI_OPT_EFA_EMULATED_READ:
+		*(bool *)optval = !efa_domain_support_rdma_read(rxr_ep_domain(rxr_ep));
+		break;
+	case FI_OPT_EFA_EMULATED_WRITE:
+		*(bool *)optval = !efa_domain_support_rdma_write(rxr_ep_domain(rxr_ep));
+		break;
+	case FI_OPT_EFA_EMULATED_ATOMICS:
+		*(bool *)optval = true;
+		break;
 	default:
 		EFA_WARN(FI_LOG_EP_CTRL,
 			"Unknown endpoint option %s\n", __func__);


### PR DESCRIPTION
 * Added three new options for fi_getopts in fi_ext.h: FI_OPT_EFA_EMULATED_READ FI_OPT_EFA_EMULATED_WRITE FI_OPT_EFA_EMULATED_ATOMICS

 * Added documentation in fi_efa.7.md These options can be used by libfabric users to query if an EFA endpoint is using emulation or has hardware support for the Read, Write, and Atomics operations.