### PR TITLE
fabtests/pytests: skip neuron memory type for shm and sm2

### DIFF
--- a/fabtests/pytest/shm/conftest.py
+++ b/fabtests/pytest/shm/conftest.py
@@ -4,9 +4,6 @@ import pytest
 @pytest.fixture(scope="module", params=["host_to_host",
                                         pytest.param("host_to_cuda", marks=pytest.mark.cuda_memory),
                                         pytest.param("cuda_to_host", marks=pytest.mark.cuda_memory),
-                                        pytest.param("cuda_to_cuda", marks=pytest.mark.cuda_memory),
-                                        pytest.param("neuron_to_neuron", marks=pytest.mark.neuron_memory),
-                                        pytest.param("neuron_to_host", marks=pytest.mark.neuron_memory),
-                                        pytest.param("host_to_neuron", marks=pytest.mark.neuron_memory)])
+                                        pytest.param("cuda_to_cuda", marks=pytest.mark.cuda_memory)])
 def memory_type(request):
     return request.param

--- a/fabtests/pytest/sm2/conftest.py
+++ b/fabtests/pytest/sm2/conftest.py
@@ -3,10 +3,7 @@ import pytest
 @pytest.fixture(scope="module", params=["host_to_host",
                                         pytest.param("host_to_cuda", marks=pytest.mark.cuda_memory),
                                         pytest.param("cuda_to_host", marks=pytest.mark.cuda_memory),
-                                        pytest.param("cuda_to_cuda", marks=pytest.mark.cuda_memory),
-                                        pytest.param("neuron_to_neuron", marks=pytest.mark.neuron_memory),
-                                        pytest.param("neuron_to_host", marks=pytest.mark.neuron_memory),
-                                        pytest.param("host_to_neuron", marks=pytest.mark.neuron_memory)])
+                                        pytest.param("cuda_to_cuda", marks=pytest.mark.cuda_memory)])
 def memory_type(request):
     return request.param
 


### PR DESCRIPTION
intra node communication involving neuron iface won't work for shm and sm2 because the neuron to host memcpy is currently not supported in libfabric. This patch skips neuron for shm and sm2.