### PR TITLE
prov/verbs: Remove saved_wc_list and use CQ directly

### DIFF
--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -53,112 +53,85 @@ enum ibv_wc_opcode vrb_wr2wc_opcode(enum ibv_wr_opcode wr)
 	return (wr < ARRAY_SIZE(wc)) ? wc[wr] : IBV_WC_SEND;
 }
 
-static void vrb_cq_read_context_entry(struct ibv_wc *wc, void *buf)
+static void
+vrb_get_cq_info(struct ibv_wc *wc, uint64_t *flags, uint64_t *data,
+		size_t *len)
 {
-	struct fi_cq_entry *entry = buf;
-
-	entry->op_context = (void *) (uintptr_t) wc->wr_id;
-}
-
-static void vrb_cq_read_msg_entry(struct ibv_wc *wc, void *buf)
-{
-	struct fi_cq_msg_entry *entry = buf;
-
-	entry->op_context = (void *) (uintptr_t) wc->wr_id;
-
 	switch (wc->opcode) {
 	case IBV_WC_SEND:
-		entry->flags = (FI_SEND | FI_MSG);
+		*len = 0;
+		*flags = (FI_SEND | FI_MSG);
+		*data = 0;
 		break;
 	case IBV_WC_RDMA_WRITE:
-		entry->flags = (FI_RMA | FI_WRITE);
+		*len = 0;
+		*flags = (FI_RMA | FI_WRITE);
+		*data = 0;
 		break;
 	case IBV_WC_RDMA_READ:
-		entry->flags = (FI_RMA | FI_READ);
+		*len = 0;
+		*flags = (FI_RMA | FI_READ);
+		*data = 0;
 		break;
 	case IBV_WC_COMP_SWAP:
-		entry->flags = FI_ATOMIC;
+		*len = 0;
+		*flags = FI_ATOMIC;
+		*data = 0;
 		break;
 	case IBV_WC_FETCH_ADD:
-		entry->flags = FI_ATOMIC;
+		*len = 0;
+		*flags = FI_ATOMIC;
+		*data = 0;
 		break;
 	case IBV_WC_RECV:
-		entry->len = wc->byte_len;
-		entry->flags = (FI_RECV | FI_MSG);
+		*len = wc->byte_len;
+		if (wc->wc_flags & IBV_WC_WITH_IMM) {
+			*flags = (FI_RECV | FI_MSG | FI_REMOTE_CQ_DATA);
+			*data = ntohl(wc->imm_data);
+		} else {
+			*flags = (FI_RECV | FI_MSG);
+			*data = 0;
+		}
 		break;
 	case IBV_WC_RECV_RDMA_WITH_IMM:
-		entry->len = wc->byte_len;
-		entry->flags = (FI_RMA | FI_REMOTE_WRITE);
+		*len = wc->byte_len;
+		*flags = (FI_RMA | FI_REMOTE_WRITE | FI_REMOTE_CQ_DATA);
+		*data = ntohl(wc->imm_data);
 		break;
 	default:
+		*len = 0;
+		*flags = 0;
+		*data = 0;
 		break;
-	}
-}
-
-static void vrb_cq_read_data_entry(struct ibv_wc *wc, void *buf)
-{
-	struct fi_cq_data_entry *entry = buf;
-
-	/* fi_cq_data_entry can cast to fi_cq_msg_entry */
-	vrb_cq_read_msg_entry(wc, buf);
-	if ((wc->wc_flags & IBV_WC_WITH_IMM) &&
-	    (wc->opcode & IBV_WC_RECV)) {
-		entry->data = ntohl(wc->imm_data);
-		entry->flags |= FI_REMOTE_CQ_DATA;
 	}
 }
 
 static ssize_t
-vrb_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *entry,
-		  uint64_t flags)
+vrb_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t count,
+		fi_addr_t *src_addr)
 {
 	struct vrb_cq *cq;
-	struct vrb_wc_entry *wce;
-	struct slist_entry *slist_entry;
-	uint32_t api_version;
+	ssize_t ret;
 
 	cq = container_of(cq_fid, struct vrb_cq, util_cq.cq_fid);
-
 	ofi_genlock_lock(vrb_cq2_progress(cq)->active_lock);
-	if (slist_empty(&cq->saved_wc_list))
-		goto err;
-
-	wce = container_of(cq->saved_wc_list.head, struct vrb_wc_entry, entry);
-	if (!wce->wc.status)
-		goto err;
-
-	api_version = cq->util_cq.domain->fabric->fabric_fid.api_version;
-
-	slist_entry = slist_remove_head(&cq->saved_wc_list);
+	ret = ofi_cq_readfrom(cq_fid, buf, count, src_addr);
 	ofi_genlock_unlock(vrb_cq2_progress(cq)->active_lock);
+	return ret;
+}
 
-	wce = container_of(slist_entry, struct vrb_wc_entry, entry);
+static ssize_t
+vrb_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *entry,
+	       uint64_t flags)
+{
+	struct vrb_cq *cq;
+	ssize_t ret;
 
-	entry->op_context = (void *)(uintptr_t)wce->wc.wr_id;
-	entry->prov_errno = wce->wc.status;
-	if (wce->wc.status == IBV_WC_WR_FLUSH_ERR)
-		entry->err = FI_ECANCELED;
-	else
-		entry->err = EIO;
-
-	/* fi_cq_err_entry can cast to fi_cq_data_entry */
-	vrb_cq_read_data_entry(&wce->wc, (void *) entry);
-
-	if ((FI_VERSION_GE(api_version, FI_VERSION(1, 5))) &&
-		entry->err_data && entry->err_data_size) {
-		entry->err_data_size = MIN(entry->err_data_size,
-			sizeof(wce->wc.vendor_err));
-		memcpy(entry->err_data, &wce->wc.vendor_err, entry->err_data_size);
-	} else {
-		memcpy(&entry->err_data, &wce->wc.vendor_err,
-			sizeof(wce->wc.vendor_err));
-	}
-
-	ofi_buf_free(wce);
-	return 1;
-err:
+	cq = container_of(cq_fid, struct vrb_cq, util_cq.cq_fid);
+	ofi_genlock_lock(vrb_cq2_progress(cq)->active_lock);
+	ret = ofi_cq_readerr(cq_fid, entry, flags);
 	ofi_genlock_unlock(vrb_cq2_progress(cq)->active_lock);
-	return -FI_EAGAIN;
+	return ret;
 }
 
 static inline int
@@ -285,24 +258,38 @@ int vrb_poll_cq(struct vrb_cq *cq, struct ibv_wc *wc)
 	return ret;
 }
 
-int vrb_save_wc(struct vrb_cq *cq, struct ibv_wc *wc)
+void vrb_report_wc(struct vrb_cq *cq, struct ibv_wc *wc)
 {
-	struct vrb_wc_entry *wce;
+	struct fi_cq_err_entry err_entry;
+	uint64_t flags, data;
+	size_t len;
 
 	assert(ofi_genlock_held(vrb_cq2_progress(cq)->active_lock));
-	wce = ofi_buf_alloc(cq->wce_pool);
-	if (!wce) {
-		FI_WARN(&vrb_prov, FI_LOG_CQ,
-			"Unable to save completion, completion lost!\n");
-		return -FI_ENOMEM;
-	}
 
-	wce->wc = *wc;
-	slist_insert_tail(&wce->entry, &cq->saved_wc_list);
-	return FI_SUCCESS;
+	if (wc->status) {
+		vrb_get_cq_info(wc, &err_entry.flags, &err_entry.data, &len);
+
+		err_entry.op_context = (void *) (uintptr_t) wc->wr_id;
+		err_entry.len = 0;
+		err_entry.buf = NULL;
+		err_entry.tag = 0;
+		err_entry.olen = 0;
+
+		err_entry.err = (wc->status == IBV_WC_WR_FLUSH_ERR) ?
+				FI_ECANCELED : FI_EIO;
+		err_entry.prov_errno = (int) wc->status;
+		err_entry.err_data = NULL;
+		err_entry.err_data_size = 0;
+
+		(void) ofi_cq_write_error(&cq->util_cq, &err_entry);
+	} else {
+		vrb_get_cq_info(wc, &flags, &data, &len);
+		(void) ofi_cq_write(&cq->util_cq, (void *) (uintptr_t) wc->wr_id,
+				    flags, len, NULL, data, 0);
+	}
 }
 
-static void vrb_flush_cq(struct vrb_cq *cq)
+void vrb_flush_cq(struct vrb_cq *cq)
 {
 	struct ibv_wc wc;
 	ssize_t ret;
@@ -313,7 +300,7 @@ static void vrb_flush_cq(struct vrb_cq *cq)
 		if (ret <= 0)
 			break;
 
-		vrb_save_wc(cq, &wc);
+		vrb_report_wc(cq, &wc);
 	};
 }
 
@@ -330,62 +317,14 @@ void vrb_cleanup_cq(struct vrb_ep *ep)
 	}
 }
 
-static ssize_t vrb_cq_read(struct fid_cq *cq_fid, void *buf, size_t count)
-{
-	struct vrb_cq *cq;
-	struct vrb_wc_entry *wce;
-	struct slist_entry *entry;
-	struct ibv_wc wc;
-	ssize_t ret = 0, i;
-
-	cq = container_of(cq_fid, struct vrb_cq, util_cq.cq_fid);
-
-	ofi_genlock_lock(vrb_cq2_progress(cq)->active_lock);
-	for (i = 0; i < count; i++) {
-		if (!slist_empty(&cq->saved_wc_list)) {
-			wce = container_of(cq->saved_wc_list.head,
-					   struct vrb_wc_entry, entry);
-			if (wce->wc.status) {
-				ret = -FI_EAVAIL;
-				break;
-			}
-			entry = slist_remove_head(&cq->saved_wc_list);
-			wce = container_of(entry, struct vrb_wc_entry, entry);
-			cq->read_entry(&wce->wc, (char *) buf + i * cq->entry_size);
-			ofi_buf_free(wce);
-			continue;
-		}
-
-		ret = vrb_poll_cq(cq, &wc);
-		if (ret <= 0)
-			break;
-
-		if (wc.status) {
-			wce = ofi_buf_alloc(cq->wce_pool);
-			if (!wce) {
-				ofi_genlock_unlock(vrb_cq2_progress(cq)->active_lock);
-				return -FI_ENOMEM;
-			}
-			memset(wce, 0, sizeof(*wce));
-			memcpy(&wce->wc, &wc, sizeof wc);
-			slist_insert_tail(&wce->entry, &cq->saved_wc_list);
-			ret = -FI_EAVAIL;
-			break;
-		}
-
-		cq->read_entry(&wc, (char *)buf + i * cq->entry_size);
-	}
-
-	ofi_genlock_unlock(vrb_cq2_progress(cq)->active_lock);
-	return i ? i : (ret < 0 ? ret : -FI_EAGAIN);
-}
-
 static const char *
 vrb_cq_strerror(struct fid_cq *eq, int prov_errno, const void *err_data,
 		   char *buf, size_t len)
 {
-	if (buf && len)
+	if (buf && len) {
 		strncpy(buf, ibv_wc_status_str(prov_errno), len);
+		return buf;
+	}
 	return ibv_wc_status_str(prov_errno);
 }
 
@@ -402,9 +341,8 @@ int vrb_cq_signal(struct fid_cq *cq)
 
 int vrb_cq_trywait(struct vrb_cq *cq)
 {
-	struct ibv_wc wc;
 	void *context;
-	int ret = -FI_EAGAIN, rc;
+	int ret;
 
 	if (!cq->channel) {
 		VRB_WARN(FI_LOG_CQ, "No wait object object associated with CQ\n");
@@ -412,36 +350,25 @@ int vrb_cq_trywait(struct vrb_cq *cq)
 	}
 
 	ofi_genlock_lock(vrb_cq2_progress(cq)->active_lock);
-	if (!slist_empty(&cq->saved_wc_list))
-		goto out;
-
-	rc = vrb_poll_cq(cq, &wc);
-	if (rc) {
-		if (rc > 0)
-			vrb_save_wc(cq, &wc);
+	if (!ofi_cirque_isempty(cq->util_cq.cirq)) {
+		ret = -FI_EAGAIN;
 		goto out;
 	}
 
 	while (!ibv_get_cq_event(cq->channel, &cq->cq, &context))
 		ofi_atomic_inc32(&cq->nevents);
 
-	rc = ibv_req_notify_cq(cq->cq, 0);
-	if (rc) {
+	ret = ibv_req_notify_cq(cq->cq, 0);
+	if (ret) {
 		VRB_WARN(FI_LOG_CQ, "ibv_req_notify_cq error: %d\n", ret);
 		ret = -errno;
 		goto out;
 	}
 
-	/* Read again to fetch any completions that we might have missed
-	 * while rearming */
-	rc = vrb_poll_cq(cq, &wc);
-	if (rc) {
-		if (rc > 0)
-			vrb_save_wc(cq, &wc);
-		goto out;
-	}
+	/* Fetch any completions that we might have missed while rearming */
+	vrb_flush_cq(cq);
+	ret = ofi_cirque_isempty(cq->util_cq.cirq) ? FI_SUCCESS : -FI_EAGAIN;
 
-	ret = FI_SUCCESS;
 out:
 	ofi_genlock_unlock(vrb_cq2_progress(cq)->active_lock);
 	return ret;
@@ -449,11 +376,11 @@ out:
 
 static struct fi_ops_cq vrb_cq_ops = {
 	.size = sizeof(struct fi_ops_cq),
-	.read = vrb_cq_read,
-	.readfrom = fi_no_cq_readfrom,
+	.read = ofi_cq_read,
+	.readfrom = vrb_cq_readfrom,
 	.readerr = vrb_cq_readerr,
 	.sread = vrb_cq_sread,
-	.sreadfrom = fi_no_cq_sreadfrom,
+	.sreadfrom = ofi_cq_sreadfrom,
 	.signal = vrb_cq_signal,
 	.strerror = vrb_cq_strerror
 };
@@ -501,8 +428,6 @@ static int vrb_cq_control(fid_t fid, int command, void *arg)
 
 static int vrb_cq_close(fid_t fid)
 {
-	struct vrb_wc_entry *wce;
-	struct slist_entry *entry;
 	struct vrb_cq *cq = container_of(fid, struct vrb_cq, util_cq.cq_fid);
 	struct vrb_srx *srx;
 	struct dlist_entry *srx_temp;
@@ -523,15 +448,7 @@ static int vrb_cq_close(fid_t fid)
 			return -ret;
 		}
 	}
-
-	while (!slist_empty(&cq->saved_wc_list)) {
-		entry = slist_remove_head(&cq->saved_wc_list);
-		wce = container_of(entry, struct vrb_wc_entry, entry);
-		ofi_buf_free(wce);
-	}
 	ofi_genlock_unlock(vrb_cq2_progress(cq)->active_lock);
-
-	ofi_bufpool_destroy(cq->wce_pool);
 
 	if (cq->cq) {
 		ret = ibv_destroy_cq(cq->cq);
@@ -559,10 +476,12 @@ static struct fi_ops vrb_cq_fi_ops = {
 	.ops_open = fi_no_ops_open,
 };
 
-static void vrb_util_cq_progress_noop(struct util_cq *cq)
+static void vrb_cq_progress(struct util_cq *util_cq)
 {
-	/* This routine shouldn't be called */
-	assert(0);
+	struct vrb_cq *cq;
+
+	cq = container_of(util_cq, struct vrb_cq, util_cq);
+	vrb_flush_cq(cq);
 }
 
 int vrb_cq_open(struct fid_domain *domain_fid, struct fi_cq_attr *attr,
@@ -584,7 +503,7 @@ int vrb_cq_open(struct fid_domain *domain_fid, struct fi_cq_attr *attr,
 	/* verbs uses its own implementation of wait objects for CQ */
 	tmp_attr.wait_obj = FI_WAIT_NONE;
 	ret = ofi_cq_init(&vrb_prov, domain_fid, &tmp_attr, &cq->util_cq,
-			  vrb_util_cq_progress_noop, context);
+			  vrb_cq_progress, context);
 	if (ret)
 		goto err1;
 
@@ -662,40 +581,13 @@ int vrb_cq_open(struct fid_domain *domain_fid, struct fi_cq_attr *attr,
 		}
 	}
 
-	ret = ofi_bufpool_create(&cq->wce_pool, sizeof(struct vrb_wc_entry),
-				16, 0, VERBS_WCE_CNT, 0);
-	if (ret) {
-		VRB_WARN(FI_LOG_CQ, "Failed to create wce_pool\n");
-		goto err4;
-	}
-
 	cq->flags |= attr->flags;
 	cq->wait_cond = attr->wait_cond;
 	/* verbs uses its own ops for CQ */
 	cq->util_cq.cq_fid.fid.ops = &vrb_cq_fi_ops;
 	cq->util_cq.cq_fid.ops = &vrb_cq_ops;
 
-	switch (attr->format) {
-	case FI_CQ_FORMAT_UNSPEC:
-	case FI_CQ_FORMAT_CONTEXT:
-		cq->read_entry = vrb_cq_read_context_entry;
-		cq->entry_size = sizeof(struct fi_cq_entry);
-		break;
-	case FI_CQ_FORMAT_MSG:
-		cq->read_entry = vrb_cq_read_msg_entry;
-		cq->entry_size = sizeof(struct fi_cq_msg_entry);
-		break;
-	case FI_CQ_FORMAT_DATA:
-		cq->read_entry = vrb_cq_read_data_entry;
-		cq->entry_size = sizeof(struct fi_cq_data_entry);
-		break;
-	case FI_CQ_FORMAT_TAGGED:
-	default:
-		ret = -FI_ENOSYS;
-		goto err5;
-	}
-
-	slist_init(&cq->saved_wc_list);
+	// slist_init(&cq->saved_wc_list);
 	dlist_init(&cq->xrc.srq_list);
 
 	ofi_atomic_initialize32(&cq->nevents, 0);
@@ -703,8 +595,6 @@ int vrb_cq_open(struct fid_domain *domain_fid, struct fi_cq_attr *attr,
 	*cq_fid = &cq->util_cq.cq_fid;
 	return 0;
 
-err5:
-	ofi_bufpool_destroy(cq->wce_pool);
 err4:
 	ibv_destroy_cq(cq->cq);
 err3:

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -140,7 +140,6 @@ ssize_t vrb_post_send(struct vrb_ep *ep, struct ibv_send_wr *wr, uint64_t flags)
 	struct vrb_context *ctx;
 	struct ibv_send_wr *bad_wr;
 	struct vrb_cq *cq;
-	struct ibv_wc wc;
 	size_t credits_to_give = 0;
 	int ret, err;
 
@@ -153,9 +152,7 @@ ssize_t vrb_post_send(struct vrb_ep *ep, struct ibv_send_wr *wr, uint64_t flags)
 
 	if (!ep->sq_credits || !ep->peer_rq_credits) {
 		cq = container_of(ep->util_ep.rx_cq, struct vrb_cq, util_cq);
-		ret = vrb_poll_cq(cq, &wc);
-		if (ret > 0)
-			vrb_save_wc(cq, &wc);
+		vrb_flush_cq(cq);
 
 		if (!ep->sq_credits || !ep->peer_rq_credits)
 			goto freectx;
@@ -486,7 +483,7 @@ static void vrb_flush_sq(struct vrb_ep *ep)
 		vrb_free_ctx(vrb_ep2_progress(ep), ctx);
 
 		if (wc.wr_id != VERBS_NO_COMP_FLAG)
-			vrb_save_wc(cq, &wc);
+			vrb_report_wc(cq, &wc);
 	}
 }
 
@@ -514,7 +511,7 @@ static void vrb_flush_rq(struct vrb_ep *ep)
 		vrb_free_ctx(vrb_ep2_progress(ep), ctx);
 
 		if (wc.wr_id != VERBS_NO_COMP_FLAG)
-			vrb_save_wc(cq, &wc);
+			vrb_report_wc(cq, &wc);
 	}
 }
 

--- a/prov/verbs/src/verbs_ofi.h
+++ b/prov/verbs/src/verbs_ofi.h
@@ -406,7 +406,6 @@ struct vrb_domain {
 };
 
 struct vrb_cq;
-typedef void (*vrb_cq_read_entry)(struct ibv_wc *wc, void *buf);
 
 struct vrb_wc_entry {
 	struct slist_entry	entry;
@@ -425,10 +424,7 @@ struct vrb_cq {
 	enum fi_cq_wait_cond	wait_cond;
 	struct ibv_wc		wc;
 	struct fd_signal	signal;
-	vrb_cq_read_entry	read_entry;
-	struct slist		saved_wc_list;
 	ofi_atomic32_t		nevents;
-	struct ofi_bufpool	*wce_pool;
 
 	struct {
 		/* The list of XRC SRQ contexts associated with this CQ */
@@ -908,7 +904,8 @@ static inline ssize_t vrb_convert_ret(int ret)
 
 
 int vrb_poll_cq(struct vrb_cq *cq, struct ibv_wc *wc);
-int vrb_save_wc(struct vrb_cq *cq, struct ibv_wc *wc);
+void vrb_report_wc(struct vrb_cq *cq, struct ibv_wc *wc);
+void vrb_flush_cq(struct vrb_cq *cq);
 
 #define vrb_init_sge(buf, len, desc) (struct ibv_sge)	\
 	{ .addr = (uintptr_t) buf,			\


### PR DESCRIPTION
The provider reads completions from the HW CQ, processes them, and if needed reports them up to the user in the appropriate format.  Through these steps, it doesn't actually write entries into the libfabric CQ.  However, there are times when it reads from the HW CQ as part of internal progress, but can't report the completions to the user yet.  Rather than writing an entry into the libfabric CQ, it insteads stores the HW completion on a separate list.

The entire process is confusing, results in extra memory, leaves the CQ allocated memory unused, and increases code by not properly leveraging the common CQ functions.

Remove the saved_wc_list and related memory pools.  Instead, after reading from the HW CQ, simply write a completion into the libfabric CQ if one is needed.