### PR TITLE
Revert "prov/efa: Include CQ data header in prefix size"

### DIFF
--- a/prov/efa/docs/efa_rdm_protocol_v4.md
+++ b/prov/efa/docs/efa_rdm_protocol_v4.md
@@ -1374,19 +1374,15 @@ change.
 In fact, because of the existence of the handshake subprotocol, the packet header length of an EAGER_MSGRTM
 will definitely change. Recall that the handshake subprotocol's workflow is:
 
-1. Before receiving handshake packet, an endpoint will always include the
-   optional raw address header in REQ packets.
-2. After receiving handshake packet, an endpoint will stop including the
-   optional raw address header in REQ packets.
+Before receiving handshake packet, an endpoint will always include the optional raw address header in REQ packets.
 
-Furthermore, a REQ packet may also contain the optional CQ data header (section
-3.1) header (`REQ_OPT_CQ_DATA_HDR`) and is not mutually exclusive with other
-optional REQ header components.  Therefore, a compliant request of _constant
-header length_ should include space for the CQ data header.
+After receiving handshake packet, an endpoint will stop including the optional raw address header in REQ packets.
 
-The extra feature "keep packet header length constant" (constant header length)
-is designed to solve this problem. When an endpoint toggles on this extra
-request, its peer will try to satisfy it by keeping the header length constant.
+The extra feature "keep packet header length constant" (constant header length) is designed to solve this problem.
+
+When an endpoint toggles on this extra request, its peer will try to satisfy it by keeping the header length
+constant.  Exactly how to achieve that is up to the implementation to decide.  The easiest way to do so is to keep
+including the raw address header in the EAGER_MSGRTM even after receiving the handshake packet.
 
 Note, because this is an extra request, an endpoint cannot assume its peer will comply with the request. Therefore,
 the receiving endpoint must be able to handle the situation that a received packet does not have the expected header

--- a/prov/efa/src/rdm/efa_rdm_pke_req.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_req.c
@@ -275,7 +275,7 @@ size_t efa_rdm_pke_get_req_hdr_size(struct efa_rdm_pke *pkt_entry)
 		opt_hdr += sizeof(struct efa_rdm_req_opt_raw_addr_hdr) + raw_addr_hdr->addr_len;
 	}
 
-	if (base_hdr->flags & EFA_RDM_REQ_OPT_CQ_DATA_HDR || pkt_entry->ep->use_zcpy_rx)
+	if (base_hdr->flags & EFA_RDM_REQ_OPT_CQ_DATA_HDR)
 		opt_hdr += sizeof(struct efa_rdm_req_opt_cq_data_hdr);
 
 	if (base_hdr->flags & EFA_RDM_PKT_CONNID_HDR) {

--- a/prov/efa/src/rdm/efa_rdm_util.h
+++ b/prov/efa/src/rdm/efa_rdm_util.h
@@ -8,11 +8,7 @@
 #include "efa_rdm_protocol.h"
 #include "efa_rdm_pke.h"
 
-#define EFA_RDM_MSG_PREFIX_SIZE (			\
-	sizeof(struct efa_rdm_pke) +			\
-	sizeof(struct efa_rdm_eager_msgrtm_hdr)	+	\
-	sizeof(struct efa_rdm_req_opt_cq_data_hdr) +	\
-	EFA_RDM_REQ_OPT_RAW_ADDR_HDR_SIZE)
+#define EFA_RDM_MSG_PREFIX_SIZE (sizeof(struct efa_rdm_pke) + sizeof(struct efa_rdm_eager_msgrtm_hdr) + EFA_RDM_REQ_OPT_RAW_ADDR_HDR_SIZE)
 
 #if defined(static_assert) && defined(__x86_64__)
 static_assert(EFA_RDM_MSG_PREFIX_SIZE % 8 == 0, "message prefix size alignment check");


### PR DESCRIPTION
We are moving to a different direction that doesn't require CQ data to be part of the hdr. Revert this change for now.

This reverts commit 90cd7d5f2d948b1042f20635536ac0eafa485437.