### PR TITLE
infra: Add atomic indirection

### DIFF
--- a/include/ofi_atom.h
+++ b/include/ofi_atom.h
@@ -166,6 +166,25 @@ typedef atomic_long	ofi_atomic_int64_t;
 					int##radix##_t desired)						\
 	{												\
 		return ofi_atomic_cas_bool_strong##radix(atomic, expected, desired);			\
+	}												\
+	static inline											\
+	bool ofi_atomic_compare_exchange_weak##radix(ofi_atomic##radix##_t *atomic, 			\
+					int##radix##_t *expected,					\
+					int##radix##_t desired)						\
+	{												\
+		return atomic_compare_exchange_weak(&atomic->val, expected, desired);			\
+	}												\
+	static inline											\
+	void ofi_atomic_store_explicit##radix(ofi_atomic##radix##_t *atomic,				\
+					      int##radix##_t value, int memmodel)			\
+	{												\
+		atomic_store_explicit(&atomic->val, value, memmodel);					\
+	}												\
+	static inline											\
+	int##radix##_t ofi_atomic_load_explicit##radix(ofi_atomic##radix##_t *atomic,			\
+						       int memmodel)					\
+	{												\
+		return atomic_load_explicit(&atomic->val, memmodel);					\
 	}
 
 #elif defined HAVE_BUILTIN_ATOMICS
@@ -249,6 +268,26 @@ typedef atomic_long	ofi_atomic_int64_t;
 					     int##radix##_t desired)					\
 	{												\
 		return ofi_atomic_cas_bool##radix(atomic, expected, desired);				\
+	}												\
+	static inline											\
+	bool ofi_atomic_compare_exchange_weak##radix(ofi_atomic##radix##_t *atomic,			\
+					int##radix##_t *expected,					\
+					int##radix##_t desired)						\
+	{												\
+		return ofi_atomic_compare_exchange_weak(radix, ofi_atomic_ptr(atomic), expected,	\
+						desired, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);		\
+	}												\
+	static inline											\
+	void ofi_atomic_store_explicit##radix(ofi_atomic##radix##_t *atomic,				\
+					      int##radix##_t value, int memmodel)			\
+	{												\
+		ofi_atomic_store_explicit(radix, ofi_atomic_ptr(atomic), value, memmodel);		\
+	}												\
+	static inline											\
+	int##radix##_t ofi_atomic_load_explicit##radix(ofi_atomic##radix##_t *atomic,			\
+						       int memmodel)					\
+	{												\
+		return ofi_atomic_load_explicit(radix, ofi_atomic_ptr(atomic), memmodel);		\
 	}
 
 #else /* HAVE_ATOMICS */
@@ -355,7 +394,7 @@ typedef atomic_long	ofi_atomic_int64_t;
 							 int##radix##_t desired)		\
 	{											\
 		return ofi_atomic_cas_bool##radix(atomic, expected, desired);			\
-	}
+	}											\
 
 #endif // HAVE_ATOMICS
 

--- a/include/unix/osd.h
+++ b/include/unix/osd.h
@@ -244,13 +244,32 @@ OFI_DEF_COMPLEX_OPS(float)
 OFI_DEF_COMPLEX_OPS(double)
 OFI_DEF_COMPLEX_OPS(long_double)
 
+#ifdef HAVE_ATOMICS
+#  include <stdatomic.h>
+#endif
 
 /* atomics primitives */
 #ifdef HAVE_BUILTIN_ATOMICS
+
+#define memory_order_relaxed __ATOMIC_RELAXED
+#define memory_order_consume __ATOMIC_CONSUME
+#define memory_order_acquire __ATOMIC_ACQUIRE
+#define memory_order_release __ATOMIC_RELEASE
+#define memory_order_acq_rel __ATOMIC_ACQ_REL
+#define memory_order_seq_cst __ATOMIC_SEQ_CST
+
 #define ofi_atomic_add_and_fetch(radix, ptr, val) __sync_add_and_fetch((ptr), (val))
 #define ofi_atomic_sub_and_fetch(radix, ptr, val) __sync_sub_and_fetch((ptr), (val))
 #define ofi_atomic_cas_bool(radix, ptr, expected, desired) 	\
 	__sync_bool_compare_and_swap((ptr), (expected), (desired))
+#define ofi_atomic_compare_exchange_weak(radix, ptr, expected, desired, \
+					 succ_memmodel, fail_memmodel) \
+	__atomic_compare_exchange_n(ptr, expected, desired, true, \
+				    succ_memmodel, fail_memmodel)
+#define ofi_atomic_store_explicit(radix, ptr, value, memmodel) \
+	__atomic_store_n(ptr, value, memmodel)
+#define ofi_atomic_load_explicit(radix, ptr, memmodel) \
+	__atomic_load_n(ptr, memmodel)
 #endif /* HAVE_BUILTIN_ATOMICS */
 
 int ofi_set_thread_affinity(const char *s);

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -1031,6 +1031,13 @@ typedef LONGLONG ofi_atomic_int_64_t;
 #define ofi_atomic_cas_bool(radix, ptr, expected, desired)					\
 	(InterlockedCompareExchange##radix((ofi_atomic_int_##radix##_t volatile *)ptr, desired, expected) == expected)
 
+#define ofi_atomic_compare_exchange_weak(radix, ptr, expected, desired, \
+					 succ_memmodel, fail_memmodel) \
+	InterlockedCompareExchange((ofi_atomic_int_##radix##_t volatile *)ptr, desired, expected)
+#define ofi_atomic_store_explicit(radix, ptr, value, memmodel) \
+	InterlockedExchange((ofi_atomic_int_##radix##_t volatile *)ptr, value)
+#define ofi_atomic_load_explicit(radix, ptr, memmodel) \
+	InterlockedAdd((ofi_atomic_int_##radix##_t volatile *)ptr, 0)
 #endif /* HAVE_BUILTIN_ATOMICS */
 
 static inline int ofi_set_thread_affinity(const char *s)


### PR DESCRIPTION
Add atomic indirection to handle cases where an older compiler is being used which doesn't support atomic functions, or have other versions of the atomic functions. The three variants which were added are:

atomic_compare_exchange_weak()
atomic_store_explicit()
atomic_load_explicit()

These are needed for the atomic queue implementation