### PR TITLE
Intel/CI: Update DMABUF stage to use torchic partition

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -816,9 +816,7 @@ pipeline {
                 dmabuf_output = "${LOG_DIR}/DMABUF-Tests_verbs-rxm_dmabuf"
                 cmd = """ python3.9 runtests.py --test=dmabuf \
                            --prov=verbs --util=rxm --build_hw=gpu"""
-                slurm_batch("fabrics-ci", "1", "${dmabuf_output}_1_reg",
-                            "${cmd}")
-                slurm_batch("fabrics-ci", "2", "${dmabuf_output}_2_reg",
+                slurm_batch("torchic", "1", "${dmabuf_output}_reg",
                             "${cmd}")
               }
             }


### PR DESCRIPTION
DMABUF tests require to use new node which is available with torchic partition.
There is no need for 2 node tests hence the two node tests have been removed.
Log file name has been changed and number of nodes have been removed.