### PR TITLE
prov/efa: remove rxr_rm_tx/rx_cq_check()

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -738,8 +738,6 @@ void efa_rdm_rxe_report_completion(struct efa_rdm_ope *rxe)
 					       rxe->total_len -
 					       rxe->cq_entry.len);
 
-		rxr_rm_rx_cq_check(ep, rx_cq);
-
 		if (OFI_UNLIKELY(ret)) {
 			EFA_WARN(FI_LOG_CQ,
 				"Unable to write recv error cq: %s\n",
@@ -784,8 +782,6 @@ void efa_rdm_rxe_report_completion(struct efa_rdm_ope *rxe)
 					   rxe->cq_entry.buf,
 					   rxe->cq_entry.data,
 					   rxe->cq_entry.tag);
-
-		rxr_rm_rx_cq_check(ep, rx_cq);
 
 		if (OFI_UNLIKELY(ret)) {
 			EFA_WARN(FI_LOG_CQ,
@@ -887,8 +883,6 @@ void efa_rdm_txe_report_completion(struct efa_rdm_ope *txe)
 					   txe->cq_entry.buf,
 					   txe->cq_entry.data,
 					   txe->cq_entry.tag);
-
-		rxr_rm_tx_cq_check(txe->ep, tx_cq);
 
 		if (OFI_UNLIKELY(ret)) {
 			EFA_WARN(FI_LOG_CQ,

--- a/prov/efa/src/rdm/rxr_atomic.c
+++ b/prov/efa/src/rdm/rxr_atomic.c
@@ -138,11 +138,6 @@ ssize_t rxr_atomic_generic_efa(struct rxr_ep *rxr_ep,
 
 	ofi_mutex_lock(&rxr_ep->base_ep.util_ep.lock);
 
-	if (OFI_UNLIKELY(is_tx_res_full(rxr_ep))) {
-		err = -FI_EAGAIN;
-		goto out;
-	}
-
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
 	assert(peer);
 

--- a/prov/efa/src/rdm/rxr_ep.c
+++ b/prov/efa/src/rdm/rxr_ep.c
@@ -2455,8 +2455,6 @@ void recv_rdma_with_imm_completion(struct rxr_ep *ep, int32_t imm_data,
 		ret = ofi_cq_write(target_cq, NULL, flags, 0, NULL, imm_data, 0);
 	}
 
-	rxr_rm_rx_cq_check(ep, target_cq);
-
 	if (OFI_UNLIKELY(ret)) {
 		EFA_WARN(FI_LOG_CQ,
 			"Unable to write a cq entry for remote for RECV_RDMA operation: %s\n",

--- a/prov/efa/src/rdm/rxr_ep.h
+++ b/prov/efa/src/rdm/rxr_ep.h
@@ -384,50 +384,6 @@ bool rxr_ep_should_write_rnr_completion(struct rxr_ep *ep)
 }
 
 /*
- * RM flags
- */
-#define RXR_RM_TX_CQ_FULL	BIT_ULL(0)
-#define RXR_RM_RX_CQ_FULL	BIT_ULL(1)
-
-/*
- * today we have only cq res check, in future we will have ctx, and other
- * resource check as well.
- */
-static inline
-uint64_t is_tx_res_full(struct rxr_ep *ep)
-{
-	return ep->rm_full & RXR_RM_TX_CQ_FULL;
-}
-
-static inline
-uint64_t is_rx_res_full(struct rxr_ep *ep)
-{
-	return ep->rm_full & RXR_RM_RX_CQ_FULL;
-}
-
-static inline
-void rxr_rm_rx_cq_check(struct rxr_ep *ep, struct util_cq *rx_cq)
-{
-	ofi_genlock_lock(&rx_cq->cq_lock);
-	if (ofi_cirque_isfull(rx_cq->cirq))
-		ep->rm_full |= RXR_RM_RX_CQ_FULL;
-	else
-		ep->rm_full &= ~RXR_RM_RX_CQ_FULL;
-	ofi_genlock_unlock(&rx_cq->cq_lock);
-}
-
-static inline
-void rxr_rm_tx_cq_check(struct rxr_ep *ep, struct util_cq *tx_cq)
-{
-	ofi_genlock_lock(&tx_cq->cq_lock);
-	if (ofi_cirque_isfull(tx_cq->cirq))
-		ep->rm_full |= RXR_RM_TX_CQ_FULL;
-	else
-		ep->rm_full &= ~RXR_RM_TX_CQ_FULL;
-	ofi_genlock_unlock(&tx_cq->cq_lock);
-}
-
-/*
  * @brief: check whether we should use p2p for this transaction
  *
  * @param[in]	ep	rxr_ep

--- a/prov/efa/src/rdm/rxr_msg.c
+++ b/prov/efa/src/rdm/rxr_msg.c
@@ -189,11 +189,6 @@ ssize_t rxr_msg_generic_send(struct fid_ep *ep, const struct fi_msg *msg,
 	efa_perfset_start(rxr_ep, perf_efa_tx);
 	ofi_mutex_lock(&rxr_ep->base_ep.util_ep.lock);
 
-	if (OFI_UNLIKELY(is_tx_res_full(rxr_ep))) {
-		err = -FI_EAGAIN;
-		goto out;
-	}
-
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
 	assert(peer);
 
@@ -1147,10 +1142,6 @@ ssize_t rxr_msg_generic_recv(struct fid_ep *ep, const struct fi_msg *msg,
 	efa_perfset_start(rxr_ep, perf_efa_recv);
 
 	ofi_mutex_lock(&rxr_ep->base_ep.util_ep.lock);
-	if (OFI_UNLIKELY(is_rx_res_full(rxr_ep))) {
-		ret = -FI_EAGAIN;
-		goto out;
-	}
 
 	if (flags & FI_MULTI_RECV) {
 		ret = rxr_msg_multi_recv(rxr_ep, msg, tag, ignore, op, flags);
@@ -1220,7 +1211,6 @@ ssize_t rxr_msg_discard_trecv(struct rxr_ep *ep,
 			   FI_TAGGED | FI_RECV | FI_MSG,
 			   0, NULL, rxe->cq_entry.data,
 			   rxe->cq_entry.tag);
-	rxr_rm_rx_cq_check(ep, ep->base_ep.util_ep.rx_cq);
 	return ret;
 }
 
@@ -1324,7 +1314,6 @@ ssize_t rxr_msg_peek_trecv(struct fid_ep *ep_fid,
 				   FI_TAGGED | FI_RECV,
 				   data_len, NULL,
 				   rxe->cq_entry.data, tag);
-	rxr_rm_rx_cq_check(ep, ep->base_ep.util_ep.rx_cq);
 out:
 	ofi_mutex_unlock(&ep->base_ep.util_ep.lock);
 	return ret;

--- a/prov/efa/src/rdm/rxr_rma.c
+++ b/prov/efa/src/rdm/rxr_rma.c
@@ -163,11 +163,6 @@ ssize_t rxr_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uint64_
 	efa_perfset_start(rxr_ep, perf_efa_tx);
 	ofi_mutex_lock(&rxr_ep->base_ep.util_ep.lock);
 
-	if (OFI_UNLIKELY(is_tx_res_full(rxr_ep))) {
-		err = -FI_EAGAIN;
-		goto out;
-	}
-
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
 	assert(peer);
 


### PR DESCRIPTION
rxr_rm_cq_check() check whether util_cq is overflow, and set the RXR_RM_TX/RX_CQ_FULL flag.

If the flags are full, fi_send/read/write/atomic will return -FI_EAGAIN.

The code as is does not work, because when -FI_EAGAIN is returned, progress engine is not called so if the RXR_RM_TX/RX_CQ_FULL flag is ever set, an application will hang.

Meanwhile, the check itself is not necesary because util_cq can handle the situation that CQ is full
by writing overflow CQ entry.

Therefore, this patch remove the code from critical code path.