### PR TITLE
[v1.19.x] prov/efa: do not insert shm av inside efa progress engine

### DIFF
--- a/prov/efa/src/efa_av.h
+++ b/prov/efa/src/efa_av.h
@@ -108,7 +108,8 @@ int efa_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 		struct fid_av **av_fid, void *context);
 
 int efa_av_insert_one(struct efa_av *av, struct efa_ep_addr *addr,
-		      fi_addr_t *fi_addr, uint64_t flags, void *context);
+		      fi_addr_t *fi_addr, uint64_t flags, void *context,
+		      bool insert_shm_av);
 
 struct efa_conn *efa_av_addr_to_conn(struct efa_av *av, fi_addr_t fi_addr);
 

--- a/prov/efa/src/rdm/efa_rdm_pke_cmd.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_cmd.c
@@ -739,8 +739,15 @@ fi_addr_t efa_rdm_pke_insert_addr(struct efa_rdm_pke *pkt_entry, void *raw_addr)
 
 	assert(base_hdr->type >= EFA_RDM_REQ_PKT_BEGIN);
 
+	/*
+	 * The message is from a peer through efa device, which means peer is not local
+	 * or shm is disabled for transmission.
+	 * We shouldn't insert shm av anyway in this case.
+	 * Also, calling fi_av_insert internally inside progress engine is violating
+	 * Libfabric standard for FI_AV_TABLE.
+	 */
 	ret = efa_av_insert_one(ep->base_ep.av, (struct efa_ep_addr *)raw_addr,
-	                        &rdm_addr, 0, NULL);
+	                        &rdm_addr, 0, NULL, false);
 	if (OFI_UNLIKELY(ret != 0)) {
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_EINVAL, FI_EFA_ERR_AV_INSERT);
 		return -1;


### PR DESCRIPTION
Currently, efa progress engine will call efa_av_insert_one() when it gets a message from unknown peer through efa device. which means peer is not local or shm is disabled for transmission. We shouldn't insert shm av anyway in this case.
Also, calling fi_av_insert internally inside progress engine is violating Libfabric standard for FI_AV_TABLE.

Signed-off-by: Shi Jin <sjina@amazon.com>
(cherry picked from commit c68c5b3c94f3ced1b53fb98a49ba340a0dfb069d)