### PR TITLE
prov/efa: Enable SM2 provider as peer provider

### DIFF
--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -327,12 +327,12 @@ int efa_conn_rdm_init(struct efa_av *av, struct efa_conn *conn)
 		 * The shm provider supports FI_AV_USER_ID flag. This flag
 		 * associates a user-assigned identifier with each av entry that is
 		 * returned with any completion entry in place of the AV's address.
-		 * In the fi_av_insert_call below, the &peer->shm_fiaddr is both an input
+		 * In the fi_av_insert call below, the &peer->shm_fiaddr is both an input
 		 * and an output. peer->shm_fiaddr is passed in the function with value as
 		 * conn->fi_addr, which is the address of peer in efa provider's av. shm
 		 * records this value as user id in its internal hashmap for the use of cq
 		 * write, and then overwrite peer->shm_fiaddr as the actual fi_addr in shm's
-		 * av. The efa provider should still use peer->shm_fiaddr for transmissions 
+		 * av. The efa provider should still use peer->shm_fiaddr for transmissions
 		 * through shm ep.
 		 */
 		peer->shm_fiaddr = conn->fi_addr;

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -133,7 +133,6 @@ static int efa_domain_init_rdm(struct efa_domain *efa_domain, struct fi_info *in
 	efa_shm_info_create(info, &efa_domain->shm_info);
 
 	if (efa_domain->shm_info) {
-		assert(!strcmp(efa_domain->shm_info->fabric_attr->name, "shm"));
 		err = fi_fabric(efa_domain->shm_info->fabric_attr,
 				&efa_domain->fabric->shm_fabric,
 				efa_domain->fabric->util_fabric.fabric_fid.fid.context);
@@ -144,7 +143,6 @@ static int efa_domain_init_rdm(struct efa_domain *efa_domain, struct fi_info *in
 	}
 
 	if (efa_domain->fabric->shm_fabric) {
-		assert(!strcmp(efa_domain->shm_info->fabric_attr->name, "shm"));
 		err = fi_domain(efa_domain->fabric->shm_fabric, efa_domain->shm_info,
 				&efa_domain->shm_domain, NULL);
 		if (err)

--- a/prov/efa/src/efa_shm.c
+++ b/prov/efa/src/efa_shm.c
@@ -98,12 +98,27 @@ void efa_shm_info_create(const struct fi_info *app_info, struct fi_info **shm_in
 	int ret;
 	struct fi_info *shm_hints;
 
+	char *shm_provider;
+	if (rxr_env.use_sm2) {
+		shm_provider = "sm2";
+	} else {
+		shm_provider = "shm";
+	}
+
 	shm_hints = fi_allocinfo();
-	shm_hints->caps = FI_MSG | FI_TAGGED | FI_RECV | FI_SEND | FI_READ
-			   | FI_WRITE | FI_REMOTE_READ | FI_REMOTE_WRITE
-			   | FI_MULTI_RECV | FI_RMA | FI_SOURCE;
-	shm_hints->domain_attr->av_type = FI_AV_TABLE;
+	shm_hints->caps = app_info->caps;
+	shm_hints->caps &= ~FI_REMOTE_COMM;
+
+	/*
+	 * If application requests FI_HMEM and efa supports it,
+	 * make this request to shm as well.
+	 */
 	shm_hints->domain_attr->mr_mode = FI_MR_VIRT_ADDR;
+	if (app_info && (app_info->caps & FI_HMEM)) {
+		shm_hints->domain_attr->mr_mode |= FI_MR_HMEM;
+	}
+
+	shm_hints->domain_attr->av_type = FI_AV_TABLE;
 	shm_hints->domain_attr->caps |= FI_LOCAL_COMM;
 	shm_hints->tx_attr->msg_order = FI_ORDER_SAS;
 	shm_hints->rx_attr->msg_order = FI_ORDER_SAS;
@@ -118,18 +133,9 @@ void efa_shm_info_create(const struct fi_info *app_info, struct fi_info **shm_in
 	 */
 	shm_hints->tx_attr->op_flags  = FI_COMPLETION;
 	shm_hints->rx_attr->op_flags  = FI_COMPLETION;
-	shm_hints->fabric_attr->name = strdup("shm");
-	shm_hints->fabric_attr->prov_name = strdup("shm");
+	shm_hints->fabric_attr->name = strdup(shm_provider);
+	shm_hints->fabric_attr->prov_name = strdup(shm_provider);
 	shm_hints->ep_attr->type = FI_EP_RDM;
-
-	/*
-	 * If application requests FI_HMEM and efa supports it,
-	 * make this request to shm as well.
-	 */
-	if (app_info && (app_info->caps & FI_HMEM)) {
-		shm_hints->caps |= FI_HMEM;
-		shm_hints->domain_attr->mr_mode |= FI_MR_HMEM;
-	}
 
 	ret = fi_getinfo(FI_VERSION(1, 8), NULL, NULL,
 	                 OFI_GETINFO_HIDDEN, shm_hints, shm_info);
@@ -140,7 +146,6 @@ void efa_shm_info_create(const struct fi_info *app_info, struct fi_info **shm_in
 		rxr_env.enable_shm_transfer = 0;
 		*shm_info = NULL;
 	} else {
-		assert(!strcmp((*shm_info)->fabric_attr->name, "shm"));
+		assert(!strcmp((*shm_info)->fabric_attr->name, shm_provider));
 	}
 }
-

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -45,7 +45,7 @@
 /**
  * @brief set the "efa_qp" field in the efa_rdm_ep->efa_base_ep
  * called by efa_rdm_ep_open()
- * 
+ *
  * @param[in,out] ep The EFA RDM endpoint to set the qp in
  * @return int 0 on success, negative libfabric error code otherwise
  * @todo merge this function with #efa_base_ep_construct
@@ -85,7 +85,7 @@ int efa_rdm_ep_create_base_ep_ibv_qp(struct efa_rdm_ep *ep)
 /** @brief initializes the various buffer pools of EFA RDM endpoint.
  *
  * called by efa_rdm_ep_open()
- * 
+ *
  * @param ep efa_rdm_ep struct to initialize.
  * @return 0 on success, fi_errno on error.
  * @related #efa_rdm_ep
@@ -299,7 +299,7 @@ static struct fi_ops efa_rdm_ep_base_ops = {
 /**
  * @brief set the "use_zcpy_rx" flag in an EFA RDM endpoint.
  * called by efa_rdm_ep_open()
- * 
+ *
  * @param[in,out] ep EFA RDM endpoint
  */
 static inline
@@ -319,7 +319,7 @@ void efa_rdm_ep_set_use_zcpy_rx(struct efa_rdm_ep *ep)
 
 /**
  * @brief implement the fi_endpoint() API for EFA RDM endpoint
- * 
+ *
  * @param[in,out] domain The domain this endpoint belongs to
  * @param[in] info The info struct used to create this endpoint
  * @param[out] ep The endpoint to be created
@@ -361,7 +361,6 @@ int efa_rdm_ep_open(struct fid_domain *domain, struct fi_info *info,
 		if (ret)
 			goto err_destroy_base_ep;
 
-		assert(!strcmp(efa_domain->shm_info->fabric_attr->name, "shm"));
 		ret = fi_endpoint(efa_domain->shm_domain, efa_domain->shm_info,
 				  &efa_rdm_ep->shm_ep, efa_rdm_ep);
 		if (ret)
@@ -961,7 +960,7 @@ int efa_rdm_ep_compare_rxe_context(struct dlist_entry *item,
 
 /**
  * @brief cancel a posted receive
- * 
+ *
  * @param[in,out]	ep	EFA RDM endpoint
  */
 static
@@ -1234,7 +1233,7 @@ int efa_rdm_ep_set_write_in_order_aligned_128_bytes(struct efa_rdm_ep *ep,
  * @param[in]	optval		value of the option
  * @param[in]	optlen		length of the option
  * @related efa_rdm_ep
- * 
+ *
  */
 static int efa_rdm_ep_setopt(fid_t fid, int level, int optname,
 			 const void *optval, size_t optlen)

--- a/prov/efa/src/rdm/rxr_env.c
+++ b/prov/efa/src/rdm/rxr_env.c
@@ -69,6 +69,7 @@ struct rxr_env rxr_env = {
 	.efa_write_segment_size = 1073741824, /* need to confirm this constant. */
 	.rnr_retry = 3, /* Setting this value to EFA_RNR_INFINITE_RETRY makes the firmware retry indefinitey */
 	.host_id_file = "/sys/devices/virtual/dmi/id/board_asset_tag", /* Available on EC2 instances and containers */
+	.use_sm2 = false,
 };
 
 /**
@@ -160,6 +161,7 @@ void rxr_env_param_get(void)
 			    &rxr_env.efa_read_segment_size);
 	fi_param_get_size_t(&efa_prov, "inter_max_gdrcopy_message_size",
 			    &rxr_env.efa_max_gdrcopy_msg_size);
+	fi_param_get_bool(&efa_prov, "use_sm2", &rxr_env.use_sm2);
 	efa_fork_support_request_initialize();
 }
 
@@ -228,6 +230,8 @@ void rxr_env_define()
 			"Enables fork support and disables internal usage of huge pages. Has no effect on kernels which set copy-on-fork for registered pages, generally 5.13 and later. (Default: false)");
 	fi_param_define(&efa_prov, "runt_size", FI_PARAM_INT,
 			"The maximum number of bytes that will be eagerly sent by inflight messages uses runting read message protocol (Default 307200).");
+	fi_param_define(&efa_prov, "use_sm2", FI_PARAM_BOOL,
+			"Use the experimental shared memory provider SM2 for intra node communication.");
 }
 
 

--- a/prov/efa/src/rdm/rxr_env.h
+++ b/prov/efa/src/rdm/rxr_env.h
@@ -100,6 +100,7 @@ struct rxr_env {
 	 * is malformatted, the program should proceed with a default host id, e.g. 0.
 	 */
 	char *host_id_file;
+	int use_sm2;
 };
 
 /**


### PR DESCRIPTION
Implement FI_EFA_USE_SM2 environment variable to switch between SHM and SM2.

This cannot merge until https://github.com/ofiwg/libfabric/pull/8808 b/c SM2 in main doesn't implement peer provider.

@sunkuamzn is on vacation, so this updates his changes here: https://github.com/ofiwg/libfabric/pull/8791