### PR TITLE
[v1.19.x] prov/efa: Disable RUNTING for Neuron

### DIFF
--- a/prov/efa/src/efa_hmem.c
+++ b/prov/efa/src/efa_hmem.c
@@ -89,7 +89,7 @@ static int efa_domain_hmem_info_init_protocol_thresholds(struct efa_domain *efa_
 		fi_param_get_size_t(&efa_prov, "inter_min_read_write_size", &info->min_read_write_size);
 		break;
 	case FI_HMEM_NEURON:
-		info->runt_size = EFA_DEFAULT_RUNT_SIZE;
+		info->runt_size = 0;
 		info->max_intra_eager_size = 0;
 		info->max_medium_msg_size = 0;
 		info->min_read_msg_size = efa_max_eager_msg_size_with_largest_header(efa_domain) + 1;


### PR DESCRIPTION
We noticed a performance regression for runting read + neuron so we are choosing to disable it in order to resolve regression.

Signed-off-by: Seth Zegelstein <szegel@amazon.com>
(cherry picked from commit 56b22865ffc39015cf6cbf54f2888a0e0855f683)