### PR TITLE
prov/efa: several bug fixes to FI_PEEK path

### DIFF
--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -59,3 +59,12 @@ def test_rdm_atomic(cmdline_args, iteration_type, completion_type, memory_type):
     test = ClientServerTest(cmdline_args_copy, "fi_rdm_atomic", iteration_type, completion_type,
                             memory_type=memory_type, timeout=1800)
     test.run()
+
+@pytest.mark.functional
+def test_rdm_tagged_peek(cmdline_args):
+    from copy import copy
+
+    from common import ClientServerTest
+
+    test = ClientServerTest(cmdline_args, "fi_rdm_tagged_peek", timeout=1800)
+    test.run()

--- a/fabtests/test_configs/efa/efa.exclude
+++ b/fabtests/test_configs/efa/efa.exclude
@@ -83,9 +83,6 @@ ubertest
 # Not useful on efa rdm ep
 pd_test
 
-# Test requires sread support
-rdm_tagged_peek
-
 # fail on timeout - cannot be supported
 dgram_bw
 

--- a/prov/efa/src/rdm/rxr_ep.c
+++ b/prov/efa/src/rdm/rxr_ep.c
@@ -433,7 +433,9 @@ static void rxr_ep_free_res(struct rxr_ep *rxr_ep)
 		EFA_WARN(FI_LOG_EP_CTRL,
 			"Closing ep with unmatched unexpected tagged rx_entry: %p pkt_entry %p\n",
 			rx_entry, rx_entry->unexp_pkt);
-		rxr_pkt_entry_release_rx(rxr_ep, rx_entry->unexp_pkt);
+		/* rx entry for peer srx does not allocate unexp_pkt */
+		if (!(rx_entry->rxr_flags & RXR_RX_ENTRY_FOR_PEER_SRX))
+			rxr_pkt_entry_release_rx(rxr_ep, rx_entry->unexp_pkt);
 		rxr_rx_entry_release(rx_entry);
 	}
 

--- a/prov/efa/src/rdm/rxr_msg.c
+++ b/prov/efa/src/rdm/rxr_msg.c
@@ -1341,6 +1341,12 @@ ssize_t rxr_msg_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 
 	ep = container_of(ep_fid, struct rxr_ep, base_ep.util_ep.ep_fid.fid);
 
+	/*
+	 * For rxr_msg_recvmsg (trecvmsg), it should pass application
+	 * flags |= util_ep.rx_msg_flags, which will have NO FI_COMPLETION
+	 * when application binds rx cq with FI_SELECTIVE_COMPLETION,
+	 * and does not have FI_COMPLETION in the flags of fi_recvmsg.
+	 */
 	return rxr_msg_generic_recv(ep_fid, msg, 0, 0, ofi_op_msg, flags | ep->base_ep.util_ep.rx_msg_flags);
 }
 
@@ -1420,11 +1426,17 @@ ssize_t rxr_msg_trecvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *tmsg
 
 	ep = container_of(ep_fid, struct rxr_ep, base_ep.util_ep.ep_fid.fid);
 
+	/*
+	 * For rxr_msg_recvmsg (trecvmsg), it should pass application
+	 * flags |= util_ep.rx_msg_flags, which will have NO FI_COMPLETION
+	 * when application binds rx cq with FI_SELECTIVE_COMPLETION,
+	 * and does not have FI_COMPLETION in the flags of fi_recvmsg.
+	 */
 	if (flags & FI_PEEK) {
-		ret = rxr_msg_peek_trecv(ep_fid, tmsg, flags);
+		ret = rxr_msg_peek_trecv(ep_fid, tmsg, flags | ep->base_ep.util_ep.rx_msg_flags);
 		goto out;
 	} else if (flags & FI_CLAIM) {
-		ret = rxr_msg_claim_trecv(ep_fid, tmsg, flags);
+		ret = rxr_msg_claim_trecv(ep_fid, tmsg, flags | ep->base_ep.util_ep.rx_msg_flags);
 		goto out;
 	}
 


### PR DESCRIPTION
This PR contains 3 commits to fix bugs in the FI_PEEK related (FI_CLAIM, FI_DISCARD) code path.

This PR should be tested with a modified `rdm_tagged_peek` fabtest, which will be part of a separate PR to fabtests/functional (preparing now)