### PR TITLE
common/bsock: Fix error checking for -EAGAIN

### DIFF
--- a/prov/hook/hook_hmem/src/hook_hmem.c
+++ b/prov/hook/hook_hmem/src/hook_hmem.c
@@ -1669,6 +1669,7 @@ static int hook_hmem_mr_regv(struct fid *fid, const struct iovec *iov,
 	 */
 	attr.iface = FI_HMEM_SYSTEM;
 	attr.device.reserved = 0;
+	attr.hmem_data = NULL;
 
 	return hook_hmem_mr_regattr(fid, &attr, flags, mr);
 }

--- a/prov/tcp/src/xnet_progress.c
+++ b/prov/tcp/src/xnet_progress.c
@@ -1159,8 +1159,13 @@ static void xnet_uring_run_ep(struct xnet_ep *ep, struct ofi_sockctx *sockctx,
 
 static void xnet_uring_run_conn(struct xnet_conn_handle *conn, int res)
 {
-	conn->sock = res < 0 ? INVALID_SOCKET : res;
-	xnet_handle_conn(conn, res < 0);
+	if (res >= 0) {
+		conn->sock = res;
+		xnet_handle_conn(conn, false);
+	} else {
+		FI_WARN(&xnet_prov, FI_LOG_EP_CTRL, "accept socket error\n");
+		free(conn);
+	}
 }
 
 static void xnet_progress_cqe(struct xnet_progress *progress,

--- a/src/common.c
+++ b/src/common.c
@@ -1225,7 +1225,7 @@ int ofi_bsock_send(struct ofi_bsock *bsock, const void *buf, size_t *len)
 		if (ret == -OFI_EINPROGRESS_URING)
 			return ret;
 
-		if (OFI_SOCK_TRY_SND_RCV_AGAIN(ret) &&
+		if (OFI_SOCK_TRY_SND_RCV_AGAIN(-ret) &&
 		    *len < ofi_byteq_writeable(&bsock->sq)) {
 			ofi_byteq_write(&bsock->sq, buf, *len);
 			return 0;
@@ -1285,7 +1285,7 @@ int ofi_bsock_sendv(struct ofi_bsock *bsock, const struct iovec *iov,
 		if (ret == -OFI_EINPROGRESS_URING)
 			return ret;
 
-		if (OFI_SOCK_TRY_SND_RCV_AGAIN(ret) &&
+		if (OFI_SOCK_TRY_SND_RCV_AGAIN(-ret) &&
 		    *len < ofi_byteq_writeable(&bsock->sq)) {
 			ofi_byteq_writev(&bsock->sq, iov, cnt);
 			return 0;


### PR DESCRIPTION
In ofi_bsock_send(), we need to check if (-ret) == EAGAIN. The negation is missing, as a result, we won't use the buffered space for queuing messages that can't be written directly to the socket.

This problem was reported by coverity as unreachable code.