### PR TITLE
prov/efa: set and use pke->payload and pke->payload_size

### DIFF
--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -895,6 +895,7 @@
     <ClCompile Include="prov\efa\src\rdm\efa_rdm_msg.c" />
     <ClCompile Include="prov\efa\src\rdm\rxr_pkt_cmd.c" />
     <ClCompile Include="prov\efa\src\rdm\efa_rdm_pke.c" />
+    <ClCompile Include="prov\efa\src\rdm\efa_rdm_pke_utils.c" />
     <ClCompile Include="prov\efa\src\rdm\rxr_pkt_pool.c" />
     <ClCompile Include="prov\efa\src\rdm\rxr_pkt_type_data.c" />
     <ClCompile Include="prov\efa\src\rdm\rxr_pkt_type_misc.c" />

--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -59,6 +59,7 @@ _efa_files = \
 	prov/efa/src/rdm/efa_rdm_rma.c	\
 	prov/efa/src/rdm/efa_rdm_msg.c	\
 	prov/efa/src/rdm/efa_rdm_pke.c \
+	prov/efa/src/rdm/efa_rdm_pke_utils.c \
 	prov/efa/src/rdm/rxr_pkt_type_req.c \
 	prov/efa/src/rdm/rxr_pkt_type_base.c \
 	prov/efa/src/rdm/rxr_pkt_type_data.c \
@@ -97,8 +98,8 @@ _efa_headers = \
 	prov/efa/src/rdm/efa_rdm_ep.h \
 	prov/efa/src/rdm/efa_rdm_rma.h \
 	prov/efa/src/rdm/efa_rdm_msg.h \
-	prov/efa/src/rdm/rxr_pkt_hdr.h \
 	prov/efa/src/rdm/efa_rdm_pke.h \
+	prov/efa/src/rdm/efa_rdm_pke_utils.h \
 	prov/efa/src/rdm/efa_rdm_pkt_type.h \
 	prov/efa/src/rdm/rxr_pkt_type.h \
 	prov/efa/src/rdm/rxr_pkt_type_req.h \

--- a/prov/efa/src/efa_mr.h
+++ b/prov/efa/src/efa_mr.h
@@ -33,7 +33,8 @@
 #ifndef EFA_MR_H
 #define EFA_MR_H
 
-#include "efa.h"
+#include <stdbool.h>
+#include <ofi_mr.h>
 
 /*
  * Descriptor returned for FI_HMEM peer memory registrations
@@ -65,6 +66,8 @@ struct efa_mr {
 extern int efa_mr_cache_enable;
 extern size_t efa_mr_max_cached_count;
 extern size_t efa_mr_max_cached_size;
+
+struct efa_domain;
 
 int efa_mr_cache_open(struct ofi_mr_cache **cache, struct efa_domain *domain);
 

--- a/prov/efa/src/rdm/efa_rdm_pke.c
+++ b/prov/efa/src/rdm/efa_rdm_pke.c
@@ -211,11 +211,22 @@ void efa_rdm_pke_copy(struct efa_rdm_ep *ep,
 	 * from src_pkt to the beginning of dest_pkt->wiredata.
 	 */
 	if (dest->alloc_type == EFA_RDM_PKE_FROM_READ_COPY_POOL) {
-		src_pkt_offset = rxr_pkt_req_data_offset(src);
+		assert(src->payload_size > 0);
+		assert(src->payload);
+		src_pkt_offset = src->payload - src->wiredata;
 		dest->pkt_size = src->pkt_size - src_pkt_offset;
+		dest->payload = dest->wiredata;
+		dest->payload_size = dest->pkt_size;
+		dest->payload_mr = dest->mr;
 	} else {
 		src_pkt_offset = 0;
 		dest->pkt_size = src->pkt_size;
+		if (src->payload_size > 0) {
+			assert(src->payload);
+			dest->payload = (src->payload - src->wiredata) + dest->wiredata;
+			dest->payload_size = src->payload_size;
+			dest->payload_mr = dest->mr;
+		}
 	}
 	dest->addr = src->addr;
 	dest->flags = EFA_RDM_PKE_IN_USE;

--- a/prov/efa/src/rdm/efa_rdm_pke.h
+++ b/prov/efa/src/rdm/efa_rdm_pke.h
@@ -34,6 +34,8 @@
 #ifndef _EFA_RDM_PKE_H
 #define _EFA_RDM_PKE_H
 
+#include <uthash.h>
+#include <ofi_mem.h>
 #include <ofi_list.h>
 
 #define EFA_RDM_PKE_IN_USE		BIT_ULL(0) /**< this packet entry is being used */

--- a/prov/efa/src/rdm/efa_rdm_pke_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_utils.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include <rdma/fi_rma.h>
+#include "efa_mr.h"
+#include "efa_hmem.h"
+#include "efa_rdm_pke.h"
+#include "rxr_pkt_type.h"
+#include "efa_rdm_pkt_type.h"
+#include "efa_rdm_protocol.h"
+#include "rxr_pkt_type_req.h"
+
+/**
+ * @brief determine the payload offset of a received packet.
+ *
+ * For a packet receive overwire, the payload is in the wiredata,
+ * immediately after header and optional user buffer information.
+ * This function find the offset of payoff in respect of wiredata.
+ *
+ * @param[in]	pkt_entry	received paket entry
+ * @return	an integer offset
+ */
+size_t efa_rdm_pke_get_payload_offset(struct efa_rdm_pke *pkt_entry)
+{
+	struct rxr_base_hdr *base_hdr;
+	int pkt_type, read_iov_count;
+	size_t payload_offset;
+
+	assert(pkt_entry->alloc_type != EFA_RDM_PKE_FROM_EFA_TX_POOL);
+
+	/* packet entry from read copy pool contains only payload
+	 * in its wire data (no header, no optional user buffer
+	 * information)
+	 */
+	if (pkt_entry->alloc_type == EFA_RDM_PKE_FROM_READ_COPY_POOL)
+		return 0;
+
+	base_hdr = rxr_get_base_hdr(pkt_entry->wiredata);
+	pkt_type = base_hdr->type;
+	assert(efa_rdm_pkt_type_contains_data(pkt_type));
+	if (efa_rdm_pkt_type_is_req(pkt_type)) {
+		payload_offset = rxr_pkt_req_hdr_size_from_pkt_entry(pkt_entry);
+		assert(payload_offset > 0);
+
+		if (pkt_type == RXR_RUNTREAD_MSGRTM_PKT ||
+		    pkt_type == RXR_RUNTREAD_TAGRTM_PKT) {
+			read_iov_count = rxr_get_runtread_rtm_base_hdr(pkt_entry->wiredata)->read_iov_count;
+			payload_offset +=  read_iov_count * sizeof(struct fi_rma_iov);
+		}
+
+		return payload_offset;
+	}
+
+	if (pkt_type == RXR_DATA_PKT) {
+		payload_offset = sizeof(struct rxr_data_hdr);
+		if (base_hdr->flags & RXR_PKT_CONNID_HDR)
+			payload_offset += sizeof(struct rxr_data_opt_connid_hdr);
+		return payload_offset;
+	}
+
+	if (pkt_type == RXR_READRSP_PKT)
+		return sizeof(struct rxr_readrsp_hdr);
+
+	if (pkt_type == RXR_ATOMRSP_PKT)
+		return sizeof(struct rxr_atomrsp_hdr);
+
+	/* all packet types that can contain data has been processed.
+	 * we should never reach here;
+	 */
+	assert(0);
+	return -1;
+}

--- a/prov/efa/src/rdm/efa_rdm_pkt_type.h
+++ b/prov/efa/src/rdm/efa_rdm_pkt_type.h
@@ -205,4 +205,32 @@ bool efa_rdm_pkt_type_contains_data(int pkt_type)
 	       efa_rdm_pkt_type_is_rta(pkt_type);
 }
 
+/**
+ * @brief determine whether a pack type is req packet
+ *
+ * @returns a boolean
+ */
+static inline
+bool efa_rdm_pkt_type_is_req(int pkt_type)
+{
+	if (pkt_type >= RXR_REQ_PKT_BEGIN) {
+		assert(pkt_type < RXR_BASELINE_REQ_PKT_END ||
+		       (pkt_type >= RXR_EXTRA_REQ_PKT_BEGIN &&
+		        pkt_type < RXR_EXTRA_REQ_PKT_END));
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * @brief determine whether a packet type has "seg_offset" field in it.
+ *
+ */
+static inline
+bool efa_rdm_pkt_type_contains_seg_offset(int pkt_type)
+{
+	return efa_rdm_pkt_type_is_mulreq(pkt_type) || pkt_type == RXR_DATA_PKT;
+}
+
 #endif

--- a/prov/efa/src/rdm/rxr_pkt_type_base.h
+++ b/prov/efa/src/rdm/rxr_pkt_type_base.h
@@ -45,11 +45,8 @@ int rxr_pkt_init_data_from_ope(struct efa_rdm_ep *ep,
 				    size_t op_data_offset,
 				    size_t data_size);
 
-ssize_t rxr_pkt_copy_data_to_ope(struct efa_rdm_ep *ep,
-				      struct efa_rdm_ope *rxe,
-				      size_t data_offset,
-				      struct efa_rdm_pke *pkt_entry,
-				      char *data, size_t data_size);
+ssize_t efa_rdm_pke_copy_payload(struct efa_rdm_pke *pke,
+				 struct efa_rdm_ope *ope);
 
 size_t rxr_pkt_data_size(struct efa_rdm_pke *pkt_entry);
 

--- a/prov/efa/src/rdm/rxr_pkt_type_data.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_data.c
@@ -165,8 +165,7 @@ void rxr_pkt_proc_data(struct efa_rdm_ep *ep,
 		ep->pending_recv_counter--;
 	}
 #endif
-	err = rxr_pkt_copy_data_to_ope(ep, ope, seg_offset,
-					    pkt_entry, data, seg_size);
+	err = efa_rdm_pke_copy_payload(pkt_entry, ope);
 	if (err) {
 		efa_rdm_pke_release_rx(ep, pkt_entry);
 		efa_rdm_rxe_handle_error(ope, -err, FI_EFA_ERR_RXE_COPY);

--- a/prov/efa/src/rdm/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_misc.c
@@ -409,7 +409,6 @@ void rxr_pkt_handle_rma_read_completion(struct efa_rdm_ep *ep,
 	struct efa_rdm_ope *rxe;
 	struct efa_rdm_pke *data_pkt_entry;
 	struct efa_rdm_rma_context_pkt *rma_context_pkt;
-	size_t data_size;
 	int err;
 
 	rma_context_pkt = (struct efa_rdm_rma_context_pkt *)context_pkt_entry->wiredata;
@@ -417,7 +416,6 @@ void rxr_pkt_handle_rma_read_completion(struct efa_rdm_ep *ep,
 	assert(rma_context_pkt->context_type == RXR_READ_CONTEXT);
 
 	x_entry_type = context_pkt_entry->ope->type;
-
 	if (x_entry_type == EFA_RDM_TXE) {
 		txe = context_pkt_entry->ope;
 		assert(txe->op == ofi_op_read_req);
@@ -425,9 +423,9 @@ void rxr_pkt_handle_rma_read_completion(struct efa_rdm_ep *ep,
 		if (txe->bytes_read_total_len == txe->bytes_read_completed) {
 			if (txe->addr == FI_ADDR_NOTAVAIL) {
 				data_pkt_entry = txe->local_read_pkt_entry;
-				data_size = rxr_pkt_data_size(data_pkt_entry);
-				assert(data_size > 0);
-				rxr_pkt_handle_data_copied(ep, data_pkt_entry, data_size);
+				assert(data_pkt_entry->payload_size > 0);
+				rxr_pkt_handle_data_copied(ep, data_pkt_entry,
+							   data_pkt_entry->payload_size);
 			} else {
 				assert(txe && txe->cq_entry.flags & FI_READ);
 				efa_rdm_txe_report_completion(txe);


### PR DESCRIPTION
This patch added following changes to properly set payload and payload_size of a packet:

1. Upon receiving a packet, set its payload and payload_size if the packet contains data.

2. When clone a packet, set cloned packet's payload and payload_size if the packet contains data.

With the above changes, a packet's payload and payload_size is always set properly.  This patch then started using payload and payload_size:

1. it used payload_size to replace fucntion calls to rxr_pkt_data_size() and rxr_pkt_req_data_size(), and eliminated these two functions.

2. it used payload in rxr_pkt_copy_data_to_ope() and renamed the function efa_rdm_pke_copy_payload()

It then eliminated two functions that calculate payload size on the fly: rxr_pkt_data_size() rxr_pkt_req_data_size()