### PR TITLE
fabtests/efa: Improve MR exhaustion test

### DIFF
--- a/fabtests/prov/efa/src/efa_exhaust_mr_reg_common.c
+++ b/fabtests/prov/efa/src/efa_exhaust_mr_reg_common.c
@@ -20,6 +20,10 @@ int ft_efa_open_ibv_device(struct ibv_context **ctx) {
 	return 0;
 }
 
+int ft_efa_close_ibv_device(struct ibv_context *ctx) {
+	return ibv_close_device(ctx);
+}
+
 int ft_efa_get_max_mr(struct ibv_context *ctx) {
 	int ret;
 	struct ibv_device_attr dev_attr = {0};

--- a/fabtests/prov/efa/src/efa_exhaust_mr_reg_common.h
+++ b/fabtests/prov/efa/src/efa_exhaust_mr_reg_common.h
@@ -6,11 +6,12 @@
 #ifndef _EFA_EXHAUST_MR_REG_COMMON_H
 #define _EFA_EXHAUST_MR_REG_COMMON_H
 
-/* The EFA NIC currently supports a maximum of 256 * 1024 = 262144 registrations */
-#define EFA_MR_REG_LIMIT 262144
 #define EFA_MR_REG_BUF_SIZE 128
 
-int ft_efa_setup_ibv_pd(struct ibv_pd **pd);
+int ft_efa_open_ibv_device(struct ibv_context **ctx);
+int ft_efa_close_ibv_device(struct ibv_context *ctx);
+int ft_efa_get_max_mr(struct ibv_context *ctx);
+int ft_efa_setup_ibv_pd(struct ibv_context *ctx, struct ibv_pd **pd);
 void ft_efa_destroy_ibv_pd(struct ibv_pd *pd);
 int ft_efa_register_mr_reg(struct ibv_pd *pd, void **buffers, size_t buf_size,
 			   struct ibv_mr **mr_reg_vec, size_t count, size_t *registered);

--- a/fabtests/prov/efa/src/efa_exhaust_mr_reg_common.h
+++ b/fabtests/prov/efa/src/efa_exhaust_mr_reg_common.h
@@ -16,5 +16,6 @@ int ft_efa_register_mr_reg(struct ibv_pd *pd, void **buffers, size_t buf_size,
 			   struct ibv_mr **mr_reg_vec, size_t count, size_t *registered);
 int ft_efa_deregister_mr_reg(struct ibv_mr **mr_reg_vec, size_t count);
 int ft_efa_alloc_bufs(void **buffers, size_t buf_size, size_t count);
+int ft_efa_unexpected_pingpong(void);
 
 #endif /* _EFA_EXHAUST_MR_REG_COMMON_H */

--- a/fabtests/prov/efa/src/efa_exhaust_mr_reg_rdm_pingpong.c
+++ b/fabtests/prov/efa/src/efa_exhaust_mr_reg_rdm_pingpong.c
@@ -40,7 +40,7 @@ int main(int argc, char **argv)
 	size_t registered;
 	void **buffers = NULL;
 	struct ibv_mr **mr_reg_vec = NULL;
-	struct ibv_context *ibv_ctx;
+	struct ibv_context *ibv_ctx = NULL;
 	struct ibv_pd *pd;
 
 	opts = INIT_OPTS;
@@ -135,6 +135,7 @@ out:
 		if (err)
 			FT_PRINTERR("ibv mr dereg", -err);
 		ft_efa_destroy_ibv_pd(pd);
+		ft_efa_close_ibv_device(ibv_ctx);
 	}
 
 	free(buffers);


### PR DESCRIPTION
Some improvements to the MR exhaustion test
* Add a simple test for the unexpected message path
* Get device MR limit by querying the device instead of hardcoding the value
* Close ibv device after use