### PR TITLE
[v1.19.x] prov/shm: fix coverity warning

### DIFF
--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -814,7 +814,7 @@ static int smr_copy_saved(struct smr_cmd_ctx *cmd_ctx,
 					&cmd_ctx->sar_entry->iov_count,
 					cmd_ctx->cmd.msg.hdr.size);
 		memcpy(cmd_ctx->sar_entry->mr, rx_entry->desc,
-		       sizeof(rx_entry->desc) * cmd_ctx->sar_entry->iov_count);
+		       sizeof(*rx_entry->desc) * cmd_ctx->sar_entry->iov_count);
 		return FI_SUCCESS;
 	}
 	assert(!cmd_ctx->sar_entry);


### PR DESCRIPTION
@shefty  Coverity spotted this last night. Not needed but leaving it here if you want to grab it, sorry!