### PR TITLE
common: fix the cast of epoll_t to int when HAVE_EPOLL is not defined

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -1863,7 +1863,11 @@ static int
 ofi_dynpoll_get_fd_epoll(struct ofi_dynpoll *dynpoll)
 {
 	assert(dynpoll->type == OFI_DYNPOLL_EPOLL);
+#ifdef HAVE_EPOLL
 	return dynpoll->ep;
+#else
+	return INVALID_SOCKET; /* unsupported if not HAVE_EPOLL */
+#endif
 }
 
 static int


### PR DESCRIPTION
fixes #8847, obtained when compiling with clang-16 on a system not supporting epoll (no `HAVE_EPOLL`)

the logic behind `get_fd_epoll` is not clear to me when the system doesn't have `epoll`.
I guess it then becomes an invalid call (see the commit), but happy to change it to something else

