### PR TITLE
Add fi_cq_err_entry::src_addr

### DIFF
--- a/include/ofi_abi.h
+++ b/include/ofi_abi.h
@@ -164,6 +164,20 @@ struct fi_cq_err_entry_1_0 {
 	void			*err_data;
 };
 
+struct fi_cq_err_entry_1_1 {
+	void			*op_context;
+	uint64_t		flags;
+	size_t			len;
+	void			*buf;
+	uint64_t		data;
+	uint64_t		tag;
+	size_t			olen;
+	int			err;
+	int			prov_errno;
+	/* err_data is available until the next time the CQ is read */
+	void			*err_data;
+	size_t			err_data_size;
+};
 
 #ifdef __cplusplus
 }

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -1322,6 +1322,23 @@ ssize_t util_srx_generic_trecv(struct fid_ep *ep_fid, const struct iovec *iov,
 			       void **desc, size_t iov_count, fi_addr_t addr,
 			       void *context, uint64_t tag, uint64_t ignore,
 			       uint64_t flags);
+
+static inline void ofi_cq_err_memcpy(uint32_t api_version,
+				     struct fi_cq_err_entry *user_buf,
+				     const struct fi_cq_err_entry *prov_buf)
+{
+	size_t size;
+
+	if (FI_VERSION_GE(api_version, FI_VERSION(1, 20)))
+		size = sizeof(struct fi_cq_err_entry);
+	else if (FI_VERSION_GE(api_version, FI_VERSION(1, 5)))
+		size = sizeof(struct fi_cq_err_entry_1_1);
+	else
+		size = sizeof(struct fi_cq_err_entry_1_0);
+
+	memcpy(user_buf, prov_buf, size);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -84,7 +84,7 @@ extern "C" {
 #endif
 
 #define FI_MAJOR_VERSION 1
-#define FI_MINOR_VERSION 19
+#define FI_MINOR_VERSION 20
 #define FI_REVISION_VERSION 0
 
 enum {

--- a/include/rdma/fi_eq.h
+++ b/include/rdma/fi_eq.h
@@ -239,6 +239,7 @@ struct fi_cq_err_entry {
 	/* err_data is available until the next time the CQ is read */
 	void			*err_data;
 	size_t			err_data_size;
+	fi_addr_t		src_addr;
 };
 
 enum fi_cq_wait_cond {
@@ -403,6 +404,9 @@ fi_cq_readfrom(struct fid_cq *cq, void *buf, size_t count, fi_addr_t *src_addr)
 static inline ssize_t
 fi_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf, uint64_t flags)
 {
+	/* For compatibility with older providers. */
+	if (buf)
+		buf->src_addr = FI_ADDR_NOTAVAIL;
 	return cq->ops->readerr(cq, buf, flags);
 }
 

--- a/man/fi_cq.3.md
+++ b/man/fi_cq.3.md
@@ -414,6 +414,7 @@ struct fi_cq_err_entry {
 	int      prov_errno;  /* provider error code */
 	void    *err_data;    /*  error data */
 	size_t   err_data_size; /* size of err_data */
+	fi_addr_t src_addr; /* error source address */
 };
 ```
 
@@ -547,6 +548,10 @@ of these fields are the same for all CQ entry structure formats.
   subsequent read call against the CQ.  Applications must serialize access
   to the CQ when processing errors to ensure that the buffer referenced by
   err_data does not change.
+
+*src_addr*
+: Used to return source addressed related information for error events. How
+  this field is used is error event specific.
 
 # COMPLETION FLAGS
 

--- a/prov/bgq/src/fi_bgq_cq.c
+++ b/prov/bgq/src/fi_bgq_cq.c
@@ -186,7 +186,8 @@ fi_bgq_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf, uint64_t flags
 		if (NULL == bgq_cq->err_head)
 			bgq_cq->err_tail = NULL;
 
-		*buf = ext->err_entry;
+		ofi_cq_err_memcpy(bgq_cq->domain->fabric->fabric_fid.api_version,
+				  buf, &ext->err_entry);
 		free(ext);
 
 		ret = fi_bgq_unlock_if_required(&bgq_cq->lock, lock_required);
@@ -213,7 +214,8 @@ fi_bgq_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf, uint64_t flags
 
 		assert(ext->bgq_context.flags & FI_BGQ_CQ_CONTEXT_EXT);	/* DEBUG */
 
-		*buf = ext->err_entry;
+		ofi_cq_err_memcpy(bgq_cq->domain->fabric->fabric_fid.api_version,
+				  buf, &ext->err_entry);
 		free(ext);
 
 		l2atomic_fifo_advance(&bgq_cq->err_consumer);

--- a/prov/opx/include/rdma/opx/fi_opx_cq_ops_table.h
+++ b/prov/opx/include/rdma/opx/fi_opx_cq_ops_table.h
@@ -72,7 +72,8 @@ fi_opx_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf, uint64_t flags
 		const int lock_required = fi_opx_threading_lock_required(threading, fi_opx_global.progress);
 
 		fi_opx_lock_if_required(&opx_cq->lock, lock_required);
-		*buf = ext->err_entry;
+		ofi_cq_err_memcpy(opx_cq->domain->fabric->fabric_fid.api_version,
+				  buf, &ext->err_entry);
 		slist_remove_head((struct slist *)&opx_cq->err);
 		free(ext);
 		ext = NULL;

--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -1684,19 +1684,13 @@ STATIC ssize_t psmx2_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf,
 				uint64_t flags)
 {
 	struct psmx2_fid_cq *cq_priv;
-	uint32_t api_version;
-	size_t size;
 
 	cq_priv = container_of(cq, struct psmx2_fid_cq, cq);
 
 	cq_priv->domain->cq_lock_fn(&cq_priv->lock, 2);
 	if (cq_priv->pending_error) {
-		api_version = cq_priv->domain->fabric->util_fabric.
-			      fabric_fid.api_version;
-		size = FI_VERSION_GE(api_version, FI_VERSION(1, 5)) ?
-			sizeof(*buf) : sizeof(struct fi_cq_err_entry_1_0);
-
-		memcpy(buf, &cq_priv->pending_error->cqe, size);
+		ofi_cq_err_memcpy(cq_priv->domain->fabric->util_fabric.fabric_fid.api_version,
+				  buf, &cq_priv->pending_error->cqe);
 		free(cq_priv->pending_error);
 		cq_priv->pending_error = NULL;
 		psmx2_unlock(&cq_priv->lock, 2);

--- a/prov/psm3/src/psmx3_cq.c
+++ b/prov/psm3/src/psmx3_cq.c
@@ -954,19 +954,13 @@ STATIC ssize_t psmx3_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf,
 				uint64_t flags)
 {
 	struct psmx3_fid_cq *cq_priv;
-	uint32_t api_version;
-	size_t size;
 
 	cq_priv = container_of(cq, struct psmx3_fid_cq, cq);
 
 	cq_priv->domain->cq_lock_fn(&cq_priv->lock, 2);
 	if (cq_priv->pending_error) {
-		api_version = cq_priv->domain->fabric->util_fabric.
-			      fabric_fid.api_version;
-		size = FI_VERSION_GE(api_version, FI_VERSION(1, 5)) ?
-			sizeof(*buf) : sizeof(struct fi_cq_err_entry_1_0);
-
-		memcpy(buf, &cq_priv->pending_error->cqe, size);
+		ofi_cq_err_memcpy(cq_priv->domain->fabric->util_fabric.fabric_fid.api_version,
+				  buf, &cq_priv->pending_error->cqe);
 		free(cq_priv->pending_error);
 		cq_priv->pending_error = NULL;
 		psmx3_unlock(&cq_priv->lock, 2);

--- a/prov/sockets/src/sock_cq.c
+++ b/prov/sockets/src/sock_cq.c
@@ -449,7 +449,8 @@ static ssize_t sock_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf,
 			&& buf->err_data && buf->err_data_size) {
 			err_data = buf->err_data;
 			err_data_size = buf->err_data_size;
-			*buf = entry;
+			ofi_cq_err_memcpy(api_version, buf, &entry);
+
 			buf->err_data = err_data;
 
 			/* Fill provided user's buffer */

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -300,7 +300,7 @@ ssize_t ofi_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *buf,
 		err_data_size = MIN(buf->err_data_size,
 				    aux_entry->comp.err_data_size);
 
-		*buf = aux_entry->comp;
+		ofi_cq_err_memcpy(api_version, buf, &aux_entry->comp);
 		memcpy(err_buf_save, aux_entry->comp.err_data, err_data_size);
 		buf->err_data = err_buf_save;
 		buf->err_data_size = err_data_size;


### PR DESCRIPTION
fi_cq_err_entry::src_addr can be used by CQ errors to report a source address. How this field will be used to CQ error event specific.