### PR TITLE
Fabtest: test_rma_pingpong bugfix

### DIFF
--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -158,6 +158,7 @@ nobase_dist_config_DATA = \
 	pytest/default/test_rdm.py \
 	pytest/default/test_recv_cancel.py \
 	pytest/default/test_rma_bw.py \
+	pytest/default/test_rma_pingpong.py \
 	pytest/default/test_scalable_ep.py \
 	pytest/default/test_shared_ctx.py \
 	pytest/default/test_ubertest.py \
@@ -173,6 +174,7 @@ nobase_dist_config_DATA = \
 	pytest/efa/test_dgram.py \
 	pytest/efa/test_rdm.py \
 	pytest/efa/test_rma_bw.py \
+	pytest/efa/test_rma_pingpong.py \
 	pytest/efa/test_unexpected_msg.py \
 	pytest/efa/test_multi_recv.py \
 	pytest/efa/test_rnr.py \
@@ -197,6 +199,7 @@ nobase_dist_config_DATA = \
 	pytest/shm/test_multi_recv.py \
 	pytest/shm/test_rdm.py \
 	pytest/shm/test_rma_bw.py \
+	pytest/shm/test_rma_pingpong.py \
 	pytest/shm/test_ubertest.py \
 	pytest/shm/test_unexpected_msg.py \
 	pytest/shm/test_sighandler.py \

--- a/fabtests/benchmarks/benchmark_shared.c
+++ b/fabtests/benchmarks/benchmark_shared.c
@@ -158,18 +158,20 @@ int pingpong_rma(enum ft_rma_opcodes rma_op, struct fi_rma_iov *remote)
 	if (ft_check_opts(FT_OPT_VERIFY_DATA))
 		inject_size = 0;
 
-	ret = ft_sync();
-	if (ret)
-		return ret;
-
 	if (opts.transfer_size == 0) {
 		FT_ERR("Zero-sized transfers not supported");
 		return EXIT_FAILURE;
 	}
 
-	/* Init rx_buf with invalid iteration number */
+	/* Init rx_buf with invalid iteration number.
+	 * This must be done before the sender sends any data.
+	 */
 	if (rma_op == FT_RMA_WRITE)
 		*(rx_buf + opts.transfer_size - 1) = (char)-1;
+
+	ret = ft_sync();
+	if (ret)
+		return ret;
 
 	if (opts.dst_addr) {
 		for (i = 0; i < opts.iterations + opts.warmup_iterations; i++) {

--- a/fabtests/pytest/efa/test_rma_pingpong.py
+++ b/fabtests/pytest/efa/test_rma_pingpong.py
@@ -10,33 +10,27 @@ def rma_pingpong_message_size(request):
     return request.param
 
 
-@pytest.mark.parametrize("operation_type", ["writedata", "write"])
+@pytest.mark.parametrize("operation_type", ["writedata"])
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
 def test_rma_pingpong(cmdline_args, iteration_type, operation_type, completion_semantic, memory_type):
-    if memory_type != "host_to_host" and operation_type == "write":
-        pytest.skip("no hmem memory support for pingpong_rma write test")
     command = "fi_rma_pingpong -e rdm"
     command = command + " -o " + operation_type + " " + perf_progress_model_cli
     efa_run_client_server_test(cmdline_args, command, iteration_type, completion_semantic, memory_type, "all")
 
 
 @pytest.mark.functional
-@pytest.mark.parametrize("operation_type", ["writedata", "write"])
+@pytest.mark.parametrize("operation_type", ["writedata"])
 def test_rma_pingpong_range(cmdline_args, operation_type, completion_semantic, rma_pingpong_message_size, memory_type):
-    if memory_type != "host_to_host" and operation_type == "write":
-        pytest.skip("no hmem memory support for pingpong_rma write test")
     command = "fi_rma_pingpong -e rdm"
     command = command + " -o " + operation_type
     efa_run_client_server_test(cmdline_args, command, "short", completion_semantic, memory_type, rma_pingpong_message_size)
 
 
 @pytest.mark.functional
-@pytest.mark.parametrize("operation_type", ["writedata", "write"])
+@pytest.mark.parametrize("operation_type", ["writedata"])
 def test_rma_pingpong_range_no_inject(cmdline_args, operation_type, completion_semantic, rma_pingpong_message_size, memory_type):
-    if memory_type != "host_to_host" and operation_type == "write":
-        pytest.skip("no hmem memory support for pingpong_rma write test")
     command = "fi_rma_pingpong -e rdm -j 0"
     command = command + " -o " + operation_type
     efa_run_client_server_test(cmdline_args, command, "short", completion_semantic, "host_to_host", rma_pingpong_message_size)

--- a/fabtests/pytest/efa/test_rma_pingpong.py
+++ b/fabtests/pytest/efa/test_rma_pingpong.py
@@ -31,7 +31,7 @@ def test_rma_pingpong_range(cmdline_args, operation_type, completion_semantic, m
 
 @pytest.mark.functional
 @pytest.mark.parametrize("operation_type", ["writedata", "write"])
-def test_rma_pingpong_range_no_inject(cmdline_args, operation_type, completion_semantic, inject_message_size):
+def test_rma_pingpong_range_no_inject(cmdline_args, operation_type, completion_semantic, inject_message_size, memory_type):
     if memory_type != "host_to_host" and operation_type == "write":
         pytest.skip("no hmem memory support for pingpong_rma write test")
     command = "fi_rma_pingpong -e rdm -j 0"

--- a/fabtests/pytest/efa/test_rma_pingpong.py
+++ b/fabtests/pytest/efa/test_rma_pingpong.py
@@ -3,6 +3,13 @@ from common import perf_progress_model_cli
 import pytest
 
 
+@pytest.fixture(params=["r:4048,4,4148",
+                        "r:8000,4,9000",
+                        "r:17000,4,18000"])
+def rma_pingpong_message_size(request):
+    return request.param
+
+
 @pytest.mark.parametrize("operation_type", ["writedata", "write"])
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
@@ -12,30 +19,24 @@ def test_rma_pingpong(cmdline_args, iteration_type, operation_type, completion_s
         pytest.skip("no hmem memory support for pingpong_rma write test")
     command = "fi_rma_pingpong -e rdm"
     command = command + " -o " + operation_type + " " + perf_progress_model_cli
-    # rma_pingpong test with data verification takes longer to finish
-    timeout = max(540, cmdline_args.timeout)
-    efa_run_client_server_test(cmdline_args, command, iteration_type, completion_semantic, memory_type, "all", timeout=timeout)
+    efa_run_client_server_test(cmdline_args, command, iteration_type, completion_semantic, memory_type, "all")
 
 
 @pytest.mark.functional
 @pytest.mark.parametrize("operation_type", ["writedata", "write"])
-def test_rma_pingpong_range(cmdline_args, operation_type, completion_semantic, message_size, memory_type):
+def test_rma_pingpong_range(cmdline_args, operation_type, completion_semantic, rma_pingpong_message_size, memory_type):
     if memory_type != "host_to_host" and operation_type == "write":
         pytest.skip("no hmem memory support for pingpong_rma write test")
     command = "fi_rma_pingpong -e rdm"
     command = command + " -o " + operation_type
-    # rma_pingpong test with data verification takes longer to finish
-    timeout = max(540, cmdline_args.timeout)
-    efa_run_client_server_test(cmdline_args, command, "short", completion_semantic, memory_type, message_size, timeout=timeout)
+    efa_run_client_server_test(cmdline_args, command, "short", completion_semantic, memory_type, rma_pingpong_message_size)
 
 
 @pytest.mark.functional
 @pytest.mark.parametrize("operation_type", ["writedata", "write"])
-def test_rma_pingpong_range_no_inject(cmdline_args, operation_type, completion_semantic, inject_message_size, memory_type):
+def test_rma_pingpong_range_no_inject(cmdline_args, operation_type, completion_semantic, rma_pingpong_message_size, memory_type):
     if memory_type != "host_to_host" and operation_type == "write":
         pytest.skip("no hmem memory support for pingpong_rma write test")
     command = "fi_rma_pingpong -e rdm -j 0"
     command = command + " -o " + operation_type
-    # rma_pingpong test with data verification takes longer to finish
-    timeout = max(540, cmdline_args.timeout)
-    efa_run_client_server_test(cmdline_args, command, "short", completion_semantic, "host_to_host", inject_message_size, timeout=timeout)
+    efa_run_client_server_test(cmdline_args, command, "short", completion_semantic, "host_to_host", rma_pingpong_message_size)

--- a/fabtests/pytest/shm/test_rma_pingpong.py
+++ b/fabtests/pytest/shm/test_rma_pingpong.py
@@ -3,6 +3,13 @@ from shm.shm_common import shm_run_client_server_test
 from common import perf_progress_model_cli
 
 
+@pytest.fixture(params=["r:4048,4,4148",
+                        "r:8000,4,9000",
+                        "r:17000,4,18000"])
+def rma_pingpong_message_size(request):
+    return request.param
+
+
 @pytest.mark.parametrize("operation_type", ["writedata", "write"])
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
@@ -12,17 +19,13 @@ def test_rma_pingpong(cmdline_args, iteration_type, operation_type, completion_s
         pytest.skip("no hmem memory support for pingpong_rma write test")
     command = "fi_rma_pingpong -e rdm"
     command = command + " -o " + operation_type + " " + perf_progress_model_cli
-    # rma_pingpong test with data verification takes longer to finish
-    timeout = max(540, cmdline_args.timeout)
-    shm_run_client_server_test(cmdline_args, command, iteration_type, completion_semantic, memory_type, "all", timeout=timeout)
+    shm_run_client_server_test(cmdline_args, command, iteration_type, completion_semantic, memory_type, "all")
 
 @pytest.mark.functional
 @pytest.mark.parametrize("operation_type", ["writedata", "write"])
-def test_rma_pingpong_range(cmdline_args, operation_type, completion_semantic, message_size, memory_type):
+def test_rma_pingpong_range(cmdline_args, operation_type, completion_semantic, rma_pingpong_message_size, memory_type):
     if memory_type != "host_to_host" and operation_type == "write":
         pytest.skip("no hmem memory support for pingpong_rma write test")
     command = "fi_rma_pingpong -e rdm"
     command = command + " -o " + operation_type
-    # rma_pingpong test with data verification takes longer to finish
-    timeout = max(540, cmdline_args.timeout)
-    shm_run_client_server_test(cmdline_args, command, "short", completion_semantic, memory_type, message_size, timeout=timeout)
+    shm_run_client_server_test(cmdline_args, command, "short", completion_semantic, memory_type, rma_pingpong_message_size)

--- a/fabtests/pytest/shm/test_rma_pingpong.py
+++ b/fabtests/pytest/shm/test_rma_pingpong.py
@@ -10,22 +10,18 @@ def rma_pingpong_message_size(request):
     return request.param
 
 
-@pytest.mark.parametrize("operation_type", ["writedata", "write"])
+@pytest.mark.parametrize("operation_type", ["writedata"])
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
 def test_rma_pingpong(cmdline_args, iteration_type, operation_type, completion_semantic, memory_type):
-    if memory_type != "host_to_host" and operation_type == "write":
-        pytest.skip("no hmem memory support for pingpong_rma write test")
     command = "fi_rma_pingpong -e rdm"
     command = command + " -o " + operation_type + " " + perf_progress_model_cli
     shm_run_client_server_test(cmdline_args, command, iteration_type, completion_semantic, memory_type, "all")
 
 @pytest.mark.functional
-@pytest.mark.parametrize("operation_type", ["writedata", "write"])
+@pytest.mark.parametrize("operation_type", ["writedata"])
 def test_rma_pingpong_range(cmdline_args, operation_type, completion_semantic, rma_pingpong_message_size, memory_type):
-    if memory_type != "host_to_host" and operation_type == "write":
-        pytest.skip("no hmem memory support for pingpong_rma write test")
     command = "fi_rma_pingpong -e rdm"
     command = command + " -o " + operation_type
     shm_run_client_server_test(cmdline_args, command, "short", completion_semantic, memory_type, rma_pingpong_message_size)


### PR DESCRIPTION
1. The fixture memory_type was missing in test_rma_pingpong_range_no_inject
2. The RMA pingpong test should not run with 0-byte messages as zero-sized transfers are not supported. We should use different message sizes for rma pingpong, starting from non-zero values.