### PR TITLE
prov/sm2: Reduce unexpected message copy to message size

### DIFF
--- a/prov/sm2/src/sm2_progress.c
+++ b/prov/sm2/src/sm2_progress.c
@@ -144,7 +144,8 @@ static int sm2_alloc_xfer_entry_ctx(struct sm2_ep *ep,
 		return -FI_ENOMEM;
 	}
 
-	memcpy(&xfer_ctx->xfer_entry, xfer_entry, sizeof(*xfer_entry));
+	memcpy(&xfer_ctx->xfer_entry, xfer_entry,
+	       sizeof(xfer_entry->hdr) + xfer_entry->hdr.size);
 	xfer_ctx->ep = ep;
 
 	rx_entry->peer_context = xfer_ctx;


### PR DESCRIPTION
Previously, SM2 was copying the entire xfer_entry into the unexpected message queue. We can reduce the amount of bytes copied to the header + the message size. This will give us a minor performance improvement.