### PR TITLE
prov/tcp: accept() now supports io_uring

### DIFF
--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -166,6 +166,9 @@ struct ofi_sockapi {
 	int (*connect)(struct ofi_sockapi *sockapi, SOCKET sock,
 		       const struct sockaddr *addr, socklen_t addrlen,
 		       struct ofi_sockctx *ctx);
+	int (*accept)(struct ofi_sockapi *sockapi, SOCKET sock,
+		      struct sockaddr *addr, socklen_t *addrlen,
+		      struct ofi_sockctx *ctx);
 
 	ssize_t (*send)(struct ofi_sockapi *sockapi, SOCKET sock, const void *buf,
 			size_t len, int flags, struct ofi_sockctx *ctx);
@@ -197,6 +200,22 @@ ofi_sockapi_connect_socket(struct ofi_sockapi *sockapi, SOCKET sock,
 	OFI_UNUSED(ctx);
 
 	ret = connect(sock, addr, addrlen);
+	if (ret < 0)
+		return -ofi_sockerr();
+	return ret;
+}
+
+static inline int
+ofi_sockapi_accept_socket(struct ofi_sockapi *sockapi, SOCKET sock,
+			  struct sockaddr *addr, socklen_t *addrlen,
+			  struct ofi_sockctx *ctx)
+{
+	int ret;
+
+	OFI_UNUSED(sockapi);
+	OFI_UNUSED(ctx);
+
+	ret = accept(sock, addr, addrlen);
 	if (ret < 0)
 		return -ofi_sockerr();
 	return ret;
@@ -278,6 +297,9 @@ ofi_sockapi_recvv_socket(struct ofi_sockapi *sockapi, SOCKET sock,
 int ofi_sockapi_connect_uring(struct ofi_sockapi *sockapi, SOCKET sock,
 			      const struct sockaddr *addr, socklen_t addrlen,
 			      struct ofi_sockctx *ctx);
+int ofi_sockapi_accept_uring(struct ofi_sockapi *sockapi, SOCKET sock,
+			     struct sockaddr *addr, socklen_t *addrlen,
+			     struct ofi_sockctx *ctx);
 
 ssize_t ofi_sockapi_send_uring(struct ofi_sockapi *sockapi, SOCKET sock,
 			       const void *buf, size_t len, int flags,
@@ -340,6 +362,14 @@ static inline int
 ofi_sockapi_connect_uring(struct ofi_sockapi *sockapi, SOCKET sock,
 			  const struct sockaddr *addr, socklen_t addrlen,
 			  struct ofi_sockctx *ctx)
+{
+	return -FI_ENOSYS;
+}
+
+static inline int
+ofi_sockapi_accept_uring(struct ofi_sockapi *sockapi, SOCKET sock,
+			 struct sockaddr *addr, socklen_t *addrlen,
+			 struct ofi_sockctx *ctx)
 {
 	return -FI_ENOSYS;
 }

--- a/prov/tcp/src/xnet.h
+++ b/prov/tcp/src/xnet.h
@@ -126,6 +126,8 @@ struct xnet_conn_handle {
 	struct xnet_pep		*pep;
 	SOCKET			sock;
 	bool			endian_match;
+	struct ofi_sockapi	*sockapi;
+	struct ofi_sockctx	rx_sockctx;
 };
 
 struct xnet_pep {

--- a/prov/tcp/src/xnet.h
+++ b/prov/tcp/src/xnet.h
@@ -337,7 +337,7 @@ int xnet_start_recv(struct xnet_ep *ep, struct xnet_xfer_entry *rx_entry);
 void xnet_progress(struct xnet_progress *progress, bool clear_signal);
 void xnet_run_progress(struct xnet_progress *progress, bool clear_signal);
 int xnet_progress_wait(struct xnet_progress *progress, int timeout);
-void xnet_run_conn(struct xnet_conn_handle *conn, bool pin, bool pout, bool perr);
+void xnet_handle_conn(struct xnet_conn_handle *conn, bool error);
 void xnet_handle_event_list(struct xnet_progress *progress);
 void xnet_progress_unexp(struct xnet_progress *progress);
 

--- a/prov/tcp/src/xnet_cm.c
+++ b/prov/tcp/src/xnet_cm.c
@@ -251,7 +251,7 @@ disable:
 
 }
 
-void xnet_run_conn(struct xnet_conn_handle *conn, bool pin, bool pout, bool perr)
+void xnet_handle_conn(struct xnet_conn_handle *conn, bool error)
 {
 	struct xnet_cm_msg msg;
 	struct xnet_cm_entry cm_entry;
@@ -262,10 +262,7 @@ void xnet_run_conn(struct xnet_conn_handle *conn, bool pin, bool pout, bool perr
 	FI_DBG(&xnet_prov, FI_LOG_EP_CTRL, "Receiving connect request\n");
 	assert(xnet_progress_locked(conn->pep->progress));
 
-	/* Don't monitor the socket until the user calls fi_accept */
-	xnet_halt_sock(conn->pep->progress, conn->sock);
-
-	if (perr) {
+	if (error) {
 		FI_WARN(&xnet_prov, FI_LOG_EP_CTRL, "socket error\n");
 		goto close;
 	}

--- a/prov/tcp/src/xnet_progress.c
+++ b/prov/tcp/src/xnet_progress.c
@@ -49,6 +49,7 @@ static int (*xnet_start_op[ofi_op_write + 1])(struct xnet_ep *ep);
 static struct ofi_sockapi xnet_sockapi_uring =
 {
 	.connect = ofi_sockapi_connect_uring,
+	.accept = ofi_sockapi_accept_uring,
 	.send = ofi_sockapi_send_uring,
 	.sendv = ofi_sockapi_sendv_uring,
 	.recv = ofi_sockapi_recv_uring,
@@ -58,6 +59,7 @@ static struct ofi_sockapi xnet_sockapi_uring =
 static struct ofi_sockapi xnet_sockapi_socket =
 {
 	.connect = ofi_sockapi_connect_socket,
+	.accept = ofi_sockapi_accept_socket,
 	.send = ofi_sockapi_send_socket,
 	.sendv = ofi_sockapi_sendv_socket,
 	.recv = ofi_sockapi_recv_socket,

--- a/prov/tcp/src/xnet_progress.c
+++ b/prov/tcp/src/xnet_progress.c
@@ -1164,6 +1164,16 @@ static void xnet_run_ep(struct xnet_ep *ep, bool pin, bool pout, bool perr)
 }
 
 static void
+xnet_run_conn(struct xnet_conn_handle *conn, bool pin, bool pout, bool perr)
+{
+	assert(xnet_progress_locked(conn->pep->progress));
+
+	/* Don't monitor the socket until the user calls fi_accept */
+	xnet_halt_sock(conn->pep->progress, conn->sock);
+	xnet_handle_conn(conn, perr);
+}
+
+static void
 xnet_handle_events(struct xnet_progress *progress,
 		   struct ofi_epollfds_event *events, int nfds,
 		   bool clear_signal)

--- a/src/iouring.c
+++ b/src/iouring.c
@@ -59,6 +59,28 @@ int ofi_sockapi_connect_uring(struct ofi_sockapi *sockapi, SOCKET sock,
 	return -OFI_EINPROGRESS_URING;
 }
 
+int ofi_sockapi_accept_uring(struct ofi_sockapi *sockapi, SOCKET sock,
+			     struct sockaddr *addr, socklen_t *addrlen,
+			     struct ofi_sockctx *ctx)
+{
+	struct io_uring_sqe *sqe;
+	struct ofi_sockapi_uring *uring;
+
+	uring = &sockapi->rx_uring;
+	if (ctx->uring_sqe_inuse || uring->credits == 0)
+		return -FI_EAGAIN;
+
+	sqe = io_uring_get_sqe(uring->io_uring);
+	if (!sqe)
+	return -FI_EOVERFLOW;
+
+	io_uring_prep_accept(sqe, sock, addr, addrlen, 0);
+	io_uring_sqe_set_data(sqe, ctx);
+	ctx->uring_sqe_inuse = true;
+	uring->credits--;
+	return -OFI_EINPROGRESS_URING;
+}
+
 ssize_t ofi_sockapi_send_uring(struct ofi_sockapi *sockapi, SOCKET sock,
 			       const void *buf,  size_t len, int flags,
 			       struct ofi_sockctx *ctx)


### PR DESCRIPTION
The PR enables io_uring for the code path executed when an incoming request is accepted. 