### PR TITLE
prov/ucx: Suppress UCX request leak warning by default

### DIFF
--- a/man/fi_ucx.7.md
+++ b/man/fi_ucx.7.md
@@ -53,6 +53,9 @@ Threading
 : IPv4 network interface for UCX provider's name server
   (default: any).
 
+*FI_UCX_CHECK_REQ_LEAK*
+: Check request leak (default: disabled).
+
 # SEE ALSO
 
 [`fabric`(7)](fabric.7.html),

--- a/prov/ucx/configure.m4
+++ b/prov/ucx/configure.m4
@@ -19,7 +19,11 @@ AC_DEFUN([FI_UCX_CONFIGURE],[
                     [$ucx_PREFIX],
                     [$ucx_LIBDIR],
                     [ucx_happy=1],
-                    [ucx_happy=0])
+                    [ucx_happy=0]),
+	       AC_CHECK_DECLS([UCP_WORKER_FLAG_IGNORE_REQUEST_LEAK],
+		    [],
+		    [],
+		    [#include <ucp/api/ucp.h>])
          ])
     AS_IF([test $ucx_happy -eq 1], [$1], [$2])
 ])

--- a/prov/ucx/src/ucx.h
+++ b/prov/ucx/src/ucx.h
@@ -106,6 +106,7 @@ struct ucx_global_descriptor{
 	char *localhost;
 	int ep_flush;
 	int enable_spawn;
+	int check_req_leak;
 };
 
 struct ucx_fabric {

--- a/prov/ucx/src/ucx_ep.c
+++ b/prov/ucx/src/ucx_ep.c
@@ -256,6 +256,13 @@ int ucx_ep_open(struct fid_domain *domain, struct fi_info *info,
 	if (ofi_status)
 		goto free_ep;
 
+#if HAVE_DECL_UCP_WORKER_FLAG_IGNORE_REQUEST_LEAK
+	if (!ucx_descriptor.check_req_leak) {
+		worker_params.field_mask |= UCP_WORKER_PARAM_FIELD_FLAGS;
+		worker_params.flags |= UCP_WORKER_FLAG_IGNORE_REQUEST_LEAK;
+	}
+#endif
+
 	status = ucp_worker_create(u_domain->context, &worker_params,
 				   &(ep->worker));
 	if (status != UCS_OK) {

--- a/prov/ucx/src/ucx_init.c
+++ b/prov/ucx/src/ucx_init.c
@@ -41,6 +41,7 @@ struct ucx_global_descriptor ucx_descriptor = {
 	.ns_port = FI_UCX_DEFAULT_NS_PORT,
 	.localhost = NULL,
 	.ep_flush = 0,
+	.check_req_leak = 0,
 };
 
 /*
@@ -291,6 +292,10 @@ static int ucx_getinfo(uint32_t version, const char *node,
 	if (status != FI_SUCCESS)
 		ucx_descriptor.ep_flush = 0;
 
+	status = fi_param_get(&ucx_prov, "check_req_leak", &ucx_descriptor.check_req_leak);
+	if (status != FI_SUCCESS)
+		ucx_descriptor.check_req_leak = 0;
+
 	status = ucp_config_read(NULL, configfile_name, &ucx_descriptor.config);
 	if (status != UCS_OK)
 		FI_WARN(&ucx_prov, FI_LOG_CORE,
@@ -427,6 +432,10 @@ UCX_INI
 	fi_param_define(&ucx_prov,
 			"devices", FI_PARAM_STRING,
 			"Specifies devices available for UCX provider (Default: auto)");
+
+	fi_param_define(&ucx_prov,
+			"check_req_leak", FI_PARAM_BOOL,
+			"Check request leak (Default: false)");
 
 	return &ucx_prov;
 }


### PR DESCRIPTION
It's common for applications to keep a pool of preposted receives that won't be all consumed. When the related worker is destroyed, UCX would give a warning message like this for each outstanding request:

mpool.c:55 UCX WARN object xxx {...} was not returned to mpool ucp_requests

Turn off request leak checking when the option is available to avoid unnecessary flooding in the output. Add a runtime option to turn on the checking when needed.