### PR TITLE
prov/efa: introduce setopt flags for 128 bytes in order transmission

### DIFF
--- a/include/rdma/fi_ext.h
+++ b/include/rdma/fi_ext.h
@@ -69,11 +69,13 @@ extern "C" {
 
 /* negative options are provider specific */
 enum {
-       FI_OPT_EFA_RNR_RETRY = -FI_PROV_SPECIFIC_EFA,
-       FI_OPT_EFA_EMULATED_READ,	/* bool */
-       FI_OPT_EFA_EMULATED_WRITE,	/* bool */
-       FI_OPT_EFA_EMULATED_ATOMICS,	/* bool */
-       FI_OPT_EFA_USE_DEVICE_RDMA,	/* bool */
+	FI_OPT_EFA_RNR_RETRY = -FI_PROV_SPECIFIC_EFA,
+	FI_OPT_EFA_EMULATED_READ,       /* bool */
+	FI_OPT_EFA_EMULATED_WRITE,      /* bool */
+	FI_OPT_EFA_EMULATED_ATOMICS,    /* bool */
+	FI_OPT_EFA_USE_DEVICE_RDMA,	/* bool */
+	FI_OPT_EFA_SENDRECV_IN_ORDER_ALIGNED_128_BYTES, /* bool */
+	FI_OPT_EFA_WRITE_IN_ORDER_ALIGNED_128_BYTES, /* bool */
 };
 
 struct fi_fid_export {

--- a/man/fi_efa.7.md
+++ b/man/fi_efa.7.md
@@ -119,6 +119,18 @@ provider for AWS Neuron or Habana SynapseAI.
   For API<1.18, RDMA is enabled by default only on certain newer hardware
   revisions.
 
+*FI_OPT_EFA_SENDRECV_IN_ORDER_ALIGNED_128_BYTES - bool*
+: It is used to force the endpoint to use in-order send/recv operation for each 128 bytes
+  aligned block. Enabling the option will guarantee data inside each 128 bytes
+  aligned block being sent and received in order. If endpoint is not able to
+  support this feature, it will return -FI_EOPNOTSUPP for the call to fi_setopt().
+
+*FI_OPT_EFA_WRITE_IN_ORDER_ALIGNED_128_BYTES - bool*
+: It is used to set the endpoint to use in-order RDMA write operation for each 128 bytes
+  aligned block. Enabling the option will guarantee data inside each 128 bytes
+  aligned block being written in order. If endpoint is not able to support
+  this feature, it will return -FI_EOPNOTSUPP for the call to fi_setopt().
+
 # RUNTIME PARAMETERS
 
 *FI_EFA_TX_SIZE*

--- a/prov/efa/configure.m4
+++ b/prov/efa/configure.m4
@@ -13,6 +13,8 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 	efa_h_enable_poisoning=0
 	# Determine if efa device supports extensible CQ with access to additional fields from WC
 	efadv_support_extended_cq=1
+	# Determine if efa device support in-order write at 128 bytes aligned boundary.
+	efa_support_data_in_order_aligned_128_byte=1
 
 	AS_IF([test x"$enable_efa" != x"no"],
 	      [FI_CHECK_PACKAGE([efa_ibverbs],
@@ -169,6 +171,21 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 		)
 
 	AM_CONDITIONAL([HAVE_EFADV_CQ_EX], [test $efadv_support_extended_cq -eq 1])
+
+	# IBV_QUERY_QP_DATA_IN_ORDER_ALIGNED_128_BYTES is the flag we need test,
+	# but it is flag. If it is not there, we should disable it.
+	AS_IF([test $efa_support_data_in_order_aligned_128_byte -eq 1],
+		[AC_EGREP_HEADER(
+			[IBV_QUERY_QP_DATA_IN_ORDER_ALIGNED_128_BYTES],
+			[infiniband/verbs.h],
+			[],
+			[efa_support_data_in_order_aligned_128_byte=0])
+		])
+
+	AS_IF([test $efa_support_data_in_order_aligned_128_byte -eq 1],
+		[AC_DEFINE([HAVE_EFA_DATA_IN_ORDER_ALIGNED_128_BYTES], [1], [EFA device supports 128 bytes in-order in writing.])],
+		[AC_DEFINE([HAVE_EFA_DATA_IN_ORDER_ALIGNED_128_BYTES], [0], [EFA device does not support 128 bytes in-order in writing.])]
+		)
 
 	efa_CPPFLAGS="$efa_ibverbs_CPPFLAGS $efadv_CPPFLAGS"
 	efa_LDFLAGS="$efa_ibverbs_LDFLAGS $efadv_LDFLAGS"

--- a/prov/efa/src/dgram/efa_dgram_ep.c
+++ b/prov/efa/src/dgram/efa_dgram_ep.c
@@ -219,6 +219,8 @@ static int efa_dgram_ep_enable(struct fid_ep *ep_fid)
 	struct ibv_qp_init_attr_ex attr_ex = { 0 };
 	struct ibv_pd *ibv_pd;
 	struct efa_dgram_ep *ep;
+	int err;
+
 	ep = container_of(ep_fid, struct efa_dgram_ep, base_ep.util_ep.ep_fid);
 
 	if (!ep->scq && !ep->rcq) {
@@ -268,7 +270,11 @@ static int efa_dgram_ep_enable(struct fid_ep *ep_fid)
 	attr_ex.qp_context = ep;
 	attr_ex.sq_sig_all = 1;
 
-	return efa_base_ep_enable(&ep->base_ep, &attr_ex);
+	err = efa_base_ep_create_qp(&ep->base_ep, &attr_ex);
+	if (err)
+		return err;
+
+	return efa_base_ep_enable(&ep->base_ep);
 }
 
 static int efa_dgram_ep_control(struct fid *fid, int command, void *arg)

--- a/prov/efa/src/efa_base_ep.c
+++ b/prov/efa/src/efa_base_ep.c
@@ -341,3 +341,26 @@ int efa_base_ep_getname(fid_t fid, void *addr, size_t *addrlen)
 	memcpy(addr, &base_ep->src_addr, EFA_EP_ADDR_LEN);
 	return 0;
 }
+
+/*
+ * Determine if an endpoint supports an in-order operation for a 128-bytes piece
+ * of data.
+ *
+ * @param[in]	base_ep	efa base endpoint
+ * @param[in]	op	RDMA opcode
+ * @return 	true if the base ep endpoint support the 128-bytes aligned
+ * 		in-order operation.
+ */
+#if HAVE_EFA_DATA_IN_ORDER_ALIGNED_128_BYTES
+bool efa_base_ep_support_op_in_order_aligned_128_bytes(struct efa_base_ep *base_ep, enum ibv_wr_opcode op)
+{
+	return ibv_query_qp_data_in_order(base_ep->qp, op,
+					  IBV_QUERY_QP_DATA_IN_ORDER_ALIGNED_128_BYTES);
+}
+#else
+bool efa_base_ep_support_op_in_order_aligned_128_bytes(struct efa_base_ep *base_ep, enum ibv_wr_opcode op)
+{
+	return false;
+}
+#endif
+

--- a/prov/efa/src/efa_base_ep.h
+++ b/prov/efa/src/efa_base_ep.h
@@ -62,6 +62,7 @@ struct efa_base_ep {
 	struct ibv_ah *self_ah;
 
 	bool util_ep_initialized;
+	bool efa_qp_enabled;
 
 	struct ibv_send_wr xmit_more_wr_head;
 	struct ibv_send_wr *xmit_more_wr_tail;
@@ -73,8 +74,7 @@ int efa_base_ep_bind_av(struct efa_base_ep *base_ep, struct efa_av *av);
 
 int efa_base_ep_destruct(struct efa_base_ep *base_ep);
 
-int efa_base_ep_enable(struct efa_base_ep *base_ep,
-		       struct ibv_qp_init_attr_ex *attr_ex);
+int efa_base_ep_enable(struct efa_base_ep *base_ep);
 
 int efa_base_ep_construct(struct efa_base_ep *base_ep,
 			  struct fid_domain* domain_fid,
@@ -83,5 +83,8 @@ int efa_base_ep_construct(struct efa_base_ep *base_ep,
 			  void *context);
 
 int efa_base_ep_getname(fid_t fid, void *addr, size_t *addrlen);
+
+int efa_base_ep_create_qp(struct efa_base_ep *base_ep,
+			  struct ibv_qp_init_attr_ex *init_attr_ex);
 
 #endif

--- a/prov/efa/src/efa_base_ep.h
+++ b/prov/efa/src/efa_base_ep.h
@@ -87,4 +87,7 @@ int efa_base_ep_getname(fid_t fid, void *addr, size_t *addrlen);
 int efa_base_ep_create_qp(struct efa_base_ep *base_ep,
 			  struct ibv_qp_init_attr_ex *init_attr_ex);
 
+bool efa_base_ep_support_op_in_order_aligned_128_bytes(struct efa_base_ep *base_ep,
+						       enum ibv_wr_opcode op);
+
 #endif

--- a/prov/efa/src/efa_device.c
+++ b/prov/efa/src/efa_device.c
@@ -277,6 +277,26 @@ bool efa_device_support_rdma_read(void)
 	return g_device_list[0].device_caps & EFADV_DEVICE_ATTR_CAPS_RDMA_READ;
 }
 
+/**
+ * @brief check whether efa device support rdma write
+ *
+ * @return a boolean indicating rdma write status
+ */
+#if HAVE_CAPS_RDMA_WRITE
+bool efa_device_support_rdma_write(void)
+{
+	if (g_device_cnt <=0)
+		return false;
+
+	return g_device_list[0].device_caps & EFADV_DEVICE_ATTR_CAPS_RDMA_WRITE;
+}
+#else
+bool efa_device_support_rdma_write(void)
+{
+	return false;
+}
+#endif
+
 #ifndef _WIN32
 
 static char *get_sysfs_path(void)

--- a/prov/efa/src/efa_device.h
+++ b/prov/efa/src/efa_device.h
@@ -62,6 +62,8 @@ extern int g_device_cnt;
 
 bool efa_device_support_rdma_read(void);
 
+bool efa_device_support_rdma_write(void);
+
 int efa_device_get_driver(struct efa_device *efa_device,
 			  char **efa_driver);
 

--- a/prov/efa/src/rdm/rxr_ep.h
+++ b/prov/efa/src/rdm/rxr_ep.h
@@ -256,6 +256,8 @@ struct rxr_ep {
 	bool use_device_rdma;
 
 	struct fi_info *user_info; /**< fi_info passed by user when calling fi_endpoint */
+	bool sendrecv_in_order_aligned_128_bytes; /**< whether to support in order send/recv of each aligned 128 bytes memory region */
+	bool write_in_order_aligned_128_bytes; /**< whether to support in order write of each aligned 128 bytes memory region */
 };
 
 int rxr_ep_flush_queued_blocking_copy_to_hmem(struct rxr_ep *ep);


### PR DESCRIPTION
This PR introduced setopt flags to enable the in order transmission of aligned 128 bytes.

For this change, this PR included a commit that moved the enablement of base_ep from `rxr_ep_ctrl` to `rxr_endpoint`, because the call to `fi_setopt` need to query ibv_qp, and ibv_qp is created during enablement of base_ep.