### PR TITLE
prov/verbs: Use progress lock to serialize progress functions

### DIFF
--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -119,7 +119,7 @@ vrb_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *entry,
 
 	cq = container_of(cq_fid, struct vrb_cq, util_cq.cq_fid);
 
-	ofi_genlock_lock(&cq->util_cq.cq_lock);
+	ofi_genlock_lock(vrb_cq2_progress(cq)->active_lock);
 	if (slist_empty(&cq->saved_wc_list))
 		goto err;
 
@@ -130,7 +130,7 @@ vrb_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *entry,
 	api_version = cq->util_cq.domain->fabric->fabric_fid.api_version;
 
 	slist_entry = slist_remove_head(&cq->saved_wc_list);
-	ofi_genlock_unlock(&cq->util_cq.cq_lock);
+	ofi_genlock_unlock(vrb_cq2_progress(cq)->active_lock);
 
 	wce = container_of(slist_entry, struct vrb_wc_entry, entry);
 
@@ -157,7 +157,7 @@ vrb_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *entry,
 	ofi_buf_free(wce);
 	return 1;
 err:
-	ofi_genlock_unlock(&cq->util_cq.cq_lock);
+	ofi_genlock_unlock(vrb_cq2_progress(cq)->active_lock);
 	return -FI_EAGAIN;
 }
 
@@ -245,7 +245,7 @@ int vrb_poll_cq(struct vrb_cq *cq, struct ibv_wc *wc)
 	struct vrb_ep *ep;
 	int ret;
 
-	assert(ofi_genlock_held(&cq->util_cq.cq_lock));
+	assert(ofi_genlock_held(vrb_cq2_progress(cq)->active_lock));
 	do {
 		ret = ibv_poll_cq(cq->cq, 1, wc);
 		if (ret <= 0)
@@ -288,7 +288,7 @@ int vrb_save_wc(struct vrb_cq *cq, struct ibv_wc *wc)
 {
 	struct vrb_wc_entry *wce;
 
-	assert(ofi_genlock_held(&cq->util_cq.cq_lock));
+	assert(ofi_genlock_held(vrb_cq2_progress(cq)->active_lock));
 	wce = ofi_buf_alloc(cq->wce_pool);
 	if (!wce) {
 		FI_WARN(&vrb_prov, FI_LOG_CQ,
@@ -306,7 +306,7 @@ static void vrb_flush_cq(struct vrb_cq *cq)
 	struct ibv_wc wc;
 	ssize_t ret;
 
-	ofi_genlock_lock(&cq->util_cq.cq_lock);
+	assert(ofi_genlock_held(vrb_cq2_progress(cq)->active_lock));
 	while (1) {
 		ret = vrb_poll_cq(cq, &wc);
 		if (ret <= 0)
@@ -314,12 +314,11 @@ static void vrb_flush_cq(struct vrb_cq *cq)
 
 		vrb_save_wc(cq, &wc);
 	};
-
-	ofi_genlock_unlock(&cq->util_cq.cq_lock);
 }
 
 void vrb_cleanup_cq(struct vrb_ep *ep)
 {
+	assert(ofi_genlock_held(vrb_ep2_progress(ep)->active_lock));
 	if (ep->util_ep.rx_cq) {
 		vrb_flush_cq(container_of(ep->util_ep.rx_cq,
 					  struct vrb_cq, util_cq));
@@ -340,8 +339,7 @@ static ssize_t vrb_cq_read(struct fid_cq *cq_fid, void *buf, size_t count)
 
 	cq = container_of(cq_fid, struct vrb_cq, util_cq.cq_fid);
 
-	ofi_genlock_lock(&cq->util_cq.cq_lock);
-
+	ofi_genlock_lock(vrb_cq2_progress(cq)->active_lock);
 	for (i = 0; i < count; i++) {
 		if (!slist_empty(&cq->saved_wc_list)) {
 			wce = container_of(cq->saved_wc_list.head,
@@ -364,7 +362,7 @@ static ssize_t vrb_cq_read(struct fid_cq *cq_fid, void *buf, size_t count)
 		if (wc.status) {
 			wce = ofi_buf_alloc(cq->wce_pool);
 			if (!wce) {
-				ofi_genlock_unlock(&cq->util_cq.cq_lock);
+				ofi_genlock_unlock(vrb_cq2_progress(cq)->active_lock);
 				return -FI_ENOMEM;
 			}
 			memset(wce, 0, sizeof(*wce));
@@ -377,7 +375,7 @@ static ssize_t vrb_cq_read(struct fid_cq *cq_fid, void *buf, size_t count)
 		cq->read_entry(&wc, (char *)buf + i * cq->entry_size);
 	}
 
-	ofi_genlock_unlock(&cq->util_cq.cq_lock);
+	ofi_genlock_unlock(vrb_cq2_progress(cq)->active_lock);
 	return i ? i : (ret < 0 ? ret : -FI_EAGAIN);
 }
 
@@ -412,7 +410,7 @@ int vrb_cq_trywait(struct vrb_cq *cq)
 		return -FI_EINVAL;
 	}
 
-	ofi_genlock_lock(&cq->util_cq.cq_lock);
+	ofi_genlock_lock(vrb_cq2_progress(cq)->active_lock);
 	if (!slist_empty(&cq->saved_wc_list))
 		goto out;
 
@@ -444,7 +442,7 @@ int vrb_cq_trywait(struct vrb_cq *cq)
 
 	ret = FI_SUCCESS;
 out:
-	ofi_genlock_unlock(&cq->util_cq.cq_lock);
+	ofi_genlock_unlock(vrb_cq2_progress(cq)->active_lock);
 	return ret;
 }
 
@@ -515,24 +513,22 @@ static int vrb_cq_close(fid_t fid)
 	/* Since an RX CQ and SRX context can be destroyed in any order,
 	 * and the XRC SRQ references the RX CQ, we must destroy any
 	 * XRC SRQ using this CQ before destroying the CQ. */
-	ofi_mutex_lock(&cq->xrc.srq_list_lock);
+	ofi_genlock_lock(vrb_cq2_progress(cq)->active_lock);
 	dlist_foreach_container_safe(&cq->xrc.srq_list, struct vrb_srx,
 				     srx, xrc.srq_entry, srx_temp) {
 		ret = vrb_xrc_close_srq(srx);
 		if (ret) {
-			ofi_mutex_unlock(&cq->xrc.srq_list_lock);
+			ofi_genlock_unlock(vrb_cq2_progress(cq)->active_lock);
 			return -ret;
 		}
 	}
-	ofi_mutex_unlock(&cq->xrc.srq_list_lock);
 
-	ofi_genlock_lock(&cq->util_cq.cq_lock);
 	while (!slist_empty(&cq->saved_wc_list)) {
 		entry = slist_remove_head(&cq->saved_wc_list);
 		wce = container_of(entry, struct vrb_wc_entry, entry);
 		ofi_buf_free(wce);
 	}
-	ofi_genlock_unlock(&cq->util_cq.cq_lock);
+	ofi_genlock_unlock(vrb_cq2_progress(cq)->active_lock);
 
 	ofi_bufpool_destroy(cq->wce_pool);
 
@@ -550,7 +546,6 @@ static int vrb_cq_close(fid_t fid)
 	if (cq->channel)
 		ibv_destroy_comp_channel(cq->channel);
 
-	ofi_mutex_destroy(&cq->xrc.srq_list_lock);
 	free(cq);
 	return 0;
 }
@@ -701,7 +696,6 @@ int vrb_cq_open(struct fid_domain *domain_fid, struct fi_cq_attr *attr,
 
 	slist_init(&cq->saved_wc_list);
 	dlist_init(&cq->xrc.srq_list);
-	ofi_mutex_init(&cq->xrc.srq_list_lock);
 
 	ofi_atomic_initialize32(&cq->nevents, 0);
 


### PR DESCRIPTION
To ensure that the ep state is consistent, we need to use the same lock when posting sends, receives, handling cm events, and handling async events.  Failures in any of those cases can result in the ep being transitioned into an error state, with the underlying qp being destroyed.

This also reduces the number of locks that we need to acquire to perform a data transfer and will simplify the code flow.  The changes are based on work done with the tcp provider.  One result of the change is that the provider is optimized around FI_THREAD_DOMAIN support, which ultimately ends up being the best option.

This replaces the rx and tx cq locks, which are used in racy ways, with a single progress lock for proper serialization.