### PR TITLE
core/hmem: introduce gdrcopy from/to iov functions

### DIFF
--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -172,6 +172,12 @@ void cuda_gdrcopy_to_dev(uint64_t handle, void *dev,
 			 const void *host, size_t size);
 void cuda_gdrcopy_from_dev(uint64_t handle, void *host,
 			   const void *dev, size_t size);
+ssize_t ofi_gdrcopy_to_cuda_iov(uint64_t handle, const struct iovec *iov,
+                                size_t iov_count, uint64_t iov_offset,
+                                const void *host, size_t len);
+ssize_t ofi_gdrcopy_from_cuda_iov(uint64_t handle, void *host,
+                                  const struct iovec *iov, size_t iov_count,
+                                  uint64_t iov_offset, size_t len);
 int cuda_gdrcopy_hmem_init(void);
 int cuda_gdrcopy_hmem_cleanup(void);
 int cuda_gdrcopy_dev_register(struct fi_mr_attr *mr_attr, uint64_t *handle);

--- a/src/hmem_cuda_gdrcopy.c
+++ b/src/hmem_cuda_gdrcopy.c
@@ -37,6 +37,7 @@
 
 #include "ofi_hmem.h"
 #include "ofi.h"
+#include "ofi_iov.h"
 
 #if HAVE_GDRCOPY
 
@@ -292,6 +293,44 @@ void cuda_gdrcopy_from_dev(uint64_t handle, void *hostptr,
 			  GDRCOPY_FROM_DEVICE);
 }
 
+static ssize_t cuda_gdrcopy_iov_buf(uint64_t handle,
+                                    const struct iovec *iov, size_t iov_count,
+                                    uint64_t iov_offset, void *buf,
+                                    size_t size, enum gdrcopy_dir dir)
+{
+	uint64_t done = 0, len;
+	char *dev_buf;
+	size_t i;
+
+	for (i = 0; i < iov_count && size; i++) {
+		len = ofi_iov_bytes_to_copy(&iov[i], &size, &iov_offset, &dev_buf);
+
+		if (!len)
+			continue;
+
+		cuda_gdrcopy_impl(handle, dev_buf, (void *)((char *)buf + done), len, dir);
+
+		done += len;
+	}
+	return done;
+}
+
+ssize_t ofi_gdrcopy_to_cuda_iov(uint64_t handle, const struct iovec *iov,
+                                size_t iov_count, uint64_t iov_offset,
+                                const void *host, size_t len)
+{
+	return cuda_gdrcopy_iov_buf(handle, iov, iov_count, iov_offset,
+	                           (void *) host, len, GDRCOPY_TO_DEVICE);
+}
+
+ssize_t ofi_gdrcopy_from_cuda_iov(uint64_t handle, void *host,
+                                  const struct iovec *iov, size_t iov_count,
+                                  uint64_t iov_offset, size_t len)
+{
+	return cuda_gdrcopy_iov_buf(handle, iov, iov_count, iov_offset,
+	                            host, len, GDRCOPY_FROM_DEVICE);
+}
+
 int cuda_gdrcopy_dev_register(struct fi_mr_attr *mr_attr, uint64_t *handle)
 {
 	int err;
@@ -408,6 +447,20 @@ int cuda_gdrcopy_dev_register(struct fi_mr_attr *mr_attr, uint64_t *handle)
 int cuda_gdrcopy_dev_unregister(uint64_t handle)
 {
 	return FI_SUCCESS;
+}
+
+ssize_t ofi_gdrcopy_to_cuda_iov(uint64_t handle, const struct iovec *iov,
+                                size_t iov_count, uint64_t iov_offset,
+                                const void *host, size_t len)
+{
+	return -FI_ENOSYS;
+}
+
+ssize_t ofi_gdrcopy_from_cuda_iov(uint64_t handle, void *host,
+                                  const struct iovec *iov, size_t iov_count,
+                                  uint64_t iov_offset, size_t len)
+{
+	return -FI_ENOSYS;
 }
 
 #endif /* HAVE_GDRCOPY */


### PR DESCRIPTION
Introduce equivalent utilities to ofi_copy_from/to_hmem_iov