### PR TITLE
prov/efa: Remove smr_cleanup call in efa_prov.c

### DIFF
--- a/prov/efa/src/efa_prov.c
+++ b/prov/efa/src/efa_prov.c
@@ -213,7 +213,6 @@ static void efa_prov_finalize(void)
 	efa_win_lib_finalize();
 
 #if HAVE_EFA_DL
-	smr_cleanup();
 	ofi_monitors_cleanup();
 	ofi_hmem_cleanup();
 	ofi_mem_fini();


### PR DESCRIPTION
Efa shouldn't call smr_* functions inside the provider. It also cause warning when HAVE_EFA_DL=1.