### PR TITLE
prov/sm2: Add CMA capability to SM2

### DIFF
--- a/prov/sm2/src/sm2.h
+++ b/prov/sm2/src/sm2.h
@@ -87,6 +87,7 @@ extern pthread_mutex_t sm2_ep_list_lock;
 
 enum {
 	sm2_proto_inject,
+	sm2_proto_cma,
 	sm2_proto_return,
 	sm2_proto_max,
 };
@@ -104,7 +105,7 @@ enum {
  * 		   NOTE: Only grabbing the bottom 32 bits
  * 	proto - sm2 operation
  * 	sender_gid - id of msg sender
- * 	user_data - the message
+ * 	user_data - the message, for sm2_proto_inject
  */
 struct sm2_xfer_hdr {
 	volatile long int next;
@@ -122,6 +123,11 @@ struct sm2_xfer_entry {
 	struct sm2_xfer_hdr hdr;
 	uint8_t user_data[SM2_INJECT_SIZE];
 } __attribute__((packed));
+
+struct sm2_cma_data {
+	size_t iov_count;
+	struct iovec iov[SM2_IOV_LIMIT];
+};
 
 struct sm2_ep_name {
 	char name[FI_NAME_MAX];

--- a/prov/sm2/src/sm2_attr.c
+++ b/prov/sm2/src/sm2_attr.c
@@ -88,6 +88,19 @@ struct fi_ep_attr sm2_ep_attr = {
 	.type = FI_EP_RDM,
 	.protocol = FI_PROTO_SHM,
 	.protocol_version = 1,
+	.max_msg_size = SIZE_MAX,
+	.max_order_raw_size = SIZE_MAX,
+	.max_order_waw_size = SIZE_MAX,
+	.max_order_war_size = SIZE_MAX,
+	.mem_tag_format = FI_TAG_GENERIC,
+	.tx_ctx_cnt = 1,
+	.rx_ctx_cnt = 1,
+};
+
+struct fi_ep_attr sm2_hmem_ep_attr = {
+	.type = FI_EP_RDM,
+	.protocol = FI_PROTO_SHM,
+	.protocol_version = 1,
 	.max_msg_size = SM2_INJECT_SIZE,
 	.max_order_raw_size = SM2_INJECT_SIZE,
 	.max_order_waw_size = SM2_INJECT_SIZE,
@@ -148,7 +161,7 @@ struct fi_info sm2_hmem_info = {
 	.addr_format = FI_ADDR_STR,
 	.tx_attr = &sm2_hmem_tx_attr,
 	.rx_attr = &sm2_hmem_rx_attr,
-	.ep_attr = &sm2_ep_attr,
+	.ep_attr = &sm2_hmem_ep_attr,
 	.domain_attr = &sm2_hmem_domain_attr,
 	.fabric_attr = &sm2_fabric_attr,
 };

--- a/prov/sm2/src/sm2_ep.c
+++ b/prov/sm2/src/sm2_ep.c
@@ -296,6 +296,47 @@ static ssize_t sm2_do_inject(struct sm2_ep *ep, struct sm2_region *peer_smr,
 	return FI_SUCCESS;
 }
 
+static void sm2_format_cma(struct sm2_xfer_entry *xfer_entry,
+			   const struct iovec *iov, size_t count)
+{
+	struct sm2_cma_data *cma_data =
+		(struct sm2_cma_data *) xfer_entry->user_data;
+
+	/* All CMA messages must be delivery complete to stop completion from
+	 * being written instantly */
+	xfer_entry->hdr.op_flags |= FI_DELIVERY_COMPLETE;
+	xfer_entry->hdr.proto = sm2_proto_cma;
+	xfer_entry->hdr.size = ofi_total_iov_len(iov, count);
+	cma_data->iov_count = count;
+	memcpy(cma_data->iov, iov, sizeof(*iov) * count);
+}
+
+static ssize_t sm2_do_cma(struct sm2_ep *ep, struct sm2_region *peer_smr,
+			  sm2_gid_t peer_gid, uint32_t op, uint64_t tag,
+			  uint64_t data, uint64_t op_flags, struct ofi_mr **mr,
+			  const struct iovec *iov, size_t iov_count,
+			  size_t total_len, void *context)
+{
+	struct sm2_xfer_entry *xfer_entry;
+	struct sm2_av *av =
+		container_of(ep->util_ep.av, struct sm2_av, util_av);
+	struct sm2_region *self_region = sm2_mmap_ep_region(&av->mmap, ep->gid);
+
+	if (smr_freestack_isempty(sm2_freestack(self_region))) {
+		sm2_progress_recv(ep);
+		if (smr_freestack_isempty(sm2_freestack(self_region)))
+			return -FI_EAGAIN;
+	}
+
+	xfer_entry = smr_freestack_pop(sm2_freestack(self_region));
+	sm2_generic_format(xfer_entry, ep->gid, op, tag, data, op_flags,
+			   context);
+	sm2_format_cma(xfer_entry, iov, iov_count);
+	sm2_fifo_write(ep, peer_gid, xfer_entry);
+
+	return FI_SUCCESS;
+}
+
 int sm2_srx_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 {
 	struct sm2_srx_ctx *srx;
@@ -970,4 +1011,5 @@ ep:
 
 sm2_proto_func sm2_proto_ops[sm2_proto_max] = {
 	[sm2_proto_inject] = &sm2_do_inject,
+	[sm2_proto_cma] = &sm2_do_cma,
 };

--- a/prov/sm2/src/sm2_msg.c
+++ b/prov/sm2/src/sm2_msg.c
@@ -38,6 +38,14 @@
 #include "ofi_iov.h"
 #include "sm2.h"
 
+static inline int sm2_select_proto(uint64_t total_len)
+{
+	if (total_len <= SM2_INJECT_SIZE)
+		return sm2_proto_inject;
+
+	return sm2_proto_cma;
+}
+
 struct sm2_rx_entry *sm2_alloc_rx_entry(struct sm2_srx_ctx *srx)
 {
 	if (ofi_freestack_isempty(srx->recv_fs)) {
@@ -296,6 +304,7 @@ static ssize_t sm2_generic_sendmsg(struct sm2_ep *ep, const struct iovec *iov,
 	ssize_t ret = 0;
 	size_t total_len;
 	struct ofi_mr **mr = (struct ofi_mr **) desc;
+	int proto;
 
 	assert(iov_count <= SM2_IOV_LIMIT);
 
@@ -310,13 +319,14 @@ static ssize_t sm2_generic_sendmsg(struct sm2_ep *ep, const struct iovec *iov,
 	total_len = ofi_total_iov_len(iov, iov_count);
 	assert(!(op_flags & FI_INJECT) || total_len <= SM2_INJECT_SIZE);
 
-	ret = sm2_proto_ops[sm2_proto_inject](ep, peer_smr, peer_gid, op, tag,
-					      data, op_flags, mr, iov,
-					      iov_count, total_len, context);
+	proto = sm2_select_proto(total_len);
+	ret = sm2_proto_ops[proto](ep, peer_smr, peer_gid, op, tag, data,
+				   op_flags, mr, iov, iov_count, total_len,
+				   context);
 	if (ret)
 		goto unlock_cq;
 
-	if (!(op_flags & FI_DELIVERY_COMPLETE)) {
+	if (!(op_flags & FI_DELIVERY_COMPLETE) && proto != sm2_proto_cma) {
 		ret = sm2_complete_tx(ep, context, op, op_flags);
 		if (ret) {
 			FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,

--- a/prov/sm2/src/sm2_progress.c
+++ b/prov/sm2/src/sm2_progress.c
@@ -42,6 +42,58 @@
 #include "sm2.h"
 #include "sm2_fifo.h"
 
+static inline int sm2_cma_loop(pid_t pid, struct iovec *local,
+			       unsigned long local_cnt, struct iovec *remote,
+			       unsigned long remote_cnt, size_t total,
+			       bool write)
+{
+	ssize_t ret;
+
+	while (1) {
+		if (write)
+			ret = ofi_process_vm_writev(pid, local, local_cnt,
+						    remote, remote_cnt, 0);
+		else
+			ret = ofi_process_vm_readv(pid, local, local_cnt,
+						   remote, remote_cnt, 0);
+		if (ret < 0) {
+			FI_WARN(&sm2_prov, FI_LOG_EP_CTRL, "CMA error %d\n",
+				errno);
+			return -FI_EIO;
+		}
+
+		total -= ret;
+		if (!total)
+			return FI_SUCCESS;
+
+		ofi_consume_iov(local, &local_cnt, (size_t) ret);
+		ofi_consume_iov(remote, &remote_cnt, (size_t) ret);
+	}
+}
+
+static int sm2_progress_cma(struct sm2_xfer_entry *xfer_entry,
+			    struct iovec *iov, size_t iov_count,
+			    size_t *total_len, struct sm2_ep *ep, int err)
+{
+	struct sm2_cma_data *cma_data =
+		(struct sm2_cma_data *) xfer_entry->user_data;
+	struct sm2_av *sm2_av =
+		container_of(ep->util_ep.av, struct sm2_av, util_av);
+	struct sm2_ep_allocation_entry *entries =
+		sm2_mmap_entries(&sm2_av->mmap);
+	int ret;
+
+	/* TODO Need to update last argument for RMA support (as well as generic
+	 * format) */
+	ret = sm2_cma_loop(entries[xfer_entry->hdr.sender_gid].pid, iov,
+			   iov_count, cma_data->iov, cma_data->iov_count,
+			   xfer_entry->hdr.size, false);
+	if (!ret)
+		*total_len = xfer_entry->hdr.size;
+
+	return -ret;
+}
+
 static int sm2_progress_inject(struct sm2_xfer_entry *xfer_entry,
 			       struct ofi_mr **mr, struct iovec *iov,
 			       size_t iov_count, size_t *total_len,
@@ -84,6 +136,10 @@ static int sm2_start_common(struct sm2_ep *ep,
 		err = sm2_progress_inject(
 			xfer_entry, (struct ofi_mr **) rx_entry->desc,
 			rx_entry->iov, rx_entry->count, &total_len, ep, 0);
+		break;
+	case sm2_proto_cma:
+		err = sm2_progress_cma(xfer_entry, rx_entry->iov,
+				       rx_entry->count, &total_len, ep, 0);
 		break;
 	default:
 		FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,


### PR DESCRIPTION
AWS needs SM2 to have the capability to send any message size in order to perform benchmarking on real world applications. 

The FI_DELEIVERY_COMPLETE commits will be rebased away when they are merged in with https://github.com/ofiwg/libfabric/pull/8879/files#diff-f2de75d3514282e839536e27cf5c4055b0114c7e0ff2bf7e81f9fe69d635b93d