### PR TITLE
[v1.19.x] prov/shm: only increment tx cntr when inject rma succeeded.

### DIFF
--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -376,7 +376,8 @@ static ssize_t smr_generic_rma_inject(struct fid_ep *ep_fid, const void *buf,
 	smr_cmd_queue_commit(ce, pos);
 
 out:
-	ofi_ep_peer_tx_cntr_inc(&ep->util_ep, ofi_op_write);
+	if (!ret)
+		ofi_ep_peer_tx_cntr_inc(&ep->util_ep, ofi_op_write);
 	return ret;
 }
 


### PR DESCRIPTION
Currently, smr_generic_rma_inject still increments tx cntr when smr_rma_fast returns a non-zero, which is wrong.

This patch fixes this bug.

Signed-off-by: Shi Jin <sjina@amazon.com>
(cherry picked from commit a80b72472cbc4ef9677453727979db4ee196498b)