### PR TITLE
prov/efa: Remove FI_THREAD_SAFE control interface from EFA (stopping the EFA provider from following the Libfabric API)

### DIFF
--- a/man/fi_efa.7.md
+++ b/man/fi_efa.7.md
@@ -89,6 +89,11 @@ requires peer to peer transaction support between the EFA and the FI_HMEM
 device. Therefore, the FI_HMEM_P2P_DISABLED option is not supported by the EFA
 provider for AWS Neuron or Habana SynapseAI.
 
+*FI_THREAD_DOMAIN*
+: In order to gain additional performance, if the user requests FI_THREAD_DOMAIN,
+  the control interface to the domain is also set at FI_THREAD_DOMAIN. This differs from the Libfabric API
+  which guarantees all control interfaces are always FI_THREAD_SAFE.
+
 # PROVIDER SPECIFIC ENDPOINT LEVEL OPTION
 
 *FI_OPT_EFA_RNR_RETRY*


### PR DESCRIPTION
This patch improves the performance of the EFA provider by removing locking in the CQ progress path.  It also causes the EFA provider to not comply with the Libfabric API promise of offering thread safe control interfaces.  When a user specifies FI_THREAD_DOMAIN, we will make the control interfaces thread safe to the level of FI_THREAD_DOMAIN. It is common for message endpoints to have a separate thread for just control calls, and those endpoints still want to claim FI_THREAD_DOMAIN, instead of FI_THREAD_SAFE for performance reasons. The EFA endpoint is an RDM endpoint, so the use case of a thread for the control API is not an expected use case.  I created an issue for adjusting the libfabric API https://github.com/ofiwg/libfabric/issues/9665 to make RDM points not maintain the FI_THREAD_SAFE control interface promise. Those changes might take a long time (if they ever) get passed the community. This change gets the EFA Provider the performance boost immediately.
    
Signed-off-by: Seth Zegelstein <szegel@amazon.com>
