### PR TITLE
prov/sm2: Implement CMA protocol and HMEM

### DIFF
--- a/prov/sm2/src/sm2.h
+++ b/prov/sm2/src/sm2.h
@@ -99,6 +99,12 @@ enum {
 
 #define SM2_RMA_REQ (1 << 1)
 
+/* The SM2_UNEXP flag is used for unexpected receives. On the receiver, it
+indicates that the xfer_entry that the receiver is processing is actually in the
+xfer_ctx_pool and not in the receiver's freestack.
+*/
+#define SM2_UNEXP (1 << 2)
+
 /*
  * 	next - fifo linked list next ptr
  * 		This is volatile for a reason, many things touch this

--- a/prov/sm2/src/sm2.h
+++ b/prov/sm2/src/sm2.h
@@ -105,6 +105,12 @@ xfer_ctx_pool and not in the receiver's freestack.
 */
 #define SM2_UNEXP (1 << 2)
 
+/* SM2_GENERATE_COMPLETION is used in protocols that require delivery complete
+ * semantics (CMA and IPC). It is set when the receiver has finished processing
+ * the request and wants to tell the sender that the sender should generate a
+ * send completion. */
+#define SM2_GENERATE_COMPLETION (1 << 3)
+
 /*
  * 	next - fifo linked list next ptr
  * 		This is volatile for a reason, many things touch this

--- a/prov/sm2/src/sm2.h
+++ b/prov/sm2/src/sm2.h
@@ -91,11 +91,12 @@ extern pthread_mutex_t sm2_ep_list_lock;
 
 enum {
 	sm2_proto_inject,
-	sm2_proto_return,
 	sm2_proto_max,
 };
 
 /* Protocol flags */
+#define SM2_RETURN (1 << 0)
+
 #define SM2_RMA_REQ (1 << 1)
 
 /*

--- a/prov/sm2/src/sm2.h
+++ b/prov/sm2/src/sm2.h
@@ -95,6 +95,9 @@ enum {
 	sm2_proto_max,
 };
 
+/* Protocol flags */
+#define SM2_RMA_REQ (1 << 1)
+
 /*
  * 	next - fifo linked list next ptr
  * 		This is volatile for a reason, many things touch this

--- a/prov/sm2/src/sm2.h
+++ b/prov/sm2/src/sm2.h
@@ -124,6 +124,10 @@ completions instead of waiting for the application to post the receive buffer.
  * send completion. */
 #define SM2_GENERATE_COMPLETION (1 << 3)
 
+/* Protocol flags for SM2 CMA protocol */
+#define SM2_CMA_HOST_TO_DEV	(1 << 4)
+#define SM2_CMA_HOST_TO_DEV_ACK (1 << 5)
+
 /*
  * 	next - fifo linked list next ptr
  * 		This is volatile for a reason, many things touch this
@@ -186,6 +190,10 @@ struct sm2_atomic_entry {
 struct sm2_cma_data {
 	size_t iov_count;
 	struct iovec iov[SM2_IOV_LIMIT];
+
+	/* Used for IPC host to device protocol */
+	struct ipc_info ipc_info;
+	struct fi_peer_rx_entry *rx_entry;
 };
 
 struct sm2_ep_name {

--- a/prov/sm2/src/sm2.h
+++ b/prov/sm2/src/sm2.h
@@ -92,6 +92,7 @@ extern pthread_mutex_t sm2_ep_list_lock;
 enum {
 	sm2_proto_inject,
 	sm2_proto_cma,
+	sm2_proto_ipc,
 	sm2_proto_max,
 };
 
@@ -244,6 +245,7 @@ struct sm2_xfer_ctx {
 
 struct sm2_domain {
 	struct util_domain util_domain;
+	struct ofi_mr_cache *ipc_cache;
 	struct fid_peer_srx *srx;
 };
 
@@ -330,6 +332,7 @@ static inline bool sm2_proto_imm_send_comp(uint16_t proto)
 {
 	switch (proto) {
 	case sm2_proto_cma:
+	case sm2_proto_ipc:
 		return false;
 	default:
 		return true;

--- a/prov/sm2/src/sm2_atomic.c
+++ b/prov/sm2/src/sm2_atomic.c
@@ -109,9 +109,9 @@ sm2_do_atomic_inject(struct sm2_ep *ep, int64_t peer_gid, uint32_t op,
 		return ret;
 
 	xfer_entry->hdr.proto = sm2_proto_inject;
-	xfer_entry->hdr.proto_flags |= proto_flags;
 
 	sm2_generic_format(xfer_entry, ep->gid, op, 0, 0, op_flags, context);
+	xfer_entry->hdr.proto_flags |= proto_flags;
 	sm2_atomic_format(xfer_entry, datatype, atomic_op, rma_ioc,
 			  rma_ioc_count, result_iov, result_count, iov,
 			  iov_count, compare_iov, compare_count);

--- a/prov/sm2/src/sm2_attr.c
+++ b/prov/sm2/src/sm2_attr.c
@@ -99,19 +99,6 @@ struct fi_ep_attr sm2_ep_attr = {
 	.rx_ctx_cnt = 1,
 };
 
-struct fi_ep_attr sm2_hmem_ep_attr = {
-	.type = FI_EP_RDM,
-	.protocol = FI_PROTO_SM2,
-	.protocol_version = 1,
-	.max_msg_size = SM2_INJECT_SIZE,
-	.max_order_raw_size = SM2_INJECT_SIZE,
-	.max_order_waw_size = SM2_INJECT_SIZE,
-	.max_order_war_size = SM2_INJECT_SIZE,
-	.mem_tag_format = FI_TAG_GENERIC,
-	.tx_ctx_cnt = 1,
-	.rx_ctx_cnt = 1,
-};
-
 struct fi_domain_attr sm2_domain_attr = {
 	.name = "sm2",
 	.threading = FI_THREAD_SAFE,
@@ -163,7 +150,7 @@ struct fi_info sm2_hmem_info = {
 	.addr_format = FI_ADDR_STR,
 	.tx_attr = &sm2_hmem_tx_attr,
 	.rx_attr = &sm2_hmem_rx_attr,
-	.ep_attr = &sm2_hmem_ep_attr,
+	.ep_attr = &sm2_ep_attr,
 	.domain_attr = &sm2_hmem_domain_attr,
 	.fabric_attr = &sm2_fabric_attr,
 };

--- a/prov/sm2/src/sm2_attr.c
+++ b/prov/sm2/src/sm2_attr.c
@@ -90,6 +90,19 @@ struct fi_ep_attr sm2_ep_attr = {
 	.type = FI_EP_RDM,
 	.protocol = FI_PROTO_SM2,
 	.protocol_version = 1,
+	.max_msg_size = SIZE_MAX,
+	.max_order_raw_size = SIZE_MAX,
+	.max_order_waw_size = SIZE_MAX,
+	.max_order_war_size = SIZE_MAX,
+	.mem_tag_format = FI_TAG_GENERIC,
+	.tx_ctx_cnt = 1,
+	.rx_ctx_cnt = 1,
+};
+
+struct fi_ep_attr sm2_hmem_ep_attr = {
+	.type = FI_EP_RDM,
+	.protocol = FI_PROTO_SM2,
+	.protocol_version = 1,
 	.max_msg_size = SM2_INJECT_SIZE,
 	.max_order_raw_size = SM2_INJECT_SIZE,
 	.max_order_waw_size = SM2_INJECT_SIZE,
@@ -150,7 +163,7 @@ struct fi_info sm2_hmem_info = {
 	.addr_format = FI_ADDR_STR,
 	.tx_attr = &sm2_hmem_tx_attr,
 	.rx_attr = &sm2_hmem_rx_attr,
-	.ep_attr = &sm2_ep_attr,
+	.ep_attr = &sm2_hmem_ep_attr,
 	.domain_attr = &sm2_hmem_domain_attr,
 	.fabric_attr = &sm2_fabric_attr,
 };

--- a/prov/sm2/src/sm2_coordination.h
+++ b/prov/sm2/src/sm2_coordination.h
@@ -50,6 +50,8 @@
 
 #define SM2_XFER_ENTRY_SIZE   4096
 #define SM2_MAX_UNIVERSE_SIZE 256
+/* TODO: Tune max GDRCopy size for SM2 */
+#define SM2_MAX_GDRCOPY_SIZE 3072
 /* TODO: Make the number of XFER ENTRY's configurable */
 #define SM2_NUM_XFER_ENTRY_PER_PEER 1024
 

--- a/prov/sm2/src/sm2_domain.c
+++ b/prov/sm2/src/sm2_domain.c
@@ -58,6 +58,9 @@ static int sm2_domain_close(fid_t fid)
 	domain = container_of(fid, struct sm2_domain,
 			      util_domain.domain_fid.fid);
 
+	if (domain->ipc_cache)
+		ofi_ipc_cache_destroy(domain->ipc_cache);
+
 	ret = ofi_domain_close(&domain->util_domain);
 	if (ret)
 		return ret;
@@ -98,6 +101,15 @@ int sm2_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	ret = ofi_domain_init(fabric, info, &sm2_domain->util_domain, context,
 			      OFI_LOCK_SPINLOCK);
 	if (ret) {
+		free(sm2_domain);
+		return ret;
+	}
+
+	ret = ofi_ipc_cache_open(&sm2_domain->ipc_cache,
+				 &sm2_domain->util_domain);
+	if (ret) {
+		FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,
+			"Unable to open IPC cache\n");
 		free(sm2_domain);
 		return ret;
 	}

--- a/prov/sm2/src/sm2_ep.c
+++ b/prov/sm2/src/sm2_ep.c
@@ -222,7 +222,7 @@ static void cleanup_shm_resources(struct sm2_ep *ep)
 	/* Return all free queue entries in queue without processing them */
 return_incoming:
 	while (NULL != (xfer_entry = sm2_fifo_read(ep))) {
-		if (xfer_entry->hdr.proto == sm2_proto_return) {
+		if (xfer_entry->hdr.proto_flags & SM2_RETURN) {
 			smr_freestack_push(sm2_freestack(ep->self_region),
 					   xfer_entry);
 		} else {

--- a/prov/sm2/src/sm2_ep.c
+++ b/prov/sm2/src/sm2_ep.c
@@ -228,6 +228,7 @@ return_incoming:
 		} else {
 			/* TODO Tell other side that we haven't processed their
 			 * message, just returned xfer_entry */
+			xfer_entry->hdr.proto_flags &= ~SM2_GENERATE_COMPLETION;
 			sm2_fifo_write_back(ep, xfer_entry);
 		}
 	}

--- a/prov/sm2/src/sm2_ep.c
+++ b/prov/sm2/src/sm2_ep.c
@@ -247,6 +247,64 @@ static ssize_t sm2_do_cma(struct sm2_ep *ep, struct sm2_region *peer_smr,
 	return FI_SUCCESS;
 }
 
+static ssize_t sm2_format_ipc(struct sm2_xfer_entry *xfer_entry, void *ptr,
+			      size_t len, enum fi_hmem_iface iface,
+			      uint64_t device)
+{
+	void *base;
+	ssize_t ret;
+	struct ipc_info *ipc_info = (struct ipc_info *) xfer_entry->user_data;
+
+	xfer_entry->hdr.proto = sm2_proto_ipc;
+	xfer_entry->hdr.size = len;
+	ipc_info->iface = iface;
+	ipc_info->device = device;
+
+	ret = ofi_hmem_get_base_addr(ipc_info->iface, ptr, len, &base,
+				     &ipc_info->base_length);
+	if (ret)
+		return ret;
+
+	ret = ofi_hmem_get_handle(ipc_info->iface, base, ipc_info->base_length,
+				  (void **) &ipc_info->ipc_handle);
+	if (ret)
+		return ret;
+
+	ipc_info->base_addr = (uintptr_t) base;
+	ipc_info->offset = (uintptr_t) ptr - (uintptr_t) base;
+
+	return FI_SUCCESS;
+}
+
+static ssize_t sm2_do_ipc(struct sm2_ep *ep, struct sm2_region *peer_smr,
+			  sm2_gid_t peer_gid, uint32_t op, uint64_t tag,
+			  uint64_t data, uint64_t op_flags, struct ofi_mr **mr,
+			  const struct iovec *iov, size_t iov_count,
+			  size_t total_len, void *context)
+{
+	struct sm2_xfer_entry *xfer_entry;
+	ssize_t ret;
+
+	ret = sm2_pop_xfer_entry(ep, &xfer_entry);
+	if (ret)
+		return ret;
+
+	sm2_generic_format(xfer_entry, ep->gid, op, tag, data, op_flags,
+			   context);
+	ret = sm2_format_ipc(xfer_entry, iov[0].iov_base, total_len,
+			     mr[0]->iface, mr[0]->device);
+
+	if (ret) {
+		FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,
+			"Error generating IPC header information\n");
+		smr_freestack_push(sm2_freestack(ep->self_region), xfer_entry);
+		return ret;
+	}
+
+	sm2_fifo_write(ep, peer_gid, xfer_entry);
+	return FI_SUCCESS;
+}
+
 static void cleanup_shm_resources(struct sm2_ep *ep)
 {
 	struct sm2_xfer_entry *xfer_entry;
@@ -608,4 +666,5 @@ ep:
 sm2_proto_func sm2_proto_ops[sm2_proto_max] = {
 	[sm2_proto_inject] = &sm2_do_inject,
 	[sm2_proto_cma] = &sm2_do_cma,
+	[sm2_proto_ipc] = &sm2_do_ipc,
 };

--- a/prov/sm2/src/sm2_fifo.h
+++ b/prov/sm2/src/sm2_fifo.h
@@ -236,7 +236,7 @@ static inline struct sm2_xfer_entry *sm2_fifo_read(struct sm2_ep *ep)
 static inline void sm2_fifo_write_back(struct sm2_ep *ep,
 				       struct sm2_xfer_entry *xfer_entry)
 {
-	xfer_entry->hdr.proto = sm2_proto_return;
+	xfer_entry->hdr.proto_flags |= SM2_RETURN;
 	assert(xfer_entry->hdr.sender_gid != ep->gid);
 	sm2_fifo_write(ep, xfer_entry->hdr.sender_gid, xfer_entry);
 }

--- a/prov/sm2/src/sm2_fifo.h
+++ b/prov/sm2/src/sm2_fifo.h
@@ -241,4 +241,20 @@ static inline void sm2_fifo_write_back(struct sm2_ep *ep,
 	sm2_fifo_write(ep, xfer_entry->hdr.sender_gid, xfer_entry);
 }
 
+static inline void
+sm2_fifo_write_back_ipc_host_to_dev(struct sm2_ep *ep,
+				    struct sm2_xfer_entry *xfer_entry)
+{
+	/* This function is called by the sender after the CUDA memcpy is
+	 * complete. Receiver generates receive completion after receiving this
+	 * message */
+	sm2_gid_t receiver_gid = xfer_entry->hdr.sender_gid;
+
+	xfer_entry->hdr.proto_flags &= ~SM2_CMA_HOST_TO_DEV;
+	xfer_entry->hdr.proto_flags |= SM2_CMA_HOST_TO_DEV_ACK;
+	assert(xfer_entry->hdr.sender_gid != ep->gid);
+	xfer_entry->hdr.sender_gid = ep->gid;
+	sm2_fifo_write(ep, receiver_gid, xfer_entry);
+}
+
 #endif /* _SM2_FIFO_H_ */

--- a/prov/sm2/src/sm2_msg.c
+++ b/prov/sm2/src/sm2_msg.c
@@ -38,8 +38,34 @@
 #include "ofi_iov.h"
 #include "sm2.h"
 
-static inline int sm2_select_proto(uint64_t total_len)
+static inline int sm2_select_proto(void **desc, size_t iov_count,
+				   uint64_t op_flags, uint64_t total_len)
 {
+	struct ofi_mr *sm2_desc;
+	enum fi_hmem_iface iface;
+
+	if (desc && *desc) {
+		sm2_desc = (struct ofi_mr *) *desc;
+		iface = sm2_desc->iface;
+		if (iface == FI_HMEM_CUDA) {
+			if ((sm2_desc->flags & OFI_HMEM_DATA_GDRCOPY_HANDLE) &&
+			    (total_len <= SM2_MAX_GDRCOPY_SIZE)) {
+				assert(sm2_desc->hmem_data);
+				return sm2_proto_inject;
+			}
+			/* Do not inject if IPC is available so device to device
+			 * transfer may occur if possible. */
+			/* TODO - multi IOV support */
+			if (iov_count == 1 && desc && desc[0]) {
+				if (ofi_hmem_is_ipc_enabled(iface) &&
+				    sm2_desc->flags & FI_HMEM_DEVICE_ONLY &&
+				    !(op_flags & FI_INJECT)) {
+					return sm2_proto_ipc;
+				}
+			}
+		}
+	}
+
 	if (total_len <= SM2_INJECT_SIZE)
 		return sm2_proto_inject;
 
@@ -108,7 +134,8 @@ static ssize_t sm2_generic_sendmsg(struct sm2_ep *ep, const struct iovec *iov,
 	total_len = ofi_total_iov_len(iov, iov_count);
 	assert(!(op_flags & FI_INJECT) || total_len <= SM2_INJECT_SIZE);
 
-	proto = sm2_select_proto(total_len);
+	proto = sm2_select_proto(desc, iov_count, op_flags, total_len);
+
 	ret = sm2_proto_ops[proto](ep, peer_smr, peer_gid, op, tag, data,
 				   op_flags, mr, iov, iov_count, total_len,
 				   context);

--- a/prov/sm2/src/sm2_msg.c
+++ b/prov/sm2/src/sm2_msg.c
@@ -38,6 +38,14 @@
 #include "ofi_iov.h"
 #include "sm2.h"
 
+static inline int sm2_select_proto(uint64_t total_len)
+{
+	if (total_len <= SM2_INJECT_SIZE)
+		return sm2_proto_inject;
+
+	return sm2_proto_cma;
+}
+
 static ssize_t sm2_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 			   uint64_t flags)
 {
@@ -85,6 +93,7 @@ static ssize_t sm2_generic_sendmsg(struct sm2_ep *ep, const struct iovec *iov,
 	ssize_t ret = 0;
 	size_t total_len;
 	struct ofi_mr **mr = (struct ofi_mr **) desc;
+	int proto;
 
 	assert(iov_count <= SM2_IOV_LIMIT);
 
@@ -99,13 +108,14 @@ static ssize_t sm2_generic_sendmsg(struct sm2_ep *ep, const struct iovec *iov,
 	total_len = ofi_total_iov_len(iov, iov_count);
 	assert(!(op_flags & FI_INJECT) || total_len <= SM2_INJECT_SIZE);
 
-	ret = sm2_proto_ops[sm2_proto_inject](ep, peer_smr, peer_gid, op, tag,
-					      data, op_flags, mr, iov,
-					      iov_count, total_len, context);
+	proto = sm2_select_proto(total_len);
+	ret = sm2_proto_ops[proto](ep, peer_smr, peer_gid, op, tag, data,
+				   op_flags, mr, iov, iov_count, total_len,
+				   context);
 	if (ret)
 		goto unlock_cq;
 
-	if (!(op_flags & FI_DELIVERY_COMPLETE)) {
+	if (sm2_proto_imm_send_comp(proto)) {
 		ret = sm2_complete_tx(ep, context, op, op_flags);
 		if (ret) {
 			FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,

--- a/prov/sm2/src/sm2_msg.c
+++ b/prov/sm2/src/sm2_msg.c
@@ -135,7 +135,6 @@ static ssize_t sm2_generic_sendmsg(struct sm2_ep *ep, const struct iovec *iov,
 	assert(!(op_flags & FI_INJECT) || total_len <= SM2_INJECT_SIZE);
 
 	proto = sm2_select_proto(desc, iov_count, op_flags, total_len);
-
 	ret = sm2_proto_ops[proto](ep, peer_smr, peer_gid, op, tag, data,
 				   op_flags, mr, iov, iov_count, total_len,
 				   context);

--- a/prov/sm2/src/sm2_msg.c
+++ b/prov/sm2/src/sm2_msg.c
@@ -48,7 +48,7 @@ static inline int sm2_select_proto(void **desc, size_t iov_count,
 		sm2_desc = (struct ofi_mr *) *desc;
 		iface = sm2_desc->iface;
 		if (iface == FI_HMEM_CUDA) {
-			if ((sm2_desc->flags & OFI_HMEM_DATA_GDRCOPY_HANDLE) &&
+			if ((sm2_desc->flags & OFI_HMEM_DATA_DEV_REG_HANDLE) &&
 			    (total_len <= SM2_MAX_GDRCOPY_SIZE)) {
 				assert(sm2_desc->hmem_data);
 				return sm2_proto_inject;

--- a/prov/sm2/src/sm2_progress.c
+++ b/prov/sm2/src/sm2_progress.c
@@ -122,6 +122,53 @@ static int sm2_progress_inject(struct sm2_xfer_entry *xfer_entry,
 	return FI_SUCCESS;
 }
 
+static int sm2_progress_ipc(struct sm2_xfer_entry *xfer_entry,
+			    struct ofi_mr **mr, struct iovec *iov,
+			    size_t iov_count, size_t *total_len,
+			    struct sm2_ep *ep)
+{
+	void *ptr;
+	ssize_t hmem_copy_ret;
+	int ret, err;
+	struct sm2_domain *domain;
+	struct ofi_mr_entry *mr_entry;
+	struct ipc_info *ipc_info = (struct ipc_info *) xfer_entry->user_data;
+
+	domain = container_of(ep->util_ep.domain, struct sm2_domain,
+			      util_domain);
+
+	ret = ofi_ipc_cache_search(domain->ipc_cache,
+				   xfer_entry->hdr.sender_gid, ipc_info,
+				   &mr_entry);
+	if (ret)
+		return ret;
+
+	ptr = (char *) (uintptr_t) mr_entry->info.mapped_addr +
+	      (uintptr_t) ipc_info->offset;
+
+	hmem_copy_ret =
+		ofi_copy_to_hmem_iov(ipc_info->iface, ipc_info->device, iov,
+				     iov_count, 0, ptr, xfer_entry->hdr.size);
+
+	ofi_mr_cache_delete(domain->ipc_cache, mr_entry);
+
+	if (hmem_copy_ret < 0) {
+		FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,
+			"IPC recv failed with code %d\n",
+			(int) (-hmem_copy_ret));
+		err = hmem_copy_ret;
+	} else if (hmem_copy_ret != xfer_entry->hdr.size) {
+		FI_WARN(&sm2_prov, FI_LOG_EP_CTRL, "IPC recv truncated\n");
+		err = -FI_ETRUNC;
+	} else {
+		err = ret;
+	}
+
+	*total_len = hmem_copy_ret;
+
+	return err;
+}
+
 static int sm2_start_common(struct sm2_ep *ep,
 			    struct sm2_xfer_entry *xfer_entry,
 			    struct fi_peer_rx_entry *rx_entry)
@@ -137,6 +184,11 @@ static int sm2_start_common(struct sm2_ep *ep,
 		err = sm2_progress_inject(
 			xfer_entry, (struct ofi_mr **) rx_entry->desc,
 			rx_entry->iov, rx_entry->count, &total_len, ep, 0);
+		break;
+	case sm2_proto_ipc:
+		err = sm2_progress_ipc(
+			xfer_entry, (struct ofi_mr **) rx_entry->desc,
+			rx_entry->iov, rx_entry->count, &total_len, ep);
 		break;
 	case sm2_proto_cma:
 		err = sm2_progress_cma(xfer_entry, rx_entry->iov,

--- a/prov/sm2/src/sm2_progress.c
+++ b/prov/sm2/src/sm2_progress.c
@@ -70,8 +70,7 @@ static int sm2_progress_inject(struct sm2_xfer_entry *xfer_entry,
 
 static int sm2_start_common(struct sm2_ep *ep,
 			    struct sm2_xfer_entry *xfer_entry,
-			    struct fi_peer_rx_entry *rx_entry,
-			    bool return_xfer_entry)
+			    struct fi_peer_rx_entry *rx_entry)
 {
 	size_t total_len = 0;
 	uint64_t comp_flags;
@@ -111,7 +110,7 @@ static int sm2_start_common(struct sm2_ep *ep,
 			"Unable to process rx completion\n");
 	}
 
-	if (return_xfer_entry)
+	if (!(xfer_entry->hdr.proto_flags & SM2_UNEXP))
 		sm2_fifo_write_back(ep, xfer_entry);
 
 	sm2_get_peer_srx(ep)->owner_ops->free_entry(rx_entry);
@@ -124,8 +123,7 @@ int sm2_unexp_start(struct fi_peer_rx_entry *rx_entry)
 	struct sm2_xfer_ctx *xfer_ctx = rx_entry->peer_context;
 	int ret;
 
-	ret = sm2_start_common(xfer_ctx->ep, &xfer_ctx->xfer_entry, rx_entry,
-			       false);
+	ret = sm2_start_common(xfer_ctx->ep, &xfer_ctx->xfer_entry, rx_entry);
 	ofi_buf_free(xfer_ctx);
 
 	return ret;
@@ -172,6 +170,7 @@ static int sm2_progress_recv_msg(struct sm2_ep *ep,
 		ret = peer_srx->owner_ops->get_tag(
 			peer_srx, addr, xfer_entry->hdr.tag, &rx_entry);
 		if (ret == -FI_ENOENT) {
+			xfer_entry->hdr.proto_flags |= SM2_UNEXP;
 			ret = sm2_alloc_xfer_entry_ctx(ep, rx_entry,
 						       xfer_entry);
 			sm2_fifo_write_back(ep, xfer_entry);
@@ -185,6 +184,7 @@ static int sm2_progress_recv_msg(struct sm2_ep *ep,
 		ret = peer_srx->owner_ops->get_msg(
 			peer_srx, addr, xfer_entry->hdr.size, &rx_entry);
 		if (ret == -FI_ENOENT) {
+			xfer_entry->hdr.proto_flags |= SM2_UNEXP;
 			ret = sm2_alloc_xfer_entry_ctx(ep, rx_entry,
 						       xfer_entry);
 			sm2_fifo_write_back(ep, xfer_entry);
@@ -199,7 +199,7 @@ static int sm2_progress_recv_msg(struct sm2_ep *ep,
 		FI_WARN(&sm2_prov, FI_LOG_EP_CTRL, "Error getting rx_entry\n");
 		return ret;
 	}
-	ret = sm2_start_common(ep, xfer_entry, rx_entry, true);
+	ret = sm2_start_common(ep, xfer_entry, rx_entry);
 
 out:
 	return ret < 0 ? ret : 0;
@@ -354,7 +354,8 @@ void sm2_progress_recv(struct sm2_ep *ep)
 					0, atomic_entry->atomic_data.data,
 					xfer_entry->hdr.size);
 			}
-			if (xfer_entry->hdr.op_flags & FI_DELIVERY_COMPLETE) {
+			if (xfer_entry->hdr.op_flags & FI_DELIVERY_COMPLETE &&
+			    !(xfer_entry->hdr.proto_flags & SM2_UNEXP)) {
 				ret = sm2_complete_tx(
 					ep, (void *) xfer_entry->hdr.context,
 					xfer_entry->hdr.op,

--- a/prov/sm2/src/sm2_progress.c
+++ b/prov/sm2/src/sm2_progress.c
@@ -42,9 +42,116 @@
 #include "sm2.h"
 #include "sm2_fifo.h"
 
-static inline int sm2_cma_loop(pid_t pid, struct iovec *local,
-			       unsigned long local_cnt, struct iovec *remote,
-			       unsigned long remote_cnt, size_t total,
+static int sm2_cma_send_ipc_handle(struct sm2_ep *ep,
+				   struct sm2_xfer_entry *xfer_entry,
+				   struct fi_peer_rx_entry *rx_entry,
+				   struct ofi_mr **mr)
+{
+	sm2_gid_t sender_gid = xfer_entry->hdr.sender_gid;
+	struct sm2_xfer_entry *new_xfer_entry;
+	struct sm2_cma_data *cma_data =
+		((struct sm2_cma_data *) xfer_entry->user_data);
+	struct ipc_info *ipc_info;
+	void *device_ptr, *base;
+	int ret;
+
+	/* TODO - multiple IOV support - update protocol selection logic
+	 * to use SAR for multiple IOVs */
+	assert(cma_data->iov_count == 1);
+
+	device_ptr = rx_entry->iov[0].iov_base;
+	ipc_info = &cma_data->ipc_info;
+
+	xfer_entry->hdr.proto = sm2_proto_cma;
+	xfer_entry->hdr.proto_flags |= SM2_CMA_HOST_TO_DEV;
+	xfer_entry->hdr.sender_gid = ep->gid;
+
+	cma_data->rx_entry = rx_entry;
+
+	ipc_info->iface = mr[0]->iface;
+	ipc_info->device = mr[0]->device;
+
+	ret = ofi_hmem_get_base_addr(ipc_info->iface, device_ptr,
+				     xfer_entry->hdr.size, &base,
+				     &ipc_info->base_length);
+	if (ret) {
+		FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,
+			"Failed to get device memory base address. Error code: "
+			"%d\n",
+			ret);
+		return ret;
+	}
+
+	ret = ofi_hmem_get_handle(ipc_info->iface, base, ipc_info->base_length,
+				  (void **) &ipc_info->ipc_handle);
+	if (ret) {
+		FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,
+			"Failed to open IPC handle in host to device protocol. "
+			"Error code: %d\n",
+			ret);
+		return ret;
+	}
+
+	ipc_info->base_addr = (uintptr_t) base;
+	ipc_info->offset =
+		(uintptr_t) device_ptr - (uintptr_t) ipc_info->base_addr;
+
+	/* Send xfer_entry with IPC handle back to sender */
+	if (xfer_entry->hdr.proto_flags & SM2_UNEXP) {
+		/* xfer_entry with SM2_UNEXP flag actually points to an
+		 * ofi_bufpool entry in the receiver memory which the sender
+		 * can't read. So we create a new xfer_entry and send it instead
+		 */
+		ret = sm2_pop_xfer_entry(ep, &new_xfer_entry);
+		if (ret)
+			return ret;
+
+		memcpy(new_xfer_entry, xfer_entry,
+		       sizeof(struct sm2_xfer_entry));
+		sm2_fifo_write(ep, sender_gid, new_xfer_entry);
+	} else {
+		sm2_fifo_write(ep, sender_gid, xfer_entry);
+	}
+
+	return FI_SUCCESS;
+}
+
+static int sm2_cma_hmem_memcpy(struct sm2_ep *ep,
+			       struct sm2_xfer_entry *xfer_entry)
+{
+	struct sm2_domain *domain;
+	struct sm2_cma_data *cma_data;
+	struct ipc_info *ipc_info;
+	struct ofi_mr_entry *mr_entry;
+	void *dest;
+	int ret;
+
+	cma_data = (struct sm2_cma_data *) xfer_entry->user_data;
+
+	domain = container_of(ep->util_ep.domain, struct sm2_domain,
+			      util_domain);
+
+	ipc_info = &cma_data->ipc_info;
+	ret = ofi_ipc_cache_search(domain->ipc_cache,
+				   xfer_entry->hdr.sender_gid, ipc_info,
+				   &mr_entry);
+	if (ret)
+		return ret;
+
+	dest = (char *) (uintptr_t) mr_entry->info.mapped_addr +
+	       (uintptr_t) ipc_info->offset;
+
+	ret = ofi_copy_to_hmem(ipc_info->iface, ipc_info->device, dest,
+			       cma_data->iov[0].iov_base, xfer_entry->hdr.size);
+
+	ofi_mr_cache_delete(domain->ipc_cache, mr_entry);
+
+	return ret;
+}
+
+static inline int sm2_cma_loop(struct sm2_ep *ep,
+			       struct sm2_xfer_entry *xfer_entry,
+			       struct fi_peer_rx_entry *rx_entry, size_t total,
 			       bool write)
 {
 	ssize_t ret;
@@ -56,11 +163,13 @@ static inline int sm2_cma_loop(pid_t pid, struct iovec *local,
 
 	while (1) {
 		if (write)
-			ret = ofi_process_vm_writev(pid, local, local_cnt,
-						    remote, remote_cnt, 0);
+			ret = ofi_process_vm_writev(
+				pid, rx_entry->iov, rx_entry->count,
+				cma_data->iov, cma_data->iov_count, 0);
 		else
-			ret = ofi_process_vm_readv(pid, local, local_cnt,
-						   remote, remote_cnt, 0);
+			ret = ofi_process_vm_readv(
+				pid, rx_entry->iov, rx_entry->count,
+				cma_data->iov, cma_data->iov_count, 0);
 		if (ret < 0) {
 			FI_WARN(&sm2_prov, FI_LOG_EP_CTRL, "CMA error %d\n",
 				errno);
@@ -71,25 +180,50 @@ static inline int sm2_cma_loop(pid_t pid, struct iovec *local,
 		if (!total)
 			return FI_SUCCESS;
 
-		ofi_consume_iov(local, &local_cnt, (size_t) ret);
-		ofi_consume_iov(remote, &remote_cnt, (size_t) ret);
+		ofi_consume_iov(rx_entry->iov, &rx_entry->count, (size_t) ret);
+		ofi_consume_iov(cma_data->iov, &cma_data->iov_count,
+				(size_t) ret);
 	}
 }
 
-static int sm2_progress_cma(struct sm2_xfer_entry *xfer_entry,
-			    struct iovec *iov, size_t iov_count,
-			    size_t *total_len, struct sm2_ep *ep, int err)
+static int sm2_progress_cma(struct sm2_ep *ep,
+			    struct sm2_xfer_entry *xfer_entry,
+			    struct fi_peer_rx_entry *rx_entry,
+			    size_t *total_len, int err, bool *ipc_host_to_dev)
 {
-	struct sm2_cma_data *cma_data =
-		(struct sm2_cma_data *) xfer_entry->user_data;
-	struct sm2_ep_allocation_entry *entries = sm2_mmap_entries(ep->mmap);
 	int ret;
+	struct ofi_mr **mr = (struct ofi_mr **) rx_entry->desc;
+	enum fi_hmem_iface iface;
+
+	if (mr && mr[0])
+		iface = mr[0]->iface;
+	else
+		iface = FI_HMEM_SYSTEM;
+
+	if (iface != FI_HMEM_SYSTEM) {
+		/* The sender is trying to send from host
+		 * memory to device memory. CMA does not support
+		 * device memory, so we open the IPC handle,
+		 * return the handle to the sender for the
+		 * sender to a device memcpy */
+
+		/* TODO - multiple IOV support - update protocol selection logic
+		 * to use SAR for multiple IOVs */
+		assert(rx_entry->count == 1);
+
+		err = sm2_cma_send_ipc_handle(ep, xfer_entry, rx_entry, mr);
+		if (err == FI_SUCCESS) {
+			*ipc_host_to_dev = true;
+			return err;
+		}
+		FI_WARN(&sm2_prov, FI_LOG_EP_CTRL, "CMA error %d\n", errno);
+		return -FI_EIO;
+	}
 
 	/* TODO Need to update last argument for RMA support (as well as generic
 	 * format) */
-	ret = sm2_cma_loop(entries[xfer_entry->hdr.sender_gid].pid, iov,
-			   iov_count, cma_data->iov, cma_data->iov_count,
-			   xfer_entry->hdr.size, false);
+	ret = sm2_cma_loop(ep, xfer_entry, rx_entry, xfer_entry->hdr.size,
+			   false);
 	if (!ret)
 		*total_len = xfer_entry->hdr.size;
 
@@ -178,6 +312,7 @@ static int sm2_start_common(struct sm2_ep *ep,
 	void *comp_buf;
 	int err = 0, ret = 0;
 	struct sm2_xfer_entry *new_xfer_entry;
+	bool ipc_host_to_dev = false;
 
 	switch (xfer_entry->hdr.proto) {
 	case sm2_proto_inject:
@@ -191,8 +326,8 @@ static int sm2_start_common(struct sm2_ep *ep,
 			rx_entry->iov, rx_entry->count, &total_len, ep);
 		break;
 	case sm2_proto_cma:
-		err = sm2_progress_cma(xfer_entry, rx_entry->iov,
-				       rx_entry->count, &total_len, ep, 0);
+		err = sm2_progress_cma(ep, xfer_entry, rx_entry, &total_len, 0,
+				       &ipc_host_to_dev);
 		break;
 	default:
 		FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,
@@ -209,16 +344,26 @@ static int sm2_start_common(struct sm2_ep *ep,
 		ret = sm2_write_err_comp(ep->util_ep.rx_cq, rx_entry->context,
 					 comp_flags, rx_entry->tag, err);
 	} else {
-		ret = sm2_complete_rx(
-			ep, rx_entry->context, xfer_entry->hdr.op, comp_flags,
-			total_len, comp_buf, xfer_entry->hdr.sender_gid,
-			xfer_entry->hdr.tag, xfer_entry->hdr.cq_data);
+		/* If the IPC device to host protocol is used, the receive
+		 * completion is not generated at this stage. Instead, it's
+		 * generated after the sender completes the device memcpy */
+		if (!ipc_host_to_dev)
+			ret = sm2_complete_rx(
+				ep, rx_entry->context, xfer_entry->hdr.op,
+				comp_flags, total_len, comp_buf,
+				xfer_entry->hdr.sender_gid, xfer_entry->hdr.tag,
+				xfer_entry->hdr.cq_data);
 	}
 
 	if (ret) {
 		FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,
 			"Unable to process rx completion\n");
 	}
+
+	sm2_get_peer_srx(ep)->owner_ops->free_entry(rx_entry);
+
+	if (ipc_host_to_dev)
+		return 0;
 
 	if (!sm2_proto_imm_send_comp(xfer_entry->hdr.proto))
 		xfer_entry->hdr.proto_flags |= SM2_GENERATE_COMPLETION;
@@ -254,8 +399,6 @@ static int sm2_start_common(struct sm2_ep *ep,
 		new_xfer_entry->hdr.sender_gid = ep->gid;
 		sm2_fifo_write(ep, xfer_entry->hdr.sender_gid, new_xfer_entry);
 	}
-
-	sm2_get_peer_srx(ep)->owner_ops->free_entry(rx_entry);
 
 	return 0;
 }
@@ -296,6 +439,82 @@ static int sm2_alloc_xfer_entry_ctx(struct sm2_ep *ep,
 	return FI_SUCCESS;
 }
 
+static inline void
+sm2_progress_cma_host_to_dev(struct sm2_ep *ep,
+			     struct sm2_xfer_entry *xfer_entry)
+{
+	/* Sender received IPC handle from receiver and needs to
+	 * do a device memcpy, so skip rx entry lookup */
+	int ret;
+
+	ret = sm2_cma_hmem_memcpy(ep, xfer_entry);
+	if (ret) {
+		FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,
+			"Device memcpy in host to device IPC "
+			"protocol failed\n");
+		if (xfer_entry->hdr.proto_flags & SM2_UNEXP) {
+			xfer_entry->hdr.proto_flags &= ~SM2_GENERATE_COMPLETION;
+			sm2_fifo_write_back(ep, xfer_entry);
+		} else {
+			smr_freestack_push(sm2_freestack(ep->self_region),
+					   xfer_entry);
+		}
+		return;
+	}
+
+	ret = sm2_complete_tx(ep, (void *) xfer_entry->hdr.context,
+			      xfer_entry->hdr.op, xfer_entry->hdr.op_flags);
+
+	if (ret) {
+		FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,
+			"Unable to process tx completion\n");
+	}
+
+	sm2_fifo_write_back_ipc_host_to_dev(ep, xfer_entry);
+}
+
+static inline void
+sm2_progress_cma_host_to_dev_ack(struct sm2_ep *ep,
+				 struct sm2_xfer_entry *xfer_entry)
+{
+	/* Generate receive completion on the receiver because
+	 * the receiver received a IPC device to host ack
+	 * message */
+
+	struct sm2_cma_data *cma_data;
+	int ret;
+	uint64_t comp_flags;
+
+	cma_data = (struct sm2_cma_data *) xfer_entry->user_data;
+
+	comp_flags =
+		sm2_rx_cq_flags(xfer_entry->hdr.op, cma_data->rx_entry->flags,
+				xfer_entry->hdr.op_flags);
+
+	ret = sm2_complete_rx(ep, cma_data->rx_entry->context,
+			      xfer_entry->hdr.op, comp_flags,
+			      xfer_entry->hdr.size, cma_data->iov[0].iov_base,
+			      xfer_entry->hdr.sender_gid, xfer_entry->hdr.tag,
+			      xfer_entry->hdr.cq_data);
+
+	if (ret) {
+		FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,
+			"Unable to process rx completion\n");
+	}
+
+	if (xfer_entry->hdr.proto_flags & SM2_UNEXP) {
+		/* The xfer_entry was actually allocated on the
+		 * receiver side, so we just push it back */
+		smr_freestack_push(sm2_freestack(ep->self_region), xfer_entry);
+	} else {
+		/* Unset the delivery complete flag so that we
+		 * don't write another completion entry on the
+		 * sender after the xfer entry is returned */
+		xfer_entry->hdr.proto_flags &= ~SM2_GENERATE_COMPLETION;
+		sm2_fifo_write_back(ep, xfer_entry);
+	}
+}
+
 static int sm2_progress_recv_msg(struct sm2_ep *ep,
 				 struct sm2_xfer_entry *xfer_entry)
 {
@@ -304,6 +523,19 @@ static int sm2_progress_recv_msg(struct sm2_ep *ep,
 	struct sm2_av *sm2_av;
 	fi_addr_t addr;
 	int ret;
+
+	/* TODO - Switch on protocol before switching on op to avoid messy
+	 * checks like this */
+
+	/* We don't want to look for rx entries for xfer entries with
+	 * SM2_CMA_HOST_TO_DEV and SM2_CMA_HOST_TO_DEV_ACK flags*/
+	if (xfer_entry->hdr.proto_flags & SM2_CMA_HOST_TO_DEV) {
+		sm2_progress_cma_host_to_dev(ep, xfer_entry);
+		goto out;
+	} else if (xfer_entry->hdr.proto_flags & SM2_CMA_HOST_TO_DEV_ACK) {
+		sm2_progress_cma_host_to_dev_ack(ep, xfer_entry);
+		goto out;
+	}
 
 	sm2_av = container_of(ep->util_ep.av, struct sm2_av, util_av);
 	addr = sm2_av->reverse_lookup[xfer_entry->hdr.sender_gid];


### PR DESCRIPTION
This PR implements (again) the CMA protocol for arbitrary sized host-host message transfers. It also implements the IPC protocol for arbitrary sized device->host/device transfers and a IPC fallback protocol for host->device transfers.