### PR TITLE
[v1.18.x] prov/tcp: fix missing iov truncation on saved message path

### DIFF
--- a/prov/tcp/src/xnet_progress.c
+++ b/prov/tcp/src/xnet_progress.c
@@ -272,6 +272,9 @@ void xnet_recv_saved(struct xnet_xfer_entry *saved_entry,
 		done_len = msg_len - ep->cur_rx.data_left;
 		assert(msg_len && ep->cur_rx.data_left);
 
+		(void) ofi_truncate_iov(&saved_entry->iov[0],
+				        &saved_entry->iov_cnt, msg_len);
+
 		copy_len = ofi_copy_iov_buf(saved_entry->iov,
 					    saved_entry->iov_cnt, 0, msg_data,
 					    done_len, OFI_COPY_BUF_TO_IOV);


### PR DESCRIPTION
Commit 489d7804cf78fe2cd6fe119aff595df5b8b8659c added truncation handling in the saved message path but removed the iov truncation of the rx entry iov. This caused erroneous truncation errors when a receive was posted that was larger than the matched send because too much data would be read off the socket, corrupting the tcp stream relative to the receiver.

This fixes a sporadic failure in the fi_rdm_tagged_bw test

Cherry-picked from commit 67cf6d97e49f570e77ac86ac148f893ca486a537