### PR TITLE
[v1.18.x] prov/shm: backport the fix for the cmd_ctx pool exhaustion issue

### DIFF
--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -173,7 +173,6 @@ struct smr_cmd_ctx {
 };
 
 OFI_DECLARE_FREESTACK(struct smr_rx_entry, smr_recv_fs);
-OFI_DECLARE_FREESTACK(struct smr_cmd_ctx, smr_cmd_ctx_fs);
 OFI_DECLARE_FREESTACK(struct smr_tx_entry, smr_tx_fs);
 OFI_DECLARE_FREESTACK(struct smr_pend_entry, smr_pend_fs);
 
@@ -272,7 +271,7 @@ struct smr_ep {
 	ofi_spin_t		tx_lock;
 
 	struct fid_ep		*srx;
-	struct smr_cmd_ctx_fs	*cmd_ctx_fs;
+	struct ofi_bufpool	*cmd_ctx_pool;
 	struct smr_tx_fs	*tx_fs;
 	struct smr_pend_fs	*pend_fs;
 	struct dlist_entry	sar_list;

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -944,7 +944,8 @@ static int smr_ep_close(struct fid *fid)
 	if (ep->util_ep.ep_fid.msg != &smr_no_recv_msg_ops)
 		smr_srx_close(&ep->srx->fid);
 
-	smr_cmd_ctx_fs_free(ep->cmd_ctx_fs);
+	if (ep->cmd_ctx_pool)
+		ofi_bufpool_destroy(ep->cmd_ctx_pool);
 	smr_tx_fs_free(ep->tx_fs);
 	smr_pend_fs_free(ep->pend_fs);
 	ofi_spin_destroy(&ep->tx_lock);
@@ -1555,7 +1556,7 @@ static int smr_discard(struct fi_peer_rx_entry *rx_entry)
 {
 	struct smr_cmd_ctx *cmd_ctx = rx_entry->peer_context;
 
-	ofi_freestack_push(cmd_ctx->ep->cmd_ctx_fs, cmd_ctx);
+	ofi_buf_free(cmd_ctx);
 	return FI_SUCCESS;
 }
 
@@ -1794,7 +1795,14 @@ int smr_endpoint(struct fid_domain *domain, struct fi_info *info,
 	ep->util_ep.ep_fid.msg = &smr_msg_ops;
 	ep->util_ep.ep_fid.tagged = &smr_tag_ops;
 
-	ep->cmd_ctx_fs = smr_cmd_ctx_fs_create(info->rx_attr->size, NULL, NULL);
+	ret = ofi_bufpool_create(&ep->cmd_ctx_pool, sizeof(struct smr_cmd_ctx),
+				 16, 0, info->rx_attr->size,
+				 OFI_BUFPOOL_NO_TRACK);
+	if (ret || ofi_bufpool_grow(ep->cmd_ctx_pool)) {
+		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+			"Unable to create cmd ctx pool\n");
+		return -FI_ENOMEM;
+	}
 	ep->tx_fs = smr_tx_fs_create(info->tx_attr->size, NULL, NULL);
 	ep->pend_fs = smr_pend_fs_create(info->rx_attr->size, NULL, NULL);
 

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -1776,10 +1776,10 @@ int smr_endpoint(struct fid_domain *domain, struct fi_info *info,
 
 	ret = smr_endpoint_name(ep, name, info->src_addr, info->src_addrlen);
 	if (ret)
-		goto ep;
+		goto free;
 	ret = smr_setname(&ep->util_ep.ep_fid.fid, name, SMR_NAME_MAX);
 	if (ret)
-		goto ep;
+		goto free;
 
 	ret = ofi_spin_init(&ep->tx_lock);
 	if (ret)
@@ -1798,10 +1798,18 @@ int smr_endpoint(struct fid_domain *domain, struct fi_info *info,
 	ret = ofi_bufpool_create(&ep->cmd_ctx_pool, sizeof(struct smr_cmd_ctx),
 				 16, 0, info->rx_attr->size,
 				 OFI_BUFPOOL_NO_TRACK);
-	if (ret || ofi_bufpool_grow(ep->cmd_ctx_pool)) {
+	if (ret) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"Unable to create cmd ctx pool\n");
-		return -FI_ENOMEM;
+		goto ep;
+	}
+
+	ret = ofi_bufpool_grow(ep->cmd_ctx_pool);
+	if (ret) {
+		ofi_bufpool_destroy(ep->cmd_ctx_pool);
+		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+			"Unable to create cmd ctx pool\n");
+		goto ep;
 	}
 	ep->tx_fs = smr_tx_fs_create(info->tx_attr->size, NULL, NULL);
 	ep->pend_fs = smr_pend_fs_create(info->rx_attr->size, NULL, NULL);
@@ -1817,12 +1825,13 @@ int smr_endpoint(struct fid_domain *domain, struct fi_info *info,
 
 	*ep_fid = &ep->util_ep.ep_fid;
 	return 0;
-
+ep:
+	ofi_endpoint_close(&ep->util_ep);
 lock:
 	ofi_spin_destroy(&ep->tx_lock);
 name:
 	free((void *)ep->name);
-ep:
+free:
 	free(ep);
 	return ret;
 }


### PR DESCRIPTION
This PR backports https://github.com/ofiwg/libfabric/pull/8766 and its follow-up fix https://github.com/ofiwg/libfabric/pull/8777 to v1.18.x branch