### PR TITLE
prov/shm: Add memory barrier before updating resp for atomic

### DIFF
--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -1145,6 +1145,13 @@ static int smr_progress_cmd_atomic(struct smr_ep *ep, struct smr_cmd *cmd,
 	if (cmd->msg.hdr.data) {
 		peer_smr = smr_peer_region(ep->region, cmd->msg.hdr.id);
 		resp = smr_get_ptr(peer_smr, cmd->msg.hdr.data);
+		/*
+		 * smr_do_atomic will do memcpy when flags has SMR_RMA_REQ.
+		 * Add a memory barrier before updating resp status to ensure
+		 * the buffer is ready before the status update.
+		 */
+		if (cmd->msg.hdr.op_flags & SMR_RMA_REQ)
+			ofi_wmb();
 		resp->status = -err;
 	}
 


### PR DESCRIPTION
In smr_progress_cmd_atomic, resp is updated after calling smr_progress_inline/inject_atomic, which involves a memcpy in smr_do_atmoic for compare and fetch cases. Currently, there is no memory barrier between the memcpy and the resp update, this can make resp updated before the memcpy is done on ARM, which has a weak memory model. This patch adds a memory barrier before updating the resp to make the operations serialized.