### PR TITLE
[v1.18.x] prov/efa: Handle RNRs from RDMA writedata

### DIFF
--- a/fabtests/prov/efa/src/rdm_rnr_queue_resend.c
+++ b/fabtests/prov/efa/src/rdm_rnr_queue_resend.c
@@ -58,6 +58,7 @@
  *    "fi_efa_rnr_queue_resend -c 1 -o write -U -S 4" - DC_EAGER_RTW
  *    "fi_efa_rnr_queue_resend -c 1 -o write -U -S 1048576" - DC_LONGCTS_RTW
  *    "fi_efa_rnr_queue_resend -c 1 -A write -U -S 4" - DC_WRITE_RTA
+ *    "fi_efa_rnr_queue_resend -c 1 -o writedata -S 4" - WRITEDATA
  *
  * In addition, HANDSHAKE packet's queue/re-send can be easily triggered during
  * initial ft_sync's ft_rx() on the server side, as the client does not
@@ -140,7 +141,8 @@ static int trigger_rnr_queue_resend(enum fi_op atomic_op, void *result, void *co
 		for (i = 0; i < global_expected_rnr_error; i++) {
 			switch (opts.rma_op) {
 			case FT_RMA_WRITE:
-				ret = ft_post_rma(FT_RMA_WRITE, ep, opts.transfer_size,
+			case FT_RMA_WRITEDATA:
+				ret = ft_post_rma(opts.rma_op, ep, opts.transfer_size,
 						&remote, &tx_ctx_arr[fi->rx_attr->size].context);
 				break;
 			case FT_RMA_READ:

--- a/fabtests/pytest/efa/test_rnr.py
+++ b/fabtests/pytest/efa/test_rnr.py
@@ -44,7 +44,8 @@ packet_type_option_map = {
     "dc_longcts_tagrtm" : "-c 1 -T -U -S 1048576",
     "dc_eager_rtw" : "-c 1 -o write -U -S 4",
     "dc_longcts_rtw" : "-c 1 -o write -U -S 1048576",
-    "dc_write_rta": "-c 1 -A write -U -S 4"
+    "dc_write_rta": "-c 1 -A write -U -S 4",
+    "writedata": "-c 1 -o writedata -S 4"
 }
 
 @pytest.mark.functional

--- a/prov/efa/src/rdm/rxr_ep.h
+++ b/prov/efa/src/rdm/rxr_ep.h
@@ -208,6 +208,7 @@ struct rxr_ep {
 	size_t shm_total_posted_tx_ops;
 	size_t send_comps;
 	size_t failed_send_comps;
+	size_t failed_write_comps;
 	size_t recv_comps;
 #endif
 	/* track allocated rx_entries and tx_entries for endpoint cleanup */

--- a/prov/efa/src/rdm/rxr_op_entry.c
+++ b/prov/efa/src/rdm/rxr_op_entry.c
@@ -1414,13 +1414,11 @@ int rxr_op_entry_post_remote_write(struct rxr_op_entry *op_entry)
 
 		if (OFI_UNLIKELY(!pkt_entry))
 			return -FI_EAGAIN;
-		rxr_pkt_init_write_context(op_entry, pkt_entry);
-		err = rxr_pkt_entry_write(ep, pkt_entry,
-					  (char *)op_entry->iov[0].iov_base,
-					  0,
-					  op_entry->desc[0],
-					  op_entry->rma_iov[0].addr,
-					  op_entry->rma_iov[0].key);
+		rxr_pkt_init_write_context(op_entry, pkt_entry,
+				(char *)op_entry->iov[0].iov_base, 0, op_entry->desc[0],
+				op_entry->rma_iov[0].addr,
+				op_entry->rma_iov[0].key);
+		err = rxr_pkt_entry_write(ep, pkt_entry);
 		if (err)
 			rxr_pkt_entry_release_tx(ep, pkt_entry);
 		return err;
@@ -1476,13 +1474,12 @@ int rxr_op_entry_post_remote_write(struct rxr_op_entry *op_entry)
 				    op_entry->rma_iov[rma_iov_idx].len - rma_iov_offset);
 		write_once_len = MIN(write_once_len, max_write_once_len);
 
-		rxr_pkt_init_write_context(op_entry, pkt_entry);
-		err = rxr_pkt_entry_write(ep, pkt_entry,
-					 (char *)op_entry->iov[iov_idx].iov_base + iov_offset,
-					 write_once_len,
-					 op_entry->desc[iov_idx],
-					 op_entry->rma_iov[rma_iov_idx].addr + rma_iov_offset,
-					 op_entry->rma_iov[rma_iov_idx].key);
+		rxr_pkt_init_write_context(op_entry, pkt_entry,
+			(char *)op_entry->iov[iov_idx].iov_base + iov_offset,
+			write_once_len, op_entry->desc[iov_idx],
+			op_entry->rma_iov[rma_iov_idx].addr + rma_iov_offset,
+			op_entry->rma_iov[rma_iov_idx].key);
+		err = rxr_pkt_entry_write(ep, pkt_entry);
 		if (err) {
 			EFA_WARN(FI_LOG_CQ, "rxr_pkt_entry_write failed! err: %d\n", err);
 			rxr_pkt_entry_release_tx(ep, pkt_entry);

--- a/prov/efa/src/rdm/rxr_pkt_cmd.c
+++ b/prov/efa/src/rdm/rxr_pkt_cmd.c
@@ -575,7 +575,7 @@ void rxr_pkt_handle_data_copied(struct rxr_ep *ep,
  * @param[in]	err		libfabric error code
  * @param[in]	prov_errno	provider specific error code
  */
-void rxr_pkt_handle_send_error(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry, int err, int prov_errno)
+void rxr_pkt_handle_tx_error(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry, int err, int prov_errno)
 {
 	struct efa_rdm_peer *peer;
 	struct rxr_op_entry *tx_entry;
@@ -842,7 +842,7 @@ void rxr_pkt_handle_send_completion(struct rxr_ep *ep, struct rxr_pkt_entry *pkt
  * @param[in]	err		libfabric error code
  * @param[in]	prov_errno	provider specific error code
  */
-void rxr_pkt_handle_recv_error(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry, int err, int prov_errno)
+void rxr_pkt_handle_rx_error(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry, int err, int prov_errno)
 {
 	EFA_DBG(FI_LOG_CQ, "Packet receive error: %s (%d)\n",
 	        efa_strerror(prov_errno, NULL), prov_errno);

--- a/prov/efa/src/rdm/rxr_pkt_cmd.h
+++ b/prov/efa/src/rdm/rxr_pkt_cmd.h
@@ -51,14 +51,14 @@ void rxr_pkt_handle_data_copied(struct rxr_ep *ep,
 				struct rxr_pkt_entry *pkt_entry,
 				size_t data_size);
 
-void rxr_pkt_handle_send_error(struct rxr_ep *ep,
+void rxr_pkt_handle_tx_error(struct rxr_ep *ep,
 			       struct rxr_pkt_entry *pkt_entry,
 			       int err, int prov_errno);
 
 void rxr_pkt_handle_send_completion(struct rxr_ep *ep,
 				    struct rxr_pkt_entry *pkt_entry);
 
-void rxr_pkt_handle_recv_error(struct rxr_ep *ep,
+void rxr_pkt_handle_rx_error(struct rxr_ep *ep,
 			       struct rxr_pkt_entry *pkt_entry,
 			       int err, int prov_errno);
 

--- a/prov/efa/src/rdm/rxr_pkt_entry.c
+++ b/prov/efa/src/rdm/rxr_pkt_entry.c
@@ -537,9 +537,7 @@ int rxr_pkt_entry_read(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry,
  * @return	On success, return 0
  * 		On failure, return a negative error code.
  */
-int rxr_pkt_entry_write(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry,
-			void *local_buf, size_t len, void *desc,
-			uint64_t remote_buf, size_t remote_key)
+int rxr_pkt_entry_write(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 {
 	struct efa_rdm_peer *peer;
 	struct efa_qp *qp;
@@ -548,13 +546,22 @@ int rxr_pkt_entry_write(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry,
 	struct rxr_rma_context_pkt *rma_context_pkt;
 	struct rxr_op_entry *tx_entry;
 	bool self_comm;
+	void *local_buf;
+	size_t len;
+	void *desc;
+	uint64_t remote_buf;
+	size_t remote_key;
 	int err = 0;
 
 	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
 	tx_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
 
 	rma_context_pkt = (struct rxr_rma_context_pkt *)pkt_entry->wiredata;
-	rma_context_pkt->seg_size = len;
+	local_buf = rma_context_pkt->local_buf;
+	len = rma_context_pkt->seg_size;
+	desc = rma_context_pkt->desc;
+	remote_buf = rma_context_pkt->remote_buf;
+	remote_key = rma_context_pkt->remote_key;
 
 	if (peer && peer->is_local && ep->use_shm_for_tx) {
 		err = fi_write(ep->shm_ep, local_buf, len, efa_mr_get_shm_desc(desc), peer->shm_fiaddr, remote_buf, remote_key, pkt_entry);

--- a/prov/efa/src/rdm/rxr_pkt_entry.h
+++ b/prov/efa/src/rdm/rxr_pkt_entry.h
@@ -292,9 +292,7 @@ ssize_t rxr_pkt_entry_inject(struct rxr_ep *ep,
 			     struct rxr_pkt_entry *pkt_entry,
 			     fi_addr_t addr);
 
-int rxr_pkt_entry_write(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry,
-		       void *local_buf, size_t len, void *desc,
-		       uint64_t remote_buf, size_t remote_key);
+int rxr_pkt_entry_write(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
 
 struct rxr_pkt_rx_key {
 	uint64_t msg_id;

--- a/prov/efa/src/rdm/rxr_pkt_type.h
+++ b/prov/efa/src/rdm/rxr_pkt_type.h
@@ -177,9 +177,17 @@ struct rxr_rma_context_pkt {
 	uint16_t flags;
 	/* end of rxr_base_hdr */
 	uint32_t context_type;
-	uint32_t tx_id; /* used by write context */
-	uint32_t read_id; /* used by read context */
-	size_t seg_size; /* used by read context */
+
+	/* used by write context */
+	uint32_t tx_id;
+	void *local_buf;
+	void *desc;
+	uint64_t remote_buf;
+	size_t remote_key;
+
+	/* used by read context */
+	uint32_t read_id;
+	size_t seg_size;
 };
 
 enum rxr_rma_context_pkt_type {
@@ -188,7 +196,9 @@ enum rxr_rma_context_pkt_type {
 };
 
 void rxr_pkt_init_write_context(struct rxr_op_entry *tx_entry,
-				struct rxr_pkt_entry *pkt_entry);
+				struct rxr_pkt_entry *pkt_entry, void *local_buf,
+				size_t len, void *desc, uint64_t remote_buf,
+				size_t remote_key);
 
 void rxr_pkt_init_read_context(struct rxr_ep *rxr_ep,
 			       void *x_entry,

--- a/prov/efa/src/rdm/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rdm/rxr_pkt_type_misc.c
@@ -372,7 +372,9 @@ void rxr_pkt_handle_readrsp_recv(struct rxr_ep *ep,
  *  use a packet as context.
  */
 void rxr_pkt_init_write_context(struct rxr_op_entry *tx_entry,
-				struct rxr_pkt_entry *pkt_entry)
+				struct rxr_pkt_entry *pkt_entry, void *local_buf,
+				size_t len, void *desc, uint64_t remote_buf,
+				size_t remote_key)
 {
 	struct rxr_rma_context_pkt *rma_context_pkt;
 
@@ -383,6 +385,11 @@ void rxr_pkt_init_write_context(struct rxr_op_entry *tx_entry,
 	rma_context_pkt->version = RXR_PROTOCOL_VERSION;
 	rma_context_pkt->context_type = RXR_WRITE_CONTEXT;
 	rma_context_pkt->tx_id = tx_entry->tx_id;
+	rma_context_pkt->local_buf = local_buf;
+	rma_context_pkt->seg_size = len;
+	rma_context_pkt->desc = desc;
+	rma_context_pkt->remote_buf = remote_buf;
+	rma_context_pkt->remote_key = remote_key;
 }
 
 void rxr_pkt_init_read_context(struct rxr_ep *rxr_ep,

--- a/prov/efa/src/rdm/rxr_rma.c
+++ b/prov/efa/src/rdm/rxr_rma.c
@@ -112,7 +112,6 @@ size_t rxr_rma_post_shm_write(struct rxr_ep *rxr_ep, struct rxr_op_entry *tx_ent
 	struct rxr_pkt_entry *pkt_entry;
 	struct fi_msg_rma msg;
 	struct efa_rdm_peer *peer;
-	struct rxr_rma_context_pkt *rma_context_pkt;
 	int i, err;
 
 	assert(tx_entry->op == ofi_op_write);
@@ -123,9 +122,8 @@ size_t rxr_rma_post_shm_write(struct rxr_ep *rxr_ep, struct rxr_op_entry *tx_ent
 	if (OFI_UNLIKELY(!pkt_entry))
 		return -FI_EAGAIN;
 
-	rxr_pkt_init_write_context(tx_entry, pkt_entry);
-	rma_context_pkt = (struct rxr_rma_context_pkt *)pkt_entry->wiredata;
-	rma_context_pkt->seg_size = tx_entry->bytes_write_total_len;
+	rxr_pkt_init_write_context(tx_entry, pkt_entry, NULL, tx_entry->bytes_write_total_len,
+							NULL, 0, 0);
 
 	/* If no FI_MR_VIRT_ADDR being set, have to use 0-based offset */
 	if (!(rxr_ep_domain(rxr_ep)->shm_info->domain_attr->mr_mode & FI_MR_VIRT_ADDR)) {


### PR DESCRIPTION
Re-implementation of the changes in https://github.com/ofiwg/libfabric/pull/9276 for 1.18.x branch