### PR TITLE
[v1.18.x] Cherry-picked commits for enabling mpichsuite rma tests

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -7,7 +7,7 @@ properties([disableConcurrentBuilds(abortPrevious: true)])
 @Field def RELEASE=false
 @Field def BUILD_MODES=["reg", "dbg", "dl"]
 @Field def PYTHON_VERSION="3.9"
-@Field def TIMEOUT="3600"
+@Field def TIMEOUT="7200"
 
 def run_python(version, command, output=null) {
   if (output != null)

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -719,6 +719,10 @@ class MpichTestSuite(Test):
                       'spawn'        : [('concurrent_spawns 1', 'test')],
                       'pt2pt'        : [('sendrecv3 2','test'),
                                         ('sendrecv3 2 arg=-isendrecv','test')],
+                      'threads/pt2pt': [(f"mt_improbe_sendrecv_huge 2 "
+                                       f"arg=-iter=64 arg=-count=4194304 "
+                                       f"env=MPIR_CVAR_CH4_OFI_EAGER_MAX_MSG_SIZE"
+                                       f"=16384", 'test')]
                     }
         }
 

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -712,11 +712,11 @@ class MpichTestSuite(Test):
         self.pwd = os.getcwd()
         self.weekly = weekly
         self.mpichtests_exclude = {
-        'tcp'   :   {   '.'        : [('spawn','dir'), ('rma','dir')],
-                    'threads'      : [('spawn','dir'), ('rma','dir')],
+        'tcp'   :   {   '.'        : [('spawn','dir')],
+                    'threads'      : [('spawn','dir')],
                     'threads/comm' : [('idup_nb 4','test'),
                                       ('idup_comm_gen 4','test')],
-                    'errors'       : [('spawn','dir'),('rma','dir')]
+                    'errors'       : [('spawn','dir')]
                 },
         'verbs' :   {   '.'        : [('spawn','dir')],
                     'threads/comm' : [('idup_nb 4','test')],

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -713,6 +713,7 @@ class MpichTestSuite(Test):
         self.weekly = weekly
         self.mpichtests_exclude = {
         'tcp'   :   {   '.'        : [('spawn','dir')],
+                        'rma'      : [('win_shared_put_flush_load 3', 'test')],
                     'threads'      : [('spawn','dir')],
                     'threads/comm' : [('idup_nb 4','test'),
                                       ('idup_comm_gen 4','test')],

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -474,6 +474,7 @@ class MPICH:
         else:
             cmd += f"export FI_PROVIDER={self.core_prov}; "
         cmd += "export I_MPI_FABRICS=ofi; "
+        cmd += "export HYDRA_LAUNCHER=fork;"
         cmd += "export MPIR_CVAR_CH4_OFI_ENABLE_ATOMICS=0; "
         cmd += "export MPIR_CVAR_CH4_OFI_CAPABILITY_SETS_DEBUG=0; "
         cmd += f"export LD_LIBRARY_PATH={self.mpich_dir}/lib:$LD_LIBRARY_PATH; "
@@ -712,23 +713,13 @@ class MpichTestSuite(Test):
         self.pwd = os.getcwd()
         self.weekly = weekly
         self.mpichtests_exclude = {
-        'tcp'   :   {   '.'        : [('spawn','dir')],
-                        'rma'      : [('win_shared_put_flush_load 3', 'test')],
-                    'threads'      : [('spawn','dir')],
-                    'threads/comm' : [('idup_nb 4','test'),
-                                      ('idup_comm_gen 4','test')],
-                    'errors'       : [('spawn','dir')]
-                },
-        'verbs' :   {   '.'        : [('spawn','dir')],
-                    'threads/comm' : [('idup_nb 4','test')],
-                    'threads'      : [('spawn','dir'), ('rma','dir')],
-                    'pt2pt'        : [('sendrecv3 2','test'),
-                                      ('sendrecv3 2 arg=-isendrecv','test')],
-                    'threads/pt2pt': [(f"mt_improbe_sendrecv_huge 2 "
-                                       f"arg=-iter=64 arg=-count=4194304 "
-                                       f"env=MPIR_CVAR_CH4_OFI_EAGER_MAX_MSG_SIZE"
-                                       f"=16384", 'test')]
-                }
+        'tcp'   :   { 'rma'      : [('win_shared_put_flush_load 3', 'test')]
+                    },
+        'verbs' :   { 'threads/comm' : [('idup_nb 4','test')],
+                      'spawn'        : [('concurrent_spawns 1', 'test')],
+                      'pt2pt'        : [('sendrecv3 2','test'),
+                                        ('sendrecv3 2 arg=-isendrecv','test')],
+                    }
         }
 
     def create_hostfile(self, file, hostlist):

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -713,7 +713,8 @@ class MpichTestSuite(Test):
         self.pwd = os.getcwd()
         self.weekly = weekly
         self.mpichtests_exclude = {
-        'tcp'   :   { 'rma'      : [('win_shared_put_flush_load 3', 'test')]
+        'tcp'   :   { 'rma'          : [('win_shared_put_flush_load 3', 'test')],
+                      'threads/comm' : [('idup_nb 4','test')]
                     },
         'verbs' :   { 'threads/comm' : [('idup_nb 4','test')],
                       'spawn'        : [('concurrent_spawns 1', 'test')],

--- a/prov/tcp/src/xnet.h
+++ b/prov/tcp/src/xnet.h
@@ -568,18 +568,27 @@ xnet_set_commit_flags(struct xnet_xfer_entry *xfer, uint64_t flags)
 }
 
 static inline uint64_t
-xnet_tx_completion_flag(struct xnet_ep *ep, uint64_t op_flags)
+xnet_tx_completion_get_msgflags(struct xnet_ep *ep, uint64_t flags)
 {
-	/* Generate a completion if op flags indicate or we generate
-	 * completions by default
+	/* Generate a completion if msg flags indicate or app
+	 * requests
 	 */
-	return (ep->util_ep.tx_op_flags | op_flags) & FI_COMPLETION;
+	return (ep->util_ep.tx_msg_flags | flags) & FI_COMPLETION;
 }
 
 static inline uint64_t
 xnet_rx_completion_flag(struct xnet_ep *ep)
 {
 	return ep->util_ep.rx_op_flags & FI_COMPLETION;
+}
+
+static inline uint64_t
+xnet_tx_completion_get_opflags(struct xnet_ep *ep)
+{
+	/* Generate a completion if op flags indicate or we generate
+	 * completions by default
+	 */
+	return ep->util_ep.tx_op_flags & FI_COMPLETION;
 }
 
 static inline struct xnet_xfer_entry *

--- a/prov/tcp/src/xnet_msg.c
+++ b/prov/tcp/src/xnet_msg.c
@@ -299,7 +299,7 @@ xnet_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t flags)
 	}
 
 	xnet_init_tx_iov(tx_entry, hdr_len, msg->msg_iov, msg->iov_count);
-	tx_entry->cq_flags = xnet_tx_completion_flag(ep, flags) |
+	tx_entry->cq_flags = xnet_tx_completion_get_msgflags(ep, flags) |
 			     FI_MSG | FI_SEND;
 	xnet_set_ack_flags(tx_entry, flags);
 	tx_entry->context = msg->context;
@@ -329,7 +329,7 @@ xnet_send(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	xnet_init_tx_buf(tx_entry, sizeof(tx_entry->hdr.base_hdr), buf, len);
 	tx_entry->context = context;
-	tx_entry->cq_flags = xnet_tx_completion_flag(ep, 0) |
+	tx_entry->cq_flags = xnet_tx_completion_get_opflags(ep) |
 			     FI_MSG | FI_SEND;
 	xnet_set_ack_flags(tx_entry, ep->util_ep.tx_op_flags);
 
@@ -358,7 +358,7 @@ xnet_sendv(struct fid_ep *ep_fid, const struct iovec *iov,
 
 	xnet_init_tx_iov(tx_entry, sizeof(tx_entry->hdr.base_hdr), iov, count);
 	tx_entry->context = context;
-	tx_entry->cq_flags = xnet_tx_completion_flag(ep, 0) |
+	tx_entry->cq_flags = xnet_tx_completion_get_opflags(ep) |
 			     FI_MSG | FI_SEND;
 	xnet_set_ack_flags(tx_entry, ep->util_ep.tx_op_flags);
 
@@ -421,7 +421,7 @@ xnet_senddata(struct fid_ep *ep_fid, const void *buf, size_t len,
 	xnet_init_tx_buf(tx_entry, sizeof(tx_entry->hdr.cq_data_hdr),
 			 buf, len);
 	tx_entry->context = context;
-	tx_entry->cq_flags = xnet_tx_completion_flag(ep, 0) |
+	tx_entry->cq_flags = xnet_tx_completion_get_opflags(ep) |
 			     FI_MSG | FI_SEND;
 	xnet_set_ack_flags(tx_entry, ep->util_ep.tx_op_flags);
 
@@ -504,7 +504,7 @@ xnet_tsendmsg(struct fid_ep *fid_ep, const struct fi_msg_tagged *msg,
 	}
 
 	xnet_init_tx_iov(tx_entry, hdr_len, msg->msg_iov, msg->iov_count);
-	tx_entry->cq_flags = xnet_tx_completion_flag(ep, flags) |
+	tx_entry->cq_flags = xnet_tx_completion_get_msgflags(ep, flags) |
 			     FI_TAGGED | FI_SEND;
 	xnet_set_ack_flags(tx_entry, flags);
 	tx_entry->context = msg->context;
@@ -536,7 +536,7 @@ xnet_tsend(struct fid_ep *fid_ep, const void *buf, size_t len,
 
 	xnet_init_tx_buf(tx_entry, sizeof(tx_entry->hdr.tag_hdr), buf, len);
 	tx_entry->context = context;
-	tx_entry->cq_flags = xnet_tx_completion_flag(ep, 0) |
+	tx_entry->cq_flags = xnet_tx_completion_get_opflags(ep) |
 			     FI_TAGGED | FI_SEND;
 	xnet_set_ack_flags(tx_entry, ep->util_ep.tx_op_flags);
 
@@ -567,7 +567,7 @@ xnet_tsendv(struct fid_ep *fid_ep, const struct iovec *iov, void **desc,
 
 	xnet_init_tx_iov(tx_entry, sizeof(tx_entry->hdr.tag_hdr), iov, count);
 	tx_entry->context = context;
-	tx_entry->cq_flags = xnet_tx_completion_flag(ep, 0) |
+	tx_entry->cq_flags = xnet_tx_completion_get_opflags(ep) |
 			     FI_TAGGED | FI_SEND;
 	xnet_set_ack_flags(tx_entry, ep->util_ep.tx_op_flags);
 
@@ -631,7 +631,7 @@ xnet_tsenddata(struct fid_ep *fid_ep, const void *buf, size_t len, void *desc,
 	xnet_init_tx_buf(tx_entry, sizeof(tx_entry->hdr.tag_data_hdr),
 			 buf, len);
 	tx_entry->context = context;
-	tx_entry->cq_flags = xnet_tx_completion_flag(ep, 0) |
+	tx_entry->cq_flags = xnet_tx_completion_get_opflags(ep) |
 			     FI_TAGGED | FI_SEND;
 	xnet_set_ack_flags(tx_entry, ep->util_ep.tx_op_flags);
 

--- a/prov/tcp/src/xnet_rdm_cm.c
+++ b/prov/tcp/src/xnet_rdm_cm.c
@@ -161,6 +161,11 @@ static int xnet_bind_conn(struct xnet_rdm *rdm, struct xnet_ep *ep)
 		if (ret)
 			return ret;
 	}
+	ep->util_ep.tx_msg_flags = rdm->util_ep.tx_msg_flags;
+	ep->util_ep.rx_msg_flags = rdm->util_ep.rx_msg_flags;
+	ep->util_ep.tx_op_flags = rdm->util_ep.tx_op_flags;
+	ep->util_ep.rx_op_flags = rdm->util_ep.rx_op_flags;
+
 
 	return 0;
 }

--- a/prov/tcp/src/xnet_rma.c
+++ b/prov/tcp/src/xnet_rma.c
@@ -92,7 +92,7 @@ static void xnet_rma_read_recv_entry_fill(struct xnet_xfer_entry *recv_entry,
 
 	recv_entry->iov_cnt = msg->iov_count;
 	recv_entry->context = msg->context;
-	recv_entry->cq_flags = xnet_tx_completion_flag(ep, flags) |
+	recv_entry->cq_flags = xnet_tx_completion_get_msgflags(ep, flags) |
 			       FI_RMA | FI_READ;
 
 	/* Read response completes the RMA read transmit */
@@ -167,7 +167,9 @@ xnet_rma_read(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 		.data = 0,
 	};
 
-	return xnet_rma_readmsg(ep_fid, &msg, 0);
+	struct xnet_ep *ep;
+	ep = container_of(ep_fid, struct xnet_ep, util_ep.ep_fid);
+	return xnet_rma_readmsg(ep_fid, &msg, ep->util_ep.tx_op_flags);
 }
 
 static ssize_t
@@ -191,7 +193,9 @@ xnet_rma_readv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 		.data = 0,
 	};
 
-	return xnet_rma_readmsg(ep_fid, &msg, 0);
+	struct xnet_ep *ep;
+	ep = container_of(ep_fid, struct xnet_ep, util_ep.ep_fid);
+	return xnet_rma_readmsg(ep_fid, &msg, ep->util_ep.tx_op_flags);
 }
 
 static ssize_t
@@ -258,7 +262,7 @@ xnet_rma_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 	send_entry->iov[0].iov_base = (void *) &send_entry->hdr;
 	send_entry->iov[0].iov_len = offset;
 
-	send_entry->cq_flags = xnet_tx_completion_flag(ep, flags) |
+	send_entry->cq_flags = xnet_tx_completion_get_msgflags(ep, flags) |
 			       FI_RMA | FI_WRITE;
 	send_entry->cntr = ep->util_ep.wr_cntr;
 	xnet_set_commit_flags(send_entry, flags);
@@ -294,7 +298,9 @@ xnet_rma_write(struct fid_ep *ep_fid, const void *buf, size_t len, void *desc,
 		.data = 0,
 	};
 
-	return xnet_rma_writemsg(ep_fid, &msg, 0);
+	struct xnet_ep *ep;
+	ep = container_of(ep_fid, struct xnet_ep, util_ep.ep_fid);
+	return xnet_rma_writemsg(ep_fid, &msg, ep->util_ep.tx_op_flags);
 }
 
 static ssize_t
@@ -318,7 +324,9 @@ xnet_rma_writev(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 		.data = 0,
 	};
 
-	return xnet_rma_writemsg(ep_fid, &msg, 0);
+	struct xnet_ep *ep;
+	ep = container_of(ep_fid, struct xnet_ep, util_ep.ep_fid);
+	return xnet_rma_writemsg(ep_fid, &msg, ep->util_ep.tx_op_flags);
 }
 
 
@@ -347,7 +355,9 @@ xnet_rma_writedata(struct fid_ep *ep_fid, const void *buf, size_t len,
 		.data = data,
 	};
 
-	return xnet_rma_writemsg(ep_fid, &msg, FI_REMOTE_CQ_DATA);
+	struct xnet_ep *ep;
+	ep = container_of(ep_fid, struct xnet_ep, util_ep.ep_fid);
+	return xnet_rma_writemsg(ep_fid, &msg, FI_REMOTE_CQ_DATA | ep->util_ep.tx_op_flags);
 }
 
 static ssize_t


### PR DESCRIPTION
Added the following commits
[prov/tcp: Derive cq flags from op and msg flags](https://github.com/ofiwg/libfabric/pull/9460/commits/a3ed3ad3873fc172b50a6252b1efec3a38981199)
[prov/tcp: Pass through rdm_ep flags to msg eps.](https://github.com/ofiwg/libfabric/pull/9460/commits/dbf226504d9ef7b19ccca811994e528f7a3ad2ca)
[intel/ci: enable mpich rma tests for tcp](https://github.com/ofiwg/libfabric/pull/9460/commits/f80e00051d18381b23bf82d1f0f0b32b317f9cf9)
[intel/ci: disable rma/win_shared_put_flush_load test from mpich suite](https://github.com/ofiwg/libfabric/commit/6bd0b5de4a773e04933f9b585f6e715f3405b98d)
[Intel/CI: Enable Previously Failing tests on CI.](https://github.com/ofiwg/libfabric/commit/7e47412777c634337db47ac1b9d97b701704c725)
[intel/ci: excluding mt_improbe_sendrecv_huge from mpichsuite testing](https://github.com/ofiwg/libfabric/commit/22712ffa82637451ebc8090e5221ecaf72b96924)
[intel/ci: exclude idup_nb test mpichsuite tests for tcp.](https://github.com/ofiwg/libfabric/commit/d351e13fa7f7387a122c0ca6287b11f54270aef3)