### PR TITLE
prov/efa: Fix a bug in rxr_pkt_handle_rma_read_completion

### DIFF
--- a/prov/efa/src/rdm/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_misc.c
@@ -420,7 +420,7 @@ void rxr_pkt_handle_rma_read_completion(struct rxr_ep *ep,
 		if (rx_entry->bytes_read_completed == rx_entry->bytes_read_total_len) {
 			rxr_tracepoint(read_completed,
 				    rx_entry->msg_id, (size_t) rx_entry->cq_entry.op_context,
-				    rx_entry->total_len, (size_t) read_entry->context);
+				    rx_entry->total_len, (size_t) rx_entry);
 			err = rxr_pkt_post_or_queue(ep, rx_entry, RXR_EOR_PKT, false);
 			if (OFI_UNLIKELY(err)) {
 				EFA_WARN(FI_LOG_CQ,


### PR DESCRIPTION
rxr_pkt_handle_rma_read_completion call rxr_tracepoint with read_entry->context as an argument, while read_entry is a null ptr at this time. This patch fixes this issue by changing read_entry->context to rx_entry, which is what it was referring to.