### PR TITLE
prov/verbs: Non blocking EP creation (asynchronous route resolution using event channel)

### DIFF
--- a/prov/verbs/src/verbs_cm.c
+++ b/prov/verbs/src/verbs_cm.c
@@ -193,6 +193,17 @@ vrb_msg_ep_connect(struct fid_ep *ep_fid, const void *addr,
 	if (ep->srx)
 		ep->conn_param.srq = 1;
 
+	if (addr) {
+		free(ep->info_attr.dest_addr);
+		ep->info_attr.dest_addr = mem_dup(addr, ofi_sizeofaddr(addr));
+		if (!ep->info_attr.dest_addr) {
+			free(ep->cm_priv_data);
+			ep->cm_priv_data = NULL;
+			return -FI_ENOMEM;
+		}
+		ep->info_attr.dest_addrlen = ofi_sizeofaddr(addr);
+	}
+
 	ofi_genlock_lock(&vrb_ep2_progress(ep)->ep_lock);
 	assert(ep->state == VRB_IDLE);
 	ep->state = VRB_RESOLVE_ROUTE;

--- a/prov/verbs/src/verbs_cm.c
+++ b/prov/verbs/src/verbs_cm.c
@@ -133,7 +133,7 @@ vrb_ep_prepare_rdma_cm_param(struct rdma_conn_param *conn_param,
 	conn_param->rnr_retry_count = 7;
 }
 
-static void
+void
 vrb_msg_ep_prepare_rdma_cm_hdr(void *priv_data,
 				const struct rdma_cm_id *id)
 {
@@ -159,8 +159,7 @@ vrb_msg_ep_connect(struct fid_ep *ep_fid, const void *addr,
 	struct vrb_ep *ep = container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	size_t priv_data_len;
 	struct vrb_cm_data_hdr *cm_hdr;
-	off_t rdma_cm_hdr_len = 0;
-	int ret;
+	int ret = 0;
 
 	if (OFI_UNLIKELY(paramlen > VERBS_CM_DATA_SIZE))
 		return -FI_EINVAL;
@@ -173,18 +172,12 @@ vrb_msg_ep_connect(struct fid_ep *ep_fid, const void *addr,
 		}
 	}
 
-	if (ep->id->route.addr.src_addr.sa_family == AF_IB)
-		rdma_cm_hdr_len = sizeof(struct vrb_rdma_cm_hdr);
-
-	priv_data_len = sizeof(*cm_hdr) + paramlen + rdma_cm_hdr_len;
+	priv_data_len = sizeof(*cm_hdr) + paramlen + sizeof(struct vrb_rdma_cm_hdr);
 	ep->cm_priv_data = malloc(priv_data_len);
 	if (!ep->cm_priv_data)
 		return -FI_ENOMEM;
 
-	if (rdma_cm_hdr_len)
-		vrb_msg_ep_prepare_rdma_cm_hdr(ep->cm_priv_data, ep->id);
-
-	cm_hdr = (void *)((char *)ep->cm_priv_data + rdma_cm_hdr_len);
+	cm_hdr = (void *)((char *)ep->cm_priv_data + sizeof(struct vrb_rdma_cm_hdr));
 	vrb_msg_ep_prepare_cm_data(param, paramlen, cm_hdr);
 	vrb_ep_prepare_rdma_cm_param(&ep->conn_param, ep->cm_priv_data,
 					priv_data_len);

--- a/prov/verbs/src/verbs_cm.c
+++ b/prov/verbs/src/verbs_cm.c
@@ -199,11 +199,15 @@ vrb_msg_ep_connect(struct fid_ep *ep_fid, const void *addr,
 
 	ofi_genlock_lock(&vrb_ep2_progress(ep)->ep_lock);
 	assert(ep->state == VRB_IDLE);
-	ep->state = VRB_RESOLVE_ROUTE;
-	ret = rdma_resolve_route(ep->id, VERBS_RESOLVE_TIMEOUT);
-	if (ret) {
+	ep->state = VRB_RESOLVE_ADDR;
+	if (rdma_resolve_addr(ep->id, ep->info_attr.src_addr,
+			      ep->info_attr.dest_addr, VERBS_RESOLVE_TIMEOUT)) {
 		ret = -errno;
-		VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "rdma_resolve_route");
+		VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "rdma_resolve_addr");
+		ofi_straddr_log(&vrb_prov, FI_LOG_WARN, FI_LOG_EP_CTRL,
+				"src addr", ep->info_attr.src_addr);
+		ofi_straddr_log(&vrb_prov, FI_LOG_WARN, FI_LOG_EP_CTRL,
+				"dst addr", ep->info_attr.dest_addr);
 		free(ep->cm_priv_data);
 		ep->cm_priv_data = NULL;
 		ep->state = VRB_IDLE;

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -608,7 +608,7 @@ err1:
 }
 
 
-int vrb_init_progress(struct vrb_progress *progress, struct ibv_context *verbs)
+int vrb_init_progress(struct vrb_progress *progress, struct fi_info *info)
 {
 	int ret;
 

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -416,7 +416,7 @@ vrb_domain(struct fid_fabric *fabric, struct fi_info *info,
 		goto err4;
 	}
 
-	ret = vrb_init_progress(&_domain->progress, _domain->verbs);
+	ret = vrb_init_progress(&_domain->progress, _domain->info);
 	if (ret)
 		goto err4;
 

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -884,6 +884,14 @@ vrb_eq_cm_process_event(struct vrb_eq *eq,
 		ofi_genlock_lock(&vrb_ep2_progress(ep)->ep_lock);
 		assert(ep->state == VRB_RESOLVE_ROUTE);
 		ep->state = VRB_CONNECTING;
+
+		if (cma_event->id->route.addr.src_addr.sa_family != AF_IB) {
+			vrb_eq_skip_rdma_cm_hdr((const void **)&ep->conn_param.private_data,
+						(size_t *)&ep->conn_param.private_data_len);
+		} else {
+			vrb_msg_ep_prepare_rdma_cm_hdr(ep->cm_priv_data, ep->id);
+		}
+
 		if (rdma_connect(ep->id, &ep->conn_param)) {
 			ep->state = VRB_DISCONNECTED;
 			ret = -errno;

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -941,6 +941,11 @@ vrb_eq_cm_process_event(struct vrb_eq *eq,
 		ofi_genlock_lock(&vrb_ep2_progress(ep)->ep_lock);
 		ret = vrb_eq_addr_resolved_event(ep);
 		ofi_genlock_unlock(&vrb_ep2_progress(ep)->ep_lock);
+		if (ret != -FI_EAGAIN) {
+			eq->err.err = -ret;
+			eq->err.prov_errno = ret;
+			goto err;
+		}
 		goto ack;
 
 	case RDMA_CM_EVENT_ROUTE_RESOLVED:
@@ -971,6 +976,11 @@ vrb_eq_cm_process_event(struct vrb_eq *eq,
 			ret = -FI_EAGAIN;
 		}
 		ofi_genlock_unlock(&vrb_ep2_progress(ep)->ep_lock);
+		if (ret != -FI_EAGAIN) {
+			eq->err.err = -ret;
+			eq->err.prov_errno = ret;
+			goto err;
+		}
 		goto ack;
 	case RDMA_CM_EVENT_CONNECT_REQUEST:
 		*event = FI_CONNREQ;

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -875,6 +875,7 @@ vrb_eq_addr_resolved_event(struct vrb_ep *ep)
 	if (ep->util_ep.type == FI_EP_MSG) {
 		vrb_msg_ep_get_qp_attr(ep, &attr);
 
+		/* Client-side QP creation */
 		if (rdma_create_qp(ep->id, vrb_ep2_domain(ep)->pd, &attr)) {
 			ep->state = VRB_DISCONNECTED;
 			ret = -errno;

--- a/prov/verbs/src/verbs_init.c
+++ b/prov/verbs/src/verbs_init.c
@@ -338,29 +338,9 @@ int vrb_create_ep(struct vrb_ep *ep, enum rdma_port_space ps,
 		goto err1;
 	}
 
-	/* TODO convert this call to non-blocking (use event channel) as well:
-	 * This may likely be needed for better scaling when running large
-	 * MPI jobs.
-	 * Making this non-blocking would mean we can't create QP at EP enable
-	 * time. We need to wait for RDMA_CM_EVENT_ADDR_RESOLVED event before
-	 * creating the QP using rdma_create_qp. It would also require a SW
-	 * receive queue to store recvs posted by app after enabling the EP.
-	 */
-	if (rdma_resolve_addr(*id, rai->ai_src_addr, rai->ai_dst_addr,
-			      VERBS_RESOLVE_TIMEOUT)) {
-		ret = -errno;
-		VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "rdma_resolve_addr");
-		ofi_straddr_log(&vrb_prov, FI_LOG_WARN, FI_LOG_EP_CTRL,
-				"src addr", rai->ai_src_addr);
-		ofi_straddr_log(&vrb_prov, FI_LOG_WARN, FI_LOG_EP_CTRL,
-				"dst addr", rai->ai_dst_addr);
-		goto err2;
-	}
 	rdma_freeaddrinfo(rai);
 	return 0;
 
-err2:
-	rdma_destroy_id(*id);
 err1:
 	rdma_freeaddrinfo(rai);
 	return ret;

--- a/prov/verbs/src/verbs_init.c
+++ b/prov/verbs/src/verbs_init.c
@@ -295,17 +295,20 @@ int vrb_get_rai_id(const char *node, const char *service, uint64_t flags,
 		return 0;
 	}
 
-	ret = rdma_resolve_addr(*id, (*rai)->ai_src_addr,
-				(*rai)->ai_dst_addr, VERBS_RESOLVE_TIMEOUT);
-	if (ret) {
-		VRB_WARN_ERRNO(FI_LOG_FABRIC, "rdma_resolve_addr");
-		ofi_straddr_log(&vrb_prov, FI_LOG_INFO, FI_LOG_FABRIC,
-				"src addr", (*rai)->ai_src_addr);
-		ofi_straddr_log(&vrb_prov, FI_LOG_INFO, FI_LOG_FABRIC,
-				"dst addr", (*rai)->ai_dst_addr);
-		ret = -errno;
-		goto err2;
+	if (node || (hints && hints->dest_addr)) {
+		ret = rdma_resolve_addr(*id, (*rai)->ai_src_addr,
+					(*rai)->ai_dst_addr, VERBS_RESOLVE_TIMEOUT);
+		if (ret) {
+			VRB_WARN_ERRNO(FI_LOG_FABRIC, "rdma_resolve_addr");
+			ofi_straddr_log(&vrb_prov, FI_LOG_INFO, FI_LOG_FABRIC,
+					"src addr", (*rai)->ai_src_addr);
+			ofi_straddr_log(&vrb_prov, FI_LOG_INFO, FI_LOG_FABRIC,
+					"dst addr", (*rai)->ai_dst_addr);
+			ret = -errno;
+			goto err2;
+		}
 	}
+
 	return 0;
 err2:
 	if (rdma_destroy_id(*id))

--- a/prov/verbs/src/verbs_ofi.h
+++ b/prov/verbs/src/verbs_ofi.h
@@ -593,6 +593,7 @@ struct vrb_ep {
 	uint64_t			saved_peer_rq_credits;
 	struct slist			sq_list;
 	struct slist			rq_list;
+	struct slist			prepost_wr_list;
 	/* Protected by recv CQ lock */
 	int64_t				rq_credits_avail;
 	int64_t				threshold;
@@ -943,6 +944,7 @@ struct vrb_recv_wr {
 void vrb_shutdown_ep(struct vrb_ep *ep);
 ssize_t vrb_post_send(struct vrb_ep *ep, struct ibv_send_wr *wr, uint64_t flags);
 ssize_t vrb_post_recv(struct vrb_ep *ep, struct ibv_recv_wr *wr);
+int vrb_post_recv_internal(struct vrb_ep *ep, struct ibv_recv_wr *wr);
 
 static inline ssize_t
 vrb_send_buf(struct vrb_ep *ep, struct ibv_send_wr *wr,

--- a/prov/verbs/src/verbs_ofi.h
+++ b/prov/verbs/src/verbs_ofi.h
@@ -264,7 +264,7 @@ struct vrb_progress {
 	struct ofi_bufpool	*ctx_pool;
 };
 
-int vrb_init_progress(struct vrb_progress *progress, struct ibv_context *verbs);
+int vrb_init_progress(struct vrb_progress *progress, struct fi_info *info);
 void vrb_close_progress(struct vrb_progress *progress);
 
 struct vrb_eq_entry {

--- a/prov/verbs/src/verbs_ofi.h
+++ b/prov/verbs/src/verbs_ofi.h
@@ -575,6 +575,7 @@ struct vrb_xrc_ep_conn_setup {
 
 enum vrb_ep_state {
 	VRB_IDLE,
+	VRB_RESOLVE_ADDR,
 	VRB_RESOLVE_ROUTE,
 	VRB_CONNECTING,
 	VRB_REQ_RCVD,

--- a/prov/verbs/src/verbs_ofi.h
+++ b/prov/verbs/src/verbs_ofi.h
@@ -783,6 +783,9 @@ void vrb_eq_remove_sidr_conn(struct vrb_xrc_ep *ep);
 
 void vrb_msg_ep_get_qp_attr(struct vrb_ep *ep,
 			       struct ibv_qp_init_attr *attr);
+void vrb_msg_ep_prepare_rdma_cm_hdr(void *priv_data,
+				    const struct rdma_cm_id *id);
+
 int vrb_process_xrc_connreq(struct vrb_ep *ep,
 			       struct vrb_connreq *connreq);
 


### PR DESCRIPTION
The PR reworks the verbs provider to avoid blocking the caller in `rdma_resolve_route()`. 
The solution I implemented is based on the following TODO from `vrb_create_ep()`:
```
       /* TODO convert this call to non-blocking (use event channel) as well:
        * This may likely be needed for better scaling when running large
        * MPI jobs.
        * Making this non-blocking would mean we can't create QP at EP enable
        * time. We need to wait for RDMA_CM_EVENT_ADDR_RESOLVED event before
        * creating the QP using rdma_create_qp. It would also require a SW
        * receive queue to store recvs posted by app after enabling the EP.
        */
```

Fixes #9494