### PR TITLE
[v1.18.x] fabtests/pytest/efa: add cuda memory marker

### DIFF
--- a/fabtests/pytest/efa/test_efa_protocol_selection.py
+++ b/fabtests/pytest/efa/test_efa_protocol_selection.py
@@ -6,6 +6,7 @@ from efa.efa_common import has_gdrcopy
 # TODO Expand this test to run on all memory types (and rename)
 @pytest.mark.serial
 @pytest.mark.functional
+@pytest.mark.cuda_memory
 @pytest.mark.parametrize("fabtest_name,cntrl_env_var", [("fi_rdm_tagged_bw", "FI_EFA_INTER_MIN_READ_MESSAGE_SIZE"), ("fi_rma_bw", "FI_EFA_INTER_MIN_READ_WRITE_SIZE")])
 def test_transfer_with_read_protocol_cuda(cmdline_args, fabtest_name, cntrl_env_var):
     """


### PR DESCRIPTION
Add cuda memory marker to test_transfer_with_read_protocol_cuda so they can collected with other cuda tests in the same group.

Signed-off-by: Shi Jin <sjina@amazon.com>
(cherry picked from commit 0f6a9653ef6c1c2514a3f50b4700767eb22a9d6e)