### PR TITLE
prov/efa: remove EFA_FORK_STATUS_UNNEEEDED

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -141,7 +141,8 @@ nodist_prov_efa_test_efa_unit_test_SOURCES = \
 	prov/efa/test/efa_unit_test_srx.c \
 	prov/efa/test/efa_unit_test_rnr.c \
 	prov/efa/test/efa_unit_test_ope.c \
-	prov/efa/test/efa_unit_test_send.c
+	prov/efa/test/efa_unit_test_send.c \
+	prov/efa/test/efa_unit_test_fork_support.c
 
 efa_CPPFLAGS += -I$(top_srcdir)/include -I$(top_srcdir)/prov/efa/test $(cmocka_CPPFLAGS)
 
@@ -149,6 +150,7 @@ prov_efa_test_efa_unit_test_CPPFLAGS = $(efa_CPPFLAGS)
 prov_efa_test_efa_unit_test_LDADD = $(cmocka_LIBS) $(linkback)
 prov_efa_test_efa_unit_test_LDFLAGS = $(cmocka_rpath) $(efa_LDFLAGS) $(cmocka_LDFLAGS) \
 					-Wl,--wrap=ibv_create_ah \
+					-Wl,--wrap=ibv_is_fork_initialized \
 					-Wl,--wrap=efadv_query_device \
 					-Wl,--wrap=ofi_copy_from_hmem_iov
 

--- a/prov/efa/src/efa_fork_support.h
+++ b/prov/efa/src/efa_fork_support.h
@@ -42,7 +42,6 @@
 enum efa_fork_support_status {
 	EFA_FORK_SUPPORT_OFF = 0,
 	EFA_FORK_SUPPORT_ON,
-	EFA_FORK_SUPPORT_UNNEEDED,
 };
 extern enum efa_fork_support_status g_efa_fork_status;
 

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -295,9 +295,6 @@ void test_efa_rdm_ep_pkt_pool_flags(struct efa_resource **state) {
 
 	g_efa_fork_status = EFA_FORK_SUPPORT_OFF;
 	check_ep_pkt_pool_flags(resource, OFI_BUFPOOL_HUGEPAGES);
-
-	g_efa_fork_status = EFA_FORK_SUPPORT_UNNEEDED;
-	check_ep_pkt_pool_flags(resource, OFI_BUFPOOL_HUGEPAGES);
 }
 
 /**

--- a/prov/efa/test/efa_unit_test_fork_support.c
+++ b/prov/efa/test/efa_unit_test_fork_support.c
@@ -1,0 +1,21 @@
+#include "efa_unit_tests.h"
+
+/**
+ * @brief verify efa_fork_support_request_initialize() set value of g_efa_fork_status correctly
+ * 
+ * @brief
+ * as long as user set FI_EFA_FORK_SAFE to 1, g_efa_fork_status should be
+ * EFA_FORK_SUPPORT_ON, even what ibv_is_fork_initialize() return
+ * IBV_FOKR_UNNEEDED.
+ */
+void test_efa_fork_support_request_initialize_when_ibv_fork_unneeded(void **state)
+{
+	setenv("FI_EFA_FORK_SAFE", "1", true);
+	g_efa_unit_test_mocks.ibv_is_fork_initialized = &efa_mock_ibv_is_fork_initialize_return_unneeded;
+
+	efa_fork_support_request_initialize();
+	assert_int_equal(g_efa_fork_status, EFA_FORK_SUPPORT_ON);
+
+	g_efa_unit_test_mocks.ibv_is_fork_initialized = __real_ibv_is_fork_initialized;
+	unsetenv("FI_EFA_FORK_SAFE");
+}

--- a/prov/efa/test/efa_unit_test_mocks.c
+++ b/prov/efa/test/efa_unit_test_mocks.c
@@ -191,6 +191,7 @@ struct efa_unit_test_mocks g_efa_unit_test_mocks = {
 	.neuron_alloc = __real_neuron_alloc,
 #endif
 	.ofi_copy_from_hmem_iov = __real_ofi_copy_from_hmem_iov,
+	.ibv_is_fork_initialized = __real_ibv_is_fork_initialized,
 };
 
 struct ibv_ah *__wrap_ibv_create_ah(struct ibv_pd *pd, struct ibv_ah_attr *attr)
@@ -292,4 +293,14 @@ ssize_t __wrap_ofi_copy_from_hmem_iov(void *dest, size_t size,
 				      size_t hmem_iov_count, uint64_t hmem_iov_offset)
 {
 	return g_efa_unit_test_mocks.ofi_copy_from_hmem_iov(dest, size, hmem_iface, device, hmem_iov, hmem_iov_count, hmem_iov_offset);
+}
+
+enum ibv_fork_status __wrap_ibv_is_fork_initialized(void)
+{
+	return g_efa_unit_test_mocks.ibv_is_fork_initialized();
+}
+
+enum ibv_fork_status efa_mock_ibv_is_fork_initialize_return_unneeded(void)
+{
+	return IBV_FORK_UNNEEDED;
 }

--- a/prov/efa/test/efa_unit_test_mocks.h
+++ b/prov/efa/test/efa_unit_test_mocks.h
@@ -100,6 +100,8 @@ struct efa_unit_test_mocks
 					  enum fi_hmem_iface hmem_iface, uint64_t device,
 					  const struct iovec *hmem_iov,
 					  size_t hmem_iov_count, uint64_t hmem_iov_offset);
+
+	enum ibv_fork_status (*ibv_is_fork_initialized)(void);
 };
 
 struct ibv_cq_ex *efa_mock_create_cq_ex_return_null(struct ibv_context *context, struct ibv_cq_init_attr_ex *init_attr);
@@ -131,5 +133,10 @@ struct ibv_cq_ex *efa_mock_efadv_create_cq_set_eopnotsupp_and_return_null(struct
 void *__real_neuron_alloc(void **handle, size_t size);
 void *efa_mock_neuron_alloc_return_null(void **handle, size_t size);
 #endif
+
+enum ibv_fork_status __real_ibv_is_fork_initialized(void);
+
+enum ibv_fork_status efa_mock_ibv_is_fork_initialize_return_unneeded(void);
+
 
 #endif

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -54,10 +54,12 @@ static int efa_unit_test_mocks_teardown(void **state)
 		.neuron_alloc = __real_neuron_alloc,
 #endif
 		.ofi_copy_from_hmem_iov = __real_ofi_copy_from_hmem_iov,
+		.ibv_is_fork_initialized = __real_ibv_is_fork_initialized,
 	};
 
 	/* Reset environment */
 	efa_env = orig_efa_env;
+	unsetenv("FI_EFA_FORK_SAFE");
 	unsetenv("FI_EFA_USE_DEVICE_RDMA");
 
 	return 0;
@@ -125,6 +127,7 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ope_post_write_0_byte,
 		efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_msg_send_to_local_peer_with_null_desc, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_fork_support_request_initialize_when_ibv_fork_unneeded, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 	};
 
 	cmocka_set_message_output(CM_OUTPUT_XML);

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -134,5 +134,6 @@ void test_efa_rdm_ope_prepare_to_post_send_cuda_memory();
 void test_efa_rdm_ope_prepare_to_post_send_cuda_memory_align128();
 void test_efa_rdm_ope_post_write_0_byte();
 void test_efa_rdm_msg_send_to_local_peer_with_null_desc();
+void test_efa_fork_support_request_initialize_when_ibv_fork_unneeded();
 
 #endif


### PR DESCRIPTION
Remove the status EFA_FORK_STATUS_UNNEEEDED because using this option can cause system to run out of memory.