### PR TITLE
contrib/intel/jenkins: Fix multinode filename & add extra information to summary

### DIFF
--- a/contrib/intel/jenkins/runtests.py
+++ b/contrib/intel/jenkins/runtests.py
@@ -6,6 +6,7 @@ import cloudbees_config
 import subprocess
 import run
 import common
+import shlex
 
 class ParseDict(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
@@ -63,6 +64,7 @@ way = args.way
 hosts = []
 if 'slurm' in os.environ['FABRIC']:
     slurm_nodes = os.environ['SLURM_JOB_NODELIST'] # example cb[1-4,11]
+    common.run_command(shlex.split(f"sinfo --Format=Features -n {slurm_nodes}"))
     if int(os.environ['SLURM_NNODES']) == 1:
         hosts.append(slurm_nodes)
     else:

--- a/contrib/intel/jenkins/summary.py
+++ b/contrib/intel/jenkins/summary.py
@@ -617,7 +617,7 @@ def summarize_items(summary_item, logger, log_dir, mode):
 
             ret = MultinodePerformanceSummarizer(
                 logger, log_dir, prov,
-                f'multinode_performance_{prov}_{mode}',
+                f'multinode_performance_{prov}_multinode_{mode}',
                 f"multinode performance {prov} {mode}"
             ).summarize()
             err += ret if ret else 0


### PR DESCRIPTION
Fix multinode_performace stage's expected file name in the summarizer
Add more information about what hardware each test ran on to the summary output