### PR TITLE
prov/shm: Handle Freestack Exhaustion, and ensure smr_signal() on EAGAIN

### DIFF
--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -418,12 +418,14 @@ static inline int smr_cma_loop(pid_t pid, struct iovec *local,
 static inline struct smr_inject_buf *
 smr_get_txbuf(struct smr_region *smr)
 {
-	struct smr_inject_buf * txbuf;
+	struct smr_inject_buf *txbuf;
 
 	pthread_spin_lock(&smr->lock);
-	txbuf = smr_freestack_pop(smr_inject_pool(smr));
+	if (!smr_freestack_isempty(smr_inject_pool(smr)))
+		txbuf = smr_freestack_pop(smr_inject_pool(smr));
+	else
+		txbuf = NULL;
 	pthread_spin_unlock(&smr->lock);
-
 	return txbuf;
 }
 

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -125,6 +125,8 @@ static ssize_t smr_do_atomic_inject(struct smr_ep *ep, struct smr_region *peer_s
 	struct smr_resp *resp;
 
 	tx_buf = smr_get_txbuf(peer_smr);
+	if (!tx_buf)
+		return -FI_EAGAIN;
 
 	smr_generic_format(cmd, peer_id, op, 0, 0, op_flags);
 	smr_generic_atomic_format(cmd, datatype, atomic_op);

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -426,9 +426,12 @@ static ssize_t smr_generic_inject(struct fid_ep *ep_fid, const void *buf,
 	proto = len <= SMR_MSG_DATA_LEN ? smr_src_inline : smr_src_inject;
 	ret = smr_proto_ops[proto](ep, peer_smr, id, peer_id, op, tag, data,
 			op_flags, NULL, &msg_iov, 1, len, NULL, &ce->cmd);
+	if (ret) {
+		smr_cmd_queue_discard(ce, pos);
+		return ret;
+	}
 	smr_cmd_queue_commit(ce, pos);
 
-	assert(!ret);
 	ofi_ep_tx_cntr_inc_func(&ep->util_ep, op);
 
 	smr_signal(peer_smr);

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -381,8 +381,10 @@ static ssize_t smr_generic_rma_inject(struct fid_ep *ep_fid, const void *buf,
 	proto = len <= SMR_MSG_DATA_LEN ? smr_src_inline : smr_src_inject;
 	ret = smr_proto_ops[proto](ep, peer_smr, id, peer_id, ofi_op_write, 0,
 			data, flags, NULL, &iov, 1, len, NULL, &ce->cmd);
-
-	assert(!ret);
+	if (ret) {
+		smr_cmd_queue_discard(ce, pos);
+		return -FI_EAGAIN;
+	}
 	smr_add_rma_cmd(peer_smr, &rma_iov, 1, ce);
 	smr_cmd_queue_commit(ce, pos);
 signal:

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -89,7 +89,7 @@ static ssize_t smr_rma_fast(struct smr_region *peer_smr, const struct iovec *iov
 			    (op == ofi_op_write) ? ofi_op_write_async :
 			    ofi_op_read_async, op_flags);
 	smr_cmd_queue_commit(ce, pos);
-
+	smr_signal(peer_smr);
 	return 0;
 
 discard_cmd:


### PR DESCRIPTION
A series of commits to address https://github.com/ofiwg/libfabric/issues/8976

Ultimately the real cause of the hang may be that there was a path that could use command entries or freestack entries without signalling the peer.  These changes try to address those paths, but also signals the peer any time the peer seems to be out of resources, which should ensure the peer attempts progress.