### PR TITLE
[v1.18.x] prov/verbs: Recover RXM connection from verbs QP in error state

### DIFF
--- a/prov/verbs/include/fi_verbs.h
+++ b/prov/verbs/include/fi_verbs.h
@@ -926,6 +926,7 @@ do {								\
 	( wr->opcode == IBV_WR_SEND || wr->opcode == IBV_WR_SEND_WITH_IMM	\
 	|| wr->opcode == IBV_WR_RDMA_WRITE_WITH_IMM )
 
+void vrb_shutdown_qp_in_err(struct vrb_ep *ep);
 ssize_t vrb_post_send(struct vrb_ep *ep, struct ibv_send_wr *wr, uint64_t flags);
 ssize_t vrb_post_recv(struct vrb_ep *ep, struct ibv_recv_wr *wr);
 

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -253,6 +253,8 @@ int vrb_poll_cq(struct vrb_cq *cq, struct ibv_wc *wc)
 
 		ctx = (struct vrb_context *) (uintptr_t) wc->wr_id;
 		wc->wr_id = (uintptr_t) ctx->user_ctx;
+		if (wc->status != IBV_WC_SUCCESS)
+			vrb_shutdown_qp_in_err(ctx->ep);
 		if (ctx->op_queue == VRB_OP_SQ) {
 			ep = ctx->ep;
 			assert(ep);

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -112,6 +112,27 @@ unlock:
 	return -FI_EAGAIN;
 }
 
+void vrb_shutdown_qp_in_err(struct vrb_ep *ep)
+{
+	struct ibv_qp_attr attr;
+	struct ibv_qp_init_attr init_attr;
+	struct fi_eq_cm_entry entry;
+
+	if (!ep || !ep->ibv_qp || ep->ibv_qp->state == IBV_QPS_UNKNOWN || !ep->eq)
+		return;
+
+	memset(&attr, 0, sizeof(attr));
+	memset(&init_attr, 0, sizeof(init_attr));
+	ibv_query_qp(ep->ibv_qp, &attr, IBV_QP_STATE, &init_attr);
+	if (attr.cur_qp_state != IBV_QPS_ERR)
+		return;
+
+	memset(&entry, 0, sizeof(entry));
+	entry.fid = &ep->util_ep.ep_fid.fid;
+	if (vrb_eq_write_event(ep->eq, FI_SHUTDOWN, &entry, sizeof(entry)) > 0)
+		ep->ibv_qp->state = IBV_QPS_UNKNOWN;
+}
+
 ssize_t vrb_post_send(struct vrb_ep *ep, struct ibv_send_wr *wr, uint64_t flags)
 {
 	struct vrb_context *ctx;


### PR DESCRIPTION
Verbs QP can transition to error state for number of reasons such as retransmission time out or protection error, rendering RXM connection unusable until QP is back in RTS state.  Since not all RDMA adapters can transition a QP from error state back to RTS, the solution is to destroy the QP and create a new one on subsequent use.

On a completion with error status, check current QP state (expensive) against error state. Write a FI_SHUTDOWN event to event queue for RXM to process and close the connection.  When a new request to use the connection, a new QP will be created.