### PR TITLE
prov/shm: remove shm signal

### DIFF
--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -54,7 +54,7 @@ extern "C" {
 #endif
 
 
-#define SMR_VERSION	4
+#define SMR_VERSION	5
 
 #define SMR_FLAG_ATOMIC	(1 << 0)
 #define SMR_FLAG_DEBUG	(1 << 1)
@@ -229,7 +229,6 @@ struct smr_region {
 				 if both ep->tx_lock and this lock need to
 				 held, then ep->tx_lock needs to be held
 				 first */
-	ofi_atomic32_t	signal;
 
 	struct smr_map	*map;
 
@@ -359,11 +358,6 @@ struct smr_region *smr_map_get(struct smr_map *map, int64_t id);
 int	smr_create(const struct fi_provider *prov, struct smr_map *map,
 		   const struct smr_attr *attr, struct smr_region *volatile *smr);
 void	smr_free(struct smr_region *smr);
-
-static inline void smr_signal(struct smr_region *smr)
-{
-	ofi_atomic_set32(&smr->signal, 1);
-}
 
 #ifdef __cplusplus
 }

--- a/prov/shm/src/smr_dsa.c
+++ b/prov/shm/src/smr_dsa.c
@@ -477,8 +477,6 @@ static void smr_dsa_copy_sar(struct smr_freestack *sar_pool,
 	dsa_cmd_context->bytes_in_progress = dsa_bytes_pending;
 	dsa_context->copy_type_stats[dsa_cmd_context->dir]++;
 	dsa_cmd_context->op = cmd->msg.hdr.op;
-
-	smr_signal(region);
 }
 
 static void dsa_handle_page_fault(struct dsa_completion_record *comp)
@@ -551,7 +549,6 @@ static void dsa_update_tx_entry(struct smr_region *smr,
 	assert(resp->status == SMR_STATUS_BUSY);
 	resp->status = (dsa_cmd_context->dir == OFI_COPY_IOV_TO_BUF ?
 			SMR_STATUS_SAR_READY : SMR_STATUS_SAR_FREE);
-	smr_signal(peer_smr);
 }
 
 static void dsa_update_sar_entry(struct smr_region *smr,
@@ -570,8 +567,6 @@ static void dsa_update_sar_entry(struct smr_region *smr,
 	assert(resp->status == SMR_STATUS_BUSY);
 	resp->status = (dsa_cmd_context->dir == OFI_COPY_IOV_TO_BUF ?
 			SMR_STATUS_SAR_READY : SMR_STATUS_SAR_FREE);
-
-	smr_signal(peer_smr);
 }
 
 static void dsa_process_complete_work(struct smr_region *smr,
@@ -754,8 +749,6 @@ void smr_dsa_progress(struct smr_ep *ep)
 			dsa_process_complete_work(ep->region, dsa_cmd_context,
 					      dsa_context);
 	}
-	// Always signal the self to complete dsa, tx or rx.
-	smr_signal(ep->region);
 	pthread_spin_unlock(&ep->region->lock);
 }
 

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -206,7 +206,6 @@ static void smr_send_name(struct smr_ep *ep, int64_t id)
 
 	smr_peer_data(ep->region)[id].name_sent = 1;
 	smr_cmd_queue_commit(ce, pos);
-	smr_signal(peer_smr);
 }
 
 int64_t smr_verify_peer(struct smr_ep *ep, fi_addr_t fi_addr)

--- a/prov/util/src/util_shm.c
+++ b/prov/util/src/util_shm.c
@@ -270,7 +270,6 @@ int smr_create(const struct fi_provider *prov, struct smr_map *map,
 
 	*smr = mapped_addr;
 	smr_lock_init(&(*smr)->lock);
-	ofi_atomic_initialize32(&(*smr)->signal, 0);
 
 	(*smr)->map = map;
 	(*smr)->version = SMR_VERSION;


### PR DESCRIPTION
The signal was originally added to reduce locking contention in the shared memory region. Now that the command queue uses atomics instead of locking, the signal adds redunancy and extra atomics. Removing it improves performance.

Requires bumping the shm version