### PR TITLE
contrib/intel/jenkins: Add two node dmabuf tests to CI

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -557,6 +557,7 @@ pipeline {
                 cmd = """ python3.9 runtests.py --test=dmabuf \
                            --prov=verbs --util=rxm"""
                 slurm_batch("fabrics-ci", "1", "${output}", "${cmd}")
+		slurm_batch("fabrics-ci", "2", "${output}", "${cmd}")
               }
             }
           }


### PR DESCRIPTION
This commit adds two node dmabuf tests to CI.