### PR TITLE
[v1.18.x] prov/efa: fix switch case fallthrough

### DIFF
--- a/prov/efa/src/rdm/rxr_ep.c
+++ b/prov/efa/src/rdm/rxr_ep.c
@@ -1355,7 +1355,9 @@ static int rxr_ep_setopt(fid_t fid, int level, int optname,
 		if (optlen != sizeof(bool))
 			return -FI_EINVAL;
 		ret = rxr_ep_set_use_device_rdma(rxr_ep, *(bool *)optval);
-		if (ret) return ret;
+		if (ret)
+			return ret;
+		break;
 	case FI_OPT_EFA_SENDRECV_IN_ORDER_ALIGNED_128_BYTES:
 		if (optlen != sizeof(bool))
 			return -FI_EINVAL;


### PR DESCRIPTION
Fix compiler warning.

Signed-off-by: Wenduo Wang <wenduwan@amazon.com>
(cherry picked from commit dc7d0cacebdc50c66c774d764d2fd050ab1f3dee)