### PR TITLE
Intel/CI: Resolve OneCCL summary bug

### DIFF
--- a/contrib/intel/jenkins/summary.py
+++ b/contrib/intel/jenkins/summary.py
@@ -417,7 +417,9 @@ class OnecclSummarizer(Summarizer):
         if '[0] PASSED' in line or "All done" in line:
             self.passes += 1
             self.passed_tests.append(f"{self.name}: 1")
-        if '[0] [  PASSED  ]' in line:
+        if ("[0] [  PASSED  ]" in line and "tests." in line) or \
+            ("tests." in line and "[1] [  PASSED  ]" not in line and \
+            "[0] [  PASSED  ]" not in line):
             token = line.split()
             no_of_tests = f"{token[token.index('tests.') - 1]} "
             self.passes += int(no_of_tests)


### PR DESCRIPTION
A bug was found in oneccl summary in counting passed tests logic because the log file logged it differently.
Expected log:
[0] [  PASSED  ] [0] 384 tests.
Logged line:
[0] [  PASSED  ] (13 ms)
[0] 384 tests.

The fix is to check whether there are any lines having 'tests.' but not having [0] [  PASSED  ] and [1] [  PASSED  ] in line.