### PR TITLE
hmem: Fix compilation warnings

### DIFF
--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -204,7 +204,7 @@ ssize_t ofi_gdrcopy_from_cuda_iov(uint64_t handle, void *host,
                                   uint64_t iov_offset, size_t len);
 int cuda_gdrcopy_hmem_init(void);
 int cuda_gdrcopy_hmem_cleanup(void);
-int cuda_gdrcopy_dev_register(void *buf, size_t len, uint64_t *handle);
+int cuda_gdrcopy_dev_register(const void *buf, size_t len, uint64_t *handle);
 int cuda_gdrcopy_dev_unregister(uint64_t handle);
 int cuda_set_sync_memops(void *ptr);
 

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -545,13 +545,14 @@ void ofi_hmem_set_iface_filter(const char* iface_filter_str, bool* filter)
 		"neuron",
 		"synapseai"
 	};
+	char *iface_filter_str_copy = strdup(iface_filter_str);
 
 	memset(filter, false, sizeof(bool) * ARRAY_SIZE(hmem_ops));
 
 	/* always enable system hmem interface */
 	filter[FI_HMEM_SYSTEM] = true;
 
-	entry = strtok(iface_filter_str, token);
+	entry = strtok(iface_filter_str_copy, token);
 	while (entry != NULL) {
 		for (iface = 0; iface < ARRAY_SIZE(hmem_ops); iface++) {
 			if (!strcasecmp(iface_labels[iface], entry)) {
@@ -584,7 +585,7 @@ void ofi_hmem_init(void)
 
 	if (hmem_filter) {
 		if (strlen(hmem_filter) != 0) {
-			ofi_hmem_set_iface_filter(hmem_filter, &iface_filter_array);
+			ofi_hmem_set_iface_filter(hmem_filter, iface_filter_array);
 			filter_hmem_ifaces = true;
 		} else {
 			FI_WARN(&core_prov, FI_LOG_CORE,

--- a/src/hmem_cuda_gdrcopy.c
+++ b/src/hmem_cuda_gdrcopy.c
@@ -331,7 +331,7 @@ ssize_t ofi_gdrcopy_from_cuda_iov(uint64_t handle, void *host,
 	                            host, len, GDRCOPY_FROM_DEVICE);
 }
 
-int cuda_gdrcopy_dev_register(void *buf, size_t len, uint64_t *handle)
+int cuda_gdrcopy_dev_register(const void *buf, size_t len, uint64_t *handle)
 {
 	int err;
 	uintptr_t regbgn, regend;
@@ -439,7 +439,7 @@ void cuda_gdrcopy_from_dev(uint64_t devhandle, void *hostptr,
 {
 }
 
-int cuda_gdrcopy_dev_register(void *buf, size_t len, uint64_t *handle)
+int cuda_gdrcopy_dev_register(const void *buf, size_t len, uint64_t *handle)
 {
 	return FI_SUCCESS;
 }


### PR DESCRIPTION
This PR contains 2 commits that fix the compilation warnings that I observed.

The warnings were

```
src/hmem.c: In function 'ofi_hmem_set_iface_filter':
src/hmem.c:554:17: warning: passing argument 1 of 'strtok' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  entry = strtok(iface_filter_str, token);
                 ^~~~~~~~~~~~~~~~
In file included from ./include/rdma/fi_domain.h:37:0,
                 from ./include/ofi_hmem.h:41,
                 from src/hmem.c:39:
/usr/include/string.h:335:14: note: expected 'char * restrict' but argument is of type 'const char *'
 extern char *strtok (char *__restrict __s, const char *__restrict __delim)
              ^~~~~~
src/hmem.c: In function 'ofi_hmem_init':
src/hmem.c:587:43: warning: passing argument 2 of 'ofi_hmem_set_iface_filter' from incompatible pointer type [-Wincompatible-pointer-types]
    ofi_hmem_set_iface_filter(hmem_filter, &iface_filter_array);
                                           ^
src/hmem.c:535:6: note: expected '_Bool *' but argument is of type '_Bool (*)[6]'
 void ofi_hmem_set_iface_filter(const char* iface_filter_str, bool* filter)

src/hmem_cuda.c: In function 'cuda_dev_register':
src/hmem_cuda.c:318:36: warning: passing argument 1 of 'cuda_gdrcopy_dev_register' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
   return cuda_gdrcopy_dev_register(addr, size, handle);
                                    ^~~~
In file included from src/hmem_cuda.c:38:0:
./include/ofi_hmem.h:207:5: note: expected 'void *' but argument is of type 'const void *'
 int cuda_gdrcopy_dev_register(void *buf, size_t len, uint64_t *handle);
```