### PR TITLE
contrib/intel/jenkins: Add new AWS CI to Intel CI's opt out path

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -316,7 +316,7 @@ def skip() {
   }
 
   echo "Changeset is: ${changeStrings.toArray()}"
-  if (changeStrings.toArray().every { it =~ /(?:fabtests\/pytests|man|prov\/efa|prov\/opx).*$/ }) {
+  if (changeStrings.toArray().every { it =~ /(?:fabtests\/pytests|man|prov\/efa|prov\/opx|contrib\/aws).*$/ }) {
     echo "DONT RUN!"
     return true
   }


### PR DESCRIPTION
No need to run Intel CI when all of a PR's code changes are to contrib/aws