### PR TITLE
prov/ucx: Fix a typo in the configure script

### DIFF
--- a/prov/ucx/configure.m4
+++ b/prov/ucx/configure.m4
@@ -19,7 +19,7 @@ AC_DEFUN([FI_UCX_CONFIGURE],[
                     [$ucx_PREFIX],
                     [$ucx_LIBDIR],
                     [ucx_happy=1],
-                    [ucx_happy=0]),
+                    [ucx_happy=0])
 	       AC_CHECK_DECLS([UCP_WORKER_FLAG_IGNORE_REQUEST_LEAK],
 		    [],
 		    [],


### PR DESCRIPTION
There was an unwanted comma that led to the follwoing error message:

`configure: line xxxx: ,: command not found`