### PR TITLE
core/util_cq: split the cq progress and reading entries in ofi_cq_readfrom

### DIFF
--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -250,62 +250,13 @@ static void util_cq_read_tagged(void **dst, void *src)
 ssize_t ofi_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 			fi_addr_t *src_addr)
 {
-	struct fi_cq_tagged_entry *entry;
-	struct util_cq_aux_entry *aux_entry;
 	struct util_cq *cq;
-	ssize_t i;
 
 	cq = container_of(cq_fid, struct util_cq, cq_fid);
 
 	cq->progress(cq);
-	ofi_genlock_lock(&cq->cq_lock);
-	if (ofi_cirque_isempty(cq->cirq)) {
-		i = -FI_EAGAIN;
-		goto out;
-	}
 
-	if (count > ofi_cirque_usedcnt(cq->cirq))
-		count = ofi_cirque_usedcnt(cq->cirq);
-
-	for (i = 0; i < (ssize_t) count; i++) {
-		entry = ofi_cirque_head(cq->cirq);
-		if (!(entry->flags & UTIL_FLAG_AUX)) {
-			if (src_addr && cq->src)
-				src_addr[i] = cq->src[ofi_cirque_rindex(cq->cirq)];
-			cq->read_entry(&buf, entry);
-			ofi_cirque_discard(cq->cirq);
-		} else {
-			assert(!slist_empty(&cq->aux_queue));
-			aux_entry = container_of(cq->aux_queue.head,
-						 struct util_cq_aux_entry,
-						 list_entry);
-			assert(aux_entry->cq_slot == entry);
-			if (aux_entry->comp.err) {
-				if (!i)
-					i = -FI_EAVAIL;
-				break;
-			}
-
-			if (src_addr && cq->src)
-				src_addr[i] = aux_entry->src;
-			cq->read_entry(&buf, &aux_entry->comp);
-			slist_remove_head(&cq->aux_queue);
-			free(aux_entry);
-
-			if (slist_empty(&cq->aux_queue)) {
-				ofi_cirque_discard(cq->cirq);
-			} else {
-				aux_entry = container_of(cq->aux_queue.head,
-							struct util_cq_aux_entry,
-							list_entry);
-				if (aux_entry->cq_slot != ofi_cirque_head(cq->cirq))
-					ofi_cirque_discard(cq->cirq);
-			}
-		}
-	}
-out:
-	ofi_genlock_unlock(&cq->cq_lock);
-	return i;
+	return ofi_cq_read_entries(cq, buf, count, src_addr);
 }
 
 ssize_t ofi_cq_read(struct fid_cq *cq_fid, void *buf, size_t count)


### PR DESCRIPTION
Currently, ofi_cq_readfrom always progress the cq before reading the cq entries.
    When an owner provider is sharing its cq to a peer provider, it may first progress
    the peer provider cq via `fi_cq_read(peer_cq, NULL, 0)`. If a cqe is already written
    after the progress, the owner provider can just return it without progressing its owner
    cq again. So it is ideal to introduce a method to purely read the cq entries without
    progressing the cq. This patch is intended to make that goal. Based on this patch, the
    owner provider can return immediately after fi_cq_read(peer_cq, NULL, 0) is called and
    ofi_cq_read_entries returns a postive integer.