### PR TITLE
prov/tcp: Add fi_set_val support for active/passive port range

### DIFF
--- a/include/rdma/fi_ext.h
+++ b/include/rdma/fi_ext.h
@@ -81,6 +81,7 @@ enum {
 enum {
 	/* null terminated string, <low port>-<high port> */
 	FI_TCP_DOMAIN_ACTIVE_PORT_RANGE = -FI_PROV_SPECIFIC_TCP,
+	FI_TCP_FABRIC_PASSIVE_PORT_RANGE,
 };
 
 struct fi_fid_export {

--- a/include/rdma/fi_ext.h
+++ b/include/rdma/fi_ext.h
@@ -78,6 +78,11 @@ enum {
 	FI_OPT_EFA_WRITE_IN_ORDER_ALIGNED_128_BYTES, /* bool */
 };
 
+enum {
+	/* null terminated string, <low port>-<high port> */
+	FI_TCP_DOMAIN_ACTIVE_PORT_RANGE = -FI_PROV_SPECIFIC_TCP,
+};
+
 struct fi_fid_export {
 	struct fid **fid;
 	uint64_t flags;

--- a/man/fi_tcp.7.md
+++ b/man/fi_tcp.7.md
@@ -90,6 +90,17 @@ show all environment variables defined for the tcp provider.
   through the standard socket APIs (i.e. connect, accept, send, recv).
   Default: disabled.
 
+The tcp provider also supports domain parameter via fi_set_val.
+
+*FI_TCP_DOMAIN_ACTIVE_PORT_RANGE*
+: Limit active connections to a TCP port range for a domain.  Value is
+  struct xnet_port_range *.  To disable, set hight and low to 0.
+  If an active connection's source address has a port number, it will
+  be used instead of the port range.
+  Sample:
+    struct xnet_port_range range = { .high = 5000, .low = 6000 };
+    fi_set_val(&domain->fid, FI_TCP_DOMAIN_ACTIVE_PORT_RANGE, &range);
+
 # NOTES
 
 The tcp provider supports both msg and rdm endpoints directly.  Support

--- a/man/fi_tcp.7.md
+++ b/man/fi_tcp.7.md
@@ -90,7 +90,14 @@ show all environment variables defined for the tcp provider.
   through the standard socket APIs (i.e. connect, accept, send, recv).
   Default: disabled.
 
-The tcp provider also supports domain parameter via fi_set_val.
+The tcp provider also supports setting parameters via fi_set_val.
+
+*FI_TCP_FABRIC_PASSIVE_PORT_RANGE*
+: Set values corresponding to FI_TCP_PORT_LOW_RANGE and FI_TCP_PORT_HIGH_RANGE.
+  Use fabric object with struct xnet_port_range * set with desired values.
+  Sample:
+    struct xnet_port_range range = { .low = 9000, .high = 9100 };
+    fi_set_val(&fabric->fid, FI_TCP_FABRIC_PASSIVE_PORT_RANGE, &range);
 
 *FI_TCP_DOMAIN_ACTIVE_PORT_RANGE*
 : Limit active connections to a TCP port range for a domain.  Value is
@@ -98,7 +105,7 @@ The tcp provider also supports domain parameter via fi_set_val.
   If an active connection's source address has a port number, it will
   be used instead of the port range.
   Sample:
-    struct xnet_port_range range = { .high = 5000, .low = 6000 };
+    struct xnet_port_range range = { .low = 5000, .high = 6000 };
     fi_set_val(&domain->fid, FI_TCP_DOMAIN_ACTIVE_PORT_RANGE, &range);
 
 # NOTES

--- a/prov/tcp/src/xnet.h
+++ b/prov/tcp/src/xnet.h
@@ -171,6 +171,8 @@ void xnet_connect_done(struct xnet_ep *ep);
 void xnet_req_done(struct xnet_ep *ep);
 int xnet_send_cm_msg(struct xnet_ep *ep);
 void xnet_uring_req_done(struct xnet_ep *ep, int res);
+int xnet_bind_to_port_range(SOCKET sock, void* src_addr, size_t addrlen,
+			    struct xnet_port_range *range);
 
 /* Inject buffer space is included */
 union xnet_hdrs {
@@ -471,6 +473,7 @@ struct xnet_domain {
 	struct util_domain		util_domain;
 	struct xnet_progress		progress;
 	enum fi_ep_type			ep_type;
+	struct xnet_port_range		active_ports;
 };
 
 static inline struct xnet_progress *xnet_ep2_progress(struct xnet_ep *ep)

--- a/prov/tcp/src/xnet_init.c
+++ b/prov/tcp/src/xnet_init.c
@@ -91,9 +91,9 @@ static void xnet_init_env(void)
 			"Specify interface name");
 
 	fi_param_define(&xnet_prov, "port_low_range", FI_PARAM_INT,
-			"define port low range");
+			"define passive port low range");
 	fi_param_define(&xnet_prov, "port_high_range", FI_PARAM_INT,
-			"define port high range");
+			"define passive port high range");
 	fi_param_get_int(&xnet_prov, "port_high_range", &xnet_ports.high);
 	fi_param_get_int(&xnet_prov, "port_low_range", &xnet_ports.low);
 
@@ -103,7 +103,7 @@ static void xnet_init_env(void)
 	if (xnet_ports.low < 0 || xnet_ports.high < 0 ||
 	    xnet_ports.low > xnet_ports.high) {
 		FI_WARN(&xnet_prov, FI_LOG_EP_CTRL,"User provided "
-			"port range invalid. Ignoring. \n");
+			"passive port range invalid. Ignoring. \n");
 		xnet_ports.low  = 0;
 		xnet_ports.high = 0;
 	}


### PR DESCRIPTION
There is a need (e.g. firewall rule) to limit TCP ports used for active connections.  Add FI_TCP_EGRESS_PORT_LOW_RANGE and FI_TCP_EGRESS_PORT_HIGH_RANGE environment variables to specify the port range for active connections.  If a port is specified for the active connection, it will be used over the specified range. This is the same behavior as passive connection.

I don't understand the check !ofi_is_any_addr(info->src_addr) in the original code.  It seems there is a possibility of INADDR_ANY with a port number and continue to call bind.  Anyhow, this is my best interpretation.