### PR TITLE
02 of 10 LNX series - Minor fix to ofi_check_fabric_attr()

### DIFF
--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -406,6 +406,7 @@ int ofi_check_fabric_attr(const struct fi_provider *prov,
 	 * user's hints, if one is specified.
 	 */
 	if (prov_attr->prov_name && user_attr->prov_name &&
+		user_attr->prov_name[0] != '^' &&
 	    !strcasestr(user_attr->prov_name, prov_attr->prov_name)) {
 		FI_INFO(prov, FI_LOG_CORE,
 			"Requesting provider %s, skipping %s\n",


### PR DESCRIPTION
util: Consider provider exclusion

When checking fabric attributes with ofi_check_fabric_attr() make sure to
consider provider exclusion.

When checking to see if a provider name is given, only consider ones which
are not excluded using the '^' character.

Signed-off-by: Amir Shehata <shehataa@ornl.gov>
