### PR TITLE
fabtests: Add barrier before starting test

### DIFF
--- a/fabtests/functional/unexpected_msg.c
+++ b/fabtests/functional/unexpected_msg.c
@@ -319,6 +319,7 @@ static int run_test(void)
 			return ret;
 	}
 
+	ft_sync();
 	ret = run_test_loop();
 
 	return ret;


### PR DESCRIPTION
The messages from the address exchange can overlap with the test messages and cause spurious failures. Add a barrier to prevent that.