### PR TITLE
contrib/intel/jenkins: Add tracer check to DSA

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -612,7 +612,8 @@ pipeline {
                 run_python(PYTHON_VERSION,
                 """runtests.py --prov=shm --test=fabtests \
                    --log_file=${env.LOG_DIR}/fabtests_shm_dsa_reg \
-                   --user_env FI_SHM_DISABLE_CMA=1 FI_SHM_USE_DSA_SAR=1""")
+                   --user_env FI_SHM_DISABLE_CMA=1 FI_SHM_USE_DSA_SAR=1 \
+                   FI_LOG_LEVEL=warn""")
               }
             }
           }


### PR DESCRIPTION
Add FI_LOG_LEVEL=warn to DSA stage so that it prints out information to determine if DSA is actually being used.
The summary stage will then parse this information to determine if DSA was correctly used in the tests and will fail if it did not.