### PR TITLE
prov/efa: optimize ep lock usage.

### DIFF
--- a/prov/efa/src/dgram/efa_dgram_ep.c
+++ b/prov/efa/src/dgram/efa_dgram_ep.c
@@ -380,7 +380,7 @@ void efa_dgram_ep_progress(struct util_ep *ep)
 	rcq = efa_dgram_ep->rcq;
 	scq = efa_dgram_ep->scq;
 
-	ofi_mutex_lock(&ep->lock);
+	ofi_ep_lock_acquire(ep);
 
 	if (rcq)
 		efa_dgram_ep_progress_internal(efa_dgram_ep, rcq);
@@ -388,7 +388,7 @@ void efa_dgram_ep_progress(struct util_ep *ep)
 	if (scq && scq != rcq)
 		efa_dgram_ep_progress_internal(efa_dgram_ep, scq);
 
-	ofi_mutex_unlock(&ep->lock);
+	ofi_ep_lock_release(ep);
 }
 
 static struct fi_ops_atomic efa_dgram_ep_atomic_ops = {

--- a/prov/efa/src/rdm/efa_rdm_atomic.c
+++ b/prov/efa/src/rdm/efa_rdm_atomic.c
@@ -136,7 +136,7 @@ ssize_t efa_rdm_atomic_generic_efa(struct efa_rdm_ep *efa_rdm_ep,
 	assert(msg->iov_count <= efa_rdm_ep->tx_iov_limit);
 	efa_perfset_start(efa_rdm_ep, perf_efa_tx);
 
-	ofi_mutex_lock(&efa_rdm_ep->base_ep.util_ep.lock);
+	ofi_ep_lock_acquire(&efa_rdm_ep->base_ep.util_ep);
 
 	peer = efa_rdm_ep_get_peer(efa_rdm_ep, msg->addr);
 	assert(peer);
@@ -214,7 +214,7 @@ ssize_t efa_rdm_atomic_generic_efa(struct efa_rdm_ep *efa_rdm_ep,
 	}
 
 out:
-	ofi_mutex_unlock(&efa_rdm_ep->base_ep.util_ep.lock);
+	ofi_ep_lock_release(&efa_rdm_ep->base_ep.util_ep);
 	efa_perfset_end(efa_rdm_ep, perf_efa_tx);
 	return err;
 }

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -732,13 +732,13 @@ bool efa_rdm_ep_has_unfinished_send(struct efa_rdm_ep *efa_rdm_ep)
 static inline
 void efa_rdm_ep_wait_send(struct efa_rdm_ep *efa_rdm_ep)
 {
-	ofi_mutex_lock(&efa_rdm_ep->base_ep.util_ep.lock);
+	ofi_ep_lock_acquire(&efa_rdm_ep->base_ep.util_ep);
 
 	while (efa_rdm_ep_has_unfinished_send(efa_rdm_ep)) {
 		efa_rdm_ep_progress_internal(efa_rdm_ep);
 	}
 
-	ofi_mutex_unlock(&efa_rdm_ep->base_ep.util_ep.lock);
+	ofi_ep_lock_release(&efa_rdm_ep->base_ep.util_ep);
 }
 
 /**
@@ -900,7 +900,7 @@ static int efa_rdm_ep_ctrl(struct fid *fid, int command, void *arg)
 		if (ret)
 			return ret;
 
-		ofi_mutex_lock(&ep->base_ep.util_ep.lock);
+		ofi_ep_lock_acquire(&ep->base_ep.util_ep);
 
 		efa_rdm_ep_set_extra_info(ep);
 
@@ -935,7 +935,7 @@ static int efa_rdm_ep_ctrl(struct fid *fid, int command, void *arg)
 				goto out;
 		}
 out:
-		ofi_mutex_unlock(&ep->base_ep.util_ep.lock);
+		ofi_ep_lock_release(&ep->base_ep.util_ep);
 		break;
 	default:
 		ret = -FI_ENOSYS;
@@ -973,12 +973,12 @@ ssize_t efa_rdm_ep_cancel_recv(struct efa_rdm_ep *ep,
 	struct fi_cq_err_entry err_entry;
 	uint32_t api_version;
 
-	ofi_mutex_lock(&ep->base_ep.util_ep.lock);
+	ofi_ep_lock_acquire(&ep->base_ep.util_ep);
 	entry = dlist_remove_first_match(recv_list,
 					 &efa_rdm_ep_compare_rxe_context,
 					 context);
 	if (!entry) {
-		ofi_mutex_unlock(&ep->base_ep.util_ep.lock);
+		ofi_ep_lock_release(&ep->base_ep.util_ep);
 		return 0;
 	}
 
@@ -1002,7 +1002,7 @@ ssize_t efa_rdm_ep_cancel_recv(struct efa_rdm_ep *ep,
 		   rxe->rxr_flags & EFA_RDM_RXE_MULTI_RECV_CONSUMER) {
 		efa_rdm_msg_multi_recv_handle_completion(ep, rxe);
 	}
-	ofi_mutex_unlock(&ep->base_ep.util_ep.lock);
+	ofi_ep_lock_release(&ep->base_ep.util_ep);
 	memset(&err_entry, 0, sizeof(err_entry));
 	err_entry.op_context = rxe->cq_entry.op_context;
 	err_entry.flags |= rxe->cq_entry.flags;

--- a/prov/efa/src/rdm/efa_rdm_ep_progress.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_progress.c
@@ -837,7 +837,7 @@ void efa_rdm_ep_progress(struct util_ep *util_ep)
 
 	ep = container_of(util_ep, struct efa_rdm_ep, base_ep.util_ep);
 
-	ofi_mutex_lock(&ep->base_ep.util_ep.lock);
+	ofi_ep_lock_acquire(&ep->base_ep.util_ep);
 	efa_rdm_ep_progress_internal(ep);
-	ofi_mutex_unlock(&ep->base_ep.util_ep.lock);
+	ofi_ep_lock_release(&ep->base_ep.util_ep);
 }

--- a/prov/efa/src/rdm/efa_rdm_rma.c
+++ b/prov/efa/src/rdm/efa_rdm_rma.c
@@ -161,7 +161,7 @@ ssize_t efa_rdm_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uin
 	assert(msg->iov_count <= efa_rdm_ep->tx_iov_limit);
 
 	efa_perfset_start(efa_rdm_ep, perf_efa_tx);
-	ofi_mutex_lock(&efa_rdm_ep->base_ep.util_ep.lock);
+	ofi_ep_lock_acquire(&efa_rdm_ep->base_ep.util_ep);
 
 	peer = efa_rdm_ep_get_peer(efa_rdm_ep, msg->addr);
 	assert(peer);
@@ -242,7 +242,7 @@ out:
 	if (OFI_UNLIKELY(err && txe))
 		efa_rdm_txe_release(txe);
 
-	ofi_mutex_unlock(&efa_rdm_ep->base_ep.util_ep.lock);
+	ofi_ep_lock_release(&efa_rdm_ep->base_ep.util_ep);
 	efa_perfset_end(efa_rdm_ep, perf_efa_tx);
 	return err;
 }
@@ -460,7 +460,7 @@ ssize_t efa_rdm_rma_writemsg(struct fid_ep *ep,
 	assert(msg->iov_count <= efa_rdm_ep->tx_iov_limit);
 
 	efa_perfset_start(efa_rdm_ep, perf_efa_tx);
-	ofi_mutex_lock(&efa_rdm_ep->base_ep.util_ep.lock);
+	ofi_ep_lock_acquire(&efa_rdm_ep->base_ep.util_ep);
 
 	peer = efa_rdm_ep_get_peer(efa_rdm_ep, msg->addr);
 	assert(peer);
@@ -500,7 +500,7 @@ ssize_t efa_rdm_rma_writemsg(struct fid_ep *ep,
 		efa_rdm_txe_release(txe);
 	}
 out:
-	ofi_mutex_unlock(&efa_rdm_ep->base_ep.util_ep.lock);
+	ofi_ep_lock_release(&efa_rdm_ep->base_ep.util_ep);
 	efa_perfset_end(efa_rdm_ep, perf_efa_tx);
 	return err;
 }


### PR DESCRIPTION
Currently, efa provider always do ofi_mutex_lock/ofi_mutex_unlock to acquire and release ep lock. However, this is not optimal because such lock is unnecessary unless for multi-thread. This patch makes efa provider use ofi_ep_lock_acquire and ofi_ep_lock_release to acquire/release ep lock, which will be no-ops in single thread situation.