### PR TITLE
[v1.18.x] prov/efa: Only select readbase_rtm when both sides support rdma-read

### DIFF
--- a/prov/efa/src/rdm/rxr_msg.c
+++ b/prov/efa/src/rdm/rxr_msg.c
@@ -134,7 +134,7 @@ int rxr_msg_select_rtm(struct rxr_ep *rxr_ep, struct rxr_op_entry *tx_entry, int
 	readbase_rtm = rxr_pkt_type_readbase_rtm(peer, tx_entry->op, tx_entry->fi_flags, &hmem_info[iface]);
 
 	if (tx_entry->total_len >= hmem_info[iface].min_read_msg_size &&
-		efa_rdm_ep_support_rdma_read(rxr_ep) &&
+		efa_both_support_rdma_read(rxr_ep, peer) &&
 		(tx_entry->desc[0] || efa_is_cache_available(rxr_ep_domain(rxr_ep))))
 		return readbase_rtm;
 


### PR DESCRIPTION
Currently, rxr_msg_select_rtm return readbase_rtm if local ep support rdma-read. This is wrong because the read protocols require both local and peer support rdma-read. This patch fixes this issue.

Signed-off-by: Shi Jin <sjina@amazon.com>

(cherry picked from commit 085c21c)