### PR TITLE
prov/efa: allocate memory for map_entry_pool during 1st call to progress

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_ep_progress.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_progress.c
@@ -175,6 +175,17 @@ int efa_rdm_ep_grow_rx_pools(struct efa_rdm_ep *ep)
 		}
 	}
 
+	if (ep->map_entry_pool) {
+		err = ofi_bufpool_grow(ep->map_entry_pool);
+		if (err) {
+			EFA_WARN(FI_LOG_CQ,
+				 "cannot allocate memory for map entry pool. error: %s\n",
+				 strerror(-err));
+		}
+
+		return err;
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
This patch would explicitly allocate memory for ep->map_entry_pool during the 1st call to progress engine.

This prevents that different progress allocate memory at different time and cause delay.