### PR TITLE
contrib/intel/jenkins: Add dmabuf tests to the CI

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -546,6 +546,20 @@ pipeline {
             }
           }
         }
+        stage ('DMABUF-Tests') {
+          agent { node { label 'ze' } }
+          options { skipDefaultCheckout() }
+          steps {
+            script {
+              dir ("${env.WORKSPACE}/${SCRIPT_LOCATION}/") {
+                output = "${LOG_DIR}/DMABUF-Tests_verbs-rxm_dmabuf_reg"
+                cmd = """ python3.9 runtests.py --test=dmabuf \
+                           --prov=verbs --util=rxm"""
+                slurm_batch("fabrics-ci", "1", "${output}", "${cmd}")
+              }
+            }
+          }
+        }
         stage ('ze-shm') {
           steps {
             script {

--- a/contrib/intel/jenkins/run.py
+++ b/contrib/intel/jenkins/run.py
@@ -209,5 +209,35 @@ def daos_cart_tests(core, hosts, mode, user_env, log_file, util):
         runcarttests.execute_cmd()
     print('-------------------------------------------------------------------')
 
+def dmabuftests(core, hosts, mode, user_env, log_file, util):
+
+    rundmabuftests = tests.DMABUFTest(jobname=jbname,buildno=bno,
+                                      testname="DMABUF Tests", core_prov=core,
+                                      fabric=fab, hosts=hosts,
+                                      ofi_build_mode=mode, user_env=user_env,
+                                      log_file=log_file, util_prov=util)
+
+    print('-------------------------------------------------------------------')
+    if (rundmabuftests.execute_condn):
+        print(f"Running dmabuf H->H tests for {core}-{util}-{fab}")
+        rundmabuftests.execute_cmd('H2H')
+
+        print('---------------------------------------------------------------')
+        print(f"Running dmabuf H->D tests for {core}-{util}-{fab}")
+        rundmabuftests.execute_cmd('H2D')
+
+        print('---------------------------------------------------------------')
+        print(f"Running dmabuf D->H tests for {core}-{util}-{fab}")
+        rundmabuftests.execute_cmd('D2H')
+
+        print('---------------------------------------------------------------')
+        print(f"Running dmabuf D->D tests for {core}-{util}-{fab}")
+        rundmabuftests.execute_cmd('D2D')
+
+        print('---------------------------------------------------------------')
+    else:
+        print(f"Skipping {rundmabuftests.testname} as execute condition fails")
+    print('-------------------------------------------------------------------')
+
 if __name__ == "__main__":
     pass

--- a/contrib/intel/jenkins/runtests.py
+++ b/contrib/intel/jenkins/runtests.py
@@ -24,7 +24,7 @@ parser.add_argument('--ofi_build_mode', help="specify the build configuration",\
 parser.add_argument('--test', help="specify test to execute", \
                     choices = ['all', 'shmem', 'IMB', 'osu', 'oneccl', \
                                'mpichtestsuite', 'fabtests', 'onecclgpu', \
-                               'fi_info', 'daos', 'multinode'])
+                               'fi_info', 'daos', 'multinode', 'dmabuf'])
 
 parser.add_argument('--imb_grp', help="IMB test group 1:[MPI1, P2P], \
                     2:[EXT, IO], 3:[NBC, RMA, MT]", choices=['1', '2', '3'])
@@ -142,6 +142,10 @@ if(args_core):
             run.osu_benchmark(args_core, hosts, mpi,
                                 ofi_build_mode, user_env, log_file,
                                 args_util)
+
+        if (run_test == 'all' or run_test == 'dmabuf'):
+            run.dmabuftests(args_core, hosts, ofi_build_mode,
+                              user_env, log_file, args_util)
     else:
         run.ze_fabtests(args_core, hosts, ofi_build_mode, way, user_env, log_file,
                         args_util)

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -8,6 +8,7 @@ import re
 import cloudbees_config
 import common
 import shlex
+import time
 
 # A Jenkins env variable for job name is composed of the name of the jenkins job and the branch name
 # it is building for. for e.g. in our case jobname = 'ofi_libfabric/master'
@@ -1005,3 +1006,93 @@ class DaosCartTest(Test):
             common.run_logging_command(outputcmd, self.log_file)
             print("--------------------TEST COMPLETED----------------------")
         os.chdir(curdir)
+
+class DMABUFTest(Test):
+
+    def __init__(self, jobname, buildno, testname, core_prov, fabric,
+                 hosts, ofi_build_mode, user_env, log_file, util_prov=None):
+
+        super().__init__(jobname, buildno, testname, core_prov, fabric,
+                         hosts, ofi_build_mode, user_env, log_file,
+                         None, util_prov)
+        self.DMABUFtestpath = f'{self.libfab_installpath}/bin'
+        self.timeout = 300
+        self.n = os.environ['SLURM_NNODES'] if 'SLURM_NNODES' \
+                                                in os.environ.keys() \
+                                            else 0
+
+        if util_prov:
+            self.prov = f'{self.core_prov}\;{self.util_prov}'
+        else:
+            self.prov = self.core_prov
+
+        self.dmabuf_environ = {
+            'ZEX_NUMBER_OF_CCS'       : '0:4,1:4',
+            'NEOReadDebugKeys'        : '1',
+            'EnableImplicitScaling'   : '0',
+            'MLX5_SCATTER_TO_CQE'     : '0'
+        }
+
+        self.tests = {
+                'H2H'   : [
+                            'write',
+                            'read',
+                            'send'
+                        ],
+                'H2D'   : [
+                            'write',
+                            'read',
+                            'send'
+                        ],
+                'D2H'   : [
+                            'write',
+                            'read',
+                            'send'
+                        ],
+                'D2D'   : [
+                            'write',
+                            'read',
+                            'send'
+                        ]
+        }
+
+    @property
+    def execute_condn(self):
+        return True if (self.core_prov == 'verbs') \
+                    else False
+
+    @property
+    def cmd(self):
+        return f"{self.DMABUFtestpath}/fi_xe_rdmabw"
+
+    def dmabuf_env(self):
+        return ' '.join([f"{key}={self.dmabuf_environ[key]}" \
+                        for key in self.dmabuf_environ])
+
+    def execute_cmd(self, test_type):
+        os.chdir(self.DMABUFtestpath)
+        base_cmd = ''
+        log_prefix = f"{os.environ['LOG_DIR']}/dmabuf_{self.n}"
+        if 'H2H' in test_type or 'D2H' in test_type:
+            base_cmd = f"{self.cmd} -m malloc -p {self.core_prov}"
+        else:
+            base_cmd = f"{self.cmd} -m device -d 0 -p {self.core_prov}"
+
+        for test in self.tests[test_type]:
+            client_command = f"{base_cmd} -t {test} {self.server}"
+            if 'send' in test:
+                server_command = f"{base_cmd} -t {test} "
+            else:
+                server_command = f"{base_cmd} "
+            RC = common.ClientServerTest(
+                    f"ssh {self.server} {self.dmabuf_env()} {server_command}",
+                    f"ssh {self.client} {self.dmabuf_env()} {client_command}",
+                    f"{log_prefix}_server.log", f"{log_prefix}_client.log",
+                    self.timeout
+                 ).run()
+
+            if RC == (0, 0):
+                print("------------------ TEST COMPLETED -------------------")
+            else:
+                print("------------------ TEST FAILED -------------------")
+                sys.exit(f"Exiting with returncode: {RC}")


### PR DESCRIPTION
This commit adds dmabuf single node tests to the CI.
The DMABUF stage will run 12 single node tests (H->H read,write,send, D->H read,write,send, H->D read,write,send, D->D read,write,send) and takes 50 seconds.
There are three patches:
Add dmabuf test class and ClientServerTest class.
Add dmabuf stage to Jenkinsfile.
Add summary stage to the summary.