### PR TITLE
OPX: Initialize cq error data size

### DIFF
--- a/prov/opx/include/rdma/opx/fi_opx_endpoint.h
+++ b/prov/opx/include/rdma/opx/fi_opx_endpoint.h
@@ -2713,6 +2713,7 @@ int fi_opx_ep_cancel_context(struct fi_opx_ep * opx_ep,
 		ext->err_entry.err = FI_ECANCELED;
 		ext->err_entry.prov_errno = 0;
 		ext->err_entry.err_data = NULL;
+		ext->err_entry.err_data_size = 0;
 
 		/* post an 'error' completion event for the canceled receive */
 		if (lock_required) { fprintf(stderr, "%s:%s():%d\n", __FILE__, __func__, __LINE__); abort(); }

--- a/prov/opx/src/fi_opx_ep.c
+++ b/prov/opx/src/fi_opx_ep.c
@@ -1585,6 +1585,7 @@ int fi_opx_ep_rx_cancel (struct fi_opx_ep_rx * rx,
 			ext->err_entry.err = FI_ECANCELED;
 			ext->err_entry.prov_errno = 0;
 			ext->err_entry.err_data = NULL;
+			ext->err_entry.err_data_size = 0;
 
 			if (lock_required) { fprintf(stderr, "%s:%s():%d\n", __FILE__, __func__, __LINE__); abort(); }
 			fi_opx_context_slist_insert_tail((union fi_opx_context*)ext, rx->cq_err_ptr);
@@ -2113,6 +2114,7 @@ void fi_opx_ep_rx_process_context_noinline (struct fi_opx_ep * opx_ep,
 		ext->err_entry.err = FI_ENOMSG;
 		ext->err_entry.prov_errno = 0;
 		ext->err_entry.err_data = NULL;
+		ext->err_entry.err_data_size = 0;
 		ext->opx_context.byte_counter = 0;
 
 		FI_DBG_TRACE(fi_opx_global.prov, FI_LOG_EP_DATA, "no match found on unexpected queue posting error\n");


### PR DESCRIPTION
This commit is to add in an initialization that was missing and addresses a bug seen in the OPX provider in the 1.20 release.