### PR TITLE
prov/efa: fix 0 byte write and add unit test

### DIFF
--- a/prov/efa/test/efa_unit_test_cq.c
+++ b/prov/efa/test/efa_unit_test_cq.c
@@ -127,12 +127,12 @@ static void test_rdm_cq_read_bad_send_status(struct efa_resource *resource,
 	ibv_qpx->wr_set_sge_list = &efa_mock_ibv_wr_set_sge_list_no_op;
 	ibv_qpx->wr_set_ud_addr = &efa_mock_ibv_wr_set_ud_addr_no_op;
 	ibv_qpx->wr_complete = &efa_mock_ibv_wr_complete_no_op;
-	assert_int_equal(g_ibv_send_wr_id_cnt, 0);
+	assert_int_equal(g_ibv_submitted_wr_id_cnt, 0);
 
 	err = fi_send(resource->ep, send_buff.buff, send_buff.size, fi_mr_desc(send_buff.mr), addr, NULL /* context */);
 	assert_int_equal(err, 0);
-	/* fi_send() called efa_mock_ibv_wr_send_save_wr(), which saved one send_wr in g_ibv_send_wr_id_vec */
-	assert_int_equal(g_ibv_send_wr_id_cnt, 1);
+	/* fi_send() called efa_mock_ibv_wr_send_save_wr(), which saved one send_wr in g_ibv_submitted_wr_id_vec */
+	assert_int_equal(g_ibv_submitted_wr_id_cnt, 1);
 
 	/* this mock will set ibv_cq_ex->wr_id to the wr_id f the head of global send_wr,
 	 * and set ibv_cq_ex->status to mock value */
@@ -145,8 +145,8 @@ static void test_rdm_cq_read_bad_send_status(struct efa_resource *resource,
 	will_return(efa_mock_ibv_read_opcode_return_mock, IBV_WC_SEND);
 	will_return(efa_mock_ibv_read_vendor_err_return_mock, vendor_error);
 	ret = fi_cq_read(resource->cq, &cq_entry, 1);
-	/* fi_cq_read() called efa_mock_ibv_start_poll_use_saved_send_wr(), which pulled one send_wr from g_ibv_send_wr_idv=_vec */
-	assert_int_equal(g_ibv_send_wr_id_cnt, 0);
+	/* fi_cq_read() called efa_mock_ibv_start_poll_use_saved_send_wr(), which pulled one send_wr from g_ibv_submitted_wr_idv=_vec */
+	assert_int_equal(g_ibv_submitted_wr_id_cnt, 0);
 	assert_int_equal(ret, -FI_EAVAIL);
 
 	/* Allocate memory to read CQ error */

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -187,7 +187,7 @@ void test_efa_rdm_ep_handshake_exchange_host_id(struct efa_resource **state, uin
 	 * to the saved send wr in handshake
 	 */
 	efa_rdm_ep->ibv_cq_ex->status = IBV_WC_GENERAL_ERR;
-	efa_rdm_ep->ibv_cq_ex->wr_id = (uintptr_t)g_ibv_send_wr_id_vec[0];
+	efa_rdm_ep->ibv_cq_ex->wr_id = (uintptr_t)g_ibv_submitted_wr_id_vec[0];
 
 	/* Progress the send wr to clean up outstanding tx ops */
 	cq_read_send_ret = fi_cq_read(resource->cq, &cq_entry, 1);

--- a/prov/efa/test/efa_unit_test_mocks.h
+++ b/prov/efa/test/efa_unit_test_mocks.h
@@ -21,17 +21,20 @@ int __real_efadv_query_device(struct ibv_context *ibvctx, struct efadv_device_at
 int efa_mock_efadv_query_device_return_mock(struct ibv_context *ibvctx, struct efadv_device_attr *attr,
 					    uint32_t inlen);
 
-extern void *g_ibv_send_wr_id_vec[EFA_RDM_EP_MAX_WR_PER_IBV_POST_SEND];
+extern void *g_ibv_submitted_wr_id_vec[EFA_RDM_EP_MAX_WR_PER_IBV_POST_SEND];
 
-extern int g_ibv_send_wr_id_cnt;
+extern int g_ibv_submitted_wr_id_cnt;
 
-void efa_ibv_send_wr_id_vec_clear();
+void efa_ibv_submitted_wr_id_vec_clear();
 
 void efa_mock_ibv_wr_start_no_op(struct ibv_qp_ex *qp);
 
 void efa_mock_ibv_wr_send_save_wr(struct ibv_qp_ex *qp);
 
 void efa_mock_ibv_wr_send_verify_handshake_pkt_local_host_id_and_save_wr(struct ibv_qp_ex *qp);
+
+void efa_mock_ibv_wr_rdma_write_save_wr(struct ibv_qp_ex *qp, uint32_t rkey,
+					uint64_t remote_addr);
 
 void efa_mock_ibv_wr_set_inline_data_list_no_op(struct ibv_qp_ex *qp,
 						size_t num_buf,

--- a/prov/efa/test/efa_unit_test_rnr.c
+++ b/prov/efa/test/efa_unit_test_rnr.c
@@ -41,10 +41,10 @@ void test_efa_rnr_queue_and_resend(struct efa_resource **state)
 	ret = fi_send(resource->ep, send_buff.buff, send_buff.size, fi_mr_desc(send_buff.mr), peer_addr, NULL /* context */);
 	assert_int_equal(ret, 0);
 	assert_false(dlist_empty(&efa_rdm_ep->txe_list));
-	assert_int_equal(g_ibv_send_wr_id_cnt, 1);
+	assert_int_equal(g_ibv_submitted_wr_id_cnt, 1);
 
 	txe = container_of(efa_rdm_ep->txe_list.next, struct efa_rdm_ope, ep_entry);
-	pkt_entry = (struct efa_rdm_pke *)g_ibv_send_wr_id_vec[0];
+	pkt_entry = (struct efa_rdm_pke *)g_ibv_submitted_wr_id_vec[0];
 
 	efa_rdm_ep_record_tx_op_completed(efa_rdm_ep, pkt_entry);
 	efa_rdm_ep_queue_rnr_pkt(efa_rdm_ep, &txe->queued_pkts, pkt_entry);

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -40,7 +40,7 @@ static int efa_unit_test_mocks_teardown(void **state)
 
 	efa_unit_test_resource_destruct(resource);
 
-	efa_ibv_send_wr_id_vec_clear();
+	efa_ibv_submitted_wr_id_vec_clear();
 
 	g_efa_unit_test_mocks = (struct efa_unit_test_mocks) {
 		.local_host_id = 0,
@@ -122,6 +122,8 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ope_prepare_to_post_send_host_memory_align128, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ope_prepare_to_post_send_cuda_memory, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ope_prepare_to_post_send_cuda_memory_align128, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_rdm_ope_post_write_0_byte,
+		efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_msg_send_to_local_peer_with_null_desc, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 	};
 

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -132,6 +132,7 @@ void test_efa_rdm_ope_prepare_to_post_send_host_memory();
 void test_efa_rdm_ope_prepare_to_post_send_host_memory_align128();
 void test_efa_rdm_ope_prepare_to_post_send_cuda_memory();
 void test_efa_rdm_ope_prepare_to_post_send_cuda_memory_align128();
+void test_efa_rdm_ope_post_write_0_byte();
 void test_efa_rdm_msg_send_to_local_peer_with_null_desc();
 
 #endif


### PR DESCRIPTION
fix efa_rdm_ope_post_remote_write for 0 byte, and add a unit test.