### PR TITLE
Use nvmlDeviceGetCount_v2() first for CUDA check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -595,7 +595,7 @@ AS_IF([test x"$with_cuda" != x"no"],
 				 [cuda_runtime.h],
 				 [cudart],
 				 [cudaMemcpy],
-				 [-lcuda],
+				 [-lcuda -lnvidia-ml],
 				 [$with_cuda],
 				 [],
 				 [have_cuda=1])


### PR DESCRIPTION
Check for CUDA devices with nvmlDeviceGetCount_v2() first, to avoid more expensive call to cudaGetDeviceCount() when possible.