### PR TITLE
[v1.17.x] prov/hook,verbs,rxm: Fix credit size parameter for flow ctrl

### DIFF
--- a/include/ofi_hook.h
+++ b/include/ofi_hook.h
@@ -163,7 +163,7 @@ struct hook_domain {
 	struct fid_domain *hdomain;
 	struct hook_fabric *fabric;
 	struct ofi_ops_flow_ctrl *base_ops_flow_ctrl;
-	ssize_t (*base_credit_handler)(struct fid_ep *ep_fid, size_t credits);
+	ssize_t (*base_credit_handler)(struct fid_ep *ep_fid, uint64_t credits);
 };
 
 int hook_domain_init(struct fid_fabric *fabric, struct fi_info *info,

--- a/prov/hook/src/hook_domain.c
+++ b/prov/hook/src/hook_domain.c
@@ -102,7 +102,7 @@ static struct fi_ops_mr hook_mr_ops = {
 	.regattr = hook_mr_regattr,
 };
 
-static ssize_t hook_credit_handler(struct fid_ep *ep_fid, size_t credits)
+static ssize_t hook_credit_handler(struct fid_ep *ep_fid, uint64_t credits)
 {
 	/*
 	 * called from the base provider, ep_fid is the base ep, and
@@ -114,7 +114,7 @@ static ssize_t hook_credit_handler(struct fid_ep *ep_fid, size_t credits)
 }
 
 static void hook_set_send_handler(struct fid_domain *domain_fid,
-		ssize_t (*credit_handler)(struct fid_ep *ep, size_t credits))
+		ssize_t (*credit_handler)(struct fid_ep *ep, uint64_t credits))
 {
 	struct hook_domain *domain = container_of(domain_fid,
 						  struct hook_domain, domain);
@@ -131,7 +131,7 @@ static int hook_enable_ep_flow_ctrl(struct fid_ep *ep_fid, uint64_t threshold)
 	return ep->domain->base_ops_flow_ctrl->enable(ep->hep, threshold);
 }
 
-static void hook_add_credits(struct fid_ep *ep_fid, size_t credits)
+static void hook_add_credits(struct fid_ep *ep_fid, uint64_t credits)
 {
 	struct hook_ep *ep = container_of(ep_fid, struct hook_ep, ep);
 

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -582,7 +582,7 @@ static struct fi_ops_mr rxm_domain_mr_thru_ops = {
 	.regattr = rxm_mr_regattr_thru,
 };
 
-static ssize_t rxm_send_credits(struct fid_ep *ep, size_t credits)
+static ssize_t rxm_send_credits(struct fid_ep *ep, uint64_t credits)
 {
 	struct rxm_conn *rxm_conn = ep->fid.context;
 	struct rxm_ep *rxm_ep = rxm_conn->ep;
@@ -635,12 +635,14 @@ defer:
 	return FI_SUCCESS;
 }
 
-static void rxm_no_add_credits(struct fid_ep *ep_fid, size_t credits)
-{ }
+static void rxm_no_add_credits(struct fid_ep *ep_fid, uint64_t credits)
+{
+}
 
 static void rxm_no_credit_handler(struct fid_domain *domain_fid,
-		ssize_t (*credit_handler)(struct fid_ep *ep, size_t credits))
-{ }
+		ssize_t (*credit_handler)(struct fid_ep *ep, uint64_t credits))
+{
+}
 
 static int rxm_no_enable_flow_ctrl(struct fid_ep *ep_fid, uint64_t threshold)
 {

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -40,7 +40,7 @@
 
 
 static void vrb_set_credit_handler(struct fid_domain *domain_fid,
-		ssize_t (*credit_handler)(struct fid_ep *ep, size_t credits))
+		ssize_t (*credit_handler)(struct fid_ep *ep, uint64_t credits))
 {
 	struct vrb_domain *domain;
 

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -38,7 +38,7 @@
 static struct fi_ops_msg vrb_srq_msg_ops;
 
 
-void vrb_add_credits(struct fid_ep *ep_fid, size_t credits)
+void vrb_add_credits(struct fid_ep *ep_fid, uint64_t credits)
 {
 	struct vrb_ep *ep;
 	struct util_cq *cq;


### PR DESCRIPTION
ofi_ops_flow_ctrl defines callbacks for use between rxm and verbs.  Those callbacks include u64 parameters for credit values.  However, the callers use size_t instead.  This results in build warnings.