### PR TITLE
fabtests: Fix array OOB during fabtest list parsing

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -3258,7 +3258,6 @@ void ft_parse_opts_list(char* optarg)
 	token = strtok(optarg, ",");
 	test_cnt = 0;
 	while (token != NULL) {
-		user_test_sizes[i].enable_flags = 0;
 		ret = sscanf(token, "%zu", &user_test_sizes[test_cnt].size);
 		if (ret != 1) {
 			fprintf(stderr, "Cannot parse integer \"%s\" in list.\n",token);


### PR DESCRIPTION
An incorrect index was used to attempt to set test_sizes.enable_flags. For small list sizes (<3 chars) malloc would become corrupted and future calls would fail unexpectedly.

Setting this variable to 0 was uncessary as the calloc() cleared the memory already.