### PR TITLE
prov/tcp: Fix a few bugs during cancelation of outstanding io_uring requests

### DIFF
--- a/prov/tcp/src/xnet_progress.c
+++ b/prov/tcp/src/xnet_progress.c
@@ -1091,7 +1091,7 @@ int xnet_uring_cancel(struct xnet_progress *progress,
 	int ret = 0;
 
 	assert(xnet_progress_locked(progress));
-	while (canceled_ctx->uring_sqe_inuse) {
+	while (canceled_ctx->uring_sqe_inuse || ctx->uring_sqe_inuse) {
 		assert(xnet_io_uring);
 		if (!submitted) {
 			ret = ofi_sockctx_uring_cancel(uring->sockapi,

--- a/prov/tcp/src/xnet_progress.c
+++ b/prov/tcp/src/xnet_progress.c
@@ -1088,7 +1088,7 @@ int xnet_uring_cancel(struct xnet_progress *progress,
 		      struct ofi_sockctx *ctx)
 {
 	bool submitted = false;
-	int ret = 0;
+	int ret;
 
 	assert(xnet_progress_locked(progress));
 	while (canceled_ctx->uring_sqe_inuse || ctx->uring_sqe_inuse) {
@@ -1106,7 +1106,7 @@ int xnet_uring_cancel(struct xnet_progress *progress,
 
 		xnet_progress_uring(progress, uring);
 	}
-	return ret;
+	return 0;
 }
 
 void xnet_tx_queue_insert(struct xnet_ep *ep,


### PR DESCRIPTION
This PR fixes a few bugs I found while reviewing/testing the code related to the cancellation of outstanding io_uring requests. 