### PR TITLE
prov/shm: Rename SAR status enum to be more clear

### DIFF
--- a/prov/shm/src/smr_dsa.c
+++ b/prov/shm/src/smr_dsa.c
@@ -548,7 +548,7 @@ static void dsa_update_tx_entry(struct smr_region *smr,
 
 	assert(resp->status == SMR_STATUS_BUSY);
 	resp->status = (dsa_cmd_context->dir == OFI_COPY_IOV_TO_BUF ?
-			SMR_STATUS_SAR_READY : SMR_STATUS_SAR_FREE);
+			SMR_STATUS_SAR_FULL : SMR_STATUS_SAR_EMPTY);
 }
 
 static void dsa_update_sar_entry(struct smr_region *smr,
@@ -566,7 +566,7 @@ static void dsa_update_sar_entry(struct smr_region *smr,
 
 	assert(resp->status == SMR_STATUS_BUSY);
 	resp->status = (dsa_cmd_context->dir == OFI_COPY_IOV_TO_BUF ?
-			SMR_STATUS_SAR_READY : SMR_STATUS_SAR_FREE);
+			SMR_STATUS_SAR_FULL : SMR_STATUS_SAR_EMPTY);
 }
 
 static void dsa_process_complete_work(struct smr_region *smr,
@@ -761,7 +761,7 @@ size_t smr_dsa_copy_to_sar(struct smr_ep *ep, struct smr_freestack *sar_pool,
 
 	assert(smr_env.use_dsa_sar);
 
-	if (resp->status != SMR_STATUS_SAR_FREE)
+	if (resp->status != SMR_STATUS_SAR_EMPTY)
 		return -FI_EAGAIN;
 
 	dsa_cmd_context = dsa_allocate_cmd_context(ep->dsa_context);
@@ -785,7 +785,7 @@ size_t smr_dsa_copy_from_sar(struct smr_ep *ep, struct smr_freestack *sar_pool,
 
 	assert(smr_env.use_dsa_sar);
 
-	if (resp->status != SMR_STATUS_SAR_READY)
+	if (resp->status != SMR_STATUS_SAR_FULL)
 		return FI_EAGAIN;
 
 	dsa_cmd_context = dsa_allocate_cmd_context(ep->dsa_context);

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -69,7 +69,7 @@ smr_try_progress_from_sar(struct smr_ep *ep, struct smr_region *smr,
 {
 	if (*bytes_done < cmd->msg.hdr.size) {
 		if (smr_env.use_dsa_sar && ofi_mr_all_host(mr, iov_count)) {
-			(void) smr_dsa_copy_from_sar(ep, sar_pool, resp, cmd, 
+			(void) smr_dsa_copy_from_sar(ep, sar_pool, resp, cmd,
 					iov, iov_count, bytes_done, entry_ptr);
 			return;
 		} else {
@@ -104,7 +104,7 @@ static int smr_progress_resp_entry(struct smr_ep *ep, struct smr_resp *resp,
 		sar_buf = smr_freestack_get_entry_from_index(
 		    smr_sar_pool(peer_smr), pending->cmd.msg.data.sar[0]);
 		if (pending->bytes_done == pending->cmd.msg.hdr.size &&
-		    (resp->status == SMR_STATUS_SAR_FREE ||
+		    (resp->status == SMR_STATUS_SAR_EMPTY ||
 		     resp->status == SMR_STATUS_SUCCESS)) {
 			resp->status = SMR_STATUS_SUCCESS;
 			break;
@@ -123,7 +123,7 @@ static int smr_progress_resp_entry(struct smr_ep *ep, struct smr_resp *resp,
 					pending->iov_count, &pending->bytes_done,
 					&pending->next, pending);
 		if (pending->bytes_done != pending->cmd.msg.hdr.size ||
-		    resp->status != SMR_STATUS_SAR_FREE) {
+		    resp->status != SMR_STATUS_SAR_EMPTY) {
 			return -FI_EAGAIN;
 		}
 

--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -264,8 +264,8 @@ enum smr_status {
 	SMR_STATUS_BUSY = FI_EBUSY, 	/* busy */
 
 	SMR_STATUS_OFFSET = 1024, 	/* Beginning of shm-specific codes */
-	SMR_STATUS_SAR_FREE, 		/* buffer can be used */
-	SMR_STATUS_SAR_READY, 		/* buffer has data in it */
+	SMR_STATUS_SAR_EMPTY, 	/* buffer can be written into */
+	SMR_STATUS_SAR_FULL, 	/* buffer can be read from */
 };
 
 struct smr_sar_buf {


### PR DESCRIPTION
Replace SMR_STATUS_SAR_READY with SMR_STATUS_SAR_FULL and SMR_STATUS_SAR_FREE with SMR_STATUS_SAR_EMPTY. The current enum names are confusing to me b/c READY depends on if you are taking the perspective of the sender or the receiver.