### PR TITLE
contrib/intel/jenkins: Disable failing io_uring tests

### DIFF
--- a/fabtests/test_configs/tcp/io_uring.exclude
+++ b/fabtests/test_configs/tcp/io_uring.exclude
@@ -74,9 +74,17 @@ fi_unexpected_msg -e rdm
 # fi_eq_sread(): common/shared.c:1165, ret=-4 (Interrupted system call)
 fi_bw -e msg
 
+# fi_bw fails by hanging
+# This is a suspected race condition
+fi_bw
+
 # fi_msg_pingpong fails with
 # fi_eq_sread(): common/shared.c:1127, ret=-4 (Interrupted system call)
 fi_msg_pingpong
+
+# fi_rdm_cntr_pingpong passes but reports errors of
+# fi_cntr_wait(): common/shared.c:2708, ret=-4 (Interrupted system call)
+fi_rdm_cntr_pingpong
 
 # fi_msg_bw fails with
 # fi_eq_sread(): common/shared.c:1127, ret=-4 (Interrupted system call)


### PR DESCRIPTION
We have identified a hand in fi_bw test due to a race condition. fi_rdm_cntr_pingpong test prints out failures but reports a pass. Both of these tests are disabled in this commit.