### PR TITLE
prov/cxi: Fix configure error with "--enable-only" option

### DIFF
--- a/prov/cxi/configure.m4
+++ b/prov/cxi/configure.m4
@@ -131,7 +131,6 @@ AC_DEFUN([FI_CXI_CONFIGURE],[
 				cxitest_LDFLAGS="-L$with_criterion/lib64 -Wl,-rpath=$(realpath $with_criterion/lib64)"
 				cxitest_LIBS="-lcriterion"
 				have_criterion=true])
-			AM_CONDITIONAL([HAVE_CRITERION], [test "x$have_criterion" = "xtrue"])
 
 			AS_IF([test "$have_ze" = "1" && test "$with_ze" != "" && test x"$with_ze" != x"yes"],
 					[cxitest_CPPFLAGS="$cxitest_CPPFLAGS -I$with_ze/include"
@@ -149,5 +148,6 @@ AC_DEFUN([FI_CXI_CONFIGURE],[
 		],
 		[cxi_happy=0])
 
+	AM_CONDITIONAL([HAVE_CRITERION], [test "x$have_criterion" = "xtrue"])
 	AS_IF([test $cxi_happy -eq 1], [$1], [$2])
 ])


### PR DESCRIPTION
Running configure with the `--enable-only` option but without enabling cxi generates the following error:

```
configure: error: conditional "HAVE_CRITERION" was never defined.
Usually this means the macro was only invoked conditionally
```