### PR TITLE
Fix incompatible pointer warnings on macOS with GCC 14

### DIFF
--- a/include/ofi_iov.h
+++ b/include/ofi_iov.h
@@ -86,7 +86,7 @@ static inline size_t ofi_total_rma_ioc_cnt(const struct fi_rma_ioc *rma_ioc,
 static inline size_t ofi_iov_bytes_to_copy(const struct iovec *iov,
 			size_t *size, size_t *offset, char **copy_buf)
 {
-	uint64_t len;
+	size_t len;
 
 	len = iov->iov_len;
 
@@ -105,16 +105,16 @@ static inline size_t ofi_iov_bytes_to_copy(const struct iovec *iov,
 	return len;
 }
 
-uint64_t ofi_copy_iov_buf(const struct iovec *iov, size_t iov_count, uint64_t iov_offset,
-			  void *buf, uint64_t bufsize, int dir);
+size_t ofi_copy_iov_buf(const struct iovec *iov, size_t iov_count, size_t iov_offset,
+			void *buf, size_t bufsize, int dir);
 
-static inline uint64_t
-ofi_copy_to_iov(const struct iovec *iov, size_t iov_count, uint64_t iov_offset,
-		void *buf, uint64_t bufsize)
+static inline size_t
+ofi_copy_to_iov(const struct iovec *iov, size_t iov_count, size_t iov_offset,
+		void *buf, size_t bufsize)
 {
 	if (iov_count == 1) {
-		uint64_t size = ((iov_offset > iov[0].iov_len) ?
-				 0 : MIN(bufsize, iov[0].iov_len - iov_offset));
+		size_t size = ((iov_offset > iov[0].iov_len) ?
+			       0 : MIN(bufsize, iov[0].iov_len - iov_offset));
 
 		memcpy((char *)iov[0].iov_base + iov_offset, buf, size);
 		return size;
@@ -124,13 +124,13 @@ ofi_copy_to_iov(const struct iovec *iov, size_t iov_count, uint64_t iov_offset,
 	}
 }
 
-static inline uint64_t
-ofi_copy_from_iov(void *buf, uint64_t bufsize,
-		  const struct iovec *iov, size_t iov_count, uint64_t iov_offset)
+static inline size_t
+ofi_copy_from_iov(void *buf, size_t bufsize,
+		  const struct iovec *iov, size_t iov_count, size_t iov_offset)
 {
 	if (iov_count == 1) {
-		uint64_t size = ((iov_offset > iov[0].iov_len) ?
-				 0 : MIN(bufsize, iov[0].iov_len - iov_offset));
+		size_t size = ((iov_offset > iov[0].iov_len) ?
+			       0 : MIN(bufsize, iov[0].iov_len - iov_offset));
 
 		memcpy(buf, (char *)iov[0].iov_base + iov_offset, size);
 		return size;

--- a/prov/hook/dmabuf_peer_mem/src/hook_dmabuf_peer_mem.c
+++ b/prov/hook/dmabuf_peer_mem/src/hook_dmabuf_peer_mem.c
@@ -185,7 +185,7 @@ static void get_mr_fd(struct dmabuf_peer_mem_mr *mr,
 		goto out;
 
 	err = ze_hmem_get_base_addr(iov->iov_base, iov->iov_len,
-				    (void **)&mr->base, &mr->size);
+				    (void **)&mr->base, (size_t *)&mr->size);
 	if (err)
 		goto out;
 

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -314,7 +314,7 @@ static ssize_t
 ofi_async_copy_hmem_iov_buf(enum fi_hmem_iface hmem_iface, uint64_t device,
 			    const struct iovec *hmem_iov,
 			    size_t hmem_iov_count,
-			    uint64_t hmem_iov_offset, void *buf,
+			    size_t hmem_iov_offset, void *buf,
 			    size_t size, int dir, ofi_hmem_async_event_t event)
 {
 	uint64_t done = 0, len;
@@ -353,7 +353,7 @@ ofi_async_copy_hmem_iov_buf(enum fi_hmem_iface hmem_iface, uint64_t device,
 static ssize_t ofi_copy_hmem_iov_buf(enum fi_hmem_iface hmem_iface, uint64_t device,
 				     const struct iovec *hmem_iov,
 				     size_t hmem_iov_count,
-				     uint64_t hmem_iov_offset, void *buf,
+				     size_t hmem_iov_offset, void *buf,
 				     size_t size, int dir)
 {
 	uint64_t done = 0, len;
@@ -385,7 +385,7 @@ static ssize_t ofi_copy_hmem_iov_buf(enum fi_hmem_iface hmem_iface, uint64_t dev
 static ssize_t ofi_dev_reg_copy_hmem_iov_buf(enum fi_hmem_iface hmem_iface, uint64_t handle,
 					      const struct iovec *hmem_iov,
 					      size_t hmem_iov_count,
-					      uint64_t hmem_iov_offset, void *buf,
+					      size_t hmem_iov_offset, void *buf,
 					      size_t size, int dir)
 {
 	uint64_t done = 0, len;
@@ -414,7 +414,7 @@ static ssize_t ofi_dev_reg_copy_hmem_iov_buf(enum fi_hmem_iface hmem_iface, uint
 }
 
 static ssize_t ofi_copy_mr_iov(struct ofi_mr **mr, const struct iovec *iov,
-		size_t iov_count, uint64_t offset, void *buf,
+		size_t iov_count, size_t offset, void *buf,
 		size_t size, int dir)
 {
 	uint64_t done = 0, len;

--- a/src/iov.c
+++ b/src/iov.c
@@ -37,10 +37,10 @@
 #include <ofi.h>
 #include <ofi_iov.h>
 
-uint64_t ofi_copy_iov_buf(const struct iovec *iov, size_t iov_count, uint64_t iov_offset,
-			  void *buf, uint64_t bufsize, int dir)
+size_t ofi_copy_iov_buf(const struct iovec *iov, size_t iov_count, size_t iov_offset,
+			void *buf, size_t bufsize, int dir)
 {
-	uint64_t done = 0, len;
+	size_t done = 0, len;
 	char *iov_buf;
 	size_t i;
 


### PR DESCRIPTION
Fixes compilation issue reported in #10052.