### PR TITLE
prov/shm: revert the smr_region fields adjustment

### DIFF
--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -226,6 +226,9 @@ struct smr_region {
 	uint8_t		cma_cap_peer;
 	uint8_t		cma_cap_self;
 	uint32_t	max_sar_buf_per_peer;
+	uint8_t		xpmem_cap_self;
+	struct xpmem_pinfo xpmem_self;
+	struct xpmem_pinfo xpmem_peer;
 	void		*base_addr;
 	pthread_spinlock_t	lock; /* lock for shm access
 				 if both ep->tx_lock and this lock need to
@@ -244,10 +247,6 @@ struct smr_region {
 	size_t		peer_data_offset;
 	size_t		name_offset;
 	size_t		sock_name_offset;
-
-	uint8_t		xpmem_cap_self;
-	struct xpmem_pinfo xpmem_self;
-	struct xpmem_pinfo xpmem_peer;
 };
 
 struct smr_resp {


### PR DESCRIPTION
The earlier change caused regression for inline message size and didn't bump the SMR protocol version. Revert it before we have a better fix on the alignment and cahce coherency.

This reverts commit b069cb494dc411f1cba9b8f66292c142862da254.