### PR TITLE
prov/efa: update signature of efa_rdm_pke functions

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -676,7 +676,7 @@ static void efa_rdm_ep_destroy_buffer_pools(struct efa_rdm_ep *efa_rdm_ep)
 #if ENABLE_DEBUG
 	dlist_foreach_safe(&efa_rdm_ep->rx_posted_buf_list, entry, tmp) {
 		pkt_entry = container_of(entry, struct efa_rdm_pke, dbg_entry);
-		efa_rdm_pke_release_rx(efa_rdm_ep, pkt_entry);
+		efa_rdm_pke_release_rx(pkt_entry);
 	}
 
 	dlist_foreach_safe(&efa_rdm_ep->rx_pkt_list, entry, tmp) {
@@ -684,7 +684,7 @@ static void efa_rdm_ep_destroy_buffer_pools(struct efa_rdm_ep *efa_rdm_ep)
 		EFA_WARN(FI_LOG_EP_CTRL,
 			"Closing ep with unreleased RX pkt_entry: %p\n",
 			pkt_entry);
-		efa_rdm_pke_release_rx(efa_rdm_ep, pkt_entry);
+		efa_rdm_pke_release_rx(pkt_entry);
 	}
 
 	dlist_foreach_safe(&efa_rdm_ep->tx_pkt_list, entry, tmp) {
@@ -692,7 +692,7 @@ static void efa_rdm_ep_destroy_buffer_pools(struct efa_rdm_ep *efa_rdm_ep)
 		EFA_WARN(FI_LOG_EP_CTRL,
 			"Closing ep with unreleased TX pkt_entry: %p\n",
 			pkt_entry);
-		efa_rdm_pke_release_tx(efa_rdm_ep, pkt_entry);
+		efa_rdm_pke_release_tx(pkt_entry);
 	}
 #endif
 

--- a/prov/efa/src/rdm/efa_rdm_ep_progress.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_progress.c
@@ -62,16 +62,15 @@ int efa_rdm_ep_bulk_post_internal_rx_pkts(struct efa_rdm_ep *ep)
 
 	assert(ep->efa_rx_pkts_to_post + ep->efa_rx_pkts_posted <= ep->efa_max_outstanding_rx_ops);
 	for (i = 0; i < ep->efa_rx_pkts_to_post; ++i) {
-		pke_vec[i] = efa_rdm_pke_alloc(ep,
-					       ep->efa_rx_pkt_pool,
+		pke_vec[i] = efa_rdm_pke_alloc(ep, ep->efa_rx_pkt_pool,
 					       EFA_RDM_PKE_FROM_EFA_RX_POOL);
 		assert(pke_vec[i]);
 	}
 
-	err = efa_rdm_pke_recvv(ep, pke_vec, ep->efa_rx_pkts_to_post);
+	err = efa_rdm_pke_recvv(pke_vec, ep->efa_rx_pkts_to_post);
 	if (OFI_UNLIKELY(err)) {
 		for (i = 0; i < ep->efa_rx_pkts_to_post; ++i)
-			efa_rdm_pke_release_rx(ep, pke_vec[i]);
+			efa_rdm_pke_release_rx(pke_vec[i]);
 
 		EFA_WARN(FI_LOG_EP_CTRL,
 			"failed to post buf %d (%s)\n", -err,
@@ -330,7 +329,7 @@ void efa_rdm_ep_proc_ibv_recv_rdma_with_imm_completion(struct efa_rdm_ep *ep,
 	   filled, so free the pkt_entry and record we have one less posted
 	   packet now. */
 	ep->efa_rx_pkts_posted--;
-	efa_rdm_pke_release_rx(ep, pkt_entry);
+	efa_rdm_pke_release_rx(pkt_entry);
 }
 
 #if HAVE_EFADV_CQ_EX
@@ -564,7 +563,7 @@ ssize_t efa_rdm_ep_send_queued_pkts(struct efa_rdm_ep *ep,
 		 */
 		dlist_remove(&pkt_entry->entry);
 
-		ret = efa_rdm_pke_sendv(ep, &pkt_entry, 1);
+		ret = efa_rdm_pke_sendv(&pkt_entry, 1);
 		if (ret) {
 			if (ret == -FI_EAGAIN) {
 				/* add the pkt back to pkts, so it can be resent again */

--- a/prov/efa/src/rdm/efa_rdm_ep_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_utils.c
@@ -258,9 +258,9 @@ int efa_rdm_ep_post_user_recv_buf(struct efa_rdm_ep *ep, struct efa_rdm_ope *rxe
 	pkt_entry->ope = rxe;
 	rxe->state = EFA_RDM_RXE_MATCHED;
 
-	err = efa_rdm_pke_recvv(ep, &pkt_entry, 1);
+	err = efa_rdm_pke_recvv(&pkt_entry, 1);
 	if (OFI_UNLIKELY(err)) {
-		efa_rdm_pke_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(pkt_entry);
 		EFA_WARN(FI_LOG_EP_CTRL,
 			"failed to post user supplied buffer %d (%s)\n", -err,
 			fi_strerror(-err));
@@ -616,9 +616,9 @@ ssize_t efa_rdm_ep_post_handshake(struct efa_rdm_ep *ep, struct efa_rdm_peer *pe
 
 	efa_rdm_pke_init_handshake(pkt_entry, addr);
 
-	ret = efa_rdm_pke_sendv(ep, &pkt_entry, 1);
+	ret = efa_rdm_pke_sendv(&pkt_entry, 1);
 	if (OFI_UNLIKELY(ret)) {
-		efa_rdm_pke_release_tx(ep, pkt_entry);
+		efa_rdm_pke_release_tx(pkt_entry);
 	}
 	return ret;
 }

--- a/prov/efa/src/rdm/efa_rdm_msg.c
+++ b/prov/efa/src/rdm/efa_rdm_msg.c
@@ -700,7 +700,7 @@ struct efa_rdm_ope *efa_rdm_msg_alloc_unexp_rxe_for_rtm(struct efa_rdm_ep *ep,
 
 	assert(op == ofi_op_msg || ofi_op_tagged);
 
-	unexp_pkt_entry = efa_rdm_pke_get_unexp(ep, pkt_entry_ptr);
+	unexp_pkt_entry = efa_rdm_pke_get_unexp(pkt_entry_ptr);
 	if (OFI_UNLIKELY(!unexp_pkt_entry)) {
 		EFA_WARN(FI_LOG_CQ, "packet entries exhausted.\n");
 		return NULL;

--- a/prov/efa/src/rdm/efa_rdm_peer.c
+++ b/prov/efa/src/rdm/efa_rdm_peer.c
@@ -186,13 +186,13 @@ int efa_rdm_peer_reorder_msg(struct efa_rdm_peer *peer, struct efa_rdm_ep *ep,
 
 	if (OFI_LIKELY(efa_env.rx_copy_ooo)) {
 		assert(pkt_entry->alloc_type == EFA_RDM_PKE_FROM_EFA_RX_POOL);
-		ooo_entry = efa_rdm_pke_clone(ep, ep->rx_ooo_pkt_pool, EFA_RDM_PKE_FROM_OOO_POOL, pkt_entry);
+		ooo_entry = efa_rdm_pke_clone(pkt_entry, ep->rx_ooo_pkt_pool, EFA_RDM_PKE_FROM_OOO_POOL);
 		if (OFI_UNLIKELY(!ooo_entry)) {
 			EFA_WARN(FI_LOG_EP_CTRL,
 				"Unable to allocate rx_pkt_entry for OOO msg\n");
 			return -FI_ENOMEM;
 		}
-		efa_rdm_pke_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(pkt_entry);
 	} else {
 		ooo_entry = pkt_entry;
 	}

--- a/prov/efa/src/rdm/efa_rdm_pke.h
+++ b/prov/efa/src/rdm/efa_rdm_pke.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 Amazon.com, Inc. or its affiliates.
+ * Copyright (c) Amazon.com, Inc. or its affiliates.
  * All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -245,42 +245,33 @@ struct efa_rdm_pke *efa_rdm_pke_alloc(struct efa_rdm_ep *ep,
 				      struct ofi_bufpool *pkt_pool,
 				      enum efa_rdm_pke_alloc_type alloc_type);
 
-void efa_rdm_pke_release_tx(struct efa_rdm_ep *ep,
-			      struct efa_rdm_pke *pkt_entry);
+void efa_rdm_pke_release_tx(struct efa_rdm_pke *pkt_entry);
 
-void efa_rdm_pke_release_rx(struct efa_rdm_ep *ep,
-			      struct efa_rdm_pke *pkt_entry);
+void efa_rdm_pke_release_rx(struct efa_rdm_pke *pkt_entry);
 
-void efa_rdm_pke_release(struct efa_rdm_ep *ep,
-			   struct efa_rdm_pke *pkt_entry);
+void efa_rdm_pke_release(struct efa_rdm_pke *pkt_entry);
 
 void efa_rdm_pke_append(struct efa_rdm_pke *dst,
-			  struct efa_rdm_pke *src);
+			struct efa_rdm_pke *src);
 
-struct efa_rdm_pke *efa_rdm_pke_clone(struct efa_rdm_ep *ep,
+struct efa_rdm_pke *efa_rdm_pke_clone(struct efa_rdm_pke *src,
 				      struct ofi_bufpool *pkt_pool,
-				      enum efa_rdm_pke_alloc_type alloc_type,
-				      struct efa_rdm_pke *src);
+				      enum efa_rdm_pke_alloc_type alloc_type
+				      );
 
-struct efa_rdm_pke *efa_rdm_pke_get_unexp(struct efa_rdm_ep *ep,
-					struct efa_rdm_pke **pkt_entry_ptr);
+struct efa_rdm_pke *efa_rdm_pke_get_unexp(struct efa_rdm_pke **pkt_entry_ptr);
 
-ssize_t efa_rdm_pke_sendv(struct efa_rdm_ep *ep,
-			    struct efa_rdm_pke **pkt_entry_vec,
-			    int pkt_entry_cnt);
+ssize_t efa_rdm_pke_sendv(struct efa_rdm_pke **pkt_entry_vec,
+			  int pkt_entry_cnt);
 
-int efa_rdm_pke_read(struct efa_rdm_ep *ep, struct efa_rdm_pke *pkt_entry,
-		       void *local_buf, size_t len, void *desc,
-		       uint64_t remote_buf, size_t remote_key);
+int efa_rdm_pke_read(struct efa_rdm_pke *pkt_entry,
+		     void *local_buf, size_t len, void *desc,
+		     uint64_t remote_buf, size_t remote_key);
 
-ssize_t efa_rdm_pke_recvv(struct efa_rdm_ep *ep,
-			  struct efa_rdm_pke **pke_vec,
+ssize_t efa_rdm_pke_recvv(struct efa_rdm_pke **pke_vec,
 			  int pke_cnt);
 
-int efa_rdm_pke_write(struct efa_rdm_ep *ep, struct efa_rdm_pke *pkt_entry,
-		       void *local_buf, size_t len, void *desc,
-		       uint64_t remote_buf, size_t remote_key);
-
-
-
+int efa_rdm_pke_write(struct efa_rdm_pke *pkt_entry,
+		      void *local_buf, size_t len, void *desc,
+		      uint64_t remote_buf, size_t remote_key);
 #endif

--- a/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
@@ -126,7 +126,7 @@ void efa_rdm_pke_handle_handshake_recv(struct efa_rdm_pke *pkt_entry)
 		EFA_INFO(FI_LOG_CQ, "Received peer host id: i-%017lx\n", peer->host_id);
 	}
 
-	efa_rdm_pke_release_rx(pkt_entry->ep, pkt_entry);
+	efa_rdm_pke_release_rx(pkt_entry);
 }
 
 /*  CTS packet related functions */
@@ -198,7 +198,7 @@ void efa_rdm_pke_handle_cts_recv(struct efa_rdm_pke *pkt_entry)
 	ope->window = cts_pkt->recv_length;
 	assert(ope->window > 0);
 
-	efa_rdm_pke_release_rx(pkt_entry->ep, pkt_entry);
+	efa_rdm_pke_release_rx(pkt_entry);
 
 	if (ope->state != EFA_RDM_TXE_SEND) {
 		ope->state = EFA_RDM_TXE_SEND;
@@ -329,7 +329,7 @@ void efa_rdm_pke_proc_ctsdata(struct efa_rdm_pke *pkt_entry,
 #endif
 	err = efa_rdm_pke_copy_payload_to_ope(pkt_entry, ope);
 	if (err) {
-		efa_rdm_pke_release_rx(pkt_entry->ep, pkt_entry);
+		efa_rdm_pke_release_rx(pkt_entry);
 		efa_rdm_rxe_handle_error(ope, -err, FI_EFA_ERR_RXE_COPY);
 	}
 
@@ -584,7 +584,7 @@ void efa_rdm_pke_handle_rma_completion(struct efa_rdm_pke *context_pkt_entry)
 	}
 
 	efa_rdm_ep_record_tx_op_completed(context_pkt_entry->ep, context_pkt_entry);
-	efa_rdm_pke_release_tx(context_pkt_entry->ep, context_pkt_entry);
+	efa_rdm_pke_release_tx(context_pkt_entry);
 }
 
 /*  EOR packet related functions */
@@ -645,7 +645,7 @@ void efa_rdm_pke_handle_eor_recv(struct efa_rdm_pke *pkt_entry)
 		efa_rdm_txe_release(txe);
 	}
 
-	efa_rdm_pke_release_rx(pkt_entry->ep, pkt_entry);
+	efa_rdm_pke_release_rx(pkt_entry);
 
 }
 
@@ -694,7 +694,7 @@ void efa_rdm_pke_handle_receipt_recv(struct efa_rdm_pke *pkt_entry)
 	}
 
 	efa_rdm_ope_handle_send_completed(txe);
-	efa_rdm_pke_release_rx(pkt_entry->ep, pkt_entry);
+	efa_rdm_pke_release_rx(pkt_entry);
 }
 
 /* atomrsp packet related functions: init, handle_sent, handle_send_completion and recv
@@ -763,5 +763,5 @@ void efa_rdm_pke_handle_atomrsp_recv(struct efa_rdm_pke *pkt_entry)
 		efa_cntr_report_tx_completion(&pkt_entry->ep->base_ep.util_ep, txe->cq_entry.flags);
 
 	efa_rdm_txe_release(txe);
-	efa_rdm_pke_release_rx(pkt_entry->ep, pkt_entry);
+	efa_rdm_pke_release_rx(pkt_entry);
 }

--- a/prov/efa/src/rdm/efa_rdm_pke_rta.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_rta.c
@@ -266,7 +266,7 @@ int efa_rdm_pke_proc_write_rta(struct efa_rdm_pke *pkt_entry)
 		offset += iov[i].iov_len;
 	}
 
-	efa_rdm_pke_release_rx(pkt_entry->ep, pkt_entry);
+	efa_rdm_pke_release_rx(pkt_entry);
 	return 0;
 }
 
@@ -311,7 +311,7 @@ int efa_rdm_pke_proc_dc_write_rta(struct efa_rdm_pke *pkt_entry)
 	rxe = efa_rdm_pke_alloc_rta_rxe(pkt_entry, ofi_op_atomic);
 	if (OFI_UNLIKELY(!rxe)) {
 		efa_base_ep_write_eq_error(&pkt_entry->ep->base_ep, FI_ENOBUFS, FI_EFA_ERR_RXE_POOL_EXHAUSTED);
-		efa_rdm_pke_release_rx(pkt_entry->ep, pkt_entry);
+		efa_rdm_pke_release_rx(pkt_entry);
 		return -FI_ENOBUFS;
 	}
 
@@ -447,7 +447,7 @@ int efa_rdm_pke_proc_fetch_rta(struct efa_rdm_pke *pkt_entry)
 	if (OFI_UNLIKELY(err))
 		efa_rdm_rxe_handle_error(rxe, -err, FI_EFA_ERR_PKT_POST);
 
-	efa_rdm_pke_release_rx(ep, pkt_entry);
+	efa_rdm_pke_release_rx(pkt_entry);
 	return 0;
 }
 
@@ -540,7 +540,7 @@ int efa_rdm_pke_proc_compare_rta(struct efa_rdm_pke *pkt_entry)
 	rxe = efa_rdm_pke_alloc_rta_rxe(pkt_entry, ofi_op_atomic_compare);
 	if(OFI_UNLIKELY(!rxe)) {
 		efa_base_ep_write_eq_error(&pkt_entry->ep->base_ep, FI_ENOBUFS, FI_EFA_ERR_RXE_POOL_EXHAUSTED);
-		efa_rdm_pke_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(pkt_entry);
 		return -FI_ENOBUFS;
 	}
 
@@ -551,7 +551,7 @@ int efa_rdm_pke_proc_compare_rta(struct efa_rdm_pke *pkt_entry)
 	if (OFI_UNLIKELY(!dtsize)) {
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_EINVAL, FI_EFA_ERR_INVALID_DATATYPE);
 		efa_rdm_rxe_release(rxe);
-		efa_rdm_pke_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(pkt_entry);
 		return -errno;
 	}
 
@@ -583,10 +583,10 @@ int efa_rdm_pke_proc_compare_rta(struct efa_rdm_pke *pkt_entry)
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_EIO, FI_EFA_ERR_PKT_POST);
 		ofi_buf_free(rxe->atomrsp_data);
 		efa_rdm_rxe_release(rxe);
-		efa_rdm_pke_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(pkt_entry);
 		return err;
 	}
 
-	efa_rdm_pke_release_rx(ep, pkt_entry);
+	efa_rdm_pke_release_rx(pkt_entry);
 	return 0;
 }

--- a/prov/efa/src/rdm/efa_rdm_pke_rtr.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtr.c
@@ -115,7 +115,7 @@ void efa_rdm_pke_handle_rtr_recv(struct efa_rdm_pke *pkt_entry)
 		EFA_WARN(FI_LOG_CQ,
 			"RX entries exhausted.\n");
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_ENOBUFS, FI_EFA_ERR_RXE_POOL_EXHAUSTED);
-		efa_rdm_pke_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(pkt_entry);
 		return;
 	}
 
@@ -133,7 +133,7 @@ void efa_rdm_pke_handle_rtr_recv(struct efa_rdm_pke *pkt_entry)
 		EFA_WARN(FI_LOG_CQ, "RMA address verification failed!\n");
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_EINVAL, FI_EFA_ERR_RMA_ADDR);
 		efa_rdm_rxe_release(rxe);
-		efa_rdm_pke_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(pkt_entry);
 		return;
 	}
 
@@ -147,9 +147,9 @@ void efa_rdm_pke_handle_rtr_recv(struct efa_rdm_pke *pkt_entry)
 		EFA_WARN(FI_LOG_CQ, "Posting of readrsp packet failed! err=%ld\n", err);
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_EIO, FI_EFA_ERR_PKT_POST);
 		efa_rdm_rxe_release(rxe);
-		efa_rdm_pke_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(pkt_entry);
 		return;
 	}
 
-	efa_rdm_pke_release_rx(ep, pkt_entry);
+	efa_rdm_pke_release_rx(pkt_entry);
 }

--- a/prov/efa/src/rdm/efa_rdm_pke_rtw.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtw.c
@@ -178,7 +178,7 @@ void efa_rdm_pke_proc_eager_rtw(struct efa_rdm_pke *pkt_entry,
 		EFA_WARN(FI_LOG_CQ, "RMA address verify failed!\n");
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_EIO, FI_EFA_ERR_RMA_ADDR);
 		efa_rdm_rxe_release(rxe);
-		efa_rdm_pke_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(pkt_entry);
 		return;
 	}
 
@@ -193,13 +193,13 @@ void efa_rdm_pke_proc_eager_rtw(struct efa_rdm_pke *pkt_entry,
 		EFA_WARN(FI_LOG_CQ, "target buffer: %p length: %ld\n", rxe->iov[0].iov_base,
 			rxe->iov[0].iov_len);
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_EINVAL, FI_EFA_ERR_RTM_MISMATCH);
-		efa_rdm_pke_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(pkt_entry);
 		efa_rdm_rxe_release(rxe);
 	} else {
 		err = efa_rdm_pke_copy_payload_to_ope(pkt_entry, rxe);
 		if (OFI_UNLIKELY(err)) {
 			efa_base_ep_write_eq_error(&ep->base_ep, FI_EINVAL, FI_EFA_ERR_RXE_COPY);
-			efa_rdm_pke_release_rx(ep, pkt_entry);
+			efa_rdm_pke_release_rx(pkt_entry);
 			efa_rdm_rxe_release(rxe);
 		}
 	}
@@ -226,7 +226,7 @@ void efa_rdm_pke_handle_eager_rtw_recv(struct efa_rdm_pke *pkt_entry)
 		EFA_WARN(FI_LOG_CQ,
 			"RX entries exhausted.\n");
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_ENOBUFS, FI_EFA_ERR_RXE_POOL_EXHAUSTED);
-		efa_rdm_pke_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(pkt_entry);
 		return;
 	}
 
@@ -287,7 +287,7 @@ void efa_rdm_pke_handle_dc_eager_rtw_recv(struct efa_rdm_pke *pkt_entry)
 			"RX entries exhausted.\n");
 		efa_base_ep_write_eq_error(&pkt_entry->ep->base_ep,
 					   FI_ENOBUFS, FI_EFA_ERR_RXE_POOL_EXHAUSTED);
-		efa_rdm_pke_release_rx(pkt_entry->ep, pkt_entry);
+		efa_rdm_pke_release_rx(pkt_entry);
 		return;
 	}
 
@@ -406,7 +406,7 @@ void efa_rdm_pke_handle_longcts_rtw_recv(struct efa_rdm_pke *pkt_entry)
 		efa_base_ep_write_eq_error(&pkt_entry->ep->base_ep,
 					   FI_ENOBUFS,
 					   FI_EFA_ERR_RXE_POOL_EXHAUSTED);
-		efa_rdm_pke_release_rx(pkt_entry->ep, pkt_entry);
+		efa_rdm_pke_release_rx(pkt_entry);
 		return;
 	}
 
@@ -422,7 +422,7 @@ void efa_rdm_pke_handle_longcts_rtw_recv(struct efa_rdm_pke *pkt_entry)
 		EFA_WARN(FI_LOG_CQ, "RMA address verify failed!\n");
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_EIO, FI_EFA_ERR_RMA_ADDR);
 		efa_rdm_rxe_release(rxe);
-		efa_rdm_pke_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(pkt_entry);
 		return;
 	}
 
@@ -438,14 +438,14 @@ void efa_rdm_pke_handle_longcts_rtw_recv(struct efa_rdm_pke *pkt_entry)
 			rxe->iov[0].iov_len);
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_EINVAL, FI_EFA_ERR_RTM_MISMATCH);
 		efa_rdm_rxe_release(rxe);
-		efa_rdm_pke_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(pkt_entry);
 		return;
 	} else {
 		err = efa_rdm_pke_copy_payload_to_ope(pkt_entry, rxe);
 		if (OFI_UNLIKELY(err)) {
 			efa_base_ep_write_eq_error(&ep->base_ep, FI_EINVAL, FI_EFA_ERR_RXE_COPY);
 			efa_rdm_rxe_release(rxe);
-			efa_rdm_pke_release_rx(ep, pkt_entry);
+			efa_rdm_pke_release_rx(pkt_entry);
 			return;
 		}
 	}
@@ -556,7 +556,7 @@ void efa_rdm_pke_handle_longread_rtw_recv(struct efa_rdm_pke *pkt_entry)
 		efa_base_ep_write_eq_error(&pkt_entry->ep->base_ep,
 					   FI_ENOBUFS,
 					   FI_EFA_ERR_RXE_POOL_EXHAUSTED);
-		efa_rdm_pke_release_rx(pkt_entry->ep, pkt_entry);
+		efa_rdm_pke_release_rx(pkt_entry);
 		return;
 	}
 
@@ -570,7 +570,7 @@ void efa_rdm_pke_handle_longread_rtw_recv(struct efa_rdm_pke *pkt_entry)
 		EFA_WARN(FI_LOG_CQ, "RMA address verify failed!\n");
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_EINVAL, FI_EFA_ERR_RMA_ADDR);
 		efa_rdm_rxe_release(rxe);
-		efa_rdm_pke_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(pkt_entry);
 		return;
 	}
 
@@ -586,7 +586,7 @@ void efa_rdm_pke_handle_longread_rtw_recv(struct efa_rdm_pke *pkt_entry)
 	memcpy(rxe->rma_iov, read_iov,
 	       rxe->rma_iov_count * sizeof(struct fi_rma_iov));
 
-	efa_rdm_pke_release_rx(pkt_entry->ep, pkt_entry);
+	efa_rdm_pke_release_rx(pkt_entry);
 
 	err = efa_rdm_ope_post_remote_read_or_queue(rxe);
 	if (OFI_UNLIKELY(err)) {
@@ -594,6 +594,6 @@ void efa_rdm_pke_handle_longread_rtw_recv(struct efa_rdm_pke *pkt_entry)
 			"RDMA post read or queue failed.\n");
 		efa_base_ep_write_eq_error(&ep->base_ep, err, FI_EFA_ERR_RDMA_READ_POST);
 		efa_rdm_rxe_release(rxe);
-		efa_rdm_pke_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(pkt_entry);
 	}
 }

--- a/prov/efa/src/rdm/efa_rdm_srx.c
+++ b/prov/efa/src/rdm/efa_rdm_srx.c
@@ -80,7 +80,6 @@ void efa_rdm_srx_update_rxe(struct fi_peer_rx_entry *peer_rxe,
 static int efa_rdm_srx_start(struct fi_peer_rx_entry *peer_rxe)
 {
 	int ret;
-	struct efa_rdm_ep *ep;
 	struct efa_rdm_pke *pkt_entry;
 	struct efa_rdm_ope *rxe;
 
@@ -89,7 +88,6 @@ static int efa_rdm_srx_start(struct fi_peer_rx_entry *peer_rxe)
 	pkt_entry = peer_rxe->peer_context;
 	assert(pkt_entry);
 	rxe = pkt_entry->ope;
-	ep = rxe->ep;
 	efa_rdm_srx_update_rxe(peer_rxe, rxe);
 
 	rxe->state = EFA_RDM_RXE_MATCHED;
@@ -98,7 +96,7 @@ static int efa_rdm_srx_start(struct fi_peer_rx_entry *peer_rxe)
 	if (OFI_UNLIKELY(ret)) {
 		efa_rdm_rxe_handle_error(rxe, -ret,
 			rxe->op == ofi_op_msg ? FI_EFA_ERR_PKT_PROC_MSGRTM : FI_EFA_ERR_PKT_PROC_TAGRTM);
-		efa_rdm_pke_release_rx(ep, pkt_entry);
+		efa_rdm_pke_release_rx(pkt_entry);
 		efa_rdm_rxe_release(rxe);
 	}
 
@@ -118,7 +116,6 @@ static int efa_rdm_srx_start(struct fi_peer_rx_entry *peer_rxe)
  */
 static int efa_rdm_srx_discard(struct fi_peer_rx_entry *peer_rxe)
 {
-	struct efa_rdm_ep *ep;
 	struct efa_rdm_pke *pkt_entry;
 	struct efa_rdm_ope *rxe;
 
@@ -127,11 +124,10 @@ static int efa_rdm_srx_discard(struct fi_peer_rx_entry *peer_rxe)
 	pkt_entry = peer_rxe->peer_context;
 	assert(pkt_entry);
 	rxe = pkt_entry->ope;
-	ep = rxe->ep;
 	EFA_WARN(FI_LOG_EP_CTRL,
 		"Discarding unmatched unexpected rxe: %p pkt_entry %p\n",
 		rxe, rxe->unexp_pkt);
-	efa_rdm_pke_release_rx(ep, rxe->unexp_pkt);
+	efa_rdm_pke_release_rx(rxe->unexp_pkt);
 	efa_rdm_rxe_release_internal(rxe);
 	return FI_SUCCESS;
 }

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -326,7 +326,7 @@ void test_efa_rdm_ep_pkt_pool_page_alignment(struct efa_resource **state)
 	pkt_entry = efa_rdm_pke_alloc(efa_rdm_ep, efa_rdm_ep->efa_rx_pkt_pool, EFA_RDM_PKE_FROM_EFA_RX_POOL);
 	assert_non_null(pkt_entry);
 	assert_true(((uintptr_t)ofi_buf_region(pkt_entry)->alloc_region % ofi_get_page_size()) == 0);
-	efa_rdm_pke_release_rx(efa_rdm_ep, pkt_entry);
+	efa_rdm_pke_release_rx(pkt_entry);
 
 	fi_close(&ep->fid);
 

--- a/prov/efa/test/efa_unit_test_ope.c
+++ b/prov/efa/test/efa_unit_test_ope.c
@@ -274,7 +274,7 @@ void test_efa_rdm_ope_post_write_0_byte(struct efa_resource **state)
 	assert_int_equal(err, 0);
 	assert_int_equal(g_ibv_submitted_wr_id_cnt, 1);
 
-	efa_rdm_pke_release_tx(mock_txe.ep, (struct efa_rdm_pke *)g_ibv_submitted_wr_id_vec[0]);
+	efa_rdm_pke_release_tx((struct efa_rdm_pke *)g_ibv_submitted_wr_id_vec[0]);
 	mock_txe.ep->efa_outstanding_tx_ops = 0;
 	efa_unit_test_buff_destruct(&local_buff);
 }


### PR DESCRIPTION
According to our coding convention, functions with efa_rdm_pke prefix should use a pointer to efa_rdm_pke as 1st argument. This patch ensures that.