### PR TITLE
core: Support multiple auth keys per EP

### DIFF
--- a/include/ofi_abi.h
+++ b/include/ofi_abi.h
@@ -111,7 +111,7 @@ extern "C" {
  * name appended with the ABI version that it is compatible with.
  */
 
-#define CURRENT_ABI "FABRIC_1.6"
+#define CURRENT_ABI "FABRIC_1.7"
 
 #if  HAVE_ALIAS_ATTRIBUTE == 1
 #define DEFAULT_SYMVER_PRE(a) a##_

--- a/include/ofi_abi.h
+++ b/include/ofi_abi.h
@@ -164,6 +164,20 @@ struct fi_cq_err_entry_1_0 {
 	void			*err_data;
 };
 
+struct fi_cq_err_entry_1_1 {
+	void			*op_context;
+	uint64_t		flags;
+	size_t			len;
+	void			*buf;
+	uint64_t		data;
+	uint64_t		tag;
+	size_t			olen;
+	int			err;
+	int			prov_errno;
+	/* err_data is available until the next time the CQ is read */
+	void			*err_data;
+	size_t			err_data_size;
+};
 
 #ifdef __cplusplus
 }

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -1322,6 +1322,23 @@ ssize_t util_srx_generic_trecv(struct fid_ep *ep_fid, const struct iovec *iov,
 			       void **desc, size_t iov_count, fi_addr_t addr,
 			       void *context, uint64_t tag, uint64_t ignore,
 			       uint64_t flags);
+
+static inline void ofi_cq_err_memcpy(uint32_t api_version,
+				     struct fi_cq_err_entry *user_buf,
+				     const struct fi_cq_err_entry *prov_buf)
+{
+	size_t size;
+
+	if (FI_VERSION_GE(api_version, FI_VERSION(1, 20)))
+		size = sizeof(struct fi_cq_err_entry);
+	else if (FI_VERSION_GE(api_version, FI_VERSION(1, 5)))
+		size = sizeof(struct fi_cq_err_entry_1_1);
+	else
+		size = sizeof(struct fi_cq_err_entry_1_0);
+
+	memcpy(user_buf, prov_buf, size);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -190,7 +190,7 @@ typedef struct fid *fid_t;
 /* Tagged messages, buffered receives, CQ flags */
 #define FI_CLAIM		(1ULL << 59)
 #define FI_DISCARD		(1ULL << 58)
-
+#define FI_AUTH_KEY		(1ULL << 57)
 
 struct fi_ioc {
 	void			*addr;
@@ -227,6 +227,7 @@ enum {
 #define FI_ADDR_NOTAVAIL	((uint64_t) -1)
 #define FI_KEY_NOTAVAIL		((uint64_t) -1)
 #define FI_SHARED_CONTEXT	SIZE_MAX
+#define FI_AV_AUTH_KEY		SIZE_MAX
 typedef uint64_t		fi_addr_t;
 
 enum fi_av_type {

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -449,6 +449,7 @@ struct fi_domain_attr {
 	size_t			max_err_data;
 	size_t			mr_cnt;
 	uint32_t		tclass;
+	size_t			max_ep_auth_key;
 };
 
 struct fi_fabric_attr {

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -392,6 +392,7 @@ struct fi_tx_attr {
 	size_t			iov_limit;
 	size_t			rma_iov_limit;
 	uint32_t		tclass;
+	uint64_t		optional_caps;
 };
 
 struct fi_rx_attr {
@@ -403,6 +404,7 @@ struct fi_rx_attr {
 	size_t			total_buffered_recv;
 	size_t			size;
 	size_t			iov_limit;
+	uint64_t		optional_caps;
 };
 
 struct fi_ep_attr {
@@ -450,6 +452,7 @@ struct fi_domain_attr {
 	size_t			mr_cnt;
 	uint32_t		tclass;
 	size_t			max_ep_auth_key;
+	uint64_t		optional_caps;
 };
 
 struct fi_fabric_attr {
@@ -476,6 +479,7 @@ struct fi_info {
 	struct fi_domain_attr	*domain_attr;
 	struct fi_fabric_attr	*fabric_attr;
 	struct fid_nic		*nic;
+	uint64_t		optional_caps;
 };
 
 struct fi_device_attr {

--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -102,6 +102,11 @@ struct fi_ops_av {
 			char *buf, size_t *len);
 	int	(*av_set)(struct fid_av *av, struct fi_av_set_attr *attr,
 			struct fid_av_set **av_set, void *context);
+	int	(*insert_auth_key)(struct fid_av *av, const void *auth_key,
+				   size_t auth_key_size, fi_addr_t *fi_addr,
+				   uint64_t flags);
+	int	(*lookup_auth_key)(struct fid_av *av, fi_addr_t fi_addr,
+				   void *auth_key, size_t *auth_key_size);
 };
 
 struct fid_av {
@@ -139,6 +144,11 @@ struct fi_mr_dmabuf {
 	int		fd;
 	uint64_t	offset;
 	size_t		len;
+};
+
+struct fi_mr_auth_key {
+	struct fid_av		*av;
+	fi_addr_t		src_addr;
 };
 
 struct fi_mr_attr {
@@ -530,6 +540,24 @@ static inline const char *
 fi_av_straddr(struct fid_av *av, const void *addr, char *buf, size_t *len)
 {
 	return av->ops->straddr(av, addr, buf, len);
+}
+
+static inline int
+fi_av_insert_auth_key(struct fid_av *av, const void *auth_key,
+		      size_t auth_key_size, fi_addr_t *fi_addr, uint64_t flags)
+{
+	return FI_CHECK_OP(av->ops, struct fi_ops_av, insert_auth_key) ?
+		av->ops->insert_auth_key(av, auth_key, auth_key_size, fi_addr,
+					 flags) : -FI_ENOSYS;
+}
+
+static inline int
+fi_av_lookup_auth_key(struct fid_av *av, fi_addr_t addr, void *auth_key,
+		      size_t *auth_key_size)
+{
+	return FI_CHECK_OP(av->ops, struct fi_ops_av, lookup_auth_key) ?
+		av->ops->lookup_auth_key(av, addr, auth_key, auth_key_size) :
+		-FI_ENOSYS;
 }
 
 static inline fi_addr_t

--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -107,6 +107,8 @@ struct fi_ops_av {
 				   uint64_t flags);
 	int	(*lookup_auth_key)(struct fid_av *av, fi_addr_t fi_addr,
 				   void *auth_key, size_t *auth_key_size);
+	int	(*set_user_id)(struct fid_av *av, fi_addr_t fi_addr,
+			       fi_addr_t user_id);
 };
 
 struct fid_av {
@@ -558,6 +560,13 @@ fi_av_lookup_auth_key(struct fid_av *av, fi_addr_t addr, void *auth_key,
 	return FI_CHECK_OP(av->ops, struct fi_ops_av, lookup_auth_key) ?
 		av->ops->lookup_auth_key(av, addr, auth_key, auth_key_size) :
 		-FI_ENOSYS;
+}
+
+static inline int
+fi_av_set_user_id(struct fid_av *av, fi_addr_t fi_addr, fi_addr_t user_id)
+{
+	return FI_CHECK_OP(av->ops, struct fi_ops_av, set_user_id) ?
+		av->ops->set_user_id(av, fi_addr, user_id) : -FI_ENOSYS;
 }
 
 static inline fi_addr_t

--- a/include/rdma/fi_eq.h
+++ b/include/rdma/fi_eq.h
@@ -239,6 +239,7 @@ struct fi_cq_err_entry {
 	/* err_data is available until the next time the CQ is read */
 	void			*err_data;
 	size_t			err_data_size;
+	fi_addr_t		src_addr;
 };
 
 enum fi_cq_wait_cond {
@@ -403,6 +404,9 @@ fi_cq_readfrom(struct fid_cq *cq, void *buf, size_t count, fi_addr_t *src_addr)
 static inline ssize_t
 fi_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf, uint64_t flags)
 {
+	/* For compatibility with older providers. */
+	if (buf)
+		buf->src_addr = FI_ADDR_NOTAVAIL;
 	return cq->ops->readerr(cq, buf, flags);
 }
 

--- a/libfabric.map.in
+++ b/libfabric.map.in
@@ -53,3 +53,10 @@ FABRIC_1.6 {
 	global:
 		fi_log_ready;
 } FABRIC_1.5;
+
+FABRIC_1.7 {
+	global:
+		fi_getinfo;
+		fi_freeinfo;
+		fi_dupinfo;
+} FABRIC_1.6;

--- a/man/fabric.7.md
+++ b/man/fabric.7.md
@@ -389,6 +389,23 @@ call.
 
 ABI version starting with libfabric 1.14.  Added fi_log_ready for providers.
 
+## ABI 1.7
+
+ABI version starting with libfabric 1.20. Added new fields to the following
+attributes:
+
+*fi_domain_attr*
+: Added max_ep_auth_key and optional_caps
+
+*fi_info*
+: Added optional_caps
+
+*fi_tx_attr*
+: Added optional_caps
+
+*fi_rx_attr*
+: Added optional_caps
+
 # SEE ALSO
 
 [`fi_info`(1)](fi_info.1.html),

--- a/man/fi_cq.3.md
+++ b/man/fi_cq.3.md
@@ -414,6 +414,7 @@ struct fi_cq_err_entry {
 	int      prov_errno;  /* provider error code */
 	void    *err_data;    /*  error data */
 	size_t   err_data_size; /* size of err_data */
+	fi_addr_t src_addr; /* error source address */
 };
 ```
 
@@ -547,6 +548,10 @@ of these fields are the same for all CQ entry structure formats.
   subsequent read call against the CQ.  Applications must serialize access
   to the CQ when processing errors to ensure that the buffer referenced by
   err_data does not change.
+
+*src_addr*
+: Used to return source addressed related information for error events. How
+  this field is used is error event specific.
 
 # COMPLETION FLAGS
 

--- a/man/fi_cq.3.md
+++ b/man/fi_cq.3.md
@@ -448,6 +448,11 @@ Notable completion error codes are given below.
   passed directly into an fi_av_insert call to add the source address
   to the address vector.
 
+  For API versions 1.20 and later, if the EP is configured with
+  FI_AV_AUTH_KEY, src_addr will be set to the fi_addr_t authorization key
+  handle corresponding to the incoming data transfer. Otherwise, the
+  value will be set to FI_ADDR_NOTAVAIL.
+
 ## fi_cq_signal
 
 The fi_cq_signal call will unblock any thread waiting in fi_cq_sread

--- a/man/fi_domain.3.md
+++ b/man/fi_domain.3.md
@@ -710,6 +710,13 @@ The following are support primary capabilities:
 : When the domain is configured with FI_DIRECTED_RECV and FI_AV_AUTH_KEY,
   memory regions can be limited to specific authorization keys.
 
+*FI_AV_USER_ID*
+: Indicates that the domain supports the ability to open address vectors
+  with the FI_AV_USER_ID flag. If this domain capability is not set,
+  address vectors cannot be opened with FI_AV_USER_ID. Note that
+  FI_AV_USER_ID can still be support without this domain capability set.
+  See [`fi_av`(3)](fi_av.3.html).
+
 The following are supported secondary capabilities:
 
 *FI_LOCAL_COMM*

--- a/man/fi_domain.3.md
+++ b/man/fi_domain.3.md
@@ -214,6 +214,7 @@ struct fi_domain_attr {
 	size_t                max_err_data;
 	size_t                mr_cnt;
 	uint32_t              tclass;
+	size_t                max_ep_auth_key;
 };
 ```
 
@@ -771,6 +772,11 @@ provider to optimize any memory registration cache or lookup tables.
 This specifies the default traffic class that will be associated any endpoints
 created within the domain.  See [`fi_endpoint`(3)](fi_endpoint.3.html)
 for additional information.
+
+## Max Authorization Keys per Endpoint (max_ep_auth_key)
+
+: The maximum number of authorization keys which can be supported per connectionless
+  endpoint.
 
 # RETURN VALUE
 

--- a/man/fi_domain.3.md
+++ b/man/fi_domain.3.md
@@ -705,6 +705,13 @@ that a single memory registration operation may reference.
 Domain level capabilities.  Domain capabilities indicate domain
 level features that are supported by the provider.
 
+The following are support primary capabilities:
+*FI_DIRECTED_RECV*
+: When the domain is configured with FI_DIRECTED_RECV and FI_AV_AUTH_KEY,
+  memory regions can be limited to specific authorization keys.
+
+The following are supported secondary capabilities:
+
 *FI_LOCAL_COMM*
 : At a conceptual level, this field indicates that the underlying device
   supports loopback communication.  More specifically, this field
@@ -726,8 +733,7 @@ level features that are supported by the provider.
   feature.
 
 See [`fi_getinfo`(3)](fi_getinfo.3.html) for a discussion on primary versus
-secondary capabilities.  All domain capabilities are considered secondary
-capabilities.
+secondary capabilities.
 
 ## mode
 
@@ -744,6 +750,9 @@ The default authorization key to associate with endpoint and memory
 registrations created within the domain. This field is ignored unless the
 fabric is opened with API version 1.5 or greater.
 
+If domain auth_key_size is set to the value FI_AV_AUTH_KEY, auth_key must be
+NULL.
+
 ## Default authorization key length (auth_key_size)
 
 The length in bytes of the default authorization key for the domain. If set to 0,
@@ -751,6 +760,11 @@ then no authorization key will be associated with endpoints and memory
 registrations created within the domain unless specified in the endpoint or
 memory registration attributes. This field is ignored unless the fabric is
 opened with API version 1.5 or greater.
+
+If the size is set to the value FI_AV_AUTH_KEY, all endpoints and memory
+regions will be configured to use authorization keys associated with the AV.
+Providers which support authorization keys and connectionless endpoint must
+support this option.
 
 ## Max Error Data Size (max_err_data)
 : The maximum amount of error data, in bytes, that may be returned as part of
@@ -777,7 +791,7 @@ for additional information.
 ## Max Authorization Keys per Endpoint (max_ep_auth_key)
 
 : The maximum number of authorization keys which can be supported per connectionless
-  endpoint.
+  endpoint. If this value is non-zero, providers must support FI_AV_AUTH_KEY.
 
 ## Optional Capabilities (optional_caps)
 

--- a/man/fi_domain.3.md
+++ b/man/fi_domain.3.md
@@ -215,6 +215,7 @@ struct fi_domain_attr {
 	size_t                mr_cnt;
 	uint32_t              tclass;
 	size_t                max_ep_auth_key;
+	uint64_t              optional_caps;
 };
 ```
 
@@ -777,6 +778,15 @@ for additional information.
 
 : The maximum number of authorization keys which can be supported per connectionless
   endpoint.
+
+## Optional Capabilities (optional_caps)
+
+The requested optional capabilities of the domain. If the optional_caps field is
+0 on input to fi_getinfo(), the capabilities fi_info optional_caps field will be
+used. See [`fi_getinfo`(3)](fi_getinfo.3.html) for a discussion on primary,
+secondary, and optional capabilities.
+
+Note that during domain allocation, optional_caps will be ignored.
 
 # RETURN VALUE
 

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -940,6 +940,7 @@ struct fi_tx_attr {
 	size_t    iov_limit;
 	size_t    rma_iov_limit;
 	uint32_t  tclass;
+	uint64_t  optional_caps;
 };
 {% endhighlight %}
 
@@ -1233,6 +1234,15 @@ domain.
   the fi_tc_dscp_set and fi_tc_dscp_get function definitions for details
   on their use.
 
+## optional_caps - Optional Capabilities
+
+The requested optional capabilities of the context. If the optional_caps field
+is 0 on input to fi_getinfo(), the capabilities fi_info optional_caps field
+will be used. See [`fi_getinfo`(3)](fi_getinfo.3.html) for a discussion on
+primary, secondary, and optional capabilities.
+
+Note that during endpoint and context allocation, optional_caps will be ignored.
+
 # RECEIVE CONTEXT ATTRIBUTES
 
 Attributes specific to the receive capabilities of an endpoint are
@@ -1248,6 +1258,7 @@ struct fi_rx_attr {
 	size_t    total_buffered_recv;
 	size_t    size;
 	size_t    iov_limit;
+	uint64_t  optional_caps;
 };
 {% endhighlight %}
 
@@ -1364,6 +1375,15 @@ the endpoint's receive size, in order to reduce resource utilization.
 
 This is the maximum number of IO vectors (scatter-gather elements)
 that a single posted operating may reference.
+
+## optional_caps - Optional Capabilities
+
+The requested optional capabilities of the context. If the optional_caps field
+is 0 on input to fi_getinfo(), the capabilities fi_info optional_caps field
+will be used. See [`fi_getinfo`(3)](fi_getinfo.3.html) for a discussion on
+primary, secondary, and optional capabilities.
+
+Note that during endpoint and context allocation, optional_caps will be ignored.
 
 # SCALABLE ENDPOINTS
 

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -911,6 +911,8 @@ The length of the authorization key in bytes.  This field will be 0 if
 authorization keys are not available or used.  This field is ignored
 unless the fabric is opened with API version 1.5 or greater.
 
+If the domain is opened with FI_AV_AUTH_KEY, auth_key_size must be 0.
+
 ## auth_key - Authorization Key
 
 If supported by the fabric, an authorization key (a.k.a. job
@@ -922,6 +924,8 @@ that processes running in different jobs do not accidentally
 cross traffic.  The domain authorization key will be used if auth_key_size
 is set to 0.  This field is ignored unless the fabric is opened with API
 version 1.5 or greater.
+
+If the domain is opened with FI_AV_AUTH_KEY, auth_key is must be NULL.
 
 # TRANSMIT CONTEXT ATTRIBUTES
 

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -142,6 +142,7 @@ struct fi_info {
 	struct fi_domain_attr *domain_attr;
 	struct fi_fabric_attr *fabric_attr;
 	struct fid_nic        *nic;
+	uint64_t              optional_caps;
 };
 ```
 
@@ -247,6 +248,10 @@ struct fi_info {
   only valid for providers where the corresponding attributes are
   closely associated with a hardware NIC.  See
   [`fi_nic`(3)](fi_nic.3.html) for details.
+
+*optional_caps - optional fabric interface capabilities*
+: If specified, indicates the desired optional capabilities of the fabric
+  interfaces. See _Capabilities_ section below for more information.
 
 # CAPABILITIES
 
@@ -473,6 +478,15 @@ FI_REMOTE_READ, FI_REMOTE_WRITE
 
 Secondary capabilities: FI_MULTI_RECV, FI_SOURCE, FI_RMA_EVENT, FI_SHARED_AV,
 FI_TRIGGER, FI_FENCE, FI_LOCAL_COMM, FI_REMOTE_COMM, FI_SOURCE_ERR, FI_RMA_PMEM.
+
+Optional capabilities may optionally be requested by an application. This
+ability enables applications to optionally request a capability without resulting
+in fi_getinfo() failing to return a fi_info if a provider cannot support the
+capability. If an provider supports an optional capability, the corresponding
+capability will be set in the caps field. Applications can use this information
+to dynamically change their behavior based on provider capabilities.
+
+All primary and secondary capabilities are eligible for optional capabilities.
 
 # MODE
 

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -279,8 +279,9 @@ additional optimizations.
 *FI_AV_USER_ID*
 : Requests that the provider support the association of a user specified
   identifier with each address vector (AV) address.  User identifiers are
-  returned with completion data in place of the AV address.  See [`fi_av`(3)]
-  (fi_av.3.html) for more details.
+  returned with completion data in place of the AV address.  See
+  [`fi_domain`(3)](fi_domain.3.html) and [`fi_av`(3)] (fi_av.3.html) for
+  more details.
 
 *FI_COLLECTIVE*
 : Requests support for collective operations.  Endpoints that support
@@ -471,7 +472,7 @@ would not compromise performance or security.
 
 Primary capabilities: FI_MSG, FI_RMA, FI_TAGGED, FI_ATOMIC, FI_MULTICAST,
 FI_NAMED_RX_CTX, FI_DIRECTED_RECV, FI_VARIABLE_MSG, FI_HMEM, FI_COLLECTIVE,
-FI_XPU
+FI_XPU, FI_AV_USER_ID
 
 Primary modifiers: FI_READ, FI_WRITE, FI_RECV, FI_SEND,
 FI_REMOTE_READ, FI_REMOTE_WRITE

--- a/man/fi_msg.3.md
+++ b/man/fi_msg.3.md
@@ -305,6 +305,10 @@ fi_sendmsg.
   be used in all multicast transfers, in conjunction with a multicast
   fi_addr_t.
 
+*FI_AUTH_KEY*
+: Denotes that the fi_addr_t src_addr being passed in authorization key
+  fi_addr_t.
+
 # Buffered Receives
 
 Buffered receives indicate that the networking layer allocates and

--- a/man/fi_tagged.3.md
+++ b/man/fi_tagged.3.md
@@ -285,6 +285,10 @@ and/or fi_tsendmsg.
   operation (inclusive) to the posting of a subsequent fenced operation
   (exclusive) is controlled by the endpoint's ordering semantics.
 
+*FI_AUTH_KEY*
+: Denotes that the fi_addr_t src_addr being passed in authorization key
+  fi_addr_t.
+
 The following flags may be used with fi_trecvmsg.
 
 *FI_PEEK*

--- a/prov/bgq/src/fi_bgq_cq.c
+++ b/prov/bgq/src/fi_bgq_cq.c
@@ -186,7 +186,8 @@ fi_bgq_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf, uint64_t flags
 		if (NULL == bgq_cq->err_head)
 			bgq_cq->err_tail = NULL;
 
-		*buf = ext->err_entry;
+		ofi_cq_err_memcpy(bgq_cq->domain->fabric->fabric_fid.api_version,
+				  buf, &ext->err_entry);
 		free(ext);
 
 		ret = fi_bgq_unlock_if_required(&bgq_cq->lock, lock_required);
@@ -213,7 +214,8 @@ fi_bgq_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf, uint64_t flags
 
 		assert(ext->bgq_context.flags & FI_BGQ_CQ_CONTEXT_EXT);	/* DEBUG */
 
-		*buf = ext->err_entry;
+		ofi_cq_err_memcpy(bgq_cq->domain->fabric->fabric_fid.api_version,
+				  buf, &ext->err_entry);
 		free(ext);
 
 		l2atomic_fifo_advance(&bgq_cq->err_consumer);

--- a/prov/opx/include/rdma/opx/fi_opx_cq_ops_table.h
+++ b/prov/opx/include/rdma/opx/fi_opx_cq_ops_table.h
@@ -72,7 +72,8 @@ fi_opx_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf, uint64_t flags
 		const int lock_required = fi_opx_threading_lock_required(threading, fi_opx_global.progress);
 
 		fi_opx_lock_if_required(&opx_cq->lock, lock_required);
-		*buf = ext->err_entry;
+		ofi_cq_err_memcpy(opx_cq->domain->fabric->fabric_fid.api_version,
+				  buf, &ext->err_entry);
 		slist_remove_head((struct slist *)&opx_cq->err);
 		free(ext);
 		ext = NULL;

--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -1684,19 +1684,13 @@ STATIC ssize_t psmx2_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf,
 				uint64_t flags)
 {
 	struct psmx2_fid_cq *cq_priv;
-	uint32_t api_version;
-	size_t size;
 
 	cq_priv = container_of(cq, struct psmx2_fid_cq, cq);
 
 	cq_priv->domain->cq_lock_fn(&cq_priv->lock, 2);
 	if (cq_priv->pending_error) {
-		api_version = cq_priv->domain->fabric->util_fabric.
-			      fabric_fid.api_version;
-		size = FI_VERSION_GE(api_version, FI_VERSION(1, 5)) ?
-			sizeof(*buf) : sizeof(struct fi_cq_err_entry_1_0);
-
-		memcpy(buf, &cq_priv->pending_error->cqe, size);
+		ofi_cq_err_memcpy(cq_priv->domain->fabric->util_fabric.fabric_fid.api_version,
+				  buf, &cq_priv->pending_error->cqe);
 		free(cq_priv->pending_error);
 		cq_priv->pending_error = NULL;
 		psmx2_unlock(&cq_priv->lock, 2);

--- a/prov/psm3/src/psmx3_cq.c
+++ b/prov/psm3/src/psmx3_cq.c
@@ -954,19 +954,13 @@ STATIC ssize_t psmx3_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf,
 				uint64_t flags)
 {
 	struct psmx3_fid_cq *cq_priv;
-	uint32_t api_version;
-	size_t size;
 
 	cq_priv = container_of(cq, struct psmx3_fid_cq, cq);
 
 	cq_priv->domain->cq_lock_fn(&cq_priv->lock, 2);
 	if (cq_priv->pending_error) {
-		api_version = cq_priv->domain->fabric->util_fabric.
-			      fabric_fid.api_version;
-		size = FI_VERSION_GE(api_version, FI_VERSION(1, 5)) ?
-			sizeof(*buf) : sizeof(struct fi_cq_err_entry_1_0);
-
-		memcpy(buf, &cq_priv->pending_error->cqe, size);
+		ofi_cq_err_memcpy(cq_priv->domain->fabric->util_fabric.fabric_fid.api_version,
+				  buf, &cq_priv->pending_error->cqe);
 		free(cq_priv->pending_error);
 		cq_priv->pending_error = NULL;
 		psmx3_unlock(&cq_priv->lock, 2);

--- a/prov/sockets/src/sock_cq.c
+++ b/prov/sockets/src/sock_cq.c
@@ -449,7 +449,8 @@ static ssize_t sock_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf,
 			&& buf->err_data && buf->err_data_size) {
 			err_data = buf->err_data;
 			err_data_size = buf->err_data_size;
-			*buf = entry;
+			ofi_cq_err_memcpy(api_version, buf, &entry);
+
 			buf->err_data = err_data;
 
 			/* Fill provided user's buffer */

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -300,7 +300,7 @@ ssize_t ofi_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *buf,
 		err_data_size = MIN(buf->err_data_size,
 				    aux_entry->comp.err_data_size);
 
-		*buf = aux_entry->comp;
+		ofi_cq_err_memcpy(api_version, buf, &aux_entry->comp);
 		memcpy(err_buf_save, aux_entry->comp.err_data, err_data_size);
 		buf->err_data = err_buf_save;
 		buf->err_data_size = err_data_size;

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -990,7 +990,7 @@ void DEFAULT_SYMVER_PRE(fi_freeinfo)(struct fi_info *info)
 		free(info);
 	}
 }
-DEFAULT_SYMVER(fi_freeinfo_, fi_freeinfo, FABRIC_1.3);
+CURRENT_SYMVER(fi_freeinfo_, fi_freeinfo);
 
 static bool
 ofi_info_match_prov(struct fi_info *info, struct ofi_info_match *match)
@@ -1328,7 +1328,7 @@ int DEFAULT_SYMVER_PRE(fi_getinfo)(uint32_t version, const char *node,
 
 	return *info ? 0 : -FI_ENODATA;
 }
-DEFAULT_SYMVER(fi_getinfo_, fi_getinfo, FABRIC_1.3);
+CURRENT_SYMVER(fi_getinfo_, fi_getinfo);
 
 struct fi_info *ofi_allocinfo_internal(void)
 {
@@ -1459,7 +1459,7 @@ fail:
 	fi_freeinfo(dup);
 	return NULL;
 }
-DEFAULT_SYMVER(fi_dupinfo_, fi_dupinfo, FABRIC_1.3);
+CURRENT_SYMVER(fi_dupinfo_, fi_dupinfo);
 
 __attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
 int DEFAULT_SYMVER_PRE(fi_fabric)(struct fi_fabric_attr *attr,

--- a/src/log.c
+++ b/src/log.c
@@ -343,7 +343,7 @@ int DEFAULT_SYMVER_PRE(fi_log_ready)(const struct fi_provider *prov,
 
 	return log_fid.ops->ready(prov, level, subsys, flags, showtime);
 }
-CURRENT_SYMVER(fi_log_ready_, fi_log_ready);
+DEFAULT_SYMVER(fi_log_ready_, fi_log_ready, FABRIC_1.6);
 
 __attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
 void DEFAULT_SYMVER_PRE(fi_log)(const struct fi_provider *prov, enum fi_log_level level,


### PR DESCRIPTION
EPs bound to an AV configure with FI_AUTH_KEY can support 1+ auth keys per EPs.

All eligible auth keys must be pre-inserted into the AV via fi_av_insert_auth_key(). Acceptable flags are the following:
- FI_TRANSMIT: Restrict the auth key to outbound data transfers. This includes send message, RMA, and atomic operations.
- FI_RECV: Restrict the auth key to inbound data transfers. This includes received messages and target MRs of RMA and atomic operations.

The FI_AUTH_KEY_MATCH_ALL fi_av_attr flag can be used to pre-configure the AV for all possible auth keys with a FI_TRANSMIT | FI_RECV configuration.

Once the AV is bound to an EP and the EP is successfully enabled, the EP will be configured to support all auth keys in the AV at that point in time. Later fi_av_insert_auth_key() will not propagate to already enabled EPs.

For AVs configured with FI_AUTH_KEY,
fi_av_insert_auth_key_{addr, svc, sym} must be used to generate fi_addr_t's for a specific <EP addr, auth key> tuple.
fi_av_insert_{addr, svc, sym} will not be supported. The resulting fi_addr_t's can be used for outgoing data transfers. If the endpoint is configured with FI_DIRECTED_RECV, the resulting fi_addr_t's can be used to restrict a receive buffer to a specific <EP addr, auth key> tuple. FI_ADDR_UNSEPC can be used to match any <EP addr, auth key> combination. An insert can be done with FI_AUTH_KEY_MATCH_ALL to generate an fi_addr_t to match on all EP addr and a specific auth key.

All inserted auth_keys must have buffer size equal to fi_info::domain_attr::auth_key_size reported by the provider. Failure to ensure this may lead to memory corruption.

For FI_EADDRNOTAVAIL CQ errors, the FI_SOURCE_ERR flag in fi_cq_err_entry::flags can be used to distinguish if fi_cq_err_entry::src_err_data or fi_cq_err_entry::err_data is valid. If set, fi_cq_err_entry::src_err_data is valid.

For EPs configured with FI_SOURCE_ERR and bound to an AV with FI_AUTH_KEY, all FI_EADDRNOTAVAIL CQ errors need to be generated with the FI_SOURCE_ERR flag set and fi_cq_err_entry::src_err_data filled in accordingly. fi_cq_err_source_err_data::addr and
fi_cq_err_source_err_data::auth_key will be set to valid pointers which can be used for fi_av_insert_auth_key_addr().