### PR TITLE
util/buf: Add bounds checks to ibuf get

### DIFF
--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -383,6 +383,7 @@ struct ofi_bufpool_hdr {
 	struct ofi_bufpool_region	*region;
 	size_t 				index;
 
+	OFI_DBG_VAR(bool, allocated)
 	OFI_DBG_VAR(struct ofi_bufpool_ftr *, ftr)
 	OFI_DBG_VAR(size_t,		magic)
 };
@@ -438,6 +439,9 @@ static inline void ofi_buf_free(void *buf)
 	assert(!(ofi_buf_pool(buf)->attr.flags & OFI_BUFPOOL_INDEXED));
 	assert(ofi_buf_hdr(buf)->magic == OFI_MAGIC_SIZE_T);
 	assert(ofi_buf_hdr(buf)->ftr->magic == OFI_MAGIC_SIZE_T);
+	assert(ofi_buf_hdr(buf)->allocated == true);
+
+	OFI_DBG_SET(ofi_buf_hdr(buf)->allocated, false);
 
 	slist_insert_head(&ofi_buf_hdr(buf)->entry.slist,
 			  &ofi_buf_pool(buf)->free_list.entries);
@@ -456,6 +460,9 @@ static inline void ofi_ibuf_free(void *buf)
 	assert(ofi_buf_pool(buf)->attr.flags & OFI_BUFPOOL_INDEXED);
 	assert(buf_hdr->magic == OFI_MAGIC_SIZE_T);
 	assert(buf_hdr->ftr->magic == OFI_MAGIC_SIZE_T);
+	assert(buf_hdr->allocated == true);
+
+	OFI_DBG_SET(buf_hdr->allocated, false);
 
 	dlist_insert_order(&buf_hdr->region->free_list,
 			   ofi_ibuf_is_lower, &buf_hdr->entry.dlist);
@@ -474,11 +481,15 @@ static inline size_t ofi_buf_index(void *buf)
 static inline void *ofi_bufpool_get_ibuf(struct ofi_bufpool *pool, size_t index)
 {
 	void *buf;
+	size_t region_index = index / pool->attr.chunk_cnt;
 
-	buf = pool->region_table[(size_t)(index / pool->attr.chunk_cnt)]->
-		mem_region + (index % pool->attr.chunk_cnt) * pool->entry_size;
+	assert(region_index < pool->region_cnt);
 
-	assert(ofi_atomic_get32(&ofi_buf_region(buf)->use_cnt));
+	buf = pool->region_table[region_index]->mem_region +
+		(index % pool->attr.chunk_cnt) * pool->entry_size;
+
+	assert(ofi_buf_hdr(buf)->allocated);
+
 	return buf;
 }
 
@@ -505,6 +516,10 @@ static inline void *ofi_buf_alloc(struct ofi_bufpool *pool)
 	slist_remove_head_container(&pool->free_list.entries,
 				struct ofi_bufpool_hdr, buf_hdr, entry.slist);
 	assert(ofi_atomic_inc32(&buf_hdr->region->use_cnt));
+	assert(buf_hdr->allocated == false);
+
+	OFI_DBG_SET(buf_hdr->allocated, true);
+
 	return ofi_buf_data(buf_hdr);
 }
 
@@ -537,6 +552,9 @@ static inline void *ofi_ibuf_alloc(struct ofi_bufpool *pool)
 	dlist_pop_front(&buf_region->free_list, struct ofi_bufpool_hdr,
 			buf_hdr, entry.dlist);
 	assert(ofi_atomic_inc32(&buf_hdr->region->use_cnt));
+	assert(buf_hdr->allocated == false);
+
+	OFI_DBG_SET(buf_hdr->allocated, true);
 
 	if (dlist_empty(&buf_region->free_list))
 		dlist_remove_init(&buf_region->entry);

--- a/prov/util/src/util_buf.c
+++ b/prov/util/src/util_buf.c
@@ -171,6 +171,7 @@ int ofi_bufpool_grow(struct ofi_bufpool *pool)
 		buf_hdr = ofi_buf_hdr(buf);
 		buf_hdr->region = buf_region;
 		buf_hdr->index = pool->entry_cnt + i;
+		OFI_DBG_SET(buf_hdr->allocated, false);
 		OFI_DBG_SET(buf_hdr->magic, OFI_MAGIC_SIZE_T);
 		OFI_DBG_SET(buf_hdr->ftr,
 			    (struct ofi_bufpool_ftr *) ((char *) buf +


### PR DESCRIPTION
With debug enabled, only return buffers pointers for allocated buffers. This requires additional bounds checking and tracking of allocated buffers.