### PR TITLE
prov/ucx: Add FI_HMEM support

### DIFF
--- a/prov/ucx/src/ucx.h
+++ b/prov/ucx/src/ucx.h
@@ -58,13 +58,11 @@ extern "C" {
 #include <ofi.h>
 #include <ofi_lock.h>
 #include <ofi_list.h>
-#include "ofi_enosys.h"
-#include <ofi_mem.h>
-#include <ofi_atom.h>
+#include <ofi_enosys.h>
 #include <ofi_util.h>
 #include <ofi_prov.h>
 #include <ofi_mr.h>
-#include <ofi_indexer.h>
+#include <ofi_hmem.h>
 
 #include <arpa/inet.h>
 #include <netdb.h>
@@ -90,7 +88,7 @@ extern "C" {
 #define FI_UCX_RMA_CAPS (FI_RMA | FI_READ | FI_WRITE | FI_REMOTE_READ |\
 			 FI_REMOTE_WRITE)
 #define FI_UCX_CAPS (FI_SEND | FI_RECV | FI_TAGGED | FI_MSG | FI_MULTI_RECV |\
-		     FI_UCX_RMA_CAPS | FI_UCX_DOM_CAPS)
+		     FI_UCX_RMA_CAPS | FI_UCX_DOM_CAPS | FI_HMEM)
 
 #define FI_UCX_MODE (0ULL)
 #define FI_UCX_TX_FLAGS (FI_COMPLETION | FI_INJECT)

--- a/prov/ucx/src/ucx_init.c
+++ b/prov/ucx/src/ucx_init.c
@@ -364,6 +364,10 @@ static int ucx_getinfo(uint32_t version, const char *node,
 		if ((*info)->nic)
 			(*info)->nic->link_attr->speed =
 				(size_t) speed_gbps * 1000 * 1000 * 1000;
+
+		if (hints && hints->domain_attr &&
+		    (hints->domain_attr->mr_mode & FI_MR_HMEM))
+			(*info)->domain_attr->mr_mode |= FI_MR_HMEM;
 	}
 
 	/* make sure the memery hooks are installed for memory type cache */
@@ -374,6 +378,10 @@ out:
 
 static void ucx_cleanup(void)
 {
+#if HAVE_UCX_DL
+        ofi_hmem_cleanup();
+#endif
+
 	FI_DBG(&ucx_prov, FI_LOG_CORE, "provider goes cleanup sequence\n");
 	if (ucx_descriptor.config) {
 		ucp_config_release(ucx_descriptor.config);
@@ -392,6 +400,10 @@ struct fi_provider ucx_prov = {
 
 UCX_INI
 {
+#if HAVE_UCX_DL
+        ofi_hmem_init();
+#endif
+
 	ucx_init_errcodes();
 
 	fi_param_define(&ucx_prov,


### PR DESCRIPTION
Device memory access is handled by UCX internally. UCX by default uses a memtype cache to speed up identification of where a buffer belongs to. Memory allocator hooks are installed to keep the memtype cache updated.

Not much is needed at the provider level except for adding FI_HMEM to the supported caps. The remaining changes are mostly workarounds for the cases that the memory allocator hooks may not always work as expected and thus the memtype cache may not have the information for the device memory allocation:

* When device memory is registered, check if the allocation is already in the memtype cache. Try updating the cache if the information is missing.

* Enable FI_MR_HMEM mode if the application supports that. This requires all device memory allocation go through the memory registratin process and thus ensure the memtype cache is updated accordingly.

Removed a few unused headers.