### PR TITLE
Support ofi_hmem_get_base_addr() with FI_HMEM_SYSTEM

### DIFF
--- a/include/freebsd/osd.h
+++ b/include/freebsd/osd.h
@@ -56,6 +56,11 @@ static inline int ofi_shm_remap(struct util_shm *shm, size_t newsize, void **map
 	return -1;
 }
 
+static inline ssize_t ofi_get_addr_page_size(const void *addr)
+{
+	return ofi_sysconf(_SC_PAGESIZE);
+}
+
 static inline ssize_t ofi_get_hugepage_size(void)
 {
 	return -FI_ENOSYS;

--- a/include/linux/osd.h
+++ b/include/linux/osd.h
@@ -62,6 +62,7 @@ static inline int ofi_shm_remap(struct util_shm *shm,
 	return shm->ptr == MAP_FAILED ? -FI_EINVAL : FI_SUCCESS;
 }
 
+ssize_t ofi_get_addr_page_size(const void *addr);
 ssize_t ofi_get_hugepage_size(void);
 
 static inline int ofi_alloc_hugepage_buf(void **memptr, size_t size)

--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -116,7 +116,7 @@ struct ofi_hmem_ops {
 	int (*close_handle)(void *mapped_addr);
 	int (*host_register)(void *addr, size_t size);
 	int (*host_unregister)(void *addr);
-	int (*get_base_addr)(const void *addr, void **base_addr,
+	int (*get_base_addr)(const void *addr, size_t len, void **base_addr,
 			     size_t *base_length);
 	bool (*is_ipc_enabled)(void);
 	int (*get_ipc_handle_size)(size_t *size);
@@ -134,7 +134,7 @@ bool rocr_is_addr_valid(const void *addr, uint64_t *device, uint64_t *flags);
 int rocr_host_register(void *ptr, size_t size);
 int rocr_host_unregister(void *ptr);
 int rocr_get_ipc_handle_size(size_t *size);
-int rocr_get_base_addr(const void *ptr, void **base, size_t *size);
+int rocr_get_base_addr(const void *ptr, size_t len, void **base, size_t *size);
 int rocr_get_handle(void *dev_buf, size_t size, void **handle);
 int rocr_open_handle(void **handle, size_t size, uint64_t device,
 		     void **ipc_ptr);
@@ -162,7 +162,7 @@ int cuda_get_handle(void *dev_buf, size_t size, void **handle);
 int cuda_open_handle(void **handle, size_t size, uint64_t device,
 		     void **ipc_ptr);
 int cuda_close_handle(void *ipc_ptr);
-int cuda_get_base_addr(const void *ptr, void **base, size_t *size);
+int cuda_get_base_addr(const void *ptr, size_t len, void **base, size_t *size);
 
 bool cuda_is_ipc_enabled(void);
 int cuda_get_ipc_handle_size(size_t *size);
@@ -199,7 +199,8 @@ int ze_hmem_open_shared_handle(int dev_fd, void **handle, int *ze_fd,
 int ze_hmem_close_handle(void *ipc_ptr);
 bool ze_hmem_p2p_enabled(void);
 int ze_hmem_get_ipc_handle_size(size_t *size);
-int ze_hmem_get_base_addr(const void *ptr, void **base, size_t *size);
+int ze_hmem_get_base_addr(const void *ptr, size_t len, void **base,
+			  size_t *size);
 int ze_hmem_get_id(const void *ptr, uint64_t *id);
 int *ze_hmem_get_dev_fds(int *nfds);
 int ze_hmem_host_register(void *ptr, size_t size);
@@ -300,7 +301,8 @@ static inline int ofi_hmem_host_unregister_noop(void *addr)
 }
 
 static inline int
-ofi_hmem_no_base_addr(const void *addr, void **base_addr, size_t *base_length)
+ofi_hmem_no_base_addr(const void *addr, size_t len, void **base_addr,
+		      size_t *base_length)
 {
 	return -FI_ENOSYS;
 }
@@ -371,7 +373,7 @@ int ofi_hmem_open_handle(enum fi_hmem_iface iface, void **handle,
 			 size_t size, uint64_t device, void **mapped_addr);
 int ofi_hmem_close_handle(enum fi_hmem_iface iface, void *mapped_addr);
 int ofi_hmem_get_base_addr(enum fi_hmem_iface iface, const void *addr,
-			   void **base_addr, size_t *base_length);
+			   size_t len, void **base_addr, size_t *base_length);
 bool ofi_hmem_is_initialized(enum fi_hmem_iface iface);
 
 void ofi_hmem_init(void);

--- a/include/osx/osd.h
+++ b/include/osx/osd.h
@@ -79,6 +79,11 @@ static inline int ofi_shm_remap(struct util_shm *shm, size_t newsize, void **map
 	return -1;
 }
 
+static inline ssize_t ofi_get_addr_page_size(const void *addr)
+{
+	return ofi_sysconf(_SC_PAGESIZE);
+}
+
 static inline ssize_t ofi_get_hugepage_size(void)
 {
 	return -FI_ENOSYS;

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -953,6 +953,11 @@ static inline long ofi_sysconf(int name)
 
 int ofi_shm_unmap(struct util_shm *shm);
 
+static inline ssize_t ofi_get_addr_page_size(const void *addr)
+{
+	return ofi_sysconf(_SC_PAGESIZE);
+}
+
 static inline ssize_t ofi_get_hugepage_size(void)
 {
 	return -FI_ENOSYS;

--- a/prov/hook/dmabuf_peer_mem/src/hook_dmabuf_peer_mem.c
+++ b/prov/hook/dmabuf_peer_mem/src/hook_dmabuf_peer_mem.c
@@ -184,8 +184,8 @@ static void get_mr_fd(struct dmabuf_peer_mem_mr *mr,
 	if (!iov_count)
 		goto out;
 
-	err = ze_hmem_get_base_addr(iov->iov_base, (void **)&mr->base,
-				    &mr->size);
+	err = ze_hmem_get_base_addr(iov->iov_base, iov->iov_len,
+				    (void **)&mr->base, &mr->size);
 	if (err)
 		goto out;
 

--- a/prov/hook/hook_hmem/src/hook_hmem.c
+++ b/prov/hook/hook_hmem/src/hook_hmem.c
@@ -69,8 +69,8 @@ static int hook_hmem_add_region(struct hook_hmem_domain *domain,
 		goto out;
 	}
 
-	ret = ofi_hmem_get_base_addr(iface, iov->iov_base, &base_iov.iov_base,
-				     &base_iov.iov_len);
+	ret = ofi_hmem_get_base_addr(iface, iov->iov_base, iov->iov_len,
+				     &base_iov.iov_base, &base_iov.iov_len);
 	if (ret) {
 		ofi_buf_free(*hmem_desc);
 		return -FI_EINVAL;

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -318,7 +318,8 @@ static int smr_format_ze_ipc(struct smr_ep *ep, int64_t id, struct smr_cmd *cmd,
 	if (ep->sock_info->peers[id].state != SMR_CMAP_SUCCESS)
 		return -FI_EAGAIN;
 
-	ret = ze_hmem_get_base_addr(iov[0].iov_base, &base, NULL);
+	ret = ze_hmem_get_base_addr(iov[0].iov_base, iov[0].iov_len, &base,
+				    NULL);
 	if (ret)
 		return ret;
 
@@ -347,7 +348,8 @@ static int smr_format_ipc(struct smr_cmd *cmd, void *ptr, size_t len,
 	cmd->msg.hdr.size = len;
 	cmd->msg.data.ipc_info.iface = iface;
 	cmd->msg.data.ipc_info.device = device;
-	ret = ofi_hmem_get_base_addr(cmd->msg.data.ipc_info.iface, ptr, &base,
+	ret = ofi_hmem_get_base_addr(cmd->msg.data.ipc_info.iface, ptr, len,
+				     &base,
 				     &cmd->msg.data.ipc_info.base_length);
 	if (ret)
 		return ret;

--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -77,7 +77,7 @@ static struct ibv_mr *vrb_reg_ze_dmabuf(struct ibv_pd *pd, const void *buf,
 	if (err)
 		return NULL;
 
-	err = ze_hmem_get_base_addr((void *)buf, &base, NULL);
+	err = ze_hmem_get_base_addr((void *)buf, len, &base, NULL);
 	if (err)
 		return NULL;
 

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -420,9 +420,9 @@ int ofi_hmem_close_handle(enum fi_hmem_iface iface, void *mapped_addr)
 }
 
 int ofi_hmem_get_base_addr(enum fi_hmem_iface iface, const void *addr,
-			   void **base_addr, size_t *base_length)
+			   size_t len, void **base_addr, size_t *base_length)
 {
-	return hmem_ops[iface].get_base_addr(addr, base_addr, base_length);
+	return hmem_ops[iface].get_base_addr(addr, len, base_addr, base_length);
 }
 
 bool ofi_hmem_is_initialized(enum fi_hmem_iface iface)

--- a/src/hmem_cuda.c
+++ b/src/hmem_cuda.c
@@ -382,7 +382,7 @@ int cuda_close_handle(void *ipc_ptr)
 	return -FI_EINVAL;
 }
 
-int cuda_get_base_addr(const void *ptr, void **base, size_t *size)
+int cuda_get_base_addr(const void *ptr, size_t len, void **base, size_t *size)
 {
 	CUresult cu_result;
 	const char *cu_error_name;
@@ -837,7 +837,7 @@ int cuda_close_handle(void *ipc_ptr)
 	return -FI_ENOSYS;
 }
 
-int cuda_get_base_addr(const void *ptr, void **base, size_t *size)
+int cuda_get_base_addr(const void *ptr, size_t len, void **base, size_t *size)
 {
 	return -FI_ENOSYS;
 }

--- a/src/hmem_rocr.c
+++ b/src/hmem_rocr.c
@@ -621,7 +621,7 @@ int rocr_get_ipc_handle_size(size_t *size)
 	return FI_SUCCESS;
 }
 
-int rocr_get_base_addr(const void *ptr, void **base, size_t *size)
+int rocr_get_base_addr(const void *ptr, size_t len, void **base, size_t *size)
 {
 	return rocr_host_memory_ptr((void*)ptr, base, NULL, size, NULL, NULL);
 }
@@ -1043,7 +1043,7 @@ int rocr_get_ipc_handle_size(size_t *size)
 	return -FI_ENOSYS;
 }
 
-int rocr_get_base_addr(const void *ptr, void **base, size_t *size)
+int rocr_get_base_addr(const void *ptr, size_t len, void **base, size_t *size)
 {
 	return -FI_ENOSYS;
 }

--- a/src/hmem_ze.c
+++ b/src/hmem_ze.c
@@ -1051,7 +1051,8 @@ int ze_hmem_get_ipc_handle_size(size_t *size)
 	return FI_SUCCESS;
 }
 
-int ze_hmem_get_base_addr(const void *ptr, void **base, size_t *size)
+int ze_hmem_get_base_addr(const void *ptr, size_t len, void **base,
+			  size_t *size)
 {
 	ze_result_t ze_ret;
 
@@ -1178,7 +1179,8 @@ int ze_hmem_get_ipc_handle_size(size_t *size)
 	return -FI_ENOSYS;
 }
 
-int ze_hmem_get_base_addr(const void *ptr, void **base, size_t *size)
+int ze_hmem_get_base_addr(const void *ptr, size_t len, void **base,
+			  size_t *size)
 {
 	return -FI_ENOSYS;
 }

--- a/src/linux/osd.c
+++ b/src/linux/osd.c
@@ -46,6 +46,81 @@
 #include <linux/ethtool.h>
 #include <linux/sockios.h>
 #include <sys/ioctl.h>
+#include <inttypes.h>
+
+static size_t ofi_base_page_size;
+
+static unsigned long ofi_smaps_page_size(FILE *file)
+{
+	int n;
+	unsigned long size = ofi_base_page_size;
+	char buf[1024];
+
+	while (fgets(buf, sizeof(buf), file) != NULL) {
+		if (!strstr(buf, "KernelPageSize:"))
+			continue;
+
+		n = sscanf(buf, "%*s %lu", &size);
+		if (n < 1)
+			continue;
+
+		/* page size is printed in Kb */
+		size = size * 1024;
+
+		break;
+	}
+
+	return size;
+}
+
+ssize_t ofi_get_addr_page_size(const void *addr)
+{
+	pid_t pid;
+	ssize_t ret;
+	FILE *file;
+	char buf[1024];
+
+	pid = getpid();
+	snprintf(buf, sizeof(buf), "/proc/%d/smaps", pid);
+
+	if (!ofi_base_page_size) {
+		ret = ofi_sysconf(_SC_PAGESIZE);
+		if (ret < 0) {
+			FI_WARN(&core_prov, FI_LOG_CORE,
+				"ofi_sysconf(_SC_PAGESIZE) failed: %d:%s\n", -errno,
+				strerror(errno));
+			return -FI_EINVAL;
+		}
+
+		ofi_base_page_size = ret;
+	}
+
+	file = fopen(buf, "re");
+	if (!file)
+		return ofi_base_page_size;
+
+	ret = ofi_base_page_size;
+
+	while (fgets(buf, sizeof(buf), file) != NULL) {
+		int n;
+		uintptr_t range_start, range_end;
+
+		n = sscanf(buf, "%" SCNxPTR "-%" SCNxPTR, &range_start,
+			   &range_end);
+
+		if (n < 2)
+			continue;
+
+		if ((uintptr_t) addr >= range_start && (uintptr_t) addr < range_end) {
+			ret = ofi_smaps_page_size(file);
+			break;
+		}
+	}
+
+	fclose(file);
+
+	return ret;
+}
 
 ssize_t ofi_get_hugepage_size(void)
 {


### PR DESCRIPTION
Implementation uses the same approach libibverbs does to expand memory region: https://github.com/linux-rdma/rdma-core/blob/master/libibverbs/memory.c