### PR TITLE
prov/xnet: Do not progress ep that is disconnected

### DIFF
--- a/prov/tcp/src/xnet_progress.c
+++ b/prov/tcp/src/xnet_progress.c
@@ -1454,9 +1454,9 @@ static void xnet_run_ep(struct xnet_ep *ep, bool pin, bool pout, bool perr)
 	case XNET_CONNECTED:
 		if (perr)
 			xnet_progress_async(ep);
-		if (pin)
+		if (pin && ep->state == XNET_CONNECTED)
 			xnet_progress_rx(ep);
-		if (pout)
+		if (pout && ep->state == XNET_CONNECTED)
 			xnet_progress_tx(ep);
 		break;
 	case XNET_CONNECTING:


### PR DESCRIPTION
A recent patch added a check to ensure that ep state is XNET_CONNECTED
when xnet_progress_rx() is called. This new assertion failure has triggered
in one of our tests:

```
10 0x0000fffff15e3fd0 in __assert_fail_base (fmt=0xfffff16fd3c8 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", assertion=assertion@entry=0xfffff5820860 "ep->state == XNET_CONNECTED",
   file=file@entry=0xfffff581fda0 "prov/tcp/src/xnet_progress.c", line=line@entry=985, function=function@entry=0xfffff5821d80 <__PRETTY_FUNCTION__.30> "xnet_progress_rx") at ./assert/assert.c:92
11 0x0000fffff15e4040 in __GI___assert_fail (assertion=0xfffff5820860 "ep->state == XNET_CONNECTED", file=0xfffff581fda0 "prov/tcp/src/xnet_progress.c", line=985,
   function=0xfffff5821d80 <__PRETTY_FUNCTION__.30> "xnet_progress_rx") at ./assert/assert.c:101
12 0x0000fffff49875fc in xnet_progress_rx (ep=0xffffe5387200) at prov/tcp/src/xnet_progress.c:985
13 0x0000fffff498943c in xnet_run_ep (ep=0xffffe5387200, pin=true, pout=false, perr=true) at prov/tcp/src/xnet_progress.c:1307
14 0x0000fffff49898cc in xnet_handle_events (progress=0xffffb7e25b80, events=0xffffb7e25f60, nfds=4, clear_signal=false) at prov/tcp/src/xnet_progress.c:1352
15 0x0000fffff4989e98 in xnet_run_progress (progress=0xffffb7e25b80, clear_signal=false) at prov/tcp/src/xnet_progress.c:1409
16 0x0000fffff4978864 in xnet_cq_progress (util_cq=0xffffe57055c0) at prov/tcp/src/xnet_cq.c:84
```

ep state is set to XNET_DISCONNECTED when xnet_progress_rx() is
executed because xnet_run_ep() is called with both pin == true and
perr == true (see GDB frame 13 in above):

```
static void xnet_run_ep(struct xnet_ep *ep, bool pin, bool pout, bool perr)
{
    assert(xnet_progress_locked(xnet_ep2_progress(ep)));
    switch (ep->state) {
    case XNET_CONNECTED:
        if (perr)
            xnet_progress_async(ep);
        if (pin)
            xnet_progress_rx(ep);
        if (pout)
            xnet_progress_tx(ep);
        break;
```

As a consequence, xnet_progress_async() is executed (which disables the endpoint)
and xnet_progress_rx() gets immediately executed after that.
The fix is to check the endpoint state before each of the 3 functions
xnet_progress_async(), xnet_progress_rx() and xnet_progress_tx().

On a side-note, the assertion failure when zero-copy is enabled is still
impacting us from time to time and I wonder if it wouldn't be a side-effect
of xnet_progress_rx() being called when the EP is disconnected.

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>

Fixes #9411