### PR TITLE
Opx upstream for 1.18.x

### DIFF
--- a/prov/opx/Makefile.include
+++ b/prov/opx/Makefile.include
@@ -134,6 +134,7 @@ noinst_HEADERS = \
 	$(top_srcdir)/prov/opx/include/rdma/opx/fi_opx_hfi1_progress.h \
 	$(top_srcdir)/prov/opx/include/rdma/opx/fi_opx_progress.h \
 	$(top_srcdir)/prov/opx/include/rdma/opx/fi_opx_tid_domain.h \
+	$(top_srcdir)/prov/opx/include/rdma/opx/fi_opx_match.h \
 	$(top_srcdir)/prov/opx/include/rdma/fi_direct_trigger.h \
 	$(top_srcdir)/prov/opx/include/rdma/fi_direct_atomic.h \
 	$(top_srcdir)/prov/opx/include/rdma/fi_direct.h \

--- a/prov/opx/include/opa_udebug.h
+++ b/prov/opx/include/opa_udebug.h
@@ -6,7 +6,7 @@
   GPL LICENSE SUMMARY
 
   Copyright(c) 2015 Intel Corporation.
-  Copyright(c) 2021 Cornelis Networks.
+  Copyright(c) 2021-2023 Cornelis Networks.
 
   This program is free software; you can redistribute it and/or modify
   it under the terms of version 2 of the GNU General Public License as
@@ -23,7 +23,7 @@
   BSD LICENSE
 
   Copyright(c) 2015 Intel Corporation.
-  Copyright(c) 2021 Cornelis Networks.
+  Copyright(c) 2021-2023 Cornelis Networks.
 
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions
@@ -54,11 +54,13 @@
 */
 
 /* Copyright (c) 2003-2014 Intel Corporation. All rights reserved. */
+/* Copyright (C) 2021-2023 by Cornelis Networks.                    */
 
 #ifndef OPA_UDEBUG_H
 #define OPA_UDEBUG_H
 
 #include <stdio.h>
+#include "rdma/providers/fi_log.h"
 #include "rdma/opx/fi_opx.h"
 
 #define _HFI_UNIT_ERROR(unit, fmt, ...) \
@@ -119,5 +121,111 @@
 	do { if (fi_opx_global.prov) { \
 		FI_DBG(fi_opx_global.prov, FI_LOG_FABRIC, fmt, ##__VA_ARGS__); \
 	} } while (0)
+
+
+/******************** Logging best practices for OPX *********************************
+--Use FI_WARN() to log messages that are important and need the most visiblity
+	* These logs will be seen on any build of libfabric where FI_LOG_LEVEL is
+	set to anything valid.
+	FI_WARN() has a slight performance hit and should not be used in the crit path
+
+--Use FI_INFO() to log messages that are useful information but not repetitive
+	* These logs will be seen on any build of libfabric where FI_LOG_LEVEL is
+	set to info or debug (not warn)
+	FI_INFO() has a slight performance hit and should not be used in the crit path
+
+--Use OPX_LOG_OBSERVABLE() to log messages that may be documented for service
+	* These messages may be monitored by external supervisors, log harvesters, 
+	or other customer applications, so don't change their text or format without 
+	checking to see that you're not breaking something.  This is just a FI_INFO() 
+	in a 'special' wrapper so devs are warned.
+	* Do not use this on the crit path or for overly repetitive messages
+
+--Use OPX_LOG() or one of its subclasses to log verbose messages on high-use paths.  
+    This enables developers to quickly disable versbose logs that aren't needed 
+	when debugging.  These can also be used on the non-critical path, however 
+	these messages probably won't show up without a special/debug build.
+*************************************************************************************/
+#define OPX_LOG_OBSERVABLE(subsystem, ...)	   	 \
+	FI_INFO(fi_opx_global.prov, subsystem, __VA_ARGS__);
+
+
+/************************************************************************************
+ * To enable one or more sub-classes of verbose logs in OPX, uncomment 
+ * at least one of the following #define OPX_ENABLE_LOG*** lines and re-compile 
+ * libfabric, OR use a -D parm to the compliler to define one more of the OPX verbose 
+ * log class #defines below. Verbose logging will then be enabled on all build types
+ * 
+ * IF this is a debug type of build, AND none of the verbose log classes are enabled, 
+ * THEN enable them all.  This is the default libfabric behavior, debug builds get 
+ * all verbose logs.  However, this can get quite large when processing  traffic, 
+ * therefore these log classes have been provided to reduce the volume of output.
+ ************************************************************************************/
+
+//#define OPX_ENABLE_LOG			//Enable verbose logs for general Opx 
+//#define OPX_ENABLE_LOG_SHM		//Enable verbose logs for Shared-memory (Intranode)
+//#define OPX_ENABLE_LOG_PKT		//Enable verbose logs for Packet processing/packet headers
+//#define OPX_ENABLE_LOG_REL		//Enable verbose logs for Reliablity
+
+//Debug builds with no verbose logging #define get all verbose logs (default libfabric behavior)
+#if					\
+defined(ENABLE_DEBUG) && ENABLE_DEBUG &&	\
+!defined(OPX_ENABLE_LOG) &&		\
+!defined(OPX_ENABLE_LOG_SHM) &&		\
+!defined(OPX_ENABLE_LOG_PKT) &&		\
+!defined(OPX_ENABLE_LOG_REL)	
+	#define OPX_ENABLE_LOG
+	#define OPX_ENABLE_LOG_SHM
+	#define OPX_ENABLE_LOG_PKT
+	#define OPX_ENABLE_LOG_REL
+#endif
+
+/* 
+ * OPX_LOG() will by default be a nop/no code on optimzed builds and not affect performance.  
+ * Use OPX_LOG() to safely handle message logging on critical/high use paths.
+ * This log class is for general messages in Opx that don't fit into a particular class
+*/
+#ifdef OPX_ENABLE_LOG
+#define OPX_LOG(level, subsystem, ...)	    \
+	FI_LOG(fi_opx_global.prov, level, subsystem, __VA_ARGS__)
+#else
+#define OPX_LOG(level, subsystem, ...)
+#endif
+
+/* 
+ * OPX_LOG_SHM() will by default be a nop/no code on optimzed builds and not affect performance.  
+ * Use OPX_LOG_SHM() to safely handle message logging on critical/high use paths.
+ * This log class is for shared memory/intranode tracing
+*/
+#ifdef OPX_ENABLE_LOG_SHM
+#define OPX_LOG_SHM(level, subsystem, ...)	    \
+	FI_LOG(fi_opx_global.prov, level, subsystem, __VA_ARGS__)
+#else
+#define OPX_LOG_SHM(level, subsystem, ...)
+#endif
+
+/* 
+ * OPX_LOG_PKT() will by default be a nop/no code on optimzed builds and not affect performance.  
+ * Use OPX_LOG_PKT() to safely handle message logging on critical/high use paths.
+ * This log class is for packet processing tracing and packet header debug
+*/
+#ifdef OPX_ENABLE_LOG_PKT
+#define OPX_LOG_PKT(level, subsystem, ...)	    \
+	FI_LOG(fi_opx_global.prov, level, subsystem, __VA_ARGS__)
+#else
+#define OPX_LOG_PKT(level, subsystem, ...)
+#endif
+
+/* 
+ * OPX_LOG_REL() will by default be a nop/no code on optimzed builds and not affect performance.  
+ * Use OPX_LOG_REL() to safely handle message logging on critical/high use paths.
+ * This log class is for tracing issues with reliability
+*/
+#ifdef OPX_ENABLE_LOG_REL
+#define OPX_LOG_REL(level, subsystem, ...)	    \
+	FI_LOG(fi_opx_global.prov, level, subsystem, __VA_ARGS__)
+#else
+#define OPX_LOG_REL(level, subsystem, ...)
+#endif
 
 #endif /* OPA_UDEBUG_H */

--- a/prov/opx/include/rdma/opx/fi_opx_debug_counters.h
+++ b/prov/opx/include/rdma/opx/fi_opx_debug_counters.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Cornelis Networks.
+ * Copyright (C) 2021-2023 Cornelis Networks.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -42,6 +42,7 @@
 	#define OPX_DEBUG_COUNTERS_RELIABILITY
 	#define OPX_DEBUG_COUNTERS_SDMA
 	#define OPX_DEBUG_COUNTERS_EXPECTED_RECEIVE
+	#define OPX_DEBUG_COUNTERS_MATCH
 #endif
 
 struct fi_opx_debug_counters {
@@ -98,11 +99,11 @@ struct fi_opx_debug_counters {
 		uint64_t	tid_updates;
 		uint64_t	tid_replays;
 		uint64_t	rts_fallback_eager;
-		uint64_t        tid_buckets[4];
-		uint64_t        first_tidpair_minlen;
-		uint64_t        first_tidpair_maxlen;
-		uint64_t        first_tidpair_minoffset;
-		uint64_t        first_tidpair_maxoffset;
+		uint64_t	tid_buckets[4];
+		uint64_t	first_tidpair_minlen;
+		uint64_t	first_tidpair_maxlen;
+		uint64_t	first_tidpair_minoffset;
+		uint64_t	first_tidpair_maxoffset;
 		uint64_t	generation_wrap;
 	} expected_receive;
 
@@ -111,6 +112,31 @@ struct fi_opx_debug_counters {
 		uint64_t	replay_cts;
 		uint64_t	replay_rzv;
 	} reliability;
+
+	struct {
+		uint64_t	total_searches;
+		uint64_t	total_misses;
+		uint64_t	total_hits;
+		uint64_t	total_not_found;
+
+		uint64_t	default_searches;
+		uint64_t	default_misses;
+		uint64_t	default_hits;
+		uint64_t	default_not_found;
+		uint64_t	default_max_length;
+
+		uint64_t	ue_hash_linear_searches;
+		uint64_t	ue_hash_linear_misses;
+		uint64_t	ue_hash_linear_hits;
+		uint64_t	ue_hash_linear_not_found;
+		uint64_t	ue_hash_linear_max_length;
+
+		uint64_t	ue_hash_tag_searches;
+		uint64_t	ue_hash_tag_misses;
+		uint64_t	ue_hash_tag_hits;
+		uint64_t	ue_hash_tag_not_found;
+		uint64_t	ue_hash_tag_max_length;
+	} match;
 };
 
 static inline
@@ -138,6 +164,7 @@ void fi_opx_debug_counters_print_counter(pid_t pid, char *name, uint64_t value)
 }
 
 #define FI_OPX_DEBUG_COUNTERS_PRINT_COUNTER(pid, name) fi_opx_debug_counters_print_counter(pid, #name, counters->name)
+#define FI_OPX_DEBUG_COUNTERS_PRINT_VAL(pid, name) fi_opx_debug_counters_print_counter(pid, #name, name)
 
 #define FI_OPX_DEBUG_COUNTERS_PRINT_COUNTER_ARR(pid, name, size)		\
 {										\
@@ -230,13 +257,62 @@ void fi_opx_debug_counters_print(struct fi_opx_debug_counters *counters) {
 		FI_OPX_DEBUG_COUNTERS_PRINT_COUNTER(pid, reliability.replay_cts);
 		FI_OPX_DEBUG_COUNTERS_PRINT_COUNTER(pid, reliability.replay_rzv);
 	#endif
+
+	#ifdef OPX_DEBUG_COUNTERS_MATCH
+		uint64_t total_searches = counters->match.default_searches +
+					  counters->match.ue_hash_linear_searches +
+					  counters->match.ue_hash_tag_searches;
+
+		uint64_t total_misses = counters->match.default_misses +
+					counters->match.ue_hash_linear_misses +
+					counters->match.ue_hash_tag_misses;
+
+		uint64_t total_hits = counters->match.default_hits +
+				      counters->match.ue_hash_linear_hits +
+				      counters->match.ue_hash_tag_hits;
+
+		uint64_t total_not_found = counters->match.default_not_found +
+					   counters->match.ue_hash_linear_not_found +
+					   counters->match.ue_hash_tag_not_found;
+
+		uint64_t avg_len_per_hit = total_hits ? (total_misses / total_hits) : 0;
+
+		FI_OPX_DEBUG_COUNTERS_PRINT_VAL(pid, total_searches);
+		FI_OPX_DEBUG_COUNTERS_PRINT_VAL(pid, total_misses);
+		FI_OPX_DEBUG_COUNTERS_PRINT_VAL(pid, total_hits);
+		FI_OPX_DEBUG_COUNTERS_PRINT_VAL(pid, total_not_found);
+		FI_OPX_DEBUG_COUNTERS_PRINT_VAL(pid, avg_len_per_hit);
+		fprintf(stderr, "\n");
+
+		FI_OPX_DEBUG_COUNTERS_PRINT_COUNTER(pid, match.default_searches);
+		FI_OPX_DEBUG_COUNTERS_PRINT_COUNTER(pid, match.default_misses);
+		FI_OPX_DEBUG_COUNTERS_PRINT_COUNTER(pid, match.default_hits);
+		FI_OPX_DEBUG_COUNTERS_PRINT_COUNTER(pid, match.default_not_found);
+		FI_OPX_DEBUG_COUNTERS_PRINT_COUNTER(pid, match.default_max_length);
+		fprintf(stderr, "\n");
+
+		FI_OPX_DEBUG_COUNTERS_PRINT_COUNTER(pid, match.ue_hash_linear_searches);
+		FI_OPX_DEBUG_COUNTERS_PRINT_COUNTER(pid, match.ue_hash_linear_misses);
+		FI_OPX_DEBUG_COUNTERS_PRINT_COUNTER(pid, match.ue_hash_linear_hits);
+		FI_OPX_DEBUG_COUNTERS_PRINT_COUNTER(pid, match.ue_hash_linear_not_found);
+		FI_OPX_DEBUG_COUNTERS_PRINT_COUNTER(pid, match.ue_hash_linear_max_length);
+		fprintf(stderr, "\n");
+
+		FI_OPX_DEBUG_COUNTERS_PRINT_COUNTER(pid, match.ue_hash_tag_searches);
+		FI_OPX_DEBUG_COUNTERS_PRINT_COUNTER(pid, match.ue_hash_tag_misses);
+		FI_OPX_DEBUG_COUNTERS_PRINT_COUNTER(pid, match.ue_hash_tag_hits);
+		FI_OPX_DEBUG_COUNTERS_PRINT_COUNTER(pid, match.ue_hash_tag_not_found);
+		FI_OPX_DEBUG_COUNTERS_PRINT_COUNTER(pid, match.ue_hash_tag_max_length);
+		fprintf(stderr, "\n");
+	#endif
 }
 
 #if defined(OPX_DEBUG_COUNTERS_MP_EAGER)		||		\
 	defined(OPX_DEBUG_COUNTERS_RELIABILITY_PING)	||		\
 	defined(OPX_DEBUG_COUNTERS_RELIABILITY) 	||		\
-	defined(OPX_DEBUG_COUNTERS_SDMA)                ||              \
-	defined(OPX_DEBUG_COUNTERS_EXPECTED_RECEIVE)
+	defined(OPX_DEBUG_COUNTERS_SDMA)		||		\
+	defined(OPX_DEBUG_COUNTERS_EXPECTED_RECEIVE)	||		\
+	defined(OPX_DEBUG_COUNTERS_MATCH)
 
 #define FI_OPX_DEBUG_COUNTERS_DECLARE_COUNTERS struct fi_opx_debug_counters debug_counters
 #define FI_OPX_DEBUG_COUNTERS_DECLARE_TMP(x) uint64_t x = 0
@@ -261,6 +337,7 @@ void fi_opx_debug_counters_print(struct fi_opx_debug_counters *counters) {
 									\
 	} while(0)
 
+#define FI_OPX_DEBUG_COUNTERS_GET_PTR(opx_ep)	(&((opx_ep)->debug_counters))
 #else
 
 #define FI_OPX_DEBUG_COUNTERS_DECLARE_COUNTERS
@@ -273,6 +350,7 @@ void fi_opx_debug_counters_print(struct fi_opx_debug_counters *counters) {
 #define FI_OPX_DEBUG_COUNTERS_INC_COND_N(cond, n, x)
 #define FI_OPX_DEBUG_COUNTERS_MAX_OF(x, y)
 #define FI_OPX_DEBUG_COUNTERS_MIN_OF(x, y)
+#define FI_OPX_DEBUG_COUNTERS_GET_PTR(opx_ep)	(NULL)
 #endif
 
 #endif

--- a/prov/opx/include/rdma/opx/fi_opx_domain.h
+++ b/prov/opx/include/rdma/opx/fi_opx_domain.h
@@ -96,7 +96,7 @@ struct fi_opx_node {
 
 #define OPX_MIN_DCOMP_THRESHOLD FI_OPX_SDMA_MIN_LENGTH
 #define OPX_DEFAULT_DCOMP_THRESHOLD FI_OPX_SDMA_DC_MIN
-#define OPX_MAX_DCOMP_THRESHOLD INT_MAX
+#define OPX_MAX_DCOMP_THRESHOLD (INT_MAX - 1)
 
 struct fi_opx_domain {
 	struct fid_domain	domain_fid;

--- a/prov/opx/include/rdma/opx/fi_opx_endpoint.h
+++ b/prov/opx/include/rdma/opx/fi_opx_endpoint.h
@@ -1713,10 +1713,6 @@ void fi_opx_ep_rx_process_header_rzv_data(struct fi_opx_ep * opx_ep,
 					hdr->dput.target.last_bytes :
 					hdr->dput.target.bytes;
 
-		if(bytes > FI_OPX_HFI1_PACKET_MTU) {
-			fprintf(stderr, "bytes is %d\n", bytes);
-			fflush(stderr);
-		}
 		assert(bytes <= FI_OPX_HFI1_PACKET_MTU);
 
 		const uint64_t *sbuf_qws = (uint64_t*)&payload->byte[0];

--- a/prov/opx/include/rdma/opx/fi_opx_hfi1_packet.h
+++ b/prov/opx/include/rdma/opx/fi_opx_hfi1_packet.h
@@ -762,7 +762,7 @@ union fi_opx_hfi1_dput_rbuf {
 
 #define FI_OPX_MAX_DPUT_IOV ((FI_OPX_HFI1_PACKET_MTU/sizeof(struct fi_opx_hfi1_dput_iov) - 4) + 3)
 
-#define FI_OPX_MAX_DPUT_TIDPAIRS ((FI_OPX_HFI1_PACKET_MTU - sizeof(struct fi_opx_hfi1_dput_iov) - sizeof(uint32_t))/sizeof(uint32_t))
+#define FI_OPX_MAX_DPUT_TIDPAIRS ((FI_OPX_HFI1_PACKET_MTU - sizeof(struct fi_opx_hfi1_dput_iov) - (2 * sizeof(uint32_t)))/sizeof(uint32_t))
 
 union fi_opx_hfi1_packet_payload {
 	uint8_t				byte[FI_OPX_HFI1_PACKET_MTU];
@@ -810,6 +810,7 @@ union fi_opx_hfi1_packet_payload {
 	/* tid_cts extends cts*/
 	struct {
 		struct fi_opx_hfi1_dput_iov	iov[1];
+		uint32_t  tid_offset;
 		uint32_t  ntidpairs;
 		uint32_t  tidpairs[FI_OPX_MAX_DPUT_TIDPAIRS];
 	} tid_cts;

--- a/prov/opx/include/rdma/opx/fi_opx_hfi1_progress.h
+++ b/prov/opx/include/rdma/opx/fi_opx_hfi1_progress.h
@@ -123,6 +123,7 @@ void fi_opx_hfi1_handle_ud_ping(struct fi_opx_ep *opx_ep,
 	} else {
 		ping_op = ofi_buf_alloc(opx_ep->reliability->state.service
 						->pending_rx_reliability_pool);
+		assert(ping_op != NULL);
 		ping_op->ud_opcode = hdr->ud.opcode;
 		ping_op->slid = (uint64_t)hdr->stl.lrh.slid;
 		ping_op->rx = (uint64_t)hdr->service.origin_reliability_rx;

--- a/prov/opx/include/rdma/opx/fi_opx_hfi1_transport.h
+++ b/prov/opx/include/rdma/opx/fi_opx_hfi1_transport.h
@@ -380,6 +380,8 @@ struct fi_opx_hfi1_dput_params {
 	uint32_t cur_iov;
 	uint32_t opcode;
 	uint32_t payload_bytes_for_iovec;
+	uint32_t ntidpairs;
+	uint32_t tidoffset;
 	uint32_t tididx;
 	uint32_t tidlen_consumed;
 	uint32_t tidlen_remaining;
@@ -388,7 +390,6 @@ struct fi_opx_hfi1_dput_params {
 	uint16_t sdma_reqs_used;
 	bool is_intranode;
 	bool delivery_completion;
-	bool use_tid;
 	bool use_expected_opcode;
 	uint8_t u8_rx;
 	uint32_t u32_extended_rx;
@@ -423,6 +424,7 @@ struct fi_opx_hfi1_rx_rzv_rts_params {
 	uint64_t immediate_data;
 	uint64_t immediate_end_block_count;
 	uint32_t ntidpairs;
+	uint32_t tid_offset;
 	uint8_t opcode;
 	uint8_t fallback_opcode;
 	unsigned is_intranode;

--- a/prov/opx/include/rdma/opx/fi_opx_match.h
+++ b/prov/opx/include/rdma/opx/fi_opx_match.h
@@ -1,0 +1,276 @@
+/*
+ * Copyright (C) 2023 Cornelis Networks.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _FI_PROV_OPX_MATCH_H_
+#define _FI_PROV_OPX_MATCH_H_
+#include <stdint.h>
+
+#include "rdma/opx/fi_opx_debug_counters.h"
+#include "rdma/opx/fi_opx_addr.h"
+#include "rdma/opx/fi_opx_hfi1_packet.h"
+#include "rdma/opx/fi_opx_internal.h"
+#include "rdma/opx/fi_opx.h"
+#include "rdma/opx/fi_opx_compiler.h"
+#include <ofi_list.h>
+#include <ofi_mem.h>
+
+/*
+ * The maximum length of the default non-hashing UE slist before new early arriving
+ * packets are put on the new hashing list.
+ */
+#ifndef FI_OPX_MATCH_DEFAULT_UE_LIST_MAX_LENGTH
+#define FI_OPX_MATCH_DEFAULT_UE_LIST_MAX_LENGTH	(1024)
+#endif
+
+/*
+ * The size of the tag and addr hash tables. Must be a power of 2.
+ */
+#ifndef FI_OPX_MATCH_UE_HT_SIZE
+#define FI_OPX_MATCH_UE_HT_SIZE		(1024ul)
+#endif
+
+#define FI_OPX_MATCH_UE_HT_MASK		(FI_OPX_MATCH_UE_HT_SIZE - 1)
+OPX_COMPILE_TIME_ASSERT((FI_OPX_MATCH_UE_HT_SIZE & FI_OPX_MATCH_UE_HT_MASK) == 0,
+			"FI_OPX_MATCH_UE_HT_SIZE must be a power of 2!");
+
+#define FI_OPX_MATCH_IGNORE_ALL		(-1ul)
+#define FI_OPX_MATCH_TAG_ZERO		(0ul)
+
+struct fi_opx_match_ue_hash {
+	struct fi_opx_hfi1_ue_packet_slist	ue;	/* 3 qws */
+	struct fi_opx_hfi1_ue_packet_slist	tag_ht[FI_OPX_MATCH_UE_HT_SIZE];
+} __attribute__((__packed__)) __attribute__((aligned(64)));
+
+__OPX_FORCE_INLINE__
+int fi_opx_match_ue_hash_init(struct fi_opx_match_ue_hash **ue_hash) {
+	if (posix_memalign((void **)ue_hash, 64, sizeof(struct fi_opx_match_ue_hash))) {
+		*ue_hash = NULL;
+		return -FI_ENOMEM;
+	}
+	memset(*ue_hash, 0, sizeof(struct fi_opx_match_ue_hash));
+	return 0;
+}
+
+__OPX_FORCE_INLINE__
+void fi_opx_match_ue_hash_free(struct fi_opx_match_ue_hash **ue_hash) {
+	if (*ue_hash) {
+		free(*ue_hash);
+		*ue_hash = NULL;
+	}
+}
+
+__OPX_FORCE_INLINE__
+void fi_opx_match_ue_hash_append(struct fi_opx_hfi1_ue_packet *uepkt,
+				struct fi_opx_match_ue_hash *ue_hash,
+				struct fi_opx_debug_counters *debug_counters)
+{
+	const uint64_t index = uepkt->tag & FI_OPX_MATCH_UE_HT_MASK;
+	struct fi_opx_hfi1_ue_packet_slist *ue_ht = &ue_hash->tag_ht[index];
+
+	uepkt->tag_ht.ht = ue_ht;
+	struct fi_opx_hfi1_ue_packet *tail = (struct fi_opx_hfi1_ue_packet *) ue_ht->tail;
+
+	++ue_ht->length;
+
+	if (!tail) {
+		assert(ue_ht->length == 1);
+		ue_ht->head = uepkt;
+		ue_ht->tail = uepkt;
+		uepkt->tag_ht.next = NULL;
+		uepkt->tag_ht.prev = NULL;
+	} else {
+		assert(ue_ht->length > 1);
+
+		uepkt->tag_ht.prev = tail;
+		uepkt->tag_ht.next = NULL;
+		tail->tag_ht.next = uepkt;
+		ue_ht->tail = uepkt;
+	}
+
+	FI_OPX_DEBUG_COUNTERS_MAX_OF(debug_counters->match.ue_hash_tag_max_length, ue_ht->length);
+	FI_OPX_DEBUG_COUNTERS_MAX_OF(debug_counters->match.ue_hash_linear_max_length, ue_hash->ue.length);
+}
+
+__OPX_FORCE_INLINE__
+void fi_opx_match_ue_ht_remove(struct fi_opx_hfi1_ue_packet *uepkt)
+{
+	/* Packet was the first */
+	if (!uepkt->tag_ht.prev) {
+		assert(uepkt->tag_ht.ht->head == uepkt);
+
+		/* Packet was also the only one, hq_list now empty */
+		if (!uepkt->tag_ht.next) {
+			assert(uepkt->tag_ht.ht->tail == uepkt);
+
+			uepkt->tag_ht.ht->head = NULL;
+			uepkt->tag_ht.ht->tail = NULL;
+		} else {
+			uepkt->tag_ht.next->tag_ht.prev = NULL;
+			uepkt->tag_ht.ht->head = uepkt->tag_ht.next;
+		}
+	} else if (!uepkt->tag_ht.next) {
+		assert(uepkt->tag_ht.ht->tail == uepkt);
+
+		uepkt->tag_ht.prev->tag_ht.next = NULL;
+		uepkt->tag_ht.ht->tail = uepkt->tag_ht.prev;
+	} else {
+		uepkt->tag_ht.prev->tag_ht.next = uepkt->tag_ht.next;
+		uepkt->tag_ht.next->tag_ht.prev = uepkt->tag_ht.prev;
+	}
+	assert(uepkt->tag_ht.ht->length > 0);
+	--uepkt->tag_ht.ht->length;
+
+	uepkt->tag_ht.ht = NULL;
+	uepkt->tag_ht.next = NULL;
+	uepkt->tag_ht.prev = NULL;
+}
+
+__OPX_FORCE_INLINE__
+void fi_opx_match_ue_hash_pop(struct fi_opx_hfi1_ue_packet *uepkt,
+				struct fi_opx_match_ue_hash *ue_hash)
+{
+	fi_opx_match_ue_ht_remove(uepkt);
+
+	fi_opx_hfi1_ue_packet_slist_pop_item(uepkt, &ue_hash->ue);
+}
+
+__OPX_FORCE_INLINE__
+struct fi_opx_hfi1_ue_packet *fi_opx_match_ue_hash_remove(struct fi_opx_hfi1_ue_packet *uepkt,
+							  struct fi_opx_match_ue_hash *ue_hash)
+{
+	struct fi_opx_hfi1_ue_packet *next = uepkt->next;
+	fi_opx_match_ue_hash_pop(uepkt, ue_hash);
+	OPX_BUF_FREE(uepkt);
+	return next;
+}
+
+__OPX_FORCE_INLINE__
+uint64_t fi_opx_match_packet(const uint64_t origin_tag,
+			     const fi_opx_uid_t origin_uid_fi,
+			     const uint64_t target_tag,
+			     const uint64_t ignore_bits,
+			     const union fi_opx_addr src_opx_addr,
+			     const fi_addr_t ctx_src_addr)
+{
+	const uint64_t origin_tag_and_not_ignore = origin_tag & ~ignore_bits;
+	const uint64_t answer = (origin_tag_and_not_ignore == target_tag) &&
+				((ctx_src_addr == FI_ADDR_UNSPEC) ||
+				 (origin_uid_fi == src_opx_addr.uid.fi));
+	return answer;
+}
+
+__OPX_FORCE_INLINE__
+struct fi_opx_hfi1_ue_packet *fi_opx_match_find_uepkt_linear(struct fi_opx_match_ue_hash *ue_hash,
+								const uint64_t target_tag,
+								const uint64_t ignore_bits,
+								const union fi_opx_addr src_opx_addr,
+								const fi_addr_t ctx_src_addr,
+								struct fi_opx_debug_counters *debug_counters)
+{
+	struct fi_opx_hfi1_ue_packet *uepkt = ue_hash->ue.head;
+	assert(uepkt);
+
+	FI_OPX_DEBUG_COUNTERS_INC(debug_counters->match.ue_hash_linear_searches);
+
+	while (uepkt && !fi_opx_match_packet(uepkt->tag, uepkt->origin_uid_fi,
+					     target_tag, ignore_bits,
+					     src_opx_addr, ctx_src_addr)) {
+		FI_OPX_DEBUG_COUNTERS_INC(debug_counters->match.ue_hash_linear_misses);
+		uepkt = uepkt->next;
+	}
+
+	FI_OPX_DEBUG_COUNTERS_INC_COND(uepkt, debug_counters->match.ue_hash_linear_hits);
+	FI_OPX_DEBUG_COUNTERS_INC_COND(!uepkt, debug_counters->match.ue_hash_linear_not_found);
+	return uepkt;
+}
+
+__OPX_FORCE_INLINE__
+struct fi_opx_hfi1_ue_packet *fi_opx_match_find_uepkt_by_tag(struct fi_opx_match_ue_hash *ue_hash,
+								const uint64_t hash_index,
+								const uint64_t target_tag,
+								const uint64_t ignore_bits,
+								const union fi_opx_addr src_opx_addr,
+								const fi_addr_t ctx_src_addr,
+								struct fi_opx_debug_counters *debug_counters)
+{
+	struct fi_opx_hfi1_ue_packet *uepkt = ue_hash->tag_ht[hash_index].head;
+	assert(uepkt);
+
+	FI_OPX_DEBUG_COUNTERS_INC(debug_counters->match.ue_hash_tag_searches);
+
+	while (uepkt && !fi_opx_match_packet(uepkt->tag, uepkt->origin_uid_fi,
+					     target_tag, ignore_bits,
+					     src_opx_addr, ctx_src_addr)) {
+		FI_OPX_DEBUG_COUNTERS_INC(debug_counters->match.ue_hash_tag_misses);
+		uepkt = uepkt->tag_ht.next;
+	}
+	FI_OPX_DEBUG_COUNTERS_INC_COND(uepkt, debug_counters->match.ue_hash_tag_hits);
+	FI_OPX_DEBUG_COUNTERS_INC_COND(!uepkt, debug_counters->match.ue_hash_tag_not_found);
+
+	return uepkt;
+}
+
+__OPX_FORCE_INLINE__
+struct fi_opx_hfi1_ue_packet *fi_opx_match_find_uepkt(struct fi_opx_match_ue_hash *ue_hash,
+							const union fi_opx_context *context,
+							struct fi_opx_debug_counters *debug_counters)
+{
+	if (!ue_hash->ue.head) {
+		return NULL;
+	}
+
+	const union fi_opx_addr src_opx_addr = {.fi = context->src_addr};
+
+	const uint64_t ignore_bits = context->ignore;
+	const uint64_t target_tag = context->tag & ~ignore_bits;
+
+	/* If ignore bits don't overlap our hash bits, we can potentially search by tag */
+	if (!(ignore_bits & FI_OPX_MATCH_UE_HT_MASK)) {
+		const uint64_t hashed_tag = target_tag & FI_OPX_MATCH_UE_HT_MASK;
+		return fi_opx_match_find_uepkt_by_tag(ue_hash,
+							hashed_tag,
+							target_tag,
+							ignore_bits,
+							src_opx_addr,
+							context->src_addr,
+							debug_counters);
+	}
+
+	return fi_opx_match_find_uepkt_linear(ue_hash,
+						target_tag,
+						ignore_bits,
+						src_opx_addr,
+						FI_ADDR_UNSPEC,
+						debug_counters);
+}
+
+#endif

--- a/prov/opx/include/rdma/opx/fi_opx_rma.h
+++ b/prov/opx/include/rdma/opx/fi_opx_rma.h
@@ -187,7 +187,7 @@ void fi_opx_write_internal(struct fi_opx_ep *opx_ep, const void *buf, size_t len
 	assert(rc == FI_SUCCESS);
 	fi_opx_ep_rx_poll(&opx_ep->ep_fid, 0, OPX_RELIABILITY, FI_OPX_HDRQ_MASK_RUNTIME);
 
-	fi_opx_hfi1_dput_sdma_init(opx_ep, params, len, 0, NULL);
+	fi_opx_hfi1_dput_sdma_init(opx_ep, params, len, 0, 0, NULL);
 
 	rc = params->work_elem.work_fn(work);
 	if (rc == FI_SUCCESS) {

--- a/prov/opx/src/fi_opx_atomic.c
+++ b/prov/opx/src/fi_opx_atomic.c
@@ -169,7 +169,7 @@ void fi_opx_atomic_op_internal(struct fi_opx_ep *opx_ep,
 
 	fi_opx_ep_rx_poll(&opx_ep->ep_fid, 0, OPX_RELIABILITY, FI_OPX_HDRQ_MASK_RUNTIME);
 
-	fi_opx_hfi1_dput_sdma_init(opx_ep, params, len, 0, NULL);
+	fi_opx_hfi1_dput_sdma_init(opx_ep, params, len, 0, 0, NULL);
 
 	int rc = params->work_elem.work_fn(work);
 	if(rc == FI_SUCCESS) {

--- a/prov/opx/src/fi_opx_cm.c
+++ b/prov/opx/src/fi_opx_cm.c
@@ -98,7 +98,7 @@ int fi_opx_getname(fid_t fid, void *addr, size_t *addrlen)
 			struct fi_opx_sep *opx_sep;
 			opx_sep = container_of(fid, struct fi_opx_sep, ep_fid);
 			unsigned i;
-			for (i = 0; (opx_sep->ep[i] == NULL) && (i < FI_OPX_ADDR_SEP_RX_MAX); ++i);
+			for (i = 0; (i < FI_OPX_ADDR_SEP_RX_MAX) && (opx_sep->ep[i] == NULL); ++i);
 			if (i == FI_OPX_ADDR_SEP_RX_MAX) {
 				/* no sep rx ctx were created? */
 				errno = FI_EINVAL;

--- a/prov/opx/src/fi_opx_domain.c
+++ b/prov/opx/src/fi_opx_domain.c
@@ -264,8 +264,8 @@ int fi_opx_domain(struct fid_fabric *fabric,
 {
 	FI_DBG_TRACE(fi_opx_global.prov, FI_LOG_DOMAIN, "open domain\n");
 
-	int ret;
-	int get_param_check;
+	int ret = 0;
+	int get_param_check = 0;
 	struct fi_opx_domain 	*opx_domain = NULL;
 	struct fi_opx_fabric 	*opx_fabric =
 		container_of(fabric, struct fi_opx_fabric, fabric_fid);
@@ -404,27 +404,37 @@ skip:
 
 	// Max UUID consists of 32 hex digits.
 	char * env_var_uuid = OPX_DEFAULT_JOB_KEY_STR;
-	fi_param_get_str(fi_opx_global.prov, "uuid", &env_var_uuid);
+	get_param_check = fi_param_get_str(fi_opx_global.prov, "uuid", &env_var_uuid);
+	char * impi_uuid = getenv("I_MPI_HYDRA_UUID");
+	char * slurm_job_id = getenv("SLURM_JOB_ID");
+
+	if (get_param_check == FI_SUCCESS) {
+		FI_INFO(fi_opx_global.prov, FI_LOG_DOMAIN, "Detected user specified FI_OPX_UUID\n");
+	} else if (slurm_job_id) {
+		env_var_uuid = slurm_job_id;
+		FI_INFO(fi_opx_global.prov, FI_LOG_DOMAIN, "Found SLURM_JOB_ID.  Using it for FI_OPX_UUID\n");
+	} else if (impi_uuid) {
+		env_var_uuid = impi_uuid;
+		FI_INFO(fi_opx_global.prov, FI_LOG_DOMAIN, "Found I_MPI_HYDRA_UUID.  Using it for FI_OPX_UUID\n");
+	} else {
+		env_var_uuid = OPX_DEFAULT_JOB_KEY_STR;
+	}
 
 	if (strlen(env_var_uuid) >= OPX_JOB_KEY_STR_SIZE) {
-		env_var_uuid[OPX_JOB_KEY_STR_SIZE-1] = 0;
 		FI_WARN(fi_opx_global.prov, FI_LOG_DOMAIN,
-			"UUID too long. UUID must consist of 1-32 hexadecimal digits.\n");
-		errno=FI_EINVAL;
-		goto err;
+			"UUID too long. UUID must consist of 1-32 hexadecimal digits.  Using default OPX uuid instead\n");
+		env_var_uuid = OPX_DEFAULT_JOB_KEY_STR;
 	} 
 
 	int i;
 	for (i=0; i < OPX_JOB_KEY_STR_SIZE && env_var_uuid[i] != 0; i++) {
 		if (!isxdigit(env_var_uuid[i])) {
 			FI_WARN(fi_opx_global.prov, FI_LOG_DOMAIN,
-				"Invalid UUID. UUID must consist solely of hexadecimal digits.\n");
-			errno=FI_EINVAL;
-			goto err;
+				"Invalid UUID. UUID must consist solely of hexadecimal digits.  Using default OPX uuid instead\n");
+			env_var_uuid = OPX_DEFAULT_JOB_KEY_STR;
 		}
 	}
 	
-
 	// Copy the job key and guarantee null termination.
 	strncpy(opx_domain->unique_job_key_str, env_var_uuid, OPX_JOB_KEY_STR_SIZE-1);
 	opx_domain->unique_job_key_str[OPX_JOB_KEY_STR_SIZE-1] = '\0';
@@ -446,6 +456,9 @@ skip:
 		&opx_domain->unique_job_key[13],
 		&opx_domain->unique_job_key[14],
 		&opx_domain->unique_job_key[15]);
+
+	FI_INFO(fi_opx_global.prov, FI_LOG_DOMAIN, "Domain unique job key set to %s\n", opx_domain->unique_job_key_str);
+	//TODO: Print out a summary of all domain settings wtih FI_INFO
 
 	opx_domain->rx_count = 0;
 	opx_domain->tx_count = 0;

--- a/prov/opx/src/fi_opx_ep.c
+++ b/prov/opx/src/fi_opx_ep.c
@@ -1962,6 +1962,29 @@ int fi_opx_endpoint_rx_tx (struct fid_domain *dom, struct fi_info *info,
 		opx_ep->reuse_tidpairs = 0; /*unused without use_expected_tid_rzv*/
 	}
 
+	int immediate_blocks = 1;
+	if (fi_param_get_int(fi_opx_global.prov, "immediate_blocks", &immediate_blocks) == FI_SUCCESS) {
+		if ((immediate_blocks < 0) || (immediate_blocks > 64)) {
+			FI_WARN(fi_opx_global.prov, FI_LOG_EP_DATA, "Invalid value (%u) specified for immediate_blocks. Valid range is 0-64. Defaulting to 1\n", immediate_blocks);
+			opx_ep->immediate_blocks = 1;
+		} else {
+			FI_INFO(fi_opx_global.prov, FI_LOG_EP_DATA, "immediate_blocks parm specified as %u\n", immediate_blocks);
+			opx_ep->immediate_blocks = immediate_blocks;
+		}
+	} else {
+		FI_INFO(fi_opx_global.prov, FI_LOG_EP_DATA, "immediate_blocks parm not specified; using default value 1\n");
+		opx_ep->immediate_blocks = immediate_blocks;
+	}
+
+	int replay_use_sdma;
+	if (fi_param_get_bool(fi_opx_global.prov, "replay_use_sdma", &replay_use_sdma) == FI_SUCCESS) {
+		opx_ep->replay_use_sdma = replay_use_sdma;
+		FI_INFO(fi_opx_global.prov, FI_LOG_EP_DATA, "replay_use_sdma parm specified as %0hhX; opx_ep->replay_use_sdma = set to %0hhX\n", replay_use_sdma, opx_ep->replay_use_sdma);
+	} else {
+		FI_INFO(fi_opx_global.prov, FI_LOG_EP_DATA, "replay_use_sdma parm not specified; disabled expected receive rendezvous\n");
+		opx_ep->replay_use_sdma = false;
+	}
+
 	*ep = &opx_ep->ep_fid;
 
 	FI_OPX_DEBUG_COUNTERS_INIT(opx_ep->debug_counters);

--- a/prov/opx/src/fi_opx_ep.c
+++ b/prov/opx/src/fi_opx_ep.c
@@ -732,7 +732,7 @@ err:
 static int fi_opx_ep_tx_init (struct fi_opx_ep *opx_ep,
 		struct fi_opx_domain *opx_domain)
 {
-	FI_DBG_TRACE(fi_opx_global.prov, FI_LOG_EP_DATA, "==== TX init.  Calculating optimal Tx send thresholds\n");
+	OPX_LOG(FI_LOG_INFO, FI_LOG_EP_DATA, "==== TX init.  Calculating optimal Tx send thresholds\n");
 
 	assert(opx_ep);
 	assert(opx_domain);
@@ -783,7 +783,7 @@ static int fi_opx_ep_tx_init (struct fi_opx_ep *opx_ep,
 	assert((l_pio_max_eager_tx_bytes & 0x3f) == 0); //Make sure the value is 64 bit aligned
 	opx_ep->tx->pio_max_eager_tx_bytes = l_pio_max_eager_tx_bytes;
 
-	FI_INFO(fi_opx_global.prov, FI_LOG_EP_DATA, "Credits_total is %d, so set pio_max_eager_tx_bytes to %d \n", 
+	OPX_LOG_OBSERVABLE(FI_LOG_EP_DATA, "Credits_total is %d, so set pio_max_eager_tx_bytes to %d \n", 
 	hfi->state.pio.credits_total, opx_ep->tx->pio_max_eager_tx_bytes);
 
 	/* Similar logic to l_pio_max_eager_tx_bytes, calculate l_pio_flow_eager_tx_bytes to be an 'optimal' value for PIO
@@ -802,7 +802,7 @@ static int fi_opx_ep_tx_init (struct fi_opx_ep *opx_ep,
 
 	opx_ep->tx->pio_flow_eager_tx_bytes = l_pio_flow_eager_tx_bytes;
 
-	FI_INFO(fi_opx_global.prov, FI_LOG_EP_DATA, "Set pio_flow_eager_tx_bytes to %d \n", opx_ep->tx->pio_flow_eager_tx_bytes);
+	OPX_LOG_OBSERVABLE(FI_LOG_EP_DATA, "Set pio_flow_eager_tx_bytes to %d \n", opx_ep->tx->pio_flow_eager_tx_bytes);
 
 	/* Set delivery completion max threshold.  Any messages larger than this value in bytes will not be copied to 
 	 * replay bounce buffers.  Instead, hold the sender's large message buffer until we get all ACKs back from the Rx 
@@ -812,20 +812,20 @@ static int fi_opx_ep_tx_init (struct fi_opx_ep *opx_ep,
 	ssize_t rc = fi_param_get_int(fi_opx_global.prov, "delivery_completion_threshold", &l_dcomp_threshold);
 	if (rc != FI_SUCCESS) {
 		opx_ep->tx->dcomp_threshold = OPX_DEFAULT_DCOMP_THRESHOLD;
-		FI_INFO(fi_opx_global.prov, FI_LOG_EP_DATA, "FI_OPX_DELIVERY_COMPLETION_THRESHOLD not set.  Using default setting of %d\n",
+		OPX_LOG_OBSERVABLE(FI_LOG_EP_DATA, "FI_OPX_DELIVERY_COMPLETION_THRESHOLD not set.  Using default setting of %d\n",
 		opx_ep->tx->dcomp_threshold);
 	} else if (l_dcomp_threshold < OPX_MIN_DCOMP_THRESHOLD || l_dcomp_threshold > OPX_MAX_DCOMP_THRESHOLD) {
 		opx_ep->tx->dcomp_threshold = OPX_DEFAULT_DCOMP_THRESHOLD;
-		FI_INFO(fi_opx_global.prov, FI_LOG_EP_DATA, 
+		FI_WARN(fi_opx_global.prov, FI_LOG_EP_DATA,
 			"Error: FI_OPX_DELIVERY_COMPLETION_THRESHOLD was set but is outside of MIN/MAX thresholds.  Using default setting of %d\n", 
 			opx_ep->tx->dcomp_threshold);
 	} else {
 		opx_ep->tx->dcomp_threshold = l_dcomp_threshold;
-		FI_INFO(fi_opx_global.prov, FI_LOG_EP_DATA, "FI_OPX_DELIVERY_COMPLETION_THRESHOLD was specified.  Set to %d\n", 
+		OPX_LOG_OBSERVABLE(FI_LOG_EP_DATA, "FI_OPX_DELIVERY_COMPLETION_THRESHOLD was specified.  Set to %d\n", 
 			opx_ep->tx->dcomp_threshold);
 	}
 
-	FI_INFO(fi_opx_global.prov, FI_LOG_EP_DATA, "Multi-packet eager max message length is %d, chunk-size is %d.\n", 
+	OPX_LOG_OBSERVABLE(FI_LOG_EP_DATA, "Multi-packet eager max message length is %d, chunk-size is %d.\n", 
 		FI_OPX_MP_EGR_MAX_PAYLOAD_BYTES, FI_OPX_MP_EGR_CHUNK_SIZE);	
 
 	opx_ep->tx->force_credit_return = 0;
@@ -838,9 +838,10 @@ static int fi_opx_ep_tx_init (struct fi_opx_ep *opx_ep,
 	int sdma_disable;
 	if (fi_param_get_int(fi_opx_global.prov, "sdma_disable", &sdma_disable) == FI_SUCCESS) {
 		opx_ep->tx->use_sdma = !sdma_disable;
-		FI_INFO(fi_opx_global.prov, FI_LOG_EP_DATA, "sdma_disable parm specified as %0hhX; opx_ep->tx->use_sdma set to %0hhX\n", sdma_disable, opx_ep->tx->use_sdma);
+		OPX_LOG_OBSERVABLE(FI_LOG_EP_DATA, 
+		"sdma_disable parm specified as %0hhX; opx_ep->tx->use_sdma set to %0hhX\n", sdma_disable, opx_ep->tx->use_sdma);
 	} else {
-		FI_INFO(fi_opx_global.prov, FI_LOG_EP_DATA, "sdma_disable parm not specified; using SDMA\n");
+		OPX_LOG_OBSERVABLE(FI_LOG_EP_DATA, "sdma_disable parm not specified; using SDMA\n");
 		opx_ep->tx->use_sdma = 1;
 	}
 
@@ -867,7 +868,7 @@ static int fi_opx_ep_tx_init (struct fi_opx_ep *opx_ep,
 		opx_ep->tx->sdma_work_pool = NULL;
 		opx_ep->tx->sdma_replay_work_pool = NULL;
 	}
-	FI_DBG_TRACE(fi_opx_global.prov, FI_LOG_EP_DATA, "==== TX init finished\n");
+	OPX_LOG(FI_LOG_INFO, FI_LOG_EP_DATA, "==== TX init finished\n");
 	return 0;
 }
 
@@ -2346,7 +2347,7 @@ void fi_opx_ep_rx_reliability_process_packet (struct fid_ep * ep,
 		const uint8_t * const payload,
 		const uint8_t origin_rs) {
 
-	FI_DBG_TRACE(fi_opx_global.prov, FI_LOG_EP_DATA, "================ received a packet from the reliability service\n");
+	OPX_LOG_PKT(FI_LOG_DEBUG, FI_LOG_EP_DATA, "================ received a packet from the reliability service\n");
 
 	const uint8_t opcode = hdr->stl.bth.opcode;
 

--- a/prov/opx/src/fi_opx_ep.c
+++ b/prov/opx/src/fi_opx_ep.c
@@ -519,13 +519,14 @@ static int fi_opx_close_ep(fid_t fid)
 		ret = fi_opx_ref_dec(&opx_ep->rx->cq->ref_cnt, "completion queue");
 		if (ret) return ret;
 	}
-
+    // Placeholder functions to be uncommented when they do more than return 0
+	/*
 	fi_opx_finalize_cm_ops(&opx_ep->ep_fid.fid);
 	fi_opx_finalize_msg_ops(&opx_ep->ep_fid);
 	fi_opx_finalize_rma_ops(&opx_ep->ep_fid);
 	fi_opx_finalize_tagged_ops(&opx_ep->ep_fid);
 	fi_opx_finalize_atomic_ops(&opx_ep->ep_fid);
-
+	*/
 	if(opx_ep->common_info) { fi_freeinfo(opx_ep->common_info); opx_ep->common_info = NULL; }
 	if(opx_ep->tx_info) { fi_freeinfo(opx_ep->tx_info); opx_ep->tx_info = NULL; }
 	if(opx_ep->rx_info) { fi_freeinfo(opx_ep->rx_info); opx_ep->rx_info = NULL; }
@@ -818,7 +819,7 @@ static int fi_opx_ep_tx_init (struct fi_opx_ep *opx_ep,
 		opx_ep->tx->dcomp_threshold = OPX_DEFAULT_DCOMP_THRESHOLD;
 		OPX_LOG_OBSERVABLE(FI_LOG_EP_DATA, "FI_OPX_DELIVERY_COMPLETION_THRESHOLD not set.  Using default setting of %d\n",
 		opx_ep->tx->dcomp_threshold);
-	} else if (l_dcomp_threshold < OPX_MIN_DCOMP_THRESHOLD || l_dcomp_threshold > OPX_MAX_DCOMP_THRESHOLD) {
+	} else if (l_dcomp_threshold < OPX_MIN_DCOMP_THRESHOLD || l_dcomp_threshold > (OPX_MAX_DCOMP_THRESHOLD)) {
 		opx_ep->tx->dcomp_threshold = OPX_DEFAULT_DCOMP_THRESHOLD;
 		FI_WARN(fi_opx_global.prov, FI_LOG_EP_DATA,
 			"Error: FI_OPX_DELIVERY_COMPLETION_THRESHOLD was set but is outside of MIN/MAX thresholds.  Using default setting of %d\n", 
@@ -2010,8 +2011,12 @@ int fi_opx_endpoint_rx_tx (struct fid_domain *dom, struct fi_info *info,
 	FI_DBG_TRACE(fi_opx_global.prov, FI_LOG_EP_DATA, "(end)\n");
 	return 0;
 err:
-	if (opx_domain)
-		fi_opx_ref_dec(&opx_domain->ref_cnt, "domain");
+	if (opx_domain) {
+		ret = fi_opx_ref_dec(&opx_domain->ref_cnt, "domain");
+		if (ret) {
+			FI_DBG(fi_opx_global.prov, FI_LOG_EP_DATA, "%s:%d: Error: %d\n", __FILE__, __LINE__, ret);
+		}
+	}
 	if (opx_ep){
 #ifdef FLIGHT_RECORDER_ENABLE
 		if (opx_ep->fr) {

--- a/prov/opx/src/fi_opx_fabric.c
+++ b/prov/opx/src/fi_opx_fabric.c
@@ -115,14 +115,14 @@ int fi_opx_fabric(struct fi_fabric_attr *attr,
 	FI_DBG_TRACE(fi_opx_global.prov, FI_LOG_FABRIC, "open fabric\n");
 
 	int ret;
-	struct fi_opx_fabric *opx_fabric;
+	struct fi_opx_fabric *opx_fabric = NULL;
 
 	if (attr) {
 		if (attr->fabric) {
 			FI_WARN(fi_opx_global.prov, FI_LOG_FABRIC,
 				"attr->fabric only valid on getinfo\n");
 			errno = FI_EINVAL;
-			return -errno;
+			goto err;
 		}
 
 		ret = fi_opx_check_fabric_attr(attr);
@@ -131,8 +131,10 @@ int fi_opx_fabric(struct fi_fabric_attr *attr,
 	}
 
 	opx_fabric = calloc(1, sizeof(*opx_fabric));
-	if (!opx_fabric)
+	if (!opx_fabric) {
+		errno = FI_ENOMEM;
 		goto err;
+	}
 
 	opx_fabric->fabric_fid.fid.fclass = FI_CLASS_FABRIC;
 	opx_fabric->fabric_fid.fid.context = context;
@@ -145,7 +147,7 @@ int fi_opx_fabric(struct fi_fabric_attr *attr,
 		FI_WARN(fi_opx_global.prov, FI_LOG_FABRIC,
 			"Couldn't create tid fabric\n");
 		errno = FI_EINVAL;
-		return -errno;
+		goto err;
 	}
 	opx_fabric->tid_fabric = opx_tid_fabric;
 
@@ -161,6 +163,7 @@ int fi_opx_fabric(struct fi_fabric_attr *attr,
 	FI_DBG_TRACE(fi_opx_global.prov, FI_LOG_FABRIC, "fabric opened\n");
 	return 0;
 err:
-	errno = FI_ENOMEM;
+	free(opx_fabric);
+	opx_fabric = NULL;
 	return -errno;
 }

--- a/prov/opx/src/fi_opx_hfi1.c
+++ b/prov/opx/src/fi_opx_hfi1.c
@@ -1862,7 +1862,7 @@ int fi_opx_hfi1_do_dput (union fi_opx_hfi1_deferred_work * work)
 					psn_ptr = NULL;
 					psn = 0;
 				}
-
+				assert(replay != NULL);
 				union fi_opx_hfi1_packet_payload *replay_payload =
 					(union fi_opx_hfi1_packet_payload *) replay->payload;
 				assert(!replay->use_iov);
@@ -2358,6 +2358,7 @@ int fi_opx_hfi1_do_dput_sdma (union fi_opx_hfi1_deferred_work * work)
 
 				const uint16_t lrh_dws = htons(pbc_dws - 1);
 
+				assert(replay != NULL);
 				replay->scb.qw0 = opx_ep->rx->tx.dput.qw0 | pbc_dws;
 
 				// Passing in PSN of 0 for this because we'll set it later

--- a/prov/opx/src/fi_opx_init.c
+++ b/prov/opx/src/fi_opx_init.c
@@ -630,7 +630,7 @@ OPX_INI
  	fi_param_define(&fi_opx_provider, "sdma_disable", FI_PARAM_INT, "Disables SDMA offload hardware. Default is 0");
  	fi_param_define(&fi_opx_provider, "reliability_service_nack_threshold", FI_PARAM_INT, "The number of NACKs needed to be seen before a replay is initiated. Valid values are 1-32767. Default is 1");
 	fi_param_define(&fi_opx_provider, "expected_receive_enable", FI_PARAM_BOOL, "Enables expected receive rendezvous using Token ID (TID). Defaults to \"No\"");
-	fi_param_define(&fi_opx_provider, "immediate_blocks", FI_PARAM_INT, "The number of immediate blocks to send on rzv rts. Valid values are 0-64. Defaults to 1.");
+	fi_param_define(&fi_opx_provider, "immediate_blocks", FI_PARAM_INT, "The number of immediate blocks to send on rzv rts. Valid values are 0-64. Note that '0' is only supported with page aligned buffers and could cause a performance degradation if used with unaligned buffers. Defaults to 1.");
 	fi_param_define(&fi_opx_provider, "replay_use_sdma", FI_PARAM_BOOL, "Enable SDMA replays. Defaults to \"No\"");
 	fi_param_define(&fi_opx_provider, "tid_reuse_enable", FI_PARAM_BOOL, "Enables the reuse cache for Token ID (TID) and pinned rendezvous receive buffers. Defaults to \"No\"");
 	fi_param_define(&fi_opx_provider, "prog_affinity", FI_PARAM_STRING,

--- a/prov/opx/src/fi_opx_init.c
+++ b/prov/opx/src/fi_opx_init.c
@@ -630,6 +630,8 @@ OPX_INI
  	fi_param_define(&fi_opx_provider, "sdma_disable", FI_PARAM_INT, "Disables SDMA offload hardware. Default is 0");
  	fi_param_define(&fi_opx_provider, "reliability_service_nack_threshold", FI_PARAM_INT, "The number of NACKs needed to be seen before a replay is initiated. Valid values are 1-32767. Default is 1");
 	fi_param_define(&fi_opx_provider, "expected_receive_enable", FI_PARAM_BOOL, "Enables expected receive rendezvous using Token ID (TID). Defaults to \"No\"");
+	fi_param_define(&fi_opx_provider, "immediate_blocks", FI_PARAM_INT, "The number of immediate blocks to send on rzv rts. Valid values are 0-64. Defaults to 1.");
+	fi_param_define(&fi_opx_provider, "replay_use_sdma", FI_PARAM_BOOL, "Enable SDMA replays. Defaults to \"No\"");
 	fi_param_define(&fi_opx_provider, "tid_reuse_enable", FI_PARAM_BOOL, "Enables the reuse cache for Token ID (TID) and pinned rendezvous receive buffers. Defaults to \"No\"");
 	fi_param_define(&fi_opx_provider, "prog_affinity", FI_PARAM_STRING,
                         "When set, specify the set of CPU cores to set the progress "

--- a/prov/opx/src/fi_opx_progress.c
+++ b/prov/opx/src/fi_opx_progress.c
@@ -214,14 +214,8 @@ void fi_opx_stop_progress(struct fi_opx_progress_track *progress_track)
 
 	progress_track->keep_running = false;
 	pthread_join(*progress_track->progress_thread, &progress_track->returned_value);
-
-	if (progress_track->returned_value) {
-		free(progress_track->returned_value);
-		progress_track->returned_value = NULL;
-	}
-
-	if (progress_track->progress_thread) {
-		free(progress_track->progress_thread);
-		progress_track->progress_thread = NULL;
-	}
+	free(progress_track->returned_value);
+	progress_track->returned_value = NULL;
+	free(progress_track->progress_thread);
+	progress_track->progress_thread = NULL;
 }

--- a/prov/opx/src/fi_opx_reliability.c
+++ b/prov/opx/src/fi_opx_reliability.c
@@ -1707,6 +1707,16 @@ void fi_opx_hfi1_rx_reliability_nack (struct fid_ep *ep,
 
 		if (!replay->use_sdma) {
 			if (!queing_replays) {
+#ifdef OPX_DEBUG_COUNTERS_RELIABILITY
+				struct fi_opx_ep *opx_ep = container_of(ep, struct fi_opx_ep, ep_fid);
+				if(replay->scb.hdr.stl.bth.opcode == FI_OPX_HFI_BTH_OPCODE_MSG_RZV_RTS || replay->scb.hdr.stl.bth.opcode == FI_OPX_HFI_BTH_OPCODE_TAG_RZV_RTS) {
+					FI_OPX_DEBUG_COUNTERS_INC(opx_ep->debug_counters.reliability.replay_rts);
+				} else if (replay->scb.hdr.stl.bth.opcode == FI_OPX_HFI_BTH_OPCODE_RZV_CTS) {
+					FI_OPX_DEBUG_COUNTERS_INC(opx_ep->debug_counters.reliability.replay_cts);
+				} else if (replay->scb.hdr.stl.bth.opcode == FI_OPX_HFI_BTH_OPCODE_RZV_DATA) {
+					FI_OPX_DEBUG_COUNTERS_INC(opx_ep->debug_counters.reliability.replay_rzv);
+				}
+#endif
 				if (fi_opx_reliability_service_do_replay(service, replay) != FI_SUCCESS) {
 					queing_replays = true;
 
@@ -1741,6 +1751,16 @@ void fi_opx_hfi1_rx_reliability_nack (struct fid_ep *ep,
 				++sdma_count;
 			}
 		}
+#ifdef OPX_DEBUG_COUNTERS_RELIABILITY
+		struct fi_opx_ep *opx_ep = container_of(ep, struct fi_opx_ep, ep_fid);
+		if(replay->scb.hdr.stl.bth.opcode == FI_OPX_HFI_BTH_OPCODE_MSG_RZV_RTS || replay->scb.hdr.stl.bth.opcode == FI_OPX_HFI_BTH_OPCODE_TAG_RZV_RTS) {
+			FI_OPX_DEBUG_COUNTERS_INC(opx_ep->debug_counters.reliability.replay_rts);
+		} else if (replay->scb.hdr.stl.bth.opcode == FI_OPX_HFI_BTH_OPCODE_RZV_CTS) {
+			FI_OPX_DEBUG_COUNTERS_INC(opx_ep->debug_counters.reliability.replay_cts);
+		} else if (replay->scb.hdr.stl.bth.opcode == FI_OPX_HFI_BTH_OPCODE_RZV_DATA) {
+			FI_OPX_DEBUG_COUNTERS_INC(opx_ep->debug_counters.reliability.replay_rzv);
+		}
+#endif
 		fi_opx_reliability_service_do_replay_sdma(ep, service, sdma_start, replay->next, sdma_count);
 		replay = replay->next;
 	} while (replay != halt);

--- a/prov/opx/src/fi_opx_reliability.c
+++ b/prov/opx/src/fi_opx_reliability.c
@@ -1742,7 +1742,7 @@ void fi_opx_hfi1_rx_reliability_nack (struct fid_ep *ep,
 			replay = replay->next;
 			continue;
 		}
-		FI_DBG_TRACE(fi_opx_global.prov, FI_LOG_EP_DATA, "SDMA replay\n");
+		OPX_LOG_REL(FI_LOG_DEBUG, FI_LOG_EP_DATA, "SDMA replay\n");
 		uint32_t sdma_count = 1;
 		struct fi_opx_reliability_tx_replay *sdma_start = replay;
 		while (replay->next != halt && replay->next->use_sdma) {
@@ -2220,7 +2220,7 @@ uint8_t fi_opx_reliability_service_init (struct fi_opx_reliability_service * ser
 	service->backoff_period = 1;
 	if (env) {
 		unsigned long period = strtoul(env, NULL, 10);
-		FI_TRACE(fi_opx_global.prov, FI_LOG_EP_DATA, "FI_OPX_RELIABILITY_SERVICE_BACKOFF_PERIOD = '%s' (%lu)\n", env, period);
+		OPX_LOG_REL(FI_LOG_DEBUG, FI_LOG_EP_DATA,"FI_OPX_RELIABILITY_SERVICE_BACKOFF_PERIOD = '%s' (%lu)\n", env, period);
 		
 		service->is_backoff_enabled = 1;
 		service->backoff_period=(uint64_t)period;

--- a/prov/opx/src/fi_opx_service.c
+++ b/prov/opx/src/fi_opx_service.c
@@ -611,12 +611,14 @@ int opx_hfi_get_port_rate(int unit, int port)
 	}
 
 	free(data_rate);
+	data_rate = NULL;
 	return ((int)(rate * 2) >> 1);
 
 get_port_rate_error:
 	_HFI_INFO("Failed to get link rate for unit %u:%u: %s\n",
 		  unit, port, strerror(errno));
-
+	free(data_rate);
+	data_rate = NULL;
 	return ret;
 }
 

--- a/prov/opx/src/fi_opx_sysfs.c
+++ b/prov/opx/src/fi_opx_sysfs.c
@@ -244,6 +244,8 @@ static int opx_sysfs_unit_open_for_node(uint32_t unit, int flags)
 	}
 
 	errno = saved_errno;
+	free(path_copy);
+	path_copy = NULL;
 	return fd;
 }
 

--- a/prov/opx/src/fi_opx_tid_domain.c
+++ b/prov/opx/src/fi_opx_tid_domain.c
@@ -124,8 +124,11 @@ int fi_opx_tid_fabric(struct fi_opx_tid_fabric ** opx_tid_fabric)
 	dlist_init(&tid_fabric->util_fabric.domain_list);
 	ofi_mutex_init(&tid_fabric->util_fabric.lock);
 	tid_fabric->util_fabric.name = strdup(fi_opx_global.default_domain_attr->name);
-	if (!tid_fabric->util_fabric.name)
+	if (!tid_fabric->util_fabric.name){
+		free(tid_fabric);
+		tid_fabric = NULL;
 		return -FI_ENOMEM;
+	}
 
 	ofi_fabric_insert(&tid_fabric->util_fabric);
 	*opx_tid_fabric = tid_fabric;

--- a/prov/opx/src/opa_proto.c
+++ b/prov/opx/src/opa_proto.c
@@ -257,6 +257,7 @@ static int map_hfi_mem(int fd, struct _hfi_ctrl *ctrl, size_t subctxt_cnt)
 
 	/* 11a) subctxt_uregbase */
 	sz = HFI_MMAP_PGSIZE;
+	assert(sz > 0);
 	maddr = HFI_MMAP_ERRCHECK(fd, binfo, subctxt_uregbase, sz, PROT_READ|PROT_WRITE);
 	opx_hfi_touch_mmap(maddr, sz);
 	arrsz[SUBCTXT_UREGBASE] = sz;


### PR DESCRIPTION
Commits for OPX provider for 1.18. Included are:
-Bug fixes
-Observability enhancements
-Expected recv fixes (note that expected recv is still disabled by default for the OPX provider)
-Improved tag matching
-Some fixes meant to address some Coverity report issues