### PR TITLE
contrib/intel/jenkins: Update jenkins architecture for future changes

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -3,7 +3,7 @@ import groovy.transform.Field
 properties([disableConcurrentBuilds(abortPrevious: true)])
 @Field def DO_RUN=true
 @Field def TARGET="main"
-@Field def SCRIPT_LOCATION="py_scripts/contrib/intel/jenkins"
+@Field def SCRIPT_LOCATION="upstream/libfabric/contrib/intel/jenkins"
 @Field def RELEASE=false
 @Field def BUILD_MODES=["reg", "dbg", "dl"]
 @Field def PYTHON_VERSION="3.9"
@@ -129,21 +129,22 @@ def save_summary() {
   """
 }
 
-def checkout_py_scripts() {
+def checkout_upstream() {
+  def loc = "${env.WORKSPACE}/upstream/libfabric"
   sh """
-    if [[ ! -d ${env.WORKSPACE}/py_scripts ]]; then
-      mkdir ${env.WORKSPACE}/py_scripts
+    if [[ ! -d ${env.WORKSPACE}/upstream ]]; then
+      mkdir -p ${loc}
     else
-      rm -rf ${env.WORKSPACE}/py_scripts && mkdir ${env.WORKSPACE}/py_scripts
+      rm -rf ${env.WORKSPACE}/upstream && mkdir -p ${loc}
     fi
 
-    git clone --branch ${TARGET} ${env.UPSTREAM} ${env.WORKSPACE}/py_scripts
+    git clone --branch ${TARGET} ${env.UPSTREAM} ${loc}
   """
 }
 
 def checkout_ci_resources() {
   sh """
-    if [[ ! -d ${env.WORKSPACE}/py_scripts ]]; then
+    if [[ ! -d ${env.WORKSPACE}/upstream ]]; then
       mkdir ${env.WORKSPACE}/ci_resources
     else
       rm -rf ${env.WORKSPACE}/ci_resources && mkdir ${env.WORKSPACE}/ci_resources
@@ -156,7 +157,7 @@ def checkout_ci_resources() {
 
 def checkout_external_resources() {
   checkout_ci_resources()
-  checkout_py_scripts()
+  checkout_upstream()
 }
 
 def generate_diff(def branch_name, def output_loc) {

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -315,11 +315,10 @@ pipeline {
   }
   environment {
       JOB_CADENCE = 'PR'
-      LOG_DIR = "${env.JOB_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}/log_dir"
       WITH_ENV="'PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH'"
-      DELETE_LOCATION="${env.JOB_INSTALL_DIR}/${env.JOB_NAME}/${env.BUILD_NUMBER}"
       RUN_LOCATION="${env.WORKSPACE}/${SCRIPT_LOCATION}/"
       CUSTOM_WORKSPACE="${CB_HOME}/workspace/${JOB_NAME}/${env.BUILD_NUMBER}"
+      LOG_DIR = "${env.CUSTOM_WORKSPACE}/log_dir"
   }
   stages {
     stage ('checkout') {
@@ -768,7 +767,6 @@ pipeline {
     }
     aborted {
       node ('daos_head') {
-        dir ("${DELETE_LOCATION}/middlewares") { deleteDir() }
       }
       node ('ze') {
         dir ("${DELETE_LOCATION}/middlewares") { deleteDir() }
@@ -777,16 +775,13 @@ pipeline {
     }
     cleanup {
       node ('daos_head') {
-        dir ("${DELETE_LOCATION}") { deleteDir() }
         dir("${env.WORKSPACE}") { deleteDir() }
         dir("${env.WORKSPACE}@tmp") { deleteDir() }
       }
       node ('ze') {
-        dir("${DELETE_LOCATION}") { deleteDir() }
         dir("${env.WORKSPACE}") { deleteDir() }
         dir("${env.WORKSPACE}@tmp") { deleteDir() }
       }
-      dir("${DELETE_LOCATION}") { deleteDir() }
       dir("${env.WORKSPACE}") { deleteDir() }
       dir("${env.WORKSPACE}@tmp") { deleteDir() }
     }

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -30,9 +30,9 @@ def slurm_batch(partition, node_num, output, command) {
   sh "cat ${output}"
 }
 
-def run_fabtests(stage_name, partition, node_num, prov, util=null,
+def run_fabtests(stage_name, hw, partition, node_num, prov, util=null,
                  user_env=null, way=null) {
-  def command = "python3.9 ${RUN_LOCATION}/runtests.py"
+  def command = "python3.9 ${RUN_LOCATION}/runtests.py --build_hw=${hw}"
   def opts = "--prov=${prov} --test=fabtests"
   def modes = BUILD_MODES
   if (util)
@@ -56,9 +56,9 @@ def run_fabtests(stage_name, partition, node_num, prov, util=null,
   echo "${stage_name} completed."
 }
 
-def run_middleware(providers, stage_name, test, partition, node_num, mpi=null,
-                   imb_grp=null) {
-  def base_cmd = "python3.9 ${RUN_LOCATION}/runtests.py --test=${test}"
+def run_middleware(providers, stage_name, test, hw, partition, node_num,
+                   mpi=null, imb_grp=null) {
+  def base_cmd = "python3.9 ${RUN_LOCATION}/runtests.py --test=${test} --build_hw=${hw}"
   def opts = ""
   def prefix = "${env.LOG_DIR}/${stage_name}_"
   def suffix = "_${test}_reg"
@@ -182,17 +182,49 @@ def generate_release_num(def branch_name, def output_loc) {
   """
 }
 
-def build(item, mode=null, cluster=null, release=false, additional_args=null) {
+def slurm_build(modes, partition, location, hw=null, additional_args=null) {
+  def cmd = "pwd; "
+  def prefix = "python${PYTHON_VERSION} ${RUN_LOCATION}/build.py"
+  def libfabric = "--build_item=libfabric --build_loc=${CUSTOM_WORKSPACE}/${location}/libfabric"
+  def fabtests = "--build_item=fabtests --build_loc=${CUSTOM_WORKSPACE}/${location}/libfabric/fabtests"
+  if (RELEASE) {
+    prefix = "${prefix} --release"
+  }
+
+  if (hw) {
+    prefix = "${prefix} --build_hw=${hw}"
+  }
+
+  if (additional_args) {
+    prefix = "${prefix} ${additional_args} "
+  }
+
+  for (mode in modes) {
+    cmd = "${cmd} ${prefix} ${libfabric} --ofi_build_mode=${mode};"
+    cmd = "${cmd} ${prefix} ${fabtests} --ofi_build_mode=${mode};"
+  }
+
+  slurm_batch(partition, "1", "${env.LOG_DIR}/libfabric_${partition}", cmd)
+}
+
+def build(item, mode=null, hw=null, additional_args=null) {
   def cmd = "${RUN_LOCATION}/build.py --build_item=${item}"
+
+  if (item == "fabtests") {
+    cmd ="${cmd} --build_loc=${CUSTOM_WORKSPACE}/source/libfabric/fabtests"
+  } else {
+    cmd ="${cmd} --build_loc=${CUSTOM_WORKSPACE}/source/libfabric"
+  }
+
   if (mode) {
     cmd = "${cmd} --ofi_build_mode=${mode} "
   }
 
-  if (cluster) {
-    cmd = "${cmd} --build_cluster=${cluster} "
+  if (hw) {
+    cmd = "${cmd} --build_hw=${hw} "
   }
 
-  if (release) {
+  if (RELEASE) {
     cmd = "${cmd} --release "
   }
 
@@ -240,7 +272,7 @@ def release() {
 }
 
 def skip() {
-  def file = "${env.WORKSPACE}/commit_id"
+  def file = "${env.WORKSPACE}/source/libfabric/commit_id"
   if (!fileExists(file)) {
     echo "CI Run has not rebased with ofiwg/libfabric. Please Rebase."
     return 1
@@ -277,6 +309,7 @@ pipeline {
   options {
       timestamps()
       timeout(activity: true, time: 6, unit: 'HOURS')
+      skipDefaultCheckout()
   }
   environment {
       JOB_CADENCE = 'PR'
@@ -287,13 +320,38 @@ pipeline {
       CUSTOM_WORKSPACE="${CB_HOME}/workspace/${JOB_NAME}/${env.BUILD_NUMBER}"
   }
   stages {
+    stage ('checkout') {
+      steps {
+        script {
+          dir ("${CUSTOM_WORKSPACE}/source/libfabric") {
+            checkout scm
+          }
+          dir ("${CUSTOM_WORKSPACE}/grass/libfabric") {
+            checkout scm
+          }
+          dir ("${CUSTOM_WORKSPACE}/water/libfabric") {
+            checkout scm
+          }
+          dir ("${CUSTOM_WORKSPACE}/electric/libfabric") {
+            checkout scm
+          }
+          dir ("${CUSTOM_WORKSPACE}/ucx/libfabric") {
+            checkout scm
+          }
+          dir (CUSTOM_WORKSPACE) {
+            checkout_external_resources()
+          }
+        }
+      }
+    }
     stage ('opt-out') {
       steps {
         script {
           TARGET=check_target()
-          checkout_external_resources()
-          generate_diff("${TARGET}", "${env.WORKSPACE}")
-          generate_release_num("${TARGET}", "${env.WORKSPACE}")
+          dir ("${CUSTOM_WORKSPACE}/source/libfabric") {
+            generate_diff("${TARGET}", "${env.WORKSPACE}/source/libfabric")
+            generate_release_num("${TARGET}", "${env.WORKSPACE}/source/libfabric")
+          }
 
           if (env.WEEKLY == null) {
             weekly = false
@@ -318,67 +376,48 @@ pipeline {
           echo "Copying build dirs."
           build("builddir")
           echo "Copying log dirs."
-          build("logdir", null, null, RELEASE)
-          build("extract_mpich")
-          build("extract_impi_mpich")
+          build("logdir")
         }
       }
     }
     stage ('parallel-builds') {
       when { equals expected: true, actual: DO_RUN }
       parallel {
-        stage ('build') {
+        stage ('build-water') {
           steps {
             script {
-              dir (CUSTOM_WORKSPACE) {
-                for (mode in  BUILD_MODES) {
-                  echo "Building Libfabric $mode"
-                  build("libfabric", "$mode")
-                  echo "Building Fabtests $mode"
-                  build("fabtests", "$mode")
-                }
-              }
-            }
-          }
-        }
-        stage ('buildmpich-libfabric') {
-          steps {
-            script {
-              dir("${CUSTOM_WORKSPACE}/mpich"){
-                checkout scm
-                echo "Building Libfabric reg"
-                slurm_batch("squirtle,totodile", "1",
-                            "${env.LOG_DIR}/libfabric_mpich_log", 
+              slurm_build(BUILD_MODES, "water", "water", "water")
+              slurm_batch("squirtle,totodile", "1",
+                            "${env.LOG_DIR}/build_mpich_water_log",
                             """python$PYTHON_VERSION ${RUN_LOCATION}/build.py \
-                              --build_item=libfabric_mpich """
+                              --build_item=mpich --build_hw=water"""
                           )
-                slurm_batch("squirtle,totodile", "1",
-                            "${env.LOG_DIR}/build_mpich_log", 
-                            """python$PYTHON_VERSION ${RUN_LOCATION}/build.py \
-                              --build_item=mpich """
-                          ) 
-              }
             }
           }
         }
-        stage ('build_ucx') {
+        stage ('build-grass') {
           steps {
             script {
-              dir ("${CUSTOM_WORKSPACE}/ucx") {
-                checkout scm
-                def prefix = "python$PYTHON_VERSION ${RUN_LOCATION}/build.py"
-                def opts = ""
-                def build_cmd = ""
-                for (mode in BUILD_MODES) {
-                  for (item in ["libfabric", "fabtests"]) {
-                    opts = "--build_item=${item} --ofi_build_mode=${mode} --ucx"
-                    build_cmd = "${build_cmd} ${prefix} ${opts}; "
-                  }
-                }
-                slurm_batch("squirtle,totodile", "1",
-                            "${env.LOG_DIR}/libfabric_ucx_build_log",
-                            "${build_cmd}")
-              }
+              slurm_build(BUILD_MODES, "grass", "grass", "grass")
+              slurm_batch("grass", "1",
+                            "${env.LOG_DIR}/build_mpich_grass_log",
+                            """python$PYTHON_VERSION ${RUN_LOCATION}/build.py \
+                              --build_item=mpich --build_hw=grass"""
+                          )
+            }
+          }
+        }
+        stage ('build-electric') {
+          steps {
+            script {
+              slurm_build(BUILD_MODES, "electric", "electric", "electric")
+            }
+          }
+        }
+        stage ('build-ucx') {
+          steps {
+            script {
+              slurm_build(BUILD_MODES, "totodile", "ucx", "ucx")
             }
           }
         }
@@ -389,13 +428,15 @@ pipeline {
               customWorkspace CUSTOM_WORKSPACE
             }
           }
+          options { skipDefaultCheckout() }
           steps {
             script {
+              dir ("${CUSTOM_WORKSPACE}/source/libfabric") { checkout scm }
               checkout_external_resources()
               dir (CUSTOM_WORKSPACE) {
                 build("logdir")
                 build("libfabric", "reg", "daos")
-                build("fabtests", "reg")
+                build("fabtests", "reg", "daos")
               }
             }
           }
@@ -407,14 +448,16 @@ pipeline {
               customWorkspace CUSTOM_WORKSPACE
             }
           }
+          options { skipDefaultCheckout() }
           steps {
             script {
+              dir ("${CUSTOM_WORKSPACE}/source/libfabric") { checkout scm }
               checkout_external_resources()
               dir (CUSTOM_WORKSPACE) {
                 build("logdir")
                 build("builddir")
-                build("libfabric", "reg", "gpu")
-                build("fabtests", "reg")
+                build("libfabric", "reg", "gpu", "--gpu")
+                build("fabtests", "reg", "gpu")
               }
             }
           }
@@ -431,7 +474,7 @@ pipeline {
                 def providers = [["verbs", "rxm"]]
                 for (def mpi in ["impi"]) {
                   for (imb_grp = 1; imb_grp < 4; imb_grp++) {
-                    run_middleware(providers, "MPI", "IMB",
+                    run_middleware(providers, "MPI", "IMB", "water",
                                    "squirtle,totodile", "2", "${mpi}",
                                    "${imb_grp}")
                   }
@@ -446,8 +489,8 @@ pipeline {
               dir (RUN_LOCATION) {
                 def providers = [["verbs", "rxm"]]
                 for (def mpi in ["impi", "mpich"]) {
-                  run_middleware(providers, "MPI", "osu", "squirtle,totodile",
-                                 "2", "${mpi}")
+                  run_middleware(providers, "MPI", "osu", "water",
+                                 "squirtle,totodile", "2", "${mpi}")
                 }
               }
             }
@@ -459,12 +502,12 @@ pipeline {
               dir (RUN_LOCATION) {
                 def providers = [["tcp", null]]
                 for (imb_grp = 1; imb_grp < 4; imb_grp++) {
-                  run_middleware(providers, "MPI", "IMB",
+                  run_middleware(providers, "MPI", "IMB", "grass",
                                  "bulbasaur", "2", "impi", "${imb_grp}")
                 }
                 for (def mpi in ["impi", "mpich"]) {
-                  run_middleware(providers, "MPI", "osu", "bulbasaur", "2",
-                                 "${mpi}")
+                  run_middleware(providers, "MPI", "osu", "grass", "bulbasaur",
+                                 "2", "${mpi}")
                 }
               }
             }
@@ -474,7 +517,7 @@ pipeline {
            steps {
             script {
               dir (RUN_LOCATION) {
-                run_fabtests("tcp", "bulbasaur", "2", "tcp")
+                run_fabtests("tcp", "grass", "bulbasaur", "2", "tcp")
               }
             }
           }
@@ -483,12 +526,12 @@ pipeline {
           steps {
             script {
               dir (RUN_LOCATION) {
-                run_fabtests("verbs-rxm", "squirtle,totodile", "2", "verbs",
-                             "rxm")
-                run_fabtests("verbs-rxm", "squirtle,totodile", "2", "verbs",
-                             "rxm", "FI_MR_CACHE_MAX_COUNT=0")
-                run_fabtests("verbs-rxm", "squirtle,totodile", "2", "verbs",
-                             "rxm", "FI_MR_CACHE_MONITOR=userfaultfd")
+                run_fabtests("verbs-rxm", "water", "squirtle,totodile", "2",
+                             "verbs", "rxm")
+                run_fabtests("verbs-rxm", "water", "squirtle,totodile", "2",
+                             "verbs", "rxm", "FI_MR_CACHE_MAX_COUNT=0")
+                run_fabtests("verbs-rxm", "water", "squirtle,totodile", "2",
+                             "verbs", "rxm", "FI_MR_CACHE_MONITOR=userfaultfd")
               }
             }
           }
@@ -497,11 +540,11 @@ pipeline {
           steps {
             script {
               dir (RUN_LOCATION) {
-                run_fabtests("verbs-rxd", "squirtle", "2", "verbs",
+                run_fabtests("verbs-rxd", "water", "squirtle", "2", "verbs",
                              "rxd")
-                run_fabtests("verbs-rxd", "squirtle", "2", "verbs",
+                run_fabtests("verbs-rxd", "water", "squirtle", "2", "verbs",
                              "rxd", "FI_MR_CACHE_MAX_COUNT=0")
-                run_fabtests("verbs-rxd", "squirtle", "2", "verbs",
+                run_fabtests("verbs-rxd", "water", "squirtle", "2", "verbs",
                              "rxd", "FI_MR_CACHE_MONITOR=userfaultfd")
               }
             }
@@ -511,7 +554,7 @@ pipeline {
           steps {
             script {
               dir (RUN_LOCATION) {
-                run_fabtests("udp", "bulbasaur", "2", "udp")
+                run_fabtests("udp", "grass", "bulbasaur", "2", "udp")
               }
             }
           }
@@ -520,8 +563,8 @@ pipeline {
           steps {
             script {
               dir (RUN_LOCATION) {
-                run_fabtests("shm", "bulbasaur", "1", "shm")
-                run_fabtests("shm", "bulbasaur", "1", "shm", null,
+                run_fabtests("shm", "grass", "bulbasaur", "1", "shm")
+                run_fabtests("shm", "grass", "bulbasaur", "1", "shm", null,
                             "FI_SHM_DISABLE_CMA=1")
               }
             }
@@ -531,7 +574,7 @@ pipeline {
           steps {
             script {
               dir (RUN_LOCATION) {
-                run_fabtests("sockets", "bulbasaur", "2", "sockets")
+                run_fabtests("sockets", "grass", "bulbasaur", "2", "sockets")
               }
             }
           }
@@ -540,7 +583,7 @@ pipeline {
           steps {
             script {
               dir (RUN_LOCATION) {
-                run_fabtests("ucx", "totodile", "2", "ucx")
+                run_fabtests("ucx", "ucx", "totodile", "2", "ucx")
               }
             }
           }
@@ -549,8 +592,8 @@ pipeline {
           steps {
             script {
               dir (RUN_LOCATION) {
-                run_fabtests("psm3", "squirtle", "2", "psm3", null,
-                            "PSM3_IDENTIFY=1")
+                run_fabtests("psm3", "water", "squirtle", "2", "psm3", null,
+                             "PSM3_IDENTIFY=1")
               }
             }
           }
@@ -566,7 +609,7 @@ pipeline {
                 }
                 for (def mpi in MPIS) {
                   run_middleware(providers, "mpichtestsuite", "mpichtestsuite",
-                                 "squirtle,totodile", "2", "${mpi}")
+                                 "water", "squirtle,totodile", "2", "${mpi}")
                 }
               }
             }
@@ -578,7 +621,7 @@ pipeline {
               dir (RUN_LOCATION) {
                 run_middleware([["verbs", null], ["tcp", null],
                                 ["sockets", null]], "SHMEM", "shmem",
-                                "squirtle,totodile", "2")
+                                "water", "squirtle,totodile", "2")
               }
             }
           }
@@ -588,7 +631,7 @@ pipeline {
             script {
               dir (RUN_LOCATION) {
                 run_middleware([["tcp", null]], "multinode_performance",
-                               "multinode", "bulbasaur", "2")
+                               "multinode", "grass", "bulbasaur", "2")
               }
             }
           }
@@ -598,7 +641,7 @@ pipeline {
             script {
               dir (RUN_LOCATION) {
                 run_middleware([["tcp", "rxm"]/*, ["psm3", null]*/], "oneCCL",
-                               "oneccl", "bulbasaur", "2")
+                               "oneccl", "grass", "bulbasaur", "2")
               }
             }
           }
@@ -610,7 +653,7 @@ pipeline {
             script {
               dir (RUN_LOCATION) {
                 run_middleware([["verbs", "rxm"]], "oneCCL-GPU-v3", "onecclgpu",
-                               "fabrics-ci", "2")
+                               "gpu", "fabrics-ci", "2")
               } 
             }
           }
@@ -623,7 +666,7 @@ pipeline {
               dir (RUN_LOCATION) {
                 run_python(PYTHON_VERSION,
                            """runtests.py --prov='tcp' --util='rxm' \
-                           --test=daos \
+                           --test=daos --build_hw=daos \
                            --log_file=${env.LOG_DIR}/daos_tcp-rxm_reg""")
               }
             }
@@ -637,7 +680,7 @@ pipeline {
               dir (RUN_LOCATION) {
                 run_python(PYTHON_VERSION,
                            """runtests.py --prov='verbs' --util='rxm' \
-                           --test=daos \
+                           --test=daos --build_hw=daos \
                            --log_file=${env.LOG_DIR}/daos_verbs-rxm_reg""")
               }
             }
@@ -651,7 +694,7 @@ pipeline {
               dir ("${env.WORKSPACE}/${SCRIPT_LOCATION}/") {
                 dmabuf_output = "${LOG_DIR}/DMABUF-Tests_verbs-rxm_dmabuf"
                 cmd = """ python3.9 runtests.py --test=dmabuf \
-                           --prov=verbs --util=rxm"""
+                           --prov=verbs --util=rxm --build_hw=gpu"""
                 slurm_batch("fabrics-ci", "1", "${dmabuf_output}_1_reg",
                             "${cmd}")
                 slurm_batch("fabrics-ci", "2", "${dmabuf_output}_2_reg",
@@ -666,9 +709,12 @@ pipeline {
           steps {
             script {
               dir (RUN_LOCATION) {
-                run_fabtests("ze_v3_shm", "fabrics-ci", "1", "shm", null, null, "h2d")
-                run_fabtests("ze_v3_shm", "fabrics-ci", "1", "shm", null, null, "d2d")
-                run_fabtests("ze_v3_shm", "fabrics-ci", "1", "shm", null, null, "xd2d")
+                run_fabtests("ze_v3_shm", "gpu", "fabrics-ci", "1", "shm", null,
+                             null, "h2d")
+                run_fabtests("ze_v3_shm", "gpu", "fabrics-ci", "1", "shm", null,
+                             null, "d2d")
+                run_fabtests("ze_v3_shm", "gpu", "fabrics-ci", "1", "shm", null,
+                             null, "xd2d")
               }
             }
           }
@@ -678,7 +724,7 @@ pipeline {
           steps {
             script {
               dir (RUN_LOCATION) {
-                run_fabtests("shm_dsa", "pikachu", "1", "shm", null,
+                run_fabtests("shm_dsa", "electric", "pikachu", "1", "shm", null,
                              """FI_SHM_DISABLE_CMA=1 FI_SHM_USE_DSA_SAR=1 \
                                 FI_LOG_LEVEL=warn""")
               }

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -19,8 +19,9 @@ def run_python(version, command, output=null) {
 def slurm_batch(partition, node_num, output, command) {
   
   try {
-    sh """timeout $TIMEOUT sbatch --partition=${partition} -N ${node_num} \
-          --wait -o ${output} --open-mode=append --wrap=\'env; ${command}\'
+    sh """sbatch --partition=${partition} -N ${node_num} \
+          --wait -o ${output} --open-mode=append \
+          --wrap=\'env; timeout $TIMEOUT ${command}\'
        """
   } catch (Exception e) {
     sh "scancel \$(cat ${output} | grep SLURM_JOBID | cut -d \"=\" -f 2)"

--- a/contrib/intel/jenkins/build.py
+++ b/contrib/intel/jenkins/build.py
@@ -155,6 +155,7 @@ if __name__ == "__main__":
 	jobname = os.environ['JOB_NAME']
 	buildno = os.environ['BUILD_NUMBER']
 	workspace = os.environ['WORKSPACE']
+	custom_workspace = os.environ['CUSTOM_WORKSPACE']
 
 	parser = argparse.ArgumentParser()
 	parser.add_argument('--build_item', help="build libfabric or fabtests", \
@@ -184,9 +185,7 @@ if __name__ == "__main__":
 	else:
 		ofi_build_mode = 'reg'
 
-	install_path = f'{cloudbees_config.install_dir}/{jobname}/{buildno}'
-	libfab_install_path = f'{cloudbees_config.install_dir}/{jobname}/'\
-						  f'{buildno}/{build_hw}/{ofi_build_mode}'
+	libfab_install_path = f'{custom_workspace}/{build_hw}/{ofi_build_mode}'
 
 	p = re.compile('mpi*')
 
@@ -198,11 +197,11 @@ if __name__ == "__main__":
 	elif (build_item == 'fabtests'):
 		build_fabtests(libfab_install_path, ofi_build_mode)
 	elif (build_item == 'builddir'):
-		copy_build_dir(install_path)
+		copy_build_dir(custom_workspace)
 	elif (build_item == 'logdir'):
-		log_dir(install_path, release)
+		log_dir(custom_workspace, release)
 	elif(build_item == 'mpich'):
-		build_mpich(install_path, libfab_install_path, build_hw)
-		build_mpich_osu(install_path, libfab_install_path, build_hw)
+		build_mpich(custom_workspace, libfab_install_path, build_hw)
+		build_mpich_osu(custom_workspace, libfab_install_path, build_hw)
 
 	os.chdir(curr_dir)

--- a/contrib/intel/jenkins/common.py
+++ b/contrib/intel/jenkins/common.py
@@ -109,34 +109,48 @@ prov_list = [
    Prov('shm', None),
    Prov('ucx', None)
 ]
-default_prov_list = [
-    'verbs',
-    'tcp',
-    'sockets',
-    'udp',
-    'shm',
-    'psm3'
-]
-daos_prov_list = [
-    'verbs',
-    'tcp'
-]
-dsa_prov_list = [
-    'shm'
-]
-gpu_prov_list = [
-    'verbs',
-    'shm'
-]
+
+providers = {
+    'daos'      : {
+                    'enable'     : ['verbs', 'tcp'],
+                    'disable'    : []
+                  },
+    'gpu'       : {
+                    'enable'     : ['verbs', 'shm'],
+                    'disable'    : ['psm3']
+                  },
+    'dsa'       : {
+                    'enable'     : ['shm'],
+                    'disable'    : []
+                  },
+    'ucx'       : {
+                    'enable'    : ['ucx'],
+                    'disable'   : []
+                  },
+    'water'     : {
+                    'enable'     : ['tcp', 'verbs', 'psm3', 'sockets'],
+                    'disable'    : []
+                  },
+    'grass'     : {
+                    'enable'     : ['tcp', 'sockets', 'udp', 'shm'],
+                    'disable'    : []
+                  },
+    'fire'      : {
+                    'enable'     : ['shm'],
+                    'disable'    : []
+                  },
+    'electric'  : {
+                    'enable'     : ['shm'],
+                    'disable'    : []
+                  }
+}
+
 common_disable_list = [
     'efa',
     'perf',
     'hook_debug',
     'mrail',
     'opx'
-]
-default_enable_list = [
-    'ze-dlopen'
 ]
 
 cloudbees_log_start_string = "Begin Cloudbees Test Output"

--- a/contrib/intel/jenkins/run.py
+++ b/contrib/intel/jenkins/run.py
@@ -19,10 +19,10 @@ if 'slurm' in fab:
 jbname = os.environ['JOB_NAME']#args.jobname
 bno = os.environ['BUILD_NUMBER']#args.buildno
 
-def fi_info_test(core, hosts, mode, user_env, log_file, util):
+def fi_info_test(hw, core, hosts, mode, user_env, log_file, util):
 
     fi_info_test = tests.FiInfoTest(jobname=jbname,buildno=bno,
-                                    testname='fi_info', core_prov=core,
+                                    testname='fi_info', hw=hw, core_prov=core,
                                     fabric=fab, hosts=hosts,
                                     ofi_build_mode=mode, user_env=user_env,
                                     log_file=log_file, util_prov=util)
@@ -31,10 +31,10 @@ def fi_info_test(core, hosts, mode, user_env, log_file, util):
     fi_info_test.execute_cmd()
     print('-------------------------------------------------------------------')
 
-def fabtests(core, hosts, mode, user_env, log_file, util, way):
+def fabtests(hw, core, hosts, mode, user_env, log_file, util, way):
 
     runfabtest = tests.Fabtest(jobname=jbname,buildno=bno,
-                               testname='runfabtests', core_prov=core,
+                               testname='runfabtests', hw=hw, core_prov=core,
                                fabric=fab, hosts=hosts, ofi_build_mode=mode,
                                user_env=user_env, log_file=log_file,
                                util_prov=util, way=way)
@@ -44,13 +44,13 @@ def fabtests(core, hosts, mode, user_env, log_file, util, way):
         print(f"Running Fabtests for {core}-{util}-{fab}")
         runfabtest.execute_cmd()
     else:
-        print(f"Skipping {core} {runfabtest.testname} as execute condition fails")
+        print(f"Skipping {core} {runfabtest.testname} as exec condn fails")
     print('-------------------------------------------------------------------')
 
-def shmemtest(core, hosts, mode, user_env, log_file, util):
+def shmemtest(hw, core, hosts, mode, user_env, log_file, util):
 
     runshmemtest = tests.ShmemTest(jobname=jbname,buildno=bno,
-                                   testname="shmem test", core_prov=core,
+                                   testname="shmem test", hw=hw, core_prov=core,
                                    fabric=fab, hosts=hosts,
                                    ofi_build_mode=mode, user_env=user_env,
                                    log_file=log_file, util_prov=util)
@@ -71,16 +71,17 @@ def shmemtest(core, hosts, mode, user_env, log_file, util):
         print(f"Running shmem uh test for {core}-{util}-{fab}")
         runshmemtest.execute_cmd("uh")
     else:
-        print(f"Skipping {core} {runshmemtest.testname} as execute condition fails")
+        print(f"Skipping {core} {runshmemtest.testname} as exec condn fails")
     print('-------------------------------------------------------------------')
 
-def multinodetest(core, hosts, mode, user_env, log_file, util):
+def multinodetest(hw, core, hosts, mode, user_env, log_file, util):
 
     runmultinodetest = tests.MultinodeTests(jobname=jbname,buildno=bno,
                                       testname="multinode performance test",
-                                      core_prov=core, fabric=fab, hosts=hosts,
-                                      ofi_build_mode=mode, user_env=user_env,
-                                      log_file=log_file, util_prov=util)
+                                      hw=hw, core_prov=core, fabric=fab,
+                                      hosts=hosts, ofi_build_mode=mode,
+                                      user_env=user_env, log_file=log_file,
+                                      util_prov=util)
 
     print("-------------------------------------------------------------------")
     if (runmultinodetest.execute_condn):
@@ -94,10 +95,11 @@ def multinodetest(core, hosts, mode, user_env, log_file, util):
               .format(runmultinodetest.testname))
     print("-------------------------------------------------------------------")
 
-def intel_mpi_benchmark(core, hosts, mpi, mode, group, user_env, log_file, util):
+def intel_mpi_benchmark(hw, core, hosts, mpi, mode, group, user_env, log_file,
+                        util):
 
     imb = tests.IMBtests(jobname=jbname, buildno=bno,
-                         testname='IntelMPIbenchmark', core_prov=core,
+                         testname='IntelMPIbenchmark', core_prov=core, hw=hw,
                          fabric=fab, hosts=hosts, mpitype=mpi,
                          ofi_build_mode=mode, user_env=user_env,
                          log_file=log_file, test_group=group, util_prov=util)
@@ -110,28 +112,29 @@ def intel_mpi_benchmark(core, hosts, mpi, mode, group, user_env, log_file, util)
         print(f"Skipping {mpi.upper} {imb.testname} as execute condition fails")
     print('-------------------------------------------------------------------')
 
-def mpich_test_suite(core, hosts, mpi, mode, user_env, log_file, util, weekly=None):
+def mpich_test_suite(hw, core, hosts, mpi, mode, user_env, log_file, util,
+                     weekly=None):
 
     mpich_tests = tests.MpichTestSuite(jobname=jbname,buildno=bno,
                                        testname="MpichTestSuite",core_prov=core,
-                                       fabric=fab, mpitype=mpi, hosts=hosts,
-                                       ofi_build_mode=mode, user_env=user_env,
-                                       log_file=log_file, util_prov=util, 
-                                       weekly=weekly)
+                                       hw=hw, fabric=fab, mpitype=mpi,
+                                       hosts=hosts, ofi_build_mode=mode,
+                                       user_env=user_env, log_file=log_file,
+                                       util_prov=util, weekly=weekly)
 
     print('-------------------------------------------------------------------')
     if (mpich_tests.execute_condn == True):
         print(f"Running mpichtestsuite for {core}-{util}-{fab}-{mpi}")
         mpich_tests.execute_cmd()
     else:
-        print(f"Skipping {mpi.upper()} {mpich_tests.testname} as exec condn fails")
+        print(f"Skipping {mpi.upper()} {mpich_tests.testname} exec condn fails")
     print('-------------------------------------------------------------------')
 
-def osu_benchmark(core, hosts, mpi, mode, user_env, log_file, util):
+def osu_benchmark(hw, core, hosts, mpi, mode, user_env, log_file, util):
 
     osu_test = tests.OSUtests(jobname=jbname, buildno=bno,
                                 testname='osu-benchmarks', core_prov=core,
-                                fabric=fab, mpitype=mpi, hosts=hosts,
+                                hw=hw, fabric=fab, mpitype=mpi, hosts=hosts,
                                 ofi_build_mode=mode, user_env=user_env,
                                 log_file=log_file, util_prov=util)
 
@@ -143,11 +146,11 @@ def osu_benchmark(core, hosts, mpi, mode, user_env, log_file, util):
         print(f"Skipping {mpi.upper()} {osu_test.testname} as exec condn fails")
     print('-------------------------------------------------------------------')
 
-def oneccltest(core, hosts, mode, user_env, log_file, util):
+def oneccltest(hw, core, hosts, mode, user_env, log_file, util):
 
     runoneccltest = tests.OneCCLTests(jobname=jbname,buildno=bno,
                                       testname="oneccl test", core_prov=core,
-                                      fabric=fab, hosts=hosts,
+                                      hw=hw, fabric=fab, hosts=hosts,
                                       ofi_build_mode=mode, user_env=user_env,
                                       log_file=log_file, util_prov=util)
 
@@ -159,11 +162,11 @@ def oneccltest(core, hosts, mode, user_env, log_file, util):
         print(f"Skipping {runoneccltest.testname} as execute condition fails")
     print('-------------------------------------------------------------------')
 
-def oneccltestgpu(core, hosts, mode, user_env, log_file, util):
+def oneccltestgpu(hw, core, hosts, mode, user_env, log_file, util):
 
     runoneccltestgpu = tests.OneCCLTestsGPU(jobname=jbname,buildno=bno,
                                          testname="oneccl GPU test",
-                                         core_prov=core, fabric=fab,
+                                         core_prov=core, hw=hw, fabric=fab,
                                          hosts=hosts, ofi_build_mode=mode,
                                          user_env=user_env, log_file=log_file,
                                          util_prov=util)
@@ -180,11 +183,11 @@ def oneccltestgpu(core, hosts, mode, user_env, log_file, util):
         print(f"Skipping {runoneccltestgpu.testname} as execute condition fails")
     print('-------------------------------------------------------------------')
 
-def daos_cart_tests(core, hosts, mode, user_env, log_file, util):
+def daos_cart_tests(hw, core, hosts, mode, user_env, log_file, util):
 
     runcarttests = tests.DaosCartTest(jobname=jbname, buildno=bno,
                                       testname="Daos Cart Test", core_prov=core,
-                                      fabric=fab, hosts=hosts,
+                                      hw=hw, fabric=fab, hosts=hosts,
                                       ofi_build_mode=mode, user_env=user_env,
                                       log_file=log_file, util_prov=util)
 
@@ -194,11 +197,11 @@ def daos_cart_tests(core, hosts, mode, user_env, log_file, util):
         runcarttests.execute_cmd()
     print('-------------------------------------------------------------------')
 
-def dmabuftests(core, hosts, mode, user_env, log_file, util):
+def dmabuftests(hw, core, hosts, mode, user_env, log_file, util):
 
     rundmabuftests = tests.DMABUFTest(jobname=jbname,buildno=bno,
                                       testname="DMABUF Tests", core_prov=core,
-                                      fabric=fab, hosts=hosts,
+                                      hw=hw, fabric=fab, hosts=hosts,
                                       ofi_build_mode=mode, user_env=user_env,
                                       log_file=log_file, util_prov=util)
 

--- a/contrib/intel/jenkins/runtests.py
+++ b/contrib/intel/jenkins/runtests.py
@@ -16,6 +16,9 @@ class ParseDict(argparse.Action):
             getattr(namespace, self.dest)[key] = value
 
 parser = argparse.ArgumentParser()
+parser.add_argument('--build_hw', help="HW type for build",
+                    choices=['water', 'grass', 'fire', 'electric', 'daos',\
+                                'gpu', 'ucx'])
 parser.add_argument('--prov', help="core provider", choices=['verbs', \
                      'tcp', 'udp', 'sockets', 'shm', 'psm3', 'ucx'])
 parser.add_argument('--util', help="utility provider", choices=['rxd', 'rxm'])
@@ -39,8 +42,8 @@ parser.add_argument('--log_file', help="Full path to log file",
 parser.add_argument('--weekly', help="run weekly", default=False, type=bool)
 
 args = parser.parse_args()
+build_hw = args.build_hw
 args_core = args.prov
-
 args_util = args.util
 user_env = args.user_env
 log_file = args.log_file
@@ -102,50 +105,50 @@ os.chdir('/tmp/')
 
 if(args_core):
     if (run_test == 'all' or run_test == 'fi_info'):
-        run.fi_info_test(args_core, hosts, ofi_build_mode,
+        run.fi_info_test(build_hw, args_core, hosts, ofi_build_mode,
                          user_env, log_file, util=args.util)
 
     if (run_test == 'all' or run_test == 'fabtests'):
-        run.fabtests(args_core, hosts, ofi_build_mode, user_env, log_file,
-                     args_util, way)
+        run.fabtests(build_hw, args_core, hosts, ofi_build_mode, user_env,
+                     log_file, args_util, way)
 
     if (run_test == 'all' or run_test == 'shmem'):
-        run.shmemtest(args_core, hosts, ofi_build_mode, user_env, log_file,
-                      args_util)
+        run.shmemtest(build_hw, args_core, hosts, ofi_build_mode, user_env,
+                      log_file, args_util)
 
     if (run_test == 'all' or run_test == 'oneccl'):
-        run.oneccltest(args_core, hosts, ofi_build_mode, user_env, log_file,
-                       args_util)
+        run.oneccltest(build_hw, args_core, hosts, ofi_build_mode, user_env,
+                       log_file, args_util)
 
     if (run_test == 'all' or run_test == 'onecclgpu'):
-        run.oneccltestgpu(args_core, hosts, ofi_build_mode,
+        run.oneccltestgpu(build_hw, args_core, hosts, ofi_build_mode,
                           user_env, log_file, args_util)
 
     if (run_test == 'all' or run_test == 'daos'):
-        run.daos_cart_tests(args_core, hosts, ofi_build_mode,
+        run.daos_cart_tests(build_hw, args_core, hosts, ofi_build_mode,
                             user_env, log_file, args_util)
 
     if (run_test == 'all' or run_test == 'multinode'):
-        run.multinodetest(args_core, hosts, ofi_build_mode,
+        run.multinodetest(build_hw, args_core, hosts, ofi_build_mode,
                           user_env, log_file, args_util)
 
     if (run_test == 'all' or run_test == 'mpichtestsuite'):
-        run.mpich_test_suite(args_core, hosts, mpi,
+        run.mpich_test_suite(build_hw, args_core, hosts, mpi,
                              ofi_build_mode, user_env, log_file,
                              args_util, weekly)
 
     if (run_test == 'all' or run_test == 'IMB'):
-        run.intel_mpi_benchmark(args_core, hosts, mpi,
+        run.intel_mpi_benchmark(build_hw, args_core, hosts, mpi,
                                 ofi_build_mode, imb_group,
                                 user_env, log_file, args_util)
 
     if (run_test == 'all' or run_test == 'osu'):
-        run.osu_benchmark(args_core, hosts, mpi,
+        run.osu_benchmark(build_hw, args_core, hosts, mpi,
                           ofi_build_mode, user_env, log_file,
                           args_util)
 
     if (run_test == 'all' or run_test == 'dmabuf'):
-        run.dmabuftests(args_core, hosts, ofi_build_mode,
+        run.dmabuftests(build_hw, args_core, hosts, ofi_build_mode,
                         user_env, log_file, args_util)
 else:
     print("Error : Specify a core provider to run tests")

--- a/contrib/intel/jenkins/summary.py
+++ b/contrib/intel/jenkins/summary.py
@@ -768,8 +768,8 @@ class DmabufSummarizer(Summarizer):
                 self.check_type(line)
                 self.check_line(line)
 
-def get_release_num(log_dir):
-    file_name = f'{log_dir}/release_num.txt'
+def get_release_num():
+    file_name = f'{os.environ["WORKSPACE"]}/source/release_num.txt'
     if os.path.exists(file_name):
         with open(file_name) as f:
             num = f.readline()
@@ -954,7 +954,7 @@ if __name__ == "__main__":
     print(f"Files to be summarized: {os.listdir(log_dir)}")
 
     if (release):
-        release_num = get_release_num(log_dir)
+        release_num = get_release_num()
         date = datetime.now().strftime("%Y%m%d%H%M%S")
         output_name = f'summary_{release_num}_{job_name}_{date}.log'
     else:

--- a/contrib/intel/jenkins/summary.py
+++ b/contrib/intel/jenkins/summary.py
@@ -12,7 +12,7 @@ from email.mime.base import MIMEBase
 from email import encoders
 
 # add jenkins config location to PATH
-sys.path.append(f"{os.environ['WORKSPACE']}/ci_resources/configs/{os.environ['CLUSTER']}")
+sys.path.append(f"{os.environ['CUSTOM_WORKSPACE']}/ci_resources/configs/{os.environ['CLUSTER']}")
 
 import cloudbees_config
 import argparse
@@ -769,7 +769,8 @@ class DmabufSummarizer(Summarizer):
                 self.check_line(line)
 
 def get_release_num():
-    file_name = f'{os.environ["WORKSPACE"]}/source/release_num.txt'
+    file_name = f'{os.environ["CUSTOM_WORKSPACE"]}/source/libfabric/'\
+                'release_num.txt'
     if os.path.exists(file_name):
         with open(file_name) as f:
             num = f.readline()
@@ -921,6 +922,7 @@ if __name__ == "__main__":
     jobname = os.environ['JOB_NAME']
     buildno = os.environ['BUILD_NUMBER']
     workspace = os.environ['WORKSPACE']
+    custom_workspace = os.environ['CUSTOM_WORKSPACE']
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--summary_item', help="functional test to summarize",
@@ -945,7 +947,7 @@ if __name__ == "__main__":
     send_mail = args.send_mail
 
     mpi_list = ['impi', 'mpich', 'ompi']
-    log_dir = f'{cloudbees_config.install_dir}/{jobname}/{buildno}/log_dir'
+    log_dir = f'{custom_workspace}/log_dir'
     if (not os.path.exists(log_dir)):
         os.makedirs(log_dir)
 
@@ -981,7 +983,7 @@ if __name__ == "__main__":
             err += summarize_items(summary_item, logger, log_dir, mode)
 
     if (release):
-        shutil.copyfile(f'{full_file_name}', f'{workspace}/{output_name}')
+        shutil.copyfile(f'{full_file_name}', f'{custom_workspace}/{output_name}')
 
     if (send_mail):
         SendEmail(sender = os.environ['SENDER'],

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -37,16 +37,12 @@ class Test:
             self.client = hosts[1]
 
         self.nw_interface = cloudbees_config.interface_map[self.fabric]
-        self.libfab_installpath = f'{cloudbees_config.install_dir}/'\
-                                  f'{self.jobname}/{self.buildno}/{self.hw}/'\
-                                  f'{self.ofi_build_mode}'
+        self.custom_workspace = os.environ['CUSTOM_WORKSPACE']
+        self.libfab_installpath = f'{self.custom_workspace}/'\
+                                  f'{self.hw}/{self.ofi_build_mode}'
 
-        self.middlewares_path = f'{cloudbees_config.install_dir}/'\
-                                   f'{self.jobname}/{self.buildno}/'\
-                                   'middlewares'
-        self.ci_logdir_path = f'{cloudbees_config.install_dir}/'\
-                                   f'{self.jobname}/{self.buildno}/'\
-                                   'log_dir'
+        self.middlewares_path = f'{self.custom_workspace}/middlewares'
+        self.ci_logdir_path = f'{self.custom_workspace}/log_dir'
         self.env = user_env
         self.way = way
 


### PR DESCRIPTION
Separate software builds by hardware.
This will allow easier debugging in the case of test failures as well as make it easier to distinguish which packages are in use on a given node.
This separates each job by HW type and then builds on that specific hardware. The directory structure is now structured by workspace with everything in sub directories inside it instead of installing to a new location not controlled by cloudbees.
These changes will make it easier to upgrade our CI in the future by enabling movement of an entire HW type to the new software solution instead of having to wait for everything to be ready.