### PR TITLE
hmem/rocr: report bytes done

### DIFF
--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -1188,7 +1188,7 @@ static void smr_progress_ipc_list(struct smr_ep *ep)
 		}
 
 		ret = smr_complete_rx(ep, context, ipc_entry->cmd.msg.hdr.op,
-				flags, ipc_entry->bytes_done,
+				flags, ipc_entry->cmd.msg.hdr.size,
 				ipc_entry->iov[0].iov_base,
 				ipc_entry->cmd.msg.hdr.id,
 				ipc_entry->cmd.msg.hdr.tag,


### PR DESCRIPTION
For asynchronous operations the bytes copied is not reported back. When an asynchronous copy completes the entire size requested to be copied should've already been copied. Therefore, keep track of that and report it back in the copy_query API.

Since it's possible to have multiple asynchronous operations for a single copy, if the copy is described over multiple IOVECs, then make sure to add all these up when reporting the final completion.