### PR TITLE
prov/efa: Use util srx framework

### DIFF
--- a/fabtests/pytest/efa/test_unexpected_msg.py
+++ b/fabtests/pytest/efa/test_unexpected_msg.py
@@ -3,7 +3,5 @@ import pytest
 @pytest.mark.functional
 def test_unexpected_msg(cmdline_args):
     from common import ClientServerTest
-    if cmdline_args.server_id == cmdline_args.client_id:
-        pytest.skip("Temporarily skip single node before the unknown peer bug is fixed")
     test = ClientServerTest(cmdline_args, "fi_unexpected_msg -e rdm -I 10")
     test.run()

--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -130,7 +130,8 @@ nodist_prov_efa_test_efa_unit_test_SOURCES = \
 	prov/efa/test/efa_unit_test_cq.c \
 	prov/efa/test/efa_unit_test_device.c \
 	prov/efa/test/efa_unit_test_info.c \
-	prov/efa/test/efa_unit_test_hmem.c
+	prov/efa/test/efa_unit_test_hmem.c \
+	prov/efa/test/efa_unit_test_srx.c
 
 efa_CPPFLAGS += -I$(top_srcdir)/include -I$(top_srcdir)/prov/efa/test $(cmocka_CPPFLAGS)
 

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -188,6 +188,15 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 		ret = err;
 		goto err_free;
 	}
+
+	err = ofi_genlock_init(&efa_domain->srx_lock, efa_domain->util_domain.threading != FI_THREAD_SAFE ?
+			       OFI_LOCK_NOOP : OFI_LOCK_MUTEX);
+	if (err) {
+		EFA_WARN(FI_LOG_DOMAIN, "srx lock init failed! err: %d\n", err);
+		ret = err;
+		goto err_free;
+	}
+
 	efa_domain->util_domain.av_type = FI_AV_TABLE;
 	efa_domain->util_domain.mr_map.mode |= FI_MR_VIRT_ADDR;
 	/*
@@ -333,6 +342,8 @@ static int efa_domain_close(fid_t fid)
 
 	if (efa_domain->info)
 		fi_freeinfo(efa_domain->info);
+
+	ofi_genlock_destroy(&efa_domain->srx_lock);
 	free(efa_domain->qp_table);
 	free(efa_domain);
 	return 0;

--- a/prov/efa/src/efa_domain.h
+++ b/prov/efa/src/efa_domain.h
@@ -58,6 +58,7 @@ struct efa_domain {
 	uint64_t		rdm_mode;
 	size_t			rdm_cq_size;
 	struct dlist_entry	list_entry; /* linked to g_efa_domain_list */
+	struct ofi_genlock	srx_lock; /* shared among peer providers */
 };
 
 extern struct dlist_entry g_efa_domain_list;

--- a/prov/efa/src/rdm/efa_rdm_atomic.c
+++ b/prov/efa/src/rdm/efa_rdm_atomic.c
@@ -132,11 +132,14 @@ ssize_t efa_rdm_atomic_generic_efa(struct efa_rdm_ep *efa_rdm_ep,
 		[ofi_op_atomic_fetch] = RXR_FETCH_RTA_PKT,
 		[ofi_op_atomic_compare] = RXR_COMPARE_RTA_PKT
 	};
+	struct util_srx_ctx *srx_ctx;
 
 	assert(msg->iov_count <= efa_rdm_ep->tx_iov_limit);
 	efa_perfset_start(efa_rdm_ep, perf_efa_tx);
 
-	ofi_genlock_lock(&efa_rdm_ep->base_ep.util_ep.lock);
+	srx_ctx = efa_rdm_ep_get_peer_srx_ctx(efa_rdm_ep);
+
+	ofi_genlock_lock(srx_ctx->lock);
 
 	peer = efa_rdm_ep_get_peer(efa_rdm_ep, msg->addr);
 	assert(peer);
@@ -214,7 +217,7 @@ ssize_t efa_rdm_atomic_generic_efa(struct efa_rdm_ep *efa_rdm_ep,
 	}
 
 out:
-	ofi_genlock_unlock(&efa_rdm_ep->base_ep.util_ep.lock);
+	ofi_genlock_unlock(srx_ctx->lock);
 	efa_perfset_end(efa_rdm_ep, perf_efa_tx);
 	return err;
 }

--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -147,14 +147,6 @@ struct efa_rdm_ep {
 	 * emulated fetch and compare atomic.
 	 */
 	struct ofi_bufpool *rx_atomrsp_pool;
-	/* rx_entries with recv buf */
-	struct dlist_entry rx_list;
-	/* rx_entries without recv buf (unexpected message) */
-	struct dlist_entry rx_unexp_list;
-	/* rx_entries with tagged recv buf */
-	struct dlist_entry rx_tagged_list;
-	/* rx_entries without tagged recv buf (unexpected message) */
-	struct dlist_entry rx_unexp_tagged_list;
 	/* list of pre-posted recv buffers */
 	struct dlist_entry rx_posted_buf_list;
 	/* op entries with queued rnr packets */
@@ -213,7 +205,7 @@ struct efa_rdm_ep {
 	int blocking_copy_rxe_num; /* number of RX entries that are using gdrcopy/cudaMemcpy */
 
 	int	hmem_p2p_opt; /* what to do for hmem transfers */
-	struct fid_peer_srx peer_srx; /* support sharing receive context with peer providers */
+	struct fid_ep *peer_srx_ep; /* support sharing receive context with peer providers */
 	bool cuda_api_permitted; /**< whether end point is permitted to call CUDA API */
 
 	/* use_device_rdma:
@@ -437,6 +429,22 @@ static inline int efa_rdm_ep_cap_check_atomic(struct efa_rdm_ep *ep) {
 		return 0;
 	EFA_WARN_ONCE(FI_LOG_EP_DATA, "Operation requires FI_ATOMIC capability, which was not requested.");
 	return -FI_EOPNOTSUPP;
+}
+
+/**
+ * @brief Get the peer_srx from ep
+ *
+ * @param ep efa rdm endpoint
+ * @return struct fid_peer_srx* a ptr to the peer srx
+ */
+static inline struct fid_peer_srx *efa_rdm_ep_get_peer_srx(struct efa_rdm_ep *ep)
+{
+	return container_of(ep->peer_srx_ep, struct fid_peer_srx, ep_fid);
+}
+
+static inline struct util_srx_ctx *efa_rdm_ep_get_peer_srx_ctx(struct efa_rdm_ep *ep)
+{
+	return (struct util_srx_ctx *) ep->peer_srx_ep->fid.context;
 }
 
 #endif

--- a/prov/efa/src/rdm/efa_rdm_ep_progress.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_progress.c
@@ -619,6 +619,8 @@ void efa_rdm_ep_progress_internal(struct efa_rdm_ep *ep)
 	ssize_t ret;
 	uint64_t flags;
 
+	assert(ofi_genlock_held(efa_rdm_ep_get_peer_srx_ctx(ep)->lock));
+
 	/* Poll the EFA completion queue. Restrict poll size
 	 * to avoid CQE flooding and thereby blocking user thread. */
 	efa_rdm_ep_poll_ibv_cq(ep, efa_env.efa_cq_read_size);
@@ -837,7 +839,5 @@ void efa_rdm_ep_progress(struct util_ep *util_ep)
 
 	ep = container_of(util_ep, struct efa_rdm_ep, base_ep.util_ep);
 
-	ofi_genlock_lock(&ep->base_ep.util_ep.lock);
-	efa_rdm_ep_progress_internal(ep);
-	ofi_genlock_unlock(&ep->base_ep.util_ep.lock);
+	return efa_rdm_ep_progress_internal(ep);
 }

--- a/prov/efa/src/rdm/efa_rdm_ep_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_utils.c
@@ -184,15 +184,8 @@ struct efa_rdm_ope *efa_rdm_ep_alloc_rxe(struct efa_rdm_ep *ep, fi_addr_t addr, 
 	rxe->cuda_copy_method = EFA_RDM_CUDA_COPY_UNSPEC;
 	rxe->efa_outstanding_tx_ops = 0;
 	rxe->op = op;
+	rxe->peer_rxe = NULL;
 
-	rxe->peer_rxe.addr = addr;
-	/* This field points to the fid_peer_srx struct that's part of the peer API
-	*  We always set it to the EFA provider's SRX here. For SHM messages, we will set
-	*  this to SHM provider's SRX in the get_msg/get_tag function call
-	*/
-	rxe->peer_rxe.srx = &ep->peer_srx;
-
-	dlist_init(&rxe->entry);
 	switch (op) {
 	case ofi_op_tagged:
 		rxe->cq_entry.flags = (FI_RECV | FI_MSG | FI_TAGGED);

--- a/prov/efa/src/rdm/efa_rdm_msg.h
+++ b/prov/efa/src/rdm/efa_rdm_msg.h
@@ -31,44 +31,6 @@
  * SOFTWARE.
  */
 
-/**
- * @brief Populate the fields in fi_peer_rx_entry object
- * with the equivalences in efa_rdm_ope
- *
- * @param[in,out] peer_rxe the fi_peer_rx_entry object to be updated
- * @param[in] rxe the efa_rdm_ope
- * @param[in] op the ofi op code
- */
-static inline
-void efa_rdm_msg_update_peer_rxe(struct fi_peer_rx_entry *peer_rxe,
-				  struct efa_rdm_ope *rxe,
-				  uint32_t op)
-{
-	assert(op == ofi_op_msg || op == ofi_op_tagged);
-
-	/*
-	 * We cannot pass FI_MULTI_RECV flag to peer provider
-	 * because it will write it to the cqe for each completed rx.
-	 * However, this flag should only be written to the cqe of either
-	 * the last rxe that consumed the posted buffer, or a dummy cqe
-	 * with FI_MULTI_RECV flag only that indicates the multi recv has finished.
-	 * We will do the second way, see efa_rdm_srx_free_entry().
-	 */
-	peer_rxe->flags = (rxe->fi_flags & ~FI_MULTI_RECV);
-	if (rxe->desc[0] && ((struct efa_mr *)rxe->desc[0])->shm_mr) {
-		memcpy(rxe->shm_desc, rxe->desc, rxe->iov_count * sizeof(void *));
-		efa_rdm_get_desc_for_shm(rxe->iov_count, rxe->desc, rxe->shm_desc);
-		peer_rxe->desc = rxe->shm_desc;
-	} else {
-		peer_rxe->desc = NULL;
-	}
-	peer_rxe->iov = rxe->iov;
-	peer_rxe->count = rxe->iov_count;
-	peer_rxe->context = rxe->cq_entry.op_context;
-	if (op == ofi_op_tagged)
-		peer_rxe->tag = rxe->tag;
-}
-
 static inline
 void efa_rdm_msg_construct(struct fi_msg *msg, const struct iovec *iov, void **desc,
 		       size_t count, fi_addr_t addr, void *context, uint64_t data)
@@ -93,54 +55,6 @@ void rxr_tmsg_construct(struct fi_msg_tagged *msg, const struct iovec *iov, void
 	msg->data = data;
 	msg->tag = tag;
 }
-
-/**
- * @brief Queue an unexp rxe to unexp msg queues
- *
- * @param ep efa_rdm_ep
- * @param unexp_rxe the unexp rxe to be queued
- */
-static inline
-void efa_rdm_msg_queue_unexp_rxe_for_msgrtm(struct efa_rdm_ep *ep,
-					      struct efa_rdm_ope *unexp_rxe)
-{
-	struct efa_rdm_peer *peer;
-
-	dlist_insert_tail(&unexp_rxe->entry, &ep->rx_unexp_list);
-	peer = efa_rdm_ep_get_peer(ep, unexp_rxe->addr);
-	dlist_insert_tail(&unexp_rxe->peer_unexp_entry, &peer->rx_unexp_list);
-}
-
-/**
- * @brief Queue an unexp rxe to unexp tag queues
- *
- * @param ep efa_rdm_ep
- * @param unexp_rxe the unexp rxe to be queued
- */
-static inline
-void efa_rdm_msg_queue_unexp_rxe_for_tagrtm(struct efa_rdm_ep *ep,
-					      struct efa_rdm_ope *unexp_rxe)
-{
-	struct efa_rdm_peer *peer;
-
-	dlist_insert_tail(&unexp_rxe->entry, &ep->rx_unexp_tagged_list);
-	peer = efa_rdm_ep_get_peer(ep, unexp_rxe->addr);
-	dlist_insert_tail(&unexp_rxe->peer_unexp_entry, &peer->rx_unexp_tagged_list);
-}
-
-/**
- * multi recv related functions
- */
-
-
-bool efa_rdm_msg_multi_recv_buffer_available(struct efa_rdm_ep *ep,
-					 struct efa_rdm_ope *rxe);
-
-void efa_rdm_msg_multi_recv_handle_completion(struct efa_rdm_ep *ep,
-					  struct efa_rdm_ope *rxe);
-
-void efa_rdm_msg_multi_recv_free_posted_entry(struct efa_rdm_ep *ep,
-					  struct efa_rdm_ope *rxe);
 
 /**
  * functions to allocate rxe for two sided operations

--- a/prov/efa/src/rdm/efa_rdm_peer.c
+++ b/prov/efa/src/rdm/efa_rdm_peer.c
@@ -53,8 +53,6 @@ void efa_rdm_peer_construct(struct efa_rdm_peer *peer, struct efa_rdm_ep *ep, st
 	peer->num_runt_bytes_in_flight = 0;
 	ofi_recvwin_buf_alloc(&peer->robuf, efa_env.recvwin_size);
 	dlist_init(&peer->outstanding_tx_pkts);
-	dlist_init(&peer->rx_unexp_list);
-	dlist_init(&peer->rx_unexp_tagged_list);
 	dlist_init(&peer->txe_list);
 	dlist_init(&peer->rxe_list);
 }

--- a/prov/efa/src/rdm/efa_rdm_srx.h
+++ b/prov/efa/src/rdm/efa_rdm_srx.h
@@ -36,9 +36,14 @@
 
 #include "efa.h"
 
-#define PEER_SRX_MSG_PKT_SIZE sizeof(struct rxr_pkt_entry) + sizeof(struct rxr_longread_msgrtm_hdr)
-#define PEER_SRX_TAG_PKT_SIZE sizeof(struct rxr_pkt_entry) + sizeof(struct rxr_longread_tagrtm_hdr)
+int efa_rdm_peer_srx_construct(struct efa_rdm_ep *efa_rdm_ep);
 
-void efa_rdm_peer_srx_construct(struct efa_rdm_ep *efa_rdm_ep, struct fid_peer_srx *peer_srx);
+void efa_rdm_srx_update_rxe(struct fi_peer_rx_entry *peer_rxe,
+			    struct efa_rdm_ope *rxe);
+
+static inline struct util_srx_ctx *efa_rdm_srx_get_srx_ctx(struct fi_peer_rx_entry *peer_rxe)
+{
+	return (struct util_srx_ctx *) peer_rxe->srx->ep_fid.fid.context;
+}
 
 #endif /* _EFA_RDM_SRX_H */

--- a/prov/efa/src/rdm/rxr_pkt_entry.c
+++ b/prov/efa/src/rdm/rxr_pkt_entry.c
@@ -180,9 +180,6 @@ void rxr_pkt_entry_release_rx(struct efa_rdm_ep *ep,
 {
 	assert(pkt_entry->next == NULL);
 
-	if (pkt_entry->alloc_type == RXR_PKT_FROM_PEER_SRX)
-		return;
-
 	if (ep->use_zcpy_rx && pkt_entry->alloc_type == RXR_PKT_FROM_USER_BUFFER)
 		return;
 

--- a/prov/efa/src/rdm/rxr_pkt_entry.h
+++ b/prov/efa/src/rdm/rxr_pkt_entry.h
@@ -53,7 +53,6 @@ enum rxr_pkt_entry_alloc_type {
 	RXR_PKT_FROM_OOO_POOL,	      /**< packet is allocated from `ep->rx_ooo_pkt_pool` */
 	RXR_PKT_FROM_USER_BUFFER,     /**< packet is from user provided buffer` */
 	RXR_PKT_FROM_READ_COPY_POOL,  /**< packet is allocated from `ep->rx_readcopy_pkt_pool` */
-	RXR_PKT_FROM_PEER_SRX,    /**< packet is created in flight from peer SRX ops */
 };
 
 struct rxr_pkt_sendv {

--- a/prov/efa/test/efa_unit_test_srx.c
+++ b/prov/efa/test/efa_unit_test_srx.c
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Amazon.com, Inc. or its affiliates. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "efa_unit_tests.h"
+#include "ofi_util.h"
+#include "efa_rdm_ep.h"
+
+/**
+ * @brief This test validates whether the default min_multi_recv size is correctly
+ * passed from ep to srx, and whether is correctly modified when application
+ * change it via fi_setopt
+ * 
+ */
+void test_efa_srx_min_multi_recv_size(struct efa_resource **state)
+{
+        struct efa_resource *resource = *state;
+        struct efa_rdm_ep *efa_rdm_ep;
+        struct util_srx_ctx *srx_ctx;
+        size_t min_multi_recv_size_new;
+
+        efa_unit_test_resource_construct(resource, FI_EP_RDM);
+
+        efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
+        srx_ctx = efa_rdm_ep_get_peer_srx_ctx(efa_rdm_ep);
+        /*
+         * After ep is enabled, the srx->min_multi_recv_size should be
+         * exactly the same with ep->min_multi_recv_size
+         */
+        assert_true(efa_rdm_ep->min_multi_recv_size == srx_ctx->min_multi_recv_size);
+        /* Set a new min_multi_recv_size via setopt*/
+        min_multi_recv_size_new = 1024;
+        assert_int_equal(fi_setopt(&resource->ep->fid, FI_OPT_ENDPOINT, FI_OPT_MIN_MULTI_RECV,
+			&min_multi_recv_size_new, sizeof(min_multi_recv_size_new)), 0);
+
+        /* Check whether srx->min_multi_recv_size is set correctly */
+        assert_true(srx_ctx->min_multi_recv_size == min_multi_recv_size_new);
+}
+
+
+/* This test verified that cq is correctly bound to srx when it's bound to ep */
+void test_efa_srx_cq(struct efa_resource **state)
+{
+        struct efa_resource *resource = *state;
+        struct efa_rdm_ep *efa_rdm_ep;
+        struct util_srx_ctx *srx_ctx;
+
+        efa_unit_test_resource_construct(resource, FI_EP_RDM);
+
+        efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
+        srx_ctx = efa_rdm_ep_get_peer_srx_ctx(efa_rdm_ep);
+        assert_true((void *) &srx_ctx->cq->cq_fid == (void *) resource->cq);
+}
+
+/* This test verified that srx_lock created in efa_domain is correctly passed to srx */
+void test_efa_srx_lock(struct efa_resource **state)
+{
+        struct efa_resource *resource = *state;
+        struct efa_rdm_ep *efa_rdm_ep;
+        struct util_srx_ctx *srx_ctx;
+        struct efa_domain *efa_domain;
+
+        efa_unit_test_resource_construct(resource, FI_EP_RDM);
+
+        efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
+        srx_ctx = efa_rdm_ep_get_peer_srx_ctx(efa_rdm_ep);
+        efa_domain = container_of(resource->domain, struct efa_domain,
+				  util_domain.domain_fid.fid);
+        assert_true(((void *) srx_ctx->lock == (void *) &efa_domain->srx_lock));
+}

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -113,6 +113,9 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_use_device_rdma_opt0, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_use_device_rdma_opt_old, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_hmem_info_update_neuron, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_srx_min_multi_recv_size, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_srx_cq, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_srx_lock, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 	};
 
 	cmocka_set_message_output(CM_OUTPUT_XML);

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -113,6 +113,9 @@ void test_efa_use_device_rdma_opt0();
 void test_efa_use_device_rdma_env1();
 void test_efa_use_device_rdma_env0();
 void test_efa_use_device_rdma_opt_old();
+void test_efa_srx_min_multi_recv_size();
+void test_efa_srx_cq();
+void test_efa_srx_lock();
 
 
 #endif


### PR DESCRIPTION
This PR makes efa provider uses the util SRX framework
    proposed in https://github.com/ofiwg/libfabric/pull/8907.
    It replaced the recv post (including multi-recv), and msg/tag
    matching procedure with the ones defined in util_srx.c

