### PR TITLE
prov/cxi: honor `FI_CXI_DISABLE_NON_INJECT_MSG_IDC` with rma

### DIFF
--- a/prov/cxi/src/cxip_rma.c
+++ b/prov/cxi/src/cxip_rma.c
@@ -503,6 +503,10 @@ static bool cxip_rma_is_idc(struct cxip_txc *txc, uint64_t key, size_t len,
 {
 	size_t max_idc_size = unr ? CXIP_INJECT_SIZE : C_MAX_IDC_PAYLOAD_RES;
 
+	/* DISABLE_NON_INJECT_MSG_IDC disables the IDC
+	 */
+	if (cxip_env.disable_non_inject_msg_idc)
+		return false;
 	/* IDC commands are not supported for unoptimized MR since the IDC
 	 * small message format does not support remote offset which is needed
 	 * for RMA commands.


### PR DESCRIPTION
Hi all, 

I would like the `cxi` provider to honor the use variable `FI_CXI_DISABLE_NON_INJECT_MSG_IDC=1` in both the `msg` and `rma` paths.
When disabling the use of GDR copy on CUDA devices, here is the latency I get when disabling `NON_INJECT_MSG_IDC` (before the PR):
- `fi_tsend`: `9.779660us` -> `3.314845us`
- `fi_write`: `10.573375us` -> `10.326375us`