### PR TITLE
prov/efa: Enable SM2 provider as a SHM offload in EFA provider

### DIFF
--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -133,7 +133,10 @@ static int efa_domain_init_rdm(struct efa_domain *efa_domain, struct fi_info *in
 	efa_shm_info_create(info, &efa_domain->shm_info);
 
 	if (efa_domain->shm_info) {
-		assert(!strcmp(efa_domain->shm_info->fabric_attr->name, "shm"));
+		if (rxr_env.use_sm2)
+			assert(!strcmp(efa_domain->shm_info->fabric_attr->name, "sm2"));
+		else
+			assert(!strcmp(efa_domain->shm_info->fabric_attr->name, "shm"));
 		err = fi_fabric(efa_domain->shm_info->fabric_attr,
 				&efa_domain->fabric->shm_fabric,
 				efa_domain->fabric->util_fabric.fabric_fid.fid.context);
@@ -144,7 +147,10 @@ static int efa_domain_init_rdm(struct efa_domain *efa_domain, struct fi_info *in
 	}
 
 	if (efa_domain->fabric->shm_fabric) {
-		assert(!strcmp(efa_domain->shm_info->fabric_attr->name, "shm"));
+		if (rxr_env.use_sm2)
+			assert(!strcmp(efa_domain->shm_info->fabric_attr->name, "sm2"));
+		else
+			assert(!strcmp(efa_domain->shm_info->fabric_attr->name, "shm"));
 		err = fi_domain(efa_domain->fabric->shm_fabric, efa_domain->shm_info,
 				&efa_domain->shm_domain, NULL);
 		if (err)
@@ -191,7 +197,7 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 		ret = err;
 		goto err_free;
 	}
-	efa_domain->util_domain.av_type = FI_AV_TABLE;
+	efa_domain->util_domain.av_type = FI_AV_UNSPEC;
 	efa_domain->util_domain.mr_map.mode |= FI_MR_VIRT_ADDR;
 	/*
 	 * FI_MR_PROV_KEY means provider will generate a key for MR,

--- a/prov/efa/src/efa_shm.c
+++ b/prov/efa/src/efa_shm.c
@@ -98,6 +98,13 @@ void efa_shm_info_create(const struct fi_info *app_info, struct fi_info **shm_in
 	int ret;
 	struct fi_info *shm_hints;
 
+	char *shm_provider;
+	if (rxr_env.use_sm2) {
+		shm_provider = "sm2";
+	} else {
+		shm_provider = "shm";
+	}
+
 	shm_hints = fi_allocinfo();
 	shm_hints->caps = FI_MSG | FI_TAGGED | FI_RECV | FI_SEND | FI_READ
 			   | FI_WRITE | FI_REMOTE_READ | FI_REMOTE_WRITE
@@ -118,8 +125,8 @@ void efa_shm_info_create(const struct fi_info *app_info, struct fi_info **shm_in
 	 */
 	shm_hints->tx_attr->op_flags  = FI_COMPLETION;
 	shm_hints->rx_attr->op_flags  = FI_COMPLETION;
-	shm_hints->fabric_attr->name = strdup("shm");
-	shm_hints->fabric_attr->prov_name = strdup("shm");
+	shm_hints->fabric_attr->name = strdup(shm_provider);
+	shm_hints->fabric_attr->prov_name = strdup(shm_provider);
 	shm_hints->ep_attr->type = FI_EP_RDM;
 
 	/*
@@ -140,7 +147,6 @@ void efa_shm_info_create(const struct fi_info *app_info, struct fi_info **shm_in
 		rxr_env.enable_shm_transfer = 0;
 		*shm_info = NULL;
 	} else {
-		assert(!strcmp((*shm_info)->fabric_attr->name, "shm"));
+		assert(!strcmp((*shm_info)->fabric_attr->name, shm_provider));
 	}
 }
-

--- a/prov/efa/src/rdm/rxr_env.c
+++ b/prov/efa/src/rdm/rxr_env.c
@@ -69,6 +69,7 @@ struct rxr_env rxr_env = {
 	.efa_write_segment_size = 1073741824, /* need to confirm this constant. */
 	.rnr_retry = 3, /* Setting this value to EFA_RNR_INFINITE_RETRY makes the firmware retry indefinitey */
 	.host_id_file = "/sys/devices/virtual/dmi/id/board_asset_tag", /* Available on EC2 instances and containers */
+	.use_sm2 = 0,
 };
 
 /**
@@ -160,6 +161,7 @@ void rxr_env_param_get(void)
 			    &rxr_env.efa_read_segment_size);
 	fi_param_get_size_t(&efa_prov, "inter_max_gdrcopy_message_size",
 			    &rxr_env.efa_max_gdrcopy_msg_size);
+	fi_param_get_int(&efa_prov, "use_sm2", &rxr_env.use_sm2);
 	efa_fork_support_request_initialize();
 }
 
@@ -228,6 +230,8 @@ void rxr_env_define()
 			"Enables fork support and disables internal usage of huge pages. Has no effect on kernels which set copy-on-fork for registered pages, generally 5.13 and later. (Default: false)");
 	fi_param_define(&efa_prov, "runt_size", FI_PARAM_INT,
 			"The maximum number of bytes that will be eagerly sent by inflight messages uses runting read message protocol (Default 307200).");
+	fi_param_define(&efa_prov, "use_sm2", FI_PARAM_INT,
+			"Use the experimental shared memory provider SM2.");
 }
 
 

--- a/prov/efa/src/rdm/rxr_env.h
+++ b/prov/efa/src/rdm/rxr_env.h
@@ -100,6 +100,7 @@ struct rxr_env {
 	 * is malformatted, the program should proceed with a default host id, e.g. 0.
 	 */
 	char *host_id_file;
+	int use_sm2;
 };
 
 /**

--- a/prov/efa/src/rdm/rxr_ep.c
+++ b/prov/efa/src/rdm/rxr_ep.c
@@ -2193,7 +2193,10 @@ int rxr_endpoint(struct fid_domain *domain, struct fi_info *info,
 		if (ret)
 			goto err_destroy_base_ep;
 
-		assert(!strcmp(efa_domain->shm_info->fabric_attr->name, "shm"));
+		if (rxr_env.use_sm2)
+			assert(!strcmp(efa_domain->shm_info->fabric_attr->name, "sm2"));
+		else
+			assert(!strcmp(efa_domain->shm_info->fabric_attr->name, "shm"));
 		ret = fi_endpoint(efa_domain->shm_domain, efa_domain->shm_info,
 				  &rxr_ep->shm_ep, rxr_ep);
 		if (ret)


### PR DESCRIPTION
This PR allows EFA provider to use SM2 as a shared memory offload

Do not merge this until https://github.com/ofiwg/libfabric/pull/8781/ is merged