### PR TITLE
[v1.18.x] Check for CUDA devices with nvmlDeviceGetCount_v2() first

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -587,7 +587,7 @@ AS_IF([test x"$with_cuda" != x"no"],
 				 [cuda_runtime.h],
 				 [cudart],
 				 [cudaMemcpy],
-				 [-lcuda],
+				 [-lcuda -lnvidia-ml],
 				 [$with_cuda],
 				 [],
 				 [have_cuda=1])


### PR DESCRIPTION
Checking w/lightweight nvmlDeviceGetCount_v2() call first allows us to avoid the more expensive call to cudaGetDeviceCount() when there's no NVIDIA devices on the node.


(cherry picked from commit fad962b8cb2cc7c0333e166a56b2e1144cd92869)