### PR TITLE
prov/shm: Fix ROCR data coherency

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -56,6 +56,8 @@ struct ofi_mr_info {
 	struct iovec iov;
 	enum fi_hmem_iface iface;
 	uint64_t device;
+
+	uint64_t peer_id;
 	void     *ipc_mapped_addr;
 	uint8_t  ipc_handle[MAX_IPC_HANDLE_SIZE];
 };
@@ -351,8 +353,9 @@ void ofi_mr_cache_notify(struct ofi_mr_cache *cache, const void *addr, size_t le
 int ofi_ipc_cache_open(struct ofi_mr_cache **cache,
 			struct util_domain *domain);
 void ofi_ipc_cache_destroy(struct ofi_mr_cache *cache);
-int  ofi_ipc_cache_search(struct ofi_mr_cache *cache, struct ipc_info *ipc_info,
-			   struct ofi_mr_entry **mr_entry);
+int  ofi_ipc_cache_search(struct ofi_mr_cache *cache, uint64_t peer_id,
+			  struct ipc_info *ipc_info,
+			  struct ofi_mr_entry **mr_entry);
 
 static inline bool ofi_mr_cache_full(struct ofi_mr_cache *cache)
 {

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -383,6 +383,8 @@ static int efa_mr_cache_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	struct ofi_mr_info info;
 	int ret;
 
+	memset(&info, 0, sizeof(info));
+
 	if (attr->iface == FI_HMEM_NEURON || attr->iface == FI_HMEM_SYNAPSEAI)
 		flags |= OFI_MR_NOCACHE;
 

--- a/prov/opx/include/fi_opx_tid_cache.h
+++ b/prov/opx/include/fi_opx_tid_cache.h
@@ -85,6 +85,7 @@ static inline int opx_tid_cache_open_region(struct fi_opx_tid_domain *opx_tid_do
 
 	struct ofi_mr_entry *entry = NULL;
 	struct ofi_mr_info info;
+	memset(&info, 0, sizeof(info));
 	opx_tid_cache_flush(opx_tid_domain, false);
 
 	info.iov.iov_base = (void *)buf;

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -572,8 +572,9 @@ static struct smr_pend_entry *smr_progress_ipc(struct smr_cmd *cmd,
 				&ipc_fd, ipc_device, &base);
 	} else {
 		ret = ofi_ipc_cache_search(domain->ipc_cache,
-				           &cmd->msg.data.ipc_info,
-				           &mr_entry);
+					   cmd->msg.hdr.id,
+					   &cmd->msg.data.ipc_info,
+					   &mr_entry);
 	}
 	if (ret)
 		goto out;

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -56,6 +56,11 @@ static int util_mr_find_within(struct ofi_rbmap *map, void *key, void *data)
 	struct ofi_mr_entry *entry = data;
 	struct ofi_mr_info *info = key;
 
+	if (info->peer_id < entry->info.peer_id)
+		return -1;
+	if (info->peer_id > entry->info.peer_id)
+		return 1;
+
 	if (ofi_iov_shifted_left(&info->iov, &entry->info.iov))
 		return -1;
 	if (ofi_iov_shifted_right(&info->iov, &entry->info.iov))
@@ -68,6 +73,11 @@ static int util_mr_find_overlap(struct ofi_rbmap *map, void *key, void *data)
 {
 	struct ofi_mr_entry *entry = data;
 	struct ofi_mr_info *info = key;
+
+	if (info->peer_id < entry->info.peer_id)
+		return -1;
+	if (info->peer_id > entry->info.peer_id)
+		return 1;
 
 	if (ofi_iov_left(&info->iov, &entry->info.iov))
 		return -1;

--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -282,6 +282,8 @@ vrb_mr_cache_reg(struct vrb_domain *domain, const void *buf, size_t len,
 	struct iovec iov;
 	int ret;
 
+	memset(&info, 0, sizeof(info));
+
 	attr.access = access;
 	attr.context = context;
 	attr.iov_count = 1;

--- a/src/hmem_ipc_cache.c
+++ b/src/hmem_ipc_cache.c
@@ -148,17 +148,21 @@ void ofi_ipc_cache_destroy(struct ofi_mr_cache *cache)
  * @param[out] mr_entry the matched mr_entry of the ipc_info and mapped_addr.
  * @return int 0 on success, negative value otherwise.
  */
-int ofi_ipc_cache_search(struct ofi_mr_cache *cache, struct ipc_info *ipc_info,
-			  struct ofi_mr_entry **mr_entry)
+int ofi_ipc_cache_search(struct ofi_mr_cache *cache, uint64_t peer_id,
+			 struct ipc_info *ipc_info,
+			 struct ofi_mr_entry **mr_entry)
 {
 	struct ofi_mr_info info;
 	struct ofi_mr_entry *entry;
 	int ret;
 	size_t ipc_handle_size;
 
+	memset(&info, 0, sizeof(info));
+
 	info.iov.iov_base = (void *) (uintptr_t) ipc_info->base_addr;
 	info.iov.iov_len = ipc_info->base_length;
 	info.iface = ipc_info->iface;
+	info.peer_id = peer_id;
 
 	ipc_handle_size = ofi_hmem_get_ipc_handle_size(info.iface);
 	assert(ipc_handle_size);


### PR DESCRIPTION
Set the response status to SMR_STATUS_BUSY after launching an async copy operation. Set the response status to SMR_STATUS_SUCCESS after the async operation completes.

This will prevent the tx complete on the transmit side until the data from the sending buffer is no longer in use.

This avoids a scenario where the application can overwrite the buffer before it has been copied over, causing the receiving side to get unexpected data.