### PR TITLE
fabtests/pytest: Allow parallel run for shm provider, extend test_unexpected_msg for shm and efa

### DIFF
--- a/fabtests/pytest/conftest.py
+++ b/fabtests/pytest/conftest.py
@@ -148,6 +148,10 @@ class CmdlineArgs:
         if host_type == "host":
             return command
 
+        if ("PYTEST_XDIST_WORKER" in os.environ) and (not self.oob_address_exchange):
+            raise RuntimeError("Parallel run currently only supports OOB address exchange. "
+                               "Please run runfabtests.py with -b option")
+
         if self.oob_address_exchange:
             oob_argument = "-E"
             if "PYTEST_XDIST_WORKER" in os.environ:

--- a/fabtests/pytest/efa/test_unexpected_msg.py
+++ b/fabtests/pytest/efa/test_unexpected_msg.py
@@ -1,7 +1,19 @@
 import pytest
+from efa.efa_common import efa_run_client_server_test
+
+
+SHM_DEFAULT_MAX_INJECT_SIZE = 4096
+SHM_DEFAULT_RX_SIZE = 1024
+
 
 @pytest.mark.functional
-def test_unexpected_msg(cmdline_args):
+@pytest.mark.parametrize("msg_size", [1, 512, 9000, 1048576]) # cover various switch points of shm/efa protocols
+@pytest.mark.parametrize("msg_count", [1, 1024, 2048]) # below and above shm's default rx size
+def test_unexpected_msg(cmdline_args, msg_size, msg_count, memory_type, completion_semantic):
     from common import ClientServerTest
-    test = ClientServerTest(cmdline_args, "fi_unexpected_msg -e rdm -I 10")
-    test.run()
+    if cmdline_args.server_id == cmdline_args.client_id:
+        if (msg_size > SHM_DEFAULT_MAX_INJECT_SIZE or memory_type != "host_to_host" or completion_semantic == "delivery_complete") and msg_count > SHM_DEFAULT_RX_SIZE:
+            pytest.skip("SHM's CMA/IPC protocol currently cannot handle > rx size number of unexpected messages")
+    efa_run_client_server_test(cmdline_args, f"fi_unexpected_msg -e rdm -M {msg_count}", iteration_type="short",
+                               completion_semantic=completion_semantic, memory_type=memory_type,
+                               message_size=msg_size, completion_type="queue", timeout=1800)

--- a/fabtests/pytest/shm/shm_common.py
+++ b/fabtests/pytest/shm/shm_common.py
@@ -10,5 +10,5 @@ def shm_run_client_server_test(cmdline_args, executable, iteration_type,
                             memory_type=memory_type,
                             message_size=message_size,
                             warmup_iteration_type=warmup_iteration_type,
-                            completion_type=completion_type)
+                            completion_type=completion_type, timeout=timeout)
     test.run()

--- a/fabtests/pytest/shm/test_unexpected_msg.py
+++ b/fabtests/pytest/shm/test_unexpected_msg.py
@@ -8,10 +8,10 @@ SHM_DEFAULT_RX_SIZE = 1024
 @pytest.mark.functional
 @pytest.mark.parametrize("msg_size", [1, 512, 9000, 1048576]) # cover various switch points of shm/efa protocols
 @pytest.mark.parametrize("msg_count", [1, 1024, 2048]) # below and above shm's default rx size
-def test_unexpected_msg(cmdline_args, msg_size, msg_count):
+def test_unexpected_msg(cmdline_args, msg_size, msg_count, memory_type, completion_semantic):
     from common import ClientServerTest
-    if msg_size > SHM_DEFAULT_MAX_INJECT_SIZE and msg_count > SHM_DEFAULT_RX_SIZE and cmdline_args.server_id == cmdline_args.client_id:
-        pytest.skip("SHM's CMA/SAR protocol currently cannot handle > rx size number of unexpected messages")
+    if (msg_size > SHM_DEFAULT_MAX_INJECT_SIZE or memory_type != "host_to_host" or completion_semantic == "delivery_complete") and msg_count > SHM_DEFAULT_RX_SIZE:
+        pytest.skip("SHM's CMA/IPC protocol currently cannot handle > rx size number of unexpected messages")
     shm_run_client_server_test(cmdline_args, f"fi_unexpected_msg -e rdm -M {msg_count}", iteration_type="short",
-                               completion_semantic="transmit_complete", memory_type="host_to_host",
-                               message_size=msg_size, completion_type="queue")
+                               completion_semantic=completion_semantic, memory_type=memory_type,
+                               message_size=msg_size, completion_type="queue", timeout=1800)

--- a/fabtests/scripts/runfabtests.py
+++ b/fabtests/scripts/runfabtests.py
@@ -336,8 +336,8 @@ def main():
     add_common_arguments(parser, shared_options)
 
     fabtests_args = parser.parse_args()
-    if fabtests_args.provider != "efa" and fabtests_args.nworkers > 1:
-        print("only efa provider support parallelized tests. Setting nworkers to 1 ....")
+    if fabtests_args.provider not in ["efa", "shm"] and fabtests_args.nworkers > 1:
+        print("only efa and shm provider support parallelized tests. Setting nworkers to 1 ....")
         fabtests_args.nworkers = 1
 
     if fabtests_args.html:

--- a/fabtests/scripts/runfabtests.py
+++ b/fabtests/scripts/runfabtests.py
@@ -39,6 +39,7 @@ import sys
 import yaml
 
 import pytest
+from pytest import ExitCode
 
 
 def get_option_longform(option_name, option_params):
@@ -362,10 +363,11 @@ def main():
             os.unlink(fabtests_args.junit_xml + ".parallel")
             os.unlink(fabtests_args.junit_xml + ".serial")
 
-        if parallel_status != 0:
+        # Still return success when no tests are collected.
+        if parallel_status not in [ExitCode.OK, ExitCode.NO_TESTS_COLLECTED]:
             exit(parallel_status)
 
-        if serial_status !=0:
+        if serial_status not in [ExitCode.OK, ExitCode.NO_TESTS_COLLECTED]:
             exit(serial_status)
 
         exit(0)


### PR DESCRIPTION
This PR contains a series of commits to allow parallel run for shm provider, and extend test_unexpected_msg for shm and efa


