### PR TITLE
.github/workflows: Explicitly enable sm2 for Coverity

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -36,6 +36,7 @@ env:
     --enable-udp
     --enable-usnic
     --enable-verbs=rdma-core/build
+    --enable-sm2
   RDMA_CORE_PATH: 'rdma-core/build'
   RDMA_CORE_VERSION: v34.1
 jobs:


### PR DESCRIPTION
Try to enable SM2 for Coverity (https://github.com/ofiwg/libfabric/issues/8967)

I expect more work is needed as well.