### PR TITLE
fabtests: Add backlog > 0 to listen call

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -3804,7 +3804,7 @@ int ft_sock_listen(char *node, char *service)
 		goto out;
 	}
 
-	ret = listen(listen_sock, 0);
+	ret = listen(listen_sock, 511);
 	if (ret)
 		perror("listen");
 

--- a/fabtests/component/sock_test.c
+++ b/fabtests/component/sock_test.c
@@ -113,7 +113,7 @@ static int start_server(void)
 		goto close;
 	}
 
-	ret = listen(listen_sock, 0);
+	ret = listen(listen_sock, 511);
 	if (ret) {
 		FT_PRINTERR("listen", -errno);
 		goto close;


### PR DESCRIPTION
Currently the listen() call has a 0 value for backlog. This causes syn (synchronize) flooding on port 3000. Port 3000 is used by fabtests for OOO (out of bounds) exchanges.

This call needs to have a non-zero positive value for backlog to prevent this flooding. Setting the backlog is necessary so that it is changeable by the user and not hidden values that users must set at the kernel level. The kernel variables are called net.ipv4.tcp_max_syn_backlog, and net.core.somaxconn to fix the issue instead. However, it is encouraged that a user make sure all of these values are set appropriately as well as using an adequate size for backlog in the listen call.