### PR TITLE
hmem/ze: Change the library name passed to dlopen

### DIFF
--- a/fabtests/common/hmem_ze.c
+++ b/fabtests/common/hmem_ze.c
@@ -84,7 +84,7 @@ static void *libze_handle;
 struct libze_ops libze_ops;
 int init_libze_ops(void)
 {
-	libze_handle = dlopen("libze_loader.so", RTLD_NOW);
+	libze_handle = dlopen("libze_loader.so.1", RTLD_NOW);
 	if (!libze_handle) {
 		FT_ERR("Failed to dlopen libze_loader.so\n");
 		goto err_out;

--- a/src/hmem_ze.c
+++ b/src/hmem_ze.c
@@ -495,7 +495,7 @@ bool ze_hmem_p2p_enabled(void)
 static int ze_hmem_dl_init(void)
 {
 #if ENABLE_ZE_DLOPEN
-	libze_handle = dlopen("libze_loader.so", RTLD_NOW);
+	libze_handle = dlopen("libze_loader.so.1", RTLD_NOW);
 	if (!libze_handle) {
 		FI_WARN(&core_prov, FI_LOG_CORE,
 			"Failed to dlopen libze_loader.so\n");


### PR DESCRIPTION
libze_loader.so requires level-zero-devel package. Use libze_loader.so.1 instead.