### PR TITLE
prov/util, shm, sm2: Add FI_PEER support to util counter and make shm/sm2 use it.

### DIFF
--- a/include/ofi_enosys.h
+++ b/include/ofi_enosys.h
@@ -379,6 +379,9 @@ static struct fi_ops_cntr X = {
 int fi_no_cntr_add(struct fid_cntr *cntr, uint64_t value);
 int fi_no_cntr_set(struct fid_cntr *cntr, uint64_t value);
 int fi_no_cntr_wait(struct fid_cntr *cntr, uint64_t threshold, int timeout);
+uint64_t fi_no_cntr_readerr(struct fid_cntr *cntr);
+int fi_no_cntr_adderr(struct fid_cntr *cntr, uint64_t value);
+int fi_no_cntr_seterr(struct fid_cntr *cntr, uint64_t value);
 
 /*
 static struct fi_ops_rma X = {

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -734,6 +734,9 @@ struct util_cntr {
 
 	int			internal_wait;
 	ofi_cntr_progress_func	progress;
+
+	struct fid_peer_cntr	*peer_cntr;
+	uint64_t		flags;
 };
 
 #define OFI_TIMEOUT_QUANTUM_MS 50
@@ -758,6 +761,50 @@ static inline void ofi_cntr_inc_noop(struct util_cntr *cntr)
 static inline void ofi_cntr_inc(struct util_cntr *cntr)
 {
 	cntr->cntr_fid.ops->add(&cntr->cntr_fid, 1);
+}
+
+static inline void ofi_ep_peer_tx_cntr_inc(struct util_ep *ep, uint8_t op)
+{
+	struct util_cntr *cntr;
+	int cntr_index;
+
+	cntr_index = ofi_get_cntr_index_from_tx_op(op);
+	cntr = ep->cntrs[cntr_index];
+	if (cntr)
+		cntr->peer_cntr->owner_ops->inc(cntr->peer_cntr);
+}
+
+static inline void ofi_ep_peer_tx_cntr_incerr(struct util_ep *ep, uint8_t op)
+{
+	struct util_cntr *cntr;
+	int cntr_index;
+
+	cntr_index = ofi_get_cntr_index_from_tx_op(op);
+	cntr = ep->cntrs[cntr_index];
+	if (cntr)
+		cntr->peer_cntr->owner_ops->incerr(cntr->peer_cntr);
+}
+
+static inline void ofi_ep_peer_rx_cntr_inc(struct util_ep *ep, uint8_t op)
+{
+	struct util_cntr *cntr;
+	int cntr_index;
+
+	cntr_index = ofi_get_cntr_index_from_rx_op(op);
+	cntr = ep->cntrs[cntr_index];
+	if (cntr)
+		cntr->peer_cntr->owner_ops->inc(cntr->peer_cntr);
+}
+
+static inline void ofi_ep_peer_rx_cntr_incerr(struct util_ep *ep, uint8_t op)
+{
+	struct util_cntr *cntr;
+	int cntr_index;
+
+	cntr_index = ofi_get_cntr_index_from_rx_op(op);
+	cntr = ep->cntrs[cntr_index];
+	if (cntr)
+		cntr->peer_cntr->owner_ops->incerr(cntr->peer_cntr);
 }
 
 /*

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -381,7 +381,7 @@ static ssize_t smr_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 
 	smr_format_rma_ioc(&ce->rma_cmd, &rma_ioc, 1);
 	smr_cmd_queue_commit(ce, pos);
-	ofi_ep_tx_cntr_inc_func(&ep->util_ep, ofi_op_atomic);
+	ofi_ep_peer_tx_cntr_inc(&ep->util_ep, ofi_op_atomic);
 out:
 	smr_signal(peer_smr);
 	return ret;

--- a/prov/shm/src/smr_comp.c
+++ b/prov/shm/src/smr_comp.c
@@ -40,7 +40,7 @@
 int smr_complete_tx(struct smr_ep *ep, void *context, uint32_t op,
 		    uint64_t flags)
 {
-	ofi_ep_tx_cntr_inc_func(&ep->util_ep, op);
+	ofi_ep_peer_tx_cntr_inc(&ep->util_ep, op);
 
 	if (!(flags & FI_COMPLETION))
 		return 0;
@@ -68,7 +68,7 @@ int smr_complete_rx(struct smr_ep *ep, void *context, uint32_t op,
 		    uint64_t flags, size_t len, void *buf, int64_t id,
 		    uint64_t tag, uint64_t data)
 {
-	ofi_ep_rx_cntr_inc_func(&ep->util_ep, op);
+	ofi_ep_peer_rx_cntr_inc(&ep->util_ep, op);
 
 	if (!(flags & (FI_REMOTE_CQ_DATA | FI_COMPLETION)))
 		return 0;

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -242,7 +242,7 @@ static ssize_t smr_generic_inject(struct fid_ep *ep_fid, const void *buf,
 		goto signal;
 	}
 	smr_cmd_queue_commit(ce, pos);
-	ofi_ep_tx_cntr_inc_func(&ep->util_ep, op);
+	ofi_ep_peer_tx_cntr_inc(&ep->util_ep, op);
 
 signal:
 	smr_signal(peer_smr);

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -389,7 +389,7 @@ static ssize_t smr_generic_rma_inject(struct fid_ep *ep_fid, const void *buf,
 	smr_cmd_queue_commit(ce, pos);
 signal:
 	smr_signal(peer_smr);
-	ofi_ep_tx_cntr_inc_func(&ep->util_ep, ofi_op_write);
+	ofi_ep_peer_tx_cntr_inc(&ep->util_ep, ofi_op_write);
 	return ret;
 }
 

--- a/prov/sm2/src/sm2_atomic.c
+++ b/prov/sm2/src/sm2_atomic.c
@@ -292,7 +292,7 @@ static ssize_t sm2_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 				   NULL, 0, total_len, 0);
 
 	if (!ret)
-		ofi_ep_tx_cntr_inc_func(&ep->util_ep, ofi_op_atomic);
+		ofi_ep_peer_tx_cntr_inc(&ep->util_ep, ofi_op_atomic);
 
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;

--- a/prov/sm2/src/sm2_comp.c
+++ b/prov/sm2/src/sm2_comp.c
@@ -41,7 +41,7 @@
 int sm2_complete_tx(struct sm2_ep *ep, void *context, uint32_t op,
 		    uint64_t flags)
 {
-	ofi_ep_tx_cntr_inc_func(&ep->util_ep, op);
+	ofi_ep_peer_tx_cntr_inc(&ep->util_ep, op);
 
 	if (!(flags & FI_COMPLETION))
 		return 0;
@@ -70,7 +70,7 @@ int sm2_complete_rx(struct sm2_ep *ep, void *context, uint32_t op,
 {
 	struct sm2_av *sm2_av;
 
-	ofi_ep_rx_cntr_inc_func(&ep->util_ep, op);
+	ofi_ep_peer_rx_cntr_inc(&ep->util_ep, op);
 
 	if (!(flags & (FI_REMOTE_CQ_DATA | FI_COMPLETION)))
 		return 0;

--- a/prov/sm2/src/sm2_msg.c
+++ b/prov/sm2/src/sm2_msg.c
@@ -188,7 +188,7 @@ static ssize_t sm2_generic_inject(struct fid_ep *ep_fid, const void *buf,
 					      len, NULL);
 
 	if (!ret)
-		ofi_ep_tx_cntr_inc_func(&ep->util_ep, op);
+		ofi_ep_peer_tx_cntr_inc(&ep->util_ep, op);
 
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;

--- a/prov/util/src/util_cntr.c
+++ b/prov/util/src/util_cntr.c
@@ -42,7 +42,7 @@ static int ofi_check_cntr_attr(const struct fi_provider *prov,
 	if (!attr)
 		return FI_SUCCESS;
 
-        if (attr->flags) {
+        if (attr->flags && attr->flags != FI_PEER) {
 		FI_WARN(prov, FI_LOG_CNTR, "unsupported flags\n");
 		return -FI_EINVAL;
 	}
@@ -204,10 +204,54 @@ static struct fi_ops_cntr util_cntr_no_wait_ops = {
 	.wait = fi_no_cntr_wait,
 };
 
+static void util_peer_cntr_inc(struct fid_peer_cntr *cntr)
+{
+	struct util_cntr *util_cntr = cntr->fid.context;
+
+	util_cntr->cntr_fid.ops->add(&util_cntr->cntr_fid, 1);
+}
+
+static void util_peer_cntr_incerr(struct fid_peer_cntr *cntr)
+{
+	struct util_cntr *util_cntr = cntr->fid.context;
+
+	util_cntr->cntr_fid.ops->adderr(&util_cntr->cntr_fid, 1);
+}
+
+static struct fi_ops_cntr_owner util_peer_cntr_owner_ops = {
+	.size = sizeof(struct fi_ops_cntr_owner),
+	.inc = &util_peer_cntr_inc,
+	.incerr = &util_peer_cntr_incerr,
+};
+
+static uint64_t ofi_peer_cntr_read(struct fid_cntr *cntr_fid)
+{
+	struct util_cntr *cntr = container_of(cntr_fid, struct util_cntr, cntr_fid);
+
+	assert(cntr->cntr_fid.fid.fclass == FI_CLASS_CNTR);
+	cntr->progress(cntr);
+
+	return 0;
+}
+
+static struct fi_ops_cntr util_peer_cntr_ops = {
+	.size = sizeof(struct fi_ops_cntr),
+	.read = ofi_peer_cntr_read,
+	.readerr = fi_no_cntr_readerr,
+	.add = fi_no_cntr_add,
+	.adderr = fi_no_cntr_adderr,
+	.set = fi_no_cntr_set,
+	.seterr = fi_no_cntr_seterr,
+	.wait = fi_no_cntr_wait,
+};
+
 int ofi_cntr_cleanup(struct util_cntr *cntr)
 {
 	if (ofi_atomic_get32(&cntr->ref))
 		return -FI_EBUSY;
+
+	if (!(cntr->flags & FI_PEER))
+		fi_close(&cntr->peer_cntr->fid);
 
 	if (cntr->wait) {
 		fi_poll_del(&cntr->wait->pollset->poll_fid,
@@ -257,6 +301,34 @@ static struct fi_ops util_cntr_fi_ops = {
 	.ops_open = fi_no_ops_open,
 };
 
+static int util_peer_cntr_close(struct fid *fid)
+{
+       free(container_of(fid, struct fid_peer_cntr, fid));
+       return 0;
+}
+
+static struct fi_ops util_peer_cntr_fi_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = util_peer_cntr_close,
+	.bind = fi_no_bind,
+	.control = fi_no_control,
+	.ops_open = fi_no_ops_open,
+};
+
+static int util_init_peer_cntr(struct util_cntr *cntr)
+{
+	cntr->peer_cntr = calloc(1, sizeof(*cntr->peer_cntr));
+	if (!cntr->peer_cntr)
+		return -FI_ENOMEM;
+
+	cntr->peer_cntr->owner_ops = &util_peer_cntr_owner_ops;
+	cntr->peer_cntr->fid.fclass = FI_CLASS_PEER_CNTR;
+	cntr->peer_cntr->fid.context = cntr;
+	cntr->peer_cntr->fid.ops = &util_peer_cntr_fi_ops;
+
+	return FI_SUCCESS;
+}
+
 int ofi_cntr_init(const struct fi_provider *prov, struct fid_domain *domain,
 		  struct fi_cntr_attr *attr, struct util_cntr *cntr,
 		  ofi_cntr_progress_func progress, void *context)
@@ -277,6 +349,7 @@ int ofi_cntr_init(const struct fi_provider *prov, struct fid_domain *domain,
 	ofi_atomic_initialize64(&cntr->err, 0);
 	dlist_init(&cntr->ep_list);
 
+	cntr->flags = attr->flags;
 	cntr->cntr_fid.fid.fclass = FI_CLASS_CNTR;
 	cntr->cntr_fid.fid.context = context;
 	cntr->cntr_fid.fid.ops = &util_cntr_fi_ops;
@@ -308,6 +381,15 @@ int ofi_cntr_init(const struct fi_provider *prov, struct fid_domain *domain,
 		return -FI_EINVAL;
 	}
 
+	if (attr->flags & FI_PEER) {
+		cntr->peer_cntr = ((struct fi_peer_cntr_context *) context)->cntr;
+		cntr->cntr_fid.ops = &util_peer_cntr_ops;
+	} else {
+		ret = util_init_peer_cntr(cntr);
+		if (ret)
+			return ret;
+	}
+
 	ofi_mutex_init(&cntr->ep_list_lock);
 	ofi_atomic_inc32(&cntr->domain->ref);
 
@@ -324,4 +406,3 @@ int ofi_cntr_init(const struct fi_provider *prov, struct fid_domain *domain,
 
 	return 0;
 }
-

--- a/src/enosys.c
+++ b/src/enosys.c
@@ -504,6 +504,18 @@ int fi_no_cntr_wait(struct fid_cntr *cntr, uint64_t threshold, int timeout)
 {
 	return -FI_ENOSYS;
 }
+uint64_t fi_no_cntr_readerr(struct fid_cntr *cntr)
+{
+	return 0;
+}
+int fi_no_cntr_adderr(struct fid_cntr *cntr, uint64_t value)
+{
+	return -FI_ENOSYS;
+}
+int fi_no_cntr_seterr(struct fid_cntr *cntr, uint64_t value)
+{
+	return -FI_ENOSYS;
+}
 
 /*
  * struct fi_ops_rma


### PR DESCRIPTION
This PR contains a series of commits to add FI_PEER support to util counter and make shm/sm2 use it.

Still working on adding fabtests in fabtests/pytest for the cntr for shm and sm2, will push more commits later.