### PR TITLE
prov/util,efa,tcp,mrail,rxd,rxm,ucx: Refactor the usage of cntrs

### DIFF
--- a/fabtests/pytest/conftest.py
+++ b/fabtests/pytest/conftest.py
@@ -227,6 +227,10 @@ def server_address(cmdline_args, good_address):
 def completion_semantic(request):
     return request.param
 
+@pytest.fixture(scope="module", params=["queue", "counter"])
+def completion_type(request):
+    return request.param
+
 @pytest.fixture(scope="module", params=["with_prefix", "wout_prefix"])
 def prefix_type(request):
     return request.param

--- a/fabtests/pytest/shm/shm_common.py
+++ b/fabtests/pytest/shm/shm_common.py
@@ -1,11 +1,13 @@
 def shm_run_client_server_test(cmdline_args, executable, iteration_type,
                                completion_semantic, memory_type,
-                               warmup_iteration_type=None):
+                               warmup_iteration_type=None,
+                               completion_type="queue"):
     from common import ClientServerTest
 
     test = ClientServerTest(cmdline_args, executable, iteration_type,
                             completion_semantic=completion_semantic,
                             datacheck_type="with_datacheck",
                             memory_type=memory_type,
-                            warmup_iteration_type=warmup_iteration_type)
+                            warmup_iteration_type=warmup_iteration_type,
+                            completion_type=completion_type)
     test.run()

--- a/fabtests/pytest/shm/test_rdm.py
+++ b/fabtests/pytest/shm/test_rdm.py
@@ -6,25 +6,25 @@ from shm.shm_common import shm_run_client_server_test
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rdm_pingpong(cmdline_args, iteration_type, completion_semantic, memory_type):
+def test_rdm_pingpong(cmdline_args, iteration_type, completion_semantic, memory_type, completion_type):
     shm_run_client_server_test(cmdline_args, "fi_rdm_pingpong", iteration_type,
-                               completion_semantic, memory_type)
+                               completion_semantic, memory_type, completion_type=completion_type)
 
 
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rdm_tagged_pingpong(cmdline_args, iteration_type, completion_semantic, memory_type):
+def test_rdm_tagged_pingpong(cmdline_args, iteration_type, completion_semantic, memory_type, completion_type):
     shm_run_client_server_test(cmdline_args, "fi_rdm_tagged_pingpong", iteration_type,
-                               completion_semantic, memory_type)
+                               completion_semantic, memory_type, completion_type=completion_type)
 
 
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rdm_tagged_bw(cmdline_args, iteration_type, completion_semantic, memory_type):
+def test_rdm_tagged_bw(cmdline_args, iteration_type, completion_semantic, memory_type, completion_type):
     shm_run_client_server_test(cmdline_args, "fi_rdm_tagged_bw", iteration_type,
-                               completion_semantic, memory_type)
+                               completion_semantic, memory_type, completion_type=completion_type)
 
 @pytest.mark.functional
 def test_rdm_tagged_peek(cmdline_args):

--- a/fabtests/pytest/sm2/sm2_common.py
+++ b/fabtests/pytest/sm2/sm2_common.py
@@ -1,11 +1,13 @@
 def sm2_run_client_server_test(cmdline_args, executable, iteration_type,
                                completion_semantic, memory_type,
-                               warmup_iteration_type=None):
+                               warmup_iteration_type=None,
+                               completion_type="queue"):
     from common import ClientServerTest
 
     test = ClientServerTest(cmdline_args, executable, iteration_type,
                             completion_semantic=completion_semantic,
                             datacheck_type="with_datacheck",
                             memory_type=memory_type,
-                            warmup_iteration_type=warmup_iteration_type)
+                            warmup_iteration_type=warmup_iteration_type,
+                            completion_type=completion_type)
     test.run()

--- a/fabtests/pytest/sm2/test_rdm.py
+++ b/fabtests/pytest/sm2/test_rdm.py
@@ -5,22 +5,22 @@ from sm2.sm2_common import sm2_run_client_server_test
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rdm_pingpong(cmdline_args, iteration_type, completion_semantic, memory_type):
+def test_rdm_pingpong(cmdline_args, iteration_type, completion_semantic, memory_type, completion_type):
     sm2_run_client_server_test(cmdline_args, "fi_rdm_pingpong", iteration_type,
-                               completion_semantic, memory_type)
+                               completion_semantic, memory_type, completion_type=completion_type)
 
 
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rdm_tagged_pingpong(cmdline_args, iteration_type, completion_semantic, memory_type):
+def test_rdm_tagged_pingpong(cmdline_args, iteration_type, completion_semantic, memory_type, completion_type):
     sm2_run_client_server_test(cmdline_args, "fi_rdm_tagged_pingpong", iteration_type,
-                               completion_semantic, memory_type)
+                               completion_semantic, memory_type, completion_type=completion_type)
 
 
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rdm_tagged_bw(cmdline_args, iteration_type, completion_semantic, memory_type):
+def test_rdm_tagged_bw(cmdline_args, iteration_type, completion_semantic, memory_type, completion_type):
     sm2_run_client_server_test(cmdline_args, "fi_rdm_tagged_bw", iteration_type,
-                               completion_semantic, memory_type)
+                               completion_semantic, memory_type, completion_type=completion_type)

--- a/prov/efa/src/efa_cntr.c
+++ b/prov/efa/src/efa_cntr.c
@@ -116,11 +116,11 @@ void efa_cntr_report_tx_completion(struct util_ep *ep, uint64_t flags)
 	assert(flags == FI_SEND || flags == FI_WRITE || flags == FI_READ);
 
 	if (flags == FI_SEND)
-		cntr = ep->tx_cntr;
+		cntr = ep->cntrs[CNTR_TX];
 	else if (flags == FI_WRITE)
-		cntr = ep->wr_cntr;
+		cntr = ep->cntrs[CNTR_WR];
 	else if (flags == FI_READ)
-		cntr = ep->rd_cntr;
+		cntr = ep->cntrs[CNTR_RD];
 	else
 		cntr = NULL;
 
@@ -136,11 +136,11 @@ void efa_cntr_report_rx_completion(struct util_ep *ep, uint64_t flags)
 	assert(flags == FI_RECV || flags == FI_REMOTE_WRITE || flags == FI_REMOTE_READ);
 
 	if (flags == FI_RECV)
-		cntr = ep->rx_cntr;
+		cntr = ep->cntrs[CNTR_RX];
 	else if (flags == FI_REMOTE_READ)
-		cntr = ep->rem_rd_cntr;
+		cntr = ep->cntrs[CNTR_REM_RD];
 	else if (flags == FI_REMOTE_WRITE)
-		cntr = ep->rem_wr_cntr;
+		cntr = ep->cntrs[CNTR_REM_WR];
 	else
 		cntr = NULL;
 
@@ -156,17 +156,17 @@ void efa_cntr_report_error(struct util_ep *ep, uint64_t flags)
 	struct util_cntr *cntr;
 
 	if (flags == FI_WRITE || flags == FI_ATOMIC)
-		cntr = ep->wr_cntr;
+		cntr = ep->cntrs[CNTR_WR];
 	else if (flags == FI_READ)
-		cntr = ep->rd_cntr;
+		cntr = ep->cntrs[CNTR_RD];
 	else if (flags == FI_SEND)
-		cntr = ep->tx_cntr;
+		cntr = ep->cntrs[CNTR_TX];
 	else if (flags == FI_RECV)
-		cntr = ep->rx_cntr;
+		cntr = ep->cntrs[CNTR_RX];
 	else if (flags == FI_REMOTE_READ)
-		cntr = ep->rem_rd_cntr;
+		cntr = ep->cntrs[CNTR_REM_RD];
 	else if (flags == FI_REMOTE_WRITE)
-		cntr = ep->rem_wr_cntr;
+		cntr = ep->cntrs[CNTR_REM_WR];
 	else
 		cntr = NULL;
 

--- a/prov/mrail/src/mrail_cq.c
+++ b/prov/mrail/src/mrail_cq.c
@@ -39,7 +39,7 @@ static int mrail_cq_write_send_comp(struct util_cq *cq,
 {
 	int ret = 0;
 
-	ofi_ep_tx_cntr_inc(&tx_buf->ep->util_ep);
+	ofi_ep_cntr_inc(&tx_buf->ep->util_ep, CNTR_TX);
 
 	if (tx_buf->flags & FI_COMPLETION) {
 		ret = ofi_cq_write(cq, tx_buf->context,
@@ -72,7 +72,7 @@ int mrail_cq_write_recv_comp(struct mrail_ep *mrail_ep, struct mrail_hdr *hdr,
 	FI_DBG(&mrail_prov, FI_LOG_CQ, "finish recv: length: %zu "
 	       "tag: 0x%" PRIx64 "\n", comp->len - sizeof(struct mrail_pkt),
 	       hdr->tag);
-	ofi_ep_rx_cntr_inc(&mrail_ep->util_ep);
+	ofi_ep_cntr_inc(&mrail_ep->util_ep, CNTR_RX);
 	if (!(recv->flags & FI_COMPLETION))
 		return 0;
 	return ofi_cq_write(mrail_ep->util_ep.rx_cq, recv->context,
@@ -87,7 +87,7 @@ static int mrail_cq_write_rndv_recv_comp(struct mrail_ep *mrail_ep,
 {
 	FI_DBG(&mrail_prov, FI_LOG_CQ, "finish rndv recv: length: %zu "
 	       "tag: 0x%" PRIx64 "\n", recv->rndv.len, recv->rndv.tag);
-	ofi_ep_rx_cntr_inc(&mrail_ep->util_ep);
+	ofi_ep_cntr_inc(&mrail_ep->util_ep, CNTR_RX);
 	if (!(recv->flags & FI_COMPLETION))
 		return 0;
 	return ofi_cq_write(mrail_ep->util_ep.rx_cq, recv->context,
@@ -271,7 +271,7 @@ int mrail_cq_process_buf_recv(struct fi_cq_tagged_entry *comp,
 				"Unable to write truncation error to util cq\n");
 			retv = ret;
 		}
-		mrail_cntr_incerr(mrail_ep->util_ep.rx_cntr);
+		mrail_cntr_incerr(mrail_ep->util_ep.cntrs[CNTR_RX]);
 		goto out;
 	}
 	ret = mrail_cq_write_recv_comp(mrail_ep, &mrail_pkt->hdr, comp, recv);
@@ -536,9 +536,9 @@ static void mrail_handle_rma_completion(struct util_cq *cq,
 		}
 
 		if (comp->flags & FI_WRITE)
-			ofi_ep_wr_cntr_inc(&req->mrail_ep->util_ep);
+			ofi_ep_cntr_inc(&req->mrail_ep->util_ep, CNTR_WR);
 		else
-			ofi_ep_rd_cntr_inc(&req->mrail_ep->util_ep);
+			ofi_ep_cntr_inc(&req->mrail_ep->util_ep, CNTR_RD);
 
 		mrail_free_req(req->mrail_ep, req);
 	}

--- a/prov/mrail/src/mrail_ep.c
+++ b/prov/mrail/src/mrail_ep.c
@@ -544,7 +544,7 @@ mrail_send_common(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 			"Unable to fi_sendmsg on rail: %" PRIu32 "\n", rail);
 		goto err2;
 	} else if (!(flags & FI_COMPLETION)) {
-		ofi_ep_tx_cntr_inc(&mrail_ep->util_ep);
+		ofi_ep_cntr_inc(&mrail_ep->util_ep, CNTR_TX);
 	}
 	ofi_genlock_unlock(&mrail_ep->util_ep.lock);
 	return ret;

--- a/prov/mrail/src/mrail_rma.c
+++ b/prov/mrail/src/mrail_rma.c
@@ -402,7 +402,7 @@ static ssize_t mrail_ep_inject_write(struct fid_ep *ep_fid, const void *buf,
 			rail);
 		return ret;
 	}
-	ofi_ep_wr_cntr_inc(&mrail_ep->util_ep);
+	ofi_ep_cntr_inc(&mrail_ep->util_ep, CNTR_WR);
 
 	return 0;
 }

--- a/prov/rxd/src/rxd_cntr.c
+++ b/prov/rxd/src/rxd_cntr.c
@@ -109,11 +109,11 @@ void rxd_cntr_report_error(struct rxd_ep *ep, struct fi_cq_err_entry *err)
 {
         struct util_cntr *cntr;
 
-	cntr = RXD_FLAG(err->flags, (FI_WRITE)) ? ep->util_ep.wr_cntr :
-	       RXD_FLAG(err->flags, (FI_ATOMIC)) ? ep->util_ep.wr_cntr :
-	       RXD_FLAG(err->flags, (FI_READ)) ? ep->util_ep.rd_cntr :
-	       RXD_FLAG(err->flags, (FI_SEND)) ? ep->util_ep.tx_cntr :
-	       RXD_FLAG(err->flags, (FI_RECV)) ? ep->util_ep.rx_cntr :
+	cntr = RXD_FLAG(err->flags, (FI_WRITE)) ? ep->util_ep.cntrs[CNTR_WR] :
+	       RXD_FLAG(err->flags, (FI_ATOMIC)) ? ep->util_ep.cntrs[CNTR_WR] :
+	       RXD_FLAG(err->flags, (FI_READ)) ? ep->util_ep.cntrs[CNTR_RD] :
+	       RXD_FLAG(err->flags, (FI_SEND)) ? ep->util_ep.cntrs[CNTR_TX] :
+	       RXD_FLAG(err->flags, (FI_RECV)) ? ep->util_ep.cntrs[CNTR_RX] :
 	       NULL;
 
 	if (cntr)

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -110,8 +110,8 @@ static int rxm_bind_comp(struct rxm_ep *ep, struct fid_ep *msg_ep)
 	if (!rxm_passthru_info(ep->rxm_info))
 		return 0;
 
-	if (ep->util_ep.tx_cntr) {
-		cntr = container_of(ep->util_ep.tx_cntr, struct rxm_cntr,
+	if (ep->util_ep.cntrs[CNTR_TX]) {
+		cntr = container_of(ep->util_ep.cntrs[CNTR_TX], struct rxm_cntr,
 				    util_cntr);
 		ret = fi_ep_bind(msg_ep, &cntr->msg_cntr->fid, FI_SEND);
 		if (ret) {
@@ -120,8 +120,8 @@ static int rxm_bind_comp(struct rxm_ep *ep, struct fid_ep *msg_ep)
 		}
 	}
 
-	if (ep->util_ep.rx_cntr) {
-		cntr = container_of(ep->util_ep.rx_cntr, struct rxm_cntr,
+	if (ep->util_ep.cntrs[CNTR_RX]) {
+		cntr = container_of(ep->util_ep.cntrs[CNTR_RX], struct rxm_cntr,
 				    util_cntr);
 		ret = fi_ep_bind(msg_ep, &cntr->msg_cntr->fid, FI_RECV);
 		if (ret) {
@@ -130,8 +130,8 @@ static int rxm_bind_comp(struct rxm_ep *ep, struct fid_ep *msg_ep)
 		}
 	}
 
-	if (ep->util_ep.rd_cntr) {
-		cntr = container_of(ep->util_ep.rd_cntr, struct rxm_cntr,
+	if (ep->util_ep.cntrs[CNTR_RD]) {
+		cntr = container_of(ep->util_ep.cntrs[CNTR_RD], struct rxm_cntr,
 				    util_cntr);
 		ret = fi_ep_bind(msg_ep, &cntr->msg_cntr->fid, FI_READ);
 		if (ret) {
@@ -140,8 +140,8 @@ static int rxm_bind_comp(struct rxm_ep *ep, struct fid_ep *msg_ep)
 		}
 	}
 
-	if (ep->util_ep.wr_cntr) {
-		cntr = container_of(ep->util_ep.wr_cntr, struct rxm_cntr,
+	if (ep->util_ep.cntrs[CNTR_WR]) {
+		cntr = container_of(ep->util_ep.cntrs[CNTR_WR], struct rxm_cntr,
 				    util_cntr);
 		ret = fi_ep_bind(msg_ep, &cntr->msg_cntr->fid, FI_WRITE);
 		if (ret) {
@@ -150,8 +150,8 @@ static int rxm_bind_comp(struct rxm_ep *ep, struct fid_ep *msg_ep)
 		}
 	}
 
-	if (ep->util_ep.rem_rd_cntr) {
-		cntr = container_of(ep->util_ep.rem_rd_cntr, struct rxm_cntr,
+	if (ep->util_ep.cntrs[CNTR_REM_RD]) {
+		cntr = container_of(ep->util_ep.cntrs[CNTR_REM_RD], struct rxm_cntr,
 				    util_cntr);
 		ret = fi_ep_bind(msg_ep, &cntr->msg_cntr->fid, FI_REMOTE_READ);
 		if (ret) {
@@ -160,8 +160,8 @@ static int rxm_bind_comp(struct rxm_ep *ep, struct fid_ep *msg_ep)
 		}
 	}
 
-	if (ep->util_ep.rem_wr_cntr) {
-		cntr = container_of(ep->util_ep.rem_wr_cntr, struct rxm_cntr,
+	if (ep->util_ep.cntrs[CNTR_REM_WR]) {
+		cntr = container_of(ep->util_ep.cntrs[CNTR_REM_WR], struct rxm_cntr,
 				    util_cntr);
 		ret = fi_ep_bind(msg_ep, &cntr->msg_cntr->fid, FI_REMOTE_WRITE);
 		if (ret) {

--- a/prov/rxm/src/rxm_msg.c
+++ b/prov/rxm/src/rxm_msg.c
@@ -608,7 +608,7 @@ rxm_inject_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	assert(len <= rxm_ep->rxm_info->tx_attr->inject_size);
 
 	inject_pkt->ctrl_hdr.conn_id = rxm_conn->remote_index;
-	if (pkt_size <= rxm_ep->inject_limit && !rxm_ep->util_ep.tx_cntr) {
+	if (pkt_size <= rxm_ep->inject_limit && !rxm_ep->util_ep.cntrs[CNTR_TX]) {
 		if (rxm_use_msg_tinject(rxm_ep, inject_pkt->hdr.op)) {
 			return rxm_msg_tinject(rxm_conn->msg_ep, buf, len,
 					       inject_pkt->hdr.flags &

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -292,7 +292,7 @@ rxm_ep_rma_inject_common(struct rxm_ep *rxm_ep, const struct fi_msg_rma *msg,
 		goto unlock;
 
 	if ((total_size > rxm_ep->rxm_info->tx_attr->inject_size) ||
-	    rxm_ep->util_ep.wr_cntr ||
+	    rxm_ep->util_ep.cntrs[CNTR_WR] ||
 	    (flags & FI_COMPLETION) || (msg->iov_count > 1) ||
 	    (msg->rma_iov_count > 1)) {
 		ret = rxm_ep_rma_emulate_inject_msg(rxm_ep, rxm_conn,
@@ -449,7 +449,7 @@ static ssize_t rxm_ep_inject_write(struct fid_ep *ep_fid, const void *buf,
 	if (ret)
 		goto unlock;
 
-	if (len > rxm_ep->inject_limit || rxm_ep->util_ep.wr_cntr) {
+	if (len > rxm_ep->inject_limit || rxm_ep->util_ep.cntrs[CNTR_WR]) {
 		ret = rxm_ep_rma_emulate_inject(rxm_ep, rxm_conn, buf, len, 0,
 						dest_addr, addr, key,
 						FI_INJECT);
@@ -483,7 +483,7 @@ static ssize_t rxm_ep_inject_writedata(struct fid_ep *ep_fid, const void *buf,
 	if (ret)
 		goto unlock;
 
-	if (len > rxm_ep->inject_limit || rxm_ep->util_ep.wr_cntr) {
+	if (len > rxm_ep->inject_limit || rxm_ep->util_ep.cntrs[CNTR_WR]) {
 		ret = rxm_ep_rma_emulate_inject(
 			rxm_ep, rxm_conn, buf, len, data, dest_addr,
 			addr, key, FI_REMOTE_CQ_DATA | FI_INJECT);

--- a/prov/tcp/src/xnet.h
+++ b/prov/tcp/src/xnet.h
@@ -621,7 +621,7 @@ xnet_alloc_rx(struct xnet_ep *ep)
 	assert(xnet_progress_locked(xnet_ep2_progress(ep)));
 	xfer = xnet_alloc_xfer(xnet_ep2_progress(ep));
 	if (xfer) {
-		xfer->cntr = ep->util_ep.rx_cntr;
+		xfer->cntr = ep->util_ep.cntrs[CNTR_RX];
 		xfer->cq = xnet_ep_rx_cq(ep);
 	}
 

--- a/prov/tcp/src/xnet_msg.c
+++ b/prov/tcp/src/xnet_msg.c
@@ -58,7 +58,7 @@ xnet_alloc_send(struct xnet_ep *ep)
 	send_entry = xnet_alloc_tx(ep);
 	if (send_entry) {
 		send_entry->hdr.base_hdr.op = ofi_op_msg;
-		send_entry->cntr = ep->util_ep.tx_cntr;
+		send_entry->cntr = ep->util_ep.cntrs[CNTR_TX];
 	}
 
 	return send_entry;
@@ -74,7 +74,7 @@ xnet_alloc_tsend(struct xnet_ep *ep)
 	if (send_entry) {
 		assert(ep->srx);
 		send_entry->hdr.base_hdr.op = ofi_op_tagged;
-		send_entry->cntr = ep->util_ep.tx_cntr;
+		send_entry->cntr = ep->util_ep.cntrs[CNTR_TX];
 	}
 
 	return send_entry;

--- a/prov/tcp/src/xnet_progress.c
+++ b/prov/tcp/src/xnet_progress.c
@@ -121,7 +121,7 @@ xnet_get_save_rx(struct xnet_ep *ep, uint64_t tag)
 		return NULL;
 
 	rx_entry->saving_ep = ep;
-	rx_entry->cntr = ep->util_ep.rx_cntr;
+	rx_entry->cntr = ep->util_ep.cntrs[CNTR_RX];
 	rx_entry->cq = xnet_ep_tx_cq(ep);
 	rx_entry->tag = tag;
 	rx_entry->ignore = 0;
@@ -668,7 +668,7 @@ int xnet_start_recv(struct xnet_ep *ep, struct xnet_xfer_entry *rx_entry)
 	if (ep->peer)
 		rx_entry->src_addr = ep->peer->fi_addr;
 	rx_entry->cq = xnet_ep_rx_cq(ep);
-	rx_entry->cntr = ep->util_ep.rx_cntr;
+	rx_entry->cntr = ep->util_ep.cntrs[CNTR_RX];
 
 	if (rx_entry->ctrl_flags & XNET_MULTI_RECV) {
 		assert(msg->hdr.base_hdr.op == ofi_op_msg);
@@ -824,7 +824,7 @@ static int xnet_op_write(struct xnet_ep *ep)
 		rma_iov = (struct ofi_rma_iov *) ((uint8_t *) &rx_entry->hdr +
 			  sizeof(rx_entry->hdr.base_hdr));
 	}
-	rx_entry->cntr = ep->util_ep.rem_wr_cntr;
+	rx_entry->cntr = ep->util_ep.cntrs[CNTR_REM_WR];
 	rx_entry->cq = xnet_ep_rx_cq(ep);
 
 	memcpy(&rx_entry->hdr, &ep->cur_rx.hdr,

--- a/prov/tcp/src/xnet_rdm.c
+++ b/prov/tcp/src/xnet_rdm.c
@@ -704,9 +704,9 @@ static int xnet_enable_rdm(struct xnet_rdm *rdm)
 
 	(void) fi_ep_bind(&rdm->srx->rx_fid, &rdm->util_ep.rx_cq->cq_fid.fid,
 			  FI_RECV);
-	if (rdm->util_ep.rx_cntr) {
+	if (rdm->util_ep.cntrs[CNTR_RX]) {
 		(void) fi_ep_bind(&rdm->srx->rx_fid,
-				  &rdm->util_ep.rx_cntr->cntr_fid.fid, FI_RECV);
+				  &rdm->util_ep.cntrs[CNTR_RX]->cntr_fid.fid, FI_RECV);
 	}
 	(void) fi_ep_bind(&rdm->srx->rx_fid, &rdm->util_ep.ep_fid.fid,
 			  FI_TAGGED | FI_MSG);

--- a/prov/tcp/src/xnet_rdm_cm.c
+++ b/prov/tcp/src/xnet_rdm_cm.c
@@ -118,45 +118,45 @@ static int xnet_bind_conn(struct xnet_rdm *rdm, struct xnet_ep *ep)
 	if (ret)
 		return ret;
 
-	if (rdm->util_ep.rx_cntr) {
+	if (rdm->util_ep.cntrs[CNTR_RX]) {
 		ret = fi_ep_bind(&ep->util_ep.ep_fid,
-				 &rdm->util_ep.rx_cntr->cntr_fid.fid, FI_RECV);
+				 &rdm->util_ep.cntrs[CNTR_RX]->cntr_fid.fid, FI_RECV);
 		if (ret)
 			return ret;
 	}
 
-	if (rdm->util_ep.tx_cntr) {
+	if (rdm->util_ep.cntrs[CNTR_TX]) {
 		ret = fi_ep_bind(&ep->util_ep.ep_fid,
-				 &rdm->util_ep.tx_cntr->cntr_fid.fid, FI_SEND);
+				 &rdm->util_ep.cntrs[CNTR_TX]->cntr_fid.fid, FI_SEND);
 		if (ret)
 			return ret;
 	}
 
-	if (rdm->util_ep.rd_cntr) {
+	if (rdm->util_ep.cntrs[CNTR_RD]) {
 		ret = fi_ep_bind(&ep->util_ep.ep_fid,
-				 &rdm->util_ep.rd_cntr->cntr_fid.fid, FI_READ);
+				 &rdm->util_ep.cntrs[CNTR_RD]->cntr_fid.fid, FI_READ);
 		if (ret)
 			return ret;
 	}
 
-	if (rdm->util_ep.wr_cntr) {
+	if (rdm->util_ep.cntrs[CNTR_WR]) {
 		ret = fi_ep_bind(&ep->util_ep.ep_fid,
-				 &rdm->util_ep.wr_cntr->cntr_fid.fid, FI_WRITE);
+				 &rdm->util_ep.cntrs[CNTR_WR]->cntr_fid.fid, FI_WRITE);
 		if (ret)
 			return ret;
 	}
 
-	if (rdm->util_ep.rem_rd_cntr) {
+	if (rdm->util_ep.cntrs[CNTR_REM_RD]) {
 		ret = fi_ep_bind(&ep->util_ep.ep_fid,
-				 &rdm->util_ep.rem_rd_cntr->cntr_fid.fid,
+				 &rdm->util_ep.cntrs[CNTR_REM_RD]->cntr_fid.fid,
 				 FI_REMOTE_READ);
 		if (ret)
 			return ret;
 	}
 
-	if (rdm->util_ep.rem_wr_cntr) {
+	if (rdm->util_ep.cntrs[CNTR_REM_WR]) {
 		ret = fi_ep_bind(&ep->util_ep.ep_fid,
-				 &rdm->util_ep.rem_wr_cntr->cntr_fid.fid,
+				 &rdm->util_ep.cntrs[CNTR_REM_WR]->cntr_fid.fid,
 				 FI_REMOTE_WRITE);
 		if (ret)
 			return ret;

--- a/prov/tcp/src/xnet_rma.c
+++ b/prov/tcp/src/xnet_rma.c
@@ -78,7 +78,7 @@ static void xnet_rma_read_send_entry_fill(struct xnet_xfer_entry *send_entry,
 	send_entry->resp_entry = recv_entry;
 
 	/* Read request generates a completion on error */
-	send_entry->cntr = ep->util_ep.rd_cntr;
+	send_entry->cntr = ep->util_ep.cntrs[CNTR_RD];
 	send_entry->cq = xnet_ep_tx_cq(ep);
 }
 
@@ -96,7 +96,7 @@ static void xnet_rma_read_recv_entry_fill(struct xnet_xfer_entry *recv_entry,
 			       FI_RMA | FI_READ;
 
 	/* Read response completes the RMA read transmit */
-	recv_entry->cntr = ep->util_ep.rd_cntr;
+	recv_entry->cntr = ep->util_ep.cntrs[CNTR_RD];
 	recv_entry->cq = xnet_ep_tx_cq(ep);
 	/* Read response is marked as internal until the request completes
 	 * successfully.  This way we won't generate 2 completion to the
@@ -260,7 +260,7 @@ xnet_rma_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 
 	send_entry->cq_flags = xnet_tx_completion_flag(ep, flags) |
 			       FI_RMA | FI_WRITE;
-	send_entry->cntr = ep->util_ep.wr_cntr;
+	send_entry->cntr = ep->util_ep.cntrs[CNTR_WR];
 	xnet_set_commit_flags(send_entry, flags);
 	send_entry->context = msg->context;
 
@@ -400,7 +400,7 @@ xnet_rma_inject_common(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	send_entry->hdr.base_hdr.size = offset;
 	send_entry->cq_flags = FI_INJECT | FI_WRITE;
-	send_entry->cntr = ep->util_ep.wr_cntr;
+	send_entry->cntr = ep->util_ep.cntrs[CNTR_WR];
 	xnet_tx_queue_insert(ep, send_entry);
 unlock:
 	ofi_genlock_unlock(&xnet_ep2_progress(ep)->lock);

--- a/prov/ucx/src/ucx_callbacks.c
+++ b/prov/ucx/src/ucx_callbacks.c
@@ -38,7 +38,7 @@ void ucx_send_callback_no_compl(void *request, ucs_status_t status)
 	struct ucx_request *ucx_req = request;
 
 	if (ucx_req->ep)
-		ofi_ep_tx_cntr_inc(&ucx_req->ep->ep);
+		ofi_ep_cntr_inc(&ucx_req->ep->ep, CNTR_TX);
 
 	ucx_req_release(request);
 }
@@ -58,7 +58,7 @@ void ucx_send_callback(void *request, ucs_status_t status)
 	} else {
 		ofi_cq_write(cq, tc->op_context, tc->flags, tc->len,
 			     tc->buf, 0, tc->tag);
-		ofi_ep_tx_cntr_inc(&ucx_req->ep->ep);
+		ofi_ep_cntr_inc(&ucx_req->ep->ep, CNTR_TX);
 	}
 	ucx_req_release(request);
 }
@@ -69,7 +69,7 @@ void ucx_recv_callback_no_compl(void *request, ucs_status_t status,
 	struct ucx_request *ucx_req = request;
 
 	if (ucx_req->ep)
-		ofi_ep_rx_cntr_inc(&ucx_req->ep->ep);
+		ofi_ep_cntr_inc(&ucx_req->ep->ep, CNTR_RX);
 
 	ucx_req_release(request);
 }
@@ -105,7 +105,7 @@ void ucx_recv_callback(void *request, ucs_status_t status,
 	} else {
 		ofi_cq_write(cq, tc->op_context, tc->flags, tc->len, tc->buf,
 			     0, tc->tag);
-		ofi_ep_rx_cntr_inc(&ucx_req->ep->ep);
+		ofi_ep_cntr_inc(&ucx_req->ep->ep, CNTR_RX);
 	}
 
 	if (cq->wait)

--- a/prov/ucx/src/ucx_core.c
+++ b/prov/ucx/src/ucx_core.c
@@ -150,7 +150,7 @@ done:
 			     0, msg->tag);
 	}
 
-	ofi_ep_tx_cntr_inc(&u_ep->ep);
+	ofi_ep_cntr_inc(&u_ep->ep, CNTR_TX);
 
 fence:
 	if(flags & (FI_FENCE | FI_TRANSMIT_COMPLETE))
@@ -274,7 +274,7 @@ ssize_t ucx_do_recvmsg(struct fid_ep *ep, const struct fi_msg_tagged *msg,
 			ofi_cq_write(cq, tc->op_context, tc->flags, tc->len, tc->buf,
 				     0, tc->tag);
 
-		ofi_ep_rx_cntr_inc(&u_ep->ep);
+		ofi_ep_cntr_inc(&u_ep->ep, CNTR_RX);
 	}
 
 	ucx_req_release(req);

--- a/prov/ucx/src/ucx_core.h
+++ b/prov/ucx/src/ucx_core.h
@@ -91,7 +91,7 @@ static inline ssize_t ucx_gen_mrecv_completion(struct ucx_mrecv_request *req)
 			flags |= FI_MULTI_RECV;
 		ofi_cq_write(cq, mctx->context, flags,  req->last_recvd,
 			     mctx->head, 0, 0);
-		ofi_ep_rx_cntr_inc(&req->ep->ep);
+		ofi_ep_cntr_inc(&req->ep->ep, CNTR_RX);
 		if (buff_is_full)
 			ret = FI_SUCCESS;
 	}
@@ -119,7 +119,7 @@ static inline ssize_t ucx_do_inject(struct fid_ep *ep, const void *buf,
 				 tag, ucx_send_callback_no_compl);
 
 	if (status == NULL) {
-		ofi_ep_tx_cntr_inc(&u_ep->ep);
+		ofi_ep_cntr_inc(&u_ep->ep, CNTR_TX);
 		return FI_SUCCESS;
 	}
 

--- a/prov/ucx/src/ucx_rma.c
+++ b/prov/ucx/src/ucx_rma.c
@@ -174,9 +174,9 @@ void ucx_rma_callback(void *request, ucs_status_t status)
 
 	if (status == UCS_OK){
 		if (ucx_req->type == UCX_REQ_WRITE)
-			ofi_ep_wr_cntr_inc(&(ucx_req->ep->ep));
+			ofi_ep_cntr_inc(&(ucx_req->ep->ep), CNTR_WR);
 		else
-			ofi_ep_rd_cntr_inc(&(ucx_req->ep->ep));
+			ofi_ep_cntr_inc(&(ucx_req->ep->ep), CNTR_RD);
 
 		if (ucx_req->completion.flags & FI_COMPLETION)
 			ofi_cq_write(ucx_req->ep->ep.tx_cq,
@@ -188,8 +188,8 @@ void ucx_rma_callback(void *request, ucs_status_t status)
 			"RMA completion error %s\n",
 			ucs_status_string(status));
 		struct util_cntr *cntr = (ucx_req->type == UCX_REQ_WRITE) ?
-						ucx_req->ep->ep.wr_cntr :
-						ucx_req->ep->ep.rd_cntr;
+						ucx_req->ep->ep.cntrs[CNTR_WR] :
+						ucx_req->ep->ep.cntrs[CNTR_RD];
 		if (cntr)
 			cntr->cntr_fid.ops->adderr(&cntr->cntr_fid, 1);
 
@@ -296,9 +296,9 @@ static ssize_t ucx_proc_rma_msg(struct fid_ep *ep,
 
 	if (status == UCS_OK) {
 		if (op_type == UCX_DO_WRITE)
-			ofi_ep_wr_cntr_inc(&u_ep->ep);
+			ofi_ep_cntr_inc(&u_ep->ep, CNTR_WR);
 		else
-			ofi_ep_rd_cntr_inc(&u_ep->ep);
+			ofi_ep_cntr_inc(&u_ep->ep, CNTR_RD);
 
 		if (flags & FI_COMPLETION)
 			ofi_cq_write(u_ep->ep.tx_cq, msg->context, flags,
@@ -350,7 +350,7 @@ ssize_t ucx_inject_write(struct fid_ep *ep, const void *buf, size_t len,
 			ucp_worker_progress(u_ep->worker);
 	}
 
-	ofi_ep_wr_cntr_inc(&(u_ep->ep));
+	ofi_ep_cntr_inc(&(u_ep->ep), CNTR_WR);
 
 	return ucx_translate_errcode(ret);
 }

--- a/prov/util/src/util_cntr.c
+++ b/prov/util/src/util_cntr.c
@@ -325,28 +325,3 @@ int ofi_cntr_init(const struct fi_provider *prov, struct fid_domain *domain,
 	return 0;
 }
 
-ofi_ep_cntr_inc_func ofi_ep_tx_cntr_inc_funcs[] = {
-	[ofi_op_msg] = ofi_ep_tx_cntr_inc,
-	[ofi_op_tagged] = ofi_ep_tx_cntr_inc,
-	[ofi_op_read_req] = ofi_ep_rd_cntr_inc,
-	[ofi_op_read_rsp] = ofi_ep_rem_rd_cntr_inc,
-	[ofi_op_write] = ofi_ep_wr_cntr_inc,
-	[ofi_op_write_async] = ofi_ep_wr_cntr_inc,
-	[ofi_op_atomic] = ofi_ep_wr_cntr_inc,
-	[ofi_op_atomic_fetch] = ofi_ep_rd_cntr_inc,
-	[ofi_op_atomic_compare] = ofi_ep_rd_cntr_inc,
-	[ofi_op_read_async] = ofi_ep_rd_cntr_inc,
-};
-
-ofi_ep_cntr_inc_func ofi_ep_rx_cntr_inc_funcs[] = {
-	[ofi_op_msg] = ofi_ep_rx_cntr_inc,
-	[ofi_op_tagged] = ofi_ep_rx_cntr_inc,
-	[ofi_op_read_req] = ofi_ep_rem_rd_cntr_inc,
-	[ofi_op_read_rsp] = ofi_ep_rd_cntr_inc,
-	[ofi_op_write] = ofi_ep_rem_wr_cntr_inc,
-	[ofi_op_write_async] = ofi_ep_rem_wr_cntr_inc,
-	[ofi_op_atomic] = ofi_ep_rem_wr_cntr_inc,
-	[ofi_op_atomic_fetch] = ofi_ep_rem_rd_cntr_inc,
-	[ofi_op_atomic_compare] = ofi_ep_rem_rd_cntr_inc,
-	[ofi_op_read_async] = ofi_ep_rem_rd_cntr_inc,
-};

--- a/prov/util/src/util_ep.c
+++ b/prov/util/src/util_ep.c
@@ -108,50 +108,50 @@ int ofi_ep_bind_cntr(struct util_ep *ep, struct util_cntr *cntr, uint64_t flags)
 		return -FI_EBADFLAGS;
 	}
 
-	if (((flags & FI_TRANSMIT) && ep->tx_cntr) ||
-	    ((flags & FI_RECV) && ep->rx_cntr) ||
-	    ((flags & FI_READ) && ep->rd_cntr) ||
-	    ((flags & FI_WRITE) && ep->wr_cntr) ||
-	    ((flags & FI_REMOTE_READ) && ep->rem_rd_cntr) ||
-	    ((flags & FI_REMOTE_WRITE) && ep->rem_wr_cntr)) {
+	if (((flags & FI_TRANSMIT) && ep->cntrs[CNTR_TX]) ||
+	    ((flags & FI_RECV) && ep->cntrs[CNTR_RX]) ||
+	    ((flags & FI_READ) && ep->cntrs[CNTR_RD]) ||
+	    ((flags & FI_WRITE) && ep->cntrs[CNTR_WR]) ||
+	    ((flags & FI_REMOTE_READ) && ep->cntrs[CNTR_REM_RD]) ||
+	    ((flags & FI_REMOTE_WRITE) && ep->cntrs[CNTR_REM_WR])) {
 		FI_WARN(ep->domain->fabric->prov, FI_LOG_EP_CTRL,
 			"Duplicate counter binding\n");
 		return -FI_EINVAL;
 	}
 
 	if (flags & FI_TRANSMIT) {
-		ep->tx_cntr = cntr;
-		ep->tx_cntr_inc = ofi_cntr_inc;
+		ep->cntrs[CNTR_TX] = cntr;
+		ep->cntr_inc_funcs[CNTR_TX] = ofi_cntr_inc;
 		ofi_atomic_inc32(&cntr->ref);
 	}
 
 	if (flags & FI_RECV) {
-		ep->rx_cntr = cntr;
-		ep->rx_cntr_inc = ofi_cntr_inc;
+		ep->cntrs[CNTR_RX]= cntr;
+		ep->cntr_inc_funcs[CNTR_RX] = ofi_cntr_inc;
 		ofi_atomic_inc32(&cntr->ref);
 	}
 
 	if (flags & FI_READ) {
-		ep->rd_cntr = cntr;
-		ep->rd_cntr_inc = ofi_cntr_inc;
+		ep->cntrs[CNTR_RD] = cntr;
+		ep->cntr_inc_funcs[CNTR_RD] = ofi_cntr_inc;
 		ofi_atomic_inc32(&cntr->ref);
 	}
 
 	if (flags & FI_WRITE) {
-		ep->wr_cntr = cntr;
-		ep->wr_cntr_inc = ofi_cntr_inc;
+		ep->cntrs[CNTR_WR] = cntr;
+		ep->cntr_inc_funcs[CNTR_WR] = ofi_cntr_inc;
 		ofi_atomic_inc32(&cntr->ref);
 	}
 
 	if (flags & FI_REMOTE_READ) {
-		ep->rem_rd_cntr = cntr;
-		ep->rem_rd_cntr_inc = ofi_cntr_inc;
+		ep->cntrs[CNTR_REM_RD] = cntr;
+		ep->cntr_inc_funcs[CNTR_REM_RD] = ofi_cntr_inc;
 		ofi_atomic_inc32(&cntr->ref);
 	}
 
 	if (flags & FI_REMOTE_WRITE) {
-		ep->rem_wr_cntr = cntr;
-		ep->rem_wr_cntr_inc = ofi_cntr_inc;
+		ep->cntrs[CNTR_REM_WR] = cntr;
+		ep->cntr_inc_funcs[CNTR_REM_WR] = ofi_cntr_inc;
 		ofi_atomic_inc32(&cntr->ref);
 	}
 
@@ -211,6 +211,7 @@ int ofi_endpoint_init(struct fid_domain *domain, const struct util_prov *util_pr
 {
 	struct util_domain *util_domain;
 	int ret;
+	int i;
 
 	util_domain = container_of(domain, struct util_domain, domain_fid);
 
@@ -237,12 +238,10 @@ int ofi_endpoint_init(struct fid_domain *domain, const struct util_prov *util_pr
 		((info->tx_attr->op_flags &
 		  ~(FI_COMPLETION | FI_INJECT_COMPLETE |
 		    FI_TRANSMIT_COMPLETE | FI_DELIVERY_COMPLETE)) | FI_INJECT);
-	ep->tx_cntr_inc 	= ofi_cntr_inc_noop;
-	ep->rx_cntr_inc 	= ofi_cntr_inc_noop;
-	ep->rd_cntr_inc 	= ofi_cntr_inc_noop;
-	ep->wr_cntr_inc 	= ofi_cntr_inc_noop;
-	ep->rem_rd_cntr_inc 	= ofi_cntr_inc_noop;
-	ep->rem_wr_cntr_inc 	= ofi_cntr_inc_noop;
+
+	for (i = 0; i < CNTR_CNT; i++)
+		ep->cntr_inc_funcs[i] = ofi_cntr_inc_noop;
+
 	ep->type = info->ep_attr->type;
 	ofi_atomic_inc32(&util_domain->ref);
 	if (util_domain->eq)
@@ -270,6 +269,8 @@ int ofi_endpoint_init(struct fid_domain *domain, const struct util_prov *util_pr
 
 int ofi_endpoint_close(struct util_ep *util_ep)
 {
+	int i;
+
 	if (util_ep->tx_cq) {
 		fid_list_remove(&util_ep->tx_cq->ep_list,
 				&util_ep->tx_cq->ep_list_lock,
@@ -284,46 +285,13 @@ int ofi_endpoint_close(struct util_ep *util_ep)
 		ofi_atomic_dec32(&util_ep->rx_cq->ref);
 	}
 
-	if (util_ep->rx_cntr) {
-		fid_list_remove(&util_ep->rx_cntr->ep_list,
-				&util_ep->rx_cntr->ep_list_lock,
-				&util_ep->ep_fid.fid);
-		ofi_atomic_dec32(&util_ep->rx_cntr->ref);
-	}
-
-	if (util_ep->tx_cntr) {
-		fid_list_remove(&util_ep->tx_cntr->ep_list,
-				&util_ep->tx_cntr->ep_list_lock,
-				&util_ep->ep_fid.fid);
-		ofi_atomic_dec32(&util_ep->tx_cntr->ref);
-	}
-
-	if (util_ep->rd_cntr) {
-		fid_list_remove(&util_ep->rd_cntr->ep_list,
-				&util_ep->rd_cntr->ep_list_lock,
-				&util_ep->ep_fid.fid);
-		ofi_atomic_dec32(&util_ep->rd_cntr->ref);
-	}
-
-	if (util_ep->wr_cntr) {
-		fid_list_remove(&util_ep->wr_cntr->ep_list,
-				&util_ep->wr_cntr->ep_list_lock,
-				&util_ep->ep_fid.fid);
-		ofi_atomic_dec32(&util_ep->wr_cntr->ref);
-	}
-
-	if (util_ep->rem_rd_cntr) {
-		fid_list_remove(&util_ep->rem_rd_cntr->ep_list,
-				&util_ep->rem_rd_cntr->ep_list_lock,
-				&util_ep->ep_fid.fid);
-		ofi_atomic_dec32(&util_ep->rem_rd_cntr->ref);
-	}
-
-	if (util_ep->rem_wr_cntr) {
-		fid_list_remove(&util_ep->rem_wr_cntr->ep_list,
-				&util_ep->rem_wr_cntr->ep_list_lock,
-				&util_ep->ep_fid.fid);
-		ofi_atomic_dec32(&util_ep->rem_wr_cntr->ref);
+	for (i = 0; i < CNTR_CNT; i++) {
+		if (util_ep->cntrs[i]) {
+			fid_list_remove(&util_ep->cntrs[i]->ep_list,
+					&util_ep->cntrs[i]->ep_list_lock,
+					&util_ep->ep_fid.fid);
+			ofi_atomic_dec32(&util_ep->cntrs[i]->ref);
+		}
 	}
 
 	if (util_ep->av) {


### PR DESCRIPTION
Currently, cntrs for different operations have different
    field names in util_ep, which causes code duplication and
    makes it hard to expand in the future. This patch refactor
    this code path by introducing two arrays: util_ep.cntrs, and
    util_ep.cntr_inc_funcs to store the pointers to the cntrs
    and its inc functions, which share the uniform procedure
    in ep creation, bind, and close.


This PR also expand the rdm test in fabtests/pytest/shm,sm2 to cover cntr completion type.