### PR TITLE
prov/efa: exchange rxr endpoint host id information during handshake

### DIFF
--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -1009,6 +1009,7 @@
     <ClInclude Include="prov\efa\src\efa_base_ep.h" />
     <ClInclude Include="prov\efa\src\dgram\efa_dgram.h" />
     <ClInclude Include="prov\efa\src\rdm\rxr_pkt_type_base.h" />
+    <ClInclude Include="prov\efa\src\rdm\rxr_pkt_type_misc.h" />
     <ClInclude Include="prov\efa\src\rdm\rxr.h" />
     <ClInclude Include="prov\efa\src\rdm\rxr_atomic.h" />
     <ClInclude Include="prov\efa\src\rdm\rxr_cntr.h" />

--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -101,6 +101,7 @@ _efa_headers = \
 	prov/efa/src/rdm/rxr_pkt_type.h \
 	prov/efa/src/rdm/rxr_pkt_type_req.h \
 	prov/efa/src/rdm/rxr_pkt_type_base.h \
+	prov/efa/src/rdm/rxr_pkt_type_misc.h \
 	prov/efa/src/rdm/rxr_pkt_cmd.h \
 	prov/efa/src/rdm/rxr_pkt_pool.h \
 	prov/efa/src/rdm/rxr_read.h \

--- a/prov/efa/docs/efa_rdm_protocol_v4.md
+++ b/prov/efa/docs/efa_rdm_protocol_v4.md
@@ -383,6 +383,7 @@ Table: 2.2 binary format of the HANDSHAKE packet
 | `extra_info`  | `8 * (nextra_p3 - 3)` | integer array | `uint64_t[]` |
 | `connid`  | 4 | integer | sender connection ID, optional, present when the CONNID_HDR flag is on `flags` |
 | `padding` | 4 | integer | padding for `connid`, optional, present when the CONNID_HDR flag is on `flags` |
+| `host_id` | 8 | integer | sender host id, optional, present when the HANDSHAKE_HOST_ID_HDR flag is on `flags` (table 2.3) |
 
 The first 4 bytes (3 fields: `type`, `version`, `flags`) is the EFA RDM base header (section 1.3).
 
@@ -429,6 +430,15 @@ to 8 bytes boundary.
 These two fields were introduced with the extra request "connid in header". They are optional,
 therefore an implemenation is not required to set them. (section 4.4 for more details) If an implementation
 does set the connid, the implementation needs to toggle on the CONNID_HDR flag in `flags` (table 1.4).
+
+`connid` and `padding` fields are followed by an optional `host_id` (8 bytes) which is the sender's host id.
+If `connid` and `padding` are not present, `host_id` will follow `extra_info`.
+
+Table: 2.3 A list of handshake packet flags
+
+| Bit Id | Value | Name | Meaning |
+|---|---|---|---|
+|  0     | 0x1    | `HANDSHAKE_HOST_ID_HDR` | This packet has the optional sender host id header |
 
 ### 2.2 Handshake subprotocol and raw address exchange
 

--- a/prov/efa/src/rdm/efa_rdm_peer.c
+++ b/prov/efa/src/rdm/efa_rdm_peer.c
@@ -48,6 +48,7 @@ void efa_rdm_peer_construct(struct efa_rdm_peer *peer, struct rxr_ep *ep, struct
 
 	peer->efa_fiaddr = conn->fi_addr;
 	peer->is_self = efa_is_same_addr(&ep->base_ep.src_addr, conn->ep_addr);
+	peer->host_id = peer->is_self ? ep->host_id : 0;	/* Peer host id is exchanged via handshake */
 	peer->num_read_msg_in_flight = 0;
 	peer->num_runt_bytes_in_flight = 0;
 	ofi_recvwin_buf_alloc(&peer->robuf, rxr_env.recvwin_size);

--- a/prov/efa/src/rdm/efa_rdm_peer.h
+++ b/prov/efa/src/rdm/efa_rdm_peer.h
@@ -57,6 +57,7 @@ struct efa_rdm_peer {
 	bool is_local;			/**< flag indicating wehther the peer is local (on the same instance) */
 	fi_addr_t efa_fiaddr;		/**< libfabric addr from efa provider's perspective */
 	fi_addr_t shm_fiaddr;		/**< libfabric addr from shm provider's perspective */
+	uint64_t host_id; 		/* Optional peer host id. Default 0 */
 	/**
 	 * @brief reorder buffer
 	 * 

--- a/prov/efa/src/rdm/rdm_proto_v4.h
+++ b/prov/efa/src/rdm/rdm_proto_v4.h
@@ -364,6 +364,9 @@ struct rxr_handshake_hdr {
 	uint64_t extra_info[0];
 };
 
+/* indicate this package has the sender host id */
+#define RXR_HANDSHAKE_HOST_ID_HDR	BIT_ULL(0)
+
 #if defined(static_assert) && defined(__x86_64__)
 static_assert(sizeof(struct rxr_handshake_hdr) == 8, "rxr_handshake_hdr check");
 #endif
@@ -373,8 +376,13 @@ struct rxr_handshake_opt_connid_hdr {
 	uint32_t padding; /* padding to 8 bytes boundary */
 };
 
+struct rxr_handshake_opt_host_id_hdr {
+	uint64_t host_id;
+};
+
 #if defined(static_assert) && defined(__x86_64__)
 static_assert(sizeof(struct rxr_handshake_opt_connid_hdr) == 8, "rxr_handshake_opt_connid_hdr check");
+static_assert(sizeof(struct rxr_handshake_opt_host_id_hdr) == 8, "rxr_handshake_opt_host_id_hdr check");
 #endif
 
 /* @brief header format of RECEIPT packet */

--- a/prov/efa/src/rdm/rxr_env.c
+++ b/prov/efa/src/rdm/rxr_env.c
@@ -68,8 +68,8 @@ struct rxr_env rxr_env = {
 	.efa_read_segment_size = 1073741824,
 	.efa_write_segment_size = 1073741824, /* need to confirm this constant. */
 	.rnr_retry = 3, /* Setting this value to EFA_RNR_INFINITE_RETRY makes the firmware retry indefinitey */
+	.host_id_file = "/sys/devices/virtual/dmi/id/board_asset_tag", /* Available on EC2 instances and containers */
 };
-
 
 /**
  * @brief Get default value of using device's RDMA

--- a/prov/efa/src/rdm/rxr_env.h
+++ b/prov/efa/src/rdm/rxr_env.h
@@ -81,6 +81,23 @@ struct rxr_env {
 	 *      EFA_RNR_INFINITY_RETRY (retry infinitely)
 	 */
 	int rnr_retry;
+	/**
+	 * The absolute path to a file that contains an EC2 instance id-like string.
+	 * If host_id_file is provided, the program will attempt to read the
+	 * 16 hex characters starting at the 4th character and convert it to an 8-byte
+	 * integer as the host id.
+	 *
+	 * 	Accept example:
+	 *		i-0f7c826e5f3bd8685	->	0xf7c826e5f3bd8685 is a valid hex string
+	 *
+	 * 	Illegal examples,
+	 *		quickfoxbrownfence	->	Not a hex string
+	 *		789e1cab			->	String is too short
+	 *
+	 * Host id parsing is best-effort. If the file does not exist, or the file
+	 * is malformatted, the program should proceed with a default host id, e.g. 0.
+	 */
+	char *host_id_file;
 };
 
 extern struct rxr_env rxr_env;

--- a/prov/efa/src/rdm/rxr_ep.c
+++ b/prov/efa/src/rdm/rxr_ep.c
@@ -304,7 +304,7 @@ int rxr_ep_post_internal_rx_pkt(struct rxr_ep *ep, uint64_t flags, enum rxr_lowe
 
 	rx_pkt_entry->x_entry = NULL;
 
-	msg_iov.iov_base = (void *)rxr_pkt_start(rx_pkt_entry);
+	msg_iov.iov_base = (void *)(rx_pkt_entry->wiredata);
 	msg_iov.iov_len = ep->mtu_size;
 
 	switch (lower_ep_type) {
@@ -2272,6 +2272,11 @@ int rxr_endpoint(struct fid_domain *domain, struct fi_info *info,
 	if (!rxr_ep->user_info) {
 		ret = -FI_ENOMEM;
 		goto err_free_ep;
+	}
+
+	rxr_ep->host_id = rxr_get_host_id(rxr_env.host_id_file);
+	if (rxr_ep->host_id) {
+		EFA_INFO(FI_LOG_EP_CTRL, "rxr_ep->host_id: i-%017lx\n", rxr_ep->host_id);
 	}
 
 	rxr_ep->rx_size = info->rx_attr->size;

--- a/prov/efa/src/rdm/rxr_pkt_entry.c
+++ b/prov/efa/src/rdm/rxr_pkt_entry.c
@@ -654,8 +654,7 @@ ssize_t rxr_pkt_entry_inject(struct rxr_ep *ep,
 	assert(peer);
 
 	assert(ep->use_shm_for_tx && peer->is_local);
-	ret = fi_inject(ep->shm_ep, rxr_pkt_start(pkt_entry), pkt_entry->pkt_size,
-			 peer->shm_fiaddr);
+	ret = fi_inject(ep->shm_ep, pkt_entry->wiredata, pkt_entry->pkt_size, peer->shm_fiaddr);
 
 	if (OFI_UNLIKELY(ret))
 		return ret;

--- a/prov/efa/src/rdm/rxr_pkt_entry.h
+++ b/prov/efa/src/rdm/rxr_pkt_entry.h
@@ -246,11 +246,6 @@ static_assert(sizeof(struct rxr_pkt_entry) == 128, "rxr_pkt_entry check");
 #endif
 #endif
 
-static inline void *rxr_pkt_start(struct rxr_pkt_entry *pkt_entry)
-{
-	return pkt_entry->wiredata;
-}
-
 struct rxr_ep;
 
 struct rxr_op_entry;

--- a/prov/efa/src/rdm/rxr_pkt_type.h
+++ b/prov/efa/src/rdm/rxr_pkt_type.h
@@ -67,6 +67,28 @@ struct rxr_handshake_opt_connid_hdr *rxr_get_handshake_opt_connid_hdr(void *pkt)
 	return (struct rxr_handshake_opt_connid_hdr *)((char *)pkt + base_hdr_size);
 }
 
+static inline
+struct rxr_handshake_opt_host_id_hdr *rxr_get_handshake_opt_host_id_hdr(void *pkt)
+{
+	struct rxr_handshake_hdr *handshake_hdr;
+	size_t offset = 0;
+
+	handshake_hdr = (struct rxr_handshake_hdr *)pkt;
+	assert(handshake_hdr->type == RXR_HANDSHAKE_PKT);
+
+	offset += sizeof(struct rxr_handshake_hdr) +
+					(handshake_hdr->nextra_p3 - 3) * sizeof(uint64_t);
+
+	assert(handshake_hdr->flags & RXR_HANDSHAKE_HOST_ID_HDR);
+
+	if (handshake_hdr->flags & RXR_PKT_CONNID_HDR) {
+		/* HOST_ID_HDR is always immediately after CONNID_HDR(if present) */
+		offset += sizeof(struct rxr_handshake_opt_connid_hdr);
+	}
+
+	return (struct rxr_handshake_opt_host_id_hdr *)((char *)pkt + offset);
+}
+
 ssize_t rxr_pkt_init_handshake(struct rxr_ep *ep,
 			       struct rxr_pkt_entry *pkt_entry,
 			       fi_addr_t addr);

--- a/prov/efa/src/rdm/rxr_pkt_type_misc.h
+++ b/prov/efa/src/rdm/rxr_pkt_type_misc.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _RXR_PKT_TYPE_MISC_H
+#define _RXR_PKT_TYPE_MISC_H
+
+#include "rxr.h"
+
+/**
+ * @brief Return a pointer to the optional host id header in a handshake packet
+ *
+ * @param[in]	pkt_entry	A packet entry
+ * @return	If the input has the optional host id header, return the pointer to
+ *	host id value; otherwise, return NULL
+ */
+static inline
+uint64_t *rxr_pkt_handshake_host_id_ptr(struct rxr_pkt_entry *pkt_entry)
+{
+	struct rxr_base_hdr *base_hdr = rxr_get_base_hdr(pkt_entry->wiredata);
+
+	if (base_hdr->type != RXR_HANDSHAKE_PKT || !(base_hdr->flags & RXR_HANDSHAKE_HOST_ID_HDR))
+		return NULL;
+
+	return &(rxr_get_handshake_opt_host_id_hdr(pkt_entry->wiredata)->host_id);
+}
+
+#endif

--- a/prov/efa/test/efa_unit_test_mocks.h
+++ b/prov/efa/test/efa_unit_test_mocks.h
@@ -24,6 +24,8 @@ int efa_mock_efadv_query_device_return_mock(struct ibv_context *ibvctx, struct e
 extern struct efa_mock_ibv_send_wr_list g_ibv_send_wr_list;
 int efa_mock_ibv_post_send_save_send_wr(struct ibv_qp *qp, struct ibv_send_wr *wr,
 					struct ibv_send_wr **bad_wr);
+int efa_mock_ibv_post_send_verify_handshake_pkt_local_host_id_and_save_wr(struct ibv_qp *qp, struct ibv_send_wr *wr,
+					struct ibv_send_wr **bad_wr);
 
 int efa_mock_ibv_start_poll_return_mock(struct ibv_cq_ex *ibvcqx,
 					struct ibv_poll_cq_attr *attr);
@@ -54,6 +56,8 @@ ssize_t efa_mock_ofi_copy_from_hmem_iov_inc_counter(void *dest, size_t size,
 
 struct efa_unit_test_mocks
 {
+	uint64_t local_host_id;
+	uint64_t peer_host_id;
 	struct ibv_ah *(*ibv_create_ah)(struct ibv_pd *pd, struct ibv_ah_attr *attr);
 
 	int (*efadv_query_device)(struct ibv_context *ibvctx, struct efadv_device_attr *attr,
@@ -86,6 +90,7 @@ struct ibv_cq_ex *__real_efadv_create_cq(struct ibv_context *ibvctx,
 uint32_t efa_mock_ibv_read_src_qp_return_mock(struct ibv_cq_ex *current);
 uint32_t efa_mock_ibv_read_byte_len_return_mock(struct ibv_cq_ex *current);
 uint32_t efa_mock_ibv_read_slid_return_mock(struct ibv_cq_ex *current);
+int efa_mock_efadv_wc_read_sgid_return_mock(struct efadv_cq *efadv_cq, union ibv_gid *sgid);
 int efa_mock_efadv_wc_read_sgid_return_zero_code_and_expect_next_poll_and_set_gid(struct efadv_cq *efadv_cq, union ibv_gid *sgid);
 int efa_mock_ibv_start_poll_expect_efadv_wc_read_ah_and_return_mock(struct ibv_cq_ex *ibvcqx,
 																	struct ibv_poll_cq_attr *attr);

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -14,6 +14,7 @@
 
 extern struct efa_mock_ibv_send_wr_list g_ibv_send_wr_list;
 extern struct efa_unit_test_mocks g_efa_unit_test_mocks;
+extern struct rxr_env rxr_env;
 
 struct efa_resource {
 	struct fi_info *hints;
@@ -32,6 +33,8 @@ void efa_unit_test_resource_construct(struct efa_resource *resource, enum fi_ep_
 
 void efa_unit_test_resource_destruct(struct efa_resource *resource);
 
+void new_temp_file(char *template, size_t len);
+
 struct efa_unit_test_buff {
 	uint8_t *buff;
 	size_t  size;
@@ -41,6 +44,11 @@ struct efa_unit_test_buff {
 struct efa_unit_test_eager_rtm_pkt_attr {
 	uint32_t msg_id;
 	uint32_t connid;
+};
+
+struct efa_unit_test_handshake_pkt_attr {
+	uint32_t connid;
+	uint64_t host_id;
 };
 
 int efa_device_construct(struct efa_device *efa_device,
@@ -53,11 +61,21 @@ void efa_unit_test_buff_destruct(struct efa_unit_test_buff *buff);
 
 void efa_unit_test_eager_msgrtm_pkt_construct(struct rxr_pkt_entry *pkt_entry, struct efa_unit_test_eager_rtm_pkt_attr *attr);
 
+void efa_unit_test_handshake_pkt_construct(struct rxr_pkt_entry *pkt_entry, struct efa_unit_test_handshake_pkt_attr *attr);
+
 /* test cases */
 void test_av_insert_duplicate_raw_addr();
 void test_av_insert_duplicate_gid();
 void test_efa_device_construct_error_handling();
-void test_rxr_endpoint_cq_create_error_handling();
+void test_rxr_ep_ignore_missing_host_id_file();
+void test_rxr_ep_has_valid_host_id();
+void test_rxr_ep_ignore_short_host_id();
+void test_rxr_ep_ignore_non_hex_host_id();
+void test_rxr_ep_handshake_receive_and_send_valid_host_ids_with_connid();
+void test_rxr_ep_handshake_receive_and_send_valid_host_ids_without_connid();
+void test_rxr_ep_handshake_receive_valid_peer_host_id_and_do_not_send_local_host_id();
+void test_rxr_ep_handshake_receive_without_peer_host_id_and_do_not_send_local_host_id();
+void test_rxr_ep_cq_create_error_handling();
 void test_rxr_ep_pkt_pool_flags();
 void test_rxr_ep_pkt_pool_page_alignment();
 void test_rxr_ep_dc_atomic_error_handling();


### PR DESCRIPTION
This change introduces a new optional handshake packet field hid(host id) enabled by the HID_HDR flag. The hid value is parsed from a host id file configured in rxr_env.

Notably, hid is optional and provided at best effort, which means:
- It is set to 0 by default.
- If the endpoint fails to parse hid, it will skip the error.
- hid is included in handshake if and only if it is non-zero.