### PR TITLE
prov/efa: use peer pointer from txe in read, write and send

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -422,18 +422,14 @@ size_t efa_rdm_ope_mulreq_total_data_size(struct efa_rdm_ope *ope, int pkt_type)
  */
 size_t efa_rdm_txe_max_req_data_capacity(struct efa_rdm_ep *ep, struct efa_rdm_ope *txe, int pkt_type)
 {
-	struct efa_rdm_peer *peer;
 	uint16_t header_flags = 0;
 	int max_data_offset;
 
 	assert(pkt_type >= EFA_RDM_REQ_PKT_BEGIN);
 
-	peer = efa_rdm_ep_get_peer(ep, txe->addr);
-	assert(peer);
-
-	if (efa_rdm_peer_need_raw_addr_hdr(peer))
+	if (efa_rdm_peer_need_raw_addr_hdr(txe->peer))
 		header_flags |= EFA_RDM_REQ_OPT_RAW_ADDR_HDR;
-	else if (efa_rdm_peer_need_connid(peer))
+	else if (efa_rdm_peer_need_connid(txe->peer))
 		header_flags |= EFA_RDM_PKT_CONNID_HDR;
 
 	if (txe->fi_flags & FI_REMOTE_CQ_DATA)
@@ -1704,7 +1700,6 @@ ssize_t efa_rdm_ope_post_send(struct efa_rdm_ope *ope, int pkt_type)
 {
 	struct efa_rdm_ep *ep;
 	struct efa_rdm_pke *pkt_entry_vec[EFA_RDM_EP_MAX_WR_PER_IBV_POST_SEND];
-	struct efa_rdm_peer *peer;
 	ssize_t err;
 	size_t segment_offset;
 	int pkt_entry_cnt, pkt_entry_data_size_vec[EFA_RDM_EP_MAX_WR_PER_IBV_POST_SEND];
@@ -1746,9 +1741,7 @@ ssize_t efa_rdm_ope_post_send(struct efa_rdm_ope *ope, int pkt_type)
 		goto handle_err;
 	}
 
-	peer = efa_rdm_ep_get_peer(ep, ope->addr);
-	assert(peer);
-	peer->flags |= EFA_RDM_PEER_REQ_SENT;
+	ope->peer->flags |= EFA_RDM_PEER_REQ_SENT;
 	for (i = 0; i < pkt_entry_cnt; ++i)
 		efa_rdm_pke_handle_sent(pkt_entry_vec[i]);
 	return 0;

--- a/prov/efa/src/rdm/efa_rdm_pke_req.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_req.c
@@ -56,7 +56,6 @@ void efa_rdm_pke_init_req_hdr_common(struct efa_rdm_pke *pkt_entry,
 {
 	char *opt_hdr;
 	struct efa_rdm_ep *ep;
-	struct efa_rdm_peer *peer;
 	struct efa_rdm_base_hdr *base_hdr;
 
 	/* init the base header */
@@ -66,17 +65,15 @@ void efa_rdm_pke_init_req_hdr_common(struct efa_rdm_pke *pkt_entry,
 	base_hdr->flags = 0;
 
 	ep = txe->ep;
-	peer = efa_rdm_ep_get_peer(ep, txe->addr);
-	assert(peer);
 
-	if (efa_rdm_peer_need_raw_addr_hdr(peer)) {
+	if (efa_rdm_peer_need_raw_addr_hdr(txe->peer)) {
 		/*
 		 * This is the first communication with this peer on this
 		 * endpoint, so send the core's address for this EP in the REQ
 		 * so the remote side can insert it into its address vector.
 		 */
 		base_hdr->flags |= EFA_RDM_REQ_OPT_RAW_ADDR_HDR;
-	} else if (efa_rdm_peer_need_connid(peer)) {
+	} else if (efa_rdm_peer_need_connid(txe->peer)) {
 		/*
 		 * After receiving handshake packet, we will know the peer's capability.
 		 *
@@ -257,7 +254,7 @@ uint32_t efa_rdm_pke_get_req_rma_iov_count(struct efa_rdm_pke *pkt_entry)
 
 /**
  * @brief get the base header size of a REQ packet
- * 
+ *
  * @return
  * a integer that is > 0.
  */

--- a/prov/efa/test/efa_unit_test_ope.c
+++ b/prov/efa/test/efa_unit_test_ope.c
@@ -10,6 +10,7 @@ void test_efa_rdm_ope_prepare_to_post_send_impl(struct efa_resource *resource,
 	struct efa_ep_addr raw_addr;
 	struct efa_mr mock_mr;
 	struct efa_rdm_ope mock_txe;
+	struct efa_rdm_peer mock_peer;
 	size_t raw_addr_len = sizeof(raw_addr);
 	fi_addr_t addr;
 	int pkt_entry_cnt, pkt_entry_data_size_vec[1024];
@@ -31,8 +32,9 @@ void test_efa_rdm_ope_prepare_to_post_send_impl(struct efa_resource *resource,
 	mock_txe.iov[0].iov_base = NULL;
 	mock_txe.iov[0].iov_len = 9000;
 	mock_txe.desc[0] = &mock_mr;
-
 	mock_txe.ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
+	mock_txe.peer = &mock_peer;
+
 	err = efa_rdm_ope_prepare_to_post_send(&mock_txe,
 					       EFA_RDM_MEDIUM_MSGRTM_PKT,
 					       &pkt_entry_cnt,


### PR DESCRIPTION
The peer pointer is calculated and stored in the txe.  Use this pointer instead of constantly re-calling efa_rdm_ep_get_peer() to get this pointer for performance reasons.