### PR TITLE
prov/efa: rxr_pkt_post() call rxr_pkt_entry_sendv() once

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -131,7 +131,8 @@ nodist_prov_efa_test_efa_unit_test_SOURCES = \
 	prov/efa/test/efa_unit_test_device.c \
 	prov/efa/test/efa_unit_test_info.c \
 	prov/efa/test/efa_unit_test_hmem.c \
-	prov/efa/test/efa_unit_test_srx.c
+	prov/efa/test/efa_unit_test_srx.c \
+	prov/efa/test/efa_unit_test_rnr.c
 
 efa_CPPFLAGS += -I$(top_srcdir)/include -I$(top_srcdir)/prov/efa/test $(cmocka_CPPFLAGS)
 

--- a/prov/efa/src/rdm/efa_rdm_atomic.c
+++ b/prov/efa/src/rdm/efa_rdm_atomic.c
@@ -194,20 +194,18 @@ ssize_t efa_rdm_atomic_generic_efa(struct efa_rdm_ep *efa_rdm_ep,
 			    peer->next_msg_id++ : ++peer->next_msg_id;
 
 	if (delivery_complete_requested && op == ofi_op_atomic) {
-		err = rxr_pkt_post_req(efa_rdm_ep,
-				       txe,
-				       RXR_DC_WRITE_RTA_PKT,
-				       0);
+		err = rxr_pkt_post(efa_rdm_ep,
+				   txe,
+				   RXR_DC_WRITE_RTA_PKT);
 	} else {
 		/*
 		 * Fetch atomic and compare atomic
 		 * support DELIVERY_COMPLETE
 		 * by nature
 		 */
-		err = rxr_pkt_post_req(efa_rdm_ep,
-				       txe,
-				       req_pkt_type_list[op],
-				       0);
+		err = rxr_pkt_post(efa_rdm_ep,
+				   txe,
+				   req_pkt_type_list[op]);
 	}
 
 	if (OFI_UNLIKELY(err)) {

--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -291,8 +291,11 @@ int efa_rdm_ep_determine_rdma_write_support(struct efa_rdm_ep *ep, fi_addr_t add
 					struct efa_rdm_peer *peer);
 
 void efa_rdm_ep_queue_rnr_pkt(struct efa_rdm_ep *ep,
-			  struct dlist_entry *list,
-			  struct rxr_pkt_entry *pkt_entry);
+			      struct dlist_entry *list,
+			      struct rxr_pkt_entry *pkt_entry);
+
+ssize_t efa_rdm_ep_send_queued_pkts(struct efa_rdm_ep *ep,
+				   struct dlist_entry *pkts);
 
 static inline
 struct efa_domain *efa_rdm_ep_domain(struct efa_rdm_ep *ep)

--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -100,6 +100,7 @@ struct efa_rdm_ep {
 	/* rx/tx queue size of core provider */
 	size_t efa_max_outstanding_rx_ops;
 	size_t efa_max_outstanding_tx_ops;
+	size_t efa_rnr_queued_pkt_cnt;
 	size_t max_data_payload_size;
 
 	/* Resource management flag */

--- a/prov/efa/src/rdm/efa_rdm_ep_progress.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_progress.c
@@ -605,6 +605,7 @@ ssize_t efa_rdm_ep_send_queued_pkts(struct efa_rdm_ep *ep,
 		pkt_entry->flags &= ~RXR_PKT_ENTRY_RNR_RETRANSMIT;
 		peer = efa_rdm_ep_get_peer(ep, pkt_entry->addr);
 		assert(peer);
+		ep->efa_rnr_queued_pkt_cnt--;
 		peer->rnr_queued_pkt_cnt--;
 	}
 

--- a/prov/efa/src/rdm/efa_rdm_ep_progress.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_progress.c
@@ -579,6 +579,7 @@ ssize_t efa_rdm_ep_send_queued_pkts(struct efa_rdm_ep *ep,
 				    struct dlist_entry *pkts)
 {
 	struct dlist_entry *tmp;
+	struct efa_rdm_peer *peer;
 	struct rxr_pkt_entry *pkt_entry;
 	ssize_t ret;
 
@@ -600,7 +601,13 @@ ssize_t efa_rdm_ep_send_queued_pkts(struct efa_rdm_ep *ep,
 
 			return ret;
 		}
+
+		pkt_entry->flags &= ~RXR_PKT_ENTRY_RNR_RETRANSMIT;
+		peer = efa_rdm_ep_get_peer(ep, pkt_entry->addr);
+		assert(peer);
+		peer->rnr_queued_pkt_cnt--;
 	}
+
 	return 0;
 }
 

--- a/prov/efa/src/rdm/efa_rdm_ep_progress.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_progress.c
@@ -574,7 +574,6 @@ static inline void efa_rdm_ep_poll_ibv_cq(struct efa_rdm_ep *ep, size_t cqe_to_p
  * @param[in]	pkts	Linked list of packets to send
  * @return		0 on success, negative error code on failure
  */
-static inline
 ssize_t efa_rdm_ep_send_queued_pkts(struct efa_rdm_ep *ep,
 				    struct dlist_entry *pkts)
 {

--- a/prov/efa/src/rdm/efa_rdm_ep_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_utils.c
@@ -533,7 +533,7 @@ void efa_rdm_ep_queue_rnr_pkt(struct efa_rdm_ep *ep,
 	dlist_remove(&pkt_entry->dbg_entry);
 #endif
 	dlist_insert_tail(&pkt_entry->entry, list);
-
+	ep->efa_rnr_queued_pkt_cnt += 1;
 	peer = efa_rdm_ep_get_peer(ep, pkt_entry->addr);
 	assert(peer);
 	if (!(pkt_entry->flags & RXR_PKT_ENTRY_RNR_RETRANSMIT)) {

--- a/prov/efa/src/rdm/efa_rdm_msg.c
+++ b/prov/efa/src/rdm/efa_rdm_msg.c
@@ -156,7 +156,7 @@ ssize_t efa_rdm_msg_post_rtm(struct efa_rdm_ep *ep, struct efa_rdm_ope *txe, int
 
 	if (rtm_type < RXR_EXTRA_REQ_PKT_BEGIN) {
 		/* rtm requires only baseline feature, which peer should always support. */
-		return rxr_pkt_post_req(ep, txe, rtm_type, 0);
+		return rxr_pkt_post(ep, txe, rtm_type);
 	}
 
 	/*
@@ -172,7 +172,7 @@ ssize_t efa_rdm_msg_post_rtm(struct efa_rdm_ep *ep, struct efa_rdm_ope *txe, int
 	if (!rxr_pkt_req_supported_by_peer(rtm_type, peer))
 		return -FI_EOPNOTSUPP;
 
-	return rxr_pkt_post_req(ep, txe, rtm_type, 0);
+	return rxr_pkt_post(ep, txe, rtm_type);
 }
 
 ssize_t efa_rdm_msg_generic_send(struct fid_ep *ep, const struct fi_msg *msg,

--- a/prov/efa/src/rdm/efa_rdm_ope.h
+++ b/prov/efa/src/rdm/efa_rdm_ope.h
@@ -186,7 +186,6 @@ struct efa_rdm_ope {
 	/* the following variables are for TX operation only */
 	uint64_t bytes_acked;
 	uint64_t bytes_sent;
-	uint64_t max_req_data_size;
 	/* end of TX only variables */
 
 	uint64_t bytes_read_completed;
@@ -294,17 +293,9 @@ void efa_rdm_ope_try_fill_desc(struct efa_rdm_ope *ope, int mr_iov_start, uint64
 int efa_rdm_txe_prepare_to_be_read(struct efa_rdm_ope *txe,
 				    struct fi_rma_iov *read_iov);
 
-struct efa_rdm_ep;
-
-void efa_rdm_txe_set_runt_size(struct efa_rdm_ep *ep, struct efa_rdm_ope *txe);
-
 size_t efa_rdm_ope_mulreq_total_data_size(struct efa_rdm_ope *ope, int pkt_type);
 
 size_t efa_rdm_txe_max_req_data_capacity(struct efa_rdm_ep *ep, struct efa_rdm_ope *txe, int pkt_type);
-
-void efa_rdm_txe_set_max_req_data_size(struct efa_rdm_ep *ep, struct efa_rdm_ope *txe, int pkt_type);
-
-size_t efa_rdm_txe_num_req(struct efa_rdm_ope *txe, int pkt_type);
 
 void efa_rdm_txe_handle_error(struct efa_rdm_ope *txe, int err, int prov_errno);
 
@@ -317,6 +308,11 @@ void efa_rdm_rxe_report_completion(struct efa_rdm_ope *rxe);
 void efa_rdm_ope_handle_recv_completed(struct efa_rdm_ope *ope);
 
 void efa_rdm_ope_handle_send_completed(struct efa_rdm_ope *ope);
+
+ssize_t efa_rdm_ope_prepare_to_post_send(struct efa_rdm_ope *ope,
+					 int pkt_type,
+					 int *pkt_entry_cnt,
+					 int *pkt_entry_data_size_vec);
 
 int efa_rdm_ope_prepare_to_post_read(struct efa_rdm_ope *ope);
 

--- a/prov/efa/src/rdm/efa_rdm_rma.c
+++ b/prov/efa/src/rdm/efa_rdm_rma.c
@@ -118,12 +118,12 @@ ssize_t efa_rdm_rma_post_efa_emulated_read(struct efa_rdm_ep *ep, struct efa_rdm
 #endif
 
 	if (txe->total_len < ep->mtu_size - sizeof(struct rxr_readrsp_hdr)) {
-		err = rxr_pkt_post_req(ep, txe, RXR_SHORT_RTR_PKT, 0);
+		err = rxr_pkt_post(ep, txe, RXR_SHORT_RTR_PKT);
 	} else {
 		assert(efa_env.tx_min_credits > 0);
 		txe->window = MIN(txe->total_len,
 				       efa_env.tx_min_credits * ep->max_data_payload_size);
-		err = rxr_pkt_post_req(ep, txe, RXR_LONGCTS_RTR_PKT, 0);
+		err = rxr_pkt_post(ep, txe, RXR_LONGCTS_RTR_PKT);
 	}
 
 	if (OFI_UNLIKELY(err)) {
@@ -418,7 +418,7 @@ ssize_t efa_rdm_rma_post_write(struct efa_rdm_ep *ep, struct efa_rdm_ope *txe)
 	if (txe->total_len >= efa_rdm_ep_domain(ep)->hmem_info[iface].min_read_write_size &&
 		efa_rdm_ep_determine_rdma_read_support(ep, txe->addr, peer) &&
 		(txe->desc[0] || efa_is_cache_available(efa_rdm_ep_domain(ep)))) {
-		err = rxr_pkt_post_req(ep, txe, RXR_LONGREAD_RTW_PKT, 0);
+		err = rxr_pkt_post(ep, txe, RXR_LONGREAD_RTW_PKT);
 		if (err != -FI_ENOMEM)
 			return err;
 		/*
@@ -429,11 +429,11 @@ ssize_t efa_rdm_rma_post_write(struct efa_rdm_ep *ep, struct efa_rdm_ope *txe)
 
 	if (txe->total_len <= max_eager_rtw_data_size) {
 		ctrl_type = delivery_complete_requested ? RXR_DC_EAGER_RTW_PKT : RXR_EAGER_RTW_PKT;
-		return rxr_pkt_post_req(ep, txe, ctrl_type, 0);
+		return rxr_pkt_post(ep, txe, ctrl_type);
 	}
 
 	ctrl_type = delivery_complete_requested ? RXR_DC_LONGCTS_RTW_PKT : RXR_LONGCTS_RTW_PKT;
-	return rxr_pkt_post_req(ep, txe, ctrl_type, 0);
+	return rxr_pkt_post(ep, txe, ctrl_type);
 }
 
 ssize_t efa_rdm_rma_writemsg(struct fid_ep *ep,

--- a/prov/efa/src/rdm/rxr_pkt_cmd.h
+++ b/prov/efa/src/rdm/rxr_pkt_cmd.h
@@ -34,16 +34,11 @@
 #ifndef _RXR_PKT_CMD_H
 #define _RXR_PKT_CMD_H
 
-
-
 ssize_t rxr_pkt_post(struct efa_rdm_ep *ep, struct efa_rdm_ope *ope,
-		     int pkt_type, uint64_t flags);
+		     int pkt_type);
 
 ssize_t rxr_pkt_post_or_queue(struct efa_rdm_ep *ep, struct efa_rdm_ope *ope,
 			      int req_type);
-
-ssize_t rxr_pkt_post_req(struct efa_rdm_ep *ep, struct efa_rdm_ope *txe,
-			 int req_type, uint64_t flags);
 
 fi_addr_t rxr_pkt_determine_addr(struct efa_rdm_ep *ep, struct rxr_pkt_entry *pkt_entry);
 

--- a/prov/efa/src/rdm/rxr_pkt_entry.c
+++ b/prov/efa/src/rdm/rxr_pkt_entry.c
@@ -143,6 +143,8 @@ void rxr_pkt_entry_release_tx(struct efa_rdm_ep *ep, struct rxr_pkt_entry *pkt_e
 	 * we get a send completion for a retransmitted packet.
 	 */
 	if (OFI_UNLIKELY(pkt_entry->flags & RXR_PKT_ENTRY_RNR_RETRANSMIT)) {
+		assert(ep->efa_rnr_queued_pkt_cnt);
+		ep->efa_rnr_queued_pkt_cnt--;
 		peer = efa_rdm_ep_get_peer(ep, pkt_entry->addr);
 		assert(peer);
 		peer->rnr_queued_pkt_cnt--;

--- a/prov/efa/src/rdm/rxr_pkt_entry.h
+++ b/prov/efa/src/rdm/rxr_pkt_entry.h
@@ -280,8 +280,7 @@ struct rxr_pkt_entry *rxr_pkt_get_unexp(struct efa_rdm_ep *ep,
 
 ssize_t rxr_pkt_entry_sendv(struct efa_rdm_ep *ep,
 			    struct rxr_pkt_entry **pkt_entry_vec,
-			    int pkt_entry_cnt,
-			    uint64_t flags);
+			    int pkt_entry_cnt);
 
 int rxr_pkt_entry_read(struct efa_rdm_ep *ep, struct rxr_pkt_entry *pkt_entry,
 		       void *local_buf, size_t len, void *desc,

--- a/prov/efa/src/rdm/rxr_pkt_type_data.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_data.c
@@ -38,7 +38,9 @@
 #include "rxr_pkt_type_base.h"
 
 int rxr_pkt_init_data(struct rxr_pkt_entry *pkt_entry,
-		      struct efa_rdm_ope *ope)
+		      struct efa_rdm_ope *ope,
+		      size_t data_offset,
+		      int data_size)
 {
 	struct rxr_data_hdr *data_hdr;
 	struct efa_rdm_peer *peer;
@@ -78,13 +80,10 @@ int rxr_pkt_init_data(struct rxr_pkt_entry *pkt_entry,
 	/*
 	 * Data packets are sent in order so using bytes_sent is okay here.
 	 */
-	data_hdr->seg_offset = ope->bytes_sent;
-	data_hdr->seg_length = MIN(ope->total_len - ope->bytes_sent,
-				   ep->max_data_payload_size);
-	data_hdr->seg_length = MIN(data_hdr->seg_length, ope->window);
+	data_hdr->seg_offset = data_offset;
+	data_hdr->seg_length = data_size;
 	ret = rxr_pkt_init_data_from_ope(ep, pkt_entry, hdr_size,
-					      ope, ope->bytes_sent,
-					      data_hdr->seg_length);
+					 ope, data_offset, data_size);
 	if (ret)
 		return ret;
 

--- a/prov/efa/src/rdm/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_misc.c
@@ -116,7 +116,7 @@ ssize_t rxr_pkt_post_handshake(struct efa_rdm_ep *ep, struct efa_rdm_peer *peer)
 
 	rxr_pkt_init_handshake(ep, pkt_entry, addr);
 
-	ret = rxr_pkt_entry_sendv(ep, &pkt_entry, 1, 0);
+	ret = rxr_pkt_entry_sendv(ep, &pkt_entry, 1);
 	if (OFI_UNLIKELY(ret)) {
 		rxr_pkt_entry_release_tx(ep, pkt_entry);
 	}

--- a/prov/efa/src/rdm/rxr_pkt_type_req.h
+++ b/prov/efa/src/rdm/rxr_pkt_type_req.h
@@ -181,18 +181,27 @@ ssize_t rxr_pkt_init_eager_tagrtm(struct rxr_pkt_entry *pkt_entry,
 				  struct efa_rdm_ope *txe);
 
 ssize_t rxr_pkt_init_medium_msgrtm(struct rxr_pkt_entry *pkt_entry,
-				     struct efa_rdm_ope *txe);
+				   struct efa_rdm_ope *txe,
+				   size_t data_offset,
+				   int data_size);
 
 ssize_t rxr_pkt_init_dc_eager_tagrtm(struct rxr_pkt_entry *pkt_entry,
 				     struct efa_rdm_ope *txe);
 
 ssize_t rxr_pkt_init_dc_medium_msgrtm(struct rxr_pkt_entry *pkt_entry,
-				      struct efa_rdm_ope *txe);
+				      struct efa_rdm_ope *txe,
+				      size_t data_offset,
+				      int data_size);
+
 ssize_t rxr_pkt_init_medium_tagrtm(struct rxr_pkt_entry *pkt_entry,
-				   struct efa_rdm_ope *txe);
+				   struct efa_rdm_ope *txe,
+				   size_t data_offset,
+				   int data_size);
 
 ssize_t rxr_pkt_init_dc_medium_tagrtm(struct rxr_pkt_entry *pkt_entry,
-				      struct efa_rdm_ope *txe);
+				      struct efa_rdm_ope *txe,
+				      size_t data_offset,
+				      int data_size);
 
 ssize_t rxr_pkt_init_longcts_msgrtm(struct rxr_pkt_entry *pkt_entry,
 				    struct efa_rdm_ope *txe);
@@ -213,10 +222,14 @@ ssize_t rxr_pkt_init_longread_tagrtm(struct rxr_pkt_entry *pkt_entry,
 				     struct efa_rdm_ope *txe);
 
 ssize_t rxr_pkt_init_runtread_msgrtm(struct rxr_pkt_entry *pkt_entry,
-				     struct efa_rdm_ope *txe);
+				     struct efa_rdm_ope *txe,
+				     size_t data_offset,
+				     int data_size);
 
 ssize_t rxr_pkt_init_runtread_tagrtm(struct rxr_pkt_entry *pkt_entry,
-				     struct efa_rdm_ope *txe);
+				     struct efa_rdm_ope *txe,
+				     size_t data_offset,
+				     int data_size);
 
 static inline
 void rxr_pkt_handle_eager_rtm_sent(struct efa_rdm_ep *ep,

--- a/prov/efa/test/efa_unit_test_rnr.c
+++ b/prov/efa/test/efa_unit_test_rnr.c
@@ -1,0 +1,60 @@
+#include "efa_unit_tests.h"
+#include "rxr_pkt_cmd.h"
+
+/**
+ * @brief this test validate that during RNR queuing and resending,
+ * the "rnr_queued_pkt_cnt" in endpoint and peer were properly updated,
+ * so is the RXR_PKT_ENTRY_RNR_RETRANSMIT flag.
+ */
+void test_efa_rnr_queue_and_resend(struct efa_resource **state)
+{
+	struct efa_resource *resource = *state;
+	struct efa_unit_test_buff send_buff;
+	struct efa_ep_addr raw_addr;
+	struct efa_rdm_ep *efa_rdm_ep;
+	struct efa_rdm_ope *txe;
+	struct rxr_pkt_entry *pkt_entry;
+	size_t raw_addr_len = sizeof(raw_addr);
+	fi_addr_t peer_addr;
+	int ret;
+
+	efa_unit_test_resource_construct(resource, FI_EP_RDM);
+	efa_unit_test_buff_construct(&send_buff, resource, 4096 /* buff_size */);
+	/* Create and register a fake peer */
+	ret = fi_getname(&resource->ep->fid, &raw_addr, &raw_addr_len);
+	assert_int_equal(ret, 0);
+	raw_addr.qpn = 0;
+	raw_addr.qkey = 0x1234;
+
+	ret = fi_av_insert(resource->av, &raw_addr, 1, &peer_addr, 0, NULL);
+	assert_int_equal(ret, 1);
+
+	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
+	efa_rdm_ep->base_ep.qp->ibv_qp->context->ops.post_send = &efa_mock_ibv_post_send_save_send_wr;
+	assert_true(dlist_empty(&efa_rdm_ep->txe_list));
+
+	efa_rdm_ep->use_shm_for_tx = false;
+	ret = fi_send(resource->ep, send_buff.buff, send_buff.size, fi_mr_desc(send_buff.mr), peer_addr, NULL /* context */);
+	assert_int_equal(ret, 0);
+	assert_false(dlist_empty(&efa_rdm_ep->txe_list));
+	assert_non_null(g_ibv_send_wr_list.head->wr_id);
+
+	txe = container_of(efa_rdm_ep->txe_list.next, struct efa_rdm_ope, ep_entry);
+	pkt_entry = (struct rxr_pkt_entry *)g_ibv_send_wr_list.head->wr_id;
+
+	efa_rdm_ep_record_tx_op_completed(efa_rdm_ep, pkt_entry);
+	efa_rdm_ep_queue_rnr_pkt(efa_rdm_ep, &txe->queued_pkts, pkt_entry);
+	assert_int_equal(pkt_entry->flags & RXR_PKT_ENTRY_RNR_RETRANSMIT, RXR_PKT_ENTRY_RNR_RETRANSMIT);
+	assert_int_equal(efa_rdm_ep->efa_rnr_queued_pkt_cnt, 1);
+	assert_int_equal(efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr)->rnr_queued_pkt_cnt, 1);
+
+	ret = efa_rdm_ep_send_queued_pkts(efa_rdm_ep, &txe->queued_pkts);
+	assert_int_equal(ret, 0);
+	assert_int_equal(pkt_entry->flags & RXR_PKT_ENTRY_RNR_RETRANSMIT, 0);
+	assert_int_equal(efa_rdm_ep->efa_rnr_queued_pkt_cnt, 0);
+	assert_int_equal(efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr)->rnr_queued_pkt_cnt, 0);
+
+	rxr_pkt_handle_send_completion(efa_rdm_ep, pkt_entry);
+
+	efa_unit_test_buff_destruct(&send_buff);
+}

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -116,6 +116,7 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_srx_min_multi_recv_size, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_srx_cq, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_srx_lock, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_rnr_queue_and_resend, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 	};
 
 	cmocka_set_message_output(CM_OUTPUT_XML);

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -116,6 +116,6 @@ void test_efa_use_device_rdma_opt_old();
 void test_efa_srx_min_multi_recv_size();
 void test_efa_srx_cq();
 void test_efa_srx_lock();
-
+void test_efa_rnr_queue_and_resend();
 
 #endif


### PR DESCRIPTION
For some packet type, rxr_pkt_post() may need to send multiple packets.

Prior to this change, to send N packets, rxr_pkt_post() will call rxr_pkt_entry_sendv() N times. The first N - 1 call will has the flag FI_MORE, to indicate there are more to come. The last call without the FI_MORE flag will cause all N packets to be sent via device, which require the endpoint to maintain a list of outgoing packets.

This patch change to rxr_pkt_post() to

1. create N packets
2. call rxr_pkt_entry_send() once to send all N packets.

With this change, some functions became useless and was eliminated by this patch. Including the following functions:

1. efa_rdm_ep_post_flush() was used by rxr_pkt_entry_sendv() to actually post send. With this change, rxr_pkt_entry_sendv() post send directly, therefore efa_rdm_ep_post_flush() is no longer used and is eliminated.

2. rxr_pkt_post_req() was used to post REQ packet, which will queue medium/runt REQ packets if -FI_EAGAIN is encountered. This was to handle the case that rxr_pkt_post() posted some but not all packets. After this patch, rxr_pkt_post() will post "all or none" of the series of packet entires, so rxr_pkt_post_req() became useless.

3. efa_rdm_ope_set_max_req_data_size() was used to set the "max_req_data_size" field of an efa_rdm_ope. This patch pass the data size explicitly to each packet type's init() function, there efa_rdm_ope_set_max_req_data_size() became useless.