### PR TITLE
intel/ci: Enable-Mpichtestsuite PR and weekly 

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -8,6 +8,7 @@ properties([disableConcurrentBuilds(abortPrevious: true)])
 @Field def BUILD_MODES=["reg", "dbg", "dl"]
 @Field def MPI_TYPES=["impi", "mpich", "ompi"]
 @Field def PYTHON_VERSION="3.9"
+@Field def TIMEOUT="3600"
 
 def run_python(version, command, output=null) {
   if (output != null)
@@ -17,8 +18,9 @@ def run_python(version, command, output=null) {
 }
 
 def slurm_batch(partition, node_num, output, command) {
+  
   try {
-    sh """timeout 3600 sbatch --partition=${partition} -N ${node_num} \
+    sh """timeout $TIMEOUT sbatch --partition=${partition} -N ${node_num} \
           --wait -o ${output} --open-mode=append --wrap=\'env; ${command}\'
        """
   } catch (Exception e) {
@@ -63,6 +65,9 @@ def run_middleware(providers, stage_name, test, partition, node_num, mpi=null,
   if (imb_grp)
     base_cmd = "${base_cmd} --imb_grp=${imb_grp}"
 
+  if (env.WEEKLY.toBoolean())
+    base_cmd = "${base_cmd} --weekly=${env.WEEKLY}"
+    
   for (prov in providers) {
     if (prov[1]) {
       echo "Running ${prov[0]}-${prov[1]} ${stage_name}"
@@ -225,7 +230,7 @@ pipeline {
   }
   options {
       timestamps()
-      timeout(activity: true, time: 1, unit: 'HOURS')
+      timeout(activity: true, time: 6, unit: 'HOURS')
   }
   environment {
       JOB_CADENCE = 'PR'
@@ -235,7 +240,6 @@ pipeline {
       RUN_LOCATION="${env.WORKSPACE}/${SCRIPT_LOCATION}/"
       CUSTOM_WORKSPACE="${CB_HOME}/workspace/${JOB_NAME}/${env.BUILD_NUMBER}"
   }
-
   stages {
     stage ('opt-out') {
       steps {
@@ -250,11 +254,27 @@ pipeline {
           } else {
             weekly = env.WEEKLY.toBoolean()
           }
+          if (weekly) {
+            TIMEOUT="21600" 
+          } 
           skip = skip()
           RELEASE = release()
           if (skip && !weekly) {
             DO_RUN=false
           }
+        }
+      }
+    }
+    stage ('prepare build') {
+      when { equals expected: true, actual: DO_RUN }
+      steps {
+        script {  
+          echo "Copying build dirs."
+          build("builddir")
+          echo "Copying log dirs."
+          build("logdir", null, null, RELEASE)
+          build("extract_mpich")
+          build("extract_impi_mpich")
         }
       }
     }
@@ -265,16 +285,27 @@ pipeline {
           steps {
             script {
               dir (CUSTOM_WORKSPACE) {
-                echo "Copying build dirs."
-                build("builddir")
-                echo "Copying log dirs."
-                build("logdir", null, null, RELEASE)
                 for (mode in  BUILD_MODES) {
                   echo "Building Libfabric $mode"
                   build("libfabric", "$mode")
                   echo "Building Fabtests $mode"
                   build("fabtests", "$mode")
                 }
+              }
+            }
+          }
+        }
+        stage ('buildmpich-libfabric') {
+          steps {
+            script {
+              dir("${CUSTOM_WORKSPACE}/mpich"){
+                checkout scm
+                echo "Building Libfabric reg"
+                slurm_batch("squirtle,totodile", "1",
+                            "${env.LOG_DIR}/libfabric_mpich_log", 
+                            """python$PYTHON_VERSION ${RUN_LOCATION}/build.py \
+                              --build_item=libfabric_mpich """
+                          )  
               }
             }
           }
@@ -464,8 +495,7 @@ pipeline {
           steps {
             script {
               dir (RUN_LOCATION) {
-                def providers = [["verbs", "rxm"], ["tcp", null],
-                                 ["tcp", "rxm"], ["sockets", null]]
+                def providers = [['tcp', null], ["verbs","rxm"]]
                 for (mpi in MPI_TYPES) {
                   run_middleware(providers, "mpichtestsuite", "mpichtestsuite",
                                  "squirtle,totodile", "2", "${mpi}")

--- a/contrib/intel/jenkins/run.py
+++ b/contrib/intel/jenkins/run.py
@@ -126,18 +126,22 @@ def intel_mpi_benchmark(core, hosts, mpi, mode, group, user_env, log_file, util)
         print(f"Skipping {mpi.upper} {imb.testname} as execute condition fails")
     print('-------------------------------------------------------------------')
 
-def mpich_test_suite(core, hosts, mpi, mode, user_env, log_file, util):
+def mpich_test_suite(core, hosts, mpi, mode, user_env, log_file, util, weekly=None):
 
     mpich_tests = tests.MpichTestSuite(jobname=jbname,buildno=bno,
                                        testname="MpichTestSuite",core_prov=core,
                                        fabric=fab, mpitype=mpi, hosts=hosts,
                                        ofi_build_mode=mode, user_env=user_env,
-                                       log_file=log_file, util_prov=util)
+                                       log_file=log_file, util_prov=util, 
+                                       weekly=weekly)
 
     print('-------------------------------------------------------------------')
     if (mpich_tests.execute_condn == True):
-        print(f"Running mpichtestsuite: Spawn Tests for {core}-{util}-{fab}-{mpi}")
-        mpich_tests.execute_cmd("spawn")
+        if (mpi == "mpich"):
+            print("Building mpich")
+            mpich_tests.build_mpich()
+        print(f"Running mpichtestsuite for {core}-{util}-{fab}-{mpi}")
+        mpich_tests.execute_cmd()
     else:
         print(f"Skipping {mpi.upper()} {mpich_tests.testname} as exec condn fails")
     print('-------------------------------------------------------------------')

--- a/contrib/intel/jenkins/runtests.py
+++ b/contrib/intel/jenkins/runtests.py
@@ -37,6 +37,7 @@ parser.add_argument('--mpi', help="Select mpi to use for middlewares",
                     choices=['impi', 'mpich', 'ompi'], default='impi')
 parser.add_argument('--log_file', help="Full path to log file",
                     default=os.environ['DEFAULT_LOG_LOCATION'], type=str)
+parser.add_argument('--weekly', help="run weekly", default=False, type=bool)
 
 args = parser.parse_args()
 args_core = args.prov
@@ -45,6 +46,7 @@ args_util = args.util
 args_device = args.device
 user_env = args.user_env
 log_file = args.log_file
+weekly = args.weekly
 
 if (args.ofi_build_mode):
     ofi_build_mode = args.ofi_build_mode
@@ -131,7 +133,7 @@ if(args_core):
         if (run_test == 'all' or run_test == 'mpichtestsuite'):
             run.mpich_test_suite(args_core, hosts, mpi,
                                 ofi_build_mode, user_env, log_file,
-                                args_util)
+                                args_util, weekly)
 
         if (run_test == 'all' or run_test == 'IMB'):
             run.intel_mpi_benchmark(args_core, hosts, mpi,


### PR DESCRIPTION
Add code changes to enable the all tests from the mpich test suite with impi and mpich.
- test.py: class MpichtestSuite modified to build and run PR tests as well as weekly tests (impi & mpich). added functions to process exclude list.
- build.py: options and functions added for extracting mpich tar files. Also added libfabric_mpich option to build libfabric with options exclusive for mpich (-without-ze)
- run.py: changes to calls made to build and execute tests based on MpichTestSuite class.
- summary.py: summary functions modified to create summary based on new log file.
- Jenkinsfile: added prepare build stage; added parallel build stage for libfabric_mpich; increased jenkins timeout limit for weekly tests. Running tests for tcp and verbs-rxm.