### PR TITLE
intel/ci: disable rma/win_shared_put_flush_load test from mpich suite

### DIFF
--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -689,6 +689,7 @@ class MpichTestSuite(Test):
         self.weekly = weekly
         self.mpichtests_exclude = {
         'tcp'   :   {   '.'        : [('spawn','dir')],
+                        'rma'      : [('win_shared_put_flush_load 3', 'test')],
                     'threads'      : [('spawn','dir')],
                     'threads/comm' : [('idup_nb 4','test'),
                                       ('idup_comm_gen 4','test')],


### PR DESCRIPTION
This particular rma test fails sometimes and
is currently under investigation. 
Temporarily being disabled from CI to prevent
unrelated PRs to be flagged as  failures.