### PR TITLE
prov/shm: fix DSA enable

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -283,6 +283,17 @@ struct ofi_mr {
 	void *hmem_data;
 };
 
+static inline bool ofi_mr_all_host(struct ofi_mr **mr, size_t count)
+{
+	int i;
+
+	for (i = 0; i < count; i++) {
+		if (mr[i] && mr[i]->iface != FI_HMEM_SYSTEM)
+			return false;
+	}
+	return true;
+}
+
 void ofi_mr_update_attr(uint32_t user_version, uint64_t caps,
 			const struct fi_mr_attr *user_attr,
 			struct fi_mr_attr *cur_abi_attr);

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -612,7 +612,7 @@ static int smr_format_sar(struct smr_ep *ep, struct smr_cmd *cmd,
 	pending->next = 0;
 
 	if (cmd->msg.hdr.op != ofi_op_read_req) {
-		if (smr_env.use_dsa_sar && !mr) {
+		if (smr_env.use_dsa_sar && ofi_mr_all_host(mr, count)) {
 			ret = smr_dsa_copy_to_sar(ep, smr_sar_pool(peer_smr),
 					resp, cmd, iov,	count,
 					&pending->bytes_done, pending);

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -49,7 +49,7 @@ smr_try_progress_to_sar(struct smr_ep *ep, struct smr_region *smr,
                         size_t *bytes_done, int *next, void *entry_ptr)
 {
 	if (*bytes_done < cmd->msg.hdr.size) {
-		if (smr_env.use_dsa_sar && !mr) {
+		if (smr_env.use_dsa_sar && ofi_mr_all_host(mr, iov_count)) {
 			(void) smr_dsa_copy_to_sar(ep, sar_pool, resp, cmd, iov,
 					    iov_count, bytes_done, entry_ptr);
 			return;
@@ -69,7 +69,7 @@ smr_try_progress_from_sar(struct smr_ep *ep, struct smr_region *smr,
                           size_t *bytes_done, int *next, void *entry_ptr)
 {
 	if (*bytes_done < cmd->msg.hdr.size) {
-		if (smr_env.use_dsa_sar && !mr) {
+		if (smr_env.use_dsa_sar && ofi_mr_all_host(mr, iov_count)) {
 			(void) smr_dsa_copy_from_sar(ep, sar_pool, resp, cmd, 
 					iov, iov_count, bytes_done, entry_ptr);
 			return;


### PR DESCRIPTION
When multiple interface iov support was added, DSA support was skipped because of an incorrect MR check. This adds an extra check to make sure all iovs are host buffers in order to enable the DSA path correctly.