### PR TITLE
.github: Add dependabot.yml file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      # Check for updates to GitHub Actions weekly on Monday
+      interval: "weekly"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+


### PR DESCRIPTION
Enables dependabot tool and checks for any version updates to all the github actions weekly on Mondays.
Dependabot.yml file needs to be in .github folder as opposed to .github/workflows like all other workflow yml files since .github folder is checked by github actions and also by OSSF scorecard.