### PR TITLE
prov/sm2: Replace FI_REMOTE_READ op flag with  SM2_RMA_REQ proto flag

### DIFF
--- a/prov/sm2/src/sm2.h
+++ b/prov/sm2/src/sm2.h
@@ -95,6 +95,9 @@ enum {
 	sm2_proto_max,
 };
 
+/* Protocol flags */
+#define SM2_RMA_REQ (1 << 1)
+
 /*
  * 	next - fifo linked list next ptr
  * 		This is volatile for a reason, many things touch this

--- a/prov/sm2/src/sm2_atomic.c
+++ b/prov/sm2/src/sm2_atomic.c
@@ -99,7 +99,7 @@ sm2_do_atomic_inject(struct sm2_ep *ep, int64_t peer_gid, uint32_t op,
 		     const struct fi_rma_ioc *rma_ioc, size_t rma_ioc_count,
 		     const struct iovec *compare_iov, size_t compare_count,
 		     const struct iovec *result_iov, size_t result_count,
-		     size_t total_len, void *context)
+		     size_t total_len, void *context, uint16_t proto_flags)
 {
 	struct sm2_xfer_entry *xfer_entry;
 	size_t ret;
@@ -111,6 +111,8 @@ sm2_do_atomic_inject(struct sm2_ep *ep, int64_t peer_gid, uint32_t op,
 	xfer_entry->hdr.proto = sm2_proto_inject;
 
 	sm2_generic_format(xfer_entry, ep->gid, op, 0, 0, op_flags, context);
+	xfer_entry->hdr.proto_flags |= proto_flags;
+
 	sm2_atomic_format(xfer_entry, datatype, atomic_op, rma_ioc,
 			  rma_ioc_count, result_iov, result_count, iov,
 			  iov_count, compare_iov, compare_count);
@@ -132,6 +134,7 @@ static inline ssize_t sm2_generic_atomic(
 	struct iovec result_iov[SM2_IOV_LIMIT];
 	sm2_gid_t peer_gid;
 	ssize_t ret = 0;
+	uint16_t proto_flags = 0;
 	size_t total_len;
 
 	assert(iov_count <= SM2_IOV_LIMIT);
@@ -157,7 +160,7 @@ static inline ssize_t sm2_generic_atomic(
 		assert(result_ioc);
 		ofi_ioc_to_iov(result_ioc, result_iov, result_count,
 			       ofi_datatype_size(datatype));
-		op_flags |= FI_REMOTE_READ;
+		proto_flags |= SM2_RMA_REQ;
 		op_flags |= FI_DELIVERY_COMPLETE;
 		/* fall through */
 	case ofi_op_atomic:
@@ -179,12 +182,12 @@ static inline ssize_t sm2_generic_atomic(
 	ret = sm2_do_atomic_inject(
 		ep, peer_gid, op, op_flags, datatype, atomic_op, iov, iov_count,
 		rma_ioc, rma_ioc_count, compare_iov, compare_count, result_iov,
-		result_count, total_len, context);
+		result_count, total_len, context, proto_flags);
 
 	if (ret)
 		goto out;
 
-	if (!(op_flags & FI_REMOTE_READ) &&
+	if (!(proto_flags & SM2_RMA_REQ) &&
 	    !(op_flags & FI_DELIVERY_COMPLETE)) {
 		ret = sm2_complete_tx(ep, context, op, op_flags);
 		if (ret)
@@ -289,7 +292,7 @@ static ssize_t sm2_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 
 	ret = sm2_do_atomic_inject(ep, peer_gid, ofi_op_atomic, 0, datatype,
 				   atomic_op, &iov, 1, &rma_ioc, 1, NULL, 0,
-				   NULL, 0, total_len, 0);
+				   NULL, 0, total_len, 0, 0);
 
 	if (!ret)
 		ofi_ep_peer_tx_cntr_inc(&ep->util_ep, ofi_op_atomic);

--- a/prov/sm2/src/sm2_progress.c
+++ b/prov/sm2/src/sm2_progress.c
@@ -204,14 +204,14 @@ out:
 
 static void sm2_do_atomic(void *src, void *dst, void *cmp,
 			  enum fi_datatype datatype, enum fi_op op, size_t cnt,
-			  uint32_t op_flags)
+			  uint16_t proto_flags)
 {
 	char tmp_result[SM2_ATOMIC_INJECT_SIZE];
 
 	if (ofi_atomic_isswap_op(op)) {
 		ofi_atomic_swap_handler(op, datatype, dst, src, cmp, tmp_result,
 					cnt);
-	} else if (op_flags & FI_REMOTE_READ && ofi_atomic_isreadwrite_op(op)) {
+	} else if (proto_flags & SM2_RMA_REQ && ofi_atomic_isreadwrite_op(op)) {
 		ofi_atomic_readwrite_handler(op, datatype, dst, src, tmp_result,
 					     cnt);
 	} else if (ofi_atomic_iswrite_op(op)) {
@@ -221,7 +221,7 @@ static void sm2_do_atomic(void *src, void *dst, void *cmp,
 			"invalid atomic operation\n");
 	}
 
-	if (op_flags & FI_REMOTE_READ)
+	if (proto_flags & SM2_RMA_REQ)
 		memcpy(src, op == FI_ATOMIC_READ ? dst : tmp_result,
 		       cnt * ofi_datatype_size(datatype));
 }
@@ -251,7 +251,7 @@ static int sm2_progress_inject_atomic(struct sm2_xfer_entry *xfer_entry,
 			      comp ? &comp[*len] : NULL,
 			      atomic_entry->atomic_hdr.datatype,
 			      atomic_entry->atomic_hdr.atomic_op, ioc[i].count,
-			      xfer_entry->hdr.op_flags);
+			      xfer_entry->hdr.proto_flags);
 		*len += ioc[i].count *
 			ofi_datatype_size(atomic_entry->atomic_hdr.datatype);
 	}
@@ -341,7 +341,7 @@ void sm2_progress_recv(struct sm2_ep *ep)
 			break;
 
 		if (xfer_entry->hdr.proto == sm2_proto_return) {
-			if (xfer_entry->hdr.op_flags & FI_REMOTE_READ) {
+			if (xfer_entry->hdr.proto_flags & SM2_RMA_REQ) {
 				atomic_entry = (struct sm2_atomic_entry *)
 						       xfer_entry->user_data;
 				ofi_copy_to_iov(


### PR DESCRIPTION
Now that SM2 has proto flags, we can use a proto flag instead of overloading the op flag. The other op flag FI_DELIVERY_COMPLETE will be removed in a future commit