### PR TITLE
prov/efa: Don't fail the whole domain init if cudamalloc failed

### DIFF
--- a/prov/efa/src/efa_hmem.c
+++ b/prov/efa/src/efa_hmem.c
@@ -156,16 +156,15 @@ static int efa_domain_hmem_info_init_cuda(struct efa_domain *efa_domain)
 		return 0;
 	}
 
-	info->initialized = true;
-
 	cuda_ret = ofi_cudaMalloc(&ptr, len);
 	if (cuda_ret != cudaSuccess) {
 		EFA_WARN(FI_LOG_DOMAIN,
 			 "Failed to allocate CUDA buffer: %s\n",
 			 ofi_cudaGetErrorString(cuda_ret));
-		return -FI_ENOMEM;
+		return 0;
 	}
 
+	info->initialized = true;
 	info->p2p_disabled_by_user = false;
 
 	/* If user is using libfabric API 1.18 or later, by default EFA provider is permitted to


### PR DESCRIPTION
we use cuda malloc to allocate temporary cuda buffer for a dummy memory registration to check the p2p support on the platform. It's not needed if users only run host workloads. This patch makes libfabric not hard fail in this situation but leave cuda hmem interface not initialized.