### PR TITLE
03 of 10 LNX series - Add address matching callback to fi_ops_srx_peer

### DIFF
--- a/include/rdma/providers/fi_peer.h
+++ b/include/rdma/providers/fi_peer.h
@@ -197,6 +197,7 @@ struct fi_ops_srx_peer {
 	int	(*start_tag)(struct fi_peer_rx_entry *entry);
 	int	(*discard_msg)(struct fi_peer_rx_entry *entry);
 	int	(*discard_tag)(struct fi_peer_rx_entry *entry);
+	int	(*addr_match)(fi_addr_t addr, struct fi_peer_match *match);
 };
 
 struct fid_peer_srx {

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -406,6 +406,7 @@ int ofi_check_fabric_attr(const struct fi_provider *prov,
 	 * user's hints, if one is specified.
 	 */
 	if (prov_attr->prov_name && user_attr->prov_name &&
+		user_attr->prov_name[0] != '^' &&
 	    !strcasestr(user_attr->prov_name, prov_attr->prov_name)) {
 		FI_INFO(prov, FI_LOG_CORE,
 			"Requesting provider %s, skipping %s\n",


### PR DESCRIPTION
include/rdma: Add address matching call back to peer_srx

It is not efficient to do a reverse lookup on the AV table when a message
is received. Some providers do not store the fi_addr_t associated with the
peer in the header passed on the wire. And it is not practical to require
providers to add that to wire header, as it would break backwards
compatibility.

In order to handle this case, an address matching callback is added to the
peer_srx.peer_ops structure. This allows the provider receiving the
message to register an address matching callback. This callback is called
by the owner provider to match an fi_addr_t with provider specific address
in the message received.

The callback allows the receiving provider to do an O(1) index into the AV
table to lookup the address of the peer, and then compare that with the
source address in the received message.

As part of this change provider specific address information needs to be
passed to the owner provider, which the owner will need to give back to the
receiving provider, when it attempts to do address matching.

Update the SHM and LINKx providers to conform with the API changes

Signed-off-by: Amir Shehata <shehataa@ornl.gov>
