### PR TITLE
prov/sm2: Add self_region and mmap to struct sm2_ep

### DIFF
--- a/prov/sm2/src/sm2_progress.c
+++ b/prov/sm2/src/sm2_progress.c
@@ -331,9 +331,6 @@ out:
 
 void sm2_progress_recv(struct sm2_ep *ep)
 {
-	struct sm2_av *av =
-		container_of(ep->util_ep.av, struct sm2_av, util_av);
-	struct sm2_mmap *map = &av->mmap;
 	struct sm2_atomic_entry *atomic_entry;
 	struct sm2_xfer_entry *xfer_entry;
 	int ret = 0, i;
@@ -366,9 +363,8 @@ void sm2_progress_recv(struct sm2_ep *ep)
 						"completion\n");
 			}
 
-			smr_freestack_push(
-				sm2_freestack(sm2_mmap_ep_region(map, ep->gid)),
-				xfer_entry);
+			smr_freestack_push(sm2_freestack(ep->self_region),
+					   xfer_entry);
 			continue;
 		}
 


### PR DESCRIPTION
Clean up code, and save instructions by adding self_region and mmap to struct sm2_ep.