### PR TITLE
fabtests/rdm_tagged_peek: fix race condition synchronization

### DIFF
--- a/fabtests/functional/rdm_tagged_peek.c
+++ b/fabtests/functional/rdm_tagged_peek.c
@@ -309,34 +309,13 @@ static int run(void)
 		ret = do_recvs();
 		if (ret)
 			return ret;
-
-		/* sync with sender before ft_finalize, since we sent
-		 * and received messages outside of the sequence numbers
-		 * maintained by common code */
-		do {
-			ret = fi_tsend(ep, tx_buf, 1, mr_desc,
-					remote_fi_addr, 0xabc,
-					&tx_ctx_arr[0].context);
-		} while (ret == -FI_EAGAIN);
-		if (ret)
-			return ret;
-
-		ret = wait_for_send_comp(1);
-		if (ret)
-			return ret;
 	} else {
 		ret = do_sends();
 		if (ret)
 			return ret;
-
-		ret = trecv_op(0xabc, 0, false);
-		if (ret) {
-			FT_PRINTERR("Receive sync", ret);
-			return ret;
-		}
 	}
 
-	ft_finalize();
+	ft_sync();
 	return 0;
 }
 
@@ -345,7 +324,7 @@ int main(int argc, char **argv)
 	int ret, op;
 
 	opts = INIT_OPTS;
-	opts.options |= FT_OPT_SIZE;
+	opts.options |= FT_OPT_SIZE | FT_OPT_OOB_SYNC;
 	opts.transfer_size = 64;  /* Don't expect receiver buffering */
 	opts.window_size = SEND_CNT;
 

--- a/fabtests/test_configs/sockets/sockets.exclude
+++ b/fabtests/test_configs/sockets/sockets.exclude
@@ -5,6 +5,3 @@
 -e dgram
 dgram
 multinode_coll
-# This test fails for sockets provider randomly,
-# temporarily skip this test before the issue is fixed.
-rdm_tagged_peek


### PR DESCRIPTION
It was possible for the client to complete the finalize send before the server gets the last 0xabc completion, causing a tag mismatch when processing the incorrect receive.

This removes the extra synchronization sends and adds an OOB sync to make sure all of the test sends have finished before quitting the test.