### PR TITLE
github/workflow: More fix for coverity build

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,8 +1,8 @@
 name: Nightly Coverity Scan
 on:
   schedule:
-  # Every night, at midnight
-  - cron: '0 0 * * *'
+  # UTC time, 'minute hour day-of-month month day-of-week'
+  - cron: '0 1 * * *'
 env:
   APT_PACKAGES: >-
     abi-compliance-checker

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -76,7 +76,7 @@ jobs:
           ./autogen.sh
           ./configure --with-libfabric=$PWD/../install CC=clang
           popd
-          cov-build --dir cov-int bash -c "make && make -C fabtests LDFLAGS=-L${{ env.RDMA_CORE_PATH }}/lib"
+          cov-build --dir cov-int bash -c "make && make -C fabtests LDFLAGS=-L$PWD/${{ env.RDMA_CORE_PATH }}/lib"
       - name: Submit results
         run: |
           tar czvf libfabric.tgz cov-int


### PR DESCRIPTION
The LDFLAGS passed to fabtests build command line also needs to use absolute path.