### PR TITLE
prov/verbs(ND): Release lock in network direct error paths

### DIFF
--- a/prov/verbs/src/windows/verbs_nd_ibv.c
+++ b/prov/verbs/src/windows/verbs_nd_ibv.c
@@ -431,6 +431,7 @@ int ibv_req_notify_cq(struct ibv_cq *cq, int solicited_only)
 {
 	struct nd_cq *cq_nd;
 	HRESULT hr;
+	int ret = 0;
 
 	VRB_TRACE(FI_LOG_FABRIC, "\n");
 
@@ -455,12 +456,12 @@ int ibv_req_notify_cq(struct ibv_cq *cq, int solicited_only)
 		if (FAILED(hr)) {
 			cq_nd->notification.cb_pending = 0;
 			errno = hresult2fi(hr);
-			return errno;
+			ret = errno;
 		}
 	}
 	ofi_mutex_unlock(&cq_nd->notification.lock);
 
-	return 0;
+	return ret;
 }
 
 int ibv_get_cq_event(struct ibv_comp_channel *channel, struct ibv_cq **cq,

--- a/prov/verbs/src/windows/verbs_nd_rdma.c
+++ b/prov/verbs/src/windows/verbs_nd_rdma.c
@@ -499,6 +499,7 @@ int rdma_listen(struct rdma_cm_id *id, int backlog)
 	if (FAILED(hr)) {
 		--id_nd->listen_event.base.cb_pending;
 		errno = hresult2fi(hr);
+		ofi_mutex_unlock(&id_nd->listen_event.base.lock);
 		goto err1;
 	}
 	ofi_mutex_unlock(&id_nd->listen_event.base.lock);
@@ -514,6 +515,7 @@ int rdma_connect(struct rdma_cm_id *id, struct rdma_conn_param *conn_param)
 	struct nd_cm_id *id_nd;
 	struct nd_qp *qp_nd;
 	HRESULT hr;
+	int ret = 0;
 
 	VRB_TRACE(FI_LOG_FABRIC, "\n");
 
@@ -541,7 +543,7 @@ int rdma_connect(struct rdma_cm_id *id, struct rdma_conn_param *conn_param)
 	if (FAILED(hr)) {
 		--id_nd->connect_event.base.cb_pending;
 		errno = hresult2fi(hr);
-		return -1;
+		ret = -1;
 	}
 	ofi_mutex_unlock(&id_nd->connect_event.base.lock);
 
@@ -553,6 +555,7 @@ int rdma_accept(struct rdma_cm_id *id, struct rdma_conn_param *conn_param)
 	struct nd_cm_id *id_nd;
 	struct nd_qp *qp_nd;
 	HRESULT hr;
+	int ret = 0;
 
 	VRB_TRACE(FI_LOG_FABRIC, "\n");
 
@@ -579,11 +582,11 @@ int rdma_accept(struct rdma_cm_id *id, struct rdma_conn_param *conn_param)
 	if (FAILED(hr)) {
 		--id_nd->connect_event.base.cb_pending;
 		errno = hresult2fi(hr);
-		return -1;
+		ret = -1;
 	}
 	ofi_mutex_unlock(&id_nd->connect_event.base.lock);
 
-	return 0;
+	return ret;
 }
 
 int rdma_reject(struct rdma_cm_id *id, const void *private_data,
@@ -616,6 +619,7 @@ int rdma_disconnect(struct rdma_cm_id *id)
 {
 	struct nd_cm_id *id_nd;
 	HRESULT hr;
+	int ret = 0;
 
 	VRB_TRACE(FI_LOG_FABRIC, "\n");
 
@@ -641,11 +645,11 @@ int rdma_disconnect(struct rdma_cm_id *id)
 	if (FAILED(hr)) {
 		--id_nd->connect_event.base.cb_pending;
 		errno = hresult2fi(hr);
-		return -1;
+		ret = -1;
 	}
 	ofi_mutex_unlock(&id_nd->connect_event.base.lock);
 
-	return 0;
+	return ret;
 }
 
 int rdma_get_cm_event(struct rdma_event_channel *channel,


### PR DESCRIPTION
Flagged by coverity.  Return in case of errors without releasing lock.