### PR TITLE
[v1.18.x] unit/setopt_test: fix data type of "op"

### DIFF
--- a/fabtests/unit/setopt_test.c
+++ b/fabtests/unit/setopt_test.c
@@ -122,7 +122,7 @@ static void usage(char *name)
 
 int main(int argc, char **argv)
 {
-	char op;
+	int op;
 	struct test_entry test_array[] = {
 		TEST_ENTRY(test_setopt_cuda_api_permmitted, "Test FI_OPT_CUDA_API_PERMITTED"),
 		TEST_ENTRY(NULL, ""),


### PR DESCRIPTION
"op" is used to store the return of getopt(), and should be "int". Current code has it as a "char", which can cause hang. This patch fixed the issue.

Signed-off-by: Wei Zhang <wzam@amazon.com>
(cherry picked from commit 8a3bf0a7c9b1f1903ed8d2268261ef8674e2df3f)