### PR TITLE
fabtests: correct ft_exchange_keys in prefix-mode

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -1584,7 +1584,7 @@ int ft_exchange_keys(struct fi_rma_iov *peer_iov)
 	if (ret)
 		return ret;
 
-	ret = ft_tx(ep, remote_fi_addr, len, &tx_ctx);
+	ret = ft_tx(ep, remote_fi_addr, len + ft_tx_prefix_size(), &tx_ctx);
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
When -k is passed to fabtest, ft_exchange_keys sends a message which has a length < ft_tx_prefix_size.  This change corrects the issue.
