### PR TITLE
Enable data integrity checks for fi_rma_bw

### DIFF
--- a/fabtests/benchmarks/benchmark_shared.c
+++ b/fabtests/benchmarks/benchmark_shared.c
@@ -288,11 +288,12 @@ int bandwidth_rma(enum ft_rma_opcodes rma_op, struct fi_rma_iov *remote)
 		switch (rma_op) {
 		case FT_RMA_WRITE:
 			if (opts.transfer_size < inject_size) {
-				ret = ft_post_rma_inject(FT_RMA_WRITE, ep,
+				ret = ft_post_rma_inject(FT_RMA_WRITE, tx_buf,
 						opts.transfer_size, remote);
 			} else {
-				ret = ft_post_rma(rma_op, ep, opts.transfer_size,
-						remote,	&tx_ctx_arr[j].context);
+				ret = ft_post_rma(FT_RMA_WRITE, tx_buf,
+						opts.transfer_size, remote,
+						&tx_ctx_arr[j].context);
 			}
 			break;
 		case FT_RMA_WRITEDATA:
@@ -316,19 +317,19 @@ int bandwidth_rma(enum ft_rma_opcodes rma_op, struct fi_rma_iov *remote)
 
 				if (opts.transfer_size < inject_size) {
 					ret = ft_post_rma_inject(FT_RMA_WRITEDATA,
-							ep,
+							tx_buf,
 							opts.transfer_size,
 							remote);
 				} else {
 					ret = ft_post_rma(FT_RMA_WRITEDATA,
-							ep,
+							tx_buf,
 							opts.transfer_size,
 							remote,	&tx_ctx_arr[j].context);
 				}
 			}
 			break;
 		case FT_RMA_READ:
-			ret = ft_post_rma(FT_RMA_READ, ep, opts.transfer_size,
+			ret = ft_post_rma(FT_RMA_READ, rx_buf, opts.transfer_size,
 					remote,	&tx_ctx_arr[j].context);
 			break;
 		default:

--- a/fabtests/benchmarks/rma_bw.c
+++ b/fabtests/benchmarks/rma_bw.c
@@ -127,6 +127,10 @@ int main(int argc, char **argv)
 		}
 	}
 
+	/* data validation on read and write ops requires delivery_complete semantics. */
+	if (opts.rma_op != FT_RMA_WRITEDATA && ft_check_opts(FT_OPT_VERIFY_DATA))
+		hints->tx_attr->op_flags |= FI_DELIVERY_COMPLETE;
+
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
 

--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -2088,36 +2088,6 @@ ssize_t ft_post_rma(enum ft_rma_opcodes op, struct fid_ep *ep, size_t size,
 	return 0;
 }
 
-ssize_t ft_rma(enum ft_rma_opcodes op, struct fid_ep *ep, size_t size,
-		struct fi_rma_iov *remote, void *context)
-{
-	int ret;
-
-	ret = ft_post_rma(op, ep, size, remote, context);
-	if (ret)
-		return ret;
-
-	if (op == FT_RMA_WRITEDATA) {
-		if (fi->rx_attr->mode & FI_RX_CQ_DATA) {
-			ret = ft_rx(ep, 0);
-		} else {
-			ret = ft_get_rx_comp(rx_seq);
-			/* Just increment the seq # instead of posting recv so
-			 * that we wait for remote write completion on the next
-			 * iteration. */
-			rx_seq++;
-		}
-		if (ret)
-			return ret;
-	}
-
-	ret = ft_get_tx_comp(tx_seq);
-	if (ret)
-		return ret;
-
-	return 0;
-}
-
 ssize_t ft_post_rma_inject(enum ft_rma_opcodes op, struct fid_ep *ep, size_t size,
 		struct fi_rma_iov *remote)
 {

--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -2060,25 +2060,25 @@ ssize_t ft_inject(struct fid_ep *ep, fi_addr_t fi_addr, size_t size)
 	return ret;
 }
 
-ssize_t ft_post_rma(enum ft_rma_opcodes op, struct fid_ep *ep, size_t size,
+ssize_t ft_post_rma(enum ft_rma_opcodes op, char *buf, size_t size,
 		struct fi_rma_iov *remote, void *context)
 {
 	switch (op) {
 	case FT_RMA_WRITE:
 		FT_POST(fi_write, ft_progress, txcq, tx_seq, &tx_cq_cntr,
-			"fi_write", ep, tx_buf, size, mr_desc,
+			"fi_write", ep, buf, size, mr_desc,
 			remote_fi_addr, remote->addr, remote->key, context);
 		break;
 	case FT_RMA_WRITEDATA:
 		FT_POST(fi_writedata, ft_progress, txcq, tx_seq, &tx_cq_cntr,
-			"fi_writedata", ep, tx_buf, size, mr_desc,
+			"fi_writedata", ep, buf, size, mr_desc,
 			remote_cq_data, remote_fi_addr,	remote->addr,
 			remote->key, context);
 		break;
 	case FT_RMA_READ:
 		FT_POST(fi_read, ft_progress, txcq, tx_seq, &tx_cq_cntr,
-			"fi_read", ep, rx_buf, size, mr_desc,
-			remote_fi_addr, remote->addr,remote->key, context);
+			"fi_read", ep, buf, size, mr_desc,
+			remote_fi_addr, remote->addr, remote->key, context);
 		break;
 	default:
 		FT_ERR("Unknown RMA op type\n");
@@ -2088,18 +2088,18 @@ ssize_t ft_post_rma(enum ft_rma_opcodes op, struct fid_ep *ep, size_t size,
 	return 0;
 }
 
-ssize_t ft_post_rma_inject(enum ft_rma_opcodes op, struct fid_ep *ep, size_t size,
+ssize_t ft_post_rma_inject(enum ft_rma_opcodes op, char *buf, size_t size,
 		struct fi_rma_iov *remote)
 {
 	switch (op) {
 	case FT_RMA_WRITE:
 		FT_POST(fi_inject_write, ft_progress, txcq, tx_seq, &tx_cq_cntr,
-			"fi_inject_write", ep, tx_buf, opts.transfer_size,
+			"fi_inject_write", ep, buf, opts.transfer_size,
 			remote_fi_addr, remote->addr, remote->key);
 		break;
 	case FT_RMA_WRITEDATA:
 		FT_POST(fi_inject_writedata, ft_progress, txcq, tx_seq,
-			&tx_cq_cntr, "fi_inject_writedata", ep, tx_buf,
+			&tx_cq_cntr, "fi_inject_writedata", ep, buf,
 			opts.transfer_size, remote_cq_data, remote_fi_addr,
 			remote->addr, remote->key);
 		break;

--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -555,7 +555,7 @@ int ft_alloc_msgs(void)
 		if (ret)
 			return ret;
 
-		ret = ft_alloc_host_tx_buf(MAX(tx_size, FT_MAX_CTRL_MSG));
+		ret = ft_alloc_host_tx_buf(MAX(tx_size, FT_MAX_CTRL_MSG) * opts.window_size);
 		if (ret)
 			return ret;
 	}

--- a/fabtests/functional/cq_data.c
+++ b/fabtests/functional/cq_data.c
@@ -61,7 +61,7 @@ static int run_test()
 				"Posting write with CQ data: 0x%" PRIx64 "\n",
 				ft_init_cq_data(fi));
 
-			ret = ft_post_rma(FT_RMA_WRITEDATA, ep, size, &remote, &tx_ctx);
+			ret = ft_post_rma(FT_RMA_WRITEDATA, tx_buf, size, &remote, &tx_ctx);
 		} else {
 			fprintf(stdout, "invalid cqdata_op: %d\n", opts.cqdata_op);
 			ret = -FI_EINVAL;

--- a/fabtests/functional/multi_mr.c
+++ b/fabtests/functional/multi_mr.c
@@ -193,7 +193,7 @@ static int mr_key_test()
 				printf("write to host's key %lx\n",
 						(unsigned long)fi_mr_key(mr_res_array[i].mr));
 
-			ft_post_rma(FT_RMA_WRITE, ep, opts.transfer_size,
+			ft_post_rma(FT_RMA_WRITE, tx_buf, opts.transfer_size,
 					mr_res_array[i].remote, &rma_ctx);
 
 			if (verbose)
@@ -242,7 +242,7 @@ static int mr_key_test()
 				printf("write to client's key %lx\n",
 						(unsigned long)fi_mr_key(mr_res_array[i].mr));
 
-			ft_post_rma(FT_RMA_WRITE, ep, opts.transfer_size,
+			ft_post_rma(FT_RMA_WRITE, tx_buf, opts.transfer_size,
 					mr_res_array[i].remote, &rma_ctx);
 
 			if (verbose)

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -85,6 +85,11 @@ extern unsigned int test_cnt;
 
 #define FT_ENABLE_SIZES		(~0)
 #define FT_DEFAULT_SIZE		(1 << 0)
+/* for RMA tests, reserve this much space for sync() and the various completion
+ * routines to operate in without interference from RMA.
+ */
+#define FT_RMA_SYNC_MSG_BYTES 4
+
 
 enum precision {
 	NANO = 1,

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -527,9 +527,9 @@ ssize_t ft_post_tx_buf(struct fid_ep *ep, fi_addr_t fi_addr, size_t size,
 ssize_t ft_rx(struct fid_ep *ep, size_t size);
 ssize_t ft_tx(struct fid_ep *ep, fi_addr_t fi_addr, size_t size, void *ctx);
 ssize_t ft_inject(struct fid_ep *ep, fi_addr_t fi_addr, size_t size);
-ssize_t ft_post_rma(enum ft_rma_opcodes op, struct fid_ep *ep, size_t size,
+ssize_t ft_post_rma(enum ft_rma_opcodes op, char *buf, size_t size,
 		struct fi_rma_iov *remote, void *context);
-ssize_t ft_post_rma_inject(enum ft_rma_opcodes op, struct fid_ep *ep, size_t size,
+ssize_t ft_post_rma_inject(enum ft_rma_opcodes op, char *buf, size_t size,
 		struct fi_rma_iov *remote);
 
 

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -529,8 +529,6 @@ ssize_t ft_tx(struct fid_ep *ep, fi_addr_t fi_addr, size_t size, void *ctx);
 ssize_t ft_inject(struct fid_ep *ep, fi_addr_t fi_addr, size_t size);
 ssize_t ft_post_rma(enum ft_rma_opcodes op, struct fid_ep *ep, size_t size,
 		struct fi_rma_iov *remote, void *context);
-ssize_t ft_rma(enum ft_rma_opcodes op, struct fid_ep *ep, size_t size,
-		struct fi_rma_iov *remote, void *context);
 ssize_t ft_post_rma_inject(enum ft_rma_opcodes op, struct fid_ep *ep, size_t size,
 		struct fi_rma_iov *remote);
 

--- a/fabtests/prov/efa/src/rdm_rnr_queue_resend.c
+++ b/fabtests/prov/efa/src/rdm_rnr_queue_resend.c
@@ -140,11 +140,11 @@ static int trigger_rnr_queue_resend(enum fi_op atomic_op, void *result, void *co
 		for (i = 0; i < global_expected_rnr_error; i++) {
 			switch (opts.rma_op) {
 			case FT_RMA_WRITE:
-				ret = ft_post_rma(FT_RMA_WRITE, ep, opts.transfer_size,
+				ret = ft_post_rma(FT_RMA_WRITE, tx_buf, opts.transfer_size,
 						&remote, &tx_ctx_arr[fi->rx_attr->size].context);
 				break;
 			case FT_RMA_READ:
-				ret = ft_post_rma(FT_RMA_READ, ep, opts.transfer_size,
+				ret = ft_post_rma(FT_RMA_READ, rx_buf, opts.transfer_size,
 						&remote, &tx_ctx_arr[fi->rx_attr->size].context);
 				break;
 			default:


### PR DESCRIPTION
A series of commits to enable `-o write` and `-o read` to perform data validation.

There is a notable performance impact when validation is enabled.

Addresses https://github.com/ofiwg/libfabric/issues/8784