### PR TITLE
prov/shm: no-op logic to toggle data transfer protocol for gdrcopy

### DIFF
--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -73,6 +73,7 @@ struct smr_env {
 	size_t sar_threshold;
 	int disable_cma;
 	int use_dsa_sar;
+	size_t max_gdrcopy_size;
 };
 
 extern struct smr_env smr_env;
@@ -330,8 +331,9 @@ size_t smr_copy_from_sar(struct smr_freestack *sar_pool, struct smr_resp *resp,
 			 struct smr_cmd *cmd, struct ofi_mr **mr,
 			 const struct iovec *iov, size_t count,
 			 size_t *bytes_done, int *next);
-int smr_select_proto(enum fi_hmem_iface, bool use_ipc, bool cma_avail, uint32_t op,
-                     uint64_t total_len, uint64_t op_flags);
+int smr_select_proto(enum fi_hmem_iface, bool use_ipc, bool cma_avail,
+                     bool gdrcopy_avail, uint32_t op, uint64_t total_len,
+                     uint64_t op_flags);
 typedef ssize_t (*smr_proto_func)(struct smr_ep *ep, struct smr_region *peer_smr,
 		int64_t id, int64_t peer_id, uint32_t op, uint64_t tag,
 		uint64_t data, uint64_t op_flags, struct ofi_mr **desc,

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -635,8 +635,13 @@ static int smr_format_sar(struct smr_ep *ep, struct smr_cmd *cmd,
 }
 
 int smr_select_proto(enum fi_hmem_iface iface, bool use_ipc, bool cma_avail,
-                     uint32_t op, uint64_t total_len, uint64_t op_flags)
+                     bool gdrcopy_avail, uint32_t op, uint64_t total_len,
+                     uint64_t op_flags)
 {
+	/* TODO: Move gdrcopy check out of non-cuda fast paths */
+	if (gdrcopy_avail && total_len <= smr_env.max_gdrcopy_size)
+		return total_len <= SMR_MSG_DATA_LEN ? smr_src_inline : smr_src_inject;
+
 	if (op == ofi_op_read_req) {
 		if (use_ipc)
 			return smr_src_ipc;

--- a/prov/shm/src/smr_init.c
+++ b/prov/shm/src/smr_init.c
@@ -44,6 +44,7 @@ struct smr_env smr_env = {
 	.sar_threshold = SIZE_MAX,
 	.disable_cma = false,
 	.use_dsa_sar = false,
+	.max_gdrcopy_size = 3072,
 };
 
 static void smr_init_env(void)

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -280,7 +280,7 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 	int64_t id, peer_id;
 	ssize_t ret = 0;
 	size_t total_len;
-	bool use_ipc = false;
+	bool use_ipc = false, gdrcopy_available = false;
 	int proto;
 	struct smr_cmd_entry *ce;
 	int64_t pos;
@@ -317,7 +317,7 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 				!(op_flags & FI_INJECT);
 	}
 	proto = smr_select_proto(iface, use_ipc, smr_cma_enabled(ep, peer_smr),
-	                         op, total_len, op_flags);
+	                         gdrcopy_available, op, total_len, op_flags);
 
 	ret = smr_proto_ops[proto](ep, peer_smr, id, peer_id, op, tag, data, op_flags,
 				   (struct ofi_mr **)desc, iov, iov_count, total_len,

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -111,7 +111,7 @@ static ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 	int cmds, err = 0, proto = smr_src_inline;
 	ssize_t ret = 0;
 	size_t total_len;
-	bool use_ipc = false;
+	bool use_ipc = false, gdrcopy_available = false;
 	struct smr_cmd_entry *ce;
 	int64_t pos;
 	enum fi_hmem_iface iface = FI_HMEM_SYSTEM;
@@ -184,7 +184,7 @@ static ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 				!(op_flags & FI_INJECT);
 	}
 	proto = smr_select_proto(iface, use_ipc, smr_cma_enabled(ep, peer_smr),
-	                         op, total_len, op_flags);
+	                         gdrcopy_available, op, total_len, op_flags);
 
 	ret = smr_proto_ops[proto](ep, peer_smr, id, peer_id, op, 0, data,
 				   op_flags, (struct ofi_mr **)desc, iov,


### PR DESCRIPTION
This patch introduces the no-op logic to switch data transfer protocol based on the availability of gdrcopy, and data size.

For small data sizes, gdrcopy offers better performance than cudaMemcpy. Based on experiments, we have selected 3kb as the threshold.

Note that, gdrcopy is claimed to offer asymmetric H2D/D2H performance, and for larger messages it could be slower than cudaMemcpy. However, here we make a simplification based on our experiments, and use only one threshold for both H2D/D2H copies.