### PR TITLE
prov/shm: store incoming message size in tagged rx_entry.

### DIFF
--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -878,6 +878,7 @@ static int smr_progress_cmd_msg(struct smr_ep *ep, struct smr_cmd *cmd)
 			if (ret)
 				return ret;
 
+			rx_entry->size = cmd->msg.hdr.size;
 			ret = peer_srx->owner_ops->queue_tag(rx_entry);
 			goto out;
 		}


### PR DESCRIPTION
Currently, when getting an unexpected tagged msg, shm does not fill the size of incoming message to the rx_entry before queueing it. However, middlewares like MPI will call fi_trecvmsg with FI_PEEK flag in MPI_Probe() to peek if there is an incoming message, and application will call MPI_Get_count to derive the size of the incoming message from the output of MPI_Probe(). In this case, shm needs to store the incoming message size in tagged rx_entry before queueing it, so owner provider can get the size and write it in the CQE for FI_PEEK.