### PR TITLE
fabtests/pytest/efa: increase default timeout for rma_bw to 540 seconds

### DIFF
--- a/fabtests/pytest/efa/efa_common.py
+++ b/fabtests/pytest/efa/efa_common.py
@@ -1,17 +1,18 @@
 import subprocess
 import functools
-from common import SshConnectionError, is_ssh_connection_error, has_ssh_connection_err_msg
+from common import SshConnectionError, is_ssh_connection_error, has_ssh_connection_err_msg, ClientServerTest
 from retrying import retry
 
 def efa_run_client_server_test(cmdline_args, executable, iteration_type,
                                completion_type, memory_type, message_size,
-                               warmup_iteration_type=None):
-    from common import ClientServerTest
+                               warmup_iteration_type=None, timeout=None):
+    if timeout is None:
+        timeout = cmdline_args.timeout
+
     # It is observed that cuda tests requires larger time-out limit to test all
     # message sizes (especailly when running with multiple workers).
-    timeout = None
     if "cuda" in memory_type:
-        timeout = max(1000, cmdline_args.timeout)
+        timeout = max(1000, timeout)
 
     test = ClientServerTest(cmdline_args, executable, iteration_type,
                             completion_type=completion_type,

--- a/fabtests/pytest/efa/test_rma_bw.py
+++ b/fabtests/pytest/efa/test_rma_bw.py
@@ -8,7 +8,9 @@ def test_rma_bw(cmdline_args, iteration_type, operation_type, completion_type, m
     from efa.efa_common import efa_run_client_server_test
     command = "fi_rma_bw -e rdm"
     command = command + " -o " + operation_type
-    efa_run_client_server_test(cmdline_args, command, iteration_type, completion_type, memory_type, "all")
+    # rma_bw test with data verification takes longer to finish
+    timeout = max(540, cmdline_args.timeout)
+    efa_run_client_server_test(cmdline_args, command, iteration_type, completion_type, memory_type, "all", timeout=timeout)
 
 @pytest.mark.functional
 @pytest.mark.parametrize("operation_type", ["read", "writedata", "write"])
@@ -16,4 +18,6 @@ def test_rma_bw_range(cmdline_args, operation_type, completion_type, message_siz
     from efa.efa_common import efa_run_client_server_test
     command = "fi_rma_bw -e rdm"
     command = command + " -o " + operation_type
-    efa_run_client_server_test(cmdline_args, command, "short", completion_type, memory_type, message_size)
+    # rma_bw test with data verification takes longer to finish
+    timeout = max(540, cmdline_args.timeout)
+    efa_run_client_server_test(cmdline_args, command, "short", completion_type, memory_type, message_size, timeout=timeout)


### PR DESCRIPTION
With newly introduced data verification to rma_bw, the test
can take new longer than 360 seconds (current default) to finish.
This patch increased the default timeout for rma_bw test to
540 seconds