### PR TITLE
fabtests/pytest: efa test to flood peer during startup

### DIFF
--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -161,6 +161,7 @@ nobase_dist_config_DATA = \
 	pytest/default/test_sighandler.py \
 	pytest/efa/conftest.py \
 	pytest/efa/efa_common.py \
+	pytest/efa/test_flood_peer.py \
 	pytest/efa/test_from_default.py \
 	pytest/efa/test_av.py \
 	pytest/efa/test_cq.py \

--- a/fabtests/pytest/efa/test_flood_peer.py
+++ b/fabtests/pytest/efa/test_flood_peer.py
@@ -1,0 +1,8 @@
+import pytest
+
+@pytest.mark.functional
+def test_flood_peer(cmdline_args):
+    from common import ClientServerTest
+    test = ClientServerTest(cmdline_args, "fi_bw -e rdm -W 6400 -S 512 -T 5",
+                            timeout=20)
+    test.run()


### PR DESCRIPTION
Add a test to flood a peer during startup to ensure good error handling in FI_EAGAIN paths.

---

This test tries to simulate a similar situation as in https://github.com/ofiwg/libfabric/issues/8976, but it's not a perfect reproducer.  In particular main passes this test, but main still had issues on the workloads we were investigating.  Despite that, this is a helpful test, and it does currently error on 1.18.x branch.

The primary reason this test is different than the workload is that the sleep in this test occurs before any exchange of messages.  In the real application we saw an initial exchange, then a flood.