### PR TITLE
[v1.19.x] prov/shm: Add memory barrier before updating resp for atomic

### DIFF
--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -1137,6 +1137,13 @@ static int smr_progress_cmd_atomic(struct smr_ep *ep, struct smr_cmd *cmd,
 	if (cmd->msg.hdr.data) {
 		peer_smr = smr_peer_region(ep->region, cmd->msg.hdr.id);
 		resp = smr_get_ptr(peer_smr, cmd->msg.hdr.data);
+		/*
+		 * smr_do_atomic will do memcpy when flags has SMR_RMA_REQ.
+		 * Add a memory barrier before updating resp status to ensure
+		 * the buffer is ready before the status update.
+		 */
+		if (cmd->msg.hdr.op_flags & SMR_RMA_REQ)
+			ofi_wmb();
 		resp->status = -err;
 	}
 


### PR DESCRIPTION
Backport the bug fix in https://github.com/ofiwg/libfabric/pull/9370