### PR TITLE
prov/shm: limit CQ polling to 8

### DIFF
--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -108,6 +108,7 @@ int smr_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 int smr_query_atomic(struct fid_domain *domain, enum fi_datatype datatype,
 		enum fi_op op, struct fi_atomic_attr *attr, uint64_t flags);
 
+#define SMR_MAX_MSGS		8
 #define SMR_IOV_LIMIT		4
 
 struct smr_tx_entry {

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -69,7 +69,7 @@ smr_try_progress_from_sar(struct smr_ep *ep, struct smr_region *smr,
 {
 	if (*bytes_done < cmd->msg.hdr.size) {
 		if (smr_env.use_dsa_sar && ofi_mr_all_host(mr, iov_count)) {
-			(void) smr_dsa_copy_from_sar(ep, sar_pool, resp, cmd, 
+			(void) smr_dsa_copy_from_sar(ep, sar_pool, resp, cmd,
 					iov, iov_count, bytes_done, entry_ptr);
 			return;
 		} else {
@@ -1066,7 +1066,7 @@ out:
 static void smr_progress_cmd(struct smr_ep *ep)
 {
 	struct smr_cmd_entry *ce;
-	int ret = 0;
+	int ret = 0, i;
 	int64_t pos;
 
 	/* ep->util_ep.lock is used to serialize the message/tag matching.
@@ -1082,7 +1082,7 @@ static void smr_progress_cmd(struct smr_ep *ep)
 	 * for locking the queue.
 	 */
 	ofi_genlock_lock(&ep->util_ep.lock);
-	while (1) {
+	for (i = 0; i < SMR_MAX_MSGS; i++) {
 		ret = smr_cmd_queue_head(smr_cmd_queue(ep->region), &ce, &pos);
 		if (ret == -FI_ENOENT)
 			break;


### PR DESCRIPTION
Limit the number of messages progressed to 8. This prevents SHM from starving the ep of sends. This change improves collective performance for SHM.