### PR TITLE
prov/shm: increase default rx size and print warning

### DIFF
--- a/prov/shm/src/smr_attr.c
+++ b/prov/shm/src/smr_attr.c
@@ -58,7 +58,7 @@ struct fi_rx_attr smr_rx_attr = {
 	.op_flags = SMR_RX_OP_FLAGS,
 	.comp_order = FI_ORDER_STRICT,
 	.msg_order = SMR_RMA_ORDER | FI_ORDER_SAS,
-	.size = 1024,
+	.size = 16384,
 	.iov_limit = SMR_IOV_LIMIT
 };
 

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -875,8 +875,12 @@ static int smr_progress_cmd_msg(struct smr_ep *ep, struct smr_cmd *cmd)
 		ofi_ep_lock_release(&ep->util_ep);
 		if (ret == -FI_ENOENT) {
 			ret = smr_alloc_cmd_ctx(ep, rx_entry, cmd);
-			if (ret)
+			if (ret) {
+				FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+					"smr_alloc_cmd_ctx failed! ret: %d\n",
+					ret);
 				return ret;
+			}
 
 			ret = peer_srx->owner_ops->queue_tag(rx_entry);
 			goto out;
@@ -887,8 +891,12 @@ static int smr_progress_cmd_msg(struct smr_ep *ep, struct smr_cmd *cmd)
 		ofi_ep_lock_release(&ep->util_ep);
 		if (ret == -FI_ENOENT) {
 			ret = smr_alloc_cmd_ctx(ep, rx_entry, cmd);
-			if (ret)
+			if (ret) {
+				FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+					"smr_alloc_cmd_ctx failed! ret: %d\n",
+					ret);
 				return ret;
+			}
 
 			ret = peer_srx->owner_ops->queue_msg(rx_entry);
 			goto out;


### PR DESCRIPTION
Two commits:

1. increase default RX size
2. print warning when `smr_alloc_cmd_ctx` failed.