### PR TITLE
prov/efa: Add missing locking around cntr progress

### DIFF
--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -67,3 +67,14 @@ def test_rdm_tagged_peek(cmdline_args):
 
     test = ClientServerTest(cmdline_args, "fi_rdm_tagged_peek", timeout=1800)
     test.run()
+
+@pytest.mark.functional
+def test_rdm_with_cntr(cmdline_args):
+    from common import ClientServerTest
+
+    # TODO: remove this skip after getting cntr works on single node.
+    if cmdline_args.server_id == cmdline_args.client_id:
+        pytest.skip("This test requires 2 nodes")
+        return
+
+    test = ClientServerTest(cmdline_args, "fi_rdm_pingpong -t counter", timeout=1800)

--- a/prov/efa/src/efa_cntr.c
+++ b/prov/efa/src/efa_cntr.c
@@ -74,6 +74,16 @@ static int efa_cntr_wait(struct fid_cntr *cntr_fid, uint64_t threshold, int time
 	return ret;
 }
 
+static void efa_cntr_progress(struct util_cntr *cntr)
+{
+	struct util_srx_ctx *srx_ctx;
+	srx_ctx = cntr->domain->srx->ep_fid.fid.context;
+
+	ofi_genlock_lock(srx_ctx->lock);
+	ofi_cntr_progress(cntr);
+	ofi_genlock_unlock(srx_ctx->lock);
+}
+
 int efa_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 		  struct fid_cntr **cntr_fid, void *context)
 {
@@ -85,7 +95,7 @@ int efa_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 		return -FI_ENOMEM;
 
 	ret = ofi_cntr_init(&efa_prov, domain, attr, cntr,
-			    &ofi_cntr_progress, context);
+			    &efa_cntr_progress, context);
 	if (ret)
 		goto free;
 


### PR DESCRIPTION
ofi_cntr_progress will call ep->progress for every ep
    it was bound to. There was a ep->lock in efa_rdm_ep_progress,
    but it was recently changed to srx_ctx->lock
    and moved from efa_rdm_ep_progress() to its upper layer callers.
    This patch adds this locking around ofi_cntr_progress.

Also added a test that poll completions with cntr instead of queue, to cover this code path.