### PR TITLE
prov/xnet,common: Disable the EP if an error is detected for zero-copy

### DIFF
--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -606,8 +606,8 @@ int ofi_bsock_sendv(struct ofi_bsock *bsock, const struct iovec *iov,
 int ofi_bsock_recv(struct ofi_bsock *bsock, void *buf, size_t *len);
 int ofi_bsock_recvv(struct ofi_bsock *bsock, struct iovec *iov,
 		    size_t cnt, size_t *len);
-uint32_t ofi_bsock_async_done(const struct fi_provider *prov,
-			      struct ofi_bsock *bsock);
+int ofi_bsock_async_done(const struct fi_provider *prov,
+			 struct ofi_bsock *bsock);
 void ofi_bsock_prefetch_done(struct ofi_bsock *bsock, size_t len);
 
 

--- a/prov/tcp/src/xnet_progress.c
+++ b/prov/tcp/src/xnet_progress.c
@@ -1016,14 +1016,19 @@ void xnet_progress_rx(struct xnet_ep *ep)
 void xnet_progress_async(struct xnet_ep *ep)
 {
 	struct xnet_xfer_entry *xfer;
-	uint32_t done;
+	int ret;
 
 	assert(xnet_progress_locked(xnet_ep2_progress(ep)));
-	done = ofi_bsock_async_done(&xnet_prov, &ep->bsock);
+	ret = ofi_bsock_async_done(&xnet_prov, &ep->bsock);
+	if (ret) {
+		xnet_ep_disable(ep, 0, NULL, 0);
+		return;
+	}
+
 	while (!slist_empty(&ep->async_queue)) {
 		xfer = container_of(ep->async_queue.head,
 				    struct xnet_xfer_entry, entry);
-		if (ofi_val32_gt(xfer->async_index, done))
+		if (ofi_val32_gt(xfer->async_index, ep->bsock.done_index))
 			break;
 
 		slist_remove_head(&ep->async_queue);


### PR DESCRIPTION
This patch disables the endpoint if zero-copy reports an error. The goal is to prevent the stream to be corrupted if zero-copy gets disabled after the transfer has started.

Fixes #7887