### PR TITLE
include/ofi_mem.h: Fix Freestack Alignment

### DIFF
--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -213,7 +213,7 @@ void dummy ## name (void) /* work-around global ; scope */
 /*
  * Buffer pool (free stack) template for shared memory regions
  */
-#define SMR_ALIGN_BOUNDARY	64
+#define SMR_ALIGN_BOUNDARY	4096
 #define SMR_FREESTACK_EMPTY	(-1)
 
 struct smr_freestack {


### PR DESCRIPTION
Switching freestack alignment to be at 4096 page boundaries has a latency benefit for both SHM/SM2.

For SHM: .33us -> .32us
For SM2: .2us -> .19us