### PR TITLE
prov/efa: Only update tag in rxe for tagged operation.

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_msg.c
+++ b/prov/efa/src/rdm/efa_rdm_msg.c
@@ -701,8 +701,6 @@ struct efa_rdm_ope *efa_rdm_msg_alloc_unexp_rxe_for_rtm(struct efa_rdm_ep *ep,
 	if (OFI_UNLIKELY(!rxe))
 		return NULL;
 
-	if (op == ofi_op_tagged)
-		rxe->tag = efa_rdm_pke_get_rtm_tag(unexp_pkt_entry);
 	rxe->internal_flags = 0;
 	rxe->state = EFA_RDM_RXE_UNEXP;
 	rxe->unexp_pkt = unexp_pkt_entry;

--- a/prov/efa/src/rdm/efa_rdm_pke_rtm.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtm.c
@@ -167,8 +167,10 @@ void efa_rdm_pke_rtm_update_rxe(struct efa_rdm_pke *pkt_entry,
 	rxe->addr = pkt_entry->addr;
 	rxe->msg_id = efa_rdm_pke_get_rtm_msg_id(pkt_entry);
 	rxe->total_len = efa_rdm_pke_get_rtm_msg_length(pkt_entry);
-	rxe->tag = efa_rdm_pke_get_rtm_tag(pkt_entry);
-	rxe->cq_entry.tag = rxe->tag;
+	if (rxe->op == ofi_op_tagged) {
+		rxe->tag = efa_rdm_pke_get_rtm_tag(pkt_entry);
+		rxe->cq_entry.tag = rxe->tag;
+	}
 }
 
 /**


### PR DESCRIPTION
Currently, efa_rdm_pke_rtm_update_rxe updates rxe->tag and rxe->cq_entry.tag for both untagged and tagged operations. This is a bug because it should be updated for ofi_op_tagged operation only.