### PR TITLE
prov/shm: Set threading domain attr to FI_THREAD_UNSPEC

### DIFF
--- a/prov/shm/src/smr_attr.c
+++ b/prov/shm/src/smr_attr.c
@@ -97,7 +97,7 @@ struct fi_ep_attr smr_ep_attr = {
 
 struct fi_domain_attr smr_domain_attr = {
 	.name = "shm",
-	.threading = FI_THREAD_SAFE,
+	.threading = FI_THREAD_UNSPEC,
 	.control_progress = FI_PROGRESS_AUTO,
 	.data_progress = FI_PROGRESS_MANUAL,
 	.resource_mgmt = FI_RM_ENABLED,
@@ -117,7 +117,7 @@ struct fi_domain_attr smr_domain_attr = {
 
 struct fi_domain_attr smr_hmem_domain_attr = {
 	.name = "shm",
-	.threading = FI_THREAD_SAFE,
+	.threading = FI_THREAD_UNSPEC,
 	.control_progress = FI_PROGRESS_AUTO,
 	.data_progress = FI_PROGRESS_MANUAL,
 	.resource_mgmt = FI_RM_ENABLED,


### PR DESCRIPTION
SHM is using real mutex's by default instead of no-op locks.  This change will cause SHM to use no-op locks, which will increase the performance of the default case (non-multithreaded).  If a user wants to run a multi-threaded application, they will need to set threading to be FI_THREAD_SAFE.

I am not sure why this change needs to happen because I thought I already fixed, and tested this in https://github.com/ofiwg/libfabric/pull/9101.  Either my testing was insufficient, or something else changed to cause the mutex locks to be applied by default.

If this change is accepted, it should be back ported to 1.19.x