### PR TITLE
fabtests/multinode: Fix function declarations to silence build

### DIFF
--- a/fabtests/functional/multi_mr.c
+++ b/fabtests/functional/multi_mr.c
@@ -112,7 +112,7 @@ static int alloc_multi_mr_res()
 	return 0;
 }
 
-static int init_multi_mr_res()
+static int init_multi_mr_res(void)
 {
 	int ret = 0, i;
 

--- a/fabtests/functional/multi_recv.c
+++ b/fabtests/functional/multi_recv.c
@@ -99,7 +99,7 @@ static int wait_for_recv_completion(int num_completions)
 
 		if (comp.flags & FI_RECV) {
 			if (comp.len != opts.transfer_size) {
-				FT_ERR("completion length %lu, expected %lu",
+				FT_ERR("completion length %zu, expected %zu",
 					comp.len, opts.transfer_size);
 				return -FI_EIO;
 			}

--- a/fabtests/include/windows/netdb.h
+++ b/fabtests/include/windows/netdb.h
@@ -30,9 +30,7 @@
 #define _FABTESTS_OSD_WINDOWS_NETDB_H_
 
 #include <ws2def.h>
-
-/* Error values for `getaddrinfo' function.  */
-# define EAI_MEMORY - 10   /* Memory allocation failure.  */
+#include <Ws2tcpip.h>
 
 #endif /* _FABTESTS_OSD_WINDOWS_NETDB_H_ */
 

--- a/fabtests/multinode/include/core.h
+++ b/fabtests/multinode/include/core.h
@@ -58,9 +58,9 @@ enum multi_pattern {
 
 struct multi_xfer_method {
 	char* name;
-	int (*send)();
-	int (*recv)();
-	int (*wait)();
+	int (*send)(void);
+	int (*recv)(void);
+	int (*wait)(void);
 };
 
 struct pm_job_info {
@@ -110,10 +110,11 @@ int multinode_run_tests(int argc, char **argv);
 int pm_allgather(void *my_item, void *items, int item_size);
 ssize_t socket_send(int sock, void *buf, size_t len, int flags);
 int socket_recv(int sock, void *buf, size_t len, int flags);
-void pm_barrier();
-int multi_msg_send();
-int multi_msg_recv();
-int multi_msg_wait();
-int multi_rma_write();
-int multi_rma_recv();
-int multi_rma_wait();
+void pm_barrier(void);
+
+int multi_msg_send(void);
+int multi_msg_recv(void);
+int multi_msg_wait(void);
+int multi_rma_write(void);
+int multi_rma_recv(void);
+int multi_rma_wait(void);

--- a/fabtests/multinode/src/core.c
+++ b/fabtests/multinode/src/core.c
@@ -169,7 +169,7 @@ static int multi_setup_fabric(int argc, char **argv)
 	}
 
 	for (i = 0; i < pm_job.num_ranks; i++) {
-		ret = fi_av_insert(av, (char *)pm_job.names + i * pm_job.name_len, 
+		ret = fi_av_insert(av, (char *)pm_job.names + i * pm_job.name_len,
 				   1, &pm_job.fi_addrs[i], 0, NULL);
 		if (ret != 1) {
 			FT_ERR("unable to insert all addresses into AV table\n");
@@ -206,7 +206,7 @@ err:
 	return ft_exit_code(ret);
 }
 
-int multi_msg_recv()
+int multi_msg_recv(void)
 {
 	int ret, offset;
 
@@ -238,7 +238,7 @@ int multi_msg_recv()
 	return 0;
 }
 
-int multi_msg_send()
+int multi_msg_send(void)
 {
 	int ret, offset;
 	fi_addr_t dest;
@@ -274,7 +274,7 @@ int multi_msg_send()
 	return 0;
 }
 
-int multi_msg_wait()
+int multi_msg_wait(void)
 {
 	int ret, i;
 
@@ -300,7 +300,7 @@ int multi_msg_wait()
 	return 0;
 }
 
-int multi_rma_write()
+int multi_rma_write(void)
 {
 	int ret, rc;
 
@@ -347,13 +347,13 @@ int multi_rma_write()
 	return 0;
 }
 
-int multi_rma_recv()
+int multi_rma_recv(void)
 {
 	state.all_recvs_posted = true;
 	return 0;
 }
 
-int multi_rma_wait()
+int multi_rma_wait(void)
 {
 	int ret;
 
@@ -397,7 +397,7 @@ int send_recv_barrier(int sync)
 	return ret;
 }
 
-static inline void multi_init_state()
+static inline void multi_init_state(void)
 {
 	state.cur_source = PATTERN_NO_CURRENT;
 	state.cur_target = PATTERN_NO_CURRENT;
@@ -410,14 +410,14 @@ static inline void multi_init_state()
 	state.tx_window = opts.window_size;
 }
 
-static int multi_run_test()
+static int multi_run_test(void)
 {
 	int ret, i;
 
 	for (state.iter = 0; state.iter < opts.iterations; state.iter++) {
 		multi_init_state();
 		for (i = 0; i < pm_job.num_ranks && ft_check_opts(FT_OPT_PERF); i++)
-			multi_timer_init(&timers[timer_index(state.iter, i)], 
+			multi_timer_init(&timers[timer_index(state.iter, i)],
 					 pm_job.my_rank);
 
 		while (!state.all_completions_done ||
@@ -447,7 +447,7 @@ static int multi_run_test()
 	return 0;
 }
 
-static void pm_job_free_res()
+static void pm_job_free_res(void)
 {
 	free(timers);
 	free(pm_job.names);
@@ -480,7 +480,7 @@ int multinode_run_tests(int argc, char **argv)
 		printf("passed\n");
 
 		if (ft_check_opts(FT_OPT_PERF)) {
-			ret = multi_timer_analyze(timers, opts.iterations * 
+			ret = multi_timer_analyze(timers, opts.iterations *
 							  pm_job.num_ranks);
 			if (ret)
 				goto out;

--- a/fabtests/multinode/src/core_coll.c
+++ b/fabtests/multinode/src/core_coll.c
@@ -63,7 +63,7 @@ struct fid_mc *coll_mc;
 struct fi_av_set_attr av_set_attr;
 
 
-static bool is_my_rank_participating()
+static bool is_my_rank_participating(void)
 {
 	size_t rank = pm_job.my_rank;
 
@@ -167,17 +167,17 @@ static int coll_setup_w_start_addr_stride(int start_addr, int stride)
 	return wait_for_event(FI_JOIN_COMPLETE, &done_flag);
 }
 
-static int coll_setup()
+static int coll_setup(void)
 {
 	return coll_setup_w_start_addr_stride(0, 1);
 }
 
-static int coll_setup_w_stride()
+static int coll_setup_w_stride(void)
 {
 	return coll_setup_w_start_addr_stride(1, 2);
 }
 
-static int coll_teardown()
+static int coll_teardown(void)
 {
 	int ret;
 	if (!is_my_rank_participating())
@@ -191,7 +191,8 @@ static int coll_teardown()
 	return ret;
 }
 
-static int join_test_run()
+static int join_test_run(enum fi_collective_op coll_op, enum fi_op op,
+		enum fi_datatype datatype)
 {
 	return FI_SUCCESS;
 }
@@ -208,7 +209,7 @@ static int test_query(enum fi_collective_op coll_op, enum fi_op op,
 	return fi_query_collective(domain, coll_op, &attr, 0);
 }
 
-static int barrier_test_run(enum fi_collective_op coll_op, enum fi_op op, 
+static int barrier_test_run(enum fi_collective_op coll_op, enum fi_op op,
 		enum fi_datatype datatype)
 {
 	uint64_t done_flag;
@@ -519,7 +520,7 @@ struct coll_test tests[] = {
 	},
 };
 
-static inline void setup_hints()
+static inline void setup_hints(void)
 {
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_MSG | FI_COLLECTIVE;
@@ -598,7 +599,7 @@ errout:
 	return ft_exit_code(err);
 }
 
-static void pm_job_free_res()
+static void pm_job_free_res(void)
 {
 	free(pm_job.names);
 	free(pm_job.fi_addrs);

--- a/fabtests/multinode/src/harness.c
+++ b/fabtests/multinode/src/harness.c
@@ -70,7 +70,7 @@ static enum multi_pattern parse_pattern(char *pattern)
 	} else {
 		printf("Warn: Invalid pattern, defaulting to full_mesh\n");
 		return PATTERN_MESH;
-	} 
+	}
 }
 
 ssize_t socket_send(int sock, void *buf, size_t len, int flags)
@@ -147,7 +147,7 @@ int pm_allgather(void *my_item, void *items, int item_size)
 	return 0;
 }
 
-void pm_barrier()
+void pm_barrier(void)
 {
 	char ch;
 	char *chs = alloca(pm_job.num_ranks);
@@ -155,7 +155,7 @@ void pm_barrier()
 	pm_allgather(&ch, chs, 1);
 }
 
-static int pm_init_ranks()
+static int pm_init_ranks(void)
 {
 	int ret;
 	int i;
@@ -177,7 +177,7 @@ static int pm_init_ranks()
 	return ret;
 }
 
-static int server_connect()
+static int server_connect(void)
 {
 	int new_sock;
 	int ret, i;
@@ -211,7 +211,7 @@ err:
 	return new_sock;
 }
 
-static int pm_conn_setup()
+static int pm_conn_setup(void)
 {
 	int sock,  ret;
 	int optval = 1;
@@ -254,7 +254,7 @@ static int pm_conn_setup()
 	return ret;
 }
 
-static void pm_finalize()
+static void pm_finalize(void)
 {
 	int i;
 
@@ -269,7 +269,7 @@ static void pm_finalize()
 	free(pm_job.clients);
 }
 
-int pm_get_oob_server_addr()
+int pm_get_oob_server_addr(void)
 {
 	struct addrinfo *res;
 	struct sockaddr_in *in;


### PR DESCRIPTION
Add missing 'void' parameter to function declarations.  Fix one function declaration.

Fixes #8995