### PR TITLE
prov/sm2: Introduce new proto_flags

### DIFF
--- a/prov/sm2/src/sm2.h
+++ b/prov/sm2/src/sm2.h
@@ -91,9 +91,10 @@ extern pthread_mutex_t sm2_ep_list_lock;
 
 enum {
 	sm2_proto_inject,
-	sm2_proto_return,
 	sm2_proto_max,
 };
+
+#define SM2_RETURN (1 << 0)
 
 /*
  * 	next - fifo linked list next ptr

--- a/prov/sm2/src/sm2.h
+++ b/prov/sm2/src/sm2.h
@@ -95,6 +95,7 @@ enum {
 };
 
 #define SM2_RETURN (1 << 0)
+#define SM2_UNEXP  (1 << 1)
 
 /*
  * 	next - fifo linked list next ptr

--- a/prov/sm2/src/sm2_ep.c
+++ b/prov/sm2/src/sm2_ep.c
@@ -222,7 +222,7 @@ static void cleanup_shm_resources(struct sm2_ep *ep)
 	/* Return all free queue entries in queue without processing them */
 return_incoming:
 	while (NULL != (xfer_entry = sm2_fifo_read(ep))) {
-		if (xfer_entry->hdr.proto == sm2_proto_return) {
+		if (xfer_entry->hdr.proto_flags & SM2_RETURN) {
 			smr_freestack_push(sm2_freestack(ep->self_region),
 					   xfer_entry);
 		} else {

--- a/prov/sm2/src/sm2_fifo.h
+++ b/prov/sm2/src/sm2_fifo.h
@@ -236,7 +236,7 @@ static inline struct sm2_xfer_entry *sm2_fifo_read(struct sm2_ep *ep)
 static inline void sm2_fifo_write_back(struct sm2_ep *ep,
 				       struct sm2_xfer_entry *xfer_entry)
 {
-	xfer_entry->hdr.proto = sm2_proto_return;
+	xfer_entry->hdr.proto_flags |= SM2_RETURN;
 	assert(xfer_entry->hdr.sender_gid != ep->gid);
 	sm2_fifo_write(ep, xfer_entry->hdr.sender_gid, xfer_entry);
 }

--- a/prov/sm2/src/sm2_progress.c
+++ b/prov/sm2/src/sm2_progress.c
@@ -340,7 +340,7 @@ void sm2_progress_recv(struct sm2_ep *ep)
 		if (!xfer_entry)
 			break;
 
-		if (xfer_entry->hdr.proto == sm2_proto_return) {
+		if (xfer_entry->hdr.proto_flags & SM2_RETURN) {
 			if (xfer_entry->hdr.op_flags & FI_REMOTE_READ) {
 				atomic_entry = (struct sm2_atomic_entry *)
 						       xfer_entry->user_data;


### PR DESCRIPTION
Using `SM2_RETURN` flag instead of `sm2_proto_return` preserves the original protocol in the xfer_entry.
Meaning we can control when to generate completions without explicitly modifying `FI_DELIVERY_COMPLETE`

`SM2_UNEXP` flag specifies that the xfer entry was immediately returned because a corresponding buffer was not posted by the receiver. So no send completion is generated.

The `SM2_UNEXP` flag also replaces the `return_xfer_entry` bool in `sm2_start_common`