### PR TITLE
fabtests/common: fix wrong size used to allocate tx_msg_buf     

### DIFF
--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -221,6 +221,7 @@ extern struct fid_mc *mc;
 
 extern fi_addr_t remote_fi_addr;
 extern char *buf, *tx_buf, *rx_buf;
+extern void *tx_msg_buf;
 extern struct ft_context *tx_ctx_arr, *rx_ctx_arr;
 extern char **tx_mr_bufs, **rx_mr_bufs;
 extern size_t buf_size, tx_size, rx_size, tx_mr_size, rx_mr_size;

--- a/fabtests/ubertest/domain.c
+++ b/fabtests/ubertest/domain.c
@@ -315,7 +315,8 @@ static int ft_setup_bufs(void)
 	if (ret)
 		return ret;
 
-	ret = ft_alloc_host_tx_buf(ft_ctrl.size_array[ft_ctrl.size_cnt - 1]);
+	ret = ft_hmem_alloc_host(opts.iface, &tx_msg_buf,
+				 ft_ctrl.size_array[ft_ctrl.size_cnt - 1]);
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
 tx_msg_buf was used to stage outgoing message, so its size must be larger than the maximum outgoing message size.
    
Prior to this change, it is allocated by ft_alloc_tx_host_buf(), with the size being MAX(tx_size, FT_MAX_CTRL_MSG_SIZE) * opt.window_size.
    
When FT_OPT_ALLOC_MULT_MR is requested, this value is too small because at that time "tx_mr_size" is max message size.
    
Otherwise, this value is too large, because "tx_size" is enough (no need to mulitply by opts.window_size).
    
This patch removed the function ft_alloc_tx_host_buf(), and pass correct size to ft_hmem_alloc_host() directly.