### PR TITLE
prov/shm: only increment tx cntr when inject rma succeeded.

### DIFF
--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -364,7 +364,8 @@ static ssize_t smr_generic_rma_inject(struct fid_ep *ep_fid, const void *buf,
 	smr_cmd_queue_commit(ce, pos);
 
 out:
-	ofi_ep_peer_tx_cntr_inc(&ep->util_ep, ofi_op_write);
+	if (!ret)
+		ofi_ep_peer_tx_cntr_inc(&ep->util_ep, ofi_op_write);
 	return ret;
 }
 


### PR DESCRIPTION
Currently, smr_generic_rma_inject still increments tx cntr when smr_rma_fast returns a non-zero, which is wrong.

This patch fixes this bug.