### PR TITLE
prov/tcp: separate the max inject and recv buf size

### DIFF
--- a/prov/tcp/src/xnet.h
+++ b/prov/tcp/src/xnet.h
@@ -69,6 +69,7 @@
 
 #define XNET_RDM_VERSION	0
 #define XNET_DEF_INJECT		128
+#define XNET_DEF_BUF_SIZE	16384
 #define XNET_MAX_EVENTS		128
 #define XNET_MIN_MULTI_RECV	16384
 #define XNET_PORT_MAX_RANGE	(USHRT_MAX)
@@ -92,7 +93,7 @@ extern int xnet_disable_autoprog;
 extern int xnet_io_uring;
 extern int xnet_max_saved;
 extern size_t xnet_max_inject;
-
+extern size_t xnet_buf_size;
 struct xnet_xfer_entry;
 struct xnet_ep;
 struct xnet_rdm;

--- a/prov/tcp/src/xnet_init.c
+++ b/prov/tcp/src/xnet_init.c
@@ -69,6 +69,7 @@ int xnet_disable_autoprog;
 int xnet_io_uring;
 int xnet_max_saved = 4;
 size_t xnet_max_inject = XNET_DEF_INJECT;
+size_t xnet_buf_size = XNET_DEF_BUF_SIZE;
 
 
 static void xnet_init_env(void)
@@ -117,9 +118,7 @@ static void xnet_init_env(void)
 	if (!fi_param_get_size_t(&xnet_prov, "rx_size", &rx_size))
 		xnet_default_rx_size = rx_size;
 	fi_param_define(&xnet_prov, "max_inject", FI_PARAM_SIZE_T,
-			"maximum size for inject messages.  This also "
-			"includes the maximum size for messages that may "
-			"be buffered at the receiver (default: %zu)",
+			"maximum size for inject messages (default: %zu)",
 			xnet_max_inject);
 	fi_param_get_size_t(&xnet_prov, "max_inject", &xnet_max_inject);
 
@@ -132,6 +131,16 @@ static void xnet_init_env(void)
 			"applications to prevent hangs. (default: %d)",
 			xnet_max_saved);
 	fi_param_get_int(&xnet_prov, "max_saved", &xnet_max_saved);
+
+	fi_param_define(&xnet_prov, "max_rx_size", FI_PARAM_SIZE_T,
+			"maximum size for message buffers. If set lower "
+			"than FI_TCP_MAX_INJECT, it will be increased to "
+			"match (default: %zu)", xnet_buf_size);
+	fi_param_get_size_t(&xnet_prov, "max_rx_size", &xnet_buf_size);
+
+	if (xnet_max_inject > xnet_buf_size)
+		xnet_buf_size = xnet_max_inject;
+
 	fi_param_define(&xnet_prov, "nodelay", FI_PARAM_BOOL,
 			"overrides default TCP_NODELAY socket setting "
 			"(default %d)", xnet_nodelay);

--- a/prov/tcp/src/xnet_progress.c
+++ b/prov/tcp/src/xnet_progress.c
@@ -88,7 +88,7 @@ static bool xnet_save_and_cont(struct xnet_ep *ep)
 	assert(ep->cur_rx.hdr.base_hdr.op == ofi_op_tagged);
 	assert(ep->srx);
 
-	if ((ep->cur_rx.data_left > xnet_max_inject) ||
+	if ((ep->cur_rx.data_left > xnet_buf_size) ||
 	    (ep->peer->fi_addr == FI_ADDR_NOTAVAIL))
 		return false;
 
@@ -134,7 +134,7 @@ xnet_get_save_rx(struct xnet_ep *ep, uint64_t tag)
 	rx_entry->user_buf = NULL;
 	rx_entry->iov_cnt = 1;
 	rx_entry->iov[0].iov_base = &rx_entry->msg_data;
-	rx_entry->iov[0].iov_len = xnet_max_inject;
+	rx_entry->iov[0].iov_len = xnet_buf_size;
 
 	slist_insert_tail(&rx_entry->entry, &ep->saved_msg->queue);
 	if (!ep->saved_msg->cnt++) {
@@ -1610,7 +1610,7 @@ int xnet_init_progress(struct xnet_progress *progress, struct fi_info *info)
 		goto err2;
 
 	ret = ofi_bufpool_create(&progress->xfer_pool,
-			sizeof(struct xnet_xfer_entry) + xnet_max_inject,
+			sizeof(struct xnet_xfer_entry) + xnet_buf_size,
 			16, 0, 1024, 0);
 	if (ret)
 		goto err3;


### PR DESCRIPTION
this change allows for larger buffers on the receive side without forcing larger copies on the send side