### PR TITLE
prov/netdir: Fix ep leak in error path in ofi_nd_endpoint

### DIFF
--- a/prov/netdir/src/netdir_ep.c
+++ b/prov/netdir/src/netdir_ep.c
@@ -197,8 +197,10 @@ int ofi_nd_endpoint(struct fid_domain *pdomain, struct fi_info *info,
 
 	if (info->handle) {
 		assert(info->handle->fclass == FI_CLASS_CONNREQ);
-		if (info->handle->fclass != FI_CLASS_CONNREQ)
-			return -FI_EINVAL;
+		if (info->handle->fclass != FI_CLASS_CONNREQ) {
+			hr = E_HANDLE;
+			goto fn_fail;
+		}
 		connreq = container_of(info->handle, struct nd_connreq,
 				       handle);
 	}


### PR DESCRIPTION
If handle isn't correct type, fail through the error path to silence coverity.