### PR TITLE
Intel/CI: Update oneCCL GPU stage to use torchic partition

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -763,15 +763,18 @@ pipeline {
           steps {
             script {
               dir (RUN_LOCATION) {
-		            run_middleware([["tcp", null]], "oneCCL-GPU-v3", "onecclgpu",
-			                         "gpu", "fabrics-ci", "2", null, null,
-                               "FI_HMEM_DISABLE_P2P=1")
 		            run_middleware([["psm3", null]], "oneCCL-GPU-v3", "onecclgpu",
-			                         "gpu", "fabrics-ci", "2", null, null,
+			       "gpu", "torchic", "1", null, null,
                                "FI_HMEM_DISABLE_P2P=1")
 		            run_middleware([["verbs", null]], "oneCCL-GPU-v3", "onecclgpu",
-                               "gpu", "fabrics-ci", "2", null, null,
+                               "gpu", "torchic", "1", null, null,
                                "FI_HMEM_DISABLE_P2P=1")
+			    run_middleware([["tcp", null]], "oneCCL-GPU-v3", "onecclgpu",
+			       "gpu", "torchic", "1", null, null,
+			       "FI_HMEM_DISABLE_P2P=1")
+			    run_middleware([["shm", null]], "oneCCL-GPU-v3", "onecclgpu",
+			       "gpu", "torchic", "1", null, null,
+			       "FI_HMEM_DISABLE_P2P=1")
               }
             }
           }


### PR DESCRIPTION
OneCCL GPU tests require to use new node which is available with torchic partition.