### PR TITLE
[v1.19.x] configure.ac Fix `--with-lttng` causing `yes/` to populate {CPP,LD}FLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -752,7 +752,7 @@ AS_IF([test -n "$with_lttng" && test x"$with_lttng" != x"no"],
                         [AC_MSG_ERROR([LTTNG is requested but no found. Please check your prefix])])
       ])
 
-AS_IF([test "$have_lttng" = "1"],
+AS_IF([test "$have_lttng" = "1" && test x"$with_lttng" != x"yes"],
       [CPPFLAGS="$CPPFLAGS $lttng_CPPFLAGS"
        LDFLAGS="$LDFLAGS $lttng_LDFLAGS"])
 


### PR DESCRIPTION
When configured with LTTng-UST support without specifying an installation prefix (--with-lttng), the resulting CPPFLAGS and LDFLAGS contain the (likely) non-existant `yes/` path.

This is a little hacky since it technically breaks builds for people who use `yes/` for some reason, but seems to be the convention used elsewhere.

Signed-off-by: Darryl Abbate <drl@amazon.com>
(cherry picked from commit bbcbaf24af9c232a50a41c87f89d196e641f8bda)

NOTE:

This commit is cherry-picked from main to make CI build check work properly. Without this one, the '--with-lttng' configure option used by CI would lead to failure with the following error message:

    checking if libibverbs is linkable by libtool... no
    ......
    configure: verbs provider: disabled
    configure: WARNING: verbs provider was requested, but cannot be compiled
    configure: error: Cannot continue

Commented-by: Jianxin Xiong <jianxin.xiong@intel.com>