### PR TITLE
prov/efa: migrate variables/data structures in efa_rdm_protocol.h

### DIFF
--- a/fabtests/prov/efa/src/rdm_rnr_queue_resend.c
+++ b/fabtests/prov/efa/src/rdm_rnr_queue_resend.c
@@ -223,10 +223,10 @@ static int rnr_queue_resend_test(int req_pkt, enum fi_op atomic_op)
 		}
 	}
 	/*
-	 * Wait 1s here to ensure the server receives RXR_RECEIPT_PKT if delivery_complete
+	 * Wait 1s here to ensure the server receives EFA_RDM_RECEIPT_PKT if delivery_complete
 	 * is requested, before the client starts sending (fi->rx_attr->size) packets.
 	 * Without this, the server might already receive multiple packets, before
-	 * receiving RXR_RECEIPT_PKT, which causes the server's internally
+	 * receiving EFA_RDM_RECEIPT_PKT, which causes the server's internally
 	 * pre-posted rx buffer not getting run out.
 	 */
 	sleep(1);
@@ -441,9 +441,9 @@ int main(int argc, char **argv)
 	ft_efa_rnr_disable_hints_shm();
 
 	/*
-	 * When the server posts RXR_LONGCTS_MSGRTM_PKT in order to trigger RXR_CTS_PKT with
+	 * When the server posts EFA_RDM_LONGCTS_MSGRTM_PKT in order to trigger EFA_RDM_CTS_PKT with
 	 * RNR, also reset number of pre-posted rx buffer to 1, so we can easily check for
-	 * RXR_CTSDATA_PKT in the same test.
+	 * EFA_RDM_CTSDATA_PKT in the same test.
 	 */
 	if (!req_pkt && !atomic_op && !opts.rma_op && opts.transfer_size >= size_to_check_data_pkt) {
 		ret = setenv("FI_EFA_RX_SIZE", "1", 1);

--- a/prov/efa/src/efa_prov_info.c
+++ b/prov/efa/src/efa_prov_info.c
@@ -606,7 +606,7 @@ int efa_prov_info_alloc_for_rxr(struct fi_info **prov_info_rxr_ptr,
 
 		prov_info_rxr->ep_attr->protocol = FI_PROTO_EFA;
 		prov_info_rxr->ep_attr->mem_tag_format = FI_TAG_GENERIC;
-		prov_info_rxr->ep_attr->protocol_version = RXR_PROTOCOL_VERSION;
+		prov_info_rxr->ep_attr->protocol_version = EFA_RDM_PROTOCOL_VERSION;
 		/*
 		 * RxR support message segmentation, hence increase the max_msg_size
 		 */
@@ -616,7 +616,7 @@ int efa_prov_info_alloc_for_rxr(struct fi_info **prov_info_rxr_ptr,
 		 * RxR implemented emulated atomic, hence set atomic size
 		 */
 		max_atomic_size = device->rdm_info->ep_attr->max_msg_size
-					- sizeof(struct rxr_rta_hdr)
+					- sizeof(struct efa_rdm_rta_hdr)
 					- device->rdm_info->src_addrlen
 					- RXR_IOV_LIMIT * sizeof(struct fi_rma_iov);
 		prov_info_rxr->ep_attr->max_order_raw_size = max_atomic_size;

--- a/prov/efa/src/rdm/efa_rdm_atomic.c
+++ b/prov/efa/src/rdm/efa_rdm_atomic.c
@@ -128,9 +128,9 @@ ssize_t efa_rdm_atomic_generic_efa(struct efa_rdm_ep *efa_rdm_ep,
 	bool delivery_complete_requested;
 	ssize_t err;
 	static int req_pkt_type_list[] = {
-		[ofi_op_atomic] = RXR_WRITE_RTA_PKT,
-		[ofi_op_atomic_fetch] = RXR_FETCH_RTA_PKT,
-		[ofi_op_atomic_compare] = RXR_COMPARE_RTA_PKT
+		[ofi_op_atomic] = EFA_RDM_WRITE_RTA_PKT,
+		[ofi_op_atomic_fetch] = EFA_RDM_FETCH_RTA_PKT,
+		[ofi_op_atomic_compare] = EFA_RDM_COMPARE_RTA_PKT
 	};
 	struct util_srx_ctx *srx_ctx;
 
@@ -194,7 +194,7 @@ ssize_t efa_rdm_atomic_generic_efa(struct efa_rdm_ep *efa_rdm_ep,
 			    peer->next_msg_id++ : ++peer->next_msg_id;
 
 	if (delivery_complete_requested && op == ofi_op_atomic) {
-		err = efa_rdm_ope_post_send(txe, RXR_DC_WRITE_RTA_PKT);
+		err = efa_rdm_ope_post_send(txe, EFA_RDM_DC_WRITE_RTA_PKT);
 	} else {
 		/*
 		 * Fetch atomic and compare atomic
@@ -571,7 +571,7 @@ int efa_rdm_atomic_query(struct fid_domain *domain,
 	efa_domain = container_of(domain, struct efa_domain,
 				  util_domain.domain_fid);
 
-	max_atomic_size = efa_domain->mtu_size - sizeof(struct rxr_rta_hdr)
+	max_atomic_size = efa_domain->mtu_size - sizeof(struct efa_rdm_rta_hdr)
 			  - efa_domain->addrlen
 			  - RXR_IOV_LIMIT * sizeof(struct fi_rma_iov);
 

--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -77,7 +77,7 @@ struct efa_rdm_ep {
 	uint64_t host_id;
 
 	/* per-version extra feature/request flag */
-	uint64_t extra_info[RXR_MAX_NUM_EXINFO];
+	uint64_t extra_info[EFA_RDM_MAX_NUM_EXINFO];
 
 	struct ibv_cq_ex *ibv_cq_ex;
 

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -463,7 +463,7 @@ int efa_rdm_ep_open(struct fid_domain *domain, struct fi_info *info,
 	efa_rdm_ep->max_proto_hdr_size = efa_rdm_pkt_type_get_max_hdr_size();
 	efa_rdm_ep->mtu_size = efa_domain->device->rdm_info->ep_attr->max_msg_size;
 
-	efa_rdm_ep->max_data_payload_size = efa_rdm_ep->mtu_size - sizeof(struct rxr_ctsdata_hdr) - sizeof(struct rxr_ctsdata_opt_connid_hdr);
+	efa_rdm_ep->max_data_payload_size = efa_rdm_ep->mtu_size - sizeof(struct efa_rdm_ctsdata_hdr) - sizeof(struct efa_rdm_ctsdata_opt_connid_hdr);
 	efa_rdm_ep->min_multi_recv_size = efa_rdm_ep->mtu_size - efa_rdm_ep->max_proto_hdr_size;
 
 	if (efa_env.tx_queue_size > 0 &&
@@ -845,13 +845,13 @@ void efa_rdm_ep_set_extra_info(struct efa_rdm_ep *ep)
 
 	/* RDMA read is an extra feature defined in protocol version 4 (the base version) */
 	if (efa_rdm_ep_support_rdma_read(ep))
-		ep->extra_info[0] |= RXR_EXTRA_FEATURE_RDMA_READ;
+		ep->extra_info[0] |= EFA_RDM_EXTRA_FEATURE_RDMA_READ;
 
 	/* RDMA write is defined in protocol v4, and introduced in libfabric 1.18.0 */
 	if (efa_rdm_ep_support_rdma_write(ep))
-		ep->extra_info[0] |= RXR_EXTRA_FEATURE_RDMA_WRITE;
+		ep->extra_info[0] |= EFA_RDM_EXTRA_FEATURE_RDMA_WRITE;
 
-	ep->extra_info[0] |= RXR_EXTRA_FEATURE_DELIVERY_COMPLETE;
+	ep->extra_info[0] |= EFA_RDM_EXTRA_FEATURE_DELIVERY_COMPLETE;
 
 	if (ep->use_zcpy_rx) {
 		/*
@@ -859,12 +859,12 @@ void efa_rdm_ep_set_extra_info(struct efa_rdm_ep *ep)
 		 * constant, so the application receive buffer is match with
 		 * incoming application data.
 		 */
-		ep->extra_info[0] |= RXR_EXTRA_REQUEST_CONSTANT_HEADER_LENGTH;
+		ep->extra_info[0] |= EFA_RDM_EXTRA_REQUEST_CONSTANT_HEADER_LENGTH;
 	}
 
-	ep->extra_info[0] |= RXR_EXTRA_REQUEST_CONNID_HEADER;
+	ep->extra_info[0] |= EFA_RDM_EXTRA_REQUEST_CONNID_HEADER;
 
-	ep->extra_info[0] |= RXR_EXTRA_FEATURE_RUNT;
+	ep->extra_info[0] |= EFA_RDM_EXTRA_FEATURE_RUNT;
 }
 
 /**

--- a/prov/efa/src/rdm/efa_rdm_ep_progress.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_progress.c
@@ -732,7 +732,7 @@ void efa_rdm_ep_progress_internal(struct efa_rdm_ep *ep)
 			continue;
 
 		if (ope->window > 0) {
-			ret = efa_rdm_ope_post_send(ope, RXR_CTSDATA_PKT);
+			ret = efa_rdm_ope_post_send(ope, EFA_RDM_CTSDATA_PKT);
 			if (OFI_UNLIKELY(ret)) {
 				if (ret == -FI_EAGAIN)
 					break;

--- a/prov/efa/src/rdm/efa_rdm_ep_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_utils.c
@@ -589,7 +589,7 @@ ssize_t efa_rdm_ep_trigger_handshake(struct efa_rdm_ep *ep,
 
 	dlist_insert_tail(&txe->ep_entry, &ep->txe_list);
 
-	err = efa_rdm_ope_post_send(txe, RXR_EAGER_RTW_PKT);
+	err = efa_rdm_ope_post_send(txe, EFA_RDM_EAGER_RTW_PKT);
 
 	if (OFI_UNLIKELY(err))
 		return err;

--- a/prov/efa/src/rdm/efa_rdm_msg.c
+++ b/prov/efa/src/rdm/efa_rdm_msg.c
@@ -78,13 +78,13 @@ int efa_rdm_msg_select_rtm(struct efa_rdm_ep *efa_rdm_ep, struct efa_rdm_ope *tx
 	 * For performance consideration, this function assume the tagged rtm packet type id is
 	 * always the correspondent message rtm packet type id + 1, thus the assertion here.
 	 */
-	assert(RXR_EAGER_MSGRTM_PKT + 1 == RXR_EAGER_TAGRTM_PKT);
-	assert(RXR_MEDIUM_MSGRTM_PKT + 1 == RXR_MEDIUM_TAGRTM_PKT);
-	assert(RXR_LONGCTS_MSGRTM_PKT + 1 == RXR_LONGCTS_TAGRTM_PKT);
-	assert(RXR_LONGREAD_MSGRTM_PKT + 1 == RXR_LONGREAD_TAGRTM_PKT);
-	assert(RXR_DC_EAGER_MSGRTM_PKT + 1 == RXR_DC_EAGER_TAGRTM_PKT);
-	assert(RXR_DC_MEDIUM_MSGRTM_PKT + 1 == RXR_DC_MEDIUM_TAGRTM_PKT);
-	assert(RXR_DC_LONGCTS_MSGRTM_PKT + 1 == RXR_DC_LONGCTS_TAGRTM_PKT);
+	assert(EFA_RDM_EAGER_MSGRTM_PKT + 1 == EFA_RDM_EAGER_TAGRTM_PKT);
+	assert(EFA_RDM_MEDIUM_MSGRTM_PKT + 1 == EFA_RDM_MEDIUM_TAGRTM_PKT);
+	assert(EFA_RDM_LONGCTS_MSGRTM_PKT + 1 == EFA_RDM_LONGCTS_TAGRTM_PKT);
+	assert(EFA_RDM_LONGREAD_RTA_MSGRTM_PKT + 1 == EFA_RDM_LONGREAD_RTA_TAGRTM_PKT);
+	assert(EFA_RDM_DC_EAGER_MSGRTM_PKT + 1 == EFA_RDM_DC_EAGER_TAGRTM_PKT);
+	assert(EFA_RDM_DC_MEDIUM_MSGRTM_PKT + 1 == EFA_RDM_DC_MEDIUM_TAGRTM_PKT);
+	assert(EFA_RDM_DC_LONGCTS_MSGRTM_PKT + 1 == EFA_RDM_DC_LONGCTS_TAGRTM_PKT);
 
 	int tagged;
 	int eager_rtm, medium_rtm, longcts_rtm, readbase_rtm, iface;
@@ -108,14 +108,14 @@ int efa_rdm_msg_select_rtm(struct efa_rdm_ep *efa_rdm_ep, struct efa_rdm_ope *tx
 	else
 		delivery_complete_requested = txe->fi_flags & FI_DELIVERY_COMPLETE;
 
-	eager_rtm = (delivery_complete_requested) ? RXR_DC_EAGER_MSGRTM_PKT + tagged
-						  : RXR_EAGER_MSGRTM_PKT + tagged;
+	eager_rtm = (delivery_complete_requested) ? EFA_RDM_DC_EAGER_MSGRTM_PKT + tagged
+						  : EFA_RDM_EAGER_MSGRTM_PKT + tagged;
 
-	medium_rtm = (delivery_complete_requested) ? RXR_DC_MEDIUM_MSGRTM_PKT + tagged
-						   :  RXR_MEDIUM_MSGRTM_PKT + tagged;
+	medium_rtm = (delivery_complete_requested) ? EFA_RDM_DC_MEDIUM_MSGRTM_PKT + tagged
+						   :  EFA_RDM_MEDIUM_MSGRTM_PKT + tagged;
 
-	longcts_rtm = (delivery_complete_requested) ? RXR_DC_LONGCTS_MSGRTM_PKT + tagged
-						    : RXR_LONGCTS_MSGRTM_PKT + tagged;
+	longcts_rtm = (delivery_complete_requested) ? EFA_RDM_DC_LONGCTS_MSGRTM_PKT + tagged
+						    : EFA_RDM_LONGCTS_MSGRTM_PKT + tagged;
 
 	eager_rtm_max_data_size = efa_rdm_txe_max_req_data_capacity(efa_rdm_ep, txe, eager_rtm);
 
@@ -167,9 +167,9 @@ ssize_t efa_rdm_msg_post_rtm(struct efa_rdm_ep *ep, struct efa_rdm_ope *txe, int
 	}
 
 	rtm_type = efa_rdm_msg_select_rtm(ep, txe, use_p2p);
-	assert(rtm_type >= RXR_REQ_PKT_BEGIN);
+	assert(rtm_type >= EFA_RDM_REQ_PKT_BEGIN);
 
-	if (rtm_type < RXR_EXTRA_REQ_PKT_BEGIN) {
+	if (rtm_type < EFA_RDM_EXTRA_REQ_PKT_BEGIN) {
 		/* rtm requires only baseline feature, which peer should always support. */
 		return efa_rdm_ope_post_send(txe, rtm_type);
 	}

--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -428,18 +428,18 @@ size_t efa_rdm_txe_max_req_data_capacity(struct efa_rdm_ep *ep, struct efa_rdm_o
 	uint16_t header_flags = 0;
 	int max_data_offset;
 
-	assert(pkt_type >= RXR_REQ_PKT_BEGIN);
+	assert(pkt_type >= EFA_RDM_REQ_PKT_BEGIN);
 
 	peer = efa_rdm_ep_get_peer(ep, txe->addr);
 	assert(peer);
 
 	if (efa_rdm_peer_need_raw_addr_hdr(peer))
-		header_flags |= RXR_REQ_OPT_RAW_ADDR_HDR;
+		header_flags |= EFA_RDM_REQ_OPT_RAW_ADDR_HDR;
 	else if (efa_rdm_peer_need_connid(peer))
-		header_flags |= RXR_PKT_CONNID_HDR;
+		header_flags |= EFA_RDM_PKT_CONNID_HDR;
 
 	if (txe->fi_flags & FI_REMOTE_CQ_DATA)
-		header_flags |= RXR_REQ_OPT_CQ_DATA_HDR;
+		header_flags |= EFA_RDM_REQ_OPT_CQ_DATA_HDR;
 
 	max_data_offset = efa_rdm_pkt_type_get_req_hdr_size(pkt_type, header_flags,
 					       txe->rma_iov_count);
@@ -495,7 +495,7 @@ ssize_t efa_rdm_ope_prepare_to_post_send(struct efa_rdm_ope *ope,
 	if (available_tx_pkts == 0)
 		return -FI_EAGAIN;
 
-	if (pkt_type == RXR_CTSDATA_PKT) {
+	if (pkt_type == EFA_RDM_CTSDATA_PKT) {
 		assert(ope->window);
 		*pkt_entry_cnt = (ope->window - 1) / ope->ep->max_data_payload_size + 1;
 		if (*pkt_entry_cnt > available_tx_pkts)
@@ -1113,7 +1113,7 @@ void efa_rdm_ope_handle_recv_completed(struct efa_rdm_ope *ope)
 	if (ope->rxr_flags & EFA_RDM_TXE_DELIVERY_COMPLETE_REQUESTED) {
 		assert(ope->type == EFA_RDM_RXE);
 		rxe = ope; /* Intentionally assigned for easier understanding */
-		err = efa_rdm_ope_post_send_or_queue(rxe, RXR_RECEIPT_PKT);
+		err = efa_rdm_ope_post_send_or_queue(rxe, EFA_RDM_RECEIPT_PKT);
 		if (OFI_UNLIKELY(err)) {
 			EFA_WARN(FI_LOG_CQ,
 				 "Posting of ctrl packet failed when complete rx! err=%s(%d)\n",

--- a/prov/efa/src/rdm/efa_rdm_peer.c
+++ b/prov/efa/src/rdm/efa_rdm_peer.c
@@ -152,7 +152,7 @@ int efa_rdm_peer_reorder_msg(struct efa_rdm_peer *peer, struct efa_rdm_ep *ep,
 	struct efa_rdm_robuf *robuf;
 	uint32_t msg_id;
 
-	assert(efa_rdm_pke_get_base_hdr(pkt_entry)->type >= RXR_REQ_PKT_BEGIN);
+	assert(efa_rdm_pke_get_base_hdr(pkt_entry)->type >= EFA_RDM_REQ_PKT_BEGIN);
 
 	msg_id = efa_rdm_pke_get_rtm_msg_id(pkt_entry);
 
@@ -259,10 +259,10 @@ int efa_rdm_peer_select_readbase_rtm(struct efa_rdm_peer *peer, int op, uint64_t
 	if (peer->num_read_msg_in_flight == 0 &&
 	    hmem_info->runt_size > peer->num_runt_bytes_in_flight &&
 	    !(fi_flags & FI_DELIVERY_COMPLETE)) {
-		return (op == ofi_op_tagged) ? RXR_RUNTREAD_TAGRTM_PKT
-					     : RXR_RUNTREAD_MSGRTM_PKT;
+		return (op == ofi_op_tagged) ? EFA_RDM_RUNTREAD_TAGRTM_PKT
+					     : EFA_RDM_RUNTREAD_MSGRTM_PKT;
 	} else {
-		return (op == ofi_op_tagged) ? RXR_LONGREAD_TAGRTM_PKT
-					     : RXR_LONGREAD_MSGRTM_PKT;
+		return (op == ofi_op_tagged) ? EFA_RDM_LONGREAD_RTA_TAGRTM_PKT
+					     : EFA_RDM_LONGREAD_RTA_MSGRTM_PKT;
 	}
 }

--- a/prov/efa/src/rdm/efa_rdm_peer.h
+++ b/prov/efa/src/rdm/efa_rdm_peer.h
@@ -68,7 +68,7 @@ struct efa_rdm_peer {
 	uint32_t next_msg_id;		/**< msg_id to be assigned to the next packet sent to the peer. */
 	uint32_t flags;			/**< flags such as #EFA_RDM_PEER_REQ_SENT #EFA_RDM_PEER_HANDSHAKE_SENT #EFA_RDM_PEER_HANDSHAKE_RECEIVED and #EFA_RDM_PEER_IN_BACKOFF */
 	uint32_t nextra_p3;		/**< number of members in extra_info plus 3 (See protocol v4 document section 2.1) */
-	uint64_t extra_info[RXR_MAX_NUM_EXINFO]; /**< the feature/request flag for each version (See protocol v4 document section 2.1)*/
+	uint64_t extra_info[EFA_RDM_MAX_NUM_EXINFO]; /**< the feature/request flag for each version (See protocol v4 document section 2.1)*/
 	size_t efa_outstanding_tx_ops;	/**< tracks outstanding tx ops (send/read) to this peer on EFA device */
 	struct dlist_entry outstanding_tx_pkts; /**< a list of outstanding pkts sent to the peer */
 	uint64_t rnr_backoff_begin_ts;	/**< timestamp for RNR backoff period begin */
@@ -107,7 +107,7 @@ bool efa_rdm_peer_support_rdma_read(struct efa_rdm_peer *peer)
 	 * it before a handshake packet was received.
 	 */
 	return (peer->flags & EFA_RDM_PEER_HANDSHAKE_RECEIVED) &&
-	       (peer->extra_info[0] & RXR_EXTRA_FEATURE_RDMA_READ);
+	       (peer->extra_info[0] & EFA_RDM_EXTRA_FEATURE_RDMA_READ);
 }
 
 /**
@@ -124,7 +124,7 @@ bool efa_rdm_peer_support_rdma_write(struct efa_rdm_peer *peer)
 	 * it before a handshake packet was received.
 	 */
 	return (peer->flags & EFA_RDM_PEER_HANDSHAKE_RECEIVED) &&
-	       (peer->extra_info[0] & RXR_EXTRA_FEATURE_RDMA_WRITE);
+	       (peer->extra_info[0] & EFA_RDM_EXTRA_FEATURE_RDMA_WRITE);
 }
 
 static inline
@@ -137,14 +137,14 @@ bool efa_rdm_peer_support_delivery_complete(struct efa_rdm_peer *peer)
 	 * it before a handshake packet was received.
 	 */
 	return (peer->flags & EFA_RDM_PEER_HANDSHAKE_RECEIVED) &&
-	       (peer->extra_info[0] & RXR_EXTRA_FEATURE_DELIVERY_COMPLETE);
+	       (peer->extra_info[0] & EFA_RDM_EXTRA_FEATURE_DELIVERY_COMPLETE);
 }
 
 /**
  * @brief determine if both peers support RDMA read
  *
  * This function can only return true if a handshake packet has already been
- * exchanged, and the peer set the RXR_EXTRA_FEATURE_RDMA_READ flag.
+ * exchanged, and the peer set the EFA_RDM_EXTRA_FEATURE_RDMA_READ flag.
  * @params[in]		ep		Endpoint for communication with peer
  * @params[in]		peer		An EFA peer
  * @return		boolean		both self and peer support RDMA read
@@ -160,7 +160,7 @@ bool efa_both_support_rdma_read(struct efa_rdm_ep *ep, struct efa_rdm_peer *peer
  * @brief determine if both peers support RDMA write
  *
  * This function can only return true if a handshake packet has already been
- * exchanged, and the peer set the RXR_EXTRA_FEATURE_RDMA_WRITE flag.
+ * exchanged, and the peer set the EFA_RDM_EXTRA_FEATURE_RDMA_WRITE flag.
  * @params[in]		ep		Endpoint for communication with peer
  * @params[in]		peer		An EFA peer
  * @return		boolean		both self and peer support RDMA write
@@ -200,7 +200,7 @@ bool efa_rdm_peer_need_raw_addr_hdr(struct efa_rdm_peer *peer)
 	if (OFI_UNLIKELY(!(peer->flags & EFA_RDM_PEER_HANDSHAKE_RECEIVED)))
 		return true;
 
-	return peer->extra_info[0] & RXR_EXTRA_REQUEST_CONSTANT_HEADER_LENGTH;
+	return peer->extra_info[0] & EFA_RDM_EXTRA_REQUEST_CONSTANT_HEADER_LENGTH;
 }
 
 /**
@@ -222,7 +222,7 @@ static inline
 bool efa_rdm_peer_need_connid(struct efa_rdm_peer *peer)
 {
 	return (peer->flags & EFA_RDM_PEER_HANDSHAKE_RECEIVED) &&
-	       (peer->extra_info[0] & RXR_EXTRA_REQUEST_CONNID_HEADER);
+	       (peer->extra_info[0] & EFA_RDM_EXTRA_REQUEST_CONNID_HEADER);
 }
 
 struct efa_conn;

--- a/prov/efa/src/rdm/efa_rdm_pke.c
+++ b/prov/efa/src/rdm/efa_rdm_pke.c
@@ -431,7 +431,7 @@ ssize_t efa_rdm_pke_sendv(struct efa_rdm_ep *ep,
 #if ENABLE_DEBUG
 		dlist_insert_tail(&pkt_entry->dbg_entry, &ep->tx_pkt_list);
 #ifdef ENABLE_RXR_PKT_DUMP
-		rxr_pkt_print("Sent", ep, (struct rxr_base_hdr *)pkt_entry->wiredata);
+		rxr_pkt_print("Sent", ep, (struct efa_rdm_base_hdr *)pkt_entry->wiredata);
 #endif
 #endif
 

--- a/prov/efa/src/rdm/efa_rdm_pke_cmd.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_cmd.c
@@ -45,7 +45,7 @@
 #include "efa_rdm_pke_req.h"
 
 /* Handshake wait timeout in microseconds */
-#define RXR_HANDSHAKE_WAIT_TIMEOUT 1000000
+#define EFA_RDM_HANDSHAKE_WAIT_TIMEOUT 1000000
 
 /**
  * @brief fill the a pkt_entry with data
@@ -94,135 +94,135 @@ int efa_rdm_pke_fill_data(struct efa_rdm_pke *pkt_entry,
 	 * type's init() function.
 	 */
 	switch (pkt_type) {
-	case RXR_READRSP_PKT:
+	case EFA_RDM_READRSP_PKT:
 		assert(data_offset == 0 && data_size == -1);
 		ret = efa_rdm_pke_init_readrsp(pkt_entry, ope);
 		break;
-	case RXR_CTS_PKT:
+	case EFA_RDM_CTS_PKT:
 		assert(data_offset == -1 && data_size == -1);
 		ret = efa_rdm_pke_init_cts(pkt_entry, ope);
 		break;
-	case RXR_EOR_PKT:
+	case EFA_RDM_EOR_PKT:
 		assert(data_offset == -1 && data_size == -1);
 		ret = efa_rdm_pke_init_eor(pkt_entry, ope);
 		break;
-	case RXR_ATOMRSP_PKT:
+	case EFA_RDM_ATOMRSP_PKT:
 		assert(data_offset == 0 && data_size == -1);
 		ret = efa_rdm_pke_init_atomrsp(pkt_entry, ope);
 		break;
-	case RXR_RECEIPT_PKT:
+	case EFA_RDM_RECEIPT_PKT:
 		assert(data_offset == -1 && data_size == -1);
 		ret = efa_rdm_pke_init_receipt(pkt_entry, ope);
 		break;
-	case RXR_EAGER_MSGRTM_PKT:
+	case EFA_RDM_EAGER_MSGRTM_PKT:
 		assert(data_offset == 0 && data_size == -1);
 		ret = efa_rdm_pke_init_eager_msgrtm(pkt_entry, ope);
 		break;
-	case RXR_EAGER_TAGRTM_PKT:
+	case EFA_RDM_EAGER_TAGRTM_PKT:
 		assert(data_offset == 0 && data_size == -1);
 		ret = efa_rdm_pke_init_eager_tagrtm(pkt_entry, ope);
 		break;
-	case RXR_MEDIUM_MSGRTM_PKT:
+	case EFA_RDM_MEDIUM_MSGRTM_PKT:
 		assert(data_offset >= 0 && data_size > 0);
 		ret = efa_rdm_pke_init_medium_msgrtm(pkt_entry, ope, data_offset, data_size);
 		break;
-	case RXR_MEDIUM_TAGRTM_PKT:
+	case EFA_RDM_MEDIUM_TAGRTM_PKT:
 		assert(data_offset >= 0 && data_size > 0);
 		ret = efa_rdm_pke_init_medium_tagrtm(pkt_entry, ope, data_offset, data_size);
 		break;
-	case RXR_LONGCTS_MSGRTM_PKT:
+	case EFA_RDM_LONGCTS_MSGRTM_PKT:
 		assert(data_offset == 0 && data_size == -1);
 		ret = efa_rdm_pke_init_longcts_msgrtm(pkt_entry, ope);
 		break;
-	case RXR_LONGCTS_TAGRTM_PKT:
+	case EFA_RDM_LONGCTS_TAGRTM_PKT:
 		assert(data_offset == 0 && data_size == -1);
 		ret = efa_rdm_pke_init_longcts_tagrtm(pkt_entry, ope);
 		break;
-	case RXR_LONGREAD_MSGRTM_PKT:
+	case EFA_RDM_LONGREAD_RTA_MSGRTM_PKT:
 		assert(data_offset == -1 && data_size == -1);
 		ret = efa_rdm_pke_init_longread_msgrtm(pkt_entry, ope);
 		break;
-	case RXR_LONGREAD_TAGRTM_PKT:
+	case EFA_RDM_LONGREAD_RTA_TAGRTM_PKT:
 		assert(data_offset == -1 && data_size == -1);
 		ret = efa_rdm_pke_init_longread_tagrtm(pkt_entry, ope);
 		break;
-	case RXR_RUNTREAD_MSGRTM_PKT:
+	case EFA_RDM_RUNTREAD_MSGRTM_PKT:
 		assert(data_offset >= 0 && data_size > 0);
 		ret = efa_rdm_pke_init_runtread_msgrtm(pkt_entry, ope, data_offset, data_size);
 		break;
-	case RXR_RUNTREAD_TAGRTM_PKT:
+	case EFA_RDM_RUNTREAD_TAGRTM_PKT:
 		assert(data_offset >= 0 && data_size > 0);
 		ret = efa_rdm_pke_init_runtread_tagrtm(pkt_entry, ope, data_offset, data_size);
 		break;
-	case RXR_EAGER_RTW_PKT:
+	case EFA_RDM_EAGER_RTW_PKT:
 		assert(data_offset == 0 && data_size == -1);
 		ret = efa_rdm_pke_init_eager_rtw(pkt_entry, ope);
 		break;
-	case RXR_LONGCTS_RTW_PKT:
+	case EFA_RDM_LONGCTS_RTW_PKT:
 		assert(data_offset == 0 && data_size == -1);
 		ret = efa_rdm_pke_init_longcts_rtw(pkt_entry, ope);
 		break;
-	case RXR_LONGREAD_RTW_PKT:
+	case EFA_RDM_LONGREAD_RTA_RTW_PKT:
 		assert(data_offset == -1 && data_size == -1);
 		ret = efa_rdm_pke_init_longread_rtw(pkt_entry, ope);
 		break;
-	case RXR_SHORT_RTR_PKT:
+	case EFA_RDM_SHORT_RTR_PKT:
 		assert(data_offset == -1 && data_size == -1);
 		ret = efa_rdm_pke_init_short_rtr(pkt_entry, ope);
 		break;
-	case RXR_LONGCTS_RTR_PKT:
+	case EFA_RDM_LONGCTS_RTR_PKT:
 		assert(data_offset == -1 && data_size == -1);
 		ret = efa_rdm_pke_init_longcts_rtr(pkt_entry, ope);
 		break;
-	case RXR_WRITE_RTA_PKT:
+	case EFA_RDM_WRITE_RTA_PKT:
 		assert(data_offset == 0 && data_size == -1);
 		ret = efa_rdm_pke_init_write_rta(pkt_entry, ope);
 		break;
-	case RXR_FETCH_RTA_PKT:
+	case EFA_RDM_FETCH_RTA_PKT:
 		assert(data_offset == 0 && data_size == -1);
 		ret = efa_rdm_pke_init_fetch_rta(pkt_entry, ope);
 		break;
-	case RXR_COMPARE_RTA_PKT:
+	case EFA_RDM_COMPARE_RTA_PKT:
 		assert(data_offset == 0 && data_size == -1);
 		ret = efa_rdm_pke_init_compare_rta(pkt_entry, ope);
 		break;
-	case RXR_DC_EAGER_MSGRTM_PKT:
+	case EFA_RDM_DC_EAGER_MSGRTM_PKT:
 		assert(data_offset == 0 && data_size == -1);
 		ret = efa_rdm_pke_init_dc_eager_msgrtm(pkt_entry, ope);
 		break;
-	case RXR_DC_EAGER_TAGRTM_PKT:
+	case EFA_RDM_DC_EAGER_TAGRTM_PKT:
 		assert(data_offset == 0 && data_size == -1);
 		ret = efa_rdm_pke_init_dc_eager_tagrtm(pkt_entry, ope);
 		break;
-	case RXR_DC_MEDIUM_MSGRTM_PKT:
+	case EFA_RDM_DC_MEDIUM_MSGRTM_PKT:
 		assert(data_offset >= 0 && data_size > 0);
 		ret = efa_rdm_pke_init_dc_medium_msgrtm(pkt_entry, ope, data_offset, data_size);
 		break;
-	case RXR_DC_MEDIUM_TAGRTM_PKT:
+	case EFA_RDM_DC_MEDIUM_TAGRTM_PKT:
 		assert(data_offset >= 0 && data_size > 0);
 		ret = efa_rdm_pke_init_dc_medium_tagrtm(pkt_entry, ope, data_offset, data_size);
 		break;
-	case RXR_DC_LONGCTS_MSGRTM_PKT:
+	case EFA_RDM_DC_LONGCTS_MSGRTM_PKT:
 		assert(data_offset == 0 && data_size == -1);
 		ret = efa_rdm_pke_init_dc_longcts_msgrtm(pkt_entry, ope);
 		break;
-	case RXR_DC_LONGCTS_TAGRTM_PKT:
+	case EFA_RDM_DC_LONGCTS_TAGRTM_PKT:
 		assert(data_offset == 0 && data_size == -1);
 		ret = efa_rdm_pke_init_dc_longcts_tagrtm(pkt_entry, ope);
 		break;
-	case RXR_DC_EAGER_RTW_PKT:
+	case EFA_RDM_DC_EAGER_RTW_PKT:
 		assert(data_offset == 0 && data_size == -1);
 		ret = efa_rdm_pke_init_dc_eager_rtw(pkt_entry, ope);
 		break;
-	case RXR_DC_LONGCTS_RTW_PKT:
+	case EFA_RDM_DC_LONGCTS_RTW_PKT:
 		assert(data_offset == 0 && data_size == -1);
 		ret = efa_rdm_pke_init_dc_longcts_rtw(pkt_entry, ope);
 		break;
-	case RXR_DC_WRITE_RTA_PKT:
+	case EFA_RDM_DC_WRITE_RTA_PKT:
 		assert(data_offset == 0 && data_size == -1);
 		ret = efa_rdm_pke_init_dc_write_rta(pkt_entry, ope);
 		break;
-	case RXR_CTSDATA_PKT:
+	case EFA_RDM_CTSDATA_PKT:
 		assert(data_offset >= 0 && data_size > 0);
 		ret = efa_rdm_pke_init_ctsdata(pkt_entry, ope, data_offset, data_size);
 		break;
@@ -251,71 +251,71 @@ void efa_rdm_pke_handle_sent(struct efa_rdm_pke *pkt_entry)
 	int pkt_type = efa_rdm_pke_get_base_hdr(pkt_entry)->type;
 
 	switch (pkt_type) {
-	case RXR_READRSP_PKT:
+	case EFA_RDM_READRSP_PKT:
 		efa_rdm_pke_handle_readrsp_sent(pkt_entry);
 		break;
-	case RXR_CTS_PKT:
+	case EFA_RDM_CTS_PKT:
 		efa_rdm_pke_handle_cts_sent(pkt_entry);
 		break;
-	case RXR_EOR_PKT:
+	case EFA_RDM_EOR_PKT:
 		/* nothing to do */
 		break;
-	case RXR_ATOMRSP_PKT:
+	case EFA_RDM_ATOMRSP_PKT:
 		/* nothing to do */
 		break;
-	case RXR_RECEIPT_PKT:
+	case EFA_RDM_RECEIPT_PKT:
 		/* nothing to do */
 		break;
-	case RXR_EAGER_MSGRTM_PKT:
-	case RXR_EAGER_TAGRTM_PKT:
+	case EFA_RDM_EAGER_MSGRTM_PKT:
+	case EFA_RDM_EAGER_TAGRTM_PKT:
 		/* nothing to do */
 		break;
-	case RXR_MEDIUM_MSGRTM_PKT:
-	case RXR_MEDIUM_TAGRTM_PKT:
-	case RXR_DC_MEDIUM_MSGRTM_PKT:
-	case RXR_DC_MEDIUM_TAGRTM_PKT:
+	case EFA_RDM_MEDIUM_MSGRTM_PKT:
+	case EFA_RDM_MEDIUM_TAGRTM_PKT:
+	case EFA_RDM_DC_MEDIUM_MSGRTM_PKT:
+	case EFA_RDM_DC_MEDIUM_TAGRTM_PKT:
 		efa_rdm_pke_handle_medium_rtm_sent(pkt_entry);
 		break;
-	case RXR_LONGCTS_MSGRTM_PKT:
-	case RXR_DC_LONGCTS_MSGRTM_PKT:
-	case RXR_LONGCTS_TAGRTM_PKT:
-	case RXR_DC_LONGCTS_TAGRTM_PKT:
+	case EFA_RDM_LONGCTS_MSGRTM_PKT:
+	case EFA_RDM_DC_LONGCTS_MSGRTM_PKT:
+	case EFA_RDM_LONGCTS_TAGRTM_PKT:
+	case EFA_RDM_DC_LONGCTS_TAGRTM_PKT:
 		efa_rdm_pke_handle_longcts_rtm_sent(pkt_entry);
 		break;
-	case RXR_LONGREAD_MSGRTM_PKT:
-	case RXR_LONGREAD_TAGRTM_PKT:
+	case EFA_RDM_LONGREAD_RTA_MSGRTM_PKT:
+	case EFA_RDM_LONGREAD_RTA_TAGRTM_PKT:
 		efa_rdm_pke_handle_longread_rtm_sent(pkt_entry);
 		break;
-	case RXR_RUNTREAD_MSGRTM_PKT:
-	case RXR_RUNTREAD_TAGRTM_PKT:
+	case EFA_RDM_RUNTREAD_MSGRTM_PKT:
+	case EFA_RDM_RUNTREAD_TAGRTM_PKT:
 		efa_rdm_pke_handle_runtread_rtm_sent(pkt_entry);
 		break;
-	case RXR_EAGER_RTW_PKT:
+	case EFA_RDM_EAGER_RTW_PKT:
 		/* nothing to do when EAGER RTW is sent */
 		break;
-	case RXR_LONGCTS_RTW_PKT:
-	case RXR_DC_LONGCTS_RTW_PKT:
+	case EFA_RDM_LONGCTS_RTW_PKT:
+	case EFA_RDM_DC_LONGCTS_RTW_PKT:
 		efa_rdm_pke_handle_longcts_rtw_sent(pkt_entry);
 		break;
-	case RXR_LONGREAD_RTW_PKT:
+	case EFA_RDM_LONGREAD_RTA_RTW_PKT:
 		/* nothing to do when LONGREAD RTW is sent */
 		break;
-	case RXR_SHORT_RTR_PKT:
-	case RXR_LONGCTS_RTR_PKT:
+	case EFA_RDM_SHORT_RTR_PKT:
+	case EFA_RDM_LONGCTS_RTR_PKT:
 		/* nothing can be done when RTR packets are sent */
 		break;
-	case RXR_WRITE_RTA_PKT:
-	case RXR_DC_WRITE_RTA_PKT:
-	case RXR_FETCH_RTA_PKT:
-	case RXR_COMPARE_RTA_PKT:
+	case EFA_RDM_WRITE_RTA_PKT:
+	case EFA_RDM_DC_WRITE_RTA_PKT:
+	case EFA_RDM_FETCH_RTA_PKT:
+	case EFA_RDM_COMPARE_RTA_PKT:
 		/* nothing can be done when RTA packets are sent */
 		break;
-	case RXR_DC_EAGER_MSGRTM_PKT:
-	case RXR_DC_EAGER_TAGRTM_PKT:
-	case RXR_DC_EAGER_RTW_PKT:
+	case EFA_RDM_DC_EAGER_MSGRTM_PKT:
+	case EFA_RDM_DC_EAGER_TAGRTM_PKT:
+	case EFA_RDM_DC_EAGER_RTW_PKT:
 		/* nothing to do for DC EAGER RTM/RTW */
 		break;
-	case RXR_CTSDATA_PKT:
+	case EFA_RDM_CTSDATA_PKT:
 		efa_rdm_pke_handle_ctsdata_sent(pkt_entry);
 		break;
 	default:
@@ -422,7 +422,7 @@ void efa_rdm_pke_handle_send_error(struct efa_rdm_pke *pkt_entry, int err, int p
 
 	if (!pkt_entry->ope) {
 		/* only handshake packet is not associated with any TX/RX operation */
-		assert(efa_rdm_pke_get_base_hdr(pkt_entry)->type == RXR_HANDSHAKE_PKT);
+		assert(efa_rdm_pke_get_base_hdr(pkt_entry)->type == EFA_RDM_HANDSHAKE_PKT);
 		efa_rdm_pke_release_tx(ep, pkt_entry);
 		if (prov_errno == FI_EFA_REMOTE_ERROR_RNR) {
 			/*
@@ -561,81 +561,81 @@ void efa_rdm_pke_handle_send_completion(struct efa_rdm_pke *pkt_entry)
 	}
 
 	switch (efa_rdm_pke_get_base_hdr(pkt_entry)->type) {
-	case RXR_HANDSHAKE_PKT:
+	case EFA_RDM_HANDSHAKE_PKT:
 		break;
-	case RXR_CTS_PKT:
+	case EFA_RDM_CTS_PKT:
 		break;
-	case RXR_CTSDATA_PKT:
+	case EFA_RDM_CTSDATA_PKT:
 		efa_rdm_pke_handle_ctsdata_send_completion(pkt_entry);
 		break;
-	case RXR_READRSP_PKT:
+	case EFA_RDM_READRSP_PKT:
 		efa_rdm_pke_handle_readrsp_send_completion(pkt_entry);
 		break;
-	case RXR_EOR_PKT:
+	case EFA_RDM_EOR_PKT:
 		efa_rdm_pke_handle_eor_send_completion(pkt_entry);
 		break;
-	case RXR_RMA_CONTEXT_PKT:
+	case EFA_RDM_RMA_CONTEXT_PKT:
 		efa_rdm_pke_handle_rma_completion(pkt_entry);
 		return;
-	case RXR_ATOMRSP_PKT:
+	case EFA_RDM_ATOMRSP_PKT:
 		efa_rdm_pke_handle_atomrsp_send_completion(pkt_entry);
 		break;
-	case RXR_RECEIPT_PKT:
+	case EFA_RDM_RECEIPT_PKT:
 		efa_rdm_pke_handle_receipt_send_completion(pkt_entry);
 		break;
-	case RXR_EAGER_MSGRTM_PKT:
-	case RXR_EAGER_TAGRTM_PKT:
+	case EFA_RDM_EAGER_MSGRTM_PKT:
+	case EFA_RDM_EAGER_TAGRTM_PKT:
 		efa_rdm_pke_handle_eager_rtm_send_completion(pkt_entry);
 		break;
-	case RXR_MEDIUM_MSGRTM_PKT:
-	case RXR_MEDIUM_TAGRTM_PKT:
+	case EFA_RDM_MEDIUM_MSGRTM_PKT:
+	case EFA_RDM_MEDIUM_TAGRTM_PKT:
 		efa_rdm_pke_handle_medium_rtm_send_completion(pkt_entry);
 		break;
-	case RXR_LONGCTS_MSGRTM_PKT:
-	case RXR_LONGCTS_TAGRTM_PKT:
+	case EFA_RDM_LONGCTS_MSGRTM_PKT:
+	case EFA_RDM_LONGCTS_TAGRTM_PKT:
 		efa_rdm_pke_handle_longcts_rtm_send_completion(pkt_entry);
 		break;
-	case RXR_LONGREAD_MSGRTM_PKT:
-	case RXR_LONGREAD_TAGRTM_PKT:
+	case EFA_RDM_LONGREAD_RTA_MSGRTM_PKT:
+	case EFA_RDM_LONGREAD_RTA_TAGRTM_PKT:
 		/* nothing to do */
 		break;
-	case RXR_RUNTREAD_MSGRTM_PKT:
-	case RXR_RUNTREAD_TAGRTM_PKT:
+	case EFA_RDM_RUNTREAD_MSGRTM_PKT:
+	case EFA_RDM_RUNTREAD_TAGRTM_PKT:
 		efa_rdm_pke_handle_runtread_rtm_send_completion(pkt_entry);
 		break;
-	case RXR_EAGER_RTW_PKT:
+	case EFA_RDM_EAGER_RTW_PKT:
 		efa_rdm_pke_handle_eager_rtw_send_completion(pkt_entry);
 		break;
-	case RXR_LONGCTS_RTW_PKT:
+	case EFA_RDM_LONGCTS_RTW_PKT:
 		efa_rdm_pke_handle_longcts_rtw_send_completion(pkt_entry);
 		break;
-	case RXR_LONGREAD_RTW_PKT:
+	case EFA_RDM_LONGREAD_RTA_RTW_PKT:
 		/* nothing to do when long rtw send completes*/
 		break;
-	case RXR_SHORT_RTR_PKT:
-	case RXR_LONGCTS_RTR_PKT:
+	case EFA_RDM_SHORT_RTR_PKT:
+	case EFA_RDM_LONGCTS_RTR_PKT:
 		/* Unlike other protocol, for emulated read, txe
 	 	 * is released in rxr_cq_complete_recv().
 	         * Therefore there is nothing to be done here. */
 		break;
-	case RXR_WRITE_RTA_PKT:
+	case EFA_RDM_WRITE_RTA_PKT:
 		efa_rdm_pke_handle_write_rta_send_completion(pkt_entry);
 		break;
-	case RXR_FETCH_RTA_PKT:
+	case EFA_RDM_FETCH_RTA_PKT:
 		/* no action to be taken here */
 		break;
-	case RXR_COMPARE_RTA_PKT:
+	case EFA_RDM_COMPARE_RTA_PKT:
 		/* no action to be taken here */
 		break;
-	case RXR_DC_EAGER_MSGRTM_PKT:
-	case RXR_DC_EAGER_TAGRTM_PKT:
-	case RXR_DC_MEDIUM_MSGRTM_PKT:
-	case RXR_DC_MEDIUM_TAGRTM_PKT:
-	case RXR_DC_EAGER_RTW_PKT:
-	case RXR_DC_WRITE_RTA_PKT:
-	case RXR_DC_LONGCTS_MSGRTM_PKT:
-	case RXR_DC_LONGCTS_TAGRTM_PKT:
-	case RXR_DC_LONGCTS_RTW_PKT:
+	case EFA_RDM_DC_EAGER_MSGRTM_PKT:
+	case EFA_RDM_DC_EAGER_TAGRTM_PKT:
+	case EFA_RDM_DC_MEDIUM_MSGRTM_PKT:
+	case EFA_RDM_DC_MEDIUM_TAGRTM_PKT:
+	case EFA_RDM_DC_EAGER_RTW_PKT:
+	case EFA_RDM_DC_WRITE_RTA_PKT:
+	case EFA_RDM_DC_LONGCTS_MSGRTM_PKT:
+	case EFA_RDM_DC_LONGCTS_TAGRTM_PKT:
+	case EFA_RDM_DC_LONGCTS_RTW_PKT:
 		/* no action to be taken here
 		 * For non-dc version of these packet types,
 		 * this is the place to increase bytes_acked or
@@ -715,12 +715,12 @@ fi_addr_t efa_rdm_pke_insert_addr(struct efa_rdm_pke *pkt_entry, void *raw_addr)
 	int ret;
 	fi_addr_t rdm_addr;
 	struct efa_rdm_ep *ep;
-	struct rxr_base_hdr *base_hdr;
+	struct efa_rdm_base_hdr *base_hdr;
 
 	ep = pkt_entry->ep;
 
 	base_hdr = efa_rdm_pke_get_base_hdr(pkt_entry);
-	if (base_hdr->version < RXR_PROTOCOL_VERSION) {
+	if (base_hdr->version < EFA_RDM_PROTOCOL_VERSION) {
 		char self_raw_addr_str[OFI_ADDRSTRLEN];
 		size_t buflen = OFI_ADDRSTRLEN;
 
@@ -728,15 +728,15 @@ fi_addr_t efa_rdm_pke_insert_addr(struct efa_rdm_pke *pkt_entry, void *raw_addr)
 		EFA_WARN(FI_LOG_CQ,
 			"Host %s received a packet with invalid protocol version %d.\n"
 			"This host can only support protocol version %d and above.\n",
-			self_raw_addr_str, base_hdr->version, RXR_PROTOCOL_VERSION);
+			self_raw_addr_str, base_hdr->version, EFA_RDM_PROTOCOL_VERSION);
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_EIO, FI_EFA_ERR_INVALID_PKT_TYPE);
 		fprintf(stderr, "Host %s received a packet with invalid protocol version %d.\n"
 			"This host can only support protocol version %d and above. %s:%d\n",
-			self_raw_addr_str, base_hdr->version, RXR_PROTOCOL_VERSION, __FILE__, __LINE__);
+			self_raw_addr_str, base_hdr->version, EFA_RDM_PROTOCOL_VERSION, __FILE__, __LINE__);
 		abort();
 	}
 
-	assert(base_hdr->type >= RXR_REQ_PKT_BEGIN);
+	assert(base_hdr->type >= EFA_RDM_REQ_PKT_BEGIN);
 
 	ret = efa_av_insert_one(ep->base_ep.av, (struct efa_ep_addr *)raw_addr,
 	                        &rdm_addr, 0, NULL);
@@ -757,7 +757,7 @@ fi_addr_t efa_rdm_pke_insert_addr(struct efa_rdm_pke *pkt_entry, void *raw_addr)
 void efa_rdm_pke_proc_received(struct efa_rdm_pke *pkt_entry)
 {
 	struct efa_rdm_ep *ep;
-	struct rxr_base_hdr *base_hdr;
+	struct efa_rdm_base_hdr *base_hdr;
 	size_t payload_offset;
 
 	ep = pkt_entry->ep;
@@ -770,78 +770,78 @@ void efa_rdm_pke_proc_received(struct efa_rdm_pke *pkt_entry)
 	}
 
 	switch (base_hdr->type) {
-	case RXR_RETIRED_RTS_PKT:
+	case EFA_RDM_RETIRED_RTS_PKT:
 		EFA_WARN(FI_LOG_CQ,
 			"Received a RTS packet, which has been retired since protocol version 4\n");
 		assert(0 && "deprecated RTS pakcet received");
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_EIO, FI_EFA_ERR_DEPRECATED_PKT_TYPE);
 		efa_rdm_pke_release_rx(ep, pkt_entry);
 		return;
-	case RXR_RETIRED_CONNACK_PKT:
+	case EFA_RDM_RETIRED_CONNACK_PKT:
 		EFA_WARN(FI_LOG_CQ,
 			"Received a CONNACK packet, which has been retired since protocol version 4\n");
 		assert(0 && "deprecated CONNACK pakcet received");
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_EIO, FI_EFA_ERR_DEPRECATED_PKT_TYPE);
 		efa_rdm_pke_release_rx(ep, pkt_entry);
 		return;
-	case RXR_EOR_PKT:
+	case EFA_RDM_EOR_PKT:
 		efa_rdm_pke_handle_eor_recv(pkt_entry);
 		return;
-	case RXR_HANDSHAKE_PKT:
+	case EFA_RDM_HANDSHAKE_PKT:
 		efa_rdm_pke_handle_handshake_recv(pkt_entry);
 		return;
-	case RXR_CTS_PKT:
+	case EFA_RDM_CTS_PKT:
 		efa_rdm_pke_handle_cts_recv(pkt_entry);
 		return;
-	case RXR_CTSDATA_PKT:
+	case EFA_RDM_CTSDATA_PKT:
 		efa_rdm_pke_handle_ctsdata_recv(pkt_entry);
 		return;
-	case RXR_READRSP_PKT:
+	case EFA_RDM_READRSP_PKT:
 		efa_rdm_pke_handle_readrsp_recv(pkt_entry);
 		return;
-	case RXR_ATOMRSP_PKT:
+	case EFA_RDM_ATOMRSP_PKT:
 		efa_rdm_pke_handle_atomrsp_recv(pkt_entry);
 		return;
-	case RXR_RECEIPT_PKT:
+	case EFA_RDM_RECEIPT_PKT:
 		efa_rdm_pke_handle_receipt_recv(pkt_entry);
 		return;
-	case RXR_EAGER_MSGRTM_PKT:
-	case RXR_EAGER_TAGRTM_PKT:
-	case RXR_DC_EAGER_MSGRTM_PKT:
-	case RXR_DC_EAGER_TAGRTM_PKT:
-	case RXR_MEDIUM_MSGRTM_PKT:
-	case RXR_MEDIUM_TAGRTM_PKT:
-	case RXR_DC_MEDIUM_MSGRTM_PKT:
-	case RXR_DC_MEDIUM_TAGRTM_PKT:
-	case RXR_LONGCTS_MSGRTM_PKT:
-	case RXR_LONGCTS_TAGRTM_PKT:
-	case RXR_DC_LONGCTS_MSGRTM_PKT:
-	case RXR_DC_LONGCTS_TAGRTM_PKT:
-	case RXR_LONGREAD_MSGRTM_PKT:
-	case RXR_LONGREAD_TAGRTM_PKT:
-	case RXR_RUNTREAD_MSGRTM_PKT:
-	case RXR_RUNTREAD_TAGRTM_PKT:
-	case RXR_WRITE_RTA_PKT:
-	case RXR_DC_WRITE_RTA_PKT:
-	case RXR_FETCH_RTA_PKT:
-	case RXR_COMPARE_RTA_PKT:
+	case EFA_RDM_EAGER_MSGRTM_PKT:
+	case EFA_RDM_EAGER_TAGRTM_PKT:
+	case EFA_RDM_DC_EAGER_MSGRTM_PKT:
+	case EFA_RDM_DC_EAGER_TAGRTM_PKT:
+	case EFA_RDM_MEDIUM_MSGRTM_PKT:
+	case EFA_RDM_MEDIUM_TAGRTM_PKT:
+	case EFA_RDM_DC_MEDIUM_MSGRTM_PKT:
+	case EFA_RDM_DC_MEDIUM_TAGRTM_PKT:
+	case EFA_RDM_LONGCTS_MSGRTM_PKT:
+	case EFA_RDM_LONGCTS_TAGRTM_PKT:
+	case EFA_RDM_DC_LONGCTS_MSGRTM_PKT:
+	case EFA_RDM_DC_LONGCTS_TAGRTM_PKT:
+	case EFA_RDM_LONGREAD_RTA_MSGRTM_PKT:
+	case EFA_RDM_LONGREAD_RTA_TAGRTM_PKT:
+	case EFA_RDM_RUNTREAD_MSGRTM_PKT:
+	case EFA_RDM_RUNTREAD_TAGRTM_PKT:
+	case EFA_RDM_WRITE_RTA_PKT:
+	case EFA_RDM_DC_WRITE_RTA_PKT:
+	case EFA_RDM_FETCH_RTA_PKT:
+	case EFA_RDM_COMPARE_RTA_PKT:
 		efa_rdm_pke_handle_rtm_rta_recv(pkt_entry);
 		return;
-	case RXR_EAGER_RTW_PKT:
+	case EFA_RDM_EAGER_RTW_PKT:
 		efa_rdm_pke_handle_eager_rtw_recv(pkt_entry);
 		return;
-	case RXR_LONGCTS_RTW_PKT:
-	case RXR_DC_LONGCTS_RTW_PKT:
+	case EFA_RDM_LONGCTS_RTW_PKT:
+	case EFA_RDM_DC_LONGCTS_RTW_PKT:
 		efa_rdm_pke_handle_longcts_rtw_recv(pkt_entry);
 		return;
-	case RXR_LONGREAD_RTW_PKT:
+	case EFA_RDM_LONGREAD_RTA_RTW_PKT:
 		efa_rdm_pke_handle_longread_rtw_recv(pkt_entry);
 		return;
-	case RXR_SHORT_RTR_PKT:
-	case RXR_LONGCTS_RTR_PKT:
+	case EFA_RDM_SHORT_RTR_PKT:
+	case EFA_RDM_LONGCTS_RTR_PKT:
 		efa_rdm_pke_handle_rtr_recv(pkt_entry);
 		return;
-	case RXR_DC_EAGER_RTW_PKT:
+	case EFA_RDM_DC_EAGER_RTW_PKT:
 		efa_rdm_pke_handle_dc_eager_rtw_recv(pkt_entry);
 		return;
 	default:
@@ -863,10 +863,10 @@ void efa_rdm_pke_proc_received(struct efa_rdm_pke *pkt_entry)
  */
 fi_addr_t efa_rdm_pke_determine_addr(struct efa_rdm_pke *pkt_entry)
 {
-	struct rxr_base_hdr *base_hdr;
+	struct efa_rdm_base_hdr *base_hdr;
 
 	base_hdr = efa_rdm_pke_get_base_hdr(pkt_entry);
-	if (base_hdr->type >= RXR_REQ_PKT_BEGIN && efa_rdm_pke_get_req_raw_addr(pkt_entry)) {
+	if (base_hdr->type >= EFA_RDM_REQ_PKT_BEGIN && efa_rdm_pke_get_req_raw_addr(pkt_entry)) {
 		void *raw_addr;
 		raw_addr = efa_rdm_pke_get_req_raw_addr(pkt_entry);
 		assert(raw_addr);
@@ -887,7 +887,7 @@ void efa_rdm_pke_handle_recv_completion(struct efa_rdm_pke *pkt_entry)
 	int pkt_type;
 	struct efa_rdm_ep *ep;
 	struct efa_rdm_peer *peer;
-	struct rxr_base_hdr *base_hdr;
+	struct efa_rdm_base_hdr *base_hdr;
 	struct efa_rdm_ope *zcpy_rxe = NULL;
 
 	ep = pkt_entry->ep;
@@ -895,7 +895,7 @@ void efa_rdm_pke_handle_recv_completion(struct efa_rdm_pke *pkt_entry)
 
 	base_hdr = efa_rdm_pke_get_base_hdr(pkt_entry);
 	pkt_type = base_hdr->type;
-	if (pkt_type >= RXR_EXTRA_REQ_PKT_END) {
+	if (pkt_type >= EFA_RDM_EXTRA_REQ_PKT_END) {
 		EFA_WARN(FI_LOG_CQ,
 			"Peer %d is requesting feature %d, which this EP does not support.\n",
 			(int)pkt_entry->addr, base_hdr->type);
@@ -928,7 +928,7 @@ void efa_rdm_pke_handle_recv_completion(struct efa_rdm_pke *pkt_entry)
 		dlist_insert_tail(&pkt_entry->dbg_entry, &ep->rx_pkt_list);
 	}
 #ifdef ENABLE_efa_rdm_pke_DUMP
-	efa_rdm_pke_print("Received", ep, (struct rxr_base_hdr *)pkt_entry->wiredata);
+	efa_rdm_pke_print("Received", ep, (struct efa_rdm_base_hdr *)pkt_entry->wiredata);
 #endif
 #endif
 	peer = efa_rdm_ep_get_peer(ep, pkt_entry->addr);
@@ -954,7 +954,7 @@ void efa_rdm_pke_handle_recv_completion(struct efa_rdm_pke *pkt_entry)
 
 	efa_rdm_pke_proc_received(pkt_entry);
 
-	if (zcpy_rxe && pkt_type != RXR_EAGER_MSGRTM_PKT) {
+	if (zcpy_rxe && pkt_type != EFA_RDM_EAGER_MSGRTM_PKT) {
 		/* user buffer was not matched with a message,
 		 * therefore reposting the buffer */
 		efa_rdm_ep_post_user_recv_buf(ep, zcpy_rxe, 0);
@@ -971,7 +971,7 @@ void efa_rdm_pke_handle_recv_completion(struct efa_rdm_pke *pkt_entry)
 
 static
 void efa_rdm_pke_print_handshake(char *prefix,
-			         struct rxr_handshake_hdr *handshake_hdr)
+			         struct efa_rdm_handshake_hdr *handshake_hdr)
 {
 	EFA_DBG(FI_LOG_EP_DATA,
 	       "%s RxR HANDSHAKE packet - version: %" PRIu8
@@ -984,7 +984,7 @@ void efa_rdm_pke_print_handshake(char *prefix,
 }
 
 static
-void efa_rdm_pke_print_cts(char *prefix, struct rxr_cts_hdr *cts_hdr)
+void efa_rdm_pke_print_cts(char *prefix, struct efa_rdm_cts_hdr *cts_hdr)
 {
 	EFA_DBG(FI_LOG_EP_DATA,
 	       "%s RxR CTS packet - version: %"	PRIu8
@@ -998,7 +998,7 @@ void efa_rdm_pke_print_cts(char *prefix, struct rxr_cts_hdr *cts_hdr)
 static
 void efa_rdm_pke_print_data(char *prefix, struct efa_rdm_pke *pkt_entry)
 {
-	struct rxr_ctsdata_hdr *data_hdr;
+	struct efa_rdm_ctsdata_hdr *data_hdr;
 	char str[efa_rdm_pke_DUMP_DATA_LEN * 4];
 	size_t str_len = efa_rdm_pke_DUMP_DATA_LEN * 4, l, hdr_size;
 	uint8_t *data;
@@ -1017,9 +1017,9 @@ void efa_rdm_pke_print_data(char *prefix, struct efa_rdm_pke *pkt_entry)
 	       data_hdr->recv_id, data_hdr->seg_length,
 	       data_hdr->seg_offset);
 
-	hdr_size = sizeof(struct rxr_ctsdata_hdr);
-	if (data_hdr->flags & RXR_PKT_CONNID_HDR) {
-		hdr_size += sizeof(struct rxr_ctsdata_opt_connid_hdr);
+	hdr_size = sizeof(struct efa_rdm_ctsdata_hdr);
+	if (data_hdr->flags & EFA_RDM_PKT_CONNID_HDR) {
+		hdr_size += sizeof(struct efa_rdm_ctsdata_opt_connid_hdr);
 		EFA_DBG(FI_LOG_EP_DATA,
 		       "sender_connid: %d\n",
 		       data_hdr->connid_hdr->connid);
@@ -1037,18 +1037,18 @@ void efa_rdm_pke_print_data(char *prefix, struct efa_rdm_pke *pkt_entry)
 
 void efa_rdm_pke_print(struct efa_rdm_pke *pkt_entry, char *prefix)
 {
-	struct rxr_base_hdr *hdr;
+	struct efa_rdm_base_hdr *hdr;
 
 	hdr = efa_rdm_pke_get_base_hdr(pkt_entry);
 
 	switch (hdr->type) {
-	case RXR_HANDSHAKE_PKT:
+	case EFA_RDM_HANDSHAKE_PKT:
 		efa_rdm_pke_print_handshake(prefix, efa_rdm_pke_get_handshake_hdr(pkt_entry));
 		break;
-	case RXR_CTS_PKT:
+	case EFA_RDM_CTS_PKT:
 		efa_rdm_pke_print_cts(prefix, efa_rdm_pke_get_cts_hdr(pkt_entry));
 		break;
-	case RXR_CTSDATA_PKT:
+	case EFA_RDM_CTSDATA_PKT:
 		efa_rdm_pke_print_data(prefix, pkt_entry);
 		break;
 	default:

--- a/prov/efa/src/rdm/efa_rdm_pke_nonreq.h
+++ b/prov/efa/src/rdm/efa_rdm_pke_nonreq.h
@@ -43,23 +43,23 @@ struct efa_rdm_peer;
 
 /* HANDSHAKE packet related functions */
 static inline
-struct rxr_handshake_hdr *efa_rdm_pke_get_handshake_hdr(struct efa_rdm_pke *pke)
+struct efa_rdm_handshake_hdr *efa_rdm_pke_get_handshake_hdr(struct efa_rdm_pke *pke)
 {
-	return (struct rxr_handshake_hdr *)pke->wiredata;
+	return (struct efa_rdm_handshake_hdr *)pke->wiredata;
 }
 
 static inline
-struct rxr_handshake_opt_connid_hdr *efa_rdm_pke_get_handshake_opt_connid_hdr(struct efa_rdm_pke *pke)
+struct efa_rdm_handshake_opt_connid_hdr *efa_rdm_pke_get_handshake_opt_connid_hdr(struct efa_rdm_pke *pke)
 {
-	struct rxr_handshake_hdr *handshake_hdr;
+	struct efa_rdm_handshake_hdr *handshake_hdr;
 	size_t base_hdr_size;
 
-	handshake_hdr = (struct rxr_handshake_hdr *)pke->wiredata;
-	assert(handshake_hdr->type == RXR_HANDSHAKE_PKT);
-	assert(handshake_hdr->flags & RXR_PKT_CONNID_HDR);
-	base_hdr_size = sizeof(struct rxr_handshake_hdr) +
+	handshake_hdr = (struct efa_rdm_handshake_hdr *)pke->wiredata;
+	assert(handshake_hdr->type == EFA_RDM_HANDSHAKE_PKT);
+	assert(handshake_hdr->flags & EFA_RDM_PKT_CONNID_HDR);
+	base_hdr_size = sizeof(struct efa_rdm_handshake_hdr) +
 			(handshake_hdr->nextra_p3 - 3) * sizeof(uint64_t);
-	return (struct rxr_handshake_opt_connid_hdr *)((char *)pke->wiredata + base_hdr_size);
+	return (struct efa_rdm_handshake_opt_connid_hdr *)((char *)pke->wiredata + base_hdr_size);
 }
 
 /**
@@ -72,28 +72,28 @@ struct rxr_handshake_opt_connid_hdr *efa_rdm_pke_get_handshake_opt_connid_hdr(st
 static inline
 uint64_t *efa_rdm_pke_get_handshake_opt_host_id_ptr(struct efa_rdm_pke *pke)
 {
-	struct rxr_base_hdr *base_hdr = efa_rdm_pke_get_base_hdr(pke);
-	struct rxr_handshake_hdr *handshake_hdr;
-	struct rxr_handshake_opt_host_id_hdr *handshake_opt_host_id_hdr;
+	struct efa_rdm_base_hdr *base_hdr = efa_rdm_pke_get_base_hdr(pke);
+	struct efa_rdm_handshake_hdr *handshake_hdr;
+	struct efa_rdm_handshake_opt_host_id_hdr *handshake_opt_host_id_hdr;
 	size_t offset = 0;
 
-	if (base_hdr->type != RXR_HANDSHAKE_PKT || !(base_hdr->flags & RXR_HANDSHAKE_HOST_ID_HDR))
+	if (base_hdr->type != EFA_RDM_HANDSHAKE_PKT || !(base_hdr->flags & EFA_RDM_HANDSHAKE_HOST_ID_HDR))
 		return NULL;
 
-	handshake_hdr = (struct rxr_handshake_hdr *)pke->wiredata;
-	assert(handshake_hdr->type == RXR_HANDSHAKE_PKT);
+	handshake_hdr = (struct efa_rdm_handshake_hdr *)pke->wiredata;
+	assert(handshake_hdr->type == EFA_RDM_HANDSHAKE_PKT);
 
-	offset += sizeof(struct rxr_handshake_hdr) +
+	offset += sizeof(struct efa_rdm_handshake_hdr) +
 		  (handshake_hdr->nextra_p3 - 3) * sizeof(uint64_t);
 
-	assert(handshake_hdr->flags & RXR_HANDSHAKE_HOST_ID_HDR);
+	assert(handshake_hdr->flags & EFA_RDM_HANDSHAKE_HOST_ID_HDR);
 
-	if (handshake_hdr->flags & RXR_PKT_CONNID_HDR) {
+	if (handshake_hdr->flags & EFA_RDM_PKT_CONNID_HDR) {
 		/* HOST_ID_HDR is always immediately after CONNID_HDR(if present) */
-		offset += sizeof(struct rxr_handshake_opt_connid_hdr);
+		offset += sizeof(struct efa_rdm_handshake_opt_connid_hdr);
 	}
 
-	handshake_opt_host_id_hdr = (struct rxr_handshake_opt_host_id_hdr *)(pke->wiredata + offset);
+	handshake_opt_host_id_hdr = (struct efa_rdm_handshake_opt_host_id_hdr *)(pke->wiredata + offset);
 	return &handshake_opt_host_id_hdr->host_id;
 }
 
@@ -104,9 +104,9 @@ void efa_rdm_pke_handle_handshake_recv(struct efa_rdm_pke *pkt_entry);
 
 /* CTS packet related functions */
 static inline
-struct rxr_cts_hdr *efa_rdm_pke_get_cts_hdr(struct efa_rdm_pke *pke)
+struct efa_rdm_cts_hdr *efa_rdm_pke_get_cts_hdr(struct efa_rdm_pke *pke)
 {
-	return (struct rxr_cts_hdr *)pke->wiredata;
+	return (struct efa_rdm_cts_hdr *)pke->wiredata;
 }
 
 void efa_rdm_pke_calc_cts_window_credits(struct efa_rdm_peer *peer,
@@ -121,9 +121,9 @@ void efa_rdm_pke_handle_cts_sent(struct efa_rdm_pke *pkt_entry);
 void efa_rdm_pke_handle_cts_recv(struct efa_rdm_pke *pkt_entry);
 
 static inline
-struct rxr_ctsdata_hdr *efa_rdm_pke_get_ctsdata_hdr(struct efa_rdm_pke *pke)
+struct efa_rdm_ctsdata_hdr *efa_rdm_pke_get_ctsdata_hdr(struct efa_rdm_pke *pke)
 {
-	return (struct rxr_ctsdata_hdr *)pke->wiredata;
+	return (struct efa_rdm_ctsdata_hdr *)pke->wiredata;
 }
 
 int efa_rdm_pke_init_ctsdata(struct efa_rdm_pke *pkt_entry,
@@ -138,9 +138,9 @@ void efa_rdm_pke_handle_ctsdata_send_completion(struct efa_rdm_pke *pkt_entry);
 void efa_rdm_pke_handle_ctsdata_recv(struct efa_rdm_pke *pkt_entry);
 
 /* READRSP packet related functions */
-static inline struct rxr_readrsp_hdr *efa_rdm_pke_get_readrsp_hdr(struct efa_rdm_pke *pke)
+static inline struct efa_rdm_readrsp_hdr *efa_rdm_pke_get_readrsp_hdr(struct efa_rdm_pke *pke)
 {
-	return (struct rxr_readrsp_hdr *)pke->wiredata;
+	return (struct efa_rdm_readrsp_hdr *)pke->wiredata;
 }
 
 int efa_rdm_pke_init_readrsp(struct efa_rdm_pke *pkt_entry,
@@ -161,7 +161,7 @@ struct efa_rdm_rma_context_pkt {
 	uint8_t type;
 	uint8_t version;
 	uint16_t flags;
-	/* end of rxr_base_hdr */
+	/* end of efa_rdm_base_hdr */
 	uint32_t context_type;
 	uint32_t tx_id; /* used by write context */
 	uint32_t read_id; /* used by read context */
@@ -186,9 +186,9 @@ void efa_rdm_pke_handle_rma_completion(struct efa_rdm_pke *pkt_entry);
 
 /* EOR packet related functions */
 static inline
-struct rxr_eor_hdr *efa_rdm_pke_get_eor_hdr(struct efa_rdm_pke *pke)
+struct efa_rdm_eor_hdr *efa_rdm_pke_get_eor_hdr(struct efa_rdm_pke *pke)
 {
-	return (struct rxr_eor_hdr *)pke->wiredata;
+	return (struct efa_rdm_eor_hdr *)pke->wiredata;
 }
 
 int efa_rdm_pke_init_eor(struct efa_rdm_pke *pkt_entry,
@@ -199,9 +199,9 @@ void efa_rdm_pke_handle_eor_send_completion(struct efa_rdm_pke *pkt_entry);
 void efa_rdm_pke_handle_eor_recv(struct efa_rdm_pke *pkt_entry);
 
 /* ATOMRSP packet related functions */
-static inline struct rxr_atomrsp_hdr *efa_rdm_pke_get_atomrsp_hdr(struct efa_rdm_pke *pke)
+static inline struct efa_rdm_atomrsp_hdr *efa_rdm_pke_get_atomrsp_hdr(struct efa_rdm_pke *pke)
 {
-	return (struct rxr_atomrsp_hdr *)pke->wiredata;
+	return (struct efa_rdm_atomrsp_hdr *)pke->wiredata;
 }
 
 int efa_rdm_pke_init_atomrsp(struct efa_rdm_pke *pkt_entry, struct efa_rdm_ope *rxe);
@@ -214,9 +214,9 @@ void efa_rdm_pke_handle_atomrsp_recv(struct efa_rdm_pke *pkt_entry);
 
 /* RECEIPT packet related functions */
 static inline
-struct rxr_receipt_hdr *efa_rdm_pke_get_receipt_hdr(struct efa_rdm_pke *pke)
+struct efa_rdm_receipt_hdr *efa_rdm_pke_get_receipt_hdr(struct efa_rdm_pke *pke)
 {
-	return (struct rxr_receipt_hdr *)pke->wiredata;
+	return (struct efa_rdm_receipt_hdr *)pke->wiredata;
 }
 
 int efa_rdm_pke_init_receipt(struct efa_rdm_pke *pkt_entry, struct efa_rdm_ope *rxe);

--- a/prov/efa/src/rdm/efa_rdm_pke_rta.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_rta.c
@@ -50,8 +50,8 @@
  * 
  * @param[in,out]	pkt_entry	packet entry
  * @param[in]		pkt_type	packet type. possible values are:
- * 					RXR_WRITE_RTA_PKT, RXR_FETCH_RTA_PKT and
- *					RXR_COMPARE_RTA_PKT
+ * 					EFA_RDM_WRITE_RTA_PKT, EFA_RDM_FETCH_RTA_PKT and
+ *					EFA_RDM_COMPARE_RTA_PKT
  * @param[in]		txe		TX entry that has information of the
  * 					atomic operation
  * @retunrns
@@ -65,19 +65,19 @@ ssize_t efa_rdm_pke_init_rta_common(struct efa_rdm_pke *pkt_entry,
 				    struct efa_rdm_ope *txe)
 {
 	struct efa_rma_iov *rma_iov;
-	struct rxr_rta_hdr *rta_hdr;
+	struct efa_rdm_rta_hdr *rta_hdr;
 	char *data;
 	size_t hdr_size, data_size;
 	ssize_t ret;
 	int i;
 
-	rta_hdr = (struct rxr_rta_hdr *)pkt_entry->wiredata;
+	rta_hdr = (struct efa_rdm_rta_hdr *)pkt_entry->wiredata;
 	rta_hdr->msg_id = txe->msg_id;
 	rta_hdr->rma_iov_count = txe->rma_iov_count;
 	rta_hdr->atomic_datatype = txe->atomic_hdr.datatype;
 	rta_hdr->atomic_op = txe->atomic_hdr.atomic_op;
 	efa_rdm_pke_init_req_hdr_common(pkt_entry, pkt_type, txe);
-	rta_hdr->flags |= RXR_REQ_ATOMIC;
+	rta_hdr->flags |= EFA_RDM_REQ_ATOMIC;
 	rma_iov = rta_hdr->rma_iov;
 	for (i=0; i < txe->rma_iov_count; ++i) {
 		rma_iov[i].addr = txe->rma_iov[i].addr;
@@ -118,7 +118,7 @@ ssize_t efa_rdm_pke_init_rta_common(struct efa_rdm_pke *pkt_entry,
 struct efa_rdm_ope *efa_rdm_pke_alloc_rta_rxe(struct efa_rdm_pke *pkt_entry, int op)
 {
 	struct efa_rdm_ope *rxe;
-	struct rxr_rta_hdr *rta_hdr;
+	struct efa_rdm_rta_hdr *rta_hdr;
 
 	rxe = efa_rdm_ep_alloc_rxe(pkt_entry->ep, pkt_entry->addr, op);
 	if (OFI_UNLIKELY(!rxe)) {
@@ -132,7 +132,7 @@ struct efa_rdm_ope *efa_rdm_pke_alloc_rta_rxe(struct efa_rdm_pke *pkt_entry, int
 		return rxe;
 	}
 
-	rta_hdr = (struct rxr_rta_hdr *)pkt_entry->wiredata;
+	rta_hdr = (struct efa_rdm_rta_hdr *)pkt_entry->wiredata;
 	rxe->atomic_hdr.atomic_op = rta_hdr->atomic_op;
 	rxe->atomic_hdr.datatype = rta_hdr->atomic_datatype;
 
@@ -178,7 +178,7 @@ struct efa_rdm_ope *efa_rdm_pke_alloc_rta_rxe(struct efa_rdm_pke *pkt_entry, int
 ssize_t efa_rdm_pke_init_write_rta(struct efa_rdm_pke *pkt_entry,
 				   struct efa_rdm_ope *txe)
 {
-	efa_rdm_pke_init_rta_common(pkt_entry, RXR_WRITE_RTA_PKT, txe);
+	efa_rdm_pke_init_rta_common(pkt_entry, EFA_RDM_WRITE_RTA_PKT, txe);
 	return 0;
 }
 
@@ -226,14 +226,14 @@ int efa_rdm_pke_proc_write_rta(struct efa_rdm_pke *pkt_entry)
 {
 	struct iovec iov[RXR_IOV_LIMIT];
 	struct efa_mr *efa_mr;
-	struct rxr_rta_hdr *rta_hdr;
+	struct efa_rdm_rta_hdr *rta_hdr;
 	void *desc[RXR_IOV_LIMIT];
 	char *data;
 	int iov_count, op, dt, i, err;
 	size_t dtsize, offset, hdr_size;
 	enum fi_hmem_iface hmem_iface;
 
-	rta_hdr = (struct rxr_rta_hdr *)pkt_entry->wiredata;
+	rta_hdr = (struct efa_rdm_rta_hdr *)pkt_entry->wiredata;
 	op = rta_hdr->atomic_op;
 	dt = rta_hdr->atomic_datatype;
 	dtsize = ofi_datatype_size(dt);
@@ -287,10 +287,10 @@ ssize_t efa_rdm_pke_init_dc_write_rta(struct efa_rdm_pke *pkt_entry,
 				      struct efa_rdm_ope *txe)
 
 {
-	struct rxr_rta_hdr *rta_hdr;
+	struct efa_rdm_rta_hdr *rta_hdr;
 
 	txe->rxr_flags |= EFA_RDM_TXE_DELIVERY_COMPLETE_REQUESTED;
-	efa_rdm_pke_init_rta_common(pkt_entry, RXR_DC_WRITE_RTA_PKT, txe);
+	efa_rdm_pke_init_rta_common(pkt_entry, EFA_RDM_DC_WRITE_RTA_PKT, txe);
 	rta_hdr = efa_rdm_pke_get_rta_hdr(pkt_entry);
 	rta_hdr->send_id = txe->tx_id;
 	return 0;
@@ -304,7 +304,7 @@ ssize_t efa_rdm_pke_init_dc_write_rta(struct efa_rdm_pke *pkt_entry,
 int efa_rdm_pke_proc_dc_write_rta(struct efa_rdm_pke *pkt_entry)
 {
 	struct efa_rdm_ope *rxe;
-	struct rxr_rta_hdr *rta_hdr;
+	struct efa_rdm_rta_hdr *rta_hdr;
 	ssize_t err;
 	int ret;
 
@@ -315,7 +315,7 @@ int efa_rdm_pke_proc_dc_write_rta(struct efa_rdm_pke *pkt_entry)
 		return -FI_ENOBUFS;
 	}
 
-	rta_hdr = (struct rxr_rta_hdr *)pkt_entry->wiredata;
+	rta_hdr = (struct efa_rdm_rta_hdr *)pkt_entry->wiredata;
 	rxe->tx_id = rta_hdr->send_id;
 	rxe->rxr_flags |= EFA_RDM_TXE_DELIVERY_COMPLETE_REQUESTED;
 
@@ -325,7 +325,7 @@ int efa_rdm_pke_proc_dc_write_rta(struct efa_rdm_pke *pkt_entry)
 		return ret;
 	}
 
-	err = efa_rdm_ope_post_send_or_queue(rxe, RXR_RECEIPT_PKT);
+	err = efa_rdm_ope_post_send_or_queue(rxe, EFA_RDM_RECEIPT_PKT);
 	if (OFI_UNLIKELY(err)) {
 		EFA_WARN(FI_LOG_CQ,
 			"Posting of receipt packet failed! err=%s\n",
@@ -354,9 +354,9 @@ ssize_t efa_rdm_pke_init_fetch_rta(struct efa_rdm_pke *pkt_entry,
 				   struct efa_rdm_ope *txe)
 
 {
-	struct rxr_rta_hdr *rta_hdr;
+	struct efa_rdm_rta_hdr *rta_hdr;
 
-	efa_rdm_pke_init_rta_common(pkt_entry, RXR_FETCH_RTA_PKT, txe);
+	efa_rdm_pke_init_rta_common(pkt_entry, EFA_RDM_FETCH_RTA_PKT, txe);
 	rta_hdr = efa_rdm_pke_get_rta_hdr(pkt_entry);
 	rta_hdr->recv_id = txe->tx_id;
 	return 0;
@@ -443,7 +443,7 @@ int efa_rdm_pke_proc_fetch_rta(struct efa_rdm_pke *pkt_entry)
 		offset += rxe->iov[i].iov_len;
 	}
 
-	err = efa_rdm_ope_post_send_or_queue(rxe, RXR_ATOMRSP_PKT);
+	err = efa_rdm_ope_post_send_or_queue(rxe, EFA_RDM_ATOMRSP_PKT);
 	if (OFI_UNLIKELY(err))
 		efa_rdm_rxe_handle_error(rxe, -err, FI_EFA_ERR_PKT_POST);
 
@@ -471,11 +471,11 @@ ssize_t efa_rdm_pke_init_compare_rta(struct efa_rdm_pke *pkt_entry,
 	char *data;
 	size_t data_size;
 	ssize_t ret;
-	struct rxr_rta_hdr *rta_hdr;
+	struct efa_rdm_rta_hdr *rta_hdr;
 
 	/* TODO Add check here to fail if buf size + compare_size > mtu_size - header_size */
 
-	efa_rdm_pke_init_rta_common(pkt_entry, RXR_COMPARE_RTA_PKT, txe);
+	efa_rdm_pke_init_rta_common(pkt_entry, EFA_RDM_COMPARE_RTA_PKT, txe);
 	rta_hdr = efa_rdm_pke_get_rta_hdr(pkt_entry);
 	rta_hdr->recv_id = txe->tx_id;
 	/* efa_rdm_pke_init_rta() will copy data from txe->iov to pkt entry
@@ -578,7 +578,7 @@ int efa_rdm_pke_proc_compare_rta(struct efa_rdm_pke *pkt_entry)
 		}
 	}
 
-	err = efa_rdm_ope_post_send_or_queue(rxe, RXR_ATOMRSP_PKT);
+	err = efa_rdm_ope_post_send_or_queue(rxe, EFA_RDM_ATOMRSP_PKT);
 	if (OFI_UNLIKELY(err)) {
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_EIO, FI_EFA_ERR_PKT_POST);
 		ofi_buf_free(rxe->atomrsp_data);

--- a/prov/efa/src/rdm/efa_rdm_pke_rta.h
+++ b/prov/efa/src/rdm/efa_rdm_pke_rta.h
@@ -37,9 +37,9 @@
 #include "efa_rdm_protocol.h"
 
 static inline
-struct rxr_rta_hdr *efa_rdm_pke_get_rta_hdr(struct efa_rdm_pke *pkt_entry)
+struct efa_rdm_rta_hdr *efa_rdm_pke_get_rta_hdr(struct efa_rdm_pke *pkt_entry)
 {
-	return (struct rxr_rta_hdr *)pkt_entry->wiredata;
+	return (struct efa_rdm_rta_hdr *)pkt_entry->wiredata;
 }
 
 ssize_t efa_rdm_pke_init_write_rta(struct efa_rdm_pke *pkt_entry, struct efa_rdm_ope *txe);

--- a/prov/efa/src/rdm/efa_rdm_pke_rtm.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtm.c
@@ -64,31 +64,31 @@
  */
 size_t efa_rdm_pke_get_rtm_msg_length(struct efa_rdm_pke *pkt_entry)
 {
-	struct rxr_base_hdr *base_hdr;
+	struct efa_rdm_base_hdr *base_hdr;
 
 	base_hdr = efa_rdm_pke_get_base_hdr(pkt_entry);
 	switch (base_hdr->type) {
-	case RXR_EAGER_MSGRTM_PKT:
-	case RXR_EAGER_TAGRTM_PKT:
-	case RXR_DC_EAGER_MSGRTM_PKT:
-	case RXR_DC_EAGER_TAGRTM_PKT:
+	case EFA_RDM_EAGER_MSGRTM_PKT:
+	case EFA_RDM_EAGER_TAGRTM_PKT:
+	case EFA_RDM_DC_EAGER_MSGRTM_PKT:
+	case EFA_RDM_DC_EAGER_TAGRTM_PKT:
 		return pkt_entry->payload_size;
-	case RXR_MEDIUM_MSGRTM_PKT:
-	case RXR_MEDIUM_TAGRTM_PKT:
+	case EFA_RDM_MEDIUM_MSGRTM_PKT:
+	case EFA_RDM_MEDIUM_TAGRTM_PKT:
 		return efa_rdm_pke_get_medium_rtm_base_hdr(pkt_entry)->msg_length;
-	case RXR_DC_MEDIUM_MSGRTM_PKT:
-	case RXR_DC_MEDIUM_TAGRTM_PKT:
+	case EFA_RDM_DC_MEDIUM_MSGRTM_PKT:
+	case EFA_RDM_DC_MEDIUM_TAGRTM_PKT:
 		return efa_rdm_pke_get_dc_medium_rtm_base_hdr(pkt_entry)->msg_length;
-	case RXR_LONGCTS_MSGRTM_PKT:
-	case RXR_LONGCTS_TAGRTM_PKT:
-	case RXR_DC_LONGCTS_MSGRTM_PKT:
-	case RXR_DC_LONGCTS_TAGRTM_PKT:
+	case EFA_RDM_LONGCTS_MSGRTM_PKT:
+	case EFA_RDM_LONGCTS_TAGRTM_PKT:
+	case EFA_RDM_DC_LONGCTS_MSGRTM_PKT:
+	case EFA_RDM_DC_LONGCTS_TAGRTM_PKT:
 		return efa_rdm_pke_get_longcts_rtm_base_hdr(pkt_entry)->msg_length;
-	case RXR_LONGREAD_MSGRTM_PKT:
-	case RXR_LONGREAD_TAGRTM_PKT:
+	case EFA_RDM_LONGREAD_RTA_MSGRTM_PKT:
+	case EFA_RDM_LONGREAD_RTA_TAGRTM_PKT:
 		return efa_rdm_pke_get_longread_rtm_base_hdr(pkt_entry)->msg_length;
-	case RXR_RUNTREAD_MSGRTM_PKT:
-	case RXR_RUNTREAD_TAGRTM_PKT:
+	case EFA_RDM_RUNTREAD_MSGRTM_PKT:
+	case EFA_RDM_RUNTREAD_TAGRTM_PKT:
 		return efa_rdm_pke_get_runtread_rtm_base_hdr(pkt_entry)->msg_length;
 	default:
 		assert(0 && "Unknown REQ packet type\n");
@@ -124,13 +124,13 @@ ssize_t efa_rdm_pke_init_rtm_with_payload(struct efa_rdm_pke *pkt_entry,
 					  size_t segment_offset,
 					  int data_size)
 {
-	struct rxr_rtm_base_hdr *rtm_hdr;
+	struct efa_rdm_rtm_base_hdr *rtm_hdr;
 	int ret;
 
 	efa_rdm_pke_init_req_hdr_common(pkt_entry, pkt_type, txe);
 
-	rtm_hdr = (struct rxr_rtm_base_hdr *)pkt_entry->wiredata;
-	rtm_hdr->flags |= RXR_REQ_MSG;
+	rtm_hdr = (struct efa_rdm_rtm_base_hdr *)pkt_entry->wiredata;
+	rtm_hdr->flags |= EFA_RDM_REQ_MSG;
 	rtm_hdr->msg_id = txe->msg_id;
 
 	if (data_size == -1) {
@@ -175,10 +175,10 @@ ssize_t efa_rdm_pke_init_rtm_with_payload(struct efa_rdm_pke *pkt_entry,
 void efa_rdm_pke_rtm_update_rxe(struct efa_rdm_pke *pkt_entry,
 				struct efa_rdm_ope *rxe)
 {
-	struct rxr_base_hdr *base_hdr;
+	struct efa_rdm_base_hdr *base_hdr;
 
 	base_hdr = efa_rdm_pke_get_base_hdr(pkt_entry);
-	if (base_hdr->flags & RXR_REQ_OPT_CQ_DATA_HDR) {
+	if (base_hdr->flags & EFA_RDM_REQ_OPT_CQ_DATA_HDR) {
 		rxe->cq_entry.flags |= FI_REMOTE_CQ_DATA;
 		rxe->cq_entry.data = efa_rdm_pke_get_req_cq_data(pkt_entry);
 	}
@@ -230,42 +230,42 @@ ssize_t efa_rdm_pke_proc_matched_rtm(struct efa_rdm_pke *pkt_entry)
 
 	pkt_type = efa_rdm_pke_get_base_hdr(pkt_entry)->type;
 
-	if (pkt_type > RXR_DC_REQ_PKT_BEGIN &&
-	    pkt_type < RXR_DC_REQ_PKT_END)
+	if (pkt_type > EFA_RDM_DC_REQ_PKT_BEGIN &&
+	    pkt_type < EFA_RDM_DC_REQ_PKT_END)
 		rxe->rxr_flags |= EFA_RDM_TXE_DELIVERY_COMPLETE_REQUESTED;
 
-	if (pkt_type == RXR_LONGCTS_MSGRTM_PKT ||
-	    pkt_type == RXR_LONGCTS_TAGRTM_PKT)
+	if (pkt_type == EFA_RDM_LONGCTS_MSGRTM_PKT ||
+	    pkt_type == EFA_RDM_LONGCTS_TAGRTM_PKT)
 		rxe->tx_id = efa_rdm_pke_get_longcts_rtm_base_hdr(pkt_entry)->send_id;
-	else if (pkt_type == RXR_DC_EAGER_MSGRTM_PKT ||
-		 pkt_type == RXR_DC_EAGER_TAGRTM_PKT)
+	else if (pkt_type == EFA_RDM_DC_EAGER_MSGRTM_PKT ||
+		 pkt_type == EFA_RDM_DC_EAGER_TAGRTM_PKT)
 		rxe->tx_id = efa_rdm_pke_get_dc_eager_rtm_base_hdr(pkt_entry)->send_id;
-	else if (pkt_type == RXR_DC_MEDIUM_MSGRTM_PKT ||
-		 pkt_type == RXR_DC_MEDIUM_TAGRTM_PKT)
+	else if (pkt_type == EFA_RDM_DC_MEDIUM_MSGRTM_PKT ||
+		 pkt_type == EFA_RDM_DC_MEDIUM_TAGRTM_PKT)
 		rxe->tx_id = efa_rdm_pke_get_dc_medium_rtm_base_hdr(pkt_entry)->send_id;
-	else if (pkt_type == RXR_DC_LONGCTS_MSGRTM_PKT ||
-		 pkt_type == RXR_DC_LONGCTS_TAGRTM_PKT)
+	else if (pkt_type == EFA_RDM_DC_LONGCTS_MSGRTM_PKT ||
+		 pkt_type == EFA_RDM_DC_LONGCTS_TAGRTM_PKT)
 		rxe->tx_id = efa_rdm_pke_get_longcts_rtm_base_hdr(pkt_entry)->send_id;
 
 	rxe->msg_id = efa_rdm_pke_get_rtm_base_hdr(pkt_entry)->msg_id;
 
-	if (pkt_type == RXR_LONGREAD_MSGRTM_PKT || pkt_type == RXR_LONGREAD_TAGRTM_PKT)
+	if (pkt_type == EFA_RDM_LONGREAD_RTA_MSGRTM_PKT || pkt_type == EFA_RDM_LONGREAD_RTA_TAGRTM_PKT)
 		return efa_rdm_pke_proc_matched_longread_rtm(pkt_entry);
 
 	if (efa_rdm_pkt_type_is_mulreq(pkt_type))
 		return efa_rdm_pke_proc_matched_mulreq_rtm(pkt_entry);
 
-	if (pkt_type == RXR_EAGER_MSGRTM_PKT ||
-	    pkt_type == RXR_EAGER_TAGRTM_PKT ||
-	    pkt_type == RXR_DC_EAGER_MSGRTM_PKT ||
-	    pkt_type == RXR_DC_EAGER_TAGRTM_PKT) {
+	if (pkt_type == EFA_RDM_EAGER_MSGRTM_PKT ||
+	    pkt_type == EFA_RDM_EAGER_TAGRTM_PKT ||
+	    pkt_type == EFA_RDM_DC_EAGER_MSGRTM_PKT ||
+	    pkt_type == EFA_RDM_DC_EAGER_TAGRTM_PKT) {
 		return efa_rdm_pke_proc_matched_eager_rtm(pkt_entry);
 	}
 
-	assert(pkt_type == RXR_LONGCTS_MSGRTM_PKT ||
-	       pkt_type == RXR_LONGCTS_TAGRTM_PKT ||
-	       pkt_type == RXR_DC_LONGCTS_MSGRTM_PKT ||
-	       pkt_type == RXR_DC_LONGCTS_TAGRTM_PKT);
+	assert(pkt_type == EFA_RDM_LONGCTS_MSGRTM_PKT ||
+	       pkt_type == EFA_RDM_LONGCTS_TAGRTM_PKT ||
+	       pkt_type == EFA_RDM_DC_LONGCTS_MSGRTM_PKT ||
+	       pkt_type == EFA_RDM_DC_LONGCTS_TAGRTM_PKT);
 
 	rxe->bytes_received += pkt_entry->payload_size;
 	ret = efa_rdm_pke_copy_payload_to_ope(pkt_entry, rxe);
@@ -277,7 +277,7 @@ ssize_t efa_rdm_pke_proc_matched_rtm(struct efa_rdm_pke *pkt_entry)
 	ep->pending_recv_counter++;
 #endif
 	rxe->state = EFA_RDM_RXE_RECV;
-	ret = efa_rdm_ope_post_send_or_queue(rxe, RXR_CTS_PKT);
+	ret = efa_rdm_ope_post_send_or_queue(rxe, EFA_RDM_CTS_PKT);
 
 	return ret;
 }
@@ -372,38 +372,38 @@ ssize_t efa_rdm_pke_proc_tagrtm(struct efa_rdm_pke *pkt_entry)
 ssize_t efa_rdm_pke_proc_rtm_rta(struct efa_rdm_pke *pkt_entry)
 {
 	struct efa_rdm_ep *ep;
-	struct rxr_base_hdr *base_hdr;
+	struct efa_rdm_base_hdr *base_hdr;
 
 	ep = pkt_entry->ep;
 	base_hdr = efa_rdm_pke_get_base_hdr(pkt_entry);
-	assert(base_hdr->type >= RXR_BASELINE_REQ_PKT_BEGIN);
+	assert(base_hdr->type >= EFA_RDM_BASELINE_REQ_PKT_BEGIN);
 
 	switch (base_hdr->type) {
-	case RXR_EAGER_MSGRTM_PKT:
-	case RXR_MEDIUM_MSGRTM_PKT:
-	case RXR_LONGCTS_MSGRTM_PKT:
-	case RXR_LONGREAD_MSGRTM_PKT:
-	case RXR_RUNTREAD_MSGRTM_PKT:
-	case RXR_DC_EAGER_MSGRTM_PKT:
-	case RXR_DC_MEDIUM_MSGRTM_PKT:
-	case RXR_DC_LONGCTS_MSGRTM_PKT:
+	case EFA_RDM_EAGER_MSGRTM_PKT:
+	case EFA_RDM_MEDIUM_MSGRTM_PKT:
+	case EFA_RDM_LONGCTS_MSGRTM_PKT:
+	case EFA_RDM_LONGREAD_RTA_MSGRTM_PKT:
+	case EFA_RDM_RUNTREAD_MSGRTM_PKT:
+	case EFA_RDM_DC_EAGER_MSGRTM_PKT:
+	case EFA_RDM_DC_MEDIUM_MSGRTM_PKT:
+	case EFA_RDM_DC_LONGCTS_MSGRTM_PKT:
 		return efa_rdm_pke_proc_msgrtm(pkt_entry);
-	case RXR_EAGER_TAGRTM_PKT:
-	case RXR_MEDIUM_TAGRTM_PKT:
-	case RXR_LONGCTS_TAGRTM_PKT:
-	case RXR_LONGREAD_TAGRTM_PKT:
-	case RXR_RUNTREAD_TAGRTM_PKT:
-	case RXR_DC_EAGER_TAGRTM_PKT:
-	case RXR_DC_MEDIUM_TAGRTM_PKT:
-	case RXR_DC_LONGCTS_TAGRTM_PKT:
+	case EFA_RDM_EAGER_TAGRTM_PKT:
+	case EFA_RDM_MEDIUM_TAGRTM_PKT:
+	case EFA_RDM_LONGCTS_TAGRTM_PKT:
+	case EFA_RDM_LONGREAD_RTA_TAGRTM_PKT:
+	case EFA_RDM_RUNTREAD_TAGRTM_PKT:
+	case EFA_RDM_DC_EAGER_TAGRTM_PKT:
+	case EFA_RDM_DC_MEDIUM_TAGRTM_PKT:
+	case EFA_RDM_DC_LONGCTS_TAGRTM_PKT:
 		return efa_rdm_pke_proc_tagrtm(pkt_entry);
-	case RXR_WRITE_RTA_PKT:
+	case EFA_RDM_WRITE_RTA_PKT:
 		return efa_rdm_pke_proc_write_rta(pkt_entry);
-	case RXR_DC_WRITE_RTA_PKT:
+	case EFA_RDM_DC_WRITE_RTA_PKT:
 		return efa_rdm_pke_proc_dc_write_rta(pkt_entry);
-	case RXR_FETCH_RTA_PKT:
+	case EFA_RDM_FETCH_RTA_PKT:
 		return efa_rdm_pke_proc_fetch_rta(pkt_entry);
-	case RXR_COMPARE_RTA_PKT:
+	case EFA_RDM_COMPARE_RTA_PKT:
 		return efa_rdm_pke_proc_compare_rta(pkt_entry);
 	default:
 		EFA_WARN(FI_LOG_EP_CTRL,
@@ -428,14 +428,14 @@ ssize_t efa_rdm_pke_proc_rtm_rta(struct efa_rdm_pke *pkt_entry)
 void efa_rdm_pke_handle_rtm_rta_recv(struct efa_rdm_pke *pkt_entry)
 {
 	struct efa_rdm_ep *ep;
-	struct rxr_base_hdr *base_hdr;
+	struct efa_rdm_base_hdr *base_hdr;
 	struct efa_rdm_peer *peer;
 	int ret, msg_id;
 
 	ep = pkt_entry->ep;
 
 	base_hdr = efa_rdm_pke_get_base_hdr(pkt_entry);
-	assert(base_hdr->type >= RXR_BASELINE_REQ_PKT_BEGIN);
+	assert(base_hdr->type >= EFA_RDM_BASELINE_REQ_PKT_BEGIN);
 
 	if (efa_rdm_pkt_type_is_mulreq(base_hdr->type)) {
 		struct efa_rdm_ope *rxe;
@@ -504,9 +504,9 @@ void efa_rdm_pke_handle_rtm_rta_recv(struct efa_rdm_pke *pkt_entry)
 }
 
 /**
- * @brief initialzie a RXR_EAGER_MSGRTM pacekt entry
+ * @brief initialzie a EFA_RDM_EAGER_MSGRTM pacekt entry
  * 
- * @param[in,out]	pkt_entry	RXR_EAGER_MSGRTM to be initialized
+ * @param[in,out]	pkt_entry	EFA_RDM_EAGER_MSGRTM to be initialized
  * @param[in]		txe		TX entry
  */
 ssize_t efa_rdm_pke_init_eager_msgrtm(struct efa_rdm_pke *pkt_entry,
@@ -515,7 +515,7 @@ ssize_t efa_rdm_pke_init_eager_msgrtm(struct efa_rdm_pke *pkt_entry,
 	int ret;
 
 	ret = efa_rdm_pke_init_rtm_with_payload(pkt_entry,
-						RXR_EAGER_MSGRTM_PKT,
+						EFA_RDM_EAGER_MSGRTM_PKT,
 						txe, 0, -1);
 	if (ret)
 		return ret;
@@ -525,41 +525,41 @@ ssize_t efa_rdm_pke_init_eager_msgrtm(struct efa_rdm_pke *pkt_entry,
 }
 
 /**
- * @brief initialize a RXR_EAGER_TAGRTM packet entry
- * @param[in,out]	pkt_entry	RXR_EAGER_TAGRTM to be initialized
+ * @brief initialize a EFA_RDM_EAGER_TAGRTM packet entry
+ * @param[in,out]	pkt_entry	EFA_RDM_EAGER_TAGRTM to be initialized
  * @param[in]		txe		TX entry
  */
 ssize_t efa_rdm_pke_init_eager_tagrtm(struct efa_rdm_pke *pkt_entry,
 				  struct efa_rdm_ope *txe)
 {
-	struct rxr_base_hdr *base_hdr;
+	struct efa_rdm_base_hdr *base_hdr;
 	int ret;
 
-	ret = efa_rdm_pke_init_rtm_with_payload(pkt_entry, RXR_EAGER_TAGRTM_PKT, txe, 0, -1);
+	ret = efa_rdm_pke_init_rtm_with_payload(pkt_entry, EFA_RDM_EAGER_TAGRTM_PKT, txe, 0, -1);
 	if (ret)
 		return ret;
 	assert(txe->total_len == pkt_entry->payload_size);
 	base_hdr = efa_rdm_pke_get_base_hdr(pkt_entry);
-	base_hdr->flags |= RXR_REQ_TAGGED;
+	base_hdr->flags |= EFA_RDM_REQ_TAGGED;
 	efa_rdm_pke_set_rtm_tag(pkt_entry, txe->tag);
 	return 0;
 }
 
 /**
- * @brief initialzie a RXR_DC_EAGER_MSGRTM pacekt entry
+ * @brief initialzie a EFA_RDM_DC_EAGER_MSGRTM pacekt entry
  * 
- * @param[in,out]	pkt_entry	RXR_DC_EAGER_MSGRTM to be initialized
+ * @param[in,out]	pkt_entry	EFA_RDM_DC_EAGER_MSGRTM to be initialized
  * @param[in]		txe		TX entry
  */
 ssize_t efa_rdm_pke_init_dc_eager_msgrtm(struct efa_rdm_pke *pkt_entry,
 					 struct efa_rdm_ope *txe)
 
 {
-	struct rxr_dc_eager_msgrtm_hdr *dc_eager_msgrtm_hdr;
+	struct efa_rdm_dc_eager_msgrtm_hdr *dc_eager_msgrtm_hdr;
 	int ret;
 
 	txe->rxr_flags |= EFA_RDM_TXE_DELIVERY_COMPLETE_REQUESTED;
-	ret = efa_rdm_pke_init_rtm_with_payload(pkt_entry, RXR_DC_EAGER_MSGRTM_PKT, txe, 0, -1);
+	ret = efa_rdm_pke_init_rtm_with_payload(pkt_entry, EFA_RDM_DC_EAGER_MSGRTM_PKT, txe, 0, -1);
 	if (ret)
 		return ret;
 	dc_eager_msgrtm_hdr = efa_rdm_pke_get_dc_eager_msgrtm_hdr(pkt_entry);
@@ -568,24 +568,24 @@ ssize_t efa_rdm_pke_init_dc_eager_msgrtm(struct efa_rdm_pke *pkt_entry,
 }
 
 /**
- * @brief initialize a RXR_DC_EAGER_TAGRTM pacekt entry
+ * @brief initialize a EFA_RDM_DC_EAGER_TAGRTM pacekt entry
  * 
- * @param[in,out]	pkt_entry	RXR_DC_EAGER_TAGRTM to be initialized
+ * @param[in,out]	pkt_entry	EFA_RDM_DC_EAGER_TAGRTM to be initialized
  * @param[in]		txe		TX entry
  */
 ssize_t efa_rdm_pke_init_dc_eager_tagrtm(struct efa_rdm_pke *pkt_entry,
 					 struct efa_rdm_ope *txe)
 {
-	struct rxr_base_hdr *base_hdr;
-	struct rxr_dc_eager_tagrtm_hdr *dc_eager_tagrtm_hdr;
+	struct efa_rdm_base_hdr *base_hdr;
+	struct efa_rdm_dc_eager_tagrtm_hdr *dc_eager_tagrtm_hdr;
 	int ret;
 
 	txe->rxr_flags |= EFA_RDM_TXE_DELIVERY_COMPLETE_REQUESTED;
-	ret = efa_rdm_pke_init_rtm_with_payload(pkt_entry, RXR_DC_EAGER_TAGRTM_PKT, txe, 0, -1);
+	ret = efa_rdm_pke_init_rtm_with_payload(pkt_entry, EFA_RDM_DC_EAGER_TAGRTM_PKT, txe, 0, -1);
 	if (ret)
 		return ret;
 	base_hdr = efa_rdm_pke_get_base_hdr(pkt_entry);
-	base_hdr->flags |= RXR_REQ_TAGGED;
+	base_hdr->flags |= EFA_RDM_REQ_TAGGED;
 	efa_rdm_pke_set_rtm_tag(pkt_entry, txe->tag);
 
 	dc_eager_tagrtm_hdr = efa_rdm_pke_get_dc_eager_tagrtm_hdr(pkt_entry);
@@ -672,9 +672,9 @@ ssize_t efa_rdm_pke_proc_matched_eager_rtm(struct efa_rdm_pke *pkt_entry)
 
 
 /**
- * @brief initialize a RXR_MEDIUM_MSGRTM packet
+ * @brief initialize a EFA_RDM_MEDIUM_MSGRTM packet
  * 
- * @param[in,out]	pkt_entry	RXR_MEDIUM_MSGRTM packet entry
+ * @param[in,out]	pkt_entry	EFA_RDM_MEDIUM_MSGRTM packet entry
  * @param[in]		txe		TX entry
  * @param[in]		segment_offset	data offset in repect of user buffer
  * @param[in]		data_size	data size in the unit of bytes
@@ -685,12 +685,12 @@ ssize_t efa_rdm_pke_init_medium_msgrtm(struct efa_rdm_pke *pkt_entry,
 				       int data_size)
 
 {
-	struct rxr_medium_rtm_base_hdr *rtm_hdr;
+	struct efa_rdm_medium_rtm_base_hdr *rtm_hdr;
 	int ret;
 
 	efa_rdm_ope_try_fill_desc(txe, 0, FI_SEND);
 
-	ret = efa_rdm_pke_init_rtm_with_payload(pkt_entry, RXR_MEDIUM_MSGRTM_PKT,
+	ret = efa_rdm_pke_init_rtm_with_payload(pkt_entry, EFA_RDM_MEDIUM_MSGRTM_PKT,
 						txe, segment_offset, data_size);
 	if (ret)
 		return ret;
@@ -702,9 +702,9 @@ ssize_t efa_rdm_pke_init_medium_msgrtm(struct efa_rdm_pke *pkt_entry,
 }
 
 /**
- * @brief initialize a RXR_MEDIUM_TAGRTM packet
+ * @brief initialize a EFA_RDM_MEDIUM_TAGRTM packet
  * 
- * @param[in,out]	pkt_entry	RXR_MEDIUM_TAGRTM packet entry
+ * @param[in,out]	pkt_entry	EFA_RDM_MEDIUM_TAGRTM packet entry
  * @param[in]		txe		TX entry
  * @param[in]		segment_offset	data offset in repect of user buffer
  * @param[in]		data_size	data size in the unit of bytes
@@ -714,12 +714,12 @@ ssize_t efa_rdm_pke_init_medium_tagrtm(struct efa_rdm_pke *pkt_entry,
 				       size_t segment_offset,
 				       int data_size)
 {
-	struct rxr_medium_rtm_base_hdr *rtm_hdr;
+	struct efa_rdm_medium_rtm_base_hdr *rtm_hdr;
 	int ret;
 
 	efa_rdm_ope_try_fill_desc(txe, 0, FI_SEND);
 
-	ret = efa_rdm_pke_init_rtm_with_payload(pkt_entry, RXR_MEDIUM_TAGRTM_PKT,
+	ret = efa_rdm_pke_init_rtm_with_payload(pkt_entry, EFA_RDM_MEDIUM_TAGRTM_PKT,
 						txe, segment_offset, data_size);
 	if (ret)
 		return ret;
@@ -727,18 +727,18 @@ ssize_t efa_rdm_pke_init_medium_tagrtm(struct efa_rdm_pke *pkt_entry,
 	rtm_hdr = efa_rdm_pke_get_medium_rtm_base_hdr(pkt_entry);
 	rtm_hdr->msg_length = txe->total_len;
 	rtm_hdr->seg_offset = segment_offset;
-	rtm_hdr->hdr.flags |= RXR_REQ_TAGGED;
+	rtm_hdr->hdr.flags |= EFA_RDM_REQ_TAGGED;
 	efa_rdm_pke_set_rtm_tag(pkt_entry, txe->tag);
 	return 0;
 }
 
 /**
- * @brief initialize a RXR_DC_MEDIUM_MSGRTM packet
+ * @brief initialize a EFA_RDM_DC_MEDIUM_MSGRTM packet
  *
  * @details
  * DC means delivery complete
  * 
- * @param[in,out]	pkt_entry	RXR_DC_MEDIUM_MSGRTM packet entry
+ * @param[in,out]	pkt_entry	EFA_RDM_DC_MEDIUM_MSGRTM packet entry
  * @param[in]		txe		TX entry
  * @param[in]		segment_offset	data offset in repect of user buffer
  * @param[in]		data_size	data size in the unit of bytes
@@ -748,14 +748,14 @@ ssize_t efa_rdm_pke_init_dc_medium_msgrtm(struct efa_rdm_pke *pkt_entry,
 					  size_t segment_offset,
 					  int data_size)
 {
-	struct rxr_dc_medium_msgrtm_hdr *dc_medium_msgrtm_hdr;
+	struct efa_rdm_dc_medium_msgrtm_hdr *dc_medium_msgrtm_hdr;
 	int ret;
 
 	txe->rxr_flags |= EFA_RDM_TXE_DELIVERY_COMPLETE_REQUESTED;
 
 	efa_rdm_ope_try_fill_desc(txe, 0, FI_SEND);
 
-	ret = efa_rdm_pke_init_rtm_with_payload(pkt_entry, RXR_DC_MEDIUM_MSGRTM_PKT,
+	ret = efa_rdm_pke_init_rtm_with_payload(pkt_entry, EFA_RDM_DC_MEDIUM_MSGRTM_PKT,
 						txe, segment_offset, data_size);
 	if (ret)
 		return ret;
@@ -768,9 +768,9 @@ ssize_t efa_rdm_pke_init_dc_medium_msgrtm(struct efa_rdm_pke *pkt_entry,
 }
 
 /**
- * @brief initialize a RXR_DC_MEDIUM_TAGRTM packet
+ * @brief initialize a EFA_RDM_DC_MEDIUM_TAGRTM packet
  * 
- * @param[in,out]	pkt_entry	RXR_DC_MEDIUM_TAGRTM packet entry
+ * @param[in,out]	pkt_entry	EFA_RDM_DC_MEDIUM_TAGRTM packet entry
  * @param[in]		txe		TX entry
  * @param[in]		segment_offset	data offset in repect of user buffer
  * @param[in]		data_size	data size in the unit of bytes
@@ -780,14 +780,14 @@ ssize_t efa_rdm_pke_init_dc_medium_tagrtm(struct efa_rdm_pke *pkt_entry,
 					  size_t segment_offset,
 					  int data_size)
 {
-	struct rxr_dc_medium_tagrtm_hdr *dc_medium_tagrtm_hdr;
+	struct efa_rdm_dc_medium_tagrtm_hdr *dc_medium_tagrtm_hdr;
 	int ret;
 
 	txe->rxr_flags |= EFA_RDM_TXE_DELIVERY_COMPLETE_REQUESTED;
 
 	efa_rdm_ope_try_fill_desc(txe, 0, FI_SEND);
 
-	ret = efa_rdm_pke_init_rtm_with_payload(pkt_entry, RXR_DC_MEDIUM_TAGRTM_PKT,
+	ret = efa_rdm_pke_init_rtm_with_payload(pkt_entry, EFA_RDM_DC_MEDIUM_TAGRTM_PKT,
 						txe, segment_offset, data_size);
 	if (ret)
 		return ret;
@@ -795,7 +795,7 @@ ssize_t efa_rdm_pke_init_dc_medium_tagrtm(struct efa_rdm_pke *pkt_entry,
 	dc_medium_tagrtm_hdr = efa_rdm_pke_get_dc_medium_tagrtm_hdr(pkt_entry);
 	dc_medium_tagrtm_hdr->hdr.msg_length = txe->total_len;
 	dc_medium_tagrtm_hdr->hdr.seg_offset = segment_offset;
-	dc_medium_tagrtm_hdr->hdr.hdr.flags |= RXR_REQ_TAGGED;
+	dc_medium_tagrtm_hdr->hdr.hdr.flags |= EFA_RDM_REQ_TAGGED;
 	dc_medium_tagrtm_hdr->hdr.send_id = txe->tx_id;
 	efa_rdm_pke_set_rtm_tag(pkt_entry, txe->tag);
 	return 0;
@@ -857,7 +857,7 @@ ssize_t efa_rdm_pke_proc_matched_mulreq_rtm(struct efa_rdm_pke *pkt_entry)
 	pkt_type = efa_rdm_pke_get_base_hdr(pkt_entry)->type;
 
 	if (efa_rdm_pkt_type_is_runtread(pkt_type)) {
-		struct rxr_runtread_rtm_base_hdr *runtread_rtm_hdr;
+		struct efa_rdm_runtread_rtm_base_hdr *runtread_rtm_hdr;
 
 		runtread_rtm_hdr = efa_rdm_pke_get_runtread_rtm_base_hdr(pkt_entry);
 		rxe->bytes_runt = runtread_rtm_hdr->runt_length;
@@ -916,17 +916,17 @@ ssize_t efa_rdm_pke_proc_matched_mulreq_rtm(struct efa_rdm_pke *pkt_entry)
  * 
  * @param[in,out]	pkt_entry	LONGCTS RTM packet entry
  * @param[in]		pkt_type	packe type, must be one of:
- *					RXR_LONGCTS_MSGRTM_PKT,
- *					RXR_LONGCTS_TAGGRTM_PKT,
- *					RXR_DC_LONGCTS_MSGRTM_PKT,
- *					RXR_DC_LONGCTS_TAGRTM_PKT,
+ *					EFA_RDM_LONGCTS_MSGRTM_PKT,
+ *					EFA_RDM_LONGCTS_TAGGRTM_PKT,
+ *					EFA_RDM_DC_LONGCTS_MSGRTM_PKT,
+ *					EFA_RDM_DC_LONGCTS_TAGRTM_PKT,
  * @param[in]		txe		TX entry
  */
 int efa_rdm_pke_init_longcts_rtm_common(struct efa_rdm_pke *pkt_entry,
 					int pkt_type,
 					struct efa_rdm_ope *txe)
 {
-	struct rxr_longcts_rtm_base_hdr *rtm_hdr;
+	struct efa_rdm_longcts_rtm_base_hdr *rtm_hdr;
 	int ret;
 
 	ret = efa_rdm_pke_init_rtm_with_payload(pkt_entry, pkt_type, txe, 0, -1);
@@ -941,47 +941,47 @@ int efa_rdm_pke_init_longcts_rtm_common(struct efa_rdm_pke *pkt_entry,
 }
 
 /**
- * @brief initialize a RXR_LONGCTS_MSGRTM packet
+ * @brief initialize a EFA_RDM_LONGCTS_MSGRTM packet
  * 
- * @param[in,out]	pkt_entry	RXR_LONGCTS_MSGRTM packet entry
+ * @param[in,out]	pkt_entry	EFA_RDM_LONGCTS_MSGRTM packet entry
  * @param[in]		txe		TX entry
  */
 ssize_t efa_rdm_pke_init_longcts_msgrtm(struct efa_rdm_pke *pkt_entry,
 					struct efa_rdm_ope *txe)
 {
 	return efa_rdm_pke_init_longcts_rtm_common(pkt_entry,
-						   RXR_LONGCTS_MSGRTM_PKT,
+						   EFA_RDM_LONGCTS_MSGRTM_PKT,
 						   txe);
 }
 
 /**
- * @brief initialize a RXR_LONGCTS_TAGRTM packet
+ * @brief initialize a EFA_RDM_LONGCTS_TAGRTM packet
  * 
- * @param[in,out]	pkt_entry	RXR_LONGCTS_TAGRTM packet entry
+ * @param[in,out]	pkt_entry	EFA_RDM_LONGCTS_TAGRTM packet entry
  * @param[in]		txe		TX entry
  */
 ssize_t efa_rdm_pke_init_longcts_tagrtm(struct efa_rdm_pke *pkt_entry,
 				    struct efa_rdm_ope *txe)
 {
-	struct rxr_base_hdr *base_hdr;
+	struct efa_rdm_base_hdr *base_hdr;
 	int ret;
 
 	ret = efa_rdm_pke_init_longcts_rtm_common(pkt_entry,
-						  RXR_LONGCTS_TAGRTM_PKT,
+						  EFA_RDM_LONGCTS_TAGRTM_PKT,
 						  txe);
 	if (ret)
 		return ret;
 
 	base_hdr = efa_rdm_pke_get_base_hdr(pkt_entry);
-	base_hdr->flags |= RXR_REQ_TAGGED;
+	base_hdr->flags |= EFA_RDM_REQ_TAGGED;
 	efa_rdm_pke_set_rtm_tag(pkt_entry, txe->tag);
 	return 0;
 }
 
 /**
- * @brief initialize a RXR_DC_LONGCTS_MSGRTM packet
+ * @brief initialize a EFA_RDM_DC_LONGCTS_MSGRTM packet
  * 
- * @param[in,out]	pkt_entry	RXR_DC_LONGCTS_TAGRTM packet entry
+ * @param[in,out]	pkt_entry	EFA_RDM_DC_LONGCTS_TAGRTM packet entry
  * @param[in]		txe		TX entry
  */
 ssize_t efa_rdm_pke_init_dc_longcts_msgrtm(struct efa_rdm_pke *pkt_entry,
@@ -989,30 +989,30 @@ ssize_t efa_rdm_pke_init_dc_longcts_msgrtm(struct efa_rdm_pke *pkt_entry,
 {
 	txe->rxr_flags |= EFA_RDM_TXE_DELIVERY_COMPLETE_REQUESTED;
 	return efa_rdm_pke_init_longcts_rtm_common(pkt_entry,
-						   RXR_DC_LONGCTS_MSGRTM_PKT,
+						   EFA_RDM_DC_LONGCTS_MSGRTM_PKT,
 						   txe);
 }
 
 /**
- * @brief initialize a RXR_DC_LONGCTS_TAGRTM packet
+ * @brief initialize a EFA_RDM_DC_LONGCTS_TAGRTM packet
  * 
- * @param[in,out]	pkt_entry	RXR_DC_MEDIUM_TAGRTM packet entry
+ * @param[in,out]	pkt_entry	EFA_RDM_DC_MEDIUM_TAGRTM packet entry
  * @param[in]		txe		TX entry
  */
 ssize_t efa_rdm_pke_init_dc_longcts_tagrtm(struct efa_rdm_pke *pkt_entry,
 					   struct efa_rdm_ope *txe)
 {
-	struct rxr_base_hdr *base_hdr;
+	struct efa_rdm_base_hdr *base_hdr;
 	int ret;
 
 	txe->rxr_flags |= EFA_RDM_TXE_DELIVERY_COMPLETE_REQUESTED;
 	ret = efa_rdm_pke_init_longcts_rtm_common(pkt_entry,
-						  RXR_DC_LONGCTS_TAGRTM_PKT,
+						  EFA_RDM_DC_LONGCTS_TAGRTM_PKT,
 						  txe);
 	if (ret)
 		return ret;
 	base_hdr = efa_rdm_pke_get_base_hdr(pkt_entry);
-	base_hdr->flags |= RXR_REQ_TAGGED;
+	base_hdr->flags |= EFA_RDM_REQ_TAGGED;
 	efa_rdm_pke_set_rtm_tag(pkt_entry, txe->tag);
 	return 0;
 }
@@ -1065,7 +1065,7 @@ ssize_t efa_rdm_pke_init_longread_rtm(struct efa_rdm_pke *pkt_entry,
 				      int pkt_type,
 				      struct efa_rdm_ope *txe)
 {
-	struct rxr_longread_rtm_base_hdr *rtm_hdr;
+	struct efa_rdm_longread_rtm_base_hdr *rtm_hdr;
 	struct fi_rma_iov *read_iov;
 	size_t hdr_size;
 	int err;
@@ -1073,7 +1073,7 @@ ssize_t efa_rdm_pke_init_longread_rtm(struct efa_rdm_pke *pkt_entry,
 	efa_rdm_pke_init_req_hdr_common(pkt_entry, pkt_type, txe);
 
 	rtm_hdr = efa_rdm_pke_get_longread_rtm_base_hdr(pkt_entry);
-	rtm_hdr->hdr.flags |= RXR_REQ_MSG;
+	rtm_hdr->hdr.flags |= EFA_RDM_REQ_MSG;
 	rtm_hdr->hdr.msg_id = txe->msg_id;
 	rtm_hdr->msg_length = txe->total_len;
 	rtm_hdr->send_id = txe->tx_id;
@@ -1091,31 +1091,31 @@ ssize_t efa_rdm_pke_init_longread_rtm(struct efa_rdm_pke *pkt_entry,
 }
 
 /**
- * @brief initialize a RXR_LONGREAD_MSGRTM
+ * @brief initialize a EFA_RDM_LONGREAD_RTA_MSGRTM
  * 
  */
 ssize_t efa_rdm_pke_init_longread_msgrtm(struct efa_rdm_pke *pkt_entry,
 					 struct efa_rdm_ope *txe)
 {
-	return efa_rdm_pke_init_longread_rtm(pkt_entry, RXR_LONGREAD_MSGRTM_PKT, txe);
+	return efa_rdm_pke_init_longread_rtm(pkt_entry, EFA_RDM_LONGREAD_RTA_MSGRTM_PKT, txe);
 }
 
 /**
- * @brief initialize a RXR_LONGREAD_TAGRTM
+ * @brief initialize a EFA_RDM_LONGREAD_RTA_TAGRTM
  * 
  */
 ssize_t efa_rdm_pke_init_longread_tagrtm(struct efa_rdm_pke *pkt_entry,
 					 struct efa_rdm_ope *txe)
 {
 	ssize_t err;
-	struct rxr_base_hdr *base_hdr;
+	struct efa_rdm_base_hdr *base_hdr;
 
-	err = efa_rdm_pke_init_longread_rtm(pkt_entry, RXR_LONGREAD_TAGRTM_PKT, txe);
+	err = efa_rdm_pke_init_longread_rtm(pkt_entry, EFA_RDM_LONGREAD_RTA_TAGRTM_PKT, txe);
 	if (err)
 		return err;
 
 	base_hdr = efa_rdm_pke_get_base_hdr(pkt_entry);
-	base_hdr->flags |= RXR_REQ_TAGGED;
+	base_hdr->flags |= EFA_RDM_REQ_TAGGED;
 	efa_rdm_pke_set_rtm_tag(pkt_entry, txe->tag);
 	return 0;
 }
@@ -1151,7 +1151,7 @@ ssize_t efa_rdm_pke_proc_matched_longread_rtm(struct efa_rdm_pke *pkt_entry)
 {
 	struct efa_rdm_ep *ep;
 	struct efa_rdm_ope *rxe;
-	struct rxr_longread_rtm_base_hdr *rtm_hdr;
+	struct efa_rdm_longread_rtm_base_hdr *rtm_hdr;
 	struct fi_rma_iov *read_iov;
 
 	ep = pkt_entry->ep;
@@ -1173,12 +1173,12 @@ ssize_t efa_rdm_pke_proc_matched_longread_rtm(struct efa_rdm_pke *pkt_entry)
 }
 
 /**
- * @brief fill in the rxr_runtread_rtm_base_hdr and data of a RUNTREAD packet
+ * @brief fill in the efa_rdm_runtread_rtm_base_hdr and data of a RUNTREAD packet
  *
  * only thing left that need to be set is tag
  * 
  * @param[out]		pkt_entry	pkt_entry to be initialzied
- * @param[in]		pkt_type	RXR_RUNREAD_MSGRTM or RXR_RUNTREAD_TAGRTM
+ * @param[in]		pkt_type	RXR_RUNREAD_MSGRTM or EFA_RDM_RUNTREAD_TAGRTM
  * @param[in]		txe		contains information of the send operation
  * @param[in]		segment_offset	data offset in repect of user buffer
  * @param[in]		data_size	data size in the unit of bytes
@@ -1190,7 +1190,7 @@ ssize_t efa_rdm_pke_init_runtread_rtm(struct efa_rdm_pke *pkt_entry,
 				      int64_t segment_offset,
 				      int64_t data_size)
 {
-	struct rxr_runtread_rtm_base_hdr *rtm_hdr;
+	struct efa_rdm_runtread_rtm_base_hdr *rtm_hdr;
 	struct fi_rma_iov *read_iov;
 	size_t hdr_size, payload_offset;
 	int err;
@@ -1200,7 +1200,7 @@ ssize_t efa_rdm_pke_init_runtread_rtm(struct efa_rdm_pke *pkt_entry,
 	efa_rdm_pke_init_req_hdr_common(pkt_entry, pkt_type, txe);
 
 	rtm_hdr = efa_rdm_pke_get_runtread_rtm_base_hdr(pkt_entry);
-	rtm_hdr->hdr.flags |= RXR_REQ_MSG;
+	rtm_hdr->hdr.flags |= EFA_RDM_REQ_MSG;
 	rtm_hdr->hdr.msg_id = txe->msg_id;
 	rtm_hdr->msg_length = txe->total_len;
 	rtm_hdr->send_id = txe->tx_id;
@@ -1222,7 +1222,7 @@ ssize_t efa_rdm_pke_init_runtread_rtm(struct efa_rdm_pke *pkt_entry,
 }
 
 /**
- * @brief initialize a RXR_RUNTREAD_MSGRTM packet
+ * @brief initialize a EFA_RDM_RUNTREAD_MSGRTM packet
  * 
  * @param[out]		pkt_entry	pkt_entry to be initialzied
  * @param[in]		txe		contains information of the send operation
@@ -1235,14 +1235,14 @@ ssize_t efa_rdm_pke_init_runtread_msgrtm(struct efa_rdm_pke *pkt_entry,
 					 int data_size)
 {
 	return efa_rdm_pke_init_runtread_rtm(pkt_entry,
-					     RXR_RUNTREAD_MSGRTM_PKT,
+					     EFA_RDM_RUNTREAD_MSGRTM_PKT,
 					     txe,
 					     segment_offset,
 					     data_size);
 }
 
 /**
- * @brief initialize a RXR_RUNTREAD_TAGRTM packet
+ * @brief initialize a EFA_RDM_RUNTREAD_TAGRTM packet
  *
  * @param[out]		pkt_entry	pkt_entry to be initialzied
  * @param[in]		txe		contains information of the send operation
@@ -1255,10 +1255,10 @@ ssize_t efa_rdm_pke_init_runtread_tagrtm(struct efa_rdm_pke *pkt_entry,
 					 int data_size)
 {
 	ssize_t err;
-	struct rxr_base_hdr *base_hdr;
+	struct efa_rdm_base_hdr *base_hdr;
 
 	err = efa_rdm_pke_init_runtread_rtm(pkt_entry,
-					    RXR_RUNTREAD_TAGRTM_PKT,
+					    EFA_RDM_RUNTREAD_TAGRTM_PKT,
 					    txe,
 					    segment_offset,
 					    data_size);
@@ -1266,7 +1266,7 @@ ssize_t efa_rdm_pke_init_runtread_tagrtm(struct efa_rdm_pke *pkt_entry,
 		return err;
 
 	base_hdr = efa_rdm_pke_get_base_hdr(pkt_entry);
-	base_hdr->flags |= RXR_REQ_TAGGED;
+	base_hdr->flags |= EFA_RDM_REQ_TAGGED;
 	efa_rdm_pke_set_rtm_tag(pkt_entry, txe->tag);
 	return 0;
 }

--- a/prov/efa/src/rdm/efa_rdm_pke_rtm.h
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtm.h
@@ -44,12 +44,12 @@
  * @param[in]	pke	RTM packet entry
  *
  * @returns
- * pointer to #rxr_rtm_base_hdr
+ * pointer to #efa_rdm_rtm_base_hdr
  */
 static inline
-struct rxr_rtm_base_hdr *efa_rdm_pke_get_rtm_base_hdr(struct efa_rdm_pke *pke)
+struct efa_rdm_rtm_base_hdr *efa_rdm_pke_get_rtm_base_hdr(struct efa_rdm_pke *pke)
 {
-	return (struct rxr_rtm_base_hdr *)pke->wiredata;
+	return (struct efa_rdm_rtm_base_hdr *)pke->wiredata;
 }
 
 /**
@@ -65,11 +65,11 @@ struct rxr_rtm_base_hdr *efa_rdm_pke_get_rtm_base_hdr(struct efa_rdm_pke *pke)
 static inline
 uint32_t efa_rdm_pke_get_rtm_msg_id(struct efa_rdm_pke *pkt_entry)
 {
-	struct rxr_rtm_base_hdr *rtm_hdr;
+	struct efa_rdm_rtm_base_hdr *rtm_hdr;
 
 	rtm_hdr = efa_rdm_pke_get_rtm_base_hdr(pkt_entry);
 	/* only msg and atomic request has msg_id */
-	assert(rtm_hdr->flags & (RXR_REQ_MSG | RXR_REQ_ATOMIC));
+	assert(rtm_hdr->flags & (EFA_RDM_REQ_MSG | EFA_RDM_REQ_ATOMIC));
 	return rtm_hdr->msg_id;
 }
 
@@ -127,63 +127,63 @@ ssize_t efa_rdm_pke_proc_rtm_rta(struct efa_rdm_pke *pkt_entry);
 void efa_rdm_pke_handle_rtm_rta_recv(struct efa_rdm_pke *pkt_entry);
 
 static inline
-struct rxr_dc_eager_rtm_base_hdr *efa_rdm_pke_get_dc_eager_rtm_base_hdr(struct efa_rdm_pke *pke)
+struct efa_rdm_dc_eager_rtm_base_hdr *efa_rdm_pke_get_dc_eager_rtm_base_hdr(struct efa_rdm_pke *pke)
 {
-	return (struct rxr_dc_eager_rtm_base_hdr *)pke->wiredata;
+	return (struct efa_rdm_dc_eager_rtm_base_hdr *)pke->wiredata;
 }
 
 static inline
-struct rxr_dc_eager_msgrtm_hdr *efa_rdm_pke_get_dc_eager_msgrtm_hdr(struct efa_rdm_pke *pke)
+struct efa_rdm_dc_eager_msgrtm_hdr *efa_rdm_pke_get_dc_eager_msgrtm_hdr(struct efa_rdm_pke *pke)
 {
-	return (struct rxr_dc_eager_msgrtm_hdr *)pke->wiredata;
+	return (struct efa_rdm_dc_eager_msgrtm_hdr *)pke->wiredata;
 }
 
 static inline
-struct rxr_dc_eager_tagrtm_hdr *efa_rdm_pke_get_dc_eager_tagrtm_hdr(struct efa_rdm_pke *pke)
+struct efa_rdm_dc_eager_tagrtm_hdr *efa_rdm_pke_get_dc_eager_tagrtm_hdr(struct efa_rdm_pke *pke)
 {
-	return (struct rxr_dc_eager_tagrtm_hdr *)pke->wiredata;
+	return (struct efa_rdm_dc_eager_tagrtm_hdr *)pke->wiredata;
 }
 
 static inline
-struct rxr_medium_rtm_base_hdr *efa_rdm_pke_get_medium_rtm_base_hdr(struct efa_rdm_pke *pke)
+struct efa_rdm_medium_rtm_base_hdr *efa_rdm_pke_get_medium_rtm_base_hdr(struct efa_rdm_pke *pke)
 {
-	return (struct rxr_medium_rtm_base_hdr *)pke->wiredata;
+	return (struct efa_rdm_medium_rtm_base_hdr *)pke->wiredata;
 }
 
 static inline
-struct rxr_dc_medium_rtm_base_hdr *efa_rdm_pke_get_dc_medium_rtm_base_hdr(struct efa_rdm_pke *pke)
+struct efa_rdm_dc_medium_rtm_base_hdr *efa_rdm_pke_get_dc_medium_rtm_base_hdr(struct efa_rdm_pke *pke)
 {
-	return (struct rxr_dc_medium_rtm_base_hdr *)pke->wiredata;
+	return (struct efa_rdm_dc_medium_rtm_base_hdr *)pke->wiredata;
 }
 
 static inline
-struct rxr_dc_medium_msgrtm_hdr *efa_rdm_pke_get_dc_medium_msgrtm_hdr(struct efa_rdm_pke *pke)
+struct efa_rdm_dc_medium_msgrtm_hdr *efa_rdm_pke_get_dc_medium_msgrtm_hdr(struct efa_rdm_pke *pke)
 {
-	return (struct rxr_dc_medium_msgrtm_hdr *)pke->wiredata;
+	return (struct efa_rdm_dc_medium_msgrtm_hdr *)pke->wiredata;
 }
 
 static inline
-struct rxr_dc_medium_tagrtm_hdr *efa_rdm_pke_get_dc_medium_tagrtm_hdr(struct efa_rdm_pke *pke)
+struct efa_rdm_dc_medium_tagrtm_hdr *efa_rdm_pke_get_dc_medium_tagrtm_hdr(struct efa_rdm_pke *pke)
 {
-	return (struct rxr_dc_medium_tagrtm_hdr *)pke->wiredata;
+	return (struct efa_rdm_dc_medium_tagrtm_hdr *)pke->wiredata;
 }
 
 static inline
-struct rxr_longcts_rtm_base_hdr *efa_rdm_pke_get_longcts_rtm_base_hdr(struct efa_rdm_pke *pke)
+struct efa_rdm_longcts_rtm_base_hdr *efa_rdm_pke_get_longcts_rtm_base_hdr(struct efa_rdm_pke *pke)
 {
-	return (struct rxr_longcts_rtm_base_hdr *)pke->wiredata;
+	return (struct efa_rdm_longcts_rtm_base_hdr *)pke->wiredata;
 }
 
 static inline
-struct rxr_longread_rtm_base_hdr *efa_rdm_pke_get_longread_rtm_base_hdr(struct efa_rdm_pke *pke)
+struct efa_rdm_longread_rtm_base_hdr *efa_rdm_pke_get_longread_rtm_base_hdr(struct efa_rdm_pke *pke)
 {
-	return (struct rxr_longread_rtm_base_hdr *)pke->wiredata;
+	return (struct efa_rdm_longread_rtm_base_hdr *)pke->wiredata;
 }
 
 static inline
-struct rxr_runtread_rtm_base_hdr *efa_rdm_pke_get_runtread_rtm_base_hdr(struct efa_rdm_pke *pke)
+struct efa_rdm_runtread_rtm_base_hdr *efa_rdm_pke_get_runtread_rtm_base_hdr(struct efa_rdm_pke *pke)
 {
-	return (struct rxr_runtread_rtm_base_hdr *)pke->wiredata;
+	return (struct efa_rdm_runtread_rtm_base_hdr *)pke->wiredata;
 }
 
 ssize_t efa_rdm_pke_init_eager_msgrtm(struct efa_rdm_pke *pkt_entry,

--- a/prov/efa/src/rdm/efa_rdm_pke_rtr.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtr.c
@@ -49,11 +49,11 @@ void efa_rdm_pke_init_rtr_common(struct efa_rdm_pke *pkt_entry,
 				 struct efa_rdm_ope *txe,
 				 int window)
 {
-	struct rxr_rtr_hdr *rtr_hdr;
+	struct efa_rdm_rtr_hdr *rtr_hdr;
 	int i;
 
 	assert(txe->op == ofi_op_read_req);
-	rtr_hdr = (struct rxr_rtr_hdr *)pkt_entry->wiredata;
+	rtr_hdr = (struct efa_rdm_rtr_hdr *)pkt_entry->wiredata;
 	rtr_hdr->rma_iov_count = txe->rma_iov_count;
 	efa_rdm_pke_init_req_hdr_common(pkt_entry, pkt_type, txe);
 	rtr_hdr->msg_length = txe->total_len;
@@ -70,7 +70,7 @@ void efa_rdm_pke_init_rtr_common(struct efa_rdm_pke *pkt_entry,
 }
 
 /**
- * @brief initialize a RXR_SHORT_RTR_PKT
+ * @brief initialize a EFA_RDM_SHORT_RTR_PKT
  * 
  * @param[in]		pkt_entry	packet entry to be initialized
  * 
@@ -79,7 +79,7 @@ ssize_t efa_rdm_pke_init_short_rtr(struct efa_rdm_pke *pkt_entry,
 				   struct efa_rdm_ope *txe)
 {
 	efa_rdm_pke_init_rtr_common(pkt_entry,
-				    RXR_SHORT_RTR_PKT,
+				    EFA_RDM_SHORT_RTR_PKT,
 				    txe,
 				    txe->total_len);
 	return 0;
@@ -89,7 +89,7 @@ ssize_t efa_rdm_pke_init_longcts_rtr(struct efa_rdm_pke *pkt_entry,
 				     struct efa_rdm_ope *txe)
 {
 	efa_rdm_pke_init_rtr_common(pkt_entry,
-				    RXR_LONGCTS_RTR_PKT,
+				    EFA_RDM_LONGCTS_RTR_PKT,
 				    txe,
 				    txe->window);
 	return 0;
@@ -98,13 +98,13 @@ ssize_t efa_rdm_pke_init_longcts_rtr(struct efa_rdm_pke *pkt_entry,
 /**
  * @brief process an incoming RTR packet
  * 
- * This functions works for both RXR_SHORT_RTR_PKT and RXR_LONGCTS_RTR_PKT
+ * This functions works for both EFA_RDM_SHORT_RTR_PKT and EFA_RDM_LONGCTS_RTR_PKT
  * @param[in]		pkt_entry	packet entry
  */
 void efa_rdm_pke_handle_rtr_recv(struct efa_rdm_pke *pkt_entry)
 {
 	struct efa_rdm_ep *ep;
-	struct rxr_rtr_hdr *rtr_hdr;
+	struct efa_rdm_rtr_hdr *rtr_hdr;
 	struct efa_rdm_ope *rxe;
 	ssize_t err;
 
@@ -123,7 +123,7 @@ void efa_rdm_pke_handle_rtr_recv(struct efa_rdm_pke *pkt_entry)
 	rxe->bytes_received = 0;
 	rxe->bytes_copied = 0;
 
-	rtr_hdr = (struct rxr_rtr_hdr *)pkt_entry->wiredata;
+	rtr_hdr = (struct efa_rdm_rtr_hdr *)pkt_entry->wiredata;
 	rxe->tx_id = rtr_hdr->recv_id;
 	rxe->window = rtr_hdr->recv_length;
 	rxe->iov_count = rtr_hdr->rma_iov_count;
@@ -142,7 +142,7 @@ void efa_rdm_pke_handle_rtr_recv(struct efa_rdm_pke *pkt_entry)
 	rxe->cq_entry.buf = rxe->iov[0].iov_base;
 	rxe->total_len = rxe->cq_entry.len;
 
-	err = efa_rdm_ope_post_send_or_queue(rxe, RXR_READRSP_PKT);
+	err = efa_rdm_ope_post_send_or_queue(rxe, EFA_RDM_READRSP_PKT);
 	if (OFI_UNLIKELY(err)) {
 		EFA_WARN(FI_LOG_CQ, "Posting of readrsp packet failed! err=%ld\n", err);
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_EIO, FI_EFA_ERR_PKT_POST);

--- a/prov/efa/src/rdm/efa_rdm_pke_rtr.h
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtr.h
@@ -38,9 +38,9 @@
 #include "efa_rdm_protocol.h"
 
 static inline
-struct rxr_rtr_hdr *efa_rdm_pke_get_rtr_hdr(struct efa_rdm_pke *pkt_entry)
+struct efa_rdm_rtr_hdr *efa_rdm_pke_get_rtr_hdr(struct efa_rdm_pke *pkt_entry)
 {
-	return (struct rxr_rtr_hdr *)pkt_entry->wiredata;
+	return (struct efa_rdm_rtr_hdr *)pkt_entry->wiredata;
 }
 
 ssize_t efa_rdm_pke_init_short_rtr(struct efa_rdm_pke *pkt_entry,

--- a/prov/efa/src/rdm/efa_rdm_pke_rtw.h
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtw.h
@@ -38,15 +38,15 @@
 #include "efa_rdm_protocol.h"
 
 static inline
-struct rxr_rtw_base_hdr *efa_rdm_pke_get_rtw_base_hdr(struct efa_rdm_pke *pkt_entry)
+struct efa_rdm_rtw_base_hdr *efa_rdm_pke_get_rtw_base_hdr(struct efa_rdm_pke *pkt_entry)
 {
-	return (struct rxr_rtw_base_hdr *)pkt_entry->wiredata;
+	return (struct efa_rdm_rtw_base_hdr *)pkt_entry->wiredata;
 }
 
 static inline
-struct rxr_dc_eager_rtw_hdr *efa_rdm_pke_dc_eager_rtw_hdr(struct efa_rdm_pke *pkt_entry)
+struct efa_rdm_dc_eager_rtw_hdr *efa_rdm_pke_dc_eager_rtw_hdr(struct efa_rdm_pke *pkt_entry)
 {
-	return (struct rxr_dc_eager_rtw_hdr *)pkt_entry->wiredata;
+	return (struct efa_rdm_dc_eager_rtw_hdr *)pkt_entry->wiredata;
 }
 
 ssize_t efa_rdm_pke_init_eager_rtw(struct efa_rdm_pke *pkt_entry,

--- a/prov/efa/src/rdm/efa_rdm_pke_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_utils.c
@@ -490,7 +490,7 @@ ssize_t efa_rdm_pke_copy_payload_to_ope(struct efa_rdm_pke *pke,
  */
 size_t efa_rdm_pke_get_payload_offset(struct efa_rdm_pke *pkt_entry)
 {
-	struct rxr_base_hdr *base_hdr;
+	struct efa_rdm_base_hdr *base_hdr;
 	int pkt_type, read_iov_count;
 	size_t payload_offset;
 
@@ -510,8 +510,8 @@ size_t efa_rdm_pke_get_payload_offset(struct efa_rdm_pke *pkt_entry)
 		payload_offset = efa_rdm_pke_get_req_hdr_size(pkt_entry);
 		assert(payload_offset > 0);
 
-		if (pkt_type == RXR_RUNTREAD_MSGRTM_PKT ||
-		    pkt_type == RXR_RUNTREAD_TAGRTM_PKT) {
+		if (pkt_type == EFA_RDM_RUNTREAD_MSGRTM_PKT ||
+		    pkt_type == EFA_RDM_RUNTREAD_TAGRTM_PKT) {
 			read_iov_count = efa_rdm_pke_get_runtread_rtm_base_hdr(pkt_entry)->read_iov_count;
 			payload_offset +=  read_iov_count * sizeof(struct fi_rma_iov);
 		}
@@ -519,18 +519,18 @@ size_t efa_rdm_pke_get_payload_offset(struct efa_rdm_pke *pkt_entry)
 		return payload_offset;
 	}
 
-	if (pkt_type == RXR_CTSDATA_PKT) {
-		payload_offset = sizeof(struct rxr_ctsdata_hdr);
-		if (base_hdr->flags & RXR_PKT_CONNID_HDR)
-			payload_offset += sizeof(struct rxr_ctsdata_opt_connid_hdr);
+	if (pkt_type == EFA_RDM_CTSDATA_PKT) {
+		payload_offset = sizeof(struct efa_rdm_ctsdata_hdr);
+		if (base_hdr->flags & EFA_RDM_PKT_CONNID_HDR)
+			payload_offset += sizeof(struct efa_rdm_ctsdata_opt_connid_hdr);
 		return payload_offset;
 	}
 
-	if (pkt_type == RXR_READRSP_PKT)
-		return sizeof(struct rxr_readrsp_hdr);
+	if (pkt_type == EFA_RDM_READRSP_PKT)
+		return sizeof(struct efa_rdm_readrsp_hdr);
 
-	if (pkt_type == RXR_ATOMRSP_PKT)
-		return sizeof(struct rxr_atomrsp_hdr);
+	if (pkt_type == EFA_RDM_ATOMRSP_PKT)
+		return sizeof(struct efa_rdm_atomrsp_hdr);
 
 	/* all packet types that can contain data has been processed.
 	 * we should never reach here;
@@ -548,36 +548,36 @@ size_t efa_rdm_pke_get_payload_offset(struct efa_rdm_pke *pkt_entry)
  */
 uint32_t *efa_rdm_pke_connid_ptr(struct efa_rdm_pke *pkt_entry)
 {
-	struct rxr_base_hdr *base_hdr;
+	struct efa_rdm_base_hdr *base_hdr;
 
 	base_hdr = efa_rdm_pke_get_base_hdr(pkt_entry);
 
-	if (base_hdr->type >= RXR_REQ_PKT_BEGIN)
+	if (base_hdr->type >= EFA_RDM_REQ_PKT_BEGIN)
 		return efa_rdm_pke_get_req_connid_ptr(pkt_entry);
 
-	if (!(base_hdr->flags & RXR_PKT_CONNID_HDR))
+	if (!(base_hdr->flags & EFA_RDM_PKT_CONNID_HDR))
 		return NULL;
 
 	switch (base_hdr->type) {
-	case RXR_CTS_PKT:
+	case EFA_RDM_CTS_PKT:
 		return &(efa_rdm_pke_get_cts_hdr(pkt_entry)->connid);
 
-	case RXR_RECEIPT_PKT:
+	case EFA_RDM_RECEIPT_PKT:
 		return &(efa_rdm_pke_get_receipt_hdr(pkt_entry)->connid);
 
-	case RXR_CTSDATA_PKT:
+	case EFA_RDM_CTSDATA_PKT:
 		return &(efa_rdm_pke_get_ctsdata_hdr(pkt_entry)->connid_hdr->connid);
 
-	case RXR_READRSP_PKT:
+	case EFA_RDM_READRSP_PKT:
 		return &(efa_rdm_pke_get_readrsp_hdr(pkt_entry)->connid);
 
-	case RXR_ATOMRSP_PKT:
+	case EFA_RDM_ATOMRSP_PKT:
 		return &(efa_rdm_pke_get_atomrsp_hdr(pkt_entry)->connid);
 
-	case RXR_EOR_PKT:
+	case EFA_RDM_EOR_PKT:
 		return &efa_rdm_pke_get_eor_hdr(pkt_entry)->connid;
 
-	case RXR_HANDSHAKE_PKT:
+	case EFA_RDM_HANDSHAKE_PKT:
 		return &(efa_rdm_pke_get_handshake_opt_connid_hdr(pkt_entry)->connid);
 
 	default:

--- a/prov/efa/src/rdm/efa_rdm_pke_utils.h
+++ b/prov/efa/src/rdm/efa_rdm_pke_utils.h
@@ -45,9 +45,9 @@
  * @returns	base header
  */
 static inline
-struct rxr_base_hdr *efa_rdm_pke_get_base_hdr(struct efa_rdm_pke *pke)
+struct efa_rdm_base_hdr *efa_rdm_pke_get_base_hdr(struct efa_rdm_pke *pke)
 {
-	return (struct rxr_base_hdr *)pke->wiredata;
+	return (struct efa_rdm_base_hdr *)pke->wiredata;
 }
 
 /**
@@ -64,13 +64,13 @@ size_t efa_rdm_pke_get_segment_offset(struct efa_rdm_pke *pke)
 {
 	int pkt_type, hdr_offset;
 	static const int offset_of_seg_offset_in_header[] = {
-		[RXR_CTSDATA_PKT] = offsetof(struct rxr_ctsdata_hdr, seg_offset),
-		[RXR_MEDIUM_MSGRTM_PKT] = offsetof(struct rxr_medium_rtm_base_hdr, seg_offset),
-		[RXR_MEDIUM_TAGRTM_PKT] = offsetof(struct rxr_medium_rtm_base_hdr, seg_offset),
-		[RXR_DC_MEDIUM_MSGRTM_PKT] = offsetof(struct rxr_dc_medium_rtm_base_hdr, seg_offset),
-		[RXR_DC_MEDIUM_TAGRTM_PKT] = offsetof(struct rxr_dc_medium_rtm_base_hdr, seg_offset),
-		[RXR_RUNTREAD_MSGRTM_PKT] = offsetof(struct rxr_runtread_rtm_base_hdr, seg_offset),
-		[RXR_RUNTREAD_TAGRTM_PKT] = offsetof(struct rxr_runtread_rtm_base_hdr, seg_offset),
+		[EFA_RDM_CTSDATA_PKT] = offsetof(struct efa_rdm_ctsdata_hdr, seg_offset),
+		[EFA_RDM_MEDIUM_MSGRTM_PKT] = offsetof(struct efa_rdm_medium_rtm_base_hdr, seg_offset),
+		[EFA_RDM_MEDIUM_TAGRTM_PKT] = offsetof(struct efa_rdm_medium_rtm_base_hdr, seg_offset),
+		[EFA_RDM_DC_MEDIUM_MSGRTM_PKT] = offsetof(struct efa_rdm_dc_medium_rtm_base_hdr, seg_offset),
+		[EFA_RDM_DC_MEDIUM_TAGRTM_PKT] = offsetof(struct efa_rdm_dc_medium_rtm_base_hdr, seg_offset),
+		[EFA_RDM_RUNTREAD_MSGRTM_PKT] = offsetof(struct efa_rdm_runtread_rtm_base_hdr, seg_offset),
+		[EFA_RDM_RUNTREAD_TAGRTM_PKT] = offsetof(struct efa_rdm_runtread_rtm_base_hdr, seg_offset),
 	};
 
 	pkt_type = efa_rdm_pke_get_base_hdr(pke)->type;

--- a/prov/efa/src/rdm/efa_rdm_pkt_type.c
+++ b/prov/efa/src/rdm/efa_rdm_pkt_type.c
@@ -7,41 +7,41 @@
 
 struct efa_rdm_pkt_type_req_info EFA_RDM_PKT_TYPE_REQ_INFO_VEC[] = {
 	/* rtm header */
-	[RXR_EAGER_MSGRTM_PKT] = {0, sizeof(struct rxr_eager_msgrtm_hdr), 0},
-	[RXR_EAGER_TAGRTM_PKT] = {0, sizeof(struct rxr_eager_tagrtm_hdr), 0},
-	[RXR_MEDIUM_MSGRTM_PKT] = {0, sizeof(struct rxr_medium_msgrtm_hdr), 0},
-	[RXR_MEDIUM_TAGRTM_PKT] = {0, sizeof(struct rxr_medium_tagrtm_hdr), 0},
-	[RXR_LONGCTS_MSGRTM_PKT] = {0, sizeof(struct rxr_longcts_msgrtm_hdr), 0},
-	[RXR_LONGCTS_TAGRTM_PKT] = {0, sizeof(struct rxr_longcts_tagrtm_hdr), 0},
-	[RXR_LONGREAD_MSGRTM_PKT] = {0, sizeof(struct rxr_longread_msgrtm_hdr), RXR_EXTRA_FEATURE_RDMA_READ},
-	[RXR_LONGREAD_TAGRTM_PKT] = {0, sizeof(struct rxr_longread_tagrtm_hdr), RXR_EXTRA_FEATURE_RDMA_READ},
-	[RXR_DC_EAGER_MSGRTM_PKT] = {0, sizeof(struct rxr_dc_eager_msgrtm_hdr), RXR_EXTRA_FEATURE_DELIVERY_COMPLETE},
-	[RXR_DC_EAGER_TAGRTM_PKT] = {0, sizeof(struct rxr_dc_eager_tagrtm_hdr), RXR_EXTRA_FEATURE_DELIVERY_COMPLETE},
-	[RXR_DC_MEDIUM_MSGRTM_PKT] = {0, sizeof(struct rxr_dc_medium_msgrtm_hdr), RXR_EXTRA_FEATURE_DELIVERY_COMPLETE},
-	[RXR_DC_MEDIUM_TAGRTM_PKT] = {0, sizeof(struct rxr_dc_medium_tagrtm_hdr), RXR_EXTRA_FEATURE_DELIVERY_COMPLETE},
-	[RXR_DC_LONGCTS_MSGRTM_PKT] = {0, sizeof(struct rxr_longcts_msgrtm_hdr), RXR_EXTRA_FEATURE_DELIVERY_COMPLETE},
-	[RXR_DC_LONGCTS_TAGRTM_PKT] = {0, sizeof(struct rxr_longcts_tagrtm_hdr), RXR_EXTRA_FEATURE_DELIVERY_COMPLETE},
-	[RXR_RUNTCTS_MSGRTM_PKT] = {0, sizeof(struct rxr_runtcts_msgrtm_hdr), RXR_EXTRA_FEATURE_RUNT},
-	[RXR_RUNTCTS_TAGRTM_PKT] = {0, sizeof(struct rxr_runtcts_tagrtm_hdr), RXR_EXTRA_FEATURE_RUNT},
-	[RXR_RUNTREAD_MSGRTM_PKT] = {0, sizeof(struct rxr_runtread_msgrtm_hdr), RXR_EXTRA_FEATURE_RUNT | RXR_EXTRA_FEATURE_RDMA_READ},
-	[RXR_RUNTREAD_TAGRTM_PKT] = {0, sizeof(struct rxr_runtread_tagrtm_hdr), RXR_EXTRA_FEATURE_RUNT | RXR_EXTRA_FEATURE_RDMA_READ},
+	[EFA_RDM_EAGER_MSGRTM_PKT] = {0, sizeof(struct efa_rdm_eager_msgrtm_hdr), 0},
+	[EFA_RDM_EAGER_TAGRTM_PKT] = {0, sizeof(struct efa_rdm_eager_tagrtm_hdr), 0},
+	[EFA_RDM_MEDIUM_MSGRTM_PKT] = {0, sizeof(struct efa_rdm_medium_msgrtm_hdr), 0},
+	[EFA_RDM_MEDIUM_TAGRTM_PKT] = {0, sizeof(struct efa_rdm_medium_tagrtm_hdr), 0},
+	[EFA_RDM_LONGCTS_MSGRTM_PKT] = {0, sizeof(struct efa_rdm_longcts_msgrtm_hdr), 0},
+	[EFA_RDM_LONGCTS_TAGRTM_PKT] = {0, sizeof(struct efa_rdm_longcts_tagrtm_hdr), 0},
+	[EFA_RDM_LONGREAD_RTA_MSGRTM_PKT] = {0, sizeof(struct efa_rdm_longread_msgrtm_hdr), EFA_RDM_EXTRA_FEATURE_RDMA_READ},
+	[EFA_RDM_LONGREAD_RTA_TAGRTM_PKT] = {0, sizeof(struct efa_rdm_longread_tagrtm_hdr), EFA_RDM_EXTRA_FEATURE_RDMA_READ},
+	[EFA_RDM_DC_EAGER_MSGRTM_PKT] = {0, sizeof(struct efa_rdm_dc_eager_msgrtm_hdr), EFA_RDM_EXTRA_FEATURE_DELIVERY_COMPLETE},
+	[EFA_RDM_DC_EAGER_TAGRTM_PKT] = {0, sizeof(struct efa_rdm_dc_eager_tagrtm_hdr), EFA_RDM_EXTRA_FEATURE_DELIVERY_COMPLETE},
+	[EFA_RDM_DC_MEDIUM_MSGRTM_PKT] = {0, sizeof(struct efa_rdm_dc_medium_msgrtm_hdr), EFA_RDM_EXTRA_FEATURE_DELIVERY_COMPLETE},
+	[EFA_RDM_DC_MEDIUM_TAGRTM_PKT] = {0, sizeof(struct efa_rdm_dc_medium_tagrtm_hdr), EFA_RDM_EXTRA_FEATURE_DELIVERY_COMPLETE},
+	[EFA_RDM_DC_LONGCTS_MSGRTM_PKT] = {0, sizeof(struct efa_rdm_longcts_msgrtm_hdr), EFA_RDM_EXTRA_FEATURE_DELIVERY_COMPLETE},
+	[EFA_RDM_DC_LONGCTS_TAGRTM_PKT] = {0, sizeof(struct efa_rdm_longcts_tagrtm_hdr), EFA_RDM_EXTRA_FEATURE_DELIVERY_COMPLETE},
+	[EFA_RDM_RUNTCTS_MSGRTM_PKT] = {0, sizeof(struct efa_rdm_runtcts_msgrtm_hdr), EFA_RDM_EXTRA_FEATURE_RUNT},
+	[EFA_RDM_RUNTCTS_TAGRTM_PKT] = {0, sizeof(struct efa_rdm_runtcts_tagrtm_hdr), EFA_RDM_EXTRA_FEATURE_RUNT},
+	[EFA_RDM_RUNTREAD_MSGRTM_PKT] = {0, sizeof(struct efa_rdm_runtread_msgrtm_hdr), EFA_RDM_EXTRA_FEATURE_RUNT | EFA_RDM_EXTRA_FEATURE_RDMA_READ},
+	[EFA_RDM_RUNTREAD_TAGRTM_PKT] = {0, sizeof(struct efa_rdm_runtread_tagrtm_hdr), EFA_RDM_EXTRA_FEATURE_RUNT | EFA_RDM_EXTRA_FEATURE_RDMA_READ},
 	/* rtw header */
-	[RXR_EAGER_RTW_PKT] = {0, sizeof(struct rxr_eager_rtw_hdr), 0},
-	[RXR_DC_EAGER_RTW_PKT] = {0, sizeof(struct rxr_dc_eager_rtw_hdr), RXR_EXTRA_FEATURE_DELIVERY_COMPLETE},
-	[RXR_LONGCTS_RTW_PKT] = {0, sizeof(struct rxr_longcts_rtw_hdr), 0},
-	[RXR_DC_LONGCTS_RTW_PKT] = {0, sizeof(struct rxr_longcts_rtw_hdr), RXR_EXTRA_FEATURE_DELIVERY_COMPLETE},
-	[RXR_LONGREAD_RTW_PKT] = {0, sizeof(struct rxr_longread_rtw_hdr), RXR_EXTRA_FEATURE_RDMA_READ},
-	[RXR_RUNTCTS_RTW_PKT] = {0, sizeof(struct rxr_runtcts_rtw_hdr), RXR_EXTRA_FEATURE_RUNT},
-	[RXR_RUNTREAD_RTW_PKT] = {0, sizeof(struct rxr_runtread_rtw_hdr), RXR_EXTRA_FEATURE_RUNT},
+	[EFA_RDM_EAGER_RTW_PKT] = {0, sizeof(struct efa_rdm_eager_rtw_hdr), 0},
+	[EFA_RDM_DC_EAGER_RTW_PKT] = {0, sizeof(struct efa_rdm_dc_eager_rtw_hdr), EFA_RDM_EXTRA_FEATURE_DELIVERY_COMPLETE},
+	[EFA_RDM_LONGCTS_RTW_PKT] = {0, sizeof(struct efa_rdm_longcts_rtw_hdr), 0},
+	[EFA_RDM_DC_LONGCTS_RTW_PKT] = {0, sizeof(struct efa_rdm_longcts_rtw_hdr), EFA_RDM_EXTRA_FEATURE_DELIVERY_COMPLETE},
+	[EFA_RDM_LONGREAD_RTA_RTW_PKT] = {0, sizeof(struct efa_rdm_longread_rtw_hdr), EFA_RDM_EXTRA_FEATURE_RDMA_READ},
+	[EFA_RDM_RUNTCTS_RTW_PKT] = {0, sizeof(struct efa_rdm_runtcts_rtw_hdr), EFA_RDM_EXTRA_FEATURE_RUNT},
+	[EFA_RDM_RUNTREAD_RTW_PKT] = {0, sizeof(struct efa_rdm_runtread_rtw_hdr), EFA_RDM_EXTRA_FEATURE_RUNT},
 	/* rtr header */
-	[RXR_SHORT_RTR_PKT] = {0, sizeof(struct rxr_rtr_hdr), 0},
-	[RXR_LONGCTS_RTR_PKT] = {0, sizeof(struct rxr_rtr_hdr), 0},
-	[RXR_READ_RTR_PKT] = {0, sizeof(struct rxr_base_hdr), RXR_EXTRA_FEATURE_RDMA_READ},
+	[EFA_RDM_SHORT_RTR_PKT] = {0, sizeof(struct efa_rdm_rtr_hdr), 0},
+	[EFA_RDM_LONGCTS_RTR_PKT] = {0, sizeof(struct efa_rdm_rtr_hdr), 0},
+	[EFA_RDM_READ_RTR_PKT] = {0, sizeof(struct efa_rdm_base_hdr), EFA_RDM_EXTRA_FEATURE_RDMA_READ},
 	/* rta header */
-	[RXR_WRITE_RTA_PKT] = {0, sizeof(struct rxr_rta_hdr), 0},
-	[RXR_DC_WRITE_RTA_PKT] = {0, sizeof(struct rxr_rta_hdr), RXR_EXTRA_FEATURE_DELIVERY_COMPLETE},
-	[RXR_FETCH_RTA_PKT] = {0, sizeof(struct rxr_rta_hdr), 0},
-	[RXR_COMPARE_RTA_PKT] = {0, sizeof(struct rxr_rta_hdr), 0},
+	[EFA_RDM_WRITE_RTA_PKT] = {0, sizeof(struct efa_rdm_rta_hdr), 0},
+	[EFA_RDM_DC_WRITE_RTA_PKT] = {0, sizeof(struct efa_rdm_rta_hdr), EFA_RDM_EXTRA_FEATURE_DELIVERY_COMPLETE},
+	[EFA_RDM_FETCH_RTA_PKT] = {0, sizeof(struct efa_rdm_rta_hdr), 0},
+	[EFA_RDM_COMPARE_RTA_PKT] = {0, sizeof(struct efa_rdm_rta_hdr), 0},
 };
 
 /**
@@ -79,19 +79,19 @@ size_t efa_rdm_pkt_type_get_req_hdr_size(int pkt_type, uint16_t flags, size_t rm
 {
 	int hdr_size = EFA_RDM_PKT_TYPE_REQ_INFO_VEC[pkt_type].base_hdr_size;
 
-	if (flags & RXR_REQ_OPT_RAW_ADDR_HDR) {
+	if (flags & EFA_RDM_REQ_OPT_RAW_ADDR_HDR) {
 		/* It is impossible to have both optional connid hdr and opt_raw_addr_hdr
 		 * in the header, and length of opt raw addr hdr is larger than
 		 * connid hdr (which is confirmed by the following assertion).
 		 */
-		assert(RXR_REQ_OPT_RAW_ADDR_HDR_SIZE >= sizeof(struct rxr_req_opt_connid_hdr));
-		hdr_size += RXR_REQ_OPT_RAW_ADDR_HDR_SIZE;
-	} else if (flags & RXR_PKT_CONNID_HDR) {
-		hdr_size += sizeof(struct rxr_req_opt_connid_hdr);
+		assert(EFA_RDM_REQ_OPT_RAW_ADDR_HDR_SIZE >= sizeof(struct efa_rdm_req_opt_connid_hdr));
+		hdr_size += EFA_RDM_REQ_OPT_RAW_ADDR_HDR_SIZE;
+	} else if (flags & EFA_RDM_PKT_CONNID_HDR) {
+		hdr_size += sizeof(struct efa_rdm_req_opt_connid_hdr);
 	}
 
-	if (flags & RXR_REQ_OPT_CQ_DATA_HDR) {
-		hdr_size += sizeof(struct rxr_req_opt_cq_data_hdr);
+	if (flags & EFA_RDM_REQ_OPT_CQ_DATA_HDR) {
+		hdr_size += sizeof(struct efa_rdm_req_opt_cq_data_hdr);
 	}
 
 	if (efa_rdm_pkt_type_contains_rma_iov(pkt_type)) {
@@ -115,7 +115,7 @@ size_t efa_rdm_pkt_type_get_req_max_hdr_size(int pkt_type)
 	 * exist at the same time, and the raw address header is longer than connid header,
 	 * we did not include the flag for CONNID header
 	 */
-	uint16_t header_flags = RXR_REQ_OPT_RAW_ADDR_HDR | RXR_REQ_OPT_CQ_DATA_HDR;
+	uint16_t header_flags = EFA_RDM_REQ_OPT_RAW_ADDR_HDR | EFA_RDM_REQ_OPT_CQ_DATA_HDR;
 
 	return efa_rdm_pkt_type_get_req_hdr_size(pkt_type, header_flags, RXR_IOV_LIMIT);
 }
@@ -126,13 +126,13 @@ size_t efa_rdm_pkt_type_get_req_max_hdr_size(int pkt_type)
 size_t efa_rdm_pkt_type_get_max_hdr_size(void)
 {
 	size_t max_hdr_size = 0;
-	size_t pkt_type = RXR_REQ_PKT_BEGIN;
+	size_t pkt_type = EFA_RDM_REQ_PKT_BEGIN;
 
-	while (pkt_type < RXR_EXTRA_REQ_PKT_END) {
+	while (pkt_type < EFA_RDM_EXTRA_REQ_PKT_END) {
 		max_hdr_size = MAX(max_hdr_size,
 				efa_rdm_pkt_type_get_req_max_hdr_size(pkt_type));
-		if (pkt_type == RXR_BASELINE_REQ_PKT_END)
-			pkt_type = RXR_EXTRA_REQ_PKT_BEGIN;
+		if (pkt_type == EFA_RDM_BASELINE_REQ_PKT_END)
+			pkt_type = EFA_RDM_EXTRA_REQ_PKT_BEGIN;
 		else
 			pkt_type += 1;
 	}

--- a/prov/efa/src/rdm/efa_rdm_pkt_type.h
+++ b/prov/efa/src/rdm/efa_rdm_pkt_type.h
@@ -57,17 +57,17 @@ static inline
 int efa_rdm_pkt_type_contains_rma_iov(int pkt_type)
 {
 	switch (pkt_type) {
-		case RXR_EAGER_RTW_PKT:
-		case RXR_DC_EAGER_RTW_PKT:
-		case RXR_LONGCTS_RTW_PKT:
-		case RXR_DC_LONGCTS_RTW_PKT:
-		case RXR_LONGREAD_RTW_PKT:
-		case RXR_SHORT_RTR_PKT:
-		case RXR_LONGCTS_RTR_PKT:
-		case RXR_WRITE_RTA_PKT:
-		case RXR_DC_WRITE_RTA_PKT:
-		case RXR_FETCH_RTA_PKT:
-		case RXR_COMPARE_RTA_PKT:
+		case EFA_RDM_EAGER_RTW_PKT:
+		case EFA_RDM_DC_EAGER_RTW_PKT:
+		case EFA_RDM_LONGCTS_RTW_PKT:
+		case EFA_RDM_DC_LONGCTS_RTW_PKT:
+		case EFA_RDM_LONGREAD_RTA_RTW_PKT:
+		case EFA_RDM_SHORT_RTR_PKT:
+		case EFA_RDM_LONGCTS_RTR_PKT:
+		case EFA_RDM_WRITE_RTA_PKT:
+		case EFA_RDM_DC_WRITE_RTA_PKT:
+		case EFA_RDM_FETCH_RTA_PKT:
+		case EFA_RDM_COMPARE_RTA_PKT:
 			return 1;
 			break;
 		default:
@@ -89,7 +89,7 @@ int efa_rdm_pkt_type_contains_rma_iov(int pkt_type)
 static inline
 bool efa_rdm_pkt_type_is_runt(int pkt_type)
 {
-	return (pkt_type >= RXR_RUNT_PKT_BEGIN && pkt_type < RXR_RUNT_PKT_END);
+	return (pkt_type >= EFA_RDM_RUNT_PKT_BEGIN && pkt_type < EFA_RDM_RUNT_PKT_END);
 }
 
 /**
@@ -102,12 +102,12 @@ static inline
 bool efa_rdm_pkt_type_is_eager(int pkt_type)
 {
 	switch(pkt_type) {
-	case RXR_EAGER_MSGRTM_PKT:
-	case RXR_EAGER_TAGRTM_PKT:
-	case RXR_EAGER_RTW_PKT:
-	case RXR_DC_EAGER_MSGRTM_PKT:
-	case RXR_DC_EAGER_TAGRTM_PKT:
-	case RXR_DC_EAGER_RTW_PKT:
+	case EFA_RDM_EAGER_MSGRTM_PKT:
+	case EFA_RDM_EAGER_TAGRTM_PKT:
+	case EFA_RDM_EAGER_RTW_PKT:
+	case EFA_RDM_DC_EAGER_MSGRTM_PKT:
+	case EFA_RDM_DC_EAGER_TAGRTM_PKT:
+	case EFA_RDM_DC_EAGER_RTW_PKT:
 		return 1;
 	default:
 		return 0;
@@ -125,8 +125,8 @@ bool efa_rdm_pkt_type_is_eager(int pkt_type)
 static inline
 bool efa_rdm_pkt_type_is_medium(int pkt_type)
 {
-	return pkt_type == RXR_MEDIUM_TAGRTM_PKT || pkt_type == RXR_MEDIUM_MSGRTM_PKT ||
-	       pkt_type == RXR_DC_MEDIUM_MSGRTM_PKT ||pkt_type == RXR_DC_MEDIUM_TAGRTM_PKT;
+	return pkt_type == EFA_RDM_MEDIUM_TAGRTM_PKT || pkt_type == EFA_RDM_MEDIUM_MSGRTM_PKT ||
+	       pkt_type == EFA_RDM_DC_MEDIUM_MSGRTM_PKT ||pkt_type == EFA_RDM_DC_MEDIUM_TAGRTM_PKT;
 }
 
 /**
@@ -139,12 +139,12 @@ static inline
 bool efa_rdm_pkt_type_is_longcts_req(int pkt_type)
 {
 	switch(pkt_type) {
-	case RXR_LONGCTS_MSGRTM_PKT:
-	case RXR_LONGCTS_TAGRTM_PKT:
-	case RXR_LONGCTS_RTW_PKT:
-	case RXR_DC_LONGCTS_MSGRTM_PKT:
-	case RXR_DC_LONGCTS_TAGRTM_PKT:
-	case RXR_DC_LONGCTS_RTW_PKT:
+	case EFA_RDM_LONGCTS_MSGRTM_PKT:
+	case EFA_RDM_LONGCTS_TAGRTM_PKT:
+	case EFA_RDM_LONGCTS_RTW_PKT:
+	case EFA_RDM_DC_LONGCTS_MSGRTM_PKT:
+	case EFA_RDM_DC_LONGCTS_TAGRTM_PKT:
+	case EFA_RDM_DC_LONGCTS_RTW_PKT:
 		return 1;
 	default:
 		return 0;
@@ -161,10 +161,10 @@ static inline
 bool efa_rdm_pkt_type_is_rta(int pkt_type)
 {
 	switch(pkt_type) {
-	case RXR_WRITE_RTA_PKT:
-	case RXR_FETCH_RTA_PKT:
-	case RXR_COMPARE_RTA_PKT:
-	case RXR_DC_WRITE_RTA_PKT:
+	case EFA_RDM_WRITE_RTA_PKT:
+	case EFA_RDM_FETCH_RTA_PKT:
+	case EFA_RDM_COMPARE_RTA_PKT:
+	case EFA_RDM_DC_WRITE_RTA_PKT:
 		return 1;
 	default:
 		return 0;
@@ -180,7 +180,7 @@ bool efa_rdm_pkt_type_is_rta(int pkt_type)
 static inline
 bool efa_rdm_pkt_type_is_runtread(int pkt_type)
 {
-	return pkt_type == RXR_RUNTREAD_TAGRTM_PKT || pkt_type == RXR_RUNTREAD_MSGRTM_PKT;
+	return pkt_type == EFA_RDM_RUNTREAD_TAGRTM_PKT || pkt_type == EFA_RDM_RUNTREAD_MSGRTM_PKT;
 }
 
 /**
@@ -208,9 +208,9 @@ bool efa_rdm_pkt_type_is_mulreq(int pkt_type)
 static inline
 bool efa_rdm_pkt_type_contains_data(int pkt_type)
 {
-	return pkt_type == RXR_READRSP_PKT ||
-	       pkt_type == RXR_ATOMRSP_PKT ||
-	       pkt_type == RXR_CTSDATA_PKT ||
+	return pkt_type == EFA_RDM_READRSP_PKT ||
+	       pkt_type == EFA_RDM_ATOMRSP_PKT ||
+	       pkt_type == EFA_RDM_CTSDATA_PKT ||
 	       efa_rdm_pkt_type_is_runt(pkt_type) ||
 	       efa_rdm_pkt_type_is_eager(pkt_type) ||
 	       efa_rdm_pkt_type_is_medium(pkt_type) ||
@@ -226,10 +226,10 @@ bool efa_rdm_pkt_type_contains_data(int pkt_type)
 static inline
 bool efa_rdm_pkt_type_is_req(int pkt_type)
 {
-	if (pkt_type >= RXR_REQ_PKT_BEGIN) {
-		assert(pkt_type < RXR_BASELINE_REQ_PKT_END ||
-		       (pkt_type >= RXR_EXTRA_REQ_PKT_BEGIN &&
-		        pkt_type < RXR_EXTRA_REQ_PKT_END));
+	if (pkt_type >= EFA_RDM_REQ_PKT_BEGIN) {
+		assert(pkt_type < EFA_RDM_BASELINE_REQ_PKT_END ||
+		       (pkt_type >= EFA_RDM_EXTRA_REQ_PKT_BEGIN &&
+		        pkt_type < EFA_RDM_EXTRA_REQ_PKT_END));
 		return true;
 	}
 
@@ -243,7 +243,7 @@ bool efa_rdm_pkt_type_is_req(int pkt_type)
 static inline
 bool efa_rdm_pkt_type_contains_seg_offset(int pkt_type)
 {
-	return efa_rdm_pkt_type_is_mulreq(pkt_type) || pkt_type == RXR_CTSDATA_PKT;
+	return efa_rdm_pkt_type_is_mulreq(pkt_type) || pkt_type == EFA_RDM_CTSDATA_PKT;
 }
 
 bool efa_rdm_pkt_type_is_supported_by_peer(int pkt_type, struct efa_rdm_peer *peer);

--- a/prov/efa/src/rdm/efa_rdm_protocol.h
+++ b/prov/efa/src/rdm/efa_rdm_protocol.h
@@ -31,8 +31,8 @@
  * SOFTWARE.
  */
 
-#ifndef _RXR_PROTO_V4_H
-#define _RXR_PROTO_V4_H
+#ifndef _EFA_RDM_PROTO_V4_H
+#define _EFA_RDM_PROTO_V4_H
 
 /*
  * This header file contains constants, flags and data structures
@@ -44,7 +44,7 @@
  * in EFA RDM protocol version 4.
  */
 
-#define RXR_PROTOCOL_VERSION	(4)
+#define EFA_RDM_PROTOCOL_VERSION	(4)
 
 /* raw address format. (section 1.4) */
 #define EFA_GID_LEN	16
@@ -62,14 +62,14 @@ struct efa_ep_addr {
 /*
  * Extra Feature/Request Flags (section 2.1)
  */
-#define RXR_EXTRA_FEATURE_RDMA_READ			BIT_ULL(0)
-#define RXR_EXTRA_FEATURE_DELIVERY_COMPLETE 		BIT_ULL(1)
-#define RXR_EXTRA_REQUEST_CONSTANT_HEADER_LENGTH	BIT_ULL(2)
-#define RXR_EXTRA_REQUEST_CONNID_HEADER			BIT_ULL(3)
-#define RXR_EXTRA_FEATURE_RUNT				BIT_ULL(4)
-#define RXR_EXTRA_FEATURE_RDMA_WRITE			BIT_ULL(5)
-#define RXR_NUM_EXTRA_FEATURE_OR_REQUEST		6
-#define RXR_MAX_NUM_EXINFO	(256)
+#define EFA_RDM_EXTRA_FEATURE_RDMA_READ			BIT_ULL(0)
+#define EFA_RDM_EXTRA_FEATURE_DELIVERY_COMPLETE 	BIT_ULL(1)
+#define EFA_RDM_EXTRA_REQUEST_CONSTANT_HEADER_LENGTH	BIT_ULL(2)
+#define EFA_RDM_EXTRA_REQUEST_CONNID_HEADER		BIT_ULL(3)
+#define EFA_RDM_EXTRA_FEATURE_RUNT			BIT_ULL(4)
+#define EFA_RDM_EXTRA_FEATURE_RDMA_WRITE			BIT_ULL(5)
+#define EFA_RDM_NUM_EXTRA_FEATURE_OR_REQUEST		6
+#define EFA_RDM_MAX_NUM_EXINFO				(256)
 
 /*
  * Packet type ID of each packet type (section 1.3)
@@ -80,88 +80,88 @@ struct efa_ep_addr {
  * New packet types can be added with introduction of an extra feature
  * (section 2.1)
  */
-#define RXR_RETIRED_RTS_PKT		1
-#define RXR_RETIRED_CONNACK_PKT		2
-#define RXR_CTS_PKT			3
-#define RXR_CTSDATA_PKT			4
-#define RXR_READRSP_PKT			5
-#define RXR_RMA_CONTEXT_PKT		6
-#define RXR_EOR_PKT			7
-#define RXR_ATOMRSP_PKT 	        8
-#define RXR_HANDSHAKE_PKT		9
-#define RXR_RECEIPT_PKT 		10
+#define EFA_RDM_RETIRED_RTS_PKT		1
+#define EFA_RDM_RETIRED_CONNACK_PKT	2
+#define EFA_RDM_CTS_PKT			3
+#define EFA_RDM_CTSDATA_PKT		4
+#define EFA_RDM_READRSP_PKT		5
+#define EFA_RDM_RMA_CONTEXT_PKT		6
+#define EFA_RDM_EOR_PKT			7
+#define EFA_RDM_ATOMRSP_PKT 	        8
+#define EFA_RDM_HANDSHAKE_PKT		9
+#define EFA_RDM_RECEIPT_PKT 		10
 
-#define RXR_REQ_PKT_BEGIN		64
-#define RXR_BASELINE_REQ_PKT_BEGIN	64
-#define RXR_EAGER_MSGRTM_PKT		64
-#define RXR_EAGER_TAGRTM_PKT		65
-#define RXR_MEDIUM_MSGRTM_PKT		66
-#define RXR_MEDIUM_TAGRTM_PKT		67
-#define RXR_LONGCTS_MSGRTM_PKT		68
-#define RXR_LONGCTS_TAGRTM_PKT		69
-#define RXR_EAGER_RTW_PKT		70
-#define RXR_LONGCTS_RTW_PKT		71
-#define RXR_SHORT_RTR_PKT		72
-#define RXR_LONGCTS_RTR_PKT		73
-#define RXR_WRITE_RTA_PKT		74
-#define RXR_FETCH_RTA_PKT		75
-#define RXR_COMPARE_RTA_PKT		76
-#define RXR_BASELINE_REQ_PKT_END	77
+#define EFA_RDM_REQ_PKT_BEGIN			64
+#define EFA_RDM_BASELINE_REQ_PKT_BEGIN		64
+#define EFA_RDM_EAGER_MSGRTM_PKT		64
+#define EFA_RDM_EAGER_TAGRTM_PKT		65
+#define EFA_RDM_MEDIUM_MSGRTM_PKT		66
+#define EFA_RDM_MEDIUM_TAGRTM_PKT		67
+#define EFA_RDM_LONGCTS_MSGRTM_PKT		68
+#define EFA_RDM_LONGCTS_TAGRTM_PKT		69
+#define EFA_RDM_EAGER_RTW_PKT		70
+#define EFA_RDM_LONGCTS_RTW_PKT		71
+#define EFA_RDM_SHORT_RTR_PKT		72
+#define EFA_RDM_LONGCTS_RTR_PKT		73
+#define EFA_RDM_WRITE_RTA_PKT		74
+#define EFA_RDM_FETCH_RTA_PKT		75
+#define EFA_RDM_COMPARE_RTA_PKT		76
+#define EFA_RDM_BASELINE_REQ_PKT_END	77
 
-#define RXR_EXTRA_REQ_PKT_BEGIN		128
-#define RXR_LONGREAD_MSGRTM_PKT		128
-#define RXR_LONGREAD_TAGRTM_PKT		129
-#define RXR_LONGREAD_RTW_PKT		130
-#define RXR_READ_RTR_PKT		131
+#define EFA_RDM_EXTRA_REQ_PKT_BEGIN		128
+#define EFA_RDM_LONGREAD_RTA_MSGRTM_PKT		128
+#define EFA_RDM_LONGREAD_RTA_TAGRTM_PKT		129
+#define EFA_RDM_LONGREAD_RTA_RTW_PKT		130
+#define EFA_RDM_READ_RTR_PKT		131
 
-#define RXR_DC_REQ_PKT_BEGIN		132
-#define RXR_DC_EAGER_MSGRTM_PKT 	133
-#define RXR_DC_EAGER_TAGRTM_PKT 	134
-#define RXR_DC_MEDIUM_MSGRTM_PKT 	135
-#define RXR_DC_MEDIUM_TAGRTM_PKT 	136
-#define RXR_DC_LONGCTS_MSGRTM_PKT  	137
-#define RXR_DC_LONGCTS_TAGRTM_PKT  	138
-#define RXR_DC_EAGER_RTW_PKT    	139
-#define RXR_DC_LONGCTS_RTW_PKT     	140
-#define RXR_DC_WRITE_RTA_PKT    	141
-#define RXR_DC_REQ_PKT_END		142
+#define EFA_RDM_DC_REQ_PKT_BEGIN		132
+#define EFA_RDM_DC_EAGER_MSGRTM_PKT 	133
+#define EFA_RDM_DC_EAGER_TAGRTM_PKT 	134
+#define EFA_RDM_DC_MEDIUM_MSGRTM_PKT 	135
+#define EFA_RDM_DC_MEDIUM_TAGRTM_PKT 	136
+#define EFA_RDM_DC_LONGCTS_MSGRTM_PKT  	137
+#define EFA_RDM_DC_LONGCTS_TAGRTM_PKT  	138
+#define EFA_RDM_DC_EAGER_RTW_PKT    	139
+#define EFA_RDM_DC_LONGCTS_RTW_PKT     	140
+#define EFA_RDM_DC_WRITE_RTA_PKT    	141
+#define EFA_RDM_DC_REQ_PKT_END		142
 
-#define RXR_RUNT_PKT_BEGIN		142
-#define RXR_RUNTCTS_MSGRTM_PKT		142
-#define RXR_RUNTCTS_TAGRTM_PKT		143
-#define RXR_RUNTCTS_RTW_PKT		144
-#define RXR_RUNTREAD_MSGRTM_PKT		145
-#define RXR_RUNTREAD_TAGRTM_PKT		146
-#define RXR_RUNTREAD_RTW_PKT		147
-#define RXR_RUNT_PKT_END		148
-#define RXR_EXTRA_REQ_PKT_END   	148
+#define EFA_RDM_RUNT_PKT_BEGIN		142
+#define EFA_RDM_RUNTCTS_MSGRTM_PKT		142
+#define EFA_RDM_RUNTCTS_TAGRTM_PKT		143
+#define EFA_RDM_RUNTCTS_RTW_PKT		144
+#define EFA_RDM_RUNTREAD_MSGRTM_PKT		145
+#define EFA_RDM_RUNTREAD_TAGRTM_PKT		146
+#define EFA_RDM_RUNTREAD_RTW_PKT		147
+#define EFA_RDM_RUNT_PKT_END		148
+#define EFA_RDM_EXTRA_REQ_PKT_END   	148
 
 /*
- *  Packet fields common to all rxr packets. The other packet headers below must
+ *  Packet fields common to all packets. The other packet headers below must
  *  be changed if this is updated.
  */
-struct rxr_base_hdr {
+struct efa_rdm_base_hdr {
 	uint8_t type;
 	uint8_t version;
 	uint16_t flags;
 };
 
 #if defined(static_assert) && defined(__x86_64__)
-static_assert(sizeof(struct rxr_base_hdr) == 4, "rxr_base_hdr check");
+static_assert(sizeof(struct efa_rdm_base_hdr) == 4, "efa_rdm_base_hdr check");
 #endif
 
-/* Universal flags that can be applied on "rxr_base_hdr.flags".
+/* Universal flags that can be applied on "efa_rdm_base_hdr.flags".
  *
  * Universal flags start from the last bit and goes backwards.
- * Because "rxr_base_hdr.flags" is a 16-bits integer, the
+ * Because "efa_rdm_base_hdr.flags" is a 16-bits integer, the
  * last bit is the 15th bit.
  * Other than universal flags, each packet type defines its
  * own set of flags, which generally starts from the 0th bit
- * in "rxr_base_hdr.flags".
+ * in "efa_rdm_base_hdr.flags".
  */
 
 /* indicate this packet has the sender connid */
-#define RXR_PKT_CONNID_HDR		BIT_ULL(15)
+#define EFA_RDM_PKT_CONNID_HDR		BIT_ULL(15)
 
 struct efa_rma_iov {
 	uint64_t		addr;
@@ -184,13 +184,13 @@ struct efa_rma_iov {
  *
  * In emulated read, requester is receiver, and responder is sender.
  */
-struct rxr_cts_hdr {
+struct efa_rdm_cts_hdr {
 	uint8_t type;
 	uint8_t version;
 	uint16_t flags;
-	/* end of rxr_base_hdr */
+	/* end of efa_rdm_base_hdr */
 	union {
-		uint32_t connid; /* sender connection ID, set when RXR_PKT_CONNID_HDR is on */
+		uint32_t connid; /* sender connection ID, set when EFA_RDM_PKT_CONNID_HDR is on */
 		uint32_t padding; /* otherwise, a padding space to 8 bytes */
 	};
 	uint32_t send_id; /* ID of the send opertaion on sender side */
@@ -199,17 +199,17 @@ struct rxr_cts_hdr {
 };
 
 #if defined(static_assert) && defined(__x86_64__)
-static_assert(sizeof(struct rxr_cts_hdr) == 24, "rxr_cts_hdr check");
+static_assert(sizeof(struct efa_rdm_cts_hdr) == 24, "efa_rdm_cts_hdr check");
 #endif
 
 /* this flag is to indicated the CTS is the response of a RTR packet */
-#define RXR_CTS_READ_REQ		BIT_ULL(7)
+#define EFA_RDM_CTS_READ_REQ		BIT_ULL(7)
 
 
 /*
  * @brief optional connid header for DATA packet
  */
-struct rxr_ctsdata_opt_connid_hdr {
+struct efa_rdm_ctsdata_opt_connid_hdr {
 	uint32_t connid;
 	uint32_t padding;
 };
@@ -229,20 +229,20 @@ struct rxr_ctsdata_opt_connid_hdr {
  *
  * In emulated read, requester is receiver, and responder is sender.
  */
-struct rxr_ctsdata_hdr {
+struct efa_rdm_ctsdata_hdr {
 	uint8_t type;
 	uint8_t version;
 	uint16_t flags;
-	/* end of rxr_base_hdr */
+	/* end of efa_rdm_base_hdr */
 	uint32_t recv_id; /* ID of the receive operation on receiver */
 	uint64_t seg_length;
 	uint64_t seg_offset;
-	/* optional connid header, present when RXR_PKT_CONNID_HDR is on */
-	struct rxr_ctsdata_opt_connid_hdr connid_hdr[0];
+	/* optional connid header, present when EFA_RDM_PKT_CONNID_HDR is on */
+	struct efa_rdm_ctsdata_opt_connid_hdr connid_hdr[0];
 };
 
 #if defined(static_assert) && defined(__x86_64__)
-static_assert(sizeof(struct rxr_ctsdata_hdr) == 24, "rxr_ctsdata_hdr check");
+static_assert(sizeof(struct efa_rdm_ctsdata_hdr) == 24, "efa_rdm_ctsdata_hdr check");
 #endif
 
 /*
@@ -251,13 +251,13 @@ static_assert(sizeof(struct rxr_ctsdata_hdr) == 24, "rxr_ctsdata_hdr check");
  *  READRSP is sent from read responder to read requester, and it contains
  *  application data.
  */
-struct rxr_readrsp_hdr {
+struct efa_rdm_readrsp_hdr {
 	uint8_t type;
 	uint8_t version;
 	uint16_t flags;
-	/* end of rxr_base_hdr */
+	/* end of efa_rdm_base_hdr */
 	union {
-		uint32_t connid; /* sender connection ID, set when RXR_PKT_CONNID_HDR is on */
+		uint32_t connid; /* sender connection ID, set when EFA_RDM_PKT_CONNID_HDR is on */
 		uint32_t padding; /* otherwise, a padding space to 8 bytes boundary */
 	};
 	uint32_t recv_id; /* ID of the receive operation on the read requester, from rtr packet */
@@ -266,11 +266,11 @@ struct rxr_readrsp_hdr {
 };
 
 #if defined(static_assert) && defined(__x86_64__)
-static_assert(sizeof(struct rxr_readrsp_hdr) == sizeof(struct rxr_ctsdata_hdr), "rxr_readrsp_hdr check");
+static_assert(sizeof(struct efa_rdm_readrsp_hdr) == sizeof(struct efa_rdm_ctsdata_hdr), "efa_rdm_readrsp_hdr check");
 #endif
 
-struct rxr_readrsp_pkt {
-	struct rxr_readrsp_hdr hdr;
+struct efa_rdm_readrsp_pkt {
+	struct efa_rdm_readrsp_hdr hdr;
 	char data[];
 };
 
@@ -296,21 +296,21 @@ struct rxr_readrsp_pkt {
  *
  * In emulated write, requester is sender, and responder is receiver.
  */
-struct rxr_eor_hdr {
+struct efa_rdm_eor_hdr {
 	uint8_t type;
 	uint8_t version;
 	uint16_t flags;
-	/* end of rxr_base_hdr */
+	/* end of efa_rdm_base_hdr */
 	uint32_t send_id; /* ID of the send operation on sender */
 	uint32_t recv_id; /* ID of the receive operation on receiver */
 	union {
-		uint32_t connid; /* sender connection ID, optional, set whne RXR_PKT_CONNID_HDR is on */
+		uint32_t connid; /* sender connection ID, optional, set whne EFA_RDM_PKT_CONNID_HDR is on */
 		uint32_t padding; /* otherwise, a padding space to 8 bytes boundary */
 	};
 };
 
 #if defined(static_assert) && defined(__x86_64__)
-static_assert(sizeof(struct rxr_eor_hdr) == 16, "rxr_eor_hdr check");
+static_assert(sizeof(struct efa_rdm_eor_hdr) == 16, "efa_rdm_eor_hdr check");
 #endif
 
 /**
@@ -320,13 +320,13 @@ static_assert(sizeof(struct rxr_eor_hdr) == 16, "rxr_eor_hdr check");
  * It is sent from responder to requester, which contains the response
  * to a fetch/compare atomic request
  */
-struct rxr_atomrsp_hdr {
+struct efa_rdm_atomrsp_hdr {
 	uint8_t type;
 	uint8_t version;
 	uint16_t flags;
-	/* end of rxr_base_hdr */
+	/* end of efa_rdm_base_hdr */
 	union {
-		uint32_t connid; /* sender connid. set when RXR_PKT_CONNID_HDR is on in flags */
+		uint32_t connid; /* sender connid. set when EFA_RDM_PKT_CONNID_HDR is on in flags */
 		uint32_t padding; /* otherwise, a padding space to 8 bytes boundary */
 	};
 	uint32_t reserved;
@@ -335,11 +335,11 @@ struct rxr_atomrsp_hdr {
 };
 
 #if defined(static_assert) && defined(__x86_64__)
-static_assert(sizeof(struct rxr_atomrsp_hdr) == 24, "rxr_atomrsp_hdr check");
+static_assert(sizeof(struct efa_rdm_atomrsp_hdr) == 24, "efa_rdm_atomrsp_hdr check");
 #endif
 
-struct rxr_atomrsp_pkt {
-	struct rxr_atomrsp_hdr hdr;
+struct efa_rdm_atomrsp_pkt {
+	struct efa_rdm_atomrsp_hdr hdr;
 	char data[];
 };
 
@@ -351,11 +351,11 @@ struct rxr_atomrsp_pkt {
  * Upon receiving 1st packet from a peer, an endpoint will
  * send a HANDSHAKE packet back, which contains its capablity bits
  */
-struct rxr_handshake_hdr {
+struct efa_rdm_handshake_hdr {
 	uint8_t type;
 	uint8_t version;
 	uint16_t flags;
-	/* end of rxr_base_hdr */
+	/* end of efa_rdm_base_hdr */
 	/* nextra_p3 is number of members in extra_info plus 3.
 	 * The "p3" part was introduced for backward compatibility.
 	 * See protocol v4 document section 2.1 for detail.
@@ -365,36 +365,36 @@ struct rxr_handshake_hdr {
 };
 
 /* indicate this package has the sender host id */
-#define RXR_HANDSHAKE_HOST_ID_HDR	BIT_ULL(0)
+#define EFA_RDM_HANDSHAKE_HOST_ID_HDR	BIT_ULL(0)
 
 #if defined(static_assert) && defined(__x86_64__)
-static_assert(sizeof(struct rxr_handshake_hdr) == 8, "rxr_handshake_hdr check");
+static_assert(sizeof(struct efa_rdm_handshake_hdr) == 8, "efa_rdm_handshake_hdr check");
 #endif
 
-struct rxr_handshake_opt_connid_hdr {
+struct efa_rdm_handshake_opt_connid_hdr {
 	uint32_t connid;
 	uint32_t padding; /* padding to 8 bytes boundary */
 };
 
-struct rxr_handshake_opt_host_id_hdr {
+struct efa_rdm_handshake_opt_host_id_hdr {
 	uint64_t host_id;
 };
 
 #if defined(static_assert) && defined(__x86_64__)
-static_assert(sizeof(struct rxr_handshake_opt_connid_hdr) == 8, "rxr_handshake_opt_connid_hdr check");
-static_assert(sizeof(struct rxr_handshake_opt_host_id_hdr) == 8, "rxr_handshake_opt_host_id_hdr check");
+static_assert(sizeof(struct efa_rdm_handshake_opt_connid_hdr) == 8, "efa_rdm_handshake_opt_connid_hdr check");
+static_assert(sizeof(struct efa_rdm_handshake_opt_host_id_hdr) == 8, "efa_rdm_handshake_opt_host_id_hdr check");
 #endif
 
 /* @brief header format of RECEIPT packet */
-struct rxr_receipt_hdr {
+struct efa_rdm_receipt_hdr {
 	uint8_t type;
 	uint8_t version;
 	uint16_t flags;
-	/* end of rxr_base_hdr */
+	/* end of efa_rdm_base_hdr */
 	uint32_t tx_id;
 	uint32_t msg_id;
 	union {
-		uint32_t connid; /* sender connection ID, set when RXR_PKT_CONNID_HDR is on */
+		uint32_t connid; /* sender connection ID, set when EFA_RDM_PKT_CONNID_HDR is on */
 		uint32_t padding; /* otherwise, a padding space to 8 bytes */
 	};
 };
@@ -414,36 +414,36 @@ struct rxr_receipt_hdr {
 /*
  * REQ Packets common Header Flags (section 3.1)
  */
-#define RXR_REQ_OPT_RAW_ADDR_HDR	BIT_ULL(0)
-#define RXR_REQ_OPT_CQ_DATA_HDR		BIT_ULL(1)
-#define RXR_REQ_MSG			BIT_ULL(2)
-#define RXR_REQ_TAGGED			BIT_ULL(3)
-#define RXR_REQ_RMA			BIT_ULL(4)
-#define RXR_REQ_ATOMIC			BIT_ULL(5)
+#define EFA_RDM_REQ_OPT_RAW_ADDR_HDR	BIT_ULL(0)
+#define EFA_RDM_REQ_OPT_CQ_DATA_HDR	BIT_ULL(1)
+#define EFA_RDM_REQ_MSG			BIT_ULL(2)
+#define EFA_RDM_REQ_TAGGED		BIT_ULL(3)
+#define EFA_RDM_REQ_RMA			BIT_ULL(4)
+#define EFA_RDM_REQ_ATOMIC		BIT_ULL(5)
 
 /*
  * optional headers for REQ packets
  */
-struct rxr_req_opt_raw_addr_hdr {
+struct efa_rdm_req_opt_raw_addr_hdr {
 	uint32_t addr_len;
 	char raw_addr[0];
 };
 
-struct rxr_req_opt_cq_data_hdr {
+struct efa_rdm_req_opt_cq_data_hdr {
 	int64_t cq_data;
 };
 
-struct rxr_req_opt_connid_hdr {
+struct efa_rdm_req_opt_connid_hdr {
 	uint32_t connid; /* sender's connection ID */
 };
 
-#define RXR_REQ_OPT_HDR_ALIGNMENT 8
-#define RXR_REQ_OPT_RAW_ADDR_HDR_SIZE (((sizeof(struct rxr_req_opt_raw_addr_hdr) + EFA_EP_ADDR_LEN - 1)/RXR_REQ_OPT_HDR_ALIGNMENT + 1) * RXR_REQ_OPT_HDR_ALIGNMENT)
+#define EFA_RDM_REQ_OPT_HDR_ALIGNMENT 8
+#define EFA_RDM_REQ_OPT_RAW_ADDR_HDR_SIZE (((sizeof(struct efa_rdm_req_opt_raw_addr_hdr) + EFA_EP_ADDR_LEN - 1)/EFA_RDM_REQ_OPT_HDR_ALIGNMENT + 1) * EFA_RDM_REQ_OPT_HDR_ALIGNMENT)
 
 /*
  * Base header for all RTM packets
  */
-struct rxr_rtm_base_hdr {
+struct efa_rdm_rtm_base_hdr {
 	uint8_t type;
 	uint8_t version;
 	uint16_t flags;
@@ -453,21 +453,21 @@ struct rxr_rtm_base_hdr {
 /**
  * @brief header format of EAGER_MSGRTM packet (Packet Type ID 64)
  */
-struct rxr_eager_msgrtm_hdr {
-	struct rxr_rtm_base_hdr hdr;
+struct efa_rdm_eager_msgrtm_hdr {
+	struct efa_rdm_rtm_base_hdr hdr;
 };
 
 
 /**
  * @brief header format of EAGER_TAGRTM packet (Packet Type ID 65)
  */
-struct rxr_eager_tagrtm_hdr {
-	struct rxr_rtm_base_hdr hdr;
+struct efa_rdm_eager_tagrtm_hdr {
+	struct efa_rdm_rtm_base_hdr hdr;
 	uint64_t tag;
 };
 
-struct rxr_medium_rtm_base_hdr {
-	struct rxr_rtm_base_hdr hdr;
+struct efa_rdm_medium_rtm_base_hdr {
+	struct efa_rdm_rtm_base_hdr hdr;
 	uint64_t msg_length;
 	uint64_t seg_offset;
 };
@@ -475,20 +475,20 @@ struct rxr_medium_rtm_base_hdr {
 /**
  * @brief header format of MEDIUM_MSGRTM packet (Packet Type ID 66)
  */
-struct rxr_medium_msgrtm_hdr {
-	struct rxr_medium_rtm_base_hdr hdr;
+struct efa_rdm_medium_msgrtm_hdr {
+	struct efa_rdm_medium_rtm_base_hdr hdr;
 };
 
 /**
  * @brief header format of MEDIUM_TAGRTM packet (Packet Type ID 67)
  */
-struct rxr_medium_tagrtm_hdr {
-	struct rxr_medium_rtm_base_hdr hdr;
+struct efa_rdm_medium_tagrtm_hdr {
+	struct efa_rdm_medium_rtm_base_hdr hdr;
 	uint64_t tag;
 };
 
-struct rxr_longcts_rtm_base_hdr {
-	struct rxr_rtm_base_hdr hdr;
+struct efa_rdm_longcts_rtm_base_hdr {
+	struct efa_rdm_rtm_base_hdr hdr;
 	uint64_t msg_length;
 	uint32_t send_id;
 	uint32_t credit_request;
@@ -497,34 +497,34 @@ struct rxr_longcts_rtm_base_hdr {
 /**
  * @brief header format of LONGCTS_MSGRTM packet (Packet Type ID 68)
  */
-struct rxr_longcts_msgrtm_hdr {
-	struct rxr_longcts_rtm_base_hdr hdr;
+struct efa_rdm_longcts_msgrtm_hdr {
+	struct efa_rdm_longcts_rtm_base_hdr hdr;
 };
 
 /**
  * @brief header format of LONGCTS_TAGRTM packet (Packet Type ID 69)
  */
-struct rxr_longcts_tagrtm_hdr {
-	struct rxr_longcts_rtm_base_hdr hdr;
+struct efa_rdm_longcts_tagrtm_hdr {
+	struct efa_rdm_longcts_rtm_base_hdr hdr;
 	uint64_t tag;
 };
 
-struct rxr_rtw_base_hdr {
+struct efa_rdm_rtw_base_hdr {
 	uint8_t type;
 	uint8_t version;
 	uint16_t flags;
-	/* end of rxr_base_hdr */
+	/* end of efa_rdm_base_hdr */
 	uint32_t rma_iov_count;
 };
 
 /**
  * @brief header format of EAGER_RTW packet (Packet Type ID 70)
  */
-struct rxr_eager_rtw_hdr {
+struct efa_rdm_eager_rtw_hdr {
 	uint8_t type;
 	uint8_t version;
 	uint16_t flags;
-	/* end of rxr_base_hdr */
+	/* end of efa_rdm_base_hdr */
 	uint32_t rma_iov_count;
 	struct efa_rma_iov rma_iov[0];
 };
@@ -532,11 +532,11 @@ struct rxr_eager_rtw_hdr {
 /**
  * @brief header format of LONGCTS_RTW packet (Packet Type ID 71)
  */
-struct rxr_longcts_rtw_hdr {
+struct efa_rdm_longcts_rtw_hdr {
 	uint8_t type;
 	uint8_t version;
 	uint16_t flags;
-	/* end of rxr_base_hdr */
+	/* end of efa_rdm_base_hdr */
 	uint32_t rma_iov_count;
 	uint64_t msg_length;
 	uint32_t send_id;
@@ -545,14 +545,14 @@ struct rxr_longcts_rtw_hdr {
 };
 
 /*
- * rxr_rtr_hdr is used by both SHORT_RTR (Packet Type ID 72)
+ * efa_rdm_rtr_hdr is used by both SHORT_RTR (Packet Type ID 72)
  * and LONGCTS_RTR (Packet Type ID 73)
  */
-struct rxr_rtr_hdr {
+struct efa_rdm_rtr_hdr {
 	uint8_t type;
 	uint8_t version;
 	uint16_t flags;
-	/* end of rxr_base_hdr */
+	/* end of efa_rdm_base_hdr */
 	uint32_t rma_iov_count;
 	uint64_t msg_length;
 	uint32_t recv_id; /* ID of the receive operation of the read requester, will be included in DATA/READRSP header */
@@ -560,13 +560,13 @@ struct rxr_rtr_hdr {
 	struct efa_rma_iov rma_iov[0];
 };
 
-/* @brief rxr_rta_hdr are shared by 4 types of RTA:
+/* @brief efa_rdm_rta_hdr are shared by 4 types of RTA:
  *    WRITE_RTA (Packet Type ID 74),
  *    FETCH_RTA (Packet Type ID 75),
  *    COMPARE_RTA (Packet Type ID 76) and
  *    DC_WRTIE_RTA (Packe Type ID 141)
  */
-struct rxr_rta_hdr {
+struct efa_rdm_rta_hdr {
 	uint8_t type;
 	uint8_t version;
 	uint16_t flags;
@@ -594,8 +594,8 @@ struct rxr_rta_hdr {
 /*
  * Extra request: RDMA read based data transfer (section 4.1)
  */
-struct rxr_longread_rtm_base_hdr {
-	struct rxr_rtm_base_hdr hdr;
+struct efa_rdm_longread_rtm_base_hdr {
+	struct efa_rdm_rtm_base_hdr hdr;
 	uint64_t msg_length;
 	uint32_t send_id;
 	uint32_t read_iov_count;
@@ -604,26 +604,26 @@ struct rxr_longread_rtm_base_hdr {
 /**
  * @brief header format of LONGREAD_MSGRTM (Packet Type ID 128)
  */
-struct rxr_longread_msgrtm_hdr {
-	struct rxr_longread_rtm_base_hdr hdr;
+struct efa_rdm_longread_msgrtm_hdr {
+	struct efa_rdm_longread_rtm_base_hdr hdr;
 };
 
 /**
  * @brief header format of LONGREAD_MSGRTM (Packet Type ID 129)
  */
-struct rxr_longread_tagrtm_hdr {
-	struct rxr_longread_rtm_base_hdr hdr;
+struct efa_rdm_longread_tagrtm_hdr {
+	struct efa_rdm_longread_rtm_base_hdr hdr;
 	uint64_t tag;
 };
 
 /**
  * @brief header format of LONGREAD_MSGRTM (Packet Type ID 130)
  */
-struct rxr_longread_rtw_hdr {
+struct efa_rdm_longread_rtw_hdr {
 	uint8_t type;
 	uint8_t version;
 	uint16_t flags;
-	/* end of rxr_base_hdr */
+	/* end of efa_rdm_base_hdr */
 	uint32_t rma_iov_count;
 	uint64_t msg_length;
 	uint32_t send_id;
@@ -635,7 +635,7 @@ struct rxr_longread_rtw_hdr {
  * Extra requester: delivery complete (section 4.2)
  */
 
-struct rxr_dc_eager_rtm_base_hdr {
+struct efa_rdm_dc_eager_rtm_base_hdr {
 	uint8_t type;
 	uint8_t version;
 	uint16_t flags;
@@ -647,20 +647,20 @@ struct rxr_dc_eager_rtm_base_hdr {
 /**
  * @brief header format of a DC_EAGER_MSGRTM packet
  */
-struct rxr_dc_eager_msgrtm_hdr {
-	struct rxr_dc_eager_rtm_base_hdr hdr;
+struct efa_rdm_dc_eager_msgrtm_hdr {
+	struct efa_rdm_dc_eager_rtm_base_hdr hdr;
 };
 
 /**
  * @brief header format of a DC_EAGER_TAGRTM packet
  */
-struct rxr_dc_eager_tagrtm_hdr {
-	struct rxr_dc_eager_rtm_base_hdr hdr;
+struct efa_rdm_dc_eager_tagrtm_hdr {
+	struct efa_rdm_dc_eager_rtm_base_hdr hdr;
 	uint64_t tag;
 };
 
-struct rxr_dc_medium_rtm_base_hdr {
-	struct rxr_rtm_base_hdr hdr;
+struct efa_rdm_dc_medium_rtm_base_hdr {
+	struct efa_rdm_rtm_base_hdr hdr;
 	uint32_t send_id;
 	uint32_t padding;
 	uint64_t msg_length;
@@ -670,43 +670,43 @@ struct rxr_dc_medium_rtm_base_hdr {
 /**
  * @brief header format of a DC_MEDIUM_MSGRTM packet
  */
-struct rxr_dc_medium_msgrtm_hdr {
-	struct rxr_dc_medium_rtm_base_hdr hdr;
+struct efa_rdm_dc_medium_msgrtm_hdr {
+	struct efa_rdm_dc_medium_rtm_base_hdr hdr;
 };
 
 /**
  * @brief header format of a DC_MEDIUM_TAGRTM packet
  */
-struct rxr_dc_medium_tagrtm_hdr {
-	struct rxr_dc_medium_rtm_base_hdr hdr;
+struct efa_rdm_dc_medium_tagrtm_hdr {
+	struct efa_rdm_dc_medium_rtm_base_hdr hdr;
 	uint64_t tag;
 };
 
 /**
  * @brief header format of a DC_LONGCTS_MSGRTM packet
  */
-struct rxr_dc_longcts_msgrtm_hdr {
-	struct rxr_longcts_rtm_base_hdr hdr;
+struct efa_rdm_dc_longcts_msgrtm_hdr {
+	struct efa_rdm_longcts_rtm_base_hdr hdr;
 };
 
 /**
  * @brief header format of a DC_LONGCTS_TAGRTM packet
  */
-struct rxr_dc_longcts_tagrtm_hdr {
-	struct rxr_longcts_rtm_base_hdr hdr;
+struct efa_rdm_dc_longcts_tagrtm_hdr {
+	struct efa_rdm_longcts_rtm_base_hdr hdr;
 	uint64_t tag;
 };
 
 /**
  * @brief header format of a DC_EAGER_RTW packet
  */
-struct rxr_dc_eager_rtw_hdr {
+struct efa_rdm_dc_eager_rtw_hdr {
 	uint8_t type;
 	uint8_t version;
 	uint16_t flags;
-	/* end of rxr_base_hdr */
+	/* end of efa_rdm_base_hdr */
 	uint32_t rma_iov_count;
-	/* end of rxr_rtw_base_hdr */
+	/* end of efa_rdm_rtw_base_hdr */
 	uint32_t send_id;
 	uint32_t padding;
 	struct efa_rma_iov rma_iov[0];
@@ -715,11 +715,11 @@ struct rxr_dc_eager_rtw_hdr {
 /**
  * @brief header format of a DC_LONGCTS_RTW packet
  */
-struct rxr_dc_longcts_rtw_hdr {
+struct efa_rdm_dc_longcts_rtw_hdr {
 	uint8_t type;
 	uint8_t version;
 	uint16_t flags;
-	/* end of rxr_base_hdr */
+	/* end of efa_rdm_base_hdr */
 	uint32_t rma_iov_count;
 	uint64_t msg_length;
 	uint32_t send_id;
@@ -727,12 +727,12 @@ struct rxr_dc_longcts_rtw_hdr {
 	struct efa_rma_iov rma_iov[0];
 };
 
-/* DC_WRITE_RTA header format is merged into rxr_rta_hdr */
+/* DC_WRITE_RTA header format is merged into efa_rdm_rta_hdr */
 
 /* Extra feature runting protocols related headers */
 
-struct rxr_runtcts_rtm_base_hdr {
-	struct rxr_rtm_base_hdr hdr;
+struct efa_rdm_runtcts_rtm_base_hdr {
+	struct efa_rdm_rtm_base_hdr hdr;
 	uint64_t msg_length;
 	uint32_t send_id;
 	uint32_t credit_request;
@@ -743,26 +743,26 @@ struct rxr_runtcts_rtm_base_hdr {
 /**
  * @brief header format of RUNTCTS_MSGRTM (Packet Type ID 142)
  */
-struct rxr_runtcts_msgrtm_hdr {
-	struct rxr_runtcts_rtm_base_hdr hdr;
+struct efa_rdm_runtcts_msgrtm_hdr {
+	struct efa_rdm_runtcts_rtm_base_hdr hdr;
 };
 
 /**
  * @brief header format of RUNTCTS_TAGRTM (Packet Type ID 143)
  */
-struct rxr_runtcts_tagrtm_hdr {
-	struct rxr_runtcts_rtm_base_hdr hdr;
+struct efa_rdm_runtcts_tagrtm_hdr {
+	struct efa_rdm_runtcts_rtm_base_hdr hdr;
 	uint64_t tag;
 };
 
 /**
  * @brief header format of RUNTCTS_RTW (Packet Type ID 144)
  */
-struct rxr_runtcts_rtw_hdr {
+struct efa_rdm_runtcts_rtw_hdr {
 	uint8_t type;
 	uint8_t version;
 	uint16_t flags;
-	/* end of rxr_base_hdr */
+	/* end of efa_rdm_base_hdr */
 	uint32_t rma_iov_count;
 	uint64_t msg_length;
 	uint32_t send_id;
@@ -772,8 +772,8 @@ struct rxr_runtcts_rtw_hdr {
 	struct efa_rma_iov rma_iov[0];
 };
 
-struct rxr_runtread_rtm_base_hdr {
-	struct rxr_rtm_base_hdr hdr;
+struct efa_rdm_runtread_rtm_base_hdr {
+	struct efa_rdm_rtm_base_hdr hdr;
 	uint64_t msg_length;
 	uint32_t send_id;
 	uint32_t read_iov_count;
@@ -784,26 +784,26 @@ struct rxr_runtread_rtm_base_hdr {
 /**
  * @brief header format of RUNTREAD_MSGRTM (Packet Type ID 145)
  */
-struct rxr_runtread_msgrtm_hdr {
-	struct rxr_runtread_rtm_base_hdr hdr;
+struct efa_rdm_runtread_msgrtm_hdr {
+	struct efa_rdm_runtread_rtm_base_hdr hdr;
 };
 
 /**
  * @brief header format of RUNTREAD_MSGRTM (Packet Type ID 146)
  */
-struct rxr_runtread_tagrtm_hdr {
-	struct rxr_runtread_rtm_base_hdr hdr;
+struct efa_rdm_runtread_tagrtm_hdr {
+	struct efa_rdm_runtread_rtm_base_hdr hdr;
 	uint64_t tag;
 };
 
 /**
  * @brief header format of RUNTREAD_RTW (Packet Type ID 147)
  */
-struct rxr_runtread_rtw_hdr {
+struct efa_rdm_runtread_rtw_hdr {
 	uint8_t type;
 	uint8_t version;
 	uint16_t flags;
-	/* end of rxr_base_hdr */
+	/* end of efa_rdm_base_hdr */
 	uint32_t rma_iov_count;
 	uint64_t msg_length;
 	uint32_t send_id;

--- a/prov/efa/src/rdm/efa_rdm_rma.c
+++ b/prov/efa/src/rdm/efa_rdm_rma.c
@@ -117,13 +117,13 @@ ssize_t efa_rdm_rma_post_efa_emulated_read(struct efa_rdm_ep *ep, struct efa_rdm
 	ep->pending_recv_counter++;
 #endif
 
-	if (txe->total_len < ep->mtu_size - sizeof(struct rxr_readrsp_hdr)) {
-		err = efa_rdm_ope_post_send(txe, RXR_SHORT_RTR_PKT);
+	if (txe->total_len < ep->mtu_size - sizeof(struct efa_rdm_readrsp_hdr)) {
+		err = efa_rdm_ope_post_send(txe, EFA_RDM_SHORT_RTR_PKT);
 	} else {
 		assert(efa_env.tx_min_credits > 0);
 		txe->window = MIN(txe->total_len,
 				       efa_env.tx_min_credits * ep->max_data_payload_size);
-		err = efa_rdm_ope_post_send(txe, RXR_LONGCTS_RTR_PKT);
+		err = efa_rdm_ope_post_send(txe, EFA_RDM_LONGCTS_RTR_PKT);
 	}
 
 	if (OFI_UNLIKELY(err)) {
@@ -416,9 +416,9 @@ ssize_t efa_rdm_rma_post_write(struct efa_rdm_ep *ep, struct efa_rdm_ope *txe)
 		else if (!efa_rdm_peer_support_delivery_complete(peer))
 			return -FI_EOPNOTSUPP;
 
-		max_eager_rtw_data_size = efa_rdm_txe_max_req_data_capacity(ep, txe, RXR_DC_EAGER_RTW_PKT);
+		max_eager_rtw_data_size = efa_rdm_txe_max_req_data_capacity(ep, txe, EFA_RDM_DC_EAGER_RTW_PKT);
 	} else {
-		max_eager_rtw_data_size = efa_rdm_txe_max_req_data_capacity(ep, txe, RXR_EAGER_RTW_PKT);
+		max_eager_rtw_data_size = efa_rdm_txe_max_req_data_capacity(ep, txe, EFA_RDM_EAGER_RTW_PKT);
 	}
 
 	iface = txe->desc[0] ? ((struct efa_mr*) txe->desc[0])->peer.iface : FI_HMEM_SYSTEM;
@@ -426,7 +426,7 @@ ssize_t efa_rdm_rma_post_write(struct efa_rdm_ep *ep, struct efa_rdm_ope *txe)
 	if (txe->total_len >= efa_rdm_ep_domain(ep)->hmem_info[iface].min_read_write_size &&
 		efa_both_support_rdma_read(ep, peer) &&
 		(txe->desc[0] || efa_is_cache_available(efa_rdm_ep_domain(ep)))) {
-		err = efa_rdm_ope_post_send(txe, RXR_LONGREAD_RTW_PKT);
+		err = efa_rdm_ope_post_send(txe, EFA_RDM_LONGREAD_RTA_RTW_PKT);
 		if (err != -FI_ENOMEM)
 			return err;
 		/*
@@ -436,11 +436,11 @@ ssize_t efa_rdm_rma_post_write(struct efa_rdm_ep *ep, struct efa_rdm_ope *txe)
 	}
 
 	if (txe->total_len <= max_eager_rtw_data_size) {
-		ctrl_type = delivery_complete_requested ? RXR_DC_EAGER_RTW_PKT : RXR_EAGER_RTW_PKT;
+		ctrl_type = delivery_complete_requested ? EFA_RDM_DC_EAGER_RTW_PKT : EFA_RDM_EAGER_RTW_PKT;
 		return efa_rdm_ope_post_send(txe, ctrl_type);
 	}
 
-	ctrl_type = delivery_complete_requested ? RXR_DC_LONGCTS_RTW_PKT : RXR_LONGCTS_RTW_PKT;
+	ctrl_type = delivery_complete_requested ? EFA_RDM_DC_LONGCTS_RTW_PKT : EFA_RDM_LONGCTS_RTW_PKT;
 	return efa_rdm_ope_post_send(txe, ctrl_type);
 }
 

--- a/prov/efa/src/rdm/efa_rdm_util.h
+++ b/prov/efa/src/rdm/efa_rdm_util.h
@@ -38,7 +38,7 @@
 #include "efa_rdm_protocol.h"
 #include "efa_rdm_pke.h"
 
-#define RXR_MSG_PREFIX_SIZE (sizeof(struct efa_rdm_pke) + sizeof(struct rxr_eager_msgrtm_hdr) + RXR_REQ_OPT_RAW_ADDR_HDR_SIZE)
+#define RXR_MSG_PREFIX_SIZE (sizeof(struct efa_rdm_pke) + sizeof(struct efa_rdm_eager_msgrtm_hdr) + EFA_RDM_REQ_OPT_RAW_ADDR_HDR_SIZE)
 
 #if defined(static_assert) && defined(__x86_64__)
 static_assert(RXR_MSG_PREFIX_SIZE % 8 == 0, "message prefix size alignment check");

--- a/prov/efa/test/efa_unit_test_common.c
+++ b/prov/efa/test/efa_unit_test_common.c
@@ -173,32 +173,32 @@ void efa_unit_test_buff_destruct(struct efa_unit_test_buff *buff)
 }
 
 /**
- * @brief Construct RXR_EAGER_MSGRTM_PKT
+ * @brief Construct EFA_RDM_EAGER_MSGRTM_PKT
  *
  * @param[in] pkt_entry Packet entry. Must be non-NULL.
  * @param[in] attr Packet attributes.
  */
 void efa_unit_test_eager_msgrtm_pkt_construct(struct efa_rdm_pke *pkt_entry, struct efa_unit_test_eager_rtm_pkt_attr *attr)
 {
-	struct rxr_eager_msgrtm_hdr base_hdr = {0};
-	struct rxr_req_opt_connid_hdr opt_connid_hdr = {0};
+	struct efa_rdm_eager_msgrtm_hdr base_hdr = {0};
+	struct efa_rdm_req_opt_connid_hdr opt_connid_hdr = {0};
 	uint32_t *connid = NULL;
 
-	base_hdr.hdr.type = RXR_EAGER_MSGRTM_PKT;
-	base_hdr.hdr.flags |= RXR_PKT_CONNID_HDR | RXR_REQ_MSG;
+	base_hdr.hdr.type = EFA_RDM_EAGER_MSGRTM_PKT;
+	base_hdr.hdr.flags |= EFA_RDM_PKT_CONNID_HDR | EFA_RDM_REQ_MSG;
 	base_hdr.hdr.msg_id = attr->msg_id;
-	memcpy(pkt_entry->wiredata, &base_hdr, sizeof(struct rxr_eager_msgrtm_hdr));
-	assert_int_equal(efa_rdm_pke_get_base_hdr(pkt_entry)->type, RXR_EAGER_MSGRTM_PKT);
-	assert_int_equal(efa_rdm_pke_get_req_base_hdr_size(pkt_entry), sizeof(struct rxr_eager_msgrtm_hdr));
+	memcpy(pkt_entry->wiredata, &base_hdr, sizeof(struct efa_rdm_eager_msgrtm_hdr));
+	assert_int_equal(efa_rdm_pke_get_base_hdr(pkt_entry)->type, EFA_RDM_EAGER_MSGRTM_PKT);
+	assert_int_equal(efa_rdm_pke_get_req_base_hdr_size(pkt_entry), sizeof(struct efa_rdm_eager_msgrtm_hdr));
 	opt_connid_hdr.connid = attr->connid;
-	memcpy(pkt_entry->wiredata + sizeof(struct rxr_eager_msgrtm_hdr), &opt_connid_hdr, sizeof(struct rxr_req_opt_connid_hdr));
+	memcpy(pkt_entry->wiredata + sizeof(struct efa_rdm_eager_msgrtm_hdr), &opt_connid_hdr, sizeof(struct efa_rdm_req_opt_connid_hdr));
 	connid = efa_rdm_pke_connid_ptr(pkt_entry);
 	assert_int_equal(*connid, attr->connid);
 	pkt_entry->pkt_size = sizeof(base_hdr) + sizeof(opt_connid_hdr);
 }
 
 /**
- * @brief Construct RXR_HANDSHAKE_PKT
+ * @brief Construct EFA_RDM_HANDSHAKE_PKT
  *	The function will include the optional connid/host id headers if and only if
  *	attr->connid/host id are non-zero.
  *
@@ -208,33 +208,33 @@ void efa_unit_test_eager_msgrtm_pkt_construct(struct efa_rdm_pke *pkt_entry, str
 void efa_unit_test_handshake_pkt_construct(struct efa_rdm_pke *pkt_entry, struct efa_unit_test_handshake_pkt_attr *attr)
 {
 
-	int nex = (RXR_NUM_EXTRA_FEATURE_OR_REQUEST - 1) / 64 + 1;
-	struct rxr_handshake_hdr *handshake_hdr = (struct rxr_handshake_hdr *)pkt_entry->wiredata;
+	int nex = (EFA_RDM_NUM_EXTRA_FEATURE_OR_REQUEST - 1) / 64 + 1;
+	struct efa_rdm_handshake_hdr *handshake_hdr = (struct efa_rdm_handshake_hdr *)pkt_entry->wiredata;
 
-	handshake_hdr->type = RXR_HANDSHAKE_PKT;
-	handshake_hdr->version = RXR_PROTOCOL_VERSION;
+	handshake_hdr->type = EFA_RDM_HANDSHAKE_PKT;
+	handshake_hdr->version = EFA_RDM_PROTOCOL_VERSION;
 	handshake_hdr->nextra_p3 = nex + 3;
 	handshake_hdr->flags = 0;
 
 	calloc((uintptr_t)handshake_hdr->extra_info, nex * sizeof(uint64_t));
-	pkt_entry->pkt_size = sizeof(struct rxr_handshake_hdr) + nex * sizeof(uint64_t);
-	memcpy(pkt_entry->wiredata, handshake_hdr, sizeof(struct rxr_handshake_hdr));
-	assert_int_equal(efa_rdm_pke_get_base_hdr(pkt_entry)->type, RXR_HANDSHAKE_PKT);
+	pkt_entry->pkt_size = sizeof(struct efa_rdm_handshake_hdr) + nex * sizeof(uint64_t);
+	memcpy(pkt_entry->wiredata, handshake_hdr, sizeof(struct efa_rdm_handshake_hdr));
+	assert_int_equal(efa_rdm_pke_get_base_hdr(pkt_entry)->type, EFA_RDM_HANDSHAKE_PKT);
 
 	if (attr->connid) {
-		struct rxr_handshake_opt_connid_hdr opt_connid_hdr = {0};
+		struct efa_rdm_handshake_opt_connid_hdr opt_connid_hdr = {0};
 		opt_connid_hdr.connid = attr->connid;
-		handshake_hdr->flags |= RXR_PKT_CONNID_HDR;
-		memcpy(pkt_entry->wiredata + pkt_entry->pkt_size, &opt_connid_hdr, sizeof(struct rxr_handshake_opt_connid_hdr));
+		handshake_hdr->flags |= EFA_RDM_PKT_CONNID_HDR;
+		memcpy(pkt_entry->wiredata + pkt_entry->pkt_size, &opt_connid_hdr, sizeof(struct efa_rdm_handshake_opt_connid_hdr));
 		assert_int_equal(*efa_rdm_pke_connid_ptr(pkt_entry), attr->connid);
 		pkt_entry->pkt_size += sizeof(opt_connid_hdr);
 	}
 
 	if (attr->host_id) {
-		struct rxr_handshake_opt_host_id_hdr opt_host_id_hdr = {0};
+		struct efa_rdm_handshake_opt_host_id_hdr opt_host_id_hdr = {0};
 		opt_host_id_hdr.host_id = attr->host_id;
-		handshake_hdr->flags |= RXR_HANDSHAKE_HOST_ID_HDR;
-		memcpy(pkt_entry->wiredata + pkt_entry->pkt_size, &opt_host_id_hdr, sizeof(struct rxr_handshake_opt_host_id_hdr));
+		handshake_hdr->flags |= EFA_RDM_HANDSHAKE_HOST_ID_HDR;
+		memcpy(pkt_entry->wiredata + pkt_entry->pkt_size, &opt_host_id_hdr, sizeof(struct efa_rdm_handshake_opt_host_id_hdr));
 		assert_int_equal(*efa_rdm_pke_get_handshake_opt_host_id_ptr(pkt_entry), attr->host_id);
 		pkt_entry->pkt_size += sizeof(opt_host_id_hdr);
 	}

--- a/prov/efa/test/efa_unit_test_cq.c
+++ b/prov/efa/test/efa_unit_test_cq.c
@@ -430,7 +430,7 @@ static void test_impl_ibv_cq_ex_read_unknow_peer_ah(struct efa_resource *resourc
 	pkt_entry = efa_rdm_pke_alloc(efa_rdm_ep, efa_rdm_ep->efa_rx_pkt_pool, EFA_RDM_PKE_FROM_EFA_RX_POOL);
 	pkt_attr.msg_id = 0;
 	pkt_attr.connid = raw_addr.qkey;
-	/* Packet type must be in [RXR_REQ_PKT_BEGIN, RXR_EXTRA_REQ_PKT_END) */
+	/* Packet type must be in [EFA_RDM_REQ_PKT_BEGIN, EFA_RDM_EXTRA_REQ_PKT_END) */
 	efa_unit_test_eager_msgrtm_pkt_construct(pkt_entry, &pkt_attr);
 
 	/* Setup CQ */

--- a/prov/efa/test/efa_unit_test_mocks.c
+++ b/prov/efa/test/efa_unit_test_mocks.c
@@ -65,20 +65,20 @@ void efa_mock_ibv_wr_send_save_wr(struct ibv_qp_ex *qp)
 void efa_mock_ibv_wr_send_verify_handshake_pkt_local_host_id_and_save_wr(struct ibv_qp_ex *qp)
 {
 	struct efa_rdm_pke* pke;
-	struct rxr_base_hdr *rxr_base_hdr;
+	struct efa_rdm_base_hdr *efa_rdm_base_hdr;
 	uint64_t *host_id_ptr;
 
 	pke = (struct efa_rdm_pke *)qp->wr_id;
-	rxr_base_hdr = efa_rdm_pke_get_base_hdr(pke);
+	efa_rdm_base_hdr = efa_rdm_pke_get_base_hdr(pke);
 
-	assert_int_equal(rxr_base_hdr->type, RXR_HANDSHAKE_PKT);
+	assert_int_equal(efa_rdm_base_hdr->type, EFA_RDM_HANDSHAKE_PKT);
 
 	if (g_efa_unit_test_mocks.local_host_id) {
-		assert_true(rxr_base_hdr->flags & RXR_HANDSHAKE_HOST_ID_HDR);
+		assert_true(efa_rdm_base_hdr->flags & EFA_RDM_HANDSHAKE_HOST_ID_HDR);
 		host_id_ptr = efa_rdm_pke_get_handshake_opt_host_id_ptr(pke);
 		assert_true(*host_id_ptr == g_efa_unit_test_mocks.local_host_id);
 	} else {
-		assert_false(rxr_base_hdr->flags & RXR_HANDSHAKE_HOST_ID_HDR);
+		assert_false(efa_rdm_base_hdr->flags & EFA_RDM_HANDSHAKE_HOST_ID_HDR);
 	}
 
 	function_called();

--- a/prov/efa/test/efa_unit_test_ope.c
+++ b/prov/efa/test/efa_unit_test_ope.c
@@ -34,7 +34,7 @@ void test_efa_rdm_ope_prepare_to_post_send_impl(struct efa_resource *resource,
 
 	mock_txe.ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
 	err = efa_rdm_ope_prepare_to_post_send(&mock_txe,
-					       RXR_MEDIUM_MSGRTM_PKT,
+					       EFA_RDM_MEDIUM_MSGRTM_PKT,
 					       &pkt_entry_cnt,
 					       pkt_entry_data_size_vec);
 


### PR DESCRIPTION
Change the RXR/rxr prefix to EFA_RDM/efa_rdm.