### PR TITLE
[v1.17.x] fabtests/pytest/efa: use lsmod on default PATH

### DIFF
--- a/fabtests/pytest/efa/efa_common.py
+++ b/fabtests/pytest/efa/efa_common.py
@@ -51,7 +51,7 @@ def has_gdrcopy(hostname):
     hostname: a host
     return: a boolean
     """
-    command = "ssh {} /usr/sbin/lsmod | grep gdrdrv".format(hostname)
+    command = "ssh {} lsmod | grep gdrdrv".format(hostname)
     process = subprocess.run(command, shell=True, check=False, stdout=subprocess.PIPE)
     return process.returncode == 0
 


### PR DESCRIPTION
Backport bugfix