### PR TITLE
prov/efa: merge multiple ope queued list

### DIFF
--- a/prov/efa/src/efa_domain.h
+++ b/prov/efa/src/efa_domain.h
@@ -34,12 +34,8 @@ struct efa_domain {
 	size_t			rdm_cq_size;
 	/* number of rdma-read messages in flight */
 	uint64_t		num_read_msg_in_flight;
-	/* op entries with queued rnr packets */
-	struct dlist_entry ope_queued_rnr_list;
-	/* op entries with queued ctrl packets */
-	struct dlist_entry ope_queued_ctrl_list;
-	/* op entries with queued read requests */
-	struct dlist_entry ope_queued_read_list;
+	/* queued op entries */
+	struct dlist_entry ope_queued_list;
 	/* tx/rx_entries used by long CTS msg/write/read protocol
          * which have data to be sent */
 	struct dlist_entry ope_longcts_send_list;

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -754,17 +754,17 @@ bool efa_rdm_ep_has_unfinished_send(struct efa_rdm_ep *efa_rdm_ep)
 	if (efa_rdm_ep->efa_outstanding_tx_ops > 0)
 		return true;
 
-	dlist_foreach_safe(&efa_rdm_ep_domain(efa_rdm_ep)->ope_queued_rnr_list, entry, tmp) {
+	dlist_foreach_safe(&efa_rdm_ep_domain(efa_rdm_ep)->ope_queued_list, entry, tmp) {
 		ope = container_of(entry, struct efa_rdm_ope,
-					queued_rnr_entry);
+					queued_entry);
 		if (ope->ep == efa_rdm_ep) {
 			return true;
 		}
 	}
 
-	dlist_foreach_safe(&efa_rdm_ep_domain(efa_rdm_ep)->ope_queued_ctrl_list, entry, tmp) {
+	dlist_foreach_safe(&efa_rdm_ep_domain(efa_rdm_ep)->ope_queued_list, entry, tmp) {
 		ope = container_of(entry, struct efa_rdm_ope,
-					queued_ctrl_entry);
+					queued_entry);
 		if (ope->ep == efa_rdm_ep) {
 			return true;
 		}

--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -130,10 +130,10 @@ void efa_rdm_txe_release(struct efa_rdm_ope *txe)
 	}
 
 	if (txe->internal_flags & EFA_RDM_OPE_QUEUED_RNR)
-		dlist_remove(&txe->queued_rnr_entry);
+		dlist_remove(&txe->queued_entry);
 
 	if (txe->internal_flags & EFA_RDM_OPE_QUEUED_CTRL)
-		dlist_remove(&txe->queued_ctrl_entry);
+		dlist_remove(&txe->queued_entry);
 
 #ifdef ENABLE_EFA_POISONING
 	efa_rdm_poison_mem_region(txe,
@@ -177,11 +177,11 @@ void efa_rdm_rxe_release_internal(struct efa_rdm_ope *rxe)
 					     pkt_entry, entry, tmp) {
 			efa_rdm_pke_release_tx(pkt_entry);
 		}
-		dlist_remove(&rxe->queued_rnr_entry);
+		dlist_remove(&rxe->queued_entry);
 	}
 
 	if (rxe->internal_flags & EFA_RDM_OPE_QUEUED_CTRL)
-		dlist_remove(&rxe->queued_ctrl_entry);
+		dlist_remove(&rxe->queued_entry);
 
 #ifdef ENABLE_EFA_POISONING
 	efa_rdm_poison_mem_region(rxe,
@@ -588,11 +588,11 @@ void efa_rdm_rxe_handle_error(struct efa_rdm_ope *rxe, int err, int prov_errno)
 					     struct efa_rdm_pke,
 					     pkt_entry, entry, tmp)
 			efa_rdm_pke_release_tx(pkt_entry);
-		dlist_remove(&rxe->queued_rnr_entry);
+		dlist_remove(&rxe->queued_entry);
 	}
 
 	if (rxe->internal_flags & EFA_RDM_OPE_QUEUED_CTRL)
-		dlist_remove(&rxe->queued_ctrl_entry);
+		dlist_remove(&rxe->queued_entry);
 
 	if (rxe->unexp_pkt) {
 		efa_rdm_pke_release_rx(rxe->unexp_pkt);
@@ -685,10 +685,10 @@ void efa_rdm_txe_handle_error(struct efa_rdm_ope *txe, int err, int prov_errno)
 	}
 
 	if (txe->internal_flags & EFA_RDM_OPE_QUEUED_RNR)
-		dlist_remove(&txe->queued_rnr_entry);
+		dlist_remove(&txe->queued_entry);
 
 	if (txe->internal_flags & EFA_RDM_OPE_QUEUED_CTRL)
-		dlist_remove(&txe->queued_ctrl_entry);
+		dlist_remove(&txe->queued_entry);
 
 	dlist_foreach_container_safe(&txe->queued_pkts,
 				     struct efa_rdm_pke,
@@ -1571,8 +1571,8 @@ int efa_rdm_ope_post_remote_read_or_queue(struct efa_rdm_ope *ope)
 	err = efa_rdm_ope_post_read(ope);
 	switch (err) {
 	case -FI_EAGAIN:
-		dlist_insert_tail(&ope->queued_read_entry,
-				  &efa_rdm_ep_domain(ope->ep)->ope_queued_read_list);
+		dlist_insert_tail(&ope->queued_entry,
+				  &efa_rdm_ep_domain(ope->ep)->ope_queued_list);
 		ope->internal_flags |= EFA_RDM_OPE_QUEUED_READ;
 		err = 0;
 		break;
@@ -1807,8 +1807,8 @@ ssize_t efa_rdm_ope_post_send_fallback(struct efa_rdm_ope *ope,
  * @brief post packet(s) according to packet type. Queue the post if -FI_EAGAIN is encountered.
  *
  * This function will call efa_rdm_ope_post_send() to post packet(s) according to packet type.
- * If efa_rdm_ope_post_send() returned -FI_EAGAIN, this function will put the txe in efa_rdm_ep's
- * queued_ctrl_list. The progress engine will try to post the packet later.
+ * If efa_rdm_ope_post_send() returned -FI_EAGAIN, this function will put the txe in efa_domain's
+ * queued_list. The progress engine will try to post the packet later.
  *
  * This function is mainly used by packet handler to post responsive ctrl packet (such as EOR and CTS).
  *
@@ -1825,8 +1825,8 @@ ssize_t efa_rdm_ope_post_send_or_queue(struct efa_rdm_ope *ope, int pkt_type)
 		assert(!(ope->internal_flags & EFA_RDM_OPE_QUEUED_RNR));
 		ope->internal_flags |= EFA_RDM_OPE_QUEUED_CTRL;
 		ope->queued_ctrl_type = pkt_type;
-		dlist_insert_tail(&ope->queued_ctrl_entry,
-				  &efa_rdm_ep_domain(ope->ep)->ope_queued_ctrl_list);
+		dlist_insert_tail(&ope->queued_entry,
+				  &efa_rdm_ep_domain(ope->ep)->ope_queued_list);
 		err = 0;
 	}
 

--- a/prov/efa/src/rdm/efa_rdm_ope.h
+++ b/prov/efa/src/rdm/efa_rdm_ope.h
@@ -126,14 +126,8 @@ struct efa_rdm_ope {
 	/* ep_entry is linked to tx/rxe_list in efa_rdm_ep */
 	struct dlist_entry ep_entry;
 
-	/* queued_ctrl_entry is linked with tx/rx_queued_ctrl_list in efa_domain */
-	struct dlist_entry queued_ctrl_entry;
-
-	/* queued_read_entry is linked with ope_queued_read_list in efa_domain */
-	struct dlist_entry queued_read_entry;
-
-	/* queued_rnr_entry is linked with tx/rx_queued_rnr_list in efa_domain */
-	struct dlist_entry queued_rnr_entry;
+	/* queued_entry is linked with ope_queued_list in efa_domain */
+	struct dlist_entry queued_entry;
 
 	/* Queued packets due to TX queue full or RNR backoff */
 	struct dlist_entry queued_pkts;
@@ -218,7 +212,7 @@ void efa_rdm_rxe_release_internal(struct efa_rdm_ope *rxe);
 /**
  * @brief flag to tell if an ope encouter RNR when sending packets
  *
- * If an ope has this flag, it is on the ope_queued_rnr_list
+ * If an ope has this flag, it is on the ope_queued_list
  * of the endpoint.
  */
 #define EFA_RDM_OPE_QUEUED_RNR BIT_ULL(9)
@@ -242,7 +236,7 @@ void efa_rdm_rxe_release_internal(struct efa_rdm_ope *rxe);
 /**
  * @brief flag to indicate an ope has queued ctrl packet,
  *
- * If this flag is on, the op_entyr is on the ope_queued_ctrl_list
+ * If this flag is on, the op_entyr is on the ope_queued_list
  * of the endpoint
  */
 #define EFA_RDM_OPE_QUEUED_CTRL BIT_ULL(11)
@@ -264,7 +258,7 @@ void efa_rdm_rxe_release_internal(struct efa_rdm_ope *rxe);
 /**
  * @brief flag to indicate an ope has queued read requests
  *
- * When this flag is on, the ope is on ope_queued_read_list
+ * When this flag is on, the ope is on ope_queued_list
  * of the endpoint
  */
 #define EFA_RDM_OPE_QUEUED_READ 	BIT_ULL(12)

--- a/prov/efa/src/rdm/efa_rdm_pke_cmd.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_cmd.c
@@ -475,8 +475,8 @@ void efa_rdm_pke_handle_tx_error(struct efa_rdm_pke *pkt_entry, int prov_errno)
 				efa_rdm_ep_queue_rnr_pkt(ep, &txe->queued_pkts, pkt_entry);
 				if (!(txe->internal_flags & EFA_RDM_OPE_QUEUED_RNR)) {
 					txe->internal_flags |= EFA_RDM_OPE_QUEUED_RNR;
-					dlist_insert_tail(&txe->queued_rnr_entry,
-							  &efa_rdm_ep_domain(ep)->ope_queued_rnr_list);
+					dlist_insert_tail(&txe->queued_entry,
+							  &efa_rdm_ep_domain(ep)->ope_queued_list);
 				}
 			}
 		} else {
@@ -496,8 +496,8 @@ void efa_rdm_pke_handle_tx_error(struct efa_rdm_pke *pkt_entry, int prov_errno)
 			efa_rdm_ep_queue_rnr_pkt(ep, &rxe->queued_pkts, pkt_entry);
 			if (!(rxe->internal_flags & EFA_RDM_OPE_QUEUED_RNR)) {
 				rxe->internal_flags |= EFA_RDM_OPE_QUEUED_RNR;
-				dlist_insert_tail(&rxe->queued_rnr_entry,
-						  &efa_rdm_ep_domain(ep)->ope_queued_rnr_list);
+				dlist_insert_tail(&rxe->queued_entry,
+						  &efa_rdm_ep_domain(ep)->ope_queued_list);
 			}
 		} else {
 			efa_rdm_rxe_handle_error(pkt_entry->ope, err, prov_errno);


### PR DESCRIPTION
Combine ope_queued_rnr_list, ope_queued_ctrl_list
and ope_queued_read_list in to one list: ope_queued_list. One op entry can only be queued for 1 reason at the same time so there is no value to maintain 3 separate lists