### PR TITLE
prov/shm: Only poll IPC list when ROCR IPC is enabled

### DIFF
--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -382,5 +382,6 @@ int ofi_hmem_host_register(void *addr, size_t size);
 int ofi_hmem_host_unregister(void *addr);
 bool ofi_hmem_is_ipc_enabled(enum fi_hmem_iface iface);
 size_t ofi_hmem_get_ipc_handle_size(enum fi_hmem_iface iface);
+bool ofi_hmem_any_ipc_enabled(void);
 
 #endif /* _OFI_HMEM_H_ */

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -230,6 +230,7 @@ struct smr_ep {
 	int			ep_idx;
 	struct smr_sock_info	*sock_info;
 	void			*dsa_context;
+	void 			(*smr_progress_ipc_list)(struct smr_ep *ep);
 };
 
 static inline struct fid_peer_srx *smr_get_peer_srx(struct smr_ep *ep)
@@ -373,4 +374,11 @@ smr_release_txbuf(struct smr_region *smr,
 }
 
 int smr_unexp_start(struct fi_peer_rx_entry *rx_entry);
+
+void smr_progress_ipc_list(struct smr_ep *ep);
+static inline void smr_progress_ipc_list_noop(struct smr_ep *ep)
+{
+	// noop
+}
+
 #endif

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -1329,6 +1329,11 @@ static int smr_ep_ctrl(struct fid *fid, int command, void *arg)
 			}
 		}
 
+		if (ofi_hmem_any_ipc_enabled())
+			ep->smr_progress_ipc_list = smr_progress_ipc_list;
+		else
+			ep->smr_progress_ipc_list = smr_progress_ipc_list_noop;
+
 		if (!ep->srx) {
 			domain = container_of(ep->util_ep.domain,
 					      struct smr_domain,

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -1127,7 +1127,7 @@ static void smr_progress_cmd(struct smr_ep *ep)
 	ofi_genlock_unlock(&ep->util_ep.lock);
 }
 
-static void smr_progress_ipc_list(struct smr_ep *ep)
+void smr_progress_ipc_list(struct smr_ep *ep)
 {
 	struct smr_pend_entry *ipc_entry;
 	struct smr_region *peer_smr;
@@ -1273,5 +1273,5 @@ void smr_ep_progress(struct util_ep *util_ep)
 
 	/* always drive forward the ipc list since the completion is
 	 * independent of any action by the provider */
-	smr_progress_ipc_list(ep);
+	ep->smr_progress_ipc_list(ep);
 }

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -168,6 +168,16 @@ struct ofi_hmem_ops hmem_ops[] = {
 	},
 };
 
+bool ofi_hmem_any_ipc_enabled(void)
+{
+	int iface;
+
+	for (iface = 0; iface < ARRAY_SIZE(hmem_ops); iface++)
+		if (ofi_hmem_is_initialized(iface) && ofi_hmem_is_ipc_enabled(iface))
+			return true;
+	return false;
+}
+
 int ofi_create_async_copy_event(enum fi_hmem_iface iface, uint64_t device,
 				ofi_hmem_async_event_t *event)
 {


### PR DESCRIPTION
This optimization disables the polling of the async ipc list when there are no users of it.

https://github.com/ofiwg/libfabric/issues/9141