### PR TITLE
[v1.18.x] src/hmem_ze: fix incorrect device id in copy function

### DIFF
--- a/src/hmem_ze.c
+++ b/src/hmem_ze.c
@@ -918,7 +918,7 @@ int ze_hmem_copy(uint64_t device, void *dst, const void *src, size_t size)
 	}
 
 	ofi_spin_lock(&cl_lock);
-	if (!cmd_queue[device]) {
+	if (!cmd_queue[dev_id]) {
 		ze_ret = ze_init_res(dev_id);
 		if (ze_ret) {
 			ofi_spin_unlock(&cl_lock);


### PR DESCRIPTION
The uint64_t device was updated to include the device and driver indices. The index is isolated using the ze_get_device_idx function which masks the driver bits. The cmd_queue used in the copy function was using the full device rather than just the dev_id