### PR TITLE
contrib/intel/jenkins: Fix logfile variable for dmabuf stage

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -553,11 +553,11 @@ pipeline {
           steps {
             script {
               dir ("${env.WORKSPACE}/${SCRIPT_LOCATION}/") {
-                output = "${LOG_DIR}/DMABUF-Tests_verbs-rxm_dmabuf_reg"
+                dmabuf_output = "${LOG_DIR}/DMABUF-Tests_verbs-rxm_dmabuf_reg"
                 cmd = """ python3.9 runtests.py --test=dmabuf \
                            --prov=verbs --util=rxm"""
-                slurm_batch("fabrics-ci", "1", "${output}", "${cmd}")
-                slurm_batch("fabrics-ci", "2", "${output}", "${cmd}")
+                slurm_batch("fabrics-ci", "1", "${dmabuf_output}", "${cmd}")
+                slurm_batch("fabrics-ci", "2", "${dmabuf_output}", "${cmd}")
               }
             }
           }


### PR DESCRIPTION
The output variable was getting re-written with another log file in the CI.
This commit fixes that error.