### PR TITLE
prov/tcp: Filter loopback device if iface is specified

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -2155,7 +2155,9 @@ void ofi_get_list_of_addr(const struct fi_provider *prov, const char *env_name,
 
 insert_lo:
 	/* Always add loopback address at the end */
-	ofi_insert_loopback_addr(prov, addr_list);
+	if (!iface || !strncmp(iface, "lo", strlen(iface) + 1) ||
+	    !strncmp(iface, "loopback", strlen(iface) + 1))
+		ofi_insert_loopback_addr(prov, addr_list);
 }
 
 #elif defined HAVE_MIB_IPADDRTABLE


### PR DESCRIPTION
Fixes #7706

If the user specified a specific interface, the loopback device should be filtered out (unless the loopback device was the selected device).