### PR TITLE
prov/shm: Update SHM to use ROCR

### DIFF
--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -135,7 +135,7 @@ struct smr_tx_entry {
 	int			fd;
 };
 
-struct smr_sar_entry {
+struct smr_pend_entry {
 	struct dlist_entry	entry;
 	struct smr_cmd		cmd;
 	struct fi_peer_rx_entry	*rx_entry;
@@ -145,6 +145,8 @@ struct smr_sar_entry {
 	size_t			iov_count;
 	struct ofi_mr		*mr[SMR_IOV_LIMIT];
 	bool			in_use;
+	struct ofi_mr_entry	*ipc_entry;
+	ofi_hmem_async_event_t	async_event;
 };
 
 struct smr_match_attr {
@@ -172,8 +174,8 @@ struct smr_cmd_ctx {
 
 OFI_DECLARE_FREESTACK(struct smr_rx_entry, smr_recv_fs);
 OFI_DECLARE_FREESTACK(struct smr_cmd_ctx, smr_cmd_ctx_fs);
-OFI_DECLARE_FREESTACK(struct smr_tx_entry, smr_pend_fs);
-OFI_DECLARE_FREESTACK(struct smr_sar_entry, smr_sar_fs);
+OFI_DECLARE_FREESTACK(struct smr_tx_entry, smr_tx_fs);
+OFI_DECLARE_FREESTACK(struct smr_pend_entry, smr_pend_fs);
 
 struct smr_queue {
 	struct dlist_entry list;
@@ -271,10 +273,10 @@ struct smr_ep {
 
 	struct fid_ep		*srx;
 	struct smr_cmd_ctx_fs	*cmd_ctx_fs;
+	struct smr_tx_fs	*tx_fs;
 	struct smr_pend_fs	*pend_fs;
-	struct smr_sar_fs	*sar_fs;
-
 	struct dlist_entry	sar_list;
+	struct dlist_entry	ipc_cpy_pend_list;
 
 	int			ep_idx;
 	struct smr_sock_info	*sock_info;

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -137,7 +137,7 @@ static ssize_t smr_do_atomic_inject(struct smr_ep *ep, struct smr_region *peer_s
 			return -FI_EAGAIN;
 		}
 		resp = ofi_cirque_next(smr_resp_queue(ep->region));
-		pend = ofi_freestack_pop(ep->pend_fs);
+		pend = ofi_freestack_pop(ep->tx_fs);
 		smr_format_pend_resp(pend, cmd, context, NULL, resultv,
 				     result_count, op_flags, id, resp);
 		cmd->msg.hdr.data = smr_get_offset(ep->region, resp);

--- a/prov/shm/src/smr_dsa.c
+++ b/prov/shm/src/smr_dsa.c
@@ -557,7 +557,7 @@ static void dsa_update_tx_entry(struct smr_region *smr,
 static void dsa_update_sar_entry(struct smr_region *smr,
 				 struct dsa_cmd_context *dsa_cmd_context)
 {
-	struct smr_sar_entry *sar_entry = dsa_cmd_context->entry_ptr;
+	struct smr_pend_entry *sar_entry = dsa_cmd_context->entry_ptr;
 	struct smr_region *peer_smr;
 	struct smr_resp *resp;
 	struct smr_cmd *cmd;

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -699,7 +699,7 @@ static ssize_t smr_do_iov(struct smr_ep *ep, struct smr_region *peer_smr, int64_
 		return -FI_EAGAIN;
 
 	resp = ofi_cirque_next(smr_resp_queue(ep->region));
-	pend = ofi_freestack_pop(ep->pend_fs);
+	pend = ofi_freestack_pop(ep->tx_fs);
 
 	smr_generic_format(cmd, peer_id, op, tag, data, op_flags);
 	smr_format_iov(cmd, iov, iov_count, total_len, ep->region, resp);
@@ -724,13 +724,13 @@ static ssize_t smr_do_sar(struct smr_ep *ep, struct smr_region *peer_smr, int64_
 		return -FI_EAGAIN;
 
 	resp = ofi_cirque_next(smr_resp_queue(ep->region));
-	pend = ofi_freestack_pop(ep->pend_fs);
+	pend = ofi_freestack_pop(ep->tx_fs);
 
 	smr_generic_format(cmd, peer_id, op, tag, data, op_flags);
 	ret = smr_format_sar(ep, cmd, desc, iov, iov_count, total_len,
 			     ep->region, peer_smr, id, pend, resp);
 	if (ret) {
-		ofi_freestack_push(ep->pend_fs, pend);
+		ofi_freestack_push(ep->tx_fs, pend);
 		return ret;
 	}
 
@@ -755,7 +755,7 @@ static ssize_t smr_do_ipc(struct smr_ep *ep, struct smr_region *peer_smr, int64_
 		return -FI_EAGAIN;
 
 	resp = ofi_cirque_next(smr_resp_queue(ep->region));
-	pend = ofi_freestack_pop(ep->pend_fs);
+	pend = ofi_freestack_pop(ep->tx_fs);
 
 	smr_generic_format(cmd, peer_id, op, tag, data, op_flags);
 	assert(iov_count == 1 && desc && desc[0]);
@@ -772,7 +772,7 @@ static ssize_t smr_do_ipc(struct smr_ep *ep, struct smr_region *peer_smr, int64_
 	if (ret) {
 		FI_WARN_ONCE(&smr_prov, FI_LOG_EP_CTRL,
 			     "unable to use IPC for msg, fallback to using SAR\n");
-		ofi_freestack_push(ep->pend_fs, pend);
+		ofi_freestack_push(ep->tx_fs, pend);
 		return smr_do_sar(ep, peer_smr, id, peer_id, op, tag, data,
 				  op_flags, desc, iov, iov_count,
 				  total_len, context, cmd);
@@ -799,12 +799,12 @@ static ssize_t smr_do_mmap(struct smr_ep *ep, struct smr_region *peer_smr, int64
 		return -FI_EAGAIN;
 
 	resp = ofi_cirque_next(smr_resp_queue(ep->region));
-	pend = ofi_freestack_pop(ep->pend_fs);
+	pend = ofi_freestack_pop(ep->tx_fs);
 
 	smr_generic_format(cmd, peer_id, op, tag, data, op_flags);
 	ret = smr_format_mmap(ep, cmd, iov, iov_count, total_len, pend, resp);
 	if (ret) {
-		ofi_freestack_push(ep->pend_fs, pend);
+		ofi_freestack_push(ep->tx_fs, pend);
 		return ret;
 	}
 
@@ -931,8 +931,8 @@ static int smr_ep_close(struct fid *fid)
 		smr_srx_close(&ep->srx->fid);
 
 	smr_cmd_ctx_fs_free(ep->cmd_ctx_fs);
+	smr_tx_fs_free(ep->tx_fs);
 	smr_pend_fs_free(ep->pend_fs);
-	smr_sar_fs_free(ep->sar_fs);
 	ofi_spin_destroy(&ep->tx_lock);
 
 	free((void *)ep->name);
@@ -1781,10 +1781,11 @@ int smr_endpoint(struct fid_domain *domain, struct fi_info *info,
 	ep->util_ep.ep_fid.tagged = &smr_tag_ops;
 
 	ep->cmd_ctx_fs = smr_cmd_ctx_fs_create(info->rx_attr->size, NULL, NULL);
-	ep->pend_fs = smr_pend_fs_create(info->tx_attr->size, NULL, NULL);
-	ep->sar_fs = smr_sar_fs_create(info->rx_attr->size, NULL, NULL);
+	ep->tx_fs = smr_tx_fs_create(info->tx_attr->size, NULL, NULL);
+	ep->pend_fs = smr_pend_fs_create(info->rx_attr->size, NULL, NULL);
 
 	dlist_init(&ep->sar_list);
+	dlist_init(&ep->ipc_cpy_pend_list);
 
 	ep->util_ep.ep_fid.fid.ops = &smr_ep_fi_ops;
 	ep->util_ep.ep_fid.ops = &smr_ep_ops;

--- a/prov/util/src/rocr_mem_monitor.c
+++ b/prov/util/src/rocr_mem_monitor.c
@@ -37,6 +37,7 @@
 
 #include "ofi_tree.h"
 #include "ofi_iov.h"
+#include "ofi_hmem.h"
 
 #include <hsa/hsa_ext_amd.h>
 


### PR DESCRIPTION
Update the SHM provider to use the ROCR HMEM asynchronous memory operations.

   . Add an IPC entry freestack
   . When progressing an IPC operation, check if the device is ROCR and trigger
     an asynchronous operation.
   . When an asynchronous operation is queued, create an IPC entry and
     add it to the queue of pending operations.
   . During the top level progress loop check the queue of pending asynchronous
     operations and query the state of each one. Generate a complete event
     for finished operations. Since completions happen outside the context
     of libfabric we can't rely on the ep->region->signal flag to be set.
     Always check the pending queue. This shouldn't introduce much of an
     overhead if the queue is empty