### PR TITLE
github/workflows: Add needed permissions

### DIFF
--- a/.github/workflows/gh-man.yaml
+++ b/.github/workflows/gh-man.yaml
@@ -14,7 +14,7 @@ jobs:
         name: GH Man Page Updater
         runs-on: ubuntu-latest
         permissions:
-          contents: read
+          contents: write
           pull-requests: write
         steps:
           - name: Debug information

--- a/.github/workflows/nroff-elves.yaml
+++ b/.github/workflows/nroff-elves.yaml
@@ -12,7 +12,7 @@ jobs:
         name: The Nroff Elves
         runs-on: ubuntu-latest
         permissions:
-          contents: read
+          contents: write
           pull-requests: write
         steps:
           - name: Debug information


### PR DESCRIPTION
The man page converter and updater need content write permission to perform push operation.