### PR TITLE
[v1.21.x] prov/shm: manually align 8 byte fields in memory region

### DIFF
--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -54,7 +54,7 @@
 extern "C" {
 #endif
 
-#define SMR_VERSION	6
+#define SMR_VERSION	7
 
 #define SMR_FLAG_ATOMIC	(1 << 0)
 #define SMR_FLAG_DEBUG	(1 << 1)
@@ -225,8 +225,10 @@ struct smr_region {
 	int		pid;
 	uint8_t		cma_cap_peer;
 	uint8_t		cma_cap_self;
-	uint32_t	max_sar_buf_per_peer;
 	uint8_t		xpmem_cap_self;
+	uint8_t		resv2;
+
+	uint32_t	max_sar_buf_per_peer;
 	struct xpmem_pinfo xpmem_self;
 	struct xpmem_pinfo xpmem_peer;
 	void		*base_addr;


### PR DESCRIPTION
Move all of the 8 byte fields together to eliminate extra padding. Previously, the last 8 byte field was after a 4 byte field, forcing the compiler to add extra padding before the 4 byte field and after the third 8 byte field. This increased the size of the memory region and pushed some fields to a new cache line. Consolidating them eliminates those extra bytes and allows for better caching performance.
This also adds a reserved value to force alignment of the next 32 bit field though the compiler should automatically add that memory anyway.

Altering the order of the fields in the shared memory region requires a version increment.

Cherry-picked from commit d9517e54289c2075f2ad3064a3be5f547b7527ce