### PR TITLE
configure.ac: Prevent `--with-lttng` from populating `{CPP,LD}FLAGS` with `yes/...` by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -788,7 +788,7 @@ AS_IF([test -n "$with_lttng" && test x"$with_lttng" != x"no"],
                         [AC_MSG_ERROR([LTTNG is requested but no found. Please check your prefix])])
       ])
 
-AS_IF([test "$have_lttng" = "1"],
+AS_IF([test "$have_lttng" = "1" && test x"$with_lttng" != x"yes"],
       [CPPFLAGS="$CPPFLAGS $lttng_CPPFLAGS"
        LDFLAGS="$LDFLAGS $lttng_LDFLAGS"])
 

--- a/configure.ac
+++ b/configure.ac
@@ -770,11 +770,11 @@ AC_ARG_ENABLE([memhooks-monitor],
 AC_DEFINE_UNQUOTED(ENABLE_MEMHOOKS_MONITOR, [$enable_memhooks],
 	[Define to 1 to enable memhooks memory monitor])
 
-dnl Check for LTTNG tracking capability
+dnl Check for LTTNG tracing capability
 have_lttng=0
 AC_ARG_WITH([lttng],
     AS_HELP_STRING([--with-lttng=DIR],
-           [Enable tracing capability with LTTNG @<:@default=no@:>@]))
+           [Enable LTTng userspace tracepoints @<:@default=no@:>@]))
 
 AS_IF([test -n "$with_lttng" && test x"$with_lttng" != x"no"],
       [FI_CHECK_PACKAGE([lttng],
@@ -785,7 +785,7 @@ AS_IF([test -n "$with_lttng" && test x"$with_lttng" != x"no"],
                         [$with_lttng],
                         [],
                         [have_lttng=1],
-                        [AC_MSG_ERROR([LTTNG is requested but no found. Please check your prefix])])
+                        [AC_MSG_ERROR([LTTng-UST support requested but liblttng-ust is not available.])])
       ])
 
 AS_IF([test "$have_lttng" = "1" && test x"$with_lttng" != x"yes"],
@@ -793,7 +793,7 @@ AS_IF([test "$have_lttng" = "1" && test x"$with_lttng" != x"yes"],
        LDFLAGS="$LDFLAGS $lttng_LDFLAGS"])
 
 AM_CONDITIONAL([HAVE_LTTNG], test "$have_lttng" -eq 1)
-AC_DEFINE_UNQUOTED([HAVE_LTTNG], [$have_lttng], [Build with LTTNG tracing])
+AC_DEFINE_UNQUOTED([HAVE_LTTNG], [$have_lttng], [Build with LTTng userspace tracepoints])
 
 AS_IF([test "$enable_memhooks" = "1"], [
 	AC_CHECK_FUNCS([__curbrk __clear_cache])


### PR DESCRIPTION
This allows building with LTTng-UST without needing to specify an installation prefix (i.e. installed to a default location). Otherwise, you end up invoking the compiler with something like `-Iyes/include` and `-Lyes/lib64`.