### PR TITLE
fabtests: support testing inject with cq data

### DIFF
--- a/fabtests/benchmarks/benchmark_shared.c
+++ b/fabtests/benchmarks/benchmark_shared.c
@@ -306,7 +306,7 @@ int bandwidth(void)
 			}
 			if (opts.transfer_size <= inject_size) {
 				ret = ft_post_inject_buf(ep, remote_fi_addr,
-						opts.transfer_size,
+						opts.transfer_size, NO_CQ_DATA,
 						tx_ctx_arr[j].buf, tx_seq);
 			} else {
 				ret = ft_post_tx_buf(ep, remote_fi_addr,

--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -2195,16 +2195,28 @@ ssize_t ft_tx_rma(enum ft_rma_opcodes rma_op, struct fi_rma_iov *remote,
 }
 
 ssize_t ft_post_inject_buf(struct fid_ep *ep, fi_addr_t fi_addr, size_t size,
-			   void *op_buf, uint64_t op_tag)
+			   uint64_t data, void *op_buf, uint64_t op_tag)
 {
 	if (hints->caps & FI_TAGGED) {
-		FT_POST(fi_tinject, ft_progress, txcq, tx_seq, &tx_cq_cntr,
-			"inject", ep, op_buf, size + ft_tx_prefix_size(),
-			fi_addr, op_tag);
+		if (data != NO_CQ_DATA) {
+			FT_POST(fi_tinjectdata, ft_progress, txcq, tx_seq, &tx_cq_cntr,
+				"inject", ep, op_buf, size + ft_tx_prefix_size(),
+				data, fi_addr, op_tag);
+		} else {
+			FT_POST(fi_tinject, ft_progress, txcq, tx_seq, &tx_cq_cntr,
+				"inject", ep, op_buf, size + ft_tx_prefix_size(),
+				fi_addr, op_tag);
+		}
 	} else {
-		FT_POST(fi_inject, ft_progress, txcq, tx_seq, &tx_cq_cntr,
-			"inject", ep, op_buf, size + ft_tx_prefix_size(),
-			fi_addr);
+		if (data != NO_CQ_DATA) {
+			FT_POST(fi_injectdata, ft_progress, txcq, tx_seq, &tx_cq_cntr,
+				"inject", ep, op_buf, size + ft_tx_prefix_size(),
+				data, fi_addr);
+		} else {
+			FT_POST(fi_inject, ft_progress, txcq, tx_seq, &tx_cq_cntr,
+				"inject", ep, op_buf, size + ft_tx_prefix_size(),
+				fi_addr);
+		}
 	}
 
 	tx_cq_cntr++;
@@ -2213,7 +2225,7 @@ ssize_t ft_post_inject_buf(struct fid_ep *ep, fi_addr_t fi_addr, size_t size,
 
 ssize_t ft_post_inject(struct fid_ep *ep, fi_addr_t fi_addr, size_t size)
 {
-	return ft_post_inject_buf(ep, fi_addr, size, tx_buf, tx_seq);
+	return ft_post_inject_buf(ep, fi_addr, size, NO_CQ_DATA, tx_buf, tx_seq);
 }
 
 ssize_t ft_inject(struct fid_ep *ep, fi_addr_t fi_addr, size_t size)

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -567,7 +567,7 @@ ssize_t ft_tx(struct fid_ep *ep, fi_addr_t fi_addr, size_t size, void *ctx);
 ssize_t ft_tx_rma(enum ft_rma_opcodes rma_op, struct fi_rma_iov *remote,
 		  struct fid_ep *ep, fi_addr_t fi_addr, size_t size, void *ctx);
 ssize_t ft_post_inject_buf(struct fid_ep *ep, fi_addr_t fi_addr, size_t size,
-		       void *op_buf, uint64_t op_tag);
+		       uint64_t data, void *op_buf, uint64_t op_tag);
 ssize_t ft_post_inject(struct fid_ep *ep, fi_addr_t fi_addr, size_t size);
 ssize_t ft_inject(struct fid_ep *ep, fi_addr_t fi_addr, size_t size);
 ssize_t ft_inject_rma(enum ft_rma_opcodes rma_op, struct fi_rma_iov *remote,


### PR DESCRIPTION
Currently, ft_post_inject_buf doesn't support posting fi_injectdata and fi_tinjectdata when given a cq data. This patch adds such feature without changing the current tests' behavior