### PR TITLE
prov/efa: Add rdma_core support for RDMA write

### DIFF
--- a/prov/efa/configure.m4
+++ b/prov/efa/configure.m4
@@ -75,14 +75,14 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 	AS_IF([test x"$enable_efa" != x"no"],
 	      [AC_CHECK_MEMBER(struct efadv_device_attr.max_rdma_size,
 			      [AC_DEFINE([HAVE_RDMA_SIZE], [1], [efadv_device_attr has max_rdma_size])],
-			      [],
+			      [AC_DEFINE([HAVE_RDMA_SIZE], [0], [efadv_device_attr does not have max_rdma_size])],
 			      [[#include <infiniband/efadv.h>]])
 	      ])
 
 	AS_IF([test x"$enable_efa" != x"no"],
 	      [AC_CHECK_DECL(EFADV_DEVICE_ATTR_CAPS_RNR_RETRY,
 			    [AC_DEFINE([HAVE_CAPS_RNR_RETRY], [1], [EFADV_DEVICE_ATTR_CAPS_RNR_RETRY is defined])],
-			    [],
+			    [AC_DEFINE([HAVE_CAPS_RNR_RETRY], [0], [EFADV_DEVICE_ATTR_CAPS_RNR_RETRY is not defined])],
 			    [[#include <infiniband/efadv.h>]])
 	      ])
 

--- a/prov/efa/configure.m4
+++ b/prov/efa/configure.m4
@@ -85,6 +85,13 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 			    [],
 			    [[#include <infiniband/efadv.h>]])
 	      ])
+
+	AS_IF([test x"$enable_efa" != x"no"],
+	      [AC_CHECK_DECL(EFADV_DEVICE_ATTR_CAPS_RDMA_WRITE,
+			    [AC_DEFINE([HAVE_CAPS_RDMA_WRITE], [1], [EFADV_DEVICE_ATTR_CAPS_RDMA_WRITE is defined])],
+			    [AC_DEFINE([HAVE_CAPS_RDMA_WRITE], [0], [EFADV_DEVICE_ATTR_CAPS_RDMA_WRITE is not defined])],
+			    [[#include <infiniband/efadv.h>]])
+	      ])
 	CPPFLAGS=$save_CPPFLAGS
 
 	dnl Check for ibv_is_fork_initialized() in libibverbs

--- a/prov/efa/src/efa_device.c
+++ b/prov/efa/src/efa_device.c
@@ -121,7 +121,7 @@ int efa_device_construct(struct efa_device *efa_device,
 		goto err_close;
 	}
 
-#ifdef HAVE_RDMA_SIZE
+#if HAVE_RDMA_SIZE
 	efa_device->max_rdma_size = efa_device->efa_attr.max_rdma_size;
 	efa_device->device_caps = efa_device->efa_attr.device_caps;
 #else

--- a/prov/efa/src/efa_domain.h
+++ b/prov/efa/src/efa_domain.h
@@ -138,8 +138,14 @@ bool efa_domain_support_rdma_read(struct efa_domain *domain)
 static inline
 bool efa_domain_support_rdma_write(struct efa_domain *domain)
 {
-	/* Not yet supported in rdma-core. */
+	if (!domain->use_device_rdma)
+		return false;
+
+#if HAVE_CAPS_RDMA_WRITE
+	return domain->device->device_caps & EFADV_DEVICE_ATTR_CAPS_RDMA_WRITE;
+#else
 	return false;
+#endif
 }
 
 int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,

--- a/prov/efa/src/efa_domain.h
+++ b/prov/efa/src/efa_domain.h
@@ -105,7 +105,7 @@ struct fi_info *efa_domain_get_prov_info(struct efa_domain *efa_domain, enum fi_
 static inline
 bool efa_domain_support_rnr_retry_modify(struct efa_domain *domain)
 {
-#ifdef HAVE_CAPS_RNR_RETRY
+#if HAVE_CAPS_RNR_RETRY
 	return domain->device->device_caps & EFADV_DEVICE_ATTR_CAPS_RNR_RETRY;
 #else
 	return false;


### PR DESCRIPTION
During configure, check efadv.h to see if rdma-core is new enough to include the RDMA write capability flag.

If the flag is available, use it to check the device for RDMA write capability during runtime.