### PR TITLE
prov/efa: Fix the error handling of gdrcopy_dev_register.

### DIFF
--- a/prov/efa/src/efa_mr.h
+++ b/prov/efa/src/efa_mr.h
@@ -49,6 +49,7 @@ struct efa_mr_peer {
 		int             neuron;
 		int             synapseai;
 	} device;
+	bool use_gdrcopy;
 };
 
 struct efa_mr {


### PR DESCRIPTION
cuda_gdrcopy_dev_register could fail due to some hardware limitation, e.g. memory limit. In this case, if user enable cuda API, efa should fallback to cudaMemcpy.
Per this, efa provider should only unregister cuda gdr handle when it's indeed registered, i.e. the device.cuda is a gdr handle rather than a device id