### PR TITLE
contrib/intel/jenkins: Fix DAOS logging and summary

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -508,8 +508,9 @@ pipeline {
             script {
               dir ("${env.WORKSPACE}/${SCRIPT_LOCATION}/") {
                 run_python(PYTHON_VERSION,
-                           "runtests.py --prov='tcp' --util='rxm' --test=daos",
-                           "${env.LOG_DIR}/daos_tcp-rxm_reg")
+                           """runtests.py --prov='tcp' --util='rxm' \
+                           --test=daos \
+                           --log_file=${env.LOG_DIR}/daos_tcp-rxm_reg""")
               }
             }
           }
@@ -521,8 +522,9 @@ pipeline {
             script {
               dir ("${env.WORKSPACE}/${SCRIPT_LOCATION}/") {
                 run_python(PYTHON_VERSION,
-                           "runtests.py --prov='verbs' --util='rxm' --test=daos",
-                           "${env.LOG_DIR}/daos_verbs-rxm_reg")
+                           """runtests.py --prov='verbs' --util='rxm' \
+                           --test=daos \
+                           --log_file=${env.LOG_DIR}/daos_verbs-rxm_reg""")
               }
             }
           }
@@ -642,6 +644,7 @@ pipeline {
     }
     stage ('Summary-daos') {
       agent {node {label 'daos_head'}}
+      options { skipDefaultCheckout() }
       when { equals expected: true, actual: DO_RUN }
       steps {
         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
@@ -666,7 +669,7 @@ pipeline {
       node ('daos_head') {
         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
             sh """
-              if [[ ${DO_RUN} -eq 1 ]]; then
+              if [[ ${DO_RUN} -eq true ]]; then
                 python3.7 ${env.WORKSPACE}/${SCRIPT_LOCATION}/summary.py -v --summary_item=daos
               fi
             """

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -619,13 +619,13 @@ pipeline {
           sh """
             env
             (
-              if [[ $RELEASE -eq 1 ]]; then
+              if [[ ${RELEASE} = true ]]; then
                 python3.9 ${env.WORKSPACE}/${SCRIPT_LOCATION}/summary.py --summary_item=all --release
               else
                 python3.9 ${env.WORKSPACE}/${SCRIPT_LOCATION}/summary.py --summary_item=all
               fi
               echo "------------"
-              if [[ ${RELEASE} -eq 1 ]]; then
+              if [[ ${RELEASE} = true ]]; then
                 mkdir -p ${env.WORKSPACE}/internal
                 rm -rf ${env.WORKSPACE}/internal/*
                 git clone https://${env.PAT}@github.com/${env.INTERNAL} ${env.WORKSPACE}/internal

--- a/contrib/intel/jenkins/common.py
+++ b/contrib/intel/jenkins/common.py
@@ -21,6 +21,27 @@ def run_command(command):
         print("exiting with " + str(p.poll()))
         sys.exit(p.returncode)
 
+def run_logging_command(command, log_file):
+    print("filename: ".format(log_file))
+    f = open(log_file, 'a')
+    print(" ".join(command))
+    p = subprocess.Popen(command, stdout=subprocess.PIPE, text=True)
+    print(p.returncode)
+    f.write(" ".join(command) + '\n')
+    while True:
+        out = p.stdout.read(1)
+        f.write(out)
+        if (out == '' and p.poll() != None):
+            break
+        if (out != ''):
+            sys.stdout.write(out)
+            sys.stdout.flush()
+    if (p.returncode != 0):
+        print("exiting with " + str(p.poll()))
+        f.close()
+        sys.exit(p.returncode)
+    f.close()
+
 Prov = collections.namedtuple('Prov', 'core util')
 prov_list = [
    Prov('psm3', None),

--- a/contrib/intel/jenkins/run.py
+++ b/contrib/intel/jenkins/run.py
@@ -19,23 +19,25 @@ if 'slurm' in fab:
 jbname = os.environ['JOB_NAME']#args.jobname
 bno = os.environ['BUILD_NUMBER']#args.buildno
 
-def fi_info_test(core, hosts, mode, user_env, util):
+def fi_info_test(core, hosts, mode, user_env, log_file, util):
 
     fi_info_test = tests.FiInfoTest(jobname=jbname,buildno=bno,
                                     testname='fi_info', core_prov=core,
-                                    fabric=fab, hosts=hosts, ofi_build_mode=mode,
-                                    user_env=user_env, util_prov=util)
+                                    fabric=fab, hosts=hosts,
+                                    ofi_build_mode=mode, user_env=user_env,
+                                    log_file=log_file, util_prov=util)
     print('-------------------------------------------------------------------')
     print(f"Running fi_info test for {core}-{util}-{fab}")
     fi_info_test.execute_cmd()
     print('-------------------------------------------------------------------')
 
-def fabtests(core, hosts, mode, user_env, util):
+def fabtests(core, hosts, mode, user_env, log_file, util):
 
     runfabtest = tests.Fabtest(jobname=jbname,buildno=bno,
                                testname='runfabtests', core_prov=core,
                                fabric=fab, hosts=hosts, ofi_build_mode=mode,
-                               user_env=user_env, util_prov=util)
+                               user_env=user_env, log_file=log_file,
+                               util_prov=util)
 
     print('-------------------------------------------------------------------')
     if (runfabtest.execute_condn):
@@ -45,12 +47,13 @@ def fabtests(core, hosts, mode, user_env, util):
         print(f"Skipping {core} {runfabtest.testname} as execute condition fails")
     print('-------------------------------------------------------------------')
 
-def shmemtest(core, hosts, mode, user_env, util):
+def shmemtest(core, hosts, mode, user_env, log_file, util):
 
     runshmemtest = tests.ShmemTest(jobname=jbname,buildno=bno,
                                    testname="shmem test", core_prov=core,
                                    fabric=fab, hosts=hosts,
-                                   ofi_build_mode=mode, user_env=user_env, util_prov=util)
+                                   ofi_build_mode=mode, user_env=user_env,
+                                   log_file=log_file, util_prov=util)
 
     print('-------------------------------------------------------------------')
     if (runshmemtest.execute_condn):
@@ -71,13 +74,13 @@ def shmemtest(core, hosts, mode, user_env, util):
         print(f"Skipping {core} {runshmemtest.testname} as execute condition fails")
     print('-------------------------------------------------------------------')
 
-def multinodetest(core, hosts, mode, user_env, util):
+def multinodetest(core, hosts, mode, user_env, log_file, util):
 
     runmultinodetest = tests.MultinodeTests(jobname=jbname,buildno=bno,
                                       testname="multinode performance test",
                                       core_prov=core, fabric=fab, hosts=hosts,
                                       ofi_build_mode=mode, user_env=user_env,
-                                      util_prov=util)
+                                      log_file=log_file, util_prov=util)
 
     print("-------------------------------------------------------------------")
     if (runmultinodetest.execute_condn):
@@ -91,13 +94,13 @@ def multinodetest(core, hosts, mode, user_env, util):
               .format(runmultinodetest.testname))
     print("-------------------------------------------------------------------")
 
-def ze_fabtests(core, hosts, mode, way, user_env, util):
+def ze_fabtests(core, hosts, mode, way, user_env, log_file, util):
 
     runzefabtests = tests.ZeFabtests(jobname=jbname,buildno=bno,
                                      testname="ze test", core_prov=core,
                                      fabric=fab, hosts=hosts,
                                      ofi_build_mode=mode, user_env=user_env,
-                                     util_prov=util)
+                                     log_file=log_file, util_prov=util)
 
     print('-------------------------------------------------------------------')
     if (runzefabtests.execute_condn):
@@ -107,13 +110,13 @@ def ze_fabtests(core, hosts, mode, way, user_env, util):
         print(f"Skipping {core} {runzefabtests.testname} as execute condition fails")
     print('-------------------------------------------------------------------')
 
-def intel_mpi_benchmark(core, hosts, mpi, mode, group, user_env, util):
+def intel_mpi_benchmark(core, hosts, mpi, mode, group, user_env, log_file, util):
 
     imb = tests.IMBtests(jobname=jbname, buildno=bno,
                          testname='IntelMPIbenchmark', core_prov=core,
                          fabric=fab, hosts=hosts, mpitype=mpi,
                          ofi_build_mode=mode, user_env=user_env,
-                         test_group=group, util_prov=util)
+                         log_file=log_file, test_group=group, util_prov=util)
 
     print('-------------------------------------------------------------------')
     if (imb.execute_condn == True):
@@ -123,13 +126,13 @@ def intel_mpi_benchmark(core, hosts, mpi, mode, group, user_env, util):
         print(f"Skipping {mpi.upper} {imb.testname} as execute condition fails")
     print('-------------------------------------------------------------------')
 
-def mpich_test_suite(core, hosts, mpi, mode, user_env, util):
+def mpich_test_suite(core, hosts, mpi, mode, user_env, log_file, util):
 
     mpich_tests = tests.MpichTestSuite(jobname=jbname,buildno=bno,
                                        testname="MpichTestSuite",core_prov=core,
                                        fabric=fab, mpitype=mpi, hosts=hosts,
                                        ofi_build_mode=mode, user_env=user_env,
-                                       util_prov=util)
+                                       log_file=log_file, util_prov=util)
 
     print('-------------------------------------------------------------------')
     if (mpich_tests.execute_condn == True):
@@ -139,13 +142,13 @@ def mpich_test_suite(core, hosts, mpi, mode, user_env, util):
         print(f"Skipping {mpi.upper()} {mpich_tests.testname} as exec condn fails")
     print('-------------------------------------------------------------------')
 
-def osu_benchmark(core, hosts, mpi, mode, user_env, util):
+def osu_benchmark(core, hosts, mpi, mode, user_env, log_file, util):
 
     osu_test = tests.OSUtests(jobname=jbname, buildno=bno,
                                 testname='osu-benchmarks', core_prov=core,
                                 fabric=fab, mpitype=mpi, hosts=hosts,
                                 ofi_build_mode=mode, user_env=user_env,
-                                util_prov=util)
+                                log_file=log_file, util_prov=util)
 
     print('-------------------------------------------------------------------')
     if (osu_test.execute_condn == True):
@@ -155,13 +158,13 @@ def osu_benchmark(core, hosts, mpi, mode, user_env, util):
         print(f"Skipping {mpi.upper()} {osu_test.testname} as exec condn fails")
     print('-------------------------------------------------------------------')
 
-def oneccltest(core, hosts, mode, user_env, util):
+def oneccltest(core, hosts, mode, user_env, log_file, util):
 
     runoneccltest = tests.OneCCLTests(jobname=jbname,buildno=bno,
                                       testname="oneccl test", core_prov=core,
                                       fabric=fab, hosts=hosts,
                                       ofi_build_mode=mode, user_env=user_env,
-                                      util_prov=util)
+                                      log_file=log_file, util_prov=util)
 
     print('-------------------------------------------------------------------')
     if (runoneccltest.execute_condn):
@@ -171,12 +174,13 @@ def oneccltest(core, hosts, mode, user_env, util):
         print(f"Skipping {runoneccltest.testname} as execute condition fails")
     print('-------------------------------------------------------------------')
 
-def oneccltestgpu(core, hosts, mode, user_env, util):
+def oneccltestgpu(core, hosts, mode, user_env, log_file, util):
 
     runoneccltestgpu = tests.OneCCLTestsGPU(jobname=jbname,buildno=bno,
-                                         testname="oneccl GPU test", core_prov=core,
-                                         fabric=fab, hosts=hosts,
-                                         ofi_build_mode=mode, user_env=user_env,
+                                         testname="oneccl GPU test",
+                                         core_prov=core, fabric=fab,
+                                         hosts=hosts, ofi_build_mode=mode,
+                                         user_env=user_env, log_file=log_file,
                                          util_prov=util)
 
     print('-------------------------------------------------------------------')
@@ -191,13 +195,13 @@ def oneccltestgpu(core, hosts, mode, user_env, util):
         print(f"Skipping {runoneccltestgpu.testname} as execute condition fails")
     print('-------------------------------------------------------------------')
 
-def daos_cart_tests(core, hosts, mode, user_env, util):
+def daos_cart_tests(core, hosts, mode, user_env, log_file, util):
 
     runcarttests = tests.DaosCartTest(jobname=jbname, buildno=bno,
                                       testname="Daos Cart Test", core_prov=core,
                                       fabric=fab, hosts=hosts,
                                       ofi_build_mode=mode, user_env=user_env,
-                                      util_prov=util)
+                                      log_file=log_file, util_prov=util)
 
     print('-------------------------------------------------------------------')
     if (runcarttests.execute_condn):

--- a/contrib/intel/jenkins/runtests.py
+++ b/contrib/intel/jenkins/runtests.py
@@ -35,6 +35,8 @@ parser.add_argument('--user_env', help="Run with additional environment " \
                     "variables", nargs='*', action=ParseDict, default={})
 parser.add_argument('--mpi', help="Select mpi to use for middlewares",
                     choices=['impi', 'mpich', 'ompi'], default='impi')
+parser.add_argument('--log_file', help="Full path to log file",
+                    default=os.environ['DEFAULT_LOG_LOCATION'], type=str)
 
 args = parser.parse_args()
 args_core = args.prov
@@ -42,6 +44,7 @@ args_core = args.prov
 args_util = args.util
 args_device = args.device
 user_env = args.user_env
+log_file = args.log_file
 
 if (args.ofi_build_mode):
     ofi_build_mode = args.ofi_build_mode
@@ -99,48 +102,48 @@ if(args_core):
     if (args.device != 'ze'):
         if (run_test == 'all' or run_test == 'fi_info'):
             run.fi_info_test(args_core, hosts, ofi_build_mode,
-                             user_env, util=args.util)
+                             user_env, log_file, util=args.util)
 
         if (run_test == 'all' or run_test == 'fabtests'):
-            run.fabtests(args_core, hosts, ofi_build_mode, user_env,
+            run.fabtests(args_core, hosts, ofi_build_mode, user_env, log_file,
                          args_util)
 
         if (run_test == 'all' or run_test == 'shmem'):
-            run.shmemtest(args_core, hosts, ofi_build_mode, user_env,
+            run.shmemtest(args_core, hosts, ofi_build_mode, user_env, log_file,
                           args_util)
 
         if (run_test == 'all' or run_test == 'oneccl'):
-            run.oneccltest(args_core, hosts, ofi_build_mode, user_env,
+            run.oneccltest(args_core, hosts, ofi_build_mode, user_env, log_file,
                            args_util)
 
         if (run_test == 'all' or run_test == 'onecclgpu'):
             run.oneccltestgpu(args_core, hosts, ofi_build_mode,
-                              user_env, args_util)
+                              user_env, log_file, args_util)
 
         if (run_test == 'all' or run_test == 'daos'):
             run.daos_cart_tests(args_core, hosts, ofi_build_mode,
-                                user_env, args_util)
+                                user_env, log_file, args_util)
 
         if (run_test == 'all' or run_test == 'multinode'):
             run.multinodetest(args_core, hosts, ofi_build_mode,
-                              user_env, args_util)
+                              user_env, log_file, args_util)
 
         if (run_test == 'all' or run_test == 'mpichtestsuite'):
             run.mpich_test_suite(args_core, hosts, mpi,
-                                ofi_build_mode, user_env,
+                                ofi_build_mode, user_env, log_file,
                                 args_util)
 
         if (run_test == 'all' or run_test == 'IMB'):
             run.intel_mpi_benchmark(args_core, hosts, mpi,
                                     ofi_build_mode, imb_group,
-                                    user_env, args_util)
+                                    user_env, log_file, args_util)
 
         if (run_test == 'all' or run_test == 'osu'):
             run.osu_benchmark(args_core, hosts, mpi,
-                                ofi_build_mode, user_env,
+                                ofi_build_mode, user_env, log_file,
                                 args_util)
     else:
-        run.ze_fabtests(args_core, hosts, ofi_build_mode, way, user_env,
+        run.ze_fabtests(args_core, hosts, ofi_build_mode, way, user_env, log_file,
                         args_util)
 
 else:

--- a/contrib/intel/jenkins/summary.py
+++ b/contrib/intel/jenkins/summary.py
@@ -107,14 +107,21 @@ class Summarizer(ABC):
         percent = self.passes/total * 100
         if (verbose):
             self.logger.log(
-                f"<>{self.stage_name} : {self.node} : [{self.features}] : ",
-                lpad=1, ljust=80, end_delimiter = ''
+                f"<>{self.stage_name} : ", lpad=1, ljust=40, end_delimiter = ''
             )
         else:
             self.logger.log(
-                f"{self.stage_name} : {self.node} : [{self.features}] : ",
-                lpad=1, ljust=80, end_delimiter = ''
+                f"{self.stage_name} : ",
+                lpad=1, ljust=40, end_delimiter = ''
             )
+        self.logger.log(
+                f"{self.node} : ",
+                lpad=1, ljust=20, end_delimiter = ''
+        )
+        self.logger.log(
+                f"[{self.features}] : ",
+                lpad=1, ljust=30, end_delimiter = ''
+        )
         self.logger.log(f"{self.passes}:{total} ", ljust=10, end_delimiter = '')
         self.logger.log(f": {percent:.2f}% : ", ljust=12, end_delimiter = '')
         self.logger.log("Pass", end_delimiter = '')

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -998,6 +998,6 @@ class DaosCartTest(Test):
             print(test)
             command = self.remote_launch_cmd(test) + self.cmd + self.options(test)
             outputcmd = shlex.split(command)
-            common.run_command(outputcmd)
+            common.run_logging_command(outputcmd, self.log_file)
             print("--------------------TEST COMPLETED----------------------")
         os.chdir(curdir)

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -14,7 +14,7 @@ import shlex
 class Test:
 
     def __init__ (self, jobname, buildno, testname, core_prov, fabric,
-                  hosts, ofi_build_mode, user_env, mpitype=None, util_prov=None):
+                  hosts, ofi_build_mode, user_env, log_file, mpitype=None, util_prov=None):
         self.jobname = jobname
         self.buildno = buildno
         self.testname = testname
@@ -22,6 +22,7 @@ class Test:
         self.util_prov = f'ofi_{util_prov}' if util_prov != None else ''
         self.fabric = fabric
         self.hosts = hosts
+        self.log_file = log_file
         self.mpi_type = mpitype
         self.ofi_build_mode = ofi_build_mode
         if (len(hosts) == 1):
@@ -66,10 +67,10 @@ class Test:
 class FiInfoTest(Test):
 
     def __init__(self, jobname, buildno, testname, core_prov, fabric,
-                 hosts, ofi_build_mode, user_env, util_prov=None):
+                 hosts, ofi_build_mode, user_env, log_file, util_prov=None):
 
         super().__init__(jobname, buildno, testname, core_prov, fabric,
-                     hosts, ofi_build_mode, user_env, None, util_prov)
+                     hosts, ofi_build_mode, user_env, log_file, None, util_prov)
 
         self.fi_info_testpath =  f'{self.libfab_installpath}/bin'
 
@@ -97,10 +98,10 @@ class FiInfoTest(Test):
 class Fabtest(Test):
 
     def __init__(self, jobname, buildno, testname, core_prov, fabric,
-                 hosts, ofi_build_mode, user_env, util_prov=None):
+                 hosts, ofi_build_mode, user_env, log_file, util_prov=None):
 
         super().__init__(jobname, buildno, testname, core_prov, fabric,
-                         hosts, ofi_build_mode, user_env, None, util_prov)
+                         hosts, ofi_build_mode, user_env, log_file, None, util_prov)
         self.fabtestpath = f'{self.libfab_installpath}/bin'
         self.fabtestconfigpath = f'{self.libfab_installpath}/share/fabtests'
 
@@ -195,10 +196,11 @@ class Fabtest(Test):
 class ShmemTest(Test):
 
     def __init__(self, jobname, buildno, testname, core_prov, fabric,
-                    hosts, ofi_build_mode, user_env, util_prov=None):
+                    hosts, ofi_build_mode, user_env, log_file, util_prov=None):
 
         super().__init__(jobname, buildno, testname, core_prov, fabric,
-                            hosts, ofi_build_mode, user_env, None, util_prov)
+                         hosts, ofi_build_mode, user_env, log_file, None,
+                         util_prov)
 
         self.n = 4
         self.ppn = 2
@@ -299,10 +301,10 @@ class ShmemTest(Test):
 class MultinodeTests(Test):
 
     def __init__(self, jobname, buildno, testname, core_prov, fabric,
-                 hosts, ofi_build_mode, user_env, util_prov=None):
+                 hosts, ofi_build_mode, user_env, log_file, util_prov=None):
 
         super().__init__(jobname, buildno, testname, core_prov, fabric,
-                         hosts, ofi_build_mode, user_env, None, util_prov)
+                         hosts, ofi_build_mode, user_env, log_file, None, util_prov)
         self.fabtestpath = f'{self.libfab_installpath}/bin'
         self.fabtestconfigpath = f'{self.libfab_installpath}/share/fabtests'
         self.n = 2
@@ -349,10 +351,10 @@ class MultinodeTests(Test):
 
 class ZeFabtests(Test):
     def __init__(self, jobname, buildno, testname, core_prov, fabric,
-                 hosts, ofi_build_mode, user_env, util_prov=None):
+                 hosts, ofi_build_mode, user_env, log_file, util_prov=None):
 
         super().__init__(jobname, buildno, testname, core_prov, fabric,
-                         hosts, ofi_build_mode, user_env, None, util_prov)
+                         hosts, ofi_build_mode, user_env, log_file, None, util_prov)
 
         self.fabtestpath = f'{self.libfab_installpath}/bin'
         self.zefabtest_script_path = f'{cloudbees_config.ze_testpath}'
@@ -546,11 +548,11 @@ class IMPI:
 
 class IMBtests(Test):
     def __init__(self, jobname, buildno, testname, core_prov, fabric,
-                 hosts, mpitype, ofi_build_mode, user_env, test_group,
+                 hosts, mpitype, ofi_build_mode, user_env, log_file, test_group,
                  util_prov=None):
 
         super().__init__(jobname, buildno, testname, core_prov,
-                         fabric, hosts, ofi_build_mode, user_env, mpitype,
+                         fabric, hosts, ofi_build_mode, user_env, log_file, mpitype,
                          util_prov)
 
         self.test_group = test_group
@@ -633,10 +635,10 @@ class IMBtests(Test):
 class OSUtests(Test):
 
     def __init__(self, jobname, buildno, testname, core_prov, fabric,
-                 hosts, mpitype, ofi_build_mode, user_env, util_prov=None):
+                 hosts, mpitype, ofi_build_mode, user_env, log_file, util_prov=None):
 
         super().__init__(jobname, buildno, testname, core_prov,
-                         fabric, hosts, ofi_build_mode, user_env, mpitype,
+                         fabric, hosts, ofi_build_mode, user_env, log_file, mpitype,
                          util_prov)
 
         self.n_ppn = {
@@ -685,10 +687,10 @@ class OSUtests(Test):
 class MpichTestSuite(Test):
 
     def __init__(self, jobname, buildno, testname, core_prov, fabric,
-                 hosts, mpitype, ofi_build_mode, user_env, util_prov=None):
+                 hosts, mpitype, ofi_build_mode, user_env, log_file, util_prov=None):
 
         super().__init__(jobname, buildno, testname, core_prov,
-                         fabric, hosts, ofi_build_mode, user_env, mpitype,
+                         fabric, hosts, ofi_build_mode, user_env, log_file, mpitype,
                          util_prov)
 
         self.mpichsuitepath = f'{self.middlewares_path}/{mpitype}/'\
@@ -741,9 +743,9 @@ class MpichTestSuite(Test):
 class OneCCLTests(Test):
 
     def __init__(self, jobname, buildno, testname, core_prov, fabric,
-                 hosts, ofi_build_mode, user_env, util_prov=None):
+                 hosts, ofi_build_mode, user_env, log_file, util_prov=None):
         super().__init__(jobname, buildno, testname, core_prov, fabric,
-                         hosts, ofi_build_mode, user_env, None, util_prov)
+                         hosts, ofi_build_mode, user_env, log_file, None, util_prov)
 
         self.oneccl_path = f'{self.middlewares_path}/oneccl/'
         self.test_dir = f'{self.middlewares_path}/oneccl/ci_tests'
@@ -805,9 +807,9 @@ class OneCCLTests(Test):
 class OneCCLTestsGPU(Test):
 
     def __init__(self, jobname, buildno, testname, core_prov, fabric,
-                 hosts, ofi_build_mode, user_env, util_prov=None):
+                 hosts, ofi_build_mode, user_env, log_file, util_prov=None):
         super().__init__(jobname, buildno, testname, core_prov, fabric,
-                         hosts, ofi_build_mode, user_env, None, util_prov)
+                         hosts, ofi_build_mode, user_env, log_file, None, util_prov)
 
         self.n = 2
         self.ppn = 1
@@ -917,9 +919,9 @@ class OneCCLTestsGPU(Test):
 class DaosCartTest(Test):
 
     def __init__(self, jobname, buildno, testname, core_prov, fabric,
-                 hosts, ofi_build_mode, user_env, util_prov=None):
+                 hosts, ofi_build_mode, user_env, log_file, util_prov=None):
         super().__init__(jobname, buildno, testname, core_prov, fabric,
-                         hosts, ofi_build_mode, user_env, None, util_prov)
+                         hosts, ofi_build_mode, user_env, log_file, None, util_prov)
 
 
         self.set_paths(core_prov)


### PR DESCRIPTION
DAOS was using the output of the wrong command for its log. This PR fixes that issue.
Any invocation of runtests.py can now provide its own logfile instead of using the one generated with slurm or the jenkinsfile.
It also addresses the failure summary case for daos by cleaning up the multiple prints of the same test and providing a better log of what failed.
The summary gets better spacing in addition to the failure case for daos.
The release case gets updated to match the true/false boolean variable update that all other variables in the Jenkinsfile follow.