### PR TITLE
prov/verbs: Fix memory leak when creating EQ with unsupported wait object

### DIFF
--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -1364,6 +1364,20 @@ int vrb_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 	if (!_eq)
 		return -ENOMEM;
 
+	switch (attr->wait_obj) {
+	case FI_WAIT_NONE:
+	case FI_WAIT_UNSPEC:
+	case FI_WAIT_FD:
+		_eq->wait_obj = FI_WAIT_FD;
+		break;
+	case FI_WAIT_POLLFD:
+		_eq->wait_obj = FI_WAIT_POLLFD;
+		break;
+	default:
+		ret = -FI_ENOSYS;
+		goto err0;
+	}
+
 	_eq->fab = container_of(fabric, struct vrb_fabric,
 				util_fabric.fabric_fid);
 
@@ -1391,20 +1405,6 @@ int vrb_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 			  OFI_EPOLL_IN, NULL)) {
 		ret = -errno;
 		goto err3;
-	}
-
-	switch (attr->wait_obj) {
-	case FI_WAIT_NONE:
-	case FI_WAIT_UNSPEC:
-	case FI_WAIT_FD:
-		_eq->wait_obj = FI_WAIT_FD;
-		break;
-	case FI_WAIT_POLLFD:
-		_eq->wait_obj = FI_WAIT_POLLFD;
-		break;
-	default:
-		ret = -FI_ENOSYS;
-		goto err1;
 	}
 
 	_eq->channel = rdma_create_event_channel();


### PR DESCRIPTION
Calling `fi_eq_open` with `wait_obj` equal to `FI_WAIT_SET`, `FI_WAIT_MUTEX_COND` or `FI_WAIT_YIELD` for verbs provider causes a memory leak as we don't release all the objects created prior to validating value of `wait_obj`. Instead of just changing a jump to `err3` this PR moves argument validation to be done sooner (similar to other providers). 