### PR TITLE
prov/psm3: add missing `FI_REMOTE_CQ_DATA` for `fi_inject_writedata`

### DIFF
--- a/prov/psm3/src/psmx3_rma.c
+++ b/prov/psm3/src/psmx3_rma.c
@@ -1435,7 +1435,7 @@ STATIC ssize_t psmx3_inject_writedata(struct fid_ep *ep, const void *buf, size_t
 	ep_priv = container_of(ep, struct psmx3_fid_ep, ep);
 
 	return psmx3_write_generic(ep, buf, len, NULL, dest_addr, addr, key, NULL,
-				   ep_priv->tx_flags | FI_INJECT | PSMX3_NO_COMPLETION,
+				   ep_priv->tx_flags | FI_INJECT | PSMX3_NO_COMPLETION | FI_REMOTE_CQ_DATA,
 				   data);
 }
 


### PR DESCRIPTION
in the provider `psm3`, the function `fi_inject_writedata` does not forward the flag `FI_REMOTE_CQ_DATA` to the `write_generic` function, leading to no cq data being actually generated.

Assuming that the function `fi_writedata` is correct, I presume that adding the flag is the right fix