### PR TITLE
prov/rxm: revert util peer CQ support

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -865,13 +865,14 @@ rxm_cq_write(struct util_cq *cq, void *context, uint64_t flags, size_t len,
 	FI_DBG(&rxm_prov, FI_LOG_CQ, "Reporting %s completion\n",
 	       fi_tostr((void *) &flags, FI_TYPE_CQ_EVENT_FLAGS));
 
-	ret = ofi_peer_cq_write(cq, context, flags, len, buf, data, tag,
-				FI_ADDR_NOTAVAIL);
+	ret = ofi_cq_write(cq, context, flags, len, buf, data, tag);
 	if (ret) {
 		FI_WARN(&rxm_prov, FI_LOG_CQ,
 			"Unable to report completion\n");
 		assert(0);
 	}
+	if (cq->wait)
+		cq->wait->signal(cq->wait);
 }
 
 static inline void
@@ -883,12 +884,14 @@ rxm_cq_write_src(struct util_cq *cq, void *context, uint64_t flags, size_t len,
 	FI_DBG(&rxm_prov, FI_LOG_CQ, "Reporting %s completion\n",
 	       fi_tostr((void *) &flags, FI_TYPE_CQ_EVENT_FLAGS));
 
-	ret = ofi_peer_cq_write(cq, context, flags, len, buf, data, tag, addr);
+	ret = ofi_cq_write_src(cq, context, flags, len, buf, data, tag, addr);
 	if (ret) {
 		FI_WARN(&rxm_prov, FI_LOG_CQ,
 			"Unable to report completion\n");
 		assert(0);
 	}
+	if (cq->wait)
+		cq->wait->signal(cq->wait);
 }
 
 ssize_t rxm_get_conn(struct rxm_ep *rxm_ep, fi_addr_t addr,

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -141,14 +141,14 @@ static void rxm_cq_write_error_trunc(struct rxm_rx_buf *rx_buf, size_t done_len)
 	FI_WARN(&rxm_prov, FI_LOG_CQ, "Message truncated: "
 		"recv buf length: %zu message length: %" PRIu64 "\n",
 		done_len, rx_buf->pkt.hdr.size);
-	ret = ofi_peer_cq_write_error_trunc(rx_buf->ep->util_ep.rx_cq,
-				rx_buf->recv_entry->context,
-				rx_buf->recv_entry->comp_flags |
-				rx_buf->pkt.hdr.flags,
-				rx_buf->pkt.hdr.size,
-				rx_buf->recv_entry->rxm_iov.iov[0].iov_base,
-				rx_buf->pkt.hdr.data, rx_buf->pkt.hdr.tag,
-				rx_buf->pkt.hdr.size - done_len);
+	ret = ofi_cq_write_error_trunc(rx_buf->ep->util_ep.rx_cq,
+				       rx_buf->recv_entry->context,
+				       rx_buf->recv_entry->comp_flags |
+				       rx_buf->pkt.hdr.flags,
+				       rx_buf->pkt.hdr.size,
+				       rx_buf->recv_entry->rxm_iov.iov[0].iov_base,
+				       rx_buf->pkt.hdr.data, rx_buf->pkt.hdr.tag,
+				       rx_buf->pkt.hdr.size - done_len);
 	if (ret) {
 		FI_WARN(&rxm_prov, FI_LOG_CQ, "Unable to write recv error CQ\n");
 		assert(0);
@@ -1671,8 +1671,8 @@ void rxm_cq_write_error(struct util_cq *cq, struct util_cntr *cntr,
 	if (cntr)
 		rxm_cntr_incerr(cntr);
 
-	if (ofi_peer_cq_write_error(cq, &err_entry)) {
-		FI_WARN(&rxm_prov, FI_LOG_CQ, "Unable to write error\n");
+	if (ofi_cq_write_error(cq, &err_entry)) {
+		FI_WARN(&rxm_prov, FI_LOG_CQ, "Unable to ofi_cq_write_error\n");
 		assert(0);
 	}
 }
@@ -1685,20 +1685,18 @@ void rxm_cq_write_error_all(struct rxm_ep *rxm_ep, int err)
 	err_entry.prov_errno = err;
 	err_entry.err = -err;
 	if (rxm_ep->util_ep.tx_cq) {
-		ret = ofi_peer_cq_write_error(rxm_ep->util_ep.tx_cq,
-					      &err_entry);
+		ret = ofi_cq_write_error(rxm_ep->util_ep.tx_cq, &err_entry);
 		if (ret) {
 			FI_WARN(&rxm_prov, FI_LOG_CQ,
-				"Unable to write error\n");
+				"Unable to ofi_cq_write_error\n");
 			assert(0);
 		}
 	}
 	if (rxm_ep->util_ep.rx_cq) {
-		ret = ofi_peer_cq_write_error(rxm_ep->util_ep.rx_cq,
-					      &err_entry);
+		ret = ofi_cq_write_error(rxm_ep->util_ep.rx_cq, &err_entry);
 		if (ret) {
 			FI_WARN(&rxm_prov, FI_LOG_CQ,
-				"Unable to write error\n");
+				"Unable to ofi_cq_write_error\n");
 			assert(0);
 		}
 	}
@@ -1832,9 +1830,9 @@ void rxm_handle_comp_error(struct rxm_ep *rxm_ep)
 		rxm_cntr_incerr(cntr);
 
 	assert(cq);
-	ret = ofi_peer_cq_write_error(cq, &err_entry);
+	ret = ofi_cq_write_error(cq, &err_entry);
 	if (ret) {
-		FI_WARN(&rxm_prov, FI_LOG_CQ, "Unable to write error\n");
+		FI_WARN(&rxm_prov, FI_LOG_CQ, "Unable to ofi_cq_write_error\n");
 		assert(0);
 	}
 }
@@ -1847,12 +1845,14 @@ ssize_t rxm_thru_comp(struct rxm_ep *ep, struct fi_cq_data_entry *comp)
 	cq = (comp->flags & (FI_RECV | FI_REMOTE_WRITE | FI_REMOTE_READ)) ?
 	     ep->util_ep.rx_cq : ep->util_ep.tx_cq;
 
-	ret = ofi_peer_cq_write(cq, comp->op_context, comp->flags, comp->len,
-				comp->buf, comp->data, 0, FI_ADDR_NOTAVAIL);
+	ret = ofi_cq_write(cq, comp->op_context, comp->flags, comp->len,
+			   comp->buf, comp->data, 0);
 	if (ret) {
 		FI_WARN(&rxm_prov, FI_LOG_CQ, "Unable to report completion\n");
 		assert(0);
 	}
+	if (cq->wait)
+		cq->wait->signal(cq->wait);
 
 	return ret;
 }
@@ -1872,9 +1872,9 @@ void rxm_thru_comp_error(struct rxm_ep *ep)
 	}
 
 	cq = (err_entry.flags & FI_RECV) ? ep->util_ep.rx_cq : ep->util_ep.tx_cq;
-	ret = ofi_peer_cq_write_error(cq, &err_entry);
+	ret = ofi_cq_write_error(cq, &err_entry);
 	if (ret) {
-		FI_WARN(&rxm_prov, FI_LOG_CQ, "Unable to write error\n");
+		FI_WARN(&rxm_prov, FI_LOG_CQ, "Unable to ofi_cq_write_error\n");
 		assert(0);
 	}
 }

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -443,7 +443,7 @@ static bool rxm_ep_cancel_recv(struct rxm_ep *rxm_ep,
 	err_entry.err = FI_ECANCELED;
 	err_entry.prov_errno = -FI_ECANCELED;
 	rxm_recv_entry_release(recv_entry);
-	ret = ofi_peer_cq_write_error(rxm_ep->util_ep.rx_cq, &err_entry);
+	ret = ofi_cq_write_error(rxm_ep->util_ep.rx_cq, &err_entry);
 	if (ret) {
 		FI_WARN(&rxm_prov, FI_LOG_CQ, "Error writing to CQ\n");
 		assert(0);

--- a/prov/rxm/src/rxm_tagged.c
+++ b/prov/rxm/src/rxm_tagged.c
@@ -73,8 +73,8 @@ rxm_peek_recv(struct rxm_ep *rxm_ep, fi_addr_t addr, uint64_t tag,
 	rx_buf = rxm_get_unexp_msg(recv_queue, addr, tag, ignore);
 	if (!rx_buf) {
 		FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Message not found\n");
-		ret = ofi_peer_cq_write_error_peek(rxm_ep->util_ep.rx_cq, tag,
-						   context);
+		ret = ofi_cq_write_error_peek(rxm_ep->util_ep.rx_cq, tag,
+					      context);
 		if (ret)
 			FI_WARN(&rxm_prov, FI_LOG_CQ, "Error writing to CQ\n");
 		return;


### PR DESCRIPTION
rxm_cq_owner_writeerr() expects the err_entry has a valid op_context pointing to ‘struct rxm_coll_buf’

Updated to revert peer CQ support