### PR TITLE
[v1.21.x] fabtests/efa: reset error completion entry for each fi_cq_r…

### DIFF
--- a/fabtests/prov/efa/src/rdm_rnr_read_cq_error.c
+++ b/fabtests/prov/efa/src/rdm_rnr_read_cq_error.c
@@ -41,8 +41,6 @@
 
 static int rnr_read_cq_error(void)
 {
-	struct fi_cq_data_entry comp;
-	struct fi_cq_err_entry comp_err = {0};
 	int total_send, expected_rnr_error;
 	int ret, i, cnt, rnr_flag;
 	const char *prov_errmsg;
@@ -74,6 +72,9 @@ static int rnr_read_cq_error(void)
 
 	cnt = total_send;
 	do {
+		struct fi_cq_data_entry comp = {0};
+		struct fi_cq_err_entry comp_err = {0};
+
 		ret = fi_cq_read(txcq, &comp, 1);
 		if (ret == 1) {
 			cnt--;


### PR DESCRIPTION
backport https://github.com/ofiwg/libfabric/pull/10006