### PR TITLE
prov/hook: fix compilation issue interchanging `size_t` and `uint64_t`

### DIFF
--- a/include/ofi_hook.h
+++ b/include/ofi_hook.h
@@ -164,7 +164,7 @@ struct hook_domain {
 	struct fid_domain *hdomain;
 	struct hook_fabric *fabric;
 	struct ofi_ops_flow_ctrl *base_ops_flow_ctrl;
-	ssize_t (*base_credit_handler)(struct fid_ep *ep_fid, size_t credits);
+	ssize_t (*base_credit_handler)(struct fid_ep *ep_fid, uint64_t credits);
 };
 
 int hook_domain_init(struct fid_fabric *fabric, struct fi_info *info,

--- a/prov/hook/src/hook_domain.c
+++ b/prov/hook/src/hook_domain.c
@@ -102,7 +102,7 @@ static struct fi_ops_mr hook_mr_ops = {
 	.regattr = hook_mr_regattr,
 };
 
-static ssize_t hook_credit_handler(struct fid_ep *ep_fid, size_t credits)
+static ssize_t hook_credit_handler(struct fid_ep *ep_fid, uint64_t credits)
 {
 	/*
 	 * called from the base provider, ep_fid is the base ep, and
@@ -114,7 +114,7 @@ static ssize_t hook_credit_handler(struct fid_ep *ep_fid, size_t credits)
 }
 
 static void hook_set_send_handler(struct fid_domain *domain_fid,
-		ssize_t (*credit_handler)(struct fid_ep *ep, size_t credits))
+		ssize_t (*credit_handler)(struct fid_ep *ep, uint64_t credits))
 {
 	struct hook_domain *domain = container_of(domain_fid,
 						  struct hook_domain, domain);
@@ -131,7 +131,7 @@ static int hook_enable_ep_flow_ctrl(struct fid_ep *ep_fid, uint64_t threshold)
 	return ep->domain->base_ops_flow_ctrl->enable(ep->hep, threshold);
 }
 
-static void hook_add_credits(struct fid_ep *ep_fid, size_t credits)
+static void hook_add_credits(struct fid_ep *ep_fid, uint64_t credits)
 {
 	struct hook_ep *ep = container_of(ep_fid, struct hook_ep, ep);
 


### PR DESCRIPTION
This PR fixes compilation issues mentioned in #7860
With clang-16, the current main branch doesn't compile and fails with the error:
```
prov/hook/src/hook_domain.c:124:12: error: incompatible function pointer types passing 'ssize_t (struct fid_ep *, size_t)' (aka 'long (struct fid_ep *, unsigned long)') to parameter of type 'ssize_t (*)(struct fid_ep *, uint64_t)' (aka 'long (*)(struct fid_ep *, unsigned long long)') [-Wincompatible-function-pointer-types]
                                                     hook_credit_handler);
                                                     ^~~~~~~~~~~~~~~~~~~
prov/hook/src/hook_domain.c:150:17: error: incompatible function pointer types initializing 'void (*)(struct fid_ep *, uint64_t)' (aka 'void (*)(struct fid_ep *, unsigned long long)') with an expression of type 'void (struct fid_ep *, size_t)' (aka 'void (struct fid_ep *, unsigned long)') [-Wincompatible-function-pointer-types]
        .add_credits = hook_add_credits,
                       ^~~~~~~~~~~~~~~~
prov/hook/src/hook_domain.c:152:22: error: incompatible function pointer types initializing 'void (*)(struct fid_domain *, ssize_t (*)(struct fid_ep *, uint64_t))' (aka 'void (*)(struct fid_domain *, long (*)(struct fid_ep *, unsigned long long))') with an expression of type 'void (struct fid_domain *, ssize_t (*)(struct fid_ep *, size_t))' (aka 'void (struct fid_domain *, long (*)(struct fid_ep *, unsigned long))') [-Wincompatible-function-pointer-types]
        .set_send_handler = hook_set_send_handler,
                            ^~~~~~~~~~~~~~~~~~~~~
3 errors generated.

```

I am not 100% confident about the fix but it seems to work for me at least.
Please double check before merging