### PR TITLE
rxm: use `gdrcopy` for injection

### DIFF
--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -451,6 +451,7 @@
     <ClCompile Include="prov\rxm\src\rxm_domain.c" />
     <ClCompile Include="prov\rxm\src\rxm_ep.c" />
     <ClCompile Include="prov\rxm\src\rxm_eq.c" />
+    <ClCompile Include="prov\rxm\src\rxm_hmem.c" />
     <ClCompile Include="prov\rxm\src\rxm_fabric.c" />
     <ClCompile Include="prov\rxm\src\rxm_atomic.c" />
     <ClCompile Include="prov\rxm\src\rxm_init.c">

--- a/libfabric.vcxproj.filters
+++ b/libfabric.vcxproj.filters
@@ -408,6 +408,9 @@
     <ClCompile Include="prov\rxm\src\rxm_ep.c">
       <Filter>Source Files\prov\rxm\src</Filter>
     </ClCompile>
+    <ClCompile Include="prov\rxm\src\rxm_hmem.c">
+      <Filter>Source Files\prov\rxm\src</Filter>
+    </ClCompile>
     <ClCompile Include="prov\rxm\src\rxm_eq.c">
       <Filter>Source Files\prov\rxm\src</Filter>
     </ClCompile>

--- a/prov/rxm/Makefile.include
+++ b/prov/rxm/Makefile.include
@@ -12,6 +12,7 @@ _rxm_files = \
        prov/rxm/src/rxm_rma.c	\
        prov/rxm/src/rxm_atomic.c	\
        prov/rxm/src/rxm_eq.c	\
+       prov/rxm/src/rxm_hmem.c	\
        prov/rxm/src/rxm.h
 
 if HAVE_RXM_DL

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -303,6 +303,8 @@ struct rxm_mr {
 	struct rxm_domain *domain;
 	enum fi_hmem_iface iface;
 	uint64_t device;
+	void *hmem_handle;
+	uint64_t hmem_flags;
 	ofi_mutex_t amo_lock;
 };
 
@@ -773,6 +775,26 @@ void rxm_rndv_hdr_init(struct rxm_ep *rxm_ep, void *buf,
 			      const struct iovec *iov, size_t count,
 			      struct fid_mr **mr);
 
+ssize_t rxm_copy_hmem(void *desc, char *host_buf, void *dev_buf, size_t size,
+		      int dir);
+ssize_t rxm_copy_hmem_iov(void **desc, char *buf, size_t buf_size,
+			  const struct iovec *hmem_iov, int iov_count,
+			  size_t iov_offset, int dir);
+static inline ssize_t rxm_copy_from_hmem_iov(void **desc, char *buf,
+					     size_t buf_size,
+					     const struct iovec *hmem_iov,
+					     int iov_count, size_t iov_offset)
+{
+	return rxm_copy_hmem_iov(desc, buf, buf_size, hmem_iov, iov_count,
+				 iov_offset, OFI_COPY_IOV_TO_BUF);
+}
+static inline ssize_t rxm_copy_to_hmem_iov(void **desc, char *buf, int buf_size,
+					   const struct iovec *hmem_iov,
+					   int iov_count, size_t iov_offset)
+{
+	return rxm_copy_hmem_iov(desc, buf, buf_size, hmem_iov, iov_count,
+				 iov_offset, OFI_COPY_BUF_TO_IOV);
+}
 
 static inline size_t rxm_ep_max_atomic_size(struct fi_info *info)
 {

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -624,18 +624,10 @@ static ssize_t rxm_handle_rndv(struct rxm_rx_buf *rx_buf)
 
 void rxm_handle_eager(struct rxm_rx_buf *rx_buf)
 {
-	enum fi_hmem_iface iface;
-	uint64_t device;
-	ssize_t done_len;
-
-	iface = rxm_mr_desc_to_hmem_iface_dev(rx_buf->recv_entry->rxm_iov.desc,
-					      rx_buf->recv_entry->rxm_iov.count,
-					      &device);
-
-	done_len = ofi_copy_to_hmem_iov(iface, device,
-					rx_buf->recv_entry->rxm_iov.iov,
-					rx_buf->recv_entry->rxm_iov.count, 0,
-					rx_buf->data, rx_buf->pkt.hdr.size);
+	ssize_t done_len = rxm_copy_to_hmem_iov(
+		rx_buf->recv_entry->rxm_iov.desc, rx_buf->data,
+		rx_buf->pkt.hdr.size, rx_buf->recv_entry->rxm_iov.iov,
+		rx_buf->recv_entry->rxm_iov.count, 0);
 	assert((size_t) done_len == rx_buf->pkt.hdr.size);
 
 	rxm_finish_recv(rx_buf, done_len);

--- a/prov/rxm/src/rxm_hmem.c
+++ b/prov/rxm/src/rxm_hmem.c
@@ -1,0 +1,81 @@
+#include "rxm.h"
+
+/**
+ * @brief copy list of IOVs from/to the host to/from an hmem device
+ *
+ * @param buf       host buffer address
+ * @param buf_size  size of the host buffer
+ * @param hmem_iov  list of IOVs on the device
+ * @param iov_count number of IOVs in the list
+ * @param iov_offset offset in bytes in the IOVs struct (cummulative over IOVs)
+ *
+ * note: inspired by efa_copy_from/to_hmem_iov
+ */
+ssize_t rxm_copy_hmem_iov(void **desc, char *buf, size_t buf_size,
+			  const struct iovec *hmem_iov, int iov_count,
+			  size_t iov_offset, int dir)
+{
+	int i, ret = -1;
+	ssize_t data_size = 0;
+
+	for (i = 0; i < iov_count; i++) {
+		char *hmem_buf;
+		void *local_desc = (desc) ? desc[i] : NULL;
+		size_t len = ofi_iov_bytes_to_copy(hmem_iov + i, &buf_size,
+						   &iov_offset, &hmem_buf);
+		if (!len)
+			continue;
+
+		ret = rxm_copy_hmem(local_desc, buf + data_size, hmem_buf, len,
+				    dir);
+		if (ret)
+			return ret;
+
+		data_size += len;
+	}
+	return data_size;
+}
+
+/**
+ * @brief copy data from/to the host to/from an hmem device
+ *
+ * note: inspired by efa_copy_from/to_hmem
+ */
+ssize_t rxm_copy_hmem(void *desc, char *host_buf, void *dev_buf, size_t size,
+		      int dir)
+{
+	int ret = FI_SUCCESS;
+	uint64_t device = 0, flags = 0;
+	enum fi_hmem_iface iface = FI_HMEM_SYSTEM;
+	void *hmem_handle = NULL;
+
+	if (desc) {
+		iface = ((struct rxm_mr *) desc)->iface;
+		device = ((struct rxm_mr *) desc)->device;
+		flags = ((struct rxm_mr *) desc)->hmem_flags;
+		hmem_handle = ((struct rxm_mr *) desc)->hmem_handle;
+	}
+
+	if (flags & OFI_HMEM_DATA_DEV_REG_HANDLE) {
+		assert(hmem_handle);
+		/* TODO: Fine tune the max data size to switch from dev_reg copy
+		 * to ofi_hmem regular copy */
+		if (dir == OFI_COPY_IOV_TO_BUF) {
+			ofi_hmem_dev_reg_copy_from_hmem(
+				iface, (uint64_t) hmem_handle, host_buf,
+				dev_buf, size);
+		} else {
+			ofi_hmem_dev_reg_copy_to_hmem(iface,
+						      (uint64_t) hmem_handle,
+						      dev_buf, host_buf, size);
+		}
+		return FI_SUCCESS;
+	}
+	if (dir == OFI_COPY_IOV_TO_BUF) {
+		ret = ofi_copy_from_hmem(iface, device, host_buf, dev_buf,
+					 size);
+	} else {
+		ret = ofi_copy_to_hmem(iface, device, dev_buf, host_buf, size);
+	}
+	return ret;
+};

--- a/prov/rxm/src/rxm_msg.c
+++ b/prov/rxm/src/rxm_msg.c
@@ -650,8 +650,6 @@ rxm_send_eager(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	       uint8_t op, size_t data_len, size_t total_len)
 {
 	struct rxm_tx_buf *eager_buf;
-	enum fi_hmem_iface iface;
-	uint64_t device;
 	ssize_t ret;
 
 	eager_buf = rxm_get_tx_buf(rxm_ep);
@@ -672,11 +670,9 @@ rxm_send_eager(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	} else {
 		rxm_ep_format_tx_buf_pkt(rxm_conn, data_len, op, data, tag,
 					 flags, &eager_buf->pkt);
-
-		iface = rxm_mr_desc_to_hmem_iface_dev(desc, count, &device);
-		ret = ofi_copy_from_hmem_iov(eager_buf->pkt.data,
-					     eager_buf->pkt.hdr.size,
-					     iface, device, iov, count, 0);
+		ret = rxm_copy_from_hmem_iov(desc, eager_buf->pkt.data,
+					     eager_buf->pkt.hdr.size, iov,
+					     count, 0);
 		assert((size_t) ret == eager_buf->pkt.hdr.size);
 		ret = fi_send(rxm_conn->msg_ep, &eager_buf->pkt, total_len,
 			      eager_buf->hdr.desc, 0, eager_buf);

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -187,18 +187,12 @@ rxm_ep_format_rma_msg(struct rxm_tx_buf *rma_buf,
 		      struct iovec *rxm_iov, struct fi_msg_rma *rxm_msg)
 {
 	ssize_t ret __attribute__((unused));
-	enum fi_hmem_iface iface;
-	uint64_t device;
-
-	iface = rxm_mr_desc_to_hmem_iface_dev(orig_msg->desc,
-					      orig_msg->iov_count, &device);
-
 	rxm_msg->context = rma_buf;
 	rxm_msg->addr = orig_msg->addr;
 	rxm_msg->data = orig_msg->data;
 
-	ret = ofi_copy_from_hmem_iov(rma_buf->pkt.data, rma_buf->pkt.hdr.size,
-				     iface, device, orig_msg->msg_iov,
+	ret = rxm_copy_from_hmem_iov(orig_msg->desc, rma_buf->pkt.data,
+				     rma_buf->pkt.hdr.size, orig_msg->msg_iov,
 				     orig_msg->iov_count, 0);
 	assert((size_t) ret == rma_buf->pkt.hdr.size);
 


### PR DESCRIPTION
This PR adds the usage of gdrcopy when injection is used of send/recv and rma

- [x] grdcopy register is done as part of `fi_mr_regattr` and cleanup when closing the MR
- [x] used for eager send/recv
- [x] used when faking injection for RMA. When the base provider does the injection (e.g. `verbs`), nothing is done in `rxm`
- [x] ~used for SAR~ > I cannot get good performance with grdcopy and SAR

note: largely based on (https://github.com/ofiwg/libfabric/pull/8836)

comparison with and without gdrcopy (`FI_HMEM_CUDA_USE_GDRCOPY=0/1`):

<img width="776" alt="Screenshot 2023-10-19 at 9 59 49 PM" src="https://github.com/ofiwg/libfabric/assets/25429825/6f4666f1-0746-4a35-8d01-4d4a7ad51f62">


