### PR TITLE
contrib/intel/jenkins: Add missing tests from cloudbees migration back to summarizer.

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -496,21 +496,24 @@ pipeline {
             script {
               dir ("${env.WORKSPACE}/${SCRIPT_LOCATION}/") {
                 def providers = [["shm", null]]
+                def directions = ["h2d", "d2d", "xd2d"]
                 def base_cmd = "python3.9 runtests.py --device=ze"
-                def prefix = "${env.LOG_DIR}/ze-shm_"
+                def prefix = "${env.LOG_DIR}/ze_"
                 def suffix = "_reg"
                 for (prov in providers) {
-                  if (prov[1]) {
-                    echo "Running ${prov[0]}-${prov[1]} ze-shm"
-                    slurm_batch("charmander", "1",
-                                "${prefix}${prov[0]}-${prov[1]}${suffix}",
+                  for (way in directions) {
+                    if (prov[1]) {
+                      echo "Running ${prov[0]}-${prov[1]} ze"
+                      slurm_batch("charmander", "1",
+                                "${prefix}${prov[0]}-${prov[1]}_${way}${suffix}",
                                 """${base_cmd} --prov=${prov[0]} \
-                                --util=${prov[1]}""")
-                  } else {
-                    echo "Running ${prov[0]} ze-shm"
-                    slurm_batch("charmander", "1",
-                                "${prefix}${prov[0]}${suffix}",
-                                "${base_cmd} --prov=${prov[0]}")
+                                --util=${prov[1]} --way=${way}""")
+                    } else {
+                      echo "Running ${prov[0]} ze"
+                      slurm_batch("charmander", "1",
+                                  "${prefix}${prov[0]}_${way}${suffix}",
+                                  "${base_cmd} --prov=${prov[0]} --way=${way}")
+                    }
                   }
                 }
               }

--- a/contrib/intel/jenkins/run.py
+++ b/contrib/intel/jenkins/run.py
@@ -91,7 +91,7 @@ def multinodetest(core, hosts, mode, user_env, util):
               .format(runmultinodetest.testname))
     print("-------------------------------------------------------------------")
 
-def ze_fabtests(core, hosts, mode, user_env, util):
+def ze_fabtests(core, hosts, mode, way, user_env, util):
 
     runzefabtests = tests.ZeFabtests(jobname=jbname,buildno=bno,
                                      testname="ze test", core_prov=core,
@@ -101,12 +101,8 @@ def ze_fabtests(core, hosts, mode, user_env, util):
 
     print('-------------------------------------------------------------------')
     if (runzefabtests.execute_condn):
-        print(f"Running ze h2d tests for {core}-{util}-{fab}")
-        runzefabtests.execute_cmd('h2d')
-        print(f"Running ze d2d tests for {core}-{util}-{fab}")
-        runzefabtests.execute_cmd('d2d')
-        print(f"Running ze xd2d tests for {core}-{util}-{fab}")
-        runzefabtests.execute_cmd('xd2d')
+        print(f"Running ze {way} tests for {core}-{util}-{fab}")
+        runzefabtests.execute_cmd(way)
     else:
         print(f"Skipping {core} {runzefabtests.testname} as execute condition fails")
     print('-------------------------------------------------------------------')

--- a/contrib/intel/jenkins/runtests.py
+++ b/contrib/intel/jenkins/runtests.py
@@ -28,6 +28,8 @@ parser.add_argument('--test', help="specify test to execute", \
 parser.add_argument('--imb_grp', help="IMB test group 1:[MPI1, P2P], \
                     2:[EXT, IO], 3:[NBC, RMA, MT]", choices=['1', '2', '3'])
 parser.add_argument('--device', help="optional gpu device", choices=['ze'])
+parser.add_argument('--way', help="direction to run with device option",
+                    choices=['h2d', 'd2d', 'xd2d'], default='h2d')
 parser.add_argument('--user_env', help="Run with additional environment " \
                     "variables", nargs='*', action=ParseDict, default={})
 parser.add_argument('--mpi', help="Select mpi to use for middlewares",
@@ -56,6 +58,7 @@ else:
     imb_group = '1'
 
 mpi = args.mpi
+way = args.way
 
 hosts = []
 if 'slurm' in os.environ['FABRIC']:
@@ -134,7 +137,7 @@ if(args_core):
                                 ofi_build_mode, user_env,
                                 args_util)
     else:
-        run.ze_fabtests(args_core, hosts, ofi_build_mode, user_env,
+        run.ze_fabtests(args_core, hosts, ofi_build_mode, way, user_env,
                         args_util)
 
 else:

--- a/contrib/intel/jenkins/summary.py
+++ b/contrib/intel/jenkins/summary.py
@@ -278,7 +278,7 @@ class OnecclSummarizer(Summarizer):
                    f"{tokens[len(tokens) - 1]}"
 
     def check_pass(self, line):
-        if 'passed' in line:
+        if 'passed' in line or "all done" in line:
             self.passes += 1
             self.passed_tests.append(self.name)
 
@@ -291,17 +291,24 @@ class ShmemSummarizer(Summarizer):
     def __init__(self, logger, log_dir, prov, file_name, stage_name):
         super().__init__(logger, log_dir, prov, file_name, stage_name)
         self.shmem_type = {
-            'uh'    : { 'func' : self.check_uh,
-                        'keyphrase' : 'summary'
+            'uh'    : { 'func'      : self.check_uh,
+                        'keyphrase' : 'summary',
+                        'passes'    : 0,
+                        'fails'     : 0
                       },
-            'isx'   : { 'func' : self.check_isx,
-                        'keyphrase' : 'scaling'
+            'isx'   : { 'func'      : self.check_isx,
+                        'keyphrase' : 'scaling',
+                        'passes'    : 0,
+                        'fails'     : 0
                       },
-            'prk'   : { 'func' : self.check_prk,
-                        'keyphrase' : 'solution'
+            'prk'   : { 'func'      : self.check_prk,
+                        'keyphrase' : 'solution',
+                        'passes'    : 0,
+                        'fails'     : 0
                       }
         }
-        self.keyphrase = self.shmem_type[self.prov]['keyphrase']
+        self.test_type = 'prk'
+        self.keyphrase = self.shmem_type[self.test_type]['keyphrase']
         self.name = 'no_test'
 
     def check_uh(self, line, log_file):
@@ -313,10 +320,10 @@ class ShmemSummarizer(Summarizer):
                 if 'test_' in token:
                     self.name = token
             if tokens[len(tokens) - 1] == 'ok':
-                self.passes += 1
+                self.shmem_type[self.test_type]['passes'] += 1
                 self.passed_tests.append(self.name)
             else:
-                self.fails += 1
+                self.shmem_type[self.test_type]['fails'] += 1
                 self.failed_tests.append(self.name)
         # Summary
         # x/z Passed.
@@ -325,24 +332,26 @@ class ShmemSummarizer(Summarizer):
             passed = log_file.readline().lower()
             failed = log_file.readline().lower()
             token = int(passed.split()[1].split('/')[0])
-            if self.passes != token:
+            if self.shmem_type[self.test_type]['passes'] != token:
                 self.logger.log(
-                    f"passes {self.passes} do not match log reported passes "\
-                    f"{token}"
+                    f"passes {self.shmem_type[self.test_type]['passes']} do " \
+                    f"not match log reported passes {token}"
                 )
             token = int(failed.split()[1].split('/')[0])
-            if self.fails != int(token):
+            if self.shmem_type[self.test_type]['fails'] != int(token):
                 self.logger.log(
-                    f"fails {self.fails} does not match log fails "\
-                    f"{token}"
+                    f"fails {self.shmem_type[self.test_type]['fails']} does "\
+                    f"not match log fails {token}"
                 )
 
     def check_prk(self, line, log_file=None):
         if self.keyphrase in line:
-            self.passes += 1
+            self.shmem_type[self.test_type]['passes'] += 1
         if 'error:' in line or "exiting with" in line:
-            self.fails += 1
-            self.failed_tests.append(f"{self.prov} {self.passes + self.fails}")
+            self.shmem_type[self.test_type]['fails'] += 1
+            p = self.shmem_type[self.test_type]['passes']
+            f = self.shmem_type[self.test_type]['fails']
+            self.failed_tests.append(f"{self.prov} {p + f}")
         if 'test(s)' in line:
             token = line.split()[0]
             if self.fails != int(token):
@@ -353,32 +362,47 @@ class ShmemSummarizer(Summarizer):
 
     def check_isx(self, line, log_file=None):
         if self.keyphrase in line:
-            self.passes += 1
+            self.shmem_type[self.test_type]['passes'] += 1
         if ('failed' in line and 'test(s)' not in line) or \
             "exiting with" in line:
-            self.fails += 1
-            self.failed_tests.append(f"{self.prov} {self.passes + self.fails}")
+            self.shmem_type[self.test_type]['fails'] += 1
+            p = self.shmem_type[self.test_type]['passes']
+            f = self.shmem_type[self.test_type]['fails']
+            self.failed_tests.append(f"{self.prov} {p + f}")
         if 'test(s)' in line:
             token = line.split()[0]
-            if int(token) != self.fails:
+            if int(token) != self.shmem_type[self.test_type]['fails']:
                 self.logger.log(
-                    f"fails {self.fails} does not match log reported fails " \
-                    f"{int(token)}"
+                    f"fails {self.shmem_type[self.test_type]['fails']} does " \
+                    f"not match log reported fails {int(token)}"
                 )
 
     def check_fails(self, line):
         if "exiting with" in line:
-            self.fails += 1
-            self.failed_tests.append(f"{self.prov} {self.passes + self.fails}")
+            self.shmem_type[self.test_type]['fails'] += 1
+            p = self.shmem_type[self.test_type]['passes']
+            f = self.shmem_type[self.test_type]['fails']
+            self.failed_tests.append(f"{self.prov} {p + f}")
+
+    def check_test_type(self, line):
+        if "running shmem" in line:
+            self.test_type = line.split(' ')[2].lower()
+            self.keyphrase = self.shmem_type[self.test_type]['keyphrase']
 
     def check_line(self, line, log_file):
-        self.shmem_type[self.prov]['func'](line, log_file)
-        self.check_fails(line)
+        self.check_test_type(line)
+        if self.test_type is not None:
+            self.shmem_type[self.test_type]['func'](line, log_file)
+            self.check_fails(line)
 
     def read_file(self):
         with open(self.file_path, 'r') as log_file:
             for line in log_file:
                 self.check_line(line.lower(), log_file)
+
+        for key in self.shmem_type.keys():
+            self.passes += self.shmem_type[key]['passes']
+            self.fails += self.shmem_type[key]['fails']
 
 class MpichTestSuiteSummarizer(Summarizer):
     def __init__(self, logger, log_dir, prov, mpi, file_name, stage_name):
@@ -599,38 +623,39 @@ def summarize_items(summary_item, logger, log_dir, mode):
             err += ret if ret else 0
 
     if summary_item == 'oneccl' or summary_item == 'all':
-        ret = OnecclSummarizer(
-            logger, log_dir, 'oneCCL',
-            f'oneCCL_oneccl_{mode}',
-            f'oneCCL {mode}'
-        ).summarize()
-        err += ret if ret else 0
-        ret = OnecclSummarizer(
-            logger, log_dir, 'oneCCL-GPU',
-            f'oneCCL-GPU_onecclgpu_{mode}',
-            f'oneCCL-GPU {mode}'
-        ).summarize()
+        for prov in ['tcp-rxm', 'verbs-rxm']:
+            ret = OnecclSummarizer(
+                logger, log_dir, 'oneCCL',
+                f'oneCCL_{prov}_oneccl_{mode}',
+                f'oneCCL {prov} {mode}'
+            ).summarize()
+            err += ret if ret else 0
+            ret = OnecclSummarizer(
+                logger, log_dir, 'oneCCL-GPU',
+                f'oneCCL-GPU_{prov}_onecclgpu_{mode}',
+                f'oneCCL-GPU {prov} {mode}'
+            ).summarize()
         err += ret if ret else 0
 
     if summary_item == 'shmem' or summary_item == 'all':
-        shmem_types = ['uh', 'prk', 'isx']
-        for type in shmem_types:
+        for prov in ['tcp', 'verbs', 'sockets']:
             ret= ShmemSummarizer(
-                logger, log_dir, f'{type}',
-                f'SHMEM_{type}_shmem_{mode}',
-                f'shmem {type} {mode}'
+                logger, log_dir, prov,
+                f'SHMEM_{prov}_shmem_{mode}',
+                f'shmem {prov} {mode}'
             ).summarize()
         err += ret if ret else 0
 
     if summary_item == 'ze' or summary_item == 'all':
         test_types = ['h2d', 'd2d', 'xd2d']
         for type in test_types:
-            ret = FabtestsSummarizer(
-                logger, log_dir, 'shm',
-                f'ze-{prov}_{type}_{mode}',
-                f"ze {prov} {type} {mode}"
-            ).summarize()
-            err += ret if ret else 0
+            for prov in ['shm']:
+                ret = FabtestsSummarizer(
+                    logger, log_dir, 'shm',
+                    f'ze_{prov}_{type}_{mode}',
+                    f"ze {prov} {type} {mode}"
+                ).summarize()
+                err += ret if ret else 0
 
     if ((summary_item == 'daos' or summary_item == 'all')
          and mode == 'reg'):


### PR DESCRIPTION
Tests missing from summary due to typos that will be added back: oneCCL reg
oneCCL-GPU reg
shmem prov tests (isx, uh, prk)
ze shm h2d reg
ze shm d2d reg
ze shm xd2d reg

Fixing summary.py's expectation of these filenames will bring these tests back to the summary stage. Changing how filenames are generated will also help with some cases and have names make more sense.