### PR TITLE
contrib/intel/jenkins: Add summary fast forward

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -591,11 +591,13 @@ pipeline {
           steps {
             script {
               dir ("${env.WORKSPACE}/${SCRIPT_LOCATION}/") {
-                dmabuf_output = "${LOG_DIR}/DMABUF-Tests_verbs-rxm_dmabuf_reg"
+                dmabuf_output = "${LOG_DIR}/DMABUF-Tests_verbs-rxm_dmabuf"
                 cmd = """ python3.9 runtests.py --test=dmabuf \
                            --prov=verbs --util=rxm"""
-                slurm_batch("fabrics-ci", "1", "${dmabuf_output}", "${cmd}")
-                slurm_batch("fabrics-ci", "2", "${dmabuf_output}", "${cmd}")
+                slurm_batch("fabrics-ci", "1", "${dmabuf_output}_1_reg",
+                            "${cmd}")
+                slurm_batch("fabrics-ci", "2", "${dmabuf_output}_2_reg",
+                            "${cmd}")
               }
             }
           }

--- a/contrib/intel/jenkins/common.py
+++ b/contrib/intel/jenkins/common.py
@@ -138,3 +138,5 @@ common_disable_list = [
 default_enable_list = [
     'ze-dlopen'
 ]
+
+cloudbees_log_start_string = "Begin Cloudbees Test Output"

--- a/contrib/intel/jenkins/common.py
+++ b/contrib/intel/jenkins/common.py
@@ -19,6 +19,8 @@ def run_command(command):
         if (out != ''):
             sys.stdout.write(out)
             sys.stdout.flush()
+
+    print(f"Return code is {p.returncode}")
     if (p.returncode != 0):
         print("exiting with " + str(p.poll()))
         sys.exit(p.returncode)
@@ -38,6 +40,8 @@ def run_logging_command(command, log_file):
         if (out != ''):
             sys.stdout.write(out)
             sys.stdout.flush()
+
+    print(f"Return code is {p.returncode}")
     if (p.returncode != 0):
         print("exiting with " + str(p.poll()))
         f.close()

--- a/contrib/intel/jenkins/runtests.py
+++ b/contrib/intel/jenkins/runtests.py
@@ -91,6 +91,8 @@ else:
         hosts.append(host)
     print(f"hosts = {hosts}")
 
+print(common.cloudbees_log_start_string)
+
 #this script is executed from /tmp
 #this is done since some mpi tests
 #look for a valid location before running

--- a/contrib/intel/jenkins/summary.py
+++ b/contrib/intel/jenkins/summary.py
@@ -147,12 +147,12 @@ class Summarizer(ABC):
         percent = self.passes/total * 100
         if (verbose):
             self.logger.log(
-                f"<>{self.stage_name} : ", lpad=1, ljust=40, end_delimiter = ''
+                f"<>{self.stage_name} : ", lpad=1, ljust=50, end_delimiter = ''
             )
         else:
             self.logger.log(
                 f"{self.stage_name} : ",
-                lpad=1, ljust=40, end_delimiter = ''
+                lpad=1, ljust=50, end_delimiter = ''
             )
         self.logger.log(
                 f"{self.node} : ",
@@ -903,12 +903,13 @@ def summarize_items(summary_item, logger, log_dir, mode):
 
     if summary_item == 'dmabuf' or summary_item == 'all':
         for prov in ['verbs-rxm']:
-            ret = DmabufSummarizer(
-                logger, log_dir, 'verbs-rxm',
-                f'DMABUF-Tests_{prov}_dmabuf_{mode}',
-                f"DMABUF-Tests {prov} dmabuf {mode}"
-            ).summarize()
-            err += ret if ret else 0
+            for num_nodes in range(1,3):
+                ret = DmabufSummarizer(
+                    logger, log_dir, 'verbs-rxm',
+                    f'DMABUF-Tests_{prov}_dmabuf_{num_nodes}_{mode}',
+                    f"DMABUF-Tests {prov} dmabuf {num_nodes} node {mode}"
+                ).summarize()
+                err += ret if ret else 0
 
     return err
 


### PR DESCRIPTION
Fast forwarding the summary to the start of test output. This will eliminate false positives where a user could put a keyword in their title to get the summary to think its something to pay attention to when it actually is just the title.