### PR TITLE
[v1.20.x] fabtests: Add dmabuf ops for cuda, add an option to support MR via dmabuf

### DIFF
--- a/fabtests/common/hmem.c
+++ b/fabtests/common/hmem.c
@@ -48,6 +48,8 @@ struct ft_hmem_ops {
 			    size_t size);
 	int (*copy_from_hmem)(uint64_t device, void *dst, const void *src,
 			      size_t size);
+	int (*get_dmabuf_fd)(void *buf, size_t len,
+			     int *fd, uint64_t *offset);
 };
 
 static struct ft_hmem_ops hmem_ops[] = {
@@ -61,6 +63,7 @@ static struct ft_hmem_ops hmem_ops[] = {
 		.mem_set = ft_host_memset,
 		.copy_to_hmem = ft_host_memcpy,
 		.copy_from_hmem = ft_host_memcpy,
+		.get_dmabuf_fd = ft_hmem_no_get_dmabuf_fd,
 	},
 	[FI_HMEM_CUDA] = {
 		.init = ft_cuda_init,
@@ -72,6 +75,7 @@ static struct ft_hmem_ops hmem_ops[] = {
 		.mem_set = ft_cuda_memset,
 		.copy_to_hmem = ft_cuda_copy_to_hmem,
 		.copy_from_hmem = ft_cuda_copy_from_hmem,
+		.get_dmabuf_fd = ft_cuda_get_dmabuf_fd,
 	},
 	[FI_HMEM_ROCR] = {
 		.init = ft_rocr_init,
@@ -83,6 +87,7 @@ static struct ft_hmem_ops hmem_ops[] = {
 		.mem_set = ft_rocr_memset,
 		.copy_to_hmem = ft_rocr_memcpy,
 		.copy_from_hmem = ft_rocr_memcpy,
+		.get_dmabuf_fd = ft_hmem_no_get_dmabuf_fd,
 	},
 	[FI_HMEM_ZE] = {
 		.init = ft_ze_init,
@@ -94,6 +99,7 @@ static struct ft_hmem_ops hmem_ops[] = {
 		.mem_set = ft_ze_memset,
 		.copy_to_hmem = ft_ze_copy,
 		.copy_from_hmem = ft_ze_copy,
+		.get_dmabuf_fd = ft_hmem_no_get_dmabuf_fd,
 	},
 	[FI_HMEM_NEURON] = {
 		.init = ft_neuron_init,
@@ -105,6 +111,7 @@ static struct ft_hmem_ops hmem_ops[] = {
 		.mem_set = ft_neuron_memset,
 		.copy_to_hmem = ft_neuron_memcpy_to_hmem,
 		.copy_from_hmem = ft_neuron_memcpy_from_hmem,
+		.get_dmabuf_fd = ft_hmem_no_get_dmabuf_fd,
 	},
 };
 
@@ -182,4 +189,17 @@ int ft_hmem_copy_from(enum fi_hmem_iface iface, uint64_t device, void *dst,
 		      const void *src, size_t size)
 {
 	return hmem_ops[iface].copy_from_hmem(device, dst, src, size);
+}
+
+int ft_hmem_get_dmabuf_fd(enum fi_hmem_iface iface,
+			  void *buf, size_t len,
+			  int *fd, uint64_t *offset)
+{
+	return hmem_ops[iface].get_dmabuf_fd(buf, len, fd, offset);
+}
+
+int ft_hmem_no_get_dmabuf_fd(void *buf, size_t len,
+			      int *fd, uint64_t *offset)
+{
+	return -FI_ENOSYS;
 }

--- a/fabtests/configure.ac
+++ b/fabtests/configure.ac
@@ -122,6 +122,8 @@ AC_ARG_WITH([libfabric],
             [])
 
 dnl Check for CUDA support. Require fabtests to dlopen CUDA runtime.
+have_cuda=0
+have_cuda_dmabuf=0
 AC_ARG_WITH([cuda],
             [AS_HELP_STRING([--with-cuda=DIR],
                             [Provide path to where the CUDA development
@@ -131,10 +133,33 @@ AC_ARG_WITH([cuda],
                    [])
              CPPFLAGS="-I$withval/include $CPPFLAGS"
              AC_CHECK_HEADER([cuda_runtime.h],
-                             [AC_DEFINE([HAVE_CUDA_RUNTIME_H], [1],
-                                        [Define to 1 if you have <cuda_runtime.h>])],
+                             [have_cuda=1],
                              [AC_MSG_ERROR([<cuda_runtime.h> not found])])],
             [])
+
+AC_DEFINE_UNQUOTED([HAVE_CUDA_RUNTIME_H], [$have_cuda],
+            [Define to 1 if you have <cuda_runtime.h>])
+
+AS_IF([test x"$have_cuda" = x"1"],
+      [
+            have_cuda_dmabuf=1
+            AC_CHECK_DECL([cuMemGetHandleForAddressRange],
+		      [],
+		      [have_cuda_dmabuf=0],
+		      [[#include <cuda.h>]])
+
+            AC_CHECK_DECL([CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED],
+		      [],
+		      [have_cuda_dmabuf=0],
+		      [[#include <cuda.h>]])
+
+            AC_CHECK_DECL([CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD],
+		      [],
+		      [have_cuda_dmabuf=0],
+		      [[#include <cuda.h>]])
+      ])
+
+AC_DEFINE_UNQUOTED([HAVE_CUDA_DMABUF], [$have_cuda_dmabuf], [CUDA dmabuf support])
 
 dnl Check for ROCR support. Require fabtests to dlopen ROCR.
 AC_ARG_WITH([rocr],

--- a/fabtests/functional/unexpected_msg.c
+++ b/fabtests/functional/unexpected_msg.c
@@ -58,9 +58,6 @@ static bool send_data = false;
 static int alloc_bufs(void)
 {
 	int ret;
-	uint64_t flags;
-	struct iovec iov;
-	struct fi_mr_attr mr_attr;
 
 	tx_size = MAX(opts.transfer_size, FT_MAX_CTRL_MSG) + ft_tx_prefix_size();
 	rx_size = MAX(opts.transfer_size, FT_MAX_CTRL_MSG) + ft_rx_prefix_size();
@@ -85,21 +82,13 @@ static int alloc_bufs(void)
 	rx_buf = buf;
 	tx_buf = (char *) buf + rx_size * concurrent_msgs;
 
-	if (ft_need_mr_reg(fi)) {
-		iov.iov_base = buf;
-		iov.iov_len = buf_size;
+	ret = ft_reg_mr(fi, buf, buf_size, ft_info_to_mr_access(fi), FT_MR_KEY,
+		opts.iface, opts.device, &mr, &mr_desc);
 
-		ft_fill_mr_attr(&iov, NULL, 1, ft_info_to_mr_access(fi), FT_MR_KEY,
-				opts.iface, opts.device, &mr_attr, 0);
-
-		flags = (opts.iface) ? FI_HMEM_DEVICE_ONLY : 0;
-		ret = fi_mr_regattr(domain, &mr_attr, flags, &mr);
-		if (ret)
-			return ret;
-
-		mr_desc = fi_mr_desc(mr);
+	if (ret) {
+		FT_ERR("ft_reg_mr failed: %d\n", ret);
+		return ret;
 	}
-
 	return 0;
 }
 

--- a/fabtests/functional/unexpected_msg.c
+++ b/fabtests/functional/unexpected_msg.c
@@ -89,8 +89,8 @@ static int alloc_bufs(void)
 		iov.iov_base = buf;
 		iov.iov_len = buf_size;
 
-		ft_fill_mr_attr(&iov, 1, ft_info_to_mr_access(fi), FT_MR_KEY,
-				opts.iface, opts.device, &mr_attr);
+		ft_fill_mr_attr(&iov, NULL, 1, ft_info_to_mr_access(fi), FT_MR_KEY,
+				opts.iface, opts.device, &mr_attr, 0);
 
 		flags = (opts.iface) ? FI_HMEM_DEVICE_ONLY : 0;
 		ret = fi_mr_regattr(domain, &mr_attr, flags, &mr);

--- a/fabtests/include/hmem.h
+++ b/fabtests/include/hmem.h
@@ -182,6 +182,8 @@ int ft_cuda_copy_to_hmem(uint64_t device, void *dst, const void *src,
 			 size_t size);
 int ft_cuda_copy_from_hmem(uint64_t device, void *dst, const void *src,
 			   size_t size);
+int ft_cuda_get_dmabuf_fd(void *buf, size_t len,
+			  int *fd, uint64_t *offset);
 int ft_rocr_init(void);
 int ft_rocr_cleanup(void);
 int ft_rocr_alloc(uint64_t device, void **buf, size_t size);
@@ -210,5 +212,10 @@ int ft_hmem_copy_to(enum fi_hmem_iface iface, uint64_t device, void *dst,
 		    const void *src, size_t size);
 int ft_hmem_copy_from(enum fi_hmem_iface iface, uint64_t device, void *dst,
 		      const void *src, size_t size);
+int ft_hmem_get_dmabuf_fd(enum fi_hmem_iface iface,
+			  void *buf, size_t len,
+			  int *fd, uint64_t *offset);
+int ft_hmem_no_get_dmabuf_fd(void *buf, size_t len,
+			     int *fd, uint64_t *offset);
 
 #endif /* _HMEM_H_ */

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -687,4 +687,15 @@ void ft_longopts_usage();
 }
 #endif
 
+static inline void *ft_get_page_start(const void *addr, size_t page_size)
+{
+	return (void *)((uintptr_t) addr & ~(page_size - 1));
+}
+
+static inline void *ft_get_page_end(const void *addr, size_t page_size)
+{
+	return (void *)((uintptr_t)ft_get_page_start((const char *)addr
+			+ page_size, page_size) - 1);
+}
+
 #endif /* _SHARED_H_ */

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -134,6 +134,7 @@ enum {
 	FT_OPT_PERF			= 1 << 24,
 	FT_OPT_DISABLE_TAG_VALIDATION	= 1 << 25,
 	FT_OPT_ADDR_IS_OOB		= 1 << 26,
+	FT_OPT_REG_DMABUF_MR		= 1 << 27,
 	FT_OPT_OOB_CTRL			= FT_OPT_OOB_SYNC | FT_OPT_OOB_ADDR_EXCH,
 };
 
@@ -278,7 +279,7 @@ extern int sock, oob_sock;
 extern int listen_sock;
 #define ADDR_OPTS "B:P:s:a:b::E::C:F:O:"
 #define FAB_OPTS "f:d:p:K"
-#define HMEM_OPTS "D:i:H"
+#define HMEM_OPTS "D:i:HR"
 #define INFO_OPTS FAB_OPTS HMEM_OPTS "e:M:"
 #define CS_OPTS ADDR_OPTS "I:QS:mc:t:w:l"
 #define API_OPTS "o:"
@@ -452,9 +453,10 @@ int ft_init_av_dst_addr(struct fid_av *av_ptr, struct fid_ep *ep_ptr,
 int ft_init_av_addr(struct fid_av *av, struct fid_ep *ep,
 		fi_addr_t *addr);
 int ft_exchange_keys(struct fi_rma_iov *peer_iov);
-void ft_fill_mr_attr(struct iovec *iov, int iov_count, uint64_t access,
+void ft_fill_mr_attr(struct iovec *iov, struct fi_mr_dmabuf *dmabuf,
+		     int iov_count, uint64_t access,
 		     uint64_t key, enum fi_hmem_iface iface, uint64_t device,
-		     struct fi_mr_attr *attr);
+		     struct fi_mr_attr *attr, uint64_t flags);
 bool ft_need_mr_reg(struct fi_info *fi);
 int ft_reg_mr(struct fi_info *info, void *buf, size_t size, uint64_t access,
 	      uint64_t key, enum fi_hmem_iface iface, uint64_t device,

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -53,7 +53,7 @@ extern "C" {
 #endif
 
 #ifndef FT_FIVERSION
-#define FT_FIVERSION FI_VERSION(1,18)
+#define FT_FIVERSION FI_VERSION(1,20)
 #endif
 
 #include "ft_osd.h"

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -458,6 +458,9 @@ void ft_fill_mr_attr(struct iovec *iov, struct fi_mr_dmabuf *dmabuf,
 		     uint64_t key, enum fi_hmem_iface iface, uint64_t device,
 		     struct fi_mr_attr *attr, uint64_t flags);
 bool ft_need_mr_reg(struct fi_info *fi);
+int ft_get_dmabuf_from_iov(struct fi_mr_dmabuf *dmabuf,
+			   struct iovec *iov, size_t iov_count,
+			   enum fi_hmem_iface iface);
 int ft_reg_mr(struct fi_info *info, void *buf, size_t size, uint64_t access,
 	      uint64_t key, enum fi_hmem_iface iface, uint64_t device,
 	      struct fid_mr **mr, void **desc);

--- a/fabtests/pytest/common.py
+++ b/fabtests/pytest/common.py
@@ -293,10 +293,12 @@ class ClientServerTest:
                  memory_type="host_to_host",
                  timeout=None,
                  warmup_iteration_type=None,
-                 completion_type="queue"):
+                 completion_type="queue",
+                 do_dmabuf_reg_for_hmem=False):
 
         self._cmdline_args = cmdline_args
         self._timeout = timeout or cmdline_args.timeout
+        self.do_dmabuf_reg_for_hmem = do_dmabuf_reg_for_hmem
         self._server_base_command, server_additonal_environment = self.prepare_base_command("server", executable, iteration_type,
                                                               completion_semantic, prefix_type,
                                                               datacheck_type, message_size,
@@ -397,6 +399,10 @@ class ClientServerTest:
                 pytest.skip("no {} device".format(host_memory_type))
 
         command += " -D " + host_memory_type
+
+        if self.do_dmabuf_reg_for_hmem:
+            command += " -R"
+
         additional_environment = None
 
         if "PYTEST_XDIST_WORKER" in os.environ:

--- a/fabtests/unit/mr_test.c
+++ b/fabtests/unit/mr_test.c
@@ -178,8 +178,8 @@ static int mr_regattr()
 			base += iov[j].iov_len;
 		}
 
-		ft_fill_mr_attr(&iov[0], n, ft_info_to_mr_access(fi),
-				FT_MR_KEY, opts.iface, opts.device, &attr);
+		ft_fill_mr_attr(&iov[0], NULL, n, ft_info_to_mr_access(fi),
+				FT_MR_KEY, opts.iface, opts.device, &attr, 0);
 		ret = fi_mr_regattr(domain, &attr, 0, &mr);
 		if (ret) {
 			FT_UNIT_STRERR(err_buf, "fi_mr_regattr failed", ret);
@@ -213,8 +213,8 @@ static int mr_reg_free_then_alloc()
 	for (i = 0; i < numtry; ++i) {
 		iov.iov_base = buf;
 		iov.iov_len = buf_size;
-		ft_fill_mr_attr(&iov, 1, ft_info_to_mr_access(fi),
-				FT_MR_KEY, opts.iface, opts.device, &attr);
+		ft_fill_mr_attr(&iov, NULL, 1, ft_info_to_mr_access(fi),
+				FT_MR_KEY, opts.iface, opts.device, &attr, 0);
 
 		ret = fi_mr_regattr(domain, &attr, 0, &mr);
 		if (ret) {


### PR DESCRIPTION
Backport https://github.com/ofiwg/libfabric/pull/9500 to v1.20.x