### PR TITLE
[v1.18.x] include/ofi_atom: fix no atomics support

### DIFF
--- a/include/ofi_atom.h
+++ b/include/ofi_atom.h
@@ -395,6 +395,25 @@ typedef atomic_long	ofi_atomic_int64_t;
 	{											\
 		return ofi_atomic_cas_bool##radix(atomic, expected, desired);			\
 	}											\
+	static inline										\
+	bool ofi_atomic_compare_exchange_weak##radix(ofi_atomic##radix##_t *atomic,		\
+					int##radix##_t *expected,				\
+					int##radix##_t desired)					\
+	{											\
+		return ofi_atomic_cas_bool_weak##radix(atomic, *expected, desired);		\
+	}											\
+	static inline										\
+	void ofi_atomic_store_explicit##radix(ofi_atomic##radix##_t *atomic,			\
+					      int##radix##_t value, int memmodel)		\
+	{											\
+		(void) ofi_atomic_set##radix(atomic, value);						\
+	}											\
+	static inline										\
+	int##radix##_t ofi_atomic_load_explicit##radix(ofi_atomic##radix##_t *atomic,		\
+						       int memmodel)				\
+	{											\
+		return ofi_atomic_get##radix(atomic);						\
+	}											\
 
 #endif // HAVE_ATOMICS
 

--- a/include/unix/osd.h
+++ b/include/unix/osd.h
@@ -246,11 +246,9 @@ OFI_DEF_COMPLEX_OPS(long_double)
 
 #ifdef HAVE_ATOMICS
 #  include <stdatomic.h>
-#endif
+#else
 
 /* atomics primitives */
-#ifdef HAVE_BUILTIN_ATOMICS
-
 #define memory_order_relaxed __ATOMIC_RELAXED
 #define memory_order_consume __ATOMIC_CONSUME
 #define memory_order_acquire __ATOMIC_ACQUIRE
@@ -258,6 +256,9 @@ OFI_DEF_COMPLEX_OPS(long_double)
 #define memory_order_acq_rel __ATOMIC_ACQ_REL
 #define memory_order_seq_cst __ATOMIC_SEQ_CST
 
+#endif /* HAVE_ATOMICS */
+
+#ifdef HAVE_BUILTIN_ATOMICS
 #define ofi_atomic_add_and_fetch(radix, ptr, val) __sync_add_and_fetch((ptr), (val))
 #define ofi_atomic_sub_and_fetch(radix, ptr, val) __sync_sub_and_fetch((ptr), (val))
 #define ofi_atomic_cas_bool(radix, ptr, expected, desired) 	\


### PR DESCRIPTION
When build with --enable-atomics=no, OFI defines its own set of emulated atomics. Some functions were missing from that definition:
	ofi_atomic_compare_exchange_weak
	ofi_atomic_store_explicit
	ofi_atomic_load_explicit

The memory order definitions need to be included in the no atomics as well. Move the ifdef to include them.

Cherry-picked from commit fad158efd99c81e69d5e29d37403ac17d6b2e0d7