### PR TITLE
[v1.20.x] prov/util_mem_hooks: add missing parantheses

### DIFF
--- a/prov/util/src/util_mem_hooks.c
+++ b/prov/util/src/util_mem_hooks.c
@@ -190,13 +190,13 @@ static inline void ofi_clear_instruction_cache(uintptr_t address, size_t data_si
 #if (defined(__x86_64__) || defined(__amd64__))
 		__asm__ volatile("mfence;clflush %0;mfence"::
 				 "m" (*((char*) address + i)));
-#elif (defined(__aarch64__)
+#elif (defined(__aarch64__))
 		__asm__ volatile ("dc cvau, %0\n\t"
 			  "dsb ish\n\t"
 			  "ic ivau, %0\n\t"
 			  "dsb ish\n\t"
 			  "isb":: "r" (address + i));
-#elif (defined(__riscv) && (__riscv_xlen == 64)
+#elif (defined(__riscv) && (__riscv_xlen == 64))
 	        __riscv_flush_icache(address, address+data_size, SYS_RISCV_FLUSH_ICACHE_LOCAL);
 		__asm__ volatile ("fence.i\n");
 #endif


### PR DESCRIPTION
Cherry-picked fomr commit c9fd334faee74c0c38d2f62b93b2f02a0299e371