### PR TITLE
fabtests/shared.c: Check if fi_info is returned correctly in case of FI_CONNREQ

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -1083,6 +1083,20 @@ int ft_complete_connect(struct fid_ep *ep, struct fid_eq *eq)
 	return 0;
 }
 
+int ft_verify_info(struct fi_info *fi_pep, struct fi_info *info)
+{
+	if (!info || !info->fabric_attr || !info->domain_attr ||
+	    !info->ep_attr || !info->tx_attr || !info->rx_attr)
+		return -FI_EINVAL;
+
+	if (!info->fabric_attr->prov_name ||
+	    !info->fabric_attr->name || !info->domain_attr->name ||
+	    info->fabric_attr->api_version != fi_pep->fabric_attr->api_version)
+		return -FI_EINVAL;
+
+	return 0;
+}
+
 int ft_retrieve_conn_req(struct fid_eq *eq, struct fi_info **fi)
 {
 	struct fi_eq_cm_entry entry;
@@ -1100,6 +1114,11 @@ int ft_retrieve_conn_req(struct fid_eq *eq, struct fi_info **fi)
 	if (event != FI_CONNREQ) {
 		fprintf(stderr, "Unexpected CM event %d\n", event);
 		ret = -FI_EOTHER;
+		return ret;
+	}
+
+	if ((ret = ft_verify_info(fi_pep, entry.info))) {
+		printf("ret: %d\n", ret);
 		return ret;
 	}
 

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -423,6 +423,7 @@ int ft_server_connect();
 int ft_client_connect();
 int ft_init_fabric_cm(void);
 int ft_complete_connect(struct fid_ep *ep, struct fid_eq *eq);
+int ft_verify_info(struct fi_info *fi_pep, struct fi_info *info);
 int ft_retrieve_conn_req(struct fid_eq *eq, struct fi_info **fi);
 int ft_accept_connection(struct fid_ep *ep, struct fid_eq *eq);
 int ft_connect_ep(struct fid_ep *ep,

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1417,7 +1417,8 @@ static void sock_set_fabric_attr(void *src_addr, const struct fi_fabric_attr *hi
 	if (!attr->name)
 		attr->name = strdup(sock_fab_name);
 
-	attr->prov_name = NULL;
+	attr->prov_name = strdup(hint_attr->prov_name);
+	attr->api_version = hint_attr->api_version;
 }
 
 static void sock_set_domain_attr(uint32_t api_version, void *src_addr,
@@ -1498,11 +1499,17 @@ struct fi_info *sock_fi_info(uint32_t version, enum fi_ep_type ep_type,
 {
 	struct fi_info *info;
 
-	info = fi_allocinfo();
+	info = fi_dupinfo(hints);
 	if (!info)
 		return NULL;
+	free(info->src_addr);
+	free(info->dest_addr);
+	info->src_addr = NULL;
+	info->dest_addr = NULL;
+	info->src_addrlen = 0;
+	info->dest_addrlen = 0;
 
-	info->src_addr = calloc(1, sizeof(union ofi_sock_ip));
+	info->src_addr = calloc(1, ofi_sizeofip(src_addr));
 	if (!info->src_addr)
 		goto err;
 
@@ -1523,7 +1530,7 @@ struct fi_info *sock_fi_info(uint32_t version, enum fi_ep_type ep_type,
 		info->addr_format = FI_SOCKADDR_IN;
 
 	if (dest_addr) {
-		info->dest_addr = calloc(1, sizeof(union ofi_sock_ip));
+		info->dest_addr = calloc(1, ofi_sizeofip(dest_addr));
 		if (!info->dest_addr)
 			goto err;
 		info->dest_addrlen = ofi_sizeofaddr(dest_addr);
@@ -1531,21 +1538,6 @@ struct fi_info *sock_fi_info(uint32_t version, enum fi_ep_type ep_type,
 	}
 
 	if (hints) {
-		if (hints->caps)
-			info->caps = hints->caps;
-
-		if (hints->ep_attr)
-			*(info->ep_attr) = *(hints->ep_attr);
-
-		if (hints->tx_attr)
-			*(info->tx_attr) = *(hints->tx_attr);
-
-		if (hints->rx_attr)
-			*(info->rx_attr) = *(hints->rx_attr);
-
-		if (hints->handle)
-			info->handle = hints->handle;
-
 		sock_set_domain_attr(version, info->src_addr, hints->domain_attr,
 				     info->domain_attr);
 		sock_set_fabric_attr(info->src_addr, hints->fabric_attr, info->fabric_attr);


### PR DESCRIPTION
This commit adds validation that the fi_info returned with an FI_CONNREQ
event is filled out properly with valid fields. The fi_info should be
similar to the fi_info that is used to open passive endpoint.