### PR TITLE
prov/xnet: Reset ep->rx_avail to 0 after RX queue is flushed

### DIFF
--- a/prov/tcp/src/xnet_ep.c
+++ b/prov/tcp/src/xnet_ep.c
@@ -418,6 +418,7 @@ static void xnet_ep_flush_all_queues(struct xnet_ep *ep)
 	}
 	xnet_reset_rx(ep);
 	xnet_flush_xfer_queue(progress, &ep->rx_queue, NULL);
+	ep->rx_avail = 0;
 	ofi_bsock_discard(&ep->bsock);
 }
 

--- a/prov/tcp/src/xnet_progress.c
+++ b/prov/tcp/src/xnet_progress.c
@@ -1105,6 +1105,7 @@ void xnet_progress_rx(struct xnet_ep *ep)
 
 	assert(xnet_progress_locked(xnet_ep2_progress(ep)));
 	do {
+		assert(ep->state == XNET_CONNECTED);
 		if (ep->cur_rx.hdr_done < ep->cur_rx.hdr_len) {
 			ret = xnet_recv_hdr(ep);
 		} else {


### PR DESCRIPTION
We are hitting an issue where the following assertion fails in
xnet_queue_recv(): assert(!dlist_empty(&ep->unexp_entry));

In GDB, the endpoint state is XNET_DISCONNECTED, but ep->cur_rx
seems to indicate that the endpoint has received a header:
```
(gdb) print ep->cur_rx
[...]
  hdr_len = 24,
  hdr_done = 24,
  data_left = 528,
  entry = 0x0,
  handler = 0xfffff26bba00 <xnet_op_msg>,
  claim_ctx = 0x0
```

ep->cur_rx is supposed to be reset by xnet_reset_rx() when the
endpoint is marked as disconnected in xnet_ep_{disable,close}().
The GDB output above clearly shows the evidence that xnet_progress_rx()
was called after the endpoint was disconnected, which is not supposed
to happen.

The only function that may call xnet_progress_rx() after the
endpoint is disconnected is xnet_queue_recv(), when ep->rx_avail
is > 0.

The problem is that ep->rx_avail is never reset to 0 when the RX
queue is flushed, so the provider wrongly assumes that RX buffers
are available.

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>