### PR TITLE
prov/tcp: Dynamically allocate large saved Rx buffers

### DIFF
--- a/prov/tcp/src/xnet.h
+++ b/prov/tcp/src/xnet.h
@@ -92,6 +92,7 @@ extern int xnet_trace_msg;
 extern int xnet_disable_autoprog;
 extern int xnet_io_uring;
 extern int xnet_max_saved;
+extern size_t xnet_max_saved_size;
 extern size_t xnet_max_inject;
 extern size_t xnet_buf_size;
 struct xnet_xfer_entry;

--- a/prov/tcp/src/xnet.h
+++ b/prov/tcp/src/xnet.h
@@ -643,6 +643,20 @@ xnet_alloc_tx(struct xnet_ep *ep)
 	return xfer;
 }
 
+static inline int
+xnet_alloc_xfer_buf(struct xnet_xfer_entry *xfer, size_t len)
+{
+	xfer->user_buf = malloc(len);
+	if (!xfer->user_buf)
+		return -FI_ENOMEM;
+
+	xfer->iov[0].iov_base = xfer->user_buf;
+	xfer->iov[0].iov_len = len;
+	xfer->iov_cnt = 1;
+	xfer->ctrl_flags |= XNET_FREE_BUF;
+	return 0;
+}
+
 /* We need to progress receives in the case where we're waiting
  * on the application to post a buffer to consume a receive
  * that we've already read from the kernel.  If the message is

--- a/prov/tcp/src/xnet.h
+++ b/prov/tcp/src/xnet.h
@@ -656,7 +656,8 @@ static inline bool xnet_has_unexp(struct xnet_ep *ep)
 
 void xnet_recv_saved(struct xnet_xfer_entry *saved_entry,
 		     struct xnet_xfer_entry *rx_entry);
-void xnet_complete_saved(struct xnet_xfer_entry *saved_entry);
+void xnet_complete_saved(struct xnet_xfer_entry *saved_entry,
+			 void *msg_data);
 
 #define XNET_WARN_ERR(subsystem, log_str, err) \
 	FI_WARN(&xnet_prov, subsystem, log_str "%s (%d)\n", \

--- a/prov/tcp/src/xnet.h
+++ b/prov/tcp/src/xnet.h
@@ -173,7 +173,6 @@ struct xnet_active_tx {
 };
 
 struct xnet_saved_msg {
-	struct xnet_ep		*ep;
 	struct dlist_entry	entry;
 	struct slist		queue;
 	int			cnt;

--- a/prov/tcp/src/xnet_cq.c
+++ b/prov/tcp/src/xnet_cq.c
@@ -143,7 +143,8 @@ void xnet_report_success(struct xnet_xfer_entry *xfer_entry)
 	cq = &xfer_entry->cq->util_cq;
 	if (xfer_entry->ctrl_flags & XNET_COPY_RECV) {
 		xfer_entry->ctrl_flags &= ~XNET_COPY_RECV;
-		xnet_complete_saved(xfer_entry);
+		/* TODO: io_uring support, see comment in xnet_recv_saved() */
+		xnet_complete_saved(xfer_entry, &xfer_entry->msg_data);
 		return;
 	}
 

--- a/prov/tcp/src/xnet_init.c
+++ b/prov/tcp/src/xnet_init.c
@@ -70,6 +70,7 @@ int xnet_io_uring;
 int xnet_max_saved = 64;
 size_t xnet_max_inject = XNET_DEF_INJECT;
 size_t xnet_buf_size = XNET_DEF_BUF_SIZE;
+size_t xnet_max_saved_size = SIZE_MAX;
 
 
 static void xnet_init_env(void)
@@ -131,6 +132,14 @@ static void xnet_init_env(void)
 			"applications to prevent hangs. (default: %d)",
 			xnet_max_saved);
 	fi_param_get_int(&xnet_prov, "max_saved", &xnet_max_saved);
+	fi_param_define(&xnet_prov, "max_saved_size", FI_PARAM_SIZE_T,
+			"maximum size of any message that will be buffered "
+			"by the provider which does not have an application "
+			"posted buffer ready (i.e. an unexpected message) "
+			"A larger value increases memory and data copying "
+			"overhead to handle unexpected messages, but may be "
+			"required by some applications to prevents hangs.");
+	fi_param_get_size_t(&xnet_prov, "max_saved_size", &xnet_max_saved_size);
 
 	fi_param_define(&xnet_prov, "max_rx_size", FI_PARAM_SIZE_T,
 			"maximum size for message buffers. If set lower "
@@ -140,6 +149,8 @@ static void xnet_init_env(void)
 
 	if (xnet_max_inject > xnet_buf_size)
 		xnet_buf_size = xnet_max_inject;
+	if (xnet_max_saved_size < xnet_buf_size)
+		xnet_max_saved_size = xnet_buf_size;
 
 	fi_param_define(&xnet_prov, "nodelay", FI_PARAM_BOOL,
 			"overrides default TCP_NODELAY socket setting "

--- a/prov/tcp/src/xnet_init.c
+++ b/prov/tcp/src/xnet_init.c
@@ -67,7 +67,7 @@ size_t xnet_zerocopy_size = SIZE_MAX;
 int xnet_trace_msg;
 int xnet_disable_autoprog;
 int xnet_io_uring;
-int xnet_max_saved = 4;
+int xnet_max_saved = 64;
 size_t xnet_max_inject = XNET_DEF_INJECT;
 size_t xnet_buf_size = XNET_DEF_BUF_SIZE;
 

--- a/prov/tcp/src/xnet_progress.c
+++ b/prov/tcp/src/xnet_progress.c
@@ -97,8 +97,6 @@ static bool xnet_save_and_cont(struct xnet_ep *ep)
 					     ep->peer->fi_addr);
 		if (!ep->saved_msg)
 			return false;
-		assert(!ep->saved_msg->ep);
-		ep->saved_msg->ep = ep;
 	}
 
 	return (ep->saved_msg->cnt < xnet_max_saved);

--- a/prov/tcp/src/xnet_progress.c
+++ b/prov/tcp/src/xnet_progress.c
@@ -88,7 +88,8 @@ static bool xnet_save_and_cont(struct xnet_ep *ep)
 	assert(ep->cur_rx.hdr.base_hdr.op == ofi_op_tagged);
 	assert(ep->srx);
 
-	if (ep->peer->fi_addr == FI_ADDR_NOTAVAIL)
+	if ((ep->cur_rx.data_left > xnet_max_saved_size) ||
+	    (ep->peer->fi_addr == FI_ADDR_NOTAVAIL))
 		return false;
 
 	if (!ep->saved_msg) {

--- a/prov/tcp/src/xnet_srx.c
+++ b/prov/tcp/src/xnet_srx.c
@@ -824,7 +824,6 @@ xnet_srx_cleanup_saved(struct ofi_dyn_arr *arr, void *item, void *context)
 	dlist_remove_init(&saved_msg->entry);
 	xnet_srx_cleanup(srx, &saved_msg->queue);
 	saved_msg->cnt = 0;
-	saved_msg->ep = NULL;
 	return 0;
 }
 

--- a/prov/tcp/src/xnet_srx.c
+++ b/prov/tcp/src/xnet_srx.c
@@ -346,14 +346,9 @@ xnet_srx_claim(struct xnet_srx *srx, struct xnet_xfer_entry *recv_entry,
 		hdr = saved_entry ? &saved_entry->hdr : &ep->cur_rx.hdr;
 		msg_len = hdr->base_hdr.size - hdr->base_hdr.hdr_size;
 		if (msg_len) {
-			recv_entry->user_buf = calloc(1, msg_len);
-			if (!recv_entry->user_buf)
-				return -FI_ENOMEM;
-
-			recv_entry->iov[0].iov_base = recv_entry->user_buf;
-			recv_entry->iov[0].iov_len = msg_len;
-			recv_entry->iov_cnt = 1;
-			recv_entry->ctrl_flags |= XNET_FREE_BUF;
+			ret = xnet_alloc_xfer_buf(recv_entry, msg_len);
+			if (ret)
+				return ret;
 		} else {
 			recv_entry->iov_cnt = 0;
 		}


### PR DESCRIPTION
If we receive a message that's larger than the transfer pool buffer size that's been allocated, dynamically allocate the bounce buffer.  This allows us to queue larger messages in order to make progress with some MPI applications.

@ooststep - This patch should handle saving messages of any size at the receiver.  I tested this by shrinking the inject size to 4 bytes and buffer size to 32 bytes.  That at least allowed fabtests to check this flow.  The changes weren't quite a simple as setting the XNET_FREE_BUF ctrl_flag, but aren't that invasive.  We still have the max_saved limit, but I haven't added any other limits or optimizations.  We'll likely want both prior to merging.

I haven't decided on what limits we'll want, but was at least considering these options (with probably better names):

total_rx_buffering - total size of all messages buffered for an RDM endpoint (can store with SRX)
total_peer_rx_buffering - total size of all messages buffered for a single socket connection
max_msg_saved_size - max size of any message that will be buffered

Of course, this ends up with a hoard of tunable values needed to make this work...

I think the key to performance without hanging will be dependent on how intelligent we can make the check that determines if we save a message or leave it on a socket.