### PR TITLE
prov/efa: Bugfix for initializing SHM offload

### DIFF
--- a/prov/efa/src/efa_shm.c
+++ b/prov/efa/src/efa_shm.c
@@ -143,7 +143,6 @@ void efa_shm_info_create(const struct fi_info *app_info, struct fi_info **shm_in
 	if (ret) {
 		EFA_WARN(FI_LOG_CORE, "Disabling EFA shared memory support; failed to get shm provider's info: %s\n",
 			fi_strerror(-ret));
-		efa_env.enable_shm_transfer = 0;
 		*shm_info = NULL;
 	} else {
 		assert(!strcmp((*shm_info)->fabric_attr->name, shm_provider));


### PR DESCRIPTION
Do not set efa_env.enable_shm_transfer=0, when we are not able to initialize SHM b/c of its capabilities.  This is b/c efa_env is a global variable. When using OMPI, SM2 fails to be launched for the BTL, which will make the next EP instance of EFA fail for MTL as well.

I verified this doesn't mess up other places where efa_env.enable_shm_transfer is used.  The only other questionable place is in efa_prov_info, where we resize the EFA inject size to the SHM inject size before we are sure that we will be able to use a SHM offload.