### PR TITLE
contrib/intel/jenkins: Add file importing to Summarizer & Cleanup Jenkinsfile

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -89,6 +89,33 @@ def gather_logs(cluster, key, dest, source) {
   }
 }
 
+def summarize(item, verbose=false, release=false) {
+  def cmd = "${env.WORKSPACE}/${SCRIPT_LOCATION}/summary.py --summary_item=all"
+  if (verbose) {
+    cmd = "${cmd} -v "
+  }
+  if (release) {
+    cmd = "${cmd} --release "
+  }
+
+  run_python(PYTHON_VERSION, cmd)
+}
+
+def save_summary() {
+  sh """
+    mkdir -p ${env.WORKSPACE}/internal
+    rm -rf ${env.WORKSPACE}/internal/*
+    git clone https://${env.PAT}@github.com/${env.INTERNAL} ${env.WORKSPACE}/internal
+    cd ${env.WORKSPACE}/internal
+    mkdir -p ${env.WORKSPACE}/internal/summaries
+    cp ${env.WORKSPACE}/summary_*.log ${env.WORKSPACE}/internal/summaries/
+    git add ${env.WORKSPACE}/internal/summaries/
+    git commit -am \"add ${env.JOB_NAME}'s summary\"
+    git pull -r origin master
+    git push origin master
+  """
+}
+
 def checkout_py_scripts() {
   sh """
     if [[ ! -d ${env.WORKSPACE}/py_scripts ]]; then
@@ -195,6 +222,7 @@ pipeline {
       JOB_CADENCE = 'PR'
       LOG_DIR = "${env.JOB_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}/log_dir"
       WITH_ENV="'PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH'"
+      DELETE_LOCATION="${env.JOB_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}"
   }
 
   stages {
@@ -638,89 +666,46 @@ pipeline {
 
   post {
     always {
-      withEnv(["${WITH_ENV}"]) {
-        sh "python3.9 ${env.WORKSPACE}/${SCRIPT_LOCATION}/summary.py --summary_item=all"
+      script {
+        summarize("all")
+      }
+    }
+    success {
+      script {
+        summarize("all", verbose=true, release=false)
       }
     }
     aborted {
       node ('daos_head') {
-        withEnv(["${WITH_ENV}"]) {
-          dir ("${env.JOB_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}/middlewares") {
-            deleteDir()
-          }
-        }
+        dir ("${DELETE_LOCATION}/middlewares") { deleteDir() }
       }
       node ('dsa') {
-        withEnv(["${WITH_ENV}"]) {
-          dir ("${env.JOB_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}/middlewares") {
-            deleteDir()
-          }
-        }
+        dir ("${DELETE_LOCATION}/middlewares") { deleteDir() }
       }
       node ('ze') {
-        withEnv(["${WITH_ENV}"]) {
-          dir ("${env.JOB_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}/middlewares") {
-            deleteDir()
-          }
-        }
+        dir ("${DELETE_LOCATION}/middlewares") { deleteDir() }
       }
-      withEnv(["${WITH_ENV}"]) {
-        dir ("${env.JOB_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}/middlewares") {
-          deleteDir()
-        }
-      }
+      dir ("${DELETE_LOCATION}/middlewares") { deleteDir() }
     }
     cleanup {
       node ('daos_head') {
-        withEnv(["${WITH_ENV}"]) {
-          dir ("${env.JOB_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}") {
-            deleteDir()
-          }
-          dir("${env.WORKSPACE}") {
-            deleteDir()
-          }
-          dir("${env.WORKSPACE}@tmp") {
-            deleteDir()
-          }
-        }
+        dir ("${DELETE_LOCATION}") { deleteDir() }
+        dir("${env.WORKSPACE}") { deleteDir() }
+        dir("${env.WORKSPACE}@tmp") { deleteDir() }
       }
       node ('dsa') {
-        withEnv(["${WITH_ENV}"]) {
-          dir ("${env.JOB_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}") {
-            deleteDir()
-          }
-          dir("${env.WORKSPACE}") {
-            deleteDir()
-          }
-          dir("${env.WORKSPACE}@tmp") {
-            deleteDir()
-          }
-        }
+        dir("${DELETE_LOCATION}") { deleteDir() }
+        dir("${env.WORKSPACE}") { deleteDir() }
+        dir("${env.WORKSPACE}@tmp") { deleteDir() }
       }
       node ('ze') {
-        withEnv(["${WITH_ENV}"]) {
-          dir ("${env.JOB_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}") {
-            deleteDir()
-          }
-          dir("${env.WORKSPACE}") {
-            deleteDir()
-          }
-          dir("${env.WORKSPACE}@tmp") {
-            deleteDir()
-          }
-        }
+        dir("${DELETE_LOCATION}") { deleteDir() }
+        dir("${env.WORKSPACE}") { deleteDir() }
+        dir("${env.WORKSPACE}@tmp") { deleteDir() }
       }
-      withEnv([${WITH_ENV}]) {
-        dir ("${env.JOB_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}") {
-          deleteDir()
-        }
-        dir("${env.WORKSPACE}") {
-          deleteDir()
-        }
-        dir("${env.WORKSPACE}@tmp") {
-          deleteDir()
-        }
-      }
+      dir("${DELETE_LOCATION}") { deleteDir() }
+      dir("${env.WORKSPACE}") { deleteDir() }
+      dir("${env.WORKSPACE}@tmp") { deleteDir() }
     }
   }
 }

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -603,18 +603,14 @@ pipeline {
           }
         }
         stage('dsa') {
-          agent {
-            node {
-              label 'dsa'
-              customWorkspace "${CB_HOME}/workspace/${JOB_NAME}/${env.BUILD_NUMBER}"
-            }
-          }
+          agent { node { label 'dsa' } }
           when { equals expected: true, actual: DO_RUN }
           steps {
             script {
               dir (RUN_LOCATION) {
                 run_python(PYTHON_VERSION,
                 """runtests.py --prov=shm --test=fabtests \
+                   --log_file=${env.LOG_DIR}/fabtests_shm_dsa_reg \
                    --user_env FI_SHM_DISABLE_CMA=1 FI_SHM_USE_DSA_SAR=1""")
               }
             }
@@ -628,8 +624,8 @@ pipeline {
         script {
           gather_logs("${env.DAOS_ADDR}", "${env.DAOS_KEY}", "${env.LOG_DIR}",
                       "${env.LOG_DIR}")
-          // gather_logs("${env.DSA_ADDR}", "${env.DSA_KEY}", "${env.LOG_DIR}",
-          //             "${env.LOG_DIR}")
+          gather_logs("${env.DSA_ADDR}", "${env.DSA_KEY}", "${env.LOG_DIR}",
+                      "${env.LOG_DIR}")
           gather_logs("${env.ZE_ADDR}", "${env.ZE_KEY}", "${env.LOG_DIR}",
                       "${env.LOG_DIR}")
 

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -79,6 +79,16 @@ def run_middleware(providers, stage_name, test, partition, node_num, mpi=null,
   }
 }
 
+def gather_logs(cluster, key, dest, source) {
+  def address = "${env.USER}@${cluster}"
+
+  try {
+    sh "scp -i ${key} ${address}:${source}/* ${dest}/"
+  } catch (Exception e) {
+    echo "Caught exception ${e} when transfering files from ${cluster}"
+  }
+}
+
 def check_target() {
   echo "CHANGE_TARGET = ${env.CHANGE_TARGET}"
   if (changeRequest()) {
@@ -495,7 +505,7 @@ pipeline {
           steps {
             script {
               dir ("${env.WORKSPACE}/${SCRIPT_LOCATION}/") {
-                run_middleware([["verbs", "rxm"]], "oneCCL-GPU", "onecclgpu",
+                run_middleware([["verbs", "rxm"]], "oneCCL-GPU-v3", "onecclgpu",
                                "fabrics-ci", "2")
               } 
             }
@@ -567,7 +577,7 @@ pipeline {
                 def providers = [["shm", null]]
                 def directions = ["h2d", "d2d", "xd2d"]
                 def base_cmd = "python3.9 runtests.py --device=ze"
-                def prefix = "${env.LOG_DIR}/ze_"
+                def prefix = "${env.LOG_DIR}/ze_v3_"
                 def suffix = "_reg"
                 for (prov in providers) {
                   for (way in directions) {
@@ -615,6 +625,14 @@ pipeline {
     stage ('Summary') {
       when { equals expected: true, actual: DO_RUN }
       steps {
+        script {
+          gather_logs("${env.DAOS_ADDR}", "${env.DAOS_KEY}", "${env.LOG_DIR}",
+                      "${env.LOG_DIR}")
+          // gather_logs("${env.DSA_ADDR}", "${env.DSA_KEY}", "${env.LOG_DIR}",
+          //             "${env.LOG_DIR}")
+          gather_logs("${env.ZE_ADDR}", "${env.ZE_KEY}", "${env.LOG_DIR}",
+                      "${env.LOG_DIR}")
+        }
         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
           sh """
             env
@@ -642,46 +660,12 @@ pipeline {
         }
       }
     }
-    stage ('Summary-daos') {
-      agent {node {label 'daos_head'}}
-      options { skipDefaultCheckout() }
-      when { equals expected: true, actual: DO_RUN }
-      steps {
-        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
-          sh """
-            env
-            (
-              python3.7 ${env.WORKSPACE}/${SCRIPT_LOCATION}/summary.py --summary_item=daos
-            )
-          """
-        }
-      }
-    }
   }
 
   post {
     always {
       withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
         sh "python3.9 ${env.WORKSPACE}/${SCRIPT_LOCATION}/summary.py --summary_item=all"
-      }
-    }
-    success {
-      node ('daos_head') {
-        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
-            sh """
-              if [[ ${DO_RUN} -eq true ]]; then
-                python3.7 ${env.WORKSPACE}/${SCRIPT_LOCATION}/summary.py -v --summary_item=daos
-              fi
-            """
-          dir ("${env.DAOS_CLUSTER_HOME}/avocado") {
-            deleteDir()
-          }
-        }
-      }
-      withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
-        dir("${env.WORKSPACE}") {
-          sh "python3.9 ${env.WORKSPACE}/${SCRIPT_LOCATION}/summary.py -v --summary_item=all"
-        }
       }
     }
     aborted {

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -224,6 +224,7 @@ pipeline {
       WITH_ENV="'PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH'"
       DELETE_LOCATION="${env.JOB_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}"
       RUN_LOCATION="${env.WORKSPACE}/${SCRIPT_LOCATION}/"
+      CUSTOM_WORKSPACE="${CB_HOME}/workspace/${JOB_NAME}/${env.BUILD_NUMBER}"
   }
 
   stages {
@@ -271,7 +272,7 @@ pipeline {
           agent {
             node {
               label 'daos_head'
-              customWorkspace "${CB_HOME}/workspace/${JOB_NAME}/${env.BUILD_NUMBER}"
+              customWorkspace CUSTOM_WORKSPACE
             }
           }
           steps {
@@ -287,7 +288,7 @@ pipeline {
           agent {
             node {
               label 'dsa'
-              customWorkspace "${CB_HOME}/workspace/${JOB_NAME}/${env.BUILD_NUMBER}"
+              customWorkspace CUSTOM_WORKSPACE
             }
           }
           steps {
@@ -303,7 +304,7 @@ pipeline {
           agent {
             node {
               label 'ze'
-              customWorkspace "${CB_HOME}/workspace/${JOB_NAME}/${env.BUILD_NUMBER}"
+              customWorkspace CUSTOM_WORKSPACE
             }
           }
           steps {

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -194,6 +194,7 @@ pipeline {
   environment {
       JOB_CADENCE = 'PR'
       LOG_DIR = "${env.JOB_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}/log_dir"
+      WITH_ENV="'PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH'"
   }
 
   stages {
@@ -581,7 +582,7 @@ pipeline {
           }
           when { equals expected: true, actual: DO_RUN }
           steps {
-            withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
+            withEnv(["${WITH_ENV}"]) {
               sh """
               env
               (
@@ -606,7 +607,7 @@ pipeline {
           gather_logs("${env.ZE_ADDR}", "${env.ZE_KEY}", "${env.LOG_DIR}",
                       "${env.LOG_DIR}")
         }
-        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
+        withEnv(["${WITH_ENV}"]) {
           sh """
             env
             (
@@ -637,33 +638,33 @@ pipeline {
 
   post {
     always {
-      withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
+      withEnv(["${WITH_ENV}"]) {
         sh "python3.9 ${env.WORKSPACE}/${SCRIPT_LOCATION}/summary.py --summary_item=all"
       }
     }
     aborted {
       node ('daos_head') {
-        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
+        withEnv(["${WITH_ENV}"]) {
           dir ("${env.JOB_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}/middlewares") {
             deleteDir()
           }
         }
       }
       node ('dsa') {
-        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
+        withEnv(["${WITH_ENV}"]) {
           dir ("${env.JOB_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}/middlewares") {
             deleteDir()
           }
         }
       }
       node ('ze') {
-        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
+        withEnv(["${WITH_ENV}"]) {
           dir ("${env.JOB_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}/middlewares") {
             deleteDir()
           }
         }
       }
-      withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
+      withEnv(["${WITH_ENV}"]) {
         dir ("${env.JOB_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}/middlewares") {
           deleteDir()
         }
@@ -671,7 +672,7 @@ pipeline {
     }
     cleanup {
       node ('daos_head') {
-        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
+        withEnv(["${WITH_ENV}"]) {
           dir ("${env.JOB_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}") {
             deleteDir()
           }
@@ -684,7 +685,7 @@ pipeline {
         }
       }
       node ('dsa') {
-        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
+        withEnv(["${WITH_ENV}"]) {
           dir ("${env.JOB_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}") {
             deleteDir()
           }
@@ -697,7 +698,7 @@ pipeline {
         }
       }
       node ('ze') {
-        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
+        withEnv(["${WITH_ENV}"]) {
           dir ("${env.JOB_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}") {
             deleteDir()
           }
@@ -709,7 +710,7 @@ pipeline {
           }
         }
       }
-      withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
+      withEnv([${WITH_ENV}]) {
         dir ("${env.JOB_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}") {
           deleteDir()
         }

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -3,11 +3,11 @@ import groovy.transform.Field
 properties([disableConcurrentBuilds(abortPrevious: true)])
 @Field def DO_RUN=true
 @Field def TARGET="main"
-def SCRIPT_LOCATION="py_scripts/contrib/intel/jenkins"
-def RELEASE=false
+@Field def SCRIPT_LOCATION="py_scripts/contrib/intel/jenkins"
+@Field def RELEASE=false
 @Field def BUILD_MODES=["reg", "dbg", "dl"]
 @Field def MPI_TYPES=["impi", "mpich", "ompi"]
-def PYTHON_VERSION="3.9"
+@Field def PYTHON_VERSION="3.9"
 
 def run_python(version, command, output=null) {
   if (output != null)
@@ -87,6 +87,33 @@ def gather_logs(cluster, key, dest, source) {
   } catch (Exception e) {
     echo "Caught exception ${e} when transfering files from ${cluster}"
   }
+}
+
+def checkout_py_scripts() {
+  sh """
+    if [[ ! -d ${env.WORKSPACE}/py_scripts ]]; then
+      mkdir ${env.WORKSPACE}/py_scripts
+    else
+      rm -rf ${env.WORKSPACE}/py_scripts && mkdir ${env.WORKSPACE}/py_scripts
+    fi
+
+    git clone --branch ${TARGET} ${env.UPSTREAM} ${env.WORKSPACE}/py_scripts
+  """
+}
+
+def build(item, mode=null, cluster=null, release=false) {
+  def cmd = "${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=${item}"
+  if (mode) {
+    cmd = "${cmd} --ofi_build_mode=${mode} "
+  }
+  if (cluster) {
+    cmd = "${cmd} --build_cluster=${cluster} "
+  }
+  if (release) {
+    cmd = "${cmd} --release "
+  }
+
+  run_python(PYTHON_VERSION, cmd)
 }
 
 def check_target() {
@@ -198,29 +225,14 @@ pipeline {
           steps {
             script {
               echo "Copying build dirs."
-              build_item="builddir"
-              command="""${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py \
-                     --build_item="""
-              run_python(PYTHON_VERSION, "${command}${build_item}")
+              build("builddir")
               echo "Copying log dirs."
-              build_item="logdir"
-              if (RELEASE) {
-                run_python(PYTHON_VERSION, "${command}${build_item} --release")
-              } else {
-                run_python(PYTHON_VERSION, "${command}${build_item}")
-              }
-              build_item="libfabric"
+              build("logdir", null, null, RELEASE)
               for (mode in  BUILD_MODES) {
                 echo "Building Libfabric $mode"
-                build_item="libfabric"
-                run_python(PYTHON_VERSION,
-                           """${command}${build_item} \
-                           --ofi_build_mode=$mode""")
+                build("libfabric", "$mode")
                 echo "Building Fabtests $mode"
-                build_item="fabtests"
-                run_python(PYTHON_VERSION,
-                           """${command}${build_item} \
-                           --ofi_build_mode=$mode""")
+                build("fabtests", "$mode")
               }
             }
           }
@@ -233,30 +245,11 @@ pipeline {
             }
           }
           steps {
-            withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
-              sh """
-                env
-                (
-                  if [[ ! -d ${env.WORKSPACE}/py_scripts ]]; then
-                    mkdir ${env.WORKSPACE}/py_scripts
-                  else
-                    rm -rf ${env.WORKSPACE}/py_scripts && mkdir ${env.WORKSPACE}/py_scripts
-                  fi
-
-                  git clone --branch ${TARGET} ${env.UPSTREAM} ${env.WORKSPACE}/py_scripts
-                )
-              """
-            }
             script {
-              run_python(PYTHON_VERSION,
-                  """${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py \
-                  --build_item=logdir""")
-              run_python(PYTHON_VERSION,
-                  """${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py \
-                  --build_item=libfabric --build_cluster='daos'""")
-              run_python(PYTHON_VERSION,
-                  """${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py \
-                  --build_item=fabtests""")
+              checkout_py_scripts()
+              build("logdir")
+              build("libfabric", "reg", "daos")
+              build("fabtests", "reg")
             }
           }
         }
@@ -268,21 +261,11 @@ pipeline {
             }
           }
           steps {
-            withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
-              sh """
-                env
-                (
-                  if [[ ! -d ${env.WORKSPACE}/py_scripts ]]; then
-                    mkdir ${env.WORKSPACE}/py_scripts
-                  else
-                    rm -rf ${env.WORKSPACE}/py_scripts && mkdir ${env.WORKSPACE}/py_scripts
-                  fi
-                  git clone --branch ${TARGET} ${env.UPSTREAM} ${env.WORKSPACE}/py_scripts
-                  python3.9 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=logdir
-                  python3.9 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=libfabric --build_cluster='dsa'
-                  python3.9 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=fabtests
-                )
-              """
+            script {
+              checkout_py_scripts()
+              build("logdir")
+              build("libfabric", "reg", "dsa")
+              build("fabtests", "reg")
             }
           }
         }
@@ -294,22 +277,12 @@ pipeline {
             }
           }
           steps {
-            withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
-              sh """
-                env
-                (
-                  if [[ ! -d ${env.WORKSPACE}/py_scripts ]]; then
-                    mkdir ${env.WORKSPACE}/py_scripts
-                  else
-                    rm -rf ${env.WORKSPACE}/py_scripts && mkdir ${env.WORKSPACE}/py_scripts
-                  fi
-                  git clone --branch ${TARGET} ${env.UPSTREAM} ${env.WORKSPACE}/py_scripts
-                  python3.9 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=logdir
-                  python3.9 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=builddir
-                  python3.9 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=libfabric --build_cluster='gpu'
-                  python3.9 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=fabtests
-                )
-              """
+            script {
+              checkout_py_scripts()
+              build("logdir")
+              build("builddir")
+              build("libfabric", "reg", "gpu")
+              build("fabtests", "reg")
             }
           }
         }

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -223,6 +223,7 @@ pipeline {
       LOG_DIR = "${env.JOB_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}/log_dir"
       WITH_ENV="'PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH'"
       DELETE_LOCATION="${env.JOB_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}"
+      RUN_LOCATION="${env.WORKSPACE}/${SCRIPT_LOCATION}/"
   }
 
   stages {
@@ -323,7 +324,7 @@ pipeline {
         stage('MPI_verbs-rxm') {
           steps {
             script {
-              dir ("${env.WORKSPACE}/${SCRIPT_LOCATION}/") {
+              dir (RUN_LOCATION) {
                 def providers = [["verbs", "rxm"]]
                 for (mpi in MPI_TYPES) {
                   for (imb_grp = 1; imb_grp < 4; imb_grp++) {
@@ -341,7 +342,7 @@ pipeline {
         stage('MPI_tcp-rxm') {
           steps {
             script {
-              dir ("${env.WORKSPACE}/${SCRIPT_LOCATION}/") {
+              dir (RUN_LOCATION) {
                 def providers = [["tcp", "rxm"]]
                 for (mpi in MPI_TYPES) {
                   for (imb_grp = 1; imb_grp < 4; imb_grp++) {
@@ -358,7 +359,7 @@ pipeline {
         stage('tcp') {
            steps {
             script {
-              dir ("${env.WORKSPACE}/${SCRIPT_LOCATION}/") {
+              dir (RUN_LOCATION) {
                 run_fabtests("tcp", "bulbasaur", "2", "tcp")
               }
             }
@@ -367,7 +368,7 @@ pipeline {
         stage('verbs-rxm') {
           steps {
             script {
-              dir ("${env.WORKSPACE}/${SCRIPT_LOCATION}/") {
+              dir (RUN_LOCATION) {
                 run_fabtests("verbs-rxm", "squirtle,totodile", "2", "verbs",
                              "rxm")
               }
@@ -377,7 +378,7 @@ pipeline {
         stage('verbs-rxd') {
           steps {
             script {
-              dir ("${env.WORKSPACE}/${SCRIPT_LOCATION}/") {
+              dir (RUN_LOCATION) {
                 run_fabtests("verbs-rxd", "squirtle", "2", "verbs",
                              "rxd")
               }
@@ -387,7 +388,7 @@ pipeline {
         stage('udp') {
           steps {
             script {
-              dir ("${env.WORKSPACE}/${SCRIPT_LOCATION}/") {
+              dir (RUN_LOCATION) {
                 run_fabtests("udp", "bulbasaur", "2", "udp")
               }
             }
@@ -396,7 +397,7 @@ pipeline {
         stage('shm') {
           steps {
             script {
-              dir ("${env.WORKSPACE}/${SCRIPT_LOCATION}/") {
+              dir (RUN_LOCATION) {
                 run_fabtests("shm", "bulbasaur", "1", "shm")
                 run_fabtests("shm", "bulbasaur", "1", "shm", null,
                             "FI_SHM_DISABLE_CMA=1")
@@ -407,7 +408,7 @@ pipeline {
         stage('sockets') {
           steps {
             script {
-              dir ("${env.WORKSPACE}/${SCRIPT_LOCATION}/") {
+              dir (RUN_LOCATION) {
                 run_fabtests("sockets", "bulbasaur", "2", "sockets")
               }
             }
@@ -416,7 +417,7 @@ pipeline {
         stage('ucx') {
           steps {
             script {
-             command="""${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py \
+             command="""${RUN_LOCATION}/build.py \
                       --ucx --build_item="""
               for (mode in  BUILD_MODES) {
                 echo "Building Libfabric $mode"
@@ -430,7 +431,7 @@ pipeline {
                            """${command}${build_item} \
                            --ofi_build_mode=$mode""")
               }
-              dir ("${env.WORKSPACE}/${SCRIPT_LOCATION}/") {
+              dir (RUN_LOCATION) {
                 run_fabtests("ucx", "totodile", "2", "ucx")
               }
             }
@@ -439,7 +440,7 @@ pipeline {
         stage('psm3') {
           steps {
             script {
-              dir ("${env.WORKSPACE}/${SCRIPT_LOCATION}/") {
+              dir (RUN_LOCATION) {
                 run_fabtests("psm3", "squirtle", "2", "psm3", null,
                             "PSM3_IDENTIFY=1")
               }
@@ -449,7 +450,7 @@ pipeline {
         stage('mpichtestsuite') {
           steps {
             script {
-              dir ("${env.WORKSPACE}/${SCRIPT_LOCATION}/") {
+              dir (RUN_LOCATION) {
                 def providers = [["verbs", "rxm"], ["tcp", null],
                                  ["tcp", "rxm"], ["sockets", null]]
                 for (mpi in MPI_TYPES) {
@@ -463,7 +464,7 @@ pipeline {
         stage('SHMEM') {
           steps {
             script {
-              dir ("${env.WORKSPACE}/${SCRIPT_LOCATION}/") {
+              dir (RUN_LOCATION) {
                 run_middleware([["verbs", null], ["tcp", null],
                                 ["sockets", null]], "SHMEM", "shmem",
                                 "squirtle,totodile", "2")
@@ -474,7 +475,7 @@ pipeline {
         stage ('multinode_performance') {
           steps {
             script {
-              dir ("${env.WORKSPACE}/${SCRIPT_LOCATION}/") {
+              dir (RUN_LOCATION) {
                 run_middleware([["tcp", null]], "multinode_performance",
                                "multinode", "bulbasaur", "2")
               }
@@ -484,7 +485,7 @@ pipeline {
         stage ('oneCCL') {
           steps {
             script {
-              dir ("${env.WORKSPACE}/${SCRIPT_LOCATION}/") {
+              dir (RUN_LOCATION) {
                 run_middleware([["tcp", "rxm"]/*, ["psm3", null]*/], "oneCCL",
                                "oneccl", "bulbasaur", "2")
               }
@@ -494,7 +495,7 @@ pipeline {
         stage ('oneCCL-GPU') {
           steps {
             script {
-              dir ("${env.WORKSPACE}/${SCRIPT_LOCATION}/") {
+              dir (RUN_LOCATION) {
                 run_middleware([["verbs", "rxm"]], "oneCCL-GPU", "onecclgpu",
                                "charmander", "2")
               }
@@ -506,7 +507,7 @@ pipeline {
           options { skipDefaultCheckout() }
           steps {
             script {
-              dir ("${env.WORKSPACE}/${SCRIPT_LOCATION}/") {
+              dir (RUN_LOCATION) {
                 run_middleware([["verbs", "rxm"]], "oneCCL-GPU-v3", "onecclgpu",
                                "fabrics-ci", "2")
               } 
@@ -518,7 +519,7 @@ pipeline {
           options { skipDefaultCheckout() }
           steps {
             script {
-              dir ("${env.WORKSPACE}/${SCRIPT_LOCATION}/") {
+              dir (RUN_LOCATION) {
                 run_python(PYTHON_VERSION,
                            """runtests.py --prov='tcp' --util='rxm' \
                            --test=daos \
@@ -532,7 +533,7 @@ pipeline {
           options { skipDefaultCheckout() }
           steps {
             script {
-              dir ("${env.WORKSPACE}/${SCRIPT_LOCATION}/") {
+              dir (RUN_LOCATION) {
                 run_python(PYTHON_VERSION,
                            """runtests.py --prov='verbs' --util='rxm' \
                            --test=daos \
@@ -544,7 +545,7 @@ pipeline {
         stage ('ze-shm') {
           steps {
             script {
-              dir ("${env.WORKSPACE}/${SCRIPT_LOCATION}/") {
+              dir (RUN_LOCATION) {
                 def providers = [["shm", null]]
                 def directions = ["h2d", "d2d", "xd2d"]
                 def base_cmd = "python3.9 runtests.py --device=ze"
@@ -575,7 +576,7 @@ pipeline {
           options { skipDefaultCheckout() }
           steps {
             script {
-              dir ("${env.WORKSPACE}/${SCRIPT_LOCATION}/") {
+              dir (RUN_LOCATION) {
                 def providers = [["shm", null]]
                 def directions = ["h2d", "d2d", "xd2d"]
                 def base_cmd = "python3.9 runtests.py --device=ze"
@@ -610,15 +611,12 @@ pipeline {
           }
           when { equals expected: true, actual: DO_RUN }
           steps {
-            withEnv(["${WITH_ENV}"]) {
-              sh """
-              env
-              (
-                echo `hostname`
-                cd ${env.WORKSPACE}/${SCRIPT_LOCATION}/
-                python3.9 runtests.py --prov=shm --test=fabtests --user_env FI_SHM_DISABLE_CMA=1 FI_SHM_USE_DSA_SAR=1
-              )
-              """
+            script {
+              dir (RUN_LOCATION) {
+                run_python(PYTHON_VERSION,
+                """runtests.py --prov=shm --test=fabtests \
+                   --user_env FI_SHM_DISABLE_CMA=1 FI_SHM_USE_DSA_SAR=1""")
+              }
             }
           }
         }
@@ -634,31 +632,11 @@ pipeline {
           //             "${env.LOG_DIR}")
           gather_logs("${env.ZE_ADDR}", "${env.ZE_KEY}", "${env.LOG_DIR}",
                       "${env.LOG_DIR}")
-        }
-        withEnv(["${WITH_ENV}"]) {
-          sh """
-            env
-            (
-              if [[ ${RELEASE} = true ]]; then
-                python3.9 ${env.WORKSPACE}/${SCRIPT_LOCATION}/summary.py --summary_item=all --release
-              else
-                python3.9 ${env.WORKSPACE}/${SCRIPT_LOCATION}/summary.py --summary_item=all
-              fi
-              echo "------------"
-              if [[ ${RELEASE} = true ]]; then
-                mkdir -p ${env.WORKSPACE}/internal
-                rm -rf ${env.WORKSPACE}/internal/*
-                git clone https://${env.PAT}@github.com/${env.INTERNAL} ${env.WORKSPACE}/internal
-                cd ${env.WORKSPACE}/internal
-                mkdir -p ${env.WORKSPACE}/internal/summaries
-                cp ${env.WORKSPACE}/summary_*.log ${env.WORKSPACE}/internal/summaries/
-                git add ${env.WORKSPACE}/internal/summaries/
-                git commit -am \"add ${env.JOB_NAME}'s summary\"
-                git pull -r origin master
-                git push origin master
-              fi
-            )
-          """
+
+          summarize("all", verbose=false, release=RELEASE)
+          if (RELEASE) {
+            save_summary()
+          }
         }
       }
     }

--- a/contrib/intel/jenkins/summary.py
+++ b/contrib/intel/jenkins/summary.py
@@ -757,6 +757,15 @@ def summarize_items(summary_item, logger, log_dir, mode):
         ).summarize()
         err += ret if ret else 0
 
+    if summary_item == 'dsa' or summary_item == 'all':
+        for prov in ['shm']:
+            ret = FabtestsSummarizer(
+                logger, log_dir, 'shm',
+                f'fabtests_{prov}_dsa_{mode}',
+                f"fabtests {prov} dsa {mode}"
+            ).summarize()
+            err += ret if ret else 0
+
     return err
 
 if __name__ == "__main__":
@@ -772,7 +781,7 @@ if __name__ == "__main__":
     parser.add_argument('--summary_item', help="functional test to summarize",
                          choices=['fabtests', 'imb', 'osu', 'mpichtestsuite',
                          'oneccl', 'shmem', 'ze', 'multinode', 'daos', 'v3',
-                         'all'])
+                         'dsa', 'all'])
     parser.add_argument('--ofi_build_mode', help="select buildmode debug or dl",
                         choices=['dbg', 'dl', 'reg'], default='all')
     parser.add_argument('-v', help="Verbose mode. Print all tests", \

--- a/contrib/intel/jenkins/summary.py
+++ b/contrib/intel/jenkins/summary.py
@@ -653,6 +653,16 @@ def summarize_items(summary_item, logger, log_dir, mode):
             ).summarize()
             err += ret if ret else 0
 
+    if ((summary_item == 'daos' or summary_item == 'all')
+         and mode == 'reg'):
+        for prov in ['tcp-rxm', 'verbs-rxm']:
+            ret = DaosSummarizer(
+                logger, log_dir, prov,
+                f'daos_{prov}_{mode}',
+                f"{prov} daos {mode}"
+            ).summarize()
+            err += ret if ret else 0
+
     if summary_item == 'imb' or summary_item == 'all':
         for mpi in mpi_list:
             for item in ['tcp-rxm', 'verbs-rxm', 'tcp']:
@@ -729,16 +739,6 @@ def summarize_items(summary_item, logger, log_dir, mode):
                     f"ze {prov} {type} {mode}"
                 ).summarize()
                 err += ret if ret else 0
-
-    if ((summary_item == 'daos' or summary_item == 'all')
-         and mode == 'reg'):
-        for prov in ['tcp-rxm', 'verbs-rxm']:
-            ret = DaosSummarizer(
-                logger, log_dir, prov,
-                f'daos_{prov}_{mode}',
-                f"{prov} daos {mode}"
-            ).summarize()
-            err += ret if ret else 0
 
     return err
 

--- a/contrib/intel/jenkins/summary.py
+++ b/contrib/intel/jenkins/summary.py
@@ -565,11 +565,11 @@ class DaosSummarizer(Summarizer):
 
         if (self.exists):
             if ('verbs' in file_name):
-                self.node = cloudbees_config.prov_node_map['verbs']
+                self.node = cloudbees_config.daos_prov_node_map['verbs']
             if ('tcp' in file_name):
-                self.node = cloudbees_config.prov_node_map['tcp']
+                self.node = cloudbees_config.daos_prov_node_map['tcp']
 
-            self.features = cloudbees_config.node_features
+            self.features = cloudbees_config.daos_node_features
 
     def check_name(self, line):
         if "reading ." in line:

--- a/contrib/intel/jenkins/summary.py
+++ b/contrib/intel/jenkins/summary.py
@@ -740,6 +740,23 @@ def summarize_items(summary_item, logger, log_dir, mode):
                 ).summarize()
                 err += ret if ret else 0
 
+    if summary_item == 'v3' or summary_item == 'all':
+        test_types = ['h2d', 'd2d', 'xd2d']
+        for type in test_types:
+            ret = FabtestsSummarizer(
+                logger, log_dir, 'shm',
+                f'ze_v3_shm_{type}_{mode}',
+                f"ze v3 shm {type} {mode}"
+            ).summarize()
+            err += ret if ret else 0
+
+        ret = OnecclSummarizer(
+                logger, log_dir, 'oneCCL-GPU',
+                f'oneCCL-GPU-v3_verbs-rxm_onecclgpu_{mode}',
+                f'oneCCL-GPU-v3 verbs-rxm {mode}'
+        ).summarize()
+        err += ret if ret else 0
+
     return err
 
 if __name__ == "__main__":
@@ -754,7 +771,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('--summary_item', help="functional test to summarize",
                          choices=['fabtests', 'imb', 'osu', 'mpichtestsuite',
-                         'oneccl', 'shmem', 'ze', 'multinode', 'daos', 'all'])
+                         'oneccl', 'shmem', 'ze', 'multinode', 'daos', 'v3',
+                         'all'])
     parser.add_argument('--ofi_build_mode', help="select buildmode debug or dl",
                         choices=['dbg', 'dl', 'reg'], default='all')
     parser.add_argument('-v', help="Verbose mode. Print all tests", \

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -189,7 +189,11 @@ class Fabtest(Test):
         os.chdir(self.fabtestconfigpath)
         command = self.cmd + self.options
         outputcmd = shlex.split(command)
-        common.run_command(outputcmd)
+        if sum([(True if 'dsa' in key.lower() else False)
+                for key in self.env.keys()]) > 0:
+            common.run_logging_command(outputcmd, self.log_file)
+        else:
+            common.run_command(outputcmd)
         os.chdir(curdir)
 
 


### PR DESCRIPTION
Import files from sub-clusters (non main pipeline clusters) to be run through the summarizer once rather than have to invoke the summarizer on each cluster.
Add DSA and GPU-V3 to the summary

Cleanup the Jenkinsfile:
Make re-used variables global pipeline environment variables
Add methods for withEnv statements to remove large triple quote shell blocks.
Replace non script{} blocks with script{} blocks for better maintainability 
Reduce new line use in post stage by consolidating one line bracket statements into one line
Reduce most lines to less than 80 characters to follow libfabric coding style