### PR TITLE
prov/efa: use rxr_op_entry for local read

### DIFF
--- a/prov/efa/src/rdm/rxr_ep.c
+++ b/prov/efa/src/rdm/rxr_ep.c
@@ -2180,7 +2180,7 @@ void rxr_ep_progress_internal(struct rxr_ep *ep)
 		if (ep->efa_outstanding_tx_ops == ep->efa_max_outstanding_tx_ops)
 			goto out;
 
-		ret = rxr_op_entry_post_remote_read(op_entry);
+		ret = rxr_op_entry_post_read(op_entry);
 		if (ret == -FI_EAGAIN)
 			break;
 

--- a/prov/efa/src/rdm/rxr_op_entry.h
+++ b/prov/efa/src/rdm/rxr_op_entry.h
@@ -202,6 +202,9 @@ struct rxr_op_entry {
 
 	/* used by peer SRX ops */
 	struct fi_peer_rx_entry peer_rx_entry;
+
+	/** the source packet entry of a local read operation */
+	struct rxr_pkt_entry *local_read_pkt_entry;
 };
 
 
@@ -364,10 +367,15 @@ int rxr_op_entry_prepare_to_post_read(struct rxr_op_entry *op_entry);
 
 void rxr_op_entry_prepare_to_post_write(struct rxr_op_entry *op_entry);
 
-int rxr_op_entry_post_remote_read(struct rxr_op_entry *op_entry);
+int rxr_op_entry_post_read(struct rxr_op_entry *op_entry);
 
 int rxr_op_entry_post_remote_write(struct rxr_op_entry *op_entry);
 
 int rxr_op_entry_post_remote_read_or_queue(struct rxr_op_entry *op_entry);
+
+int rxr_rx_entry_post_local_read_or_queue(struct rxr_op_entry *rx_entry,
+					  size_t rx_data_offset,
+					  struct rxr_pkt_entry *pkt_entry,
+					  char *pkt_data, size_t data_size);
 
 #endif

--- a/prov/efa/src/rdm/rxr_pkt_type_base.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_base.c
@@ -419,8 +419,8 @@ int rxr_pkt_copy_data_to_cuda(struct rxr_ep *ep,
 		/* prefer local read over cudaMemcpy (when it is available)
 		 * because local read copy is faster
 		 */
-		err = rxr_read_post_local_read_or_queue(ep, rx_entry, data_offset,
-							pkt_entry, data, data_size);
+		err = rxr_rx_entry_post_local_read_or_queue(rx_entry, data_offset,
+							    pkt_entry, data, data_size);
 		if (err)
 			EFA_WARN(FI_LOG_CQ, "cannot post read to copy data\n");
 		return err;
@@ -460,8 +460,8 @@ int rxr_pkt_copy_data_to_cuda(struct rxr_ep *ep,
 	if (rx_entry->cuda_copy_method == RXR_CUDA_COPY_UNSPEC)
 		rx_entry->cuda_copy_method = RXR_CUDA_COPY_LOCALREAD;
 
-	err = rxr_read_post_local_read_or_queue(ep, rx_entry, data_offset,
-						pkt_entry, data, data_size);
+	err = rxr_rx_entry_post_local_read_or_queue(rx_entry, data_offset,
+						    pkt_entry, data, data_size);
 	if (err)
 		EFA_WARN(FI_LOG_CQ, "cannot post read to copy data\n");
 

--- a/prov/efa/src/rdm/rxr_rma.c
+++ b/prov/efa/src/rdm/rxr_rma.c
@@ -227,7 +227,7 @@ ssize_t rxr_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uint64_
 		if (err)
 			goto out;
 			
-		err = rxr_op_entry_post_remote_read(tx_entry);
+		err = rxr_op_entry_post_read(tx_entry);
 		if (OFI_UNLIKELY(err)) {
 			if (err == -FI_ENOBUFS)
 				err = -FI_EAGAIN;

--- a/prov/efa/src/rdm/rxr_rma.h
+++ b/prov/efa/src/rdm/rxr_rma.h
@@ -45,4 +45,10 @@ int rxr_rma_verified_copy_iov(struct rxr_ep *ep, struct efa_rma_iov *rma,
 
 extern struct fi_ops_rma rxr_ops_rma;
 
+struct rxr_op_entry *
+rxr_rma_alloc_tx_entry(struct rxr_ep *rxr_ep,
+		       const struct fi_msg_rma *msg_rma,
+		       uint32_t op,
+		       uint64_t flags);
+
 #endif


### PR DESCRIPTION
This patch uses rxr_op_entry for local read.
This changed paved the way to eliminate rxr_read_entry.