### PR TITLE
core/cuda: Use correct debug string calls

### DIFF
--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -58,6 +58,8 @@ cudaError_t ofi_cudaMemcpy(void* dst, const void* src, size_t count,
 			   enum cudaMemcpyKind kind);
 const char *ofi_cudaGetErrorName(cudaError_t error);
 const char *ofi_cudaGetErrorString(cudaError_t error);
+CUresult ofi_cuGetErrorName(CUresult error, const char** pStr);
+CUresult ofi_cuGetErrorString(CUresult error, const char** pStr);
 CUresult ofi_cuPointerGetAttribute(void *data, CUpointer_attribute attribute,
 				   CUdeviceptr ptr);
 cudaError_t ofi_cudaHostRegister(void *ptr, size_t size, unsigned int flags);

--- a/prov/util/src/cuda_mem_monitor.c
+++ b/prov/util/src/cuda_mem_monitor.c
@@ -40,6 +40,7 @@ static int cuda_mm_subscribe(struct ofi_mem_monitor *monitor, const void *addr,
 			     size_t len, union ofi_mr_hmem_info *hmem_info)
 {
 	CUresult ret;
+	const char *errname, *errstr;
 
 	ret = ofi_cuPointerGetAttribute(&hmem_info->cuda_id,
 					CU_POINTER_ATTRIBUTE_BUFFER_ID,
@@ -51,10 +52,12 @@ static int cuda_mm_subscribe(struct ofi_mem_monitor *monitor, const void *addr,
 		return FI_SUCCESS;
 	}
 
+	ofi_cuGetErrorName(ret, &errname);
+	ofi_cuGetErrorString(ret, &errstr);
 	FI_WARN(&core_prov, FI_LOG_MR,
 		"Failed to get CUDA buffer ID for buffer %p len %lu\n"
 		"cuPointerGetAttribute() failed: %s:%s\n", addr, len,
-		ofi_cudaGetErrorName(ret), ofi_cudaGetErrorString(ret));
+		errname, errstr);
 
 	return -FI_EFAULT;
 }
@@ -72,6 +75,7 @@ static bool cuda_mm_valid(struct ofi_mem_monitor *monitor,
 {
 	uint64_t id;
 	CUresult ret;
+	const char *errname, *errstr;
 
 	/* CUDA buffer IDs are associated for each CUDA monitor entry. If the
 	 * device pages backing the device virtual address change, a different
@@ -89,11 +93,13 @@ static bool cuda_mm_valid(struct ofi_mem_monitor *monitor,
 		       "CUDA buffer ID %lu invalid for buffer %p\n",
 		       entry->hmem_info.cuda_id, entry->info.iov.iov_base);
 	} else {
+		ofi_cuGetErrorName(ret, &errname);
+		ofi_cuGetErrorString(ret, &errstr);
 		FI_WARN(&core_prov, FI_LOG_MR,
 			"Failed to get CUDA buffer ID for buffer %p len %lu\n"
 			"cuPointerGetAttribute() failed: %s:%s\n",
 			entry->info.iov.iov_base, entry->info.iov.iov_len,
-			ofi_cudaGetErrorName(ret), ofi_cudaGetErrorString(ret));
+			errname, errstr);
 	}
 
 	return false;


### PR DESCRIPTION
Use correct calls for CUresult values, not cudaError_t calls.

Fixes #8604  -- maybe, I can't test the build for this on my system