### PR TITLE
man, prov/efa,shm,verbs,rxm: implement FI_OPT_CUDA_API_PERMITTED for all providers that support FI_HMEM

### DIFF
--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -573,6 +573,9 @@ The following option levels and option names and parameters are defined.
   making such calls, user can achieve that by set this option to false.
   If an endpoint's support of CUDA memory relies on making calls to CUDA API,
   it will return -FI_EOPNOTSUPP for the call to fi_setopt.
+  If either CUDA library or CUDA device is not available, endpoint will
+  return -FI_EINVAL.
+  All providers that support FI_HMEM capability implement this option.
 
 ## fi_tc_dscp_set
 

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -213,9 +213,6 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 	/* Check the value of environment variable FI_EFA_USE_DEVICE_RDMA */
 	efa_domain->use_device_rdma = rxr_env_get_use_device_rdma();
 	
-	/* Check the value of environment variable FI_HMEM_CUDA_ENABLE_XFER */
-	efa_domain->cuda_xfer_setting = cuda_get_xfer_setting();
-
 	efa_domain->mr_local = ofi_mr_local(info);
 	if (EFA_EP_TYPE_IS_DGRAM(info) && !efa_domain->mr_local) {
 		EFA_WARN(FI_LOG_EP_DATA, "dgram require FI_MR_LOCAL, but application does not support it\n");

--- a/prov/efa/src/efa_domain.h
+++ b/prov/efa/src/efa_domain.h
@@ -57,7 +57,6 @@ struct efa_domain {
 	uint64_t		rdm_mode;
 	size_t			rdm_cq_size;
 	int	                use_device_rdma;
-	enum cuda_xfer_setting  cuda_xfer_setting;
 	struct dlist_entry	list_entry; /* linked to g_efa_domain_list */
 };
 

--- a/prov/efa/src/efa_hmem.c
+++ b/prov/efa/src/efa_hmem.c
@@ -164,11 +164,13 @@ static int efa_domain_hmem_info_init_cuda(struct efa_domain *efa_domain)
 
 	info->p2p_disabled_by_user = false;
 
-	/*
-	 * Require p2p for FI_HMEM_CUDA unless the user exlipictly enables
-	 * FI_HMEM_CUDA_ENABLE_XFER
+	/* If user is using libfabric API 1.18 or later, by default EFA provider is permitted to
+	 * use CUDA library to support CUDA memory, therefore p2p is not required.
 	 */
-	info->p2p_required_by_impl = efa_domain->cuda_xfer_setting != CUDA_XFER_ENABLED;
+	if (FI_VERSION_GE(efa_domain->util_domain.fabric->fabric_fid.api_version, FI_VERSION(1,18)))
+		info->p2p_required_by_impl = !hmem_ops[FI_HMEM_CUDA].initialized;
+	else
+		info->p2p_required_by_impl = true;
 
 	ibv_mr = ibv_reg_mr(g_device_list[0].ibv_pd, ptr, len, ibv_access);
 	if (!ibv_mr) {

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -262,9 +262,8 @@ static int efa_mr_hmem_setup(struct efa_mr *efa_mr,
 				EFA_WARN(FI_LOG_MR,
 					 "Unable to register handle for GPU memory. err: %d buf: %p len: %zu\n",
 					 err, attr->mr_iov->iov_base, attr->mr_iov->iov_len);
-				/* When gdrcopy pin buf failed, fallback to cudaMemcpy when user enables cuda xfer */
-				if (efa_mr->domain->cuda_xfer_setting != CUDA_XFER_ENABLED)
-					return err;
+				/* When gdrcopy pin buf failed, fallback to cudaMemcpy */
+				efa_mr->peer.use_gdrcopy = false;
 				efa_mr->peer.device.cuda = attr->device.cuda;
 			} else {
 				efa_mr->peer.use_gdrcopy = true;

--- a/prov/efa/src/rdm/rxr_ep.h
+++ b/prov/efa/src/rdm/rxr_ep.h
@@ -234,8 +234,9 @@ struct rxr_ep {
 	int blocking_copy_rx_entry_num; /* number of RX entries that are using gdrcopy/cudaMemcpy */
 
 	int	hmem_p2p_opt; /* what to do for hmem transfers */
-
 	struct fid_peer_srx peer_srx; /* support sharing receive context with peer providers */
+	bool cuda_api_permitted; /**< whether end point is permitted to call CUDA API */
+	struct fi_info *user_info; /**< fi_info passed by user when calling fi_endpoint */
 };
 
 int rxr_ep_flush_queued_blocking_copy_to_hmem(struct rxr_ep *ep);

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -554,6 +554,23 @@ static int rxm_ep_setopt(fid_t fid, int level, int optname,
 				rxm_ep->buffered_limit);
 		}
 		break;
+	case FI_OPT_CUDA_API_PERMITTED:
+		if (!hmem_ops[FI_HMEM_CUDA].initialized) {
+			FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
+				"FI_OPT_CUDA_API_PERMITTED cannot be set "
+				"when CUDA library or CUDA device is not "
+				"available.");
+			ret = -FI_EINVAL;
+			break;
+		}
+
+		/* if direct send is enabled, we directly pass CUDA buffer to
+		 * the msg endpoint, therefore we do not need to copy the buffer
+		 * and we do not need to call CUDA API.
+		 */
+		ret = rxm_ep->enable_direct_send ? FI_SUCCESS : -FI_EOPNOTSUPP;
+		break;
+
 	default:
 		ret = -FI_ENOPROTOOPT;
 	}


### PR DESCRIPTION
This PR implement the FI_OPT_CUDA_API_PERMITTED option for all providers that support FI_HMEM.

It also update the document of `fi_endpoint` to commit that all providers support FI_HMEM will implement this option.

This is to address: https://github.com/ofiwg/libfabric/issues/8639