### PR TITLE
prov/efa: Fix compilation warning

### DIFF
--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -900,7 +900,7 @@ static int efa_mr_reg_impl(struct efa_mr *efa_mr, uint64_t flags, const void *at
 				fi_strerror(-ret),
 				efa_mr->mr_fid.key,
 				mr_attr.mr_iov ? mr_attr.mr_iov->iov_base : NULL,
-				mr_attr.mr_iov ? mr_attr.mr_iov->iov_len : NULL);
+				mr_attr.mr_iov ? mr_attr.mr_iov->iov_len : 0);
 			efa_mr_dereg_impl(efa_mr);
 			return ret;
 		}


### PR DESCRIPTION
NULL has type void * while len is a size_t.
This caused a compilation warning. Use 0
to fix it.