### PR TITLE
prov/efa: Don't do handshake for local read

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_rma.c
+++ b/prov/efa/src/rdm/efa_rdm_rma.c
@@ -173,8 +173,10 @@ ssize_t efa_rdm_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uin
 
 	/*
 	 * A handshake is required to choose the correct protocol (whether to use device read).
+	 * For local read (read from self ep), such handshake is not needed because we only
+	 * need to check the local ep's capabilities.
 	 */
-	if (!(peer->flags & EFA_RDM_PEER_HANDSHAKE_RECEIVED)) {
+	if (!(peer->is_self) && !(peer->flags & EFA_RDM_PEER_HANDSHAKE_RECEIVED)) {
 		err = efa_rdm_ep_trigger_handshake(efa_rdm_ep, txe->addr);
 		err = err ? err : -FI_EAGAIN;
 		goto out;


### PR DESCRIPTION
Currently, we always trigger a handshake to check the interoperatability on two sides for rdma read capabilities, before determining the protocol to use. However, if the read is from the self peer, we don't need such handshake and just need to check the rdma capability for local ep.