### PR TITLE
contrib/intel/jenkins: Fix minor CI bugs

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -767,6 +767,7 @@ pipeline {
     }
     aborted {
       node ('daos_head') {
+        dir ("${DELETE_LOCATION}/middlewares") { deleteDir() }
       }
       node ('ze') {
         dir ("${DELETE_LOCATION}/middlewares") { deleteDir() }

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -44,6 +44,7 @@ def run_fabtests(stage_name, hw, partition, node_num, prov, util=null,
 
   if (way) {
     opts = "${opts} --way ${way}"
+    stage_name = "${stage_name}_${way}"
     modes = ["reg"]
   }
 

--- a/contrib/intel/jenkins/summary.py
+++ b/contrib/intel/jenkins/summary.py
@@ -878,11 +878,11 @@ def summarize_items(summary_item, logger, log_dir, mode):
 
     if summary_item == 'v3' or summary_item == 'all':
         test_types = ['h2d', 'd2d', 'xd2d']
-        for type in test_types:
+        for t in test_types:
             ret = FabtestsSummarizer(
                 logger, log_dir, 'shm',
-                f'ze_v3_shm_{type}_{mode}',
-                f"ze v3 shm {type} {mode}"
+                f'ze_v3_shm_{t}_fabtests_{mode}',
+                f"ze v3 shm {t} fabtests {mode}"
             ).summarize()
             err += ret if ret else 0
 

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -632,9 +632,13 @@ class OSUtests(Test):
                           'one-sided':  (2, 1),
                           'startup':    (2, 1)
                      }
-        self.osu_src = f'{self.middlewares_path}/{mpitype}/osu/libexec/'\
+        if mpitype == 'mpich' and hw in ['water', 'grass']:
+            self.mpitype = f'{mpitype}_{hw}'
+        else:
+            self.mpitype = mpitype
+
+        self.osu_src = f'{self.middlewares_path}/{self.mpitype}/osu/libexec/'\
                        'osu-micro-benchmarks/mpi/'
-        self.mpi_type = mpitype
 
     @property
     def execute_condn(self):


### PR DESCRIPTION
Daos cleanup was missing on abort.
verbs-rxm-mpich wasn't being run because it was looking in the wrong location.
ze_v3_shm filenames changed and weren't being picked up by the summarizer.
All three of these are fixed in this PR.