### PR TITLE
core,fabtests: Replace strtok with strtok_r

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -3461,6 +3461,7 @@ void ft_parse_opts_list(char* optarg)
 {
 	int i, ret;
 	char *token;
+	char *saveptr;
 
 	optarg += 2; // remove 'l:'
 	test_cnt = 1;
@@ -3473,7 +3474,7 @@ void ft_parse_opts_list(char* optarg)
 		exit(EXIT_FAILURE);
 	}
 
-	token = strtok(optarg, ",");
+	token = strtok_r(optarg, ",", &saveptr);
 	test_cnt = 0;
 	while (token != NULL) {
 		ret = sscanf(token, "%zu", &user_test_sizes[test_cnt].size);
@@ -3482,7 +3483,7 @@ void ft_parse_opts_list(char* optarg)
 			exit(EXIT_FAILURE);
 		}
 		test_cnt++;
-		token = strtok(NULL, ",");
+		token = strtok_r(NULL, ",", &saveptr);
 	}
 	test_size = user_test_sizes;
 }

--- a/fabtests/component/dmabuf-rdma/fi-rdmabw-xe.c
+++ b/fabtests/component/dmabuf-rdma/fi-rdmabw-xe.c
@@ -515,19 +515,20 @@ static void init_ofi(int sockfd, char *server_name, int port, int test_type)
 	int err;
 	size_t len;
 	char *domain_name;
+	char *saveptr;
 
 	EXIT_ON_NULL((context_pool = init_context_pool(TX_DEPTH + 1)));
 
 	num_nics = 0;
 	if (domain_names) {
-		domain_name = strtok(domain_names, ",");
+		domain_name = strtok_r(domain_names, ",", &saveptr);
 		while (domain_name && num_nics < MAX_NICS) {
 			err = init_nic(num_nics, domain_name, server_name,
 				       port, test_type);
 			if (err)
 				return;
 			num_nics++;
-			domain_name = strtok(NULL, ",");
+			domain_name = strtok_r(NULL, ",", &saveptr);
 		}
 	} else {
 		err = init_nic(num_nics, NULL, server_name, port, test_type);
@@ -1104,11 +1105,12 @@ static inline int string_to_location(char *s, int default_loc)
 void parse_buf_location(char *string, int *loc1, int *loc2, int default_loc)
 {
 	char *s;
+	char *saveptr;
 
-	s = strtok(string, ":");
+	s = strtok_r(string, ":", &saveptr);
 	if (s) {
 		*loc1 = string_to_location(s, default_loc);
-		s = strtok(NULL, ":");
+		s = strtok_r(NULL, ":", &saveptr);
 		if (s)
 			*loc2 = string_to_location(s, default_loc);
 		else

--- a/fabtests/component/dmabuf-rdma/rdmabw-xe.c
+++ b/fabtests/component/dmabuf-rdma/rdmabw-xe.c
@@ -408,6 +408,7 @@ static void init_ib(char *ibdev_names, int sockfd)
 	int ib_port = 1;
 	char *ibdev_name;
 	int i, j;
+	char *saveptr;
 
 	dev_list = ibv_get_device_list(NULL);
 	if (!dev_list) {
@@ -422,11 +423,11 @@ static void init_ib(char *ibdev_names, int sockfd)
 
 	num_nics = 0;
 	if (ibdev_names) {
-		ibdev_name = strtok(ibdev_names, ",");
+		ibdev_name = strtok_r(ibdev_names, ",", &saveptr);
 		while (ibdev_name && num_nics < MAX_NICS) {
 			EXIT_ON_ERROR(init_nic(num_nics, ibdev_name, ib_port));
 			num_nics++;
-			ibdev_name = strtok(NULL, ",");
+			ibdev_name = strtok_r(NULL, ",", &saveptr);
 		}
 	} else {
 		EXIT_ON_ERROR(init_nic(0, NULL, ib_port));

--- a/fabtests/component/dmabuf-rdma/xe.c
+++ b/fabtests/component/dmabuf-rdma/xe.c
@@ -137,6 +137,7 @@ int xe_init(char *gpu_dev_nums, int enable_multi_gpu)
 	char *gpu_dev_num;
 	char *s;
 	int dev_num, subdev_num;
+	char *saveptr;
 
 	EXIT_ON_ERROR(init_libze_ops());
 	EXIT_ON_ERROR(libze_ops.zeInit(ZE_INIT_FLAG_GPU_ONLY));
@@ -150,7 +151,7 @@ int xe_init(char *gpu_dev_nums, int enable_multi_gpu)
 
 	num_gpus = 0;
 	if (gpu_dev_nums) {
-		gpu_dev_num = strtok(gpu_dev_nums, ",");
+		gpu_dev_num = strtok_r(gpu_dev_nums, ",", &saveptr);
 		while (gpu_dev_num && num_gpus < MAX_GPUS) {
 			dev_num = 0;
 			subdev_num = -1;
@@ -158,7 +159,7 @@ int xe_init(char *gpu_dev_nums, int enable_multi_gpu)
 			s = strchr(gpu_dev_num, '.');
 			if (s)
 				subdev_num = atoi(s + 1);
-			gpu_dev_num = strtok(NULL, ",");
+			gpu_dev_num = strtok_r(NULL, ",", &saveptr);
 
 			if (init_gpu(num_gpus, dev_num, subdev_num) < 0)
 				continue;

--- a/fabtests/include/windows/osd.h
+++ b/fabtests/include/windows/osd.h
@@ -617,6 +617,11 @@ static inline char* strsep(char **stringp, const char *delim)
 	return ptr;
 }
 
+static inline char *strtok_r(char *str, const char *delimiters, char **saveptr)
+{
+	return strtok_s(str, delimiters, saveptr);
+}
+
 #define _SC_PAGESIZE	30
 
 static long int sysconf(int name)

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -924,6 +924,11 @@ static inline char *strcasestr(const char *haystack, const char *needle)
 	return pos;
 }
 
+static inline char *strtok_r(char *str, const char *delimiters, char **saveptr)
+{
+	return strtok_s(str, delimiters, saveptr);
+}
+
 #ifndef _SC_PAGESIZE
 #define _SC_PAGESIZE	0
 #endif

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -546,13 +546,14 @@ void ofi_hmem_set_iface_filter(const char* iface_filter_str, bool* filter)
 		"synapseai"
 	};
 	char *iface_filter_str_copy = strdup(iface_filter_str);
+	char *saveptr;
 
 	memset(filter, false, sizeof(bool) * ARRAY_SIZE(hmem_ops));
 
 	/* always enable system hmem interface */
 	filter[FI_HMEM_SYSTEM] = true;
 
-	entry = strtok(iface_filter_str_copy, token);
+	entry = strtok_r(iface_filter_str_copy, token, &saveptr);
 	while (entry != NULL) {
 		for (iface = 0; iface < ARRAY_SIZE(hmem_ops); iface++) {
 			if (!strcasecmp(iface_labels[iface], entry)) {
@@ -567,7 +568,7 @@ void ofi_hmem_set_iface_filter(const char* iface_filter_str, bool* filter)
 					entry);
 		}
 
-		entry = strtok(NULL, token);
+		entry = strtok_r(NULL, token, &saveptr);
 	}
 
 	free(iface_filter_str_copy);

--- a/src/hmem_ze.c
+++ b/src/hmem_ze.c
@@ -393,6 +393,7 @@ static int ze_hmem_init_fds(void)
 	char *str;
 	uint16_t domain_id;
 	uint8_t pci_id;
+	char *saveptr;
 
 	dir = opendir(dev_dir);
 	if (dir == NULL)
@@ -411,10 +412,10 @@ static int ze_hmem_init_fds(void)
 		dev_fds[num_pci_devices] = open(dev_name, O_RDWR);
 		if (dev_fds[num_pci_devices] == -1)
 			goto err;
-		str = strtok(ent->d_name, "-");
-		str = strtok(NULL, ":");
+		str = strtok_r(ent->d_name, "-", &saveptr);
+		str = strtok_r(NULL, ":", &saveptr);
 		domain_id = (uint16_t) strtol(str, NULL, 16);
-		str = strtok(NULL, ":");
+		str = strtok_r(NULL, ":", &saveptr);
 		pci_id = (uint8_t) strtol(str, NULL, 16);
 		for (i = 0; i < num_devices; i++) {
 			if (dev_info[i].uuid.id[8] == pci_id &&


### PR DESCRIPTION
strtok() is non-reentrant. One error case discovered recently looks like the following:

```
func_A()
{
	s = strtok(s1, ',');
	while (s) {
		func_B(s);
		s = strtok(NULL, ',');
	}
}
```
somewhere down the calling chain of func_B(), strtok() is called to parse another string, and that destroys the parsing state of s1.

Replace all the remaining occurences of strtok() with the reentrant version strtok_r() to prevent such error from happening again.