### PR TITLE
prov/efa: fix a bug when calling ibv_query_qp_data_in_order

### DIFF
--- a/prov/efa/src/efa_base_ep.c
+++ b/prov/efa/src/efa_base_ep.c
@@ -356,7 +356,7 @@ bool efa_base_ep_support_op_in_order_aligned_128_bytes(struct efa_base_ep *base_
 {
 	int caps;
 
-	caps = ibv_query_qp_data_in_order(base_ep->qp, op,
+	caps = ibv_query_qp_data_in_order(base_ep->qp->ibv_qp, op,
 					  IBV_QUERY_QP_DATA_IN_ORDER_RETURN_CAPS);
 
 	return !!(caps & IBV_QUERY_QP_DATA_IN_ORDER_ALIGNED_128_BYTES);


### PR DESCRIPTION
The first argument of this call should be base_ep->qp->ibv_qp.