### PR TITLE
fabtests/pytest: improve client-server test timeout behavior

### DIFF
--- a/fabtests/pytest/common.py
+++ b/fabtests/pytest/common.py
@@ -495,7 +495,7 @@ class ClientServerTest:
                 shell=True,
                 universal_newlines=True,
             ),
-            self._timeout,
+            self._timeout + SERVER_RESTART_DELAY_MS/1000,
             output_file,
         )
 
@@ -554,7 +554,7 @@ class ClientServerTest:
         server_timed_out = False
         try:
             server_output, _ = server_process.communicate(
-                timeout=self._timeout)
+                timeout=self._timeout + SERVER_RESTART_DELAY_MS/1000)
         except TimeoutExpired:
             server_process.terminate()
             server_timed_out = True


### PR DESCRIPTION
This patch improves the client-server test timeout behavior in 2 ways:
- Save client process output to a file instead of reading from pipe. Currently if the client times out, there is a chance that we cannot read the output.
- Add additional timeout in process.communicate to account for the overhead in process startup.