### PR TITLE
github/actions: Add "-Werror" to CI build check runs

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -65,7 +65,7 @@ jobs:
           export LD_LIBRARY_PATH="${{ env.RDMA_CORE_PATH }}/lib:$LD_LIBRARY_PATH"
           ./autogen.sh
           ./configure --prefix=$PWD/install ${{ env.OFI_PROVIDER_FLAGS }} CC=${{ matrix.cc }} --with-lttng
-          make -j 2; make install
+          make -j 2 AM_CFLAGS="-Wall -Werror"; make install
           DISTCHECK_CONFIGURE_FLAGS="${{ env.OFI_PROVIDER_FLAGS }}" make -j 2 distcheck
           $PWD/install/bin/fi_info -l
       - name: Upload build logs
@@ -111,7 +111,7 @@ jobs:
                                             --with-cuda=/usr/local/cuda --with-ze \
                                             --with-lttng \
                                             CC=${{ matrix.cc }}
-          make -j 2; make install
+          make -j 2 AM_CFLAGS="-Wall -Werror"; make install
           $PWD/install/bin/fi_info -l
           $PWD/install/bin/fi_info -c FI_HMEM
       - name: Upload build logs


### PR DESCRIPTION
Instead of turning on "-Werror" permanently, which has been proven to be troublesome, add the flag to the CI build check pipeline. This way we are still able to identify and fix warnings as early as possible while avoid causing failures to other CI jobs.