### PR TITLE
fabtests/efa: reset error completion entry for each fi_cq_readerr call

### DIFF
--- a/fabtests/prov/efa/src/rdm_rnr_read_cq_error.c
+++ b/fabtests/prov/efa/src/rdm_rnr_read_cq_error.c
@@ -41,8 +41,6 @@
 
 static int rnr_read_cq_error(void)
 {
-	struct fi_cq_data_entry comp;
-	struct fi_cq_err_entry comp_err = {0};
 	int total_send, expected_rnr_error;
 	int ret, i, cnt, rnr_flag;
 	const char *prov_errmsg;
@@ -74,6 +72,9 @@ static int rnr_read_cq_error(void)
 
 	cnt = total_send;
 	do {
+		struct fi_cq_data_entry comp = {0};
+		struct fi_cq_err_entry comp_err = {0};
+
 		ret = fi_cq_read(txcq, &comp, 1);
 		if (ret == 1) {
 			cnt--;


### PR DESCRIPTION
Currently, rdm_rnr_read_cq_error.c reuse the same comp_err between different fi_cq_readerr, which is wrong because the err_entry has fields as both input and output. The outputted err_entry fields cannot be used as the input for the next call because some of them will be invalid, such as err_entry.err_data. Same issue applies to the completion entry for fi_cq_read.

This patch fixes this issue by declaring comp and comp_err within the block that calls fi_cq_read and fi_cq_readerr.