### PR TITLE
core/hmem: Deprecate `FI_HMEM_CUDA_ENABLE_XFER`

### DIFF
--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -55,7 +55,6 @@ def test_rdm_atomic(cmdline_args, iteration_type, completion_type, memory_type):
     # the issue is tracked in:  https://github.com/ofiwg/libfabric/issues/7002
     # to mitigate the issue, set the maximum timeout of fi_rdm_atomic to 1800 seconds.
     cmdline_args_copy = copy(cmdline_args)
-    cmdline_args_copy.append_environ("FI_HMEM_CUDA_ENABLE_XFER=1")
     test = ClientServerTest(cmdline_args_copy, "fi_rdm_atomic", iteration_type, completion_type,
                             memory_type=memory_type, timeout=1800)
     test.run()

--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -164,17 +164,6 @@ int cuda_open_handle(void **handle, size_t size, uint64_t device,
 int cuda_close_handle(void *ipc_ptr);
 int cuda_get_base_addr(const void *ptr, void **base, size_t *size);
 
-/*
- * This enum lists all the possible situations about how
- * the environment variable FI_HMEM_CUDA_ENABLE_XFER was set.
- */
-enum cuda_xfer_setting {
-	CUDA_XFER_UNSPECIFIED, /* FI_HMEM_CUDA_ENABLE_XFER was not set */
-	CUDA_XFER_ENABLED, /* FI_HMEM_CUDA_ENABLE_XFER set to 1/true/yes */
-	CUDA_XFER_DISABLED /* FI_HMEM_CUDA_ENABLE_XFER set to 0/false/no */
-};
-
-enum cuda_xfer_setting cuda_get_xfer_setting(void);
 bool cuda_is_ipc_enabled(void);
 int cuda_get_ipc_handle_size(size_t *size);
 bool cuda_is_gdrcopy_enabled(void);

--- a/man/fabric.7.md
+++ b/man/fabric.7.md
@@ -300,23 +300,18 @@ portability across providers.
   on write restrictions.
 
 ## CUDA deadlock
-In some cases, calls to `cudaMemcpy` within libfabric may result in a
-deadlock. This typically occurs when a CUDA kernel blocks until a
-`cudaMemcpy` on the host completes.  To avoid this deadlock,
-`cudaMemcpy` may be disabled by setting
-`FI_HMEM_CUDA_ENABLE_XFER=0`. If this environment variable is set and
-there is a call to `cudaMemcpy` with libfabric, a warning will be
-emitted and no copy will occur. Note that not all providers support
-this option.
+In some cases, calls to `cudaMemcpy()` within libfabric may result in a deadlock.
+This typically occurs when a CUDA kernel blocks until a `cudaMemcpy` on the host
+completes.  Applications which can cause such behavior can restrict Libfabric's
+ability to invoke CUDA API operations with the endpoint option
+`FI_OPT_CUDA_API_PERMITTED`. See [`fi_endpoint`(3)](fi_endpoint.3.html) for more
+details.
 
 Another mechanism which can be used to avoid deadlock is Nvidia's
-gdrcopy. Using gdrcopy requires an external library and kernel module
-available at https://github.com/NVIDIA/gdrcopy. Libfabric must be
-configured with gdrcopy support using the `--with-gdrcopy` option, and
-be run with `FI_HMEM_CUDA_USE_GDRCOPY=1`. This may be used in
-conjunction with the above option to provide a method for copying
-to/from CUDA device memory when `cudaMemcpy` cannot be used. Again,
-this may not be supported by all providers.
+GDRCopy. Using GDRCopy requires an external library and kernel module available
+at https://github.com/NVIDIA/gdrcopy. Libfabric must be configured with GDRCopy
+support using the `--with-gdrcopy` option, and be run with
+`FI_HMEM_CUDA_USE_GDRCOPY=1`. This may not be supported by all providers.
 
 # ABI CHANGES
 


### PR DESCRIPTION
This removes the initialization logic related to `FI_HMEM_CUDA_ENABLE_XFER` for the `FI_HMEM` CUDA interface in favor of the endpoint option `FI_OPT_CUDA_API_PERMITTED`.

This also removes some facilities which are no longer needed, such as the `cuda_xfer_setting` enum and the dummy `cuda_disabled_cudaMemCpy()` function.

The environment variable itself doesn't seem to have been explicitly defined in any of the section 7 man pages, so no explicit deprecation notices or warning messages were added.