### PR TITLE
prov/efa: eliminate the recv_wr in packet entry and sendv_pool

### DIFF
--- a/prov/efa/src/dgram/efa_dgram_ep.h
+++ b/prov/efa/src/dgram/efa_dgram_ep.h
@@ -58,6 +58,20 @@ struct efa_send_wr {
 	struct ibv_sge sge[2];
 };
 
+struct efa_recv_wr {
+	/** @brief Work request struct used by rdma-core */
+	struct ibv_recv_wr wr;
+
+	/** @brief Scatter gather element array
+	 *
+	 * @details
+	 * EFA device supports a maximum of 2 iov/SGE
+	 * For receive, we only use 1 SGE
+	 */
+	struct ibv_sge sge[1];
+};
+
+
 int efa_dgram_ep_open(struct fid_domain *domain_fid, struct fi_info *info,
 		      struct fid_ep **ep_fid, void *context);
 

--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -64,6 +64,7 @@ struct rxr_queued_copy {
  * The value was from EFA device's attribute (device->efa_attr.max_sq_wr)
  */
 #define EFA_RDM_EP_MAX_WR_PER_IBV_POST_SEND (4096)
+#define EFA_RDM_EP_MAX_WR_PER_IBV_POST_RECV (8192)
 
 struct efa_rdm_ep {
 	struct efa_base_ep base_ep;

--- a/prov/efa/src/rdm/efa_rdm_ep_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_utils.c
@@ -224,7 +224,7 @@ struct efa_rdm_ope *efa_rdm_ep_alloc_rxe(struct efa_rdm_ep *ep, fi_addr_t addr, 
  * @param[in]	rxe	rxe that contain user buffer information
  * @param[in]	flags		user supplied flags passed to fi_recv
  */
-int efa_rdm_ep_post_user_recv_buf(struct efa_rdm_ep *ep, struct efa_rdm_ope *rxe, uint64_t flags)
+int efa_rdm_ep_post_user_recv_buf(struct efa_rdm_ep *ep, struct efa_rdm_ope *rxe, size_t flags)
 {
 	struct efa_rdm_pke *pkt_entry;
 	struct efa_mr *mr;
@@ -259,7 +259,7 @@ int efa_rdm_ep_post_user_recv_buf(struct efa_rdm_ep *ep, struct efa_rdm_ope *rxe
 	pkt_entry->ope = rxe;
 	rxe->state = EFA_RDM_RXE_MATCHED;
 
-	err = efa_rdm_pke_recv(ep, pkt_entry, rxe->desc, flags);
+	err = efa_rdm_pke_recvv(ep, &pkt_entry, 1);
 	if (OFI_UNLIKELY(err)) {
 		efa_rdm_pke_release_rx(ep, pkt_entry);
 		EFA_WARN(FI_LOG_EP_CTRL,

--- a/prov/efa/src/rdm/efa_rdm_pke.c
+++ b/prov/efa/src/rdm/efa_rdm_pke.c
@@ -86,7 +86,6 @@ struct efa_rdm_pke *efa_rdm_pke_alloc(struct efa_rdm_ep *ep, struct rxr_pkt_pool
 #if ENABLE_DEBUG
 	dlist_init(&pkt_entry->dbg_entry);
 #endif
-
 	/* Initialize necessary fields in pkt_entry.
 	 * The memory region allocated by ofi_buf_alloc_ex is not initalized.
 	 */
@@ -95,7 +94,6 @@ struct efa_rdm_pke *efa_rdm_pke_alloc(struct efa_rdm_ep *ep, struct rxr_pkt_pool
 	pkt_entry->flags = EFA_RDM_PKE_IN_USE;
 	pkt_entry->next = NULL;
 	pkt_entry->ope = NULL;
-	pkt_entry->recv_wr.wr.next = NULL;
 	return pkt_entry;
 }
 

--- a/prov/efa/src/rdm/efa_rdm_pke.h
+++ b/prov/efa/src/rdm/efa_rdm_pke.h
@@ -265,9 +265,9 @@ int efa_rdm_pke_read(struct efa_rdm_ep *ep, struct efa_rdm_pke *pkt_entry,
 		       void *local_buf, size_t len, void *desc,
 		       uint64_t remote_buf, size_t remote_key);
 
-ssize_t efa_rdm_pke_recv(struct efa_rdm_ep *ep,
-			   struct efa_rdm_pke *pkt_entry, void **desc,
-			   uint64_t flags);
+ssize_t efa_rdm_pke_recvv(struct efa_rdm_ep *ep,
+			  struct efa_rdm_pke **pke_vec,
+			  int pke_cnt);
 
 int efa_rdm_pke_write(struct efa_rdm_ep *ep, struct efa_rdm_pke *pkt_entry,
 		       void *local_buf, size_t len, void *desc,

--- a/prov/efa/src/rdm/efa_rdm_pke.h
+++ b/prov/efa/src/rdm/efa_rdm_pke.h
@@ -70,18 +70,6 @@ struct rxr_pkt_sendv {
 	void *desc[2];
 };
 
-struct efa_recv_wr {
-	/** @brief Work request struct used by rdma-core */
-	struct ibv_recv_wr wr;
-
-	/** @brief Scatter gather element array
-	 *
-	 * @details
-	 * EFA device supports a maximum of 2 iov/SGE
-	 * For receive, we only use 1 SGE
-	 */
-	struct ibv_sge sge[1];
-};
 
 /**
  * @brief Packet entry
@@ -203,13 +191,7 @@ struct efa_rdm_pke {
 	 */
 	struct rxr_pkt_sendv *send;
 
-	/**
-	 * @brief Work request struct used by rdma-core for receive.
-	 * @todo move this field out of efa_rdm_pke to a separate pool.
-	 */
-	struct efa_recv_wr recv_wr;
-
-	uint8_t pad2[8];
+	uint8_t pad2[56];
 
 	/** @brief buffer that contains data that is going over wire */
 	char wiredata[0];

--- a/prov/efa/src/rdm/rxr_pkt_pool.h
+++ b/prov/efa/src/rdm/rxr_pkt_pool.h
@@ -42,7 +42,6 @@ struct efa_rdm_ep;
 
 struct rxr_pkt_pool {
 	struct ofi_bufpool *entry_pool;
-	struct ofi_bufpool *sendv_pool;
 };
 
 int rxr_pkt_pool_create(struct efa_rdm_ep *ep,


### PR DESCRIPTION
a series of patches that eliminates the recv_wr in packet entry and the sendv_pool, and clean up space in `efa_rdm_pke`