### PR TITLE
fabtests/rdm_tagged_peek: Align rx's msg_order with tx's

### DIFF
--- a/fabtests/functional/rdm_tagged_peek.c
+++ b/fabtests/functional/rdm_tagged_peek.c
@@ -352,6 +352,7 @@ int main(int argc, char **argv)
 
 	hints->domain_attr->resource_mgmt = FI_RM_ENABLED;
 	hints->tx_attr->msg_order = FI_ORDER_SAS;
+	hints->rx_attr->msg_order = FI_ORDER_SAS;
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_TAGGED;
 	hints->mode = FI_CONTEXT;


### PR DESCRIPTION
The tx_attr and the sender should align with the rx_attr at the receiver. For peek test, the receiver can request messages out of order, but the tag matching has to be done in order.