### PR TITLE
prov/util, efa: use shm cntr as a peer cntr

### DIFF
--- a/fabtests/pytest/efa/efa_common.py
+++ b/fabtests/pytest/efa/efa_common.py
@@ -5,7 +5,8 @@ from retrying import retry
 
 def efa_run_client_server_test(cmdline_args, executable, iteration_type,
                                completion_semantic, memory_type, message_size,
-                               warmup_iteration_type=None, timeout=None):
+                               warmup_iteration_type=None, timeout=None,
+                               completion_type="queue"):
     if timeout is None:
         timeout = cmdline_args.timeout
 
@@ -20,7 +21,8 @@ def efa_run_client_server_test(cmdline_args, executable, iteration_type,
                             message_size=message_size,
                             memory_type=memory_type,
                             timeout=timeout,
-                            warmup_iteration_type=warmup_iteration_type)
+                            warmup_iteration_type=warmup_iteration_type,
+                            completion_type=completion_type)
     test.run()
 
 @retry(retry_on_exception=is_ssh_connection_error, stop_max_attempt_number=3, wait_fixed=5000)

--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -7,9 +7,9 @@ import pytest
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rdm_pingpong(cmdline_args, iteration_type, completion_semantic, memory_type):
+def test_rdm_pingpong(cmdline_args, iteration_type, completion_semantic, memory_type, completion_type):
     efa_run_client_server_test(cmdline_args, "fi_rdm_pingpong", iteration_type,
-                               completion_semantic, memory_type, "all")
+                               completion_semantic, memory_type, "all", completion_type=completion_type)
 
 @pytest.mark.functional
 def test_rdm_pingpong_range(cmdline_args, completion_semantic, memory_type, message_size):
@@ -19,9 +19,9 @@ def test_rdm_pingpong_range(cmdline_args, completion_semantic, memory_type, mess
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rdm_tagged_pingpong(cmdline_args, iteration_type, completion_semantic, memory_type):
+def test_rdm_tagged_pingpong(cmdline_args, iteration_type, completion_semantic, memory_type, completion_type):
     efa_run_client_server_test(cmdline_args, "fi_rdm_tagged_pingpong", iteration_type,
-                               completion_semantic, memory_type, "all")
+                               completion_semantic, memory_type, "all", completion_type=completion_type)
 
 @pytest.mark.functional
 def test_rdm_tagged_pingpong_range(cmdline_args, completion_semantic, memory_type, message_size):
@@ -31,9 +31,9 @@ def test_rdm_tagged_pingpong_range(cmdline_args, completion_semantic, memory_typ
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rdm_tagged_bw(cmdline_args, iteration_type, completion_semantic, memory_type):
+def test_rdm_tagged_bw(cmdline_args, iteration_type, completion_semantic, memory_type, completion_type):
     efa_run_client_server_test(cmdline_args, "fi_rdm_tagged_bw", iteration_type,
-                               completion_semantic, memory_type, "all")
+                               completion_semantic, memory_type, "all", completion_type=completion_type)
 
 @pytest.mark.functional
 def test_rdm_tagged_bw_range(cmdline_args, completion_semantic, memory_type, message_size):
@@ -68,13 +68,3 @@ def test_rdm_tagged_peek(cmdline_args):
     test = ClientServerTest(cmdline_args, "fi_rdm_tagged_peek", timeout=1800)
     test.run()
 
-@pytest.mark.functional
-def test_rdm_with_cntr(cmdline_args):
-    from common import ClientServerTest
-
-    # TODO: remove this skip after getting cntr works on single node.
-    if cmdline_args.server_id == cmdline_args.client_id:
-        pytest.skip("This test requires 2 nodes")
-        return
-
-    test = ClientServerTest(cmdline_args, "fi_rdm_pingpong", timeout=1800, completion_type="counter")

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -746,6 +746,13 @@ int ofi_cntr_init(const struct fi_provider *prov, struct fid_domain *domain,
 		  struct fi_cntr_attr *attr, struct util_cntr *cntr,
 		  ofi_cntr_progress_func progress, void *context);
 int ofi_cntr_cleanup(struct util_cntr *cntr);
+uint64_t ofi_cntr_read(struct fid_cntr *cntr_fid);
+uint64_t ofi_cntr_readerr(struct fid_cntr *cntr_fid);
+int ofi_cntr_add(struct fid_cntr *cntr_fid, uint64_t value);
+int ofi_cntr_adderr(struct fid_cntr *cntr_fid, uint64_t value);
+int ofi_cntr_set(struct fid_cntr *cntr_fid, uint64_t value);
+int ofi_cntr_seterr(struct fid_cntr *cntr_fid, uint64_t value);
+int ofi_cntr_wait(struct fid_cntr *cntr_fid, uint64_t threshold, int timeout);
 
 static inline void util_cntr_signal(struct util_cntr *cntr)
 {

--- a/prov/efa/src/efa_cntr.h
+++ b/prov/efa/src/efa_cntr.h
@@ -38,6 +38,11 @@
 #ifndef _EFA_CNTR_H_
 #define _EFA_CNTR_H_
 
+struct efa_cntr {
+	struct util_cntr util_cntr;
+	struct fid_cntr *shm_cntr;
+};
+
 int efa_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 		  struct fid_cntr **cntr_fid, void *context);
 

--- a/prov/util/src/util_cntr.c
+++ b/prov/util/src/util_cntr.c
@@ -69,7 +69,7 @@ static int ofi_check_cntr_attr(const struct fi_provider *prov,
 	return 0;
 }
 
-static uint64_t ofi_cntr_read(struct fid_cntr *cntr_fid)
+uint64_t ofi_cntr_read(struct fid_cntr *cntr_fid)
 {
 	struct util_cntr *cntr = container_of(cntr_fid, struct util_cntr, cntr_fid);
 
@@ -79,7 +79,7 @@ static uint64_t ofi_cntr_read(struct fid_cntr *cntr_fid)
 	return ofi_atomic_get64(&cntr->cnt);
 }
 
-static uint64_t ofi_cntr_readerr(struct fid_cntr *cntr_fid)
+uint64_t ofi_cntr_readerr(struct fid_cntr *cntr_fid)
 {
 	struct util_cntr *cntr = container_of(cntr_fid, struct util_cntr, cntr_fid);
 
@@ -89,7 +89,7 @@ static uint64_t ofi_cntr_readerr(struct fid_cntr *cntr_fid)
 	return ofi_atomic_get64(&cntr->err);
 }
 
-static int ofi_cntr_add(struct fid_cntr *cntr_fid, uint64_t value)
+int ofi_cntr_add(struct fid_cntr *cntr_fid, uint64_t value)
 {
 	struct util_cntr *cntr = container_of(cntr_fid, struct util_cntr, cntr_fid);
 
@@ -102,7 +102,7 @@ static int ofi_cntr_add(struct fid_cntr *cntr_fid, uint64_t value)
 	return FI_SUCCESS;
 }
 
-static int ofi_cntr_adderr(struct fid_cntr *cntr_fid, uint64_t value)
+int ofi_cntr_adderr(struct fid_cntr *cntr_fid, uint64_t value)
 {
 	struct util_cntr *cntr = container_of(cntr_fid, struct util_cntr, cntr_fid);
 
@@ -115,7 +115,7 @@ static int ofi_cntr_adderr(struct fid_cntr *cntr_fid, uint64_t value)
 	return FI_SUCCESS;
 }
 
-static int ofi_cntr_set(struct fid_cntr *cntr_fid, uint64_t value)
+int ofi_cntr_set(struct fid_cntr *cntr_fid, uint64_t value)
 {
 	struct util_cntr *cntr = container_of(cntr_fid, struct util_cntr, cntr_fid);
 
@@ -128,7 +128,7 @@ static int ofi_cntr_set(struct fid_cntr *cntr_fid, uint64_t value)
 	return FI_SUCCESS;
 }
 
-static int ofi_cntr_seterr(struct fid_cntr *cntr_fid, uint64_t value)
+int ofi_cntr_seterr(struct fid_cntr *cntr_fid, uint64_t value)
 {
 	struct util_cntr *cntr = container_of(cntr_fid, struct util_cntr, cntr_fid);
 	assert(cntr->cntr_fid.fid.fclass == FI_CLASS_CNTR);
@@ -140,7 +140,7 @@ static int ofi_cntr_seterr(struct fid_cntr *cntr_fid, uint64_t value)
 	return FI_SUCCESS;
 }
 
-static int ofi_cntr_wait(struct fid_cntr *cntr_fid, uint64_t threshold, int timeout)
+int ofi_cntr_wait(struct fid_cntr *cntr_fid, uint64_t threshold, int timeout)
 {
 	struct util_cntr *cntr;
 	uint64_t endtime, errcnt;


### PR DESCRIPTION
This PR makes efa provider open shm's cntr as a peer cntr, so the cntr completion written by shm provider can be populated to efa's cntr.

Also extended the efa rdm fabtests to cover counter completion type. Before this PR, this test will fail on single node.
