### PR TITLE
prov/verbs: code restructuring

### DIFF
--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -989,7 +989,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)|$(Platform)'!='Debug-Efa-v142|x64' AND '$(Configuration)|$(Platform)'!='Release-Efa-v142|x64'">
     <ClInclude Include="prov\verbs\include\fi_verbs.h" />
-    <ClInclude Include="prov\verbs\include\ofi_verbs_priv.h" />
+    <ClInclude Include="prov\verbs\include\ofi_verbs_compat.h" />
     <ClInclude Include="prov\verbs\include\windows\verbs_nd.h" />
     <ClInclude Include="prov\verbs\include\windows\verbs_osd.h" />
     <ClInclude Include="prov\verbs\include\windows\infiniband\ib.h" />

--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -988,7 +988,7 @@
     <ClInclude Include="prov\coll\src\coll.h" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)|$(Platform)'!='Debug-Efa-v142|x64' AND '$(Configuration)|$(Platform)'!='Release-Efa-v142|x64'">
-    <ClInclude Include="prov\verbs\include\fi_verbs.h" />
+    <ClInclude Include="prov\verbs\src\verbs_ofi.h" />
     <ClInclude Include="prov\verbs\include\ofi_verbs_compat.h" />
     <ClInclude Include="prov\verbs\include\windows\verbs_nd.h" />
     <ClInclude Include="prov\verbs\include\windows\verbs_osd.h" />

--- a/libfabric.vcxproj.filters
+++ b/libfabric.vcxproj.filters
@@ -896,7 +896,7 @@
     <ClInclude Include="include\ofi_hook.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="prov\verbs\include\ofi_verbs_priv.h">
+    <ClInclude Include="prov\verbs\include\ofi_verbs_compat.h">
       <Filter>Source Files\prov\verbs\include</Filter>
     </ClInclude>
     <ClInclude Include="include\windows\asm\types.h">

--- a/libfabric.vcxproj.filters
+++ b/libfabric.vcxproj.filters
@@ -917,7 +917,7 @@
     <ClInclude Include="prov\verbs\include\windows\rdma\rdma_cma.h">
       <Filter>Source Files\prov\verbs\include\windows\rdma</Filter>
     </ClInclude>
-    <ClInclude Include="prov\verbs\include\fi_verbs.h">
+    <ClInclude Include="prov\verbs\src\verbs_ofi.h">
       <Filter>Source Files\prov\verbs\include</Filter>
     </ClInclude>
     <ClInclude Include="prov\verbs\include\windows\verbs_osd.h">

--- a/prov/verbs/Makefile.include
+++ b/prov/verbs/Makefile.include
@@ -15,7 +15,7 @@ _verbs_files =							\
 	prov/verbs/src/verbs_rma.c				\
 	prov/verbs/src/verbs_dgram_ep_msg.c			\
 	prov/verbs/src/verbs_dgram_av.c				\
-	prov/verbs/include/ofi_verbs_priv.h			\
+	prov/verbs/include/ofi_verbs_compat.h			\
 	prov/verbs/include/linux/verbs_osd.h
 
 if HAVE_VERBS_DL

--- a/prov/verbs/Makefile.include
+++ b/prov/verbs/Makefile.include
@@ -1,6 +1,6 @@
 if HAVE_VERBS
 _verbs_files =							\
-	prov/verbs/include/fi_verbs.h				\
+	prov/verbs/src/verbs_ofi.h				\
 	prov/verbs/src/fi_verbs.c				\
 	prov/verbs/src/verbs_cm.c				\
 	prov/verbs/src/verbs_cm_xrc.c				\

--- a/prov/verbs/include/fi_verbs.h
+++ b/prov/verbs/include/fi_verbs.h
@@ -77,7 +77,7 @@
 #include "ofi_iov.h"
 #include "ofi_hmem.h"
 
-#include "ofi_verbs_priv.h"
+#include "ofi_verbs_compat.h"
 
 
 #ifndef AF_IB

--- a/prov/verbs/include/ofi_verbs_compat.h
+++ b/prov/verbs/include/ofi_verbs_compat.h
@@ -31,8 +31,8 @@
  * SOFTWARE.
  */
 
-#ifndef OFI_VERBS_PRIV_H
-#define OFI_VERBS_PRIV_H
+#ifndef OFI_VERBS_COMPAT_H
+#define OFI_VERBS_COMPAT_H
 
 #if !VERBS_HAVE_XRC
 #define IBV_QPT_XRC_SEND 9ull
@@ -66,4 +66,4 @@
 #define rdma_establish(id) do { } while (0)
 #endif
 
-#endif /* OFI_VERBS_PRIV_H */
+#endif /* OFI_VERBS_COMPAT_H */

--- a/prov/verbs/include/windows/verbs_nd.h
+++ b/prov/verbs/include/windows/verbs_nd.h
@@ -36,7 +36,8 @@
 
 #include <assert.h>
 #include "ndspi.h"
-#include "fi_verbs.h"
+#include <infiniband/verbs.h>
+#include <rdma/rdma_cma.h>
 
 HRESULT nd_startup();
 void nd_shutdown();

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -34,7 +34,7 @@
 
 #include <ofi_mem.h>
 
-#include "fi_verbs.h"
+#include "verbs_ofi.h"
 #include "ofi_hmem.h"
 #include "verbs_osd.h"
 

--- a/prov/verbs/src/verbs_cm.c
+++ b/prov/verbs/src/verbs_cm.c
@@ -32,7 +32,7 @@
 
 #include "config.h"
 
-#include "fi_verbs.h"
+#include "verbs_ofi.h"
 
 
 static int vrb_copy_addr(void *dst_addr, size_t *dst_addrlen, void *src_addr)

--- a/prov/verbs/src/verbs_cm_xrc.c
+++ b/prov/verbs/src/verbs_cm_xrc.c
@@ -32,7 +32,7 @@
  */
 
 #include "config.h"
-#include "fi_verbs.h"
+#include "verbs_ofi.h"
 
 void vrb_next_xrc_conn_state(struct vrb_xrc_ep *ep)
 {

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -35,7 +35,7 @@
 #include <stdint.h>
 #include <ofi_mem.h>
 
-#include "fi_verbs.h"
+#include "verbs_ofi.h"
 
 
 enum ibv_wc_opcode vrb_wr2wc_opcode(enum ibv_wr_opcode wr)

--- a/prov/verbs/src/verbs_dgram_av.c
+++ b/prov/verbs/src/verbs_dgram_av.c
@@ -30,7 +30,7 @@
  * SOFTWARE.
  */
 
-#include "fi_verbs.h"
+#include "verbs_ofi.h"
 
 static inline int vrb_dgram_av_is_addr_valid(struct vrb_dgram_av *av,
 						const void *addr)

--- a/prov/verbs/src/verbs_dgram_ep_msg.c
+++ b/prov/verbs/src/verbs_dgram_ep_msg.c
@@ -30,7 +30,7 @@
  * SOFTWARE.
  */
 
-#include "fi_verbs.h"
+#include "verbs_ofi.h"
 
 static inline int
 vrb_dgram_ep_set_addr(struct vrb_ep *ep, fi_addr_t addr,

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -35,7 +35,7 @@
 
 #include "ofi_iov.h"
 
-#include "fi_verbs.h"
+#include "verbs_ofi.h"
 #include <malloc.h>
 
 

--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -32,7 +32,7 @@
  */
 
 #include "config.h"
-#include "fi_verbs.h"
+#include "verbs_ofi.h"
 #include <sys/stat.h>
 
 

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -33,7 +33,7 @@
 
 #include "config.h"
 
-#include "fi_verbs.h"
+#include "verbs_ofi.h"
 
 static struct fi_ops_msg vrb_srq_msg_ops;
 

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -35,7 +35,7 @@
 #include "config.h"
 
 #include <ofi_util.h>
-#include "fi_verbs.h"
+#include "verbs_ofi.h"
 
 /* XRC SIDR connection map RBTree key */
 struct vrb_sidr_conn_key {

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -38,7 +38,7 @@
 #include <stdint.h>
 #include <rdma/rdma_cma.h>
 
-#include "fi_verbs.h"
+#include "verbs_ofi.h"
 
 
 #define VERBS_IB_PREFIX "IB-0x"

--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -32,7 +32,7 @@
  */
 
 #include <ofi_util.h>
-#include "fi_verbs.h"
+#include "verbs_ofi.h"
 
 static int vrb_mr_close(fid_t fid)
 {

--- a/prov/verbs/src/verbs_msg.c
+++ b/prov/verbs/src/verbs_msg.c
@@ -33,7 +33,7 @@
 
 #include "config.h"
 
-#include "fi_verbs.h"
+#include "verbs_ofi.h"
 
 
 static inline ssize_t

--- a/prov/verbs/src/verbs_ofi.h
+++ b/prov/verbs/src/verbs_ofi.h
@@ -34,8 +34,8 @@
  * SOFTWARE.
  */
 
-#ifndef FI_VERBS_H
-#define FI_VERBS_H
+#ifndef VERBS_OFI_H
+#define VERBS_OFI_H
 
 #include "config.h"
 
@@ -951,4 +951,4 @@ int vrb_get_rai_id(const char *node, const char *service, uint64_t flags,
 		      const struct fi_info *hints, struct rdma_addrinfo **rai,
 		      struct rdma_cm_id **id);
 
-#endif /* FI_VERBS_H */
+#endif /* VERBS_OFI_H */

--- a/prov/verbs/src/verbs_rma.c
+++ b/prov/verbs/src/verbs_rma.c
@@ -33,7 +33,7 @@
 
 #include "config.h"
 
-#include "fi_verbs.h"
+#include "verbs_ofi.h"
 
 
 #define VERBS_COMP_READ_FLAGS(ep, flags, context)		\


### PR DESCRIPTION
These changes are intended as a starting point in optimizing the verbs provider, and the eventually addition of rdm ep support directly into the provider.  The changes are based on the optimizations integrated into the tcp provider.  As a starting point, the code separates the 1:1 relationship between a CQ exposed to the application and the HW CQ allocated through verbs.  The verbs CQ is instead moved to the domain and hidden from the app.  The reasoning is that in order to drive progress over an endpoint, both the send and receive queues must be checked.  For example, the receive queue is checked to handle acks, flow control messages, etc.  An app may create a send-only endpoints, but internally, some operations will still need receive handling.

The resulting code ends up quite a bit simpler and should simplify further as optimizations are moved up the call path.

These changes are incomplete.  (I'm sure the locking is messed up.)  I'm posting early for feedback, as I'm unsure if I want to break the 1:1 relationship between a libfabric CQ and HW CQ.  An alternative is to maintain that mapping, but implement the other optimizations involved in moving progress up to the domain.

One downside to the changes is if the app uses a shared Rx and has multiple endpoints bound to *separate* CQs, then there's no easy way to figure out which libfabric CQ to write a completion to.  A lookup using the qpn in the verbs completion is needed to identify the libfabric ep, which then points to the cq.  I'm skeptical any apps are actually doing this, since it's technically silly.  It's worth noting that XRC QPs already have this restriction.

Another downside is that this essentially sets the threading model to FI_THREAD_DOMAIN.  Apps that use msg ep's with separate cq's allocated to different threads could see an impact to performance.  This downside is likely even if a 1:1 mapping is maintained, but the progress model is reworked.