### PR TITLE
prov/shm: Fix coverity issue about resource leak

### DIFF
--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -1037,8 +1037,10 @@ static void *smr_start_listener(void *args)
 					ep->sock_info->peers[id].device_fds =
 						calloc(ep->sock_info->nfds,
 							sizeof(*ep->sock_info->peers[id].device_fds));
-					if (!ep->sock_info->peers[id].device_fds)
+					if (!ep->sock_info->peers[id].device_fds) {
+						close(sock);
 						goto out;
+					}
 				}
 				memcpy(ep->sock_info->peers[id].device_fds,
 				       peer_fds, sizeof(*peer_fds) *


### PR DESCRIPTION
Sock variable handle goes out of scope and leaks the handle. This cleans it up properly.