### PR TITLE
include/windows/config.h: fix efa windows build

### DIFF
--- a/include/windows/config.h
+++ b/include/windows/config.h
@@ -32,8 +32,10 @@
 /* dmabuf_peer_mem provider is built as DSO */
 #define HAVE_DMABUF_PEER_MEM_DL 0
 
+#ifndef HAVE_EFA
 /* efa provider is built */
 #define HAVE_EFA 0
+#endif /* HAVE_EFA */
 
 /* efa provider is built as DSO */
 #define HAVE_EFA_DL 0


### PR DESCRIPTION
The #define HAVE_EFA 0 line breaks the DHAVE_EFA
option passed to windows build. This patch wraps
this definition with #ifndef to fix this issue.