### PR TITLE
prov/efa: Various zero-copy receive bugfixes

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_atomic.c
+++ b/prov/efa/src/rdm/efa_rdm_atomic.c
@@ -58,15 +58,15 @@ efa_rdm_atomic_alloc_txe(struct efa_rdm_ep *efa_rdm_ep,
 		return NULL;
 	}
 
-	dlist_insert_tail(&txe->ep_entry, &efa_rdm_ep->txe_list);
-
 	ofi_ioc_to_iov(msg_atomic->msg_iov, iov, msg_atomic->iov_count, datatype_size);
-	msg.addr = msg_atomic->addr;
-	msg.msg_iov = iov;
-	msg.context = msg_atomic->context;
-	msg.iov_count = msg_atomic->iov_count;
-	msg.data = msg_atomic->data;
-	msg.desc = msg_atomic->desc;
+	msg = (struct fi_msg) {
+		.msg_iov	= iov,
+		.desc		= msg_atomic->desc,
+		.iov_count	= msg_atomic->iov_count,
+		.addr		= msg_atomic->addr,
+		.context	= msg_atomic->context,
+		.data		= msg_atomic->data,
+	};
 	efa_rdm_txe_construct(txe, efa_rdm_ep, peer, &msg, op, flags);
 
 	assert(msg_atomic->rma_iov_count > 0);
@@ -76,6 +76,8 @@ efa_rdm_atomic_alloc_txe(struct efa_rdm_ep *efa_rdm_ep,
 			   txe->rma_iov,
 			   msg_atomic->rma_iov_count,
 			   datatype_size);
+
+	dlist_insert_tail(&txe->ep_entry, &efa_rdm_ep->txe_list);
 
 	txe->atomic_hdr.atomic_op = msg_atomic->op;
 	txe->atomic_hdr.datatype = msg_atomic->datatype;

--- a/prov/efa/src/rdm/efa_rdm_ep_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_utils.c
@@ -588,11 +588,10 @@ ssize_t efa_rdm_ep_post_handshake(struct efa_rdm_ep *ep, struct efa_rdm_peer *pe
 	struct efa_rdm_ope *txe;
 	struct fi_msg msg = {0};
 	struct efa_rdm_pke *pkt_entry;
-	fi_addr_t addr;
 	ssize_t ret;
 
-	addr = peer->efa_fiaddr;
-	msg.addr = addr;
+	assert(peer);
+	msg.addr = peer->efa_fiaddr;
 
 	/* ofi_op_write is ignored in handshake path */
 	txe = efa_rdm_ep_alloc_txe(ep, peer, &msg, ofi_op_write, 0, 0);
@@ -615,7 +614,7 @@ ssize_t efa_rdm_ep_post_handshake(struct efa_rdm_ep *ep, struct efa_rdm_peer *pe
 
 	pkt_entry->ope = txe;
 
-	efa_rdm_pke_init_handshake(pkt_entry, addr);
+	efa_rdm_pke_init_handshake(pkt_entry, msg.addr);
 
 	ret = efa_rdm_pke_sendv(&pkt_entry, 1);
 	if (OFI_UNLIKELY(ret)) {

--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -57,7 +57,7 @@ void efa_rdm_txe_construct(struct efa_rdm_ope *txe,
 
 	dlist_init(&txe->queued_pkts);
 
-	if (ep->user_info->mode & FI_MSG_PREFIX)
+	if (txe->iov_count > 0 && ep->user_info->mode & FI_MSG_PREFIX)
 		ofi_consume_iov_desc(txe->iov, txe->desc, &txe->iov_count, ep->msg_prefix_size);
 	txe->total_len = ofi_total_iov_len(txe->iov, txe->iov_count);
 

--- a/prov/efa/src/rdm/efa_rdm_pke_cmd.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_cmd.c
@@ -961,7 +961,13 @@ void efa_rdm_pke_handle_recv_completion(struct efa_rdm_pke *pkt_entry)
 		zcpy_rxe = pkt_entry->ope;
 	}
 
-	efa_rdm_pke_proc_received(pkt_entry);
+	if (ep->use_zcpy_rx) {
+		efa_rdm_pke_rtm_update_rxe(pkt_entry, zcpy_rxe);
+		efa_rdm_pke_rtm_handle_zcpy_recv_completion(pkt_entry, zcpy_rxe);
+		return;
+	} else {
+		efa_rdm_pke_proc_received(pkt_entry);
+	}
 
 	if (zcpy_rxe && pkt_type != EFA_RDM_EAGER_MSGRTM_PKT) {
 		/* user buffer was not matched with a message,

--- a/prov/efa/src/rdm/efa_rdm_pke_req.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_req.c
@@ -73,7 +73,7 @@ void efa_rdm_pke_init_req_hdr_common(struct efa_rdm_pke *pkt_entry,
 		opt_hdr += EFA_RDM_REQ_OPT_RAW_ADDR_HDR_SIZE;
 	}
 
-	if (base_hdr->flags & EFA_RDM_REQ_OPT_CQ_DATA_HDR) {
+	if (base_hdr->flags & EFA_RDM_REQ_OPT_CQ_DATA_HDR || pkt_entry->ep->use_zcpy_rx) {
 		struct efa_rdm_req_opt_cq_data_hdr *cq_data_hdr;
 
 		cq_data_hdr = (struct efa_rdm_req_opt_cq_data_hdr *)opt_hdr;
@@ -148,7 +148,7 @@ uint32_t *efa_rdm_pke_get_req_connid_ptr(struct efa_rdm_pke *pkt_entry)
 		return &raw_addr->qkey;
 	}
 
-	if (base_hdr->flags & EFA_RDM_REQ_OPT_CQ_DATA_HDR)
+	if (base_hdr->flags & EFA_RDM_REQ_OPT_CQ_DATA_HDR || pkt_entry->ep->use_zcpy_rx)
 		opt_hdr += sizeof(struct efa_rdm_req_opt_cq_data_hdr);
 
 	if (base_hdr->flags & EFA_RDM_PKT_CONNID_HDR) {

--- a/prov/efa/src/rdm/efa_rdm_pke_rtm.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtm.c
@@ -134,6 +134,22 @@ ssize_t efa_rdm_pke_init_rtm_with_payload(struct efa_rdm_pke *pkt_entry,
 	return ret;
 }
 
+void efa_rdm_pke_rtm_handle_zcpy_recv_completion(struct efa_rdm_pke *pkt_entry,
+		struct efa_rdm_ope *rxe)
+{
+	ptrdiff_t hdr_size = pkt_entry->payload - pkt_entry->wiredata;
+	ptrdiff_t expected = pkt_entry->ep->msg_prefix_size - sizeof *pkt_entry;
+
+	/* If the header size doesn't match what's expected, set cq_entry.len to
+	 * 0, which will trigger an error upon reporting completion.
+	 */
+	rxe->cq_entry.len = OFI_LIKELY(hdr_size >= expected) ?
+		pkt_entry->pkt_size + sizeof *pkt_entry : 0;
+
+	efa_rdm_rxe_report_completion(rxe);
+	efa_rdm_rxe_release(rxe);
+}
+
 /**
  * @brief Update RX entry with the information in RTM packet entry.
  *
@@ -635,11 +651,8 @@ void efa_rdm_pke_handle_eager_rtm_send_completion(struct efa_rdm_pke *pkt_entry)
  */
 ssize_t efa_rdm_pke_proc_matched_eager_rtm(struct efa_rdm_pke *pkt_entry)
 {
-	int err;
-	int hdr_size;
-	struct efa_rdm_ope *rxe;
-
-	rxe = pkt_entry->ope;
+	int err = 0;
+	struct efa_rdm_ope *rxe = pkt_entry->ope;
 
 	if (pkt_entry->alloc_type != EFA_RDM_PKE_FROM_USER_BUFFER) {
 		/*
@@ -649,36 +662,11 @@ ssize_t efa_rdm_pke_proc_matched_eager_rtm(struct efa_rdm_pke *pkt_entry)
 		err = efa_rdm_pke_copy_payload_to_ope(pkt_entry, rxe);
 		if (err)
 			efa_rdm_pke_release_rx(pkt_entry);
-
-		return err;
-	}
-
-	/* In this case, data is already in user provided buffer, so no need
-	 * to copy. However, we do need to make sure the packet header length
-	 * is correct. Otherwise, user will get wrong data.
-	 *
-	 * The expected header size is
-	 * 	ep->msg_prefix_size - sizeof(struct efa_rdm_pke)
-	 * because we used the first sizeof(struct efa_rdm_pke) to construct
-	 * a pkt_entry.
-	 */
-	hdr_size = pkt_entry->payload - pkt_entry->wiredata;
-	if (hdr_size != pkt_entry->ep->msg_prefix_size - sizeof(struct efa_rdm_pke)) {
-		/* if header size is wrong, the data in user buffer is not useful.
-		 * setting rxe->cq_entry.len here will cause an error cq entry
-		 * to be written to application.
-		 */
-		rxe->cq_entry.len = 0;
 	} else {
-		rxe->cq_entry.len = pkt_entry->pkt_size + sizeof(struct efa_rdm_pke);
+		efa_rdm_pke_rtm_handle_zcpy_recv_completion(pkt_entry, rxe);
 	}
 
-	efa_rdm_rxe_report_completion(rxe);
-	efa_rdm_rxe_release(rxe);
-
-	/* no need to release packet entry because it is
-	 * constructed using user supplied buffer */
-	return 0;
+	return err;
 }
 
 

--- a/prov/efa/src/rdm/efa_rdm_pke_rtm.h
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtm.h
@@ -87,6 +87,9 @@ void efa_rdm_pke_set_rtm_tag(struct efa_rdm_pke *pkt_entry, uint64_t tag)
 	*tagptr = tag;
 }
 
+void efa_rdm_pke_rtm_handle_zcpy_recv_completion(struct efa_rdm_pke *pkt_entry,
+				struct efa_rdm_ope *rxe);
+
 void efa_rdm_pke_rtm_update_rxe(struct efa_rdm_pke *pkt_entry,
 				struct efa_rdm_ope *rxe);
 

--- a/prov/efa/src/rdm/efa_rdm_rma.c
+++ b/prov/efa/src/rdm/efa_rdm_rma.c
@@ -59,12 +59,14 @@ efa_rdm_rma_alloc_txe(struct efa_rdm_ep *efa_rdm_ep,
 		return NULL;
 	}
 
-	msg.addr = msg_rma->addr;
-	msg.msg_iov = msg_rma->msg_iov;
-	msg.context = msg_rma->context;
-	msg.iov_count = msg_rma->iov_count;
-	msg.data = msg_rma->data;
-	msg.desc = msg_rma->desc;
+	msg = (struct fi_msg) {
+		.msg_iov	= msg_rma->msg_iov,
+		.desc		= msg_rma->desc,
+		.iov_count	= msg_rma->iov_count,
+		.addr		= msg_rma->addr,
+		.context	= msg_rma->context,
+		.data		= msg_rma->data,
+	};
 	efa_rdm_txe_construct(txe, efa_rdm_ep, peer, &msg, op, flags);
 
 	assert(msg_rma->rma_iov_count > 0);


### PR DESCRIPTION
This includes the CQ data header size for the zero-copy receive use-case