### PR TITLE
prov/shm: Fix new coverity issue introduced by 7f23127

### DIFF
--- a/prov/shm/src/smr_util.c
+++ b/prov/shm/src/smr_util.c
@@ -572,13 +572,15 @@ void smr_map_del(struct smr_map *map, int64_t id)
 {
 	struct dlist_entry *entry;
 
+	assert(id >= 0 && id < SMR_MAX_PEERS);
+
 	pthread_mutex_lock(&ep_list_lock);
 	entry = dlist_find_first_match(&ep_name_list, smr_match_name,
 				       smr_no_prefix(map->peers[id].peer.name));
 	pthread_mutex_unlock(&ep_list_lock);
 
 	ofi_spin_lock(&map->lock);
-	if (id >= SMR_MAX_PEERS || id < 0 || map->peers[id].peer.id < 0)
+	if (map->peers[id].peer.id < 0)
 		goto unlock;
 
 	if (!entry) {


### PR DESCRIPTION
Must assert that the id is within the allowable range before using it to check a peer's name