### PR TITLE
prov/hook/trace: fixed trace log format on some attributes.

### DIFF
--- a/prov/hook/trace/src/hook_trace.c
+++ b/prov/hook/trace/src/hook_trace.c
@@ -95,11 +95,11 @@
 	do {	 \
 		FI_TRACE(dom->fabric->hprov, FI_LOG_DOMAIN,   \
 		    "%s %p context %p\n", name, ep, context);  \
-		FI_TRACE(dom->fabric->hprov, FI_LOG_DOMAIN, "%s",  \
+		FI_TRACE(dom->fabric->hprov, FI_LOG_DOMAIN, "\n%s",  \
 		    fi_tostr_r(buf, len, info->ep_attr, FI_TYPE_EP_ATTR));  \
-		FI_TRACE(dom->fabric->hprov, FI_LOG_DOMAIN, "%s",  \
+		FI_TRACE(dom->fabric->hprov, FI_LOG_DOMAIN, "\n%s",  \
 		    fi_tostr_r(buf,len, info->tx_attr, FI_TYPE_TX_ATTR));   \
-		FI_TRACE(dom->fabric->hprov, FI_LOG_DOMAIN, "%s",  \
+		FI_TRACE(dom->fabric->hprov, FI_LOG_DOMAIN, "\n%s",  \
 		    fi_tostr_r(buf,len, info->rx_attr, FI_TYPE_RX_ATTR));  \
 	} while (0);
 


### PR DESCRIPTION
Add newline to start trace log for fi_ep_attr, fi_rx_attr and fi_tx_attr. This makes the logs in a consistent format for the attributes.