### PR TITLE
src/iov.c: ofi_consume_iov allows 0-byte consume

### DIFF
--- a/src/iov.c
+++ b/src/iov.c
@@ -66,7 +66,7 @@ void ofi_consume_iov_desc(struct iovec *iov, void **desc,
 	struct iovec *cur_iov;
 	void **cur_desc;
 
-	assert(to_consume && *iov_count);
+	assert(*iov_count);
 	assert(to_consume <= ofi_total_iov_len(iov, *iov_count));
 
 	if (*iov_count == 1) {
@@ -108,7 +108,7 @@ void ofi_consume_rma_iov(struct fi_rma_iov *rma_iov, size_t *rma_iov_count,
 {
 	struct fi_rma_iov *cur_iov;
 
-	assert(to_consume && *rma_iov_count);
+	assert(*rma_iov_count);
 	assert(to_consume <= ofi_total_rma_iov_len(rma_iov, *rma_iov_count));
 
 	if (*rma_iov_count == 1) {


### PR DESCRIPTION
Removed assert(to_consume) in ofi_consume_iov and ofi_consume_rma_iov. This check is not required as the functions can correctly consume 0 bytes from an iov.

--

A regression was noticed by EFA nightly CI after merging #9050.  Rather than prevent zero-sized consumes, it was decided that it should be legal to consume 0 bytes (as it was before #9050).  See https://github.com/ofiwg/libfabric/pull/9166 for additional context.