### PR TITLE
prov/sm2: Add HMEM Support to SM2 Inject Protocol

### DIFF
--- a/fabtests/pytest/sm2/conftest.py
+++ b/fabtests/pytest/sm2/conftest.py
@@ -1,7 +1,12 @@
 import pytest
 
-# TODO Restore GPU Memory Types
-@pytest.fixture(scope="module", params=["host_to_host"])
+@pytest.fixture(scope="module", params=["host_to_host",
+                                        pytest.param("host_to_cuda", marks=pytest.mark.cuda_memory),
+                                        pytest.param("cuda_to_host", marks=pytest.mark.cuda_memory),
+                                        pytest.param("cuda_to_cuda", marks=pytest.mark.cuda_memory),
+                                        pytest.param("neuron_to_neuron", marks=pytest.mark.neuron_memory),
+                                        pytest.param("neuron_to_host", marks=pytest.mark.neuron_memory),
+                                        pytest.param("host_to_neuron", marks=pytest.mark.neuron_memory)])
 def memory_type(request):
     return request.param
 

--- a/prov/sm2/src/sm2.h
+++ b/prov/sm2/src/sm2.h
@@ -265,9 +265,8 @@ typedef ssize_t (*sm2_proto_func)(struct sm2_ep *ep,
 				  struct sm2_region *peer_smr,
 				  sm2_gid_t peer_gid, uint32_t op, uint64_t tag,
 				  uint64_t data, uint64_t op_flags,
-				  enum fi_hmem_iface iface, uint64_t device,
-				  const struct iovec *iov, size_t iov_count,
-				  size_t total_len);
+				  struct ofi_mr **mr, const struct iovec *iov,
+				  size_t iov_count, size_t total_len);
 extern sm2_proto_func sm2_proto_ops[sm2_proto_max];
 
 int sm2_write_err_comp(struct util_cq *cq, void *context, uint64_t flags,

--- a/prov/sm2/src/sm2_attr.c
+++ b/prov/sm2/src/sm2_attr.c
@@ -37,8 +37,10 @@
 #define SM2_RX_CAPS                                                   \
 	(FI_SOURCE | OFI_RX_MSG_CAPS | FI_TAGGED | FI_DIRECTED_RECV | \
 	 FI_MULTI_RECV)
-#define SM2_TX_OP_FLAGS (FI_COMPLETION | FI_INJECT_COMPLETE)
-#define SM2_RX_OP_FLAGS (FI_COMPLETION | FI_MULTI_RECV)
+#define SM2_HMEM_TX_CAPS (SM2_TX_CAPS | FI_HMEM)
+#define SM2_HMEM_RX_CAPS (SM2_RX_CAPS | FI_HMEM)
+#define SM2_TX_OP_FLAGS	 (FI_COMPLETION | FI_INJECT_COMPLETE)
+#define SM2_RX_OP_FLAGS	 (FI_COMPLETION | FI_MULTI_RECV)
 
 struct fi_tx_attr sm2_tx_attr = {
 	.caps = SM2_TX_CAPS,
@@ -53,6 +55,26 @@ struct fi_tx_attr sm2_tx_attr = {
 
 struct fi_rx_attr sm2_rx_attr = {
 	.caps = SM2_RX_CAPS,
+	.op_flags = SM2_RX_OP_FLAGS,
+	.comp_order = FI_ORDER_STRICT,
+	.msg_order = FI_ORDER_SAS,
+	.size = 1024,
+	.iov_limit = SM2_IOV_LIMIT,
+};
+
+struct fi_tx_attr sm2_hmem_tx_attr = {
+	.caps = SM2_HMEM_TX_CAPS,
+	.op_flags = SM2_TX_OP_FLAGS,
+	.comp_order = FI_ORDER_NONE,
+	.msg_order = FI_ORDER_SAS,
+	.inject_size = 0,
+	.size = 1024,
+	.iov_limit = SM2_IOV_LIMIT,
+	.rma_iov_limit = SM2_IOV_LIMIT,
+};
+
+struct fi_rx_attr sm2_hmem_rx_attr = {
+	.caps = SM2_HMEM_RX_CAPS,
 	.op_flags = SM2_RX_OP_FLAGS,
 	.comp_order = FI_ORDER_STRICT,
 	.msg_order = FI_ORDER_SAS,
@@ -118,6 +140,17 @@ struct fi_fabric_attr sm2_fabric_attr = {
 	.prov_version = OFI_VERSION_DEF_PROV,
 };
 
+struct fi_info sm2_hmem_info = {
+	.caps = SM2_HMEM_TX_CAPS | SM2_HMEM_RX_CAPS | FI_MULTI_RECV |
+		FI_LOCAL_COMM,
+	.addr_format = FI_ADDR_STR,
+	.tx_attr = &sm2_hmem_tx_attr,
+	.rx_attr = &sm2_hmem_rx_attr,
+	.ep_attr = &sm2_ep_attr,
+	.domain_attr = &sm2_hmem_domain_attr,
+	.fabric_attr = &sm2_fabric_attr,
+};
+
 struct fi_info sm2_info = {
 	.caps = SM2_TX_CAPS | SM2_RX_CAPS | FI_MULTI_RECV | FI_LOCAL_COMM,
 	.addr_format = FI_ADDR_STR,
@@ -126,5 +159,5 @@ struct fi_info sm2_info = {
 	.ep_attr = &sm2_ep_attr,
 	.domain_attr = &sm2_domain_attr,
 	.fabric_attr = &sm2_fabric_attr,
-	.next = NULL,
+	.next = &sm2_hmem_info,
 };

--- a/prov/sm2/src/sm2_msg.c
+++ b/prov/sm2/src/sm2_msg.c
@@ -295,6 +295,7 @@ static ssize_t sm2_generic_sendmsg(struct sm2_ep *ep, const struct iovec *iov,
 	sm2_gid_t peer_gid;
 	ssize_t ret = 0;
 	size_t total_len;
+	struct ofi_mr **mr = (struct ofi_mr **) desc;
 
 	assert(iov_count <= SM2_IOV_LIMIT);
 
@@ -310,8 +311,8 @@ static ssize_t sm2_generic_sendmsg(struct sm2_ep *ep, const struct iovec *iov,
 	assert(!(op_flags & FI_INJECT) || total_len <= SM2_INJECT_SIZE);
 
 	ret = sm2_proto_ops[sm2_proto_inject](ep, peer_smr, peer_gid, op, tag,
-					      data, op_flags, FI_HMEM_SYSTEM, 0,
-					      iov, iov_count, total_len);
+					      data, op_flags, mr, iov,
+					      iov_count, total_len);
 	if (ret)
 		goto unlock_cq;
 
@@ -391,8 +392,8 @@ static ssize_t sm2_generic_inject(struct fid_ep *ep_fid, const void *buf,
 	peer_smr = sm2_peer_region(ep, peer_gid);
 
 	ret = sm2_proto_ops[sm2_proto_inject](ep, peer_smr, peer_gid, op, tag,
-					      data, op_flags, FI_HMEM_SYSTEM, 0,
-					      &msg_iov, 1, len);
+					      data, op_flags, NULL, &msg_iov, 1,
+					      len);
 
 	if (!ret)
 		ofi_ep_tx_cntr_inc_func(&ep->util_ep, op);


### PR DESCRIPTION
EFA is not picking up SM2 b/c it does not support FI_HMEM.  OMPI attempts to create a libfabric provider with HMEM support, and if it fails, it tries to create one without HMEM support.  EFA is choosing to not hard-fail if SHM provider cannot be picked up, so when we specify SM2 for EFA, we run without SHM.

This patch adds support for HMEM, and allows EFA to pick up SM2.