### PR TITLE
prov/tcp: Move from fabric progress to EP progress

### DIFF
--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -969,8 +969,9 @@ static int smr_ep_bind_cq(struct smr_ep *ep, struct util_cq *cq, uint64_t flags)
 	ret = fid_list_insert(&cq->ep_list,
 			      &cq->ep_list_lock,
 			      &ep->util_ep.ep_fid.fid);
-
-	return ret;
+	if (ret && ret != -FI_EALREADY)
+	    return ret;
+	return 0;
 }
 
 static int smr_ep_bind_cntr(struct smr_ep *ep, struct util_cntr *cntr, uint64_t flags)

--- a/prov/sockets/src/sock_cntr.c
+++ b/prov/sockets/src/sock_cntr.c
@@ -58,7 +58,7 @@ void sock_cntr_add_tx_ctx(struct sock_cntr *cntr, struct sock_tx_ctx *tx_ctx)
 	int ret;
 	struct fid *fid = &tx_ctx->fid.ctx.fid;
 	ret = fid_list_insert(&cntr->tx_list, &cntr->list_lock, fid);
-	if (ret)
+	if (ret && ret != -FI_EALREADY)
 		SOCK_LOG_ERROR("Error in adding ctx to progress list\n");
 	else
 		ofi_atomic_inc32(&cntr->ref);
@@ -76,7 +76,7 @@ void sock_cntr_add_rx_ctx(struct sock_cntr *cntr, struct sock_rx_ctx *rx_ctx)
 	int ret;
 	struct fid *fid = &rx_ctx->ctx.fid;
 	ret = fid_list_insert(&cntr->rx_list, &cntr->list_lock, fid);
-	if (ret)
+	if (ret && ret != -FI_EALREADY)
 		SOCK_LOG_ERROR("Error in adding ctx to progress list\n");
 	else
 		ofi_atomic_inc32(&cntr->ref);

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -868,7 +868,7 @@ static int sock_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 		}
 		ofi_mutex_lock(&av->list_lock);
 		ret = fid_list_insert(&av->ep_list, &ep->attr->lock, &ep->ep.fid);
-		if (ret) {
+		if (ret && ret != -FI_EALREADY) {
 			SOCK_LOG_ERROR("Error in adding fid in the EP list\n");
 			ofi_mutex_unlock(&av->list_lock);
 			return ret;

--- a/prov/tcp/src/xnet.h
+++ b/prov/tcp/src/xnet.h
@@ -461,11 +461,8 @@ static inline struct xnet_progress *xnet_cntr2_progress(struct util_cntr *cntr)
 struct xnet_eq {
 	struct util_eq		util_eq;
 	struct xnet_progress	progress;
-	/*
-	  The following lock avoids race between ep close
-	  and connection management code.
-	 */
-	ofi_mutex_t		close_lock;
+	struct dlist_entry	domain_list;
+	ofi_mutex_t		domain_list_lock;
 	struct dlist_entry	eq_entry;
 };
 

--- a/prov/tcp/src/xnet.h
+++ b/prov/tcp/src/xnet.h
@@ -460,6 +460,7 @@ static inline struct xnet_progress *xnet_cntr2_progress(struct util_cntr *cntr)
 
 struct xnet_eq {
 	struct util_eq		util_eq;
+	struct xnet_progress	progress;
 	/*
 	  The following lock avoids race between ep close
 	  and connection management code.

--- a/prov/tcp/src/xnet.h
+++ b/prov/tcp/src/xnet.h
@@ -358,7 +358,7 @@ static inline int xnet_progress_locked(struct xnet_progress *progress)
 struct xnet_fabric {
 	struct util_fabric	util_fabric;
 	struct xnet_progress	progress;
-	struct dlist_entry	wait_eq_list;
+	struct dlist_entry	eq_list;
 };
 
 int xnet_start_all(struct xnet_fabric *fabric);
@@ -465,7 +465,7 @@ struct xnet_eq {
 	  and connection management code.
 	 */
 	ofi_mutex_t		close_lock;
-	struct dlist_entry	wait_eq_entry;
+	struct dlist_entry	eq_entry;
 };
 
 static inline struct xnet_progress *xnet_eq2_progress(struct xnet_eq *eq)

--- a/prov/tcp/src/xnet.h
+++ b/prov/tcp/src/xnet.h
@@ -357,12 +357,8 @@ static inline int xnet_progress_locked(struct xnet_progress *progress)
 
 struct xnet_fabric {
 	struct util_fabric	util_fabric;
-	struct xnet_progress	progress;
 	struct dlist_entry	eq_list;
 };
-
-int xnet_start_all(struct xnet_fabric *fabric);
-void xnet_progress_all(struct xnet_fabric *fabric);
 
 static inline void xnet_signal_progress(struct xnet_progress *progress)
 {
@@ -466,12 +462,12 @@ struct xnet_eq {
 	struct dlist_entry	eq_entry;
 };
 
+int xnet_start_all(struct xnet_eq *eq);
+void xnet_progress_all(struct xnet_eq *eq);
+
 static inline struct xnet_progress *xnet_eq2_progress(struct xnet_eq *eq)
 {
-	struct xnet_fabric *fabric ;
-	fabric = container_of(eq->util_eq.fabric, struct xnet_fabric,
-			      util_fabric);
-	return &fabric->progress;
+	return &eq->progress;
 }
 
 int xnet_eq_write(struct util_eq *eq, uint32_t event,
@@ -536,6 +532,7 @@ int xnet_eq_create(struct fid_fabric *fabric_fid, struct fi_eq_attr *attr,
 int xnet_eq_add_progress(struct xnet_eq *eq, struct xnet_progress *progress,
 		         void *context);
 int xnet_eq_del_progress(struct xnet_eq *eq, struct xnet_progress *progress);
+int xnet_eq_add_domain(struct xnet_eq *eq, struct xnet_domain *domain);
 
 static inline void
 xnet_set_ack_flags(struct xnet_xfer_entry *xfer, uint64_t flags)

--- a/prov/tcp/src/xnet_cq.c
+++ b/prov/tcp/src/xnet_cq.c
@@ -262,10 +262,10 @@ static int xnet_cq_add_progress(struct xnet_cq *cq,
 			       POLLIN, xnet_cq_wait_try_func, NULL, context);
 }
 
-int xnet_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
+int xnet_cq_open(struct fid_domain *fid_domain, struct fi_cq_attr *attr,
 		 struct fid_cq **cq_fid, void *context)
 {
-	struct xnet_fabric *fabric;
+	struct xnet_domain *domain;
 	struct xnet_cq *cq;
 	struct fi_cq_attr cq_attr;
 	int ret;
@@ -283,15 +283,15 @@ int xnet_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		attr = &cq_attr;
 	}
 
-	ret = ofi_cq_init(&xnet_prov, domain, attr, &cq->util_cq,
+	ret = ofi_cq_init(&xnet_prov, fid_domain, attr, &cq->util_cq,
 			  &xnet_cq_progress, context);
 	if (ret)
 		goto free_cq;
 
 	if (cq->util_cq.wait) {
-		fabric = container_of(cq->util_cq.domain->fabric, struct xnet_fabric,
-				      util_fabric);
-		if (fabric->progress.auto_progress)
+		domain = container_of(fid_domain, struct xnet_domain,
+				      util_domain.domain_fid);
+		if (domain->progress.auto_progress)
 			ret = xnet_start_progress(xnet_cq2_progress(cq));
 		else
 			ret = xnet_cq_add_progress(cq, xnet_cq2_progress(cq),

--- a/prov/tcp/src/xnet_domain.c
+++ b/prov/tcp/src/xnet_domain.c
@@ -145,8 +145,8 @@ static void xnet_del_wait_eq_list(struct xnet_domain *domain)
 			      util_fabric.fabric_fid);
 
 	ofi_mutex_lock(&fabric->util_fabric.lock);
-	dlist_foreach(&fabric->wait_eq_list, item) {
-		eq = container_of(item, struct xnet_eq, wait_eq_entry);
+	dlist_foreach(&fabric->eq_list, item) {
+		eq = container_of(item, struct xnet_eq, eq_entry);
 		ret = xnet_eq_del_progress(eq, &domain->progress);
 		if (ret) {
 			FI_WARN(&xnet_prov, FI_LOG_DOMAIN,
@@ -210,8 +210,8 @@ static int xnet_add_wait_eq_list(struct xnet_domain *domain)
 			      util_fabric.fabric_fid);
 
 	ofi_mutex_lock(&fabric->util_fabric.lock);
-	dlist_foreach(&fabric->wait_eq_list, item) {
-		eq = container_of(item, struct xnet_eq, wait_eq_entry);
+	dlist_foreach(&fabric->eq_list, item) {
+		eq = container_of(item, struct xnet_eq, eq_entry);
 		ret = xnet_eq_add_progress(eq, &domain->progress,
 					   &domain->util_domain.domain_fid);
 		if (ret) {
@@ -225,7 +225,7 @@ static int xnet_add_wait_eq_list(struct xnet_domain *domain)
 clean:
 	/* Traverse the list backwards from where the error occurred */
 	dlist_foreach_reverse(error_item, item) {
-		eq = container_of(item, struct xnet_eq, wait_eq_entry);
+		eq = container_of(item, struct xnet_eq, eq_entry);
 		xnet_eq_del_progress(eq, &domain->progress);
 	}
 	ofi_mutex_unlock(&fabric->util_fabric.lock);

--- a/prov/tcp/src/xnet_ep.c
+++ b/prov/tcp/src/xnet_ep.c
@@ -570,7 +570,9 @@ static int xnet_ep_ctrl(struct fid *fid, int command, void *arg)
 
 static int xnet_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 {
+	struct xnet_domain *domain;
 	struct xnet_ep *ep;
+	struct xnet_eq *eq;
 	struct xnet_srx *srx;
 	int ret;
 
@@ -583,6 +585,12 @@ static int xnet_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 	}
 
 	ret = ofi_ep_bind(&ep->util_ep, bfid, flags);
+	if (ret == 0 && bfid->fclass == FI_CLASS_EQ) {
+		eq = container_of(bfid, struct xnet_eq, util_eq.eq_fid.fid);
+		domain = container_of(ep->util_ep.domain, struct xnet_domain,
+				      util_domain.domain_fid.fid);
+		ret = xnet_eq_add_domain(eq, domain);
+	}
 	return ret;
 }
 

--- a/prov/tcp/src/xnet_eq.c
+++ b/prov/tcp/src/xnet_eq.c
@@ -95,6 +95,10 @@ static int xnet_eq_unmonitor_all(struct xnet_eq *eq, struct xnet_fabric *fabric)
 	if (ret)
 		return ret;
 
+	ret = xnet_eq_del_progress(eq, &eq->progress);
+	if (ret)
+		return ret;
+
 	ofi_mutex_lock(&fabric->util_fabric.lock);
 	dlist_foreach(&fabric->util_fabric.domain_list, item) {
 		domain = container_of(item, struct xnet_domain,
@@ -183,7 +187,12 @@ static int xnet_eq_monitor_all(struct xnet_eq *eq, struct xnet_fabric *fabric)
 	ret = xnet_eq_add_progress(eq, &fabric->progress,
 				   &fabric->util_fabric.fabric_fid);
 	if (ret)
-	    return ret;
+		return ret;
+
+	ret = xnet_eq_add_progress(eq, &eq->progress,
+				   &eq->util_eq.eq_fid);
+	if (ret)
+		goto del_fabric_progress;
 
 	ofi_mutex_lock(&fabric->util_fabric.lock);
 	dlist_foreach(&fabric->util_fabric.domain_list, item) {
@@ -209,6 +218,7 @@ clean:
 	}
 	ofi_mutex_unlock(&fabric->util_fabric.lock);
 
+del_fabric_progress:
 	xnet_eq_del_progress(eq, &fabric->progress);
 	return ret;
 }

--- a/prov/tcp/src/xnet_eq.c
+++ b/prov/tcp/src/xnet_eq.c
@@ -134,7 +134,7 @@ static int xnet_eq_close(struct fid *fid)
 	if (ret)
 		return ret;
 
-	ofi_mutex_destroy(&eq->close_lock);
+	ofi_mutex_destroy(&eq->domain_list_lock);
 	xnet_close_progress(&eq->progress);
 	free(eq);
 	return 0;
@@ -241,7 +241,8 @@ int xnet_eq_create(struct fid_fabric *fabric_fid, struct fi_eq_attr *attr,
 		goto err1;
 	}
 
-	ret = ofi_mutex_init(&eq->close_lock);
+	dlist_init(&eq->domain_list);
+	ret = ofi_mutex_init(&eq->domain_list_lock);
 	if (ret)
 		goto err2;
 
@@ -270,7 +271,7 @@ int xnet_eq_create(struct fid_fabric *fabric_fid, struct fi_eq_attr *attr,
 err4:
 	xnet_close_progress(&eq->progress);
 err3:
-	ofi_mutex_destroy(&eq->close_lock);
+	ofi_mutex_destroy(&eq->domain_list_lock);
 err2:
 	ofi_eq_cleanup(&eq->util_eq.eq_fid.fid);
 err1:

--- a/prov/tcp/src/xnet_eq.c
+++ b/prov/tcp/src/xnet_eq.c
@@ -103,7 +103,7 @@ static int xnet_eq_unmonitor_all(struct xnet_eq *eq, struct xnet_fabric *fabric)
 		if (ret)
 			goto unlock;
 	}
-	dlist_remove(&eq->wait_eq_entry);
+	dlist_remove(&eq->eq_entry);
 unlock:
 	ofi_mutex_unlock(&fabric->util_fabric.lock);
 	return ret;
@@ -195,7 +195,7 @@ static int xnet_eq_monitor_all(struct xnet_eq *eq, struct xnet_fabric *fabric)
 			goto clean;
 		}
 	}
-	dlist_insert_tail(&eq->wait_eq_entry, &fabric->wait_eq_list);
+	dlist_insert_tail(&eq->eq_entry, &fabric->eq_list);
 	ofi_mutex_unlock(&fabric->util_fabric.lock);
 	return FI_SUCCESS;
 

--- a/prov/tcp/src/xnet_fabric.c
+++ b/prov/tcp/src/xnet_fabric.c
@@ -58,7 +58,7 @@ static int xnet_fabric_close(fid_t fid)
 	fabric = container_of(fid, struct xnet_fabric,
 			      util_fabric.fabric_fid.fid);
 
-	assert(dlist_empty(&fabric->wait_eq_list));
+	assert(dlist_empty(&fabric->eq_list));
 
 	ret = ofi_fabric_close(&fabric->util_fabric);
 	if (ret)
@@ -87,7 +87,7 @@ int xnet_create_fabric(struct fi_fabric_attr *attr,
 	if (!fabric)
 		return -FI_ENOMEM;
 
-	dlist_init(&fabric->wait_eq_list);
+	dlist_init(&fabric->eq_list);
 
 	ret = ofi_fabric_init(&xnet_prov, &xnet_fabric_attr, attr,
 			      &fabric->util_fabric, context);

--- a/prov/tcp/src/xnet_fabric.c
+++ b/prov/tcp/src/xnet_fabric.c
@@ -64,7 +64,6 @@ static int xnet_fabric_close(fid_t fid)
 	if (ret)
 		return ret;
 
-	xnet_close_progress(&fabric->progress);
 	free(fabric);
 	return 0;
 }
@@ -94,17 +93,12 @@ int xnet_create_fabric(struct fi_fabric_attr *attr,
 	if (ret)
 		goto free;
 
-	ret = xnet_init_progress(&fabric->progress, NULL);
-	if (ret)
-		goto close;
-
 	fabric->util_fabric.fabric_fid.fid.ops = &xnet_fabric_fi_ops;
 	fabric->util_fabric.fabric_fid.ops = &xnet_fabric_ops;
 	*fabric_fid = &fabric->util_fabric.fabric_fid;
 
 	return 0;
 
-close:
 	(void) ofi_fabric_close(&fabric->util_fabric);
 free:
 	free(fabric);

--- a/prov/tcp/src/xnet_pep.c
+++ b/prov/tcp/src/xnet_pep.c
@@ -254,13 +254,13 @@ int xnet_listen(struct xnet_pep *pep, struct xnet_progress *progress)
 
 static int xnet_pep_listen(struct fid_pep *pep_fid)
 {
-	struct xnet_fabric *fabric;
+	struct xnet_eq *eq;
 	struct xnet_pep *pep;
 
 	pep = container_of(pep_fid, struct xnet_pep, util_pep.pep_fid);
-	fabric = container_of(pep->util_pep.fabric, struct xnet_fabric,
-			      util_fabric);
-	return xnet_listen(pep, &fabric->progress);
+	eq = container_of(pep->util_pep.eq, struct xnet_eq,
+			  util_eq);
+	return xnet_listen(pep, &eq->progress);
 }
 
 static int xnet_pep_reject(struct fid_pep *pep, fid_t fid_handle,

--- a/prov/tcp/src/xnet_progress.c
+++ b/prov/tcp/src/xnet_progress.c
@@ -1184,21 +1184,23 @@ void xnet_progress(struct xnet_progress *progress, bool clear_signal)
 	ofi_genlock_unlock(progress->active_lock);
 }
 
-void xnet_progress_all(struct xnet_fabric *fabric)
+void xnet_progress_all(struct xnet_eq *eq)
 {
 	struct xnet_domain *domain;
 	struct dlist_entry *item;
+	struct fid_list_entry *fid_entry;
 
-	ofi_mutex_lock(&fabric->util_fabric.lock);
-	dlist_foreach(&fabric->util_fabric.domain_list, item) {
-		domain = container_of(item, struct xnet_domain,
-				      util_domain.list_entry);
+	ofi_mutex_lock(&eq->domain_list_lock);
+	dlist_foreach(&eq->domain_list, item) {
+		fid_entry = container_of(item, struct fid_list_entry, entry);
+		domain = container_of(fid_entry->fid, struct xnet_domain,
+				      util_domain.domain_fid.fid);
 		xnet_progress(&domain->progress, false);
 	}
 
-	ofi_mutex_unlock(&fabric->util_fabric.lock);
+	ofi_mutex_unlock(&eq->domain_list_lock);
 
-	xnet_progress(&fabric->progress, false);
+	xnet_progress(&eq->progress, false);
 }
 
 /* The epoll fd is updated dynamically for polling/pollout events on the
@@ -1315,26 +1317,28 @@ unlock:
 	return ret;
 }
 
-int xnet_start_all(struct xnet_fabric *fabric)
+int xnet_start_all(struct xnet_eq *eq)
 {
 	struct xnet_domain *domain;
 	struct dlist_entry *item;
+	struct fid_list_entry *fid_entry;
 	int ret;
 
-	ret = xnet_start_progress(&fabric->progress);
+	ret = xnet_start_progress(&eq->progress);
 	if (ret)
 		return ret;
 
-	ofi_mutex_lock(&fabric->util_fabric.lock);
-	dlist_foreach(&fabric->util_fabric.domain_list, item) {
-		domain = container_of(item, struct xnet_domain,
-				      util_domain.list_entry);
+	ofi_mutex_lock(&eq->domain_list_lock);
+	dlist_foreach(&eq->domain_list, item) {
+		fid_entry = container_of(item, struct fid_list_entry, entry);
+		domain = container_of(fid_entry->fid, struct xnet_domain,
+				      util_domain.domain_fid.fid);
 		ret = xnet_start_progress(&domain->progress);
 		if (ret)
 			break;
 	}
 
-	ofi_mutex_unlock(&fabric->util_fabric.lock);
+	ofi_mutex_unlock(&eq->domain_list_lock);
 	return ret;
 }
 

--- a/prov/udp/src/udpx_ep.c
+++ b/prov/udp/src/udpx_ep.c
@@ -617,7 +617,7 @@ static int udpx_ep_bind_cq(struct udpx_ep *ep, struct util_cq *cq,
 		ret = fid_list_insert(&cq->ep_list,
 				      &cq->ep_list_lock,
 				      &ep->util_ep.ep_fid.fid);
-		if (ret)
+		if (ret && -FI_EALREADY)
 			return ret;
 	}
 

--- a/prov/usnic/src/usdf_cq.c
+++ b/prov/usnic/src/usdf_cq.c
@@ -1179,7 +1179,7 @@ static int usdf_cq_bind_wait(struct usdf_cq *cq)
 
 	ret = fid_list_insert(&wait_priv->list, &wait_priv->lock,
 			&cq->cq_fid.fid);
-	if (ret) {
+	if (ret && ret != -FI_EALREADY) {
 		USDF_WARN_SYS(CQ,
 				"failed to associate cq with wait fid list\n");
 		return ret;

--- a/prov/usnic/src/usdf_eq.c
+++ b/prov/usnic/src/usdf_eq.c
@@ -444,7 +444,7 @@ static int usdf_eq_bind_wait(struct usdf_eq *eq)
 
 	ret = fid_list_insert(&wait_priv->list, &wait_priv->lock,
 			&eq->eq_fid.fid);
-	if (ret) {
+	if (ret && ret != -FI_EALREADY) {
 		USDF_WARN_SYS(EQ,
 				"failed to associate eq with wait fid list\n");
 		return ret;

--- a/prov/usnic/src/usdf_poll.c
+++ b/prov/usnic/src/usdf_poll.c
@@ -116,7 +116,7 @@ static int usdf_poll_add(struct fid_poll *fps, struct fid *event_fid,
 	}
 
 	ret = fid_list_insert(&ps->list, &ps->lock, event_fid);
-	if (ret)
+	if (ret && ret != -FI_EALREADY)
 		return ret;
 
 	cq = cq_fidtou(event_fid);

--- a/prov/util/src/util_ep.c
+++ b/prov/util/src/util_ep.c
@@ -64,9 +64,11 @@ int ofi_ep_bind_cq(struct util_ep *ep, struct util_cq *cq, uint64_t flags)
 	}
 
 	if (flags & (FI_TRANSMIT | FI_RECV)) {
-		return fid_list_insert(&cq->ep_list,
-				       &cq->ep_list_lock,
-				       &ep->ep_fid.fid);
+		ret = fid_list_insert(&cq->ep_list,
+				      &cq->ep_list_lock,
+				      &ep->ep_fid.fid);
+		if (ret && ret != -FI_EALREADY)
+			return ret;
 	}
 
 	return FI_SUCCESS;
@@ -101,6 +103,8 @@ int ofi_ep_bind_av(struct util_ep *util_ep, struct util_av *av)
 
 int ofi_ep_bind_cntr(struct util_ep *ep, struct util_cntr *cntr, uint64_t flags)
 {
+	int ret;
+
 	if (flags & ~(FI_TRANSMIT | FI_RECV | FI_READ  | FI_WRITE |
 		      FI_REMOTE_READ | FI_REMOTE_WRITE)) {
 		FI_WARN(ep->domain->fabric->prov, FI_LOG_EP_CTRL,
@@ -157,8 +161,11 @@ int ofi_ep_bind_cntr(struct util_ep *ep, struct util_cntr *cntr, uint64_t flags)
 
 	ep->flags |= OFI_CNTR_ENABLED;
 
-	return fid_list_insert(&cntr->ep_list, &cntr->ep_list_lock,
-			       &ep->ep_fid.fid);
+	ret = fid_list_insert(&cntr->ep_list, &cntr->ep_list_lock,
+			      &ep->ep_fid.fid);
+	if (ret && ret != -FI_EALREADY)
+		return ret;
+	return 0;
 }
 
 int ofi_ep_bind(struct util_ep *util_ep, struct fid *fid, uint64_t flags)

--- a/prov/util/src/util_main.c
+++ b/prov/util/src/util_main.c
@@ -79,7 +79,8 @@ int fid_list_insert(struct dlist_entry *fid_list, ofi_mutex_t *lock,
 	struct dlist_entry *entry;
 	struct fid_list_entry *item;
 
-	ofi_mutex_lock(lock);
+	if (lock)
+		ofi_mutex_lock(lock);
 	entry = dlist_find_first_match(fid_list, ofi_fid_match, fid);
 	if (entry)
 		goto out;
@@ -93,7 +94,8 @@ int fid_list_insert(struct dlist_entry *fid_list, ofi_mutex_t *lock,
 	item->fid = fid;
 	dlist_insert_tail(&item->entry, fid_list);
 out:
-	ofi_mutex_unlock(lock);
+	if (lock)
+		ofi_mutex_unlock(lock);
 	return ret;
 }
 

--- a/prov/util/src/util_main.c
+++ b/prov/util/src/util_main.c
@@ -82,8 +82,10 @@ int fid_list_insert(struct dlist_entry *fid_list, ofi_mutex_t *lock,
 	if (lock)
 		ofi_mutex_lock(lock);
 	entry = dlist_find_first_match(fid_list, ofi_fid_match, fid);
-	if (entry)
+	if (entry) {
+		ret = -FI_EALREADY;
 		goto out;
+	}
 
 	item = calloc(1, sizeof(*item));
 	if (!item) {

--- a/prov/util/src/util_poll.c
+++ b/prov/util/src/util_poll.c
@@ -41,6 +41,7 @@ static int util_poll_add(struct fid_poll *poll_fid, struct fid *event_fid,
 			 uint64_t flags)
 {
 	struct util_poll *pollset;
+	int ret;
 
 	pollset = container_of(poll_fid, struct util_poll, poll_fid);
 	switch (event_fid->fclass) {
@@ -58,7 +59,10 @@ static int util_poll_add(struct fid_poll *poll_fid, struct fid *event_fid,
 		return -FI_EINVAL;
 	}
 
-	return fid_list_insert(&pollset->fid_list, &pollset->lock, event_fid);
+	ret = fid_list_insert(&pollset->fid_list, &pollset->lock, event_fid);
+	if (ret && ret != -FI_EALREADY)
+		return ret;
+	return 0;
 }
 
 static int util_poll_del(struct fid_poll *poll_fid, struct fid *event_fid,


### PR DESCRIPTION
Context: With the new TCP provider, polling an EQ results in progressing all the domains that belong to the same
fabric + the fabric itself. As a consequence, polling some EQs from the same fabric but from different threads would result
in a high contention on the fabric and the domain lock.

The PR moves the progress from the fabric to the EP. The intention behind this change is to improve multi-threaded applications that are driving progress with the EQ (see issue #8505 for more details).
With this PR, progressing an EQ results in progressing the domains that have EPs active for the given EQ only. As
a consequence, lock contention is reduced, and the performance of multi-threaded applications that drive progress of the
EQs is improved.
