### PR TITLE
prov/efa: update rx_entry.total_len in srx queue_tag

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_srx.c
+++ b/prov/efa/src/rdm/efa_rdm_srx.c
@@ -228,6 +228,12 @@ static int efa_rdm_srx_queue_tag(struct fi_peer_rx_entry *peer_rx_entry)
 	ep = rx_entry->ep;
 
 	ofi_mutex_lock(&ep->base_ep.util_ep.lock);
+	/*
+	 * rx_entry->peer_rx_entry.size is updated by peer provider before calling queue_tag.
+	 * we can remove this line after replacing total_len by peer_rx_entry.size in all
+	 * the efa provider code.
+	 */
+	rx_entry->total_len = rx_entry->peer_rx_entry.size;
 	rxr_msg_queue_unexp_rx_entry_for_tagrtm(ep, rx_entry);
 	ofi_mutex_unlock(&ep->base_ep.util_ep.lock);
 	return FI_SUCCESS;


### PR DESCRIPTION
Currently, when peer provider getting an unexpected tagged msg, efa incorrectly set the total_len in the unexp rx entry as 0 because get_tag API does not have size as the input. However, middlewares like MPI will call fi_trecvmsg with FI_PEEK flag in MPI_Probe() to peek if there is an incoming message, and application will call MPI_Get_count to derive the size of the incoming message from the output of MPI_Probe(). In this case, efa needs to store the incoming message size in tagged rx_entry before queueing it, so efa can get the size and write it in the CQE after finding the rx_entry in the unexp queue.

The value of peer_rx_entry.size will be updated by peer provider before calling queue_tag.