### PR TITLE
prov/efa: Get rid of noop instruction from empty #define

### DIFF
--- a/prov/efa/src/efa_tp.h
+++ b/prov/efa/src/efa_tp.h
@@ -42,9 +42,9 @@ static inline void efa_tracepoint_wr_id_post_recv(const void *wr_id)
 
 #else
 
-#define efa_tracepoint(...)	while (0) {}
-#define efa_tracef(...)	while (0) {}
-#define efa_tracelog(...)	while (0) {}
+#define efa_tracepoint(...)	do {} while(0)
+#define efa_tracef(...)	do {} while(0)
+#define efa_tracelog(...)	do {} while(0)
 
 #endif /* HAVE_LTTNG */
 

--- a/prov/efa/src/rdm/efa_rdm_tracepoint.h
+++ b/prov/efa/src/rdm/efa_rdm_tracepoint.h
@@ -24,9 +24,9 @@
 
 #else
 
-#define efa_rdm_tracepoint(...)	while (0) {}
-#define efa_rdm_tracef(...)	while (0) {}
-#define efa_rdm_tracelog(...)	while (0) {}
+#define efa_rdm_tracepoint(...)	do {} while (0)
+#define efa_rdm_tracef(...)	do {} while (0)
+#define efa_rdm_tracelog(...)	do {} while (0)
 
 #endif /* HAVE_LTTNG */
 


### PR DESCRIPTION
I was playing around on godbolt and saw that while (0) {} generates a noop instruction, but (void) 0; does not.  Get rid of noop instructions from critical path without hurting the readability of the code.
![Screenshot 2023-12-18 at 5 49 51 PM](https://github.com/ofiwg/libfabric/assets/97712042/07bffefa-8323-4b25-9101-3425952f19ce)
![Screenshot 2023-12-18 at 5 52 43 PM](https://github.com/ofiwg/libfabric/assets/97712042/2154f2ef-2c85-4a82-a1c1-e1d087b61642)
