### PR TITLE
Intel/CI: Add OneCCL CPU tests with DSA + shm to the CI

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -694,18 +694,22 @@ pipeline {
             }
           }
         }
-	stage ('oneCCL') {
+	      stage ('oneCCL') {
           steps {
             script {
               dir (RUN_LOCATION) {
-		run_middleware([["verbs", null]], "oneCCL",
+		            run_middleware([["verbs", null]], "oneCCL",
                                "oneccl", "water", "squirtle,totodile", "2")
-		run_middleware([["shm", null]], "oneCCL",
-			       "oneccl", "grass", "bulbasaur", "1")
-		run_middleware([["psm3", null]], "oneCCL",
-			       "oneccl", "water", "squirtle", "2")
-		run_middleware([["tcp", null]], "oneCCL",
-			       "oneccl", "grass", "bulbasaur", "2")
+		            run_middleware([["shm", null]], "oneCCL",
+			                         "oneccl", "grass", "bulbasaur", "1")
+		            run_middleware([["psm3", null]], "oneCCL",
+			                         "oneccl", "water", "squirtle", "2")
+		            run_middleware([["tcp", null]], "oneCCL",
+			                         "oneccl", "grass", "bulbasaur", "2")
+                run_middleware([["shm", null]], "oneCCL_DSA",
+                               "oneccl", "electric", "pikachu", "1", null, null,
+                               """CCL_ATL_SHM=1 FI_SHM_DISABLE_CMA=1 \
+                               FI_SHM_USE_DSA_SAR=1 FI_LOG_LEVEL=warn""")
               }
             }
           }

--- a/contrib/intel/jenkins/build.py
+++ b/contrib/intel/jenkins/build.py
@@ -36,6 +36,8 @@ def build_libfabric(libfab_install_path, mode, hw_type, gpu=False, cuda=False):
 
 	if (gpu):
 		config_cmd.append('--enable-ze-dlopen')
+	else:
+		config_cmd.append('--with-ze=no')
 
 	if (cuda):
 		config_cmd.append(f'--with-cuda={os.environ["CUDA_INSTALL"]}')


### PR DESCRIPTION
- Add OneCCL DSA stage.
- There was an issue with libfabric being built with ze and oneccl built without.
This led to failure and CCL transport being switched to MPI because oneccl looked for the library.
To avoid this, an else case is added with --with-ze=no.
- Update oneccl summarizer to support DSA + shm summary.
- Add the logic to check whether DSA was actually used or not.
