### PR TITLE
prov/sm2: Use FI_NAME_MAX for names

### DIFF
--- a/prov/sm2/src/sm2.h
+++ b/prov/sm2/src/sm2.h
@@ -121,7 +121,7 @@ struct sm2_xfer_entry {
 } __attribute__((aligned(16)));
 
 struct sm2_ep_name {
-	char name[SM2_NAME_MAX];
+	char name[FI_NAME_MAX];
 	struct sm2_region *region;
 	struct dlist_entry entry;
 };

--- a/prov/sm2/src/sm2_av.c
+++ b/prov/sm2/src/sm2_av.c
@@ -150,7 +150,7 @@ static int sm2_av_lookup(struct fid_av *av, fi_addr_t fi_addr, void *addr,
 	struct sm2_ep_allocation_entry *entries;
 	sm2_gid_t gid;
 
-	*addrlen = MIN(SM2_NAME_MAX, *addrlen);
+	*addrlen = MIN(FI_NAME_MAX, *addrlen);
 
 	util_av = container_of(av, struct util_av, av_fid);
 	sm2_av = container_of(util_av, struct sm2_av, util_av);
@@ -171,7 +171,7 @@ static int sm2_av_lookup(struct fid_av *av, fi_addr_t fi_addr, void *addr,
 	entries = (void *) (sm2_av->mmap.base + header->ep_allocation_offset);
 
 	strncpy(addr, entries[gid].ep_name, *addrlen);
-	*addrlen = strnlen(entries[gid].ep_name, SM2_NAME_MAX);
+	*addrlen = strnlen(entries[gid].ep_name, FI_NAME_MAX);
 
 	FI_DBG(&sm2_prov, FI_LOG_AV, "sm2_av_lookup: %s\n", (char *) addr);
 

--- a/prov/sm2/src/sm2_coordination.c
+++ b/prov/sm2/src/sm2_coordination.c
@@ -178,7 +178,7 @@ ssize_t sm2_file_open_or_create(struct sm2_mmap *map_shared)
 {
 	pthread_mutexattr_t att;
 	struct sm2_mmap map_ours;
-	char template[SM2_NAME_MAX];
+	char template[FI_NAME_MAX];
 	struct sm2_coord_file_header *header, *tmp_header;
 	struct sm2_ep_allocation_entry *entries;
 	int fd, common_fd, err, tries, item;
@@ -322,7 +322,7 @@ retry_lookup:
 					"file size is reset)!\n",
 					item);
 				strncpy(entries[item].ep_name,
-					ZOMBIE_ALLOCATION_NAME, SM2_NAME_MAX);
+					ZOMBIE_ALLOCATION_NAME, FI_NAME_MAX);
 				goto retry_lookup;
 			}
 		}
@@ -422,8 +422,8 @@ found:
 		"Using sm2 region at allocation entry[%d] for %s\n", item,
 		name);
 
-	strncpy(entries[item].ep_name, name, SM2_NAME_MAX - 1);
-	entries[item].ep_name[SM2_NAME_MAX - 1] = '\0';
+	strncpy(entries[item].ep_name, name, FI_NAME_MAX - 1);
+	entries[item].ep_name[FI_NAME_MAX - 1] = '\0';
 
 	*gid = item;
 
@@ -440,7 +440,7 @@ int sm2_entry_lookup(const char *name, struct sm2_mmap *map)
 	entries = sm2_mmap_entries(map);
 	/* TODO Optimize this lookup*/
 	for (item = 0; item < SM2_MAX_UNIVERSE_SIZE; item++) {
-		if (0 == strncmp(name, entries[item].ep_name, SM2_NAME_MAX)) {
+		if (0 == strncmp(name, entries[item].ep_name, FI_NAME_MAX)) {
 			FI_DBG(&sm2_prov, FI_LOG_AV,
 			       "Found existing %s in slot %d\n", name, item);
 			return item;

--- a/prov/sm2/src/sm2_coordination.h
+++ b/prov/sm2/src/sm2_coordination.h
@@ -48,7 +48,6 @@
 
 #include <rdma/providers/fi_prov.h>
 
-#define SM2_NAME_MAX	      256
 #define SM2_INJECT_SIZE	      4096
 #define SM2_MAX_UNIVERSE_SIZE 2048
 /* TODO: Make the number of XFER ENTRY's configurable */
@@ -64,7 +63,7 @@ struct sm2_mmap {
 
 struct sm2_ep_allocation_entry {
 	int pid; /* This is for allocation startup */
-	char ep_name[SM2_NAME_MAX];
+	char ep_name[FI_NAME_MAX];
 	bool startup_ready; /* TODO Do I need to make atomic */
 };
 

--- a/prov/sm2/src/sm2_ep.c
+++ b/prov/sm2/src/sm2_ep.c
@@ -52,9 +52,9 @@ int sm2_setname(fid_t fid, void *addr, size_t addrlen)
 	struct sm2_ep *ep;
 	char *name;
 
-	if (addrlen > SM2_NAME_MAX) {
+	if (addrlen > FI_NAME_MAX) {
 		FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,
-			"Addrlen exceeds max addrlen (%d)\n", SM2_NAME_MAX);
+			"Addrlen exceeds max addrlen (%d)\n", FI_NAME_MAX);
 		return -FI_EINVAL;
 	}
 
@@ -893,8 +893,8 @@ static struct fi_ops sm2_ep_fi_ops = {
 static int sm2_endpoint_name(struct sm2_ep *ep, char *name, char *addr,
 			     size_t addrlen)
 {
-	memset(name, 0, SM2_NAME_MAX);
-	if (!addr || addrlen > SM2_NAME_MAX)
+	memset(name, 0, FI_NAME_MAX);
+	if (!addr || addrlen > FI_NAME_MAX)
 		return -FI_EINVAL;
 
 	pthread_mutex_lock(&sm2_ep_list_lock);
@@ -902,11 +902,11 @@ static int sm2_endpoint_name(struct sm2_ep *ep, char *name, char *addr,
 	pthread_mutex_unlock(&sm2_ep_list_lock);
 
 	if (strstr(addr, SM2_PREFIX)) {
-		snprintf(name, SM2_NAME_MAX - 1, "%s:%d:%d", addr, getuid(),
+		snprintf(name, FI_NAME_MAX - 1, "%s:%d:%d", addr, getuid(),
 			 ep->ep_idx);
 	} else {
 		/* this is an fi_ns:// address.*/
-		snprintf(name, SM2_NAME_MAX - 1, "%s", addr);
+		snprintf(name, FI_NAME_MAX - 1, "%s", addr);
 	}
 
 	return 0;
@@ -917,7 +917,7 @@ int sm2_endpoint(struct fid_domain *domain, struct fi_info *info,
 {
 	struct sm2_ep *ep;
 	int ret;
-	char name[SM2_NAME_MAX];
+	char name[FI_NAME_MAX];
 
 	ep = calloc(1, sizeof(*ep));
 	if (!ep)
@@ -927,7 +927,7 @@ int sm2_endpoint(struct fid_domain *domain, struct fi_info *info,
 
 	if (ret)
 		goto ep;
-	ret = sm2_setname(&ep->util_ep.ep_fid.fid, name, SM2_NAME_MAX);
+	ret = sm2_setname(&ep->util_ep.ep_fid.fid, name, FI_NAME_MAX);
 	if (ret)
 		goto ep;
 

--- a/prov/sm2/src/sm2_init.c
+++ b/prov/sm2/src/sm2_init.c
@@ -43,27 +43,27 @@
 static void sm2_resolve_addr(const char *node, const char *service, char **addr,
 			     size_t *addrlen)
 {
-	char temp_name[SM2_NAME_MAX];
+	char temp_name[FI_NAME_MAX];
 
 	FI_INFO(&sm2_prov, FI_LOG_EP_CTRL, "resolving node=%s, service=%s\n",
 		node ? node : "NULL", service ? service : "NULL");
 	if (service) {
 		if (node)
 			*addrlen =
-				snprintf(temp_name, SM2_NAME_MAX - 1, "%s%s:%s",
+				snprintf(temp_name, FI_NAME_MAX - 1, "%s%s:%s",
 					 SM2_PREFIX_NS, node, service);
 		else
-			*addrlen = snprintf(temp_name, SM2_NAME_MAX - 1, "%s%s",
+			*addrlen = snprintf(temp_name, FI_NAME_MAX - 1, "%s%s",
 					    SM2_PREFIX_NS, service);
 	} else {
 		if (node)
-			*addrlen = snprintf(temp_name, SM2_NAME_MAX - 1, "%s%s",
+			*addrlen = snprintf(temp_name, FI_NAME_MAX - 1, "%s%s",
 					    SM2_PREFIX, node);
 		else
-			*addrlen = snprintf(temp_name, SM2_NAME_MAX - 1, "%s%d",
+			*addrlen = snprintf(temp_name, FI_NAME_MAX - 1, "%s%d",
 					    SM2_PREFIX, getpid());
 	}
-	*addr = strndup(temp_name, SM2_NAME_MAX - 1);
+	*addr = strndup(temp_name, FI_NAME_MAX - 1);
 	FI_INFO(&sm2_prov, FI_LOG_EP_CTRL, "resolved to %s\n", temp_name);
 }
 

--- a/prov/sm2/src/sm2_util.c
+++ b/prov/sm2/src/sm2_util.c
@@ -92,8 +92,8 @@ int sm2_create(const struct fi_provider *prov, const struct sm2_attr *attr,
 		FI_WARN(prov, FI_LOG_EP_CTRL, "calloc error\n");
 		return -FI_ENOMEM;
 	}
-	strncpy(ep_name->name, (char *) attr->name, SM2_NAME_MAX - 1);
-	ep_name->name[SM2_NAME_MAX - 1] = '\0';
+	strncpy(ep_name->name, (char *) attr->name, FI_NAME_MAX - 1);
+	ep_name->name[FI_NAME_MAX - 1] = '\0';
 
 	if (ret < 0) {
 		FI_WARN(prov, FI_LOG_EP_CTRL, "ftruncate error\n");


### PR DESCRIPTION
Remove `#define SM2_NAME_MAX 256` and use FI_NAME_MAX for names.  SM2 doesn't care how long names are... and they should be less than FI_NAME_MAX.