### PR TITLE
[v1.17.x] fabtests/pytest/efa: execute lsmod in interactive shell

### DIFF
--- a/fabtests/pytest/efa/efa_common.py
+++ b/fabtests/pytest/efa/efa_common.py
@@ -51,7 +51,7 @@ def has_gdrcopy(hostname):
     hostname: a host
     return: a boolean
     """
-    command = "ssh {} lsmod | grep gdrdrv".format(hostname)
+    command = "ssh {} /bin/bash --login -c lsmod | grep gdrdrv".format(hostname)
     process = subprocess.run(command, shell=True, check=False, stdout=subprocess.PIPE)
     return process.returncode == 0
 


### PR DESCRIPTION
Backport https://github.com/ofiwg/libfabric/commit/54c90d50d067c4aa5802bbfb7945a393ee05d4aa to v1.17.x