### PR TITLE
prov/verbs: Address cm_id resource leak in rdma_reject path

### DIFF
--- a/prov/verbs/src/verbs_cm.c
+++ b/prov/verbs/src/verbs_cm.c
@@ -296,6 +296,9 @@ vrb_msg_xrc_ep_reject(struct vrb_connreq *connreq,
 			       connreq->xrc.conn_tag, connreq->xrc.port, 0, 0);
 	ret = rdma_reject(connreq->id, cm_data,
 			  (uint8_t) paramlen) ? -errno : 0;
+	if (rdma_destroy_id(connreq->id))
+		VRB_WARN_ERR(FI_LOG_EP_CTRL, "rdma_destroy_id", -errno);
+	connreq->id = NULL;
 	free(cm_data);
 	return ret;
 }
@@ -324,6 +327,9 @@ vrb_msg_ep_reject(struct fid_pep *pep, fid_t handle,
 	} else if (connreq->id) {
 		ret = rdma_reject(connreq->id, cm_hdr,
 			(uint8_t)(sizeof(*cm_hdr) + paramlen)) ? -errno : 0;
+		if (rdma_destroy_id(connreq->id))
+			VRB_WARN_ERR(FI_LOG_EP_CTRL, "rdma_destroy_id", -errno);
+		connreq->id = NULL;
 	} else {
 		ret = -FI_EBUSY;
 	}

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -540,6 +540,13 @@ vrb_eq_xrc_connreq_event(struct vrb_eq *eq, struct fi_eq_cm_entry *entry,
 send_reject:
 	if (rdma_reject(connreq->id, *priv_data, *priv_datalen))
 		VRB_WARN(FI_LOG_EP_CTRL, "rdma_reject %d\n", -errno);
+	if (rdma_destroy_id(connreq->id))
+		VRB_WARN(FI_LOG_EP_CTRL, "rdma_destroy_id %d\n", -errno);
+
+	ep->base_ep.info_attr.handle = NULL;
+	ep->tgt_id = NULL;
+	ep->recip_req_received = 0;
+	connreq->id = NULL;
 
 	return -FI_EAGAIN;
 }


### PR DESCRIPTION
Add missing calls to `rdma_destroy_id` after a call to `rdma_reject` to prevent `cm_id` resource leak.

The resource leak can be observed by running `rdma res` and checking the value of `cm_id`. Each time a passive endpoint rejects an incoming connection, `cm_id` is increased. This behavior is not observed when a connection is accepted and then closed abruptly or gracefully by a call to `fi_shutdown`.

I'm not sure about the correctness of `rdma_destroy_id` in XRC path in verbs_eq.c