### PR TITLE
prov/efa: cleanup configure.m4

### DIFF
--- a/prov/efa/configure.m4
+++ b/prov/efa/configure.m4
@@ -8,13 +8,9 @@ dnl $1: action if configured successfully
 dnl $2: action if not configured successfully
 dnl
 AC_DEFUN([FI_EFA_CONFIGURE],[
-	# Determine if we can support the efa provider
+	dnl Determine if we can support the efa provider
 	efa_happy=0
 	efa_h_enable_poisoning=0
-	# Determine if efa device supports extensible CQ with access to additional fields from WC
-	efadv_support_extended_cq=1
-	# Determine if efa device support in-order write at 128 bytes aligned boundary.
-	efa_support_data_in_order_aligned_128_byte=1
 
 	AS_IF([test x"$enable_efa" != x"no"],
 	      [FI_CHECK_PACKAGE([efa_ibverbs],
@@ -45,146 +41,116 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 	      [AC_MSG_RESULT([no])
 	       efa_happy=0])
 
-	AS_IF([test x"$enable_efa" != x"no"],
-	      [FI_CHECK_PACKAGE([efadv],
-				[infiniband/efadv.h],
-				[efa],
-				[efadv_query_ah],
-				[-libverbs],
-				[$efa_PREFIX],
-				[$efa_LIBDIR],
-				[efa_happy=1],
-				[
-					efa_happy=0
-					AC_MSG_WARN([The EFA provider requires rdma-core v31 or newer.])
-				])
-	      ])
+	AS_IF([test x"$enable_efa" != x"no"], [
+		efa_happy=1
+		efadv_support_extended_cq=1
 
-	AS_IF([test x"$enable_efa" != x"no"],
-	      [FI_CHECK_PACKAGE([efadv],
-				[infiniband/efadv.h],
-				[efa],
-				[efadv_query_device],
-				[-libverbs],
-				[$efa_PREFIX],
-				[$efa_LIBDIR],
-				[efa_happy=1],
-				[efa_happy=0])
-	      ])
-
-	save_CPPFLAGS=$CPPFLAGS
-	CPPFLAGS=-I$efa_PREFIX/include
-	AS_IF([test x"$enable_efa" != x"no"],
-	      [AC_CHECK_MEMBER(struct efadv_device_attr.max_rdma_size,
-			      [AC_DEFINE([HAVE_RDMA_SIZE], [1], [efadv_device_attr has max_rdma_size])],
-			      [AC_DEFINE([HAVE_RDMA_SIZE], [0], [efadv_device_attr does not have max_rdma_size])],
-			      [[#include <infiniband/efadv.h>]])
-	      ])
-
-	AS_IF([test x"$enable_efa" != x"no"],
-	      [AC_CHECK_DECL(EFADV_DEVICE_ATTR_CAPS_RNR_RETRY,
-			    [AC_DEFINE([HAVE_CAPS_RNR_RETRY], [1], [EFADV_DEVICE_ATTR_CAPS_RNR_RETRY is defined])],
-			    [AC_DEFINE([HAVE_CAPS_RNR_RETRY], [0], [EFADV_DEVICE_ATTR_CAPS_RNR_RETRY is not defined])],
-			    [[#include <infiniband/efadv.h>]])
-	      ])
-
-	AS_IF([test x"$enable_efa" != x"no"],
-	      [AC_CHECK_DECL(EFADV_DEVICE_ATTR_CAPS_RDMA_WRITE,
-			    [AC_DEFINE([HAVE_CAPS_RDMA_WRITE], [1], [EFADV_DEVICE_ATTR_CAPS_RDMA_WRITE is defined])],
-			    [AC_DEFINE([HAVE_CAPS_RDMA_WRITE], [0], [EFADV_DEVICE_ATTR_CAPS_RDMA_WRITE is not defined])],
-			    [[#include <infiniband/efadv.h>]])
-	      ])
-
-	dnl Check for ibv_is_fork_initialized() in libibverbs
-	have_ibv_is_fork_initialized=0
-	AS_IF([test $efa_happy -eq 1],
-		[AC_CHECK_DECL([ibv_is_fork_initialized],
-			[have_ibv_is_fork_initialized=1],
+		FI_CHECK_PACKAGE([efadv],
+			[infiniband/efadv.h],
+			[efa],
+			[efadv_query_ah],
+			[-libverbs],
+			[$efa_PREFIX],
+			[$efa_LIBDIR],
 			[],
-			[[#include <infiniband/verbs.h>]])
-		])
+			[
+				efa_happy=0
+				AC_MSG_WARN([The EFA provider requires rdma-core v31 or newer.])
+			])
 
-	AC_DEFINE_UNQUOTED([HAVE_IBV_IS_FORK_INITIALIZED],
-		[$have_ibv_is_fork_initialized],
-		[Define to 1 if libibverbs has ibv_is_fork_initialized])
-
-	dnl Check for ibv_reg_dmabuf_mr() in libibverbs if built with synapseai support.
-	AS_IF([test $efa_happy -eq 1 && test $have_synapseai -eq 1],[
-		AC_CHECK_DECL([ibv_reg_dmabuf_mr],
-		[],
-		[AC_MSG_ERROR(
-			[ibv_reg_dmabuf_mr is required by synapseai but not available 
-			 in the current rdma-core library. Please build libfabric with
-			 rdma-core >= v34.0])],
-		[[#include <infiniband/verbs.h>]])
-		])
-
-	AS_IF([test "$enable_efa" = "no"], [efa_happy=0])
-
-	AS_IF([test $ac_cv_sizeof_void_p -eq 4],
-		[
+		AS_IF([test $ac_cv_sizeof_void_p -eq 4], [
 			efa_happy=0
 			AC_MSG_WARN([The EFA provider is not supported on 32-bit systems.])
 		])
+	])
 
-	AS_IF([test $efa_happy -eq 1 ], [$1], [$2])
+	save_CPPFLAGS=$CPPFLAGS
+	AS_IF([test -n "$efa_PREFIX"], [CPPFLAGS="$CPPFLAGS -I$efa_PREFIX/include"])
 
-	AS_IF([test $efadv_support_extended_cq -eq 1],
-		[FI_CHECK_PACKAGE([efadv],
-			[infiniband/efadv.h],
-			[efa],
-			[efadv_create_cq],
-			[-libverbs],
-			[$efa_PREFIX],
-			[$efa_LIBDIR],
-			[],
-			[efadv_support_extended_cq=0])
-	      ])
+	dnl define these defaults for when efa_happy is 0
+	have_rdma_size=0
+	have_caps_rnr_retry=0
+	have_caps_rdma_write=0
+	have_ibv_is_fork_initialized=0
+	efa_support_data_in_order_aligned_128_byte=0
+	efadv_support_extended_cq=0
 
-	AS_IF([test $efadv_support_extended_cq -eq 1],
-		[FI_CHECK_PACKAGE([efadv],
-			[infiniband/efadv.h],
-			[efa],
-			[efadv_cq_from_ibv_cq_ex],
-			[-libverbs],
-			[$efa_PREFIX],
-			[$efa_LIBDIR],
-			[],
-			[efadv_support_extended_cq=0])
-	      ])
+	dnl $have_neuron is defined at top-level configure.ac
+	AM_CONDITIONAL([HAVE_NEURON], [ test x"$have_neuron" = x1 ])
 
-	# efadv_wc_read_sgid is a static inline function, which is
-	# required to use extended CQ for recovering peer address.
-	# Extended CQ should be disabled if it is not available.
-	AS_IF([test $efadv_support_extended_cq -eq 1],
-		[AC_EGREP_HEADER(
-			[int efadv_wc_read_sgid],
-			[infiniband/efadv.h],
-			[],
-			[efadv_support_extended_cq=0])
+	AS_IF([test x"$efa_happy" = x"1"], [
+		AC_CHECK_MEMBER(struct efadv_device_attr.max_rdma_size,
+			[have_rdma_size=1],
+			[have_rdma_size=0],
+			[[#include <infiniband/efadv.h>]])
+
+		AC_CHECK_DECL(EFADV_DEVICE_ATTR_CAPS_RNR_RETRY,
+			[have_caps_rnr_retry=1],
+			[have_caps_rnr_retry=0],
+			[[#include <infiniband/efadv.h>]])
+
+		AC_CHECK_DECL(EFADV_DEVICE_ATTR_CAPS_RDMA_WRITE,
+			[have_caps_rdma_write=1],
+			[have_caps_rdma_write=0],
+			[[#include <infiniband/efadv.h>]])
+
+		AC_CHECK_DECL([ibv_is_fork_initialized],
+			[have_ibv_is_fork_initialized=1],
+			[have_ibv_is_fork_initialized=0],
+			[[#include <infiniband/verbs.h>]])
+
+		AC_CHECK_DECL([IBV_QUERY_QP_DATA_IN_ORDER_ALIGNED_128_BYTES],
+			[efa_support_data_in_order_aligned_128_byte=1],
+			[efa_support_data_in_order_aligned_128_byte=0],
+			[[#include <infiniband/verbs.h>]])
+
+		dnl Check for ibv_reg_dmabuf_mr() in libibverbs if built with synapseai support.
+		AS_IF([test x"$have_synapseai" = x"1"],[
+			AC_CHECK_DECL([ibv_reg_dmabuf_mr],
+				[],
+				[AC_MSG_ERROR(
+					[ibv_reg_dmabuf_mr is required by synapseai but not available
+					in the current rdma-core library. Please build libfabric with
+					rdma-core >= v34.0])],
+				[[#include <infiniband/verbs.h>]])
 		])
 
-	AS_IF([test $efadv_support_extended_cq -eq 1],
-		[AC_DEFINE([HAVE_EFADV_CQ_EX], [1], [EFA device support extensible CQ])],
-		[AC_DEFINE([HAVE_EFADV_CQ_EX], [0], [EFA device does not support extensible CQ])]
-		)
-
-	AM_CONDITIONAL([HAVE_EFADV_CQ_EX], [test $efadv_support_extended_cq -eq 1])
-
-	# IBV_QUERY_QP_DATA_IN_ORDER_ALIGNED_128_BYTES is the flag we need test,
-	# but it is flag. If it is not there, we should disable it.
-	AS_IF([test $efa_support_data_in_order_aligned_128_byte -eq 1],
-		[AC_EGREP_HEADER(
-			[IBV_QUERY_QP_DATA_IN_ORDER_ALIGNED_128_BYTES],
-			[infiniband/verbs.h],
+		dnl For efadv_support_extended_cq, we check several things,
+		dnl and if any of them fail, we disable CQ_EX
+		efadv_support_extended_cq=1
+		AC_CHECK_DECL([efadv_create_cq],
 			[],
-			[efa_support_data_in_order_aligned_128_byte=0])
-		])
+			[efadv_support_extended_cq=0],
+			[[#include <infiniband/efadv.h>]])
+		AC_CHECK_DECL([efadv_cq_from_ibv_cq_ex],
+			[],
+			[efadv_support_extended_cq=0],
+			[[#include <infiniband/efadv.h>]])
+		AC_CHECK_DECL([efadv_wc_read_sgid],
+			[],
+			[efadv_support_extended_cq=0],
+			[[#include <infiniband/efadv.h>]])
+	])
 
-	AS_IF([test $efa_support_data_in_order_aligned_128_byte -eq 1],
-		[AC_DEFINE([HAVE_EFA_DATA_IN_ORDER_ALIGNED_128_BYTES], [1], [EFA device supports 128 bytes in-order in writing.])],
-		[AC_DEFINE([HAVE_EFA_DATA_IN_ORDER_ALIGNED_128_BYTES], [0], [EFA device does not support 128 bytes in-order in writing.])]
-		)
+	AC_DEFINE_UNQUOTED([HAVE_RDMA_SIZE],
+		[$have_rdma_size],
+		[Indicates if efadv_device_attr has max_rdma_size])
+	AC_DEFINE_UNQUOTED([HAVE_CAPS_RNR_RETRY],
+		[$have_caps_rnr_retry],
+		[Indicates if EFADV_DEVICE_ATTR_CAPS_RNR_RETRY is defined])
+	AC_DEFINE_UNQUOTED([HAVE_CAPS_RDMA_WRITE],
+		[$have_caps_rdma_write],
+		[Indicates if EFADV_DEVICE_ATTR_CAPS_RDMA_WRITE is defined])
+	AC_DEFINE_UNQUOTED([HAVE_IBV_IS_FORK_INITIALIZED],
+		[$have_ibv_is_fork_initialized],
+		[Indicates if libibverbs has ibv_is_fork_initialized])
+	AC_DEFINE_UNQUOTED([HAVE_EFADV_CQ_EX],
+		[$efadv_support_extended_cq],
+		[Indicates EFA supports extensible CQ])
+	AC_DEFINE_UNQUOTED([HAVE_EFA_DATA_IN_ORDER_ALIGNED_128_BYTES],
+		[$efa_support_data_in_order_aligned_128_byte],
+		[Indicates if EFA supports 128 bytes in-order in writing.])
+
 
 	CPPFLAGS=$save_CPPFLAGS
 	efa_CPPFLAGS="$efa_ibverbs_CPPFLAGS $efadv_CPPFLAGS"
@@ -192,48 +158,43 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 	efa_LIBS="$efa_ibverbs_LIBS $efadv_LIBS"
 	cmocka_rpath=""
 	AC_ARG_ENABLE([efa-unit-test],
-		[AS_HELP_STRING([--enable-efa-unit-test=CMOCKA_INSTALL_DIR],
+		[
+			AS_HELP_STRING([--enable-efa-unit-test=CMOCKA_INSTALL_DIR],
 				[Provide a path to the CMocka installation directory
-				 in order to enable EFA Unit Tests.])])
+				in order to enable EFA Unit Tests.])
+		],
+		[cmocka_dir=$enableval],
+		[enable_efa_unit_test=no])
 
-	cmocka_dir=""
-	if [test x"$enable_efa_unit_test" = x"yes"]; then
-		cmocka_dir=""
-	else
-		cmocka_dir="$enable_efa_unit_test"
-	fi
-
-	if [ test x"$enable_efa_unit_test" != x"" && test x"$enable_efa_unit_test" != x"no" ]; then
+	AS_IF([test x"$enable_efa_unit_test" != xno ],
+	[
+		efa_unit_test=1
 		FI_CHECK_PACKAGE(cmocka,
-						 [cmocka.h],
-						 [cmocka],
-						 [_expect_any],
-						 [],
-						 [$cmocka_dir],
-						 [],
-						 [
-							efa_LIBS+=" $cmocka_LDFLAGS $cmocka_LIBS -static"
-							AC_DEFINE([EFA_UNIT_TEST], [1], [EFA unit testing])
-						 ],
-					 	 [
-							AC_DEFINE([EFA_UNIT_TEST], [0], [EFA unit testing])
-							AC_MSG_ERROR([Cannot compile EFA unit tests without a valid Cmocka installation directory.])
-					 	 ],
-						 [
-							#include <stdarg.h>
-							#include <stddef.h>
-							#include <stdint.h>
-							#include <setjmp.h>
-					 	 ])
-        if [ test x"$cmocka_dir" != x""]; then
-            cmocka_rpath+=" -R${cmocka_LDFLAGS:3} "
-        fi
-	else
-		AC_DEFINE([EFA_UNIT_TEST], [0], [EFA unit testing])
-	fi
+			[cmocka.h],
+			[cmocka],
+			[_expect_any],
+			[],
+			[$cmocka_dir],
+			[],
+			[efa_LIBS+=" $cmocka_LDFLAGS $cmocka_LIBS -static"],
+			[AC_MSG_ERROR([Cannot compile EFA unit tests without a valid Cmocka installation directory.])],
+			[
+				#include <stdarg.h>
+				#include <stddef.h>
+				#include <stdint.h>
+				#include <setjmp.h>
+			])
+		cmocka_rpath+=" -R${cmocka_LDFLAGS:3} "
+	],
+	[
+		efa_unit_test=0
+	])
 
-	AM_CONDITIONAL([ENABLE_EFA_UNIT_TEST], [ test x"$enable_efa_unit_test" != x"" && test x"$enable_efa_unit_test" != x"no" ])
-	AM_CONDITIONAL([HAVE_NEURON], [ test "$have_neuron" = "1" ])
+	AC_SUBST(cmocka_rpath)
+	AC_DEFINE_UNQUOTED([EFA_UNIT_TEST], [$efa_unit_test], [EFA unit testing])
+
+	AM_CONDITIONAL([HAVE_EFADV_CQ_EX], [ test $efadv_support_extended_cq = 1])
+	AM_CONDITIONAL([ENABLE_EFA_UNIT_TEST], [ test x"$enable_efa_unit_test" != xno])
 
 	AC_SUBST(efa_CPPFLAGS)
 	AC_SUBST(efa_LDFLAGS)


### PR DESCRIPTION
Address some conflicting styles and inconsistent macro usage in
configure.m4.

This commit doesn't have impactful changes for efa configuration.