### PR TITLE
core/tostr: Moved ofi_strncatf() and ofi_nic_tostr() to ofi_str.c.

### DIFF
--- a/include/ofi.h
+++ b/include/ofi.h
@@ -257,7 +257,6 @@ int ofi_apply_filter(struct ofi_filter *filter, const char *name);
 
 int ofi_nic_close(struct fid *fid);
 struct fid_nic *ofi_nic_dup(const struct fid_nic *nic);
-int ofi_nic_tostr(const struct fid *fid_nic, char *buf, size_t len);
 
 void fi_log_init(void);
 void fi_log_fini(void);
@@ -265,7 +264,6 @@ void fi_param_init(void);
 void fi_param_fini(void);
 void fi_param_undefine(const struct fi_provider *provider);
 void ofi_remove_comma(char *buffer);
-void ofi_strncatf(char *dest, size_t n, const char *fmt, ...);
 void ofi_dump_sysconfig(void);
 
 const char *ofi_hex_str(const uint8_t *data, size_t len);

--- a/include/shared/ofi_str.h
+++ b/include/shared/ofi_str.h
@@ -37,6 +37,7 @@
 #include <string.h>
 #include <stdint.h>
 
+#include <rdma/fabric.h>
 #include "config.h"
 
 #ifdef __cplusplus
@@ -49,6 +50,8 @@ char **ofi_split_and_alloc(const char *s, const char *delim, size_t *count);
 void ofi_free_string_array(char **s);
 char *ofi_tostr_size(char *str, size_t len, uint64_t size);
 char *ofi_tostr_count(char *str, size_t len, uint64_t count);
+void ofi_strncatf(char *dest, size_t n, const char *fmt, ...);
+int ofi_nic_tostr(const struct fid *fid_nic, char *buf, size_t len);
 
 #ifdef __cplusplus
 }

--- a/src/common.c
+++ b/src/common.c
@@ -2238,16 +2238,6 @@ void ofi_remove_comma(char *buffer)
 		buffer[sz-2] = '\0';
 }
 
-void ofi_strncatf(char *dest, size_t n, const char *fmt, ...)
-{
-	size_t len = strnlen(dest, n);
-	va_list arglist;
-
-	va_start(arglist, fmt);
-	vsnprintf(&dest[len], n - 1 - len, fmt, arglist);
-	va_end(arglist);
-}
-
 /* The provider must free any prov_attr data prior to calling this
  * routine.
  */
@@ -2291,110 +2281,6 @@ int ofi_nic_control(struct fid *fid, int command, void *arg)
 	default:
 		return -FI_ENOSYS;
 	}
-}
-
-static void ofi_tostr_device_attr(char *buf, size_t len,
-				  const struct fi_device_attr *attr)
-{
-	const char *prefix = TAB TAB;
-
-	ofi_strncatf(buf, len, "%sfi_device_attr:\n", prefix);
-
-	prefix = TAB TAB TAB;
-	ofi_strncatf(buf, len, "%sname: %s\n", prefix, attr->name);
-	ofi_strncatf(buf, len, "%sdevice_id: %s\n", prefix, attr->device_id);
-	ofi_strncatf(buf, len, "%sdevice_version: %s\n", prefix,
-		     attr->device_version);
-	ofi_strncatf(buf, len, "%svendor_id: %s\n", prefix, attr->vendor_id);
-	ofi_strncatf(buf, len, "%sdriver: %s\n", prefix, attr->driver);
-	ofi_strncatf(buf, len, "%sfirmware: %s\n", prefix, attr->firmware);
-}
-
-static void ofi_tostr_pci_attr(char *buf, size_t len,
-			       const struct fi_pci_attr *attr)
-{
-	const char *prefix = TAB TAB TAB;
-
-	ofi_strncatf(buf, len, "%sfi_pci_attr:\n", prefix);
-
-	prefix = TAB TAB TAB TAB;
-	ofi_strncatf(buf, len, "%sdomain_id: %u\n", prefix, attr->domain_id);
-	ofi_strncatf(buf, len, "%sbus_id: %u\n", prefix, attr->bus_id);
-	ofi_strncatf(buf, len, "%sdevice_id: %u\n", prefix, attr->device_id);
-	ofi_strncatf(buf, len, "%sfunction_id: %u\n", prefix, attr->function_id);
-}
-
-static void ofi_tostr_bus_type(char *buf, size_t len, int type)
-{
-	switch (type) {
-	CASEENUMSTRN(FI_BUS_UNKNOWN, len);
-	CASEENUMSTRN(FI_BUS_PCI, len);
-	default:
-		ofi_strncatf(buf, len, "Unknown");
-		break;
-	}
-}
-
-static void ofi_tostr_bus_attr(char *buf, size_t len,
-			       const struct fi_bus_attr *attr)
-{
-	const char *prefix = TAB TAB;
-
-	ofi_strncatf(buf, len, "%sfi_bus_attr:\n", prefix);
-
-	prefix = TAB TAB TAB;
-	ofi_strncatf(buf, len, "%sbus_type: ", prefix);
-	ofi_tostr_bus_type(buf, len, attr->bus_type);
-	ofi_strncatf(buf, len, "\n");
-
-	switch (attr->bus_type) {
-	case FI_BUS_PCI:
-		ofi_tostr_pci_attr(buf, len, &attr->attr.pci);
-		break;
-	default:
-		break;
-	}
-}
-
-static void ofi_tostr_link_state(char *buf, size_t len, int state)
-{
-	switch (state) {
-	CASEENUMSTRN(FI_LINK_UNKNOWN, len);
-	CASEENUMSTRN(FI_LINK_DOWN, len);
-	CASEENUMSTRN(FI_LINK_UP, len);
-	default:
-		ofi_strncatf(buf, len, "Unknown");
-		break;
-	}
-}
-
-static void ofi_tostr_link_attr(char *buf, size_t len,
-				const struct fi_link_attr *attr)
-{
-	const char *prefix = TAB TAB;
-	ofi_strncatf(buf, len, "%sfi_link_attr:\n", prefix);
-
-	prefix = TAB TAB TAB;
-	ofi_strncatf(buf, len, "%saddress: %s\n", prefix, attr->address);
-	ofi_strncatf(buf, len, "%smtu: %zu\n", prefix, attr->mtu);
-	ofi_strncatf(buf, len, "%sspeed: %zu\n", prefix, attr->speed);
-	ofi_strncatf(buf, len, "%sstate: ", prefix);
-	ofi_tostr_link_state(buf, len, attr->state);
-	ofi_strncatf(buf, len, "\n%snetwork_type: %s\n", prefix,
-		     attr->network_type);
-}
-
-int ofi_nic_tostr(const struct fid *fid_nic, char *buf, size_t len)
-{
-	const struct fid_nic *nic = (const struct fid_nic*) fid_nic;
-
-	assert(fid_nic->fclass == FI_CLASS_NIC);
-	ofi_strncatf(buf, len, "%snic:\n", TAB);
-
-	ofi_tostr_device_attr(buf, len, nic->device_attr);
-	ofi_tostr_bus_attr(buf, len, nic->bus_attr);
-	ofi_tostr_link_attr(buf, len, nic->link_attr);
-	return 0;
 }
 
 struct fi_ops default_nic_ops = {

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -44,6 +44,7 @@
 #include <arpa/inet.h>
 
 #include "ofi.h"
+#include "shared/ofi_str.h"
 #include <rdma/fabric.h>
 #include <rdma/fi_domain.h>
 #include <rdma/fi_endpoint.h>

--- a/src/log.c
+++ b/src/log.c
@@ -41,6 +41,7 @@
 #include <rdma/fi_ext.h>
 
 #include "ofi.h"
+#include "shared/ofi_str.h"
 #include "ofi_enosys.h"
 #include "ofi_util.h"
 

--- a/src/shared/ofi_str.c
+++ b/src/shared/ofi_str.c
@@ -148,6 +148,16 @@ void ofi_free_string_array(char **s)
 	free(s);
 }
 
+void ofi_strncatf(char *dest, size_t n, const char *fmt, ...)
+{
+	size_t len = strnlen(dest, n);
+	va_list arglist;
+
+	va_start(arglist, fmt);
+	vsnprintf(&dest[len], n - 1 - len, fmt, arglist);
+	va_end(arglist);
+}
+
 char *ofi_tostr_size(char *str, size_t len, uint64_t size)
 {
 	uint64_t base = 0;
@@ -191,4 +201,108 @@ char *ofi_tostr_count(char *str, size_t len, uint64_t count)
 		ofi_strncatf(str, len, "%lu", count);
 
 	return str;
+}
+
+static void ofi_tostr_device_attr(char *buf, size_t len,
+				  const struct fi_device_attr *attr)
+{
+	const char *prefix = TAB TAB;
+
+	ofi_strncatf(buf, len, "%sfi_device_attr:\n", prefix);
+
+	prefix = TAB TAB TAB;
+	ofi_strncatf(buf, len, "%sname: %s\n", prefix, attr->name);
+	ofi_strncatf(buf, len, "%sdevice_id: %s\n", prefix, attr->device_id);
+	ofi_strncatf(buf, len, "%sdevice_version: %s\n", prefix,
+		     attr->device_version);
+	ofi_strncatf(buf, len, "%svendor_id: %s\n", prefix, attr->vendor_id);
+	ofi_strncatf(buf, len, "%sdriver: %s\n", prefix, attr->driver);
+	ofi_strncatf(buf, len, "%sfirmware: %s\n", prefix, attr->firmware);
+}
+
+static void ofi_tostr_pci_attr(char *buf, size_t len,
+			       const struct fi_pci_attr *attr)
+{
+	const char *prefix = TAB TAB TAB;
+
+	ofi_strncatf(buf, len, "%sfi_pci_attr:\n", prefix);
+
+	prefix = TAB TAB TAB TAB;
+	ofi_strncatf(buf, len, "%sdomain_id: %u\n", prefix, attr->domain_id);
+	ofi_strncatf(buf, len, "%sbus_id: %u\n", prefix, attr->bus_id);
+	ofi_strncatf(buf, len, "%sdevice_id: %u\n", prefix, attr->device_id);
+	ofi_strncatf(buf, len, "%sfunction_id: %u\n", prefix, attr->function_id);
+}
+
+static void ofi_tostr_bus_type(char *buf, size_t len, int type)
+{
+	switch (type) {
+	CASEENUMSTRN(FI_BUS_UNKNOWN, len);
+	CASEENUMSTRN(FI_BUS_PCI, len);
+	default:
+		ofi_strncatf(buf, len, "Unknown");
+		break;
+	}
+}
+
+static void ofi_tostr_bus_attr(char *buf, size_t len,
+			       const struct fi_bus_attr *attr)
+{
+	const char *prefix = TAB TAB;
+
+	ofi_strncatf(buf, len, "%sfi_bus_attr:\n", prefix);
+
+	prefix = TAB TAB TAB;
+	ofi_strncatf(buf, len, "%sbus_type: ", prefix);
+	ofi_tostr_bus_type(buf, len, attr->bus_type);
+	ofi_strncatf(buf, len, "\n");
+
+	switch (attr->bus_type) {
+	case FI_BUS_PCI:
+		ofi_tostr_pci_attr(buf, len, &attr->attr.pci);
+		break;
+	default:
+		break;
+	}
+}
+
+static void ofi_tostr_link_state(char *buf, size_t len, int state)
+{
+	switch (state) {
+	CASEENUMSTRN(FI_LINK_UNKNOWN, len);
+	CASEENUMSTRN(FI_LINK_DOWN, len);
+	CASEENUMSTRN(FI_LINK_UP, len);
+	default:
+		ofi_strncatf(buf, len, "Unknown");
+		break;
+	}
+}
+
+static void ofi_tostr_link_attr(char *buf, size_t len,
+				const struct fi_link_attr *attr)
+{
+	const char *prefix = TAB TAB;
+	ofi_strncatf(buf, len, "%sfi_link_attr:\n", prefix);
+
+	prefix = TAB TAB TAB;
+	ofi_strncatf(buf, len, "%saddress: %s\n", prefix, attr->address);
+	ofi_strncatf(buf, len, "%smtu: %zu\n", prefix, attr->mtu);
+	ofi_strncatf(buf, len, "%sspeed: %zu\n", prefix, attr->speed);
+	ofi_strncatf(buf, len, "%sstate: ", prefix);
+	ofi_tostr_link_state(buf, len, attr->state);
+	ofi_strncatf(buf, len, "\n%snetwork_type: %s\n", prefix,
+		     attr->network_type);
+}
+
+int ofi_nic_tostr(const struct fid *fid_nic, char *buf, size_t len)
+{
+	const struct fid_nic *nic = (const struct fid_nic*) fid_nic;
+
+	assert(fid_nic->fclass == FI_CLASS_NIC);
+	ofi_strncatf(buf, len, "%snic:\n", TAB);
+
+	ofi_tostr_device_attr(buf, len, nic->device_attr);
+	ofi_tostr_bus_attr(buf, len, nic->bus_attr);
+	ofi_tostr_link_attr(buf, len, nic->link_attr);
+	return 0;
 }


### PR DESCRIPTION
Moved functions ofi_strncatf(), ofi_nic_tostr() and other static ofi_tostr_xxx functions from common.c to ofi_str.c. The declaration of these functions are moved from ofi.h to ofi_str.h.