### PR TITLE
[v1.18.x] contrib/intel/jenkins: Add dmabuf tests to the CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,8 @@ fabtests/common/check_hmem
 fabtests/regression/sighandler_test
 fabtests/benchmarks/fi_*
 fabtests/component/sock_test
+fabtests/component/dmabuf-rdma/xe_*
+fabtests/component/dmabuf-rdma/fi_*
 fabtests/functional/fi_*
 fabtests/unit/fi_*
 fabtests/multinode/fi_*

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -530,6 +530,20 @@ pipeline {
             }
           }
         }
+        stage ('DMABUF-Tests') {
+          agent { node { label 'ze' } }
+          options { skipDefaultCheckout() }
+          steps {
+            script {
+              dir ("${env.WORKSPACE}/${SCRIPT_LOCATION}/") {
+                output = "${LOG_DIR}/DMABUF-Tests_verbs-rxm_dmabuf_reg"
+                cmd = """ python3.9 runtests.py --test=dmabuf \
+                           --prov=verbs --util=rxm"""
+                slurm_batch("fabrics-ci", "1", "${output}", "${cmd}")
+              }
+            }
+          }
+        }
         stage ('ze-shm') {
           steps {
             script {

--- a/contrib/intel/jenkins/run.py
+++ b/contrib/intel/jenkins/run.py
@@ -209,5 +209,35 @@ def daos_cart_tests(core, hosts, mode, user_env, log_file, util):
         runcarttests.execute_cmd()
     print('-------------------------------------------------------------------')
 
+def dmabuftests(core, hosts, mode, user_env, log_file, util):
+
+    rundmabuftests = tests.DMABUFTest(jobname=jbname,buildno=bno,
+                                      testname="DMABUF Tests", core_prov=core,
+                                      fabric=fab, hosts=hosts,
+                                      ofi_build_mode=mode, user_env=user_env,
+                                      log_file=log_file, util_prov=util)
+
+    print('-------------------------------------------------------------------')
+    if (rundmabuftests.execute_condn):
+        print(f"Running dmabuf H->H tests for {core}-{util}-{fab}")
+        rundmabuftests.execute_cmd('H2H')
+
+        print('---------------------------------------------------------------')
+        print(f"Running dmabuf H->D tests for {core}-{util}-{fab}")
+        rundmabuftests.execute_cmd('H2D')
+
+        print('---------------------------------------------------------------')
+        print(f"Running dmabuf D->H tests for {core}-{util}-{fab}")
+        rundmabuftests.execute_cmd('D2H')
+
+        print('---------------------------------------------------------------')
+        print(f"Running dmabuf D->D tests for {core}-{util}-{fab}")
+        rundmabuftests.execute_cmd('D2D')
+
+        print('---------------------------------------------------------------')
+    else:
+        print(f"Skipping {rundmabuftests.testname} as execute condition fails")
+    print('-------------------------------------------------------------------')
+
 if __name__ == "__main__":
     pass

--- a/contrib/intel/jenkins/runtests.py
+++ b/contrib/intel/jenkins/runtests.py
@@ -24,7 +24,7 @@ parser.add_argument('--ofi_build_mode', help="specify the build configuration",\
 parser.add_argument('--test', help="specify test to execute", \
                     choices = ['all', 'shmem', 'IMB', 'osu', 'oneccl', \
                                'mpichtestsuite', 'fabtests', 'onecclgpu', \
-                               'fi_info', 'daos', 'multinode'])
+                               'fi_info', 'daos', 'multinode', 'dmabuf'])
 
 parser.add_argument('--imb_grp', help="IMB test group 1:[MPI1, P2P], \
                     2:[EXT, IO], 3:[NBC, RMA, MT]", choices=['1', '2', '3'])
@@ -142,6 +142,10 @@ if(args_core):
             run.osu_benchmark(args_core, hosts, mpi,
                                 ofi_build_mode, user_env, log_file,
                                 args_util)
+
+        if (run_test == 'all' or run_test == 'dmabuf'):
+            run.dmabuftests(args_core, hosts, ofi_build_mode,
+                              user_env, log_file, args_util)
     else:
         run.ze_fabtests(args_core, hosts, ofi_build_mode, way, user_env, log_file,
                         args_util)

--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -73,13 +73,13 @@ bin_PROGRAMS = \
 if HAVE_ZE_DEVEL
 if HAVE_VERBS_DEVEL
 bin_PROGRAMS += \
-	component/dmabuf-rdma/rdmabw-xe \
-	component/dmabuf-rdma/mr-reg-xe
+	component/dmabuf-rdma/xe_rdmabw \
+	component/dmabuf-rdma/xe_mr_reg
 endif HAVE_VERBS_DEVEL
 bin_PROGRAMS += \
-	component/dmabuf-rdma/fi-rdmabw-xe \
-	component/dmabuf-rdma/fi-mr-reg-xe \
-	component/dmabuf-rdma/memcopy-xe
+	component/dmabuf-rdma/fi_xe_rdmabw \
+	component/dmabuf-rdma/fi_xe_mr_reg \
+	component/dmabuf-rdma/xe_memcopy
 endif HAVE_ZE_DEVEL
 
 dist_bin_SCRIPTS = \
@@ -496,7 +496,7 @@ component_sock_test_CFLAGS = \
 
 if HAVE_ZE_DEVEL
 if HAVE_VERBS_DEVEL
-component_dmabuf_rdma_rdmabw_xe_SOURCES = \
+component_dmabuf_rdma_xe_rdmabw_SOURCES = \
 	component/dmabuf-rdma/rdmabw-xe.c \
 	component/dmabuf-rdma/util.c \
 	component/dmabuf-rdma/util.h \
@@ -505,13 +505,13 @@ component_dmabuf_rdma_rdmabw_xe_SOURCES = \
 	component/dmabuf-rdma/dmabuf_reg.c \
 	component/dmabuf-rdma/dmabuf_reg.h
 
-component_dmabuf_rdma_rdmabw_xe_LDADD = libfabtests.la
+component_dmabuf_rdma_xe_rdmabw_LDADD = libfabtests.la
 
-component_dmabuf_rdma_rdmabw_xe_CFLAGS = \
+component_dmabuf_rdma_xe_rdmabw_CFLAGS = \
 	$(AM_CFLAGS) \
 	-I$(srcdir)/component/dmabuf-rdma
 
-component_dmabuf_rdma_mr_reg_xe_SOURCES = \
+component_dmabuf_rdma_xe_mr_reg_SOURCES = \
 	component/dmabuf-rdma/mr-reg-xe.c \
 	component/dmabuf-rdma/util.h \
 	component/dmabuf-rdma/xe.c \
@@ -519,14 +519,15 @@ component_dmabuf_rdma_mr_reg_xe_SOURCES = \
 	component/dmabuf-rdma/dmabuf_reg.c \
 	component/dmabuf-rdma/dmabuf_reg.h
 
-component_dmabuf_rdma_mr_reg_xe_LDADD = libfabtests.la
+component_dmabuf_rdma_xe_mr_reg_LDADD = libfabtests.la
 
-component_dmabuf_rdma_mr_reg_xe_CFLAGS = \
+component_dmabuf_rdma_xe_mr_reg_CFLAGS = \
 	$(AM_CFLAGS) \
 	-I$(srcdir)/component/dmabuf-rdma
 endif HAVE_VERBS_DEVEL
 
-component_dmabuf_rdma_fi_rdmabw_xe_SOURCES = \
+
+component_dmabuf_rdma_fi_xe_rdmabw_SOURCES = \
 	component/dmabuf-rdma/fi-rdmabw-xe.c \
 	component/dmabuf-rdma/ofi_ctx_pool.h \
 	component/dmabuf-rdma/util.c \
@@ -536,13 +537,13 @@ component_dmabuf_rdma_fi_rdmabw_xe_SOURCES = \
 	component/dmabuf-rdma/dmabuf_reg.c \
 	component/dmabuf-rdma/dmabuf_reg.h
 
-component_dmabuf_rdma_fi_rdmabw_xe_LDADD = libfabtests.la
+component_dmabuf_rdma_fi_xe_rdmabw_LDADD = libfabtests.la
 
-component_dmabuf_rdma_fi_rdmabw_xe_CFLAGS = \
+component_dmabuf_rdma_fi_xe_rdmabw_CFLAGS = \
 	$(AM_CFLAGS) \
 	-I$(srcdir)/component/dmabuf-rdma
 
-component_dmabuf_rdma_fi_mr_reg_xe_SOURCES = \
+component_dmabuf_rdma_fi_xe_mr_reg_SOURCES = \
 	component/dmabuf-rdma/fi-mr-reg-xe.c \
 	component/dmabuf-rdma/util.h \
 	component/dmabuf-rdma/xe.c \
@@ -550,20 +551,20 @@ component_dmabuf_rdma_fi_mr_reg_xe_SOURCES = \
 	component/dmabuf-rdma/dmabuf_reg.c \
 	component/dmabuf-rdma/dmabuf_reg.h
 
-component_dmabuf_rdma_fi_mr_reg_xe_LDADD = libfabtests.la
+component_dmabuf_rdma_fi_xe_mr_reg_LDADD = libfabtests.la
 
-component_dmabuf_rdma_fi_mr_reg_xe_CFLAGS = \
+component_dmabuf_rdma_fi_xe_mr_reg_CFLAGS = \
 	$(AM_CFLAGS) \
 	-I$(srcdir)/component/dmabuf-rdma
 
-component_dmabuf_rdma_memcopy_xe_SOURCES = \
+component_dmabuf_rdma_xe_memcopy_SOURCES = \
 	component/dmabuf-rdma/memcopy-xe.c \
 	component/dmabuf-rdma/util.c \
 	component/dmabuf-rdma/util.h
 
-component_dmabuf_rdma_memcopy_xe_LDADD = libfabtests.la
+component_dmabuf_rdma_xe_memcopy_LDADD = libfabtests.la
 
-component_dmabuf_rdma_memcopy_xe_CFLAGS = \
+component_dmabuf_rdma_xe_memcopy_CFLAGS = \
 	$(AM_CFLAGS)
 endif HAVE_ZE_DEVEL
 

--- a/fabtests/component/dmabuf-rdma/fi-mr-reg-xe.c
+++ b/fabtests/component/dmabuf-rdma/fi-mr-reg-xe.c
@@ -34,19 +34,19 @@
  *
  *	Register memory allocted with malloc():
  *
- *	    ./fi-mr-reg-xe -m malloc
+ *	    ./fi_xe_mr_reg -m malloc
  *
  *	Register memory allocated with zeMemAllocHost():
  *
- *	    ./fi-mr-reg-xe -m host
+ *	    ./fi_xe_mr_reg -m host
  *
  *	Register memory allocated with zeMemAllocDevice() on device 0
  *
- *	    ./fi-mr-reg-xe -m device -d 0
+ *	    ./fi_xe_mr_reg -m device -d 0
  *
  *	For more options:
  *
- *	    ./fi-mr-reg-xe -h
+ *	    ./fi_xe_mr_reg -h
  */
 
 #include <stdio.h>

--- a/fabtests/component/dmabuf-rdma/fi-rdmabw-xe.c
+++ b/fabtests/component/dmabuf-rdma/fi-rdmabw-xe.c
@@ -38,38 +38,38 @@
  *
  *	RDMA write host memory --> device memory:
  *
- *	    ./fi-rdmabw-xe -m device -d 0 &
+ *	    ./fi_xe_rdmabw -m device -d 0 &
  *	    sleep 1 &&
- *	    ./fi-rdmabw-xe -m host -t write localhost
+ *	    ./fi_xe_rdmabw -m host -t write localhost
  *
  *	RDMA read host memory <-- device memory:
  *
- *	    ./fi-rdmabw-xe -m device -d 0 &
+ *	    ./fi_xe_rdmabw -m device -d 0 &
  *	    sleep 1 &&
- *	    ./fi-rdmabw-xe -m host -t read localhost
+ *	    ./fi_xe_rdmabw -m host -t read localhost
  *
  *	RDMA write between memory on the same device:
  *
- *	    ./fi-rdmabw-xe -m device -d 0 &
+ *	    ./fi_xe_rdmabw -m device -d 0 &
  *	    sleep 1 &&
- *	    ./fi-rdmabw-xe -m device -d 0 -t write localhost
+ *	    ./fi_xe_rdmabw -m device -d 0 -t write localhost
  *
  *	RDMA write test between memory on different devices:
  *
- *	    ./fi-rdmabw-xe -m device -d 0 &
+ *	    ./fi_xe_rdmabw -m device -d 0 &
  *	    sleep 1 &&
- *	    ./fi-rdmabw-xe -m device -d 1 -t write localhost
+ *	    ./fi_xe_rdmabw -m device -d 1 -t write localhost
  *
  *	RDMA write test between memory on different devices, use specified
  *	network interface (as OFI domain name):
  *
- *	    ./fi-rdmabw-xe -m device -d 0 -D mlx5_0 &
+ *	    ./fi_xe_rdmabw -m device -d 0 -D mlx5_0 &
  *	    sleep 1 &&
- *	    ./fi-rdmabw-xe -m device -d 1 -D mlx5_1 -t write localhost
+ *	    ./fi_xe_rdmabw -m device -d 1 -D mlx5_1 -t write localhost
  *
  *	For more options:
  *
- *	    ./fi-rdmabw-xe -h
+ *	    ./fi_xe_rdmabw -h
  */
 
 #include <stdio.h>

--- a/fabtests/component/dmabuf-rdma/memcopy-xe.c
+++ b/fabtests/component/dmabuf-rdma/memcopy-xe.c
@@ -34,69 +34,69 @@
  *
  *	Copy using memcpy() between buffers allocated with malloc():
  *
- *	    ./memcopy-xe -c memcpy M M
+ *	    ./xe_memcopy -c memcpy M M
  *
  *	Copy using memcpy between buffers allocated with zeMemAllocHost():
  *
- *	    ./memcopy-xe -c memcpy H H
+ *	    ./xe_memcopy -c memcpy H H
  *
  *	Copy using GPU between buffers allocated with zeMemAllocDevice():
  *
- *	    ./memcopy-xe -c cmdq D D
+ *	    ./xe_memcopy -c cmdq D D
  *
  *	Copy using GPU from buffer allocated with zeMemAllocDevice() to buffer
  *	allcated with zeMemAllocHost():
  *
- *	    ./memcopy-xe -c cmdq D H
+ *	    ./xe_memcopy -c cmdq D H
  *
  *	Copy using GPU between buffers allocated with zeMemAllocDevice(), with
  *	cached command list:
  *
- *	    ./memcopy-xe -c cmdq -C D D
+ *	    ./xe_memcopy -c cmdq -C D D
  *
  *	Copy using GPU between buffers allocated with zeMemAllocDevice(), with
  *	immediate command list:
  *
- *	    ./memcopy-xe -c cmdq -i D D
+ *	    ./xe_memcopy -c cmdq -i D D
  *
  *	Copy using GPU between buffers allocated with zeMemAllocDevice(), using
  *	specified device (src=dst=0):
  *
- *	    ./memcopy-xe -c cmdq -d 0 D D
+ *	    ./xe_memcopy -c cmdq -d 0 D D
  *
  *	Copy using GPU between buffers allocated with zeMemAllocDevice(), using
  *	specified device (src=0, dst=1):
  *
- *	    ./memcopy-xe -c cmdq -d 0 -D 1 D D
+ *	    ./xe_memcopy -c cmdq -d 0 -D 1 D D
  *
  *	Copy using GPU between buffers allocated with zeMemAllocDevice(), using
  *	specified command queue group:
  *
- *	    ./memcopy-xe -c cmdq -G 2 D D
+ *	    ./xe_memcopy -c cmdq -G 2 D D
  *
  *	Copy using GPU between buffers allocated with zeMemAllocDevice(), using
  *	specified devices, command queue group and engine index:
  *
- *	    ./memcopy-xe -c cmdq -d 0 -D 1 -G 2 -I 1 D D
+ *	    ./xe_memcopy -c cmdq -d 0 -D 1 -G 2 -I 1 D D
  *
  *	Copy using GPU between buffers allocated with zeMemAllocDevice(), using
  *	specified devices, 2nd device's command queue group and engine index:
  *
- *	    ./memcopy-xe -c cmdq -d 0 -D 1 -r -G 2 -I 1 D D
+ *	    ./xe_memcopy -c cmdq -d 0 -D 1 -r -G 2 -I 1 D D
  *
  *	Copy using mmap + memcpy between buffers allocated with zeMemAllocDevice(),
  *	mmap() is called before each memcpy():
  *
- *	    ./memcopy-xe -c mmap D D
+ *	    ./xe_memcopy -c mmap D D
  *
  *	Copy using mmap + memcpy between buffers allocated with zeMemAllocDevice(),
  *	mmap() is called once (cached):
  *
- *	    ./memcopy-xe -c mmap -C D D
+ *	    ./xe_memcopy -c mmap -C D D
  *
  *	For more options:
  *
- *	    ./memcopy-xe -h
+ *	    ./xe_memcopy -h
  */
 
 #include <stdio.h>

--- a/fabtests/component/dmabuf-rdma/mr-reg-xe.c
+++ b/fabtests/component/dmabuf-rdma/mr-reg-xe.c
@@ -36,19 +36,19 @@
  *
  *	Register memory allocted with malloc():
  *
- *	    ./mr-reg-xe -m malloc
+ *	    ./xe_mr_reg -m malloc
  *
  *	Register memory allocated with zeMemAllocHost():
  *
- *	    ./mr-reg-xe -m host
+ *	    ./xe_mr_reg -m host
  *
  *	Register memory allocated with zeMemAllocDevice() on device 0
  *
- *	    ./mr-reg-xe -m device -d 0
+ *	    ./xe_mr_reg -m device -d 0
  *
  *	For more options:
  *
- *	    ./mr-reg-xe -h
+ *	    ./xe_mr_reg -h
  *
  */
 

--- a/fabtests/component/dmabuf-rdma/rdmabw-xe.c
+++ b/fabtests/component/dmabuf-rdma/rdmabw-xe.c
@@ -38,37 +38,37 @@
  *
  *	RDMA write host memory --> device memory:
  *
- *	    ./rdmabw-xe -m device -d 0 &
+ *	    ./xe_rdmabw -m device -d 0 &
  *	    sleep 1 &&
- *	    ./rdmabw-xe -m host -t write localhost
+ *	    ./xe_rdmabw -m host -t write localhost
  *
  *	RDMA read host memory <-- device memory:
  *
- *	    ./rdmabw-xe -m device -d 0 &
+ *	    ./xe_rdmabw -m device -d 0 &
  *	    sleep 1 &&
- *	    ./rdmabw-xe -m host -t read localhost
+ *	    ./xe_rdmabw -m host -t read localhost
  *
  *	RDMA write between memory on the same device:
  *
- *	    ./rdmabw-xe -m device -d 0 &
+ *	    ./xe_rdmabw -m device -d 0 &
  *	    sleep 1 &&
- *	    ./rdmabw-xe -m device -d 0 -t write localhost
+ *	    ./xe_rdmabw -m device -d 0 -t write localhost
  *
  *	RDMA write between memory on different devices:
  *
- *	    ./rdmabw-xe -m device -d 0 &
+ *	    ./xe_rdmabw -m device -d 0 &
  *	    sleep 1 &&
- *	    ./rdmabw-xe -m device -d 1 -t write localhost
+ *	    ./xe_rdmabw -m device -d 1 -t write localhost
  *
  *	RDMA write between memory on different devices, use specified IB device:
  *
- *	    ./rdmabw-xe -m device -d 0 -D mlx5_0 &
+ *	    ./xe_rdmabw -m device -d 0 -D mlx5_0 &
  *	    sleep 1 &&
- *	    ./rdmabw-xe -m device -d 1 -D mlx5_1 -t write localhost
+ *	    ./xe_rdmabw -m device -d 1 -D mlx5_1 -t write localhost
  *
  *	For more options:
  *
- *	    ./rdmabw-xe -h
+ *	    ./xe_rdmabw -h
  */
 
 #include <stdio.h>


### PR DESCRIPTION
There are two commits:
1. fabtests/component: Rename executables to prefix with xe_ or fi_xe_ #9004
This commit is cherry-picked from upstream to support dmabuf CI.
Adding component tests to the gitignore by renaming them to have xe_ or fi_xe_ prefix to follow previous convention.


2. [v1.18.x] contrib/intel/jenkins: Add dmabuf tests to the CI
This commit adds dmabuf single node tests to the CI.
The DMABUF stage will run 12 single node tests (H->H read,write,send, D->H read,write,send, H->D read,write,send, D->D read,write,send) and takes 50 seconds.
There are three patches:
Add dmabuf test class and ClientServerTest class.
Add dmabuf stage to Jenkinsfile.
Add summary stage to the summary.