### PR TITLE
hmem and prov/efa: introduce ofi_dev_reg_copy_*_iov ops

### DIFF
--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -195,12 +195,6 @@ void cuda_gdrcopy_to_dev(uint64_t handle, void *dev,
 			 const void *host, size_t size);
 void cuda_gdrcopy_from_dev(uint64_t handle, void *host,
 			   const void *dev, size_t size);
-ssize_t ofi_gdrcopy_to_cuda_iov(uint64_t handle, const struct iovec *iov,
-                                size_t iov_count, uint64_t iov_offset,
-                                const void *host, size_t len);
-ssize_t ofi_gdrcopy_from_cuda_iov(uint64_t handle, void *host,
-                                  const struct iovec *iov, size_t iov_count,
-                                  uint64_t iov_offset, size_t len);
 int cuda_gdrcopy_hmem_init(void);
 int cuda_gdrcopy_hmem_cleanup(void);
 int cuda_gdrcopy_dev_register(const void *buf, size_t len, uint64_t *handle);
@@ -385,6 +379,16 @@ ssize_t ofi_copy_to_hmem_iov(enum fi_hmem_iface hmem_iface, uint64_t device,
 			     const struct iovec *hmem_iov,
 			     size_t hmem_iov_count, uint64_t hmem_iov_offset,
 			     const void *src, size_t size);
+
+ssize_t ofi_dev_reg_copy_from_hmem_iov(void *dest, size_t size,
+				       enum fi_hmem_iface hmem_iface, uint64_t handle,
+				       const struct iovec *hmem_iov,
+				       size_t hmem_iov_count, uint64_t hmem_iov_offset);
+
+ssize_t ofi_dev_reg_copy_to_hmem_iov(enum fi_hmem_iface hmem_iface, uint64_t handle,
+				     const struct iovec *hmem_iov,
+				     size_t hmem_iov_count, uint64_t hmem_iov_offset,
+				     const void *src, size_t size);
 
 static inline int ofi_copy_to_hmem(enum fi_hmem_iface iface, uint64_t device,
 				   void *dest, const void *src, size_t size)

--- a/src/hmem_cuda_gdrcopy.c
+++ b/src/hmem_cuda_gdrcopy.c
@@ -293,44 +293,6 @@ void cuda_gdrcopy_from_dev(uint64_t handle, void *hostptr,
 			  GDRCOPY_FROM_DEVICE);
 }
 
-static ssize_t cuda_gdrcopy_iov_buf(uint64_t handle,
-                                    const struct iovec *iov, size_t iov_count,
-                                    uint64_t iov_offset, void *buf,
-                                    size_t size, enum gdrcopy_dir dir)
-{
-	uint64_t done = 0, len;
-	char *dev_buf;
-	size_t i;
-
-	for (i = 0; i < iov_count && size; i++) {
-		len = ofi_iov_bytes_to_copy(&iov[i], &size, &iov_offset, &dev_buf);
-
-		if (!len)
-			continue;
-
-		cuda_gdrcopy_impl(handle, dev_buf, (void *)((char *)buf + done), len, dir);
-
-		done += len;
-	}
-	return done;
-}
-
-ssize_t ofi_gdrcopy_to_cuda_iov(uint64_t handle, const struct iovec *iov,
-                                size_t iov_count, uint64_t iov_offset,
-                                const void *host, size_t len)
-{
-	return cuda_gdrcopy_iov_buf(handle, iov, iov_count, iov_offset,
-	                           (void *) host, len, GDRCOPY_TO_DEVICE);
-}
-
-ssize_t ofi_gdrcopy_from_cuda_iov(uint64_t handle, void *host,
-                                  const struct iovec *iov, size_t iov_count,
-                                  uint64_t iov_offset, size_t len)
-{
-	return cuda_gdrcopy_iov_buf(handle, iov, iov_count, iov_offset,
-	                            host, len, GDRCOPY_FROM_DEVICE);
-}
-
 int cuda_gdrcopy_dev_register(const void *buf, size_t len, uint64_t *handle)
 {
 	int err;


### PR DESCRIPTION
Reuse the dev_reg_copy ops recently introduced in hmem API,
    in a similar approach as ofi_async_copy_hmem_iov_buf.
    
Replace the hard-coded ofi_cuda_gdrcopy_*iov ops by
    the new ofi_dev_reg_copy_*_iov ops which is general
    for all hmem ifaces.