### PR TITLE
prov/efa: Try to register user buffer for long CTS protocol

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_pke_rtm.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtm.c
@@ -1001,6 +1001,8 @@ int efa_rdm_pke_init_longcts_rtm_common(struct efa_rdm_pke *pkt_entry,
 	struct efa_rdm_longcts_rtm_base_hdr *rtm_hdr;
 	int ret;
 
+	efa_rdm_ope_try_fill_desc(txe, 0, FI_SEND);
+
 	ret = efa_rdm_pke_init_rtm_with_payload(pkt_entry, pkt_type, txe, 0, -1);
 	if (ret)
 		return ret;


### PR DESCRIPTION
In the medium message protocol, we try to register the user buffer and send from the user buffer to avoid a copy 
https://github.com/ofiwg/libfabric/blob/71ba4cbb253e8b91b1d9b3ab9023cdb962bc9a5b/prov/efa/src/rdm/efa_rdm_pke_rtm.c#L734 and https://github.com/ofiwg/libfabric/blob/71ba4cbb253e8b91b1d9b3ab9023cdb962bc9a5b/prov/efa/src/rdm/efa_rdm_pke_rtm.c#L763
But somehow we don't do the same for long CTS protocol. Fix that.