### PR TITLE
prov/efa: handle the IBV_WC_RDMA_READ opcode.

### DIFF
--- a/prov/efa/src/rdm/rxr_ep.c
+++ b/prov/efa/src/rdm/rxr_ep.c
@@ -1715,6 +1715,7 @@ static inline void rdm_ep_poll_ibv_cq_ex(struct rxr_ep *ep, size_t cqe_to_proces
 			ep->recv_comps++;
 #endif
 			break;
+		case IBV_WC_RDMA_READ:
 		case IBV_WC_RDMA_WRITE:
 			pkt_entry = (void *)(uintptr_t)ep->ibv_cq_ex->wr_id;
 			rxr_pkt_handle_rma_completion(ep, pkt_entry);


### PR DESCRIPTION
Currently, rdma-core efa provider return IBV_WC_SEND as opcode of a read operation. This issue will be addressed in the future version of rdma-core.

This patch handle the IBV_WC_RDMA_READ opcode to prepare for the future rdma-core change.