### PR TITLE
[v1.18.x] prov/verbs: Prevent duplicate FI_SHUTDOWN events

### DIFF
--- a/prov/verbs/include/fi_verbs.h
+++ b/prov/verbs/include/fi_verbs.h
@@ -621,6 +621,7 @@ struct vrb_ep {
 	struct vrb_cm_data_hdr		*cm_hdr;
 	void				*cm_priv_data;
 	bool				hmem_enabled;
+	bool				shutdown; /* protected by eq->lock */
 };
 
 

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -941,6 +941,11 @@ vrb_eq_cm_process_event(struct vrb_eq *eq,
 			ret = -FI_EAGAIN;
 			goto ack;
 		}
+		if (ep->shutdown) {
+			ret = -FI_EAGAIN;
+			goto ack;
+		}
+		ep->shutdown = true;
 		*event = FI_SHUTDOWN;
 		entry->info = NULL;
 		break;


### PR DESCRIPTION
Flushed CQEs would come ether after the CQE for the op that caused the QP tranition or in QP destrouction.  There is no need to check with flushed CQEs.

Add missing return code check for ibv_query_qp.