### PR TITLE
prov/tcp: Fix a leak found by ASAN when EQ destroyed before domain

### DIFF
--- a/prov/tcp/src/xnet_eq.c
+++ b/prov/tcp/src/xnet_eq.c
@@ -85,6 +85,7 @@ static int xnet_eq_close(struct fid *fid)
 {
 	struct xnet_eq *eq;
 	struct xnet_fabric *fabric;
+	struct dlist_entry *item, *tmp;
 	int ret;
 
 	eq = container_of(fid, struct xnet_eq, util_eq.eq_fid.fid);
@@ -95,6 +96,11 @@ static int xnet_eq_close(struct fid *fid)
 	ofi_mutex_lock(&fabric->util_fabric.lock);
 	dlist_remove(&eq->fabric_entry);
 	ofi_mutex_unlock(&fabric->util_fabric.lock);
+
+	ofi_mutex_lock(&eq->domain_lock);
+	dlist_foreach_safe(&eq->domain_list, item, tmp)
+		free(item);
+	ofi_mutex_unlock(&eq->domain_lock);
 
 	ret = ofi_eq_cleanup(fid);
 	if (ret)


### PR DESCRIPTION
ASAN detects a memory leak when running 'fi_rdm_atomic -I 5 -o all -U -p "tcp"':

Direct leak of 24 byte(s) in 1 object(s) allocated from:
    0 0x7f8248757a37 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
    1 0x7f8248063cf8 in fid_list_search prov/util/src/util_main.c:85
    2 0x7f8248397816 in xnet_add_domain_progress prov/tcp/src/xnet_eq.c:167
    3 0x7f8248383668 in xnet_ep_bind prov/tcp/src/xnet_ep.c:610
    4 0x7f824828ee5b in fi_ep_bind include/rdma/fi_endpoint.h:202
    5 0x7f82482911b8 in rxm_open_conn prov/rxm/src/rxm_conn.c:196
    6 0x7f8248295fdd in rxm_process_connreq prov/rxm/src/rxm_conn.c:732
    7 0x7f8248296e0c in rxm_handle_event prov/rxm/src/rxm_conn.c:829
    8 0x7f8248297113 in rxm_conn_progress prov/rxm/src/rxm_conn.c:855
    9 0x7f82482ceef9 in rxm_ep_do_progress prov/rxm/src/rxm_cq.c:2020
    10 0x7f82482cf10a in rxm_ep_progress prov/rxm/src/rxm_cq.c:2040
    11 0x7f82480568c7 in ofi_cq_progress prov/util/src/util_cq.c:547
    12 0x7f8248054914 in ofi_cq_readfrom prov/util/src/util_cq.c:260
    13 0x7f8248050e14 in fi_cq_readfrom include/rdma/fi_eq.h:400
    14 0x7f824805530a in ofi_cq_read prov/util/src/util_cq.c:313
    15 0x55dabb288a4a in fi_cq_read /home/sdidelot/bin/libfabric//include/rdma/fi_eq.h:394
    16 0x55dabb29c2b9 in ft_spin_for_comp common/shared.c:2331
    17 0x55dabb29cb6b in ft_get_cq_comp common/shared.c:2421
    18 0x55dabb29d1f6 in ft_get_rx_comp common/shared.c:2501
    19 0x55dabb29323f in ft_init_av_dst_addr common/shared.c:1439
    20 0x55dabb292a3f in ft_init_av common/shared.c:1364
    21 0x55dabb2910c0 in ft_init_fabric common/shared.c:1194
    22 0x55dabb287989 in run functional/rdm_atomic.c:424
    23 0x55dabb288480 in main functional/rdm_atomic.c:508
    24 0x7f8247cc1d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

For this test, the EQ is destroyed before the domain. As a consequence, it causes all the domains that are listed in eq->domain_list to leak after the EQ is destroyed.