### PR TITLE
fabtests/pytest: Add more ssh connection error patterns

### DIFF
--- a/fabtests/pytest/common.py
+++ b/fabtests/pytest/common.py
@@ -29,6 +29,7 @@ def has_ssh_connection_err_msg(output):
     err_msgs = ["Connection closed",
                 "Connection reset by peer",
                 "Connection refused",
+                "Permission denied",
                 r"ssh_dispatch_run_fatal: .* incorrect signature"]
 
     for msg in err_msgs:


### PR DESCRIPTION
This is for SSH connection issue: `Permission denied (publickey,gssapi-keyex,gssapi-with-mic).`