### PR TITLE
prov/sm2: Switch sm2_verify_peer to return ssize_t

### DIFF
--- a/prov/sm2/src/sm2.h
+++ b/prov/sm2/src/sm2.h
@@ -253,7 +253,7 @@ int sm2_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 int sm2_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 		  struct fid_cntr **cntr_fid, void *context);
 
-int sm2_verify_peer(struct sm2_ep *ep, fi_addr_t fi_addr, sm2_gid_t *gid);
+ssize_t sm2_verify_peer(struct sm2_ep *ep, fi_addr_t fi_addr, sm2_gid_t *gid);
 
 typedef ssize_t (*sm2_proto_func)(struct sm2_ep *ep,
 				  struct sm2_region *peer_smr,

--- a/prov/sm2/src/sm2_ep.c
+++ b/prov/sm2/src/sm2_ep.c
@@ -220,7 +220,7 @@ static void sm2_init_queue(struct sm2_queue *queue, dlist_func_t *match_func)
 	queue->match_func = match_func;
 }
 
-int sm2_verify_peer(struct sm2_ep *ep, fi_addr_t fi_addr, sm2_gid_t *gid)
+ssize_t sm2_verify_peer(struct sm2_ep *ep, fi_addr_t fi_addr, sm2_gid_t *gid)
 {
 	struct sm2_av *sm2_av;
 	struct sm2_ep_allocation_entry *entries;


### PR DESCRIPTION
This removes the implicit cast from int to ssize_t in the critical sm2 path saving an instruction.