### PR TITLE
src/hmem_cuda: Restrict CUDA IPC based on peer accessibility of devices + refactor

### DIFF
--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -62,6 +62,8 @@ CUresult ofi_cuGetErrorName(CUresult error, const char** pStr);
 CUresult ofi_cuGetErrorString(CUresult error, const char** pStr);
 CUresult ofi_cuPointerGetAttribute(void *data, CUpointer_attribute attribute,
 				   CUdeviceptr ptr);
+CUresult ofi_cuDeviceCanAccessPeer(int *canAccessPeer, CUdevice srcDevice,
+				   CUdevice dstDevice);
 cudaError_t ofi_cudaHostRegister(void *ptr, size_t size, unsigned int flags);
 cudaError_t ofi_cudaHostUnregister(void *ptr);
 cudaError_t ofi_cudaMalloc(void **ptr, size_t size);

--- a/prov/efa/src/efa_user_info.c
+++ b/prov/efa/src/efa_user_info.c
@@ -302,7 +302,7 @@ bool efa_user_info_should_support_hmem(int version)
 	if (hmem_ops[FI_HMEM_CUDA].initialized && FI_VERSION_GE(version, FI_VERSION(1, 18))) {
 		EFA_INFO(FI_LOG_CORE,
 			"User is using API version >= 1.18. CUDA library and "
-			"device are available, claim support of FI_HMEM.");
+			"devices are available, claim support of FI_HMEM.\n");
 			/* For this API we can support HMEM regardless of
 			   use_device_rdma and P2P support, because we can use
 			   CUDA api calls.*/

--- a/src/hmem_cuda.c
+++ b/src/hmem_cuda.c
@@ -474,6 +474,10 @@ static int cuda_hmem_verify_devices(void)
 		return -FI_EIO;
 	}
 
+	FI_INFO(&core_prov, FI_LOG_CORE,
+		"Number of CUDA devices detected: %d\n",
+		cuda_attr.device_count);
+
 	if (cuda_attr.device_count <= 0)
 		return -FI_ENOSYS;
 

--- a/src/hmem_cuda.c
+++ b/src/hmem_cuda.c
@@ -598,7 +598,7 @@ bool cuda_is_addr_valid(const void *addr, uint64_t *device, uint64_t *flags)
 	 */
 	case CUDA_ERROR_INVALID_CONTEXT:
 		FI_WARN(&core_prov, FI_LOG_CORE,
-			"CUcontext does not support unified virtual addressining\n");
+			"CUcontext does not support unified virtual addressing\n");
 		break;
 
 	default:


### PR DESCRIPTION
This PR:
- Implements logic to check the P2P capabilities of the detected CUDA devices, and conditionally enable CUDA IPC availability
    - If any device cannot access some other device, consider peer access to be unsupported on the host
        - "peer access" in this context refers to the peer-to-peer access capabilities between CUDA devices on the same node
    - If peer access is unsupported, prevent CUDA IPC usage
        - This mitigates an issue where  `cudaIpcOpenMemHandle()` can fail on hosts with multiple CUDA devices without P2P access - e.g. Amazon EC2 instance types g4dn.12xlarge or g5.48xlarge
        - This logic is admittedly not perfect, but is an improvement over simply checking for `cudaMemcpy()` availability
    - This change still allows CUDA IPC usage when the host has a single device, regardless of its peer capabilities
        - I also tested `CUDA_VISIBLE_DEVICES=1` on a g5.48xlarge EC2 instance (8 CUDA devices w/o peer access support) to confirm this works. As a future improvement, we may also be able to allow the user to limit the number of GPUs discoverable by Libfabric via `cudaSetValidDevices()`
- Refactors the file-scoped variables (e.g. `cuda_ipc_enabled`) into a single `cuda_attr` struct
    - Variables were inconsistently named and becoming increasingly unruly for every new dimension added to the CUDA HMEM interface (`cuda_xfer_setting`, GDR Copy usage, etc)
- Adds some preprocessor hullabaloo to reduce boilerplate
    - Notably the long `dlsym()` sequence in `cuda_hmem_dl_init()` for the `cuda_ops` function pointers