### PR TITLE
fabtests/dmabuf-rdma: Increase the number of NICs that can be tested

### DIFF
--- a/fabtests/component/dmabuf-rdma/fi-rdmabw-xe.c
+++ b/fabtests/component/dmabuf-rdma/fi-rdmabw-xe.c
@@ -98,7 +98,7 @@
 #define MIN_PROXY_BLOCK	(131072)
 #define TX_DEPTH	(128)
 #define RX_DEPTH	(1)
-#define MAX_NICS	(4)
+#define MAX_NICS	(32)
 #define MAX_RAW_KEY_SIZE (256)
 
 enum test_type {

--- a/fabtests/component/dmabuf-rdma/rdmabw-xe.c
+++ b/fabtests/component/dmabuf-rdma/rdmabw-xe.c
@@ -86,7 +86,7 @@
 #define MIN_PROXY_BLOCK	(131072)
 #define TX_DEPTH	(128)
 #define RX_DEPTH	(1)
-#define MAX_NICS	(4)
+#define MAX_NICS	(32)
 
 enum test_type {
 	READ,


### PR DESCRIPTION
We have already seen the need for testing 8-NICs. Increase the limit from 4 to 32 to leave room for future expansion.