### PR TITLE
[v1.20.x] prov/efa: Fix the ibv cq error handling.

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -189,8 +189,6 @@ struct efa_rdm_ep {
 
 	size_t efa_total_posted_tx_ops;
 	size_t send_comps;
-	size_t failed_send_comps;
-	size_t failed_write_comps;
 	size_t recv_comps;
 #endif
 	/* track allocated rx_entries and tx_entries for endpoint cleanup */

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -492,8 +492,6 @@ int efa_rdm_ep_open(struct fid_domain *domain, struct fi_info *info,
 #if ENABLE_DEBUG
 	efa_rdm_ep->efa_total_posted_tx_ops = 0;
 	efa_rdm_ep->send_comps = 0;
-	efa_rdm_ep->failed_send_comps = 0;
-	efa_rdm_ep->failed_write_comps = 0;
 	efa_rdm_ep->recv_comps = 0;
 #endif
 


### PR DESCRIPTION
backport https://github.com/ofiwg/libfabric/pull/9652