### PR TITLE
prov/shm: respect the mr mode from the hints

### DIFF
--- a/prov/shm/src/smr_init.c
+++ b/prov/shm/src/smr_init.c
@@ -164,6 +164,7 @@ static int smr_getinfo(uint32_t version, const char *node, const char *service,
 				smr_resolve_addr(NULL, NULL, (char **) &cur->src_addr,
 						 &cur->src_addrlen);
 		}
+		cur->domain_attr->mr_mode = mr_mode;
 		if (fast_rma) {
 			cur->domain_attr->mr_mode |= FI_MR_VIRT_ADDR;
 			cur->tx_attr->msg_order = FI_ORDER_SAS;


### PR DESCRIPTION
Currently, when user requests FI_MR_VIRT_ADDR
in hints->domain_attr->mr_mode, shm actually
doesn't respect it unless fast_rma is true.
This patch makes shm use the mr_mode of the hints
by default.