### PR TITLE
prov/efa: Avoid iterating cq->ep_list in cq read

### DIFF
--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -886,7 +886,6 @@
     <ClCompile Include="prov\efa\src\rdm\efa_rdm_atomic.c" />
     <ClCompile Include="prov\efa\src\rdm\efa_rdm_ep_utils.c" />
     <ClCompile Include="prov\efa\src\rdm\efa_rdm_ep_fiops.c" />
-    <ClCompile Include="prov\efa\src\rdm\efa_rdm_ep_progress.c" />
     <ClCompile Include="prov\efa\src\rdm\efa_rdm_msg.c" />
     <ClCompile Include="prov\efa\src\rdm\efa_rdm_pke.c" />
     <ClCompile Include="prov\efa\src\rdm\efa_rdm_pke_cmd.c" />

--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -55,7 +55,6 @@ _efa_files = \
 	prov/efa/src/rdm/efa_rdm_cq.c \
 	prov/efa/src/rdm/efa_rdm_ep_utils.c \
 	prov/efa/src/rdm/efa_rdm_ep_fiops.c \
-	prov/efa/src/rdm/efa_rdm_ep_progress.c \
 	prov/efa/src/rdm/efa_rdm_rma.c	\
 	prov/efa/src/rdm/efa_rdm_msg.c	\
 	prov/efa/src/rdm/efa_rdm_pke.c \

--- a/prov/efa/docs/pkt-processing.md
+++ b/prov/efa/docs/pkt-processing.md
@@ -31,7 +31,7 @@ keep track of whether long message receives are completed. Just like the txe,
 when a receive operation is completed a receive completion is written to the app 
 and the `rxe` (RX entry) is released.
 
-`efa_rdm_ep_progress` is the progress handler we register when the completion queue
+`efa_rdm_cq_progress` is the progress handler we register when the completion queue
 is created and is called via the util completion queue functions. While the EFA
 device will progress sends and receives posted to it, the Libfabric provider
 has to process those device completions, potentially copy data out of a bounce
@@ -55,7 +55,7 @@ those cases.
 
 We also may queue an rxe/te if we're unable to continue sending segments
 or if we fail to post a control message for that entry. You'll find the lists
-where those are queued and progressed in `efa_rdm_ep_progress_internal`.
+where those are queued and progressed in `efa_domain_progress_rdm_peers_and_queues`.
 
 ### Dealing with receiver not ready errors (RNR)
 
@@ -77,5 +77,5 @@ to that peer until the peer exits backoff, meaning we either received a
 successful send completion for that peer or the backoff timer expires.
 
 See `efa_rdm_ep_queue_rnr_pkt` for where the packets are queued and backoff timers are
-set, and see `efa_rdm_ep_check_peer_backoff_timer` for where those timers are
+set, and see `efa_domain_progress_rdm_peers_and_queues` for where those timers are
 checked and we allow sends to that remote peer again.

--- a/prov/efa/src/efa_domain.h
+++ b/prov/efa/src/efa_domain.h
@@ -26,11 +26,28 @@ struct efa_domain {
 	size_t			mtu_size;
 	size_t			addrlen;
 	bool 			mr_local;
-	uint64_t		rdm_mode;
-	size_t			rdm_cq_size;
 	struct dlist_entry	list_entry; /* linked to g_efa_domain_list */
 	struct ofi_genlock	srx_lock; /* shared among peer providers */
+
+	/* Only valid for RDM EP type */
+	uint64_t		rdm_mode;
+	size_t			rdm_cq_size;
+	/* number of rdma-read messages in flight */
 	uint64_t		num_read_msg_in_flight;
+	/* op entries with queued rnr packets */
+	struct dlist_entry ope_queued_rnr_list;
+	/* op entries with queued ctrl packets */
+	struct dlist_entry ope_queued_ctrl_list;
+	/* op entries with queued read requests */
+	struct dlist_entry ope_queued_read_list;
+	/* tx/rx_entries used by long CTS msg/write/read protocol
+         * which have data to be sent */
+	struct dlist_entry ope_longcts_send_list;
+	/* list of #efa_rdm_peer that are in backoff due to RNR */
+	struct dlist_entry peer_backoff_list;
+	/* list of #efa_rdm_peer that will retry posting handshake pkt */
+	struct dlist_entry handshake_queued_peer_list;
+
 };
 
 extern struct dlist_entry g_efa_domain_list;
@@ -87,5 +104,7 @@ bool efa_domain_support_rnr_retry_modify(struct efa_domain *domain)
 
 int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 		    struct fid_domain **domain_fid, void *context);
+
+void efa_domain_progress_rdm_peers_and_queues(struct efa_domain *domain);
 
 #endif

--- a/prov/efa/src/rdm/efa_rdm_cq.c
+++ b/prov/efa/src/rdm/efa_rdm_cq.c
@@ -309,6 +309,10 @@ static int efa_rdm_cq_get_prov_errno(struct ibv_cq_ex *ibv_cq_ex) {
 	return vendor_err;
 }
 
+static int efa_rdm_cq_match_ep(struct dlist_entry *item, const void *ep)
+{
+	return (container_of(item, struct efa_rdm_ep, entry) == ep) ;
+}
 
 /**
  * @brief poll rdma-core cq and process the cq entry
@@ -335,9 +339,11 @@ void efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq)
 	struct efa_rdm_cq *efa_rdm_cq;
 	struct efa_domain *efa_domain;
 	struct efa_qp *qp;
+	struct dlist_entry rx_progressed_ep_list, *item;
 
 	efa_rdm_cq = container_of(ibv_cq, struct efa_rdm_cq, ibv_cq);
 	efa_domain = container_of(efa_rdm_cq->util_cq.domain, struct efa_domain, util_domain);
+	dlist_init(&rx_progressed_ep_list);
 
 	/* Call ibv_start_poll only once */
 	err = ibv_start_poll(ibv_cq->ibv_cq_ex, &poll_cq_attr);
@@ -347,7 +353,6 @@ void efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq)
 		pkt_entry = (void *)(uintptr_t)ibv_cq->ibv_cq_ex->wr_id;
 		qp = efa_domain->qp_table[ibv_wc_read_qp_num(ibv_cq->ibv_cq_ex) & efa_domain->qp_table_sz_m1];
 		ep = container_of(qp->base_ep, struct efa_rdm_ep, base_ep);
-		efa_av = ep->base_ep.av;
 		efa_rdm_tracepoint(poll_cq, (size_t) ibv_cq->ibv_cq_ex->wr_id);
 		opcode = ibv_wc_read_opcode(ibv_cq->ibv_cq_ex);
 		if (ibv_cq->ibv_cq_ex->status) {
@@ -360,6 +365,8 @@ void efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq)
 				break;
 			case IBV_WC_RECV: /* fall through */
 			case IBV_WC_RECV_RDMA_WITH_IMM:
+				if (!dlist_find_first_match(&rx_progressed_ep_list, &efa_rdm_cq_match_ep, ep))
+					dlist_insert_tail(&ep->entry, &rx_progressed_ep_list);
 				efa_rdm_pke_handle_rx_error(pkt_entry, prov_errno);
 				break;
 			default:
@@ -376,6 +383,9 @@ void efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq)
 			efa_rdm_pke_handle_send_completion(pkt_entry);
 			break;
 		case IBV_WC_RECV:
+			efa_av = ep->base_ep.av;
+			if (!dlist_find_first_match(&rx_progressed_ep_list, &efa_rdm_cq_match_ep, ep))
+				dlist_insert_tail(&ep->entry, &rx_progressed_ep_list);
 			pkt_entry->addr = efa_av_reverse_lookup_rdm(efa_av, ibv_wc_read_slid(ibv_cq->ibv_cq_ex),
 								ibv_wc_read_src_qp(ibv_cq->ibv_cq_ex), pkt_entry);
 
@@ -395,6 +405,8 @@ void efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq)
 			efa_rdm_pke_handle_rma_completion(pkt_entry);
 			break;
 		case IBV_WC_RECV_RDMA_WITH_IMM:
+			if (!dlist_find_first_match(&rx_progressed_ep_list, &efa_rdm_cq_match_ep, ep))
+				dlist_insert_tail(&ep->entry, &rx_progressed_ep_list);
 			efa_rdm_cq_proc_ibv_recv_rdma_with_imm_completion(
 				ibv_cq->ibv_cq_ex,
 				FI_REMOTE_CQ_DATA | FI_RMA | FI_REMOTE_WRITE,
@@ -433,6 +445,14 @@ void efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq)
 
 	if (should_end_poll)
 		ibv_end_poll(ibv_cq->ibv_cq_ex);
+
+	dlist_foreach(&rx_progressed_ep_list, item) {
+		ep = container_of(item, struct efa_rdm_ep, entry);
+		efa_rdm_ep_post_internal_rx_pkts(ep);
+		dlist_remove(&ep->entry);
+	}
+	assert(dlist_empty(&rx_progressed_ep_list));
+
 }
 
 static ssize_t efa_rdm_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t count, fi_addr_t *src_addr)
@@ -482,25 +502,20 @@ static struct fi_ops_cq efa_rdm_cq_ops = {
 
 static void efa_rdm_cq_progress(struct util_cq *cq)
 {
-	struct util_ep *ep;
-	struct fid_list_entry *fid_entry;
 	struct dlist_entry *item;
 	struct efa_rdm_cq *efa_rdm_cq;
 	struct efa_ibv_cq_poll_list_entry *poll_list_entry;
+	struct efa_domain *efa_domain;
 
 	ofi_genlock_lock(&cq->ep_list_lock);
 	efa_rdm_cq = container_of(cq, struct efa_rdm_cq, util_cq);
+	efa_domain = container_of(efa_rdm_cq->util_cq.domain, struct efa_domain, util_domain);
 
 	dlist_foreach(&efa_rdm_cq->ibv_cq_poll_list, item) {
 		poll_list_entry = container_of(item, struct efa_ibv_cq_poll_list_entry, entry);
 		efa_rdm_cq_poll_ibv_cq(efa_env.efa_cq_read_size, poll_list_entry->cq);
 	}
-
-	dlist_foreach(&cq->ep_list, item) {
-		fid_entry = container_of(item, struct fid_list_entry, entry);
-		ep = container_of(fid_entry->fid, struct util_ep, ep_fid.fid);
-		ep->progress(ep);
-	}
+	efa_domain_progress_rdm_peers_and_queues(efa_domain);
 	ofi_genlock_unlock(&cq->ep_list_lock);
 }
 

--- a/prov/efa/src/rdm/efa_rdm_cq.h
+++ b/prov/efa/src/rdm/efa_rdm_cq.h
@@ -23,4 +23,6 @@ int efa_rdm_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		    struct fid_cq **cq_fid, void *context);
 
 void efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq);
+
+void efa_rdm_cq_progress_peers_and_queues(struct efa_rdm_cq *efa_rdm_cq);
 #endif

--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -116,20 +116,6 @@ struct efa_rdm_ep {
 	struct ofi_bufpool *rx_atomrsp_pool;
 	/* list of pre-posted recv buffers */
 	struct dlist_entry rx_posted_buf_list;
-	/* op entries with queued rnr packets */
-	struct dlist_entry ope_queued_rnr_list;
-	/* op entries with queued ctrl packets */
-	struct dlist_entry ope_queued_ctrl_list;
-	/* op entries with queued read requests */
-	struct dlist_entry ope_queued_read_list;
-	/* tx/rx_entries used by long CTS msg/write/read protocol
-         * which have data to be sent */
-	struct dlist_entry ope_longcts_send_list;
-	/* list of #efa_rdm_peer that are in backoff due to RNR */
-	struct dlist_entry peer_backoff_list;
-	/* list of #efa_rdm_peer that will retry posting handshake pkt */
-	struct dlist_entry handshake_queued_peer_list;
-
 #if ENABLE_DEBUG
 	/* tx/rx_entries waiting to receive data in
          * long CTS msg/read/write protocols */
@@ -194,6 +180,7 @@ struct efa_rdm_ep {
 	bool write_in_order_aligned_128_bytes; /**< whether to support in order write of each aligned 128 bytes memory region */
 	char err_msg[EFA_RDM_ERROR_MSG_BUFFER_LENGTH]; /* A large enough buffer to store CQ/EQ error data used by e.g. fi_cq_readerr */
 	struct efa_rdm_pke **pke_vec;
+	struct dlist_entry entry;
 };
 
 int efa_rdm_ep_flush_queued_blocking_copy_to_hmem(struct efa_rdm_ep *ep);
@@ -248,10 +235,6 @@ static inline int efa_rdm_ep_need_sas(struct efa_rdm_ep *ep)
 int efa_rdm_ep_open(struct fid_domain *domain, struct fi_info *info,
 		    struct fid_ep **ep, void *context);
 
-/* EP sub-functions */
-void efa_rdm_ep_progress(struct util_ep *util_ep);
-void efa_rdm_ep_progress_internal(struct efa_rdm_ep *efa_rdm_ep);
-
 int efa_rdm_ep_post_user_recv_buf(struct efa_rdm_ep *ep, struct efa_rdm_ope *rxe,
 			      uint64_t flags);
 
@@ -271,6 +254,8 @@ struct efa_domain *efa_rdm_ep_domain(struct efa_rdm_ep *ep)
 {
 	return container_of(ep->base_ep.util_ep.domain, struct efa_domain, util_domain);
 }
+
+void efa_rdm_ep_post_internal_rx_pkts(struct efa_rdm_ep *ep);
 
 /**
  * @brief return whether this endpoint should write error cq entry for RNR.

--- a/prov/efa/src/rdm/efa_rdm_ep_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_utils.c
@@ -495,7 +495,7 @@ void efa_rdm_ep_queue_rnr_pkt(struct efa_rdm_ep *ep,
 
 	peer->flags |= EFA_RDM_PEER_IN_BACKOFF;
 	dlist_insert_tail(&peer->rnr_backoff_entry,
-			  &ep->peer_backoff_list);
+			  &efa_rdm_ep_domain(ep)->peer_backoff_list);
 
 	peer->rnr_backoff_begin_ts = ofi_gettime_us();
 	if (peer->rnr_backoff_wait_time == 0) {
@@ -660,7 +660,7 @@ void efa_rdm_ep_post_handshake_or_queue(struct efa_rdm_ep *ep, struct efa_rdm_pe
 		/* add peer to handshake_queued_peer_list for retry later */
 		peer->flags |= EFA_RDM_PEER_HANDSHAKE_QUEUED;
 		dlist_insert_tail(&peer->handshake_queued_entry,
-				  &ep->handshake_queued_peer_list);
+				  &efa_rdm_ep_domain(ep)->handshake_queued_peer_list);
 		return;
 	}
 
@@ -673,6 +673,278 @@ void efa_rdm_ep_post_handshake_or_queue(struct efa_rdm_ep *ep, struct efa_rdm_pe
 	}
 
 	peer->flags |= EFA_RDM_PEER_HANDSHAKE_SENT;
+}
+
+/**
+ * @brief post a linked list of packets
+ *
+ * @param[in]	ep	RDM endpoint
+ * @param[in]	pkts	Linked list of packets to post
+ * @return		0 on success, negative error code on failure
+ */
+ssize_t efa_rdm_ep_post_queued_pkts(struct efa_rdm_ep *ep,
+				    struct dlist_entry *pkts)
+{
+	struct dlist_entry *tmp;
+	struct efa_rdm_peer *peer;
+	struct efa_rdm_pke *pkt_entry;
+	struct efa_rdm_base_hdr *base_hdr;
+	ssize_t ret;
+
+	dlist_foreach_container_safe(pkts, struct efa_rdm_pke,
+				     pkt_entry, entry, tmp) {
+
+		/* If send succeeded, pkt_entry->entry will be added
+		 * to peer->outstanding_tx_pkts. Therefore, it must
+		 * be removed from the list before send.
+		 */
+		dlist_remove(&pkt_entry->entry);
+
+		base_hdr = efa_rdm_pke_get_base_hdr(pkt_entry);
+		if (base_hdr->type == EFA_RDM_RMA_CONTEXT_PKT) {
+			assert(((struct efa_rdm_rma_context_pkt *)pkt_entry->wiredata)->context_type == EFA_RDM_RDMA_WRITE_CONTEXT);
+			ret = efa_rdm_pke_write(pkt_entry);
+		} else {
+			ret = efa_rdm_pke_sendv(&pkt_entry, 1, 0);
+		}
+
+		if (ret) {
+			if (ret == -FI_EAGAIN) {
+				/* add the pkt back to pkts, so it can be resent again */
+				dlist_insert_tail(&pkt_entry->entry, pkts);
+			}
+
+			return ret;
+		}
+
+		pkt_entry->flags &= ~EFA_RDM_PKE_RNR_RETRANSMIT;
+		peer = efa_rdm_ep_get_peer(ep, pkt_entry->addr);
+		assert(peer);
+		ep->efa_rnr_queued_pkt_cnt--;
+		peer->rnr_queued_pkt_cnt--;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief bulk post internal receive buffers to EFA device
+ *
+ * Received packets were not reposted to device immediately
+ * after they are processed. Instead, endpoint keep a counter
+ * of number packets to be posted, and post them in bulk
+ *
+ * @param[in]	ep		endpoint
+ * @return	On success, return 0
+ * 		On failure, return a negative error code.
+ */
+int efa_rdm_ep_bulk_post_internal_rx_pkts(struct efa_rdm_ep *ep)
+{
+	int i, err;
+
+	if (ep->efa_rx_pkts_to_post == 0)
+		return 0;
+
+	assert(ep->efa_rx_pkts_to_post + ep->efa_rx_pkts_posted <= ep->efa_max_outstanding_rx_ops);
+	for (i = 0; i < ep->efa_rx_pkts_to_post; ++i) {
+		ep->pke_vec[i] = efa_rdm_pke_alloc(ep, ep->efa_rx_pkt_pool,
+					       EFA_RDM_PKE_FROM_EFA_RX_POOL);
+		assert(ep->pke_vec[i]);
+	}
+
+	err = efa_rdm_pke_recvv(ep->pke_vec, ep->efa_rx_pkts_to_post);
+	if (OFI_UNLIKELY(err)) {
+		for (i = 0; i < ep->efa_rx_pkts_to_post; ++i)
+			efa_rdm_pke_release_rx(ep->pke_vec[i]);
+
+		EFA_WARN(FI_LOG_EP_CTRL,
+			"failed to post buf %d (%s)\n", -err,
+			fi_strerror(-err));
+		return err;
+	}
+
+#if ENABLE_DEBUG
+	for (i = 0; i < ep->efa_rx_pkts_to_post; ++i) {
+		dlist_insert_tail(&ep->pke_vec[i]->dbg_entry,
+				  &ep->rx_posted_buf_list);
+	}
+#endif
+
+	ep->efa_rx_pkts_posted += ep->efa_rx_pkts_to_post;
+	ep->efa_rx_pkts_to_post = 0;
+	return 0;
+}
+
+/*
+ * @brief explicitly allocate a chunk of memory for 6 pools on RX side:
+ *     efa's receive packet pool (efa_rx_pkt_pool)
+ *     unexpected packet pool (rx_unexp_pkt_pool),
+ *     out-of-order packet pool (rx_ooo_pkt_pool), and
+ *     local read-copy packet pool (rx_readcopy_pkt_pool).
+ *
+ * This function is called when the progress engine is called for
+ * the 1st time on this endpoint.
+ *
+ * @param ep[in,out]	endpoint
+ * @return		On success, return 0
+ * 			On failure, return a negative error code.
+ */
+int efa_rdm_ep_grow_rx_pools(struct efa_rdm_ep *ep)
+{
+	int err;
+
+	assert(ep->efa_rx_pkt_pool);
+	err = ofi_bufpool_grow(ep->efa_rx_pkt_pool);
+	if (OFI_UNLIKELY(err)) {
+		EFA_WARN(FI_LOG_CQ,
+			"cannot allocate memory for EFA's RX packet pool. error: %s\n",
+			strerror(-err));
+		return err;
+	}
+
+	if (ep->rx_unexp_pkt_pool) {
+		err = ofi_bufpool_grow(ep->rx_unexp_pkt_pool);
+		if (OFI_UNLIKELY(err)) {
+			EFA_WARN(FI_LOG_CQ,
+				"cannot allocate memory for unexpected packet pool. error: %s\n",
+				strerror(-err));
+			return err;
+		}
+	}
+
+	if (ep->rx_ooo_pkt_pool) {
+		err = ofi_bufpool_grow(ep->rx_ooo_pkt_pool);
+		if (OFI_UNLIKELY(err)) {
+			EFA_WARN(FI_LOG_CQ,
+				"cannot allocate memory for out-of-order packet pool. error: %s\n",
+				strerror(-err));
+			return err;
+		}
+	}
+
+	if (ep->rx_readcopy_pkt_pool) {
+		err = ofi_bufpool_grow(ep->rx_readcopy_pkt_pool);
+		if (OFI_UNLIKELY(err)) {
+			EFA_WARN(FI_LOG_CQ,
+				"cannot allocate and register memory for readcopy packet pool. error: %s\n",
+				strerror(-err));
+			return err;
+		}
+	}
+
+	if (ep->map_entry_pool) {
+		err = ofi_bufpool_grow(ep->map_entry_pool);
+		if (OFI_UNLIKELY(err)) {
+			EFA_WARN(FI_LOG_CQ,
+				 "cannot allocate memory for map entry pool. error: %s\n",
+				 strerror(-err));
+			return err;
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * @brief post internal receive buffers for progress engine.
+ *
+ * It is more efficient to post multiple receive buffers
+ * to the device at once than to post each receive buffer
+ * individually.
+ *
+ * Therefore, after an internal receive buffer (a packet
+ * entry) was processed, it is not posted to the device
+ * right away.
+ *
+ * Instead, we increase counter
+ *      ep->efa_rx_pkts_to_post
+ * by one.
+ *
+ * Later, progress engine calls this function to
+ * bulk post internal receive buffers (according to
+ * the counter).
+ *
+ * This function also control number of internal
+ * buffers posted to the device in zero copy receive
+ * mode.
+ *
+ * param[in]	ep	endpoint
+ */
+void efa_rdm_ep_post_internal_rx_pkts(struct efa_rdm_ep *ep)
+{
+	int err;
+
+	if (ep->use_zcpy_rx) {
+		/*
+		 * In zero copy receive mode,
+		 *
+		 * If application did not post any receive buffer,
+		 * we post one internal buffer so endpoint can
+		 * receive control packets such as handshake.
+		 *
+		 * If buffers have posted to the device, we do NOT
+		 * repost internal buffers to maximize the chance
+		 * user buffer is used to receive data.
+		 */
+		if (ep->efa_rx_pkts_posted == 0 && ep->efa_rx_pkts_to_post == 0) {
+			ep->efa_rx_pkts_to_post = 1;
+		} else if (ep->efa_rx_pkts_posted > 0){
+			ep->efa_rx_pkts_to_post = 0;
+		}
+	} else {
+		if (ep->efa_rx_pkts_posted == 0 && ep->efa_rx_pkts_to_post == 0 && ep->efa_rx_pkts_held == 0) {
+			/* All of efa_rx_pkts_posted, efa_rx_pkts_to_post and
+			 * efa_rx_pkts_held equal to 0 means
+			 * this is the first call of the progress engine on this endpoint.
+			 *
+			 * In this case, we explictly allocate the 1st chunk of memory
+			 * for unexp/ooo/readcopy RX packet pool.
+			 *
+			 * The reason to explicitly allocate the memory for RX packet
+			 * pool is to improve efficiency.
+			 *
+			 * Without explicit memory allocation, a pkt pools's memory
+			 * is allocated when 1st packet is allocated from it.
+			 * During the computation, different processes got their 1st
+			 * unexp/ooo/read-copy packet at different time. Therefore,
+			 * if we do not explicitly allocate memory at the beginning,
+			 * memory will be allocated at different time.
+			 *
+			 * When one process is allocating memory, other processes
+			 * have to wait. When each process allocate memory at different
+			 * time, the accumulated waiting time became significant.
+			 *
+			 * By explicitly allocating memory at 1st call to progress
+			 * engine, the memory allocation is parallelized.
+			 * (This assumes the 1st call to the progress engine on
+			 * all processes happen at roughly the same time, which
+			 * is a valid assumption according to our knowledge of
+			 * the workflow of most application)
+			 *
+			 * The memory was not allocated during endpoint initialization
+			 * because some applications will initialize some endpoints
+			 * but never uses it, thus allocating memory initialization
+			 * causes waste.
+			 */
+			err = efa_rdm_ep_grow_rx_pools(ep);
+			if (err)
+				goto err_exit;
+
+			ep->efa_rx_pkts_to_post = efa_rdm_ep_get_rx_pool_size(ep);
+		}
+		/* only valid for non-zero copy */
+		assert(ep->efa_rx_pkts_to_post + ep->efa_rx_pkts_posted + ep->efa_rx_pkts_held == efa_rdm_ep_get_rx_pool_size(ep));
+	}
+
+	err = efa_rdm_ep_bulk_post_internal_rx_pkts(ep);
+	if (err)
+		goto err_exit;
+
+	return;
+
+err_exit:
+
+	efa_base_ep_write_eq_error(&ep->base_ep, err, FI_EFA_ERR_INTERNAL_RX_BUF_POST);
 }
 
 /**

--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -1572,7 +1572,7 @@ int efa_rdm_ope_post_remote_read_or_queue(struct efa_rdm_ope *ope)
 	switch (err) {
 	case -FI_EAGAIN:
 		dlist_insert_tail(&ope->queued_read_entry,
-				  &ope->ep->ope_queued_read_list);
+				  &efa_rdm_ep_domain(ope->ep)->ope_queued_read_list);
 		ope->internal_flags |= EFA_RDM_OPE_QUEUED_READ;
 		err = 0;
 		break;
@@ -1826,7 +1826,7 @@ ssize_t efa_rdm_ope_post_send_or_queue(struct efa_rdm_ope *ope, int pkt_type)
 		ope->internal_flags |= EFA_RDM_OPE_QUEUED_CTRL;
 		ope->queued_ctrl_type = pkt_type;
 		dlist_insert_tail(&ope->queued_ctrl_entry,
-				  &ope->ep->ope_queued_ctrl_list);
+				  &efa_rdm_ep_domain(ope->ep)->ope_queued_ctrl_list);
 		err = 0;
 	}
 

--- a/prov/efa/src/rdm/efa_rdm_ope.h
+++ b/prov/efa/src/rdm/efa_rdm_ope.h
@@ -126,13 +126,13 @@ struct efa_rdm_ope {
 	/* ep_entry is linked to tx/rxe_list in efa_rdm_ep */
 	struct dlist_entry ep_entry;
 
-	/* queued_ctrl_entry is linked with tx/rx_queued_ctrl_list in efa_rdm_ep */
+	/* queued_ctrl_entry is linked with tx/rx_queued_ctrl_list in efa_domain */
 	struct dlist_entry queued_ctrl_entry;
 
-	/* queued_read_entry is linked with ope_queued_read_list in efa_rdm_ep */
+	/* queued_read_entry is linked with ope_queued_read_list in efa_domain */
 	struct dlist_entry queued_read_entry;
 
-	/* queued_rnr_entry is linked with tx/rx_queued_rnr_list in efa_rdm_ep */
+	/* queued_rnr_entry is linked with tx/rx_queued_rnr_list in efa_domain */
 	struct dlist_entry queued_rnr_entry;
 
 	/* Queued packets due to TX queue full or RNR backoff */

--- a/prov/efa/src/rdm/efa_rdm_peer.c
+++ b/prov/efa/src/rdm/efa_rdm_peer.c
@@ -21,6 +21,7 @@ void efa_rdm_peer_construct(struct efa_rdm_peer *peer, struct efa_rdm_ep *ep, st
 {
 	memset(peer, 0, sizeof(struct efa_rdm_peer));
 
+	peer->ep = ep;
 	peer->efa_fiaddr = conn->fi_addr;
 	peer->is_self = efa_is_same_addr(&ep->base_ep.src_addr, conn->ep_addr);
 	peer->host_id = peer->is_self ? ep->host_id : 0;	/* Peer host id is exchanged via handshake */

--- a/prov/efa/src/rdm/efa_rdm_peer.h
+++ b/prov/efa/src/rdm/efa_rdm_peer.h
@@ -25,6 +25,7 @@ OFI_DECL_RECVWIN_BUF(struct efa_rdm_pke*, efa_rdm_robuf, uint32_t);
 #define EFA_RDM_PEER_HANDSHAKE_QUEUED      BIT_ULL(5)
 
 struct efa_rdm_peer {
+	struct efa_rdm_ep *ep;		/**< local ep */
 	bool is_self;			/**< flag indicating whether the peer is the endpoint itself */
 	bool is_local;			/**< flag indicating wehther the peer is local (on the same instance) */
 	uint32_t device_version;	/**< EFA device version */
@@ -46,8 +47,8 @@ struct efa_rdm_peer {
 	uint64_t rnr_backoff_begin_ts;	/**< timestamp for RNR backoff period begin */
 	uint64_t rnr_backoff_wait_time;	/**< how long the RNR backoff period last */
 	int rnr_queued_pkt_cnt;		/**< queued RNR packet count */
-	struct dlist_entry rnr_backoff_entry;	/**< linked to efa_rdm_ep peer_backoff_list */
-	struct dlist_entry handshake_queued_entry; /**< linked with efa_rdm_ep->handshake_queued_peer_list */
+	struct dlist_entry rnr_backoff_entry;	/**< linked to efa_domain->peer_backoff_list */
+	struct dlist_entry handshake_queued_entry; /**< linked with efa_domain->handshake_queued_peer_list */
 	struct dlist_entry rx_unexp_list; /**< a list of unexpected untagged rxe for this peer */
 	struct dlist_entry rx_unexp_tagged_list; /**< a list of unexpected tagged rxe for this peer */
 	struct dlist_entry txe_list; /**< a list of txe related to this peer */

--- a/prov/efa/src/rdm/efa_rdm_pke_cmd.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_cmd.c
@@ -415,7 +415,7 @@ void efa_rdm_pke_handle_tx_error(struct efa_rdm_pke *pkt_entry, int prov_errno)
 				assert(!(peer->flags & EFA_RDM_PEER_HANDSHAKE_QUEUED));
 				peer->flags |= EFA_RDM_PEER_HANDSHAKE_QUEUED;
 				dlist_insert_tail(&peer->handshake_queued_entry,
-						  &ep->handshake_queued_peer_list);
+						  &efa_rdm_ep_domain(ep)->handshake_queued_peer_list);
 			} else if (prov_errno != EFA_IO_COMP_STATUS_REMOTE_ERROR_BAD_DEST_QPN) {
 				/*
 				 * If prov_errno is EFA_IO_COMP_STATUS_REMOTE_ERROR_BAD_DEST_QPN
@@ -476,7 +476,7 @@ void efa_rdm_pke_handle_tx_error(struct efa_rdm_pke *pkt_entry, int prov_errno)
 				if (!(txe->internal_flags & EFA_RDM_OPE_QUEUED_RNR)) {
 					txe->internal_flags |= EFA_RDM_OPE_QUEUED_RNR;
 					dlist_insert_tail(&txe->queued_rnr_entry,
-							  &ep->ope_queued_rnr_list);
+							  &efa_rdm_ep_domain(ep)->ope_queued_rnr_list);
 				}
 			}
 		} else {
@@ -497,7 +497,7 @@ void efa_rdm_pke_handle_tx_error(struct efa_rdm_pke *pkt_entry, int prov_errno)
 			if (!(rxe->internal_flags & EFA_RDM_OPE_QUEUED_RNR)) {
 				rxe->internal_flags |= EFA_RDM_OPE_QUEUED_RNR;
 				dlist_insert_tail(&rxe->queued_rnr_entry,
-						  &ep->ope_queued_rnr_list);
+						  &efa_rdm_ep_domain(ep)->ope_queued_rnr_list);
 			}
 		} else {
 			efa_rdm_rxe_handle_error(pkt_entry->ope, err, prov_errno);

--- a/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
@@ -187,7 +187,7 @@ void efa_rdm_pke_handle_cts_recv(struct efa_rdm_pke *pkt_entry)
 
 	if (ope->state != EFA_RDM_TXE_SEND) {
 		ope->state = EFA_RDM_TXE_SEND;
-		dlist_insert_tail(&ope->entry, &ep->ope_longcts_send_list);
+		dlist_insert_tail(&ope->entry, &efa_rdm_ep_domain(ep)->ope_longcts_send_list);
 	}
 }
 
@@ -391,7 +391,7 @@ void efa_rdm_pke_handle_readrsp_sent(struct efa_rdm_pke *pkt_entry)
 			efa_rdm_ope_try_fill_desc(rxe, 0, FI_SEND);
 
 		rxe->state = EFA_RDM_TXE_SEND;
-		dlist_insert_tail(&rxe->entry, &pkt_entry->ep->ope_longcts_send_list);
+		dlist_insert_tail(&rxe->entry, &efa_rdm_ep_domain(pkt_entry->ep)->ope_longcts_send_list);
 	}
 }
 

--- a/prov/efa/test/efa_unit_test_cq.c
+++ b/prov/efa/test/efa_unit_test_cq.c
@@ -289,19 +289,12 @@ void test_ibv_cq_ex_read_bad_recv_status(struct efa_resource **state)
 	efa_unit_test_resource_construct(resource, FI_EP_RDM);
 	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
 
-	/*
-	 * The rx pkt entry should only be allocated and posted by the progress engine.
-	 * However, to mock a receive completion, we have to allocate an rx entry
-	 * and modify it out of band. The proess engine grow the rx pool in the first
-	 * call and set efa_rdm_ep->efa_rx_pkts_posted as the rx pool size. Here we
-	 * follow the progress engine to set the efa_rx_pkts_posted counter manually
-	 * TODO: modify the rx pkt as part of the ibv cq poll mock so we don't have to
-	 * allocate pkt entry and hack the pkt counters.
+	/**
+	 * At this time, pkt entry is already allocated and posted
+	 * Just grab the first pkt entry in the buffer pool.
 	 */
-	pkt_entry = efa_rdm_pke_alloc(efa_rdm_ep, efa_rdm_ep->efa_rx_pkt_pool, EFA_RDM_PKE_FROM_EFA_RX_POOL);
+	pkt_entry = ofi_bufpool_get_ibuf(efa_rdm_ep->efa_rx_pkt_pool, 0);
 	assert_non_null(pkt_entry);
-	efa_rdm_ep->efa_rx_pkts_posted = efa_rdm_ep_get_rx_pool_size(efa_rdm_ep);
-
 
 	efa_rdm_cq = container_of(resource->cq, struct efa_rdm_cq, util_cq.cq_fid.fid);
 
@@ -546,18 +539,12 @@ static void test_impl_ibv_cq_ex_read_unknow_peer_ah(struct efa_resource *resourc
 	assert_non_null(peer);
 	peer->flags |= EFA_RDM_PEER_HANDSHAKE_SENT;
 
-	/*
-	 * The rx pkt entry should only be allocated and posted by the progress engine.
-	 * However, to mock a receive completion, we have to allocate an rx entry
-	 * and modify it out of band. The proess engine grow the rx pool in the first
-	 * call and set efa_rdm_ep->efa_rx_pkts_posted as the rx pool size. Here we
-	 * follow the progress engine to set the efa_rx_pkts_posted counter manually
-	 * TODO: modify the rx pkt as part of the ibv cq poll mock so we don't have to
-	 * allocate pkt entry and hack the pkt counters.
+	/**
+	 * At this time, pkt entry is already allocated and posted
+	 * Just grab the first pkt entry in the buffer pool.
 	 */
-	pkt_entry = efa_rdm_pke_alloc(efa_rdm_ep, efa_rdm_ep->efa_rx_pkt_pool, EFA_RDM_PKE_FROM_EFA_RX_POOL);
+	pkt_entry = ofi_bufpool_get_ibuf(efa_rdm_ep->efa_rx_pkt_pool, 0);
 	assert_non_null(pkt_entry);
-	efa_rdm_ep->efa_rx_pkts_posted = efa_rdm_ep_get_rx_pool_size(efa_rdm_ep);
 
 	pkt_attr.msg_id = 0;
 	pkt_attr.connid = raw_addr.qkey;

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -143,18 +143,12 @@ void test_efa_rdm_ep_handshake_exchange_host_id(struct efa_resource **state, uin
 	assert_int_equal(peer->host_id, 0);
 	assert_int_not_equal(peer->flags & EFA_RDM_PEER_HANDSHAKE_SENT, EFA_RDM_PEER_HANDSHAKE_SENT);
 
-	/*
-	 * The rx pkt entry should only be allocated and posted by the progress engine.
-	 * However, to mock a receive completion, we have to allocate an rx entry
-	 * and modify it out of band. The proess engine grow the rx pool in the first
-	 * call and set efa_rdm_ep->efa_rx_pkts_posted as the rx pool size. Here we
-	 * follow the progress engine to set the efa_rx_pkts_posted counter manually
-	 * TODO: modify the rx pkt as part of the ibv cq poll mock so we don't have to
-	 * allocate pkt entry and hack the pkt counters.
+	/**
+	 * At this time, pkt entry is already allocated and posted
+	 * Just grab the first pkt entry in the buffer pool.
 	 */
-	pkt_entry = efa_rdm_pke_alloc(efa_rdm_ep, efa_rdm_ep->efa_rx_pkt_pool, EFA_RDM_PKE_FROM_EFA_RX_POOL);
+	pkt_entry = ofi_bufpool_get_ibuf(efa_rdm_ep->efa_rx_pkt_pool, 0);
 	assert_non_null(pkt_entry);
-	efa_rdm_ep->efa_rx_pkts_posted = efa_rdm_ep_get_rx_pool_size(efa_rdm_ep);
 
 	pkt_attr.connid = include_connid ? raw_addr.qkey : 0;
 	pkt_attr.host_id = g_efa_unit_test_mocks.peer_host_id;


### PR DESCRIPTION
This patch includes two aspects of changes that get rid
    of the ep_list iteration in cq and cntr progress.
    
1. Pre-post the internal rx pkts and grow pools during ep enable,
    and only repost rx pkts when the ep has recv wc.
    
2. Move the rnr backoff peer list and other queued ope/pkt lists
    into efa_domain, so fi_cq_read can progress these lists once
    no matter how many eps are bind.
    
These 2 changes finally make efa_rdm_ep_progress.c not useful
    because there is no dedicated progress for each ep any more.