### PR TITLE
prov/efa: remove wrong assertion in preparing local_read_pkt_entry mr

### DIFF
--- a/prov/efa/src/rdm/rxr_op_entry.c
+++ b/prov/efa/src/rdm/rxr_op_entry.c
@@ -1173,7 +1173,6 @@ ssize_t rxr_tx_entry_prepare_local_read_pkt_entry_mr(struct rxr_op_entry *tx_ent
 
 	assert(tx_entry->type == RXR_TX_ENTRY);
 	assert(tx_entry->rma_iov_count == 1);
-	assert(!tx_entry->rma_iov[0].key);
 
 	pkt_entry = tx_entry->local_read_pkt_entry;
 	if (pkt_entry->mr)


### PR DESCRIPTION
the function rxr_tx_entry_prepare_local_read_pkt_entry_mr() can be called on a packet entry whose memory has already been registered. Therefore the assertion of tx_entry->rma_iov[0].key being 0 is wrong.

This patch removed it.