### PR TITLE
prov/efa: Do not use shm peer provider when neuron or synapseai devices exist

### DIFF
--- a/prov/efa/src/efa_hmem.c
+++ b/prov/efa/src/efa_hmem.c
@@ -97,6 +97,9 @@ static int efa_domain_hmem_info_init_protocol_thresholds(struct efa_domain *efa_
 		fi_param_get_size_t(&efa_prov, "runt_size", &info->runt_size);
 		fi_param_get_size_t(&efa_prov, "inter_min_read_message_size", &info->min_read_msg_size);
 		fi_param_get_size_t(&efa_prov, "inter_min_read_write_size", &info->min_read_write_size);
+		/* Always turn SHM off for Neuron by default, but let user override if they choose */
+		efa_env.enable_shm_transfer = false;
+		fi_param_get_int(&efa_prov, "enable_shm_transfer", &efa_env.enable_shm_transfer);
 		break;
 	case FI_HMEM_SYNAPSEAI:
 		info->runt_size = 0;
@@ -104,6 +107,9 @@ static int efa_domain_hmem_info_init_protocol_thresholds(struct efa_domain *efa_
 		info->max_medium_msg_size = 0;
 		info->min_read_msg_size = 1;
 		info->min_read_write_size = 1;
+		/* Always turn SHM off for SynapseAI by default, but let user override if they choose  */
+		efa_env.enable_shm_transfer = false;
+		fi_param_get_int(&efa_prov, "enable_shm_transfer", &efa_env.enable_shm_transfer);
 		break;
 	default:
 		break;

--- a/prov/efa/test/efa_unit_test_hmem.c
+++ b/prov/efa/test/efa_unit_test_hmem.c
@@ -2,13 +2,17 @@
 
 
 #if HAVE_NEURON
+#include <dlfcn.h>
+#include "nrt/nrt.h"
+#include "nrt/nrt_experimental.h"
+
 /**
  * @brief Verify when neuron_alloc failed (return null),
  * efa_domain_open, which call efa_hmem_info_update_neuron
  * when HAVE_NEURON=1, will still return 0 but leave
  * efa_hmem_info[FI_HMEM_NEURON].initialized and
  * efa_hmem_info[FI_HMEM_NEURON].p2p_supported_by_device as false.
- * 
+ *
  * @param[in]	state		struct efa_resource that is managed by the framework
  */
 void test_efa_hmem_info_update_neuron(struct efa_resource **state)
@@ -46,9 +50,74 @@ void test_efa_hmem_info_update_neuron(struct efa_resource **state)
         assert_false(efa_domain->hmem_info[FI_HMEM_NEURON].initialized);
         assert_false(efa_domain->hmem_info[FI_HMEM_NEURON].p2p_supported_by_device);
 }
+
+
+int neuron_init(void)
+{
+	NRT_STATUS (*nrt_init)(nrt_framework_type_t framework, const char *fw_version, const char *fal_version);
+	NRT_STATUS ret;
+	void *neuron_handle = NULL;
+
+	neuron_handle = dlopen("libnrt.so.1", RTLD_NOW);
+	if (!neuron_handle) {
+		return -1;
+	}
+
+	nrt_init = dlsym(neuron_handle, "nrt_init");
+	if (!nrt_init) {
+		return -1;
+	}
+
+	ret = nrt_init(NRT_FRAMEWORK_TYPE_NO_FW, "2.0", "");
+	if (ret != NRT_SUCCESS) {
+		return -1;
+	}
+
+	return 0;
+}
+
+
+void test_efa_hmem_neuron_no_shm(struct efa_resource **state)
+{
+	int ret;
+	struct efa_resource *resource = *state;
+	struct efa_domain *efa_domain;
+
+	int no_neuron = neuron_init();
+	if (no_neuron) {
+		/* This test requires that it be run on a neuron instance */
+		skip();
+	}
+
+	resource->hints = efa_unit_test_alloc_hints(FI_EP_RDM);
+	assert_non_null(resource->hints);
+
+	ret = fi_getinfo(FI_VERSION(1, 14), NULL, NULL, 0ULL, resource->hints, &resource->info);
+	assert_int_equal(ret, 0);
+
+	ret = fi_fabric(resource->info->fabric_attr, &resource->fabric, NULL);
+	assert_int_equal(ret, 0);
+
+	ret = fi_domain(resource->fabric, resource->info, &resource->domain, NULL);
+
+	efa_domain = container_of(resource->domain, struct efa_domain,
+				  util_domain.domain_fid.fid);
+
+	/* Make sure that SHM is not being used with Neuron */
+	assert_null(efa_domain->shm_domain);
+	assert_null(efa_domain->shm_info);
+	assert_null(efa_domain->fabric->shm_fabric);
+
+	/* TODO: When we fix inject size for neuron, we should test for it */
+}
 #else
 void test_efa_hmem_info_update_neuron()
 {
         skip();
+}
+
+void test_efa_hmem_neuron_no_shm(struct efa_resource **state)
+{
+	skip();
 }
 #endif /* HAVE_NEURON */

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -133,6 +133,7 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_rdm_msg_send_to_local_peer_with_null_desc, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_fork_support_request_initialize_when_ibv_fork_support_is_needed, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_fork_support_request_initialize_when_ibv_fork_support_is_unneeded, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_hmem_neuron_no_shm, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown), // Needs to be last b/c this will shut down shm on neuron
 	};
 
 	cmocka_set_message_output(CM_OUTPUT_XML);

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -119,6 +119,7 @@ void test_info_check_hmem_cuda_support_on_api_lt_1_18();
 void test_info_check_hmem_cuda_support_on_api_ge_1_18();
 void test_info_check_no_hmem_support_when_not_requested();
 void test_efa_hmem_info_update_neuron();
+void test_efa_hmem_neuron_no_shm();
 void test_efa_use_device_rdma_env1_opt1();
 void test_efa_use_device_rdma_env0_opt0();
 void test_efa_use_device_rdma_env1_opt0();


### PR DESCRIPTION
UT Results on trn1:
```
cat /home/ec2-user/PortaFiducia/tests/test_suites/libfabric/efa_unit_test.xml
<?xml version="1.0" encoding="UTF-8" ?>
<testsuites>
  <testsuite name="efa unit tests" time="9.869" tests="63" failures="0" errors="0" skipped="2" >
    <testcase name="test_av_insert_duplicate_raw_addr" time="0.097" >
    </testcase>
    <testcase name="test_av_insert_duplicate_gid" time="0.017" >
    </testcase>
    <testcase name="test_efa_device_construct_error_handling" time="0.001" >
    </testcase>
    <testcase name="test_efa_rdm_ep_ignore_missing_host_id_file" time="0.004" >
    </testcase>
    <testcase name="test_efa_rdm_ep_has_valid_host_id" time="0.004" >
    </testcase>
    <testcase name="test_efa_rdm_ep_ignore_short_host_id" time="0.004" >
    </testcase>
    <testcase name="test_efa_rdm_ep_ignore_non_hex_host_id" time="0.004" >
    </testcase>
    <testcase name="test_efa_rdm_ep_handshake_receive_and_send_valid_host_ids_with_connid" time="0.033" >
    </testcase>
    <testcase name="test_efa_rdm_ep_handshake_receive_and_send_valid_host_ids_without_connid" time="0.034" >
    </testcase>
    <testcase name="test_efa_rdm_ep_handshake_receive_valid_peer_host_id_and_do_not_send_local_host_id" time="0.034" >
    </testcase>
    <testcase name="test_efa_rdm_ep_handshake_receive_without_peer_host_id_and_do_not_send_local_host_id" time="0.034" >
    </testcase>
    <testcase name="test_efa_rdm_ep_getopt_undersized_optlen" time="0.004" >
    </testcase>
    <testcase name="test_efa_rdm_ep_getopt_oversized_optlen" time="0.004" >
    </testcase>
    <testcase name="test_efa_rdm_ep_cq_create_error_handling" time="0.001" >
    </testcase>
    <testcase name="test_efa_rdm_ep_pkt_pool_flags" time="0.003" >
    </testcase>
    <testcase name="test_efa_rdm_ep_pkt_pool_page_alignment" time="0.036" >
    </testcase>
    <testcase name="test_efa_rdm_ep_dc_atomic_error_handling" time="0.021" >
    </testcase>
    <testcase name="test_efa_rdm_ep_send_with_shm_no_copy" time="0.016" >
    </testcase>
    <testcase name="test_efa_rdm_ep_rma_without_caps" time="0.016" >
    </testcase>
    <testcase name="test_efa_rdm_ep_atomic_without_caps" time="0.015" >
    </testcase>
    <testcase name="test_dgram_cq_read_empty_cq" time="0.002" >
    </testcase>
    <testcase name="test_ibv_cq_ex_read_empty_cq" time="0.019" >
    </testcase>
    <testcase name="test_ibv_cq_ex_read_failed_poll" time="0.018" >
    </testcase>
    <testcase name="test_rdm_cq_read_bad_send_status_unresponsive_receiver" time="0.043" >
    </testcase>
    <testcase name="test_rdm_cq_read_bad_send_status_unresponsive_receiver_missing_peer_host_id" time="0.041" >
    </testcase>
    <testcase name="test_rdm_cq_read_bad_send_status_invalid_qpn" time="0.038" >
    </testcase>
    <testcase name="test_rdm_cq_read_bad_send_status_message_too_long" time="0.041" >
    </testcase>
    <testcase name="test_ibv_cq_ex_read_bad_recv_status" time="0.015" >
    </testcase>
    <testcase name="test_ibv_cq_ex_read_recover_forgotten_peer_ah" time="0.033" >
    </testcase>
    <testcase name="test_ibv_cq_ex_read_ignore_removed_peer" time="0.029" >
    </testcase>
    <testcase name="test_rdm_fallback_to_ibv_create_cq_ex_cq_read_ignore_forgotton_peer" time="0.029" >
    </testcase>
    <testcase name="test_info_open_ep_with_wrong_info" time="0.000" >
    </testcase>
    <testcase name="test_info_open_ep_with_api_1_1_info" time="0.001" >
    </testcase>
    <testcase name="test_info_check_shm_info_hmem" time="0.000" >
    </testcase>
    <testcase name="test_info_check_shm_info_op_flags" time="0.000" >
    </testcase>
    <testcase name="test_info_check_shm_info_threading" time="0.000" >
    </testcase>
    <testcase name="test_info_check_hmem_cuda_support_on_api_lt_1_18" time="0.000" >
      <skipped/>
    </testcase>
    <testcase name="test_info_check_hmem_cuda_support_on_api_ge_1_18" time="0.000" >
      <skipped/>
    </testcase>
    <testcase name="test_info_check_no_hmem_support_when_not_requested" time="0.000" >
    </testcase>
    <testcase name="test_efa_use_device_rdma_env1_opt1" time="0.001" >
    </testcase>
    <testcase name="test_efa_use_device_rdma_env0_opt0" time="0.001" >
    </testcase>
    <testcase name="test_efa_use_device_rdma_env1_opt0" time="0.001" >
    </testcase>
    <testcase name="test_efa_use_device_rdma_env0_opt1" time="0.001" >
    </testcase>
    <testcase name="test_efa_use_device_rdma_env1" time="0.001" >
    </testcase>
    <testcase name="test_efa_use_device_rdma_env0" time="0.001" >
    </testcase>
    <testcase name="test_efa_use_device_rdma_opt1" time="0.001" >
    </testcase>
    <testcase name="test_efa_use_device_rdma_opt0" time="0.001" >
    </testcase>
    <testcase name="test_efa_use_device_rdma_opt_old" time="0.003" >
    </testcase>
    <testcase name="test_efa_hmem_info_update_neuron" time="0.000" >
    </testcase>
    <testcase name="test_efa_srx_min_multi_recv_size" time="0.004" >
    </testcase>
    <testcase name="test_efa_srx_cq" time="0.003" >
    </testcase>
    <testcase name="test_efa_srx_lock" time="0.003" >
    </testcase>
    <testcase name="test_efa_rnr_queue_and_resend" time="0.027" >
    </testcase>
    <testcase name="test_efa_rdm_ope_prepare_to_post_send_with_no_enough_tx_pkts" time="0.017" >
    </testcase>
    <testcase name="test_efa_rdm_ope_prepare_to_post_send_host_memory" time="0.017" >
    </testcase>
    <testcase name="test_efa_rdm_ope_prepare_to_post_send_host_memory_align128" time="0.016" >
    </testcase>
    <testcase name="test_efa_rdm_ope_prepare_to_post_send_cuda_memory" time="0.015" >
    </testcase>
    <testcase name="test_efa_rdm_ope_prepare_to_post_send_cuda_memory_align128" time="0.015" >
    </testcase>
    <testcase name="test_efa_rdm_ope_post_write_0_byte" time="0.022" >
    </testcase>
    <testcase name="test_efa_rdm_msg_send_to_local_peer_with_null_desc" time="0.016" >
    </testcase>
    <testcase name="test_efa_fork_support_request_initialize_when_ibv_fork_support_is_needed" time="0.000" >
    </testcase>
    <testcase name="test_efa_fork_support_request_initialize_when_ibv_fork_support_is_unneeded" time="0.000" >
    </testcase>
    <testcase name="test_efa_hmem_neuron_no_shm" time="9.010" >                <<<<<<<<<<<<<<<<<<< THIS IS WHAT WE CARE ABOUT
    </testcase>
  </testsuite>
</testsuites>
```