### PR TITLE
[v1.19.x] contrib/intel/jenkins: Add two node dmabuf tests to CI

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -553,10 +553,11 @@ pipeline {
           steps {
             script {
               dir ("${env.WORKSPACE}/${SCRIPT_LOCATION}/") {
-                output = "${LOG_DIR}/DMABUF-Tests_verbs-rxm_dmabuf_reg"
+                dmabuf_output = "${LOG_DIR}/DMABUF-Tests_verbs-rxm_dmabuf_reg"
                 cmd = """ python3.9 runtests.py --test=dmabuf \
                            --prov=verbs --util=rxm"""
-                slurm_batch("fabrics-ci", "1", "${output}", "${cmd}")
+                slurm_batch("fabrics-ci", "1", "${dmabuf_output}", "${cmd}")
+		slurm_batch("fabrics-ci", "2", "${dmabuf_output}", "${cmd}")
               }
             }
           }


### PR DESCRIPTION
This commit adds two node dmabuf tests to CI.