### PR TITLE
prov/shm: Use peer cntr inc ops in smr_progress_cmd

### DIFF
--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -1203,7 +1203,7 @@ static void smr_progress_cmd(struct smr_ep *ep)
 			break;
 		case ofi_op_write_async:
 		case ofi_op_read_async:
-			ofi_ep_rx_cntr_inc_func(&ep->util_ep,
+			ofi_ep_peer_rx_cntr_inc(&ep->util_ep,
 						ce->cmd.msg.hdr.op);
 			break;
 		case ofi_op_atomic:


### PR DESCRIPTION
Currently, smr_progress_cmd still uses
ofi_ep_rx_cntr_inc_func to increment rx cntrs.
It should be replaced to ofi_ep_peer_rx_cntr_inc
to onboard peer cntr API as other cntr ops inside
shm.