### PR TITLE
prov/tcp: Add locking to trywait path for potential data race

### DIFF
--- a/prov/tcp/src/xnet.h
+++ b/prov/tcp/src/xnet.h
@@ -310,7 +310,7 @@ struct xnet_uring {
  */
 struct xnet_progress {
 	struct fid		fid;
-	struct ofi_genlock	lock;
+	struct ofi_genlock	ep_lock;
 	struct ofi_genlock	rdm_lock;
 	struct ofi_genlock	*active_lock;
 

--- a/prov/tcp/src/xnet_domain.c
+++ b/prov/tcp/src/xnet_domain.c
@@ -46,9 +46,9 @@ static int xnet_mr_close(struct fid *fid)
 	domain = container_of(&mr->domain->domain_fid, struct xnet_domain,
 			      util_domain.domain_fid.fid);
 
-	ofi_genlock_lock(&domain->progress.lock);
+	ofi_genlock_lock(domain->progress.active_lock);
 	ret = ofi_mr_close(fid);
-	ofi_genlock_unlock(&domain->progress.lock);
+	ofi_genlock_unlock(domain->progress.active_lock);
 	return ret;
 }
 
@@ -71,10 +71,10 @@ xnet_mr_reg(struct fid *fid, const void *buf, size_t len,
 
 	domain = container_of(fid, struct xnet_domain,
 			      util_domain.domain_fid.fid);
-	ofi_genlock_lock(&domain->progress.lock);
+	ofi_genlock_lock(domain->progress.active_lock);
 	ret = ofi_mr_reg(fid, buf, len, access, offset, requested_key, flags,
 			 mr_fid, context);
-	ofi_genlock_unlock(&domain->progress.lock);
+	ofi_genlock_unlock(domain->progress.active_lock);
 
 	if (!ret) {
 		mr = container_of(*mr_fid, struct ofi_mr, mr_fid.fid);
@@ -95,10 +95,10 @@ xnet_mr_regv(struct fid *fid, const struct iovec *iov,
 
 	domain = container_of(fid, struct xnet_domain,
 			      util_domain.domain_fid.fid);
-	ofi_genlock_lock(&domain->progress.lock);
+	ofi_genlock_lock(domain->progress.active_lock);
 	ret = ofi_mr_regv(fid, iov, count, access, offset, requested_key, flags,
 			 mr_fid, context);
-	ofi_genlock_unlock(&domain->progress.lock);
+	ofi_genlock_unlock(domain->progress.active_lock);
 
 	if (!ret) {
 		mr = container_of(*mr_fid, struct ofi_mr, mr_fid.fid);
@@ -117,9 +117,9 @@ xnet_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 
 	domain = container_of(fid, struct xnet_domain,
 			      util_domain.domain_fid.fid);
-	ofi_genlock_lock(&domain->progress.lock);
+	ofi_genlock_lock(domain->progress.active_lock);
 	ret = ofi_mr_regattr(fid, attr, flags, mr_fid);
-	ofi_genlock_unlock(&domain->progress.lock);
+	ofi_genlock_unlock(domain->progress.active_lock);
 
 	if (!ret) {
 		mr = container_of(*mr_fid, struct ofi_mr, mr_fid.fid);

--- a/prov/tcp/src/xnet_msg.c
+++ b/prov/tcp/src/xnet_msg.c
@@ -177,7 +177,7 @@ xnet_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t flags)
 
 	assert(msg->iov_count <= XNET_IOV_LIMIT);
 
-	ofi_genlock_lock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_lock(&xnet_ep2_progress(ep)->ep_lock);
 	recv_entry = xnet_alloc_rx(ep);
 	if (!recv_entry) {
 		ret = -FI_EAGAIN;
@@ -199,7 +199,7 @@ xnet_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t flags)
 		ret = -FI_EAGAIN;
 	}
 unlock:
-	ofi_genlock_unlock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_unlock(&xnet_ep2_progress(ep)->ep_lock);
 	return ret;
 }
 
@@ -213,7 +213,7 @@ xnet_recv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 
 	ep = container_of(ep_fid, struct xnet_ep, util_ep.ep_fid);
 
-	ofi_genlock_lock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_lock(&xnet_ep2_progress(ep)->ep_lock);
 	recv_entry = xnet_alloc_rx(ep);
 	if (!recv_entry) {
 		ret = -FI_EAGAIN;
@@ -233,7 +233,7 @@ xnet_recv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 		ret = -FI_EAGAIN;
 	}
 unlock:
-	ofi_genlock_unlock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_unlock(&xnet_ep2_progress(ep)->ep_lock);
 	return ret;
 }
 
@@ -249,7 +249,7 @@ xnet_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 
 	assert(count <= XNET_IOV_LIMIT);
 
-	ofi_genlock_lock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_lock(&xnet_ep2_progress(ep)->ep_lock);
 	recv_entry = xnet_alloc_rx(ep);
 	if (!recv_entry) {
 		ret = -FI_EAGAIN;
@@ -269,7 +269,7 @@ xnet_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 		ret = -FI_EAGAIN;
 	}
 unlock:
-	ofi_genlock_unlock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_unlock(&xnet_ep2_progress(ep)->ep_lock);
 	return ret;
 }
 
@@ -283,7 +283,7 @@ xnet_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t flags)
 
 	ep = container_of(ep_fid, struct xnet_ep, util_ep.ep_fid);
 
-	ofi_genlock_lock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_lock(&xnet_ep2_progress(ep)->ep_lock);
 	tx_entry = xnet_alloc_send(ep);
 	if (!tx_entry) {
 		ret = -FI_EAGAIN;
@@ -306,7 +306,7 @@ xnet_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t flags)
 
 	xnet_tx_queue_insert(ep, tx_entry);
 unlock:
-	ofi_genlock_unlock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_unlock(&xnet_ep2_progress(ep)->ep_lock);
 	return ret;
 }
 
@@ -320,7 +320,7 @@ xnet_send(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	ep = container_of(ep_fid, struct xnet_ep, util_ep.ep_fid);
 
-	ofi_genlock_lock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_lock(&xnet_ep2_progress(ep)->ep_lock);
 	tx_entry = xnet_alloc_send(ep);
 	if (!tx_entry) {
 		ret = -FI_EAGAIN;
@@ -335,7 +335,7 @@ xnet_send(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	xnet_tx_queue_insert(ep, tx_entry);
 unlock:
-	ofi_genlock_unlock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_unlock(&xnet_ep2_progress(ep)->ep_lock);
 	return ret;
 }
 
@@ -349,7 +349,7 @@ xnet_sendv(struct fid_ep *ep_fid, const struct iovec *iov,
 
 	ep = container_of(ep_fid, struct xnet_ep, util_ep.ep_fid);
 
-	ofi_genlock_lock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_lock(&xnet_ep2_progress(ep)->ep_lock);
 	tx_entry = xnet_alloc_send(ep);
 	if (!tx_entry) {
 		ret = -FI_EAGAIN;
@@ -364,7 +364,7 @@ xnet_sendv(struct fid_ep *ep_fid, const struct iovec *iov,
 
 	xnet_tx_queue_insert(ep, tx_entry);
 unlock:
-	ofi_genlock_unlock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_unlock(&xnet_ep2_progress(ep)->ep_lock);
 	return ret;
 }
 
@@ -379,7 +379,7 @@ xnet_inject(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	ep = container_of(ep_fid, struct xnet_ep, util_ep.ep_fid);
 
-	ofi_genlock_lock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_lock(&xnet_ep2_progress(ep)->ep_lock);
 	tx_entry = xnet_alloc_send(ep);
 	if (!tx_entry) {
 		ret = -FI_EAGAIN;
@@ -392,7 +392,7 @@ xnet_inject(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	xnet_tx_queue_insert(ep, tx_entry);
 unlock:
-	ofi_genlock_unlock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_unlock(&xnet_ep2_progress(ep)->ep_lock);
 	return ret;
 }
 
@@ -406,7 +406,7 @@ xnet_senddata(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	ep = container_of(ep_fid, struct xnet_ep, util_ep.ep_fid);
 
-	ofi_genlock_lock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_lock(&xnet_ep2_progress(ep)->ep_lock);
 	tx_entry = xnet_alloc_send(ep);
 	if (!tx_entry) {
 		ret = -FI_EAGAIN;
@@ -427,7 +427,7 @@ xnet_senddata(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	xnet_tx_queue_insert(ep, tx_entry);
 unlock:
-	ofi_genlock_unlock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_unlock(&xnet_ep2_progress(ep)->ep_lock);
 	return ret;
 }
 
@@ -441,7 +441,7 @@ xnet_injectdata(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	ep = container_of(ep_fid, struct xnet_ep, util_ep.ep_fid);
 
-	ofi_genlock_lock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_lock(&xnet_ep2_progress(ep)->ep_lock);
 	tx_entry = xnet_alloc_send(ep);
 	if (!tx_entry) {
 		ret = -FI_EAGAIN;
@@ -458,7 +458,7 @@ xnet_injectdata(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	xnet_tx_queue_insert(ep, tx_entry);
 unlock:
-	ofi_genlock_unlock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_unlock(&xnet_ep2_progress(ep)->ep_lock);
 	return ret;
 }
 
@@ -486,7 +486,7 @@ xnet_tsendmsg(struct fid_ep *fid_ep, const struct fi_msg_tagged *msg,
 
 	ep = container_of(fid_ep, struct xnet_ep, util_ep.ep_fid);
 
-	ofi_genlock_lock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_lock(&xnet_ep2_progress(ep)->ep_lock);
 	tx_entry = xnet_alloc_tsend(ep);
 	if (!tx_entry) {
 		ret = -FI_EAGAIN;
@@ -511,7 +511,7 @@ xnet_tsendmsg(struct fid_ep *fid_ep, const struct fi_msg_tagged *msg,
 
 	xnet_tx_queue_insert(ep, tx_entry);
 unlock:
-	ofi_genlock_unlock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_unlock(&xnet_ep2_progress(ep)->ep_lock);
 	return ret;
 }
 
@@ -525,7 +525,7 @@ xnet_tsend(struct fid_ep *fid_ep, const void *buf, size_t len,
 
 	ep = container_of(fid_ep, struct xnet_ep, util_ep.ep_fid);
 
-	ofi_genlock_lock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_lock(&xnet_ep2_progress(ep)->ep_lock);
 	tx_entry = xnet_alloc_tsend(ep);
 	if (!tx_entry) {
 		ret = -FI_EAGAIN;
@@ -542,7 +542,7 @@ xnet_tsend(struct fid_ep *fid_ep, const void *buf, size_t len,
 
 	xnet_tx_queue_insert(ep, tx_entry);
 unlock:
-	ofi_genlock_unlock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_unlock(&xnet_ep2_progress(ep)->ep_lock);
 	return ret;
 }
 
@@ -556,7 +556,7 @@ xnet_tsendv(struct fid_ep *fid_ep, const struct iovec *iov, void **desc,
 
 	ep = container_of(fid_ep, struct xnet_ep, util_ep.ep_fid);
 
-	ofi_genlock_lock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_lock(&xnet_ep2_progress(ep)->ep_lock);
 	tx_entry = xnet_alloc_tsend(ep);
 	if (!tx_entry) {
 		ret = -FI_EAGAIN;
@@ -573,7 +573,7 @@ xnet_tsendv(struct fid_ep *fid_ep, const struct iovec *iov, void **desc,
 
 	xnet_tx_queue_insert(ep, tx_entry);
 unlock:
-	ofi_genlock_unlock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_unlock(&xnet_ep2_progress(ep)->ep_lock);
 	return ret;
 }
 
@@ -588,7 +588,7 @@ xnet_tinject(struct fid_ep *fid_ep, const void *buf, size_t len,
 
 	ep = container_of(fid_ep, struct xnet_ep, util_ep.ep_fid);
 
-	ofi_genlock_lock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_lock(&xnet_ep2_progress(ep)->ep_lock);
 	tx_entry = xnet_alloc_tsend(ep);
 	if (!tx_entry) {
 		ret = -FI_EAGAIN;
@@ -603,7 +603,7 @@ xnet_tinject(struct fid_ep *fid_ep, const void *buf, size_t len,
 
 	xnet_tx_queue_insert(ep, tx_entry);
 unlock:
-	ofi_genlock_unlock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_unlock(&xnet_ep2_progress(ep)->ep_lock);
 	return ret;
 }
 
@@ -617,7 +617,7 @@ xnet_tsenddata(struct fid_ep *fid_ep, const void *buf, size_t len, void *desc,
 
 	ep = container_of(fid_ep, struct xnet_ep, util_ep.ep_fid);
 
-	ofi_genlock_lock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_lock(&xnet_ep2_progress(ep)->ep_lock);
 	tx_entry = xnet_alloc_tsend(ep);
 	if (!tx_entry) {
 		ret = -FI_EAGAIN;
@@ -637,7 +637,7 @@ xnet_tsenddata(struct fid_ep *fid_ep, const void *buf, size_t len, void *desc,
 
 	xnet_tx_queue_insert(ep, tx_entry);
 unlock:
-	ofi_genlock_unlock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_unlock(&xnet_ep2_progress(ep)->ep_lock);
 	return ret;
 }
 
@@ -651,7 +651,7 @@ xnet_tinjectdata(struct fid_ep *fid_ep, const void *buf, size_t len,
 
 	ep = container_of(fid_ep, struct xnet_ep, util_ep.ep_fid);
 
-	ofi_genlock_lock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_lock(&xnet_ep2_progress(ep)->ep_lock);
 	tx_entry = xnet_alloc_tsend(ep);
 	if (!tx_entry) {
 		ret = -FI_EAGAIN;
@@ -669,7 +669,7 @@ xnet_tinjectdata(struct fid_ep *fid_ep, const void *buf, size_t len,
 
 	xnet_tx_queue_insert(ep, tx_entry);
 unlock:
-	ofi_genlock_unlock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_unlock(&xnet_ep2_progress(ep)->ep_lock);
 	return ret;
 }
 

--- a/prov/tcp/src/xnet_pep.c
+++ b/prov/tcp/src/xnet_pep.c
@@ -53,7 +53,7 @@ static int xnet_pep_close(struct fid *fid)
 	 */
 
 	if (pep->state == XNET_LISTENING) {
-		ofi_genlock_lock(&pep->progress->lock);
+		ofi_genlock_lock(&pep->progress->ep_lock);
 		if (xnet_io_uring) {
 			ret = xnet_uring_cancel(pep->progress,
 						&pep->progress->rx_uring,
@@ -63,7 +63,7 @@ static int xnet_pep_close(struct fid *fid)
 			xnet_halt_sock(pep->progress, pep->sock);
 			ret = 0;
 		}
-		ofi_genlock_unlock(&pep->progress->lock);
+		ofi_genlock_unlock(&pep->progress->ep_lock);
 		if (ret)
 			return ret;
 	}
@@ -251,7 +251,7 @@ int xnet_listen(struct xnet_pep *pep, struct xnet_progress *progress)
 		return -ofi_sockerr();
 	}
 
-	ofi_genlock_lock(&progress->lock);
+	ofi_genlock_lock(&progress->ep_lock);
 	if (xnet_io_uring) {
 		ret = xnet_uring_pollin_add(progress, pep->sock, true,
 					    &pep->pollin_sockctx);
@@ -264,7 +264,7 @@ int xnet_listen(struct xnet_pep *pep, struct xnet_progress *progress)
 		pep->progress = progress;
 		pep->state = XNET_LISTENING;
 	}
-	ofi_genlock_unlock(&progress->lock);
+	ofi_genlock_unlock(&progress->ep_lock);
 
 	return ret;
 }

--- a/prov/tcp/src/xnet_progress.c
+++ b/prov/tcp/src/xnet_progress.c
@@ -1463,50 +1463,58 @@ static void xnet_reset_wait(struct util_wait *wait)
  */
 int xnet_trywait(struct fid_fabric *fabric_fid, struct fid **fid, int count)
 {
-	struct util_cq *cq;
+	struct xnet_cq *cq;
 	struct xnet_eq *eq;
 	struct util_cntr *cntr;
 	struct util_wait *wait;
-	int ret, i;
+	int ret = 0, i;
 
-	for (i = 0; i < count; i++) {
+	for (i = 0; i < count && !ret; i++) {
 		switch (fid[i]->fclass) {
 		case FI_CLASS_CQ:
-			cq = container_of(fid[i], struct util_cq, cq_fid.fid);
-			if (!ofi_cirque_isempty(cq->cirq))
-				return -FI_EAGAIN;
-
-			xnet_reset_wait(cq->wait);
+			cq = container_of(fid[i], struct xnet_cq,
+					  util_cq.cq_fid.fid);
+			ofi_genlock_lock(xnet_cq2_progress(cq)->active_lock);
+			if (ofi_cirque_isempty(cq->util_cq.cirq))
+				xnet_reset_wait(cq->util_cq.wait);
+			else
+				ret = -FI_EAGAIN;
+			ofi_genlock_unlock(xnet_cq2_progress(cq)->active_lock);
 			break;
 		case FI_CLASS_EQ:
 			eq = container_of(fid[i], struct xnet_eq,
 					  util_eq.eq_fid.fid);
+			ofi_mutex_lock(&eq->util_eq.lock);
 			if (!slist_empty(&eq->util_eq.list))
-				return -FI_EAGAIN;
-
-			xnet_reset_wait(eq->util_eq.wait);
+				ret = -FI_EAGAIN;
+			ofi_mutex_unlock(&eq->util_eq.lock);
+			if (!ret)
+				xnet_reset_wait(eq->util_eq.wait);
 			break;
 		case FI_CLASS_CNTR:
 			/* The user must read the counter before and after
 			 * fi_trywait and compare the results to ensure that no
 			 * events were lost.
 			 */
-			cntr = container_of(fid[i], struct util_cntr, cntr_fid.fid);
+			cntr = container_of(fid[i], struct util_cntr,
+					    cntr_fid.fid);
+			ofi_genlock_lock(xnet_cntr2_progress(cntr)->active_lock);
 			xnet_reset_wait(cntr->wait);
+			ofi_genlock_unlock(xnet_cntr2_progress(cntr)->active_lock);
 			break;
 		case FI_CLASS_WAIT:
-			wait = container_of(fid[i], struct util_wait, wait_fid.fid);
+			wait = container_of(fid[i], struct util_wait,
+					    wait_fid.fid);
 			ret = wait->wait_try(wait);
-			if (ret)
-				return ret;
 			break;
 		default:
-			return -FI_ENOSYS;
+			ret = -FI_ENOSYS;
+			break;
 		}
 
 	}
 
-	return 0;
+	return ret;
 }
 
 /* We can't hold the progress lock around waiting, or we

--- a/prov/tcp/src/xnet_progress.c
+++ b/prov/tcp/src/xnet_progress.c
@@ -1645,16 +1645,16 @@ static int xnet_init_locks(struct xnet_progress *progress, struct fi_info *info)
 	} else {
 		base_type = OFI_LOCK_MUTEX;
 		rdm_type = OFI_LOCK_NONE;
-		progress->active_lock = &progress->lock;
+		progress->active_lock = &progress->ep_lock;
 	}
 
-	ret = ofi_genlock_init(&progress->lock, base_type);
+	ret = ofi_genlock_init(&progress->ep_lock, base_type);
 	if (ret)
 		return ret;
 
 	ret = ofi_genlock_init(&progress->rdm_lock, rdm_type);
 	if (ret)
-		ofi_genlock_destroy(&progress->lock);
+		ofi_genlock_destroy(&progress->ep_lock);
 
 	return ret;
 }
@@ -1773,7 +1773,7 @@ err3:
 	ofi_dynpoll_close(&progress->epoll_fd);
 err2:
 	ofi_genlock_destroy(&progress->rdm_lock);
-	ofi_genlock_destroy(&progress->lock);
+	ofi_genlock_destroy(&progress->ep_lock);
 err1:
 	fd_signal_free(&progress->signal);
 	return ret;
@@ -1793,7 +1793,7 @@ void xnet_close_progress(struct xnet_progress *progress)
 	}
 	ofi_dynpoll_close(&progress->epoll_fd);
 	ofi_bufpool_destroy(progress->xfer_pool);
-	ofi_genlock_destroy(&progress->lock);
+	ofi_genlock_destroy(&progress->ep_lock);
 	ofi_genlock_destroy(&progress->rdm_lock);
 	fd_signal_free(&progress->signal);
 }

--- a/prov/tcp/src/xnet_rma.c
+++ b/prov/tcp/src/xnet_rma.c
@@ -120,7 +120,7 @@ xnet_rma_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 	assert(ofi_total_iov_len(msg->msg_iov, msg->iov_count) ==
 	       ofi_total_rma_iov_len(msg->rma_iov, msg->rma_iov_count));
 
-	ofi_genlock_lock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_lock(&xnet_ep2_progress(ep)->ep_lock);
 	send_entry = xnet_alloc_tx(ep);
 	if (!send_entry) {
 		ret = -FI_EAGAIN;
@@ -139,7 +139,7 @@ xnet_rma_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 	slist_insert_tail(&recv_entry->entry, &ep->rma_read_queue);
 	xnet_tx_queue_insert(ep, send_entry);
 unlock:
-	ofi_genlock_unlock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_unlock(&xnet_ep2_progress(ep)->ep_lock);
 	return ret;
 }
 
@@ -207,7 +207,7 @@ xnet_rma_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 
 	ep = container_of(ep_fid, struct xnet_ep, util_ep.ep_fid);
 
-	ofi_genlock_lock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_lock(&xnet_ep2_progress(ep)->ep_lock);
 	send_entry = xnet_alloc_tx(ep);
 	if (!send_entry) {
 		ret = -FI_EAGAIN;
@@ -266,7 +266,7 @@ xnet_rma_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 
 	xnet_tx_queue_insert(ep, send_entry);
 unlock:
-	ofi_genlock_unlock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_unlock(&xnet_ep2_progress(ep)->ep_lock);
 	return ret;
 }
 
@@ -364,7 +364,7 @@ xnet_rma_inject_common(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	ep = container_of(ep_fid, struct xnet_ep, util_ep.ep_fid);
 
-	ofi_genlock_lock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_lock(&xnet_ep2_progress(ep)->ep_lock);
 	send_entry = xnet_alloc_tx(ep);
 	if (!send_entry) {
 		ret = -FI_EAGAIN;
@@ -403,7 +403,7 @@ xnet_rma_inject_common(struct fid_ep *ep_fid, const void *buf, size_t len,
 	send_entry->cntr = ep->util_ep.cntrs[CNTR_WR];
 	xnet_tx_queue_insert(ep, send_entry);
 unlock:
-	ofi_genlock_unlock(&xnet_ep2_progress(ep)->lock);
+	ofi_genlock_unlock(&xnet_ep2_progress(ep)->ep_lock);
 	return ret;
 }
 


### PR DESCRIPTION
Problems reported by thread sanitizer.  There is no locking around checking the CQ or EQ for being empty.  It's unclear if the locking is technically needed, but safer to add given the code is not in a fast path (prior to the app making a blocking call).

Note that with the change, the lock used by the CQ and cntr signaling fd is not technically needed, as the progress lock protects the entire operation.  Removal of the lock is deferred for subsequent patches, as the EQ locking requires further investigation (in order to remove).

Fixes #9148