### PR TITLE
github/actions: migrate from "hub" to "gh"

### DIFF
--- a/.github/workflows/nroff-elves.sh
+++ b/.github/workflows/nroff-elves.sh
@@ -67,7 +67,7 @@ fi
 # Yes, we committed something.  Push the branch and make a PR.
 # Extract the PR number.
 git push --set-upstream origin $branch_name
-url=`hub pull-request -b $BASE_REF -m 'Update nroff-generated man pages'`
+url=`gh pr create --base $BASE_REF --title 'Update nroff-generated man pages' --body ''`
 pr_num=`echo $url | cut -d/ -f7`
 
 # Wait for the required "DCO" CI to complete
@@ -80,9 +80,9 @@ echo "Waiting up to $max_seconds seconds for DCO CI to complete..."
 while test $i -lt $i_max; do
     date
     set +e
-    status=`hub ci-status --format "%t %S%n" | egrep '^DCO' | awk '{ print $2 }'`
+    status=`gh pr checks | egrep '^DCO' | awk '{ print $2 }'`
     set -e
-    if test "$status" = "success"; then
+    if test "$status" = "pass"; then
         echo "DCO CI is complete!"
         break
     fi
@@ -92,12 +92,15 @@ done
 
 status=0
 if test $i -lt $i_max; then
-    # Sadly, there is no "hub" command to merge a PR.  So do it by
-    # hand.
-    curl \
-        -XPUT \
-        -H "Authorization: token $GITHUB_TOKEN" \
-        https://api.github.com/repos/$GITHUB_REPOSITORY/pulls/$pr_num/merge
+    # rebase the commit onto the base branch
+    gh pr merge $pr_num -r
+
+    # command to do it by hand when "hub" was used which didn't have command
+    # to merge a PR. keep it here for reference.
+    #curl \
+    #    -XPUT \
+    #    -H "Authorization: token $GITHUB_TOKEN" \
+    #    https://api.github.com/repos/$GITHUB_REPOSITORY/pulls/$pr_num/merge
 else
     echo "Sad panda; DCO CI didn't complete -- did not merge $url"
     status=1

--- a/.github/workflows/nroff-elves.yaml
+++ b/.github/workflows/nroff-elves.yaml
@@ -21,9 +21,6 @@ jobs:
           - name: Check out the git repo
             uses: actions/checkout@v4
 
-          - name: Get the required packages
-            run: sudo apt install -y pandoc hub
-
           - name: Build the nroff man pages
             run: .github/workflows/nroff-elves.sh
             env:


### PR DESCRIPTION
GitHub has removed "hub" from their runners since Oct.2, 2023. The recommendation is to use "gh" instead. One benefits is that "gh" has a command for merging the PR, with option to rebase. This allows simpler action script and makes it possible to make "rebase" as the only merge strategy allowed.