### PR TITLE
[v1.18.x] prov/shm: change recv entry freestack into bufpool 

### DIFF
--- a/fabtests/pytest/efa/test_unexpected_msg.py
+++ b/fabtests/pytest/efa/test_unexpected_msg.py
@@ -1,7 +1,9 @@
 import pytest
 
 @pytest.mark.functional
-def test_unexpected_msg(cmdline_args):
+@pytest.mark.parametrize("msg_size", ["1", "512", "9000", "1048576"]) # cover various switch points of shm/efa protocols
+@pytest.mark.parametrize("msg_count", ["1", "1024", "2048"]) # below and above efa/shm's default rx size
+def test_unexpected_msg(cmdline_args, msg_size, msg_count):
     from common import ClientServerTest
-    test = ClientServerTest(cmdline_args, "fi_unexpected_msg -e rdm -I 10")
+    test = ClientServerTest(cmdline_args, f"fi_unexpected_msg -e rdm -I 10 -S {msg_size} -M {msg_count}")
     test.run()

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -172,7 +172,6 @@ struct smr_cmd_ctx {
 	struct smr_cmd cmd;
 };
 
-OFI_DECLARE_FREESTACK(struct smr_rx_entry, smr_recv_fs);
 OFI_DECLARE_FREESTACK(struct smr_tx_entry, smr_tx_fs);
 OFI_DECLARE_FREESTACK(struct smr_pend_entry, smr_pend_fs);
 
@@ -253,7 +252,7 @@ struct smr_srx_ctx {
 	struct util_cq		*cq;
 	struct smr_queue	unexp_msg_queue;
 	struct smr_queue	unexp_tagged_queue;
-	struct smr_recv_fs	*recv_fs;
+	struct ofi_bufpool	*rx_pool;
 	ofi_spin_t		lock;
 };
 

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -40,13 +40,16 @@
 
 struct smr_rx_entry *smr_alloc_rx_entry(struct smr_srx_ctx *srx)
 {
-	if (ofi_freestack_isempty(srx->recv_fs)) {
+	struct smr_rx_entry *rx_entry;
+
+	rx_entry = ofi_buf_alloc(srx->rx_pool);
+	if (!rx_entry) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-			"not enough space to post recv\n");
+			"Error allocating rx entry\n");
 		return NULL;
 	}
 
-	return ofi_freestack_pop(srx->recv_fs);
+	return rx_entry;
 }
 
 void smr_init_rx_entry(struct smr_rx_entry *entry, const struct iovec *iov,


### PR DESCRIPTION
Currently smr_rx_entry is popped from a freestack of a fixed size (rx_size). However, both posted recv and unexpected message allocation will pop rx entry from the same stack, which makes it drained when the number of posted_recv + unexp_message >= rx_size.

This patch switch srx->recv_fs into srx->rx_pool as a buffer pool that can grow, and makes smr_rx_entry allocated from the rx pool


Note that this PR is opened directly to v1.18.x branch because shm's rx entry is already allocated from buffer pool in main branch, after using util srx.