### PR TITLE
prov/sm2: Fix SM2 fabtest issues

### DIFF
--- a/prov/sm2/src/sm2.h
+++ b/prov/sm2/src/sm2.h
@@ -253,7 +253,7 @@ int sm2_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 int sm2_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 		  struct fid_cntr **cntr_fid, void *context);
 
-sm2_gid_t sm2_verify_peer(struct sm2_ep *ep, fi_addr_t fi_addr, sm2_gid_t *gid);
+int sm2_verify_peer(struct sm2_ep *ep, fi_addr_t fi_addr, sm2_gid_t *gid);
 
 typedef ssize_t (*sm2_proto_func)(struct sm2_ep *ep,
 				  struct sm2_region *peer_smr,

--- a/prov/sm2/src/sm2_av.c
+++ b/prov/sm2/src/sm2_av.c
@@ -249,13 +249,13 @@ int sm2_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 	if (ret)
 		goto out;
 
-	*av = &sm2_av->util_av.av_fid;
-	(*av)->fid.ops = &sm2_av_fi_ops;
-	(*av)->ops = &sm2_av_ops;
-
 	ret = sm2_file_open_or_create(&sm2_av->mmap);
 	if (ret)
 		goto out;
+
+	*av = &sm2_av->util_av.av_fid;
+	(*av)->fid.ops = &sm2_av_fi_ops;
+	(*av)->ops = &sm2_av_ops;
 
 	/* Initialize all addresses to FI_ADDR_NOTAVAIL */
 	for (i = 0; i < SM2_MAX_UNIVERSE_SIZE; i++)

--- a/prov/sm2/src/sm2_ep.c
+++ b/prov/sm2/src/sm2_ep.c
@@ -220,7 +220,7 @@ static void sm2_init_queue(struct sm2_queue *queue, dlist_func_t *match_func)
 	queue->match_func = match_func;
 }
 
-sm2_gid_t sm2_verify_peer(struct sm2_ep *ep, fi_addr_t fi_addr, sm2_gid_t *gid)
+int sm2_verify_peer(struct sm2_ep *ep, fi_addr_t fi_addr, sm2_gid_t *gid)
 {
 	struct sm2_av *sm2_av;
 	struct sm2_ep_allocation_entry *entries;


### PR DESCRIPTION
This PR fixes two bugs which prevented fabtests for SM2 from being run in CI.

The primary issue is the return value of verify peer.

The failed startup is a symptom of that, but causes a crash rather than a clean exit.