### PR TITLE
prov/efa: Fix efa_rdm_cq_wc_is_unsolicited check

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_cq.c
+++ b/prov/efa/src/rdm/efa_rdm_cq.c
@@ -83,7 +83,7 @@ static struct fi_ops efa_rdm_cq_fi_ops = {
 static inline
 bool efa_rdm_cq_wc_is_unsolicited(struct ibv_cq_ex *ibv_cq_ex)
 {
-	return efadv_wc_is_unsolicited(efadv_cq_from_ibv_cq_ex(ibv_cq_ex));
+	return efa_device_support_unsolicited_write_recv() ? efadv_wc_is_unsolicited(efadv_cq_from_ibv_cq_ex(ibv_cq_ex)) : false;
 }
 
 #else


### PR DESCRIPTION
efadv_wc_is_unsolicited() can only be called when driver/FW supports unsolicited write recv, in which we create IBV CQ with EFADV_DEVICE_ATTR_CAPS_UNSOLICITED_WRITE_RECV. Otherwise the function pointer will be a NULL and cause segfault.