### PR TITLE
fabtests: make tx_buf and rx_buf aligned to 64 bytes by default

### DIFF
--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -42,6 +42,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <getopt.h>
+#include <assert.h>
 
 #include <rdma/fabric.h>
 #include <rdma/fi_rma.h>
@@ -507,6 +508,21 @@ static inline bool ft_check_prefix_forced(struct fi_info *info,
 
 	/* Continue if forced prefix wasn't requested. */
 	return true;
+}
+
+static inline
+size_t ft_get_aligned_size(size_t size, size_t alignment)
+{
+	return ((size % alignment) == 0) ?
+		size : ((size / alignment) + 1) * alignment;
+}
+
+static inline
+void *ft_get_aligned_addr(void *ptr, size_t alignment)
+{
+	/* alignment must be power of 2, hence the assertion */
+	assert((alignment & (alignment - 1)) == 0);
+	return (void *)(((uintptr_t)ptr + alignment - 1) & ~((uintptr_t)alignment - 1));
 }
 
 int ft_read_cq(struct fid_cq *cq, uint64_t *cur, uint64_t total,


### PR DESCRIPTION
Prior to this change, tx_buf and rx_buf is not aligned by default. Moreover, tx_buf is usually on the 2nd half of the whole buf. Therefore, any change to buf_size would change the alignment of tx_buf, which leads to the performance change.

For example, recently fabtests added the data verificiaton of rma_bw, for which 4 bytes was added to buf size, which shifted tx_buf's alignment and changed performance.

To address this issue, this patch make tx_buf and rx_buf to align on 64 bytes boundary by default.