### PR TITLE
prov/sm2: Fix return_xfer_entry bug

### DIFF
--- a/prov/sm2/src/sm2_progress.c
+++ b/prov/sm2/src/sm2_progress.c
@@ -109,10 +109,10 @@ static int sm2_start_common(struct sm2_ep *ep,
 	if (ret) {
 		FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,
 			"Unable to process rx completion\n");
-	} else if (return_xfer_entry) {
-		/* Return Free Queue Entries here */
-		sm2_fifo_write_back(ep, xfer_entry);
 	}
+
+	if (return_xfer_entry)
+		sm2_fifo_write_back(ep, xfer_entry);
 
 	sm2_get_peer_srx(ep)->owner_ops->free_entry(rx_entry);
 


### PR DESCRIPTION
We need to return the xfer_entry irrespective of the completion status