### PR TITLE
prov/verbs_nd: Fix use-after-free in case of failure in fi_listen

### DIFF
--- a/prov/verbs/src/windows/verbs_nd_rdma.c
+++ b/prov/verbs/src/windows/verbs_nd_rdma.c
@@ -507,6 +507,7 @@ int rdma_listen(struct rdma_cm_id *id, int backlog)
 	return 0;
 err1:
 	id_nd->listener->lpVtbl->Release(id_nd->listener);
+	id_nd->listener = NULL;
 	return -1;
 }
 


### PR DESCRIPTION
When fi_listen is called while another passive endpoint is already bound to the same address, it triggers an error, leading to the immediate release of the IND2Listener object. Subsequently, when fi_close is called, it attempts to free the already-released object, causing a use-after-free issue.