### PR TITLE
Fix compiler warning when compiling with ICX

### DIFF
--- a/src/hmem_cuda.c
+++ b/src/hmem_cuda.c
@@ -631,8 +631,8 @@ static int cuda_hmem_detect_p2p_access_support(void)
 				"Failed to detect support for peer-to-peer "
 				"access between CUDA devices via "
 				"cuDeviceCanAccessPeer(): %s:%s\n",
-				ofi_cudaGetErrorName(cuda_ret),
-				ofi_cudaGetErrorString(cuda_ret));
+				ofi_cudaGetErrorName((cudaError_t)cuda_ret),
+				ofi_cudaGetErrorString((cudaError_t)cuda_ret));
 			return -FI_EIO;
 		}
 		FI_INFO(&core_prov, FI_LOG_CORE,


### PR DESCRIPTION
Compiling with icx uncovered an error from -Wenum-conversion. Need to explicitly cast from CUresult to cudaError_t for ofi_cudaGetErrorName and ofi_cudaGetErrorString calls.

Even with this fix, there is a risk that the return code is not a valid cudaError_t enumeration, but the only consequence will be that the functions return "Unknown Error".