### PR TITLE
[v1.19.x] prov/ucx: Pick Initialize ep_flush to 1

### DIFF
--- a/prov/ucx/src/ucx_init.c
+++ b/prov/ucx/src/ucx_init.c
@@ -40,7 +40,7 @@ struct ucx_global_descriptor ucx_descriptor = {
 	.use_ns = 0,
 	.ns_port = FI_UCX_DEFAULT_NS_PORT,
 	.localhost = NULL,
-	.ep_flush = 0,
+	.ep_flush = 1,
 	.check_req_leak = 0,
 };
 
@@ -291,7 +291,7 @@ static int ucx_getinfo(uint32_t version, const char *node,
 
 	status = fi_param_get(&ucx_prov, "ep_flush", &ucx_descriptor.ep_flush);
 	if (status != FI_SUCCESS)
-		ucx_descriptor.ep_flush = 0;
+		ucx_descriptor.ep_flush = 1;
 
 	status = fi_param_get(&ucx_prov, "check_req_leak", &ucx_descriptor.check_req_leak);
 	if (status != FI_SUCCESS)


### PR DESCRIPTION
ep_flush needs to initialize to 1 so that the send queue gets flushed by default on ep_close. If it isn't flushed then there is a chance of segmentation faulting when the address handle gets destroyed.