### PR TITLE
prov/efa: Implement owner_ops in peer API.

### DIFF
--- a/prov/efa/src/rdm/rxr_msg.c
+++ b/prov/efa/src/rdm/rxr_msg.c
@@ -651,10 +651,25 @@ struct rxr_op_entry *rxr_msg_alloc_rx_entry(struct rxr_ep *ep,
 	return rx_entry;
 }
 
+/**
+ * @brief Queue an unexp rx entry to unexp msg queues
+ *
+ * @param ep rxr_ep
+ * @param unexp_rx_entry the unexp rx entry to be queued
+ */
+void rxr_msg_queue_unexp_rx_entry_for_msgrtm(struct rxr_ep *ep,
+					      struct rxr_op_entry *unexp_rx_entry)
+{
+	struct efa_rdm_peer *peer;
+
+	dlist_insert_tail(&unexp_rx_entry->entry, &ep->rx_unexp_list);
+	peer = rxr_ep_get_peer(ep, unexp_rx_entry->addr);
+	dlist_insert_tail(&unexp_rx_entry->peer_unexp_entry, &peer->rx_unexp_list);
+}
+
 struct rxr_op_entry *rxr_msg_alloc_unexp_rx_entry_for_msgrtm(struct rxr_ep *ep,
 							     struct rxr_pkt_entry **pkt_entry_ptr)
 {
-	struct efa_rdm_peer *peer;
 	struct rxr_op_entry *rx_entry;
 	struct rxr_pkt_entry *unexp_pkt_entry;
 
@@ -672,16 +687,28 @@ struct rxr_op_entry *rxr_msg_alloc_unexp_rx_entry_for_msgrtm(struct rxr_ep *ep,
 	rx_entry->state = RXR_RX_UNEXP;
 	rx_entry->unexp_pkt = unexp_pkt_entry;
 	rxr_pkt_rtm_update_rx_entry(unexp_pkt_entry, rx_entry);
-	dlist_insert_tail(&rx_entry->entry, &ep->rx_unexp_list);
-	peer = rxr_ep_get_peer(ep, unexp_pkt_entry->addr);
-	dlist_insert_tail(&rx_entry->peer_unexp_entry, &peer->rx_unexp_list);
 	return rx_entry;
+}
+
+/**
+ * @brief Queue an unexp rx entry to unexp tag queues
+ *
+ * @param ep rxr_ep
+ * @param unexp_rx_entry the unexp rx entry to be queued
+ */
+void rxr_msg_queue_unexp_rx_entry_for_tagrtm(struct rxr_ep *ep,
+					      struct rxr_op_entry *unexp_rx_entry)
+{
+	struct efa_rdm_peer *peer;
+
+	dlist_insert_tail(&unexp_rx_entry->entry, &ep->rx_unexp_tagged_list);
+	peer = rxr_ep_get_peer(ep, unexp_rx_entry->addr);
+	dlist_insert_tail(&unexp_rx_entry->peer_unexp_entry, &peer->rx_unexp_tagged_list);
 }
 
 struct rxr_op_entry *rxr_msg_alloc_unexp_rx_entry_for_tagrtm(struct rxr_ep *ep,
 							     struct rxr_pkt_entry **pkt_entry_ptr)
 {
-	struct efa_rdm_peer *peer;
 	struct rxr_op_entry *rx_entry;
 	struct rxr_pkt_entry *unexp_pkt_entry;
 
@@ -700,9 +727,6 @@ struct rxr_op_entry *rxr_msg_alloc_unexp_rx_entry_for_tagrtm(struct rxr_ep *ep,
 	rx_entry->state = RXR_RX_UNEXP;
 	rx_entry->unexp_pkt = unexp_pkt_entry;
 	rxr_pkt_rtm_update_rx_entry(unexp_pkt_entry, rx_entry);
-	dlist_insert_tail(&rx_entry->entry, &ep->rx_unexp_tagged_list);
-	peer = rxr_ep_get_peer(ep, unexp_pkt_entry->addr);
-	dlist_insert_tail(&rx_entry->peer_unexp_entry, &peer->rx_unexp_tagged_list);
 	return rx_entry;
 }
 

--- a/prov/efa/src/rdm/rxr_msg.h
+++ b/prov/efa/src/rdm/rxr_msg.h
@@ -71,6 +71,12 @@ struct rxr_op_entry *rxr_msg_alloc_unexp_rx_entry_for_msgrtm(struct rxr_ep *ep,
 struct rxr_op_entry *rxr_msg_alloc_unexp_rx_entry_for_tagrtm(struct rxr_ep *ep,
 							     struct rxr_pkt_entry **pkt_entry);
 
+void rxr_msg_queue_unexp_rx_entry_for_msgrtm(struct rxr_ep *ep,
+					     struct rxr_op_entry *unexp_rx_entry);
+
+void rxr_msg_queue_unexp_rx_entry_for_tagrtm(struct rxr_ep *ep,
+					     struct rxr_op_entry *unexp_rx_entry);
+
 struct rxr_op_entry *rxr_msg_split_rx_entry(struct rxr_ep *ep,
 					    struct rxr_op_entry *posted_entry,
 					    struct rxr_op_entry *consumer_entry,

--- a/prov/efa/src/rdm/rxr_pkt_entry.c
+++ b/prov/efa/src/rdm/rxr_pkt_entry.c
@@ -179,6 +179,9 @@ void rxr_pkt_entry_release_rx(struct rxr_ep *ep,
 {
 	assert(pkt_entry->next == NULL);
 
+	if (pkt_entry->alloc_type == RXR_PKT_FROM_PEER_SRX)
+		return;
+
 	if (ep->use_zcpy_rx && pkt_entry->alloc_type == RXR_PKT_FROM_USER_BUFFER)
 		return;
 
@@ -229,7 +232,7 @@ void rxr_pkt_entry_copy(struct rxr_ep *ep,
  * Packets from the EFA RX pool will be copied into a separate buffer not
  * registered with the device (if this option is enabled) so that we can repost
  * the registered buffer again to keep the EFA RX queue full. Packets from the
- * SHM RX pool will also be copied to reuse the unexpected message pool.
+ * SHM RX pool and peer srx ops will also be copied to reuse the unexpected message pool.
  *
  * @param[in]     ep  the end point
  * @param[in,out] pkt_entry_ptr unexpected packet, if this packet is copied to
@@ -247,7 +250,8 @@ struct rxr_pkt_entry *rxr_pkt_get_unexp(struct rxr_ep *ep,
 	type = (*pkt_entry_ptr)->alloc_type;
 
 	if (rxr_env.rx_copy_unexp && (type == RXR_PKT_FROM_EFA_RX_POOL ||
-				      type == RXR_PKT_FROM_SHM_RX_POOL)) {
+				      type == RXR_PKT_FROM_SHM_RX_POOL ||
+				      type == RXR_PKT_FROM_PEER_SRX)) {
 		unexp_pkt_entry = rxr_pkt_entry_clone(ep, ep->rx_unexp_pkt_pool,
 						      RXR_PKT_FROM_UNEXP_POOL,
 						      *pkt_entry_ptr);

--- a/prov/efa/src/rdm/rxr_pkt_entry.h
+++ b/prov/efa/src/rdm/rxr_pkt_entry.h
@@ -52,9 +52,10 @@ enum rxr_pkt_entry_alloc_type {
 	RXR_PKT_FROM_SHM_TX_POOL,     /**< packet is allocated from `ep->shm_tx_pkt_pool` */
 	RXR_PKT_FROM_SHM_RX_POOL,     /**< packet is allocated from `ep->shm_rx_pkt_pool` */
 	RXR_PKT_FROM_UNEXP_POOL,      /**< packet is allocated from `ep->rx_unexp_pkt_pool` */
-	RXR_PKT_FROM_OOO_POOL,	      /**< packet is allocated from e`p->rx_ooo_pkt_pool` */
+	RXR_PKT_FROM_OOO_POOL,	      /**< packet is allocated from `ep->rx_ooo_pkt_pool` */
 	RXR_PKT_FROM_USER_BUFFER,     /**< packet is from user provided buffer` */
 	RXR_PKT_FROM_READ_COPY_POOL,  /**< packet is allocated from `ep->rx_readcopy_pkt_pool` */
+	RXR_PKT_FROM_PEER_SRX,    /**< packet is created in flight from peer SRX ops */
 };
 
 struct rxr_pkt_sendv {
@@ -270,6 +271,9 @@ void rxr_pkt_entry_release_tx(struct rxr_ep *ep,
 
 void rxr_pkt_entry_release_rx(struct rxr_ep *ep,
 			      struct rxr_pkt_entry *pkt_entry);
+
+void rxr_pkt_entry_release(struct rxr_ep *ep,
+			   struct rxr_pkt_entry *pkt_entry);
 
 void rxr_pkt_entry_append(struct rxr_pkt_entry *dst,
 			  struct rxr_pkt_entry *src);

--- a/prov/efa/src/rdm/rxr_pkt_type_req.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_req.c
@@ -1121,7 +1121,6 @@ int rxr_pkt_rtm_match_trecv(struct dlist_entry *item, const void *arg)
 	       ofi_match_tag(rx_entry->cq_entry.tag, rx_entry->ignore, match_tag);
 }
 
-static
 struct rxr_op_entry *rxr_pkt_get_msgrtm_rx_entry(struct rxr_ep *ep,
 						 struct rxr_pkt_entry **pkt_entry_ptr)
 {
@@ -1178,7 +1177,6 @@ struct rxr_op_entry *rxr_pkt_get_msgrtm_rx_entry(struct rxr_ep *ep,
 	return rx_entry;
 }
 
-static
 struct rxr_op_entry *rxr_pkt_get_tagrtm_rx_entry(struct rxr_ep *ep,
 						 struct rxr_pkt_entry **pkt_entry_ptr)
 {
@@ -1478,6 +1476,8 @@ ssize_t rxr_pkt_proc_msgrtm(struct rxr_ep *ep,
 			rxr_rx_entry_release(rx_entry);
 			return err;
 		}
+	} else if (rx_entry->state == RXR_RX_UNEXP) {
+		rxr_msg_queue_unexp_rx_entry_for_msgrtm(ep, rx_entry);
 	}
 
 	return 0;
@@ -1504,6 +1504,8 @@ ssize_t rxr_pkt_proc_tagrtm(struct rxr_ep *ep,
 			rxr_rx_entry_release(rx_entry);
 			return err;
 		}
+	} else if (rx_entry->state == RXR_RX_UNEXP) {
+		rxr_msg_queue_unexp_rx_entry_for_tagrtm(ep, rx_entry);
 	}
 
 	return 0;

--- a/prov/efa/src/rdm/rxr_pkt_type_req.h
+++ b/prov/efa/src/rdm/rxr_pkt_type_req.h
@@ -431,4 +431,9 @@ int rxr_pkt_proc_compare_rta(struct rxr_ep *ep,
 
 void rxr_pkt_handle_rta_recv(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
 
+struct rxr_op_entry *rxr_pkt_get_msgrtm_rx_entry(struct rxr_ep *ep,
+						 struct rxr_pkt_entry **pkt_entry_ptr);
+
+struct rxr_op_entry *rxr_pkt_get_tagrtm_rx_entry(struct rxr_ep *ep,
+						 struct rxr_pkt_entry **pkt_entry_ptr);
 #endif


### PR DESCRIPTION
Implement all the functions in efa_rdm_srx_owner_ops. Also refactor the code in rxr_pkt_proc_msgrtm() and rxr_pkt_proc_tagrtm() so they can be reused by efa_rdm_srx_owner_ops.