### PR TITLE
include/ofi_mem: smr_freestack_init enhancements

### DIFF
--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -226,6 +226,7 @@ struct smr_freestack {
 };
 
 #define smr_freestack_isempty(fs)	((fs)->top == SMR_FREESTACK_EMPTY)
+#define smr_freestack_isfull(fs)	((fs)->free == (fs)->size)
 
 static inline void* smr_freestack_get_entry_from_index(struct smr_freestack *fs,
 		int16_t index)
@@ -271,6 +272,7 @@ static inline void smr_freestack_init(struct smr_freestack *fs, size_t elem_coun
 	ssize_t i, next_aligned_addr;
 	assert(elem_count == roundup_power_of_two(elem_count));
 	fs->size = elem_count;
+	fs->free = 0;
 	fs->object_size = fs_object_size;
 	fs->top = SMR_FREESTACK_EMPTY;
 	fs->entry_base_offset =


### PR DESCRIPTION
Correctly initialize fs->free in smr_freestack_init(). 
Add new macro smr_freestack_isfull() to determine if freestack is full.

This is required for SM2 b/c it re-uses the SHM file, so we require that we initialize to 0 every time.