### PR TITLE
fabtests/efa: Fix coverity issue in rnr_read_cq_err

### DIFF
--- a/fabtests/prov/efa/src/rdm_rnr_read_cq_error.c
+++ b/fabtests/prov/efa/src/rdm_rnr_read_cq_error.c
@@ -61,7 +61,7 @@ static int rnr_read_cq_error(void)
 		do {
 			ret = fi_send(ep, tx_buf, 32, mr_desc, remote_fi_addr, &tx_ctx);
 			if (ret == -FI_EAGAIN) {
-				fi_cq_read(txcq, NULL, 0);
+				(void) fi_cq_read(txcq, NULL, 0);
 				continue;
 			}
 


### PR DESCRIPTION
Add a (void) before fi_cq_read(txcq, NULL, 0)
as in this case we don't care the return of fi_cq_read.