### PR TITLE
prov/tcp: Reduce stack size for epoll event array

### DIFF
--- a/prov/tcp/src/xnet.h
+++ b/prov/tcp/src/xnet.h
@@ -69,7 +69,7 @@
 
 #define XNET_RDM_VERSION	0
 #define XNET_DEF_INJECT		128
-#define XNET_MAX_EVENTS		1024
+#define XNET_MAX_EVENTS		128
 #define XNET_MIN_MULTI_RECV	16384
 #define XNET_PORT_MAX_RANGE	(USHRT_MAX)
 
@@ -325,6 +325,7 @@ struct xnet_progress {
 	struct ofi_sockapi	sockapi;
 
 	struct ofi_dynpoll	epoll_fd;
+	struct ofi_epollfds_event events[XNET_MAX_EVENTS];
 
 	bool			auto_progress;
 	pthread_t		thread;

--- a/prov/tcp/src/xnet_progress.c
+++ b/prov/tcp/src/xnet_progress.c
@@ -1252,13 +1252,12 @@ void xnet_progress_unexp(struct xnet_progress *progress)
 
 void xnet_run_progress(struct xnet_progress *progress, bool clear_signal)
 {
-	struct ofi_epollfds_event events[XNET_MAX_EVENTS];
 	int nfds;
 
 	assert(ofi_genlock_held(progress->active_lock));
-	nfds = ofi_dynpoll_wait(&progress->epoll_fd, events,
-				XNET_MAX_EVENTS, 0);
-	xnet_handle_events(progress, events, nfds, clear_signal);
+	nfds = ofi_dynpoll_wait(&progress->epoll_fd, &progress->events[0],
+				ARRAY_SIZE(progress->events), 0);
+	xnet_handle_events(progress, &progress->events[0], nfds, clear_signal);
 }
 
 void xnet_progress(struct xnet_progress *progress, bool clear_signal)


### PR DESCRIPTION
Allocate the epoll event array dynamically with the progress engine to reduce the stack size (2 x 8 bytes x 1024 entries). Further reduce the memory by setting max events down to 128 from 1024, since epoll implements fairness on event reporting. (This was verified using a modified version of sock_test.)