### PR TITLE
prov/efa: fix the gdrcopy_handle procedure

### DIFF
--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -929,9 +929,7 @@ static int efa_mr_reg_impl(struct efa_mr *efa_mr, uint64_t flags, void *attr)
 			shm_flags |= FI_HMEM_DEVICE_ONLY;
 		}
 
-		if (FI_VERSION_GE(efa_mr->domain->util_domain.fabric->fabric_fid.api_version, FI_VERSION(1, 19))) {
-			mr_attr->hmem_data = efa_mr->peer.hmem_data;
-		}
+		mr_attr->hmem_data = efa_mr->peer.hmem_data;
 
 		ret = fi_mr_regattr(efa_mr->domain->shm_domain, mr_attr,
 				    shm_flags, &efa_mr->shm_mr);

--- a/prov/efa/src/efa_shm.c
+++ b/prov/efa/src/efa_shm.c
@@ -137,7 +137,7 @@ void efa_shm_info_create(const struct fi_info *app_info, struct fi_info **shm_in
 	shm_hints->fabric_attr->prov_name = strdup(shm_provider);
 	shm_hints->ep_attr->type = FI_EP_RDM;
 
-	ret = fi_getinfo(FI_VERSION(1, 8), NULL, NULL,
+	ret = fi_getinfo(FI_VERSION(1, 19), NULL, NULL,
 	                 OFI_GETINFO_HIDDEN, shm_hints, shm_info);
 	fi_freeinfo(shm_hints);
 	if (ret) {


### PR DESCRIPTION
This PR contains 2 commits to fix the procedure that efa pass gdrcopy handle to shm.

1. Use shm with 1.19 API, since hmem_data is introduced for libfabric >= 1.19
2. Remove the version check in efa_mr.c, since efa is using hmem_data internally so it should not care what api version that application is using