### PR TITLE
prov/efa, fabtests/efa: Do not progress cq inside transmission call when hitting EAGAIN

### DIFF
--- a/fabtests/prov/efa/src/rdm_rnr_read_cq_error.c
+++ b/fabtests/prov/efa/src/rdm_rnr_read_cq_error.c
@@ -60,7 +60,12 @@ static int rnr_read_cq_error(void)
 	for (i = 0; i < total_send; i++) {
 		do {
 			ret = fi_send(ep, tx_buf, 32, mr_desc, remote_fi_addr, &tx_ctx);
-			if (ret < 0 && ret != -FI_EAGAIN) {
+			if (ret == -FI_EAGAIN) {
+				fi_cq_read(txcq, NULL, 0);
+				continue;
+			}
+
+			if (ret < 0) {
 				FT_PRINTERR("fi_send", -ret);
 				return ret;
 			}

--- a/prov/efa/src/rdm/efa_rdm_atomic.c
+++ b/prov/efa/src/rdm/efa_rdm_atomic.c
@@ -123,7 +123,6 @@ ssize_t efa_rdm_atomic_generic_efa(struct efa_rdm_ep *efa_rdm_ep,
 	txe = efa_rdm_atomic_alloc_txe(efa_rdm_ep, peer, msg, atomic_ex, op, flags);
 	if (OFI_UNLIKELY(!txe)) {
 		err = -FI_EAGAIN;
-		efa_rdm_ep_progress_internal(efa_rdm_ep);
 		goto out;
 	}
 
@@ -176,7 +175,6 @@ ssize_t efa_rdm_atomic_generic_efa(struct efa_rdm_ep *efa_rdm_ep,
 	}
 
 	if (OFI_UNLIKELY(err)) {
-		efa_rdm_ep_progress_internal(efa_rdm_ep);
 		efa_rdm_txe_release(txe);
 		peer->next_msg_id--;
 	}

--- a/prov/efa/src/rdm/efa_rdm_rma.c
+++ b/prov/efa/src/rdm/efa_rdm_rma.c
@@ -167,7 +167,6 @@ ssize_t efa_rdm_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uin
 
 	txe = efa_rdm_rma_alloc_txe(efa_rdm_ep, peer, msg, ofi_op_read_req, flags);
 	if (OFI_UNLIKELY(!txe)) {
-		efa_rdm_ep_progress_internal(efa_rdm_ep);
 		err = -FI_EAGAIN;
 		goto out;
 	}
@@ -209,13 +208,10 @@ ssize_t efa_rdm_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uin
 		if (OFI_UNLIKELY(err)) {
 			if (err == -FI_ENOBUFS)
 				err = -FI_EAGAIN;
-			efa_rdm_ep_progress_internal(efa_rdm_ep);
 			goto out;
 		}
 	} else {
 		err = efa_rdm_rma_post_efa_emulated_read(efa_rdm_ep, txe);
-		if (OFI_UNLIKELY(err))
-			efa_rdm_ep_progress_internal(efa_rdm_ep);
 	}
 
 out:
@@ -440,14 +436,12 @@ static inline ssize_t efa_rdm_generic_writemsg(struct efa_rdm_ep *efa_rdm_ep,
 
 	txe = efa_rdm_rma_alloc_txe(efa_rdm_ep, peer, msg, ofi_op_write, flags);
 	if (OFI_UNLIKELY(!txe)) {
-		efa_rdm_ep_progress_internal(efa_rdm_ep);
 		err = -FI_EAGAIN;
 		goto out;
 	}
 
 	err = efa_rdm_rma_post_write(efa_rdm_ep, txe);
 	if (OFI_UNLIKELY(err)) {
-		efa_rdm_ep_progress_internal(efa_rdm_ep);
 		efa_rdm_txe_release(txe);
 	}
 out:


### PR DESCRIPTION
It's application's responsibility to poll cq
    when hitting EAGAIN, efa provider shouldn't have
    to progress the ep again inside the transmission
    call.


Also fix the EAGAIN handling in rnr_cq_read_error test