### PR TITLE
workflows: Update to actions/xxx@v3

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y ${{ env.APT_PACKAGES }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download Coverity tools
         run: |
           wget https://scan.coverity.com/download/linux64 --post-data "token=${{ secrets.COVERITY_SCAN_TOKEN }}&project=ofiwg%2Flibfabric" -O coverity_tool.tgz
@@ -84,7 +84,7 @@ jobs:
             --form description="`$PWD/install/bin/fi_info -l`" \
             https://scan.coverity.com/builds?project=ofiwg%2Flibfabric
       - name: Upload build logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: coverity-build-log.txt
           path: cov-int/build-log.txt

--- a/.github/workflows/gh-man.yaml
+++ b/.github/workflows/gh-man.yaml
@@ -21,7 +21,7 @@ jobs:
               echo "$GITHUB_DATA"
 
           - name: Check out the git repo
-            uses: actions/checkout@v2
+            uses: actions/checkout@v3
 
           - name: Update the man pages in branch gh-pages
             run: .github/workflows/gh-man.sh

--- a/.github/workflows/nroff-elves.yaml
+++ b/.github/workflows/nroff-elves.yaml
@@ -19,7 +19,7 @@ jobs:
               echo "$GITHUB_DATA"
 
           - name: Check out the git repo
-            uses: actions/checkout@v2
+            uses: actions/checkout@v3
 
           - name: Get the required packages
             run: sudo apt install -y pandoc hub

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y ${{ env.APT_PACKAGES }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build Check
         run: |
           set -x
@@ -66,7 +66,7 @@ jobs:
           $PWD/install/bin/fi_info -l
       - name: Upload build logs
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: config.log
           path: config.log
@@ -92,7 +92,7 @@ jobs:
           sudo apt-add-repository 'deb [arch=amd64] https://repositories.intel.com/graphics/ubuntu focal main'
           sudo apt-get update
           sudo apt-get install -y level-zero level-zero-dev
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: HMEM Checks
         run: |
           set -x
@@ -110,7 +110,7 @@ jobs:
           $PWD/install/bin/fi_info -c FI_HMEM
       - name: Upload build logs
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: config.log
           path: config.log
@@ -121,7 +121,7 @@ jobs:
         run: |
            brew install automake
            brew install libtool
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build Check
         run: |
           ./autogen.sh
@@ -130,7 +130,7 @@ jobs:
           $PWD/install/bin/fi_info -l
       - name: Upload build logs
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: config.log
           path: config.log


### PR DESCRIPTION
Switch from Node12 to Node16 (whatever that means) in response to Github Actions warnings on PRs.

Fixes #8294