### PR TITLE
[v1.19.x] contrib/intel/jenkins: Add dmabuf tests to the CI

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -530,6 +530,20 @@ pipeline {
             }
           }
         }
+        stage ('DMABUF-Tests') {
+          agent { node { label 'ze' } }
+          options { skipDefaultCheckout() }
+          steps {
+            script {
+              dir ("${env.WORKSPACE}/${SCRIPT_LOCATION}/") {
+                output = "${LOG_DIR}/DMABUF-Tests_verbs-rxm_dmabuf_reg"
+                cmd = """ python3.9 runtests.py --test=dmabuf \
+                           --prov=verbs --util=rxm"""
+                slurm_batch("fabrics-ci", "1", "${output}", "${cmd}")
+              }
+            }
+          }
+        }
         stage ('ze-shm') {
           steps {
             script {

--- a/contrib/intel/jenkins/run.py
+++ b/contrib/intel/jenkins/run.py
@@ -209,5 +209,35 @@ def daos_cart_tests(core, hosts, mode, user_env, log_file, util):
         runcarttests.execute_cmd()
     print('-------------------------------------------------------------------')
 
+def dmabuftests(core, hosts, mode, user_env, log_file, util):
+
+    rundmabuftests = tests.DMABUFTest(jobname=jbname,buildno=bno,
+                                      testname="DMABUF Tests", core_prov=core,
+                                      fabric=fab, hosts=hosts,
+                                      ofi_build_mode=mode, user_env=user_env,
+                                      log_file=log_file, util_prov=util)
+
+    print('-------------------------------------------------------------------')
+    if (rundmabuftests.execute_condn):
+        print(f"Running dmabuf H->H tests for {core}-{util}-{fab}")
+        rundmabuftests.execute_cmd('H2H')
+
+        print('---------------------------------------------------------------')
+        print(f"Running dmabuf H->D tests for {core}-{util}-{fab}")
+        rundmabuftests.execute_cmd('H2D')
+
+        print('---------------------------------------------------------------')
+        print(f"Running dmabuf D->H tests for {core}-{util}-{fab}")
+        rundmabuftests.execute_cmd('D2H')
+
+        print('---------------------------------------------------------------')
+        print(f"Running dmabuf D->D tests for {core}-{util}-{fab}")
+        rundmabuftests.execute_cmd('D2D')
+
+        print('---------------------------------------------------------------')
+    else:
+        print(f"Skipping {rundmabuftests.testname} as execute condition fails")
+    print('-------------------------------------------------------------------')
+
 if __name__ == "__main__":
     pass

--- a/contrib/intel/jenkins/runtests.py
+++ b/contrib/intel/jenkins/runtests.py
@@ -24,7 +24,7 @@ parser.add_argument('--ofi_build_mode', help="specify the build configuration",\
 parser.add_argument('--test', help="specify test to execute", \
                     choices = ['all', 'shmem', 'IMB', 'osu', 'oneccl', \
                                'mpichtestsuite', 'fabtests', 'onecclgpu', \
-                               'fi_info', 'daos', 'multinode'])
+                               'fi_info', 'daos', 'multinode', 'dmabuf'])
 
 parser.add_argument('--imb_grp', help="IMB test group 1:[MPI1, P2P], \
                     2:[EXT, IO], 3:[NBC, RMA, MT]", choices=['1', '2', '3'])
@@ -142,6 +142,10 @@ if(args_core):
             run.osu_benchmark(args_core, hosts, mpi,
                                 ofi_build_mode, user_env, log_file,
                                 args_util)
+
+        if (run_test == 'all' or run_test == 'dmabuf'):
+            run.dmabuftests(args_core, hosts, ofi_build_mode,
+                              user_env, log_file, args_util)
     else:
         run.ze_fabtests(args_core, hosts, ofi_build_mode, way, user_env, log_file,
                         args_util)


### PR DESCRIPTION
This commit adds dmabuf single node tests to the CI.
The DMABUF stage will run 12 single node tests (H->H read,write,send, D->H read,write,send, H->D read,write,send, D->D read,write,send) and takes 50 seconds.
There are three patches:
Add dmabuf test class and ClientServerTest class.
Add dmabuf stage to Jenkinsfile.
Add summary stage to the summary.