### PR TITLE
prov/verbs: Add additional checks to vrb_shutdown_qp_in_err

### DIFF
--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -226,7 +226,7 @@ int vrb_poll_cq(struct vrb_cq *cq, struct ibv_wc *wc)
 
 		ctx = (struct vrb_context *) (uintptr_t) wc->wr_id;
 		wc->wr_id = (uintptr_t) ctx->user_ctx;
-		if (wc->status != IBV_WC_SUCCESS)
+		if (wc->status != IBV_WC_SUCCESS && wc->status != IBV_WC_WR_FLUSH_ERR)
 			vrb_shutdown_qp_in_err(ctx->ep);
 		if (ctx->op_queue == VRB_OP_SQ) {
 			ep = ctx->ep;

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -125,7 +125,8 @@ void vrb_shutdown_qp_in_err(struct vrb_ep *ep)
 
 	memset(&attr, 0, sizeof(attr));
 	memset(&init_attr, 0, sizeof(init_attr));
-	ibv_query_qp(ep->ibv_qp, &attr, IBV_QP_STATE, &init_attr);
+	if (ibv_query_qp(ep->ibv_qp, &attr, IBV_QP_STATE, &init_attr))
+		return;
 	if (attr.cur_qp_state != IBV_QPS_ERR)
 		return;
 


### PR DESCRIPTION
Flushed CQEs would come ether after the CQE for the op that caused the QP tranition or in QP destrouction.  There is no need to check with flushed CQEs.

Add missing return code check for ibv_query_qp.