### PR TITLE
rdma/fi_eq: Support cntr byte counting

### DIFF
--- a/include/rdma/fi_eq.h
+++ b/include/rdma/fi_eq.h
@@ -285,7 +285,9 @@ struct fid_cq {
  */
 
 enum fi_cntr_events {
-	FI_CNTR_EVENTS_COMP
+	FI_CNTR_EVENTS_COMP,
+	FI_CNTR_EVENTS_BYTES	/* Increment counting events by MLENGTH */
+
 };
 
 struct fi_cntr_attr {

--- a/man/fi_cntr.3.md
+++ b/man/fi_cntr.3.md
@@ -121,7 +121,16 @@ struct fi_cntr_attr {
   and/or receives -- which are counted may be restricted using control
   flags when binding the counter and the endpoint.  Counters increment
   on all successful completions, separately from whether the operation
-  generates an entry in an event queue.
+  generates an entry in an event queue.  This includes truncated messages.
+
+- *FI_CNTR_EVENTS_BYTES*
+: The counter increments by the manipulated length for every successful 
+  completion that occurs on an associated bound endpoint.  The type of 
+  completions -- sends and/or receives -- which are counted may be 
+  restricted using control flags when binding the counter and the 
+  endpoint.  Counters increment on all successful completions, 
+  separately from whether the operation generates an entry in an 
+  event queue.  This includes truncated messages.
 
 *wait_obj*
 : Counters may be associated with a specific wait object.  Wait

--- a/man/fi_cntr.3.md
+++ b/man/fi_cntr.3.md
@@ -121,16 +121,18 @@ struct fi_cntr_attr {
   and/or receives -- which are counted may be restricted using control
   flags when binding the counter and the endpoint.  Counters increment
   on all successful completions, separately from whether the operation
-  generates an entry in an event queue.  This includes truncated messages.
+  generates an entry in an event queue.
 
 - *FI_CNTR_EVENTS_BYTES*
-: The counter increments by the manipulated length for every successful 
+: The counter increments by the the transer size for every successful 
   completion that occurs on an associated bound endpoint.  The type of 
   completions -- sends and/or receives -- which are counted may be 
   restricted using control flags when binding the counter and the 
   endpoint.  Counters increment on all successful completions, 
   separately from whether the operation generates an entry in an 
-  event queue.  This includes truncated messages.
+  event queue. On error, the tranfer size is not applied to the
+  error field, that field is increment by 1.  The FI_COLLECTIVE
+  transfer type is not supported.
 
 *wait_obj*
 : Counters may be associated with a specific wait object.  Wait

--- a/man/fi_cntr.3.md
+++ b/man/fi_cntr.3.md
@@ -124,7 +124,7 @@ struct fi_cntr_attr {
   generates an entry in an event queue.
 
 - *FI_CNTR_EVENTS_BYTES*
-: The counter increments by the the transer size for every successful 
+: The counter increments by the the tranfser size for every successful 
   completion that occurs on an associated bound endpoint.  The type of 
   completions -- sends and/or receives -- which are counted may be 
   restricted using control flags when binding the counter and the 


### PR DESCRIPTION
Define new enum value to support byte counting with counters.
Document new define.