### PR TITLE
prov/efa: Fix the efa_env_initialize() call sequence.

### DIFF
--- a/prov/efa/src/efa_prov.c
+++ b/prov/efa/src/efa_prov.c
@@ -184,13 +184,18 @@ EFA_INI
 	if (g_device_cnt <= 0)
 		return NULL;
 
+	/*
+	 * efa_env_initialize uses g_efa_device_list
+	 * so it must be called after efa_device_list_initialize()
+	 */
+	efa_env_initialize();
+
 	err = efa_util_prov_initialize();
 	if (err)
 		goto err_free;
 
 	dlist_init(&g_efa_domain_list);
 
-	efa_env_initialize();
 	return &efa_prov;
 
 err_free:


### PR DESCRIPTION
Currently, efa_env_initialize() is called after
efa_util_prov_initialize(). However, efa_util_prov_initialize() uses efa_env to determine the tx/rx size in info.tx/rx_attr which doesn't work because of the calling sequence issue.

This patch fixes this issue by making efa_env_initialize() called before efa_util_prov_initialize().