### PR TITLE
prov/efa: remove RXR_RX_MAX_QUEUE_SIZE and RXR_TX_MAX_QUEUE_SIZE

### DIFF
--- a/prov/efa/src/rdm/rxr.h
+++ b/prov/efa/src/rdm/rxr.h
@@ -102,13 +102,6 @@ static inline void rxr_poison_mem_region(void *ptr, size_t size)
  */
 #define RXR_AVAILABLE_DATA_BUFS_TIMEOUT	(5000000)
 
-/*
- * Based on size of tx_id and rx_id in headers, can be arbitrary once those are
- * removed.
- */
-#define RXR_MAX_RX_QUEUE_SIZE (UINT32_MAX)
-#define RXR_MAX_TX_QUEUE_SIZE (UINT32_MAX)
-
 void rxr_get_desc_for_shm(int numdesc, void **efa_desc, void **shm_desc);
 
 /* Aborts if unable to write to the eq */

--- a/prov/efa/src/rdm/rxr_ep.c
+++ b/prov/efa/src/rdm/rxr_ep.c
@@ -1411,21 +1411,24 @@ int rxr_ep_init(struct rxr_ep *ep)
 
 	ret = ofi_bufpool_create(&ep->map_entry_pool,
 				 sizeof(struct rxr_pkt_rx_map),
-				 RXR_BUF_POOL_ALIGNMENT, RXR_MAX_RX_QUEUE_SIZE,
+				 RXR_BUF_POOL_ALIGNMENT,
+				 0, /* no limit for max_cnt */
 				 ep->rx_size, 0);
 
 	if (ret)
 		goto err_free;
 
 	ret = ofi_bufpool_create(&ep->rx_atomrsp_pool, ep->mtu_size,
-				 RXR_BUF_POOL_ALIGNMENT, RXR_MAX_RX_QUEUE_SIZE,
+				 RXR_BUF_POOL_ALIGNMENT,
+				 0, /* no limit for max_cnt */
 				 rxr_env.atomrsp_pool_size, 0);
 	if (ret)
 		goto err_free;
 
 	ret = ofi_bufpool_create(&ep->ope_pool,
 				 sizeof(struct efa_rdm_ope),
-				 RXR_BUF_POOL_ALIGNMENT, RXR_MAX_RX_QUEUE_SIZE,
+				 RXR_BUF_POOL_ALIGNMENT,
+				 0, /* no limit for max_cnt */
 				 ep->tx_size + ep->rx_size, 0);
 	if (ret)
 		goto err_free;


### PR DESCRIPTION
RXR_TX_MAX_QUEUE_SIZE is not used any more, so this patch removed it.

RXR_RX_MAX_QUEUE_SIZE is used to as max_cnt of ofi_bufpool_create(). Its value was set to UIN32_MAX, which is same as no limit. Therefore this patch used 0 for max_cnt, which has the same effect and removed RXR_RX_MAX_QUEUE_SIZE.