### PR TITLE
hmem: remove cuda-specific functions when using `ofi_hmem_dev_reg_*`

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -270,10 +270,10 @@ int ofi_mr_map_verify(struct ofi_mr_map *map, uintptr_t *io_addr,
 
 /* libfabric internal flags starting from 60 to 63 */
 /**
- * OFI_HMEM_DATA_GDRCOPY_HANDLE indicates that hmem_data points to
- * a gdrcopy_handle data structure
+ * OFI_HMEM_DATA_DEV_REG_HANDLE indicates that hmem_data points to
+ * a dev_reg data structure, e.g. gdrcopy handle in cuda
  */
-#define OFI_HMEM_DATA_GDRCOPY_HANDLE	(1ULL << 60)
+#define OFI_HMEM_DATA_DEV_REG_HANDLE	(1ULL << 60)
 
 struct ofi_mr {
 	struct fid_mr mr_fid;

--- a/prov/efa/src/efa_hmem.h
+++ b/prov/efa/src/efa_hmem.h
@@ -90,7 +90,7 @@ static inline int efa_copy_from_hmem(void *desc, void *buff, const void *src, si
 		hmem_data = ((struct efa_mr *)desc)->peer.hmem_data;
 	}
 
-	if (FI_HMEM_CUDA == iface && (flags & OFI_HMEM_DATA_GDRCOPY_HANDLE)) {
+	if (FI_HMEM_CUDA == iface && (flags & OFI_HMEM_DATA_DEV_REG_HANDLE)) {
 		assert(hmem_data);
 		/* TODO: Fine tune the max data size to switch from gdrcopy to cudaMemcpy */
 		cuda_gdrcopy_from_dev((uint64_t)hmem_data, buff, src, size);
@@ -122,7 +122,7 @@ static inline int efa_copy_to_hmem(void *desc, void *dest, const void *buff, siz
 		hmem_data = ((struct efa_mr *)desc)->peer.hmem_data;
 	}
 
-	if (FI_HMEM_CUDA == iface && (flags & OFI_HMEM_DATA_GDRCOPY_HANDLE)) {
+	if (FI_HMEM_CUDA == iface && (flags & OFI_HMEM_DATA_DEV_REG_HANDLE)) {
 		assert(hmem_data);
 		/* TODO: Fine tune the max data size to switch from gdrcopy to cudaMemcpy */
 		cuda_gdrcopy_to_dev((uint64_t)hmem_data, dest, buff, size);

--- a/prov/efa/src/rdm/efa_rdm_pke_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_utils.c
@@ -121,7 +121,7 @@ ssize_t efa_rdm_pke_init_payload_from_ope(struct efa_rdm_pke *pke,
 	}
 
 	if (iov_mr && FI_HMEM_CUDA == iov_mr->peer.iface &&
-	    (iov_mr->peer.flags & OFI_HMEM_DATA_GDRCOPY_HANDLE)) {
+	    (iov_mr->peer.flags & OFI_HMEM_DATA_DEV_REG_HANDLE)) {
 		assert(iov_mr->peer.hmem_data);
 		copied = ofi_gdrcopy_from_cuda_iov((uint64_t)iov_mr->peer.hmem_data,
 						   pke->wiredata + payload_offset,
@@ -180,7 +180,7 @@ int efa_rdm_ep_flush_queued_blocking_copy_to_hmem(struct efa_rdm_ep *ep)
 		assert(desc && desc->peer.iface != FI_HMEM_SYSTEM);
 
 		if (FI_HMEM_CUDA == desc->peer.iface &&
-		    (desc->peer.flags & OFI_HMEM_DATA_GDRCOPY_HANDLE)) {
+		    (desc->peer.flags & OFI_HMEM_DATA_DEV_REG_HANDLE)) {
 			assert(desc->peer.hmem_data);
 			bytes_copied[i] = ofi_gdrcopy_to_cuda_iov((uint64_t)desc->peer.hmem_data,
 								  rxe->iov, rxe->iov_count,
@@ -307,7 +307,7 @@ int efa_rdm_pke_copy_payload_to_cuda(struct efa_rdm_pke *pke,
 	p2p_available = ret;
 	local_read_available = p2p_available && efa_rdm_ep_support_rdma_read(ep);
 	cuda_memcpy_available = ep->cuda_api_permitted;
-	gdrcopy_available = desc->peer.flags & OFI_HMEM_DATA_GDRCOPY_HANDLE;
+	gdrcopy_available = desc->peer.flags & OFI_HMEM_DATA_DEV_REG_HANDLE;
 
 	/* For in-order aligned send/recv, only allow local read to be used to copy data */
 	if (ep->sendrecv_in_order_aligned_128_bytes) {

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -410,17 +410,15 @@ static ssize_t ofi_copy_mr_iov(struct ofi_mr **mr, const struct iovec *iov,
 			hmem_data = NULL;
 		}
 
-		if (hmem_iface == FI_HMEM_CUDA && (hmem_flags & OFI_HMEM_DATA_GDRCOPY_HANDLE)) {
-			/**
-			 * TODO: Fine tune the max data size to switch from gdrcopy to cudaMemcpy
-			 * Note: buf must be on the host since gdrcopy does not support D2D copy
-			 */
+		if (hmem_flags & OFI_HMEM_DATA_DEV_REG_HANDLE) {
 			if (dir == OFI_COPY_BUF_TO_IOV)
-				cuda_gdrcopy_to_dev((uint64_t) hmem_data, hmem_buf,
-				                    (char *) buf + done, len);
+				ofi_hmem_dev_reg_copy_to_hmem(
+					hmem_iface, (uint64_t) hmem_data,
+					hmem_buf, (char *) buf + done, len);
 			else
-				cuda_gdrcopy_from_dev((uint64_t) hmem_data, (char *) buf + done,
-				                      hmem_buf, len);
+				ofi_hmem_dev_reg_copy_from_hmem(
+					hmem_iface, (uint64_t) hmem_data,
+					(char *) buf + done, hmem_buf, len);
 			ret = FI_SUCCESS;
 		} else if (dir == OFI_COPY_BUF_TO_IOV)
 			ret = ofi_copy_to_hmem(hmem_iface, hmem_device, hmem_buf,

--- a/src/hmem_cuda.c
+++ b/src/hmem_cuda.c
@@ -314,7 +314,9 @@ int cuda_copy_from_dev(uint64_t device, void *dst, const void *src, size_t size)
 
 int cuda_dev_register(const void *addr, size_t size, uint64_t *handle)
 {
-	return cuda_gdrcopy_dev_register(addr, size, handle);
+	if (cuda_is_gdrcopy_enabled())
+		return cuda_gdrcopy_dev_register(addr, size, handle);
+	return -FI_ENOSYS;
 }
 
 int cuda_dev_unregister(uint64_t handle)


### PR DESCRIPTION
remove cuda-specific naming and functions when using `ofi_hmem_dev_reg_*` function family
- [x] removes the need to check for `cuda_is_gdrcopy_enabled()`: `ofi_hmem_dev_register` fails if GDR copy is not available
- [x] update the bit mask to remove reference to cuda
- [x] ~update the EFA provider accordingly (@wenduwan do you want to do it here or in another PR?)~