### PR TITLE
prov/util: Add missing calls to (de)initialize monitor's mutexes

### DIFF
--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -167,7 +167,9 @@ void ofi_monitor_cleanup(struct ofi_mem_monitor *monitor)
  */
 void ofi_monitors_init(void)
 {
+	pthread_mutex_init(&mm_lock, NULL);
 	pthread_mutex_init(&mm_state_lock, NULL);
+	pthread_rwlock_init(&mm_list_rwlock, NULL);
 
 	uffd_monitor->init(uffd_monitor);
 	memhooks_monitor->init(memhooks_monitor);
@@ -281,6 +283,10 @@ void ofi_monitors_cleanup(void)
 	rocr_monitor->cleanup(rocr_monitor);
 	ze_monitor->cleanup(ze_monitor);
 	import_monitor->cleanup(import_monitor);
+
+	pthread_rwlock_destroy(&mm_list_rwlock);
+	pthread_mutex_destroy(&mm_state_lock);
+	pthread_mutex_destroy(&mm_lock);
 }
 
 /* Monitors array must be of size OFI_HMEM_MAX. */


### PR DESCRIPTION
This is especially needed on Windows where `PTHREAD_MUTEX_INITIALIZER` is not enough and explicit initialization via call to `pthread_mutex_init`/`InitializeCriticalSection` is required before using a mutex.