### PR TITLE
prov/tcp: Fix ret not set if connect() fails with io_uring

### DIFF
--- a/prov/tcp/src/xnet_progress.c
+++ b/prov/tcp/src/xnet_progress.c
@@ -998,6 +998,7 @@ static void xnet_uring_connect_done(struct xnet_ep *ep, int res)
 	if (res < 0) {
 		FI_WARN_SPARSE(&xnet_prov, FI_LOG_EP_CTRL,
 				"connection failure (sockerr %d)\n", res);
+		ret = res;
 		goto disable;
 	}
 


### PR DESCRIPTION
"ret" must be set to the value of "res", otherwise the caller wouldn't know the reason for a failing call to connect().