### PR TITLE
[v1.19.x] Try libnvidia-ml.so.1 if .so symlink missing, and skip NVML when not available

### DIFF
--- a/src/hmem_cuda.c
+++ b/src/hmem_cuda.c
@@ -443,7 +443,7 @@ static int cuda_hmem_dl_init(void)
 	if (!cuda_attr.nvml_handle) {
 		FI_WARN(&core_prov, FI_LOG_CORE,
 			"Failed to dlopen libnvidia-ml.so.  Trying libnvidia-ml.so.1\n");
-		cuda_attr.nvml_handle = dlopen("libnvidia-ml.so", RTLD_NOW);
+		cuda_attr.nvml_handle = dlopen("libnvidia-ml.so.1", RTLD_NOW);
 		if (!cuda_attr.nvml_handle) {
 			FI_WARN(&core_prov, FI_LOG_CORE,
 			"Failed to dlopen libnvidia-ml.so.1 also, bypassing nvml calls\n");


### PR DESCRIPTION
[v1.19.x] Try libnvidia-ml.so.1 if .so symlink missing, and skip NVML when not available

Local testing on Debian has shown a case where the libnvidia-ml-so symlink to
libnvidia-ml.so.1 doesn't exist (but libnvidia-ml.so.1 exists).  So, try to
dlopen the .so.1 library if the generic .so dlopen fails.  In either case, if
libnvidia-ml doesn't exist, but the CUDA shared libraries do, skip trying to
use the NVML routines for getting the device count and just proceed to using
the CUDA routine.

Signed-off-by: Quincey Koziol <qkoziol@amazon.com>