### PR TITLE
prov/efa: Correct send_ops_flags for RMDA writes

### DIFF
--- a/prov/efa/src/rdm/rxr_ep.c
+++ b/prov/efa/src/rdm/rxr_ep.c
@@ -822,6 +822,10 @@ static int rxr_ep_ctrl(struct fid *fid, int command, void *arg)
 		attr_ex.send_ops_flags = IBV_QP_EX_WITH_SEND;
 		if (efa_domain_support_rdma_read(ep->base_ep.domain))
 			attr_ex.send_ops_flags |= IBV_QP_EX_WITH_RDMA_READ;
+		if (efa_domain_support_rdma_write(ep->base_ep.domain)) {
+			attr_ex.send_ops_flags |= IBV_QP_EX_WITH_RDMA_WRITE;
+			attr_ex.send_ops_flags |= IBV_QP_EX_WITH_RDMA_WRITE_WITH_IMM;
+		}
 		attr_ex.pd = rxr_ep_domain(ep)->ibv_pd;
 
 		attr_ex.qp_context = ep;


### PR DESCRIPTION
During initialization of the qp_ex for efadv and ibv, we must include IBV_QP_EX_WITH_RDMA_WRITE and *_WITH_IMM flags if we intend to issue RDMA writes.

---

Sorry, this should have been in the previous PR, but was missed at the time.