### PR TITLE
contrib/intel/jenkins: use python to invoke launch.py

### DIFF
--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -958,7 +958,7 @@ class DaosCartTest(Test):
 
     @property
     def cmd(self):
-        return "./launch.py "
+        return "python3.6 launch.py "
     
     def remote_launch_cmd(self, testname):
 


### PR DESCRIPTION
Use python to invoke launch.py for daos instead of ./ since ./will use the latest version.