### PR TITLE
prov/efa: Refactor dmabuf reg

### DIFF
--- a/prov/efa/src/efa_hmem.c
+++ b/prov/efa/src/efa_hmem.c
@@ -97,6 +97,8 @@ static int efa_domain_hmem_info_init_system(struct efa_domain *efa_domain)
 	info->p2p_disabled_by_user = false;
 	info->p2p_required_by_impl = false;
 	info->p2p_supported_by_device = true;
+	info->dmabuf_supported = false;
+
 	efa_domain_hmem_info_init_protocol_thresholds(efa_domain, FI_HMEM_SYSTEM);
 	return 0;
 }
@@ -137,6 +139,7 @@ static int efa_domain_hmem_info_init_cuda(struct efa_domain *efa_domain)
 
 	info->initialized = true;
 	info->p2p_disabled_by_user = false;
+	info->dmabuf_supported = false;
 
 	/* If user is using libfabric API 1.18 or later, by default EFA provider is permitted to
 	 * use CUDA library to support CUDA memory, therefore p2p is not required.
@@ -146,26 +149,24 @@ static int efa_domain_hmem_info_init_cuda(struct efa_domain *efa_domain)
 	else
 		info->p2p_required_by_impl = true;
 
-#if HAVE_EFA_DMABUF_MR
-	ret = cuda_get_dmabuf_fd(ptr, len, &dmabuf_fd, &dmabuf_offset);
+	ret = ofi_hmem_get_dmabuf_fd(FI_HMEM_CUDA, ptr, len, &dmabuf_fd, &dmabuf_offset);
 	if (ret == FI_SUCCESS) {
-		ibv_mr = ibv_reg_dmabuf_mr(g_device_list[0].ibv_pd, dmabuf_offset,
+		ibv_mr = efa_mr_reg_ibv_dmabuf_mr(efa_domain->ibv_pd, dmabuf_offset,
 					   len, (uint64_t)ptr, dmabuf_fd, ibv_access);
 		if (!ibv_mr) {
 			EFA_INFO(FI_LOG_DOMAIN,
 				"Unable to register CUDA device buffer via dmabuf: %s. "
 				"Fall back to ibv_reg_mr\n", fi_strerror(-errno));
-			ibv_mr = ibv_reg_mr(g_device_list[0].ibv_pd, ptr, len, ibv_access);
+			ibv_mr = ibv_reg_mr(efa_domain->ibv_pd, ptr, len, ibv_access);
+		} else {
+			info->dmabuf_supported = true;
 		}
 	} else {
 		EFA_INFO(FI_LOG_DOMAIN,
 			"Unable to retrieve dmabuf fd of CUDA device buffer: %d. "
 			"Fall back to ibv_reg_mr\n", ret);
-		ibv_mr = ibv_reg_mr(g_device_list[0].ibv_pd, ptr, len, ibv_access);
+		ibv_mr = ibv_reg_mr(efa_domain->ibv_pd, ptr, len, ibv_access);
 	}
-#else
-	ibv_mr = ibv_reg_mr(g_device_list[0].ibv_pd, ptr, len, ibv_access);
-#endif
 
 	if (!ibv_mr) {
 		info->p2p_supported_by_device = false;
@@ -247,22 +248,27 @@ static int efa_domain_hmem_info_init_neuron(struct efa_domain *efa_domain)
 	info->p2p_disabled_by_user = false;
 	/* Neuron currently requires P2P */
 	info->p2p_required_by_impl = true;
+	info->dmabuf_supported = false;
 
-#if HAVE_EFA_DMABUF_MR
-	ret = neuron_get_dmabuf_fd(ptr, (uint64_t)len, &dmabuf_fd, &offset);
+	ret = ofi_hmem_get_dmabuf_fd(FI_HMEM_NEURON, ptr, (uint64_t)len, &dmabuf_fd, &offset);
 	if (ret == FI_SUCCESS) {
-		ibv_mr = ibv_reg_dmabuf_mr(
-					g_device_list[0].ibv_pd, offset,
+		ibv_mr = efa_mr_reg_ibv_dmabuf_mr(
+					efa_domain->ibv_pd, offset,
 					len, (uint64_t)ptr, dmabuf_fd, ibv_access);
-	} else if (ret == -FI_ENOPROTOOPT) {
-		EFA_INFO(FI_LOG_MR,
+		if (!ibv_mr) {
+			EFA_INFO(FI_LOG_DOMAIN,
+				"Unable to register neuron device buffer via dmabuf: %s. "
+				"Fall back to ibv_reg_mr\n", fi_strerror(-errno));
+			ibv_mr = ibv_reg_mr(efa_domain->ibv_pd, ptr, len, ibv_access);
+		} else {
+			info->dmabuf_supported = true;
+		}
+	} else {
+		EFA_INFO(FI_LOG_DOMAIN,
 			"Unable to retrieve dmabuf fd of Neuron device buffer, "
 			"Fall back to ibv_reg_mr\n");
-		ibv_mr = ibv_reg_mr(g_device_list[0].ibv_pd, ptr, len, ibv_access);
+		ibv_mr = ibv_reg_mr(efa_domain->ibv_pd, ptr, len, ibv_access);
 	}
-#else
-	ibv_mr = ibv_reg_mr(g_device_list[0].ibv_pd, ptr, len, ibv_access);
-#endif
 
 	if (!ibv_mr) {
 		info->p2p_supported_by_device = false;
@@ -325,6 +331,7 @@ static int efa_domain_hmem_info_init_synapseai(struct efa_domain *efa_domain)
 	/* SynapseAI currently requires P2P */
 	info->p2p_required_by_impl = true;
 	info->p2p_supported_by_device = true;
+	info->dmabuf_supported = true;
 	efa_domain_hmem_info_init_protocol_thresholds(efa_domain, FI_HMEM_SYNAPSEAI);
 
 	/*  Only the long read protocol is supported */

--- a/prov/efa/src/efa_hmem.h
+++ b/prov/efa/src/efa_hmem.h
@@ -26,6 +26,7 @@ struct efa_hmem_info {
 	bool p2p_disabled_by_user;	/* Did the user disable p2p via FI_OPT_FI_HMEM_P2P? */
 	bool p2p_required_by_impl;	/* Is p2p required for this interface? */
 	bool p2p_supported_by_device;	/* do we support p2p with this device */
+	bool dmabuf_supported;
 
 	size_t max_intra_eager_size; /* Maximum message size to use eager protocol for intra-node */
 	size_t max_medium_msg_size;

--- a/prov/efa/src/efa_mr.h
+++ b/prov/efa/src/efa_mr.h
@@ -6,6 +6,9 @@
 
 #include <stdbool.h>
 #include <ofi_mr.h>
+#include <infiniband/verbs.h>
+
+#include "efa_prov.h"
 
 /*
  * Descriptor returned for FI_HMEM peer memory registrations
@@ -34,6 +37,31 @@ struct efa_mr {
 	bool			inserted_to_mr_map;
 	bool 			needs_sync;
 };
+
+#if HAVE_EFA_DMABUF_MR
+
+static inline
+struct ibv_mr *efa_mr_reg_ibv_dmabuf_mr(struct ibv_pd *pd, uint64_t offset,
+					size_t len, uint64_t iova, int fd, int access)
+{
+	return ibv_reg_dmabuf_mr(pd, offset, len, iova, fd, access);
+}
+
+#else
+
+static inline
+struct ibv_mr *efa_mr_reg_ibv_dmabuf_mr(struct ibv_pd *pd, uint64_t offset,
+					size_t len, uint64_t iova, int fd, int access)
+{
+	EFA_WARN(FI_LOG_MR,
+		"ibv_reg_dmabuf_mr is required for memory"
+		" registration with FI_MR_DMABUF flags, but "
+		" not available in the current rdma-core library."
+		" please build libfabric with rdma-core >= 34.0\n");
+	return NULL;
+}
+
+#endif
 
 extern int efa_mr_cache_enable;
 extern size_t efa_mr_max_cached_count;


### PR DESCRIPTION
Introduce a boolean dmabuf_supported in efa_hmem_info, check if dmabuf is supported for different hmem ifaces.

When dmabuf is supported, retrieve the dmabuf fd and use ibv_reg_dmabuf_mr to register memory. 
Otherwise, fall back to ibv_reg_mr. 
Always use ibv_reg_dmabuf_mr when FI_MR_DMABUF is set.

Remove macros in efa_mr_reg_ibv_mr and combine duplicate logic of different hmem ifaces.