### PR TITLE
[v1.18.x] prov/shm: add iface parameter to smr_select_proto

### DIFF
--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -331,8 +331,8 @@ size_t smr_copy_from_sar(struct smr_freestack *sar_pool, struct smr_resp *resp,
 			 struct smr_cmd *cmd, struct ofi_mr **mr,
 			 const struct iovec *iov, size_t count,
 			 size_t *bytes_done, int *next);
-int smr_select_proto(bool use_ipc, bool cma_avail, uint32_t op,
-		     uint64_t total_len, uint64_t op_flags);
+int smr_select_proto(enum fi_hmem_iface, bool use_ipc, bool cma_avail, uint32_t op,
+                     uint64_t total_len, uint64_t op_flags);
 typedef ssize_t (*smr_proto_func)(struct smr_ep *ep, struct smr_region *peer_smr,
 		int64_t id, int64_t peer_id, uint32_t op, uint64_t tag,
 		uint64_t data, uint64_t op_flags, struct ofi_mr **desc,

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -634,13 +634,13 @@ static int smr_format_sar(struct smr_ep *ep, struct smr_cmd *cmd,
 	return 0;
 }
 
-int smr_select_proto(bool use_ipc, bool cma_avail,
-		     uint32_t op, uint64_t total_len, uint64_t op_flags)
+int smr_select_proto(enum fi_hmem_iface iface, bool use_ipc, bool cma_avail,
+                     uint32_t op, uint64_t total_len, uint64_t op_flags)
 {
 	if (op == ofi_op_read_req) {
 		if (use_ipc)
 			return smr_src_ipc;
-		if (cma_avail && FI_HMEM_SYSTEM)
+		if (cma_avail && FI_HMEM_SYSTEM == iface)
 			return smr_src_iov;
 		return smr_src_sar;
 	}

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -114,6 +114,7 @@ static ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 	bool use_ipc = false;
 	struct smr_cmd_entry *ce;
 	int64_t pos;
+	enum fi_hmem_iface iface = FI_HMEM_SYSTEM;
 
 	assert(iov_count <= SMR_IOV_LIMIT);
 	assert(rma_count <= SMR_IOV_LIMIT);
@@ -177,12 +178,13 @@ static ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 	 * transfer may occur if possible. */
 	if (iov_count == 1 && desc && desc[0]) {
 		smr_desc = (struct ofi_mr *) *desc;
-		use_ipc = ofi_hmem_is_ipc_enabled(((struct ofi_mr *) *desc)->iface) &&
+		iface = smr_desc->iface;
+		use_ipc = ofi_hmem_is_ipc_enabled(iface) &&
 				smr_desc->flags & FI_HMEM_DEVICE_ONLY &&
 				!(op_flags & FI_INJECT);
 	}
-	proto = smr_select_proto(use_ipc, smr_cma_enabled(ep, peer_smr), op,
-				 total_len, op_flags);
+	proto = smr_select_proto(iface, use_ipc, smr_cma_enabled(ep, peer_smr),
+	                         op, total_len, op_flags);
 
 	ret = smr_proto_ops[proto](ep, peer_smr, id, peer_id, op, 0, data,
 				   op_flags, (struct ofi_mr **)desc, iov,


### PR DESCRIPTION
Pass through hmem iface to proto selection logic.

This change re-enables CMA for read ops.

Signed-off-by: Wenduo Wang <wenduwan@amazon.com>
(cherry picked from commit 6b4ddb22f7c06a12a28903cb5370da6c1c727545)