### PR TITLE
contrib/intel/jenkins: Make jobs checkout their own ci resources

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -135,6 +135,47 @@ def checkout_py_scripts() {
   """
 }
 
+def checkout_ci_resources() {
+  sh """
+    if [[ ! -d ${env.WORKSPACE}/py_scripts ]]; then
+      mkdir ${env.WORKSPACE}/ci_resources
+    else
+      rm -rf ${env.WORKSPACE}/ci_resources && mkdir ${env.WORKSPACE}/ci_resources
+    fi
+
+    git clone ${env.CI_RESOURCES} ${env.WORKSPACE}/ci_resources
+
+  """
+}
+
+def checkout_external_resources() {
+  checkout_ci_resources()
+  checkout_py_scripts()
+}
+
+def generate_diff(def branch_name, def output_loc) {
+  sh """
+    git remote add mainRepo ${env.UPSTREAM}
+    git fetch mainRepo
+    git diff --name-only HEAD..mainRepo/${branch_name} > ${output_loc}/commit_id
+    git remote remove mainRepo
+  """
+}
+
+def generate_release_num(def branch_name, def output_loc) {
+  sh """
+    git remote add mainRepo ${env.UPSTREAM}
+    git fetch mainRepo
+    git diff mainRepo/${branch_name}:Makefile.am Makefile.am > \
+        ${output_loc}/Makefile.am.diff
+    git diff mainRepo/${branch_name}:configure.ac configure.ac > \
+        ${output_loc}/configure.ac.diff
+    cat configure.ac | grep AC_INIT | cut -d ' ' -f 2 | \
+        cut -d '[' -f 2 | cut -d ']' -f 1 > ${output_loc}/release_num.txt
+    git remote remove mainRepo
+  """
+}
+
 def build(item, mode=null, cluster=null, release=false, additional_args=null) {
   def cmd = "${RUN_LOCATION}/build.py --build_item=${item}"
   if (mode) {
@@ -244,10 +285,10 @@ pipeline {
       steps {
         script {
           TARGET=check_target()
-          sh "mkdir ${env.WORKSPACE}/py_scripts"
-          sh "git clone --branch ${TARGET} ${env.UPSTREAM} ${env.WORKSPACE}/py_scripts"
-          sh "${env.SKIP_PATH}/skip.sh ${env.WORKSPACE} ${TARGET}"
-          sh "${env.SKIP_PATH}/release.sh ${env.WORKSPACE} ${TARGET}"
+          checkout_external_resources()
+          generate_diff("${TARGET}", "${env.WORKSPACE}")
+          generate_release_num("${TARGET}", "${env.WORKSPACE}")
+
           if (env.WEEKLY == null) {
             weekly = false
           } else {
@@ -344,7 +385,7 @@ pipeline {
           }
           steps {
             script {
-              checkout_py_scripts()
+              checkout_external_resources()
               dir (CUSTOM_WORKSPACE) {
                 build("logdir")
                 build("libfabric", "reg", "daos")
@@ -362,7 +403,7 @@ pipeline {
           }
           steps {
             script {
-              checkout_py_scripts()
+              checkout_external_resources()
               dir (CUSTOM_WORKSPACE) {
                 build("logdir")
                 build("builddir")

--- a/contrib/intel/jenkins/build.py
+++ b/contrib/intel/jenkins/build.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 # add jenkins config location to PATH
-sys.path.append(os.environ['CLOUDBEES_CONFIG'])
+sys.path.append(f"{os.environ['WORKSPACE']}/ci_resources/configs/{os.environ['CLUSTER']}")
 import cloudbees_config
 
 import argparse

--- a/contrib/intel/jenkins/run.py
+++ b/contrib/intel/jenkins/run.py
@@ -5,7 +5,7 @@ import argparse
 import os
 import common
 
-sys.path.append(os.environ['CLOUDBEES_CONFIG'])
+sys.path.append(f"{os.environ['WORKSPACE']}/ci_resources/configs/{os.environ['CLUSTER']}")
 import cloudbees_config
 
 # read Jenkins environment variables

--- a/contrib/intel/jenkins/runtests.py
+++ b/contrib/intel/jenkins/runtests.py
@@ -1,7 +1,7 @@
 import argparse
 import os
 import sys
-sys.path.append(os.environ['CLOUDBEES_CONFIG'])
+sys.path.append(f"{os.environ['WORKSPACE']}/ci_resources/configs/{os.environ['CLUSTER']}")
 import cloudbees_config
 import subprocess
 import run

--- a/contrib/intel/jenkins/summary.py
+++ b/contrib/intel/jenkins/summary.py
@@ -12,7 +12,7 @@ from email.mime.base import MIMEBase
 from email import encoders
 
 # add jenkins config location to PATH
-sys.path.append(os.environ['CLOUDBEES_CONFIG'])
+sys.path.append(f"{os.environ['WORKSPACE']}/ci_resources/configs/{os.environ['CLUSTER']}")
 
 import cloudbees_config
 import argparse

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -1,7 +1,8 @@
 import sys
 import os
 import io
-sys.path.append(os.environ['CLOUDBEES_CONFIG'])
+
+sys.path.append(f"{os.environ['WORKSPACE']}/ci_resources/configs/{os.environ['CLUSTER']}")
 
 import subprocess
 import re


### PR DESCRIPTION
Making jobs checkout their own ci resources will make it so they depend on less static things on each cluster. This will make jobs more portable between clusters and will make development work easier.

Move skip and release scripts into jenkinsfile to reduce the number of external files needed.