### PR TITLE
hmem/rocr: Add ROCr dmabuf support under verbs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -928,6 +928,7 @@ AC_ARG_WITH([rocr],
 
 have_rocr=0
 rocr_dlopen=0
+have_hsa_amd_portable_export_dmabuf=0
 AC_ARG_ENABLE([rocr-dlopen],
     [AS_HELP_STRING([--enable-rocr-dlopen],
         [Enable dlopen of ROCR libraries @<:@default=no@:>@])
@@ -970,7 +971,20 @@ AC_DEFINE_UNQUOTED([HAVE_ROCR], [$have_rocr], [ROCR support])
 AS_IF([test "$rocr_dlopen" != "1"], [LIBS="$LIBS $rocr_LIBS"])
 AS_IF([test "$have_rocr" = "1" && test x"$with_rocr" != x"yes"],
       [CPPFLAGS="$CPPFLAGS $rocr_CPPFLAGS"
-       LDFLAGS="$LDFLAGS $rocr_LDFLAGS"])
+       LDFLAGS="$LDFLAGS $rocr_LDFLAGS"
+       have_hsa_amd_portable_export_dmabuf=1
+       AC_CHECK_DECL([hsa_amd_portable_export_dmabuf],
+                     [],
+                     [have_hsa_amd_portable_export_dmabuf=0],
+                     [[#include <hsa/hsa_ext_amd.h>]])
+
+       AC_CHECK_DECL([HSA_AMD_SYSTEM_INFO_DMABUF_SUPPORTED],
+                     [],
+                     [have_hsa_amd_portable_export_dmabuf=0],
+                     [[#include <hsa/hsa.h>]])
+      ],
+      [])
+AC_DEFINE_UNQUOTED([HAVE_HSA_AMD_PORTABLE_EXPORT_DMABUF],[$have_hsa_amd_portable_export_dmabuf],[dmabuf handle support])
 
 AC_CHECK_SIZEOF([void *])
 

--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -162,6 +162,8 @@ int rocr_dev_reg_copy_to_hmem(uint64_t handle, void *dest, const void *src,
 			      size_t size);
 int rocr_dev_reg_copy_from_hmem(uint64_t handle, void *dest, const void *src,
 				size_t size);
+int rocr_hmem_get_dmabuf_fd(const void *addr, uint64_t size, int *dmabuf_fd,
+			    uint64_t *offset);
 
 int cuda_copy_to_dev(uint64_t device, void *dev, const void *host, size_t size);
 int cuda_copy_from_dev(uint64_t device, void *host, const void *dev, size_t size);

--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -82,7 +82,7 @@ static struct ibv_mr *vrb_reg_hmem_dmabuf(enum fi_hmem_iface iface,
 
 	err = ofi_hmem_get_dmabuf_fd(iface, buf, len, &fd, &offset);
 	if (err)
-		return NULL;
+		goto failover;
 
 	mr = ibv_reg_dmabuf_mr(pd, offset, len, (uint64_t)buf/* iova */,
 			       fd, vrb_access);

--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -142,8 +142,10 @@ vrb_mr_reg_common(struct vrb_mem_desc *md, int vrb_access, const void *base_addr
 		md->mr = ibv_reg_dmabuf_mr(md->domain->pd, (uintptr_t) buf,
 					   len, (uintptr_t) base_addr + (uintptr_t) buf,
 					   (int) device, vrb_access);
-	else if ((vrb_gl_data.dmabuf_support && iface == FI_HMEM_ZE) ||
-		 (vrb_gl_data.dmabuf_support && iface == FI_HMEM_SYNAPSEAI))
+	else if (vrb_gl_data.dmabuf_support &&
+		 (iface == FI_HMEM_ZE ||
+		  iface == FI_HMEM_SYNAPSEAI ||
+		  iface == FI_HMEM_ROCR))
 		md->mr = vrb_reg_hmem_dmabuf(iface, md->domain->pd, buf, len,
 						vrb_access);
 	else

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -192,7 +192,7 @@ struct ofi_hmem_ops hmem_ops[] = {
 		.dev_unregister = rocr_dev_unregister,
 		.dev_reg_copy_to_hmem = rocr_dev_reg_copy_to_hmem,
 		.dev_reg_copy_from_hmem = rocr_dev_reg_copy_from_hmem,
-		.get_dmabuf_fd = ofi_hmem_no_get_dmabuf_fd,
+		.get_dmabuf_fd = rocr_hmem_get_dmabuf_fd,
 	},
 	[FI_HMEM_ZE] = {
 		.initialized = false,


### PR DESCRIPTION
- Added `get_dmabuf_fd` for ROCr under HMEM interface, it acquires dmabuf handle through HSA runtime and is now invoked by `verbs` providers.
- 3 conditions for support of this functionality: ROCr support, Linux kernel support, and a user set environmental variable `FI_HMEM_ROCR_USE_DMABUF` (please let us know if naming is ok) as a switch that will be checked during runtime
- currently for verbs, if dmabuf handle cannot be successfully acquired for any reason, it will opt to not register any memory region and [just crash](https://github.com/ofiwg/libfabric/blob/main/prov/verbs/src/verbs_mr.c#L85). We are not sure if this is intended or a bug, but tentatively we fixed this and make it invoke failover routine in case of failure.