### PR TITLE
prov/efa: Revert the change of efa intranode provider selection

### DIFF
--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -129,10 +129,7 @@ static int efa_domain_init_rdm(struct efa_domain *efa_domain, struct fi_info *in
 {
 	int err;
 
-	if (strcmp(efa_env.intranode_provider, "efa"))
-		efa_shm_info_create(info, &efa_domain->shm_info);
-	else
-		efa_domain->shm_info = NULL;
+	efa_shm_info_create(info, &efa_domain->shm_info);
 
 	if (efa_domain->shm_info) {
 		err = fi_fabric(efa_domain->shm_info->fabric_attr,

--- a/prov/efa/src/efa_env.h
+++ b/prov/efa/src/efa_env.h
@@ -107,8 +107,8 @@ struct efa_env {
 	 * is malformatted, the program should proceed with a default host id, e.g. 0.
 	 */
 	char *host_id_file;
+	int use_sm2;
 	enum efa_env_huge_page_setting huge_page_setting;
-	char *intranode_provider;
 };
 
 /**

--- a/prov/efa/src/efa_prov_info.c
+++ b/prov/efa/src/efa_prov_info.c
@@ -646,7 +646,7 @@ int efa_prov_info_alloc_for_rdm(struct fi_info **prov_info_rdm_ptr,
 		 * then send the packet entry. Therefore the maximum inject size is
 		 *    pkt_entry_size - maximum_header_size.
 		 */
-		if (strcmp(efa_env.intranode_provider, "efa"))
+		if (efa_env.enable_shm_transfer)
 			min_pkt_size = MIN(device->rdm_info->ep_attr->max_msg_size, efa_env.shm_max_medium_size);
 		else
 			min_pkt_size = device->rdm_info->ep_attr->max_msg_size;

--- a/prov/efa/src/efa_shm.c
+++ b/prov/efa/src/efa_shm.c
@@ -98,6 +98,13 @@ void efa_shm_info_create(const struct fi_info *app_info, struct fi_info **shm_in
 	int ret;
 	struct fi_info *shm_hints;
 
+	char *shm_provider;
+	if (efa_env.use_sm2) {
+		shm_provider = "sm2";
+	} else {
+		shm_provider = "shm";
+	}
+
 	shm_hints = fi_allocinfo();
 	shm_hints->caps = app_info->caps;
 	shm_hints->caps &= ~FI_REMOTE_COMM;
@@ -120,19 +127,18 @@ void efa_shm_info_create(const struct fi_info *app_info, struct fi_info **shm_in
 	 */
 	shm_hints->tx_attr->op_flags  = app_info->tx_attr->op_flags;
 	shm_hints->rx_attr->op_flags  = app_info->rx_attr->op_flags;
-	shm_hints->fabric_attr->name = strdup(efa_env.intranode_provider);
-	shm_hints->fabric_attr->prov_name = strdup(efa_env.intranode_provider);
+	shm_hints->fabric_attr->name = strdup(shm_provider);
+	shm_hints->fabric_attr->prov_name = strdup(shm_provider);
 	shm_hints->ep_attr->type = FI_EP_RDM;
 
 	ret = fi_getinfo(FI_VERSION(1, 19), NULL, NULL,
 	                 OFI_GETINFO_HIDDEN, shm_hints, shm_info);
 	fi_freeinfo(shm_hints);
 	if (ret) {
-		EFA_WARN(FI_LOG_CORE, "Disabling EFA's shared memory support; "
-		         "Failed to get info struct for provider %s: %s\n",
-		         efa_env.intranode_provider, fi_strerror(-ret));
+		EFA_WARN(FI_LOG_CORE, "Disabling EFA shared memory support; failed to get shm provider's info: %s\n",
+			fi_strerror(-ret));
 		*shm_info = NULL;
 	} else {
-		assert(!strcmp((*shm_info)->fabric_attr->name, efa_env.intranode_provider));
+		assert(!strcmp((*shm_info)->fabric_attr->name, shm_provider));
 	}
 }

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -114,7 +114,7 @@ void efa_rdm_pke_pool_mr_dereg_handler(struct ofi_bufpool_region *region)
 
 /**
  * @brief creates a packet entry pool.
- *
+ * 
  * The pool is allowed to grow if
  * max_cnt is 0 and is fixed size otherwise.
  *
@@ -944,11 +944,7 @@ void efa_rdm_ep_set_use_shm_for_tx(struct efa_rdm_ep *ep)
 		return;
 	}
 
-	if (strcmp(efa_env.intranode_provider, "efa"))
-		ep->use_shm_for_tx = true;
-	else
-		ep->use_shm_for_tx = false;
-
+	ep->use_shm_for_tx = efa_env.enable_shm_transfer;
 	return;
 }
 


### PR DESCRIPTION
SM2 is currently not fully functional as SHM provider yet. Rollback to the earlier enable_shm_transfer env to avoid users picking this provider by accident.

This reverts commit 331c616324e8df64a3373090794d25ded2f476cf.