### PR TITLE
fabtests/macos: Fix build error with clang

### DIFF
--- a/fabtests/include/unix/osd.h
+++ b/fabtests/include/unix/osd.h
@@ -36,6 +36,7 @@
 #include <complex.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <sys/socket.h>
 
 #ifndef SOCKET
 #define SOCKET int


### PR DESCRIPTION
Fixes #9306

Add missing include to osd.h for socket calls.