### PR TITLE
prov/efa: Remove unnecessary handshake in send path

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_msg.c
+++ b/prov/efa/src/rdm/efa_rdm_msg.c
@@ -120,17 +120,6 @@ ssize_t efa_rdm_msg_post_rtm(struct efa_rdm_ep *ep, struct efa_rdm_ope *txe, int
 
 	assert(txe->peer);
 
-	/*
-	 * A handshake is required for hmem (non-system) ifaces
-	 * to choose the correct protocol, e.g. rdma-read support
-	 * on both sides.
-	 */
-	if (efa_mr_is_hmem(txe->desc[0]) &&
-	    !(txe->peer->flags & EFA_RDM_PEER_HANDSHAKE_RECEIVED)) {
-		err = efa_rdm_ep_trigger_handshake(ep, txe->peer);
-		return err ? err : -FI_EAGAIN;
-	}
-
 	rtm_type = efa_rdm_msg_select_rtm(ep, txe, use_p2p);
 	assert(rtm_type >= EFA_RDM_REQ_PKT_BEGIN);
 

--- a/prov/efa/src/rdm/efa_rdm_peer.h
+++ b/prov/efa/src/rdm/efa_rdm_peer.h
@@ -163,13 +163,15 @@ static inline
 bool efa_rdm_interop_rdma_read(struct efa_rdm_ep *ep, struct efa_rdm_peer *peer)
 {
 	bool rdma_read_support = efa_both_support_rdma_read(ep, peer);
-	uint32_t ep_dev_ver = efa_rdm_ep_domain(ep)->device->ibv_attr.vendor_part_id,
-		 peer_dev_ver = peer->device_version;
+	uint32_t ep_dev_ver, peer_dev_ver;
 
-	if (ep_dev_ver == 0xEFA0) {
-		return rdma_read_support && peer_dev_ver == 0xEFA0;
-	}
-	return rdma_read_support && peer_dev_ver != 0xEFA0;
+	if (!rdma_read_support)
+		return false;
+
+	ep_dev_ver = efa_rdm_ep_domain(ep)->device->ibv_attr.vendor_part_id;
+	peer_dev_ver = peer->device_version;
+
+	return (ep_dev_ver == 0xEFA0) ? (peer_dev_ver == 0xEFA0) : (peer_dev_ver != 0xEFA0);
 }
 
 /**


### PR DESCRIPTION
Currently, efa provider always return EAGAIN for send with hmem memory before a handshake is made. This caused unnecessary overhead in the startup. EFA should still moves with copy-based protocols (no rdma-read) before the handshake is made.