### PR TITLE
prov/efa: Fix coverity warning in efa_mr_reg_impl

### DIFF
--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -900,8 +900,8 @@ static int efa_mr_reg_impl(struct efa_mr *efa_mr, uint64_t flags, const void *at
 				ret,
 				fi_strerror(-ret),
 				efa_mr->mr_fid.key,
-				mr_attr.mr_iov->iov_base,
-				mr_attr.mr_iov->iov_len);
+				mr_attr.mr_iov ? mr_attr.mr_iov->iov_base : NULL,
+				mr_attr.mr_iov ? mr_attr.mr_iov->iov_len : NULL);
 			efa_mr_dereg_impl(efa_mr);
 			return ret;
 		}


### PR DESCRIPTION
If an applications calls fi_mr_reg with an incomplete attr, a segfault could occur