### PR TITLE
Fabtests: Resolve error handling coverity issues

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -3925,13 +3925,22 @@ int ft_sock_recv(int fd, void *msg, size_t len)
 int ft_sock_sync(int value)
 {
 	int result = -FI_EOTHER;
+	int ret;
 
 	if (listen_sock < 0) {
-		ft_sock_send(sock, &value,  sizeof value);
+		ret = ft_sock_send(sock, &value,  sizeof value);
+		if (ret) {
+			FT_PRINTERR("ft_sock_send", ret);
+			return ret;
+		}
 		ft_sock_recv(sock, &result, sizeof result);
 	} else {
 		ft_sock_recv(sock, &result, sizeof result);
-		ft_sock_send(sock, &value,  sizeof value);
+		ret = ft_sock_send(sock, &value,  sizeof value);
+		if (ret) {
+			FT_PRINTERR("ft_sock_send", ret);
+			return ret;
+		}
 	}
 
 	return result;

--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -3933,9 +3933,19 @@ int ft_sock_sync(int value)
 			FT_PRINTERR("ft_sock_send", ret);
 			return ret;
 		}
-		ft_sock_recv(sock, &result, sizeof result);
+
+		ret = ft_sock_recv(sock, &result, sizeof result);
+		if (ret) {
+			FT_PRINTERR("ft_sock_recv", ret);
+			return ret;
+		}
 	} else {
-		ft_sock_recv(sock, &result, sizeof result);
+		ret = ft_sock_recv(sock, &result, sizeof result);
+		if (ret) {
+			FT_PRINTERR("ft_sock_recv", ret);
+			return ret;
+		}
+
 		ret = ft_sock_send(sock, &value,  sizeof value);
 		if (ret) {
 			FT_PRINTERR("ft_sock_send", ret);

--- a/fabtests/functional/multi_ep.c
+++ b/fabtests/functional/multi_ep.c
@@ -136,8 +136,11 @@ static int ep_post_tx(int idx)
 {
 	int ret;
 
-	if (ft_check_opts(FT_OPT_VERIFY_DATA))
-		ft_fill_buf(send_bufs[idx], opts.transfer_size);
+	if (ft_check_opts(FT_OPT_VERIFY_DATA)) {
+		ret = ft_fill_buf(send_bufs[idx], opts.transfer_size);
+		if (ret)
+			return ret;
+	}
 
 	do {
 		ret = fi_send(eps[idx], send_bufs[idx], opts.transfer_size,

--- a/fabtests/functional/rdm_stress.c
+++ b/fabtests/functional/rdm_stress.c
@@ -470,7 +470,9 @@ static int rpc_read_req(struct rpc_ctrl *ctrl)
 	if (!ctrl->buf)
 		return -FI_ENOMEM;
 
-	ft_fill_buf(&ctrl->buf[ctrl->offset], ctrl->size);
+	ret = ft_fill_buf(&ctrl->buf[ctrl->offset], ctrl->size);
+	if (ret)
+		goto free;
 
 	ret = rpc_reg_buf(ctrl, size, FI_REMOTE_READ);
 	if (ret)

--- a/fabtests/functional/rdm_stress.c
+++ b/fabtests/functional/rdm_stress.c
@@ -989,7 +989,8 @@ static void complete_rpc(struct rpc_resp *resp)
 	}
 
 	if (resp->mr)
-		fi_close(&resp->mr->fid);
+		FT_CLOSE_FID(resp->mr);
+
 	(void) ft_check_buf(resp + 1, resp->hdr.size);
 	free(resp);
 }

--- a/fabtests/functional/rdm_stress.c
+++ b/fabtests/functional/rdm_stress.c
@@ -1111,7 +1111,11 @@ static void start_rpc(struct rpc_hdr *req)
 		goto free;
 
 	resp->hdr = *req;
-	ft_fill_buf(resp + 1, resp->hdr.size);
+	ret = ft_fill_buf(resp + 1, resp->hdr.size);
+	if (ret) {
+		free(resp);
+		goto free;
+	}
 
 	start = ft_gettime_ms();
 	do {

--- a/fabtests/ubertest/verify.c
+++ b/fabtests/ubertest/verify.c
@@ -119,7 +119,11 @@ int ft_sync_fill_bufs(size_t size)
 		if (ret)
 			return ret;
 
-		ft_hmem_copy_from(opts.iface, opts.device, ft_tx_ctrl.cpy_buf, ft_tx_ctrl.buf, size);
+		ret = ft_hmem_copy_from(opts.iface, opts.device,
+					ft_tx_ctrl.cpy_buf,
+					ft_tx_ctrl.buf, size);
+		if (ret)
+			return ret;
 	}
 
 	ft_sock_sync(0);

--- a/fabtests/unit/mr_cache_evict.c
+++ b/fabtests/unit/mr_cache_evict.c
@@ -636,19 +636,19 @@ static int mr_cache_test(enum alloc_type type)
 
 cleanup:
 	if (realloc_mr)
-		fi_close(&realloc_mr->fid);
+		FT_CLOSE_FID(realloc_mr);
 
 	if (cached_mr)
-		fi_close(&cached_mr->fid);
+		FT_CLOSE_FID(cached_mr);
 
 	if (mr)
-		fi_close(&mr->fid);
+		FT_CLOSE_FID(mr);
 
 	if (buf)
 		mem_free(buf, type);
 
 	if (prime_mr)
-		fi_close(&prime_mr->fid);
+		FT_CLOSE_FID(prime_mr);
 
 	if (prime_buf) {
 		switch (iface) {


### PR DESCRIPTION
There are multiple error handling coverity issues reported recently.

All the issues require simple return statement check.

Each commit is for each issue.

**Following is a list of issues with links:**
**414775 (Calling ft_fill_buf without checking return value):**
https://scan4.scan.coverity.com/#/project-view/61752/10344?selectedIssue=414775

**414776 (Calling fi_close without checking return value):**
https://scan4.scan.coverity.com/#/project-view/61752/10344?selectedIssue=414776

**414778 (Calling ft_sock_send without checking return value):**
https://scan4.scan.coverity.com/#/project-view/61752/10344?selectedIssue=414778

**414807 (Calling ft_sock_recv without checking return value):**
https://scan4.scan.coverity.com/#/project-view/61752/10344?selectedIssue=414807

**414780 (Calling ft_fill_buf without checking return value):**
https://scan4.scan.coverity.com/#/project-view/61752/10344?selectedIssue=414780

**414794 (Calling ft_hmem_copy_from without checking return value):**
https://scan4.scan.coverity.com/#/project-view/61752/10344?selectedIssue=414794

**414798 (Calling ft_fill_buf without checking return value):**
https://scan4.scan.coverity.com/#/project-view/61752/10344?selectedIssue=414798

**414800 (Calling fi_close without checking return value):**
https://scan4.scan.coverity.com/#/project-view/61752/10344?selectedIssue=414800