### PR TITLE
core: Add runtime parameter for choosing a specific DL provider

### DIFF
--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -281,6 +281,9 @@ do						\
 #define be64toh ntohll
 #define strncasecmp _strnicmp
 
+#define access(path, mode) _access(path, mode)
+#define F_OK 0
+
 typedef int pid_t;
 #define getpid (int)GetCurrentProcessId
 


### PR DESCRIPTION
Previously, if multiple instances of a provider with the same name are found, either the one with the highest version or the one registered first is chosen, depending on if and how FI_PROVIDER_PATH is set. This works fine for most cases. However, sometimes it is preferrable to be able to choose a specific provider instance, regardless of the version and the registration order the provider discovery mechanism would have resulted in.

Here a new variable FI_PROVIDER_PRELOAD is introduced. It is specified as a colon separated list, with each item being the full path to a DL provider. Upon successfully registration, such provider takes precedence over other providers with the same name, including the built-in one.