### PR TITLE
[v1.18.x] prov/efa: remove rxr_rm_tx/rx_cq_check()

### DIFF
--- a/prov/efa/src/rdm/rxr_atomic.c
+++ b/prov/efa/src/rdm/rxr_atomic.c
@@ -139,11 +139,6 @@ ssize_t rxr_atomic_generic_efa(struct rxr_ep *rxr_ep,
 
 	ofi_mutex_lock(&rxr_ep->base_ep.util_ep.lock);
 
-	if (OFI_UNLIKELY(is_tx_res_full(rxr_ep))) {
-		err = -FI_EAGAIN;
-		goto out;
-	}
-
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
 	assert(peer);
 

--- a/prov/efa/src/rdm/rxr_ep.c
+++ b/prov/efa/src/rdm/rxr_ep.c
@@ -2778,8 +2778,6 @@ void rxr_ep_handle_misc_shm_completion(struct rxr_ep *ep,
 				   cq_entry->data,
 				   0);
 
-	rxr_rm_rx_cq_check(ep, target_cq);
-
 	if (OFI_UNLIKELY(ret)) {
 		EFA_WARN(FI_LOG_CQ,
 			"Unable to write a cq entry for shm operation: %s\n",
@@ -2826,8 +2824,6 @@ void recv_rdma_with_imm_completion(struct rxr_ep *ep, int32_t imm_data,
 	} else {
 		ret = ofi_cq_write(target_cq, NULL, flags, 0, NULL, imm_data, 0);
 	}
-
-	rxr_rm_rx_cq_check(ep, target_cq);
 
 	if (OFI_UNLIKELY(ret)) {
 		EFA_WARN(FI_LOG_CQ,

--- a/prov/efa/src/rdm/rxr_ep.h
+++ b/prov/efa/src/rdm/rxr_ep.h
@@ -424,50 +424,6 @@ bool rxr_ep_should_write_rnr_completion(struct rxr_ep *ep)
 }
 
 /*
- * RM flags
- */
-#define RXR_RM_TX_CQ_FULL	BIT_ULL(0)
-#define RXR_RM_RX_CQ_FULL	BIT_ULL(1)
-
-/*
- * today we have only cq res check, in future we will have ctx, and other
- * resource check as well.
- */
-static inline
-uint64_t is_tx_res_full(struct rxr_ep *ep)
-{
-	return ep->rm_full & RXR_RM_TX_CQ_FULL;
-}
-
-static inline
-uint64_t is_rx_res_full(struct rxr_ep *ep)
-{
-	return ep->rm_full & RXR_RM_RX_CQ_FULL;
-}
-
-static inline
-void rxr_rm_rx_cq_check(struct rxr_ep *ep, struct util_cq *rx_cq)
-{
-	ofi_genlock_lock(&rx_cq->cq_lock);
-	if (ofi_cirque_isfull(rx_cq->cirq))
-		ep->rm_full |= RXR_RM_RX_CQ_FULL;
-	else
-		ep->rm_full &= ~RXR_RM_RX_CQ_FULL;
-	ofi_genlock_unlock(&rx_cq->cq_lock);
-}
-
-static inline
-void rxr_rm_tx_cq_check(struct rxr_ep *ep, struct util_cq *tx_cq)
-{
-	ofi_genlock_lock(&tx_cq->cq_lock);
-	if (ofi_cirque_isfull(tx_cq->cirq))
-		ep->rm_full |= RXR_RM_TX_CQ_FULL;
-	else
-		ep->rm_full &= ~RXR_RM_TX_CQ_FULL;
-	ofi_genlock_unlock(&tx_cq->cq_lock);
-}
-
-/*
  * @brief: check whether we should use p2p for this transaction
  *
  * @param[in]	ep	rxr_ep

--- a/prov/efa/src/rdm/rxr_msg.c
+++ b/prov/efa/src/rdm/rxr_msg.c
@@ -231,11 +231,6 @@ ssize_t rxr_msg_generic_send(struct fid_ep *ep, const struct fi_msg *msg,
 	efa_perfset_start(rxr_ep, perf_efa_tx);
 	ofi_mutex_lock(&rxr_ep->base_ep.util_ep.lock);
 
-	if (OFI_UNLIKELY(is_tx_res_full(rxr_ep))) {
-		err = -FI_EAGAIN;
-		goto out;
-	}
-
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
 	assert(peer);
 
@@ -1045,10 +1040,6 @@ ssize_t rxr_msg_generic_recv(struct fid_ep *ep, const struct fi_msg *msg,
 	flags = flags | rx_op_flags;
 
 	ofi_mutex_lock(&rxr_ep->base_ep.util_ep.lock);
-	if (OFI_UNLIKELY(is_rx_res_full(rxr_ep))) {
-		ret = -FI_EAGAIN;
-		goto out;
-	}
 
 	if (flags & FI_MULTI_RECV) {
 		ret = rxr_msg_multi_recv(rxr_ep, msg, tag, ignore, op, flags);
@@ -1118,7 +1109,6 @@ ssize_t rxr_msg_discard_trecv(struct rxr_ep *ep,
 			   FI_TAGGED | FI_RECV | FI_MSG,
 			   0, NULL, rx_entry->cq_entry.data,
 			   rx_entry->cq_entry.tag);
-	rxr_rm_rx_cq_check(ep, ep->base_ep.util_ep.rx_cq);
 	return ret;
 }
 
@@ -1229,7 +1219,6 @@ ssize_t rxr_msg_peek_trecv(struct fid_ep *ep_fid,
 				   FI_TAGGED | FI_RECV,
 				   data_len, NULL,
 				   rx_entry->cq_entry.data, tag);
-	rxr_rm_rx_cq_check(ep, ep->base_ep.util_ep.rx_cq);
 out:
 	ofi_mutex_unlock(&ep->base_ep.util_ep.lock);
 	return ret;

--- a/prov/efa/src/rdm/rxr_op_entry.c
+++ b/prov/efa/src/rdm/rxr_op_entry.c
@@ -771,8 +771,6 @@ void rxr_rx_entry_report_completion(struct rxr_op_entry *rx_entry)
 					       rx_entry->total_len -
 					       rx_entry->cq_entry.len);
 
-		rxr_rm_rx_cq_check(ep, rx_cq);
-
 		if (OFI_UNLIKELY(ret)) {
 			EFA_WARN(FI_LOG_CQ,
 				"Unable to write recv error cq: %s\n",
@@ -817,8 +815,6 @@ void rxr_rx_entry_report_completion(struct rxr_op_entry *rx_entry)
 					   rx_entry->cq_entry.buf,
 					   rx_entry->cq_entry.data,
 					   rx_entry->cq_entry.tag);
-
-		rxr_rm_rx_cq_check(ep, rx_cq);
 
 		if (OFI_UNLIKELY(ret)) {
 			EFA_WARN(FI_LOG_CQ,
@@ -920,8 +916,6 @@ void rxr_tx_entry_report_completion(struct rxr_op_entry *tx_entry)
 					   tx_entry->cq_entry.buf,
 					   tx_entry->cq_entry.data,
 					   tx_entry->cq_entry.tag);
-
-		rxr_rm_tx_cq_check(tx_entry->ep, tx_cq);
 
 		if (OFI_UNLIKELY(ret)) {
 			EFA_WARN(FI_LOG_CQ,

--- a/prov/efa/src/rdm/rxr_rma.c
+++ b/prov/efa/src/rdm/rxr_rma.c
@@ -211,11 +211,6 @@ ssize_t rxr_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uint64_
 	efa_perfset_start(rxr_ep, perf_efa_tx);
 	ofi_mutex_lock(&rxr_ep->base_ep.util_ep.lock);
 
-	if (OFI_UNLIKELY(is_tx_res_full(rxr_ep))) {
-		err = -FI_EAGAIN;
-		goto out;
-	}
-
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
 	assert(peer);
 


### PR DESCRIPTION
rxr_rm_cq_check() check whether util_cq is overflow, and set the RXR_RM_TX/RX_CQ_FULL flag.

If the flags are full, fi_send/read/write/atomic will return -FI_EAGAIN.

The code as is does not work, because when -FI_EAGAIN is returned, progress engine is not called so if the RXR_RM_TX/RX_CQ_FULL flag is ever set, an application will hang.

Meanwhile, the check itself is not necesary because util_cq can handle the situation that CQ is full
by writing overflow CQ entry.

Therefore, this patch remove the code from critical code path.

Reimplementation of commit 1de4f5a9032cd3b2df0cca128735b95dd4a1b5d2