### PR TITLE
prov/efa: merge two functions into one.

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_msg.h
+++ b/prov/efa/src/rdm/efa_rdm_msg.h
@@ -150,11 +150,9 @@ struct efa_rdm_ope *efa_rdm_msg_alloc_rxe(struct efa_rdm_ep *ep,
 					    uint32_t op, uint64_t flags,
 					    uint64_t tag, uint64_t ignore);
 
-struct efa_rdm_ope *efa_rdm_msg_alloc_unexp_rxe_for_msgrtm(struct efa_rdm_ep *ep,
-							     struct rxr_pkt_entry **pkt_entry);
-
-struct efa_rdm_ope *efa_rdm_msg_alloc_unexp_rxe_for_tagrtm(struct efa_rdm_ep *ep,
-							     struct rxr_pkt_entry **pkt_entry);
+struct efa_rdm_ope *efa_rdm_msg_alloc_unexp_rxe_for_rtm(struct efa_rdm_ep *ep,
+							struct rxr_pkt_entry **pkt_entry_ptr,
+							uint32_t op);
 
 struct efa_rdm_ope *efa_rdm_msg_split_rxe(struct efa_rdm_ep *ep,
 					    struct efa_rdm_ope *posted_entry,

--- a/prov/efa/src/rdm/rxr_pkt_type_req.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_req.c
@@ -1160,10 +1160,10 @@ struct efa_rdm_ope *rxr_pkt_get_msgrtm_rxe(struct efa_rdm_ep *ep,
 	                               *pkt_entry_ptr);
 	if (OFI_UNLIKELY(!match)) {
 		/*
-		 * efa_rdm_msg_alloc_unexp_rxe_for_msgrtm() might release pkt_entry,
+		 * efa_rdm_msg_alloc_unexp_rxe_for_rtm() might release pkt_entry,
 		 * thus we have to use pkt_entry_ptr here
 		 */
-		rxe = efa_rdm_msg_alloc_unexp_rxe_for_msgrtm(ep, pkt_entry_ptr);
+		rxe = efa_rdm_msg_alloc_unexp_rxe_for_rtm(ep, pkt_entry_ptr, ofi_op_msg);
 		if (OFI_UNLIKELY(!rxe)) {
 			EFA_WARN(FI_LOG_CQ,
 				"RX entries exhausted.\n");
@@ -1202,10 +1202,10 @@ struct efa_rdm_ope *rxr_pkt_get_tagrtm_rxe(struct efa_rdm_ep *ep,
 	                               *pkt_entry_ptr);
 	if (OFI_UNLIKELY(!match)) {
 		/*
-		 * efa_rdm_msg_alloc_unexp_rxe_for_tagrtm() might release pkt_entry,
+		 * efa_rdm_msg_alloc_unexp_rxe_for_rtm() might release pkt_entry,
 		 * thus we have to use pkt_entry_ptr here
 		 */
-		rxe = efa_rdm_msg_alloc_unexp_rxe_for_tagrtm(ep, pkt_entry_ptr);
+		rxe = efa_rdm_msg_alloc_unexp_rxe_for_rtm(ep, pkt_entry_ptr, ofi_op_tagged);
 		if (OFI_UNLIKELY(!rxe)) {
 			efa_base_ep_write_eq_error(&ep->base_ep, FI_ENOBUFS, FI_EFA_ERR_RXE_POOL_EXHAUSTED);
 			return NULL;


### PR DESCRIPTION
efa_rdm_msg_alloc_unexp_rxe_for_msgrtm and efa_rdm_msg_alloc_unexp_rxe_for_tagrtm are mostly the same. This patch merges these two functions into one to remove code duplication.