### PR TITLE
prov/efa: Use shm as a peer provider

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_cq.h
+++ b/prov/efa/src/rdm/efa_rdm_cq.h
@@ -36,7 +36,10 @@
 
 #include <ofi_util.h>
 
-typedef struct util_cq efa_rdm_cq;
+struct efa_rdm_cq {
+	struct util_cq util_cq;
+	struct fid_cq *shm_cq;
+};
 
 /*
  * Control header with completion data. CQ data length is static.

--- a/prov/efa/src/rdm/efa_rdm_peer.h
+++ b/prov/efa/src/rdm/efa_rdm_peer.h
@@ -69,7 +69,6 @@ struct efa_rdm_peer {
 	uint32_t nextra_p3;		/**< number of members in extra_info plus 3 (See protocol v4 document section 2.1) */
 	uint64_t extra_info[RXR_MAX_NUM_EXINFO]; /**< the feature/request flag for each version (See protocol v4 document section 2.1)*/
 	size_t efa_outstanding_tx_ops;	/**< tracks outstanding tx ops (send/read) to this peer on EFA device */
-	size_t shm_outstanding_tx_ops;  /**< tracks outstanding tx ops (send/read/write/atomic) to this peer on SHM */
 	struct dlist_entry outstanding_tx_pkts; /**< a list of outstanding pkts sent to the peer */
 	uint64_t rnr_backoff_begin_ts;	/**< timestamp for RNR backoff period begin */
 	uint64_t rnr_backoff_wait_time;	/**< how long the RNR backoff period last */

--- a/prov/efa/src/rdm/efa_rdm_srx.c
+++ b/prov/efa/src/rdm/efa_rdm_srx.c
@@ -34,6 +34,62 @@
 #include "efa.h"
 #include "efa_rdm_srx.h"
 #include "rxr_msg.h"
+#include "rxr_pkt_type_req.h"
+
+/**
+ * @brief Construct a packet entry that will be used as input of
+ * rxr_pkt_get_msg(tag)rtm_rx_entry in efa_rdm_srx_get_msg(tag).
+ *
+ * @param[in,out] pkt_entry the pkt_entry to be constructed.
+ * @param[in] addr the fi_addr_t of the pkt entry
+ * @param[in] size the data size of the pkt entry
+ * @param[in] tag the tag of the pkt entry, ignored unless the op is ofi_op_tagged
+ * @param[in] op the ofi_op code, allowed values: ofi_op_msg and ofi_op_tagged
+ */
+static
+void efa_rdm_srx_construct_pkt_entry(struct rxr_pkt_entry *pkt_entry,
+				     fi_addr_t addr,
+				     size_t size,
+				     uint64_t tag,
+				     int op)
+{
+	struct rxr_longread_rtm_base_hdr *rtm_hdr;
+	int pkt_type;
+	assert(op == ofi_op_msg || op == ofi_op_tagged);
+
+	/*
+	 * Use longread msg/tag rtm pkt type because it has the
+	 * msg length in the pkt hdr that is used to derive the
+	 * pkt size for the multi-recv path.
+	 * And we cannot make the data size part of pkt_entry->pkt_size
+	 * because we are not allocating memory for it.
+	 */
+	if (op == ofi_op_msg)
+		pkt_type = RXR_LONGREAD_MSGRTM_PKT;
+	else
+		pkt_type = RXR_LONGREAD_TAGRTM_PKT;
+
+	rtm_hdr = (struct rxr_longread_rtm_base_hdr *)pkt_entry->wiredata;
+	rtm_hdr->hdr.type = pkt_type;
+	rtm_hdr->hdr.version = RXR_PROTOCOL_VERSION;
+	rtm_hdr->hdr.flags = RXR_REQ_MSG;
+	rtm_hdr->msg_length = size;
+
+	if (op == ofi_op_tagged) {
+		rtm_hdr->hdr.flags |= RXR_REQ_TAGGED;
+		rxr_pkt_rtm_settag(pkt_entry, tag);
+	}
+
+	pkt_entry->pkt_size = rxr_pkt_req_hdr_size(pkt_type, 0, 0);
+	pkt_entry->addr = addr;
+	pkt_entry->alloc_type = RXR_PKT_FROM_PEER_SRX;
+	pkt_entry->flags = RXR_PKT_ENTRY_IN_USE;
+	pkt_entry->next = NULL;
+	pkt_entry->x_entry = NULL;
+	pkt_entry->recv_wr.wr.next = NULL;
+	pkt_entry->send_wr = NULL;
+	pkt_entry->mr = NULL;
+}
 
 /**
  * @brief This call is invoked by the peer provider to obtain a
@@ -42,12 +98,45 @@
  * @param[in] addr the source address of the incoming message
  * @param[in] size the size of the incoming message
  * @param[out] peer_rx_entry the obtained peer_rx_entry
- * @return int 0 on success, a negative integer on failure
+ * @return int FI_SUCCESS when a matched rx entry is found, -FI_ENOENT when the
+ * match is not found, other negative integer for other errors.
  */
 static int efa_rdm_srx_get_msg(struct fid_peer_srx *srx, fi_addr_t addr,
 		       size_t size, struct fi_peer_rx_entry **peer_rx_entry)
 {
-    return -FI_ENOSYS;
+	struct rxr_ep *rxr_ep;
+	struct rxr_pkt_entry *pkt_entry;
+	struct rxr_op_entry *rx_entry;
+	int ret;
+	char buf[PEER_SRX_MSG_PKT_SIZE];
+
+	pkt_entry = (struct rxr_pkt_entry *) &buf[0];
+
+	rxr_ep = (struct rxr_ep *) srx->ep_fid.fid.context;
+	/*
+	 * TODO:
+	 * In theory we should not need to create a pkt_entry to get a rx entry,
+	 * but the current EFA code needs an pkt_entry as input. A major refactor
+	 * is needed to split the context (addr, size etc.) and data from pkt entry
+	 * and make rxr_*_get_*_rx_entry needs context only.
+	 */
+	efa_rdm_srx_construct_pkt_entry(pkt_entry, addr, size, 0, ofi_op_msg);
+
+	ofi_mutex_lock(&rxr_ep->base_ep.util_ep.lock);
+	rx_entry = rxr_pkt_get_msgrtm_rx_entry(rxr_ep, &pkt_entry);
+	if (OFI_UNLIKELY(!rx_entry)) {
+		efa_eq_write_error(&rxr_ep->base_ep.util_ep, FI_ENOBUFS, FI_EFA_ERR_RX_ENTRIES_EXHAUSTED);
+		ret = -FI_ENOBUFS;
+		goto out;
+	}
+	ret = rx_entry->state == RXR_RX_MATCHED ? FI_SUCCESS : -FI_ENOENT;
+	/* Override this field to be peer provider's srx so the correct srx can be used by start_msg ops */
+	rx_entry->peer_rx_entry.srx = srx;
+	*peer_rx_entry = &rx_entry->peer_rx_entry;
+
+out:
+	ofi_mutex_unlock(&rxr_ep->base_ep.util_ep.lock);
+	return ret;
 }
 
 /**
@@ -63,7 +152,39 @@ static int efa_rdm_srx_get_msg(struct fid_peer_srx *srx, fi_addr_t addr,
 static int efa_rdm_srx_get_tag(struct fid_peer_srx *srx, fi_addr_t addr,
 			uint64_t tag, struct fi_peer_rx_entry **peer_rx_entry)
 {
-    return -FI_ENOSYS;
+	struct rxr_ep *rxr_ep;
+	struct rxr_pkt_entry *pkt_entry;
+	struct rxr_op_entry *rx_entry;
+	int ret;
+	char buf[PEER_SRX_TAG_PKT_SIZE];
+
+	pkt_entry = (struct rxr_pkt_entry *) &buf[0];
+
+	rxr_ep = (struct rxr_ep *) srx->ep_fid.fid.context;
+	/*
+	 * TODO:
+	 * In theory we should not need to create a pkt_entry to get a rx entry,
+	 * but the current EFA code needs an pkt_entry as input. A major refactor
+	 * is needed to split the context (addr, size etc.) and data from pkt entry
+	 * and make rxr_*_get_*_rx_entry needs context only.
+	 */
+	efa_rdm_srx_construct_pkt_entry(pkt_entry, addr, 0, tag, ofi_op_tagged);
+
+	ofi_mutex_lock(&rxr_ep->base_ep.util_ep.lock);
+	rx_entry = rxr_pkt_get_tagrtm_rx_entry(rxr_ep, &pkt_entry);
+	if (OFI_UNLIKELY(!rx_entry)) {
+		efa_eq_write_error(&rxr_ep->base_ep.util_ep, FI_ENOBUFS, FI_EFA_ERR_RX_ENTRIES_EXHAUSTED);
+		ret = -FI_ENOBUFS;
+		goto out;
+	}
+	ret = rx_entry->state == RXR_RX_MATCHED ? FI_SUCCESS : -FI_ENOENT;
+	/* Override this field to be peer provider's srx so the correct srx can be used by start_tag ops */
+	rx_entry->peer_rx_entry.srx = srx;
+	*peer_rx_entry = &rx_entry->peer_rx_entry;
+
+out:
+	ofi_mutex_unlock(&rxr_ep->base_ep.util_ep.lock);
+	return ret;
 }
 
 /**
@@ -77,7 +198,16 @@ static int efa_rdm_srx_get_tag(struct fid_peer_srx *srx, fi_addr_t addr,
  */
 static int efa_rdm_srx_queue_msg(struct fi_peer_rx_entry *peer_rx_entry)
 {
-    return -FI_ENOSYS;
+	struct rxr_op_entry *rx_entry;
+	struct rxr_ep *ep;
+
+	rx_entry = container_of(peer_rx_entry, struct rxr_op_entry, peer_rx_entry);
+	ep = rx_entry->ep;
+
+	ofi_mutex_lock(&ep->base_ep.util_ep.lock);
+	rxr_msg_queue_unexp_rx_entry_for_msgrtm(ep, rx_entry);
+	ofi_mutex_unlock(&ep->base_ep.util_ep.lock);
+	return FI_SUCCESS;
 }
 
 /**
@@ -91,7 +221,16 @@ static int efa_rdm_srx_queue_msg(struct fi_peer_rx_entry *peer_rx_entry)
  */
 static int efa_rdm_srx_queue_tag(struct fi_peer_rx_entry *peer_rx_entry)
 {
-	return -FI_ENOSYS;
+	struct rxr_op_entry *rx_entry;
+	struct rxr_ep *ep;
+
+	rx_entry = container_of(peer_rx_entry, struct rxr_op_entry, peer_rx_entry);
+	ep = rx_entry->ep;
+
+	ofi_mutex_lock(&ep->base_ep.util_ep.lock);
+	rxr_msg_queue_unexp_rx_entry_for_tagrtm(ep, rx_entry);
+	ofi_mutex_unlock(&ep->base_ep.util_ep.lock);
+	return FI_SUCCESS;
 }
 
 /**
@@ -102,6 +241,28 @@ static int efa_rdm_srx_queue_tag(struct fi_peer_rx_entry *peer_rx_entry)
  */
 static void efa_rdm_srx_free_entry(struct fi_peer_rx_entry *peer_rx_entry)
 {
+	struct rxr_op_entry *rx_entry;
+	struct rxr_ep *ep;
+
+	rx_entry = container_of(peer_rx_entry, struct rxr_op_entry, peer_rx_entry);
+	ep = rx_entry->ep;
+
+	ofi_mutex_lock(&ep->base_ep.util_ep.lock);
+	if (rx_entry->fi_flags & FI_MULTI_RECV) {
+		rxr_msg_multi_recv_handle_completion(rx_entry->ep, rx_entry);
+		if (rx_entry->cq_entry.flags & FI_MULTI_RECV) {
+			if (ofi_peer_cq_write(rx_entry->ep->base_ep.util_ep.rx_cq,
+					      rx_entry->master_entry->cq_entry.op_context,
+					      FI_MULTI_RECV, 0, NULL, 0, 0,
+					      FI_ADDR_NOTAVAIL)) {
+				EFA_WARN(FI_LOG_EP_CTRL,
+					"unable to write rx MULTI_RECV completion\n");
+			}
+		}
+	}
+	rxr_msg_multi_recv_free_posted_entry(rx_entry->ep, rx_entry);
+	rxr_rx_entry_release(rx_entry);
+	ofi_mutex_unlock(&ep->base_ep.util_ep.lock);
 }
 
 /**
@@ -114,10 +275,17 @@ static void efa_rdm_srx_free_entry(struct fi_peer_rx_entry *peer_rx_entry)
 static int efa_rdm_srx_start_msg(struct fi_peer_rx_entry *peer_rx_entry)
 {
 	struct rxr_op_entry *rx_op_entry;
+	int ret;
+	struct rxr_ep *ep;
 
 	rx_op_entry = container_of(peer_rx_entry, struct rxr_op_entry, peer_rx_entry);
+	ep = rx_op_entry->ep;
 
-	return rxr_pkt_proc_matched_rtm(rx_op_entry->ep, rx_op_entry, peer_rx_entry->owner_context);
+	ofi_mutex_lock(&ep->base_ep.util_ep.lock);
+	ret = rxr_pkt_proc_matched_rtm(ep, rx_op_entry, peer_rx_entry->owner_context);
+	ofi_mutex_unlock(&ep->base_ep.util_ep.lock);
+
+	return ret;
 }
 
 /**
@@ -130,10 +298,17 @@ static int efa_rdm_srx_start_msg(struct fi_peer_rx_entry *peer_rx_entry)
 static int efa_rdm_srx_start_tag(struct fi_peer_rx_entry *peer_rx_entry)
 {
 	struct rxr_op_entry *rx_op_entry;
+	int ret;
+	struct rxr_ep *ep;
 
 	rx_op_entry = container_of(peer_rx_entry, struct rxr_op_entry, peer_rx_entry);
+	ep = rx_op_entry->ep;
 
-	return rxr_pkt_proc_matched_rtm(rx_op_entry->ep, rx_op_entry, peer_rx_entry->owner_context);
+	ofi_mutex_lock(&ep->base_ep.util_ep.lock);
+	ret = rxr_pkt_proc_matched_rtm(ep, rx_op_entry, peer_rx_entry->owner_context);
+	ofi_mutex_unlock(&ep->base_ep.util_ep.lock);
+
+	return ret;
 }
 
 /**

--- a/prov/efa/src/rdm/efa_rdm_srx.h
+++ b/prov/efa/src/rdm/efa_rdm_srx.h
@@ -36,6 +36,9 @@
 
 #include "efa.h"
 
+#define PEER_SRX_MSG_PKT_SIZE sizeof(struct rxr_pkt_entry) + sizeof(struct rxr_longread_msgrtm_hdr)
+#define PEER_SRX_TAG_PKT_SIZE sizeof(struct rxr_pkt_entry) + sizeof(struct rxr_longread_tagrtm_hdr)
+
 void efa_rdm_peer_srx_construct(struct rxr_ep *rxr_ep, struct fid_peer_srx *peer_srx);
 
 #endif /* _EFA_RDM_SRX_H */

--- a/prov/efa/src/rdm/rxr.h
+++ b/prov/efa/src/rdm/rxr.h
@@ -109,7 +109,7 @@ static inline void rxr_poison_mem_region(void *ptr, size_t size)
 #define RXR_MAX_RX_QUEUE_SIZE (UINT32_MAX)
 #define RXR_MAX_TX_QUEUE_SIZE (UINT32_MAX)
 
-void rxr_convert_desc_for_shm(int numdesc, void **desc);
+void rxr_get_desc_for_shm(int numdesc, void **efa_desc, void **shm_desc);
 
 /* Aborts if unable to write to the eq */
 static inline void efa_eq_write_error(struct util_ep *ep, ssize_t err,

--- a/prov/efa/src/rdm/rxr_atomic.c
+++ b/prov/efa/src/rdm/rxr_atomic.c
@@ -57,8 +57,7 @@ static void rxr_atomic_init_shm_msg(struct rxr_ep *ep, struct fi_msg_atomic *shm
 	}
 
 	if (msg->desc) {
-		memcpy(shm_desc, msg->desc, msg->iov_count * sizeof(void *));
-		rxr_convert_desc_for_shm(msg->iov_count, shm_desc);
+		rxr_get_desc_for_shm(msg->iov_count, msg->desc, shm_desc);
 		shm_msg->desc = shm_desc;
 	} else {
 		shm_msg->desc = NULL;

--- a/prov/efa/src/rdm/rxr_atomic.c
+++ b/prov/efa/src/rdm/rxr_atomic.c
@@ -199,7 +199,6 @@ ssize_t rxr_atomic_generic_efa(struct rxr_ep *rxr_ep,
 		err = rxr_pkt_post_req(rxr_ep,
 				       tx_entry,
 				       RXR_DC_WRITE_RTA_PKT,
-				       0,
 				       0);
 	} else {
 		/*
@@ -210,7 +209,6 @@ ssize_t rxr_atomic_generic_efa(struct rxr_ep *rxr_ep,
 		err = rxr_pkt_post_req(rxr_ep,
 				       tx_entry,
 				       req_pkt_type_list[op],
-				       0,
 				       0);
 	}
 

--- a/prov/efa/src/rdm/rxr_ep.c
+++ b/prov/efa/src/rdm/rxr_ep.c
@@ -468,7 +468,9 @@ static void rxr_ep_free_res(struct rxr_ep *rxr_ep)
 		EFA_WARN(FI_LOG_EP_CTRL,
 			"Closing ep with unmatched unexpected rx_entry: %p pkt_entry %p\n",
 			rx_entry, rx_entry->unexp_pkt);
-		rxr_pkt_entry_release_rx(rxr_ep, rx_entry->unexp_pkt);
+		/* rx entry for peer srx does not allocate unexp_pkt */
+		if (!(rx_entry->rxr_flags & RXR_RX_ENTRY_FOR_PEER_SRX))
+			rxr_pkt_entry_release_rx(rxr_ep, rx_entry->unexp_pkt);
 		rxr_rx_entry_release(rx_entry);
 	}
 

--- a/prov/efa/src/rdm/rxr_ep.c
+++ b/prov/efa/src/rdm/rxr_ep.c
@@ -51,6 +51,7 @@
 #include "rxr_tp.h"
 #include "rxr_cntr.h"
 #include "efa_rdm_srx.h"
+#include "efa_rdm_cq.h"
 
 void recv_rdma_with_imm_completion(struct rxr_ep *ep, int32_t imm_data, uint64_t flags);
 
@@ -295,26 +296,12 @@ int rxr_ep_post_user_recv_buf(struct rxr_ep *ep, struct rxr_op_entry *rx_entry, 
  */
 int rxr_ep_post_internal_rx_pkt(struct rxr_ep *ep, uint64_t flags, enum rxr_lower_ep_type lower_ep_type)
 {
-	struct iovec msg_iov;
 	void *desc;
 	struct rxr_pkt_entry *rx_pkt_entry = NULL;
 	int ret = 0;
 
-	switch (lower_ep_type) {
-	case SHM_EP:
-		rx_pkt_entry = rxr_pkt_entry_alloc(ep, ep->shm_rx_pkt_pool, RXR_PKT_FROM_SHM_RX_POOL);
-		break;
-	case EFA_EP:
-		rx_pkt_entry = rxr_pkt_entry_alloc(ep, ep->efa_rx_pkt_pool, RXR_PKT_FROM_EFA_RX_POOL);
-		break;
-	default:
-		/* Coverity will complain about this being a dead code segment,
-		 * but it is useful for future proofing.
-		 */
-		EFA_WARN(FI_LOG_EP_CTRL,
-			"invalid lower EP type %d\n", lower_ep_type);
-		assert(0 && "invalid lower EP type\n");
-	}
+	rx_pkt_entry = rxr_pkt_entry_alloc(ep, ep->efa_rx_pkt_pool, RXR_PKT_FROM_EFA_RX_POOL);
+
 	if (OFI_UNLIKELY(!rx_pkt_entry)) {
 		EFA_WARN(FI_LOG_EP_CTRL,
 			"Unable to allocate rx_pkt_entry\n");
@@ -323,48 +310,20 @@ int rxr_ep_post_internal_rx_pkt(struct rxr_ep *ep, uint64_t flags, enum rxr_lowe
 
 	rx_pkt_entry->x_entry = NULL;
 
-	msg_iov.iov_base = (void *)(rx_pkt_entry->wiredata);
-	msg_iov.iov_len = ep->mtu_size;
-
-	switch (lower_ep_type) {
-	case SHM_EP:
-		/* pre-post buffer with shm */
 #if ENABLE_DEBUG
-		dlist_insert_tail(&rx_pkt_entry->dbg_entry,
-				  &ep->rx_posted_buf_shm_list);
-#endif
-		desc = NULL;
-		ret = fi_recvv(ep->shm_ep, &msg_iov, &desc, 1, FI_ADDR_UNSPEC, rx_pkt_entry);
-		if (OFI_UNLIKELY(ret)) {
-			rxr_pkt_entry_release_rx(ep, rx_pkt_entry);
-			EFA_WARN(FI_LOG_EP_CTRL,
-				"failed to post buf for shm  %d (%s)\n", -ret,
-				fi_strerror(-ret));
-			return ret;
-		}
-		ep->shm_rx_pkts_posted++;
-		break;
-	case EFA_EP:
-#if ENABLE_DEBUG
-		dlist_insert_tail(&rx_pkt_entry->dbg_entry,
+	dlist_insert_tail(&rx_pkt_entry->dbg_entry,
 				  &ep->rx_posted_buf_list);
 #endif
-		desc = fi_mr_desc(rx_pkt_entry->mr);
-		ret = rxr_pkt_entry_recv(ep, rx_pkt_entry, &desc, flags);
-		if (OFI_UNLIKELY(ret)) {
-			rxr_pkt_entry_release_rx(ep, rx_pkt_entry);
-			EFA_WARN(FI_LOG_EP_CTRL,
-				"failed to post buf %d (%s)\n", -ret,
-				fi_strerror(-ret));
-			return ret;
-		}
-		ep->efa_rx_pkts_posted++;
-		break;
-	default:
+	desc = fi_mr_desc(rx_pkt_entry->mr);
+	ret = rxr_pkt_entry_recv(ep, rx_pkt_entry, &desc, flags);
+	if (OFI_UNLIKELY(ret)) {
+		rxr_pkt_entry_release_rx(ep, rx_pkt_entry);
 		EFA_WARN(FI_LOG_EP_CTRL,
-			"invalid lower EP type %d\n", lower_ep_type);
-		assert(0 && "invalid lower EP type\n");
+			"failed to post buf %d (%s)\n", -ret,
+			fi_strerror(-ret));
+		return ret;
 	}
+	ep->efa_rx_pkts_posted++;
 
 	return 0;
 }
@@ -427,7 +386,6 @@ struct rxr_op_entry *rxr_ep_alloc_tx_entry(struct rxr_ep *rxr_ep,
 	return tx_entry;
 }
 
-
 /**
  * @brief convert EFA descriptors to shm descriptors.
  *
@@ -437,18 +395,19 @@ struct rxr_op_entry *rxr_ep_alloc_tx_entry(struct rxr_ep *rxr_ep,
  * shm can use.
  *
  * @param numdesc[in]       number of descriptors in the array
- * @param desc[in,out]      descriptors input is EFA descriptor, output
+ * @param efa_desc[in]      efa descriptors
+ * @param shm_desc[out]     shm descriptors
  *                          is shm descriptor.
  */
-void rxr_convert_desc_for_shm(int numdesc, void **desc)
+void rxr_get_desc_for_shm(int numdesc, void **efa_desc, void **shm_desc)
 {
 	int i;
 	struct efa_mr *efa_mr;
 
 	for (i = 0; i < numdesc; ++i) {
-		efa_mr = desc[i];
+		efa_mr = efa_desc[i];
 		if (efa_mr)
-			desc[i] = fi_mr_desc(efa_mr->shm_mr);
+			shm_desc[i] = fi_mr_desc(efa_mr->shm_mr);
 	}
 }
 
@@ -659,14 +618,6 @@ static int rxr_ep_close(struct fid *fid)
 		}
 	}
 
-	if (rxr_ep->shm_cq) {
-		ret = fi_close(&rxr_ep->shm_cq->fid);
-		if (ret) {
-			EFA_WARN(FI_LOG_EP_CTRL, "Unable to close shm CQ\n");
-			retv = ret;
-		}
-	}
-
 	rxr_ep_free_res(rxr_ep);
 	free(rxr_ep);
 	return retv;
@@ -676,7 +627,7 @@ static int rxr_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 {
 	struct rxr_ep *rxr_ep =
 		container_of(ep_fid, struct rxr_ep, base_ep.util_ep.ep_fid.fid);
-	struct util_cq *cq;
+	struct efa_rdm_cq *cq;
 	struct efa_av *av;
 	struct util_cntr *cntr;
 	struct util_eq *eq;
@@ -703,11 +654,18 @@ static int rxr_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 		}
 		break;
 	case FI_CLASS_CQ:
-		cq = container_of(bfid, struct util_cq, cq_fid.fid);
+		cq = container_of(bfid, struct efa_rdm_cq, util_cq.cq_fid.fid);
 
-		ret = ofi_ep_bind_cq(&rxr_ep->base_ep.util_ep, cq, flags);
+		ret = ofi_ep_bind_cq(&rxr_ep->base_ep.util_ep, &cq->util_cq, flags);
 		if (ret)
 			return ret;
+
+		if (cq->shm_cq) {
+			/* Bind ep with shm provider's cq */
+			ret = fi_ep_bind(rxr_ep->shm_ep, &cq->shm_cq->fid, flags);
+			if (ret)
+				return ret;
+		}
 		break;
 	case FI_CLASS_CNTR:
 		cntr = container_of(bfid, struct util_cntr, cntr_fid.fid);
@@ -956,6 +914,12 @@ static int rxr_ep_ctrl(struct fid *fid, int command, void *arg)
 			if (ret < 0)
 				goto out;
 			fi_setname(&ep->shm_ep->fid, shm_ep_name, shm_ep_name_len);
+
+			/* Bind srx to shm ep */
+			ret = fi_ep_bind(ep->shm_ep, &ep->peer_srx.ep_fid.fid, 0);
+			if (ret)
+				goto out;
+
 			ret = fi_enable(ep->shm_ep);
 			if (ret)
 				goto out;
@@ -1775,14 +1739,6 @@ void rxr_ep_progress_post_internal_rx_pkts(struct rxr_ep *ep)
 
 	ep->efa_rx_pkts_to_post = 0;
 
-	if (ep->shm_ep) {
-		err = rxr_ep_bulk_post_internal_rx_pkts(ep, ep->shm_rx_pkts_to_post, SHM_EP);
-		if (err)
-			goto err_exit;
-
-		ep->shm_rx_pkts_to_post = 0;
-	}
-
 	return;
 
 err_exit:
@@ -1799,10 +1755,6 @@ static inline ssize_t rxr_ep_send_queued_pkts(struct rxr_ep *ep,
 
 	dlist_foreach_container_safe(pkts, struct rxr_pkt_entry,
 				     pkt_entry, entry, tmp) {
-		if (ep->use_shm_for_tx && rxr_ep_get_peer(ep, pkt_entry->addr)->is_local) {
-			dlist_remove(&pkt_entry->entry);
-			continue;
-		}
 
 		/* If send succeeded, pkt_entry->entry will be added
 		 * to peer->outstanding_tx_pkts. Therefore, it must
@@ -2069,75 +2021,6 @@ void rdm_ep_poll_shm_err_cq(struct fid_cq *shm_cq, struct fi_cq_err_entry *cq_er
 	cq_err_entry->prov_errno = FI_EFA_ERR_SHM_INTERNAL_ERROR;
 }
 
-static inline void rdm_ep_poll_shm_cq(struct rxr_ep *ep,
-				      size_t cqe_to_process)
-{
-	struct fi_cq_data_entry cq_entry;
-	struct fi_cq_err_entry cq_err_entry = { 0 };
-	struct rxr_pkt_entry *pkt_entry;
-	fi_addr_t src_addr;
-	ssize_t ret;
-	int i;
-
-	VALGRIND_MAKE_MEM_DEFINED(&cq_entry, sizeof(struct fi_cq_data_entry));
-
-	for (i = 0; i < cqe_to_process; i++) {
-		ret = fi_cq_readfrom(ep->shm_cq, &cq_entry, 1, &src_addr);
-
-		if (ret == -FI_EAGAIN)
-			return;
-
-		if (OFI_UNLIKELY(ret < 0)) {
-			if (ret != -FI_EAVAIL) {
-				efa_eq_write_error(&ep->base_ep.util_ep, -ret, FI_EFA_ERR_SHM_INTERNAL_ERROR);
-				return;
-			}
-
-			rdm_ep_poll_shm_err_cq(ep->shm_cq, &cq_err_entry);
-			if (cq_err_entry.flags & (FI_SEND | FI_READ | FI_WRITE)) {
-				assert(cq_entry.op_context);
-				rxr_pkt_handle_send_error(ep, cq_entry.op_context, cq_err_entry.err, cq_err_entry.prov_errno);
-			} else if (cq_err_entry.flags & FI_RECV) {
-				assert(cq_entry.op_context);
-				rxr_pkt_handle_recv_error(ep, cq_entry.op_context, cq_err_entry.err, cq_err_entry.prov_errno);
-			} else {
-				efa_eq_write_error(&ep->base_ep.util_ep, cq_err_entry.err, cq_err_entry.prov_errno);
-			}
-
-			return;
-		}
-
-		if (OFI_UNLIKELY(ret == 0))
-			return;
-
-		pkt_entry = cq_entry.op_context;
-
-		if (cq_entry.flags & (FI_ATOMIC | FI_REMOTE_CQ_DATA)) {
-			rxr_ep_handle_misc_shm_completion(ep, &cq_entry, src_addr);
-		} else if (cq_entry.flags & (FI_SEND | FI_READ | FI_WRITE)) {
-			rxr_pkt_handle_send_completion(ep, pkt_entry);
-		} else if (cq_entry.flags & (FI_RECV | FI_REMOTE_CQ_DATA)) {
-			pkt_entry->addr = src_addr;
-
-			if (pkt_entry->addr == FI_ADDR_NOTAVAIL) {
-				/*
-				 * Attempt to inject or determine peer address if not available. This usually
-				 * happens when the endpoint receives the first packet from a new peer.
-				 */
-				pkt_entry->addr = rxr_pkt_determine_addr(ep, pkt_entry);
-			}
-
-			pkt_entry->pkt_size = cq_entry.len;
-			assert(pkt_entry->pkt_size > 0);
-			rxr_pkt_handle_recv_completion(ep, pkt_entry, SHM_EP);
-		} else {
-			EFA_WARN(FI_LOG_EP_CTRL,
-				"Unhandled cq type\n");
-			assert(0 && "Unhandled cq type");
-		}
-	}
-}
-
 void rxr_ep_progress_internal(struct rxr_ep *ep)
 {
 	struct ibv_send_wr *bad_wr;
@@ -2151,11 +2034,6 @@ void rxr_ep_progress_internal(struct rxr_ep *ep)
 	/* Poll the EFA completion queue. Restrict poll size
 	 * to avoid CQE flooding and thereby blocking user thread. */
 	rdm_ep_poll_ibv_cq_ex(ep, rxr_env.efa_cq_read_size);
-
-	if (ep->shm_cq) {
-		/* Poll the SHM completion queue */
-		rdm_ep_poll_shm_cq(ep, rxr_env.shm_cq_read_size);
-	}
 
 	rxr_ep_progress_post_internal_rx_pkts(ep);
 
@@ -2413,6 +2291,9 @@ int rxr_endpoint(struct fid_domain *domain, struct fi_info *info,
 	struct rxr_ep *rxr_ep = NULL;
 	struct fi_cq_attr cq_attr;
 	int ret, retv, i;
+	struct fi_peer_srx_context peer_srx_context = {0};
+	struct fi_rx_attr peer_srx_attr = {0};
+	struct fid_ep *peer_srx_ep = NULL;
 
 	rxr_ep = calloc(1, sizeof(*rxr_ep));
 	if (!rxr_ep)
@@ -2432,6 +2313,12 @@ int rxr_endpoint(struct fid_domain *domain, struct fi_info *info,
 	efa_rdm_peer_srx_construct(rxr_ep, &rxr_ep->peer_srx);
 
 	if (efa_domain->shm_domain) {
+		peer_srx_context.srx = &rxr_ep->peer_srx;
+		peer_srx_attr.op_flags |= FI_PEER;
+		ret = fi_srx_context(efa_domain->shm_domain, &peer_srx_attr, &peer_srx_ep, &peer_srx_context);
+		if (ret)
+			goto err_destroy_base_ep;
+
 		assert(!strcmp(efa_domain->shm_info->fabric_attr->name, "shm"));
 		ret = fi_endpoint(efa_domain->shm_domain, efa_domain->shm_info,
 				  &rxr_ep->shm_ep, rxr_ep);
@@ -2516,22 +2403,9 @@ int rxr_endpoint(struct fid_domain *domain, struct fi_info *info,
 		goto err_close_shm_ep;
 	}
 
-	if (efa_domain->shm_domain) {
-		/* Bind ep with shm provider's cq */
-		ret = fi_cq_open(efa_domain->shm_domain, &cq_attr,
-				 &rxr_ep->shm_cq, rxr_ep);
-		if (ret)
-			goto err_close_core_cq;
-
-		ret = fi_ep_bind(rxr_ep->shm_ep, &rxr_ep->shm_cq->fid,
-				 FI_TRANSMIT | FI_RECV);
-		if (ret)
-			goto err_close_shm_cq;
-	}
-
 	ret = rxr_ep_init(rxr_ep);
 	if (ret)
-		goto err_close_shm_cq;
+		goto err_close_core_cq;
 
 	/* Set hmem_p2p_opt */
 	rxr_ep->hmem_p2p_opt = FI_HMEM_P2P_DISABLED;
@@ -2557,7 +2431,7 @@ int rxr_endpoint(struct fid_domain *domain, struct fi_info *info,
 
 	ret = rxr_ep_create_base_ep_ibv_qp(rxr_ep);
 	if (ret)
-		goto err_close_shm_cq;
+		goto err_close_core_cq;
 
 	*ep = &rxr_ep->base_ep.util_ep.ep_fid;
 	(*ep)->msg = &rxr_ops_msg;
@@ -2569,13 +2443,6 @@ int rxr_endpoint(struct fid_domain *domain, struct fi_info *info,
 	(*ep)->cm = &rxr_ep_cm;
 	return 0;
 
-err_close_shm_cq:
-	if (rxr_ep->shm_cq) {
-		retv = fi_close(&rxr_ep->shm_cq->fid);
-		if (retv)
-			EFA_WARN(FI_LOG_CQ, "Unable to close shm cq: %s\n",
-				fi_strerror(-retv));
-	}
 err_close_core_cq:
 	retv = -ibv_destroy_cq(ibv_cq_ex_to_cq(rxr_ep->ibv_cq_ex));
 	if (retv)

--- a/prov/efa/src/rdm/rxr_ep.h
+++ b/prov/efa/src/rdm/rxr_ep.h
@@ -84,7 +84,6 @@ struct rxr_ep {
 	/* shm provider fid */
 	bool use_shm_for_tx;
 	struct fid_ep *shm_ep;
-	struct fid_cq *shm_cq;
 
 	/*
 	 * RxR rx/tx queue sizes. These may be different from the core

--- a/prov/efa/src/rdm/rxr_msg.c
+++ b/prov/efa/src/rdm/rxr_msg.c
@@ -156,7 +156,7 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *ep, struct rxr_op_entry *tx_entry, int u
 
 	if (rtm_type < RXR_EXTRA_REQ_PKT_BEGIN) {
 		/* rtm requires only baseline feature, which peer should always support. */
-		return rxr_pkt_post_req(ep, tx_entry, rtm_type, 0, 0);
+		return rxr_pkt_post_req(ep, tx_entry, rtm_type, 0);
 	}
 
 	/*
@@ -172,7 +172,7 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *ep, struct rxr_op_entry *tx_entry, int u
 	if (!rxr_pkt_req_supported_by_peer(rtm_type, peer))
 		return -FI_EOPNOTSUPP;
 
-	return rxr_pkt_post_req(ep, tx_entry, rtm_type, 0, 0);
+	return rxr_pkt_post_req(ep, tx_entry, rtm_type, 0);
 }
 
 ssize_t rxr_msg_generic_send(struct fid_ep *ep, const struct fi_msg *msg,

--- a/prov/efa/src/rdm/rxr_msg.h
+++ b/prov/efa/src/rdm/rxr_msg.h
@@ -57,7 +57,7 @@ void rxr_msg_update_peer_rx_entry(struct fi_peer_rx_entry *peer_rx_entry,
 	peer_rx_entry->flags = (rx_entry->fi_flags & ~FI_MULTI_RECV);
 	if (rx_entry->desc && rx_entry->desc[0] && ((struct efa_mr *)rx_entry->desc[0])->shm_mr) {
 		memcpy(rx_entry->shm_desc, rx_entry->desc, rx_entry->iov_count * sizeof(void *));
-		rxr_convert_desc_for_shm(rx_entry->iov_count, rx_entry->shm_desc);
+		rxr_get_desc_for_shm(rx_entry->iov_count, rx_entry->desc, rx_entry->shm_desc);
 		peer_rx_entry->desc = rx_entry->shm_desc;
 	} else {
 		peer_rx_entry->desc = NULL;
@@ -79,6 +79,19 @@ void rxr_msg_construct(struct fi_msg *msg, const struct iovec *iov, void **desc,
 	msg->addr = addr;
 	msg->context = context;
 	msg->data = data;
+}
+
+static inline
+void rxr_tmsg_construct(struct fi_msg_tagged *msg, const struct iovec *iov, void **desc,
+		       size_t count, fi_addr_t addr, void *context, uint64_t data, uint64_t tag)
+{
+	msg->msg_iov = iov;
+	msg->desc = desc;
+	msg->iov_count = count;
+	msg->addr = addr;
+	msg->context = context;
+	msg->data = data;
+	msg->tag = tag;
 }
 
 /**

--- a/prov/efa/src/rdm/rxr_op_entry.c
+++ b/prov/efa/src/rdm/rxr_op_entry.c
@@ -715,7 +715,9 @@ void rxr_rx_entry_report_completion(struct rxr_op_entry *rx_entry)
 	struct rxr_ep *ep = rx_entry->ep;
 	struct util_cq *rx_cq = ep->base_ep.util_ep.rx_cq;
 	int ret = 0;
+	uint64_t cq_flags;
 
+	cq_flags = (ep->base_ep.util_ep.rx_msg_flags == FI_COMPLETION) ? 0 : FI_SELECTIVE_COMPLETION;
 	if (OFI_UNLIKELY(rx_entry->cq_entry.len < rx_entry->total_len)) {
 		EFA_WARN(FI_LOG_CQ,
 			"Message truncated! tag: %"PRIu64" incoming message size: %"PRIu64" receiving buffer size: %zu\n",
@@ -747,7 +749,7 @@ void rxr_rx_entry_report_completion(struct rxr_op_entry *rx_entry)
 	}
 
 	if (!(rx_entry->rxr_flags & RXR_RX_ENTRY_RECV_CANCEL) &&
-	    (ofi_need_completion(rxr_rx_flags(ep), rx_entry->fi_flags) ||
+	    (ofi_need_completion(cq_flags, rx_entry->fi_flags) ||
 	     (rx_entry->cq_entry.flags & FI_MULTI_RECV))) {
 		EFA_DBG(FI_LOG_CQ,
 		       "Writing recv completion for rx_entry from peer: %"

--- a/prov/efa/src/rdm/rxr_op_entry.h
+++ b/prov/efa/src/rdm/rxr_op_entry.h
@@ -124,6 +124,7 @@ struct rxr_op_entry {
 	size_t iov_count;
 	struct iovec iov[RXR_IOV_LIMIT];
 	void *desc[RXR_IOV_LIMIT];
+	void *shm_desc[RXR_IOV_LIMIT];
 	struct fid_mr *mr[RXR_IOV_LIMIT];
 
 	size_t rma_iov_count;
@@ -329,6 +330,12 @@ struct rxr_op_entry *rxr_op_entry_of_pkt_entry(struct rxr_pkt_entry *pkt_entry)
  * of the endpoint
  */
 #define RXR_OP_ENTRY_QUEUED_READ 	BIT_ULL(12)
+
+/**
+ * @brief flag to indicate an rx_entry is shared to peer provider's receive context.
+ *
+ */
+#define RXR_RX_ENTRY_FOR_PEER_SRX 	BIT_ULL(13)
 
 void rxr_op_entry_try_fill_desc(struct rxr_op_entry *op_entry, int mr_iov_start, uint64_t access);
 

--- a/prov/efa/src/rdm/rxr_op_entry.h
+++ b/prov/efa/src/rdm/rxr_op_entry.h
@@ -56,11 +56,6 @@ enum rxr_op_comm_type {
 	RXR_RX_RECV,		/* rx_entry large msg recv data pkts */
 };
 
-struct rxr_queued_ctrl_info {
-	int type;
-	int inject;
-};
-
 struct rxr_atomic_hdr {
 	/* atomic_op is different from tx_op */
 	uint32_t atomic_op;
@@ -116,7 +111,7 @@ struct rxr_op_entry {
 	uint64_t total_len;
 
 	enum rxr_op_comm_type state;
-	struct rxr_queued_ctrl_info queued_ctrl;
+	int queued_ctrl_type;
 
 	uint64_t fi_flags;
 	uint16_t rxr_flags;
@@ -173,7 +168,6 @@ struct rxr_op_entry {
 #endif
 
 	size_t efa_outstanding_tx_ops;
-	size_t shm_outstanding_tx_ops;
 
 	/*
 	 * A list of rx_entries tracking FI_MULTI_RECV buffers. An rx_entry of

--- a/prov/efa/src/rdm/rxr_pkt_cmd.h
+++ b/prov/efa/src/rdm/rxr_pkt_cmd.h
@@ -37,13 +37,13 @@
 #include "rxr.h"
 
 ssize_t rxr_pkt_post(struct rxr_ep *ep, struct rxr_op_entry *op_entry,
-		     int pkt_type, bool inject, uint64_t flags);
+		     int pkt_type, uint64_t flags);
 
 ssize_t rxr_pkt_post_or_queue(struct rxr_ep *ep, struct rxr_op_entry *op_entry,
-			      int req_type, bool inject);
+			      int req_type);
 
 ssize_t rxr_pkt_post_req(struct rxr_ep *ep, struct rxr_op_entry *tx_entry,
-			 int req_type, bool inject, uint64_t flags);
+			 int req_type, uint64_t flags);
 
 fi_addr_t rxr_pkt_determine_addr(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
 
@@ -63,8 +63,7 @@ void rxr_pkt_handle_recv_error(struct rxr_ep *ep,
 			       int err, int prov_errno);
 
 void rxr_pkt_handle_recv_completion(struct rxr_ep *ep,
-				    struct rxr_pkt_entry *pkt_entry,
-				    enum rxr_lower_ep_type lower_ep_type);
+				    struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_trigger_handshake(struct rxr_ep *ep,
 				  fi_addr_t addr, struct efa_rdm_peer *peer);

--- a/prov/efa/src/rdm/rxr_pkt_entry.c
+++ b/prov/efa/src/rdm/rxr_pkt_entry.c
@@ -396,11 +396,6 @@ ssize_t rxr_pkt_entry_send(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry,
 #endif
 #endif
 
-	if (pkt_entry->alloc_type == RXR_PKT_FROM_SHM_TX_POOL) {
-		ret = fi_sendv(ep->shm_ep, send->iov, NULL, send->iov_count, peer->shm_fiaddr, pkt_entry);
-		goto out;
-	}
-
 	assert(pkt_entry->send_wr);
 	send_wr = &pkt_entry->send_wr->wr;
 	send_wr->num_sge = send->iov_count;
@@ -437,7 +432,6 @@ ssize_t rxr_pkt_entry_send(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry,
 
 	ret = efa_rdm_ep_post_flush(ep, &bad_wr);
 
-out:
 	if (OFI_UNLIKELY(ret)) {
 		return ret;
 	}

--- a/prov/efa/src/rdm/rxr_pkt_entry.c
+++ b/prov/efa/src/rdm/rxr_pkt_entry.c
@@ -179,6 +179,9 @@ void rxr_pkt_entry_release_rx(struct rxr_ep *ep,
 {
 	assert(pkt_entry->next == NULL);
 
+	if (pkt_entry->alloc_type == RXR_PKT_FROM_PEER_SRX)
+		return;
+
 	if (ep->use_zcpy_rx && pkt_entry->alloc_type == RXR_PKT_FROM_USER_BUFFER)
 		return;
 
@@ -229,7 +232,7 @@ void rxr_pkt_entry_copy(struct rxr_ep *ep,
  * Packets from the EFA RX pool will be copied into a separate buffer not
  * registered with the device (if this option is enabled) so that we can repost
  * the registered buffer again to keep the EFA RX queue full. Packets from the
- * SHM RX pool will also be copied to reuse the unexpected message pool.
+ * SHM RX pool and peer srx ops will also be copied to reuse the unexpected message pool.
  *
  * @param[in]     ep  the end point
  * @param[in,out] pkt_entry_ptr unexpected packet, if this packet is copied to

--- a/prov/efa/src/rdm/rxr_pkt_entry.c
+++ b/prov/efa/src/rdm/rxr_pkt_entry.c
@@ -187,8 +187,6 @@ void rxr_pkt_entry_release_rx(struct rxr_ep *ep,
 
 	if (pkt_entry->alloc_type == RXR_PKT_FROM_EFA_RX_POOL) {
 		ep->efa_rx_pkts_to_post++;
-	} else if (pkt_entry->alloc_type == RXR_PKT_FROM_SHM_RX_POOL) {
-		ep->shm_rx_pkts_to_post++;
 	} else if (pkt_entry->alloc_type == RXR_PKT_FROM_READ_COPY_POOL) {
 		assert(ep->rx_readcopy_pkt_pool_used > 0);
 		ep->rx_readcopy_pkt_pool_used--;
@@ -249,8 +247,7 @@ struct rxr_pkt_entry *rxr_pkt_get_unexp(struct rxr_ep *ep,
 
 	type = (*pkt_entry_ptr)->alloc_type;
 
-	if (rxr_env.rx_copy_unexp && (type == RXR_PKT_FROM_EFA_RX_POOL ||
-				      type == RXR_PKT_FROM_SHM_RX_POOL)) {
+	if (rxr_env.rx_copy_unexp && (type == RXR_PKT_FROM_EFA_RX_POOL)) {
 		unexp_pkt_entry = rxr_pkt_entry_clone(ep, ep->rx_unexp_pkt_pool,
 						      RXR_PKT_FROM_UNEXP_POOL,
 						      *pkt_entry_ptr);
@@ -386,7 +383,7 @@ ssize_t rxr_pkt_entry_send(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry,
 		send->iov_count = 1;
 		send->iov[0].iov_base = pkt_entry->wiredata;
 		send->iov[0].iov_len = pkt_entry->pkt_size;
-		send->desc[0] = (pkt_entry->alloc_type == RXR_PKT_FROM_SHM_TX_POOL) ? NULL : pkt_entry->mr;
+		send->desc[0] = pkt_entry->mr;
 	}
 
 #if ENABLE_DEBUG
@@ -463,39 +460,33 @@ int rxr_pkt_entry_read(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry,
 	struct efa_qp *qp;
 	struct efa_conn *conn;
 	struct ibv_sge sge;
-	bool self_comm;
 	int err = 0;
 
 	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
-	if (peer && peer->is_local && ep->use_shm_for_tx) {
-		err = fi_read(ep->shm_ep, local_buf, len, efa_mr_get_shm_desc(desc), peer->shm_fiaddr, remote_buf, remote_key, pkt_entry);
+	if (peer == NULL)
+		pkt_entry->flags |= RXR_PKT_ENTRY_LOCAL_READ;
+
+	qp = ep->base_ep.qp;
+	ibv_wr_start(qp->ibv_qp_ex);
+	qp->ibv_qp_ex->wr_id = (uintptr_t)pkt_entry;
+	ibv_wr_rdma_read(qp->ibv_qp_ex, remote_key, remote_buf);
+
+	sge.addr = (uint64_t)local_buf;
+	sge.length = len;
+	sge.lkey = ((struct efa_mr *)desc)->ibv_mr->lkey;
+
+	ibv_wr_set_sge_list(qp->ibv_qp_ex, 1, &sge);
+	if (peer == NULL) {
+		ibv_wr_set_ud_addr(qp->ibv_qp_ex, ep->base_ep.self_ah,
+				   qp->qp_num, qp->qkey);
 	} else {
-		self_comm = (peer == NULL);
-		if (self_comm)
-			pkt_entry->flags |= RXR_PKT_ENTRY_LOCAL_READ;
-
-		qp = ep->base_ep.qp;
-		ibv_wr_start(qp->ibv_qp_ex);
-		qp->ibv_qp_ex->wr_id = (uintptr_t)pkt_entry;
-		ibv_wr_rdma_read(qp->ibv_qp_ex, remote_key, remote_buf);
-
-		sge.addr = (uint64_t)local_buf;
-		sge.length = len;
-		sge.lkey = ((struct efa_mr *)desc)->ibv_mr->lkey;
-
-		ibv_wr_set_sge_list(qp->ibv_qp_ex, 1, &sge);
-		if (self_comm) {
-			ibv_wr_set_ud_addr(qp->ibv_qp_ex, ep->base_ep.self_ah,
-					   qp->qp_num, qp->qkey);
-		} else {
-			conn = efa_av_addr_to_conn(ep->base_ep.av, pkt_entry->addr);
-			assert(conn && conn->ep_addr);
-			ibv_wr_set_ud_addr(qp->ibv_qp_ex, conn->ah->ibv_ah,
-					   conn->ep_addr->qpn, conn->ep_addr->qkey);
-		}
-
-		err = ibv_wr_complete(qp->ibv_qp_ex);
+		conn = efa_av_addr_to_conn(ep->base_ep.av, pkt_entry->addr);
+		assert(conn && conn->ep_addr);
+		ibv_wr_set_ud_addr(qp->ibv_qp_ex, conn->ah->ibv_ah,
+				   conn->ep_addr->qpn, conn->ep_addr->qkey);
 	}
+
+	err = ibv_wr_complete(qp->ibv_qp_ex);
 
 	if (OFI_UNLIKELY(err))
 		return err;
@@ -538,49 +529,45 @@ int rxr_pkt_entry_write(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry,
 	rma_context_pkt = (struct rxr_rma_context_pkt *)pkt_entry->wiredata;
 	rma_context_pkt->seg_size = len;
 
-	if (peer && peer->is_local && ep->use_shm_for_tx) {
-		err = fi_write(ep->shm_ep, local_buf, len, efa_mr_get_shm_desc(desc), peer->shm_fiaddr, remote_buf, remote_key, pkt_entry);
-	} else {
-		assert(((struct efa_mr *)desc)->ibv_mr);
+	assert(((struct efa_mr *)desc)->ibv_mr);
 
-		self_comm = (peer == NULL);
-		if (self_comm)
-			pkt_entry->flags |= RXR_PKT_ENTRY_LOCAL_WRITE;
+	self_comm = (peer == NULL);
+	if (self_comm)
+		pkt_entry->flags |= RXR_PKT_ENTRY_LOCAL_WRITE;
 
-		qp = ep->base_ep.qp;
-		ibv_wr_start(qp->ibv_qp_ex);
-		qp->ibv_qp_ex->wr_id = (uintptr_t)pkt_entry;
+	qp = ep->base_ep.qp;
+	ibv_wr_start(qp->ibv_qp_ex);
+	qp->ibv_qp_ex->wr_id = (uintptr_t)pkt_entry;
 
-		if (tx_entry->fi_flags & FI_REMOTE_CQ_DATA) {
-			/* assert that we are sending the entire buffer as a
+	if (tx_entry->fi_flags & FI_REMOTE_CQ_DATA) {
+		/* assert that we are sending the entire buffer as a
 			   single IOV when immediate data is also included. */
-			assert( len == tx_entry->bytes_write_total_len );
-			ibv_wr_rdma_write_imm(qp->ibv_qp_ex, remote_key,
-				remote_buf, tx_entry->cq_entry.data);
-		} else {
-			ibv_wr_rdma_write(qp->ibv_qp_ex, remote_key, remote_buf);
-		}
+		assert(len == tx_entry->bytes_write_total_len);
+		ibv_wr_rdma_write_imm(qp->ibv_qp_ex, remote_key, remote_buf,
+				      tx_entry->cq_entry.data);
+	} else {
+		ibv_wr_rdma_write(qp->ibv_qp_ex, remote_key, remote_buf);
+	}
 
-		sge.addr = (uint64_t)local_buf;
-		sge.length = len;
-		sge.lkey = ((struct efa_mr *)desc)->ibv_mr->lkey;
+	sge.addr = (uint64_t)local_buf;
+	sge.length = len;
+	sge.lkey = ((struct efa_mr *)desc)->ibv_mr->lkey;
 
-		/* As an optimization, we should consider implementing multiple-
+	/* As an optimization, we should consider implementing multiple-
 		   iov writes using an IBV wr with multiple sge entries.
 		   For now, each WR contains only one sge. */
-		ibv_wr_set_sge_list(qp->ibv_qp_ex, 1, &sge);
-		if (self_comm) {
-			ibv_wr_set_ud_addr(qp->ibv_qp_ex, ep->base_ep.self_ah,
-					   qp->qp_num, qp->qkey);
-		} else {
-			conn = efa_av_addr_to_conn(ep->base_ep.av, pkt_entry->addr);
-			assert(conn && conn->ep_addr);
-			ibv_wr_set_ud_addr(qp->ibv_qp_ex, conn->ah->ibv_ah,
-					   conn->ep_addr->qpn, conn->ep_addr->qkey);
-		}
-
-		err = ibv_wr_complete(qp->ibv_qp_ex);
+	ibv_wr_set_sge_list(qp->ibv_qp_ex, 1, &sge);
+	if (self_comm) {
+		ibv_wr_set_ud_addr(qp->ibv_qp_ex, ep->base_ep.self_ah,
+				   qp->qp_num, qp->qkey);
+	} else {
+		conn = efa_av_addr_to_conn(ep->base_ep.av, pkt_entry->addr);
+		assert(conn && conn->ep_addr);
+		ibv_wr_set_ud_addr(qp->ibv_qp_ex, conn->ah->ibv_ah,
+				   conn->ep_addr->qpn, conn->ep_addr->qkey);
 	}
+
+	err = ibv_wr_complete(qp->ibv_qp_ex);
 
 	if (OFI_UNLIKELY(err))
 		return err;
@@ -637,27 +624,6 @@ ssize_t rxr_pkt_entry_recv(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry,
 	ep->base_ep.recv_more_wr_tail = &ep->base_ep.recv_more_wr_head;
 
 	return err;
-}
-
-ssize_t rxr_pkt_entry_inject(struct rxr_ep *ep,
-			     struct rxr_pkt_entry *pkt_entry,
-			     fi_addr_t addr)
-{
-	struct efa_rdm_peer *peer;
-	ssize_t ret;
-
-	/* currently only EOR packet is injected using shm ep */
-	peer = rxr_ep_get_peer(ep, addr);
-	assert(peer);
-
-	assert(ep->use_shm_for_tx && peer->is_local);
-	ret = fi_inject(ep->shm_ep, pkt_entry->wiredata, pkt_entry->pkt_size, peer->shm_fiaddr);
-
-	if (OFI_UNLIKELY(ret))
-		return ret;
-
-	rxr_ep_record_tx_op_submitted(ep, pkt_entry);
-	return 0;
 }
 
 /*

--- a/prov/efa/src/rdm/rxr_pkt_entry.h
+++ b/prov/efa/src/rdm/rxr_pkt_entry.h
@@ -52,9 +52,10 @@ enum rxr_pkt_entry_alloc_type {
 	RXR_PKT_FROM_SHM_TX_POOL,     /**< packet is allocated from `ep->shm_tx_pkt_pool` */
 	RXR_PKT_FROM_SHM_RX_POOL,     /**< packet is allocated from `ep->shm_rx_pkt_pool` */
 	RXR_PKT_FROM_UNEXP_POOL,      /**< packet is allocated from `ep->rx_unexp_pkt_pool` */
-	RXR_PKT_FROM_OOO_POOL,	      /**< packet is allocated from e`p->rx_ooo_pkt_pool` */
+	RXR_PKT_FROM_OOO_POOL,	      /**< packet is allocated from `ep->rx_ooo_pkt_pool` */
 	RXR_PKT_FROM_USER_BUFFER,     /**< packet is from user provided buffer` */
 	RXR_PKT_FROM_READ_COPY_POOL,  /**< packet is allocated from `ep->rx_readcopy_pkt_pool` */
+	RXR_PKT_FROM_PEER_SRX,    /**< packet is created in flight from peer SRX ops */
 };
 
 struct rxr_pkt_sendv {
@@ -265,6 +266,9 @@ void rxr_pkt_entry_release_tx(struct rxr_ep *ep,
 
 void rxr_pkt_entry_release_rx(struct rxr_ep *ep,
 			      struct rxr_pkt_entry *pkt_entry);
+
+void rxr_pkt_entry_release(struct rxr_ep *ep,
+			   struct rxr_pkt_entry *pkt_entry);
 
 void rxr_pkt_entry_append(struct rxr_pkt_entry *dst,
 			  struct rxr_pkt_entry *src);

--- a/prov/efa/src/rdm/rxr_pkt_entry.h
+++ b/prov/efa/src/rdm/rxr_pkt_entry.h
@@ -49,8 +49,6 @@
 enum rxr_pkt_entry_alloc_type {
 	RXR_PKT_FROM_EFA_TX_POOL = 1, /**< packet is allocated from `ep->efa_tx_pkt_pool` */
 	RXR_PKT_FROM_EFA_RX_POOL,     /**< packet is allocated from `ep->efa_rx_pkt_pool` */
-	RXR_PKT_FROM_SHM_TX_POOL,     /**< packet is allocated from `ep->shm_tx_pkt_pool` */
-	RXR_PKT_FROM_SHM_RX_POOL,     /**< packet is allocated from `ep->shm_rx_pkt_pool` */
 	RXR_PKT_FROM_UNEXP_POOL,      /**< packet is allocated from `ep->rx_unexp_pkt_pool` */
 	RXR_PKT_FROM_OOO_POOL,	      /**< packet is allocated from `ep->rx_ooo_pkt_pool` */
 	RXR_PKT_FROM_USER_BUFFER,     /**< packet is from user provided buffer` */
@@ -128,12 +126,12 @@ struct efa_recv_wr {
  * 
  * For SHM, a TX operation can be send/read/write/atomic.
  * 
- * When used as context of request, packet was allocated from endpoint's shm/efa_tx/rx_pool.
+ * When used as context of request, packet was allocated from endpoint's efa_tx/rx_pool.
  * When the request is to EFA device, the packet's memory must be registered to EFA device,
  * and the memory registration must be stored as the `mr` field of packet entry.
  * 
  * Second, packet entries can be used to store received packet entries that is
- * unexpected or out-of-order. This is because the efa/shm_rx_pkt_pool's size is fixed,
+ * unexpected or out-of-order. This is because the efa_rx_pkt_pool's size is fixed,
  * therefore it cannot be used to hold unexpected/out-of-order packets. When an unexpected/out-of-order
  * packet is received, a new packet entry will be cloned from unexpected/ooo_pkt_pool.
  * The old packet will be released then reposted to EFA device or SHM. The new packet
@@ -291,10 +289,6 @@ int rxr_pkt_entry_read(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry,
 ssize_t rxr_pkt_entry_recv(struct rxr_ep *ep,
 			   struct rxr_pkt_entry *pkt_entry, void **desc,
 			   uint64_t flags);
-
-ssize_t rxr_pkt_entry_inject(struct rxr_ep *ep,
-			     struct rxr_pkt_entry *pkt_entry,
-			     fi_addr_t addr);
 
 int rxr_pkt_entry_write(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry,
 		       void *local_buf, size_t len, void *desc,

--- a/prov/efa/src/rdm/rxr_pkt_pool.c
+++ b/prov/efa/src/rdm/rxr_pkt_pool.c
@@ -43,8 +43,6 @@ struct rxr_pkt_pool_inf {
 struct rxr_pkt_pool_inf RXR_PKT_POOL_INF_LIST[] = {
 	[RXR_PKT_FROM_EFA_TX_POOL] = {true /* need memory registration */, true /* need sendv */, true /* need send_wr */},
 	[RXR_PKT_FROM_EFA_RX_POOL] = {true /* need memory registration */, false /* no sendv */, false /* no send_wr */},
-	[RXR_PKT_FROM_SHM_TX_POOL] = {false /* no memory registration */, true /* need sendv */, false /* no send_wr */},
-	[RXR_PKT_FROM_SHM_RX_POOL] = {false /* no memory registration */, false /* no sendv */, false /* no send_wr */},
 	[RXR_PKT_FROM_UNEXP_POOL] = {false /* no memory registration */, false /* no sendv */, false /* no send_wr */},
 	[RXR_PKT_FROM_OOO_POOL] = {false /* no memory registration */, false /* no sendv */, false /* no send_wr */},
 	[RXR_PKT_FROM_READ_COPY_POOL] = {true /* no memory registration */, false /* no sendv */, false /* no send_wr */},

--- a/prov/efa/src/rdm/rxr_pkt_type_data.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_data.c
@@ -176,7 +176,7 @@ void rxr_pkt_proc_data(struct rxr_ep *ep,
 		return;
 
 	if (!op_entry->window) {
-		err = rxr_pkt_post_or_queue(ep, op_entry, RXR_CTS_PKT, 0);
+		err = rxr_pkt_post_or_queue(ep, op_entry, RXR_CTS_PKT);
 		if (err) {
 			EFA_WARN(FI_LOG_CQ, "post CTS packet failed!\n");
 			rxr_rx_entry_handle_error(op_entry, -err, FI_EFA_ERR_PKT_POST);

--- a/prov/efa/src/rdm/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_misc.c
@@ -111,10 +111,7 @@ ssize_t rxr_pkt_post_handshake(struct rxr_ep *ep, struct efa_rdm_peer *peer)
 	ssize_t ret;
 
 	addr = peer->efa_fiaddr;
-	if (peer->is_local && ep->use_shm_for_tx)
-		pkt_entry = rxr_pkt_entry_alloc(ep, ep->shm_tx_pkt_pool, RXR_PKT_FROM_SHM_TX_POOL);
-	else
-		pkt_entry = rxr_pkt_entry_alloc(ep, ep->efa_tx_pkt_pool, RXR_PKT_FROM_EFA_TX_POOL);
+	pkt_entry = rxr_pkt_entry_alloc(ep, ep->efa_tx_pkt_pool, RXR_PKT_FROM_EFA_TX_POOL);
 	if (OFI_UNLIKELY(!pkt_entry))
 		return -FI_EAGAIN;
 
@@ -442,7 +439,7 @@ void rxr_pkt_handle_rma_read_completion(struct rxr_ep *ep,
 			rxr_tracepoint(read_completed,
 				    rx_entry->msg_id, (size_t) rx_entry->cq_entry.op_context,
 				    rx_entry->total_len, (size_t) rx_entry);
-			err = rxr_pkt_post_or_queue(ep, rx_entry, RXR_EOR_PKT, false);
+			err = rxr_pkt_post_or_queue(ep, rx_entry, RXR_EOR_PKT);
 			if (OFI_UNLIKELY(err)) {
 				EFA_WARN(FI_LOG_CQ,
 					"Posting of EOR failed! err=%s(%d)\n",

--- a/prov/efa/src/rdm/rxr_pkt_type_req.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_req.c
@@ -1456,7 +1456,7 @@ ssize_t rxr_pkt_proc_matched_rtm(struct rxr_ep *ep,
 	ep->pending_recv_counter++;
 #endif
 	rx_entry->state = RXR_RX_RECV;
-	ret = rxr_pkt_post_or_queue(ep, rx_entry, RXR_CTS_PKT, 0);
+	ret = rxr_pkt_post_or_queue(ep, rx_entry, RXR_CTS_PKT);
 
 	return ret;
 }
@@ -2012,7 +2012,7 @@ void rxr_pkt_handle_longcts_rtw_recv(struct rxr_ep *ep,
 #endif
 	rx_entry->state = RXR_RX_RECV;
 	rx_entry->tx_id = tx_id;
-	err = rxr_pkt_post_or_queue(ep, rx_entry, RXR_CTS_PKT, 0);
+	err = rxr_pkt_post_or_queue(ep, rx_entry, RXR_CTS_PKT);
 	if (OFI_UNLIKELY(err)) {
 		EFA_WARN(FI_LOG_CQ, "Cannot post CTS packet\n");
 		rxr_rx_entry_handle_error(rx_entry, -err, FI_EFA_ERR_PKT_POST);
@@ -2161,7 +2161,7 @@ void rxr_pkt_handle_rtr_recv(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 	rx_entry->cq_entry.buf = rx_entry->iov[0].iov_base;
 	rx_entry->total_len = rx_entry->cq_entry.len;
 
-	err = rxr_pkt_post_or_queue(ep, rx_entry, RXR_READRSP_PKT, 0);
+	err = rxr_pkt_post_or_queue(ep, rx_entry, RXR_READRSP_PKT);
 	if (OFI_UNLIKELY(err)) {
 		EFA_WARN(FI_LOG_CQ, "Posting of readrsp packet failed! err=%ld\n", err);
 		efa_eq_write_error(&ep->base_ep.util_ep, FI_EIO, FI_EFA_ERR_PKT_POST);
@@ -2434,7 +2434,7 @@ int rxr_pkt_proc_dc_write_rta(struct rxr_ep *ep,
 		return ret;
 	}
 
-	err = rxr_pkt_post_or_queue(ep, rx_entry, RXR_RECEIPT_PKT, 0);
+	err = rxr_pkt_post_or_queue(ep, rx_entry, RXR_RECEIPT_PKT);
 	if (OFI_UNLIKELY(err)) {
 		EFA_WARN(FI_LOG_CQ,
 			"Posting of receipt packet failed! err=%s\n",
@@ -2518,7 +2518,7 @@ int rxr_pkt_proc_fetch_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 		offset += rx_entry->iov[i].iov_len;
 	}
 
-	err = rxr_pkt_post_or_queue(ep, rx_entry, RXR_ATOMRSP_PKT, 0);
+	err = rxr_pkt_post_or_queue(ep, rx_entry, RXR_ATOMRSP_PKT);
 	if (OFI_UNLIKELY(err))
 		rxr_rx_entry_handle_error(rx_entry, -err, FI_EFA_ERR_PKT_POST);
 
@@ -2600,7 +2600,7 @@ int rxr_pkt_proc_compare_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 		}
 	}
 
-	err = rxr_pkt_post_or_queue(ep, rx_entry, RXR_ATOMRSP_PKT, 0);
+	err = rxr_pkt_post_or_queue(ep, rx_entry, RXR_ATOMRSP_PKT);
 	if (OFI_UNLIKELY(err)) {
 		efa_eq_write_error(&ep->base_ep.util_ep, FI_EIO, FI_EFA_ERR_PKT_POST);
 		ofi_buf_free(rx_entry->atomrsp_data);

--- a/prov/efa/src/rdm/rxr_pkt_type_req.h
+++ b/prov/efa/src/rdm/rxr_pkt_type_req.h
@@ -431,4 +431,9 @@ int rxr_pkt_proc_compare_rta(struct rxr_ep *ep,
 
 void rxr_pkt_handle_rta_recv(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
 
+struct rxr_op_entry *rxr_pkt_get_msgrtm_rx_entry(struct rxr_ep *ep,
+						 struct rxr_pkt_entry **pkt_entry_ptr);
+
+struct rxr_op_entry *rxr_pkt_get_tagrtm_rx_entry(struct rxr_ep *ep,
+						 struct rxr_pkt_entry **pkt_entry_ptr);
 #endif

--- a/prov/efa/src/rdm/rxr_read.h
+++ b/prov/efa/src/rdm/rxr_read.h
@@ -78,7 +78,6 @@ enum rxr_read_entry_state {
 struct rxr_read_entry {
 	enum rxr_x_entry_type type;
 	int read_id;
-	enum rxr_lower_ep_type lower_ep_type;
 
 	void *context;
 	enum rxr_read_context_type context_type;
@@ -102,8 +101,7 @@ struct rxr_read_entry {
 	struct dlist_entry pending_entry;
 };
 
-struct rxr_read_entry *rxr_read_alloc_entry(struct rxr_ep *ep, struct rxr_op_entry *x_entry,
-					    enum rxr_lower_ep_type lower_ep_type);
+struct rxr_read_entry *rxr_read_alloc_entry(struct rxr_ep *ep, struct rxr_op_entry *x_entry);
 
 void rxr_read_release_entry(struct rxr_ep *ep, struct rxr_read_entry *read_entry);
 


### PR DESCRIPTION
This PR contains a series of commits that allow efa use shm as a peer provider to offload the intra-node communication.