### PR TITLE
prov/ucx: Initialize ep_flush to 1

### DIFF
--- a/prov/ucx/src/ucx_init.c
+++ b/prov/ucx/src/ucx_init.c
@@ -40,7 +40,7 @@ struct ucx_global_descriptor ucx_descriptor = {
 	.use_ns = 0,
 	.ns_port = FI_UCX_DEFAULT_NS_PORT,
 	.localhost = NULL,
-	.ep_flush = 0,
+	.ep_flush = 1,
 	.check_req_leak = 0,
 };
 
@@ -291,7 +291,7 @@ static int ucx_getinfo(uint32_t version, const char *node,
 
 	status = fi_param_get(&ucx_prov, "ep_flush", &ucx_descriptor.ep_flush);
 	if (status != FI_SUCCESS)
-		ucx_descriptor.ep_flush = 0;
+		ucx_descriptor.ep_flush = 1;
 
 	status = fi_param_get(&ucx_prov, "check_req_leak", &ucx_descriptor.check_req_leak);
 	if (status != FI_SUCCESS)


### PR DESCRIPTION
Fixes intermittent segmentation fault with ucx on cleanup.

UCX requires ft_finalize because it passes in the ft_transmit_complete flag which forces the queue to be flushed. If the queue isn't flushed, it results in a segmentation fault because ucx marks it as still in use.