### PR TITLE
prov/efa: Disallow RDMA read between incompatible EFA devices

### DIFF
--- a/prov/efa/docs/efa_rdm_protocol_v4.md
+++ b/prov/efa/docs/efa_rdm_protocol_v4.md
@@ -374,16 +374,18 @@ The binary format of a HANDSHAKE packet is listed in table 2.2.
 
 Table: 2.2 binary format of the HANDSHAKE packet
 
-| Field        | Length (bytes)        | Type          | C data type  | Flag (optional fields)  |
-| -----        | --------------        | ----          | -----------  | ----------------------  |
-| `type`       | 1                     | integer       | `uint8_t`    | _Required_              |
-| `version`    | 1                     | integer       | `uint8_t`    | _Required_              |
-| `flags`      | 2                     | integer       | `uint16_t`   | _Required_              |
-| `nextra_p3`  | 4                     | integer       | `uint32_t`   | _Required_              |
-| `extra_info` | 8 * (`nextra_p3` - 3) | integer array | `uint64_t[]` | _Required_              |
-| `connid`     | 4                     | integer       | `uint32_t`   | `CONNID_HDR`            |
-| _padding_    | 4                     | _N/A_         | _N/A_        | `CONNID_HDR`            |
-| `host_id`    | 8                     | integer       | `uint64_t`   | `HANDSHAKE_HOST_ID_HDR` |
+| Field            | Length (bytes)        | Type          | C data type  | Flag (optional fields)         |
+| -----            | --------------        | ----          | -----------  | ----------------------         |
+| `type`           | 1                     | integer       | `uint8_t`    | _Required_                     |
+| `version`        | 1                     | integer       | `uint8_t`    | _Required_                     |
+| `flags`          | 2                     | integer       | `uint16_t`   | _Required_                     |
+| `nextra_p3`      | 4                     | integer       | `uint32_t`   | _Required_                     |
+| `extra_info`     | 8 * (`nextra_p3` - 3) | integer array | `uint64_t[]` | _Required_                     |
+| `connid`         | 4                     | integer       | `uint32_t`   | `CONNID_HDR`                   |
+| _padding_        | 4                     | _N/A_         | _N/A_        | `CONNID_HDR`                   |
+| `host_id`        | 8                     | integer       | `uint64_t`   | `HANDSHAKE_HOST_ID_HDR`        |
+| `device_version` | 4                     | integer       | `uint32_t`   | `HANDSHAKE_DEVICE_VERSION_HDR` |
+| _reserved_       | 4                     | _N/A_         | _N/A_        | `HANDSHAKE_DEVICE_VERSION_HDR` |
 
 The first 4 bytes (3 fields: `type`, `version`, `flags`) is the EFA RDM base header (section 1.3).
 
@@ -430,13 +432,15 @@ HANDSHAKE packet's header (table 2.3).
 
 - `connid` is a universal field explained in detail in section 4.4.
 - `host_id` is an unsigned integer representing the host identifier of the sender.
+- `device_version` represents the version of the sender's EFA device.
 
 Table 2.3 Flags for optional HANDSHAKE packet fields
 
-| Flag                    | Value    | Hex      | Field     |
-| ----                    | -----    | ---      | -----     |
-| `CONNID_HDR`            | $2^{15}$ | `0x8000` | `connid`  |
-| `HANDSHAKE_HOST_ID_HDR` | $2^0$    | `0x0001` | `host_id` |
+| Flag                           | Value    | Hex      | Field            |
+| ----                           | -----    | ---      | -----            |
+| `CONNID_HDR`                   | $2^{15}$ | `0x8000` | `connid`         |
+| `HANDSHAKE_HOST_ID_HDR`        | $2^0$    | `0x0001` | `host_id`        |
+| `HANDSHAKE_DEVICE_VERSION_HDR` | $2^1$    | `0x0002` | `device_version` |
 
 Refer to table 2.2 for field attributes, such as corresponding C data
 types and length in bytes (including padding).

--- a/prov/efa/src/rdm/efa_rdm_msg.c
+++ b/prov/efa/src/rdm/efa_rdm_msg.c
@@ -1,35 +1,5 @@
-/*
- * Copyright (c) Amazon.com, Inc. or its affiliates.
- * All rights reserved.
- *
- * This software is available to you under a choice of one of two
- * licenses.  You may choose to be licensed under the terms of the GNU
- * General Public License (GPL) Version 2, available from the file
- * COPYING in the main directory of this source tree, or the
- * BSD license below:
- *
- *     Redistribution and use in source and binary forms, with or
- *     without modification, are permitted provided that the following
- *     conditions are met:
- *
- *      - Redistributions of source code must retain the above
- *        copyright notice, this list of conditions and the following
- *        disclaimer.
- *
- *      - Redistributions in binary form must reproduce the above
- *        copyright notice, this list of conditions and the following
- *        disclaimer in the documentation and/or other materials
- *        provided with the distribution.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
- * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
- * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
+/* Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
 
 #include <inttypes.h>
 #include <stdlib.h>
@@ -123,7 +93,7 @@ int efa_rdm_msg_select_rtm(struct efa_rdm_ep *efa_rdm_ep, struct efa_rdm_ope *tx
 	readbase_rtm = efa_rdm_peer_select_readbase_rtm(peer, txe->op, txe->fi_flags, &hmem_info[iface]);
 
 	if (txe->total_len >= hmem_info[iface].min_read_msg_size &&
-		efa_both_support_rdma_read(efa_rdm_ep, peer) &&
+		efa_rdm_interop_rdma_read(efa_rdm_ep, peer) &&
 		(txe->desc[0] || efa_is_cache_available(efa_rdm_ep_domain(efa_rdm_ep))))
 		return readbase_rtm;
 

--- a/prov/efa/src/rdm/efa_rdm_peer.h
+++ b/prov/efa/src/rdm/efa_rdm_peer.h
@@ -1,35 +1,6 @@
-/*
- * Copyright (c) 2019-2023 Amazon.com, Inc. or its affiliates.
- * All rights reserved.
- *
- * This software is available to you under a choice of one of two
- * licenses.  You may choose to be licensed under the terms of the GNU
- * General Public License (GPL) Version 2, available from the file
- * COPYING in the main directory of this source tree, or the
- * BSD license below:
- *
- *     Redistribution and use in source and binary forms, with or
- *     without modification, are permitted provided that the following
- *     conditions are met:
- *
- *      - Redistributions of source code must retain the above
- *        copyright notice, this list of conditions and the following
- *        disclaimer.
- *
- *      - Redistributions in binary form must reproduce the above
- *        copyright notice, this list of conditions and the following
- *        disclaimer in the documentation and/or other materials
- *        provided with the distribution.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
- * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
- * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
+/* Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+
 #ifndef EFA_RDM_PEER_H
 #define EFA_RDM_PEER_H
 
@@ -47,7 +18,7 @@ OFI_DECL_RECVWIN_BUF(struct efa_rdm_pke*, efa_rdm_robuf, uint32_t);
 #define EFA_RDM_PEER_IN_BACKOFF BIT_ULL(3) /**< peer is in backoff mode due to RNR (Endpoint should not send packet to this peer) */
 /**
  * @details
- * FI_EAGAIN error was encountered when sending handsahke to this peer,
+ * FI_EAGAIN error was encountered when sending handshake to this peer,
  * the peer was put in efa_rdm_ep->handshake_queued_peer_list.
  * Progress engine will retry sending handshake.
  */
@@ -56,6 +27,7 @@ OFI_DECL_RECVWIN_BUF(struct efa_rdm_pke*, efa_rdm_robuf, uint32_t);
 struct efa_rdm_peer {
 	bool is_self;			/**< flag indicating whether the peer is the endpoint itself */
 	bool is_local;			/**< flag indicating wehther the peer is local (on the same instance) */
+	uint32_t device_version;	/**< EFA device version */
 	fi_addr_t efa_fiaddr;		/**< libfabric addr from efa provider's perspective */
 	fi_addr_t shm_fiaddr;		/**< libfabric addr from shm provider's perspective */
 	uint64_t host_id; 		/* Optional peer host id. Default 0 */

--- a/prov/efa/src/rdm/efa_rdm_pke_nonreq.h
+++ b/prov/efa/src/rdm/efa_rdm_pke_nonreq.h
@@ -1,38 +1,8 @@
-/*
- * Copyright (c) Amazon.com, Inc. or its affiliates.
- * All rights reserved.
- *
- * This software is available to you under a choice of one of two
- * licenses.  You may choose to be licensed under the terms of the GNU
- * General Public License (GPL) Version 2, available from the file
- * COPYING in the main directory of this source tree, or the
- * BSD license below:
- *
- *     Redistribution and use in source and binary forms, with or
- *     without modification, are permitted provided that the following
- *     conditions are met:
- *
- *      - Redistributions of source code must retain the above
- *        copyright notice, this list of conditions and the following
- *        disclaimer.
- *
- *      - Redistributions in binary form must reproduce the above
- *        copyright notice, this list of conditions and the following
- *        disclaimer in the documentation and/or other materials
- *        provided with the distribution.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
- * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
- * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
+/* Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
 
-#ifndef _EFA_RDM_PKE_MISC_H
-#define _EFA_RDM_PKE_MISC_H
+#ifndef _EFA_RDM_PKE_NONREQ_H
+#define _EFA_RDM_PKE_NONREQ_H
 
 #include "efa_rdm_ope.h"
 #include "efa_rdm_protocol.h"
@@ -95,6 +65,30 @@ uint64_t *efa_rdm_pke_get_handshake_opt_host_id_ptr(struct efa_rdm_pke *pke)
 
 	handshake_opt_host_id_hdr = (struct efa_rdm_handshake_opt_host_id_hdr *)(pke->wiredata + offset);
 	return &handshake_opt_host_id_hdr->host_id;
+}
+
+static inline
+uint32_t efa_rdm_pke_get_handshake_opt_device_version(struct efa_rdm_pke *pke)
+{
+	struct efa_rdm_handshake_hdr *handshake_hdr;
+	struct efa_rdm_handshake_opt_device_version_hdr *device_version_hdr;
+	size_t offset;
+
+	handshake_hdr = efa_rdm_pke_get_handshake_hdr(pke);
+	assert(handshake_hdr->type == EFA_RDM_HANDSHAKE_PKT);
+	assert(handshake_hdr->flags & EFA_RDM_HANDSHAKE_DEVICE_VERSION_HDR);
+
+	offset = sizeof (struct efa_rdm_handshake_hdr)
+		+ ((handshake_hdr->nextra_p3 - 3) * sizeof handshake_hdr->extra_info[0]);
+
+	if (handshake_hdr->flags & EFA_RDM_PKT_CONNID_HDR)
+		offset += sizeof (struct efa_rdm_handshake_opt_connid_hdr);
+	if (handshake_hdr->flags & EFA_RDM_HANDSHAKE_HOST_ID_HDR)
+		offset += sizeof (struct efa_rdm_handshake_opt_host_id_hdr);
+
+	device_version_hdr = (struct efa_rdm_handshake_opt_device_version_hdr *) (pke->wiredata + offset);
+
+	return device_version_hdr->device_version;
 }
 
 ssize_t efa_rdm_pke_init_handshake(struct efa_rdm_pke *pkt_entry,
@@ -237,4 +231,3 @@ void efa_rdm_pke_handle_receipt_send_completion(struct efa_rdm_pke *pkt_entry);
 
 void efa_rdm_pke_handle_receipt_recv(struct efa_rdm_pke *pkt_entry);
 #endif
-

--- a/prov/efa/src/rdm/efa_rdm_protocol.h
+++ b/prov/efa/src/rdm/efa_rdm_protocol.h
@@ -316,7 +316,8 @@ struct efa_rdm_handshake_hdr {
 };
 
 /* indicate this package has the sender host id */
-#define EFA_RDM_HANDSHAKE_HOST_ID_HDR	BIT_ULL(0)
+#define EFA_RDM_HANDSHAKE_HOST_ID_HDR		BIT_ULL(0)
+#define EFA_RDM_HANDSHAKE_DEVICE_VERSION_HDR	BIT_ULL(1)
 
 EFA_RDM_ENSURE_HEADER_SIZE(efa_rdm_handshake_hdr, 8);
 
@@ -331,9 +332,16 @@ struct efa_rdm_handshake_opt_host_id_hdr {
 	uint64_t host_id;
 };
 
+struct efa_rdm_handshake_opt_device_version_hdr {
+	union {
+		uint32_t device_version;
+		uint64_t reserved;
+	};
+};
 
 EFA_RDM_ENSURE_HEADER_SIZE(efa_rdm_handshake_opt_connid_hdr, 8);
 EFA_RDM_ENSURE_HEADER_SIZE(efa_rdm_handshake_opt_host_id_hdr, 8);
+EFA_RDM_ENSURE_HEADER_SIZE(efa_rdm_handshake_opt_device_version_hdr, 8);
 
 /* @brief header format of RECEIPT packet */
 struct efa_rdm_receipt_hdr {

--- a/prov/efa/src/rdm/efa_rdm_protocol.h
+++ b/prov/efa/src/rdm/efa_rdm_protocol.h
@@ -1,35 +1,5 @@
-/*
- * Copyright (c) 2021 Amazon.com, Inc. or its affiliates.
- * All rights reserved.
- *
- * This software is available to you under a choice of one of two
- * licenses.  You may choose to be licensed under the terms of the GNU
- * General Public License (GPL) Version 2, available from the file
- * COPYING in the main directory of this source tree, or the
- * BSD license below:
- *
- *     Redistribution and use in source and binary forms, with or
- *     without modification, are permitted provided that the following
- *     conditions are met:
- *
- *      - Redistributions of source code must retain the above
- *        copyright notice, this list of conditions and the following
- *        disclaimer.
- *
- *      - Redistributions in binary form must reproduce the above
- *        copyright notice, this list of conditions and the following
- *        disclaimer in the documentation and/or other materials
- *        provided with the distribution.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
- * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
- * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
+/* Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
 
 #ifndef _EFA_RDM_PROTO_V4_H
 #define _EFA_RDM_PROTO_V4_H
@@ -67,7 +37,7 @@ struct efa_ep_addr {
 #define EFA_RDM_EXTRA_REQUEST_CONSTANT_HEADER_LENGTH	BIT_ULL(2)
 #define EFA_RDM_EXTRA_REQUEST_CONNID_HEADER		BIT_ULL(3)
 #define EFA_RDM_EXTRA_FEATURE_RUNT			BIT_ULL(4)
-#define EFA_RDM_EXTRA_FEATURE_RDMA_WRITE			BIT_ULL(5)
+#define EFA_RDM_EXTRA_FEATURE_RDMA_WRITE		BIT_ULL(5)
 #define EFA_RDM_NUM_EXTRA_FEATURE_OR_REQUEST		6
 #define EFA_RDM_MAX_NUM_EXINFO				(256)
 
@@ -91,14 +61,14 @@ struct efa_ep_addr {
 #define EFA_RDM_HANDSHAKE_PKT		9
 #define EFA_RDM_RECEIPT_PKT 		10
 
-#define EFA_RDM_REQ_PKT_BEGIN			64
-#define EFA_RDM_BASELINE_REQ_PKT_BEGIN		64
-#define EFA_RDM_EAGER_MSGRTM_PKT		64
-#define EFA_RDM_EAGER_TAGRTM_PKT		65
-#define EFA_RDM_MEDIUM_MSGRTM_PKT		66
-#define EFA_RDM_MEDIUM_TAGRTM_PKT		67
-#define EFA_RDM_LONGCTS_MSGRTM_PKT		68
-#define EFA_RDM_LONGCTS_TAGRTM_PKT		69
+#define EFA_RDM_REQ_PKT_BEGIN		64
+#define EFA_RDM_BASELINE_REQ_PKT_BEGIN	64
+#define EFA_RDM_EAGER_MSGRTM_PKT	64
+#define EFA_RDM_EAGER_TAGRTM_PKT	65
+#define EFA_RDM_MEDIUM_MSGRTM_PKT	66
+#define EFA_RDM_MEDIUM_TAGRTM_PKT	67
+#define EFA_RDM_LONGCTS_MSGRTM_PKT	68
+#define EFA_RDM_LONGCTS_TAGRTM_PKT	69
 #define EFA_RDM_EAGER_RTW_PKT		70
 #define EFA_RDM_LONGCTS_RTW_PKT		71
 #define EFA_RDM_SHORT_RTR_PKT		72
@@ -108,13 +78,13 @@ struct efa_ep_addr {
 #define EFA_RDM_COMPARE_RTA_PKT		76
 #define EFA_RDM_BASELINE_REQ_PKT_END	77
 
-#define EFA_RDM_EXTRA_REQ_PKT_BEGIN		128
-#define EFA_RDM_LONGREAD_RTA_MSGRTM_PKT		128
-#define EFA_RDM_LONGREAD_RTA_TAGRTM_PKT		129
-#define EFA_RDM_LONGREAD_RTA_RTW_PKT		130
+#define EFA_RDM_EXTRA_REQ_PKT_BEGIN	128
+#define EFA_RDM_LONGREAD_RTA_MSGRTM_PKT	128
+#define EFA_RDM_LONGREAD_RTA_TAGRTM_PKT	129
+#define EFA_RDM_LONGREAD_RTA_RTW_PKT	130
 #define EFA_RDM_READ_RTR_PKT		131
 
-#define EFA_RDM_DC_REQ_PKT_BEGIN		132
+#define EFA_RDM_DC_REQ_PKT_BEGIN	132
 #define EFA_RDM_DC_EAGER_MSGRTM_PKT 	133
 #define EFA_RDM_DC_EAGER_TAGRTM_PKT 	134
 #define EFA_RDM_DC_MEDIUM_MSGRTM_PKT 	135
@@ -127,28 +97,37 @@ struct efa_ep_addr {
 #define EFA_RDM_DC_REQ_PKT_END		142
 
 #define EFA_RDM_RUNT_PKT_BEGIN		142
-#define EFA_RDM_RUNTCTS_MSGRTM_PKT		142
-#define EFA_RDM_RUNTCTS_TAGRTM_PKT		143
+#define EFA_RDM_RUNTCTS_MSGRTM_PKT	142
+#define EFA_RDM_RUNTCTS_TAGRTM_PKT	143
 #define EFA_RDM_RUNTCTS_RTW_PKT		144
-#define EFA_RDM_RUNTREAD_MSGRTM_PKT		145
-#define EFA_RDM_RUNTREAD_TAGRTM_PKT		146
-#define EFA_RDM_RUNTREAD_RTW_PKT		147
+#define EFA_RDM_RUNTREAD_MSGRTM_PKT	145
+#define EFA_RDM_RUNTREAD_TAGRTM_PKT	146
+#define EFA_RDM_RUNTREAD_RTW_PKT	147
 #define EFA_RDM_RUNT_PKT_END		148
 #define EFA_RDM_EXTRA_REQ_PKT_END   	148
 
+#if defined(static_assert) && defined(__x86_64__)
+#define EFA_RDM_ENSURE_HEADER_SIZE(hdr, size)	\
+	static_assert(sizeof (struct hdr) == (size), #hdr " size check")
+#else
+#define EFA_RDM_ENSURE_HEADER_SIZE(hdr, size)
+#endif
+
 /*
- *  Packet fields common to all packets. The other packet headers below must
- *  be changed if this is updated.
+ * Fields common to all packets.
  */
+#define EFA_RDM_BASE_HEADER()			\
+	struct {				\
+		uint8_t		type;		\
+		uint8_t		version;	\
+		uint16_t	flags;		\
+	}
+
 struct efa_rdm_base_hdr {
-	uint8_t type;
-	uint8_t version;
-	uint16_t flags;
+	EFA_RDM_BASE_HEADER();
 };
 
-#if defined(static_assert) && defined(__x86_64__)
-static_assert(sizeof(struct efa_rdm_base_hdr) == 4, "efa_rdm_base_hdr check");
-#endif
+EFA_RDM_ENSURE_HEADER_SIZE(efa_rdm_base_hdr, 4);
 
 /* Universal flags that can be applied on "efa_rdm_base_hdr.flags".
  *
@@ -170,7 +149,7 @@ struct efa_rma_iov {
 };
 
 /*
- * @breif header format of CTS packet (Packet Type ID 3)
+ * @brief header format of CTS packet (Packet Type ID 3)
  *
  * CTS is used in long-CTS sub-protocols for flow control.
  *
@@ -185,10 +164,7 @@ struct efa_rma_iov {
  * In emulated read, requester is receiver, and responder is sender.
  */
 struct efa_rdm_cts_hdr {
-	uint8_t type;
-	uint8_t version;
-	uint16_t flags;
-	/* end of efa_rdm_base_hdr */
+	EFA_RDM_BASE_HEADER();
 	union {
 		uint32_t connid; /* sender connection ID, set when EFA_RDM_PKT_CONNID_HDR is on */
 		uint32_t padding; /* otherwise, a padding space to 8 bytes */
@@ -198,9 +174,7 @@ struct efa_rdm_cts_hdr {
 	uint64_t recv_length; /* number of bytes receiver is ready to receive */
 };
 
-#if defined(static_assert) && defined(__x86_64__)
-static_assert(sizeof(struct efa_rdm_cts_hdr) == 24, "efa_rdm_cts_hdr check");
-#endif
+EFA_RDM_ENSURE_HEADER_SIZE(efa_rdm_cts_hdr, 24);
 
 /* this flag is to indicated the CTS is the response of a RTR packet */
 #define EFA_RDM_CTS_READ_REQ		BIT_ULL(7)
@@ -230,10 +204,7 @@ struct efa_rdm_ctsdata_opt_connid_hdr {
  * In emulated read, requester is receiver, and responder is sender.
  */
 struct efa_rdm_ctsdata_hdr {
-	uint8_t type;
-	uint8_t version;
-	uint16_t flags;
-	/* end of efa_rdm_base_hdr */
+	EFA_RDM_BASE_HEADER();
 	uint32_t recv_id; /* ID of the receive operation on receiver */
 	uint64_t seg_length;
 	uint64_t seg_offset;
@@ -241,9 +212,7 @@ struct efa_rdm_ctsdata_hdr {
 	struct efa_rdm_ctsdata_opt_connid_hdr connid_hdr[0];
 };
 
-#if defined(static_assert) && defined(__x86_64__)
-static_assert(sizeof(struct efa_rdm_ctsdata_hdr) == 24, "efa_rdm_ctsdata_hdr check");
-#endif
+EFA_RDM_ENSURE_HEADER_SIZE(efa_rdm_ctsdata_hdr, 24);
 
 /*
  *  @brief READRSP packet header (Packet Type ID 5)
@@ -252,10 +221,7 @@ static_assert(sizeof(struct efa_rdm_ctsdata_hdr) == 24, "efa_rdm_ctsdata_hdr che
  *  application data.
  */
 struct efa_rdm_readrsp_hdr {
-	uint8_t type;
-	uint8_t version;
-	uint16_t flags;
-	/* end of efa_rdm_base_hdr */
+	EFA_RDM_BASE_HEADER();
 	union {
 		uint32_t connid; /* sender connection ID, set when EFA_RDM_PKT_CONNID_HDR is on */
 		uint32_t padding; /* otherwise, a padding space to 8 bytes boundary */
@@ -265,9 +231,7 @@ struct efa_rdm_readrsp_hdr {
 	uint64_t seg_length;
 };
 
-#if defined(static_assert) && defined(__x86_64__)
-static_assert(sizeof(struct efa_rdm_readrsp_hdr) == sizeof(struct efa_rdm_ctsdata_hdr), "efa_rdm_readrsp_hdr check");
-#endif
+EFA_RDM_ENSURE_HEADER_SIZE(efa_rdm_ctsdata_hdr, sizeof (struct efa_rdm_ctsdata_hdr));
 
 struct efa_rdm_readrsp_pkt {
 	struct efa_rdm_readrsp_hdr hdr;
@@ -297,10 +261,7 @@ struct efa_rdm_readrsp_pkt {
  * In emulated write, requester is sender, and responder is receiver.
  */
 struct efa_rdm_eor_hdr {
-	uint8_t type;
-	uint8_t version;
-	uint16_t flags;
-	/* end of efa_rdm_base_hdr */
+	EFA_RDM_BASE_HEADER();
 	uint32_t send_id; /* ID of the send operation on sender */
 	uint32_t recv_id; /* ID of the receive operation on receiver */
 	union {
@@ -309,9 +270,7 @@ struct efa_rdm_eor_hdr {
 	};
 };
 
-#if defined(static_assert) && defined(__x86_64__)
-static_assert(sizeof(struct efa_rdm_eor_hdr) == 16, "efa_rdm_eor_hdr check");
-#endif
+EFA_RDM_ENSURE_HEADER_SIZE(efa_rdm_eor_hdr, 16);
 
 /**
  * @brief header format of ATOMRSP packet. (Packet Type ID 8)
@@ -321,10 +280,7 @@ static_assert(sizeof(struct efa_rdm_eor_hdr) == 16, "efa_rdm_eor_hdr check");
  * to a fetch/compare atomic request
  */
 struct efa_rdm_atomrsp_hdr {
-	uint8_t type;
-	uint8_t version;
-	uint16_t flags;
-	/* end of efa_rdm_base_hdr */
+	EFA_RDM_BASE_HEADER();
 	union {
 		uint32_t connid; /* sender connid. set when EFA_RDM_PKT_CONNID_HDR is on in flags */
 		uint32_t padding; /* otherwise, a padding space to 8 bytes boundary */
@@ -334,9 +290,7 @@ struct efa_rdm_atomrsp_hdr {
 	uint64_t seg_length;
 };
 
-#if defined(static_assert) && defined(__x86_64__)
-static_assert(sizeof(struct efa_rdm_atomrsp_hdr) == 24, "efa_rdm_atomrsp_hdr check");
-#endif
+EFA_RDM_ENSURE_HEADER_SIZE(efa_rdm_atomrsp_hdr, 24);
 
 struct efa_rdm_atomrsp_pkt {
 	struct efa_rdm_atomrsp_hdr hdr;
@@ -344,7 +298,7 @@ struct efa_rdm_atomrsp_pkt {
 };
 
 /**
- * @breif header format of a HANDSHAKE packet
+ * @brief header format of a HANDSHAKE packet
  *
  * HANDSHAKE packet is used in the handshake sub-protocol.
  *
@@ -352,10 +306,7 @@ struct efa_rdm_atomrsp_pkt {
  * send a HANDSHAKE packet back, which contains its capablity bits
  */
 struct efa_rdm_handshake_hdr {
-	uint8_t type;
-	uint8_t version;
-	uint16_t flags;
-	/* end of efa_rdm_base_hdr */
+	EFA_RDM_BASE_HEADER();
 	/* nextra_p3 is number of members in extra_info plus 3.
 	 * The "p3" part was introduced for backward compatibility.
 	 * See protocol v4 document section 2.1 for detail.
@@ -367,30 +318,26 @@ struct efa_rdm_handshake_hdr {
 /* indicate this package has the sender host id */
 #define EFA_RDM_HANDSHAKE_HOST_ID_HDR	BIT_ULL(0)
 
-#if defined(static_assert) && defined(__x86_64__)
-static_assert(sizeof(struct efa_rdm_handshake_hdr) == 8, "efa_rdm_handshake_hdr check");
-#endif
+EFA_RDM_ENSURE_HEADER_SIZE(efa_rdm_handshake_hdr, 8);
 
 struct efa_rdm_handshake_opt_connid_hdr {
-	uint32_t connid;
-	uint32_t padding; /* padding to 8 bytes boundary */
+	union {
+		uint32_t connid;
+		uint64_t padding;
+	};
 };
 
 struct efa_rdm_handshake_opt_host_id_hdr {
 	uint64_t host_id;
 };
 
-#if defined(static_assert) && defined(__x86_64__)
-static_assert(sizeof(struct efa_rdm_handshake_opt_connid_hdr) == 8, "efa_rdm_handshake_opt_connid_hdr check");
-static_assert(sizeof(struct efa_rdm_handshake_opt_host_id_hdr) == 8, "efa_rdm_handshake_opt_host_id_hdr check");
-#endif
+
+EFA_RDM_ENSURE_HEADER_SIZE(efa_rdm_handshake_opt_connid_hdr, 8);
+EFA_RDM_ENSURE_HEADER_SIZE(efa_rdm_handshake_opt_host_id_hdr, 8);
 
 /* @brief header format of RECEIPT packet */
 struct efa_rdm_receipt_hdr {
-	uint8_t type;
-	uint8_t version;
-	uint16_t flags;
-	/* end of efa_rdm_base_hdr */
+	EFA_RDM_BASE_HEADER();
 	uint32_t tx_id;
 	uint32_t msg_id;
 	union {
@@ -444,9 +391,7 @@ struct efa_rdm_req_opt_connid_hdr {
  * Base header for all RTM packets
  */
 struct efa_rdm_rtm_base_hdr {
-	uint8_t type;
-	uint8_t version;
-	uint16_t flags;
+	EFA_RDM_BASE_HEADER();
 	uint32_t msg_id;
 };
 
@@ -510,10 +455,7 @@ struct efa_rdm_longcts_tagrtm_hdr {
 };
 
 struct efa_rdm_rtw_base_hdr {
-	uint8_t type;
-	uint8_t version;
-	uint16_t flags;
-	/* end of efa_rdm_base_hdr */
+	EFA_RDM_BASE_HEADER();
 	uint32_t rma_iov_count;
 };
 
@@ -521,10 +463,7 @@ struct efa_rdm_rtw_base_hdr {
  * @brief header format of EAGER_RTW packet (Packet Type ID 70)
  */
 struct efa_rdm_eager_rtw_hdr {
-	uint8_t type;
-	uint8_t version;
-	uint16_t flags;
-	/* end of efa_rdm_base_hdr */
+	EFA_RDM_BASE_HEADER();
 	uint32_t rma_iov_count;
 	struct efa_rma_iov rma_iov[0];
 };
@@ -533,10 +472,7 @@ struct efa_rdm_eager_rtw_hdr {
  * @brief header format of LONGCTS_RTW packet (Packet Type ID 71)
  */
 struct efa_rdm_longcts_rtw_hdr {
-	uint8_t type;
-	uint8_t version;
-	uint16_t flags;
-	/* end of efa_rdm_base_hdr */
+	EFA_RDM_BASE_HEADER();
 	uint32_t rma_iov_count;
 	uint64_t msg_length;
 	uint32_t send_id;
@@ -549,10 +485,7 @@ struct efa_rdm_longcts_rtw_hdr {
  * and LONGCTS_RTR (Packet Type ID 73)
  */
 struct efa_rdm_rtr_hdr {
-	uint8_t type;
-	uint8_t version;
-	uint16_t flags;
-	/* end of efa_rdm_base_hdr */
+	EFA_RDM_BASE_HEADER();
 	uint32_t rma_iov_count;
 	uint64_t msg_length;
 	uint32_t recv_id; /* ID of the receive operation of the read requester, will be included in DATA/READRSP header */
@@ -567,9 +500,7 @@ struct efa_rdm_rtr_hdr {
  *    DC_WRTIE_RTA (Packe Type ID 141)
  */
 struct efa_rdm_rta_hdr {
-	uint8_t type;
-	uint8_t version;
-	uint16_t flags;
+	EFA_RDM_BASE_HEADER();
 	uint32_t msg_id;
 	/* end of rtm_base_hdr, atomic packet need msg_id for reordering */
 	uint32_t rma_iov_count;
@@ -620,10 +551,7 @@ struct efa_rdm_longread_tagrtm_hdr {
  * @brief header format of LONGREAD_MSGRTM (Packet Type ID 130)
  */
 struct efa_rdm_longread_rtw_hdr {
-	uint8_t type;
-	uint8_t version;
-	uint16_t flags;
-	/* end of efa_rdm_base_hdr */
+	EFA_RDM_BASE_HEADER();
 	uint32_t rma_iov_count;
 	uint64_t msg_length;
 	uint32_t send_id;
@@ -636,9 +564,7 @@ struct efa_rdm_longread_rtw_hdr {
  */
 
 struct efa_rdm_dc_eager_rtm_base_hdr {
-	uint8_t type;
-	uint8_t version;
-	uint16_t flags;
+	EFA_RDM_BASE_HEADER();
 	uint32_t msg_id;
 	uint32_t send_id;
 	uint32_t padding;
@@ -701,10 +627,7 @@ struct efa_rdm_dc_longcts_tagrtm_hdr {
  * @brief header format of a DC_EAGER_RTW packet
  */
 struct efa_rdm_dc_eager_rtw_hdr {
-	uint8_t type;
-	uint8_t version;
-	uint16_t flags;
-	/* end of efa_rdm_base_hdr */
+	EFA_RDM_BASE_HEADER();
 	uint32_t rma_iov_count;
 	/* end of efa_rdm_rtw_base_hdr */
 	uint32_t send_id;
@@ -716,10 +639,7 @@ struct efa_rdm_dc_eager_rtw_hdr {
  * @brief header format of a DC_LONGCTS_RTW packet
  */
 struct efa_rdm_dc_longcts_rtw_hdr {
-	uint8_t type;
-	uint8_t version;
-	uint16_t flags;
-	/* end of efa_rdm_base_hdr */
+	EFA_RDM_BASE_HEADER();
 	uint32_t rma_iov_count;
 	uint64_t msg_length;
 	uint32_t send_id;
@@ -759,10 +679,7 @@ struct efa_rdm_runtcts_tagrtm_hdr {
  * @brief header format of RUNTCTS_RTW (Packet Type ID 144)
  */
 struct efa_rdm_runtcts_rtw_hdr {
-	uint8_t type;
-	uint8_t version;
-	uint16_t flags;
-	/* end of efa_rdm_base_hdr */
+	EFA_RDM_BASE_HEADER();
 	uint32_t rma_iov_count;
 	uint64_t msg_length;
 	uint32_t send_id;
@@ -800,10 +717,7 @@ struct efa_rdm_runtread_tagrtm_hdr {
  * @brief header format of RUNTREAD_RTW (Packet Type ID 147)
  */
 struct efa_rdm_runtread_rtw_hdr {
-	uint8_t type;
-	uint8_t version;
-	uint16_t flags;
-	/* end of efa_rdm_base_hdr */
+	EFA_RDM_BASE_HEADER();
 	uint32_t rma_iov_count;
 	uint64_t msg_length;
 	uint32_t send_id;

--- a/prov/efa/src/rdm/efa_rdm_rma.c
+++ b/prov/efa/src/rdm/efa_rdm_rma.c
@@ -1,35 +1,5 @@
-/*
- * Copyright (c) 2019-2020 Amazon.com, Inc. or its affiliates.
- * All rights reserved.
- *
- * This software is available to you under a choice of one of two
- * licenses.  You may choose to be licensed under the terms of the GNU
- * General Public License (GPL) Version 2, available from the file
- * COPYING in the main directory of this source tree, or the
- * BSD license below:
- *
- *     Redistribution and use in source and binary forms, with or
- *     without modification, are permitted provided that the following
- *     conditions are met:
- *
- *      - Redistributions of source code must retain the above
- *        copyright notice, this list of conditions and the following
- *        disclaimer.
- *
- *      - Redistributions in binary form must reproduce the above
- *        copyright notice, this list of conditions and the following
- *        disclaimer in the documentation and/or other materials
- *        provided with the distribution.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
- * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
- * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
+/* Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
 
 #include <stdlib.h>
 #include <string.h>
@@ -207,8 +177,8 @@ ssize_t efa_rdm_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uin
 	}
 
 	use_device_read = false;
-	if (efa_both_support_rdma_read(efa_rdm_ep, peer)) {
-		/* efa_both_support_rdma_read also check domain.use_device_rdma,
+	if (efa_rdm_interop_rdma_read(efa_rdm_ep, peer)) {
+		/* RDMA read interoperability check also checks domain.use_device_rdma,
 		 * so we do not check it here
 		 */
 		use_device_read = true;
@@ -424,7 +394,7 @@ ssize_t efa_rdm_rma_post_write(struct efa_rdm_ep *ep, struct efa_rdm_ope *txe)
 	iface = txe->desc[0] ? ((struct efa_mr*) txe->desc[0])->peer.iface : FI_HMEM_SYSTEM;
 
 	if (txe->total_len >= efa_rdm_ep_domain(ep)->hmem_info[iface].min_read_write_size &&
-		efa_both_support_rdma_read(ep, peer) &&
+		efa_rdm_interop_rdma_read(ep, peer) &&
 		(txe->desc[0] || efa_is_cache_available(efa_rdm_ep_domain(ep)))) {
 		err = efa_rdm_ope_post_send(txe, EFA_RDM_LONGREAD_RTA_RTW_PKT);
 		if (err != -FI_ENOMEM)

--- a/prov/efa/test/efa_unit_test_common.c
+++ b/prov/efa/test/efa_unit_test_common.c
@@ -220,11 +220,12 @@ void efa_unit_test_eager_msgrtm_pkt_construct(struct efa_rdm_pke *pkt_entry, str
 
 /**
  * @brief Construct EFA_RDM_HANDSHAKE_PKT
- *	The function will include the optional connid/host id headers if and only if
- *	attr->connid/host id are non-zero.
  *
- * @param[in,out] pkt_entry Packet entry. Must be non-NULL.
- * @param[in] attr Packet attributes.
+ * This will append any optional handshake packet fields (see EFA RDM protocol
+ * spec) iff they are non-zero in attr
+ *
+ * @param[in,out]	pkt_entry	Packet entry. Must be non-NULL.
+ * @param[in]		attr		Packet attributes.
  */
 void efa_unit_test_handshake_pkt_construct(struct efa_rdm_pke *pkt_entry, struct efa_unit_test_handshake_pkt_attr *attr)
 {
@@ -239,6 +240,7 @@ void efa_unit_test_handshake_pkt_construct(struct efa_rdm_pke *pkt_entry, struct
 
 	pkt_entry->pkt_size = sizeof(struct efa_rdm_handshake_hdr) + nex * sizeof(uint64_t);
 
-	APPEND_OPT_HANDSHAKE_FIELD(connid,	EFA_RDM_PKT_CONNID_HDR);
-        APPEND_OPT_HANDSHAKE_FIELD(host_id,	EFA_RDM_HANDSHAKE_HOST_ID_HDR);
+	APPEND_OPT_HANDSHAKE_FIELD(connid,		EFA_RDM_PKT_CONNID_HDR);
+        APPEND_OPT_HANDSHAKE_FIELD(host_id,		EFA_RDM_HANDSHAKE_HOST_ID_HDR);
+        APPEND_OPT_HANDSHAKE_FIELD(device_version,	EFA_RDM_HANDSHAKE_DEVICE_VERSION_HDR);
 }

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -127,7 +127,7 @@ void test_efa_rdm_ep_handshake_exchange_host_id(struct efa_resource **state, uin
 	assert_non_null(peer);
 	/* Peer host id is uninitialized before handshake */
 	assert_int_equal(peer->host_id, 0);
-	assert_false(peer->flags && EFA_RDM_PEER_HANDSHAKE_SENT);
+	assert_int_not_equal(peer->flags & EFA_RDM_PEER_HANDSHAKE_SENT, EFA_RDM_PEER_HANDSHAKE_SENT);
 
 	/* Setup rx packet entry. Manually increase counter to avoid underflow */
 	pkt_entry = efa_rdm_pke_alloc(efa_rdm_ep, efa_rdm_ep->efa_rx_pkt_pool, EFA_RDM_PKE_FROM_EFA_RX_POOL);

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -135,6 +135,7 @@ void test_efa_rdm_ep_handshake_exchange_host_id(struct efa_resource **state, uin
 
 	pkt_attr.connid = include_connid ? raw_addr.qkey : 0;
 	pkt_attr.host_id = g_efa_unit_test_mocks.peer_host_id;
+	pkt_attr.device_version = 0xefa0;
 	efa_unit_test_handshake_pkt_construct(pkt_entry, &pkt_attr);
 
 	ibv_qp = efa_rdm_ep->base_ep.qp->ibv_qp_ex;
@@ -142,6 +143,7 @@ void test_efa_rdm_ep_handshake_exchange_host_id(struct efa_resource **state, uin
 	/* this mock will save the send work request (wr) in a global array */
 	ibv_qp->wr_send = &efa_mock_ibv_wr_send_verify_handshake_pkt_local_host_id_and_save_wr;
 	ibv_qp->wr_set_inline_data_list = &efa_mock_ibv_wr_set_inline_data_list_no_op;
+	ibv_qp->wr_set_sge_list = &efa_mock_ibv_wr_set_sge_list_no_op;
 	ibv_qp->wr_set_ud_addr = &efa_mock_ibv_wr_set_ud_addr_no_op;
 	ibv_qp->wr_complete = &efa_mock_ibv_wr_complete_no_op;
 	expect_function_call(efa_mock_ibv_wr_send_verify_handshake_pkt_local_host_id_and_save_wr);
@@ -198,6 +200,9 @@ void test_efa_rdm_ep_handshake_exchange_host_id(struct efa_resource **state, uin
 
 	/* Peer host id is set after handshake */
 	assert_true(actual_peer_host_id == g_efa_unit_test_mocks.peer_host_id);
+
+	/* Device version should be stored after handshake */
+        assert_int_equal(peer->device_version, 0xefa0);
 }
 #else
 void test_efa_rdm_ep_handshake_exchange_host_id() {

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -63,6 +63,7 @@ struct efa_unit_test_eager_rtm_pkt_attr {
 struct efa_unit_test_handshake_pkt_attr {
 	uint32_t connid;
 	uint64_t host_id;
+	uint32_t device_version;
 };
 
 int efa_device_construct(struct efa_device *efa_device,


### PR DESCRIPTION
This simply adds the "device version" (`ibv_device_attr.vendor_part_id`) to the handshake subprotocol; storing it in the `efa_rdm_peer` struct upon recv. This is then used during RDM protocol selection; ensuring the devices can interoperate before selecting RDMA read.

Currently, the only known incompatibility is between the oldest device versions (`0xEFA0`) and newer ones (`0xEFA1`, `0xEFA2`).

This was tested by running `fi_pingpong` with various EC2 instance types and checking the `rdma_read_bytes` hardware counters before/after.

I'll write unit tests in the meantime, but this can be merged if the feature is considered urgent enough.

Side note: the replacement of license text with SPDX identifiers in file headers was [blessed by Sean](https://libfabric.slack.com/archives/C05K5E1RE7L/p1694819124677119?thread_ts=1694810617.796649&cid=C05K5E1RE7L) and aligns with the latest internal Amazon guidance.