### PR TITLE
prov/efa: Remove superfluous instances of `__func__`

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_atomic.c
+++ b/prov/efa/src/rdm/efa_rdm_atomic.c
@@ -247,9 +247,8 @@ efa_rdm_atomic_writemsg(struct fid_ep *ep,
 	void *shm_desc[EFA_RDM_IOV_LIMIT] = {NULL};
 	int err;
 
-	EFA_DBG(FI_LOG_EP_DATA,
-	       "%s: iov_len: %lu flags: %lx\n",
-	       __func__, ofi_total_ioc_cnt(msg->msg_iov, msg->iov_count), flags);
+	EFA_DBG(FI_LOG_EP_DATA, "iov_len: %lu flags: %lx\n",
+		ofi_total_ioc_cnt(msg->msg_iov, msg->iov_count), flags);
 
 	efa_rdm_ep = container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid.fid);
 	err = efa_rdm_ep_cap_check_atomic(efa_rdm_ep);
@@ -295,8 +294,8 @@ efa_rdm_atomic_writev(struct fid_ep *ep,
 	msg.context = context;
 	msg.data = 0;
 
-	EFA_DBG(FI_LOG_EP_DATA, "%s total_count=%ld atomic_op=%d\n", __func__,
-	       ofi_total_ioc_cnt(iov, count), msg.op);
+	EFA_DBG(FI_LOG_EP_DATA, "total_count=%ld atomic_op=%d\n",
+		ofi_total_ioc_cnt(iov, count), msg.op);
 
 	return efa_rdm_atomic_writemsg(ep, &msg, 0);
 }
@@ -337,8 +336,8 @@ efa_rdm_atomic_readwritemsg(struct fid_ep *ep,
 		return -errno;
 	}
 
-	EFA_DBG(FI_LOG_EP_DATA, "%s total_len=%ld atomic_op=%d\n", __func__,
-	       ofi_total_ioc_cnt(msg->msg_iov, msg->iov_count), msg->op);
+	EFA_DBG(FI_LOG_EP_DATA, "total_len=%ld atomic_op=%d\n",
+		ofi_total_ioc_cnt(msg->msg_iov, msg->iov_count), msg->op);
 
 	efa_rdm_ep = container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid.fid);
 	err = efa_rdm_ep_cap_check_atomic(efa_rdm_ep);
@@ -444,9 +443,8 @@ efa_rdm_atomic_compwritemsg(struct fid_ep *ep,
 		return -errno;
 	}
 
-	EFA_DBG(FI_LOG_EP_DATA,
-	       "%s: iov_len: %lu flags: %lx\n",
-	       __func__, ofi_total_ioc_cnt(msg->msg_iov, msg->iov_count), flags);
+	EFA_DBG(FI_LOG_EP_DATA, "iov_len: %lu flags: %lx\n",
+		ofi_total_ioc_cnt(msg->msg_iov, msg->iov_count), flags);
 
 	efa_rdm_ep = container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid.fid);
 	err = efa_rdm_ep_cap_check_atomic(efa_rdm_ep);

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -1512,14 +1512,14 @@ static int efa_rdm_ep_setopt(fid_t fid, int level, int optname,
 		 */
 		if (efa_rdm_ep->base_ep.efa_qp_enabled) {
 			EFA_WARN(FI_LOG_EP_CTRL,
-				"The option FI_OPT_EFA_RNR_RETRY is required \
-				to be set before EP enabled %s\n", __func__);
+				"The option FI_OPT_EFA_RNR_RETRY is required "
+				"to be set before EP enabled\n");
 			return -FI_EINVAL;
 		}
 
 		if (!efa_domain_support_rnr_retry_modify(efa_rdm_ep_domain(efa_rdm_ep))) {
 			EFA_WARN(FI_LOG_EP_CTRL,
-				"RNR capability is not supported %s\n", __func__);
+				"RNR capability is not supported\n");
 			return -FI_ENOSYS;
 		}
 		efa_rdm_ep->base_ep.rnr_retry = *(size_t *)optval;
@@ -1580,8 +1580,7 @@ static int efa_rdm_ep_setopt(fid_t fid, int level, int optname,
 		efa_rdm_ep->write_in_order_aligned_128_bytes = *(bool *)optval;
 		break;
 	default:
-		EFA_WARN(FI_LOG_EP_CTRL,
-			"Unknown endpoint option %s\n", __func__);
+		EFA_WARN(FI_LOG_EP_CTRL, "Unknown endpoint option\n");
 		return -FI_ENOPROTOOPT;
 	}
 
@@ -1662,8 +1661,7 @@ static int efa_rdm_ep_getopt(fid_t fid, int level, int optname, void *optval,
 		*optlen = sizeof(bool);
 		break;
 	default:
-		EFA_WARN(FI_LOG_EP_CTRL,
-			"Unknown endpoint option %s\n", __func__);
+		EFA_WARN(FI_LOG_EP_CTRL, "Unknown endpoint option\n");
 		return -FI_ENOPROTOOPT;
 	}
 

--- a/prov/efa/src/rdm/efa_rdm_ep_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_utils.c
@@ -189,7 +189,7 @@ struct efa_rdm_ope *efa_rdm_ep_alloc_rxe(struct efa_rdm_ep *ep, fi_addr_t addr, 
 		break;
 	default:
 		EFA_WARN(FI_LOG_EP_CTRL,
-			"Unknown operation while %s\n", __func__);
+			"Unknown operation for RX entry allocation\n");
 		assert(0 && "Unknown operation");
 	}
 

--- a/prov/efa/src/rdm/efa_rdm_msg.c
+++ b/prov/efa/src/rdm/efa_rdm_msg.c
@@ -915,9 +915,9 @@ ssize_t efa_rdm_msg_generic_recv(struct efa_rdm_ep *ep, const struct fi_msg *msg
 	efa_perfset_start(ep, perf_efa_recv);
 
 	EFA_DBG(FI_LOG_EP_DATA,
-	       "%s: iov_len: %lu tag: %lx ignore: %lx op: %x flags: %lx\n",
-	       __func__, ofi_total_iov_len(msg->msg_iov, msg->iov_count), tag, ignore,
-	       op, flags);
+		"iov_len: %lu tag: %lx ignore: %lx op: %x flags: %lx\n",
+		ofi_total_iov_len(msg->msg_iov, msg->iov_count),
+		tag, ignore, op, flags);
 
 	efa_rdm_tracepoint(recv_begin_msg_context, (size_t) msg->context, (size_t) msg->addr);
 

--- a/prov/efa/src/rdm/efa_rdm_pke_cmd.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_cmd.c
@@ -696,9 +696,8 @@ void efa_rdm_pke_handle_rx_error(struct efa_rdm_pke *pkt_entry, int err, int pro
 	} else if (pkt_entry->ope->type == EFA_RDM_RXE) {
 		efa_rdm_rxe_handle_error(pkt_entry->ope, err, prov_errno);
 	} else {
-		EFA_WARN(FI_LOG_CQ,
-		"%s unknown x_entry type %d\n",
-			__func__, pkt_entry->ope->type);
+		EFA_WARN(FI_LOG_CQ, "unknown RDM operation entry type encountered: %d\n",
+			pkt_entry->ope->type);
 		assert(0 && "unknown x_entry state");
 		efa_base_ep_write_eq_error(&ep->base_ep, err, prov_errno);
 	}


### PR DESCRIPTION
This also tweaks some of the logging messages themselves.