### PR TITLE
github/actions: Fix missing package error

### DIFF
--- a/.github/workflows/nroff-elves.yaml
+++ b/.github/workflows/nroff-elves.yaml
@@ -21,6 +21,9 @@ jobs:
           - name: Check out the git repo
             uses: actions/checkout@v4
 
+          - name: Get the required packages
+            run: sudo apt install -y pandoc
+
           - name: Build the nroff man pages
             run: .github/workflows/nroff-elves.sh
             env:


### PR DESCRIPTION
The installation of the pandoc package was accidentally removed during the hub->gh convertion. Add it back.