### PR TITLE
core: Extend FI_PROVIDER_PATH to allow setting preferred DL provider

### DIFF
--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -281,6 +281,9 @@ do						\
 #define be64toh ntohll
 #define strncasecmp _strnicmp
 
+#define access(path, mode) _access(path, mode)
+#define F_OK 0
+
 typedef int pid_t;
 #define getpid (int)GetCurrentProcessId
 


### PR DESCRIPTION
Existing FI_PROVIDER_PATH specifies a list of directories under which DL providers are searched for. If multiple providers with the same name are found, either the one with the highest version or the one registered first is set to be visible, depending on whether `@` appears at the beginning of FI_PROVIDER_PATH. Others are set to be hidden. This works fine for most cases.  However, sometimes it is desirable to be able to set a preferred provider directly, regardless of the version and the registration order.

Here FI_PROVIDER_PATH is extended to allow setting preferred providers in addition to provder search path. Each preferred provider is specified as `+` followed by the full path to the provider library. If registered successfully, a preferred provider takes precedence over all other providers with the same name, including the built-in one. If multiple preferred porivders with the same name are specified, the first one successfully registered takes effect.

This replaces #9872 