### PR TITLE
[v1.18.x] contrib/intel/jenkins: Cherry pick add missing quotes to oneccl

### DIFF
--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -746,7 +746,7 @@ class OneCCLTests(Test):
         else:
             self.prov = self.core_prov
         self.oneccl_environ = {
-            'FI_PROVIDER'               : self.prov,
+            'FI_PROVIDER'               : f"\"{self.prov}\"",
             'CCL_ATL_TRANSPORT'         : 'ofi',
             'CCL_ATL_TRANSPORT_LIST'    : 'ofi'
         }


### PR DESCRIPTION
tcp;ofi_rxm is missing quotes in oneccl tests which makes invoking it in bash fail