### PR TITLE
prov/efa: remove assertion on duplicate handshake

### DIFF
--- a/prov/efa/src/rdm/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_misc.c
@@ -188,7 +188,6 @@ void rxr_pkt_handle_handshake_recv(struct rxr_ep *ep,
 
 	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
 	assert(peer);
-	assert(!(peer->flags & EFA_RDM_PEER_HANDSHAKE_RECEIVED));
 
 	handshake_pkt = (struct rxr_handshake_hdr *)pkt_entry->wiredata;
 


### PR DESCRIPTION
The EFA rdm endpoint could receive multiple handshakes from the same peer address. This happens in av_xfer fabtest. In that case, the sender and receiver addresses are artificially removed  and re-inserted between send and recv ops. Thus the sender could receive two rx completions from seemingly the same peer.