### PR TITLE
prov/shm: Move selection logic to smr_select_proto()

### DIFF
--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -275,9 +275,8 @@ size_t smr_copy_from_sar(struct smr_freestack *sar_pool, struct smr_resp *resp,
 			 struct smr_cmd *cmd, struct ofi_mr **mr,
 			 const struct iovec *iov, size_t count,
 			 size_t *bytes_done, int *next);
-int smr_select_proto(enum fi_hmem_iface, bool use_ipc, bool cma_avail,
-                     bool gdrcopy_avail, uint32_t op, uint64_t total_len,
-                     uint64_t op_flags);
+int smr_select_proto(void **desc, size_t iov_count, bool cma_avail,
+		     uint32_t op, uint64_t total_len, uint64_t op_flags);
 typedef ssize_t (*smr_proto_func)(struct smr_ep *ep, struct smr_region *peer_smr,
 		int64_t id, int64_t peer_id, uint32_t op, uint64_t tag,
 		uint64_t data, uint64_t op_flags, struct ofi_mr **desc,

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -99,15 +99,12 @@ static ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 {
 	struct smr_domain *domain;
 	struct smr_region *peer_smr;
-	struct ofi_mr *smr_desc;
 	int64_t id, peer_id;
 	int cmds, err = 0, proto = smr_src_inline;
 	ssize_t ret = 0;
 	size_t total_len;
-	bool use_ipc = false, gdrcopy_available = false;
 	struct smr_cmd_entry *ce;
 	int64_t pos;
-	enum fi_hmem_iface iface = FI_HMEM_SYSTEM;
 
 	assert(iov_count <= SMR_IOV_LIMIT);
 	assert(rma_count <= SMR_IOV_LIMIT);
@@ -167,23 +164,8 @@ static ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 	total_len = ofi_total_iov_len(iov, iov_count);
 	assert(!(op_flags & FI_INJECT) || total_len <= SMR_INJECT_SIZE);
 
-	/* Do not inline/inject if IPC is available so device to device
-	 * transfer may occur if possible. */
-	if (iov_count == 1 && desc && desc[0]) {
-		smr_desc = (struct ofi_mr *) *desc;
-		iface = smr_desc->iface;
-		use_ipc = ofi_hmem_is_ipc_enabled(iface) &&
-				smr_desc->flags & FI_HMEM_DEVICE_ONLY &&
-				!(op_flags & FI_INJECT);
-
-		if (iface == FI_HMEM_CUDA &&
-		    (smr_desc->flags & OFI_HMEM_DATA_GDRCOPY_HANDLE)) {
-			assert(smr_desc->hmem_data);
-			gdrcopy_available = true;
-		}
-	}
-	proto = smr_select_proto(iface, use_ipc, smr_cma_enabled(ep, peer_smr),
-	                         gdrcopy_available, op, total_len, op_flags);
+	proto = smr_select_proto(desc, iov_count, smr_cma_enabled(ep, peer_smr),
+	                         op, total_len, op_flags);
 
 	ret = smr_proto_ops[proto](ep, peer_smr, id, peer_id, op, 0, data,
 				   op_flags, (struct ofi_mr **)desc, iov,


### PR DESCRIPTION
The same protocol selection logic was copy/pasted into both smr_generic_rma() and smr_generic_send(). Remove copy/pasted logic and put it in the common function where it belongs.