### PR TITLE
include, prov: Use RCU to protect util_ep's ep_list

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -203,6 +203,7 @@ src_libfabric_la_SOURCES =			\
 	include/uthash.h			\
 	include/ofi_prov.h			\
 	include/ofi_profile.h       \
+	include/ofi_rcu.h			\
 	include/rdma/providers/fi_log.h		\
 	include/rdma/providers/fi_prov.h	\
 	src/fabric.c				\

--- a/include/ofi_rcu.h
+++ b/include/ofi_rcu.h
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _OFI_RCU_H_
+#define _OFI_RCU_H_
+
+#include <stddef.h>
+#include <stdlib.h>
+
+#include <ofi_list.h>
+
+
+struct ofi_rcu_list {
+	void **items;
+	size_t num_items;
+};
+
+/**
+ * @brief  RCU uses a non-atomic swap for performance reasons.
+ *         There will only ever be one writer at a time b/c of
+ *         mutex lock and a pointer is an atomic sized word
+ *
+ * @param old Pointer to return
+ * @param new Pointer to swap into old pointer
+ * @return struct ofi_rcu_list*
+ */
+static inline struct ofi_rcu_list *
+ofi_rcu_list_swap(struct ofi_rcu_list **old, struct ofi_rcu_list *new)
+{
+	struct ofi_rcu_list *tmp = *old;
+	*old = new;
+	return tmp;
+}
+
+/**
+ * @param num_items Size of RCU list to create
+ * @return struct ofi_rcu_list* Newly created list
+ */
+static inline struct ofi_rcu_list*
+ofi_rcu_list_create(size_t num_items)
+{
+	struct ofi_rcu_list* list = calloc(1, sizeof(struct ofi_rcu_list));
+	if (!list)
+		return list;
+
+	list->items = calloc(num_items, sizeof(void *));
+	list->num_items = num_items;
+	return list;
+}
+
+/**
+ * @param dst  list to copy into
+ * @param src list to copy from
+ * @param size size of src list
+ */
+static inline void
+ofi_rcu_list_copy(struct ofi_rcu_list* dst, struct ofi_rcu_list* src, size_t size)
+{
+	assert(dst->num_items >= src->num_items);
+
+	for (int i = 0; i < size; i++) {
+		dst->items[i] = src->items[i];
+	}
+}
+
+/**
+ * @param list to destroy
+ */
+static inline void
+ofi_rcu_list_destroy(struct ofi_rcu_list** list)
+{
+	(*list)->num_items = 0;
+	free((*list)->items);
+	free(*list);
+	*list = NULL;
+}
+
+/**
+ * @brief Copies a list with all but one item
+ *
+ * @param old_list The original list
+ * @param item The item to not include in new list
+ * @return struct ofi_rcu_list* The new list
+ */
+static inline struct ofi_rcu_list*
+ofi_rcu_list_clone_list_without_item(struct ofi_rcu_list* old_list, void *item)
+{
+	struct ofi_rcu_list *new_rcu_list = NULL;
+	int i, j;
+
+	new_rcu_list = ofi_rcu_list_create(old_list->num_items - 1);
+	if (old_list->num_items > 1) {
+		for (i = 0, j = 0; i < old_list->num_items; i++) {
+			if (old_list->items[i] != item) {
+				new_rcu_list->items[j] = old_list->items[i];
+				j++;
+			}
+		}
+	}
+
+	return new_rcu_list;
+}
+
+/**
+ * @brief Checks to see if item is in list
+ *
+ * @param list The list to iterate through
+ * @param item The item to check if it is in list
+ * @return true Item is in the list
+ * @return false Item is not in the list
+ */
+static inline bool
+ofi_rcu_is_item_in_list(struct ofi_rcu_list* list, void *item)
+{
+	int i;
+
+	for (i = 0; i < list->num_items; i++) {
+		if (list->items[i] == item)
+			return true;
+	}
+
+	return false;
+}
+
+#endif /* _OFI_RCU_H_ */

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -67,6 +67,7 @@
 #include <ofi_epoll.h>
 #include <ofi_proto.h>
 #include <ofi_bitmask.h>
+#include <ofi_rcu.h>
 
 #include "rbtree.h"
 #include "uthash.h"
@@ -503,8 +504,10 @@ struct util_cq {
 	struct util_domain	*domain;
 	struct util_wait	*wait;
 	ofi_atomic32_t		ref;
-	struct dlist_entry	ep_list;
-	struct ofi_genlock	ep_list_lock;
+
+	ofi_mutex_t		cntrl_iface_lock;
+	struct ofi_rcu_list	*ep_list;
+
 	struct ofi_genlock	cq_lock;
 	uint64_t		flags;
 
@@ -524,6 +527,7 @@ struct util_cq {
 	fi_addr_t		*src;
 	struct slist		aux_queue;
 	fi_cq_read_func		read_entry;
+	bool			progressing_cq;
 };
 
 int ofi_cq_init(const struct fi_provider *prov, struct fid_domain *domain,

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -53,13 +53,17 @@ rxm_cq_strerror(struct fid_cq *cq_fid, int prov_errno,
 {
 	struct util_cq *cq;
 	struct rxm_ep *rxm_ep;
-	struct fid_list_entry *fid_entry;
+	const char *error = NULL;
 
 	cq = container_of(cq_fid, struct util_cq, cq_fid);
-	fid_entry = container_of(cq->ep_list.next, struct fid_list_entry, entry);
-	rxm_ep = container_of(fid_entry->fid, struct rxm_ep, util_ep.ep_fid);
-
-	return fi_cq_strerror(rxm_ep->msg_cq, prov_errno, err_data, buf, len);
+	ofi_mutex_lock(&cq->cntrl_iface_lock);
+	if (!cq->ep_list->num_items)
+		goto out;
+	rxm_ep = container_of(cq->ep_list->items[0], struct rxm_ep, util_ep);
+	error = fi_cq_strerror(rxm_ep->msg_cq, prov_errno, err_data, buf, len);
+out:
+	ofi_mutex_unlock(&cq->cntrl_iface_lock);
+	return error;
 }
 
 static struct rxm_rx_buf *

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -448,8 +448,9 @@ int ofi_cq_cleanup(struct util_cq *cq)
 		cq->err_data = NULL;
 	}
 
+	ofi_rcu_list_destroy(&cq->ep_list);
 	ofi_genlock_destroy(&cq->cq_lock);
-	ofi_genlock_destroy(&cq->ep_list_lock);
+	ofi_mutex_destroy(&cq->cntrl_iface_lock);
 	ofi_atomic_dec32(&cq->domain->ref);
 	return 0;
 }
@@ -516,17 +517,25 @@ int ofi_check_bind_cq_flags(struct util_ep *ep, struct util_cq *cq,
 void ofi_cq_progress(struct util_cq *cq)
 {
 	struct util_ep *ep;
-	struct fid_list_entry *fid_entry;
-	struct dlist_entry *item;
+	struct ofi_rcu_list *ep_list_to_itr;
+	bool need_lock = cq->domain->threading == FI_THREAD_DOMAIN ||
+				cq->domain->threading == FI_THREAD_COMPLETION ?
+				false : true;
 
-	ofi_genlock_lock(&cq->ep_list_lock);
-	dlist_foreach(&cq->ep_list, item) {
-		fid_entry = container_of(item, struct fid_list_entry, entry);
-		ep = container_of(fid_entry->fid, struct util_ep, ep_fid.fid);
+	if (need_lock)
+		ofi_mutex_lock(&cq->cntrl_iface_lock);
+
+	/* Grab a list pointer so it doesn't change while we iterate through it */
+	ep_list_to_itr = cq->ep_list;
+	cq->progressing_cq = 1;
+	for (int i = 0; i < ep_list_to_itr->num_items; i++) {
+		ep = ep_list_to_itr->items[i];
 		ep->progress(ep);
-
 	}
-	ofi_genlock_unlock(&cq->ep_list_lock);
+	cq->progressing_cq = 0;
+
+	if (need_lock)
+		ofi_mutex_unlock(&cq->cntrl_iface_lock);
 }
 
 static ssize_t util_peer_cq_write(struct fid_peer_cq *cq, void *context,
@@ -721,10 +730,14 @@ int ofi_cq_init(const struct fi_provider *prov, struct fid_domain *domain,
 	cq->progress = progress;
 	cq->err_data = NULL;
 
+	cq->ep_list = calloc(1, sizeof(struct ofi_rcu_list));
+	cq->ep_list->num_items = 0;
+	cq->ep_list->items = NULL;
+	cq->progressing_cq = false;
+
 	cq->domain = container_of(domain, struct util_domain, domain_fid);
 	ofi_atomic_initialize32(&cq->ref, 0);
 	ofi_atomic_initialize32(&cq->wakeup, 0);
-	dlist_init(&cq->ep_list);
 
 	if (cq->domain->threading == FI_THREAD_COMPLETION ||
 	    cq->domain->threading == FI_THREAD_DOMAIN)
@@ -736,8 +749,7 @@ int ofi_cq_init(const struct fi_provider *prov, struct fid_domain *domain,
 	if (ret)
 		return ret;
 
-	/* TODO Figure out how to optimize this lock for rdm and msg endpoints */
-	ret = ofi_genlock_init(&cq->ep_list_lock, OFI_LOCK_MUTEX);
+	ret = ofi_mutex_init(&cq->cntrl_iface_lock);
 	if (ret)
 		goto destroy1;
 
@@ -798,7 +810,7 @@ int ofi_cq_init(const struct fi_provider *prov, struct fid_domain *domain,
 cleanup:
 	util_peer_cq_cleanup(cq);
 destroy2:
-	ofi_genlock_destroy(&cq->ep_list_lock);
+	ofi_mutex_destroy(&cq->cntrl_iface_lock);
 destroy1:
 	ofi_genlock_destroy(&cq->cq_lock);
 	return ret;


### PR DESCRIPTION
[Read Copy Update Overview](https://en.wikipedia.org/wiki/Read-copy-update)

This PR improves libfabric's implementation of its API instead of updating the API with a new threading model https://github.com/ofiwg/libfabric/pull/9725 and resolves https://github.com/ofiwg/libfabric/issues/9665.

Impacted Providers: coll, efa, mrail, rxd, rxm, smr, sm2, tcp, ucx, udp, util, verbs

This commit uses RCU (Read, Copy, Update) in order to avoid grabbing a mutex lock in the cq progress path (critical for perf), while maintaining a thread safe control interface. Instead of immediately deleting EP's when someone calls fi_close() on the EP, we add the EP to the CQ's list of EP's to delete, and it gets deleted without a race condition in either the ofi_cq_progress(), or ofi_cq_cleanup(). It is safe to delete the EP resources in ofi_cq_progress() b/c FI_THREAD_SAFE (via locks) and FI_THREAD_DOMAIN / FI_COMPLETION (via definition) guarantee that only one thread will be progressing an endpoint at a time. It is a rare operation to call fi_close() on an EP, so the performance cost of doing it in ofi_cq_progress() amoritizes out. If someone calls fi_close() on an EP, and then never calls fi_cq_read() again, the endpoint resources will be freed when the user calls fi_close() on the cq. EP's can be bound to 0, 1, or 2 CQs, so ref counters are used to avoid double freeing the EP now that EP cleanup is tied to CQ.

This change creates a reusable utility ofi_rcu.h so that we can extend RCU behavior to other areas in the project (such as counters).

This change modifies the internal api of util_ep by requiring providers to register a resource cleanup callback with the util_ep. This requires every provider using util_ep to have a two stage EP cleanup, stage 1 calls ofi_endpoint_close() when the user calls fi_close() on the EP, and stage 2 frees the EP's resources when it is safe to do so (delaying to avoid race condition).

Provider Specific Changes:

The tcp provider does not use util_cq's progress, so it does not need to change its cleanup for this RCU change.

A small race condition was fixed in rxm/rxd's strerror fcns rxd_cq_strerror() and rxm_cq_strerror().

The rxd provider has a custom rxd_cq_sreadfrom() which could be enhanced in the future to benefit from the RCU work.

The UDP provider has a custom bind function which required copying logic from util_ep's bind function to replace fid_list_insert2. The fid_list_remove2 call is no longer needed in its ep's delete b/c it happens in ofi_endpoint_close().