### PR TITLE
prov/shm: fix cuda rma path

### DIFF
--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -638,10 +638,6 @@ int smr_select_proto(enum fi_hmem_iface iface, bool use_ipc, bool cma_avail,
                      bool gdrcopy_avail, uint32_t op, uint64_t total_len,
                      uint64_t op_flags)
 {
-	/* TODO: Move gdrcopy check out of non-cuda fast paths */
-	if (gdrcopy_avail && total_len <= smr_env.max_gdrcopy_size)
-		return total_len <= SMR_MSG_DATA_LEN ? smr_src_inline : smr_src_inject;
-
 	if (op == ofi_op_read_req) {
 		if (use_ipc)
 			return smr_src_ipc;
@@ -649,6 +645,10 @@ int smr_select_proto(enum fi_hmem_iface iface, bool use_ipc, bool cma_avail,
 			return smr_src_iov;
 		return smr_src_sar;
 	}
+
+	/* TODO: Move gdrcopy check out of non-cuda fast paths */
+	if (gdrcopy_avail && total_len <= smr_env.max_gdrcopy_size)
+		return total_len <= SMR_MSG_DATA_LEN ? smr_src_inline : smr_src_inject;
 
 	if (op_flags & FI_INJECT) {
 		if (op_flags & FI_DELIVERY_COMPLETE)


### PR DESCRIPTION
This patch consists of 2 changes:
1. Do not use inline/inject for read operations. The previous gdrcopy optimization mistakenly activated this path.
2. Explicitly assert inject protocol and read op are mutually exclusive.

We need to devise another approach to optimize cuda read operation other than the current inline/inject proto.

Currently evaluating the change.