### PR TITLE
contrib/intel/jenkins: Re-enable oneccl-gpu-v3

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -506,7 +506,6 @@ pipeline {
             }
           }
         }
-        /*
         stage ('oneCCL-GPU-v3') {
           agent { node { label 'ze' } }
           options { skipDefaultCheckout() }
@@ -519,7 +518,6 @@ pipeline {
             }
           }
         }
-        */
         stage('daos_tcp') {
           agent { node { label 'daos_tcp' } }
           options { skipDefaultCheckout() }


### PR DESCRIPTION
Re-enabling oneccl-gpu-v3 stage now that node upgrade has been completed