### PR TITLE
prov/efa: refactor send of multiple packets of same packet type

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_ep_progress.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_progress.c
@@ -591,7 +591,7 @@ ssize_t efa_rdm_ep_send_queued_pkts(struct efa_rdm_ep *ep,
 		 */
 		dlist_remove(&pkt_entry->entry);
 
-		ret = rxr_pkt_entry_send(ep, pkt_entry, 0);
+		ret = rxr_pkt_entry_sendv(ep, &pkt_entry, 1, 0);
 		if (ret) {
 			if (ret == -FI_EAGAIN) {
 				/* add the pkt back to pkts, so it can be resent again */

--- a/prov/efa/src/rdm/rxr_pkt_cmd.c
+++ b/prov/efa/src/rdm/rxr_pkt_cmd.c
@@ -49,114 +49,127 @@
  *          dump (for debug only)
  */
 
-/*
- *   rxr_pkt_init_ctrl() uses init functions declared in rxr_pkt_type.h
+/**
+ * @brief fill the "wiredata" field of a pkt_entry by packet type
+ * 
+ * @param[out]		pkt_entry	packet entry whose "wiredata" is to be filled
+ * @param[in]		ope		operation entry
+ * @param[in]		pkt_type	packet type
+ * 
+ * This function call the init functions of each packet type defined in
+ * rxr_pkt_type.h
+ * 
+ * @return 	0 on success
+ * 		negative libfabric error code on error
+ * 
+ * @related rxr_pkt_entry
  */
 static
-int rxr_pkt_init_ctrl(struct efa_rdm_ep *efa_rdm_ep, int entry_type, struct efa_rdm_ope *x_entry,
-		      int ctrl_type, struct rxr_pkt_entry *pkt_entry)
+int rxr_pkt_entry_fill_wiredata(struct rxr_pkt_entry *pkt_entry,
+				int pkt_type,
+				struct efa_rdm_ope *ope)
 {
 	int ret = 0;
 
-	switch (ctrl_type) {
+	switch (pkt_type) {
 	case RXR_READRSP_PKT:
-		ret = rxr_pkt_init_readrsp(efa_rdm_ep, x_entry, pkt_entry);
+		ret = rxr_pkt_init_readrsp(pkt_entry, ope);
 		break;
 	case RXR_CTS_PKT:
-		ret = rxr_pkt_init_cts(efa_rdm_ep, x_entry, pkt_entry);
+		ret = rxr_pkt_init_cts(pkt_entry, ope);
 		break;
 	case RXR_EOR_PKT:
-		ret = rxr_pkt_init_eor(efa_rdm_ep, x_entry, pkt_entry);
+		ret = rxr_pkt_init_eor(pkt_entry, ope);
 		break;
 	case RXR_ATOMRSP_PKT:
-		ret = rxr_pkt_init_atomrsp(efa_rdm_ep, x_entry, pkt_entry);
+		ret = rxr_pkt_init_atomrsp(pkt_entry, ope);
 		break;
 	case RXR_RECEIPT_PKT:
-		ret = rxr_pkt_init_receipt(efa_rdm_ep, x_entry, pkt_entry);
+		ret = rxr_pkt_init_receipt(pkt_entry, ope);
 		break;
 	case RXR_EAGER_MSGRTM_PKT:
-		ret = rxr_pkt_init_eager_msgrtm(efa_rdm_ep, x_entry, pkt_entry);
+		ret = rxr_pkt_init_eager_msgrtm(pkt_entry, ope);
 		break;
 	case RXR_EAGER_TAGRTM_PKT:
-		ret = rxr_pkt_init_eager_tagrtm(efa_rdm_ep, x_entry, pkt_entry);
+		ret = rxr_pkt_init_eager_tagrtm(pkt_entry, ope);
 		break;
 	case RXR_MEDIUM_MSGRTM_PKT:
-		ret = rxr_pkt_init_medium_msgrtm(efa_rdm_ep, x_entry, pkt_entry);
+		ret = rxr_pkt_init_medium_msgrtm(pkt_entry, ope);
 		break;
 	case RXR_MEDIUM_TAGRTM_PKT:
-		ret = rxr_pkt_init_medium_tagrtm(efa_rdm_ep, x_entry, pkt_entry);
+		ret = rxr_pkt_init_medium_tagrtm(pkt_entry, ope);
 		break;
 	case RXR_LONGCTS_MSGRTM_PKT:
-		ret = rxr_pkt_init_longcts_msgrtm(efa_rdm_ep, x_entry, pkt_entry);
+		ret = rxr_pkt_init_longcts_msgrtm(pkt_entry, ope);
 		break;
 	case RXR_LONGCTS_TAGRTM_PKT:
-		ret = rxr_pkt_init_longcts_tagrtm(efa_rdm_ep, x_entry, pkt_entry);
+		ret = rxr_pkt_init_longcts_tagrtm(pkt_entry, ope);
 		break;
 	case RXR_LONGREAD_MSGRTM_PKT:
-		ret = rxr_pkt_init_longread_msgrtm(efa_rdm_ep, x_entry, pkt_entry);
+		ret = rxr_pkt_init_longread_msgrtm(pkt_entry, ope);
 		break;
 	case RXR_LONGREAD_TAGRTM_PKT:
-		ret = rxr_pkt_init_longread_tagrtm(efa_rdm_ep, x_entry, pkt_entry);
+		ret = rxr_pkt_init_longread_tagrtm(pkt_entry, ope);
 		break;
 	case RXR_RUNTREAD_MSGRTM_PKT:
-		ret = rxr_pkt_init_runtread_msgrtm(efa_rdm_ep, x_entry, pkt_entry);
+		ret = rxr_pkt_init_runtread_msgrtm(pkt_entry, ope);
 		break;
 	case RXR_RUNTREAD_TAGRTM_PKT:
-		ret = rxr_pkt_init_runtread_tagrtm(efa_rdm_ep, x_entry, pkt_entry);
+		ret = rxr_pkt_init_runtread_tagrtm(pkt_entry, ope);
 		break;
 	case RXR_EAGER_RTW_PKT:
-		ret = rxr_pkt_init_eager_rtw(efa_rdm_ep, x_entry, pkt_entry);
+		ret = rxr_pkt_init_eager_rtw(pkt_entry, ope);
 		break;
 	case RXR_LONGCTS_RTW_PKT:
-		ret = rxr_pkt_init_longcts_rtw(efa_rdm_ep, x_entry, pkt_entry);
+		ret = rxr_pkt_init_longcts_rtw(pkt_entry, ope);
 		break;
 	case RXR_LONGREAD_RTW_PKT:
-		ret = rxr_pkt_init_longread_rtw(efa_rdm_ep, x_entry, pkt_entry);
+		ret = rxr_pkt_init_longread_rtw(pkt_entry, ope);
 		break;
 	case RXR_SHORT_RTR_PKT:
-		ret = rxr_pkt_init_short_rtr(efa_rdm_ep, x_entry, pkt_entry);
+		ret = rxr_pkt_init_short_rtr(pkt_entry, ope);
 		break;
 	case RXR_LONGCTS_RTR_PKT:
-		ret = rxr_pkt_init_longcts_rtr(efa_rdm_ep, x_entry, pkt_entry);
+		ret = rxr_pkt_init_longcts_rtr(pkt_entry, ope);
 		break;
 	case RXR_WRITE_RTA_PKT:
-		ret = rxr_pkt_init_write_rta(efa_rdm_ep, x_entry, pkt_entry);
+		ret = rxr_pkt_init_write_rta(pkt_entry, ope);
 		break;
 	case RXR_FETCH_RTA_PKT:
-		ret = rxr_pkt_init_fetch_rta(efa_rdm_ep, x_entry, pkt_entry);
+		ret = rxr_pkt_init_fetch_rta(pkt_entry, ope);
 		break;
 	case RXR_COMPARE_RTA_PKT:
-		ret = rxr_pkt_init_compare_rta(efa_rdm_ep, x_entry, pkt_entry);
+		ret = rxr_pkt_init_compare_rta(pkt_entry, ope);
 		break;
 	case RXR_DC_EAGER_MSGRTM_PKT:
-		ret = rxr_pkt_init_dc_eager_msgrtm(efa_rdm_ep, x_entry, pkt_entry);
+		ret = rxr_pkt_init_dc_eager_msgrtm(pkt_entry, ope);
 		break;
 	case RXR_DC_EAGER_TAGRTM_PKT:
-		ret = rxr_pkt_init_dc_eager_tagrtm(efa_rdm_ep, x_entry, pkt_entry);
+		ret = rxr_pkt_init_dc_eager_tagrtm(pkt_entry, ope);
 		break;
 	case RXR_DC_MEDIUM_MSGRTM_PKT:
-		ret = rxr_pkt_init_dc_medium_msgrtm(efa_rdm_ep, x_entry, pkt_entry);
+		ret = rxr_pkt_init_dc_medium_msgrtm(pkt_entry, ope);
 		break;
 	case RXR_DC_MEDIUM_TAGRTM_PKT:
-		ret = rxr_pkt_init_dc_medium_tagrtm(efa_rdm_ep, x_entry, pkt_entry);
+		ret = rxr_pkt_init_dc_medium_tagrtm(pkt_entry, ope);
 		break;
 	case RXR_DC_LONGCTS_MSGRTM_PKT:
-		ret = rxr_pkt_init_dc_longcts_msgrtm(efa_rdm_ep, x_entry, pkt_entry);
+		ret = rxr_pkt_init_dc_longcts_msgrtm(pkt_entry, ope);
 		break;
 	case RXR_DC_LONGCTS_TAGRTM_PKT:
-		ret = rxr_pkt_init_dc_longcts_tagrtm(efa_rdm_ep, x_entry, pkt_entry);
+		ret = rxr_pkt_init_dc_longcts_tagrtm(pkt_entry, ope);
 		break;
 	case RXR_DC_EAGER_RTW_PKT:
-		ret = rxr_pkt_init_dc_eager_rtw(efa_rdm_ep, x_entry, pkt_entry);
+		ret = rxr_pkt_init_dc_eager_rtw(pkt_entry, ope);
 		break;
 	case RXR_DC_LONGCTS_RTW_PKT:
-		ret = rxr_pkt_init_dc_longcts_rtw(efa_rdm_ep, x_entry, pkt_entry);
+		ret = rxr_pkt_init_dc_longcts_rtw(pkt_entry, ope);
 		break;
 	case RXR_DC_WRITE_RTA_PKT:
-		ret = rxr_pkt_init_dc_write_rta(efa_rdm_ep, x_entry, pkt_entry);
+		ret = rxr_pkt_init_dc_write_rta(pkt_entry, ope);
 		break;
 	case RXR_DATA_PKT:
-		ret = rxr_pkt_init_data(efa_rdm_ep, x_entry, pkt_entry);
+		ret = rxr_pkt_init_data(pkt_entry, ope);
 		break;
 	default:
 		assert(0 && "unknown pkt type to init");
@@ -286,7 +299,7 @@ ssize_t rxr_pkt_post_one(struct efa_rdm_ep *efa_rdm_ep, struct efa_rdm_ope *ope,
 	/*
 	 * rxr_pkt_init_ctrl will set pkt_entry->send if it want to use multi iov
 	 */
-	err = rxr_pkt_init_ctrl(efa_rdm_ep, ope->type, ope, pkt_type, pkt_entry);
+	err = rxr_pkt_entry_fill_wiredata(pkt_entry, pkt_type, ope);
 	if (OFI_UNLIKELY(err)) {
 		rxr_pkt_entry_release_tx(efa_rdm_ep, pkt_entry);
 		return err;

--- a/prov/efa/src/rdm/rxr_pkt_cmd.c
+++ b/prov/efa/src/rdm/rxr_pkt_cmd.c
@@ -305,10 +305,10 @@ ssize_t rxr_pkt_post_one(struct efa_rdm_ep *efa_rdm_ep, struct efa_rdm_ope *ope,
 		return err;
 	}
 
-	/* If the send succeeded, the function rxr_pkt_entry_send will increase the
+	/* If the send succeeded, the function rxr_pkt_entry_sendv() will increase the
 	 * counter in efa_rdm_ep that tracks number of outstanding TX ops.
 	 */
-	err = rxr_pkt_entry_send(efa_rdm_ep, pkt_entry, flags);
+	err = rxr_pkt_entry_sendv(efa_rdm_ep, &pkt_entry, 1, flags);
 
 	if (OFI_UNLIKELY(err)) {
 		rxr_pkt_entry_release_tx(efa_rdm_ep, pkt_entry);

--- a/prov/efa/src/rdm/rxr_pkt_entry.h
+++ b/prov/efa/src/rdm/rxr_pkt_entry.h
@@ -279,8 +279,10 @@ struct rxr_pkt_entry *rxr_pkt_entry_clone(struct efa_rdm_ep *ep,
 struct rxr_pkt_entry *rxr_pkt_get_unexp(struct efa_rdm_ep *ep,
 					struct rxr_pkt_entry **pkt_entry_ptr);
 
-ssize_t rxr_pkt_entry_send(struct efa_rdm_ep *ep,
-			   struct rxr_pkt_entry *pkt_entry, uint64_t flags);
+ssize_t rxr_pkt_entry_sendv(struct efa_rdm_ep *ep,
+			    struct rxr_pkt_entry **pkt_entry_vec,
+			    int pkt_entry_cnt,
+			    uint64_t flags);
 
 int rxr_pkt_entry_read(struct efa_rdm_ep *ep, struct rxr_pkt_entry *pkt_entry,
 		       void *local_buf, size_t len, void *desc,

--- a/prov/efa/src/rdm/rxr_pkt_type.h
+++ b/prov/efa/src/rdm/rxr_pkt_type.h
@@ -112,9 +112,8 @@ void rxr_pkt_calc_cts_window_credits(struct efa_rdm_ep *ep, struct efa_rdm_peer 
 				     uint64_t size, int request,
 				     int *window, int *credits);
 
-ssize_t rxr_pkt_init_cts(struct efa_rdm_ep *ep,
-			 struct efa_rdm_ope *ope,
-			 struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_init_cts(struct rxr_pkt_entry *pkt_entry,
+			 struct efa_rdm_ope *ope);
 
 void rxr_pkt_handle_cts_sent(struct efa_rdm_ep *ep,
 			     struct rxr_pkt_entry *pkt_entry);
@@ -128,9 +127,8 @@ struct rxr_data_hdr *rxr_get_data_hdr(void *pkt)
 	return (struct rxr_data_hdr *)pkt;
 }
 
-int rxr_pkt_init_data(struct efa_rdm_ep *ep,
-		      struct efa_rdm_ope *ope,
-		      struct rxr_pkt_entry *pkt_entry);
+int rxr_pkt_init_data(struct rxr_pkt_entry *pkt_entry,
+		      struct efa_rdm_ope *ope);
 
 void rxr_pkt_handle_data_sent(struct efa_rdm_ep *ep,
 			      struct rxr_pkt_entry *pkt_entry);
@@ -153,9 +151,8 @@ static inline struct rxr_readrsp_hdr *rxr_get_readrsp_hdr(void *pkt)
 	return (struct rxr_readrsp_hdr *)pkt;
 }
 
-int rxr_pkt_init_readrsp(struct efa_rdm_ep *ep,
-			 struct efa_rdm_ope *txe,
-			 struct rxr_pkt_entry *pkt_entry);
+int rxr_pkt_init_readrsp(struct rxr_pkt_entry *pkt_entry,
+			 struct efa_rdm_ope *txe);
 
 void rxr_pkt_handle_readrsp_sent(struct efa_rdm_ep *ep,
 				 struct rxr_pkt_entry *pkt_entry);
@@ -207,9 +204,8 @@ struct rxr_eor_hdr *rxr_get_eor_hdr(void *pkt)
 	return (struct rxr_eor_hdr *)pkt;
 }
 
-int rxr_pkt_init_eor(struct efa_rdm_ep *ep,
-		     struct efa_rdm_ope *rxe,
-		     struct rxr_pkt_entry *pkt_entry);
+int rxr_pkt_init_eor(struct rxr_pkt_entry *pkt_entry,
+		     struct efa_rdm_ope *rxe);
 
 static inline
 void rxr_pkt_handle_eor_sent(struct efa_rdm_ep *ep, struct rxr_pkt_entry *pkt_entry)
@@ -228,8 +224,7 @@ static inline struct rxr_atomrsp_hdr *rxr_get_atomrsp_hdr(void *pkt)
 	return (struct rxr_atomrsp_hdr *)pkt;
 }
 
-int rxr_pkt_init_atomrsp(struct efa_rdm_ep *ep, struct efa_rdm_ope *rxe,
-			 struct rxr_pkt_entry *pkt_entry);
+int rxr_pkt_init_atomrsp(struct rxr_pkt_entry *pkt_entry, struct efa_rdm_ope *rxe);
 
 void rxr_pkt_handle_atomrsp_sent(struct efa_rdm_ep *ep, struct rxr_pkt_entry *pkt_entry);
 
@@ -244,8 +239,7 @@ struct rxr_receipt_hdr *rxr_get_receipt_hdr(void *pkt)
 	return (struct rxr_receipt_hdr *)pkt;
 }
 
-int rxr_pkt_init_receipt(struct efa_rdm_ep *ep, struct efa_rdm_ope *rxe,
-			 struct rxr_pkt_entry *pkt_entry);
+int rxr_pkt_init_receipt(struct rxr_pkt_entry *pkt_entry, struct efa_rdm_ope *rxe);
 
 void rxr_pkt_handle_receipt_sent(struct efa_rdm_ep *ep,
 				 struct rxr_pkt_entry *pkt_entry);

--- a/prov/efa/src/rdm/rxr_pkt_type_data.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_data.c
@@ -37,15 +37,16 @@
 #include "rxr_pkt_cmd.h"
 #include "rxr_pkt_type_base.h"
 
-int rxr_pkt_init_data(struct efa_rdm_ep *ep,
-		      struct efa_rdm_ope *ope,
-		      struct rxr_pkt_entry *pkt_entry)
+int rxr_pkt_init_data(struct rxr_pkt_entry *pkt_entry,
+		      struct efa_rdm_ope *ope)
 {
 	struct rxr_data_hdr *data_hdr;
 	struct efa_rdm_peer *peer;
+	struct efa_rdm_ep *ep;
 	size_t hdr_size;
 	int ret;
 
+	ep = ope->ep;
 	data_hdr = rxr_get_data_hdr(pkt_entry->wiredata);
 	data_hdr->type = RXR_DATA_PKT;
 	data_hdr->version = RXR_PROTOCOL_VERSION;

--- a/prov/efa/src/rdm/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_misc.c
@@ -116,7 +116,7 @@ ssize_t rxr_pkt_post_handshake(struct efa_rdm_ep *ep, struct efa_rdm_peer *peer)
 
 	rxr_pkt_init_handshake(ep, pkt_entry, addr);
 
-	ret = rxr_pkt_entry_send(ep, pkt_entry, 0);
+	ret = rxr_pkt_entry_sendv(ep, &pkt_entry, 1, 0);
 	if (OFI_UNLIKELY(ret)) {
 		rxr_pkt_entry_release_tx(ep, pkt_entry);
 	}

--- a/prov/efa/src/rdm/rxr_pkt_type_req.h
+++ b/prov/efa/src/rdm/rxr_pkt_type_req.h
@@ -171,69 +171,52 @@ struct rxr_runtread_rtm_base_hdr *rxr_get_runtread_rtm_base_hdr(void *pkt)
 	return (struct rxr_runtread_rtm_base_hdr *)pkt;
 }
 
-ssize_t rxr_pkt_init_eager_msgrtm(struct efa_rdm_ep *ep,
-				  struct efa_rdm_ope *txe,
-				  struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_init_eager_msgrtm(struct rxr_pkt_entry *pkt_entry,
+				  struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_dc_eager_msgrtm(struct efa_rdm_ep *ep,
-				     struct efa_rdm_ope *txe,
-				     struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_init_dc_eager_msgrtm(struct rxr_pkt_entry *pkt_entry,
+				     struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_eager_tagrtm(struct efa_rdm_ep *ep,
-				  struct efa_rdm_ope *txe,
-				  struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_init_eager_tagrtm(struct rxr_pkt_entry *pkt_entry,
+				  struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_medium_msgrtm(struct efa_rdm_ep *ep,
-				   struct efa_rdm_ope *txe,
-				   struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_init_medium_msgrtm(struct rxr_pkt_entry *pkt_entry,
+				     struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_dc_eager_tagrtm(struct efa_rdm_ep *ep,
-				     struct efa_rdm_ope *txe,
-				     struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_init_dc_eager_tagrtm(struct rxr_pkt_entry *pkt_entry,
+				     struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_dc_medium_msgrtm(struct efa_rdm_ep *ep,
-				      struct efa_rdm_ope *txe,
-				      struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_init_dc_medium_msgrtm(struct rxr_pkt_entry *pkt_entry,
+				      struct efa_rdm_ope *txe);
+ssize_t rxr_pkt_init_medium_tagrtm(struct rxr_pkt_entry *pkt_entry,
+				   struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_medium_tagrtm(struct efa_rdm_ep *ep,
-				   struct efa_rdm_ope *txe,
-				   struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_init_dc_medium_tagrtm(struct rxr_pkt_entry *pkt_entry,
+				      struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_dc_medium_tagrtm(struct efa_rdm_ep *ep,
-				      struct efa_rdm_ope *txe,
-				      struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_init_longcts_msgrtm(struct rxr_pkt_entry *pkt_entry,
+				    struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_longcts_msgrtm(struct efa_rdm_ep *ep,
-				 struct efa_rdm_ope *txe,
-				 struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_init_dc_longcts_msgrtm(struct rxr_pkt_entry *pkt_entry,
+				       struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_dc_longcts_msgrtm(struct efa_rdm_ep *ep,
-				    struct efa_rdm_ope *txe,
-				    struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_init_longcts_tagrtm(struct rxr_pkt_entry *pkt_entry,
+				    struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_longcts_tagrtm(struct efa_rdm_ep *ep,
-				 struct efa_rdm_ope *txe,
-				 struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_init_dc_longcts_tagrtm(struct rxr_pkt_entry *pkt_entry,
+				       struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_dc_longcts_tagrtm(struct efa_rdm_ep *ep,
-				    struct efa_rdm_ope *txe,
-				    struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_init_longread_msgrtm(struct rxr_pkt_entry *pkt_entry,
+				     struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_longread_msgrtm(struct efa_rdm_ep *ep,
-				 struct efa_rdm_ope *txe,
-				 struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_init_longread_tagrtm(struct rxr_pkt_entry *pkt_entry,
+				     struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_longread_tagrtm(struct efa_rdm_ep *ep,
-				 struct efa_rdm_ope *txe,
-				 struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_init_runtread_msgrtm(struct rxr_pkt_entry *pkt_entry,
+				     struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_runtread_msgrtm(struct efa_rdm_ep *ep,
-				 struct efa_rdm_ope *txe,
-				 struct rxr_pkt_entry *pkt_entry);
-
-ssize_t rxr_pkt_init_runtread_tagrtm(struct efa_rdm_ep *ep,
-				 struct efa_rdm_ope *txe,
-				 struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_init_runtread_tagrtm(struct rxr_pkt_entry *pkt_entry,
+				     struct efa_rdm_ope *txe);
 
 static inline
 void rxr_pkt_handle_eager_rtm_sent(struct efa_rdm_ep *ep,
@@ -310,25 +293,20 @@ struct rxr_dc_eager_rtw_hdr *rxr_get_dc_eager_rtw_hdr(void *pkt)
 	return (struct rxr_dc_eager_rtw_hdr *)pkt;
 }
 
-ssize_t rxr_pkt_init_eager_rtw(struct efa_rdm_ep *ep,
-			       struct efa_rdm_ope *txe,
-			       struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_init_eager_rtw(struct rxr_pkt_entry *pkt_entry,
+			       struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_longcts_rtw(struct efa_rdm_ep *ep,
-			      struct efa_rdm_ope *txe,
-			      struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_init_longcts_rtw(struct rxr_pkt_entry *pkt_entry,
+				 struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_longread_rtw(struct efa_rdm_ep *ep,
-			      struct efa_rdm_ope *txe,
-			      struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_init_longread_rtw(struct rxr_pkt_entry *pkt_entry,
+				  struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_dc_eager_rtw(struct efa_rdm_ep *ep,
-				  struct efa_rdm_ope *txe,
-				  struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_init_dc_eager_rtw(struct rxr_pkt_entry *pkt_entry,
+				  struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_dc_longcts_rtw(struct efa_rdm_ep *ep,
-				 struct efa_rdm_ope *txe,
-				 struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_init_dc_longcts_rtw(struct rxr_pkt_entry *pkt_entry,
+				    struct efa_rdm_ope *txe);
 
 static inline
 void rxr_pkt_handle_eager_rtw_sent(struct efa_rdm_ep *ep,
@@ -376,13 +354,11 @@ struct rxr_rtr_hdr *rxr_get_rtr_hdr(void *pkt)
 	return (struct rxr_rtr_hdr *)pkt;
 }
 
-ssize_t rxr_pkt_init_short_rtr(struct efa_rdm_ep *ep,
-			       struct efa_rdm_ope *txe,
-			       struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_init_short_rtr(struct rxr_pkt_entry *pkt_entry,
+			       struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_longcts_rtr(struct efa_rdm_ep *ep,
-			      struct efa_rdm_ope *txe,
-			      struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_init_longcts_rtr(struct rxr_pkt_entry *pkt_entry,
+				 struct efa_rdm_ope *txe);
 
 void rxr_pkt_handle_rtr_sent(struct efa_rdm_ep *ep,
 			     struct rxr_pkt_entry *pkt_entry);
@@ -396,15 +372,16 @@ struct rxr_rta_hdr *rxr_get_rta_hdr(void *pkt)
 	return (struct rxr_rta_hdr *)pkt;
 }
 
-ssize_t rxr_pkt_init_write_rta(struct efa_rdm_ep *ep, struct efa_rdm_ope *txe, struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_init_write_rta(struct rxr_pkt_entry *pkt_entry, struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_dc_write_rta(struct efa_rdm_ep *ep,
-				  struct efa_rdm_ope *txe,
-				  struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_init_dc_write_rta(struct rxr_pkt_entry *pkt_entry,
+				  struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_fetch_rta(struct efa_rdm_ep *ep, struct efa_rdm_ope *txe, struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_init_fetch_rta(struct rxr_pkt_entry *pkt_entry,
+			       struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_compare_rta(struct efa_rdm_ep *ep, struct efa_rdm_ope *txe, struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_init_compare_rta(struct rxr_pkt_entry *pkt_entry,
+				 struct efa_rdm_ope *txe);
 
 static inline
 void rxr_pkt_handle_rta_sent(struct efa_rdm_ep *ep,


### PR DESCRIPTION
For certain packet types such as MEDIUM_RTM, RUNTREAD_RTM and DATA, we send out multiple packets with one call to `ibv_post_send`. Current code use the FI_MORE flag to control the behavior, which require the ep to maintain an internal list of packets that are pending send. In current setting, 1 call to `rxr_pkt_entry_send` does not necessary lead to 1 call to `ibv_post_send`.

This PR has multiple patches that eventually that eliminate the internal list, thus one call to `rxr_pkt_entry_send` will result in 1 call to `ibv_post_send`.