### PR TITLE
prov/sm2: Get rid of xfer_ctx_pool in unexpected recv path

### DIFF
--- a/prov/sm2/src/sm2.h
+++ b/prov/sm2/src/sm2.h
@@ -95,6 +95,7 @@ enum {
  * 	next - fifo linked list next ptr
  * 		This is volatile for a reason, many things touch this
  * 		and we do not want compiler optimization here
+ * 	ep - A pointer to receiver's ep (used on unexp msg path)
  * 	size - Holds total size of message
  * 	cq_data - user defined CQ data
  * 	tag - used for tagged messages
@@ -107,7 +108,10 @@ enum {
  * 	user_data - the message
  */
 struct sm2_xfer_hdr {
-	volatile long int next;
+	union {
+		volatile long int next;
+		struct sm2_ep *ep;
+	};
 	uint64_t size;
 	uint64_t cq_data;
 	uint64_t tag;
@@ -245,7 +249,6 @@ struct sm2_ep {
 	sm2_gid_t gid;
 	ofi_spin_t tx_lock;
 	struct fid_ep *srx;
-	struct ofi_bufpool *xfer_ctx_pool;
 	int ep_idx;
 };
 

--- a/prov/sm2/src/sm2_ep.c
+++ b/prov/sm2/src/sm2_ep.c
@@ -421,9 +421,6 @@ static int sm2_ep_close(struct fid *fid)
 	if (ep->util_ep.ep_fid.msg != &sm2_no_recv_msg_ops)
 		sm2_srx_close(&ep->srx->fid);
 
-	if (ep->xfer_ctx_pool)
-		ofi_bufpool_destroy(ep->xfer_ctx_pool);
-
 	ofi_spin_destroy(&ep->tx_lock);
 
 	free((void *) ep->name);
@@ -918,16 +915,6 @@ int sm2_endpoint(struct fid_domain *domain, struct fi_info *info,
 
 	ep->util_ep.ep_fid.msg = &sm2_msg_ops;
 	ep->util_ep.ep_fid.tagged = &sm2_tag_ops;
-
-	ret = ofi_bufpool_create(&ep->xfer_ctx_pool,
-				 sizeof(struct sm2_xfer_ctx), 16, 0,
-				 info->rx_attr->size, OFI_BUFPOOL_NO_TRACK);
-	if (ret || ofi_bufpool_grow(ep->xfer_ctx_pool)) {
-		FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,
-			"Unable to create xfer_entry ctx pool\n");
-		return -FI_ENOMEM;
-	}
-
 	ep->util_ep.ep_fid.fid.ops = &sm2_ep_fi_ops;
 	ep->util_ep.ep_fid.ops = &sm2_ep_ops;
 	ep->util_ep.ep_fid.cm = &sm2_cm_ops;

--- a/prov/sm2/src/sm2_progress.c
+++ b/prov/sm2/src/sm2_progress.c
@@ -70,8 +70,7 @@ static int sm2_progress_inject(struct sm2_xfer_entry *xfer_entry,
 
 static int sm2_start_common(struct sm2_ep *ep,
 			    struct sm2_xfer_entry *xfer_entry,
-			    struct fi_peer_rx_entry *rx_entry,
-			    bool return_xfer_entry)
+			    struct fi_peer_rx_entry *rx_entry)
 {
 	size_t total_len = 0;
 	uint64_t comp_flags;
@@ -108,11 +107,9 @@ static int sm2_start_common(struct sm2_ep *ep,
 	if (ret) {
 		FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,
 			"Unable to process rx completion\n");
-	} else if (return_xfer_entry) {
-		/* Return Free Queue Entries here */
-		sm2_fifo_write_back(ep, xfer_entry);
 	}
 
+	sm2_fifo_write_back(ep, xfer_entry);
 	sm2_get_peer_srx(ep)->owner_ops->free_entry(rx_entry);
 
 	return 0;
@@ -120,35 +117,8 @@ static int sm2_start_common(struct sm2_ep *ep,
 
 int sm2_unexp_start(struct fi_peer_rx_entry *rx_entry)
 {
-	struct sm2_xfer_ctx *xfer_ctx = rx_entry->peer_context;
-	int ret;
-
-	ret = sm2_start_common(xfer_ctx->ep, &xfer_ctx->xfer_entry, rx_entry,
-			       false);
-	ofi_buf_free(xfer_ctx);
-
-	return ret;
-}
-
-static int sm2_alloc_xfer_entry_ctx(struct sm2_ep *ep,
-				    struct fi_peer_rx_entry *rx_entry,
-				    struct sm2_xfer_entry *xfer_entry)
-{
-	struct sm2_xfer_ctx *xfer_ctx;
-
-	xfer_ctx = ofi_buf_alloc(ep->xfer_ctx_pool);
-	if (!xfer_ctx) {
-		FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,
-			"Error allocating xfer_entry ctx\n");
-		return -FI_ENOMEM;
-	}
-
-	memcpy(&xfer_ctx->xfer_entry, xfer_entry, sizeof(*xfer_entry));
-	xfer_ctx->ep = ep;
-
-	rx_entry->peer_context = xfer_ctx;
-
-	return FI_SUCCESS;
+	struct sm2_xfer_entry *xfer_entry = rx_entry->peer_context;
+	return sm2_start_common(xfer_entry->hdr.ep, xfer_entry, rx_entry);
 }
 
 static int sm2_progress_recv_msg(struct sm2_ep *ep,
@@ -168,12 +138,8 @@ static int sm2_progress_recv_msg(struct sm2_ep *ep,
 			peer_srx, addr, xfer_entry->hdr.size,
 			xfer_entry->hdr.tag, &rx_entry);
 		if (ret == -FI_ENOENT) {
-			ret = sm2_alloc_xfer_entry_ctx(ep, rx_entry,
-						       xfer_entry);
-			sm2_fifo_write_back(ep, xfer_entry);
-			if (ret)
-				return ret;
-
+			xfer_entry->hdr.ep = ep;
+			rx_entry->peer_context = xfer_entry;
 			ret = peer_srx->owner_ops->queue_tag(rx_entry);
 			goto out;
 		}
@@ -181,21 +147,19 @@ static int sm2_progress_recv_msg(struct sm2_ep *ep,
 		ret = peer_srx->owner_ops->get_msg(
 			peer_srx, addr, xfer_entry->hdr.size, &rx_entry);
 		if (ret == -FI_ENOENT) {
-			ret = sm2_alloc_xfer_entry_ctx(ep, rx_entry,
-						       xfer_entry);
-			sm2_fifo_write_back(ep, xfer_entry);
-			if (ret)
-				return ret;
-
+			xfer_entry->hdr.ep = ep;
+			rx_entry->peer_context = xfer_entry;
 			ret = peer_srx->owner_ops->queue_msg(rx_entry);
 			goto out;
 		}
 	}
+
 	if (ret) {
 		FI_WARN(&sm2_prov, FI_LOG_EP_CTRL, "Error getting rx_entry\n");
 		return ret;
 	}
-	ret = sm2_start_common(ep, xfer_entry, rx_entry, true);
+
+	ret = sm2_start_common(ep, xfer_entry, rx_entry);
 
 out:
 	return ret < 0 ? ret : 0;


### PR DESCRIPTION
Remove a legacy SHM construct, xfer_ctx_pool. For the unexpected path, SHM needs to copy the message out of the circular buffer and into a temporary context until a receive is posted.  SM2 doesn't need to do this behavior.  SM2 pops the message from the fifo queue, and then can hold onto the peer's xfer_entry until the receiving endpoint posts a buffer that matches it. This change reduces the amount of code on SM2's critical path, and speeds it up a little bit.