### PR TITLE
prov/efa: allocate pke_vec, recv_wr_vec, sge_vec from heap

### DIFF
--- a/prov/efa/src/dgram/efa_dgram_ep.h
+++ b/prov/efa/src/dgram/efa_dgram_ep.h
@@ -58,19 +58,6 @@ struct efa_send_wr {
 	struct ibv_sge sge[2];
 };
 
-struct efa_recv_wr {
-	/** @brief Work request struct used by rdma-core */
-	struct ibv_recv_wr wr;
-
-	/** @brief Scatter gather element array
-	 *
-	 * @details
-	 * EFA device supports a maximum of 2 iov/SGE
-	 * For receive, we only use 1 SGE
-	 */
-	struct ibv_sge sge[1];
-};
-
 
 int efa_dgram_ep_open(struct fid_domain *domain_fid, struct fi_info *info,
 		      struct fid_ep **ep_fid, void *context);

--- a/prov/efa/src/efa_base_ep.c
+++ b/prov/efa/src/efa_base_ep.c
@@ -100,6 +100,9 @@ int efa_base_ep_destruct(struct efa_base_ep *base_ep)
 		base_ep->util_ep_initialized = false;
 	}
 
+	if (base_ep->efa_recv_wr_vec)
+		free(base_ep->efa_recv_wr_vec);
+
 	return err;
 }
 
@@ -299,6 +302,11 @@ int efa_base_ep_construct(struct efa_base_ep *base_ep,
 
 	base_ep->xmit_more_wr_tail = &base_ep->xmit_more_wr_head;
 	base_ep->recv_more_wr_tail = &base_ep->recv_more_wr_head;
+	base_ep->efa_recv_wr_vec = calloc(sizeof(struct efa_recv_wr), EFA_RDM_EP_MAX_WR_PER_IBV_POST_RECV);
+	if (!base_ep->efa_recv_wr_vec) {
+		EFA_WARN(FI_LOG_EP_CTRL, "cannot alloc memory for base_ep->efa_recv_wr_vec!\n");
+		return -FI_ENOMEM;
+	}
 	base_ep->efa_qp_enabled = false;
 	return 0;
 }

--- a/prov/efa/src/efa_base_ep.h
+++ b/prov/efa/src/efa_base_ep.h
@@ -51,6 +51,19 @@ struct efa_qp {
 
 struct efa_av;
 
+struct efa_recv_wr {
+	/** @brief Work request struct used by rdma-core */
+	struct ibv_recv_wr wr;
+
+	/** @brief Scatter gather element array
+	 *
+	 * @details
+	 * EFA device supports a maximum of 2 iov/SGE
+	 * For receive, we only use 1 SGE
+	 */
+	struct ibv_sge sge[1];
+};
+
 struct efa_base_ep {
 	struct util_ep util_ep;
 	struct efa_domain *domain;
@@ -68,6 +81,7 @@ struct efa_base_ep {
 	struct ibv_send_wr *xmit_more_wr_tail;
 	struct ibv_recv_wr recv_more_wr_head;
 	struct ibv_recv_wr *recv_more_wr_tail;
+	struct efa_recv_wr *efa_recv_wr_vec;
 };
 
 int efa_base_ep_bind_av(struct efa_base_ep *base_ep, struct efa_av *av);

--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -233,6 +233,7 @@ struct efa_rdm_ep {
 	bool sendrecv_in_order_aligned_128_bytes; /**< whether to support in order send/recv of each aligned 128 bytes memory region */
 	bool write_in_order_aligned_128_bytes; /**< whether to support in order write of each aligned 128 bytes memory region */
 	char err_msg[EFA_RDM_ERROR_MSG_BUFFER_LENGTH]; /* A large enough buffer to store CQ/EQ error data used by e.g. fi_cq_readerr */
+	struct efa_rdm_pke **pke_vec;
 };
 
 int efa_rdm_ep_flush_queued_blocking_copy_to_hmem(struct efa_rdm_ep *ep);

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -543,6 +543,13 @@ int efa_rdm_ep_open(struct fid_domain *domain, struct fi_info *info,
 	if (ret)
 		goto err_close_core_cq;
 
+	efa_rdm_ep->pke_vec = calloc(sizeof(struct efa_rdm_pke *), EFA_RDM_EP_MAX_WR_PER_IBV_POST_RECV);
+	if (!efa_rdm_ep->pke_vec) {
+		EFA_WARN(FI_LOG_EP_CTRL, "cannot alloc memory for efa_rdm_ep->pke_vec!\n");
+		ret = -FI_ENOMEM;
+		goto err_close_core_cq;
+	}
+
 	*ep = &efa_rdm_ep->base_ep.util_ep.ep_fid;
 	(*ep)->msg = &efa_rdm_msg_ops;
 	(*ep)->rma = &efa_rdm_rma_ops;
@@ -845,6 +852,9 @@ static int efa_rdm_ep_close(struct fid *fid)
 		efa_rdm_ep->peer_srx_ep = NULL;
 	}
 	efa_rdm_ep_destroy_buffer_pools(efa_rdm_ep);
+
+	if (efa_rdm_ep->pke_vec)
+		free(efa_rdm_ep->pke_vec);
 	free(efa_rdm_ep);
 	return retv;
 }


### PR DESCRIPTION
Currently, efa_rdm_pke_recvv and efa_rdm_ep_bulk_post_internal_rx_pkts allocate pke_vec, recv_wr_vec, sge_vec from stack inside the function. This patch moves these allocation to heap during ep's creation.