### PR TITLE
prov/efa: include header to fix compilation warning

### DIFF
--- a/prov/efa/src/efa_hmem.c
+++ b/prov/efa/src/efa_hmem.c
@@ -32,6 +32,7 @@
 
 #include "efa.h"
 #include "efa_hmem.h"
+#include "rdm/rxr_pkt_type_req.h"
 
 #if HAVE_CUDA || HAVE_NEURON
 static size_t efa_max_eager_msg_size_with_largest_header(struct efa_domain *efa_domain) {

--- a/prov/efa/src/efa_prov_info.c
+++ b/prov/efa/src/efa_prov_info.c
@@ -39,6 +39,8 @@
 
 #include "efa.h"
 #include "rdm/efa_rdm_cq.h"
+#include "rdm/rxr_pkt_type_req.h"
+
 #if HAVE_EFA_DL
 #include <ofi_shm.h>
 #endif


### PR DESCRIPTION
efa_hmem.c and efa_prov_info.c did not include
rxr_pkt_type_req.h therefore cannot find rxr_pkt_max_hdr_size() during compilation. This patch fixed the issue.