### PR TITLE
prov/tcp: Fix a use-after if ep closed after reject

### DIFF
--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -627,8 +627,10 @@ static int tcpx_ep_close(struct fid *fid)
 					 &ep->util_ep.ep_fid.fid);
 	}
 
-	if (ep->fid && ep->fid->fclass == TCPX_CLASS_CM)
+	if (ep->state != TCPX_RCVD_REQ && ep->fid) {
+	        assert(ep->fid->fclass == TCPX_CLASS_CM);
 		tcpx_free_cm_ctx(ep->cm_ctx);
+	}
 
 	ofi_close_socket(ep->bsock.sock);
 	if (ep->util_ep.eq)


### PR DESCRIPTION
The following sequence causes a use-after-free that can be
detected by ASAN:
- Incoming connection request received on PEP
- Create the endpoint with fi_endpoint(info)
- Reject the connection request with fi_reject(pep, info->handle);
- Close the endpoint with fi_close(&ep->fid)

The use-after free occurs in tcpx_ep_close() when the following
condition is evaluated:
if (ep->fid && ep->fid->fclass == TCPX_CLASS_CM)

The pointer stored in ep->fid references a memory that is freed.
When tcpx_endpoint() is executed the EP saves a reference
to the handle in ep->handle. Later, this handle is freed
by fi_reject() and ep->handle becomes a dangling pointer as
a consequence.
Finally, tcpx_ep_close() accesses ep->fid, which triggers
the use-after-free (note that ep->fid and ep->handle are part
of the same union).

The fix implemented in the patch moves the destruction of
ep->handle from fi_reject() to fi_close().