### PR TITLE
hmem,efa: remove gdrcopy from cuda hmem copy path and make gdrcopy calls explicit

### DIFF
--- a/prov/efa/src/efa_hmem.c
+++ b/prov/efa/src/efa_hmem.c
@@ -31,6 +31,7 @@
  */
 
 #include "efa.h"
+#include "efa_hmem.h"
 
 #if HAVE_CUDA || HAVE_NEURON
 static size_t efa_max_eager_msg_size_with_largest_header(struct efa_domain *efa_domain) {
@@ -463,33 +464,27 @@ int efa_domain_hmem_info_init_all(struct efa_domain *efa_domain)
  * @param[in]   buff_size     The size of the target buffer
  * @param[in]   hmem_iov      IOV data source
  * @param[in]   iov_count     Number of IOV structures in IOV array
- * @return  number of bytes copied on success, -FI_ETRUNC on error
+ * @return  number of bytes copied on success, or a negative error code
  */
 ssize_t efa_copy_from_hmem_iov(void **desc, char *buff, int buff_size,
                                const struct iovec *hmem_iov, int iov_count)
 {
-	uint64_t device;
-	enum fi_hmem_iface hmem_iface;
-	int i;
+	int i, ret = -1;
 	size_t data_size = 0;
 
 	for (i = 0; i < iov_count; i++) {
-		if (desc && desc[i]) {
-			hmem_iface = ((struct efa_mr **) desc)[i]->peer.iface;
-			device = ((struct efa_mr **) desc)[i]->peer.device.reserved;
-		} else {
-			hmem_iface = FI_HMEM_SYSTEM;
-			device = 0;
-		}
-
-		if (data_size + hmem_iov[i].iov_len < buff_size) {
-			ofi_copy_from_hmem(hmem_iface, device, buff + data_size, hmem_iov[i].iov_base,
-		                       hmem_iov[i].iov_len);
-			data_size += hmem_iov[i].iov_len;
-		} else {
-			EFA_WARN(FI_LOG_CQ, "IOV larger is larger than the target buffer\n");
+		if (data_size + hmem_iov[i].iov_len > buff_size) {
+			EFA_WARN(FI_LOG_CQ, "IOV is larger than the target buffer\n");
 			return -FI_ETRUNC;
 		}
+
+		ret = efa_copy_from_hmem(desc[i], buff + data_size,
+		                         hmem_iov[i].iov_base, hmem_iov[i].iov_len);
+
+		if (ret < 0)
+			return ret;
+
+		data_size += hmem_iov[i].iov_len;
 	}
 
 	return data_size;
@@ -503,35 +498,29 @@ ssize_t efa_copy_from_hmem_iov(void **desc, char *buff, int buff_size,
  * @param[in]    iov_count       Number of IOV entries in vector
  * @param[in]    buff            System buffer data source
  * @param[in]    buff_size       Size of data to copy
- * @return  number of bytes copied on success, -FI_ETRUNC on error
+ * @return  number of bytes copied on success, or a negative error code
  */
-ssize_t efa_copy_to_hmem_iov(void **desc, struct iovec *hmem_iov, int iov_count,
-                             char *buff, int buff_size)
+ssize_t efa_copy_to_hmem_iov(void **desc, struct iovec *hmem_iov,
+                             int iov_count, char *buff, int buff_size)
 {
-	uint64_t device;
-	enum fi_hmem_iface hmem_iface;
-	int i, bytes_remaining = buff_size, size;
+	int i, ret, bytes_remaining = buff_size, size;
 
 	for (i = 0; i < iov_count && bytes_remaining; i++) {
-		if (desc && desc[i]) {
-			hmem_iface = ((struct efa_mr **) desc)[i]->peer.iface;
-			device = ((struct efa_mr **) desc)[i]->peer.device.reserved;
-		} else {
-			hmem_iface = FI_HMEM_SYSTEM;
-			device = 0;
-		}
-
 		size = hmem_iov[i].iov_len;
 		if (bytes_remaining < size) {
 			size = bytes_remaining;
 		}
 
-		ofi_copy_to_hmem(hmem_iface, device, hmem_iov[i].iov_base, buff, size);
+		ret = efa_copy_to_hmem(desc[i], hmem_iov[i].iov_base, buff, size);
+
+		if (ret < 0)
+			return ret;
+
 		bytes_remaining -= size;
 	}
 
 	if (bytes_remaining) {
-		EFA_WARN(FI_LOG_CQ, "Source buffer larger than target IOV");
+		EFA_WARN(FI_LOG_CQ, "Source buffer is larger than target IOV");
 		return -FI_ETRUNC;
 	}
 	return buff_size;

--- a/prov/efa/src/efa_mr.h
+++ b/prov/efa/src/efa_mr.h
@@ -39,17 +39,15 @@
  * Descriptor returned for FI_HMEM peer memory registrations
  */
 struct efa_mr_peer {
-	enum fi_hmem_iface      iface;
+	enum fi_hmem_iface  iface;
 	union {
-		uint64_t        reserved;
-		/* this field is gdrcopy handle when gdrcopy is enabled,
-		 * otherwise it is cuda device id.
-		 */
-		uint64_t        cuda;
-		int             neuron;
-		int             synapseai;
+	    uint64_t        reserved;
+	    uint64_t        cuda;
+	    int             neuron;
+	    int             synapseai;
 	} device;
-	bool use_gdrcopy;
+	uint64_t            flags;
+	void                *hmem_data;
 };
 
 struct efa_mr {

--- a/prov/efa/src/rdm/rxr_pkt_type_base.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_base.c
@@ -181,13 +181,18 @@ int rxr_pkt_init_data_from_ope(struct rxr_ep *ep,
 	}
 
 	data = pkt_entry->wiredata + pkt_data_offset;
-	copied = ofi_copy_from_hmem_iov(data,
-					data_size,
-					iov_mr ? iov_mr->peer.iface : FI_HMEM_SYSTEM,
-					iov_mr ? iov_mr->peer.device.reserved : 0,
-					ope->iov,
-					ope->iov_count,
-					tx_data_offset);
+	if (iov_mr && FI_HMEM_CUDA == iov_mr->peer.iface &&
+	    (iov_mr->peer.flags & OFI_HMEM_DATA_GDRCOPY_HANDLE)) {
+		assert(iov_mr->peer.hmem_data);
+		copied = ofi_gdrcopy_from_cuda_iov((uint64_t)iov_mr->peer.hmem_data, data,
+		                                   ope->iov, ope->iov_count,
+		                                   tx_data_offset, data_size);
+	} else {
+		copied = ofi_copy_from_hmem_iov(data, data_size,
+		                                iov_mr ? iov_mr->peer.iface : FI_HMEM_SYSTEM,
+		                                iov_mr ? iov_mr->peer.device.reserved : 0,
+		                                ope->iov, ope->iov_count, tx_data_offset);
+	}
 	assert(copied == data_size);
 	pkt_entry->send->iov_count = 0;
 	pkt_entry->pkt_size = pkt_data_offset + copied;
@@ -275,10 +280,21 @@ int rxr_ep_flush_queued_blocking_copy_to_hmem(struct rxr_ep *ep)
 		rxe = pkt_entry->ope;
 		desc = rxe->desc[0];
 		assert(desc && desc->peer.iface != FI_HMEM_SYSTEM);
-		bytes_copied[i] = ofi_copy_to_hmem_iov(desc->peer.iface, desc->peer.device.reserved,
-						       rxe->iov, rxe->iov_count,
-						       data_offset + ep->msg_prefix_size,
-						       data, data_size);
+
+		if (FI_HMEM_CUDA == desc->peer.iface &&
+		    (desc->peer.flags & OFI_HMEM_DATA_GDRCOPY_HANDLE)) {
+			assert(desc->peer.hmem_data);
+			bytes_copied[i] = ofi_gdrcopy_to_cuda_iov((uint64_t)desc->peer.hmem_data,
+			                                          rxe->iov, rxe->iov_count,
+			                                          data_offset + ep->msg_prefix_size,
+			                                          data, data_size);
+		} else {
+			bytes_copied[i] = ofi_copy_to_hmem_iov(desc->peer.iface,
+			                                       desc->peer.device.reserved,
+			                                       rxe->iov, rxe->iov_count,
+			                                       data_offset + ep->msg_prefix_size,
+			                                       data, data_size);
+		}
 	}
 
 	for (i = 0; i < ep->queued_copy_num; ++i) {
@@ -404,7 +420,7 @@ int rxr_pkt_copy_data_to_cuda(struct rxr_ep *ep,
 	p2p_available = ret;
 	local_read_available = p2p_available && efa_rdm_ep_support_rdma_read(ep);
 	cuda_memcpy_available = ep->cuda_api_permitted;
-	gdrcopy_available = desc->peer.use_gdrcopy;
+	gdrcopy_available = desc->peer.flags & OFI_HMEM_DATA_GDRCOPY_HANDLE;
 
 	if (!local_read_available && !gdrcopy_available && !cuda_memcpy_available) {
 		EFA_WARN(FI_LOG_CQ, "None of the copy methods: localread, gdrcopy or cudaMemcpy is available,"
@@ -441,10 +457,11 @@ int rxr_pkt_copy_data_to_cuda(struct rxr_ep *ep,
 		 * to achieve best latency.
 		 */
 		if (rxe->bytes_copied + data_size == rxe->total_len) {
-			ofi_copy_to_hmem_iov(desc->peer.iface, desc->peer.device.reserved,
-					     rxe->iov, rxe->iov_count,
-					     data_offset + ep->msg_prefix_size,
-					     data, data_size);
+			assert(desc->peer.hmem_data);
+			ofi_gdrcopy_to_cuda_iov((uint64_t)desc->peer.hmem_data,
+			                        rxe->iov, rxe->iov_count,
+			                        data_offset + ep->msg_prefix_size,
+			                        data, data_size);
 			rxr_pkt_handle_data_copied(ep, pkt_entry, data_size);
 			return 0;
 		}

--- a/prov/efa/src/rdm/rxr_pkt_type_req.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_req.c
@@ -2289,11 +2289,10 @@ static int rxr_write_atomic_hmem(struct efa_mr *efa_mr, struct iovec *dst, char 
                                  size_t dtsize, int op, int dt)
 {
 	char *host_data = (char *) malloc(dst->iov_len);
-	uint64_t device = efa_mr->peer.device.reserved;
 	int err;
 
 	/* Step 1: Copy data from device to temporary host buffer */
-	err = ofi_copy_from_hmem(efa_mr->peer.iface, device, host_data, dst->iov_base, dst->iov_len);
+	err = efa_copy_from_hmem(efa_mr, host_data, dst->iov_base, dst->iov_len);
 	if (OFI_UNLIKELY(err)) {
 		free(host_data);
 		return err;
@@ -2305,7 +2304,7 @@ static int rxr_write_atomic_hmem(struct efa_mr *efa_mr, struct iovec *dst, char 
 	                                  dst->iov_len / dtsize);
 
 	/* Step 3: Copy temporary host buffer to device */
-	err = ofi_copy_to_hmem(efa_mr->peer.iface, device, dst->iov_base, host_data, dst->iov_len);
+	err = efa_copy_to_hmem(efa_mr, dst->iov_base, host_data, dst->iov_len);
 	free(host_data);
 	return err;
 }
@@ -2449,11 +2448,10 @@ static int rxr_fetch_atomic_hmem(struct efa_mr *efa_mr, struct iovec *dst, char 
                                  void* result, size_t dtsize, int op, int dt)
 {
 	char *host_data = (char *) malloc(dst->iov_len);
-	uint64_t device = efa_mr->peer.device.reserved;
 	int err;
 
 	/* Step 1: Copy data from device to temporary host buffer */
-	err = ofi_copy_from_hmem(efa_mr->peer.iface, device, host_data, dst->iov_base, dst->iov_len);
+	err = efa_copy_from_hmem(efa_mr, host_data, dst->iov_base, dst->iov_len);
 	if (OFI_UNLIKELY(err)) {
 		free(host_data);
 		return err;
@@ -2466,7 +2464,7 @@ static int rxr_fetch_atomic_hmem(struct efa_mr *efa_mr, struct iovec *dst, char 
 	                                      dst->iov_len / dtsize);
 
 	/* Step 3: Copy data from host buffer to device */
-	err = ofi_copy_to_hmem(efa_mr->peer.iface, device, dst->iov_base, host_data, dst->iov_len);
+	err = efa_copy_to_hmem(efa_mr, dst->iov_base, host_data, dst->iov_len);
 	free(host_data);
 	return err;
 }
@@ -2529,11 +2527,10 @@ static int rxr_compare_atomic_hmem(struct efa_mr *efa_mr, struct iovec *dst, cha
                                    void* cmp, size_t dtsize, int op, int dt)
 {
 	char *host_data = (char *) malloc(dst->iov_len);
-	uint64_t device = efa_mr->peer.device.reserved;
 	int err;
 
 	/* Step 1: Copy From HMEM into temp_host_buffer */
-	err = ofi_copy_from_hmem(efa_mr->peer.iface, device, host_data, dst->iov_base, dst->iov_len);
+	err = efa_copy_from_hmem(efa_mr, host_data, dst->iov_base, dst->iov_len);
 	if (OFI_UNLIKELY(err)) {
 		free(host_data);
 		return err;
@@ -2543,7 +2540,7 @@ static int rxr_compare_atomic_hmem(struct efa_mr *efa_mr, struct iovec *dst, cha
 	ofi_atomic_swap_handler(op, dt, host_data, src, cmp, res, dst->iov_len / dtsize);
 
 	/* Step 3: Copy host buffer back to device*/
-	err = ofi_copy_to_hmem(efa_mr->peer.iface, device, dst->iov_base, host_data, dst->iov_len);
+	err = efa_copy_to_hmem(efa_mr, dst->iov_base, host_data, dst->iov_len);
 	free(host_data);
 	return err;
 }

--- a/src/hmem_cuda.c
+++ b/src/hmem_cuda.c
@@ -243,10 +243,6 @@ static cudaError_t ofi_cudaGetDeviceCount(int *count)
 	return cuda_ops.cudaGetDeviceCount(count);
 }
 
-static bool ofi_cudaIsDeviceId(uint64_t device) {
-	return device < cuda_attr.device_count;
-}
-
 cudaError_t ofi_cudaMalloc(void **ptr, size_t size)
 {
 	return cuda_ops.cudaMalloc(ptr, size);
@@ -259,11 +255,6 @@ cudaError_t ofi_cudaFree(void *ptr)
 
 int cuda_copy_to_dev(uint64_t device, void *dst, const void *src, size_t size)
 {
-	if (cuda_attr.use_gdrcopy && !ofi_cudaIsDeviceId(device)) {
-		cuda_gdrcopy_to_dev(device, dst, src, size);
-		return FI_SUCCESS;
-	}
-
 	cudaError_t cuda_ret;
 
 	cuda_ret = ofi_cudaMemcpy(dst, src, size, cudaMemcpyDefault);
@@ -280,11 +271,6 @@ int cuda_copy_to_dev(uint64_t device, void *dst, const void *src, size_t size)
 
 int cuda_copy_from_dev(uint64_t device, void *dst, const void *src, size_t size)
 {
-	if (cuda_attr.use_gdrcopy && !ofi_cudaIsDeviceId(device)) {
-		cuda_gdrcopy_from_dev(device, dst, src, size);
-		return FI_SUCCESS;
-	}
-
 	cudaError_t cuda_ret;
 
 	cuda_ret = ofi_cudaMemcpy(dst, src, size, cudaMemcpyDefault);


### PR DESCRIPTION
With the introduction of hmem_data MR field, the gdrcopy handle should be
stored along side device id, and gdrcopy should be requested explicitly
by the caller.

This patch:
1. replaces calls to ofi_copy_from/to_hmem* functions with
ofi_gdrcopy_from/to_cuda* equivalent when a gdrcopy handle is present.
1. removes gdrcopy from cuda hmem copy path
