### PR TITLE
contrib/intel/jenkins: Update SHMEM testing

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -647,13 +647,22 @@ pipeline {
             }
           }
         }
-        stage('SHMEM') {
+        stage('SHMEM_grass') {
           steps {
             script {
               dir (RUN_LOCATION) {
-                run_middleware([["verbs", null], ["tcp", null],
-                                ["sockets", null]], "SHMEM", "shmem",
-                                "water", "squirtle,totodile", "2")
+                run_middleware([["tcp", null]], "SHMEM", "shmem",
+                                "grass", "grass", "2")
+              }
+            }
+          }
+        }
+        stage('SHMEM_water') {
+          steps {
+            script {
+              dir (RUN_LOCATION) {
+                run_middleware([["verbs", "rxm"], ["sockets", null]], "SHMEM",
+                                "shmem", "water", "water", "2")
               }
             }
           }

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -397,6 +397,11 @@ pipeline {
                             """python$PYTHON_VERSION ${RUN_LOCATION}/build.py \
                               --build_item=mpich --build_hw=water"""
                           )
+              slurm_batch("water", "1",
+                          "${env.LOG_DIR}/build_shmem_water_log",
+                          """python$PYTHON_VERSION ${RUN_LOCATION}/build.py \
+                              --build_item=shmem --build_hw=water"""
+                         )
             }
           }
         }
@@ -409,6 +414,11 @@ pipeline {
                             """python$PYTHON_VERSION ${RUN_LOCATION}/build.py \
                               --build_item=mpich --build_hw=grass"""
                           )
+              slurm_batch("grass", "1",
+                          "${env.LOG_DIR}/build_shmem_grass_log",
+                          """python$PYTHON_VERSION ${RUN_LOCATION}/build.py \
+                              --build_item=shmem --build_hw=grass"""
+                         )
             }
           }
         }

--- a/contrib/intel/jenkins/build.py
+++ b/contrib/intel/jenkins/build.py
@@ -111,6 +111,38 @@ def build_mpich_osu(install_path, libfab_installpath, hw_type):
 		os.environ['PATH'] = path
 		os.environ['LD_LIBRARY_PATH'] = ld_library_path
 
+def build_shmem(install_path, libfab_installpath, hw_type):
+	shmem_build = f'{install_path}/middlewares/shmem_{hw_type}'
+	shmem_build_dir = f'{shmem_build}/SOS'
+	cwd = os.getcwd()
+	if (os.path.exists(shmem_build_dir)):
+		os.chdir(shmem_build_dir)
+
+		os.environ['LDFLAGS']=f'-fno-pie'
+		command = "bash -c \'"
+		command += "./autogen.sh; "
+		command += "./configure "
+		command += f"--prefix={shmem_build} "
+		command += "--disable-fortran "
+		command += "--enable-remote-virtual-addressing "
+		command += "--disable-aslr-check "
+		command += "--enable-pmi-simple "
+		command += "--enable-hard-polling "
+		if hw_type == 'water':
+			command += "--enable-ofi-mr=basic "
+
+		command += f"--with-ofi={libfab_installpath}; "
+
+		command += "make clean; "
+		command += "make -j; "
+		command += "make check TESTS=; "
+		command += "make install"
+		command += "\'"
+
+		common.run_command(shlex.split(command))
+
+	os.chdir(cwd)
+
 
 def copy_build_dir(install_path):
 	middlewares_path = f'{install_path}/middlewares'
@@ -160,7 +192,7 @@ if __name__ == "__main__":
 	parser = argparse.ArgumentParser()
 	parser.add_argument('--build_item', help="build libfabric or fabtests", \
 						choices=['libfabric', 'fabtests', 'builddir', 'logdir',\
-								 'mpich'])
+								 'mpich', 'shmem'])
 	parser.add_argument('--build_hw', help="HW type for build",
 						choices=['water', 'grass', 'fire', 'electric', 'ucx',
 								 'daos', 'gpu', 'ivysaur'])
@@ -203,5 +235,7 @@ if __name__ == "__main__":
 	elif(build_item == 'mpich'):
 		build_mpich(custom_workspace, libfab_install_path, build_hw)
 		build_mpich_osu(custom_workspace, libfab_install_path, build_hw)
+	elif (build_item == 'shmem'):
+		build_shmem(custom_workspace, libfab_install_path, build_hw)
 
 	os.chdir(curr_dir)

--- a/contrib/intel/jenkins/build.py
+++ b/contrib/intel/jenkins/build.py
@@ -149,8 +149,10 @@ def copy_build_dir(install_path):
 	if (os.path.exists(middlewares_path) != True):
 		os.makedirs(f'{install_path}/middlewares')
 
-	shutil.copytree(f'{cloudbees_config.build_dir}/shmem',
-					f'{middlewares_path}/shmem')
+	shutil.copytree(f'{cloudbees_config.build_dir}/shmem_grass',
+					f'{middlewares_path}/shmem_grass')
+	shutil.copytree(f'{cloudbees_config.build_dir}/shmem_water',
+					f'{middlewares_path}/shmem_water')
 	shutil.copytree(f'{cloudbees_config.build_dir}/oneccl',
 					f'{middlewares_path}/oneccl')
 	shutil.copytree(f'{cloudbees_config.build_dir}/mpich_water',

--- a/contrib/intel/jenkins/run.py
+++ b/contrib/intel/jenkins/run.py
@@ -47,13 +47,14 @@ def fabtests(hw, core, hosts, mode, user_env, log_file, util, way):
         print(f"Skipping {core} {runfabtest.testname} as exec condn fails")
     print('-------------------------------------------------------------------')
 
-def shmemtest(hw, core, hosts, mode, user_env, log_file, util):
+def shmemtest(hw, core, hosts, mode, user_env, log_file, util, weekly):
 
     runshmemtest = tests.ShmemTest(jobname=jbname,buildno=bno,
                                    testname="shmem test", hw=hw, core_prov=core,
                                    fabric=fab, hosts=hosts,
                                    ofi_build_mode=mode, user_env=user_env,
-                                   log_file=log_file, util_prov=util)
+                                   log_file=log_file, util_prov=util,
+                                   weekly=weekly)
 
     print('-------------------------------------------------------------------')
     if (runshmemtest.execute_condn):

--- a/contrib/intel/jenkins/run.py
+++ b/contrib/intel/jenkins/run.py
@@ -67,10 +67,6 @@ def shmemtest(hw, core, hosts, mode, user_env, log_file, util, weekly):
         print('--------------------------------------------------------------')
         print(f"Running shmem ISx test for {core}-{util}-{fab}")
         runshmemtest.execute_cmd("isx")
-
-        print('---------------------------------------------------------------')
-        print(f"Running shmem uh test for {core}-{util}-{fab}")
-        runshmemtest.execute_cmd("uh")
     else:
         print(f"Skipping {core} {runshmemtest.testname} as exec condn fails")
     print('-------------------------------------------------------------------')

--- a/contrib/intel/jenkins/run.py
+++ b/contrib/intel/jenkins/run.py
@@ -48,7 +48,6 @@ def fabtests(hw, core, hosts, mode, user_env, log_file, util, way):
     print('-------------------------------------------------------------------')
 
 def shmemtest(hw, core, hosts, mode, user_env, log_file, util, weekly):
-
     runshmemtest = tests.ShmemTest(jobname=jbname,buildno=bno,
                                    testname="shmem test", hw=hw, core_prov=core,
                                    fabric=fab, hosts=hosts,
@@ -58,9 +57,10 @@ def shmemtest(hw, core, hosts, mode, user_env, log_file, util, weekly):
 
     print('-------------------------------------------------------------------')
     if (runshmemtest.execute_condn):
-#        skip unit because it is failing shmem_team_split_2d
-#        print(f"Running shmem unit test for {core}-{util}-{fab}")
-#        runshmemtest.execute_cmd("unit")
+        print(f"Running shmem SOS test for {core}-{util}-{fab}")
+        runshmemtest.execute_cmd("sos")
+
+        print('--------------------------------------------------------------')
         print(f"Running shmem PRK test for {core}-{util}-{fab}")
         runshmemtest.execute_cmd("prk")
 

--- a/contrib/intel/jenkins/runtests.py
+++ b/contrib/intel/jenkins/runtests.py
@@ -114,7 +114,7 @@ if(args_core):
 
     if (run_test == 'all' or run_test == 'shmem'):
         run.shmemtest(build_hw, args_core, hosts, ofi_build_mode, user_env,
-                      log_file, args_util)
+                      log_file, args_util, weekly)
 
     if (run_test == 'all' or run_test == 'oneccl'):
         run.oneccltest(build_hw, args_core, hosts, ofi_build_mode, user_env,

--- a/contrib/intel/jenkins/summary.py
+++ b/contrib/intel/jenkins/summary.py
@@ -430,11 +430,6 @@ class ShmemSummarizer(Summarizer):
     def __init__(self, logger, log_dir, prov, file_name, stage_name):
         super().__init__(logger, log_dir, prov, file_name, stage_name)
         self.shmem_type = {
-            'uh'    : { 'func'      : self.check_uh,
-                        'keyphrase' : 'summary',
-                        'passes'    : 0,
-                        'fails'     : 0
-                      },
             'isx'   : { 'func'      : self.check_isx,
                         'keyphrase' : 'scaling',
                         'passes'    : 0,
@@ -450,41 +445,6 @@ class ShmemSummarizer(Summarizer):
         self.keyphrase = self.shmem_type[self.test_type]['keyphrase']
         self.name = 'no_test'
         self.previous = ''
-
-    def check_uh(self, line, log_file):
-        # (test_002) Running test_shmem_atomics.x: Test all atomics... OK
-        # (test_003) Running test_shmem_barrier.x: Tests barrier ... Failed
-        if "running test_" in line:
-            tokens = line.split()
-            for token in tokens:
-                if 'test_shmem' in token:
-                    name = '_'.join(token.split('_')[2:]).strip('.x:')
-                    self.name = f"UH {name}"
-                    break
-            if tokens[len(tokens) - 1] == 'ok':
-                self.shmem_type[self.test_type]['passes'] += 1
-                self.passed_tests.append(self.name)
-            else:
-                self.shmem_type[self.test_type]['fails'] += 1
-                self.failed_tests.append(self.name)
-        # Summary
-        # x/z Passed.
-        # y/z Failed.
-        if self.keyphrase in line: #double check
-            passed = log_file.readline().lower()
-            failed = log_file.readline().lower()
-            token = int(passed.split()[1].split('/')[0])
-            if self.shmem_type[self.test_type]['passes'] != token:
-                self.logger.log(
-                    f"passes {self.shmem_type[self.test_type]['passes']} do " \
-                    f"not match log reported passes {token}"
-                )
-            token = int(failed.split()[1].split('/')[0])
-            if self.shmem_type[self.test_type]['fails'] != int(token):
-                self.logger.log(
-                    f"fails {self.shmem_type[self.test_type]['fails']} does "\
-                    f"not match log fails {token}"
-                )
 
     def check_prk(self, line, log_file=None):
         if "parallel research kernels" in self.previous:

--- a/contrib/intel/jenkins/summary.py
+++ b/contrib/intel/jenkins/summary.py
@@ -11,10 +11,6 @@ from email.mime.text import MIMEText
 from email.mime.base import MIMEBase
 from email import encoders
 
-# add jenkins config location to PATH
-sys.path.append(f"{os.environ['CUSTOM_WORKSPACE']}/ci_resources/configs/{os.environ['CLUSTER']}")
-
-import cloudbees_config
 import argparse
 import common
 
@@ -947,15 +943,6 @@ def summarize_items(summary_item, logger, log_dir, mode):
     return err
 
 if __name__ == "__main__":
-#read Jenkins environment variables
-    # In Jenkins,  JOB_NAME  = 'ofi_libfabric/master' vs BRANCH_NAME = 'master'
-    # job name is better to use to distinguish between builds of different
-    # jobs but with same branch name.
-    jobname = os.environ['JOB_NAME']
-    buildno = os.environ['BUILD_NUMBER']
-    workspace = os.environ['WORKSPACE']
-    custom_workspace = os.environ['CUSTOM_WORKSPACE']
-
     parser = argparse.ArgumentParser()
     parser.add_argument('--summary_item', help="functional test to summarize",
                          choices=['fabtests', 'imb', 'osu', 'mpichtestsuite',
@@ -979,6 +966,7 @@ if __name__ == "__main__":
     send_mail = args.send_mail
 
     mpi_list = ['impi', 'mpich', 'ompi']
+    custom_workspace = os.environ['CUSTOM_WORKSPACE']
     log_dir = f'{custom_workspace}/log_dir'
     if (not os.path.exists(log_dir)):
         os.makedirs(log_dir)

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -235,7 +235,6 @@ class ShmemTest(Test):
 
         self.test_dir = {
             'sos'  : 'SOS/test',
-            'uh'    : 'tests-uh',
             'isx'   : 'ISx/SHMEM',
             'prk'   : 'PRK/SHMEM'
         }
@@ -328,9 +327,6 @@ class ShmemTest(Test):
 
                     cmd_list.append(f"{test_dir_path}/{f_name}")
 
-        elif self.shmem_testname == 'uh':
-            cmd_list.append(f'{self.shmem_dir}/{self.test_dir[self.shmem_testname]}/bin '\
-                       f'{self.make[self.shmem_testname]}')
         elif self.shmem_testname == 'isx':
             exec_path = f'{self.shmem_dir}/{self.test_dir[self.shmem_testname]}/bin'
             cmd_list.append(f"{exec_path}/isx.strong {self.isx_shmem_kernel_max} " \

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -208,7 +208,8 @@ class Fabtest(Test):
 class ShmemTest(Test):
 
     def __init__(self, jobname, buildno, testname, hw, core_prov, fabric,
-                    hosts, ofi_build_mode, user_env, log_file, util_prov=None):
+                    hosts, ofi_build_mode, user_env, log_file, util_prov=None,
+                    weekly=False):
 
         super().__init__(jobname, buildno, testname, hw, core_prov, fabric,
                          hosts, ofi_build_mode, user_env, log_file, None,
@@ -216,7 +217,9 @@ class ShmemTest(Test):
 
         self.n = 4
         self.ppn = 2
-        self.shmem_dir = f'{self.middlewares_path}/shmem'
+        self.weekly = weekly
+        self.shmem_dir = f'{self.middlewares_path}/shmem_{self.hw}'
+        self.oshrun = f'{self.shmem_dir}/bin/oshrun'
         self.hydra = f'{cloudbees_config.hydra}'
         self.shmem_testname = ''
         self.threshold = '1'
@@ -231,17 +234,10 @@ class ShmemTest(Test):
             self.prov = self.core_prov
 
         self.test_dir = {
-            'unit'  : 'SOS',
+            'sos'  : 'SOS/test',
             'uh'    : 'tests-uh',
             'isx'   : 'ISx/SHMEM',
             'prk'   : 'PRK/SHMEM'
-        }
-
-        self.make = {
-            'unit'  : 'make VERBOSE=1',
-            'uh'    : 'make C_feature_tests-run',
-            'isx'   : '',
-            'prk'   : ''
         }
 
         self.shmem_environ = {
@@ -256,6 +252,48 @@ class ShmemTest(Test):
             'threshold'              : self.threshold
         }
 
+        self.exclude_extensions = ['.cpp', '.c', '.o', '.h', '.f90', '.log',
+                                   '.am', '.in', '.deps', '.libs']
+
+        self.SOS_tests = [
+            'unit',
+            'shmemx',
+            'apps',
+            'spec-example'
+        ]
+
+        if self.weekly:
+            self.SOS_tests.append('performance/shmem_perf_suite')
+            self.SOS_tests.append('performance/tests')
+
+        self.exclude = {
+            'sos'  : {
+                        'verbs'   : [
+                                        'c11_test_shmem_wait_until',
+                                        'c11_test_shmem_test',
+                                        'cxx_test_shmem_wait_until',
+                                        'cxx_test_shmem_test',
+                                        'alltoall',
+                                        'gettid_register',
+                                        'rma_coverage',
+                                        'iput_longlong',
+                                        'hello',
+                                        'makefile',
+                                        'readme'
+                                   ],
+                        'tcp'     : [
+                                        'c11_test_shmem_put',
+                                        'cxx_test_shmem_put',
+                                        'makefile',
+                                        'readme'
+                                    ],
+                        'sockets' : [
+                                        'makefile',
+                                        'readme'
+                                    ]
+                     }
+        }
+
     def export_env(self):
         environ = ''
         if self.shmem_testname == 'isx' or self.shmem_testname == 'prk':
@@ -265,50 +303,70 @@ class ShmemTest(Test):
             environ += f"export {key}={val}; "
         return environ
 
-    def cmd(self):
-        cmd = ''
-        if self.shmem_testname == 'unit':
-            cmd += f"{self.make[self.shmem_testname]} "
-            cmd += "mpiexec.hydra "
-            cmd += f"-n {self.n} "
-            cmd += f"-np {self.ppn} "
-            cmd += 'check'
+    def check_ending(self, f_name):
+        """
+        Returns True if ending is okay, false if not
+        """
+        for ext in self.exclude_extensions:
+            if f_name.lower().endswith(ext):
+                return False
+
+        return True
+
+    def get_cmds(self):
+        cmd_list = []
+        if self.shmem_testname == 'sos':
+            for test_dir in self.SOS_tests:
+                test_dir_path = f'{self.shmem_dir}/' \
+                                f'{self.test_dir[self.shmem_testname]}/' \
+                                f'{test_dir}'
+                for f_name in os.listdir(test_dir_path):
+                    if not self.check_ending(f_name) or \
+                       f_name.lower() in \
+                       self.exclude[self.shmem_testname][self.core_prov]:
+                        continue
+
+                    cmd_list.append(f"{test_dir_path}/{f_name}")
+
         elif self.shmem_testname == 'uh':
-            cmd += f'{self.make[self.shmem_testname]}'
+            cmd_list.append(f'{self.shmem_dir}/{self.test_dir[self.shmem_testname]}/bin '\
+                       f'{self.make[self.shmem_testname]}')
         elif self.shmem_testname == 'isx':
-            cmd += f"oshrun -np 4 ./bin/isx.strong {self.isx_shmem_kernel_max}"\
-                    " output_strong; "
-            cmd += f"oshrun -np 4 ./bin/isx.weak {self.isx_shmem_total_size} "\
-                    "output_weak; "
-            cmd += f"oshrun -np 4 ./bin/isx.weak_iso "\
-                   f"{self.isx_shmem_total_size} output_weak_iso "
+            exec_path = f'{self.shmem_dir}/{self.test_dir[self.shmem_testname]}/bin'
+            cmd_list.append(f"{exec_path}/isx.strong {self.isx_shmem_kernel_max} " \
+                        "output_strong")
+            cmd_list.append(f"{exec_path}/isx.weak " \
+                       f"{self.isx_shmem_total_size} output_weak")
+            cmd_list.append(f"{exec_path}/isx.weak_iso " \
+                       f"{self.isx_shmem_total_size} output_weak_iso")
         elif self.shmem_testname == 'prk':
-            cmd += f"oshrun -np 4 ./Stencil/stencil {self.prk_iterations} "\
-                   f"{self.prk_first_arr_dim}; "
-            cmd += f"oshrun -np 4 ./Synch_p2p/p2p {self.prk_iterations} "\
-                   f"{self.prk_first_arr_dim} {self.prk_second_arr_dim}; "
-            cmd += f"oshrun -np 4 ./Transpose/transpose {self.prk_iterations} "\
-                   f"{self.prk_first_arr_dim} "
+            exec_path = f'{self.shmem_dir}/{self.test_dir[self.shmem_testname]}'
+            cmd_list.append(f"{exec_path}/Stencil/stencil " \
+                       f"{self.prk_iterations} {self.prk_first_arr_dim}")
+            cmd_list.append(f"{exec_path}/Synch_p2p/p2p " \
+                       f"{self.prk_iterations} {self.prk_first_arr_dim} "\
+                       f"{self.prk_second_arr_dim}")
+            cmd_list.append(f"{exec_path}/Transpose/transpose " \
+                       f"{self.prk_iterations} {self.prk_first_arr_dim}")
 
-        return cmd
-
+        return cmd_list
 
     @property
     def execute_condn(self):
-        #make always true when verbs and sockets are passing
-        return True if (self.core_prov == 'tcp') \
-                    else False
+        return True
 
     def execute_cmd(self, shmem_testname):
         self.shmem_testname = shmem_testname
-        cwd = os.getcwd()
-        os.chdir(f'{self.shmem_dir}/{self.test_dir[self.shmem_testname]}')
-        print("Changed directory to "\
-              f'{self.shmem_dir}/{self.test_dir[self.shmem_testname]}')
-        command = f"bash -c \'{self.export_env()} {self.cmd()}\'"
-        outputcmd = shlex.split(command)
-        common.run_command(outputcmd)
-        os.chdir(cwd)
+        base_cmd = f"{self.oshrun}"
+        base_cmd = f"{base_cmd} -n {self.n}"
+        base_cmd = f"{base_cmd} -ppn {self.ppn}"
+        cmds = self.get_cmds()
+        for cmd in self.get_cmds():
+            command = f"bash -c \'{self.export_env()} {base_cmd} {cmd}\'"
+            outputcmd = shlex.split(command)
+            print(f"Running {self.shmem_testname} {cmd.split('/')[-1]}")
+            common.run_command(outputcmd)
+            print(f"{self.shmem_testname} {cmd.split('/')[-1]} PASS!")
 
 class MultinodeTests(Test):
 

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -229,7 +229,7 @@ class ShmemTest(Test):
         self.prk_first_arr_dim = 1000
         self.prk_second_arr_dim = 1000
         if self.util_prov:
-            self.prov = f'{self.core_prov};{self.util_prov}'
+            self.prov = f'{self.core_prov}\\;{self.util_prov}'
         else:
             self.prov = self.core_prov
 


### PR DESCRIPTION
Build shmem in build steps onto specific hardware types
Add back SOS tests
Add support to run test executables instead of using "make check" as implied in SOS repository
Add summarizer support for new test output
Add shmem tests for sockets and verbs-rxm
Add ability to disable failing tests until further investigation
Remove shmem-uh tests since they haven't been updated in 6 years and are stale
Remove unused summary fields
Place performance only tests in weekly