### PR TITLE
prov/util: Revert ofi_genlock changes completely

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -504,7 +504,7 @@ struct util_cq {
 	struct util_wait	*wait;
 	ofi_atomic32_t		ref;
 	struct dlist_entry	ep_list;
-	struct ofi_genlock	ep_list_lock;
+	ofi_mutex_t		ep_list_lock;
 	struct ofi_genlock	cq_lock;
 	uint64_t		flags;
 

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -1135,12 +1135,8 @@ struct fid_list_entry {
 
 int fid_list_insert(struct dlist_entry *fid_list, ofi_mutex_t *lock,
 		    struct fid *fid);
-int fid_list_insert2(struct dlist_entry *fid_list, struct ofi_genlock *lock,
-		     struct fid *fid);
 void fid_list_remove(struct dlist_entry *fid_list, ofi_mutex_t *lock,
 		     struct fid *fid);
-void fid_list_remove2(struct dlist_entry *fid_list, struct ofi_genlock *lock,
-		      struct fid *fid);
 int fid_list_search(struct dlist_entry *fid_list, struct fid *fid);
 
 

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -881,7 +881,7 @@ struct util_av {
 	 */
 	size_t			context_offset;
 	struct dlist_entry	ep_list;
-	struct ofi_genlock	ep_list_lock;
+	ofi_mutex_t		ep_list_lock;
 	void			(*remove_handler)(struct util_ep *util_ep,
 						  struct util_peer_addr *peer);
 };

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -731,7 +731,7 @@ struct util_cntr {
 	uint64_t		checkpoint_err;
 
 	struct dlist_entry	ep_list;
-	struct ofi_genlock	ep_list_lock;
+	ofi_mutex_t		ep_list_lock;
 
 	int			internal_wait;
 	ofi_cntr_progress_func	progress;

--- a/prov/rxd/src/rxd_cntr.c
+++ b/prov/rxd/src/rxd_cntr.c
@@ -60,7 +60,7 @@ static int rxd_cntr_wait(struct fid_cntr *cntr_fid, uint64_t threshold, int time
 			return -FI_ETIMEDOUT;
 
 		ep_retry = -1;
-		ofi_genlock_lock(&cntr->ep_list_lock);
+		ofi_mutex_lock(&cntr->ep_list_lock);
 		dlist_foreach_container(&cntr->ep_list, struct fid_list_entry,
 					fid_entry, entry) {
 			ep = container_of(fid_entry->fid, struct rxd_ep,
@@ -70,7 +70,7 @@ static int rxd_cntr_wait(struct fid_cntr *cntr_fid, uint64_t threshold, int time
 			ep_retry = ep_retry == -1 ? ep->next_retry :
 					MIN(ep_retry, ep->next_retry);
 		}
-		ofi_genlock_unlock(&cntr->ep_list_lock);
+		ofi_mutex_unlock(&cntr->ep_list_lock);
 
 		ret = fi_wait(&cntr->wait->wait_fid, ep_retry == -1 ?
 			      timeout : rxd_get_timeout(ep_retry));

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -52,7 +52,7 @@ static const char *rxd_cq_strerror(struct fid_cq *cq_fid, int prov_errno,
 
 	cq = container_of(cq_fid, struct rxd_cq, util_cq.cq_fid);
 
-	ofi_genlock_lock(&cq->util_cq.ep_list_lock);
+	ofi_mutex_lock(&cq->util_cq.ep_list_lock);
 	assert(!dlist_empty(&cq->util_cq.ep_list));
 	fid_entry = container_of(cq->util_cq.ep_list.next,
 				struct fid_list_entry, entry);
@@ -60,7 +60,7 @@ static const char *rxd_cq_strerror(struct fid_cq *cq_fid, int prov_errno,
 	ep = container_of(util_ep, struct rxd_ep, util_ep);
 
 	str = fi_cq_strerror(ep->dg_cq, prov_errno, err_data, buf, len);
-	ofi_genlock_unlock(&cq->util_cq.ep_list_lock);
+	ofi_mutex_unlock(&cq->util_cq.ep_list_lock);
 	return str;
 }
 
@@ -1257,7 +1257,7 @@ ssize_t rxd_cq_sreadfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 		}
 
 		ep_retry = -1;
-		ofi_genlock_lock(&cq->ep_list_lock);
+		ofi_mutex_lock(&cq->ep_list_lock);
 		dlist_foreach_container(&cq->ep_list, struct fid_list_entry,
 					fid_entry, entry) {
 			ep = container_of(fid_entry->fid, struct rxd_ep,
@@ -1267,7 +1267,7 @@ ssize_t rxd_cq_sreadfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 			ep_retry = ep_retry == -1 ? ep->next_retry :
 					MIN(ep_retry, ep->next_retry);
 		}
-		ofi_genlock_unlock(&cq->ep_list_lock);
+		ofi_mutex_unlock(&cq->ep_list_lock);
 
 		ret = fi_wait(&cq->wait->wait_fid, ep_retry == -1 ?
 			      timeout : rxd_get_timeout(ep_retry));

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -881,7 +881,7 @@ static int smr_ep_bind_cq(struct smr_ep *ep, struct util_cq *cq, uint64_t flags)
 			return ret;
 	}
 
-	ret = fid_list_insert2(&cq->ep_list,
+	ret = fid_list_insert(&cq->ep_list,
 			      &cq->ep_list_lock,
 			      &ep->util_ep.ep_fid.fid);
 

--- a/prov/sm2/src/sm2_ep.c
+++ b/prov/sm2/src/sm2_ep.c
@@ -311,8 +311,8 @@ static int sm2_ep_bind_cq(struct sm2_ep *ep, struct util_cq *cq, uint64_t flags)
 			return ret;
 	}
 
-	ret = fid_list_insert2(&cq->ep_list, &cq->ep_list_lock,
-			       &ep->util_ep.ep_fid.fid);
+	ret = fid_list_insert(&cq->ep_list, &cq->ep_list_lock,
+			      &ep->util_ep.ep_fid.fid);
 
 	return ret;
 }

--- a/prov/udp/src/udpx_ep.c
+++ b/prov/udp/src/udpx_ep.c
@@ -563,7 +563,7 @@ static int udpx_ep_close(struct fid *fid)
 					    struct util_wait_fd, util_wait);
 			ofi_epoll_del(wait->epoll_fd, (int)ep->sock);
 		}
-		fid_list_remove2(&ep->util_ep.rx_cq->ep_list,
+		fid_list_remove(&ep->util_ep.rx_cq->ep_list,
 				&ep->util_ep.rx_cq->ep_list_lock,
 				&ep->util_ep.ep_fid.fid);
 	}
@@ -614,7 +614,7 @@ static int udpx_ep_bind_cq(struct udpx_ep *ep, struct util_cq *cq,
 				udpx_rx_src_comp : udpx_rx_comp;
 		}
 
-		ret = fid_list_insert2(&cq->ep_list,
+		ret = fid_list_insert(&cq->ep_list,
 				      &cq->ep_list_lock,
 				      &ep->util_ep.ep_fid.fid);
 		if (ret)

--- a/prov/util/src/rxm_av.c
+++ b/prov/util/src/rxm_av.c
@@ -249,13 +249,13 @@ static int rxm_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr,
 			(*peer)->refcnt++;
 			ofi_mutex_unlock(&av->util_av.lock);
 
-			ofi_genlock_lock(&av->util_av.ep_list_lock);
+			ofi_mutex_lock(&av->util_av.ep_list_lock);
 			dlist_foreach(&av->util_av.ep_list, item) {
 				util_ep = container_of(item, struct util_ep,
 						       av_entry);
 				av->util_av.remove_handler(util_ep, *peer);
 			}
-			ofi_genlock_unlock(&av->util_av.ep_list_lock);
+			ofi_mutex_unlock(&av->util_av.ep_list_lock);
 
 			ofi_mutex_lock(&av->util_av.lock);
 			util_deref_peer(*peer);

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -403,7 +403,7 @@ int ofi_av_close_lightweight(struct util_av *av)
 	if (av->eq)
 		ofi_atomic_dec32(&av->eq->ref);
 
-	ofi_genlock_destroy(&av->ep_list_lock);
+	ofi_mutex_destroy(&av->ep_list_lock);
 
 	ofi_atomic_dec32(&av->domain->ref);
 	ofi_mutex_destroy(&av->lock);
@@ -552,9 +552,7 @@ int ofi_av_init_lightweight(struct util_domain *domain, const struct fi_av_attr 
 	 */
 	av->context = context;
 	av->domain = domain;
-	ofi_genlock_init(&av->ep_list_lock,
-			 domain->threading == FI_THREAD_DOMAIN ?
-			       OFI_LOCK_NOOP : OFI_LOCK_MUTEX);
+	ofi_mutex_init(&av->ep_list_lock);
 	dlist_init(&av->ep_list);
 	ofi_atomic_inc32(&domain->ref);
 	return 0;

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -552,7 +552,9 @@ int ofi_av_init_lightweight(struct util_domain *domain, const struct fi_av_attr 
 	 */
 	av->context = context;
 	av->domain = domain;
-	ofi_genlock_init(&av->ep_list_lock, OFI_LOCK_MUTEX);
+	ofi_genlock_init(&av->ep_list_lock,
+			 domain->threading == FI_THREAD_DOMAIN ?
+			       OFI_LOCK_NOOP : OFI_LOCK_MUTEX);
 	dlist_init(&av->ep_list);
 	ofi_atomic_inc32(&domain->ref);
 	return 0;

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -707,8 +707,7 @@ int ofi_cq_init(const struct fi_provider *prov, struct fid_domain *domain,
 	if (ret)
 		goto destroy1;
 
-	/* TODO Figure out how to optimize this lock for rdm and msg endpoints */
-	ret = ofi_genlock_init(&cq->ep_list_lock, OFI_LOCK_MUTEX);
+	ret = ofi_genlock_init(&cq->ep_list_lock, lock_type);
 	if (ret)
 		return ret;
 

--- a/prov/util/src/util_ep.c
+++ b/prov/util/src/util_ep.c
@@ -64,7 +64,7 @@ int ofi_ep_bind_cq(struct util_ep *ep, struct util_cq *cq, uint64_t flags)
 	}
 
 	if (flags & (FI_TRANSMIT | FI_RECV)) {
-		return fid_list_insert2(&cq->ep_list,
+		return fid_list_insert(&cq->ep_list,
 				       &cq->ep_list_lock,
 				       &ep->ep_fid.fid);
 	}
@@ -272,14 +272,14 @@ int ofi_endpoint_close(struct util_ep *util_ep)
 	int i;
 
 	if (util_ep->tx_cq) {
-		fid_list_remove2(&util_ep->tx_cq->ep_list,
+		fid_list_remove(&util_ep->tx_cq->ep_list,
 				&util_ep->tx_cq->ep_list_lock,
 				&util_ep->ep_fid.fid);
 		ofi_atomic_dec32(&util_ep->tx_cq->ref);
 	}
 
 	if (util_ep->rx_cq) {
-		fid_list_remove2(&util_ep->rx_cq->ep_list,
+		fid_list_remove(&util_ep->rx_cq->ep_list,
 				&util_ep->rx_cq->ep_list_lock,
 				&util_ep->ep_fid.fid);
 		ofi_atomic_dec32(&util_ep->rx_cq->ref);

--- a/prov/util/src/util_ep.c
+++ b/prov/util/src/util_ep.c
@@ -157,7 +157,7 @@ int ofi_ep_bind_cntr(struct util_ep *ep, struct util_cntr *cntr, uint64_t flags)
 
 	ep->flags |= OFI_CNTR_ENABLED;
 
-	return fid_list_insert2(&cntr->ep_list, &cntr->ep_list_lock,
+	return fid_list_insert(&cntr->ep_list, &cntr->ep_list_lock,
 			       &ep->ep_fid.fid);
 }
 
@@ -287,7 +287,7 @@ int ofi_endpoint_close(struct util_ep *util_ep)
 
 	for (i = 0; i < CNTR_CNT; i++) {
 		if (util_ep->cntrs[i]) {
-			fid_list_remove2(&util_ep->cntrs[i]->ep_list,
+			fid_list_remove(&util_ep->cntrs[i]->ep_list,
 					&util_ep->cntrs[i]->ep_list_lock,
 					&util_ep->ep_fid.fid);
 			ofi_atomic_dec32(&util_ep->cntrs[i]->ref);

--- a/prov/util/src/util_ep.c
+++ b/prov/util/src/util_ep.c
@@ -92,9 +92,9 @@ int ofi_ep_bind_av(struct util_ep *util_ep, struct util_av *av)
 	util_ep->av = av;
 	ofi_atomic_inc32(&av->ref);
 
-	ofi_genlock_lock(&av->ep_list_lock);
+	ofi_mutex_lock(&av->ep_list_lock);
 	dlist_insert_tail(&util_ep->av_entry, &av->ep_list);
-	ofi_genlock_unlock(&av->ep_list_lock);
+	ofi_mutex_unlock(&av->ep_list_lock);
 
 	return 0;
 }
@@ -295,9 +295,9 @@ int ofi_endpoint_close(struct util_ep *util_ep)
 	}
 
 	if (util_ep->av) {
-		ofi_genlock_lock(&util_ep->av->ep_list_lock);
+		ofi_mutex_lock(&util_ep->av->ep_list_lock);
 		dlist_remove(&util_ep->av_entry);
-		ofi_genlock_unlock(&util_ep->av->ep_list_lock);
+		ofi_mutex_unlock(&util_ep->av->ep_list_lock);
 
 		ofi_atomic_dec32(&util_ep->av->ref);
 	}

--- a/prov/util/src/util_ep.c
+++ b/prov/util/src/util_ep.c
@@ -247,8 +247,9 @@ int ofi_endpoint_init(struct fid_domain *domain, const struct util_prov *util_pr
 	if (util_domain->eq)
 		ofi_ep_bind_eq(ep, util_domain->eq);
 
-	/* TODO Figure out how to optimize this lock for rdm and msg endpoints */
-	ret = ofi_genlock_init(&ep->lock, OFI_LOCK_MUTEX);
+	ret = ofi_genlock_init(&ep->lock,
+			       ep->domain->threading != FI_THREAD_SAFE ?
+			       OFI_LOCK_NOOP : OFI_LOCK_MUTEX);
 	if (ret)
 		return ret;
 

--- a/prov/util/src/util_main.c
+++ b/prov/util/src/util_main.c
@@ -105,18 +105,6 @@ int fid_list_insert(struct dlist_entry *fid_list, ofi_mutex_t *lock,
 	return (!ret || (ret == -FI_EALREADY)) ? 0 : ret;
 }
 
-int fid_list_insert2(struct dlist_entry *fid_list, struct ofi_genlock *lock,
-		    struct fid *fid)
-{
-	int ret = 0;
-
-	ofi_genlock_lock(lock);
-	ret = fid_list_search(fid_list, fid);
-	ofi_genlock_unlock(lock);
-
-	return (!ret || (ret == -FI_EALREADY)) ? 0 : ret;
-}
-
 void fid_list_remove(struct dlist_entry *fid_list, ofi_mutex_t *lock,
 		     struct fid *fid)
 {
@@ -128,22 +116,6 @@ void fid_list_remove(struct dlist_entry *fid_list, ofi_mutex_t *lock,
 	entry = dlist_remove_first_match(fid_list, ofi_fid_match, fid);
 	if (lock)
 		ofi_mutex_unlock(lock);
-
-	if (entry) {
-		item = container_of(entry, struct fid_list_entry, entry);
-		free(item);
-	}
-}
-
-void fid_list_remove2(struct dlist_entry *fid_list, struct ofi_genlock *lock,
-		      struct fid *fid)
-{
-	struct fid_list_entry *item;
-	struct dlist_entry *entry;
-
-	ofi_genlock_lock(lock);
-	entry = dlist_remove_first_match(fid_list, ofi_fid_match, fid);
-	ofi_genlock_unlock(lock);
 
 	if (entry) {
 		item = container_of(entry, struct fid_list_entry, entry);


### PR DESCRIPTION
Completely reverting the ofi_genlock changes from main saves us 20ns in fi_rdm_tagged_pingpong for the SHM provider.

instance: aws c5n.18xlarge
os: al2
client: fi_rdm_tagged_pingpong --pin-core 1 -S 1 -s 127.0.0.1 -p shm 127.0.0.1
server: fi_rdm_tagged_pingpong --pin-core 0 -S 1 -s 127.0.0.1 -p shm

main @ 8db85946d (has genlocks that are always mutex): .48us
git revert 64b31bea3 is .45us  (my changes to make us have genlocks with no mutex)
git revert 96f35fa29a2e60b3c8f6828c78162488fd80dd59 36703606af7c1627b02feae391190f3d280eb6c6 1c4e8ea9daedbef97908b18390910fb1d3fa3624 0d398560ca50ee9ac27b941be9a2e236c7c74402 is .46us  (ofi_mutex directly)