### PR TITLE
hmem: Set FI_HMEM_HOST_ALLOC for ze addr valid

### DIFF
--- a/src/hmem_ze.c
+++ b/src/hmem_ze.c
@@ -973,9 +973,18 @@ bool ze_hmem_is_addr_valid(const void *addr, uint64_t *device, uint64_t *flags)
 	if (ze_ret || mem_props.type == ZE_MEMORY_TYPE_UNKNOWN)
 		return false;
 
-	if (flags)
-		*flags = mem_props.type == ZE_MEMORY_TYPE_DEVICE ?
-			 FI_HMEM_DEVICE_ONLY : 0;
+	if (flags) {
+		switch (mem_props.type) {
+		case ZE_MEMORY_TYPE_DEVICE:
+			*flags = FI_HMEM_DEVICE_ONLY;
+			break;
+		case ZE_MEMORY_TYPE_HOST:
+			*flags = FI_HMEM_HOST_ALLOC;
+			break;
+		default:
+			*flags = 0;
+		}
+	}
 
 	if (!device)
 		return true;


### PR DESCRIPTION
Update ze_hmem_is_addr_valid() to set the FI_HMEM_HOST_ALLOC based on ze mem type.