### PR TITLE
contrib/intel/jenkins: Fix bug where shm device is slurm partition

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -776,8 +776,8 @@ pipeline {
                              "shm", null, null, "h2d")
                 run_fabtests("cuda_v1_shm", "cyndaquil", "cyndaquil", "1",
                              "shm", null, null, "d2d")
-                run_fabtests("cuda_v1_shm", "cyndaquil", "cyndaquil", "1",
-                             "shm", null, null, "xd2d")
+                // run_fabtests("cuda_v1_shm", "cyndaquil", "cyndaquil", "1",
+                //              "shm", null, null, "xd2d")
               }
             }
           }
@@ -790,8 +790,8 @@ pipeline {
                              null, null, "h2d")
                 run_fabtests("cuda_v2_shm", "quilava", "quilava", "1", "shm",
                              null, null, "d2d")
-                run_fabtests("cuda_v2_shm", "quilava ", "quilava", "1", "shm",
-                             null, null, "xd2d")
+                // run_fabtests("cuda_v2_shm", "quilava ", "quilava", "1", "shm",
+                //              null, null, "xd2d")
               }
             }
           }

--- a/contrib/intel/jenkins/build.py
+++ b/contrib/intel/jenkins/build.py
@@ -56,6 +56,9 @@ def build_fabtests(libfab_install_path, mode, cuda=False):
 		config_cmd = ['./configure', f'--prefix={libfab_install_path}',
 					  f'--with-libfabric={libfab_install_path}']
 
+	if cuda:
+		config_cmd.append(f'--with-cuda={os.environ["CUDA_INSTALL"]}')
+
 	common.run_command(['./autogen.sh'])
 	common.run_command(config_cmd)
 	common.run_command(['make','clean'])

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -106,6 +106,7 @@ class Fabtest(Test):
                          util_prov, way)
         self.fabtestpath = f'{self.libfab_installpath}/bin'
         self.fabtestconfigpath = f'{self.libfab_installpath}/share/fabtests'
+        self.device = cloudbees_config.fabric_map[self.hw]
 
     def get_exclude_file(self):
         path = self.libfab_installpath
@@ -113,6 +114,8 @@ class Fabtest(Test):
 
         if self.hw == 'ivysaur':
             efile = f'{efile_path}/{self.core_prov}/io_uring.exclude'
+        elif self.hw == 'cyndaquil' or self.hw == 'quilava':
+            efile = f'{efile_path}/{self.core_prov}/cuda.exclude'
         else:
             prov = self.util_prov if self.util_prov else self.core_prov
             efile_old = f'{efile_path}/{prov}/{prov}.exclude'
@@ -155,11 +158,11 @@ class Fabtest(Test):
             opts += "-t all "
 
         if (self.way == 'h2d'):
-            opts += f"-C \"-H\" -L \"-D {self.hw}\" "
+            opts += f"-C \"-H\" -L \"-D {self.device}\" "
         elif (self.way == 'd2d'):
-            opts += f"-C \"-D {self.hw}\" -L \"-D {self.hw}\" "
+            opts += f"-C \"-D {self.device}\" -L \"-D {self.device}\" "
         elif (self.way == 'xd2d'):
-            opts += f"-C \"-D {self.hw}\" -L \"-D {self.hw} -i 1\" "
+            opts += f"-C \"-D {self.device}\" -L \"-D {self.device} -i 1\" "
 
         if (self.core_prov == 'sockets' and self.ofi_build_mode == 'reg'):
             complex_test_file = f'{self.libfab_installpath}/share/fabtests/'\

--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -125,6 +125,7 @@ nobase_dist_config_DATA = \
 	test_configs/ofi_rxd/ofi_rxd.exclude \
 	test_configs/shm/all.test \
 	test_configs/shm/shm.exclude \
+	test_configs/shm/cuda.exclude \
 	test_configs/shm/quick.test \
 	test_configs/shm/verify.test \
 	test_configs/sm2/quick.test \

--- a/fabtests/test_configs/shm/cuda.exclude
+++ b/fabtests/test_configs/shm/cuda.exclude
@@ -1,0 +1,28 @@
+# Regex patterns of tests to exclude in runfabtests.sh
+
+inject_test
+^fi_msg
+-e msg
+^fi_dgram
+-e dgram
+rdm_tagged_peek
+multi_ep
+av_xfer
+unexpected_msg
+multi_recv
+
+# Exclude tests that use sread/polling
+rdm_cntr_pingpong
+poll
+
+# Exclude tests with unsupported capabilities
+-k
+cm_data
+trigger
+shared_ctx
+scalable_ep
+shared_av
+multi_mr
+av_test
+
+multinode


### PR DESCRIPTION
Slurm partition name is getting passed in as the device when it shouldn't be.
Add cuda.exclude file for failing cuda tests that need to be revisited in the future