### PR TITLE
[v1.18.x] core, prov/efa: backport fixes for in-order aligned send/recv support

### DIFF
--- a/include/ofi.h
+++ b/include/ofi.h
@@ -328,6 +328,16 @@ static inline void *ofi_get_page_end(const void *addr, size_t page_size)
 			+ page_size, page_size) - 1);
 }
 
+static inline bool ofi_is_size_multiple(size_t size, size_t multiple)
+{
+	return ((size % multiple) == 0);
+}
+
+static inline bool ofi_is_addr_aligned(void *addr, size_t alignment)
+{
+	return ((((uintptr_t) addr) % alignment) == 0);
+}
+
 static inline size_t
 ofi_get_page_bytes(const void *addr, size_t len, size_t page_size)
 {

--- a/prov/efa/src/rdm/rxr.h
+++ b/prov/efa/src/rdm/rxr.h
@@ -80,6 +80,11 @@ static inline void rxr_poison_mem_region(void *ptr, size_t size)
 #endif
 
 /*
+ * The alignment to support in-order aligned ops.
+ */
+#define EFA_RDM_IN_ORDER_ALIGNMENT (128)
+
+/*
  * Set alignment to x86 cache line size.
  */
 #define RXR_BUF_POOL_ALIGNMENT	(64)

--- a/prov/efa/src/rdm/rxr.h
+++ b/prov/efa/src/rdm/rxr.h
@@ -80,6 +80,11 @@ static inline void rxr_poison_mem_region(void *ptr, size_t size)
 #endif
 
 /*
+ * The CUDA memory alignment
+ */
+#define EFA_RDM_CUDA_MEMORY_ALIGNMENT (64)
+
+/*
  * The alignment to support in-order aligned ops.
  */
 #define EFA_RDM_IN_ORDER_ALIGNMENT (128)

--- a/prov/efa/src/rdm/rxr_ep.c
+++ b/prov/efa/src/rdm/rxr_ep.c
@@ -1194,9 +1194,6 @@ static int rxr_ep_set_use_device_rdma(struct rxr_ep *ep, bool use_device_rdma)
 
 /**
  * @brief set sendrecv_in_order_aligned_128_bytes flag in rxr_ep
- * Supporting send/receive aligned 128 bytes buffer in order is more complicated than
- * supporting RDMA write. There is no plan to support it in the near future.
- * Therefore this function always returns -FI_EOPNOTSUPP if the user tries to enable it.
  *
  * @param[in,out]	ep					endpoint
  * @param[in]		sendrecv_in_order_aligned_128_bytes	whether to enable in_order send/recv
@@ -1207,7 +1204,12 @@ static
 int rxr_ep_set_sendrecv_in_order_aligned_128_bytes(struct rxr_ep *ep,
 						   bool sendrecv_in_order_aligned_128_bytes)
 {
-	if (sendrecv_in_order_aligned_128_bytes)
+	/*
+	 * RDMA read is used to copy data from host bounce buffer to the
+	 * application buffer on device
+	 */
+	if (sendrecv_in_order_aligned_128_bytes &&
+	    !efa_base_ep_support_op_in_order_aligned_128_bytes(&ep->base_ep, IBV_WR_RDMA_READ))
 		return -FI_EOPNOTSUPP;
 
 	ep->sendrecv_in_order_aligned_128_bytes = sendrecv_in_order_aligned_128_bytes;

--- a/prov/efa/src/rdm/rxr_ep.c
+++ b/prov/efa/src/rdm/rxr_ep.c
@@ -1411,6 +1411,7 @@ int rxr_ep_init(struct rxr_ep *ep)
 		RXR_PKT_FROM_EFA_TX_POOL,
 		rxr_get_tx_pool_chunk_cnt(ep),
 		rxr_get_tx_pool_chunk_cnt(ep), /* max count */
+		RXR_BUF_POOL_ALIGNMENT,
 		&ep->efa_tx_pkt_pool);
 	if (ret)
 		goto err_free;
@@ -1420,6 +1421,7 @@ int rxr_ep_init(struct rxr_ep *ep)
 		RXR_PKT_FROM_EFA_RX_POOL,
 		rxr_get_rx_pool_chunk_cnt(ep),
 		rxr_get_rx_pool_chunk_cnt(ep), /* max count */
+		RXR_BUF_POOL_ALIGNMENT,
 		&ep->efa_rx_pkt_pool);
 	if (ret)
 		goto err_free;
@@ -1430,6 +1432,7 @@ int rxr_ep_init(struct rxr_ep *ep)
 			RXR_PKT_FROM_UNEXP_POOL,
 			rxr_env.unexp_pool_chunk_size,
 			0, /* max count = 0, so pool is allowed to grow */
+			RXR_BUF_POOL_ALIGNMENT,
 			&ep->rx_unexp_pkt_pool);
 		if (ret)
 			goto err_free;
@@ -1441,6 +1444,7 @@ int rxr_ep_init(struct rxr_ep *ep)
 			RXR_PKT_FROM_OOO_POOL,
 			rxr_env.ooo_pool_chunk_size,
 			0, /* max count = 0, so pool is allowed to grow */
+			RXR_BUF_POOL_ALIGNMENT,
 			&ep->rx_ooo_pkt_pool);
 		if (ret)
 			goto err_free;
@@ -1454,6 +1458,7 @@ int rxr_ep_init(struct rxr_ep *ep)
 			RXR_PKT_FROM_READ_COPY_POOL,
 			rxr_env.readcopy_pool_size,
 			rxr_env.readcopy_pool_size, /* max count */
+			EFA_RDM_IN_ORDER_ALIGNMENT, /* support in-order aligned send/recv */
 			&ep->rx_readcopy_pkt_pool);
 		if (ret)
 			goto err_free;
@@ -1498,6 +1503,7 @@ int rxr_ep_init(struct rxr_ep *ep)
 			RXR_PKT_FROM_SHM_TX_POOL,
 			rxr_ep_domain(ep)->shm_info->tx_attr->size,
 			rxr_ep_domain(ep)->shm_info->tx_attr->size, /* max count */
+			RXR_BUF_POOL_ALIGNMENT,
 			&ep->shm_tx_pkt_pool);
 		if (ret)
 			goto err_free;
@@ -1507,6 +1513,7 @@ int rxr_ep_init(struct rxr_ep *ep)
 			RXR_PKT_FROM_SHM_RX_POOL,
 			rxr_ep_domain(ep)->shm_info->tx_attr->size,
 			rxr_ep_domain(ep)->shm_info->tx_attr->size, /* max count */
+			RXR_BUF_POOL_ALIGNMENT,
 			&ep->shm_rx_pkt_pool);
 		if (ret)
 			goto err_free;

--- a/prov/efa/src/rdm/rxr_pkt_entry.c
+++ b/prov/efa/src/rdm/rxr_pkt_entry.c
@@ -47,6 +47,7 @@
 #include "rxr_op_entry.h"
 #include "rxr_pkt_cmd.h"
 #include "rxr_pkt_pool.h"
+#include "rxr_pkt_type_req.h"
 
 /**
  * @brief allocate a packet entry
@@ -201,6 +202,8 @@ void rxr_pkt_entry_copy(struct rxr_ep *ep,
 			struct rxr_pkt_entry *dest,
 			struct rxr_pkt_entry *src)
 {
+	size_t src_pkt_offset;
+
 	EFA_DBG(FI_LOG_EP_CTRL,
 	       "Copying packet out of posted buffer! src_entry_alloc_type: %d desc_entry_alloc_type: %d\n",
 		src->alloc_type, dest->alloc_type);
@@ -213,12 +216,24 @@ void rxr_pkt_entry_copy(struct rxr_ep *ep,
 	 * not be changed.
 	 */
 	dest->x_entry = src->x_entry;
-	dest->pkt_size = src->pkt_size;
+	/* Pkt from read-copy pkt pool is only used for staging data
+	 * that will be copied to application buffer via rdma-read,
+	 * so it does not need to store anything other than application
+	 * data in its wiredata. Therefore, we copy the actual data
+	 * from src_pkt to the beginning of dest_pkt->wiredata.
+	 */
+	if (dest->alloc_type == RXR_PKT_FROM_READ_COPY_POOL) {
+		src_pkt_offset = rxr_pkt_req_data_offset(src);
+		dest->pkt_size = src->pkt_size - src_pkt_offset;
+	} else {
+		src_pkt_offset = 0;
+		dest->pkt_size = src->pkt_size;
+	}
 	dest->addr = src->addr;
 	dest->flags = RXR_PKT_ENTRY_IN_USE;
 	dest->next = NULL;
-	assert(src->pkt_size > 0);
-	memcpy(dest->wiredata, src->wiredata, src->pkt_size);
+	assert(dest->pkt_size > 0);
+	memcpy(dest->wiredata, src->wiredata + src_pkt_offset, dest->pkt_size);
 }
 
 /**

--- a/prov/efa/src/rdm/rxr_pkt_entry.h
+++ b/prov/efa/src/rdm/rxr_pkt_entry.h
@@ -157,7 +157,7 @@ struct rxr_pkt_entry {
 #if ENABLE_DEBUG
 	/** @brief entry to a linked list of posted buf list */
 	struct dlist_entry dbg_entry;
-	uint8_t pad[48];
+	uint8_t pad[112];
 #endif
 	/** @brief pointer to #rxr_op_entry or #rxr_read_entry */
 	void *x_entry;
@@ -240,7 +240,7 @@ struct rxr_pkt_entry {
 
 #if defined(static_assert) && defined(__x86_64__)
 #if ENABLE_DEBUG
-static_assert(sizeof(struct rxr_pkt_entry) == 192, "rxr_pkt_entry check");
+static_assert(sizeof(struct rxr_pkt_entry) == 256, "rxr_pkt_entry check");
 #else
 static_assert(sizeof(struct rxr_pkt_entry) == 128, "rxr_pkt_entry check");
 #endif

--- a/prov/efa/src/rdm/rxr_pkt_pool.c
+++ b/prov/efa/src/rdm/rxr_pkt_pool.c
@@ -93,16 +93,22 @@ size_t rxr_pkt_pool_mr_flags()
 	return OFI_BUFPOOL_HUGEPAGES;
 }
 
-/*
- * rxr_pkt_pool_create creates a packet pool. The pool is allowed to grow if
+/**
+ * @brief rxr_pkt_pool_create creates a packet pool. The pool is allowed to grow if
  * max_cnt is 0 and is fixed size otherwise.
  *
- * Important arguments:
- * 	    mr: whether memory registration for the wiredata pool is required
+ * @param ep rxr_ep
+ * @param pkt_pool_type type of pkt pool
+ * @param chunk_cnt count of chunks in the pool
+ * @param max_cnt maximal count of chunks
+ * @param alignment memory alignment
+ * @param pkt_pool pkt pool
+ * @return int 0 on success, a negative integer on failure
  */
 int rxr_pkt_pool_create(struct rxr_ep *ep,
 			enum rxr_pkt_entry_alloc_type pkt_pool_type,
 			size_t chunk_cnt, size_t max_cnt,
+			size_t alignment,
 			struct rxr_pkt_pool **pkt_pool)
 {
 	int ret;
@@ -114,7 +120,7 @@ int rxr_pkt_pool_create(struct rxr_ep *ep,
 
 	struct ofi_bufpool_attr wiredata_attr = {
 		.size = sizeof(struct rxr_pkt_entry) + ep->mtu_size,
-		.alignment = RXR_BUF_POOL_ALIGNMENT,
+		.alignment = alignment,
 		.max_cnt = max_cnt,
 		.chunk_cnt = chunk_cnt,
 		.alloc_fn = RXR_PKT_POOL_INF_LIST[pkt_pool_type].reg_memory ? rxr_pkt_pool_mr_reg_hndlr : NULL,

--- a/prov/efa/src/rdm/rxr_pkt_pool.h
+++ b/prov/efa/src/rdm/rxr_pkt_pool.h
@@ -49,6 +49,7 @@ struct rxr_pkt_pool {
 int rxr_pkt_pool_create(struct rxr_ep *ep,
 			enum rxr_pkt_entry_alloc_type pkt_pool_type,
 			size_t chunk_cnt, size_t max_cnt,
+			size_t alignment,
 			struct rxr_pkt_pool **pkt_pool);
 
 int rxr_pkt_pool_grow(struct rxr_pkt_pool *rxr_pkt_pool);

--- a/prov/efa/src/rdm/rxr_pkt_type_base.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_base.c
@@ -402,6 +402,12 @@ int rxr_pkt_copy_data_to_cuda(struct rxr_ep *ep,
 	cuda_memcpy_available = ep->cuda_api_permitted;
 	gdrcopy_available = desc->peer.use_gdrcopy;
 
+	/* For in-order aligned send/recv, only allow local read to be used to copy data */
+	if (ep->sendrecv_in_order_aligned_128_bytes) {
+		cuda_memcpy_available = false;
+		gdrcopy_available = false;
+	}
+
 	if (!local_read_available && !gdrcopy_available && !cuda_memcpy_available) {
 		EFA_WARN(FI_LOG_CQ, "None of the copy methods: localread, gdrcopy or cudaMemcpy is available,"
 			"thus libfabric is not able to copy received data to Nvidia GPU");

--- a/prov/efa/src/rdm/rxr_pkt_type_base.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_base.c
@@ -202,6 +202,15 @@ size_t rxr_pkt_data_size(struct rxr_pkt_entry *pkt_entry)
 	int pkt_type;
 
 	assert(pkt_entry);
+
+	/*
+	 * pkt entry from read copy pool only stores actual
+	 * application data in pkt_entry->wiredata, so its
+	 * data_size is just pkt_entry->pkt_size.
+	 */
+	if (pkt_entry->alloc_type == RXR_PKT_FROM_READ_COPY_POOL)
+		return pkt_entry->pkt_size;
+
 	pkt_type = rxr_get_base_hdr(pkt_entry->wiredata)->type;
 
 	if (pkt_type == RXR_DATA_PKT)

--- a/prov/efa/src/rdm/rxr_pkt_type_req.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_req.c
@@ -480,7 +480,6 @@ int rxr_pkt_init_rtm(struct rxr_ep *ep,
 	size_t data_size;
 	struct rxr_rtm_base_hdr *rtm_hdr;
 	int ret;
-	static const size_t CUDA_MEMORY_ALIGNMENT = 64;
 
 	rxr_pkt_init_req_hdr(ep, tx_entry, pkt_type, pkt_entry);
 
@@ -495,8 +494,12 @@ int rxr_pkt_init_rtm(struct rxr_ep *ep,
 		if (tx_entry->max_req_data_size > 0)
 			data_size = MIN(data_size, tx_entry->max_req_data_size);
 
-		if (efa_mr_is_cuda(tx_entry->desc[0]))
-			data_size &= ~(CUDA_MEMORY_ALIGNMENT -1);
+		if (efa_mr_is_cuda(tx_entry->desc[0])) {
+			if (ep->sendrecv_in_order_aligned_128_bytes)
+				data_size &= ~(EFA_RDM_IN_ORDER_ALIGNMENT - 1);
+			else
+				data_size &= ~(EFA_RDM_CUDA_MEMORY_ALIGNMENT -1);
+		}
 	}
 
 

--- a/prov/efa/src/rdm/rxr_pkt_type_req.h
+++ b/prov/efa/src/rdm/rxr_pkt_type_req.h
@@ -62,6 +62,8 @@ size_t rxr_pkt_req_max_hdr_size(int pkt_type);
 
 size_t rxr_pkt_max_hdr_size(void);
 
+size_t rxr_pkt_req_data_offset(struct rxr_pkt_entry *pkt_entry);
+
 static inline
 struct rxr_rtm_base_hdr *rxr_get_rtm_base_hdr(void *pkt)
 {


### PR DESCRIPTION
This PR backports https://github.com/ofiwg/libfabric/pull/8841 to v1.18.x. It also backports this core change https://github.com/ofiwg/libfabric/pull/8829 as a dependency.