### PR TITLE
[v1.19.x] contrib/intel/jenkins: Pick add cloudbees start string to daos log

### DIFF
--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -1029,7 +1029,8 @@ class DaosCartTest(Test):
 
     @property
     def cmd(self):
-        return "python3.6 launch.py "
+        return f"env; echo {common.cloudbees_log_start_string}; "\
+                "python3.6 launch.py "
     
     def remote_launch_cmd(self, testname):
 


### PR DESCRIPTION
Adding the cloudbees log start string to the daos log will ensure that the daos summarizer doesn't fast forward through the entire test file. This will make the output files look more like all of the other outputs.