### PR TITLE
Revert "prov/sm2: Get rid of xfer_ctx_pool in unexpected recv path"

### DIFF
--- a/prov/sm2/src/sm2.h
+++ b/prov/sm2/src/sm2.h
@@ -95,7 +95,6 @@ enum {
  * 	next - fifo linked list next ptr
  * 		This is volatile for a reason, many things touch this
  * 		and we do not want compiler optimization here
- * 	ep - A pointer to receiver's ep (used on unexp msg path)
  * 	size - Holds total size of message
  * 	cq_data - user defined CQ data
  * 	tag - used for tagged messages
@@ -108,10 +107,7 @@ enum {
  * 	user_data - the message
  */
 struct sm2_xfer_hdr {
-	union {
-		volatile long int next;
-		struct sm2_ep *ep;
-	};
+	volatile long int next;
 	uint64_t size;
 	uint64_t cq_data;
 	uint64_t tag;
@@ -194,6 +190,7 @@ struct sm2_ep {
 	sm2_gid_t gid;
 	ofi_spin_t tx_lock;
 	struct fid_ep *srx;
+	struct ofi_bufpool *xfer_ctx_pool;
 	int ep_idx;
 };
 


### PR DESCRIPTION
Reverts ofiwg/libfabric#8960

This gives SM2 unlimited unexpected msg queue buffering again.