### PR TITLE
fabtests: Add FI_CONTEXT mode to rdm_cntr_pingpong

### DIFF
--- a/fabtests/benchmarks/rdm_cntr_pingpong.c
+++ b/fabtests/benchmarks/rdm_cntr_pingpong.c
@@ -106,6 +106,7 @@ int main(int argc, char **argv)
 	hints->domain_attr->threading = FI_THREAD_DOMAIN;
 	hints->tx_attr->tclass = FI_TC_LOW_LATENCY;
 	hints->addr_format = opts.address_format;
+	hints->mode |= FI_CONTEXT;
 
 	ret = run();
 


### PR DESCRIPTION
All other benchmarks have this mode and this allows to run the test with providers requiring it.