### PR TITLE
fabtests: improve ft_sendmsg, use FI_DELIVERY_COMPLETE for ft_sync

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -2826,11 +2826,9 @@ int ft_recvmsg(struct fid_ep *ep, fi_addr_t fi_addr,
 		tagged_msg.tag = ft_tag ? ft_tag : tx_seq;
 		tagged_msg.ignore = 0;
 
-		ret = fi_trecvmsg(ep, &tagged_msg, flags);
-		if (ret) {
-			FT_PRINTERR("fi_trecvmsg", ret);
-			return ret;
-		}
+		FT_POST(fi_trecvmsg, ft_progress, rxcq, rx_seq,
+			&rx_cq_cntr, "trecvmsg", ep, &tagged_msg,
+			flags);
 	} else {
 		msg.msg_iov = &msg_iov;
 		msg.desc = &mr_desc;
@@ -2839,11 +2837,9 @@ int ft_recvmsg(struct fid_ep *ep, fi_addr_t fi_addr,
 		msg.data = NO_CQ_DATA;
 		msg.context = ctx;
 
-		ret = fi_recvmsg(ep, &msg, flags);
-		if (ret) {
-			FT_PRINTERR("fi_recvmsg", ret);
-			return ret;
-		}
+		FT_POST(fi_recvmsg, ft_progress, rxcq, rx_seq,
+			&rx_cq_cntr, "recvmsg", ep, &msg,
+			flags);
 	}
 
 	return 0;

--- a/fabtests/functional/inject_test.c
+++ b/fabtests/functional/inject_test.c
@@ -52,23 +52,9 @@ static int send_msg(int sendmsg, size_t size)
 	}
 
 	if (sendmsg) {
-		while(1) {
-			ret = ft_sendmsg(ep, remote_fi_addr, size,
-					 &tx_ctx, flag);
-			if (!ret)
-				break;
-
-			if (ret != -FI_EAGAIN) {
-				FT_PRINTERR("ft_sendmsg", ret);
-				return ret;
-			}
-
-			ret = ft_progress(txcq, tx_seq, &tx_cq_cntr);
-			if (ret && ret != -FI_EAGAIN) {
-				FT_ERR("Failed to get send completion");
-				return ret;
-			}
-		}
+		ret = ft_sendmsg(ep, remote_fi_addr, size, &tx_ctx, flag);
+		if (ret)
+			return ret;
 	} else {
 		ret = ft_post_tx(ep, remote_fi_addr, size, NO_CQ_DATA, &tx_ctx);
 		if (ret) {

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -600,6 +600,8 @@ int ft_recvmsg(struct fid_ep *ep, fi_addr_t fi_addr,
 		size_t size, void *ctx, int flags);
 int ft_sendmsg(struct fid_ep *ep, fi_addr_t fi_addr,
 		size_t size, void *ctx, int flags);
+int ft_tx_msg(struct fid_ep *ep, fi_addr_t fi_addr,
+	      size_t size, void *ctx, uint64_t flags);
 int ft_cq_read_verify(struct fid_cq *cq, void *op_context);
 
 void eq_readerr(struct fid_eq *eq, const char *eq_str);


### PR DESCRIPTION
This PR contains two changes
1. Improve ft_sendmsg: Use FT_POST to handle EAGAIN, make inject_test.c and ft_finalize_ep use the new ft_sendmsg function to remove code duplication.

2. Make ft_sync do tx with FI_DELIVERY_COMPLETE: Use FI_DELIVERY_COMPLETE to have a stronger sync up between the sender and receiver, which can enforce the handshake made in the protocols of RDM endpoints.