### PR TITLE
core: Implement memhooks atfork child handler

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -417,4 +417,6 @@ int ofi_mr_cache_reg(struct ofi_mr_cache *cache, const struct fi_mr_attr *attr,
 void ofi_mr_cache_delete(struct ofi_mr_cache *cache, struct ofi_mr_entry *entry);
 
 
+void ofi_memhooks_atfork_handler(void);
+
 #endif /* _OFI_MR_H_ */

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -684,6 +684,12 @@ static inline char* strsep(char **stringp, const char *delim)
 
 #define __attribute__(x)
 
+static inline int pthread_atfork(void (*prepare)(void), void (*parent)(void),
+				 void (*child)(void))
+{
+	return FI_ENOSYS;
+}
+
 static inline int ofi_mmap_anon_pages(void **memptr, size_t size, int flags)
 {
 	return -FI_ENOSYS;

--- a/prov/util/src/util_mem_hooks.c
+++ b/prov/util/src/util_mem_hooks.c
@@ -108,6 +108,8 @@ struct ofi_mem_monitor *memhooks_monitor = &memhooks.monitor;
 
 #define OFI_INTERCEPT_MAX_PATCH 32
 
+static bool symbols_intercepted;
+
 struct ofi_intercept {
 	struct dlist_entry 		entry;
 	const char			*symbol;
@@ -712,6 +714,8 @@ static int ofi_memhooks_start(struct ofi_mem_monitor *monitor)
 		}
 	}
 
+	symbols_intercepted = true;
+
 	return 0;
 
 err_intercept_failed:
@@ -730,6 +734,12 @@ static void ofi_memhooks_stop(struct ofi_mem_monitor *monitor)
 	memhooks_monitor->unsubscribe = NULL;
 }
 
+void ofi_memhooks_atfork_handler(void)
+{
+	if (symbols_intercepted)
+		ofi_restore_intercepts();
+}
+
 #else
 
 static int ofi_memhooks_start(struct ofi_mem_monitor *monitor)
@@ -738,6 +748,10 @@ static int ofi_memhooks_start(struct ofi_mem_monitor *monitor)
 }
 
 static void ofi_memhooks_stop(struct ofi_mem_monitor *monitor)
+{
+}
+
+void ofi_memhooks_atfork_handler(void)
 {
 }
 

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -50,6 +50,7 @@
 #include "ofi_prov.h"
 #include "ofi_perf.h"
 #include "ofi_hmem.h"
+#include "ofi_mr.h"
 #include <ofi_shm_p2p.h>
 #include <rdma/fi_ext.h>
 
@@ -916,6 +917,8 @@ void fi_ini(void)
 	ofi_register_provider(HOOK_NOOP_INIT, NULL);
 
 	ofi_register_provider(COLL_INIT, NULL);
+
+	pthread_atfork(NULL, NULL, ofi_memhooks_atfork_handler);
 
 	ofi_init = 1;
 


### PR DESCRIPTION
If the parent process forks, memhooks could be installed in the child process. If the fork occurred with the MR cache locked and the child memhooks intercepts fire, the child process would deadlock.

Add a pthread_atfork() handler to clear memhooks in the child process.

Note: RDMA is NOT supported in the child process.