### PR TITLE
[v1.17.x]  prov/tcp: Suspicion of bug where RX entry is freed twice

### DIFF
--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -368,7 +368,6 @@ static ssize_t tcpx_process_remote_read(struct tcpx_ep *ep)
 		ep->report_success(ep, &cq->util_cq, rx_entry);
 	}
 
-	slist_remove_head(&rx_entry->ep->rma_read_queue);
 	tcpx_free_xfer(cq, rx_entry);
 	tcpx_reset_rx(ep);
 	return ret;
@@ -621,13 +620,12 @@ static ssize_t tcpx_op_write(struct tcpx_ep *ep)
 static ssize_t tcpx_op_read_rsp(struct tcpx_ep *ep)
 {
 	struct tcpx_xfer_entry *rx_entry;
-	struct slist_entry *entry;
 
 	if (slist_empty(&ep->rma_read_queue))
 		return -FI_EINVAL;
 
-	entry = ep->rma_read_queue.head;
-	rx_entry = container_of(entry, struct tcpx_xfer_entry, entry);
+	rx_entry = container_of(slist_remove_head(&ep->rma_read_queue),
+				struct tcpx_xfer_entry, entry);
 
 	memcpy(&rx_entry->hdr, &ep->cur_rx.hdr,
 	       (size_t) ep->cur_rx.hdr.base_hdr.hdr_size);


### PR DESCRIPTION
I am chasing a bug where the following assertion failure triggers:
./include/ofi_mem.h:402: ofi_buf_free: Assertion `ofi_atomic_dec32(&ofi_buf_region(buf)->use_cnt) >= 0' failed.

Here is the corresponding callstack when the assertion failure happens:
0x7ffff64aca7c  pthread_kill  [/lib/x86_64-linux-gnu/libc.so.6, 0x7ffff6416000]
0x7ffff6458476  raise  [/lib/x86_64-linux-gnu/libc.so.6, 0x7ffff6416000]
0x7ffff643e7f3  abort  [/lib/x86_64-linux-gnu/libc.so.6, 0x7ffff6416000]
0x7ffff643e71b  *unknown*  [/lib/x86_64-linux-gnu/libc.so.6, 0x7ffff6416000]
0x7ffff644fe96  __assert_fail  [/lib/x86_64-linux-gnu/libc.so.6, 0x7ffff6416000]
0x7ffff74c78b3  tcpx_ep_flush_queue  [xxx.so, 0x7ffff686c000]
0x7ffff74c850b  tcpx_ep_flush_all_queues  [xxx.so, 0x7ffff686c000]
0x7ffff74c86bb  tcpx_ep_disable  [/xxx.so, 0x7ffff686c000]
0x7ffff74cbe00  tcpx_progress  [/xxx.so, 0x7ffff686c000]
0x7ffff74cbf78  tcpx_cq_progress  [/xxx.so, 0x7ffff686c000]
0x7ffff74e1946  ofi_cq_readfrom  [/xxx.so, 0x7ffff686c000]

Before the assertion failure, I see several error messages in the logs:
warn tcpx_cq_report_error:202 internal transfer failed (Operation canceled)
OR
warn tcpx_progress_tx:121 msg send failed

It only happens on a system I don't have access to and symbols are
unfortunately not resolved. I have reviewed the code and found a code
path where the same RX entry can be freed twice.

When tcpx_op_read_rsp() is executed, ep->cur_rx.entry is set to the head
element of the list 'rma_read_queue'. The RX entry is effectively
removed from the list only after the operation completes. This pattern
becomes problematic if the EP is disabled before the RX completes (i.e.,
EP disabled because of a failing TX entry or an explicit shutdown).
In this case, tcpx_ep_flush_all_queues would complete the same RX entry
twice: once rma_read_queue is flushed (the RX entry is still listed here)
and another time in the block for the condition "if (ep->cur_rx.entry)".

The patch removes the RX entry from rma_read_queue before it gets
assigned to ep->cur_rx.entry. It guarantees that the RX entry will
be completed only once if the EP is disabled.

NOTE: I was not able to verify the patch on the system where libfabric
is failing. The patch was written based on my personal understanding of
the code.

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>