### PR TITLE
mr/cache: Fix fi_mr_info initialization

### DIFF
--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -380,10 +380,8 @@ static int efa_mr_cache_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	struct efa_domain *domain;
 	struct efa_mr *efa_mr;
 	struct ofi_mr_entry *entry;
-	struct ofi_mr_info info;
+	struct ofi_mr_info info = {0};
 	int ret;
-
-	memset(&info, 0, sizeof(info));
 
 	if (attr->iface == FI_HMEM_NEURON || attr->iface == FI_HMEM_SYNAPSEAI)
 		flags |= OFI_MR_NOCACHE;

--- a/prov/opx/include/fi_opx_tid_cache.h
+++ b/prov/opx/include/fi_opx_tid_cache.h
@@ -84,8 +84,7 @@ static inline int opx_tid_cache_open_region(struct fi_opx_tid_domain *opx_tid_do
 	assert(opx_tid_domain && buf && len && p_opx_tid_mr);
 
 	struct ofi_mr_entry *entry = NULL;
-	struct ofi_mr_info info;
-	memset(&info, 0, sizeof(info));
+	struct ofi_mr_info info = {0};
 	opx_tid_cache_flush(opx_tid_domain, false);
 
 	info.iov.iov_base = (void *)buf;

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -168,8 +168,11 @@ static struct ofi_mr_entry *ofi_mr_rbt_overlap(struct ofi_rbmap *tree,
 					       const struct iovec *key)
 {
 	struct ofi_rbnode *node;
+	struct ofi_mr_info info = {0};
 
-	node = ofi_rbmap_search(tree, (void *) key,
+	info.iov = *key;
+
+	node = ofi_rbmap_search(tree, (void *) &info,
 				util_mr_find_overlap);
 	if (!node)
 		return NULL;
@@ -398,6 +401,7 @@ struct ofi_mr_entry *ofi_mr_cache_find(struct ofi_mr_cache *cache,
 	pthread_mutex_lock(&mm_lock);
 	cache->search_cnt++;
 
+	info.peer_id = 0;
 	info.iov = *attr->mr_iov;
 	entry = ofi_mr_rbt_find(&cache->tree, &info);
 	if (!entry) {

--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -278,11 +278,9 @@ vrb_mr_cache_reg(struct vrb_domain *domain, const void *buf, size_t len,
 	struct vrb_mem_desc *md;
 	struct ofi_mr_entry *entry;
 	struct fi_mr_attr attr;
-	struct ofi_mr_info info;
+	struct ofi_mr_info info = {0};
 	struct iovec iov;
 	int ret;
-
-	memset(&info, 0, sizeof(info));
 
 	attr.access = access;
 	attr.context = context;

--- a/src/hmem_ipc_cache.c
+++ b/src/hmem_ipc_cache.c
@@ -152,12 +152,10 @@ int ofi_ipc_cache_search(struct ofi_mr_cache *cache, uint64_t peer_id,
 			 struct ipc_info *ipc_info,
 			 struct ofi_mr_entry **mr_entry)
 {
-	struct ofi_mr_info info;
+	struct ofi_mr_info info = {0};
 	struct ofi_mr_entry *entry;
 	int ret;
 	size_t ipc_handle_size;
-
-	memset(&info, 0, sizeof(info));
 
 	info.iov.iov_base = (void *) (uintptr_t) ipc_info->base_addr;
 	info.iov.iov_len = ipc_info->base_length;


### PR DESCRIPTION
In the ofi_mr_rbt_overlap() function an iovec pointer is passed in as the key. However, it's then passed to util_mr_find_overlap() and assigned to an fi_mr_info pointer. This assumes that only the iovec pointer is accessed. With the addition of the peer_id check that is no longer true.

To avoid this situation allocate an fi_mr_info block on the stack, initialize the block to 0, copy in the iovec info, and pass it to the call to ofi_rbmap_search()