### PR TITLE
github/workflow: Fix coverity build error for fabtests

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -57,7 +57,7 @@ jobs:
           set -x
           git clone --depth 1 -b ${{ env.RDMA_CORE_VERSION }} https://github.com/linux-rdma/rdma-core.git
           pushd rdma-core; bash build.sh; popd
-          export LD_LIBRARY_PATH="${{ env.RDMA_CORE_PATH }}/lib:$LD_LIBRARY_PATH"
+          export LD_LIBRARY_PATH="$PWD/${{ env.RDMA_CORE_PATH }}/lib:$LD_LIBRARY_PATH"
 
           # We use a compiler extension that supports broader complex type
           # definitions than what's defined in C99 standard (which only defines


### PR DESCRIPTION
LD_LIBRRARY_PATH (for rdma-core libraries) was set to relative path, which didn't work for fabtests build due to working directory change.

Fix by using absolution path.