### PR TITLE
V1.21.x Intel/CI: Cherry-pick oneccl gpu stage and dmabuf stage commits

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -816,9 +816,7 @@ pipeline {
                 dmabuf_output = "${LOG_DIR}/DMABUF-Tests_verbs-rxm_dmabuf"
                 cmd = """ python3.9 runtests.py --test=dmabuf \
                            --prov=verbs --util=rxm --build_hw=gpu"""
-                slurm_batch("fabrics-ci", "1", "${dmabuf_output}_1_reg",
-                            "${cmd}")
-                slurm_batch("fabrics-ci", "2", "${dmabuf_output}_2_reg",
+                slurm_batch("torchic", "1", "${dmabuf_output}_reg",
                             "${cmd}")
               }
             }

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -764,14 +764,17 @@ pipeline {
             script {
               dir (RUN_LOCATION) {
 		            run_middleware([["tcp", null]], "oneCCL-GPU-v3", "onecclgpu",
-			                         "gpu", "fabrics-ci", "2", null, null,
+			                         "gpu", "torchic", "1", null, null,
                                "FI_HMEM_DISABLE_P2P=1")
 		            run_middleware([["psm3", null]], "oneCCL-GPU-v3", "onecclgpu",
-			                         "gpu", "fabrics-ci", "2", null, null,
+			                         "gpu", "torchic", "1", null, null,
                                "FI_HMEM_DISABLE_P2P=1")
 		            run_middleware([["verbs", null]], "oneCCL-GPU-v3", "onecclgpu",
-                               "gpu", "fabrics-ci", "2", null, null,
+                               "gpu", "torchic", "1", null, null,
                                "FI_HMEM_DISABLE_P2P=1")
+			    run_middleware([["shm", null]], "oneCCL-GPU-v3", "onecclgpu",
+			       "gpu", "torchic", "1", null, null,
+			       "FI_HMEM_DISABLE_P2P=1")
               }
             }
           }


### PR DESCRIPTION
OneCCL GPU tests require to use new node which is available with torchic partition.
DMABUF tests require to use new node which is available with
torchic partition.
There is no need for 2 node tests hence the two node tests have
been removed.