### PR TITLE
prov/efa: adopt to rdma-core API adjustment

### DIFF
--- a/prov/efa/src/efa_base_ep.c
+++ b/prov/efa/src/efa_base_ep.c
@@ -354,8 +354,12 @@ int efa_base_ep_getname(fid_t fid, void *addr, size_t *addrlen)
 #if HAVE_EFA_DATA_IN_ORDER_ALIGNED_128_BYTES
 bool efa_base_ep_support_op_in_order_aligned_128_bytes(struct efa_base_ep *base_ep, enum ibv_wr_opcode op)
 {
-	return ibv_query_qp_data_in_order(base_ep->qp, op,
-					  IBV_QUERY_QP_DATA_IN_ORDER_ALIGNED_128_BYTES);
+	int caps;
+
+	caps = ibv_query_qp_data_in_order(base_ep->qp, op,
+					  IBV_QUERY_QP_DATA_IN_ORDER_RETURN_CAPS);
+
+	return caps == IBV_QUERY_QP_DATA_IN_ORDER_ALIGNED_128_BYTES;
 }
 #else
 bool efa_base_ep_support_op_in_order_aligned_128_bytes(struct efa_base_ep *base_ep, enum ibv_wr_opcode op)


### PR DESCRIPTION
There has been adjustment regarding rdma-core API
ibv_query_qp_data_in_order(). This patch adjust
the code accordingly.