### PR TITLE
prov/efa: fix calling of efa_rdm_pke_print()

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_pke.c
+++ b/prov/efa/src/rdm/efa_rdm_pke.c
@@ -431,7 +431,7 @@ ssize_t efa_rdm_pke_sendv(struct efa_rdm_ep *ep,
 #if ENABLE_DEBUG
 		dlist_insert_tail(&pkt_entry->dbg_entry, &ep->tx_pkt_list);
 #ifdef ENABLE_EFA_RDM_PKT_DUMP
-		rxr_pkt_print("Sent", ep, (struct efa_rdm_base_hdr *)pkt_entry->wiredata);
+		efa_rdm_pke_print(pkt_entry, "Sent");
 #endif
 #endif
 

--- a/prov/efa/src/rdm/efa_rdm_pke_cmd.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_cmd.c
@@ -929,7 +929,7 @@ void efa_rdm_pke_handle_recv_completion(struct efa_rdm_pke *pkt_entry)
 		dlist_insert_tail(&pkt_entry->dbg_entry, &ep->rx_pkt_list);
 	}
 #ifdef ENABLE_efa_rdm_pke_DUMP
-	efa_rdm_pke_print("Received", ep, (struct efa_rdm_base_hdr *)pkt_entry->wiredata);
+	efa_rdm_pke_print(pkt_entry, "Received");
 #endif
 #endif
 	peer = efa_rdm_ep_get_peer(ep, pkt_entry->addr);


### PR DESCRIPTION
The name and the signature of the function changed, therefore the caller need to be updated accordingly.