### PR TITLE
prov/efa: rename "rxr_op_entry" to "efa_rdm_ope"

### DIFF
--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -884,7 +884,7 @@
     <ClCompile Include="prov\efa\src\dgram\efa_dgram_msg.c" />
     <ClCompile Include="prov\efa\src\dgram\efa_dgram_rma.c" />
     <ClCompile Include="prov\efa\src\rdm\rxr_pkt_type_base.c" />
-    <ClCompile Include="prov\efa\src\rdm\rxr_op_entry.c" />
+    <ClCompile Include="prov\efa\src\rdm\efa_rdm_ope.c" />
     <ClCompile Include="prov\efa\src\rdm\rxr_atomic.c" />
     <ClCompile Include="prov\efa\src\rdm\rxr_cntr.c" />
     <ClCompile Include="prov\efa\src\rdm\rxr_ep.c" />

--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -63,7 +63,7 @@ _efa_files = \
 	prov/efa/src/rdm/rxr_pkt_type_misc.c \
 	prov/efa/src/rdm/rxr_pkt_cmd.c \
 	prov/efa/src/rdm/rxr_pkt_pool.c \
-	prov/efa/src/rdm/rxr_op_entry.c \
+	prov/efa/src/rdm/efa_rdm_ope.c \
 	prov/efa/src/rdm/rxr_atomic.c \
 	prov/efa/src/rdm/rxr_tp_def.c \
 	prov/efa/src/rdm/efa_rdm_srx.c \
@@ -105,7 +105,7 @@ _efa_headers = \
 	prov/efa/src/rdm/rxr_pkt_cmd.h \
 	prov/efa/src/rdm/rxr_pkt_pool.h \
 	prov/efa/src/rdm/rxr_atomic.h \
-	prov/efa/src/rdm/rxr_op_entry.h \
+	prov/efa/src/rdm/efa_rdm_ope.h \
 	prov/efa/src/rdm/rdm_proto_v4.h \
 	prov/efa/src/rdm/rxr_tp_def.h \
 	prov/efa/src/rdm/rxr_tp.h \

--- a/prov/efa/docs/pkt-processing.md
+++ b/prov/efa/docs/pkt-processing.md
@@ -21,7 +21,7 @@ in progress, sends and receives queued due to resource exhaustion, unexpected
 messages, and structures to track out of order packets and remote peer
 capabilities and status.
 
-`rxr_op_entry` contains information and structures used in send/receive operations. 
+`efa_rdm_ope` contains information and structures used in send/receive operations. 
 It is used in send operation for send posted directly by the app or indirectly 
 by emulated read/write operations. When the send is completed a send completion 
 will be written and the tx_entry will be released.

--- a/prov/efa/src/efa_tp.h
+++ b/prov/efa/src/efa_tp.h
@@ -6,7 +6,7 @@
 #if HAVE_LTTNG
 
 #include "efa_tp_def.h"
-#include "rdm/rxr_op_entry.h"
+#include "rdm/efa_rdm_ope.h"
 
 #include <lttng/tracef.h>
 #include <lttng/tracelog.h>
@@ -25,7 +25,7 @@
 static inline void efa_tracepoint_wr_id_post_send(const void *wr_id)
 {
 	struct rxr_pkt_entry *pkt_entry = (struct rxr_pkt_entry *) wr_id;
-	struct rxr_op_entry *op_entry = (struct rxr_op_entry *) pkt_entry->x_entry;
+	struct efa_rdm_ope *op_entry = (struct efa_rdm_ope *) pkt_entry->x_entry;
 	if (!op_entry)
 		return;
 	efa_tracepoint(post_send, (size_t) wr_id, (size_t) op_entry, (size_t) op_entry->cq_entry.op_context);
@@ -34,7 +34,7 @@ static inline void efa_tracepoint_wr_id_post_send(const void *wr_id)
 static inline void efa_tracepoint_wr_id_post_recv(const void *wr_id)
 {
 	struct rxr_pkt_entry *pkt_entry = (struct rxr_pkt_entry *) wr_id;
-	struct rxr_op_entry *op_entry = (struct rxr_op_entry *) pkt_entry->x_entry;
+	struct efa_rdm_ope *op_entry = (struct efa_rdm_ope *) pkt_entry->x_entry;
 	if (!op_entry)
 		return;
 	efa_tracepoint(post_recv, (size_t) wr_id, (size_t) op_entry, (size_t) op_entry->cq_entry.op_context);

--- a/prov/efa/src/efa_tp_def.h
+++ b/prov/efa/src/efa_tp_def.h
@@ -15,12 +15,12 @@
 
 #define X_PKT_ARGS \
 	size_t, wr_id, \
-	size_t, rxr_op_entry, \
+	size_t, efa_rdm_ope, \
 	size_t, context
 
 #define X_PKT_FIELDS \
 	lttng_ust_field_integer_hex(size_t, wr_id, wr_id) \
-	lttng_ust_field_integer_hex(size_t, rxr_op_entry, rxr_op_entry) \
+	lttng_ust_field_integer_hex(size_t, efa_rdm_ope, efa_rdm_ope) \
 	lttng_ust_field_integer_hex(size_t, context, context)
 
 LTTNG_UST_TRACEPOINT_EVENT_CLASS(EFA_TP_PROV, post_wr_id,

--- a/prov/efa/src/rdm/efa_rdm_peer.c
+++ b/prov/efa/src/rdm/efa_rdm_peer.c
@@ -70,8 +70,8 @@ void efa_rdm_peer_construct(struct efa_rdm_peer *peer, struct rxr_ep *ep, struct
 void efa_rdm_peer_destruct(struct efa_rdm_peer *peer, struct rxr_ep *ep)
 {
 	struct dlist_entry *tmp;
-	struct rxr_op_entry *tx_entry;
-	struct rxr_op_entry *rx_entry;
+	struct efa_rdm_ope *tx_entry;
+	struct efa_rdm_ope *rx_entry;
 	struct rxr_pkt_entry *pkt_entry;
 	/*
 	 * TODO: Add support for wait/signal until all pending messages have
@@ -106,15 +106,15 @@ void efa_rdm_peer_destruct(struct efa_rdm_peer *peer, struct rxr_ep *ep)
 	}
 
 	dlist_foreach_container_safe(&peer->tx_entry_list,
-				     struct rxr_op_entry,
+				     struct efa_rdm_ope,
 				     tx_entry, peer_entry, tmp) {
-		rxr_tx_entry_release(tx_entry);
+		efa_rdm_txe_release(tx_entry);
 	}
 
 	dlist_foreach_container_safe(&peer->rx_entry_list,
-				     struct rxr_op_entry,
+				     struct efa_rdm_ope,
 				     rx_entry, peer_entry, tmp) {
-		rxr_rx_entry_release(rx_entry);
+		efa_rdm_rxe_release(rx_entry);
 	}
 
 	if (peer->flags & EFA_RDM_PEER_HANDSHAKE_QUEUED)

--- a/prov/efa/src/rdm/efa_rdm_srx.c
+++ b/prov/efa/src/rdm/efa_rdm_srx.c
@@ -106,7 +106,7 @@ static int efa_rdm_srx_get_msg(struct fid_peer_srx *srx, fi_addr_t addr,
 {
 	struct rxr_ep *rxr_ep;
 	struct rxr_pkt_entry *pkt_entry;
-	struct rxr_op_entry *rx_entry;
+	struct efa_rdm_ope *rx_entry;
 	int ret;
 	char buf[PEER_SRX_MSG_PKT_SIZE];
 
@@ -129,7 +129,7 @@ static int efa_rdm_srx_get_msg(struct fid_peer_srx *srx, fi_addr_t addr,
 		ret = -FI_ENOBUFS;
 		goto out;
 	}
-	ret = rx_entry->state == RXR_RX_MATCHED ? FI_SUCCESS : -FI_ENOENT;
+	ret = rx_entry->state == EFA_RDM_RXE_MATCHED ? FI_SUCCESS : -FI_ENOENT;
 	/* Override this field to be peer provider's srx so the correct srx can be used by start_msg ops */
 	rx_entry->peer_rx_entry.srx = srx;
 	*peer_rx_entry = &rx_entry->peer_rx_entry;
@@ -154,7 +154,7 @@ static int efa_rdm_srx_get_tag(struct fid_peer_srx *srx, fi_addr_t addr,
 {
 	struct rxr_ep *rxr_ep;
 	struct rxr_pkt_entry *pkt_entry;
-	struct rxr_op_entry *rx_entry;
+	struct efa_rdm_ope *rx_entry;
 	int ret;
 	char buf[PEER_SRX_TAG_PKT_SIZE];
 
@@ -177,7 +177,7 @@ static int efa_rdm_srx_get_tag(struct fid_peer_srx *srx, fi_addr_t addr,
 		ret = -FI_ENOBUFS;
 		goto out;
 	}
-	ret = rx_entry->state == RXR_RX_MATCHED ? FI_SUCCESS : -FI_ENOENT;
+	ret = rx_entry->state == EFA_RDM_RXE_MATCHED ? FI_SUCCESS : -FI_ENOENT;
 	/* Override this field to be peer provider's srx so the correct srx can be used by start_tag ops */
 	rx_entry->peer_rx_entry.srx = srx;
 	*peer_rx_entry = &rx_entry->peer_rx_entry;
@@ -198,10 +198,10 @@ out:
  */
 static int efa_rdm_srx_queue_msg(struct fi_peer_rx_entry *peer_rx_entry)
 {
-	struct rxr_op_entry *rx_entry;
+	struct efa_rdm_ope *rx_entry;
 	struct rxr_ep *ep;
 
-	rx_entry = container_of(peer_rx_entry, struct rxr_op_entry, peer_rx_entry);
+	rx_entry = container_of(peer_rx_entry, struct efa_rdm_ope, peer_rx_entry);
 	ep = rx_entry->ep;
 
 	ofi_mutex_lock(&ep->base_ep.util_ep.lock);
@@ -221,10 +221,10 @@ static int efa_rdm_srx_queue_msg(struct fi_peer_rx_entry *peer_rx_entry)
  */
 static int efa_rdm_srx_queue_tag(struct fi_peer_rx_entry *peer_rx_entry)
 {
-	struct rxr_op_entry *rx_entry;
+	struct efa_rdm_ope *rx_entry;
 	struct rxr_ep *ep;
 
-	rx_entry = container_of(peer_rx_entry, struct rxr_op_entry, peer_rx_entry);
+	rx_entry = container_of(peer_rx_entry, struct efa_rdm_ope, peer_rx_entry);
 	ep = rx_entry->ep;
 
 	ofi_mutex_lock(&ep->base_ep.util_ep.lock);
@@ -241,10 +241,10 @@ static int efa_rdm_srx_queue_tag(struct fi_peer_rx_entry *peer_rx_entry)
  */
 static void efa_rdm_srx_free_entry(struct fi_peer_rx_entry *peer_rx_entry)
 {
-	struct rxr_op_entry *rx_entry;
+	struct efa_rdm_ope *rx_entry;
 	struct rxr_ep *ep;
 
-	rx_entry = container_of(peer_rx_entry, struct rxr_op_entry, peer_rx_entry);
+	rx_entry = container_of(peer_rx_entry, struct efa_rdm_ope, peer_rx_entry);
 	ep = rx_entry->ep;
 
 	ofi_mutex_lock(&ep->base_ep.util_ep.lock);
@@ -261,7 +261,7 @@ static void efa_rdm_srx_free_entry(struct fi_peer_rx_entry *peer_rx_entry)
 		}
 	}
 	rxr_msg_multi_recv_free_posted_entry(rx_entry->ep, rx_entry);
-	rxr_rx_entry_release(rx_entry);
+	efa_rdm_rxe_release(rx_entry);
 	ofi_mutex_unlock(&ep->base_ep.util_ep.lock);
 }
 
@@ -274,11 +274,11 @@ static void efa_rdm_srx_free_entry(struct fi_peer_rx_entry *peer_rx_entry)
  */
 static int efa_rdm_srx_start_msg(struct fi_peer_rx_entry *peer_rx_entry)
 {
-	struct rxr_op_entry *rx_op_entry;
+	struct efa_rdm_ope *rx_op_entry;
 	int ret;
 	struct rxr_ep *ep;
 
-	rx_op_entry = container_of(peer_rx_entry, struct rxr_op_entry, peer_rx_entry);
+	rx_op_entry = container_of(peer_rx_entry, struct efa_rdm_ope, peer_rx_entry);
 	ep = rx_op_entry->ep;
 
 	ofi_mutex_lock(&ep->base_ep.util_ep.lock);
@@ -297,11 +297,11 @@ static int efa_rdm_srx_start_msg(struct fi_peer_rx_entry *peer_rx_entry)
  */
 static int efa_rdm_srx_start_tag(struct fi_peer_rx_entry *peer_rx_entry)
 {
-	struct rxr_op_entry *rx_op_entry;
+	struct efa_rdm_ope *rx_op_entry;
 	int ret;
 	struct rxr_ep *ep;
 
-	rx_op_entry = container_of(peer_rx_entry, struct rxr_op_entry, peer_rx_entry);
+	rx_op_entry = container_of(peer_rx_entry, struct efa_rdm_ope, peer_rx_entry);
 	ep = rx_op_entry->ep;
 
 	ofi_mutex_lock(&ep->base_ep.util_ep.lock);

--- a/prov/efa/src/rdm/rxr.h
+++ b/prov/efa/src/rdm/rxr.h
@@ -66,7 +66,7 @@
 #include "efa_prov.h"
 #include "efa_base_ep.h"
 #include "rxr_pkt_type.h"
-#include "rxr_op_entry.h"
+#include "efa_rdm_ope.h"
 #include "rxr_env.h"
 #include "rxr_ep.h"
 

--- a/prov/efa/src/rdm/rxr_ep.h
+++ b/prov/efa/src/rdm/rxr_ep.h
@@ -250,13 +250,13 @@ struct efa_rdm_peer *rxr_ep_get_peer(struct rxr_ep *ep, fi_addr_t addr);
 
 int32_t rxr_ep_get_peer_ahn(struct rxr_ep *ep, fi_addr_t addr);
 
-struct rxr_op_entry *rxr_ep_alloc_tx_entry(struct rxr_ep *rxr_ep,
+struct efa_rdm_ope *rxr_ep_alloc_tx_entry(struct rxr_ep *rxr_ep,
 					   const struct fi_msg *msg,
 					   uint32_t op,
 					   uint64_t tag,
 					   uint64_t flags);
 
-struct rxr_op_entry *rxr_ep_alloc_rx_entry(struct rxr_ep *ep,
+struct efa_rdm_ope *rxr_ep_alloc_rx_entry(struct rxr_ep *ep,
 					   fi_addr_t addr, uint32_t op);
 
 void rxr_ep_record_tx_op_submitted(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
@@ -342,7 +342,7 @@ int rxr_endpoint(struct fid_domain *domain, struct fi_info *info,
 void rxr_ep_progress(struct util_ep *util_ep);
 void rxr_ep_progress_internal(struct rxr_ep *rxr_ep);
 
-int rxr_ep_post_user_recv_buf(struct rxr_ep *ep, struct rxr_op_entry *rx_entry,
+int rxr_ep_post_user_recv_buf(struct rxr_ep *ep, struct efa_rdm_ope *rx_entry,
 			      uint64_t flags);
 
 struct efa_rdm_peer;
@@ -352,12 +352,12 @@ int rxr_ep_determine_rdma_read_support(struct rxr_ep *ep, fi_addr_t addr,
 int rxr_ep_determine_rdma_write_support(struct rxr_ep *ep, fi_addr_t addr,
 					struct efa_rdm_peer *peer);
 
-struct rxr_op_entry *rxr_ep_lookup_mediumrtm_rx_entry(struct rxr_ep *ep,
+struct efa_rdm_ope *rxr_ep_lookup_mediumrtm_rx_entry(struct rxr_ep *ep,
 						      struct rxr_pkt_entry *pkt_entry);
 
 void rxr_ep_record_mediumrtm_rx_entry(struct rxr_ep *ep,
 				      struct rxr_pkt_entry *pkt_entry,
-				      struct rxr_op_entry *rx_entry);
+				      struct efa_rdm_ope *rx_entry);
 
 void rxr_ep_queue_rnr_pkt(struct rxr_ep *ep,
 			  struct dlist_entry *list,

--- a/prov/efa/src/rdm/rxr_msg.h
+++ b/prov/efa/src/rdm/rxr_msg.h
@@ -33,15 +33,15 @@
 
 /**
  * @brief Populate the fields in fi_peer_rx_entry object
- * with the equivalences in rxr_op_entry
+ * with the equivalences in efa_rdm_ope
  *
  * @param[in,out] peer_rx_entry the fi_peer_rx_entry object to be updated
- * @param[in] rx_entry the rxr_op_entry
+ * @param[in] rx_entry the efa_rdm_ope
  * @param[in] op the ofi op code
  */
 static inline
 void rxr_msg_update_peer_rx_entry(struct fi_peer_rx_entry *peer_rx_entry,
-				  struct rxr_op_entry *rx_entry,
+				  struct efa_rdm_ope *rx_entry,
 				  uint32_t op)
 {
 	assert(op == ofi_op_msg || op == ofi_op_tagged);
@@ -102,7 +102,7 @@ void rxr_tmsg_construct(struct fi_msg_tagged *msg, const struct iovec *iov, void
  */
 static inline
 void rxr_msg_queue_unexp_rx_entry_for_msgrtm(struct rxr_ep *ep,
-					      struct rxr_op_entry *unexp_rx_entry)
+					      struct efa_rdm_ope *unexp_rx_entry)
 {
 	struct efa_rdm_peer *peer;
 
@@ -119,7 +119,7 @@ void rxr_msg_queue_unexp_rx_entry_for_msgrtm(struct rxr_ep *ep,
  */
 static inline
 void rxr_msg_queue_unexp_rx_entry_for_tagrtm(struct rxr_ep *ep,
-					      struct rxr_op_entry *unexp_rx_entry)
+					      struct efa_rdm_ope *unexp_rx_entry)
 {
 	struct efa_rdm_peer *peer;
 
@@ -134,37 +134,37 @@ void rxr_msg_queue_unexp_rx_entry_for_tagrtm(struct rxr_ep *ep,
 
 
 bool rxr_msg_multi_recv_buffer_available(struct rxr_ep *ep,
-					 struct rxr_op_entry *rx_entry);
+					 struct efa_rdm_ope *rx_entry);
 
 void rxr_msg_multi_recv_handle_completion(struct rxr_ep *ep,
-					  struct rxr_op_entry *rx_entry);
+					  struct efa_rdm_ope *rx_entry);
 
 void rxr_msg_multi_recv_free_posted_entry(struct rxr_ep *ep,
-					  struct rxr_op_entry *rx_entry);
+					  struct efa_rdm_ope *rx_entry);
 
 /**
  * functions to allocate rx_entry for two sided operations
  */
-struct rxr_op_entry *rxr_msg_alloc_rx_entry(struct rxr_ep *ep,
+struct efa_rdm_ope *rxr_msg_alloc_rx_entry(struct rxr_ep *ep,
 					    const struct fi_msg *msg,
 					    uint32_t op, uint64_t flags,
 					    uint64_t tag, uint64_t ignore);
 
-struct rxr_op_entry *rxr_msg_alloc_unexp_rx_entry_for_msgrtm(struct rxr_ep *ep,
+struct efa_rdm_ope *rxr_msg_alloc_unexp_rx_entry_for_msgrtm(struct rxr_ep *ep,
 							     struct rxr_pkt_entry **pkt_entry);
 
-struct rxr_op_entry *rxr_msg_alloc_unexp_rx_entry_for_tagrtm(struct rxr_ep *ep,
+struct efa_rdm_ope *rxr_msg_alloc_unexp_rx_entry_for_tagrtm(struct rxr_ep *ep,
 							     struct rxr_pkt_entry **pkt_entry);
 
 void rxr_msg_queue_unexp_rx_entry_for_msgrtm(struct rxr_ep *ep,
-					     struct rxr_op_entry *unexp_rx_entry);
+					     struct efa_rdm_ope *unexp_rx_entry);
 
 void rxr_msg_queue_unexp_rx_entry_for_tagrtm(struct rxr_ep *ep,
-					     struct rxr_op_entry *unexp_rx_entry);
+					     struct efa_rdm_ope *unexp_rx_entry);
 
-struct rxr_op_entry *rxr_msg_split_rx_entry(struct rxr_ep *ep,
-					    struct rxr_op_entry *posted_entry,
-					    struct rxr_op_entry *consumer_entry,
+struct efa_rdm_ope *rxr_msg_split_rx_entry(struct rxr_ep *ep,
+					    struct efa_rdm_ope *posted_entry,
+					    struct efa_rdm_ope *consumer_entry,
 					    struct rxr_pkt_entry *pkt_entry);
 /*
  * The following 2 OP structures are defined in rxr_msg.c and is
@@ -174,6 +174,6 @@ extern struct fi_ops_msg rxr_ops_msg;
 
 extern struct fi_ops_tagged rxr_ops_tagged;
 
-ssize_t rxr_msg_post_medium_rtm(struct rxr_ep *ep, struct rxr_op_entry *tx_entry);
+ssize_t rxr_msg_post_medium_rtm(struct rxr_ep *ep, struct efa_rdm_ope *tx_entry);
 
-ssize_t rxr_msg_post_medium_rtm_or_queue(struct rxr_ep *ep, struct rxr_op_entry *tx_entry);
+ssize_t rxr_msg_post_medium_rtm_or_queue(struct rxr_ep *ep, struct efa_rdm_ope *tx_entry);

--- a/prov/efa/src/rdm/rxr_pkt_cmd.h
+++ b/prov/efa/src/rdm/rxr_pkt_cmd.h
@@ -36,13 +36,13 @@
 
 #include "rxr.h"
 
-ssize_t rxr_pkt_post(struct rxr_ep *ep, struct rxr_op_entry *op_entry,
+ssize_t rxr_pkt_post(struct rxr_ep *ep, struct efa_rdm_ope *op_entry,
 		     int pkt_type, uint64_t flags);
 
-ssize_t rxr_pkt_post_or_queue(struct rxr_ep *ep, struct rxr_op_entry *op_entry,
+ssize_t rxr_pkt_post_or_queue(struct rxr_ep *ep, struct efa_rdm_ope *op_entry,
 			      int req_type);
 
-ssize_t rxr_pkt_post_req(struct rxr_ep *ep, struct rxr_op_entry *tx_entry,
+ssize_t rxr_pkt_post_req(struct rxr_ep *ep, struct efa_rdm_ope *tx_entry,
 			 int req_type, uint64_t flags);
 
 fi_addr_t rxr_pkt_determine_addr(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);

--- a/prov/efa/src/rdm/rxr_pkt_entry.c
+++ b/prov/efa/src/rdm/rxr_pkt_entry.c
@@ -44,7 +44,7 @@
 #include "rxr.h"
 #include "rxr_msg.h"
 #include "rxr_rma.h"
-#include "rxr_op_entry.h"
+#include "efa_rdm_ope.h"
 #include "rxr_pkt_cmd.h"
 #include "rxr_pkt_pool.h"
 
@@ -519,12 +519,12 @@ int rxr_pkt_entry_write(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry,
 	struct efa_conn *conn;
 	struct ibv_sge sge;
 	struct rxr_rma_context_pkt *rma_context_pkt;
-	struct rxr_op_entry *tx_entry;
+	struct efa_rdm_ope *tx_entry;
 	bool self_comm;
 	int err = 0;
 
 	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
-	tx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
+	tx_entry = (struct efa_rdm_ope *)pkt_entry->x_entry;
 
 	rma_context_pkt = (struct rxr_rma_context_pkt *)pkt_entry->wiredata;
 	rma_context_pkt->seg_size = len;
@@ -629,7 +629,7 @@ ssize_t rxr_pkt_entry_recv(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry,
 /*
  * Functions for pkt_rx_map
  */
-struct rxr_op_entry *rxr_pkt_rx_map_lookup(struct rxr_ep *ep,
+struct efa_rdm_ope *rxr_pkt_rx_map_lookup(struct rxr_ep *ep,
 					   struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_pkt_rx_map *entry = NULL;
@@ -644,7 +644,7 @@ struct rxr_op_entry *rxr_pkt_rx_map_lookup(struct rxr_ep *ep,
 
 void rxr_pkt_rx_map_insert(struct rxr_ep *ep,
 			   struct rxr_pkt_entry *pkt_entry,
-			   struct rxr_op_entry *rx_entry)
+			   struct efa_rdm_ope *rx_entry)
 {
 	struct rxr_pkt_rx_map *entry;
 
@@ -675,7 +675,7 @@ void rxr_pkt_rx_map_insert(struct rxr_ep *ep,
 
 void rxr_pkt_rx_map_remove(struct rxr_ep *ep,
 			   struct rxr_pkt_entry *pkt_entry,
-			   struct rxr_op_entry *rx_entry)
+			   struct efa_rdm_ope *rx_entry)
 {
 	struct rxr_pkt_rx_map *entry;
 	struct rxr_pkt_rx_key key;

--- a/prov/efa/src/rdm/rxr_pkt_entry.h
+++ b/prov/efa/src/rdm/rxr_pkt_entry.h
@@ -158,8 +158,8 @@ struct rxr_pkt_entry {
 	struct dlist_entry dbg_entry;
 	uint8_t pad[48];
 #endif
-	/** @brief pointer to #rxr_op_entry */
-	struct rxr_op_entry *x_entry;
+	/** @brief pointer to #efa_rdm_ope */
+	struct efa_rdm_ope *x_entry;
 
 	/** @brief number of bytes sent/received over wire */
 	size_t pkt_size;
@@ -247,7 +247,7 @@ static_assert(sizeof(struct rxr_pkt_entry) == 128, "rxr_pkt_entry check");
 
 struct rxr_ep;
 
-struct rxr_op_entry;
+struct efa_rdm_ope;
 
 struct rxr_pkt_pool;
 
@@ -299,24 +299,24 @@ struct rxr_pkt_rx_key {
 	fi_addr_t addr;
 };
 
-struct rxr_op_entry;
+struct efa_rdm_ope;
 
 struct rxr_pkt_rx_map {
 	struct rxr_pkt_rx_key key;
-	struct rxr_op_entry *rx_entry;
+	struct efa_rdm_ope *rx_entry;
 	UT_hash_handle hh;
 };
 
-struct rxr_op_entry *rxr_pkt_rx_map_lookup(struct rxr_ep *ep,
+struct efa_rdm_ope *rxr_pkt_rx_map_lookup(struct rxr_ep *ep,
 					   struct rxr_pkt_entry *pkt_entry);
 
 void rxr_pkt_rx_map_insert(struct rxr_ep *ep,
 			   struct rxr_pkt_entry *pkt_entry,
-			   struct rxr_op_entry *rx_entry);
+			   struct efa_rdm_ope *rx_entry);
 
 void rxr_pkt_rx_map_remove(struct rxr_ep *pkt_rx_map,
 			   struct rxr_pkt_entry *pkt_entry,
-			   struct rxr_op_entry *rx_entry);
+			   struct efa_rdm_ope *rx_entry);
 
 static inline bool rxr_pkt_entry_has_hmem_mr(struct rxr_pkt_sendv *send)
 {

--- a/prov/efa/src/rdm/rxr_pkt_type.h
+++ b/prov/efa/src/rdm/rxr_pkt_type.h
@@ -34,7 +34,7 @@
 #ifndef _RXR_PKT_TYPE_H
 #define _RXR_PKT_TYPE_H
 
-#include "rxr_op_entry.h"
+#include "efa_rdm_ope.h"
 #include "rdm_proto_v4.h"
 
 static inline struct rxr_base_hdr *rxr_get_base_hdr(void *pkt)
@@ -113,7 +113,7 @@ void rxr_pkt_calc_cts_window_credits(struct rxr_ep *ep, struct efa_rdm_peer *pee
 				     int *window, int *credits);
 
 ssize_t rxr_pkt_init_cts(struct rxr_ep *ep,
-			 struct rxr_op_entry *op_entry,
+			 struct efa_rdm_ope *op_entry,
 			 struct rxr_pkt_entry *pkt_entry);
 
 void rxr_pkt_handle_cts_sent(struct rxr_ep *ep,
@@ -129,14 +129,14 @@ struct rxr_data_hdr *rxr_get_data_hdr(void *pkt)
 }
 
 int rxr_pkt_init_data(struct rxr_ep *ep,
-		      struct rxr_op_entry *op_entry,
+		      struct efa_rdm_ope *op_entry,
 		      struct rxr_pkt_entry *pkt_entry);
 
 void rxr_pkt_handle_data_sent(struct rxr_ep *ep,
 			      struct rxr_pkt_entry *pkt_entry);
 
 void rxr_pkt_proc_data(struct rxr_ep *ep,
-		       struct rxr_op_entry *op_entry,
+		       struct efa_rdm_ope *op_entry,
 		       struct rxr_pkt_entry *pkt_entry,
 		       char *data, size_t seg_offset,
 		       size_t seg_size);
@@ -154,7 +154,7 @@ static inline struct rxr_readrsp_hdr *rxr_get_readrsp_hdr(void *pkt)
 }
 
 int rxr_pkt_init_readrsp(struct rxr_ep *ep,
-			 struct rxr_op_entry *tx_entry,
+			 struct efa_rdm_ope *tx_entry,
 			 struct rxr_pkt_entry *pkt_entry);
 
 void rxr_pkt_handle_readrsp_sent(struct rxr_ep *ep,
@@ -187,7 +187,7 @@ enum rxr_rma_context_pkt_type {
 	RXR_WRITE_CONTEXT,
 };
 
-void rxr_pkt_init_write_context(struct rxr_op_entry *tx_entry,
+void rxr_pkt_init_write_context(struct efa_rdm_ope *tx_entry,
 				struct rxr_pkt_entry *pkt_entry);
 
 void rxr_pkt_init_read_context(struct rxr_ep *rxr_ep,
@@ -208,7 +208,7 @@ struct rxr_eor_hdr *rxr_get_eor_hdr(void *pkt)
 }
 
 int rxr_pkt_init_eor(struct rxr_ep *ep,
-		     struct rxr_op_entry *rx_entry,
+		     struct efa_rdm_ope *rx_entry,
 		     struct rxr_pkt_entry *pkt_entry);
 
 static inline
@@ -228,7 +228,7 @@ static inline struct rxr_atomrsp_hdr *rxr_get_atomrsp_hdr(void *pkt)
 	return (struct rxr_atomrsp_hdr *)pkt;
 }
 
-int rxr_pkt_init_atomrsp(struct rxr_ep *ep, struct rxr_op_entry *rx_entry,
+int rxr_pkt_init_atomrsp(struct rxr_ep *ep, struct efa_rdm_ope *rx_entry,
 			 struct rxr_pkt_entry *pkt_entry);
 
 void rxr_pkt_handle_atomrsp_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
@@ -244,7 +244,7 @@ struct rxr_receipt_hdr *rxr_get_receipt_hdr(void *pkt)
 	return (struct rxr_receipt_hdr *)pkt;
 }
 
-int rxr_pkt_init_receipt(struct rxr_ep *ep, struct rxr_op_entry *rx_entry,
+int rxr_pkt_init_receipt(struct rxr_ep *ep, struct efa_rdm_ope *rx_entry,
 			 struct rxr_pkt_entry *pkt_entry);
 
 void rxr_pkt_handle_receipt_sent(struct rxr_ep *ep,

--- a/prov/efa/src/rdm/rxr_pkt_type_base.h
+++ b/prov/efa/src/rdm/rxr_pkt_type_base.h
@@ -41,12 +41,12 @@ uint32_t *rxr_pkt_connid_ptr(struct rxr_pkt_entry *pkt_entry);
 int rxr_pkt_init_data_from_op_entry(struct rxr_ep *ep,
 				    struct rxr_pkt_entry *pkt_entry,
 				    size_t pkt_data_offset,
-				    struct rxr_op_entry *op_entry,
+				    struct efa_rdm_ope *op_entry,
 				    size_t op_data_offset,
 				    size_t data_size);
 
 ssize_t rxr_pkt_copy_data_to_op_entry(struct rxr_ep *ep,
-				      struct rxr_op_entry *rx_entry,
+				      struct efa_rdm_ope *rx_entry,
 				      size_t data_offset,
 				      struct rxr_pkt_entry *pkt_entry,
 				      char *data, size_t data_size);

--- a/prov/efa/src/rdm/rxr_pkt_type_req.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_req.c
@@ -149,7 +149,7 @@ int rxr_pkt_type_readbase_rtm(struct efa_rdm_peer *peer, int op, uint64_t fi_fla
 
 
 void rxr_pkt_init_req_hdr(struct rxr_ep *ep,
-			  struct rxr_op_entry *tx_entry,
+			  struct efa_rdm_ope *tx_entry,
 			  int pkt_type,
 			  struct rxr_pkt_entry *pkt_entry)
 {
@@ -472,7 +472,7 @@ size_t rxr_pkt_max_hdr_size(void)
  */
 static inline
 int rxr_pkt_init_rtm(struct rxr_ep *ep,
-		     struct rxr_op_entry *tx_entry,
+		     struct efa_rdm_ope *tx_entry,
 		     int pkt_type, uint64_t data_offset,
 		     struct rxr_pkt_entry *pkt_entry)
 {
@@ -505,7 +505,7 @@ int rxr_pkt_init_rtm(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_eager_msgrtm(struct rxr_ep *ep,
-				  struct rxr_op_entry *tx_entry,
+				  struct efa_rdm_ope *tx_entry,
 				  struct rxr_pkt_entry *pkt_entry)
 {
 	int ret;
@@ -519,13 +519,13 @@ ssize_t rxr_pkt_init_eager_msgrtm(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_dc_eager_msgrtm(struct rxr_ep *ep,
-				     struct rxr_op_entry *tx_entry,
+				     struct efa_rdm_ope *tx_entry,
 				     struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_dc_eager_msgrtm_hdr *dc_eager_msgrtm_hdr;
 	int ret;
 
-	tx_entry->rxr_flags |= RXR_TX_ENTRY_DELIVERY_COMPLETE_REQUESTED;
+	tx_entry->rxr_flags |= EFA_RDM_TXE_DELIVERY_COMPLETE_REQUESTED;
 	ret = rxr_pkt_init_rtm(ep, tx_entry, RXR_DC_EAGER_MSGRTM_PKT, 0, pkt_entry);
 	if (ret)
 		return ret;
@@ -535,7 +535,7 @@ ssize_t rxr_pkt_init_dc_eager_msgrtm(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_eager_tagrtm(struct rxr_ep *ep,
-				  struct rxr_op_entry *tx_entry,
+				  struct efa_rdm_ope *tx_entry,
 				  struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_base_hdr *base_hdr;
@@ -552,14 +552,14 @@ ssize_t rxr_pkt_init_eager_tagrtm(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_dc_eager_tagrtm(struct rxr_ep *ep,
-				     struct rxr_op_entry *tx_entry,
+				     struct efa_rdm_ope *tx_entry,
 				     struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_base_hdr *base_hdr;
 	struct rxr_dc_eager_tagrtm_hdr *dc_eager_tagrtm_hdr;
 	int ret;
 
-	tx_entry->rxr_flags |= RXR_TX_ENTRY_DELIVERY_COMPLETE_REQUESTED;
+	tx_entry->rxr_flags |= EFA_RDM_TXE_DELIVERY_COMPLETE_REQUESTED;
 	ret = rxr_pkt_init_rtm(ep, tx_entry, RXR_DC_EAGER_TAGRTM_PKT, 0, pkt_entry);
 	if (ret)
 		return ret;
@@ -573,13 +573,13 @@ ssize_t rxr_pkt_init_dc_eager_tagrtm(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_medium_msgrtm(struct rxr_ep *ep,
-				   struct rxr_op_entry *tx_entry,
+				   struct efa_rdm_ope *tx_entry,
 				   struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_medium_rtm_base_hdr *rtm_hdr;
 	int ret;
 
-	rxr_op_entry_try_fill_desc(tx_entry, 0, FI_SEND);
+	efa_rdm_ope_try_fill_desc(tx_entry, 0, FI_SEND);
 
 	ret = rxr_pkt_init_rtm(ep, tx_entry, RXR_MEDIUM_MSGRTM_PKT,
 			       tx_entry->bytes_sent, pkt_entry);
@@ -593,15 +593,15 @@ ssize_t rxr_pkt_init_medium_msgrtm(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_dc_medium_msgrtm(struct rxr_ep *ep,
-				      struct rxr_op_entry *tx_entry,
+				      struct efa_rdm_ope *tx_entry,
 				      struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_dc_medium_msgrtm_hdr *dc_medium_msgrtm_hdr;
 	int ret;
 
-	tx_entry->rxr_flags |= RXR_TX_ENTRY_DELIVERY_COMPLETE_REQUESTED;
+	tx_entry->rxr_flags |= EFA_RDM_TXE_DELIVERY_COMPLETE_REQUESTED;
 
-	rxr_op_entry_try_fill_desc(tx_entry, 0, FI_SEND);
+	efa_rdm_ope_try_fill_desc(tx_entry, 0, FI_SEND);
 
 	ret = rxr_pkt_init_rtm(ep, tx_entry, RXR_DC_MEDIUM_MSGRTM_PKT,
 			       tx_entry->bytes_sent, pkt_entry);
@@ -616,13 +616,13 @@ ssize_t rxr_pkt_init_dc_medium_msgrtm(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_medium_tagrtm(struct rxr_ep *ep,
-				   struct rxr_op_entry *tx_entry,
+				   struct efa_rdm_ope *tx_entry,
 				   struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_medium_rtm_base_hdr *rtm_hdr;
 	int ret;
 
-	rxr_op_entry_try_fill_desc(tx_entry, 0, FI_SEND);
+	efa_rdm_ope_try_fill_desc(tx_entry, 0, FI_SEND);
 
 	ret = rxr_pkt_init_rtm(ep, tx_entry, RXR_MEDIUM_TAGRTM_PKT,
 			       tx_entry->bytes_sent, pkt_entry);
@@ -638,15 +638,15 @@ ssize_t rxr_pkt_init_medium_tagrtm(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_dc_medium_tagrtm(struct rxr_ep *ep,
-				      struct rxr_op_entry *tx_entry,
+				      struct efa_rdm_ope *tx_entry,
 				      struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_dc_medium_tagrtm_hdr *dc_medium_tagrtm_hdr;
 	int ret;
 
-	tx_entry->rxr_flags |= RXR_TX_ENTRY_DELIVERY_COMPLETE_REQUESTED;
+	tx_entry->rxr_flags |= EFA_RDM_TXE_DELIVERY_COMPLETE_REQUESTED;
 
-	rxr_op_entry_try_fill_desc(tx_entry, 0, FI_SEND);
+	efa_rdm_ope_try_fill_desc(tx_entry, 0, FI_SEND);
 
 	ret = rxr_pkt_init_rtm(ep, tx_entry, RXR_DC_MEDIUM_TAGRTM_PKT,
 			       tx_entry->bytes_sent, pkt_entry);
@@ -663,7 +663,7 @@ ssize_t rxr_pkt_init_dc_medium_tagrtm(struct rxr_ep *ep,
 }
 
 int rxr_pkt_init_longcts_rtm(struct rxr_ep *ep,
-			     struct rxr_op_entry *tx_entry,
+			     struct efa_rdm_ope *tx_entry,
 			     int pkt_type,
 			     struct rxr_pkt_entry *pkt_entry)
 {
@@ -682,22 +682,22 @@ int rxr_pkt_init_longcts_rtm(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_longcts_msgrtm(struct rxr_ep *ep,
-				 struct rxr_op_entry *tx_entry,
+				 struct efa_rdm_ope *tx_entry,
 				 struct rxr_pkt_entry *pkt_entry)
 {
 	return rxr_pkt_init_longcts_rtm(ep, tx_entry, RXR_LONGCTS_MSGRTM_PKT, pkt_entry);
 }
 
 ssize_t rxr_pkt_init_dc_longcts_msgrtm(struct rxr_ep *ep,
-				    struct rxr_op_entry *tx_entry,
+				    struct efa_rdm_ope *tx_entry,
 				    struct rxr_pkt_entry *pkt_entry)
 {
-	tx_entry->rxr_flags |= RXR_TX_ENTRY_DELIVERY_COMPLETE_REQUESTED;
+	tx_entry->rxr_flags |= EFA_RDM_TXE_DELIVERY_COMPLETE_REQUESTED;
 	return rxr_pkt_init_longcts_rtm(ep, tx_entry, RXR_DC_LONGCTS_MSGRTM_PKT, pkt_entry);
 }
 
 ssize_t rxr_pkt_init_longcts_tagrtm(struct rxr_ep *ep,
-				 struct rxr_op_entry *tx_entry,
+				 struct efa_rdm_ope *tx_entry,
 				 struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_base_hdr *base_hdr;
@@ -714,13 +714,13 @@ ssize_t rxr_pkt_init_longcts_tagrtm(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_dc_longcts_tagrtm(struct rxr_ep *ep,
-				    struct rxr_op_entry *tx_entry,
+				    struct efa_rdm_ope *tx_entry,
 				    struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_base_hdr *base_hdr;
 	int ret;
 
-	tx_entry->rxr_flags |= RXR_TX_ENTRY_DELIVERY_COMPLETE_REQUESTED;
+	tx_entry->rxr_flags |= EFA_RDM_TXE_DELIVERY_COMPLETE_REQUESTED;
 	ret = rxr_pkt_init_longcts_rtm(ep, tx_entry, RXR_DC_LONGCTS_TAGRTM_PKT, pkt_entry);
 	if (ret)
 		return ret;
@@ -731,7 +731,7 @@ ssize_t rxr_pkt_init_dc_longcts_tagrtm(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_longread_rtm(struct rxr_ep *ep,
-			      struct rxr_op_entry *tx_entry,
+			      struct efa_rdm_ope *tx_entry,
 			      int pkt_type,
 			      struct rxr_pkt_entry *pkt_entry)
 {
@@ -751,7 +751,7 @@ ssize_t rxr_pkt_init_longread_rtm(struct rxr_ep *ep,
 
 	hdr_size = rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
 	read_iov = (struct fi_rma_iov *)(pkt_entry->wiredata + hdr_size);
-	err = rxr_tx_entry_prepare_to_be_read(tx_entry, read_iov);
+	err = efa_rdm_txe_prepare_to_be_read(tx_entry, read_iov);
 	if (OFI_UNLIKELY(err))
 		return err;
 
@@ -761,14 +761,14 @@ ssize_t rxr_pkt_init_longread_rtm(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_longread_msgrtm(struct rxr_ep *ep,
-				 struct rxr_op_entry *tx_entry,
+				 struct efa_rdm_ope *tx_entry,
 				 struct rxr_pkt_entry *pkt_entry)
 {
 	return rxr_pkt_init_longread_rtm(ep, tx_entry, RXR_LONGREAD_MSGRTM_PKT, pkt_entry);
 }
 
 ssize_t rxr_pkt_init_longread_tagrtm(struct rxr_ep *ep,
-				 struct rxr_op_entry *tx_entry,
+				 struct efa_rdm_ope *tx_entry,
 				 struct rxr_pkt_entry *pkt_entry)
 {
 	ssize_t err;
@@ -796,7 +796,7 @@ ssize_t rxr_pkt_init_longread_tagrtm(struct rxr_ep *ep,
  */
 static
 ssize_t rxr_pkt_init_runtread_rtm(struct rxr_ep *ep,
-				  struct rxr_op_entry *tx_entry,
+				  struct efa_rdm_ope *tx_entry,
 				  int pkt_type,
 				  struct rxr_pkt_entry *pkt_entry)
 {
@@ -821,7 +821,7 @@ ssize_t rxr_pkt_init_runtread_rtm(struct rxr_ep *ep,
 
 	hdr_size = rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
 	read_iov = (struct fi_rma_iov *)(pkt_entry->wiredata + hdr_size);
-	err = rxr_tx_entry_prepare_to_be_read(tx_entry, read_iov);
+	err = efa_rdm_txe_prepare_to_be_read(tx_entry, read_iov);
 	if (OFI_UNLIKELY(err))
 		return err;
 
@@ -837,14 +837,14 @@ ssize_t rxr_pkt_init_runtread_rtm(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_runtread_msgrtm(struct rxr_ep *ep,
-				 struct rxr_op_entry *tx_entry,
+				 struct efa_rdm_ope *tx_entry,
 				 struct rxr_pkt_entry *pkt_entry)
 {
 	return rxr_pkt_init_runtread_rtm(ep, tx_entry, RXR_RUNTREAD_MSGRTM_PKT, pkt_entry);
 }
 
 ssize_t rxr_pkt_init_runtread_tagrtm(struct rxr_ep *ep,
-				 struct rxr_op_entry *tx_entry,
+				 struct efa_rdm_ope *tx_entry,
 				 struct rxr_pkt_entry *pkt_entry)
 {
 	ssize_t err;
@@ -871,23 +871,23 @@ ssize_t rxr_pkt_init_runtread_tagrtm(struct rxr_ep *ep,
 void rxr_pkt_handle_medium_rtm_sent(struct rxr_ep *ep,
 				    struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_op_entry *tx_entry;
+	struct efa_rdm_ope *tx_entry;
 
-	tx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
+	tx_entry = (struct efa_rdm_ope *)pkt_entry->x_entry;
 	tx_entry->bytes_sent += rxr_pkt_req_data_size(pkt_entry);
 }
 
 void rxr_pkt_handle_longcts_rtm_sent(struct rxr_ep *ep,
 				  struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_op_entry *tx_entry;
+	struct efa_rdm_ope *tx_entry;
 
-	tx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
+	tx_entry = (struct efa_rdm_ope *)pkt_entry->x_entry;
 	tx_entry->bytes_sent += rxr_pkt_req_data_size(pkt_entry);
 	assert(tx_entry->bytes_sent < tx_entry->total_len);
 
 	if (efa_is_cache_available(rxr_ep_domain(ep)))
-		rxr_op_entry_try_fill_desc(tx_entry, 0, FI_SEND);
+		efa_rdm_ope_try_fill_desc(tx_entry, 0, FI_SEND);
 }
 
 
@@ -905,13 +905,13 @@ void rxr_pkt_handle_runtread_rtm_sent(struct rxr_ep *ep,
 				      struct rxr_pkt_entry *pkt_entry)
 {
 	struct efa_rdm_peer *peer;
-	struct rxr_op_entry *tx_entry;
+	struct efa_rdm_ope *tx_entry;
 	size_t pkt_data_size = rxr_pkt_req_data_size(pkt_entry);
 
 	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
 	assert(peer);
 
-	tx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
+	tx_entry = (struct efa_rdm_ope *)pkt_entry->x_entry;
 	tx_entry->bytes_sent += pkt_data_size;
 	peer->num_runt_bytes_in_flight += pkt_data_size;
 
@@ -926,43 +926,43 @@ void rxr_pkt_handle_runtread_rtm_sent(struct rxr_ep *ep,
 void rxr_pkt_handle_eager_rtm_send_completion(struct rxr_ep *ep,
 					      struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_op_entry *tx_entry;
+	struct efa_rdm_ope *tx_entry;
 
-	tx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
+	tx_entry = (struct efa_rdm_ope *)pkt_entry->x_entry;
 	assert(tx_entry->total_len == rxr_pkt_req_data_size(pkt_entry));
-	rxr_op_entry_handle_send_completed(tx_entry);
+	efa_rdm_ope_handle_send_completed(tx_entry);
 }
 
 void rxr_pkt_handle_medium_rtm_send_completion(struct rxr_ep *ep,
 					       struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_op_entry *tx_entry;
+	struct efa_rdm_ope *tx_entry;
 
-	tx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
+	tx_entry = (struct efa_rdm_ope *)pkt_entry->x_entry;
 	tx_entry->bytes_acked += rxr_pkt_req_data_size(pkt_entry);
 	if (tx_entry->total_len == tx_entry->bytes_acked)
-		rxr_op_entry_handle_send_completed(tx_entry);
+		efa_rdm_ope_handle_send_completed(tx_entry);
 }
 
 void rxr_pkt_handle_longcts_rtm_send_completion(struct rxr_ep *ep,
 					     struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_op_entry *tx_entry;
+	struct efa_rdm_ope *tx_entry;
 
-	tx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
+	tx_entry = (struct efa_rdm_ope *)pkt_entry->x_entry;
 	tx_entry->bytes_acked += rxr_pkt_req_data_size(pkt_entry);
 	if (tx_entry->total_len == tx_entry->bytes_acked)
-		rxr_op_entry_handle_send_completed(tx_entry);
+		efa_rdm_ope_handle_send_completed(tx_entry);
 }
 
 void rxr_pkt_handle_runtread_rtm_send_completion(struct rxr_ep *ep,
 						 struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_op_entry *tx_entry;
+	struct efa_rdm_ope *tx_entry;
 	struct efa_rdm_peer *peer;
 	size_t pkt_data_size;
 
-	tx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
+	tx_entry = (struct efa_rdm_ope *)pkt_entry->x_entry;
 	pkt_data_size = rxr_pkt_req_data_size(pkt_entry);
 	tx_entry->bytes_acked += pkt_data_size;
 
@@ -971,7 +971,7 @@ void rxr_pkt_handle_runtread_rtm_send_completion(struct rxr_ep *ep,
 	assert(peer->num_runt_bytes_in_flight >= pkt_data_size);
 	peer->num_runt_bytes_in_flight -= pkt_data_size;
 	if (tx_entry->total_len == tx_entry->bytes_acked)
-		rxr_op_entry_handle_send_completed(tx_entry);
+		efa_rdm_ope_handle_send_completed(tx_entry);
 }
 
 /*
@@ -1030,7 +1030,7 @@ size_t rxr_pkt_rtm_total_len(struct rxr_pkt_entry *pkt_entry)
  * @param rx_entry(input)   rx entry to be updated
  */
 void rxr_pkt_rtm_update_rx_entry(struct rxr_pkt_entry *pkt_entry,
-				 struct rxr_op_entry *rx_entry)
+				 struct efa_rdm_ope *rx_entry)
 {
 	struct rxr_base_hdr *base_hdr;
 	enum rxr_pkt_entry_alloc_type type;
@@ -1050,18 +1050,18 @@ void rxr_pkt_rtm_update_rx_entry(struct rxr_pkt_entry *pkt_entry,
 	rx_entry->cq_entry.tag = rx_entry->tag;
 
 	if (type == RXR_PKT_FROM_PEER_SRX)
-		rx_entry->rxr_flags |= RXR_RX_ENTRY_FOR_PEER_SRX;
+		rx_entry->rxr_flags |= EFA_RDM_RXE_FOR_PEER_SRX;
 }
 
-struct rxr_op_entry *rxr_pkt_get_rtm_matched_rx_entry(struct rxr_ep *ep,
+struct efa_rdm_ope *rxr_pkt_get_rtm_matched_rx_entry(struct rxr_ep *ep,
 						      struct dlist_entry *match,
 						      struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_op_entry *rx_entry;
+	struct efa_rdm_ope *rx_entry;
 
 	assert(match);
-	rx_entry = container_of(match, struct rxr_op_entry, entry);
-	if (rx_entry->rxr_flags & RXR_RX_ENTRY_MULTI_RECV_POSTED) {
+	rx_entry = container_of(match, struct efa_rdm_ope, entry);
+	if (rx_entry->rxr_flags & EFA_RDM_RXE_MULTI_RECV_POSTED) {
 		rx_entry = rxr_msg_split_rx_entry(ep, rx_entry, NULL, pkt_entry);
 		if (OFI_UNLIKELY(!rx_entry)) {
 			EFA_WARN(FI_LOG_CQ,
@@ -1073,7 +1073,7 @@ struct rxr_op_entry *rxr_pkt_get_rtm_matched_rx_entry(struct rxr_ep *ep,
 		rxr_pkt_rtm_update_rx_entry(pkt_entry, rx_entry);
 	}
 
-	rx_entry->state = RXR_RX_MATCHED;
+	rx_entry->state = EFA_RDM_RXE_MATCHED;
 
 	if (!(rx_entry->fi_flags & FI_MULTI_RECV) ||
 	    !rxr_msg_multi_recv_buffer_available(ep, rx_entry->master_entry))
@@ -1092,9 +1092,9 @@ static
 int rxr_pkt_rtm_match_recv(struct dlist_entry *item, const void *arg)
 {
 	const struct rxr_pkt_entry *pkt_entry = arg;
-	struct rxr_op_entry *rx_entry;
+	struct efa_rdm_ope *rx_entry;
 
-	rx_entry = container_of(item, struct rxr_op_entry, entry);
+	rx_entry = container_of(item, struct efa_rdm_ope, entry);
 	return ofi_match_addr(rx_entry->addr, pkt_entry->addr);
 }
 
@@ -1102,10 +1102,10 @@ static
 int rxr_pkt_rtm_match_trecv_anyaddr(struct dlist_entry *item, const void *arg)
 {
 	struct rxr_pkt_entry *pkt_entry = (struct rxr_pkt_entry *)arg;
-	struct rxr_op_entry *rx_entry;
+	struct efa_rdm_ope *rx_entry;
 	uint64_t match_tag;
 
-	rx_entry = container_of(item, struct rxr_op_entry, entry);
+	rx_entry = container_of(item, struct efa_rdm_ope, entry);
 	match_tag = rxr_pkt_rtm_tag(pkt_entry);
 
 	return ofi_match_tag(rx_entry->cq_entry.tag, rx_entry->ignore,
@@ -1116,20 +1116,20 @@ static
 int rxr_pkt_rtm_match_trecv(struct dlist_entry *item, const void *arg)
 {
 	struct rxr_pkt_entry *pkt_entry = (struct rxr_pkt_entry *)arg;
-	struct rxr_op_entry *rx_entry;
+	struct efa_rdm_ope *rx_entry;
 	uint64_t match_tag;
 
-	rx_entry = container_of(item, struct rxr_op_entry, entry);
+	rx_entry = container_of(item, struct efa_rdm_ope, entry);
 	match_tag = rxr_pkt_rtm_tag(pkt_entry);
 
 	return ofi_match_addr(rx_entry->addr, pkt_entry->addr) &&
 	       ofi_match_tag(rx_entry->cq_entry.tag, rx_entry->ignore, match_tag);
 }
 
-struct rxr_op_entry *rxr_pkt_get_msgrtm_rx_entry(struct rxr_ep *ep,
+struct efa_rdm_ope *rxr_pkt_get_msgrtm_rx_entry(struct rxr_ep *ep,
 						 struct rxr_pkt_entry **pkt_entry_ptr)
 {
-	struct rxr_op_entry *rx_entry;
+	struct efa_rdm_ope *rx_entry;
 	struct dlist_entry *match;
 	dlist_func_t *match_func;
 	int pkt_type;
@@ -1182,10 +1182,10 @@ struct rxr_op_entry *rxr_pkt_get_msgrtm_rx_entry(struct rxr_ep *ep,
 	return rx_entry;
 }
 
-struct rxr_op_entry *rxr_pkt_get_tagrtm_rx_entry(struct rxr_ep *ep,
+struct efa_rdm_ope *rxr_pkt_get_tagrtm_rx_entry(struct rxr_ep *ep,
 						 struct rxr_pkt_entry **pkt_entry_ptr)
 {
-	struct rxr_op_entry *rx_entry;
+	struct efa_rdm_ope *rx_entry;
 	struct dlist_entry *match;
 	dlist_func_t *match_func;
 	int pkt_type;
@@ -1224,7 +1224,7 @@ struct rxr_op_entry *rxr_pkt_get_tagrtm_rx_entry(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_proc_matched_longread_rtm(struct rxr_ep *ep,
-				      struct rxr_op_entry *rx_entry,
+				      struct efa_rdm_ope *rx_entry,
 				      struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_longread_rtm_base_hdr *rtm_hdr;
@@ -1243,11 +1243,11 @@ ssize_t rxr_pkt_proc_matched_longread_rtm(struct rxr_ep *ep,
 	rxr_tracepoint(longread_read_posted, rx_entry->msg_id,
 		    (size_t) rx_entry->cq_entry.op_context, rx_entry->total_len);
 
-	return rxr_op_entry_post_remote_read_or_queue(rx_entry);
+	return efa_rdm_ope_post_remote_read_or_queue(rx_entry);
 }
 
 ssize_t rxr_pkt_proc_matched_mulreq_rtm(struct rxr_ep *ep,
-					struct rxr_op_entry *rx_entry,
+					struct efa_rdm_ope *rx_entry,
 					struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_pkt_entry *cur, *nxt;
@@ -1273,7 +1273,7 @@ ssize_t rxr_pkt_proc_matched_mulreq_rtm(struct rxr_ep *ep,
 			rxr_tracepoint(runtread_read_posted, rx_entry->msg_id,
 				    (size_t) rx_entry->cq_entry.op_context, rx_entry->total_len);
 
-			err = rxr_op_entry_post_remote_read_or_queue(rx_entry);
+			err = efa_rdm_ope_post_remote_read_or_queue(rx_entry);
 			if (err)
 				return err;
 		}
@@ -1293,7 +1293,7 @@ ssize_t rxr_pkt_proc_matched_mulreq_rtm(struct rxr_ep *ep,
 		 */
 		rx_entry->bytes_received += data_size;
 		rx_entry->bytes_received_via_mulreq += data_size;
-		if (rxr_op_entry_mulreq_total_data_size(rx_entry, pkt_type) == rx_entry->bytes_received_via_mulreq)
+		if (efa_rdm_ope_mulreq_total_data_size(rx_entry, pkt_type) == rx_entry->bytes_received_via_mulreq)
 			rxr_pkt_rx_map_remove(ep, cur, rx_entry);
 
 		/* rxr_pkt_copy_data_to_op_entry() will release cur, so
@@ -1327,7 +1327,7 @@ ssize_t rxr_pkt_proc_matched_mulreq_rtm(struct rxr_ep *ep,
  * 		On failure, return libfabric error code
  */
 ssize_t rxr_pkt_proc_matched_eager_rtm(struct rxr_ep *ep,
-				       struct rxr_op_entry *rx_entry,
+				       struct efa_rdm_ope *rx_entry,
 				       struct rxr_pkt_entry *pkt_entry)
 {
 	int err;
@@ -1371,8 +1371,8 @@ ssize_t rxr_pkt_proc_matched_eager_rtm(struct rxr_ep *ep,
 		rx_entry->cq_entry.len = pkt_entry->pkt_size + sizeof(struct rxr_pkt_entry);
 	}
 
-	rxr_rx_entry_report_completion(rx_entry);
-	rxr_rx_entry_release(rx_entry);
+	efa_rdm_rxe_report_completion(rx_entry);
+	efa_rdm_rxe_release(rx_entry);
 
 	/* no need to release packet entry because it is
 	 * constructed using user supplied buffer */
@@ -1380,7 +1380,7 @@ ssize_t rxr_pkt_proc_matched_eager_rtm(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_proc_matched_rtm(struct rxr_ep *ep,
-				 struct rxr_op_entry *rx_entry,
+				 struct efa_rdm_ope *rx_entry,
 				 struct rxr_pkt_entry *pkt_entry)
 {
 	int pkt_type;
@@ -1388,7 +1388,7 @@ ssize_t rxr_pkt_proc_matched_rtm(struct rxr_ep *ep,
 	size_t hdr_size, data_size;
 	ssize_t ret;
 
-	assert(rx_entry->state == RXR_RX_MATCHED);
+	assert(rx_entry->state == EFA_RDM_RXE_MATCHED);
 
 	if (!rx_entry->peer) {
 		rx_entry->addr = pkt_entry->addr;
@@ -1411,7 +1411,7 @@ ssize_t rxr_pkt_proc_matched_rtm(struct rxr_ep *ep,
 
 	if (pkt_type > RXR_DC_REQ_PKT_BEGIN &&
 	    pkt_type < RXR_DC_REQ_PKT_END)
-		rx_entry->rxr_flags |= RXR_TX_ENTRY_DELIVERY_COMPLETE_REQUESTED;
+		rx_entry->rxr_flags |= EFA_RDM_TXE_DELIVERY_COMPLETE_REQUESTED;
 
 	if (pkt_type == RXR_LONGCTS_MSGRTM_PKT ||
 	    pkt_type == RXR_LONGCTS_TAGRTM_PKT)
@@ -1454,7 +1454,7 @@ ssize_t rxr_pkt_proc_matched_rtm(struct rxr_ep *ep,
 	dlist_insert_tail(&rx_entry->pending_recv_entry, &ep->op_entry_recv_list);
 	ep->pending_recv_counter++;
 #endif
-	rx_entry->state = RXR_RX_RECV;
+	rx_entry->state = EFA_RDM_RXE_RECV;
 	ret = rxr_pkt_post_or_queue(ep, rx_entry, RXR_CTS_PKT);
 
 	return ret;
@@ -1464,7 +1464,7 @@ ssize_t rxr_pkt_proc_msgrtm(struct rxr_ep *ep,
 			    struct rxr_pkt_entry *pkt_entry)
 {
 	ssize_t err;
-	struct rxr_op_entry *rx_entry;
+	struct efa_rdm_ope *rx_entry;
 
 	rx_entry = rxr_pkt_get_msgrtm_rx_entry(ep, &pkt_entry);
 	if (OFI_UNLIKELY(!rx_entry)) {
@@ -1473,15 +1473,15 @@ ssize_t rxr_pkt_proc_msgrtm(struct rxr_ep *ep,
 		return -FI_ENOBUFS;
 	}
 
-	if (rx_entry->state == RXR_RX_MATCHED) {
+	if (rx_entry->state == EFA_RDM_RXE_MATCHED) {
 		err = rxr_pkt_proc_matched_rtm(ep, rx_entry, pkt_entry);
 		if (OFI_UNLIKELY(err)) {
-			rxr_rx_entry_handle_error(rx_entry, -err, FI_EFA_ERR_PKT_PROC_MSGRTM);
+			efa_rdm_rxe_handle_error(rx_entry, -err, FI_EFA_ERR_PKT_PROC_MSGRTM);
 			rxr_pkt_entry_release_rx(ep, pkt_entry);
-			rxr_rx_entry_release(rx_entry);
+			efa_rdm_rxe_release(rx_entry);
 			return err;
 		}
-	} else if (rx_entry->state == RXR_RX_UNEXP) {
+	} else if (rx_entry->state == EFA_RDM_RXE_UNEXP) {
 		rxr_msg_queue_unexp_rx_entry_for_msgrtm(ep, rx_entry);
 	}
 
@@ -1492,7 +1492,7 @@ ssize_t rxr_pkt_proc_tagrtm(struct rxr_ep *ep,
 			    struct rxr_pkt_entry *pkt_entry)
 {
 	ssize_t err;
-	struct rxr_op_entry *rx_entry;
+	struct efa_rdm_ope *rx_entry;
 
 	rx_entry = rxr_pkt_get_tagrtm_rx_entry(ep, &pkt_entry);
 	if (OFI_UNLIKELY(!rx_entry)) {
@@ -1501,15 +1501,15 @@ ssize_t rxr_pkt_proc_tagrtm(struct rxr_ep *ep,
 		return -FI_ENOBUFS;
 	}
 
-	if (rx_entry->state == RXR_RX_MATCHED) {
+	if (rx_entry->state == EFA_RDM_RXE_MATCHED) {
 		err = rxr_pkt_proc_matched_rtm(ep, rx_entry, pkt_entry);
 		if (OFI_UNLIKELY(err)) {
-			rxr_rx_entry_handle_error(rx_entry, -err, FI_EFA_ERR_PKT_PROC_TAGRTM);
+			efa_rdm_rxe_handle_error(rx_entry, -err, FI_EFA_ERR_PKT_PROC_TAGRTM);
 			rxr_pkt_entry_release_rx(ep, pkt_entry);
-			rxr_rx_entry_release(rx_entry);
+			efa_rdm_rxe_release(rx_entry);
 			return err;
 		}
-	} else if (rx_entry->state == RXR_RX_UNEXP) {
+	} else if (rx_entry->state == EFA_RDM_RXE_UNEXP) {
 		rxr_msg_queue_unexp_rx_entry_for_tagrtm(ep, rx_entry);
 	}
 
@@ -1576,12 +1576,12 @@ void rxr_pkt_handle_rtm_rta_recv(struct rxr_ep *ep,
 	assert(base_hdr->type >= RXR_BASELINE_REQ_PKT_BEGIN);
 
 	if (rxr_pkt_type_is_mulreq(base_hdr->type)) {
-		struct rxr_op_entry *rx_entry;
+		struct efa_rdm_ope *rx_entry;
 		struct rxr_pkt_entry *unexp_pkt_entry;
 
 		rx_entry = rxr_pkt_rx_map_lookup(ep, pkt_entry);
 		if (rx_entry) {
-			if (rx_entry->state == RXR_RX_MATCHED) {
+			if (rx_entry->state == EFA_RDM_RXE_MATCHED) {
 				rxr_pkt_proc_matched_mulreq_rtm(ep, rx_entry, pkt_entry);
 			} else {
 				assert(rx_entry->unexp_pkt);
@@ -1644,7 +1644,7 @@ void rxr_pkt_handle_rtm_rta_recv(struct rxr_ep *ep,
  * RTW packet type functions
  */
 int rxr_pkt_init_rtw_data(struct rxr_ep *ep,
-			  struct rxr_op_entry *tx_entry,
+			  struct efa_rdm_ope *tx_entry,
 			  struct rxr_pkt_entry *pkt_entry,
 			  struct efa_rma_iov *rma_iov)
 {
@@ -1664,7 +1664,7 @@ int rxr_pkt_init_rtw_data(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_eager_rtw(struct rxr_ep *ep,
-			       struct rxr_op_entry *tx_entry,
+			       struct efa_rdm_ope *tx_entry,
 			       struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_eager_rtw_hdr *rtw_hdr;
@@ -1678,7 +1678,7 @@ ssize_t rxr_pkt_init_eager_rtw(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_dc_eager_rtw(struct rxr_ep *ep,
-				  struct rxr_op_entry *tx_entry,
+				  struct efa_rdm_ope *tx_entry,
 				  struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_dc_eager_rtw_hdr *dc_eager_rtw_hdr;
@@ -1686,7 +1686,7 @@ ssize_t rxr_pkt_init_dc_eager_rtw(struct rxr_ep *ep,
 
 	assert(tx_entry->op == ofi_op_write);
 
-	tx_entry->rxr_flags |= RXR_TX_ENTRY_DELIVERY_COMPLETE_REQUESTED;
+	tx_entry->rxr_flags |= EFA_RDM_TXE_DELIVERY_COMPLETE_REQUESTED;
 	dc_eager_rtw_hdr = (struct rxr_dc_eager_rtw_hdr *)pkt_entry->wiredata;
 	dc_eager_rtw_hdr->rma_iov_count = tx_entry->rma_iov_count;
 	rxr_pkt_init_req_hdr(ep, tx_entry, RXR_DC_EAGER_RTW_PKT, pkt_entry);
@@ -1697,7 +1697,7 @@ ssize_t rxr_pkt_init_dc_eager_rtw(struct rxr_ep *ep,
 }
 
 static inline void rxr_pkt_init_longcts_rtw_hdr(struct rxr_ep *ep,
-					     struct rxr_op_entry *tx_entry,
+					     struct efa_rdm_ope *tx_entry,
 					     struct rxr_pkt_entry *pkt_entry,
 					     int pkt_type)
 {
@@ -1712,7 +1712,7 @@ static inline void rxr_pkt_init_longcts_rtw_hdr(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_longcts_rtw(struct rxr_ep *ep,
-			      struct rxr_op_entry *tx_entry,
+			      struct efa_rdm_ope *tx_entry,
 			      struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_longcts_rtw_hdr *rtw_hdr;
@@ -1725,21 +1725,21 @@ ssize_t rxr_pkt_init_longcts_rtw(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_dc_longcts_rtw(struct rxr_ep *ep,
-				 struct rxr_op_entry *tx_entry,
+				 struct efa_rdm_ope *tx_entry,
 				 struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_longcts_rtw_hdr *rtw_hdr;
 
 	assert(tx_entry->op == ofi_op_write);
 
-	tx_entry->rxr_flags |= RXR_TX_ENTRY_DELIVERY_COMPLETE_REQUESTED;
+	tx_entry->rxr_flags |= EFA_RDM_TXE_DELIVERY_COMPLETE_REQUESTED;
 	rtw_hdr = (struct rxr_longcts_rtw_hdr *)pkt_entry->wiredata;
 	rxr_pkt_init_longcts_rtw_hdr(ep, tx_entry, pkt_entry, RXR_DC_LONGCTS_RTW_PKT);
 	return rxr_pkt_init_rtw_data(ep, tx_entry, pkt_entry, rtw_hdr->rma_iov);
 }
 
 ssize_t rxr_pkt_init_longread_rtw(struct rxr_ep *ep,
-			      struct rxr_op_entry *tx_entry,
+			      struct efa_rdm_ope *tx_entry,
 			      struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_longread_rtw_hdr *rtw_hdr;
@@ -1766,7 +1766,7 @@ ssize_t rxr_pkt_init_longread_rtw(struct rxr_ep *ep,
 
 	hdr_size = rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
 	read_iov = (struct fi_rma_iov *)(pkt_entry->wiredata + hdr_size);
-	err = rxr_tx_entry_prepare_to_be_read(tx_entry, read_iov);
+	err = efa_rdm_txe_prepare_to_be_read(tx_entry, read_iov);
 	if (OFI_UNLIKELY(err))
 		return err;
 
@@ -1783,14 +1783,14 @@ ssize_t rxr_pkt_init_longread_rtw(struct rxr_ep *ep,
 void rxr_pkt_handle_longcts_rtw_sent(struct rxr_ep *ep,
 				  struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_op_entry *tx_entry;
+	struct efa_rdm_ope *tx_entry;
 	struct efa_domain *efa_domain = rxr_ep_domain(ep);
 
-	tx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
+	tx_entry = (struct efa_rdm_ope *)pkt_entry->x_entry;
 	tx_entry->bytes_sent += rxr_pkt_req_data_size(pkt_entry);
 	assert(tx_entry->bytes_sent < tx_entry->total_len);
 	if (efa_is_cache_available(efa_domain))
-		rxr_op_entry_try_fill_desc(tx_entry, 0, FI_SEND);
+		efa_rdm_ope_try_fill_desc(tx_entry, 0, FI_SEND);
 }
 
 /*
@@ -1799,22 +1799,22 @@ void rxr_pkt_handle_longcts_rtw_sent(struct rxr_ep *ep,
 void rxr_pkt_handle_eager_rtw_send_completion(struct rxr_ep *ep,
 					      struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_op_entry *tx_entry;
+	struct efa_rdm_ope *tx_entry;
 
-	tx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
+	tx_entry = (struct efa_rdm_ope *)pkt_entry->x_entry;
 	assert(tx_entry->total_len == rxr_pkt_req_data_size(pkt_entry));
-	rxr_op_entry_handle_send_completed(tx_entry);
+	efa_rdm_ope_handle_send_completed(tx_entry);
 }
 
 void rxr_pkt_handle_longcts_rtw_send_completion(struct rxr_ep *ep,
 					     struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_op_entry *tx_entry;
+	struct efa_rdm_ope *tx_entry;
 
-	tx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
+	tx_entry = (struct efa_rdm_ope *)pkt_entry->x_entry;
 	tx_entry->bytes_acked += rxr_pkt_req_data_size(pkt_entry);
 	if (tx_entry->total_len == tx_entry->bytes_acked)
-		rxr_op_entry_handle_send_completed(tx_entry);
+		efa_rdm_ope_handle_send_completed(tx_entry);
 }
 
 /*
@@ -1822,10 +1822,10 @@ void rxr_pkt_handle_longcts_rtw_send_completion(struct rxr_ep *ep,
  */
 
 static
-struct rxr_op_entry *rxr_pkt_alloc_rtw_rx_entry(struct rxr_ep *ep,
+struct efa_rdm_ope *rxr_pkt_alloc_rtw_rx_entry(struct rxr_ep *ep,
 						struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_op_entry *rx_entry;
+	struct efa_rdm_ope *rx_entry;
 	struct rxr_base_hdr *base_hdr;
 
 	rx_entry = rxr_ep_alloc_rx_entry(ep, pkt_entry->addr, ofi_op_write);
@@ -1847,7 +1847,7 @@ struct rxr_op_entry *rxr_pkt_alloc_rtw_rx_entry(struct rxr_ep *ep,
 void rxr_pkt_proc_eager_rtw(struct rxr_ep *ep,
 			    struct efa_rma_iov *rma_iov,
 			    size_t rma_iov_count,
-			    struct rxr_op_entry *rx_entry,
+			    struct efa_rdm_ope *rx_entry,
 			    struct rxr_pkt_entry *pkt_entry)
 {
 	ssize_t err;
@@ -1860,7 +1860,7 @@ void rxr_pkt_proc_eager_rtw(struct rxr_ep *ep,
 	if (OFI_UNLIKELY(err)) {
 		EFA_WARN(FI_LOG_CQ, "RMA address verify failed!\n");
 		efa_eq_write_error(&ep->base_ep.util_ep, FI_EIO, FI_EFA_ERR_RMA_ADDR);
-		rxr_rx_entry_release(rx_entry);
+		efa_rdm_rxe_release(rx_entry);
 		rxr_pkt_entry_release_rx(ep, pkt_entry);
 		return;
 	}
@@ -1881,13 +1881,13 @@ void rxr_pkt_proc_eager_rtw(struct rxr_ep *ep,
 			rx_entry->iov[0].iov_len);
 		efa_eq_write_error(&ep->base_ep.util_ep, FI_EINVAL, FI_EFA_ERR_RTM_MISMATCH);
 		rxr_pkt_entry_release_rx(ep, pkt_entry);
-		rxr_rx_entry_release(rx_entry);
+		efa_rdm_rxe_release(rx_entry);
 	} else {
 		err = rxr_pkt_copy_data_to_op_entry(ep, rx_entry, 0, pkt_entry, data, data_size);
 		if (OFI_UNLIKELY(err)) {
 			efa_eq_write_error(&ep->base_ep.util_ep, FI_EINVAL, FI_EFA_ERR_RX_ENTRY_COPY);
 			rxr_pkt_entry_release_rx(ep, pkt_entry);
-			rxr_rx_entry_release(rx_entry);
+			efa_rdm_rxe_release(rx_entry);
 		}
 	}
 }
@@ -1895,7 +1895,7 @@ void rxr_pkt_proc_eager_rtw(struct rxr_ep *ep,
 void rxr_pkt_handle_eager_rtw_recv(struct rxr_ep *ep,
 				   struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_op_entry *rx_entry;
+	struct efa_rdm_ope *rx_entry;
 	struct rxr_eager_rtw_hdr *rtw_hdr;
 
 	rx_entry = rxr_pkt_alloc_rtw_rx_entry(ep, pkt_entry);
@@ -1919,7 +1919,7 @@ void rxr_pkt_handle_eager_rtw_recv(struct rxr_ep *ep,
 void rxr_pkt_handle_dc_eager_rtw_recv(struct rxr_ep *ep,
 				      struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_op_entry *rx_entry;
+	struct efa_rdm_ope *rx_entry;
 	struct rxr_dc_eager_rtw_hdr *rtw_hdr;
 
 	rx_entry = rxr_pkt_alloc_rtw_rx_entry(ep, pkt_entry);
@@ -1931,7 +1931,7 @@ void rxr_pkt_handle_dc_eager_rtw_recv(struct rxr_ep *ep,
 		return;
 	}
 
-	rx_entry->rxr_flags |= RXR_TX_ENTRY_DELIVERY_COMPLETE_REQUESTED;
+	rx_entry->rxr_flags |= EFA_RDM_TXE_DELIVERY_COMPLETE_REQUESTED;
 	rtw_hdr = (struct rxr_dc_eager_rtw_hdr *)pkt_entry->wiredata;
 	rx_entry->tx_id = rtw_hdr->send_id;
 	rx_entry->iov_count = rtw_hdr->rma_iov_count;
@@ -1944,7 +1944,7 @@ void rxr_pkt_handle_dc_eager_rtw_recv(struct rxr_ep *ep,
 void rxr_pkt_handle_longcts_rtw_recv(struct rxr_ep *ep,
 				  struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_op_entry *rx_entry;
+	struct efa_rdm_ope *rx_entry;
 	struct rxr_longcts_rtw_hdr *rtw_hdr;
 	char *data;
 	size_t hdr_size, data_size;
@@ -1963,7 +1963,7 @@ void rxr_pkt_handle_longcts_rtw_recv(struct rxr_ep *ep,
 	rtw_hdr = (struct rxr_longcts_rtw_hdr *)pkt_entry->wiredata;
 	tx_id = rtw_hdr->send_id;
 	if (rtw_hdr->type == RXR_DC_LONGCTS_RTW_PKT)
-		rx_entry->rxr_flags |= RXR_TX_ENTRY_DELIVERY_COMPLETE_REQUESTED;
+		rx_entry->rxr_flags |= EFA_RDM_TXE_DELIVERY_COMPLETE_REQUESTED;
 
 	rx_entry->iov_count = rtw_hdr->rma_iov_count;
 	err = rxr_rma_verified_copy_iov(ep, rtw_hdr->rma_iov, rtw_hdr->rma_iov_count,
@@ -1971,7 +1971,7 @@ void rxr_pkt_handle_longcts_rtw_recv(struct rxr_ep *ep,
 	if (OFI_UNLIKELY(err)) {
 		EFA_WARN(FI_LOG_CQ, "RMA address verify failed!\n");
 		efa_eq_write_error(&ep->base_ep.util_ep, FI_EIO, FI_EFA_ERR_RMA_ADDR);
-		rxr_rx_entry_release(rx_entry);
+		efa_rdm_rxe_release(rx_entry);
 		rxr_pkt_entry_release_rx(ep, pkt_entry);
 		return;
 	}
@@ -1991,14 +1991,14 @@ void rxr_pkt_handle_longcts_rtw_recv(struct rxr_ep *ep,
 		EFA_WARN(FI_LOG_CQ, "target buffer: %p length: %ld\n", rx_entry->iov[0].iov_base,
 			rx_entry->iov[0].iov_len);
 		efa_eq_write_error(&ep->base_ep.util_ep, FI_EINVAL, FI_EFA_ERR_RTM_MISMATCH);
-		rxr_rx_entry_release(rx_entry);
+		efa_rdm_rxe_release(rx_entry);
 		rxr_pkt_entry_release_rx(ep, pkt_entry);
 		return;
 	} else {
 		err = rxr_pkt_copy_data_to_op_entry(ep, rx_entry, 0, pkt_entry, data, data_size);
 		if (OFI_UNLIKELY(err)) {
 			efa_eq_write_error(&ep->base_ep.util_ep, FI_EINVAL, FI_EFA_ERR_RX_ENTRY_COPY);
-			rxr_rx_entry_release(rx_entry);
+			efa_rdm_rxe_release(rx_entry);
 			rxr_pkt_entry_release_rx(ep, pkt_entry);
 			return;
 		}
@@ -2009,20 +2009,20 @@ void rxr_pkt_handle_longcts_rtw_recv(struct rxr_ep *ep,
 	dlist_insert_tail(&rx_entry->pending_recv_entry, &ep->op_entry_recv_list);
 	ep->pending_recv_counter++;
 #endif
-	rx_entry->state = RXR_RX_RECV;
+	rx_entry->state = EFA_RDM_RXE_RECV;
 	rx_entry->tx_id = tx_id;
 	err = rxr_pkt_post_or_queue(ep, rx_entry, RXR_CTS_PKT);
 	if (OFI_UNLIKELY(err)) {
 		EFA_WARN(FI_LOG_CQ, "Cannot post CTS packet\n");
-		rxr_rx_entry_handle_error(rx_entry, -err, FI_EFA_ERR_PKT_POST);
-		rxr_rx_entry_release(rx_entry);
+		efa_rdm_rxe_handle_error(rx_entry, -err, FI_EFA_ERR_PKT_POST);
+		efa_rdm_rxe_release(rx_entry);
 	}
 }
 
 void rxr_pkt_handle_longread_rtw_recv(struct rxr_ep *ep,
 				  struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_op_entry *rx_entry;
+	struct efa_rdm_ope *rx_entry;
 	struct rxr_longread_rtw_hdr *rtw_hdr;
 	struct fi_rma_iov *read_iov;
 	size_t hdr_size;
@@ -2044,7 +2044,7 @@ void rxr_pkt_handle_longread_rtw_recv(struct rxr_ep *ep,
 	if (OFI_UNLIKELY(err)) {
 		EFA_WARN(FI_LOG_CQ, "RMA address verify failed!\n");
 		efa_eq_write_error(&ep->base_ep.util_ep, FI_EINVAL, FI_EFA_ERR_RMA_ADDR);
-		rxr_rx_entry_release(rx_entry);
+		efa_rdm_rxe_release(rx_entry);
 		rxr_pkt_entry_release_rx(ep, pkt_entry);
 		return;
 	}
@@ -2063,12 +2063,12 @@ void rxr_pkt_handle_longread_rtw_recv(struct rxr_ep *ep,
 
 	rxr_pkt_entry_release_rx(ep, pkt_entry);
 
-	err = rxr_op_entry_post_remote_read_or_queue(rx_entry);
+	err = efa_rdm_ope_post_remote_read_or_queue(rx_entry);
 	if (OFI_UNLIKELY(err)) {
 		EFA_WARN(FI_LOG_CQ,
 			"RDMA post read or queue failed.\n");
 		efa_eq_write_error(&ep->base_ep.util_ep, err, FI_EFA_ERR_RDMA_READ_POST);
-		rxr_rx_entry_release(rx_entry);
+		efa_rdm_rxe_release(rx_entry);
 		rxr_pkt_entry_release_rx(ep, pkt_entry);
 	}
 }
@@ -2078,7 +2078,7 @@ void rxr_pkt_handle_longread_rtw_recv(struct rxr_ep *ep,
  *     init() functions for RTR packets
  */
 void rxr_pkt_init_rtr(struct rxr_ep *ep,
-		      struct rxr_op_entry *tx_entry,
+		      struct efa_rdm_ope *tx_entry,
 		      int pkt_type, int window,
 		      struct rxr_pkt_entry *pkt_entry)
 {
@@ -2103,7 +2103,7 @@ void rxr_pkt_init_rtr(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_short_rtr(struct rxr_ep *ep,
-			       struct rxr_op_entry *tx_entry,
+			       struct efa_rdm_ope *tx_entry,
 			       struct rxr_pkt_entry *pkt_entry)
 {
 	rxr_pkt_init_rtr(ep, tx_entry, RXR_SHORT_RTR_PKT, tx_entry->total_len, pkt_entry);
@@ -2111,7 +2111,7 @@ ssize_t rxr_pkt_init_short_rtr(struct rxr_ep *ep,
 }
 
 ssize_t rxr_pkt_init_longcts_rtr(struct rxr_ep *ep,
-			      struct rxr_op_entry *tx_entry,
+			      struct efa_rdm_ope *tx_entry,
 			      struct rxr_pkt_entry *pkt_entry)
 {
 	rxr_pkt_init_rtr(ep, tx_entry, RXR_LONGCTS_RTR_PKT, tx_entry->window, pkt_entry);
@@ -2125,7 +2125,7 @@ ssize_t rxr_pkt_init_longcts_rtr(struct rxr_ep *ep,
 void rxr_pkt_handle_rtr_recv(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_rtr_hdr *rtr_hdr;
-	struct rxr_op_entry *rx_entry;
+	struct efa_rdm_ope *rx_entry;
 	ssize_t err;
 
 	rx_entry = rxr_ep_alloc_rx_entry(ep, pkt_entry->addr, ofi_op_read_rsp);
@@ -2150,7 +2150,7 @@ void rxr_pkt_handle_rtr_recv(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 	if (OFI_UNLIKELY(err)) {
 		EFA_WARN(FI_LOG_CQ, "RMA address verification failed!\n");
 		efa_eq_write_error(&ep->base_ep.util_ep, FI_EINVAL, FI_EFA_ERR_RMA_ADDR);
-		rxr_rx_entry_release(rx_entry);
+		efa_rdm_rxe_release(rx_entry);
 		rxr_pkt_entry_release_rx(ep, pkt_entry);
 		return;
 	}
@@ -2164,7 +2164,7 @@ void rxr_pkt_handle_rtr_recv(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 	if (OFI_UNLIKELY(err)) {
 		EFA_WARN(FI_LOG_CQ, "Posting of readrsp packet failed! err=%ld\n", err);
 		efa_eq_write_error(&ep->base_ep.util_ep, FI_EIO, FI_EFA_ERR_PKT_POST);
-		rxr_rx_entry_release(rx_entry);
+		efa_rdm_rxe_release(rx_entry);
 		rxr_pkt_entry_release_rx(ep, pkt_entry);
 		return;
 	}
@@ -2175,7 +2175,7 @@ void rxr_pkt_handle_rtr_recv(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 /*
  * RTA packet functions
  */
-ssize_t rxr_pkt_init_rta(struct rxr_ep *ep, struct rxr_op_entry *tx_entry,
+ssize_t rxr_pkt_init_rta(struct rxr_ep *ep, struct efa_rdm_ope *tx_entry,
 			 int pkt_type, struct rxr_pkt_entry *pkt_entry)
 {
 	struct efa_rma_iov *rma_iov;
@@ -2215,7 +2215,7 @@ ssize_t rxr_pkt_init_rta(struct rxr_ep *ep, struct rxr_op_entry *tx_entry,
 	return 0;
 }
 
-ssize_t rxr_pkt_init_write_rta(struct rxr_ep *ep, struct rxr_op_entry *tx_entry,
+ssize_t rxr_pkt_init_write_rta(struct rxr_ep *ep, struct efa_rdm_ope *tx_entry,
 			    struct rxr_pkt_entry *pkt_entry)
 {
 	rxr_pkt_init_rta(ep, tx_entry, RXR_WRITE_RTA_PKT, pkt_entry);
@@ -2223,19 +2223,19 @@ ssize_t rxr_pkt_init_write_rta(struct rxr_ep *ep, struct rxr_op_entry *tx_entry,
 }
 
 ssize_t rxr_pkt_init_dc_write_rta(struct rxr_ep *ep,
-				  struct rxr_op_entry *tx_entry,
+				  struct efa_rdm_ope *tx_entry,
 				  struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_rta_hdr *rta_hdr;
 
-	tx_entry->rxr_flags |= RXR_TX_ENTRY_DELIVERY_COMPLETE_REQUESTED;
+	tx_entry->rxr_flags |= EFA_RDM_TXE_DELIVERY_COMPLETE_REQUESTED;
 	rxr_pkt_init_rta(ep, tx_entry, RXR_DC_WRITE_RTA_PKT, pkt_entry);
 	rta_hdr = rxr_get_rta_hdr(pkt_entry->wiredata);
 	rta_hdr->send_id = tx_entry->tx_id;
 	return 0;
 }
 
-ssize_t rxr_pkt_init_fetch_rta(struct rxr_ep *ep, struct rxr_op_entry *tx_entry,
+ssize_t rxr_pkt_init_fetch_rta(struct rxr_ep *ep, struct efa_rdm_ope *tx_entry,
 			      struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_rta_hdr *rta_hdr;
@@ -2246,7 +2246,7 @@ ssize_t rxr_pkt_init_fetch_rta(struct rxr_ep *ep, struct rxr_op_entry *tx_entry,
 	return 0;
 }
 
-ssize_t rxr_pkt_init_compare_rta(struct rxr_ep *ep, struct rxr_op_entry *tx_entry,
+ssize_t rxr_pkt_init_compare_rta(struct rxr_ep *ep, struct efa_rdm_ope *tx_entry,
 				 struct rxr_pkt_entry *pkt_entry)
 {
 	char *data;
@@ -2279,10 +2279,10 @@ ssize_t rxr_pkt_init_compare_rta(struct rxr_ep *ep, struct rxr_op_entry *tx_entr
 
 void rxr_pkt_handle_write_rta_send_completion(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_op_entry *tx_entry;
+	struct efa_rdm_ope *tx_entry;
 
-	tx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
-	rxr_op_entry_handle_send_completed(tx_entry);
+	tx_entry = (struct efa_rdm_ope *)pkt_entry->x_entry;
+	efa_rdm_ope_handle_send_completed(tx_entry);
 }
 
 static int rxr_write_atomic_hmem(struct efa_mr *efa_mr, struct iovec *dst, char *data,
@@ -2358,9 +2358,9 @@ int rxr_pkt_proc_write_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 	return 0;
 }
 
-struct rxr_op_entry *rxr_pkt_alloc_rta_rx_entry(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry, int op)
+struct efa_rdm_ope *rxr_pkt_alloc_rta_rx_entry(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry, int op)
 {
-	struct rxr_op_entry *rx_entry;
+	struct efa_rdm_ope *rx_entry;
 	struct rxr_rta_hdr *rta_hdr;
 
 	rx_entry = rxr_ep_alloc_rx_entry(ep, pkt_entry->addr, op);
@@ -2399,7 +2399,7 @@ struct rxr_op_entry *rxr_pkt_alloc_rta_rx_entry(struct rxr_ep *ep, struct rxr_pk
 	if (!rx_entry->atomrsp_data) {
 		EFA_WARN(FI_LOG_CQ,
 			"atomic repsonse buffer pool exhausted.\n");
-		rxr_rx_entry_release(rx_entry);
+		efa_rdm_rxe_release(rx_entry);
 		return NULL;
 	}
 
@@ -2409,7 +2409,7 @@ struct rxr_op_entry *rxr_pkt_alloc_rta_rx_entry(struct rxr_ep *ep, struct rxr_pk
 int rxr_pkt_proc_dc_write_rta(struct rxr_ep *ep,
 			      struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_op_entry *rx_entry;
+	struct efa_rdm_ope *rx_entry;
 	struct rxr_rta_hdr *rta_hdr;
 	ssize_t err;
 	int ret;
@@ -2423,7 +2423,7 @@ int rxr_pkt_proc_dc_write_rta(struct rxr_ep *ep,
 
 	rta_hdr = (struct rxr_rta_hdr *)pkt_entry->wiredata;
 	rx_entry->tx_id = rta_hdr->send_id;
-	rx_entry->rxr_flags |= RXR_TX_ENTRY_DELIVERY_COMPLETE_REQUESTED;
+	rx_entry->rxr_flags |= EFA_RDM_TXE_DELIVERY_COMPLETE_REQUESTED;
 
 	ret = rxr_pkt_proc_write_rta(ep, pkt_entry);
 	if (OFI_UNLIKELY(ret)) {
@@ -2438,7 +2438,7 @@ int rxr_pkt_proc_dc_write_rta(struct rxr_ep *ep,
 		EFA_WARN(FI_LOG_CQ,
 			"Posting of receipt packet failed! err=%s\n",
 			fi_strerror(err));
-		rxr_rx_entry_handle_error(rx_entry, -err, FI_EFA_ERR_PKT_POST);
+		efa_rdm_rxe_handle_error(rx_entry, -err, FI_EFA_ERR_PKT_POST);
 		return err;
 	}
 
@@ -2473,7 +2473,7 @@ static int rxr_fetch_atomic_hmem(struct efa_mr *efa_mr, struct iovec *dst, char 
 
 int rxr_pkt_proc_fetch_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_op_entry *rx_entry;
+	struct efa_rdm_ope *rx_entry;
 	struct efa_mr *efa_mr;
 	char *data;
 	int op, dt, i;
@@ -2519,7 +2519,7 @@ int rxr_pkt_proc_fetch_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 
 	err = rxr_pkt_post_or_queue(ep, rx_entry, RXR_ATOMRSP_PKT);
 	if (OFI_UNLIKELY(err))
-		rxr_rx_entry_handle_error(rx_entry, -err, FI_EFA_ERR_PKT_POST);
+		efa_rdm_rxe_handle_error(rx_entry, -err, FI_EFA_ERR_PKT_POST);
 
 	rxr_pkt_entry_release_rx(ep, pkt_entry);
 	return 0;
@@ -2551,7 +2551,7 @@ static int rxr_compare_atomic_hmem(struct efa_mr *efa_mr, struct iovec *dst, cha
 int rxr_pkt_proc_compare_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 {
 	struct efa_mr *efa_mr;
-	struct rxr_op_entry *rx_entry;
+	struct efa_rdm_ope *rx_entry;
 	char *src_data, *cmp_data;
 	int op, dt, i;
 	enum fi_hmem_iface hmem_iface;
@@ -2571,7 +2571,7 @@ int rxr_pkt_proc_compare_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 	dtsize = ofi_datatype_size(rx_entry->atomic_hdr.datatype);
 	if (OFI_UNLIKELY(!dtsize)) {
 		efa_eq_write_error(&ep->base_ep.util_ep, FI_EINVAL, FI_EFA_ERR_INVALID_DATATYPE);
-		rxr_rx_entry_release(rx_entry);
+		efa_rdm_rxe_release(rx_entry);
 		rxr_pkt_entry_release_rx(ep, pkt_entry);
 		return -errno;
 	}
@@ -2603,7 +2603,7 @@ int rxr_pkt_proc_compare_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 	if (OFI_UNLIKELY(err)) {
 		efa_eq_write_error(&ep->base_ep.util_ep, FI_EIO, FI_EFA_ERR_PKT_POST);
 		ofi_buf_free(rx_entry->atomrsp_data);
-		rxr_rx_entry_release(rx_entry);
+		efa_rdm_rxe_release(rx_entry);
 		rxr_pkt_entry_release_rx(ep, pkt_entry);
 		return err;
 	}

--- a/prov/efa/src/rdm/rxr_pkt_type_req.h
+++ b/prov/efa/src/rdm/rxr_pkt_type_req.h
@@ -170,67 +170,67 @@ struct rxr_runtread_rtm_base_hdr *rxr_get_runtread_rtm_base_hdr(void *pkt)
 }
 
 ssize_t rxr_pkt_init_eager_msgrtm(struct rxr_ep *ep,
-				  struct rxr_op_entry *tx_entry,
+				  struct efa_rdm_ope *tx_entry,
 				  struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_dc_eager_msgrtm(struct rxr_ep *ep,
-				     struct rxr_op_entry *tx_entry,
+				     struct efa_rdm_ope *tx_entry,
 				     struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_eager_tagrtm(struct rxr_ep *ep,
-				  struct rxr_op_entry *tx_entry,
+				  struct efa_rdm_ope *tx_entry,
 				  struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_medium_msgrtm(struct rxr_ep *ep,
-				   struct rxr_op_entry *tx_entry,
+				   struct efa_rdm_ope *tx_entry,
 				   struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_dc_eager_tagrtm(struct rxr_ep *ep,
-				     struct rxr_op_entry *tx_entry,
+				     struct efa_rdm_ope *tx_entry,
 				     struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_dc_medium_msgrtm(struct rxr_ep *ep,
-				      struct rxr_op_entry *tx_entry,
+				      struct efa_rdm_ope *tx_entry,
 				      struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_medium_tagrtm(struct rxr_ep *ep,
-				   struct rxr_op_entry *tx_entry,
+				   struct efa_rdm_ope *tx_entry,
 				   struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_dc_medium_tagrtm(struct rxr_ep *ep,
-				      struct rxr_op_entry *tx_entry,
+				      struct efa_rdm_ope *tx_entry,
 				      struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_longcts_msgrtm(struct rxr_ep *ep,
-				 struct rxr_op_entry *tx_entry,
+				 struct efa_rdm_ope *tx_entry,
 				 struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_dc_longcts_msgrtm(struct rxr_ep *ep,
-				    struct rxr_op_entry *tx_entry,
+				    struct efa_rdm_ope *tx_entry,
 				    struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_longcts_tagrtm(struct rxr_ep *ep,
-				 struct rxr_op_entry *tx_entry,
+				 struct efa_rdm_ope *tx_entry,
 				 struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_dc_longcts_tagrtm(struct rxr_ep *ep,
-				    struct rxr_op_entry *tx_entry,
+				    struct efa_rdm_ope *tx_entry,
 				    struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_longread_msgrtm(struct rxr_ep *ep,
-				 struct rxr_op_entry *tx_entry,
+				 struct efa_rdm_ope *tx_entry,
 				 struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_longread_tagrtm(struct rxr_ep *ep,
-				 struct rxr_op_entry *tx_entry,
+				 struct efa_rdm_ope *tx_entry,
 				 struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_runtread_msgrtm(struct rxr_ep *ep,
-				 struct rxr_op_entry *tx_entry,
+				 struct efa_rdm_ope *tx_entry,
 				 struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_runtread_tagrtm(struct rxr_ep *ep,
-				 struct rxr_op_entry *tx_entry,
+				 struct efa_rdm_ope *tx_entry,
 				 struct rxr_pkt_entry *pkt_entry);
 
 static inline
@@ -272,14 +272,14 @@ void rxr_pkt_handle_runtread_rtm_send_completion(struct rxr_ep *ep,
 						 struct rxr_pkt_entry *pkt_entry);
 
 void rxr_pkt_rtm_update_rx_entry(struct rxr_pkt_entry *pkt_entry,
-				 struct rxr_op_entry *rx_entry);
+				 struct efa_rdm_ope *rx_entry);
 
 /*         This function is called by both
  *            rxr_pkt_handle_rtm_recv() and
  *            rxr_msg_handle_unexp_match()
  */
 ssize_t rxr_pkt_proc_matched_rtm(struct rxr_ep *ep,
-				 struct rxr_op_entry *rx_entry,
+				 struct efa_rdm_ope *rx_entry,
 				 struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_proc_rtm_rta(struct rxr_ep *ep,
@@ -309,23 +309,23 @@ struct rxr_dc_eager_rtw_hdr *rxr_get_dc_eager_rtw_hdr(void *pkt)
 }
 
 ssize_t rxr_pkt_init_eager_rtw(struct rxr_ep *ep,
-			       struct rxr_op_entry *tx_entry,
+			       struct efa_rdm_ope *tx_entry,
 			       struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_longcts_rtw(struct rxr_ep *ep,
-			      struct rxr_op_entry *tx_entry,
+			      struct efa_rdm_ope *tx_entry,
 			      struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_longread_rtw(struct rxr_ep *ep,
-			      struct rxr_op_entry *tx_entry,
+			      struct efa_rdm_ope *tx_entry,
 			      struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_dc_eager_rtw(struct rxr_ep *ep,
-				  struct rxr_op_entry *tx_entry,
+				  struct efa_rdm_ope *tx_entry,
 				  struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_dc_longcts_rtw(struct rxr_ep *ep,
-				 struct rxr_op_entry *tx_entry,
+				 struct efa_rdm_ope *tx_entry,
 				 struct rxr_pkt_entry *pkt_entry);
 
 static inline
@@ -375,11 +375,11 @@ struct rxr_rtr_hdr *rxr_get_rtr_hdr(void *pkt)
 }
 
 ssize_t rxr_pkt_init_short_rtr(struct rxr_ep *ep,
-			       struct rxr_op_entry *tx_entry,
+			       struct efa_rdm_ope *tx_entry,
 			       struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_longcts_rtr(struct rxr_ep *ep,
-			      struct rxr_op_entry *tx_entry,
+			      struct efa_rdm_ope *tx_entry,
 			      struct rxr_pkt_entry *pkt_entry);
 
 void rxr_pkt_handle_rtr_sent(struct rxr_ep *ep,
@@ -394,15 +394,15 @@ struct rxr_rta_hdr *rxr_get_rta_hdr(void *pkt)
 	return (struct rxr_rta_hdr *)pkt;
 }
 
-ssize_t rxr_pkt_init_write_rta(struct rxr_ep *ep, struct rxr_op_entry *tx_entry, struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_init_write_rta(struct rxr_ep *ep, struct efa_rdm_ope *tx_entry, struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_dc_write_rta(struct rxr_ep *ep,
-				  struct rxr_op_entry *tx_entry,
+				  struct efa_rdm_ope *tx_entry,
 				  struct rxr_pkt_entry *pkt_entry);
 
-ssize_t rxr_pkt_init_fetch_rta(struct rxr_ep *ep, struct rxr_op_entry *tx_entry, struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_init_fetch_rta(struct rxr_ep *ep, struct efa_rdm_ope *tx_entry, struct rxr_pkt_entry *pkt_entry);
 
-ssize_t rxr_pkt_init_compare_rta(struct rxr_ep *ep, struct rxr_op_entry *tx_entry, struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_init_compare_rta(struct rxr_ep *ep, struct efa_rdm_ope *tx_entry, struct rxr_pkt_entry *pkt_entry);
 
 static inline
 void rxr_pkt_handle_rta_sent(struct rxr_ep *ep,
@@ -431,9 +431,9 @@ int rxr_pkt_proc_compare_rta(struct rxr_ep *ep,
 
 void rxr_pkt_handle_rta_recv(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
 
-struct rxr_op_entry *rxr_pkt_get_msgrtm_rx_entry(struct rxr_ep *ep,
+struct efa_rdm_ope *rxr_pkt_get_msgrtm_rx_entry(struct rxr_ep *ep,
 						 struct rxr_pkt_entry **pkt_entry_ptr);
 
-struct rxr_op_entry *rxr_pkt_get_tagrtm_rx_entry(struct rxr_ep *ep,
+struct efa_rdm_ope *rxr_pkt_get_tagrtm_rx_entry(struct rxr_ep *ep,
 						 struct rxr_pkt_entry **pkt_entry_ptr);
 #endif

--- a/prov/efa/src/rdm/rxr_rma.h
+++ b/prov/efa/src/rdm/rxr_rma.h
@@ -45,7 +45,7 @@ int rxr_rma_verified_copy_iov(struct rxr_ep *ep, struct efa_rma_iov *rma,
 
 extern struct fi_ops_rma rxr_ops_rma;
 
-struct rxr_op_entry *
+struct efa_rdm_ope *
 rxr_rma_alloc_tx_entry(struct rxr_ep *rxr_ep,
 		       const struct fi_msg_rma *msg_rma,
 		       uint32_t op,


### PR DESCRIPTION
First step to retire the legacy term "rxr"