### PR TITLE
[v1.18.x] prov/tcp: Rename DL package from libnet to libtcp

### DIFF
--- a/prov/tcp/Makefile.include
+++ b/prov/tcp/Makefile.include
@@ -19,11 +19,11 @@ _xnet_files = \
 	prov/tcp/src/xnet.h
 
 if HAVE_TCP_DL
-pkglib_LTLIBRARIES += libnet-fi.la
-libnet_fi_la_SOURCES = $(_xnet_files) $(common_srcs)
-libnet_fi_la_LIBADD = $(linkback) $(xnet_shm_LIBS)
-libnet_fi_la_LDFLAGS = -module -avoid-version -shared -export-dynamic
-libnet_fi_la_DEPENDENCIES = $(linkback)
+pkglib_LTLIBRARIES += libtcp-fi.la
+libtcp_fi_la_SOURCES = $(_xnet_files) $(common_srcs)
+libtcp_fi_la_LIBADD = $(linkback) $(xnet_shm_LIBS)
+libtcp_fi_la_LDFLAGS = -module -avoid-version -shared -export-dynamic
+libtcp_fi_la_DEPENDENCIES = $(linkback)
 else !HAVE_TCP_DL
 src_libfabric_la_SOURCES += $(_xnet_files)
 src_libfabric_la_LIBADD += $(xnet_shm_LIBS)


### PR DESCRIPTION
The DL name doesn't technically matter, but it is confusing for users wanting a DL build.