### PR TITLE
prov/efa: Fix a bug in desc convert and adding tests

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -129,7 +129,8 @@ nodist_prov_efa_test_efa_unit_test_SOURCES = \
 	prov/efa/test/efa_unit_test_hmem.c \
 	prov/efa/test/efa_unit_test_srx.c \
 	prov/efa/test/efa_unit_test_rnr.c \
-	prov/efa/test/efa_unit_test_ope.c
+	prov/efa/test/efa_unit_test_ope.c \
+	prov/efa/test/efa_unit_test_send.c
 
 efa_CPPFLAGS += -I$(top_srcdir)/include -I$(top_srcdir)/prov/efa/test $(cmocka_CPPFLAGS)
 

--- a/prov/efa/src/rdm/efa_rdm_msg.c
+++ b/prov/efa/src/rdm/efa_rdm_msg.c
@@ -308,7 +308,8 @@ ssize_t efa_rdm_msg_sendv(struct fid_ep *ep, const struct iovec *iov,
 	peer = efa_rdm_ep_get_peer(efa_rdm_ep, dest_addr);
 	assert(peer);
 	if (peer->is_local && efa_rdm_ep->use_shm_for_tx) {
-		efa_rdm_get_desc_for_shm(count, desc, shm_desc);
+		if (desc)
+			efa_rdm_get_desc_for_shm(count, desc, shm_desc);
 		return fi_sendv(efa_rdm_ep->shm_ep, iov, shm_desc, count, peer->shm_fiaddr, context);
 	}
 

--- a/prov/efa/test/efa_unit_test_common.c
+++ b/prov/efa/test/efa_unit_test_common.c
@@ -3,6 +3,35 @@
 #include "efa_rdm_pke_nonreq.h"
 #include "rxr_pkt_type_req.h"
 
+void efa_unit_test_construct_msg(struct fi_msg *msg, struct iovec *iov,
+				 size_t iov_count, fi_addr_t addr,
+				 void *context, uint64_t data,
+				 void **desc)
+{
+	msg->msg_iov = iov;
+	msg->iov_count = iov_count;
+	msg->addr = addr;
+	msg->context = context;
+	msg->data = data;
+	msg->desc = desc;
+}
+
+void efa_unit_test_construct_tmsg(struct fi_msg_tagged *tmsg, struct iovec *iov,
+				  size_t iov_count, fi_addr_t addr,
+				  void *context, uint64_t data,
+				  void **desc, uint64_t tag,
+				  uint64_t ignore)
+{
+	tmsg->msg_iov = iov;
+	tmsg->iov_count = iov_count;
+	tmsg->addr = addr;
+	tmsg->context = context;
+	tmsg->data = data;
+	tmsg->desc = desc;
+	tmsg->tag = tag;
+	tmsg->ignore = ignore;
+}
+
 struct fi_info *efa_unit_test_alloc_hints(enum fi_ep_type ep_type)
 {
 	struct fi_info *hints;

--- a/prov/efa/test/efa_unit_test_ope.c
+++ b/prov/efa/test/efa_unit_test_ope.c
@@ -10,7 +10,7 @@ void test_efa_rdm_ope_prepare_to_post_send_impl(struct efa_resource *resource,
 	struct efa_ep_addr raw_addr;
 	struct efa_mr mock_mr;
 	struct efa_rdm_ope mock_txe;
-	size_t raw_addr_len;
+	size_t raw_addr_len = sizeof(raw_addr);
 	fi_addr_t addr;
 	int pkt_entry_cnt, pkt_entry_data_size_vec[1024];
 	int i, err, ret;

--- a/prov/efa/test/efa_unit_test_send.c
+++ b/prov/efa/test/efa_unit_test_send.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) Amazon.com, Inc. or its affiliates. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "efa_unit_tests.h"
+#include "ofi_util.h"
+#include "efa_rdm_ep.h"
+
+#define MSG_SIZE 10
+
+void test_efa_rdm_msg_send_to_local_peer_with_null_desc(struct efa_resource **state)
+{
+        struct efa_resource *resource = *state;
+        char buf[MSG_SIZE];
+        int i;
+        struct iovec iov;
+        struct efa_ep_addr raw_addr;
+	size_t raw_addr_len = sizeof(raw_addr);
+        fi_addr_t addr;
+        int ret;
+        struct fi_msg msg = {0};
+        struct fi_msg_tagged tmsg = {0};
+
+        efa_unit_test_resource_construct(resource, FI_EP_RDM);
+
+        ret = fi_getname(&resource->ep->fid, &raw_addr, &raw_addr_len);
+	assert_int_equal(ret, 0);
+
+	raw_addr.qpn = 1;
+	raw_addr.qkey = 0x1234;
+	ret = fi_av_insert(resource->av, &raw_addr, 1, &addr, 0 /* flags */, NULL /* context */);
+	assert_int_equal(ret, 1);
+
+        for (i = 0; i < MSG_SIZE; i++)
+                buf[i] = 'a' + i;
+
+        iov.iov_base = buf;
+        iov.iov_len = MSG_SIZE;
+
+        efa_unit_test_construct_msg(&msg, &iov, 1, addr, NULL, 0, NULL);
+
+        efa_unit_test_construct_tmsg(&tmsg, &iov, 1, addr, NULL, 0, NULL, 0, 0);
+
+        /* The peer won't be verified by shm so it is expected that EAGAIN will be returned */
+        ret = fi_send(resource->ep, buf, MSG_SIZE, NULL, addr, NULL);
+        assert_int_equal(ret, -FI_EAGAIN);
+
+        ret = fi_sendv(resource->ep, &iov, NULL, 1, addr, NULL);
+        assert_int_equal(ret, -FI_EAGAIN);
+
+        ret = fi_senddata(resource->ep, buf, MSG_SIZE, NULL, 0, addr, NULL);
+        assert_int_equal(ret, -FI_EAGAIN);
+
+        ret = fi_sendmsg(resource->ep, &msg, 0);
+        assert_int_equal(ret, -FI_EAGAIN);
+
+        ret = fi_tsend(resource->ep, buf, MSG_SIZE, NULL, addr, 0, NULL);
+        assert_int_equal(ret, -FI_EAGAIN);
+
+        ret = fi_tsendv(resource->ep, &iov, NULL, 1, addr, 0, NULL);
+        assert_int_equal(ret, -FI_EAGAIN);
+
+        ret = fi_tsenddata(resource->ep, buf, MSG_SIZE, NULL, 0, addr, 0, NULL);
+        assert_int_equal(ret, -FI_EAGAIN);
+
+        ret = fi_tsendmsg(resource->ep, &tmsg, 0);
+        assert_int_equal(ret, -FI_EAGAIN);
+}

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -122,6 +122,7 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ope_prepare_to_post_send_host_memory_align128, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ope_prepare_to_post_send_cuda_memory, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ope_prepare_to_post_send_cuda_memory_align128, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_rdm_msg_send_to_local_peer_with_null_desc, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 	};
 
 	cmocka_set_message_output(CM_OUTPUT_XML);

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -36,6 +36,17 @@ void efa_unit_test_resource_construct_with_hints(struct efa_resource *resource,
 
 void efa_unit_test_resource_destruct(struct efa_resource *resource);
 
+void efa_unit_test_construct_msg(struct fi_msg *msg, struct iovec *iov,
+				 size_t iov_count, fi_addr_t addr,
+				 void *context, uint64_t data,
+				 void **desc);
+
+void efa_unit_test_construct_tmsg(struct fi_msg_tagged *tmsg, struct iovec *iov,
+				  size_t iov_count, fi_addr_t addr,
+				  void *context, uint64_t data,
+				  void **desc, uint64_t tag,
+				  uint64_t ignore);
+
 void new_temp_file(char *template, size_t len);
 
 struct efa_unit_test_buff {
@@ -121,5 +132,6 @@ void test_efa_rdm_ope_prepare_to_post_send_host_memory();
 void test_efa_rdm_ope_prepare_to_post_send_host_memory_align128();
 void test_efa_rdm_ope_prepare_to_post_send_cuda_memory();
 void test_efa_rdm_ope_prepare_to_post_send_cuda_memory_align128();
+void test_efa_rdm_msg_send_to_local_peer_with_null_desc();
 
 #endif


### PR DESCRIPTION
In efa_rdm_msg_sendv, when desc is NULL, we shouldn't try to get desc for shm.

Also add a unit test to scan all fi_send* and fi_tsend APIs for such issue.