### PR TITLE
prov/util: Switch cq->ep_list_lock from mutex to spinlock

### DIFF
--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -737,7 +737,7 @@ int ofi_cq_init(const struct fi_provider *prov, struct fid_domain *domain,
 		goto destroy1;
 
 	/* TODO Figure out how to optimize this lock for rdm and msg endpoints */
-	ret = ofi_genlock_init(&cq->ep_list_lock, OFI_LOCK_MUTEX);
+	ret = ofi_genlock_init(&cq->ep_list_lock, OFI_LOCK_SPINLOCK);
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
This PR switches the cq's ep_list_lock from a mutex lock to a spinlock. It was shown via EFA progress benchmarks that this change cuts ~200ns from our fi_cq_read calls.

before this PR:
```
Server fi_senddata fruitful cq progress p1 average ns: 1041.468177699095, pstd: 126.21655460969343, min: 29, max: 5220, median: 1000, num_samples: 1998457, unique: 428, num_outliers removed (5x mean): 1543
```

after this PR:
```
Server fi_senddata fruitful cq progress p1 average ns: 829.3492229892696, pstd: 105.98675207435754, min: 29, max: 3140, median: 800, num_samples: 1998428, unique: 364, num_outliers removed (5x mean): 1572
```