### PR TITLE
contrib/intel/jenkins: Switch dsa node to pikachu partition

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -688,7 +688,7 @@ pipeline {
           steps {
             script {
               dir (RUN_LOCATION) {
-                run_fabtests("shm_dsa", "mudkip", "1", "shm", null,
+                run_fabtests("shm_dsa", "pikachu", "1", "shm", null,
                              """FI_SHM_DISABLE_CMA=1 FI_SHM_USE_DSA_SAR=1 \
                                 FI_LOG_LEVEL=warn""")
               }


### PR DESCRIPTION
The Mudkip partition is being moved to a different cluster. The new Pikachu node will be used instead of the Mudkip ones for DSA tests.