### PR TITLE
prov/shm: adjust the order of smr_region fields.

### DIFF
--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -226,9 +226,6 @@ struct smr_region {
 	uint8_t		cma_cap_peer;
 	uint8_t		cma_cap_self;
 	uint32_t	max_sar_buf_per_peer;
-	uint8_t		xpmem_cap_self;
-	struct xpmem_pinfo xpmem_self;
-	struct xpmem_pinfo xpmem_peer;
 	void		*base_addr;
 	pthread_spinlock_t	lock; /* lock for shm access
 				 if both ep->tx_lock and this lock need to
@@ -247,6 +244,10 @@ struct smr_region {
 	size_t		peer_data_offset;
 	size_t		name_offset;
 	size_t		sock_name_offset;
+
+	uint8_t		xpmem_cap_self;
+	struct xpmem_pinfo xpmem_self;
+	struct xpmem_pinfo xpmem_peer;
 };
 
 struct smr_resp {


### PR DESCRIPTION
xpmem is a opt-in feature, and xpmem_cap_self, xpmem_self, and xpmem_peer are not used in fast path. The previous commit e0906f6f inserts xpmem related fields in the middle of smr_region struct, which makes the size of smr_region struct increase from 104 (2 cache lines) to 144 ( 3 cache lines). The insertion of xpmem_cap_self, xpmem_self, and xpmem_peer make the fields (offsets) used in the fast path shifted to the next cache line and causes more cache misses.

This patch moves the xpmem fields to the end of the struct to fix this issue.