### PR TITLE
prov/coll: Fix Coverity issue about race condition accessing av->av_set

### DIFF
--- a/prov/coll/src/coll_coll.c
+++ b/prov/coll/src/coll_coll.c
@@ -931,8 +931,10 @@ int coll_join_collective(struct fid_ep *ep, const void *addr,
 	av_set = container_of(set, struct util_av_set, av_set_fid);
 
 	if (coll_addr == FI_ADDR_NOTAVAIL) {
+		ofi_mutex_lock(&av_set->av->lock);
 		assert(av_set->av->av_set);
 		coll_mc = &av_set->av->av_set->coll_mc;
+		ofi_mutex_unlock(&av_set->av->lock);
 	} else {
 		coll_mc = (struct util_coll_mc*) ((uintptr_t) coll_addr);
 	}


### PR DESCRIPTION
CID 407572: Data race condition (MISSING_LOCK)

Accessing av_set->av->av_set without holding lock util_av.lock. Elsewhere, util_av.av_set is written to with util_av.lock held 1 out of 1 times (prov/util/src/util_av.c: ofi_av_close()).