### PR TITLE
[v1.18.x] fabtests/component/dmabuf: Handle partial read scenario for fi_xe_rdmabw test

### DIFF
--- a/fabtests/component/dmabuf-rdma/util.c
+++ b/fabtests/component/dmabuf-rdma/util.c
@@ -133,7 +133,7 @@ int exchange_info(int sockfd, size_t size, void *me, void *peer)
 		return -1;
 	}
 
-	if (read(sockfd, peer, size) != size) {
+	if (recv(sockfd, peer, size, MSG_WAITALL) != size) {
 		fprintf(stderr, "Failed to read peer info\n");
 		return -1;
 	}


### PR DESCRIPTION
For cross node tests, under certain conditions, the read() call may return with bytes read less than size,
causing exchange_info() to return failure.
This fix would ensure that all the expected data are read.
This bug was found while running 2 node fi_xe_rdmabw test on CI.
Changes have been tested and verified both manually and on the CI.

This commit needs to be cherry-picked for v1.18.x for CI to work on this branch.
(cherry picked from commit 9e4fdbf)