### PR TITLE
prov/efa: Remove unnecessary g_device_cnt check.

### DIFF
--- a/prov/efa/src/efa_device.c
+++ b/prov/efa/src/efa_device.c
@@ -242,8 +242,7 @@ void efa_device_list_finalize(void)
  */
 bool efa_device_support_rdma_read(void)
 {
-	if (g_device_cnt <=0)
-		return false;
+	assert(g_device_cnt > 0);
 
 	return g_device_list[0].device_caps & EFADV_DEVICE_ATTR_CAPS_RDMA_READ;
 }
@@ -256,8 +255,7 @@ bool efa_device_support_rdma_read(void)
 #if HAVE_CAPS_RDMA_WRITE
 bool efa_device_support_rdma_write(void)
 {
-	if (g_device_cnt <=0)
-		return false;
+	assert(g_device_cnt > 0);
 
 	return g_device_list[0].device_caps & EFADV_DEVICE_ATTR_CAPS_RDMA_WRITE;
 }
@@ -276,8 +274,7 @@ bool efa_device_support_rdma_write(void)
 #if HAVE_CAPS_UNSOLICITED_WRITE_RECV
 bool efa_device_support_unsolicited_write_recv(void)
 {
-	if (g_device_cnt <=0)
-		return false;
+	assert(g_device_cnt > 0);
 
 	return g_device_list[0].device_caps & EFADV_DEVICE_ATTR_CAPS_UNSOLICITED_WRITE_RECV;
 }


### PR DESCRIPTION
These calls are not called when there is no efa device.
    it is unnecessary to check g_device_cnt again in the call.