### PR TITLE
prov/efa: Correct CQ flags to FI_REMOTE_WRITE

### DIFF
--- a/prov/efa/src/rdm/rxr_op_entry.c
+++ b/prov/efa/src/rdm/rxr_op_entry.c
@@ -1049,7 +1049,7 @@ void rxr_op_entry_handle_recv_completed(struct rxr_op_entry *op_entry)
 	 * action of sending ctrl packet may cause the release of RX entry (when inject
 	 * was used on lower device).
 	 */
-	if (op_entry->cq_entry.flags & FI_WRITE) {
+	if (op_entry->cq_entry.flags & FI_REMOTE_WRITE) {
 		/*
 		 * For write, only write RX completion when REMOTE_CQ_DATA is on
 		 */

--- a/prov/efa/src/rdm/rxr_pkt_type_req.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_req.c
@@ -1858,7 +1858,6 @@ void rxr_pkt_proc_eager_rtw(struct rxr_ep *ep,
 		return;
 	}
 
-	rx_entry->cq_entry.flags |= (FI_RMA | FI_WRITE);
 	rx_entry->cq_entry.len = ofi_total_iov_len(rx_entry->iov, rx_entry->iov_count);
 	rx_entry->cq_entry.buf = rx_entry->iov[0].iov_base;
 	rx_entry->total_len = rx_entry->cq_entry.len;
@@ -1970,7 +1969,6 @@ void rxr_pkt_handle_longcts_rtw_recv(struct rxr_ep *ep,
 		return;
 	}
 
-	rx_entry->cq_entry.flags |= (FI_RMA | FI_WRITE);
 	rx_entry->cq_entry.len = ofi_total_iov_len(rx_entry->iov, rx_entry->iov_count);
 	rx_entry->cq_entry.buf = rx_entry->iov[0].iov_base;
 	rx_entry->total_len = rx_entry->cq_entry.len;
@@ -2044,7 +2042,6 @@ void rxr_pkt_handle_longread_rtw_recv(struct rxr_ep *ep,
 		return;
 	}
 
-	rx_entry->cq_entry.flags |= (FI_RMA | FI_WRITE);
 	rx_entry->cq_entry.len = ofi_total_iov_len(rx_entry->iov, rx_entry->iov_count);
 	rx_entry->cq_entry.buf = rx_entry->iov[0].iov_base;
 	rx_entry->total_len = rx_entry->cq_entry.len;


### PR DESCRIPTION
The functions `rxr_pkt_proc_eager_rtw`, `rxr_pkt_handle_longcts_rtw_recv`, and `rxr_pkt_handle_longread_rtw_recv` all incorrectly added FI_WRITE to the op_entry's CQ flags.  In fact, rxr_ep_alloc_rx_entry has already initialized the flags to the correct value: `(FI_REMOTE_WRITE | FI_RMA)`.

Additionally `rxr_op_entry_handle_recv_completed` was incorrectly checking for FI_WRITE flag, when it should have checked for FI_REMOTE_WRITE.