### PR TITLE
fabtests/pytest: add cmdline argument for dmabuf reg

### DIFF
--- a/fabtests/pytest/common.py
+++ b/fabtests/pytest/common.py
@@ -293,12 +293,10 @@ class ClientServerTest:
                  memory_type="host_to_host",
                  timeout=None,
                  warmup_iteration_type=None,
-                 completion_type="queue",
-                 do_dmabuf_reg_for_hmem=False):
+                 completion_type="queue"):
 
         self._cmdline_args = cmdline_args
         self._timeout = timeout or cmdline_args.timeout
-        self.do_dmabuf_reg_for_hmem = do_dmabuf_reg_for_hmem
         self._server_base_command, server_additonal_environment = self.prepare_base_command("server", executable, iteration_type,
                                                               completion_semantic, prefix_type,
                                                               datacheck_type, message_size,
@@ -400,7 +398,7 @@ class ClientServerTest:
 
         command += " -D " + host_memory_type
 
-        if self.do_dmabuf_reg_for_hmem:
+        if self._cmdline_args.do_dmabuf_reg_for_hmem:
             command += " -R"
 
         additional_environment = None

--- a/fabtests/pytest/efa/test_mr.py
+++ b/fabtests/pytest/efa/test_mr.py
@@ -26,9 +26,14 @@ def test_mr_hmem(cmdline_args, hmem_type):
 
     cmdline_args_copy = copy.copy(cmdline_args)
 
+    test_command = f"fi_mr_test -D {hmem_type}"
+
+    if cmdline_args.do_dmabuf_reg_for_hmem:
+        test_command += " -R"
+
     test = UnitTest(
         cmdline_args_copy,
-        f"fi_mr_test -D {hmem_type}",
+        test_command,
         failing_warn_msgs=["Unable to add MR to map"],
     )
     test.run()

--- a/fabtests/pytest/options.yaml
+++ b/fabtests/pytest/options.yaml
@@ -92,3 +92,7 @@ oob_address_exchange:
   type: boolean
   help: "out-of-band address exchange over the default port"
   shortform: -b
+do_dmabuf_reg_for_hmem:
+  type: boolean
+  help: "Register hmem memory via dmabuf"
+  longform: --do-dmabuf-reg-for-hmem


### PR DESCRIPTION
This PR contains 2 commits
The first commit makes `do_dmabuf_reg_for_hmem` a cmdline argument to allow user to toggle it without modifying the scripts.

The second commit is to make efa's test_mr.py recognize this argument