### PR TITLE
core: simplify restricted-dl feature

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -559,11 +559,11 @@ dnl restricted DL open
 restricted_dl=0
 AC_ARG_ENABLE([restricted_dl],
               [AC_HELP_STRING([--enable-restricted-dl],
-                              [Restricts dlopen operations to providers which were available at compile-time])],
+                              [only look for dl providers under default location if FI_PROVIDER_PATH is not set])],
               [restricted_dl=1],
               [])
 AC_DEFINE_UNQUOTED([HAVE_RESTRICTED_DL], [$restricted_dl],
-  [Define to 1 to restrict dlopen operations to providers which were available at compile-time])
+  [Define to 1 to only look for dl providers under default location if FI_PROVIDER_PATH is not set])
 
 dnl Check support to intercept syscalls
 AC_CHECK_HEADERS_ONCE(elf.h sys/auxv.h)

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -437,17 +437,6 @@ static struct fi_provider *ofi_get_hook(const char *name)
 	return provider;
 }
 
-struct load_entry {
-	const char* provider_name;
-	int should_load;
-};
-
-#define DEFINE_LOAD_ENTRY(NAME, SHOULD_LOAD) \
-    { \
-        .provider_name = NAME, \
-        .should_load = SHOULD_LOAD \
-    }
-
 /* This is the default order that providers will be accessed when available.
  * This, in turn, sets the default ordering of fi_info's reported to the user.
  * However, ofi_reorder_info() may re-arrange the list based on hard-coded
@@ -455,61 +444,35 @@ struct load_entry {
  */
 static void ofi_ordered_provs_init(void)
 {
-	struct load_entry ordered_load_list[] = {
-		DEFINE_LOAD_ENTRY("efa", (HAVE_EFA | HAVE_EFA_DL)),
-		DEFINE_LOAD_ENTRY("psm2", (HAVE_PSM2 | HAVE_PSM2_DL)),
-		DEFINE_LOAD_ENTRY("opx", (HAVE_OPX | HAVE_OPX_DL)),
-		DEFINE_LOAD_ENTRY("usnic", (HAVE_USNIC | HAVE_USNIC_DL)),
-		DEFINE_LOAD_ENTRY("gni", (HAVE_GNI | HAVE_GNI_DL)),
-		DEFINE_LOAD_ENTRY("bgq", (HAVE_BGQ | HAVE_BGQ_DL)),
-		DEFINE_LOAD_ENTRY("verbs", (HAVE_VERBS | HAVE_VERBS_DL)),
-		DEFINE_LOAD_ENTRY("netdir", 0),
-		DEFINE_LOAD_ENTRY("psm3", (HAVE_PSM3 | HAVE_PSM3_DL)),
-		DEFINE_LOAD_ENTRY("ucx", (HAVE_UCX | HAVE_UCX_DL)),
-		DEFINE_LOAD_ENTRY("ofi_rxm", (HAVE_RXM | HAVE_RXM_DL)),
-		DEFINE_LOAD_ENTRY("ofi_rxd", (HAVE_RXD | HAVE_RXD_DL)),
-		DEFINE_LOAD_ENTRY("shm", (HAVE_SHM | HAVE_SHM_DL)),
+	char *ordered_prov_names[] = {
+		"efa", "psm2", "opx", "usnic", "gni", "bgq", "verbs",
+		"netdir", "psm3", "ucx", "ofi_rxm", "ofi_rxd", "shm",
+
 		/* Initialize the socket based providers last of the
 		 * standard providers.  This will result in them being
 		 * the least preferred providers.
 		 */
 
 		/* Before you add ANYTHING here, read the comment above!!! */
-		DEFINE_LOAD_ENTRY("udp", (HAVE_UDP | HAVE_UDP_DL)),
-		DEFINE_LOAD_ENTRY("tcp", (HAVE_TCP | HAVE_TCP_DL)),
-		DEFINE_LOAD_ENTRY("sockets", (HAVE_SOCKETS | HAVE_SOCKETS_DL)),
-		DEFINE_LOAD_ENTRY("net", 0), /* NOTHING GOES HERE! */
+		"udp", "tcp", "sockets", "net", /* NOTHING GOES HERE! */
 		/* Seriously, read it! */
 
 		/* These are hooking providers only.  Their order
 		 * doesn't matter
 		 */
-		DEFINE_LOAD_ENTRY("ofi_hook_perf", (HAVE_PERF | HAVE_PERF_DL)),
-		DEFINE_LOAD_ENTRY("ofi_hook_trace", (HAVE_TRACE | HAVE_TRACE_DL)),
-		DEFINE_LOAD_ENTRY("ofi_hook_profile", (HAVE_PROFILE_DL)),
-		DEFINE_LOAD_ENTRY("ofi_hook_debug", (HAVE_HOOK_DEBUG_DL)),
-		DEFINE_LOAD_ENTRY("ofi_hook_noop", 0),
-		DEFINE_LOAD_ENTRY("ofi_hook_hmem", (HAVE_HOOK_HMEM_DL)),
-		DEFINE_LOAD_ENTRY("ofi_hook_dmabuf_peer_mem",
-			(HAVE_DMABUF_PEER_MEM | HAVE_DMABUF_PEER_MEM_DL)),
+		"ofi_hook_perf", "ofi_hook_trace", "ofi_hook_profile", "ofi_hook_debug",
+		"ofi_hook_noop", "ofi_hook_hmem", "ofi_hook_dmabuf_peer_mem",
 
 		/* So do the offload providers. */
-		DEFINE_LOAD_ENTRY("off_coll", 0),
+		"off_coll",
 	};
 	struct ofi_prov *prov;
 	int num_provs, i;
 
-	num_provs = sizeof(ordered_load_list) / sizeof(ordered_load_list[0]);
+	num_provs = sizeof(ordered_prov_names) / sizeof(ordered_prov_names[0]);
 
 	for (i = 0; i < num_provs; i++) {
-		/* If restricted DL is enabled, then only attempt to load
-		 * providers which were present at compile-time that were
-		 * enabled as 'yes' or 'dl'
-		 */
-		if (HAVE_RESTRICTED_DL && !ordered_load_list[i].should_load)
-			continue;
-
-		prov = ofi_alloc_prov(ordered_load_list[i].provider_name);
+		prov = ofi_alloc_prov(ordered_prov_names[i]);
 		if (prov)
 			ofi_insert_prov(prov);
 	}
@@ -779,6 +742,15 @@ static void ofi_load_dl_prov(void)
 			"(default: " PROVDLDIR ")");
 
 	fi_param_get_str(NULL, "provider_path", &provdir);
+
+#if HAVE_RESTRICTED_DL
+	if (!provdir || !strlen(provdir)) {
+		FI_INFO(&core_prov, FI_LOG_CORE,
+			"restricted_dl: setting FI_PROVIDER_PATH to \"%s\"\n", PROVDLDIR);
+		provdir = PROVDLDIR;
+	}
+#endif
+
 	if (!provdir || !strlen(provdir)) {
 		ofi_find_prov_libs();
 		dirs = ofi_split_and_alloc(PROVDLDIR, ":", NULL);


### PR DESCRIPTION
The goal of the feature can be achieved more simply by setting FI_PROVIDER_PATH for the user to PROVDLDIR if the variable hasn't been set by the user. This bypasses the most expensive dlopen operations without forcing users to set FI_PROVIDER_PATH to achieve the greatest benefit from the new compile-time flag.

With this change, users can load any provider found in PROVDLDIR by default, which is more flexible than the prior solution which only allowed any provider which was present at compile-time. Additionally, since this change completely avoids the call to ofi_find_prov_libs which incurred the overwhelming majority of the dlopen penalties.

closes #9296 