### PR TITLE
core: Add restricted dlopen flag to configure options

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -544,6 +544,16 @@ AS_IF([test $have_uffd -eq 1],
 AC_DEFINE_UNQUOTED([HAVE_UFFD_UNMAP], [$have_uffd],
 	[Define to 1 if platform supports userfault fd unmap])
 
+dnl restricted DL open
+restricted_dl=0
+AC_ARG_ENABLE([restricted_dl],
+              [AC_HELP_STRING([--enable-restricted-dl],
+                              [Restricts dlopen operations to providers which were available at compile-time])],
+              [restricted_dl=1],
+              [])
+AC_DEFINE_UNQUOTED([HAVE_RESTRICTED_DL], [$restricted_dl],
+  [Define to 1 to restrict dlopen operations to providers which were available at compile-time])
+
 dnl Check support to intercept syscalls
 AC_CHECK_HEADERS_ONCE(elf.h sys/auxv.h)
 

--- a/include/windows/config.h
+++ b/include/windows/config.h
@@ -11,6 +11,12 @@
 /* Set to 1 to use c11 atomic functions */
 /* #undef HAVE_ATOMICS */   /* TODO: add atomics support for windows */
 
+/* bgq provider is built */
+#define HAVE_BGQ 0
+
+/* bgq provider is built as DSO */
+#define HAVE_BGQ_DL 0
+
 /* Set to 1 to use built-in intrincics atomics */
 #define HAVE_BUILTIN_ATOMICS 1
 
@@ -20,8 +26,38 @@
 /* Define to 1 if you have the <dlfcn.h> header file. */
 /* #undef HAVE_DLFCN_H */
 
+/* dmabuf_peer_mem provider is built */
+#define HAVE_DMABUF_PEER_MEM 0
+
+/* dmabuf_peer_mem provider is built as DSO */
+#define HAVE_DMABUF_PEER_MEM_DL 0
+
+/* efa provider is built */
+#define HAVE_EFA 0
+
+/* efa provider is built as DSO */
+#define HAVE_EFA_DL 0
+
 /* Define to 1 if host_clock_get_service is available. */
 /* #undef HAVE_HOST_GET_CLOCK_SERVICE */
+
+/* gni provider is built */
+#define HAVE_GNI 0
+
+/* gni provider is built as DSO */
+#define HAVE_GNI_DL 0
+
+/* hook_debug provider is built */
+#define HAVE_HOOK_DEBUG 0
+
+/* hook_debug provider is built as DSO */
+#define HAVE_HOOK_DEBUG_DL 0
+
+/* hook_hmem provider is built */
+#define HAVE_HOOK_HMEM 0
+
+/* hook_hmem provider is built as DSO */
+#define HAVE_HOOK_HMEM_DL 0
 
 /* Define to 1 if you have the <infiniband/verbs.h> header file. */
 #define HAVE_INFINIBAND_VERBS_H 1
@@ -47,14 +83,35 @@
 /* Define to 1 if you have the <netlink/version.h> header file. */
 /* #undef HAVE_NETLINK_VERSION_H */
 
+/* opx provider is built */
+#define HAVE_OPX 0
+
+/* opx provider is built as DSO */
+#define HAVE_OPX_DL 0
+
 /* perf provider is built */
 #define HAVE_PERF 1
 
+/* perf provider is built as DSO */
+#define HAVE_PERF_DL 0
+
+/* profile provider is built */
+#define HAVE_PROFILE 0
+
+/* profile provider is built as DSO */
+#define HAVE_PROFILE_DL 0
+
 /* psm2 provider is built */
-/* #undef HAVE_PSM2 */
+#define HAVE_PSM2 0
 
 /* psm2 provider is built as DSO */
-/* #undef HAVE_PSM2_DL */
+#define HAVE_PSM2_DL 0
+
+/* psm3 provider is built */
+#define HAVE_PSM3 0
+
+/* psm3 provider is built as DSO */
+#define HAVE_PSM3_DL 0
 
 /* Define to 1 if you have the <psm2.h> header file. */
 /* #undef HAVE_PSM2_H */
@@ -62,29 +119,52 @@
 /* Define to 1 if you have the <rdma/rsocket.h> header file. */
 /* #undef HAVE_RDMA_RSOCKET_H */
 
+/* trace provider is built */
+#define HAVE_TRACE 0
+
+/* trace provider is built as DSO */
+#define HAVE_TRACE_DL 0
+
 /* UDP provider is built */
 #define HAVE_UDP 1
 
 /* UDP provider is built as DSO */
-/* #undef HAVE_UDP_DL */
+#define HAVE_UDP_DL 0
+
+/* usnic provider is built */
+#define HAVE_USNIC 0
+
+/* usnic provider is built as DSO */
+#define HAVE_USNIC_DL 0
 
 /* sockets provider is built */
 #define HAVE_SOCKETS 1
 
 /* sockets provider is built as DSO */
-/* #undef HAVE_SOCKETS_DL */
+#define HAVE_SOCKETS_DL 0
+
+/* Define to 1 to restrict dlopen operations to providers which were available
+   at compile-time */
+#define HAVE_RESTRICTED_DL 0
 
 /* rxm provider is built */
 #define HAVE_RXM 1
 
 /* rxm provider is built as DSO */
-/* #undef HAVE_RXM_DL */
+#define HAVE_RXM_DL 0
 
 /* rxd provider is built */
 #define HAVE_RXD 1
 
 /* rxd provider is built as DSO */
-/* #undef HAVE_RXD_DL */
+#define HAVE_RXD_DL 0
+
+/* shm provider is built */
+#define HAVE_SHM 0
+
+/* shm provider is built as DSO */
+#define HAVE_SHM_DL 0
+
 
 /* Network Direct provider is built */
 #define HAVE_NETDIR 1
@@ -96,7 +176,7 @@
 #define HAVE_TCP 1
 
 /* TCP provider is built as DSO */
-/* #undef HAVE_TCP_DL */
+#define HAVE_TCP_DL 0
 
 /* NET provider is built */
 #define HAVE_NET 1
@@ -127,6 +207,12 @@
 
 /* Define to 1 if you have the <sys/types.h> header file. */
 #define HAVE_SYS_TYPES_H 1
+
+/* ucx provider is built */
+#define HAVE_UCX 0
+
+/* ucx provider is built as DSO */
+#define HAVE_UCX_DL 0
 
 /* Define to 1 if you have the <unistd.h> header file. */
 #define HAVE_UNISTD_H 1

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -437,6 +437,17 @@ static struct fi_provider *ofi_get_hook(const char *name)
 	return provider;
 }
 
+struct load_entry {
+	const char* provider_name;
+	int should_load;
+};
+
+#define DEFINE_LOAD_ENTRY(NAME, SHOULD_LOAD) \
+    { \
+        .provider_name = NAME, \
+        .should_load = SHOULD_LOAD \
+    }
+
 /* This is the default order that providers will be accessed when available.
  * This, in turn, sets the default ordering of fi_info's reported to the user.
  * However, ofi_reorder_info() may re-arrange the list based on hard-coded
@@ -444,35 +455,61 @@ static struct fi_provider *ofi_get_hook(const char *name)
  */
 static void ofi_ordered_provs_init(void)
 {
-	char *ordered_prov_names[] = {
-		"efa", "psm2", "opx", "usnic", "gni", "bgq", "verbs",
-		"netdir", "psm3", "ucx", "ofi_rxm", "ofi_rxd", "shm",
-
+	struct load_entry ordered_load_list[] = {
+		DEFINE_LOAD_ENTRY("efa", (HAVE_EFA | HAVE_EFA_DL)),
+		DEFINE_LOAD_ENTRY("psm2", (HAVE_PSM2 | HAVE_PSM2_DL)),
+		DEFINE_LOAD_ENTRY("opx", (HAVE_OPX | HAVE_OPX_DL)),
+		DEFINE_LOAD_ENTRY("usnic", (HAVE_USNIC | HAVE_USNIC_DL)),
+		DEFINE_LOAD_ENTRY("gni", (HAVE_GNI | HAVE_GNI_DL)),
+		DEFINE_LOAD_ENTRY("bgq", (HAVE_BGQ | HAVE_BGQ_DL)),
+		DEFINE_LOAD_ENTRY("verbs", (HAVE_VERBS | HAVE_VERBS_DL)),
+		DEFINE_LOAD_ENTRY("netdir", 0),
+		DEFINE_LOAD_ENTRY("psm3", (HAVE_PSM3 | HAVE_PSM3_DL)),
+		DEFINE_LOAD_ENTRY("ucx", (HAVE_UCX | HAVE_UCX_DL)),
+		DEFINE_LOAD_ENTRY("ofi_rxm", (HAVE_RXM | HAVE_RXM_DL)),
+		DEFINE_LOAD_ENTRY("ofi_rxd", (HAVE_RXD | HAVE_RXD_DL)),
+		DEFINE_LOAD_ENTRY("shm", (HAVE_SHM | HAVE_SHM_DL)),
 		/* Initialize the socket based providers last of the
 		 * standard providers.  This will result in them being
 		 * the least preferred providers.
 		 */
 
 		/* Before you add ANYTHING here, read the comment above!!! */
-		"udp", "tcp", "sockets", "net", /* NOTHING GOES HERE! */
+		DEFINE_LOAD_ENTRY("udp", (HAVE_UDP | HAVE_UDP_DL)),
+		DEFINE_LOAD_ENTRY("tcp", (HAVE_TCP | HAVE_TCP_DL)),
+		DEFINE_LOAD_ENTRY("sockets", (HAVE_SOCKETS | HAVE_SOCKETS_DL)),
+		DEFINE_LOAD_ENTRY("net", 0), /* NOTHING GOES HERE! */
 		/* Seriously, read it! */
 
 		/* These are hooking providers only.  Their order
 		 * doesn't matter
 		 */
-		"ofi_hook_perf", "ofi_hook_trace", "ofi_hook_profile", "ofi_hook_debug",
-		"ofi_hook_noop", "ofi_hook_hmem", "ofi_hook_dmabuf_peer_mem",
+		DEFINE_LOAD_ENTRY("ofi_hook_perf", (HAVE_PERF | HAVE_PERF_DL)),
+		DEFINE_LOAD_ENTRY("ofi_hook_trace", (HAVE_TRACE | HAVE_TRACE_DL)),
+		DEFINE_LOAD_ENTRY("ofi_hook_profile", (HAVE_PROFILE_DL)),
+		DEFINE_LOAD_ENTRY("ofi_hook_debug", (HAVE_HOOK_DEBUG_DL)),
+		DEFINE_LOAD_ENTRY("ofi_hook_noop", 0),
+		DEFINE_LOAD_ENTRY("ofi_hook_hmem", (HAVE_HOOK_HMEM_DL)),
+		DEFINE_LOAD_ENTRY("ofi_hook_dmabuf_peer_mem",
+			(HAVE_DMABUF_PEER_MEM | HAVE_DMABUF_PEER_MEM_DL)),
 
 		/* So do the offload providers. */
-		"off_coll",
+		DEFINE_LOAD_ENTRY("off_coll", 0),
 	};
 	struct ofi_prov *prov;
 	int num_provs, i;
 
-	num_provs = sizeof(ordered_prov_names) / sizeof(ordered_prov_names[0]);
+	num_provs = sizeof(ordered_load_list) / sizeof(ordered_load_list[0]);
 
 	for (i = 0; i < num_provs; i++) {
-		prov = ofi_alloc_prov(ordered_prov_names[i]);
+		/* If restricted DL is enabled, then only attempt to load
+		 * providers which were present at compile-time that were
+		 * enabled as 'yes' or 'dl'
+		 */
+		if (HAVE_RESTRICTED_DL && !ordered_load_list[i].should_load)
+			continue;
+
+		prov = ofi_alloc_prov(ordered_load_list[i].provider_name);
 		if (prov)
 			ofi_insert_prov(prov);
 	}

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -528,12 +528,70 @@ bool ofi_hmem_is_initialized(enum fi_hmem_iface iface)
 	return hmem_ops[iface].initialized;
 }
 
+void ofi_hmem_set_iface_filter(const char* iface_filter_str, bool* filter)
+{
+	int iface;
+	char* entry = NULL;
+	const char* token = ";";
+	const char* iface_labels[ARRAY_SIZE(hmem_ops)] = {
+		"system",
+		"cuda",
+		"rocr",
+		"ze",
+		"neuron",
+		"synapseai"
+	};
+
+	memset(filter, false, sizeof(bool) * ARRAY_SIZE(hmem_ops));
+
+	/* always enable system hmem interface */
+	filter[FI_HMEM_SYSTEM] = true;
+
+	entry = strtok(iface_filter_str, token);
+	while (entry != NULL) {
+		for (iface = 0; iface < ARRAY_SIZE(hmem_ops); iface++) {
+			if (!strcasecmp(iface_labels[iface], entry)) {
+				filter[iface] = true;
+				break;
+			}
+		}
+
+		if (iface >= ARRAY_SIZE(hmem_ops)) {
+			FI_WARN(&core_prov, FI_LOG_CORE,
+					"unknown HMEM interface specified in FI_HMEM, entry=\"%s\"\n",
+					entry);
+		}
+
+		entry = strtok(NULL, token);
+	}
+}
+
 void ofi_hmem_init(void)
 {
 	int iface, ret;
 	int disable_p2p = 0;
+	char* hmem_filter = NULL;
+	bool filter_hmem_ifaces = false;
+	bool iface_filter_array[ARRAY_SIZE(hmem_ops)];
+
+	fi_param_define(NULL, "hmem", FI_PARAM_STRING,
+			"List of hmem interfaces to attempt to initialize (default: all available interfaces)");
+	fi_param_get_str(NULL, "hmem", &hmem_filter);
+
+	if (hmem_filter) {
+		if (strlen(hmem_filter) != 0) {
+			ofi_hmem_set_iface_filter(hmem_filter, &iface_filter_array);
+			filter_hmem_ifaces = true;
+		} else {
+			FI_WARN(&core_prov, FI_LOG_CORE,
+					"zero-length FI_HMEM provided, enabling all interfaces\n");
+		}
+	}
 
 	for (iface = 0; iface < ARRAY_SIZE(hmem_ops); iface++) {
+		if (filter_hmem_ifaces && !iface_filter_array[iface])
+			continue;
+
 		ret = hmem_ops[iface].init();
 		if (ret != FI_SUCCESS) {
 			if (ret == -FI_ENOSYS)


### PR DESCRIPTION
This commit introduces a new flag, --enable-restricted-dl. By default, restricted_dl is false, which continues the existing behavior of fi_getinfo. The current behavior of fi_getinfo causes the library to probe all paths in LD_LIBRARY_PATH for all possible provider implementations known by ofi_ordered_provs_init, or in cases where FI_PROVIDER_PATH is defined, a search along a colon-delimited set of paths for any library named lib*-fi.so. A side-effect of the non-FI_PROVIDER_PATH option is that a vast majority of the providers in the ofi_ordered_provs_init list, ordered_prov_names, will not exist on most systems. Usually a small subset of the providers exist, and the rest will not be present. A significant number of metadata fetches to the network filesystem will fail to find the desired library via dlopen incurring significant penalties during job launch at scale. As an application scales to larger rank and node counts, the impact by this behavior is expected to grow linearly, and then exponentially as the network file system metadata servers are overwhelmed.

This impact of dlopen misses can be largely mitigated with the use of FI_PROVIDER_PATH, but that eliminates the ability to naturally load DL libraries through dlopen's search capability unless the admin or workload manager specify possible paths for each known set of DL provider implementations.

This commit seeks to find a solution in the middle -- dlopen capability and natural discovery of DL providers without searching for every possible provider and no prerequisite knowledge of the available DL providers in the workload manager or module environments.

When enabled, ofi_ordered_provs_init will seed the initial prov_head with providers that satisfy the following conditions:
- The provider has been built into the library (detected at compile-time without --enable-only, or --enable-<provider>[=yes])
- The provider has been built standalone as a DL provider (--enable-<provider>=dl)
- The provider exists in the 'ordered_load_list' in ofi_ordered_provs_init.

Providers that do not meet the above conditions will not be loaded by libfabric if --enable-restricted-dl is provided to configure.

A similar feature will be required for HMEM provider solutions. Vendors may need to compile support for GPU libraries, but customers of the vendor may not use one or more of the supported GPU libraries.