### PR TITLE
Fabtests/rdm_stress: Fix coverity issue 414806

### DIFF
--- a/fabtests/functional/rdm_stress.c
+++ b/fabtests/functional/rdm_stress.c
@@ -812,6 +812,7 @@ static int init_ctrls(const char *ctrlfile)
 
 	if (stat(ctrlfile, &sb)) {
 		FT_PRINTERR("stat", -errno);
+		fclose(ctrl_f);
 		return -errno;
 	}
 


### PR DESCRIPTION
Coverity is flagging an issue for not closing file control ctrl_f in case of error getting file attributes. 
The fix is to close ctrl_f in this path before returning.