### PR TITLE
fabtests/unexpected_msg: Changes to unexpected_msg test

### DIFF
--- a/fabtests/functional/unexpected_msg.c
+++ b/fabtests/functional/unexpected_msg.c
@@ -70,6 +70,13 @@ static int alloc_bufs(void)
 	if (ret)
 		return ret;
 
+	if (opts.iface != FI_HMEM_SYSTEM) {
+		ret = ft_hmem_alloc_host(opts.iface, &tx_msg_buf,
+					 tx_size * opts.window_size);
+		if (ret)
+			return ret;
+	}
+
 	tx_ctx_arr = calloc(concurrent_msgs, sizeof(*tx_ctx_arr));
 	rx_ctx_arr = calloc(concurrent_msgs, sizeof(*rx_ctx_arr));
 	if (!buf || !tx_ctx_arr || !rx_ctx_arr)

--- a/fabtests/functional/unexpected_msg.c
+++ b/fabtests/functional/unexpected_msg.c
@@ -347,12 +347,15 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, "CM:h" CS_OPTS INFO_OPTS)) != -1) {
+	while ((op = getopt(argc, argv, "vCM:h" CS_OPTS INFO_OPTS)) != -1) {
 		switch (op) {
 		default:
 			ft_parsecsopts(op, optarg, &opts);
 			ft_parse_addr_opts(op, optarg, &opts);
 			ft_parseinfo(op, optarg, hints, &opts);
+			break;
+		case 'v':
+			opts.options |= FT_OPT_VERIFY_DATA;
 			break;
 		case 'C':
 			send_data = true;
@@ -363,6 +366,7 @@ int main(int argc, char **argv)
 		case '?':
 		case 'h':
 			ft_csusage(argv[0], "Unexpected message handling test.");
+			FT_PRINT_OPTS_USAGE("-v", "Enable data verification");
 			FT_PRINT_OPTS_USAGE("-C", "transfer remote CQ data");
 			FT_PRINT_OPTS_USAGE("-M <count>", "number of concurrent msgs");
 			return EXIT_FAILURE;


### PR DESCRIPTION
unexpected_msg test uses the `-v` option but is not a benchmark, so move the `-v` option from benchmark to shared options

Also allocate `tx_msg_buf` which is required for verification when using device buffers