### PR TITLE
08 of 10 LNX series - Add the FI_PEER to the SHM capabilities

### DIFF
--- a/include/rdma/providers/fi_peer.h
+++ b/include/rdma/providers/fi_peer.h
@@ -177,12 +177,21 @@ struct fi_peer_rx_entry {
 	struct iovec *iov;
 };
 
+struct fi_peer_match {
+	fi_addr_t addr;
+	uint64_t tag;
+	size_t size;
+	void *context;
+};
+
 struct fi_ops_srx_owner {
 	size_t	size;
-	int	(*get_msg)(struct fid_peer_srx *srx, fi_addr_t addr,
-			size_t size, struct fi_peer_rx_entry **entry);
-	int	(*get_tag)(struct fid_peer_srx *srx, fi_addr_t addr,
-			uint64_t tag, struct fi_peer_rx_entry **entry);
+	int	(*get_msg)(struct fid_peer_srx *srx,
+			   struct fi_peer_match *match,
+			   struct fi_peer_rx_entry **entry);
+	int	(*get_tag)(struct fid_peer_srx *srx,
+			   struct fi_peer_match *match,
+			   struct fi_peer_rx_entry **entry);
 	int	(*queue_msg)(struct fi_peer_rx_entry *entry);
 	int	(*queue_tag)(struct fi_peer_rx_entry *entry);
 	void	(*foreach_unspec_addr)(struct fid_peer_srx *srx,

--- a/include/rdma/providers/fi_peer.h
+++ b/include/rdma/providers/fi_peer.h
@@ -173,8 +173,10 @@ struct fi_peer_rx_entry {
 	size_t count;
 	void **desc;
 	void *peer_context;
+	void *peer_md;
 	void *owner_context;
 	struct iovec *iov;
+	uint32_t match_id;
 };
 
 struct fi_peer_match {
@@ -182,6 +184,7 @@ struct fi_peer_match {
 	uint64_t tag;
 	size_t size;
 	void *context;
+	uint32_t match_id;
 };
 
 struct fi_ops_srx_owner {
@@ -207,6 +210,8 @@ struct fi_ops_srx_peer {
 	int	(*discard_msg)(struct fi_peer_rx_entry *entry);
 	int	(*discard_tag)(struct fi_peer_rx_entry *entry);
 	int	(*addr_match)(fi_addr_t addr, struct fi_peer_match *match);
+	int	(*mem_reg)(struct fid_ep *ep, struct iovec *iov, fi_addr_t addr,
+			   void **md, uint32_t *match_id);
 };
 
 struct fid_peer_srx {

--- a/include/rdma/providers/fi_peer.h
+++ b/include/rdma/providers/fi_peer.h
@@ -197,6 +197,7 @@ struct fi_ops_srx_peer {
 	int	(*start_tag)(struct fi_peer_rx_entry *entry);
 	int	(*discard_msg)(struct fi_peer_rx_entry *entry);
 	int	(*discard_tag)(struct fi_peer_rx_entry *entry);
+	int	(*addr_match)(fi_addr_t addr, struct fi_peer_match *match);
 };
 
 struct fid_peer_srx {

--- a/prov/efa/src/rdm/efa_rdm_msg.c
+++ b/prov/efa/src/rdm/efa_rdm_msg.c
@@ -764,6 +764,7 @@ struct efa_rdm_ope *efa_rdm_msg_alloc_rxe_for_msgrtm(struct efa_rdm_ep *ep,
 	size_t data_size;
 	int ret;
 	int pkt_type;
+	struct fi_peer_match match = {0};
 
 	if ((*pkt_entry_ptr)->alloc_type == EFA_RDM_PKE_FROM_USER_BUFFER) {
 		/* If a pkt_entry is constructred from user supplied buffer,
@@ -782,7 +783,10 @@ struct efa_rdm_ope *efa_rdm_msg_alloc_rxe_for_msgrtm(struct efa_rdm_ep *ep,
 	peer_srx = util_get_peer_srx(ep->peer_srx_ep);
 	data_size = efa_rdm_pke_get_rtm_msg_length(*pkt_entry_ptr);
 
-	ret = peer_srx->owner_ops->get_msg(peer_srx, (*pkt_entry_ptr)->addr, data_size, &peer_rxe);
+	match.addr = (*pkt_entry_ptr)->addr;
+	match.size = data_size;
+
+	ret = peer_srx->owner_ops->get_msg(peer_srx, &match, &peer_rxe);
 
 	if (ret == FI_SUCCESS) { /* A matched rxe is found */
 		rxe = efa_rdm_msg_alloc_matched_rxe_for_rtm(ep, *pkt_entry_ptr, peer_rxe, ofi_op_msg);
@@ -844,12 +848,14 @@ struct efa_rdm_ope *efa_rdm_msg_alloc_rxe_for_tagrtm(struct efa_rdm_ep *ep,
 	struct efa_rdm_ope *rxe;
 	int ret;
 	int pkt_type;
+	struct fi_peer_match match = {0};
 
 	peer_srx = util_get_peer_srx(ep->peer_srx_ep);
 
-	ret = peer_srx->owner_ops->get_tag(peer_srx, (*pkt_entry_ptr)->addr,
-					   efa_rdm_pke_get_rtm_tag(*pkt_entry_ptr),
-					   &peer_rxe);
+	match.addr = (*pkt_entry_ptr)->addr;
+	match.tag = efa_rdm_pke_get_rtm_tag(*pkt_entry_ptr);
+
+	ret = peer_srx->owner_ops->get_tag(peer_srx, &match, &peer_rxe);
 
 	if (ret == FI_SUCCESS) { /* A matched rxe is found */
 		rxe = efa_rdm_msg_alloc_matched_rxe_for_rtm(ep, *pkt_entry_ptr, peer_rxe, ofi_op_tagged);

--- a/prov/shm/src/smr_attr.c
+++ b/prov/shm/src/smr_attr.c
@@ -141,7 +141,7 @@ struct fi_fabric_attr smr_fabric_attr = {
 };
 
 struct fi_info smr_hmem_info = {
-	.caps = SMR_HMEM_TX_CAPS | SMR_HMEM_RX_CAPS | FI_MULTI_RECV | FI_LOCAL_COMM,
+	.caps = SMR_HMEM_TX_CAPS | SMR_HMEM_RX_CAPS | FI_MULTI_RECV | FI_LOCAL_COMM | FI_PEER,
 	.addr_format = FI_ADDR_STR,
 	.tx_attr = &smr_hmem_tx_attr,
 	.rx_attr = &smr_hmem_rx_attr,
@@ -151,7 +151,7 @@ struct fi_info smr_hmem_info = {
 };
 
 struct fi_info smr_info = {
-	.caps = SMR_TX_CAPS | SMR_RX_CAPS | FI_MULTI_RECV | FI_LOCAL_COMM,
+	.caps = SMR_TX_CAPS | SMR_RX_CAPS | FI_MULTI_RECV | FI_LOCAL_COMM | FI_PEER,
 	.addr_format = FI_ADDR_STR,
 	.tx_attr = &smr_tx_attr,
 	.rx_attr = &smr_rx_attr,

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -1420,6 +1420,7 @@ static int smr_ep_ctrl(struct fid *fid, int command, void *arg)
 			if (ret)
 				return ret;
 		} else {
+			ep->util_ep.ep_fid.fid.context = ep->srx;
 			ep->util_ep.ep_fid.msg = &smr_no_recv_msg_ops;
 			ep->util_ep.ep_fid.tagged = &smr_no_recv_tag_ops;
 		}

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -406,6 +406,7 @@ int ofi_check_fabric_attr(const struct fi_provider *prov,
 	 * user's hints, if one is specified.
 	 */
 	if (prov_attr->prov_name && user_attr->prov_name &&
+		user_attr->prov_name[0] != '^' &&
 	    !strcasestr(user_attr->prov_name, prov_attr->prov_name)) {
 		FI_INFO(prov, FI_LOG_CORE,
 			"Requesting provider %s, skipping %s\n",

--- a/prov/util/src/util_srx.c
+++ b/prov/util/src/util_srx.c
@@ -194,12 +194,15 @@ static int util_match_msg(struct fid_peer_srx *srx, fi_addr_t addr, size_t size,
 	return ret;
 }
 
-static int util_get_msg(struct fid_peer_srx *srx, fi_addr_t addr,
-		        size_t size, struct fi_peer_rx_entry **rx_entry)
+static int util_get_msg(struct fid_peer_srx *srx,
+			struct fi_peer_match *match_info,
+			struct fi_peer_rx_entry **rx_entry)
 {
 	struct util_srx_ctx *srx_ctx;
 	struct util_rx_entry *util_entry, *any_entry;
 	struct slist *queue;
+	fi_addr_t addr = match_info->addr;
+	size_t size = match_info->size;
 
 	srx_ctx = srx->ep_fid.fid.context;
 	assert(ofi_genlock_held(srx_ctx->lock));
@@ -269,14 +272,17 @@ out:
 	return ret;
 }
 
-static int util_get_tag(struct fid_peer_srx *srx, fi_addr_t addr,
-			uint64_t tag, struct fi_peer_rx_entry **rx_entry)
+static int util_get_tag(struct fid_peer_srx *srx,
+			struct fi_peer_match *match_info,
+			struct fi_peer_rx_entry **rx_entry)
 {
 	struct util_srx_ctx *srx_ctx;
 	struct slist *queue;
 	struct slist_entry *any_item, *any_prev;
 	struct slist_entry *item, *prev;
 	struct util_rx_entry *util_entry, *any_entry;
+	uint64_t tag = match_info->tag;
+	fi_addr_t addr = match_info->addr;
 	int ret = FI_SUCCESS;
 
 	srx_ctx = srx->ep_fid.fid.context;

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -227,6 +227,7 @@ static void ofi_tostr_caps(char *buf, size_t len, uint64_t caps)
 	IFFLAGSTRN(caps, FI_NAMED_RX_CTX, len);
 	IFFLAGSTRN(caps, FI_DIRECTED_RECV, len);
 	IFFLAGSTRN(caps, FI_HMEM, len);
+	IFFLAGSTRN(caps, FI_PEER, len);
 
 	ofi_remove_comma(buf);
 }


### PR DESCRIPTION
Add the FI_PEER capability bit to SHM

Signed-off-by: Amir Shehata <shehataa@ornl.gov>