### PR TITLE
prov/efa: Implement start_msg and start_tag in peer API

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_srx.c
+++ b/prov/efa/src/rdm/efa_rdm_srx.c
@@ -33,6 +33,7 @@
 
 #include "efa.h"
 #include "efa_rdm_srx.h"
+#include "rxr_msg.h"
 
 /**
  * @brief This call is invoked by the peer provider to obtain a
@@ -112,7 +113,11 @@ static void efa_rdm_srx_free_entry(struct fi_peer_rx_entry *peer_rx_entry)
  */
 static int efa_rdm_srx_start_msg(struct fi_peer_rx_entry *peer_rx_entry)
 {
-    return -FI_ENOSYS;
+	struct rxr_op_entry *rx_op_entry;
+
+	rx_op_entry = container_of(peer_rx_entry, struct rxr_op_entry, peer_rx_entry);
+
+	return rxr_pkt_proc_matched_rtm(rx_op_entry->ep, rx_op_entry, peer_rx_entry->owner_context);
 }
 
 /**
@@ -124,7 +129,11 @@ static int efa_rdm_srx_start_msg(struct fi_peer_rx_entry *peer_rx_entry)
  */
 static int efa_rdm_srx_start_tag(struct fi_peer_rx_entry *peer_rx_entry)
 {
-    return -FI_ENOSYS;
+	struct rxr_op_entry *rx_op_entry;
+
+	rx_op_entry = container_of(peer_rx_entry, struct rxr_op_entry, peer_rx_entry);
+
+	return rxr_pkt_proc_matched_rtm(rx_op_entry->ep, rx_op_entry, peer_rx_entry->owner_context);
 }
 
 /**

--- a/prov/efa/src/rdm/rxr_ep.c
+++ b/prov/efa/src/rdm/rxr_ep.c
@@ -168,6 +168,14 @@ struct rxr_op_entry *rxr_ep_alloc_rx_entry(struct rxr_ep *ep, fi_addr_t addr, ui
 	rx_entry->efa_outstanding_tx_ops = 0;
 	rx_entry->shm_outstanding_tx_ops = 0;
 	rx_entry->op = op;
+
+	rx_entry->peer_rx_entry.addr = addr;
+	/* This field points to the fid_peer_srx struct that's part of the peer API
+	*  We always set it to the EFA provider's SRX here. For SHM messages, we will set
+	*  this to SHM provider's SRX in the get_msg/get_tag function call
+	*/
+	rx_entry->peer_rx_entry.srx = &ep->peer_srx;
+
 	dlist_init(&rx_entry->entry);
 	switch (op) {
 	case ofi_op_tagged:


### PR DESCRIPTION
This commit implements the peer ops of the peer API and uses them internally for the EFA provider

The discard_msg and discard_tag ops are not implemented because they are not called by external applications and are not used by the EFA provider