### PR TITLE
hmem/ze: Increase ZE_MAX_DEVICES to 32

### DIFF
--- a/fabtests/common/hmem_ze.c
+++ b/fabtests/common/hmem_ze.c
@@ -43,7 +43,7 @@
 #include <dlfcn.h>
 #include <level_zero/ze_api.h>
 
-#define ZE_MAX_DEVICES 8
+#define ZE_MAX_DEVICES 32
 
 static ze_context_handle_t context;
 static ze_device_handle_t devices[ZE_MAX_DEVICES];

--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -207,7 +207,7 @@ int cuda_gdrcopy_dev_register(const void *buf, size_t len, uint64_t *handle);
 int cuda_gdrcopy_dev_unregister(uint64_t handle);
 int cuda_set_sync_memops(void *ptr);
 
-#define ZE_MAX_DEVICES 8
+#define ZE_MAX_DEVICES 32
 int ze_hmem_copy(uint64_t device, void *dst, const void *src, size_t size);
 int ze_hmem_init(void);
 int ze_hmem_cleanup(void);

--- a/src/hmem_ze.c
+++ b/src/hmem_ze.c
@@ -815,8 +815,15 @@ int ze_hmem_init(void)
 
 	count = 0;
 	ze_ret = ofi_zeDeviceGet(driver, &count, NULL);
-	if (ze_ret || count > ZE_MAX_DEVICES)
+	if (ze_ret)
 		goto err;
+
+	if (count > ZE_MAX_DEVICES) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"The number of ZE devices (%d) exceeds the limit (%d). Only (%d) will be used.\n",
+			count, ZE_MAX_DEVICES, ZE_MAX_DEVICES);
+		count = ZE_MAX_DEVICES;
+	}
 
 	ze_ret = ofi_zeDeviceGet(driver, &count, devices);
 	if (ze_ret)


### PR DESCRIPTION
We have already seen setups with 16 ZE devices. Increase the maximum to 32 to leave some room for future growth.

Ultimately we will need to remove this hard limit and allocated the resources dynamicaly. That can be done later.

Also change the behavior for the case when the limit is exceeded.