### PR TITLE
intel/ci: Changes to build mpich and tcp exclude for mpichsuite

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -3,7 +3,7 @@ import groovy.transform.Field
 properties([disableConcurrentBuilds(abortPrevious: true)])
 @Field def DO_RUN=true
 @Field def TARGET="main"
-@Field def SCRIPT_LOCATION="contrib/intel/jenkins"
+@Field def SCRIPT_LOCATION="py_scripts/contrib/intel/jenkins"
 @Field def RELEASE=false
 @Field def BUILD_MODES=["reg", "dbg", "dl"]
 @Field def MPI_TYPES=["impi", "mpich", "ompi"]
@@ -691,7 +691,7 @@ pipeline {
                       "${env.LOG_DIR}")
 
           summarize("all", verbose=false, release=RELEASE,
-                    send_mail=false)
+                    send_mail=env.WEEKLY.toBoolean())
           if (RELEASE) {
             save_summary()
           }
@@ -737,4 +737,4 @@ pipeline {
       dir("${env.WORKSPACE}@tmp") { deleteDir() }
     }
   }
-} 
+}

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -3,7 +3,7 @@ import groovy.transform.Field
 properties([disableConcurrentBuilds(abortPrevious: true)])
 @Field def DO_RUN=true
 @Field def TARGET="main"
-@Field def SCRIPT_LOCATION="py_scripts/contrib/intel/jenkins"
+@Field def SCRIPT_LOCATION="contrib/intel/jenkins"
 @Field def RELEASE=false
 @Field def BUILD_MODES=["reg", "dbg", "dl"]
 @Field def MPI_TYPES=["impi", "mpich", "ompi"]
@@ -305,7 +305,12 @@ pipeline {
                             "${env.LOG_DIR}/libfabric_mpich_log", 
                             """python$PYTHON_VERSION ${RUN_LOCATION}/build.py \
                               --build_item=libfabric_mpich """
-                          )  
+                          )
+                slurm_batch("squirtle,totodile", "1",
+                            "${env.LOG_DIR}/build_mpich_log", 
+                            """python$PYTHON_VERSION ${RUN_LOCATION}/build.py \
+                              --build_item=mpich """
+                          ) 
               }
             }
           }
@@ -686,7 +691,7 @@ pipeline {
                       "${env.LOG_DIR}")
 
           summarize("all", verbose=false, release=RELEASE,
-                    send_mail=env.WEEKLY.toBoolean())
+                    send_mail=false)
           if (RELEASE) {
             save_summary()
           }
@@ -732,4 +737,4 @@ pipeline {
       dir("${env.WORKSPACE}@tmp") { deleteDir() }
     }
   }
-}
+} 

--- a/contrib/intel/jenkins/build.py
+++ b/contrib/intel/jenkins/build.py
@@ -205,6 +205,5 @@ if __name__ == "__main__":
         extract_mpich('impi')
     elif (build_item == 'builddir'):
         copy_build_dir(install_path)
-
     elif (build_item == 'logdir'):
         log_dir(install_path, release)

--- a/contrib/intel/jenkins/run.py
+++ b/contrib/intel/jenkins/run.py
@@ -137,9 +137,6 @@ def mpich_test_suite(core, hosts, mpi, mode, user_env, log_file, util, weekly=No
 
     print('-------------------------------------------------------------------')
     if (mpich_tests.execute_condn == True):
-        if (mpi == "mpich"):
-            print("Building mpich")
-            mpich_tests.build_mpich()
         print(f"Running mpichtestsuite for {core}-{util}-{fab}-{mpi}")
         mpich_tests.execute_cmd()
     else:

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -671,7 +671,7 @@ class OSUtests(Test):
         print(f"Running OSU-{test_type}-{test}")
         cmd = f'{self.osu_src}/{test_type}/{test} '
         return cmd
-    
+
     def execute_cmd(self):
         assert(self.osu_src)
         p = re.compile('osu_put*')
@@ -709,6 +709,8 @@ class MpichTestSuite(Test):
         self.mpichtests_exclude = {
         'tcp'   :   {   '.'        : [('spawn','dir'), ('rma','dir')],
                     'threads'      : [('spawn','dir'), ('rma','dir')],
+                    'threads/comm' : [('idup_nb 4','test'),
+                                      ('idup_comm_gen 4','test')],
                     'errors'       : [('spawn','dir'),('rma','dir')]
                 },
         'verbs' :   {   '.'        : [('spawn','dir')],


### PR DESCRIPTION
-Moved mpich build from test stage to parallel build stage post libfabric_mpich build stage. 
-excluded idup_nb test from mpichtests for tcp