### PR TITLE
fabtests/efa: Make 1G tests run faster

### DIFF
--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -87,9 +87,9 @@ def test_rdm_tagged_peek(cmdline_args):
 # This test is run in serial mode because it takes a lot of memory
 @pytest.mark.serial
 @pytest.mark.functional
-def test_rdm_pingpong_1G(cmdline_args, completion_semantic, memory_type):
+def test_rdm_pingpong_1G(cmdline_args, completion_semantic):
     # Default window size is 64 resulting in 128GB being registered, which
     # exceeds max number of registered host pages
-    efa_run_client_server_test(cmdline_args, "fi_rdm_pingpong -W 1", "short",
+    efa_run_client_server_test(cmdline_args, "fi_rdm_pingpong -W 1", 2,
                                completion_semantic=completion_semantic, message_size=1073741824,
-                               memory_type=memory_type, warmup_iteration_type=0)
+                               memory_type="host_to_host", warmup_iteration_type=0)

--- a/fabtests/pytest/efa/test_rma_bw.py
+++ b/fabtests/pytest/efa/test_rma_bw.py
@@ -39,12 +39,12 @@ def test_rma_bw_range_no_inject(cmdline_args, operation_type, completion_semanti
 @pytest.mark.functional
 # TODO Add "writedata", "write" back in when EFA firmware bug is fixed
 @pytest.mark.parametrize("operation_type", ["read"])
-def test_rma_bw_1G(cmdline_args, operation_type, completion_semantic, memory_type):
+def test_rma_bw_1G(cmdline_args, operation_type, completion_semantic):
     # Default window size is 64 resulting in 128GB being registered, which
     # exceeds max number of registered host pages
     timeout = max(540, cmdline_args.timeout)
     command = "fi_rma_bw -e rdm -W 1"
     command = command + " -o " + operation_type
-    efa_run_client_server_test(cmdline_args, command, "short",
+    efa_run_client_server_test(cmdline_args, command, 2,
                                completion_semantic=completion_semantic, message_size=1073741824,
-                               memory_type=memory_type, warmup_iteration_type=0, timeout=timeout)
+                               memory_type="host_to_host", warmup_iteration_type=0, timeout=timeout)


### PR DESCRIPTION
Reduce iterations from 5 to 2, and make 1G tests host only for now.