### PR TITLE
prov/util: Fix issue while displaying addresses with fi_info -a <addr_format>

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -1084,6 +1084,7 @@ const char *ofi_eq_strerror(struct fid_eq *eq_fid, int prov_errno,
 			    const void *err_data, char *buf, size_t len);
 
 int ofi_valid_addr_format(uint32_t prov_format, uint32_t user_format);
+int ofi_match_addr_format(uint32_t if_format, uint32_t user_format);
 int ofi_check_ep_type(const struct fi_provider *prov,
 		      const struct fi_ep_attr *prov_attr,
 		      const struct fi_ep_attr *user_attr);

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -40,6 +40,20 @@
 #define OFI_RMA_DIRECTION_CAPS	(FI_READ | FI_WRITE | \
 				 FI_REMOTE_READ | FI_REMOTE_WRITE)
 
+int ofi_match_addr_format(uint32_t if_format, uint32_t user_format)
+{
+	if (user_format == FI_FORMAT_UNSPEC || if_format == FI_FORMAT_UNSPEC)
+		return 1;
+
+	switch (user_format) {
+	case FI_SOCKADDR:
+		/* Provider supports INET and INET6 */
+		return if_format <= FI_SOCKADDR_IN6;
+	default:
+		return if_format == user_format;
+	}
+}
+
 int ofi_valid_addr_format(uint32_t prov_format, uint32_t user_format)
 {
 	if (user_format == FI_FORMAT_UNSPEC || prov_format == FI_FORMAT_UNSPEC)

--- a/prov/util/src/util_main.c
+++ b/prov/util/src/util_main.c
@@ -391,7 +391,7 @@ static void util_getinfo_ifs(const struct util_prov *prov,
 
 		if (hints && ((hints->caps & addr_entry->comm_caps) !=
 		    (hints->caps & (FI_LOCAL_COMM | FI_REMOTE_COMM)) ||
-		     !ofi_valid_addr_format(addr_format, hints->addr_format)))
+		     !ofi_match_addr_format(addr_format, hints->addr_format)))
 			continue;
 
 		cur = fi_dupinfo(src_info);


### PR DESCRIPTION
This commit addresses issue #9443 for tcp provider. 
A new api ofi_match_addr_format() has been introduced to match the exact addressing format with user requested format while running fi_info test with -a option.

Testing:
> fi_info -p tcp -a FI_SOCKADDR_IN -vvv | grep sockaddr
    src_addr: fi_sockaddr_in://192.168.5.254:0
    src_addr: fi_sockaddr_in://192.168.1.254:0
    src_addr: fi_sockaddr_in://10.23.219.26:0
    src_addr: fi_sockaddr_in://127.0.0.1:0
    src_addr: fi_sockaddr_in://192.168.5.254:0
    src_addr: fi_sockaddr_in://192.168.1.254:0
    src_addr: fi_sockaddr_in://10.23.219.26:0
    src_addr: fi_sockaddr_in://127.0.0.1:0
    src_addr: fi_sockaddr_in://192.168.5.254:0
    src_addr: fi_sockaddr_in://192.168.1.254:0
    src_addr: fi_sockaddr_in://10.23.219.26:0
    src_addr: fi_sockaddr_in://127.0.0.1:0
    src_addr: fi_sockaddr_in://192.168.5.254:0
    src_addr: fi_sockaddr_in://192.168.1.254:0
    src_addr: fi_sockaddr_in://10.23.219.26:0
    src_addr: fi_sockaddr_in://127.0.0.1:0
    src_addr: fi_sockaddr_in://192.168.5.254:0
    src_addr: fi_sockaddr_in://192.168.1.254:0
    src_addr: fi_sockaddr_in://10.23.219.26:0
    src_addr: fi_sockaddr_in://127.0.0.1:0
    
    > fi_info -p tcp -a FI_SOCKADDR_IN6 -vvv | grep sockaddr
    src_addr: fi_sockaddr_in6://[fe80::bace:f603:10:88d4]:0
    src_addr: fi_sockaddr_in6://[fe80::a6bf:1ff:fe84:bbfa]:0
    src_addr: fi_sockaddr_in6://[fe80::a6bf:1ff:fe84:bbf9]:0
    src_addr: fi_sockaddr_in6://[::1]:0
    src_addr: fi_sockaddr_in6://[fe80::bace:f603:10:88d4]:0
    src_addr: fi_sockaddr_in6://[fe80::a6bf:1ff:fe84:bbfa]:0
    src_addr: fi_sockaddr_in6://[fe80::a6bf:1ff:fe84:bbf9]:0
    src_addr: fi_sockaddr_in6://[::1]:0
    src_addr: fi_sockaddr_in6://[fe80::bace:f603:10:88d4]:0
    src_addr: fi_sockaddr_in6://[fe80::a6bf:1ff:fe84:bbfa]:0
    src_addr: fi_sockaddr_in6://[fe80::a6bf:1ff:fe84:bbf9]:0
    src_addr: fi_sockaddr_in6://[::1]:0
    src_addr: fi_sockaddr_in6://[fe80::bace:f603:10:88d4]:0
    src_addr: fi_sockaddr_in6://[fe80::a6bf:1ff:fe84:bbfa]:0
    src_addr: fi_sockaddr_in6://[fe80::a6bf:1ff:fe84:bbf9]:0
    src_addr: fi_sockaddr_in6://[::1]:0
    src_addr: fi_sockaddr_in6://[fe80::bace:f603:10:88d4]:0
    src_addr: fi_sockaddr_in6://[fe80::a6bf:1ff:fe84:bbfa]:0
    src_addr: fi_sockaddr_in6://[fe80::a6bf:1ff:fe84:bbf9]:0
    src_addr: fi_sockaddr_in6://[::1]:0