### PR TITLE
prov/tcp: Fix segfault accessing invalid fi_addr

### DIFF
--- a/prov/tcp/src/xnet_srx.c
+++ b/prov/tcp/src/xnet_srx.c
@@ -664,7 +664,9 @@ xnet_match_tag_addr(struct xnet_srx *srx, struct xnet_ep *ep, uint64_t tag)
 	struct slist_entry *item, *prev;
 
 	assert(xnet_progress_locked(xnet_srx2_progress(srx)));
-	queue = ofi_array_at(&srx->src_tag_queues, ep->peer->fi_addr);
+
+	queue = (ep->peer && ep->peer->fi_addr != FI_ADDR_NOTAVAIL) ?
+		ofi_array_at(&srx->src_tag_queues, ep->peer->fi_addr) : NULL;
 	if (!queue)
 		return xnet_match_tag(srx, ep, tag);
 


### PR DESCRIPTION
In xnet_match_tag_addr(), we lookup the tag queue based on the peer-> fi_addr.  However, there's no guarantee that the peer has been inserted into the AV.  This occurs during certain DAOS tests.  As a result, the tag queue is invalid, and trying to walk it can result in accessing invalid memory.

Add a check for a valid peer->fi_addr prior to checking for matches on the src queue.