### PR TITLE
[v1.18.x] backport fabtests: call cudaSetDevice() for selected device

### DIFF
--- a/fabtests/include/hmem.h
+++ b/fabtests/include/hmem.h
@@ -92,7 +92,6 @@ int ft_cuda_copy_to_hmem(uint64_t device, void *dst, const void *src,
 			 size_t size);
 int ft_cuda_copy_from_hmem(uint64_t device, void *dst, const void *src,
 			   size_t size);
-
 int ft_rocr_init(void);
 int ft_rocr_cleanup(void);
 int ft_rocr_alloc(uint64_t device, void **buf, size_t size);


### PR DESCRIPTION
If user selected device by using "-i" option and
selected CUDA memory, this patch call cudaSetDevice() to use that device.

Signed-off-by: Wei Zhang <wzam@amazon.com>
(cherry picked from commit 706cc9fbf2ba49c430757db035dcf9af68eb69e2)