### PR TITLE
prov/efa: set use_device_rdma with fi_setopt

### DIFF
--- a/include/rdma/fi_ext.h
+++ b/include/rdma/fi_ext.h
@@ -70,9 +70,10 @@ extern "C" {
 /* negative options are provider specific */
 enum {
        FI_OPT_EFA_RNR_RETRY = -FI_PROV_SPECIFIC_EFA,
-       FI_OPT_EFA_EMULATED_READ,       /* bool */
-       FI_OPT_EFA_EMULATED_WRITE,      /* bool */
-       FI_OPT_EFA_EMULATED_ATOMICS,    /* bool */
+       FI_OPT_EFA_EMULATED_READ,	/* bool */
+       FI_OPT_EFA_EMULATED_WRITE,	/* bool */
+       FI_OPT_EFA_EMULATED_ATOMICS,	/* bool */
+       FI_OPT_EFA_USE_DEVICE_RDMA,	/* bool */
 };
 
 struct fi_fid_export {

--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -899,6 +899,7 @@
     <ClCompile Include="prov\efa\src\rdm\efa_rdm_cq.c" />
     <ClCompile Include="prov\efa\src\rdm\efa_rdm_peer.c" />
     <ClCompile Include="prov\efa\src\rdm\efa_rdm_srx.c" />
+    <ClCompile Include="prov\efa\src\rdm\efa_rdm_util.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\fasthash.h" />
@@ -1022,6 +1023,7 @@
     <ClInclude Include="prov\efa\src\rdm\rxr_read.h" />
     <ClInclude Include="prov\efa\src\rdm\rxr_rma.h" />
     <ClInclude Include="prov\efa\src\rdm\efa_rdm_srx.h" />
+    <ClInclude Include="prov\efa\src\rdm\efa_rdm_util.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="libfabric.def" />

--- a/man/fi_efa.7.md
+++ b/man/fi_efa.7.md
@@ -103,6 +103,22 @@ provider for AWS Neuron or Habana SynapseAI.
   emulating Read, Write, and Atomic operations (return value is true), or if
   these operations are assisted by hardware support (return value is false).
 
+*FI_OPT_EFA_USE_DEVICE_RDMA - bool*
+: Only available if the application selects a libfabric API version >= 1.18.
+  This option allows an application to change libfabric's behavior
+  with respect to RDMA transfers.  Note that there is also an environment
+  variable FI_EFA_USE_DEVICE_RDMA which the user may set as well.  If the
+  environment variable and the argument provided with this variable are in
+  conflict, then fi_setopt will return -FI_EINVAL, and the environment variable
+  will be respected.  If the hardware does not support RDMA and the argument
+  is true, then fi_setopt will return -FI_EOPNOTSUPP.  If the application uses
+  API version < 1.18, the argument is ignored and fi_setopt returns
+  -FI_ENOPROTOOPT.
+  The default behavior for RDMA transfers depends on API version.  For
+  API >= 1.18 RDMA is enabled by default on any hardware which supports it.
+  For API<1.18, RDMA is enabled by default only on certain newer hardware
+  revisions.
+
 # RUNTIME PARAMETERS
 
 *FI_EFA_TX_SIZE*

--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -67,7 +67,8 @@ _efa_files = \
 	prov/efa/src/rdm/rxr_op_entry.c \
 	prov/efa/src/rdm/rxr_atomic.c \
 	prov/efa/src/rdm/rxr_tp_def.c \
-	prov/efa/src/rdm/efa_rdm_srx.c
+	prov/efa/src/rdm/efa_rdm_srx.c \
+	prov/efa/src/rdm/efa_rdm_util.c
 
 _efa_headers = \
 	prov/efa/src/efa.h \
@@ -110,7 +111,8 @@ _efa_headers = \
 	prov/efa/src/rdm/rdm_proto_v4.h \
 	prov/efa/src/rdm/rxr_tp_def.h \
 	prov/efa/src/rdm/rxr_tp.h \
-	prov/efa/src/rdm/efa_rdm_srx.h
+	prov/efa/src/rdm/efa_rdm_srx.h \
+	prov/efa/src/rdm/efa_rdm_util.h
 
 if HAVE_LTTNG
 efa_LDFLAGS += -llttng-ust

--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -74,6 +74,7 @@
 #include "efa_user_info.h"
 #include "efa_fork_support.h"
 #include "rdm/efa_rdm_peer.h"
+#include "rdm/efa_rdm_util.h"
 #include "rdm/rxr.h"
 
 #define EFA_ABI_VER_MAX_LEN 8

--- a/prov/efa/src/efa_device.c
+++ b/prov/efa/src/efa_device.c
@@ -265,9 +265,9 @@ void efa_device_list_finalize(void)
 }
 
 /**
- * @brief check whether efa device support rdma read
+ * @brief Check whether EFA device supports rdma read
  *
- * @return a boolean indicating rdma read status
+ * @return a boolean indicating rdma read support
  */
 bool efa_device_support_rdma_read(void)
 {

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -210,9 +210,6 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 		return -FI_EINVAL;
 	}
 
-	/* Check the value of environment variable FI_EFA_USE_DEVICE_RDMA */
-	efa_domain->use_device_rdma = rxr_env_get_use_device_rdma();
-	
 	efa_domain->mr_local = ofi_mr_local(info);
 	if (EFA_EP_TYPE_IS_DGRAM(info) && !efa_domain->mr_local) {
 		EFA_WARN(FI_LOG_EP_DATA, "dgram require FI_MR_LOCAL, but application does not support it\n");

--- a/prov/efa/src/efa_domain.h
+++ b/prov/efa/src/efa_domain.h
@@ -56,7 +56,6 @@ struct efa_domain {
 	bool 			mr_local;
 	uint64_t		rdm_mode;
 	size_t			rdm_cq_size;
-	int	                use_device_rdma;
 	struct dlist_entry	list_entry; /* linked to g_efa_domain_list */
 };
 
@@ -107,42 +106,6 @@ bool efa_domain_support_rnr_retry_modify(struct efa_domain *domain)
 {
 #if HAVE_CAPS_RNR_RETRY
 	return domain->device->device_caps & EFADV_DEVICE_ATTR_CAPS_RNR_RETRY;
-#else
-	return false;
-#endif
-}
-
-/*
- * @brief: check whether the domain supports rdma read
- *
- * @param[in]	domain	struct efa_domain
- *
- * @return: true if rdma read is supported. false otherwise.
- */
-static inline
-bool efa_domain_support_rdma_read(struct efa_domain *domain)
-{
-	if (!domain->use_device_rdma)
-		return 0;
-
-	return domain->device->device_caps & EFADV_DEVICE_ATTR_CAPS_RDMA_READ;
-}
-
-/*
- * @brief: check whether the domain supports rdma write
- *
- * @param[in]	domain	struct efa_domain
- *
- * @return: true if rdma write is supported. false otherwise.
- */
-static inline
-bool efa_domain_support_rdma_write(struct efa_domain *domain)
-{
-	if (!domain->use_device_rdma)
-		return false;
-
-#if HAVE_CAPS_RDMA_WRITE
-	return domain->device->device_caps & EFADV_DEVICE_ATTR_CAPS_RDMA_WRITE;
 #else
 	return false;
 #endif

--- a/prov/efa/src/rdm/efa_rdm_peer.h
+++ b/prov/efa/src/rdm/efa_rdm_peer.h
@@ -152,7 +152,7 @@ bool efa_rdm_peer_support_delivery_complete(struct efa_rdm_peer *peer)
 static inline
 bool efa_both_support_rdma_read(struct rxr_ep *ep, struct efa_rdm_peer *peer)
 {
-	return efa_domain_support_rdma_read(rxr_ep_domain(ep)) &&
+	return efa_rdm_ep_support_rdma_read(ep) &&
 	       (peer->is_self || efa_rdm_peer_support_rdma_read(peer));
 }
 
@@ -168,7 +168,7 @@ bool efa_both_support_rdma_read(struct rxr_ep *ep, struct efa_rdm_peer *peer)
 static inline
 bool efa_both_support_rdma_write(struct rxr_ep *ep, struct efa_rdm_peer *peer)
 {
-	return efa_domain_support_rdma_write(rxr_ep_domain(ep)) &&
+	return efa_rdm_ep_support_rdma_write(ep) &&
 	       (peer->is_self || efa_rdm_peer_support_rdma_write(peer));
 }
 

--- a/prov/efa/src/rdm/efa_rdm_util.c
+++ b/prov/efa/src/rdm/efa_rdm_util.c
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "efa_rdm_util.h"
+
+/**
+ * @brief Fetch the initial value for use_device_rdma
+ *
+ * This function fetches the value of FI_EFA_USE_DEVICE_RDMA from the
+ * user's environment.  If not set, it uses the API version and the EFA
+ * hardware's version and capabilities to decide when to enable or
+ * disable use_device_rdma during endpoint initialization.
+ *
+ * This value can be modified per-endpoint by using fi_setopt if the
+ * application uses API>=1.18.
+ *
+ * The application may abort() during this method for two reasons:
+ *  - If the Environment variable is set with non-boolean-like value
+ *  - If the Environment variable requests RDMA but no hardware support
+ *    is available.
+ *
+ * @return	bool: use_device_rdma default or environment setting.
+ */
+bool efa_rdm_get_use_device_rdma(uint32_t fabric_api_version)
+{
+	int ret;
+	int param_val;
+	bool hw_support;
+	bool default_val;
+	uint32_t vendor_part_id;
+
+	vendor_part_id = g_device_list[0].ibv_attr.vendor_part_id;
+	hw_support = efa_device_support_rdma_read();
+
+	if (FI_VERSION_GE(fabric_api_version, FI_VERSION(1,18))) {
+		default_val = hw_support;
+	} else {
+		if (vendor_part_id == 0xefa0 || vendor_part_id == 0xefa1) {
+			default_val = false;
+		} else {
+			default_val = true;
+		}
+
+		if (default_val && !hw_support) {
+			fprintf(stderr, "EFA device with vendor id %x unexpectedly has "
+				"no RDMA support. Application will abort().\n",
+				vendor_part_id);
+			abort();
+		}
+	}
+	param_val = default_val;
+
+	/* Fetch the value of environment variable set by the user if any. */
+	ret = fi_param_get_bool(&efa_prov, "use_device_rdma", &param_val);
+	if (ret == -EINVAL) {
+		fprintf(stderr, "FI_EFA_USE_DEVICE_RDMA was set to an invalid value by the user."
+			" FI_EFA_USE_DEVICE_RDMA is boolean and can be set to only 0/false/no/off or"
+			" 1/true/yes/on.  Application will abort().\n");
+		abort();
+	}
+	if (ret < 0) return default_val;
+
+	/* When the user requests use device RDMA but the device does not
+	   support RDMA, exit the run. */
+	if (param_val && !hw_support) {
+		fprintf(stderr, "FI_EFA_USE_DEVICE_RDMA=1 was set by user, but "
+			"EFA device has no rdma-read capability.  Application "
+			"will abort().\n");
+		abort();
+	}
+
+	return param_val;
+}

--- a/prov/efa/src/rdm/efa_rdm_util.h
+++ b/prov/efa/src/rdm/efa_rdm_util.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _EFA_RDM_UTIL_H
+#define _EFA_RDM_UTIL_H
+
+#include "efa.h"
+
+bool efa_rdm_get_use_device_rdma(uint32_t fabric_api_version);
+
+#endif /* _EFA_RDM_UTIL_H */

--- a/prov/efa/src/rdm/rxr_env.h
+++ b/prov/efa/src/rdm/rxr_env.h
@@ -34,6 +34,8 @@
 #ifndef _RXR_ENV_H
 #define _RXR_ENV_H
 
+#include "efa_prov.h"
+
 /**
  * Setting ibv_qp_attr.rnr_retry to this number when modifying qp
  * to cause firmware to retry indefinitely.
@@ -100,10 +102,21 @@ struct rxr_env {
 	char *host_id_file;
 };
 
+/**
+ * @brief Return true if the environment variable FI_EFA_USE_DEVICE_RDMA is present
+ *
+ * @return true  - FI_EFA_USE_DEVICE_RDMA is defined in the environment
+ * @return false - otherwise.
+ * @related efa_rdm_get_use_device_rdma
+ */
+static inline bool rxr_env_has_use_device_rdma() {
+	int ret, param_val;
+	ret = fi_param_get_bool(&efa_prov, "use_device_rdma", &param_val);
+	return (ret != -FI_ENODATA);
+}
+
 extern struct rxr_env rxr_env;
 
 void rxr_env_initialize();
-
-int rxr_env_get_use_device_rdma();
 
 #endif

--- a/prov/efa/src/rdm/rxr_msg.c
+++ b/prov/efa/src/rdm/rxr_msg.c
@@ -134,7 +134,7 @@ int rxr_msg_select_rtm(struct rxr_ep *rxr_ep, struct rxr_op_entry *tx_entry, int
 	readbase_rtm = rxr_pkt_type_readbase_rtm(peer, tx_entry->op, tx_entry->fi_flags, &hmem_info[iface]);
 
 	if (tx_entry->total_len >= hmem_info[iface].min_read_msg_size &&
-		efa_domain_support_rdma_read(rxr_ep_domain(rxr_ep)) &&
+		efa_rdm_ep_support_rdma_read(rxr_ep) &&
 		(tx_entry->desc[0] || efa_is_cache_available(rxr_ep_domain(rxr_ep))))
 		return readbase_rtm;
 

--- a/prov/efa/src/rdm/rxr_pkt_type_base.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_base.c
@@ -398,7 +398,7 @@ int rxr_pkt_copy_data_to_cuda(struct rxr_ep *ep,
 		return ret;
 
 	p2p_available = ret;
-	local_read_available = p2p_available && efa_domain_support_rdma_read(rxr_ep_domain(ep));
+	local_read_available = p2p_available && efa_rdm_ep_support_rdma_read(ep);
 	cuda_memcpy_available = ep->cuda_api_permitted;
 	gdrcopy_available = desc->peer.use_gdrcopy;
 

--- a/prov/efa/test/efa_unit_test_common.c
+++ b/prov/efa/test/efa_unit_test_common.c
@@ -1,4 +1,3 @@
-#include <stdlib.h>
 #include "efa_unit_tests.h"
 #include "rdm/rxr_pkt_type_base.h"
 #include "rdm/rxr_pkt_type_misc.h"

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -1,5 +1,3 @@
-#include <stdio.h>
-#include<unistd.h>
 #include "efa_unit_tests.h"
 #include "rxr_pkt_pool.h"
 

--- a/prov/efa/test/efa_unit_test_mocks.c
+++ b/prov/efa/test/efa_unit_test_mocks.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <errno.h>
 #include <stdlib.h>
 #include <stdint.h>

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -57,6 +57,7 @@ static int efa_unit_test_mocks_teardown(void **state)
 
 	/* Reset environment */
 	rxr_env = orig_rxr_env;
+	unsetenv("FI_EFA_USE_DEVICE_RDMA");
 
 	return 0;
 }
@@ -97,6 +98,15 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_info_check_hmem_cuda_support_on_api_lt_1_18, NULL, NULL),
 		cmocka_unit_test_setup_teardown(test_info_check_hmem_cuda_support_on_api_ge_1_18, NULL, NULL),
 		cmocka_unit_test_setup_teardown(test_info_check_no_hmem_support_when_not_requested, NULL, NULL),
+		cmocka_unit_test_setup_teardown(test_efa_use_device_rdma_env1_opt1, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_use_device_rdma_env0_opt0, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_use_device_rdma_env1_opt0, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_use_device_rdma_env0_opt1, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_use_device_rdma_env1, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_use_device_rdma_env0, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_use_device_rdma_opt1, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_use_device_rdma_opt0, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_use_device_rdma_opt_old, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_hmem_info_update_neuron, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 	};
 

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -1,6 +1,7 @@
 #ifndef EFA_UNIT_TESTS_H
 #define EFA_UNIT_TESTS_H
 
+#define _GNU_SOURCE
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdarg.h>
@@ -96,5 +97,15 @@ void test_info_check_hmem_cuda_support_on_api_lt_1_18();
 void test_info_check_hmem_cuda_support_on_api_ge_1_18();
 void test_info_check_no_hmem_support_when_not_requested();
 void test_efa_hmem_info_update_neuron();
+void test_efa_use_device_rdma_env1_opt1();
+void test_efa_use_device_rdma_env0_opt0();
+void test_efa_use_device_rdma_env1_opt0();
+void test_efa_use_device_rdma_env0_opt1();
+void test_efa_use_device_rdma_opt1();
+void test_efa_use_device_rdma_opt0();
+void test_efa_use_device_rdma_env1();
+void test_efa_use_device_rdma_env0();
+void test_efa_use_device_rdma_opt_old();
+
 
 #endif


### PR DESCRIPTION
move the use_device_rdma option from the domain to the endpoint, and use fi_setopt to control it rather than an environment variable.

This change does not modify the behavior for applications that use API version <1.18.  For these API versions we query the environment value during domain creation, which is (hopefully) the same value we queried during getinfo.

For applications that use API version >= 1.18, we still allow the user to disable RDMA via the environment (FI_EFA_USE_DEVICE_RDMA=0/1).  if fi_setopt() tries to enable RDMA but user has disabled it, then fi_setopt will return `-FI_EINVAL`.  Likewise if the application tries to disable it when the environment has it disabled.

Motivation: https://github.com/ofiwg/libfabric/pull/8529