### PR TITLE
prov/efa: Fix `cq_data` data type

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_pke_req.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_req.c
@@ -170,7 +170,7 @@ uint32_t *efa_rdm_pke_get_req_connid_ptr(struct efa_rdm_pke *pkt_entry)
  * @return
  * an integer
  */
-int64_t efa_rdm_pke_get_req_cq_data(struct efa_rdm_pke *pkt_entry)
+uint64_t efa_rdm_pke_get_req_cq_data(struct efa_rdm_pke *pkt_entry)
 {
 	char *opt_hdr;
 	struct efa_rdm_base_hdr *base_hdr;

--- a/prov/efa/src/rdm/efa_rdm_pke_req.h
+++ b/prov/efa/src/rdm/efa_rdm_pke_req.h
@@ -17,7 +17,7 @@ void efa_rdm_pke_init_req_hdr_common(struct efa_rdm_pke *pkt_entry,
 
 void *efa_rdm_pke_get_req_raw_addr(struct efa_rdm_pke *pkt_entry);
 
-int64_t efa_rdm_pke_get_req_cq_data(struct efa_rdm_pke *pkt_entry);
+uint64_t efa_rdm_pke_get_req_cq_data(struct efa_rdm_pke *pkt_entry);
 
 uint32_t *efa_rdm_pke_get_req_connid_ptr(struct efa_rdm_pke *pkt_entry);
 

--- a/prov/efa/src/rdm/efa_rdm_protocol.h
+++ b/prov/efa/src/rdm/efa_rdm_protocol.h
@@ -406,7 +406,7 @@ struct efa_rdm_req_opt_raw_addr_hdr {
 };
 
 struct efa_rdm_req_opt_cq_data_hdr {
-	int64_t cq_data;
+	uint64_t cq_data;
 };
 
 struct efa_rdm_req_opt_connid_hdr {


### PR DESCRIPTION
AFAICT, This field only corresponds to `fi_cq_tagged_entry.data`, which is a `uint64_t`.