### PR TITLE
windows/appveyor: Remove 'efa' config

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,9 +6,7 @@ build:
 
 configuration:
   - Debug-v142
-  - Debug-Efa-v142
   - Release-v142
-  - Release-Efa-v142
 
 before_build:
   - ps: .appveyor.ps1 -Verbose


### PR DESCRIPTION
The EFA config is the same as the normal debug/release configs. It's not actually EFA related, since the standard builds will also build the EFA provider.  (Actual testing of the EFA provider must be done on AWS).

This reduces CI runtime by half on windows.