### PR TITLE
[v1.18.x] src/hmem_ze: fix ZE is valid check

### DIFF
--- a/src/hmem_ze.c
+++ b/src/hmem_ze.c
@@ -970,7 +970,7 @@ bool ze_hmem_is_addr_valid(const void *addr, uint64_t *device, uint64_t *flags)
 
 	ze_ret = ofi_zeMemGetAllocProperties(context, addr, &mem_props,
 					     &device_ptr);
-	if (ze_ret)
+	if (ze_ret || mem_props.type == ZE_MEMORY_TYPE_UNKNOWN)
 		return false;
 
 	if (flags)


### PR DESCRIPTION
When seeing if an address is valid within ZE, non ZE allocated memory will still return success but will set the memory type as unknown. Check this and return false if unknown

Cherry-picked from commit bf2b88c434706196a2c73c5484b1d133c09ae3b9