### PR TITLE
prov/efa: add FI_RX_CQ_DATA to rx_attr->mode for rdm

### DIFF
--- a/prov/efa/src/efa_prov_info.c
+++ b/prov/efa/src/efa_prov_info.c
@@ -272,7 +272,7 @@ const struct fi_tx_attr efa_rdm_tx_attr = {
  */
 const struct fi_rx_attr efa_rdm_rx_attr = {
 	.caps			= EFA_RDM_RX_CAPS,
-	.mode			= EFA_RX_MODE,
+	.mode			= EFA_RX_MODE | FI_RX_CQ_DATA,
 	.op_flags		= EFA_RX_RDM_OP_FLAGS,
 	.msg_order		= EFA_MSG_ORDER,
 	.comp_order		= FI_ORDER_NONE,


### PR DESCRIPTION
rdm endpoint supports receive with CQ data, therefore this patch set it in rx_attr->mode.