### PR TITLE
hmem: Remove duplicate function declarations

### DIFF
--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -181,12 +181,6 @@ int cuda_open_handle(void **handle, size_t size, uint64_t device,
 		     void **ipc_ptr);
 int cuda_close_handle(void *ipc_ptr);
 int cuda_get_base_addr(const void *ptr, size_t len, void **base, size_t *size);
-int cuda_dev_register(const void *addr, size_t size, uint64_t *handle);
-int cuda_dev_unregister(uint64_t handle);
-int cuda_dev_reg_copy_to_hmem(uint64_t handle, void *dest, const void *src,
-			      size_t size);
-int cuda_dev_reg_copy_from_hmem(uint64_t handle, void *dest, const void *src,
-				size_t size);
 
 bool cuda_is_ipc_enabled(void);
 int cuda_get_ipc_handle_size(size_t *size);


### PR DESCRIPTION
Multiple functions are declared twice in ofi_hmem. Remove the duplicates.