### PR TITLE
contrib/intel/jenkins: Update SHMEM testing

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -647,13 +647,22 @@ pipeline {
             }
           }
         }
-        stage('SHMEM') {
+        stage('SHMEM_grass') {
           steps {
             script {
               dir (RUN_LOCATION) {
-                run_middleware([["verbs", null], ["tcp", null],
-                                ["sockets", null]], "SHMEM", "shmem",
-                                "water", "squirtle,totodile", "2")
+                run_middleware([["tcp", null]], "SHMEM", "shmem",
+                                "grass", "grass", "2")
+              }
+            }
+          }
+        }
+        stage('SHMEM_water') {
+          steps {
+            script {
+              dir (RUN_LOCATION) {
+                run_middleware([["verbs", "rxm"], ["sockets", null]], "SHMEM",
+                                "shmem", "water", "squirtle,totodile", "2")
               }
             }
           }

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -397,6 +397,11 @@ pipeline {
                             """python$PYTHON_VERSION ${RUN_LOCATION}/build.py \
                               --build_item=mpich --build_hw=water"""
                           )
+              slurm_batch("water", "1",
+                          "${env.LOG_DIR}/build_shmem_water_log",
+                          """python$PYTHON_VERSION ${RUN_LOCATION}/build.py \
+                              --build_item=shmem --build_hw=water"""
+                         )
             }
           }
         }
@@ -409,6 +414,11 @@ pipeline {
                             """python$PYTHON_VERSION ${RUN_LOCATION}/build.py \
                               --build_item=mpich --build_hw=grass"""
                           )
+              slurm_batch("grass", "1",
+                          "${env.LOG_DIR}/build_shmem_grass_log",
+                          """python$PYTHON_VERSION ${RUN_LOCATION}/build.py \
+                              --build_item=shmem --build_hw=grass"""
+                         )
             }
           }
         }

--- a/contrib/intel/jenkins/build.py
+++ b/contrib/intel/jenkins/build.py
@@ -147,8 +147,10 @@ def copy_build_dir(install_path):
 	if (os.path.exists(middlewares_path) != True):
 		os.makedirs(f'{install_path}/middlewares')
 
-	shutil.copytree(f'{cloudbees_config.build_dir}/shmem',
-					f'{middlewares_path}/shmem')
+	shutil.copytree(f'{cloudbees_config.build_dir}/shmem_grass',
+					f'{middlewares_path}/shmem_grass')
+	shutil.copytree(f'{cloudbees_config.build_dir}/shmem_water',
+					f'{middlewares_path}/shmem_water')
 	shutil.copytree(f'{cloudbees_config.build_dir}/oneccl',
 					f'{middlewares_path}/oneccl')
 	shutil.copytree(f'{cloudbees_config.build_dir}/mpich_water',

--- a/contrib/intel/jenkins/run.py
+++ b/contrib/intel/jenkins/run.py
@@ -47,13 +47,14 @@ def fabtests(hw, core, hosts, mode, user_env, log_file, util, way):
         print(f"Skipping {core} {runfabtest.testname} as exec condn fails")
     print('-------------------------------------------------------------------')
 
-def shmemtest(hw, core, hosts, mode, user_env, log_file, util):
+def shmemtest(hw, core, hosts, mode, user_env, log_file, util, weekly):
 
     runshmemtest = tests.ShmemTest(jobname=jbname,buildno=bno,
                                    testname="shmem test", hw=hw, core_prov=core,
                                    fabric=fab, hosts=hosts,
                                    ofi_build_mode=mode, user_env=user_env,
-                                   log_file=log_file, util_prov=util)
+                                   log_file=log_file, util_prov=util,
+                                   weekly=weekly)
 
     print('-------------------------------------------------------------------')
     if (runshmemtest.execute_condn):

--- a/contrib/intel/jenkins/run.py
+++ b/contrib/intel/jenkins/run.py
@@ -67,10 +67,6 @@ def shmemtest(hw, core, hosts, mode, user_env, log_file, util, weekly):
         print('--------------------------------------------------------------')
         print(f"Running shmem ISx test for {core}-{util}-{fab}")
         runshmemtest.execute_cmd("isx")
-
-        print('---------------------------------------------------------------')
-        print(f"Running shmem uh test for {core}-{util}-{fab}")
-        runshmemtest.execute_cmd("uh")
     else:
         print(f"Skipping {core} {runshmemtest.testname} as exec condn fails")
     print('-------------------------------------------------------------------')

--- a/contrib/intel/jenkins/run.py
+++ b/contrib/intel/jenkins/run.py
@@ -48,7 +48,6 @@ def fabtests(hw, core, hosts, mode, user_env, log_file, util, way):
     print('-------------------------------------------------------------------')
 
 def shmemtest(hw, core, hosts, mode, user_env, log_file, util, weekly):
-
     runshmemtest = tests.ShmemTest(jobname=jbname,buildno=bno,
                                    testname="shmem test", hw=hw, core_prov=core,
                                    fabric=fab, hosts=hosts,
@@ -58,9 +57,10 @@ def shmemtest(hw, core, hosts, mode, user_env, log_file, util, weekly):
 
     print('-------------------------------------------------------------------')
     if (runshmemtest.execute_condn):
-#        skip unit because it is failing shmem_team_split_2d
-#        print(f"Running shmem unit test for {core}-{util}-{fab}")
-#        runshmemtest.execute_cmd("unit")
+        print(f"Running shmem SOS test for {core}-{util}-{fab}")
+        runshmemtest.execute_cmd("sos")
+
+        print('--------------------------------------------------------------')
         print(f"Running shmem PRK test for {core}-{util}-{fab}")
         runshmemtest.execute_cmd("prk")
 

--- a/contrib/intel/jenkins/runtests.py
+++ b/contrib/intel/jenkins/runtests.py
@@ -114,7 +114,7 @@ if(args_core):
 
     if (run_test == 'all' or run_test == 'shmem'):
         run.shmemtest(build_hw, args_core, hosts, ofi_build_mode, user_env,
-                      log_file, args_util)
+                      log_file, args_util, weekly)
 
     if (run_test == 'all' or run_test == 'oneccl'):
         run.oneccltest(build_hw, args_core, hosts, ofi_build_mode, user_env,

--- a/contrib/intel/jenkins/summary.py
+++ b/contrib/intel/jenkins/summary.py
@@ -433,94 +433,20 @@ class OnecclSummarizer(Summarizer):
 class ShmemSummarizer(Summarizer):
     def __init__(self, logger, log_dir, prov, file_name, stage_name):
         super().__init__(logger, log_dir, prov, file_name, stage_name)
-        self.shmem_type = {
-            'isx'   : { 'func'      : self.check_isx,
-                        'keyphrase' : 'scaling',
-                        'passes'    : 0,
-                        'fails'     : 0
-                      },
-            'prk'   : { 'func'      : self.check_prk,
-                        'keyphrase' : 'solution',
-                        'passes'    : 0,
-                        'fails'     : 0
-                      }
-        }
-        self.test_type = 'prk'
-        self.keyphrase = self.shmem_type[self.test_type]['keyphrase']
         self.name = 'no_test'
-        self.previous = ''
 
-    def check_prk(self, line, log_file=None):
-        if "parallel research kernels" in self.previous:
+    def check_name(self, line):
+        line = line.strip()
+        if "running " in line:
             tokens = line.split(' ')
-            name = tokens[tokens.index('shmem') + 1]
-            self.name = f"PRK {name}"
-        if self.keyphrase in line:
-            self.shmem_type[self.test_type]['passes'] += 1
+            self.name = ' '.join(tokens[1:])
+
+    def check_pass(self, line):
+        line = line.strip()
+        if "pass!" in line:
+            self.passes += 1
             self.passed_tests.append(self.name)
-        if 'error:' in line or "exiting with" in line:
-            self.shmem_type[self.test_type]['fails'] += 1
-            p = self.shmem_type[self.test_type]['passes']
-            f = self.shmem_type[self.test_type]['fails']
-            self.failed_tests.append(f"{self.prov} {p + f} {self.name}")
-        if 'test(s)' in line:
-            token = line.split()[0]
-            if self.fails != int(token):
-                self.logger.log(
-                    f"fails {self.fails} does not match log reported fails " \
-                    f"{token}"
-                )
 
-        self.previous = line
-
-    def check_isx(self, line, log_file=None):
-        if self.keyphrase in line:
-            self.shmem_type[self.test_type]['passes'] += 1
-            tokens = line.split(' ')
-            name = tokens[tokens.index(f"{self.keyphrase}!\n") - 1]
-            self.name = f"ISx {name}"
-            self.passed_tests.append(self.name)
-        if ('failed' in line and 'test(s)' not in line) or \
-            "exiting with" in line:
-            self.shmem_type[self.test_type]['fails'] += 1
-            p = self.shmem_type[self.test_type]['passes']
-            f = self.shmem_type[self.test_type]['fails']
-            self.failed_tests.append(f"{self.prov} {p + f} {self.name}")
-        if 'test(s)' in line:
-            token = line.split()[0]
-            if int(token) != self.shmem_type[self.test_type]['fails']:
-                self.logger.log(
-                    f"fails {self.shmem_type[self.test_type]['fails']} does " \
-                    f"not match log reported fails {int(token)}"
-                )
-
-    def check_fails(self, line):
-        if "exiting with" in line:
-            self.shmem_type[self.test_type]['fails'] += 1
-            p = self.shmem_type[self.test_type]['passes']
-            f = self.shmem_type[self.test_type]['fails']
-            self.failed_tests.append(f"{self.prov} {p + f}")
-
-    def check_test_type(self, line):
-        if "running shmem" in line:
-            self.test_type = line.split(' ')[2].lower()
-            self.keyphrase = self.shmem_type[self.test_type]['keyphrase']
-
-    def check_line(self, line, log_file):
-        self.check_test_type(line)
-        if self.test_type is not None:
-            self.shmem_type[self.test_type]['func'](line, log_file)
-            self.check_fails(line)
-
-    def read_file(self):
-        with open(self.file_path, 'r') as log_file:
-            super().fast_forward(log_file)
-            for line in log_file:
-                self.check_line(line.lower(), log_file)
-
-        for key in self.shmem_type.keys():
-            self.passes += self.shmem_type[key]['passes']
-            self.fails += self.shmem_type[key]['fails']
 
 class MpichTestSuiteSummarizer(Summarizer):
     def __init__(self, logger, log_dir, prov, mpi, file_name, stage_name):
@@ -860,7 +786,7 @@ def summarize_items(summary_item, logger, log_dir, mode):
         err += ret if ret else 0
 
     if summary_item == 'shmem' or summary_item == 'all':
-        for prov in ['tcp', 'verbs', 'sockets']:
+        for prov in ['tcp', 'verbs-rxm', 'sockets']:
             ret= ShmemSummarizer(
                 logger, log_dir, prov,
                 f'SHMEM_{prov}_shmem_{mode}',

--- a/contrib/intel/jenkins/summary.py
+++ b/contrib/intel/jenkins/summary.py
@@ -434,11 +434,6 @@ class ShmemSummarizer(Summarizer):
     def __init__(self, logger, log_dir, prov, file_name, stage_name):
         super().__init__(logger, log_dir, prov, file_name, stage_name)
         self.shmem_type = {
-            'uh'    : { 'func'      : self.check_uh,
-                        'keyphrase' : 'summary',
-                        'passes'    : 0,
-                        'fails'     : 0
-                      },
             'isx'   : { 'func'      : self.check_isx,
                         'keyphrase' : 'scaling',
                         'passes'    : 0,
@@ -454,41 +449,6 @@ class ShmemSummarizer(Summarizer):
         self.keyphrase = self.shmem_type[self.test_type]['keyphrase']
         self.name = 'no_test'
         self.previous = ''
-
-    def check_uh(self, line, log_file):
-        # (test_002) Running test_shmem_atomics.x: Test all atomics... OK
-        # (test_003) Running test_shmem_barrier.x: Tests barrier ... Failed
-        if "running test_" in line:
-            tokens = line.split()
-            for token in tokens:
-                if 'test_shmem' in token:
-                    name = '_'.join(token.split('_')[2:]).strip('.x:')
-                    self.name = f"UH {name}"
-                    break
-            if tokens[len(tokens) - 1] == 'ok':
-                self.shmem_type[self.test_type]['passes'] += 1
-                self.passed_tests.append(self.name)
-            else:
-                self.shmem_type[self.test_type]['fails'] += 1
-                self.failed_tests.append(self.name)
-        # Summary
-        # x/z Passed.
-        # y/z Failed.
-        if self.keyphrase in line: #double check
-            passed = log_file.readline().lower()
-            failed = log_file.readline().lower()
-            token = int(passed.split()[1].split('/')[0])
-            if self.shmem_type[self.test_type]['passes'] != token:
-                self.logger.log(
-                    f"passes {self.shmem_type[self.test_type]['passes']} do " \
-                    f"not match log reported passes {token}"
-                )
-            token = int(failed.split()[1].split('/')[0])
-            if self.shmem_type[self.test_type]['fails'] != int(token):
-                self.logger.log(
-                    f"fails {self.shmem_type[self.test_type]['fails']} does "\
-                    f"not match log fails {token}"
-                )
 
     def check_prk(self, line, log_file=None):
         if "parallel research kernels" in self.previous:

--- a/contrib/intel/jenkins/summary.py
+++ b/contrib/intel/jenkins/summary.py
@@ -947,15 +947,6 @@ def summarize_items(summary_item, logger, log_dir, mode):
     return err
 
 if __name__ == "__main__":
-#read Jenkins environment variables
-    # In Jenkins,  JOB_NAME  = 'ofi_libfabric/master' vs BRANCH_NAME = 'master'
-    # job name is better to use to distinguish between builds of different
-    # jobs but with same branch name.
-    jobname = os.environ['JOB_NAME']
-    buildno = os.environ['BUILD_NUMBER']
-    workspace = os.environ['WORKSPACE']
-    custom_workspace = os.environ['CUSTOM_WORKSPACE']
-
     parser = argparse.ArgumentParser()
     parser.add_argument('--summary_item', help="functional test to summarize",
                          choices=['fabtests', 'imb', 'osu', 'mpichtestsuite',
@@ -979,6 +970,7 @@ if __name__ == "__main__":
     send_mail = args.send_mail
 
     mpi_list = ['impi', 'mpich', 'ompi']
+    custom_workspace = os.environ['CUSTOM_WORKSPACE']
     log_dir = f'{custom_workspace}/log_dir'
     if (not os.path.exists(log_dir)):
         os.makedirs(log_dir)

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -235,7 +235,6 @@ class ShmemTest(Test):
 
         self.test_dir = {
             'sos'  : 'SOS/test',
-            'uh'    : 'tests-uh',
             'isx'   : 'ISx/SHMEM',
             'prk'   : 'PRK/SHMEM'
         }
@@ -318,9 +317,6 @@ class ShmemTest(Test):
 
                     cmd_list.append(f"{test_dir_path}/{f_name}")
 
-        elif self.shmem_testname == 'uh':
-            cmd_list.append(f'{self.shmem_dir}/{self.test_dir[self.shmem_testname]}/bin '\
-                       f'{self.make[self.shmem_testname]}')
         elif self.shmem_testname == 'isx':
             exec_path = f'{self.shmem_dir}/{self.test_dir[self.shmem_testname]}/bin'
             cmd_list.append(f"{exec_path}/isx.strong {self.isx_shmem_kernel_max} " \

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -229,7 +229,7 @@ class ShmemTest(Test):
         self.prk_first_arr_dim = 1000
         self.prk_second_arr_dim = 1000
         if self.util_prov:
-            self.prov = f'{self.core_prov};{self.util_prov}'
+            self.prov = f'{self.core_prov}\\;{self.util_prov}'
         else:
             self.prov = self.core_prov
 


### PR DESCRIPTION
Build shmem in build steps onto specific hardware types
Add back SOS tests
Add support to run test executables instead of using "make check" as implied in SOS repository
Add summarizer support for new test output
Add shmem tests for sockets and verbs-rxm
Add ability to disable failing tests until further investigation
Remove shmem-uh tests since they haven't been updated in 6 years and are stale
Remove unused summary fields
Place performance only tests in weekly