### PR TITLE
core: Optimize tag APIs for CCL and MPI

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -348,6 +348,13 @@ enum {
 };
 
 enum {
+	FI_TAG_BITS,
+	FI_TAG_MPI,
+	FI_TAG_CCL,
+	FI_TAG_MAX_FORMAT = (1ULL << 16),
+}
+
+enum {
 	FI_TC_UNSPEC = 0,
 	FI_TC_DSCP = 0x100,
 	FI_TC_LABEL = 0x200,

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -449,6 +449,7 @@ struct fi_domain_attr {
 	size_t			max_err_data;
 	size_t			mr_cnt;
 	uint32_t		tclass;
+	uint32_t		max_group_id;
 };
 
 struct fi_fabric_attr {

--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -538,6 +538,12 @@ fi_rx_addr(fi_addr_t fi_addr, int rx_index, int rx_ctx_bits)
 	return (fi_addr_t) (((uint64_t) rx_index << (64 - rx_ctx_bits)) | fi_addr);
 }
 
+static inline fi_addr_t
+fi_group_addr(fi_addr_t fi_addr, uint32_t group_id)
+{
+	return (fi_addr_t) (((uint64_t) group_id << 32) | fi_addr);
+}
+
 #endif
 
 #ifdef __cplusplus

--- a/include/rdma/fi_tagged.h
+++ b/include/rdma/fi_tagged.h
@@ -42,6 +42,16 @@ extern "C" {
 #endif
 
 
+#define FI_MPI_IGNORE_TAG 	((uint64_t) UINT32_MAX)
+#define FI_MPI_IGNORE_PAYLOAD	(((uint64_t) UINT8_MAX) << 32)
+
+
+static inline uint64_t
+fi_tag_mpi(int tag, uint8_t payload_id)
+{
+	return (((uint64_t) payload_id) << 32) | ((uint64_t) (uint32_t) tag);
+}
+
 struct fi_msg_tagged {
 	const struct iovec	*msg_iov;
 	void			**desc;

--- a/man/fi_av.3.md
+++ b/man/fi_av.3.md
@@ -56,6 +56,8 @@ int fi_av_lookup(struct fid_av *av, fi_addr_t fi_addr,
 fi_addr_t fi_rx_addr(fi_addr_t fi_addr, int rx_index,
 	  int rx_ctx_bits);
 
+fi_addr_t fi_group_addr(fi_addr_t fi_addr, uint32_t group_id);
+
 const char * fi_av_straddr(struct fid_av *av, const void *addr,
       char *buf, size_t *len);
 ```
@@ -498,6 +500,33 @@ identifier and use it where required as part of any completion event.  Note
 that the output from the AV insertion call is unchanged.  The provider will
 return an fi_addr_t value that maps to each address, and that value must be
 used for all data transfer operations.
+
+# PEER GROUPS
+
+Peer groups provide a direct mapping to HPC and AI communicator constructs.
+
+The addresses in an AV represent the full set of peers that a local process
+may communicate with.  A peer group conceptually represents a subset of
+those peers.  A peer group may be used to identify peers working on a common
+task, which need their communication logically separated from other traffic.
+Peer groups are not a security mechanism, but instead help separate data.
+A given peer may belong to 0 or more peer groups,
+with no limit placed on how many peers can belong to a single peer group.
+
+Peer groups are identified using an integer value, known as a group id.
+Group id's are selected by the user and conveyed as part of an fi_addr_t
+value.  The management of a group id and it's relationship to addresses
+inserted into an AV is directly controlled by the user.  When enabled,
+sent messages are marked as belonging to a specific peer group, and posted
+receive buffers must have a matching group id to receive the data.
+
+Users are responsible for selecting a valid peer group id, subject to the
+limitation negotiated using the domain attribute max_group_id.  The group
+id of an fi_addr_t may be set using the fi_group_addr() function.
+
+## fi_group_addr
+
+This function is used to set the group ID portion of an fi_addr_t.
 
 # RETURN VALUES
 

--- a/man/fi_domain.3.md
+++ b/man/fi_domain.3.md
@@ -214,6 +214,7 @@ struct fi_domain_attr {
 	size_t                max_err_data;
 	size_t                mr_cnt;
 	uint32_t              tclass;
+	uint32_t              max_group_id;
 };
 ```
 
@@ -771,6 +772,15 @@ provider to optimize any memory registration cache or lookup tables.
 This specifies the default traffic class that will be associated any endpoints
 created within the domain.  See [`fi_endpoint`(3)](fi_endpoint.3.html)
 for additional information.
+
+## Maximum Peer Group Id (max_group_id)
+
+The maximum value that a peer group may be assigned, inclusive.  Valid peer
+group id's must be between 0 and max_group_id.  See [`fi_av`(3)](fi_av.3.html)
+for additional information on peer groups and their use.  Users may request
+support for peer groups by setting this to a non-zero value.  Providers that
+cannot meet the requested max_group_id will fail fi_getinfo().  On output,
+providers may return a value higher than that requested by the application.
 
 # RETURN VALUE
 

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -834,40 +834,105 @@ A value of -1 guarantees ordering for any data size.
 
 ## mem_tag_format - Memory Tag Format
 
-The memory tag format is a bit array used to convey the number of
-tagged bits supported by a provider.  Additionally, it may be used to
-divide the bit array into separate fields.  The mem_tag_format
-optionally begins with a series of bits set to 0, to signify bits
-which are ignored by the provider.  Following the initial prefix of
-ignored bits, the array will consist of alternating groups of bits set
-to all 1's or all 0's.  Each group of bits corresponds to a tagged
-field.  The implication of defining a tagged field is that when a mask
-is applied to the tagged bit array, all bits belonging to a single
-field will either be set to 1 or 0, collectively.
+The memory tag format field is used to convey information on
+the use of the tag and ignore parameters in the fi_tagged API calls.
+This information is used by the provider to optimize tag matching
+support.  The following tag formats are defined:
 
-For example, a mem_tag_format of 0x30FF indicates support for 14
-tagged bits, separated into 3 fields.  The first field consists of
-2-bits, the second field 4-bits, and the final field 8-bits.  Valid
-masks for such a tagged field would be a bitwise OR'ing of zero or
-more of the following values: 0x3000, 0x0F00, and 0x00FF. The provider
-may not validate the mask provided by the application for performance
-reasons.
+*FI_TAG_BITS*
 
-By identifying fields within a tag, a provider may be able to optimize
-their search routines.  An application which requests tag fields must
-provide tag masks that either set all mask bits corresponding to a
-field to all 0 or all 1.  When negotiating tag fields, an application
-can request a specific number of fields of a given size.  A provider
-must return a tag format that supports the requested number of fields,
-with each field being at least the size requested, or fail the
-request.  A provider may increase the size of the fields. When reporting
-completions (see FI_CQ_FORMAT_TAGGED), it is not guaranteed that the
-provider would clear out any unsupported tag bits in the tag field of
-the completion entry.
+: If specified on input to fi_getinfo, this indicates that tags
+  contain up to 64-bits of data, and the receiver must apply ignore_bits
+  to tags when matching receive buffers with sends.  The output of
+  fi_getinfo will set 0 or more upper bits of mem_tag_format to 0 to
+  indicate those tag bits which are ignored or reserved by the provider.
+  Applications must check the number of upper bits which are 0 and
+  set them to 0 on all tag and ignore bits.
 
-It is recommended that field sizes be ordered from smallest to
-largest.  A generic, unstructured tag and mask can be achieved by
-requesting a bit array consisting of alternating 1's and 0's.
+  The value of FI_TAG_BITS is 0, making this the default behavior if
+  the hints are left uninialized after being allocated by fi_allocinfo().
+  This format provides the most flexibility to applications, but limits
+  provider optimization options.
+
+*FI_TAG_MPI*
+
+: The MPI tag format specifically targets MPI based implementations and
+  applications.  An MPI formatted tag consists of 2 fields: an MPI tag
+  and a payload identier.  The MPI tag is a 32-bit searchable tag.
+  Matching on an MPI tag requires searching through a list of posted
+  buffers at the receiver, which we refer to as a searchable tag.
+  The integer tag in MPI point-to-point messages can map directly to
+  the libfabric MPI tag field.
+
+  The second field is an identifier that corresponds to the operation or
+  data being carried in the message payload.  For example, this field may
+  be used to identify the type of collective operation associated with a
+  message payload.  Note that only the size and behavior for
+  the MPI tag format.  Described use of the fields are only suggestions.
+
+  Applications that use the MPI format should initialize their tags using
+  the fi_tag_mpi() function.  Ignore bits should be specified as
+  FI_MPI_IGNORE_TAG, FI_MPI_IGNORE_PAYLOAD, or their bitwise OR'ing.
+
+*FI_TAG_CCL*
+
+: The CCL tag format targets collective communication libraries and
+  applications.  The behavior of tags formatted for FI_TAG_CCL is simpler
+  than requesting generic tag bits or using an MPI formatted tag.  The
+  CCL format consists of a single field: a payload identifier.
+  The identifier corresponds to the operation or data being carried
+  in the message payload.  For example, this field may be used
+  to identify whether a message is for point-to-point communication or
+  part of a collective operation, and in the latter case, the type of
+  collective operation.
+
+  The CCL tag format does not require searching for matching receive
+  buffers, only directing the message to the correct virtual message queue
+  based on to the payload identifier.
+
+  Applications that use the CCL format pass in the payload identifier
+  directly as the tag and set ignore bits to 0.
+
+*FI_TAG_MAX_FORMAT*
+: If the value of mem_tag_format is >= FI_TAG_MAX_FORMAT, the tag format
+  is treated as a set of bit fields.  The behavior functionally the same
+  as FI_TAG_BITS.  The following description is for backwards compatibility
+  and describes how the provider may interpret the mem_tag_format field
+  if the value is >= FI_TAG_MAX_FORMAT.
+
+  The memory tag format may be used to
+  divide the bit array into separate fields.  The mem_tag_format
+  optionally begins with a series of bits set to 0, to signify bits
+  which are ignored by the provider.  Following the initial prefix of
+  ignored bits, the array will consist of alternating groups of bits set
+  to all 1's or all 0's.  Each group of bits corresponds to a tagged
+  field.  The implication of defining a tagged field is that when a mask
+  is applied to the tagged bit array, all bits belonging to a single
+  field will either be set to 1 or 0, collectively.
+
+  For example, a mem_tag_format of 0x30FF indicates support for 14
+  tagged bits, separated into 3 fields.  The first field consists of
+  2-bits, the second field 4-bits, and the final field 8-bits.  Valid
+  masks for such a tagged field would be a bitwise OR'ing of zero or
+  more of the following values: 0x3000, 0x0F00, and 0x00FF. The provider
+  may not validate the mask provided by the application for performance
+  reasons.
+
+  By identifying fields within a tag, a provider may be able to optimize
+  their search routines.  An application which requests tag fields must
+  provide tag masks that either set all mask bits corresponding to a
+  field to all 0 or all 1.  When negotiating tag fields, an application
+  can request a specific number of fields of a given size.  A provider
+  must return a tag format that supports the requested number of fields,
+  with each field being at least the size requested, or fail the
+  request.  A provider may increase the size of the fields. When reporting
+  completions (see FI_CQ_FORMAT_TAGGED), it is not guaranteed that the
+  provider would clear out any unsupported tag bits in the tag field of
+  the completion entry.
+
+  It is recommended that field sizes be ordered from smallest to
+  largest.  A generic, unstructured tag and mask can be achieved by
+  requesting a bit array consisting of alternating 1's and 0's.
 
 ## tx_ctx_cnt - Transmit Context Count
 


### PR DESCRIPTION
Introduces 2 new features to align the API with the *needs* of MPI and NCCL, allowing optimizing for both use cases.

Add new peer group definition.  This allows the app to specify what group of peers a given data transfer belongs to.  This provides a direct mapping for MPI and NCCL communicators.  Peer groups give the provider semantic knowledge about the communication, which cannot be extracted from generic tag bits.

Extend the mem_tag_format definition to allow optimized use of the FI_TAGGED APIs.  The new formats technically break the API, so are marked for libfabric 2.0, but in practice should have no impact on existing applications.  The proposed formats enable a provider to optimize their implementations specifically for either MPI and/or NCCL, or continue to use the current more generic tagged APIs.