### PR TITLE
CI: Run CI on every patch in Change Set

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -122,12 +122,18 @@ jobs:
            brew install automake
            brew install libtool
       - uses: actions/checkout@v2
+        with:
+          # checkout full tree
+          fetch-depth: 0
       - name: Build Check
         run: |
-          ./autogen.sh
-          ./configure --prefix=$PWD/install
-          make -j 2; make install
-          $PWD/install/bin/fi_info -l
+          for commit in $(git rev-list origin/main..${{ github.sha}}); do
+            git checkout $commit
+            ./autogen.sh
+            ./configure --prefix=$PWD/install
+            make clean; make -j 2; make install
+            $PWD/install/bin/fi_info -l
+          done
       - name: Upload build logs
         if: failure()
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
The libfabric community wants to make sure that every patch in a change set builds.  We should enforce this behavior.

I haven't tested this b/c I don't know how, but I got the idea from here: https://stackoverflow.com/questions/64708371/how-to-run-github-workflow-on-every-commit-of-a-push