### PR TITLE
prov/efa: fix wrong mocked return of ibv_wc_read_slid() in unit test

### DIFF
--- a/prov/efa/src/rdm/rxr_ep.c
+++ b/prov/efa/src/rdm/rxr_ep.c
@@ -85,6 +85,25 @@ struct efa_ep_addr *rxr_ep_get_peer_raw_addr(struct rxr_ep *ep, fi_addr_t addr)
 }
 
 /**
+ * @brief return peer's ahn
+ *
+ * @param[in] ep		end point
+ * @param[in] addr 		libfabric address
+ * @returns
+ * If peer exists, return peer's ahn
+ * Otherwise, return -1
+ */
+int32_t rxr_ep_get_peer_ahn(struct rxr_ep *ep, fi_addr_t addr)
+{
+	struct efa_av *efa_av;
+	struct efa_conn *efa_conn;
+
+	efa_av = ep->base_ep.av;
+	efa_conn = efa_av_addr_to_conn(efa_av, addr);
+	return efa_conn ? efa_conn->ah->ahn : -1;
+}
+
+/**
  * @brief return peer's raw address in a reable string
  * 
  * @param[in] ep		end point 

--- a/prov/efa/src/rdm/rxr_ep.h
+++ b/prov/efa/src/rdm/rxr_ep.h
@@ -262,6 +262,8 @@ const char *rxr_ep_get_peer_raw_addr_str(struct rxr_ep *ep, fi_addr_t addr, char
 
 struct efa_rdm_peer *rxr_ep_get_peer(struct rxr_ep *ep, fi_addr_t addr);
 
+int32_t rxr_ep_get_peer_ahn(struct rxr_ep *ep, fi_addr_t addr);
+
 struct rxr_op_entry *rxr_ep_alloc_tx_entry(struct rxr_ep *rxr_ep,
 					   const struct fi_msg *msg,
 					   uint32_t op,

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -155,7 +155,7 @@ void test_rxr_ep_handshake_exchange_host_id(struct efa_resource **state, uint64_
 	will_return(efa_mock_ibv_next_poll_check_function_called_and_return_mock, ENOENT);
 	will_return(efa_mock_ibv_read_byte_len_return_mock, pkt_entry->pkt_size);
 	will_return(efa_mock_ibv_read_opcode_return_mock, IBV_WC_RECV);
-	will_return(efa_mock_ibv_read_slid_return_mock, 0);
+	will_return(efa_mock_ibv_read_slid_return_mock, rxr_ep_get_peer_ahn(rxr_ep, peer_addr));
 	will_return(efa_mock_ibv_read_src_qp_return_mock, raw_addr.qpn);
 	will_return(efa_mock_ibv_start_poll_return_mock, IBV_WC_SUCCESS);
 


### PR DESCRIPTION
In test_rxr_ep_handshake_exchange_host_id(), the mocked return of ibv_wr_read_slid() is always 0, which
is wrong, because it should return peer's ahn.

This patch fixed it.