### PR TITLE
prov/tcp: Move io_uring cqe from the stack to progress struct

### DIFF
--- a/prov/tcp/src/xnet.h
+++ b/prov/tcp/src/xnet.h
@@ -322,6 +322,8 @@ struct xnet_progress {
 
 	struct xnet_uring	tx_uring;
 	struct xnet_uring	rx_uring;
+	ofi_io_uring_cqe_t	**cqes;
+
 	struct ofi_sockapi	sockapi;
 
 	struct ofi_dynpoll	epoll_fd;

--- a/util/info.c
+++ b/util/info.c
@@ -324,7 +324,7 @@ static int run(struct fi_info *hints, char *node, char *port, uint64_t flags)
 	ret = fi_getinfo(FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION),
 			 node, port, flags, hints, &info);
 	if (ret) {
-		fprintf(stderr, "fi_getinfo: %d\n", ret);
+		fprintf(stderr, "fi_getinfo: %d (%s)\n", ret, fi_strerror(-ret));
 		return ret;
 	}
 


### PR DESCRIPTION
Reduce stack use by allocating the io_uring events with the progress structure, rather than on the stack.

note: untested (system developed on doesn't even have io_uring, so compile is questionable atm).