### PR TITLE
fabtests/efa: set cuda read test rma_op name

### DIFF
--- a/fabtests/pytest/conftest.py
+++ b/fabtests/pytest/conftest.py
@@ -80,6 +80,18 @@ class CmdlineArgs:
         else:
             self.environments = environ[:]
 
+    def append_server_arguments(self, *args):
+        if self.additional_server_arguments is None:
+            self.additional_server_arguments = ""
+        
+        self.additional_server_arguments += " " + " ".join(args)
+
+    def append_client_arguments(self, *args):
+        if self.additional_client_arguments is None:
+            self.additional_client_arguments = ""
+        
+        self.additional_client_arguments += " " + " ".join(args)
+
     def populate_command(self, base_command, host_type, timeout=None, additional_environment=None):
         '''
             populate base command with informations in command line: provider, environments, etc

--- a/fabtests/pytest/efa/test_efa_protocol_selection.py
+++ b/fabtests/pytest/efa/test_efa_protocol_selection.py
@@ -34,6 +34,10 @@ def test_transfer_with_read_protocol_cuda(cmdline_args, fabtest_name, cntrl_env_
     cmdline_args_copy.append_environ(f"{cntrl_env_var}=1000")
     cmdline_args_copy.append_environ("FI_EFA_RUNT_SIZE=0")
 
+    if fabtest_name == "fi_rma_bw":
+            cmdline_args_copy.append_server_arguments("-o read")
+            cmdline_args_copy.append_client_arguments("-o read")
+
     # wrs stands for work requests
     server_read_wrs_before_test = efa_retrieve_hw_counter_value(cmdline_args.server_id, "rdma_read_wrs")
     if server_read_wrs_before_test is None:


### PR DESCRIPTION
The cuda read test is using the default write rma_op, but we want to test the read path. Hence we should set the -o option explicitly.