### PR TITLE
prov/verbs: Recover RXM connection from verbs QP in error state

### DIFF
--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -253,6 +253,8 @@ int vrb_poll_cq(struct vrb_cq *cq, struct ibv_wc *wc)
 
 		ctx = (struct vrb_context *) (uintptr_t) wc->wr_id;
 		wc->wr_id = (uintptr_t) ctx->user_ctx;
+		if (wc->status != IBV_WC_SUCCESS)
+			vrb_shutdown_qp_in_err(ctx->ep);
 		if (ctx->op_queue == VRB_OP_SQ) {
 			ep = ctx->ep;
 			assert(ep);
@@ -272,7 +274,6 @@ int vrb_poll_cq(struct vrb_cq *cq, struct ibv_wc *wc)
 			(void) slist_remove_head(&ep->rq_list);
 			if (wc->status)
 				wc->opcode = IBV_WC_RECV;
-
 		} else {
 			assert(ctx->op_queue == VRB_OP_SRQ);
 			wc->opcode = IBV_WC_RECV;

--- a/prov/verbs/src/verbs_ofi.h
+++ b/prov/verbs/src/verbs_ofi.h
@@ -928,6 +928,7 @@ do {								\
 	( wr->opcode == IBV_WR_SEND || wr->opcode == IBV_WR_SEND_WITH_IMM	\
 	|| wr->opcode == IBV_WR_RDMA_WRITE_WITH_IMM )
 
+void vrb_shutdown_qp_in_err(struct vrb_ep *ep);
 ssize_t vrb_post_send(struct vrb_ep *ep, struct ibv_send_wr *wr, uint64_t flags);
 ssize_t vrb_post_recv(struct vrb_ep *ep, struct ibv_recv_wr *wr);
 


### PR DESCRIPTION
Verbs QP can transition to error state for number of reasons such as retransmission time out or protection error, rendering RXM connection unusable until QP is back in RTS state.  Since not all RDMA adapters can transition a QP from error state back to RTS, the solution is to destroy the QP and create a new one on subsequent use.

On a completion with error status, check current QP state (expensive) against error state. Write a FI_SHUTDOWN event to event queue for RXM to process and close the connection.  When a new request to use the connection, a new QP will be created.