### PR TITLE
prov/sm2: Allocate and map maximum size shm file at init

### DIFF
--- a/prov/sm2/src/sm2_coordination.h
+++ b/prov/sm2/src/sm2_coordination.h
@@ -49,7 +49,7 @@
 #include <rdma/providers/fi_prov.h>
 
 #define SM2_XFER_ENTRY_SIZE   4096
-#define SM2_MAX_UNIVERSE_SIZE 2048
+#define SM2_MAX_UNIVERSE_SIZE 256
 /* TODO: Make the number of XFER ENTRY's configurable */
 #define SM2_NUM_XFER_ENTRY_PER_PEER 1024
 

--- a/prov/sm2/src/sm2_coordination.h
+++ b/prov/sm2/src/sm2_coordination.h
@@ -97,7 +97,6 @@ int sm2_create(const struct fi_provider *prov, const struct sm2_attr *attr,
 	       struct sm2_mmap *sm2_mmap, sm2_gid_t *gid);
 
 ssize_t sm2_mmap_cleanup(struct sm2_mmap *map);
-int sm2_mmap_remap(struct sm2_mmap *map, size_t at_least);
 
 ssize_t sm2_entry_allocate(const char *name, struct sm2_mmap *map,
 			   sm2_gid_t *gid, bool self);


### PR DESCRIPTION
This change causes the entire shared memory file to be allocated and mapped into each processes address space on startup. This change fixes a multi-threaded race condition where one thread calls remap in sm2_av_insert() while another thread is in the middle of a sm2_fifo_read(), or sm2_fifo_write(). We need increased memory usage in order to provide correctness to the user.