### PR TITLE
fabtests/efa: test_flood_peer.py increase timeout

### DIFF
--- a/fabtests/pytest/efa/test_flood_peer.py
+++ b/fabtests/pytest/efa/test_flood_peer.py
@@ -4,5 +4,5 @@ import pytest
 def test_flood_peer(cmdline_args):
     from common import ClientServerTest
     test = ClientServerTest(cmdline_args, "fi_bw -e rdm -W 6400 -S 512 -T 5",
-                            timeout=20)
+                            timeout=300)
     test.run()


### PR DESCRIPTION
Increase timeout of new test_flood_peer.py test to 300 seconds to avoid any question if timeout is due to a hard hang or a slow run.