### PR TITLE
prov/tcp: Restrict which EPs can be opened per domain

### DIFF
--- a/prov/tcp/src/xnet.h
+++ b/prov/tcp/src/xnet.h
@@ -423,6 +423,7 @@ struct xnet_xfer_entry {
 struct xnet_domain {
 	struct util_domain		util_domain;
 	struct xnet_progress		progress;
+	enum fi_ep_type			ep_type;
 };
 
 static inline struct xnet_progress *xnet_ep2_progress(struct xnet_ep *ep)

--- a/prov/tcp/src/xnet_ep.c
+++ b/prov/tcp/src/xnet_ep.c
@@ -697,6 +697,7 @@ int xnet_endpoint(struct fid_domain *domain, struct fi_info *info,
 	if (ret)
 		goto err1;
 
+	assert(info->ep_attr->type == FI_EP_MSG);
 	ofi_bsock_init(&ep->bsock, &xnet_ep2_progress(ep)->sockapi,
 		       xnet_staging_sbuf_size, xnet_prefetch_rbuf_size,
 		       &ep->util_ep.ep_fid);

--- a/prov/tcp/src/xnet_rdm.c
+++ b/prov/tcp/src/xnet_rdm.c
@@ -878,6 +878,7 @@ int xnet_rdm_ep(struct fid_domain *domain, struct fi_info *info,
 	if (ret)
 		goto err1;
 
+	assert(info->ep_attr->type == FI_EP_RDM);
 	ret = xnet_init_rdm(rdm, info);
 	if (ret)
 		goto err2;

--- a/prov/tcp/src/xnet_rdm_cm.c
+++ b/prov/tcp/src/xnet_rdm_cm.c
@@ -171,8 +171,8 @@ static int xnet_open_conn(struct xnet_conn *conn, struct fi_info *info)
 	int ret;
 
 	assert(xnet_progress_locked(xnet_rdm2_progress(conn->rdm)));
-	ret = fi_endpoint(&conn->rdm->util_ep.domain->domain_fid, info,
-			  &ep_fid, conn);
+	ret = xnet_endpoint(&conn->rdm->util_ep.domain->domain_fid, info,
+			    &ep_fid, conn);
 	if (ret) {
 		XNET_WARN_ERR(FI_LOG_EP_CTRL, "fi_endpoint", ret);
 		return ret;


### PR DESCRIPTION
The tcp provider cannot mix rdm and msg endpoints on the same domain because of locking restrictions and optimizations targeting rdm endpoint support.  Fail calls that try to open and endpoint type not supported by the domain.