### PR TITLE
prov/efa: Fix a bug in efa_rdm_ope_post_send

### DIFF
--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -2,6 +2,7 @@ from default.test_rdm import test_rdm, test_rdm_bw_functional
 from efa.efa_common import efa_run_client_server_test
 
 import pytest
+import copy
 
 
 @pytest.mark.parametrize("iteration_type",
@@ -55,6 +56,14 @@ def test_rdm_tagged_bw_range(cmdline_args, completion_semantic, memory_type, mes
 def test_rdm_tagged_bw_no_inject_range(cmdline_args, completion_semantic, inject_message_size):
     efa_run_client_server_test(cmdline_args, "fi_rdm_tagged_bw -j 0", "short",
                                completion_semantic, "host_to_host", inject_message_size)
+
+@pytest.mark.functional
+def test_rdm_tagged_bw_small_tx(cmdline_args, completion_semantic, memory_type, completion_type):
+    cmdline_args_copy = copy.copy(cmdline_args)
+    cmdline_args_copy.append_environ("FI_EFA_TX_SIZE=64")
+    # Use a window size larger than tx size
+    efa_run_client_server_test(cmdline_args_copy, "fi_rdm_tagged_bw -W 128", "short",
+                               completion_semantic, memory_type, "all", completion_type=completion_type)
 
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),

--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -1703,8 +1703,8 @@ ssize_t efa_rdm_ope_post_send(struct efa_rdm_ope *ope, int pkt_type)
 	struct efa_rdm_pke *pkt_entry_vec[EFA_RDM_EP_MAX_WR_PER_IBV_POST_SEND];
 	ssize_t err;
 	size_t segment_offset;
-	int pkt_entry_cnt, pkt_entry_data_size_vec[EFA_RDM_EP_MAX_WR_PER_IBV_POST_SEND];
-	int i, j;
+	int pkt_entry_cnt, pkt_entry_cnt_allocated = 0, pkt_entry_data_size_vec[EFA_RDM_EP_MAX_WR_PER_IBV_POST_SEND];
+	int i;
 
 	err = efa_rdm_ope_prepare_to_post_send(ope, pkt_type, &pkt_entry_cnt, pkt_entry_data_size_vec);
 	if (err)
@@ -1716,18 +1716,21 @@ ssize_t efa_rdm_ope_post_send(struct efa_rdm_ope *ope, int pkt_type)
 	segment_offset = efa_rdm_pkt_type_contains_data(pkt_type) ? ope->bytes_sent : -1;
 	for (i = 0; i < pkt_entry_cnt; ++i) {
 		pkt_entry_vec[i] = efa_rdm_pke_alloc(ep, ep->efa_tx_pkt_pool, EFA_RDM_PKE_FROM_EFA_TX_POOL);
-		assert(pkt_entry_vec[i]);
+
+		if (OFI_UNLIKELY(!pkt_entry_vec[i])) {
+			err = -FI_EAGAIN;
+			goto handle_err;
+		}
+
+		pkt_entry_cnt_allocated++;
 
 		err = efa_rdm_pke_fill_data(pkt_entry_vec[i],
 					    pkt_type,
 					    ope,
 					    segment_offset,
 					    pkt_entry_data_size_vec[i]);
-		if (err) {
-			for (j = 0; j <= i; ++j)
-				efa_rdm_pke_release_tx(pkt_entry_vec[j]);
+		if (err)
 			goto handle_err;
-		}
 
 		if (segment_offset != -1 && pkt_entry_cnt > 1) {
 			assert(pkt_entry_data_size_vec[i] > 0);
@@ -1735,20 +1738,23 @@ ssize_t efa_rdm_ope_post_send(struct efa_rdm_ope *ope, int pkt_type)
 		}
 	}
 
+	assert(pkt_entry_cnt == pkt_entry_cnt_allocated);
+
 	err = efa_rdm_pke_sendv(pkt_entry_vec, pkt_entry_cnt);
-	if (err) {
-		for (i = 0; i < pkt_entry_cnt; ++i)
-			efa_rdm_pke_release_tx(pkt_entry_vec[i]);
+	if (err)
 		goto handle_err;
-	}
 
 	ope->peer->flags |= EFA_RDM_PEER_REQ_SENT;
 	for (i = 0; i < pkt_entry_cnt; ++i)
 		efa_rdm_pke_handle_sent(pkt_entry_vec[i]);
-	return 0;
+
+	return FI_SUCCESS;
 
 handle_err:
-		return efa_rdm_ope_post_send_fallback(ope, pkt_type, err);
+	for (i = 0; i < pkt_entry_cnt_allocated; ++i)
+		efa_rdm_pke_release_tx(pkt_entry_vec[i]);
+
+	return efa_rdm_ope_post_send_fallback(ope, pkt_type, err);
 }
 
 /**


### PR DESCRIPTION
efa_rdm_pke_alloc can return NULL when tx pkt pool is exhausted. In this case we should release allocated pkt entries and return EAGAIN.