### PR TITLE
contrib/aws: Modify Windows Test AMI

### DIFF
--- a/contrib/aws/common.groovy
+++ b/contrib/aws/common.groovy
@@ -101,7 +101,7 @@ def get_single_node_windows_test_stage(stage_name) {
                                 . venv/bin/activate;
                                 cd PortaFiducia/scripts;
                                 export PULL_REQUEST_ID=${env.CHANGE_ID};
-                                env AWS_DEFAULT_REGION=us-west-2 ./test_orchestrator_windows.py --ci public --s3-bucket-name libfabric-ci-windows-prod-test-output --pull-request-id ${env.CHANGE_ID};
+                                env AWS_DEFAULT_REGION=us-west-2 ./test_orchestrator_windows.py --ci public --s3-bucket-name libfabric-ci-windows-prod-test-output --ami-id ami-02b1cbf380f113c31 --pull-request-id ${env.CHANGE_ID};
                             """,
                             returnStatus: true
                          )


### PR DESCRIPTION
Switch the Windows Test to use an AMI owned by the account running Jenkins

This will need to be backported to all branches we wish to run Windows tests against, or they will fail in ~90 days.