### PR TITLE
prov/shm: fix atomic read

### DIFF
--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -652,7 +652,7 @@ static void smr_do_atomic(void *src, struct ofi_mr *dst_mr, void *dst,
 	}
 
 	if (flags & SMR_RMA_REQ)
-		memcpy(src, op == FI_ATOMIC_READ ? tmp_dst : tmp_result,
+		memcpy(src, op == FI_ATOMIC_READ ? cpy_dst : tmp_result,
 		       cnt * ofi_datatype_size(datatype));
 
 	if (cpy_dst != dst) {


### PR DESCRIPTION
When atomic hmem support was added, a bounce buffer was added to act as a staging buffer for the atomic buffer since we can't access the hmem memory directly. The buffer for FI_ATOMIC_READ wasn't updated appropriately resulting in the incorrect data being copied back to the sender.