### PR TITLE
fabtests/multi_ep: close all eps first during clean up

### DIFF
--- a/fabtests/functional/multi_ep.c
+++ b/fabtests/functional/multi_ep.c
@@ -74,6 +74,9 @@ static void free_ep_res()
 	FT_CLOSE_FID(data_mr);
 	for (i = 0; i < num_eps; i++) {
 		FT_CLOSE_FID(eps[i]);
+	}
+
+	for (i = 0; i < num_eps; i++) {
 		FT_CLOSE_FID(txcqs[i]);
 		FT_CLOSE_FID(rxcqs[i]);
 		FT_CLOSE_FID(avs[i]);


### PR DESCRIPTION
EPs must be closed first before closing other associated resources. The current logic will cause EBUSY error when closing a CQ that still has EPs binding (when running with shared cq)