### PR TITLE
core/hmem: Allow specifying Ze devices as device_handles

### DIFF
--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -130,6 +130,11 @@ enum fi_hmem_iface {
 	FI_HMEM_SYNAPSEAI,
 };
 
+static inline int fi_hmem_ze_device(int driver_index, int device_index)
+{
+	return driver_index << 16 | device_index;
+}
+
 struct fi_mr_attr {
 	const struct iovec	*mr_iov;
 	size_t			iov_count;


### PR DESCRIPTION
Level zero has the concept of drivers and devices, with devices belonging to driver objects.  As a result, two devices can have the same index as long as they are from different drivers. To disambiguate what device might be referred to, extend the API to allow specifying the ze device using a ze_device_handle_t value.  (This is a pointer to a structure).

We determine if the device is given as an index or a pointer based on the range of values.