### PR TITLE
prov/shm: refactor smr structures

### DIFF
--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -121,7 +121,7 @@ static ssize_t smr_do_atomic_inject(struct smr_ep *ep, struct smr_region *peer_s
 			struct smr_cmd *cmd)
 {
 	struct smr_inject_buf *tx_buf;
-	struct smr_tx_entry *pend;
+	struct smr_pend_entry *pend;
 	struct smr_resp *resp;
 
 	tx_buf = smr_get_txbuf(peer_smr);
@@ -137,7 +137,7 @@ static ssize_t smr_do_atomic_inject(struct smr_ep *ep, struct smr_region *peer_s
 			return -FI_EAGAIN;
 		}
 		resp = ofi_cirque_next(smr_resp_queue(ep->region));
-		pend = ofi_freestack_pop(ep->tx_fs);
+		pend = ofi_freestack_pop(ep->tx_pend_fs);
 		smr_format_pend_resp(pend, cmd, context, NULL, resultv,
 				     result_count, op_flags, id, resp);
 		cmd->msg.hdr.data = smr_get_offset(ep->region, resp);

--- a/prov/shm/src/smr_dsa.c
+++ b/prov/shm/src/smr_dsa.c
@@ -541,11 +541,11 @@ static void dsa_update_tx_entry(struct smr_region *smr,
 	struct smr_region *peer_smr;
 	struct smr_resp *resp;
 	struct smr_cmd *cmd;
-	struct smr_tx_entry *tx_entry = dsa_cmd_context->entry_ptr;
+	struct smr_pend_entry *tx_entry = dsa_cmd_context->entry_ptr;
 
 	tx_entry->bytes_done += dsa_cmd_context->bytes_in_progress;
 	cmd = &tx_entry->cmd;
-	peer_smr = smr_peer_region(smr, tx_entry->peer_id);
+	peer_smr = smr_peer_region(smr, tx_entry->tx_entry.peer_id);
 	resp = smr_get_ptr(smr, cmd->msg.hdr.src_data);
 
 	assert(resp->status == SMR_STATUS_BUSY);


### PR DESCRIPTION
Refactor the smr_tx_entry and smr_pend_entry structures. Both these structures serve very similar purposes and contain many of the same attributes. Instead of maintaining two different definitions combine into one definition and unionize the different fields.