### PR TITLE
hmem/cuda and prov/efa: update cuda_gdrcopy_dev_register's signature

### DIFF
--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -202,7 +202,7 @@ ssize_t ofi_gdrcopy_from_cuda_iov(uint64_t handle, void *host,
                                   uint64_t iov_offset, size_t len);
 int cuda_gdrcopy_hmem_init(void);
 int cuda_gdrcopy_hmem_cleanup(void);
-int cuda_gdrcopy_dev_register(struct fi_mr_attr *mr_attr, uint64_t *handle);
+int cuda_gdrcopy_dev_register(void *buf, size_t len, uint64_t *handle);
 int cuda_gdrcopy_dev_unregister(uint64_t handle);
 int cuda_set_sync_memops(void *ptr);
 

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -258,7 +258,7 @@ static int efa_mr_hmem_setup(struct efa_mr *efa_mr,
 		}
 
 		if (cuda_is_gdrcopy_enabled()) {
-			err = cuda_gdrcopy_dev_register(attr->mr_iov->iov_base, attr->mr_iov->iov_len,
+			err = ofi_hmem_dev_register(FI_HMEM_CUDA, attr->mr_iov->iov_base, attr->mr_iov->iov_len,
 							(uint64_t *)&efa_mr->peer.hmem_data);
 			efa_mr->peer.flags |= OFI_HMEM_DATA_GDRCOPY_HANDLE;
 			if (err) {
@@ -465,7 +465,7 @@ static int efa_mr_dereg_impl(struct efa_mr *efa_mr)
 	if (efa_mr->peer.iface == FI_HMEM_CUDA &&
 	    (efa_mr->peer.flags & OFI_HMEM_DATA_GDRCOPY_HANDLE)) {
 		assert(efa_mr->peer.hmem_data);
-		err = cuda_gdrcopy_dev_unregister((uint64_t)efa_mr->peer.hmem_data);
+		err = ofi_hmem_dev_unregister(FI_HMEM_CUDA, (uint64_t)efa_mr->peer.hmem_data);
 		if (err) {
 			EFA_WARN(FI_LOG_MR,
 				"Unable to de-register cuda handle\n");
@@ -857,7 +857,7 @@ static int efa_mr_reg_impl(struct efa_mr *efa_mr, uint64_t flags, const void *at
 			if (efa_mr->peer.iface == FI_HMEM_CUDA &&
 			    (efa_mr->peer.flags & OFI_HMEM_DATA_GDRCOPY_HANDLE)) {
 					assert(efa_mr->peer.hmem_data);
-					cuda_gdrcopy_dev_unregister((uint64_t)efa_mr->peer.hmem_data);
+					ofi_hmem_dev_unregister(FI_HMEM_CUDA, (uint64_t)efa_mr->peer.hmem_data);
 				}
 
 			return -errno;

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -258,7 +258,8 @@ static int efa_mr_hmem_setup(struct efa_mr *efa_mr,
 		}
 
 		if (cuda_is_gdrcopy_enabled()) {
-			err = cuda_gdrcopy_dev_register((struct fi_mr_attr *)attr, (uint64_t *)&efa_mr->peer.hmem_data);
+			err = cuda_gdrcopy_dev_register(attr->mr_iov->iov_base, attr->mr_iov->iov_len,
+							(uint64_t *)&efa_mr->peer.hmem_data);
 			efa_mr->peer.flags |= OFI_HMEM_DATA_GDRCOPY_HANDLE;
 			if (err) {
 				EFA_WARN(FI_LOG_MR,

--- a/src/hmem_cuda.c
+++ b/src/hmem_cuda.c
@@ -314,15 +314,7 @@ int cuda_copy_from_dev(uint64_t device, void *dst, const void *src, size_t size)
 
 int cuda_dev_register(const void *addr, size_t size, uint64_t *handle)
 {
-	struct fi_mr_attr mr_attr = {};
-	struct iovec iov = {};
-
-	iov.iov_base = (void *) addr;
-	iov.iov_len = size;
-	mr_attr.mr_iov = &iov;
-	mr_attr.iov_count = 1;
-
-	return cuda_gdrcopy_dev_register(&mr_attr, handle);
+	return cuda_gdrcopy_dev_register(addr, size, handle);
 }
 
 int cuda_dev_unregister(uint64_t handle)

--- a/src/hmem_cuda_gdrcopy.c
+++ b/src/hmem_cuda_gdrcopy.c
@@ -331,7 +331,7 @@ ssize_t ofi_gdrcopy_from_cuda_iov(uint64_t handle, void *host,
 	                            host, len, GDRCOPY_FROM_DEVICE);
 }
 
-int cuda_gdrcopy_dev_register(struct fi_mr_attr *mr_attr, uint64_t *handle)
+int cuda_gdrcopy_dev_register(void *buf, size_t len, uint64_t *handle)
 {
 	int err;
 	uintptr_t regbgn, regend;
@@ -342,8 +342,8 @@ int cuda_gdrcopy_dev_register(struct fi_mr_attr *mr_attr, uint64_t *handle)
 	assert(global_gdrcopy_ops.gdr_pin_buffer);
 	assert(global_gdrcopy_ops.gdr_map);
 
-	regbgn = (uintptr_t)ofi_get_page_start(mr_attr->mr_iov->iov_base, GPU_PAGE_SIZE);
-	regend = (uintptr_t)mr_attr->mr_iov->iov_base + mr_attr->mr_iov->iov_len;
+	regbgn = (uintptr_t)ofi_get_page_start(buf, GPU_PAGE_SIZE);
+	regend = (uintptr_t)buf + len;
 	reglen = ofi_get_aligned_size(regend - regbgn, GPU_PAGE_SIZE);
 
 	gdrcopy = malloc(sizeof(struct gdrcopy_handle));
@@ -357,7 +357,7 @@ int cuda_gdrcopy_dev_register(struct fi_mr_attr *mr_attr, uint64_t *handle)
 	if (err) {
 		FI_WARN(&core_prov, FI_LOG_CORE,
 			"gdr_pin_buffer failed! error: %s ptr: %p len: %ld\n",
-			strerror(err), mr_attr->mr_iov->iov_base, mr_attr->mr_iov->iov_len);
+			strerror(err), buf, len);
 		free(gdrcopy);
 		goto exit;
 	}
@@ -439,7 +439,7 @@ void cuda_gdrcopy_from_dev(uint64_t devhandle, void *hostptr,
 {
 }
 
-int cuda_gdrcopy_dev_register(struct fi_mr_attr *mr_attr, uint64_t *handle)
+int cuda_gdrcopy_dev_register(void *buf, size_t len, uint64_t *handle)
 {
 	return FI_SUCCESS;
 }


### PR DESCRIPTION
cuda_gdrcopy_dev_register just needs the iov from the mr_attr as input. This can also remove the extra translation in cuda_dev_register.