### PR TITLE
prov/efa: make pkt_entry->x_entry to be rxr_op_entry

### DIFF
--- a/prov/efa/src/rdm/rxr_ep.c
+++ b/prov/efa/src/rdm/rxr_ep.c
@@ -2362,7 +2362,7 @@ void rxr_ep_record_tx_op_submitted(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_
 	struct efa_rdm_peer *peer;
 	struct rxr_op_entry *op_entry;
 
-	op_entry = rxr_op_entry_of_pkt_entry(pkt_entry);
+	op_entry = pkt_entry->x_entry;
 	/*
 	 * peer can be NULL when the pkt_entry is a RMA_CONTEXT_PKT,
 	 * and the RMA is a local read toward the endpoint itself
@@ -2422,7 +2422,7 @@ void rxr_ep_record_tx_op_completed(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_
 	struct rxr_op_entry *op_entry = NULL;
 	struct efa_rdm_peer *peer;
 
-	op_entry = rxr_op_entry_of_pkt_entry(pkt_entry);
+	op_entry = pkt_entry->x_entry;
 	/*
 	 * peer can be NULL when:
 	 *

--- a/prov/efa/src/rdm/rxr_op_entry.h
+++ b/prov/efa/src/rdm/rxr_op_entry.h
@@ -206,11 +206,6 @@ struct rxr_op_entry {
 	struct rxr_pkt_entry *local_read_pkt_entry;
 };
 
-
-#define RXR_GET_X_ENTRY_TYPE(pkt_entry)	\
-	(*((enum rxr_x_entry_type *)	\
-	 ((unsigned char *)((pkt_entry)->x_entry))))
-
 void rxr_tx_entry_construct(struct rxr_op_entry *tx_entry,
 			    struct rxr_ep *ep,
 			    const struct fi_msg *msg,
@@ -219,35 +214,6 @@ void rxr_tx_entry_construct(struct rxr_op_entry *tx_entry,
 void rxr_tx_entry_release(struct rxr_op_entry *tx_entry);
 
 void rxr_rx_entry_release(struct rxr_op_entry *rx_entry);
-
-/**
- * @brief return the op_entry of a packet entry
- *
- * If a packet entry is associate with a TX/RX entry,
- * this function return the op_entry for the packet entry.
- *
- * Note that not every packet entry are associated with an op entry.
- * For example:
- *     A HANDSHAKE packet is not associated with any operation.
- *     A RMA_CONTEX packet can be associated with a rxr_read_entry.
- *
- * @param[in]		pk_entry		packet entry
- * @return		pointer to the op_entry if the input packet entry is associated with an op
- * 			NULL otherwise
- */
-static inline
-struct rxr_op_entry *rxr_op_entry_of_pkt_entry(struct rxr_pkt_entry *pkt_entry)
-{
-	enum rxr_x_entry_type x_entry_type;
-	/*
-	 * pkt_entry->x_entry can be NULL when the packet is a HANDSHAKE packet
-	 */
-	if (!pkt_entry->x_entry)
-		return NULL;
-
-	x_entry_type = RXR_GET_X_ENTRY_TYPE(pkt_entry);
-	return (x_entry_type == RXR_TX_ENTRY || x_entry_type == RXR_RX_ENTRY) ? pkt_entry->x_entry : NULL;
-}
 
 /* The follow flags are applied to the rxr_flags field
  * of an rxr_op_entry*/

--- a/prov/efa/src/rdm/rxr_pkt_cmd.c
+++ b/prov/efa/src/rdm/rxr_pkt_cmd.c
@@ -607,7 +607,7 @@ void rxr_pkt_handle_send_error(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entr
 		return;
 	}
 
-	switch (RXR_GET_X_ENTRY_TYPE(pkt_entry)) {
+	switch (pkt_entry->x_entry->type) {
 	case RXR_TX_ENTRY:
 		tx_entry = pkt_entry->x_entry;
 		if (prov_errno == FI_EFA_REMOTE_ERROR_RNR) {
@@ -669,7 +669,7 @@ void rxr_pkt_handle_send_error(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entr
 	default:
 		EFA_WARN(FI_LOG_CQ,
 				"%s unknown x_entry type %d\n",
-				__func__, RXR_GET_X_ENTRY_TYPE(pkt_entry));
+				__func__, pkt_entry->x_entry->type);
 		assert(0 && "unknown x_entry state");
 		efa_eq_write_error(&ep->base_ep.util_ep, err, prov_errno);
 		rxr_pkt_entry_release_tx(ep, pkt_entry);
@@ -825,14 +825,14 @@ void rxr_pkt_handle_recv_error(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entr
 		return;
 	}
 
-	if (RXR_GET_X_ENTRY_TYPE(pkt_entry) == RXR_TX_ENTRY) {
+	if (pkt_entry->x_entry->type == RXR_TX_ENTRY) {
 		rxr_tx_entry_handle_error(pkt_entry->x_entry, err, prov_errno);
-	} else if (RXR_GET_X_ENTRY_TYPE(pkt_entry) == RXR_RX_ENTRY) {
+	} else if (pkt_entry->x_entry->type == RXR_RX_ENTRY) {
 		rxr_rx_entry_handle_error(pkt_entry->x_entry, err, prov_errno);
 	} else {
 		EFA_WARN(FI_LOG_CQ,
 		"%s unknown x_entry type %d\n",
-			__func__, RXR_GET_X_ENTRY_TYPE(pkt_entry));
+			__func__, pkt_entry->x_entry->type);
 		assert(0 && "unknown x_entry state");
 		efa_eq_write_error(&ep->base_ep.util_ep, err, prov_errno);
 	}

--- a/prov/efa/src/rdm/rxr_pkt_entry.h
+++ b/prov/efa/src/rdm/rxr_pkt_entry.h
@@ -158,8 +158,8 @@ struct rxr_pkt_entry {
 	struct dlist_entry dbg_entry;
 	uint8_t pad[48];
 #endif
-	/** @brief pointer to #rxr_op_entry or #rxr_read_entry */
-	void *x_entry;
+	/** @brief pointer to #rxr_op_entry */
+	struct rxr_op_entry *x_entry;
 
 	/** @brief number of bytes sent/received over wire */
 	size_t pkt_size;

--- a/prov/efa/src/rdm/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_misc.c
@@ -418,7 +418,7 @@ void rxr_pkt_handle_rma_read_completion(struct rxr_ep *ep,
 	assert(rma_context_pkt->type == RXR_RMA_CONTEXT_PKT);
 	assert(rma_context_pkt->context_type == RXR_READ_CONTEXT);
 
-	x_entry_type = RXR_GET_X_ENTRY_TYPE(context_pkt_entry);
+	x_entry_type = context_pkt_entry->x_entry->type;
 
 	if (x_entry_type == RXR_TX_ENTRY) {
 		tx_entry = context_pkt_entry->x_entry;
@@ -464,7 +464,6 @@ void rxr_pkt_handle_rma_read_completion(struct rxr_ep *ep,
 				rxr_ep_flush_queued_blocking_copy_to_hmem(ep);
 			}
 		}
-
 	}
 }
 


### PR DESCRIPTION
Prior to this patch pkt_entry->x_entry's type is "void *", after we eliminate rxr_read_entry, this pointer can only be pointer to  rxr_op_entry. This patch makes this explicit.