### PR TITLE
core/fi_peer, prov/efa,shm,sm2: add size as an input of get_tag op

### DIFF
--- a/include/rdma/providers/fi_peer.h
+++ b/include/rdma/providers/fi_peer.h
@@ -161,7 +161,7 @@ struct fi_ops_srx_owner {
 	int	(*get_msg)(struct fid_peer_srx *srx, fi_addr_t addr,
 			size_t size, struct fi_peer_rx_entry **entry);
 	int	(*get_tag)(struct fid_peer_srx *srx, fi_addr_t addr,
-			uint64_t tag, struct fi_peer_rx_entry **entry);
+			size_t size, uint64_t tag, struct fi_peer_rx_entry **entry);
 	int	(*queue_msg)(struct fi_peer_rx_entry *entry);
 	int	(*queue_tag)(struct fi_peer_rx_entry *entry);
 

--- a/man/fi_peer.3.md
+++ b/man/fi_peer.3.md
@@ -384,7 +384,7 @@ struct fi_ops_srx_owner {
     int (*get_msg)(struct fid_peer_srx *srx, fi_addr_t addr,
                    size_t size, struct fi_peer_rx_entry **entry);
     int (*get_tag)(struct fid_peer_srx *srx, fi_addr_t addr,
-                   uint64_t tag, struct fi_peer_rx_entry **entry);
+                   size_t size, uint64_t tag, struct fi_peer_rx_entry **entry);
     int (*queue_msg)(struct fi_peer_rx_entry *entry);
     int (*queue_tag)(struct fi_peer_rx_entry *entry);
     void (*free_entry)(struct fi_peer_rx_entry *entry);
@@ -429,8 +429,11 @@ where an incoming message should be placed.  The peer provider will pass in
 the relevant fields to request a matching rx_entry from the owner.  If source
 addressing is required, the addr will be passed in; otherwise, the address will
 be set to FI_ADDR_NOT_AVAIL.  The size field indicates the received message size.
-This field is used by the owner when handling multi-received data buffers, but may
-be ignored otherwise.  The peer provider is responsible for checking that an incoming
+For non-tagged message, this field is used by the owner when handling multi-received
+data buffers, but may be ignored otherwise. For tagged message, this field is used
+by the owner when handling trecvmsg with FI_PEEK bit set in flags,
+which requires the owner to write the size of the unexpected tagged message as part
+of the CQ entry. The peer provider is responsible for checking that an incoming
 message fits within the provided buffer space. The tag parameter is used for tagged
 messages.  An fi_peer_rx_entry is allocated by the owner, whether or not a match was
 found. If a match was found, the owner will return FI_SUCCESS and the rx_entry will

--- a/prov/efa/src/rdm/efa_rdm_srx.c
+++ b/prov/efa/src/rdm/efa_rdm_srx.c
@@ -150,7 +150,7 @@ out:
  * @return int 0 on success, a negative integer on failure
  */
 static int efa_rdm_srx_get_tag(struct fid_peer_srx *srx, fi_addr_t addr,
-			uint64_t tag, struct fi_peer_rx_entry **peer_rx_entry)
+			size_t size, uint64_t tag, struct fi_peer_rx_entry **peer_rx_entry)
 {
 	struct rxr_ep *rxr_ep;
 	struct rxr_pkt_entry *pkt_entry;
@@ -168,7 +168,7 @@ static int efa_rdm_srx_get_tag(struct fid_peer_srx *srx, fi_addr_t addr,
 	 * is needed to split the context (addr, size etc.) and data from pkt entry
 	 * and make rxr_*_get_*_rx_entry needs context only.
 	 */
-	efa_rdm_srx_construct_pkt_entry(pkt_entry, addr, 0, tag, ofi_op_tagged);
+	efa_rdm_srx_construct_pkt_entry(pkt_entry, addr, size, tag, ofi_op_tagged);
 
 	ofi_mutex_lock(&rxr_ep->base_ep.util_ep.lock);
 	rx_entry = rxr_pkt_get_tagrtm_rx_entry(rxr_ep, &pkt_entry);

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -1413,7 +1413,7 @@ out:
 }
 
 static int smr_get_tag(struct fid_peer_srx *srx, fi_addr_t addr,
-			uint64_t tag, struct fi_peer_rx_entry **rx_entry)
+			size_t size, uint64_t tag, struct fi_peer_rx_entry **rx_entry)
 {
 	struct smr_rx_entry *smr_entry;
 	struct smr_srx_ctx *srx_ctx;
@@ -1437,6 +1437,7 @@ static int smr_get_tag(struct fid_peer_srx *srx, fi_addr_t addr,
 		} else {
 			smr_entry->peer_entry.owner_context = NULL;
 			smr_entry->peer_entry.addr = addr;
+			smr_entry->peer_entry.size = size;
 			smr_entry->peer_entry.tag = tag;
 			smr_entry->peer_entry.srx = srx;
 			*rx_entry = &smr_entry->peer_entry;

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -871,7 +871,7 @@ static int smr_progress_cmd_msg(struct smr_ep *ep, struct smr_cmd *cmd)
 	addr = ep->region->map->peers[cmd->msg.hdr.id].fiaddr;
 	if (cmd->msg.hdr.op == ofi_op_tagged) {
 		ret = peer_srx->owner_ops->get_tag(peer_srx, addr,
-				cmd->msg.hdr.tag, &rx_entry);
+				cmd->msg.hdr.size, cmd->msg.hdr.tag, &rx_entry);
 		ofi_ep_lock_release(&ep->util_ep);
 		if (ret == -FI_ENOENT) {
 			ret = smr_alloc_cmd_ctx(ep, rx_entry, cmd);

--- a/prov/sm2/src/sm2_ep.c
+++ b/prov/sm2/src/sm2_ep.c
@@ -647,7 +647,7 @@ out:
 }
 
 static int sm2_get_tag(struct fid_peer_srx *srx, fi_addr_t addr,
-			uint64_t tag, struct fi_peer_rx_entry **rx_entry)
+			size_t size, uint64_t tag, struct fi_peer_rx_entry **rx_entry)
 {
 	struct sm2_rx_entry *sm2_entry;
 	struct sm2_srx_ctx *srx_ctx;
@@ -671,6 +671,7 @@ static int sm2_get_tag(struct fid_peer_srx *srx, fi_addr_t addr,
 		} else {
 			sm2_entry->peer_entry.owner_context = NULL;
 			sm2_entry->peer_entry.addr = addr;
+			sm2_entry->peer_entry.size = size;
 			sm2_entry->peer_entry.tag = tag;
 			sm2_entry->peer_entry.srx = srx;
 			*rx_entry = &sm2_entry->peer_entry;

--- a/prov/sm2/src/sm2_progress.c
+++ b/prov/sm2/src/sm2_progress.c
@@ -326,7 +326,7 @@ static int sm2_progress_cmd_msg(struct sm2_ep *ep, struct sm2_cmd *cmd)
 	addr = ep->region->map->peers[cmd->msg.hdr.id].fiaddr;
 	if (cmd->msg.hdr.op == ofi_op_tagged) {
 		ret = peer_srx->owner_ops->get_tag(peer_srx, addr,
-				cmd->msg.hdr.tag, &rx_entry);
+				cmd->msg.hdr.size, cmd->msg.hdr.tag, &rx_entry);
 		if (ret == -FI_ENOENT) {
 			ret = sm2_alloc_cmd_ctx(ep, rx_entry, cmd);
 			if (ret)


### PR DESCRIPTION
Currently, get_tag does not have size as input. However,
    middlewares like MPI will call fi_trecvmsg with FI_PEEK
    flag in MPI_Probe() to peek if there is an incoming message,
    and application will call MPI_Get_count to derive the size of
    the incoming message from the output of MPI_Probe().
    In this case, owner provider needs to store the incoming message
    size in the unexp tagged rx_entry, so it can write it in the CQE
    for FI_PEEK.