### PR TITLE
[v1.18.x] prov/rxm: Fix data error with FI_OFI_RXM_USE_RNDV_WRITE=1

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -613,6 +613,7 @@ static ssize_t rxm_handle_rndv(struct rxm_rx_buf *rx_buf)
 			mr = rx_buf->recv_entry->rxm_iov.desc[i];
 			rx_buf->recv_entry->rxm_iov.desc[i] =
 				fi_mr_desc(mr->msg_mr);
+			rx_buf->mr[i] = mr->msg_mr;
 		}
 	}
 


### PR DESCRIPTION
Data verification would fail with rxm/verbs when FI_OFI_RXM_USE_RNDV_WRITE is set to 1. It appears that the content of the receive buffer remains unchanged after the rendezvous send is completed.

This only happens when the core provider requires FI_MR_LOCAL mode. The root cause is that MR descriptors passed through the receive call are not translated into rkeys when generating the rendezvous response. As a result, the sender always writes 0 byte.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>
(cherry picked from commit 81c0b7a54f2a9376fd6279abc8051c9d20dd4499)