### PR TITLE
prov/efa: revert queued list merge and add c5n test for efa provider

### DIFF
--- a/contrib/aws/Jenkinsfile
+++ b/contrib/aws/Jenkinsfile
@@ -75,6 +75,7 @@ pipeline {
 
                     // Multi Node Tests - EFA
                     stages["2_hpc6a_alinux2_efa"] = common.get_test_stage("2_hpc6a_alinux2_efa", env.BUILD_TAG, "alinux2", "hpc6a.48xlarge", 2, "eu-north-1", "libfabric_pr_test.yaml", addl_args_pr)
+                    stages["2_c5n_alinux2_efa"] = common.get_test_stage("2_c5n_alinux2_efa", env.BUILD_TAG, "alinux2", "c5n.18xlarge", 2, "us-east-1", "libfabric_pr_test.yaml", addl_args_pr)
                     stages["2_hpc6a_ubuntu2004_efa"] = common.get_test_stage("2_hpc6a_ubuntu2004_efa", env.BUILD_TAG, "ubuntu2004", "hpc6a.48xlarge", 2, "eu-north-1", "libfabric_pr_test.yaml", addl_args_pr)
                     stages["2_hpc6a_rhel8_efa"] = common.get_test_stage("2_hpc6a_rhel8_efa", env.BUILD_TAG, "rhel8", "hpc6a.48xlarge", 2, "eu-north-1", "libfabric_pr_test.yaml", addl_args_pr)
 

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -161,7 +161,9 @@ static int efa_domain_init_rdm(struct efa_domain *efa_domain, struct fi_info *in
 				  efa_env.cq_size);
 	efa_domain->num_read_msg_in_flight = 0;
 
-	dlist_init(&efa_domain->ope_queued_list);
+	dlist_init(&efa_domain->ope_queued_rnr_list);
+	dlist_init(&efa_domain->ope_queued_ctrl_list);
+	dlist_init(&efa_domain->ope_queued_read_list);
 	dlist_init(&efa_domain->ope_longcts_send_list);
 	dlist_init(&efa_domain->peer_backoff_list);
 	dlist_init(&efa_domain->handshake_queued_peer_list);
@@ -484,81 +486,72 @@ void efa_domain_progress_rdm_peers_and_queues(struct efa_domain *domain)
 	}
 
 	/*
-	 * Repost pkts for all queued op entries
+	 * Resend queued RNR pkts
 	 */
-	dlist_foreach_container_safe(&domain->ope_queued_list,
+	dlist_foreach_container_safe(&domain->ope_queued_rnr_list,
 				     struct efa_rdm_ope,
-				     ope, queued_entry, tmp) {
+				     ope, queued_rnr_entry, tmp) {
 		peer = efa_rdm_ep_get_peer(ope->ep, ope->addr);
+		assert(peer);
 
-		if (peer && (peer->flags & EFA_RDM_PEER_IN_BACKOFF))
+		if (peer->flags & EFA_RDM_PEER_IN_BACKOFF)
 			continue;
 
-		if (ope->internal_flags & EFA_RDM_OPE_QUEUED_RNR) {
-			assert(!dlist_empty(&ope->queued_pkts));
-			ret = efa_rdm_ep_post_queued_pkts(ope->ep, &ope->queued_pkts);
+		assert(ope->internal_flags & EFA_RDM_OPE_QUEUED_RNR);
+		assert(!dlist_empty(&ope->queued_pkts));
+		ret = efa_rdm_ep_post_queued_pkts(ope->ep, &ope->queued_pkts);
 
-			if (ret == -FI_EAGAIN)
-				break;
+		if (ret == -FI_EAGAIN)
+			break;
 
-			if (OFI_UNLIKELY(ret)) {
-				assert(ope->type == EFA_RDM_RXE || ope->type == EFA_RDM_TXE);
-				if (ope->type == EFA_RDM_RXE)
-					efa_rdm_rxe_handle_error(ope, -ret, FI_EFA_ERR_PKT_SEND);
-				else
-					efa_rdm_txe_handle_error(ope, -ret, FI_EFA_ERR_PKT_SEND);
-				return;
-			}
-
-			dlist_remove(&ope->queued_entry);
-			ope->internal_flags &= ~EFA_RDM_OPE_QUEUED_RNR;
+		if (OFI_UNLIKELY(ret)) {
+			assert(ope->type == EFA_RDM_RXE || ope->type == EFA_RDM_TXE);
+			if (ope->type == EFA_RDM_RXE)
+				efa_rdm_rxe_handle_error(ope, -ret, FI_EFA_ERR_PKT_SEND);
+			else
+				efa_rdm_txe_handle_error(ope, -ret, FI_EFA_ERR_PKT_SEND);
+			return;
 		}
 
-		if (ope->internal_flags & EFA_RDM_OPE_QUEUED_CTRL) {
-			ret = efa_rdm_ope_post_send(ope, ope->queued_ctrl_type);
-			if (ret == -FI_EAGAIN)
-				break;
-
-			if (OFI_UNLIKELY(ret)) {
-				assert(ope->type == EFA_RDM_TXE || ope->type == EFA_RDM_RXE);
-				if (ope->type == EFA_RDM_TXE)
-					efa_rdm_txe_handle_error(ope, -ret, FI_EFA_ERR_PKT_POST);
-				else
-					efa_rdm_rxe_handle_error(ope, -ret, FI_EFA_ERR_PKT_POST);
-				return;
-			}
-
-			/* it can happen that efa_rdm_ope_post_send() released ope
-			 * (if the ope is rxe and packet type is EOR and inject is used). In
-			 * that case rxe's state has been set to EFA_RDM_OPE_FREE and
-			 * it has been removed from ep->op_queued_entry_list, so nothing
-			 * is left to do.
-			 */
-			if (ope->state == EFA_RDM_OPE_FREE)
-				continue;
-
-			ope->internal_flags &= ~EFA_RDM_OPE_QUEUED_CTRL;
-			dlist_remove(&ope->queued_entry);
-		}
-
-		if (ope->internal_flags & EFA_RDM_OPE_QUEUED_READ) {
-			ret = efa_rdm_ope_post_read(ope);
-			if (ret == -FI_EAGAIN)
-				break;
-
-			if (OFI_UNLIKELY(ret)) {
-				assert(ope->type == EFA_RDM_TXE || ope->type == EFA_RDM_RXE);
-				if (ope->type == EFA_RDM_TXE)
-					efa_rdm_txe_handle_error(ope, -ret, FI_EFA_ERR_READ_POST);
-				else
-					efa_rdm_rxe_handle_error(ope, -ret, FI_EFA_ERR_READ_POST);
-				return;
-			}
-
-			ope->internal_flags &= ~EFA_RDM_OPE_QUEUED_READ;
-			dlist_remove(&ope->queued_entry);
-		}
+		dlist_remove(&ope->queued_rnr_entry);
+		ope->internal_flags &= ~EFA_RDM_OPE_QUEUED_RNR;
 	}
+
+	/*
+	 * Send any queued ctrl packets.
+	 */
+	dlist_foreach_container_safe(&domain->ope_queued_ctrl_list,
+				     struct efa_rdm_ope,
+				     ope, queued_ctrl_entry, tmp) {
+		peer = efa_rdm_ep_get_peer(ope->ep, ope->addr);
+		assert(peer);
+
+		if (peer->flags & EFA_RDM_PEER_IN_BACKOFF)
+			continue;
+
+		assert(ope->internal_flags & EFA_RDM_OPE_QUEUED_CTRL);
+		ret = efa_rdm_ope_post_send(ope, ope->queued_ctrl_type);
+		if (ret == -FI_EAGAIN)
+			break;
+
+		if (OFI_UNLIKELY(ret)) {
+			efa_rdm_rxe_handle_error(ope, -ret, FI_EFA_ERR_PKT_POST);
+			return;
+		}
+
+		/* it can happen that efa_rdm_ope_post_send() released ope
+		 * (if the ope is rxe and packet type is EOR and inject is used). In
+		 * that case rxe's state has been set to EFA_RDM_OPE_FREE and
+		 * it has been removed from ep->op_queued_entry_list, so nothing
+		 * is left to do.
+		 */
+		if (ope->state == EFA_RDM_OPE_FREE)
+			continue;
+
+		ope->internal_flags &= ~EFA_RDM_OPE_QUEUED_CTRL;
+		dlist_remove(&ope->queued_ctrl_entry);
+	}
+
 	/*
 	 * Send data packets until window or data queue is exhausted.
 	 */
@@ -603,5 +596,44 @@ void efa_domain_progress_rdm_peers_and_queues(struct efa_domain *domain)
 				return;
 			}
 		}
+	}
+
+	/*
+	 * Send remote read requests until finish or error encoutered
+	 */
+	dlist_foreach_container_safe(&domain->ope_queued_read_list, struct efa_rdm_ope,
+				     ope, queued_read_entry, tmp) {
+		peer = efa_rdm_ep_get_peer(ope->ep, ope->addr);
+		/*
+		 * Here peer can be NULL, when the read request is a
+		 * local read request. Local read request is used to copy
+		 * data from host memory to device memory on same process.
+		 */
+		if (peer && (peer->flags & EFA_RDM_PEER_IN_BACKOFF))
+			continue;
+
+		/*
+		 * The core's TX queue is full so we can't do any
+		 * additional work.
+		 */
+		if (ope->ep->efa_outstanding_tx_ops == ope->ep->efa_max_outstanding_tx_ops)
+			return;
+
+		ret = efa_rdm_ope_post_read(ope);
+		if (ret == -FI_EAGAIN)
+			break;
+
+		if (OFI_UNLIKELY(ret)) {
+			assert(ope->type == EFA_RDM_TXE || ope->type == EFA_RDM_RXE);
+			if (ope->type == EFA_RDM_TXE)
+				efa_rdm_txe_handle_error(ope, -ret, FI_EFA_ERR_READ_POST);
+			else
+				efa_rdm_rxe_handle_error(ope, -ret, FI_EFA_ERR_READ_POST);
+
+			return;
+		}
+
+		ope->internal_flags &= ~EFA_RDM_OPE_QUEUED_READ;
+		dlist_remove(&ope->queued_read_entry);
 	}
 }

--- a/prov/efa/src/efa_domain.h
+++ b/prov/efa/src/efa_domain.h
@@ -34,8 +34,12 @@ struct efa_domain {
 	size_t			rdm_cq_size;
 	/* number of rdma-read messages in flight */
 	uint64_t		num_read_msg_in_flight;
-	/* queued op entries */
-	struct dlist_entry ope_queued_list;
+	/* op entries with queued rnr packets */
+	struct dlist_entry ope_queued_rnr_list;
+	/* op entries with queued ctrl packets */
+	struct dlist_entry ope_queued_ctrl_list;
+	/* op entries with queued read requests */
+	struct dlist_entry ope_queued_read_list;
 	/* tx/rx_entries used by long CTS msg/write/read protocol
          * which have data to be sent */
 	struct dlist_entry ope_longcts_send_list;

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -754,17 +754,17 @@ bool efa_rdm_ep_has_unfinished_send(struct efa_rdm_ep *efa_rdm_ep)
 	if (efa_rdm_ep->efa_outstanding_tx_ops > 0)
 		return true;
 
-	dlist_foreach_safe(&efa_rdm_ep_domain(efa_rdm_ep)->ope_queued_list, entry, tmp) {
+	dlist_foreach_safe(&efa_rdm_ep_domain(efa_rdm_ep)->ope_queued_rnr_list, entry, tmp) {
 		ope = container_of(entry, struct efa_rdm_ope,
-					queued_entry);
+					queued_rnr_entry);
 		if (ope->ep == efa_rdm_ep) {
 			return true;
 		}
 	}
 
-	dlist_foreach_safe(&efa_rdm_ep_domain(efa_rdm_ep)->ope_queued_list, entry, tmp) {
+	dlist_foreach_safe(&efa_rdm_ep_domain(efa_rdm_ep)->ope_queued_ctrl_list, entry, tmp) {
 		ope = container_of(entry, struct efa_rdm_ope,
-					queued_entry);
+					queued_ctrl_entry);
 		if (ope->ep == efa_rdm_ep) {
 			return true;
 		}

--- a/prov/efa/src/rdm/efa_rdm_ope.h
+++ b/prov/efa/src/rdm/efa_rdm_ope.h
@@ -126,8 +126,14 @@ struct efa_rdm_ope {
 	/* ep_entry is linked to tx/rxe_list in efa_rdm_ep */
 	struct dlist_entry ep_entry;
 
-	/* queued_entry is linked with ope_queued_list in efa_domain */
-	struct dlist_entry queued_entry;
+	/* queued_ctrl_entry is linked with tx/rx_queued_ctrl_list in efa_domain */
+	struct dlist_entry queued_ctrl_entry;
+
+	/* queued_read_entry is linked with ope_queued_read_list in efa_domain */
+	struct dlist_entry queued_read_entry;
+
+	/* queued_rnr_entry is linked with tx/rx_queued_rnr_list in efa_domain */
+	struct dlist_entry queued_rnr_entry;
 
 	/* Queued packets due to TX queue full or RNR backoff */
 	struct dlist_entry queued_pkts;
@@ -212,7 +218,7 @@ void efa_rdm_rxe_release_internal(struct efa_rdm_ope *rxe);
 /**
  * @brief flag to tell if an ope encouter RNR when sending packets
  *
- * If an ope has this flag, it is on the ope_queued_list
+ * If an ope has this flag, it is on the ope_queued_rnr_list
  * of the endpoint.
  */
 #define EFA_RDM_OPE_QUEUED_RNR BIT_ULL(9)
@@ -236,7 +242,7 @@ void efa_rdm_rxe_release_internal(struct efa_rdm_ope *rxe);
 /**
  * @brief flag to indicate an ope has queued ctrl packet,
  *
- * If this flag is on, the op_entyr is on the ope_queued_list
+ * If this flag is on, the op_entyr is on the ope_queued_ctrl_list
  * of the endpoint
  */
 #define EFA_RDM_OPE_QUEUED_CTRL BIT_ULL(11)
@@ -258,7 +264,7 @@ void efa_rdm_rxe_release_internal(struct efa_rdm_ope *rxe);
 /**
  * @brief flag to indicate an ope has queued read requests
  *
- * When this flag is on, the ope is on ope_queued_list
+ * When this flag is on, the ope is on ope_queued_read_list
  * of the endpoint
  */
 #define EFA_RDM_OPE_QUEUED_READ 	BIT_ULL(12)

--- a/prov/efa/src/rdm/efa_rdm_pke_cmd.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_cmd.c
@@ -475,8 +475,8 @@ void efa_rdm_pke_handle_tx_error(struct efa_rdm_pke *pkt_entry, int prov_errno)
 				efa_rdm_ep_queue_rnr_pkt(ep, &txe->queued_pkts, pkt_entry);
 				if (!(txe->internal_flags & EFA_RDM_OPE_QUEUED_RNR)) {
 					txe->internal_flags |= EFA_RDM_OPE_QUEUED_RNR;
-					dlist_insert_tail(&txe->queued_entry,
-							  &efa_rdm_ep_domain(ep)->ope_queued_list);
+					dlist_insert_tail(&txe->queued_rnr_entry,
+							  &efa_rdm_ep_domain(ep)->ope_queued_rnr_list);
 				}
 			}
 		} else {
@@ -496,8 +496,8 @@ void efa_rdm_pke_handle_tx_error(struct efa_rdm_pke *pkt_entry, int prov_errno)
 			efa_rdm_ep_queue_rnr_pkt(ep, &rxe->queued_pkts, pkt_entry);
 			if (!(rxe->internal_flags & EFA_RDM_OPE_QUEUED_RNR)) {
 				rxe->internal_flags |= EFA_RDM_OPE_QUEUED_RNR;
-				dlist_insert_tail(&rxe->queued_entry,
-						  &efa_rdm_ep_domain(ep)->ope_queued_list);
+				dlist_insert_tail(&rxe->queued_rnr_entry,
+						  &efa_rdm_ep_domain(ep)->ope_queued_rnr_list);
 			}
 		} else {
 			efa_rdm_rxe_handle_error(pkt_entry->ope, err, prov_errno);


### PR DESCRIPTION
The earlier queue list merge caused a hang on platforms that use long-CTS protocol. 

Having a single queue can reduce the number of queues for a idle polling, but may introduce race conditions
between different queued entries and cause more entries
to poll in the busy loop.

We will revert this change first and revisit it later.

Also add c5n test for efa provider in AWS CI
