### PR TITLE
[v1.18.x] pytest/efa: unset strict mode for dgram pingpong test

### DIFF
--- a/fabtests/pytest/efa/test_efa_device_selection.py
+++ b/fabtests/pytest/efa/test_efa_device_selection.py
@@ -29,10 +29,14 @@ def test_efa_device_selection(cmdline_args):
             server_tx_bytes_before_test = efa_retrieve_hw_counter_value(cmdline_args.server_id, "tx_bytes", server_device_name)
             client_tx_bytes_before_test = efa_retrieve_hw_counter_value(cmdline_args.client_id, "tx_bytes", client_device_name)
 
+            prefix_type = "wout_prefix"
+            strict_fabtests_mode = True
             if suffix == "rdm":
                 command = "fi_rdm_pingpong"
             else:
-                command = "fi_dgram_pingpong -k" # efa provider requires prefix mode for dgram provider, hence "-k"
+                prefix_type = "with_prefix"  # efa provider requires prefix mode for dgram provider, hence "-k"
+                strict_fabtests_mode = False  # # dgram is unreliable
+                command = "fi_dgram_pingpong"
 
             server_domain_name = server_device_name + "-" + suffix
             client_domain_name = client_device_name + "-" + suffix
@@ -40,8 +44,9 @@ def test_efa_device_selection(cmdline_args):
             cmdline_args_copy = copy.copy(cmdline_args)
             cmdline_args_copy.additional_server_arguments = "-d " + server_domain_name
             cmdline_args_copy.additional_client_arguments = "-d " + client_domain_name
+            cmdline_args_copy.strict_fabtests_mode = strict_fabtests_mode
 
-            test = ClientServerTest(cmdline_args_copy, command, message_size="1000", timeout=300)
+            test = ClientServerTest(cmdline_args_copy, command, message_size="1000", prefix_type=prefix_type, timeout=300)
             test.run()
 
             server_tx_bytes_after_test = efa_retrieve_hw_counter_value(cmdline_args.server_id, "tx_bytes", server_device_name)


### PR DESCRIPTION
dgram is unreliable, therefore do not run test in strict mode.

Signed-off-by: Wenduo Wang <wenduwan@amazon.com>
(cherry picked from commit 19aba70a3ad7e1b6e7c6a683c1eb7bd82cb9a456)