### PR TITLE
prov/hook: Proposal for updating the hook provider

### DIFF
--- a/include/ofi_tree.h
+++ b/include/ofi_tree.h
@@ -81,6 +81,9 @@ void ofi_rbmap_destroy(struct ofi_rbmap *map);
 void ofi_rbmap_init(struct ofi_rbmap *map,
 		int (*compare)(struct ofi_rbmap *map, void *key, void *data));
 void ofi_rbmap_cleanup(struct ofi_rbmap *map);
+void ofi_rbmap_iterate(struct ofi_rbmap *map,
+	struct ofi_rbnode *node, void *context,
+	void (*handle_node)(struct ofi_rbnode *node, void *context));
 
 struct ofi_rbnode *ofi_rbmap_get_root(struct ofi_rbmap *map);
 struct ofi_rbnode *ofi_rbmap_find(struct ofi_rbmap *map, void *key);

--- a/src/tree.c
+++ b/src/tree.c
@@ -93,6 +93,19 @@ ofi_rbmap_create(int (*compare)(struct ofi_rbmap *map, void *key, void *data))
 	return map;
 }
 
+void ofi_rbmap_iterate(struct ofi_rbmap *map,
+	struct ofi_rbnode *node, void *context,
+	void (*handle_node)(struct ofi_rbnode *node, void *context))
+{
+	if (node == &map->sentinel)
+		return;
+
+	handle_node(node, context);
+
+	ofi_rbmap_iterate(map, node->left, context, handle_node);
+	ofi_rbmap_iterate(map, node->right, context, handle_node);
+}
+
 static void ofi_delete_tree(struct ofi_rbmap *map, struct ofi_rbnode *node)
 {
 	if (node == &map->sentinel)


### PR DESCRIPTION
As far as I could tell the hook provider dumps all the trace to the console, which is a lot to look at. This is a proposal to store the tracing information internally and then dump it when shutting down.

This patch makes a change to how the send/recv operation tracing is done.

This example code stores a record in a database. The record has a key consistent of addr/data len/operation. This way we can keep track of the number of operations of a specific len per address. I then dump it to a csv file, which is a lot easier to parse. Typically we don't need to see each operation on the console. A summary statistics of the job would be more useful (IMHO)

This is just a proposal to get some feedback.