### PR TITLE
prov/sm2: Default to ep->domain->threading

### DIFF
--- a/prov/shm/src/smr_domain.c
+++ b/prov/shm/src/smr_domain.c
@@ -104,7 +104,6 @@ int smr_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		return ret;
 	}
 
-	smr_domain->util_domain.threading = FI_THREAD_SAFE;
 	smr_fabric = container_of(fabric, struct smr_fabric, util_fabric.fabric_fid);
 	ofi_mutex_lock(&smr_fabric->util_fabric.lock);
 	smr_domain->fast_rma = smr_fast_rma_enabled(info->domain_attr->mr_mode,

--- a/prov/sm2/src/sm2_domain.c
+++ b/prov/sm2/src/sm2_domain.c
@@ -102,8 +102,6 @@ int sm2_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		return ret;
 	}
 
-	sm2_domain->util_domain.threading = FI_THREAD_SAFE;
-
 	*domain = &sm2_domain->util_domain.domain_fid;
 	(*domain)->fid.ops = &sm2_domain_fi_ops;
 	(*domain)->ops = &sm2_domain_ops;


### PR DESCRIPTION
SM2 is currently hard coding FI_THREAD_SAFE, but the correct behavior for the provider is to assume the domain thread safety-ness.