### PR TITLE
prov/verbs: Track ep state to prevent duplicate shutdown events

### DIFF
--- a/prov/tcp/src/xnet_eq.c
+++ b/prov/tcp/src/xnet_eq.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022 Intel Corporation. All rights reserved.
+ * Copyright (c) Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/prov/verbs/src/verbs_cm.c
+++ b/prov/verbs/src/verbs_cm.c
@@ -309,7 +309,7 @@ vrb_msg_ep_reject(struct fid_pep *pep, fid_t handle,
 	cm_hdr = alloca(sizeof(*cm_hdr) + paramlen);
 	vrb_msg_ep_prepare_cm_data(param, paramlen, cm_hdr);
 
-	ofi_mutex_lock(&_pep->eq->lock);
+	ofi_mutex_lock(&_pep->eq->event_lock);
 	if (connreq->is_xrc) {
 		ret = vrb_msg_xrc_ep_reject(connreq, cm_hdr,
 				(uint8_t)(sizeof(*cm_hdr) + paramlen));
@@ -319,7 +319,7 @@ vrb_msg_ep_reject(struct fid_pep *pep, fid_t handle,
 	} else {
 		ret = -FI_EBUSY;
 	}
-	ofi_mutex_unlock(&_pep->eq->lock);
+	ofi_mutex_unlock(&_pep->eq->event_lock);
 
 	if (ret)
 		VRB_WARN_ERR(FI_LOG_EP_CTRL, "rdma_reject", ret);
@@ -413,9 +413,9 @@ vrb_msg_xrc_ep_connect(struct fid_ep *ep, const void *addr,
 	}
 	xrc_ep->conn_setup->conn_tag = VERBS_CONN_TAG_INVALID;
 
-	ofi_mutex_lock(&xrc_ep->base_ep.eq->lock);
+	ofi_mutex_lock(&xrc_ep->base_ep.eq->event_lock);
 	ret = vrb_connect_xrc(xrc_ep, NULL, 0, adjusted_param, paramlen);
-	ofi_mutex_unlock(&xrc_ep->base_ep.eq->lock);
+	ofi_mutex_unlock(&xrc_ep->base_ep.eq->event_lock);
 
 	free(adjusted_param);
 	free(cm_hdr);
@@ -445,9 +445,9 @@ vrb_msg_xrc_ep_accept(struct fid_ep *ep, const void *param, size_t paramlen)
 	if (ret)
 		return ret;
 
-	ofi_mutex_lock(&xrc_ep->base_ep.eq->lock);
+	ofi_mutex_lock(&xrc_ep->base_ep.eq->event_lock);
 	ret = vrb_accept_xrc(xrc_ep, 0, adjusted_param, paramlen);
-	ofi_mutex_unlock(&xrc_ep->base_ep.eq->lock);
+	ofi_mutex_unlock(&xrc_ep->base_ep.eq->event_lock);
 
 	free(adjusted_param);
 	return ret;

--- a/prov/verbs/src/verbs_cm.c
+++ b/prov/verbs/src/verbs_cm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2021 Intel Corporation, Inc.  All rights reserved.
+ * Copyright (c) Intel Corporation, Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -156,8 +156,7 @@ static int
 vrb_msg_ep_connect(struct fid_ep *ep_fid, const void *addr,
 		      const void *param, size_t paramlen)
 {
-	struct vrb_ep *ep =
-		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
+	struct vrb_ep *ep = container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	size_t priv_data_len;
 	struct vrb_cm_data_hdr *cm_hdr;
 	off_t rdma_cm_hdr_len = 0;
@@ -194,14 +193,19 @@ vrb_msg_ep_connect(struct fid_ep *ep_fid, const void *addr,
 	if (ep->srx)
 		ep->conn_param.srq = 1;
 
-	if (rdma_resolve_route(ep->id, VERBS_RESOLVE_TIMEOUT)) {
+	ofi_genlock_lock(&vrb_ep2_progress(ep)->ep_lock);
+	assert(ep->state == VRB_IDLE);
+	ep->state = VRB_RESOLVE_ROUTE;
+	ret = rdma_resolve_route(ep->id, VERBS_RESOLVE_TIMEOUT);
+	if (ret) {
 		ret = -errno;
 		VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "rdma_resolve_route");
 		free(ep->cm_priv_data);
 		ep->cm_priv_data = NULL;
-		return ret;
+		ep->state = VRB_IDLE;
 	}
-	return 0;
+	ofi_genlock_unlock(&vrb_ep2_progress(ep)->ep_lock);
+	return ret;
 }
 
 static int
@@ -211,8 +215,7 @@ vrb_msg_ep_accept(struct fid_ep *ep, const void *param, size_t paramlen)
 	struct vrb_connreq *connreq;
 	int ret;
 	struct vrb_cm_data_hdr *cm_hdr;
-	struct vrb_ep *_ep =
-		container_of(ep, struct vrb_ep, util_ep.ep_fid);
+	struct vrb_ep *_ep = container_of(ep, struct vrb_ep, util_ep.ep_fid);
 
 	if (OFI_UNLIKELY(paramlen > VERBS_CM_DATA_SIZE))
 		return -FI_EINVAL;
@@ -233,16 +236,21 @@ vrb_msg_ep_accept(struct fid_ep *ep, const void *param, size_t paramlen)
 	if (_ep->srx)
 		conn_param.srq = 1;
 
+	ofi_genlock_lock(&vrb_ep2_progress(_ep)->ep_lock);
+	assert(_ep->state == VRB_REQ_RCVD);
+	_ep->state = VRB_ACCEPTING;
 	ret = rdma_accept(_ep->id, &conn_param);
 	if (ret) {
 		VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "rdma_accept");
-		return -errno;
+		_ep->state = VRB_DISCONNECTED;
+		ret = -errno;
+	} else {
+		connreq = container_of(_ep->info_attr.handle,
+				       struct vrb_connreq, handle);
+		free(connreq);
 	}
-
-	connreq = container_of(_ep->info_attr.handle, struct vrb_connreq, handle);
-	free(connreq);
-
-	return 0;
+	ofi_genlock_unlock(&vrb_ep2_progress(_ep)->ep_lock);
+	return ret;
 }
 
 static int vrb_msg_alloc_xrc_params(void **adjusted_param,
@@ -330,8 +338,8 @@ vrb_msg_ep_reject(struct fid_pep *pep, fid_t handle,
 
 static int vrb_msg_ep_shutdown(struct fid_ep *ep, uint64_t flags)
 {
-	struct vrb_ep *_ep =
-		container_of(ep, struct vrb_ep, util_ep.ep_fid);
+	struct vrb_ep *_ep = container_of(ep, struct vrb_ep, util_ep.ep_fid);
+
 	if (_ep->id)
 		return rdma_disconnect(_ep->id) ? -errno : 0;
 	return 0;

--- a/prov/verbs/src/verbs_cm_xrc.c
+++ b/prov/verbs/src/verbs_cm_xrc.c
@@ -167,7 +167,7 @@ static void vrb_log_ep_conn(struct vrb_xrc_ep *ep, char *desc)
 
 void vrb_free_xrc_conn_setup(struct vrb_xrc_ep *ep, int disconnect)
 {
-	assert(ofi_mutex_held(&ep->base_ep.eq->lock));
+	assert(ofi_mutex_held(&ep->base_ep.eq->event_lock));
 	assert(ep->conn_setup);
 
 	/* If a disconnect is requested then the XRC bidirectional connection
@@ -207,7 +207,7 @@ int vrb_connect_xrc(struct vrb_xrc_ep *ep, struct sockaddr *addr,
 	struct vrb_domain *domain = vrb_ep2_domain(&ep->base_ep);
 	int ret;
 
-	assert(ofi_mutex_held(&ep->base_ep.eq->lock));
+	assert(ofi_mutex_held(&ep->base_ep.eq->event_lock));
 	assert(!ep->base_ep.id && !ep->base_ep.ibv_qp && !ep->ini_conn);
 
 	domain->xrc.lock_acquire(&domain->xrc.ini_lock);
@@ -235,7 +235,7 @@ void vrb_ep_ini_conn_done(struct vrb_xrc_ep *ep, uint32_t tgt_qpn)
 {
 	struct vrb_domain *domain = vrb_ep2_domain(&ep->base_ep);
 
-	assert(ofi_mutex_held(&ep->base_ep.eq->lock));
+	assert(ofi_mutex_held(&ep->base_ep.eq->event_lock));
 	assert(ep->base_ep.id && ep->ini_conn);
 
 	domain->xrc.lock_acquire(&domain->xrc.ini_lock);
@@ -263,7 +263,7 @@ void vrb_ep_ini_conn_done(struct vrb_xrc_ep *ep, uint32_t tgt_qpn)
 
 void vrb_ep_ini_conn_rejected(struct vrb_xrc_ep *ep)
 {
-	assert(ofi_mutex_held(&ep->base_ep.eq->lock));
+	assert(ofi_mutex_held(&ep->base_ep.eq->event_lock));
 	assert(ep->base_ep.id && ep->ini_conn);
 
 	vrb_log_ep_conn(ep, "INI Connection Rejected");
@@ -288,7 +288,7 @@ int vrb_resend_shared_accept_xrc(struct vrb_xrc_ep *ep,
 	struct rdma_conn_param conn_param = { 0 };
 	struct vrb_xrc_cm_data *cm_data = ep->accept_param_data;
 
-	assert(ofi_mutex_held(&ep->base_ep.eq->lock));
+	assert(ofi_mutex_held(&ep->base_ep.eq->event_lock));
 	assert(cm_data && ep->tgt_ibv_qp);
 	assert(ep->tgt_ibv_qp->qp_num == connreq->xrc.tgt_qpn);
 	assert(ep->peer_srqn == connreq->xrc.peer_srqn);
@@ -320,7 +320,7 @@ int vrb_accept_xrc(struct vrb_xrc_ep *ep, int reciprocal,
 	struct vrb_xrc_cm_data connect_cm_data = { 0 };
 	int ret;
 
-	assert(ofi_mutex_held(&ep->base_ep.eq->lock));
+	assert(ofi_mutex_held(&ep->base_ep.eq->event_lock));
 	addr = rdma_get_local_addr(ep->tgt_id);
 	if (addr)
 		ofi_straddr_dbg(&vrb_prov, FI_LOG_CORE, "src_addr", addr);

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -612,12 +612,12 @@ int vrb_init_progress(struct vrb_progress *progress, struct ibv_context *verbs)
 {
 	int ret;
 
-	ret = ofi_genlock_init(&progress->lock, OFI_LOCK_MUTEX);
+	ret = ofi_genlock_init(&progress->ep_lock, OFI_LOCK_MUTEX);
 	if (ret)
 		return ret;
 
 	/* Active lock will be needed when adding rdm ep support */
-	progress->active_lock = &progress->lock;
+	progress->active_lock = &progress->ep_lock;
 
 	ret = ofi_bufpool_create(&progress->ctx_pool, sizeof(struct fi_context),
 				 16, 0, 1024, OFI_BUFPOOL_NO_TRACK);
@@ -627,12 +627,12 @@ int vrb_init_progress(struct vrb_progress *progress, struct ibv_context *verbs)
 	return 0;
 
 err1:
-	ofi_genlock_destroy(&progress->lock);
+	ofi_genlock_destroy(&progress->ep_lock);
 	return ret;
 }
 
 void vrb_close_progress(struct vrb_progress *progress)
 {
 	ofi_bufpool_destroy(progress->ctx_pool);
-	ofi_genlock_destroy(&progress->lock);
+	ofi_genlock_destroy(&progress->ep_lock);
 }

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2015 Intel Corporation, Inc.  All rights reserved.
+ * Copyright (c) Intel Corporation, Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -227,7 +227,7 @@ int vrb_poll_cq(struct vrb_cq *cq, struct ibv_wc *wc)
 		ctx = (struct vrb_context *) (uintptr_t) wc->wr_id;
 		wc->wr_id = (uintptr_t) ctx->user_ctx;
 		if (wc->status != IBV_WC_SUCCESS && wc->status != IBV_WC_WR_FLUSH_ERR)
-			vrb_shutdown_qp_in_err(ctx->ep);
+			vrb_shutdown_ep(ctx->ep);
 		if (ctx->op_queue == VRB_OP_SQ) {
 			ep = ctx->ep;
 			assert(ep);

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -66,7 +66,7 @@ static int vrb_enable_ep_flow_ctrl(struct fid_ep *ep_fid, uint64_t threshold)
 		return -FI_ENOSYS;
 
 	ep = container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
-	ofi_genlock_lock(&vrb_ep2_progress(ep)->lock);
+	ofi_genlock_lock(&vrb_ep2_progress(ep)->ep_lock);
 	ep->threshold = threshold;
 
 	/*
@@ -92,7 +92,7 @@ static int vrb_enable_ep_flow_ctrl(struct fid_ep *ep_fid, uint64_t threshold)
 					     credits_to_give)) {
 		ep->rq_credits_avail += credits_to_give;
 	}
-	ofi_genlock_unlock(&vrb_ep2_progress(ep)->lock);
+	ofi_genlock_unlock(&vrb_ep2_progress(ep)->ep_lock);
 
 	return FI_SUCCESS;
 }

--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -432,7 +432,7 @@ static int vrb_put_tgt_qp(struct vrb_xrc_ep *ep)
 
 int vrb_ep_destroy_xrc_qp(struct vrb_xrc_ep *ep)
 {
-	assert(ofi_mutex_held(&ep->base_ep.eq->lock));
+	assert(ofi_mutex_held(&ep->base_ep.eq->event_lock));
 	vrb_put_shared_ini_conn(ep);
 
 	if (ep->base_ep.id) {

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -80,7 +80,7 @@ void vrb_eq_set_xrc_conn_tag(struct vrb_xrc_ep *ep)
 {
 	struct vrb_eq *eq = ep->base_ep.eq;
 
-	assert(ofi_mutex_held(&eq->lock));
+	assert(ofi_mutex_held(&eq->event_lock));
 	assert(ep->conn_setup);
 	assert(ep->conn_setup->conn_tag == VERBS_CONN_TAG_INVALID);
 	ep->conn_setup->conn_tag =
@@ -93,7 +93,7 @@ void vrb_eq_clear_xrc_conn_tag(struct vrb_xrc_ep *ep)
 	struct vrb_eq *eq = ep->base_ep.eq;
 	int index;
 
-	assert(ofi_mutex_held(&eq->lock));
+	assert(ofi_mutex_held(&eq->event_lock));
 	assert(ep->conn_setup);
 	if (ep->conn_setup->conn_tag == VERBS_CONN_TAG_INVALID)
 		return;
@@ -108,13 +108,13 @@ void vrb_eq_clear_xrc_conn_tag(struct vrb_xrc_ep *ep)
 	ep->conn_setup->conn_tag = VERBS_CONN_TAG_INVALID;
 }
 
-struct vrb_xrc_ep *vrb_eq_xrc_conn_tag2ep(struct vrb_eq *eq,
-					  uint32_t conn_tag)
+static struct vrb_xrc_ep *
+vrb_eq_xrc_conn_tag2ep(struct vrb_eq *eq, uint32_t conn_tag)
 {
 	struct vrb_xrc_ep *ep;
 	int index;
 
-	assert(ofi_mutex_held(&eq->lock));
+	assert(ofi_mutex_held(&eq->event_lock));
 	index = ofi_key2idx(&eq->xrc.conn_key_idx, (uint64_t)conn_tag);
 	ep = ofi_idx_lookup(eq->xrc.conn_key_map, index);
 	if (!ep || ep->magic != VERBS_XRC_EP_MAGIC) {
@@ -356,14 +356,14 @@ static int vrb_sidr_conn_compare(struct ofi_rbmap *map,
 		-1 : _key->recip > ep->recip_accept;
 }
 
-struct vrb_xrc_ep *vrb_eq_get_sidr_conn(struct vrb_eq *eq,
-					struct sockaddr *peer,
-					uint16_t pep_port, bool recip)
+static struct vrb_xrc_ep *
+vrb_eq_get_sidr_conn(struct vrb_eq *eq, struct sockaddr *peer,
+		     uint16_t pep_port, bool recip)
 {
 	struct ofi_rbnode *node;
 	struct vrb_sidr_conn_key key;
 
-	assert(ofi_mutex_held(&eq->lock));
+	assert(ofi_mutex_held(&eq->event_lock));
 	vrb_set_sidr_conn_key(peer, pep_port, recip, &key);
 	node = ofi_rbmap_find(&eq->xrc.sidr_conn_rbmap, &key);
 	if (OFI_LIKELY(!node))
@@ -378,7 +378,7 @@ int vrb_eq_add_sidr_conn(struct vrb_xrc_ep *ep,
 	int ret;
 	struct vrb_sidr_conn_key key;
 
-	assert(ofi_mutex_held(&ep->base_ep.eq->lock));
+	assert(ofi_mutex_held(&ep->base_ep.eq->event_lock));
 	assert(!ep->accept_param_data);
 	assert(param_len);
 	assert(ep->tgt_id && ep->tgt_id->ps == RDMA_PS_UDP);
@@ -410,7 +410,7 @@ int vrb_eq_add_sidr_conn(struct vrb_xrc_ep *ep,
 
 void vrb_eq_remove_sidr_conn(struct vrb_xrc_ep *ep)
 {
-	assert(ofi_mutex_held(&ep->base_ep.eq->lock));
+	assert(ofi_mutex_held(&ep->base_ep.eq->event_lock));
 	assert(ep->conn_map_node);
 
 	ofi_rbmap_delete(&ep->base_ep.eq->xrc.sidr_conn_rbmap,
@@ -422,17 +422,16 @@ void vrb_eq_remove_sidr_conn(struct vrb_xrc_ep *ep)
 
 static int
 vrb_eq_accept_recip_conn(struct vrb_xrc_ep *ep,
-			    struct fi_eq_cm_entry *entry, size_t len,
-			    uint32_t *event, struct rdma_cm_event *cma_event,
-			    int *acked)
+			 struct fi_eq_cm_entry *entry, size_t len,
+			 uint32_t *event, struct rdma_cm_event *cma_event,
+			 int *acked)
 {
 	struct vrb_xrc_cm_data cm_data;
 	int ret;
 
 	assert(ep->conn_state == VRB_XRC_ORIG_CONNECTED);
 
-	ret = vrb_accept_xrc(ep, VRB_RECIP_CONN, &cm_data,
-				sizeof(cm_data));
+	ret = vrb_accept_xrc(ep, VRB_RECIP_CONN, &cm_data, sizeof(cm_data));
 	if (ret) {
 		VRB_WARN(FI_LOG_EP_CTRL,
 			   "Reciprocal XRC Accept failed %d\n", ret);
@@ -664,7 +663,7 @@ vrb_eq_xrc_rej_event(struct vrb_eq *eq, struct rdma_cm_event *cma_event)
 	struct vrb_xrc_conn_info xrc_info;
 	enum vrb_xrc_ep_conn_state state;
 
-	assert(ofi_mutex_held(&eq->lock));
+	assert(ofi_mutex_held(&eq->event_lock));
 	ep = container_of(fid, struct vrb_xrc_ep, base_ep.util_ep.ep_fid);
 	if (ep->magic != VERBS_XRC_EP_MAGIC) {
 		VRB_WARN(FI_LOG_EP_CTRL,
@@ -709,7 +708,7 @@ static int
 vrb_eq_xrc_connect_retry(struct vrb_xrc_ep *ep,
 			 struct rdma_cm_event *cma_event, int *acked)
 {
-	assert(ofi_mutex_held(&ep->base_ep.eq->lock));
+	assert(ofi_mutex_held(&ep->base_ep.eq->event_lock));
 
 	if (ep->base_ep.info_attr.src_addr)
 		ofi_straddr_dbg(&vrb_prov, FI_LOG_EP_CTRL,
@@ -739,7 +738,7 @@ vrb_eq_xrc_cm_err_event(struct vrb_eq *eq,
 	fid_t fid = cma_event->id->context;
 	int ret;
 
-	assert(ofi_mutex_held(&eq->lock));
+	assert(ofi_mutex_held(&eq->event_lock));
 	ep = container_of(fid, struct vrb_xrc_ep, base_ep.util_ep.ep_fid);
 	if (ep->magic != VERBS_XRC_EP_MAGIC) {
 		VRB_WARN(FI_LOG_EP_CTRL, "CM ID context invalid\n");
@@ -791,7 +790,7 @@ vrb_eq_xrc_connected_event(struct vrb_eq *eq,
 
 	ep = container_of(fid, struct vrb_xrc_ep, base_ep.util_ep.ep_fid);
 
-	assert(ofi_mutex_held(&eq->lock));
+	assert(ofi_mutex_held(&eq->event_lock));
 	assert(ep->conn_state == VRB_XRC_ORIG_CONNECTING ||
 	       ep->conn_state == VRB_XRC_RECIP_CONNECTING);
 
@@ -818,7 +817,7 @@ vrb_eq_xrc_timewait_event(struct vrb_eq *eq,
 	struct vrb_xrc_ep *ep = container_of(fid, struct vrb_xrc_ep,
 						base_ep.util_ep.ep_fid);
 
-	assert(ofi_mutex_held(&eq->lock));
+	assert(ofi_mutex_held(&eq->event_lock));
 	assert(ep->magic == VERBS_XRC_EP_MAGIC);
 	assert(ep->conn_setup);
 
@@ -845,7 +844,7 @@ vrb_eq_xrc_disconnect_event(struct vrb_eq *eq,
 	struct vrb_xrc_ep *ep = container_of(fid, struct vrb_xrc_ep,
 					     base_ep.util_ep.ep_fid);
 
-	assert(ofi_mutex_held(&eq->lock));
+	assert(ofi_mutex_held(&eq->event_lock));
 	assert(ep->magic == VERBS_XRC_EP_MAGIC);
 
 	if (ep->conn_setup && cma_event->id == ep->base_ep.id) {
@@ -871,6 +870,7 @@ vrb_eq_cm_process_event(struct vrb_eq *eq,
 	struct vrb_ep *ep;
 	struct vrb_xrc_ep *xrc_ep;
 
+	assert(ofi_mutex_held(&eq->event_lock));
 	switch (cma_event->event) {
 	case RDMA_CM_EVENT_ROUTE_RESOLVED:
 		ep = container_of(fid, struct vrb_ep, util_ep.ep_fid);
@@ -1069,7 +1069,7 @@ void vrb_eq_remove_events(struct vrb_eq *eq, struct fid *fid)
 	struct dlist_entry *item;
 	struct vrb_eq_entry *entry;
 
-	assert(ofi_mutex_held(&eq->lock));
+	assert(ofi_mutex_held(&eq->event_lock));
 	while ((item =
 		dlistfd_remove_first_match(&eq->list_head,
 					   vrb_eq_match_event, fid))) {
@@ -1180,15 +1180,15 @@ vrb_eq_read(struct fid_eq *eq_fid, uint32_t *event,
 
 	/* Skip events that are handled internally (e.g. XRC CM events). */
 	do {
-		ofi_mutex_lock(&eq->lock);
+		ofi_mutex_lock(&eq->event_lock);
 		ret = rdma_get_cm_event(eq->channel, &cma_event);
 		if (ret) {
-			ofi_mutex_unlock(&eq->lock);
+			ofi_mutex_unlock(&eq->event_lock);
 			return -errno;
 		}
 
 		ret = vrb_eq_cm_process_event(eq, cma_event, event, buf, len);
-		ofi_mutex_unlock(&eq->lock);
+		ofi_mutex_unlock(&eq->event_lock);
 
 	} while (ret == -FI_EAGAIN);
 
@@ -1311,6 +1311,7 @@ static int vrb_eq_close(fid_t fid)
 	ofi_rbmap_cleanup(&eq->xrc.sidr_conn_rbmap);
 	ofi_idx_reset(eq->xrc.conn_key_map);
 	free(eq->xrc.conn_key_map);
+	ofi_mutex_destroy(&eq->event_lock);
 	ofi_mutex_destroy(&eq->lock);
 	free(eq);
 
@@ -1347,6 +1348,7 @@ int vrb_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 	ofi_rbmap_init(&_eq->xrc.sidr_conn_rbmap, vrb_sidr_conn_compare);
 
 	ofi_mutex_init(&_eq->lock);
+	ofi_mutex_init(&_eq->event_lock);
 	ret = dlistfd_head_init(&_eq->list_head);
 	if (ret) {
 		VRB_INFO(FI_LOG_EQ, "Unable to initialize dlistfd\n");
@@ -1408,6 +1410,7 @@ err3:
 err2:
 	dlistfd_head_free(&_eq->list_head);
 err1:
+	ofi_mutex_destroy(&_eq->event_lock);
 	ofi_mutex_destroy(&_eq->lock);
 	free(_eq->xrc.conn_key_map);
 err0:

--- a/prov/verbs/src/verbs_ofi.h
+++ b/prov/verbs/src/verbs_ofi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Intel Corporation, Inc.  All rights reserved.
+ * Copyright (c) Intel Corporation, Inc.  All rights reserved.
  * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
  * Copyright (c) 2018-2019 Cray Inc. All rights reserved.
  * Copyright (c) 2018-2019 System Fabric Works, Inc. All rights reserved.
@@ -572,6 +572,16 @@ struct vrb_xrc_ep_conn_setup {
 	uint8_t				pending_param[VRB_CM_DATA_SIZE];
 };
 
+enum vrb_ep_state {
+	VRB_IDLE,
+	VRB_RESOLVE_ROUTE,
+	VRB_CONNECTING,
+	VRB_REQ_RCVD,
+	VRB_ACCEPTING,
+	VRB_CONNECTED,
+	VRB_DISCONNECTED,
+};
+
 struct vrb_ep {
 	struct util_ep			util_ep;
 	struct ibv_qp			*ibv_qp;
@@ -586,6 +596,7 @@ struct vrb_ep {
 	int64_t				rq_credits_avail;
 	int64_t				threshold;
 
+	enum vrb_ep_state		state;
 	union {
 		struct rdma_cm_id	*id;
 		struct {
@@ -922,7 +933,7 @@ do {								\
 	( wr->opcode == IBV_WR_SEND || wr->opcode == IBV_WR_SEND_WITH_IMM	\
 	|| wr->opcode == IBV_WR_RDMA_WRITE_WITH_IMM )
 
-void vrb_shutdown_qp_in_err(struct vrb_ep *ep);
+void vrb_shutdown_ep(struct vrb_ep *ep);
 ssize_t vrb_post_send(struct vrb_ep *ep, struct ibv_send_wr *wr, uint64_t flags);
 ssize_t vrb_post_recv(struct vrb_ep *ep, struct ibv_recv_wr *wr);
 

--- a/prov/verbs/src/verbs_ofi.h
+++ b/prov/verbs/src/verbs_ofi.h
@@ -258,7 +258,7 @@ int vrb_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 int vrb_find_fabric(const struct fi_fabric_attr *attr);
 
 struct vrb_progress {
-	struct ofi_genlock	lock;
+	struct ofi_genlock	ep_lock;
 	struct ofi_genlock	*active_lock;
 
 	struct ofi_bufpool	*ctx_pool;

--- a/prov/verbs/src/verbs_ofi.h
+++ b/prov/verbs/src/verbs_ofi.h
@@ -297,6 +297,7 @@ struct vrb_eq {
 	struct fid_eq		eq_fid;
 	struct vrb_fabric	*fab;
 	ofi_mutex_t		lock;
+	ofi_mutex_t		event_lock;
 	struct dlistfd_head	list_head;
 	struct rdma_event_channel *channel;
 	uint64_t		flags;
@@ -766,9 +767,6 @@ struct vrb_cm_data_hdr {
 int vrb_eq_add_sidr_conn(struct vrb_xrc_ep *ep,
 			    void *param_data, size_t param_len);
 void vrb_eq_remove_sidr_conn(struct vrb_xrc_ep *ep);
-struct vrb_xrc_ep *vrb_eq_get_sidr_conn(struct vrb_eq *eq,
-					      struct sockaddr *peer,
-					      uint16_t pep_port, bool recip);
 
 void vrb_msg_ep_get_qp_attr(struct vrb_ep *ep,
 			       struct ibv_qp_init_attr *attr);
@@ -779,8 +777,6 @@ void vrb_next_xrc_conn_state(struct vrb_xrc_ep *ep);
 void vrb_prev_xrc_conn_state(struct vrb_xrc_ep *ep);
 void vrb_eq_set_xrc_conn_tag(struct vrb_xrc_ep *ep);
 void vrb_eq_clear_xrc_conn_tag(struct vrb_xrc_ep *ep);
-struct vrb_xrc_ep *vrb_eq_xrc_conn_tag2ep(struct vrb_eq *eq,
-						uint32_t conn_tag);
 void vrb_set_xrc_cm_data(struct vrb_xrc_cm_data *local, int reciprocal,
 			    uint32_t conn_tag, uint16_t port, uint32_t tgt_qpn,
 			    uint32_t srqn);


### PR DESCRIPTION
Track the connection state of msg endpoints.  This is needed to safely transition into a disconnect state, while ensuring that we only report a shutdown event to the user once.

There are 2 separate ways that we can determine that an endpoint has been disconnected.  One is by reading a disconnect event from the rdma cm.  Another is by reading an error completion from the CQ associated with the underlying QP.  Because we're not guaranteed to get a disconnect event (the remote peer system may have crashed without generating an RDMA disconnect traffic), if we read an error completion from the CQ, we need to notify the user that the local EP is no longer usable.  We do this by generating a local shutdown event.

However, we _could_ read a disconnect event from the EQ.  We have no way of knowing beforehand, or which order the disconnect notification could occur (from a CQ or EQ event).  The state checks allow us to transition the EP once and generate a single local shutdown event.