### PR TITLE
prov/shm: Remove mmap protocol

### DIFF
--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -68,7 +68,6 @@ enum {
 	smr_src_inline,	/* command data */
 	smr_src_inject,	/* inject buffers */
 	smr_src_iov,	/* reference iovec via CMA */
-	smr_src_mmap,	/* mmap-based fallback protocol */
 	smr_src_sar,	/* segmentation fallback protocol */
 	smr_src_ipc,	/* device IPC handle protocol */
 	smr_src_max,

--- a/man/man7/fi_shm.7
+++ b/man/man7/fi_shm.7
@@ -166,11 +166,6 @@ No support for counters.
 The \f[I]shm\f[R] provider checks for the following environment
 variables:
 .TP
-\f[I]FI_SHM_SAR_THRESHOLD\f[R]
-Maximum message size to use segmentation protocol before switching to
-mmap (only valid when CMA is not available).
-Default: SIZE_MAX (18446744073709551615)
-.TP
 \f[I]FI_SHM_TX_SIZE\f[R]
 Maximum number of outstanding tx operations.
 Default 1024

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -70,7 +70,6 @@
 #define _SMR_H_
 
 struct smr_env {
-	size_t sar_threshold;
 	int disable_cma;
 	int use_dsa_sar;
 	size_t max_gdrcopy_size;
@@ -238,13 +237,6 @@ static inline struct fid_peer_srx *smr_get_peer_srx(struct smr_ep *ep)
 
 #define smr_ep_rx_flags(smr_ep) ((smr_ep)->util_ep.rx_op_flags)
 #define smr_ep_tx_flags(smr_ep) ((smr_ep)->util_ep.tx_op_flags)
-
-static inline int smr_mmap_name(char *shm_name, const char *ep_name,
-				uint64_t msg_id)
-{
-	return snprintf(shm_name, SMR_NAME_MAX - 1, "%s_%ld",
-			ep_name, msg_id);
-}
 
 int smr_srx_context(struct fid_domain *domain, struct fi_rx_attr *attr,
 		struct fid_ep **rx_ep, void *context);

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -363,85 +363,6 @@ static int smr_format_ipc(struct smr_cmd *cmd, void *ptr, size_t len,
 	return FI_SUCCESS;
 }
 
-static int smr_format_mmap(struct smr_ep *ep, struct smr_cmd *cmd,
-		const struct iovec *iov, size_t count, size_t total_len,
-		struct smr_tx_entry *pend, struct smr_resp *resp)
-{
-	void *mapped_ptr;
-	int fd, ret, num;
-	uint64_t msg_id;
-	struct smr_ep_name *map_name;
-
-	msg_id = ep->msg_id++;
-	map_name = calloc(1, sizeof(*map_name));
-	if (!map_name) {
-		FI_WARN(&smr_prov, FI_LOG_EP_CTRL, "calloc error\n");
-		return -FI_ENOMEM;
-	}
-
-	pthread_mutex_lock(&ep_list_lock);
-	dlist_insert_tail(&map_name->entry, &ep_name_list);
-	pthread_mutex_unlock(&ep_list_lock);
-	num = smr_mmap_name(map_name->name, ep->name, msg_id);
-	if (num < 0) {
-		FI_WARN(&smr_prov, FI_LOG_AV, "generating shm file name failed\n");
-		ret = -errno;
-		goto remove_entry;
-	}
-
-	fd = shm_open(map_name->name, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
-	if (fd < 0) {
-		FI_WARN(&smr_prov, FI_LOG_EP_CTRL, "shm_open error\n");
-		ret = -errno;
-		goto remove_entry;
-	}
-
-	ret = ftruncate(fd, total_len);
-	if (ret < 0) {
-		FI_WARN(&smr_prov, FI_LOG_EP_CTRL, "ftruncate error\n");
-		goto unlink_close;
-	}
-
-	mapped_ptr = mmap(NULL, total_len, PROT_READ | PROT_WRITE,
-			  MAP_SHARED, fd, 0);
-	if (mapped_ptr == MAP_FAILED) {
-		FI_WARN(&smr_prov, FI_LOG_EP_CTRL, "mmap error\n");
-		ret = -errno;
-		goto unlink_close;
-	}
-
-	if (cmd->msg.hdr.op != ofi_op_read_req) {
-		if (ofi_copy_from_iov(mapped_ptr, total_len, iov, count, 0)
-		    != total_len) {
-			FI_WARN(&smr_prov, FI_LOG_EP_CTRL, "copy from iov error\n");
-			ret = -FI_EIO;
-			goto munmap;
-		}
-		munmap(mapped_ptr, total_len);
-	} else {
-		pend->map_ptr = mapped_ptr;
-	}
-
-	cmd->msg.hdr.op_src = smr_src_mmap;
-	cmd->msg.hdr.msg_id = msg_id;
-	cmd->msg.hdr.src_data = smr_get_offset(ep->region, resp);
-	cmd->msg.hdr.size = total_len;
-	pend->map_name = map_name;
-
-	close(fd);
-	return 0;
-
-munmap:
-	munmap(mapped_ptr, total_len);
-unlink_close:
-	shm_unlink(map_name->name);
-	close(fd);
-remove_entry:
-	dlist_remove(&map_name->entry);
-	free(map_name);
-	return ret;
-}
-
 size_t smr_copy_to_sar(struct smr_freestack *sar_pool, struct smr_resp *resp,
 		       struct smr_cmd *cmd, struct ofi_mr **mr,
 		       const struct iovec *iov, size_t count,
@@ -610,10 +531,7 @@ int smr_select_proto(enum fi_hmem_iface iface, bool use_ipc, bool cma_avail,
 	if (total_len <= SMR_INJECT_SIZE)
 		return smr_src_inject;
 
-	if (total_len <= smr_env.sar_threshold)
-		return smr_src_sar;
-
-	return smr_src_mmap;
+	return smr_src_sar;
 }
 
 static ssize_t smr_do_inline(struct smr_ep *ep, struct smr_region *peer_smr, int64_t id,
@@ -745,41 +663,11 @@ static ssize_t smr_do_ipc(struct smr_ep *ep, struct smr_region *peer_smr, int64_
 	return FI_SUCCESS;
 }
 
-static ssize_t smr_do_mmap(struct smr_ep *ep, struct smr_region *peer_smr, int64_t id,
-			   int64_t peer_id, uint32_t op, uint64_t tag, uint64_t data,
-			   uint64_t op_flags, struct ofi_mr **desc,
-		           const struct iovec *iov, size_t iov_count, size_t total_len,
-		           void *context, struct smr_cmd *cmd)
-{
-	struct smr_resp *resp;
-	struct smr_tx_entry *pend;
-	int ret;
-
-	if (ofi_cirque_isfull(smr_resp_queue(ep->region)))
-		return -FI_EAGAIN;
-
-	resp = ofi_cirque_next(smr_resp_queue(ep->region));
-	pend = ofi_freestack_pop(ep->tx_fs);
-
-	smr_generic_format(cmd, peer_id, op, tag, data, op_flags);
-	ret = smr_format_mmap(ep, cmd, iov, iov_count, total_len, pend, resp);
-	if (ret) {
-		ofi_freestack_push(ep->tx_fs, pend);
-		return ret;
-	}
-
-	smr_format_pend_resp(pend, cmd, context, desc, iov,
-			     iov_count, op_flags, id, resp);
-	ofi_cirque_commit(smr_resp_queue(ep->region));
-
-	return FI_SUCCESS;
-}
 
 smr_proto_func smr_proto_ops[smr_src_max] = {
 	[smr_src_inline] = &smr_do_inline,
 	[smr_src_inject] = &smr_do_inject,
 	[smr_src_iov] = &smr_do_iov,
-	[smr_src_mmap] = &smr_do_mmap,
 	[smr_src_sar] = &smr_do_sar,
 	[smr_src_ipc] = &smr_do_ipc,
 };

--- a/prov/shm/src/smr_init.c
+++ b/prov/shm/src/smr_init.c
@@ -41,7 +41,6 @@
 struct sigaction *old_action = NULL;
 
 struct smr_env smr_env = {
-	.sar_threshold = SIZE_MAX,
 	.disable_cma = false,
 	.use_dsa_sar = false,
 	.max_gdrcopy_size = 3072,
@@ -49,7 +48,6 @@ struct smr_env smr_env = {
 
 static void smr_init_env(void)
 {
-	fi_param_get_size_t(&smr_prov, "sar_threshold", &smr_env.sar_threshold);
 	fi_param_get_size_t(&smr_prov, "tx_size", &smr_info.tx_attr->size);
 	fi_param_get_size_t(&smr_prov, "rx_size", &smr_info.rx_attr->size);
 	fi_param_get_bool(&smr_prov, "disable_cma", &smr_env.disable_cma);
@@ -202,10 +200,6 @@ SHM_INI
 #if HAVE_SHM_DL
 	ofi_hmem_init();
 #endif
-	fi_param_define(&smr_prov, "sar_threshold", FI_PARAM_SIZE_T,
-			"Max size to use for alternate SAR protocol if CMA \
-			 is not available before switching to mmap protocol \
-			 Default: SIZE_MAX (18446744073709551615)");
 	fi_param_define(&smr_prov, "tx_size", FI_PARAM_SIZE_T,
 			"Max number of outstanding tx operations \
 			 Default: 1024");

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -69,7 +69,7 @@ smr_try_progress_from_sar(struct smr_ep *ep, struct smr_region *smr,
 {
 	if (*bytes_done < cmd->msg.hdr.size) {
 		if (smr_env.use_dsa_sar && ofi_mr_all_host(mr, iov_count)) {
-			(void) smr_dsa_copy_from_sar(ep, sar_pool, resp, cmd, 
+			(void) smr_dsa_copy_from_sar(ep, sar_pool, resp, cmd,
 					iov, iov_count, bytes_done, entry_ptr);
 			return;
 		} else {
@@ -128,37 +128,6 @@ static int smr_progress_resp_entry(struct smr_ep *ep, struct smr_resp *resp,
 		}
 
 		resp->status = SMR_STATUS_SUCCESS;
-		break;
-	case smr_src_mmap:
-		if (!pending->map_name)
-			break;
-		if (pending->cmd.msg.hdr.op == ofi_op_read_req) {
-			if (!*err) {
-				hmem_copy_ret =
-					ofi_copy_to_mr_iov(pending->mr,
-							   pending->iov,
-							   pending->iov_count,
-							   0, pending->map_ptr,
-							   pending->cmd.msg.hdr.size);
-				if (hmem_copy_ret < 0) {
-					FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-						"Copy from mmapped file failed with code %d\n",
-						(int)(-hmem_copy_ret));
-					*err = hmem_copy_ret;
-				} else if (hmem_copy_ret != pending->cmd.msg.hdr.size) {
-					FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-						"Incomplete copy from mmapped file\n");
-					*err = -FI_ETRUNC;
-				} else {
-					pending->bytes_done = (size_t) hmem_copy_ret;
-				}
-			}
-			munmap(pending->map_ptr, pending->cmd.msg.hdr.size);
-		}
-		shm_unlink(pending->map_name->name);
-		dlist_remove(&pending->map_name->entry);
-		free(pending->map_name);
-		pending->map_name = NULL;
 		break;
 	case smr_src_inject:
 		inj_offset = (size_t) pending->cmd.msg.hdr.src_data;
@@ -330,86 +299,6 @@ out:
 	resp->status = ret;
 
 	return -ret;
-}
-
-static int smr_mmap_peer_copy(struct smr_ep *ep, struct smr_cmd *cmd,
-			      struct ofi_mr **mr, struct iovec *iov,
-			      size_t iov_count, size_t *total_len)
-{
-	char shm_name[SMR_NAME_MAX];
-	void *mapped_ptr;
-	int fd, num;
-	int ret = 0;
-	ssize_t hmem_copy_ret;
-
-	num = smr_mmap_name(shm_name,
-			ep->region->map->peers[cmd->msg.hdr.id].peer.name,
-			cmd->msg.hdr.msg_id);
-	if (num < 0) {
-		FI_WARN(&smr_prov, FI_LOG_AV, "generating shm file name failed\n");
-		return -errno;
-	}
-
-	fd = shm_open(shm_name, O_RDWR, S_IRUSR | S_IWUSR);
-	if (fd < 0) {
-		FI_WARN(&smr_prov, FI_LOG_AV, "shm_open error\n");
-		return -errno;
-	}
-
-	mapped_ptr = mmap(NULL, cmd->msg.hdr.size, PROT_READ | PROT_WRITE,
-			  MAP_SHARED, fd, 0);
-	if (mapped_ptr == MAP_FAILED) {
-		FI_WARN(&smr_prov, FI_LOG_AV, "mmap error %s\n", strerror(errno));
-		ret = -errno;
-		goto unlink_close;
-	}
-
-	if (cmd->msg.hdr.op == ofi_op_read_req) {
-		hmem_copy_ret = ofi_copy_from_mr_iov(mapped_ptr,
-					cmd->msg.hdr.size, mr, iov,
-					iov_count, 0);
-	} else {
-		hmem_copy_ret = ofi_copy_to_mr_iov(mr, iov, iov_count, 0,
-					mapped_ptr, cmd->msg.hdr.size);
-	}
-
-	if (hmem_copy_ret < 0) {
-		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-			"mmap copy iov failed with code %d\n",
-			(int)(-hmem_copy_ret));
-		ret = hmem_copy_ret;
-	} else if (hmem_copy_ret != cmd->msg.hdr.size) {
-		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-			"mmap copy iov truncated\n");
-		ret = -FI_ETRUNC;
-	}
-
-	*total_len = hmem_copy_ret;
-
-	munmap(mapped_ptr, cmd->msg.hdr.size);
-unlink_close:
-	shm_unlink(shm_name);
-	close(fd);
-	return ret;
-}
-
-static int smr_progress_mmap(struct smr_cmd *cmd, struct ofi_mr **mr,
-			     struct iovec *iov, size_t iov_count,
-			     size_t *total_len, struct smr_ep *ep)
-{
-	struct smr_region *peer_smr;
-	struct smr_resp *resp;
-	int ret;
-
-	peer_smr = smr_peer_region(ep->region, cmd->msg.hdr.id);
-	resp = smr_get_ptr(peer_smr, cmd->msg.hdr.src_data);
-
-	ret = smr_mmap_peer_copy(ep, cmd, mr, iov, iov_count, total_len);
-
-	//Status must be set last (signals peer: op done, valid resp entry)
-	resp->status = ret;
-
-	return ret;
 }
 
 static struct smr_pend_entry *smr_progress_sar(struct smr_cmd *cmd,
@@ -731,11 +620,6 @@ static int smr_start_common(struct smr_ep *ep, struct smr_cmd *cmd,
 		err = smr_progress_iov(cmd, rx_entry->iov, rx_entry->count,
 				       &total_len, ep, 0);
 		break;
-	case smr_src_mmap:
-		err = smr_progress_mmap(cmd, (struct ofi_mr **) rx_entry->desc,
-					rx_entry->iov, rx_entry->count,
-					&total_len, ep);
-		break;
 	case smr_src_sar:
 		pend = smr_progress_sar(cmd, rx_entry,
 				       (struct ofi_mr **) rx_entry->desc,
@@ -948,10 +832,6 @@ static int smr_progress_cmd_rma(struct smr_ep *ep, struct smr_cmd *cmd,
 		break;
 	case smr_src_iov:
 		err = smr_progress_iov(cmd, iov, iov_count, &total_len, ep, ret);
-		break;
-	case smr_src_mmap:
-		err = smr_progress_mmap(cmd, mr, iov, iov_count, &total_len,
-					ep);
 		break;
 	case smr_src_sar:
 		if (smr_progress_sar(cmd, NULL, mr, iov, iov_count, &total_len,


### PR DESCRIPTION
The mmap protocol is not used or tested, and is just dead code taking up space in our repository. Remove FI_SHM_SAR_THRESHOLD which controls switching between mmap and sar protocols. We used to default to SAR if CMA wasn't available until message size SIZE_MAX, with the env var to modify our switching point.  This patch should not change any behavior in the SHM provider.