### PR TITLE
man: Fix fi_rxm.7 and fi_collective.3 man pages

### DIFF
--- a/man/fi_collective.3.md
+++ b/man/fi_collective.3.md
@@ -119,6 +119,9 @@ int fi_query_collective(struct fid_domain *domain,
 *buf*
 : Local data buffer that specifies first operand of collective operation
 
+*count*
+: The number of elements referenced, where each element is the indicated datatype.
+
 *datatype*
 : Datatype associated with atomic operands
 

--- a/man/fi_rxm.7.md
+++ b/man/fi_rxm.7.md
@@ -122,8 +122,8 @@ FI_ORDER_SAW can not be supported.
 The ofi_rxm provider checks for the following environment variables.
 
 *FI_OFI_RXM_BUFFER_SIZE*
-: Defines the transmit buffer size / inject size. Messages of size less than this
-  would be transmitted via an eager protocol and those above would be transmitted
+: Defines the transmit buffer size / inject size. Messages of size less than or equal to this
+  would be transmitted via an eager protocol and messages greater in size would be transmitted
   via a rendezvous or SAR (Segmentation And Reassembly) protocol. Transmit data
   would be copied up to this size (default: ~16k).
 


### PR DESCRIPTION
fi_rxm.7: clarify the behavior when message size == FI_OFI_RXM_BUFFER_SIZE.

fi_collective.3: add the missing description of the `count` argument.