### PR TITLE
contrib/intel/jenkins: Split daos into build and test executors

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -9,8 +9,11 @@ def RELEASE=0
 @Field def MPI_TYPES=["impi", "mpich", "ompi"]
 def PYTHON_VERSION="3.9"
 
-def run_python(version, command) {
-  sh "python$version $command"
+def run_python(version, command, output=null) {
+  if (output != null)
+    sh "python$version $command >> $output"
+  else
+    sh "python$version $command"
 }
 
 def slurm_batch(partition, node_num, output, command) {
@@ -207,7 +210,7 @@ pipeline {
         stage ('build-daos') {
           agent {
             node {
-              label 'daos'
+              label 'daos_head'
               customWorkspace "${CB_HOME}/workspace/${JOB_NAME}/${env.BUILD_NUMBER}"
             }
           }
@@ -223,15 +226,19 @@ pipeline {
                   fi
 
                   git clone --branch ${TARGET} ${env.UPSTREAM} ${env.WORKSPACE}/py_scripts
-
-                  echo "Copy log dirs."
-                  python3.7 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=logdir
-                  echo "Copy log dirs completed."
-                  echo "-----------------------------------------------------"
-                  python3.7 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=libfabric --build_cluster='daos'
-                  python3.7 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=fabtests
                 )
               """
+            }
+            script {
+              run_python(PYTHON_VERSION,
+                  """${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py \
+                  --build_item=logdir""")
+              run_python(PYTHON_VERSION,
+                  """${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py \
+                  --build_item=libfabric --build_cluster='daos'""")
+              run_python(PYTHON_VERSION,
+                  """${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py \
+                  --build_item=fabtests""")
             }
           }
         }
@@ -448,46 +455,28 @@ pipeline {
           }
         }
         stage('daos_tcp') {
-          agent {
-            node {
-              label 'daos'
-              customWorkspace "${CB_HOME}/workspace/${JOB_NAME}/${env.BUILD_NUMBER}"
-            }
-          }
+          agent { node { label 'daos_tcp' } }
           options { skipDefaultCheckout() }
           steps {
-            withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
-              sh """
-                env
-                (
-                  echo `hostname`
-                  cd ${env.WORKSPACE}/${SCRIPT_LOCATION}/
-                  python3.7 runtests.py --prov='tcp' --util='rxm' --test=daos
-                  echo "daos-tcp test completed."
-                )
-              """
+            script {
+              dir ("${env.WORKSPACE}/${SCRIPT_LOCATION}/") {
+                run_python(PYTHON_VERSION,
+                           "runtests.py --prov='tcp' --util='rxm' --test=daos",
+                           "${env.LOG_DIR}/daos_tcp-rxm_reg")
+              }
             }
           }
         }
-        stage('daos_verbs') {
-          agent {
-            node {
-              label 'daos'
-              customWorkspace "${CB_HOME}/workspace/${JOB_NAME}/${env.BUILD_NUMBER}"
-            }
-          }
+         stage('daos_verbs') {
+          agent { node { label 'daos_verbs' } }
           options { skipDefaultCheckout() }
           steps {
-            withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
-              sh """
-                env
-                (
-                  echo `hostname` 
-                  cd ${env.WORKSPACE}/${SCRIPT_LOCATION}/
-                  python3.7 runtests.py --prov='verbs' --util='rxm' --test=daos
-                  echo "daos-verbs test completed."
-                )
-              """
+            script {
+              dir ("${env.WORKSPACE}/${SCRIPT_LOCATION}/") {
+                run_python(PYTHON_VERSION,
+                           "runtests.py --prov='verbs' --util='rxm' --test=daos",
+                           "${env.LOG_DIR}/daos_verbs-rxm_reg")
+              }
             }
           }
         }
@@ -574,7 +563,7 @@ pipeline {
       }
     }
     stage ('Summary-daos') {
-      agent {node {label 'daos'}}
+      agent {node {label 'daos_head'}}
       when { equals expected: 1, actual: DO_RUN }
       steps {
         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
@@ -596,7 +585,7 @@ pipeline {
       }
     }
     success {
-      node ('daos') {
+      node ('daos_head') {
         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
             sh """
               if [[ ${DO_RUN} -eq 1 ]]; then
@@ -615,7 +604,7 @@ pipeline {
       }
     }
     cleanup {
-      node ('daos') {
+      node ('daos_head') {
         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
           dir ("${env.JOB_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}") {
             deleteDir()

--- a/contrib/intel/jenkins/runtests.py
+++ b/contrib/intel/jenkins/runtests.py
@@ -66,6 +66,7 @@ if 'slurm' in os.environ['FABRIC']:
     if int(os.environ['SLURM_NNODES']) == 1:
         hosts.append(slurm_nodes)
     else:
+        prefix = slurm_nodes[0:slurm_nodes.find('[')]
         nodes = slurm_nodes[slurm_nodes.find('[') + 1 :
                             slurm_nodes.find(']')].split(',') # ['1-4', '11']
         for item in nodes: # ['1-4', '11'] -> ['cb1', 'cb2', 'cb3', 'cb4', 'cb11']
@@ -73,9 +74,9 @@ if 'slurm' in os.environ['FABRIC']:
                 rng = item.split('-')
                 node_list = list(range(int(rng[0]), int(rng[1]) + 1))
                 for node in node_list:
-                    hosts.append(f'cb{node}')
+                    hosts.append(f'{prefix}{node}')
             else:
-                hosts.append(f'cb{item}')
+                hosts.append(f'{prefix}{item}')
 else:
     node = (os.environ['NODE_NAME']).split('_')[0]
     hosts = [node]

--- a/contrib/intel/jenkins/summary.py
+++ b/contrib/intel/jenkins/summary.py
@@ -659,10 +659,10 @@ def summarize_items(summary_item, logger, log_dir, mode):
 
     if ((summary_item == 'daos' or summary_item == 'all')
          and mode == 'reg'):
-        for prov in ['tcp', 'verbs']:
+        for prov in ['tcp-rxm', 'verbs-rxm']:
             ret = DaosSummarizer(
                 logger, log_dir, prov,
-                f'daos_{prov}_daos_{mode}',
+                f'daos_{prov}_{mode}',
                 f"{prov} daos {mode}"
             ).summarize()
             err += ret if ret else 0


### PR DESCRIPTION
Adding daos as multiple different agents will allow concurrent building and parallel running of daos smoke tests. This will allow build, summary, and cleanup to happen while tests are running in a different job.