### PR TITLE
prov/efa: Use correct tx/rx op_flags for shm

### DIFF
--- a/prov/efa/src/efa_shm.c
+++ b/prov/efa/src/efa_shm.c
@@ -116,16 +116,10 @@ void efa_shm_info_create(const struct fi_info *app_info, struct fi_info **shm_in
 	shm_hints->tx_attr->msg_order = FI_ORDER_SAS;
 	shm_hints->rx_attr->msg_order = FI_ORDER_SAS;
 	/*
-	 * Unlike efa, shm does not have FI_COMPLETION in tx/rx_op_flags unless user request
-	 * it via hints. That means if user does not request FI_COMPLETION in the hints, and bind
-	 * shm cq to shm ep with FI_SELECTIVE_COMPLETION flags,
-	 * shm will not write cqe for fi_send* (fi_sendmsg is an exception, as user can specify flags),
-	 * similarly for the recv ops. It is common for application like ompi to
-	 * bind cq with FI_SELECTIVE_COMPLETION, and call fi_senddata in which it expects libfabric to
-	 * write cqe. We should follow this pattern and request FI_COMPLETION to shm as default tx/rx_op_flags.
+	 * use the same op_flags requested by applications for shm
 	 */
-	shm_hints->tx_attr->op_flags  = FI_COMPLETION;
-	shm_hints->rx_attr->op_flags  = FI_COMPLETION;
+	shm_hints->tx_attr->op_flags  = app_info->tx_attr->op_flags;
+	shm_hints->rx_attr->op_flags  = app_info->rx_attr->op_flags;
 	shm_hints->fabric_attr->name = strdup(efa_env.intranode_provider);
 	shm_hints->fabric_attr->prov_name = strdup(efa_env.intranode_provider);
 	shm_hints->ep_attr->type = FI_EP_RDM;

--- a/prov/efa/test/efa_unit_test_common.c
+++ b/prov/efa/test/efa_unit_test_common.c
@@ -36,27 +36,9 @@ struct fi_info *efa_unit_test_alloc_hints(enum fi_ep_type ep_type)
 {
 	struct fi_info *hints;
 
-	hints = calloc(sizeof(struct fi_info), 1);
+	hints = fi_allocinfo();
 	if (!hints)
 		return NULL;
-
-	hints->domain_attr = calloc(sizeof(struct fi_domain_attr), 1);
-	if (!hints->domain_attr) {
-		fi_freeinfo(hints);
-		return NULL;
-	}
-
-	hints->fabric_attr = calloc(sizeof(struct fi_fabric_attr), 1);
-	if (!hints->fabric_attr) {
-		fi_freeinfo(hints);
-		return NULL;
-	}
-
-	hints->ep_attr = calloc(sizeof(struct fi_ep_attr), 1);
-	if (!hints->ep_attr) {
-		fi_freeinfo(hints);
-		return NULL;
-	}
 
 	hints->fabric_attr->prov_name = "efa";
 	hints->ep_attr->type = ep_type;

--- a/prov/efa/test/efa_unit_test_info.c
+++ b/prov/efa/test/efa_unit_test_info.c
@@ -126,6 +126,10 @@ static void test_info_check_shm_info_from_hints(struct fi_info *hints)
 			assert_true(efa_domain->shm_info->caps & FI_HMEM);
 		else
 			assert_false(efa_domain->shm_info->caps & FI_HMEM);
+
+		assert_true(efa_domain->shm_info->tx_attr->op_flags == info->tx_attr->op_flags);
+
+		assert_true(efa_domain->shm_info->rx_attr->op_flags == info->rx_attr->op_flags);
 	}
 
 	fi_close(&domain->fid);
@@ -150,6 +154,15 @@ void test_info_check_shm_info()
 
 	hints->caps &= ~FI_HMEM;
 	test_info_check_shm_info_from_hints(hints);
+
+	hints->tx_attr->op_flags |= FI_COMPLETION;
+	hints->rx_attr->op_flags |= FI_COMPLETION;
+	test_info_check_shm_info_from_hints(hints);
+
+	hints->tx_attr->op_flags |= FI_DELIVERY_COMPLETE;
+	hints->rx_attr->op_flags |= FI_MULTI_RECV;
+	test_info_check_shm_info_from_hints(hints);
+
 
 }
 


### PR DESCRIPTION
Currently, the tx/rx op flags are hard-coded as FI_COMPLETION for shm, which is wrong because currently efa is using shm as a peer provider and should pass application requested op flags to shm as well.

Also add unit test for this change