### PR TITLE
prov/efa: Handle RNRs from RDMA writedata 

### DIFF
--- a/fabtests/prov/efa/src/rdm_rnr_queue_resend.c
+++ b/fabtests/prov/efa/src/rdm_rnr_queue_resend.c
@@ -58,6 +58,7 @@
  *    "fi_efa_rnr_queue_resend -c 1 -o write -U -S 4" - DC_EAGER_RTW
  *    "fi_efa_rnr_queue_resend -c 1 -o write -U -S 1048576" - DC_LONGCTS_RTW
  *    "fi_efa_rnr_queue_resend -c 1 -A write -U -S 4" - DC_WRITE_RTA
+ *    "fi_efa_rnr_queue_resend -c 1 -o writedata -S 4" - WRITEDATA
  *
  * In addition, HANDSHAKE packet's queue/re-send can be easily triggered during
  * initial ft_sync's ft_rx() on the server side, as the client does not
@@ -140,7 +141,8 @@ static int trigger_rnr_queue_resend(enum fi_op atomic_op, void *result, void *co
 		for (i = 0; i < global_expected_rnr_error; i++) {
 			switch (opts.rma_op) {
 			case FT_RMA_WRITE:
-				ret = ft_post_rma(FT_RMA_WRITE, tx_buf, opts.transfer_size,
+			case FT_RMA_WRITEDATA:
+				ret = ft_post_rma(opts.rma_op, tx_buf, opts.transfer_size,
 						&remote, &tx_ctx_arr[fi->rx_attr->size].context);
 				break;
 			case FT_RMA_READ:

--- a/fabtests/pytest/efa/test_rnr.py
+++ b/fabtests/pytest/efa/test_rnr.py
@@ -44,7 +44,8 @@ packet_type_option_map = {
     "dc_longcts_tagrtm" : "-c 1 -T -U -S 1048576",
     "dc_eager_rtw" : "-c 1 -o write -U -S 4",
     "dc_longcts_rtw" : "-c 1 -o write -U -S 1048576",
-    "dc_write_rta": "-c 1 -A write -U -S 4"
+    "dc_write_rta": "-c 1 -A write -U -S 4",
+    "writedata": "-c 1 -o writedata -S 4"
 }
 
 @pytest.mark.functional

--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -191,6 +191,7 @@ struct efa_rdm_ep {
 	size_t efa_total_posted_tx_ops;
 	size_t send_comps;
 	size_t failed_send_comps;
+	size_t failed_write_comps;
 	size_t recv_comps;
 #endif
 	/* track allocated rx_entries and tx_entries for endpoint cleanup */
@@ -298,7 +299,7 @@ void efa_rdm_ep_queue_rnr_pkt(struct efa_rdm_ep *ep,
 			      struct dlist_entry *list,
 			      struct efa_rdm_pke *pkt_entry);
 
-ssize_t efa_rdm_ep_send_queued_pkts(struct efa_rdm_ep *ep,
+ssize_t efa_rdm_ep_post_queued_pkts(struct efa_rdm_ep *ep,
 				    struct dlist_entry *pkts);
 
 static inline

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -493,6 +493,7 @@ int efa_rdm_ep_open(struct fid_domain *domain, struct fi_info *info,
 	efa_rdm_ep->efa_total_posted_tx_ops = 0;
 	efa_rdm_ep->send_comps = 0;
 	efa_rdm_ep->failed_send_comps = 0;
+	efa_rdm_ep->failed_write_comps = 0;
 	efa_rdm_ep->recv_comps = 0;
 #endif
 

--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -1473,13 +1473,10 @@ int efa_rdm_ope_post_remote_write(struct efa_rdm_ope *ope)
 		if (OFI_UNLIKELY(!pkt_entry))
 			return -FI_EAGAIN;
 
-		efa_rdm_pke_init_write_context(pkt_entry, ope);
-		err = efa_rdm_pke_write(pkt_entry,
-					ope->iov[0].iov_base,
-					0,
-					ope->desc[0],
-					ope->rma_iov[0].addr,
-					ope->rma_iov[0].key);
+		efa_rdm_pke_init_write_context(
+			pkt_entry, ope, ope->iov[0].iov_base, 0, ope->desc[0],
+			ope->rma_iov[0].addr, ope->rma_iov[0].key);
+		err = efa_rdm_pke_write(pkt_entry);
 		if (err)
 			efa_rdm_pke_release_tx(pkt_entry);
 		return err;
@@ -1534,13 +1531,13 @@ int efa_rdm_ope_post_remote_write(struct efa_rdm_ope *ope)
 				    ope->rma_iov[rma_iov_idx].len - rma_iov_offset);
 		write_once_len = MIN(write_once_len, max_write_once_len);
 
-		efa_rdm_pke_init_write_context(pkt_entry, ope);
-		err = efa_rdm_pke_write(pkt_entry,
-					 (char *)ope->iov[iov_idx].iov_base + iov_offset,
-					 write_once_len,
-					 ope->desc[iov_idx],
-					 ope->rma_iov[rma_iov_idx].addr + rma_iov_offset,
-					 ope->rma_iov[rma_iov_idx].key);
+		efa_rdm_pke_init_write_context(
+			pkt_entry, ope,
+			(char *) ope->iov[iov_idx].iov_base + iov_offset,
+			write_once_len, ope->desc[iov_idx],
+			ope->rma_iov[rma_iov_idx].addr + rma_iov_offset,
+			ope->rma_iov[rma_iov_idx].key);
+		err = efa_rdm_pke_write(pkt_entry);
 		if (err) {
 			EFA_WARN(FI_LOG_CQ, "efa_rdm_pke_write failed! err: %d\n", err);
 			efa_rdm_pke_release_tx(pkt_entry);

--- a/prov/efa/src/rdm/efa_rdm_pke.c
+++ b/prov/efa/src/rdm/efa_rdm_pke.c
@@ -534,9 +534,7 @@ int efa_rdm_pke_read(struct efa_rdm_pke *pkt_entry,
  * @return	On success, return 0
  * 		On failure, return a negative error code.
  */
-int efa_rdm_pke_write(struct efa_rdm_pke *pkt_entry,
-			void *local_buf, size_t len, void *desc,
-			uint64_t remote_buf, size_t remote_key)
+int efa_rdm_pke_write(struct efa_rdm_pke *pkt_entry)
 {
 	struct efa_rdm_ep *ep;
 	struct efa_rdm_peer *peer;
@@ -546,6 +544,11 @@ int efa_rdm_pke_write(struct efa_rdm_pke *pkt_entry,
 	struct efa_rdm_rma_context_pkt *rma_context_pkt;
 	struct efa_rdm_ope *txe;
 	bool self_comm;
+	void *local_buf;
+	size_t len;
+	void *desc;
+	uint64_t remote_buf;
+	size_t remote_key;
 	int err = 0;
 
 	ep = pkt_entry->ep;
@@ -554,7 +557,11 @@ int efa_rdm_pke_write(struct efa_rdm_pke *pkt_entry,
 	txe = pkt_entry->ope;
 
 	rma_context_pkt = (struct efa_rdm_rma_context_pkt *)pkt_entry->wiredata;
-	rma_context_pkt->seg_size = len;
+	local_buf = rma_context_pkt->local_buf;
+	len = rma_context_pkt->seg_size;
+	desc = rma_context_pkt->desc;
+	remote_buf = rma_context_pkt->remote_buf;
+	remote_key = rma_context_pkt->remote_key;
 
 	assert(((struct efa_mr *)desc)->ibv_mr);
 

--- a/prov/efa/src/rdm/efa_rdm_pke.h
+++ b/prov/efa/src/rdm/efa_rdm_pke.h
@@ -271,7 +271,5 @@ int efa_rdm_pke_read(struct efa_rdm_pke *pkt_entry,
 ssize_t efa_rdm_pke_recvv(struct efa_rdm_pke **pke_vec,
 			  int pke_cnt);
 
-int efa_rdm_pke_write(struct efa_rdm_pke *pkt_entry,
-		      void *local_buf, size_t len, void *desc,
-		      uint64_t remote_buf, size_t remote_key);
+int efa_rdm_pke_write(struct efa_rdm_pke *pkt_entry);
 #endif

--- a/prov/efa/src/rdm/efa_rdm_pke_cmd.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_cmd.c
@@ -394,7 +394,7 @@ void efa_rdm_pke_handle_data_copied(struct efa_rdm_pke *pkt_entry)
  * @param[in]	err		libfabric error code
  * @param[in]	prov_errno	provider specific error code
  */
-void efa_rdm_pke_handle_send_error(struct efa_rdm_pke *pkt_entry, int err, int prov_errno)
+void efa_rdm_pke_handle_tx_error(struct efa_rdm_pke *pkt_entry, int err, int prov_errno)
 {
 	struct efa_rdm_peer *peer;
 	struct efa_rdm_ope *txe;
@@ -670,7 +670,7 @@ void efa_rdm_pke_handle_send_completion(struct efa_rdm_pke *pkt_entry)
  * @param[in]	err		libfabric error code
  * @param[in]	prov_errno	provider specific error code
  */
-void efa_rdm_pke_handle_recv_error(struct efa_rdm_pke *pkt_entry, int err, int prov_errno)
+void efa_rdm_pke_handle_rx_error(struct efa_rdm_pke *pkt_entry, int err, int prov_errno)
 {
 	struct efa_rdm_ep *ep;
 

--- a/prov/efa/src/rdm/efa_rdm_pke_cmd.h
+++ b/prov/efa/src/rdm/efa_rdm_pke_cmd.h
@@ -50,12 +50,12 @@ fi_addr_t efa_rdm_pke_determine_addr(struct efa_rdm_pke *pkt_entry);
 
 void efa_rdm_pke_handle_data_copied(struct efa_rdm_pke *pkt_entry);
 
-void efa_rdm_pke_handle_send_error(struct efa_rdm_pke *pkt_entry,
+void efa_rdm_pke_handle_tx_error(struct efa_rdm_pke *pkt_entry,
 				   int err, int prov_errno);
 
 void efa_rdm_pke_handle_send_completion(struct efa_rdm_pke *pkt_entry);
 
-void efa_rdm_pke_handle_recv_error(struct efa_rdm_pke *pkt_entry,
+void efa_rdm_pke_handle_rx_error(struct efa_rdm_pke *pkt_entry,
 				   int err, int prov_errno);
 
 void efa_rdm_pke_handle_recv_completion(struct efa_rdm_pke *pkt_entry);

--- a/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
@@ -458,7 +458,7 @@ void efa_rdm_pke_init_write_context(struct efa_rdm_pke *pkt_entry,
 	rma_context_pkt = (struct efa_rdm_rma_context_pkt *)pkt_entry->wiredata;
 	rma_context_pkt->type = EFA_RDM_RMA_CONTEXT_PKT;
 	rma_context_pkt->version = EFA_RDM_PROTOCOL_VERSION;
-	rma_context_pkt->context_type = EFA_RDM_RDMA_WRITE_CONTEX;
+	rma_context_pkt->context_type = EFA_RDM_RDMA_WRITE_CONTEXT;
 	rma_context_pkt->tx_id = txe->tx_id;
 
 	rma_context_pkt->local_buf = local_buf;
@@ -484,7 +484,7 @@ void efa_rdm_pke_init_read_context(struct efa_rdm_pke *pkt_entry,
 	ctx_pkt->type = EFA_RDM_RMA_CONTEXT_PKT;
 	ctx_pkt->flags = 0;
 	ctx_pkt->version = EFA_RDM_PROTOCOL_VERSION;
-	ctx_pkt->context_type = EFA_RDM_RDMA_READ_CONTEX;
+	ctx_pkt->context_type = EFA_RDM_RDMA_READ_CONTEXT;
 	ctx_pkt->read_id = read_id;
 	ctx_pkt->seg_size = seg_size;
 }
@@ -501,7 +501,7 @@ void efa_rdm_pke_handle_rma_read_completion(struct efa_rdm_pke *context_pkt_entr
 
 	rma_context_pkt = (struct efa_rdm_rma_context_pkt *)context_pkt_entry->wiredata;
 	assert(rma_context_pkt->type == EFA_RDM_RMA_CONTEXT_PKT);
-	assert(rma_context_pkt->context_type == EFA_RDM_RDMA_READ_CONTEX);
+	assert(rma_context_pkt->context_type == EFA_RDM_RDMA_READ_CONTEXT);
 
 	x_entry_type = context_pkt_entry->ope->type;
 	if (x_entry_type == EFA_RDM_TXE) {
@@ -572,7 +572,7 @@ void efa_rdm_pke_handle_rma_completion(struct efa_rdm_pke *context_pkt_entry)
 	rma_context_pkt = (struct efa_rdm_rma_context_pkt *)context_pkt_entry->wiredata;
 
 	switch (rma_context_pkt->context_type) {
-	case EFA_RDM_RDMA_WRITE_CONTEX:
+	case EFA_RDM_RDMA_WRITE_CONTEXT:
 		txe = context_pkt_entry->ope;
 		txe->bytes_write_completed += rma_context_pkt->seg_size;
 		if (txe->bytes_write_completed == txe->bytes_write_total_len) {
@@ -583,7 +583,7 @@ void efa_rdm_pke_handle_rma_completion(struct efa_rdm_pke *context_pkt_entry)
 			efa_rdm_txe_release(txe);
 		}
 		break;
-	case EFA_RDM_RDMA_READ_CONTEX:
+	case EFA_RDM_RDMA_READ_CONTEXT:
 		efa_rdm_pke_handle_rma_read_completion(context_pkt_entry);
 		break;
 	default:

--- a/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
@@ -446,7 +446,10 @@ void efa_rdm_pke_handle_readrsp_recv(struct efa_rdm_pke *pkt_entry)
  *  sent over wire. It is named packet because currently all EFA operation
  *  use a packet as context.
  */
-void efa_rdm_pke_init_write_context(struct efa_rdm_pke *pkt_entry, struct efa_rdm_ope *txe)
+void efa_rdm_pke_init_write_context(struct efa_rdm_pke *pkt_entry,
+				    struct efa_rdm_ope *txe, void *local_buf,
+				    size_t seg_size, void *desc,
+				    uint64_t remote_buf, size_t remote_key)
 {
 	struct efa_rdm_rma_context_pkt *rma_context_pkt;
 
@@ -457,6 +460,12 @@ void efa_rdm_pke_init_write_context(struct efa_rdm_pke *pkt_entry, struct efa_rd
 	rma_context_pkt->version = EFA_RDM_PROTOCOL_VERSION;
 	rma_context_pkt->context_type = EFA_RDM_RDMA_WRITE_CONTEX;
 	rma_context_pkt->tx_id = txe->tx_id;
+
+	rma_context_pkt->local_buf = local_buf;
+	rma_context_pkt->seg_size = seg_size;
+	rma_context_pkt->desc = desc;
+	rma_context_pkt->remote_buf = remote_buf;
+	rma_context_pkt->remote_key = remote_key;
 }
 
 void efa_rdm_pke_init_read_context(struct efa_rdm_pke *pkt_entry,

--- a/prov/efa/src/rdm/efa_rdm_pke_nonreq.h
+++ b/prov/efa/src/rdm/efa_rdm_pke_nonreq.h
@@ -163,9 +163,17 @@ struct efa_rdm_rma_context_pkt {
 	uint16_t flags;
 	/* end of efa_rdm_base_hdr */
 	uint32_t context_type;
-	uint32_t tx_id; /* used by write context */
-	uint32_t read_id; /* used by read context */
-	size_t seg_size; /* used by read context */
+
+	/* Used by write context */
+	uint32_t tx_id;
+	void *local_buf;
+	void *desc;
+	uint64_t remote_buf;
+	size_t remote_key;
+
+	/* used by read context */
+	uint32_t read_id;
+	size_t seg_size;
 };
 
 enum efa_rdm_rma_context_pkt_type {
@@ -174,7 +182,9 @@ enum efa_rdm_rma_context_pkt_type {
 };
 
 void efa_rdm_pke_init_write_context(struct efa_rdm_pke *pkt_entry,
-				    struct efa_rdm_ope *txe);
+				    struct efa_rdm_ope *txe, void *local_buf,
+				    size_t seg_size, void *desc,
+				    uint64_t remote_buf, size_t remote_key);
 
 void efa_rdm_pke_init_read_context(struct efa_rdm_pke *pkt_entry,
 				   struct efa_rdm_ope *ope,

--- a/prov/efa/src/rdm/efa_rdm_pke_nonreq.h
+++ b/prov/efa/src/rdm/efa_rdm_pke_nonreq.h
@@ -177,8 +177,8 @@ struct efa_rdm_rma_context_pkt {
 };
 
 enum efa_rdm_rma_context_pkt_type {
-	EFA_RDM_RDMA_READ_CONTEX = 1,
-	EFA_RDM_RDMA_WRITE_CONTEX,
+	EFA_RDM_RDMA_READ_CONTEXT = 1,
+	EFA_RDM_RDMA_WRITE_CONTEXT,
 };
 
 void efa_rdm_pke_init_write_context(struct efa_rdm_pke *pkt_entry,

--- a/prov/efa/test/efa_unit_test_rnr.c
+++ b/prov/efa/test/efa_unit_test_rnr.c
@@ -52,7 +52,7 @@ void test_efa_rnr_queue_and_resend(struct efa_resource **state)
 	assert_int_equal(efa_rdm_ep->efa_rnr_queued_pkt_cnt, 1);
 	assert_int_equal(efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr)->rnr_queued_pkt_cnt, 1);
 
-	ret = efa_rdm_ep_send_queued_pkts(efa_rdm_ep, &txe->queued_pkts);
+	ret = efa_rdm_ep_post_queued_pkts(efa_rdm_ep, &txe->queued_pkts);
 	assert_int_equal(ret, 0);
 	assert_int_equal(pkt_entry->flags & EFA_RDM_PKE_RNR_RETRANSMIT, 0);
 	assert_int_equal(efa_rdm_ep->efa_rnr_queued_pkt_cnt, 0);


### PR DESCRIPTION
RDMA writedata can return RNR when the receiver is out of rx entries. This commit queues and resends the writedata packets.