### PR TITLE
prov/shm: fix coverity warning

### DIFF
--- a/prov/shm/src/smr_av.c
+++ b/prov/shm/src/smr_av.c
@@ -129,6 +129,7 @@ static int smr_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 	if (!(flags & FI_EVENT))
 		return succ_count;
 
+	assert(util_av->eq);
 	ofi_av_write_event(util_av, succ_count, 0, context);
 	return 0;
 }


### PR DESCRIPTION
If the user requests an event to be written to the EQ, we can assume the EQ is not NULL