### PR TITLE
configure: relax xpmem libdir prefix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -432,7 +432,7 @@ FI_CHECK_PACKAGE([xpmem],
 		 [xpmem_make],
 		 [],
 		 [$enable_xpmem],
-		 [$enable_xpmem/lib64],
+		 [],
 		 [xpmem_happy=1])
 
 AS_IF([test x"$enable_xpmem" != x"no" && test -n "$enable_xpmem" && test "$xpmem_happy" = "0" ],


### PR DESCRIPTION
For some installations the library files are under lib/ instead of lib64/. This patch relaxes the libdir prefix to accommodate both scenarios.