### PR TITLE
prov/util: Fix the coverify scan defects

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -328,6 +328,7 @@ ofi_ep_fid_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 
 static inline void ofi_ep_cntr_inc(struct util_ep *ep, enum ofi_cntr_index index)
 {
+	assert(index < CNTR_CNT);
 	ep->cntr_inc_funcs[index](ep->cntrs[index]);
 }
 
@@ -776,6 +777,7 @@ static inline void ofi_ep_peer_tx_cntr_inc(struct util_ep *ep, uint8_t op)
 	int cntr_index;
 
 	cntr_index = ofi_get_cntr_index_from_tx_op(op);
+	assert(cntr_index < CNTR_CNT);
 	cntr = ep->cntrs[cntr_index];
 	if (cntr)
 		cntr->peer_cntr->owner_ops->inc(cntr->peer_cntr);
@@ -787,6 +789,7 @@ static inline void ofi_ep_peer_tx_cntr_incerr(struct util_ep *ep, uint8_t op)
 	int cntr_index;
 
 	cntr_index = ofi_get_cntr_index_from_tx_op(op);
+	assert(cntr_index < CNTR_CNT);
 	cntr = ep->cntrs[cntr_index];
 	if (cntr)
 		cntr->peer_cntr->owner_ops->incerr(cntr->peer_cntr);
@@ -798,6 +801,7 @@ static inline void ofi_ep_peer_rx_cntr_inc(struct util_ep *ep, uint8_t op)
 	int cntr_index;
 
 	cntr_index = ofi_get_cntr_index_from_rx_op(op);
+	assert(cntr_index < CNTR_CNT);
 	cntr = ep->cntrs[cntr_index];
 	if (cntr)
 		cntr->peer_cntr->owner_ops->inc(cntr->peer_cntr);
@@ -809,6 +813,7 @@ static inline void ofi_ep_peer_rx_cntr_incerr(struct util_ep *ep, uint8_t op)
 	int cntr_index;
 
 	cntr_index = ofi_get_cntr_index_from_rx_op(op);
+	assert(cntr_index < CNTR_CNT);
 	cntr = ep->cntrs[cntr_index];
 	if (cntr)
 		cntr->peer_cntr->owner_ops->incerr(cntr->peer_cntr);


### PR DESCRIPTION
Add assert for the cntr_index to make sure
it is smaller than the CNTR_CNT

Related coverity scan defects

```
** CID 395887:  Memory - illegal accesses  (OVERRUN)
/include/ofi_util.h: 779 in ofi_ep_peer_tx_cntr_inc()


________________________________________________________________________________________________________
*** CID 395887:  Memory - illegal accesses  (OVERRUN)
/include/ofi_util.h: 779 in ofi_ep_peer_tx_cntr_inc()
773     static inline void ofi_ep_peer_tx_cntr_inc(struct util_ep *ep, uint8_t op)
774     {
775             struct util_cntr *cntr;
776             int cntr_index;
777
778             cntr_index = ofi_get_cntr_index_from_tx_op(op);
>>>     CID 395887:  Memory - illegal accesses  (OVERRUN)
>>>     Overrunning array "ep->cntrs" of 6 8-byte elements at element index 6 (byte offset 55) using index "cntr_index" (which evaluates to 6).
779             cntr = ep->cntrs[cntr_index];
780             if (cntr)
781                     cntr->peer_cntr->owner_ops->inc(cntr->peer_cntr);
782     }
783
784     static inline void ofi_ep_peer_tx_cntr_incerr(struct util_ep *ep, uint8_t op)

** CID 395886:  Memory - illegal accesses  (OVERRUN)
/include/ofi_util.h: 801 in ofi_ep_peer_rx_cntr_inc()

```