### PR TITLE
prov/efa: Make handshake code use TXE, and provide perf improvements to EFA

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_atomic.c
+++ b/prov/efa/src/rdm/efa_rdm_atomic.c
@@ -174,7 +174,7 @@ ssize_t efa_rdm_atomic_generic_efa(struct efa_rdm_ep *efa_rdm_ep,
 		 * the information whether the peer
 		 * support it or not.
 		 */
-		err = efa_rdm_ep_trigger_handshake(efa_rdm_ep, txe->addr);
+		err = efa_rdm_ep_trigger_handshake(efa_rdm_ep, txe->peer);
 		if (OFI_UNLIKELY(err)) {
 			efa_rdm_txe_release(txe);
 			goto out;

--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -436,8 +436,7 @@ static inline struct util_srx_ctx *efa_rdm_ep_get_peer_srx_ctx(struct efa_rdm_ep
 	return (struct util_srx_ctx *) ep->peer_srx_ep->fid.context;
 }
 
-ssize_t efa_rdm_ep_trigger_handshake(struct efa_rdm_ep *ep,
-				     fi_addr_t addr);
+ssize_t efa_rdm_ep_trigger_handshake(struct efa_rdm_ep *ep, struct efa_rdm_peer *peer);
 
 ssize_t efa_rdm_ep_post_handshake(struct efa_rdm_ep *ep, struct efa_rdm_peer *peer);
 

--- a/prov/efa/src/rdm/efa_rdm_ep_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_utils.c
@@ -342,11 +342,13 @@ void efa_rdm_ep_record_tx_op_submitted(struct efa_rdm_ep *ep, struct efa_rdm_pke
 	struct efa_rdm_ope *ope;
 
 	ope = pkt_entry->ope;
+	assert(ope);
+
 	/*
 	 * peer can be NULL when the pkt_entry is a RMA_CONTEXT_PKT,
 	 * and the RMA is a local read toward the endpoint itself
 	 */
-	peer = efa_rdm_ep_get_peer(ep, pkt_entry->addr);
+	peer = ope->peer;
 	if (peer)
 		dlist_insert_tail(&pkt_entry->entry,
 				  &peer->outstanding_tx_pkts);

--- a/prov/efa/src/rdm/efa_rdm_ep_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_utils.c
@@ -599,14 +599,35 @@ ssize_t efa_rdm_ep_trigger_handshake(struct efa_rdm_ep *ep, struct efa_rdm_peer 
  */
 ssize_t efa_rdm_ep_post_handshake(struct efa_rdm_ep *ep, struct efa_rdm_peer *peer)
 {
+	struct efa_rdm_ope *txe;
+	struct fi_msg msg = {0};
 	struct efa_rdm_pke *pkt_entry;
 	fi_addr_t addr;
 	ssize_t ret;
 
 	addr = peer->efa_fiaddr;
-	pkt_entry = efa_rdm_pke_alloc(ep, ep->efa_tx_pkt_pool, EFA_RDM_PKE_FROM_EFA_TX_POOL);
-	if (OFI_UNLIKELY(!pkt_entry))
+	msg.addr = addr;
+
+	/* ofi_op_write is ignored in handshake path */
+	txe = efa_rdm_ep_alloc_txe(ep, peer, &msg, ofi_op_write, 0, 0);
+
+	if (OFI_UNLIKELY(!txe)) {
+		EFA_WARN(FI_LOG_EP_CTRL, "TX entries exhausted.\n");
 		return -FI_EAGAIN;
+	}
+
+	/* efa_rdm_ep_alloc_txe() joins ep->base_ep.util_ep.tx_op_flags and passed in flags,
+	 * reset to desired flags (remove things like FI_DELIVERY_COMPLETE, and FI_COMPLETION)
+	 */
+	txe->fi_flags = EFA_RDM_TXE_NO_COMPLETION | EFA_RDM_TXE_NO_COUNTER;
+
+	pkt_entry = efa_rdm_pke_alloc(ep, ep->efa_tx_pkt_pool, EFA_RDM_PKE_FROM_EFA_TX_POOL);
+	if (OFI_UNLIKELY(!pkt_entry)) {
+		EFA_WARN(FI_LOG_EP_CTRL, "PKE entries exhausted.\n");
+		return -FI_EAGAIN;
+	}
+
+	pkt_entry->ope = txe;
 
 	efa_rdm_pke_init_handshake(pkt_entry, addr);
 

--- a/prov/efa/src/rdm/efa_rdm_ep_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_utils.c
@@ -557,16 +557,12 @@ void efa_rdm_ep_queue_rnr_pkt(struct efa_rdm_ep *ep,
  * return negative libfabric error code for error. Possible errors include:
  * -FI_EAGAIN	temporarily out of resource to send packet
  */
-ssize_t efa_rdm_ep_trigger_handshake(struct efa_rdm_ep *ep,
-				     fi_addr_t addr)
+ssize_t efa_rdm_ep_trigger_handshake(struct efa_rdm_ep *ep, struct efa_rdm_peer *peer)
 {
-	struct efa_rdm_peer *peer;
 	struct efa_rdm_ope *txe;
 	ssize_t err;
 
-	peer = efa_rdm_ep_get_peer(ep, addr);
 	assert(peer);
-
 	if ((peer->flags & EFA_RDM_PEER_HANDSHAKE_RECEIVED) ||
 	    (peer->flags & EFA_RDM_PEER_REQ_SENT))
 		return 0;
@@ -580,8 +576,8 @@ ssize_t efa_rdm_ep_trigger_handshake(struct efa_rdm_ep *ep,
 
 	txe->ep = ep;
 	txe->total_len = 0;
-	txe->addr = addr;
-	txe->peer = efa_rdm_ep_get_peer(ep, txe->addr);
+	txe->addr = peer->efa_fiaddr;
+	txe->peer = peer;
 	assert(txe->peer);
 	dlist_insert_tail(&txe->peer_entry, &txe->peer->txe_list);
 	txe->msg_id = -1;

--- a/prov/efa/src/rdm/efa_rdm_msg.c
+++ b/prov/efa/src/rdm/efa_rdm_msg.c
@@ -127,7 +127,7 @@ ssize_t efa_rdm_msg_post_rtm(struct efa_rdm_ep *ep, struct efa_rdm_ope *txe, int
 	 */
 	if (efa_mr_is_hmem(txe->desc[0]) &&
 	    !(txe->peer->flags & EFA_RDM_PEER_HANDSHAKE_RECEIVED)) {
-		err = efa_rdm_ep_trigger_handshake(ep, txe->addr);
+		err = efa_rdm_ep_trigger_handshake(ep, txe->peer);
 		return err ? err : -FI_EAGAIN;
 	}
 
@@ -145,7 +145,7 @@ ssize_t efa_rdm_msg_post_rtm(struct efa_rdm_ep *ep, struct efa_rdm_ope *txe, int
 	 * Check handshake packet from peer to verify support status.
 	 */
 	if (!(txe->peer->flags & EFA_RDM_PEER_HANDSHAKE_RECEIVED)) {
-		err = efa_rdm_ep_trigger_handshake(ep, txe->addr);
+		err = efa_rdm_ep_trigger_handshake(ep, txe->peer);
 		return err ? err : -FI_EAGAIN;
 	}
 

--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -69,6 +69,7 @@ void efa_rdm_txe_construct(struct efa_rdm_ope *txe,
 	txe->bytes_sent = 0;
 	txe->window = 0;
 	txe->iov_count = msg->iov_count;
+	txe->rma_iov_count = 0;
 	txe->msg_id = 0;
 	txe->efa_outstanding_tx_ops = 0;
 	dlist_init(&txe->queued_pkts);

--- a/prov/efa/src/rdm/efa_rdm_pke.c
+++ b/prov/efa/src/rdm/efa_rdm_pke.c
@@ -398,7 +398,9 @@ ssize_t efa_rdm_pke_sendv(struct efa_rdm_pke **pkt_entry_vec,
 	assert(pkt_entry_cnt);
 	ep = pkt_entry_vec[0]->ep;
 	assert(ep);
-	peer = efa_rdm_ep_get_peer(ep, pkt_entry_vec[0]->addr);
+
+	assert(pkt_entry_vec[0]->ope);
+	peer = pkt_entry_vec[0]->ope->peer;
 	assert(peer);
 	if (peer->flags & EFA_RDM_PEER_IN_BACKOFF)
 		return -FI_EAGAIN;

--- a/prov/efa/src/rdm/efa_rdm_rma.c
+++ b/prov/efa/src/rdm/efa_rdm_rma.c
@@ -178,7 +178,7 @@ ssize_t efa_rdm_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uin
 	 * need to check the local ep's capabilities.
 	 */
 	if (!(peer->is_self) && !(peer->flags & EFA_RDM_PEER_HANDSHAKE_RECEIVED)) {
-		err = efa_rdm_ep_trigger_handshake(efa_rdm_ep, txe->addr);
+		err = efa_rdm_ep_trigger_handshake(efa_rdm_ep, txe->peer);
 		err = err ? err : -FI_EAGAIN;
 		goto out;
 	}
@@ -363,7 +363,7 @@ ssize_t efa_rdm_rma_post_write(struct efa_rdm_ep *ep, struct efa_rdm_ope *txe)
 	 * check one-side capability
 	 */
 	if (!(txe->peer->is_self) && !(txe->peer->flags & EFA_RDM_PEER_HANDSHAKE_RECEIVED)) {
-		err = efa_rdm_ep_trigger_handshake(ep, txe->addr);
+		err = efa_rdm_ep_trigger_handshake(ep, txe->peer);
 		return err ? err : -FI_EAGAIN;
 	}
 
@@ -389,7 +389,7 @@ ssize_t efa_rdm_rma_post_write(struct efa_rdm_ep *ep, struct efa_rdm_ope *txe)
 		 * the information whether the peer
 		 * support it or not.
 		 */
-		err = efa_rdm_ep_trigger_handshake(ep, txe->addr);
+		err = efa_rdm_ep_trigger_handshake(ep, txe->peer);
 		if (OFI_UNLIKELY(err))
 			return err;
 

--- a/prov/efa/test/efa_unit_test_cq.c
+++ b/prov/efa/test/efa_unit_test_cq.c
@@ -45,7 +45,7 @@ void test_impl_cq_read_empty_cq(struct efa_resource *resource, enum fi_ep_type e
  * @brief verify DGRAM CQ's fi_cq_read() works with empty CQ
  *
  * When CQ is empty, fi_cq_read() should return -FI_EAGAIN.
- * 
+ *
  * @param[in]	state		struct efa_resource that is managed by the framework
  */
 void test_dgram_cq_read_empty_cq(struct efa_resource **state)
@@ -58,7 +58,7 @@ void test_dgram_cq_read_empty_cq(struct efa_resource **state)
  * @brief verify RDM CQ's fi_cq_read() works with empty CQ
  *
  * When CQ is empty, fi_cq_read() should return -FI_EAGAIN.
- * 
+ *
  * @param[in]	state		struct efa_resource that is managed by the framework
  */
 void test_ibv_cq_ex_read_empty_cq(struct efa_resource **state)
@@ -106,8 +106,11 @@ static void test_rdm_cq_read_bad_send_status(struct efa_resource *resource,
 	ibv_qpx = efa_rdm_ep->base_ep.qp->ibv_qp_ex;
 	ibv_cqx = efa_rdm_ep->ibv_cq_ex;
 	/* close shm_ep to force efa_rdm_ep to use efa device to send */
-	fi_close(&efa_rdm_ep->shm_ep->fid);
-	efa_rdm_ep->shm_ep = NULL;
+	if (efa_rdm_ep->shm_ep) {
+		err = fi_close(&efa_rdm_ep->shm_ep->fid);
+		assert_int_equal(err, 0);
+		efa_rdm_ep->shm_ep = NULL;
+	}
 
 	ret = fi_getname(&resource->ep->fid, &raw_addr, &raw_addr_len);
 	assert_int_equal(ret, 0);
@@ -280,7 +283,7 @@ void test_rdm_cq_read_bad_send_status_message_too_long(struct efa_resource **sta
  *
  * When an ibv_post_recv() operation failed, no data was received. Therefore libfabric cannot
  * find the corresponding RX operation to write a CQ error. It will write an EQ error instead.
- * 
+ *
  * @param[in]	state		struct efa_resource that is managed by the framework
  */
 void test_ibv_cq_ex_read_bad_recv_status(struct efa_resource **state)
@@ -373,7 +376,7 @@ void test_ibv_cq_ex_read_failed_poll(struct efa_resource **state)
  * Simulate EFA device by setting peer AH to unknown and make sure the
  * endpoint recovers the peer address iff(if and only if) the peer is
  * inserted to AV.
- * 
+ *
  * @param resource		struct efa_resource that is managed by the framework
  * @param remove_peer	Boolean value that indicates if the peer was removed explicitly
  * @param support_efadv_cq	Boolean value that indicates if EFA device supports EFA DV CQ
@@ -454,7 +457,7 @@ static void test_impl_ibv_cq_ex_read_unknow_peer_ah(struct efa_resource *resourc
 		/* Return unknown AH from efadv */
 		will_return(efa_mock_efadv_wc_read_sgid_return_zero_code_and_expect_next_poll_and_set_gid, raw_addr.raw);
 	} else {
-		expect_function_call(efa_mock_ibv_next_poll_check_function_called_and_return_mock);	
+		expect_function_call(efa_mock_ibv_next_poll_check_function_called_and_return_mock);
 	}
 
 	/* Read 1 entry with unknown AH */
@@ -496,7 +499,7 @@ static void test_impl_ibv_cq_ex_read_unknow_peer_ah(struct efa_resource *resourc
  * for which the EFA device returns an unknown AH. The endpoint will retrieve
  * the peer's raw address using efadv verbs, and recover it's AH using
  * Raw:QPN:QKey.
- * 
+ *
  * @param[in]	state		struct efa_resource that is managed by the framework
  */
 void test_ibv_cq_ex_read_recover_forgotten_peer_ah(struct efa_resource **state)
@@ -509,7 +512,7 @@ void test_ibv_cq_ex_read_recover_forgotten_peer_ah(struct efa_resource **state)
  * @brief Verify that RDM endpoint falls back to ibv_create_cq_ex if rdma-core
  * provides efadv_create_cq verb but EFA device does not support EFA DV CQ.
  * In this case the endpoint will not attempt to recover a forgotten peer's address.
- * 
+ *
  * @param[in]	state		struct efa_resource that is managed by the framework
  */
 void test_rdm_fallback_to_ibv_create_cq_ex_cq_read_ignore_forgotton_peer(struct efa_resource **state)
@@ -524,7 +527,7 @@ void test_rdm_fallback_to_ibv_create_cq_ex_cq_read_ignore_forgotton_peer(struct 
  * The endpoint receives a packet from an alien peer, which corresponds to
  * an unknown AH. The endpoint attempts to look up the AH for the peer but
  * was rightly unable to, thus ignoring the packet.
- * 
+ *
  * @param[in]	state		struct efa_resource that is managed by the framework
  */
 void test_ibv_cq_ex_read_ignore_removed_peer(struct efa_resource **state)

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -84,7 +84,7 @@ void test_efa_rdm_ep_ignore_non_hex_host_id(struct efa_resource **state)
  *	the packet header and set the peer host id if HOST_ID_HDR is turned on.
  *	Then the endpoint should respond with a handshake packet, and include the local host id
  *	if and only if it is non-zero.
- * 
+ *
  * @param[in]	state		cmocka state variable
  * @param[in]	local_host_id	The local host id
  * @param[in]	peer_host_id	The remote peer host id
@@ -116,9 +116,12 @@ void test_efa_rdm_ep_handshake_exchange_host_id(struct efa_resource **state, uin
 	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
 	efa_rdm_ep->host_id = g_efa_unit_test_mocks.local_host_id;
 	/* close shm_ep to force efa_rdm_ep to use efa device to send */
-	ret = fi_close(&efa_rdm_ep->shm_ep->fid);
-	assert_int_equal(ret, 0);
-	efa_rdm_ep->shm_ep = NULL;
+	if (efa_rdm_ep->shm_ep) {
+		ret = fi_close(&efa_rdm_ep->shm_ep->fid);
+		assert_int_equal(ret, 0);
+		efa_rdm_ep->shm_ep = NULL;
+	}
+
 
 	/* Create and register a fake peer */
 	assert_int_equal(fi_getname(&resource->ep->fid, &raw_addr, &raw_addr_len), 0);
@@ -373,9 +376,11 @@ void test_efa_rdm_ep_dc_atomic_error_handling(struct efa_resource **state)
 
 	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
 	/* close shm_ep to force efa_rdm_ep to use efa device to send */
-	err = fi_close(&efa_rdm_ep->shm_ep->fid);
-	assert_int_equal(err, 0);
-	efa_rdm_ep->shm_ep = NULL;
+	if (efa_rdm_ep->shm_ep) {
+		err = fi_close(&efa_rdm_ep->shm_ep->fid);
+		assert_int_equal(err, 0);
+		efa_rdm_ep->shm_ep = NULL;
+	}
 	/* set peer->flag to EFA_RDM_PEER_REQ_SENT will make efa_rdm_atomic() think
 	 * a REQ packet has been sent to the peer (so no need to send again)
 	 * handshake has not been received, so we do not know whether the peer support DC

--- a/prov/efa/test/efa_unit_test_rnr.c
+++ b/prov/efa/test/efa_unit_test_rnr.c
@@ -38,9 +38,12 @@ void test_efa_rnr_queue_and_resend(struct efa_resource **state)
 	assert_true(dlist_empty(&efa_rdm_ep->txe_list));
 
 	/* close shm_ep to force efa_rdm_ep to use efa device to send */
-	ret = fi_close(&efa_rdm_ep->shm_ep->fid);
-	assert_int_equal(ret, 0);
-	efa_rdm_ep->shm_ep = NULL;
+	if (efa_rdm_ep->shm_ep) {
+		ret = fi_close(&efa_rdm_ep->shm_ep->fid);
+		assert_int_equal(ret, 0);
+		efa_rdm_ep->shm_ep = NULL;
+	}
+
 	ret = fi_send(resource->ep, send_buff.buff, send_buff.size, fi_mr_desc(send_buff.mr), peer_addr, NULL /* context */);
 	assert_int_equal(ret, 0);
 	assert_false(dlist_empty(&efa_rdm_ep->txe_list));


### PR DESCRIPTION
Switch handshake send/response functions to create a txe.  Optimize the EFA send path by removing redundant efa_rdm_ep_get_peer() functions from it. 