### PR TITLE
fabtests/functional: av_xfer test remove av before sync

### DIFF
--- a/fabtests/functional/av_xfer.c
+++ b/fabtests/functional/av_xfer.c
@@ -109,6 +109,13 @@ static int av_removal_test(void)
 		}
 	}
 
+	/* Purge the av before sync to avoid unexpected completions */
+	ret = fi_av_remove(av, &remote_fi_addr, 1, 0);
+	if (ret) {
+		FT_PRINTERR("fi_av_remove", ret);
+		goto out;
+	}
+
 	(void) ft_sync();
 out:
 	fprintf(stdout, "%s\n", ret ? "FAIL" : "PASS");
@@ -175,6 +182,13 @@ static int av_reinsert_test(void)
 			FT_PRINTERR("ft_rx", -ret);
 			goto out;
 		}
+	}
+
+	/* Purge the av before sync to avoid unexpected completions */
+	ret = fi_av_remove(av, &remote_fi_addr, 1, 0);
+	if (ret) {
+		FT_PRINTERR("fi_av_remove", ret);
+		goto out;
 	}
 
 	(void) ft_sync();


### PR DESCRIPTION
    This test occasionally fails under load for EFA provider due to its
    handshake protocol. The recv completion triggers a handshake exchange
    that could outlast ft_sync. This causes the sender(client) to receive 2
    handshake acknowledgements from the same receiver(server). This is
    an unexpected behavior.
    
    To prevent such issues, the test should remove the peer address from the
    av before ft_sync. For EFA provider, this allows the endpoint to ignore
    the completions from its peer, thus avoiding the unexpected behavior.