### PR TITLE
man: Clarify the usage of FI_RMOTE_CQ_DATA flag

### DIFF
--- a/man/fi_msg.3.md
+++ b/man/fi_msg.3.md
@@ -219,10 +219,10 @@ The following list of flags are usable with fi_recvmsg and/or
 fi_sendmsg.
 
 *FI_REMOTE_CQ_DATA*
-: Applies to fi_sendmsg and fi_senddata.  Indicates
-  that remote CQ data is available and should be sent as part of the
-  request.  See fi_getinfo for additional details on
-  FI_REMOTE_CQ_DATA.
+: Applies to fi_sendmsg.  Indicates that remote CQ data is available
+  and should be sent as part of the request.  See fi_getinfo for
+  additional details on FI_REMOTE_CQ_DATA.  This flag is implicitly
+  set for fi_senddata and fi_injectdata.
 
 *FI_CLAIM*
 : Applies to posted receive operations for endpoints configured

--- a/man/fi_rma.3.md
+++ b/man/fi_rma.3.md
@@ -220,10 +220,10 @@ The following list of flags are usable with fi_readmsg and/or
 fi_writemsg.
 
 *FI_REMOTE_CQ_DATA*
-: Applies to fi_writemsg and fi_writedata.  Indicates
-  that remote CQ data is available and should be sent as part of the
-  request.  See fi_getinfo for additional details on
-  FI_REMOTE_CQ_DATA.
+: Applies to fi_writemsg.  Indicates that remote CQ data is available
+  and should be sent as part of the request.  See fi_getinfo for
+  additional details on FI_REMOTE_CQ_DATA.  This flag is implicitly
+  set for fi_writedata and fi_inject_writedata.
 
 *FI_COMPLETION*
 : Indicates that a completion entry should be generated for the

--- a/man/fi_tagged.3.md
+++ b/man/fi_tagged.3.md
@@ -238,10 +238,10 @@ fi_endpoint).  The following list of flags are usable with fi_trecvmsg
 and/or fi_tsendmsg.
 
 *FI_REMOTE_CQ_DATA*
-: Applies to fi_tsendmsg and fi_tsenddata.  Indicates
-  that remote CQ data is available and should be sent as part of the
-  request.  See fi_getinfo for additional details on
-  FI_REMOTE_CQ_DATA.
+: Applies to fi_tsendmsg.  Indicates that remote CQ data is available
+  and should be sent as part of the request.  See fi_getinfo for
+  additional details on FI_REMOTE_CQ_DATA.  This flag is implicitly
+  set for fi_tsenddata and fi_tinjectdata.
 
 *FI_COMPLETION*
 : Indicates that a completion entry should be generated for the


### PR DESCRIPTION
The man pages of `fi_msg`, `fi_tagged`, and `fi_rma` gave the false impression that the behavior of `fi_*data` calls could be affected by whether this flag is set. In reality, the flag is not a valid choice for endpoint `op_flags` and the `fi_*data` calls always act as if the flag is set.

Update the man pages to eliminate the confusion.

Reference: https://github.com/ofiwg/libfabric/discussions/9527