### PR TITLE
core: handle dmabuf for ofi_mr functions

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -255,7 +255,8 @@ void ofi_mr_map_close(struct ofi_mr_map *map);
 
 int ofi_mr_map_insert(struct ofi_mr_map *map,
 		      const struct fi_mr_attr *attr,
-		      uint64_t *key, void *context);
+		      uint64_t *key, void *context,
+		      uint64_t flags);
 int ofi_mr_map_remove(struct ofi_mr_map *map, uint64_t key);
 void *ofi_mr_map_get(struct ofi_mr_map *map,  uint64_t key);
 
@@ -294,6 +295,20 @@ static inline bool ofi_mr_all_host(struct ofi_mr **mr, size_t count)
 			return false;
 	}
 	return true;
+}
+
+static inline
+void ofi_mr_get_iov_from_dmabuf(struct iovec *iov,
+				 const struct fi_mr_dmabuf *dmabuf,
+				 size_t count)
+{
+	int i;
+
+	for (i = 0; i < count; i++) {
+		iov[i].iov_base = (void *) (
+			(uintptr_t) dmabuf[i].base_addr + dmabuf[i].offset);
+		iov[i].iov_len = dmabuf[i].len;
+	}
 }
 
 void ofi_mr_update_attr(uint32_t user_version, uint64_t caps,

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -313,7 +313,8 @@ void ofi_mr_get_iov_from_dmabuf(struct iovec *iov,
 
 void ofi_mr_update_attr(uint32_t user_version, uint64_t caps,
 			const struct fi_mr_attr *user_attr,
-			struct fi_mr_attr *cur_abi_attr);
+			struct fi_mr_attr *cur_abi_attr,
+			uint64_t flags);
 int ofi_mr_close(struct fid *fid);
 int ofi_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 		   uint64_t flags, struct fid_mr **mr_fid);

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -311,6 +311,17 @@ void ofi_mr_get_iov_from_dmabuf(struct iovec *iov,
 	}
 }
 
+static inline
+void ofi_mr_info_get_iov_from_mr_attr(struct ofi_mr_info *info,
+				const struct fi_mr_attr *attr,
+				uint64_t flags)
+{
+	if (flags & FI_MR_DMABUF)
+		ofi_mr_get_iov_from_dmabuf(&info->iov, attr->dmabuf, 1);
+	else
+		info->iov = *attr->mr_iov;
+}
+
 void ofi_mr_update_attr(uint32_t user_version, uint64_t caps,
 			const struct fi_mr_attr *user_attr,
 			struct fi_mr_attr *cur_abi_attr,
@@ -428,9 +439,10 @@ int ofi_mr_cache_search(struct ofi_mr_cache *cache,
  *				with the cache.
  */
 struct ofi_mr_entry *ofi_mr_cache_find(struct ofi_mr_cache *cache,
-				       const struct fi_mr_attr *attr);
+				       const struct fi_mr_attr *attr,
+				       uint64_t flags);
 int ofi_mr_cache_reg(struct ofi_mr_cache *cache, const struct fi_mr_attr *attr,
-		     struct ofi_mr_entry **entry);
+		     struct ofi_mr_entry **entry, uint64_t flags);
 void ofi_mr_cache_delete(struct ofi_mr_cache *cache, struct ofi_mr_entry *entry);
 
 

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -358,7 +358,7 @@ static int efa_mr_cache_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 			      util_domain.domain_fid.fid);
 
 	assert(attr->iov_count == 1);
-	info.iov = *attr->mr_iov;
+	ofi_mr_info_get_iov_from_mr_attr(&info, attr, flags);
 	info.iface = attr->iface;
 	info.device = attr->device.reserved;
 	ret = ofi_mr_cache_search(domain->cache, &info, &entry);

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -812,7 +812,7 @@ static int efa_mr_reg_impl(struct efa_mr *efa_mr, uint64_t flags, const void *at
 	ofi_mr_update_attr(
 		efa_mr->domain->util_domain.fabric->fabric_fid.api_version,
 		efa_mr->domain->util_domain.info_domain_caps,
-		(const struct fi_mr_attr *) attr, &mr_attr);
+		(const struct fi_mr_attr *) attr, &mr_attr, flags);
 
 	ret = efa_mr_hmem_setup(efa_mr, &mr_attr, flags);
 	if (ret)

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -634,7 +634,8 @@ int efa_mr_is_cuda_memory_freed(struct efa_mr *efa_mr, bool *freed)
  * 		negative libfabric error code on failure.
  */
 static
-int efa_mr_update_domain_mr_map(struct efa_mr *efa_mr, struct fi_mr_attr *mr_attr)
+int efa_mr_update_domain_mr_map(struct efa_mr *efa_mr, struct fi_mr_attr *mr_attr,
+				uint64_t flags)
 {
 	struct fid_mr *existing_mr_fid;
 	struct efa_mr *existing_mr;
@@ -644,7 +645,7 @@ int efa_mr_update_domain_mr_map(struct efa_mr *efa_mr, struct fi_mr_attr *mr_att
 	mr_attr->requested_key = efa_mr->mr_fid.key;
 	ofi_genlock_lock(&efa_mr->domain->util_domain.lock);
 	err = ofi_mr_map_insert(&efa_mr->domain->util_domain.mr_map, mr_attr,
-				&efa_mr->mr_fid.key, &efa_mr->mr_fid);
+				&efa_mr->mr_fid.key, &efa_mr->mr_fid, flags);
 	ofi_genlock_unlock(&efa_mr->domain->util_domain.lock);
 	if (!err)
 		return 0;
@@ -731,7 +732,7 @@ int efa_mr_update_domain_mr_map(struct efa_mr *efa_mr, struct fi_mr_attr *mr_att
 	 */
 	ofi_genlock_lock(&efa_mr->domain->util_domain.lock);
 	err = ofi_mr_map_insert(&efa_mr->domain->util_domain.mr_map, mr_attr,
-				&efa_mr->mr_fid.key, &efa_mr->mr_fid);
+				&efa_mr->mr_fid.key, &efa_mr->mr_fid, flags);
 	ofi_genlock_unlock(&efa_mr->domain->util_domain.lock);
 	if (err) {
 		EFA_WARN(FI_LOG_MR,
@@ -750,14 +751,15 @@ int efa_mr_update_domain_mr_map(struct efa_mr *efa_mr, struct fi_mr_attr *mr_att
 }
 #else /* HAVE_CUDA */
 static
-int efa_mr_update_domain_mr_map(struct efa_mr *efa_mr, struct fi_mr_attr *mr_attr)
+int efa_mr_update_domain_mr_map(struct efa_mr *efa_mr, struct fi_mr_attr *mr_attr,
+				uint64_t flags)
 {
 	int err;
 
 	mr_attr->requested_key = efa_mr->mr_fid.key;
 	ofi_genlock_lock(&efa_mr->domain->util_domain.lock);
 	err = ofi_mr_map_insert(&efa_mr->domain->util_domain.mr_map, mr_attr,
-				&efa_mr->mr_fid.key, &efa_mr->mr_fid);
+				&efa_mr->mr_fid.key, &efa_mr->mr_fid, flags);
 	ofi_genlock_unlock(&efa_mr->domain->util_domain.lock);
 	if (err) {
 		EFA_WARN(FI_LOG_MR,
@@ -864,7 +866,7 @@ static int efa_mr_reg_impl(struct efa_mr *efa_mr, uint64_t flags, const void *at
 	efa_mr->mr_fid.mem_desc = efa_mr;
 	assert(efa_mr->mr_fid.key != FI_KEY_NOTAVAIL);
 
-	ret = efa_mr_update_domain_mr_map(efa_mr, &mr_attr);
+	ret = efa_mr_update_domain_mr_map(efa_mr, &mr_attr, flags);
 	if (ret) {
 		efa_mr_dereg_impl(efa_mr);
 		return ret;

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -578,7 +578,7 @@ static int rxm_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 
 	ofi_mr_update_attr(rxm_domain->util_domain.fabric->fabric_fid.api_version,
 			   rxm_domain->util_domain.info_domain_caps, attr,
-			   &msg_attr);
+			   &msg_attr, flags);
 
 	if ((flags & FI_HMEM_HOST_ALLOC) && (attr->iface == FI_HMEM_ZE))
 		msg_attr.device.ze = -1;

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -361,7 +361,8 @@ static void rxm_mr_remove_map_entry(struct rxm_mr *mr)
 
 static int rxm_mr_add_map_entry(struct util_domain *domain,
 				struct fi_mr_attr *msg_attr,
-				struct rxm_mr *rxm_mr)
+				struct rxm_mr *rxm_mr,
+				uint64_t flags)
 {
 	uint64_t temp_key;
 	int ret;
@@ -369,7 +370,7 @@ static int rxm_mr_add_map_entry(struct util_domain *domain,
 	msg_attr->requested_key = rxm_mr->mr_fid.key;
 
 	ofi_genlock_lock(&domain->lock);
-	ret = ofi_mr_map_insert(&domain->mr_map, msg_attr, &temp_key, rxm_mr);
+	ret = ofi_mr_map_insert(&domain->mr_map, msg_attr, &temp_key, rxm_mr, flags);
 	if (OFI_UNLIKELY(ret)) {
 		FI_WARN(&rxm_prov, FI_LOG_DOMAIN,
 			"MR map insert for atomic verification failed %d\n",
@@ -608,7 +609,7 @@ static int rxm_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 
 	if (rxm_domain->util_domain.info_domain_caps & FI_ATOMIC) {
 		ret = rxm_mr_add_map_entry(&rxm_domain->util_domain,
-					   &msg_attr, rxm_mr);
+					   &msg_attr, rxm_mr, flags);
 		if (ret)
 			goto map_err;
 	}
@@ -660,7 +661,7 @@ static int rxm_mr_regv(struct fid *fid, const struct iovec *iov, size_t count,
 
 	if (rxm_domain->util_domain.info_domain_caps & FI_ATOMIC) {
 		ret = rxm_mr_add_map_entry(&rxm_domain->util_domain,
-					   &msg_attr, rxm_mr);
+					   &msg_attr, rxm_mr, flags);
 		if (ret)
 			goto map_err;
 	}

--- a/prov/sockets/src/sock_mr.c
+++ b/prov/sockets/src/sock_mr.c
@@ -151,7 +151,7 @@ static int sock_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 		return -FI_ENOMEM;
 
 	ofi_mr_update_attr(dom->fab->fab_fid.api_version, dom->info.caps,
-			   attr, &cur_abi_attr);
+			   attr, &cur_abi_attr, flags);
 	ofi_mutex_lock(&dom->lock);
 
 	_mr->mr_fid.fid.fclass = FI_CLASS_MR;

--- a/prov/sockets/src/sock_mr.c
+++ b/prov/sockets/src/sock_mr.c
@@ -161,7 +161,7 @@ static int sock_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	_mr->domain = dom;
 	_mr->flags = flags;
 
-	ret = ofi_mr_map_insert(&dom->mr_map, &cur_abi_attr, &key, _mr);
+	ret = ofi_mr_map_insert(&dom->mr_map, &cur_abi_attr, &key, _mr, flags);
 	if (ret != 0)
 		goto err;
 

--- a/prov/ucx/src/ucx_domain.c
+++ b/prov/ucx/src/ucx_domain.c
@@ -274,7 +274,7 @@ static int ucx_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 		goto out;
 	}
 
-	ret = ofi_mr_map_insert(&domain->mr_map, attr, &key, mr);
+	ret = ofi_mr_map_insert(&domain->mr_map, attr, &key, mr, flags);
 	if (ret) {
 		ucp_mem_unmap(m_domain->context, ucx_mr->memh);
 		free(ucx_mr);

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -389,7 +389,8 @@ hit:
 }
 
 struct ofi_mr_entry *ofi_mr_cache_find(struct ofi_mr_cache *cache,
-				       const struct fi_mr_attr *attr)
+				       const struct fi_mr_attr *attr,
+				       uint64_t flags)
 {
 	struct ofi_mr_info info;
 	struct ofi_mr_entry *entry;
@@ -410,7 +411,7 @@ struct ofi_mr_entry *ofi_mr_cache_find(struct ofi_mr_cache *cache,
 	cache->search_cnt++;
 
 	info.peer_id = 0;
-	info.iov = *attr->mr_iov;
+	ofi_mr_info_get_iov_from_mr_attr(&info, attr, flags);
 	entry = ofi_mr_rbt_find(&cache->tree, &info);
 	if (!entry) {
 		goto unlock;
@@ -436,7 +437,7 @@ unlock:
 }
 
 int ofi_mr_cache_reg(struct ofi_mr_cache *cache, const struct fi_mr_attr *attr,
-		     struct ofi_mr_entry **entry)
+		     struct ofi_mr_entry **entry, uint64_t flags)
 {
 	int ret;
 
@@ -453,7 +454,7 @@ int ofi_mr_cache_reg(struct ofi_mr_cache *cache, const struct fi_mr_attr *attr,
 	cache->uncached_size += attr->mr_iov->iov_len;
 	pthread_mutex_unlock(&mm_lock);
 
-	(*entry)->info.iov = *attr->mr_iov;
+	ofi_mr_info_get_iov_from_mr_attr(&(*entry)->info, attr, flags);
 	(*entry)->use_cnt = 1;
 	(*entry)->node = NULL;
 

--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -333,12 +333,12 @@ vrb_mr_cache_reg(struct vrb_domain *domain, const void *buf, size_t len,
 	attr.iface = iface;
 	attr.device.reserved = device;
 	assert(attr.iov_count == 1);
-	info.iov = iov;
+	ofi_mr_info_get_iov_from_mr_attr(&info, &attr, flags);
 	info.iface = iface;
 	info.device = device;
 
 	ret = (flags & OFI_MR_NOCACHE) ?
-	      ofi_mr_cache_reg(&domain->cache, &attr, &entry) :
+	      ofi_mr_cache_reg(&domain->cache, &attr, &entry, flags) :
 	      ofi_mr_cache_search(&domain->cache, &info, &entry);
 	if (OFI_UNLIKELY(ret))
 		return ret;

--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -414,7 +414,7 @@ static int vrb_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 
 	ofi_mr_update_attr(domain->util_domain.fabric->fabric_fid.api_version,
 			   domain->util_domain.info_domain_caps, attr,
-			   &cur_abi_attr);
+			   &cur_abi_attr, flags);
 
 	if (flags & FI_MR_DMABUF)
 		return vrb_reg_dmabuf(domain, &cur_abi_attr, flags, mr);


### PR DESCRIPTION
When mr is registered with FI_MR_DMABUF bit in the flag,
    ofi_mr_attr_update should pass the fi_mr_dmabuf object
    from the attr user passed.

When inserting the mr to mr map, libfabric
    needs to translate the dmabuf object to mr_iov.

When constructing ofi_mr_info from mr_attr for ofi_mr_cache_search.
Convert dmabuf to iov if the flags has FI_MR_DMABUF.