### PR TITLE
prov/shm: Replace tx_lock with ep_lock

### DIFF
--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -216,10 +216,6 @@ struct smr_ep {
 	const char		*name;
 	uint64_t		msg_id;
 	struct smr_region	*volatile region;
-	//if double locking is needed, shm region lock must
-	//be acquired before any shm EP locks
-	ofi_spin_t		tx_lock;
-
 	struct fid_ep		*srx;
 	struct ofi_bufpool	*cmd_ctx_pool;
 	struct smr_tx_fs	*tx_fs;

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -202,7 +202,7 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 	if (ret == -FI_ENOENT)
 		return -FI_EAGAIN;
 
-	ofi_spin_lock(&ep->tx_lock);
+	ofi_genlock_lock(&ep->util_ep.lock);
 	total_len = ofi_datatype_size(datatype) * ofi_total_ioc_cnt(ioc, count);
 
 	switch (op) {
@@ -260,7 +260,7 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 	smr_format_rma_ioc(&ce->rma_cmd, rma_ioc, rma_count);
 	smr_cmd_queue_commit(ce, pos);
 unlock:
-	ofi_spin_unlock(&ep->tx_lock);
+	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
 }
 

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -106,7 +106,7 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 	if (ret == -FI_ENOENT)
 		return -FI_EAGAIN;
 
-	ofi_spin_lock(&ep->tx_lock);
+	ofi_genlock_lock(&ep->util_ep.lock);
 
 	total_len = ofi_total_iov_len(iov, iov_count);
 	assert(!(op_flags & FI_INJECT) || total_len <= SMR_INJECT_SIZE);
@@ -134,7 +134,7 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 	}
 
 unlock:
-	ofi_spin_unlock(&ep->tx_lock);
+	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
 }
 

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -212,7 +212,7 @@ static void smr_progress_resp(struct smr_ep *ep)
 	struct smr_tx_entry *pending;
 	int ret;
 
-	ofi_spin_lock(&ep->tx_lock);
+	ofi_genlock_lock(&ep->util_ep.lock);
 	while (!ofi_cirque_isempty(smr_resp_queue(ep->region))) {
 		resp = ofi_cirque_head(smr_resp_queue(ep->region));
 		if (resp->status == SMR_STATUS_BUSY)
@@ -238,7 +238,7 @@ static void smr_progress_resp(struct smr_ep *ep)
 		ofi_freestack_push(ep->tx_fs, pending);
 		ofi_cirque_discard(smr_resp_queue(ep->region));
 	}
-	ofi_spin_unlock(&ep->tx_lock);
+	ofi_genlock_unlock(&ep->util_ep.lock);
 }
 
 static int smr_progress_inline(struct smr_cmd *cmd, struct ofi_mr **mr,

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -127,7 +127,7 @@ static ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 	if (smr_peer_data(ep->region)[id].sar_status)
 		return -FI_EAGAIN;
 
-	ofi_spin_lock(&ep->tx_lock);
+	ofi_genlock_lock(&ep->util_ep.lock);
 
 	if (cmds == 1) {
 		err = smr_rma_fast(peer_smr, iov, iov_count, rma_iov,
@@ -188,7 +188,7 @@ static ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 	}
 
 unlock:
-	ofi_spin_unlock(&ep->tx_lock);
+	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
 }
 


### PR DESCRIPTION
The tx_lock allows a sender thread to send at the same time a receiver thread can receive on an endpoint. This change gets rid of that functionality and only allows 1 thread in an endpoint send or receive at a time. When we move all SHM resources to the sender, we suspect that the sender/receiver will be to intertwined to be able to progress independently.

This change also boosts performance by switching to a ofi_genlock instead of an ofi_spinlock.