### PR TITLE
prov/verbs: Add synapseai dmabuf mr support

### DIFF
--- a/prov/rxm/src/rxm_msg.c
+++ b/prov/rxm/src/rxm_msg.c
@@ -714,7 +714,7 @@ rxm_send_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	       (data_len <= rxm_ep->rxm_info->tx_attr->inject_size));
 
 	iface = rxm_mr_desc_to_hmem_iface_dev(desc, count, &device);
-	if (iface == FI_HMEM_ZE)
+	if (iface == FI_HMEM_ZE || iface == FI_HMEM_SYNAPSEAI)
 		goto rndv_send;
 
 	if (data_len <= rxm_ep->eager_limit) {

--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -142,9 +142,10 @@ vrb_mr_reg_common(struct vrb_mem_desc *md, int vrb_access, const void *base_addr
 		md->mr = ibv_reg_dmabuf_mr(md->domain->pd, (uintptr_t) buf,
 					   len, (uintptr_t) base_addr + (uintptr_t) buf,
 					   (int) device, vrb_access);
-	else if (iface == FI_HMEM_ZE && vrb_gl_data.dmabuf_support)
+	else if ((vrb_gl_data.dmabuf_support && iface == FI_HMEM_ZE) ||
+		 (vrb_gl_data.dmabuf_support && iface == FI_HMEM_SYNAPSEAI))
 		md->mr = vrb_reg_hmem_dmabuf(iface, md->domain->pd, buf, len,
-					     vrb_access);
+						vrb_access);
 	else
 #endif
 		md->mr = ibv_reg_mr(md->domain->pd, (void *) buf, len,


### PR DESCRIPTION
The following changes were made to enable Gaudi-direct support over libfabric verbs provider, to allow peer-to-peer communication using dmabuf mr. They are applicble to device memory with iface value of FI_HMEM_SYNAPSEAI:

* Use dmabuf hmem registration function with synapseai.
* Use rndv protocol for rxm msg send to avoid copy between host and device memory.