### PR TITLE
prov/shm: Handle 0 byte transfer in SAR protocol

### DIFF
--- a/fabtests/pytest/shm/conftest.py
+++ b/fabtests/pytest/shm/conftest.py
@@ -7,3 +7,12 @@ import pytest
                                         pytest.param("cuda_to_cuda", marks=pytest.mark.cuda_memory)])
 def memory_type(request):
     return request.param
+
+
+@pytest.fixture(scope="module", params=["r:0,4,64",
+                                        "r:4048,4,4148",
+                                        "r:8000,4,9000",
+                                        "r:17000,4,18000",
+                                        "r:0,1024,1048576"])
+def message_size(request):
+    return request.param

--- a/fabtests/pytest/shm/shm_common.py
+++ b/fabtests/pytest/shm/shm_common.py
@@ -1,6 +1,6 @@
 def shm_run_client_server_test(cmdline_args, executable, iteration_type,
-                               completion_semantic, memory_type,
-                               warmup_iteration_type=None,
+                               completion_semantic, memory_type, message_size=None,
+                               warmup_iteration_type=None, timeout=None,
                                completion_type="queue"):
     from common import ClientServerTest
 
@@ -8,6 +8,7 @@ def shm_run_client_server_test(cmdline_args, executable, iteration_type,
                             completion_semantic=completion_semantic,
                             datacheck_type="with_datacheck",
                             memory_type=memory_type,
+                            message_size=message_size,
                             warmup_iteration_type=warmup_iteration_type,
                             completion_type=completion_type)
     test.run()

--- a/fabtests/pytest/shm/test_rma_bw.py
+++ b/fabtests/pytest/shm/test_rma_bw.py
@@ -9,4 +9,15 @@ from shm.shm_common import shm_run_client_server_test
 def test_rma_bw(cmdline_args, iteration_type, operation_type, completion_semantic, memory_type):
     command = "fi_rma_bw -e rdm"
     command = command + " -o " + operation_type
-    shm_run_client_server_test(cmdline_args, command, iteration_type, completion_semantic, memory_type)
+    # rma_bw test with data verification takes longer to finish
+    timeout = max(540, cmdline_args.timeout)
+    shm_run_client_server_test(cmdline_args, command, iteration_type, completion_semantic, memory_type, "all", timeout=timeout)
+
+@pytest.mark.functional
+@pytest.mark.parametrize("operation_type", ["read", "writedata", "write"])
+def test_rma_bw_range(cmdline_args, operation_type, completion_semantic, message_size, memory_type):
+    command = "fi_rma_bw -e rdm"
+    command = command + " -o " + operation_type
+    # rma_bw test with data verification takes longer to finish
+    timeout = max(540, cmdline_args.timeout)
+    shm_run_client_server_test(cmdline_args, command, "short", completion_semantic, memory_type, message_size, timeout=timeout)

--- a/fabtests/test_configs/shm/shm.exclude
+++ b/fabtests/test_configs/shm/shm.exclude
@@ -7,7 +7,6 @@ inject_test
 -e dgram
 
 # Exclude tests that use sread/polling
--S
 rdm_cntr_pingpong
 poll
 

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -549,6 +549,10 @@ static int smr_format_sar(struct smr_ep *ep, struct smr_cmd *cmd,
 	pending->bytes_done = 0;
 	pending->next = 0;
 
+	/* Nothing to copy for 0 byte transfer */
+	if (!cmd->msg.hdr.size)
+		return 0;
+
 	if (cmd->msg.hdr.op != ofi_op_read_req) {
 		if (smr_env.use_dsa_sar && ofi_mr_all_host(mr, count)) {
 			ret = smr_dsa_copy_to_sar(ep, smr_sar_pool(peer_smr),

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -426,6 +426,12 @@ static struct smr_pend_entry *smr_progress_sar(struct smr_cmd *cmd,
 	peer_smr = smr_peer_region(ep->region, cmd->msg.hdr.id);
 	resp = smr_get_ptr(peer_smr, cmd->msg.hdr.src_data);
 
+	/* Nothing to do for 0 byte transfer */
+	if (!cmd->msg.hdr.size) {
+		resp->status = SMR_STATUS_SUCCESS;
+		return NULL;
+	}
+
 	memcpy(sar_iov, iov, sizeof(*iov) * iov_count);
 	(void) ofi_truncate_iov(sar_iov, &iov_count, cmd->msg.hdr.size);
 


### PR DESCRIPTION
Currently, SAR protocol doesn't handle 0 byte transfer because it fails to update the resp->status correctly in this corner case. This patch fixes this issue.

Also added test to verify the fix.

The issue can be reproduced by running 

```
fi_rma_bw -p shm -I 5 -v -S 0 -e rdm -s localhost
```

`-v` is needed to make fi_rma_bw run with FI_DELIVERY_COMPLETE, which will force SHM to use SAR protocol.