### PR TITLE
[V1.19.x] prov/efa,shm: backport the fix for SHM's 0 byte SAR and EFA's tx/rx op flags

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -489,6 +489,7 @@ pipeline {
             }
           }
         }
+        /*
         stage ('oneCCL-GPU-v3') {
           agent { node { label 'ze' } }
           options { skipDefaultCheckout() }
@@ -501,6 +502,7 @@ pipeline {
             }
           }
         }
+        */
         stage('daos_tcp') {
           agent { node { label 'daos_tcp' } }
           options { skipDefaultCheckout() }

--- a/fabtests/pytest/shm/conftest.py
+++ b/fabtests/pytest/shm/conftest.py
@@ -7,3 +7,12 @@ import pytest
                                         pytest.param("cuda_to_cuda", marks=pytest.mark.cuda_memory)])
 def memory_type(request):
     return request.param
+
+
+@pytest.fixture(scope="module", params=["r:0,4,64",
+                                        "r:4048,4,4148",
+                                        "r:8000,4,9000",
+                                        "r:17000,4,18000",
+                                        "r:0,1024,1048576"])
+def message_size(request):
+    return request.param

--- a/fabtests/pytest/shm/shm_common.py
+++ b/fabtests/pytest/shm/shm_common.py
@@ -1,6 +1,6 @@
 def shm_run_client_server_test(cmdline_args, executable, iteration_type,
-                               completion_semantic, memory_type,
-                               warmup_iteration_type=None,
+                               completion_semantic, memory_type, message_size=None,
+                               warmup_iteration_type=None, timeout=None,
                                completion_type="queue"):
     from common import ClientServerTest
 
@@ -8,6 +8,7 @@ def shm_run_client_server_test(cmdline_args, executable, iteration_type,
                             completion_semantic=completion_semantic,
                             datacheck_type="with_datacheck",
                             memory_type=memory_type,
+                            message_size=message_size,
                             warmup_iteration_type=warmup_iteration_type,
                             completion_type=completion_type)
     test.run()

--- a/fabtests/pytest/shm/test_rma_bw.py
+++ b/fabtests/pytest/shm/test_rma_bw.py
@@ -9,4 +9,15 @@ from shm.shm_common import shm_run_client_server_test
 def test_rma_bw(cmdline_args, iteration_type, operation_type, completion_semantic, memory_type):
     command = "fi_rma_bw -e rdm"
     command = command + " -o " + operation_type
-    shm_run_client_server_test(cmdline_args, command, iteration_type, completion_semantic, memory_type)
+    # rma_bw test with data verification takes longer to finish
+    timeout = max(540, cmdline_args.timeout)
+    shm_run_client_server_test(cmdline_args, command, iteration_type, completion_semantic, memory_type, "all", timeout=timeout)
+
+@pytest.mark.functional
+@pytest.mark.parametrize("operation_type", ["read", "writedata", "write"])
+def test_rma_bw_range(cmdline_args, operation_type, completion_semantic, message_size, memory_type):
+    command = "fi_rma_bw -e rdm"
+    command = command + " -o " + operation_type
+    # rma_bw test with data verification takes longer to finish
+    timeout = max(540, cmdline_args.timeout)
+    shm_run_client_server_test(cmdline_args, command, "short", completion_semantic, memory_type, message_size, timeout=timeout)

--- a/fabtests/test_configs/shm/shm.exclude
+++ b/fabtests/test_configs/shm/shm.exclude
@@ -7,7 +7,6 @@ inject_test
 -e dgram
 
 # Exclude tests that use sread/polling
--S
 rdm_cntr_pingpong
 poll
 

--- a/prov/efa/src/efa_shm.c
+++ b/prov/efa/src/efa_shm.c
@@ -116,16 +116,10 @@ void efa_shm_info_create(const struct fi_info *app_info, struct fi_info **shm_in
 	shm_hints->tx_attr->msg_order = FI_ORDER_SAS;
 	shm_hints->rx_attr->msg_order = FI_ORDER_SAS;
 	/*
-	 * Unlike efa, shm does not have FI_COMPLETION in tx/rx_op_flags unless user request
-	 * it via hints. That means if user does not request FI_COMPLETION in the hints, and bind
-	 * shm cq to shm ep with FI_SELECTIVE_COMPLETION flags,
-	 * shm will not write cqe for fi_send* (fi_sendmsg is an exception, as user can specify flags),
-	 * similarly for the recv ops. It is common for application like ompi to
-	 * bind cq with FI_SELECTIVE_COMPLETION, and call fi_senddata in which it expects libfabric to
-	 * write cqe. We should follow this pattern and request FI_COMPLETION to shm as default tx/rx_op_flags.
+	 * use the same op_flags requested by applications for shm
 	 */
-	shm_hints->tx_attr->op_flags  = FI_COMPLETION;
-	shm_hints->rx_attr->op_flags  = FI_COMPLETION;
+	shm_hints->tx_attr->op_flags  = app_info->tx_attr->op_flags;
+	shm_hints->rx_attr->op_flags  = app_info->rx_attr->op_flags;
 	shm_hints->fabric_attr->name = strdup(efa_env.intranode_provider);
 	shm_hints->fabric_attr->prov_name = strdup(efa_env.intranode_provider);
 	shm_hints->ep_attr->type = FI_EP_RDM;

--- a/prov/efa/test/efa_unit_test_common.c
+++ b/prov/efa/test/efa_unit_test_common.c
@@ -36,27 +36,9 @@ struct fi_info *efa_unit_test_alloc_hints(enum fi_ep_type ep_type)
 {
 	struct fi_info *hints;
 
-	hints = calloc(sizeof(struct fi_info), 1);
+	hints = fi_allocinfo();
 	if (!hints)
 		return NULL;
-
-	hints->domain_attr = calloc(sizeof(struct fi_domain_attr), 1);
-	if (!hints->domain_attr) {
-		fi_freeinfo(hints);
-		return NULL;
-	}
-
-	hints->fabric_attr = calloc(sizeof(struct fi_fabric_attr), 1);
-	if (!hints->fabric_attr) {
-		fi_freeinfo(hints);
-		return NULL;
-	}
-
-	hints->ep_attr = calloc(sizeof(struct fi_ep_attr), 1);
-	if (!hints->ep_attr) {
-		fi_freeinfo(hints);
-		return NULL;
-	}
 
 	hints->fabric_attr->prov_name = "efa";
 	hints->ep_attr->type = ep_type;

--- a/prov/efa/test/efa_unit_test_info.c
+++ b/prov/efa/test/efa_unit_test_info.c
@@ -126,6 +126,10 @@ static void test_info_check_shm_info_from_hints(struct fi_info *hints)
 			assert_true(efa_domain->shm_info->caps & FI_HMEM);
 		else
 			assert_false(efa_domain->shm_info->caps & FI_HMEM);
+
+		assert_true(efa_domain->shm_info->tx_attr->op_flags == info->tx_attr->op_flags);
+
+		assert_true(efa_domain->shm_info->rx_attr->op_flags == info->rx_attr->op_flags);
 	}
 
 	fi_close(&domain->fid);
@@ -150,6 +154,15 @@ void test_info_check_shm_info()
 
 	hints->caps &= ~FI_HMEM;
 	test_info_check_shm_info_from_hints(hints);
+
+	hints->tx_attr->op_flags |= FI_COMPLETION;
+	hints->rx_attr->op_flags |= FI_COMPLETION;
+	test_info_check_shm_info_from_hints(hints);
+
+	hints->tx_attr->op_flags |= FI_DELIVERY_COMPLETE;
+	hints->rx_attr->op_flags |= FI_MULTI_RECV;
+	test_info_check_shm_info_from_hints(hints);
+
 
 }
 

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -549,6 +549,10 @@ static int smr_format_sar(struct smr_ep *ep, struct smr_cmd *cmd,
 	pending->bytes_done = 0;
 	pending->next = 0;
 
+	/* Nothing to copy for 0 byte transfer */
+	if (!cmd->msg.hdr.size)
+		return 0;
+
 	if (cmd->msg.hdr.op != ofi_op_read_req) {
 		if (smr_env.use_dsa_sar && ofi_mr_all_host(mr, count)) {
 			ret = smr_dsa_copy_to_sar(ep, smr_sar_pool(peer_smr),

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -426,6 +426,12 @@ static struct smr_pend_entry *smr_progress_sar(struct smr_cmd *cmd,
 	peer_smr = smr_peer_region(ep->region, cmd->msg.hdr.id);
 	resp = smr_get_ptr(peer_smr, cmd->msg.hdr.src_data);
 
+	/* Nothing to do for 0 byte transfer */
+	if (!cmd->msg.hdr.size) {
+		resp->status = SMR_STATUS_SUCCESS;
+		return NULL;
+	}
+
 	memcpy(sar_iov, iov, sizeof(*iov) * iov_count);
 	(void) ofi_truncate_iov(sar_iov, &iov_count, cmd->msg.hdr.size);
 


### PR DESCRIPTION
This PR backports https://github.com/ofiwg/libfabric/pull/9203 and https://github.com/ofiwg/libfabric/pull/9200 to v1.19.x