### PR TITLE
Update util CQ code to support err_data

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -514,6 +514,11 @@ struct util_cq {
 
 	struct fid_peer_cq	*peer_cq;
 
+	/* Error data buffer used to support API version 1.5 and if the user
+	 * provider err_data_size is zero.
+	 */
+	void *err_data;
+
 	/* Only valid if not FI_PEER */
 	struct util_comp_cirq	*cirq;
 	fi_addr_t		*src;
@@ -556,6 +561,12 @@ ssize_t ofi_cq_read_entries(struct util_cq *cq, void *buf, size_t count,
 	ssize_t i;
 
 	ofi_genlock_lock(&cq->cq_lock);
+
+	if (cq->err_data) {
+		free(cq->err_data);
+		cq->err_data = NULL;
+	}
+
 	if (ofi_cirque_isempty(cq->cirq)) {
 		i = -FI_EAGAIN;
 		goto out;

--- a/prov/psm3/src/psmx3_cq.c
+++ b/prov/psm3/src/psmx3_cq.c
@@ -960,7 +960,7 @@ STATIC ssize_t psmx3_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf,
 	cq_priv->domain->cq_lock_fn(&cq_priv->lock, 2);
 	if (cq_priv->pending_error) {
 		ofi_cq_err_memcpy(cq_priv->domain->fabric->util_fabric.fabric_fid.api_version,
-				  buf, &cq_priv->pending_error->cqe);
+				  buf, &cq_priv->pending_error->cqe.err);
 		free(cq_priv->pending_error);
 		cq_priv->pending_error = NULL;
 		psmx3_unlock(&cq_priv->lock, 2);

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -269,8 +269,6 @@ ssize_t ofi_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *buf,
 {
 	struct util_cq_aux_entry *aux_entry;
 	struct util_cq *cq;
-	char *err_buf_save;
-	size_t err_data_size;
 	uint32_t api_version;
 	ssize_t ret;
 
@@ -294,20 +292,7 @@ ssize_t ofi_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *buf,
 		goto unlock;
 	}
 
-	if ((FI_VERSION_GE(api_version, FI_VERSION(1, 5))) &&
-	    buf->err_data_size) {
-		err_buf_save = buf->err_data;
-		err_data_size = MIN(buf->err_data_size,
-				    aux_entry->comp.err_data_size);
-
-		ofi_cq_err_memcpy(api_version, buf, &aux_entry->comp);
-		memcpy(err_buf_save, aux_entry->comp.err_data, err_data_size);
-		buf->err_data = err_buf_save;
-		buf->err_data_size = err_data_size;
-	} else {
-		memcpy(buf, &aux_entry->comp,
-		       sizeof(struct fi_cq_err_entry_1_0));
-	}
+	ofi_cq_err_memcpy(api_version, buf, &aux_entry->comp);
 
 	slist_remove_head(&cq->aux_queue);
 	free(aux_entry);

--- a/prov/util/src/util_srx.c
+++ b/prov/util/src/util_srx.c
@@ -879,7 +879,7 @@ int util_srx_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 static int util_cancel_entry(struct util_srx_ctx *srx, uint64_t flags,
 			     struct util_rx_entry *rx_entry)
 {
-	struct fi_cq_err_entry err_entry;
+	struct fi_cq_err_entry err_entry = {0};
 	int ret;
 
 	err_entry.op_context = rx_entry->peer_entry.context;


### PR DESCRIPTION
The CXI provider uses the util CQ code. When implementing FI_SOURCE_ERR, it was discovered that the util CQ code does not properly support err_data. This PR updates/fixes the util CQ code to support this..