### PR TITLE
prov/psm3: Convert error message to debug output

### DIFF
--- a/prov/psm3/psm3/psm2_hal.c
+++ b/prov/psm3/psm3/psm2_hal.c
@@ -572,7 +572,7 @@ static struct _psmi_hal_instance *psm3_hal_get_pi_inst(void)
 		return psm3_hal_current_hal_instance;
 
 	if (!psm3_num_hal) {
-		_HFI_ERROR("No HALs registered\n");
+		_HFI_DBG("No HALs registered\n");
 		return NULL;
 	}
 


### PR DESCRIPTION
In pmodels/mpich#6518, a user reported seeing a "No HALs registered" message when using MPICH+libfabric. The message appears to come from the failed initialization of the psm3 provider. Convert it to debug output to avoid spamming applications.