### PR TITLE
fabtests/efa: Add new test cases to unexpected message test

### DIFF
--- a/fabtests/pytest/efa/test_unexpected_msg.py
+++ b/fabtests/pytest/efa/test_unexpected_msg.py
@@ -1,7 +1,19 @@
 import pytest
+from efa.efa_common import efa_run_client_server_test
 
+@pytest.mark.parametrize("iteration_type",
+                         [pytest.param("short", marks=pytest.mark.short),
+                          pytest.param("standard", marks=pytest.mark.standard)])
 @pytest.mark.functional
-def test_unexpected_msg(cmdline_args):
-    from common import ClientServerTest
-    test = ClientServerTest(cmdline_args, "fi_unexpected_msg -e rdm -I 10")
-    test.run()
+def test_unexpected_msg(cmdline_args, iteration_type, completion_semantic, memory_type, message_size):
+    if completion_semantic == "delivery_complete":
+        pytest.skip("Unexpected message test does not support delivery_complete completion semantic")
+
+    # SHM provider currently supports 1 in flight message for host<->device transfers
+    if memory_type in ["cuda_to_host", "host_to_cuda"]:
+        inflight_msgs = 1
+    else:
+        inflight_msgs = 4
+
+    efa_run_client_server_test(cmdline_args, f"fi_unexpected_msg -M {inflight_msgs}", iteration_type,
+                               completion_semantic, memory_type, message_size)


### PR DESCRIPTION
Added a dependency on the message_size and memory_type fixtures
    
We use different protocols for different message sizes, so it's good to test the unexpected path for all message sizes
    
Also good to test unexpected path with HMEM buffers