### PR TITLE
prov/sm2: Remove locks causing RMA to hang

### DIFF
--- a/prov/sm2/src/sm2_progress.c
+++ b/prov/sm2/src/sm2_progress.c
@@ -366,11 +366,9 @@ void sm2_progress_recv(struct sm2_ep *ep)
 						"completion\n");
 			}
 
-			ofi_spin_lock(&ep->tx_lock);
 			smr_freestack_push(
 				sm2_freestack(sm2_mmap_ep_region(map, ep->gid)),
 				xfer_entry);
-			ofi_spin_unlock(&ep->tx_lock);
 			continue;
 		}
 


### PR DESCRIPTION
This PR makes it so that the RMA PR does not hang on fabtests.

The following things need to be locked:

1. We cannot have two simultaneous pop/push to the freestack
  a. This is complicated b/c we have the freestack being used in send/recv paths
          b. This suggests that we want to have per queue locking
2. We cannot have two simultaneous fifo reads
3. If we happen to re-map while another thread is doing something with its pointers, we might invalidate its pointers
  a. This is complicated b/c we can remap in both the send/recv paths... and the re-map on send has the potential to hurt a recv.
            b. I am not sure how we want to deal with this.

I think we need to re-think the sm2 locking.  The most glaring issue is how can we prevent another thread from re-mapping (during a recv).  Does this mean that the single shared memory file isn't a viable approach?