### PR TITLE
contrib/intel/jenkins: Add testing for different key environment variables

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -382,6 +382,10 @@ pipeline {
               dir (RUN_LOCATION) {
                 run_fabtests("verbs-rxm", "squirtle,totodile", "2", "verbs",
                              "rxm")
+                run_fabtests("verbs-rxm", "squirtle,totodile", "2", "verbs",
+                             "rxm", "FI_MR_CACHE_MAX_COUNT=0")
+                run_fabtests("verbs-rxm", "squirtle,totodile", "2", "verbs",
+                             "rxm", "FI_MR_CACHE_MONITOR=userfaultfd")
               }
             }
           }
@@ -392,6 +396,10 @@ pipeline {
               dir (RUN_LOCATION) {
                 run_fabtests("verbs-rxd", "squirtle", "2", "verbs",
                              "rxd")
+                run_fabtests("verbs-rxd", "squirtle", "2", "verbs",
+                             "rxd", "FI_MR_CACHE_MAX_COUNT=0")
+                run_fabtests("verbs-rxd", "squirtle", "2", "verbs",
+                             "rxd", "FI_MR_CACHE_MONITOR=userfaultfd")
               }
             }
           }


### PR DESCRIPTION
This commit adds two env vars to verbs;ofi_rxd stage: FI_MR_CACHE_MAX_COUNT=0 and FI_MR_CACHE_MONITOR=userfaultfd.
Verbs ofi_rxm stage has two new env vars:
FI_MR_CACHE_MAX_COUNT=0 and FI_MR_CACHE_MONITOR=userfaultfd. The third env var FI_OFI_RXM_USE_SRX=true resulted in assertion failure and core dump. Issue #9336 has been opened for that and it will be added to verbs;ofi_rxm stage after issue has been fixed.

This commit is a fix for issue #7304