### PR TITLE
prov/efa: rename rxr_pkt_entry to efa_rdm_pke

### DIFF
--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -894,7 +894,7 @@
     <ClCompile Include="prov\efa\src\rdm\efa_rdm_ep_progress.c" />
     <ClCompile Include="prov\efa\src\rdm\efa_rdm_msg.c" />
     <ClCompile Include="prov\efa\src\rdm\rxr_pkt_cmd.c" />
-    <ClCompile Include="prov\efa\src\rdm\rxr_pkt_entry.c" />
+    <ClCompile Include="prov\efa\src\rdm\efa_rdm_pke.c" />
     <ClCompile Include="prov\efa\src\rdm\rxr_pkt_pool.c" />
     <ClCompile Include="prov\efa\src\rdm\rxr_pkt_type_data.c" />
     <ClCompile Include="prov\efa\src\rdm\rxr_pkt_type_misc.c" />
@@ -1019,7 +1019,7 @@
     <ClInclude Include="prov\efa\src\rdm\efa_rdm_atomic.h" />
     <ClInclude Include="prov\efa\src\rdm\efa_rdm_msg.h" />
     <ClInclude Include="prov\efa\src\rdm\rxr_pkt_cmd.h" />
-    <ClInclude Include="prov\efa\src\rdm\rxr_pkt_entry.h" />
+    <ClInclude Include="prov\efa\src\rdm\efa_rdm_pke.h" />
     <ClInclude Include="prov\efa\src\rdm\rxr_pkt_pool.h" />
     <ClInclude Include="prov\efa\src\rdm\rxr_pkt_type.h" />
     <ClInclude Include="prov\efa\src\rdm\rxr_pkt_type_req.h" />

--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -58,7 +58,7 @@ _efa_files = \
 	prov/efa/src/rdm/efa_rdm_ep_progress.c \
 	prov/efa/src/rdm/efa_rdm_rma.c	\
 	prov/efa/src/rdm/efa_rdm_msg.c	\
-	prov/efa/src/rdm/rxr_pkt_entry.c \
+	prov/efa/src/rdm/efa_rdm_pke.c \
 	prov/efa/src/rdm/rxr_pkt_type_req.c \
 	prov/efa/src/rdm/rxr_pkt_type_base.c \
 	prov/efa/src/rdm/rxr_pkt_type_data.c \
@@ -98,7 +98,7 @@ _efa_headers = \
 	prov/efa/src/rdm/efa_rdm_rma.h \
 	prov/efa/src/rdm/efa_rdm_msg.h \
 	prov/efa/src/rdm/rxr_pkt_hdr.h \
-	prov/efa/src/rdm/rxr_pkt_entry.h \
+	prov/efa/src/rdm/efa_rdm_pke.h \
 	prov/efa/src/rdm/rxr_pkt_type.h \
 	prov/efa/src/rdm/rxr_pkt_type_req.h \
 	prov/efa/src/rdm/rxr_pkt_type_base.h \

--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -130,7 +130,7 @@ fi_addr_t efa_av_reverse_lookup_dgram(struct efa_av *av, uint16_t ahn, uint16_t 
  * @return	On success, return fi_addr to the peer who send the packet
  * 		If no such peer exist, return FI_ADDR_NOTAVAIL
  */
-fi_addr_t efa_av_reverse_lookup_rdm(struct efa_av *av, uint16_t ahn, uint16_t qpn, struct rxr_pkt_entry *pkt_entry)
+fi_addr_t efa_av_reverse_lookup_rdm(struct efa_av *av, uint16_t ahn, uint16_t qpn, struct efa_rdm_pke *pkt_entry)
 {
 	struct efa_cur_reverse_av *cur_entry;
 	struct efa_prv_reverse_av *prv_entry;

--- a/prov/efa/src/efa_av.h
+++ b/prov/efa/src/efa_av.h
@@ -112,7 +112,7 @@ int efa_av_insert_one(struct efa_av *av, struct efa_ep_addr *addr,
 
 struct efa_conn *efa_av_addr_to_conn(struct efa_av *av, fi_addr_t fi_addr);
 
-fi_addr_t efa_av_reverse_lookup_rdm(struct efa_av *av, uint16_t ahn, uint16_t qpn, struct rxr_pkt_entry *pkt_entry);
+fi_addr_t efa_av_reverse_lookup_rdm(struct efa_av *av, uint16_t ahn, uint16_t qpn, struct efa_rdm_pke *pkt_entry);
 
 fi_addr_t efa_av_reverse_lookup_dgram(struct efa_av *av, uint16_t ahn, uint16_t qpn);
 

--- a/prov/efa/src/efa_tp.h
+++ b/prov/efa/src/efa_tp.h
@@ -24,7 +24,7 @@
 
 static inline void efa_tracepoint_wr_id_post_send(const void *wr_id)
 {
-	struct rxr_pkt_entry *pkt_entry = (struct rxr_pkt_entry *) wr_id;
+	struct efa_rdm_pke *pkt_entry = (struct efa_rdm_pke *) wr_id;
 	struct efa_rdm_ope *ope = pkt_entry->ope;
 	if (!ope)
 		return;
@@ -33,7 +33,7 @@ static inline void efa_tracepoint_wr_id_post_send(const void *wr_id)
 
 static inline void efa_tracepoint_wr_id_post_recv(const void *wr_id)
 {
-	struct rxr_pkt_entry *pkt_entry = (struct rxr_pkt_entry *) wr_id;
+	struct efa_rdm_pke *pkt_entry = (struct efa_rdm_pke *) wr_id;
 	struct efa_rdm_ope *ope = pkt_entry->ope;
 	if (!ope)
 		return;

--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -52,7 +52,7 @@ enum ibv_cq_ex_type {
  * copies, and improve performance.
  */
 struct rxr_queued_copy {
-	struct rxr_pkt_entry *pkt_entry;
+	struct efa_rdm_pke *pkt_entry;
 	char *data;
 	size_t data_size;
 	size_t data_offset;
@@ -256,9 +256,9 @@ struct efa_rdm_ope *efa_rdm_ep_alloc_txe(struct efa_rdm_ep *efa_rdm_ep,
 struct efa_rdm_ope *efa_rdm_ep_alloc_rxe(struct efa_rdm_ep *ep,
 					   fi_addr_t addr, uint32_t op);
 
-void efa_rdm_ep_record_tx_op_submitted(struct efa_rdm_ep *ep, struct rxr_pkt_entry *pkt_entry);
+void efa_rdm_ep_record_tx_op_submitted(struct efa_rdm_ep *ep, struct efa_rdm_pke *pkt_entry);
 
-void efa_rdm_ep_record_tx_op_completed(struct efa_rdm_ep *ep, struct rxr_pkt_entry *pkt_entry);
+void efa_rdm_ep_record_tx_op_completed(struct efa_rdm_ep *ep, struct efa_rdm_pke *pkt_entry);
 
 static inline size_t rxr_get_rx_pool_chunk_cnt(struct efa_rdm_ep *ep)
 {
@@ -297,10 +297,10 @@ int efa_rdm_ep_determine_rdma_write_support(struct efa_rdm_ep *ep, fi_addr_t add
 
 void efa_rdm_ep_queue_rnr_pkt(struct efa_rdm_ep *ep,
 			      struct dlist_entry *list,
-			      struct rxr_pkt_entry *pkt_entry);
+			      struct efa_rdm_pke *pkt_entry);
 
 ssize_t efa_rdm_ep_send_queued_pkts(struct efa_rdm_ep *ep,
-				   struct dlist_entry *pkts);
+				    struct dlist_entry *pkts);
 
 static inline
 struct efa_domain *efa_rdm_ep_domain(struct efa_rdm_ep *ep)

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -96,7 +96,7 @@ int efa_rdm_ep_create_buffer_pools(struct efa_rdm_ep *ep)
 
 	ret = rxr_pkt_pool_create(
 		ep,
-		RXR_PKT_FROM_EFA_TX_POOL,
+		EFA_RDM_PKE_FROM_EFA_TX_POOL,
 		rxr_get_tx_pool_chunk_cnt(ep),
 		rxr_get_tx_pool_chunk_cnt(ep), /* max count */
 		EFA_RDM_BUFPOOL_ALIGNMENT,
@@ -106,7 +106,7 @@ int efa_rdm_ep_create_buffer_pools(struct efa_rdm_ep *ep)
 
 	ret = rxr_pkt_pool_create(
 		ep,
-		RXR_PKT_FROM_EFA_RX_POOL,
+		EFA_RDM_PKE_FROM_EFA_RX_POOL,
 		rxr_get_rx_pool_chunk_cnt(ep),
 		rxr_get_rx_pool_chunk_cnt(ep), /* max count */
 		EFA_RDM_BUFPOOL_ALIGNMENT,
@@ -117,7 +117,7 @@ int efa_rdm_ep_create_buffer_pools(struct efa_rdm_ep *ep)
 	if (efa_env.rx_copy_unexp) {
 		ret = rxr_pkt_pool_create(
 			ep,
-			RXR_PKT_FROM_UNEXP_POOL,
+			EFA_RDM_PKE_FROM_UNEXP_POOL,
 			efa_env.unexp_pool_chunk_size,
 			0, /* max count = 0, so pool is allowed to grow */
 			EFA_RDM_BUFPOOL_ALIGNMENT,
@@ -129,7 +129,7 @@ int efa_rdm_ep_create_buffer_pools(struct efa_rdm_ep *ep)
 	if (efa_env.rx_copy_ooo) {
 		ret = rxr_pkt_pool_create(
 			ep,
-			RXR_PKT_FROM_OOO_POOL,
+			EFA_RDM_PKE_FROM_OOO_POOL,
 			efa_env.ooo_pool_chunk_size,
 			0, /* max count = 0, so pool is allowed to grow */
 			EFA_RDM_BUFPOOL_ALIGNMENT,
@@ -143,7 +143,7 @@ int efa_rdm_ep_create_buffer_pools(struct efa_rdm_ep *ep)
 		/* this pool is only needed when application requested FI_HMEM capability */
 		ret = rxr_pkt_pool_create(
 			ep,
-			RXR_PKT_FROM_READ_COPY_POOL,
+			EFA_RDM_PKE_FROM_READ_COPY_POOL,
 			efa_env.readcopy_pool_size,
 			efa_env.readcopy_pool_size, /* max count */
 			EFA_RDM_IN_ORDER_ALIGNMENT, /* support in-order aligned send/recv */
@@ -570,7 +570,7 @@ static void efa_rdm_ep_destroy_buffer_pools(struct efa_rdm_ep *efa_rdm_ep)
 	struct efa_rdm_ope *txe;
 	struct efa_rdm_ope *ope;
 #if ENABLE_DEBUG
-	struct rxr_pkt_entry *pkt_entry;
+	struct efa_rdm_pke *pkt_entry;
 #endif
 
 	dlist_foreach_safe(&efa_rdm_ep->ope_queued_rnr_list, entry, tmp) {
@@ -598,24 +598,24 @@ static void efa_rdm_ep_destroy_buffer_pools(struct efa_rdm_ep *efa_rdm_ep)
 
 #if ENABLE_DEBUG
 	dlist_foreach_safe(&efa_rdm_ep->rx_posted_buf_list, entry, tmp) {
-		pkt_entry = container_of(entry, struct rxr_pkt_entry, dbg_entry);
-		rxr_pkt_entry_release_rx(efa_rdm_ep, pkt_entry);
+		pkt_entry = container_of(entry, struct efa_rdm_pke, dbg_entry);
+		efa_rdm_pke_release_rx(efa_rdm_ep, pkt_entry);
 	}
 
 	dlist_foreach_safe(&efa_rdm_ep->rx_pkt_list, entry, tmp) {
-		pkt_entry = container_of(entry, struct rxr_pkt_entry, dbg_entry);
+		pkt_entry = container_of(entry, struct efa_rdm_pke, dbg_entry);
 		EFA_WARN(FI_LOG_EP_CTRL,
 			"Closing ep with unreleased RX pkt_entry: %p\n",
 			pkt_entry);
-		rxr_pkt_entry_release_rx(efa_rdm_ep, pkt_entry);
+		efa_rdm_pke_release_rx(efa_rdm_ep, pkt_entry);
 	}
 
 	dlist_foreach_safe(&efa_rdm_ep->tx_pkt_list, entry, tmp) {
-		pkt_entry = container_of(entry, struct rxr_pkt_entry, dbg_entry);
+		pkt_entry = container_of(entry, struct efa_rdm_pke, dbg_entry);
 		EFA_WARN(FI_LOG_EP_CTRL,
 			"Closing ep with unreleased TX pkt_entry: %p\n",
 			pkt_entry);
-		rxr_pkt_entry_release_tx(efa_rdm_ep, pkt_entry);
+		efa_rdm_pke_release_tx(efa_rdm_ep, pkt_entry);
 	}
 #endif
 

--- a/prov/efa/src/rdm/efa_rdm_msg.c
+++ b/prov/efa/src/rdm/efa_rdm_msg.c
@@ -669,11 +669,11 @@ struct efa_rdm_ope *efa_rdm_msg_alloc_rxe(struct efa_rdm_ep *ep,
 }
 
 struct efa_rdm_ope *efa_rdm_msg_alloc_unexp_rxe_for_rtm(struct efa_rdm_ep *ep,
-							struct rxr_pkt_entry **pkt_entry_ptr,
+							struct efa_rdm_pke **pkt_entry_ptr,
 							uint32_t op)
 {
 	struct efa_rdm_ope *rxe;
-	struct rxr_pkt_entry *unexp_pkt_entry;
+	struct efa_rdm_pke *unexp_pkt_entry;
 
 	assert(op == ofi_op_msg || ofi_op_tagged);
 

--- a/prov/efa/src/rdm/efa_rdm_msg.h
+++ b/prov/efa/src/rdm/efa_rdm_msg.h
@@ -65,13 +65,13 @@ struct efa_rdm_ope *efa_rdm_msg_alloc_rxe(struct efa_rdm_ep *ep,
 					    uint64_t tag, uint64_t ignore);
 
 struct efa_rdm_ope *efa_rdm_msg_alloc_unexp_rxe_for_rtm(struct efa_rdm_ep *ep,
-							struct rxr_pkt_entry **pkt_entry_ptr,
+							struct efa_rdm_pke **pkt_entry_ptr,
 							uint32_t op);
 
 struct efa_rdm_ope *efa_rdm_msg_split_rxe(struct efa_rdm_ep *ep,
 					    struct efa_rdm_ope *posted_entry,
 					    struct efa_rdm_ope *consumer_entry,
-					    struct rxr_pkt_entry *pkt_entry);
+					    struct efa_rdm_pke *pkt_entry);
 /*
  * The following 2 OP structures are defined in efa_rdm_msg.c and is
  * used by rxr_endpoint()

--- a/prov/efa/src/rdm/efa_rdm_ope.h
+++ b/prov/efa/src/rdm/efa_rdm_ope.h
@@ -34,7 +34,7 @@
 #ifndef _EFA_RDM_OPE_H
 #define _EFA_RDM_OPE_H
 
-#include "rxr_pkt_entry.h"
+#include "efa_rdm_pke.h"
 
 #define RXR_IOV_LIMIT		(4)
 
@@ -179,7 +179,7 @@ struct efa_rdm_ope {
 
 	size_t efa_outstanding_tx_ops;
 
-	struct rxr_pkt_entry *unexp_pkt;
+	struct efa_rdm_pke *unexp_pkt;
 	char *atomrsp_data;
 	enum efa_rdm_cuda_copy_method cuda_copy_method;
 	/* end of RX related variables */
@@ -202,7 +202,7 @@ struct efa_rdm_ope {
 	struct fi_peer_rx_entry *peer_rxe;
 
 	/** the source packet entry of a local read operation */
-	struct rxr_pkt_entry *local_read_pkt_entry;
+	struct efa_rdm_pke *local_read_pkt_entry;
 };
 
 void efa_rdm_txe_construct(struct efa_rdm_ope *txe,
@@ -326,7 +326,7 @@ int efa_rdm_ope_post_remote_read_or_queue(struct efa_rdm_ope *ope);
 
 int efa_rdm_rxe_post_local_read_or_queue(struct efa_rdm_ope *rxe,
 					  size_t rx_data_offset,
-					  struct rxr_pkt_entry *pkt_entry,
+					  struct efa_rdm_pke *pkt_entry,
 					  char *pkt_data, size_t data_size);
 
 #endif

--- a/prov/efa/src/rdm/efa_rdm_peer.h
+++ b/prov/efa/src/rdm/efa_rdm_peer.h
@@ -38,7 +38,7 @@
 
 #define EFA_RDM_PEER_DEFAULT_REORDER_BUFFER_SIZE	(16384)
 
-OFI_DECL_RECVWIN_BUF(struct rxr_pkt_entry*, efa_rdm_robuf, uint32_t);
+OFI_DECL_RECVWIN_BUF(struct efa_rdm_pke*, efa_rdm_robuf, uint32_t);
 
 #define EFA_RDM_PEER_REQ_SENT BIT_ULL(0) /**< A REQ packet has been sent to the peer (peer should send a handshake back) */
 #define EFA_RDM_PEER_HANDSHAKE_SENT BIT_ULL(1) /**< a handshake packet has been sent to the peer */
@@ -230,7 +230,7 @@ void efa_rdm_peer_construct(struct efa_rdm_peer *peer, struct efa_rdm_ep *ep, st
 
 void efa_rdm_peer_destruct(struct efa_rdm_peer *peer, struct efa_rdm_ep *ep);
 
-int efa_rdm_peer_reorder_msg(struct efa_rdm_peer *peer, struct efa_rdm_ep *ep, struct rxr_pkt_entry *pkt_entry);
+int efa_rdm_peer_reorder_msg(struct efa_rdm_peer *peer, struct efa_rdm_ep *ep, struct efa_rdm_pke *pkt_entry);
 
 void efa_rdm_peer_proc_pending_items_in_robuf(struct efa_rdm_peer *peer, struct efa_rdm_ep *ep);
 

--- a/prov/efa/src/rdm/efa_rdm_pke.h
+++ b/prov/efa/src/rdm/efa_rdm_pke.h
@@ -31,28 +31,28 @@
  * SOFTWARE.
  */
 
-#ifndef _RXR_PKT_ENTRY_H
-#define _RXR_PKT_ENTRY_H
+#ifndef _EFA_RDM_PKE_H
+#define _EFA_RDM_PKE_H
 
 #include <ofi_list.h>
 
-#define RXR_PKT_ENTRY_IN_USE		BIT_ULL(0) /**< this packet entry is being used */
-#define RXR_PKT_ENTRY_RNR_RETRANSMIT	BIT_ULL(1) /**< this packet entry encountered RNR and is being retransmitted*/
-#define RXR_PKT_ENTRY_LOCAL_READ	BIT_ULL(2) /**< this packet entry is used as context of a local read operation */
-#define RXR_PKT_ENTRY_DC_LONGCTS_DATA	BIT_ULL(3) /**< this DATA packet entry is used by a delivery complete LONGCTS send/write protocol*/
-#define RXR_PKT_ENTRY_LOCAL_WRITE	BIT_ULL(4) /**< this packet entry is used as context of an RDMA Write to self */
+#define EFA_RDM_PKE_IN_USE		BIT_ULL(0) /**< this packet entry is being used */
+#define EFA_RDM_PKE_RNR_RETRANSMIT	BIT_ULL(1) /**< this packet entry encountered RNR and is being retransmitted*/
+#define EFA_RDM_PKE_LOCAL_READ	BIT_ULL(2) /**< this packet entry is used as context of a local read operation */
+#define EFA_RDM_PKE_DC_LONGCTS_DATA	BIT_ULL(3) /**< this DATA packet entry is used by a delivery complete LONGCTS send/write protocol*/
+#define EFA_RDM_PKE_LOCAL_WRITE	BIT_ULL(4) /**< this packet entry is used as context of an RDMA Write to self */
 
 
 /**
  * @enum for packet entry allocation type
  */
-enum rxr_pkt_entry_alloc_type {
-	RXR_PKT_FROM_EFA_TX_POOL = 1, /**< packet is allocated from `ep->efa_tx_pkt_pool` */
-	RXR_PKT_FROM_EFA_RX_POOL,     /**< packet is allocated from `ep->efa_rx_pkt_pool` */
-	RXR_PKT_FROM_UNEXP_POOL,      /**< packet is allocated from `ep->rx_unexp_pkt_pool` */
-	RXR_PKT_FROM_OOO_POOL,	      /**< packet is allocated from `ep->rx_ooo_pkt_pool` */
-	RXR_PKT_FROM_USER_BUFFER,     /**< packet is from user provided buffer` */
-	RXR_PKT_FROM_READ_COPY_POOL,  /**< packet is allocated from `ep->rx_readcopy_pkt_pool` */
+enum efa_rdm_pke_alloc_type {
+	EFA_RDM_PKE_FROM_EFA_TX_POOL = 1, /**< packet is allocated from `ep->efa_tx_pkt_pool` */
+	EFA_RDM_PKE_FROM_EFA_RX_POOL,     /**< packet is allocated from `ep->efa_rx_pkt_pool` */
+	EFA_RDM_PKE_FROM_UNEXP_POOL,      /**< packet is allocated from `ep->rx_unexp_pkt_pool` */
+	EFA_RDM_PKE_FROM_OOO_POOL,	      /**< packet is allocated from `ep->rx_ooo_pkt_pool` */
+	EFA_RDM_PKE_FROM_USER_BUFFER,     /**< packet is from user provided buffer` */
+	EFA_RDM_PKE_FROM_READ_COPY_POOL,  /**< packet is allocated from `ep->rx_readcopy_pkt_pool` */
 };
 
 struct rxr_pkt_sendv {
@@ -102,32 +102,31 @@ struct efa_recv_wr {
 /**
  * @brief Packet entry
  * 
- * rxr_pkt_entry is used the following occassions:
+ * efa_rdm_pke (pke stands for packet entry) is used the following occassions:
  * 
- * First, it is used as the context of the request EFA provider posted to EFA device and SHM:
+ * First, it is used as the work request ID for the request EFA provider posted to EFA
+ * device via rdma-core:
  * 
- * For each request EFA provider submits to (EFA device or SHM), it will allocate a packet entry.
+ * For each request EFA provider submits to EFA device, it will allocate a packet entry.
  * 
- * When the request was submitted, the pointer of the packet entry will be used as context.
- * For EFA device, context is work request ID (`wr_id`), For SHM, context is the `op_context`
- * in a `fi_msg`.
+ * When the request was submitted to rdma-core, the pointer of the packet entry will be used as work
+ * request ID (`wr_id`).
  * 
- * When the request was completed, EFA device or SHM will return a completion entry, with the
- * the pointer to the rxr_pkt_entry in it.
+ * When the request was completed, rdma-core return a completion, with the "wr_id"
+ * in it, so EFA provder knows which request has completed.
  * 
  * Sometimes, the completion can be a Receiver Not Ready (RNR) error completion.
  * In that case the packet entry will be queued and resubmitted. For the resubmission,
  * the packet entry must contain all the information of the request.
  * 
- * An operation can be either a TX operation or a receive (RX) operation
+ * EFA device (rdma-core) supported request types are:
+ *  send and receive (by all EFA device)
+ *  read and write (by certain EFA device)
  * 
- * For EFA device, a TX operation can be send/read.
- * 
- * For SHM, a TX operation can be send/read/write/atomic.
- * 
- * When used as context of request, packet was allocated from endpoint's efa_tx/rx_pool.
- * When the request is to EFA device, the packet's memory must be registered to EFA device,
- * and the memory registration must be stored as the `mr` field of packet entry.
+ * a send/read/write request uses a packet entry allocated from endpoint's efa_tx_pkt_pool.
+ * a read request uses a packet entry allocated from efa_rx_pkt_pool. Both pool's memories
+ * are registeredd with efa device, the registration is stored in
+ * the "mr" field of the packet entry.
  * 
  * Second, packet entries can be used to store received packet entries that is
  * unexpected or out-of-order. This is because the efa_rx_pkt_pool's size is fixed,
@@ -142,8 +141,7 @@ struct efa_recv_wr {
  * is not registered (when it is unexpected or out-of-order). A new packet entry will be cloned
  * using endpoint's read_copy_pkt_pool, whose memory was registered.
  */
-
-struct rxr_pkt_entry {
+struct efa_rdm_pke {
 	/**
 	 * entry to the linked list of outstanding/queued packet entries
 	 *
@@ -197,14 +195,14 @@ struct rxr_pkt_entry {
 	fi_addr_t addr;
 
 	/** @brief indicate where the memory of this packet entry reside */
-	enum rxr_pkt_entry_alloc_type alloc_type;
+	enum efa_rdm_pke_alloc_type alloc_type;
 
 	/** 
 	 * @brief flags indicating the status of the packet entry
 	 * 
 	 * @details
-	 * Possible flags include  #RXR_PKT_ENTRY_IN_USE #RXR_PKT_ENTRY_RNR_RETRANSMIT,
-	 * #RXR_PKT_ENTRY_LOCAL_READ, and #RXR_PKT_ENTRY_DC_LONGCTS_DATA
+	 * Possible flags include  #EFA_RDM_PKE_IN_USE #EFA_RDM_PKE_RNR_RETRANSMIT,
+	 * #EFA_RDM_PKE_LOCAL_READ, and #EFA_RDM_PKE_DC_LONGCTS_DATA
 	 */
 	uint32_t flags;
 
@@ -214,7 +212,7 @@ struct rxr_pkt_entry {
 	 * @details
 	 * used on receiver side only
 	 */
-	struct rxr_pkt_entry *next;
+	struct efa_rdm_pke *next;
 
 	/** @brief information of send buffer
 	 *  @todo make this field a union with `next` to reduce memory usage
@@ -222,13 +220,13 @@ struct rxr_pkt_entry {
 	struct rxr_pkt_sendv *send;
 
 	/** @brief Work request struct used by rdma-core.
-	 *  @todo move this field out of rxr_pkt_entry, which requires re-implement the buld send.
+	 *  @todo move this field out of efa_rdm_pke, which requires re-implement the buld send.
 	 */
 	struct efa_send_wr *send_wr;
 
 	/**
 	 * @brief Work request struct used by rdma-core for receive.
-	 * @todo move this field out of rxr_pkt_entry to a separate pool.
+	 * @todo move this field out of efa_rdm_pke to a separate pool.
 	 */
 	struct efa_recv_wr recv_wr;
 
@@ -238,9 +236,9 @@ struct rxr_pkt_entry {
 
 #if defined(static_assert) && defined(__x86_64__)
 #if ENABLE_DEBUG
-static_assert(sizeof(struct rxr_pkt_entry) == 256, "rxr_pkt_entry check");
+static_assert(sizeof(struct efa_rdm_pke) == 256, "efa_rdm_pke check");
 #else
-static_assert(sizeof(struct rxr_pkt_entry) == 128, "rxr_pkt_entry check");
+static_assert(sizeof(struct efa_rdm_pke) == 128, "efa_rdm_pke check");
 #endif
 #endif
 
@@ -250,47 +248,47 @@ struct efa_rdm_ope;
 
 struct rxr_pkt_pool;
 
-struct rxr_pkt_entry *rxr_pkt_entry_init_prefix(struct efa_rdm_ep *ep,
+struct efa_rdm_pke *efa_rdm_pke_init_prefix(struct efa_rdm_ep *ep,
 						const struct fi_msg *posted_buf,
 						struct ofi_bufpool *pkt_pool);
 
-struct rxr_pkt_entry *rxr_pkt_entry_alloc(struct efa_rdm_ep *ep,
+struct efa_rdm_pke *efa_rdm_pke_alloc(struct efa_rdm_ep *ep,
 					  struct rxr_pkt_pool *pkt_pool,
-					  enum rxr_pkt_entry_alloc_type alloc_type);
+					  enum efa_rdm_pke_alloc_type alloc_type);
 
-void rxr_pkt_entry_release_tx(struct efa_rdm_ep *ep,
-			      struct rxr_pkt_entry *pkt_entry);
+void efa_rdm_pke_release_tx(struct efa_rdm_ep *ep,
+			      struct efa_rdm_pke *pkt_entry);
 
-void rxr_pkt_entry_release_rx(struct efa_rdm_ep *ep,
-			      struct rxr_pkt_entry *pkt_entry);
+void efa_rdm_pke_release_rx(struct efa_rdm_ep *ep,
+			      struct efa_rdm_pke *pkt_entry);
 
-void rxr_pkt_entry_release(struct efa_rdm_ep *ep,
-			   struct rxr_pkt_entry *pkt_entry);
+void efa_rdm_pke_release(struct efa_rdm_ep *ep,
+			   struct efa_rdm_pke *pkt_entry);
 
-void rxr_pkt_entry_append(struct rxr_pkt_entry *dst,
-			  struct rxr_pkt_entry *src);
+void efa_rdm_pke_append(struct efa_rdm_pke *dst,
+			  struct efa_rdm_pke *src);
 
-struct rxr_pkt_entry *rxr_pkt_entry_clone(struct efa_rdm_ep *ep,
+struct efa_rdm_pke *efa_rdm_pke_clone(struct efa_rdm_ep *ep,
 					  struct rxr_pkt_pool *pkt_pool,
-					  enum rxr_pkt_entry_alloc_type alloc_type,
-					  struct rxr_pkt_entry *src);
+					  enum efa_rdm_pke_alloc_type alloc_type,
+					  struct efa_rdm_pke *src);
 
-struct rxr_pkt_entry *rxr_pkt_get_unexp(struct efa_rdm_ep *ep,
-					struct rxr_pkt_entry **pkt_entry_ptr);
+struct efa_rdm_pke *rxr_pkt_get_unexp(struct efa_rdm_ep *ep,
+					struct efa_rdm_pke **pkt_entry_ptr);
 
-ssize_t rxr_pkt_entry_sendv(struct efa_rdm_ep *ep,
-			    struct rxr_pkt_entry **pkt_entry_vec,
+ssize_t efa_rdm_pke_sendv(struct efa_rdm_ep *ep,
+			    struct efa_rdm_pke **pkt_entry_vec,
 			    int pkt_entry_cnt);
 
-int rxr_pkt_entry_read(struct efa_rdm_ep *ep, struct rxr_pkt_entry *pkt_entry,
+int efa_rdm_pke_read(struct efa_rdm_ep *ep, struct efa_rdm_pke *pkt_entry,
 		       void *local_buf, size_t len, void *desc,
 		       uint64_t remote_buf, size_t remote_key);
 
-ssize_t rxr_pkt_entry_recv(struct efa_rdm_ep *ep,
-			   struct rxr_pkt_entry *pkt_entry, void **desc,
+ssize_t efa_rdm_pke_recv(struct efa_rdm_ep *ep,
+			   struct efa_rdm_pke *pkt_entry, void **desc,
 			   uint64_t flags);
 
-int rxr_pkt_entry_write(struct efa_rdm_ep *ep, struct rxr_pkt_entry *pkt_entry,
+int efa_rdm_pke_write(struct efa_rdm_ep *ep, struct efa_rdm_pke *pkt_entry,
 		       void *local_buf, size_t len, void *desc,
 		       uint64_t remote_buf, size_t remote_key);
 
@@ -308,17 +306,17 @@ struct rxr_pkt_rx_map {
 };
 
 struct efa_rdm_ope *rxr_pkt_rx_map_lookup(struct efa_rdm_ep *ep,
-					   struct rxr_pkt_entry *pkt_entry);
+					   struct efa_rdm_pke *pkt_entry);
 
 void rxr_pkt_rx_map_insert(struct efa_rdm_ep *ep,
-			   struct rxr_pkt_entry *pkt_entry,
+			   struct efa_rdm_pke *pkt_entry,
 			   struct efa_rdm_ope *rxe);
 
 void rxr_pkt_rx_map_remove(struct efa_rdm_ep *pkt_rx_map,
-			   struct rxr_pkt_entry *pkt_entry,
+			   struct efa_rdm_pke *pkt_entry,
 			   struct efa_rdm_ope *rxe);
 
-static inline bool rxr_pkt_entry_has_hmem_mr(struct rxr_pkt_sendv *send)
+static inline bool efa_rdm_pke_has_hmem_mr(struct rxr_pkt_sendv *send)
 {
 	/* the device only support send up 2 iov, so iov_count cannot be > 2 */
 	assert(send->iov_count == 1 || send->iov_count == 2);

--- a/prov/efa/src/rdm/efa_rdm_srx.c
+++ b/prov/efa/src/rdm/efa_rdm_srx.c
@@ -80,7 +80,7 @@ static int efa_rdm_srx_start(struct fi_peer_rx_entry *peer_rxe)
 {
 	int ret;
 	struct efa_rdm_ep *ep;
-	struct rxr_pkt_entry *pkt_entry;
+	struct efa_rdm_pke *pkt_entry;
 	struct efa_rdm_ope *rxe;
 
 	assert(ofi_genlock_held(efa_rdm_srx_get_srx_ctx(peer_rxe)->lock));
@@ -97,7 +97,7 @@ static int efa_rdm_srx_start(struct fi_peer_rx_entry *peer_rxe)
 	if (OFI_UNLIKELY(ret)) {
 		efa_rdm_rxe_handle_error(rxe, -ret,
 			rxe->op == ofi_op_msg ? FI_EFA_ERR_PKT_PROC_MSGRTM : FI_EFA_ERR_PKT_PROC_TAGRTM);
-		rxr_pkt_entry_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(ep, pkt_entry);
 		efa_rdm_rxe_release(rxe);
 	}
 
@@ -118,7 +118,7 @@ static int efa_rdm_srx_start(struct fi_peer_rx_entry *peer_rxe)
 static int efa_rdm_srx_discard(struct fi_peer_rx_entry *peer_rxe)
 {
 	struct efa_rdm_ep *ep;
-	struct rxr_pkt_entry *pkt_entry;
+	struct efa_rdm_pke *pkt_entry;
 	struct efa_rdm_ope *rxe;
 
 	assert(ofi_genlock_held(efa_rdm_srx_get_srx_ctx(peer_rxe)->lock));
@@ -130,7 +130,7 @@ static int efa_rdm_srx_discard(struct fi_peer_rx_entry *peer_rxe)
 	EFA_WARN(FI_LOG_EP_CTRL,
 		"Discarding unmatched unexpected rxe: %p pkt_entry %p\n",
 		rxe, rxe->unexp_pkt);
-	rxr_pkt_entry_release_rx(ep, rxe->unexp_pkt);
+	efa_rdm_pke_release_rx(ep, rxe->unexp_pkt);
 	efa_rdm_rxe_release_internal(rxe);
 	return FI_SUCCESS;
 }

--- a/prov/efa/src/rdm/rxr_pkt_cmd.h
+++ b/prov/efa/src/rdm/rxr_pkt_cmd.h
@@ -40,25 +40,25 @@ ssize_t rxr_pkt_post(struct efa_rdm_ep *ep, struct efa_rdm_ope *ope,
 ssize_t rxr_pkt_post_or_queue(struct efa_rdm_ep *ep, struct efa_rdm_ope *ope,
 			      int req_type);
 
-fi_addr_t rxr_pkt_determine_addr(struct efa_rdm_ep *ep, struct rxr_pkt_entry *pkt_entry);
+fi_addr_t rxr_pkt_determine_addr(struct efa_rdm_ep *ep, struct efa_rdm_pke *pkt_entry);
 
 void rxr_pkt_handle_data_copied(struct efa_rdm_ep *ep,
-				struct rxr_pkt_entry *pkt_entry,
+				struct efa_rdm_pke *pkt_entry,
 				size_t data_size);
 
 void rxr_pkt_handle_send_error(struct efa_rdm_ep *ep,
-			       struct rxr_pkt_entry *pkt_entry,
+			       struct efa_rdm_pke *pkt_entry,
 			       int err, int prov_errno);
 
 void rxr_pkt_handle_send_completion(struct efa_rdm_ep *ep,
-				    struct rxr_pkt_entry *pkt_entry);
+				    struct efa_rdm_pke *pkt_entry);
 
 void rxr_pkt_handle_recv_error(struct efa_rdm_ep *ep,
-			       struct rxr_pkt_entry *pkt_entry,
+			       struct efa_rdm_pke *pkt_entry,
 			       int err, int prov_errno);
 
 void rxr_pkt_handle_recv_completion(struct efa_rdm_ep *ep,
-				    struct rxr_pkt_entry *pkt_entry);
+				    struct efa_rdm_pke *pkt_entry);
 
 ssize_t rxr_pkt_trigger_handshake(struct efa_rdm_ep *ep,
 				  fi_addr_t addr, struct efa_rdm_peer *peer);
@@ -66,7 +66,7 @@ ssize_t rxr_pkt_trigger_handshake(struct efa_rdm_ep *ep,
 #if ENABLE_DEBUG
 void rxr_pkt_print(char *prefix,
 		   struct efa_rdm_ep *ep,
-		   struct rxr_pkt_entry *pkt_entry);
+		   struct efa_rdm_pke *pkt_entry);
 #endif
 
 #endif

--- a/prov/efa/src/rdm/rxr_pkt_pool.c
+++ b/prov/efa/src/rdm/rxr_pkt_pool.c
@@ -41,11 +41,11 @@ struct rxr_pkt_pool_inf {
 };
 
 struct rxr_pkt_pool_inf RXR_PKT_POOL_INF_LIST[] = {
-	[RXR_PKT_FROM_EFA_TX_POOL] = {true /* need memory registration */, true /* need sendv */, true /* need send_wr */},
-	[RXR_PKT_FROM_EFA_RX_POOL] = {true /* need memory registration */, false /* no sendv */, false /* no send_wr */},
-	[RXR_PKT_FROM_UNEXP_POOL] = {false /* no memory registration */, false /* no sendv */, false /* no send_wr */},
-	[RXR_PKT_FROM_OOO_POOL] = {false /* no memory registration */, false /* no sendv */, false /* no send_wr */},
-	[RXR_PKT_FROM_READ_COPY_POOL] = {true /* no memory registration */, false /* no sendv */, false /* no send_wr */},
+	[EFA_RDM_PKE_FROM_EFA_TX_POOL] = {true /* need memory registration */, true /* need sendv */, true /* need send_wr */},
+	[EFA_RDM_PKE_FROM_EFA_RX_POOL] = {true /* need memory registration */, false /* no sendv */, false /* no send_wr */},
+	[EFA_RDM_PKE_FROM_UNEXP_POOL] = {false /* no memory registration */, false /* no sendv */, false /* no send_wr */},
+	[EFA_RDM_PKE_FROM_OOO_POOL] = {false /* no memory registration */, false /* no sendv */, false /* no send_wr */},
+	[EFA_RDM_PKE_FROM_READ_COPY_POOL] = {true /* no memory registration */, false /* no sendv */, false /* no send_wr */},
 };
 
 static int rxr_pkt_pool_mr_reg_hndlr(struct ofi_bufpool_region *region)
@@ -104,7 +104,7 @@ size_t rxr_pkt_pool_mr_flags()
  * @return int 0 on success, a negative integer on failure
  */
 int rxr_pkt_pool_create(struct efa_rdm_ep *ep,
-			enum rxr_pkt_entry_alloc_type pkt_pool_type,
+			enum efa_rdm_pke_alloc_type pkt_pool_type,
 			size_t chunk_cnt, size_t max_cnt,
 			size_t alignment,
 			struct rxr_pkt_pool **pkt_pool)
@@ -117,7 +117,7 @@ int rxr_pkt_pool_create(struct efa_rdm_ep *ep,
 		return -FI_ENOMEM;
 
 	struct ofi_bufpool_attr wiredata_attr = {
-		.size = sizeof(struct rxr_pkt_entry) + ep->mtu_size,
+		.size = sizeof(struct efa_rdm_pke) + ep->mtu_size,
 		.alignment = alignment,
 		.max_cnt = max_cnt,
 		.chunk_cnt = chunk_cnt,

--- a/prov/efa/src/rdm/rxr_pkt_pool.h
+++ b/prov/efa/src/rdm/rxr_pkt_pool.h
@@ -35,7 +35,7 @@
 #define _RXR_PKT_POOL_H
 
 #include <stddef.h>
-#include "rxr_pkt_entry.h"
+#include "efa_rdm_pke.h"
 
 /* Forward declaration to avoid circular dependency */
 struct efa_rdm_ep;
@@ -47,7 +47,7 @@ struct rxr_pkt_pool {
 };
 
 int rxr_pkt_pool_create(struct efa_rdm_ep *ep,
-			enum rxr_pkt_entry_alloc_type pkt_pool_type,
+			enum efa_rdm_pke_alloc_type pkt_pool_type,
 			size_t chunk_cnt, size_t max_cnt,
 			size_t alignment,
 			struct rxr_pkt_pool **pkt_pool);

--- a/prov/efa/src/rdm/rxr_pkt_type.h
+++ b/prov/efa/src/rdm/rxr_pkt_type.h
@@ -90,7 +90,7 @@ struct rxr_handshake_opt_host_id_hdr *rxr_get_handshake_opt_host_id_hdr(void *pk
 }
 
 ssize_t rxr_pkt_init_handshake(struct efa_rdm_ep *ep,
-			       struct rxr_pkt_entry *pkt_entry,
+			       struct efa_rdm_pke *pkt_entry,
 			       fi_addr_t addr);
 
 ssize_t rxr_pkt_post_handshake(struct efa_rdm_ep *ep, struct efa_rdm_peer *peer);
@@ -99,7 +99,7 @@ void rxr_pkt_post_handshake_or_queue(struct efa_rdm_ep *ep,
 				     struct efa_rdm_peer *peer);
 
 void rxr_pkt_handle_handshake_recv(struct efa_rdm_ep *ep,
-				   struct rxr_pkt_entry *pkt_entry);
+				   struct efa_rdm_pke *pkt_entry);
 
 /* CTS packet related functions */
 static inline
@@ -112,14 +112,14 @@ void rxr_pkt_calc_cts_window_credits(struct efa_rdm_ep *ep, struct efa_rdm_peer 
 				     uint64_t size, int request,
 				     int *window, int *credits);
 
-ssize_t rxr_pkt_init_cts(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_cts(struct efa_rdm_pke *pkt_entry,
 			 struct efa_rdm_ope *ope);
 
 void rxr_pkt_handle_cts_sent(struct efa_rdm_ep *ep,
-			     struct rxr_pkt_entry *pkt_entry);
+			     struct efa_rdm_pke *pkt_entry);
 
 void rxr_pkt_handle_cts_recv(struct efa_rdm_ep *ep,
-			     struct rxr_pkt_entry *pkt_entry);
+			     struct efa_rdm_pke *pkt_entry);
 
 static inline
 struct rxr_data_hdr *rxr_get_data_hdr(void *pkt)
@@ -127,25 +127,25 @@ struct rxr_data_hdr *rxr_get_data_hdr(void *pkt)
 	return (struct rxr_data_hdr *)pkt;
 }
 
-int rxr_pkt_init_data(struct rxr_pkt_entry *pkt_entry,
+int rxr_pkt_init_data(struct efa_rdm_pke *pkt_entry,
 		      struct efa_rdm_ope *ope,
 		      size_t data_offset,
 		      int data_size);
 
 void rxr_pkt_handle_data_sent(struct efa_rdm_ep *ep,
-			      struct rxr_pkt_entry *pkt_entry);
+			      struct efa_rdm_pke *pkt_entry);
 
 void rxr_pkt_proc_data(struct efa_rdm_ep *ep,
 		       struct efa_rdm_ope *ope,
-		       struct rxr_pkt_entry *pkt_entry,
+		       struct efa_rdm_pke *pkt_entry,
 		       char *data, size_t seg_offset,
 		       size_t seg_size);
 
 void rxr_pkt_handle_data_send_completion(struct efa_rdm_ep *ep,
-					 struct rxr_pkt_entry *pkt_entry);
+					 struct efa_rdm_pke *pkt_entry);
 
 void rxr_pkt_handle_data_recv(struct efa_rdm_ep *ep,
-			      struct rxr_pkt_entry *pkt_entry);
+			      struct efa_rdm_pke *pkt_entry);
 
 /* READRSP packet related functions */
 static inline struct rxr_readrsp_hdr *rxr_get_readrsp_hdr(void *pkt)
@@ -153,17 +153,17 @@ static inline struct rxr_readrsp_hdr *rxr_get_readrsp_hdr(void *pkt)
 	return (struct rxr_readrsp_hdr *)pkt;
 }
 
-int rxr_pkt_init_readrsp(struct rxr_pkt_entry *pkt_entry,
+int rxr_pkt_init_readrsp(struct efa_rdm_pke *pkt_entry,
 			 struct efa_rdm_ope *txe);
 
 void rxr_pkt_handle_readrsp_sent(struct efa_rdm_ep *ep,
-				 struct rxr_pkt_entry *pkt_entry);
+				 struct efa_rdm_pke *pkt_entry);
 
 void rxr_pkt_handle_readrsp_send_completion(struct efa_rdm_ep *ep,
-					    struct rxr_pkt_entry *pkt_entry);
+					    struct efa_rdm_pke *pkt_entry);
 
 void rxr_pkt_handle_readrsp_recv(struct efa_rdm_ep *ep,
-				 struct rxr_pkt_entry *pkt_entry);
+				 struct efa_rdm_pke *pkt_entry);
 
 /*
  *  RMA context packet, used to differentiate the normal RMA read, normal RMA
@@ -187,17 +187,17 @@ enum efa_rdm_rma_context_pkt_type {
 };
 
 void rxr_pkt_init_write_context(struct efa_rdm_ope *txe,
-				struct rxr_pkt_entry *pkt_entry);
+				struct efa_rdm_pke *pkt_entry);
 
 void rxr_pkt_init_read_context(struct efa_rdm_ep *efa_rdm_ep,
 			       void *x_entry,
 			       fi_addr_t addr,
 			       int read_id,
 			       size_t seg_size,
-			       struct rxr_pkt_entry *pkt_entry);
+			       struct efa_rdm_pke *pkt_entry);
 
 void rxr_pkt_handle_rma_completion(struct efa_rdm_ep *ep,
-				   struct rxr_pkt_entry *pkt_entry);
+				   struct efa_rdm_pke *pkt_entry);
 
 /* EOR packet related functions */
 static inline
@@ -206,19 +206,19 @@ struct rxr_eor_hdr *rxr_get_eor_hdr(void *pkt)
 	return (struct rxr_eor_hdr *)pkt;
 }
 
-int rxr_pkt_init_eor(struct rxr_pkt_entry *pkt_entry,
+int rxr_pkt_init_eor(struct efa_rdm_pke *pkt_entry,
 		     struct efa_rdm_ope *rxe);
 
 static inline
-void rxr_pkt_handle_eor_sent(struct efa_rdm_ep *ep, struct rxr_pkt_entry *pkt_entry)
+void rxr_pkt_handle_eor_sent(struct efa_rdm_ep *ep, struct efa_rdm_pke *pkt_entry)
 {
 }
 
 void rxr_pkt_handle_eor_send_completion(struct efa_rdm_ep *ep,
-					struct rxr_pkt_entry *pkt_entry);
+					struct efa_rdm_pke *pkt_entry);
 
 void rxr_pkt_handle_eor_recv(struct efa_rdm_ep *ep,
-			     struct rxr_pkt_entry *pkt_entry);
+			     struct efa_rdm_pke *pkt_entry);
 
 /* ATOMRSP packet related functions */
 static inline struct rxr_atomrsp_hdr *rxr_get_atomrsp_hdr(void *pkt)
@@ -226,13 +226,13 @@ static inline struct rxr_atomrsp_hdr *rxr_get_atomrsp_hdr(void *pkt)
 	return (struct rxr_atomrsp_hdr *)pkt;
 }
 
-int rxr_pkt_init_atomrsp(struct rxr_pkt_entry *pkt_entry, struct efa_rdm_ope *rxe);
+int rxr_pkt_init_atomrsp(struct efa_rdm_pke *pkt_entry, struct efa_rdm_ope *rxe);
 
-void rxr_pkt_handle_atomrsp_sent(struct efa_rdm_ep *ep, struct rxr_pkt_entry *pkt_entry);
+void rxr_pkt_handle_atomrsp_sent(struct efa_rdm_ep *ep, struct efa_rdm_pke *pkt_entry);
 
-void rxr_pkt_handle_atomrsp_send_completion(struct efa_rdm_ep *ep, struct rxr_pkt_entry *pkt_entry);
+void rxr_pkt_handle_atomrsp_send_completion(struct efa_rdm_ep *ep, struct efa_rdm_pke *pkt_entry);
 
-void rxr_pkt_handle_atomrsp_recv(struct efa_rdm_ep *ep, struct rxr_pkt_entry *pkt_entry);
+void rxr_pkt_handle_atomrsp_recv(struct efa_rdm_ep *ep, struct efa_rdm_pke *pkt_entry);
 
 /* RECEIPT packet related functions */
 static inline
@@ -241,16 +241,16 @@ struct rxr_receipt_hdr *rxr_get_receipt_hdr(void *pkt)
 	return (struct rxr_receipt_hdr *)pkt;
 }
 
-int rxr_pkt_init_receipt(struct rxr_pkt_entry *pkt_entry, struct efa_rdm_ope *rxe);
+int rxr_pkt_init_receipt(struct efa_rdm_pke *pkt_entry, struct efa_rdm_ope *rxe);
 
 void rxr_pkt_handle_receipt_sent(struct efa_rdm_ep *ep,
-				 struct rxr_pkt_entry *pkt_entry);
+				 struct efa_rdm_pke *pkt_entry);
 
 void rxr_pkt_handle_receipt_send_completion(struct efa_rdm_ep *ep,
-					    struct rxr_pkt_entry *pkt_entry);
+					    struct efa_rdm_pke *pkt_entry);
 
 void rxr_pkt_handle_receipt_recv(struct efa_rdm_ep *ep,
-				 struct rxr_pkt_entry *pkt_entry);
+				 struct efa_rdm_pke *pkt_entry);
 
 /* General packet type helper functions */
 static inline

--- a/prov/efa/src/rdm/rxr_pkt_type_base.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_base.c
@@ -41,7 +41,7 @@
  * @return	If the input has the optional connid header, return the pointer to connid header
  * 		Otherwise, return NULL
  */
-uint32_t *rxr_pkt_connid_ptr(struct rxr_pkt_entry *pkt_entry)
+uint32_t *rxr_pkt_connid_ptr(struct efa_rdm_pke *pkt_entry)
 {
 	struct rxr_base_hdr *base_hdr;
 
@@ -98,7 +98,7 @@ uint32_t *rxr_pkt_connid_ptr(struct rxr_pkt_entry *pkt_entry)
  * @return		0 on success, negative FI code on error
  */
 int rxr_pkt_init_data_from_ope(struct efa_rdm_ep *ep,
-				    struct rxr_pkt_entry *pkt_entry,
+				    struct efa_rdm_pke *pkt_entry,
 				    size_t pkt_data_offset,
 				    struct efa_rdm_ope *ope,
 				    size_t tx_data_offset,
@@ -206,7 +206,7 @@ int rxr_pkt_init_data_from_ope(struct efa_rdm_ep *ep,
  * 		if the packet entry does not contain data,
  * 		return 0.
  */
-size_t rxr_pkt_data_size(struct rxr_pkt_entry *pkt_entry)
+size_t rxr_pkt_data_size(struct efa_rdm_pke *pkt_entry)
 {
 	int pkt_type;
 
@@ -217,7 +217,7 @@ size_t rxr_pkt_data_size(struct rxr_pkt_entry *pkt_entry)
 	 * application data in pkt_entry->wiredata, so its
 	 * data_size is just pkt_entry->pkt_size.
 	 */
-	if (pkt_entry->alloc_type == RXR_PKT_FROM_READ_COPY_POOL)
+	if (pkt_entry->alloc_type == EFA_RDM_PKE_FROM_READ_COPY_POOL)
 		return pkt_entry->pkt_size;
 
 	pkt_type = rxr_get_base_hdr(pkt_entry->wiredata)->type;
@@ -276,7 +276,7 @@ int efa_rdm_ep_flush_queued_blocking_copy_to_hmem(struct efa_rdm_ep *ep)
 	size_t bytes_copied[RXR_EP_MAX_QUEUED_COPY] = {0};
 	struct efa_mr *desc;
 	struct efa_rdm_ope *rxe;
-	struct rxr_pkt_entry *pkt_entry;
+	struct efa_rdm_pke *pkt_entry;
 	char *data;
 	size_t data_size, data_offset;
 
@@ -345,7 +345,7 @@ int efa_rdm_ep_flush_queued_blocking_copy_to_hmem(struct efa_rdm_ep *ep)
  */
 static inline
 int rxr_pkt_queued_copy_data_to_hmem(struct efa_rdm_ep *ep,
-				     struct rxr_pkt_entry *pkt_entry,
+				     struct efa_rdm_pke *pkt_entry,
 				     char *data,
 				     size_t data_size,
 				     size_t data_offset)
@@ -407,7 +407,7 @@ int rxr_pkt_queued_copy_data_to_hmem(struct efa_rdm_ep *ep,
  */
 static inline
 int rxr_pkt_copy_data_to_cuda(struct efa_rdm_ep *ep,
-			      struct rxr_pkt_entry *pkt_entry,
+			      struct efa_rdm_pke *pkt_entry,
 			      char *data,
 			      size_t data_size,
 			      size_t data_offset)
@@ -544,7 +544,7 @@ int rxr_pkt_copy_data_to_cuda(struct efa_rdm_ep *ep,
 ssize_t rxr_pkt_copy_data_to_ope(struct efa_rdm_ep *ep,
 				      struct efa_rdm_ope *ope,
 				      size_t data_offset,
-				      struct rxr_pkt_entry *pkt_entry,
+				      struct efa_rdm_pke *pkt_entry,
 				      char *data, size_t data_size)
 {
 	struct efa_mr *desc;

--- a/prov/efa/src/rdm/rxr_pkt_type_base.h
+++ b/prov/efa/src/rdm/rxr_pkt_type_base.h
@@ -36,10 +36,10 @@
 
 
 
-uint32_t *rxr_pkt_connid_ptr(struct rxr_pkt_entry *pkt_entry);
+uint32_t *rxr_pkt_connid_ptr(struct efa_rdm_pke *pkt_entry);
 
 int rxr_pkt_init_data_from_ope(struct efa_rdm_ep *ep,
-				    struct rxr_pkt_entry *pkt_entry,
+				    struct efa_rdm_pke *pkt_entry,
 				    size_t pkt_data_offset,
 				    struct efa_rdm_ope *ope,
 				    size_t op_data_offset,
@@ -48,9 +48,9 @@ int rxr_pkt_init_data_from_ope(struct efa_rdm_ep *ep,
 ssize_t rxr_pkt_copy_data_to_ope(struct efa_rdm_ep *ep,
 				      struct efa_rdm_ope *rxe,
 				      size_t data_offset,
-				      struct rxr_pkt_entry *pkt_entry,
+				      struct efa_rdm_pke *pkt_entry,
 				      char *data, size_t data_size);
 
-size_t rxr_pkt_data_size(struct rxr_pkt_entry *pkt_entry);
+size_t rxr_pkt_data_size(struct efa_rdm_pke *pkt_entry);
 
 #endif

--- a/prov/efa/src/rdm/rxr_pkt_type_misc.h
+++ b/prov/efa/src/rdm/rxr_pkt_type_misc.h
@@ -44,7 +44,7 @@
  *	host id value; otherwise, return NULL
  */
 static inline
-uint64_t *rxr_pkt_handshake_host_id_ptr(struct rxr_pkt_entry *pkt_entry)
+uint64_t *rxr_pkt_handshake_host_id_ptr(struct efa_rdm_pke *pkt_entry)
 {
 	struct rxr_base_hdr *base_hdr = rxr_get_base_hdr(pkt_entry->wiredata);
 

--- a/prov/efa/src/rdm/rxr_pkt_type_req.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_req.c
@@ -102,7 +102,7 @@ bool rxr_pkt_req_supported_by_peer(int req_type, struct efa_rdm_peer *peer)
 	return peer->extra_info[extra_info_id] & REQ_INF_LIST[req_type].ex_feature_flag;
 }
 
-size_t rxr_pkt_req_data_offset(struct rxr_pkt_entry *pkt_entry)
+size_t rxr_pkt_req_data_offset(struct efa_rdm_pke *pkt_entry)
 {
 	int pkt_type, read_iov_count;
 	size_t pkt_data_offset;
@@ -120,7 +120,7 @@ size_t rxr_pkt_req_data_offset(struct rxr_pkt_entry *pkt_entry)
 	return pkt_data_offset;
 }
 
-size_t rxr_pkt_req_data_size(struct rxr_pkt_entry *pkt_entry)
+size_t rxr_pkt_req_data_size(struct efa_rdm_pke *pkt_entry)
 {
 	return pkt_entry->pkt_size - rxr_pkt_req_data_offset(pkt_entry);
 }
@@ -148,7 +148,7 @@ int rxr_pkt_type_readbase_rtm(struct efa_rdm_peer *peer, int op, uint64_t fi_fla
 	}
 }
 
-void rxr_pkt_init_req_hdr(struct rxr_pkt_entry *pkt_entry,
+void rxr_pkt_init_req_hdr(struct efa_rdm_pke *pkt_entry,
 			  int pkt_type,
 			  struct efa_rdm_ope *txe)
 {
@@ -231,7 +231,7 @@ void rxr_pkt_init_req_hdr(struct rxr_pkt_entry *pkt_entry,
  * @return The rma_iov_count in the pkt header, if it is part of the header.
  * Otherwise return 0.
  */
-uint32_t rxr_pkt_hdr_rma_iov_count(struct rxr_pkt_entry *pkt_entry)
+uint32_t rxr_pkt_hdr_rma_iov_count(struct efa_rdm_pke *pkt_entry)
 {
 	int pkt_type = rxr_get_base_hdr(pkt_entry->wiredata)->type;
 
@@ -255,7 +255,7 @@ uint32_t rxr_pkt_hdr_rma_iov_count(struct rxr_pkt_entry *pkt_entry)
 	return 0;
 }
 
-size_t rxr_pkt_req_base_hdr_size(struct rxr_pkt_entry *pkt_entry)
+size_t rxr_pkt_req_base_hdr_size(struct efa_rdm_pke *pkt_entry)
 {
 	struct rxr_base_hdr *base_hdr;
 	uint32_t rma_iov_count;
@@ -275,7 +275,7 @@ size_t rxr_pkt_req_base_hdr_size(struct rxr_pkt_entry *pkt_entry)
  * @return	If the input has the optional raw addres header, return the pointer to it.
  *		Otherwise, return NULL
  */
-void *rxr_pkt_req_raw_addr(struct rxr_pkt_entry *pkt_entry)
+void *rxr_pkt_req_raw_addr(struct efa_rdm_pke *pkt_entry)
 {
 	char *opt_hdr;
 	struct rxr_base_hdr *base_hdr;
@@ -302,7 +302,7 @@ void *rxr_pkt_req_raw_addr(struct rxr_pkt_entry *pkt_entry)
  * @return	If the input has the optional connid header, return the pointer to connid
  * 		Otherwise, return NULL
  */
-uint32_t *rxr_pkt_req_connid_ptr(struct rxr_pkt_entry *pkt_entry)
+uint32_t *rxr_pkt_req_connid_ptr(struct efa_rdm_pke *pkt_entry)
 {
 	char *opt_hdr;
 	struct rxr_base_hdr *base_hdr;
@@ -346,7 +346,7 @@ uint32_t *rxr_pkt_req_connid_ptr(struct rxr_pkt_entry *pkt_entry)
  * @param[in]	pkt_entry		packet entry
  * @return 	header size of the REQ packet entry
  */
-size_t rxr_pkt_req_hdr_size_from_pkt_entry(struct rxr_pkt_entry *pkt_entry)
+size_t rxr_pkt_req_hdr_size_from_pkt_entry(struct efa_rdm_pke *pkt_entry)
 {
 	char *opt_hdr;
 	struct rxr_base_hdr *base_hdr;
@@ -376,7 +376,7 @@ size_t rxr_pkt_req_hdr_size_from_pkt_entry(struct rxr_pkt_entry *pkt_entry)
 	return opt_hdr - pkt_entry->wiredata;
 }
 
-int64_t rxr_pkt_req_cq_data(struct rxr_pkt_entry *pkt_entry)
+int64_t rxr_pkt_req_cq_data(struct efa_rdm_pke *pkt_entry)
 {
 	char *opt_hdr;
 	struct rxr_base_hdr *base_hdr;
@@ -472,7 +472,7 @@ size_t rxr_pkt_max_hdr_size(void)
  *     init() functions
  */
 static inline
-ssize_t rxr_pkt_init_rtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_rtm(struct efa_rdm_pke *pkt_entry,
 			 int pkt_type,
 			 struct efa_rdm_ope *txe,
 			 size_t data_offset,
@@ -506,7 +506,7 @@ ssize_t rxr_pkt_init_rtm(struct rxr_pkt_entry *pkt_entry,
 	return ret;
 }
 
-ssize_t rxr_pkt_init_eager_msgrtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_eager_msgrtm(struct efa_rdm_pke *pkt_entry,
 				  struct efa_rdm_ope *txe)
 {
 	int ret;
@@ -519,7 +519,7 @@ ssize_t rxr_pkt_init_eager_msgrtm(struct rxr_pkt_entry *pkt_entry,
 	return 0;
 }
 
-ssize_t rxr_pkt_init_dc_eager_msgrtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_dc_eager_msgrtm(struct efa_rdm_pke *pkt_entry,
 				     struct efa_rdm_ope *txe)
 
 {
@@ -535,7 +535,7 @@ ssize_t rxr_pkt_init_dc_eager_msgrtm(struct rxr_pkt_entry *pkt_entry,
 	return 0;
 }
 
-ssize_t rxr_pkt_init_eager_tagrtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_eager_tagrtm(struct efa_rdm_pke *pkt_entry,
 				  struct efa_rdm_ope *txe)
 {
 	struct rxr_base_hdr *base_hdr;
@@ -551,7 +551,7 @@ ssize_t rxr_pkt_init_eager_tagrtm(struct rxr_pkt_entry *pkt_entry,
 	return 0;
 }
 
-ssize_t rxr_pkt_init_dc_eager_tagrtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_dc_eager_tagrtm(struct efa_rdm_pke *pkt_entry,
 				     struct efa_rdm_ope *txe)
 {
 	struct rxr_base_hdr *base_hdr;
@@ -571,7 +571,7 @@ ssize_t rxr_pkt_init_dc_eager_tagrtm(struct rxr_pkt_entry *pkt_entry,
 	return 0;
 }
 
-ssize_t rxr_pkt_init_medium_msgrtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_medium_msgrtm(struct efa_rdm_pke *pkt_entry,
 				   struct efa_rdm_ope *txe,
 				   size_t data_offset,
 				   int data_size)
@@ -593,7 +593,7 @@ ssize_t rxr_pkt_init_medium_msgrtm(struct rxr_pkt_entry *pkt_entry,
 	return 0;
 }
 
-ssize_t rxr_pkt_init_dc_medium_msgrtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_dc_medium_msgrtm(struct efa_rdm_pke *pkt_entry,
 				      struct efa_rdm_ope *txe,
 				      size_t data_offset,
 				      int data_size)
@@ -617,7 +617,7 @@ ssize_t rxr_pkt_init_dc_medium_msgrtm(struct rxr_pkt_entry *pkt_entry,
 	return 0;
 }
 
-ssize_t rxr_pkt_init_medium_tagrtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_medium_tagrtm(struct efa_rdm_pke *pkt_entry,
 				   struct efa_rdm_ope *txe,
 				   size_t data_offset,
 				   int data_size)
@@ -640,7 +640,7 @@ ssize_t rxr_pkt_init_medium_tagrtm(struct rxr_pkt_entry *pkt_entry,
 	return 0;
 }
 
-ssize_t rxr_pkt_init_dc_medium_tagrtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_dc_medium_tagrtm(struct efa_rdm_pke *pkt_entry,
 				      struct efa_rdm_ope *txe,
 				      size_t data_offset,
 				      int data_size)
@@ -666,7 +666,7 @@ ssize_t rxr_pkt_init_dc_medium_tagrtm(struct rxr_pkt_entry *pkt_entry,
 	return 0;
 }
 
-int rxr_pkt_init_longcts_rtm(struct rxr_pkt_entry *pkt_entry,
+int rxr_pkt_init_longcts_rtm(struct efa_rdm_pke *pkt_entry,
 			     int pkt_type,
 			     struct efa_rdm_ope *txe)
 {
@@ -684,20 +684,20 @@ int rxr_pkt_init_longcts_rtm(struct rxr_pkt_entry *pkt_entry,
 	return 0;
 }
 
-ssize_t rxr_pkt_init_longcts_msgrtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_longcts_msgrtm(struct efa_rdm_pke *pkt_entry,
 				    struct efa_rdm_ope *txe)
 {
 	return rxr_pkt_init_longcts_rtm(pkt_entry, RXR_LONGCTS_MSGRTM_PKT, txe);
 }
 
-ssize_t rxr_pkt_init_dc_longcts_msgrtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_dc_longcts_msgrtm(struct efa_rdm_pke *pkt_entry,
 				       struct efa_rdm_ope *txe)
 {
 	txe->rxr_flags |= EFA_RDM_TXE_DELIVERY_COMPLETE_REQUESTED;
 	return rxr_pkt_init_longcts_rtm(pkt_entry, RXR_DC_LONGCTS_MSGRTM_PKT, txe);
 }
 
-ssize_t rxr_pkt_init_longcts_tagrtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_longcts_tagrtm(struct efa_rdm_pke *pkt_entry,
 				    struct efa_rdm_ope *txe)
 {
 	struct rxr_base_hdr *base_hdr;
@@ -713,7 +713,7 @@ ssize_t rxr_pkt_init_longcts_tagrtm(struct rxr_pkt_entry *pkt_entry,
 	return 0;
 }
 
-ssize_t rxr_pkt_init_dc_longcts_tagrtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_dc_longcts_tagrtm(struct efa_rdm_pke *pkt_entry,
 				       struct efa_rdm_ope *txe)
 {
 	struct rxr_base_hdr *base_hdr;
@@ -729,7 +729,7 @@ ssize_t rxr_pkt_init_dc_longcts_tagrtm(struct rxr_pkt_entry *pkt_entry,
 	return 0;
 }
 
-ssize_t rxr_pkt_init_longread_rtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_longread_rtm(struct efa_rdm_pke *pkt_entry,
 				  int pkt_type,
 				  struct efa_rdm_ope *txe)
 {
@@ -758,13 +758,13 @@ ssize_t rxr_pkt_init_longread_rtm(struct rxr_pkt_entry *pkt_entry,
 	return 0;
 }
 
-ssize_t rxr_pkt_init_longread_msgrtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_longread_msgrtm(struct efa_rdm_pke *pkt_entry,
 				     struct efa_rdm_ope *txe)
 {
 	return rxr_pkt_init_longread_rtm(pkt_entry, RXR_LONGREAD_MSGRTM_PKT, txe);
 }
 
-ssize_t rxr_pkt_init_longread_tagrtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_longread_tagrtm(struct efa_rdm_pke *pkt_entry,
 				     struct efa_rdm_ope *txe)
 {
 	ssize_t err;
@@ -791,7 +791,7 @@ ssize_t rxr_pkt_init_longread_tagrtm(struct rxr_pkt_entry *pkt_entry,
  * @param[in]		txe	contains information of the send operation
  */
 static
-ssize_t rxr_pkt_init_runtread_rtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_runtread_rtm(struct efa_rdm_pke *pkt_entry,
 				  int pkt_type,
 				  struct efa_rdm_ope *txe,
 				  int64_t tx_data_offset,
@@ -825,7 +825,7 @@ ssize_t rxr_pkt_init_runtread_rtm(struct rxr_pkt_entry *pkt_entry,
 	return rxr_pkt_init_data_from_ope(txe->ep, pkt_entry, pkt_data_offset, txe, tx_data_offset, data_size);
 }
 
-ssize_t rxr_pkt_init_runtread_msgrtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_runtread_msgrtm(struct efa_rdm_pke *pkt_entry,
 				     struct efa_rdm_ope *txe,
 				     size_t data_offset,
 				     int data_size)
@@ -833,7 +833,7 @@ ssize_t rxr_pkt_init_runtread_msgrtm(struct rxr_pkt_entry *pkt_entry,
 	return rxr_pkt_init_runtread_rtm(pkt_entry, RXR_RUNTREAD_MSGRTM_PKT, txe, data_offset, data_size);
 }
 
-ssize_t rxr_pkt_init_runtread_tagrtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_runtread_tagrtm(struct efa_rdm_pke *pkt_entry,
 				     struct efa_rdm_ope *txe,
 				     size_t data_offset,
 				     int data_size)
@@ -859,7 +859,7 @@ ssize_t rxr_pkt_init_runtread_tagrtm(struct rxr_pkt_entry *pkt_entry,
  *         rxr_pkt_handle_eager_rtm_sent() is empty and is defined in rxr_pkt_type_req.h
  */
 void rxr_pkt_handle_medium_rtm_sent(struct efa_rdm_ep *ep,
-				    struct rxr_pkt_entry *pkt_entry)
+				    struct efa_rdm_pke *pkt_entry)
 {
 	struct efa_rdm_ope *txe;
 
@@ -868,7 +868,7 @@ void rxr_pkt_handle_medium_rtm_sent(struct efa_rdm_ep *ep,
 }
 
 void rxr_pkt_handle_longcts_rtm_sent(struct efa_rdm_ep *ep,
-				  struct rxr_pkt_entry *pkt_entry)
+				  struct efa_rdm_pke *pkt_entry)
 {
 	struct efa_rdm_ope *txe;
 
@@ -882,7 +882,7 @@ void rxr_pkt_handle_longcts_rtm_sent(struct efa_rdm_ep *ep,
 
 
 void rxr_pkt_handle_longread_rtm_sent(struct efa_rdm_ep *ep,
-				      struct rxr_pkt_entry *pkt_entry)
+				      struct efa_rdm_pke *pkt_entry)
 {
 	struct efa_rdm_peer *peer;
 
@@ -892,7 +892,7 @@ void rxr_pkt_handle_longread_rtm_sent(struct efa_rdm_ep *ep,
 }
 
 void rxr_pkt_handle_runtread_rtm_sent(struct efa_rdm_ep *ep,
-				      struct rxr_pkt_entry *pkt_entry)
+				      struct efa_rdm_pke *pkt_entry)
 {
 	struct efa_rdm_peer *peer;
 	struct efa_rdm_ope *txe;
@@ -914,7 +914,7 @@ void rxr_pkt_handle_runtread_rtm_sent(struct efa_rdm_ep *ep,
  *     handle_send_completion() functions
  */
 void rxr_pkt_handle_eager_rtm_send_completion(struct efa_rdm_ep *ep,
-					      struct rxr_pkt_entry *pkt_entry)
+					      struct efa_rdm_pke *pkt_entry)
 {
 	struct efa_rdm_ope *txe;
 
@@ -924,7 +924,7 @@ void rxr_pkt_handle_eager_rtm_send_completion(struct efa_rdm_ep *ep,
 }
 
 void rxr_pkt_handle_medium_rtm_send_completion(struct efa_rdm_ep *ep,
-					       struct rxr_pkt_entry *pkt_entry)
+					       struct efa_rdm_pke *pkt_entry)
 {
 	struct efa_rdm_ope *txe;
 
@@ -935,7 +935,7 @@ void rxr_pkt_handle_medium_rtm_send_completion(struct efa_rdm_ep *ep,
 }
 
 void rxr_pkt_handle_longcts_rtm_send_completion(struct efa_rdm_ep *ep,
-					     struct rxr_pkt_entry *pkt_entry)
+					     struct efa_rdm_pke *pkt_entry)
 {
 	struct efa_rdm_ope *txe;
 
@@ -946,7 +946,7 @@ void rxr_pkt_handle_longcts_rtm_send_completion(struct efa_rdm_ep *ep,
 }
 
 void rxr_pkt_handle_runtread_rtm_send_completion(struct efa_rdm_ep *ep,
-						 struct rxr_pkt_entry *pkt_entry)
+						 struct efa_rdm_pke *pkt_entry)
 {
 	struct efa_rdm_ope *txe;
 	struct efa_rdm_peer *peer;
@@ -967,7 +967,7 @@ void rxr_pkt_handle_runtread_rtm_send_completion(struct efa_rdm_ep *ep,
 /*
  *     proc() functions
  */
-size_t rxr_pkt_rtm_total_len(struct rxr_pkt_entry *pkt_entry)
+size_t rxr_pkt_rtm_total_len(struct efa_rdm_pke *pkt_entry)
 {
 	struct rxr_base_hdr *base_hdr;
 
@@ -1019,7 +1019,7 @@ size_t rxr_pkt_rtm_total_len(struct rxr_pkt_entry *pkt_entry)
  * @param pkt_entry(input)  RTM packet entry
  * @param rxe(input)   rxe to be updated
  */
-void rxr_pkt_rtm_update_rxe(struct rxr_pkt_entry *pkt_entry,
+void rxr_pkt_rtm_update_rxe(struct efa_rdm_pke *pkt_entry,
 				 struct efa_rdm_ope *rxe)
 {
 	struct rxr_base_hdr *base_hdr;
@@ -1038,7 +1038,7 @@ void rxr_pkt_rtm_update_rxe(struct rxr_pkt_entry *pkt_entry,
 }
 
 struct efa_rdm_ope *rxr_pkt_get_rtm_matched_rxe(struct efa_rdm_ep *ep,
-						struct rxr_pkt_entry *pkt_entry,
+						struct efa_rdm_pke *pkt_entry,
 						struct fi_peer_rx_entry *peer_rxe,
 						uint32_t op)
 {
@@ -1057,7 +1057,7 @@ struct efa_rdm_ope *rxr_pkt_get_rtm_matched_rxe(struct efa_rdm_ep *ep,
 }
 
 struct efa_rdm_ope *rxr_pkt_get_msgrtm_rxe(struct efa_rdm_ep *ep,
-						 struct rxr_pkt_entry **pkt_entry_ptr)
+						 struct efa_rdm_pke **pkt_entry_ptr)
 {
 	struct fid_peer_srx *peer_srx;
 	struct fi_peer_rx_entry *peer_rxe;
@@ -1066,7 +1066,7 @@ struct efa_rdm_ope *rxr_pkt_get_msgrtm_rxe(struct efa_rdm_ep *ep,
 	int ret;
 	int pkt_type;
 
-	if ((*pkt_entry_ptr)->alloc_type == RXR_PKT_FROM_USER_BUFFER) {
+	if ((*pkt_entry_ptr)->alloc_type == EFA_RDM_PKE_FROM_USER_BUFFER) {
 		/* If a pkt_entry is constructred from user supplied buffer,
 		 * the endpoint must be in zero copy receive mode.
 		 */
@@ -1123,7 +1123,7 @@ struct efa_rdm_ope *rxr_pkt_get_msgrtm_rxe(struct efa_rdm_ep *ep,
 }
 
 struct efa_rdm_ope *rxr_pkt_get_tagrtm_rxe(struct efa_rdm_ep *ep,
-						 struct rxr_pkt_entry **pkt_entry_ptr)
+						 struct efa_rdm_pke **pkt_entry_ptr)
 {
 	struct fid_peer_srx *peer_srx;
 	struct fi_peer_rx_entry *peer_rxe;
@@ -1179,7 +1179,7 @@ struct efa_rdm_ope *rxr_pkt_get_tagrtm_rxe(struct efa_rdm_ep *ep,
 
 ssize_t rxr_pkt_proc_matched_longread_rtm(struct efa_rdm_ep *ep,
 				      struct efa_rdm_ope *rxe,
-				      struct rxr_pkt_entry *pkt_entry)
+				      struct efa_rdm_pke *pkt_entry)
 {
 	struct rxr_longread_rtm_base_hdr *rtm_hdr;
 	struct fi_rma_iov *read_iov;
@@ -1193,7 +1193,7 @@ ssize_t rxr_pkt_proc_matched_longread_rtm(struct efa_rdm_ep *ep,
 	memcpy(rxe->rma_iov, read_iov,
 	       rxe->rma_iov_count * sizeof(struct fi_rma_iov));
 
-	rxr_pkt_entry_release_rx(ep, pkt_entry);
+	efa_rdm_pke_release_rx(ep, pkt_entry);
 	rxr_tracepoint(longread_read_posted, rxe->msg_id,
 		    (size_t) rxe->cq_entry.op_context, rxe->total_len);
 
@@ -1202,9 +1202,9 @@ ssize_t rxr_pkt_proc_matched_longread_rtm(struct efa_rdm_ep *ep,
 
 ssize_t rxr_pkt_proc_matched_mulreq_rtm(struct efa_rdm_ep *ep,
 					struct efa_rdm_ope *rxe,
-					struct rxr_pkt_entry *pkt_entry)
+					struct efa_rdm_pke *pkt_entry)
 {
-	struct rxr_pkt_entry *cur, *nxt;
+	struct efa_rdm_pke *cur, *nxt;
 	char *pkt_data;
 	int pkt_type;
 	ssize_t ret, err;
@@ -1258,7 +1258,7 @@ ssize_t rxr_pkt_proc_matched_mulreq_rtm(struct efa_rdm_ep *ep,
 
 		err = rxr_pkt_copy_data_to_ope(ep, rxe, rx_data_offset, cur, pkt_data, data_size);
 		if (err) {
-			rxr_pkt_entry_release_rx(ep, cur);
+			efa_rdm_pke_release_rx(ep, cur);
 			ret = err;
 		}
 
@@ -1282,7 +1282,7 @@ ssize_t rxr_pkt_proc_matched_mulreq_rtm(struct efa_rdm_ep *ep,
  */
 ssize_t rxr_pkt_proc_matched_eager_rtm(struct efa_rdm_ep *ep,
 				       struct efa_rdm_ope *rxe,
-				       struct rxr_pkt_entry *pkt_entry)
+				       struct efa_rdm_pke *pkt_entry)
 {
 	int err;
 	char *data;
@@ -1290,7 +1290,7 @@ ssize_t rxr_pkt_proc_matched_eager_rtm(struct efa_rdm_ep *ep,
 
 	hdr_size = rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
 
-	if (pkt_entry->alloc_type != RXR_PKT_FROM_USER_BUFFER) {
+	if (pkt_entry->alloc_type != EFA_RDM_PKE_FROM_USER_BUFFER) {
 		data = pkt_entry->wiredata + hdr_size;
 		data_size = pkt_entry->pkt_size - hdr_size;
 
@@ -1300,7 +1300,7 @@ ssize_t rxr_pkt_proc_matched_eager_rtm(struct efa_rdm_ep *ep,
 		 */
 		err = rxr_pkt_copy_data_to_ope(ep, rxe, 0, pkt_entry, data, data_size);
 		if (err)
-			rxr_pkt_entry_release_rx(ep, pkt_entry);
+			efa_rdm_pke_release_rx(ep, pkt_entry);
 
 		return err;
 	}
@@ -1310,19 +1310,19 @@ ssize_t rxr_pkt_proc_matched_eager_rtm(struct efa_rdm_ep *ep,
 	 * is correct. Otherwise, user will get wrong data.
 	 *
 	 * The expected header size is
-	 * 	ep->msg_prefix_size - sizeof(struct rxr_pkt_entry)
-	 * because we used the first sizeof(struct rxr_pkt_entry) to construct
+	 * 	ep->msg_prefix_size - sizeof(struct efa_rdm_pke)
+	 * because we used the first sizeof(struct efa_rdm_pke) to construct
 	 * a pkt_entry.
 	 */
-	if (hdr_size != ep->msg_prefix_size - sizeof(struct rxr_pkt_entry)) {
+	if (hdr_size != ep->msg_prefix_size - sizeof(struct efa_rdm_pke)) {
 		/* if header size is wrong, the data in user buffer is not useful.
 		 * setting rxe->cq_entry.len here will cause an error cq entry
 		 * to be written to application.
 		 */
 		rxe->cq_entry.len = 0;
 	} else {
-		assert(rxe->cq_entry.buf == pkt_entry->wiredata - sizeof(struct rxr_pkt_entry));
-		rxe->cq_entry.len = pkt_entry->pkt_size + sizeof(struct rxr_pkt_entry);
+		assert(rxe->cq_entry.buf == pkt_entry->wiredata - sizeof(struct efa_rdm_pke));
+		rxe->cq_entry.len = pkt_entry->pkt_size + sizeof(struct efa_rdm_pke);
 	}
 
 	efa_rdm_rxe_report_completion(rxe);
@@ -1335,7 +1335,7 @@ ssize_t rxr_pkt_proc_matched_eager_rtm(struct efa_rdm_ep *ep,
 
 ssize_t rxr_pkt_proc_matched_rtm(struct efa_rdm_ep *ep,
 				 struct efa_rdm_ope *rxe,
-				 struct rxr_pkt_entry *pkt_entry)
+				 struct efa_rdm_pke *pkt_entry)
 {
 	int pkt_type;
 	char *data;
@@ -1415,7 +1415,7 @@ ssize_t rxr_pkt_proc_matched_rtm(struct efa_rdm_ep *ep,
 }
 
 ssize_t rxr_pkt_proc_msgrtm(struct efa_rdm_ep *ep,
-			    struct rxr_pkt_entry *pkt_entry)
+			    struct efa_rdm_pke *pkt_entry)
 {
 	ssize_t err;
 	struct efa_rdm_ope *rxe;
@@ -1424,7 +1424,7 @@ ssize_t rxr_pkt_proc_msgrtm(struct efa_rdm_ep *ep,
 	rxe = rxr_pkt_get_msgrtm_rxe(ep, &pkt_entry);
 	if (OFI_UNLIKELY(!rxe)) {
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_ENOBUFS, FI_EFA_ERR_RXE_POOL_EXHAUSTED);
-		rxr_pkt_entry_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(ep, pkt_entry);
 		return -FI_ENOBUFS;
 	}
 
@@ -1432,7 +1432,7 @@ ssize_t rxr_pkt_proc_msgrtm(struct efa_rdm_ep *ep,
 		err = rxr_pkt_proc_matched_rtm(ep, rxe, pkt_entry);
 		if (OFI_UNLIKELY(err)) {
 			efa_rdm_rxe_handle_error(rxe, -err, FI_EFA_ERR_PKT_PROC_MSGRTM);
-			rxr_pkt_entry_release_rx(ep, pkt_entry);
+			efa_rdm_pke_release_rx(ep, pkt_entry);
 			efa_rdm_rxe_release(rxe);
 			return err;
 		}
@@ -1445,7 +1445,7 @@ ssize_t rxr_pkt_proc_msgrtm(struct efa_rdm_ep *ep,
 }
 
 ssize_t rxr_pkt_proc_tagrtm(struct efa_rdm_ep *ep,
-			    struct rxr_pkt_entry *pkt_entry)
+			    struct efa_rdm_pke *pkt_entry)
 {
 	ssize_t err;
 	struct efa_rdm_ope *rxe;
@@ -1454,7 +1454,7 @@ ssize_t rxr_pkt_proc_tagrtm(struct efa_rdm_ep *ep,
 	rxe = rxr_pkt_get_tagrtm_rxe(ep, &pkt_entry);
 	if (OFI_UNLIKELY(!rxe)) {
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_ENOBUFS, FI_EFA_ERR_RXE_POOL_EXHAUSTED);
-		rxr_pkt_entry_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(ep, pkt_entry);
 		return -FI_ENOBUFS;
 	}
 
@@ -1462,7 +1462,7 @@ ssize_t rxr_pkt_proc_tagrtm(struct efa_rdm_ep *ep,
 		err = rxr_pkt_proc_matched_rtm(ep, rxe, pkt_entry);
 		if (OFI_UNLIKELY(err)) {
 			efa_rdm_rxe_handle_error(rxe, -err, FI_EFA_ERR_PKT_PROC_TAGRTM);
-			rxr_pkt_entry_release_rx(ep, pkt_entry);
+			efa_rdm_pke_release_rx(ep, pkt_entry);
 			efa_rdm_rxe_release(rxe);
 			return err;
 		}
@@ -1478,7 +1478,7 @@ ssize_t rxr_pkt_proc_tagrtm(struct efa_rdm_ep *ep,
  * proc() functions called by rxr_pkt_handle_recv_completion()
  */
 ssize_t rxr_pkt_proc_rtm_rta(struct efa_rdm_ep *ep,
-			     struct rxr_pkt_entry *pkt_entry)
+			     struct efa_rdm_pke *pkt_entry)
 {
 	struct rxr_base_hdr *base_hdr;
 
@@ -1517,14 +1517,14 @@ ssize_t rxr_pkt_proc_rtm_rta(struct efa_rdm_ep *ep,
 			"Unknown packet type ID: %d\n",
 		       base_hdr->type);
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_EINVAL, FI_EFA_ERR_UNKNOWN_PKT_TYPE);
-		rxr_pkt_entry_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(ep, pkt_entry);
 	}
 
 	return -FI_EINVAL;
 }
 
 void rxr_pkt_handle_rtm_rta_recv(struct efa_rdm_ep *ep,
-				 struct rxr_pkt_entry *pkt_entry)
+				 struct efa_rdm_pke *pkt_entry)
 {
 	struct rxr_base_hdr *base_hdr;
 	struct efa_rdm_peer *peer;
@@ -1535,7 +1535,7 @@ void rxr_pkt_handle_rtm_rta_recv(struct efa_rdm_ep *ep,
 
 	if (rxr_pkt_type_is_mulreq(base_hdr->type)) {
 		struct efa_rdm_ope *rxe;
-		struct rxr_pkt_entry *unexp_pkt_entry;
+		struct efa_rdm_pke *unexp_pkt_entry;
 
 		rxe = rxr_pkt_rx_map_lookup(ep, pkt_entry);
 		if (rxe) {
@@ -1544,7 +1544,7 @@ void rxr_pkt_handle_rtm_rta_recv(struct efa_rdm_ep *ep,
 			} else {
 				assert(rxe->unexp_pkt);
 				unexp_pkt_entry = rxr_pkt_get_unexp(ep, &pkt_entry);
-				rxr_pkt_entry_append(rxe->unexp_pkt, unexp_pkt_entry);
+				efa_rdm_pke_append(rxe->unexp_pkt, unexp_pkt_entry);
 			}
 
 			return;
@@ -1567,7 +1567,7 @@ void rxr_pkt_handle_rtm_rta_recv(struct efa_rdm_ep *ep,
 			" robuf->exp_msg_id: %" PRIu32 "\n",
 		       msg_id, peer->robuf.exp_msg_id);
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_EIO, FI_EFA_ERR_PKT_ALREADY_PROCESSED);
-		rxr_pkt_entry_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(ep, pkt_entry);
 		return;
 	}
 
@@ -1602,7 +1602,7 @@ void rxr_pkt_handle_rtm_rta_recv(struct efa_rdm_ep *ep,
  * RTW packet type functions
  */
 static inline
-ssize_t rxr_pkt_init_rtw_data(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_rtw_data(struct efa_rdm_pke *pkt_entry,
 			      struct efa_rdm_ope *txe,
 			      struct efa_rma_iov *rma_iov)
 {
@@ -1621,7 +1621,7 @@ ssize_t rxr_pkt_init_rtw_data(struct rxr_pkt_entry *pkt_entry,
 	return rxr_pkt_init_data_from_ope(txe->ep, pkt_entry, hdr_size, txe, 0, data_size);
 }
 
-ssize_t rxr_pkt_init_eager_rtw(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_eager_rtw(struct efa_rdm_pke *pkt_entry,
 			       struct efa_rdm_ope *txe)
 {
 	struct rxr_eager_rtw_hdr *rtw_hdr;
@@ -1634,7 +1634,7 @@ ssize_t rxr_pkt_init_eager_rtw(struct rxr_pkt_entry *pkt_entry,
 	return rxr_pkt_init_rtw_data(pkt_entry, txe, rtw_hdr->rma_iov);
 }
 
-ssize_t rxr_pkt_init_dc_eager_rtw(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_dc_eager_rtw(struct efa_rdm_pke *pkt_entry,
 				  struct efa_rdm_ope *txe)
 {
 	struct rxr_dc_eager_rtw_hdr *dc_eager_rtw_hdr;
@@ -1653,7 +1653,7 @@ ssize_t rxr_pkt_init_dc_eager_rtw(struct rxr_pkt_entry *pkt_entry,
 }
 
 static inline
-void rxr_pkt_init_longcts_rtw_hdr(struct rxr_pkt_entry *pkt_entry,
+void rxr_pkt_init_longcts_rtw_hdr(struct efa_rdm_pke *pkt_entry,
 				  int pkt_type,
 				  struct efa_rdm_ope *txe)
 {
@@ -1667,7 +1667,7 @@ void rxr_pkt_init_longcts_rtw_hdr(struct rxr_pkt_entry *pkt_entry,
 	rxr_pkt_init_req_hdr(pkt_entry, pkt_type, txe);
 }
 
-ssize_t rxr_pkt_init_longcts_rtw(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_longcts_rtw(struct efa_rdm_pke *pkt_entry,
 				 struct efa_rdm_ope *txe)
 {
 	struct rxr_longcts_rtw_hdr *rtw_hdr;
@@ -1679,7 +1679,7 @@ ssize_t rxr_pkt_init_longcts_rtw(struct rxr_pkt_entry *pkt_entry,
 	return rxr_pkt_init_rtw_data(pkt_entry, txe, rtw_hdr->rma_iov);
 }
 
-ssize_t rxr_pkt_init_dc_longcts_rtw(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_dc_longcts_rtw(struct efa_rdm_pke *pkt_entry,
 				    struct efa_rdm_ope *txe)
 {
 	struct rxr_longcts_rtw_hdr *rtw_hdr;
@@ -1692,7 +1692,7 @@ ssize_t rxr_pkt_init_dc_longcts_rtw(struct rxr_pkt_entry *pkt_entry,
 	return rxr_pkt_init_rtw_data(pkt_entry, txe, rtw_hdr->rma_iov);
 }
 
-ssize_t rxr_pkt_init_longread_rtw(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_longread_rtw(struct efa_rdm_pke *pkt_entry,
 				  struct efa_rdm_ope *txe)
 {
 	struct rxr_longread_rtw_hdr *rtw_hdr;
@@ -1734,7 +1734,7 @@ ssize_t rxr_pkt_init_longread_rtw(struct rxr_pkt_entry *pkt_entry,
  *         rxr_pkt_handle_longcts_rtw_sent() is empty and is defined in rxr_pkt_type_req.h
  */
 void rxr_pkt_handle_longcts_rtw_sent(struct efa_rdm_ep *ep,
-				  struct rxr_pkt_entry *pkt_entry)
+				  struct efa_rdm_pke *pkt_entry)
 {
 	struct efa_rdm_ope *txe;
 	struct efa_domain *efa_domain = efa_rdm_ep_domain(ep);
@@ -1750,7 +1750,7 @@ void rxr_pkt_handle_longcts_rtw_sent(struct efa_rdm_ep *ep,
  *     handle_send_completion() functions
  */
 void rxr_pkt_handle_eager_rtw_send_completion(struct efa_rdm_ep *ep,
-					      struct rxr_pkt_entry *pkt_entry)
+					      struct efa_rdm_pke *pkt_entry)
 {
 	struct efa_rdm_ope *txe;
 
@@ -1760,7 +1760,7 @@ void rxr_pkt_handle_eager_rtw_send_completion(struct efa_rdm_ep *ep,
 }
 
 void rxr_pkt_handle_longcts_rtw_send_completion(struct efa_rdm_ep *ep,
-					     struct rxr_pkt_entry *pkt_entry)
+					     struct efa_rdm_pke *pkt_entry)
 {
 	struct efa_rdm_ope *txe;
 
@@ -1776,7 +1776,7 @@ void rxr_pkt_handle_longcts_rtw_send_completion(struct efa_rdm_ep *ep,
 
 static
 struct efa_rdm_ope *rxr_pkt_alloc_rtw_rxe(struct efa_rdm_ep *ep,
-						struct rxr_pkt_entry *pkt_entry)
+						struct efa_rdm_pke *pkt_entry)
 {
 	struct efa_rdm_ope *rxe;
 	struct rxr_base_hdr *base_hdr;
@@ -1801,7 +1801,7 @@ void rxr_pkt_proc_eager_rtw(struct efa_rdm_ep *ep,
 			    struct efa_rma_iov *rma_iov,
 			    size_t rma_iov_count,
 			    struct efa_rdm_ope *rxe,
-			    struct rxr_pkt_entry *pkt_entry)
+			    struct efa_rdm_pke *pkt_entry)
 {
 	ssize_t err;
 	char *data;
@@ -1814,7 +1814,7 @@ void rxr_pkt_proc_eager_rtw(struct efa_rdm_ep *ep,
 		EFA_WARN(FI_LOG_CQ, "RMA address verify failed!\n");
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_EIO, FI_EFA_ERR_RMA_ADDR);
 		efa_rdm_rxe_release(rxe);
-		rxr_pkt_entry_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(ep, pkt_entry);
 		return;
 	}
 
@@ -1833,20 +1833,20 @@ void rxr_pkt_proc_eager_rtw(struct efa_rdm_ep *ep,
 		EFA_WARN(FI_LOG_CQ, "target buffer: %p length: %ld\n", rxe->iov[0].iov_base,
 			rxe->iov[0].iov_len);
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_EINVAL, FI_EFA_ERR_RTM_MISMATCH);
-		rxr_pkt_entry_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(ep, pkt_entry);
 		efa_rdm_rxe_release(rxe);
 	} else {
 		err = rxr_pkt_copy_data_to_ope(ep, rxe, 0, pkt_entry, data, data_size);
 		if (OFI_UNLIKELY(err)) {
 			efa_base_ep_write_eq_error(&ep->base_ep, FI_EINVAL, FI_EFA_ERR_RXE_COPY);
-			rxr_pkt_entry_release_rx(ep, pkt_entry);
+			efa_rdm_pke_release_rx(ep, pkt_entry);
 			efa_rdm_rxe_release(rxe);
 		}
 	}
 }
 
 void rxr_pkt_handle_eager_rtw_recv(struct efa_rdm_ep *ep,
-				   struct rxr_pkt_entry *pkt_entry)
+				   struct efa_rdm_pke *pkt_entry)
 {
 	struct efa_rdm_ope *rxe;
 	struct rxr_eager_rtw_hdr *rtw_hdr;
@@ -1857,7 +1857,7 @@ void rxr_pkt_handle_eager_rtw_recv(struct efa_rdm_ep *ep,
 		EFA_WARN(FI_LOG_CQ,
 			"RX entries exhausted.\n");
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_ENOBUFS, FI_EFA_ERR_RXE_POOL_EXHAUSTED);
-		rxr_pkt_entry_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(ep, pkt_entry);
 		return;
 	}
 
@@ -1870,7 +1870,7 @@ void rxr_pkt_handle_eager_rtw_recv(struct efa_rdm_ep *ep,
 }
 
 void rxr_pkt_handle_dc_eager_rtw_recv(struct efa_rdm_ep *ep,
-				      struct rxr_pkt_entry *pkt_entry)
+				      struct efa_rdm_pke *pkt_entry)
 {
 	struct efa_rdm_ope *rxe;
 	struct rxr_dc_eager_rtw_hdr *rtw_hdr;
@@ -1880,7 +1880,7 @@ void rxr_pkt_handle_dc_eager_rtw_recv(struct efa_rdm_ep *ep,
 		EFA_WARN(FI_LOG_CQ,
 			"RX entries exhausted.\n");
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_ENOBUFS, FI_EFA_ERR_RXE_POOL_EXHAUSTED);
-		rxr_pkt_entry_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(ep, pkt_entry);
 		return;
 	}
 
@@ -1895,7 +1895,7 @@ void rxr_pkt_handle_dc_eager_rtw_recv(struct efa_rdm_ep *ep,
 }
 
 void rxr_pkt_handle_longcts_rtw_recv(struct efa_rdm_ep *ep,
-				  struct rxr_pkt_entry *pkt_entry)
+				  struct efa_rdm_pke *pkt_entry)
 {
 	struct efa_rdm_ope *rxe;
 	struct rxr_longcts_rtw_hdr *rtw_hdr;
@@ -1909,7 +1909,7 @@ void rxr_pkt_handle_longcts_rtw_recv(struct efa_rdm_ep *ep,
 		EFA_WARN(FI_LOG_CQ,
 			"RX entries exhausted.\n");
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_ENOBUFS, FI_EFA_ERR_RXE_POOL_EXHAUSTED);
-		rxr_pkt_entry_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(ep, pkt_entry);
 		return;
 	}
 
@@ -1925,7 +1925,7 @@ void rxr_pkt_handle_longcts_rtw_recv(struct efa_rdm_ep *ep,
 		EFA_WARN(FI_LOG_CQ, "RMA address verify failed!\n");
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_EIO, FI_EFA_ERR_RMA_ADDR);
 		efa_rdm_rxe_release(rxe);
-		rxr_pkt_entry_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(ep, pkt_entry);
 		return;
 	}
 
@@ -1945,14 +1945,14 @@ void rxr_pkt_handle_longcts_rtw_recv(struct efa_rdm_ep *ep,
 			rxe->iov[0].iov_len);
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_EINVAL, FI_EFA_ERR_RTM_MISMATCH);
 		efa_rdm_rxe_release(rxe);
-		rxr_pkt_entry_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(ep, pkt_entry);
 		return;
 	} else {
 		err = rxr_pkt_copy_data_to_ope(ep, rxe, 0, pkt_entry, data, data_size);
 		if (OFI_UNLIKELY(err)) {
 			efa_base_ep_write_eq_error(&ep->base_ep, FI_EINVAL, FI_EFA_ERR_RXE_COPY);
 			efa_rdm_rxe_release(rxe);
-			rxr_pkt_entry_release_rx(ep, pkt_entry);
+			efa_rdm_pke_release_rx(ep, pkt_entry);
 			return;
 		}
 	}
@@ -1973,7 +1973,7 @@ void rxr_pkt_handle_longcts_rtw_recv(struct efa_rdm_ep *ep,
 }
 
 void rxr_pkt_handle_longread_rtw_recv(struct efa_rdm_ep *ep,
-				  struct rxr_pkt_entry *pkt_entry)
+				  struct efa_rdm_pke *pkt_entry)
 {
 	struct efa_rdm_ope *rxe;
 	struct rxr_longread_rtw_hdr *rtw_hdr;
@@ -1986,7 +1986,7 @@ void rxr_pkt_handle_longread_rtw_recv(struct efa_rdm_ep *ep,
 		EFA_WARN(FI_LOG_CQ,
 			"RX entries exhausted.\n");
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_ENOBUFS, FI_EFA_ERR_RXE_POOL_EXHAUSTED);
-		rxr_pkt_entry_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(ep, pkt_entry);
 		return;
 	}
 
@@ -1998,7 +1998,7 @@ void rxr_pkt_handle_longread_rtw_recv(struct efa_rdm_ep *ep,
 		EFA_WARN(FI_LOG_CQ, "RMA address verify failed!\n");
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_EINVAL, FI_EFA_ERR_RMA_ADDR);
 		efa_rdm_rxe_release(rxe);
-		rxr_pkt_entry_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(ep, pkt_entry);
 		return;
 	}
 
@@ -2014,7 +2014,7 @@ void rxr_pkt_handle_longread_rtw_recv(struct efa_rdm_ep *ep,
 	memcpy(rxe->rma_iov, read_iov,
 	       rxe->rma_iov_count * sizeof(struct fi_rma_iov));
 
-	rxr_pkt_entry_release_rx(ep, pkt_entry);
+	efa_rdm_pke_release_rx(ep, pkt_entry);
 
 	err = efa_rdm_ope_post_remote_read_or_queue(rxe);
 	if (OFI_UNLIKELY(err)) {
@@ -2022,7 +2022,7 @@ void rxr_pkt_handle_longread_rtw_recv(struct efa_rdm_ep *ep,
 			"RDMA post read or queue failed.\n");
 		efa_base_ep_write_eq_error(&ep->base_ep, err, FI_EFA_ERR_RDMA_READ_POST);
 		efa_rdm_rxe_release(rxe);
-		rxr_pkt_entry_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(ep, pkt_entry);
 	}
 }
 
@@ -2030,7 +2030,7 @@ void rxr_pkt_handle_longread_rtw_recv(struct efa_rdm_ep *ep,
  * RTR packet functions
  *     init() functions for RTR packets
  */
-void rxr_pkt_init_rtr(struct rxr_pkt_entry *pkt_entry,
+void rxr_pkt_init_rtr(struct efa_rdm_pke *pkt_entry,
 		      int pkt_type,
 		      struct efa_rdm_ope *txe,
 		      int window)
@@ -2055,14 +2055,14 @@ void rxr_pkt_init_rtr(struct rxr_pkt_entry *pkt_entry,
 	pkt_entry->ope = txe;
 }
 
-ssize_t rxr_pkt_init_short_rtr(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_short_rtr(struct efa_rdm_pke *pkt_entry,
 			       struct efa_rdm_ope *txe)
 {
 	rxr_pkt_init_rtr(pkt_entry, RXR_SHORT_RTR_PKT, txe, txe->total_len);
 	return 0;
 }
 
-ssize_t rxr_pkt_init_longcts_rtr(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_longcts_rtr(struct efa_rdm_pke *pkt_entry,
 				 struct efa_rdm_ope *txe)
 {
 	rxr_pkt_init_rtr(pkt_entry, RXR_LONGCTS_RTR_PKT, txe, txe->window);
@@ -2072,7 +2072,7 @@ ssize_t rxr_pkt_init_longcts_rtr(struct rxr_pkt_entry *pkt_entry,
 /*
  *     handle_recv() functions for RTR packet
  */
-void rxr_pkt_handle_rtr_recv(struct efa_rdm_ep *ep, struct rxr_pkt_entry *pkt_entry)
+void rxr_pkt_handle_rtr_recv(struct efa_rdm_ep *ep, struct efa_rdm_pke *pkt_entry)
 {
 	struct rxr_rtr_hdr *rtr_hdr;
 	struct efa_rdm_ope *rxe;
@@ -2083,7 +2083,7 @@ void rxr_pkt_handle_rtr_recv(struct efa_rdm_ep *ep, struct rxr_pkt_entry *pkt_en
 		EFA_WARN(FI_LOG_CQ,
 			"RX entries exhausted.\n");
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_ENOBUFS, FI_EFA_ERR_RXE_POOL_EXHAUSTED);
-		rxr_pkt_entry_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(ep, pkt_entry);
 		return;
 	}
 
@@ -2101,7 +2101,7 @@ void rxr_pkt_handle_rtr_recv(struct efa_rdm_ep *ep, struct rxr_pkt_entry *pkt_en
 		EFA_WARN(FI_LOG_CQ, "RMA address verification failed!\n");
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_EINVAL, FI_EFA_ERR_RMA_ADDR);
 		efa_rdm_rxe_release(rxe);
-		rxr_pkt_entry_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(ep, pkt_entry);
 		return;
 	}
 
@@ -2115,17 +2115,17 @@ void rxr_pkt_handle_rtr_recv(struct efa_rdm_ep *ep, struct rxr_pkt_entry *pkt_en
 		EFA_WARN(FI_LOG_CQ, "Posting of readrsp packet failed! err=%ld\n", err);
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_EIO, FI_EFA_ERR_PKT_POST);
 		efa_rdm_rxe_release(rxe);
-		rxr_pkt_entry_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(ep, pkt_entry);
 		return;
 	}
 
-	rxr_pkt_entry_release_rx(ep, pkt_entry);
+	efa_rdm_pke_release_rx(ep, pkt_entry);
 }
 
 /*
  * RTA packet functions
  */
-ssize_t rxr_pkt_init_rta(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_rta(struct efa_rdm_pke *pkt_entry,
 			 int pkt_type,
 			 struct efa_rdm_ope *txe)
 {
@@ -2166,14 +2166,14 @@ ssize_t rxr_pkt_init_rta(struct rxr_pkt_entry *pkt_entry,
 	return 0;
 }
 
-ssize_t rxr_pkt_init_write_rta(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_write_rta(struct efa_rdm_pke *pkt_entry,
 			       struct efa_rdm_ope *txe)
 {
 	rxr_pkt_init_rta(pkt_entry, RXR_WRITE_RTA_PKT, txe);
 	return 0;
 }
 
-ssize_t rxr_pkt_init_dc_write_rta(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_dc_write_rta(struct efa_rdm_pke *pkt_entry,
 				  struct efa_rdm_ope *txe)
 
 {
@@ -2186,7 +2186,7 @@ ssize_t rxr_pkt_init_dc_write_rta(struct rxr_pkt_entry *pkt_entry,
 	return 0;
 }
 
-ssize_t rxr_pkt_init_fetch_rta(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_fetch_rta(struct efa_rdm_pke *pkt_entry,
 			       struct efa_rdm_ope *txe)
 
 {
@@ -2198,7 +2198,7 @@ ssize_t rxr_pkt_init_fetch_rta(struct rxr_pkt_entry *pkt_entry,
 	return 0;
 }
 
-ssize_t rxr_pkt_init_compare_rta(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_compare_rta(struct efa_rdm_pke *pkt_entry,
 				 struct efa_rdm_ope *txe)
 
 {
@@ -2230,7 +2230,7 @@ ssize_t rxr_pkt_init_compare_rta(struct rxr_pkt_entry *pkt_entry,
 	return 0;
 }
 
-void rxr_pkt_handle_write_rta_send_completion(struct efa_rdm_ep *ep, struct rxr_pkt_entry *pkt_entry)
+void rxr_pkt_handle_write_rta_send_completion(struct efa_rdm_ep *ep, struct efa_rdm_pke *pkt_entry)
 {
 	struct efa_rdm_ope *txe;
 
@@ -2262,7 +2262,7 @@ static int rxr_write_atomic_hmem(struct efa_mr *efa_mr, struct iovec *dst, char 
 	return err;
 }
 
-int rxr_pkt_proc_write_rta(struct efa_rdm_ep *ep, struct rxr_pkt_entry *pkt_entry)
+int rxr_pkt_proc_write_rta(struct efa_rdm_ep *ep, struct efa_rdm_pke *pkt_entry)
 {
 	struct iovec iov[RXR_IOV_LIMIT];
 	struct efa_mr *efa_mr;
@@ -2306,11 +2306,11 @@ int rxr_pkt_proc_write_rta(struct efa_rdm_ep *ep, struct rxr_pkt_entry *pkt_entr
 		offset += iov[i].iov_len;
 	}
 
-	rxr_pkt_entry_release_rx(ep, pkt_entry);
+	efa_rdm_pke_release_rx(ep, pkt_entry);
 	return 0;
 }
 
-struct efa_rdm_ope *rxr_pkt_alloc_rta_rxe(struct efa_rdm_ep *ep, struct rxr_pkt_entry *pkt_entry, int op)
+struct efa_rdm_ope *rxr_pkt_alloc_rta_rxe(struct efa_rdm_ep *ep, struct efa_rdm_pke *pkt_entry, int op)
 {
 	struct efa_rdm_ope *rxe;
 	struct rxr_rta_hdr *rta_hdr;
@@ -2359,7 +2359,7 @@ struct efa_rdm_ope *rxr_pkt_alloc_rta_rxe(struct efa_rdm_ep *ep, struct rxr_pkt_
 }
 
 int rxr_pkt_proc_dc_write_rta(struct efa_rdm_ep *ep,
-			      struct rxr_pkt_entry *pkt_entry)
+			      struct efa_rdm_pke *pkt_entry)
 {
 	struct efa_rdm_ope *rxe;
 	struct rxr_rta_hdr *rta_hdr;
@@ -2369,7 +2369,7 @@ int rxr_pkt_proc_dc_write_rta(struct efa_rdm_ep *ep,
 	rxe = rxr_pkt_alloc_rta_rxe(ep, pkt_entry, ofi_op_atomic);
 	if (OFI_UNLIKELY(!rxe)) {
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_ENOBUFS, FI_EFA_ERR_RXE_POOL_EXHAUSTED);
-		rxr_pkt_entry_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(ep, pkt_entry);
 		return -FI_ENOBUFS;
 	}
 
@@ -2422,7 +2422,7 @@ static int rxr_fetch_atomic_hmem(struct efa_mr *efa_mr, struct iovec *dst, char 
 	return err;
 }
 
-int rxr_pkt_proc_fetch_rta(struct efa_rdm_ep *ep, struct rxr_pkt_entry *pkt_entry)
+int rxr_pkt_proc_fetch_rta(struct efa_rdm_ep *ep, struct efa_rdm_pke *pkt_entry)
 {
 	struct efa_rdm_ope *rxe;
 	struct efa_mr *efa_mr;
@@ -2472,7 +2472,7 @@ int rxr_pkt_proc_fetch_rta(struct efa_rdm_ep *ep, struct rxr_pkt_entry *pkt_entr
 	if (OFI_UNLIKELY(err))
 		efa_rdm_rxe_handle_error(rxe, -err, FI_EFA_ERR_PKT_POST);
 
-	rxr_pkt_entry_release_rx(ep, pkt_entry);
+	efa_rdm_pke_release_rx(ep, pkt_entry);
 	return 0;
 }
 
@@ -2498,7 +2498,7 @@ static int rxr_compare_atomic_hmem(struct efa_mr *efa_mr, struct iovec *dst, cha
 	return err;
 }
 
-int rxr_pkt_proc_compare_rta(struct efa_rdm_ep *ep, struct rxr_pkt_entry *pkt_entry)
+int rxr_pkt_proc_compare_rta(struct efa_rdm_ep *ep, struct efa_rdm_pke *pkt_entry)
 {
 	struct efa_mr *efa_mr;
 	struct efa_rdm_ope *rxe;
@@ -2511,7 +2511,7 @@ int rxr_pkt_proc_compare_rta(struct efa_rdm_ep *ep, struct rxr_pkt_entry *pkt_en
 	rxe = rxr_pkt_alloc_rta_rxe(ep, pkt_entry, ofi_op_atomic_compare);
 	if(OFI_UNLIKELY(!rxe)) {
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_ENOBUFS, FI_EFA_ERR_RXE_POOL_EXHAUSTED);
-		rxr_pkt_entry_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(ep, pkt_entry);
 		return -FI_ENOBUFS;
 	}
 
@@ -2522,7 +2522,7 @@ int rxr_pkt_proc_compare_rta(struct efa_rdm_ep *ep, struct rxr_pkt_entry *pkt_en
 	if (OFI_UNLIKELY(!dtsize)) {
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_EINVAL, FI_EFA_ERR_INVALID_DATATYPE);
 		efa_rdm_rxe_release(rxe);
-		rxr_pkt_entry_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(ep, pkt_entry);
 		return -errno;
 	}
 
@@ -2554,10 +2554,10 @@ int rxr_pkt_proc_compare_rta(struct efa_rdm_ep *ep, struct rxr_pkt_entry *pkt_en
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_EIO, FI_EFA_ERR_PKT_POST);
 		ofi_buf_free(rxe->atomrsp_data);
 		efa_rdm_rxe_release(rxe);
-		rxr_pkt_entry_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(ep, pkt_entry);
 		return err;
 	}
 
-	rxr_pkt_entry_release_rx(ep, pkt_entry);
+	efa_rdm_pke_release_rx(ep, pkt_entry);
 	return 0;
 }

--- a/prov/efa/src/rdm/rxr_pkt_type_req.h
+++ b/prov/efa/src/rdm/rxr_pkt_type_req.h
@@ -34,7 +34,7 @@
 #ifndef _RXR_PKT_TYPE_REQ_H
 #define _RXR_PKT_TYPE_REQ_H
 
-#define RXR_MSG_PREFIX_SIZE (sizeof(struct rxr_pkt_entry) + sizeof(struct rxr_eager_msgrtm_hdr) + RXR_REQ_OPT_RAW_ADDR_HDR_SIZE)
+#define RXR_MSG_PREFIX_SIZE (sizeof(struct efa_rdm_pke) + sizeof(struct rxr_eager_msgrtm_hdr) + RXR_REQ_OPT_RAW_ADDR_HDR_SIZE)
 
 #if defined(static_assert) && defined(__x86_64__)
 static_assert(RXR_MSG_PREFIX_SIZE % 8 == 0, "message prefix size alignment check");
@@ -42,27 +42,27 @@ static_assert(RXR_MSG_PREFIX_SIZE % 8 == 0, "message prefix size alignment check
 
 bool rxr_pkt_req_supported_by_peer(int req_type, struct efa_rdm_peer *peer);
 
-void *rxr_pkt_req_raw_addr(struct rxr_pkt_entry *pkt_entry);
+void *rxr_pkt_req_raw_addr(struct efa_rdm_pke *pkt_entry);
 
-int64_t rxr_pkt_req_cq_data(struct rxr_pkt_entry *pkt_entry);
+int64_t rxr_pkt_req_cq_data(struct efa_rdm_pke *pkt_entry);
 
-uint32_t *rxr_pkt_req_connid_ptr(struct rxr_pkt_entry *pkt_entry);
+uint32_t *rxr_pkt_req_connid_ptr(struct efa_rdm_pke *pkt_entry);
 
-size_t rxr_pkt_req_hdr_size_from_pkt_entry(struct rxr_pkt_entry *pkt_entry);
+size_t rxr_pkt_req_hdr_size_from_pkt_entry(struct efa_rdm_pke *pkt_entry);
 
-size_t rxr_pkt_req_base_hdr_size(struct rxr_pkt_entry *pkt_entry);
+size_t rxr_pkt_req_base_hdr_size(struct efa_rdm_pke *pkt_entry);
 
-size_t rxr_pkt_req_data_size(struct rxr_pkt_entry *pkt_entry);
+size_t rxr_pkt_req_data_size(struct efa_rdm_pke *pkt_entry);
 
 size_t rxr_pkt_req_hdr_size(int pkt_type, uint16_t flags, size_t rma_iov_count);
 
-uint32_t rxr_pkt_hdr_rma_iov_count(struct rxr_pkt_entry *pkt_entry);
+uint32_t rxr_pkt_hdr_rma_iov_count(struct efa_rdm_pke *pkt_entry);
 
 size_t rxr_pkt_req_max_hdr_size(int pkt_type);
 
 size_t rxr_pkt_max_hdr_size(void);
 
-size_t rxr_pkt_req_data_offset(struct rxr_pkt_entry *pkt_entry);
+size_t rxr_pkt_req_data_offset(struct efa_rdm_pke *pkt_entry);
 
 static inline
 struct rxr_rtm_base_hdr *rxr_get_rtm_base_hdr(void *pkt)
@@ -71,7 +71,7 @@ struct rxr_rtm_base_hdr *rxr_get_rtm_base_hdr(void *pkt)
 }
 
 static inline
-uint32_t rxr_pkt_msg_id(struct rxr_pkt_entry *pkt_entry)
+uint32_t rxr_pkt_msg_id(struct efa_rdm_pke *pkt_entry)
 {
 	struct rxr_rtm_base_hdr *rtm_hdr;
 
@@ -81,10 +81,10 @@ uint32_t rxr_pkt_msg_id(struct rxr_pkt_entry *pkt_entry)
 	return rtm_hdr->msg_id;
 }
 
-size_t rxr_pkt_rtm_total_len(struct rxr_pkt_entry *pkt_entry);
+size_t rxr_pkt_rtm_total_len(struct efa_rdm_pke *pkt_entry);
 
 static inline
-uint64_t rxr_pkt_rtm_tag(struct rxr_pkt_entry *pkt_entry)
+uint64_t rxr_pkt_rtm_tag(struct efa_rdm_pke *pkt_entry)
 {
 	size_t offset;
 	uint64_t *tagptr;
@@ -100,7 +100,7 @@ uint64_t rxr_pkt_rtm_tag(struct rxr_pkt_entry *pkt_entry)
 }
 
 static inline
-void rxr_pkt_rtm_settag(struct rxr_pkt_entry *pkt_entry, uint64_t tag)
+void rxr_pkt_rtm_settag(struct efa_rdm_pke *pkt_entry, uint64_t tag)
 {
 	size_t offset;
 	uint64_t *tagptr;
@@ -171,105 +171,105 @@ struct rxr_runtread_rtm_base_hdr *rxr_get_runtread_rtm_base_hdr(void *pkt)
 	return (struct rxr_runtread_rtm_base_hdr *)pkt;
 }
 
-ssize_t rxr_pkt_init_eager_msgrtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_eager_msgrtm(struct efa_rdm_pke *pkt_entry,
 				  struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_dc_eager_msgrtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_dc_eager_msgrtm(struct efa_rdm_pke *pkt_entry,
 				     struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_eager_tagrtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_eager_tagrtm(struct efa_rdm_pke *pkt_entry,
 				  struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_medium_msgrtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_medium_msgrtm(struct efa_rdm_pke *pkt_entry,
 				   struct efa_rdm_ope *txe,
 				   size_t data_offset,
 				   int data_size);
 
-ssize_t rxr_pkt_init_dc_eager_tagrtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_dc_eager_tagrtm(struct efa_rdm_pke *pkt_entry,
 				     struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_dc_medium_msgrtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_dc_medium_msgrtm(struct efa_rdm_pke *pkt_entry,
 				      struct efa_rdm_ope *txe,
 				      size_t data_offset,
 				      int data_size);
 
-ssize_t rxr_pkt_init_medium_tagrtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_medium_tagrtm(struct efa_rdm_pke *pkt_entry,
 				   struct efa_rdm_ope *txe,
 				   size_t data_offset,
 				   int data_size);
 
-ssize_t rxr_pkt_init_dc_medium_tagrtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_dc_medium_tagrtm(struct efa_rdm_pke *pkt_entry,
 				      struct efa_rdm_ope *txe,
 				      size_t data_offset,
 				      int data_size);
 
-ssize_t rxr_pkt_init_longcts_msgrtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_longcts_msgrtm(struct efa_rdm_pke *pkt_entry,
 				    struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_dc_longcts_msgrtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_dc_longcts_msgrtm(struct efa_rdm_pke *pkt_entry,
 				       struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_longcts_tagrtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_longcts_tagrtm(struct efa_rdm_pke *pkt_entry,
 				    struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_dc_longcts_tagrtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_dc_longcts_tagrtm(struct efa_rdm_pke *pkt_entry,
 				       struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_longread_msgrtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_longread_msgrtm(struct efa_rdm_pke *pkt_entry,
 				     struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_longread_tagrtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_longread_tagrtm(struct efa_rdm_pke *pkt_entry,
 				     struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_runtread_msgrtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_runtread_msgrtm(struct efa_rdm_pke *pkt_entry,
 				     struct efa_rdm_ope *txe,
 				     size_t data_offset,
 				     int data_size);
 
-ssize_t rxr_pkt_init_runtread_tagrtm(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_runtread_tagrtm(struct efa_rdm_pke *pkt_entry,
 				     struct efa_rdm_ope *txe,
 				     size_t data_offset,
 				     int data_size);
 
 static inline
 void rxr_pkt_handle_eager_rtm_sent(struct efa_rdm_ep *ep,
-				   struct rxr_pkt_entry *pkt_entry)
+				   struct efa_rdm_pke *pkt_entry)
 {
 	/* there is nothing to be done for eager RTM */
 	return;
 }
 
 void rxr_pkt_handle_medium_rtm_sent(struct efa_rdm_ep *ep,
-				    struct rxr_pkt_entry *pkt_entry);
+				    struct efa_rdm_pke *pkt_entry);
 
 void rxr_pkt_handle_longcts_rtm_sent(struct efa_rdm_ep *ep,
-				  struct rxr_pkt_entry *pkt_entry);
+				  struct efa_rdm_pke *pkt_entry);
 
 void rxr_pkt_handle_longread_rtm_sent(struct efa_rdm_ep *ep,
-				      struct rxr_pkt_entry *pkt_entry);
+				      struct efa_rdm_pke *pkt_entry);
 
 void rxr_pkt_handle_runtread_rtm_sent(struct efa_rdm_ep *ep,
-				      struct rxr_pkt_entry *pkt_entry);
+				      struct efa_rdm_pke *pkt_entry);
 
 void rxr_pkt_handle_eager_rtm_send_completion(struct efa_rdm_ep *ep,
-					      struct rxr_pkt_entry *pkt_entry);
+					      struct efa_rdm_pke *pkt_entry);
 
 void rxr_pkt_handle_medium_rtm_send_completion(struct efa_rdm_ep *ep,
-					       struct rxr_pkt_entry *pkt_entry);
+					       struct efa_rdm_pke *pkt_entry);
 
 void rxr_pkt_handle_longcts_rtm_send_completion(struct efa_rdm_ep *ep,
-					     struct rxr_pkt_entry *pkt_entry);
+					     struct efa_rdm_pke *pkt_entry);
 
 static inline
 void rxr_pkt_handle_longread_rtm_send_completion(struct efa_rdm_ep *ep,
-					     struct rxr_pkt_entry *pkt_entry)
+					     struct efa_rdm_pke *pkt_entry)
 {
 }
 
 void rxr_pkt_handle_runtread_rtm_send_completion(struct efa_rdm_ep *ep,
-						 struct rxr_pkt_entry *pkt_entry);
+						 struct efa_rdm_pke *pkt_entry);
 
-void rxr_pkt_rtm_update_rxe(struct rxr_pkt_entry *pkt_entry,
+void rxr_pkt_rtm_update_rxe(struct efa_rdm_pke *pkt_entry,
 				 struct efa_rdm_ope *rxe);
 
 /*         This function is called by both
@@ -278,21 +278,21 @@ void rxr_pkt_rtm_update_rxe(struct rxr_pkt_entry *pkt_entry,
  */
 ssize_t rxr_pkt_proc_matched_rtm(struct efa_rdm_ep *ep,
 				 struct efa_rdm_ope *rxe,
-				 struct rxr_pkt_entry *pkt_entry);
+				 struct efa_rdm_pke *pkt_entry);
 
 ssize_t rxr_pkt_proc_rtm_rta(struct efa_rdm_ep *ep,
-			     struct rxr_pkt_entry *pkt_entry);
+			     struct efa_rdm_pke *pkt_entry);
 /*
  *         This function handles zero-copy receives that do not require ordering
  */
 void rxr_pkt_handle_zcpy_recv(struct efa_rdm_ep *ep,
-			      struct rxr_pkt_entry *pkt_entry);
+			      struct efa_rdm_pke *pkt_entry);
 /*
  *         This function is shared by all RTM packet types which handle
  *         reordering
  */
 void rxr_pkt_handle_rtm_rta_recv(struct efa_rdm_ep *ep,
-				 struct rxr_pkt_entry *pkt_entry);
+				 struct efa_rdm_pke *pkt_entry);
 
 static inline
 struct rxr_rtw_base_hdr *rxr_get_rtw_base_hdr(void *pkt)
@@ -306,78 +306,78 @@ struct rxr_dc_eager_rtw_hdr *rxr_get_dc_eager_rtw_hdr(void *pkt)
 	return (struct rxr_dc_eager_rtw_hdr *)pkt;
 }
 
-ssize_t rxr_pkt_init_eager_rtw(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_eager_rtw(struct efa_rdm_pke *pkt_entry,
 			       struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_longcts_rtw(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_longcts_rtw(struct efa_rdm_pke *pkt_entry,
 				 struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_longread_rtw(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_longread_rtw(struct efa_rdm_pke *pkt_entry,
 				  struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_dc_eager_rtw(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_dc_eager_rtw(struct efa_rdm_pke *pkt_entry,
 				  struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_dc_longcts_rtw(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_dc_longcts_rtw(struct efa_rdm_pke *pkt_entry,
 				    struct efa_rdm_ope *txe);
 
 static inline
 void rxr_pkt_handle_eager_rtw_sent(struct efa_rdm_ep *ep,
-				   struct rxr_pkt_entry *pkt_entry)
+				   struct efa_rdm_pke *pkt_entry)
 {
 	/* For eager RTW, there is nothing to be done here */
 	return;
 }
 
 void rxr_pkt_handle_longcts_rtw_sent(struct efa_rdm_ep *ep,
-				  struct rxr_pkt_entry *pkt_entry);
+				  struct efa_rdm_pke *pkt_entry);
 
 static inline
 void rxr_pkt_handle_longread_rtw_sent(struct efa_rdm_ep *ep,
-				  struct rxr_pkt_entry *pkt_entry)
+				  struct efa_rdm_pke *pkt_entry)
 {
 }
 
 void rxr_pkt_handle_eager_rtw_send_completion(struct efa_rdm_ep *ep,
-					      struct rxr_pkt_entry *pkt_entry);
+					      struct efa_rdm_pke *pkt_entry);
 
 void rxr_pkt_handle_longcts_rtw_send_completion(struct efa_rdm_ep *ep,
-					     struct rxr_pkt_entry *pkt_entry);
+					     struct efa_rdm_pke *pkt_entry);
 
 static inline
 void rxr_pkt_handle_longread_rtw_send_completion(struct efa_rdm_ep *ep,
-					     struct rxr_pkt_entry *pkt_entry)
+					     struct efa_rdm_pke *pkt_entry)
 {
 }
 
 void rxr_pkt_handle_eager_rtw_recv(struct efa_rdm_ep *ep,
-				   struct rxr_pkt_entry *pkt_entry);
+				   struct efa_rdm_pke *pkt_entry);
 
 void rxr_pkt_handle_dc_eager_rtw_recv(struct efa_rdm_ep *ep,
-				      struct rxr_pkt_entry *pkt_entry);
+				      struct efa_rdm_pke *pkt_entry);
 
 void rxr_pkt_handle_longcts_rtw_recv(struct efa_rdm_ep *ep,
-				  struct rxr_pkt_entry *pkt_entry);
+				  struct efa_rdm_pke *pkt_entry);
 
 void rxr_pkt_handle_longread_rtw_recv(struct efa_rdm_ep *ep,
-				  struct rxr_pkt_entry *pkt_entry);
+				  struct efa_rdm_pke *pkt_entry);
 static inline
 struct rxr_rtr_hdr *rxr_get_rtr_hdr(void *pkt)
 {
 	return (struct rxr_rtr_hdr *)pkt;
 }
 
-ssize_t rxr_pkt_init_short_rtr(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_short_rtr(struct efa_rdm_pke *pkt_entry,
 			       struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_longcts_rtr(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_longcts_rtr(struct efa_rdm_pke *pkt_entry,
 				 struct efa_rdm_ope *txe);
 
 void rxr_pkt_handle_rtr_sent(struct efa_rdm_ep *ep,
-			     struct rxr_pkt_entry *pkt_entry);
+			     struct efa_rdm_pke *pkt_entry);
 
 void rxr_pkt_handle_rtr_recv(struct efa_rdm_ep *ep,
-			     struct rxr_pkt_entry *pkt_entry);
+			     struct efa_rdm_pke *pkt_entry);
 
 static inline
 struct rxr_rta_hdr *rxr_get_rta_hdr(void *pkt)
@@ -385,47 +385,47 @@ struct rxr_rta_hdr *rxr_get_rta_hdr(void *pkt)
 	return (struct rxr_rta_hdr *)pkt;
 }
 
-ssize_t rxr_pkt_init_write_rta(struct rxr_pkt_entry *pkt_entry, struct efa_rdm_ope *txe);
+ssize_t rxr_pkt_init_write_rta(struct efa_rdm_pke *pkt_entry, struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_dc_write_rta(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_dc_write_rta(struct efa_rdm_pke *pkt_entry,
 				  struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_fetch_rta(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_fetch_rta(struct efa_rdm_pke *pkt_entry,
 			       struct efa_rdm_ope *txe);
 
-ssize_t rxr_pkt_init_compare_rta(struct rxr_pkt_entry *pkt_entry,
+ssize_t rxr_pkt_init_compare_rta(struct efa_rdm_pke *pkt_entry,
 				 struct efa_rdm_ope *txe);
 
 static inline
 void rxr_pkt_handle_rta_sent(struct efa_rdm_ep *ep,
-			     struct rxr_pkt_entry *pkt_entry)
+			     struct efa_rdm_pke *pkt_entry)
 {
 }
 
 void rxr_pkt_handle_write_rta_send_completion(struct efa_rdm_ep *ep,
-					      struct rxr_pkt_entry *pkt_entry);
+					      struct efa_rdm_pke *pkt_entry);
 
 /* no action to be taken for compare_rta and fetch rta's send completion therefore
  * there are not functions named rxr_pkt_handle_compare/fetch_rta_send_completion()
  */
 
 int rxr_pkt_proc_write_rta(struct efa_rdm_ep *ep,
-			   struct rxr_pkt_entry *pkt_entry);
+			   struct efa_rdm_pke *pkt_entry);
 
 int rxr_pkt_proc_dc_write_rta(struct efa_rdm_ep *ep,
-			      struct rxr_pkt_entry *pkt_entry);
+			      struct efa_rdm_pke *pkt_entry);
 
 int rxr_pkt_proc_fetch_rta(struct efa_rdm_ep *ep,
-			   struct rxr_pkt_entry *pkt_entry);
+			   struct efa_rdm_pke *pkt_entry);
 
 int rxr_pkt_proc_compare_rta(struct efa_rdm_ep *ep,
-			     struct rxr_pkt_entry *pkt_entry);
+			     struct efa_rdm_pke *pkt_entry);
 
-void rxr_pkt_handle_rta_recv(struct efa_rdm_ep *ep, struct rxr_pkt_entry *pkt_entry);
+void rxr_pkt_handle_rta_recv(struct efa_rdm_ep *ep, struct efa_rdm_pke *pkt_entry);
 
 struct efa_rdm_ope *rxr_pkt_get_msgrtm_rxe(struct efa_rdm_ep *ep,
-						 struct rxr_pkt_entry **pkt_entry_ptr);
+						 struct efa_rdm_pke **pkt_entry_ptr);
 
 struct efa_rdm_ope *rxr_pkt_get_tagrtm_rxe(struct efa_rdm_ep *ep,
-						 struct rxr_pkt_entry **pkt_entry_ptr);
+						 struct efa_rdm_pke **pkt_entry_ptr);
 #endif

--- a/prov/efa/test/efa_unit_test_common.c
+++ b/prov/efa/test/efa_unit_test_common.c
@@ -177,7 +177,7 @@ void efa_unit_test_buff_destruct(struct efa_unit_test_buff *buff)
  * @param[in] pkt_entry Packet entry. Must be non-NULL.
  * @param[in] attr Packet attributes.
  */
-void efa_unit_test_eager_msgrtm_pkt_construct(struct rxr_pkt_entry *pkt_entry, struct efa_unit_test_eager_rtm_pkt_attr *attr)
+void efa_unit_test_eager_msgrtm_pkt_construct(struct efa_rdm_pke *pkt_entry, struct efa_unit_test_eager_rtm_pkt_attr *attr)
 {
 	struct rxr_eager_msgrtm_hdr base_hdr = {0};
 	struct rxr_req_opt_connid_hdr opt_connid_hdr = {0};
@@ -204,7 +204,7 @@ void efa_unit_test_eager_msgrtm_pkt_construct(struct rxr_pkt_entry *pkt_entry, s
  * @param[in,out] pkt_entry Packet entry. Must be non-NULL.
  * @param[in] attr Packet attributes.
  */
-void efa_unit_test_handshake_pkt_construct(struct rxr_pkt_entry *pkt_entry, struct efa_unit_test_handshake_pkt_attr *attr)
+void efa_unit_test_handshake_pkt_construct(struct efa_rdm_pke *pkt_entry, struct efa_unit_test_handshake_pkt_attr *attr)
 {
 
 	int nex = (RXR_NUM_EXTRA_FEATURE_OR_REQUEST - 1) / 64 + 1;

--- a/prov/efa/test/efa_unit_test_cq.c
+++ b/prov/efa/test/efa_unit_test_cq.c
@@ -338,7 +338,7 @@ void test_ibv_cq_ex_read_bad_recv_status(struct efa_resource **state)
 {
 	struct efa_rdm_ep *efa_rdm_ep;
 	struct efa_resource *resource = *state;
-	struct rxr_pkt_entry *pkt_entry;
+	struct efa_rdm_pke *pkt_entry;
 	struct fi_cq_data_entry cq_entry;
 	struct fi_eq_err_entry eq_err_entry;
 	int ret;
@@ -346,7 +346,7 @@ void test_ibv_cq_ex_read_bad_recv_status(struct efa_resource **state)
 	efa_unit_test_resource_construct(resource, FI_EP_RDM);
 	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
 
-	pkt_entry = rxr_pkt_entry_alloc(efa_rdm_ep, efa_rdm_ep->efa_rx_pkt_pool, RXR_PKT_FROM_EFA_RX_POOL);
+	pkt_entry = efa_rdm_pke_alloc(efa_rdm_ep, efa_rdm_ep->efa_rx_pkt_pool, EFA_RDM_PKE_FROM_EFA_RX_POOL);
 	assert_non_null(pkt_entry);
 
 	efa_rdm_ep->ibv_cq_ex->start_poll = &efa_mock_ibv_start_poll_return_mock;
@@ -430,7 +430,7 @@ void test_ibv_cq_ex_read_failed_poll(struct efa_resource **state)
 static void test_impl_ibv_cq_ex_read_unknow_peer_ah(struct efa_resource *resource, bool remove_peer, bool support_efadv_cq)
 {
 	struct efa_rdm_ep *efa_rdm_ep;
-	struct rxr_pkt_entry *pkt_entry;
+	struct efa_rdm_pke *pkt_entry;
 	struct efa_ep_addr raw_addr = {0};
 	size_t raw_addr_len = sizeof(raw_addr);
 	fi_addr_t peer_addr = 0;
@@ -477,7 +477,7 @@ static void test_impl_ibv_cq_ex_read_unknow_peer_ah(struct efa_resource *resourc
 	peer->flags |= EFA_RDM_PEER_HANDSHAKE_SENT;
 
 	/* Setup packet entry */
-	pkt_entry = rxr_pkt_entry_alloc(efa_rdm_ep, efa_rdm_ep->efa_rx_pkt_pool, RXR_PKT_FROM_EFA_RX_POOL);
+	pkt_entry = efa_rdm_pke_alloc(efa_rdm_ep, efa_rdm_ep->efa_rx_pkt_pool, EFA_RDM_PKE_FROM_EFA_RX_POOL);
 	pkt_attr.msg_id = 0;
 	pkt_attr.connid = raw_addr.qkey;
 	/* Packet type must be in [RXR_REQ_PKT_BEGIN, RXR_EXTRA_REQ_PKT_END) */

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -103,7 +103,7 @@ void test_efa_rdm_ep_handshake_exchange_host_id(struct efa_resource **state, uin
 	struct fi_cq_data_entry cq_entry;
 	struct ibv_qp *ibv_qp;
 	struct efa_rdm_ep *efa_rdm_ep;
-	struct rxr_pkt_entry *pkt_entry;
+	struct efa_rdm_pke *pkt_entry;
 	uint64_t actual_peer_host_id = UINT64_MAX;
 
 	g_efa_unit_test_mocks.local_host_id = local_host_id;
@@ -131,7 +131,7 @@ void test_efa_rdm_ep_handshake_exchange_host_id(struct efa_resource **state, uin
 	assert_false(peer->flags && EFA_RDM_PEER_HANDSHAKE_SENT);
 
 	/* Setup rx packet entry. Manually increase counter to avoid underflow */
-	pkt_entry = rxr_pkt_entry_alloc(efa_rdm_ep, efa_rdm_ep->efa_rx_pkt_pool, RXR_PKT_FROM_EFA_RX_POOL);
+	pkt_entry = efa_rdm_pke_alloc(efa_rdm_ep, efa_rdm_ep->efa_rx_pkt_pool, EFA_RDM_PKE_FROM_EFA_RX_POOL);
 	efa_rdm_ep->efa_rx_pkts_posted++;
 
 	pkt_attr.connid = include_connid ? raw_addr.qkey : 0;
@@ -306,7 +306,7 @@ void test_efa_rdm_ep_pkt_pool_flags(struct efa_resource **state) {
 void test_efa_rdm_ep_pkt_pool_page_alignment(struct efa_resource **state)
 {
 	int ret;
-	struct rxr_pkt_entry *pkt_entry;
+	struct efa_rdm_pke *pkt_entry;
 	struct fid_ep *ep;
 	struct efa_rdm_ep *efa_rdm_ep;
 	struct efa_resource *resource = *state;
@@ -320,10 +320,10 @@ void test_efa_rdm_ep_pkt_pool_page_alignment(struct efa_resource **state)
 	efa_rdm_ep = container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
 	assert_int_equal(efa_rdm_ep->efa_rx_pkt_pool->entry_pool->attr.flags, OFI_BUFPOOL_NONSHARED);
 
-	pkt_entry = rxr_pkt_entry_alloc(efa_rdm_ep, efa_rdm_ep->efa_rx_pkt_pool, RXR_PKT_FROM_EFA_RX_POOL);
+	pkt_entry = efa_rdm_pke_alloc(efa_rdm_ep, efa_rdm_ep->efa_rx_pkt_pool, EFA_RDM_PKE_FROM_EFA_RX_POOL);
 	assert_non_null(pkt_entry);
 	assert_true(((uintptr_t)ofi_buf_region(pkt_entry)->alloc_region % ofi_get_page_size()) == 0);
-	rxr_pkt_entry_release_rx(efa_rdm_ep, pkt_entry);
+	efa_rdm_pke_release_rx(efa_rdm_ep, pkt_entry);
 
 	fi_close(&ep->fid);
 

--- a/prov/efa/test/efa_unit_test_rnr.c
+++ b/prov/efa/test/efa_unit_test_rnr.c
@@ -4,7 +4,7 @@
 /**
  * @brief this test validate that during RNR queuing and resending,
  * the "rnr_queued_pkt_cnt" in endpoint and peer were properly updated,
- * so is the RXR_PKT_ENTRY_RNR_RETRANSMIT flag.
+ * so is the EFA_RDM_PKE_RNR_RETRANSMIT flag.
  */
 void test_efa_rnr_queue_and_resend(struct efa_resource **state)
 {
@@ -13,7 +13,7 @@ void test_efa_rnr_queue_and_resend(struct efa_resource **state)
 	struct efa_ep_addr raw_addr;
 	struct efa_rdm_ep *efa_rdm_ep;
 	struct efa_rdm_ope *txe;
-	struct rxr_pkt_entry *pkt_entry;
+	struct efa_rdm_pke *pkt_entry;
 	size_t raw_addr_len = sizeof(raw_addr);
 	fi_addr_t peer_addr;
 	int ret;
@@ -44,13 +44,13 @@ void test_efa_rnr_queue_and_resend(struct efa_resource **state)
 
 	efa_rdm_ep_record_tx_op_completed(efa_rdm_ep, pkt_entry);
 	efa_rdm_ep_queue_rnr_pkt(efa_rdm_ep, &txe->queued_pkts, pkt_entry);
-	assert_int_equal(pkt_entry->flags & RXR_PKT_ENTRY_RNR_RETRANSMIT, RXR_PKT_ENTRY_RNR_RETRANSMIT);
+	assert_int_equal(pkt_entry->flags & EFA_RDM_PKE_RNR_RETRANSMIT, EFA_RDM_PKE_RNR_RETRANSMIT);
 	assert_int_equal(efa_rdm_ep->efa_rnr_queued_pkt_cnt, 1);
 	assert_int_equal(efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr)->rnr_queued_pkt_cnt, 1);
 
 	ret = efa_rdm_ep_send_queued_pkts(efa_rdm_ep, &txe->queued_pkts);
 	assert_int_equal(ret, 0);
-	assert_int_equal(pkt_entry->flags & RXR_PKT_ENTRY_RNR_RETRANSMIT, 0);
+	assert_int_equal(pkt_entry->flags & EFA_RDM_PKE_RNR_RETRANSMIT, 0);
 	assert_int_equal(efa_rdm_ep->efa_rnr_queued_pkt_cnt, 0);
 	assert_int_equal(efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr)->rnr_queued_pkt_cnt, 0);
 

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -62,9 +62,9 @@ void efa_unit_test_buff_construct(struct efa_unit_test_buff *buff, struct efa_re
 
 void efa_unit_test_buff_destruct(struct efa_unit_test_buff *buff);
 
-void efa_unit_test_eager_msgrtm_pkt_construct(struct rxr_pkt_entry *pkt_entry, struct efa_unit_test_eager_rtm_pkt_attr *attr);
+void efa_unit_test_eager_msgrtm_pkt_construct(struct efa_rdm_pke *pkt_entry, struct efa_unit_test_eager_rtm_pkt_attr *attr);
 
-void efa_unit_test_handshake_pkt_construct(struct rxr_pkt_entry *pkt_entry, struct efa_unit_test_handshake_pkt_attr *attr);
+void efa_unit_test_handshake_pkt_construct(struct efa_rdm_pke *pkt_entry, struct efa_unit_test_handshake_pkt_attr *attr);
 
 /* test cases */
 void test_av_insert_duplicate_raw_addr();


### PR DESCRIPTION
Another big step toward eliminating the deprecated term "rxr"