### PR TITLE
fabtests: Adding tests for SM2 Provider

### DIFF
--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -128,6 +128,8 @@ nobase_dist_config_DATA = \
 	test_configs/shm/shm.exclude \
 	test_configs/shm/quick.test \
 	test_configs/shm/verify.test \
+	test_configs/sm2/quick.test \
+	test_configs/sm2/verify.test \
 	test_configs/efa/efa-neuron.exclude \
 	test_configs/efa/efa.exclude \
 	pytest/pytest.ini \
@@ -188,7 +190,18 @@ nobase_dist_config_DATA = \
 	pytest/shm/test_rma_bw.py \
 	pytest/shm/test_ubertest.py \
 	pytest/shm/test_unexpected_msg.py \
-	pytest/shm/test_sighandler.py
+	pytest/shm/test_sighandler.py \
+	pytest/sm2/conftest.py \
+	pytest/sm2/sm2_common.py \
+	pytest/sm2/test_rdm.py \
+	pytest/sm2/test_av.py \
+	pytest/sm2/test_cntr.py \
+	pytest/sm2/test_cq.py \
+	pytest/sm2/test_dom.py \
+	pytest/sm2/test_eq.py \
+	pytest/sm2/test_mr.py \
+	pytest/sm2/test_sighandler.py \
+	pytest/sm2/test_ubertest.py
 
 noinst_LTLIBRARIES = libfabtests.la
 

--- a/fabtests/pytest/sm2/conftest.py
+++ b/fabtests/pytest/sm2/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+# TODO Restore GPU Memory Types
+@pytest.fixture(scope="module", params=["host_to_host"])
+def memory_type(request):
+    return request.param
+
+# TODO Restore delivery_complete when completed
+@pytest.fixture(scope="module", params=["transmit_complete"])
+def completion_type(request):
+    return request.param

--- a/fabtests/pytest/sm2/sm2_common.py
+++ b/fabtests/pytest/sm2/sm2_common.py
@@ -1,0 +1,11 @@
+def sm2_run_client_server_test(cmdline_args, executable, iteration_type,
+                               completion_type, memory_type,
+                               warmup_iteration_type=None):
+    from common import ClientServerTest
+
+    test = ClientServerTest(cmdline_args, executable, iteration_type,
+                            completion_type=completion_type,
+                            datacheck_type="with_datacheck",
+                            memory_type=memory_type,
+                            warmup_iteration_type=warmup_iteration_type)
+    test.run()

--- a/fabtests/pytest/sm2/test_av.py
+++ b/fabtests/pytest/sm2/test_av.py
@@ -1,0 +1,1 @@
+from default.test_av import test_av_xfer

--- a/fabtests/pytest/sm2/test_cntr.py
+++ b/fabtests/pytest/sm2/test_cntr.py
@@ -1,0 +1,1 @@
+from default.test_cntr import test_cntr

--- a/fabtests/pytest/sm2/test_cq.py
+++ b/fabtests/pytest/sm2/test_cq.py
@@ -1,0 +1,1 @@
+from default.test_cq import test_cq

--- a/fabtests/pytest/sm2/test_dom.py
+++ b/fabtests/pytest/sm2/test_dom.py
@@ -1,0 +1,1 @@
+from default.test_dom import test_dom

--- a/fabtests/pytest/sm2/test_eq.py
+++ b/fabtests/pytest/sm2/test_eq.py
@@ -1,0 +1,1 @@
+from default.test_eq import test_eq

--- a/fabtests/pytest/sm2/test_mr.py
+++ b/fabtests/pytest/sm2/test_mr.py
@@ -1,0 +1,1 @@
+from default.test_mr import test_mr

--- a/fabtests/pytest/sm2/test_rdm.py
+++ b/fabtests/pytest/sm2/test_rdm.py
@@ -1,0 +1,26 @@
+import pytest
+from default.test_rdm import test_rdm_bw_functional, test_rdm
+from sm2.sm2_common import sm2_run_client_server_test
+
+@pytest.mark.parametrize("iteration_type",
+                         [pytest.param("short", marks=pytest.mark.short),
+                          pytest.param("standard", marks=pytest.mark.standard)])
+def test_rdm_pingpong(cmdline_args, iteration_type, completion_type, memory_type):
+    sm2_run_client_server_test(cmdline_args, "fi_rdm_pingpong", iteration_type,
+                               completion_type, memory_type)
+
+
+@pytest.mark.parametrize("iteration_type",
+                         [pytest.param("short", marks=pytest.mark.short),
+                          pytest.param("standard", marks=pytest.mark.standard)])
+def test_rdm_tagged_pingpong(cmdline_args, iteration_type, completion_type, memory_type):
+    sm2_run_client_server_test(cmdline_args, "fi_rdm_tagged_pingpong", iteration_type,
+                               completion_type, memory_type)
+
+
+@pytest.mark.parametrize("iteration_type",
+                         [pytest.param("short", marks=pytest.mark.short),
+                          pytest.param("standard", marks=pytest.mark.standard)])
+def test_rdm_tagged_bw(cmdline_args, iteration_type, completion_type, memory_type):
+    sm2_run_client_server_test(cmdline_args, "fi_rdm_tagged_bw", iteration_type,
+                               completion_type, memory_type)

--- a/fabtests/pytest/sm2/test_sighandler.py
+++ b/fabtests/pytest/sm2/test_sighandler.py
@@ -1,0 +1,1 @@
+from default.test_sighandler import test_sighandler

--- a/fabtests/pytest/sm2/test_ubertest.py
+++ b/fabtests/pytest/sm2/test_ubertest.py
@@ -1,0 +1,1 @@
+from default.test_ubertest import test_ubertest

--- a/fabtests/test_configs/sm2/quick.test
+++ b/fabtests/test_configs/sm2/quick.test
@@ -1,0 +1,118 @@
+{
+	prov_name: sm2,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+	],
+	class_function: [
+		FT_FUNC_SEND,
+		FT_FUNC_SENDV,
+		FT_FUNC_SENDMSG,
+		FT_FUNC_SENDDATA,
+		FT_FUNC_INJECT,
+		FT_FUNC_INJECTDATA,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	test_class: [
+		FT_CAP_MSG,
+		FT_CAP_TAGGED,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+		FT_COMP_CNTR,
+	],
+	mr_mode: [
+		FI_MR_VIRT_ADDR,
+	],
+	test_flags: FT_FLAG_QUICKTEST
+},
+{
+	prov_name: sm2,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+	],
+	class_function: [
+		FT_FUNC_SENDMSG,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	test_class: [
+		FT_CAP_MSG,
+		FT_CAP_TAGGED,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+		FT_COMP_CNTR,
+	],
+	tx_cq_bind_flags: [
+		FI_SELECTIVE_COMPLETION,
+	],
+	tx_op_flags: [
+		FI_COMPLETION,
+	],
+	msg_flags: [
+		FI_COMPLETION,
+	],
+	test_flags: FT_FLAG_QUICKTEST
+},
+{
+	prov_name: sm2,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+	],
+	class_function: [
+		FT_FUNC_SENDMSG,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	test_class: [
+		FT_CAP_MSG,
+		FT_CAP_TAGGED,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+		FT_COMP_CNTR,
+	],
+	tx_cq_bind_flags: [
+		FI_SELECTIVE_COMPLETION,
+	],
+	msg_flags: [
+		FI_COMPLETION,
+	],
+	test_flags: FT_FLAG_QUICKTEST
+},
+{
+	prov_name: sm2,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+	],
+	class_function: [
+		FT_FUNC_SENDMSG,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	test_class: [
+		FT_CAP_MSG,
+		FT_CAP_TAGGED,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+		FT_COMP_CNTR,
+	],
+	tx_cq_bind_flags: [
+		FI_SELECTIVE_COMPLETION,
+	],
+	tx_op_flags: [
+		FI_COMPLETION,
+	],
+	test_flags: FT_FLAG_QUICKTEST
+},
+

--- a/fabtests/test_configs/sm2/verify.test
+++ b/fabtests/test_configs/sm2/verify.test
@@ -1,0 +1,28 @@
+{
+	prov_name: sm2,
+	test_type: [
+		FT_TEST_UNIT,
+	],
+	class_function: [
+		FT_FUNC_SEND,
+		FT_FUNC_SENDV,
+		FT_FUNC_SENDMSG,
+		FT_FUNC_SENDDATA,
+		FT_FUNC_INJECT,
+		FT_FUNC_INJECTDATA,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	test_class: [
+		FT_CAP_MSG,
+		FT_CAP_TAGGED,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	mr_mode: [
+		FI_MR_VIRT_ADDR,
+	],
+	test_flags: FT_FLAG_QUICKTEST
+},


### PR DESCRIPTION
Creates a test directory and config files for SM2 provider. Included only passing tests for SM2 with its current limited functionality.  This is the first step in putting SM2 in AWS CI.  Will expand tests as SM2 functionality increases.