### PR TITLE
fabtests/pytest/efa: Remove the env append in test_mr.py

### DIFF
--- a/fabtests/pytest/efa/test_mr.py
+++ b/fabtests/pytest/efa/test_mr.py
@@ -25,7 +25,6 @@ def test_mr_hmem(cmdline_args, hmem_type):
         pytest.skip("no neuron device")
 
     cmdline_args_copy = copy.copy(cmdline_args)
-    cmdline_args_copy.append_environ("FI_EFA_USE_DEVICE_RDMA=1")
 
     test = UnitTest(
         cmdline_args_copy,


### PR DESCRIPTION
This FI_EFA_USE_DEVICE_RDMA export should be handled by the caller of the script based on platform.