### PR TITLE
prov/efa: Correct the order of arguments in declaration

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_pke_utils.h
+++ b/prov/efa/src/rdm/efa_rdm_pke_utils.h
@@ -61,8 +61,8 @@ size_t efa_rdm_pke_get_payload_offset(struct efa_rdm_pke *pkt_entry);
 
 ssize_t efa_rdm_pke_init_payload_from_ope(struct efa_rdm_pke *pke,
 					  struct efa_rdm_ope *ope,
-					  size_t segment_offset,
 					  size_t payload_offset,
+					  size_t segment_offset,
 					  size_t data_size);
 
 ssize_t efa_rdm_pke_copy_payload_to_ope(struct efa_rdm_pke *pke,


### PR DESCRIPTION
The order of payload_offset and segment_offset is flipped in the declaration of efa_rdm_pke_init_payload_from_ope. It didn't introduce trouble today because these two arguments have the same data type.