### PR TITLE
contrib/intel/jenkins: Migrate dsa from standalone to main cluster

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -287,22 +287,6 @@ pipeline {
             }
           }
         }
-        stage ('build-dsa') {
-          agent {
-            node {
-              label 'dsa'
-              customWorkspace CUSTOM_WORKSPACE
-            }
-          }
-          steps {
-            script {
-              checkout_py_scripts()
-              build("logdir")
-              build("libfabric", "reg", "dsa")
-              build("fabtests", "reg")
-            }
-          }
-        }
         stage ('build-gpu') {
           agent {
             node {
@@ -621,16 +605,13 @@ pipeline {
           }
         }
         stage('dsa') {
-          agent { node { label 'dsa' } }
           when { equals expected: true, actual: DO_RUN }
           steps {
             script {
               dir (RUN_LOCATION) {
-                run_python(PYTHON_VERSION,
-                """runtests.py --prov=shm --test=fabtests \
-                   --log_file=${env.LOG_DIR}/fabtests_shm_dsa_reg \
-                   --user_env FI_SHM_DISABLE_CMA=1 FI_SHM_USE_DSA_SAR=1 \
-                   FI_LOG_LEVEL=warn""")
+                run_fabtests("shm_dsa", "mudkip", "1", "shm", null,
+                             """FI_SHM_DISABLE_CMA=1 FI_SHM_USE_DSA_SAR=1 \
+                                FI_LOG_LEVEL=warn""")
               }
             }
           }
@@ -642,8 +623,6 @@ pipeline {
       steps {
         script {
           gather_logs("${env.DAOS_ADDR}", "${env.DAOS_KEY}", "${env.LOG_DIR}",
-                      "${env.LOG_DIR}")
-          gather_logs("${env.DSA_ADDR}", "${env.DSA_KEY}", "${env.LOG_DIR}",
                       "${env.LOG_DIR}")
           gather_logs("${env.ZE_ADDR}", "${env.ZE_KEY}", "${env.LOG_DIR}",
                       "${env.LOG_DIR}")
@@ -674,9 +653,6 @@ pipeline {
       node ('daos_head') {
         dir ("${DELETE_LOCATION}/middlewares") { deleteDir() }
       }
-      node ('dsa') {
-        dir ("${DELETE_LOCATION}/middlewares") { deleteDir() }
-      }
       node ('ze') {
         dir ("${DELETE_LOCATION}/middlewares") { deleteDir() }
       }
@@ -685,11 +661,6 @@ pipeline {
     cleanup {
       node ('daos_head') {
         dir ("${DELETE_LOCATION}") { deleteDir() }
-        dir("${env.WORKSPACE}") { deleteDir() }
-        dir("${env.WORKSPACE}@tmp") { deleteDir() }
-      }
-      node ('dsa') {
-        dir("${DELETE_LOCATION}") { deleteDir() }
         dir("${env.WORKSPACE}") { deleteDir() }
         dir("${env.WORKSPACE}@tmp") { deleteDir() }
       }

--- a/contrib/intel/jenkins/build.py
+++ b/contrib/intel/jenkins/build.py
@@ -26,8 +26,6 @@ def build_libfabric(libfab_install_path, mode, cluster=None, ucx=None):
         enable_prov_val='dl'
     if (cluster == 'daos'):
         prov_list = common.daos_prov_list
-    elif (cluster == 'dsa'):
-        prov_list = common.dsa_prov_list
     elif (cluster == 'gpu'):
         prov_list = common.gpu_prov_list
     else:
@@ -120,7 +118,7 @@ if __name__ == "__main__":
                         "build mode", choices=['reg', 'dbg', 'dl'])
 
     parser.add_argument('--build_cluster', help="build libfabric on specified cluster", \
-                        choices=['daos', 'dsa', 'gpu'], default='default')
+                        choices=['daos', 'gpu'], default='default')
     parser.add_argument('--release', help="This job is likely testing a "\
                         "release and will be checked into a git tree.",
                         action='store_true')

--- a/contrib/intel/jenkins/summary.py
+++ b/contrib/intel/jenkins/summary.py
@@ -882,8 +882,8 @@ def summarize_items(summary_item, logger, log_dir, mode):
         for prov in ['shm']:
             ret = FabtestsSummarizer(
                 logger, log_dir, 'shm',
-                f'fabtests_{prov}_dsa_{mode}',
-                f"fabtests {prov} dsa {mode}"
+                f'{prov}_dsa_fabtests_{mode}',
+                f"{prov} dsa fabtests {mode}"
             ).summarize()
             err += ret if ret else 0
 

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -190,11 +190,7 @@ class Fabtest(Test):
         os.chdir(self.fabtestconfigpath)
         command = self.cmd + self.options
         outputcmd = shlex.split(command)
-        if sum([(True if 'dsa' in key.lower() else False)
-                for key in self.env.keys()]) > 0:
-            common.run_logging_command(outputcmd, self.log_file)
-        else:
-            common.run_command(outputcmd)
+        common.run_command(outputcmd)
         os.chdir(curdir)
 
 


### PR DESCRIPTION
Move our dsa testing to the new designated nodes in the main cluster.
Remove code needed for testing on the designated node and enable it in the main cluster.