### PR TITLE
core/hmem_cuda: expose cuda_is_device_id API

### DIFF
--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -176,6 +176,7 @@ enum cuda_xfer_setting cuda_get_xfer_setting(void);
 bool cuda_is_ipc_enabled(void);
 int cuda_get_ipc_handle_size(size_t *size);
 bool cuda_is_gdrcopy_enabled(void);
+bool cuda_is_device_id(uint64_t device);
 
 void cuda_gdrcopy_to_dev(uint64_t handle, void *dev,
 			 const void *host, size_t size);

--- a/src/hmem_cuda.c
+++ b/src/hmem_cuda.c
@@ -221,7 +221,7 @@ static cudaError_t ofi_cudaGetDeviceCount(int *count)
 	return cuda_ops.cudaGetDeviceCount(count);
 }
 
-static bool ofi_cudaIsDeviceId(uint64_t device) {
+bool cuda_is_device_id(uint64_t device) {
 	return device < cuda_device_count;
 }
 
@@ -237,7 +237,7 @@ cudaError_t ofi_cudaFree(void *ptr)
 
 int cuda_copy_to_dev(uint64_t device, void *dst, const void *src, size_t size)
 {
-	if (hmem_cuda_use_gdrcopy && !ofi_cudaIsDeviceId(device)) {
+	if (hmem_cuda_use_gdrcopy && !cuda_is_device_id(device)) {
 		cuda_gdrcopy_to_dev(device, dst, src, size);
 		return FI_SUCCESS;
 	}
@@ -258,7 +258,7 @@ int cuda_copy_to_dev(uint64_t device, void *dst, const void *src, size_t size)
 
 int cuda_copy_from_dev(uint64_t device, void *dst, const void *src, size_t size)
 {
-	if (hmem_cuda_use_gdrcopy && !ofi_cudaIsDeviceId(device)) {
+	if (hmem_cuda_use_gdrcopy && !cuda_is_device_id(device)) {
 		cuda_gdrcopy_from_dev(device, dst, src, size);
 		return FI_SUCCESS;
 	}


### PR DESCRIPTION
cuda currently supports 2 memcpy ops, i.e. cudaMemcpy(always available) and gdrcopy. struct ofi_mr->device is the only attribute to determine if gdrcopy can be used.

This patch renames ofi_cudaIsDeviceId and exposes it to provider code, thus enables provider to switch between the memcpy ops and achieve performance gains.

Related: https://github.com/ofiwg/libfabric/issues/8745