### PR TITLE
fabtests/cq_test: Fix a bug in opened cq cnt

### DIFF
--- a/fabtests/unit/cq_test.c
+++ b/fabtests/unit/cq_test.c
@@ -79,13 +79,15 @@ static int cq_open_close_simultaneous(void)
 		return -FI_ENOMEM;
 
 	ret = 0;
-	for (opened = 0; opened < count && !ret; opened++) {
+	for (opened = 0; opened < count; opened++) {
 		ret = create_cq(&cq_array[opened], 0, 0, FI_CQ_FORMAT_UNSPEC,
 				FI_WAIT_UNSPEC);
 		if (ret) {
 			ret = create_cq(&cq_array[opened], 0, 0,
 					FI_CQ_FORMAT_UNSPEC, FI_WAIT_NONE);
 		}
+		if (ret)
+			break;
 	}
 	if (ret) {
 		FT_WARN("fi_cq_open failed after %d (cq_cnt: %zu): %s",


### PR DESCRIPTION
opened should only be incremented when
create_cq returns 0. The current implementation
will make it set as the actual opened count
plus 1 when some error happens. This will
cause a double free error when fi_close
the last cq which is not opened.