### PR TITLE
github/actions: Fix incorrect directory name

### DIFF
--- a/.github/workflows/nroff-elves.sh
+++ b/.github/workflows/nroff-elves.sh
@@ -44,7 +44,7 @@ for file in `ls man/*.md`; do
     perl config/md2nroff.pl --source=$file
 done
 
-for file in `ls fabtest/man/*.md`; do
+for file in `ls fabtests/man/*.md`; do
     perl config/md2nroff.pl --source=$file
 done
 


### PR DESCRIPTION
The man page convertion action tries to access MarkDown files under 'fabtest'. The correct directory name is 'fabtests'.