### PR TITLE
mr_cache: Define ofi_mr_info::flags

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -56,6 +56,7 @@ struct ofi_mr_info {
 	struct iovec iov;
 	enum fi_hmem_iface iface;
 	uint64_t device;
+	uint64_t flags;
 
 	uint64_t peer_id;
 	void     *mapped_addr;


### PR DESCRIPTION
This can be used by providers to store flags, such as FI_HMEM_HOST_ALLOC or FI_HMEM_DEVICE_ONLY, with the MR.