### PR TITLE
prov/efa: Add a missing rx pkt counter

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -175,6 +175,12 @@ struct efa_rdm_ep {
 	 */
 	size_t efa_rx_pkts_to_post;
 
+	/*
+	 * Number of RX packets that are held (not released) by progress engine
+	 * due to queued hmem copy or local read.
+	 */
+	size_t efa_rx_pkts_held;
+
 	/* number of outstanding tx ops on efa device */
 	size_t efa_outstanding_tx_ops;
 

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -498,6 +498,7 @@ int efa_rdm_ep_open(struct fid_domain *domain, struct fi_info *info,
 
 	efa_rdm_ep->efa_rx_pkts_posted = 0;
 	efa_rdm_ep->efa_rx_pkts_to_post = 0;
+	efa_rdm_ep->efa_rx_pkts_held = 0;
 	efa_rdm_ep->efa_outstanding_tx_ops = 0;
 
 	assert(!efa_rdm_ep->ibv_cq_ex);

--- a/prov/efa/src/rdm/efa_rdm_ep_progress.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_progress.c
@@ -180,8 +180,9 @@ void efa_rdm_ep_progress_post_internal_rx_pkts(struct efa_rdm_ep *ep)
 			ep->efa_rx_pkts_to_post = 0;
 		}
 	} else {
-		if (ep->efa_rx_pkts_posted == 0 && ep->efa_rx_pkts_to_post == 0) {
-			/* Both efa_rx_pkts_posted and efa_rx_pkts_to_post equal to 0 means
+		if (ep->efa_rx_pkts_posted == 0 && ep->efa_rx_pkts_to_post == 0 && ep->efa_rx_pkts_held == 0) {
+			/* All of efa_rx_pkts_posted, efa_rx_pkts_to_post and
+			 * efa_rx_pkts_held equal to 0 means
 			 * this is the first call of the progress engine on this endpoint.
 			 *
 			 * In this case, we explictly allocate the 1st chunk of memory
@@ -219,6 +220,8 @@ void efa_rdm_ep_progress_post_internal_rx_pkts(struct efa_rdm_ep *ep)
 
 			ep->efa_rx_pkts_to_post = efa_rdm_ep_get_rx_pool_size(ep);
 		}
+		/* only valid for non-zero copy */
+		assert(ep->efa_rx_pkts_to_post + ep->efa_rx_pkts_posted + ep->efa_rx_pkts_held == efa_rdm_ep_get_rx_pool_size(ep));
 	}
 
 	err = efa_rdm_ep_bulk_post_internal_rx_pkts(ep);

--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -1665,7 +1665,12 @@ int efa_rdm_rxe_post_local_read_or_queue(struct efa_rdm_ope *rxe,
 	}
 
 	txe->local_read_pkt_entry = pkt_entry;
-	return efa_rdm_ope_post_remote_read_or_queue(txe);
+	err = efa_rdm_ope_post_remote_read_or_queue(txe);
+	/* The rx pkts are held until the local read completes */
+	if (txe->local_read_pkt_entry->alloc_type == EFA_RDM_PKE_FROM_EFA_RX_POOL && !err)
+		txe->ep->efa_rx_pkts_held++;
+
+	return err;
 }
 
 /**

--- a/prov/efa/src/rdm/efa_rdm_pke_cmd.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_cmd.c
@@ -663,6 +663,12 @@ void efa_rdm_pke_handle_rx_error(struct efa_rdm_pke *pkt_entry, int err, int pro
 	struct efa_rdm_ep *ep;
 
 	ep = pkt_entry->ep;
+	/*
+	 * we should still decrement the efa_rx_pkts_posted
+	 * when getting a failed rx completion.
+	 */
+	assert(ep->efa_rx_pkts_posted > 0);
+	ep->efa_rx_pkts_posted--;
 
 	EFA_DBG(FI_LOG_CQ, "Packet receive error: %s (%d)\n",
 	        efa_strerror(prov_errno), prov_errno);

--- a/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
@@ -497,6 +497,11 @@ void efa_rdm_pke_handle_rma_read_completion(struct efa_rdm_pke *context_pkt_entr
 			if (txe->addr == FI_ADDR_NOTAVAIL) {
 				data_pkt_entry = txe->local_read_pkt_entry;
 				assert(data_pkt_entry->payload_size > 0);
+				/* We were using a held rx pkt to post local read */
+				if (data_pkt_entry->alloc_type == EFA_RDM_PKE_FROM_EFA_RX_POOL) {
+					assert(txe->ep->efa_rx_pkts_held > 0);
+					txe->ep->efa_rx_pkts_held--;
+				}
 				efa_rdm_pke_handle_data_copied(data_pkt_entry);
 			} else {
 				assert(txe && txe->cq_entry.flags & FI_READ);

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -136,9 +136,18 @@ void test_efa_rdm_ep_handshake_exchange_host_id(struct efa_resource **state, uin
 	assert_int_equal(peer->host_id, 0);
 	assert_int_not_equal(peer->flags & EFA_RDM_PEER_HANDSHAKE_SENT, EFA_RDM_PEER_HANDSHAKE_SENT);
 
-	/* Setup rx packet entry. Manually increase counter to avoid underflow */
+	/*
+	 * The rx pkt entry should only be allocated and posted by the progress engine.
+	 * However, to mock a receive completion, we have to allocate an rx entry
+	 * and modify it out of band. The proess engine grow the rx pool in the first
+	 * call and set efa_rdm_ep->efa_rx_pkts_posted as the rx pool size. Here we
+	 * follow the progress engine to set the efa_rx_pkts_posted counter manually
+	 * TODO: modify the rx pkt as part of the ibv cq poll mock so we don't have to
+	 * allocate pkt entry and hack the pkt counters.
+	 */
 	pkt_entry = efa_rdm_pke_alloc(efa_rdm_ep, efa_rdm_ep->efa_rx_pkt_pool, EFA_RDM_PKE_FROM_EFA_RX_POOL);
-	efa_rdm_ep->efa_rx_pkts_posted++;
+	assert_non_null(pkt_entry);
+	efa_rdm_ep->efa_rx_pkts_posted = efa_rdm_ep_get_rx_pool_size(efa_rdm_ep);
 
 	pkt_attr.connid = include_connid ? raw_addr.qkey : 0;
 	pkt_attr.host_id = g_efa_unit_test_mocks.peer_host_id;


### PR DESCRIPTION
Currently efa rdm ep has 2 rx pkt counters:
efa_rx_pkt_posted, efa_rx_pkt_to_post. The
progress engine uses efa_rx_pkt_posted==0
and efa_rx_pkt_to_post==0 to identify whether
the endpoint is progressed the first time.

However, these 2 counters do not cover the activity of all rx pkts. Some rx pkts can be held within
a round of progress engine due to queued hmem
copy or being posted for local read. And when the
rx pkt pool is small (customized by env or hints), the held rx pkts can cause both efa_rx_pkt_posted
and efa_rx_pkt_to_post as 0 in the middle of the
progress engine, which will trigger another
pkt pool grow and fail.

This patch adds an additional counter: efa_rx_pkts_held in efa_rdm_ep to cover this part of rx pkts. And added a stronger assertion that

efa_rx_pkts_posted + efa_rx_pkts_to_post + efa_rx_pkts_held must be equal to the rx pool size during the beginning of progress engine call. This assertion will make us catch any rx packet leak in the future.