### PR TITLE
fabtests/recv_cancel: initialize error entry

### DIFF
--- a/fabtests/functional/recv_cancel.c
+++ b/fabtests/functional/recv_cancel.c
@@ -78,6 +78,8 @@ static int recv_cancel_host(void)
 	struct fi_cq_err_entry recv_completion, cancel_error_entry;
 	struct fi_context cancel_recv_ctx, standard_recv_ctx;
 
+	memset(&cancel_error_entry, 0, sizeof(cancel_error_entry));
+
 	/* Pre-post two recvs, one of which will be cancelled */
 	ft_tag = CANCEL_TAG;
 	ret = ft_post_rx(ep, opts.transfer_size, &cancel_recv_ctx);


### PR DESCRIPTION
In recv_cancel_host(), the cancel_error_entry should be memset as 0, because fi_cq_readerr uses err_data and err_data_size from it as input. Not initialized error entry will cause unexpected values to be used.