### PR TITLE
man/fi_efa: add write-once guarantee for IN_ORDER_ALIGNED_128 flags

### DIFF
--- a/man/fi_efa.7.md
+++ b/man/fi_efa.7.md
@@ -122,13 +122,16 @@ provider for AWS Neuron or Habana SynapseAI.
 *FI_OPT_EFA_SENDRECV_IN_ORDER_ALIGNED_128_BYTES - bool*
 : It is used to force the endpoint to use in-order send/recv operation for each 128 bytes
   aligned block. Enabling the option will guarantee data inside each 128 bytes
-  aligned block being sent and received in order. If endpoint is not able to
+  aligned block being sent and received in order, it will also guarantee data
+  to be delivered to the receive buffer only once. If endpoint is not able to
   support this feature, it will return -FI_EOPNOTSUPP for the call to fi_setopt().
+
 
 *FI_OPT_EFA_WRITE_IN_ORDER_ALIGNED_128_BYTES - bool*
 : It is used to set the endpoint to use in-order RDMA write operation for each 128 bytes
   aligned block. Enabling the option will guarantee data inside each 128 bytes
-  aligned block being written in order. If endpoint is not able to support
+  aligned block being written in order, it will also guarantee data to be
+  delivered to the target buffer only once. If endpoint is not able to support
   this feature, it will return -FI_EOPNOTSUPP for the call to fi_setopt().
 
 # RUNTIME PARAMETERS


### PR DESCRIPTION
Clarify that those flags will also support write-once semantic