### PR TITLE
prov/efa: record tx op submitted/completed for write

### DIFF
--- a/prov/efa/src/rdm/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_misc.c
@@ -357,6 +357,7 @@ void rxr_pkt_init_write_context(struct rxr_op_entry *tx_entry,
 	struct rxr_rma_context_pkt *rma_context_pkt;
 
 	pkt_entry->x_entry = (void *)tx_entry;
+	pkt_entry->addr = tx_entry->addr;
 	rma_context_pkt = (struct rxr_rma_context_pkt *)pkt_entry->wiredata;
 	rma_context_pkt->type = RXR_RMA_CONTEXT_PKT;
 	rma_context_pkt->version = RXR_PROTOCOL_VERSION;
@@ -454,8 +455,6 @@ void rxr_pkt_handle_rma_read_completion(struct rxr_ep *ep,
 			rxr_read_release_entry(ep, read_entry);
 		}
 	}
-
-	rxr_ep_record_tx_op_completed(ep, context_pkt_entry);
 }
 
 /**
@@ -501,6 +500,7 @@ void rxr_pkt_handle_rma_completion(struct rxr_ep *ep,
 		assert(0 && "invalid RXR_RMA_CONTEXT_PKT rma_context_type\n");
 	}
 
+	rxr_ep_record_tx_op_completed(ep, context_pkt_entry);
 	rxr_pkt_entry_release_tx(ep, context_pkt_entry);
 }
 

--- a/prov/efa/src/rdm/rxr_rma.c
+++ b/prov/efa/src/rdm/rxr_rma.c
@@ -154,6 +154,7 @@ size_t rxr_rma_post_shm_write(struct rxr_ep *rxr_ep, struct rxr_op_entry *tx_ent
 #if ENABLE_DEBUG
 	dlist_insert_tail(&pkt_entry->dbg_entry, &rxr_ep->tx_pkt_list);
 #endif
+	rxr_ep_record_tx_op_submitted(rxr_ep, pkt_entry);
 	return 0;
 }
 


### PR DESCRIPTION
Piror to this patch, rxr_ep_record_tx_op_completed() was not called for the  write operation. 

rxr_ep_record_tx_op_completed() was not called for the  write operation. 

rxr_ep_record_tx_op_submitted() was not called for the  shm write operation. 

This patch addressed both issues.