### PR TITLE
[v1.19.x] fabtests/pytest/efa: Skip some configuration for unexp msg test on neuron.

### DIFF
--- a/fabtests/pytest/efa/test_unexpected_msg.py
+++ b/fabtests/pytest/efa/test_unexpected_msg.py
@@ -14,6 +14,12 @@ def test_unexpected_msg(cmdline_args, msg_size, msg_count, memory_type, completi
     if cmdline_args.server_id == cmdline_args.client_id:
         if (msg_size > SHM_DEFAULT_MAX_INJECT_SIZE or memory_type != "host_to_host" or completion_semantic == "delivery_complete") and msg_count > SHM_DEFAULT_RX_SIZE:
             pytest.skip("SHM's CMA/IPC protocol currently cannot handle > rx size number of unexpected messages")
+    # This fabtests will allocate msg_size * 2 * msg_count memory for send/recv
+    allocated_memory = msg_size * 2 * msg_count
+    # The limit size (4 GB) of neuron_tensor_alloc
+    neuron_maximal_buffer_size = 2**32
+    if "neuron" in memory_type and allocated_memory >= neuron_maximal_buffer_size:
+        pytest.skip("Cannot hit neuron allocation limit")
     efa_run_client_server_test(cmdline_args, f"fi_unexpected_msg -e rdm -M {msg_count}", iteration_type="short",
                                completion_semantic=completion_semantic, memory_type=memory_type,
                                message_size=msg_size, completion_type="queue", timeout=1800)


### PR DESCRIPTION
unexpected_msg test will allocate msg_size * 2 * msg_count memory for send/recv The limit size of neuron_tensor_alloc is 4GB. Skip the configurations that can hit such limit on neuron.

Signed-off-by: Shi Jin <sjina@amazon.com>
(cherry picked from commit b27a0afccb0aa636733817052a7495bf0b18f5fe)