### PR TITLE
hmem: Add new op to hmem_ops for getting dmabuf fd

### DIFF
--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -126,6 +126,8 @@ struct ofi_hmem_ops {
 				    const void *src, size_t size);
 	int (*dev_reg_copy_from_hmem)(uint64_t handle, void *dest,
 				      const void *src, size_t size);
+	int (*get_dmabuf_fd)(void *addr, uint64_t size, int *fd,
+			     uint64_t *offset);
 };
 
 extern struct ofi_hmem_ops hmem_ops[];
@@ -233,6 +235,7 @@ int ze_dev_reg_copy_to_hmem(uint64_t handle, void *dest, const void *src,
 			    size_t size);
 int ze_dev_reg_copy_from_hmem(uint64_t handle, void *dest, const void *src,
 			      size_t size);
+int ze_hmem_get_dmabuf_fd(void *addr, uint64_t size, int *fd, uint64_t *offset);
 
 int neuron_copy_to_dev(uint64_t device, void *dev, const void *host, size_t size);
 int neuron_copy_from_dev(uint64_t device, void *host, const void *dev, size_t size);
@@ -242,7 +245,7 @@ int neuron_hmem_init(void);
 int neuron_hmem_cleanup(void);
 void *neuron_alloc(void **handle, size_t size);
 void neuron_free(void **handle);
-int neuron_get_dmabuf_fd(uint64_t va, uint64_t size, int* fd);
+int neuron_get_dmabuf_fd(void *addr, uint64_t size, int *fd, uint64_t *offset);
 
 int synapseai_init(void);
 int synapseai_cleanup(void);
@@ -250,7 +253,8 @@ int synapseai_copy_to_hmem(uint64_t device, void *dest, const void *src,
                            size_t size);
 int synapseai_copy_from_hmem(uint64_t device, void *dest, const void *src,
                              size_t size);
-int synapseai_get_dmabuf_fd(uint64_t addr, uint64_t size, int* fd);
+int synapseai_get_dmabuf_fd(void *addr, uint64_t size, int *fd,
+			    uint64_t *offset);
 bool synapseai_is_addr_valid(const void *addr, uint64_t *device,
                              uint64_t *flags);
 int synapseai_host_register(void *ptr, size_t size);
@@ -340,6 +344,12 @@ static inline bool ofi_hmem_no_is_ipc_enabled(void)
 	return false;
 }
 
+static inline int ofi_hmem_no_get_dmabuf_fd(void *addr, uint64_t size, int *fd,
+					    uint64_t *offset)
+{
+	return -FI_ENOSYS;
+}
+
 static inline bool ofi_hmem_p2p_disabled(void)
 {
 	return ofi_hmem_disable_p2p;
@@ -420,5 +430,7 @@ int ofi_hmem_dev_reg_copy_to_hmem(enum fi_hmem_iface iface, uint64_t handle,
 				  void *dest, const void *src, size_t size);
 int ofi_hmem_dev_reg_copy_from_hmem(enum fi_hmem_iface iface, uint64_t handle,
 				    void *dest, const void *src, size_t size);
+int ofi_hmem_get_dmabuf_fd(enum fi_hmem_iface, void *addr, uint64_t size,
+			   int *fd, uint64_t *offset);
 
 #endif /* _OFI_HMEM_H_ */

--- a/prov/efa/src/efa_hmem.c
+++ b/prov/efa/src/efa_hmem.c
@@ -224,6 +224,7 @@ static int efa_domain_hmem_info_init_neuron(struct efa_domain *efa_domain)
 	void *ptr = NULL;
 	size_t len = ofi_get_page_size() * 2, tmp_value;
 	int dmabuf_fd;
+	uint64_t offset;
 	int ret;
 
 	if (!ofi_hmem_is_initialized(FI_HMEM_NEURON)) {
@@ -255,10 +256,10 @@ static int efa_domain_hmem_info_init_neuron(struct efa_domain *efa_domain)
 	/* Neuron currently requires P2P */
 	info->p2p_required_by_impl = true;
 
-	ret = neuron_get_dmabuf_fd((uint64_t)ptr, (uint64_t)len, &dmabuf_fd);
+	ret = neuron_get_dmabuf_fd(ptr, (uint64_t)len, &dmabuf_fd, &offset);
 	if (ret == FI_SUCCESS) {
 		ibv_mr = ibv_reg_dmabuf_mr(
-					g_device_list[0].ibv_pd, 0,
+					g_device_list[0].ibv_pd, offset,
 					len, (uint64_t)ptr, dmabuf_fd, ibv_access);
 	} else if (ret == -FI_ENOPROTOOPT) {
 		EFA_INFO(FI_LOG_MR,

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -140,6 +140,7 @@ struct ofi_hmem_ops hmem_ops[] = {
 		.dev_unregister = ofi_hmem_system_dev_unregister,
 		.dev_reg_copy_to_hmem = ofi_hmem_system_dev_reg_copy,
 		.dev_reg_copy_from_hmem = ofi_hmem_system_dev_reg_copy,
+		.get_dmabuf_fd = ofi_hmem_no_get_dmabuf_fd,
 	},
 	[FI_HMEM_CUDA] = {
 		.initialized = false,
@@ -165,6 +166,7 @@ struct ofi_hmem_ops hmem_ops[] = {
 		.dev_unregister = cuda_dev_unregister,
 		.dev_reg_copy_to_hmem = cuda_dev_reg_copy_to_hmem,
 		.dev_reg_copy_from_hmem = cuda_dev_reg_copy_from_hmem,
+		.get_dmabuf_fd = ofi_hmem_no_get_dmabuf_fd,
 	},
 	[FI_HMEM_ROCR] = {
 		.initialized = false,
@@ -190,6 +192,7 @@ struct ofi_hmem_ops hmem_ops[] = {
 		.dev_unregister = rocr_dev_unregister,
 		.dev_reg_copy_to_hmem = rocr_dev_reg_copy_to_hmem,
 		.dev_reg_copy_from_hmem = rocr_dev_reg_copy_from_hmem,
+		.get_dmabuf_fd = ofi_hmem_no_get_dmabuf_fd,
 	},
 	[FI_HMEM_ZE] = {
 		.initialized = false,
@@ -215,6 +218,7 @@ struct ofi_hmem_ops hmem_ops[] = {
 		.dev_unregister = ze_dev_unregister,
 		.dev_reg_copy_to_hmem = ze_dev_reg_copy_to_hmem,
 		.dev_reg_copy_from_hmem = ze_dev_reg_copy_from_hmem,
+		.get_dmabuf_fd = ze_hmem_get_dmabuf_fd,
 	},
 	[FI_HMEM_NEURON] = {
 		.initialized = false,
@@ -239,6 +243,7 @@ struct ofi_hmem_ops hmem_ops[] = {
 		.dev_unregister = ofi_hmem_no_dev_unregister,
 		.dev_reg_copy_to_hmem = ofi_hmem_no_dev_reg_copy_to_hmem,
 		.dev_reg_copy_from_hmem = ofi_hmem_no_dev_reg_copy_from_hmem,
+		.get_dmabuf_fd = neuron_get_dmabuf_fd,
 	},
 	[FI_HMEM_SYNAPSEAI] = {
 		.initialized = false,
@@ -263,6 +268,7 @@ struct ofi_hmem_ops hmem_ops[] = {
 		.dev_unregister = ofi_hmem_no_dev_unregister,
 		.dev_reg_copy_to_hmem = ofi_hmem_no_dev_reg_copy_to_hmem,
 		.dev_reg_copy_from_hmem = ofi_hmem_no_dev_reg_copy_from_hmem,
+		.get_dmabuf_fd = synapseai_get_dmabuf_fd,
 	},
 };
 
@@ -694,4 +700,10 @@ int ofi_hmem_dev_reg_copy_from_hmem(enum fi_hmem_iface iface, uint64_t handle,
 				    void *dest, const void *src, size_t size)
 {
 	return hmem_ops[iface].dev_reg_copy_from_hmem(handle, dest, src, size);
+}
+
+int ofi_hmem_get_dmabuf_fd(enum fi_hmem_iface iface, void *addr, uint64_t size,
+			   int *fd, uint64_t *offset)
+{
+	return hmem_ops[iface].get_dmabuf_fd(addr, size, fd, offset);
 }


### PR DESCRIPTION
Now that we have multiple ifaces that support dmabuf, it makes sense to have a common method to retrieve the fd associated with the dmabuf object.