### PR TITLE
prov/efa: Implement FI_MORE for send and rdma-write

### DIFF
--- a/prov/efa/src/efa_base_ep.h
+++ b/prov/efa/src/efa_base_ep.h
@@ -46,6 +46,7 @@ struct efa_base_ep {
 
 	bool util_ep_initialized;
 	bool efa_qp_enabled;
+	bool is_wr_started;
 
 	struct ibv_send_wr xmit_more_wr_head;
 	struct ibv_send_wr *xmit_more_wr_tail;

--- a/prov/efa/src/rdm/efa_rdm_ep_progress.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_progress.c
@@ -286,7 +286,7 @@ ssize_t efa_rdm_ep_post_queued_pkts(struct efa_rdm_ep *ep,
 			assert(((struct efa_rdm_rma_context_pkt *)pkt_entry->wiredata)->context_type == EFA_RDM_RDMA_WRITE_CONTEXT);
 			ret = efa_rdm_pke_write(pkt_entry);
 		} else {
-			ret = efa_rdm_pke_sendv(&pkt_entry, 1);
+			ret = efa_rdm_pke_sendv(&pkt_entry, 1, 0);
 		}
 
 		if (ret) {

--- a/prov/efa/src/rdm/efa_rdm_ep_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_utils.c
@@ -617,7 +617,7 @@ ssize_t efa_rdm_ep_post_handshake(struct efa_rdm_ep *ep, struct efa_rdm_peer *pe
 
 	efa_rdm_pke_init_handshake(pkt_entry, addr);
 
-	ret = efa_rdm_pke_sendv(&pkt_entry, 1);
+	ret = efa_rdm_pke_sendv(&pkt_entry, 1, 0);
 	if (OFI_UNLIKELY(ret)) {
 		efa_rdm_pke_release_tx(pkt_entry);
 	}

--- a/prov/efa/src/rdm/efa_rdm_pke.h
+++ b/prov/efa/src/rdm/efa_rdm_pke.h
@@ -227,7 +227,7 @@ struct efa_rdm_pke *efa_rdm_pke_clone(struct efa_rdm_pke *src,
 struct efa_rdm_pke *efa_rdm_pke_get_unexp(struct efa_rdm_pke **pkt_entry_ptr);
 
 ssize_t efa_rdm_pke_sendv(struct efa_rdm_pke **pkt_entry_vec,
-			  int pkt_entry_cnt);
+			  int pkt_entry_cnt, uint64_t flags);
 
 int efa_rdm_pke_read(struct efa_rdm_pke *pkt_entry,
 		     void *local_buf, size_t len, void *desc,


### PR DESCRIPTION
For send, only respect FI_MORE for eager pkt type
because
1. For some non-REQ pkts like CTSDATA, its current implementation
relies on the logic that efa_rdm_ope_post_send always rings the doorbell,
because the ep progress call will keep calling this function until
ope->window is 0, but ope->window will only be decremented after
the CTSDATA pkts are actually posted to rdma-core.
2. For non-eager REQ packets, we already send multiple pkts that contain
data and make the firmware saturated, there is no value to queue
pkts in this case.