### PR TITLE
prov/util: Add Mem Monitor State Lock to state init

### DIFF
--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -163,7 +163,9 @@ out:
 void ofi_monitor_init(struct ofi_mem_monitor *monitor)
 {
 	dlist_init(&monitor->list);
+	pthread_mutex_lock(&mm_state_lock);
 	monitor->state = FI_MM_STATE_IDLE;
+	pthread_mutex_unlock(&mm_state_lock);
 }
 
 void ofi_monitor_cleanup(struct ofi_mem_monitor *monitor)


### PR DESCRIPTION
Fix this coverity issue.
When initializing state two threads can access the field at the same timie and update it concurrently. Adding this lock prevents this case.