### PR TITLE
fabtests/rdm_tagged_*: Add FI_DIRECTED_RECV to requested capabilities

### DIFF
--- a/fabtests/benchmarks/rdm_tagged_bw.c
+++ b/fabtests/benchmarks/rdm_tagged_bw.c
@@ -104,7 +104,7 @@ int main(int argc, char **argv)
 
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->domain_attr->resource_mgmt = FI_RM_ENABLED;
-	hints->caps = FI_TAGGED;
+	hints->caps = FI_TAGGED | FI_DIRECTED_RECV;
 	hints->mode |= FI_CONTEXT;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->domain_attr->threading = FI_THREAD_DOMAIN;

--- a/fabtests/benchmarks/rdm_tagged_pingpong.c
+++ b/fabtests/benchmarks/rdm_tagged_pingpong.c
@@ -102,7 +102,7 @@ int main(int argc, char **argv)
 		opts.dst_addr = argv[optind];
 
 	hints->ep_attr->type = FI_EP_RDM;
-	hints->caps = FI_TAGGED;
+	hints->caps = FI_TAGGED | FI_DIRECTED_RECV;
 	hints->mode |= FI_CONTEXT;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->domain_attr->threading = FI_THREAD_DOMAIN;

--- a/fabtests/functional/rdm_tagged_peek.c
+++ b/fabtests/functional/rdm_tagged_peek.c
@@ -353,7 +353,7 @@ int main(int argc, char **argv)
 	hints->domain_attr->resource_mgmt = FI_RM_ENABLED;
 	hints->tx_attr->msg_order = FI_ORDER_SAS;
 	hints->ep_attr->type = FI_EP_RDM;
-	hints->caps = FI_TAGGED;
+	hints->caps = FI_TAGGED | FI_DIRECTED_RECV;
 	hints->mode = FI_CONTEXT;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->addr_format = opts.address_format;

--- a/prov/tcp/src/xnet_init.c
+++ b/prov/tcp/src/xnet_init.c
@@ -138,7 +138,9 @@ static void xnet_init_env(void)
 			"posted buffer ready (i.e. an unexpected message) "
 			"A larger value increases memory and data copying "
 			"overhead to handle unexpected messages, but may be "
-			"required by some applications to prevents hangs.");
+			"required by some applications to prevents hangs. "
+			"Tagged messages larger than the max_saved_size will "
+			"use a rendezvous protocol, if supported by the peer.");
 	fi_param_get_size_t(&xnet_prov, "max_saved_size", &xnet_max_saved_size);
 
 	fi_param_define(&xnet_prov, "max_rx_size", FI_PARAM_SIZE_T,


### PR DESCRIPTION
This change better aligns with common use of FI_TAGGED.

Bonus patch - update help text to the tcp provider max_saved_size