### PR TITLE
prov/tcp: Complete the io_uring implementation (poll_add + polling without poll/epoll overhead)

### DIFF
--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -533,6 +533,7 @@ struct ofi_bsock {
 	struct ofi_sockapi *sockapi;
 	struct ofi_sockctx tx_sockctx;
 	struct ofi_sockctx rx_sockctx;
+	struct ofi_sockctx pollin_sockctx;
 	struct ofi_byteq sq;
 	struct ofi_byteq rq;
 	size_t zerocopy_size;
@@ -549,6 +550,7 @@ ofi_bsock_init(struct ofi_bsock *bsock, struct ofi_sockapi *sockapi,
 	bsock->sockapi = sockapi;
 	ofi_sockctx_init(&bsock->tx_sockctx, context);
 	ofi_sockctx_init(&bsock->rx_sockctx, context);
+	ofi_sockctx_init(&bsock->pollin_sockctx, context);
 	ofi_byteq_init(&bsock->sq, sbuf_size);
 	ofi_byteq_init(&bsock->rq, rbuf_size);
 	bsock->zerocopy_size = SIZE_MAX;

--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -521,7 +521,6 @@ struct ofi_bsock {
 	struct ofi_sockapi *sockapi;
 	struct ofi_sockctx tx_sockctx;
 	struct ofi_sockctx rx_sockctx;
-	struct ofi_sockctx cancel_sockctx;
 	struct ofi_byteq sq;
 	struct ofi_byteq rq;
 	size_t zerocopy_size;
@@ -538,7 +537,6 @@ ofi_bsock_init(struct ofi_bsock *bsock, struct ofi_sockapi *sockapi,
 	bsock->sockapi = sockapi;
 	ofi_sockctx_init(&bsock->tx_sockctx, context);
 	ofi_sockctx_init(&bsock->rx_sockctx, context);
-	ofi_sockctx_init(&bsock->cancel_sockctx, context);
 	ofi_byteq_init(&bsock->sq, sbuf_size);
 	ofi_byteq_init(&bsock->rq, rbuf_size);
 	bsock->zerocopy_size = SIZE_MAX;

--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -318,6 +318,10 @@ int ofi_sockctx_uring_cancel(struct ofi_sockapi_uring *uring,
 			     struct ofi_sockctx *canceled_ctx,
 			     struct ofi_sockctx *ctx);
 
+int ofi_sockctx_uring_poll_add(struct ofi_sockapi_uring *uring,
+			       int fd, short poll_mask, bool multishot,
+			       struct ofi_sockctx *ctx);
+
 int ofi_uring_init(ofi_io_uring_t *io_uring, size_t entries);
 int ofi_uring_destroy(ofi_io_uring_t *io_uring);
 
@@ -409,6 +413,14 @@ static inline int
 ofi_sockctx_uring_cancel(struct ofi_sockapi_uring *uring,
 			 struct ofi_sockctx *canceled_ctx,
 			 struct ofi_sockctx *ctx)
+{
+	return -FI_ENOSYS;
+}
+
+static inline int
+ofi_sockctx_uring_poll_add(struct ofi_sockapi_uring *uring,
+			   int fd, short poll_mask, bool multishot,
+			   struct ofi_sockctx *ctx)
 {
 	return -FI_ENOSYS;
 }

--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -362,6 +362,8 @@ static inline void ofi_uring_cq_advance(ofi_io_uring_t *io_uring, unsigned int c
 	io_uring_cq_advance(io_uring, count);
 }
 #else
+#define IORING_CQE_F_MORE	(1U << 1)
+
 static inline int
 ofi_sockapi_connect_uring(struct ofi_sockapi *sockapi, SOCKET sock,
 			  const struct sockaddr *addr, socklen_t addrlen,

--- a/prov/tcp/src/xnet.h
+++ b/prov/tcp/src/xnet.h
@@ -355,6 +355,9 @@ int xnet_uring_cancel(struct xnet_progress *progress,
 		      struct xnet_uring *uring,
 		      struct ofi_sockctx *canceled_ctx,
 		      void *context);
+int xnet_uring_pollin_add(struct xnet_progress *progress,
+			  int fd, bool multishot,
+			  struct ofi_sockctx *pollin_ctx);
 
 static inline int xnet_progress_locked(struct xnet_progress *progress)
 {

--- a/prov/tcp/src/xnet.h
+++ b/prov/tcp/src/xnet.h
@@ -354,7 +354,7 @@ void xnet_halt_sock(struct xnet_progress *progress, SOCKET sock);
 int xnet_uring_cancel(struct xnet_progress *progress,
 		      struct xnet_uring *uring,
 		      struct ofi_sockctx *canceled_ctx,
-		      struct ofi_sockctx *ctx);
+		      void *context);
 
 static inline int xnet_progress_locked(struct xnet_progress *progress)
 {

--- a/prov/tcp/src/xnet.h
+++ b/prov/tcp/src/xnet.h
@@ -136,6 +136,7 @@ struct xnet_pep {
 	struct xnet_progress	*progress;
 	SOCKET			sock;
 	enum xnet_state		state;
+	struct ofi_sockctx	pollin_sockctx;
 };
 
 int xnet_listen(struct xnet_pep *pep, struct xnet_progress *progress);

--- a/prov/tcp/src/xnet_cm.c
+++ b/prov/tcp/src/xnet_cm.c
@@ -235,8 +235,8 @@ void xnet_uring_req_done(struct xnet_ep *ep, int res)
 	}
 
 	ep->pollflags = POLLIN;
-	ret = xnet_monitor_sock(xnet_ep2_progress(ep), ep->bsock.sock, ep->pollflags,
-			        &ep->util_ep.ep_fid.fid);
+	ret = xnet_uring_pollin_add(xnet_ep2_progress(ep), ep->bsock.sock,
+				    false, &ep->bsock.pollin_sockctx);
 	if (ret)
 		goto disable;
 

--- a/prov/tcp/src/xnet_ep.c
+++ b/prov/tcp/src/xnet_ep.c
@@ -340,13 +340,13 @@ static void xnet_ep_flush_all_queues(struct xnet_ep *ep)
 
 	ret = xnet_uring_cancel(progress, &progress->tx_uring,
 				&ep->bsock.tx_sockctx,
-				&ep->bsock.cancel_sockctx);
+				&ep->util_ep.ep_fid);
 	if (ret)
 		FI_WARN(&xnet_prov, FI_LOG_EP_DATA, "Failed to cancel TX uring\n");
 
 	ret = xnet_uring_cancel(progress, &progress->rx_uring,
 				&ep->bsock.rx_sockctx,
-				&ep->bsock.cancel_sockctx);
+				&ep->util_ep.ep_fid);
 	if (ret)
 		FI_WARN(&xnet_prov, FI_LOG_EP_DATA, "Failed to cancel RX uring\n");
 
@@ -548,8 +548,7 @@ static int xnet_ep_close(struct fid *fid)
 	ofi_genlock_unlock(&progress->lock);
 
 	if (ep->bsock.tx_sockctx.uring_sqe_inuse ||
-	    ep->bsock.rx_sockctx.uring_sqe_inuse ||
-	    ep->bsock.cancel_sockctx.uring_sqe_inuse)
+	    ep->bsock.rx_sockctx.uring_sqe_inuse)
 	    return -FI_EBUSY;
 
 	free(ep->cm_msg);

--- a/prov/tcp/src/xnet_pep.c
+++ b/prov/tcp/src/xnet_pep.c
@@ -44,6 +44,7 @@
 static int xnet_pep_close(struct fid *fid)
 {
 	struct xnet_pep *pep;
+	int ret;
 
 	pep = container_of(fid, struct xnet_pep, util_pep.pep_fid.fid);
 	/* TODO: We need to abort any outstanding active connection requests.
@@ -53,8 +54,18 @@ static int xnet_pep_close(struct fid *fid)
 
 	if (pep->state == XNET_LISTENING) {
 		ofi_genlock_lock(&pep->progress->lock);
-		xnet_halt_sock(pep->progress, pep->sock);
+		if (xnet_io_uring) {
+			ret = xnet_uring_cancel(pep->progress,
+						&pep->progress->rx_uring,
+						&pep->pollin_sockctx,
+						&pep->util_pep.pep_fid);
+		} else {
+			xnet_halt_sock(pep->progress, pep->sock);
+			ret = 0;
+		}
 		ofi_genlock_unlock(&pep->progress->lock);
+		if (ret)
+			return ret;
 	}
 
 	ofi_close_socket(pep->sock);
@@ -241,8 +252,14 @@ int xnet_listen(struct xnet_pep *pep, struct xnet_progress *progress)
 	}
 
 	ofi_genlock_lock(&progress->lock);
-	ret = xnet_monitor_sock(progress, pep->sock, POLLIN,
-				&pep->util_pep.pep_fid.fid);
+	if (xnet_io_uring) {
+		ret = xnet_uring_pollin_add(progress, pep->sock, true,
+					    &pep->pollin_sockctx);
+	} else {
+		ret = xnet_monitor_sock(progress, pep->sock, POLLIN,
+					&pep->util_pep.pep_fid.fid);
+	}
+
 	if (!ret) {
 		pep->progress = progress;
 		pep->state = XNET_LISTENING;
@@ -365,6 +382,7 @@ int xnet_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 	pep->util_pep.pep_fid.fid.ops = &xnet_pep_fi_ops;
 	pep->util_pep.pep_fid.cm = &xnet_pep_cm_ops;
 	pep->util_pep.pep_fid.ops = &xnet_pep_ops;
+	ofi_sockctx_init(&pep->pollin_sockctx, &pep->util_pep.pep_fid);
 
 	pep->info = fi_dupinfo(info);
 	if (!pep->info) {

--- a/prov/tcp/src/xnet_progress.c
+++ b/prov/tcp/src/xnet_progress.c
@@ -1449,6 +1449,7 @@ int xnet_monitor_sock(struct xnet_progress *progress, SOCKET sock,
 {
 	int ret;
 
+	assert(!xnet_io_uring);
 	assert(xnet_progress_locked(progress));
 	ret = ofi_dynpoll_add(&progress->epoll_fd, sock, events, fid);
 	if (ret) {
@@ -1463,6 +1464,7 @@ void xnet_halt_sock(struct xnet_progress *progress, SOCKET sock)
 {
 	int ret;
 
+	assert(!xnet_io_uring);
 	assert(xnet_progress_locked(progress));
 	ret = ofi_dynpoll_del(&progress->epoll_fd, sock);
 	if (ret && ret != -FI_ENOENT) {

--- a/prov/tcp/src/xnet_progress.c
+++ b/prov/tcp/src/xnet_progress.c
@@ -407,7 +407,10 @@ static void xnet_progress_tx(struct xnet_ep *ep)
 	/* Buffered data is sent first by xnet_send_msg, but if we don't
 	 * have other data to send, we need to try flushing any buffered data.
 	 */
-	(void) ofi_bsock_flush(&ep->bsock);
+	ret = ofi_bsock_flush(&ep->bsock);
+	if (ret == -OFI_EINPROGRESS_URING)
+		return;
+
 	ret = xnet_update_pollflag(ep, POLLOUT, ofi_bsock_tosend(&ep->bsock));
 	if (!ret)
 		return;

--- a/prov/tcp/src/xnet_progress.c
+++ b/prov/tcp/src/xnet_progress.c
@@ -1130,6 +1130,9 @@ int xnet_uring_cancel(struct xnet_progress *progress,
 	int ret;
 
 	assert(xnet_progress_locked(progress));
+	if (!xnet_io_uring)
+		return 0;
+
 	ofi_sockctx_init(&ctx, context);
 	while (canceled_ctx->uring_sqe_inuse || ctx.uring_sqe_inuse) {
 		assert(xnet_io_uring);
@@ -1146,6 +1149,8 @@ int xnet_uring_cancel(struct xnet_progress *progress,
 
 		xnet_progress_uring(progress, uring);
 	}
+
+	xnet_submit_uring(uring);
 	return 0;
 }
 

--- a/src/iouring.c
+++ b/src/iouring.c
@@ -50,7 +50,7 @@ int ofi_sockapi_connect_uring(struct ofi_sockapi *sockapi, SOCKET sock,
 
 	sqe = io_uring_get_sqe(uring->io_uring);
 	if (!sqe)
-	return -FI_EOVERFLOW;
+		return -FI_EOVERFLOW;
 
 	io_uring_prep_connect(sqe, sock, addr, addrlen);
 	io_uring_sqe_set_data(sqe, ctx);
@@ -72,7 +72,7 @@ int ofi_sockapi_accept_uring(struct ofi_sockapi *sockapi, SOCKET sock,
 
 	sqe = io_uring_get_sqe(uring->io_uring);
 	if (!sqe)
-	return -FI_EOVERFLOW;
+		return -FI_EOVERFLOW;
 
 	io_uring_prep_accept(sqe, sock, addr, addrlen, 0);
 	io_uring_sqe_set_data(sqe, ctx);


### PR DESCRIPTION
This PR is hopefully the last set of major io_uring changes for the TCP provider.
It moves all the poll/epoll operations to io_uring, which allows for progressing outstanding io_uring operations without the extra overhead of epoll()/poll().
As a side-effect it also fixes the issue #6745, which was the real trigger for the entire io_uring work. The circle is now complete :)