### PR TITLE
man: Fix uninitialized err_entry

### DIFF
--- a/man/fi_setup.7.md
+++ b/man/fi_setup.7.md
@@ -947,7 +947,11 @@ struct fi_cq_err_entry {
 /* Sample error handling */
 struct fi_cq_msg_entry entry;
 struct fi_cq_err_entry err_entry;
+char err_data[256];
 int ret;
+
+err_entry.err_data = err_data;
+err_entry.err_data_size = 256;
 
 ret = fi_cq_read(cq, &entry, 1);
 if (ret == -FI_EAVAIL)


### PR DESCRIPTION
`fi_cq_readerr` was previously called on uninitialized `.err_data` and `.err_data_size` in a code snippet from [fi_setup.7.md](https://github.com/ofiwg/libfabric/blob/8b402387c12b9a1ec6a96f600daa726b2b21cb8c/man/fi_setup.7.md#retrieving-errors):

```c
/* Sample error handling */
struct fi_cq_msg_entry entry;
struct fi_cq_err_entry err_entry;
int ret;

ret = fi_cq_read(cq, &entry, 1);
if (ret == -FI_EAVAIL)
    ret = fi_cq_readerr(cq, &err_entry, 0);
```

According to [fi_cq.3.md](https://github.com/ofiwg/libfabric/blob/8b402387c12b9a1ec6a96f600daa726b2b21cb8c/man/fi_cq.3.md#completion-fields) however, both `.err_data` and `.err_data_size` must be initialized prior to any call to `fi_cq_readerr`.

> `err_data` : The err_data field is used to return provider specific information, if available, about the error. On input, err_data should reference a data buffer of size err_data_size. On output, the provider will fill in this buffer with any provider specific data which may help identify the cause of the error. The contents of the err_data field and its meaning is provider specific. It is intended to be used as a debugging aid. See fi_cq_strerror for additional details on converting this error data into a human readable string. See the compatibility note below on how this field is used for older libfabric releases.

> `err_data_size` : On input, err_data_size indicates the size of the err_data buffer in bytes. On output, err_data_size will be set to the number of bytes copied to the err_data buffer. The err_data information is typically used with fi_cq_strerror to provide details about the type of error that occurred.

By looking at the source code and at Valgrind errors in my application based on this code snippet, input `.err_data` and `.err_data_size` are used in  `ofi_cq_readerr`, and must indeed be initialized.
https://github.com/ofiwg/libfabric/blob/8b402387c12b9a1ec6a96f600daa726b2b21cb8c/prov/util/src/util_cq.c#L287
