### PR TITLE
include/ofi_atom.h: Set ofi_atom atomic->is_initalized in release builds

### DIFF
--- a/include/ofi_atom.h
+++ b/include/ofi_atom.h
@@ -58,9 +58,9 @@ extern "C" {
 #define ATOMIC_IS_INITIALIZED(atomic) assert(atomic->is_initialized)
 #define ATOMIC_INIT(atomic) atomic->is_initialized = 1
 #else
-#define ATOMIC_DEF_INIT
+#define ATOMIC_DEF_INIT int is_initialized
 #define ATOMIC_IS_INITIALIZED(atomic)
-#define ATOMIC_INIT(atomic)
+#define ATOMIC_INIT(atomic) atomic->is_initialized = 1
 #endif
 
 #ifdef HAVE_ATOMICS


### PR DESCRIPTION
prov/sm2 keeps a stateful SHM file which has persistent atomics int32's in it.  When we run a release build, and then we run a debug build, we fail the assert(atomic->is_initialized).