### PR TITLE
prov/shm: Use FI_NAME_MAX for name length

### DIFF
--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -164,12 +164,11 @@ struct smr_cmd {
 #define SMR_SAR_SIZE		32768
 
 #define SMR_DIR "/dev/shm/"
-#define SMR_NAME_MAX	256
-#define SMR_PATH_MAX	(SMR_NAME_MAX + sizeof(SMR_DIR))
+#define SMR_PATH_MAX	(FI_NAME_MAX + sizeof(SMR_DIR))
 #define SMR_SOCK_NAME_MAX sizeof(((struct sockaddr_un *)0)->sun_path)
 
 struct smr_addr {
-	char		name[SMR_NAME_MAX];
+	char		name[FI_NAME_MAX];
 	int64_t		id;
 };
 
@@ -187,7 +186,7 @@ extern pthread_mutex_t sock_list_lock;
 struct smr_region;
 
 struct smr_ep_name {
-	char name[SMR_NAME_MAX];
+	char name[FI_NAME_MAX];
 	struct smr_region *region;
 	struct dlist_entry entry;
 };

--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -164,7 +164,6 @@ struct smr_cmd {
 #define SMR_SAR_SIZE		32768
 
 #define SMR_DIR "/dev/shm/"
-#define SMR_PATH_MAX	(FI_NAME_MAX + sizeof(SMR_DIR))
 #define SMR_SOCK_NAME_MAX sizeof(((struct sockaddr_un *)0)->sun_path)
 
 struct smr_addr {

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -298,7 +298,7 @@ static inline struct fid_peer_srx *smr_get_peer_srx(struct smr_ep *ep)
 static inline int smr_mmap_name(char *shm_name, const char *ep_name,
 				uint64_t msg_id)
 {
-	return snprintf(shm_name, SMR_NAME_MAX - 1, "%s_%ld",
+	return snprintf(shm_name, FI_NAME_MAX - 1, "%s_%ld",
 			ep_name, msg_id);
 }
 

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -55,9 +55,9 @@ int smr_setname(fid_t fid, void *addr, size_t addrlen)
 	struct smr_ep *ep;
 	char *name;
 
-	if (addrlen > SMR_NAME_MAX) {
+	if (addrlen > FI_NAME_MAX) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-			"Addrlen exceeds max addrlen (%d)\n", SMR_NAME_MAX);
+			"Addrlen exceeds max addrlen (%d)\n", FI_NAME_MAX);
 		return -FI_EINVAL;
 	}
 
@@ -1729,8 +1729,8 @@ static struct fi_ops smr_ep_fi_ops = {
 static int smr_endpoint_name(struct smr_ep *ep, char *name, char *addr,
 			     size_t addrlen)
 {
-	memset(name, 0, SMR_NAME_MAX);
-	if (!addr || addrlen > SMR_NAME_MAX)
+	memset(name, 0, FI_NAME_MAX);
+	if (!addr || addrlen > FI_NAME_MAX)
 		return -FI_EINVAL;
 
 	pthread_mutex_lock(&ep_list_lock);
@@ -1738,10 +1738,10 @@ static int smr_endpoint_name(struct smr_ep *ep, char *name, char *addr,
 	pthread_mutex_unlock(&ep_list_lock);
 
 	if (strstr(addr, SMR_PREFIX))
-		snprintf(name, SMR_NAME_MAX - 1, "%s:%d:%d", addr, getuid(),
+		snprintf(name, FI_NAME_MAX - 1, "%s:%d:%d", addr, getuid(),
 			 ep->ep_idx);
 	else
-		snprintf(name, SMR_NAME_MAX - 1, "%s", addr);
+		snprintf(name, FI_NAME_MAX - 1, "%s", addr);
 
 	return 0;
 }
@@ -1772,7 +1772,7 @@ int smr_endpoint(struct fid_domain *domain, struct fi_info *info,
 {
 	struct smr_ep *ep;
 	int ret;
-	char name[SMR_NAME_MAX];
+	char name[FI_NAME_MAX];
 
 	smr_init_sig_handlers();
 
@@ -1783,7 +1783,7 @@ int smr_endpoint(struct fid_domain *domain, struct fi_info *info,
 	ret = smr_endpoint_name(ep, name, info->src_addr, info->src_addrlen);
 	if (ret)
 		goto free;
-	ret = smr_setname(&ep->util_ep.ep_fid.fid, name, SMR_NAME_MAX);
+	ret = smr_setname(&ep->util_ep.ep_fid.fid, name, FI_NAME_MAX);
 	if (ret)
 		goto free;
 

--- a/prov/shm/src/smr_init.c
+++ b/prov/shm/src/smr_init.c
@@ -58,21 +58,21 @@ static void smr_init_env(void)
 static void smr_resolve_addr(const char *node, const char *service,
 			     char **addr, size_t *addrlen)
 {
-	char temp_name[SMR_NAME_MAX];
+	char temp_name[FI_NAME_MAX];
 
 	if (service) {
 		if (node)
-			snprintf(temp_name, SMR_NAME_MAX - 1, "%s%s:%s",
+			snprintf(temp_name, FI_NAME_MAX - 1, "%s%s:%s",
 				 SMR_PREFIX_NS, node, service);
 		else
-			snprintf(temp_name, SMR_NAME_MAX - 1, "%s%s",
+			snprintf(temp_name, FI_NAME_MAX - 1, "%s%s",
 				 SMR_PREFIX_NS, service);
 	} else {
 		if (node)
-			snprintf(temp_name, SMR_NAME_MAX - 1, "%s%s",
+			snprintf(temp_name, FI_NAME_MAX - 1, "%s%s",
 				 SMR_PREFIX, node);
 		else
-			snprintf(temp_name, SMR_NAME_MAX - 1, "%s%d",
+			snprintf(temp_name, FI_NAME_MAX - 1, "%s%d",
 				 SMR_PREFIX, getpid());
 	}
 

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -70,7 +70,7 @@ smr_try_progress_from_sar(struct smr_ep *ep, struct smr_region *smr,
 {
 	if (*bytes_done < cmd->msg.hdr.size) {
 		if (smr_env.use_dsa_sar && !mr) {
-			(void) smr_dsa_copy_from_sar(ep, sar_pool, resp, cmd, 
+			(void) smr_dsa_copy_from_sar(ep, sar_pool, resp, cmd,
 					iov, iov_count, bytes_done, entry_ptr);
 			return;
 		} else {
@@ -343,7 +343,7 @@ static int smr_mmap_peer_copy(struct smr_ep *ep, struct smr_cmd *cmd,
 			      struct ofi_mr **mr, struct iovec *iov,
 			      size_t iov_count, size_t *total_len)
 {
-	char shm_name[SMR_NAME_MAX];
+	char shm_name[FI_NAME_MAX];
 	void *mapped_ptr;
 	int fd, num;
 	int ret = 0;

--- a/prov/util/src/util_shm.c
+++ b/prov/util/src/util_shm.c
@@ -382,7 +382,7 @@ int smr_map_to_region(const struct fi_provider *prov, struct smr_map *map,
 	struct stat sts;
 	struct dlist_entry *entry;
 	const char *name = smr_no_prefix(peer_buf->peer.name);
-	char tmp[SMR_PATH_MAX];
+	char tmp[FI_PATH_MAX];
 
 	if (peer_buf->region)
 		return FI_SUCCESS;

--- a/prov/util/src/util_shm.c
+++ b/prov/util/src/util_shm.c
@@ -61,7 +61,7 @@ void smr_cleanup(void)
 
 static void smr_peer_addr_init(struct smr_addr *peer)
 {
-	memset(peer->name, 0, SMR_NAME_MAX);
+	memset(peer->name, 0, FI_NAME_MAX);
 	peer->id = -1;
 }
 
@@ -119,7 +119,7 @@ size_t smr_calculate_size_offsets(size_t tx_count, size_t rx_count,
 	ep_name_offset = peer_data_offset + sizeof(struct smr_peer_data) *
 		SMR_MAX_PEERS;
 
-	sock_name_offset = ep_name_offset + SMR_NAME_MAX;
+	sock_name_offset = ep_name_offset + FI_NAME_MAX;
 
 	if (cmd_offset)
 		*cmd_offset = cmd_queue_offset;
@@ -235,8 +235,8 @@ int smr_create(const struct fi_provider *prov, struct smr_map *map,
 		ret = -FI_ENOMEM;
 		goto close;
 	}
-	strncpy(ep_name->name, (char *)attr->name, SMR_NAME_MAX - 1);
-	ep_name->name[SMR_NAME_MAX - 1] = '\0';
+	strncpy(ep_name->name, (char *)attr->name, FI_NAME_MAX - 1);
+	ep_name->name[FI_NAME_MAX - 1] = '\0';
 
 	pthread_mutex_lock(&ep_list_lock);
 	dlist_insert_tail(&ep_name->entry, &ep_name_list);
@@ -340,7 +340,7 @@ static int smr_name_compare(struct ofi_rbmap *map, void *key, void *data)
 	smr_map = container_of(map, struct smr_map, rbmap);
 
 	return strncmp(smr_map->peers[(uintptr_t) data].peer.name,
-		       (char *) key, SMR_NAME_MAX);
+		       (char *) key, FI_NAME_MAX);
 }
 
 int smr_map_create(const struct fi_provider *prov, int peer_count,
@@ -459,8 +459,8 @@ void smr_map_to_endpoint(struct smr_region *region, int64_t id)
 	local_peers = smr_peer_data(region);
 
 	strncpy(local_peers[id].addr.name,
-		region->map->peers[id].peer.name, SMR_NAME_MAX - 1);
-	local_peers[id].addr.name[SMR_NAME_MAX - 1] = '\0';
+		region->map->peers[id].peer.name, FI_NAME_MAX - 1);
+	local_peers[id].addr.name[FI_NAME_MAX - 1] = '\0';
 
 	peer_smr = smr_peer_region(region, id);
 
@@ -477,7 +477,7 @@ void smr_unmap_from_endpoint(struct smr_region *region, int64_t id)
 
 	local_peers = smr_peer_data(region);
 
-	memset(local_peers[id].addr.name, 0, SMR_NAME_MAX);
+	memset(local_peers[id].addr.name, 0, FI_NAME_MAX);
 	peer_id = region->map->peers[id].peer.id;
 	if (peer_id < 0)
 		return;
@@ -522,8 +522,8 @@ int smr_map_add(const struct fi_provider *prov, struct smr_map *map,
 	assert(map->cur_id < SMR_MAX_PEERS && tries < SMR_MAX_PEERS);
 	*id = map->cur_id;
 	node->data = (void *) (intptr_t) *id;
-	strncpy(map->peers[*id].peer.name, name, SMR_NAME_MAX);
-	map->peers[*id].peer.name[SMR_NAME_MAX - 1] = '\0';
+	strncpy(map->peers[*id].peer.name, name, FI_NAME_MAX);
+	map->peers[*id].peer.name[FI_NAME_MAX - 1] = '\0';
 	map->peers[*id].region = NULL;
 
 	ret = smr_map_to_region(prov, map, *id);


### PR DESCRIPTION
SMR_NAME_LENGTH is 256 b/c the max file size is 256.  We should be using FI_NAME_MAX b/c a user should be able to use any endpoint with their app.  If a user is specifying endpoint names that are longer than FI_NAME_MAX (64)... then they will not be able to take advantage of using other providers (the entire point of having a framework :)).

Also... the user doesn't have a good way of knowing that SHM has a SMR_NAME_LENGTH of 256... the only way they can find out is by trying to use fi_setname and providing a buffer that is too big.