### PR TITLE
doc/fi_getinfo: add FI_ENOSYS to return value

### DIFF
--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -745,6 +745,9 @@ via fi_freeinfo().
 *FI_ENOMEM*
 : Indicates that there was insufficient memory to complete the operation.
 
+*F_ENOSYS*
+: Indicates that requested version is newer than the library being used.
+
 # NOTES
 
 If hints are provided, the operation will be controlled by the values


### PR DESCRIPTION
Current implementation of fi_getinfo() will return -FI_ENOSYS if the "version" argument of fi_getinfo() is too high to be supported. This patch added that return value to document.