### PR TITLE
contrib/intel/jenkins: Disable Oneccl-GPU-v3 tests

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -506,6 +506,7 @@ pipeline {
             }
           }
         }
+        /*
         stage ('oneCCL-GPU-v3') {
           agent { node { label 'ze' } }
           options { skipDefaultCheckout() }
@@ -518,6 +519,7 @@ pipeline {
             }
           }
         }
+        */
         stage('daos_tcp') {
           agent { node { label 'daos_tcp' } }
           options { skipDefaultCheckout() }


### PR DESCRIPTION
Oneccl-GPU-V3 tests need to be temporarily disabled while node upgrades occur.