### PR TITLE
prov/efa: Improve `efa_rdm_pke` definition

### DIFF
--- a/libfabric.sln
+++ b/libfabric.sln
@@ -1,8 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29709.97
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio Version 17
+VisualStudioVersion = 17
+# Version >= 16.8 required for C11 usage
+MinimumVisualStudioVersion = 16.8
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libfabric", "libfabric.vcxproj", "{6B3A874F-B14C-4F16-B7C3-31E94859AE3E}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "info", "info.vcxproj", "{90850937-D15C-491D-B294-66DCA165254D}"

--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug-ICC|x64">
       <Configuration>Debug-ICC</Configuration>
@@ -196,6 +196,7 @@
       <SDLCheck>true</SDLCheck>
       <CompileAs>CompileAsC</CompileAs>
       <ExceptionHandling>false</ExceptionHandling>
+      <AdditionalOptions>/std:c11 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
This removes the hardcoded padding bytes from the struct definition, which were ostensibly used as a mechanism to enforce alignment of `wiredata` to the 128 byte boundary.

While the `static_assert`s somewhat protect against changes made to the members which the struct is composed of, the manual calculation is a maintenance headache which is prone to developer error, as well as implementation-defined quirks.

More importantly, this change more clearly indicates the intent to align to the 128-byte boundary.

This commit also makes the struct size uniform when debug mode is enabled. This wasn't (currently) necessary, as the 32 bytes of padding were already sufficient for the 16-byte `dlist_entry` struct.

This is the C11-compliant version, utilizing `_Alignas` (stdalign.h)

For sake of comparison, I also pushed a (less-preferred) C99 version: https://github.com/darrylabbate/libfabric/commit/b479b5cd76d7395d9ade57bbdc501d8e0c3f79a4