### PR TITLE
prov/verbs: Allow for large TX queues with limited (or no) inline data

### DIFF
--- a/man/fi_verbs.7.md
+++ b/man/fi_verbs.7.md
@@ -163,21 +163,21 @@ The verbs provider checks for the following environment variables.
 ### Common variables:
 
 *FI_VERBS_TX_SIZE*
-:  Default maximum tx context size (default: 384)
+:  Default tx context size (default: 384)
 
 *FI_VERBS_RX_SIZE*
-:  Default maximum rx context size (default: 384)
+:  Default rx context size (default: 384)
 
 *FI_VERBS_TX_IOV_LIMIT*
-: Default maximum tx iov_limit (default: 4). Note: RDM (internal -
+: Default tx iov_limit (default: 4). Note: RDM (internal -
   deprecated) EP type supports only 1
 
 *FI_VERBS_RX_IOV_LIMIT*
-: Default maximum rx iov_limit (default: 4). Note: RDM (internal -
+: Default rx iov_limit (default: 4). Note: RDM (internal -
   deprecated) EP type supports only 1
 
 *FI_VERBS_INLINE_SIZE*
-: Default maximum inline size. Actual inject size returned in fi_info
+: Default inline size. Actual inject size returned in fi_info
   may be greater (default: 64)
 
 *FI_VERBS_MIN_RNR_TIMER*

--- a/prov/verbs/src/verbs_init.c
+++ b/prov/verbs/src/verbs_init.c
@@ -614,31 +614,31 @@ static int vrb_get_param_str(const char *param_name,
 int vrb_read_params(void)
 {
 	/* Common parameters */
-	if (vrb_get_param_int("tx_size", "Default maximum tx context size",
+	if (vrb_get_param_int("tx_size", "Default tx context size",
 			      &vrb_gl_data.def_tx_size) ||
 	    (vrb_gl_data.def_tx_size < 0)) {
 		VRB_WARN(FI_LOG_CORE, "Invalid value of tx_size\n");
 		return -FI_EINVAL;
 	}
-	if (vrb_get_param_int("rx_size", "Default maximum rx context size",
+	if (vrb_get_param_int("rx_size", "Default rx context size",
 			      &vrb_gl_data.def_rx_size) ||
 	    (vrb_gl_data.def_rx_size < 0)) {
 		VRB_WARN(FI_LOG_CORE, "Invalid value of rx_size\n");
 		return -FI_EINVAL;
 	}
-	if (vrb_get_param_int("tx_iov_limit", "Default maximum tx iov_limit",
+	if (vrb_get_param_int("tx_iov_limit", "Default tx iov_limit",
 			      &vrb_gl_data.def_tx_iov_limit) ||
 	    (vrb_gl_data.def_tx_iov_limit < 0)) {
 		VRB_WARN(FI_LOG_CORE, "Invalid value of tx_iov_limit\n");
 		return -FI_EINVAL;
 	}
-	if (vrb_get_param_int("rx_iov_limit", "Default maximum rx iov_limit",
+	if (vrb_get_param_int("rx_iov_limit", "Default rx iov_limit",
 			      &vrb_gl_data.def_rx_iov_limit) ||
 	    (vrb_gl_data.def_rx_iov_limit < 0)) {
 		VRB_WARN(FI_LOG_CORE, "Invalid value of rx_iov_limit\n");
 		return -FI_EINVAL;
 	}
-	if (vrb_get_param_int("inline_size", "Default maximum inline size. "
+	if (vrb_get_param_int("inline_size", "Default inline size. "
 			      "Actual inject size returned in fi_info may be "
 			      "greater", &vrb_gl_data.def_inline_size) ||
 	    (vrb_gl_data.def_inline_size < 0)) {

--- a/prov/verbs/src/verbs_init.c
+++ b/prov/verbs/src/verbs_init.c
@@ -479,7 +479,8 @@ int vrb_find_max_inline(struct ibv_pd *pd, struct ibv_context *context,
 	}
 
 	cq = ibv_create_cq(context, 1, NULL, NULL, 0);
-	assert(cq);
+	if (!cq)
+		goto out;
 
 	memset(&qp_attr, 0, sizeof(qp_attr));
 	qp_attr.send_cq = cq;
@@ -540,10 +541,8 @@ int vrb_find_max_inline(struct ibv_pd *pd, struct ibv_context *context,
 		ibv_destroy_qp(qp);
 	}
 
-	if (cq) {
-		ibv_destroy_cq(cq);
-	}
-
+	ibv_destroy_cq(cq);
+out:
 	return rst;
 }
 

--- a/prov/verbs/src/verbs_ofi.h
+++ b/prov/verbs/src/verbs_ofi.h
@@ -4,6 +4,7 @@
  * Copyright (c) 2018-2019 Cray Inc. All rights reserved.
  * Copyright (c) 2018-2019 System Fabric Works, Inc. All rights reserved.
  * (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+ * Copyright (c) 2024 DataDirect Networks, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -878,8 +879,7 @@ int vrb_query_atomic(struct fid_domain *domain_fid, enum fi_datatype datatype,
 			uint64_t flags);
 void vrb_set_rnr_timer(struct ibv_qp *qp);
 void vrb_cleanup_cq(struct vrb_ep *cur_ep);
-int vrb_find_max_inline(struct ibv_pd *pd, struct ibv_context *context,
-			   enum ibv_qp_type qp_type);
+int vrb_find_max_inline(struct ibv_context *context, enum ibv_qp_type qp_type);
 
 struct vrb_dgram_av {
 	struct util_av util_av;


### PR DESCRIPTION
Using large TX queues with the verbs provider would cause fi_getinfo() to return an empty list of verbs adapters because the call to ibv_create_qp() executed as part of fi_getinfo() would fail with EINVAL.

The failure happens because the code allocates the QP with the maximum amount of inline data supported by the adapter, which is empirically determined by vrb_find_max_inline(). The problem is that using inline data limits the TX queue size that can be allocated.

The fix implemented in this patch is to set max_inline_data = 0 when the QP is created, then update info->tx_attr->inject_size with the value returned by vrb_find_max_inline() after the QP is created. The code in vrb_find_max_inline() guarantees that the calculated inline value is correct as it is also tested with a fake QP creation.

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>