### PR TITLE
prov/efa: Pass in peer pointer to txe

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_atomic.c
+++ b/prov/efa/src/rdm/efa_rdm_atomic.c
@@ -67,9 +67,10 @@ static void efa_rdm_atomic_init_shm_msg(struct efa_rdm_ep *ep, struct fi_msg_ato
 static
 struct efa_rdm_ope *
 efa_rdm_atomic_alloc_txe(struct efa_rdm_ep *efa_rdm_ep,
-			  const struct fi_msg_atomic *msg_atomic,
-			  const struct efa_rdm_atomic_ex *atomic_ex,
-			  uint32_t op, uint64_t flags)
+		      	 struct efa_rdm_peer *peer,
+			 const struct fi_msg_atomic *msg_atomic,
+			 const struct efa_rdm_atomic_ex *atomic_ex,
+			 uint32_t op, uint64_t flags)
 {
 	struct efa_rdm_ope *txe;
 	struct fi_msg msg;
@@ -96,7 +97,7 @@ efa_rdm_atomic_alloc_txe(struct efa_rdm_ep *efa_rdm_ep,
 	msg.iov_count = msg_atomic->iov_count;
 	msg.data = msg_atomic->data;
 	msg.desc = msg_atomic->desc;
-	efa_rdm_txe_construct(txe, efa_rdm_ep, &msg, op, flags);
+	efa_rdm_txe_construct(txe, efa_rdm_ep, peer, &msg, op, flags);
 
 	assert(msg_atomic->rma_iov_count > 0);
 	assert(msg_atomic->rma_iov);
@@ -149,7 +150,7 @@ ssize_t efa_rdm_atomic_generic_efa(struct efa_rdm_ep *efa_rdm_ep,
 		goto out;
 	}
 
-	txe = efa_rdm_atomic_alloc_txe(efa_rdm_ep, msg, atomic_ex, op, flags);
+	txe = efa_rdm_atomic_alloc_txe(efa_rdm_ep, peer, msg, atomic_ex, op, flags);
 	if (OFI_UNLIKELY(!txe)) {
 		err = -FI_EAGAIN;
 		efa_rdm_ep_progress_internal(efa_rdm_ep);

--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -251,10 +251,11 @@ struct efa_rdm_peer *efa_rdm_ep_get_peer(struct efa_rdm_ep *ep, fi_addr_t addr);
 int32_t efa_rdm_ep_get_peer_ahn(struct efa_rdm_ep *ep, fi_addr_t addr);
 
 struct efa_rdm_ope *efa_rdm_ep_alloc_txe(struct efa_rdm_ep *efa_rdm_ep,
-					   const struct fi_msg *msg,
-					   uint32_t op,
-					   uint64_t tag,
-					   uint64_t flags);
+					 struct efa_rdm_peer *peer,
+					 const struct fi_msg *msg,
+					 uint32_t op,
+					 uint64_t tag,
+					 uint64_t flags);
 
 struct efa_rdm_ope *efa_rdm_ep_alloc_rxe(struct efa_rdm_ep *ep,
 					   fi_addr_t addr, uint32_t op);

--- a/prov/efa/src/rdm/efa_rdm_ep_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_utils.c
@@ -63,8 +63,8 @@ const char *efa_rdm_ep_raw_addr_str(struct efa_rdm_ep *ep, char *buf, size_t *bu
 
 /**
  * @brief return peer's raw address in #efa_ep_addr
- * 
- * @param[in] ep		end point 
+ *
+ * @param[in] ep		end point
  * @param[in] addr 		libfabric address
  * @returns
  * If peer exists, return peer's raw addrress as pointer to #efa_ep_addr;
@@ -102,8 +102,8 @@ int32_t efa_rdm_ep_get_peer_ahn(struct efa_rdm_ep *ep, fi_addr_t addr)
 
 /**
  * @brief return peer's raw address in a reable string
- * 
- * @param[in] ep		end point 
+ *
+ * @param[in] ep		end point
  * @param[in] addr 		libfabric address
  * @param[out] buf		a buffer tat to be used to store string
  * @param[in,out] buflen	length of `buf` as input. length of the string as output.
@@ -117,8 +117,8 @@ const char *efa_rdm_ep_get_peer_raw_addr_str(struct efa_rdm_ep *ep, fi_addr_t ad
 
 /**
  * @brief get pointer to efa_rdm_peer structure for a given libfabric address
- * 
- * @param[in]		ep		endpoint 
+ *
+ * @param[in]		ep		endpoint
  * @param[in]		addr 		libfabric address
  * @returns if peer exists, return pointer to #efa_rdm_peer;
  *          otherwise, return NULL.
@@ -275,10 +275,11 @@ int efa_rdm_ep_post_user_recv_buf(struct efa_rdm_ep *ep, struct efa_rdm_ope *rxe
 
 /* create a new txe */
 struct efa_rdm_ope *efa_rdm_ep_alloc_txe(struct efa_rdm_ep *efa_rdm_ep,
-					   const struct fi_msg *msg,
-					   uint32_t op,
-					   uint64_t tag,
-					   uint64_t flags)
+					 struct efa_rdm_peer *peer,
+					 const struct fi_msg *msg,
+					 uint32_t op,
+					 uint64_t tag,
+					 uint64_t flags)
 {
 	struct efa_rdm_ope *txe;
 
@@ -288,7 +289,7 @@ struct efa_rdm_ope *efa_rdm_ep_alloc_txe(struct efa_rdm_ep *efa_rdm_ep,
 		return NULL;
 	}
 
-	efa_rdm_txe_construct(txe, efa_rdm_ep, msg, op, flags);
+	efa_rdm_txe_construct(txe, efa_rdm_ep, peer, msg, op, flags);
 	if (op == ofi_op_tagged) {
 		txe->cq_entry.tag = tag;
 		txe->tag = tag;

--- a/prov/efa/src/rdm/efa_rdm_msg.c
+++ b/prov/efa/src/rdm/efa_rdm_msg.c
@@ -187,7 +187,7 @@ ssize_t efa_rdm_msg_generic_send(struct fid_ep *ep, const struct fi_msg *msg,
 		goto out;
 	}
 
-	txe = efa_rdm_ep_alloc_txe(efa_rdm_ep, msg, op, tag, flags);
+	txe = efa_rdm_ep_alloc_txe(efa_rdm_ep, peer, msg, op, tag, flags);
 	if (OFI_UNLIKELY(!txe)) {
 		err = -FI_EAGAIN;
 		efa_rdm_ep_progress_internal(efa_rdm_ep);

--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -43,9 +43,10 @@
 #include "efa_rdm_pkt_type.h"
 
 void efa_rdm_txe_construct(struct efa_rdm_ope *txe,
-			    struct efa_rdm_ep *ep,
-			    const struct fi_msg *msg,
-			    uint32_t op, uint64_t flags)
+			   struct efa_rdm_ep *ep,
+			   struct efa_rdm_peer *peer,
+			   const struct fi_msg *msg,
+			   uint32_t op, uint64_t flags)
 {
 	uint64_t tx_op_flags;
 
@@ -55,7 +56,7 @@ void efa_rdm_txe_construct(struct efa_rdm_ope *txe,
 	txe->tx_id = ofi_buf_index(txe);
 	txe->state = EFA_RDM_TXE_REQ;
 	txe->addr = msg->addr;
-	txe->peer = efa_rdm_ep_get_peer(ep, txe->addr);
+	txe->peer = peer;
 	/* peer would be NULL for local read operation */
 	if (txe->peer) {
 		dlist_insert_tail(&txe->peer_entry, &txe->peer->txe_list);
@@ -1677,9 +1678,10 @@ int efa_rdm_rxe_post_local_read_or_queue(struct efa_rdm_ope *rxe,
 	msg_rma.rma_iov_count = 1;
 
 	txe = efa_rdm_rma_alloc_txe(rxe->ep,
-					  &msg_rma,
-					  ofi_op_read_req,
-					  0 /* flags*/);
+				    efa_rdm_ep_get_peer(rxe->ep, msg_rma.addr),
+				    &msg_rma,
+				    ofi_op_read_req,
+				    0 /* flags*/);
 	if (!txe) {
 		return -FI_ENOBUFS;
 	}

--- a/prov/efa/src/rdm/efa_rdm_ope.h
+++ b/prov/efa/src/rdm/efa_rdm_ope.h
@@ -61,7 +61,7 @@ enum efa_rdm_ope_state {
 
 /**
  * @brief basic information of an atomic operation
- * used by all 3 types of atomic operations: fetch, compare and write  
+ * used by all 3 types of atomic operations: fetch, compare and write
  */
 struct efa_rdm_atomic_hdr {
 	/* atomic_op is different from tx_op */
@@ -96,7 +96,7 @@ enum efa_rdm_cuda_copy_method {
 
 /**
  * @brief EFA RDM operation entry (ope)
- * 
+ *
  */
 struct efa_rdm_ope {
 	enum efa_rdm_ope_type type;
@@ -216,9 +216,10 @@ struct efa_rdm_ope {
 };
 
 void efa_rdm_txe_construct(struct efa_rdm_ope *txe,
-			    struct efa_rdm_ep *ep,
-			    const struct fi_msg *msg,
-			    uint32_t op, uint64_t flags);
+			   struct efa_rdm_ep *ep,
+		      	   struct efa_rdm_peer *peer,
+			   const struct fi_msg *msg,
+			   uint32_t op, uint64_t flags);
 
 void efa_rdm_txe_release(struct efa_rdm_ope *txe);
 
@@ -231,7 +232,7 @@ void efa_rdm_rxe_release_internal(struct efa_rdm_ope *rxe);
 
 /**
  * @brief indicate an ope's receive has been cancel
- * 
+ *
  * @todo: In future we will send RECV_CANCEL signal to sender,
  * to stop transmitting large message, this flag is also
  * used for fi_discard which has similar behavior.
@@ -246,7 +247,7 @@ void efa_rdm_rxe_release_internal(struct efa_rdm_ope *rxe);
 
 /**
  * @brief flag to tell if an ope encouter RNR when sending packets
- * 
+ *
  * If an ope has this flag, it is on the ope_queued_rnr_list
  * of the endpoint.
  */
@@ -254,7 +255,7 @@ void efa_rdm_rxe_release_internal(struct efa_rdm_ope *rxe);
 
 /**
  * @brief Flag to indicate an rxe has an EOR in flight
- * 
+ *
  * In flag means the EOR has been sent or queued, and has not got send completion.
  * hence the rxe cannot be released
  */
@@ -262,7 +263,7 @@ void efa_rdm_rxe_release_internal(struct efa_rdm_ope *rxe);
 
 /**
  * @brief flag to indicate a txe has already written an cq error entry for RNR
- * 
+ *
  * This flag is used to prevent writing multiple cq error entries
  * for the same txe
  */
@@ -278,15 +279,15 @@ void efa_rdm_rxe_release_internal(struct efa_rdm_ope *rxe);
 
 /**
  * @brief flag to indicate an ope does not need to report completion to user
- * 
+ *
  * This flag is used to by emulated injection and #efa_rdm_ep_trigger_handshake
  */
 #define EFA_RDM_TXE_NO_COMPLETION	BIT_ULL(60)
 /**
  * @brief flag to indicate an ope does not need to increase counter
- * 
+ *
  * This flag is used to implement #efa_rdm_ep_trigger_handshake
- * 
+ *
  */
 #define EFA_RDM_TXE_NO_COUNTER		BIT_ULL(61)
 

--- a/prov/efa/src/rdm/efa_rdm_rma.c
+++ b/prov/efa/src/rdm/efa_rdm_rma.c
@@ -45,9 +45,10 @@ int efa_rdm_rma_verified_copy_iov(struct efa_rdm_ep *ep, struct efa_rma_iov *rma
 
 struct efa_rdm_ope *
 efa_rdm_rma_alloc_txe(struct efa_rdm_ep *efa_rdm_ep,
-		       const struct fi_msg_rma *msg_rma,
-		       uint32_t op,
-		       uint64_t flags)
+		      struct efa_rdm_peer *peer,
+		      const struct fi_msg_rma *msg_rma,
+		      uint32_t op,
+		      uint64_t flags)
 {
 	struct efa_rdm_ope *txe;
 	struct fi_msg msg;
@@ -64,7 +65,7 @@ efa_rdm_rma_alloc_txe(struct efa_rdm_ep *efa_rdm_ep,
 	msg.iov_count = msg_rma->iov_count;
 	msg.data = msg_rma->data;
 	msg.desc = msg_rma->desc;
-	efa_rdm_txe_construct(txe, efa_rdm_ep, &msg, op, flags);
+	efa_rdm_txe_construct(txe, efa_rdm_ep, peer, &msg, op, flags);
 
 	assert(msg_rma->rma_iov_count > 0);
 	assert(msg_rma->rma_iov);
@@ -164,7 +165,7 @@ ssize_t efa_rdm_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uin
 		goto out;
 	}
 
-	txe = efa_rdm_rma_alloc_txe(efa_rdm_ep, msg, ofi_op_read_req, flags);
+	txe = efa_rdm_rma_alloc_txe(efa_rdm_ep, peer, msg, ofi_op_read_req, flags);
 	if (OFI_UNLIKELY(!txe)) {
 		efa_rdm_ep_progress_internal(efa_rdm_ep);
 		err = -FI_EAGAIN;
@@ -488,7 +489,7 @@ ssize_t efa_rdm_rma_writemsg(struct fid_ep *ep,
 		goto out;
 	}
 
-	txe = efa_rdm_rma_alloc_txe(efa_rdm_ep, msg, ofi_op_write, flags);
+	txe = efa_rdm_rma_alloc_txe(efa_rdm_ep, peer, msg, ofi_op_write, flags);
 	if (OFI_UNLIKELY(!txe)) {
 		efa_rdm_ep_progress_internal(efa_rdm_ep);
 		err = -FI_EAGAIN;

--- a/prov/efa/src/rdm/efa_rdm_rma.h
+++ b/prov/efa/src/rdm/efa_rdm_rma.h
@@ -47,8 +47,9 @@ extern struct fi_ops_rma efa_rdm_rma_ops;
 
 struct efa_rdm_ope *
 efa_rdm_rma_alloc_txe(struct efa_rdm_ep *efa_rdm_ep,
-		       const struct fi_msg_rma *msg_rma,
-		       uint32_t op,
-		       uint64_t flags);
+		      struct efa_rdm_peer *peer,
+		      const struct fi_msg_rma *msg_rma,
+		      uint32_t op,
+		      uint64_t flags);
 
 #endif


### PR DESCRIPTION
The EFA provider needs to find the peer pointer early so we can decide if we should use SHM to send the message, or if the message should go through EFA.  Instead of losing the pointer, and re-finding it when we create the txe, pass it through parameters to the txe so we don't have to duplicate the effort of finding the peer.