### PR TITLE
core, fabtests, prov/verbs: Add base_addr to fi_mr_dmabuf

### DIFF
--- a/fabtests/component/dmabuf-rdma/fi-mr-reg-xe.c
+++ b/fabtests/component/dmabuf-rdma/fi-mr-reg-xe.c
@@ -177,6 +177,7 @@ void reg_dmabuf_mr(void)
 		.fd = xe_get_buf_fd(buf),
 		.offset = 0,
 		.len = buf_size,
+		.base_addr = NULL,
 	};
 	struct fi_mr_attr mr_attr = {
 		.dmabuf = &dmabuf,

--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -139,6 +139,7 @@ struct fi_mr_dmabuf {
 	int		fd;
 	uint64_t	offset;
 	size_t		len;
+	void 		*base_addr;
 };
 
 struct fi_mr_attr {

--- a/man/fi_mr.3.md
+++ b/man/fi_mr.3.md
@@ -543,6 +543,10 @@ by iov_count.
 
 ## dmabuf
 
+DMA-buf registrations are used to share device memory between a given
+device and the fabric NIC and does not require that the device memory
+be mmap'ed into the virtual address space of the calling process.
+
 This structure references a DMA-buf backed device memory region.  This field
 is only usable if the application has successfully requested support for
 FI_HMEM and the FI_MR_DMABUF flag is passed into the memory registration
@@ -554,17 +558,20 @@ struct fi_mr_dmabuf {
 	int      fd;
 	uint64_t offset;
 	size_t   len;
+	void     *base_addr;
 };
 ```
 The fd is the file descriptor associated with the DMA-buf region.  The
 offset is the offset into the region where the memory registration should
 begin.  And len is the size of the region to register, starting at the
-offset.  The selection of dmabuf over the mr_iov field is controlled by
-specifying the FI_MR_DMABUF flag.
+offset. The base_addr is the page-aligned starting virtual address of
+the memory region allocated by the DMA-buf. If a base virtual address
+is not available (because, for example, the calling process has not
+mapped the memory region into its address space), base_addr can be
+set to NULL.
 
-DMA-buf registrations are used to share device memory between a given
-device and the fabric NIC and does not require that the device memory
-be mmap'ed into the virtual address space of the calling process.
+The selection of dmabuf over the mr_iov field is controlled by
+specifying the FI_MR_DMABUF flag.
 
 ## iov_count
 


### PR DESCRIPTION
base_addr field can be used to pass in the virtual address of the memory region to be registered