### PR TITLE
prov/sm2: Change SM2 protocol to FI_PROTO_SM2

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -343,6 +343,7 @@ enum {
 	FI_PROTO_XNET,
 	FI_PROTO_COLL,
 	FI_PROTO_UCX,
+	FI_PROTO_SM2,
 };
 
 enum {

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -741,6 +741,14 @@ protocol value set to one.
   remote peer that is using Berkeley *SOCK_DGRAM* sockets using
   *IPPROTO_UDP*.
 
+*FI_PROTO_SHM*
+: Protocol for intra-node communication using shared memory segments
+  used by the shm provider
+
+*FI_PROTO_SM2*
+: Protocol for intra-node communication using shared memory segments
+  used by the sm2 provider
+
 *FI_PROTO_UNSPEC*
 : The protocol is not specified.  This is usually provided as input,
   with other attributes of the socket or the provider selecting the

--- a/prov/sm2/src/sm2_attr.c
+++ b/prov/sm2/src/sm2_attr.c
@@ -88,7 +88,7 @@ struct fi_rx_attr sm2_hmem_rx_attr = {
 
 struct fi_ep_attr sm2_ep_attr = {
 	.type = FI_EP_RDM,
-	.protocol = FI_PROTO_SHM,
+	.protocol = FI_PROTO_SM2,
 	.protocol_version = 1,
 	.max_msg_size = SM2_INJECT_SIZE,
 	.max_order_raw_size = SM2_INJECT_SIZE,

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -278,6 +278,7 @@ static void ofi_tostr_protocol(char *buf, size_t len, uint32_t protocol)
 	CASEENUMSTRN(FI_PROTO_OPX, len);
 	CASEENUMSTRN(FI_PROTO_CXI, len);
 	CASEENUMSTRN(FI_PROTO_XNET, len);
+	CASEENUMSTRN(FI_PROTO_SM2, len);
 	default:
 		if (protocol & FI_PROV_SPECIFIC)
 			ofi_strncatf(buf, len, "Provider specific");


### PR DESCRIPTION
Libfabric documentation states that endpoints with the same protocol must interoperate. SHM and SM2 cannot interoperate, so SM2 needs a new protocol