### PR TITLE
prov/sm2: Add CMA and CUDA IPC capabilities to sm2

### DIFF
--- a/prov/sm2/src/sm2.h
+++ b/prov/sm2/src/sm2.h
@@ -92,6 +92,7 @@ extern pthread_mutex_t sm2_ep_list_lock;
 enum {
 	sm2_proto_inject,
 	sm2_proto_return,
+	sm2_proto_cma,
 	sm2_proto_max,
 };
 
@@ -108,7 +109,7 @@ enum {
  * 		   NOTE: Only grabbing the bottom 32 bits
  * 	proto - sm2 operation
  * 	sender_gid - id of msg sender
- * 	user_data - the message
+ * 	user_data - the message, for sm2_proto_inject
  */
 struct sm2_xfer_hdr {
 	volatile long int next;
@@ -149,6 +150,11 @@ struct sm2_atomic_data {
 struct sm2_atomic_entry {
 	struct sm2_atomic_hdr atomic_hdr;
 	struct sm2_atomic_data atomic_data;
+};
+
+struct sm2_cma_data {
+	size_t iov_count;
+	struct iovec iov[SM2_IOV_LIMIT];
 };
 
 struct sm2_ep_name {

--- a/prov/sm2/src/sm2.h
+++ b/prov/sm2/src/sm2.h
@@ -109,6 +109,7 @@ enum {
  * 	op_flags - flags associated with op,
  * 		   NOTE: Only grabbing the bottom 32 bits
  * 	proto - sm2 operation
+ * 	proto_flags - Flags used by the sm2 operation
  * 	sender_gid - id of msg sender
  * 	user_data - the message, for sm2_proto_inject
  */
@@ -120,7 +121,8 @@ struct sm2_xfer_hdr {
 	uint64_t context;
 	uint32_t op;
 	uint32_t op_flags;
-	uint32_t proto;
+	uint16_t proto;
+	uint16_t proto_flags;
 	sm2_gid_t sender_gid;
 };
 

--- a/prov/sm2/src/sm2.h
+++ b/prov/sm2/src/sm2.h
@@ -93,6 +93,7 @@ enum {
 	sm2_proto_inject,
 	sm2_proto_return,
 	sm2_proto_cma,
+	sm2_proto_ipc,
 	sm2_proto_max,
 };
 
@@ -213,6 +214,7 @@ struct sm2_xfer_ctx {
 
 struct sm2_domain {
 	struct util_domain util_domain;
+	struct ofi_mr_cache *ipc_cache;
 	struct fid_peer_srx *srx;
 };
 

--- a/prov/sm2/src/sm2.h
+++ b/prov/sm2/src/sm2.h
@@ -82,6 +82,9 @@
 #define SM2_ATOMIC_INJECT_SIZE	    (SM2_INJECT_SIZE - sizeof(struct sm2_atomic_hdr))
 #define SM2_ATOMIC_COMP_INJECT_SIZE (SM2_ATOMIC_INJECT_SIZE / 2)
 
+/* Protocol flags for all protocols */
+#define FI_SM2_UNEXP	   (1 << 0)
+
 extern struct fi_provider sm2_prov;
 extern struct fi_info sm2_info;
 extern struct util_prov sm2_util_prov;

--- a/prov/sm2/src/sm2.h
+++ b/prov/sm2/src/sm2.h
@@ -85,6 +85,10 @@
 /* Protocol flags for all protocols */
 #define FI_SM2_UNEXP	   (1 << 0)
 
+/* Protocol flags for SM2 CMA protocol */
+#define FI_SM2_CMA_HOST_TO_DEV	   (1 << 1)
+#define FI_SM2_CMA_HOST_TO_DEV_ACK (1 << 2)
+
 extern struct fi_provider sm2_prov;
 extern struct fi_info sm2_info;
 extern struct util_prov sm2_util_prov;
@@ -161,6 +165,10 @@ struct sm2_atomic_entry {
 struct sm2_cma_data {
 	size_t iov_count;
 	struct iovec iov[SM2_IOV_LIMIT];
+
+	/* Used for IPC host to device protocol */
+	struct ipc_info ipc_info;
+	struct fi_peer_rx_entry *rx_entry;
 };
 
 struct sm2_ep_name {

--- a/prov/sm2/src/sm2.h
+++ b/prov/sm2/src/sm2.h
@@ -244,7 +244,7 @@ ssize_t sm2_verify_peer(struct sm2_ep *ep, fi_addr_t fi_addr, sm2_gid_t *gid);
 typedef ssize_t (*sm2_proto_func)(struct sm2_ep *ep,
 				  struct sm2_region *peer_smr,
 				  sm2_gid_t peer_gid, uint32_t op, uint64_t tag,
-				  uint64_t data, uint64_t op_flags,
+				  uint64_t data, uint64_t *op_flags,
 				  struct ofi_mr **mr, const struct iovec *iov,
 				  size_t iov_count, size_t total_len,
 				  void *context);

--- a/prov/sm2/src/sm2_attr.c
+++ b/prov/sm2/src/sm2_attr.c
@@ -90,6 +90,19 @@ struct fi_ep_attr sm2_ep_attr = {
 	.type = FI_EP_RDM,
 	.protocol = FI_PROTO_SHM,
 	.protocol_version = 1,
+	.max_msg_size = SIZE_MAX,
+	.max_order_raw_size = SIZE_MAX,
+	.max_order_waw_size = SIZE_MAX,
+	.max_order_war_size = SIZE_MAX,
+	.mem_tag_format = FI_TAG_GENERIC,
+	.tx_ctx_cnt = 1,
+	.rx_ctx_cnt = 1,
+};
+
+struct fi_ep_attr sm2_hmem_ep_attr = {
+	.type = FI_EP_RDM,
+	.protocol = FI_PROTO_SHM,
+	.protocol_version = 1,
 	.max_msg_size = SM2_INJECT_SIZE,
 	.max_order_raw_size = SM2_INJECT_SIZE,
 	.max_order_waw_size = SM2_INJECT_SIZE,
@@ -150,7 +163,7 @@ struct fi_info sm2_hmem_info = {
 	.addr_format = FI_ADDR_STR,
 	.tx_attr = &sm2_hmem_tx_attr,
 	.rx_attr = &sm2_hmem_rx_attr,
-	.ep_attr = &sm2_ep_attr,
+	.ep_attr = &sm2_hmem_ep_attr,
 	.domain_attr = &sm2_hmem_domain_attr,
 	.fabric_attr = &sm2_fabric_attr,
 };

--- a/prov/sm2/src/sm2_attr.c
+++ b/prov/sm2/src/sm2_attr.c
@@ -99,19 +99,6 @@ struct fi_ep_attr sm2_ep_attr = {
 	.rx_ctx_cnt = 1,
 };
 
-struct fi_ep_attr sm2_hmem_ep_attr = {
-	.type = FI_EP_RDM,
-	.protocol = FI_PROTO_SHM,
-	.protocol_version = 1,
-	.max_msg_size = SM2_INJECT_SIZE,
-	.max_order_raw_size = SM2_INJECT_SIZE,
-	.max_order_waw_size = SM2_INJECT_SIZE,
-	.max_order_war_size = SM2_INJECT_SIZE,
-	.mem_tag_format = FI_TAG_GENERIC,
-	.tx_ctx_cnt = 1,
-	.rx_ctx_cnt = 1,
-};
-
 struct fi_domain_attr sm2_domain_attr = {
 	.name = "sm2",
 	.threading = FI_THREAD_SAFE,
@@ -163,7 +150,7 @@ struct fi_info sm2_hmem_info = {
 	.addr_format = FI_ADDR_STR,
 	.tx_attr = &sm2_hmem_tx_attr,
 	.rx_attr = &sm2_hmem_rx_attr,
-	.ep_attr = &sm2_hmem_ep_attr,
+	.ep_attr = &sm2_ep_attr,
 	.domain_attr = &sm2_hmem_domain_attr,
 	.fabric_attr = &sm2_fabric_attr,
 };

--- a/prov/sm2/src/sm2_coordination.h
+++ b/prov/sm2/src/sm2_coordination.h
@@ -50,6 +50,7 @@
 
 #define SM2_XFER_ENTRY_SIZE   4096
 #define SM2_MAX_UNIVERSE_SIZE 256
+#define SM2_MAX_GDRCOPY_SIZE  3072
 /* TODO: Make the number of XFER ENTRY's configurable */
 #define SM2_NUM_XFER_ENTRY_PER_PEER 1024
 

--- a/prov/sm2/src/sm2_ep.c
+++ b/prov/sm2/src/sm2_ep.c
@@ -193,7 +193,7 @@ static void sm2_format_inject(struct sm2_xfer_entry *xfer_entry,
 
 static ssize_t sm2_do_inject(struct sm2_ep *ep, struct sm2_region *peer_smr,
 			     sm2_gid_t peer_gid, uint32_t op, uint64_t tag,
-			     uint64_t data, uint64_t op_flags,
+			     uint64_t data, uint64_t *op_flags,
 			     struct ofi_mr **mr, const struct iovec *iov,
 			     size_t iov_count, size_t total_len, void *context)
 {
@@ -206,9 +206,110 @@ static ssize_t sm2_do_inject(struct sm2_ep *ep, struct sm2_region *peer_smr,
 	if (ret)
 		return ret;
 
-	sm2_generic_format(xfer_entry, ep->gid, op, tag, data, op_flags,
+	sm2_generic_format(xfer_entry, ep->gid, op, tag, data, *op_flags,
 			   context);
 	sm2_format_inject(xfer_entry, mr, iov, iov_count);
+
+	sm2_fifo_write(ep, peer_gid, xfer_entry);
+	return FI_SUCCESS;
+}
+
+static void sm2_format_cma(struct sm2_xfer_entry *xfer_entry,
+			   const struct iovec *iov, size_t count)
+{
+	struct sm2_cma_data *cma_data =
+		(struct sm2_cma_data *) xfer_entry->user_data;
+
+	/* All CMA messages must be delivery complete to stop completion from
+	 * being written instantly */
+	xfer_entry->hdr.proto = sm2_proto_cma;
+	xfer_entry->hdr.size = ofi_total_iov_len(iov, count);
+	cma_data->iov_count = count;
+	memcpy(cma_data->iov, iov, sizeof(*iov) * count);
+}
+
+static ssize_t sm2_do_cma(struct sm2_ep *ep, struct sm2_region *peer_smr,
+			  sm2_gid_t peer_gid, uint32_t op, uint64_t tag,
+			  uint64_t data, uint64_t *op_flags, struct ofi_mr **mr,
+			  const struct iovec *iov, size_t iov_count,
+			  size_t total_len, void *context)
+{
+	ssize_t ret;
+	struct sm2_xfer_entry *xfer_entry;
+
+	ret = sm2_pop_xfer_entry(ep, &xfer_entry);
+	if (ret)
+		return ret;
+
+	*op_flags |= FI_DELIVERY_COMPLETE;
+	sm2_generic_format(xfer_entry, ep->gid, op, tag, data, *op_flags,
+			   context);
+	sm2_format_cma(xfer_entry, iov, iov_count);
+	sm2_fifo_write(ep, peer_gid, xfer_entry);
+
+	return FI_SUCCESS;
+}
+
+static ssize_t sm2_format_ipc(struct sm2_xfer_entry *xfer_entry, void *ptr,
+			      size_t len, enum fi_hmem_iface iface,
+			      uint64_t device)
+{
+	void *base;
+	ssize_t ret;
+	struct ipc_info *ipc_info = (struct ipc_info *) xfer_entry->user_data;
+
+	xfer_entry->hdr.proto = sm2_proto_ipc;
+	xfer_entry->hdr.size = len;
+	ipc_info->iface = iface;
+	ipc_info->device = device;
+
+	ret = ofi_hmem_get_base_addr(ipc_info->iface, ptr, &base,
+				     &ipc_info->base_length);
+	if (ret)
+		return ret;
+
+	ret = ofi_hmem_get_handle(ipc_info->iface, base, ipc_info->base_length,
+				  (void **) &ipc_info->ipc_handle);
+	if (ret)
+		return ret;
+
+	ipc_info->base_addr = (uintptr_t) base;
+	ipc_info->offset = (uintptr_t) ptr - (uintptr_t) base;
+
+	return FI_SUCCESS;
+}
+
+static ssize_t sm2_do_ipc(struct sm2_ep *ep, struct sm2_region *peer_smr,
+			  sm2_gid_t peer_gid, uint32_t op, uint64_t tag,
+			  uint64_t data, uint64_t *op_flags, struct ofi_mr **mr,
+			  const struct iovec *iov, size_t iov_count,
+			  size_t total_len, void *context)
+{
+	struct sm2_xfer_entry *xfer_entry;
+	struct sm2_region *self_region;
+	struct sm2_av *av =
+		container_of(ep->util_ep.av, struct sm2_av, util_av);
+	struct sm2_mmap *map = &av->mmap;
+	ssize_t ret;
+
+	self_region = sm2_mmap_ep_region(map, ep->gid);
+
+	ret = sm2_pop_xfer_entry(ep, &xfer_entry);
+	if (ret)
+		return ret;
+
+	*op_flags |= FI_DELIVERY_COMPLETE;
+	sm2_generic_format(xfer_entry, ep->gid, op, tag, data, *op_flags,
+			   context);
+	ret = sm2_format_ipc(xfer_entry, iov[0].iov_base, total_len,
+			     mr[0]->iface, mr[0]->device);
+
+	if (ret) {
+		FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,
+			"Error generating IPC header information\n");
+		smr_freestack_push(sm2_freestack(self_region), xfer_entry);
+		return ret;
+	}
 
 	sm2_fifo_write(ep, peer_gid, xfer_entry);
 	return FI_SUCCESS;

--- a/prov/sm2/src/sm2_ep.c
+++ b/prov/sm2/src/sm2_ep.c
@@ -684,4 +684,5 @@ ep:
 sm2_proto_func sm2_proto_ops[sm2_proto_max] = {
 	[sm2_proto_inject] = &sm2_do_inject,
 	[sm2_proto_cma] = &sm2_do_cma,
+	[sm2_proto_ipc] = &sm2_do_ipc,
 };

--- a/prov/sm2/src/sm2_ep.c
+++ b/prov/sm2/src/sm2_ep.c
@@ -683,4 +683,5 @@ ep:
 
 sm2_proto_func sm2_proto_ops[sm2_proto_max] = {
 	[sm2_proto_inject] = &sm2_do_inject,
+	[sm2_proto_cma] = &sm2_do_cma,
 };

--- a/prov/sm2/src/sm2_fifo.h
+++ b/prov/sm2/src/sm2_fifo.h
@@ -249,4 +249,21 @@ static inline void sm2_fifo_write_back(struct sm2_ep *ep,
 	sm2_fifo_write(ep, xfer_entry->hdr.sender_gid, xfer_entry);
 }
 
+static inline void
+sm2_fifo_write_back_ipc_host_to_dev(struct sm2_ep *ep,
+				    struct sm2_xfer_entry *xfer_entry)
+{
+	/* This function is called by the sender after the CUDA memcpy is
+	 * complete. Receiver generates receive completion after receiving this
+	 * message */
+	sm2_gid_t receiver_gid = xfer_entry->hdr.sender_gid;
+
+	xfer_entry->hdr.proto = sm2_proto_cma;
+	xfer_entry->hdr.proto_flags &= ~FI_SM2_CMA_HOST_TO_DEV;
+	xfer_entry->hdr.proto_flags |= FI_SM2_CMA_HOST_TO_DEV_ACK;
+	assert(xfer_entry->hdr.sender_gid != ep->gid);
+	xfer_entry->hdr.sender_gid = ep->gid;
+	sm2_fifo_write(ep, receiver_gid, xfer_entry);
+}
+
 #endif /* _SM2_FIFO_H_ */

--- a/prov/sm2/src/sm2_fifo.h
+++ b/prov/sm2/src/sm2_fifo.h
@@ -244,6 +244,7 @@ static inline void sm2_fifo_write_back(struct sm2_ep *ep,
 				       struct sm2_xfer_entry *xfer_entry)
 {
 	xfer_entry->hdr.proto = sm2_proto_return;
+	xfer_entry->hdr.proto_flags = 0;
 	assert(xfer_entry->hdr.sender_gid != ep->gid);
 	sm2_fifo_write(ep, xfer_entry->hdr.sender_gid, xfer_entry);
 }

--- a/prov/sm2/src/sm2_msg.c
+++ b/prov/sm2/src/sm2_msg.c
@@ -38,6 +38,14 @@
 #include "ofi_iov.h"
 #include "sm2.h"
 
+static inline int sm2_select_proto(uint64_t total_len)
+{
+	if (total_len <= SM2_INJECT_SIZE)
+		return sm2_proto_inject;
+
+	return sm2_proto_cma;
+}
+
 static ssize_t sm2_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 			   uint64_t flags)
 {
@@ -85,6 +93,7 @@ static ssize_t sm2_generic_sendmsg(struct sm2_ep *ep, const struct iovec *iov,
 	ssize_t ret = 0;
 	size_t total_len;
 	struct ofi_mr **mr = (struct ofi_mr **) desc;
+	int proto;
 
 	assert(iov_count <= SM2_IOV_LIMIT);
 
@@ -99,9 +108,10 @@ static ssize_t sm2_generic_sendmsg(struct sm2_ep *ep, const struct iovec *iov,
 	total_len = ofi_total_iov_len(iov, iov_count);
 	assert(!(op_flags & FI_INJECT) || total_len <= SM2_INJECT_SIZE);
 
-	ret = sm2_proto_ops[sm2_proto_inject](ep, peer_smr, peer_gid, op, tag,
-					      data, &op_flags, mr, iov,
-					      iov_count, total_len, context);
+	proto = sm2_select_proto(total_len);
+	ret = sm2_proto_ops[proto](ep, peer_smr, peer_gid, op, tag, data,
+				   &op_flags, mr, iov, iov_count, total_len,
+				   context);
 	if (ret)
 		goto unlock_cq;
 

--- a/prov/sm2/src/sm2_msg.c
+++ b/prov/sm2/src/sm2_msg.c
@@ -38,8 +38,37 @@
 #include "ofi_iov.h"
 #include "sm2.h"
 
-static inline int sm2_select_proto(uint64_t total_len)
+static inline int sm2_select_proto(void **desc, size_t iov_count,
+				   uint64_t op_flags, uint64_t total_len)
 {
+	struct ofi_mr *sm2_desc;
+	enum fi_hmem_iface iface;
+
+	if (desc && *desc) {
+		sm2_desc = (struct ofi_mr *) *desc;
+		iface = sm2_desc->iface;
+	} else {
+		iface = FI_HMEM_SYSTEM;
+	}
+
+	/* TODO: Move gdrcopy check out of non-cuda fast paths */
+	if (iface == FI_HMEM_CUDA) {
+		if ((sm2_desc->flags & OFI_HMEM_DATA_GDRCOPY_HANDLE) &&
+		    (total_len <= SM2_MAX_GDRCOPY_SIZE)) {
+			assert(sm2_desc->hmem_data);
+			return sm2_proto_inject;
+		}
+		/* Do not inject if IPC is available so device to device
+		 * transfer may occur if possible. */
+		if (iov_count == 1 && desc && desc[0]) {
+			if (ofi_hmem_is_ipc_enabled(iface) &&
+			    sm2_desc->flags & FI_HMEM_DEVICE_ONLY &&
+			    !(op_flags & FI_INJECT)) {
+				return sm2_proto_ipc;
+			}
+		}
+	}
+
 	if (total_len <= SM2_INJECT_SIZE)
 		return sm2_proto_inject;
 
@@ -108,7 +137,8 @@ static ssize_t sm2_generic_sendmsg(struct sm2_ep *ep, const struct iovec *iov,
 	total_len = ofi_total_iov_len(iov, iov_count);
 	assert(!(op_flags & FI_INJECT) || total_len <= SM2_INJECT_SIZE);
 
-	proto = sm2_select_proto(total_len);
+	proto = sm2_select_proto(desc, iov_count, op_flags, total_len);
+
 	ret = sm2_proto_ops[proto](ep, peer_smr, peer_gid, op, tag, data,
 				   &op_flags, mr, iov, iov_count, total_len,
 				   context);
@@ -194,8 +224,8 @@ static ssize_t sm2_generic_inject(struct fid_ep *ep_fid, const void *buf,
 
 	ofi_genlock_lock(&ep->util_ep.lock);
 	ret = sm2_proto_ops[sm2_proto_inject](ep, peer_smr, peer_gid, op, tag,
-					      data, &op_flags, NULL, &msg_iov, 1,
-					      len, NULL);
+					      data, &op_flags, NULL, &msg_iov,
+					      1, len, NULL);
 
 	if (!ret)
 		ofi_ep_tx_cntr_inc_func(&ep->util_ep, op);

--- a/prov/sm2/src/sm2_msg.c
+++ b/prov/sm2/src/sm2_msg.c
@@ -100,7 +100,7 @@ static ssize_t sm2_generic_sendmsg(struct sm2_ep *ep, const struct iovec *iov,
 	assert(!(op_flags & FI_INJECT) || total_len <= SM2_INJECT_SIZE);
 
 	ret = sm2_proto_ops[sm2_proto_inject](ep, peer_smr, peer_gid, op, tag,
-					      data, op_flags, mr, iov,
+					      data, &op_flags, mr, iov,
 					      iov_count, total_len, context);
 	if (ret)
 		goto unlock_cq;
@@ -184,7 +184,7 @@ static ssize_t sm2_generic_inject(struct fid_ep *ep_fid, const void *buf,
 
 	ofi_genlock_lock(&ep->util_ep.lock);
 	ret = sm2_proto_ops[sm2_proto_inject](ep, peer_smr, peer_gid, op, tag,
-					      data, op_flags, NULL, &msg_iov, 1,
+					      data, &op_flags, NULL, &msg_iov, 1,
 					      len, NULL);
 
 	if (!ret)

--- a/prov/sm2/src/sm2_progress.c
+++ b/prov/sm2/src/sm2_progress.c
@@ -42,6 +42,58 @@
 #include "sm2.h"
 #include "sm2_fifo.h"
 
+static inline int sm2_cma_loop(pid_t pid, struct iovec *local,
+			       unsigned long local_cnt, struct iovec *remote,
+			       unsigned long remote_cnt, size_t total,
+			       bool write)
+{
+	ssize_t ret;
+
+	while (1) {
+		if (write)
+			ret = ofi_process_vm_writev(pid, local, local_cnt,
+						    remote, remote_cnt, 0);
+		else
+			ret = ofi_process_vm_readv(pid, local, local_cnt,
+						   remote, remote_cnt, 0);
+		if (ret < 0) {
+			FI_WARN(&sm2_prov, FI_LOG_EP_CTRL, "CMA error %d\n",
+				errno);
+			return -FI_EIO;
+		}
+
+		total -= ret;
+		if (!total)
+			return FI_SUCCESS;
+
+		ofi_consume_iov(local, &local_cnt, (size_t) ret);
+		ofi_consume_iov(remote, &remote_cnt, (size_t) ret);
+	}
+}
+
+static int sm2_progress_cma(struct sm2_xfer_entry *xfer_entry,
+			    struct iovec *iov, size_t iov_count,
+			    size_t *total_len, struct sm2_ep *ep, int err)
+{
+	struct sm2_cma_data *cma_data =
+		(struct sm2_cma_data *) xfer_entry->user_data;
+	struct sm2_av *sm2_av =
+		container_of(ep->util_ep.av, struct sm2_av, util_av);
+	struct sm2_ep_allocation_entry *entries =
+		sm2_mmap_entries(&sm2_av->mmap);
+	int ret;
+
+	/* TODO Need to update last argument for RMA support (as well as generic
+	 * format) */
+	ret = sm2_cma_loop(entries[xfer_entry->hdr.sender_gid].pid, iov,
+			   iov_count, cma_data->iov, cma_data->iov_count,
+			   xfer_entry->hdr.size, false);
+	if (!ret)
+		*total_len = xfer_entry->hdr.size;
+
+	return -ret;
+}
+
 static int sm2_progress_inject(struct sm2_xfer_entry *xfer_entry,
 			       struct ofi_mr **mr, struct iovec *iov,
 			       size_t iov_count, size_t *total_len,
@@ -84,6 +136,10 @@ static int sm2_start_common(struct sm2_ep *ep,
 		err = sm2_progress_inject(
 			xfer_entry, (struct ofi_mr **) rx_entry->desc,
 			rx_entry->iov, rx_entry->count, &total_len, ep, 0);
+		break;
+	case sm2_proto_cma:
+		err = sm2_progress_cma(xfer_entry, rx_entry->iov,
+				       rx_entry->count, &total_len, ep, 0);
 		break;
 	default:
 		FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,

--- a/prov/sm2/src/sm2_progress.c
+++ b/prov/sm2/src/sm2_progress.c
@@ -109,8 +109,9 @@ static int sm2_start_common(struct sm2_ep *ep,
 	if (ret) {
 		FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,
 			"Unable to process rx completion\n");
-	} else if (return_xfer_entry) {
-		/* Return Free Queue Entries here */
+	}
+
+	if (return_xfer_entry) {
 		sm2_fifo_write_back(ep, xfer_entry);
 	}
 

--- a/prov/sm2/src/sm2_progress.c
+++ b/prov/sm2/src/sm2_progress.c
@@ -172,6 +172,7 @@ static int sm2_progress_recv_msg(struct sm2_ep *ep,
 		if (ret == -FI_ENOENT) {
 			ret = sm2_alloc_xfer_entry_ctx(ep, rx_entry,
 						       xfer_entry);
+			xfer_entry->hdr.op_flags &= ~FI_DELIVERY_COMPLETE;
 			sm2_fifo_write_back(ep, xfer_entry);
 			if (ret)
 				return ret;
@@ -185,6 +186,7 @@ static int sm2_progress_recv_msg(struct sm2_ep *ep,
 		if (ret == -FI_ENOENT) {
 			ret = sm2_alloc_xfer_entry_ctx(ep, rx_entry,
 						       xfer_entry);
+			xfer_entry->hdr.op_flags &= ~FI_DELIVERY_COMPLETE;
 			sm2_fifo_write_back(ep, xfer_entry);
 			if (ret)
 				return ret;

--- a/prov/sm2/src/sm2_progress.c
+++ b/prov/sm2/src/sm2_progress.c
@@ -42,20 +42,138 @@
 #include "sm2.h"
 #include "sm2_fifo.h"
 
-static inline int sm2_cma_loop(pid_t pid, struct iovec *local,
-			       unsigned long local_cnt, struct iovec *remote,
-			       unsigned long remote_cnt, size_t total,
-			       bool write)
+static int sm2_cma_send_ipc_handle(struct sm2_ep *ep,
+				   struct sm2_xfer_entry *xfer_entry,
+				   struct fi_peer_rx_entry *rx_entry,
+				   struct ofi_mr **mr)
+{
+	sm2_gid_t sender_gid = xfer_entry->hdr.sender_gid;
+	struct sm2_xfer_entry *new_xfer_entry;
+	struct sm2_cma_data *cma_data =
+		((struct sm2_cma_data *) xfer_entry->user_data);
+	struct ipc_info *ipc_info;
+	void *device_ptr, *base;
+	int ret;
+
+	/* TODO - multiple IOV support - update protocol selection logic
+	 * to use SAR for multiple IOVs */
+	assert(cma_data->iov_count == 1);
+
+	device_ptr = rx_entry->iov[0].iov_base;
+	ipc_info = &cma_data->ipc_info;
+
+	xfer_entry->hdr.proto = sm2_proto_cma;
+	xfer_entry->hdr.proto_flags |= FI_SM2_CMA_HOST_TO_DEV;
+	xfer_entry->hdr.sender_gid = ep->gid;
+
+	cma_data->rx_entry = rx_entry;
+
+	ipc_info->iface = mr[0]->iface;
+	ipc_info->device = mr[0]->device;
+
+	ret = ofi_hmem_get_base_addr(ipc_info->iface, device_ptr, &base,
+				     &ipc_info->base_length);
+	if (ret) {
+		FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,
+			"Failed to get device memory base "
+			"address. "
+			"Error code: %d\n",
+			ret);
+		return ret;
+	}
+
+	ret = ofi_hmem_get_handle(ipc_info->iface, base, ipc_info->base_length,
+				  (void **) &ipc_info->ipc_handle);
+	if (ret) {
+		FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,
+			"Failed to open IPC handle in host to "
+			"device "
+			"protocol. Error code: %d\n",
+			ret);
+		return ret;
+	}
+
+	ipc_info->base_addr = (uintptr_t) base;
+	ipc_info->offset =
+		(uintptr_t) device_ptr - (uintptr_t) ipc_info->base_addr;
+
+	/* Send xfer_entry with IPC handle back to sender */
+	if (xfer_entry->hdr.proto_flags & FI_SM2_UNEXP) {
+		/* xfer_entry with FI_SM2_UNEXP flag actually points to an
+		 * ofi_bufpool entry in the receiver memory which the sender
+		 * can't read. So we create a new xfer_entry and send it instead
+		 */
+		ret = sm2_pop_xfer_entry(ep, &new_xfer_entry);
+		if (ret)
+			return ret;
+
+		memcpy(new_xfer_entry, xfer_entry,
+		       sizeof(struct sm2_xfer_entry));
+		sm2_fifo_write(ep, sender_gid, new_xfer_entry);
+	} else {
+		sm2_fifo_write(ep, sender_gid, xfer_entry);
+	}
+
+	return FI_SUCCESS;
+}
+
+static int sm2_cma_hmem_memcpy(struct sm2_ep *ep,
+			       struct sm2_xfer_entry *xfer_entry)
+{
+	struct sm2_domain *domain;
+	struct sm2_cma_data *cma_data;
+	struct ipc_info *ipc_info;
+	struct ofi_mr_entry *mr_entry;
+	void *dest;
+	int ret;
+
+	cma_data = (struct sm2_cma_data *) xfer_entry->user_data;
+
+	domain = container_of(ep->util_ep.domain, struct sm2_domain,
+			      util_domain);
+
+	ipc_info = &cma_data->ipc_info;
+	ret = ofi_ipc_cache_search(domain->ipc_cache,
+				   xfer_entry->hdr.sender_gid, ipc_info,
+				   &mr_entry);
+	if (ret)
+		return ret;
+
+	dest = (char *) (uintptr_t) mr_entry->info.ipc_mapped_addr +
+	       (uintptr_t) ipc_info->offset;
+
+	ret = ofi_copy_to_hmem(ipc_info->iface, ipc_info->device, dest,
+			       cma_data->iov[0].iov_base, xfer_entry->hdr.size);
+
+	ofi_mr_cache_delete(domain->ipc_cache, mr_entry);
+
+	return ret ? ret : FI_SUCCESS;
+}
+
+static inline int sm2_cma_loop(struct sm2_ep *ep,
+			       struct sm2_xfer_entry *xfer_entry,
+			       struct fi_peer_rx_entry *rx_entry, size_t total,
+			       bool write, bool *ipc_host_to_dev)
 {
 	ssize_t ret;
+	struct sm2_av *sm2_av =
+		container_of(ep->util_ep.av, struct sm2_av, util_av);
+	struct sm2_ep_allocation_entry *entries =
+		sm2_mmap_entries(&sm2_av->mmap);
+	struct sm2_cma_data *cma_data =
+		(struct sm2_cma_data *) xfer_entry->user_data;
+
+	pid_t pid = entries[xfer_entry->hdr.sender_gid].pid;
 
 	while (1) {
 		if (write)
-			ret = ofi_process_vm_writev(pid, local, local_cnt,
-						    remote, remote_cnt, 0);
+			ret = ofi_process_vm_writev(
+				pid, rx_entry->iov, rx_entry->count,
+				cma_data->iov, cma_data->iov_count, 0);
 		else
-			ret = ofi_process_vm_readv(pid, local, local_cnt,
-						   remote, remote_cnt, 0);
+			ret = ofi_process_vm_readv(
+				pid, rx_entry->iov, rx_entry->count,
+				cma_data->iov, cma_data->iov_count, 0);
 		if (ret < 0) {
 			FI_WARN(&sm2_prov, FI_LOG_EP_CTRL, "CMA error %d\n",
 				errno);
@@ -66,28 +184,50 @@ static inline int sm2_cma_loop(pid_t pid, struct iovec *local,
 		if (!total)
 			return FI_SUCCESS;
 
-		ofi_consume_iov(local, &local_cnt, (size_t) ret);
-		ofi_consume_iov(remote, &remote_cnt, (size_t) ret);
+		ofi_consume_iov(rx_entry->iov, &rx_entry->count, (size_t) ret);
+		ofi_consume_iov(cma_data->iov, &cma_data->iov_count,
+				(size_t) ret);
 	}
 }
 
-static int sm2_progress_cma(struct sm2_xfer_entry *xfer_entry,
-			    struct iovec *iov, size_t iov_count,
-			    size_t *total_len, struct sm2_ep *ep, int err)
+static int sm2_progress_cma(struct sm2_ep *ep,
+			    struct sm2_xfer_entry *xfer_entry,
+			    struct fi_peer_rx_entry *rx_entry,
+			    size_t *total_len, int err, bool *ipc_host_to_dev)
 {
-	struct sm2_cma_data *cma_data =
-		(struct sm2_cma_data *) xfer_entry->user_data;
-	struct sm2_av *sm2_av =
-		container_of(ep->util_ep.av, struct sm2_av, util_av);
-	struct sm2_ep_allocation_entry *entries =
-		sm2_mmap_entries(&sm2_av->mmap);
 	int ret;
+	struct ofi_mr **mr = (struct ofi_mr **) rx_entry->desc;
+	enum fi_hmem_iface iface;
+
+	if (mr && mr[0])
+		iface = mr[0]->iface;
+	else
+		iface = FI_HMEM_SYSTEM;
+
+	if (iface != FI_HMEM_SYSTEM) {
+		/* The sender is trying to send from host
+		 * memory to device memory. CMA does not support
+		 * device memory, so we open the IPC handle,
+		 * return the handle to the sender for the
+		 * sender to a device memcpy */
+
+		/* TODO - multiple IOV support - update protocol selection logic
+		 * to use SAR for multiple IOVs */
+		assert(rx_entry->count == 1);
+
+		err = sm2_cma_send_ipc_handle(ep, xfer_entry, rx_entry, mr);
+		if (err == FI_SUCCESS) {
+			*ipc_host_to_dev = true;
+			return err;
+		}
+		FI_WARN(&sm2_prov, FI_LOG_EP_CTRL, "CMA error %d\n", errno);
+		return -FI_EIO;
+	}
 
 	/* TODO Need to update last argument for RMA support (as well as generic
 	 * format) */
-	ret = sm2_cma_loop(entries[xfer_entry->hdr.sender_gid].pid, iov,
-			   iov_count, cma_data->iov, cma_data->iov_count,
-			   xfer_entry->hdr.size, false);
+	ret = sm2_cma_loop(ep, xfer_entry, rx_entry, xfer_entry->hdr.size,
+			   false, ipc_host_to_dev);
 	if (!ret)
 		*total_len = xfer_entry->hdr.size;
 
@@ -159,15 +299,13 @@ static int sm2_progress_ipc(struct sm2_xfer_entry *xfer_entry,
 	} else if (hmem_copy_ret != xfer_entry->hdr.size) {
 		FI_WARN(&sm2_prov, FI_LOG_EP_CTRL, "IPC recv truncated\n");
 		err = -FI_ETRUNC;
-	} else
+	} else {
 		err = ret;
+	}
 
 	*total_len = hmem_copy_ret;
 
-	if (err)
-		return err;
-	else
-		return FI_SUCCESS;
+	return err ? err : FI_SUCCESS;
 }
 
 static int sm2_start_common(struct sm2_ep *ep,
@@ -177,8 +315,8 @@ static int sm2_start_common(struct sm2_ep *ep,
 	size_t total_len = 0;
 	uint64_t comp_flags;
 	void *comp_buf;
-	int ret;
-	int err = 0;
+	int err = 0, ret = 0;
+	bool ipc_host_to_dev = false;
 
 	switch (xfer_entry->hdr.proto) {
 	case sm2_proto_inject:
@@ -192,8 +330,8 @@ static int sm2_start_common(struct sm2_ep *ep,
 			rx_entry->iov, rx_entry->count, &total_len, ep);
 		break;
 	case sm2_proto_cma:
-		err = sm2_progress_cma(xfer_entry, rx_entry->iov,
-				       rx_entry->count, &total_len, ep, 0);
+		err = sm2_progress_cma(ep, xfer_entry, rx_entry, &total_len, 0,
+				       &ipc_host_to_dev);
 		break;
 	default:
 		FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,
@@ -210,10 +348,15 @@ static int sm2_start_common(struct sm2_ep *ep,
 		ret = sm2_write_err_comp(ep->util_ep.rx_cq, rx_entry->context,
 					 comp_flags, rx_entry->tag, err);
 	} else {
-		ret = sm2_complete_rx(
-			ep, rx_entry->context, xfer_entry->hdr.op, comp_flags,
-			total_len, comp_buf, xfer_entry->hdr.sender_gid,
-			xfer_entry->hdr.tag, xfer_entry->hdr.cq_data);
+		/* If the IPC device to host protocol is used, the receive
+		 * completion is not generated at this stage. Instead, it's
+		 * generated after the sender completes the device memcpy */
+		if (!ipc_host_to_dev)
+			ret = sm2_complete_rx(
+				ep, rx_entry->context, xfer_entry->hdr.op,
+				comp_flags, total_len, comp_buf,
+				xfer_entry->hdr.sender_gid, xfer_entry->hdr.tag,
+				xfer_entry->hdr.cq_data);
 	}
 
 	if (ret) {
@@ -223,7 +366,6 @@ static int sm2_start_common(struct sm2_ep *ep,
 
 	if (!(xfer_entry->hdr.proto_flags & FI_SM2_UNEXP) && !ipc_host_to_dev)
 		sm2_fifo_write_back(ep, xfer_entry);
-	}
 
 	sm2_get_peer_srx(ep)->owner_ops->free_entry(rx_entry);
 
@@ -266,11 +408,87 @@ static int sm2_alloc_xfer_entry_ctx(struct sm2_ep *ep,
 static int sm2_progress_recv_msg(struct sm2_ep *ep,
 				 struct sm2_xfer_entry *xfer_entry)
 {
+	struct sm2_av *av =
+		container_of(ep->util_ep.av, struct sm2_av, util_av);
+	struct sm2_mmap *map = &av->mmap;
 	struct fid_peer_srx *peer_srx = sm2_get_peer_srx(ep);
 	struct fi_peer_rx_entry *rx_entry;
+	struct sm2_cma_data *cma_data;
 	struct sm2_av *sm2_av;
 	fi_addr_t addr;
+	uint64_t comp_flags;
 	int ret;
+
+	/* TODO - Switch on protocol before switching on op to avoid messy
+	 * checks like this */
+
+	/* We don't want to look for rx entries for xfer entries with
+	 * FI_SM2_CMA_HOST_TO_DEV and FI_SM2_CMA_HOST_TO_DEV_ACK flags*/
+	if (xfer_entry->hdr.proto == sm2_proto_cma &&
+	    (xfer_entry->hdr.proto_flags & FI_SM2_CMA_HOST_TO_DEV)) {
+		/* Sender received IPC handle from receiver and needs to do a
+		 * device memcpy, so skip rx entry lookup */
+		ret = sm2_cma_hmem_memcpy(ep, xfer_entry);
+		if (ret) {
+			FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,
+				"Device memcpy in host to device IPC protocol "
+				"failed\n");
+			if (xfer_entry->hdr.op_flags & FI_SM2_UNEXP) {
+				xfer_entry->hdr.op_flags &= ~FI_DELIVERY_COMPLETE;
+				sm2_fifo_write_back(ep, xfer_entry);
+			} else {
+				smr_freestack_push(
+					sm2_freestack(sm2_mmap_ep_region(
+						map, ep->gid)),
+					xfer_entry);
+			}
+			goto out;
+		}
+
+		ret = sm2_complete_tx(ep, (void *) xfer_entry->hdr.context,
+				      xfer_entry->hdr.op,
+				      xfer_entry->hdr.op_flags);
+
+		sm2_fifo_write_back_ipc_host_to_dev(ep, xfer_entry);
+		goto out;
+	} else if (xfer_entry->hdr.proto == sm2_proto_cma &&
+		   (xfer_entry->hdr.proto_flags & FI_SM2_CMA_HOST_TO_DEV_ACK)) {
+		/* Generate receive completion on the receiver because
+		 * the receiver received a IPC device to host ack
+		 * message */
+		cma_data = (struct sm2_cma_data *) xfer_entry->user_data;
+
+		comp_flags = sm2_rx_cq_flags(xfer_entry->hdr.op,
+					     cma_data->rx_entry->flags,
+					     xfer_entry->hdr.op_flags);
+
+		ret = sm2_complete_rx(
+			ep, cma_data->rx_entry->context, xfer_entry->hdr.op,
+			comp_flags, xfer_entry->hdr.size,
+			cma_data->iov[0].iov_base, xfer_entry->hdr.sender_gid,
+			xfer_entry->hdr.tag, xfer_entry->hdr.cq_data);
+
+		if (ret) {
+			FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,
+				"Unable to process rx completion\n");
+		}
+
+		if (xfer_entry->hdr.op_flags & FI_SM2_UNEXP) {
+			/* The xfer_entry was actually allocated on the receiver
+			 * side, so we just push it back */
+			smr_freestack_push(
+				sm2_freestack(sm2_mmap_ep_region(map, ep->gid)),
+				xfer_entry);
+		} else {
+			/* Unset the delivery complete flag so that we don't
+			 * write another completion entry on the sender after
+			 * the xfer entry is returned */
+			xfer_entry->hdr.op_flags &= ~FI_DELIVERY_COMPLETE;
+			sm2_fifo_write_back(ep, xfer_entry);
+		}
+
+		goto out;
+	}
 
 	sm2_av = container_of(ep->util_ep.av, struct sm2_av, util_av);
 	addr = sm2_av->reverse_lookup[xfer_entry->hdr.sender_gid];
@@ -484,7 +702,6 @@ void sm2_progress_recv(struct sm2_ep *ep)
 				xfer_entry);
 			continue;
 		}
-
 		switch (xfer_entry->hdr.op) {
 		case ofi_op_msg:
 		case ofi_op_tagged:


### PR DESCRIPTION
AWS needs SM2 to have the capability to send any message size in order to perform benchmarking on real world applications.

The CUDA IPC commit only enables device-device and device-host transfers using CUDA IPC.

~~Host-device transfers need a new protocol which will come later.~~ Added host to CUDA device commit