### PR TITLE
prov/shm: fix potential deadlock in smr_generic_rma()

### DIFF
--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -145,8 +145,10 @@ static ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 		if (err) {
 			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 				"error doing fast RMA\n");
-			if (err == -FI_EAGAIN)
-				return err;
+			if (err == -FI_EAGAIN) {
+				ret = -FI_EAGAIN;
+				goto signal;
+			}
 
 			ret = smr_write_err_comp(ep->util_ep.rx_cq, NULL,
 						op_flags, 0, -err);


### PR DESCRIPTION
Prior commit b7f25be5c7  introduced a bug that can cause the function smr_generic_rma() to return
without release ep->tx_lock.

This patch fixed the issue.