### PR TITLE
prov/efa: Fix error handling in efa_rdm_cq_poll_ibv_cq

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_cq.c
+++ b/prov/efa/src/rdm/efa_rdm_cq.c
@@ -381,7 +381,7 @@ void efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq)
 
 	if (err && err != ENOENT) {
 		err = err > 0 ? err : -err;
-		prov_errno = efa_rdm_cq_get_prov_errno(ibv_cq->ibv_cq_ex);
+		prov_errno = ibv_wc_read_vendor_err(ibv_cq->ibv_cq_ex);
 		EFA_WARN(FI_LOG_CQ, "Unexpected error when polling ibv cq, err: %s (%zd) prov_errno: %s (%d)\n", fi_strerror(err), err, efa_strerror(prov_errno), prov_errno);
 		efa_show_help(prov_errno);
 		err_entry = (struct fi_cq_err_entry) {


### PR DESCRIPTION
When ibv_start_poll or ibv_next_poll return error, it may read a cqe from a destroyed EP (QP). In this case we shouldn't call efa_rdm_cq_get_prov_errno, which may use a freed EP from the pkt_entry (wr_id) and cause segmentation fault.