### PR TITLE
prov/efa,tcp: Squelch some unused variable warnings

### DIFF
--- a/prov/efa/src/efa_user_info.c
+++ b/prov/efa/src/efa_user_info.c
@@ -408,6 +408,8 @@ int efa_user_info_alter_rxr(struct fi_info *info, const struct fi_info *hints)
 			 */
 			info->caps &= ~FI_HMEM;
 		}
+#else
+		(void) support_atomic; /* avoid unused variable warning */
 #endif
 		/*
 		 * The provider does not force applications to register buffers

--- a/prov/tcp/src/xnet_progress.c
+++ b/prov/tcp/src/xnet_progress.c
@@ -74,6 +74,7 @@ static void xnet_submit_uring(struct xnet_uring *uring)
 		return;
 
 	submitted = ofi_uring_submit(&uring->ring);
+	(void) submitted; /* avoid unused variable warning */
 	assert(ready == submitted);
 }
 


### PR DESCRIPTION
Small changes to remove a warning seen in gcc 7.3.1, due to either debug code (prov/tcp/src/xnet_progress.c) or #ifdef path (prov/efa/src/efa_user_info.c).

Added a `(void) var;` line to "use" the variable.