### PR TITLE
prov/efa: Use srx lock from domain directly

### DIFF
--- a/prov/efa/src/efa_cntr.h
+++ b/prov/efa/src/efa_cntr.h
@@ -23,20 +23,5 @@ void efa_cntr_report_rx_completion(struct util_ep *ep, uint64_t flags);
 
 void efa_cntr_report_error(struct util_ep *ep, uint64_t flags);
 
-static inline
-void *efa_cntr_get_srx_ctx(struct fid_cntr *cntr_fid)
-{
-	struct efa_cntr *efa_cntr;
-	struct fid_peer_srx *srx = NULL;
-
-	efa_cntr = container_of(cntr_fid, struct efa_cntr, util_cntr.cntr_fid);
-
-	srx = efa_cntr->util_cntr.domain->srx;
-	if (!srx)
-		return NULL;
-
-	return srx->ep_fid.fid.context;
-}
-
 #endif
 

--- a/prov/efa/src/rdm/efa_rdm_cq.c
+++ b/prov/efa/src/rdm/efa_rdm_cq.c
@@ -401,13 +401,13 @@ static ssize_t efa_rdm_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t coun
 {
 	struct efa_rdm_cq *cq;
 	ssize_t ret;
-	struct util_srx_ctx *srx_ctx;
+	struct efa_domain *domain;
 
 	cq = container_of(cq_fid, struct efa_rdm_cq, util_cq.cq_fid.fid);
 
-	srx_ctx = cq->util_cq.domain->srx->ep_fid.fid.context;
+	domain = container_of(cq->util_cq.domain, struct efa_domain, util_domain);
 
-	ofi_genlock_lock(srx_ctx->lock);
+	ofi_genlock_lock(&domain->srx_lock);
 
 	if (cq->shm_cq) {
 		fi_cq_read(cq->shm_cq, NULL, 0);
@@ -426,7 +426,7 @@ static ssize_t efa_rdm_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t coun
 	ret = ofi_cq_readfrom(&cq->util_cq.cq_fid, buf, count, src_addr);
 
 out:
-	ofi_genlock_unlock(srx_ctx->lock);
+	ofi_genlock_unlock(&domain->srx_lock);
 
 	return ret;
 }


### PR DESCRIPTION
Currently, efa_rdm_cq_readfrom access srx_lock
via util_domain->srx->peer_srx.ep_fid.fid.context. However, srx is destroyed during ep close and may not be accessible if a cq read is called after ep close. This patch fixes this issue by accessing the srx lock via efa_domain directly, as the lock is created by efa domain and cannot be destroyed before domain close.

Same issue applies to efa cntr.