### PR TITLE
[v1.18.x] fabtests, tcp, rxm: setopt test for FI_OPT_CUDA_API_PERMITTED

### DIFF
--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -162,6 +162,7 @@ nobase_dist_config_DATA = \
 	pytest/efa/test_from_default.py \
 	pytest/efa/test_av.py \
 	pytest/efa/test_cq.py \
+	pytest/efa/test_setopt.py \
 	pytest/efa/test_dgram.py \
 	pytest/efa/test_rdm.py \
 	pytest/efa/test_rma_bw.py \

--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -62,6 +62,7 @@ bin_PROGRAMS = \
 	unit/fi_av_test \
 	unit/fi_dom_test \
 	unit/fi_getinfo_test \
+	unit/fi_setopt_test \
 	ubertest/fi_ubertest	\
 	multinode/fi_multinode	\
 	multinode/fi_multinode_coll \
@@ -432,6 +433,11 @@ unit_fi_getinfo_test_SOURCES = \
 	unit/getinfo_test.c \
 	$(unit_srcs)
 unit_fi_getinfo_test_LDADD = libfabtests.la
+
+unit_fi_setopt_test_SOURCES = \
+	unit/setopt_test.c \
+	$(unit_srcs)
+unit_fi_setopt_test_LDADD = libfabtests.la
 
 ubertest_fi_ubertest_SOURCES = \
 	ubertest/fabtest.h \

--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -1631,7 +1631,7 @@ static void ft_cleanup_mr_array(struct ft_context *ctx_arr, char **mr_bufs)
 	}
 }
 
-static void ft_close_fids(void)
+void ft_close_fids(void)
 {
 	FT_CLOSE_FID(mc);
 	FT_CLOSE_FID(alias_ep);

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -52,7 +52,7 @@ extern "C" {
 #endif
 
 #ifndef FT_FIVERSION
-#define FT_FIVERSION FI_VERSION(1,9)
+#define FT_FIVERSION FI_VERSION(1,18)
 #endif
 
 #include "ft_osd.h"
@@ -406,6 +406,7 @@ int ft_getinfo(struct fi_info *hints, struct fi_info **info);
 int ft_init_fabric();
 int ft_init_oob();
 int ft_close_oob();
+void ft_close_fids();
 int ft_reset_oob();
 int ft_start_server();
 int ft_server_connect();

--- a/fabtests/pytest/efa/test_setopt.py
+++ b/fabtests/pytest/efa/test_setopt.py
@@ -1,0 +1,8 @@
+import pytest
+
+@pytest.mark.unit
+def test_setopt(cmdline_args):
+    from common import UnitTest
+    test = UnitTest(cmdline_args, "fi_setopt_test")
+    test.run()
+

--- a/fabtests/scripts/runfabtests.sh
+++ b/fabtests/scripts/runfabtests.sh
@@ -232,6 +232,7 @@ unit_tests=(
 	"fi_cq_test"
 	"fi_mr_test"
 	"fi_cntr_test"
+	"fi_setopt_test"
 )
 
 regression_tests=(

--- a/fabtests/unit/setopt_test.c
+++ b/fabtests/unit/setopt_test.c
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) Amazon Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include <stdio.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_errno.h>
+
+#include "unit_common.h"
+#include "hmem.h"
+#include "shared.h"
+
+char err_buf[512];
+
+int test_setopt_cuda_api_permmitted()
+{
+	bool optval = true;
+	int err, ret;
+
+	hints->caps |= FI_HMEM;
+	hints->domain_attr->mr_mode |= FI_MR_HMEM;
+
+	err = fi_getinfo(FT_FIVERSION, NULL,
+			 0, 0, hints, &fi);
+	if (err) {
+		if (err == -FI_ENODATA) {
+			ret = SKIPPED;
+			FT_UNIT_STRERR(err_buf,
+				       "no HMEM support",
+				       err);
+		} else {
+			ret = FAIL;
+			FT_UNIT_STRERR(err_buf,
+				       "fi_getinfo failed!",
+				       err);
+		}
+
+		goto out;
+	}
+
+	err = ft_open_fabric_res();
+	if (err) {
+		ret = FAIL;
+		FT_UNIT_STRERR(err_buf,
+			       "open fabric resource failed!",
+			       err);
+		goto out;
+	}
+
+	err = fi_endpoint(domain, fi, &ep, NULL);
+	if (err) {
+		ret = FAIL;
+		FT_UNIT_STRERR(err_buf,
+			       "open endpoint failed!",
+			       err);
+		goto out;
+	}
+
+	err = fi_setopt(&ep->fid, FI_OPT_ENDPOINT,
+			FI_OPT_CUDA_API_PERMITTED,
+			&optval, sizeof(optval) );
+	if (err == -FI_ENOPROTOOPT) {
+		/* Per document, any provider that claim
+		 * support FI_HMEM capability is required
+		 * to implement this option
+		 */
+		ret = FAIL;
+		FT_UNIT_STRERR(err_buf,
+			       "FI_OPT_CUDA_API_PERMITTED was not implemented!",
+			       err);
+	} else if (err == -FI_EOPNOTSUPP || err == -FI_EINVAL || err == 0) {
+		/* per document, both -FI_EOPNOTSUPP and
+		 * -FI_EINVAL are valid return for setting
+		 * this option:
+		 *	-FI_EOPNOTSUPP means the provider's HMEM CUDA
+		 *	support rely on calling CUDA API.
+		 *	-FI_EINVAL means there is no CUDA device
+		 *	 or CUDA library available
+		 */
+		ret = PASS;
+	} else {
+		FT_UNIT_STRERR(err_buf, "fi_setopt failed!", err);
+		ret = FAIL;
+	}
+
+out:
+	ft_close_fids(); /* close ep, eq, domain, fabric */
+	return ret;
+}
+
+static void usage(char *name)
+{
+        ft_unit_usage(name, "Unit test for fi_setopt");
+}
+
+int main(int argc, char **argv)
+{
+	char op;
+	struct test_entry test_array[] = {
+		TEST_ENTRY(test_setopt_cuda_api_permmitted, "Test FI_OPT_CUDA_API_PERMITTED"),
+		TEST_ENTRY(NULL, ""),
+	};
+
+	int failed;
+
+	hints = fi_allocinfo();
+	if (!hints) {
+		FT_UNIT_STRERR(err_buf,
+			       "hints allocationed failed!",
+			       -FI_ENOMEM);
+		return FAIL;
+	}
+
+	while ((op = getopt(argc, argv, FAB_OPTS HMEM_OPTS "h")) != -1) {
+		switch (op) {
+		default:
+			ft_parseinfo(op, optarg, hints, &opts);
+			break;
+		case '?':
+		case 'h':
+			usage(argv[0]);
+			return EXIT_FAILURE;
+		}
+	}
+
+	hints->mode = ~0;
+	hints->domain_attr->mode = ~0;
+	hints->domain_attr->mr_mode = ~(FI_MR_BASIC | FI_MR_SCALABLE);
+	hints->caps |= FI_MSG;
+
+	failed = run_tests(test_array, err_buf);
+	if (failed > 0) {
+		printf("Summary: %d tests failed\n", failed);
+	} else {
+		printf("Summary: all tests passed\n");
+	}
+
+	ft_free_res();
+	return (failed > 0) ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -366,6 +366,9 @@ void rxm_freeall_conns(struct rxm_ep *ep)
 	struct rxm_av *av;
 	int i, cnt;
 
+	if (!ep->util_ep.av)
+		return;
+
 	av = container_of(ep->util_ep.av, struct rxm_av, util_av);
 	ofi_ep_lock_acquire(&ep->util_ep);
 

--- a/prov/tcp/src/xnet_rdm_cm.c
+++ b/prov/tcp/src/xnet_rdm_cm.c
@@ -262,6 +262,9 @@ void xnet_freeall_conns(struct xnet_rdm *rdm)
 	struct rxm_av *av;
 	int i, cnt;
 
+	if (!rdm->util_ep.av)
+		return;
+
 	av = container_of(rdm->util_ep.av, struct rxm_av, util_av);
 	assert(xnet_progress_locked(xnet_rdm2_progress(rdm)));
 


### PR DESCRIPTION
back port the setopt_test to v1.18.x branch