### PR TITLE
Added ofi_gettime interfaces to support CLOCK_REALTIME

### DIFF
--- a/include/ofi.h
+++ b/include/ofi.h
@@ -377,6 +377,10 @@ uint64_t ofi_gettime_ns(void);
 uint64_t ofi_gettime_us(void);
 uint64_t ofi_gettime_ms(void);
 
+uint64_t ofi_get_realtime_ns(void);
+uint64_t ofi_get_realtime_ms(void);
+uint64_t ofi_get_realtime_us(void);
+
 static inline uint64_t ofi_timeout_time(int timeout)
 {
 	return (timeout >= 0) ? ofi_gettime_ms() + timeout : 0;

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -1008,6 +1008,7 @@ size_t ofi_ifaddr_get_speed(struct ifaddrs *ifa);
 
 #define file2unix_time	10000000i64
 #define win2unix_epoch	116444736000000000i64
+#define CLOCK_REALTIME 0
 #define CLOCK_MONOTONIC 1
 
 /* Own implementation of clock_gettime*/

--- a/prov/sockets/src/sock_cntr.c
+++ b/prov/sockets/src/sock_cntr.c
@@ -325,7 +325,7 @@ static int sock_cntr_wait(struct fid_cntr *fid_cntr, uint64_t threshold,
 	ofi_atomic_inc32(&cntr->num_waiting);
 
 	if (timeout >= 0) {
-		start_ms = ofi_gettime_ms();
+		start_ms = ofi_get_realtime_ms();
 		end_ms = start_ms + timeout;
 	}
 
@@ -341,7 +341,7 @@ static int sock_cntr_wait(struct fid_cntr *fid_cntr, uint64_t threshold,
 			ret = ofi_wait_cond(&cntr->cond, &cntr->mut, (int) remaining_ms);
 		}
 
-		uint64_t curr_ms = ofi_gettime_ms();
+		uint64_t curr_ms = ofi_get_realtime_ms();
 		if (timeout >= 0) {
 			if (curr_ms >= end_ms) {
 				ret = -FI_ETIMEDOUT;

--- a/prov/sockets/src/sock_wait.c
+++ b/prov/sockets/src/sock_wait.c
@@ -127,7 +127,7 @@ static int sock_wait_wait(struct fid_wait *wait_fid, int timeout)
 
 	wait = container_of(wait_fid, struct sock_wait, wait_fid);
 	if (timeout > 0)
-		start_ms = ofi_gettime_ms();
+		start_ms = ofi_get_realtime_ms();
 
 	head = &wait->fid_list;
 	for (p = head->next; p != head; p = p->next) {
@@ -154,7 +154,7 @@ static int sock_wait_wait(struct fid_wait *wait_fid, int timeout)
 		}
 	}
 	if (timeout > 0) {
-		end_ms = ofi_gettime_ms();
+		end_ms = ofi_get_realtime_ms();
 		timeout -=  (int) (end_ms - start_ms);
 		timeout = timeout < 0 ? 0 : timeout;
 	}

--- a/src/common.c
+++ b/src/common.c
@@ -304,6 +304,24 @@ uint32_t ofi_generate_seed(void)
 	return rand_seed;
 }
 
+uint64_t ofi_get_realtime_ns(void)
+{
+	struct timespec now;
+
+	clock_gettime(CLOCK_REALTIME, &now);
+	return now.tv_sec * 1000000000 + now.tv_nsec;
+}
+
+uint64_t ofi_get_realtime_us(void)
+{
+	return ofi_get_realtime_ns() / 1000;
+}
+
+uint64_t ofi_get_realtime_ms(void)
+{
+	return ofi_get_realtime_ns() / 1000000;
+}
+
 uint64_t ofi_gettime_ns(void)
 {
 	struct timespec now;

--- a/src/unix/osd.c
+++ b/src/unix/osd.c
@@ -116,7 +116,7 @@ int ofi_wait_cond(pthread_cond_t *cond, pthread_mutex_t *mut, int timeout_ms)
 	if (timeout_ms < 0)
 		return pthread_cond_wait(cond, mut);
 
-	t = ofi_gettime_ms() + timeout_ms;
+	t = ofi_get_realtime_ms() + timeout_ms;
 	ts.tv_sec = t / 1000;
 	ts.tv_nsec = (t % 1000) * 1000000;
 	return pthread_cond_timedwait(cond, mut, &ts);


### PR DESCRIPTION
[src/common]: added ofi_get_realtime intefaces to support pthread_cond_timedwait which use CLOCK_REALTIME.In general CLOCK_MONOTONIC is preferred and in use by several providers, therefore new interfaces are added to support the special case of pthread apis.(ref #9614 )

[prov/sockets]: changes made to use ofi_get_realtime instead of ofi_get_time before ofi_wait_cond.

Signed-of-by: Nikhil Nanal <nikhil.nanal@intel.com>