### PR TITLE
Support for max_ep_auth_key

### DIFF
--- a/include/ofi_abi.h
+++ b/include/ofi_abi.h
@@ -111,7 +111,7 @@ extern "C" {
  * name appended with the ABI version that it is compatible with.
  */
 
-#define CURRENT_ABI "FABRIC_1.6"
+#define CURRENT_ABI "FABRIC_1.7"
 
 #if  HAVE_ALIAS_ATTRIBUTE == 1
 #define DEFAULT_SYMVER_PRE(a) a##_

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -449,6 +449,7 @@ struct fi_domain_attr {
 	size_t			max_err_data;
 	size_t			mr_cnt;
 	uint32_t		tclass;
+	size_t			max_ep_auth_key;
 };
 
 struct fi_fabric_attr {

--- a/libfabric.map.in
+++ b/libfabric.map.in
@@ -53,3 +53,10 @@ FABRIC_1.6 {
 	global:
 		fi_log_ready;
 } FABRIC_1.5;
+
+FABRIC_1.7 {
+	global:
+		fi_getinfo;
+		fi_freeinfo;
+		fi_dupinfo;
+} FABRIC_1.6;

--- a/man/fabric.7.md
+++ b/man/fabric.7.md
@@ -389,6 +389,14 @@ call.
 
 ABI version starting with libfabric 1.14.  Added fi_log_ready for providers.
 
+## ABI 1.7
+
+ABI version starting with libfabric 1.20. Added new fields to the following
+attributes:
+
+*fi_domain_attr*
+: Added max_ep_auth_key
+
 # SEE ALSO
 
 [`fi_info`(1)](fi_info.1.html),

--- a/man/fi_domain.3.md
+++ b/man/fi_domain.3.md
@@ -214,6 +214,7 @@ struct fi_domain_attr {
 	size_t                max_err_data;
 	size_t                mr_cnt;
 	uint32_t              tclass;
+	size_t                max_ep_auth_key;
 };
 ```
 
@@ -771,6 +772,11 @@ provider to optimize any memory registration cache or lookup tables.
 This specifies the default traffic class that will be associated any endpoints
 created within the domain.  See [`fi_endpoint`(3)](fi_endpoint.3.html)
 for additional information.
+
+## Max Authorization Keys per Endpoint (max_ep_auth_key)
+
+: The maximum number of authorization keys which can be supported per connectionless
+  endpoint.
 
 # RETURN VALUE
 

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -1187,6 +1187,8 @@ static void fi_alter_domain_attr(struct fi_domain_attr *attr,
 		attr->data_progress = hints->data_progress;
 	if (hints->av_type)
 		attr->av_type = hints->av_type;
+	if (hints->max_ep_auth_key)
+		attr->max_ep_auth_key = hints->max_ep_auth_key;
 }
 
 static void fi_alter_ep_attr(struct fi_ep_attr *attr,

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -661,6 +661,13 @@ int ofi_check_domain_attr(const struct fi_provider *prov, uint32_t api_version,
 		return -FI_ENODATA;
 	}
 
+	if (FI_VERSION_GE(api_version, FI_VERSION(1, 20)) &&
+	    user_attr->max_ep_auth_key > prov_attr->max_ep_auth_key) {
+		OFI_INFO_CHECK_SIZE(prov, prov_attr, user_attr,
+				    max_ep_auth_key);
+		return -FI_ENODATA;
+	}
+
 	return 0;
 }
 

--- a/src/abi_1_0.c
+++ b/src/abi_1_0.c
@@ -196,14 +196,59 @@ struct fi_info_1_2 {
         struct fid_nic_1_2        *nic;
 };
 
-/*
+struct fi_domain_attr_1_3 {
+	struct fid_domain	*domain;
+	char			*name;
+	enum fi_threading	threading;
+	enum fi_progress	control_progress;
+	enum fi_progress	data_progress;
+	enum fi_resource_mgmt	resource_mgmt;
+	enum fi_av_type		av_type;
+	int			mr_mode;
+	size_t			mr_key_size;
+	size_t			cq_data_size;
+	size_t			cq_cnt;
+	size_t			ep_cnt;
+	size_t			tx_ctx_cnt;
+	size_t			rx_ctx_cnt;
+	size_t			max_ep_tx_ctx;
+	size_t			max_ep_rx_ctx;
+	size_t			max_ep_stx_ctx;
+	size_t			max_ep_srx_ctx;
+	size_t			cntr_cnt;
+	size_t			mr_iov_limit;
+	uint64_t		caps;
+	uint64_t		mode;
+	uint8_t			*auth_key;
+	size_t 			auth_key_size;
+	size_t			max_err_data;
+	size_t			mr_cnt;
+	uint32_t		tclass;
+};
+
 #define fi_tx_attr_1_3 fi_tx_attr
 #define fi_rx_attr_1_3 fi_rx_attr_1_2
 #define fi_ep_attr_1_3 fi_ep_attr_1_2
-#define fi_domain_attr_1_3 fi_domain_attr
 #define fi_fabric_attr_1_3 fi_fabric_attr_1_2
-fi_info_1_3 -> fi_info
-*/
+#define fid_nic_1_3 fid_nic_1_2
+
+struct fi_info_1_3 {
+        struct fi_info            *next;
+        uint64_t                  caps;
+        uint64_t                  mode;
+        uint32_t                  addr_format;
+        size_t                    src_addrlen;
+        size_t                    dest_addrlen;
+        void                      *src_addr;
+        void                      *dest_addr;
+        fid_t                     handle;
+        struct fi_tx_attr_1_3     *tx_attr;
+        struct fi_rx_attr_1_3     *rx_attr;
+        struct fi_ep_attr_1_3     *ep_attr;
+        struct fi_domain_attr_1_3 *domain_attr;
+        struct fi_fabric_attr_1_3 *fabric_attr;
+        struct fid_nic_1_3        *nic;
+};
 
 #define ofi_dup_attr(dst, src)				\
 	do {						\
@@ -524,3 +569,55 @@ int fi_getinfo_1_2(uint32_t version, const char *node, const char *service,
 	return ret;
 }
 COMPAT_SYMVER(fi_getinfo_1_2, fi_getinfo, FABRIC_1.2);
+
+/*
+ * ABI 1.3
+ */
+__attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
+void fi_freeinfo_1_3(struct fi_info_1_3 *info)
+{
+	fi_freeinfo((struct fi_info *) info);
+}
+COMPAT_SYMVER(fi_freeinfo_1_3, fi_freeinfo, FABRIC_1.3);
+
+__attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
+struct fi_info_1_3 *fi_dupinfo_1_3(const struct fi_info_1_3 *info)
+{
+	struct fi_info *dup, *base;
+
+	if (!info)
+		return (struct fi_info_1_3 *) ofi_allocinfo_internal();
+
+	ofi_dup_info(base, info);
+	if (base == NULL)
+		return NULL;
+
+	dup = fi_dupinfo(base);
+
+	ofi_free_info(base);
+	return (struct fi_info_1_3 *) dup;
+}
+COMPAT_SYMVER(fi_dupinfo_1_3, fi_dupinfo, FABRIC_1.3);
+
+__attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
+int fi_getinfo_1_3(uint32_t version, const char *node, const char *service,
+		   uint64_t flags, const struct fi_info_1_3 *hints_1_3,
+		   struct fi_info_1_3 **info)
+{
+	struct fi_info *hints;
+	int ret;
+
+	if (hints_1_3) {
+		hints = (struct fi_info *) fi_dupinfo_1_3(hints_1_3);
+		if (!hints)
+			return -FI_ENOMEM;
+	} else {
+		hints = NULL;
+	}
+	ret = fi_getinfo(version, node, service, flags, hints,
+			 (struct fi_info **) info);
+	fi_freeinfo(hints);
+
+	return ret;
+}
+COMPAT_SYMVER(fi_getinfo_1_3, fi_getinfo, FABRIC_1.3);

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -990,7 +990,7 @@ void DEFAULT_SYMVER_PRE(fi_freeinfo)(struct fi_info *info)
 		free(info);
 	}
 }
-DEFAULT_SYMVER(fi_freeinfo_, fi_freeinfo, FABRIC_1.3);
+CURRENT_SYMVER(fi_freeinfo_, fi_freeinfo);
 
 static bool
 ofi_info_match_prov(struct fi_info *info, struct ofi_info_match *match)
@@ -1328,7 +1328,7 @@ int DEFAULT_SYMVER_PRE(fi_getinfo)(uint32_t version, const char *node,
 
 	return *info ? 0 : -FI_ENODATA;
 }
-DEFAULT_SYMVER(fi_getinfo_, fi_getinfo, FABRIC_1.3);
+CURRENT_SYMVER(fi_getinfo_, fi_getinfo);
 
 struct fi_info *ofi_allocinfo_internal(void)
 {
@@ -1459,7 +1459,7 @@ fail:
 	fi_freeinfo(dup);
 	return NULL;
 }
-DEFAULT_SYMVER(fi_dupinfo_, fi_dupinfo, FABRIC_1.3);
+CURRENT_SYMVER(fi_dupinfo_, fi_dupinfo);
 
 __attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
 int DEFAULT_SYMVER_PRE(fi_fabric)(struct fi_fabric_attr *attr,

--- a/src/log.c
+++ b/src/log.c
@@ -343,7 +343,7 @@ int DEFAULT_SYMVER_PRE(fi_log_ready)(const struct fi_provider *prov,
 
 	return log_fid.ops->ready(prov, level, subsys, flags, showtime);
 }
-CURRENT_SYMVER(fi_log_ready_, fi_log_ready);
+DEFAULT_SYMVER(fi_log_ready_, fi_log_ready, FABRIC_1.6);
 
 __attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
 void DEFAULT_SYMVER_PRE(fi_log)(const struct fi_provider *prov, enum fi_log_level level,


### PR DESCRIPTION
Since both of this changes require ABI updates, I decided to include them in the same PR. If it is easier to have these changes in separate PRs, I can separate it out.

Update: the optional_caps changes have been removed.