### PR TITLE
fabtests/pytest: Two changes on the "completion_type" parameter

### DIFF
--- a/fabtests/pytest/common.py
+++ b/fabtests/pytest/common.py
@@ -286,7 +286,7 @@ class ClientServerTest:
 
     def __init__(self, cmdline_args, executable,
                  iteration_type=None,
-                 completion_type="transmit_complete",
+                 completion_semantic="transmit_complete",
                  prefix_type="wout_prefix",
                  datacheck_type="wout_datacheck",
                  message_size=None,
@@ -297,11 +297,11 @@ class ClientServerTest:
         self._cmdline_args = cmdline_args
         self._timeout = timeout or cmdline_args.timeout
         self._server_base_command, server_additonal_environment = self.prepare_base_command("server", executable, iteration_type,
-                                                              completion_type, prefix_type,
+                                                              completion_semantic, prefix_type,
                                                               datacheck_type, message_size,
                                                               memory_type, warmup_iteration_type)
         self._client_base_command, client_additonal_environment = self.prepare_base_command("client", executable, iteration_type,
-                                                              completion_type, prefix_type,
+                                                              completion_semantic, prefix_type,
                                                               datacheck_type, message_size,
                                                               memory_type, warmup_iteration_type)
 
@@ -311,7 +311,7 @@ class ClientServerTest:
 
     def prepare_base_command(self, command_type, executable,
                              iteration_type=None,
-                             completion_type="transmit_complete",
+                             completion_semantic="transmit_complete",
                              prefix_type="wout_prefix",
                              datacheck_type="wout_datacheck",
                              message_size=None,
@@ -346,10 +346,10 @@ class ClientServerTest:
         if warmup_iteration_type:
             command += " -w " + str(warmup_iteration_type)
 
-        if completion_type == "delivery_complete":
+        if completion_semantic == "delivery_complete":
             command += " -U"
         else:
-            assert completion_type == "transmit_complete"
+            assert completion_semantic == "transmit_complete"
 
         if datacheck_type == "with_datacheck":
             command += " -v"

--- a/fabtests/pytest/common.py
+++ b/fabtests/pytest/common.py
@@ -292,18 +292,21 @@ class ClientServerTest:
                  message_size=None,
                  memory_type="host_to_host",
                  timeout=None,
-                 warmup_iteration_type=None):
+                 warmup_iteration_type=None,
+                 completion_type="queue"):
 
         self._cmdline_args = cmdline_args
         self._timeout = timeout or cmdline_args.timeout
         self._server_base_command, server_additonal_environment = self.prepare_base_command("server", executable, iteration_type,
                                                               completion_semantic, prefix_type,
                                                               datacheck_type, message_size,
-                                                              memory_type, warmup_iteration_type)
+                                                              memory_type, warmup_iteration_type,
+                                                              completion_type)
         self._client_base_command, client_additonal_environment = self.prepare_base_command("client", executable, iteration_type,
                                                               completion_semantic, prefix_type,
                                                               datacheck_type, message_size,
-                                                              memory_type, warmup_iteration_type)
+                                                              memory_type, warmup_iteration_type,
+                                                              completion_type)
 
 
         self._server_command = self._cmdline_args.populate_command(self._server_base_command, "server", self._timeout, server_additonal_environment)
@@ -316,7 +319,8 @@ class ClientServerTest:
                              datacheck_type="wout_datacheck",
                              message_size=None,
                              memory_type="host_to_host",
-                             warmup_iteration_type=None):
+                             warmup_iteration_type=None,
+                             completion_type="queue"):
         if executable == "fi_ubertest":
             return "fi_ubertest", None
 
@@ -350,6 +354,15 @@ class ClientServerTest:
             command += " -U"
         else:
             assert completion_semantic == "transmit_complete"
+
+        # Most fabtests actually run as -t queue by default.
+        # However, not all fabtests binaries support -t option.
+        # Therefore, only add this option for tests
+        # that requests counter type explicitly.
+        if completion_type == "counter":
+            command += " -t counter"
+        else:
+            assert completion_type == "queue"
 
         if datacheck_type == "with_datacheck":
             command += " -v"

--- a/fabtests/pytest/conftest.py
+++ b/fabtests/pytest/conftest.py
@@ -224,7 +224,7 @@ def server_address(cmdline_args, good_address):
     return cmdline_args.server_id
 
 @pytest.fixture(scope="module", params=["transmit_complete", "delivery_complete"])
-def completion_type(request):
+def completion_semantic(request):
     return request.param
 
 @pytest.fixture(scope="module", params=["with_prefix", "wout_prefix"])

--- a/fabtests/pytest/default/test_rdm.py
+++ b/fabtests/pytest/default/test_rdm.py
@@ -7,9 +7,9 @@ def test_rdm_g00n13s(cmdline_args):
     test.run()
 
 @pytest.mark.functional
-def test_rdm(cmdline_args, completion_type):
+def test_rdm(cmdline_args, completion_semantic):
     from common import ClientServerTest
-    test = ClientServerTest(cmdline_args, "fi_rdm", completion_type=completion_type)
+    test = ClientServerTest(cmdline_args, "fi_rdm", completion_semantic=completion_semantic)
     test.run()
 
 @pytest.mark.functional
@@ -37,17 +37,17 @@ def test_rdm_shared_av(cmdline_args):
     test.run()
 
 @pytest.mark.functional
-def test_rdm_bw_functional(cmdline_args, completion_type):
+def test_rdm_bw_functional(cmdline_args, completion_semantic):
     from common import ClientServerTest
-    test = ClientServerTest(cmdline_args, "fi_bw -e rdm -v -T 1", completion_type=completion_type)
+    test = ClientServerTest(cmdline_args, "fi_bw -e rdm -v -T 1", completion_semantic=completion_semantic)
     test.run()
 
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rdm_atomic(cmdline_args, iteration_type, completion_type):
+def test_rdm_atomic(cmdline_args, iteration_type, completion_semantic):
     from common import ClientServerTest
-    test = ClientServerTest(cmdline_args, "fi_rdm_atomic", iteration_type, completion_type)
+    test = ClientServerTest(cmdline_args, "fi_rdm_atomic", iteration_type, completion_semantic)
     test.run()
 
 @pytest.mark.parametrize("iteration_type",
@@ -62,29 +62,29 @@ def test_rdm_cntr_pingpong(cmdline_args, iteration_type):
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
 def test_rdm_pingpong(cmdline_args, iteration_type,
-                      prefix_type, datacheck_type, completion_type):
+                      prefix_type, datacheck_type, completion_semantic):
     from common import ClientServerTest
     test = ClientServerTest(cmdline_args, "fi_rdm_pingpong", iteration_type,
-                            completion_type, prefix_type, datacheck_type)
+                            completion_semantic, prefix_type, datacheck_type)
     test.run()
 
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
 def test_rdm_tagged_pingpong(cmdline_args, iteration_type,
-                             datacheck_type, completion_type):
+                             datacheck_type, completion_semantic):
     from common import ClientServerTest
     test = ClientServerTest(cmdline_args, "fi_rdm_tagged_pingpong", iteration_type,
-                            completion_type, datacheck_type=datacheck_type)
+                            completion_semantic, datacheck_type=datacheck_type)
     test.run()
 
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rdm_tagged_bw(cmdline_args, iteration_type, datacheck_type, completion_type):
+def test_rdm_tagged_bw(cmdline_args, iteration_type, datacheck_type, completion_semantic):
     from common import ClientServerTest
     test = ClientServerTest(cmdline_args, "fi_rdm_tagged_bw", iteration_type,
-                            completion_type, datacheck_type=datacheck_type)
+                            completion_semantic, datacheck_type=datacheck_type)
     test.run()
 
 

--- a/fabtests/pytest/default/test_rma_bw.py
+++ b/fabtests/pytest/default/test_rma_bw.py
@@ -5,13 +5,13 @@ import pytest
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rma_bw(cmdline_args, iteration_type, endpoint_type, operation_type, completion_type):
+def test_rma_bw(cmdline_args, iteration_type, endpoint_type, operation_type, completion_semantic):
     from common import ClientServerTest
 
     command = "fi_rma_bw"
     command = command + " -e " + endpoint_type
     command = command + " -o " + operation_type
     test = ClientServerTest(cmdline_args, command, iteration_type,
-                            completion_type=completion_type)
+                            completion_semantic=completion_semantic)
     test.run()
 

--- a/fabtests/pytest/efa/efa_common.py
+++ b/fabtests/pytest/efa/efa_common.py
@@ -4,7 +4,7 @@ from common import SshConnectionError, is_ssh_connection_error, has_ssh_connecti
 from retrying import retry
 
 def efa_run_client_server_test(cmdline_args, executable, iteration_type,
-                               completion_type, memory_type, message_size,
+                               completion_semantic, memory_type, message_size,
                                warmup_iteration_type=None, timeout=None):
     if timeout is None:
         timeout = cmdline_args.timeout
@@ -15,7 +15,7 @@ def efa_run_client_server_test(cmdline_args, executable, iteration_type,
         timeout = max(1000, timeout)
 
     test = ClientServerTest(cmdline_args, executable, iteration_type,
-                            completion_type=completion_type,
+                            completion_semantic=completion_semantic,
                             datacheck_type="with_datacheck",
                             message_size=message_size,
                             memory_type=memory_type,

--- a/fabtests/pytest/efa/test_efa_protocol_selection.py
+++ b/fabtests/pytest/efa/test_efa_protocol_selection.py
@@ -43,7 +43,7 @@ def test_transfer_with_read_protocol_cuda(cmdline_args, fabtest_name, cntrl_env_
     efa_run_client_server_test(cmdline_args_copy,
                                fabtest_name,
                                iteration_type="1",
-                               completion_type="transmit_complete",
+                               completion_semantic="transmit_complete",
                                memory_type="cuda_to_cuda",
                                message_size=message_size,
                                warmup_iteration_type="0")

--- a/fabtests/pytest/efa/test_fork_support.py
+++ b/fabtests/pytest/efa/test_fork_support.py
@@ -3,14 +3,14 @@ import pytest
 
 @pytest.mark.functional
 @pytest.mark.parametrize("environment_variable", ["FI_EFA_FORK_SAFE", "RDMAV_FORK_SAFE"])
-def test_fork_support(cmdline_args, completion_type, environment_variable):
+def test_fork_support(cmdline_args, completion_semantic, environment_variable):
     from common import ClientServerTest
     import copy
     cmdline_args_copy = copy.copy(cmdline_args)
 
     cmdline_args_copy.append_environ("{}=1".format(environment_variable))
     test = ClientServerTest(cmdline_args_copy, "fi_rdm_tagged_bw -K",
-                            completion_type=completion_type,
+                            completion_semantic=completion_semantic,
                             datacheck_type="with_datacheck")
     test.run()
 

--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -77,4 +77,4 @@ def test_rdm_with_cntr(cmdline_args):
         pytest.skip("This test requires 2 nodes")
         return
 
-    test = ClientServerTest(cmdline_args, "fi_rdm_pingpong -t counter", timeout=1800)
+    test = ClientServerTest(cmdline_args, "fi_rdm_pingpong", timeout=1800, completion_type="counter")

--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -7,43 +7,43 @@ import pytest
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rdm_pingpong(cmdline_args, iteration_type, completion_type, memory_type):
+def test_rdm_pingpong(cmdline_args, iteration_type, completion_semantic, memory_type):
     efa_run_client_server_test(cmdline_args, "fi_rdm_pingpong", iteration_type,
-                               completion_type, memory_type, "all")
+                               completion_semantic, memory_type, "all")
 
 @pytest.mark.functional
-def test_rdm_pingpong_range(cmdline_args, completion_type, memory_type, message_size):
+def test_rdm_pingpong_range(cmdline_args, completion_semantic, memory_type, message_size):
     efa_run_client_server_test(cmdline_args, "fi_rdm_pingpong", "short",
-                               completion_type, memory_type, message_size)
+                               completion_semantic, memory_type, message_size)
 
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rdm_tagged_pingpong(cmdline_args, iteration_type, completion_type, memory_type):
+def test_rdm_tagged_pingpong(cmdline_args, iteration_type, completion_semantic, memory_type):
     efa_run_client_server_test(cmdline_args, "fi_rdm_tagged_pingpong", iteration_type,
-                               completion_type, memory_type, "all")
+                               completion_semantic, memory_type, "all")
 
 @pytest.mark.functional
-def test_rdm_tagged_pingpong_range(cmdline_args, completion_type, memory_type, message_size):
+def test_rdm_tagged_pingpong_range(cmdline_args, completion_semantic, memory_type, message_size):
     efa_run_client_server_test(cmdline_args, "fi_rdm_tagged_pingpong", "short",
-                               completion_type, memory_type, message_size)
+                               completion_semantic, memory_type, message_size)
 
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rdm_tagged_bw(cmdline_args, iteration_type, completion_type, memory_type):
+def test_rdm_tagged_bw(cmdline_args, iteration_type, completion_semantic, memory_type):
     efa_run_client_server_test(cmdline_args, "fi_rdm_tagged_bw", iteration_type,
-                               completion_type, memory_type, "all")
+                               completion_semantic, memory_type, "all")
 
 @pytest.mark.functional
-def test_rdm_tagged_bw_range(cmdline_args, completion_type, memory_type, message_size):
+def test_rdm_tagged_bw_range(cmdline_args, completion_semantic, memory_type, message_size):
     efa_run_client_server_test(cmdline_args, "fi_rdm_tagged_bw", "short",
-                               completion_type, memory_type, message_size)
+                               completion_semantic, memory_type, message_size)
 
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rdm_atomic(cmdline_args, iteration_type, completion_type, memory_type):
+def test_rdm_atomic(cmdline_args, iteration_type, completion_semantic, memory_type):
     from copy import copy
 
     from common import ClientServerTest
@@ -55,7 +55,7 @@ def test_rdm_atomic(cmdline_args, iteration_type, completion_type, memory_type):
     # the issue is tracked in:  https://github.com/ofiwg/libfabric/issues/7002
     # to mitigate the issue, set the maximum timeout of fi_rdm_atomic to 1800 seconds.
     cmdline_args_copy = copy(cmdline_args)
-    test = ClientServerTest(cmdline_args_copy, "fi_rdm_atomic", iteration_type, completion_type,
+    test = ClientServerTest(cmdline_args_copy, "fi_rdm_atomic", iteration_type, completion_semantic,
                             memory_type=memory_type, timeout=1800)
     test.run()
 

--- a/fabtests/pytest/efa/test_rma_bw.py
+++ b/fabtests/pytest/efa/test_rma_bw.py
@@ -4,20 +4,20 @@ import pytest
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rma_bw(cmdline_args, iteration_type, operation_type, completion_type, memory_type):
+def test_rma_bw(cmdline_args, iteration_type, operation_type, completion_semantic, memory_type):
     from efa.efa_common import efa_run_client_server_test
     command = "fi_rma_bw -e rdm"
     command = command + " -o " + operation_type
     # rma_bw test with data verification takes longer to finish
     timeout = max(540, cmdline_args.timeout)
-    efa_run_client_server_test(cmdline_args, command, iteration_type, completion_type, memory_type, "all", timeout=timeout)
+    efa_run_client_server_test(cmdline_args, command, iteration_type, completion_semantic, memory_type, "all", timeout=timeout)
 
 @pytest.mark.functional
 @pytest.mark.parametrize("operation_type", ["read", "writedata", "write"])
-def test_rma_bw_range(cmdline_args, operation_type, completion_type, message_size, memory_type):
+def test_rma_bw_range(cmdline_args, operation_type, completion_semantic, message_size, memory_type):
     from efa.efa_common import efa_run_client_server_test
     command = "fi_rma_bw -e rdm"
     command = command + " -o " + operation_type
     # rma_bw test with data verification takes longer to finish
     timeout = max(540, cmdline_args.timeout)
-    efa_run_client_server_test(cmdline_args, command, "short", completion_type, memory_type, message_size, timeout=timeout)
+    efa_run_client_server_test(cmdline_args, command, "short", completion_semantic, memory_type, message_size, timeout=timeout)

--- a/fabtests/pytest/efa/test_runt.py
+++ b/fabtests/pytest/efa/test_runt.py
@@ -42,7 +42,7 @@ def test_runt_read_functional(cmdline_args, memory_type, copy_method):
     efa_run_client_server_test(cmdline_args,
                                "fi_rdm_tagged_bw",
                                iteration_type="1",
-                               completion_type="transmit_complete",
+                               completion_semantic="transmit_complete",
                                memory_type=memory_type,
                                message_size="262144",
                                warmup_iteration_type="0")

--- a/fabtests/pytest/shm/shm_common.py
+++ b/fabtests/pytest/shm/shm_common.py
@@ -1,10 +1,10 @@
 def shm_run_client_server_test(cmdline_args, executable, iteration_type,
-                               completion_type, memory_type,
+                               completion_semantic, memory_type,
                                warmup_iteration_type=None):
     from common import ClientServerTest
 
     test = ClientServerTest(cmdline_args, executable, iteration_type,
-                            completion_type=completion_type,
+                            completion_semantic=completion_semantic,
                             datacheck_type="with_datacheck",
                             memory_type=memory_type,
                             warmup_iteration_type=warmup_iteration_type)

--- a/fabtests/pytest/shm/test_rdm.py
+++ b/fabtests/pytest/shm/test_rdm.py
@@ -6,25 +6,25 @@ from shm.shm_common import shm_run_client_server_test
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rdm_pingpong(cmdline_args, iteration_type, completion_type, memory_type):
+def test_rdm_pingpong(cmdline_args, iteration_type, completion_semantic, memory_type):
     shm_run_client_server_test(cmdline_args, "fi_rdm_pingpong", iteration_type,
-                               completion_type, memory_type)
+                               completion_semantic, memory_type)
 
 
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rdm_tagged_pingpong(cmdline_args, iteration_type, completion_type, memory_type):
+def test_rdm_tagged_pingpong(cmdline_args, iteration_type, completion_semantic, memory_type):
     shm_run_client_server_test(cmdline_args, "fi_rdm_tagged_pingpong", iteration_type,
-                               completion_type, memory_type)
+                               completion_semantic, memory_type)
 
 
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rdm_tagged_bw(cmdline_args, iteration_type, completion_type, memory_type):
+def test_rdm_tagged_bw(cmdline_args, iteration_type, completion_semantic, memory_type):
     shm_run_client_server_test(cmdline_args, "fi_rdm_tagged_bw", iteration_type,
-                               completion_type, memory_type)
+                               completion_semantic, memory_type)
 
 @pytest.mark.functional
 def test_rdm_tagged_peek(cmdline_args):

--- a/fabtests/pytest/shm/test_rma_bw.py
+++ b/fabtests/pytest/shm/test_rma_bw.py
@@ -6,7 +6,7 @@ from shm.shm_common import shm_run_client_server_test
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rma_bw(cmdline_args, iteration_type, operation_type, completion_type, memory_type):
+def test_rma_bw(cmdline_args, iteration_type, operation_type, completion_semantic, memory_type):
     command = "fi_rma_bw -e rdm"
     command = command + " -o " + operation_type
-    shm_run_client_server_test(cmdline_args, command, iteration_type, completion_type, memory_type)
+    shm_run_client_server_test(cmdline_args, command, iteration_type, completion_semantic, memory_type)

--- a/fabtests/pytest/sm2/sm2_common.py
+++ b/fabtests/pytest/sm2/sm2_common.py
@@ -1,10 +1,10 @@
 def sm2_run_client_server_test(cmdline_args, executable, iteration_type,
-                               completion_type, memory_type,
+                               completion_semantic, memory_type,
                                warmup_iteration_type=None):
     from common import ClientServerTest
 
     test = ClientServerTest(cmdline_args, executable, iteration_type,
-                            completion_type=completion_type,
+                            completion_semantic=completion_semantic,
                             datacheck_type="with_datacheck",
                             memory_type=memory_type,
                             warmup_iteration_type=warmup_iteration_type)

--- a/fabtests/pytest/sm2/test_rdm.py
+++ b/fabtests/pytest/sm2/test_rdm.py
@@ -5,22 +5,22 @@ from sm2.sm2_common import sm2_run_client_server_test
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rdm_pingpong(cmdline_args, iteration_type, completion_type, memory_type):
+def test_rdm_pingpong(cmdline_args, iteration_type, completion_semantic, memory_type):
     sm2_run_client_server_test(cmdline_args, "fi_rdm_pingpong", iteration_type,
-                               completion_type, memory_type)
+                               completion_semantic, memory_type)
 
 
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rdm_tagged_pingpong(cmdline_args, iteration_type, completion_type, memory_type):
+def test_rdm_tagged_pingpong(cmdline_args, iteration_type, completion_semantic, memory_type):
     sm2_run_client_server_test(cmdline_args, "fi_rdm_tagged_pingpong", iteration_type,
-                               completion_type, memory_type)
+                               completion_semantic, memory_type)
 
 
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rdm_tagged_bw(cmdline_args, iteration_type, completion_type, memory_type):
+def test_rdm_tagged_bw(cmdline_args, iteration_type, completion_semantic, memory_type):
     sm2_run_client_server_test(cmdline_args, "fi_rdm_tagged_bw", iteration_type,
-                               completion_type, memory_type)
+                               completion_semantic, memory_type)


### PR DESCRIPTION
This PR renames the original `completion_type` to `complete_semantic` to better reflect its meaning. Also introduce a new `completion_type` parameter to stand for the `queue` and `counter` completion types.