### PR TITLE
prov/shm: introduce gdrcopy awareness to hmem copy

### DIFF
--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -315,7 +315,14 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 		use_ipc = ofi_hmem_is_ipc_enabled(iface) &&
 				smr_desc->flags & FI_HMEM_DEVICE_ONLY &&
 				!(op_flags & FI_INJECT);
+
+		if (iface == FI_HMEM_CUDA &&
+		    (smr_desc->flags & OFI_HMEM_DATA_GDRCOPY_HANDLE)) {
+			assert(smr_desc->hmem_data);
+			gdrcopy_available = true;
+		}
 	}
+
 	proto = smr_select_proto(iface, use_ipc, smr_cma_enabled(ep, peer_smr),
 	                         gdrcopy_available, op, total_len, op_flags);
 

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -182,6 +182,12 @@ static ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 		use_ipc = ofi_hmem_is_ipc_enabled(iface) &&
 				smr_desc->flags & FI_HMEM_DEVICE_ONLY &&
 				!(op_flags & FI_INJECT);
+
+		if (iface == FI_HMEM_CUDA &&
+		    (smr_desc->flags & OFI_HMEM_DATA_GDRCOPY_HANDLE)) {
+			assert(smr_desc->hmem_data);
+			gdrcopy_available = true;
+		}
 	}
 	proto = smr_select_proto(iface, use_ipc, smr_cma_enabled(ep, peer_smr),
 	                         gdrcopy_available, op, total_len, op_flags);


### PR DESCRIPTION
From v1.19, OFI_HMEM_DATA_GDRCOPY_HANDLE flag will signal the presence of gdrcopy handle in ofi_mr.hmem_data. SHM provider can take advantage of gdrcopy to achieve lower memcpy latencies from/to cuda devices.

This patch introduces the logic to select gdrcopy on hmem copy paths, with the exception of cuda IPC which is not supported by gdrcopy.

For OMB single-node cuda->cuda latency we are seeing improvement(via EFA owner provider, which is responsible for gdr pinning).
|  pt2pt/osu_latency  |        |       |
|---------------------|--------|-------|
|         Size        | Before | After |
|                   0 |   0.95 |  0.93 |
|                   1 |  15.41 |  2.78 |
|                   2 |  15.18 |  4.36 |
|                   4 |  15.04 |  4.45 |
|                   8 |  15.11 |  4.38 |
|                  16 |  15.13 |  3.00 |
|                  32 |  15.29 |  2.99 |
|                  64 |  14.85 |  3.07 |
|                 128 |  14.85 |  4.66 |
|                 256 |  14.62 |  3.34 |
|                 512 |  14.82 |  4.96 |
|                1024 |  15.13 |  6.38 |
|                2048 |  15.68 | 10.99 |
|                2560 |  15.57 | 12.77 |
|                3072 |  15.57 | 15.79 |
|                3584 |  15.65 | 15.80 |
|                4096 |  15.89 | 15.95 |
|                8192 |  15.58 | 15.59 |
|               16384 |  15.31 | 15.24 |
|               32768 |  15.11 | 15.12 |
|               65536 |  15.24 | 15.27 |
|              131072 |  15.52 | 15.60 |
|              262144 |  16.01 | 16.07 |
|              524288 |  17.24 | 19.95 |
|             1048576 |  19.28 | 19.29 |
|             2097152 |  23.23 | 23.20 |
|             4194304 |  30.93 | 30.90 |
