### PR TITLE
man: Fix the fi_provider.7 man page for the man page converter

### DIFF
--- a/man/fi_provider.7.md
+++ b/man/fi_provider.7.md
@@ -25,11 +25,11 @@ following diagram illustrates the architecture between the provider
 types.
 
 ```
----------------------------- libfabric API ----------------------------
+---------------------------- libfabric API ---------------------------- 
   [core]   provider|<- [hooking provider]
-[services]   API   |  --- libfabric API ---
+[services]   API   |  --- libfabric API --- 
                    |<- [utility provider]
-                   |  ---------------- libfabric API ------------------
+                   |  ---------------- libfabric API ------------------ 
                    |<-  [core provider] <-peer API-> [offload provider]
 
 ```


### PR DESCRIPTION
The perl script to convert markdown to man page would remove all content between to lines ending with '---'. Add a space to the end of such lines that are not intended to match the pattern.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>
(cherry picked from commit 23043e73a48af74652d0199d04d0238e5e7926de)