### PR TITLE
prov/sm2: Fix locking

### DIFF
--- a/prov/sm2/src/sm2_msg.c
+++ b/prov/sm2/src/sm2_msg.c
@@ -182,6 +182,7 @@ static ssize_t sm2_generic_inject(struct fid_ep *ep_fid, const void *buf,
 
 	peer_smr = sm2_peer_region(ep, peer_gid);
 
+	ofi_spin_lock(&ep->tx_lock);
 	ret = sm2_proto_ops[sm2_proto_inject](ep, peer_smr, peer_gid, op, tag,
 					      data, op_flags, NULL, &msg_iov, 1,
 					      len, NULL);
@@ -189,6 +190,7 @@ static ssize_t sm2_generic_inject(struct fid_ep *ep_fid, const void *buf,
 	if (!ret)
 		ofi_ep_tx_cntr_inc_func(&ep->util_ep, op);
 
+	ofi_spin_unlock(&ep->tx_lock);
 	return ret;
 }
 

--- a/prov/sm2/src/sm2_progress.c
+++ b/prov/sm2/src/sm2_progress.c
@@ -227,9 +227,11 @@ void sm2_progress_recv(struct sm2_ep *ep)
 						"completion\n");
 			}
 
+			ofi_spin_lock(&ep->tx_lock);
 			smr_freestack_push(
 				sm2_freestack(sm2_mmap_ep_region(map, ep->gid)),
 				xfer_entry);
+			ofi_spin_unlock(&ep->tx_lock);
 			continue;
 		}
 


### PR DESCRIPTION
Add tx_lock to generic inject path.
Add tx_lock (which currently controls freestack access) to buffer return.