### PR TITLE
fabtests/pytest/efa: execute lsmod in interactive shell

### DIFF
--- a/fabtests/pytest/efa/efa_common.py
+++ b/fabtests/pytest/efa/efa_common.py
@@ -58,7 +58,7 @@ def has_gdrcopy(hostname):
     hostname: a host
     return: a boolean
     """
-    command = "ssh {} lsmod | grep gdrdrv".format(hostname)
+    command = "ssh {} /bin/bash --login -c lsmod | grep gdrdrv".format(hostname)
     process = subprocess.run(command, shell=True, check=False, stdout=subprocess.PIPE)
     return process.returncode == 0
 


### PR DESCRIPTION
This is a follow up bugfix to PR8628. On RHEL7 lsmod is not on the default ssh PATH. For portability, execute the command in interactive shell.

Need to backport to v1.17.x.