### PR TITLE
[1.18.x] prov/verbs: Fix vrb_add_credits signature

### DIFF
--- a/prov/verbs/include/fi_verbs.h
+++ b/prov/verbs/include/fi_verbs.h
@@ -946,7 +946,7 @@ ssize_t vrb_send_iov(struct vrb_ep *ep, struct ibv_send_wr *wr,
 		     const struct iovec *iov, void **desc, int count,
 		     uint64_t flags);
 
-void vrb_add_credits(struct fid_ep *ep, size_t credits);
+void vrb_add_credits(struct fid_ep *ep, uint64_t credits);
 
 int vrb_get_rai_id(const char *node, const char *service, uint64_t flags,
 		      const struct fi_info *hints, struct rdma_addrinfo **rai,


### PR DESCRIPTION
The implementation uses a uint64_t argument, not size_t.