### PR TITLE
fabtests/unexpected_msg: Make tx/rx_size large enough

### DIFF
--- a/fabtests/functional/unexpected_msg.c
+++ b/fabtests/functional/unexpected_msg.c
@@ -62,8 +62,8 @@ static int alloc_bufs(void)
 	struct iovec iov;
 	struct fi_mr_attr mr_attr;
 
-	tx_size = opts.transfer_size + ft_tx_prefix_size();
-	rx_size = opts.transfer_size + ft_rx_prefix_size();
+	tx_size = MAX(opts.transfer_size, FT_MAX_CTRL_MSG) + ft_tx_prefix_size();
+	rx_size = MAX(opts.transfer_size, FT_MAX_CTRL_MSG) + ft_rx_prefix_size();
 	buf_size = (tx_size + rx_size) * concurrent_msgs;
 
 	ret = ft_hmem_alloc(opts.iface, opts.device, (void **) &buf, buf_size);


### PR DESCRIPTION
Currently, tx/rx_size is opts.transfer_size + ft_tx_prefix_size(),
    which may be not large enough for the address message in
    exchange_unexp_addr, which is of size FT_MAX_CTRL_MSG. This patch
    fixes this issue.