### PR TITLE
prov/sm2: Fix startup resource leaks

### DIFF
--- a/prov/sm2/src/sm2_coordination.c
+++ b/prov/sm2/src/sm2_coordination.c
@@ -268,8 +268,12 @@ ssize_t sm2_file_open_or_create(struct sm2_mmap *map_shared)
 		}
 
 		common_fd = open(SM2_COORDINATION_FILE, O_RDWR);
-		if (common_fd > 0) {
+		if (common_fd >= 0) {
 			tmp_header = sm2_mmap_map(common_fd, map_shared);
+			if (!tmp_header) {
+				close(common_fd);
+				continue;
+			}
 			err = sm2_mmap_check_version(tmp_header);
 			if (err)
 				break;

--- a/prov/sm2/src/sm2_coordination.c
+++ b/prov/sm2/src/sm2_coordination.c
@@ -192,7 +192,9 @@ ssize_t sm2_file_open_or_create(struct sm2_mmap *map_shared)
 {
 	pthread_mutexattr_t att;
 	struct sm2_mmap map_ours;
-	char template[FI_NAME_MAX];
+	static const int template_len = sizeof(SM2_COORDINATION_DIR) +
+					sizeof("/fi_sm2_pid1234567_XXXXXX") + 1;
+	char template[template_len];
 	struct sm2_coord_file_header *header, *tmp_header;
 	struct sm2_ep_allocation_entry *entries;
 	int fd, common_fd, err, tries, item;
@@ -205,8 +207,7 @@ ssize_t sm2_file_open_or_create(struct sm2_mmap *map_shared)
 			"Unable to determine page size %ld\n", page_size);
 		return -FI_EINVAL;
 	}
-
-	sprintf(template, "%s/fi_sm2_pid%d_XXXXXX", SM2_COORDINATION_DIR,
+	sprintf(template, "%s/fi_sm2_pid%7d_XXXXXX", SM2_COORDINATION_DIR,
 		getpid());
 
 	/* Assume we are the first process here.


### PR DESCRIPTION
Fix CID 384050 by allowing common_fd=0 and catching mmap-related errors.

Fix similar leak when mkostemp file creation or map fails.

Change size of mkostemp file's template, as it's not related to FI_NAME_MAX.

check return values of several system calls which were previously ignored.