### PR TITLE
fabtests/benchmarks: fix HMEM support in rma_pingpong benchmark

### DIFF
--- a/fabtests/benchmarks/benchmark_shared.c
+++ b/fabtests/benchmarks/benchmark_shared.c
@@ -167,8 +167,9 @@ int pingpong_rma(enum ft_rma_opcodes rma_op, struct fi_rma_iov *remote)
 		return EXIT_FAILURE;
 	}
 
-	/* Init rx_buf for test */
-	*(rx_buf + opts.transfer_size - 1) = (char)-1;
+	/* Init rx_buf with invalid iteration number */
+	if (rma_op == FT_RMA_WRITE)
+		*(rx_buf + opts.transfer_size - 1) = (char)-1;
 
 	if (opts.dst_addr) {
 		for (i = 0; i < opts.iterations + opts.warmup_iterations; i++) {
@@ -176,8 +177,8 @@ int pingpong_rma(enum ft_rma_opcodes rma_op, struct fi_rma_iov *remote)
 			if (i == opts.warmup_iterations)
 				ft_start();
 
-			/* Init tx_buf for test */
-			*(tx_buf + opts.transfer_size - 1) = (char)i;
+			if (rma_op == FT_RMA_WRITE)
+				*(tx_buf + opts.transfer_size - 1) = (char)i;
 
 			if (opts.transfer_size <= inject_size)
 				ret = ft_inject_rma(rma_op, remote, ep,
@@ -202,8 +203,8 @@ int pingpong_rma(enum ft_rma_opcodes rma_op, struct fi_rma_iov *remote)
 			if (ret)
 				return ret;
 
-			/* Init tx_buf for test */
-			*(tx_buf + opts.transfer_size - 1) = (char)i;
+			if (rma_op == FT_RMA_WRITE)
+				*(tx_buf + opts.transfer_size - 1) = (char)i;
 
 			if (opts.transfer_size <= inject_size)
 				ret = ft_inject_rma(rma_op, remote, ep,

--- a/fabtests/benchmarks/rma_pingpong.c
+++ b/fabtests/benchmarks/rma_pingpong.c
@@ -128,6 +128,11 @@ int main(int argc, char **argv)
 		return EXIT_FAILURE;
 	}
 
+	if (opts.iface != FI_HMEM_SYSTEM && opts.rma_op == FT_RMA_WRITE) {
+		FT_ERR("rma_pingpong write test does not support HMEM");
+		return EXIT_FAILURE;
+	}
+
 	/* data validation on read and write ops requires delivery_complete semantics. */
 	if (opts.rma_op != FT_RMA_WRITEDATA && ft_check_opts(FT_OPT_VERIFY_DATA))
 		hints->tx_attr->op_flags |= FI_DELIVERY_COMPLETE;


### PR DESCRIPTION
* Don't init {tx,rx}_buf for writedata tests
* Fail rma_pingpong with `-o write` and HMEM

With this PR, rma_pingpong write test with HMEM fails as expected, and writedata with HMEM succeeds. (Tested on EFA provider.)