### PR TITLE
github/workflow: Add libfabric lib path to coverity fabtests build

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -2,7 +2,8 @@ name: Nightly Coverity Scan
 on:
   schedule:
   # UTC time, 'minute hour day-of-month month day-of-week'
-  - cron: '0 1 * * *'
+  - cron: '0 5 * * *'
+
 env:
   APT_PACKAGES: >-
     abi-compliance-checker
@@ -76,7 +77,7 @@ jobs:
           ./autogen.sh
           ./configure --with-libfabric=$PWD/../install CC=clang
           popd
-          cov-build --dir cov-int bash -c "make && make -C fabtests LDFLAGS=-L$PWD/${{ env.RDMA_CORE_PATH }}/lib"
+          cov-build --dir cov-int bash -c "make && make -C fabtests LDFLAGS=\"-L$PWD/${{ env.RDMA_CORE_PATH }}/lib -L$PWD/install/lib\""
       - name: Submit results
         run: |
           tar czvf libfabric.tgz cov-int


### PR DESCRIPTION
Also adjust the schedule time to be truely in the night (US).