### PR TITLE
prov/efa: Add testing for small messages without inject

### DIFF
--- a/fabtests/pytest/efa/conftest.py
+++ b/fabtests/pytest/efa/conftest.py
@@ -18,3 +18,10 @@ def memory_type(request):
                                         "r:0,1024,1048576"])
 def message_size(request):
     return request.param
+
+
+@pytest.fixture(scope="module", params=["r:0,4,64",
+                                        "r:4048,4,4148",
+                                        "r:8000,4,9000",])
+def inject_message_size(request):
+    return request.param

--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -16,6 +16,11 @@ def test_rdm_pingpong_range(cmdline_args, completion_semantic, memory_type, mess
     efa_run_client_server_test(cmdline_args, "fi_rdm_pingpong", "short",
                                completion_semantic, memory_type, message_size)
 
+@pytest.mark.functional
+def test_rdm_pingpong_no_inject_range(cmdline_args, completion_semantic, inject_message_size):
+    efa_run_client_server_test(cmdline_args, "fi_rdm_pingpong -j 0", "short",
+                               completion_semantic, "host_to_host", inject_message_size)
+
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
@@ -39,6 +44,11 @@ def test_rdm_tagged_bw(cmdline_args, iteration_type, completion_semantic, memory
 def test_rdm_tagged_bw_range(cmdline_args, completion_semantic, memory_type, message_size):
     efa_run_client_server_test(cmdline_args, "fi_rdm_tagged_bw", "short",
                                completion_semantic, memory_type, message_size)
+
+@pytest.mark.functional
+def test_rdm_tagged_bw_no_inject_range(cmdline_args, completion_semantic, inject_message_size):
+    efa_run_client_server_test(cmdline_args, "fi_rdm_tagged_bw -j 0", "short",
+                               completion_semantic, "host_to_host", inject_message_size)
 
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),

--- a/fabtests/pytest/efa/test_rma_bw.py
+++ b/fabtests/pytest/efa/test_rma_bw.py
@@ -1,23 +1,34 @@
+from efa.efa_common import efa_run_client_server_test
 import pytest
+
 
 @pytest.mark.parametrize("operation_type", ["read", "writedata", "write"])
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
 def test_rma_bw(cmdline_args, iteration_type, operation_type, completion_semantic, memory_type):
-    from efa.efa_common import efa_run_client_server_test
     command = "fi_rma_bw -e rdm"
     command = command + " -o " + operation_type
     # rma_bw test with data verification takes longer to finish
     timeout = max(540, cmdline_args.timeout)
     efa_run_client_server_test(cmdline_args, command, iteration_type, completion_semantic, memory_type, "all", timeout=timeout)
 
+
 @pytest.mark.functional
 @pytest.mark.parametrize("operation_type", ["read", "writedata", "write"])
 def test_rma_bw_range(cmdline_args, operation_type, completion_semantic, message_size, memory_type):
-    from efa.efa_common import efa_run_client_server_test
     command = "fi_rma_bw -e rdm"
     command = command + " -o " + operation_type
     # rma_bw test with data verification takes longer to finish
     timeout = max(540, cmdline_args.timeout)
     efa_run_client_server_test(cmdline_args, command, "short", completion_semantic, memory_type, message_size, timeout=timeout)
+
+
+@pytest.mark.functional
+@pytest.mark.parametrize("operation_type", ["read", "writedata", "write"])
+def test_rma_bw_range_no_inject(cmdline_args, operation_type, completion_semantic, inject_message_size):
+    command = "fi_rma_bw -e rdm -j 0"
+    command = command + " -o " + operation_type
+    # rma_bw test with data verification takes longer to finish
+    timeout = max(540, cmdline_args.timeout)
+    efa_run_client_server_test(cmdline_args, command, "short", completion_semantic, "host_to_host", inject_message_size, timeout=timeout)


### PR DESCRIPTION
Add tests to fabtests that test small message sizes without fi_inject. By default, fabtests injects all host messages when the message size is <= the providers inject size.  This change adds testing coverage for fi_send/fi_rma without inject.