### PR TITLE
prov/tcp: Correct setting of completion flags 

### DIFF
--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -688,11 +688,11 @@ class MpichTestSuite(Test):
         self.pwd = os.getcwd()
         self.weekly = weekly
         self.mpichtests_exclude = {
-        'tcp'   :   {   '.'        : [('spawn','dir'), ('rma','dir')],
-                    'threads'      : [('spawn','dir'), ('rma','dir')],
+        'tcp'   :   {   '.'        : [('spawn','dir')],
+                    'threads'      : [('spawn','dir')],
                     'threads/comm' : [('idup_nb 4','test'),
                                       ('idup_comm_gen 4','test')],
-                    'errors'       : [('spawn','dir'),('rma','dir')]
+                    'errors'       : [('spawn','dir')]
                 },
         'verbs' :   {   '.'        : [('spawn','dir')],
                     'threads/comm' : [('idup_nb 4','test')],

--- a/prov/tcp/src/xnet.h
+++ b/prov/tcp/src/xnet.h
@@ -583,18 +583,27 @@ xnet_set_commit_flags(struct xnet_xfer_entry *xfer, uint64_t flags)
 }
 
 static inline uint64_t
-xnet_tx_completion_flag(struct xnet_ep *ep, uint64_t op_flags)
+xnet_tx_completion_get_msgflags(struct xnet_ep *ep, uint64_t flags)
 {
-	/* Generate a completion if op flags indicate or we generate
-	 * completions by default
+	/* Generate a completion if msg flags indicate or app
+	 * requests
 	 */
-	return (ep->util_ep.tx_op_flags | op_flags) & FI_COMPLETION;
+	return (ep->util_ep.tx_msg_flags | flags) & FI_COMPLETION;
 }
 
 static inline uint64_t
 xnet_rx_completion_flag(struct xnet_ep *ep)
 {
 	return ep->util_ep.rx_op_flags & FI_COMPLETION;
+}
+
+static inline uint64_t
+xnet_tx_completion_get_opflags(struct xnet_ep *ep)
+{
+	/* Generate a completion if op flags indicate or we generate
+	 * completions by default
+	 */
+	return ep->util_ep.tx_op_flags & FI_COMPLETION;
 }
 
 static inline struct xnet_xfer_entry *

--- a/prov/tcp/src/xnet_msg.c
+++ b/prov/tcp/src/xnet_msg.c
@@ -340,7 +340,7 @@ xnet_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t flags)
 	}
 
 	xnet_init_tx_iov(tx_entry, hdr_len, msg->msg_iov, msg->iov_count);
-	tx_entry->cq_flags = xnet_tx_completion_flag(ep, flags) |
+	tx_entry->cq_flags = xnet_tx_completion_get_msgflags(ep, flags) |
 			     FI_MSG | FI_SEND;
 	xnet_set_ack_flags(tx_entry, flags);
 	tx_entry->context = msg->context;
@@ -370,7 +370,7 @@ xnet_send(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	xnet_init_tx_buf(tx_entry, sizeof(tx_entry->hdr.base_hdr), buf, len);
 	tx_entry->context = context;
-	tx_entry->cq_flags = xnet_tx_completion_flag(ep, 0) |
+	tx_entry->cq_flags = xnet_tx_completion_get_opflags(ep) |
 			     FI_MSG | FI_SEND;
 	xnet_set_ack_flags(tx_entry, ep->util_ep.tx_op_flags);
 
@@ -399,7 +399,7 @@ xnet_sendv(struct fid_ep *ep_fid, const struct iovec *iov,
 
 	xnet_init_tx_iov(tx_entry, sizeof(tx_entry->hdr.base_hdr), iov, count);
 	tx_entry->context = context;
-	tx_entry->cq_flags = xnet_tx_completion_flag(ep, 0) |
+	tx_entry->cq_flags = xnet_tx_completion_get_opflags(ep) |
 			     FI_MSG | FI_SEND;
 	xnet_set_ack_flags(tx_entry, ep->util_ep.tx_op_flags);
 
@@ -462,7 +462,7 @@ xnet_senddata(struct fid_ep *ep_fid, const void *buf, size_t len,
 	xnet_init_tx_buf(tx_entry, sizeof(tx_entry->hdr.cq_data_hdr),
 			 buf, len);
 	tx_entry->context = context;
-	tx_entry->cq_flags = xnet_tx_completion_flag(ep, 0) |
+	tx_entry->cq_flags = xnet_tx_completion_get_opflags(ep) |
 			     FI_MSG | FI_SEND;
 	xnet_set_ack_flags(tx_entry, ep->util_ep.tx_op_flags);
 
@@ -545,7 +545,7 @@ xnet_tsendmsg(struct fid_ep *fid_ep, const struct fi_msg_tagged *msg,
 	}
 
 	xnet_init_tx_iov(tx_entry, hdr_len, msg->msg_iov, msg->iov_count);
-	tx_entry->cq_flags = xnet_tx_completion_flag(ep, flags) |
+	tx_entry->cq_flags = xnet_tx_completion_get_msgflags(ep, flags) |
 			     FI_TAGGED | FI_SEND;
 	xnet_set_ack_flags(tx_entry, flags);
 	tx_entry->context = msg->context;
@@ -579,7 +579,7 @@ xnet_tsend(struct fid_ep *fid_ep, const void *buf, size_t len,
 
 	xnet_init_tx_buf(tx_entry, sizeof(tx_entry->hdr.tag_hdr), buf, len);
 	tx_entry->context = context;
-	tx_entry->cq_flags = xnet_tx_completion_flag(ep, 0) |
+	tx_entry->cq_flags = xnet_tx_completion_get_opflags(ep) |
 			     FI_TAGGED | FI_SEND;
 	xnet_set_ack_flags(tx_entry, ep->util_ep.tx_op_flags);
 
@@ -612,7 +612,7 @@ xnet_tsendv(struct fid_ep *fid_ep, const struct iovec *iov, void **desc,
 
 	xnet_init_tx_iov(tx_entry, sizeof(tx_entry->hdr.tag_hdr), iov, count);
 	tx_entry->context = context;
-	tx_entry->cq_flags = xnet_tx_completion_flag(ep, 0) |
+	tx_entry->cq_flags = xnet_tx_completion_get_opflags(ep) |
 			     FI_TAGGED | FI_SEND;
 	xnet_set_ack_flags(tx_entry, ep->util_ep.tx_op_flags);
 
@@ -678,7 +678,7 @@ xnet_tsenddata(struct fid_ep *fid_ep, const void *buf, size_t len, void *desc,
 	xnet_init_tx_buf(tx_entry, sizeof(tx_entry->hdr.tag_data_hdr),
 			 buf, len);
 	tx_entry->context = context;
-	tx_entry->cq_flags = xnet_tx_completion_flag(ep, 0) |
+	tx_entry->cq_flags = xnet_tx_completion_get_opflags(ep) |
 			     FI_TAGGED | FI_SEND;
 	xnet_set_ack_flags(tx_entry, ep->util_ep.tx_op_flags);
 

--- a/prov/tcp/src/xnet_rdm_cm.c
+++ b/prov/tcp/src/xnet_rdm_cm.c
@@ -161,6 +161,11 @@ static int xnet_bind_conn(struct xnet_rdm *rdm, struct xnet_ep *ep)
 		if (ret)
 			return ret;
 	}
+	ep->util_ep.tx_msg_flags = rdm->util_ep.tx_msg_flags;
+	ep->util_ep.rx_msg_flags = rdm->util_ep.rx_msg_flags;
+	ep->util_ep.tx_op_flags = rdm->util_ep.tx_op_flags;
+	ep->util_ep.rx_op_flags = rdm->util_ep.rx_op_flags;
+
 
 	return 0;
 }

--- a/prov/tcp/src/xnet_rma.c
+++ b/prov/tcp/src/xnet_rma.c
@@ -92,7 +92,7 @@ static void xnet_rma_read_recv_entry_fill(struct xnet_xfer_entry *recv_entry,
 
 	recv_entry->iov_cnt = msg->iov_count;
 	recv_entry->context = msg->context;
-	recv_entry->cq_flags = xnet_tx_completion_flag(ep, flags) |
+	recv_entry->cq_flags = xnet_tx_completion_get_msgflags(ep, flags) |
 			       FI_RMA | FI_READ;
 
 	/* Read response completes the RMA read transmit */
@@ -167,7 +167,9 @@ xnet_rma_read(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 		.data = 0,
 	};
 
-	return xnet_rma_readmsg(ep_fid, &msg, 0);
+	struct xnet_ep *ep;
+	ep = container_of(ep_fid, struct xnet_ep, util_ep.ep_fid);
+	return xnet_rma_readmsg(ep_fid, &msg, ep->util_ep.tx_op_flags);
 }
 
 static ssize_t
@@ -191,7 +193,9 @@ xnet_rma_readv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 		.data = 0,
 	};
 
-	return xnet_rma_readmsg(ep_fid, &msg, 0);
+	struct xnet_ep *ep;
+	ep = container_of(ep_fid, struct xnet_ep, util_ep.ep_fid);
+	return xnet_rma_readmsg(ep_fid, &msg, ep->util_ep.tx_op_flags);
 }
 
 static ssize_t
@@ -258,7 +262,7 @@ xnet_rma_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 	send_entry->iov[0].iov_base = (void *) &send_entry->hdr;
 	send_entry->iov[0].iov_len = offset;
 
-	send_entry->cq_flags = xnet_tx_completion_flag(ep, flags) |
+	send_entry->cq_flags = xnet_tx_completion_get_msgflags(ep, flags) |
 			       FI_RMA | FI_WRITE;
 	send_entry->cntr = ep->util_ep.cntrs[CNTR_WR];
 	xnet_set_commit_flags(send_entry, flags);
@@ -294,7 +298,9 @@ xnet_rma_write(struct fid_ep *ep_fid, const void *buf, size_t len, void *desc,
 		.data = 0,
 	};
 
-	return xnet_rma_writemsg(ep_fid, &msg, 0);
+	struct xnet_ep *ep;
+	ep = container_of(ep_fid, struct xnet_ep, util_ep.ep_fid);
+	return xnet_rma_writemsg(ep_fid, &msg, ep->util_ep.tx_op_flags);
 }
 
 static ssize_t
@@ -318,7 +324,9 @@ xnet_rma_writev(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 		.data = 0,
 	};
 
-	return xnet_rma_writemsg(ep_fid, &msg, 0);
+	struct xnet_ep *ep;
+	ep = container_of(ep_fid, struct xnet_ep, util_ep.ep_fid);
+	return xnet_rma_writemsg(ep_fid, &msg, ep->util_ep.tx_op_flags);
 }
 
 
@@ -347,7 +355,9 @@ xnet_rma_writedata(struct fid_ep *ep_fid, const void *buf, size_t len,
 		.data = data,
 	};
 
-	return xnet_rma_writemsg(ep_fid, &msg, FI_REMOTE_CQ_DATA);
+	struct xnet_ep *ep;
+	ep = container_of(ep_fid, struct xnet_ep, util_ep.ep_fid);
+	return xnet_rma_writemsg(ep_fid, &msg, FI_REMOTE_CQ_DATA | ep->util_ep.tx_op_flags);
 }
 
 static ssize_t


### PR DESCRIPTION
This PR makes 3 changes:
1. setting of FI_COMPLETION flags for data transfer interfaces(sends and rmas) by combining it with default  settings for the msg flags and op flags
2. Inheriting tx rx flags set during msg endpoint creation from the corresponding rdm endpoint when connection is being created.  For example, if the application requested selective completion then the corresponding msg endpoint is created with the same settings. 
3. re-enables mpichsuite rma tests into Intel CI for tcp provider. 