### PR TITLE
core: Add coding style enforcement and update selected code areas

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,121 @@
+# copied from: https://github.com/torvalds/linux/blob/master/.clang-format
+#
+# SPDX-License-Identifier: GPL-2.0
+#
+# clang-format configuration file. Intended for clang-format >= 11.
+#
+# For more information, see:
+#
+#   Documentation/process/clang-format.rst
+#   https://clang.llvm.org/docs/ClangFormat.html
+#   https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+#
+---
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: true
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass: false
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterFunction: true
+  AfterNamespace: true
+  AfterObjCDeclaration: false
+  AfterStruct: false
+  AfterUnion: false
+  AfterExternBlock: false
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeComma
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: false
+ColumnLimit: 80
+CommentPragmas: '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 8
+ContinuationIndentWidth: 8
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat: false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: false
+
+IncludeBlocks: Preserve
+IncludeCategories:
+  - Regex: '.*'
+    Priority: 1
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: false
+IndentGotoLabels: false
+IndentPPDirectives: None
+IndentWidth: 8
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 8
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+
+# Taken from git's rules
+PenaltyBreakAssignment: 10
+PenaltyBreakBeforeFirstCallParameter: 30
+PenaltyBreakComment: 10
+PenaltyBreakFirstLessLess: 0
+PenaltyBreakString: 10
+PenaltyExcessCharacter: 100
+PenaltyReturnTypeOnItsOwnLine: 60
+
+PointerAlignment: Right
+ReflowComments: false
+SortIncludes: false
+SortUsingDeclarations: false
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatementsExceptForEachMacros
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: Cpp03
+TabWidth: 8
+UseTab: Always
+...

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,0 +1,17 @@
+name: clang-format Check
+on: [push, pull_request]
+jobs:
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        path:
+          - 'include'
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run clang-format style check for C/C++/Protobuf programs.
+      uses: jidicula/clang-format-action@v4.10.2
+      with:
+        clang-format-version: '14'
+        check-path: ${{ matrix.path }}

--- a/include/fasthash.h
+++ b/include/fasthash.h
@@ -39,7 +39,7 @@ extern "C" {
  * @len:  data size
  * @seed: the seed
  */
-	uint32_t fasthash32(const void *buf, size_t len, uint32_t seed);
+uint32_t fasthash32(const void *buf, size_t len, uint32_t seed);
 
 /**
  * fasthash64 - 64-bit implementation of fasthash
@@ -47,7 +47,7 @@ extern "C" {
  * @len:  data size
  * @seed: the seed
  */
-	uint64_t fasthash64(const void *buf, size_t len, uint64_t seed);
+uint64_t fasthash64(const void *buf, size_t len, uint64_t seed);
 
 #ifdef __cplusplus
 }

--- a/include/freebsd/osd.h
+++ b/include/freebsd/osd.h
@@ -46,12 +46,13 @@
 #define bswap_64 bswap64
 
 #define ENODATA ENOMSG
-#define HOST_NAME_MAX  128
+#define HOST_NAME_MAX 128
 #define SOL_TCP IPPROTO_TCP
 
 typedef cpuset_t cpu_set_t;
 
-static inline int ofi_shm_remap(struct util_shm *shm, size_t newsize, void **mapped)
+static inline int ofi_shm_remap(struct util_shm *shm, size_t newsize,
+				void **mapped)
 {
 	return -1;
 }
@@ -71,22 +72,18 @@ static inline size_t ofi_ifaddr_get_speed(struct ifaddrs *ifa)
 	return 0;
 }
 
-static inline ssize_t ofi_process_vm_readv(pid_t pid,
-			const struct iovec *local_iov,
-			unsigned long liovcnt,
-			const struct iovec *remote_iov,
-			unsigned long riovcnt,
-			unsigned long flags)
+static inline ssize_t
+ofi_process_vm_readv(pid_t pid, const struct iovec *local_iov,
+		     unsigned long liovcnt, const struct iovec *remote_iov,
+		     unsigned long riovcnt, unsigned long flags)
 {
 	return -FI_ENOSYS;
 }
 
-static inline size_t ofi_process_vm_writev(pid_t pid,
-			 const struct iovec *local_iov,
-			 unsigned long liovcnt,
-			 const struct iovec *remote_iov,
-			 unsigned long riovcnt,
-			 unsigned long flags)
+static inline size_t
+ofi_process_vm_writev(pid_t pid, const struct iovec *local_iov,
+		      unsigned long liovcnt, const struct iovec *remote_iov,
+		      unsigned long riovcnt, unsigned long flags)
 {
 	return -FI_ENOSYS;
 }
@@ -107,8 +104,9 @@ static inline ssize_t ofi_recv_socket(SOCKET fd, void *buf, size_t count,
 	return recv(fd, buf, count, flags);
 }
 
-static inline ssize_t ofi_recvfrom_socket(SOCKET fd, void *buf, size_t count, int flags,
-					  struct sockaddr *from, socklen_t *fromlen)
+static inline ssize_t ofi_recvfrom_socket(SOCKET fd, void *buf, size_t count,
+					  int flags, struct sockaddr *from,
+					  socklen_t *fromlen)
 {
 	return recvfrom(fd, buf, count, flags, from, fromlen);
 }
@@ -119,66 +117,67 @@ static inline ssize_t ofi_send_socket(SOCKET fd, const void *buf, size_t count,
 	return send(fd, buf, count, flags);
 }
 
-static inline ssize_t ofi_sendto_socket(SOCKET fd, const void *buf, size_t count, int flags,
-					const struct sockaddr *to, socklen_t tolen)
+static inline ssize_t ofi_sendto_socket(SOCKET fd, const void *buf,
+					size_t count, int flags,
+					const struct sockaddr *to,
+					socklen_t tolen)
 {
 	return sendto(fd, buf, count, flags, to, tolen);
 }
 
-static inline ssize_t ofi_writev_socket(SOCKET fd, struct iovec *iov, size_t iov_cnt)
+static inline ssize_t ofi_writev_socket(SOCKET fd, struct iovec *iov,
+					size_t iov_cnt)
 {
 	return writev(fd, iov, iov_cnt);
 }
 
-static inline ssize_t ofi_readv_socket(SOCKET fd, struct iovec *iov, int iov_cnt)
+static inline ssize_t ofi_readv_socket(SOCKET fd, struct iovec *iov,
+				       int iov_cnt)
 {
 	return readv(fd, iov, iov_cnt);
 }
 
-static inline ssize_t
-ofi_sendmsg_tcp(SOCKET fd, const struct msghdr *msg, int flags)
+static inline ssize_t ofi_sendmsg_tcp(SOCKET fd, const struct msghdr *msg,
+				      int flags)
 {
 	return sendmsg(fd, msg, flags);
 }
 
-static inline ssize_t
-ofi_recvmsg_tcp(SOCKET fd, struct msghdr *msg, int flags)
+static inline ssize_t ofi_recvmsg_tcp(SOCKET fd, struct msghdr *msg, int flags)
 {
 	return recvmsg(fd, msg, flags);
 }
 
-static inline ssize_t
-ofi_sendv_socket(SOCKET fd, const struct iovec *iov, size_t cnt, int flags)
+static inline ssize_t ofi_sendv_socket(SOCKET fd, const struct iovec *iov,
+				       size_t cnt, int flags)
 {
-       struct msghdr msg;
+	struct msghdr msg;
 
-       msg.msg_control = NULL;
-       msg.msg_controllen = 0;
-       msg.msg_flags = 0;
-       msg.msg_name = NULL;
-       msg.msg_namelen = 0;
-       msg.msg_iov = (struct iovec *) iov;
-       msg.msg_iovlen = cnt;
+	msg.msg_control = NULL;
+	msg.msg_controllen = 0;
+	msg.msg_flags = 0;
+	msg.msg_name = NULL;
+	msg.msg_namelen = 0;
+	msg.msg_iov = (struct iovec *)iov;
+	msg.msg_iovlen = cnt;
 
-       return ofi_sendmsg_tcp(fd, &msg, flags);
+	return ofi_sendmsg_tcp(fd, &msg, flags);
 }
 
-static inline ssize_t
-ofi_recvv_socket(SOCKET fd, const struct iovec *iov, size_t cnt, int flags)
+static inline ssize_t ofi_recvv_socket(SOCKET fd, const struct iovec *iov,
+				       size_t cnt, int flags)
 {
-       struct msghdr msg;
+	struct msghdr msg;
 
-       msg.msg_control = NULL;
-       msg.msg_controllen = 0;
-       msg.msg_flags = 0;
-       msg.msg_name = NULL;
-       msg.msg_namelen = 0;
-       msg.msg_iov = (struct iovec *) iov;
-       msg.msg_iovlen = cnt;
+	msg.msg_control = NULL;
+	msg.msg_controllen = 0;
+	msg.msg_flags = 0;
+	msg.msg_name = NULL;
+	msg.msg_namelen = 0;
+	msg.msg_iov = (struct iovec *)iov;
+	msg.msg_iovlen = cnt;
 
-       return ofi_recvmsg_tcp(fd, &msg, flags);
+	return ofi_recvmsg_tcp(fd, &msg, flags);
 }
 
 #endif /* _FREEBSD_OSD_H_ */
-
-

--- a/include/linux/osd.h
+++ b/include/linux/osd.h
@@ -52,9 +52,8 @@
 #include "unix/osd.h"
 #include "rdma/fi_errno.h"
 
-
-static inline int ofi_shm_remap(struct util_shm *shm,
-				size_t newsize, void **mapped)
+static inline int ofi_shm_remap(struct util_shm *shm, size_t newsize,
+				void **mapped)
 {
 	shm->ptr = mremap(shm->ptr, shm->size, newsize, 0);
 	shm->size = newsize;
@@ -92,30 +91,26 @@ static inline int ofi_hugepage_enabled(void)
 size_t ofi_ifaddr_get_speed(struct ifaddrs *ifa);
 
 #ifndef __NR_process_vm_readv
-# define __NR_process_vm_readv 310
+#define __NR_process_vm_readv 310
 #endif
 
 #ifndef __NR_process_vm_writev
-# define __NR_process_vm_writev 311
+#define __NR_process_vm_writev 311
 #endif
 
-static inline ssize_t ofi_process_vm_readv(pid_t pid,
-			const struct iovec *local_iov,
-			unsigned long liovcnt,
-			const struct iovec *remote_iov,
-			unsigned long riovcnt,
-			unsigned long flags)
+static inline ssize_t
+ofi_process_vm_readv(pid_t pid, const struct iovec *local_iov,
+		     unsigned long liovcnt, const struct iovec *remote_iov,
+		     unsigned long riovcnt, unsigned long flags)
 {
 	return syscall(__NR_process_vm_readv, pid, local_iov, liovcnt,
 		       remote_iov, riovcnt, flags);
 }
 
-static inline size_t ofi_process_vm_writev(pid_t pid,
-			 const struct iovec *local_iov,
-			 unsigned long liovcnt,
-			 const struct iovec *remote_iov,
-			 unsigned long riovcnt,
-			 unsigned long flags)
+static inline size_t
+ofi_process_vm_writev(pid_t pid, const struct iovec *local_iov,
+		      unsigned long liovcnt, const struct iovec *remote_iov,
+		      unsigned long riovcnt, unsigned long flags)
 {
 	return syscall(__NR_process_vm_writev, pid, local_iov, liovcnt,
 		       remote_iov, riovcnt, flags);
@@ -137,8 +132,9 @@ static inline ssize_t ofi_recv_socket(SOCKET fd, void *buf, size_t count,
 	return recv(fd, buf, count, flags);
 }
 
-static inline ssize_t ofi_recvfrom_socket(SOCKET fd, void *buf, size_t count, int flags,
-					  struct sockaddr *from, socklen_t *fromlen)
+static inline ssize_t ofi_recvfrom_socket(SOCKET fd, void *buf, size_t count,
+					  int flags, struct sockaddr *from,
+					  socklen_t *fromlen)
 {
 	return recvfrom(fd, buf, count, flags, from, fromlen);
 }
@@ -149,64 +145,67 @@ static inline ssize_t ofi_send_socket(SOCKET fd, const void *buf, size_t count,
 	return send(fd, buf, count, flags);
 }
 
-static inline ssize_t ofi_sendto_socket(SOCKET fd, const void *buf, size_t count, int flags,
-					const struct sockaddr *to, socklen_t tolen)
+static inline ssize_t ofi_sendto_socket(SOCKET fd, const void *buf,
+					size_t count, int flags,
+					const struct sockaddr *to,
+					socklen_t tolen)
 {
 	return sendto(fd, buf, count, flags, to, tolen);
 }
 
-static inline ssize_t ofi_writev_socket(SOCKET fd, struct iovec *iov, size_t iov_cnt)
+static inline ssize_t ofi_writev_socket(SOCKET fd, struct iovec *iov,
+					size_t iov_cnt)
 {
 	return writev(fd, iov, iov_cnt);
 }
 
-static inline ssize_t ofi_readv_socket(SOCKET fd, struct iovec *iov, int iov_cnt)
+static inline ssize_t ofi_readv_socket(SOCKET fd, struct iovec *iov,
+				       int iov_cnt)
 {
 	return readv(fd, iov, iov_cnt);
 }
 
-static inline ssize_t
-ofi_sendmsg_tcp(SOCKET fd, const struct msghdr *msg, int flags)
+static inline ssize_t ofi_sendmsg_tcp(SOCKET fd, const struct msghdr *msg,
+				      int flags)
 {
 	return sendmsg(fd, msg, flags);
 }
 
-static inline ssize_t
-ofi_recvmsg_tcp(SOCKET fd, struct msghdr *msg, int flags)
+static inline ssize_t ofi_recvmsg_tcp(SOCKET fd, struct msghdr *msg, int flags)
 {
 	return recvmsg(fd, msg, flags);
 }
 
-static inline ssize_t
-ofi_sendv_socket(SOCKET fd, const struct iovec *iov, size_t cnt, int flags)
+static inline ssize_t ofi_sendv_socket(SOCKET fd, const struct iovec *iov,
+				       size_t cnt, int flags)
 {
-       struct msghdr msg;
+	struct msghdr msg;
 
-       msg.msg_control = NULL;
-       msg.msg_controllen = 0;
-       msg.msg_flags = 0;
-       msg.msg_name = NULL;
-       msg.msg_namelen = 0;
-       msg.msg_iov = (struct iovec *) iov;
-       msg.msg_iovlen = cnt;
+	msg.msg_control = NULL;
+	msg.msg_controllen = 0;
+	msg.msg_flags = 0;
+	msg.msg_name = NULL;
+	msg.msg_namelen = 0;
+	msg.msg_iov = (struct iovec *)iov;
+	msg.msg_iovlen = cnt;
 
-       return ofi_sendmsg_tcp(fd, &msg, flags);
+	return ofi_sendmsg_tcp(fd, &msg, flags);
 }
 
-static inline ssize_t
-ofi_recvv_socket(SOCKET fd, const struct iovec *iov, size_t cnt, int flags)
+static inline ssize_t ofi_recvv_socket(SOCKET fd, const struct iovec *iov,
+				       size_t cnt, int flags)
 {
-       struct msghdr msg;
+	struct msghdr msg;
 
-       msg.msg_control = NULL;
-       msg.msg_controllen = 0;
-       msg.msg_flags = 0;
-       msg.msg_name = NULL;
-       msg.msg_namelen = 0;
-       msg.msg_iov = (struct iovec *) iov;
-       msg.msg_iovlen = cnt;
+	msg.msg_control = NULL;
+	msg.msg_controllen = 0;
+	msg.msg_flags = 0;
+	msg.msg_name = NULL;
+	msg.msg_namelen = 0;
+	msg.msg_iov = (struct iovec *)iov;
+	msg.msg_iovlen = cnt;
 
-       return ofi_recvmsg_tcp(fd, &msg, flags);
+	return ofi_recvmsg_tcp(fd, &msg, flags);
 }
 
 #endif /* _LINUX_OSD_H_ */

--- a/include/linux/rdpmc.h
+++ b/include/linux/rdpmc.h
@@ -22,7 +22,6 @@
 #include <linux/perf_event.h>
 #include <ofi_perf.h>
 
-
 struct rdpmc_ctx {
 	int fd;
 	struct perf_event_mmap_page *buf;
@@ -34,11 +33,9 @@ int rdpmc_open_attr(struct perf_event_attr *attr, struct rdpmc_ctx *ctx,
 void rdpmc_close(struct rdpmc_ctx *ctx);
 unsigned long long rdpmc_read(struct rdpmc_ctx *ctx);
 
-
 struct ofi_perf_ctx {
 	struct rdpmc_ctx ctx;
 };
-
 
 #endif /* HAVE_LINUX_PERF_RDPMC */
 

--- a/include/ofi.h
+++ b/include/ofi.h
@@ -60,117 +60,118 @@
 
 #include <ofi_osd.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /* For in-tree providers */
-#define OFI_VERSION_LATEST	FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION)
+#define OFI_VERSION_LATEST FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION)
 /* The lower minor digit is reserved for custom libfabric builds */
-#define OFI_VERSION_DEF_PROV \
+#define OFI_VERSION_DEF_PROV                                  \
 	FI_VERSION(FI_MAJOR_VERSION * 100 + FI_MINOR_VERSION, \
 		   FI_REVISION_VERSION * 10)
 
-#define OFI_GETINFO_INTERNAL	(1ULL << 58)
-#define OFI_CORE_PROV_ONLY	(1ULL << 59)
-#define OFI_GETINFO_HIDDEN	(1ULL << 60)
-#define OFI_OFFLOAD_PROV_ONLY	(1ULL << 61)
+#define OFI_GETINFO_INTERNAL (1ULL << 58)
+#define OFI_CORE_PROV_ONLY (1ULL << 59)
+#define OFI_GETINFO_HIDDEN (1ULL << 60)
+#define OFI_OFFLOAD_PROV_ONLY (1ULL << 61)
 
-#define OFI_ORDER_RAR_SET	(FI_ORDER_RAR | FI_ORDER_RMA_RAR | \
-				 FI_ORDER_ATOMIC_RAR)
-#define OFI_ORDER_RAW_SET	(FI_ORDER_RAW | FI_ORDER_RMA_RAW | \
-				 FI_ORDER_ATOMIC_RAW)
-#define OFI_ORDER_WAR_SET	(FI_ORDER_WAR | FI_ORDER_RMA_WAR | \
-				 FI_ORDER_ATOMIC_WAR)
-#define OFI_ORDER_WAW_SET	(FI_ORDER_WAW | FI_ORDER_RMA_WAW | \
-				 FI_ORDER_ATOMIC_WAW)
+#define OFI_ORDER_RAR_SET \
+	(FI_ORDER_RAR | FI_ORDER_RMA_RAR | FI_ORDER_ATOMIC_RAR)
+#define OFI_ORDER_RAW_SET \
+	(FI_ORDER_RAW | FI_ORDER_RMA_RAW | FI_ORDER_ATOMIC_RAW)
+#define OFI_ORDER_WAR_SET \
+	(FI_ORDER_WAR | FI_ORDER_RMA_WAR | FI_ORDER_ATOMIC_WAR)
+#define OFI_ORDER_WAW_SET \
+	(FI_ORDER_WAW | FI_ORDER_RMA_WAW | FI_ORDER_ATOMIC_WAW)
 
-#define OFI_PRIMARY_TX_CAPS \
-	(FI_MSG | FI_RMA | FI_TAGGED | FI_ATOMIC | FI_MULTICAST | \
-	 FI_READ | FI_WRITE | FI_SEND | \
-	 FI_COLLECTIVE | FI_NAMED_RX_CTX | FI_HMEM)
+#define OFI_PRIMARY_TX_CAPS                                                 \
+	(FI_MSG | FI_RMA | FI_TAGGED | FI_ATOMIC | FI_MULTICAST | FI_READ | \
+	 FI_WRITE | FI_SEND | FI_COLLECTIVE | FI_NAMED_RX_CTX | FI_HMEM)
 
-#define OFI_SECONDARY_TX_CAPS \
-	(FI_TRIGGER | FI_FENCE | FI_RMA_PMEM)
+#define OFI_SECONDARY_TX_CAPS (FI_TRIGGER | FI_FENCE | FI_RMA_PMEM)
 
-#define OFI_PRIMARY_RX_CAPS \
-	(FI_MSG | FI_RMA | FI_TAGGED | FI_ATOMIC | \
-	 FI_REMOTE_READ | FI_REMOTE_WRITE | FI_RECV | \
-	 FI_DIRECTED_RECV | FI_VARIABLE_MSG | \
+#define OFI_PRIMARY_RX_CAPS                                               \
+	(FI_MSG | FI_RMA | FI_TAGGED | FI_ATOMIC | FI_REMOTE_READ |       \
+	 FI_REMOTE_WRITE | FI_RECV | FI_DIRECTED_RECV | FI_VARIABLE_MSG | \
 	 FI_COLLECTIVE | FI_HMEM)
 
-#define OFI_SECONDARY_RX_CAPS \
-	(FI_MULTI_RECV | FI_TRIGGER | FI_RMA_PMEM | FI_SOURCE | \
-	 FI_RMA_EVENT | FI_SOURCE_ERR)
+#define OFI_SECONDARY_RX_CAPS                                                  \
+	(FI_MULTI_RECV | FI_TRIGGER | FI_RMA_PMEM | FI_SOURCE | FI_RMA_EVENT | \
+	 FI_SOURCE_ERR)
 
-#define OFI_PRIMARY_CAPS \
-	(OFI_PRIMARY_TX_CAPS | OFI_PRIMARY_RX_CAPS | \
-	 FI_REMOTE_COMM | FI_LOCAL_COMM)
+#define OFI_PRIMARY_CAPS                                              \
+	(OFI_PRIMARY_TX_CAPS | OFI_PRIMARY_RX_CAPS | FI_REMOTE_COMM | \
+	 FI_LOCAL_COMM)
 
 #define OFI_SECONDARY_CAPS \
-	(OFI_SECONDARY_TX_CAPS | OFI_SECONDARY_RX_CAPS | \
-	 FI_SHARED_AV)
+	(OFI_SECONDARY_TX_CAPS | OFI_SECONDARY_RX_CAPS | FI_SHARED_AV)
 
 #define OFI_TX_MSG_CAPS (FI_MSG | FI_SEND)
 #define OFI_RX_MSG_CAPS (FI_MSG | FI_RECV)
 #define OFI_TX_RMA_CAPS (FI_RMA | FI_READ | FI_WRITE)
 #define OFI_RX_RMA_CAPS (FI_RMA | FI_REMOTE_READ | FI_REMOTE_WRITE)
 
-#define OFI_IGNORED_TX_CAPS /* older Rx caps not applicable to Tx */ \
+#define OFI_IGNORED_TX_CAPS /* older Rx caps not applicable to Tx */     \
 	(FI_REMOTE_READ | FI_REMOTE_WRITE | FI_RECV | FI_DIRECTED_RECV | \
-	 FI_VARIABLE_MSG | FI_MULTI_RECV | FI_SOURCE | FI_RMA_EVENT | \
+	 FI_VARIABLE_MSG | FI_MULTI_RECV | FI_SOURCE | FI_RMA_EVENT |    \
 	 FI_SOURCE_ERR)
 #define OFI_IGNORED_RX_CAPS /* Older Tx caps not applicable to Rx */ \
-	(FI_READ | FI_WRITE | FI_SEND | FI_FENCE | FI_MULTICAST | \
+	(FI_READ | FI_WRITE | FI_SEND | FI_FENCE | FI_MULTICAST |    \
 	 FI_NAMED_RX_CTX)
 
-#define OFI_TX_OP_FLAGS \
+#define OFI_TX_OP_FLAGS                                              \
 	(FI_COMMIT_COMPLETE | FI_COMPLETION | FI_DELIVERY_COMPLETE | \
 	 FI_INJECT | FI_INJECT_COMPLETE | FI_MULTICAST | FI_TRANSMIT_COMPLETE)
 
-#define OFI_RX_OP_FLAGS \
-	(FI_COMPLETION | FI_MULTI_RECV)
-
+#define OFI_RX_OP_FLAGS (FI_COMPLETION | FI_MULTI_RECV)
 
 #define sizeof_field(type, field) sizeof(((type *)0)->field)
 
 #ifndef MIN
-#define MIN(a, b) \
-	({ typeof (a) _a = (a); \
-		typeof (b) _b = (b); \
-		_a < _b ? _a : _b; })
+#define MIN(a, b)                   \
+	({                          \
+		typeof(a) _a = (a); \
+		typeof(b) _b = (b); \
+		_a < _b ? _a : _b;  \
+	})
 #endif
 
 #ifndef MAX
-#define MAX(a, b) \
-	({ typeof (a) _a = (a); \
-		typeof (b) _b = (b); \
-		_a > _b ? _a : _b; })
+#define MAX(a, b)                   \
+	({                          \
+		typeof(a) _a = (a); \
+		typeof(b) _b = (b); \
+		_a > _b ? _a : _b;  \
+	})
 #endif
 
 #define ofi_div_ceil(a, b) ((a + b - 1) / b)
 
-static inline int ofi_val64_gt(uint64_t x, uint64_t y) {
-	return ((int64_t) (x - y)) > 0;
+static inline int ofi_val64_gt(uint64_t x, uint64_t y)
+{
+	return ((int64_t)(x - y)) > 0;
 }
-static inline int ofi_val64_ge(uint64_t x, uint64_t y) {
-	return ((int64_t) (x - y)) >= 0;
+static inline int ofi_val64_ge(uint64_t x, uint64_t y)
+{
+	return ((int64_t)(x - y)) >= 0;
 }
 #define ofi_val64_lt(x, y) ofi_val64_gt(y, x)
 
-static inline int ofi_val32_gt(uint32_t x, uint32_t y) {
-	return ((int32_t) (x - y)) > 0;
+static inline int ofi_val32_gt(uint32_t x, uint32_t y)
+{
+	return ((int32_t)(x - y)) > 0;
 }
-static inline int ofi_val32_ge(uint32_t x, uint32_t y) {
-	return ((int32_t) (x - y)) >= 0;
+static inline int ofi_val32_ge(uint32_t x, uint32_t y)
+{
+	return ((int32_t)(x - y)) >= 0;
 }
 #define ofi_val32_lt(x, y) ofi_val32_gt(y, x)
 
 #define ofi_val32_inrange(start, length, value) \
-    ofi_val32_ge(value, start) && ofi_val32_lt(value, start + length)
+	ofi_val32_ge(value, start) && ofi_val32_lt(value, start + length)
 #define ofi_val64_inrange(start, length, value) \
-    ofi_val64_ge(value, start) && ofi_val64_lt(value, start + length)
+	ofi_val64_ge(value, start) && ofi_val64_lt(value, start + length)
 
 #ifndef BIT
 #define BIT(nr) (1UL << (nr))
@@ -199,11 +200,16 @@ static inline int ofi_val32_ge(uint32_t x, uint32_t y) {
 
 #define TAB "    "
 
-#define CASEENUMSTRN(SYM, N) \
-	case SYM: { ofi_strncatf(buf, N, #SYM); break; }
-#define IFFLAGSTRN(flags, SYM, N) \
-	do { if (flags & SYM) ofi_strncatf(buf, N, #SYM ", "); } while(0)
-
+#define CASEENUMSTRN(SYM, N)                \
+	case SYM: {                         \
+		ofi_strncatf(buf, N, #SYM); \
+		break;                      \
+	}
+#define IFFLAGSTRN(flags, SYM, N)                        \
+	do {                                             \
+		if (flags & SYM)                         \
+			ofi_strncatf(buf, N, #SYM ", "); \
+	} while (0)
 
 /*
  * CPU specific features
@@ -211,16 +217,15 @@ static inline int ofi_val32_ge(uint32_t x, uint32_t y) {
 
 /* X86_64 */
 enum {
-	OFI_CLWB_REG		= 1,
-	OFI_CLWB_BIT		= (1 << 24),
-	OFI_CLFLUSHOPT_REG	= 1,
-	OFI_CLFLUSHOPT_BIT	= (1 << 23),
-	OFI_CLFLUSH_REG		= 3,
-	OFI_CLFLUSH_BIT		= (1 << 19),
+	OFI_CLWB_REG = 1,
+	OFI_CLWB_BIT = (1 << 24),
+	OFI_CLFLUSHOPT_REG = 1,
+	OFI_CLFLUSHOPT_BIT = (1 << 23),
+	OFI_CLFLUSH_REG = 3,
+	OFI_CLFLUSH_BIT = (1 << 19),
 };
 
 int ofi_cpu_supports(unsigned func, unsigned reg, unsigned bit);
-
 
 enum ofi_prov_type {
 	OFI_PROV_CORE,
@@ -233,13 +238,13 @@ enum ofi_prov_type {
 struct ofi_prov_context {
 	enum ofi_prov_type type;
 	bool disable_logging;
-	bool disable_layering;	/* applies to core providers only */
+	bool disable_layering; /* applies to core providers only */
 };
 
 static inline struct ofi_prov_context *
 ofi_prov_ctx(const struct fi_provider *prov)
 {
-	return (struct ofi_prov_context *) &prov->context;
+	return (struct ofi_prov_context *)&prov->context;
 }
 
 struct ofi_filter {
@@ -269,7 +274,7 @@ void ofi_strncatf(char *dest, size_t n, const char *fmt, ...);
 
 const char *ofi_hex_str(const uint8_t *data, size_t len);
 
-#define MAX_IPC_HANDLE_SIZE	64
+#define MAX_IPC_HANDLE_SIZE 64
 
 /*
  * This structure is part of the
@@ -281,12 +286,12 @@ const char *ofi_hex_str(const uint8_t *data, size_t len);
  * structure.
  */
 struct ipc_info {
-	uint64_t	iface;
-	uint64_t	base_addr;
-	uint64_t	base_length;
-	uint64_t	device;
-	uint64_t	offset;
-	uint8_t		ipc_handle[MAX_IPC_HANDLE_SIZE];
+	uint64_t iface;
+	uint64_t base_addr;
+	uint64_t base_length;
+	uint64_t device;
+	uint64_t offset;
+	uint8_t ipc_handle[MAX_IPC_HANDLE_SIZE];
 };
 
 static inline uint64_t roundup_power_of_two(uint64_t n)
@@ -312,35 +317,36 @@ static inline uint64_t rounddown_power_of_two(uint64_t n)
 
 static inline size_t ofi_get_aligned_size(size_t size, size_t alignment)
 {
-	return ((size % alignment) == 0) ?
-		size : ((size / alignment) + 1) * alignment;
+	return ((size % alignment) == 0) ? size :
+					   ((size / alignment) + 1) * alignment;
 }
 
 static inline void *ofi_get_page_start(const void *addr, size_t page_size)
 {
-	return (void *)((uintptr_t) addr & ~(page_size - 1));
+	return (void *)((uintptr_t)addr & ~(page_size - 1));
 }
 
 static inline void *ofi_get_page_end(const void *addr, size_t page_size)
 {
-	return (void *)((uintptr_t)ofi_get_page_start((const char *)addr
-			+ page_size, page_size) - 1);
+	return (void *)((uintptr_t)ofi_get_page_start(
+				(const char *)addr + page_size, page_size) -
+			1);
 }
 
-static inline size_t
-ofi_get_page_bytes(const void *addr, size_t len, size_t page_size)
+static inline size_t ofi_get_page_bytes(const void *addr, size_t len,
+					size_t page_size)
 {
 	char *start = (char *)ofi_get_page_start(addr, page_size);
-	char *end = (char *)ofi_get_page_start((const char*)addr + len - 1, page_size)
-		    + page_size;
+	char *end = (char *)ofi_get_page_start((const char *)addr + len - 1,
+					       page_size) +
+		    page_size;
 	size_t result = end - start;
 
 	assert(result % page_size == 0);
 	return result;
 }
 
-#define FI_TAG_GENERIC	0xAAAAAAAAAAAAAAAAULL
-
+#define FI_TAG_GENERIC 0xAAAAAAAAAAAAAAAAULL
 
 uint64_t ofi_max_tag(uint64_t mem_tag_format);
 uint64_t ofi_tag_format(uint64_t max_tag);
@@ -374,7 +380,7 @@ static inline uint64_t ofi_timeout_time(int timeout)
 static inline int ofi_adjust_timeout(uint64_t timeout_time, int *timeout)
 {
 	if (*timeout >= 0) {
-		*timeout = (int) (timeout_time - ofi_gettime_ms());
+		*timeout = (int)(timeout_time - ofi_gettime_ms());
 		return (*timeout <= 0) ? -FI_ETIMEDOUT : 0;
 	}
 	return 0;
@@ -383,7 +389,6 @@ static inline int ofi_adjust_timeout(uint64_t timeout_time, int *timeout)
 #define OFI_ENUM_VAL(X) X
 #define OFI_STR(X) #X
 #define OFI_STR_INT(X) OFI_STR(X)
-
 
 /*
  * Key Index
@@ -403,7 +408,8 @@ struct ofi_key_idx {
 	uint8_t idx_bits;
 };
 
-static inline void ofi_key_idx_init(struct ofi_key_idx *key_idx, uint8_t idx_bits)
+static inline void ofi_key_idx_init(struct ofi_key_idx *key_idx,
+				    uint8_t idx_bits)
 {
 	key_idx->seq_no = 0;
 	key_idx->idx_bits = idx_bits;
@@ -447,8 +453,8 @@ uint32_t ofi_generate_seed(void);
 
 size_t ofi_vrb_speed(uint8_t speed, uint8_t width);
 
-int ofi_open_log(uint32_t version, void *attr, size_t attr_len,
-		 uint64_t flags, struct fid **fid, void *context);
+int ofi_open_log(uint32_t version, void *attr, size_t attr_len, uint64_t flags,
+		 struct fid **fid, void *context);
 void ofi_tostr_log_level(char *buf, size_t len, enum fi_log_level level);
 void ofi_tostr_log_subsys(char *buf, size_t len, enum fi_log_subsys subsys);
 

--- a/include/ofi_abi.h
+++ b/include/ofi_abi.h
@@ -37,11 +37,9 @@
 
 #include <ofi_osd.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
-
 
 /*
  * ABI version support definitions.
@@ -113,7 +111,7 @@ extern "C" {
 
 #define CURRENT_ABI "FABRIC_1.6"
 
-#if  HAVE_ALIAS_ATTRIBUTE == 1
+#if HAVE_ALIAS_ATTRIBUTE == 1
 #define DEFAULT_SYMVER_PRE(a) a##_
 #else
 #define DEFAULT_SYMVER_PRE(a) a
@@ -135,35 +133,33 @@ extern "C" {
 
 #if HAVE_ALIAS_ATTRIBUTE == 1
 #define DEFAULT_SYMVER(name, api, ver) \
-	extern typeof (name) api __attribute__((alias(#name)));
+	extern typeof(name) api __attribute__((alias(#name)));
 #define CURRENT_SYMVER(name, api) \
-	extern typeof (name) api __attribute__((alias(#name)));
+	extern typeof(name) api __attribute__((alias(#name)));
 #else
 #define DEFAULT_SYMVER(name, api, ver)
 #define CURRENT_SYMVER(name, api)
-#endif  /* HAVE_ALIAS_ATTRIBUTE == 1*/
+#endif /* HAVE_ALIAS_ATTRIBUTE == 1*/
 
 #endif /* HAVE_SYMVER_SUPPORT */
-
 
 /*
  * The conversion from abi 1.0 requires being able to cast from a newer
  * structure back to the older version.
  */
 struct fi_cq_err_entry_1_0 {
-	void			*op_context;
-	uint64_t		flags;
-	size_t			len;
-	void			*buf;
-	uint64_t		data;
-	uint64_t		tag;
-	size_t			olen;
-	int			err;
-	int			prov_errno;
+	void *op_context;
+	uint64_t flags;
+	size_t len;
+	void *buf;
+	uint64_t data;
+	uint64_t tag;
+	size_t olen;
+	int err;
+	int prov_errno;
 	/* err_data is available until the next time the CQ is read */
-	void			*err_data;
+	void *err_data;
 };
-
 
 #ifdef __cplusplus
 }

--- a/include/ofi_atom.h
+++ b/include/ofi_atom.h
@@ -44,14 +44,12 @@
 #include <ofi_osd.h>
 
 #ifdef HAVE_ATOMICS
-#  include <stdatomic.h>
+#include <stdatomic.h>
 #endif
-
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
 
 #if ENABLE_DEBUG
 #define ATOMIC_DEF_INIT int is_initialized
@@ -65,82 +63,85 @@ extern "C" {
 
 #ifdef HAVE_ATOMICS
 #ifdef HAVE_ATOMICS_LEAST_TYPES
-typedef atomic_int_least32_t	ofi_atomic_int32_t;
-typedef atomic_int_least64_t	ofi_atomic_int64_t;
+typedef atomic_int_least32_t ofi_atomic_int32_t;
+typedef atomic_int_least64_t ofi_atomic_int64_t;
 #else
-typedef atomic_int	ofi_atomic_int32_t;
-typedef atomic_long	ofi_atomic_int64_t;
+typedef atomic_int ofi_atomic_int32_t;
+typedef atomic_long ofi_atomic_int64_t;
 #endif
 
-#define OFI_ATOMIC_DEFINE(radix)									\
-	typedef struct {										\
-		ofi_atomic_int##radix##_t val;								\
-		ATOMIC_DEF_INIT;									\
-	} ofi_atomic##radix##_t;									\
-													\
-	static inline											\
-	int##radix##_t ofi_atomic_inc##radix(ofi_atomic##radix##_t *atomic)				\
-	{												\
-		ATOMIC_IS_INITIALIZED(atomic);								\
-		return (int##radix##_t)atomic_fetch_add_explicit(&atomic->val, 1,			\
-								 memory_order_acq_rel) + 1;		\
-	}												\
-	static inline											\
-	int##radix##_t ofi_atomic_dec##radix(ofi_atomic##radix##_t *atomic)				\
-	{												\
-		ATOMIC_IS_INITIALIZED(atomic);								\
-		return (int##radix##_t)atomic_fetch_sub_explicit(&atomic->val, 1,			\
-								 memory_order_acq_rel) - 1;		\
-	}												\
-	static inline											\
-	int##radix##_t ofi_atomic_set##radix(ofi_atomic##radix##_t *atomic, int##radix##_t value)	\
-	{												\
-		ATOMIC_IS_INITIALIZED(atomic);								\
-		atomic_store(&atomic->val, value);							\
-		return (int##radix##_t)value;								\
-	}												\
-	static inline											\
-	int##radix##_t ofi_atomic_get##radix(ofi_atomic##radix##_t *atomic)				\
-	{												\
-		ATOMIC_IS_INITIALIZED(atomic);								\
-		return (int##radix##_t)atomic_load(&atomic->val);					\
-	}												\
-	static inline											\
-	void ofi_atomic_initialize##radix(ofi_atomic##radix##_t *atomic, int##radix##_t value)		\
-	{												\
-		atomic_init(&atomic->val, value);							\
-		ATOMIC_INIT(atomic);									\
-	}												\
-	static inline											\
-	int##radix##_t ofi_atomic_add##radix(ofi_atomic##radix##_t *atomic, int##radix##_t val)		\
-	{												\
-		ATOMIC_IS_INITIALIZED(atomic);								\
-		return (int##radix##_t)atomic_fetch_add_explicit(&atomic->val, val,			\
-								 memory_order_acq_rel) + val;		\
-	}												\
-	static inline											\
-	int##radix##_t ofi_atomic_sub##radix(ofi_atomic##radix##_t *atomic, int##radix##_t val)		\
-	{												\
-		ATOMIC_IS_INITIALIZED(atomic);								\
-		return (int##radix##_t)atomic_fetch_sub_explicit(&atomic->val, val,			\
-								 memory_order_acq_rel) - val;		\
-	}												\
+#define OFI_ATOMIC_DEFINE(radix)                                           \
+	typedef struct {                                                   \
+		ofi_atomic_int##radix##_t val;                             \
+		ATOMIC_DEF_INIT;                                           \
+	} ofi_atomic##radix##_t;                                           \
+                                                                           \
+	static inline int##radix##_t ofi_atomic_inc##radix(                \
+		ofi_atomic##radix##_t *atomic)                             \
+	{                                                                  \
+		ATOMIC_IS_INITIALIZED(atomic);                             \
+		return (int##radix##_t)atomic_fetch_add_explicit(          \
+			       &atomic->val, 1, memory_order_acq_rel) +    \
+		       1;                                                  \
+	}                                                                  \
+	static inline int##radix##_t ofi_atomic_dec##radix(                \
+		ofi_atomic##radix##_t *atomic)                             \
+	{                                                                  \
+		ATOMIC_IS_INITIALIZED(atomic);                             \
+		return (int##radix##_t)atomic_fetch_sub_explicit(          \
+			       &atomic->val, 1, memory_order_acq_rel) -    \
+		       1;                                                  \
+	}                                                                  \
+	static inline int##radix##_t ofi_atomic_set##radix(                \
+		ofi_atomic##radix##_t *atomic, int##radix##_t value)       \
+	{                                                                  \
+		ATOMIC_IS_INITIALIZED(atomic);                             \
+		atomic_store(&atomic->val, value);                         \
+		return (int##radix##_t)value;                              \
+	}                                                                  \
+	static inline int##radix##_t ofi_atomic_get##radix(                \
+		ofi_atomic##radix##_t *atomic)                             \
+	{                                                                  \
+		ATOMIC_IS_INITIALIZED(atomic);                             \
+		return (int##radix##_t)atomic_load(&atomic->val);          \
+	}                                                                  \
+	static inline void ofi_atomic_initialize##radix(                   \
+		ofi_atomic##radix##_t *atomic, int##radix##_t value)       \
+	{                                                                  \
+		atomic_init(&atomic->val, value);                          \
+		ATOMIC_INIT(atomic);                                       \
+	}                                                                  \
+	static inline int##radix##_t ofi_atomic_add##radix(                \
+		ofi_atomic##radix##_t *atomic, int##radix##_t val)         \
+	{                                                                  \
+		ATOMIC_IS_INITIALIZED(atomic);                             \
+		return (int##radix##_t)atomic_fetch_add_explicit(          \
+			       &atomic->val, val, memory_order_acq_rel) +  \
+		       val;                                                \
+	}                                                                  \
+	static inline int##radix##_t ofi_atomic_sub##radix(                \
+		ofi_atomic##radix##_t *atomic, int##radix##_t val)         \
+	{                                                                  \
+		ATOMIC_IS_INITIALIZED(atomic);                             \
+		return (int##radix##_t)atomic_fetch_sub_explicit(          \
+			       &atomic->val, val, memory_order_acq_rel) -  \
+		       val;                                                \
+	}                                                                  \
 	/**												\
 	 *  Compare and swap, strong version								\
 	 *												\
 	 *  @return true if atomic matches expected and the change is done, false			\
 	 *   otherwise.											\
-	 */												\
-	static inline											\
-	bool ofi_atomic_cas_bool_strong##radix(ofi_atomic##radix##_t *atomic, 				\
-						      int##radix##_t expected, 				\
-						      int##radix##_t desired)				\
-	{												\
-		ATOMIC_IS_INITIALIZED(atomic);								\
-		return atomic_compare_exchange_strong_explicit(&atomic->val, &expected, desired,	\
-							       memory_order_acq_rel,			\
-							       memory_order_relaxed);			\
-	}												\
+	 */                                                   \
+	static inline bool ofi_atomic_cas_bool_strong##radix(              \
+		ofi_atomic##radix##_t *atomic, int##radix##_t expected,    \
+		int##radix##_t desired)                                    \
+	{                                                                  \
+		ATOMIC_IS_INITIALIZED(atomic);                             \
+		return atomic_compare_exchange_strong_explicit(            \
+			&atomic->val, &expected, desired,                  \
+			memory_order_acq_rel, memory_order_relaxed);       \
+	}                                                                  \
 	/**												\
 	 *  Compare and swap, weak version								\
 	 *												\
@@ -148,213 +149,205 @@ typedef atomic_long	ofi_atomic_int64_t;
 	 *   otherwise.											\
 	 *   This is the weak version and may incorrectly report a failed match.			\
 	 *   As a result it is most useful in loops that wait until the check succeeds.			\
-	 */												\
-	 static inline											\
-	 bool ofi_atomic_cas_bool_weak##radix(ofi_atomic##radix##_t *atomic, 				\
-					      int##radix##_t expected, 					\
-					      int##radix##_t desired)					\
-	{												\
-		ATOMIC_IS_INITIALIZED(atomic);								\
-		return atomic_compare_exchange_weak_explicit(&atomic->val, 				\
-							     &expected, desired,			\
-							     memory_order_acq_rel,			\
-							     memory_order_relaxed);			\
-	}												\
-	static inline											\
-	bool ofi_atomic_cas_bool##radix(ofi_atomic##radix##_t *atomic, 					\
-					int##radix##_t expected, 					\
-					int##radix##_t desired)						\
-	{												\
-		return ofi_atomic_cas_bool_strong##radix(atomic, expected, desired);			\
+	 */                                                   \
+	static inline bool ofi_atomic_cas_bool_weak##radix(                \
+		ofi_atomic##radix##_t *atomic, int##radix##_t expected,    \
+		int##radix##_t desired)                                    \
+	{                                                                  \
+		ATOMIC_IS_INITIALIZED(atomic);                             \
+		return atomic_compare_exchange_weak_explicit(              \
+			&atomic->val, &expected, desired,                  \
+			memory_order_acq_rel, memory_order_relaxed);       \
+	}                                                                  \
+	static inline bool ofi_atomic_cas_bool##radix(                     \
+		ofi_atomic##radix##_t *atomic, int##radix##_t expected,    \
+		int##radix##_t desired)                                    \
+	{                                                                  \
+		return ofi_atomic_cas_bool_strong##radix(atomic, expected, \
+							 desired);         \
 	}
 
 #elif defined HAVE_BUILTIN_ATOMICS
-#  if ENABLE_DEBUG
-#    define ATOMIC_T(radix)		\
-	struct {			\
-		int##radix##_t val;	\
-		ATOMIC_DEF_INIT;	\
+#if ENABLE_DEBUG
+#define ATOMIC_T(radix)             \
+	struct {                    \
+		int##radix##_t val; \
+		ATOMIC_DEF_INIT;    \
 	}
 
-#    define ofi_atomic_ptr(atomic) (&((atomic)->val))
-#  else
-#    define ATOMIC_T(radix) int##radix##_t
-#    define ofi_atomic_ptr(atomic) (atomic)
-#  endif
+#define ofi_atomic_ptr(atomic) (&((atomic)->val))
+#else
+#define ATOMIC_T(radix) int##radix##_t
+#define ofi_atomic_ptr(atomic) (atomic)
+#endif
 
-#define OFI_ATOMIC_DEFINE(radix)									\
-	typedef ATOMIC_T(radix) ofi_atomic##radix##_t;							\
-													\
-	static inline											\
-	int##radix##_t ofi_atomic_add##radix(ofi_atomic##radix##_t *atomic, int##radix##_t val)		\
-	{												\
-		ATOMIC_IS_INITIALIZED(atomic);								\
-		return (int##radix##_t)ofi_atomic_add_and_fetch(radix, ofi_atomic_ptr(atomic), val);	\
-	}												\
-	static inline											\
-	int##radix##_t ofi_atomic_sub##radix(ofi_atomic##radix##_t *atomic, int##radix##_t val)		\
-	{												\
-		ATOMIC_IS_INITIALIZED(atomic);								\
-		return (int##radix##_t)ofi_atomic_sub_and_fetch(radix, ofi_atomic_ptr(atomic), val);	\
-	}												\
-	static inline											\
-	int##radix##_t ofi_atomic_inc##radix(ofi_atomic##radix##_t *atomic)				\
-	{												\
-		ATOMIC_IS_INITIALIZED(atomic);								\
-		return ofi_atomic_add##radix(atomic, 1);						\
-	}												\
-	static inline											\
-	int##radix##_t ofi_atomic_dec##radix(ofi_atomic##radix##_t *atomic)				\
-	{												\
-		ATOMIC_IS_INITIALIZED(atomic);								\
-		return ofi_atomic_sub##radix(atomic, 1);						\
-	}												\
-	static inline											\
-	int##radix##_t ofi_atomic_set##radix(ofi_atomic##radix##_t *atomic, int##radix##_t value)	\
-	{												\
-		ATOMIC_IS_INITIALIZED(atomic);								\
-		*(ofi_atomic_ptr(atomic)) = value;							\
-		return value;										\
-	}												\
-	static inline											\
-	int##radix##_t ofi_atomic_get##radix(ofi_atomic##radix##_t *atomic)				\
-	{												\
-		ATOMIC_IS_INITIALIZED(atomic);								\
-		return *ofi_atomic_ptr(atomic);								\
-	}												\
-	static inline											\
-	void ofi_atomic_initialize##radix(ofi_atomic##radix##_t *atomic, int##radix##_t value)		\
-	{												\
-		*(ofi_atomic_ptr(atomic)) = value;							\
-		ATOMIC_INIT(atomic);									\
-	}												\
-	static inline											\
-	bool ofi_atomic_cas_bool##radix(ofi_atomic##radix##_t *atomic, 					\
-					int##radix##_t expected,					\
-					int##radix##_t desired)						\
-	{												\
-		 ATOMIC_IS_INITIALIZED(atomic);								\
-		 return ofi_atomic_cas_bool(radix, ofi_atomic_ptr(atomic), expected, desired);		\
-	}												\
-	static inline											\
-	bool ofi_atomic_cas_bool_strong##radix(ofi_atomic##radix##_t *atomic, 				\
-					       int##radix##_t expected,					\
-					       int##radix##_t desired)					\
-	{												\
-		return ofi_atomic_cas_bool##radix(atomic, expected, desired);				\
-	}												\
-	static inline											\
-	bool ofi_atomic_cas_bool_weak##radix(ofi_atomic##radix##_t *atomic, 				\
-					     int##radix##_t expected,					\
-					     int##radix##_t desired)					\
-	{												\
-		return ofi_atomic_cas_bool##radix(atomic, expected, desired);				\
+#define OFI_ATOMIC_DEFINE(radix)                                              \
+	typedef ATOMIC_T(radix) ofi_atomic##radix##_t;                        \
+                                                                              \
+	static inline int##radix##_t ofi_atomic_add##radix(                   \
+		ofi_atomic##radix##_t *atomic, int##radix##_t val)            \
+	{                                                                     \
+		ATOMIC_IS_INITIALIZED(atomic);                                \
+		return (int##radix##_t)ofi_atomic_add_and_fetch(              \
+			radix, ofi_atomic_ptr(atomic), val);                  \
+	}                                                                     \
+	static inline int##radix##_t ofi_atomic_sub##radix(                   \
+		ofi_atomic##radix##_t *atomic, int##radix##_t val)            \
+	{                                                                     \
+		ATOMIC_IS_INITIALIZED(atomic);                                \
+		return (int##radix##_t)ofi_atomic_sub_and_fetch(              \
+			radix, ofi_atomic_ptr(atomic), val);                  \
+	}                                                                     \
+	static inline int##radix##_t ofi_atomic_inc##radix(                   \
+		ofi_atomic##radix##_t *atomic)                                \
+	{                                                                     \
+		ATOMIC_IS_INITIALIZED(atomic);                                \
+		return ofi_atomic_add##radix(atomic, 1);                      \
+	}                                                                     \
+	static inline int##radix##_t ofi_atomic_dec##radix(                   \
+		ofi_atomic##radix##_t *atomic)                                \
+	{                                                                     \
+		ATOMIC_IS_INITIALIZED(atomic);                                \
+		return ofi_atomic_sub##radix(atomic, 1);                      \
+	}                                                                     \
+	static inline int##radix##_t ofi_atomic_set##radix(                   \
+		ofi_atomic##radix##_t *atomic, int##radix##_t value)          \
+	{                                                                     \
+		ATOMIC_IS_INITIALIZED(atomic);                                \
+		*(ofi_atomic_ptr(atomic)) = value;                            \
+		return value;                                                 \
+	}                                                                     \
+	static inline int##radix##_t ofi_atomic_get##radix(                   \
+		ofi_atomic##radix##_t *atomic)                                \
+	{                                                                     \
+		ATOMIC_IS_INITIALIZED(atomic);                                \
+		return *ofi_atomic_ptr(atomic);                               \
+	}                                                                     \
+	static inline void ofi_atomic_initialize##radix(                      \
+		ofi_atomic##radix##_t *atomic, int##radix##_t value)          \
+	{                                                                     \
+		*(ofi_atomic_ptr(atomic)) = value;                            \
+		ATOMIC_INIT(atomic);                                          \
+	}                                                                     \
+	static inline bool ofi_atomic_cas_bool##radix(                        \
+		ofi_atomic##radix##_t *atomic, int##radix##_t expected,       \
+		int##radix##_t desired)                                       \
+	{                                                                     \
+		ATOMIC_IS_INITIALIZED(atomic);                                \
+		return ofi_atomic_cas_bool(radix, ofi_atomic_ptr(atomic),     \
+					   expected, desired);                \
+	}                                                                     \
+	static inline bool ofi_atomic_cas_bool_strong##radix(                 \
+		ofi_atomic##radix##_t *atomic, int##radix##_t expected,       \
+		int##radix##_t desired)                                       \
+	{                                                                     \
+		return ofi_atomic_cas_bool##radix(atomic, expected, desired); \
+	}                                                                     \
+	static inline bool ofi_atomic_cas_bool_weak##radix(                   \
+		ofi_atomic##radix##_t *atomic, int##radix##_t expected,       \
+		int##radix##_t desired)                                       \
+	{                                                                     \
+		return ofi_atomic_cas_bool##radix(atomic, expected, desired); \
 	}
 
 #else /* HAVE_ATOMICS */
 
-#define OFI_ATOMIC_DEFINE(radix)								\
-	typedef	struct {									\
-		ofi_spin_t lock;								\
-		int##radix##_t val;								\
-		ATOMIC_DEF_INIT;								\
-	} ofi_atomic##radix##_t;								\
-												\
-	static inline										\
-	int##radix##_t ofi_atomic_inc##radix(ofi_atomic##radix##_t *atomic)			\
-	{											\
-		int##radix##_t v = 0;								\
-		ATOMIC_IS_INITIALIZED(atomic);							\
-		ofi_spin_lock(&atomic->lock);						\
-		v = ++(atomic->val);								\
-		ofi_spin_unlock(&atomic->lock);						\
-		return v;									\
-	}											\
-	static inline										\
-	int##radix##_t ofi_atomic_dec##radix(ofi_atomic##radix##_t *atomic)			\
-	{											\
-		int##radix##_t v = 0;								\
-		ATOMIC_IS_INITIALIZED(atomic);							\
-		ofi_spin_lock(&atomic->lock);						\
-		v = --(atomic->val);								\
-		ofi_spin_unlock(&atomic->lock);						\
-		return v;									\
-	}											\
-	static inline										\
-	int##radix##_t ofi_atomic_set##radix(ofi_atomic##radix##_t *atomic,			\
-					     int##radix##_t value)				\
-	{											\
-		ATOMIC_IS_INITIALIZED(atomic);							\
-		ofi_spin_lock(&atomic->lock);						\
-		atomic->val = value;								\
-		ofi_spin_unlock(&atomic->lock);						\
-		return value;									\
-	}											\
-	static inline int##radix##_t ofi_atomic_get##radix(ofi_atomic##radix##_t *atomic)	\
-	{											\
-		ATOMIC_IS_INITIALIZED(atomic);							\
-		return atomic->val;								\
-	}											\
-	static inline										\
-	void ofi_atomic_initialize##radix(ofi_atomic##radix##_t *atomic,			\
-					  int##radix##_t value)					\
-	{											\
-		ofi_spin_init(&atomic->lock);							\
-		atomic->val = value;								\
-		ATOMIC_INIT(atomic);								\
-	}											\
-	static inline										\
-	int##radix##_t ofi_atomic_add##radix(ofi_atomic##radix##_t *atomic,			\
-					     int##radix##_t val)				\
-	{											\
-		int##radix##_t v;								\
-		ATOMIC_IS_INITIALIZED(atomic);							\
-		ofi_spin_lock(&atomic->lock);						\
-		atomic->val += val;								\
-		v = atomic->val;								\
-		ofi_spin_unlock(&atomic->lock);						\
-		return v;									\
-	}											\
-	static inline										\
-	int##radix##_t ofi_atomic_sub##radix(ofi_atomic##radix##_t *atomic,			\
-					     int##radix##_t val)				\
-	{											\
-		int##radix##_t v;								\
-		ATOMIC_IS_INITIALIZED(atomic);							\
-		ofi_spin_lock(&atomic->lock);						\
-		atomic->val -= val;								\
-		v = atomic->val;								\
-		ofi_spin_unlock(&atomic->lock);						\
-		return v;									\
-	}											\
-	static inline										\
-	bool ofi_atomic_cas_bool##radix(ofi_atomic##radix##_t *atomic,				\
-					int##radix##_t expected,				\
-					int##radix##_t desired)					\
-	{											\
-		bool ret = false;								\
-		ATOMIC_IS_INITIALIZED(atomic);							\
-		ofi_spin_lock(&atomic->lock);						\
-		if (atomic->val == expected) {							\
-			atomic->val = desired;							\
-			ret = true;								\
-		}										\
-		ofi_spin_unlock(&atomic->lock);						\
-		return ret;									\
-	}											\
-	static inline										\
-	bool ofi_atomic_cas_bool_strong##radix(ofi_atomic##radix##_t *atomic,			\
-							 int##radix##_t expected,		\
-							 int##radix##_t desired)		\
-	{											\
-		return ofi_atomic_cas_bool##radix(atomic, expected, desired);			\
-	}											\
-	static inline										\
-	bool ofi_atomic_cas_bool_weak##radix(ofi_atomic##radix##_t *atomic,			\
-							 int##radix##_t expected,		\
-							 int##radix##_t desired)		\
-	{											\
-		return ofi_atomic_cas_bool##radix(atomic, expected, desired);			\
+#define OFI_ATOMIC_DEFINE(radix)                                              \
+	typedef struct {                                                      \
+		ofi_spin_t lock;                                              \
+		int##radix##_t val;                                           \
+		ATOMIC_DEF_INIT;                                              \
+	} ofi_atomic##radix##_t;                                              \
+                                                                              \
+	static inline int##radix##_t ofi_atomic_inc##radix(                   \
+		ofi_atomic##radix##_t *atomic)                                \
+	{                                                                     \
+		int##radix##_t v = 0;                                         \
+		ATOMIC_IS_INITIALIZED(atomic);                                \
+		ofi_spin_lock(&atomic->lock);                                 \
+		v = ++(atomic->val);                                          \
+		ofi_spin_unlock(&atomic->lock);                               \
+		return v;                                                     \
+	}                                                                     \
+	static inline int##radix##_t ofi_atomic_dec##radix(                   \
+		ofi_atomic##radix##_t *atomic)                                \
+	{                                                                     \
+		int##radix##_t v = 0;                                         \
+		ATOMIC_IS_INITIALIZED(atomic);                                \
+		ofi_spin_lock(&atomic->lock);                                 \
+		v = --(atomic->val);                                          \
+		ofi_spin_unlock(&atomic->lock);                               \
+		return v;                                                     \
+	}                                                                     \
+	static inline int##radix##_t ofi_atomic_set##radix(                   \
+		ofi_atomic##radix##_t *atomic, int##radix##_t value)          \
+	{                                                                     \
+		ATOMIC_IS_INITIALIZED(atomic);                                \
+		ofi_spin_lock(&atomic->lock);                                 \
+		atomic->val = value;                                          \
+		ofi_spin_unlock(&atomic->lock);                               \
+		return value;                                                 \
+	}                                                                     \
+	static inline int##radix##_t ofi_atomic_get##radix(                   \
+		ofi_atomic##radix##_t *atomic)                                \
+	{                                                                     \
+		ATOMIC_IS_INITIALIZED(atomic);                                \
+		return atomic->val;                                           \
+	}                                                                     \
+	static inline void ofi_atomic_initialize##radix(                      \
+		ofi_atomic##radix##_t *atomic, int##radix##_t value)          \
+	{                                                                     \
+		ofi_spin_init(&atomic->lock);                                 \
+		atomic->val = value;                                          \
+		ATOMIC_INIT(atomic);                                          \
+	}                                                                     \
+	static inline int##radix##_t ofi_atomic_add##radix(                   \
+		ofi_atomic##radix##_t *atomic, int##radix##_t val)            \
+	{                                                                     \
+		int##radix##_t v;                                             \
+		ATOMIC_IS_INITIALIZED(atomic);                                \
+		ofi_spin_lock(&atomic->lock);                                 \
+		atomic->val += val;                                           \
+		v = atomic->val;                                              \
+		ofi_spin_unlock(&atomic->lock);                               \
+		return v;                                                     \
+	}                                                                     \
+	static inline int##radix##_t ofi_atomic_sub##radix(                   \
+		ofi_atomic##radix##_t *atomic, int##radix##_t val)            \
+	{                                                                     \
+		int##radix##_t v;                                             \
+		ATOMIC_IS_INITIALIZED(atomic);                                \
+		ofi_spin_lock(&atomic->lock);                                 \
+		atomic->val -= val;                                           \
+		v = atomic->val;                                              \
+		ofi_spin_unlock(&atomic->lock);                               \
+		return v;                                                     \
+	}                                                                     \
+	static inline bool ofi_atomic_cas_bool##radix(                        \
+		ofi_atomic##radix##_t *atomic, int##radix##_t expected,       \
+		int##radix##_t desired)                                       \
+	{                                                                     \
+		bool ret = false;                                             \
+		ATOMIC_IS_INITIALIZED(atomic);                                \
+		ofi_spin_lock(&atomic->lock);                                 \
+		if (atomic->val == expected) {                                \
+			atomic->val = desired;                                \
+			ret = true;                                           \
+		}                                                             \
+		ofi_spin_unlock(&atomic->lock);                               \
+		return ret;                                                   \
+	}                                                                     \
+	static inline bool ofi_atomic_cas_bool_strong##radix(                 \
+		ofi_atomic##radix##_t *atomic, int##radix##_t expected,       \
+		int##radix##_t desired)                                       \
+	{                                                                     \
+		return ofi_atomic_cas_bool##radix(atomic, expected, desired); \
+	}                                                                     \
+	static inline bool ofi_atomic_cas_bool_weak##radix(                   \
+		ofi_atomic##radix##_t *atomic, int##radix##_t expected,       \
+		int##radix##_t desired)                                       \
+	{                                                                     \
+		return ofi_atomic_cas_bool##radix(atomic, expected, desired); \
 	}
 
 #endif // HAVE_ATOMICS

--- a/include/ofi_atomic.h
+++ b/include/ofi_atomic.h
@@ -46,49 +46,49 @@ size_t ofi_datatype_size(enum fi_datatype datatype);
 /* The START value is included, LAST is exclusive, which matches the public
  * header file use of LAST.  CNT is the number of valid values.
  */
-#define OFI_WRITE_OP_START	FI_MIN
-#define OFI_WRITE_OP_LAST	(FI_ATOMIC_WRITE + 1)
-#define OFI_WRITE_OP_CNT	(OFI_WRITE_OP_LAST - OFI_WRITE_OP_START)
-#define OFI_READWRITE_OP_START	FI_MIN
-#define OFI_READWRITE_OP_LAST	(FI_ATOMIC_WRITE + 1)
-#define OFI_READWRITE_OP_CNT	(OFI_READWRITE_OP_LAST - OFI_READWRITE_OP_START)
-#define OFI_SWAP_OP_START	FI_CSWAP
-#define OFI_SWAP_OP_LAST	(FI_MSWAP + 1)
-#define OFI_SWAP_OP_CNT		(OFI_SWAP_OP_LAST - OFI_SWAP_OP_START)
+#define OFI_WRITE_OP_START FI_MIN
+#define OFI_WRITE_OP_LAST (FI_ATOMIC_WRITE + 1)
+#define OFI_WRITE_OP_CNT (OFI_WRITE_OP_LAST - OFI_WRITE_OP_START)
+#define OFI_READWRITE_OP_START FI_MIN
+#define OFI_READWRITE_OP_LAST (FI_ATOMIC_WRITE + 1)
+#define OFI_READWRITE_OP_CNT (OFI_READWRITE_OP_LAST - OFI_READWRITE_OP_START)
+#define OFI_SWAP_OP_START FI_CSWAP
+#define OFI_SWAP_OP_LAST (FI_MSWAP + 1)
+#define OFI_SWAP_OP_CNT (OFI_SWAP_OP_LAST - OFI_SWAP_OP_START)
 
-#define ofi_atomic_iswrite_op(op) \
-	(op >= OFI_WRITE_OP_START && op < OFI_WRITE_OP_LAST && op != FI_ATOMIC_READ)
+#define ofi_atomic_iswrite_op(op)                              \
+	(op >= OFI_WRITE_OP_START && op < OFI_WRITE_OP_LAST && \
+	 op != FI_ATOMIC_READ)
 #define ofi_atomic_isreadwrite_op(op) \
 	(op >= OFI_READWRITE_OP_START && op < OFI_READWRITE_OP_LAST)
 #define ofi_atomic_isswap_op(op) \
 	(op >= OFI_SWAP_OP_START && op < OFI_SWAP_OP_LAST)
 
-#define OFI_DATATYPE_CNT	(FI_UINT128 + 1)
+#define OFI_DATATYPE_CNT (FI_UINT128 + 1)
 
 #ifdef HAVE___INT128
 typedef __int128 ofi_int128_t;
 typedef unsigned __int128 ofi_uint128_t;
 #endif
 
-extern void (*ofi_atomic_write_handlers[OFI_WRITE_OP_CNT][OFI_DATATYPE_CNT])
-			(void *dst, const void *src, size_t cnt);
-extern void (*ofi_atomic_readwrite_handlers[OFI_READWRITE_OP_CNT][OFI_DATATYPE_CNT])
-			(void *dst, const void *src, void *res, size_t cnt);
-extern void (*ofi_atomic_swap_handlers[OFI_SWAP_OP_CNT][OFI_DATATYPE_CNT])
-			(void *dst, const void *src, const void *cmp,
-			 void *res, size_t cnt);
+extern void (*ofi_atomic_write_handlers[OFI_WRITE_OP_CNT][OFI_DATATYPE_CNT])(
+	void *dst, const void *src, size_t cnt);
+extern void (
+	*ofi_atomic_readwrite_handlers[OFI_READWRITE_OP_CNT][OFI_DATATYPE_CNT])(
+	void *dst, const void *src, void *res, size_t cnt);
+extern void (*ofi_atomic_swap_handlers[OFI_SWAP_OP_CNT][OFI_DATATYPE_CNT])(
+	void *dst, const void *src, const void *cmp, void *res, size_t cnt);
 
 #define ofi_atomic_write_handler(op, datatype, dst, src, cnt) \
 	ofi_atomic_write_handlers[op][datatype](dst, src, cnt)
 #define ofi_atomic_readwrite_handler(op, datatype, dst, src, res, cnt) \
 	ofi_atomic_readwrite_handlers[op][datatype](dst, src, res, cnt)
 #define ofi_atomic_swap_handler(op, datatype, dst, src, cmp, res, cnt) \
-	ofi_atomic_swap_handlers[op - OFI_SWAP_OP_START][datatype](dst, src, \
-								cmp, res, cnt)
+	ofi_atomic_swap_handlers[op - OFI_SWAP_OP_START][datatype](    \
+		dst, src, cmp, res, cnt)
 
-int ofi_atomic_valid(const struct fi_provider *prov,
-		     enum fi_datatype datatype, enum fi_op op, uint64_t flags);
-
+int ofi_atomic_valid(const struct fi_provider *prov, enum fi_datatype datatype,
+		     enum fi_op op, uint64_t flags);
 
 #ifdef __cplusplus
 }

--- a/include/ofi_bitmask.h
+++ b/include/ofi_bitmask.h
@@ -94,7 +94,7 @@ static inline size_t ofi_bitmask_get_lsbset(struct ofi_bitmask mask)
 	uint8_t tmp;
 	size_t ret = 0;
 
-	for (cur = 0; cur < (mask.size/8); cur++) {
+	for (cur = 0; cur < (mask.size / 8); cur++) {
 		if (mask.bytes[cur]) {
 			tmp = mask.bytes[cur];
 			while (!(tmp & 0x1)) {

--- a/include/ofi_coll.h
+++ b/include/ofi_coll.h
@@ -52,7 +52,7 @@ enum util_coll_op_type {
 	UTIL_COLL_SCATTER_OP,
 };
 
-static const char * const log_util_coll_op_type[] = {
+static const char *const log_util_coll_op_type[] = {
 	[UTIL_COLL_JOIN_OP] = "COLL_JOIN",
 	[UTIL_COLL_BARRIER_OP] = "COLL_BARRIER",
 	[UTIL_COLL_ALLREDUCE_OP] = "COLL_ALLREDUCE",
@@ -69,13 +69,9 @@ enum coll_work_type {
 	UTIL_COLL_COMP,
 };
 
-enum coll_state {
-	UTIL_COLL_WAITING,
-	UTIL_COLL_PROCESSING,
-	UTIL_COLL_COMPLETE
-};
+enum coll_state { UTIL_COLL_WAITING, UTIL_COLL_PROCESSING, UTIL_COLL_COMPLETE };
 
-static const char * const log_util_coll_state[] = {
+static const char *const log_util_coll_state[] = {
 	[UTIL_COLL_WAITING] = "COLL_WAITING",
 	[UTIL_COLL_PROCESSING] = "COLL_PROCESSING",
 	[UTIL_COLL_COMPLETE] = "COLL_COMPLETE"
@@ -84,38 +80,38 @@ static const char * const log_util_coll_state[] = {
 struct util_coll_operation;
 
 struct util_coll_work_item {
-	struct slist_entry		ready_entry;
-	struct dlist_entry		waiting_entry;
-	struct util_coll_operation 	*coll_op;
-	enum coll_work_type		type;
-	enum coll_state			state;
-	int				fence;
+	struct slist_entry ready_entry;
+	struct dlist_entry waiting_entry;
+	struct util_coll_operation *coll_op;
+	enum coll_work_type type;
+	enum coll_state state;
+	int fence;
 };
 
 struct util_coll_xfer_item {
-	struct util_coll_work_item	hdr;
-	void 				*buf;
-	int				count;
-	enum fi_datatype		datatype;
-	uint64_t			tag;
-	int				remote_rank;
+	struct util_coll_work_item hdr;
+	void *buf;
+	int count;
+	enum fi_datatype datatype;
+	uint64_t tag;
+	int remote_rank;
 };
 
 struct util_coll_copy_item {
-	struct util_coll_work_item	hdr;
-	void 				*in_buf;
-	void				*out_buf;
-	int				count;
-	enum fi_datatype		datatype;
+	struct util_coll_work_item hdr;
+	void *in_buf;
+	void *out_buf;
+	int count;
+	enum fi_datatype datatype;
 };
 
 struct util_coll_reduce_item {
-	struct util_coll_work_item	hdr;
-	void 				*in_buf;
-	void 				*inout_buf;
-	int				count;
-	enum fi_datatype		datatype;
-	enum fi_op			op;
+	struct util_coll_work_item hdr;
+	void *in_buf;
+	void *inout_buf;
+	int count;
+	enum fi_datatype datatype;
+	enum fi_op op;
 };
 
 struct join_data {
@@ -130,36 +126,36 @@ struct barrier_data {
 };
 
 struct allreduce_data {
-	void	*data;
-	size_t	size;
+	void *data;
+	size_t size;
 };
 
 struct broadcast_data {
-	void	*chunk;
-	size_t	size;
-	void	*scatter;
+	void *chunk;
+	size_t size;
+	void *scatter;
 };
 
 struct util_coll_operation;
 
 typedef void (*util_coll_comp_fn_t)(struct util_coll_operation *coll_op);
 struct util_coll_operation {
-	enum util_coll_op_type		type;
-	uint32_t			cid;
-	void				*context;
-	struct fid_ep			*ep;
-	struct util_coll_mc		*mc;
-	struct dlist_entry		work_queue;
+	enum util_coll_op_type type;
+	uint32_t cid;
+	void *context;
+	struct fid_ep *ep;
+	struct util_coll_mc *mc;
+	struct dlist_entry work_queue;
 
 	union {
-		struct join_data	join;
-		struct barrier_data	barrier;
-		struct allreduce_data	allreduce;
-		void			*scatter;
-		struct broadcast_data	broadcast;
+		struct join_data join;
+		struct barrier_data barrier;
+		struct allreduce_data allreduce;
+		void *scatter;
+		struct broadcast_data broadcast;
 	} data;
-	util_coll_comp_fn_t		comp_fn;
-	uint64_t			flags;
+	util_coll_comp_fn_t comp_fn;
+	uint64_t flags;
 };
 
 struct ofi_coll_cq {
@@ -168,7 +164,7 @@ struct ofi_coll_cq {
 };
 
 int ofi_coll_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
-		 struct fid_cq **cq_fid, void *context);
+		     struct fid_cq **cq_fid, void *context);
 
 struct ofi_coll_eq {
 	struct util_eq util_eq;
@@ -176,6 +172,6 @@ struct ofi_coll_eq {
 };
 
 int ofi_coll_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
-		 struct fid_eq **eq_fid, void *context);
+		     struct fid_eq **eq_fid, void *context);
 
 #endif // _OFI_COLL_H_

--- a/include/ofi_enosys.h
+++ b/include/ofi_enosys.h
@@ -63,11 +63,11 @@ static struct fi_ops X = {
 int fi_no_close(struct fid *fid);
 int fi_no_bind(struct fid *fid, struct fid *bfid, uint64_t flags);
 int fi_no_control(struct fid *fid, int command, void *arg);
-int fi_no_ops_open(struct fid *fid, const char *name,
-		uint64_t flags, void **ops, void *context);
+int fi_no_ops_open(struct fid *fid, const char *name, uint64_t flags,
+		   void **ops, void *context);
 int fi_no_tostr(const struct fid *fid, char *buf, size_t len);
-int fi_no_ops_set(struct fid *fid, const char *name, uint64_t flags,
-		  void *ops, void *context);
+int fi_no_ops_set(struct fid *fid, const char *name, uint64_t flags, void *ops,
+		  void *context);
 
 /*
 static struct fi_ops_fabric X = {
@@ -81,15 +81,15 @@ static struct fi_ops_fabric X = {
 };
 */
 int fi_no_domain(struct fid_fabric *fabric, struct fi_info *info,
-		struct fid_domain **dom, void *context);
+		 struct fid_domain **dom, void *context);
 int fi_no_domain2(struct fid_fabric *fabric, struct fi_info *info,
-		struct fid_domain **dom, uint64_t flags, void *context);
+		  struct fid_domain **dom, uint64_t flags, void *context);
 int fi_no_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
-		struct fid_pep **pep, void *context);
+		     struct fid_pep **pep, void *context);
 int fi_no_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
-		struct fid_eq **eq, void *context);
+		  struct fid_eq **eq, void *context);
 int fi_no_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
-		struct fid_wait **waitset);
+		    struct fid_wait **waitset);
 int fi_no_trywait(struct fid_fabric *fabric, struct fid **fids, int count);
 
 /*
@@ -110,56 +110,61 @@ static struct fi_ops_atomic X = {
 	.compwritevalid = fi_no_atomic_compwritevalid,
 };
 */
-ssize_t fi_no_atomic_write(struct fid_ep *ep,
-		const void *buf, size_t count, void *desc,
-		fi_addr_t dest_addr, uint64_t addr, uint64_t key,
-		enum fi_datatype datatype, enum fi_op op, void *context);
-ssize_t fi_no_atomic_writev(struct fid_ep *ep,
-		const struct fi_ioc *iov, void **desc, size_t count,
-		fi_addr_t dest_addr, uint64_t addr, uint64_t key,
-		enum fi_datatype datatype, enum fi_op op, void *context);
+ssize_t fi_no_atomic_write(struct fid_ep *ep, const void *buf, size_t count,
+			   void *desc, fi_addr_t dest_addr, uint64_t addr,
+			   uint64_t key, enum fi_datatype datatype,
+			   enum fi_op op, void *context);
+ssize_t fi_no_atomic_writev(struct fid_ep *ep, const struct fi_ioc *iov,
+			    void **desc, size_t count, fi_addr_t dest_addr,
+			    uint64_t addr, uint64_t key,
+			    enum fi_datatype datatype, enum fi_op op,
+			    void *context);
 ssize_t fi_no_atomic_writemsg(struct fid_ep *ep,
-		const struct fi_msg_atomic *msg, uint64_t flags);
+			      const struct fi_msg_atomic *msg, uint64_t flags);
 ssize_t fi_no_atomic_inject(struct fid_ep *ep, const void *buf, size_t count,
-		fi_addr_t dest_addr, uint64_t addr, uint64_t key,
-		enum fi_datatype datatype, enum fi_op op);
-ssize_t fi_no_atomic_readwrite(struct fid_ep *ep,
-		const void *buf, size_t count, void *desc,
-		void *result, void *result_desc,
-		fi_addr_t dest_addr, uint64_t addr, uint64_t key,
-		enum fi_datatype datatype, enum fi_op op, void *context);
-ssize_t fi_no_atomic_readwritev(struct fid_ep *ep,
-		const struct fi_ioc *iov, void **desc, size_t count,
-		struct fi_ioc *resultv, void **result_desc, size_t result_count,
-		fi_addr_t dest_addr, uint64_t addr, uint64_t key,
-		enum fi_datatype datatype, enum fi_op op, void *context);
+			    fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+			    enum fi_datatype datatype, enum fi_op op);
+ssize_t fi_no_atomic_readwrite(struct fid_ep *ep, const void *buf, size_t count,
+			       void *desc, void *result, void *result_desc,
+			       fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+			       enum fi_datatype datatype, enum fi_op op,
+			       void *context);
+ssize_t fi_no_atomic_readwritev(struct fid_ep *ep, const struct fi_ioc *iov,
+				void **desc, size_t count,
+				struct fi_ioc *resultv, void **result_desc,
+				size_t result_count, fi_addr_t dest_addr,
+				uint64_t addr, uint64_t key,
+				enum fi_datatype datatype, enum fi_op op,
+				void *context);
 ssize_t fi_no_atomic_readwritemsg(struct fid_ep *ep,
-		const struct fi_msg_atomic *msg,
-		struct fi_ioc *resultv, void **result_desc, size_t result_count,
-		uint64_t flags);
-ssize_t fi_no_atomic_compwrite(struct fid_ep *ep,
-		const void *buf, size_t count, void *desc,
-		const void *compare, void *compare_desc,
-		void *result, void *result_desc,
-		fi_addr_t dest_addr, uint64_t addr, uint64_t key,
-		enum fi_datatype datatype, enum fi_op op, void *context);
-ssize_t fi_no_atomic_compwritev(struct fid_ep *ep,
-		const struct fi_ioc *iov, void **desc, size_t count,
-		const struct fi_ioc *comparev, void **compare_desc, size_t compare_count,
-		struct fi_ioc *resultv, void **result_desc, size_t result_count,
-		fi_addr_t dest_addr, uint64_t addr, uint64_t key,
-		enum fi_datatype datatype, enum fi_op op, void *context);
+				  const struct fi_msg_atomic *msg,
+				  struct fi_ioc *resultv, void **result_desc,
+				  size_t result_count, uint64_t flags);
+ssize_t fi_no_atomic_compwrite(struct fid_ep *ep, const void *buf, size_t count,
+			       void *desc, const void *compare,
+			       void *compare_desc, void *result,
+			       void *result_desc, fi_addr_t dest_addr,
+			       uint64_t addr, uint64_t key,
+			       enum fi_datatype datatype, enum fi_op op,
+			       void *context);
+ssize_t fi_no_atomic_compwritev(
+	struct fid_ep *ep, const struct fi_ioc *iov, void **desc, size_t count,
+	const struct fi_ioc *comparev, void **compare_desc,
+	size_t compare_count, struct fi_ioc *resultv, void **result_desc,
+	size_t result_count, fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+	enum fi_datatype datatype, enum fi_op op, void *context);
 ssize_t fi_no_atomic_compwritemsg(struct fid_ep *ep,
-		const struct fi_msg_atomic *msg,
-		const struct fi_ioc *comparev, void **compare_desc, size_t compare_count,
-		struct fi_ioc *resultv, void **result_desc, size_t result_count,
-		uint64_t flags);
-int fi_no_atomic_writevalid(struct fid_ep *ep,
-		enum fi_datatype datatype, enum fi_op op, size_t *count);
-int fi_no_atomic_readwritevalid(struct fid_ep *ep,
-		enum fi_datatype datatype, enum fi_op op, size_t *count);
-int fi_no_atomic_compwritevalid(struct fid_ep *ep,
-		enum fi_datatype datatype, enum fi_op op, size_t *count);
+				  const struct fi_msg_atomic *msg,
+				  const struct fi_ioc *comparev,
+				  void **compare_desc, size_t compare_count,
+				  struct fi_ioc *resultv, void **result_desc,
+				  size_t result_count, uint64_t flags);
+int fi_no_atomic_writevalid(struct fid_ep *ep, enum fi_datatype datatype,
+			    enum fi_op op, size_t *count);
+int fi_no_atomic_readwritevalid(struct fid_ep *ep, enum fi_datatype datatype,
+				enum fi_op op, size_t *count);
+int fi_no_atomic_compwritevalid(struct fid_ep *ep, enum fi_datatype datatype,
+				enum fi_op op, size_t *count);
 
 /*
 static struct fi_ops_cm X = {
@@ -178,15 +183,15 @@ static struct fi_ops_cm X = {
 int fi_no_setname(fid_t fid, void *addr, size_t addrlen);
 int fi_no_getname(fid_t fid, void *addr, size_t *addrlen);
 int fi_no_getpeer(struct fid_ep *ep, void *addr, size_t *addrlen);
-int fi_no_connect(struct fid_ep *ep, const void *addr,
-		const void *param, size_t paramlen);
+int fi_no_connect(struct fid_ep *ep, const void *addr, const void *param,
+		  size_t paramlen);
 int fi_no_listen(struct fid_pep *pep);
 int fi_no_accept(struct fid_ep *ep, const void *param, size_t paramlen);
-int fi_no_reject(struct fid_pep *pep, fid_t handle,
-		const void *param, size_t paramlen);
+int fi_no_reject(struct fid_pep *pep, fid_t handle, const void *param,
+		 size_t paramlen);
 int fi_no_shutdown(struct fid_ep *ep, uint64_t flags);
 int fi_no_join(struct fid_ep *ep, const void *addr, uint64_t flags,
-		struct fid_mc **mc, void *context);
+	       struct fid_mc **mc, void *context);
 
 /*
 static struct fi_ops_domain X = {
@@ -205,26 +210,28 @@ static struct fi_ops_domain X = {
 };
 */
 int fi_no_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
-		struct fid_av **av, void *context);
+		  struct fid_av **av, void *context);
 int fi_no_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
-		struct fid_cq **cq, void *context);
+		  struct fid_cq **cq, void *context);
 int fi_no_endpoint(struct fid_domain *domain, struct fi_info *info,
-		struct fid_ep **ep, void *context);
+		   struct fid_ep **ep, void *context);
 int fi_no_endpoint2(struct fid_domain *domain, struct fi_info *info,
-		struct fid_ep **ep, uint64_t flags, void *context);
+		    struct fid_ep **ep, uint64_t flags, void *context);
 int fi_no_scalable_ep(struct fid_domain *domain, struct fi_info *info,
-		struct fid_ep **sep, void *context);
+		      struct fid_ep **sep, void *context);
 int fi_no_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
-		struct fid_cntr **cntr, void *context);
+		    struct fid_cntr **cntr, void *context);
 int fi_no_poll_open(struct fid_domain *domain, struct fi_poll_attr *attr,
-		struct fid_poll **pollset);
+		    struct fid_poll **pollset);
 int fi_no_stx_context(struct fid_domain *domain, struct fi_tx_attr *attr,
-		struct fid_stx **stx, void *context);
+		      struct fid_stx **stx, void *context);
 int fi_no_srx_context(struct fid_domain *domain, struct fi_rx_attr *attr,
-		struct fid_ep **rx_ep, void *context);
+		      struct fid_ep **rx_ep, void *context);
 int fi_no_query_atomic(struct fid_domain *domain, enum fi_datatype datatype,
-		enum fi_op op, struct fi_atomic_attr *attr, uint64_t flags);
-int fi_no_query_collective(struct fid_domain *domain, enum fi_collective_op coll,
+		       enum fi_op op, struct fi_atomic_attr *attr,
+		       uint64_t flags);
+int fi_no_query_collective(struct fid_domain *domain,
+			   enum fi_collective_op coll,
 			   struct fi_collective_attr *attr, uint64_t flags);
 
 /*
@@ -235,15 +242,14 @@ static struct fi_ops_mr X = {
 	.regattr = fi_no_mr_regattr,
 };
 */
-int fi_no_mr_reg(struct fid *fid, const void *buf, size_t len,
-		uint64_t access, uint64_t offset, uint64_t requested_key,
-		uint64_t flags, struct fid_mr **mr, void *context);
-int fi_no_mr_regv(struct fid *fid, const struct iovec *iov,
-		size_t count, uint64_t access,
-		uint64_t offset, uint64_t requested_key,
-		uint64_t flags, struct fid_mr **mr, void *context);
+int fi_no_mr_reg(struct fid *fid, const void *buf, size_t len, uint64_t access,
+		 uint64_t offset, uint64_t requested_key, uint64_t flags,
+		 struct fid_mr **mr, void *context);
+int fi_no_mr_regv(struct fid *fid, const struct iovec *iov, size_t count,
+		  uint64_t access, uint64_t offset, uint64_t requested_key,
+		  uint64_t flags, struct fid_mr **mr, void *context);
 int fi_no_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
-		uint64_t flags, struct fid_mr **mr);
+		     uint64_t flags, struct fid_mr **mr);
 
 /*
 static struct fi_ops_ep X = {
@@ -258,16 +264,14 @@ static struct fi_ops_ep X = {
 };
 */
 ssize_t fi_no_cancel(fid_t fid, void *context);
-int fi_no_getopt(fid_t fid, int level, int optname,
-		void *optval, size_t *optlen);
-int fi_no_setopt(fid_t fid, int level, int optname,
-		const void *optval, size_t optlen);
-int fi_no_tx_ctx(struct fid_ep *sep, int index,
-		struct fi_tx_attr *attr, struct fid_ep **tx_ep,
-		void *context);
-int fi_no_rx_ctx(struct fid_ep *sep, int index,
-		struct fi_rx_attr *attr, struct fid_ep **rx_ep,
-		void *context);
+int fi_no_getopt(fid_t fid, int level, int optname, void *optval,
+		 size_t *optlen);
+int fi_no_setopt(fid_t fid, int level, int optname, const void *optval,
+		 size_t optlen);
+int fi_no_tx_ctx(struct fid_ep *sep, int index, struct fi_tx_attr *attr,
+		 struct fid_ep **tx_ep, void *context);
+int fi_no_rx_ctx(struct fid_ep *sep, int index, struct fi_rx_attr *attr,
+		 struct fid_ep **rx_ep, void *context);
 ssize_t fi_no_rx_size_left(struct fid_ep *ep);
 ssize_t fi_no_tx_size_left(struct fid_ep *ep);
 
@@ -286,23 +290,24 @@ static struct fi_ops_msg X = {
 };
 */
 ssize_t fi_no_msg_recv(struct fid_ep *ep, void *buf, size_t len, void *desc,
-		fi_addr_t src_addr, void *context);
+		       fi_addr_t src_addr, void *context);
 ssize_t fi_no_msg_recvv(struct fid_ep *ep, const struct iovec *iov, void **desc,
-		size_t count, fi_addr_t src_addr, void *context);
+			size_t count, fi_addr_t src_addr, void *context);
 ssize_t fi_no_msg_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
-		uint64_t flags);
-ssize_t fi_no_msg_send(struct fid_ep *ep, const void *buf, size_t len, void *desc,
-		fi_addr_t dest_addr, void *context);
+			  uint64_t flags);
+ssize_t fi_no_msg_send(struct fid_ep *ep, const void *buf, size_t len,
+		       void *desc, fi_addr_t dest_addr, void *context);
 ssize_t fi_no_msg_sendv(struct fid_ep *ep, const struct iovec *iov, void **desc,
-		size_t count, fi_addr_t dest_addr, void *context);
+			size_t count, fi_addr_t dest_addr, void *context);
 ssize_t fi_no_msg_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
-		uint64_t flags);
+			  uint64_t flags);
 ssize_t fi_no_msg_inject(struct fid_ep *ep, const void *buf, size_t len,
-		fi_addr_t dest_addr);
-ssize_t fi_no_msg_senddata(struct fid_ep *ep, const void *buf, size_t len, void *desc,
-		uint64_t data, fi_addr_t dest_addr, void *context);
+			 fi_addr_t dest_addr);
+ssize_t fi_no_msg_senddata(struct fid_ep *ep, const void *buf, size_t len,
+			   void *desc, uint64_t data, fi_addr_t dest_addr,
+			   void *context);
 ssize_t fi_no_msg_injectdata(struct fid_ep *ep, const void *buf, size_t len,
-		uint64_t data, fi_addr_t dest_addr);
+			     uint64_t data, fi_addr_t dest_addr);
 
 /*
 static struct fi_ops_wait X = {
@@ -330,16 +335,16 @@ static struct fi_ops_eq X = {
 	.strerror = fi_no_eq_strerror,
 };
 */
-ssize_t fi_no_eq_read(struct fid_eq *eq, uint32_t *event, void *buf,
-		size_t len, uint64_t flags);
+ssize_t fi_no_eq_read(struct fid_eq *eq, uint32_t *event, void *buf, size_t len,
+		      uint64_t flags);
 ssize_t fi_no_eq_readerr(struct fid_eq *eq, struct fi_eq_err_entry *buf,
-		uint64_t flags);
-ssize_t fi_no_eq_write(struct fid_eq *eq, uint32_t event,
-		const void *buf, size_t len, uint64_t flags);
-ssize_t fi_no_eq_sread(struct fid_eq *eq, uint32_t *event,
-		void *buf, size_t len, int timeout, uint64_t flags);
+			 uint64_t flags);
+ssize_t fi_no_eq_write(struct fid_eq *eq, uint32_t event, const void *buf,
+		       size_t len, uint64_t flags);
+ssize_t fi_no_eq_sread(struct fid_eq *eq, uint32_t *event, void *buf,
+		       size_t len, int timeout, uint64_t flags);
 const char *fi_no_eq_strerror(struct fid_eq *eq, int prov_errno,
-		const void *err_data, char *buf, size_t len);
+			      const void *err_data, char *buf, size_t len);
 
 /*
 static struct fi_ops_cq X = {
@@ -355,16 +360,16 @@ static struct fi_ops_cq X = {
 */
 ssize_t fi_no_cq_read(struct fid_cq *cq, void *buf, size_t count);
 ssize_t fi_no_cq_readfrom(struct fid_cq *cq, void *buf, size_t count,
-		fi_addr_t *src_addr);
+			  fi_addr_t *src_addr);
 ssize_t fi_no_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf,
-		                uint64_t flags);
+			 uint64_t flags);
 ssize_t fi_no_cq_sread(struct fid_cq *cq, void *buf, size_t count,
-		const void *cond, int timeout);
+		       const void *cond, int timeout);
 ssize_t fi_no_cq_sreadfrom(struct fid_cq *cq, void *buf, size_t count,
-		fi_addr_t *src_addr, const void *cond, int timeout);
+			   fi_addr_t *src_addr, const void *cond, int timeout);
 int fi_no_cq_signal(struct fid_cq *cq);
-const char * fi_no_cq_strerror(struct fid_cq *cq, int prov_errno,
-		const void *err_data, char *buf, size_t len);
+const char *fi_no_cq_strerror(struct fid_cq *cq, int prov_errno,
+			      const void *err_data, char *buf, size_t len);
 
 /*
 static struct fi_ops_cntr X = {
@@ -395,26 +400,29 @@ static struct fi_ops_rma X = {
 };
 */
 ssize_t fi_no_rma_read(struct fid_ep *ep, void *buf, size_t len, void *desc,
-		fi_addr_t src_addr, uint64_t addr, uint64_t key, void *context);
+		       fi_addr_t src_addr, uint64_t addr, uint64_t key,
+		       void *context);
 ssize_t fi_no_rma_readv(struct fid_ep *ep, const struct iovec *iov, void **desc,
-		size_t count, fi_addr_t src_addr, uint64_t addr, uint64_t key,
-		void *context);
+			size_t count, fi_addr_t src_addr, uint64_t addr,
+			uint64_t key, void *context);
 ssize_t fi_no_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
-		uint64_t flags);
-ssize_t fi_no_rma_write(struct fid_ep *ep, const void *buf, size_t len, void *desc,
-		fi_addr_t dest_addr, uint64_t addr, uint64_t key, void *context);
-ssize_t fi_no_rma_writev(struct fid_ep *ep, const struct iovec *iov, void **desc,
-		size_t count, fi_addr_t dest_addr, uint64_t addr, uint64_t key,
-		void *context);
+			  uint64_t flags);
+ssize_t fi_no_rma_write(struct fid_ep *ep, const void *buf, size_t len,
+			void *desc, fi_addr_t dest_addr, uint64_t addr,
+			uint64_t key, void *context);
+ssize_t fi_no_rma_writev(struct fid_ep *ep, const struct iovec *iov,
+			 void **desc, size_t count, fi_addr_t dest_addr,
+			 uint64_t addr, uint64_t key, void *context);
 ssize_t fi_no_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
-		uint64_t flags);
+			   uint64_t flags);
 ssize_t fi_no_rma_inject(struct fid_ep *ep, const void *buf, size_t len,
-		fi_addr_t dest_addr, uint64_t addr, uint64_t key);
-ssize_t fi_no_rma_writedata(struct fid_ep *ep, const void *buf, size_t len, void *desc,
-		uint64_t data, fi_addr_t dest_addr, uint64_t addr, uint64_t key,
-		void *context);
+			 fi_addr_t dest_addr, uint64_t addr, uint64_t key);
+ssize_t fi_no_rma_writedata(struct fid_ep *ep, const void *buf, size_t len,
+			    void *desc, uint64_t data, fi_addr_t dest_addr,
+			    uint64_t addr, uint64_t key, void *context);
 ssize_t fi_no_rma_injectdata(struct fid_ep *ep, const void *buf, size_t len,
-		uint64_t data, fi_addr_t dest_addr, uint64_t addr, uint64_t key);
+			     uint64_t data, fi_addr_t dest_addr, uint64_t addr,
+			     uint64_t key);
 
 /*
 static struct fi_ops_tagged X = {
@@ -432,26 +440,32 @@ static struct fi_ops_tagged X = {
 };
 */
 ssize_t fi_no_tagged_recv(struct fid_ep *ep, void *buf, size_t len, void *desc,
-		fi_addr_t src_addr, uint64_t tag, uint64_t ignore, void *context);
-ssize_t fi_no_tagged_recvv(struct fid_ep *ep, const struct iovec *iov, void **desc,
-		size_t count, fi_addr_t src_addr,
-		uint64_t tag, uint64_t ignore, void *context);
+			  fi_addr_t src_addr, uint64_t tag, uint64_t ignore,
+			  void *context);
+ssize_t fi_no_tagged_recvv(struct fid_ep *ep, const struct iovec *iov,
+			   void **desc, size_t count, fi_addr_t src_addr,
+			   uint64_t tag, uint64_t ignore, void *context);
 ssize_t fi_no_tagged_recvmsg(struct fid_ep *ep, const struct fi_msg_tagged *msg,
-		uint64_t flags);
-ssize_t fi_no_tagged_send(struct fid_ep *ep, const void *buf, size_t len, void *desc,
-		fi_addr_t dest_addr, uint64_t tag, void *context);
-ssize_t fi_no_tagged_sendv(struct fid_ep *ep, const struct iovec *iov, void **desc,
-		size_t count, fi_addr_t dest_addr, uint64_t tag, void *context);
+			     uint64_t flags);
+ssize_t fi_no_tagged_send(struct fid_ep *ep, const void *buf, size_t len,
+			  void *desc, fi_addr_t dest_addr, uint64_t tag,
+			  void *context);
+ssize_t fi_no_tagged_sendv(struct fid_ep *ep, const struct iovec *iov,
+			   void **desc, size_t count, fi_addr_t dest_addr,
+			   uint64_t tag, void *context);
 ssize_t fi_no_tagged_sendmsg(struct fid_ep *ep, const struct fi_msg_tagged *msg,
-		uint64_t flags);
+			     uint64_t flags);
 ssize_t fi_no_tagged_inject(struct fid_ep *ep, const void *buf, size_t len,
-		fi_addr_t dest_addr, uint64_t tag);
-ssize_t fi_no_tagged_senddata(struct fid_ep *ep, const void *buf, size_t len, void *desc,
-		uint64_t data, fi_addr_t dest_addr, uint64_t tag, void *context);
+			    fi_addr_t dest_addr, uint64_t tag);
+ssize_t fi_no_tagged_senddata(struct fid_ep *ep, const void *buf, size_t len,
+			      void *desc, uint64_t data, fi_addr_t dest_addr,
+			      uint64_t tag, void *context);
 ssize_t fi_no_tagged_injectdata(struct fid_ep *ep, const void *buf, size_t len,
-		uint64_t data, fi_addr_t dest_addr, uint64_t tag);
+				uint64_t data, fi_addr_t dest_addr,
+				uint64_t tag);
 ssize_t fi_no_tagged_search(struct fid_ep *ep, uint64_t *tag, uint64_t ignore,
-		uint64_t flags, fi_addr_t *src_addr, size_t *len, void *context);
+			    uint64_t flags, fi_addr_t *src_addr, size_t *len,
+			    void *context);
 
 /*
 static struct fi_ops_av X = {
@@ -465,15 +479,14 @@ static struct fi_ops_av X = {
 };
 */
 int fi_no_av_insert(struct fid_av *av, const void *addr, size_t count,
-			fi_addr_t *fi_addr, uint64_t flags, void *context);
-int fi_no_av_insertsvc(struct fid_av *av, const char *node,
-		const char *service, fi_addr_t *fi_addr, uint64_t flags,
-		void *context);
+		    fi_addr_t *fi_addr, uint64_t flags, void *context);
+int fi_no_av_insertsvc(struct fid_av *av, const char *node, const char *service,
+		       fi_addr_t *fi_addr, uint64_t flags, void *context);
 int fi_no_av_insertsym(struct fid_av *av, const char *node, size_t nodecnt,
-			const char *service, size_t svccnt, fi_addr_t *fi_addr,
-			uint64_t flags, void *context);
+		       const char *service, size_t svccnt, fi_addr_t *fi_addr,
+		       uint64_t flags, void *context);
 int fi_no_av_remove(struct fid_av *av, fi_addr_t *fi_addr, size_t count,
-			uint64_t flags);
+		    uint64_t flags);
 int fi_no_av_lookup(struct fid_av *av, fi_addr_t fi_addr, void *addr,
 		    size_t *addrlen);
 const char *fi_no_av_straddr(struct fid_av *av, const void *addr, char *buf,
@@ -492,7 +505,8 @@ static struct fi_ops_av_set X = {
 */
 
 int fi_no_av_set_union(struct fid_av_set *dst, const struct fid_av_set *src);
-int fi_no_av_set_intersect(struct fid_av_set *dst, const struct fid_av_set *src);
+int fi_no_av_set_intersect(struct fid_av_set *dst,
+			   const struct fid_av_set *src);
 int fi_no_av_set_diff(struct fid_av_set *dst, const struct fid_av_set *src);
 int fi_no_av_set_insert(struct fid_av_set *set, fi_addr_t addr);
 int fi_no_av_set_remove(struct fid_av_set *set, fi_addr_t addr);
@@ -513,41 +527,49 @@ static struct fi_ops_collective X = {
 	.msg = fi_coll_no_msg,
 };
 */
-ssize_t fi_coll_no_barrier(struct fid_ep *ep, fi_addr_t coll_addr, void *context);
-ssize_t fi_coll_no_barrier2(struct fid_ep *ep, fi_addr_t coll_addr, uint64_t flags,
-			    void *context);
-ssize_t fi_coll_no_broadcast(struct fid_ep *ep, void *buf, size_t count, void *desc,
-			     fi_addr_t coll_addr, fi_addr_t root_addr,
-			     enum fi_datatype datatype, uint64_t flags, void *context);
-ssize_t fi_coll_no_alltoall(struct fid_ep *ep, const void *buf, size_t count, void *desc,
-			    void *result, void *result_desc, fi_addr_t coll_addr,
-			    enum fi_datatype datatype, uint64_t flags, void *context);
-ssize_t fi_coll_no_allreduce(struct fid_ep *ep, const void *buf, size_t count, void *desc,
-			     void *result, void *result_desc, fi_addr_t coll_addr,
-			     enum fi_datatype datatype, enum fi_op op, uint64_t flags,
-			     void *context);
-ssize_t fi_coll_no_allgather(struct fid_ep *ep, const void *buf, size_t count, void *desc,
-			     void *result, void *result_desc, fi_addr_t coll_addr,
-			     enum fi_datatype datatype, uint64_t flags, void *context);
-ssize_t fi_coll_no_reduce_scatter(struct fid_ep *ep, const void *buf, size_t count,
-				  void *desc, void *result, void *result_desc,
-				  fi_addr_t coll_addr, enum fi_datatype datatype,
-				  enum fi_op op, uint64_t flags, void *context);
-ssize_t fi_coll_no_reduce(struct fid_ep *ep, const void *buf, size_t count, void *desc,
-			  void *result, void *result_desc, fi_addr_t coll_addr,
-			  fi_addr_t root_addr, enum fi_datatype datatype, enum fi_op op,
-			  uint64_t flags, void *context);
-ssize_t fi_coll_no_scatter(struct fid_ep *ep, const void *buf, size_t count, void *desc,
-			   void *result, void *result_desc, fi_addr_t coll_addr,
-			   fi_addr_t root_addr, enum fi_datatype datatype, uint64_t flags,
+ssize_t fi_coll_no_barrier(struct fid_ep *ep, fi_addr_t coll_addr,
 			   void *context);
-ssize_t fi_coll_no_gather(struct fid_ep *ep, const void *buf, size_t count, void *desc,
-			  void *result, void *result_desc, fi_addr_t coll_addr,
-			  fi_addr_t root_addr, enum fi_datatype datatype, uint64_t flags,
+ssize_t fi_coll_no_barrier2(struct fid_ep *ep, fi_addr_t coll_addr,
+			    uint64_t flags, void *context);
+ssize_t fi_coll_no_broadcast(struct fid_ep *ep, void *buf, size_t count,
+			     void *desc, fi_addr_t coll_addr,
+			     fi_addr_t root_addr, enum fi_datatype datatype,
+			     uint64_t flags, void *context);
+ssize_t fi_coll_no_alltoall(struct fid_ep *ep, const void *buf, size_t count,
+			    void *desc, void *result, void *result_desc,
+			    fi_addr_t coll_addr, enum fi_datatype datatype,
+			    uint64_t flags, void *context);
+ssize_t fi_coll_no_allreduce(struct fid_ep *ep, const void *buf, size_t count,
+			     void *desc, void *result, void *result_desc,
+			     fi_addr_t coll_addr, enum fi_datatype datatype,
+			     enum fi_op op, uint64_t flags, void *context);
+ssize_t fi_coll_no_allgather(struct fid_ep *ep, const void *buf, size_t count,
+			     void *desc, void *result, void *result_desc,
+			     fi_addr_t coll_addr, enum fi_datatype datatype,
+			     uint64_t flags, void *context);
+ssize_t fi_coll_no_reduce_scatter(struct fid_ep *ep, const void *buf,
+				  size_t count, void *desc, void *result,
+				  void *result_desc, fi_addr_t coll_addr,
+				  enum fi_datatype datatype, enum fi_op op,
+				  uint64_t flags, void *context);
+ssize_t fi_coll_no_reduce(struct fid_ep *ep, const void *buf, size_t count,
+			  void *desc, void *result, void *result_desc,
+			  fi_addr_t coll_addr, fi_addr_t root_addr,
+			  enum fi_datatype datatype, enum fi_op op,
+			  uint64_t flags, void *context);
+ssize_t fi_coll_no_scatter(struct fid_ep *ep, const void *buf, size_t count,
+			   void *desc, void *result, void *result_desc,
+			   fi_addr_t coll_addr, fi_addr_t root_addr,
+			   enum fi_datatype datatype, uint64_t flags,
+			   void *context);
+ssize_t fi_coll_no_gather(struct fid_ep *ep, const void *buf, size_t count,
+			  void *desc, void *result, void *result_desc,
+			  fi_addr_t coll_addr, fi_addr_t root_addr,
+			  enum fi_datatype datatype, uint64_t flags,
 			  void *context);
 ssize_t fi_coll_no_msg(struct fid_ep *ep, const struct fi_msg_collective *msg,
-		       struct fi_ioc *resultv, void **result_desc, size_t result_count,
-		       uint64_t flags);
+		       struct fi_ioc *resultv, void **result_desc,
+		       size_t result_count, uint64_t flags);
 
 #ifdef __cplusplus
 }

--- a/include/ofi_epoll.h
+++ b/include/ofi_epoll.h
@@ -44,7 +44,6 @@
 #include <ofi_list.h>
 #include <ofi_signal.h>
 
-
 #ifdef HAVE_EPOLL
 #include <sys/epoll.h>
 #define ofi_epollfds_event epoll_event
@@ -64,25 +63,25 @@ enum ofi_pollfds_ctl {
 };
 
 struct ofi_pollfds_work_item {
-	int		fd;
-	uint32_t	events;
-	void		*context;
+	int fd;
+	uint32_t events;
+	void *context;
 	enum ofi_pollfds_ctl op;
 	struct slist_entry entry;
 };
 
 struct ofi_pollfds_ctx {
-	void		*context;
-	int		index;
+	void *context;
+	int index;
 };
 
 struct ofi_pollfds {
-	int		size;
-	int		nfds;
-	struct pollfd	*fds;
+	int size;
+	int nfds;
+	struct pollfd *fds;
 	struct ofi_pollfds_ctx *ctx;
 	struct fd_signal signal;
-	struct slist	work_item_list;
+	struct slist work_item_list;
 	struct ofi_genlock lock;
 
 	int (*add)(struct ofi_pollfds *pfds, int fd, uint32_t events,
@@ -90,12 +89,13 @@ struct ofi_pollfds {
 	int (*del)(struct ofi_pollfds *pfds, int fd);
 };
 
-int ofi_pollfds_create_(struct ofi_pollfds **pfds, enum ofi_lock_type lock_type);
+int ofi_pollfds_create_(struct ofi_pollfds **pfds,
+			enum ofi_lock_type lock_type);
 int ofi_pollfds_create(struct ofi_pollfds **pfds);
 int ofi_pollfds_grow(struct ofi_pollfds *pfds, int max_size);
 
-static inline int
-ofi_pollfds_add(struct ofi_pollfds *pfds, int fd, uint32_t events, void *context)
+static inline int ofi_pollfds_add(struct ofi_pollfds *pfds, int fd,
+				  uint32_t events, void *context)
 {
 	return pfds->add(pfds, fd, events, context);
 }
@@ -109,19 +109,18 @@ static inline int ofi_pollfds_del(struct ofi_pollfds *pfds, int fd)
 }
 
 int ofi_pollfds_wait(struct ofi_pollfds *pfds,
-		     struct ofi_epollfds_event *events,
-		     int maxevents, int timeout);
+		     struct ofi_epollfds_event *events, int maxevents,
+		     int timeout);
 void ofi_pollfds_close(struct ofi_pollfds *pfds);
 
 /* OS specific */
 struct ofi_pollfds_ctx *ofi_pollfds_get_ctx(struct ofi_pollfds *pfds, int fd);
 struct ofi_pollfds_ctx *ofi_pollfds_alloc_ctx(struct ofi_pollfds *pfds, int fd);
 
-
 #ifdef HAVE_EPOLL
 #include <sys/epoll.h>
 
-#define OFI_EPOLL_IN  EPOLLIN
+#define OFI_EPOLL_IN EPOLLIN
 #define OFI_EPOLL_OUT EPOLLOUT
 #define OFI_EPOLL_ERR EPOLLERR
 
@@ -163,14 +162,12 @@ static inline int ofi_epoll_del(int ep, int fd)
 	return epoll_ctl(ep, EPOLL_CTL_DEL, fd, NULL) ? -ofi_syserr() : 0;
 }
 
-static inline int
-ofi_epoll_wait(int ep, struct ofi_epollfds_event *events,
-	       int maxevents, int timeout)
+static inline int ofi_epoll_wait(int ep, struct ofi_epollfds_event *events,
+				 int maxevents, int timeout)
 {
 	int ret;
 
-	ret = epoll_wait(ep, (struct epoll_event *) events, maxevents,
-			 timeout);
+	ret = epoll_wait(ep, (struct epoll_event *)events, maxevents, timeout);
 	if (ret == -1)
 		return -ofi_syserr();
 
@@ -184,7 +181,7 @@ static inline void ofi_epoll_close(int ep)
 
 #else
 
-#define OFI_EPOLL_IN  POLLIN
+#define OFI_EPOLL_IN POLLIN
 #define OFI_EPOLL_OUT POLLOUT
 #define OFI_EPOLL_ERR POLLERR
 
@@ -235,54 +232,49 @@ struct ofi_dynpoll {
 		ofi_epoll_t ep;
 	};
 
-	int	(*add)(struct ofi_dynpoll *dynpoll, int fd, uint32_t events,
-			void *context);
-	int	(*mod)(struct ofi_dynpoll *dynpoll, int fd, uint32_t events,
-			void *context);
-	int	(*del)(struct ofi_dynpoll *dynpoll, int fd);
-	int	(*wait)(struct ofi_dynpoll *dynpoll,
-			struct ofi_epollfds_event *events, int maxevents,
-			int timeout);
-	int	(*get_fd)(struct ofi_dynpoll *dynpoll);
-	void	(*close)(struct ofi_dynpoll *dynpoll);
+	int (*add)(struct ofi_dynpoll *dynpoll, int fd, uint32_t events,
+		   void *context);
+	int (*mod)(struct ofi_dynpoll *dynpoll, int fd, uint32_t events,
+		   void *context);
+	int (*del)(struct ofi_dynpoll *dynpoll, int fd);
+	int (*wait)(struct ofi_dynpoll *dynpoll,
+		    struct ofi_epollfds_event *events, int maxevents,
+		    int timeout);
+	int (*get_fd)(struct ofi_dynpoll *dynpoll);
+	void (*close)(struct ofi_dynpoll *dynpoll);
 };
 
 int ofi_dynpoll_create(struct ofi_dynpoll *dynpoll, enum ofi_dynpoll_type type,
 		       enum ofi_lock_type lock_type);
 void ofi_dynpoll_close(struct ofi_dynpoll *dynpoll);
 
-static inline int
-ofi_dynpoll_add(struct ofi_dynpoll *dynpoll, int fd,
-		uint32_t events, void *context)
+static inline int ofi_dynpoll_add(struct ofi_dynpoll *dynpoll, int fd,
+				  uint32_t events, void *context)
 {
 	return dynpoll->add(dynpoll, fd, events, context);
 }
 
-static inline int
-ofi_dynpoll_mod(struct ofi_dynpoll *dynpoll, int fd,
-		uint32_t events, void *context)
+static inline int ofi_dynpoll_mod(struct ofi_dynpoll *dynpoll, int fd,
+				  uint32_t events, void *context)
 {
 	return dynpoll->mod(dynpoll, fd, events, context);
 }
 
-static inline int
-ofi_dynpoll_del(struct ofi_dynpoll *dynpoll, int fd)
+static inline int ofi_dynpoll_del(struct ofi_dynpoll *dynpoll, int fd)
 {
 	return dynpoll->del(dynpoll, fd);
 }
 
-static inline int
-ofi_dynpoll_wait(struct ofi_dynpoll *dynpoll,
-		 struct ofi_epollfds_event *events,
-		 int maxevents, int timeout)
+static inline int ofi_dynpoll_wait(struct ofi_dynpoll *dynpoll,
+				   struct ofi_epollfds_event *events,
+				   int maxevents, int timeout)
 {
 	return dynpoll->wait(dynpoll, events, maxevents, timeout);
 }
 
-static inline int
-ofi_dynpoll_get_fd(struct ofi_dynpoll *dynpoll)
+static inline int ofi_dynpoll_get_fd(struct ofi_dynpoll *dynpoll)
 {
 	return dynpoll->get_fd(dynpoll);
 }
 
-#endif  /* _OFI_EPOLL_H_ */
+#endif /* _OFI_EPOLL_H_ */

--- a/include/ofi_file.h
+++ b/include/ofi_file.h
@@ -38,18 +38,15 @@
 #include <assert.h>
 #include <stdlib.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
 int fi_read_file(const char *dir, const char *file, char *buf, size_t size);
 int fi_poll_fd(int fd, int timeout);
 
-#define RDMA_CONF_DIR  SYSCONFDIR "/" RDMADIR
+#define RDMA_CONF_DIR SYSCONFDIR "/" RDMADIR
 #define FI_CONF_DIR RDMA_CONF_DIR "/fabric"
-
 
 #ifdef __cplusplus
 }

--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -44,9 +44,9 @@
 
 extern bool ofi_hmem_disable_p2p;
 
-typedef void* ofi_hmem_async_event_t;
+typedef void *ofi_hmem_async_event_t;
 
-#define MAX_NUM_ASYNC_OP	4
+#define MAX_NUM_ASYNC_OP 4
 
 #if HAVE_CUDA
 
@@ -54,7 +54,7 @@ typedef void* ofi_hmem_async_event_t;
 #include <cuda_runtime.h>
 
 /* Libfabric supported CUDA operations. */
-cudaError_t ofi_cudaMemcpy(void* dst, const void* src, size_t count,
+cudaError_t ofi_cudaMemcpy(void *dst, const void *src, size_t count,
 			   enum cudaMemcpyKind kind);
 const char *ofi_cudaGetErrorName(cudaError_t error);
 const char *ofi_cudaGetErrorString(cudaError_t error);
@@ -96,16 +96,17 @@ struct ofi_hmem_ops {
 	int (*free_async_copy_event)(uint64_t device,
 				     ofi_hmem_async_event_t event);
 	int (*async_copy_to_hmem)(uint64_t device, void *dest, const void *src,
-			    size_t size, ofi_hmem_async_event_t event);
+				  size_t size, ofi_hmem_async_event_t event);
 	int (*async_copy_from_hmem)(uint64_t device, void *dest,
-			const void *src, size_t size,
-			ofi_hmem_async_event_t event);
+				    const void *src, size_t size,
+				    ofi_hmem_async_event_t event);
 	int (*async_copy_query)(ofi_hmem_async_event_t event);
 	int (*copy_to_hmem)(uint64_t device, void *dest, const void *src,
-			size_t size);
+			    size_t size);
 	int (*copy_from_hmem)(uint64_t device, void *dest, const void *src,
-			size_t size);
-	bool (*is_addr_valid)(const void *addr, uint64_t *device, uint64_t *flags);
+			      size_t size);
+	bool (*is_addr_valid)(const void *addr, uint64_t *device,
+			      uint64_t *flags);
 	int (*get_handle)(void *base_addr, size_t base_length, void **handle);
 	int (*open_handle)(void **handle, size_t base_length, uint64_t device,
 			   void **mapped_addr);
@@ -122,8 +123,7 @@ extern struct ofi_hmem_ops hmem_ops[];
 
 int rocr_copy_from_dev(uint64_t device, void *dest, const void *src,
 		       size_t size);
-int rocr_copy_to_dev(uint64_t device, void *dest, const void *src,
-		     size_t size);
+int rocr_copy_to_dev(uint64_t device, void *dest, const void *src, size_t size);
 int rocr_hmem_init(void);
 int rocr_hmem_cleanup(void);
 bool rocr_is_addr_valid(const void *addr, uint64_t *device, uint64_t *flags);
@@ -140,13 +140,14 @@ int rocr_create_async_copy_event(uint64_t device,
 				 ofi_hmem_async_event_t *event);
 int rocr_free_async_copy_event(uint64_t device, ofi_hmem_async_event_t event);
 int rocr_async_copy_to_dev(uint64_t device, void *dst, const void *src,
-			  size_t size, ofi_hmem_async_event_t event);
+			   size_t size, ofi_hmem_async_event_t event);
 int rocr_async_copy_from_dev(uint64_t device, void *dst, const void *src,
-			    size_t size, ofi_hmem_async_event_t event);
+			     size_t size, ofi_hmem_async_event_t event);
 int rocr_async_copy_query(ofi_hmem_async_event_t event);
 
 int cuda_copy_to_dev(uint64_t device, void *dev, const void *host, size_t size);
-int cuda_copy_from_dev(uint64_t device, void *host, const void *dev, size_t size);
+int cuda_copy_from_dev(uint64_t device, void *host, const void *dev,
+		       size_t size);
 int cuda_hmem_init(void);
 int cuda_hmem_cleanup(void);
 bool cuda_is_addr_valid(const void *addr, uint64_t *device, uint64_t *flags);
@@ -175,10 +176,10 @@ bool cuda_is_ipc_enabled(void);
 int cuda_get_ipc_handle_size(size_t *size);
 bool cuda_is_gdrcopy_enabled(void);
 
-void cuda_gdrcopy_to_dev(uint64_t handle, void *dev,
-			 const void *host, size_t size);
-void cuda_gdrcopy_from_dev(uint64_t handle, void *host,
-			   const void *dev, size_t size);
+void cuda_gdrcopy_to_dev(uint64_t handle, void *dev, const void *host,
+			 size_t size);
+void cuda_gdrcopy_from_dev(uint64_t handle, void *host, const void *dev,
+			   size_t size);
 int cuda_gdrcopy_hmem_init(void);
 int cuda_gdrcopy_hmem_cleanup(void);
 int cuda_gdrcopy_dev_register(struct fi_mr_attr *mr_attr, uint64_t *handle);
@@ -206,8 +207,10 @@ int *ze_hmem_get_dev_fds(int *nfds);
 int ze_hmem_host_register(void *ptr, size_t size);
 int ze_hmem_host_unregister(void *ptr);
 
-int neuron_copy_to_dev(uint64_t device, void *dev, const void *host, size_t size);
-int neuron_copy_from_dev(uint64_t device, void *host, const void *dev, size_t size);
+int neuron_copy_to_dev(uint64_t device, void *dev, const void *host,
+		       size_t size);
+int neuron_copy_from_dev(uint64_t device, void *host, const void *dev,
+			 size_t size);
 int neuron_host_register(void *ptr, size_t size);
 int neuron_host_unregister(void *ptr);
 int neuron_hmem_init(void);
@@ -218,12 +221,12 @@ void neuron_free(void **handle);
 int synapseai_init(void);
 int synapseai_cleanup(void);
 int synapseai_copy_to_hmem(uint64_t device, void *dest, const void *src,
-                           size_t size);
+			   size_t size);
 int synapseai_copy_from_hmem(uint64_t device, void *dest, const void *src,
-                             size_t size);
-int synapseai_get_dmabuf_fd(uint64_t addr, uint64_t size, int* fd);
+			     size_t size);
+int synapseai_get_dmabuf_fd(uint64_t addr, uint64_t size, int *fd);
 bool synapseai_is_addr_valid(const void *addr, uint64_t *device,
-                             uint64_t *flags);
+			     uint64_t *flags);
 int synapseai_host_register(void *ptr, size_t size);
 int synapseai_host_unregister(void *ptr);
 
@@ -235,19 +238,20 @@ static inline int ofi_memcpy(uint64_t device, void *dest, const void *src,
 }
 
 static inline int ofi_no_create_async_copy_event(uint64_t device,
-		ofi_hmem_async_event_t *event)
+						 ofi_hmem_async_event_t *event)
 {
 	return -FI_ENOSYS;
 }
 
 static inline int ofi_no_free_async_copy_event(uint64_t device,
-		ofi_hmem_async_event_t event)
+					       ofi_hmem_async_event_t event)
 {
 	return -FI_ENOSYS;
 }
 
-static inline int ofi_no_async_memcpy(uint64_t device, void *dest, const void *src,
-			     size_t size, ofi_hmem_async_event_t event)
+static inline int ofi_no_async_memcpy(uint64_t device, void *dest,
+				      const void *src, size_t size,
+				      ofi_hmem_async_event_t event)
 {
 	return -FI_ENOSYS;
 }
@@ -299,8 +303,8 @@ static inline int ofi_hmem_host_unregister_noop(void *addr)
 	return FI_SUCCESS;
 }
 
-static inline int
-ofi_hmem_no_base_addr(const void *addr, void **base_addr, size_t *base_length)
+static inline int ofi_hmem_no_base_addr(const void *addr, void **base_addr,
+					size_t *base_length)
 {
 	return -FI_ENOSYS;
 }
@@ -321,17 +325,17 @@ int ofi_create_async_copy_event(enum fi_hmem_iface iface, uint64_t device,
 int ofi_free_async_copy_event(enum fi_hmem_iface iface, uint64_t device,
 			      ofi_hmem_async_event_t event);
 
-ssize_t ofi_async_copy_from_hmem_iov(void *dest, size_t size,
-				enum fi_hmem_iface hmem_iface, uint64_t device,
-				const struct iovec *hmem_iov,
-				size_t hmem_iov_count, uint64_t hmem_iov_offset,
-				ofi_hmem_async_event_t event);
+ssize_t ofi_async_copy_from_hmem_iov(
+	void *dest, size_t size, enum fi_hmem_iface hmem_iface, uint64_t device,
+	const struct iovec *hmem_iov, size_t hmem_iov_count,
+	uint64_t hmem_iov_offset, ofi_hmem_async_event_t event);
 
-ssize_t ofi_async_copy_to_hmem_iov(enum fi_hmem_iface hmem_iface, uint64_t device,
-				const struct iovec *hmem_iov,
-				size_t hmem_iov_count, uint64_t hmem_iov_offset,
-				const void *src, size_t size,
-				ofi_hmem_async_event_t event);
+ssize_t ofi_async_copy_to_hmem_iov(enum fi_hmem_iface hmem_iface,
+				   uint64_t device,
+				   const struct iovec *hmem_iov,
+				   size_t hmem_iov_count,
+				   uint64_t hmem_iov_offset, const void *src,
+				   size_t size, ofi_hmem_async_event_t event);
 
 int ofi_async_copy_query(enum fi_hmem_iface iface,
 			 ofi_hmem_async_event_t event);
@@ -365,10 +369,10 @@ ssize_t ofi_copy_to_mr_iov(struct ofi_mr **mr, const struct iovec *iov,
 			   size_t iov_count, uint64_t iov_offset,
 			   const void *src, size_t size);
 
-int ofi_hmem_get_handle(enum fi_hmem_iface iface, void *base_addr,
-			size_t size, void **handle);
-int ofi_hmem_open_handle(enum fi_hmem_iface iface, void **handle,
-			 size_t size, uint64_t device, void **mapped_addr);
+int ofi_hmem_get_handle(enum fi_hmem_iface iface, void *base_addr, size_t size,
+			void **handle);
+int ofi_hmem_open_handle(enum fi_hmem_iface iface, void **handle, size_t size,
+			 uint64_t device, void **mapped_addr);
 int ofi_hmem_close_handle(enum fi_hmem_iface iface, void *mapped_addr);
 int ofi_hmem_get_base_addr(enum fi_hmem_iface iface, const void *addr,
 			   void **base_addr, size_t *base_length);

--- a/include/ofi_hook.h
+++ b/include/ofi_hook.h
@@ -65,15 +65,14 @@ enum ofi_hook_class {
 	HOOK_DMABUF_PEER_MEM,
 };
 
-
 /*
  * Default fi_ops members, can be used to construct custom fi_ops
  */
 int hook_close(struct fid *fid);
 int hook_bind(struct fid *fid, struct fid *bfid, uint64_t flags);
 int hook_control(struct fid *fid, int command, void *arg);
-int hook_ops_open(struct fid *fid, const char *name,
-		  uint64_t flags, void **ops, void *context);
+int hook_ops_open(struct fid *fid, const char *name, uint64_t flags, void **ops,
+		  void *context);
 
 /*
  * Define hook structs so we can cast from fid to parent using simple cast.
@@ -94,7 +93,7 @@ struct fid_wait *hook_to_hwait(const struct fid_wait *wait);
  * without the external hook provider needing to implement everything"
  */
 struct hook_prov_ctx {
-	struct fi_provider	prov;
+	struct fi_provider prov;
 	/*
 	 * Hooking providers can override ini/fini calls of a specific fid class
 	 * to override any initializations that the common code may have done.
@@ -105,8 +104,8 @@ struct hook_prov_ctx {
 	 * Note: if a hooking provider overrides any of the resource creation calls
 	 * (e.g. fi_endpoint) directly, then these ini/fini calls won't be
 	 * invoked. */
-	int 			(*ini_fid[HOOK_FI_CLASS_MAX])(struct fid *fid);
-	int 			(*fini_fid[HOOK_FI_CLASS_MAX])(struct fid *fid);
+	int (*ini_fid[HOOK_FI_CLASS_MAX])(struct fid *fid);
+	int (*fini_fid[HOOK_FI_CLASS_MAX])(struct fid *fid);
 };
 
 /*
@@ -118,21 +117,23 @@ struct hook_prov_ctx {
 static inline int hook_ini_fid(struct hook_prov_ctx *prov_ctx, struct fid *fid)
 {
 	return (prov_ctx->ini_fid[fid->fclass] ?
-		prov_ctx->ini_fid[fid->fclass](fid) : 0);
+			prov_ctx->ini_fid[fid->fclass](fid) :
+			0);
 }
 
 static inline int hook_fini_fid(struct hook_prov_ctx *prov_ctx, struct fid *fid)
 {
 	return (prov_ctx->fini_fid[fid->fclass] ?
-		prov_ctx->fini_fid[fid->fclass](fid) : 0);
+			prov_ctx->fini_fid[fid->fclass](fid) :
+			0);
 }
 
 struct hook_fabric {
-	struct fid_fabric	fabric;
-	struct fid_fabric	*hfabric;
-	enum ofi_hook_class	hclass;
-	struct fi_provider	*hprov;
-	struct hook_prov_ctx	*prov_ctx;
+	struct fid_fabric fabric;
+	struct fid_fabric *hfabric;
+	enum ofi_hook_class hclass;
+	struct fi_provider *hprov;
+	struct hook_prov_ctx *prov_ctx;
 };
 
 void hook_fabric_init(struct hook_fabric *fabric, enum ofi_hook_class hclass,
@@ -173,7 +174,6 @@ int hook_domain_init(struct fid_fabric *fabric, struct fi_info *info,
 int hook_domain(struct fid_fabric *fabric, struct fi_info *info,
 		struct fid_domain **domain, void *context);
 
-
 struct hook_av {
 	struct fid_av av;
 	struct fid_av *hav;
@@ -182,7 +182,6 @@ struct hook_av {
 
 int hook_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 		 struct fid_av **av, void *context);
-
 
 struct hook_wait {
 	struct fid_wait wait;
@@ -193,7 +192,6 @@ struct hook_wait {
 int hook_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
 		   struct fid_wait **waitset);
 int hook_trywait(struct fid_fabric *fabric, struct fid **fids, int count);
-
 
 struct hook_poll {
 	struct fid_poll poll;
@@ -216,10 +214,10 @@ struct hook_eq {
 	struct hook_fabric *fabric;
 };
 
-ssize_t hook_eq_read(struct fid_eq *eq, uint32_t *event,
-			    void *buf, size_t len, uint64_t flags);
-ssize_t hook_eq_sread(struct fid_eq *eq, uint32_t *event,
-			     void *buf, size_t len, int timeout, uint64_t flags);
+ssize_t hook_eq_read(struct fid_eq *eq, uint32_t *event, void *buf, size_t len,
+		     uint64_t flags);
+ssize_t hook_eq_sread(struct fid_eq *eq, uint32_t *event, void *buf, size_t len,
+		      int timeout, uint64_t flags);
 int hook_eq_init(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 		 struct fid_eq **eq, void *context, struct hook_eq *myeq);
 int hook_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
@@ -241,9 +239,8 @@ int hook_cq_init(struct fid_domain *domain, struct fi_cq_attr *attr,
 		 struct fid_cq **cq, void *context, struct hook_cq *mycq);
 int hook_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		 struct fid_cq **cq, void *context);
-const char *
-hook_cq_strerror(struct fid_cq *cq, int prov_errno,
-		 const void *err_data, char *buf, size_t len);
+const char *hook_cq_strerror(struct fid_cq *cq, int prov_errno,
+			     const void *err_data, char *buf, size_t len);
 
 struct hook_cntr {
 	struct fid_cntr cntr;
@@ -253,7 +250,6 @@ struct hook_cntr {
 
 int hook_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 		   struct fid_cntr **cntr, void *context);
-
 
 struct hook_ep {
 	struct fid_ep ep;
@@ -268,12 +264,12 @@ int hook_endpoint(struct fid_domain *domain, struct fi_info *info,
 		  struct fid_ep **ep, void *context);
 int hook_scalable_ep(struct fid_domain *domain, struct fi_info *info,
 		     struct fid_ep **sep, void *context);
-int hook_srx_ctx(struct fid_domain *domain,
-		 struct fi_rx_attr *attr, struct fid_ep **rx_ep,
-		 void *context);
+int hook_srx_ctx(struct fid_domain *domain, struct fi_rx_attr *attr,
+		 struct fid_ep **rx_ep, void *context);
 
 int hook_query_atomic(struct fid_domain *domain, enum fi_datatype datatype,
-		  enum fi_op op, struct fi_atomic_attr *attr, uint64_t flags);
+		      enum fi_op op, struct fi_atomic_attr *attr,
+		      uint64_t flags);
 int hook_query_collective(struct fid_domain *domain, enum fi_collective_op coll,
 			  struct fi_collective_attr *attr, uint64_t flags);
 
@@ -290,7 +286,6 @@ extern struct fi_ops_rma hook_rma_ops;
 extern struct fi_ops_tagged hook_tagged_ops;
 extern struct fi_ops_atomic hook_atomic_ops;
 
-
 struct hook_pep {
 	struct fid_pep pep;
 	struct fid_pep *hpep;
@@ -300,23 +295,19 @@ struct hook_pep {
 int hook_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 		    struct fid_pep **pep, void *context);
 
-
 struct hook_stx {
 	struct fid_stx stx;
 	struct fid_stx *hstx;
 	struct hook_domain *domain;
 };
 
-int hook_stx_ctx(struct fid_domain *domain,
-		 struct fi_tx_attr *attr, struct fid_stx **stx,
-		 void *context);
-
+int hook_stx_ctx(struct fid_domain *domain, struct fi_tx_attr *attr,
+		 struct fid_stx **stx, void *context);
 
 struct hook_mr {
 	struct fid_mr mr;
 	struct fid_mr *hmr;
 	struct hook_domain *domain;
 };
-
 
 #endif /* _OFI_HOOK_H_ */

--- a/include/ofi_indexer.h
+++ b/include/ofi_indexer.h
@@ -59,7 +59,7 @@
 
 struct ofi_idx_entry {
 	void *item;
-	int   next;
+	int next;
 };
 
 /* User's index is a bit field of format: [chunk_id:offset] */
@@ -69,14 +69,13 @@ struct ofi_idx_entry {
 #define OFI_IDX_CHUNK_SIZE (1 << OFI_IDX_OFFSET_BITS)
 #define OFI_IDX_MAX_CHUNKS (1 << OFI_IDX_CHUNK_BITS)
 
-#define OFI_IDX_MAX_INDEX  ((OFI_IDX_MAX_CHUNKS * OFI_IDX_CHUNK_SIZE) - 1)
+#define OFI_IDX_MAX_INDEX ((OFI_IDX_MAX_CHUNKS * OFI_IDX_CHUNK_SIZE) - 1)
 
-struct indexer
-{
-	struct ofi_idx_entry 	*chunk[OFI_IDX_MAX_CHUNKS];
-	int		 	free_list;
+struct indexer {
+	struct ofi_idx_entry *chunk[OFI_IDX_MAX_CHUNKS];
+	int free_list;
 	/* Array size (used): [0, OFI_IDX_MAX_CHUNKS) */
-	int		 	size;
+	int size;
 };
 
 #define ofi_idx_chunk_id(index) (index >> OFI_IDX_OFFSET_BITS)
@@ -93,8 +92,8 @@ static inline int ofi_idx_is_valid(struct indexer *idx, int index)
 	return (index > 0) && (index < idx->size * OFI_IDX_CHUNK_SIZE);
 }
 
-static inline struct ofi_idx_entry *
-ofi_idx_chunk(struct indexer *idx, int index)
+static inline struct ofi_idx_entry *ofi_idx_chunk(struct indexer *idx,
+						  int index)
 {
 	assert(ofi_idx_is_valid(idx, index));
 	return idx->chunk[ofi_idx_chunk_id(index)];
@@ -115,7 +114,6 @@ static inline bool ofi_idx_free_list_empty(struct indexer *idx)
 	return (idx->free_list == 0);
 }
 
-
 /*
  * Index map:
  * The index map is similar in concept to the indexer.  It allows the user
@@ -131,8 +129,7 @@ static inline bool ofi_idx_free_list_empty(struct indexer *idx)
  * the index map by setting it to 0.
  */
 
-struct index_map
-{
+struct index_map {
 	void **chunk[OFI_IDX_MAX_CHUNKS];
 	int count[OFI_IDX_MAX_CHUNKS];
 };
@@ -158,20 +155,19 @@ static inline void *ofi_idm_at(struct index_map *idm, int index)
 static inline void *ofi_idm_lookup(struct index_map *idm, int index)
 {
 	return ((index <= OFI_IDX_MAX_INDEX) && ofi_idm_chunk(idm, index)) ?
-		ofi_idm_at(idm, index) : NULL;
+		       ofi_idm_at(idm, index) :
+		       NULL;
 }
 
-
-struct ofi_dyn_arr
-{
+struct ofi_dyn_arr {
 	char *chunk[OFI_IDX_MAX_CHUNKS];
 	size_t item_size;
 	void (*init)(struct ofi_dyn_arr *arr, void *item);
 };
 
-static inline void
-ofi_array_init(struct ofi_dyn_arr *arr, size_t item_size,
-	       void (*init)(struct ofi_dyn_arr *arr, void *item))
+static inline void ofi_array_init(struct ofi_dyn_arr *arr, size_t item_size,
+				  void (*init)(struct ofi_dyn_arr *arr,
+					       void *item))
 {
 	memset(arr, 0, sizeof(*arr));
 	arr->item_size = item_size;
@@ -191,8 +187,8 @@ static inline char *ofi_array_chunk(struct ofi_dyn_arr *arr, int index)
 	return arr->chunk[ofi_idx_chunk_id(index)];
 }
 
-static inline void *
-ofi_array_item(struct ofi_dyn_arr *arr, char *chunk, int offset)
+static inline void *ofi_array_item(struct ofi_dyn_arr *arr, char *chunk,
+				   int offset)
 {
 	return chunk + arr->item_size * offset;
 }

--- a/include/ofi_iov.h
+++ b/include/ofi_iov.h
@@ -44,8 +44,8 @@
 #include <inttypes.h>
 #include <rdma/fabric.h>
 
-
-static inline size_t ofi_total_iov_len(const struct iovec *iov, size_t iov_count)
+static inline size_t ofi_total_iov_len(const struct iovec *iov,
+				       size_t iov_count)
 {
 	size_t i, len = 0;
 	for (i = 0; i < iov_count; i++)
@@ -53,7 +53,8 @@ static inline size_t ofi_total_iov_len(const struct iovec *iov, size_t iov_count
 	return len;
 }
 
-static inline size_t ofi_total_ioc_cnt(const struct fi_ioc *ioc, size_t ioc_count)
+static inline size_t ofi_total_ioc_cnt(const struct fi_ioc *ioc,
+				       size_t ioc_count)
 {
 	size_t i, cnt = 0;
 	for (i = 0; i < ioc_count; i++)
@@ -84,7 +85,8 @@ static inline size_t ofi_total_rma_ioc_cnt(const struct fi_rma_ioc *rma_ioc,
 #define OFI_COPY_BUF_TO_IOV 1
 
 static inline size_t ofi_iov_bytes_to_copy(const struct iovec *iov,
-			size_t *size, size_t *offset, char **copy_buf)
+					   size_t *size, size_t *offset,
+					   char **copy_buf)
 {
 	uint64_t len;
 
@@ -105,38 +107,43 @@ static inline size_t ofi_iov_bytes_to_copy(const struct iovec *iov,
 	return len;
 }
 
-uint64_t ofi_copy_iov_buf(const struct iovec *iov, size_t iov_count, uint64_t iov_offset,
-			  void *buf, uint64_t bufsize, int dir);
+uint64_t ofi_copy_iov_buf(const struct iovec *iov, size_t iov_count,
+			  uint64_t iov_offset, void *buf, uint64_t bufsize,
+			  int dir);
 
-static inline uint64_t
-ofi_copy_to_iov(const struct iovec *iov, size_t iov_count, uint64_t iov_offset,
-		void *buf, uint64_t bufsize)
+static inline uint64_t ofi_copy_to_iov(const struct iovec *iov,
+				       size_t iov_count, uint64_t iov_offset,
+				       void *buf, uint64_t bufsize)
 {
 	if (iov_count == 1) {
-		uint64_t size = ((iov_offset > iov[0].iov_len) ?
-				 0 : MIN(bufsize, iov[0].iov_len - iov_offset));
+		uint64_t size =
+			((iov_offset > iov[0].iov_len) ?
+				 0 :
+				 MIN(bufsize, iov[0].iov_len - iov_offset));
 
 		memcpy((char *)iov[0].iov_base + iov_offset, buf, size);
 		return size;
 	} else {
-		return ofi_copy_iov_buf(iov, iov_count, iov_offset, buf, bufsize,
-					OFI_COPY_BUF_TO_IOV);
+		return ofi_copy_iov_buf(iov, iov_count, iov_offset, buf,
+					bufsize, OFI_COPY_BUF_TO_IOV);
 	}
 }
 
-static inline uint64_t
-ofi_copy_from_iov(void *buf, uint64_t bufsize,
-		  const struct iovec *iov, size_t iov_count, uint64_t iov_offset)
+static inline uint64_t ofi_copy_from_iov(void *buf, uint64_t bufsize,
+					 const struct iovec *iov,
+					 size_t iov_count, uint64_t iov_offset)
 {
 	if (iov_count == 1) {
-		uint64_t size = ((iov_offset > iov[0].iov_len) ?
-				 0 : MIN(bufsize, iov[0].iov_len - iov_offset));
+		uint64_t size =
+			((iov_offset > iov[0].iov_len) ?
+				 0 :
+				 MIN(bufsize, iov[0].iov_len - iov_offset));
 
 		memcpy(buf, (char *)iov[0].iov_base + iov_offset, size);
 		return size;
 	} else {
-		return ofi_copy_iov_buf(iov, iov_count, iov_offset, buf, bufsize,
-					OFI_COPY_IOV_TO_BUF);
+		return ofi_copy_iov_buf(iov, iov_count, iov_offset, buf,
+					bufsize, OFI_COPY_IOV_TO_BUF);
 	}
 }
 
@@ -151,8 +158,8 @@ static inline void ofi_ioc_to_iov(const struct fi_ioc *ioc, struct iovec *iov,
 }
 
 static inline void ofi_rma_ioc_to_iov(const struct fi_rma_ioc *ioc,
-				      struct fi_rma_iov *iov,
-				      size_t count, size_t size)
+				      struct fi_rma_iov *iov, size_t count,
+				      size_t size)
 {
 	int i;
 	for (i = 0; i < count; i++) {
@@ -162,40 +169,39 @@ static inline void ofi_rma_ioc_to_iov(const struct fi_rma_ioc *ioc,
 	}
 }
 
-static inline void *
-ofi_iov_end(const struct iovec *iov)
+static inline void *ofi_iov_end(const struct iovec *iov)
 {
-	return ((char *) iov->iov_base) + iov->iov_len - 1;
+	return ((char *)iov->iov_base) + iov->iov_len - 1;
 }
 
-static inline bool
-ofi_iov_left(const struct iovec *iov1, const struct iovec *iov2)
+static inline bool ofi_iov_left(const struct iovec *iov1,
+				const struct iovec *iov2)
 {
 	return ofi_iov_end(iov1) < iov2->iov_base;
 }
 
-static inline bool
-ofi_iov_right(const struct iovec *iov1, const struct iovec *iov2)
+static inline bool ofi_iov_right(const struct iovec *iov1,
+				 const struct iovec *iov2)
 {
 	return iov1->iov_base > ofi_iov_end(iov2);
 }
 
-static inline bool
-ofi_iov_shifted_left(const struct iovec *iov1, const struct iovec *iov2)
+static inline bool ofi_iov_shifted_left(const struct iovec *iov1,
+					const struct iovec *iov2)
 {
 	return ((iov1->iov_base < iov2->iov_base) &&
 		(ofi_iov_end(iov1) < ofi_iov_end(iov2)));
 }
 
-static inline bool
-ofi_iov_shifted_right(const struct iovec *iov1, const struct iovec *iov2)
+static inline bool ofi_iov_shifted_right(const struct iovec *iov1,
+					 const struct iovec *iov2)
 {
 	return ((iov1->iov_base > iov2->iov_base) &&
 		(ofi_iov_end(iov1) > ofi_iov_end(iov2)));
 }
 
-static inline bool
-ofi_iov_within(const struct iovec *iov1, const struct iovec *iov2)
+static inline bool ofi_iov_within(const struct iovec *iov1,
+				  const struct iovec *iov2)
 {
 	return (iov1->iov_base >= iov2->iov_base) &&
 	       (ofi_iov_end(iov1) <= ofi_iov_end(iov2));
@@ -203,8 +209,8 @@ ofi_iov_within(const struct iovec *iov1, const struct iovec *iov2)
 
 void ofi_consume_iov(struct iovec *iovec, size_t *iovec_count, size_t offset);
 
-void ofi_consume_iov_desc(struct iovec *iovec, void **desc,
-			  size_t *iovec_count, size_t offset);
+void ofi_consume_iov_desc(struct iovec *iovec, void **desc, size_t *iovec_count,
+			  size_t offset);
 
 void ofi_consume_rma_iov(struct fi_rma_iov *rma_iov, size_t *rma_iov_count,
 			 size_t length);
@@ -218,6 +224,6 @@ int ofi_copy_iov_desc(struct iovec *dst_iov, void **dst_desc, size_t *dst_count,
 
 /* Copy 'len' bytes worth of src fi_rma_iov to dst */
 int ofi_copy_rma_iov(struct fi_rma_iov *dst_iov, size_t *dst_count,
-		struct fi_rma_iov *src_iov, size_t src_count,
-		size_t *index, size_t *offset, size_t len);
+		     struct fi_rma_iov *src_iov, size_t src_count,
+		     size_t *index, size_t *offset, size_t len);
 #endif /* _OFI_IOV_H_ */

--- a/include/ofi_list.h
+++ b/include/ofi_list.h
@@ -45,21 +45,20 @@
 #include <ofi_signal.h>
 #include <ofi_lock.h>
 
-
-enum ofi_list_end {
-	OFI_LIST_TAIL,
-	OFI_LIST_HEAD
-};
+enum ofi_list_end { OFI_LIST_TAIL, OFI_LIST_HEAD };
 
 /*
  * Double-linked list
  */
 struct dlist_entry {
-	struct dlist_entry	*next;
-	struct dlist_entry	*prev;
+	struct dlist_entry *next;
+	struct dlist_entry *prev;
 };
 
-#define DLIST_INIT(addr) { addr, addr }
+#define DLIST_INIT(addr)   \
+	{                  \
+		addr, addr \
+	}
 #define DEFINE_LIST(name) struct dlist_entry name = DLIST_INIT(&name)
 
 static inline void dlist_init(struct dlist_entry *head)
@@ -73,8 +72,8 @@ static inline int dlist_empty(struct dlist_entry *head)
 	return head->next == head;
 }
 
-static inline void
-dlist_insert_after(struct dlist_entry *item, struct dlist_entry *head)
+static inline void dlist_insert_after(struct dlist_entry *item,
+				      struct dlist_entry *head)
 {
 	item->next = head->next;
 	item->prev = head;
@@ -82,8 +81,8 @@ dlist_insert_after(struct dlist_entry *item, struct dlist_entry *head)
 	head->next = item;
 }
 
-static inline void
-dlist_insert_before(struct dlist_entry *item, struct dlist_entry *head)
+static inline void dlist_insert_before(struct dlist_entry *item,
+				       struct dlist_entry *head)
 {
 	dlist_insert_after(item, head->prev);
 }
@@ -103,51 +102,52 @@ static inline void dlist_remove_init(struct dlist_entry *item)
 	dlist_init(item);
 }
 
-#define dlist_pop_front(head, type, container, member)			\
-	do {								\
-		container = container_of((head)->next, type, member);	\
-		dlist_remove((head)->next);				\
+#define dlist_pop_front(head, type, container, member)                \
+	do {                                                          \
+		container = container_of((head)->next, type, member); \
+		dlist_remove((head)->next);                           \
 	} while (0)
 
-#define dlist_foreach(head, item) 						\
+#define dlist_foreach(head, item) \
 	for ((item) = (head)->next; (item) != (head); (item) = (item)->next)
 
-#define dlist_foreach_reverse(head, item) 					\
+#define dlist_foreach_reverse(head, item) \
 	for ((item) = (head)->prev; (item) != (head); (item) = (item)->prev)
 
-#define dlist_foreach_container(head, type, container, member)			\
-	for ((container) = container_of((head)->next, type, member);		\
-	     &((container)->member) != (head);					\
-	     (container) = container_of((container)->member.next,		\
-					type, member))
+#define dlist_foreach_container(head, type, container, member)       \
+	for ((container) = container_of((head)->next, type, member); \
+	     &((container)->member) != (head);                       \
+	     (container) =                                           \
+		     container_of((container)->member.next, type, member))
 
-#define dlist_foreach_container_reverse(head, type, container, member)		\
-	for ((container) = container_of((head)->prev, type, member);		\
-	     &((container)->member) != (head);					\
-	     (container) = container_of((container)->member.prev,		\
-					type, member))
+#define dlist_foreach_container_reverse(head, type, container, member) \
+	for ((container) = container_of((head)->prev, type, member);   \
+	     &((container)->member) != (head);                         \
+	     (container) =                                             \
+		     container_of((container)->member.prev, type, member))
 
-#define dlist_foreach_safe(head, item, tmp)					\
-	for ((item) = (head)->next, (tmp) = (item)->next; (item) != (head);	\
-             (item) = (tmp), (tmp) = (item)->next)
+#define dlist_foreach_safe(head, item, tmp)                                 \
+	for ((item) = (head)->next, (tmp) = (item)->next; (item) != (head); \
+	     (item) = (tmp), (tmp) = (item)->next)
 
-#define dlist_foreach_reverse_safe(head, item, tmp)				\
-	for ((item) = (head)->prev, (tmp) = (item)->prev; (item) != (head);	\
-             (item) = (tmp), (tmp) = (item)->prev)
+#define dlist_foreach_reverse_safe(head, item, tmp)                         \
+	for ((item) = (head)->prev, (tmp) = (item)->prev; (item) != (head); \
+	     (item) = (tmp), (tmp) = (item)->prev)
 
-#define dlist_foreach_container_safe(head, type, container, member, tmp)	\
-	for ((container) = container_of((head)->next, type, member),		\
-	     (tmp) = (container)->member.next;					\
-	     &((container)->member) != (head);					\
-	     (container) = container_of((tmp), type, member),			\
-	     (tmp) = (container)->member.next)
+#define dlist_foreach_container_safe(head, type, container, member, tmp) \
+	for ((container) = container_of((head)->next, type, member),     \
+	    (tmp) = (container)->member.next;                            \
+	     &((container)->member) != (head);                           \
+	     (container) = container_of((tmp), type, member),            \
+	    (tmp) = (container)->member.next)
 
-#define dlist_foreach_container_reverse_safe(head, type, container, member, tmp)\
-	for ((container) = container_of((head)->prev, type, member),		\
-	     (tmp) = (container)->member.prev;					\
-	     &((container)->member) != (head);					\
-	     (container) = container_of((tmp), type, member),			\
-	     (tmp) = (container)->member.prev)
+#define dlist_foreach_container_reverse_safe(head, type, container, member, \
+					     tmp)                           \
+	for ((container) = container_of((head)->prev, type, member),        \
+	    (tmp) = (container)->member.prev;                               \
+	     &((container)->member) != (head);                              \
+	     (container) = container_of((tmp), type, member),               \
+	    (tmp) = (container)->member.prev)
 
 typedef int dlist_func_t(struct dlist_entry *item, const void *arg);
 
@@ -157,7 +157,8 @@ dlist_find_first_match(struct dlist_entry *head, dlist_func_t *match,
 {
 	struct dlist_entry *item;
 
-	dlist_foreach(head, item) {
+	dlist_foreach(head, item)
+	{
 		if (match(item, arg))
 			return item;
 	}
@@ -178,7 +179,8 @@ dlist_remove_first_match(struct dlist_entry *head, dlist_func_t *match,
 	return item;
 }
 
-static inline void dlist_insert_order(struct dlist_entry *head, dlist_func_t *order,
+static inline void dlist_insert_order(struct dlist_entry *head,
+				      dlist_func_t *order,
 				      struct dlist_entry *entry)
 {
 	struct dlist_entry *item;
@@ -238,8 +240,8 @@ static inline void dlist_splice_tail(struct dlist_entry *head,
  * Multi-threaded Double-linked list
  */
 struct dlist_ts {
-	struct dlist_entry	head;
-	ofi_spin_t		lock;
+	struct dlist_entry head;
+	ofi_spin_t lock;
 };
 
 static inline void dlist_ts_init(struct dlist_ts *list)
@@ -253,92 +255,95 @@ static inline int dlist_ts_empty(struct dlist_ts *list)
 	return dlist_empty(&list->head);
 }
 
-static inline void
-dlist_ts_insert_after(struct dlist_ts *list, struct dlist_entry *item,
-		      struct dlist_entry *head)
+static inline void dlist_ts_insert_after(struct dlist_ts *list,
+					 struct dlist_entry *item,
+					 struct dlist_entry *head)
 {
 	ofi_spin_lock(&list->lock);
 	dlist_insert_after(item, head);
 	ofi_spin_unlock(&list->lock);
 }
 
-static inline void
-dlist_ts_insert_before(struct dlist_ts *list, struct dlist_entry *item,
-		       struct dlist_entry *head)
+static inline void dlist_ts_insert_before(struct dlist_ts *list,
+					  struct dlist_entry *item,
+					  struct dlist_entry *head)
 {
 	dlist_ts_insert_after(list, item, head->prev);
 }
 
-#define dlist_ts_insert_head(list, item) dlist_ts_insert_after(list, item, &(list)->head)
-#define dlist_ts_insert_tail(list, item) dlist_ts_insert_before(list, item, &(list)->head)
+#define dlist_ts_insert_head(list, item) \
+	dlist_ts_insert_after(list, item, &(list)->head)
+#define dlist_ts_insert_tail(list, item) \
+	dlist_ts_insert_before(list, item, &(list)->head)
 
-static inline void
-dlist_ts_remove(struct dlist_ts *list, struct dlist_entry *item)
+static inline void dlist_ts_remove(struct dlist_ts *list,
+				   struct dlist_entry *item)
 {
 	ofi_spin_lock(&list->lock);
 	dlist_remove(item);
 	ofi_spin_unlock(&list->lock);
 }
 
-#define dlist_ts_pop_front(list, type, container, member)		\
-	do {								\
-		ofi_spin_lock(&(list)->lock);			\
-		if (dlist_ts_empty(list)) {				\
-			container = NULL;				\
-		} else {						\
-			dlist_pop_front(&(list)->head, type,		\
-					container, member);		\
-		}							\
-		ofi_spin_unlock(&(list)->lock);			\
+#define dlist_ts_pop_front(list, type, container, member)               \
+	do {                                                            \
+		ofi_spin_lock(&(list)->lock);                           \
+		if (dlist_ts_empty(list)) {                             \
+			container = NULL;                               \
+		} else {                                                \
+			dlist_pop_front(&(list)->head, type, container, \
+					member);                        \
+		}                                                       \
+		ofi_spin_unlock(&(list)->lock);                         \
 	} while (0)
 
-#define dlist_ts_foreach_end(list)				\
-		ofi_spin_unlock(&(list)->lock);		\
-	} while (0)
+#define dlist_ts_foreach_end(list)      \
+	ofi_spin_unlock(&(list)->lock); \
+	}                               \
+	while (0)
 
-#define dlist_ts_foreach(list, head, item)			\
-	{							\
-		ofi_spin_lock(&(list)->lock);		\
+#define dlist_ts_foreach(list, head, item)    \
+	{                                     \
+		ofi_spin_lock(&(list)->lock); \
 		dlist_foreach(list, head, item)
 
-#define dlist_ts_foreach_reverse(list, head, item)		\
-	{							\
-		ofi_spin_lock(&(list)->lock);		\
+#define dlist_ts_foreach_reverse(list, head, item) \
+	{                                          \
+		ofi_spin_lock(&(list)->lock);      \
 		dlist_foreach_reverse(list, head, item)
 
-#define dlist_ts_foreach_container(list, head, type, container, member)		\
-	{									\
-		ofi_spin_lock(&(list)->lock);				\
+#define dlist_ts_foreach_container(list, head, type, container, member) \
+	{                                                               \
+		ofi_spin_lock(&(list)->lock);                           \
 		dlist_foreach_container(type, container, member)
 
-#define dlist_ts_foreach_container_reverse(list, head, type, container, member)\
-	{									\
-		ofi_spin_lock(&(list)->lock);				\
+#define dlist_ts_foreach_container_reverse(list, head, type, container, \
+					   member)                      \
+	{                                                               \
+		ofi_spin_lock(&(list)->lock);                           \
 		dlist_foreach_container_reverse(type, container, member)
 
-#define dlist_ts_foreach_safe(list, head, item, tmp)				\
-	{									\
-		ofi_spin_lock(&(list)->lock);				\
+#define dlist_ts_foreach_safe(list, head, item, tmp) \
+	{                                            \
+		ofi_spin_lock(&(list)->lock);        \
 		dlist_foreach_safe(head, item, tmp)
 
-#define dlist_ts_foreach_reverse_safe(list, head, item, tmp)			\
-	{									\
-		ofi_spin_lock(&(list)->lock);				\
+#define dlist_ts_foreach_reverse_safe(list, head, item, tmp) \
+	{                                                    \
+		ofi_spin_lock(&(list)->lock);                \
 		dlist_foreach_reverse_safe(head, item, tmp)
 
-#define dlist_ts_foreach_container_safe(list, head, type, container,	\
-					member, tmp)			\
-	{								\
-		ofi_spin_lock(&(list)->lock);			\
-		dlist_foreach_container_safe(head, type, container,	\
-					     member, tmp)
+#define dlist_ts_foreach_container_safe(list, head, type, container, member, \
+					tmp)                                 \
+	{                                                                    \
+		ofi_spin_lock(&(list)->lock);                                \
+		dlist_foreach_container_safe(head, type, container, member, tmp)
 
-#define dlist_ts_foreach_container_reverse_safe(list, head, type, container,\
-					member, tmp)				\
-	{									\
-		ofi_spin_lock(&(list)->lock);				\
-		dlist_foreach_container_reverse_safe(head, type, container,	\
-					     member, tmp)
+#define dlist_ts_foreach_container_reverse_safe(list, head, type, container, \
+						member, tmp)                 \
+	{                                                                    \
+		ofi_spin_lock(&(list)->lock);                                \
+		dlist_foreach_container_reverse_safe(head, type, container,  \
+						     member, tmp)
 
 static inline struct dlist_entry *
 dlist_ts_find_first_match(struct dlist_ts *list, struct dlist_entry *head,
@@ -366,28 +371,30 @@ dlist_ts_remove_first_match(struct dlist_ts *list, struct dlist_entry *head,
 	return item;
 }
 
-#define dlist_ts_splice_head(list, head, to_splice)	\
-	{						\
-		ofi_spin_lock(&(list)->lock);	\
-		dlist_splice_head(head, to_splice);	\
-		ofi_spin_unlock(&list->lock);		\
-	} while(0)
+#define dlist_ts_splice_head(list, head, to_splice) \
+	{                                           \
+		ofi_spin_lock(&(list)->lock);       \
+		dlist_splice_head(head, to_splice); \
+		ofi_spin_unlock(&list->lock);       \
+	}                                           \
+	while (0)
 
-#define dlist_ts_splice_tail(list, head, to_splice)		\
-	{							\
-		dlist_ts_splice_head(head->prev, to_splice);	\
-	} while(0)
+#define dlist_ts_splice_tail(list, head, to_splice)          \
+	{                                                    \
+		dlist_ts_splice_head(head->prev, to_splice); \
+	}                                                    \
+	while (0)
 
 /*
  * Single-linked list
  */
 struct slist_entry {
-	struct slist_entry	*next;
+	struct slist_entry *next;
 };
 
 struct slist {
-	struct slist_entry	*head;
-	struct slist_entry	*tail;
+	struct slist_entry *head;
+	struct slist_entry *tail;
 };
 
 static inline void slist_init(struct slist *list)
@@ -400,7 +407,8 @@ static inline int slist_empty(struct slist *list)
 	return !list->head;
 }
 
-static inline void slist_insert_head(struct slist_entry *item, struct slist *list)
+static inline void slist_insert_head(struct slist_entry *item,
+				     struct slist *list)
 {
 	if (slist_empty(list)) {
 		list->tail = item;
@@ -412,7 +420,8 @@ static inline void slist_insert_head(struct slist_entry *item, struct slist *lis
 	list->head = item;
 }
 
-static inline void slist_insert_tail(struct slist_entry *item, struct slist *list)
+static inline void slist_insert_tail(struct slist_entry *item,
+				     struct slist *list)
 {
 	if (slist_empty(list))
 		list->head = item;
@@ -440,27 +449,25 @@ static inline struct slist_entry *slist_remove_head(struct slist *list)
 	return item;
 }
 
-#define slist_foreach(list, item, prev)				\
-	for ((prev) = NULL, (item) = (list)->head; (item); 	\
-			(prev) = (item), (item) = (item)->next)
+#define slist_foreach(list, item, prev)                    \
+	for ((prev) = NULL, (item) = (list)->head; (item); \
+	     (prev) = (item), (item) = (item)->next)
 
-
-#define slist_remove_head_container(list, type, container, member)	\
-	do {								\
-		if (slist_empty(list)) {				\
-			container = NULL;				\
-		} else {						\
-			container = container_of((list)->head, type,    \
-					member);			\
-			slist_remove_head(list);			\
-		}							\
+#define slist_remove_head_container(list, type, container, member)            \
+	do {                                                                  \
+		if (slist_empty(list)) {                                      \
+			container = NULL;                                     \
+		} else {                                                      \
+			container = container_of((list)->head, type, member); \
+			slist_remove_head(list);                              \
+		}                                                             \
 	} while (0)
 
 typedef int slist_func_t(struct slist_entry *item, const void *arg);
 
 static inline struct slist_entry *
 slist_find_first_match(const struct slist *list, slist_func_t *match,
-			const void *arg)
+		       const void *arg)
 {
 	struct slist_entry *item;
 	for (item = list->head; item; item = item->next) {
@@ -471,13 +478,14 @@ slist_find_first_match(const struct slist *list, slist_func_t *match,
 	return NULL;
 }
 
-static inline void
-slist_insert_before_first_match(struct slist *list, slist_func_t *match,
-				struct slist_entry *entry)
+static inline void slist_insert_before_first_match(struct slist *list,
+						   slist_func_t *match,
+						   struct slist_entry *entry)
 {
 	struct slist_entry *cur, *prev;
 
-	slist_foreach(list, cur, prev) {
+	slist_foreach(list, cur, prev)
+	{
 		if (match(cur, entry)) {
 			if (!prev) {
 				slist_insert_head(entry, list);
@@ -491,8 +499,8 @@ slist_insert_before_first_match(struct slist *list, slist_func_t *match,
 	slist_insert_tail(entry, list);
 }
 
-static inline void slist_remove(struct slist *list,
-		struct slist_entry *item, struct slist_entry *prev)
+static inline void slist_remove(struct slist *list, struct slist_entry *item,
+				struct slist_entry *prev)
 {
 	if (prev)
 		prev->next = item->next;
@@ -503,12 +511,14 @@ static inline void slist_remove(struct slist *list,
 		list->tail = prev;
 }
 
-static inline struct slist_entry *
-slist_remove_first_match(struct slist *list, slist_func_t *match, const void *arg)
+static inline struct slist_entry *slist_remove_first_match(struct slist *list,
+							   slist_func_t *match,
+							   const void *arg)
 {
 	struct slist_entry *item, *prev;
 
-	slist_foreach(list, item, prev) {
+	slist_foreach(list, item, prev)
+	{
 		if (match(item, arg)) {
 			slist_remove(list, item, prev);
 			return item;
@@ -540,8 +550,8 @@ static inline void slist_swap(struct slist *dst, struct slist *src)
  * dst: HEAD->d->e->a->b->c->TAIL
  * src: HEAD->TAIL (empty list)
  */
-static inline struct slist *
-slist_splice_head(struct slist *dst, struct slist *src)
+static inline struct slist *slist_splice_head(struct slist *dst,
+					      struct slist *src)
 {
 	if (slist_empty(src))
 		return dst;
@@ -569,8 +579,8 @@ slist_splice_head(struct slist *dst, struct slist *src)
  * dst: HEAD->a->b->c->d->e->TAIL
  * src: HEAD->TAIL (empty list)
  */
-static inline struct slist *
-slist_splice_tail(struct slist *dst, struct slist *src)
+static inline struct slist *slist_splice_tail(struct slist *dst,
+					      struct slist *src)
 {
 	if (slist_empty(src))
 		return dst;
@@ -593,8 +603,8 @@ slist_splice_tail(struct slist *dst, struct slist *src)
  */
 
 struct slistfd {
-	struct slist 		list;
-	struct fd_signal	signal;
+	struct slist list;
+	struct fd_signal signal;
 };
 
 static inline int slistfd_init(struct slistfd *list)
@@ -613,15 +623,15 @@ static inline int slistfd_empty(struct slistfd *list)
 	return slist_empty(&list->list);
 }
 
-static inline void
-slistfd_insert_head(struct slist_entry *item, struct slistfd *list)
+static inline void slistfd_insert_head(struct slist_entry *item,
+				       struct slistfd *list)
 {
 	slist_insert_head(item, &list->list);
 	fd_signal_set(&list->signal);
 }
 
-static inline void
-slistfd_insert_tail(struct slist_entry *item, struct slistfd *list)
+static inline void slistfd_insert_tail(struct slist_entry *item,
+				       struct slistfd *list)
 {
 	slist_insert_tail(item, &list->list);
 	fd_signal_set(&list->signal);
@@ -657,7 +667,7 @@ static inline int slistfd_get_fd(struct slistfd *list)
 
 struct dlistfd_head {
 	struct dlist_entry list;
-	struct fd_signal   signal;
+	struct fd_signal signal;
 };
 
 static inline int dlistfd_head_init(struct dlistfd_head *head)
@@ -687,21 +697,22 @@ static inline void dlistfd_reset(struct dlistfd_head *head)
 		fd_signal_reset(&head->signal);
 }
 
-static inline void
-dlistfd_insert_head(struct dlist_entry *item, struct dlistfd_head *head)
+static inline void dlistfd_insert_head(struct dlist_entry *item,
+				       struct dlistfd_head *head)
 {
 	dlist_insert_after(item, &head->list);
 	dlistfd_signal(head);
 }
 
-static inline void
-dlistfd_insert_tail(struct dlist_entry *item, struct dlistfd_head *head)
+static inline void dlistfd_insert_tail(struct dlist_entry *item,
+				       struct dlistfd_head *head)
 {
 	dlist_insert_before(item, &head->list);
 	dlistfd_signal(head);
 }
 
-static inline void dlistfd_remove(struct dlist_entry *item, struct dlistfd_head *head)
+static inline void dlistfd_remove(struct dlist_entry *item,
+				  struct dlistfd_head *head)
 {
 	dlist_remove(item);
 	dlistfd_reset(head);

--- a/include/ofi_lock.h
+++ b/include/ofi_lock.h
@@ -43,14 +43,11 @@
 
 #include <ofi_osd.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
 int ofi_wait_cond(pthread_cond_t *cond, pthread_mutex_t *mut, int timeout_ms);
-
 
 #if PT_LOCK_SPIN == 1
 
@@ -154,28 +151,28 @@ static inline void ofi_spin_unlock_noop(ofi_spin_t *lock)
 
 #else /* !ENABLE_DEBUG */
 
-#  define ofi_spin_t ofi_spin_t_
-#  define ofi_spin_init(lock) ofi_spin_init_(lock)
-#  define ofi_spin_destroy(lock) ofi_spin_destroy_(lock)
-#  define ofi_spin_lock(lock) ofi_spin_lock_(lock)
-#  define ofi_spin_trylock(lock) ofi_spin_trylock_(lock)
-#  define ofi_spin_unlock(lock) ofi_spin_unlock_(lock)
-#  define ofi_spin_held(lock) true
+#define ofi_spin_t ofi_spin_t_
+#define ofi_spin_init(lock) ofi_spin_init_(lock)
+#define ofi_spin_destroy(lock) ofi_spin_destroy_(lock)
+#define ofi_spin_lock(lock) ofi_spin_lock_(lock)
+#define ofi_spin_trylock(lock) ofi_spin_trylock_(lock)
+#define ofi_spin_unlock(lock) ofi_spin_unlock_(lock)
+#define ofi_spin_held(lock) true
 
 static inline void ofi_spin_lock_noop(ofi_spin_t *lock)
 {
-	(void) lock;
+	(void)lock;
 }
 
 static inline void ofi_spin_unlock_noop(ofi_spin_t *lock)
 {
-	(void) lock;
+	(void)lock;
 }
 
 #endif
 
-typedef void(*ofi_spin_lock_t)(ofi_spin_t *lock);
-typedef void(*ofi_spin_unlock_t)(ofi_spin_t *lock);
+typedef void (*ofi_spin_lock_t)(ofi_spin_t *lock);
+typedef void (*ofi_spin_unlock_t)(ofi_spin_t *lock);
 
 static inline void ofi_spin_lock_op(ofi_spin_t *lock)
 {
@@ -279,8 +276,8 @@ static inline void ofi_mutex_unlock_noop(ofi_mutex_t *lock)
 	lock->in_use = 0;
 }
 
-static inline int
-ofi_pthread_wait_cond(pthread_cond_t *cond, ofi_mutex_t *lock, int timeout_ms)
+static inline int ofi_pthread_wait_cond(pthread_cond_t *cond, ofi_mutex_t *lock,
+					int timeout_ms)
 {
 	assert(lock->is_initialized);
 	return ofi_wait_cond(cond, &lock->impl, timeout_ms);
@@ -288,22 +285,22 @@ ofi_pthread_wait_cond(pthread_cond_t *cond, ofi_mutex_t *lock, int timeout_ms)
 
 #else /* !ENABLE_DEBUG */
 
-#  define ofi_mutex_t ofi_mutex_t_
-#  define ofi_mutex_init(lock) ofi_mutex_init_(lock)
-#  define ofi_mutex_destroy(lock) ofi_mutex_destroy_(lock)
-#  define ofi_mutex_lock(lock) ofi_mutex_lock_(lock)
-#  define ofi_mutex_trylock(lock) ofi_mutex_trylock_(lock)
-#  define ofi_mutex_unlock(lock) ofi_mutex_unlock_(lock)
-#  define ofi_mutex_held(lock) true
+#define ofi_mutex_t ofi_mutex_t_
+#define ofi_mutex_init(lock) ofi_mutex_init_(lock)
+#define ofi_mutex_destroy(lock) ofi_mutex_destroy_(lock)
+#define ofi_mutex_lock(lock) ofi_mutex_lock_(lock)
+#define ofi_mutex_trylock(lock) ofi_mutex_trylock_(lock)
+#define ofi_mutex_unlock(lock) ofi_mutex_unlock_(lock)
+#define ofi_mutex_held(lock) true
 
 static inline void ofi_mutex_lock_noop(ofi_mutex_t *lock)
 {
-	(void) lock;
+	(void)lock;
 }
 
 static inline void ofi_mutex_unlock_noop(ofi_mutex_t *lock)
 {
-	(void) lock;
+	(void)lock;
 }
 
 #define ofi_pthread_wait_cond(cond, mut, timeout_ms) \
@@ -311,8 +308,8 @@ static inline void ofi_mutex_unlock_noop(ofi_mutex_t *lock)
 
 #endif
 
-typedef void(*ofi_mutex_lock_t)(ofi_mutex_t *lock);
-typedef void(*ofi_mutex_unlock_t)(ofi_mutex_t *lock);
+typedef void (*ofi_mutex_lock_t)(ofi_mutex_t *lock);
+typedef void (*ofi_mutex_unlock_t)(ofi_mutex_t *lock);
 
 static inline void ofi_mutex_lock_op(ofi_mutex_t *lock)
 {
@@ -331,12 +328,12 @@ static inline int ofi_mutex_held_op(ofi_mutex_t *lock)
 
 static inline void ofi_nolock_lock_op(void *nolock)
 {
-	(void) nolock;
+	(void)nolock;
 }
 
 static inline void ofi_nolock_unlock_op(void *nolock)
 {
-	(void) nolock;
+	(void)nolock;
 }
 
 /* No way to verify, so return true to pass all asserts.
@@ -347,36 +344,34 @@ static inline int ofi_nolock_held_op(void *nolock)
 	return 1;
 }
 
-
 /*
  * Generic lock abstraction
  * Caller selects lock implementation at runtime
  */
 enum ofi_lock_type {
-	OFI_LOCK_MUTEX,		/* default */
+	OFI_LOCK_MUTEX, /* default */
 	OFI_LOCK_SPINLOCK,
 	OFI_LOCK_NOOP,
 	OFI_LOCK_NONE,
 };
 
-typedef int  (*ofi_genlock_lockheld_t)(void *baselock);
+typedef int (*ofi_genlock_lockheld_t)(void *baselock);
 typedef void (*ofi_genlock_lockop_t)(void *baselock);
 
 struct ofi_genlock {
-	enum ofi_lock_type	lock_type;
+	enum ofi_lock_type lock_type;
 	union {
-		ofi_mutex_t	mutex;
-		ofi_spin_t	spinlock;
-		void		*nolock;
+		ofi_mutex_t mutex;
+		ofi_spin_t spinlock;
+		void *nolock;
 	} base;
 
-	ofi_genlock_lockheld_t	held;
-	ofi_genlock_lockop_t	lock;
-	ofi_genlock_lockop_t	unlock;
+	ofi_genlock_lockheld_t held;
+	ofi_genlock_lockop_t lock;
+	ofi_genlock_lockop_t unlock;
 };
 
-int ofi_genlock_init(struct ofi_genlock *lock,
-		     enum ofi_lock_type lock_type);
+int ofi_genlock_init(struct ofi_genlock *lock, enum ofi_lock_type lock_type);
 void ofi_genlock_destroy(struct ofi_genlock *lock);
 
 static inline int ofi_genlock_held(struct ofi_genlock *lock)

--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -44,16 +44,15 @@
 #include <ofi_osd.h>
 
 #ifdef INCLUDE_VALGRIND
-#   include <valgrind/memcheck.h>
-#   ifndef VALGRIND_MAKE_MEM_DEFINED
-#      warning "Valgrind requested, but VALGRIND_MAKE_MEM_DEFINED undefined"
-#   endif
+#include <valgrind/memcheck.h>
+#ifndef VALGRIND_MAKE_MEM_DEFINED
+#warning "Valgrind requested, but VALGRIND_MAKE_MEM_DEFINED undefined"
+#endif
 #endif
 
 #ifndef VALGRIND_MAKE_MEM_DEFINED
-#   define VALGRIND_MAKE_MEM_DEFINED(addr, len)
+#define VALGRIND_MAKE_MEM_DEFINED(addr, len)
 #endif
-
 
 void ofi_mem_init(void);
 void ofi_mem_fini(void);
@@ -73,7 +72,6 @@ static inline long ofi_get_page_size(void)
 ssize_t ofi_get_hugepage_size(void);
 
 size_t ofi_get_mem_size(void);
-
 
 /* We implement memdup to avoid external library dependency */
 static inline void *mem_dup(const void *src, size_t size)
@@ -102,33 +100,33 @@ static inline int ofi_str_dup(const char *src, char **dst)
 /*
  * Buffer pool (free stack) template
  */
-#define OFI_FREESTACK_EMPTY	NULL
+#define OFI_FREESTACK_EMPTY NULL
 
 #define ofi_freestack_get_next(user_buf) ((char *)user_buf - sizeof(void *))
 #define ofi_freestack_get_user_buf(entry) ((char *)entry + sizeof(void *))
 
 #if ENABLE_DEBUG
-#define ofi_freestack_init_next(entry)	*((void **)entry) = NULL
-#define ofi_freestack_check_next(entry)	assert(*((void **)entry) == NULL)
+#define ofi_freestack_init_next(entry) *((void **)entry) = NULL
+#define ofi_freestack_check_next(entry) assert(*((void **)entry) == NULL)
 #else
 #define ofi_freestack_init_next(entry)
 #define ofi_freestack_check_next(entry)
 #endif
 
-#define OFI_FREESTACK_HEADER 					\
-	size_t		size;					\
-	void		*next;					\
+#define OFI_FREESTACK_HEADER \
+	size_t size;         \
+	void *next;
 
 #define ofi_freestack_isempty(fs) ((fs)->next == OFI_FREESTACK_EMPTY)
-#define ofi_freestack_push(fs, p)				\
-do {								\
-	ofi_freestack_check_next(ofi_freestack_get_next(p));	\
-	*(void **) (ofi_freestack_get_next(p)) = (fs)->next;	\
-	(fs)->next = (ofi_freestack_get_next(p));		\
-} while (0)
+#define ofi_freestack_push(fs, p)                                    \
+	do {                                                         \
+		ofi_freestack_check_next(ofi_freestack_get_next(p)); \
+		*(void **)(ofi_freestack_get_next(p)) = (fs)->next;  \
+		(fs)->next = (ofi_freestack_get_next(p));            \
+	} while (0)
 #define ofi_freestack_pop(fs) ofi_freestack_pop_impl(fs, (fs)->next)
 
-static inline void* ofi_freestack_pop_impl(void *fs, void *fs_next)
+static inline void *ofi_freestack_pop_impl(void *fs, void *fs_next)
 {
 	struct _freestack {
 		OFI_FREESTACK_HEADER
@@ -139,110 +137,106 @@ static inline void* ofi_freestack_pop_impl(void *fs, void *fs_next)
 	return ofi_freestack_get_user_buf(fs_next);
 }
 
-#define OFI_DECLARE_FREESTACK(entrytype, name)			\
-struct name ## _entry {						\
-	void		*next;					\
-	entrytype	buf;					\
-};								\
-struct name {							\
-	OFI_FREESTACK_HEADER					\
-	struct name ## _entry	entry[];			\
-};								\
-								\
-typedef void (*name ## _entry_init_func)(entrytype *buf,	\
-					 void *arg);		\
-								\
-typedef void (*name ## _entry_destroy_func)(entrytype *buf,	\
-					 void *arg);		\
-								\
-static inline void						\
-name ## _init(struct name *fs, size_t size,			\
-	      name ## _entry_init_func init, void *arg)		\
-{								\
-	ssize_t i;						\
-	assert(size == roundup_power_of_two(size));		\
-	assert(sizeof(fs->entry[0].buf) >= sizeof(void *));	\
-	fs->size = size;					\
-	fs->next = OFI_FREESTACK_EMPTY;				\
-	for (i = size - 1; i >= 0; i--) {			\
-		if (init)					\
-			init(&fs->entry[i].buf, arg);		\
-		ofi_freestack_push(fs, &fs->entry[i].buf);	\
-	}							\
-}								\
-								\
-static inline struct name *					\
-name ## _create(size_t size, name ## _entry_init_func init,	\
-		void *arg)					\
-{								\
-	struct name *fs;					\
-	fs = (struct name*) calloc(1, sizeof(*fs) +		\
-		       sizeof(struct name ## _entry) *		\
-		       (roundup_power_of_two(size)));		\
-	if (fs)							\
-		name ##_init(fs, roundup_power_of_two(size),	\
-			     init, arg);			\
-	return fs;						\
-}								\
-								\
-static inline int name ## _index(struct name *fs,		\
-				 entrytype *entry)		\
-{								\
-	return (int)((struct name ## _entry *)			\
-			(ofi_freestack_get_next(entry))		\
-			- (struct name ## _entry *)fs->entry);	\
-}								\
-								\
-static inline void name ## _free(struct name *fs)		\
-{								\
-	free(fs);						\
-}								\
-static inline void name ## _destroy(struct name *fs,		\
-	size_t size, name ## _entry_destroy_func destroy,	\
-	void *arg)						\
-{								\
-	ssize_t i;						\
-	for (i = size - 1; i >= 0; i--) {			\
-		if (destroy)					\
-			destroy(&fs->entry[i].buf, arg);	\
-	}							\
-	free(fs);						\
-}								\
-void dummy ## name (void) /* work-around global ; scope */
+#define OFI_DECLARE_FREESTACK(entrytype, name)                                 \
+	struct name##_entry {                                                  \
+		void *next;                                                    \
+		entrytype buf;                                                 \
+	};                                                                     \
+	struct name {                                                          \
+		OFI_FREESTACK_HEADER                                           \
+		struct name##_entry entry[];                                   \
+	};                                                                     \
+                                                                               \
+	typedef void (*name##_entry_init_func)(entrytype * buf, void *arg);    \
+                                                                               \
+	typedef void (*name##_entry_destroy_func)(entrytype * buf, void *arg); \
+                                                                               \
+	static inline void name##_init(struct name *fs, size_t size,           \
+				       name##_entry_init_func init, void *arg) \
+	{                                                                      \
+		ssize_t i;                                                     \
+		assert(size == roundup_power_of_two(size));                    \
+		assert(sizeof(fs->entry[0].buf) >= sizeof(void *));            \
+		fs->size = size;                                               \
+		fs->next = OFI_FREESTACK_EMPTY;                                \
+		for (i = size - 1; i >= 0; i--) {                              \
+			if (init)                                              \
+				init(&fs->entry[i].buf, arg);                  \
+			ofi_freestack_push(fs, &fs->entry[i].buf);             \
+		}                                                              \
+	}                                                                      \
+                                                                               \
+	static inline struct name *name##_create(                              \
+		size_t size, name##_entry_init_func init, void *arg)           \
+	{                                                                      \
+		struct name *fs;                                               \
+		fs = (struct name *)calloc(                                    \
+			1,                                                     \
+			sizeof(*fs) + sizeof(struct name##_entry) *            \
+					      (roundup_power_of_two(size)));   \
+		if (fs)                                                        \
+			name##_init(fs, roundup_power_of_two(size), init,      \
+				    arg);                                      \
+		return fs;                                                     \
+	}                                                                      \
+                                                                               \
+	static inline int name##_index(struct name *fs, entrytype *entry)      \
+	{                                                                      \
+		return (int)((struct name##_entry *)(ofi_freestack_get_next(   \
+				     entry)) -                                 \
+			     (struct name##_entry *)fs->entry);                \
+	}                                                                      \
+                                                                               \
+	static inline void name##_free(struct name *fs)                        \
+	{                                                                      \
+		free(fs);                                                      \
+	}                                                                      \
+	static inline void name##_destroy(struct name *fs, size_t size,        \
+					  name##_entry_destroy_func destroy,   \
+					  void *arg)                           \
+	{                                                                      \
+		ssize_t i;                                                     \
+		for (i = size - 1; i >= 0; i--) {                              \
+			if (destroy)                                           \
+				destroy(&fs->entry[i].buf, arg);               \
+		}                                                              \
+		free(fs);                                                      \
+	}                                                                      \
+	void dummy##name(void) /* work-around global ; scope */
 
 /*
  * Buffer pool (free stack) template for shared memory regions
  */
-#define SMR_ALIGN_BOUNDARY	64
-#define SMR_FREESTACK_EMPTY	(-1)
+#define SMR_ALIGN_BOUNDARY 64
+#define SMR_FREESTACK_EMPTY (-1)
 
 struct smr_freestack {
-	uint64_t		entry_base_offset;
-	size_t			object_size;
-	size_t			size;
-	int16_t			free;
-	int16_t			top;
-	int16_t 		entry_next[];
+	uint64_t entry_base_offset;
+	size_t object_size;
+	size_t size;
+	int16_t free;
+	int16_t top;
+	int16_t entry_next[];
 };
 
-#define smr_freestack_isempty(fs)	((fs)->top == SMR_FREESTACK_EMPTY)
+#define smr_freestack_isempty(fs) ((fs)->top == SMR_FREESTACK_EMPTY)
 
-static inline void* smr_freestack_get_entry_from_index(struct smr_freestack *fs,
-		int16_t index)
+static inline void *smr_freestack_get_entry_from_index(struct smr_freestack *fs,
+						       int16_t index)
 {
-	return (void*) (((char *) fs) + fs->entry_base_offset +
+	return (void *)(((char *)fs) + fs->entry_base_offset +
 			(fs->object_size * index));
 }
 
 static inline long freestack_size(int elem_size, int num_elements)
 {
 	return (sizeof(struct smr_freestack) + sizeof(int16_t) * num_elements +
-			elem_size * num_elements + SMR_ALIGN_BOUNDARY);
+		elem_size * num_elements + SMR_ALIGN_BOUNDARY);
 }
 
 /* Push by entry_index */
 static inline void smr_freestack_push_by_index(struct smr_freestack *fs,
-		int16_t entry_index)
+					       int16_t entry_index)
 {
 	fs->entry_next[entry_index] = fs->top;
 	fs->top = entry_index;
@@ -251,44 +245,42 @@ static inline void smr_freestack_push_by_index(struct smr_freestack *fs,
 
 /* Push by entry_offset */
 static inline void smr_freestack_push_by_offset(struct smr_freestack *fs,
-		uint64_t entry_offset)
+						uint64_t entry_offset)
 {
-        smr_freestack_push_by_index(fs,
-                        (entry_offset - fs->entry_base_offset) /
-                        fs->object_size);
+	smr_freestack_push_by_index(fs, (entry_offset - fs->entry_base_offset) /
+						fs->object_size);
 }
 
 /* Push by object */
 static inline void smr_freestack_push(struct smr_freestack *fs, void *local_p)
 {
-        smr_freestack_push_by_offset(fs,
-                ((char *) local_p - (char*) fs));
+	smr_freestack_push_by_offset(fs, ((char *)local_p - (char *)fs));
 }
 
-static inline void smr_freestack_init(struct smr_freestack *fs, size_t elem_count,
-		size_t fs_object_size)
+static inline void smr_freestack_init(struct smr_freestack *fs,
+				      size_t elem_count, size_t fs_object_size)
 {
 	ssize_t i, next_aligned_addr;
 	assert(elem_count == roundup_power_of_two(elem_count));
 	fs->size = elem_count;
 	fs->object_size = fs_object_size;
 	fs->top = SMR_FREESTACK_EMPTY;
-	fs->entry_base_offset =
-		((char*) &fs->entry_next[0] - (char*) fs) +
-		fs->size * sizeof(fs->top);
-	next_aligned_addr = ofi_get_aligned_size((( (uint64_t) fs) +
-			fs->entry_base_offset), SMR_ALIGN_BOUNDARY);
-	fs->entry_base_offset = next_aligned_addr - ((uint64_t) fs);
+	fs->entry_base_offset = ((char *)&fs->entry_next[0] - (char *)fs) +
+				fs->size * sizeof(fs->top);
+	next_aligned_addr = ofi_get_aligned_size(
+		(((uint64_t)fs) + fs->entry_base_offset), SMR_ALIGN_BOUNDARY);
+	fs->entry_base_offset = next_aligned_addr - ((uint64_t)fs);
 	for (i = elem_count - 1; i >= 0; i--)
 		smr_freestack_push_by_index(fs, i);
 }
 
-static inline struct smr_freestack* smr_freestack_create(size_t elem_count,
-		size_t fs_object_size)
+static inline struct smr_freestack *smr_freestack_create(size_t elem_count,
+							 size_t fs_object_size)
 {
 	struct smr_freestack *fs;
-	fs = (struct smr_freestack*) calloc(1, freestack_size(fs_object_size,
-				roundup_power_of_two(elem_count)));
+	fs = (struct smr_freestack *)calloc(
+		1, freestack_size(fs_object_size,
+				  roundup_power_of_two(elem_count)));
 	if (fs)
 		smr_freestack_init(fs, elem_count, fs_object_size);
 	return fs;
@@ -308,97 +300,96 @@ static inline int smr_freestack_pop_by_index(struct smr_freestack *fs)
 
 static inline size_t smr_freestack_pop_by_offset(struct smr_freestack *fs)
 {
-	return (size_t) (fs->entry_base_offset +
-		smr_freestack_pop_by_index(fs) * fs->object_size);
+	return (size_t)(fs->entry_base_offset +
+			smr_freestack_pop_by_index(fs) * fs->object_size);
 }
 
-static inline void* smr_freestack_pop(struct smr_freestack *fs)
+static inline void *smr_freestack_pop(struct smr_freestack *fs)
 {
-	return (void *) ( ((char*)fs) + smr_freestack_pop_by_offset(fs) );
+	return (void *)(((char *)fs) + smr_freestack_pop_by_offset(fs));
 }
 /*
  * Buffer Pool
  */
 
 enum {
-	OFI_BUFPOOL_INDEXED		= 1 << 1,
-	OFI_BUFPOOL_NO_TRACK		= 1 << 2,
-	OFI_BUFPOOL_HUGEPAGES		= 1 << 3,
-	OFI_BUFPOOL_NONSHARED		= 1 << 4,
+	OFI_BUFPOOL_INDEXED = 1 << 1,
+	OFI_BUFPOOL_NO_TRACK = 1 << 2,
+	OFI_BUFPOOL_HUGEPAGES = 1 << 3,
+	OFI_BUFPOOL_NONSHARED = 1 << 4,
 };
 
 struct ofi_bufpool_region;
 
 struct ofi_bufpool_attr {
-	size_t 		size;
-	size_t 		alignment;
-	size_t	 	max_cnt;
-	size_t 		chunk_cnt;
-	int		(*alloc_fn)(struct ofi_bufpool_region *region);
-	void		(*free_fn)(struct ofi_bufpool_region *region);
-	void		(*init_fn)(struct ofi_bufpool_region *region, void *buf);
-	void 		*context;
-	int		flags;
+	size_t size;
+	size_t alignment;
+	size_t max_cnt;
+	size_t chunk_cnt;
+	int (*alloc_fn)(struct ofi_bufpool_region *region);
+	void (*free_fn)(struct ofi_bufpool_region *region);
+	void (*init_fn)(struct ofi_bufpool_region *region, void *buf);
+	void *context;
+	int flags;
 };
 
 struct ofi_bufpool {
 	union {
-		struct slist		entries;
-		struct dlist_entry	regions;
+		struct slist entries;
+		struct dlist_entry regions;
 	} free_list;
 
-	size_t 				entry_size;
-	size_t 				entry_cnt;
+	size_t entry_size;
+	size_t entry_cnt;
 
-	struct ofi_bufpool_region	**region_table;
-	size_t				region_cnt;
-	size_t				alloc_size;
-	size_t				region_size;
-	struct ofi_bufpool_attr		attr;
+	struct ofi_bufpool_region **region_table;
+	size_t region_cnt;
+	size_t alloc_size;
+	size_t region_size;
+	struct ofi_bufpool_attr attr;
 };
 
 struct ofi_bufpool_region {
-	struct dlist_entry		entry;
-	struct dlist_entry 		free_list;
-	char				*alloc_region;
-	char 				*mem_region;
-	size_t				index;
-	void 				*context;
-	struct ofi_bufpool 		*pool;
-	int				flags;
-	OFI_DBG_VAR(ofi_atomic32_t,	use_cnt)
+	struct dlist_entry entry;
+	struct dlist_entry free_list;
+	char *alloc_region;
+	char *mem_region;
+	size_t index;
+	void *context;
+	struct ofi_bufpool *pool;
+	int flags;
+	OFI_DBG_VAR(ofi_atomic32_t, use_cnt)
 };
 
 struct ofi_bufpool_ftr {
-	size_t				magic;
+	size_t magic;
 };
 
 struct ofi_bufpool_hdr {
 	union {
-		struct slist_entry	slist;
-		struct dlist_entry	dlist;
+		struct slist_entry slist;
+		struct dlist_entry dlist;
 	} entry;
-	struct ofi_bufpool_region	*region;
-	size_t 				index;
+	struct ofi_bufpool_region *region;
+	size_t index;
 
 	OFI_DBG_VAR(struct ofi_bufpool_ftr *, ftr)
-	OFI_DBG_VAR(size_t,		magic)
+	OFI_DBG_VAR(size_t, magic)
 };
 
 int ofi_bufpool_create_attr(struct ofi_bufpool_attr *attr,
 			    struct ofi_bufpool **buf_pool);
 
-static inline int
-ofi_bufpool_create(struct ofi_bufpool **buf_pool,
-		   size_t size, size_t alignment,
-		   size_t max_cnt, size_t chunk_cnt, int flags)
+static inline int ofi_bufpool_create(struct ofi_bufpool **buf_pool, size_t size,
+				     size_t alignment, size_t max_cnt,
+				     size_t chunk_cnt, int flags)
 {
 	struct ofi_bufpool_attr attr = {
-		.size		= size,
-		.alignment 	= alignment,
-		.max_cnt	= max_cnt,
-		.chunk_cnt	= chunk_cnt,
-		.flags		= flags,
+		.size = size,
+		.alignment = alignment,
+		.max_cnt = max_cnt,
+		.chunk_cnt = chunk_cnt,
+		.flags = flags,
 	};
 	return ofi_bufpool_create_attr(&attr, buf_pool);
 }
@@ -409,8 +400,8 @@ int ofi_bufpool_grow(struct ofi_bufpool *pool);
 
 static inline struct ofi_bufpool_hdr *ofi_buf_hdr(void *buf)
 {
-	return (struct ofi_bufpool_hdr *)
-		((char *) buf - sizeof(struct ofi_bufpool_hdr));
+	return (struct ofi_bufpool_hdr *)((char *)buf -
+					  sizeof(struct ofi_bufpool_hdr));
 }
 
 static inline void *ofi_buf_data(struct ofi_bufpool_hdr *buf_hdr)
@@ -455,8 +446,8 @@ static inline void ofi_ibuf_free(void *buf)
 	assert(buf_hdr->magic == OFI_MAGIC_SIZE_T);
 	assert(buf_hdr->ftr->magic == OFI_MAGIC_SIZE_T);
 
-	dlist_insert_order(&buf_hdr->region->free_list,
-			   ofi_ibuf_is_lower, &buf_hdr->entry.dlist);
+	dlist_insert_order(&buf_hdr->region->free_list, ofi_ibuf_is_lower,
+			   &buf_hdr->entry.dlist);
 	if (dlist_empty(&buf_hdr->region->entry)) {
 		dlist_insert_order(&buf_hdr->region->pool->free_list.regions,
 				   ofi_ibufpool_region_is_lower,
@@ -473,8 +464,9 @@ static inline void *ofi_bufpool_get_ibuf(struct ofi_bufpool *pool, size_t index)
 {
 	void *buf;
 
-	buf = pool->region_table[(size_t)(index / pool->attr.chunk_cnt)]->
-		mem_region + (index % pool->attr.chunk_cnt) * pool->entry_size;
+	buf = pool->region_table[(size_t)(index / pool->attr.chunk_cnt)]
+		      ->mem_region +
+	      (index % pool->attr.chunk_cnt) * pool->entry_size;
 
 	assert(ofi_atomic_get32(&ofi_buf_region(buf)->use_cnt));
 	return buf;
@@ -501,13 +493,13 @@ static inline void *ofi_buf_alloc(struct ofi_bufpool *pool)
 	}
 
 	slist_remove_head_container(&pool->free_list.entries,
-				struct ofi_bufpool_hdr, buf_hdr, entry.slist);
+				    struct ofi_bufpool_hdr, buf_hdr,
+				    entry.slist);
 	assert(ofi_atomic_inc32(&buf_hdr->region->use_cnt));
 	return ofi_buf_data(buf_hdr);
 }
 
-static inline void *ofi_buf_alloc_ex(struct ofi_bufpool *pool,
-				     void **context)
+static inline void *ofi_buf_alloc_ex(struct ofi_bufpool *pool, void **context)
 {
 	void *buf = ofi_buf_alloc(pool);
 
@@ -532,15 +524,14 @@ static inline void *ofi_ibuf_alloc(struct ofi_bufpool *pool)
 
 	buf_region = container_of(pool->free_list.regions.next,
 				  struct ofi_bufpool_region, entry);
-	dlist_pop_front(&buf_region->free_list, struct ofi_bufpool_hdr,
-			buf_hdr, entry.dlist);
+	dlist_pop_front(&buf_region->free_list, struct ofi_bufpool_hdr, buf_hdr,
+			entry.dlist);
 	assert(ofi_atomic_inc32(&buf_hdr->region->use_cnt));
 
 	if (dlist_empty(&buf_region->free_list))
 		dlist_remove_init(&buf_region->entry);
 	return ofi_buf_data(buf_hdr);
 }
-
 
 /*
  * Persistent memory support
@@ -549,6 +540,5 @@ void ofi_pmem_init(void);
 
 extern uint64_t OFI_RMA_PMEM;
 extern void (*ofi_pmem_commit)(const void *addr, size_t len);
-
 
 #endif /* _OFI_MEM_H_ */

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -37,7 +37,7 @@
 #define _OFI_MR_H_
 
 #if HAVE_CONFIG_H
-#  include <config.h>
+#include <config.h>
 #endif /* HAVE_CONFIG_H */
 
 #include <inttypes.h>
@@ -56,10 +56,9 @@ struct ofi_mr_info {
 	struct iovec iov;
 	enum fi_hmem_iface iface;
 	uint64_t device;
-	void     *ipc_mapped_addr;
-	uint8_t  ipc_handle[MAX_IPC_HANDLE_SIZE];
+	void *ipc_mapped_addr;
+	uint8_t ipc_handle[MAX_IPC_HANDLE_SIZE];
 };
-
 
 #define OFI_MR_BASIC_MAP (FI_MR_ALLOCATED | FI_MR_PROV_KEY | FI_MR_VIRT_ADDR)
 
@@ -83,8 +82,8 @@ check_local_mr:
 	return (info->mode & FI_LOCAL_MR) ? 1 : 0;
 }
 
-#define OFI_MR_MODE_RMA_TARGET (FI_MR_RAW | FI_MR_VIRT_ADDR |			\
-				 FI_MR_PROV_KEY | FI_MR_RMA_EVENT)
+#define OFI_MR_MODE_RMA_TARGET \
+	(FI_MR_RAW | FI_MR_VIRT_ADDR | FI_MR_PROV_KEY | FI_MR_RMA_EVENT)
 
 /* If the app sets FI_MR_LOCAL, we ignore FI_LOCAL_MR.  So, if the
  * app doesn't set FI_MR_LOCAL, we need to check for FI_LOCAL_MR.
@@ -98,12 +97,12 @@ static inline uint64_t ofi_mr_get_prov_mode(uint32_t version,
 	    (user_info->domain_attr &&
 	     !(user_info->domain_attr->mr_mode & FI_MR_LOCAL))) {
 		return (prov_info->domain_attr->mr_mode & FI_MR_LOCAL) ?
-			prov_info->mode | FI_LOCAL_MR : prov_info->mode;
+			       prov_info->mode | FI_LOCAL_MR :
+			       prov_info->mode;
 	} else {
 		return prov_info->mode;
 	}
 }
-
 
 /* Single lock used by all memory monitors and MR caches. */
 extern pthread_mutex_t mm_lock;
@@ -128,12 +127,12 @@ union ofi_mr_hmem_info {
 };
 
 struct ofi_mr_entry {
-	struct ofi_mr_info		info;
-	struct ofi_rbnode		*node;
-	int				use_cnt;
-	struct dlist_entry		list_entry;
-	union ofi_mr_hmem_info		hmem_info;
-	uint8_t				data[];
+	struct ofi_mr_info info;
+	struct ofi_rbnode *node;
+	int use_cnt;
+	struct dlist_entry list_entry;
+	union ofi_mr_hmem_info hmem_info;
+	uint8_t data[];
 };
 
 enum fi_mm_state {
@@ -145,20 +144,18 @@ enum fi_mm_state {
 };
 
 struct ofi_mem_monitor {
-	struct dlist_entry		list;
-	enum fi_hmem_iface		iface;
-	enum fi_mm_state                state;
+	struct dlist_entry list;
+	enum fi_hmem_iface iface;
+	enum fi_mm_state state;
 
 	void (*init)(struct ofi_mem_monitor *monitor);
 	void (*cleanup)(struct ofi_mem_monitor *monitor);
 	int (*start)(struct ofi_mem_monitor *monitor);
 	void (*stop)(struct ofi_mem_monitor *monitor);
-	int (*subscribe)(struct ofi_mem_monitor *notifier,
-			 const void *addr, size_t len,
-			 union ofi_mr_hmem_info *hmem_info);
-	void (*unsubscribe)(struct ofi_mem_monitor *notifier,
-			    const void *addr, size_t len,
-			    union ofi_mr_hmem_info *hmem_info);
+	int (*subscribe)(struct ofi_mem_monitor *notifier, const void *addr,
+			 size_t len, union ofi_mr_hmem_info *hmem_info);
+	void (*unsubscribe)(struct ofi_mem_monitor *notifier, const void *addr,
+			    size_t len, union ofi_mr_hmem_info *hmem_info);
 
 	/* Valid is a memory monitor operation used to query a memory monitor to
 	 * see if the memory monitor's view of the buffer is still valid. If the
@@ -167,7 +164,8 @@ struct ofi_mem_monitor {
 	 * to be re-registered.
 	 */
 	bool (*valid)(struct ofi_mem_monitor *notifier,
-		      const struct ofi_mr_info *info, struct ofi_mr_entry *entry);
+		      const struct ofi_mr_info *info,
+		      struct ofi_mr_entry *entry);
 };
 
 void ofi_monitor_init(struct ofi_mem_monitor *monitor);
@@ -179,25 +177,23 @@ int ofi_monitor_import(struct fid *fid);
 int ofi_monitors_add_cache(struct ofi_mem_monitor **monitors,
 			   struct ofi_mr_cache *cache);
 void ofi_monitors_del_cache(struct ofi_mr_cache *cache);
-void ofi_monitor_notify(struct ofi_mem_monitor *monitor,
-			const void *addr, size_t len);
+void ofi_monitor_notify(struct ofi_mem_monitor *monitor, const void *addr,
+			size_t len);
 void ofi_monitor_flush(struct ofi_mem_monitor *monitor);
 
-int ofi_monitor_subscribe(struct ofi_mem_monitor *monitor,
-			  const void *addr, size_t len,
-			  union ofi_mr_hmem_info *hmem_info);
-void ofi_monitor_unsubscribe(struct ofi_mem_monitor *monitor,
-			     const void *addr, size_t len,
-			     union ofi_mr_hmem_info *hmem_info);
+int ofi_monitor_subscribe(struct ofi_mem_monitor *monitor, const void *addr,
+			  size_t len, union ofi_mr_hmem_info *hmem_info);
+void ofi_monitor_unsubscribe(struct ofi_mem_monitor *monitor, const void *addr,
+			     size_t len, union ofi_mr_hmem_info *hmem_info);
 
 int ofi_monitor_start_no_op(struct ofi_mem_monitor *monitor);
 void ofi_monitor_stop_no_op(struct ofi_mem_monitor *monitor);
 int ofi_monitor_subscribe_no_op(struct ofi_mem_monitor *notifier,
-				 const void *addr, size_t len,
-				 union ofi_mr_hmem_info *hmem_info);
+				const void *addr, size_t len,
+				union ofi_mr_hmem_info *hmem_info);
 void ofi_monitor_unsubscribe_no_op(struct ofi_mem_monitor *notifier,
-				    const void *addr, size_t len,
-				    union ofi_mr_hmem_info *hmem_info);
+				   const void *addr, size_t len,
+				   union ofi_mr_hmem_info *hmem_info);
 extern struct ofi_mem_monitor *default_monitor;
 extern struct ofi_mem_monitor *default_cuda_monitor;
 extern struct ofi_mem_monitor *default_rocr_monitor;
@@ -207,9 +203,9 @@ extern struct ofi_mem_monitor *default_ze_monitor;
  * Userfault fd memory monitor
  */
 struct ofi_uffd {
-	struct ofi_mem_monitor		monitor;
-	pthread_t			thread;
-	int				fd;
+	struct ofi_mem_monitor monitor;
+	pthread_t thread;
+	int fd;
 };
 
 extern struct ofi_mem_monitor *uffd_monitor;
@@ -218,8 +214,8 @@ extern struct ofi_mem_monitor *uffd_monitor;
  * Memory intercept call memory monitor
  */
 struct ofi_memhooks {
-	struct ofi_mem_monitor          monitor;
-	struct dlist_entry		intercept_list;
+	struct ofi_mem_monitor monitor;
+	struct dlist_entry intercept_list;
 };
 
 extern struct ofi_mem_monitor *memhooks_monitor;
@@ -240,24 +236,22 @@ extern struct ofi_mem_monitor *import_monitor;
 
 struct ofi_mr_map {
 	const struct fi_provider *prov;
-	struct ofi_rbmap	*rbtree;
-	uint64_t		key;
-	int			mode;
+	struct ofi_rbmap *rbtree;
+	uint64_t key;
+	int mode;
 };
 
 int ofi_mr_map_init(const struct fi_provider *in_prov, int mode,
 		    struct ofi_mr_map *map);
 void ofi_mr_map_close(struct ofi_mr_map *map);
 
-int ofi_mr_map_insert(struct ofi_mr_map *map,
-		      const struct fi_mr_attr *attr,
+int ofi_mr_map_insert(struct ofi_mr_map *map, const struct fi_mr_attr *attr,
 		      uint64_t *key, void *context);
 int ofi_mr_map_remove(struct ofi_mr_map *map, uint64_t key);
-void *ofi_mr_map_get(struct ofi_mr_map *map,  uint64_t key);
+void *ofi_mr_map_get(struct ofi_mr_map *map, uint64_t key);
 
-int ofi_mr_map_verify(struct ofi_mr_map *map, uintptr_t *io_addr,
-		      size_t len, uint64_t key, uint64_t access,
-		      void **context);
+int ofi_mr_map_verify(struct ofi_mr_map *map, uintptr_t *io_addr, size_t len,
+		      uint64_t key, uint64_t access, void **context);
 
 /*
  * These calls may be used be providers to implement software memory
@@ -279,58 +273,57 @@ void ofi_mr_update_attr(uint32_t user_version, uint64_t caps,
 int ofi_mr_close(struct fid *fid);
 int ofi_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 		   uint64_t flags, struct fid_mr **mr_fid);
-int ofi_mr_regv(struct fid *fid, const struct iovec *iov,
-		size_t count, uint64_t access, uint64_t offset,
-		uint64_t requested_key, uint64_t flags,
-		struct fid_mr **mr_fid, void *context);
-int ofi_mr_reg(struct fid *fid, const void *buf, size_t len,
-	       uint64_t access, uint64_t offset, uint64_t requested_key,
-	       uint64_t flags, struct fid_mr **mr_fid, void *context);
-int ofi_mr_verify(struct ofi_mr_map *map, ssize_t len,
-		  uintptr_t *addr, uint64_t key, uint64_t access);
+int ofi_mr_regv(struct fid *fid, const struct iovec *iov, size_t count,
+		uint64_t access, uint64_t offset, uint64_t requested_key,
+		uint64_t flags, struct fid_mr **mr_fid, void *context);
+int ofi_mr_reg(struct fid *fid, const void *buf, size_t len, uint64_t access,
+	       uint64_t offset, uint64_t requested_key, uint64_t flags,
+	       struct fid_mr **mr_fid, void *context);
+int ofi_mr_verify(struct ofi_mr_map *map, ssize_t len, uintptr_t *addr,
+		  uint64_t key, uint64_t access);
 
 /*
  * Memory registration cache
  */
 
 struct ofi_mr_cache_params {
-	size_t				max_cnt;
-	size_t				max_size;
-	char *				monitor;
-	int				cuda_monitor_enabled;
-	int				rocr_monitor_enabled;
-	int				ze_monitor_enabled;
+	size_t max_cnt;
+	size_t max_size;
+	char *monitor;
+	int cuda_monitor_enabled;
+	int rocr_monitor_enabled;
+	int ze_monitor_enabled;
 };
 
-extern struct ofi_mr_cache_params	cache_params;
+extern struct ofi_mr_cache_params cache_params;
 
 #define OFI_HMEM_MAX 6
 
 struct ofi_mr_cache {
-	struct util_domain		*domain;
-	struct ofi_mem_monitor		*monitors[OFI_HMEM_MAX];
-	struct dlist_entry		notify_entries[OFI_HMEM_MAX];
-	size_t				entry_data_size;
+	struct util_domain *domain;
+	struct ofi_mem_monitor *monitors[OFI_HMEM_MAX];
+	struct dlist_entry notify_entries[OFI_HMEM_MAX];
+	size_t entry_data_size;
 
-	struct ofi_rbmap		tree;
-	struct dlist_entry		lru_list;
-	struct dlist_entry		dead_region_list;
-	pthread_mutex_t 		lock;
+	struct ofi_rbmap tree;
+	struct dlist_entry lru_list;
+	struct dlist_entry dead_region_list;
+	pthread_mutex_t lock;
 
-	size_t				cached_cnt;
-	size_t				cached_size;
-	size_t				uncached_cnt;
-	size_t				uncached_size;
-	size_t				search_cnt;
-	size_t				delete_cnt;
-	size_t				hit_cnt;
-	size_t				notify_cnt;
-	struct ofi_bufpool		*entry_pool;
+	size_t cached_cnt;
+	size_t cached_size;
+	size_t uncached_cnt;
+	size_t uncached_size;
+	size_t search_cnt;
+	size_t delete_cnt;
+	size_t hit_cnt;
+	size_t notify_cnt;
+	struct ofi_bufpool *entry_pool;
 
-	int				(*add_region)(struct ofi_mr_cache *cache,
-						      struct ofi_mr_entry *entry);
-	void				(*delete_region)(struct ofi_mr_cache *cache,
-							 struct ofi_mr_entry *entry);
+	int (*add_region)(struct ofi_mr_cache *cache,
+			  struct ofi_mr_entry *entry);
+	void (*delete_region)(struct ofi_mr_cache *cache,
+			      struct ofi_mr_entry *entry);
 };
 
 int ofi_mr_cache_init(struct util_domain *domain,
@@ -338,13 +331,13 @@ int ofi_mr_cache_init(struct util_domain *domain,
 		      struct ofi_mr_cache *cache);
 void ofi_mr_cache_cleanup(struct ofi_mr_cache *cache);
 
-void ofi_mr_cache_notify(struct ofi_mr_cache *cache, const void *addr, size_t len);
+void ofi_mr_cache_notify(struct ofi_mr_cache *cache, const void *addr,
+			 size_t len);
 
-int ofi_ipc_cache_open(struct ofi_mr_cache **cache,
-			struct util_domain *domain);
+int ofi_ipc_cache_open(struct ofi_mr_cache **cache, struct util_domain *domain);
 void ofi_ipc_cache_destroy(struct ofi_mr_cache *cache);
-int  ofi_ipc_cache_search(struct ofi_mr_cache *cache, struct ipc_info *ipc_info,
-			   struct ofi_mr_entry **mr_entry);
+int ofi_ipc_cache_search(struct ofi_mr_cache *cache, struct ipc_info *ipc_info,
+			 struct ofi_mr_entry **mr_entry);
 
 static inline bool ofi_mr_cache_full(struct ofi_mr_cache *cache)
 {
@@ -367,8 +360,8 @@ bool ofi_mr_cache_flush(struct ofi_mr_cache *cache, bool flush_lru);
  * @returns On success, returns 0. On failure, returns a negative error code.
  */
 int ofi_mr_cache_search(struct ofi_mr_cache *cache,
-			 const struct ofi_mr_info *info,
-			 struct ofi_mr_entry **entry);
+			const struct ofi_mr_info *info,
+			struct ofi_mr_entry **entry);
 
 /**
  * Given an attr (with an iov range), if the iov range is already registered,
@@ -388,7 +381,7 @@ struct ofi_mr_entry *ofi_mr_cache_find(struct ofi_mr_cache *cache,
 				       const struct fi_mr_attr *attr);
 int ofi_mr_cache_reg(struct ofi_mr_cache *cache, const struct fi_mr_attr *attr,
 		     struct ofi_mr_entry **entry);
-void ofi_mr_cache_delete(struct ofi_mr_cache *cache, struct ofi_mr_entry *entry);
-
+void ofi_mr_cache_delete(struct ofi_mr_cache *cache,
+			 struct ofi_mr_entry *entry);
 
 #endif /* _OFI_MR_H_ */

--- a/include/ofi_osd.h
+++ b/include/ofi_osd.h
@@ -39,7 +39,6 @@
  * and we can't have spaces in function names */
 typedef long double long_double;
 
-
 /* Complex data type support:
  *
  * Complex data types are operating system.  For portability, each osd.h file
@@ -55,7 +54,6 @@ typedef long double long_double;
  * Where XXX = float, double, or long_double
  */
 
-
 #ifdef __APPLE__
 #include <osx/osd.h>
 #include <unix/osd.h>
@@ -70,19 +68,19 @@ typedef long double long_double;
 #endif
 
 #ifdef __GNUC__
-#define OFI_LIKELY(x)	__builtin_expect((x), 1)
-#define OFI_UNLIKELY(x)	__builtin_expect((x), 0)
+#define OFI_LIKELY(x) __builtin_expect((x), 1)
+#define OFI_UNLIKELY(x) __builtin_expect((x), 0)
 #else
-#define OFI_LIKELY(x)	(x)
-#define OFI_UNLIKELY(x)	(x)
+#define OFI_LIKELY(x) (x)
+#define OFI_UNLIKELY(x) (x)
 #endif
 
 enum {
 	OFI_ENDIAN_UNKNOWN,
 	OFI_ENDIAN_BIG,
 	OFI_ENDIAN_LITTLE,
-	OFI_ENDIAN_BIG_WORD,	/* Middle-endian, Honeywell 316 style */
-	OFI_ENDIAN_LITTLE_WORD,	/* Middle-endian, PDP-11 style */
+	OFI_ENDIAN_BIG_WORD, /* Middle-endian, Honeywell 316 style */
+	OFI_ENDIAN_LITTLE_WORD, /* Middle-endian, PDP-11 style */
 };
 
 static inline uint8_t ofi_detect_endianness(void)
@@ -108,8 +106,8 @@ static inline uint8_t ofi_detect_endianness(void)
 }
 
 #define OFI_MAGIC_64 (0x0F1C0DE0F1C0DE64)
-#define OFI_MAGIC_PTR ((void *) (uintptr_t) OFI_MAGIC_64)
-#define OFI_MAGIC_SIZE_T ((size_t) OFI_MAGIC_64)
+#define OFI_MAGIC_PTR ((void *)(uintptr_t)OFI_MAGIC_64)
+#define OFI_MAGIC_SIZE_T ((size_t)OFI_MAGIC_64)
 
 #ifndef NDEBUG
 #define OFI_DBG_VAR(type, name) type name;
@@ -118,9 +116,15 @@ static inline uint8_t ofi_detect_endianness(void)
 #define OFI_DBG_CALL(func) func
 #else
 #define OFI_DBG_VAR(type, name)
-#define OFI_DBG_SET(name, val) do {} while (0)
-#define OFI_DBG_ADD(name, val) do {} while (0)
-#define OFI_DBG_CALL(func) do {} while (0)
+#define OFI_DBG_SET(name, val) \
+	do {                   \
+	} while (0)
+#define OFI_DBG_ADD(name, val) \
+	do {                   \
+	} while (0)
+#define OFI_DBG_CALL(func) \
+	do {               \
+	} while (0)
 #endif
 
 #endif /* _OFI_OSD_H_ */

--- a/include/ofi_perf.h
+++ b/include/ofi_perf.h
@@ -40,23 +40,16 @@
 #include <ofi_osd.h>
 #include <rdma/providers/fi_prov.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
-enum ofi_perf_domain {
-	OFI_PMU_CPU,
-	OFI_PMU_CACHE,
-	OFI_PMU_OS,
-	OFI_PMU_NIC
-};
+enum ofi_perf_domain { OFI_PMU_CPU, OFI_PMU_CACHE, OFI_PMU_OS, OFI_PMU_NIC };
 
 enum {
-	OFI_PMC_FLAG_READ	= 1 << 0,
-	OFI_PMC_FLAG_WRITE	= 1 << 1,
-	OFI_PMC_FLAG_MISS	= 1 << 2,
+	OFI_PMC_FLAG_READ = 1 << 0,
+	OFI_PMC_FLAG_WRITE = 1 << 1,
+	OFI_PMC_FLAG_MISS = 1 << 2,
 };
 
 enum {
@@ -71,24 +64,20 @@ enum {
 	OFI_PMC_CACHE_TLB_INSTR,
 };
 
-enum {
-	OFI_PMC_OS_PAGE_FAULT
-};
+enum { OFI_PMC_OS_PAGE_FAULT };
 
 /* NIC counters TBD */
 
 struct ofi_perf_data {
-	uint64_t	start;
-	uint64_t	sum;
-	uint64_t	events;
+	uint64_t start;
+	uint64_t sum;
+	uint64_t events;
 };
 
-
 void ofi_perf_init(void);
-extern enum ofi_perf_domain	perf_domain;
-extern uint32_t			perf_cntr;
-extern uint32_t			perf_flags;
-
+extern enum ofi_perf_domain perf_domain;
+extern uint32_t perf_cntr;
+extern uint32_t perf_flags;
 
 /*
  * Performance management unit:
@@ -103,8 +92,8 @@ extern uint32_t			perf_flags;
 
 struct ofi_perf_ctx;
 
-int ofi_pmu_open(struct ofi_perf_ctx **ctx,
-		 enum ofi_perf_domain domain, uint32_t cntr_id, uint32_t flags);
+int ofi_pmu_open(struct ofi_perf_ctx **ctx, enum ofi_perf_domain domain,
+		 uint32_t cntr_id, uint32_t flags);
 uint64_t ofi_pmu_read(struct ofi_perf_ctx *ctx);
 void ofi_pmu_close(struct ofi_perf_ctx *ctx);
 
@@ -132,7 +121,6 @@ static inline void ofi_pmu_close(struct ofi_perf_ctx *ctx)
 }
 #endif /* HAVE_LINUX_PERF_RDPMC */
 
-
 static inline void ofi_perf_reset(struct ofi_perf_data *data)
 {
 	memset(data, 0, sizeof *data);
@@ -151,18 +139,16 @@ static inline void ofi_perf_end(struct ofi_perf_ctx *ctx,
 	data->events++;
 }
 
-
 struct ofi_perfset {
 	const struct fi_provider *prov;
-	size_t			size;
-	struct ofi_perf_ctx	*ctx;
-	struct ofi_perf_data	*data;
+	size_t size;
+	struct ofi_perf_ctx *ctx;
+	struct ofi_perf_data *data;
 };
 
-int ofi_perfset_create(const struct fi_provider *prov,
-		       struct ofi_perfset *set, size_t size,
-		       enum ofi_perf_domain domain, uint32_t cntr_id,
-		       uint32_t flags);
+int ofi_perfset_create(const struct fi_provider *prov, struct ofi_perfset *set,
+		       size_t size, enum ofi_perf_domain domain,
+		       uint32_t cntr_id, uint32_t flags);
 void ofi_perfset_close(struct ofi_perfset *set);
 
 void ofi_perfset_log(struct ofi_perfset *set, const char **names);
@@ -178,7 +164,6 @@ static inline void ofi_perfset_end(struct ofi_perfset *set, size_t index)
 	assert(index < set->size);
 	ofi_perf_end(set->ctx, &set->data[index]);
 }
-
 
 #ifdef __cplusplus
 }

--- a/include/ofi_proto.h
+++ b/include/ofi_proto.h
@@ -40,13 +40,11 @@
 
 #include <rdma/fi_rma.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
-#define OFI_CTRL_VERSION	2
+#define OFI_CTRL_VERSION 2
 
 /* ofi_ctrl_hdr::type */
 enum {
@@ -97,21 +95,20 @@ enum {
  * ctrl_data: This is provider specific data for remote side
  */
 struct ofi_ctrl_hdr {
-	uint8_t				version;
-	uint8_t				type;
-	uint16_t			seg_size;
-	uint32_t			seg_no;
-	uint64_t			conn_id;
-	uint64_t			msg_id;
+	uint8_t version;
+	uint8_t type;
+	uint16_t seg_size;
+	uint32_t seg_no;
+	uint64_t conn_id;
+	uint64_t msg_id;
 	union {
-		uint64_t		conn_data;
-		uint64_t		rx_key;
-		uint64_t		ctrl_data;
+		uint64_t conn_data;
+		uint64_t rx_key;
+		uint64_t ctrl_data;
 	};
 };
 
-
-#define OFI_OP_VERSION	2
+#define OFI_OP_VERSION 2
 
 /*
  * Basic command opcode. ofi_op_hdr::op
@@ -132,10 +129,10 @@ enum {
 	ofi_op_max,
 };
 
-#define OFI_REMOTE_CQ_DATA	(1 << 0)
-#define OFI_TRANSMIT_COMPLETE	(1 << 1)
-#define OFI_DELIVERY_COMPLETE	(1 << 2)
-#define OFI_COMMIT_COMPLETE	(1 << 3)
+#define OFI_REMOTE_CQ_DATA (1 << 0)
+#define OFI_TRANSMIT_COMPLETE (1 << 1)
+#define OFI_DELIVERY_COMPLETE (1 << 2)
+#define OFI_COMMIT_COMPLETE (1 << 3)
 
 /*
  * Common command header
@@ -155,47 +152,46 @@ enum {
  * resv: Reserved, used for msg operations
  */
 struct ofi_op_hdr {
-	uint8_t			version;
-	uint8_t			rx_index;
-	uint8_t			op;
-	uint8_t			op_data;
-	uint32_t		flags;
+	uint8_t version;
+	uint8_t rx_index;
+	uint8_t op;
+	uint8_t op_data;
+	uint32_t flags;
 
-	uint64_t		size;
-	uint64_t		data;
+	uint64_t size;
+	uint64_t data;
 	union {
-		uint64_t	tag;
-		uint8_t		iov_count;
+		uint64_t tag;
+		uint8_t iov_count;
 		struct {
-			uint8_t	datatype;
-			uint8_t	op;
+			uint8_t datatype;
+			uint8_t op;
 			uint8_t ioc_count;
 		} atomic;
-		uint64_t	remote_idx;
-		uint64_t	resv;
+		uint64_t remote_idx;
+		uint64_t resv;
 	};
 };
 
 struct ofi_iov {
-	uint64_t		addr;
-	uint64_t		len;
+	uint64_t addr;
+	uint64_t len;
 };
 
 struct ofi_rma_iov {
-	uint64_t		addr;
-	uint64_t		len;
-	uint64_t		key;
+	uint64_t addr;
+	uint64_t len;
+	uint64_t key;
 };
 
 struct ofi_rma_ioc {
-	uint64_t		addr;
-	uint64_t		count;
-	uint64_t		key;
+	uint64_t addr;
+	uint64_t count;
+	uint64_t key;
 };
 
-#define OFI_CMD_SIZE		64	/* to align with 64-byte cache line */
-#define OFI_CMD_DATA_LEN	(OFI_CMD_SIZE - sizeof(struct ofi_ctrl_hdr))
-
+#define OFI_CMD_SIZE 64 /* to align with 64-byte cache line */
+#define OFI_CMD_DATA_LEN (OFI_CMD_SIZE - sizeof(struct ofi_ctrl_hdr))
 
 #ifdef __cplusplus
 }

--- a/include/ofi_prov.h
+++ b/include/ofi_prov.h
@@ -40,7 +40,7 @@
 
 /* Provider initialization function signature that built-in providers
  * must specify. */
-#define INI_SIG(name) struct fi_provider* name(void)
+#define INI_SIG(name) struct fi_provider *name(void)
 
 /* for each provider defines for three scenarios:
  * dl: externally visible ctor with known name (see fi_prov.h)
@@ -49,14 +49,14 @@
 */
 
 #if (HAVE_GNI) && (HAVE_GNI_DL)
-#  define GNI_INI FI_EXT_INI
-#  define GNI_INIT NULL
+#define GNI_INI FI_EXT_INI
+#define GNI_INIT NULL
 #elif (HAVE_GNI)
-#  define GNI_INI INI_SIG(fi_gni_ini)
-#  define GNI_INIT fi_gni_ini()
-GNI_INI ;
+#define GNI_INI INI_SIG(fi_gni_ini)
+#define GNI_INIT fi_gni_ini()
+GNI_INI;
 #else
-#  define GNI_INIT NULL
+#define GNI_INIT NULL
 #endif
 
 /* If HAVE_EFA is defined on Windows, then the VisualStudio project configures
@@ -65,284 +65,284 @@ GNI_INI ;
  * that VERBS_INIT is NULL so that ofi_register_provider will skip it.
  */
 #if defined(_WIN32) && (HAVE_EFA)
-#  define VERBS_INIT NULL
+#define VERBS_INIT NULL
 #else
-#  if (HAVE_VERBS) && (HAVE_VERBS_DL)
-#    define VERBS_INI FI_EXT_INI
-#    define VERBS_INIT NULL
-#  elif (HAVE_VERBS)
-#    define VERBS_INI INI_SIG(fi_verbs_ini)
-#    define VERBS_INIT fi_verbs_ini()
-VERBS_INI ;
-#  else
-#    define VERBS_INIT NULL
-#  endif
+#if (HAVE_VERBS) && (HAVE_VERBS_DL)
+#define VERBS_INI FI_EXT_INI
+#define VERBS_INIT NULL
+#elif (HAVE_VERBS)
+#define VERBS_INI INI_SIG(fi_verbs_ini)
+#define VERBS_INIT fi_verbs_ini()
+VERBS_INI;
+#else
+#define VERBS_INIT NULL
+#endif
 #endif
 
 #if (HAVE_EFA) && (HAVE_EFA_DL)
-#  define EFA_INI FI_EXT_INI
-#  define EFA_INIT NULL
+#define EFA_INI FI_EXT_INI
+#define EFA_INIT NULL
 #elif (HAVE_EFA)
-#  define EFA_INI INI_SIG(fi_efa_ini)
-#  define EFA_INIT fi_efa_ini()
-EFA_INI ;
+#define EFA_INI INI_SIG(fi_efa_ini)
+#define EFA_INIT fi_efa_ini()
+EFA_INI;
 #else
-#  define EFA_INIT NULL
+#define EFA_INIT NULL
 #endif
 
 #if (HAVE_PSM) && (HAVE_PSM_DL)
-#  define PSM_INI FI_EXT_INI
-#  define PSM_INIT NULL
+#define PSM_INI FI_EXT_INI
+#define PSM_INIT NULL
 #elif (HAVE_PSM)
-#  define PSM_INI INI_SIG(fi_psm_ini)
-#  define PSM_INIT fi_psm_ini()
-PSM_INI ;
+#define PSM_INI INI_SIG(fi_psm_ini)
+#define PSM_INIT fi_psm_ini()
+PSM_INI;
 #else
-#  define PSM_INIT NULL
+#define PSM_INIT NULL
 #endif
 
 #if (HAVE_PSM2) && (HAVE_PSM2_DL)
-#  define PSM2_INI FI_EXT_INI
-#  define PSM2_INIT NULL
+#define PSM2_INI FI_EXT_INI
+#define PSM2_INIT NULL
 #elif (HAVE_PSM2)
-#  define PSM2_INI INI_SIG(fi_psm2_ini)
-#  define PSM2_INIT fi_psm2_ini()
-PSM2_INI ;
+#define PSM2_INI INI_SIG(fi_psm2_ini)
+#define PSM2_INIT fi_psm2_ini()
+PSM2_INI;
 #else
-#  define PSM2_INIT NULL
+#define PSM2_INIT NULL
 #endif
 
 #if (HAVE_PSM3) && (HAVE_PSM3_DL)
-#  define PSM3_INI FI_EXT_INI
-#  define PSM3_INIT NULL
+#define PSM3_INI FI_EXT_INI
+#define PSM3_INIT NULL
 #elif (HAVE_PSM3)
-#  define PSM3_INI INI_SIG(fi_psm3_ini)
-#  define PSM3_INIT fi_psm3_ini()
-PSM3_INI ;
+#define PSM3_INI INI_SIG(fi_psm3_ini)
+#define PSM3_INIT fi_psm3_ini()
+PSM3_INI;
 #else
-#  define PSM3_INIT NULL
+#define PSM3_INIT NULL
 #endif
 
 #if (HAVE_SOCKETS) && (HAVE_SOCKETS_DL)
-#  define SOCKETS_INI FI_EXT_INI
-#  define SOCKETS_INIT NULL
+#define SOCKETS_INI FI_EXT_INI
+#define SOCKETS_INIT NULL
 #elif (HAVE_SOCKETS)
-#  define SOCKETS_INI INI_SIG(fi_sockets_ini)
-#  define SOCKETS_INIT fi_sockets_ini()
-SOCKETS_INI ;
+#define SOCKETS_INI INI_SIG(fi_sockets_ini)
+#define SOCKETS_INIT fi_sockets_ini()
+SOCKETS_INI;
 #else
-#  define SOCKETS_INIT NULL
+#define SOCKETS_INIT NULL
 #endif
 
 #if (HAVE_USNIC) && (HAVE_USNIC_DL)
-#  define USNIC_INI FI_EXT_INI
-#  define USNIC_INIT NULL
+#define USNIC_INI FI_EXT_INI
+#define USNIC_INIT NULL
 #elif (HAVE_USNIC)
-#  define USNIC_INI INI_SIG(fi_usnic_ini)
-#  define USNIC_INIT fi_usnic_ini()
-USNIC_INI ;
+#define USNIC_INI INI_SIG(fi_usnic_ini)
+#define USNIC_INIT fi_usnic_ini()
+USNIC_INI;
 #else
-#  define USNIC_INIT NULL
+#define USNIC_INIT NULL
 #endif
 
 #if (HAVE_UDP) && (HAVE_UDP_DL)
-#  define UDP_INI FI_EXT_INI
-#  define UDP_INIT NULL
+#define UDP_INI FI_EXT_INI
+#define UDP_INIT NULL
 #elif (HAVE_UDP)
-#  define UDP_INI INI_SIG(fi_udp_ini)
-#  define UDP_INIT fi_udp_ini()
-UDP_INI ;
+#define UDP_INI INI_SIG(fi_udp_ini)
+#define UDP_INIT fi_udp_ini()
+UDP_INI;
 #else
-#  define UDP_INIT NULL
+#define UDP_INIT NULL
 #endif
 
 #if (HAVE_TCP) && (HAVE_TCP_DL)
-#  define TCP_INI FI_EXT_INI
-#  define TCP_INIT NULL
+#define TCP_INI FI_EXT_INI
+#define TCP_INIT NULL
 #elif (HAVE_TCP)
-#  define TCP_INI INI_SIG(fi_tcp_ini)
-#  define TCP_INIT fi_tcp_ini()
-TCP_INI ;
+#define TCP_INI INI_SIG(fi_tcp_ini)
+#define TCP_INIT fi_tcp_ini()
+TCP_INI;
 #else
-#  define TCP_INIT NULL
+#define TCP_INIT NULL
 #endif
 
 #if (HAVE_RXM) && (HAVE_RXM_DL)
-#  define RXM_INI FI_EXT_INI
-#  define RXM_INIT NULL
+#define RXM_INI FI_EXT_INI
+#define RXM_INIT NULL
 #elif (HAVE_RXM)
-#  define RXM_INI INI_SIG(fi_rxm_ini)
-#  define RXM_INIT fi_rxm_ini()
-RXM_INI ;
+#define RXM_INI INI_SIG(fi_rxm_ini)
+#define RXM_INIT fi_rxm_ini()
+RXM_INI;
 #else
-#  define RXM_INIT NULL
+#define RXM_INIT NULL
 #endif
 
 #if (HAVE_RXD) && (HAVE_RXD_DL)
-#  define RXD_INI FI_EXT_INI
-#  define RXD_INIT NULL
+#define RXD_INI FI_EXT_INI
+#define RXD_INIT NULL
 #elif (HAVE_RXD)
-#  define RXD_INI INI_SIG(fi_rxd_ini)
-#  define RXD_INIT fi_rxd_ini()
-RXD_INI ;
+#define RXD_INI INI_SIG(fi_rxd_ini)
+#define RXD_INIT fi_rxd_ini()
+RXD_INI;
 #else
-#  define RXD_INIT NULL
+#define RXD_INIT NULL
 #endif
 
 #if (HAVE_BGQ) && (HAVE_BGQ_DL)
-#  define BGQ_INI FI_EXT_INI
-#  define BGQ_INIT NULL
+#define BGQ_INI FI_EXT_INI
+#define BGQ_INIT NULL
 #elif (HAVE_BGQ)
-#  define BGQ_INI INI_SIG(fi_bgq_ini)
-#  define BGQ_INIT fi_bgq_ini()
-BGQ_INI ;
+#define BGQ_INI INI_SIG(fi_bgq_ini)
+#define BGQ_INIT fi_bgq_ini()
+BGQ_INI;
 #else
-#  define BGQ_INIT NULL
+#define BGQ_INIT NULL
 #endif
 
 #ifdef _WIN32
 #if (HAVE_NETDIR) && (HAVE_NETDIR_DL)
-#  define NETDIR_INI FI_EXT_INI
-#  define NETDIR_INIT NULL
+#define NETDIR_INI FI_EXT_INI
+#define NETDIR_INIT NULL
 #elif (HAVE_NETDIR)
-#  define NETDIR_INI INI_SIG(fi_netdir_ini)
-#  define NETDIR_INIT fi_netdir_ini()
-NETDIR_INI ;
+#define NETDIR_INI INI_SIG(fi_netdir_ini)
+#define NETDIR_INIT fi_netdir_ini()
+NETDIR_INI;
 #else
-#  define NETDIR_INIT NULL
+#define NETDIR_INIT NULL
 #endif
 #else /* _WIN32 */
-#  define NETDIR_INIT NULL
+#define NETDIR_INIT NULL
 #endif /* _WIN32 */
 
 #if (HAVE_SHM) && (HAVE_SHM_DL)
-#  define SHM_INI FI_EXT_INI
-#  define SHM_INIT NULL
+#define SHM_INI FI_EXT_INI
+#define SHM_INIT NULL
 #elif (HAVE_SHM)
-#  define SHM_INI INI_SIG(fi_shm_ini)
-#  define SHM_INIT fi_shm_ini()
-SHM_INI ;
+#define SHM_INI INI_SIG(fi_shm_ini)
+#define SHM_INIT fi_shm_ini()
+SHM_INI;
 #else
-#  define SHM_INIT NULL
+#define SHM_INIT NULL
 #endif
 
 #if (HAVE_SM2) && (HAVE_SM2_DL)
-#  define SM2_INI FI_EXT_INI
-#  define SM2_INIT NULL
+#define SM2_INI FI_EXT_INI
+#define SM2_INIT NULL
 #elif (HAVE_SM2)
-#  define SM2_INI INI_SIG(fi_sm2_ini)
-#  define SM2_INIT fi_sm2_ini()
-SM2_INI ;
+#define SM2_INI INI_SIG(fi_sm2_ini)
+#define SM2_INIT fi_sm2_ini()
+SM2_INI;
 #else
-#  define SM2_INIT NULL
+#define SM2_INIT NULL
 #endif
 
 #if (HAVE_MRAIL) && (HAVE_MRAIL_DL)
-#  define MRAIL_INI FI_EXT_INI
-#  define MRAIL_INIT NULL
+#define MRAIL_INI FI_EXT_INI
+#define MRAIL_INIT NULL
 #elif (HAVE_MRAIL)
-#  define MRAIL_INI INI_SIG(fi_mrail_ini)
-#  define MRAIL_INIT fi_mrail_ini()
-MRAIL_INI ;
+#define MRAIL_INI INI_SIG(fi_mrail_ini)
+#define MRAIL_INIT fi_mrail_ini()
+MRAIL_INI;
 #else
-#  define MRAIL_INIT NULL
+#define MRAIL_INIT NULL
 #endif
 
 #if (HAVE_RSTREAM) && (HAVE_RSTREAM_DL)
-#  define RSTREAM_INI FI_EXT_INI
-#  define RSTREAM_INIT NULL
+#define RSTREAM_INI FI_EXT_INI
+#define RSTREAM_INIT NULL
 #elif (HAVE_RSTREAM)
-#  define RSTREAM_INI INI_SIG(fi_rstream_ini)
-#  define RSTREAM_INIT fi_rstream_ini()
-RSTREAM_INI ;
+#define RSTREAM_INI INI_SIG(fi_rstream_ini)
+#define RSTREAM_INIT fi_rstream_ini()
+RSTREAM_INI;
 #else
-#  define RSTREAM_INIT NULL
+#define RSTREAM_INIT NULL
 #endif
 
 #if (HAVE_PERF) && (HAVE_PERF_DL)
-#  define HOOK_PERF_INI FI_EXT_INI
-#  define HOOK_PERF_INIT NULL
+#define HOOK_PERF_INI FI_EXT_INI
+#define HOOK_PERF_INIT NULL
 #elif (HAVE_PERF)
-#  define HOOK_PERF_INI INI_SIG(fi_hook_perf_ini)
-#  define HOOK_PERF_INIT fi_hook_perf_ini()
-HOOK_PERF_INI ;
+#define HOOK_PERF_INI INI_SIG(fi_hook_perf_ini)
+#define HOOK_PERF_INIT fi_hook_perf_ini()
+HOOK_PERF_INI;
 #else
-#  define HOOK_PERF_INIT NULL
+#define HOOK_PERF_INIT NULL
 #endif
 
 #if (HAVE_TRACE) && (HAVE_TRACE_DL)
-#  define HOOK_TRACE_INI FI_EXT_INI
-#  define HOOK_TRACE_INIT NULL
+#define HOOK_TRACE_INI FI_EXT_INI
+#define HOOK_TRACE_INIT NULL
 #elif (HAVE_TRACE)
-#  define HOOK_TRACE_INI INI_SIG(fi_hook_trace_ini)
-#  define HOOK_TRACE_INIT fi_hook_trace_ini()
-HOOK_TRACE_INI ;
+#define HOOK_TRACE_INI INI_SIG(fi_hook_trace_ini)
+#define HOOK_TRACE_INIT fi_hook_trace_ini()
+HOOK_TRACE_INI;
 #else
-#  define HOOK_TRACE_INIT NULL
+#define HOOK_TRACE_INIT NULL
 #endif
 
 #if (HAVE_HOOK_DEBUG) && (HAVE_HOOK_DEBUG_DL)
-#  define HOOK_DEBUG_INI FI_EXT_INI
-#  define HOOK_DEBUG_INIT NULL
+#define HOOK_DEBUG_INI FI_EXT_INI
+#define HOOK_DEBUG_INIT NULL
 #elif (HAVE_HOOK_DEBUG)
-#  define HOOK_DEBUG_INI INI_SIG(fi_debug_hook_ini)
-#  define HOOK_DEBUG_INIT fi_debug_hook_ini()
-HOOK_DEBUG_INI ;
+#define HOOK_DEBUG_INI INI_SIG(fi_debug_hook_ini)
+#define HOOK_DEBUG_INIT fi_debug_hook_ini()
+HOOK_DEBUG_INI;
 #else
-#  define HOOK_DEBUG_INIT NULL
+#define HOOK_DEBUG_INIT NULL
 #endif
 
 #if (HAVE_HOOK_HMEM) && (HAVE_HOOK_HMEM_DL)
-#  define HOOK_HMEM_INI FI_EXT_INI
-#  define HOOK_HMEM_INIT NULL
+#define HOOK_HMEM_INI FI_EXT_INI
+#define HOOK_HMEM_INIT NULL
 #elif (HAVE_HOOK_HMEM)
-#  define HOOK_HMEM_INI INI_SIG(fi_hook_hmem_ini)
-#  define HOOK_HMEM_INIT fi_hook_hmem_ini()
-HOOK_HMEM_INI ;
+#define HOOK_HMEM_INI INI_SIG(fi_hook_hmem_ini)
+#define HOOK_HMEM_INIT fi_hook_hmem_ini()
+HOOK_HMEM_INI;
 #else
-#  define HOOK_HMEM_INIT NULL
+#define HOOK_HMEM_INIT NULL
 #endif
 
 #if (HAVE_DMABUF_PEER_MEM) && (HAVE_DMABUF_PEER_MEM_DL)
-#  define HOOK_DMABUF_PEER_MEM_INI FI_EXT_INI
-#  define HOOK_DMABUF_PEER_MEM_INIT NULL
+#define HOOK_DMABUF_PEER_MEM_INI FI_EXT_INI
+#define HOOK_DMABUF_PEER_MEM_INIT NULL
 #elif (HAVE_DMABUF_PEER_MEM)
-#  define HOOK_DMABUF_PEER_MEM_INI INI_SIG(fi_dmabuf_peer_mem_hook_ini)
-#  define HOOK_DMABUF_PEER_MEM_INIT fi_dmabuf_peer_mem_hook_ini()
-HOOK_DMABUF_PEER_MEM_INI ;
+#define HOOK_DMABUF_PEER_MEM_INI INI_SIG(fi_dmabuf_peer_mem_hook_ini)
+#define HOOK_DMABUF_PEER_MEM_INIT fi_dmabuf_peer_mem_hook_ini()
+HOOK_DMABUF_PEER_MEM_INI;
 #else
-#  define HOOK_DMABUF_PEER_MEM_INIT NULL
+#define HOOK_DMABUF_PEER_MEM_INIT NULL
 #endif
 
-#  define HOOK_NOOP_INI INI_SIG(fi_hook_noop_ini)
-#  define HOOK_NOOP_INIT fi_hook_noop_ini()
-HOOK_NOOP_INI ;
+#define HOOK_NOOP_INI INI_SIG(fi_hook_noop_ini)
+#define HOOK_NOOP_INIT fi_hook_noop_ini()
+HOOK_NOOP_INI;
 
 #if (HAVE_OPX) && (HAVE_OPX_DL)
-#  define OPX_INI FI_EXT_INI
-#  define OPX_INIT NULL
+#define OPX_INI FI_EXT_INI
+#define OPX_INIT NULL
 #elif (HAVE_OPX)
-#  define OPX_INI INI_SIG(fi_opx_ini)
-#  define OPX_INIT fi_opx_ini()
-OPX_INI ;
+#define OPX_INI INI_SIG(fi_opx_ini)
+#define OPX_INIT fi_opx_ini()
+OPX_INI;
 #else
-#  define OPX_INIT NULL
+#define OPX_INIT NULL
 #endif
 
 #if (HAVE_UCX) && (HAVE_UCX_DL)
-#  define UCX_INI FI_EXT_INI
-#  define UCX_INIT NULL
+#define UCX_INI FI_EXT_INI
+#define UCX_INIT NULL
 #elif (HAVE_UCX)
-#  define UCX_INI INI_SIG(fi_ucx_ini)
-#  define UCX_INIT fi_ucx_ini()
-UCX_INI ;
+#define UCX_INI INI_SIG(fi_ucx_ini)
+#define UCX_INIT fi_ucx_ini()
+UCX_INI;
 #else
-#  define UCX_INIT NULL
+#define UCX_INIT NULL
 #endif
 
 /* the utility collective provider is always enabled and built-in */
 #define COLL_INI INI_SIG(fi_coll_ini)
 #define COLL_INIT fi_coll_ini()
-COLL_INI ;
+COLL_INI;
 
 #endif /* _OFI_PROV_H_ */

--- a/include/ofi_rbuf.h
+++ b/include/ofi_rbuf.h
@@ -47,71 +47,71 @@
 #include <ofi_file.h>
 #include <stdlib.h>
 
-
 /*
  * Circular queue/array template
  */
-#define OFI_DECLARE_CIRQUE(entrytype, name)                     \
-struct name {							\
-	size_t		size;					\
-	size_t		size_mask;				\
-	size_t		rcnt;					\
-	size_t		wcnt;					\
-	entrytype	buf[];					\
-};								\
-								\
-static inline void name ## _init(struct name *cq, size_t size)	\
-{								\
-	assert(size == roundup_power_of_two(size));		\
-	cq->size = size;					\
-	cq->size_mask = cq->size - 1;				\
-	cq->rcnt = 0;						\
-	cq->wcnt = 0;						\
-}								\
-								\
-static inline struct name * name ## _create(size_t size)	\
-{								\
-	struct name *cq;					\
-	cq = (struct name*) calloc(1, sizeof(*cq) + sizeof(entrytype) *	\
-		    (roundup_power_of_two(size)));		\
-	if (cq)							\
-		name ##_init(cq, roundup_power_of_two(size));	\
-	return cq;						\
-}								\
-								\
-static inline void name ## _free(struct name *cq)		\
-{								\
-	free(cq);						\
-}								\
-void dummy ## name (void) /* work-around global ; scope */
+#define OFI_DECLARE_CIRQUE(entrytype, name)                                  \
+	struct name {                                                        \
+		size_t size;                                                 \
+		size_t size_mask;                                            \
+		size_t rcnt;                                                 \
+		size_t wcnt;                                                 \
+		entrytype buf[];                                             \
+	};                                                                   \
+                                                                             \
+	static inline void name##_init(struct name *cq, size_t size)         \
+	{                                                                    \
+		assert(size == roundup_power_of_two(size));                  \
+		cq->size = size;                                             \
+		cq->size_mask = cq->size - 1;                                \
+		cq->rcnt = 0;                                                \
+		cq->wcnt = 0;                                                \
+	}                                                                    \
+                                                                             \
+	static inline struct name *name##_create(size_t size)                \
+	{                                                                    \
+		struct name *cq;                                             \
+		cq = (struct name *)calloc(                                  \
+			1,                                                   \
+			sizeof(*cq) + sizeof(entrytype) *                    \
+					      (roundup_power_of_two(size))); \
+		if (cq)                                                      \
+			name##_init(cq, roundup_power_of_two(size));         \
+		return cq;                                                   \
+	}                                                                    \
+                                                                             \
+	static inline void name##_free(struct name *cq)                      \
+	{                                                                    \
+		free(cq);                                                    \
+	}                                                                    \
+	void dummy##name(void) /* work-around global ; scope */
 
-#define ofi_cirque_isempty(cq)		((cq)->wcnt == (cq)->rcnt)
-#define ofi_cirque_usedcnt(cq)		((cq)->wcnt - (cq)->rcnt)
-#define ofi_cirque_freecnt(cq)		((cq)->size - ofi_cirque_usedcnt(cq))
-#define ofi_cirque_isfull(cq)		(ofi_cirque_freecnt(cq) <= 0)
+#define ofi_cirque_isempty(cq) ((cq)->wcnt == (cq)->rcnt)
+#define ofi_cirque_usedcnt(cq) ((cq)->wcnt - (cq)->rcnt)
+#define ofi_cirque_freecnt(cq) ((cq)->size - ofi_cirque_usedcnt(cq))
+#define ofi_cirque_isfull(cq) (ofi_cirque_freecnt(cq) <= 0)
 
-#define ofi_cirque_rindex(cq)		((cq)->rcnt & (cq)->size_mask)
-#define ofi_cirque_windex(cq)		((cq)->wcnt & (cq)->size_mask)
-#define ofi_cirque_tindex(cq)		(((cq)->wcnt - 1) & (cq)->size_mask)
-#define ofi_cirque_head(cq)		(&(cq)->buf[ofi_cirque_rindex(cq)])
-#define ofi_cirque_tail(cq)		(&(cq)->buf[ofi_cirque_tindex(cq)])
-#define ofi_cirque_next(cq)		(&(cq)->buf[ofi_cirque_windex(cq)])
-#define ofi_cirque_insert(cq, x)	(cq)->buf[(cq)->wcnt++ & (cq)->size_mask] = x
-#define ofi_cirque_remove(cq)		(&(cq)->buf[(cq)->rcnt++ & (cq)->size_mask])
-#define ofi_cirque_discard(cq)		((cq)->rcnt++)
-#define ofi_cirque_commit(cq)		((cq)->wcnt++)
-
+#define ofi_cirque_rindex(cq) ((cq)->rcnt & (cq)->size_mask)
+#define ofi_cirque_windex(cq) ((cq)->wcnt & (cq)->size_mask)
+#define ofi_cirque_tindex(cq) (((cq)->wcnt - 1) & (cq)->size_mask)
+#define ofi_cirque_head(cq) (&(cq)->buf[ofi_cirque_rindex(cq)])
+#define ofi_cirque_tail(cq) (&(cq)->buf[ofi_cirque_tindex(cq)])
+#define ofi_cirque_next(cq) (&(cq)->buf[ofi_cirque_windex(cq)])
+#define ofi_cirque_insert(cq, x) (cq)->buf[(cq)->wcnt++ & (cq)->size_mask] = x
+#define ofi_cirque_remove(cq) (&(cq)->buf[(cq)->rcnt++ & (cq)->size_mask])
+#define ofi_cirque_discard(cq) ((cq)->rcnt++)
+#define ofi_cirque_commit(cq) ((cq)->wcnt++)
 
 /*
  * Simple ring buffer
  */
 struct ofi_ringbuf {
-	size_t		size;
-	size_t		size_mask;
-	size_t		rcnt;
-	size_t		wcnt;
-	size_t		wpos;
-	void		*buf;
+	size_t size;
+	size_t size_mask;
+	size_t rcnt;
+	size_t wcnt;
+	size_t wpos;
+	void *buf;
 };
 
 static inline int ofi_rbinit(struct ofi_ringbuf *rb, size_t size)
@@ -159,16 +159,18 @@ static inline size_t ofi_rbavail(struct ofi_ringbuf *rb)
 	return rb->size - ofi_rbused(rb);
 }
 
-static inline void ofi_rbwrite(struct ofi_ringbuf *rb, const void *buf, size_t len)
+static inline void ofi_rbwrite(struct ofi_ringbuf *rb, const void *buf,
+			       size_t len)
 {
 	size_t endlen;
 
 	endlen = rb->size - (rb->wpos & rb->size_mask);
 	if (len <= endlen) {
-		memcpy((char*)rb->buf + (rb->wpos & rb->size_mask), buf, len);
+		memcpy((char *)rb->buf + (rb->wpos & rb->size_mask), buf, len);
 	} else {
-		memcpy((char*)rb->buf + (rb->wpos & rb->size_mask), buf, endlen);
-		memcpy(rb->buf, (char*)buf + endlen, len - endlen);
+		memcpy((char *)rb->buf + (rb->wpos & rb->size_mask), buf,
+		       endlen);
+		memcpy(rb->buf, (char *)buf + endlen, len - endlen);
 	}
 	rb->wpos += len;
 }
@@ -189,10 +191,11 @@ static inline void ofi_rbpeek(struct ofi_ringbuf *rb, void *buf, size_t len)
 
 	endlen = rb->size - (rb->rcnt & rb->size_mask);
 	if (len <= endlen) {
-		memcpy(buf, (char*)rb->buf + (rb->rcnt & rb->size_mask), len);
+		memcpy(buf, (char *)rb->buf + (rb->rcnt & rb->size_mask), len);
 	} else {
-		memcpy(buf, (char*)rb->buf + (rb->rcnt & rb->size_mask), endlen);
-		memcpy((char*)buf + endlen, rb->buf, len - endlen);
+		memcpy(buf, (char *)rb->buf + (rb->rcnt & rb->size_mask),
+		       endlen);
+		memcpy((char *)buf + endlen, rb->buf, len - endlen);
 	}
 }
 
@@ -212,16 +215,13 @@ static inline size_t ofi_rbdiscard(struct ofi_ringbuf *rb, size_t len)
 /*
  * Ring buffer with blocking read support using an fd
  */
-enum {
-	OFI_RB_READ_FD,
-	OFI_RB_WRITE_FD
-};
+enum { OFI_RB_READ_FD, OFI_RB_WRITE_FD };
 
 struct ofi_ringbuffd {
-	struct ofi_ringbuf	rb;
-	int			fdrcnt;
-	int			fdwcnt;
-	int			fd[2];
+	struct ofi_ringbuf rb;
+	int fdrcnt;
+	int fdwcnt;
+	int fd[2];
 };
 
 static inline int ofi_rbfdinit(struct ofi_ringbuffd *rbfd, size_t size)
@@ -285,7 +285,8 @@ static inline void ofi_rbfdsignal(struct ofi_ringbuffd *rbfd)
 {
 	char c = 0;
 	if (rbfd->fdwcnt == rbfd->fdrcnt) {
-		if (ofi_write_socket(rbfd->fd[OFI_RB_WRITE_FD], &c, sizeof c) == sizeof c)
+		if (ofi_write_socket(rbfd->fd[OFI_RB_WRITE_FD], &c, sizeof c) ==
+		    sizeof c)
 			rbfd->fdwcnt++;
 	}
 }
@@ -295,12 +296,14 @@ static inline void ofi_rbfdreset(struct ofi_ringbuffd *rbfd)
 	char c;
 
 	if (ofi_rbfdempty(rbfd) && (rbfd->fdrcnt != rbfd->fdwcnt)) {
-		if (ofi_read_socket(rbfd->fd[OFI_RB_READ_FD], &c, sizeof c) == sizeof c)
+		if (ofi_read_socket(rbfd->fd[OFI_RB_READ_FD], &c, sizeof c) ==
+		    sizeof c)
 			rbfd->fdrcnt++;
 	}
 }
 
-static inline void ofi_rbfdwrite(struct ofi_ringbuffd *rbfd, const void *buf, size_t len)
+static inline void ofi_rbfdwrite(struct ofi_ringbuffd *rbfd, const void *buf,
+				 size_t len)
 {
 	ofi_rbwrite(&rbfd->rb, buf, len);
 }
@@ -316,19 +319,21 @@ static inline void ofi_rbfdabort(struct ofi_ringbuffd *rbfd)
 	ofi_rbabort(&rbfd->rb);
 }
 
-static inline void ofi_rbfdpeek(struct ofi_ringbuffd *rbfd, void *buf, size_t len)
+static inline void ofi_rbfdpeek(struct ofi_ringbuffd *rbfd, void *buf,
+				size_t len)
 {
 	ofi_rbpeek(&rbfd->rb, buf, len);
 }
 
-static inline void ofi_rbfdread(struct ofi_ringbuffd *rbfd, void *buf, size_t len)
+static inline void ofi_rbfdread(struct ofi_ringbuffd *rbfd, void *buf,
+				size_t len)
 {
 	ofi_rbread(&rbfd->rb, buf, len);
 	ofi_rbfdreset(rbfd);
 }
 
-static inline size_t ofi_rbfdsread(struct ofi_ringbuffd *rbfd, void *buf, size_t len,
-				int timeout)
+static inline size_t ofi_rbfdsread(struct ofi_ringbuffd *rbfd, void *buf,
+				   size_t len, int timeout)
 {
 	int ret;
 	size_t avail;
@@ -351,8 +356,7 @@ static inline size_t ofi_rbfdsread(struct ofi_ringbuffd *rbfd, void *buf, size_t
 
 static inline size_t ofi_rbfdwait(struct ofi_ringbuffd *rbfd, int timeout)
 {
-	return  fi_poll_fd(rbfd->fd[OFI_RB_READ_FD], timeout);
+	return fi_poll_fd(rbfd->fd[OFI_RB_READ_FD], timeout);
 }
-
 
 #endif /* _OFI_RBUF_H_ */

--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -53,24 +53,23 @@
 extern "C" {
 #endif
 
+#define SMR_VERSION 4
 
-#define SMR_VERSION	4
-
-#define SMR_FLAG_ATOMIC	(1 << 0)
-#define SMR_FLAG_DEBUG	(1 << 1)
+#define SMR_FLAG_ATOMIC (1 << 0)
+#define SMR_FLAG_DEBUG (1 << 1)
 #define SMR_FLAG_IPC_SOCK (1 << 2)
 #define SMR_FLAG_HMEM_ENABLED (1 << 3)
 
-#define SMR_CMD_SIZE		256	/* align with 64-byte cache line */
+#define SMR_CMD_SIZE 256 /* align with 64-byte cache line */
 
 /* SMR op_src: Specifies data source location */
 enum {
-	smr_src_inline,	/* command data */
-	smr_src_inject,	/* inject buffers */
-	smr_src_iov,	/* reference iovec via CMA */
-	smr_src_mmap,	/* mmap-based fallback protocol */
-	smr_src_sar,	/* segmentation fallback protocol */
-	smr_src_ipc,	/* device IPC handle protocol */
+	smr_src_inline, /* command data */
+	smr_src_inject, /* inject buffers */
+	smr_src_iov, /* reference iovec via CMA */
+	smr_src_mmap, /* mmap-based fallback protocol */
+	smr_src_sar, /* segmentation fallback protocol */
+	smr_src_ipc, /* device IPC handle protocol */
 	smr_src_max,
 };
 
@@ -78,11 +77,11 @@ enum {
 //256 and beyond reserved for ctrl ops
 #define SMR_OP_MAX (1 << 8)
 
-#define SMR_REMOTE_CQ_DATA	(1 << 0)
-#define SMR_RMA_REQ		(1 << 1)
-#define SMR_TX_COMPLETION	(1 << 2)
-#define SMR_RX_COMPLETION	(1 << 3)
-#define SMR_MULTI_RECV		(1 << 4)
+#define SMR_REMOTE_CQ_DATA (1 << 0)
+#define SMR_RMA_REQ (1 << 1)
+#define SMR_TX_COMPLETION (1 << 2)
+#define SMR_RX_COMPLETION (1 << 3)
+#define SMR_MULTI_RECV (1 << 4)
 
 /* CMA capability */
 enum {
@@ -101,82 +100,82 @@ enum {
  * 	data - remote CQ data
  */
 struct smr_msg_hdr {
-	uint64_t		msg_id;
-	int64_t			id;
-	uint32_t		op;
-	uint16_t		op_src;
-	uint16_t		op_flags;
+	uint64_t msg_id;
+	int64_t id;
+	uint32_t op;
+	uint16_t op_src;
+	uint16_t op_flags;
 
-	uint64_t		size;
-	uint64_t		src_data;
-	uint64_t		data;
+	uint64_t size;
+	uint64_t src_data;
+	uint64_t data;
 	union {
-		uint64_t	tag;
+		uint64_t tag;
 		struct {
-			uint8_t	datatype;
-			uint8_t	atomic_op;
+			uint8_t datatype;
+			uint8_t atomic_op;
 		};
 	};
-} __attribute__ ((aligned(16)));
+} __attribute__((aligned(16)));
 
-#define SMR_BUF_BATCH_MAX	64
-#define SMR_MSG_DATA_LEN	(SMR_CMD_SIZE - sizeof(struct smr_msg_hdr))
+#define SMR_BUF_BATCH_MAX 64
+#define SMR_MSG_DATA_LEN (SMR_CMD_SIZE - sizeof(struct smr_msg_hdr))
 
 union smr_cmd_data {
-	uint8_t			msg[SMR_MSG_DATA_LEN];
+	uint8_t msg[SMR_MSG_DATA_LEN];
 	struct {
-		size_t		iov_count;
-		struct iovec	iov[(SMR_MSG_DATA_LEN - sizeof(size_t)) /
-				    sizeof(struct iovec)];
+		size_t iov_count;
+		struct iovec iov[(SMR_MSG_DATA_LEN - sizeof(size_t)) /
+				 sizeof(struct iovec)];
 	};
 	struct {
-		uint32_t	buf_batch_size;
-		int16_t		sar[SMR_BUF_BATCH_MAX];
+		uint32_t buf_batch_size;
+		int16_t sar[SMR_BUF_BATCH_MAX];
 	};
-	struct ipc_info		ipc_info;
+	struct ipc_info ipc_info;
 };
 
 struct smr_cmd_msg {
-	struct smr_msg_hdr	hdr;
-	union smr_cmd_data	data;
+	struct smr_msg_hdr hdr;
+	union smr_cmd_data data;
 };
 
-#define SMR_RMA_DATA_LEN	(128 - sizeof(uint64_t))
+#define SMR_RMA_DATA_LEN (128 - sizeof(uint64_t))
 struct smr_cmd_rma {
-	uint64_t		rma_count;
+	uint64_t rma_count;
 	union {
-		struct fi_rma_iov	rma_iov[SMR_RMA_DATA_LEN /
-						sizeof(struct fi_rma_iov)];
-		struct fi_rma_ioc	rma_ioc[SMR_RMA_DATA_LEN /
-						sizeof(struct fi_rma_ioc)];
+		struct fi_rma_iov
+			rma_iov[SMR_RMA_DATA_LEN / sizeof(struct fi_rma_iov)];
+		struct fi_rma_ioc
+			rma_ioc[SMR_RMA_DATA_LEN / sizeof(struct fi_rma_ioc)];
 	};
 };
 
 struct smr_cmd {
 	union {
-		struct smr_cmd_msg	msg;
-		struct smr_cmd_rma	rma;
+		struct smr_cmd_msg msg;
+		struct smr_cmd_rma rma;
 	};
 };
 
-#define SMR_INJECT_SIZE		4096
-#define SMR_COMP_INJECT_SIZE	(SMR_INJECT_SIZE / 2)
-#define SMR_SAR_SIZE		32768
+#define SMR_INJECT_SIZE 4096
+#define SMR_COMP_INJECT_SIZE (SMR_INJECT_SIZE / 2)
+#define SMR_SAR_SIZE 32768
 
 #define SMR_DIR "/dev/shm/"
-#define SMR_NAME_MAX	256
-#define SMR_PATH_MAX	(SMR_NAME_MAX + sizeof(SMR_DIR))
+#define SMR_NAME_MAX 256
+#define SMR_PATH_MAX (SMR_NAME_MAX + sizeof(SMR_DIR))
 #define SMR_SOCK_NAME_MAX sizeof(((struct sockaddr_un *)0)->sun_path)
 
 struct smr_addr {
-	char		name[SMR_NAME_MAX];
-	int64_t		id;
+	char name[SMR_NAME_MAX];
+	int64_t id;
 };
 
 struct smr_peer_data {
-	struct smr_addr		addr;
-	uint32_t		sar_status;
-	uint32_t		name_sent;
+	struct smr_addr addr;
+	uint32_t sar_status;
+	uint32_t name_sent;
 };
 
 extern struct dlist_entry ep_name_list;
@@ -200,77 +199,77 @@ static inline const char *smr_no_prefix(const char *addr)
 }
 
 struct smr_peer {
-	struct smr_addr		peer;
-	fi_addr_t		fiaddr;
-	struct smr_region	*region;
+	struct smr_addr peer;
+	fi_addr_t fiaddr;
+	struct smr_region *region;
 };
 
-#define SMR_MAX_PEERS	256
+#define SMR_MAX_PEERS 256
 
 struct smr_map {
-	ofi_spin_t		lock;
-	int64_t			cur_id;
-	int 			num_peers;
-	uint16_t		flags;
-	struct ofi_rbmap	rbmap;
-	struct smr_peer		peers[SMR_MAX_PEERS];
+	ofi_spin_t lock;
+	int64_t cur_id;
+	int num_peers;
+	uint16_t flags;
+	struct ofi_rbmap rbmap;
+	struct smr_peer peers[SMR_MAX_PEERS];
 };
 
 struct smr_region {
-	uint8_t		version;
-	uint8_t		resv;
-	uint16_t	flags;
-	int		pid;
-	uint8_t		cma_cap_peer;
-	uint8_t		cma_cap_self;
-	uint32_t	max_sar_buf_per_peer;
-	void		*base_addr;
-	pthread_spinlock_t	lock; /* lock for shm access
+	uint8_t version;
+	uint8_t resv;
+	uint16_t flags;
+	int pid;
+	uint8_t cma_cap_peer;
+	uint8_t cma_cap_self;
+	uint32_t max_sar_buf_per_peer;
+	void *base_addr;
+	pthread_spinlock_t lock; /* lock for shm access
 				 if both ep->tx_lock and this lock need to
 				 held, then ep->tx_lock needs to be held
 				 first */
-	ofi_atomic32_t	signal;
+	ofi_atomic32_t signal;
 
-	struct smr_map	*map;
+	struct smr_map *map;
 
-	size_t		total_size;
+	size_t total_size;
 
 	/* offsets from start of smr_region */
-	size_t		cmd_queue_offset;
-	size_t		resp_queue_offset;
-	size_t		inject_pool_offset;
-	size_t		sar_pool_offset;
-	size_t		peer_data_offset;
-	size_t		name_offset;
-	size_t		sock_name_offset;
+	size_t cmd_queue_offset;
+	size_t resp_queue_offset;
+	size_t inject_pool_offset;
+	size_t sar_pool_offset;
+	size_t peer_data_offset;
+	size_t name_offset;
+	size_t sock_name_offset;
 };
 
 struct smr_resp {
-	uint64_t	msg_id;
-	uint64_t	status;
+	uint64_t msg_id;
+	uint64_t status;
 };
 
 struct smr_inject_buf {
 	union {
-		uint8_t		data[SMR_INJECT_SIZE];
+		uint8_t data[SMR_INJECT_SIZE];
 		struct {
-			uint8_t	buf[SMR_COMP_INJECT_SIZE];
+			uint8_t buf[SMR_COMP_INJECT_SIZE];
 			uint8_t comp[SMR_COMP_INJECT_SIZE];
 		};
 	};
 };
 
 enum smr_status {
-	SMR_STATUS_SUCCESS = 0, 	/* success*/
-	SMR_STATUS_BUSY = FI_EBUSY, 	/* busy */
+	SMR_STATUS_SUCCESS = 0, /* success*/
+	SMR_STATUS_BUSY = FI_EBUSY, /* busy */
 
-	SMR_STATUS_OFFSET = 1024, 	/* Beginning of shm-specific codes */
-	SMR_STATUS_SAR_FREE, 		/* buffer can be used */
-	SMR_STATUS_SAR_READY, 		/* buffer has data in it */
+	SMR_STATUS_OFFSET = 1024, /* Beginning of shm-specific codes */
+	SMR_STATUS_SAR_FREE, /* buffer can be used */
+	SMR_STATUS_SAR_READY, /* buffer has data in it */
 };
 
 struct smr_sar_buf {
-	uint8_t		buf[SMR_SAR_SIZE];
+	uint8_t buf[SMR_SAR_SIZE];
 };
 
 /* TODO it is expected that a future patch will expand the smr_cmd
@@ -295,32 +294,32 @@ static inline struct smr_region *smr_peer_region(struct smr_region *smr, int i)
 }
 static inline struct smr_cmd_queue *smr_cmd_queue(struct smr_region *smr)
 {
-	return (struct smr_cmd_queue *) ((char *) smr + smr->cmd_queue_offset);
+	return (struct smr_cmd_queue *)((char *)smr + smr->cmd_queue_offset);
 }
 static inline struct smr_resp_queue *smr_resp_queue(struct smr_region *smr)
 {
-	return (struct smr_resp_queue *) ((char *) smr + smr->resp_queue_offset);
+	return (struct smr_resp_queue *)((char *)smr + smr->resp_queue_offset);
 }
 static inline struct smr_freestack *smr_inject_pool(struct smr_region *smr)
 {
-	return (struct smr_freestack *) ((char *) smr + smr->inject_pool_offset);
+	return (struct smr_freestack *)((char *)smr + smr->inject_pool_offset);
 }
 static inline struct smr_peer_data *smr_peer_data(struct smr_region *smr)
 {
-	return (struct smr_peer_data *) ((char *) smr + smr->peer_data_offset);
+	return (struct smr_peer_data *)((char *)smr + smr->peer_data_offset);
 }
 static inline struct smr_freestack *smr_sar_pool(struct smr_region *smr)
 {
-	return (struct smr_freestack *) ((char *) smr + smr->sar_pool_offset);
+	return (struct smr_freestack *)((char *)smr + smr->sar_pool_offset);
 }
 static inline const char *smr_name(struct smr_region *smr)
 {
-	return (const char *) smr + smr->name_offset;
+	return (const char *)smr + smr->name_offset;
 }
 
 static inline char *smr_sock_name(struct smr_region *smr)
 {
-	return (char *) smr + smr->sock_name_offset;
+	return (char *)smr + smr->sock_name_offset;
 }
 
 static inline void smr_set_map(struct smr_region *smr, struct smr_map *map)
@@ -329,10 +328,10 @@ static inline void smr_set_map(struct smr_region *smr, struct smr_map *map)
 }
 
 struct smr_attr {
-	const char	*name;
-	size_t		rx_count;
-	size_t		tx_count;
-	uint16_t	flags;
+	const char *name;
+	size_t rx_count;
+	size_t tx_count;
+	uint16_t flags;
 };
 
 size_t smr_calculate_size_offsets(size_t tx_count, size_t rx_count,
@@ -340,25 +339,25 @@ size_t smr_calculate_size_offsets(size_t tx_count, size_t rx_count,
 				  size_t *inject_offset, size_t *sar_offset,
 				  size_t *peer_offset, size_t *name_offset,
 				  size_t *sock_offset);
-void	smr_cma_check(struct smr_region *region, struct smr_region *peer_region);
-void	smr_cleanup(void);
-int	smr_map_create(const struct fi_provider *prov, int peer_count,
-		       uint16_t caps, struct smr_map **map);
-int	smr_map_to_region(const struct fi_provider *prov, struct smr_map *map,
-			  int64_t id);
-void	smr_map_to_endpoint(struct smr_region *region, int64_t id);
-void	smr_unmap_from_endpoint(struct smr_region *region, int64_t id);
-void	smr_exchange_all_peers(struct smr_region *region);
-int	smr_map_add(const struct fi_provider *prov,
-		    struct smr_map *map, const char *name, int64_t *id);
-void	smr_map_del(struct smr_map *map, int64_t id);
-void	smr_map_free(struct smr_map *map);
+void smr_cma_check(struct smr_region *region, struct smr_region *peer_region);
+void smr_cleanup(void);
+int smr_map_create(const struct fi_provider *prov, int peer_count,
+		   uint16_t caps, struct smr_map **map);
+int smr_map_to_region(const struct fi_provider *prov, struct smr_map *map,
+		      int64_t id);
+void smr_map_to_endpoint(struct smr_region *region, int64_t id);
+void smr_unmap_from_endpoint(struct smr_region *region, int64_t id);
+void smr_exchange_all_peers(struct smr_region *region);
+int smr_map_add(const struct fi_provider *prov, struct smr_map *map,
+		const char *name, int64_t *id);
+void smr_map_del(struct smr_map *map, int64_t id);
+void smr_map_free(struct smr_map *map);
 
 struct smr_region *smr_map_get(struct smr_map *map, int64_t id);
 
-int	smr_create(const struct fi_provider *prov, struct smr_map *map,
-		   const struct smr_attr *attr, struct smr_region *volatile *smr);
-void	smr_free(struct smr_region *smr);
+int smr_create(const struct fi_provider *prov, struct smr_map *map,
+	       const struct smr_attr *attr, struct smr_region *volatile *smr);
+void smr_free(struct smr_region *smr);
 
 static inline void smr_signal(struct smr_region *smr)
 {

--- a/include/ofi_signal.h
+++ b/include/ofi_signal.h
@@ -48,11 +48,7 @@
 #include <ofi_atom.h>
 #include <rdma/fi_errno.h>
 
-
-enum {
-	FI_READ_FD,
-	FI_WRITE_FD
-};
+enum { FI_READ_FD, FI_WRITE_FD };
 
 struct fd_signal {
 	ofi_mutex_t lock;

--- a/include/ofi_tree.h
+++ b/include/ofi_tree.h
@@ -47,50 +47,46 @@
 
 #include <stdlib.h>
 
-
-enum ofi_node_color {
-	BLACK,
-	RED
-};
+enum ofi_node_color { BLACK, RED };
 
 struct ofi_rbnode {
-	struct ofi_rbnode	*left;
-	struct ofi_rbnode	*right;
-	struct ofi_rbnode	*parent;
-	enum ofi_node_color	color;
-	void			*data;
+	struct ofi_rbnode *left;
+	struct ofi_rbnode *right;
+	struct ofi_rbnode *parent;
+	enum ofi_node_color color;
+	void *data;
 };
 
 struct ofi_rbmap {
-	struct ofi_rbnode	*root;
-	struct ofi_rbnode	sentinel;
-	struct ofi_rbnode	*free_list;
+	struct ofi_rbnode *root;
+	struct ofi_rbnode sentinel;
+	struct ofi_rbnode *free_list;
 
 	/* compare()
 	 *	= 0: a == b
 	 *	< 0: a < b
 	 *	> 0: a > b
 	 */
-	int			(*compare)(struct ofi_rbmap *map,
-					   void *key, void *data);
+	int (*compare)(struct ofi_rbmap *map, void *key, void *data);
 };
 
-struct ofi_rbmap *
-ofi_rbmap_create(int (*compare)(struct ofi_rbmap *map, void *key, void *data));
+struct ofi_rbmap *ofi_rbmap_create(int (*compare)(struct ofi_rbmap *map,
+						  void *key, void *data));
 void ofi_rbmap_destroy(struct ofi_rbmap *map);
 void ofi_rbmap_init(struct ofi_rbmap *map,
-		int (*compare)(struct ofi_rbmap *map, void *key, void *data));
+		    int (*compare)(struct ofi_rbmap *map, void *key,
+				   void *data));
 void ofi_rbmap_cleanup(struct ofi_rbmap *map);
 
 struct ofi_rbnode *ofi_rbmap_get_root(struct ofi_rbmap *map);
 struct ofi_rbnode *ofi_rbmap_find(struct ofi_rbmap *map, void *key);
 struct ofi_rbnode *ofi_rbmap_search(struct ofi_rbmap *map, void *key,
-		int (*compare)(struct ofi_rbmap *map, void *key, void *data));
+				    int (*compare)(struct ofi_rbmap *map,
+						   void *key, void *data));
 int ofi_rbmap_insert(struct ofi_rbmap *map, void *key, void *data,
-		struct ofi_rbnode **node);
+		     struct ofi_rbnode **node);
 void ofi_rbmap_delete(struct ofi_rbmap *map, struct ofi_rbnode *node);
 int ofi_rbmap_find_delete(struct ofi_rbmap *map, void *key);
 int ofi_rbmap_empty(struct ofi_rbmap *map);
-
 
 #endif /* OFI_TREE_H_ */

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -36,7 +36,7 @@
 #define _OFI_UTIL_H_
 
 #if HAVE_CONFIG_H
-#  include <config.h>
+#include <config.h>
 #endif /* HAVE_CONFIG_H */
 
 #include <pthread.h>
@@ -81,60 +81,63 @@ extern "C" {
  *        if it is an error.
  * AUX: CQ entries are stored in the auxiliary queue
  */
-#define UTIL_FLAG_ERROR		(1ULL << 60)
-#define UTIL_FLAG_AUX		(1ULL << 61)
+#define UTIL_FLAG_ERROR (1ULL << 60)
+#define UTIL_FLAG_AUX (1ULL << 61)
 
 /* Indicates that an EP has been bound to a counter */
-#define OFI_CNTR_ENABLED	(1ULL << 61)
+#define OFI_CNTR_ENABLED (1ULL << 61)
 
 /* Memory registration should not be cached */
-#define OFI_MR_NOCACHE		BIT_ULL(60)
+#define OFI_MR_NOCACHE BIT_ULL(60)
 
-#define OFI_INFO_FIELD(provider, prov_attr, user_attr, prov_str, user_str, type) \
-	do {									\
-		FI_INFO(provider, FI_LOG_CORE, prov_str ": %s\n",		\
-				fi_tostr(&prov_attr, type));			\
-		FI_INFO(provider, FI_LOG_CORE, user_str ": %s\n",		\
-				fi_tostr(&user_attr, type));			\
+#define OFI_INFO_FIELD(provider, prov_attr, user_attr, prov_str, user_str, \
+		       type)                                               \
+	do {                                                               \
+		FI_INFO(provider, FI_LOG_CORE, prov_str ": %s\n",          \
+			fi_tostr(&prov_attr, type));                       \
+		FI_INFO(provider, FI_LOG_CORE, user_str ": %s\n",          \
+			fi_tostr(&user_attr, type));                       \
 	} while (0)
 
-#define OFI_INFO_STR(provider, prov_attr, user_attr, prov_str, user_str)	\
-	do {									\
-		FI_INFO(provider, FI_LOG_CORE, prov_str ": %s\n", prov_attr);	\
-		FI_INFO(provider, FI_LOG_CORE, user_str ": %s\n", user_attr);	\
+#define OFI_INFO_STR(provider, prov_attr, user_attr, prov_str, user_str)      \
+	do {                                                                  \
+		FI_INFO(provider, FI_LOG_CORE, prov_str ": %s\n", prov_attr); \
+		FI_INFO(provider, FI_LOG_CORE, user_str ": %s\n", user_attr); \
 	} while (0)
 
-#define OFI_INFO_CHECK(provider, prov, user, field, type)		\
-	OFI_INFO_FIELD(provider, prov->field, user->field, "Supported",	\
-		      "Requested", type)
+#define OFI_INFO_CHECK(provider, prov, user, field, type)               \
+	OFI_INFO_FIELD(provider, prov->field, user->field, "Supported", \
+		       "Requested", type)
 
-#define OFI_INFO_CHECK_SIZE(provider, prov, user, field)			\
-	do {									\
-		FI_INFO(provider, FI_LOG_CORE, "Supported: %zd\n", prov->field);\
-		FI_INFO(provider, FI_LOG_CORE, "Requested: %zd\n", user->field);\
+#define OFI_INFO_CHECK_SIZE(provider, prov, user, field)           \
+	do {                                                       \
+		FI_INFO(provider, FI_LOG_CORE, "Supported: %zd\n", \
+			prov->field);                              \
+		FI_INFO(provider, FI_LOG_CORE, "Requested: %zd\n", \
+			user->field);                              \
 	} while (0)
 
-#define OFI_INFO_CHECK_U64(provider, prov, user, field)			\
-	do {								\
-		FI_INFO(provider, FI_LOG_CORE,				\
-			"Supported: %" PRIu64 "\n", prov->field);	\
-		FI_INFO(provider, FI_LOG_CORE,				\
-			"Requested: %" PRIu64 "\n", user->field);	\
+#define OFI_INFO_CHECK_U64(provider, prov, user, field)                    \
+	do {                                                               \
+		FI_INFO(provider, FI_LOG_CORE, "Supported: %" PRIu64 "\n", \
+			prov->field);                                      \
+		FI_INFO(provider, FI_LOG_CORE, "Requested: %" PRIu64 "\n", \
+			user->field);                                      \
 	} while (0)
 
-#define OFI_INFO_MODE(provider, prov_mode, user_mode)				\
-	OFI_INFO_FIELD(provider, prov_mode, user_mode, "Expected", "Given",	\
-		      FI_TYPE_MODE)
+#define OFI_INFO_MODE(provider, prov_mode, user_mode)                       \
+	OFI_INFO_FIELD(provider, prov_mode, user_mode, "Expected", "Given", \
+		       FI_TYPE_MODE)
 
-#define OFI_INFO_MR_MODE(provider, prov_mode, user_mode)			\
-	OFI_INFO_FIELD(provider, prov_mode, user_mode, "Expected", "Given",	\
-		      FI_TYPE_MR_MODE)
+#define OFI_INFO_MR_MODE(provider, prov_mode, user_mode)                    \
+	OFI_INFO_FIELD(provider, prov_mode, user_mode, "Expected", "Given", \
+		       FI_TYPE_MR_MODE)
 
-#define OFI_INFO_NAME(provider, prov, user)				\
+#define OFI_INFO_NAME(provider, prov, user) \
 	OFI_INFO_STR(provider, prov->name, user->name, "Supported", "Requested")
 
-#define ofi_after_eq(a,b)	((long)((a) - (b)) >= 0)
-#define ofi_before(a,b)		((long)((a) - (b)) < 0)
+#define ofi_after_eq(a, b) ((long)((a) - (b)) >= 0)
+#define ofi_before(a, b) ((long)((a) - (b)) < 0)
 
 enum {
 	UTIL_TX_SHARED_CTX = 1 << 0,
@@ -152,36 +155,34 @@ struct ofi_common_locks {
 typedef int (*ofi_map_info_t)(uint32_t version, const struct fi_info *src_info,
 			      const struct fi_info *base_info,
 			      struct fi_info *dest_info);
-typedef void (*ofi_alter_info_t)(uint32_t version,
-				 const struct fi_info *hints,
+typedef void (*ofi_alter_info_t)(uint32_t version, const struct fi_info *hints,
 				 const struct fi_info *base_info,
 				 struct fi_info *dest_info);
 
 struct util_prov {
-	const struct fi_provider	*prov;
-	const struct fi_info		*info;
-	ofi_alter_info_t		alter_defaults;
-	const int			flags;
+	const struct fi_provider *prov;
+	const struct fi_info *info;
+	ofi_alter_info_t alter_defaults;
+	const int flags;
 };
-
 
 /*
  * Fabric
  */
 struct util_fabric_info {
-	const char 			*name;
-	const struct fi_provider 	*prov;
+	const char *name;
+	const struct fi_provider *prov;
 };
 
 struct util_fabric {
-	struct fid_fabric	fabric_fid;
-	struct dlist_entry	list_entry;
-	ofi_mutex_t		lock;
-	ofi_atomic32_t		ref;
-	const char		*name;
+	struct fid_fabric fabric_fid;
+	struct dlist_entry list_entry;
+	ofi_mutex_t lock;
+	ofi_atomic32_t ref;
+	const char *name;
 	const struct fi_provider *prov;
 
-	struct dlist_entry	domain_list;
+	struct dlist_entry domain_list;
 };
 
 int ofi_fabric_init(const struct fi_provider *prov,
@@ -195,24 +196,24 @@ int ofi_trywait(struct fid_fabric *fabric, struct fid **fids, int count);
  * Domain
  */
 struct util_domain {
-	struct fid_domain	domain_fid;
-	struct dlist_entry	list_entry;
-	struct util_fabric	*fabric;
-	struct util_eq		*eq;
+	struct fid_domain domain_fid;
+	struct dlist_entry list_entry;
+	struct util_fabric *fabric;
+	struct util_eq *eq;
 
-	struct ofi_genlock	lock;
-	ofi_atomic32_t		ref;
+	struct ofi_genlock lock;
+	ofi_atomic32_t ref;
 	const struct fi_provider *prov;
 
-	char			*name;
-	uint64_t		info_domain_caps;
-	uint64_t		info_domain_mode;
-	int			mr_mode;
-	uint32_t		addr_format;
-	enum fi_av_type		av_type;
-	struct ofi_mr_map	mr_map;
-	enum fi_threading	threading;
-	enum fi_progress	data_progress;
+	char *name;
+	uint64_t info_domain_caps;
+	uint64_t info_domain_mode;
+	int mr_mode;
+	uint32_t addr_format;
+	enum fi_av_type av_type;
+	struct ofi_mr_map mr_map;
+	enum fi_threading threading;
+	enum fi_progress data_progress;
 };
 
 int ofi_domain_init(struct fid_fabric *fabric_fid, const struct fi_info *info,
@@ -244,12 +245,12 @@ static inline uint64_t ofi_rx_mr_reg_flags(uint32_t op, uint16_t atomic_op)
  */
 
 struct util_pep {
-	struct fid_pep		pep_fid;
-	struct util_fabric 	*fabric;
-	struct util_eq 		*eq;
+	struct fid_pep pep_fid;
+	struct util_fabric *fabric;
+	struct util_eq *eq;
 };
 
-int ofi_pep_init(struct fid_fabric *fabric,  struct fi_info *info,
+int ofi_pep_init(struct fid_fabric *fabric, struct fi_info *info,
 		 struct util_pep *pep, void *context);
 int ofi_pep_bind_eq(struct util_pep *pep, struct util_eq *eq, uint64_t flags);
 int ofi_pep_close(struct util_pep *pep);
@@ -264,64 +265,66 @@ typedef void (*ofi_ep_progress_func)(struct util_ep *util_ep);
 typedef void (*ofi_cntr_inc_func)(struct util_cntr *util_cntr);
 
 struct util_ep {
-	struct fid_ep		ep_fid;
-	struct util_domain	*domain;
+	struct fid_ep ep_fid;
+	struct util_domain *domain;
 
-	struct util_av		*av;
-	struct dlist_entry	av_entry;
-	struct util_eq		*eq;
+	struct util_av *av;
+	struct dlist_entry av_entry;
+	struct util_eq *eq;
 	/* CQ entries */
-	struct util_cq		*rx_cq;
-	uint64_t		rx_op_flags;
-	struct util_cq		*tx_cq;
-	uint64_t		tx_op_flags;
-	uint64_t		inject_op_flags;
+	struct util_cq *rx_cq;
+	uint64_t rx_op_flags;
+	struct util_cq *tx_cq;
+	uint64_t tx_op_flags;
+	uint64_t inject_op_flags;
 
 	/* flags to be ORed in to flags for *msg API calls
 	 * to properly handle FI_SELECTIVE_COMPLETION bind */
-	uint64_t		tx_msg_flags;
-	uint64_t		rx_msg_flags;
+	uint64_t tx_msg_flags;
+	uint64_t rx_msg_flags;
 
 	/* CNTR entries */
-	struct util_cntr	*tx_cntr;     /* transmit/send */
-	struct util_cntr	*rx_cntr;     /* receive       */
-	struct util_cntr	*rd_cntr;     /* read          */
-	struct util_cntr	*wr_cntr;     /* write         */
-	struct util_cntr	*rem_rd_cntr; /* remote read   */
-	struct util_cntr	*rem_wr_cntr; /* remote write  */
+	struct util_cntr *tx_cntr; /* transmit/send */
+	struct util_cntr *rx_cntr; /* receive       */
+	struct util_cntr *rd_cntr; /* read          */
+	struct util_cntr *wr_cntr; /* write         */
+	struct util_cntr *rem_rd_cntr; /* remote read   */
+	struct util_cntr *rem_wr_cntr; /* remote write  */
 
-	ofi_cntr_inc_func	tx_cntr_inc;
-	ofi_cntr_inc_func	rx_cntr_inc;
-	ofi_cntr_inc_func	rd_cntr_inc;
-	ofi_cntr_inc_func	wr_cntr_inc;
-	ofi_cntr_inc_func	rem_rd_cntr_inc;
-	ofi_cntr_inc_func	rem_wr_cntr_inc;
+	ofi_cntr_inc_func tx_cntr_inc;
+	ofi_cntr_inc_func rx_cntr_inc;
+	ofi_cntr_inc_func rd_cntr_inc;
+	ofi_cntr_inc_func wr_cntr_inc;
+	ofi_cntr_inc_func rem_rd_cntr_inc;
+	ofi_cntr_inc_func rem_wr_cntr_inc;
 
-	enum fi_ep_type		type;
-	uint64_t		caps;
-	uint64_t		flags;
-	ofi_ep_progress_func	progress;
-	ofi_mutex_t		lock;
-	ofi_mutex_lock_t	lock_acquire;
-	ofi_mutex_unlock_t	lock_release;
+	enum fi_ep_type type;
+	uint64_t caps;
+	uint64_t flags;
+	ofi_ep_progress_func progress;
+	ofi_mutex_t lock;
+	ofi_mutex_lock_t lock_acquire;
+	ofi_mutex_unlock_t lock_release;
 
-	struct ofi_bitmask	*coll_cid_mask;
-	struct slist		coll_ready_queue;
+	struct ofi_bitmask *coll_cid_mask;
+	struct slist coll_ready_queue;
 };
 
 int ofi_ep_bind_av(struct util_ep *util_ep, struct util_av *av);
 int ofi_ep_bind_eq(struct util_ep *ep, struct util_eq *eq);
 int ofi_ep_bind_cq(struct util_ep *ep, struct util_cq *cq, uint64_t flags);
-int ofi_ep_bind_cntr(struct util_ep *ep, struct util_cntr *cntr, uint64_t flags);
+int ofi_ep_bind_cntr(struct util_ep *ep, struct util_cntr *cntr,
+		     uint64_t flags);
 int ofi_ep_bind(struct util_ep *util_ep, struct fid *fid, uint64_t flags);
-int ofi_endpoint_init(struct fid_domain *domain, const struct util_prov *util_prov,
-		      struct fi_info *info, struct util_ep *ep, void *context,
+int ofi_endpoint_init(struct fid_domain *domain,
+		      const struct util_prov *util_prov, struct fi_info *info,
+		      struct util_ep *ep, void *context,
 		      ofi_ep_progress_func progress);
 
 int ofi_endpoint_close(struct util_ep *util_ep);
 
-static inline int
-ofi_ep_fid_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
+static inline int ofi_ep_fid_bind(struct fid *ep_fid, struct fid *bfid,
+				  uint64_t flags)
 {
 	return ofi_ep_bind(container_of(ep_fid, struct util_ep, ep_fid.fid),
 			   bfid, flags);
@@ -340,7 +343,7 @@ static inline void ofi_ep_lock_release(struct util_ep *ep)
 static inline bool ofi_ep_lock_held(struct util_ep *ep)
 {
 	return (ep->lock_acquire == ofi_mutex_lock_noop) ||
-		ofi_mutex_held(&ep->lock);
+	       ofi_mutex_held(&ep->lock);
 }
 
 static inline void ofi_ep_tx_cntr_inc(struct util_ep *ep)
@@ -412,18 +415,18 @@ typedef void (*fi_wait_signal_func)(struct util_wait *wait);
 typedef int (*fi_wait_try_func)(struct util_wait *wait);
 
 struct util_wait {
-	struct fid_wait		wait_fid;
-	struct util_fabric	*fabric;
-	struct util_poll	*pollset;
-	ofi_atomic32_t		ref;
+	struct fid_wait wait_fid;
+	struct util_fabric *fabric;
+	struct util_poll *pollset;
+	ofi_atomic32_t ref;
 	const struct fi_provider *prov;
 
-	enum fi_wait_obj	wait_obj;
-	fi_wait_signal_func	signal;
-	fi_wait_try_func	wait_try;
+	enum fi_wait_obj wait_obj;
+	fi_wait_signal_func signal;
+	fi_wait_try_func wait_try;
 
-	struct dlist_entry	fid_list;
-	ofi_mutex_t		lock;
+	struct dlist_entry fid_list;
+	ofi_mutex_t lock;
 };
 
 int ofi_wait_init(struct util_fabric *fabric, struct fi_wait_attr *attr,
@@ -431,39 +434,39 @@ int ofi_wait_init(struct util_fabric *fabric, struct fi_wait_attr *attr,
 int fi_wait_cleanup(struct util_wait *wait);
 
 struct util_wait_fd {
-	struct util_wait	util_wait;
-	struct fd_signal	signal;
-	struct dlist_entry	fd_list;
+	struct util_wait util_wait;
+	struct fd_signal signal;
+	struct dlist_entry fd_list;
 
 	union {
-		ofi_epoll_t		epoll_fd;
-		struct ofi_pollfds	*pollfds;
+		ofi_epoll_t epoll_fd;
+		struct ofi_pollfds *pollfds;
 	};
-	uint64_t		change_index;
+	uint64_t change_index;
 };
 
 typedef int (*ofi_wait_try_func)(void *arg);
 
 struct ofi_wait_fd_entry {
-	struct dlist_entry	entry;
-	int 			fd;
-	ofi_wait_try_func	wait_try;
-	void			*arg;
-	ofi_atomic32_t		ref;
+	struct dlist_entry entry;
+	int fd;
+	ofi_wait_try_func wait_try;
+	void *arg;
+	ofi_atomic32_t ref;
 };
 
 struct ofi_wait_fid_entry {
-	struct dlist_entry	entry;
-	ofi_wait_try_func	wait_try;
-	fid_t			fid;
-	enum fi_wait_obj	wait_obj;
-	uint32_t		events;
-	ofi_atomic32_t		ref;
-	struct fi_wait_pollfd	pollfds;
+	struct dlist_entry entry;
+	ofi_wait_try_func wait_try;
+	fid_t fid;
+	enum fi_wait_obj wait_obj;
+	uint32_t events;
+	ofi_atomic32_t ref;
+	struct fi_wait_pollfd pollfds;
 };
 
 int ofi_wait_fd_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
-		struct fid_wait **waitset);
+		     struct fid_wait **waitset);
 int ofi_wait_add_fd(struct util_wait *wait, int fd, uint32_t events,
 		    ofi_wait_try_func wait_try, void *arg, void *context);
 int ofi_wait_del_fd(struct util_wait *wait, int fd);
@@ -472,11 +475,10 @@ int ofi_wait_add_fid(struct util_wait *wat, fid_t fid, uint32_t events,
 		     ofi_wait_try_func wait_try);
 int ofi_wait_del_fid(struct util_wait *wait, fid_t fid);
 
-
 struct util_wait_yield {
-	struct util_wait	util_wait;
-	int			signal;
-	ofi_mutex_t		signal_lock;
+	struct util_wait util_wait;
+	int signal;
+	ofi_mutex_t signal_lock;
 };
 
 int ofi_wait_yield_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
@@ -495,10 +497,10 @@ int ofi_wait_yield_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
 typedef void (*fi_cq_read_func)(void **dst, void *src);
 
 struct util_cq_aux_entry {
-	struct fi_cq_tagged_entry	*cq_slot;
-	struct fi_cq_err_entry		comp;
-	fi_addr_t			src;
-	struct slist_entry		list_entry;
+	struct fi_cq_tagged_entry *cq_slot;
+	struct fi_cq_err_entry comp;
+	fi_addr_t src;
+	struct slist_entry list_entry;
 };
 
 OFI_DECLARE_CIRQUE(struct fi_cq_tagged_entry, util_comp_cirq);
@@ -506,31 +508,31 @@ OFI_DECLARE_CIRQUE(struct fi_cq_tagged_entry, util_comp_cirq);
 typedef void (*ofi_cq_progress_func)(struct util_cq *cq);
 
 struct util_cq {
-	struct fid_cq		cq_fid;
-	struct util_domain	*domain;
-	struct util_wait	*wait;
-	ofi_atomic32_t		ref;
-	struct dlist_entry	ep_list;
-	ofi_mutex_t		ep_list_lock;
-	struct ofi_genlock	cq_lock;
-	uint64_t		flags;
+	struct fid_cq cq_fid;
+	struct util_domain *domain;
+	struct util_wait *wait;
+	ofi_atomic32_t ref;
+	struct dlist_entry ep_list;
+	ofi_mutex_t ep_list_lock;
+	struct ofi_genlock cq_lock;
+	uint64_t flags;
 
-	int			internal_wait;
-	ofi_atomic32_t		wakeup;
-	ofi_cq_progress_func	progress;
+	int internal_wait;
+	ofi_atomic32_t wakeup;
+	ofi_cq_progress_func progress;
 
-	struct fid_peer_cq	*peer_cq;
+	struct fid_peer_cq *peer_cq;
 
 	/* Only valid if not FI_PEER */
-	struct util_comp_cirq	*cirq;
-	fi_addr_t		*src;
-	struct slist		aux_queue;
-	fi_cq_read_func		read_entry;
+	struct util_comp_cirq *cirq;
+	fi_addr_t *src;
+	struct slist aux_queue;
+	fi_cq_read_func read_entry;
 };
 
 int ofi_cq_init(const struct fi_provider *prov, struct fid_domain *domain,
-		 struct fi_cq_attr *attr, struct util_cq *cq,
-		 ofi_cq_progress_func progress, void *context);
+		struct fi_cq_attr *attr, struct util_cq *cq,
+		ofi_cq_progress_func progress, void *context);
 int ofi_check_bind_cq_flags(struct util_ep *ep, struct util_cq *cq,
 			    uint64_t flags);
 void ofi_cq_progress(struct util_cq *cq);
@@ -539,13 +541,13 @@ int ofi_cq_control(struct fid *fid, int command, void *arg);
 
 ssize_t ofi_cq_read(struct fid_cq *cq_fid, void *buf, size_t count);
 ssize_t ofi_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t count,
-		fi_addr_t *src_addr);
+			fi_addr_t *src_addr);
 ssize_t ofi_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *buf,
-		uint64_t flags);
+		       uint64_t flags);
 ssize_t ofi_cq_sread(struct fid_cq *cq_fid, void *buf, size_t count,
-		const void *cond, int timeout);
+		     const void *cond, int timeout);
 ssize_t ofi_cq_sreadfrom(struct fid_cq *cq_fid, void *buf, size_t count,
-		fi_addr_t *src_addr, const void *cond, int timeout);
+			 fi_addr_t *src_addr, const void *cond, int timeout);
 int ofi_cq_signal(struct fid_cq *cq_fid);
 const char *ofi_cq_strerror(struct fid_cq *cq, int prov_errno,
 			    const void *err_data, char *buf, size_t len);
@@ -554,10 +556,9 @@ int ofi_cq_write_overflow(struct util_cq *cq, void *context, uint64_t flags,
 			  size_t len, void *buf, uint64_t data, uint64_t tag,
 			  fi_addr_t src);
 
-
-static inline void
-ofi_cq_write_entry(struct util_cq *cq, void *context, uint64_t flags,
-		   size_t len, void *buf, uint64_t data, uint64_t tag)
+static inline void ofi_cq_write_entry(struct util_cq *cq, void *context,
+				      uint64_t flags, size_t len, void *buf,
+				      uint64_t data, uint64_t tag)
 {
 	struct fi_cq_tagged_entry *comp = ofi_cirque_next(cq->cirq);
 	comp->op_context = context;
@@ -569,18 +570,18 @@ ofi_cq_write_entry(struct util_cq *cq, void *context, uint64_t flags,
 	ofi_cirque_commit(cq->cirq);
 }
 
-static inline void
-ofi_cq_write_src_entry(struct util_cq *cq, void *context, uint64_t flags,
-		       size_t len, void *buf, uint64_t data, uint64_t tag,
-		       fi_addr_t src)
+static inline void ofi_cq_write_src_entry(struct util_cq *cq, void *context,
+					  uint64_t flags, size_t len, void *buf,
+					  uint64_t data, uint64_t tag,
+					  fi_addr_t src)
 {
 	cq->src[ofi_cirque_windex(cq->cirq)] = src;
 	ofi_cq_write_entry(cq, context, flags, len, buf, data, tag);
 }
 
-static inline int
-ofi_cq_write(struct util_cq *cq, void *context, uint64_t flags, size_t len,
-	     void *buf, uint64_t data, uint64_t tag)
+static inline int ofi_cq_write(struct util_cq *cq, void *context,
+			       uint64_t flags, size_t len, void *buf,
+			       uint64_t data, uint64_t tag)
 {
 	int ret;
 
@@ -589,27 +590,27 @@ ofi_cq_write(struct util_cq *cq, void *context, uint64_t flags, size_t len,
 		ofi_cq_write_entry(cq, context, flags, len, buf, data, tag);
 		ret = 0;
 	} else {
-		ret = ofi_cq_write_overflow(cq, context, flags, len,
-					    buf, data, tag, FI_ADDR_NOTAVAIL);
+		ret = ofi_cq_write_overflow(cq, context, flags, len, buf, data,
+					    tag, FI_ADDR_NOTAVAIL);
 	}
 	ofi_genlock_unlock(&cq->cq_lock);
 	return ret;
 }
 
-static inline int
-ofi_cq_write_src(struct util_cq *cq, void *context, uint64_t flags, size_t len,
-		 void *buf, uint64_t data, uint64_t tag, fi_addr_t src)
+static inline int ofi_cq_write_src(struct util_cq *cq, void *context,
+				   uint64_t flags, size_t len, void *buf,
+				   uint64_t data, uint64_t tag, fi_addr_t src)
 {
 	int ret;
 
 	ofi_genlock_lock(&cq->cq_lock);
 	if (ofi_cirque_freecnt(cq->cirq) > 1) {
-		ofi_cq_write_src_entry(cq, context, flags, len, buf, data,
-				       tag, src);
+		ofi_cq_write_src_entry(cq, context, flags, len, buf, data, tag,
+				       src);
 		ret = 0;
 	} else {
-		ret = ofi_cq_write_overflow(cq, context, flags, len,
-					    buf, data, tag, src);
+		ret = ofi_cq_write_overflow(cq, context, flags, len, buf, data,
+					    tag, src);
 	}
 	ofi_genlock_unlock(&cq->cq_lock);
 	return ret;
@@ -622,16 +623,17 @@ int ofi_cq_write_error_trunc(struct util_cq *cq, void *context, uint64_t flags,
 			     size_t len, void *buf, uint64_t data, uint64_t tag,
 			     size_t olen);
 
-static inline int
-ofi_peer_cq_write(struct util_cq *cq, void *context, uint64_t flags, size_t len,
-		  void *buf, uint64_t data, uint64_t tag, uint64_t src)
+static inline int ofi_peer_cq_write(struct util_cq *cq, void *context,
+				    uint64_t flags, size_t len, void *buf,
+				    uint64_t data, uint64_t tag, uint64_t src)
 {
 	return cq->peer_cq->owner_ops->write(cq->peer_cq, context, flags, len,
 					     buf, data, tag, src);
 }
 
-static inline int ofi_peer_cq_write_error(struct util_cq *cq,
-		const struct fi_cq_err_entry *err_entry)
+static inline int
+ofi_peer_cq_write_error(struct util_cq *cq,
+			const struct fi_cq_err_entry *err_entry)
 {
 	return cq->peer_cq->owner_ops->writeerr(cq->peer_cq, err_entry);
 }
@@ -669,22 +671,22 @@ static inline uint64_t ofi_tx_cq_flags(uint32_t op)
 typedef void (*ofi_cntr_progress_func)(struct util_cntr *cntr);
 
 struct util_cntr {
-	struct fid_cntr		cntr_fid;
-	struct util_domain	*domain;
-	struct util_wait	*wait;
-	ofi_atomic32_t		ref;
+	struct fid_cntr cntr_fid;
+	struct util_domain *domain;
+	struct util_wait *wait;
+	ofi_atomic32_t ref;
 
-	ofi_atomic64_t		cnt;
-	ofi_atomic64_t		err;
+	ofi_atomic64_t cnt;
+	ofi_atomic64_t err;
 
-	uint64_t		checkpoint_cnt;
-	uint64_t		checkpoint_err;
+	uint64_t checkpoint_cnt;
+	uint64_t checkpoint_err;
 
-	struct dlist_entry	ep_list;
-	ofi_mutex_t		ep_list_lock;
+	struct dlist_entry ep_list;
+	ofi_mutex_t ep_list_lock;
 
-	int			internal_wait;
-	ofi_cntr_progress_func	progress;
+	int internal_wait;
+	ofi_cntr_progress_func progress;
 };
 
 #define OFI_TIMEOUT_QUANTUM_MS 50
@@ -720,75 +722,75 @@ struct util_av_set;
 struct util_peer_addr;
 
 struct util_coll_mc {
-	struct fid_mc		mc_fid;
-	struct util_av_set	*av_set;
-	uint64_t		local_rank;
-	uint16_t		group_id;
-	uint16_t		seq;
-	ofi_atomic32_t		ref;
+	struct fid_mc mc_fid;
+	struct util_av_set *av_set;
+	uint64_t local_rank;
+	uint16_t group_id;
+	uint16_t seq;
+	ofi_atomic32_t ref;
 };
 
 struct util_av_set {
-	struct fid_av_set	av_set_fid;
-	struct util_av		*av;
-	fi_addr_t		*fi_addr_array;
-	size_t			fi_addr_count;
-	uint64_t		flags;
-	struct util_coll_mc     coll_mc;
-	ofi_atomic32_t		ref;
-	ofi_mutex_t		lock;
-	size_t			max_array_size;
+	struct fid_av_set av_set_fid;
+	struct util_av *av;
+	fi_addr_t *fi_addr_array;
+	size_t fi_addr_count;
+	uint64_t flags;
+	struct util_coll_mc coll_mc;
+	ofi_atomic32_t ref;
+	ofi_mutex_t lock;
+	size_t max_array_size;
 };
 
 struct util_av_entry {
-	ofi_atomic32_t	use_cnt;
-	UT_hash_handle	hh;
+	ofi_atomic32_t use_cnt;
+	UT_hash_handle hh;
 	/*
 	 * data includes 'addr' and any other additional fields
 	 * associated with av_entry. 'addr' must be the first
 	 * field in 'data' and addr length should be a multiple
 	 * of 8 bytes to ensure alignment of additional fields
 	 */
-	char		data[];
+	char data[];
 };
 
 struct util_av {
-	struct fid_av		av_fid;
-	struct util_domain	*domain;
-	struct util_eq		*eq;
-	ofi_atomic32_t		ref;
-	ofi_mutex_t		lock;
+	struct fid_av av_fid;
+	struct util_domain *domain;
+	struct util_eq *eq;
+	ofi_atomic32_t ref;
+	ofi_mutex_t lock;
 	const struct fi_provider *prov;
 
-	struct util_av_entry	*hash;
-	struct ofi_bufpool	*av_entry_pool;
+	struct util_av_entry *hash;
+	struct ofi_bufpool *av_entry_pool;
 
-	struct util_av_set	*av_set;
-	void			*context;
-	uint64_t		flags;
-	size_t			addrlen;
+	struct util_av_set *av_set;
+	void *context;
+	uint64_t flags;
+	size_t addrlen;
 	/*
 	 * context_offset is addrlen + offset (required for alignment),
 	 * if addrlen is a multiple of 8 bytes offset will be 0.
 	 */
-	size_t			context_offset;
-	struct dlist_entry	ep_list;
-	ofi_mutex_t		ep_list_lock;
-	void			(*remove_handler)(struct util_ep *util_ep,
-						  struct util_peer_addr *peer);
+	size_t context_offset;
+	struct dlist_entry ep_list;
+	ofi_mutex_t ep_list_lock;
+	void (*remove_handler)(struct util_ep *util_ep,
+			       struct util_peer_addr *peer);
 };
 
 #define OFI_AV_DYN_ADDRLEN (1 << 0)
 
 struct util_av_attr {
 	/* Must be a multiple of 8 bytes */
-	size_t	addrlen;
+	size_t addrlen;
 	/*
 	 * Specify the length of additional fields to be added
 	 * to av_entry other than struct util_av_entry and addr
 	 */
-	size_t  context_len;
-	int	flags;
+	size_t context_len;
+	int flags;
 };
 
 /* For AVs supporting RDM over MSG EPs. */
@@ -843,26 +845,27 @@ void rxm_ref_peer(struct util_peer_addr *peer);
 void *rxm_av_alloc_conn(struct rxm_av *av);
 void rxm_av_free_conn(struct rxm_av *av, void *conn_ctx);
 
-
 typedef int (*ofi_av_apply_func)(struct util_av *av, void *addr,
 				 fi_addr_t fi_addr, void *arg);
 
-int ofi_av_init(struct util_domain *domain,
-	       const struct fi_av_attr *attr, const struct util_av_attr *util_attr,
-	       struct util_av *av, void *context);
-int ofi_av_init_lightweight(struct util_domain *domain, const struct fi_av_attr *attr,
-			    struct util_av *av, void *context);
+int ofi_av_init(struct util_domain *domain, const struct fi_av_attr *attr,
+		const struct util_av_attr *util_attr, struct util_av *av,
+		void *context);
+int ofi_av_init_lightweight(struct util_domain *domain,
+			    const struct fi_av_attr *attr, struct util_av *av,
+			    void *context);
 int ofi_av_close(struct util_av *av);
 int ofi_av_close_lightweight(struct util_av *av);
 
 size_t ofi_av_size(struct util_av *av);
-int ofi_av_insert_addr(struct util_av *av, const void *addr, fi_addr_t *fi_addr);
+int ofi_av_insert_addr(struct util_av *av, const void *addr,
+		       fi_addr_t *fi_addr);
 int ofi_av_remove_addr(struct util_av *av, fi_addr_t fi_addr);
 fi_addr_t ofi_av_lookup_fi_addr_unsafe(struct util_av *av, const void *addr);
 fi_addr_t ofi_av_lookup_fi_addr(struct util_av *av, const void *addr);
 int ofi_av_bind(struct fid *av_fid, struct fid *eq_fid, uint64_t flags);
-void ofi_av_write_event(struct util_av *av, uint64_t data,
-			int err, void *context);
+void ofi_av_write_event(struct util_av *av, uint64_t data, int err,
+			void *context);
 
 int ofi_ip_av_create(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 		     struct fid_av **av, void *context);
@@ -873,12 +876,10 @@ void *ofi_av_addr_context(struct util_av *av, fi_addr_t fi_addr);
 
 fi_addr_t ofi_ip_av_get_fi_addr(struct util_av *av, const void *addr);
 
-int ofi_get_addr(uint32_t *addr_format, uint64_t flags,
-		 const char *node, const char *service,
-		 void **addr, size_t *addrlen);
-int ofi_get_src_addr(uint32_t addr_format,
-		     const void *dest_addr, size_t dest_addrlen,
-		     void **src_addr, size_t *src_addrlen);
+int ofi_get_addr(uint32_t *addr_format, uint64_t flags, const char *node,
+		 const char *service, void **addr, size_t *addrlen);
+int ofi_get_src_addr(uint32_t addr_format, const void *dest_addr,
+		     size_t dest_addrlen, void **src_addr, size_t *src_addrlen);
 void ofi_getnodename(uint16_t sa_family, char *buf, int buflen);
 int ofi_av_get_index(struct util_av *av, const void *addr);
 
@@ -887,27 +888,27 @@ int ofi_ip_av_insertv(struct util_av *av, const void *addr, size_t addrlen,
 		      size_t count, fi_addr_t *fi_addr, uint64_t flags,
 		      void *context);
 /* Caller should free *addr */
-int ofi_ip_av_sym_getaddr(struct util_av *av, const char *node,
-			  size_t nodecnt, const char *service,
-			  size_t svccnt, void **addr, size_t *addrlen);
+int ofi_ip_av_sym_getaddr(struct util_av *av, const char *node, size_t nodecnt,
+			  const char *service, size_t svccnt, void **addr,
+			  size_t *addrlen);
 int ofi_ip_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 		     fi_addr_t *fi_addr, uint64_t flags, void *context);
-int ofi_ip_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr,
-		     size_t count, uint64_t flags);
-int ofi_ip_av_lookup(struct fid_av *av_fid, fi_addr_t fi_addr,
-		     void *addr, size_t *addrlen);
-const char *
-ofi_ip_av_straddr(struct fid_av *av, const void *addr, char *buf, size_t *len);
+int ofi_ip_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr, size_t count,
+		     uint64_t flags);
+int ofi_ip_av_lookup(struct fid_av *av_fid, fi_addr_t fi_addr, void *addr,
+		     size_t *addrlen);
+const char *ofi_ip_av_straddr(struct fid_av *av, const void *addr, char *buf,
+			      size_t *len);
 
 /*
  * Poll set
  */
 struct util_poll {
-	struct fid_poll		poll_fid;
-	struct util_domain	*domain;
-	struct dlist_entry	fid_list;
-	ofi_mutex_t		lock;
-	ofi_atomic32_t		ref;
+	struct fid_poll poll_fid;
+	struct util_domain *domain;
+	struct dlist_entry fid_list;
+	ofi_mutex_t lock;
+	ofi_atomic32_t ref;
 	const struct fi_provider *prov;
 };
 
@@ -920,30 +921,30 @@ int fi_poll_create(struct fid_domain *domain, struct fi_poll_attr *attr,
  * EQ
  */
 struct util_eq {
-	struct fid_eq		eq_fid;
-	struct util_fabric	*fabric;
-	struct util_wait	*wait;
-	ofi_mutex_t		lock;
-	ofi_atomic32_t		ref;
+	struct fid_eq eq_fid;
+	struct util_fabric *fabric;
+	struct util_wait *wait;
+	ofi_mutex_t lock;
+	ofi_atomic32_t ref;
 	const struct fi_provider *prov;
 
-	struct slist		list;
+	struct slist list;
 	/* This contains error data that are read by user and need to
 	 * be freed in subsequent fi_eq_readerr call against the EQ */
-	void			*saved_err_data;
-	int			internal_wait;
+	void *saved_err_data;
+	int internal_wait;
 };
 
 struct util_event {
-	struct slist_entry	entry;
-	ssize_t			size;
-	int			event;
-	int			err;
-	uint8_t			data[]; /* offset should be 8-byte aligned */
+	struct slist_entry entry;
+	ssize_t size;
+	int event;
+	int err;
+	uint8_t data[]; /* offset should be 8-byte aligned */
 };
 
 int ofi_eq_create(struct fid_fabric *fabric, struct fi_eq_attr *attr,
-		 struct fid_eq **eq_fid, void *context);
+		  struct fid_eq **eq_fid, void *context);
 int ofi_eq_init(struct fid_fabric *fabric_fid, struct fi_eq_attr *attr,
 		struct fid_eq *eq_fid, void *context);
 int ofi_eq_control(struct fid *fid, int command, void *arg);
@@ -952,14 +953,14 @@ void ofi_eq_remove_fid_events(struct util_eq *eq, fid_t fid);
 void ofi_eq_handle_err_entry(uint32_t api_version, uint64_t flags,
 			     struct fi_eq_err_entry *err_entry,
 			     struct fi_eq_err_entry *user_err_entry);
-ssize_t ofi_eq_read(struct fid_eq *eq_fid, uint32_t *event,
-		    void *buf, size_t len, uint64_t flags);
+ssize_t ofi_eq_read(struct fid_eq *eq_fid, uint32_t *event, void *buf,
+		    size_t len, uint64_t flags);
 ssize_t ofi_eq_sread(struct fid_eq *eq_fid, uint32_t *event, void *buf,
 		     size_t len, int timeout, uint64_t flags);
 ssize_t ofi_eq_readerr(struct fid_eq *eq_fid, struct fi_eq_err_entry *buf,
 		       uint64_t flags);
-ssize_t ofi_eq_write(struct fid_eq *eq_fid, uint32_t event,
-		     const void *buf, size_t len, uint64_t flags);
+ssize_t ofi_eq_write(struct fid_eq *eq_fid, uint32_t event, const void *buf,
+		     size_t len, uint64_t flags);
 const char *ofi_eq_strerror(struct fid_eq *eq_fid, int prov_errno,
 			    const void *err_data, char *buf, size_t len);
 
@@ -973,7 +974,7 @@ int ofi_check_fabric_attr(const struct fi_provider *prov,
 			  const struct fi_fabric_attr *prov_attr,
 			  const struct fi_fabric_attr *user_attr);
 int ofi_check_wait_attr(const struct fi_provider *prov,
-		        const struct fi_wait_attr *attr);
+			const struct fi_wait_attr *attr);
 int ofi_check_domain_attr(const struct fi_provider *prov, uint32_t api_version,
 			  const struct fi_domain_attr *prov_attr,
 			  const struct fi_info *user_info);
@@ -988,18 +989,17 @@ int ofi_check_rx_attr(const struct fi_provider *prov,
 int ofi_check_tx_attr(const struct fi_provider *prov,
 		      const struct fi_tx_attr *prov_attr,
 		      const struct fi_tx_attr *user_attr, uint64_t info_mode);
-int ofi_check_attr_subset(const struct fi_provider *prov,
-			uint64_t base_caps, uint64_t requested_caps);
-int ofi_prov_check_info(const struct util_prov *util_prov,
-			uint32_t api_version,
+int ofi_check_attr_subset(const struct fi_provider *prov, uint64_t base_caps,
+			  uint64_t requested_caps);
+int ofi_prov_check_info(const struct util_prov *util_prov, uint32_t api_version,
 			const struct fi_info *user_info);
 int ofi_prov_check_dup_info(const struct util_prov *util_prov,
 			    uint32_t api_version,
 			    const struct fi_info *user_info,
 			    struct fi_info **info);
-static inline uint64_t
-ofi_pick_core_flags(uint64_t all_util_flags, uint64_t all_core_flags,
-		    uint64_t use_core_flags)
+static inline uint64_t ofi_pick_core_flags(uint64_t all_util_flags,
+					   uint64_t all_core_flags,
+					   uint64_t use_core_flags)
 {
 	return (all_util_flags & ~use_core_flags) |
 	       (all_core_flags & use_core_flags);
@@ -1019,17 +1019,15 @@ int ofi_ip_getinfo(const struct util_prov *prov, uint32_t version,
 		   const char *node, const char *service, uint64_t flags,
 		   const struct fi_info *hints, struct fi_info **info);
 
-
 struct fid_list_entry {
-	struct dlist_entry	entry;
-	struct fid		*fid;
+	struct dlist_entry entry;
+	struct fid *fid;
 };
 
 int fid_list_insert(struct dlist_entry *fid_list, ofi_mutex_t *lock,
 		    struct fid *fid);
 void fid_list_remove(struct dlist_entry *fid_list, ofi_mutex_t *lock,
 		     struct fid *fid);
-
 
 void ofi_fabric_insert(struct util_fabric *fabric);
 void ofi_fabric_remove(struct util_fabric *fabric);
@@ -1038,7 +1036,7 @@ void ofi_fabric_remove(struct util_fabric *fabric);
  * Utility Providers
  */
 
-#define OFI_NAME_DELIM	';'
+#define OFI_NAME_DELIM ';'
 #define OFI_UTIL_PREFIX "ofi_"
 #define OFI_OFFLOAD_PREFIX "off_"
 
@@ -1049,15 +1047,15 @@ static inline int ofi_has_util_prefix(const char *str)
 
 static inline int ofi_has_offload_prefix(const char *str)
 {
-	return !strncasecmp(str, OFI_OFFLOAD_PREFIX, strlen(OFI_OFFLOAD_PREFIX));
+	return !strncasecmp(str, OFI_OFFLOAD_PREFIX,
+			    strlen(OFI_OFFLOAD_PREFIX));
 }
 
 int ofi_get_core_info(uint32_t version, const char *node, const char *service,
 		      uint64_t flags, const struct util_prov *util_prov,
 		      const struct fi_info *util_hints,
 		      const struct fi_info *base_attr,
-		      ofi_map_info_t info_to_core,
-		      struct fi_info **core_info);
+		      ofi_map_info_t info_to_core, struct fi_info **core_info);
 int ofix_getinfo(uint32_t version, const char *node, const char *service,
 		 uint64_t flags, const struct util_prov *util_prov,
 		 const struct fi_info *hints, ofi_map_info_t info_to_core,
@@ -1066,12 +1064,10 @@ int ofi_get_core_info_fabric(const struct fi_provider *prov,
 			     const struct fi_fabric_attr *util_attr,
 			     struct fi_info **core_info);
 
-
 char *ofi_strdup_append(const char *head, const char *tail);
 // char *ofi_strdup_head(const char *str);
 // char *ofi_strdup_tail(const char *str);
 int ofi_exclude_prov_name(char **prov_name, const char *util_prov_name);
-
 
 int ofi_shm_map(struct util_shm *shm, const char *name, size_t size,
 		int readonly, void **mapped);
@@ -1082,25 +1078,25 @@ int ofi_shm_unmap(struct util_shm *shm);
  * (osd/windows/pthread.h should be extended)
  */
 
-typedef int(*ofi_ns_service_cmp_func_t)(void *svc1, void *svc2);
-typedef int(*ofi_ns_is_service_wildcard_func_t)(void *svc);
+typedef int (*ofi_ns_service_cmp_func_t)(void *svc1, void *svc2);
+typedef int (*ofi_ns_is_service_wildcard_func_t)(void *svc);
 
 struct util_ns {
-	SOCKET		listen_sock;
-	pthread_t	thread;
-	RbtHandle	map;
+	SOCKET listen_sock;
+	pthread_t thread;
+	RbtHandle map;
 
-	char		*hostname;
-	int		port;
+	char *hostname;
+	int port;
 
-	size_t		name_len;
-	size_t		service_len;
+	size_t name_len;
+	size_t service_len;
 
-	int		run;
-	int		is_initialized;
-	ofi_atomic32_t	ref;
+	int run;
+	int is_initialized;
+	ofi_atomic32_t ref;
 
-	ofi_ns_service_cmp_func_t	service_cmp;
+	ofi_ns_service_cmp_func_t service_cmp;
 	ofi_ns_is_service_wildcard_func_t is_service_wildcard;
 };
 
@@ -1113,7 +1109,6 @@ int ofi_ns_del_local_name(struct util_ns *ns, void *service, void *name);
 void *ofi_ns_resolve_name(struct util_ns *ns, const char *server,
 			  void *service);
 
-
 /* Setup coordination for credit based flow control between core and util.
  * threshold - When number of available RQ credits > threshold, the send
  *     handler will be invoked
@@ -1125,38 +1120,35 @@ void *ofi_ns_resolve_name(struct util_ns *ns, const char *server,
 #define OFI_OPS_FLOW_CTRL "ofix_flow_ctrl_v1"
 
 struct ofi_ops_flow_ctrl {
-	size_t	size;
-	bool	(*available)(struct fid_ep *ep);
-	int	(*enable)(struct fid_ep *ep, uint64_t threshold);
-	void	(*add_credits)(struct fid_ep *ep, uint64_t credits);
-	void	(*set_send_handler)(struct fid_domain *domain,
-			ssize_t (*send_handler)(struct fid_ep *ep, uint64_t credits));
+	size_t size;
+	bool (*available)(struct fid_ep *ep);
+	int (*enable)(struct fid_ep *ep, uint64_t threshold);
+	void (*add_credits)(struct fid_ep *ep, uint64_t credits);
+	void (*set_send_handler)(struct fid_domain *domain,
+				 ssize_t (*send_handler)(struct fid_ep *ep,
+							 uint64_t credits));
 };
-
 
 /* Dynamic receive buffering support. */
 #define OFI_OPS_DYNAMIC_RBUF "ofix_dynamic_rbuf_v2"
 
 struct ofi_cq_rbuf_entry {
-	void			*op_context;
-	uint64_t		flags;
-	size_t			len;
-	void			*buf;
-	uint64_t		data;
-	uint64_t		tag;
-	void			*ep_context;
+	void *op_context;
+	uint64_t flags;
+	size_t len;
+	void *buf;
+	uint64_t data;
+	uint64_t tag;
+	void *ep_context;
 };
 
 struct ofi_ops_dynamic_rbuf {
-	size_t	size;
-	ssize_t	(*get_rbuf)(struct ofi_cq_rbuf_entry *entry, struct iovec *iov,
+	size_t size;
+	ssize_t (*get_rbuf)(struct ofi_cq_rbuf_entry *entry, struct iovec *iov,
 			    size_t *count);
 };
 
-enum {
-	OFI_OPT_TCP_FI_ADDR = -FI_PROV_SPECIFIC_TCP
-};
-
+enum { OFI_OPT_TCP_FI_ADDR = -FI_PROV_SPECIFIC_TCP };
 
 #ifdef __cplusplus
 }

--- a/include/osx/osd.h
+++ b/include/osx/osd.h
@@ -74,7 +74,8 @@
 extern "C" {
 #endif
 
-static inline int ofi_shm_remap(struct util_shm *shm, size_t newsize, void **mapped)
+static inline int ofi_shm_remap(struct util_shm *shm, size_t newsize,
+				void **mapped)
 {
 	return -1;
 }
@@ -99,35 +100,31 @@ static inline int ofi_hugepage_enabled(void)
 	return 0;
 }
 
-static inline ssize_t ofi_process_vm_readv(pid_t pid,
-			const struct iovec *local_iov,
-			unsigned long liovcnt,
-			const struct iovec *remote_iov,
-			unsigned long riovcnt,
-			unsigned long flags)
-{
-	return -FI_ENOSYS;
-}
-
-static inline size_t ofi_process_vm_writev(pid_t pid,
-			 const struct iovec *local_iov,
-			 unsigned long liovcnt,
-			 const struct iovec *remote_iov,
-			 unsigned long riovcnt,
-			 unsigned long flags)
-{
-	return -FI_ENOSYS;
-}
-
 static inline ssize_t
-ofi_recv_socket(SOCKET fd, void *buf, size_t count, int flags)
+ofi_process_vm_readv(pid_t pid, const struct iovec *local_iov,
+		     unsigned long liovcnt, const struct iovec *remote_iov,
+		     unsigned long riovcnt, unsigned long flags)
+{
+	return -FI_ENOSYS;
+}
+
+static inline size_t
+ofi_process_vm_writev(pid_t pid, const struct iovec *local_iov,
+		      unsigned long liovcnt, const struct iovec *remote_iov,
+		      unsigned long riovcnt, unsigned long flags)
+{
+	return -FI_ENOSYS;
+}
+
+static inline ssize_t ofi_recv_socket(SOCKET fd, void *buf, size_t count,
+				      int flags)
 {
 	size_t len = count > INT_MAX ? INT_MAX : count;
 	return recv(fd, buf, len, flags);
 }
 
-static inline ssize_t
-ofi_send_socket(SOCKET fd, const void *buf, size_t count, int flags)
+static inline ssize_t ofi_send_socket(SOCKET fd, const void *buf, size_t count,
+				      int flags)
 {
 	size_t len = count > INT_MAX ? INT_MAX : count;
 	return send(fd, buf, len, flags);
@@ -143,17 +140,18 @@ static inline ssize_t ofi_write_socket(SOCKET fd, const void *buf, size_t count)
 	return ofi_send_socket(fd, buf, count, 0);
 }
 
-static inline ssize_t
-ofi_recvfrom_socket(SOCKET fd, void *buf, size_t count, int flags,
-		    struct sockaddr *from, socklen_t *fromlen)
+static inline ssize_t ofi_recvfrom_socket(SOCKET fd, void *buf, size_t count,
+					  int flags, struct sockaddr *from,
+					  socklen_t *fromlen)
 {
 	size_t len = count > INT_MAX ? INT_MAX : count;
 	return recvfrom(fd, buf, len, flags, from, fromlen);
 }
 
-static inline ssize_t
-ofi_sendto_socket(SOCKET fd, const void *buf, size_t count, int flags,
-		  const struct sockaddr *to, socklen_t tolen)
+static inline ssize_t ofi_sendto_socket(SOCKET fd, const void *buf,
+					size_t count, int flags,
+					const struct sockaddr *to,
+					socklen_t tolen)
 {
 	size_t len = count > INT_MAX ? INT_MAX : count;
 	return sendto(fd, buf, len, flags, to, tolen);

--- a/include/rbtree.h
+++ b/include/rbtree.h
@@ -45,16 +45,16 @@
 #define RBTREE_H_
 
 typedef enum {
-    RBT_STATUS_OK,
-    RBT_STATUS_MEM_EXHAUSTED,
-    RBT_STATUS_DUPLICATE_KEY,
-    RBT_STATUS_KEY_NOT_FOUND
+	RBT_STATUS_OK,
+	RBT_STATUS_MEM_EXHAUSTED,
+	RBT_STATUS_DUPLICATE_KEY,
+	RBT_STATUS_KEY_NOT_FOUND
 } RbtStatus;
 
 typedef void *RbtIterator;
 typedef void *RbtHandle;
 
-RbtHandle rbtNew(int(*compare)(void *a, void *b));
+RbtHandle rbtNew(int (*compare)(void *a, void *b));
 // create red-black tree
 // parameters:
 //     compare  pointer to function that compares keys
@@ -63,7 +63,6 @@ RbtHandle rbtNew(int(*compare)(void *a, void *b));
 //              return > 0 if a > b
 // returns:
 //     handle   use handle in calls to rbt functions
-
 
 void rbtDelete(RbtHandle h);
 // destroy red-black tree
@@ -87,11 +86,11 @@ RbtIterator rbtEnd(RbtHandle h);
 void rbtKeyValue(RbtHandle h, RbtIterator i, void **key, void **value);
 // returns key/value pair associated with iterator
 
-void ** rbtValuePtr(RbtHandle h, RbtIterator it);
+void **rbtValuePtr(RbtHandle h, RbtIterator it);
 // returns pointer to the value associated with iterator
 
 RbtIterator rbtFindLeftmost(RbtHandle h, void *key,
-		int(*compare)(void *a, void *b));
+			    int (*compare)(void *a, void *b));
 // returns iterator associated with left-most match. This is useful when a new
 //   key might invalidate the uniqueness property of the tree.
 
@@ -99,7 +98,7 @@ RbtIterator rbtFind(RbtHandle h, void *key);
 // returns iterator associated with key
 
 void rbtTraversal(RbtHandle h, RbtIterator it, void *handler_arg,
-          void(*handler)(void *arg, RbtIterator it));
+		  void (*handler)(void *arg, RbtIterator it));
 // tree traversal that visits (applies handler()) each node in the tree data
 //   strucutre exactly once.
 

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -46,7 +46,7 @@
 #define FI_DEPRECATED_FUNC __attribute__((deprecated))
 #define FI_DEPRECATED_FIELD __attribute__((deprecated))
 #define FI_FORMAT_PRINTF(string, first) \
-	__attribute__ ((__format__ (__printf__, (string), (first))))
+	__attribute__((__format__(__printf__, (string), (first))))
 #elif defined(_MSC_VER)
 #define FI_DEPRECATED_FUNC __declspec(deprecated)
 #define FI_DEPRECATED_FIELD
@@ -75,29 +75,25 @@ extern "C" {
 
 #ifndef container_of
 #define container_of(ptr, type, field) \
-	((type *) ((char *)ptr - offsetof(type, field)))
+	((type *)((char *)ptr - offsetof(type, field)))
 #endif
 
 #ifndef count_of
-#define count_of(x) 	\
-	((sizeof(x)/sizeof(0[x])) / ((size_t)(!(sizeof(x) % sizeof(0[x])))))
+#define count_of(x) \
+	((sizeof(x) / sizeof(0 [x])) / ((size_t)(!(sizeof(x) % sizeof(0 [x])))))
 #endif
 
 #define FI_MAJOR_VERSION 1
 #define FI_MINOR_VERSION 17
 #define FI_REVISION_VERSION 0
 
-enum {
-	FI_PATH_MAX		= 256,
-	FI_NAME_MAX		= 64,
-	FI_VERSION_MAX		= 64
-};
+enum { FI_PATH_MAX = 256, FI_NAME_MAX = 64, FI_VERSION_MAX = 64 };
 
 #define FI_VERSION(major, minor) (((major) << 16) | (minor))
-#define FI_MAJOR(version)	(version >> 16)
-#define FI_MINOR(version)	(version & 0xFFFF)
-#define FI_VERSION_GE(v1, v2)	(v1 >= v2)
-#define FI_VERSION_LT(v1, v2)	(v1 < v2)
+#define FI_MAJOR(version) (version >> 16)
+#define FI_MINOR(version) (version & 0xFFFF)
+#define FI_VERSION_GE(v1, v2) (v1 >= v2)
+#define FI_VERSION_LT(v1, v2) (v1 < v2)
 
 uint32_t fi_version(void);
 
@@ -121,7 +117,7 @@ typedef struct fid *fid_t;
 /*
  * Provider specific values are indicated by setting the high-order bit.
  */
-#define FI_PROV_SPECIFIC	(1U << 31)
+#define FI_PROV_SPECIFIC (1U << 31)
 
 /*
  * Flags
@@ -131,128 +127,118 @@ typedef struct fid *fid_t;
  * 60 - 63      provider specific
  */
 
-#define FI_MSG			(1ULL << 1)
-#define FI_RMA			(1ULL << 2)
-#define FI_TAGGED		(1ULL << 3)
-#define FI_ATOMIC		(1ULL << 4)
-#define FI_ATOMICS		FI_ATOMIC
-#define FI_MULTICAST		(1ULL << 5)
-#define FI_COLLECTIVE		(1ULL << 6)
+#define FI_MSG (1ULL << 1)
+#define FI_RMA (1ULL << 2)
+#define FI_TAGGED (1ULL << 3)
+#define FI_ATOMIC (1ULL << 4)
+#define FI_ATOMICS FI_ATOMIC
+#define FI_MULTICAST (1ULL << 5)
+#define FI_COLLECTIVE (1ULL << 6)
 
-#define FI_READ			(1ULL << 8)
-#define FI_WRITE		(1ULL << 9)
-#define FI_RECV			(1ULL << 10)
-#define FI_SEND			(1ULL << 11)
-#define FI_TRANSMIT		FI_SEND
-#define FI_REMOTE_READ		(1ULL << 12)
-#define FI_REMOTE_WRITE		(1ULL << 13)
+#define FI_READ (1ULL << 8)
+#define FI_WRITE (1ULL << 9)
+#define FI_RECV (1ULL << 10)
+#define FI_SEND (1ULL << 11)
+#define FI_TRANSMIT FI_SEND
+#define FI_REMOTE_READ (1ULL << 12)
+#define FI_REMOTE_WRITE (1ULL << 13)
 
-#define FI_MULTI_RECV		(1ULL << 16)
-#define FI_REMOTE_CQ_DATA	(1ULL << 17)
-#define FI_MORE			(1ULL << 18)
-#define FI_PEEK			(1ULL << 19)
-#define FI_TRIGGER		(1ULL << 20)
-#define FI_FENCE		(1ULL << 21)
-#define FI_PRIORITY		(1ULL << 22)
+#define FI_MULTI_RECV (1ULL << 16)
+#define FI_REMOTE_CQ_DATA (1ULL << 17)
+#define FI_MORE (1ULL << 18)
+#define FI_PEEK (1ULL << 19)
+#define FI_TRIGGER (1ULL << 20)
+#define FI_FENCE (1ULL << 21)
+#define FI_PRIORITY (1ULL << 22)
 
-#define FI_COMPLETION		(1ULL << 24)
-#define FI_EVENT		FI_COMPLETION
-#define FI_INJECT		(1ULL << 25)
-#define FI_INJECT_COMPLETE	(1ULL << 26)
-#define FI_TRANSMIT_COMPLETE	(1ULL << 27)
-#define FI_DELIVERY_COMPLETE	(1ULL << 28)
-#define FI_AFFINITY		(1ULL << 29)
-#define FI_COMMIT_COMPLETE	(1ULL << 30)
-#define FI_MATCH_COMPLETE	(1ULL << 31)
+#define FI_COMPLETION (1ULL << 24)
+#define FI_EVENT FI_COMPLETION
+#define FI_INJECT (1ULL << 25)
+#define FI_INJECT_COMPLETE (1ULL << 26)
+#define FI_TRANSMIT_COMPLETE (1ULL << 27)
+#define FI_DELIVERY_COMPLETE (1ULL << 28)
+#define FI_AFFINITY (1ULL << 29)
+#define FI_COMMIT_COMPLETE (1ULL << 30)
+#define FI_MATCH_COMPLETE (1ULL << 31)
 
-#define FI_PEER_TRANSFER	(1ULL << 36)
-#define FI_AV_USER_ID		(1ULL << 41)
-#define FI_PEER			(1ULL << 43)
-#define FI_XPU_TRIGGER		(1ULL << 44)
-#define FI_HMEM_HOST_ALLOC	(1ULL << 45)
-#define FI_HMEM_DEVICE_ONLY	(1ULL << 46)
-#define FI_HMEM			(1ULL << 47)
-#define FI_VARIABLE_MSG		(1ULL << 48)
-#define FI_RMA_PMEM		(1ULL << 49)
-#define FI_SOURCE_ERR		(1ULL << 50)
-#define FI_LOCAL_COMM		(1ULL << 51)
-#define FI_REMOTE_COMM		(1ULL << 52)
-#define FI_SHARED_AV		(1ULL << 53)
-#define FI_PROV_ATTR_ONLY	(1ULL << 54)
-#define FI_NUMERICHOST		(1ULL << 55)
-#define FI_RMA_EVENT		(1ULL << 56)
-#define FI_SOURCE		(1ULL << 57)
-#define FI_NAMED_RX_CTX		(1ULL << 58)
-#define FI_DIRECTED_RECV	(1ULL << 59)
-
+#define FI_PEER_TRANSFER (1ULL << 36)
+#define FI_AV_USER_ID (1ULL << 41)
+#define FI_PEER (1ULL << 43)
+#define FI_XPU_TRIGGER (1ULL << 44)
+#define FI_HMEM_HOST_ALLOC (1ULL << 45)
+#define FI_HMEM_DEVICE_ONLY (1ULL << 46)
+#define FI_HMEM (1ULL << 47)
+#define FI_VARIABLE_MSG (1ULL << 48)
+#define FI_RMA_PMEM (1ULL << 49)
+#define FI_SOURCE_ERR (1ULL << 50)
+#define FI_LOCAL_COMM (1ULL << 51)
+#define FI_REMOTE_COMM (1ULL << 52)
+#define FI_SHARED_AV (1ULL << 53)
+#define FI_PROV_ATTR_ONLY (1ULL << 54)
+#define FI_NUMERICHOST (1ULL << 55)
+#define FI_RMA_EVENT (1ULL << 56)
+#define FI_SOURCE (1ULL << 57)
+#define FI_NAMED_RX_CTX (1ULL << 58)
+#define FI_DIRECTED_RECV (1ULL << 59)
 
 /* Tagged messages, buffered receives, CQ flags */
-#define FI_CLAIM		(1ULL << 59)
-#define FI_DISCARD		(1ULL << 58)
-
+#define FI_CLAIM (1ULL << 59)
+#define FI_DISCARD (1ULL << 58)
 
 struct fi_ioc {
-	void			*addr;
-	size_t			count;
+	void *addr;
+	size_t count;
 };
 
 /*
  * Format for transport addresses to insert into address vectors
  */
 enum {
-	FI_FORMAT_UNSPEC,	/* void * */
-	FI_SOCKADDR,		/* struct sockaddr */
-	FI_SOCKADDR_IN,		/* struct sockaddr_in */
-	FI_SOCKADDR_IN6,	/* struct sockaddr_in6 */
-	FI_SOCKADDR_IB,		/* struct sockaddr_ib */
-	FI_ADDR_PSMX,		/* uint64_t */
+	FI_FORMAT_UNSPEC, /* void * */
+	FI_SOCKADDR, /* struct sockaddr */
+	FI_SOCKADDR_IN, /* struct sockaddr_in */
+	FI_SOCKADDR_IN6, /* struct sockaddr_in6 */
+	FI_SOCKADDR_IB, /* struct sockaddr_ib */
+	FI_ADDR_PSMX, /* uint64_t */
 	FI_ADDR_GNI,
 	FI_ADDR_BGQ,
 	FI_ADDR_MLX,
-	FI_ADDR_STR,		/* formatted char * */
-	FI_ADDR_PSMX2,		/* uint64_t[2] */
-	FI_ADDR_IB_UD,		/* uint64_t[4] */
+	FI_ADDR_STR, /* formatted char * */
+	FI_ADDR_PSMX2, /* uint64_t[2] */
+	FI_ADDR_IB_UD, /* uint64_t[4] */
 	FI_ADDR_EFA,
-	FI_ADDR_PSMX3,		/* uint64_t[4] */
+	FI_ADDR_PSMX3, /* uint64_t[4] */
 	FI_ADDR_OPX,
 	FI_ADDR_CXI,
 	FI_ADDR_UCX,
 };
 
-#define FI_ADDR_UNSPEC		((uint64_t) -1)
-#define FI_ADDR_NOTAVAIL	((uint64_t) -1)
-#define FI_KEY_NOTAVAIL		((uint64_t) -1)
-#define FI_SHARED_CONTEXT	SIZE_MAX
-typedef uint64_t		fi_addr_t;
+#define FI_ADDR_UNSPEC ((uint64_t)-1)
+#define FI_ADDR_NOTAVAIL ((uint64_t)-1)
+#define FI_KEY_NOTAVAIL ((uint64_t)-1)
+#define FI_SHARED_CONTEXT SIZE_MAX
+typedef uint64_t fi_addr_t;
 
-enum fi_av_type {
-	FI_AV_UNSPEC,
-	FI_AV_MAP,
-	FI_AV_TABLE
-};
+enum fi_av_type { FI_AV_UNSPEC, FI_AV_MAP, FI_AV_TABLE };
 
 /* Named enum for backwards compatibility */
 enum fi_mr_mode {
 	FI_MR_UNSPEC,
-	FI_MR_BASIC,	     /* (1 << 0) */
-	FI_MR_SCALABLE,	     /* (1 << 1) */
+	FI_MR_BASIC, /* (1 << 0) */
+	FI_MR_SCALABLE, /* (1 << 1) */
 };
-#define FI_MR_LOCAL		(1 << 2)
-#define FI_MR_RAW		(1 << 3)
-#define FI_MR_VIRT_ADDR		(1 << 4)
-#define FI_MR_ALLOCATED		(1 << 5)
-#define FI_MR_PROV_KEY		(1 << 6)
-#define FI_MR_MMU_NOTIFY	(1 << 7)
-#define FI_MR_RMA_EVENT		(1 << 8)
-#define FI_MR_ENDPOINT		(1 << 9)
-#define FI_MR_HMEM		(1 << 10)
-#define FI_MR_COLLECTIVE	(1 << 11)
+#define FI_MR_LOCAL (1 << 2)
+#define FI_MR_RAW (1 << 3)
+#define FI_MR_VIRT_ADDR (1 << 4)
+#define FI_MR_ALLOCATED (1 << 5)
+#define FI_MR_PROV_KEY (1 << 6)
+#define FI_MR_MMU_NOTIFY (1 << 7)
+#define FI_MR_RMA_EVENT (1 << 8)
+#define FI_MR_ENDPOINT (1 << 9)
+#define FI_MR_HMEM (1 << 10)
+#define FI_MR_COLLECTIVE (1 << 11)
 
-enum fi_progress {
-	FI_PROGRESS_UNSPEC,
-	FI_PROGRESS_AUTO,
-	FI_PROGRESS_MANUAL
-};
+enum fi_progress { FI_PROGRESS_UNSPEC, FI_PROGRESS_AUTO, FI_PROGRESS_MANUAL };
 
 enum fi_threading {
 	FI_THREAD_UNSPEC,
@@ -263,34 +249,30 @@ enum fi_threading {
 	FI_THREAD_ENDPOINT,
 };
 
-enum fi_resource_mgmt {
-	FI_RM_UNSPEC,
-	FI_RM_DISABLED,
-	FI_RM_ENABLED
-};
+enum fi_resource_mgmt { FI_RM_UNSPEC, FI_RM_DISABLED, FI_RM_ENABLED };
 
-#define FI_ORDER_NONE		0ULL
-#define FI_ORDER_RAR		(1ULL << 0)
-#define FI_ORDER_RAW		(1ULL << 1)
-#define FI_ORDER_RAS		(1ULL << 2)
-#define FI_ORDER_WAR		(1ULL << 3)
-#define FI_ORDER_WAW		(1ULL << 4)
-#define FI_ORDER_WAS		(1ULL << 5)
-#define FI_ORDER_SAR		(1ULL << 6)
-#define FI_ORDER_SAW		(1ULL << 7)
-#define FI_ORDER_SAS		(1ULL << 8)
-#define FI_ORDER_STRICT		0x1FF
+#define FI_ORDER_NONE 0ULL
+#define FI_ORDER_RAR (1ULL << 0)
+#define FI_ORDER_RAW (1ULL << 1)
+#define FI_ORDER_RAS (1ULL << 2)
+#define FI_ORDER_WAR (1ULL << 3)
+#define FI_ORDER_WAW (1ULL << 4)
+#define FI_ORDER_WAS (1ULL << 5)
+#define FI_ORDER_SAR (1ULL << 6)
+#define FI_ORDER_SAW (1ULL << 7)
+#define FI_ORDER_SAS (1ULL << 8)
+#define FI_ORDER_STRICT 0x1FF
 
-#define FI_ORDER_RMA_RAR	(1ULL << 32)
-#define FI_ORDER_RMA_RAW	(1ULL << 33)
-#define FI_ORDER_RMA_WAR	(1ULL << 34)
-#define FI_ORDER_RMA_WAW	(1ULL << 35)
-#define FI_ORDER_ATOMIC_RAR	(1ULL << 36)
-#define FI_ORDER_ATOMIC_RAW	(1ULL << 37)
-#define FI_ORDER_ATOMIC_WAR	(1ULL << 38)
-#define FI_ORDER_ATOMIC_WAW	(1ULL << 39)
+#define FI_ORDER_RMA_RAR (1ULL << 32)
+#define FI_ORDER_RMA_RAW (1ULL << 33)
+#define FI_ORDER_RMA_WAR (1ULL << 34)
+#define FI_ORDER_RMA_WAW (1ULL << 35)
+#define FI_ORDER_ATOMIC_RAR (1ULL << 36)
+#define FI_ORDER_ATOMIC_RAW (1ULL << 37)
+#define FI_ORDER_ATOMIC_WAR (1ULL << 38)
+#define FI_ORDER_ATOMIC_WAW (1ULL << 39)
 
-#define FI_ORDER_DATA		(1ULL << 16)
+#define FI_ORDER_DATA (1ULL << 16)
 
 enum fi_ep_type {
 	FI_EP_UNSPEC,
@@ -353,129 +335,129 @@ enum {
 
 static inline uint32_t fi_tc_dscp_set(uint8_t dscp)
 {
-	return ((uint32_t) dscp) | FI_TC_DSCP;
+	return ((uint32_t)dscp) | FI_TC_DSCP;
 }
 
 static inline uint8_t fi_tc_dscp_get(uint32_t tclass)
 {
-	return tclass & FI_TC_DSCP ? (uint8_t) tclass : 0;
+	return tclass & FI_TC_DSCP ? (uint8_t)tclass : 0;
 }
 
 /* Mode bits */
-#define FI_CONTEXT		(1ULL << 59)
-#define FI_MSG_PREFIX		(1ULL << 58)
-#define FI_ASYNC_IOV		(1ULL << 57)
-#define FI_RX_CQ_DATA		(1ULL << 56)
-#define FI_LOCAL_MR		(1ULL << 55)
-#define FI_NOTIFY_FLAGS_ONLY	(1ULL << 54)
-#define FI_RESTRICTED_COMP	(1ULL << 53)
-#define FI_CONTEXT2		(1ULL << 52)
-#define FI_BUFFERED_RECV	(1ULL << 51)
+#define FI_CONTEXT (1ULL << 59)
+#define FI_MSG_PREFIX (1ULL << 58)
+#define FI_ASYNC_IOV (1ULL << 57)
+#define FI_RX_CQ_DATA (1ULL << 56)
+#define FI_LOCAL_MR (1ULL << 55)
+#define FI_NOTIFY_FLAGS_ONLY (1ULL << 54)
+#define FI_RESTRICTED_COMP (1ULL << 53)
+#define FI_CONTEXT2 (1ULL << 52)
+#define FI_BUFFERED_RECV (1ULL << 51)
 /* #define FI_PEER_TRANSFER	(1ULL << 36) */
 
 struct fi_tx_attr {
-	uint64_t		caps;
-	uint64_t		mode;
-	uint64_t		op_flags;
-	uint64_t		msg_order;
-	uint64_t		comp_order;
-	size_t			inject_size;
-	size_t			size;
-	size_t			iov_limit;
-	size_t			rma_iov_limit;
-	uint32_t		tclass;
+	uint64_t caps;
+	uint64_t mode;
+	uint64_t op_flags;
+	uint64_t msg_order;
+	uint64_t comp_order;
+	size_t inject_size;
+	size_t size;
+	size_t iov_limit;
+	size_t rma_iov_limit;
+	uint32_t tclass;
 };
 
 struct fi_rx_attr {
-	uint64_t		caps;
-	uint64_t		mode;
-	uint64_t		op_flags;
-	uint64_t		msg_order;
-	uint64_t		comp_order;
-	size_t			total_buffered_recv;
-	size_t			size;
-	size_t			iov_limit;
+	uint64_t caps;
+	uint64_t mode;
+	uint64_t op_flags;
+	uint64_t msg_order;
+	uint64_t comp_order;
+	size_t total_buffered_recv;
+	size_t size;
+	size_t iov_limit;
 };
 
 struct fi_ep_attr {
-	enum fi_ep_type		type;
-	uint32_t		protocol;
-	uint32_t		protocol_version;
-	size_t			max_msg_size;
-	size_t			msg_prefix_size;
-	size_t			max_order_raw_size;
-	size_t			max_order_war_size;
-	size_t			max_order_waw_size;
-	uint64_t		mem_tag_format;
-	size_t			tx_ctx_cnt;
-	size_t			rx_ctx_cnt;
-	size_t			auth_key_size;
-	uint8_t			*auth_key;
+	enum fi_ep_type type;
+	uint32_t protocol;
+	uint32_t protocol_version;
+	size_t max_msg_size;
+	size_t msg_prefix_size;
+	size_t max_order_raw_size;
+	size_t max_order_war_size;
+	size_t max_order_waw_size;
+	uint64_t mem_tag_format;
+	size_t tx_ctx_cnt;
+	size_t rx_ctx_cnt;
+	size_t auth_key_size;
+	uint8_t *auth_key;
 };
 
 struct fi_domain_attr {
-	struct fid_domain	*domain;
-	char			*name;
-	enum fi_threading	threading;
-	enum fi_progress	control_progress;
-	enum fi_progress	data_progress;
-	enum fi_resource_mgmt	resource_mgmt;
-	enum fi_av_type		av_type;
-	int			mr_mode;
-	size_t			mr_key_size;
-	size_t			cq_data_size;
-	size_t			cq_cnt;
-	size_t			ep_cnt;
-	size_t			tx_ctx_cnt;
-	size_t			rx_ctx_cnt;
-	size_t			max_ep_tx_ctx;
-	size_t			max_ep_rx_ctx;
-	size_t			max_ep_stx_ctx;
-	size_t			max_ep_srx_ctx;
-	size_t			cntr_cnt;
-	size_t			mr_iov_limit;
-	uint64_t		caps;
-	uint64_t		mode;
-	uint8_t			*auth_key;
-	size_t 			auth_key_size;
-	size_t			max_err_data;
-	size_t			mr_cnt;
-	uint32_t		tclass;
+	struct fid_domain *domain;
+	char *name;
+	enum fi_threading threading;
+	enum fi_progress control_progress;
+	enum fi_progress data_progress;
+	enum fi_resource_mgmt resource_mgmt;
+	enum fi_av_type av_type;
+	int mr_mode;
+	size_t mr_key_size;
+	size_t cq_data_size;
+	size_t cq_cnt;
+	size_t ep_cnt;
+	size_t tx_ctx_cnt;
+	size_t rx_ctx_cnt;
+	size_t max_ep_tx_ctx;
+	size_t max_ep_rx_ctx;
+	size_t max_ep_stx_ctx;
+	size_t max_ep_srx_ctx;
+	size_t cntr_cnt;
+	size_t mr_iov_limit;
+	uint64_t caps;
+	uint64_t mode;
+	uint8_t *auth_key;
+	size_t auth_key_size;
+	size_t max_err_data;
+	size_t mr_cnt;
+	uint32_t tclass;
 };
 
 struct fi_fabric_attr {
-	struct fid_fabric	*fabric;
-	char			*name;
-	char			*prov_name;
-	uint32_t		prov_version;
-	uint32_t		api_version;
+	struct fid_fabric *fabric;
+	char *name;
+	char *prov_name;
+	uint32_t prov_version;
+	uint32_t api_version;
 };
 
 struct fi_info {
-	struct fi_info		*next;
-	uint64_t		caps;
-	uint64_t		mode;
-	uint32_t		addr_format;
-	size_t			src_addrlen;
-	size_t			dest_addrlen;
-	void			*src_addr;
-	void			*dest_addr;
-	fid_t			handle;
-	struct fi_tx_attr	*tx_attr;
-	struct fi_rx_attr	*rx_attr;
-	struct fi_ep_attr	*ep_attr;
-	struct fi_domain_attr	*domain_attr;
-	struct fi_fabric_attr	*fabric_attr;
-	struct fid_nic		*nic;
+	struct fi_info *next;
+	uint64_t caps;
+	uint64_t mode;
+	uint32_t addr_format;
+	size_t src_addrlen;
+	size_t dest_addrlen;
+	void *src_addr;
+	void *dest_addr;
+	fid_t handle;
+	struct fi_tx_attr *tx_attr;
+	struct fi_rx_attr *rx_attr;
+	struct fi_ep_attr *ep_attr;
+	struct fi_domain_attr *domain_attr;
+	struct fi_fabric_attr *fabric_attr;
+	struct fid_nic *nic;
 };
 
 struct fi_device_attr {
-	char			*name;
-	char			*device_id;
-	char			*device_version;
-	char			*vendor_id;
-	char			*driver;
-	char			*firmware;
+	char *name;
+	char *device_id;
+	char *device_version;
+	char *vendor_id;
+	char *driver;
+	char *firmware;
 };
 
 enum fi_bus_type {
@@ -485,16 +467,16 @@ enum fi_bus_type {
 };
 
 struct fi_pci_attr {
-	uint16_t		domain_id;
-	uint8_t			bus_id;
-	uint8_t			device_id;
-	uint8_t			function_id;
+	uint16_t domain_id;
+	uint8_t bus_id;
+	uint8_t device_id;
+	uint8_t function_id;
 };
 
 struct fi_bus_attr {
-	enum fi_bus_type	bus_type;
+	enum fi_bus_type bus_type;
 	union {
-		struct fi_pci_attr	pci;
+		struct fi_pci_attr pci;
 	} attr;
 };
 
@@ -505,11 +487,11 @@ enum fi_link_state {
 };
 
 struct fi_link_attr {
-	char			*address;
-	size_t			mtu;
-	size_t			speed;
-	enum fi_link_state	state;
-	char			*network_type;
+	char *address;
+	size_t mtu;
+	size_t speed;
+	enum fi_link_state state;
+	char *network_type;
 };
 
 enum {
@@ -548,25 +530,25 @@ struct fi_eq_attr;
 struct fi_wait_attr;
 
 /* fi_bind()-specific flags */
-#define FI_SELECTIVE_COMPLETION	(1ULL << 59)
+#define FI_SELECTIVE_COMPLETION (1ULL << 59)
 
 struct fi_ops {
-	size_t	size;
-	int	(*close)(struct fid *fid);
-	int	(*bind)(struct fid *fid, struct fid *bfid, uint64_t flags);
-	int	(*control)(struct fid *fid, int command, void *arg);
-	int	(*ops_open)(struct fid *fid, const char *name,
-			    uint64_t flags, void **ops, void *context);
-	int	(*tostr)(const struct fid *fid, char *buf, size_t len);
-	int	(*ops_set)(struct fid *fid, const char *name, uint64_t flags,
-			   void *ops, void *context);
+	size_t size;
+	int (*close)(struct fid *fid);
+	int (*bind)(struct fid *fid, struct fid *bfid, uint64_t flags);
+	int (*control)(struct fid *fid, int command, void *arg);
+	int (*ops_open)(struct fid *fid, const char *name, uint64_t flags,
+			void **ops, void *context);
+	int (*tostr)(const struct fid *fid, char *buf, size_t len);
+	int (*ops_set)(struct fid *fid, const char *name, uint64_t flags,
+		       void *ops, void *context);
 };
 
 /* All fabric interface descriptors must start with this structure */
 struct fid {
-	size_t			fclass;
-	void			*context;
-	struct fi_ops		*ops;
+	size_t fclass;
+	void *context;
+	struct fi_ops *ops;
 };
 
 int fi_getinfo(uint32_t version, const char *node, const char *service,
@@ -581,25 +563,24 @@ static inline struct fi_info *fi_allocinfo(void)
 }
 
 struct fi_ops_fabric {
-	size_t	size;
-	int	(*domain)(struct fid_fabric *fabric, struct fi_info *info,
-			struct fid_domain **dom, void *context);
-	int	(*passive_ep)(struct fid_fabric *fabric, struct fi_info *info,
-			struct fid_pep **pep, void *context);
-	int	(*eq_open)(struct fid_fabric *fabric, struct fi_eq_attr *attr,
-			struct fid_eq **eq, void *context);
-	int	(*wait_open)(struct fid_fabric *fabric, struct fi_wait_attr *attr,
-			struct fid_wait **waitset);
-	int	(*trywait)(struct fid_fabric *fabric, struct fid **fids,
-			int count);
-	int	(*domain2)(struct fid_fabric *fabric, struct fi_info *info,
-			struct fid_domain **dom, uint64_t flags, void *context);
+	size_t size;
+	int (*domain)(struct fid_fabric *fabric, struct fi_info *info,
+		      struct fid_domain **dom, void *context);
+	int (*passive_ep)(struct fid_fabric *fabric, struct fi_info *info,
+			  struct fid_pep **pep, void *context);
+	int (*eq_open)(struct fid_fabric *fabric, struct fi_eq_attr *attr,
+		       struct fid_eq **eq, void *context);
+	int (*wait_open)(struct fid_fabric *fabric, struct fi_wait_attr *attr,
+			 struct fid_wait **waitset);
+	int (*trywait)(struct fid_fabric *fabric, struct fid **fids, int count);
+	int (*domain2)(struct fid_fabric *fabric, struct fi_info *info,
+		       struct fid_domain **dom, uint64_t flags, void *context);
 };
 
 struct fid_fabric {
-	struct fid		fid;
-	struct fi_ops_fabric	*ops;
-	uint32_t		api_version;
+	struct fid fid;
+	struct fi_ops_fabric *ops;
+	uint32_t api_version;
 };
 
 int fi_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
@@ -608,11 +589,11 @@ int fi_open(uint32_t version, const char *name, void *attr, size_t attr_len,
 	    uint64_t flags, struct fid **fid, void *context);
 
 struct fid_nic {
-	struct fid		fid;
-	struct fi_device_attr	*device_attr;
-	struct fi_bus_attr	*bus_attr;
-	struct fi_link_attr	*link_attr;
-	void			*prov_attr;
+	struct fid fid;
+	struct fi_device_attr *device_attr;
+	struct fi_bus_attr *bus_attr;
+	struct fi_link_attr *link_attr;
+	void *prov_attr;
 };
 
 #define FI_CHECK_OP(ops, opstype, op) \
@@ -624,52 +605,52 @@ static inline int fi_close(struct fid *fid)
 }
 
 struct fi_alias {
-	struct fid 		**fid;
-	uint64_t		flags;
+	struct fid **fid;
+	uint64_t flags;
 };
 
 struct fi_fid_var {
-	int		name;
-	void		*val;
+	int name;
+	void *val;
 };
 
 struct fi_mr_raw_attr {
-	uint64_t	flags;
-	uint64_t	*base_addr;
-	uint8_t		*raw_key;
-	size_t		*key_size;
+	uint64_t flags;
+	uint64_t *base_addr;
+	uint8_t *raw_key;
+	size_t *key_size;
 };
 
 struct fi_mr_map_raw {
-	uint64_t	flags;
-	uint64_t	base_addr;
-	uint8_t		*raw_key;
-	size_t		key_size;
-	uint64_t	*key;
+	uint64_t flags;
+	uint64_t base_addr;
+	uint8_t *raw_key;
+	size_t key_size;
+	uint64_t *key;
 };
 
 /* control commands */
 enum {
-	FI_GETFIDFLAG,		/* uint64_t flags */
-	FI_SETFIDFLAG,		/* uint64_t flags */
-	FI_GETOPSFLAG,		/* uint64_t flags */
-	FI_SETOPSFLAG,		/* uint64_t flags */
-	FI_ALIAS,		/* struct fi_alias * */
-	FI_GETWAIT,		/* void * wait object */
-	FI_ENABLE,		/* NULL */
-	FI_BACKLOG,		/* integer * */
-	FI_GET_RAW_MR,		/* fi_mr_raw_attr */
-	FI_MAP_RAW_MR,		/* fi_mr_map_raw */
-	FI_UNMAP_KEY,		/* uint64_t key */
-	FI_QUEUE_WORK,		/* struct fi_deferred_work */
-	FI_CANCEL_WORK,		/* struct fi_deferred_work */
-	FI_FLUSH_WORK,		/* NULL */
-	FI_REFRESH,		/* mr: fi_mr_modify */
-	FI_DUP,			/* struct fid ** */
-	FI_GETWAITOBJ,		/*enum fi_wait_obj * */
-	FI_GET_VAL,		/* struct fi_fid_var */
-	FI_SET_VAL,		/* struct fi_fid_var */
-	FI_EXPORT_FID,		/* struct fi_fid_export */
+	FI_GETFIDFLAG, /* uint64_t flags */
+	FI_SETFIDFLAG, /* uint64_t flags */
+	FI_GETOPSFLAG, /* uint64_t flags */
+	FI_SETOPSFLAG, /* uint64_t flags */
+	FI_ALIAS, /* struct fi_alias * */
+	FI_GETWAIT, /* void * wait object */
+	FI_ENABLE, /* NULL */
+	FI_BACKLOG, /* integer * */
+	FI_GET_RAW_MR, /* fi_mr_raw_attr */
+	FI_MAP_RAW_MR, /* fi_mr_map_raw */
+	FI_UNMAP_KEY, /* uint64_t key */
+	FI_QUEUE_WORK, /* struct fi_deferred_work */
+	FI_CANCEL_WORK, /* struct fi_deferred_work */
+	FI_FLUSH_WORK, /* NULL */
+	FI_REFRESH, /* mr: fi_mr_modify */
+	FI_DUP, /* struct fid ** */
+	FI_GETWAITOBJ, /*enum fi_wait_obj * */
+	FI_GET_VAL, /* struct fi_fid_var */
+	FI_SET_VAL, /* struct fi_fid_var */
+	FI_EXPORT_FID, /* struct fi_fid_export */
 };
 
 static inline int fi_control(struct fid *fid, int command, void *arg)
@@ -677,7 +658,8 @@ static inline int fi_control(struct fid *fid, int command, void *arg)
 	return fid->ops->control(fid, command, arg);
 }
 
-static inline int fi_alias(struct fid *fid, struct fid **alias_fid, uint64_t flags)
+static inline int fi_alias(struct fid *fid, struct fid **alias_fid,
+			   uint64_t flags)
 {
 	struct fi_alias alias;
 	alias.fid = alias_fid;
@@ -707,19 +689,18 @@ static inline int fi_set_val(struct fid *fid, int name, void *val)
 	return fi_control(fid, FI_SET_VAL, &var);
 }
 
-static inline int
-fi_open_ops(struct fid *fid, const char *name, uint64_t flags,
-	    void **ops, void *context)
+static inline int fi_open_ops(struct fid *fid, const char *name, uint64_t flags,
+			      void **ops, void *context)
 {
 	return fid->ops->ops_open(fid, name, flags, ops, context);
 }
 
-static inline int
-fi_set_ops(struct fid *fid, const char *name, uint64_t flags,
-	   void *ops, void *context)
+static inline int fi_set_ops(struct fid *fid, const char *name, uint64_t flags,
+			     void *ops, void *context)
 {
 	return FI_CHECK_OP(fid->ops, struct fi_ops, ops_set) ?
-		fid->ops->ops_set(fid, name, flags, ops, context) : -FI_ENOSYS;
+		       fid->ops->ops_set(fid, name, flags, ops, context) :
+		       -FI_ENOSYS;
 }
 
 enum fi_type {
@@ -777,21 +758,21 @@ void fi_freeparams(struct fi_param *params);
 
 #ifdef FABRIC_DIRECT
 #include <rdma/fi_direct.h>
-#endif	/* FABRIC_DIRECT */
+#endif /* FABRIC_DIRECT */
 
 #ifndef FABRIC_DIRECT_
 struct fi_context {
-	void			*internal[4];
+	void *internal[4];
 };
 
 struct fi_context2 {
-	void			*internal[8];
+	void *internal[8];
 };
 #endif
 
 struct fi_recv_context {
-	struct fid_ep		*ep;
-	void			*context;
+	struct fid_ep *ep;
+	void *context;
 };
 
 #ifdef __cplusplus

--- a/include/rdma/fi_atomic.h
+++ b/include/rdma/fi_atomic.h
@@ -37,258 +37,250 @@
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_rma.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
 /* Atomic flags */
-#define FI_FETCH_ATOMIC		(1ULL << 58)
-#define FI_COMPARE_ATOMIC	(1ULL << 59)
+#define FI_FETCH_ATOMIC (1ULL << 58)
+#define FI_COMPARE_ATOMIC (1ULL << 59)
 
 struct fi_atomic_attr {
-	size_t			count;
-	size_t			size;
+	size_t count;
+	size_t size;
 };
 
 struct fi_msg_atomic {
-	const struct fi_ioc	*msg_iov;
-	void			**desc;
-	size_t			iov_count;
-	fi_addr_t		addr;
-	const struct fi_rma_ioc	*rma_iov;
-	size_t			rma_iov_count;
-	enum fi_datatype	datatype;
-	enum fi_op		op;
-	void			*context;
-	uint64_t		data;
+	const struct fi_ioc *msg_iov;
+	void **desc;
+	size_t iov_count;
+	fi_addr_t addr;
+	const struct fi_rma_ioc *rma_iov;
+	size_t rma_iov_count;
+	enum fi_datatype datatype;
+	enum fi_op op;
+	void *context;
+	uint64_t data;
 };
 
 struct fi_msg_fetch {
-	struct fi_ioc		*msg_iov;
-	void			**desc;
-	size_t			iov_count;
+	struct fi_ioc *msg_iov;
+	void **desc;
+	size_t iov_count;
 };
 
 struct fi_msg_compare {
-	const struct fi_ioc	*msg_iov;
-	void			**desc;
-	size_t			iov_count;
+	const struct fi_ioc *msg_iov;
+	void **desc;
+	size_t iov_count;
 };
 
 struct fi_ops_atomic {
-	size_t	size;
-	ssize_t	(*write)(struct fid_ep *ep,
-			const void *buf, size_t count, void *desc,
-			fi_addr_t dest_addr,
-			uint64_t addr, uint64_t key,
-			enum fi_datatype datatype, enum fi_op op, void *context);
-	ssize_t	(*writev)(struct fid_ep *ep,
-			const struct fi_ioc *iov, void **desc, size_t count,
-			fi_addr_t dest_addr,
-			uint64_t addr, uint64_t key,
-			enum fi_datatype datatype, enum fi_op op, void *context);
-	ssize_t	(*writemsg)(struct fid_ep *ep,
-			const struct fi_msg_atomic *msg, uint64_t flags);
-	ssize_t	(*inject)(struct fid_ep *ep, const void *buf, size_t count,
-			fi_addr_t dest_addr, uint64_t addr, uint64_t key,
-			enum fi_datatype datatype, enum fi_op op);
+	size_t size;
+	ssize_t (*write)(struct fid_ep *ep, const void *buf, size_t count,
+			 void *desc, fi_addr_t dest_addr, uint64_t addr,
+			 uint64_t key, enum fi_datatype datatype, enum fi_op op,
+			 void *context);
+	ssize_t (*writev)(struct fid_ep *ep, const struct fi_ioc *iov,
+			  void **desc, size_t count, fi_addr_t dest_addr,
+			  uint64_t addr, uint64_t key,
+			  enum fi_datatype datatype, enum fi_op op,
+			  void *context);
+	ssize_t (*writemsg)(struct fid_ep *ep, const struct fi_msg_atomic *msg,
+			    uint64_t flags);
+	ssize_t (*inject)(struct fid_ep *ep, const void *buf, size_t count,
+			  fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+			  enum fi_datatype datatype, enum fi_op op);
 
-	ssize_t	(*readwrite)(struct fid_ep *ep,
-			const void *buf, size_t count, void *desc,
-			void *result, void *result_desc,
-			fi_addr_t dest_addr,
-			uint64_t addr, uint64_t key,
-			enum fi_datatype datatype, enum fi_op op, void *context);
-	ssize_t	(*readwritev)(struct fid_ep *ep,
-			const struct fi_ioc *iov, void **desc, size_t count,
-			struct fi_ioc *resultv, void **result_desc, size_t result_count,
-			fi_addr_t dest_addr,
-			uint64_t addr, uint64_t key,
-			enum fi_datatype datatype, enum fi_op op, void *context);
-	ssize_t	(*readwritemsg)(struct fid_ep *ep,
-			const struct fi_msg_atomic *msg,
-			struct fi_ioc *resultv, void **result_desc, size_t result_count,
-			uint64_t flags);
+	ssize_t (*readwrite)(struct fid_ep *ep, const void *buf, size_t count,
+			     void *desc, void *result, void *result_desc,
+			     fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+			     enum fi_datatype datatype, enum fi_op op,
+			     void *context);
+	ssize_t (*readwritev)(struct fid_ep *ep, const struct fi_ioc *iov,
+			      void **desc, size_t count, struct fi_ioc *resultv,
+			      void **result_desc, size_t result_count,
+			      fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+			      enum fi_datatype datatype, enum fi_op op,
+			      void *context);
+	ssize_t (*readwritemsg)(struct fid_ep *ep,
+				const struct fi_msg_atomic *msg,
+				struct fi_ioc *resultv, void **result_desc,
+				size_t result_count, uint64_t flags);
 
-	ssize_t	(*compwrite)(struct fid_ep *ep,
-			const void *buf, size_t count, void *desc,
-			const void *compare, void *compare_desc,
-			void *result, void *result_desc,
-			fi_addr_t dest_addr,
-			uint64_t addr, uint64_t key,
-			enum fi_datatype datatype, enum fi_op op, void *context);
-	ssize_t	(*compwritev)(struct fid_ep *ep,
-			const struct fi_ioc *iov, void **desc, size_t count,
-			const struct fi_ioc *comparev, void **compare_desc, size_t compare_count,
-			struct fi_ioc *resultv, void **result_desc, size_t result_count,
-			fi_addr_t dest_addr,
-			uint64_t addr, uint64_t key,
-			enum fi_datatype datatype, enum fi_op op, void *context);
-	ssize_t	(*compwritemsg)(struct fid_ep *ep,
-			const struct fi_msg_atomic *msg,
-			const struct fi_ioc *comparev, void **compare_desc, size_t compare_count,
-			struct fi_ioc *resultv, void **result_desc, size_t result_count,
-			uint64_t flags);
+	ssize_t (*compwrite)(struct fid_ep *ep, const void *buf, size_t count,
+			     void *desc, const void *compare,
+			     void *compare_desc, void *result,
+			     void *result_desc, fi_addr_t dest_addr,
+			     uint64_t addr, uint64_t key,
+			     enum fi_datatype datatype, enum fi_op op,
+			     void *context);
+	ssize_t (*compwritev)(struct fid_ep *ep, const struct fi_ioc *iov,
+			      void **desc, size_t count,
+			      const struct fi_ioc *comparev,
+			      void **compare_desc, size_t compare_count,
+			      struct fi_ioc *resultv, void **result_desc,
+			      size_t result_count, fi_addr_t dest_addr,
+			      uint64_t addr, uint64_t key,
+			      enum fi_datatype datatype, enum fi_op op,
+			      void *context);
+	ssize_t (*compwritemsg)(struct fid_ep *ep,
+				const struct fi_msg_atomic *msg,
+				const struct fi_ioc *comparev,
+				void **compare_desc, size_t compare_count,
+				struct fi_ioc *resultv, void **result_desc,
+				size_t result_count, uint64_t flags);
 
-	int	(*writevalid)(struct fid_ep *ep,
-			enum fi_datatype datatype, enum fi_op op, size_t *count);
-	int	(*readwritevalid)(struct fid_ep *ep,
-			enum fi_datatype datatype, enum fi_op op, size_t *count);
-	int	(*compwritevalid)(struct fid_ep *ep,
-			enum fi_datatype datatype, enum fi_op op, size_t *count);
+	int (*writevalid)(struct fid_ep *ep, enum fi_datatype datatype,
+			  enum fi_op op, size_t *count);
+	int (*readwritevalid)(struct fid_ep *ep, enum fi_datatype datatype,
+			      enum fi_op op, size_t *count);
+	int (*compwritevalid)(struct fid_ep *ep, enum fi_datatype datatype,
+			      enum fi_op op, size_t *count);
 };
 
 #ifdef FABRIC_DIRECT
 #include <rdma/fi_direct_atomic.h>
-#endif	/* FABRIC_DIRECT */
+#endif /* FABRIC_DIRECT */
 
 #ifndef FABRIC_DIRECT_ATOMIC
 
-static inline ssize_t
-fi_atomic(struct fid_ep *ep,
-	  const void *buf, size_t count, void *desc,
-	  fi_addr_t dest_addr,
-	  uint64_t addr, uint64_t key,
-	  enum fi_datatype datatype, enum fi_op op, void *context)
+static inline ssize_t fi_atomic(struct fid_ep *ep, const void *buf,
+				size_t count, void *desc, fi_addr_t dest_addr,
+				uint64_t addr, uint64_t key,
+				enum fi_datatype datatype, enum fi_op op,
+				void *context)
 {
 	return ep->atomic->write(ep, buf, count, desc, dest_addr, addr, key,
-			datatype, op, context);
+				 datatype, op, context);
 }
 
-static inline ssize_t
-fi_atomicv(struct fid_ep *ep,
-	   const struct fi_ioc *iov, void **desc, size_t count,
-	   fi_addr_t dest_addr,
-	   uint64_t addr, uint64_t key,
-	   enum fi_datatype datatype, enum fi_op op, void *context)
+static inline ssize_t fi_atomicv(struct fid_ep *ep, const struct fi_ioc *iov,
+				 void **desc, size_t count, fi_addr_t dest_addr,
+				 uint64_t addr, uint64_t key,
+				 enum fi_datatype datatype, enum fi_op op,
+				 void *context)
 {
 	return ep->atomic->writev(ep, iov, desc, count, dest_addr, addr, key,
-			datatype, op, context);
+				  datatype, op, context);
 }
 
 static inline ssize_t
-fi_atomicmsg(struct fid_ep *ep,
-	     const struct fi_msg_atomic *msg, uint64_t flags)
+fi_atomicmsg(struct fid_ep *ep, const struct fi_msg_atomic *msg, uint64_t flags)
 {
 	return ep->atomic->writemsg(ep, msg, flags);
 }
 
-static inline ssize_t
-fi_inject_atomic(struct fid_ep *ep, const void *buf, size_t count,
-		 fi_addr_t dest_addr, uint64_t addr, uint64_t key,
-		 enum fi_datatype datatype, enum fi_op op)
+static inline ssize_t fi_inject_atomic(struct fid_ep *ep, const void *buf,
+				       size_t count, fi_addr_t dest_addr,
+				       uint64_t addr, uint64_t key,
+				       enum fi_datatype datatype, enum fi_op op)
 {
-	return ep->atomic->inject(ep, buf, count, dest_addr, addr,
-			key, datatype, op);
+	return ep->atomic->inject(ep, buf, count, dest_addr, addr, key,
+				  datatype, op);
 }
 
-static inline ssize_t
-fi_fetch_atomic(struct fid_ep *ep,
-		const void *buf, size_t count, void *desc,
-		void *result, void *result_desc,
-		fi_addr_t dest_addr,
-		uint64_t addr, uint64_t key,
-		enum fi_datatype datatype, enum fi_op op, void *context)
+static inline ssize_t fi_fetch_atomic(struct fid_ep *ep, const void *buf,
+				      size_t count, void *desc, void *result,
+				      void *result_desc, fi_addr_t dest_addr,
+				      uint64_t addr, uint64_t key,
+				      enum fi_datatype datatype, enum fi_op op,
+				      void *context)
 {
 	return ep->atomic->readwrite(ep, buf, count, desc, result, result_desc,
-			dest_addr, addr, key, datatype, op, context);
+				     dest_addr, addr, key, datatype, op,
+				     context);
 }
 
-static inline ssize_t
-fi_fetch_atomicv(struct fid_ep *ep,
-		 const struct fi_ioc *iov, void **desc, size_t count,
-		 struct fi_ioc *resultv, void **result_desc, size_t result_count,
-		 fi_addr_t dest_addr,
-		 uint64_t addr, uint64_t key,
-		 enum fi_datatype datatype, enum fi_op op, void *context)
+static inline ssize_t fi_fetch_atomicv(struct fid_ep *ep,
+				       const struct fi_ioc *iov, void **desc,
+				       size_t count, struct fi_ioc *resultv,
+				       void **result_desc, size_t result_count,
+				       fi_addr_t dest_addr, uint64_t addr,
+				       uint64_t key, enum fi_datatype datatype,
+				       enum fi_op op, void *context)
 {
-	return ep->atomic->readwritev(ep, iov, desc, count,
-			resultv, result_desc, result_count,
-			dest_addr, addr, key, datatype, op, context);
+	return ep->atomic->readwritev(ep, iov, desc, count, resultv,
+				      result_desc, result_count, dest_addr,
+				      addr, key, datatype, op, context);
 }
 
-static inline ssize_t
-fi_fetch_atomicmsg(struct fid_ep *ep,
-		   const struct fi_msg_atomic *msg,
-		   struct fi_ioc *resultv, void **result_desc, size_t result_count,
-		   uint64_t flags)
+static inline ssize_t fi_fetch_atomicmsg(struct fid_ep *ep,
+					 const struct fi_msg_atomic *msg,
+					 struct fi_ioc *resultv,
+					 void **result_desc,
+					 size_t result_count, uint64_t flags)
 {
 	return ep->atomic->readwritemsg(ep, msg, resultv, result_desc,
-			result_count, flags);
+					result_count, flags);
+}
+
+static inline ssize_t fi_compare_atomic(struct fid_ep *ep, const void *buf,
+					size_t count, void *desc,
+					const void *compare, void *compare_desc,
+					void *result, void *result_desc,
+					fi_addr_t dest_addr, uint64_t addr,
+					uint64_t key, enum fi_datatype datatype,
+					enum fi_op op, void *context)
+{
+	return ep->atomic->compwrite(ep, buf, count, desc, compare,
+				     compare_desc, result, result_desc,
+				     dest_addr, addr, key, datatype, op,
+				     context);
+}
+
+static inline ssize_t fi_compare_atomicv(
+	struct fid_ep *ep, const struct fi_ioc *iov, void **desc, size_t count,
+	const struct fi_ioc *comparev, void **compare_desc,
+	size_t compare_count, struct fi_ioc *resultv, void **result_desc,
+	size_t result_count, fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+	enum fi_datatype datatype, enum fi_op op, void *context)
+{
+	return ep->atomic->compwritev(ep, iov, desc, count, comparev,
+				      compare_desc, compare_count, resultv,
+				      result_desc, result_count, dest_addr,
+				      addr, key, datatype, op, context);
 }
 
 static inline ssize_t
-fi_compare_atomic(struct fid_ep *ep,
-		  const void *buf, size_t count, void *desc,
-		  const void *compare, void *compare_desc,
-		  void *result, void *result_desc,
-		  fi_addr_t dest_addr,
-		  uint64_t addr, uint64_t key,
-		  enum fi_datatype datatype, enum fi_op op, void *context)
+fi_compare_atomicmsg(struct fid_ep *ep, const struct fi_msg_atomic *msg,
+		     const struct fi_ioc *comparev, void **compare_desc,
+		     size_t compare_count, struct fi_ioc *resultv,
+		     void **result_desc, size_t result_count, uint64_t flags)
 {
-	return ep->atomic->compwrite(ep, buf, count, desc,
-			compare, compare_desc, result, result_desc,
-			dest_addr, addr, key, datatype, op, context);
+	return ep->atomic->compwritemsg(ep, msg, comparev, compare_desc,
+					compare_count, resultv, result_desc,
+					result_count, flags);
 }
 
-static inline ssize_t
-fi_compare_atomicv(struct fid_ep *ep,
-		   const struct fi_ioc *iov, void **desc, size_t count,
-		   const struct fi_ioc *comparev, void **compare_desc, size_t compare_count,
-		   struct fi_ioc *resultv, void **result_desc, size_t result_count,
-		   fi_addr_t dest_addr,
-		   uint64_t addr, uint64_t key,
-		   enum fi_datatype datatype, enum fi_op op, void *context)
-{
-	return ep->atomic->compwritev(ep, iov, desc, count,
-			comparev, compare_desc, compare_count,
-			resultv, result_desc, result_count,
-			dest_addr, addr, key, datatype, op, context);
-}
-
-static inline ssize_t
-fi_compare_atomicmsg(struct fid_ep *ep,
-		     const struct fi_msg_atomic *msg,
-		     const struct fi_ioc *comparev, void **compare_desc, size_t compare_count,
-		     struct fi_ioc *resultv, void **result_desc, size_t result_count,
-		     uint64_t flags)
-{
-	return ep->atomic->compwritemsg(ep, msg,
-			comparev, compare_desc, compare_count,
-			resultv, result_desc, result_count, flags);
-}
-
-static inline int
-fi_atomicvalid(struct fid_ep *ep,
-	       enum fi_datatype datatype, enum fi_op op, size_t *count)
+static inline int fi_atomicvalid(struct fid_ep *ep, enum fi_datatype datatype,
+				 enum fi_op op, size_t *count)
 {
 	return ep->atomic->writevalid(ep, datatype, op, count);
 }
 
-static inline int
-fi_fetch_atomicvalid(struct fid_ep *ep,
-		     enum fi_datatype datatype, enum fi_op op, size_t *count)
+static inline int fi_fetch_atomicvalid(struct fid_ep *ep,
+				       enum fi_datatype datatype, enum fi_op op,
+				       size_t *count)
 {
 	return ep->atomic->readwritevalid(ep, datatype, op, count);
 }
 
-static inline int
-fi_compare_atomicvalid(struct fid_ep *ep,
-		       enum fi_datatype datatype, enum fi_op op, size_t *count)
+static inline int fi_compare_atomicvalid(struct fid_ep *ep,
+					 enum fi_datatype datatype,
+					 enum fi_op op, size_t *count)
 {
 	return ep->atomic->compwritevalid(ep, datatype, op, count);
 }
 
-static inline int
-fi_query_atomic(struct fid_domain *domain,
-		enum fi_datatype datatype, enum fi_op op,
-		struct fi_atomic_attr *attr, uint64_t flags)
+static inline int fi_query_atomic(struct fid_domain *domain,
+				  enum fi_datatype datatype, enum fi_op op,
+				  struct fi_atomic_attr *attr, uint64_t flags)
 {
 	return FI_CHECK_OP(domain->ops, struct fi_ops_domain, query_atomic) ?
-		domain->ops->query_atomic(domain, datatype, op, attr, flags) :
-		-FI_ENOSYS;
+		       domain->ops->query_atomic(domain, datatype, op, attr,
+						 flags) :
+		       -FI_ENOSYS;
 }
 
 #endif

--- a/include/rdma/fi_cm.h
+++ b/include/rdma/fi_cm.h
@@ -35,37 +35,34 @@
 
 #include <rdma/fi_endpoint.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
 struct fid_mc {
-	struct fid		fid;
-	fi_addr_t		fi_addr;
+	struct fid fid;
+	fi_addr_t fi_addr;
 };
 
 struct fi_ops_cm {
-	size_t	size;
-	int	(*setname)(fid_t fid, void *addr, size_t addrlen);
-	int	(*getname)(fid_t fid, void *addr, size_t *addrlen);
-	int	(*getpeer)(struct fid_ep *ep, void *addr, size_t *addrlen);
-	int	(*connect)(struct fid_ep *ep, const void *addr,
-			const void *param, size_t paramlen);
-	int	(*listen)(struct fid_pep *pep);
-	int	(*accept)(struct fid_ep *ep, const void *param, size_t paramlen);
-	int	(*reject)(struct fid_pep *pep, fid_t handle,
-			const void *param, size_t paramlen);
-	int	(*shutdown)(struct fid_ep *ep, uint64_t flags);
-	int	(*join)(struct fid_ep *ep, const void *addr, uint64_t flags,
-			struct fid_mc **mc, void *context);
+	size_t size;
+	int (*setname)(fid_t fid, void *addr, size_t addrlen);
+	int (*getname)(fid_t fid, void *addr, size_t *addrlen);
+	int (*getpeer)(struct fid_ep *ep, void *addr, size_t *addrlen);
+	int (*connect)(struct fid_ep *ep, const void *addr, const void *param,
+		       size_t paramlen);
+	int (*listen)(struct fid_pep *pep);
+	int (*accept)(struct fid_ep *ep, const void *param, size_t paramlen);
+	int (*reject)(struct fid_pep *pep, fid_t handle, const void *param,
+		      size_t paramlen);
+	int (*shutdown)(struct fid_ep *ep, uint64_t flags);
+	int (*join)(struct fid_ep *ep, const void *addr, uint64_t flags,
+		    struct fid_mc **mc, void *context);
 };
-
 
 #ifdef FABRIC_DIRECT
 #include <rdma/fi_direct_cm.h>
-#endif	/* FABRIC_DIRECT */
+#endif /* FABRIC_DIRECT */
 
 #ifndef FABRIC_DIRECT_CM
 
@@ -91,22 +88,20 @@ static inline int fi_listen(struct fid_pep *pep)
 	return pep->cm->listen(pep);
 }
 
-static inline int
-fi_connect(struct fid_ep *ep, const void *addr,
-	   const void *param, size_t paramlen)
+static inline int fi_connect(struct fid_ep *ep, const void *addr,
+			     const void *param, size_t paramlen)
 {
 	return ep->cm->connect(ep, addr, param, paramlen);
 }
 
-static inline int
-fi_accept(struct fid_ep *ep, const void *param, size_t paramlen)
+static inline int fi_accept(struct fid_ep *ep, const void *param,
+			    size_t paramlen)
 {
 	return ep->cm->accept(ep, param, paramlen);
 }
 
-static inline int
-fi_reject(struct fid_pep *pep, fid_t handle,
-	  const void *param, size_t paramlen)
+static inline int fi_reject(struct fid_pep *pep, fid_t handle,
+			    const void *param, size_t paramlen)
 {
 	return pep->cm->reject(pep, handle, param, paramlen);
 }
@@ -120,7 +115,8 @@ static inline int fi_join(struct fid_ep *ep, const void *addr, uint64_t flags,
 			  struct fid_mc **mc, void *context)
 {
 	return FI_CHECK_OP(ep->cm, struct fi_ops_cm, join) ?
-		ep->cm->join(ep, addr, flags, mc, context) : -FI_ENOSYS;
+		       ep->cm->join(ep, addr, flags, mc, context) :
+		       -FI_ENOSYS;
 }
 
 static inline fi_addr_t fi_mc_addr(struct fid_mc *mc)

--- a/include/rdma/fi_collective.h
+++ b/include/rdma/fi_collective.h
@@ -37,7 +37,6 @@
 #include <rdma/fi_domain.h>
 #include <rdma/fi_cm.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -46,98 +45,93 @@ extern "C" {
 #include <rdma/fi_direct_collective_def.h>
 #endif /* FABRIC_DIRECT */
 
-
 struct fi_ops_av_set {
-	size_t	size;
-	int	(*set_union)(struct fid_av_set *dst,
-			const struct fid_av_set *src);
-	int	(*intersect)(struct fid_av_set *dst,
-			const struct fid_av_set *src);
-	int	(*diff)(struct fid_av_set *dst, const struct fid_av_set *src);
-	int	(*insert)(struct fid_av_set *set, fi_addr_t addr);
-	int	(*remove)(struct fid_av_set *set, fi_addr_t addr);
-	int	(*addr)(struct fid_av_set *set, fi_addr_t *coll_addr);
+	size_t size;
+	int (*set_union)(struct fid_av_set *dst, const struct fid_av_set *src);
+	int (*intersect)(struct fid_av_set *dst, const struct fid_av_set *src);
+	int (*diff)(struct fid_av_set *dst, const struct fid_av_set *src);
+	int (*insert)(struct fid_av_set *set, fi_addr_t addr);
+	int (*remove)(struct fid_av_set *set, fi_addr_t addr);
+	int (*addr)(struct fid_av_set *set, fi_addr_t *coll_addr);
 };
 
 struct fid_av_set {
-	struct fid		fid;
-	struct fi_ops_av_set	*ops;
+	struct fid fid;
+	struct fi_ops_av_set *ops;
 };
 
 struct fi_collective_attr {
-	enum fi_op 		op;
-	enum fi_datatype 	datatype;
-	struct fi_atomic_attr 	datatype_attr;
-	size_t 			max_members;
-	uint64_t 		mode;
+	enum fi_op op;
+	enum fi_datatype datatype;
+	struct fi_atomic_attr datatype_attr;
+	size_t max_members;
+	uint64_t mode;
 };
 
 struct fi_collective_addr {
-	const struct fid_av_set	*set;
-	fi_addr_t		coll_addr;
+	const struct fid_av_set *set;
+	fi_addr_t coll_addr;
 };
 
 struct fi_msg_collective {
-	const struct fi_ioc	*msg_iov;
-	void			**desc;
-	size_t			iov_count;
-	fi_addr_t		coll_addr;
-	fi_addr_t		root_addr;
-	enum fi_collective_op	coll;
-	enum fi_datatype	datatype;
-	enum fi_op		op;
-	void			*context;
+	const struct fi_ioc *msg_iov;
+	void **desc;
+	size_t iov_count;
+	fi_addr_t coll_addr;
+	fi_addr_t root_addr;
+	enum fi_collective_op coll;
+	enum fi_datatype datatype;
+	enum fi_op op;
+	void *context;
 };
 
 struct fi_ops_collective {
-	size_t	size;
+	size_t size;
 
-	ssize_t	(*barrier)(struct fid_ep *ep, fi_addr_t coll_addr, void *context);
-	ssize_t	(*broadcast)(struct fid_ep *ep,
-			void *buf, size_t count, void *desc,
-			fi_addr_t coll_addr, fi_addr_t root_addr,
-			enum fi_datatype datatype, uint64_t flags, void *context);
-	ssize_t	(*alltoall)(struct fid_ep *ep,
-			const void *buf, size_t count, void *desc,
-			void *result, void *result_desc, fi_addr_t coll_addr,
-			enum fi_datatype datatype, uint64_t flags, void *context);
-	ssize_t	(*allreduce)(struct fid_ep *ep,
-			const void *buf, size_t count, void *desc,
-			void *result, void *result_desc, fi_addr_t coll_addr,
-			enum fi_datatype datatype, enum fi_op op,
-			uint64_t flags, void *context);
-	ssize_t	(*allgather)(struct fid_ep *ep,
-			const void *buf, size_t count, void *desc,
-			void *result, void *result_desc, fi_addr_t coll_addr,
-			enum fi_datatype datatype, uint64_t flags, void *context);
-	ssize_t	(*reduce_scatter)(struct fid_ep *ep,
-			const void *buf, size_t count, void *desc,
-			void *result, void *result_desc, fi_addr_t coll_addr,
-			enum fi_datatype datatype, enum fi_op op,
-			uint64_t flags, void *context);
-	ssize_t	(*reduce)(struct fid_ep *ep,
-			const void *buf, size_t count, void *desc,
-			void *result, void *result_desc, fi_addr_t coll_addr,
-			fi_addr_t root_addr, enum fi_datatype datatype, enum fi_op op,
-			uint64_t flags, void *context);
-	ssize_t	(*scatter)(struct fid_ep *ep,
-			const void *buf, size_t count, void *desc,
-			void *result, void *result_desc,
-			fi_addr_t coll_addr, fi_addr_t root_addr,
-			enum fi_datatype datatype, uint64_t flags, void *context);
-	ssize_t	(*gather)(struct fid_ep *ep,
-			const void *buf, size_t count, void *desc,
-			void *result, void *result_desc,
-			fi_addr_t coll_addr, fi_addr_t root_addr,
-			enum fi_datatype datatype, uint64_t flags, void *context);
-	ssize_t	(*msg)(struct fid_ep *ep,
-			const struct fi_msg_collective *msg,
-			struct fi_ioc *resultv, void **result_desc,
-			size_t result_count, uint64_t flags);
-	ssize_t	(*barrier2)(struct fid_ep *ep, fi_addr_t coll_addr, uint64_t flags,
-			void *context);
+	ssize_t (*barrier)(struct fid_ep *ep, fi_addr_t coll_addr,
+			   void *context);
+	ssize_t (*broadcast)(struct fid_ep *ep, void *buf, size_t count,
+			     void *desc, fi_addr_t coll_addr,
+			     fi_addr_t root_addr, enum fi_datatype datatype,
+			     uint64_t flags, void *context);
+	ssize_t (*alltoall)(struct fid_ep *ep, const void *buf, size_t count,
+			    void *desc, void *result, void *result_desc,
+			    fi_addr_t coll_addr, enum fi_datatype datatype,
+			    uint64_t flags, void *context);
+	ssize_t (*allreduce)(struct fid_ep *ep, const void *buf, size_t count,
+			     void *desc, void *result, void *result_desc,
+			     fi_addr_t coll_addr, enum fi_datatype datatype,
+			     enum fi_op op, uint64_t flags, void *context);
+	ssize_t (*allgather)(struct fid_ep *ep, const void *buf, size_t count,
+			     void *desc, void *result, void *result_desc,
+			     fi_addr_t coll_addr, enum fi_datatype datatype,
+			     uint64_t flags, void *context);
+	ssize_t (*reduce_scatter)(struct fid_ep *ep, const void *buf,
+				  size_t count, void *desc, void *result,
+				  void *result_desc, fi_addr_t coll_addr,
+				  enum fi_datatype datatype, enum fi_op op,
+				  uint64_t flags, void *context);
+	ssize_t (*reduce)(struct fid_ep *ep, const void *buf, size_t count,
+			  void *desc, void *result, void *result_desc,
+			  fi_addr_t coll_addr, fi_addr_t root_addr,
+			  enum fi_datatype datatype, enum fi_op op,
+			  uint64_t flags, void *context);
+	ssize_t (*scatter)(struct fid_ep *ep, const void *buf, size_t count,
+			   void *desc, void *result, void *result_desc,
+			   fi_addr_t coll_addr, fi_addr_t root_addr,
+			   enum fi_datatype datatype, uint64_t flags,
+			   void *context);
+	ssize_t (*gather)(struct fid_ep *ep, const void *buf, size_t count,
+			  void *desc, void *result, void *result_desc,
+			  fi_addr_t coll_addr, fi_addr_t root_addr,
+			  enum fi_datatype datatype, uint64_t flags,
+			  void *context);
+	ssize_t (*msg)(struct fid_ep *ep, const struct fi_msg_collective *msg,
+		       struct fi_ioc *resultv, void **result_desc,
+		       size_t result_count, uint64_t flags);
+	ssize_t (*barrier2)(struct fid_ep *ep, fi_addr_t coll_addr,
+			    uint64_t flags, void *context);
 };
-
 
 #ifdef FABRIC_DIRECT
 #include <rdma/fi_direct_collective.h>
@@ -145,54 +139,51 @@ struct fi_ops_collective {
 
 #ifndef FABRIC_DIRECT_COLLECTIVE
 
-static inline int
-fi_av_set(struct fid_av *av, struct fi_av_set_attr *attr,
-	  struct fid_av_set **set, void * context)
+static inline int fi_av_set(struct fid_av *av, struct fi_av_set_attr *attr,
+			    struct fid_av_set **set, void *context)
 {
 	return FI_CHECK_OP(av->ops, struct fi_ops_av, av_set) ?
-		av->ops->av_set(av, attr, set, context) : -FI_ENOSYS;
+		       av->ops->av_set(av, attr, set, context) :
+		       -FI_ENOSYS;
 }
 
-static inline int
-fi_av_set_union(struct fid_av_set *dst, const struct fid_av_set *src)
+static inline int fi_av_set_union(struct fid_av_set *dst,
+				  const struct fid_av_set *src)
 {
 	return dst->ops->set_union(dst, src);
 }
 
-static inline int
-fi_av_set_intersect(struct fid_av_set *dst, const struct fid_av_set *src)
+static inline int fi_av_set_intersect(struct fid_av_set *dst,
+				      const struct fid_av_set *src)
 {
 	return dst->ops->intersect(dst, src);
 }
 
-static inline int
-fi_av_set_diff(struct fid_av_set *dst, const struct fid_av_set *src)
+static inline int fi_av_set_diff(struct fid_av_set *dst,
+				 const struct fid_av_set *src)
 {
 	return dst->ops->diff(dst, src);
 }
 
-static inline int
-fi_av_set_insert(struct fid_av_set *set, fi_addr_t addr)
+static inline int fi_av_set_insert(struct fid_av_set *set, fi_addr_t addr)
 {
 	return set->ops->insert(set, addr);
 }
 
-static inline int
-fi_av_set_remove(struct fid_av_set *set, fi_addr_t addr)
+static inline int fi_av_set_remove(struct fid_av_set *set, fi_addr_t addr)
 {
 	return set->ops->remove(set, addr);
 }
 
-static inline int
-fi_av_set_addr(struct fid_av_set *set, fi_addr_t *coll_addr)
+static inline int fi_av_set_addr(struct fid_av_set *set, fi_addr_t *coll_addr)
 {
 	return set->ops->addr(set, coll_addr);
 }
 
-static inline int
-fi_join_collective(struct fid_ep *ep, fi_addr_t coll_addr,
-		   const struct fid_av_set *set,
-		   uint64_t flags, struct fid_mc **mc, void *context)
+static inline int fi_join_collective(struct fid_ep *ep, fi_addr_t coll_addr,
+				     const struct fid_av_set *set,
+				     uint64_t flags, struct fid_mc **mc,
+				     void *context)
 {
 	struct fi_collective_addr addr;
 
@@ -201,109 +192,120 @@ fi_join_collective(struct fid_ep *ep, fi_addr_t coll_addr,
 	return fi_join(ep, &addr, flags | FI_COLLECTIVE, mc, context);
 }
 
-static inline ssize_t
-fi_barrier(struct fid_ep *ep, fi_addr_t coll_addr, void *context)
+static inline ssize_t fi_barrier(struct fid_ep *ep, fi_addr_t coll_addr,
+				 void *context)
 {
 	return ep->collective->barrier(ep, coll_addr, context);
 }
 
-static inline ssize_t
-fi_barrier2(struct fid_ep *ep, fi_addr_t coll_addr, uint64_t flags, void *context)
+static inline ssize_t fi_barrier2(struct fid_ep *ep, fi_addr_t coll_addr,
+				  uint64_t flags, void *context)
 {
 	if (!flags)
 		return fi_barrier(ep, coll_addr, context);
 
 	return FI_CHECK_OP(ep->collective, struct fi_ops_collective, barrier2) ?
-		ep->collective->barrier2(ep, coll_addr, flags, context) :
-		-FI_ENOSYS;
+		       ep->collective->barrier2(ep, coll_addr, flags, context) :
+		       -FI_ENOSYS;
 }
 
-static inline ssize_t
-fi_broadcast(struct fid_ep *ep, void *buf, size_t count, void *desc,
-	     fi_addr_t coll_addr, fi_addr_t root_addr,
-	     enum fi_datatype datatype, uint64_t flags, void *context)
+static inline ssize_t fi_broadcast(struct fid_ep *ep, void *buf, size_t count,
+				   void *desc, fi_addr_t coll_addr,
+				   fi_addr_t root_addr,
+				   enum fi_datatype datatype, uint64_t flags,
+				   void *context)
 {
-	return ep->collective->broadcast(ep, buf, count, desc,
-		coll_addr, root_addr, datatype, flags, context);
+	return ep->collective->broadcast(ep, buf, count, desc, coll_addr,
+					 root_addr, datatype, flags, context);
 }
 
-static inline ssize_t
-fi_alltoall(struct fid_ep *ep, const void *buf, size_t count, void *desc,
-	    void *result, void *result_desc,
-	    fi_addr_t coll_addr, enum fi_datatype datatype,
-	    uint64_t flags, void *context)
+static inline ssize_t fi_alltoall(struct fid_ep *ep, const void *buf,
+				  size_t count, void *desc, void *result,
+				  void *result_desc, fi_addr_t coll_addr,
+				  enum fi_datatype datatype, uint64_t flags,
+				  void *context)
 {
-	return ep->collective->alltoall(ep, buf, count, desc,
-		result, result_desc, coll_addr, datatype, flags, context);
+	return ep->collective->alltoall(ep, buf, count, desc, result,
+					result_desc, coll_addr, datatype, flags,
+					context);
 }
 
-static inline ssize_t
-fi_allreduce(struct fid_ep *ep, const void *buf, size_t count, void *desc,
-	     void *result, void *result_desc, fi_addr_t coll_addr,
-	     enum fi_datatype datatype, enum fi_op op,
-	     uint64_t flags, void *context)
+static inline ssize_t fi_allreduce(struct fid_ep *ep, const void *buf,
+				   size_t count, void *desc, void *result,
+				   void *result_desc, fi_addr_t coll_addr,
+				   enum fi_datatype datatype, enum fi_op op,
+				   uint64_t flags, void *context)
 {
-	return ep->collective->allreduce(ep, buf, count, desc,
-		result, result_desc, coll_addr, datatype, op, flags, context);
+	return ep->collective->allreduce(ep, buf, count, desc, result,
+					 result_desc, coll_addr, datatype, op,
+					 flags, context);
 }
 
-static inline ssize_t
-fi_allgather(struct fid_ep *ep, const void *buf, size_t count, void *desc,
-	     void *result, void *result_desc, fi_addr_t coll_addr,
-	     enum fi_datatype datatype, uint64_t flags, void *context)
+static inline ssize_t fi_allgather(struct fid_ep *ep, const void *buf,
+				   size_t count, void *desc, void *result,
+				   void *result_desc, fi_addr_t coll_addr,
+				   enum fi_datatype datatype, uint64_t flags,
+				   void *context)
 {
-	return ep->collective->allgather(ep, buf, count, desc,
-		result, result_desc, coll_addr, datatype, flags, context);
+	return ep->collective->allgather(ep, buf, count, desc, result,
+					 result_desc, coll_addr, datatype,
+					 flags, context);
 }
 
-static inline ssize_t
-fi_reduce_scatter(struct fid_ep *ep, const void *buf, size_t count, void *desc,
-		  void *result, void *result_desc, fi_addr_t coll_addr,
-		  enum fi_datatype datatype, enum fi_op op,
-		  uint64_t flags, void *context)
+static inline ssize_t fi_reduce_scatter(struct fid_ep *ep, const void *buf,
+					size_t count, void *desc, void *result,
+					void *result_desc, fi_addr_t coll_addr,
+					enum fi_datatype datatype,
+					enum fi_op op, uint64_t flags,
+					void *context)
 {
-	return ep->collective->reduce_scatter(ep, buf, count, desc,
-		result, result_desc, coll_addr, datatype, op, flags, context);
+	return ep->collective->reduce_scatter(ep, buf, count, desc, result,
+					      result_desc, coll_addr, datatype,
+					      op, flags, context);
 }
 
-static inline ssize_t
-fi_reduce(struct fid_ep *ep, const void *buf, size_t count, void *desc,
-	  void *result, void *result_desc, fi_addr_t coll_addr,
-	  fi_addr_t root_addr, enum fi_datatype datatype, enum fi_op op,
-	  uint64_t flags, void *context)
+static inline ssize_t fi_reduce(struct fid_ep *ep, const void *buf,
+				size_t count, void *desc, void *result,
+				void *result_desc, fi_addr_t coll_addr,
+				fi_addr_t root_addr, enum fi_datatype datatype,
+				enum fi_op op, uint64_t flags, void *context)
 {
 	return ep->collective->reduce(ep, buf, count, desc, result, result_desc,
-		coll_addr, root_addr, datatype, op, flags, context);
+				      coll_addr, root_addr, datatype, op, flags,
+				      context);
 }
 
-
-static inline ssize_t
-fi_scatter(struct fid_ep *ep, const void *buf, size_t count, void *desc,
-	   void *result, void *result_desc, fi_addr_t coll_addr,
-	   fi_addr_t root_addr, enum fi_datatype datatype,
-	   uint64_t flags, void *context)
+static inline ssize_t fi_scatter(struct fid_ep *ep, const void *buf,
+				 size_t count, void *desc, void *result,
+				 void *result_desc, fi_addr_t coll_addr,
+				 fi_addr_t root_addr, enum fi_datatype datatype,
+				 uint64_t flags, void *context)
 {
-	return ep->collective->scatter(ep, buf, count, desc, result, result_desc,
-		coll_addr, root_addr, datatype, flags, context);
+	return ep->collective->scatter(ep, buf, count, desc, result,
+				       result_desc, coll_addr, root_addr,
+				       datatype, flags, context);
 }
 
-
-static inline ssize_t
-fi_gather(struct fid_ep *ep, const void *buf, size_t count, void *desc,
-	  void *result, void *result_desc, fi_addr_t coll_addr,
-	  fi_addr_t root_addr, enum fi_datatype datatype,
-	  uint64_t flags, void *context)
+static inline ssize_t fi_gather(struct fid_ep *ep, const void *buf,
+				size_t count, void *desc, void *result,
+				void *result_desc, fi_addr_t coll_addr,
+				fi_addr_t root_addr, enum fi_datatype datatype,
+				uint64_t flags, void *context)
 {
 	return ep->collective->gather(ep, buf, count, desc, result, result_desc,
-		coll_addr, root_addr, datatype, flags, context);
+				      coll_addr, root_addr, datatype, flags,
+				      context);
 }
 
-static inline
-int fi_query_collective(struct fid_domain *domain, enum fi_collective_op coll,
-			struct fi_collective_attr *attr, uint64_t flags)
+static inline int fi_query_collective(struct fid_domain *domain,
+				      enum fi_collective_op coll,
+				      struct fi_collective_attr *attr,
+				      uint64_t flags)
 {
-	return FI_CHECK_OP(domain->ops, struct fi_ops_domain, query_collective) ?
-		       domain->ops->query_collective(domain, coll, attr, flags) :
+	return FI_CHECK_OP(domain->ops, struct fi_ops_domain,
+			   query_collective) ?
+		       domain->ops->query_collective(domain, coll, attr,
+						     flags) :
 		       -FI_ENOSYS;
 }
 

--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -38,77 +38,74 @@
 #include <rdma/fabric.h>
 #include <rdma/fi_eq.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
-
 
 /*
  * AV = Address Vector
  * Maps and stores transport/network addresses.
  */
 
-#define FI_SYMMETRIC		(1ULL << 59)
-#define FI_SYNC_ERR		(1ULL << 58)
-#define FI_UNIVERSE		(1ULL << 57)
-#define FI_BARRIER_SET		(1ULL << 40)
-#define FI_BROADCAST_SET	(1ULL << 41)
-#define FI_ALLTOALL_SET		(1ULL << 42)
-#define FI_ALLREDUCE_SET	(1ULL << 43)
-#define FI_ALLGATHER_SET	(1ULL << 44)
-#define FI_REDUCE_SCATTER_SET	(1ULL << 45)
-#define FI_REDUCE_SET		(1ULL << 46)
-#define FI_SCATTER_SET		(1ULL << 47)
-#define FI_GATHER_SET		(1ULL << 48)
+#define FI_SYMMETRIC (1ULL << 59)
+#define FI_SYNC_ERR (1ULL << 58)
+#define FI_UNIVERSE (1ULL << 57)
+#define FI_BARRIER_SET (1ULL << 40)
+#define FI_BROADCAST_SET (1ULL << 41)
+#define FI_ALLTOALL_SET (1ULL << 42)
+#define FI_ALLREDUCE_SET (1ULL << 43)
+#define FI_ALLGATHER_SET (1ULL << 44)
+#define FI_REDUCE_SCATTER_SET (1ULL << 45)
+#define FI_REDUCE_SET (1ULL << 46)
+#define FI_SCATTER_SET (1ULL << 47)
+#define FI_GATHER_SET (1ULL << 48)
 
 struct fi_av_attr {
-	enum fi_av_type		type;
-	int			rx_ctx_bits;
-	size_t			count;
-	size_t			ep_per_node;
-	const char		*name;
-	void			*map_addr;
-	uint64_t		flags;
+	enum fi_av_type type;
+	int rx_ctx_bits;
+	size_t count;
+	size_t ep_per_node;
+	const char *name;
+	void *map_addr;
+	uint64_t flags;
 };
 
 struct fi_av_set_attr {
-	size_t			count;
-	fi_addr_t		start_addr;
-	fi_addr_t		end_addr;
-	uint64_t		stride;
-	size_t			comm_key_size;
-	uint8_t			*comm_key;
-	uint64_t		flags;
+	size_t count;
+	fi_addr_t start_addr;
+	fi_addr_t end_addr;
+	uint64_t stride;
+	size_t comm_key_size;
+	uint8_t *comm_key;
+	uint64_t flags;
 };
 
 struct fid_av_set;
 
 struct fi_ops_av {
-	size_t	size;
-	int	(*insert)(struct fid_av *av, const void *addr, size_t count,
-			fi_addr_t *fi_addr, uint64_t flags, void *context);
-	int	(*insertsvc)(struct fid_av *av, const char *node,
-			const char *service, fi_addr_t *fi_addr,
-			uint64_t flags, void *context);
-	int	(*insertsym)(struct fid_av *av, const char *node, size_t nodecnt,
-			const char *service, size_t svccnt, fi_addr_t *fi_addr,
-			uint64_t flags, void *context);
-	int	(*remove)(struct fid_av *av, fi_addr_t *fi_addr, size_t count,
-			uint64_t flags);
-	int	(*lookup)(struct fid_av *av, fi_addr_t fi_addr, void *addr,
-			size_t *addrlen);
-	const char * (*straddr)(struct fid_av *av, const void *addr,
-			char *buf, size_t *len);
-	int	(*av_set)(struct fid_av *av, struct fi_av_set_attr *attr,
-			struct fid_av_set **av_set, void *context);
+	size_t size;
+	int (*insert)(struct fid_av *av, const void *addr, size_t count,
+		      fi_addr_t *fi_addr, uint64_t flags, void *context);
+	int (*insertsvc)(struct fid_av *av, const char *node,
+			 const char *service, fi_addr_t *fi_addr,
+			 uint64_t flags, void *context);
+	int (*insertsym)(struct fid_av *av, const char *node, size_t nodecnt,
+			 const char *service, size_t svccnt, fi_addr_t *fi_addr,
+			 uint64_t flags, void *context);
+	int (*remove)(struct fid_av *av, fi_addr_t *fi_addr, size_t count,
+		      uint64_t flags);
+	int (*lookup)(struct fid_av *av, fi_addr_t fi_addr, void *addr,
+		      size_t *addrlen);
+	const char *(*straddr)(struct fid_av *av, const void *addr, char *buf,
+			       size_t *len);
+	int (*av_set)(struct fid_av *av, struct fi_av_set_attr *attr,
+		      struct fid_av_set **av_set, void *context);
 };
 
 struct fid_av {
-	struct fid		fid;
-	struct fi_ops_av	*ops;
+	struct fid fid;
+	struct fi_ops_av *ops;
 };
-
 
 /*
  * MR = Memory Region
@@ -116,13 +113,13 @@ struct fid_av {
  * but also for local access until we can remove that need.
  */
 struct fid_mr {
-	struct fid		fid;
-	void			*mem_desc;
-	uint64_t		key;
+	struct fid fid;
+	void *mem_desc;
+	uint64_t key;
 };
 
 enum fi_hmem_iface {
-	FI_HMEM_SYSTEM	= 0,
+	FI_HMEM_SYSTEM = 0,
 	FI_HMEM_CUDA,
 	FI_HMEM_ROCR,
 	FI_HMEM_ZE,
@@ -131,35 +128,35 @@ enum fi_hmem_iface {
 };
 
 struct fi_mr_attr {
-	const struct iovec	*mr_iov;
-	size_t			iov_count;
-	uint64_t		access;
-	uint64_t		offset;
-	uint64_t		requested_key;
-	void			*context;
-	size_t			auth_key_size;
-	uint8_t			*auth_key;
-	enum fi_hmem_iface	iface;
+	const struct iovec *mr_iov;
+	size_t iov_count;
+	uint64_t access;
+	uint64_t offset;
+	uint64_t requested_key;
+	void *context;
+	size_t auth_key_size;
+	uint8_t *auth_key;
+	enum fi_hmem_iface iface;
 	union {
-		uint64_t	reserved;
-		int		cuda;
-		int		ze;
-		int		neuron;
-		int		synapseai;
+		uint64_t reserved;
+		int cuda;
+		int ze;
+		int neuron;
+		int synapseai;
 	} device;
 };
 
 struct fi_mr_modify {
-	uint64_t		flags;
-	struct fi_mr_attr	attr;
+	uint64_t flags;
+	struct fi_mr_attr attr;
 };
 
 #define FI_SET_OPS_HMEM_OVERRIDE "hmem_override_ops"
 
 struct fi_hmem_override_ops {
-	size_t	size;
+	size_t size;
 
-	ssize_t	(*copy_from_hmem_iov)(void *dest, size_t size,
+	ssize_t (*copy_from_hmem_iov)(void *dest, size_t size,
 				      enum fi_hmem_iface iface, uint64_t device,
 				      const struct iovec *hmem_iov,
 				      size_t hmem_iov_count,
@@ -253,149 +250,143 @@ enum fi_collective_op {
 
 #endif
 
-
 struct fi_atomic_attr;
 struct fi_cq_attr;
 struct fi_cntr_attr;
 struct fi_collective_attr;
 
 struct fi_ops_domain {
-	size_t	size;
-	int	(*av_open)(struct fid_domain *domain, struct fi_av_attr *attr,
-			struct fid_av **av, void *context);
-	int	(*cq_open)(struct fid_domain *domain, struct fi_cq_attr *attr,
-			struct fid_cq **cq, void *context);
-	int	(*endpoint)(struct fid_domain *domain, struct fi_info *info,
+	size_t size;
+	int (*av_open)(struct fid_domain *domain, struct fi_av_attr *attr,
+		       struct fid_av **av, void *context);
+	int (*cq_open)(struct fid_domain *domain, struct fi_cq_attr *attr,
+		       struct fid_cq **cq, void *context);
+	int (*endpoint)(struct fid_domain *domain, struct fi_info *info,
 			struct fid_ep **ep, void *context);
-	int	(*scalable_ep)(struct fid_domain *domain, struct fi_info *info,
-			struct fid_ep **sep, void *context);
-	int	(*cntr_open)(struct fid_domain *domain, struct fi_cntr_attr *attr,
-			struct fid_cntr **cntr, void *context);
-	int	(*poll_open)(struct fid_domain *domain, struct fi_poll_attr *attr,
-			struct fid_poll **pollset);
-	int	(*stx_ctx)(struct fid_domain *domain,
-			struct fi_tx_attr *attr, struct fid_stx **stx,
-			void *context);
-	int	(*srx_ctx)(struct fid_domain *domain,
-			struct fi_rx_attr *attr, struct fid_ep **rx_ep,
-			void *context);
-	int	(*query_atomic)(struct fid_domain *domain,
-			enum fi_datatype datatype, enum fi_op op,
-			struct fi_atomic_attr *attr, uint64_t flags);
-	int	(*query_collective)(struct fid_domain *domain,
-			enum fi_collective_op coll,
-			struct fi_collective_attr *attr, uint64_t flags);
-	int	(*endpoint2)(struct fid_domain *domain, struct fi_info *info,
-			struct fid_ep **ep, uint64_t flags, void *context);
+	int (*scalable_ep)(struct fid_domain *domain, struct fi_info *info,
+			   struct fid_ep **sep, void *context);
+	int (*cntr_open)(struct fid_domain *domain, struct fi_cntr_attr *attr,
+			 struct fid_cntr **cntr, void *context);
+	int (*poll_open)(struct fid_domain *domain, struct fi_poll_attr *attr,
+			 struct fid_poll **pollset);
+	int (*stx_ctx)(struct fid_domain *domain, struct fi_tx_attr *attr,
+		       struct fid_stx **stx, void *context);
+	int (*srx_ctx)(struct fid_domain *domain, struct fi_rx_attr *attr,
+		       struct fid_ep **rx_ep, void *context);
+	int (*query_atomic)(struct fid_domain *domain,
+			    enum fi_datatype datatype, enum fi_op op,
+			    struct fi_atomic_attr *attr, uint64_t flags);
+	int (*query_collective)(struct fid_domain *domain,
+				enum fi_collective_op coll,
+				struct fi_collective_attr *attr,
+				uint64_t flags);
+	int (*endpoint2)(struct fid_domain *domain, struct fi_info *info,
+			 struct fid_ep **ep, uint64_t flags, void *context);
 };
 
 /* Memory registration flags */
 /* #define FI_RMA_EVENT		(1ULL << 56) */
 
 struct fi_ops_mr {
-	size_t	size;
-	int	(*reg)(struct fid *fid, const void *buf, size_t len,
-			uint64_t access, uint64_t offset, uint64_t requested_key,
-			uint64_t flags, struct fid_mr **mr, void *context);
-	int	(*regv)(struct fid *fid, const struct iovec *iov,
-			size_t count, uint64_t access,
-			uint64_t offset, uint64_t requested_key,
-			uint64_t flags, struct fid_mr **mr, void *context);
-	int	(*regattr)(struct fid *fid, const struct fi_mr_attr *attr,
-			uint64_t flags, struct fid_mr **mr);
+	size_t size;
+	int (*reg)(struct fid *fid, const void *buf, size_t len,
+		   uint64_t access, uint64_t offset, uint64_t requested_key,
+		   uint64_t flags, struct fid_mr **mr, void *context);
+	int (*regv)(struct fid *fid, const struct iovec *iov, size_t count,
+		    uint64_t access, uint64_t offset, uint64_t requested_key,
+		    uint64_t flags, struct fid_mr **mr, void *context);
+	int (*regattr)(struct fid *fid, const struct fi_mr_attr *attr,
+		       uint64_t flags, struct fid_mr **mr);
 };
 
 /* Domain bind flags */
-#define FI_REG_MR		(1ULL << 59)
+#define FI_REG_MR (1ULL << 59)
 
 struct fid_domain {
-	struct fid		fid;
-	struct fi_ops_domain	*ops;
-	struct fi_ops_mr	*mr;
+	struct fid fid;
+	struct fi_ops_domain *ops;
+	struct fi_ops_mr *mr;
 };
-
 
 #ifdef FABRIC_DIRECT
 #include <rdma/fi_direct_domain.h>
-#endif	/* FABRIC_DIRECT */
+#endif /* FABRIC_DIRECT */
 
 #ifndef FABRIC_DIRECT_DOMAIN
 
-static inline int
-fi_domain(struct fid_fabric *fabric, struct fi_info *info,
-	   struct fid_domain **domain, void *context)
+static inline int fi_domain(struct fid_fabric *fabric, struct fi_info *info,
+			    struct fid_domain **domain, void *context)
 {
 	return fabric->ops->domain(fabric, info, domain, context);
 }
 
-static inline int
-fi_domain2(struct fid_fabric *fabric, struct fi_info *info,
-	   struct fid_domain **domain, uint64_t flags, void *context)
+static inline int fi_domain2(struct fid_fabric *fabric, struct fi_info *info,
+			     struct fid_domain **domain, uint64_t flags,
+			     void *context)
 {
 	if (!flags)
 		return fi_domain(fabric, info, domain, context);
 
 	return FI_CHECK_OP(fabric->ops, struct fi_ops_fabric, domain2) ?
-		fabric->ops->domain2(fabric, info, domain, flags, context) :
-		-FI_ENOSYS;
+		       fabric->ops->domain2(fabric, info, domain, flags,
+					    context) :
+		       -FI_ENOSYS;
 }
 
-static inline int
-fi_domain_bind(struct fid_domain *domain, struct fid *fid, uint64_t flags)
+static inline int fi_domain_bind(struct fid_domain *domain, struct fid *fid,
+				 uint64_t flags)
 {
 	return domain->fid.ops->bind(&domain->fid, fid, flags);
 }
 
-static inline int
-fi_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
-	   struct fid_cq **cq, void *context)
+static inline int fi_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
+			     struct fid_cq **cq, void *context)
 {
 	return domain->ops->cq_open(domain, attr, cq, context);
 }
 
-static inline int
-fi_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
-	      struct fid_cntr **cntr, void *context)
+static inline int fi_cntr_open(struct fid_domain *domain,
+			       struct fi_cntr_attr *attr,
+			       struct fid_cntr **cntr, void *context)
 {
 	return domain->ops->cntr_open(domain, attr, cntr, context);
 }
 
-static inline int
-fi_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
-	     struct fid_wait **waitset)
+static inline int fi_wait_open(struct fid_fabric *fabric,
+			       struct fi_wait_attr *attr,
+			       struct fid_wait **waitset)
 {
 	return fabric->ops->wait_open(fabric, attr, waitset);
 }
 
-static inline int
-fi_poll_open(struct fid_domain *domain, struct fi_poll_attr *attr,
-	     struct fid_poll **pollset)
+static inline int fi_poll_open(struct fid_domain *domain,
+			       struct fi_poll_attr *attr,
+			       struct fid_poll **pollset)
 {
 	return domain->ops->poll_open(domain, attr, pollset);
 }
 
-static inline int
-fi_mr_reg(struct fid_domain *domain, const void *buf, size_t len,
-	  uint64_t acs, uint64_t offset, uint64_t requested_key,
-	  uint64_t flags, struct fid_mr **mr, void *context)
+static inline int fi_mr_reg(struct fid_domain *domain, const void *buf,
+			    size_t len, uint64_t acs, uint64_t offset,
+			    uint64_t requested_key, uint64_t flags,
+			    struct fid_mr **mr, void *context)
 {
 	return domain->mr->reg(&domain->fid, buf, len, acs, offset,
 			       requested_key, flags, mr, context);
 }
 
-static inline int
-fi_mr_regv(struct fid_domain *domain, const struct iovec *iov,
-			size_t count, uint64_t acs,
-			uint64_t offset, uint64_t requested_key,
-			uint64_t flags, struct fid_mr **mr, void *context)
+static inline int fi_mr_regv(struct fid_domain *domain, const struct iovec *iov,
+			     size_t count, uint64_t acs, uint64_t offset,
+			     uint64_t requested_key, uint64_t flags,
+			     struct fid_mr **mr, void *context)
 {
-	return domain->mr->regv(&domain->fid, iov, count, acs,
-			offset, requested_key, flags, mr, context);
+	return domain->mr->regv(&domain->fid, iov, count, acs, offset,
+				requested_key, flags, mr, context);
 }
 
-static inline int
-fi_mr_regattr(struct fid_domain *domain, const struct fi_mr_attr *attr,
-			uint64_t flags, struct fid_mr **mr)
+static inline int fi_mr_regattr(struct fid_domain *domain,
+				const struct fi_mr_attr *attr, uint64_t flags,
+				struct fid_mr **mr)
 {
 	return domain->mr->regattr(&domain->fid, attr, flags, mr);
 }
@@ -410,9 +401,9 @@ static inline uint64_t fi_mr_key(struct fid_mr *mr)
 	return mr->key;
 }
 
-static inline int
-fi_mr_raw_attr(struct fid_mr *mr, uint64_t *base_addr,
-	       uint8_t *raw_key, size_t *key_size, uint64_t flags)
+static inline int fi_mr_raw_attr(struct fid_mr *mr, uint64_t *base_addr,
+				 uint8_t *raw_key, size_t *key_size,
+				 uint64_t flags)
 {
 	struct fi_mr_raw_attr attr;
 	attr.flags = flags;
@@ -422,9 +413,9 @@ fi_mr_raw_attr(struct fid_mr *mr, uint64_t *base_addr,
 	return mr->fid.ops->control(&mr->fid, FI_GET_RAW_MR, &attr);
 }
 
-static inline int
-fi_mr_map_raw(struct fid_domain *domain, uint64_t base_addr,
-	      uint8_t *raw_key, size_t key_size, uint64_t *key, uint64_t flags)
+static inline int fi_mr_map_raw(struct fid_domain *domain, uint64_t base_addr,
+				uint8_t *raw_key, size_t key_size,
+				uint64_t *key, uint64_t flags)
 {
 	struct fi_mr_map_raw map;
 	map.flags = flags;
@@ -435,20 +426,19 @@ fi_mr_map_raw(struct fid_domain *domain, uint64_t base_addr,
 	return domain->fid.ops->control(&domain->fid, FI_MAP_RAW_MR, &map);
 }
 
-static inline int
-fi_mr_unmap_key(struct fid_domain *domain, uint64_t key)
+static inline int fi_mr_unmap_key(struct fid_domain *domain, uint64_t key)
 {
 	return domain->fid.ops->control(&domain->fid, FI_UNMAP_KEY, &key);
 }
 
-static inline int fi_mr_bind(struct fid_mr *mr, struct fid *bfid, uint64_t flags)
+static inline int fi_mr_bind(struct fid_mr *mr, struct fid *bfid,
+			     uint64_t flags)
 {
 	return mr->fid.ops->bind(&mr->fid, bfid, flags);
 }
 
-static inline int
-fi_mr_refresh(struct fid_mr *mr, const struct iovec *iov, size_t count,
-	      uint64_t flags)
+static inline int fi_mr_refresh(struct fid_mr *mr, const struct iovec *iov,
+				size_t count, uint64_t flags)
 {
 	struct fi_mr_modify modify;
 	memset(&modify, 0, sizeof(modify));
@@ -463,64 +453,63 @@ static inline int fi_mr_enable(struct fid_mr *mr)
 	return mr->fid.ops->control(&mr->fid, FI_ENABLE, NULL);
 }
 
-static inline int
-fi_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
-	   struct fid_av **av, void *context)
+static inline int fi_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
+			     struct fid_av **av, void *context)
 {
 	return domain->ops->av_open(domain, attr, av, context);
 }
 
-static inline int
-fi_av_bind(struct fid_av *av, struct fid *fid, uint64_t flags)
+static inline int fi_av_bind(struct fid_av *av, struct fid *fid, uint64_t flags)
 {
 	return av->fid.ops->bind(&av->fid, fid, flags);
 }
 
-static inline int
-fi_av_insert(struct fid_av *av, const void *addr, size_t count,
-	     fi_addr_t *fi_addr, uint64_t flags, void *context)
+static inline int fi_av_insert(struct fid_av *av, const void *addr,
+			       size_t count, fi_addr_t *fi_addr, uint64_t flags,
+			       void *context)
 {
 	return av->ops->insert(av, addr, count, fi_addr, flags, context);
 }
 
-static inline int
-fi_av_insertsvc(struct fid_av *av, const char *node, const char *service,
-		fi_addr_t *fi_addr, uint64_t flags, void *context)
+static inline int fi_av_insertsvc(struct fid_av *av, const char *node,
+				  const char *service, fi_addr_t *fi_addr,
+				  uint64_t flags, void *context)
 {
 	return av->ops->insertsvc(av, node, service, fi_addr, flags, context);
 }
 
-static inline int
-fi_av_insertsym(struct fid_av *av, const char *node, size_t nodecnt,
-		const char *service, size_t svccnt,
-		fi_addr_t *fi_addr, uint64_t flags, void *context)
+static inline int fi_av_insertsym(struct fid_av *av, const char *node,
+				  size_t nodecnt, const char *service,
+				  size_t svccnt, fi_addr_t *fi_addr,
+				  uint64_t flags, void *context)
 {
-	return av->ops->insertsym(av, node, nodecnt, service, svccnt,
-			fi_addr, flags, context);
+	return av->ops->insertsym(av, node, nodecnt, service, svccnt, fi_addr,
+				  flags, context);
 }
 
-static inline int
-fi_av_remove(struct fid_av *av, fi_addr_t *fi_addr, size_t count, uint64_t flags)
+static inline int fi_av_remove(struct fid_av *av, fi_addr_t *fi_addr,
+			       size_t count, uint64_t flags)
 {
 	return av->ops->remove(av, fi_addr, count, flags);
 }
 
-static inline int
-fi_av_lookup(struct fid_av *av, fi_addr_t fi_addr, void *addr, size_t *addrlen)
+static inline int fi_av_lookup(struct fid_av *av, fi_addr_t fi_addr, void *addr,
+			       size_t *addrlen)
 {
-        return av->ops->lookup(av, fi_addr, addr, addrlen);
+	return av->ops->lookup(av, fi_addr, addr, addrlen);
 }
 
-static inline const char *
-fi_av_straddr(struct fid_av *av, const void *addr, char *buf, size_t *len)
+static inline const char *fi_av_straddr(struct fid_av *av, const void *addr,
+					char *buf, size_t *len)
 {
 	return av->ops->straddr(av, addr, buf, len);
 }
 
-static inline fi_addr_t
-fi_rx_addr(fi_addr_t fi_addr, int rx_index, int rx_ctx_bits)
+static inline fi_addr_t fi_rx_addr(fi_addr_t fi_addr, int rx_index,
+				   int rx_ctx_bits)
 {
-	return (fi_addr_t) (((uint64_t) rx_index << (64 - rx_ctx_bits)) | fi_addr);
+	return (fi_addr_t)(((uint64_t)rx_index << (64 - rx_ctx_bits)) |
+			   fi_addr);
 }
 
 #endif

--- a/include/rdma/fi_endpoint.h
+++ b/include/rdma/fi_endpoint.h
@@ -36,38 +36,34 @@
 #include <rdma/fabric.h>
 #include <rdma/fi_domain.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
 struct fi_msg {
-	const struct iovec	*msg_iov;
-	void			**desc;
-	size_t			iov_count;
-	fi_addr_t		addr;
-	void			*context;
-	uint64_t		data;
+	const struct iovec *msg_iov;
+	void **desc;
+	size_t iov_count;
+	fi_addr_t addr;
+	void *context;
+	uint64_t data;
 };
 
 /* Endpoint option levels */
-enum {
-	FI_OPT_ENDPOINT
-};
+enum { FI_OPT_ENDPOINT };
 
 /* FI_OPT_ENDPOINT option names */
 enum {
-	FI_OPT_MIN_MULTI_RECV,		/* size_t */
-	FI_OPT_CM_DATA_SIZE,		/* size_t */
-	FI_OPT_BUFFERED_MIN,		/* size_t */
-	FI_OPT_BUFFERED_LIMIT,		/* size_t */
+	FI_OPT_MIN_MULTI_RECV, /* size_t */
+	FI_OPT_CM_DATA_SIZE, /* size_t */
+	FI_OPT_BUFFERED_MIN, /* size_t */
+	FI_OPT_BUFFERED_LIMIT, /* size_t */
 	FI_OPT_SEND_BUF_SIZE,
 	FI_OPT_RECV_BUF_SIZE,
 	FI_OPT_TX_SIZE,
 	FI_OPT_RX_SIZE,
-	FI_OPT_FI_HMEM_P2P,		/* int */
-	FI_OPT_XPU_TRIGGER,		/* struct fi_trigger_xpu */
+	FI_OPT_FI_HMEM_P2P, /* int */
+	FI_OPT_XPU_TRIGGER, /* struct fi_trigger_xpu */
 };
 
 /*
@@ -75,49 +71,50 @@ enum {
  * support and FI_HMEM.
  */
 enum {
-	FI_HMEM_P2P_ENABLED,	/* Provider decides when to use P2P, default. */
-	FI_HMEM_P2P_REQUIRED,	/* Must use P2P for all transfers */
-	FI_HMEM_P2P_PREFERRED,	/* Should use P2P for all transfers if available */
-	FI_HMEM_P2P_DISABLED	/* Do not use P2P */
+	FI_HMEM_P2P_ENABLED, /* Provider decides when to use P2P, default. */
+	FI_HMEM_P2P_REQUIRED, /* Must use P2P for all transfers */
+	FI_HMEM_P2P_PREFERRED, /* Should use P2P for all transfers if available */
+	FI_HMEM_P2P_DISABLED /* Do not use P2P */
 };
 
 struct fi_ops_ep {
-	size_t	size;
-	ssize_t	(*cancel)(fid_t fid, void *context);
-	int	(*getopt)(fid_t fid, int level, int optname,
-			void *optval, size_t *optlen);
-	int	(*setopt)(fid_t fid, int level, int optname,
-			const void *optval, size_t optlen);
-	int	(*tx_ctx)(struct fid_ep *sep, int index,
-			struct fi_tx_attr *attr, struct fid_ep **tx_ep,
-			void *context);
-	int	(*rx_ctx)(struct fid_ep *sep, int index,
-			struct fi_rx_attr *attr, struct fid_ep **rx_ep,
-			void *context);
+	size_t size;
+	ssize_t (*cancel)(fid_t fid, void *context);
+	int (*getopt)(fid_t fid, int level, int optname, void *optval,
+		      size_t *optlen);
+	int (*setopt)(fid_t fid, int level, int optname, const void *optval,
+		      size_t optlen);
+	int (*tx_ctx)(struct fid_ep *sep, int index, struct fi_tx_attr *attr,
+		      struct fid_ep **tx_ep, void *context);
+	int (*rx_ctx)(struct fid_ep *sep, int index, struct fi_rx_attr *attr,
+		      struct fid_ep **rx_ep, void *context);
 	ssize_t (*rx_size_left)(struct fid_ep *ep);
 	ssize_t (*tx_size_left)(struct fid_ep *ep);
 };
 
 struct fi_ops_msg {
-	size_t	size;
+	size_t size;
 	ssize_t (*recv)(struct fid_ep *ep, void *buf, size_t len, void *desc,
 			fi_addr_t src_addr, void *context);
-	ssize_t (*recvv)(struct fid_ep *ep, const struct iovec *iov, void **desc,
-			size_t count, fi_addr_t src_addr, void *context);
+	ssize_t (*recvv)(struct fid_ep *ep, const struct iovec *iov,
+			 void **desc, size_t count, fi_addr_t src_addr,
+			 void *context);
 	ssize_t (*recvmsg)(struct fid_ep *ep, const struct fi_msg *msg,
-			uint64_t flags);
-	ssize_t (*send)(struct fid_ep *ep, const void *buf, size_t len, void *desc,
-			fi_addr_t dest_addr, void *context);
-	ssize_t (*sendv)(struct fid_ep *ep, const struct iovec *iov, void **desc,
-			size_t count, fi_addr_t dest_addr, void *context);
+			   uint64_t flags);
+	ssize_t (*send)(struct fid_ep *ep, const void *buf, size_t len,
+			void *desc, fi_addr_t dest_addr, void *context);
+	ssize_t (*sendv)(struct fid_ep *ep, const struct iovec *iov,
+			 void **desc, size_t count, fi_addr_t dest_addr,
+			 void *context);
 	ssize_t (*sendmsg)(struct fid_ep *ep, const struct fi_msg *msg,
-			uint64_t flags);
-	ssize_t	(*inject)(struct fid_ep *ep, const void *buf, size_t len,
-			fi_addr_t dest_addr);
-	ssize_t (*senddata)(struct fid_ep *ep, const void *buf, size_t len, void *desc,
-			uint64_t data, fi_addr_t dest_addr, void *context);
-	ssize_t	(*injectdata)(struct fid_ep *ep, const void *buf, size_t len,
-			uint64_t data, fi_addr_t dest_addr);
+			   uint64_t flags);
+	ssize_t (*inject)(struct fid_ep *ep, const void *buf, size_t len,
+			  fi_addr_t dest_addr);
+	ssize_t (*senddata)(struct fid_ep *ep, const void *buf, size_t len,
+			    void *desc, uint64_t data, fi_addr_t dest_addr,
+			    void *context);
+	ssize_t (*injectdata)(struct fid_ep *ep, const void *buf, size_t len,
+			      uint64_t data, fi_addr_t dest_addr);
 };
 
 struct fi_ops_cm;
@@ -136,25 +133,25 @@ struct fi_ops_collective;
  * ops requested by the user.
  */
 struct fid_ep {
-	struct fid		fid;
-	struct fi_ops_ep	*ops;
-	struct fi_ops_cm	*cm;
-	struct fi_ops_msg	*msg;
-	struct fi_ops_rma	*rma;
-	struct fi_ops_tagged	*tagged;
-	struct fi_ops_atomic	*atomic;
+	struct fid fid;
+	struct fi_ops_ep *ops;
+	struct fi_ops_cm *cm;
+	struct fi_ops_msg *msg;
+	struct fi_ops_rma *rma;
+	struct fi_ops_tagged *tagged;
+	struct fi_ops_atomic *atomic;
 	struct fi_ops_collective *collective;
 };
 
 struct fid_pep {
-	struct fid		fid;
-	struct fi_ops_ep	*ops;
-	struct fi_ops_cm	*cm;
+	struct fid fid;
+	struct fi_ops_ep *ops;
+	struct fi_ops_cm *cm;
 };
 
 struct fid_stx {
-	struct fid		fid;
-	struct fi_ops_ep	*ops;
+	struct fid fid;
+	struct fi_ops_ep *ops;
 };
 
 #ifdef FABRIC_DIRECT
@@ -163,50 +160,52 @@ struct fid_stx {
 
 #ifndef FABRIC_DIRECT_ENDPOINT
 
-static inline int
-fi_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
-	     struct fid_pep **pep, void *context)
+static inline int fi_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
+				struct fid_pep **pep, void *context)
 {
 	return fabric->ops->passive_ep(fabric, info, pep, context);
 }
 
-static inline int
-fi_endpoint(struct fid_domain *domain, struct fi_info *info,
-	    struct fid_ep **ep, void *context)
+static inline int fi_endpoint(struct fid_domain *domain, struct fi_info *info,
+			      struct fid_ep **ep, void *context)
 {
 	return domain->ops->endpoint(domain, info, ep, context);
 }
 
-static inline int
-fi_endpoint2(struct fid_domain *domain, struct fi_info *info,
-	     struct fid_ep **ep, uint64_t flags, void *context)
+static inline int fi_endpoint2(struct fid_domain *domain, struct fi_info *info,
+			       struct fid_ep **ep, uint64_t flags,
+			       void *context)
 {
 	if (!flags)
 		return fi_endpoint(domain, info, ep, context);
 
 	return FI_CHECK_OP(domain->ops, struct fi_ops_domain, endpoint2) ?
-		domain->ops->endpoint2(domain, info, ep, flags, context) :
-		-FI_ENOSYS;
+		       domain->ops->endpoint2(domain, info, ep, flags,
+					      context) :
+		       -FI_ENOSYS;
 }
 
-static inline int
-fi_scalable_ep(struct fid_domain *domain, struct fi_info *info,
-	    struct fid_ep **sep, void *context)
+static inline int fi_scalable_ep(struct fid_domain *domain,
+				 struct fi_info *info, struct fid_ep **sep,
+				 void *context)
 {
 	return domain->ops->scalable_ep(domain, info, sep, context);
 }
 
-static inline int fi_ep_bind(struct fid_ep *ep, struct fid *bfid, uint64_t flags)
+static inline int fi_ep_bind(struct fid_ep *ep, struct fid *bfid,
+			     uint64_t flags)
 {
 	return ep->fid.ops->bind(&ep->fid, bfid, flags);
 }
 
-static inline int fi_pep_bind(struct fid_pep *pep, struct fid *bfid, uint64_t flags)
+static inline int fi_pep_bind(struct fid_pep *pep, struct fid *bfid,
+			      uint64_t flags)
 {
 	return pep->fid.ops->bind(&pep->fid, bfid, flags);
 }
 
-static inline int fi_scalable_ep_bind(struct fid_ep *sep, struct fid *bfid, uint64_t flags)
+static inline int fi_scalable_ep_bind(struct fid_ep *sep, struct fid *bfid,
+				      uint64_t flags)
 {
 	return sep->fid.ops->bind(&sep->fid, bfid, flags);
 }
@@ -222,17 +221,15 @@ static inline ssize_t fi_cancel(fid_t fid, void *context)
 	return ep->ops->cancel(fid, context);
 }
 
-static inline int
-fi_setopt(fid_t fid, int level, int optname,
-	  const void *optval, size_t optlen)
+static inline int fi_setopt(fid_t fid, int level, int optname,
+			    const void *optval, size_t optlen)
 {
 	struct fid_ep *ep = container_of(fid, struct fid_ep, fid);
 	return ep->ops->setopt(fid, level, optname, optval, optlen);
 }
 
-static inline int
-fi_getopt(fid_t fid, int level, int optname,
-	  void *optval, size_t *optlen)
+static inline int fi_getopt(fid_t fid, int level, int optname, void *optval,
+			    size_t *optlen)
 {
 	struct fid_ep *ep = container_of(fid, struct fid_ep, fid);
 	return ep->ops->getopt(fid, level, optname, optval, optlen);
@@ -249,102 +246,98 @@ static inline int fi_ep_alias(struct fid_ep *ep, struct fid_ep **alias_ep,
 	return ret;
 }
 
-static inline int
-fi_tx_context(struct fid_ep *ep, int idx, struct fi_tx_attr *attr,
-	      struct fid_ep **tx_ep, void *context)
+static inline int fi_tx_context(struct fid_ep *ep, int idx,
+				struct fi_tx_attr *attr, struct fid_ep **tx_ep,
+				void *context)
 {
 	return ep->ops->tx_ctx(ep, idx, attr, tx_ep, context);
 }
 
-static inline int
-fi_rx_context(struct fid_ep *ep, int idx, struct fi_rx_attr *attr,
-	      struct fid_ep **rx_ep, void *context)
+static inline int fi_rx_context(struct fid_ep *ep, int idx,
+				struct fi_rx_attr *attr, struct fid_ep **rx_ep,
+				void *context)
 {
 	return ep->ops->rx_ctx(ep, idx, attr, rx_ep, context);
 }
 
-static inline FI_DEPRECATED_FUNC ssize_t
-fi_rx_size_left(struct fid_ep *ep)
+static inline FI_DEPRECATED_FUNC ssize_t fi_rx_size_left(struct fid_ep *ep)
 {
 	return ep->ops->rx_size_left(ep);
 }
 
-static inline FI_DEPRECATED_FUNC ssize_t
-fi_tx_size_left(struct fid_ep *ep)
+static inline FI_DEPRECATED_FUNC ssize_t fi_tx_size_left(struct fid_ep *ep)
 {
 	return ep->ops->tx_size_left(ep);
 }
 
-static inline int
-fi_stx_context(struct fid_domain *domain, struct fi_tx_attr *attr,
-	       struct fid_stx **stx, void *context)
+static inline int fi_stx_context(struct fid_domain *domain,
+				 struct fi_tx_attr *attr, struct fid_stx **stx,
+				 void *context)
 {
 	return domain->ops->stx_ctx(domain, attr, stx, context);
 }
 
-static inline int
-fi_srx_context(struct fid_domain *domain, struct fi_rx_attr *attr,
-	       struct fid_ep **rx_ep, void *context)
+static inline int fi_srx_context(struct fid_domain *domain,
+				 struct fi_rx_attr *attr, struct fid_ep **rx_ep,
+				 void *context)
 {
 	return domain->ops->srx_ctx(domain, attr, rx_ep, context);
 }
 
-static inline ssize_t
-fi_recv(struct fid_ep *ep, void *buf, size_t len, void *desc, fi_addr_t src_addr,
-	void *context)
+static inline ssize_t fi_recv(struct fid_ep *ep, void *buf, size_t len,
+			      void *desc, fi_addr_t src_addr, void *context)
 {
 	return ep->msg->recv(ep, buf, len, desc, src_addr, context);
 }
 
-static inline ssize_t
-fi_recvv(struct fid_ep *ep, const struct iovec *iov, void **desc,
-	 size_t count, fi_addr_t src_addr, void *context)
+static inline ssize_t fi_recvv(struct fid_ep *ep, const struct iovec *iov,
+			       void **desc, size_t count, fi_addr_t src_addr,
+			       void *context)
 {
 	return ep->msg->recvv(ep, iov, desc, count, src_addr, context);
 }
 
-static inline ssize_t
-fi_recvmsg(struct fid_ep *ep, const struct fi_msg *msg, uint64_t flags)
+static inline ssize_t fi_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
+				 uint64_t flags)
 {
 	return ep->msg->recvmsg(ep, msg, flags);
 }
 
-static inline ssize_t
-fi_send(struct fid_ep *ep, const void *buf, size_t len, void *desc,
-	fi_addr_t dest_addr, void *context)
+static inline ssize_t fi_send(struct fid_ep *ep, const void *buf, size_t len,
+			      void *desc, fi_addr_t dest_addr, void *context)
 {
 	return ep->msg->send(ep, buf, len, desc, dest_addr, context);
 }
 
-static inline ssize_t
-fi_sendv(struct fid_ep *ep, const struct iovec *iov, void **desc,
-	 size_t count, fi_addr_t dest_addr, void *context)
+static inline ssize_t fi_sendv(struct fid_ep *ep, const struct iovec *iov,
+			       void **desc, size_t count, fi_addr_t dest_addr,
+			       void *context)
 {
 	return ep->msg->sendv(ep, iov, desc, count, dest_addr, context);
 }
 
-static inline ssize_t
-fi_sendmsg(struct fid_ep *ep, const struct fi_msg *msg, uint64_t flags)
+static inline ssize_t fi_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
+				 uint64_t flags)
 {
 	return ep->msg->sendmsg(ep, msg, flags);
 }
 
-static inline ssize_t
-fi_inject(struct fid_ep *ep, const void *buf, size_t len, fi_addr_t dest_addr)
+static inline ssize_t fi_inject(struct fid_ep *ep, const void *buf, size_t len,
+				fi_addr_t dest_addr)
 {
 	return ep->msg->inject(ep, buf, len, dest_addr);
 }
 
-static inline ssize_t
-fi_senddata(struct fid_ep *ep, const void *buf, size_t len, void *desc,
-	      uint64_t data, fi_addr_t dest_addr, void *context)
+static inline ssize_t fi_senddata(struct fid_ep *ep, const void *buf,
+				  size_t len, void *desc, uint64_t data,
+				  fi_addr_t dest_addr, void *context)
 {
 	return ep->msg->senddata(ep, buf, len, desc, data, dest_addr, context);
 }
 
-static inline ssize_t
-fi_injectdata(struct fid_ep *ep, const void *buf, size_t len,
-		uint64_t data, fi_addr_t dest_addr)
+static inline ssize_t fi_injectdata(struct fid_ep *ep, const void *buf,
+				    size_t len, uint64_t data,
+				    fi_addr_t dest_addr)
 {
 	return ep->msg->injectdata(ep, buf, len, data, dest_addr);
 }

--- a/include/rdma/fi_eq.h
+++ b/include/rdma/fi_eq.h
@@ -42,12 +42,9 @@
 #include <rdma/fabric.h>
 #include <rdma/fi_errno.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-
 
 /*
  * Wait Set
@@ -60,37 +57,37 @@ enum fi_wait_obj {
 	FI_WAIT_UNSPEC,
 	FI_WAIT_SET,
 	FI_WAIT_FD,
-	FI_WAIT_MUTEX_COND,	/* pthread mutex & cond */
+	FI_WAIT_MUTEX_COND, /* pthread mutex & cond */
 	FI_WAIT_YIELD,
 	FI_WAIT_POLLFD,
 };
 
 struct fi_wait_attr {
-	enum fi_wait_obj	wait_obj;
-	uint64_t		flags;
+	enum fi_wait_obj wait_obj;
+	uint64_t flags;
 };
 
 struct fi_ops_wait {
-	size_t	size;
-	int	(*wait)(struct fid_wait *waitset, int timeout);
+	size_t size;
+	int (*wait)(struct fid_wait *waitset, int timeout);
 };
 
 struct fid_wait {
-	struct fid		fid;
-	struct fi_ops_wait	*ops;
+	struct fid fid;
+	struct fi_ops_wait *ops;
 };
 
 #ifndef _WIN32
 struct fi_mutex_cond {
-	pthread_mutex_t		*mutex;
-	pthread_cond_t		*cond;
+	pthread_mutex_t *mutex;
+	pthread_cond_t *cond;
 };
 #endif /* _WIN32 */
 
 struct fi_wait_pollfd {
-	uint64_t		change_index;
-	size_t			nfds;
-	struct pollfd		*fd;
+	uint64_t change_index;
+	size_t nfds;
+	struct pollfd *fd;
 };
 
 /*
@@ -99,21 +96,21 @@ struct fi_wait_pollfd {
  */
 
 struct fi_poll_attr {
-	uint64_t		flags;
+	uint64_t flags;
 };
 
 struct fi_ops_poll {
-	size_t	size;
-	int	(*poll)(struct fid_poll *pollset, void **context, int count);
-	int	(*poll_add)(struct fid_poll *pollset, struct fid *event_fid,
+	size_t size;
+	int (*poll)(struct fid_poll *pollset, void **context, int count);
+	int (*poll_add)(struct fid_poll *pollset, struct fid *event_fid,
 			uint64_t flags);
-	int	(*poll_del)(struct fid_poll *pollset, struct fid *event_fid,
+	int (*poll_del)(struct fid_poll *pollset, struct fid *event_fid,
 			uint64_t flags);
 };
 
 struct fid_poll {
-	struct fid		fid;
-	struct fi_ops_poll	*ops;
+	struct fid fid;
+	struct fi_ops_poll *ops;
 };
 
 /*
@@ -122,11 +119,11 @@ struct fid_poll {
  */
 
 struct fi_eq_attr {
-	size_t			size;
-	uint64_t		flags;
-	enum fi_wait_obj	wait_obj;
-	int			signaling_vector;
-	struct fid_wait		*wait_set;
+	size_t size;
+	uint64_t flags;
+	enum fi_wait_obj wait_obj;
+	int signaling_vector;
+	struct fid_wait *wait_set;
 };
 
 /* Standard EQ events */
@@ -141,49 +138,48 @@ enum {
 };
 
 struct fi_eq_entry {
-	fid_t			fid;
-	void			*context;
-	uint64_t		data;
+	fid_t fid;
+	void *context;
+	uint64_t data;
 };
 
 struct fi_eq_err_entry {
-	fid_t			fid;
-	void			*context;
-	uint64_t		data;
-	int			err;
-	int			prov_errno;
+	fid_t fid;
+	void *context;
+	uint64_t data;
+	int err;
+	int prov_errno;
 	/* err_data is available until the next time the EQ is read */
-	void			*err_data;
-	size_t			err_data_size;
+	void *err_data;
+	size_t err_data_size;
 };
 
 struct fi_eq_cm_entry {
-	fid_t			fid;
+	fid_t fid;
 	/* user must call fi_freeinfo to release info */
-	struct fi_info		*info;
+	struct fi_info *info;
 	/* connection data placed here, up to space provided */
-	uint8_t			data[];
+	uint8_t data[];
 };
 
 struct fi_ops_eq {
-	size_t	size;
-	ssize_t	(*read)(struct fid_eq *eq, uint32_t *event,
-			void *buf, size_t len, uint64_t flags);
-	ssize_t	(*readerr)(struct fid_eq *eq, struct fi_eq_err_entry *buf,
-			uint64_t flags);
-	ssize_t	(*write)(struct fid_eq *eq, uint32_t event,
-			const void *buf, size_t len, uint64_t flags);
-	ssize_t	(*sread)(struct fid_eq *eq, uint32_t *event,
-			void *buf, size_t len, int timeout, uint64_t flags);
-	const char * (*strerror)(struct fid_eq *eq, int prov_errno,
-			const void *err_data, char *buf, size_t len);
+	size_t size;
+	ssize_t (*read)(struct fid_eq *eq, uint32_t *event, void *buf,
+			size_t len, uint64_t flags);
+	ssize_t (*readerr)(struct fid_eq *eq, struct fi_eq_err_entry *buf,
+			   uint64_t flags);
+	ssize_t (*write)(struct fid_eq *eq, uint32_t event, const void *buf,
+			 size_t len, uint64_t flags);
+	ssize_t (*sread)(struct fid_eq *eq, uint32_t *event, void *buf,
+			 size_t len, int timeout, uint64_t flags);
+	const char *(*strerror)(struct fid_eq *eq, int prov_errno,
+				const void *err_data, char *buf, size_t len);
 };
 
 struct fid_eq {
-	struct fid		fid;
-	struct fi_ops_eq	*ops;
+	struct fid fid;
+	struct fi_ops_eq *ops;
 };
-
 
 /*
  * CQ = Complete Queue
@@ -199,222 +195,212 @@ enum fi_cq_format {
 };
 
 struct fi_cq_entry {
-	void			*op_context;
+	void *op_context;
 };
 
 struct fi_cq_msg_entry {
-	void			*op_context;
-	uint64_t		flags;
-	size_t			len;
+	void *op_context;
+	uint64_t flags;
+	size_t len;
 };
 
 struct fi_cq_data_entry {
-	void			*op_context;
-	uint64_t		flags;
-	size_t			len;
-	void			*buf;
+	void *op_context;
+	uint64_t flags;
+	size_t len;
+	void *buf;
 	/* data depends on operation and/or flags - e.g. remote EQ data */
-	uint64_t		data;
+	uint64_t data;
 };
 
 struct fi_cq_tagged_entry {
-	void			*op_context;
-	uint64_t		flags;
-	size_t			len;
-	void			*buf;
-	uint64_t		data;
-	uint64_t		tag;
+	void *op_context;
+	uint64_t flags;
+	size_t len;
+	void *buf;
+	uint64_t data;
+	uint64_t tag;
 };
 
 struct fi_cq_err_entry {
-	void			*op_context;
-	uint64_t		flags;
-	size_t			len;
-	void			*buf;
-	uint64_t		data;
-	uint64_t		tag;
-	size_t			olen;
-	int			err;
-	int			prov_errno;
+	void *op_context;
+	uint64_t flags;
+	size_t len;
+	void *buf;
+	uint64_t data;
+	uint64_t tag;
+	size_t olen;
+	int err;
+	int prov_errno;
 	/* err_data is available until the next time the CQ is read */
-	void			*err_data;
-	size_t			err_data_size;
+	void *err_data;
+	size_t err_data_size;
 };
 
 enum fi_cq_wait_cond {
 	FI_CQ_COND_NONE,
-	FI_CQ_COND_THRESHOLD	/* size_t threshold */
+	FI_CQ_COND_THRESHOLD /* size_t threshold */
 };
 
 struct fi_cq_attr {
-	size_t			size;
-	uint64_t		flags;
-	enum fi_cq_format	format;
-	enum fi_wait_obj	wait_obj;
-	int			signaling_vector;
-	enum fi_cq_wait_cond	wait_cond;
-	struct fid_wait		*wait_set;
+	size_t size;
+	uint64_t flags;
+	enum fi_cq_format format;
+	enum fi_wait_obj wait_obj;
+	int signaling_vector;
+	enum fi_cq_wait_cond wait_cond;
+	struct fid_wait *wait_set;
 };
 
 struct fi_ops_cq {
-	size_t	size;
-	ssize_t	(*read)(struct fid_cq *cq, void *buf, size_t count);
-	ssize_t	(*readfrom)(struct fid_cq *cq, void *buf, size_t count,
-			fi_addr_t *src_addr);
-	ssize_t	(*readerr)(struct fid_cq *cq, struct fi_cq_err_entry *buf,
-			uint64_t flags);
-	ssize_t	(*sread)(struct fid_cq *cq, void *buf, size_t count,
-			const void *cond, int timeout);
-	ssize_t	(*sreadfrom)(struct fid_cq *cq, void *buf, size_t count,
-			fi_addr_t *src_addr, const void *cond, int timeout);
-	int	(*signal)(struct fid_cq *cq);
-	const char * (*strerror)(struct fid_cq *cq, int prov_errno,
-			const void *err_data, char *buf, size_t len);
+	size_t size;
+	ssize_t (*read)(struct fid_cq *cq, void *buf, size_t count);
+	ssize_t (*readfrom)(struct fid_cq *cq, void *buf, size_t count,
+			    fi_addr_t *src_addr);
+	ssize_t (*readerr)(struct fid_cq *cq, struct fi_cq_err_entry *buf,
+			   uint64_t flags);
+	ssize_t (*sread)(struct fid_cq *cq, void *buf, size_t count,
+			 const void *cond, int timeout);
+	ssize_t (*sreadfrom)(struct fid_cq *cq, void *buf, size_t count,
+			     fi_addr_t *src_addr, const void *cond,
+			     int timeout);
+	int (*signal)(struct fid_cq *cq);
+	const char *(*strerror)(struct fid_cq *cq, int prov_errno,
+				const void *err_data, char *buf, size_t len);
 };
 
 struct fid_cq {
-	struct fid		fid;
-	struct fi_ops_cq	*ops;
+	struct fid fid;
+	struct fi_ops_cq *ops;
 };
-
 
 /*
  * CNTR = Counter
  * Used to report the number of completed of asynchronous operations.
  */
 
-enum fi_cntr_events {
-	FI_CNTR_EVENTS_COMP
-};
+enum fi_cntr_events { FI_CNTR_EVENTS_COMP };
 
 struct fi_cntr_attr {
-	enum fi_cntr_events	events;
-	enum fi_wait_obj	wait_obj;
-	struct fid_wait		*wait_set;
-	uint64_t		flags;
+	enum fi_cntr_events events;
+	enum fi_wait_obj wait_obj;
+	struct fid_wait *wait_set;
+	uint64_t flags;
 };
 
 struct fi_ops_cntr {
-	size_t	size;
+	size_t size;
 	uint64_t (*read)(struct fid_cntr *cntr);
 	uint64_t (*readerr)(struct fid_cntr *cntr);
-	int	(*add)(struct fid_cntr *cntr, uint64_t value);
-	int	(*set)(struct fid_cntr *cntr, uint64_t value);
-	int	(*wait)(struct fid_cntr *cntr, uint64_t threshold, int timeout);
-	int	(*adderr)(struct fid_cntr *cntr, uint64_t value);
-	int	(*seterr)(struct fid_cntr *cntr, uint64_t value);
+	int (*add)(struct fid_cntr *cntr, uint64_t value);
+	int (*set)(struct fid_cntr *cntr, uint64_t value);
+	int (*wait)(struct fid_cntr *cntr, uint64_t threshold, int timeout);
+	int (*adderr)(struct fid_cntr *cntr, uint64_t value);
+	int (*seterr)(struct fid_cntr *cntr, uint64_t value);
 };
 
 struct fid_cntr {
-	struct fid		fid;
-	struct fi_ops_cntr	*ops;
+	struct fid fid;
+	struct fi_ops_cntr *ops;
 };
-
 
 #ifdef FABRIC_DIRECT
 #include <rdma/fi_direct_eq.h>
-#endif	/* FABRIC_DIRECT */
+#endif /* FABRIC_DIRECT */
 
 #ifndef FABRIC_DIRECT_EQ
 
-static inline int
-fi_trywait(struct fid_fabric *fabric, struct fid **fids, int count)
+static inline int fi_trywait(struct fid_fabric *fabric, struct fid **fids,
+			     int count)
 {
 	return fabric->ops->trywait(fabric, fids, count);
 }
 
-static inline int
-fi_wait(struct fid_wait *waitset, int timeout)
+static inline int fi_wait(struct fid_wait *waitset, int timeout)
 {
 	return waitset->ops->wait(waitset, timeout);
 }
 
-static inline int
-fi_poll(struct fid_poll *pollset, void **context, int count)
+static inline int fi_poll(struct fid_poll *pollset, void **context, int count)
 {
 	return pollset->ops->poll(pollset, context, count);
 }
 
-static inline int
-fi_poll_add(struct fid_poll *pollset, struct fid *event_fid, uint64_t flags)
+static inline int fi_poll_add(struct fid_poll *pollset, struct fid *event_fid,
+			      uint64_t flags)
 {
 	return pollset->ops->poll_add(pollset, event_fid, flags);
 }
 
-static inline int
-fi_poll_del(struct fid_poll *pollset, struct fid *event_fid, uint64_t flags)
+static inline int fi_poll_del(struct fid_poll *pollset, struct fid *event_fid,
+			      uint64_t flags)
 {
 	return pollset->ops->poll_del(pollset, event_fid, flags);
 }
 
-static inline int
-fi_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
-	   struct fid_eq **eq, void *context)
+static inline int fi_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
+			     struct fid_eq **eq, void *context)
 {
 	return fabric->ops->eq_open(fabric, attr, eq, context);
 }
 
-static inline ssize_t
-fi_eq_read(struct fid_eq *eq, uint32_t *event, void *buf,
-	   size_t len, uint64_t flags)
+static inline ssize_t fi_eq_read(struct fid_eq *eq, uint32_t *event, void *buf,
+				 size_t len, uint64_t flags)
 {
 	return eq->ops->read(eq, event, buf, len, flags);
 }
 
-static inline ssize_t
-fi_eq_readerr(struct fid_eq *eq, struct fi_eq_err_entry *buf, uint64_t flags)
+static inline ssize_t fi_eq_readerr(struct fid_eq *eq,
+				    struct fi_eq_err_entry *buf, uint64_t flags)
 {
 	return eq->ops->readerr(eq, buf, flags);
 }
 
-static inline ssize_t
-fi_eq_write(struct fid_eq *eq, uint32_t event, const void *buf,
-	    size_t len, uint64_t flags)
+static inline ssize_t fi_eq_write(struct fid_eq *eq, uint32_t event,
+				  const void *buf, size_t len, uint64_t flags)
 {
 	return eq->ops->write(eq, event, buf, len, flags);
 }
 
-static inline ssize_t
-fi_eq_sread(struct fid_eq *eq, uint32_t *event, void *buf, size_t len,
-	    int timeout, uint64_t flags)
+static inline ssize_t fi_eq_sread(struct fid_eq *eq, uint32_t *event, void *buf,
+				  size_t len, int timeout, uint64_t flags)
 {
 	return eq->ops->sread(eq, event, buf, len, timeout, flags);
 }
 
-static inline const char *
-fi_eq_strerror(struct fid_eq *eq, int prov_errno, const void *err_data,
-	       char *buf, size_t len)
+static inline const char *fi_eq_strerror(struct fid_eq *eq, int prov_errno,
+					 const void *err_data, char *buf,
+					 size_t len)
 {
 	return eq->ops->strerror(eq, prov_errno, err_data, buf, len);
 }
-
 
 static inline ssize_t fi_cq_read(struct fid_cq *cq, void *buf, size_t count)
 {
 	return cq->ops->read(cq, buf, count);
 }
 
-static inline ssize_t
-fi_cq_readfrom(struct fid_cq *cq, void *buf, size_t count, fi_addr_t *src_addr)
+static inline ssize_t fi_cq_readfrom(struct fid_cq *cq, void *buf, size_t count,
+				     fi_addr_t *src_addr)
 {
 	return cq->ops->readfrom(cq, buf, count, src_addr);
 }
 
-static inline ssize_t
-fi_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf, uint64_t flags)
+static inline ssize_t fi_cq_readerr(struct fid_cq *cq,
+				    struct fi_cq_err_entry *buf, uint64_t flags)
 {
 	return cq->ops->readerr(cq, buf, flags);
 }
 
-static inline ssize_t
-fi_cq_sread(struct fid_cq *cq, void *buf, size_t count, const void *cond, int timeout)
+static inline ssize_t fi_cq_sread(struct fid_cq *cq, void *buf, size_t count,
+				  const void *cond, int timeout)
 {
 	return cq->ops->sread(cq, buf, count, cond, timeout);
 }
 
-static inline ssize_t
-fi_cq_sreadfrom(struct fid_cq *cq, void *buf, size_t count,
-		fi_addr_t *src_addr, const void *cond, int timeout)
+static inline ssize_t fi_cq_sreadfrom(struct fid_cq *cq, void *buf,
+				      size_t count, fi_addr_t *src_addr,
+				      const void *cond, int timeout)
 {
 	return cq->ops->sreadfrom(cq, buf, count, src_addr, cond, timeout);
 }
@@ -424,13 +410,12 @@ static inline int fi_cq_signal(struct fid_cq *cq)
 	return cq->ops->signal(cq);
 }
 
-static inline const char *
-fi_cq_strerror(struct fid_cq *cq, int prov_errno, const void *err_data,
-	       char *buf, size_t len)
+static inline const char *fi_cq_strerror(struct fid_cq *cq, int prov_errno,
+					 const void *err_data, char *buf,
+					 size_t len)
 {
 	return cq->ops->strerror(cq, prov_errno, err_data, buf, len);
 }
-
 
 static inline uint64_t fi_cntr_read(struct fid_cntr *cntr)
 {
@@ -450,7 +435,8 @@ static inline int fi_cntr_add(struct fid_cntr *cntr, uint64_t value)
 static inline int fi_cntr_adderr(struct fid_cntr *cntr, uint64_t value)
 {
 	return FI_CHECK_OP(cntr->ops, struct fi_ops_cntr, adderr) ?
-		cntr->ops->adderr(cntr, value) : -FI_ENOSYS;
+		       cntr->ops->adderr(cntr, value) :
+		       -FI_ENOSYS;
 }
 
 static inline int fi_cntr_set(struct fid_cntr *cntr, uint64_t value)
@@ -461,11 +447,12 @@ static inline int fi_cntr_set(struct fid_cntr *cntr, uint64_t value)
 static inline int fi_cntr_seterr(struct fid_cntr *cntr, uint64_t value)
 {
 	return FI_CHECK_OP(cntr->ops, struct fi_ops_cntr, seterr) ?
-		cntr->ops->seterr(cntr, value) : -FI_ENOSYS;
+		       cntr->ops->seterr(cntr, value) :
+		       -FI_ENOSYS;
 }
 
-static inline int
-fi_cntr_wait(struct fid_cntr *cntr, uint64_t threshold, int timeout)
+static inline int fi_cntr_wait(struct fid_cntr *cntr, uint64_t threshold,
+			       int timeout)
 {
 	return cntr->ops->wait(cntr, threshold, timeout);
 }

--- a/include/rdma/fi_errno.h
+++ b/include/rdma/fi_errno.h
@@ -42,36 +42,36 @@ extern "C" {
 
 /* FI directly mapped errno values */
 
-#define	FI_SUCCESS		0
+#define FI_SUCCESS 0
 
-#define	FI_EPERM		EPERM		/* Operation not permitted */
-#define	FI_ENOENT		ENOENT		/* No such file or directory */
+#define FI_EPERM EPERM /* Operation not permitted */
+#define FI_ENOENT ENOENT /* No such file or directory */
 //#define	FI_ESRCH		ESRCH		/* No such process */
-#define	FI_EINTR		EINTR		/* Interrupted system call */
-#define	FI_EIO		 	EIO		/* I/O error */
+#define FI_EINTR EINTR /* Interrupted system call */
+#define FI_EIO EIO /* I/O error */
 //#define	FI_ENXIO		ENXIO		/* No such device or address */
-#define	FI_E2BIG		E2BIG		/* Argument list too long */
+#define FI_E2BIG E2BIG /* Argument list too long */
 //#define	FI_ENOEXEC		ENOEXEC		/* Exec format error */
-#define	FI_EBADF		EBADF		/* Bad file number */
+#define FI_EBADF EBADF /* Bad file number */
 //#define	FI_ECHILD		ECHILD		/* No child processes */
-#define	FI_EAGAIN		EAGAIN		/* Try again */
-#define	FI_ENOMEM		ENOMEM		/* Out of memory */
-#define	FI_EACCES		EACCES		/* Permission denied */
-#define	FI_EFAULT		EFAULT		/* Bad address */
+#define FI_EAGAIN EAGAIN /* Try again */
+#define FI_ENOMEM ENOMEM /* Out of memory */
+#define FI_EACCES EACCES /* Permission denied */
+#define FI_EFAULT EFAULT /* Bad address */
 //#define	FI_ENOTBLK		ENOTBLK		/* Block device required */
-#define	FI_EBUSY		EBUSY		/* Device or resource busy */
+#define FI_EBUSY EBUSY /* Device or resource busy */
 //#define	FI_EEXIST		EEXIST		/* File exists */
 //#define	FI_EXDEV		EXDEV		/* Cross-device link */
-#define	FI_ENODEV		ENODEV		/* No such device */
+#define FI_ENODEV ENODEV /* No such device */
 //#define	FI_ENOTDIR		ENOTDIR		/* Not a directory */
 //#define	FI_EISDIR		EISDIR		/* Is a directory */
-#define	FI_EINVAL		EINVAL		/* Invalid argument */
+#define FI_EINVAL EINVAL /* Invalid argument */
 //#define	FI_ENFILE		ENFILE		/* File table overflow */
-#define	FI_EMFILE		EMFILE		/* Too many open files */
+#define FI_EMFILE EMFILE /* Too many open files */
 //#define	FI_ENOTTY		ENOTTY		/* Not a typewriter */
 //#define	FI_ETXTBSY		ETXTBSY		/* Text file busy */
 //#define	FI_EFBIG		EFBIG		/* File too large */
-#define	FI_ENOSPC		ENOSPC		/* No space left on device */
+#define FI_ENOSPC ENOSPC /* No space left on device */
 //#define	FI_ESPIPE		ESPIPE		/* Illegal seek */
 //#define	FI_EROFS		EROFS		/* Read-only file system */
 //#define	FI_EMLINK		EMLINK		/* Too many links */
@@ -81,11 +81,11 @@ extern "C" {
 //#define	FI_EDEADLK		EDEADLK		/* Resource deadlock would occur */
 //#define	FI_ENAMETOOLONG		ENAMETOLONG	/* File name too long */
 //#define	FI_ENOLCK		ENOLCK		/* No record locks available */
-#define	FI_ENOSYS		ENOSYS		/* Function not implemented */
+#define FI_ENOSYS ENOSYS /* Function not implemented */
 //#define	FI_ENOTEMPTY		ENOTEMPTY	/* Directory not empty */
 //#define	FI_ELOOP		ELOOP		/* Too many symbolic links encountered */
-#define	FI_EWOULDBLOCK		EWOULDBLOCK	/* Operation would block */
-#define	FI_ENOMSG		ENOMSG		/* No message of desired type */
+#define FI_EWOULDBLOCK EWOULDBLOCK /* Operation would block */
+#define FI_ENOMSG ENOMSG /* No message of desired type */
 //#define	FI_EIDRM		EIDRM		/* Identifier removed */
 //#define	FI_ECHRNG		ECHRNG		/* Channel number out of range */
 //#define	FI_EL2NSYNC		EL2NSYCN	/* Level 2 not synchronized */
@@ -104,7 +104,7 @@ extern "C" {
 //#define	FI_EDEADLOCK		EDEADLOCK	/* Resource deadlock would occur */
 //#define	FI_EBFONT		EBFONT		/* Bad font file format */
 //#define	FI_ENOSTR		ENOSTR		/* Device not a stream */
-#define	FI_ENODATA		ENODATA		/* No data available */
+#define FI_ENODATA ENODATA /* No data available */
 //#define	FI_ETIME		ETIME		/* Timer expired */
 //#define	FI_ENOSR		ENOSR		/* Out of streams resources */
 //#define	FI_ENONET		ENONET		/* Machine is not on the network */
@@ -118,7 +118,7 @@ extern "C" {
 //#define	FI_EMULTIHOP		EMULTIHOP	/* Multihop attempted */
 //#define	FI_EDOTDOT		EDOTDOT		/* RFS specific error */
 //#define	FI_EBADMSG		EBADMSG		/* Not a data message */
-#define	FI_EOVERFLOW		EOVERFLOW	/* Value too large for defined data type */
+#define FI_EOVERFLOW EOVERFLOW /* Value too large for defined data type */
 //#define	FI_ENOTUNIQ		ENOTUNIQ	/* Name not unique on network */
 //#define	FI_EBADFD		EBADFD		/* File descriptor in bad state */
 //#define	FI_EREMCHG		EREMCHG		/* Remote address changed */
@@ -133,67 +133,69 @@ extern "C" {
 //#define	FI_EUSERS		EUSERS		/* Too many users */
 //#define	FI_ENOTSOCK		ENOTSOCK	/* Socket operation on non-socket */
 //#define	FI_EDESTADDRREQ		EDESTADDRREQ	/* Destination address required */
-#define	FI_EMSGSIZE		EMSGSIZE	/* Message too long */
+#define FI_EMSGSIZE EMSGSIZE /* Message too long */
 //#define	FI_EPROTOTYPE		EPROTOTYPE	/* Protocol wrong type for endpoint */
-#define	FI_ENOPROTOOPT		ENOPROTOOPT	/* Protocol not available */
+#define FI_ENOPROTOOPT ENOPROTOOPT /* Protocol not available */
 //#define	FI_EPROTONOSUPPORT	EPROTONOSUPPORT	/* Protocol not supported */
 //#define	FI_ESOCKTNOSUPPORT	ESOCKTNOSUPPORT	/* Socket type not supported */
-#define	FI_EOPNOTSUPP		EOPNOTSUPP	/* Operation not supported on transport endpoint */
+#define FI_EOPNOTSUPP \
+	EOPNOTSUPP /* Operation not supported on transport endpoint */
 //#define	FI_EPFNOSUPPORT		EPFNOSUPPORT	/* Protocol family not supported */
 //#define	FI_EAFNOSUPPORT		EAFNOSUPPORT	/* Address family not supported by protocol */
-#define	FI_EADDRINUSE		EADDRINUSE	/* Address already in use */
-#define	FI_EADDRNOTAVAIL	EADDRNOTAVAIL	/* Cannot assign requested address */
-#define	FI_ENETDOWN		ENETDOWN	/* Network is down */
-#define	FI_ENETUNREACH		ENETUNREACH	/* Network is unreachable */
+#define FI_EADDRINUSE EADDRINUSE /* Address already in use */
+#define FI_EADDRNOTAVAIL EADDRNOTAVAIL /* Cannot assign requested address */
+#define FI_ENETDOWN ENETDOWN /* Network is down */
+#define FI_ENETUNREACH ENETUNREACH /* Network is unreachable */
 //#define	FI_ENETRESET		ENETRESET	/* Network dropped connection because of reset */
-#define	FI_ECONNABORTED		ECONNABORTED	/* Software caused connection abort */
-#define	FI_ECONNRESET		ECONNRESET	/* Connection reset by peer */
-#define	FI_ENOBUFS		ENOBUFS		/* No buffer space available */
-#define	FI_EISCONN		EISCONN		/* Transport endpoint is already connected */
-#define	FI_ENOTCONN		ENOTCONN	/* Transport endpoint is not connected */
-#define	FI_ESHUTDOWN		ESHUTDOWN	/* Cannot send after transport endpoint shutdown */
+#define FI_ECONNABORTED ECONNABORTED /* Software caused connection abort */
+#define FI_ECONNRESET ECONNRESET /* Connection reset by peer */
+#define FI_ENOBUFS ENOBUFS /* No buffer space available */
+#define FI_EISCONN EISCONN /* Transport endpoint is already connected */
+#define FI_ENOTCONN ENOTCONN /* Transport endpoint is not connected */
+#define FI_ESHUTDOWN \
+	ESHUTDOWN /* Cannot send after transport endpoint shutdown */
 //#define	FI_ETOOMANYREFS		ETOOMANYREFS	/* Too many references: cannot splice */
-#define	FI_ETIMEDOUT		ETIMEDOUT	/* Connection timed out */
-#define	FI_ECONNREFUSED		ECONNREFUSED	/* Connection refused */
-#define	FI_EHOSTDOWN		EHOSTDOWN	/* Host is down */
-#define	FI_EHOSTUNREACH		EHOSTUNREACH	/* No route to host */
-#define	FI_EALREADY		EALREADY	/* Operation already in progress */
-#define	FI_EINPROGRESS		EINPROGRESS	/* Operation now in progress */
+#define FI_ETIMEDOUT ETIMEDOUT /* Connection timed out */
+#define FI_ECONNREFUSED ECONNREFUSED /* Connection refused */
+#define FI_EHOSTDOWN EHOSTDOWN /* Host is down */
+#define FI_EHOSTUNREACH EHOSTUNREACH /* No route to host */
+#define FI_EALREADY EALREADY /* Operation already in progress */
+#define FI_EINPROGRESS EINPROGRESS /* Operation now in progress */
 //#define	FI_ESTALE		ESTALE		/* Stale NFS file handle */
 //#define	FI_EUCLEAN		EUNCLEAN	/* Structure needs cleaning */
 //#define	FI_ENOTNAM		ENOTNAM		/* Not a XENIX named type file */
 //#define	FI_ENAVAIL		ENAVAIL		/* No XENIX semaphores available */
 //#define	FI_EISNAM		EISNAM		/* Is a named type file */
-#define	FI_EREMOTEIO		EREMOTEIO	/* Remote I/O error */
+#define FI_EREMOTEIO EREMOTEIO /* Remote I/O error */
 //#define	FI_EDQUOT		EDQUOT		/* Quota exceeded */
 //#define	FI_ENOMEDIUM		ENOMEDIUM	/* No medium found */
 //#define	FI_EMEDIUMTYPE		EMEDIUMTYPE	/* Wrong medium type */
-#define	FI_ECANCELED		ECANCELED	/* Operation Canceled */
+#define FI_ECANCELED ECANCELED /* Operation Canceled */
 
 //#define	FI_EKEYEXPIRED		EKEYEXPIRED	/* Key has expired */
 //#define	FI_EKEYREVOKED		EKEYREVOKED	/* Key has been revoked */
-#define	FI_EKEYREJECTED		EKEYREJECTED	/* Key was rejected by service */
+#define FI_EKEYREJECTED EKEYREJECTED /* Key was rejected by service */
 //#define	FI_EOWNERDEAD		EOWNERDEAD	/* Owner died */
 //#define	FI_ENOTRECOVERABLE	ENOTRECOVERABLE	/* State not recoverable */
 
 /* FI specific return values: >= 256 */
-#define FI_ERRNO_OFFSET	256
+#define FI_ERRNO_OFFSET 256
 
 enum {
-	FI_EOTHER        = FI_ERRNO_OFFSET, /* Unspecified error */
-	FI_ETOOSMALL     = 257, /* Provided buffer is too small */
-	FI_EOPBADSTATE   = 258, /* Operation not permitted in current state */
-	FI_EAVAIL        = 259, /* Error available */
-	FI_EBADFLAGS     = 260, /* Flags not supported */
-	FI_ENOEQ         = 261, /* Missing or unavailable event queue */
-	FI_EDOMAIN       = 262, /* Invalid resource domain */
-	FI_ENOCQ         = 263, /* Missing or unavailable completion queue */
-	FI_ECRC          = 264, /* CRC error */
-	FI_ETRUNC        = 265, /* Truncation error */
-	FI_ENOKEY        = 266, /* Required key not available */
-	FI_ENOAV	 = 267, /* Missing or unavailable address vector */
-	FI_EOVERRUN	 = 268, /* Queue has been overrun */
-	FI_ENORX	 = 269, /* Receiver not ready, no receive buffers available */
+	FI_EOTHER = FI_ERRNO_OFFSET, /* Unspecified error */
+	FI_ETOOSMALL = 257, /* Provided buffer is too small */
+	FI_EOPBADSTATE = 258, /* Operation not permitted in current state */
+	FI_EAVAIL = 259, /* Error available */
+	FI_EBADFLAGS = 260, /* Flags not supported */
+	FI_ENOEQ = 261, /* Missing or unavailable event queue */
+	FI_EDOMAIN = 262, /* Invalid resource domain */
+	FI_ENOCQ = 263, /* Missing or unavailable completion queue */
+	FI_ECRC = 264, /* CRC error */
+	FI_ETRUNC = 265, /* Truncation error */
+	FI_ENOKEY = 266, /* Required key not available */
+	FI_ENOAV = 267, /* Missing or unavailable address vector */
+	FI_EOVERRUN = 268, /* Queue has been overrun */
+	FI_ENORX = 269, /* Receiver not ready, no receive buffers available */
 	FI_ERRNO_MAX
 };
 

--- a/include/rdma/fi_ext.h
+++ b/include/rdma/fi_ext.h
@@ -42,7 +42,6 @@
 #include <rdma/providers/fi_prov.h>
 #include <rdma/providers/fi_log.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -63,16 +62,15 @@ extern "C" {
  * }
  */
 
-#define FI_PROV_SPECIFIC_EFA   (0xefa << 16)
-#define FI_PROV_SPECIFIC_TCP   (0x7cb << 16)
-
+#define FI_PROV_SPECIFIC_EFA (0xefa << 16)
+#define FI_PROV_SPECIFIC_TCP (0x7cb << 16)
 
 /* negative options are provider specific */
 enum {
-       FI_OPT_EFA_RNR_RETRY = -FI_PROV_SPECIFIC_EFA,
-       FI_OPT_EFA_EMULATED_READ,       /* bool */
-       FI_OPT_EFA_EMULATED_WRITE,      /* bool */
-       FI_OPT_EFA_EMULATED_ATOMICS,    /* bool */
+	FI_OPT_EFA_RNR_RETRY = -FI_PROV_SPECIFIC_EFA,
+	FI_OPT_EFA_EMULATED_READ, /* bool */
+	FI_OPT_EFA_EMULATED_WRITE, /* bool */
+	FI_OPT_EFA_EMULATED_ATOMICS, /* bool */
 };
 
 struct fi_fid_export {
@@ -81,9 +79,8 @@ struct fi_fid_export {
 	void *context;
 };
 
-static inline int
-fi_export_fid(struct fid *fid, uint64_t flags,
-	      struct fid **expfid, void *context)
+static inline int fi_export_fid(struct fid *fid, uint64_t flags,
+				struct fid **expfid, void *context)
 {
 	struct fi_fid_export exp;
 
@@ -93,12 +90,11 @@ fi_export_fid(struct fid *fid, uint64_t flags,
 	return fi_control(fid, FI_EXPORT_FID, &exp);
 }
 
-static inline int
-fi_import_fid(struct fid *fid, struct fid *expfid, uint64_t flags)
+static inline int fi_import_fid(struct fid *fid, struct fid *expfid,
+				uint64_t flags)
 {
 	return fid->ops->bind(fid, expfid, flags);
 }
-
 
 /*
  * System memory monitor import extension:
@@ -108,21 +104,21 @@ fi_import_fid(struct fid *fid, struct fid *expfid, uint64_t flags)
 struct fid_mem_monitor;
 
 struct fi_ops_mem_monitor {
-	size_t	size;
-	int	(*start)(struct fid_mem_monitor *monitor);
-	void	(*stop)(struct fid_mem_monitor *monitor);
-	int	(*subscribe)(struct fid_mem_monitor *monitor,
-			const void *addr, size_t len);
-	void	(*unsubscribe)(struct fid_mem_monitor *monitor,
-			const void *addr, size_t len);
-	bool	(*valid)(struct fid_mem_monitor *monitor,
-			const void *addr, size_t len);
+	size_t size;
+	int (*start)(struct fid_mem_monitor *monitor);
+	void (*stop)(struct fid_mem_monitor *monitor);
+	int (*subscribe)(struct fid_mem_monitor *monitor, const void *addr,
+			 size_t len);
+	void (*unsubscribe)(struct fid_mem_monitor *monitor, const void *addr,
+			    size_t len);
+	bool (*valid)(struct fid_mem_monitor *monitor, const void *addr,
+		      size_t len);
 };
 
 struct fi_ops_mem_notify {
-	size_t	size;
-	void	(*notify)(struct fid_mem_monitor *monitor, const void *addr,
-			size_t len);
+	size_t size;
+	void (*notify)(struct fid_mem_monitor *monitor, const void *addr,
+		       size_t len);
 };
 
 struct fid_mem_monitor {
@@ -130,7 +126,6 @@ struct fid_mem_monitor {
 	struct fi_ops_mem_monitor *export_ops;
 	struct fi_ops_mem_notify *import_ops;
 };
-
 
 /*
  * System logging import extension:
@@ -144,15 +139,16 @@ struct fi_ops_log {
 	int (*enabled)(const struct fi_provider *prov, enum fi_log_level level,
 		       enum fi_log_subsys subsys, uint64_t flags);
 	int (*ready)(const struct fi_provider *prov, enum fi_log_level level,
-		     enum fi_log_subsys subsys, uint64_t flags, uint64_t *showtime);
+		     enum fi_log_subsys subsys, uint64_t flags,
+		     uint64_t *showtime);
 	void (*log)(const struct fi_provider *prov, enum fi_log_level level,
 		    enum fi_log_subsys subsys, const char *func, int line,
 		    const char *msg);
 };
 
 struct fid_logging {
-	struct fid          fid;
-	struct fi_ops_log   *ops;
+	struct fid fid;
+	struct fi_ops_log *ops;
 };
 
 static inline int fi_import(uint32_t version, const char *name, void *attr,
@@ -164,7 +160,7 @@ static inline int fi_import(uint32_t version, const char *name, void *attr,
 
 	ret = fi_open(version, name, attr, attr_len, flags, &open_fid, context);
 	if (ret != FI_SUCCESS)
-	    return ret;
+		return ret;
 
 	ret = fi_import_fid(open_fid, fid, flags);
 	fi_close(open_fid);

--- a/include/rdma/fi_rma.h
+++ b/include/rdma/fi_rma.h
@@ -41,120 +41,125 @@ extern "C" {
 #endif
 
 struct fi_rma_iov {
-	uint64_t		addr;
-	size_t			len;
-	uint64_t		key;
+	uint64_t addr;
+	size_t len;
+	uint64_t key;
 };
 
 struct fi_rma_ioc {
-	uint64_t		addr;
-	size_t			count;
-	uint64_t		key;
+	uint64_t addr;
+	size_t count;
+	uint64_t key;
 };
 
 struct fi_msg_rma {
-	const struct iovec	*msg_iov;
-	void			**desc;
-	size_t			iov_count;
-	fi_addr_t		addr;
+	const struct iovec *msg_iov;
+	void **desc;
+	size_t iov_count;
+	fi_addr_t addr;
 	const struct fi_rma_iov *rma_iov;
-	size_t			rma_iov_count;
-	void			*context;
-	uint64_t		data;
+	size_t rma_iov_count;
+	void *context;
+	uint64_t data;
 };
 
 struct fi_ops_rma {
-	size_t	size;
-	ssize_t	(*read)(struct fid_ep *ep, void *buf, size_t len, void *desc,
-			fi_addr_t src_addr, uint64_t addr, uint64_t key, void *context);
-	ssize_t	(*readv)(struct fid_ep *ep, const struct iovec *iov, void **desc,
-			size_t count, fi_addr_t src_addr, uint64_t addr, uint64_t key,
+	size_t size;
+	ssize_t (*read)(struct fid_ep *ep, void *buf, size_t len, void *desc,
+			fi_addr_t src_addr, uint64_t addr, uint64_t key,
 			void *context);
-	ssize_t	(*readmsg)(struct fid_ep *ep, const struct fi_msg_rma *msg,
-			uint64_t flags);
-	ssize_t	(*write)(struct fid_ep *ep, const void *buf, size_t len, void *desc,
-			fi_addr_t dest_addr, uint64_t addr, uint64_t key, void *context);
-	ssize_t	(*writev)(struct fid_ep *ep, const struct iovec *iov, void **desc,
-			size_t count, fi_addr_t dest_addr, uint64_t addr, uint64_t key,
-			void *context);
-	ssize_t	(*writemsg)(struct fid_ep *ep, const struct fi_msg_rma *msg,
-			uint64_t flags);
-	ssize_t	(*inject)(struct fid_ep *ep, const void *buf, size_t len,
-			fi_addr_t dest_addr, uint64_t addr, uint64_t key);
-	ssize_t	(*writedata)(struct fid_ep *ep, const void *buf, size_t len, void *desc,
-			uint64_t data, fi_addr_t dest_addr, uint64_t addr, uint64_t key,
-			void *context);
-	ssize_t	(*injectdata)(struct fid_ep *ep, const void *buf, size_t len,
-			uint64_t data, fi_addr_t dest_addr, uint64_t addr, uint64_t key);
+	ssize_t (*readv)(struct fid_ep *ep, const struct iovec *iov,
+			 void **desc, size_t count, fi_addr_t src_addr,
+			 uint64_t addr, uint64_t key, void *context);
+	ssize_t (*readmsg)(struct fid_ep *ep, const struct fi_msg_rma *msg,
+			   uint64_t flags);
+	ssize_t (*write)(struct fid_ep *ep, const void *buf, size_t len,
+			 void *desc, fi_addr_t dest_addr, uint64_t addr,
+			 uint64_t key, void *context);
+	ssize_t (*writev)(struct fid_ep *ep, const struct iovec *iov,
+			  void **desc, size_t count, fi_addr_t dest_addr,
+			  uint64_t addr, uint64_t key, void *context);
+	ssize_t (*writemsg)(struct fid_ep *ep, const struct fi_msg_rma *msg,
+			    uint64_t flags);
+	ssize_t (*inject)(struct fid_ep *ep, const void *buf, size_t len,
+			  fi_addr_t dest_addr, uint64_t addr, uint64_t key);
+	ssize_t (*writedata)(struct fid_ep *ep, const void *buf, size_t len,
+			     void *desc, uint64_t data, fi_addr_t dest_addr,
+			     uint64_t addr, uint64_t key, void *context);
+	ssize_t (*injectdata)(struct fid_ep *ep, const void *buf, size_t len,
+			      uint64_t data, fi_addr_t dest_addr, uint64_t addr,
+			      uint64_t key);
 };
 
 #ifdef FABRIC_DIRECT
 #include <rdma/fi_direct_rma.h>
-#endif	/* FABRIC_DIRECT */
+#endif /* FABRIC_DIRECT */
 
 #ifndef FABRIC_DIRECT_RMA
 
-static inline ssize_t
-fi_read(struct fid_ep *ep, void *buf, size_t len, void *desc,
-	fi_addr_t src_addr, uint64_t addr, uint64_t key, void *context)
+static inline ssize_t fi_read(struct fid_ep *ep, void *buf, size_t len,
+			      void *desc, fi_addr_t src_addr, uint64_t addr,
+			      uint64_t key, void *context)
 {
 	return ep->rma->read(ep, buf, len, desc, src_addr, addr, key, context);
 }
 
-static inline ssize_t
-fi_readv(struct fid_ep *ep, const struct iovec *iov, void **desc,
-	 size_t count, fi_addr_t src_addr, uint64_t addr, uint64_t key,
-	 void *context)
+static inline ssize_t fi_readv(struct fid_ep *ep, const struct iovec *iov,
+			       void **desc, size_t count, fi_addr_t src_addr,
+			       uint64_t addr, uint64_t key, void *context)
 {
-	return ep->rma->readv(ep, iov, desc, count, src_addr, addr, key, context);
+	return ep->rma->readv(ep, iov, desc, count, src_addr, addr, key,
+			      context);
 }
 
-static inline ssize_t
-fi_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uint64_t flags)
+static inline ssize_t fi_readmsg(struct fid_ep *ep,
+				 const struct fi_msg_rma *msg, uint64_t flags)
 {
 	return ep->rma->readmsg(ep, msg, flags);
 }
 
-static inline ssize_t
-fi_write(struct fid_ep *ep, const void *buf, size_t len, void *desc,
-	 fi_addr_t dest_addr, uint64_t addr, uint64_t key, void *context)
+static inline ssize_t fi_write(struct fid_ep *ep, const void *buf, size_t len,
+			       void *desc, fi_addr_t dest_addr, uint64_t addr,
+			       uint64_t key, void *context)
 {
-	return ep->rma->write(ep, buf, len, desc, dest_addr, addr, key, context);
+	return ep->rma->write(ep, buf, len, desc, dest_addr, addr, key,
+			      context);
 }
 
-static inline ssize_t
-fi_writev(struct fid_ep *ep, const struct iovec *iov, void **desc,
-	 size_t count, fi_addr_t dest_addr, uint64_t addr, uint64_t key,
-	 void *context)
+static inline ssize_t fi_writev(struct fid_ep *ep, const struct iovec *iov,
+				void **desc, size_t count, fi_addr_t dest_addr,
+				uint64_t addr, uint64_t key, void *context)
 {
-	return ep->rma->writev(ep, iov, desc, count, dest_addr, addr, key, context);
+	return ep->rma->writev(ep, iov, desc, count, dest_addr, addr, key,
+			       context);
 }
 
-static inline ssize_t
-fi_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uint64_t flags)
+static inline ssize_t fi_writemsg(struct fid_ep *ep,
+				  const struct fi_msg_rma *msg, uint64_t flags)
 {
 	return ep->rma->writemsg(ep, msg, flags);
 }
 
-static inline ssize_t
-fi_inject_write(struct fid_ep *ep, const void *buf, size_t len,
-		fi_addr_t dest_addr, uint64_t addr, uint64_t key)
+static inline ssize_t fi_inject_write(struct fid_ep *ep, const void *buf,
+				      size_t len, fi_addr_t dest_addr,
+				      uint64_t addr, uint64_t key)
 {
 	return ep->rma->inject(ep, buf, len, dest_addr, addr, key);
 }
 
-static inline ssize_t
-fi_writedata(struct fid_ep *ep, const void *buf, size_t len, void *desc,
-	       uint64_t data, fi_addr_t dest_addr, uint64_t addr, uint64_t key,
-	       void *context)
+static inline ssize_t fi_writedata(struct fid_ep *ep, const void *buf,
+				   size_t len, void *desc, uint64_t data,
+				   fi_addr_t dest_addr, uint64_t addr,
+				   uint64_t key, void *context)
 {
-	return ep->rma->writedata(ep, buf, len, desc,data, dest_addr,
-				  addr, key, context);
+	return ep->rma->writedata(ep, buf, len, desc, data, dest_addr, addr,
+				  key, context);
 }
 
-static inline ssize_t
-fi_inject_writedata(struct fid_ep *ep, const void *buf, size_t len,
-		uint64_t data, fi_addr_t dest_addr, uint64_t addr, uint64_t key)
+static inline ssize_t fi_inject_writedata(struct fid_ep *ep, const void *buf,
+					  size_t len, uint64_t data,
+					  fi_addr_t dest_addr, uint64_t addr,
+					  uint64_t key)
 {
 	return ep->rma->injectdata(ep, buf, len, data, dest_addr, addr, key);
 }

--- a/include/rdma/fi_tagged.h
+++ b/include/rdma/fi_tagged.h
@@ -36,66 +36,65 @@
 #include <rdma/fabric.h>
 #include <rdma/fi_endpoint.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
 struct fi_msg_tagged {
-	const struct iovec	*msg_iov;
-	void			**desc;
-	size_t			iov_count;
-	fi_addr_t		addr;
-	uint64_t		tag;
-	uint64_t		ignore;
-	void			*context;
-	uint64_t		data;
+	const struct iovec *msg_iov;
+	void **desc;
+	size_t iov_count;
+	fi_addr_t addr;
+	uint64_t tag;
+	uint64_t ignore;
+	void *context;
+	uint64_t data;
 };
 
 struct fi_ops_tagged {
-	size_t	size;
+	size_t size;
 	ssize_t (*recv)(struct fid_ep *ep, void *buf, size_t len, void *desc,
-			fi_addr_t src_addr,
-			uint64_t tag, uint64_t ignore, void *context);
-	ssize_t (*recvv)(struct fid_ep *ep, const struct iovec *iov, void **desc,
-			size_t count, fi_addr_t src_addr,
-			uint64_t tag, uint64_t ignore, void *context);
+			fi_addr_t src_addr, uint64_t tag, uint64_t ignore,
+			void *context);
+	ssize_t (*recvv)(struct fid_ep *ep, const struct iovec *iov,
+			 void **desc, size_t count, fi_addr_t src_addr,
+			 uint64_t tag, uint64_t ignore, void *context);
 	ssize_t (*recvmsg)(struct fid_ep *ep, const struct fi_msg_tagged *msg,
-			uint64_t flags);
-	ssize_t (*send)(struct fid_ep *ep, const void *buf, size_t len, void *desc,
-			fi_addr_t dest_addr, uint64_t tag, void *context);
-	ssize_t (*sendv)(struct fid_ep *ep, const struct iovec *iov, void **desc,
-			size_t count, fi_addr_t dest_addr, uint64_t tag, void *context);
+			   uint64_t flags);
+	ssize_t (*send)(struct fid_ep *ep, const void *buf, size_t len,
+			void *desc, fi_addr_t dest_addr, uint64_t tag,
+			void *context);
+	ssize_t (*sendv)(struct fid_ep *ep, const struct iovec *iov,
+			 void **desc, size_t count, fi_addr_t dest_addr,
+			 uint64_t tag, void *context);
 	ssize_t (*sendmsg)(struct fid_ep *ep, const struct fi_msg_tagged *msg,
-			uint64_t flags);
-	ssize_t	(*inject)(struct fid_ep *ep, const void *buf, size_t len,
-			fi_addr_t dest_addr, uint64_t tag);
-	ssize_t (*senddata)(struct fid_ep *ep, const void *buf, size_t len, void *desc,
-			uint64_t data, fi_addr_t dest_addr, uint64_t tag, void *context);
-	ssize_t	(*injectdata)(struct fid_ep *ep, const void *buf, size_t len,
-			uint64_t data, fi_addr_t dest_addr, uint64_t tag);
+			   uint64_t flags);
+	ssize_t (*inject)(struct fid_ep *ep, const void *buf, size_t len,
+			  fi_addr_t dest_addr, uint64_t tag);
+	ssize_t (*senddata)(struct fid_ep *ep, const void *buf, size_t len,
+			    void *desc, uint64_t data, fi_addr_t dest_addr,
+			    uint64_t tag, void *context);
+	ssize_t (*injectdata)(struct fid_ep *ep, const void *buf, size_t len,
+			      uint64_t data, fi_addr_t dest_addr, uint64_t tag);
 };
-
 
 #ifdef FABRIC_DIRECT
 #include <rdma/fi_direct_tagged.h>
-#endif	/* FABRIC_DIRECT */
+#endif /* FABRIC_DIRECT */
 
 #ifndef FABRIC_DIRECT_TAGGED
 
-static inline ssize_t
-fi_trecv(struct fid_ep *ep, void *buf, size_t len, void *desc,
-	 fi_addr_t src_addr, uint64_t tag, uint64_t ignore, void *context)
+static inline ssize_t fi_trecv(struct fid_ep *ep, void *buf, size_t len,
+			       void *desc, fi_addr_t src_addr, uint64_t tag,
+			       uint64_t ignore, void *context)
 {
 	return ep->tagged->recv(ep, buf, len, desc, src_addr, tag, ignore,
 				context);
 }
 
-static inline ssize_t
-fi_trecvv(struct fid_ep *ep, const struct iovec *iov, void **desc,
-	  size_t count, fi_addr_t src_addr, uint64_t tag, uint64_t ignore,
-	  void *context)
+static inline ssize_t fi_trecvv(struct fid_ep *ep, const struct iovec *iov,
+				void **desc, size_t count, fi_addr_t src_addr,
+				uint64_t tag, uint64_t ignore, void *context)
 {
 	return ep->tagged->recvv(ep, iov, desc, count, src_addr, tag, ignore,
 				 context);
@@ -107,18 +106,18 @@ fi_trecvmsg(struct fid_ep *ep, const struct fi_msg_tagged *msg, uint64_t flags)
 	return ep->tagged->recvmsg(ep, msg, flags);
 }
 
-static inline ssize_t
-fi_tsend(struct fid_ep *ep, const void *buf, size_t len, void *desc,
-	 fi_addr_t dest_addr, uint64_t tag, void *context)
+static inline ssize_t fi_tsend(struct fid_ep *ep, const void *buf, size_t len,
+			       void *desc, fi_addr_t dest_addr, uint64_t tag,
+			       void *context)
 {
 	return ep->tagged->send(ep, buf, len, desc, dest_addr, tag, context);
 }
 
-static inline ssize_t
-fi_tsendv(struct fid_ep *ep, const struct iovec *iov, void **desc,
-	  size_t count, fi_addr_t dest_addr, uint64_t tag, void *context)
+static inline ssize_t fi_tsendv(struct fid_ep *ep, const struct iovec *iov,
+				void **desc, size_t count, fi_addr_t dest_addr,
+				uint64_t tag, void *context)
 {
-	return ep->tagged->sendv(ep, iov, desc, count, dest_addr,tag, context);
+	return ep->tagged->sendv(ep, iov, desc, count, dest_addr, tag, context);
 }
 
 static inline ssize_t
@@ -127,24 +126,24 @@ fi_tsendmsg(struct fid_ep *ep, const struct fi_msg_tagged *msg, uint64_t flags)
 	return ep->tagged->sendmsg(ep, msg, flags);
 }
 
-static inline ssize_t
-fi_tinject(struct fid_ep *ep, const void *buf, size_t len,
-	   fi_addr_t dest_addr, uint64_t tag)
+static inline ssize_t fi_tinject(struct fid_ep *ep, const void *buf, size_t len,
+				 fi_addr_t dest_addr, uint64_t tag)
 {
 	return ep->tagged->inject(ep, buf, len, dest_addr, tag);
 }
 
-static inline ssize_t
-fi_tsenddata(struct fid_ep *ep, const void *buf, size_t len, void *desc,
-	     uint64_t data, fi_addr_t dest_addr, uint64_t tag, void *context)
+static inline ssize_t fi_tsenddata(struct fid_ep *ep, const void *buf,
+				   size_t len, void *desc, uint64_t data,
+				   fi_addr_t dest_addr, uint64_t tag,
+				   void *context)
 {
-	return ep->tagged->senddata(ep, buf, len, desc, data,
-				    dest_addr, tag, context);
+	return ep->tagged->senddata(ep, buf, len, desc, data, dest_addr, tag,
+				    context);
 }
 
-static inline ssize_t
-fi_tinjectdata(struct fid_ep *ep, const void *buf, size_t len,
-		uint64_t data, fi_addr_t dest_addr, uint64_t tag)
+static inline ssize_t fi_tinjectdata(struct fid_ep *ep, const void *buf,
+				     size_t len, uint64_t data,
+				     fi_addr_t dest_addr, uint64_t tag)
 {
 	return ep->tagged->injectdata(ep, buf, len, data, dest_addr, tag);
 }

--- a/include/rdma/fi_trigger.h
+++ b/include/rdma/fi_trigger.h
@@ -63,76 +63,76 @@ enum fi_op_type {
 };
 
 struct fi_trigger_threshold {
-	struct fid_cntr		*cntr;
-	size_t			threshold;
+	struct fid_cntr *cntr;
+	size_t threshold;
 };
 
 struct fi_trigger_var {
-	enum fi_datatype	datatype;
-	int			count;
-	void			*addr;
+	enum fi_datatype datatype;
+	int count;
+	void *addr;
 	union {
-		uint8_t		val8;
-		uint16_t	val16;
-		uint32_t	val32;
-		uint64_t	val64;
-		uint8_t		*data;
+		uint8_t val8;
+		uint16_t val16;
+		uint32_t val32;
+		uint64_t val64;
+		uint8_t *data;
 	} value;
 };
 
 struct fi_trigger_xpu {
-	int			count;
-	enum fi_hmem_iface	iface;
+	int count;
+	enum fi_hmem_iface iface;
 	union {
-		uint64_t	reserved;
-		int		cuda;
-		int		ze;
+		uint64_t reserved;
+		int cuda;
+		int ze;
 	} device;
-	struct fi_trigger_var	*var;
+	struct fi_trigger_var *var;
 };
 
 struct fi_op_msg {
-	struct fid_ep		*ep;
-	struct fi_msg		msg;
-	uint64_t		flags;
+	struct fid_ep *ep;
+	struct fi_msg msg;
+	uint64_t flags;
 };
 
 struct fi_op_tagged {
-	struct fid_ep		*ep;
-	struct fi_msg_tagged	msg;
-	uint64_t		flags;
+	struct fid_ep *ep;
+	struct fi_msg_tagged msg;
+	uint64_t flags;
 };
 
 struct fi_op_rma {
-	struct fid_ep		*ep;
-	struct fi_msg_rma	msg;
-	uint64_t		flags;
+	struct fid_ep *ep;
+	struct fi_msg_rma msg;
+	uint64_t flags;
 };
 
 struct fi_op_atomic {
-	struct fid_ep		*ep;
-	struct fi_msg_atomic	msg;
-	uint64_t		flags;
+	struct fid_ep *ep;
+	struct fi_msg_atomic msg;
+	uint64_t flags;
 };
 
 struct fi_op_fetch_atomic {
-	struct fid_ep		*ep;
-	struct fi_msg_atomic	msg;
-	struct fi_msg_fetch	fetch;
-	uint64_t		flags;
+	struct fid_ep *ep;
+	struct fi_msg_atomic msg;
+	struct fi_msg_fetch fetch;
+	uint64_t flags;
 };
 
 struct fi_op_compare_atomic {
-	struct fid_ep		*ep;
-	struct fi_msg_atomic	msg;
-	struct fi_msg_fetch	fetch;
-	struct fi_msg_compare	compare;
-	uint64_t		flags;
+	struct fid_ep *ep;
+	struct fi_msg_atomic msg;
+	struct fi_msg_fetch fetch;
+	struct fi_msg_compare compare;
+	uint64_t flags;
 };
 
 struct fi_op_cntr {
-	struct fid_cntr		*cntr;
-	uint64_t		value;
+	struct fid_cntr *cntr;
+	uint64_t value;
 };
 
 #ifdef FABRIC_DIRECT
@@ -143,46 +143,45 @@ struct fi_op_cntr {
 
 /* Size must match struct fi_context */
 struct fi_triggered_context {
-	enum fi_trigger_event			event_type;
+	enum fi_trigger_event event_type;
 	union {
-		struct fi_trigger_threshold	threshold;
-		struct fi_trigger_xpu		xpu;
-		void				*internal[3];
+		struct fi_trigger_threshold threshold;
+		struct fi_trigger_xpu xpu;
+		void *internal[3];
 	} trigger;
 };
 
 /* Size must match struct fi_context2 */
 struct fi_triggered_context2 {
-	enum fi_trigger_event			event_type;
+	enum fi_trigger_event event_type;
 	union {
-		struct fi_trigger_threshold	threshold;
-		struct fi_trigger_xpu		xpu;
-		void				*internal[7];
+		struct fi_trigger_threshold threshold;
+		struct fi_trigger_xpu xpu;
+		void *internal[7];
 	} trigger;
 };
 
 struct fi_deferred_work {
-	struct fi_context2			context;
+	struct fi_context2 context;
 
-	uint64_t				threshold;
-	struct fid_cntr				*triggering_cntr;
-	struct fid_cntr				*completion_cntr;
+	uint64_t threshold;
+	struct fid_cntr *triggering_cntr;
+	struct fid_cntr *completion_cntr;
 
-	enum fi_op_type				op_type;
+	enum fi_op_type op_type;
 
 	union {
-		struct fi_op_msg		*msg;
-		struct fi_op_tagged		*tagged;
-		struct fi_op_rma		*rma;
-		struct fi_op_atomic		*atomic;
-		struct fi_op_fetch_atomic	*fetch_atomic;
-		struct fi_op_compare_atomic	*compare_atomic;
-		struct fi_op_cntr		*cntr;
+		struct fi_op_msg *msg;
+		struct fi_op_tagged *tagged;
+		struct fi_op_rma *rma;
+		struct fi_op_atomic *atomic;
+		struct fi_op_fetch_atomic *fetch_atomic;
+		struct fi_op_compare_atomic *compare_atomic;
+		struct fi_op_cntr *cntr;
 	} op;
 };
 
 #endif
-
 
 #ifdef __cplusplus
 }

--- a/include/rdma/providers/fi_log.h
+++ b/include/rdma/providers/fi_log.h
@@ -72,61 +72,62 @@ void fi_log(const struct fi_provider *prov, enum fi_log_level level,
 	    enum fi_log_subsys subsys, const char *func, int line,
 	    const char *fmt, ...) FI_FORMAT_PRINTF(6, 7);
 
-#define FI_LOG(prov, level, subsystem, ...)				\
-	do {								\
-		if (fi_log_enabled(prov, level, subsystem)) {		\
-			int saved_errno = errno;			\
-			fi_log(prov, level, subsystem,			\
-				__func__, __LINE__, __VA_ARGS__);	\
-			errno = saved_errno;				\
-		}							\
+#define FI_LOG(prov, level, subsystem, ...)                                \
+	do {                                                               \
+		if (fi_log_enabled(prov, level, subsystem)) {              \
+			int saved_errno = errno;                           \
+			fi_log(prov, level, subsystem, __func__, __LINE__, \
+			       __VA_ARGS__);                               \
+			errno = saved_errno;                               \
+		}                                                          \
 	} while (0)
 
-#define FI_LOG_SPARSE(prov, level, subsystem, ...)			\
-	do {								\
-		static uint64_t showtime;				\
-		if (fi_log_ready(prov, level, subsystem, &showtime)) {	\
-			int saved_errno = errno;			\
-			fi_log(prov, level, subsystem,			\
-				__func__, __LINE__, __VA_ARGS__);	\
-			errno = saved_errno;				\
-		}							\
+#define FI_LOG_SPARSE(prov, level, subsystem, ...)                         \
+	do {                                                               \
+		static uint64_t showtime;                                  \
+		if (fi_log_ready(prov, level, subsystem, &showtime)) {     \
+			int saved_errno = errno;                           \
+			fi_log(prov, level, subsystem, __func__, __LINE__, \
+			       __VA_ARGS__);                               \
+			errno = saved_errno;                               \
+		}                                                          \
 	} while (0)
 
-#define FI_WARN(prov, subsystem, ...)					\
+#define FI_WARN(prov, subsystem, ...) \
 	FI_LOG(prov, FI_LOG_WARN, subsystem, __VA_ARGS__)
-#define FI_WARN_SPARSE(prov, subsystem, ...)				\
+#define FI_WARN_SPARSE(prov, subsystem, ...) \
 	FI_LOG_SPARSE(prov, FI_LOG_WARN, subsystem, __VA_ARGS__)
 
-#define FI_TRACE(prov, subsystem, ...)					\
+#define FI_TRACE(prov, subsystem, ...) \
 	FI_LOG(prov, FI_LOG_TRACE, subsystem, __VA_ARGS__)
 
-#define FI_INFO(prov, subsystem, ...)					\
+#define FI_INFO(prov, subsystem, ...) \
 	FI_LOG(prov, FI_LOG_INFO, subsystem, __VA_ARGS__)
 
 #if defined(ENABLE_DEBUG) && ENABLE_DEBUG
-#define FI_DBG(prov, subsystem, ...)					\
+#define FI_DBG(prov, subsystem, ...) \
 	FI_LOG(prov, FI_LOG_DEBUG, subsystem, __VA_ARGS__)
-#define FI_DBG_TRACE(prov, subsystem, ...)				\
+#define FI_DBG_TRACE(prov, subsystem, ...) \
 	FI_LOG(prov, FI_LOG_TRACE, subsystem, __VA_ARGS__)
 #else
-#define FI_DBG(prov_name, subsystem, ...)				\
-	do {} while (0)
-#define FI_DBG_TRACE(prov, subsystem, ...)				\
-	do {} while (0)
+#define FI_DBG(prov_name, subsystem, ...) \
+	do {                              \
+	} while (0)
+#define FI_DBG_TRACE(prov, subsystem, ...) \
+	do {                               \
+	} while (0)
 #endif
 
-#define FI_WARN_ONCE(prov, subsystem, ...)  				\
-	do {								\
-		static int warned = 0;					\
-		if (!warned &&						\
-		    fi_log_enabled(prov, FI_LOG_WARN, subsystem)) {	\
-			int saved_errno = errno;			\
-			fi_log(prov, FI_LOG_WARN, subsystem,		\
-			__func__, __LINE__, __VA_ARGS__);		\
-			warned = 1;					\
-			errno = saved_errno;				\
-		}							\
+#define FI_WARN_ONCE(prov, subsystem, ...)                                     \
+	do {                                                                   \
+		static int warned = 0;                                         \
+		if (!warned && fi_log_enabled(prov, FI_LOG_WARN, subsystem)) { \
+			int saved_errno = errno;                               \
+			fi_log(prov, FI_LOG_WARN, subsystem, __func__,         \
+			       __LINE__, __VA_ARGS__);                         \
+			warned = 1;                                            \
+			errno = saved_errno;                                   \
+		}                                                              \
 	} while (0)
 
 #ifdef __cplusplus

--- a/include/rdma/providers/fi_peer.h
+++ b/include/rdma/providers/fi_peer.h
@@ -42,7 +42,6 @@
 #include <rdma/providers/fi_prov.h>
 #include <rdma/providers/fi_log.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -53,8 +52,8 @@ extern "C" {
 struct fid_peer_av;
 
 struct fi_ops_av_owner {
-	size_t	size;
-	int	(*query)(struct fid_peer_av *av, struct fi_av_attr *attr);
+	size_t size;
+	int (*query)(struct fid_peer_av *av, struct fi_av_attr *attr);
 	fi_addr_t (*ep_addr)(struct fid_peer_av *av, struct fid_ep *ep);
 };
 
@@ -68,16 +67,15 @@ struct fi_peer_av_context {
 	struct fid_peer_av *av;
 };
 
-
 /*
  * Peer provider AV set support.
  */
 struct fid_peer_av_set;
 
 struct fi_ops_av_set_owner {
-	size_t	size;
-	int	(*members)(struct fid_peer_av_set *av, fi_addr_t *addr,
-			   size_t *count);
+	size_t size;
+	int (*members)(struct fid_peer_av_set *av, fi_addr_t *addr,
+		       size_t *count);
 };
 
 struct fid_peer_av_set {
@@ -90,19 +88,18 @@ struct fi_peer_av_set_context {
 	struct fi_peer_av_set *av_set;
 };
 
-
 /*
  * Peer provider CQ support.
  */
 struct fid_peer_cq;
 
 struct fi_ops_cq_owner {
-	size_t	size;
+	size_t size;
 	ssize_t (*write)(struct fid_peer_cq *cq, void *context, uint64_t flags,
-			size_t len, void *buf, uint64_t data, uint64_t tag,
-			fi_addr_t src);
-	ssize_t	(*writeerr)(struct fid_peer_cq *cq,
-			const struct fi_cq_err_entry *err_entry);
+			 size_t len, void *buf, uint64_t data, uint64_t tag,
+			 fi_addr_t src);
+	ssize_t (*writeerr)(struct fid_peer_cq *cq,
+			    const struct fi_cq_err_entry *err_entry);
 };
 
 struct fid_peer_cq {
@@ -115,7 +112,6 @@ struct fi_peer_cq_context {
 	struct fid_peer_cq *cq;
 };
 
-
 /*
  * Peer provider domain support.
  */
@@ -124,7 +120,6 @@ struct fi_peer_domain_context {
 	struct fid_domain *domain;
 };
 
-
 /*
  * Peer provider EQ support.
  */
@@ -132,7 +127,6 @@ struct fi_peer_eq_context {
 	size_t size;
 	struct fid_eq *eq;
 };
-
 
 /*
  * Peer shared rx context
@@ -157,23 +151,23 @@ struct fi_peer_rx_entry {
 };
 
 struct fi_ops_srx_owner {
-	size_t	size;
-	int	(*get_msg)(struct fid_peer_srx *srx, fi_addr_t addr,
-			size_t size, struct fi_peer_rx_entry **entry);
-	int	(*get_tag)(struct fid_peer_srx *srx, fi_addr_t addr,
-			uint64_t tag, struct fi_peer_rx_entry **entry);
-	int	(*queue_msg)(struct fi_peer_rx_entry *entry);
-	int	(*queue_tag)(struct fi_peer_rx_entry *entry);
+	size_t size;
+	int (*get_msg)(struct fid_peer_srx *srx, fi_addr_t addr, size_t size,
+		       struct fi_peer_rx_entry **entry);
+	int (*get_tag)(struct fid_peer_srx *srx, fi_addr_t addr, uint64_t tag,
+		       struct fi_peer_rx_entry **entry);
+	int (*queue_msg)(struct fi_peer_rx_entry *entry);
+	int (*queue_tag)(struct fi_peer_rx_entry *entry);
 
-	void	(*free_entry)(struct fi_peer_rx_entry *entry);
+	void (*free_entry)(struct fi_peer_rx_entry *entry);
 };
 
 struct fi_ops_srx_peer {
-	size_t	size;
-	int	(*start_msg)(struct fi_peer_rx_entry *entry);
-	int	(*start_tag)(struct fi_peer_rx_entry *entry);
-	int	(*discard_msg)(struct fi_peer_rx_entry *entry);
-	int	(*discard_tag)(struct fi_peer_rx_entry *entry);
+	size_t size;
+	int (*start_msg)(struct fi_peer_rx_entry *entry);
+	int (*start_tag)(struct fi_peer_rx_entry *entry);
+	int (*discard_msg)(struct fi_peer_rx_entry *entry);
+	int (*discard_tag)(struct fi_peer_rx_entry *entry);
 };
 
 struct fid_peer_srx {
@@ -187,7 +181,6 @@ struct fi_peer_srx_context {
 	struct fid_peer_srx *srx;
 };
 
-
 /*
  * Peer transfers
  */
@@ -195,9 +188,9 @@ struct fi_peer_transfer_context;
 
 struct fi_ops_transfer_peer {
 	size_t size;
-	ssize_t	(*complete)(struct fid_ep *ep, struct fi_cq_tagged_entry *buf,
+	ssize_t (*complete)(struct fid_ep *ep, struct fi_cq_tagged_entry *buf,
 			    fi_addr_t src_addr);
-	ssize_t	(*comperr)(struct fid_ep *ep, struct fi_cq_err_entry *buf);
+	ssize_t (*comperr)(struct fid_ep *ep, struct fi_cq_err_entry *buf);
 };
 
 struct fi_peer_transfer_context {
@@ -206,7 +199,6 @@ struct fi_peer_transfer_context {
 	struct fid_ep *ep;
 	struct fi_ops_transfer_peer *peer_ops;
 };
-
 
 #ifdef __cplusplus
 }

--- a/include/rdma/providers/fi_prov.h
+++ b/include/rdma/providers/fi_prov.h
@@ -56,23 +56,23 @@ extern "C" {
  * This is invoked by the libfabric framework when the provider library
  * is loaded.
  */
-#define FI_EXT_INI \
-	__attribute__((visibility ("default"),EXTERNALLY_VISIBLE)) \
-	struct fi_provider* fi_prov_ini(void)
+#define FI_EXT_INI                                               \
+	__attribute__((visibility("default"),                    \
+		       EXTERNALLY_VISIBLE)) struct fi_provider * \
+	fi_prov_ini(void)
 
 struct fi_provider {
 	uint32_t version;
 	uint32_t fi_version;
 	struct fi_context context;
 	const char *name;
-	int	(*getinfo)(uint32_t version, const char *node, const char *service,
-			uint64_t flags, const struct fi_info *hints,
-			struct fi_info **info);
-	int	(*fabric)(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
-			void *context);
-	void	(*cleanup)(void);
+	int (*getinfo)(uint32_t version, const char *node, const char *service,
+		       uint64_t flags, const struct fi_info *hints,
+		       struct fi_info **info);
+	int (*fabric)(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
+		      void *context);
+	void (*cleanup)(void);
 };
-
 
 /*
  * Defines a configuration parameter for use with libfabric.
@@ -90,26 +90,26 @@ int fi_param_define(const struct fi_provider *provider, const char *param_name,
 int fi_param_get(struct fi_provider *provider, const char *param_name,
 		 void *value);
 
-static inline int
-fi_param_get_str(struct fi_provider *provider, const char *param_name, char **value)
+static inline int fi_param_get_str(struct fi_provider *provider,
+				   const char *param_name, char **value)
 {
 	return fi_param_get(provider, param_name, value);
 }
 
-static inline int
-fi_param_get_int(struct fi_provider *provider, const char *param_name, int *value)
+static inline int fi_param_get_int(struct fi_provider *provider,
+				   const char *param_name, int *value)
 {
 	return fi_param_get(provider, param_name, value);
 }
 
-static inline int
-fi_param_get_bool(struct fi_provider *provider, const char *param_name, int *value)
+static inline int fi_param_get_bool(struct fi_provider *provider,
+				    const char *param_name, int *value)
 {
 	return fi_param_get(provider, param_name, value);
 }
 
-static inline int
-fi_param_get_size_t(struct fi_provider *provider, const char *param_name, size_t *value)
+static inline int fi_param_get_size_t(struct fi_provider *provider,
+				      const char *param_name, size_t *value)
 {
 	return fi_param_get(provider, param_name, value);
 }

--- a/include/unix/osd.h
+++ b/include/unix/osd.h
@@ -43,7 +43,6 @@
 #include <sys/uio.h>
 #include <rdma/fi_errno.h>
 
-
 /* MSG_NOSIGNAL doesn't exist on OS X */
 #ifndef MSG_NOSIGNAL
 #define MSG_NOSIGNAL 0
@@ -69,25 +68,21 @@
 #define OFI_UNUSED UNREFERENCED_PARAMETER
 #endif
 
-#define OFI_SOCK_TRY_SND_RCV_AGAIN(err)		\
-	(((err) == EAGAIN)	||		\
-	 ((err) == EWOULDBLOCK))
+#define OFI_SOCK_TRY_SND_RCV_AGAIN(err) \
+	(((err) == EAGAIN) || ((err) == EWOULDBLOCK))
 
-#define OFI_SOCK_TRY_ACCEPT_AGAIN(err)		\
-	(((err) == EAGAIN)	||		\
-	 ((err) == EWOULDBLOCK))
+#define OFI_SOCK_TRY_ACCEPT_AGAIN(err) \
+	(((err) == EAGAIN) || ((err) == EWOULDBLOCK))
 
-#define OFI_SOCK_TRY_CONN_AGAIN(err)	\
-	((err) == EINPROGRESS)
+#define OFI_SOCK_TRY_CONN_AGAIN(err) ((err) == EINPROGRESS)
 
-#define OFI_MAX_SOCKET_BUF_SIZE	SIZE_MAX
+#define OFI_MAX_SOCKET_BUF_SIZE SIZE_MAX
 
-struct util_shm
-{
-	int		shared_fd;
-	void		*ptr;
-	const char	*name;
-	size_t		size;
+struct util_shm {
+	int shared_fd;
+	void *ptr;
+	const char *name;
+	size_t size;
 };
 
 int ofi_mmap_anon_pages(void **memptr, size_t size, int flags);
@@ -111,12 +106,14 @@ static inline void ofi_osd_fini(void)
 {
 }
 
-static inline int ofi_getsockname(SOCKET fd, struct sockaddr *addr, socklen_t *len)
+static inline int ofi_getsockname(SOCKET fd, struct sockaddr *addr,
+				  socklen_t *len)
 {
 	return getsockname(fd, addr, len);
 }
 
-static inline int ofi_getpeername(SOCKET fd, struct sockaddr *addr, socklen_t *len)
+static inline int ofi_getpeername(SOCKET fd, struct sockaddr *addr,
+				  socklen_t *len)
 {
 	return getpeername(fd, addr, len);
 }
@@ -126,14 +123,13 @@ static inline SOCKET ofi_socket(int domain, int type, int protocol)
 	return socket(domain, type, protocol);
 }
 
-static inline ssize_t
-ofi_sendmsg_udp(SOCKET fd, const struct msghdr *msg, int flags)
+static inline ssize_t ofi_sendmsg_udp(SOCKET fd, const struct msghdr *msg,
+				      int flags)
 {
 	return sendmsg(fd, msg, flags);
 }
 
-static inline ssize_t
-ofi_recvmsg_udp(SOCKET fd, struct msghdr *msg, int flags)
+static inline ssize_t ofi_recvmsg_udp(SOCKET fd, struct msghdr *msg, int flags)
 {
 	return recvmsg(fd, msg, flags);
 }
@@ -180,14 +176,17 @@ static inline long ofi_sysconf(int name)
 #define s6_addr32 __u6_addr.__u6_addr32
 #endif /* s6_addr32 */
 
-static inline int ofi_is_loopback_addr(struct sockaddr *addr) {
+static inline int ofi_is_loopback_addr(struct sockaddr *addr)
+{
 	return (addr->sa_family == AF_INET &&
-		((struct sockaddr_in *)addr)->sin_addr.s_addr == htonl(INADDR_LOOPBACK)) ||
-		(addr->sa_family == AF_INET6 &&
+		((struct sockaddr_in *)addr)->sin_addr.s_addr ==
+			htonl(INADDR_LOOPBACK)) ||
+	       (addr->sa_family == AF_INET6 &&
 		((struct sockaddr_in6 *)addr)->sin6_addr.s6_addr32[0] == 0 &&
 		((struct sockaddr_in6 *)addr)->sin6_addr.s6_addr32[1] == 0 &&
 		((struct sockaddr_in6 *)addr)->sin6_addr.s6_addr32[2] == 0 &&
-		((struct sockaddr_in6 *)addr)->sin6_addr.s6_addr32[3] == htonl(1));
+		((struct sockaddr_in6 *)addr)->sin6_addr.s6_addr32[3] ==
+			htonl(1));
 }
 
 #if !HAVE_CLOCK_GETTIME
@@ -208,71 +207,71 @@ typedef float complex ofi_complex_float;
 typedef double complex ofi_complex_double;
 typedef long double complex ofi_complex_long_double;
 
-#define OFI_DEF_COMPLEX_OPS(type)				\
-static inline int ofi_complex_eq_## type			\
-	(ofi_complex_## type a, ofi_complex_## type b)		\
-{								\
-	return a == b;						\
-}								\
-static inline ofi_complex_## type ofi_complex_sum_## type	\
-	(ofi_complex_## type a, ofi_complex_## type b)		\
-{								\
-	return a + b;						\
-}								\
-static inline ofi_complex_## type ofi_complex_prod_## type	\
-	(ofi_complex_## type a, ofi_complex_## type b)		\
-{								\
-	return a * b;						\
-}								\
-static inline ofi_complex_## type ofi_complex_land_## type	\
-	(ofi_complex_## type a, ofi_complex_## type b)		\
-{								\
-	return a && b;      					\
-}								\
-static inline ofi_complex_## type ofi_complex_lor_## type	\
-	(ofi_complex_## type a, ofi_complex_## type b)		\
-{								\
-	return a || b;						\
-}								\
-static inline int ofi_complex_lxor_## type			\
-	(ofi_complex_## type a, ofi_complex_## type b)		\
-{								\
-	return (a && !b) || (!a && b);				\
-}								\
+#define OFI_DEF_COMPLEX_OPS(type)                                       \
+	static inline int ofi_complex_eq_##type(ofi_complex_##type a,   \
+						ofi_complex_##type b)   \
+	{                                                               \
+		return a == b;                                          \
+	}                                                               \
+	static inline ofi_complex_##type ofi_complex_sum_##type(        \
+		ofi_complex_##type a, ofi_complex_##type b)             \
+	{                                                               \
+		return a + b;                                           \
+	}                                                               \
+	static inline ofi_complex_##type ofi_complex_prod_##type(       \
+		ofi_complex_##type a, ofi_complex_##type b)             \
+	{                                                               \
+		return a * b;                                           \
+	}                                                               \
+	static inline ofi_complex_##type ofi_complex_land_##type(       \
+		ofi_complex_##type a, ofi_complex_##type b)             \
+	{                                                               \
+		return a && b;                                          \
+	}                                                               \
+	static inline ofi_complex_##type ofi_complex_lor_##type(        \
+		ofi_complex_##type a, ofi_complex_##type b)             \
+	{                                                               \
+		return a || b;                                          \
+	}                                                               \
+	static inline int ofi_complex_lxor_##type(ofi_complex_##type a, \
+						  ofi_complex_##type b) \
+	{                                                               \
+		return (a && !b) || (!a && b);                          \
+	}
 
 OFI_DEF_COMPLEX_OPS(float)
 OFI_DEF_COMPLEX_OPS(double)
 OFI_DEF_COMPLEX_OPS(long_double)
 
-
 /* atomics primitives */
 #ifdef HAVE_BUILTIN_ATOMICS
-#define ofi_atomic_add_and_fetch(radix, ptr, val) __sync_add_and_fetch((ptr), (val))
-#define ofi_atomic_sub_and_fetch(radix, ptr, val) __sync_sub_and_fetch((ptr), (val))
-#define ofi_atomic_cas_bool(radix, ptr, expected, desired) 	\
+#define ofi_atomic_add_and_fetch(radix, ptr, val) \
+	__sync_add_and_fetch((ptr), (val))
+#define ofi_atomic_sub_and_fetch(radix, ptr, val) \
+	__sync_sub_and_fetch((ptr), (val))
+#define ofi_atomic_cas_bool(radix, ptr, expected, desired) \
 	__sync_bool_compare_and_swap((ptr), (expected), (desired))
 #endif /* HAVE_BUILTIN_ATOMICS */
 
 int ofi_set_thread_affinity(const char *s);
 
-
 #if defined(HAVE_CPUID) && (defined(__x86_64__) || defined(__amd64__))
 
 #include <cpuid.h>
 
-static inline void
-ofi_cpuid(unsigned func, unsigned subfunc, unsigned cpuinfo[4])
+static inline void ofi_cpuid(unsigned func, unsigned subfunc,
+			     unsigned cpuinfo[4])
 {
-	__cpuid_count(func, subfunc, cpuinfo[0], cpuinfo[1],
-		      cpuinfo[2], cpuinfo[3]);
+	__cpuid_count(func, subfunc, cpuinfo[0], cpuinfo[1], cpuinfo[2],
+		      cpuinfo[3]);
 }
 
 #define ofi_clwb(addr) \
-	asm volatile(".byte 0x66; xsaveopt %0" : "+m" (*(volatile char *) (addr)))
+	asm volatile(".byte 0x66; xsaveopt %0" : "+m"(*(volatile char *)(addr)))
 #define ofi_clflushopt(addr) \
-	asm volatile(".byte 0x66; clflush %0" : "+m" (*(volatile char *) addr))
+	asm volatile(".byte 0x66; clflush %0" : "+m"(*(volatile char *)addr))
 #define ofi_clflush(addr) \
-	asm volatile("clflush %0" : "+m" (*(volatile char *) addr))
+	asm volatile("clflush %0" : "+m"(*(volatile char *)addr))
 #define ofi_sfence() asm volatile("sfence" ::: "memory")
 
 #else /* defined(__x86_64__) || defined(__amd64__) */

--- a/include/uthash.h
+++ b/include/uthash.h
@@ -26,40 +26,41 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define UTHASH_VERSION 2.0.2
 
-#include <string.h>   /* memcmp, memset, strlen */
-#include <stddef.h>   /* ptrdiff_t */
-#include <stdlib.h>   /* exit */
+#include <string.h> /* memcmp, memset, strlen */
+#include <stddef.h> /* ptrdiff_t */
+#include <stdlib.h> /* exit */
 
 /* These macros use decltype or the earlier __typeof GNU extension.
    As decltype is only available in newer compilers (VS2010 or gcc 4.3+
    when compiling c++ source) this code uses whatever method is needed
    or, for VS2008 where neither is available, uses casting workarounds. */
 #if !defined(DECLTYPE) && !defined(NO_DECLTYPE)
-#if defined(_MSC_VER)   /* MS compiler */
-#if _MSC_VER >= 1600 && defined(__cplusplus)  /* VS2010 or newer in C++ mode */
+#if defined(_MSC_VER) /* MS compiler */
+#if _MSC_VER >= 1600 && defined(__cplusplus) /* VS2010 or newer in C++ mode */
 #define DECLTYPE(x) (decltype(x))
-#else                   /* VS2008 or older (or VS2010 in C mode) */
+#else /* VS2008 or older (or VS2010 in C mode) */
 #define NO_DECLTYPE
 #endif
-#elif defined(__BORLANDC__) || defined(__ICCARM__) || defined(__LCC__) || defined(__WATCOMC__)
+#elif defined(__BORLANDC__) || defined(__ICCARM__) || defined(__LCC__) || \
+	defined(__WATCOMC__)
 #define NO_DECLTYPE
-#else                   /* GNU, Sun and other compilers */
+#else /* GNU, Sun and other compilers */
 #define DECLTYPE(x) (__typeof(x))
 #endif
 #endif
 
 #ifdef NO_DECLTYPE
 #define DECLTYPE(x)
-#define DECLTYPE_ASSIGN(dst,src)                                                 \
-do {                                                                             \
-  char **_da_dst = (char**)(&(dst));                                             \
-  *_da_dst = (char*)(src);                                                       \
-} while (0)
+#define DECLTYPE_ASSIGN(dst, src)                   \
+	do {                                        \
+		char **_da_dst = (char **)(&(dst)); \
+		*_da_dst = (char *)(src);           \
+	} while (0)
 #else
-#define DECLTYPE_ASSIGN(dst,src)                                                 \
-do {                                                                             \
-  (dst) = DECLTYPE(dst)(src);                                                    \
-} while (0)
+#define DECLTYPE_ASSIGN(dst, src)           \
+	do {                                \
+		(dst) = DECLTYPE(dst)(src); \
+	} while (0)
 #endif
 
 /* a number of the hash function use uint32_t which isn't defined on Pre VS2010 */
@@ -80,26 +81,26 @@ typedef unsigned char uint8_t;
 #endif
 
 #ifndef uthash_malloc
-#define uthash_malloc(sz) malloc(sz)      /* malloc fcn                      */
+#define uthash_malloc(sz) malloc(sz) /* malloc fcn                      */
 #endif
 #ifndef uthash_free
-#define uthash_free(ptr,sz) free(ptr)     /* free fcn                        */
+#define uthash_free(ptr, sz) free(ptr) /* free fcn                        */
 #endif
 #ifndef uthash_bzero
-#define uthash_bzero(a,n) memset(a,'\0',n)
+#define uthash_bzero(a, n) memset(a, '\0', n)
 #endif
 #ifndef uthash_memcmp
-#define uthash_memcmp(a,b,n) memcmp(a,b,n)
+#define uthash_memcmp(a, b, n) memcmp(a, b, n)
 #endif
 #ifndef uthash_strlen
 #define uthash_strlen(s) strlen(s)
 #endif
 
 #ifndef uthash_noexpand_fyi
-#define uthash_noexpand_fyi(tbl)          /* can be defined to log noexpand  */
+#define uthash_noexpand_fyi(tbl) /* can be defined to log noexpand  */
 #endif
 #ifndef uthash_expand_fyi
-#define uthash_expand_fyi(tbl)            /* can be defined to log expands   */
+#define uthash_expand_fyi(tbl) /* can be defined to log expands   */
 #endif
 
 #ifndef HASH_NONFATAL_OOM
@@ -110,17 +111,22 @@ typedef unsigned char uint8_t;
 /* malloc failures can be recovered from */
 
 #ifndef uthash_nonfatal_oom
-#define uthash_nonfatal_oom(obj) do {} while (0)    /* non-fatal OOM error */
+#define uthash_nonfatal_oom(obj) \
+	do {                     \
+	} while (0) /* non-fatal OOM error */
 #endif
 
-#define HASH_RECORD_OOM(oomed) do { (oomed) = 1; } while (0)
+#define HASH_RECORD_OOM(oomed) \
+	do {                   \
+		(oomed) = 1;   \
+	} while (0)
 #define IF_HASH_NONFATAL_OOM(x) x
 
 #else
 /* malloc failures result in lost memory, hash tables are unusable */
 
 #ifndef uthash_fatal
-#define uthash_fatal(msg) exit(-1)        /* fatal OOM error */
+#define uthash_fatal(msg) exit(-1) /* fatal OOM error */
 #endif
 
 #define HASH_RECORD_OOM(oomed) uthash_fatal("out of memory")
@@ -129,308 +135,366 @@ typedef unsigned char uint8_t;
 #endif
 
 /* initial number of buckets */
-#define HASH_INITIAL_NUM_BUCKETS 32U     /* initial number of buckets        */
+#define HASH_INITIAL_NUM_BUCKETS 32U /* initial number of buckets        */
 #define HASH_INITIAL_NUM_BUCKETS_LOG2 5U /* lg2 of initial number of buckets */
-#define HASH_BKT_CAPACITY_THRESH 10U     /* expand when bucket count reaches */
+#define HASH_BKT_CAPACITY_THRESH 10U /* expand when bucket count reaches */
 
 /* calculate the element whose hash handle address is hhp */
-#define ELMT_FROM_HH(tbl,hhp) ((void*)(((char*)(hhp)) - ((tbl)->hho)))
+#define ELMT_FROM_HH(tbl, hhp) ((void *)(((char *)(hhp)) - ((tbl)->hho)))
 /* calculate the hash handle from element address elp */
-#define HH_FROM_ELMT(tbl,elp) ((UT_hash_handle *)(((char*)(elp)) + ((tbl)->hho)))
+#define HH_FROM_ELMT(tbl, elp) \
+	((UT_hash_handle *)(((char *)(elp)) + ((tbl)->hho)))
 
-#define HASH_ROLLBACK_BKT(hh, head, itemptrhh)                                   \
-do {                                                                             \
-  struct UT_hash_handle *_hd_hh_item = (itemptrhh);                              \
-  unsigned _hd_bkt;                                                              \
-  HASH_TO_BKT(_hd_hh_item->hashv, (head)->hh.tbl->num_buckets, _hd_bkt);         \
-  (head)->hh.tbl->buckets[_hd_bkt].count++;                                      \
-  _hd_hh_item->hh_next = NULL;                                                   \
-  _hd_hh_item->hh_prev = NULL;                                                   \
-} while (0)
+#define HASH_ROLLBACK_BKT(hh, head, itemptrhh)                               \
+	do {                                                                 \
+		struct UT_hash_handle *_hd_hh_item = (itemptrhh);            \
+		unsigned _hd_bkt;                                            \
+		HASH_TO_BKT(_hd_hh_item->hashv, (head)->hh.tbl->num_buckets, \
+			    _hd_bkt);                                        \
+		(head)->hh.tbl->buckets[_hd_bkt].count++;                    \
+		_hd_hh_item->hh_next = NULL;                                 \
+		_hd_hh_item->hh_prev = NULL;                                 \
+	} while (0)
 
-#define HASH_VALUE(keyptr,keylen,hashv)                                          \
-do {                                                                             \
-  HASH_FCN(keyptr, keylen, hashv);                                               \
-} while (0)
+#define HASH_VALUE(keyptr, keylen, hashv)        \
+	do {                                     \
+		HASH_FCN(keyptr, keylen, hashv); \
+	} while (0)
 
-#define HASH_FIND_BYHASHVALUE(hh,head,keyptr,keylen,hashval,out)                 \
-do {                                                                             \
-  (out) = NULL;                                                                  \
-  if (head) {                                                                    \
-    unsigned _hf_bkt;                                                            \
-    HASH_TO_BKT(hashval, (head)->hh.tbl->num_buckets, _hf_bkt);                  \
-    if (HASH_BLOOM_TEST((head)->hh.tbl, hashval) != 0) {                         \
-      HASH_FIND_IN_BKT((head)->hh.tbl, hh, (head)->hh.tbl->buckets[ _hf_bkt ], keyptr, keylen, hashval, out); \
-    }                                                                            \
-  }                                                                              \
-} while (0)
+#define HASH_FIND_BYHASHVALUE(hh, head, keyptr, keylen, hashval, out)        \
+	do {                                                                 \
+		(out) = NULL;                                                \
+		if (head) {                                                  \
+			unsigned _hf_bkt;                                    \
+			HASH_TO_BKT(hashval, (head)->hh.tbl->num_buckets,    \
+				    _hf_bkt);                                \
+			if (HASH_BLOOM_TEST((head)->hh.tbl, hashval) != 0) { \
+				HASH_FIND_IN_BKT(                            \
+					(head)->hh.tbl, hh,                  \
+					(head)->hh.tbl->buckets[_hf_bkt],    \
+					keyptr, keylen, hashval, out);       \
+			}                                                    \
+		}                                                            \
+	} while (0)
 
-#define HASH_FIND(hh,head,keyptr,keylen,out)                                     \
-do {                                                                             \
-  unsigned _hf_hashv;                                                            \
-  HASH_VALUE(keyptr, keylen, _hf_hashv);                                         \
-  HASH_FIND_BYHASHVALUE(hh, head, keyptr, keylen, _hf_hashv, out);               \
-} while (0)
+#define HASH_FIND(hh, head, keyptr, keylen, out)                           \
+	do {                                                               \
+		unsigned _hf_hashv;                                        \
+		HASH_VALUE(keyptr, keylen, _hf_hashv);                     \
+		HASH_FIND_BYHASHVALUE(hh, head, keyptr, keylen, _hf_hashv, \
+				      out);                                \
+	} while (0)
 
 #ifdef HASH_BLOOM
 #define HASH_BLOOM_BITLEN (1UL << HASH_BLOOM)
-#define HASH_BLOOM_BYTELEN (HASH_BLOOM_BITLEN/8UL) + (((HASH_BLOOM_BITLEN%8UL)!=0UL) ? 1UL : 0UL)
-#define HASH_BLOOM_MAKE(tbl,oomed)                                               \
-do {                                                                             \
-  (tbl)->bloom_nbits = HASH_BLOOM;                                               \
-  (tbl)->bloom_bv = (uint8_t*)uthash_malloc(HASH_BLOOM_BYTELEN);                 \
-  if (!(tbl)->bloom_bv) {                                                        \
-    HASH_RECORD_OOM(oomed);                                                      \
-  } else {                                                                       \
-    uthash_bzero((tbl)->bloom_bv, HASH_BLOOM_BYTELEN);                           \
-    (tbl)->bloom_sig = HASH_BLOOM_SIGNATURE;                                     \
-  }                                                                              \
-} while (0)
+#define HASH_BLOOM_BYTELEN          \
+	(HASH_BLOOM_BITLEN / 8UL) + \
+		(((HASH_BLOOM_BITLEN % 8UL) != 0UL) ? 1UL : 0UL)
+#define HASH_BLOOM_MAKE(tbl, oomed)                                        \
+	do {                                                               \
+		(tbl)->bloom_nbits = HASH_BLOOM;                           \
+		(tbl)->bloom_bv =                                          \
+			(uint8_t *)uthash_malloc(HASH_BLOOM_BYTELEN);      \
+		if (!(tbl)->bloom_bv) {                                    \
+			HASH_RECORD_OOM(oomed);                            \
+		} else {                                                   \
+			uthash_bzero((tbl)->bloom_bv, HASH_BLOOM_BYTELEN); \
+			(tbl)->bloom_sig = HASH_BLOOM_SIGNATURE;           \
+		}                                                          \
+	} while (0)
 
-#define HASH_BLOOM_FREE(tbl)                                                     \
-do {                                                                             \
-  uthash_free((tbl)->bloom_bv, HASH_BLOOM_BYTELEN);                              \
-} while (0)
+#define HASH_BLOOM_FREE(tbl)                                      \
+	do {                                                      \
+		uthash_free((tbl)->bloom_bv, HASH_BLOOM_BYTELEN); \
+	} while (0)
 
-#define HASH_BLOOM_BITSET(bv,idx) (bv[(idx)/8U] |= (1U << ((idx)%8U)))
-#define HASH_BLOOM_BITTEST(bv,idx) (bv[(idx)/8U] & (1U << ((idx)%8U)))
+#define HASH_BLOOM_BITSET(bv, idx) (bv[(idx) / 8U] |= (1U << ((idx) % 8U)))
+#define HASH_BLOOM_BITTEST(bv, idx) (bv[(idx) / 8U] & (1U << ((idx) % 8U)))
 
-#define HASH_BLOOM_ADD(tbl,hashv)                                                \
-  HASH_BLOOM_BITSET((tbl)->bloom_bv, ((hashv) & (uint32_t)((1UL << (tbl)->bloom_nbits) - 1U)))
+#define HASH_BLOOM_ADD(tbl, hashv)         \
+	HASH_BLOOM_BITSET((tbl)->bloom_bv, \
+			  ((hashv) &       \
+			   (uint32_t)((1UL << (tbl)->bloom_nbits) - 1U)))
 
-#define HASH_BLOOM_TEST(tbl,hashv)                                               \
-  HASH_BLOOM_BITTEST((tbl)->bloom_bv, ((hashv) & (uint32_t)((1UL << (tbl)->bloom_nbits) - 1U)))
+#define HASH_BLOOM_TEST(tbl, hashv)         \
+	HASH_BLOOM_BITTEST((tbl)->bloom_bv, \
+			   ((hashv) &       \
+			    (uint32_t)((1UL << (tbl)->bloom_nbits) - 1U)))
 
 #else
-#define HASH_BLOOM_MAKE(tbl,oomed)
+#define HASH_BLOOM_MAKE(tbl, oomed)
 #define HASH_BLOOM_FREE(tbl)
-#define HASH_BLOOM_ADD(tbl,hashv)
-#define HASH_BLOOM_TEST(tbl,hashv) (1)
+#define HASH_BLOOM_ADD(tbl, hashv)
+#define HASH_BLOOM_TEST(tbl, hashv) (1)
 #define HASH_BLOOM_BYTELEN 0U
 #endif
 
-#define HASH_MAKE_TABLE(hh,head,oomed)                                           \
-do {                                                                             \
-  (head)->hh.tbl = (UT_hash_table*)uthash_malloc(sizeof(UT_hash_table));         \
-  if (!(head)->hh.tbl) {                                                         \
-    HASH_RECORD_OOM(oomed);                                                      \
-  } else {                                                                       \
-    uthash_bzero((head)->hh.tbl, sizeof(UT_hash_table));                         \
-    (head)->hh.tbl->tail = &((head)->hh);                                        \
-    (head)->hh.tbl->num_buckets = HASH_INITIAL_NUM_BUCKETS;                      \
-    (head)->hh.tbl->log2_num_buckets = HASH_INITIAL_NUM_BUCKETS_LOG2;            \
-    (head)->hh.tbl->hho = (char*)(&(head)->hh) - (char*)(head);                  \
-    (head)->hh.tbl->buckets = (UT_hash_bucket*)uthash_malloc(                    \
-        HASH_INITIAL_NUM_BUCKETS * sizeof(struct UT_hash_bucket));               \
-    (head)->hh.tbl->signature = HASH_SIGNATURE;                                  \
-    if (!(head)->hh.tbl->buckets) {                                              \
-      HASH_RECORD_OOM(oomed);                                                    \
-      uthash_free((head)->hh.tbl, sizeof(UT_hash_table));                        \
-    } else {                                                                     \
-      uthash_bzero((head)->hh.tbl->buckets,                                      \
-          HASH_INITIAL_NUM_BUCKETS * sizeof(struct UT_hash_bucket));             \
-      HASH_BLOOM_MAKE((head)->hh.tbl, oomed);                                    \
-      IF_HASH_NONFATAL_OOM(                                                      \
-        if (oomed) {                                                             \
-          uthash_free((head)->hh.tbl->buckets,                                   \
-              HASH_INITIAL_NUM_BUCKETS*sizeof(struct UT_hash_bucket));           \
-          uthash_free((head)->hh.tbl, sizeof(UT_hash_table));                    \
-        }                                                                        \
-      )                                                                          \
-    }                                                                            \
-  }                                                                              \
-} while (0)
+#define HASH_MAKE_TABLE(hh, head, oomed)                                                \
+	do {                                                                            \
+		(head)->hh.tbl =                                                        \
+			(UT_hash_table *)uthash_malloc(sizeof(UT_hash_table));          \
+		if (!(head)->hh.tbl) {                                                  \
+			HASH_RECORD_OOM(oomed);                                         \
+		} else {                                                                \
+			uthash_bzero((head)->hh.tbl, sizeof(UT_hash_table));            \
+			(head)->hh.tbl->tail = &((head)->hh);                           \
+			(head)->hh.tbl->num_buckets =                                   \
+				HASH_INITIAL_NUM_BUCKETS;                               \
+			(head)->hh.tbl->log2_num_buckets =                              \
+				HASH_INITIAL_NUM_BUCKETS_LOG2;                          \
+			(head)->hh.tbl->hho =                                           \
+				(char *)(&(head)->hh) - (char *)(head);                 \
+			(head)->hh.tbl->buckets =                                       \
+				(UT_hash_bucket *)uthash_malloc(                        \
+					HASH_INITIAL_NUM_BUCKETS *                      \
+					sizeof(struct UT_hash_bucket));                 \
+			(head)->hh.tbl->signature = HASH_SIGNATURE;                     \
+			if (!(head)->hh.tbl->buckets) {                                 \
+				HASH_RECORD_OOM(oomed);                                 \
+				uthash_free((head)->hh.tbl,                             \
+					    sizeof(UT_hash_table));                     \
+			} else {                                                        \
+				uthash_bzero(                                           \
+					(head)->hh.tbl->buckets,                        \
+					HASH_INITIAL_NUM_BUCKETS *                      \
+						sizeof(struct UT_hash_bucket));         \
+				HASH_BLOOM_MAKE((head)->hh.tbl, oomed);                 \
+				IF_HASH_NONFATAL_OOM(if (oomed) {                       \
+					uthash_free(                                    \
+						(head)->hh.tbl->buckets,                \
+						HASH_INITIAL_NUM_BUCKETS *              \
+							sizeof(struct UT_hash_bucket)); \
+					uthash_free((head)->hh.tbl,                     \
+						    sizeof(UT_hash_table));             \
+				})                                                      \
+			}                                                               \
+		}                                                                       \
+	} while (0)
 
-#define HASH_REPLACE_BYHASHVALUE_INORDER(hh,head,fieldname,keylen_in,hashval,add,replaced,cmpfcn) \
-do {                                                                             \
-  (replaced) = NULL;                                                             \
-  HASH_FIND_BYHASHVALUE(hh, head, &((add)->fieldname), keylen_in, hashval, replaced); \
-  if (replaced) {                                                                \
-    HASH_DELETE(hh, head, replaced);                                             \
-  }                                                                              \
-  HASH_ADD_KEYPTR_BYHASHVALUE_INORDER(hh, head, &((add)->fieldname), keylen_in, hashval, add, cmpfcn); \
-} while (0)
+#define HASH_REPLACE_BYHASHVALUE_INORDER(hh, head, fieldname, keylen_in,     \
+					 hashval, add, replaced, cmpfcn)     \
+	do {                                                                 \
+		(replaced) = NULL;                                           \
+		HASH_FIND_BYHASHVALUE(hh, head, &((add)->fieldname),         \
+				      keylen_in, hashval, replaced);         \
+		if (replaced) {                                              \
+			HASH_DELETE(hh, head, replaced);                     \
+		}                                                            \
+		HASH_ADD_KEYPTR_BYHASHVALUE_INORDER(hh, head,                \
+						    &((add)->fieldname),     \
+						    keylen_in, hashval, add, \
+						    cmpfcn);                 \
+	} while (0)
 
-#define HASH_REPLACE_BYHASHVALUE(hh,head,fieldname,keylen_in,hashval,add,replaced) \
-do {                                                                             \
-  (replaced) = NULL;                                                             \
-  HASH_FIND_BYHASHVALUE(hh, head, &((add)->fieldname), keylen_in, hashval, replaced); \
-  if (replaced) {                                                                \
-    HASH_DELETE(hh, head, replaced);                                             \
-  }                                                                              \
-  HASH_ADD_KEYPTR_BYHASHVALUE(hh, head, &((add)->fieldname), keylen_in, hashval, add); \
-} while (0)
+#define HASH_REPLACE_BYHASHVALUE(hh, head, fieldname, keylen_in, hashval, add, \
+				 replaced)                                     \
+	do {                                                                   \
+		(replaced) = NULL;                                             \
+		HASH_FIND_BYHASHVALUE(hh, head, &((add)->fieldname),           \
+				      keylen_in, hashval, replaced);           \
+		if (replaced) {                                                \
+			HASH_DELETE(hh, head, replaced);                       \
+		}                                                              \
+		HASH_ADD_KEYPTR_BYHASHVALUE(hh, head, &((add)->fieldname),     \
+					    keylen_in, hashval, add);          \
+	} while (0)
 
-#define HASH_REPLACE(hh,head,fieldname,keylen_in,add,replaced)                   \
-do {                                                                             \
-  unsigned _hr_hashv;                                                            \
-  HASH_VALUE(&((add)->fieldname), keylen_in, _hr_hashv);                         \
-  HASH_REPLACE_BYHASHVALUE(hh, head, fieldname, keylen_in, _hr_hashv, add, replaced); \
-} while (0)
+#define HASH_REPLACE(hh, head, fieldname, keylen_in, add, replaced)      \
+	do {                                                             \
+		unsigned _hr_hashv;                                      \
+		HASH_VALUE(&((add)->fieldname), keylen_in, _hr_hashv);   \
+		HASH_REPLACE_BYHASHVALUE(hh, head, fieldname, keylen_in, \
+					 _hr_hashv, add, replaced);      \
+	} while (0)
 
-#define HASH_REPLACE_INORDER(hh,head,fieldname,keylen_in,add,replaced,cmpfcn)    \
-do {                                                                             \
-  unsigned _hr_hashv;                                                            \
-  HASH_VALUE(&((add)->fieldname), keylen_in, _hr_hashv);                         \
-  HASH_REPLACE_BYHASHVALUE_INORDER(hh, head, fieldname, keylen_in, _hr_hashv, add, replaced, cmpfcn); \
-} while (0)
+#define HASH_REPLACE_INORDER(hh, head, fieldname, keylen_in, add, replaced, \
+			     cmpfcn)                                        \
+	do {                                                                \
+		unsigned _hr_hashv;                                         \
+		HASH_VALUE(&((add)->fieldname), keylen_in, _hr_hashv);      \
+		HASH_REPLACE_BYHASHVALUE_INORDER(hh, head, fieldname,       \
+						 keylen_in, _hr_hashv, add, \
+						 replaced, cmpfcn);         \
+	} while (0)
 
-#define HASH_APPEND_LIST(hh, head, add)                                          \
-do {                                                                             \
-  (add)->hh.next = NULL;                                                         \
-  (add)->hh.prev = ELMT_FROM_HH((head)->hh.tbl, (head)->hh.tbl->tail);           \
-  (head)->hh.tbl->tail->next = (add);                                            \
-  (head)->hh.tbl->tail = &((add)->hh);                                           \
-} while (0)
+#define HASH_APPEND_LIST(hh, head, add)                                     \
+	do {                                                                \
+		(add)->hh.next = NULL;                                      \
+		(add)->hh.prev =                                            \
+			ELMT_FROM_HH((head)->hh.tbl, (head)->hh.tbl->tail); \
+		(head)->hh.tbl->tail->next = (add);                         \
+		(head)->hh.tbl->tail = &((add)->hh);                        \
+	} while (0)
 
-#define HASH_AKBI_INNER_LOOP(hh,head,add,cmpfcn)                                 \
-do {                                                                             \
-  do {                                                                           \
-    if (cmpfcn(DECLTYPE(head)(_hs_iter), add) > 0) {                             \
-      break;                                                                     \
-    }                                                                            \
-  } while ((_hs_iter = HH_FROM_ELMT((head)->hh.tbl, _hs_iter)->next));           \
-} while (0)
+#define HASH_AKBI_INNER_LOOP(hh, head, add, cmpfcn)                         \
+	do {                                                                \
+		do {                                                        \
+			if (cmpfcn(DECLTYPE(head)(_hs_iter), add) > 0) {    \
+				break;                                      \
+			}                                                   \
+		} while ((_hs_iter = HH_FROM_ELMT((head)->hh.tbl, _hs_iter) \
+					     ->next));                      \
+	} while (0)
 
 #ifdef NO_DECLTYPE
 #undef HASH_AKBI_INNER_LOOP
-#define HASH_AKBI_INNER_LOOP(hh,head,add,cmpfcn)                                 \
-do {                                                                             \
-  char *_hs_saved_head = (char*)(head);                                          \
-  do {                                                                           \
-    DECLTYPE_ASSIGN(head, _hs_iter);                                             \
-    if (cmpfcn(head, add) > 0) {                                                 \
-      DECLTYPE_ASSIGN(head, _hs_saved_head);                                     \
-      break;                                                                     \
-    }                                                                            \
-    DECLTYPE_ASSIGN(head, _hs_saved_head);                                       \
-  } while ((_hs_iter = HH_FROM_ELMT((head)->hh.tbl, _hs_iter)->next));           \
-} while (0)
+#define HASH_AKBI_INNER_LOOP(hh, head, add, cmpfcn)                         \
+	do {                                                                \
+		char *_hs_saved_head = (char *)(head);                      \
+		do {                                                        \
+			DECLTYPE_ASSIGN(head, _hs_iter);                    \
+			if (cmpfcn(head, add) > 0) {                        \
+				DECLTYPE_ASSIGN(head, _hs_saved_head);      \
+				break;                                      \
+			}                                                   \
+			DECLTYPE_ASSIGN(head, _hs_saved_head);              \
+		} while ((_hs_iter = HH_FROM_ELMT((head)->hh.tbl, _hs_iter) \
+					     ->next));                      \
+	} while (0)
 #endif
 
 #if HASH_NONFATAL_OOM
 
-#define HASH_ADD_TO_TABLE(hh,head,keyptr,keylen_in,hashval,add,oomed)            \
-do {                                                                             \
-  if (!(oomed)) {                                                                \
-    unsigned _ha_bkt;                                                            \
-    (head)->hh.tbl->num_items++;                                                 \
-    HASH_TO_BKT(hashval, (head)->hh.tbl->num_buckets, _ha_bkt);                  \
-    HASH_ADD_TO_BKT((head)->hh.tbl->buckets[_ha_bkt], hh, &(add)->hh, oomed);    \
-    if (oomed) {                                                                 \
-      HASH_ROLLBACK_BKT(hh, head, &(add)->hh);                                   \
-      HASH_DELETE_HH(hh, head, &(add)->hh);                                      \
-      (add)->hh.tbl = NULL;                                                      \
-      uthash_nonfatal_oom(add);                                                  \
-    } else {                                                                     \
-      HASH_BLOOM_ADD((head)->hh.tbl, hashval);                                   \
-      HASH_EMIT_KEY(hh, head, keyptr, keylen_in);                                \
-    }                                                                            \
-  } else {                                                                       \
-    (add)->hh.tbl = NULL;                                                        \
-    uthash_nonfatal_oom(add);                                                    \
-  }                                                                              \
-} while (0)
+#define HASH_ADD_TO_TABLE(hh, head, keyptr, keylen_in, hashval, add, oomed)   \
+	do {                                                                  \
+		if (!(oomed)) {                                               \
+			unsigned _ha_bkt;                                     \
+			(head)->hh.tbl->num_items++;                          \
+			HASH_TO_BKT(hashval, (head)->hh.tbl->num_buckets,     \
+				    _ha_bkt);                                 \
+			HASH_ADD_TO_BKT((head)->hh.tbl->buckets[_ha_bkt], hh, \
+					&(add)->hh, oomed);                   \
+			if (oomed) {                                          \
+				HASH_ROLLBACK_BKT(hh, head, &(add)->hh);      \
+				HASH_DELETE_HH(hh, head, &(add)->hh);         \
+				(add)->hh.tbl = NULL;                         \
+				uthash_nonfatal_oom(add);                     \
+			} else {                                              \
+				HASH_BLOOM_ADD((head)->hh.tbl, hashval);      \
+				HASH_EMIT_KEY(hh, head, keyptr, keylen_in);   \
+			}                                                     \
+		} else {                                                      \
+			(add)->hh.tbl = NULL;                                 \
+			uthash_nonfatal_oom(add);                             \
+		}                                                             \
+	} while (0)
 
 #else
 
-#define HASH_ADD_TO_TABLE(hh,head,keyptr,keylen_in,hashval,add,oomed)            \
-do {                                                                             \
-  unsigned _ha_bkt;                                                              \
-  (head)->hh.tbl->num_items++;                                                   \
-  HASH_TO_BKT(hashval, (head)->hh.tbl->num_buckets, _ha_bkt);                    \
-  HASH_ADD_TO_BKT((head)->hh.tbl->buckets[_ha_bkt], hh, &(add)->hh, oomed);      \
-  HASH_BLOOM_ADD((head)->hh.tbl, hashval);                                       \
-  HASH_EMIT_KEY(hh, head, keyptr, keylen_in);                                    \
-} while (0)
+#define HASH_ADD_TO_TABLE(hh, head, keyptr, keylen_in, hashval, add, oomed) \
+	do {                                                                \
+		unsigned _ha_bkt;                                           \
+		(head)->hh.tbl->num_items++;                                \
+		HASH_TO_BKT(hashval, (head)->hh.tbl->num_buckets, _ha_bkt); \
+		HASH_ADD_TO_BKT((head)->hh.tbl->buckets[_ha_bkt], hh,       \
+				&(add)->hh, oomed);                         \
+		HASH_BLOOM_ADD((head)->hh.tbl, hashval);                    \
+		HASH_EMIT_KEY(hh, head, keyptr, keylen_in);                 \
+	} while (0)
 
 #endif
 
+#define HASH_ADD_KEYPTR_BYHASHVALUE_INORDER(hh, head, keyptr, keylen_in,       \
+					    hashval, add, cmpfcn)              \
+	do {                                                                   \
+		IF_HASH_NONFATAL_OOM(int _ha_oomed = 0;)                       \
+		(add)->hh.hashv = (hashval);                                   \
+		(add)->hh.key = (char *)(keyptr);                              \
+		(add)->hh.keylen = (unsigned)(keylen_in);                      \
+		if (!(head)) {                                                 \
+			(add)->hh.next = NULL;                                 \
+			(add)->hh.prev = NULL;                                 \
+			HASH_MAKE_TABLE(hh, add, _ha_oomed);                   \
+			IF_HASH_NONFATAL_OOM(if (!_ha_oomed) { )                                    \
+      (head) = (add);                                                          \
+    IF_HASH_NONFATAL_OOM(                                                      \
+			})                                                     \
+		} else {                                                       \
+			void *_hs_iter = (head);                               \
+			(add)->hh.tbl = (head)->hh.tbl;                        \
+			HASH_AKBI_INNER_LOOP(hh, head, add, cmpfcn);           \
+			if (_hs_iter) {                                        \
+				(add)->hh.next = _hs_iter;                     \
+				if (((add)->hh.prev =                          \
+					     HH_FROM_ELMT((head)->hh.tbl,      \
+							  _hs_iter)            \
+						     ->prev)) {                \
+					HH_FROM_ELMT((head)->hh.tbl,           \
+						     (add)->hh.prev)           \
+						->next = (add);                \
+				} else {                                       \
+					(head) = (add);                        \
+				}                                              \
+				HH_FROM_ELMT((head)->hh.tbl, _hs_iter)->prev = \
+					(add);                                 \
+			} else {                                               \
+				HASH_APPEND_LIST(hh, head, add);               \
+			}                                                      \
+		}                                                              \
+		HASH_ADD_TO_TABLE(hh, head, keyptr, keylen_in, hashval, add,   \
+				  _ha_oomed);                                  \
+		HASH_FSCK(hh, head, "HASH_ADD_KEYPTR_BYHASHVALUE_INORDER");    \
+	} while (0)
 
-#define HASH_ADD_KEYPTR_BYHASHVALUE_INORDER(hh,head,keyptr,keylen_in,hashval,add,cmpfcn) \
-do {                                                                             \
-  IF_HASH_NONFATAL_OOM( int _ha_oomed = 0; )                                     \
-  (add)->hh.hashv = (hashval);                                                   \
-  (add)->hh.key = (char*) (keyptr);                                              \
-  (add)->hh.keylen = (unsigned) (keylen_in);                                     \
-  if (!(head)) {                                                                 \
-    (add)->hh.next = NULL;                                                       \
-    (add)->hh.prev = NULL;                                                       \
-    HASH_MAKE_TABLE(hh, add, _ha_oomed);                                         \
-    IF_HASH_NONFATAL_OOM( if (!_ha_oomed) { )                                    \
-      (head) = (add);                                                            \
-    IF_HASH_NONFATAL_OOM( } )                                                    \
-  } else {                                                                       \
-    void *_hs_iter = (head);                                                     \
-    (add)->hh.tbl = (head)->hh.tbl;                                              \
-    HASH_AKBI_INNER_LOOP(hh, head, add, cmpfcn);                                 \
-    if (_hs_iter) {                                                              \
-      (add)->hh.next = _hs_iter;                                                 \
-      if (((add)->hh.prev = HH_FROM_ELMT((head)->hh.tbl, _hs_iter)->prev)) {     \
-        HH_FROM_ELMT((head)->hh.tbl, (add)->hh.prev)->next = (add);              \
-      } else {                                                                   \
-        (head) = (add);                                                          \
-      }                                                                          \
-      HH_FROM_ELMT((head)->hh.tbl, _hs_iter)->prev = (add);                      \
-    } else {                                                                     \
-      HASH_APPEND_LIST(hh, head, add);                                           \
-    }                                                                            \
-  }                                                                              \
-  HASH_ADD_TO_TABLE(hh, head, keyptr, keylen_in, hashval, add, _ha_oomed);       \
-  HASH_FSCK(hh, head, "HASH_ADD_KEYPTR_BYHASHVALUE_INORDER");                    \
-} while (0)
+#define HASH_ADD_KEYPTR_INORDER(hh, head, keyptr, keylen_in, add, cmpfcn)     \
+	do {                                                                  \
+		unsigned _hs_hashv;                                           \
+		HASH_VALUE(keyptr, keylen_in, _hs_hashv);                     \
+		HASH_ADD_KEYPTR_BYHASHVALUE_INORDER(                          \
+			hh, head, keyptr, keylen_in, _hs_hashv, add, cmpfcn); \
+	} while (0)
 
-#define HASH_ADD_KEYPTR_INORDER(hh,head,keyptr,keylen_in,add,cmpfcn)             \
-do {                                                                             \
-  unsigned _hs_hashv;                                                            \
-  HASH_VALUE(keyptr, keylen_in, _hs_hashv);                                      \
-  HASH_ADD_KEYPTR_BYHASHVALUE_INORDER(hh, head, keyptr, keylen_in, _hs_hashv, add, cmpfcn); \
-} while (0)
+#define HASH_ADD_BYHASHVALUE_INORDER(hh, head, fieldname, keylen_in, hashval, \
+				     add, cmpfcn)                             \
+	HASH_ADD_KEYPTR_BYHASHVALUE_INORDER(hh, head, &((add)->fieldname),    \
+					    keylen_in, hashval, add, cmpfcn)
 
-#define HASH_ADD_BYHASHVALUE_INORDER(hh,head,fieldname,keylen_in,hashval,add,cmpfcn) \
-  HASH_ADD_KEYPTR_BYHASHVALUE_INORDER(hh, head, &((add)->fieldname), keylen_in, hashval, add, cmpfcn)
+#define HASH_ADD_INORDER(hh, head, fieldname, keylen_in, add, cmpfcn)          \
+	HASH_ADD_KEYPTR_INORDER(hh, head, &((add)->fieldname), keylen_in, add, \
+				cmpfcn)
 
-#define HASH_ADD_INORDER(hh,head,fieldname,keylen_in,add,cmpfcn)                 \
-  HASH_ADD_KEYPTR_INORDER(hh, head, &((add)->fieldname), keylen_in, add, cmpfcn)
+#define HASH_ADD_KEYPTR_BYHASHVALUE(hh, head, keyptr, keylen_in, hashval, add) \
+	do {                                                                   \
+		IF_HASH_NONFATAL_OOM(int _ha_oomed = 0;)                       \
+		(add)->hh.hashv = (hashval);                                   \
+		(add)->hh.key = (char *)(keyptr);                              \
+		(add)->hh.keylen = (unsigned)(keylen_in);                      \
+		if (!(head)) {                                                 \
+			(add)->hh.next = NULL;                                 \
+			(add)->hh.prev = NULL;                                 \
+			HASH_MAKE_TABLE(hh, add, _ha_oomed);                   \
+			IF_HASH_NONFATAL_OOM(if (!_ha_oomed) { )                                    \
+      (head) = (add);                                                          \
+    IF_HASH_NONFATAL_OOM(                                                      \
+			})                                                     \
+		} else {                                                       \
+			(add)->hh.tbl = (head)->hh.tbl;                        \
+			HASH_APPEND_LIST(hh, head, add);                       \
+		}                                                              \
+		HASH_ADD_TO_TABLE(hh, head, keyptr, keylen_in, hashval, add,   \
+				  _ha_oomed);                                  \
+		HASH_FSCK(hh, head, "HASH_ADD_KEYPTR_BYHASHVALUE");            \
+	} while (0)
 
-#define HASH_ADD_KEYPTR_BYHASHVALUE(hh,head,keyptr,keylen_in,hashval,add)        \
-do {                                                                             \
-  IF_HASH_NONFATAL_OOM( int _ha_oomed = 0; )                                     \
-  (add)->hh.hashv = (hashval);                                                   \
-  (add)->hh.key = (char*) (keyptr);                                              \
-  (add)->hh.keylen = (unsigned) (keylen_in);                                     \
-  if (!(head)) {                                                                 \
-    (add)->hh.next = NULL;                                                       \
-    (add)->hh.prev = NULL;                                                       \
-    HASH_MAKE_TABLE(hh, add, _ha_oomed);                                         \
-    IF_HASH_NONFATAL_OOM( if (!_ha_oomed) { )                                    \
-      (head) = (add);                                                            \
-    IF_HASH_NONFATAL_OOM( } )                                                    \
-  } else {                                                                       \
-    (add)->hh.tbl = (head)->hh.tbl;                                              \
-    HASH_APPEND_LIST(hh, head, add);                                             \
-  }                                                                              \
-  HASH_ADD_TO_TABLE(hh, head, keyptr, keylen_in, hashval, add, _ha_oomed);       \
-  HASH_FSCK(hh, head, "HASH_ADD_KEYPTR_BYHASHVALUE");                            \
-} while (0)
+#define HASH_ADD_KEYPTR(hh, head, keyptr, keylen_in, add)                \
+	do {                                                             \
+		unsigned _ha_hashv;                                      \
+		HASH_VALUE(keyptr, keylen_in, _ha_hashv);                \
+		HASH_ADD_KEYPTR_BYHASHVALUE(hh, head, keyptr, keylen_in, \
+					    _ha_hashv, add);             \
+	} while (0)
 
-#define HASH_ADD_KEYPTR(hh,head,keyptr,keylen_in,add)                            \
-do {                                                                             \
-  unsigned _ha_hashv;                                                            \
-  HASH_VALUE(keyptr, keylen_in, _ha_hashv);                                      \
-  HASH_ADD_KEYPTR_BYHASHVALUE(hh, head, keyptr, keylen_in, _ha_hashv, add);      \
-} while (0)
+#define HASH_ADD_BYHASHVALUE(hh, head, fieldname, keylen_in, hashval, add)    \
+	HASH_ADD_KEYPTR_BYHASHVALUE(hh, head, &((add)->fieldname), keylen_in, \
+				    hashval, add)
 
-#define HASH_ADD_BYHASHVALUE(hh,head,fieldname,keylen_in,hashval,add)            \
-  HASH_ADD_KEYPTR_BYHASHVALUE(hh, head, &((add)->fieldname), keylen_in, hashval, add)
+#define HASH_ADD(hh, head, fieldname, keylen_in, add) \
+	HASH_ADD_KEYPTR(hh, head, &((add)->fieldname), keylen_in, add)
 
-#define HASH_ADD(hh,head,fieldname,keylen_in,add)                                \
-  HASH_ADD_KEYPTR(hh, head, &((add)->fieldname), keylen_in, add)
-
-#define HASH_TO_BKT(hashv,num_bkts,bkt)                                          \
-do {                                                                             \
-  bkt = ((hashv) & ((num_bkts) - 1U));                                           \
-} while (0)
+#define HASH_TO_BKT(hashv, num_bkts, bkt)          \
+	do {                                       \
+		bkt = ((hashv) & ((num_bkts)-1U)); \
+	} while (0)
 
 /* delete "delptr" from the hash table.
  * "the usual" patch-up process for the app-order doubly-linked-list.
@@ -444,138 +508,172 @@ do {                                                                            
  * copy the deletee pointer, then the latter references are via that
  * scratch pointer rather than through the repointed (users) symbol.
  */
-#define HASH_DELETE(hh,head,delptr)                                              \
-    HASH_DELETE_HH(hh, head, &(delptr)->hh)
+#define HASH_DELETE(hh, head, delptr) HASH_DELETE_HH(hh, head, &(delptr)->hh)
 
-#define HASH_DELETE_HH(hh,head,delptrhh)                                         \
-do {                                                                             \
-  struct UT_hash_handle *_hd_hh_del = (delptrhh);                                \
-  if ((_hd_hh_del->prev == NULL) && (_hd_hh_del->next == NULL)) {                \
-    HASH_BLOOM_FREE((head)->hh.tbl);                                             \
-    uthash_free((head)->hh.tbl->buckets,                                         \
-                (head)->hh.tbl->num_buckets * sizeof(struct UT_hash_bucket));    \
-    uthash_free((head)->hh.tbl, sizeof(UT_hash_table));                          \
-    (head) = NULL;                                                               \
-  } else {                                                                       \
-    unsigned _hd_bkt;                                                            \
-    if (_hd_hh_del == (head)->hh.tbl->tail) {                                    \
-      (head)->hh.tbl->tail = HH_FROM_ELMT((head)->hh.tbl, _hd_hh_del->prev);     \
-    }                                                                            \
-    if (_hd_hh_del->prev != NULL) {                                              \
-      HH_FROM_ELMT((head)->hh.tbl, _hd_hh_del->prev)->next = _hd_hh_del->next;   \
-    } else {                                                                     \
-      DECLTYPE_ASSIGN(head, _hd_hh_del->next);                                   \
-    }                                                                            \
-    if (_hd_hh_del->next != NULL) {                                              \
-      HH_FROM_ELMT((head)->hh.tbl, _hd_hh_del->next)->prev = _hd_hh_del->prev;   \
-    }                                                                            \
-    HASH_TO_BKT(_hd_hh_del->hashv, (head)->hh.tbl->num_buckets, _hd_bkt);        \
-    HASH_DEL_IN_BKT((head)->hh.tbl->buckets[_hd_bkt], _hd_hh_del);               \
-    (head)->hh.tbl->num_items--;                                                 \
-  }                                                                              \
-  HASH_FSCK(hh, head, "HASH_DELETE_HH");                                         \
-} while (0)
+#define HASH_DELETE_HH(hh, head, delptrhh)                                     \
+	do {                                                                   \
+		struct UT_hash_handle *_hd_hh_del = (delptrhh);                \
+		if ((_hd_hh_del->prev == NULL) &&                              \
+		    (_hd_hh_del->next == NULL)) {                              \
+			HASH_BLOOM_FREE((head)->hh.tbl);                       \
+			uthash_free((head)->hh.tbl->buckets,                   \
+				    (head)->hh.tbl->num_buckets *              \
+					    sizeof(struct UT_hash_bucket));    \
+			uthash_free((head)->hh.tbl, sizeof(UT_hash_table));    \
+			(head) = NULL;                                         \
+		} else {                                                       \
+			unsigned _hd_bkt;                                      \
+			if (_hd_hh_del == (head)->hh.tbl->tail) {              \
+				(head)->hh.tbl->tail = HH_FROM_ELMT(           \
+					(head)->hh.tbl, _hd_hh_del->prev);     \
+			}                                                      \
+			if (_hd_hh_del->prev != NULL) {                        \
+				HH_FROM_ELMT((head)->hh.tbl, _hd_hh_del->prev) \
+					->next = _hd_hh_del->next;             \
+			} else {                                               \
+				DECLTYPE_ASSIGN(head, _hd_hh_del->next);       \
+			}                                                      \
+			if (_hd_hh_del->next != NULL) {                        \
+				HH_FROM_ELMT((head)->hh.tbl, _hd_hh_del->next) \
+					->prev = _hd_hh_del->prev;             \
+			}                                                      \
+			HASH_TO_BKT(_hd_hh_del->hashv,                         \
+				    (head)->hh.tbl->num_buckets, _hd_bkt);     \
+			HASH_DEL_IN_BKT((head)->hh.tbl->buckets[_hd_bkt],      \
+					_hd_hh_del);                           \
+			(head)->hh.tbl->num_items--;                           \
+		}                                                              \
+		HASH_FSCK(hh, head, "HASH_DELETE_HH");                         \
+	} while (0)
 
 /* convenience forms of HASH_FIND/HASH_ADD/HASH_DEL */
-#define HASH_FIND_STR(head,findstr,out)                                          \
-do {                                                                             \
-    unsigned _uthash_hfstr_keylen = (unsigned)uthash_strlen(findstr);            \
-    HASH_FIND(hh, head, findstr, _uthash_hfstr_keylen, out);                     \
-} while (0)
-#define HASH_ADD_STR(head,strfield,add)                                          \
-do {                                                                             \
-    unsigned _uthash_hastr_keylen = (unsigned)uthash_strlen((add)->strfield);    \
-    HASH_ADD(hh, head, strfield[0], _uthash_hastr_keylen, add);                  \
-} while (0)
-#define HASH_REPLACE_STR(head,strfield,add,replaced)                             \
-do {                                                                             \
-    unsigned _uthash_hrstr_keylen = (unsigned)uthash_strlen((add)->strfield);    \
-    HASH_REPLACE(hh, head, strfield[0], _uthash_hrstr_keylen, add, replaced);    \
-} while (0)
-#define HASH_FIND_INT(head,findint,out)                                          \
-    HASH_FIND(hh,head,findint,sizeof(int),out)
-#define HASH_ADD_INT(head,intfield,add)                                          \
-    HASH_ADD(hh,head,intfield,sizeof(int),add)
-#define HASH_REPLACE_INT(head,intfield,add,replaced)                             \
-    HASH_REPLACE(hh,head,intfield,sizeof(int),add,replaced)
-#define HASH_FIND_PTR(head,findptr,out)                                          \
-    HASH_FIND(hh,head,findptr,sizeof(void *),out)
-#define HASH_ADD_PTR(head,ptrfield,add)                                          \
-    HASH_ADD(hh,head,ptrfield,sizeof(void *),add)
-#define HASH_REPLACE_PTR(head,ptrfield,add,replaced)                             \
-    HASH_REPLACE(hh,head,ptrfield,sizeof(void *),add,replaced)
-#define HASH_DEL(head,delptr)                                                    \
-    HASH_DELETE(hh,head,delptr)
+#define HASH_FIND_STR(head, findstr, out)                                \
+	do {                                                             \
+		unsigned _uthash_hfstr_keylen =                          \
+			(unsigned)uthash_strlen(findstr);                \
+		HASH_FIND(hh, head, findstr, _uthash_hfstr_keylen, out); \
+	} while (0)
+#define HASH_ADD_STR(head, strfield, add)                                   \
+	do {                                                                \
+		unsigned _uthash_hastr_keylen =                             \
+			(unsigned)uthash_strlen((add)->strfield);           \
+		HASH_ADD(hh, head, strfield[0], _uthash_hastr_keylen, add); \
+	} while (0)
+#define HASH_REPLACE_STR(head, strfield, add, replaced)                        \
+	do {                                                                   \
+		unsigned _uthash_hrstr_keylen =                                \
+			(unsigned)uthash_strlen((add)->strfield);              \
+		HASH_REPLACE(hh, head, strfield[0], _uthash_hrstr_keylen, add, \
+			     replaced);                                        \
+	} while (0)
+#define HASH_FIND_INT(head, findint, out) \
+	HASH_FIND(hh, head, findint, sizeof(int), out)
+#define HASH_ADD_INT(head, intfield, add) \
+	HASH_ADD(hh, head, intfield, sizeof(int), add)
+#define HASH_REPLACE_INT(head, intfield, add, replaced) \
+	HASH_REPLACE(hh, head, intfield, sizeof(int), add, replaced)
+#define HASH_FIND_PTR(head, findptr, out) \
+	HASH_FIND(hh, head, findptr, sizeof(void *), out)
+#define HASH_ADD_PTR(head, ptrfield, add) \
+	HASH_ADD(hh, head, ptrfield, sizeof(void *), add)
+#define HASH_REPLACE_PTR(head, ptrfield, add, replaced) \
+	HASH_REPLACE(hh, head, ptrfield, sizeof(void *), add, replaced)
+#define HASH_DEL(head, delptr) HASH_DELETE(hh, head, delptr)
 
 /* HASH_FSCK checks hash integrity on every add/delete when HASH_DEBUG is defined.
  * This is for uthash developer only; it compiles away if HASH_DEBUG isn't defined.
  */
 #ifdef HASH_DEBUG
-#define HASH_OOPS(...) do { fprintf(stderr,__VA_ARGS__); exit(-1); } while (0)
-#define HASH_FSCK(hh,head,where)                                                 \
-do {                                                                             \
-  struct UT_hash_handle *_thh;                                                   \
-  if (head) {                                                                    \
-    unsigned _bkt_i;                                                             \
-    unsigned _count = 0;                                                         \
-    char *_prev;                                                                 \
-    for (_bkt_i = 0; _bkt_i < (head)->hh.tbl->num_buckets; ++_bkt_i) {           \
-      unsigned _bkt_count = 0;                                                   \
-      _thh = (head)->hh.tbl->buckets[_bkt_i].hh_head;                            \
-      _prev = NULL;                                                              \
-      while (_thh) {                                                             \
-        if (_prev != (char*)(_thh->hh_prev)) {                                   \
-          HASH_OOPS("%s: invalid hh_prev %p, actual %p\n",                       \
-              (where), (void*)_thh->hh_prev, (void*)_prev);                      \
-        }                                                                        \
-        _bkt_count++;                                                            \
-        _prev = (char*)(_thh);                                                   \
-        _thh = _thh->hh_next;                                                    \
-      }                                                                          \
-      _count += _bkt_count;                                                      \
-      if ((head)->hh.tbl->buckets[_bkt_i].count !=  _bkt_count) {                \
-        HASH_OOPS("%s: invalid bucket count %u, actual %u\n",                    \
-            (where), (head)->hh.tbl->buckets[_bkt_i].count, _bkt_count);         \
-      }                                                                          \
-    }                                                                            \
-    if (_count != (head)->hh.tbl->num_items) {                                   \
-      HASH_OOPS("%s: invalid hh item count %u, actual %u\n",                     \
-          (where), (head)->hh.tbl->num_items, _count);                           \
-    }                                                                            \
-    _count = 0;                                                                  \
-    _prev = NULL;                                                                \
-    _thh =  &(head)->hh;                                                         \
-    while (_thh) {                                                               \
-      _count++;                                                                  \
-      if (_prev != (char*)_thh->prev) {                                          \
-        HASH_OOPS("%s: invalid prev %p, actual %p\n",                            \
-            (where), (void*)_thh->prev, (void*)_prev);                           \
-      }                                                                          \
-      _prev = (char*)ELMT_FROM_HH((head)->hh.tbl, _thh);                         \
-      _thh = (_thh->next ? HH_FROM_ELMT((head)->hh.tbl, _thh->next) : NULL);     \
-    }                                                                            \
-    if (_count != (head)->hh.tbl->num_items) {                                   \
-      HASH_OOPS("%s: invalid app item count %u, actual %u\n",                    \
-          (where), (head)->hh.tbl->num_items, _count);                           \
-    }                                                                            \
-  }                                                                              \
-} while (0)
+#define HASH_OOPS(...)                        \
+	do {                                  \
+		fprintf(stderr, __VA_ARGS__); \
+		exit(-1);                     \
+	} while (0)
+#define HASH_FSCK(hh, head, where)                                                             \
+	do {                                                                                   \
+		struct UT_hash_handle *_thh;                                                   \
+		if (head) {                                                                    \
+			unsigned _bkt_i;                                                       \
+			unsigned _count = 0;                                                   \
+			char *_prev;                                                           \
+			for (_bkt_i = 0; _bkt_i < (head)->hh.tbl->num_buckets;                 \
+			     ++_bkt_i) {                                                       \
+				unsigned _bkt_count = 0;                                       \
+				_thh = (head)->hh.tbl->buckets[_bkt_i].hh_head;                \
+				_prev = NULL;                                                  \
+				while (_thh) {                                                 \
+					if (_prev !=                                           \
+					    (char *)(_thh->hh_prev)) {                         \
+						HASH_OOPS(                                     \
+							"%s: invalid hh_prev %p, actual %p\n", \
+							(where),                               \
+							(void *)_thh->hh_prev,                 \
+							(void *)_prev);                        \
+					}                                                      \
+					_bkt_count++;                                          \
+					_prev = (char *)(_thh);                                \
+					_thh = _thh->hh_next;                                  \
+				}                                                              \
+				_count += _bkt_count;                                          \
+				if ((head)->hh.tbl->buckets[_bkt_i].count !=                   \
+				    _bkt_count) {                                              \
+					HASH_OOPS(                                             \
+						"%s: invalid bucket count %u, actual %u\n",    \
+						(where),                                       \
+						(head)->hh.tbl                                 \
+							->buckets[_bkt_i]                      \
+							.count,                                \
+						_bkt_count);                                   \
+				}                                                              \
+			}                                                                      \
+			if (_count != (head)->hh.tbl->num_items) {                             \
+				HASH_OOPS(                                                     \
+					"%s: invalid hh item count %u, actual %u\n",           \
+					(where), (head)->hh.tbl->num_items,                    \
+					_count);                                               \
+			}                                                                      \
+			_count = 0;                                                            \
+			_prev = NULL;                                                          \
+			_thh = &(head)->hh;                                                    \
+			while (_thh) {                                                         \
+				_count++;                                                      \
+				if (_prev != (char *)_thh->prev) {                             \
+					HASH_OOPS(                                             \
+						"%s: invalid prev %p, actual %p\n",            \
+						(where), (void *)_thh->prev,                   \
+						(void *)_prev);                                \
+				}                                                              \
+				_prev = (char *)ELMT_FROM_HH((head)->hh.tbl,                   \
+							     _thh);                            \
+				_thh = (_thh->next ?                                           \
+						HH_FROM_ELMT((head)->hh.tbl,                   \
+							     _thh->next) :                     \
+						NULL);                                         \
+			}                                                                      \
+			if (_count != (head)->hh.tbl->num_items) {                             \
+				HASH_OOPS(                                                     \
+					"%s: invalid app item count %u, actual %u\n",          \
+					(where), (head)->hh.tbl->num_items,                    \
+					_count);                                               \
+			}                                                                      \
+		}                                                                              \
+	} while (0)
 #else
-#define HASH_FSCK(hh,head,where)
+#define HASH_FSCK(hh, head, where)
 #endif
 
 /* When compiled with -DHASH_EMIT_KEYS, length-prefixed keys are emitted to
  * the descriptor to which this macro is defined for tuning the hash function.
  * The app can #include <unistd.h> to get the prototype for write(2). */
 #ifdef HASH_EMIT_KEYS
-#define HASH_EMIT_KEY(hh,head,keyptr,fieldlen)                                   \
-do {                                                                             \
-  unsigned _klen = fieldlen;                                                     \
-  write(HASH_EMIT_KEYS, &_klen, sizeof(_klen));                                  \
-  write(HASH_EMIT_KEYS, keyptr, (unsigned long)fieldlen);                        \
-} while (0)
+#define HASH_EMIT_KEY(hh, head, keyptr, fieldlen)                       \
+	do {                                                            \
+		unsigned _klen = fieldlen;                              \
+		write(HASH_EMIT_KEYS, &_klen, sizeof(_klen));           \
+		write(HASH_EMIT_KEYS, keyptr, (unsigned long)fieldlen); \
+	} while (0)
 #else
-#define HASH_EMIT_KEY(hh,head,keyptr,fieldlen)
+#define HASH_EMIT_KEY(hh, head, keyptr, fieldlen)
 #endif
 
 /* default to Jenkin's hash unless overridden e.g. DHASH_FUNCTION=HASH_SAX */
@@ -586,161 +684,204 @@ do {                                                                            
 #endif
 
 /* The Bernstein hash function, used in Perl prior to v5.6. Note (x<<5+x)=x*33. */
-#define HASH_BER(key,keylen,hashv)                                               \
-do {                                                                             \
-  unsigned _hb_keylen = (unsigned)keylen;                                        \
-  const unsigned char *_hb_key = (const unsigned char*)(key);                    \
-  (hashv) = 0;                                                                   \
-  while (_hb_keylen-- != 0U) {                                                   \
-    (hashv) = (((hashv) << 5) + (hashv)) + *_hb_key++;                           \
-  }                                                                              \
-} while (0)
-
+#define HASH_BER(key, keylen, hashv)                                         \
+	do {                                                                 \
+		unsigned _hb_keylen = (unsigned)keylen;                      \
+		const unsigned char *_hb_key = (const unsigned char *)(key); \
+		(hashv) = 0;                                                 \
+		while (_hb_keylen-- != 0U) {                                 \
+			(hashv) = (((hashv) << 5) + (hashv)) + *_hb_key++;   \
+		}                                                            \
+	} while (0)
 
 /* SAX/FNV/OAT/JEN hash functions are macro variants of those listed at
  * http://eternallyconfuzzled.com/tuts/algorithms/jsw_tut_hashing.aspx */
-#define HASH_SAX(key,keylen,hashv)                                               \
-do {                                                                             \
-  unsigned _sx_i;                                                                \
-  const unsigned char *_hs_key = (const unsigned char*)(key);                    \
-  hashv = 0;                                                                     \
-  for (_sx_i=0; _sx_i < keylen; _sx_i++) {                                       \
-    hashv ^= (hashv << 5) + (hashv >> 2) + _hs_key[_sx_i];                       \
-  }                                                                              \
-} while (0)
+#define HASH_SAX(key, keylen, hashv)                                           \
+	do {                                                                   \
+		unsigned _sx_i;                                                \
+		const unsigned char *_hs_key = (const unsigned char *)(key);   \
+		hashv = 0;                                                     \
+		for (_sx_i = 0; _sx_i < keylen; _sx_i++) {                     \
+			hashv ^= (hashv << 5) + (hashv >> 2) + _hs_key[_sx_i]; \
+		}                                                              \
+	} while (0)
 /* FNV-1a variation */
-#define HASH_FNV(key,keylen,hashv)                                               \
-do {                                                                             \
-  unsigned _fn_i;                                                                \
-  const unsigned char *_hf_key = (const unsigned char*)(key);                    \
-  (hashv) = 2166136261U;                                                         \
-  for (_fn_i=0; _fn_i < keylen; _fn_i++) {                                       \
-    hashv = hashv ^ _hf_key[_fn_i];                                              \
-    hashv = hashv * 16777619U;                                                   \
-  }                                                                              \
-} while (0)
+#define HASH_FNV(key, keylen, hashv)                                         \
+	do {                                                                 \
+		unsigned _fn_i;                                              \
+		const unsigned char *_hf_key = (const unsigned char *)(key); \
+		(hashv) = 2166136261U;                                       \
+		for (_fn_i = 0; _fn_i < keylen; _fn_i++) {                   \
+			hashv = hashv ^ _hf_key[_fn_i];                      \
+			hashv = hashv * 16777619U;                           \
+		}                                                            \
+	} while (0)
 
-#define HASH_OAT(key,keylen,hashv)                                               \
-do {                                                                             \
-  unsigned _ho_i;                                                                \
-  const unsigned char *_ho_key=(const unsigned char*)(key);                      \
-  hashv = 0;                                                                     \
-  for(_ho_i=0; _ho_i < keylen; _ho_i++) {                                        \
-      hashv += _ho_key[_ho_i];                                                   \
-      hashv += (hashv << 10);                                                    \
-      hashv ^= (hashv >> 6);                                                     \
-  }                                                                              \
-  hashv += (hashv << 3);                                                         \
-  hashv ^= (hashv >> 11);                                                        \
-  hashv += (hashv << 15);                                                        \
-} while (0)
+#define HASH_OAT(key, keylen, hashv)                                         \
+	do {                                                                 \
+		unsigned _ho_i;                                              \
+		const unsigned char *_ho_key = (const unsigned char *)(key); \
+		hashv = 0;                                                   \
+		for (_ho_i = 0; _ho_i < keylen; _ho_i++) {                   \
+			hashv += _ho_key[_ho_i];                             \
+			hashv += (hashv << 10);                              \
+			hashv ^= (hashv >> 6);                               \
+		}                                                            \
+		hashv += (hashv << 3);                                       \
+		hashv ^= (hashv >> 11);                                      \
+		hashv += (hashv << 15);                                      \
+	} while (0)
 
-#define HASH_JEN_MIX(a,b,c)                                                      \
-do {                                                                             \
-  a -= b; a -= c; a ^= ( c >> 13 );                                              \
-  b -= c; b -= a; b ^= ( a << 8 );                                               \
-  c -= a; c -= b; c ^= ( b >> 13 );                                              \
-  a -= b; a -= c; a ^= ( c >> 12 );                                              \
-  b -= c; b -= a; b ^= ( a << 16 );                                              \
-  c -= a; c -= b; c ^= ( b >> 5 );                                               \
-  a -= b; a -= c; a ^= ( c >> 3 );                                               \
-  b -= c; b -= a; b ^= ( a << 10 );                                              \
-  c -= a; c -= b; c ^= ( b >> 15 );                                              \
-} while (0)
+#define HASH_JEN_MIX(a, b, c)   \
+	do {                    \
+		a -= b;         \
+		a -= c;         \
+		a ^= (c >> 13); \
+		b -= c;         \
+		b -= a;         \
+		b ^= (a << 8);  \
+		c -= a;         \
+		c -= b;         \
+		c ^= (b >> 13); \
+		a -= b;         \
+		a -= c;         \
+		a ^= (c >> 12); \
+		b -= c;         \
+		b -= a;         \
+		b ^= (a << 16); \
+		c -= a;         \
+		c -= b;         \
+		c ^= (b >> 5);  \
+		a -= b;         \
+		a -= c;         \
+		a ^= (c >> 3);  \
+		b -= c;         \
+		b -= a;         \
+		b ^= (a << 10); \
+		c -= a;         \
+		c -= b;         \
+		c ^= (b >> 15); \
+	} while (0)
 
-#define HASH_JEN(key,keylen,hashv)                                               \
-do {                                                                             \
-  unsigned _hj_i,_hj_j,_hj_k;                                                    \
-  unsigned const char *_hj_key=(unsigned const char*)(key);                      \
-  hashv = 0xfeedbeefu;                                                           \
-  _hj_i = _hj_j = 0x9e3779b9u;                                                   \
-  _hj_k = (unsigned)(keylen);                                                    \
-  while (_hj_k >= 12U) {                                                         \
-    _hj_i +=    (_hj_key[0] + ( (unsigned)_hj_key[1] << 8 )                      \
-        + ( (unsigned)_hj_key[2] << 16 )                                         \
-        + ( (unsigned)_hj_key[3] << 24 ) );                                      \
-    _hj_j +=    (_hj_key[4] + ( (unsigned)_hj_key[5] << 8 )                      \
-        + ( (unsigned)_hj_key[6] << 16 )                                         \
-        + ( (unsigned)_hj_key[7] << 24 ) );                                      \
-    hashv += (_hj_key[8] + ( (unsigned)_hj_key[9] << 8 )                         \
-        + ( (unsigned)_hj_key[10] << 16 )                                        \
-        + ( (unsigned)_hj_key[11] << 24 ) );                                     \
-                                                                                 \
-     HASH_JEN_MIX(_hj_i, _hj_j, hashv);                                          \
-                                                                                 \
-     _hj_key += 12;                                                              \
-     _hj_k -= 12U;                                                               \
-  }                                                                              \
-  hashv += (unsigned)(keylen);                                                   \
-  switch ( _hj_k ) {                                                             \
-    case 11: hashv += ( (unsigned)_hj_key[10] << 24 ); /* FALLTHROUGH */         \
-    case 10: hashv += ( (unsigned)_hj_key[9] << 16 );  /* FALLTHROUGH */         \
-    case 9:  hashv += ( (unsigned)_hj_key[8] << 8 );   /* FALLTHROUGH */         \
-    case 8:  _hj_j += ( (unsigned)_hj_key[7] << 24 );  /* FALLTHROUGH */         \
-    case 7:  _hj_j += ( (unsigned)_hj_key[6] << 16 );  /* FALLTHROUGH */         \
-    case 6:  _hj_j += ( (unsigned)_hj_key[5] << 8 );   /* FALLTHROUGH */         \
-    case 5:  _hj_j += _hj_key[4];                      /* FALLTHROUGH */         \
-    case 4:  _hj_i += ( (unsigned)_hj_key[3] << 24 );  /* FALLTHROUGH */         \
-    case 3:  _hj_i += ( (unsigned)_hj_key[2] << 16 );  /* FALLTHROUGH */         \
-    case 2:  _hj_i += ( (unsigned)_hj_key[1] << 8 );   /* FALLTHROUGH */         \
-    case 1:  _hj_i += _hj_key[0];                                                \
-  }                                                                              \
-  HASH_JEN_MIX(_hj_i, _hj_j, hashv);                                             \
-} while (0)
+#define HASH_JEN(key, keylen, hashv)                                           \
+	do {                                                                   \
+		unsigned _hj_i, _hj_j, _hj_k;                                  \
+		unsigned const char *_hj_key = (unsigned const char *)(key);   \
+		hashv = 0xfeedbeefu;                                           \
+		_hj_i = _hj_j = 0x9e3779b9u;                                   \
+		_hj_k = (unsigned)(keylen);                                    \
+		while (_hj_k >= 12U) {                                         \
+			_hj_i += (_hj_key[0] + ((unsigned)_hj_key[1] << 8) +   \
+				  ((unsigned)_hj_key[2] << 16) +               \
+				  ((unsigned)_hj_key[3] << 24));               \
+			_hj_j += (_hj_key[4] + ((unsigned)_hj_key[5] << 8) +   \
+				  ((unsigned)_hj_key[6] << 16) +               \
+				  ((unsigned)_hj_key[7] << 24));               \
+			hashv += (_hj_key[8] + ((unsigned)_hj_key[9] << 8) +   \
+				  ((unsigned)_hj_key[10] << 16) +              \
+				  ((unsigned)_hj_key[11] << 24));              \
+                                                                               \
+			HASH_JEN_MIX(_hj_i, _hj_j, hashv);                     \
+                                                                               \
+			_hj_key += 12;                                         \
+			_hj_k -= 12U;                                          \
+		}                                                              \
+		hashv += (unsigned)(keylen);                                   \
+		switch (_hj_k) {                                               \
+		case 11:                                                       \
+			hashv += ((unsigned)_hj_key[10]                        \
+				  << 24); /* FALLTHROUGH */                    \
+		case 10:                                                       \
+			hashv += ((unsigned)_hj_key[9]                         \
+				  << 16); /* FALLTHROUGH */                    \
+		case 9:                                                        \
+			hashv +=                                               \
+				((unsigned)_hj_key[8] << 8); /* FALLTHROUGH */ \
+		case 8:                                                        \
+			_hj_j += ((unsigned)_hj_key[7]                         \
+				  << 24); /* FALLTHROUGH */                    \
+		case 7:                                                        \
+			_hj_j += ((unsigned)_hj_key[6]                         \
+				  << 16); /* FALLTHROUGH */                    \
+		case 6:                                                        \
+			_hj_j +=                                               \
+				((unsigned)_hj_key[5] << 8); /* FALLTHROUGH */ \
+		case 5:                                                        \
+			_hj_j += _hj_key[4]; /* FALLTHROUGH */                 \
+		case 4:                                                        \
+			_hj_i += ((unsigned)_hj_key[3]                         \
+				  << 24); /* FALLTHROUGH */                    \
+		case 3:                                                        \
+			_hj_i += ((unsigned)_hj_key[2]                         \
+				  << 16); /* FALLTHROUGH */                    \
+		case 2:                                                        \
+			_hj_i +=                                               \
+				((unsigned)_hj_key[1] << 8); /* FALLTHROUGH */ \
+		case 1:                                                        \
+			_hj_i += _hj_key[0];                                   \
+		}                                                              \
+		HASH_JEN_MIX(_hj_i, _hj_j, hashv);                             \
+	} while (0)
 
 /* The Paul Hsieh hash function */
 #undef get16bits
-#if (defined(__GNUC__) && defined(__i386__)) || defined(__WATCOMC__)             \
-  || defined(_MSC_VER) || defined (__BORLANDC__) || defined (__TURBOC__)
-#define get16bits(d) (*((const uint16_t *) (d)))
+#if (defined(__GNUC__) && defined(__i386__)) || defined(__WATCOMC__) || \
+	defined(_MSC_VER) || defined(__BORLANDC__) || defined(__TURBOC__)
+#define get16bits(d) (*((const uint16_t *)(d)))
 #endif
 
-#if !defined (get16bits)
-#define get16bits(d) ((((uint32_t)(((const uint8_t *)(d))[1])) << 8)             \
-                       +(uint32_t)(((const uint8_t *)(d))[0]) )
+#if !defined(get16bits)
+#define get16bits(d)                                      \
+	((((uint32_t)(((const uint8_t *)(d))[1])) << 8) + \
+	 (uint32_t)(((const uint8_t *)(d))[0]))
 #endif
-#define HASH_SFH(key,keylen,hashv)                                               \
-do {                                                                             \
-  unsigned const char *_sfh_key=(unsigned const char*)(key);                     \
-  uint32_t _sfh_tmp, _sfh_len = (uint32_t)keylen;                                \
-                                                                                 \
-  unsigned _sfh_rem = _sfh_len & 3U;                                             \
-  _sfh_len >>= 2;                                                                \
-  hashv = 0xcafebabeu;                                                           \
-                                                                                 \
-  /* Main loop */                                                                \
-  for (;_sfh_len > 0U; _sfh_len--) {                                             \
-    hashv    += get16bits (_sfh_key);                                            \
-    _sfh_tmp  = ((uint32_t)(get16bits (_sfh_key+2)) << 11) ^ hashv;              \
-    hashv     = (hashv << 16) ^ _sfh_tmp;                                        \
-    _sfh_key += 2U*sizeof (uint16_t);                                            \
-    hashv    += hashv >> 11;                                                     \
-  }                                                                              \
-                                                                                 \
-  /* Handle end cases */                                                         \
-  switch (_sfh_rem) {                                                            \
-    case 3: hashv += get16bits (_sfh_key);                                       \
-            hashv ^= hashv << 16;                                                \
-            hashv ^= (uint32_t)(_sfh_key[sizeof (uint16_t)]) << 18;              \
-            hashv += hashv >> 11;                                                \
-            break;                                                               \
-    case 2: hashv += get16bits (_sfh_key);                                       \
-            hashv ^= hashv << 11;                                                \
-            hashv += hashv >> 17;                                                \
-            break;                                                               \
-    case 1: hashv += *_sfh_key;                                                  \
-            hashv ^= hashv << 10;                                                \
-            hashv += hashv >> 1;                                                 \
-  }                                                                              \
-                                                                                 \
-  /* Force "avalanching" of final 127 bits */                                    \
-  hashv ^= hashv << 3;                                                           \
-  hashv += hashv >> 5;                                                           \
-  hashv ^= hashv << 4;                                                           \
-  hashv += hashv >> 17;                                                          \
-  hashv ^= hashv << 25;                                                          \
-  hashv += hashv >> 6;                                                           \
-} while (0)
+#define HASH_SFH(key, keylen, hashv)                                           \
+	do {                                                                   \
+		unsigned const char *_sfh_key = (unsigned const char *)(key);  \
+		uint32_t _sfh_tmp, _sfh_len = (uint32_t)keylen;                \
+                                                                               \
+		unsigned _sfh_rem = _sfh_len & 3U;                             \
+		_sfh_len >>= 2;                                                \
+		hashv = 0xcafebabeu;                                           \
+                                                                               \
+		/* Main loop */                                                \
+		for (; _sfh_len > 0U; _sfh_len--) {                            \
+			hashv += get16bits(_sfh_key);                          \
+			_sfh_tmp =                                             \
+				((uint32_t)(get16bits(_sfh_key + 2)) << 11) ^  \
+				hashv;                                         \
+			hashv = (hashv << 16) ^ _sfh_tmp;                      \
+			_sfh_key += 2U * sizeof(uint16_t);                     \
+			hashv += hashv >> 11;                                  \
+		}                                                              \
+                                                                               \
+		/* Handle end cases */                                         \
+		switch (_sfh_rem) {                                            \
+		case 3:                                                        \
+			hashv += get16bits(_sfh_key);                          \
+			hashv ^= hashv << 16;                                  \
+			hashv ^= (uint32_t)(_sfh_key[sizeof(uint16_t)]) << 18; \
+			hashv += hashv >> 11;                                  \
+			break;                                                 \
+		case 2:                                                        \
+			hashv += get16bits(_sfh_key);                          \
+			hashv ^= hashv << 11;                                  \
+			hashv += hashv >> 17;                                  \
+			break;                                                 \
+		case 1:                                                        \
+			hashv += *_sfh_key;                                    \
+			hashv ^= hashv << 10;                                  \
+			hashv += hashv >> 1;                                   \
+		}                                                              \
+                                                                               \
+		/* Force "avalanching" of final 127 bits */                    \
+		hashv ^= hashv << 3;                                           \
+		hashv += hashv >> 5;                                           \
+		hashv ^= hashv << 4;                                           \
+		hashv += hashv >> 17;                                          \
+		hashv ^= hashv << 25;                                          \
+		hashv += hashv >> 6;                                           \
+	} while (0)
 
 #ifdef HASH_USING_NO_STRICT_ALIASING
 /* The MurmurHash exploits some CPU's (x86,x86_64) tolerance for unaligned reads.
@@ -752,136 +893,158 @@ do {                                                                            
  *   gcc -m64 -dM -E - < /dev/null                  (on gcc)
  *   cc -## a.c (where a.c is a simple test file)   (Sun Studio)
  */
-#if (defined(__i386__) || defined(__x86_64__)  || defined(_M_IX86))
-#define MUR_GETBLOCK(p,i) p[i]
+#if (defined(__i386__) || defined(__x86_64__) || defined(_M_IX86))
+#define MUR_GETBLOCK(p, i) p[i]
 #else /* non intel */
 #define MUR_PLUS0_ALIGNED(p) (((unsigned long)p & 3UL) == 0UL)
 #define MUR_PLUS1_ALIGNED(p) (((unsigned long)p & 3UL) == 1UL)
 #define MUR_PLUS2_ALIGNED(p) (((unsigned long)p & 3UL) == 2UL)
 #define MUR_PLUS3_ALIGNED(p) (((unsigned long)p & 3UL) == 3UL)
-#define WP(p) ((uint32_t*)((unsigned long)(p) & ~3UL))
-#if (defined(__BIG_ENDIAN__) || defined(SPARC) || defined(__ppc__) || defined(__ppc64__))
-#define MUR_THREE_ONE(p) ((((*WP(p))&0x00ffffff) << 8) | (((*(WP(p)+1))&0xff000000) >> 24))
-#define MUR_TWO_TWO(p)   ((((*WP(p))&0x0000ffff) <<16) | (((*(WP(p)+1))&0xffff0000) >> 16))
-#define MUR_ONE_THREE(p) ((((*WP(p))&0x000000ff) <<24) | (((*(WP(p)+1))&0xffffff00) >>  8))
+#define WP(p) ((uint32_t *)((unsigned long)(p) & ~3UL))
+#if (defined(__BIG_ENDIAN__) || defined(SPARC) || defined(__ppc__) || \
+     defined(__ppc64__))
+#define MUR_THREE_ONE(p) \
+	((((*WP(p)) & 0x00ffffff) << 8) | (((*(WP(p) + 1)) & 0xff000000) >> 24))
+#define MUR_TWO_TWO(p)                     \
+	((((*WP(p)) & 0x0000ffff) << 16) | \
+	 (((*(WP(p) + 1)) & 0xffff0000) >> 16))
+#define MUR_ONE_THREE(p) \
+	((((*WP(p)) & 0x000000ff) << 24) | (((*(WP(p) + 1)) & 0xffffff00) >> 8))
 #else /* assume little endian non-intel */
-#define MUR_THREE_ONE(p) ((((*WP(p))&0xffffff00) >> 8) | (((*(WP(p)+1))&0x000000ff) << 24))
-#define MUR_TWO_TWO(p)   ((((*WP(p))&0xffff0000) >>16) | (((*(WP(p)+1))&0x0000ffff) << 16))
-#define MUR_ONE_THREE(p) ((((*WP(p))&0xff000000) >>24) | (((*(WP(p)+1))&0x00ffffff) <<  8))
+#define MUR_THREE_ONE(p) \
+	((((*WP(p)) & 0xffffff00) >> 8) | (((*(WP(p) + 1)) & 0x000000ff) << 24))
+#define MUR_TWO_TWO(p)                     \
+	((((*WP(p)) & 0xffff0000) >> 16) | \
+	 (((*(WP(p) + 1)) & 0x0000ffff) << 16))
+#define MUR_ONE_THREE(p) \
+	((((*WP(p)) & 0xff000000) >> 24) | (((*(WP(p) + 1)) & 0x00ffffff) << 8))
 #endif
-#define MUR_GETBLOCK(p,i) (MUR_PLUS0_ALIGNED(p) ? ((p)[i]) :           \
-                            (MUR_PLUS1_ALIGNED(p) ? MUR_THREE_ONE(p) : \
-                             (MUR_PLUS2_ALIGNED(p) ? MUR_TWO_TWO(p) :  \
-                                                      MUR_ONE_THREE(p))))
+#define MUR_GETBLOCK(p, i)                                         \
+	(MUR_PLUS0_ALIGNED(p) ?                                    \
+		 ((p)[i]) :                                        \
+		 (MUR_PLUS1_ALIGNED(p) ?                           \
+			  MUR_THREE_ONE(p) :                       \
+			  (MUR_PLUS2_ALIGNED(p) ? MUR_TWO_TWO(p) : \
+						  MUR_ONE_THREE(p))))
 #endif
-#define MUR_ROTL32(x,r) (((x) << (r)) | ((x) >> (32 - (r))))
-#define MUR_FMIX(_h) \
-do {                 \
-  _h ^= _h >> 16;    \
-  _h *= 0x85ebca6bu; \
-  _h ^= _h >> 13;    \
-  _h *= 0xc2b2ae35u; \
-  _h ^= _h >> 16;    \
-} while (0)
+#define MUR_ROTL32(x, r) (((x) << (r)) | ((x) >> (32 - (r))))
+#define MUR_FMIX(_h)               \
+	do {                       \
+		_h ^= _h >> 16;    \
+		_h *= 0x85ebca6bu; \
+		_h ^= _h >> 13;    \
+		_h *= 0xc2b2ae35u; \
+		_h ^= _h >> 16;    \
+	} while (0)
 
-#define HASH_MUR(key,keylen,hashv)                                     \
-do {                                                                   \
-  const uint8_t *_mur_data = (const uint8_t*)(key);                    \
-  const int _mur_nblocks = (int)(keylen) / 4;                          \
-  uint32_t _mur_h1 = 0xf88D5353u;                                      \
-  uint32_t _mur_c1 = 0xcc9e2d51u;                                      \
-  uint32_t _mur_c2 = 0x1b873593u;                                      \
-  uint32_t _mur_k1 = 0;                                                \
-  const uint8_t *_mur_tail;                                            \
-  const uint32_t *_mur_blocks = (const uint32_t*)(_mur_data+(_mur_nblocks*4)); \
-  int _mur_i;                                                          \
-  for (_mur_i = -_mur_nblocks; _mur_i != 0; _mur_i++) {                \
-    _mur_k1 = MUR_GETBLOCK(_mur_blocks,_mur_i);                        \
-    _mur_k1 *= _mur_c1;                                                \
-    _mur_k1 = MUR_ROTL32(_mur_k1,15);                                  \
-    _mur_k1 *= _mur_c2;                                                \
-                                                                       \
-    _mur_h1 ^= _mur_k1;                                                \
-    _mur_h1 = MUR_ROTL32(_mur_h1,13);                                  \
-    _mur_h1 = (_mur_h1*5U) + 0xe6546b64u;                              \
-  }                                                                    \
-  _mur_tail = (const uint8_t*)(_mur_data + (_mur_nblocks*4));          \
-  _mur_k1=0;                                                           \
-  switch ((keylen) & 3U) {                                             \
-    case 0: break;                                                     \
-    case 3: _mur_k1 ^= (uint32_t)_mur_tail[2] << 16; /* FALLTHROUGH */ \
-    case 2: _mur_k1 ^= (uint32_t)_mur_tail[1] << 8;  /* FALLTHROUGH */ \
-    case 1: _mur_k1 ^= (uint32_t)_mur_tail[0];                         \
-    _mur_k1 *= _mur_c1;                                                \
-    _mur_k1 = MUR_ROTL32(_mur_k1,15);                                  \
-    _mur_k1 *= _mur_c2;                                                \
-    _mur_h1 ^= _mur_k1;                                                \
-  }                                                                    \
-  _mur_h1 ^= (uint32_t)(keylen);                                       \
-  MUR_FMIX(_mur_h1);                                                   \
-  hashv = _mur_h1;                                                     \
-} while (0)
-#endif  /* HASH_USING_NO_STRICT_ALIASING */
+#define HASH_MUR(key, keylen, hashv)                                           \
+	do {                                                                   \
+		const uint8_t *_mur_data = (const uint8_t *)(key);             \
+		const int _mur_nblocks = (int)(keylen) / 4;                    \
+		uint32_t _mur_h1 = 0xf88D5353u;                                \
+		uint32_t _mur_c1 = 0xcc9e2d51u;                                \
+		uint32_t _mur_c2 = 0x1b873593u;                                \
+		uint32_t _mur_k1 = 0;                                          \
+		const uint8_t *_mur_tail;                                      \
+		const uint32_t *_mur_blocks =                                  \
+			(const uint32_t *)(_mur_data + (_mur_nblocks * 4));    \
+		int _mur_i;                                                    \
+		for (_mur_i = -_mur_nblocks; _mur_i != 0; _mur_i++) {          \
+			_mur_k1 = MUR_GETBLOCK(_mur_blocks, _mur_i);           \
+			_mur_k1 *= _mur_c1;                                    \
+			_mur_k1 = MUR_ROTL32(_mur_k1, 15);                     \
+			_mur_k1 *= _mur_c2;                                    \
+                                                                               \
+			_mur_h1 ^= _mur_k1;                                    \
+			_mur_h1 = MUR_ROTL32(_mur_h1, 13);                     \
+			_mur_h1 = (_mur_h1 * 5U) + 0xe6546b64u;                \
+		}                                                              \
+		_mur_tail = (const uint8_t *)(_mur_data + (_mur_nblocks * 4)); \
+		_mur_k1 = 0;                                                   \
+		switch ((keylen)&3U) {                                         \
+		case 0:                                                        \
+			break;                                                 \
+		case 3:                                                        \
+			_mur_k1 ^= (uint32_t)_mur_tail[2]                      \
+				   << 16; /* FALLTHROUGH */                    \
+		case 2:                                                        \
+			_mur_k1 ^= (uint32_t)_mur_tail[1]                      \
+				   << 8; /* FALLTHROUGH */                     \
+		case 1:                                                        \
+			_mur_k1 ^= (uint32_t)_mur_tail[0];                     \
+			_mur_k1 *= _mur_c1;                                    \
+			_mur_k1 = MUR_ROTL32(_mur_k1, 15);                     \
+			_mur_k1 *= _mur_c2;                                    \
+			_mur_h1 ^= _mur_k1;                                    \
+		}                                                              \
+		_mur_h1 ^= (uint32_t)(keylen);                                 \
+		MUR_FMIX(_mur_h1);                                             \
+		hashv = _mur_h1;                                               \
+	} while (0)
+#endif /* HASH_USING_NO_STRICT_ALIASING */
 
 /* iterate over items in a known bucket to find desired item */
-#define HASH_FIND_IN_BKT(tbl,hh,head,keyptr,keylen_in,hashval,out)               \
-do {                                                                             \
-  if ((head).hh_head != NULL) {                                                  \
-    DECLTYPE_ASSIGN(out, ELMT_FROM_HH(tbl, (head).hh_head));                     \
-  } else {                                                                       \
-    (out) = NULL;                                                                \
-  }                                                                              \
-  while ((out) != NULL) {                                                        \
-    if ((out)->hh.hashv == (hashval) && (out)->hh.keylen == (keylen_in)) {       \
-      if (uthash_memcmp((out)->hh.key, keyptr, keylen_in) == 0) {                \
-        break;                                                                   \
-      }                                                                          \
-    }                                                                            \
-    if ((out)->hh.hh_next != NULL) {                                             \
-      DECLTYPE_ASSIGN(out, ELMT_FROM_HH(tbl, (out)->hh.hh_next));                \
-    } else {                                                                     \
-      (out) = NULL;                                                              \
-    }                                                                            \
-  }                                                                              \
-} while (0)
+#define HASH_FIND_IN_BKT(tbl, hh, head, keyptr, keylen_in, hashval, out)       \
+	do {                                                                   \
+		if ((head).hh_head != NULL) {                                  \
+			DECLTYPE_ASSIGN(out,                                   \
+					ELMT_FROM_HH(tbl, (head).hh_head));    \
+		} else {                                                       \
+			(out) = NULL;                                          \
+		}                                                              \
+		while ((out) != NULL) {                                        \
+			if ((out)->hh.hashv == (hashval) &&                    \
+			    (out)->hh.keylen == (keylen_in)) {                 \
+				if (uthash_memcmp((out)->hh.key, keyptr,       \
+						  keylen_in) == 0) {           \
+					break;                                 \
+				}                                              \
+			}                                                      \
+			if ((out)->hh.hh_next != NULL) {                       \
+				DECLTYPE_ASSIGN(                               \
+					out,                                   \
+					ELMT_FROM_HH(tbl, (out)->hh.hh_next)); \
+			} else {                                               \
+				(out) = NULL;                                  \
+			}                                                      \
+		}                                                              \
+	} while (0)
 
 /* add an item to a bucket  */
-#define HASH_ADD_TO_BKT(head,hh,addhh,oomed)                                     \
-do {                                                                             \
-  UT_hash_bucket *_ha_head = &(head);                                            \
-  _ha_head->count++;                                                             \
-  (addhh)->hh_next = _ha_head->hh_head;                                          \
-  (addhh)->hh_prev = NULL;                                                       \
-  if (_ha_head->hh_head != NULL) {                                               \
-    _ha_head->hh_head->hh_prev = (addhh);                                        \
-  }                                                                              \
-  _ha_head->hh_head = (addhh);                                                   \
-  if ((_ha_head->count >= ((_ha_head->expand_mult + 1U) * HASH_BKT_CAPACITY_THRESH)) \
-      && !(addhh)->tbl->noexpand) {                                              \
-    HASH_EXPAND_BUCKETS(addhh,(addhh)->tbl, oomed);                              \
-    IF_HASH_NONFATAL_OOM(                                                        \
-      if (oomed) {                                                               \
-        HASH_DEL_IN_BKT(head,addhh);                                             \
-      }                                                                          \
-    )                                                                            \
-  }                                                                              \
-} while (0)
+#define HASH_ADD_TO_BKT(head, hh, addhh, oomed)                               \
+	do {                                                                  \
+		UT_hash_bucket *_ha_head = &(head);                           \
+		_ha_head->count++;                                            \
+		(addhh)->hh_next = _ha_head->hh_head;                         \
+		(addhh)->hh_prev = NULL;                                      \
+		if (_ha_head->hh_head != NULL) {                              \
+			_ha_head->hh_head->hh_prev = (addhh);                 \
+		}                                                             \
+		_ha_head->hh_head = (addhh);                                  \
+		if ((_ha_head->count >= ((_ha_head->expand_mult + 1U) *       \
+					 HASH_BKT_CAPACITY_THRESH)) &&        \
+		    !(addhh)->tbl->noexpand) {                                \
+			HASH_EXPAND_BUCKETS(addhh, (addhh)->tbl, oomed);      \
+			IF_HASH_NONFATAL_OOM(                                 \
+				if (oomed) { HASH_DEL_IN_BKT(head, addhh); }) \
+		}                                                             \
+	} while (0)
 
 /* remove an item from a given bucket */
-#define HASH_DEL_IN_BKT(head,delhh)                                              \
-do {                                                                             \
-  UT_hash_bucket *_hd_head = &(head);                                            \
-  _hd_head->count--;                                                             \
-  if (_hd_head->hh_head == (delhh)) {                                            \
-    _hd_head->hh_head = (delhh)->hh_next;                                        \
-  }                                                                              \
-  if ((delhh)->hh_prev) {                                                        \
-    (delhh)->hh_prev->hh_next = (delhh)->hh_next;                                \
-  }                                                                              \
-  if ((delhh)->hh_next) {                                                        \
-    (delhh)->hh_next->hh_prev = (delhh)->hh_prev;                                \
-  }                                                                              \
-} while (0)
+#define HASH_DEL_IN_BKT(head, delhh)                                  \
+	do {                                                          \
+		UT_hash_bucket *_hd_head = &(head);                   \
+		_hd_head->count--;                                    \
+		if (_hd_head->hh_head == (delhh)) {                   \
+			_hd_head->hh_head = (delhh)->hh_next;         \
+		}                                                     \
+		if ((delhh)->hh_prev) {                               \
+			(delhh)->hh_prev->hh_next = (delhh)->hh_next; \
+		}                                                     \
+		if ((delhh)->hh_next) {                               \
+			(delhh)->hh_next->hh_prev = (delhh)->hh_prev; \
+		}                                                     \
+	} while (0)
 
 /* Bucket expansion has the effect of doubling the number of buckets
  * and redistributing the items into the new buckets. Ideally the
@@ -912,245 +1075,362 @@ do {                                                                            
  *      ceil(n/b) = (n>>lb) + ( (n & (b-1)) ? 1:0)
  *
  */
-#define HASH_EXPAND_BUCKETS(hh,tbl,oomed)                                        \
-do {                                                                             \
-  unsigned _he_bkt;                                                              \
-  unsigned _he_bkt_i;                                                            \
-  struct UT_hash_handle *_he_thh, *_he_hh_nxt;                                   \
-  UT_hash_bucket *_he_new_buckets, *_he_newbkt;                                  \
-  _he_new_buckets = (UT_hash_bucket*)uthash_malloc(                              \
-           2UL * (tbl)->num_buckets * sizeof(struct UT_hash_bucket));            \
-  if (!_he_new_buckets) {                                                        \
-    HASH_RECORD_OOM(oomed);                                                      \
-  } else {                                                                       \
-    uthash_bzero(_he_new_buckets,                                                \
-        2UL * (tbl)->num_buckets * sizeof(struct UT_hash_bucket));               \
-    (tbl)->ideal_chain_maxlen =                                                  \
-       ((tbl)->num_items >> ((tbl)->log2_num_buckets+1U)) +                      \
-       ((((tbl)->num_items & (((tbl)->num_buckets*2U)-1U)) != 0U) ? 1U : 0U);    \
-    (tbl)->nonideal_items = 0;                                                   \
-    for (_he_bkt_i = 0; _he_bkt_i < (tbl)->num_buckets; _he_bkt_i++) {           \
-      _he_thh = (tbl)->buckets[ _he_bkt_i ].hh_head;                             \
-      while (_he_thh != NULL) {                                                  \
-        _he_hh_nxt = _he_thh->hh_next;                                           \
-        HASH_TO_BKT(_he_thh->hashv, (tbl)->num_buckets * 2U, _he_bkt);           \
-        _he_newbkt = &(_he_new_buckets[_he_bkt]);                                \
-        if (++(_he_newbkt->count) > (tbl)->ideal_chain_maxlen) {                 \
-          (tbl)->nonideal_items++;                                               \
-          _he_newbkt->expand_mult = _he_newbkt->count / (tbl)->ideal_chain_maxlen; \
-        }                                                                        \
-        _he_thh->hh_prev = NULL;                                                 \
-        _he_thh->hh_next = _he_newbkt->hh_head;                                  \
-        if (_he_newbkt->hh_head != NULL) {                                       \
-          _he_newbkt->hh_head->hh_prev = _he_thh;                                \
-        }                                                                        \
-        _he_newbkt->hh_head = _he_thh;                                           \
-        _he_thh = _he_hh_nxt;                                                    \
-      }                                                                          \
-    }                                                                            \
-    uthash_free((tbl)->buckets, (tbl)->num_buckets * sizeof(struct UT_hash_bucket)); \
-    (tbl)->num_buckets *= 2U;                                                    \
-    (tbl)->log2_num_buckets++;                                                   \
-    (tbl)->buckets = _he_new_buckets;                                            \
-    (tbl)->ineff_expands = ((tbl)->nonideal_items > ((tbl)->num_items >> 1)) ?   \
-        ((tbl)->ineff_expands+1U) : 0U;                                          \
-    if ((tbl)->ineff_expands > 1U) {                                             \
-      (tbl)->noexpand = 1;                                                       \
-      uthash_noexpand_fyi(tbl);                                                  \
-    }                                                                            \
-    uthash_expand_fyi(tbl);                                                      \
-  }                                                                              \
-} while (0)
-
+#define HASH_EXPAND_BUCKETS(hh, tbl, oomed)                                        \
+	do {                                                                       \
+		unsigned _he_bkt;                                                  \
+		unsigned _he_bkt_i;                                                \
+		struct UT_hash_handle *_he_thh, *_he_hh_nxt;                       \
+		UT_hash_bucket *_he_new_buckets, *_he_newbkt;                      \
+		_he_new_buckets = (UT_hash_bucket *)uthash_malloc(                 \
+			2UL * (tbl)->num_buckets *                                 \
+			sizeof(struct UT_hash_bucket));                            \
+		if (!_he_new_buckets) {                                            \
+			HASH_RECORD_OOM(oomed);                                    \
+		} else {                                                           \
+			uthash_bzero(_he_new_buckets,                              \
+				     2UL * (tbl)->num_buckets *                    \
+					     sizeof(struct UT_hash_bucket));       \
+			(tbl)->ideal_chain_maxlen =                                \
+				((tbl)->num_items >>                               \
+				 ((tbl)->log2_num_buckets + 1U)) +                 \
+				((((tbl)->num_items &                              \
+				   (((tbl)->num_buckets * 2U) - 1U)) != 0U) ?      \
+					 1U :                                      \
+					 0U);                                      \
+			(tbl)->nonideal_items = 0;                                 \
+			for (_he_bkt_i = 0; _he_bkt_i < (tbl)->num_buckets;        \
+			     _he_bkt_i++) {                                        \
+				_he_thh = (tbl)->buckets[_he_bkt_i].hh_head;       \
+				while (_he_thh != NULL) {                          \
+					_he_hh_nxt = _he_thh->hh_next;             \
+					HASH_TO_BKT(_he_thh->hashv,                \
+						    (tbl)->num_buckets * 2U,       \
+						    _he_bkt);                      \
+					_he_newbkt =                               \
+						&(_he_new_buckets[_he_bkt]);       \
+					if (++(_he_newbkt->count) >                \
+					    (tbl)->ideal_chain_maxlen) {           \
+						(tbl)->nonideal_items++;           \
+						_he_newbkt->expand_mult =          \
+							_he_newbkt->count /        \
+							(tbl)->ideal_chain_maxlen; \
+					}                                          \
+					_he_thh->hh_prev = NULL;                   \
+					_he_thh->hh_next =                         \
+						_he_newbkt->hh_head;               \
+					if (_he_newbkt->hh_head != NULL) {         \
+						_he_newbkt->hh_head->hh_prev =     \
+							_he_thh;                   \
+					}                                          \
+					_he_newbkt->hh_head = _he_thh;             \
+					_he_thh = _he_hh_nxt;                      \
+				}                                                  \
+			}                                                          \
+			uthash_free((tbl)->buckets,                                \
+				    (tbl)->num_buckets *                           \
+					    sizeof(struct UT_hash_bucket));        \
+			(tbl)->num_buckets *= 2U;                                  \
+			(tbl)->log2_num_buckets++;                                 \
+			(tbl)->buckets = _he_new_buckets;                          \
+			(tbl)->ineff_expands =                                     \
+				((tbl)->nonideal_items >                           \
+				 ((tbl)->num_items >> 1)) ?                        \
+					((tbl)->ineff_expands + 1U) :              \
+					0U;                                        \
+			if ((tbl)->ineff_expands > 1U) {                           \
+				(tbl)->noexpand = 1;                               \
+				uthash_noexpand_fyi(tbl);                          \
+			}                                                          \
+			uthash_expand_fyi(tbl);                                    \
+		}                                                                  \
+	} while (0)
 
 /* This is an adaptation of Simon Tatham's O(n log(n)) mergesort */
 /* Note that HASH_SORT assumes the hash handle name to be hh.
  * HASH_SRT was added to allow the hash handle name to be passed in. */
-#define HASH_SORT(head,cmpfcn) HASH_SRT(hh,head,cmpfcn)
-#define HASH_SRT(hh,head,cmpfcn)                                                 \
-do {                                                                             \
-  unsigned _hs_i;                                                                \
-  unsigned _hs_looping,_hs_nmerges,_hs_insize,_hs_psize,_hs_qsize;               \
-  struct UT_hash_handle *_hs_p, *_hs_q, *_hs_e, *_hs_list, *_hs_tail;            \
-  if (head != NULL) {                                                            \
-    _hs_insize = 1;                                                              \
-    _hs_looping = 1;                                                             \
-    _hs_list = &((head)->hh);                                                    \
-    while (_hs_looping != 0U) {                                                  \
-      _hs_p = _hs_list;                                                          \
-      _hs_list = NULL;                                                           \
-      _hs_tail = NULL;                                                           \
-      _hs_nmerges = 0;                                                           \
-      while (_hs_p != NULL) {                                                    \
-        _hs_nmerges++;                                                           \
-        _hs_q = _hs_p;                                                           \
-        _hs_psize = 0;                                                           \
-        for (_hs_i = 0; _hs_i < _hs_insize; ++_hs_i) {                           \
-          _hs_psize++;                                                           \
-          _hs_q = ((_hs_q->next != NULL) ?                                       \
-            HH_FROM_ELMT((head)->hh.tbl, _hs_q->next) : NULL);                   \
-          if (_hs_q == NULL) {                                                   \
-            break;                                                               \
-          }                                                                      \
-        }                                                                        \
-        _hs_qsize = _hs_insize;                                                  \
-        while ((_hs_psize != 0U) || ((_hs_qsize != 0U) && (_hs_q != NULL))) {    \
-          if (_hs_psize == 0U) {                                                 \
-            _hs_e = _hs_q;                                                       \
-            _hs_q = ((_hs_q->next != NULL) ?                                     \
-              HH_FROM_ELMT((head)->hh.tbl, _hs_q->next) : NULL);                 \
-            _hs_qsize--;                                                         \
-          } else if ((_hs_qsize == 0U) || (_hs_q == NULL)) {                     \
-            _hs_e = _hs_p;                                                       \
-            if (_hs_p != NULL) {                                                 \
-              _hs_p = ((_hs_p->next != NULL) ?                                   \
-                HH_FROM_ELMT((head)->hh.tbl, _hs_p->next) : NULL);               \
-            }                                                                    \
-            _hs_psize--;                                                         \
-          } else if ((cmpfcn(                                                    \
-                DECLTYPE(head)(ELMT_FROM_HH((head)->hh.tbl, _hs_p)),             \
-                DECLTYPE(head)(ELMT_FROM_HH((head)->hh.tbl, _hs_q))              \
-                )) <= 0) {                                                       \
-            _hs_e = _hs_p;                                                       \
-            if (_hs_p != NULL) {                                                 \
-              _hs_p = ((_hs_p->next != NULL) ?                                   \
-                HH_FROM_ELMT((head)->hh.tbl, _hs_p->next) : NULL);               \
-            }                                                                    \
-            _hs_psize--;                                                         \
-          } else {                                                               \
-            _hs_e = _hs_q;                                                       \
-            _hs_q = ((_hs_q->next != NULL) ?                                     \
-              HH_FROM_ELMT((head)->hh.tbl, _hs_q->next) : NULL);                 \
-            _hs_qsize--;                                                         \
-          }                                                                      \
-          if ( _hs_tail != NULL ) {                                              \
-            _hs_tail->next = ((_hs_e != NULL) ?                                  \
-              ELMT_FROM_HH((head)->hh.tbl, _hs_e) : NULL);                       \
-          } else {                                                               \
-            _hs_list = _hs_e;                                                    \
-          }                                                                      \
-          if (_hs_e != NULL) {                                                   \
-            _hs_e->prev = ((_hs_tail != NULL) ?                                  \
-              ELMT_FROM_HH((head)->hh.tbl, _hs_tail) : NULL);                    \
-          }                                                                      \
-          _hs_tail = _hs_e;                                                      \
-        }                                                                        \
-        _hs_p = _hs_q;                                                           \
-      }                                                                          \
-      if (_hs_tail != NULL) {                                                    \
-        _hs_tail->next = NULL;                                                   \
-      }                                                                          \
-      if (_hs_nmerges <= 1U) {                                                   \
-        _hs_looping = 0;                                                         \
-        (head)->hh.tbl->tail = _hs_tail;                                         \
-        DECLTYPE_ASSIGN(head, ELMT_FROM_HH((head)->hh.tbl, _hs_list));           \
-      }                                                                          \
-      _hs_insize *= 2U;                                                          \
-    }                                                                            \
-    HASH_FSCK(hh, head, "HASH_SRT");                                             \
-  }                                                                              \
-} while (0)
+#define HASH_SORT(head, cmpfcn) HASH_SRT(hh, head, cmpfcn)
+#define HASH_SRT(hh, head, cmpfcn)                                                                      \
+	do {                                                                                            \
+		unsigned _hs_i;                                                                         \
+		unsigned _hs_looping, _hs_nmerges, _hs_insize, _hs_psize,                               \
+			_hs_qsize;                                                                      \
+		struct UT_hash_handle *_hs_p, *_hs_q, *_hs_e, *_hs_list,                                \
+			*_hs_tail;                                                                      \
+		if (head != NULL) {                                                                     \
+			_hs_insize = 1;                                                                 \
+			_hs_looping = 1;                                                                \
+			_hs_list = &((head)->hh);                                                       \
+			while (_hs_looping != 0U) {                                                     \
+				_hs_p = _hs_list;                                                       \
+				_hs_list = NULL;                                                        \
+				_hs_tail = NULL;                                                        \
+				_hs_nmerges = 0;                                                        \
+				while (_hs_p != NULL) {                                                 \
+					_hs_nmerges++;                                                  \
+					_hs_q = _hs_p;                                                  \
+					_hs_psize = 0;                                                  \
+					for (_hs_i = 0; _hs_i < _hs_insize;                             \
+					     ++_hs_i) {                                                 \
+						_hs_psize++;                                            \
+						_hs_q = ((_hs_q->next !=                                \
+							  NULL) ?                                       \
+								 HH_FROM_ELMT(                          \
+									 (head)->hh                     \
+										 .tbl,                  \
+									 _hs_q->next) :                 \
+								 NULL);                                 \
+						if (_hs_q == NULL) {                                    \
+							break;                                          \
+						}                                                       \
+					}                                                               \
+					_hs_qsize = _hs_insize;                                         \
+					while ((_hs_psize != 0U) ||                                     \
+					       ((_hs_qsize != 0U) &&                                    \
+						(_hs_q != NULL))) {                                     \
+						if (_hs_psize == 0U) {                                  \
+							_hs_e = _hs_q;                                  \
+							_hs_q = ((_hs_q->next !=                        \
+								  NULL) ?                               \
+									 HH_FROM_ELMT(                  \
+										 (head)->hh             \
+											 .tbl,          \
+										 _hs_q->next) :         \
+									 NULL);                         \
+							_hs_qsize--;                                    \
+						} else if ((_hs_qsize ==                                \
+							    0U) ||                                      \
+							   (_hs_q == NULL)) {                           \
+							_hs_e = _hs_p;                                  \
+							if (_hs_p != NULL) {                            \
+								_hs_p = ((_hs_p->next !=                \
+									  NULL) ?                       \
+										 HH_FROM_ELMT(          \
+											 (head)->hh     \
+												 .tbl,  \
+											 _hs_p->next) : \
+										 NULL);                 \
+							}                                               \
+							_hs_psize--;                                    \
+						} else if (                                             \
+							(cmpfcn(DECLTYPE(                               \
+									head)(ELMT_FROM_HH(             \
+									(head)->hh                      \
+										.tbl,                   \
+									_hs_p)),                        \
+								DECLTYPE(                               \
+									head)(ELMT_FROM_HH(             \
+									(head)->hh                      \
+										.tbl,                   \
+									_hs_q)))) <=                    \
+							0) {                                            \
+							_hs_e = _hs_p;                                  \
+							if (_hs_p != NULL) {                            \
+								_hs_p = ((_hs_p->next !=                \
+									  NULL) ?                       \
+										 HH_FROM_ELMT(          \
+											 (head)->hh     \
+												 .tbl,  \
+											 _hs_p->next) : \
+										 NULL);                 \
+							}                                               \
+							_hs_psize--;                                    \
+						} else {                                                \
+							_hs_e = _hs_q;                                  \
+							_hs_q = ((_hs_q->next !=                        \
+								  NULL) ?                               \
+									 HH_FROM_ELMT(                  \
+										 (head)->hh             \
+											 .tbl,          \
+										 _hs_q->next) :         \
+									 NULL);                         \
+							_hs_qsize--;                                    \
+						}                                                       \
+						if (_hs_tail != NULL) {                                 \
+							_hs_tail->next =                                \
+								((_hs_e !=                              \
+								  NULL) ?                               \
+									 ELMT_FROM_HH(                  \
+										 (head)->hh             \
+											 .tbl,          \
+										 _hs_e) :               \
+									 NULL);                         \
+						} else {                                                \
+							_hs_list = _hs_e;                               \
+						}                                                       \
+						if (_hs_e != NULL) {                                    \
+							_hs_e->prev =                                   \
+								((_hs_tail !=                           \
+								  NULL) ?                               \
+									 ELMT_FROM_HH(                  \
+										 (head)->hh             \
+											 .tbl,          \
+										 _hs_tail) :            \
+									 NULL);                         \
+						}                                                       \
+						_hs_tail = _hs_e;                                       \
+					}                                                               \
+					_hs_p = _hs_q;                                                  \
+				}                                                                       \
+				if (_hs_tail != NULL) {                                                 \
+					_hs_tail->next = NULL;                                          \
+				}                                                                       \
+				if (_hs_nmerges <= 1U) {                                                \
+					_hs_looping = 0;                                                \
+					(head)->hh.tbl->tail = _hs_tail;                                \
+					DECLTYPE_ASSIGN(                                                \
+						head,                                                   \
+						ELMT_FROM_HH((head)->hh.tbl,                            \
+							     _hs_list));                                \
+				}                                                                       \
+				_hs_insize *= 2U;                                                       \
+			}                                                                               \
+			HASH_FSCK(hh, head, "HASH_SRT");                                                \
+		}                                                                                       \
+	} while (0)
 
 /* This function selects items from one hash into another hash.
  * The end result is that the selected items have dual presence
  * in both hashes. There is no copy of the items made; rather
  * they are added into the new hash through a secondary hash
  * hash handle that must be present in the structure. */
-#define HASH_SELECT(hh_dst, dst, hh_src, src, cond)                              \
-do {                                                                             \
-  unsigned _src_bkt, _dst_bkt;                                                   \
-  void *_last_elt = NULL, *_elt;                                                 \
-  UT_hash_handle *_src_hh, *_dst_hh, *_last_elt_hh=NULL;                         \
-  ptrdiff_t _dst_hho = ((char*)(&(dst)->hh_dst) - (char*)(dst));                 \
-  if ((src) != NULL) {                                                           \
-    for (_src_bkt=0; _src_bkt < (src)->hh_src.tbl->num_buckets; _src_bkt++) {    \
-      for (_src_hh = (src)->hh_src.tbl->buckets[_src_bkt].hh_head;               \
-        _src_hh != NULL;                                                         \
-        _src_hh = _src_hh->hh_next) {                                            \
-        _elt = ELMT_FROM_HH((src)->hh_src.tbl, _src_hh);                         \
-        if (cond(_elt)) {                                                        \
-          IF_HASH_NONFATAL_OOM( int _hs_oomed = 0; )                             \
-          _dst_hh = (UT_hash_handle*)(((char*)_elt) + _dst_hho);                 \
-          _dst_hh->key = _src_hh->key;                                           \
-          _dst_hh->keylen = _src_hh->keylen;                                     \
-          _dst_hh->hashv = _src_hh->hashv;                                       \
-          _dst_hh->prev = _last_elt;                                             \
-          _dst_hh->next = NULL;                                                  \
-          if (_last_elt_hh != NULL) {                                            \
-            _last_elt_hh->next = _elt;                                           \
-          }                                                                      \
-          if ((dst) == NULL) {                                                   \
-            DECLTYPE_ASSIGN(dst, _elt);                                          \
-            HASH_MAKE_TABLE(hh_dst, dst, _hs_oomed);                             \
-            IF_HASH_NONFATAL_OOM(                                                \
-              if (_hs_oomed) {                                                   \
-                uthash_nonfatal_oom(_elt);                                       \
-                (dst) = NULL;                                                    \
-                continue;                                                        \
-              }                                                                  \
-            )                                                                    \
-          } else {                                                               \
-            _dst_hh->tbl = (dst)->hh_dst.tbl;                                    \
-          }                                                                      \
-          HASH_TO_BKT(_dst_hh->hashv, _dst_hh->tbl->num_buckets, _dst_bkt);      \
-          HASH_ADD_TO_BKT(_dst_hh->tbl->buckets[_dst_bkt], hh_dst, _dst_hh, _hs_oomed); \
-          (dst)->hh_dst.tbl->num_items++;                                        \
-          IF_HASH_NONFATAL_OOM(                                                  \
-            if (_hs_oomed) {                                                     \
-              HASH_ROLLBACK_BKT(hh_dst, dst, _dst_hh);                           \
-              HASH_DELETE_HH(hh_dst, dst, _dst_hh);                              \
-              _dst_hh->tbl = NULL;                                               \
-              uthash_nonfatal_oom(_elt);                                         \
-              continue;                                                          \
-            }                                                                    \
-          )                                                                      \
-          HASH_BLOOM_ADD(_dst_hh->tbl, _dst_hh->hashv);                          \
-          _last_elt = _elt;                                                      \
-          _last_elt_hh = _dst_hh;                                                \
-        }                                                                        \
-      }                                                                          \
-    }                                                                            \
-  }                                                                              \
-  HASH_FSCK(hh_dst, dst, "HASH_SELECT");                                         \
-} while (0)
+#define HASH_SELECT(hh_dst, dst, hh_src, src, cond)                                  \
+	do {                                                                         \
+		unsigned _src_bkt, _dst_bkt;                                         \
+		void *_last_elt = NULL, *_elt;                                       \
+		UT_hash_handle *_src_hh, *_dst_hh, *_last_elt_hh = NULL;             \
+		ptrdiff_t _dst_hho =                                                 \
+			((char *)(&(dst)->hh_dst) - (char *)(dst));                  \
+		if ((src) != NULL) {                                                 \
+			for (_src_bkt = 0;                                           \
+			     _src_bkt < (src)->hh_src.tbl->num_buckets;              \
+			     _src_bkt++) {                                           \
+				for (_src_hh = (src)->hh_src.tbl                     \
+						       ->buckets[_src_bkt]           \
+						       .hh_head;                     \
+				     _src_hh != NULL;                                \
+				     _src_hh = _src_hh->hh_next) {                   \
+					_elt = ELMT_FROM_HH((src)->hh_src.tbl,       \
+							    _src_hh);                \
+					if (cond(_elt)) {                            \
+						IF_HASH_NONFATAL_OOM(                \
+							int _hs_oomed = 0;)          \
+						_dst_hh =                            \
+							(UT_hash_handle              \
+								 *)(((char *)_elt) + \
+								    _dst_hho);       \
+						_dst_hh->key = _src_hh->key;         \
+						_dst_hh->keylen =                    \
+							_src_hh->keylen;             \
+						_dst_hh->hashv =                     \
+							_src_hh->hashv;              \
+						_dst_hh->prev = _last_elt;           \
+						_dst_hh->next = NULL;                \
+						if (_last_elt_hh != NULL) {          \
+							_last_elt_hh->next =         \
+								_elt;                \
+						}                                    \
+						if ((dst) == NULL) {                 \
+							DECLTYPE_ASSIGN(dst,         \
+									_elt);       \
+							HASH_MAKE_TABLE(             \
+								hh_dst, dst,         \
+								_hs_oomed);          \
+							IF_HASH_NONFATAL_OOM(if (    \
+								_hs_oomed) {         \
+								uthash_nonfatal_oom( \
+									_elt);       \
+								(dst) = NULL;        \
+								continue;            \
+							})                           \
+						} else {                             \
+							_dst_hh->tbl =               \
+								(dst)->hh_dst        \
+									.tbl;        \
+						}                                    \
+						HASH_TO_BKT(                         \
+							_dst_hh->hashv,              \
+							_dst_hh->tbl                 \
+								->num_buckets,       \
+							_dst_bkt);                   \
+						HASH_ADD_TO_BKT(                     \
+							_dst_hh->tbl->buckets        \
+								[_dst_bkt],          \
+							hh_dst, _dst_hh,             \
+							_hs_oomed);                  \
+						(dst)->hh_dst.tbl->num_items++;      \
+						IF_HASH_NONFATAL_OOM(if (            \
+							_hs_oomed) {                 \
+							HASH_ROLLBACK_BKT(           \
+								hh_dst, dst,         \
+								_dst_hh);            \
+							HASH_DELETE_HH(              \
+								hh_dst, dst,         \
+								_dst_hh);            \
+							_dst_hh->tbl = NULL;         \
+							uthash_nonfatal_oom(         \
+								_elt);               \
+							continue;                    \
+						})                                   \
+						HASH_BLOOM_ADD(                      \
+							_dst_hh->tbl,                \
+							_dst_hh->hashv);             \
+						_last_elt = _elt;                    \
+						_last_elt_hh = _dst_hh;              \
+					}                                            \
+				}                                                    \
+			}                                                            \
+		}                                                                    \
+		HASH_FSCK(hh_dst, dst, "HASH_SELECT");                               \
+	} while (0)
 
-#define HASH_CLEAR(hh,head)                                                      \
-do {                                                                             \
-  if ((head) != NULL) {                                                          \
-    HASH_BLOOM_FREE((head)->hh.tbl);                                             \
-    uthash_free((head)->hh.tbl->buckets,                                         \
-                (head)->hh.tbl->num_buckets*sizeof(struct UT_hash_bucket));      \
-    uthash_free((head)->hh.tbl, sizeof(UT_hash_table));                          \
-    (head) = NULL;                                                               \
-  }                                                                              \
-} while (0)
+#define HASH_CLEAR(hh, head)                                                \
+	do {                                                                \
+		if ((head) != NULL) {                                       \
+			HASH_BLOOM_FREE((head)->hh.tbl);                    \
+			uthash_free((head)->hh.tbl->buckets,                \
+				    (head)->hh.tbl->num_buckets *           \
+					    sizeof(struct UT_hash_bucket)); \
+			uthash_free((head)->hh.tbl, sizeof(UT_hash_table)); \
+			(head) = NULL;                                      \
+		}                                                           \
+	} while (0)
 
-#define HASH_OVERHEAD(hh,head)                                                   \
- (((head) != NULL) ? (                                                           \
- (size_t)(((head)->hh.tbl->num_items   * sizeof(UT_hash_handle))   +             \
-          ((head)->hh.tbl->num_buckets * sizeof(UT_hash_bucket))   +             \
-           sizeof(UT_hash_table)                                   +             \
-           (HASH_BLOOM_BYTELEN))) : 0U)
+#define HASH_OVERHEAD(hh, head)                                             \
+	(((head) != NULL) ?                                                 \
+		 ((size_t)(((head)->hh.tbl->num_items *                     \
+			    sizeof(UT_hash_handle)) +                       \
+			   ((head)->hh.tbl->num_buckets *                   \
+			    sizeof(UT_hash_bucket)) +                       \
+			   sizeof(UT_hash_table) + (HASH_BLOOM_BYTELEN))) : \
+		 0U)
 
 #ifdef NO_DECLTYPE
-#define HASH_ITER(hh,head,el,tmp)                                                \
-for(((el)=(head)), ((*(char**)(&(tmp)))=(char*)((head!=NULL)?(head)->hh.next:NULL)); \
-  (el) != NULL; ((el)=(tmp)), ((*(char**)(&(tmp)))=(char*)((tmp!=NULL)?(tmp)->hh.next:NULL)))
+#define HASH_ITER(hh, head, el, tmp)                                      \
+	for (((el) = (head)),                                             \
+	     ((*(char **)(&(tmp))) =                                      \
+		      (char *)((head != NULL) ? (head)->hh.next : NULL)); \
+	     (el) != NULL;                                                \
+	     ((el) = (tmp)),                                              \
+	     ((*(char **)(&(tmp))) =                                      \
+		      (char *)((tmp != NULL) ? (tmp)->hh.next : NULL)))
 #else
-#define HASH_ITER(hh,head,el,tmp)                                                \
-for(((el)=(head)), ((tmp)=DECLTYPE(el)((head!=NULL)?(head)->hh.next:NULL));      \
-  (el) != NULL; ((el)=(tmp)), ((tmp)=DECLTYPE(el)((tmp!=NULL)?(tmp)->hh.next:NULL)))
+#define HASH_ITER(hh, head, el, tmp)                                          \
+	for (((el) = (head)),                                                 \
+	     ((tmp) = DECLTYPE(el)((head != NULL) ? (head)->hh.next : NULL)); \
+	     (el) != NULL;                                                    \
+	     ((el) = (tmp)),                                                  \
+	     ((tmp) = DECLTYPE(el)((tmp != NULL) ? (tmp)->hh.next : NULL)))
 #endif
 
 /* obtain a count of items in the hash */
-#define HASH_COUNT(head) HASH_CNT(hh,head)
-#define HASH_CNT(hh,head) ((head != NULL)?((head)->hh.tbl->num_items):0U)
+#define HASH_COUNT(head) HASH_CNT(hh, head)
+#define HASH_CNT(hh, head) ((head != NULL) ? ((head)->hh.tbl->num_items) : 0U)
 
 typedef struct UT_hash_bucket {
-   struct UT_hash_handle *hh_head;
-   unsigned count;
+	struct UT_hash_handle *hh_head;
+	unsigned count;
 
-   /* expand_mult is normally set to 0. In this situation, the max chain length
+	/* expand_mult is normally set to 0. In this situation, the max chain length
     * threshold is enforced at its default value, HASH_BKT_CAPACITY_THRESH. (If
     * the bucket's chain exceeds this length, bucket expansion is triggered).
     * However, setting expand_mult to a non-zero value delays bucket expansion
@@ -1162,7 +1442,7 @@ typedef struct UT_hash_bucket {
     * It is better to let its chain length grow to a longer yet-still-bounded
     * value, than to do an O(n) bucket expansion too often.
     */
-   unsigned expand_mult;
+	unsigned expand_mult;
 
 } UT_hash_bucket;
 
@@ -1171,47 +1451,48 @@ typedef struct UT_hash_bucket {
 #define HASH_BLOOM_SIGNATURE 0xb12220f2u
 
 typedef struct UT_hash_table {
-   UT_hash_bucket *buckets;
-   unsigned num_buckets, log2_num_buckets;
-   unsigned num_items;
-   struct UT_hash_handle *tail; /* tail hh in app order, for fast append    */
-   ptrdiff_t hho; /* hash handle offset (byte pos of hash handle in element */
+	UT_hash_bucket *buckets;
+	unsigned num_buckets, log2_num_buckets;
+	unsigned num_items;
+	struct UT_hash_handle
+		*tail; /* tail hh in app order, for fast append    */
+	ptrdiff_t hho; /* hash handle offset (byte pos of hash handle in element */
 
-   /* in an ideal situation (all buckets used equally), no bucket would have
+	/* in an ideal situation (all buckets used equally), no bucket would have
     * more than ceil(#items/#buckets) items. that's the ideal chain length. */
-   unsigned ideal_chain_maxlen;
+	unsigned ideal_chain_maxlen;
 
-   /* nonideal_items is the number of items in the hash whose chain position
+	/* nonideal_items is the number of items in the hash whose chain position
     * exceeds the ideal chain maxlen. these items pay the penalty for an uneven
     * hash distribution; reaching them in a chain traversal takes >ideal steps */
-   unsigned nonideal_items;
+	unsigned nonideal_items;
 
-   /* ineffective expands occur when a bucket doubling was performed, but
+	/* ineffective expands occur when a bucket doubling was performed, but
     * afterward, more than half the items in the hash had nonideal chain
     * positions. If this happens on two consecutive expansions we inhibit any
     * further expansion, as it's not helping; this happens when the hash
     * function isn't a good fit for the key domain. When expansion is inhibited
     * the hash will still work, albeit no longer in constant time. */
-   unsigned ineff_expands, noexpand;
+	unsigned ineff_expands, noexpand;
 
-   uint32_t signature; /* used only to find hash tables in external analysis */
+	uint32_t signature; /* used only to find hash tables in external analysis */
 #ifdef HASH_BLOOM
-   uint32_t bloom_sig; /* used only to test bloom exists in external analysis */
-   uint8_t *bloom_bv;
-   uint8_t bloom_nbits;
+	uint32_t bloom_sig; /* used only to test bloom exists in external analysis */
+	uint8_t *bloom_bv;
+	uint8_t bloom_nbits;
 #endif
 
 } UT_hash_table;
 
 typedef struct UT_hash_handle {
-   struct UT_hash_table *tbl;
-   void *prev;                       /* prev element in app order      */
-   void *next;                       /* next element in app order      */
-   struct UT_hash_handle *hh_prev;   /* previous hh in bucket order    */
-   struct UT_hash_handle *hh_next;   /* next hh in bucket order        */
-   void *key;                        /* ptr to enclosing struct's key  */
-   unsigned keylen;                  /* enclosing struct's key len     */
-   unsigned hashv;                   /* result of hash-fcn(key)        */
+	struct UT_hash_table *tbl;
+	void *prev; /* prev element in app order      */
+	void *next; /* next element in app order      */
+	struct UT_hash_handle *hh_prev; /* previous hh in bucket order    */
+	struct UT_hash_handle *hh_next; /* next hh in bucket order        */
+	void *key; /* ptr to enclosing struct's key  */
+	unsigned keylen; /* enclosing struct's key len     */
+	unsigned hashv; /* result of hash-fcn(key)        */
 } UT_hash_handle;
 
 #endif /* UTHASH_H */

--- a/include/windows/alloca.h
+++ b/include/windows/alloca.h
@@ -1,4 +1,2 @@
 
 #pragma once
-
-

--- a/include/windows/arpa/inet.h
+++ b/include/windows/arpa/inet.h
@@ -1,4 +1,2 @@
 
 #pragma once
-
-

--- a/include/windows/asm/types.h
+++ b/include/windows/asm/types.h
@@ -1,16 +1,16 @@
 #ifndef _ASM_X86_TYPES_H
 #define _ASM_X86_TYPES_H
 
-typedef signed   char __s8;
+typedef signed char __s8;
 typedef unsigned char __u8;
 
-typedef signed   short __s16;
+typedef signed short __s16;
 typedef unsigned short __u16;
 
-typedef signed   int __s32;
+typedef signed int __s32;
 typedef unsigned int __u32;
 
-typedef signed   long long __s64;
+typedef signed long long __s64;
 typedef unsigned long long __u64;
 
 typedef __u16 __le16;

--- a/include/windows/config.h
+++ b/include/windows/config.h
@@ -9,7 +9,7 @@
 /* #undef HAVE_ALIAS_ATTRIBUTE */
 
 /* Set to 1 to use c11 atomic functions */
-/* #undef HAVE_ATOMICS */   /* TODO: add atomics support for windows */
+/* #undef HAVE_ATOMICS */ /* TODO: add atomics support for windows */
 
 /* Set to 1 to use built-in intrincics atomics */
 #define HAVE_BUILTIN_ATOMICS 1
@@ -204,7 +204,10 @@
 /* Version number of package */
 #define _FI_EXP(s) #s
 #define _FI_TO_STRING(s) _FI_EXP(s)
-#define VERSION _FI_TO_STRING(FI_MAJOR_VERSION) "." _FI_TO_STRING(FI_MINOR_VERSION) "." _FI_TO_STRING(FI_REVISION_VERSION)
+#define VERSION                                                \
+	_FI_TO_STRING(FI_MAJOR_VERSION)                        \
+	"." _FI_TO_STRING(FI_MINOR_VERSION) "." _FI_TO_STRING( \
+		FI_REVISION_VERSION)
 
 #ifndef BUILD_ID
 #define BUILD_ID ""

--- a/include/windows/dirent.h
+++ b/include/windows/dirent.h
@@ -1,15 +1,14 @@
 
 #pragma once
 
-
-
 struct dirent {
-	char	d_name[256];
+	char d_name[256];
 };
 
 static inline int scandir(const char *dirp, struct dirent ***namelist,
-	    int (*filter)(const struct dirent *),
-	    int (*compar)(const struct dirent **, const struct dirent **))
+			  int (*filter)(const struct dirent *),
+			  int (*compar)(const struct dirent **,
+					const struct dirent **))
 {
 	errno = ENOSYS;
 	return -1;

--- a/include/windows/ifaddrs.h
+++ b/include/windows/ifaddrs.h
@@ -23,19 +23,18 @@
 /* here is minimal subset of ifaddr API required for sockets & UDP
    providers */
 struct ifaddrs {
-	struct ifaddrs  *ifa_next;    /* Next item in list */
-	char            *ifa_name;    /* Name of interface */
-	unsigned int     ifa_flags;   /* Flags from SIOCGIFFLAGS */
-	struct sockaddr *ifa_addr;    /* Address of interface */
+	struct ifaddrs *ifa_next; /* Next item in list */
+	char *ifa_name; /* Name of interface */
+	unsigned int ifa_flags; /* Flags from SIOCGIFFLAGS */
+	struct sockaddr *ifa_addr; /* Address of interface */
 	struct sockaddr *ifa_netmask; /* Netmask of interface */
 
 	struct sockaddr_storage in_addrs;
 	struct sockaddr_storage in_netmasks;
 
-	char		   ad_name[16];
-	size_t		   speed;
+	char ad_name[16];
+	size_t speed;
 };
 
 int getifaddrs(struct ifaddrs **ifap);
 void freeifaddrs(struct ifaddrs *ifa);
-

--- a/include/windows/net/if.h
+++ b/include/windows/net/if.h
@@ -1,4 +1,3 @@
 
 #pragma once
-#define      IFNAMSIZ        16
-
+#define IFNAMSIZ 16

--- a/include/windows/netdb.h
+++ b/include/windows/netdb.h
@@ -1,4 +1,2 @@
 
 #pragma once
-
-

--- a/include/windows/netinet/ip.h
+++ b/include/windows/netinet/ip.h
@@ -1,4 +1,2 @@
 
 #pragma once
-
-

--- a/include/windows/netinet/tcp.h
+++ b/include/windows/netinet/tcp.h
@@ -1,4 +1,2 @@
 
 #pragma once
-
-

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -44,177 +44,176 @@
 extern "C" {
 #endif
 
-#define OFI_MAX_SOCKET_BUF_SIZE	INT_MAX
+#define OFI_MAX_SOCKET_BUF_SIZE INT_MAX
 
 /*
  * The following defines redefine the Windows Socket
  * errors as BSD errors.
  */
 #ifndef ENOTEMPTY
-# define ENOTEMPTY		41	/* Directory not empty */
+#define ENOTEMPTY 41 /* Directory not empty */
 #endif
 #ifndef EREMOTE
-# define EREMOTE		66	/* The object is remote */
+#define EREMOTE 66 /* The object is remote */
 #endif
 #ifndef EPFNOSUPPORT
-# define EPFNOSUPPORT		96	/* Protocol family not supported */
+#define EPFNOSUPPORT 96 /* Protocol family not supported */
 #endif
 #ifndef EADDRINUSE
-# define EADDRINUSE		100	/* Address already in use */
+#define EADDRINUSE 100 /* Address already in use */
 #endif
 #ifndef EADDRNOTAVAIL
-# define EADDRNOTAVAIL		101	/* Can't assign requested address */
+#define EADDRNOTAVAIL 101 /* Can't assign requested address */
 #endif
 #ifndef EAFNOSUPPORT
-# define EAFNOSUPPORT		102	/* Address family not supported */
+#define EAFNOSUPPORT 102 /* Address family not supported */
 #endif
 #ifndef EALREADY
-# define EALREADY		103	/* Operation already in progress */
+#define EALREADY 103 /* Operation already in progress */
 #endif
 #ifndef EBADMSG
-# define EBADMSG		104	/* Not a data message */
+#define EBADMSG 104 /* Not a data message */
 #endif
 #ifndef ECANCELED
-# define ECANCELED		105	/* Canceled */
+#define ECANCELED 105 /* Canceled */
 #endif
 #ifndef ECONNABORTED
-# define ECONNABORTED		106	/* Software caused connection abort */
+#define ECONNABORTED 106 /* Software caused connection abort */
 #endif
 #ifndef ECONNREFUSED
-# define ECONNREFUSED		107	/* Connection refused */
+#define ECONNREFUSED 107 /* Connection refused */
 #endif
 #ifndef ECONNRESET
-# define ECONNRESET		108	/* Connection reset by peer */
+#define ECONNRESET 108 /* Connection reset by peer */
 #endif
 #ifndef EDESTADDRREQ
-# define EDESTADDRREQ		109	/* Destination address required */
+#define EDESTADDRREQ 109 /* Destination address required */
 #endif
 #ifndef EHOSTUNREACH
-# define EHOSTUNREACH		110	/* No route to host */
+#define EHOSTUNREACH 110 /* No route to host */
 #endif
 #ifndef EIDRM
-# define EIDRM			111	/* Identifier removed */
+#define EIDRM 111 /* Identifier removed */
 #endif
 #ifndef EINPROGRESS
-# define EINPROGRESS		112	/* Operation now in progress */
+#define EINPROGRESS 112 /* Operation now in progress */
 #endif
 #ifndef EISCONN
-# define EISCONN		113	/* Socket is already connected */
+#define EISCONN 113 /* Socket is already connected */
 #endif
 #ifndef ELOOP
-# define ELOOP			114	/* Symbolic link loop */
+#define ELOOP 114 /* Symbolic link loop */
 #endif
 #ifndef EMSGSIZE
-# define EMSGSIZE		115	/* Message too long */
+#define EMSGSIZE 115 /* Message too long */
 #endif
 #ifndef ENETDOWN
-# define ENETDOWN		116	/* Network is down */
+#define ENETDOWN 116 /* Network is down */
 #endif
 #ifndef ENETRESET
-# define ENETRESET		117	/* Network dropped connection on reset */
+#define ENETRESET 117 /* Network dropped connection on reset */
 #endif
 #ifndef ENETUNREACH
-# define ENETUNREACH		118	/* Network is unreachable */
+#define ENETUNREACH 118 /* Network is unreachable */
 #endif
 #ifndef ENOBUFS
-# define ENOBUFS		119	/* No buffer space available */
+#define ENOBUFS 119 /* No buffer space available */
 #endif
 #ifndef ENODATA
-# define ENODATA		120	/* No data available */
+#define ENODATA 120 /* No data available */
 #endif
 #ifndef ENOLINK
-# define ENOLINK		121	/* Link has be severed */
+#define ENOLINK 121 /* Link has be severed */
 #endif
 #ifndef ENOMSG
-# define ENOMSG			122	/* No message of desired type */
+#define ENOMSG 122 /* No message of desired type */
 #endif
 #ifndef ENOPROTOOPT
-# define ENOPROTOOPT		123	/* Protocol not available */
+#define ENOPROTOOPT 123 /* Protocol not available */
 #endif
 #ifndef ENOSR
-# define ENOSR			124	/* Out of stream resources */
+#define ENOSR 124 /* Out of stream resources */
 #endif
 #ifndef ENOSTR
-# define ENOSTR			125	/* Not a stream device */
+#define ENOSTR 125 /* Not a stream device */
 #endif
 #ifndef ENOTCONN
-# define ENOTCONN		126	/* Socket is not connected */
+#define ENOTCONN 126 /* Socket is not connected */
 #endif
 #ifndef ENOTRECOVERABLE
-# define ENOTRECOVERABLE	127	/* Not recoverable */
+#define ENOTRECOVERABLE 127 /* Not recoverable */
 #endif
 #ifndef ENOTSOCK
-# define ENOTSOCK		128	/* Socket operation on non-socket */
+#define ENOTSOCK 128 /* Socket operation on non-socket */
 #endif
 #ifndef ENOTSUP
-# define ENOTSUP		129	/* Operation not supported */
+#define ENOTSUP 129 /* Operation not supported */
 #endif
 #ifndef EOPNOTSUPP
-# define EOPNOTSUPP		130	/* Operation not supported on socket */
+#define EOPNOTSUPP 130 /* Operation not supported on socket */
 #endif
 #ifndef EOTHER
-# define EOTHER			131	/* Other error */
+#define EOTHER 131 /* Other error */
 #endif
 #ifndef EOVERFLOW
-# define EOVERFLOW		132	/* File too big */
+#define EOVERFLOW 132 /* File too big */
 #endif
 #ifndef EOWNERDEAD
-# define EOWNERDEAD		133	/* Owner dead */
+#define EOWNERDEAD 133 /* Owner dead */
 #endif
 #ifndef EPROTO
-# define EPROTO			134	/* Protocol error */
+#define EPROTO 134 /* Protocol error */
 #endif
 #ifndef EPROTONOSUPPORT
-# define EPROTONOSUPPORT	135	/* Protocol not supported */
+#define EPROTONOSUPPORT 135 /* Protocol not supported */
 #endif
 #ifndef EPROTOTYPE
-# define EPROTOTYPE		136	/* Protocol wrong type for socket */
+#define EPROTOTYPE 136 /* Protocol wrong type for socket */
 #endif
 #ifndef ETIME
-# define ETIME			137	/* Timer expired */
+#define ETIME 137 /* Timer expired */
 #endif
 #ifndef ETIMEDOUT
-# define ETIMEDOUT		138	/* Connection timed out */
+#define ETIMEDOUT 138 /* Connection timed out */
 #endif
 #ifndef ETXTBSY
-# define ETXTBSY		139	/* Text file or pseudo-device busy */
+#define ETXTBSY 139 /* Text file or pseudo-device busy */
 #endif
 #ifndef EWOULDBLOCK
-# define EWOULDBLOCK		140	/* Operation would block */
+#define EWOULDBLOCK 140 /* Operation would block */
 #endif
 
 /* Visual Studio doesn't have these, so just choose some high numbers */
 #ifndef ESOCKTNOSUPPORT
-# define ESOCKTNOSUPPORT	240	/* Socket type not supported */
+#define ESOCKTNOSUPPORT 240 /* Socket type not supported */
 #endif
 #ifndef ESHUTDOWN
-# define ESHUTDOWN		241	/* Can't send after socket shutdown */
+#define ESHUTDOWN 241 /* Can't send after socket shutdown */
 #endif
 #ifndef ETOOMANYREFS
-# define ETOOMANYREFS		242	/* Too many references: can't splice */
+#define ETOOMANYREFS 242 /* Too many references: can't splice */
 #endif
 #ifndef EHOSTDOWN
-# define EHOSTDOWN		243	/* Host is down */
+#define EHOSTDOWN 243 /* Host is down */
 #endif
 #ifndef EUSERS
-# define EUSERS			244	/* Too many users (for UFS) */
+#define EUSERS 244 /* Too many users (for UFS) */
 #endif
 #ifndef EDQUOT
-# define EDQUOT			245	/* Disc quota exceeded */
+#define EDQUOT 245 /* Disc quota exceeded */
 #endif
 #ifndef ESTALE
-# define ESTALE			246	/* Stale NFS file handle */
+#define ESTALE 246 /* Stale NFS file handle */
 #endif
 
 /* MSG_NOSIGNAL doesn't exist on Windows */
 #ifndef MSG_NOSIGNAL
-#define MSG_NOSIGNAL	0
+#define MSG_NOSIGNAL 0
 #endif
 
 #ifndef SHUT_RDWR
-#define SHUT_RDWR	SD_BOTH
+#define SHUT_RDWR SD_BOTH
 #endif
-
 
 #define FI_DESTRUCTOR(func) void func
 
@@ -222,45 +221,35 @@ extern "C" {
 #define BIG_ENDIAN 8765
 #define BYTE_ORDER LITTLE_ENDIAN
 
-#define OFI_SOCK_TRY_SND_RCV_AGAIN(err)		\
-	(((err) == ETIMEDOUT)		||	\
-	 ((err) == EWOULDBLOCK)		||	\
-	 ((err) == EAGAIN))
+#define OFI_SOCK_TRY_SND_RCV_AGAIN(err) \
+	(((err) == ETIMEDOUT) || ((err) == EWOULDBLOCK) || ((err) == EAGAIN))
 
-#define OFI_SOCK_TRY_ACCEPT_AGAIN(err)		\
-	(((err) == EAGAIN)		||	\
-	 ((err) == EWOULDBLOCK))
+#define OFI_SOCK_TRY_ACCEPT_AGAIN(err) \
+	(((err) == EAGAIN) || ((err) == EWOULDBLOCK))
 
-#define OFI_SOCK_TRY_CONN_AGAIN(err)		\
-	(((err) == EWOULDBLOCK)		||	\
-	 ((err) == EINPROGRESS))
+#define OFI_SOCK_TRY_CONN_AGAIN(err) \
+	(((err) == EWOULDBLOCK) || ((err) == EINPROGRESS))
 
-struct util_shm
-{ /* this is dummy structure to provide compilation on Windows platform. */
-  /* will be updated on real Windows implementation */
-	HANDLE		shared_fd;
-	void		*ptr;
-	const char	*name;
-	size_t		size;
+struct util_shm { /* this is dummy structure to provide compilation on Windows platform. */
+	/* will be updated on real Windows implementation */
+	HANDLE shared_fd;
+	void *ptr;
+	const char *name;
+	size_t size;
 };
 
-#define FI_FFSL(val)	 			\
-do						\
-{						\
-	int i = 0;				\
-	while(val)				\
-	{					\
-		if((val) & 1)			\
-		{				\
-			return i + 1; 		\
-		}				\
-		else				\
-		{				\
-			i++;			\
-			(val) = (val) >> 1;	\
-		}				\
-	}					\
-} while(0)
+#define FI_FFSL(val)                                \
+	do {                                        \
+		int i = 0;                          \
+		while (val) {                       \
+			if ((val)&1) {              \
+				return i + 1;       \
+			} else {                    \
+				i++;                \
+				(val) = (val) >> 1; \
+			}                           \
+		}                                   \
+	} while (0)
 
 #define strdup _strdup
 #define strcasecmp _stricmp
@@ -302,273 +291,273 @@ static unsigned char winerr2bsderr(DWORD win_errcode) /* do NOT use directly */
 	*/
 	static const unsigned char error_table[] = {
 		0,
-		EINVAL,		/* ERROR_INVALID_FUNCTION		1*/
-		ENOENT,		/* ERROR_FILE_NOT_FOUND			2 */
-		ENOENT,		/* ERROR_PATH_NOT_FOUND			3 */
-		EMFILE,		/* ERROR_TOO_MANY_OPEN_FILES		4 */
-		EACCES,		/* ERROR_ACCESS_DENIED			5 */
-		EBADF,		/* ERROR_INVALID_HANDLE			6 */
-		ENOMEM,		/* ERROR_ARENA_TRASHED			7 */
-		ENOMEM,		/* ERROR_NOT_ENOUGH_MEMORY		8 */
-		ENOMEM,		/* ERROR_INVALID_BLOCK			9 */
-		E2BIG,		/* ERROR_BAD_ENVIRONMENT		10 */
-		ENOEXEC,	/* ERROR_BAD_FORMAT			11 */
-		EACCES,		/* ERROR_INVALID_ACCESS			12 */
-		EINVAL,		/* ERROR_INVALID_DATA			13 */
-		EFAULT,		/* ERROR_OUT_OF_MEMORY			14 */
-		ENOENT,		/* ERROR_INVALID_DRIVE			15 */
-		EACCES,		/* ERROR_CURRENT_DIRECTORY		16 */
-		EXDEV,		/* ERROR_NOT_SAME_DEVICE		17 */
-		ENOENT,		/* ERROR_NO_MORE_FILES			18 */
-		EROFS,		/* ERROR_WRITE_PROTECT			19 */
-		ENXIO,		/* ERROR_BAD_UNIT			20 */
-		EBUSY,		/* ERROR_NOT_READY			21 */
-		EIO,		/* ERROR_BAD_COMMAND			22 */
-		EIO,		/* ERROR_CRC				23 */
-		EIO,		/* ERROR_BAD_LENGTH			24 */
-		EIO,		/* ERROR_SEEK				25 */
-		EIO,		/* ERROR_NOT_DOS_DISK			26 */
-		ENXIO,		/* ERROR_SECTOR_NOT_FOUND		27 */
-		EBUSY,		/* ERROR_OUT_OF_PAPER			28 */
-		EIO,		/* ERROR_WRITE_FAULT			29 */
-		EIO,		/* ERROR_READ_FAULT			30 */
-		EIO,		/* ERROR_GEN_FAILURE			31 */
-		EACCES,		/* ERROR_SHARING_VIOLATION		32 */
-		EACCES,		/* ERROR_LOCK_VIOLATION			33 */
-		ENXIO,		/* ERROR_WRONG_DISK			34 */
-		ENFILE,		/* ERROR_FCB_UNAVAILABLE		35 */
-		ENFILE,		/* ERROR_SHARING_BUFFER_EXCEEDED	36 */
-		EINVAL,		/*					37 */
-		EINVAL,		/*					38 */
-		ENOSPC,		/* ERROR_HANDLE_DISK_FULL		39 */
-		EINVAL,		/*					40 */
-		EINVAL,		/*					41 */
-		EINVAL,		/*					42 */
-		EINVAL,		/*					43 */
-		EINVAL,		/*					44 */
-		EINVAL,		/*					45 */
-		EINVAL,		/*					46 */
-		EINVAL,		/*					47 */
-		EINVAL,		/*					48 */
-		EINVAL,		/*					49 */
-		ENODEV,		/* ERROR_NOT_SUPPORTED			50 */
-		EBUSY,		/* ERROR_REM_NOT_LIST			51 */
-		EEXIST,		/* ERROR_DUP_NAME			52 */
-		ENOENT,		/* ERROR_BAD_NETPATH			53 */
-		EBUSY,		/* ERROR_NETWORK_BUSY			54 */
-		ENODEV,		/* ERROR_DEV_NOT_EXIST			55 */
-		EAGAIN,		/* ERROR_TOO_MANY_CMDS			56 */
-		EIO,		/* ERROR_ADAP_HDW_ERR			57 */
-		EIO,		/* ERROR_BAD_NET_RESP			58 */
-		EIO,		/* ERROR_UNEXP_NET_ERR			59 */
-		EINVAL,		/* ERROR_BAD_REM_ADAP			60 */
-		EFBIG,		/* ERROR_PRINTQ_FULL			61 */
-		ENOSPC,		/* ERROR_NO_SPOOL_SPACE			62 */
-		ENOENT,		/* ERROR_PRINT_CANCELLED		63 */
-		ENOENT,		/* ERROR_NETNAME_DELETED		64 */
-		EACCES,		/* ERROR_NETWORK_ACCESS_DENIED		65 */
-		ENODEV,		/* ERROR_BAD_DEV_TYPE			66 */
-		ENOENT,		/* ERROR_BAD_NET_NAME			67 */
-		ENFILE,		/* ERROR_TOO_MANY_NAMES			68 */
-		EIO,		/* ERROR_TOO_MANY_SESS			69 */
-		EAGAIN,		/* ERROR_SHARING_PAUSED			70 */
-		EINVAL,		/* ERROR_REQ_NOT_ACCEP			71 */
-		EAGAIN,		/* ERROR_REDIR_PAUSED			72 */
-		EINVAL,		/*					73 */
-		EINVAL,		/*					74 */
-		EINVAL,		/*					75 */
-		EINVAL,		/*					76 */
-		EINVAL,		/*					77 */
-		EINVAL,		/*					78 */
-		EINVAL,		/*					79 */
-		EEXIST,		/* ERROR_FILE_EXISTS			80 */
-		EINVAL,		/*					81 */
-		ENOSPC,		/* ERROR_CANNOT_MAKE			82 */
-		EIO,		/* ERROR_FAIL_I24			83 */
-		ENFILE,		/* ERROR_OUT_OF_STRUCTURES		84 */
-		EEXIST,		/* ERROR_ALREADY_ASSIGNED		85 */
-		EPERM,		/* ERROR_INVALID_PASSWORD		86 */
-		EINVAL,		/* ERROR_INVALID_PARAMETER		87 */
-		EIO,		/* ERROR_NET_WRITE_FAULT		88 */
-		EAGAIN,		/* ERROR_NO_PROC_SLOTS			89 */
-		EINVAL,		/*					90 */
-		EINVAL,		/*					91 */
-		EINVAL,		/*					92 */
-		EINVAL,		/*					93 */
-		EINVAL,		/*					94 */
-		EINVAL,		/*					95 */
-		EINVAL,		/*					96 */
-		EINVAL,		/*					97 */
-		EINVAL,		/*					98 */
-		EINVAL,		/*					99 */
-		EINVAL,		/*					100 */
-		EINVAL,		/*					101 */
-		EINVAL,		/*					102 */
-		EINVAL,		/*					103 */
-		EINVAL,		/*					104 */
-		EINVAL,		/*					105 */
-		EINVAL,		/*					106 */
-		EXDEV,		/* ERROR_DISK_CHANGE			107 */
-		EAGAIN,		/* ERROR_DRIVE_LOCKED			108 */
-		EPIPE,		/* ERROR_BROKEN_PIPE			109 */
-		ENOENT,		/* ERROR_OPEN_FAILED			110 */
-		EINVAL,		/* ERROR_BUFFER_OVERFLOW		111 */
-		ENOSPC,		/* ERROR_DISK_FULL			112 */
-		EMFILE,		/* ERROR_NO_MORE_SEARCH_HANDLES		113 */
-		EBADF,		/* ERROR_INVALID_TARGET_HANDLE		114 */
-		EFAULT,		/* ERROR_PROTECTION_VIOLATION		115 */
-		EINVAL,		/*					116 */
-		EINVAL,		/*					117 */
-		EINVAL,		/*					118 */
-		EINVAL,		/*					119 */
-		EINVAL,		/*					120 */
-		EINVAL,		/*					121 */
-		EINVAL,		/*					122 */
-		ENOENT,		/* ERROR_INVALID_NAME			123 */
-		EINVAL,		/*					124 */
-		EINVAL,		/*					125 */
-		EINVAL,		/*					126 */
-		EINVAL,		/* ERROR_PROC_NOT_FOUND			127 */
-		ECHILD,		/* ERROR_WAIT_NO_CHILDREN		128 */
-		ECHILD,		/* ERROR_CHILD_NOT_COMPLETE		129 */
-		EBADF,		/* ERROR_DIRECT_ACCESS_HANDLE		130 */
-		EINVAL,		/* ERROR_NEGATIVE_SEEK			131 */
-		ESPIPE,		/* ERROR_SEEK_ON_DEVICE			132 */
-		EINVAL,		/*					133 */
-		EINVAL,		/*					134 */
-		EINVAL,		/*					135 */
-		EINVAL,		/*					136 */
-		EINVAL,		/*					137 */
-		EINVAL,		/*					138 */
-		EINVAL,		/*					139 */
-		EINVAL,		/*					140 */
-		EINVAL,		/*					141 */
-		EAGAIN,		/* ERROR_BUSY_DRIVE			142 */
-		EINVAL,		/*					143 */
-		EINVAL,		/*					144 */
-		EEXIST,		/* ERROR_DIR_NOT_EMPTY			145 */
-		EINVAL,		/*					146 */
-		EINVAL,		/*					147 */
-		EINVAL,		/*					148 */
-		EINVAL,		/*					149 */
-		EINVAL,		/*					150 */
-		EINVAL,		/*					151 */
-		EINVAL,		/*					152 */
-		EINVAL,		/*					153 */
-		EINVAL,		/*					154 */
-		EINVAL,		/*					155 */
-		EINVAL,		/*					156 */
-		EINVAL,		/*					157 */
-		EACCES,		/* ERROR_NOT_LOCKED			158 */
-		EINVAL,		/*					159 */
-		EINVAL,		/*					160 */
-		ENOENT,		/* ERROR_BAD_PATHNAME			161 */
-		EINVAL,		/*					162 */
-		EINVAL,		/*					163 */
-		EINVAL,		/*					164 */
-		EINVAL,		/*					165 */
-		EINVAL,		/*					166 */
-		EACCES,		/* ERROR_LOCK_FAILED			167 */
-		EINVAL,		/*					168 */
-		EINVAL,		/*					169 */
-		EINVAL,		/*					170 */
-		EINVAL,		/*					171 */
-		EINVAL,		/*					172 */
-		EINVAL,		/*					173 */
-		EINVAL,		/*					174 */
-		EINVAL,		/*					175 */
-		EINVAL,		/*					176 */
-		EINVAL,		/*					177 */
-		EINVAL,		/*					178 */
-		EINVAL,		/*					179 */
-		EINVAL,		/*					180 */
-		EINVAL,		/*					181 */
-		EINVAL,		/*					182 */
-		EEXIST,		/* ERROR_ALREADY_EXISTS			183 */
-		ECHILD,		/* ERROR_NO_CHILD_PROCESS		184 */
-		EINVAL,		/*					185 */
-		EINVAL,		/*					186 */
-		EINVAL,		/*					187 */
-		EINVAL,		/*					188 */
-		EINVAL,		/*					189 */
-		EINVAL,		/*					190 */
-		EINVAL,		/*					191 */
-		EINVAL,		/*					192 */
-		EINVAL,		/*					193 */
-		EINVAL,		/*					194 */
-		EINVAL,		/*					195 */
-		EINVAL,		/*					196 */
-		EINVAL,		/*					197 */
-		EINVAL,		/*					198 */
-		EINVAL,		/*					199 */
-		EINVAL,		/*					200 */
-		EINVAL,		/*					201 */
-		EINVAL,		/*					202 */
-		EINVAL,		/*					203 */
-		EINVAL,		/*					204 */
-		EINVAL,		/*					205 */
-		ENAMETOOLONG,	/* ERROR_FILENAME_EXCED_RANGE		206 */
-		EINVAL,		/*					207 */
-		EINVAL,		/*					208 */
-		EINVAL,		/*					209 */
-		EINVAL,		/*					210 */
-		EINVAL,		/*					211 */
-		EINVAL,		/*					212 */
-		EINVAL,		/*					213 */
-		EINVAL,		/*					214 */
-		EINVAL,		/*					215 */
-		EINVAL,		/*					216 */
-		EINVAL,		/*					217 */
-		EINVAL,		/*					218 */
-		EINVAL,		/*					219 */
-		EINVAL,		/*					220 */
-		EINVAL,		/*					221 */
-		EINVAL,		/*					222 */
-		EINVAL,		/*					223 */
-		EINVAL,		/*					224 */
-		EINVAL,		/*					225 */
-		EINVAL,		/*					226 */
-		EINVAL,		/*					227 */
-		EINVAL,		/*					228 */
-		EINVAL,		/*					229 */
-		EPIPE,		/* ERROR_BAD_PIPE			230 */
-		EAGAIN,		/* ERROR_PIPE_BUSY			231 */
-		EPIPE,		/* ERROR_NO_DATA			232 */
-		EPIPE,		/* ERROR_PIPE_NOT_CONNECTED		233 */
-		EINVAL,		/*					234 */
-		EINVAL,		/*					235 */
-		EINVAL,		/*					236 */
-		EINVAL,		/*					237 */
-		EINVAL,		/*					238 */
-		EINVAL,		/*					239 */
-		EINVAL,		/*					240 */
-		EINVAL,		/*					241 */
-		EINVAL,		/*					242 */
-		EINVAL,		/*					243 */
-		EINVAL,		/*					244 */
-		EINVAL,		/*					245 */
-		EINVAL,		/*					246 */
-		EINVAL,		/*					247 */
-		EINVAL,		/*					248 */
-		EINVAL,		/*					249 */
-		EINVAL,		/*					250 */
-		EINVAL,		/*					251 */
-		EINVAL,		/*					252 */
-		EINVAL,		/*					253 */
-		EINVAL,		/*					254 */
-		EINVAL,		/*					255 */
-		EINVAL,		/*					256 */
-		EINVAL,		/*					257 */
-		EINVAL,		/*					258 */
-		EINVAL,		/*					259 */
-		EINVAL,		/*					260 */
-		EINVAL,		/*					261 */
-		EINVAL,		/*					262 */
-		EINVAL,		/*					263 */
-		EINVAL,		/*					264 */
-		EINVAL,		/*					265 */
-		EINVAL,		/*					266 */
-		ENOTDIR		/* ERROR_DIRECTORY			267 */
+		EINVAL, /* ERROR_INVALID_FUNCTION		1*/
+		ENOENT, /* ERROR_FILE_NOT_FOUND			2 */
+		ENOENT, /* ERROR_PATH_NOT_FOUND			3 */
+		EMFILE, /* ERROR_TOO_MANY_OPEN_FILES		4 */
+		EACCES, /* ERROR_ACCESS_DENIED			5 */
+		EBADF, /* ERROR_INVALID_HANDLE			6 */
+		ENOMEM, /* ERROR_ARENA_TRASHED			7 */
+		ENOMEM, /* ERROR_NOT_ENOUGH_MEMORY		8 */
+		ENOMEM, /* ERROR_INVALID_BLOCK			9 */
+		E2BIG, /* ERROR_BAD_ENVIRONMENT		10 */
+		ENOEXEC, /* ERROR_BAD_FORMAT			11 */
+		EACCES, /* ERROR_INVALID_ACCESS			12 */
+		EINVAL, /* ERROR_INVALID_DATA			13 */
+		EFAULT, /* ERROR_OUT_OF_MEMORY			14 */
+		ENOENT, /* ERROR_INVALID_DRIVE			15 */
+		EACCES, /* ERROR_CURRENT_DIRECTORY		16 */
+		EXDEV, /* ERROR_NOT_SAME_DEVICE		17 */
+		ENOENT, /* ERROR_NO_MORE_FILES			18 */
+		EROFS, /* ERROR_WRITE_PROTECT			19 */
+		ENXIO, /* ERROR_BAD_UNIT			20 */
+		EBUSY, /* ERROR_NOT_READY			21 */
+		EIO, /* ERROR_BAD_COMMAND			22 */
+		EIO, /* ERROR_CRC				23 */
+		EIO, /* ERROR_BAD_LENGTH			24 */
+		EIO, /* ERROR_SEEK				25 */
+		EIO, /* ERROR_NOT_DOS_DISK			26 */
+		ENXIO, /* ERROR_SECTOR_NOT_FOUND		27 */
+		EBUSY, /* ERROR_OUT_OF_PAPER			28 */
+		EIO, /* ERROR_WRITE_FAULT			29 */
+		EIO, /* ERROR_READ_FAULT			30 */
+		EIO, /* ERROR_GEN_FAILURE			31 */
+		EACCES, /* ERROR_SHARING_VIOLATION		32 */
+		EACCES, /* ERROR_LOCK_VIOLATION			33 */
+		ENXIO, /* ERROR_WRONG_DISK			34 */
+		ENFILE, /* ERROR_FCB_UNAVAILABLE		35 */
+		ENFILE, /* ERROR_SHARING_BUFFER_EXCEEDED	36 */
+		EINVAL, /*					37 */
+		EINVAL, /*					38 */
+		ENOSPC, /* ERROR_HANDLE_DISK_FULL		39 */
+		EINVAL, /*					40 */
+		EINVAL, /*					41 */
+		EINVAL, /*					42 */
+		EINVAL, /*					43 */
+		EINVAL, /*					44 */
+		EINVAL, /*					45 */
+		EINVAL, /*					46 */
+		EINVAL, /*					47 */
+		EINVAL, /*					48 */
+		EINVAL, /*					49 */
+		ENODEV, /* ERROR_NOT_SUPPORTED			50 */
+		EBUSY, /* ERROR_REM_NOT_LIST			51 */
+		EEXIST, /* ERROR_DUP_NAME			52 */
+		ENOENT, /* ERROR_BAD_NETPATH			53 */
+		EBUSY, /* ERROR_NETWORK_BUSY			54 */
+		ENODEV, /* ERROR_DEV_NOT_EXIST			55 */
+		EAGAIN, /* ERROR_TOO_MANY_CMDS			56 */
+		EIO, /* ERROR_ADAP_HDW_ERR			57 */
+		EIO, /* ERROR_BAD_NET_RESP			58 */
+		EIO, /* ERROR_UNEXP_NET_ERR			59 */
+		EINVAL, /* ERROR_BAD_REM_ADAP			60 */
+		EFBIG, /* ERROR_PRINTQ_FULL			61 */
+		ENOSPC, /* ERROR_NO_SPOOL_SPACE			62 */
+		ENOENT, /* ERROR_PRINT_CANCELLED		63 */
+		ENOENT, /* ERROR_NETNAME_DELETED		64 */
+		EACCES, /* ERROR_NETWORK_ACCESS_DENIED		65 */
+		ENODEV, /* ERROR_BAD_DEV_TYPE			66 */
+		ENOENT, /* ERROR_BAD_NET_NAME			67 */
+		ENFILE, /* ERROR_TOO_MANY_NAMES			68 */
+		EIO, /* ERROR_TOO_MANY_SESS			69 */
+		EAGAIN, /* ERROR_SHARING_PAUSED			70 */
+		EINVAL, /* ERROR_REQ_NOT_ACCEP			71 */
+		EAGAIN, /* ERROR_REDIR_PAUSED			72 */
+		EINVAL, /*					73 */
+		EINVAL, /*					74 */
+		EINVAL, /*					75 */
+		EINVAL, /*					76 */
+		EINVAL, /*					77 */
+		EINVAL, /*					78 */
+		EINVAL, /*					79 */
+		EEXIST, /* ERROR_FILE_EXISTS			80 */
+		EINVAL, /*					81 */
+		ENOSPC, /* ERROR_CANNOT_MAKE			82 */
+		EIO, /* ERROR_FAIL_I24			83 */
+		ENFILE, /* ERROR_OUT_OF_STRUCTURES		84 */
+		EEXIST, /* ERROR_ALREADY_ASSIGNED		85 */
+		EPERM, /* ERROR_INVALID_PASSWORD		86 */
+		EINVAL, /* ERROR_INVALID_PARAMETER		87 */
+		EIO, /* ERROR_NET_WRITE_FAULT		88 */
+		EAGAIN, /* ERROR_NO_PROC_SLOTS			89 */
+		EINVAL, /*					90 */
+		EINVAL, /*					91 */
+		EINVAL, /*					92 */
+		EINVAL, /*					93 */
+		EINVAL, /*					94 */
+		EINVAL, /*					95 */
+		EINVAL, /*					96 */
+		EINVAL, /*					97 */
+		EINVAL, /*					98 */
+		EINVAL, /*					99 */
+		EINVAL, /*					100 */
+		EINVAL, /*					101 */
+		EINVAL, /*					102 */
+		EINVAL, /*					103 */
+		EINVAL, /*					104 */
+		EINVAL, /*					105 */
+		EINVAL, /*					106 */
+		EXDEV, /* ERROR_DISK_CHANGE			107 */
+		EAGAIN, /* ERROR_DRIVE_LOCKED			108 */
+		EPIPE, /* ERROR_BROKEN_PIPE			109 */
+		ENOENT, /* ERROR_OPEN_FAILED			110 */
+		EINVAL, /* ERROR_BUFFER_OVERFLOW		111 */
+		ENOSPC, /* ERROR_DISK_FULL			112 */
+		EMFILE, /* ERROR_NO_MORE_SEARCH_HANDLES		113 */
+		EBADF, /* ERROR_INVALID_TARGET_HANDLE		114 */
+		EFAULT, /* ERROR_PROTECTION_VIOLATION		115 */
+		EINVAL, /*					116 */
+		EINVAL, /*					117 */
+		EINVAL, /*					118 */
+		EINVAL, /*					119 */
+		EINVAL, /*					120 */
+		EINVAL, /*					121 */
+		EINVAL, /*					122 */
+		ENOENT, /* ERROR_INVALID_NAME			123 */
+		EINVAL, /*					124 */
+		EINVAL, /*					125 */
+		EINVAL, /*					126 */
+		EINVAL, /* ERROR_PROC_NOT_FOUND			127 */
+		ECHILD, /* ERROR_WAIT_NO_CHILDREN		128 */
+		ECHILD, /* ERROR_CHILD_NOT_COMPLETE		129 */
+		EBADF, /* ERROR_DIRECT_ACCESS_HANDLE		130 */
+		EINVAL, /* ERROR_NEGATIVE_SEEK			131 */
+		ESPIPE, /* ERROR_SEEK_ON_DEVICE			132 */
+		EINVAL, /*					133 */
+		EINVAL, /*					134 */
+		EINVAL, /*					135 */
+		EINVAL, /*					136 */
+		EINVAL, /*					137 */
+		EINVAL, /*					138 */
+		EINVAL, /*					139 */
+		EINVAL, /*					140 */
+		EINVAL, /*					141 */
+		EAGAIN, /* ERROR_BUSY_DRIVE			142 */
+		EINVAL, /*					143 */
+		EINVAL, /*					144 */
+		EEXIST, /* ERROR_DIR_NOT_EMPTY			145 */
+		EINVAL, /*					146 */
+		EINVAL, /*					147 */
+		EINVAL, /*					148 */
+		EINVAL, /*					149 */
+		EINVAL, /*					150 */
+		EINVAL, /*					151 */
+		EINVAL, /*					152 */
+		EINVAL, /*					153 */
+		EINVAL, /*					154 */
+		EINVAL, /*					155 */
+		EINVAL, /*					156 */
+		EINVAL, /*					157 */
+		EACCES, /* ERROR_NOT_LOCKED			158 */
+		EINVAL, /*					159 */
+		EINVAL, /*					160 */
+		ENOENT, /* ERROR_BAD_PATHNAME			161 */
+		EINVAL, /*					162 */
+		EINVAL, /*					163 */
+		EINVAL, /*					164 */
+		EINVAL, /*					165 */
+		EINVAL, /*					166 */
+		EACCES, /* ERROR_LOCK_FAILED			167 */
+		EINVAL, /*					168 */
+		EINVAL, /*					169 */
+		EINVAL, /*					170 */
+		EINVAL, /*					171 */
+		EINVAL, /*					172 */
+		EINVAL, /*					173 */
+		EINVAL, /*					174 */
+		EINVAL, /*					175 */
+		EINVAL, /*					176 */
+		EINVAL, /*					177 */
+		EINVAL, /*					178 */
+		EINVAL, /*					179 */
+		EINVAL, /*					180 */
+		EINVAL, /*					181 */
+		EINVAL, /*					182 */
+		EEXIST, /* ERROR_ALREADY_EXISTS			183 */
+		ECHILD, /* ERROR_NO_CHILD_PROCESS		184 */
+		EINVAL, /*					185 */
+		EINVAL, /*					186 */
+		EINVAL, /*					187 */
+		EINVAL, /*					188 */
+		EINVAL, /*					189 */
+		EINVAL, /*					190 */
+		EINVAL, /*					191 */
+		EINVAL, /*					192 */
+		EINVAL, /*					193 */
+		EINVAL, /*					194 */
+		EINVAL, /*					195 */
+		EINVAL, /*					196 */
+		EINVAL, /*					197 */
+		EINVAL, /*					198 */
+		EINVAL, /*					199 */
+		EINVAL, /*					200 */
+		EINVAL, /*					201 */
+		EINVAL, /*					202 */
+		EINVAL, /*					203 */
+		EINVAL, /*					204 */
+		EINVAL, /*					205 */
+		ENAMETOOLONG, /* ERROR_FILENAME_EXCED_RANGE		206 */
+		EINVAL, /*					207 */
+		EINVAL, /*					208 */
+		EINVAL, /*					209 */
+		EINVAL, /*					210 */
+		EINVAL, /*					211 */
+		EINVAL, /*					212 */
+		EINVAL, /*					213 */
+		EINVAL, /*					214 */
+		EINVAL, /*					215 */
+		EINVAL, /*					216 */
+		EINVAL, /*					217 */
+		EINVAL, /*					218 */
+		EINVAL, /*					219 */
+		EINVAL, /*					220 */
+		EINVAL, /*					221 */
+		EINVAL, /*					222 */
+		EINVAL, /*					223 */
+		EINVAL, /*					224 */
+		EINVAL, /*					225 */
+		EINVAL, /*					226 */
+		EINVAL, /*					227 */
+		EINVAL, /*					228 */
+		EINVAL, /*					229 */
+		EPIPE, /* ERROR_BAD_PIPE			230 */
+		EAGAIN, /* ERROR_PIPE_BUSY			231 */
+		EPIPE, /* ERROR_NO_DATA			232 */
+		EPIPE, /* ERROR_PIPE_NOT_CONNECTED		233 */
+		EINVAL, /*					234 */
+		EINVAL, /*					235 */
+		EINVAL, /*					236 */
+		EINVAL, /*					237 */
+		EINVAL, /*					238 */
+		EINVAL, /*					239 */
+		EINVAL, /*					240 */
+		EINVAL, /*					241 */
+		EINVAL, /*					242 */
+		EINVAL, /*					243 */
+		EINVAL, /*					244 */
+		EINVAL, /*					245 */
+		EINVAL, /*					246 */
+		EINVAL, /*					247 */
+		EINVAL, /*					248 */
+		EINVAL, /*					249 */
+		EINVAL, /*					250 */
+		EINVAL, /*					251 */
+		EINVAL, /*					252 */
+		EINVAL, /*					253 */
+		EINVAL, /*					254 */
+		EINVAL, /*					255 */
+		EINVAL, /*					256 */
+		EINVAL, /*					257 */
+		EINVAL, /*					258 */
+		EINVAL, /*					259 */
+		EINVAL, /*					260 */
+		EINVAL, /*					261 */
+		EINVAL, /*					262 */
+		EINVAL, /*					263 */
+		EINVAL, /*					264 */
+		EINVAL, /*					265 */
+		EINVAL, /*					266 */
+		ENOTDIR /* ERROR_DIRECTORY			267 */
 	};
 
 	/*
@@ -576,55 +565,54 @@ static unsigned char winerr2bsderr(DWORD win_errcode) /* do NOT use directly */
 	* errno errors.
 	*/
 	static const unsigned char wsa_error_table[] = {
-		EWOULDBLOCK,		/* WSAEWOULDBLOCK */
-		EINPROGRESS,		/* WSAEINPROGRESS */
-		EALREADY,		/* WSAEALREADY */
-		ENOTSOCK,		/* WSAENOTSOCK */
-		EDESTADDRREQ,		/* WSAEDESTADDRREQ */
-		EMSGSIZE,		/* WSAEMSGSIZE */
-		EPROTOTYPE,		/* WSAEPROTOTYPE */
-		ENOPROTOOPT,		/* WSAENOPROTOOPT */
-		EPROTONOSUPPORT,	/* WSAEPROTONOSUPPORT */
-		ESOCKTNOSUPPORT,	/* WSAESOCKTNOSUPPORT */
-		EOPNOTSUPP,		/* WSAEOPNOTSUPP */
-		EPFNOSUPPORT,		/* WSAEPFNOSUPPORT */
-		EAFNOSUPPORT,		/* WSAEAFNOSUPPORT */
-		EADDRINUSE,		/* WSAEADDRINUSE */
-		EADDRNOTAVAIL,		/* WSAEADDRNOTAVAIL */
-		ENETDOWN,		/* WSAENETDOWN */
-		ENETUNREACH,		/* WSAENETUNREACH */
-		ENETRESET,		/* WSAENETRESET */
-		ECONNABORTED,		/* WSAECONNABORTED */
-		ECONNRESET,		/* WSAECONNRESET */
-		ENOBUFS,		/* WSAENOBUFS */
-		EISCONN,		/* WSAEISCONN */
-		ENOTCONN,		/* WSAENOTCONN */
-		ESHUTDOWN,		/* WSAESHUTDOWN */
-		ETOOMANYREFS,		/* WSAETOOMANYREFS */
-		ETIMEDOUT,		/* WSAETIMEDOUT */
-		ECONNREFUSED,		/* WSAECONNREFUSED */
-		ELOOP,			/* WSAELOOP */
-		ENAMETOOLONG,		/* WSAENAMETOOLONG */
-		EHOSTDOWN,		/* WSAEHOSTDOWN */
-		EHOSTUNREACH,		/* WSAEHOSTUNREACH */
-		ENOTEMPTY,		/* WSAENOTEMPTY */
-		EAGAIN,			/* WSAEPROCLIM */
-		EUSERS,			/* WSAEUSERS */
-		EDQUOT,			/* WSAEDQUOT */
-		ESTALE,			/* WSAESTALE */
-		EREMOTE			/* WSAEREMOTE */
+		EWOULDBLOCK, /* WSAEWOULDBLOCK */
+		EINPROGRESS, /* WSAEINPROGRESS */
+		EALREADY, /* WSAEALREADY */
+		ENOTSOCK, /* WSAENOTSOCK */
+		EDESTADDRREQ, /* WSAEDESTADDRREQ */
+		EMSGSIZE, /* WSAEMSGSIZE */
+		EPROTOTYPE, /* WSAEPROTOTYPE */
+		ENOPROTOOPT, /* WSAENOPROTOOPT */
+		EPROTONOSUPPORT, /* WSAEPROTONOSUPPORT */
+		ESOCKTNOSUPPORT, /* WSAESOCKTNOSUPPORT */
+		EOPNOTSUPP, /* WSAEOPNOTSUPP */
+		EPFNOSUPPORT, /* WSAEPFNOSUPPORT */
+		EAFNOSUPPORT, /* WSAEAFNOSUPPORT */
+		EADDRINUSE, /* WSAEADDRINUSE */
+		EADDRNOTAVAIL, /* WSAEADDRNOTAVAIL */
+		ENETDOWN, /* WSAENETDOWN */
+		ENETUNREACH, /* WSAENETUNREACH */
+		ENETRESET, /* WSAENETRESET */
+		ECONNABORTED, /* WSAECONNABORTED */
+		ECONNRESET, /* WSAECONNRESET */
+		ENOBUFS, /* WSAENOBUFS */
+		EISCONN, /* WSAEISCONN */
+		ENOTCONN, /* WSAENOTCONN */
+		ESHUTDOWN, /* WSAESHUTDOWN */
+		ETOOMANYREFS, /* WSAETOOMANYREFS */
+		ETIMEDOUT, /* WSAETIMEDOUT */
+		ECONNREFUSED, /* WSAECONNREFUSED */
+		ELOOP, /* WSAELOOP */
+		ENAMETOOLONG, /* WSAENAMETOOLONG */
+		EHOSTDOWN, /* WSAEHOSTDOWN */
+		EHOSTUNREACH, /* WSAEHOSTUNREACH */
+		ENOTEMPTY, /* WSAENOTEMPTY */
+		EAGAIN, /* WSAEPROCLIM */
+		EUSERS, /* WSAEUSERS */
+		EDQUOT, /* WSAEDQUOT */
+		ESTALE, /* WSAESTALE */
+		EREMOTE /* WSAEREMOTE */
 	};
 
 	if (win_errcode >= sizeof(error_table) / sizeof(error_table[0])) {
 		win_errcode -= WSAEWOULDBLOCK;
-		if (win_errcode >= (sizeof(wsa_error_table) / sizeof(wsa_error_table[0]))) {
+		if (win_errcode >=
+		    (sizeof(wsa_error_table) / sizeof(wsa_error_table[0]))) {
 			return error_table[1];
-		}
-		else {
+		} else {
 			return wsa_error_table[win_errcode];
 		}
-	}
-	else {
+	} else {
 		return error_table[win_errcode];
 	}
 }
@@ -664,17 +652,16 @@ static inline int asprintf(char **ptr, const char *format, ...)
 	return len;
 }
 
-static inline char* strsep(char **stringp, const char *delim)
+static inline char *strsep(char **stringp, const char *delim)
 {
-	char* ptr = *stringp;
-	char* p;
+	char *ptr = *stringp;
+	char *p;
 
 	p = ptr ? strpbrk(ptr, delim) : NULL;
 
-	if(!p)
+	if (!p)
 		*stringp = NULL;
-	else
-	{
+	else {
 		*p = 0;
 		*stringp = p + 1;
 	}
@@ -735,18 +722,18 @@ static inline SOCKET ofi_socket(int domain, int type, int protocol)
  * We do not handle blocking sockets that attempt to transfer more
  * than INT_MAX data at a time.
  */
-static inline ssize_t
-ofi_recv_socket(SOCKET fd, void *buf, size_t count, int flags)
+static inline ssize_t ofi_recv_socket(SOCKET fd, void *buf, size_t count,
+				      int flags)
 {
-	int len = count > INT_MAX ? INT_MAX : (int) count;
-	return (ssize_t) recv(fd, (char *) buf, len, flags);
+	int len = count > INT_MAX ? INT_MAX : (int)count;
+	return (ssize_t)recv(fd, (char *)buf, len, flags);
 }
 
-static inline ssize_t
-ofi_send_socket(SOCKET fd, const void *buf, size_t count, int flags)
+static inline ssize_t ofi_send_socket(SOCKET fd, const void *buf, size_t count,
+				      int flags)
 {
-	int len = count > INT_MAX ? INT_MAX : (int) count;
-	return (ssize_t) send(fd, (const char*) buf, len, flags);
+	int len = count > INT_MAX ? INT_MAX : (int)count;
+	return (ssize_t)send(fd, (const char *)buf, len, flags);
 }
 
 static inline ssize_t ofi_read_socket(SOCKET fd, void *buf, size_t count)
@@ -759,20 +746,21 @@ static inline ssize_t ofi_write_socket(SOCKET fd, const void *buf, size_t count)
 	return ofi_send_socket(fd, buf, count, 0);
 }
 
-static inline ssize_t
-ofi_recvfrom_socket(SOCKET fd, void *buf, size_t count, int flags,
-		    struct sockaddr *from, socklen_t *fromlen)
+static inline ssize_t ofi_recvfrom_socket(SOCKET fd, void *buf, size_t count,
+					  int flags, struct sockaddr *from,
+					  socklen_t *fromlen)
 {
-	int len = count > INT_MAX ? INT_MAX : (int) count;
-	return recvfrom(fd, (char*) buf, len, flags, from, (int *) fromlen);
+	int len = count > INT_MAX ? INT_MAX : (int)count;
+	return recvfrom(fd, (char *)buf, len, flags, from, (int *)fromlen);
 }
 
-static inline ssize_t
-ofi_sendto_socket(SOCKET fd, const void *buf, size_t count, int flags,
-		  const struct sockaddr *to, socklen_t tolen)
+static inline ssize_t ofi_sendto_socket(SOCKET fd, const void *buf,
+					size_t count, int flags,
+					const struct sockaddr *to,
+					socklen_t tolen)
 {
-	int len = count > INT_MAX ? INT_MAX : (int) count;
-	return sendto(fd, (const char*) buf, len, flags, to, (int) tolen);
+	int len = count > INT_MAX ? INT_MAX : (int)count;
+	return sendto(fd, (const char *)buf, len, flags, to, (int)tolen);
 }
 
 ssize_t ofi_sendv_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt,
@@ -784,8 +772,8 @@ ssize_t ofi_readv_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt);
 ssize_t ofi_sendmsg_tcp(SOCKET fd, const struct msghdr *msg, int flags);
 ssize_t ofi_recvmsg_tcp(SOCKET fd, struct msghdr *msg, int flags);
 
-static inline ssize_t
-ofi_sendmsg_udp(SOCKET fd, const struct msghdr *msg, int flags)
+static inline ssize_t ofi_sendmsg_udp(SOCKET fd, const struct msghdr *msg,
+				      int flags)
 {
 	DWORD bytes;
 	int ret;
@@ -840,15 +828,17 @@ static inline int ofi_syserr(void)
 	return winerr2bsderr(GetLastError());
 }
 
-static inline int ofi_wait_cond(pthread_cond_t *cond, pthread_mutex_t *mut, int timeout_ms)
+static inline int ofi_wait_cond(pthread_cond_t *cond, pthread_mutex_t *mut,
+				int timeout_ms)
 {
 	return !SleepConditionVariableCS(cond, mut, (DWORD)timeout_ms);
 }
 
 int ofi_shm_map(struct util_shm *shm, const char *name, size_t size,
-				int readonly, void **mapped);
+		int readonly, void **mapped);
 
-static inline int ofi_shm_remap(struct util_shm *shm, size_t newsize, void **mapped)
+static inline int ofi_shm_remap(struct util_shm *shm, size_t newsize,
+				void **mapped)
 {
 	OFI_UNUSED(shm);
 	OFI_UNUSED(newsize);
@@ -857,7 +847,7 @@ static inline int ofi_shm_remap(struct util_shm *shm, size_t newsize, void **map
 	return -FI_ENOENT;
 }
 
-static inline char * strndup(char const *src, size_t n)
+static inline char *strndup(char const *src, size_t n)
 {
 	size_t len = strnlen(src, n);
 	char *dst = (char *)malloc(len + 1);
@@ -872,7 +862,7 @@ static inline char * strndup(char const *src, size_t n)
 char *strcasestr(const char *haystack, const char *needle);
 
 #ifndef _SC_PAGESIZE
-#define _SC_PAGESIZE	0
+#define _SC_PAGESIZE 0
 #endif
 
 #ifndef _SC_NPROCESSORS_ONLN
@@ -921,10 +911,12 @@ static inline int ofi_hugepage_enabled(void)
 	return 0;
 }
 
-static inline int ofi_is_loopback_addr(struct sockaddr *addr) {
+static inline int ofi_is_loopback_addr(struct sockaddr *addr)
+{
 	return (addr->sa_family == AF_INET &&
-		((struct sockaddr_in *)addr)->sin_addr.s_addr == htonl(INADDR_LOOPBACK)) ||
-		(addr->sa_family == AF_INET6 &&
+		((struct sockaddr_in *)addr)->sin_addr.s_addr ==
+			htonl(INADDR_LOOPBACK)) ||
+	       (addr->sa_family == AF_INET6 &&
 		((struct sockaddr_in6 *)addr)->sin6_addr.u.Word[0] == 0 &&
 		((struct sockaddr_in6 *)addr)->sin6_addr.u.Word[1] == 0 &&
 		((struct sockaddr_in6 *)addr)->sin6_addr.u.Word[2] == 0 &&
@@ -937,17 +929,16 @@ static inline int ofi_is_loopback_addr(struct sockaddr *addr) {
 
 size_t ofi_ifaddr_get_speed(struct ifaddrs *ifa);
 
-#define file2unix_time	10000000i64
-#define win2unix_epoch	116444736000000000i64
+#define file2unix_time 10000000i64
+#define win2unix_epoch 116444736000000000i64
 #define CLOCK_MONOTONIC 1
 
 /* Own implementation of clock_gettime*/
-static inline
-int clock_gettime(int which_clock, struct timespec *spec)
+static inline int clock_gettime(int which_clock, struct timespec *spec)
 {
 	__int64 wintime;
 
-	GetSystemTimeAsFileTime((FILETIME*)&wintime);
+	GetSystemTimeAsFileTime((FILETIME *)&wintime);
 	wintime -= win2unix_epoch;
 
 	spec->tv_sec = wintime / file2unix_time;
@@ -958,66 +949,65 @@ int clock_gettime(int which_clock, struct timespec *spec)
 
 /* complex operations implementation */
 
-#define OFI_DEF_COMPLEX(type)					\
-typedef struct {						\
-	type real;						\
-	type imag;						\
-} ofi_complex_## type;						\
-static inline int ofi_complex_eq_## type			\
-	(ofi_complex_## type a, ofi_complex_## type b)		\
-{								\
-	return a.real == b.real && a.imag == b.imag;		\
-}								\
-static inline ofi_complex_## type ofi_complex_sum_## type	\
-	(ofi_complex_## type a, ofi_complex_## type b)		\
-{								\
-	ofi_complex_## type res;				\
-	res.real = a.real + b.real;				\
-	res.imag = a.imag + b.imag;				\
-	return res;						\
-}								\
-static inline ofi_complex_## type ofi_complex_prod_## type	\
-	(ofi_complex_## type a, ofi_complex_## type b)		\
-{								\
-	ofi_complex_## type res;				\
-	res.real = a.real * b.real - a.imag * b.imag;		\
-	res.imag = a.real * b.imag + a.imag * b.real;		\
-	return res;						\
-}								\
-static inline ofi_complex_## type ofi_complex_land_## type	\
-	(ofi_complex_## type a, ofi_complex_## type b)		\
-{								\
-	ofi_complex_## type res;				\
-	res.real = (type)(((a.real != 0) || (a.imag != 0)) &&	\
-		((b.real != 0) || (b.imag != 0)));		\
-	res.imag = 0;						\
-	return res;						\
-}								\
-static inline ofi_complex_## type ofi_complex_lor_## type	\
-	(ofi_complex_## type a, ofi_complex_## type b)		\
-{								\
-	ofi_complex_## type res;				\
-	res.real = (type)(((a.real != 0) || (a.imag != 0)) &&	\
-		((b.real != 0) || (b.imag != 0)));		\
-	res.imag = 0;						\
-	return res;						\
-}								\
-static inline ofi_complex_## type ofi_complex_lxor_## type	\
-	(ofi_complex_## type a, ofi_complex_## type b)		\
-{								\
-	ofi_complex_## type res;				\
-	res.real = (type)((((a.real != 0) || (a.imag != 0)) &&	\
-		    !((b.real != 0) || (b.imag != 0))) ||	\
-		   (!((a.real != 0) || (a.imag != 0)) &&	\
-		    ((b.real != 0) || (b.imag != 0))));		\
-	res.imag = 0;						\
-	return res;						\
-}
+#define OFI_DEF_COMPLEX(type)                                            \
+	typedef struct {                                                 \
+		type real;                                               \
+		type imag;                                               \
+	} ofi_complex_##type;                                            \
+	static inline int ofi_complex_eq_##type(ofi_complex_##type a,    \
+						ofi_complex_##type b)    \
+	{                                                                \
+		return a.real == b.real && a.imag == b.imag;             \
+	}                                                                \
+	static inline ofi_complex_##type ofi_complex_sum_##type(         \
+		ofi_complex_##type a, ofi_complex_##type b)              \
+	{                                                                \
+		ofi_complex_##type res;                                  \
+		res.real = a.real + b.real;                              \
+		res.imag = a.imag + b.imag;                              \
+		return res;                                              \
+	}                                                                \
+	static inline ofi_complex_##type ofi_complex_prod_##type(        \
+		ofi_complex_##type a, ofi_complex_##type b)              \
+	{                                                                \
+		ofi_complex_##type res;                                  \
+		res.real = a.real * b.real - a.imag * b.imag;            \
+		res.imag = a.real * b.imag + a.imag * b.real;            \
+		return res;                                              \
+	}                                                                \
+	static inline ofi_complex_##type ofi_complex_land_##type(        \
+		ofi_complex_##type a, ofi_complex_##type b)              \
+	{                                                                \
+		ofi_complex_##type res;                                  \
+		res.real = (type)(((a.real != 0) || (a.imag != 0)) &&    \
+				  ((b.real != 0) || (b.imag != 0)));     \
+		res.imag = 0;                                            \
+		return res;                                              \
+	}                                                                \
+	static inline ofi_complex_##type ofi_complex_lor_##type(         \
+		ofi_complex_##type a, ofi_complex_##type b)              \
+	{                                                                \
+		ofi_complex_##type res;                                  \
+		res.real = (type)(((a.real != 0) || (a.imag != 0)) &&    \
+				  ((b.real != 0) || (b.imag != 0)));     \
+		res.imag = 0;                                            \
+		return res;                                              \
+	}                                                                \
+	static inline ofi_complex_##type ofi_complex_lxor_##type(        \
+		ofi_complex_##type a, ofi_complex_##type b)              \
+	{                                                                \
+		ofi_complex_##type res;                                  \
+		res.real = (type)((((a.real != 0) || (a.imag != 0)) &&   \
+				   !((b.real != 0) || (b.imag != 0))) || \
+				  (!((a.real != 0) || (a.imag != 0)) &&  \
+				   ((b.real != 0) || (b.imag != 0))));   \
+		res.imag = 0;                                            \
+		return res;                                              \
+	}
 
 OFI_DEF_COMPLEX(float)
 OFI_DEF_COMPLEX(double)
 OFI_DEF_COMPLEX(long_double)
-
 
 /* atomics primitives */
 #ifdef HAVE_BUILTIN_ATOMICS
@@ -1026,10 +1016,16 @@ OFI_DEF_COMPLEX(long_double)
 typedef LONG ofi_atomic_int_32_t;
 typedef LONGLONG ofi_atomic_int_64_t;
 
-#define ofi_atomic_add_and_fetch(radix, ptr, val) InterlockedAdd##radix((ofi_atomic_int_##radix##_t volatile *)(ptr), (ofi_atomic_int_##radix##_t)(val))
-#define ofi_atomic_sub_and_fetch(radix, ptr, val) InterlockedAdd##radix((ofi_atomic_int_##radix##_t volatile *)(ptr), -(ofi_atomic_int_##radix##_t)(val))
-#define ofi_atomic_cas_bool(radix, ptr, expected, desired)					\
-	(InterlockedCompareExchange##radix((ofi_atomic_int_##radix##_t volatile *)ptr, desired, expected) == expected)
+#define ofi_atomic_add_and_fetch(radix, ptr, val)                           \
+	InterlockedAdd##radix((ofi_atomic_int_##radix##_t volatile *)(ptr), \
+			      (ofi_atomic_int_##radix##_t)(val))
+#define ofi_atomic_sub_and_fetch(radix, ptr, val)                           \
+	InterlockedAdd##radix((ofi_atomic_int_##radix##_t volatile *)(ptr), \
+			      -(ofi_atomic_int_##radix##_t)(val))
+#define ofi_atomic_cas_bool(radix, ptr, expected, desired)            \
+	(InterlockedCompareExchange##radix(                           \
+		 (ofi_atomic_int_##radix##_t volatile *)ptr, desired, \
+		 expected) == expected)
 
 #endif /* HAVE_BUILTIN_ATOMICS */
 
@@ -1039,19 +1035,26 @@ static inline int ofi_set_thread_affinity(const char *s)
 	return -FI_ENOSYS;
 }
 
-
 #if defined(_M_X64) || defined(_M_AMD64)
 
 #include <intrin.h>
 
-static inline void
-ofi_cpuid(unsigned func, unsigned subfunc, unsigned cpuinfo[4])
+static inline void ofi_cpuid(unsigned func, unsigned subfunc,
+			     unsigned cpuinfo[4])
 {
 	__cpuidex((int *)cpuinfo, func, subfunc);
 }
 
-#define ofi_clwb(addr) do { _mm_clflush((void const *)addr); _mm_sfence(); } while (0)
-#define ofi_clflushopt(addr) do { _mm_clflush((void const *)addr); _mm_sfence(); } while (0)
+#define ofi_clwb(addr)                           \
+	do {                                     \
+		_mm_clflush((void const *)addr); \
+		_mm_sfence();                    \
+	} while (0)
+#define ofi_clflushopt(addr)                     \
+	do {                                     \
+		_mm_clflush((void const *)addr); \
+		_mm_sfence();                    \
+	} while (0)
 #define ofi_clflush(addr) _mm_clflush((void const *)addr)
 #define ofi_sfence() _mm_sfence()
 
@@ -1064,7 +1067,6 @@ ofi_cpuid(unsigned func, unsigned subfunc, unsigned cpuinfo[4])
 #define ofi_sfence()
 
 #endif /* defined(_M_X64) || defined(_M_AMD64) */
-
 
 #ifdef __cplusplus
 }

--- a/include/windows/poll.h
+++ b/include/windows/poll.h
@@ -26,4 +26,3 @@ static inline int poll(struct pollfd *fds, int nfds, int timeout)
 		return WSAPoll(fds, nfds, timeout);
 	}
 }
-

--- a/include/windows/pthread.h
+++ b/include/windows/pthread.h
@@ -41,44 +41,50 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
-#define PTHREAD_MUTEX_INITIALIZER {0}
-#define PTHREAD_RWLOCK_INITIALIZER {0}
+#define PTHREAD_MUTEX_INITIALIZER \
+	{                         \
+		0                 \
+	}
+#define PTHREAD_RWLOCK_INITIALIZER \
+	{                          \
+		0                  \
+	}
 
 #define pthread_cond_signal WakeConditionVariable
 #define pthread_cond_broadcast WakeAllConditionVariable
 #define pthread_mutex_init(mutex, attr) (InitializeCriticalSection(mutex), 0)
 #define pthread_mutex_destroy(mutex) (DeleteCriticalSection(mutex), 0)
 #define pthread_cond_init(cond, attr) (InitializeConditionVariable(cond), 0)
-#define pthread_cond_destroy(x)	/* nothing to do */
+#define pthread_cond_destroy(x) /* nothing to do */
 
-typedef CRITICAL_SECTION	pthread_mutex_t;
-typedef CONDITION_VARIABLE	pthread_cond_t;
-typedef HANDLE			pthread_t;
+typedef CRITICAL_SECTION pthread_mutex_t;
+typedef CONDITION_VARIABLE pthread_cond_t;
+typedef HANDLE pthread_t;
 
-static inline int pthread_mutex_lock(pthread_mutex_t* mutex)
+static inline int pthread_mutex_lock(pthread_mutex_t *mutex)
 {
 	EnterCriticalSection(mutex);
 	return 0;
 }
 
-static inline int pthread_mutex_trylock(pthread_mutex_t* mutex)
+static inline int pthread_mutex_trylock(pthread_mutex_t *mutex)
 {
 	return !TryEnterCriticalSection(mutex);
 }
 
-static inline int pthread_mutex_unlock(pthread_mutex_t* mutex)
+static inline int pthread_mutex_unlock(pthread_mutex_t *mutex)
 {
 	LeaveCriticalSection(mutex);
 	return 0;
 }
 
-static inline int pthread_join(pthread_t thread, void** exit_code)
+static inline int pthread_join(pthread_t thread, void **exit_code)
 {
 	if (WaitForSingleObject(thread, INFINITE) == WAIT_OBJECT_0) {
 		if (exit_code) {
 			DWORD ex = 0;
 			GetExitCodeThread(thread, &ex);
-			*exit_code = (void*)(uint64_t)ex;
+			*exit_code = (void *)(uint64_t)ex;
 		}
 		CloseHandle(thread);
 		return 0;
@@ -87,23 +93,23 @@ static inline int pthread_join(pthread_t thread, void** exit_code)
 	return -1;
 }
 
-typedef struct fi_thread_arg
-{
-	void* (*routine)(void*);
-	void* arg;
+typedef struct fi_thread_arg {
+	void *(*routine)(void *);
+	void *arg;
 } fi_thread_arg;
 
-static DWORD WINAPI ofi_thread_starter(void* arg)
+static DWORD WINAPI ofi_thread_starter(void *arg)
 {
-	fi_thread_arg data = *(fi_thread_arg*)arg;
+	fi_thread_arg data = *(fi_thread_arg *)arg;
 	free(arg);
 	return (DWORD)(uint64_t)data.routine(data.arg);
 }
 
-static inline int pthread_create(pthread_t* thread, void* attr, void *(*routine)(void*), void* arg)
+static inline int pthread_create(pthread_t *thread, void *attr,
+				 void *(*routine)(void *), void *arg)
 {
-	(void) attr;
-	fi_thread_arg* data = (fi_thread_arg*)malloc(sizeof(*data));
+	(void)attr;
+	fi_thread_arg *data = (fi_thread_arg *)malloc(sizeof(*data));
 	data->routine = routine;
 	data->arg = arg;
 	DWORD threadid;
@@ -138,12 +144,12 @@ static inline pthread_t pthread_self(void)
 	 * TODO: temporary solution
 	 * Need to implement
 	 */
-	return (pthread_t) ENOSYS;
+	return (pthread_t)ENOSYS;
 }
 
 static inline int pthread_yield(void)
 {
-	(void) SwitchToThread();
+	(void)SwitchToThread();
 	return 0;
 }
 
@@ -151,9 +157,8 @@ static inline int pthread_yield(void)
  * TODO: temporary solution
  * Need to re-implement
  */
-typedef void(*pthread_cleanup_callback_t)(void *);
-typedef struct pthread_cleanup_t
-{
+typedef void (*pthread_cleanup_callback_t)(void *);
+typedef struct pthread_cleanup_t {
 	pthread_cleanup_callback_t routine;
 	void *arg;
 } pthread_cleanup_t;
@@ -161,12 +166,13 @@ typedef struct pthread_cleanup_t
 /* Read-Write lock implementation */
 
 typedef struct {
-    SRWLOCK	lock; /* Windows Slim Reader Writer Lock */
-    bool	write_mode;
+	SRWLOCK lock; /* Windows Slim Reader Writer Lock */
+	bool write_mode;
 } pthread_rwlock_t;
 typedef void pthread_rwlockattr_t;
 
-static inline int pthread_rwlock_init(pthread_rwlock_t *rwlock, const pthread_rwlockattr_t *attr)
+static inline int pthread_rwlock_init(pthread_rwlock_t *rwlock,
+				      const pthread_rwlockattr_t *attr)
 {
 	(void)attr;
 	if (rwlock) {
@@ -220,7 +226,6 @@ static inline int pthread_rwlock_trywrlock(pthread_rwlock_t *rwlock)
 	return 1;
 }
 
-
 static inline int pthread_rwlock_unlock(pthread_rwlock_t *rwlock)
 {
 	if (rwlock) {
@@ -235,32 +240,31 @@ static inline int pthread_rwlock_unlock(pthread_rwlock_t *rwlock)
 	return 1;
 }
 
-#ifndef __cplusplus 
-#define pthread_cleanup_push(_rout, _arg)				\
-{									\
-	pthread_cleanup_t _cleanup = {					\
-		.routine = (pthread_cleanup_callback_t) (_rout),	\
-		.arg = (_arg),						\
-	};								\
+#ifndef __cplusplus
+#define pthread_cleanup_push(_rout, _arg)                               \
+	{                                                               \
+		pthread_cleanup_t _cleanup = {                          \
+			.routine = (pthread_cleanup_callback_t)(_rout), \
+			.arg = (_arg),                                  \
+		};
 
-#define pthread_cleanup_pop(_execute)					\
-	if (_execute)							\
-		(void) (*(_cleanup.routine))(_cleanup.arg);		\
-}
+#define pthread_cleanup_pop(_execute)                      \
+	if (_execute)                                      \
+		(void)(*(_cleanup.routine))(_cleanup.arg); \
+	}
 #else
-#define pthread_cleanup_push(_rout, _arg)				\
-{									\
-	pthread_cleanup_t _cleanup;					\
-	_cleanup.routine = (pthread_cleanup_callback_t) _rout,		\
-	_cleanup.arg = (_arg);						\
-	__try								\
-	{								\
-
-#define pthread_cleanup_pop(_execute)					\
-	}								\
-	__finally {							\
-		if( _execute || AbnormalTermination())			\
-			(*(_cleanup.routine))(_cleanup.arg);		\
-	}								\
-}
+#define pthread_cleanup_push(_rout, _arg)                             \
+	{                                                             \
+		pthread_cleanup_t _cleanup;                           \
+		_cleanup.routine = (pthread_cleanup_callback_t)_rout, \
+		_cleanup.arg = (_arg);                                \
+		__try {
+#define pthread_cleanup_pop(_execute)                        \
+	}                                                    \
+	__finally                                            \
+	{                                                    \
+		if (_execute || AbnormalTermination())       \
+			(*(_cleanup.routine))(_cleanup.arg); \
+	}                                                    \
+	}
 #endif

--- a/include/windows/sched.h
+++ b/include/windows/sched.h
@@ -1,13 +1,11 @@
 
 #pragma once
 
-
 #include "osd.h"
 #include <processthreadsapi.h>
 
-
 static inline int sched_yield(void)
 {
-	(void) SwitchToThread();
+	(void)SwitchToThread();
 	return 0;
 }

--- a/include/windows/sys/epoll.h
+++ b/include/windows/sys/epoll.h
@@ -1,4 +1,2 @@
 
 #pragma once
-
-

--- a/include/windows/sys/ipc.h
+++ b/include/windows/sys/ipc.h
@@ -1,4 +1,2 @@
 
 #pragma once
-
-

--- a/include/windows/sys/mman.h
+++ b/include/windows/sys/mman.h
@@ -17,14 +17,15 @@
 #include "ofi_osd.h"
 
 /* Unix specific macro */
-#define MAP_SHARED	0x01		/* Share changes.  */
-#define MAP_PRIVATE	0x02		/* Changes are private.  */
-#define MAP_FAILED	((void*)-1)	/* Return value of `mmap' in case of an error.  */
+#define MAP_SHARED 0x01 /* Share changes.  */
+#define MAP_PRIVATE 0x02 /* Changes are private.  */
+#define MAP_FAILED \
+	((void *)-1) /* Return value of `mmap' in case of an error.  */
 
-#define PROT_READ	0x1	/* Page can be read.  */
-#define PROT_WRITE	0x2	/* Page can be written.  */
-#define PROT_EXEC	0x4	/* Page can be executed.  */
-#define PROT_NONE	0x0	/* Page can not be accessed.  */
+#define PROT_READ 0x1 /* Page can be read.  */
+#define PROT_WRITE 0x2 /* Page can be written.  */
+#define PROT_EXEC 0x4 /* Page can be executed.  */
+#define PROT_NONE 0x0 /* Page can not be accessed.  */
 
 /* Unix specific macro */
 #define S_IRUSR S_IREAD
@@ -33,7 +34,8 @@
 typedef uint32_t mode_t;
 
 /* stubs for Linux only functions */
-static inline void *mremap(void *old_address, size_t old_size, size_t new_size, int flags)
+static inline void *mremap(void *old_address, size_t old_size, size_t new_size,
+			   int flags)
 {
 	OFI_UNUSED(old_address);
 	OFI_UNUSED(old_size);
@@ -58,7 +60,8 @@ static inline int shm_unlink(const char *name)
 	return -1;
 }
 
-static inline void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset)
+static inline void *mmap(void *addr, size_t length, int prot, int flags, int fd,
+			 off_t offset)
 {
 	OFI_UNUSED(addr);
 	OFI_UNUSED(length);
@@ -85,5 +88,3 @@ static inline int ftruncate(int fd, off_t length)
 
 	return -1;
 }
-
-

--- a/include/windows/sys/param.h
+++ b/include/windows/sys/param.h
@@ -1,4 +1,2 @@
 
 #pragma once
-
-

--- a/include/windows/sys/select.h
+++ b/include/windows/sys/select.h
@@ -1,4 +1,2 @@
 
 #pragma once
-
-

--- a/include/windows/sys/socket.h
+++ b/include/windows/sys/socket.h
@@ -22,11 +22,11 @@ extern "C" {
 #endif /* __cplusplus */
 
 struct msghdr {
-	void * msg_name; /* optional address */
+	void *msg_name; /* optional address */
 	socklen_t msg_namelen; /* size of address */
-	struct iovec * msg_iov; /* scatter/gather array */
+	struct iovec *msg_iov; /* scatter/gather array */
 	size_t msg_iovlen; /* # elements in msg_iov */
-	void * msg_control; /* ancillary data, see below */
+	void *msg_control; /* ancillary data, see below */
 	socklen_t msg_controllen; /* ancillary data buffer len */
 	int msg_flags; /* flags on received message */
 };
@@ -35,7 +35,8 @@ ssize_t sendmsg(SOCKET sd, struct msghdr *msg, int flags);
 ssize_t recvmsg(SOCKET sd, struct msghdr *msg, int flags);
 
 #ifdef __cplusplus
-extern }
+extern
+}
 #endif /* __cplusplus */
 
 #endif /* _FI_WIN_SYS_SOCKET_H_ */

--- a/include/windows/sys/time.h
+++ b/include/windows/sys/time.h
@@ -16,23 +16,23 @@
 #include <WinSock2.h>
 #include <stdint.h>
 
-static inline int gettimeofday(struct timeval* time, struct timezone* zone)
+static inline int gettimeofday(struct timeval *time, struct timezone *zone)
 {
 	/* shift is difference between 1970-Jan-01 & 1601-Jan-01
 	* in 100-nanosecond intervals: (27111902 << 32) + 3577643008 */
 	const uint64_t shift = 116444736000000000ULL;
 	zone;
 
-	SYSTEMTIME  stime;
-	FILETIME    ftime;
-	uint64_t    utime;
+	SYSTEMTIME stime;
+	FILETIME ftime;
+	uint64_t utime;
 
 	GetSystemTime(&stime);
 	SystemTimeToFileTime(&stime, &ftime);
-	utime = (((uint64_t)ftime.dwHighDateTime) << 32) + ((uint64_t)ftime.dwLowDateTime);
+	utime = (((uint64_t)ftime.dwHighDateTime) << 32) +
+		((uint64_t)ftime.dwLowDateTime);
 
 	time->tv_sec = (long)((utime - shift) / 10000000L);
 	time->tv_usec = (long)(stime.wMilliseconds * 1000);
 	return 0;
 }
-

--- a/include/windows/sys/uio.h
+++ b/include/windows/sys/uio.h
@@ -23,4 +23,3 @@ struct iovec {
 };
 
 #endif /* _FI_WIN_SYS_UIO_H_ */
-

--- a/include/windows/unistd.h
+++ b/include/windows/unistd.h
@@ -37,5 +37,5 @@
 
 static inline void usleep(DWORD waitTime)
 {
-    Sleep(ceil(waitTime / 1000.0));
+	Sleep(ceil(waitTime / 1000.0));
 }


### PR DESCRIPTION
Lets enforce a style guide across the project to save everyone time (no more giving or getting formatting comments).

Adds the clang format file from linux kernel.
Adds CI to make sure future PR's are formatted (tested on this PR, it works).
Formatted all files in the project.

To format the entire project:
```
find foo/bar/ -iname *.h -o -iname *.c | xargs clang-format -i
```

To format just the files you have changed:
```
git-clang-format
```