### PR TITLE
fabtests/rdm_stress: Remove count from json test configs

### DIFF
--- a/fabtests/test_configs/rdm_stress/stress-msg.json
+++ b/fabtests/test_configs/rdm_stress/stress-msg.json
@@ -27,7 +27,7 @@ This is a sample control file for fi_rdm_stress
 Valid configuration is in the JSON array definition below.
 "
 [
-	{ "op" : "msg_req", "size" : 10000, "count" : 1000 },
+	{ "op" : "msg_req", "size" : 10000 },
 	{ "op" : "sleep", "ms" : 1 },
 	{ "op" : "exit" }
 ]

--- a/fabtests/test_configs/rdm_stress/stress.json
+++ b/fabtests/test_configs/rdm_stress/stress.json
@@ -28,7 +28,7 @@ This is a sample control file for fi_rdm_stress
 Valid configuration is in the JSON array definition below.
 "
 [
-	{ "op" : "msg_req", "size" : 1000, "count" : 2 },
+	{ "op" : "msg_req", "size" : 1000 },
 	{ "op" : "msg_resp" },
 	{ "op" : "tag_req", "size" : 2000 },
 	{ "op" : "tag_resp" },


### PR DESCRIPTION
The count parameter does not work generically when paired with message requests.  For each request, we need a corresponding response for the test to make progress.  However, we can't assume that the server will queue thousands of requests before we start looking for a response.  Flow control can back up the sending of requests.

Remove the count from the config files.