### PR TITLE
prov/opx: Fix Coverity scan waiting while holding lock errors.

### DIFF
--- a/prov/opx/src/fi_opx_reliability.c
+++ b/prov/opx/src/fi_opx_reliability.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2016 by Argonne National Laboratory.
- * Copyright (C) 2021-2023 Cornelis Networks.
+ * Copyright (C) 2021-2024 Cornelis Networks.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -450,7 +450,7 @@ ssize_t fi_opx_hfi1_tx_reliability_inject_ud_opcode (struct fid_ep *ep,
 	OPX_HFI1_BAR_STORE(&scb[5], 0UL);
 	OPX_HFI1_BAR_STORE(&scb[6], 0UL);
 	OPX_HFI1_BAR_STORE(&scb[7], key);
-	
+
 
 	/* consume one credit for the packet header */
 	FI_OPX_HFI1_CONSUME_SINGLE_CREDIT(pio_state);
@@ -519,7 +519,7 @@ ssize_t fi_opx_hfi1_tx_reliability_inject_ud_init(struct fid_ep *ep,
 #endif
 		return -FI_EAGAIN;
 	}
-	
+
 #ifdef OPX_RELIABILITY_DEBUG
 	if (opcode == FI_OPX_HFI_UD_OPCODE_RELIABILITY_INIT) {
 		fprintf(stderr, "(tx) flow__ %016lx 0x%lx inj init\n", key, reliability_rx);
@@ -552,7 +552,7 @@ ssize_t fi_opx_hfi1_tx_reliability_inject_ud_resynch(struct fid_ep *ep,
 #endif
 		return -FI_EAGAIN;
 	}
-	
+
 #ifdef OPX_RELIABILITY_DEBUG
 	if (opcode == FI_OPX_HFI_UD_OPCODE_RELIABILITY_RESYNCH) {
 		fprintf(stderr, "(tx) Client flow__ %016lx 0x%lx inj resynch\n", key, reliability_rx);
@@ -675,7 +675,7 @@ void fi_opx_hfi1_rx_reliability_send_pre_acks(struct fid_ep *ep, const uint64_t 
 	const uint64_t slid = hdr->stl.lrh.slid;
 
 	const union fi_opx_reliability_service_flow_key key = {
-		.slid = slid, 
+		.slid = slid,
 		.tx = FI_OPX_HFI1_PACKET_ORIGIN_TX(hdr),
 		.dlid = dlid,
 		.rx = reliability_rx };
@@ -1506,7 +1506,7 @@ ssize_t fi_opx_reliability_service_do_replay (struct fi_opx_reliability_service 
 	OPX_HFI1_BAR_STORE(&scb[5], replay->scb.hdr.qw[4]);
 	OPX_HFI1_BAR_STORE(&scb[6], replay->scb.hdr.qw[5]);
 	OPX_HFI1_BAR_STORE(&scb[7], replay->scb.hdr.qw[6]);
-	
+
 
 	FI_OPX_HFI1_CHECK_CREDITS_FOR_ERROR((service->tx.hfi1.pio_credits_addr));
 
@@ -1566,14 +1566,14 @@ ssize_t fi_opx_reliability_service_do_replay (struct fi_opx_reliability_service 
 		uint16_t i;
 		for (i=0; i<contiguous_full_blocks_to_write; ++i) {
 
-			OPX_HFI1_BAR_STORE(&scb_payload[0],  buf_qws[0]);
-			OPX_HFI1_BAR_STORE(&scb_payload[1],  buf_qws[1]);
-			OPX_HFI1_BAR_STORE(&scb_payload[2],  buf_qws[2]);
-			OPX_HFI1_BAR_STORE(&scb_payload[3],  buf_qws[3]);
-			OPX_HFI1_BAR_STORE(&scb_payload[4],  buf_qws[4]);
-			OPX_HFI1_BAR_STORE(&scb_payload[5],  buf_qws[5]);
-			OPX_HFI1_BAR_STORE(&scb_payload[6],  buf_qws[6]);
-			OPX_HFI1_BAR_STORE(&scb_payload[7],  buf_qws[7]);
+			OPX_HFI1_BAR_STORE(&scb_payload[0], buf_qws[0]);
+			OPX_HFI1_BAR_STORE(&scb_payload[1], buf_qws[1]);
+			OPX_HFI1_BAR_STORE(&scb_payload[2], buf_qws[2]);
+			OPX_HFI1_BAR_STORE(&scb_payload[3], buf_qws[3]);
+			OPX_HFI1_BAR_STORE(&scb_payload[4], buf_qws[4]);
+			OPX_HFI1_BAR_STORE(&scb_payload[5], buf_qws[5]);
+			OPX_HFI1_BAR_STORE(&scb_payload[6], buf_qws[6]);
+			OPX_HFI1_BAR_STORE(&scb_payload[7], buf_qws[7]);
 
 			scb_payload += 8;
 			buf_qws += 8;
@@ -1877,7 +1877,7 @@ uint64_t fi_opx_reliability_send_ping(struct fid_ep *ep,
 
 	// if the PSN of the tail is less than the PSN of the head, the
 	// PSN has rolled over. In that case, truncate the ping range
-	// to avoid rollover confusion. 
+	// to avoid rollover confusion.
 	uint64_t psn_count = ((psn_start>psn_stop)?MAX_PSN:psn_stop) - psn_start + 1;
 
 	// Send one ping to cover the entire replay range.
@@ -1965,7 +1965,7 @@ void fi_opx_reliability_service_process_pending (struct fi_opx_reliability_servi
 }
 
 #if 0
-/* 
+/*
  * Prototype code for off-loading the reliability service.
  */
 static inline
@@ -2287,14 +2287,14 @@ uint8_t fi_opx_reliability_service_init (struct fi_opx_reliability_service * ser
 	if (env) {
 		unsigned long period = strtoul(env, NULL, 10);
 		OPX_LOG_REL(FI_LOG_DEBUG, FI_LOG_EP_DATA,"FI_OPX_RELIABILITY_SERVICE_BACKOFF_PERIOD = '%s' (%lu)\n", env, period);
-		
+
 		service->is_backoff_enabled = 1;
 		service->backoff_period=(uint64_t)period;
 	}
 
 	/*
 	 * How often to preemptively acknowledge packets.
-	 * The default is 64, which indicates send a 
+	 * The default is 64, which indicates send a
 	 * preemptive, non-solicited ACK after 64 packets received.
 	 * Must be a power of 2, so that we can create an AND mask
 	 * that will quickly tell us whether or not to ack
@@ -2482,7 +2482,7 @@ uint8_t fi_opx_reliability_service_init (struct fi_opx_reliability_service * ser
 
 		for (i = 0; i < cpu_mask_chunk_num; i++) {
 			for (j = 0; j < cpu_mask_chunk_bits_size; j++) {
-				cpu_mask[i] |= CPU_ISSET(i * cpu_mask_chunk_bits_size + j, &cpu_set) << j;
+				cpu_mask[i] |= ((uint64_t) CPU_ISSET(i * cpu_mask_chunk_bits_size + j, &cpu_set)) << j;
 			}
 		}
 
@@ -2623,13 +2623,13 @@ void fi_opx_reliability_client_init (struct fi_opx_reliability_client_state * st
 	 * if a receiver is dropping packets, we should throttle the sender
 	 * by returning an EAGAIN until the # of outstanding packets falls.
 	 */
-	(void)ofi_bufpool_create(&(state->replay_pool), 
+	(void)ofi_bufpool_create(&(state->replay_pool),
 		OPX_RELIABILITY_TX_REPLAY_SIZE, // element size
 		sizeof(void *), // byte alignment
 		FI_OPX_RELIABILITY_TX_REPLAY_BLOCKS, // max # of elements
 		FI_OPX_RELIABILITY_TX_REPLAY_BLOCKS, // # of elements to allocate at once
 		OFI_BUFPOOL_NO_TRACK); // flags
-	(void)ofi_bufpool_create(&(state->replay_iov_pool), 
+	(void)ofi_bufpool_create(&(state->replay_iov_pool),
 		OPX_RELIABILITY_TX_REPLAY_IOV_SIZE, // element size
 		sizeof(void *), // byte alignment
 		FI_OPX_RELIABILITY_TX_REPLAY_IOV_BLOCKS, // max # of elements
@@ -3054,13 +3054,13 @@ void fi_opx_reliability_rx_exception (struct fi_opx_reliability_client_state * s
  * coalesced PING requests.  An ACK/NAK will be sent as a response to
  * the requests processed. We might not make it thru the entire hashmap,
  * so don't deallocate any requests that cannot be sent.
- * 
+ *
  * This function is capable to handle an incomplete run thru the loop
- * 
+ *
  * This function is optimized to only do pings, but it can easily be modfied
  * to handle all reliablity events.  If you see lots of duplicate ACK/NAK,
  * then adding those ops would be a good idea.
- */ 
+ */
 
 // TODO: Should add some feedback from the amount of PIO send credits available
 //       Each op processed takes one credit to send
@@ -3084,20 +3084,24 @@ void fi_opx_hfi_rx_reliablity_process_requests(struct fid_ep *ep, int max_to_sen
 		// Detect if we Coalesced any packets since responding to the first ping, then respond to them here
 		if (cur_op->psn_count < cur_op->psn_count_coalesce) {
 
-			FI_DBG_TRACE(fi_opx_global.prov, FI_LOG_EP_DATA, "Processing Rx Ping, psn=%lu count=%lu key=%lu\n", 
-			cur_op->key.psn_start, cur_op->psn_count, cur_op->key.key);
+			FI_DBG_TRACE(fi_opx_global.prov, FI_LOG_EP_DATA,
+				"Processing Rx Ping, psn=%lu count=%lu key=%lu\n",
+				cur_op->key.psn_start, cur_op->psn_count, cur_op->key.key);
 
-				fi_opx_hfi1_rx_reliability_ping(ep, service,
-					cur_op->key.key, cur_op->psn_count_coalesce, cur_op->key.psn_start,
-					cur_op->slid, cur_op->rx);
-			}
-			
+			fi_opx_hfi1_rx_reliability_ping(ep, service,
+				cur_op->key.key, cur_op->psn_count_coalesce,
+				cur_op->key.psn_start,
+				cur_op->slid, cur_op->rx);
+		}
+
 		HASH_DEL(service->pending_rx_reliability_ops_hashmap, cur_op);
 		OPX_BUF_FREE(cur_op);
 		pending_op_count++;
 
 		if (OFI_UNLIKELY(pending_op_count >= max_to_send)) {
-			FI_DBG_TRACE(fi_opx_global.prov, FI_LOG_EP_DATA, "WARNING: Should not break here pending_op_count=%i\n", pending_op_count);
+			FI_DBG_TRACE(fi_opx_global.prov, FI_LOG_EP_DATA,
+				"WARNING: Should not break here pending_op_count=%i\n",
+				pending_op_count);
 			break;
 		}
 	}
@@ -3130,7 +3134,7 @@ ssize_t fi_opx_hfi1_tx_reliability_inject_shm (struct fid_ep *ep,
 #endif
 
 	/* Make sure the connection to remote EP exists. */
-	rc = fi_opx_shm_dynamic_tx_connect(1, opx_ep, (unsigned)u32_reliability_rx, hfi1_unit);
+	rc = fi_opx_shm_dynamic_tx_connect(OPX_INTRANODE_TRUE, opx_ep, (unsigned)u32_reliability_rx, hfi1_unit);
 	if (OFI_UNLIKELY(rc)) {
 		return -FI_EAGAIN;
 	}
@@ -3161,7 +3165,7 @@ ssize_t fi_opx_hfi1_tx_reliability_inject_shm (struct fid_ep *ep,
 
 	hdr->qw[2] = model.hdr.qw[2];
 
-	hdr->qw[3] = model.hdr.qw[3]; 
+	hdr->qw[3] = model.hdr.qw[3];
 
 	hdr->qw[4] = model.hdr.qw[4];
 
@@ -3230,7 +3234,7 @@ struct fi_opx_reliability_resynch_flow * fi_opx_reliability_resynch_flow_init (
 
 __OPX_FORCE_INLINE__
 void fi_opx_reliability_resynch_tx_flow_reset (struct fi_opx_ep *opx_ep,
-		struct fi_opx_reliability_service * service,	
+		struct fi_opx_reliability_service * service,
 		struct fi_opx_reliability_client_state * state,
 		union fi_opx_reliability_service_flow_key tx_key)
 {
@@ -3243,7 +3247,7 @@ void fi_opx_reliability_resynch_tx_flow_reset (struct fi_opx_ep *opx_ep,
 	itr = fi_opx_rbt_find(state->tx_flow_rbtree, (void*)tx_key.value);
 	if (itr) {
 		/* When the Server does its first transmit, this will cause the Server to */
-		/* initiate a handshake with the Client.                                  */ 
+		/* initiate a handshake with the Client.                                  */
 		rbtErase(state->tx_flow_rbtree, itr);
 
 		FI_DBG_TRACE(fi_opx_global.prov, FI_LOG_EP_DATA,
@@ -3314,7 +3318,7 @@ void fi_opx_hfi1_rx_reliability_resynch (struct fid_ep *ep,
 		.rx = origin_reliability_rx
 	};
 
-	/* 
+	/*
 	 * INTRA-NODE:
 	 * Reset all SHM related reliability protocol data retained by this
 	 * Server EP about the remote Client EP.
@@ -3344,11 +3348,11 @@ void fi_opx_hfi1_rx_reliability_resynch (struct fid_ep *ep,
 			rx_key.value, tx_key.dlid, hdr->service.origin_reliability_rx,
 			(uint8_t)hfi_unit, origin_reliability_rx,
 			FI_OPX_HFI_UD_OPCODE_RELIABILITY_RESYNCH_ACK);
-		
+
 		return;
 	}
 
-	/* 
+	/*
 	 * INTER-NODE:
 	 * Reset all rx/tx related reliability protocol data retained by this
 	 * Server EP about the remote Client EP.
@@ -3410,7 +3414,7 @@ void fi_opx_hfi1_rx_reliability_resynch (struct fid_ep *ep,
 	/* Reset all (tx) related reliability protocol data */
 	fi_opx_reliability_resynch_tx_flow_reset(opx_ep, service, state, tx_key);
 
-	/* 
+	/*
 	 * When a DAOS Server is configured for multiple Engine instances, each Engine
 	 * instance can act as both a server and client EP.  If this is so, then set
 	 * the resynch_client_ep flag to indicate that a reset of all (tx) related
@@ -3433,7 +3437,7 @@ void fi_opx_hfi1_rx_reliability_resynch (struct fid_ep *ep,
 			tx_local_client_key.value);
 	}
 
-	/* 
+	/*
 	 * Create record of the RESYNCH operation being completed for all (rx) & (tx)
 	 * related reliability protocol data.
 	 */
@@ -3552,7 +3556,7 @@ ssize_t fi_opx_reliability_do_remote_ep_resynch(struct fid_ep *ep,
 				opx_shm_daos_rank_index(opx_ep->daos_info.rank, opx_ep->daos_info.rank_inst) :
 				dest_addr.hfi1_rx;
 
-		/* 
+		/*
 		 * Check whether RESYNCH request has been received from the remote EP.
 		 * If so, then this is a Server EP amd there is nothing to be done.
 		 */
@@ -3566,7 +3570,7 @@ ssize_t fi_opx_reliability_do_remote_ep_resynch(struct fid_ep *ep,
 			return FI_SUCCESS;
 		}
 
-		/* 
+		/*
 		 * Check whether a RESYNCH request was already received from the remote EP.
 		 * If so, then this is a Server EP; otherwise this is a Client EP.
 		 */
@@ -3579,7 +3583,7 @@ ssize_t fi_opx_reliability_do_remote_ep_resynch(struct fid_ep *ep,
 				(struct fi_opx_reliability_resynch_flow **) fi_opx_rbt_value_ptr(
 						opx_ep->reliability->state.flow_rbtree_resynch, rx_itr
 					);
- 
+
 			struct fi_opx_reliability_resynch_flow * resynch_flow = *value_ptr;
 			if (resynch_flow->client_ep && resynch_flow->remote_ep_resynch_completed) {
 				FI_DBG_TRACE(fi_opx_global.prov, FI_LOG_EP_DATA,
@@ -3593,7 +3597,7 @@ ssize_t fi_opx_reliability_do_remote_ep_resynch(struct fid_ep *ep,
 			}
 		}
 
-		/* 
+		/*
 		 * Check whether packets have already been sent to the dest EP.  If not,
 		 * then send RESYNCH request to the dest Server EP.  This causes the dest
 		 * Server EP to resynch all SHM related data that it maintains associated
@@ -3602,7 +3606,7 @@ ssize_t fi_opx_reliability_do_remote_ep_resynch(struct fid_ep *ep,
 		if (!resynch_rcvd ||
 			!opx_ep->tx->shm.fifo_segment[rx_index] ||
 			!opx_ep->tx->shm.connection[rx_index].inuse) {
-			rc = fi_opx_shm_dynamic_tx_connect(1, opx_ep, rx_index, dest_addr.hfi1_unit);
+			rc = fi_opx_shm_dynamic_tx_connect(OPX_INTRANODE_TRUE, opx_ep, rx_index, dest_addr.hfi1_unit);
 			if (OFI_UNLIKELY(rc)) {
 				return -FI_EAGAIN;
 			}
@@ -3623,7 +3627,7 @@ ssize_t fi_opx_reliability_do_remote_ep_resynch(struct fid_ep *ep,
 	} else {
 		/* INTER-NODE */
 
-		/* 
+		/*
 		 * Check whether a RESYNCH request was already received from the remote EP.
 		 * If so, then this is a Server EP; otherwise this is a Client EP.
 		 */
@@ -3643,7 +3647,7 @@ ssize_t fi_opx_reliability_do_remote_ep_resynch(struct fid_ep *ep,
 					tx_key.value, resynch_flow->resynch_counter);
 				return FI_SUCCESS;
 			} else {
-				/* 
+				/*
 				 * When a DAOS Server is configured for multiple Engine instances, each
 				 * Engine instance can act as both a server and client EP.  If this is so,
 				 * then the resynch_client_ep flag will indicate whether a reset of all


### PR DESCRIPTION
Remove busy-waiting/sleeping while SHM FIFO has not been created/initialized. Cast result of CPU_ISSET() to a uint64_t to fix a coverity warning about potentially left-shifting by more than 31 bits. Whitespace/formatting fixups.

### PR Details
This should fix most of, if not all of, the 37 "Waiting while holding a lock" Coverity scan defects (numerous CIDs).

It should also address the bad bit-shift operation (CID 376792) defect.

Lots of whitespace/formatting changes (removing trailing whitespace, proper tab use).