### PR TITLE
prov/shm: Remove unnecessary SAR check from generic_send

### DIFF
--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -195,9 +195,6 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 	peer_id = smr_peer_data(ep->region)[id].addr.id;
 	peer_smr = smr_peer_region(ep->region, id);
 
-	if (smr_peer_data(ep->region)[id].sar_status)
-		return -FI_EAGAIN;
-
 	ret = smr_cmd_queue_next(smr_cmd_queue(peer_smr), &ce, &pos);
 	if (ret == -FI_ENOENT)
 		return -FI_EAGAIN;
@@ -342,11 +339,6 @@ static ssize_t smr_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 
 	peer_id = smr_peer_data(ep->region)[id].addr.id;
 	peer_smr = smr_peer_region(ep->region, id);
-
-	if (smr_peer_data(ep->region)[id].sar_status) {
-		ret = -FI_EAGAIN;
-		goto out;
-	}
 
 	ret = smr_cmd_queue_next(smr_cmd_queue(peer_smr), &ce, &pos);
 	if (ret == -FI_ENOENT)

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -514,9 +514,6 @@ static int smr_format_sar(struct smr_ep *ep, struct smr_cmd *cmd,
 	if (peer_smr->max_sar_buf_per_peer == 0)
 		return -FI_EAGAIN;
 
-	if (smr_peer_data(ep->region)[id].sar_status) {
-		return -FI_EAGAIN;
-	}
 	smr_peer_data(smr)[id].sar_status = SMR_STATUS_SAR_FULL;
 
 	sar_needed = (total_len + SMR_SAR_SIZE - 1) / SMR_SAR_SIZE;

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -99,13 +99,6 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 	peer_id = smr_peer_data(ep->region)[id].addr.id;
 	peer_smr = smr_peer_region(ep->region, id);
 
-	if (smr_peer_data(ep->region)[id].sar_status)
-		return -FI_EAGAIN;
-
-	ret = smr_cmd_queue_next(smr_cmd_queue(peer_smr), &ce, &pos);
-	if (ret == -FI_ENOENT)
-		return -FI_EAGAIN;
-
 	ofi_genlock_lock(&ep->util_ep.lock);
 
 	total_len = ofi_total_iov_len(iov, iov_count);
@@ -113,6 +106,13 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 
 	proto = smr_select_proto(desc, iov_count, smr_cma_enabled(ep, peer_smr),
 	                         op, total_len, op_flags);
+
+	if (proto == smr_src_sar && smr_peer_data(ep->region)[id].sar_status)
+		goto unlock;
+
+	ret = smr_cmd_queue_next(smr_cmd_queue(peer_smr), &ce, &pos);
+	if (ret == -FI_ENOENT)
+		goto unlock;
 
 	ret = smr_proto_ops[proto](ep, peer_smr, id, peer_id, op, tag, data, op_flags,
 				   (struct ofi_mr **)desc, iov, iov_count, total_len,

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -203,9 +203,6 @@ static ssize_t smr_generic_inject(struct fid_ep *ep_fid, const void *buf,
 	peer_id = smr_peer_data(ep->region)[id].addr.id;
 	peer_smr = smr_peer_region(ep->region, id);
 
-	if (smr_peer_data(ep->region)[id].sar_status)
-		return -FI_EAGAIN;
-
 	ret = smr_cmd_queue_next(smr_cmd_queue(peer_smr), &ce, &pos);
 	if (ret == -FI_ENOENT)
 		return -FI_EAGAIN;

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -328,9 +328,6 @@ static ssize_t smr_generic_rma_inject(struct fid_ep *ep_fid, const void *buf,
 	cmds = 1 + !(domain->fast_rma && !(flags & FI_REMOTE_CQ_DATA) &&
 		     smr_cma_enabled(ep, peer_smr));
 
-	if (smr_peer_data(ep->region)[id].sar_status)
-		return -FI_EAGAIN;
-
 	iov.iov_base = (void *) buf;
 	iov.iov_len = len;
 	rma_iov.addr = addr;


### PR DESCRIPTION
Remove SAR status check from smr_generic_sendmsg() b/c the check is only required for the SAR protocol which is yet to be selected.  The check already happens in the SAR protocol in smr_format_sar().