### PR TITLE
[v1.18.x] src/linux: Fix ssize_t format specifiers

### DIFF
--- a/src/linux/osd.c
+++ b/src/linux/osd.c
@@ -59,7 +59,7 @@ ssize_t ofi_get_hugepage_size(void)
 		return -errno;
 
 	while (getline(&line, &len, fd) != -1)
-		if (sscanf(line, "Hugepagesize: %zu kB", &val) == 1)
+		if (sscanf(line, "Hugepagesize: %zi kB", &val) == 1)
 			break;
 
 	free(line);

--- a/src/mem.c
+++ b/src/mem.c
@@ -85,7 +85,7 @@ void ofi_mem_init(void)
 	}
 
 	while (n-- > 0) {
-		if (sscanf(pglist[n]->d_name, "hugepages-%zukB", &hpsize) == 1) {
+		if (sscanf(pglist[n]->d_name, "hugepages-%zikB", &hpsize) == 1) {
 			hpsize *= 1024;
 			if ((size_t) hpsize != page_sizes[OFI_DEF_HUGEPAGE_SIZE])
 				page_sizes[num_page_sizes++] = hpsize;


### PR DESCRIPTION
found using ICC -Wformat -Wformat-security -Werror=format-security %zu format specifier is for size_t, for signed size_t %i exists. destination is ssize_t.

Signed-off-by: Denis Maryin <denis.maryin@intel.com>
(cherry picked from commit b1e045cf2bb84ac877221b0ce3cf6a40d0c75115)