### PR TITLE
prov/efa: Add efa_rdm_srx_foreach_unspec_addr as no-op

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_srx.c
+++ b/prov/efa/src/rdm/efa_rdm_srx.c
@@ -291,6 +291,21 @@ static void efa_rdm_srx_free_entry(struct fi_peer_rx_entry *peer_rxe)
 }
 
 /**
+ * @brief This call is invoked by the peer when any addressing updates have
+ * occurred with the peer. This triggers the owner to iterate over any entries
+ * whose address is still unknown and call the inputed get_addr function on
+ * each to retrieve updated address information.
+ *
+ * @param srx the fid_peer_srx
+ * @param get_addr the pointer to the function that retrieve updated address information
+ */
+static void efa_rdm_srx_foreach_unspec_addr(struct fid_peer_srx *srx,
+					    fi_addr_t (*get_addr)(struct fi_peer_rx_entry *))
+{
+	/* no-op */
+}
+
+/**
  * @brief This call is invoked by the owner provider to start progressing
  * the peer_rxe that matches a received message.
  *
@@ -372,6 +387,7 @@ static struct fi_ops_srx_owner efa_rdm_srx_owner_ops = {
 	.queue_msg = efa_rdm_srx_queue_msg,
 	.queue_tag = efa_rdm_srx_queue_tag,
 	.free_entry = efa_rdm_srx_free_entry,
+	.foreach_unspec_addr = efa_rdm_srx_foreach_unspec_addr,
 };
 
 static struct fi_ops_srx_peer efa_rdm_srx_peer_ops = {


### PR DESCRIPTION
Peer API recently introduced a new function in peer SRX's owner_ops: https://ofiwg.github.io/libfabric/main/man/fi_peer.3.html

This call is invoked by the peer when any addressing updates have occurred with the peer. This triggers the owner to iterate over any entries whose address is still unknown and call the inputed get_addr function on each to retrieve updated address information.

This patch makes this function as no-op to make https://github.com/ofiwg/libfabric/pull/8907 work because shm provider invoked this call in smr_av_insert. It will be finally replaced by the util_foreach_unspec_addr call defined in util_srx.c after efa provider onboarding the util SRX framework.