### PR TITLE
fabtests: Synchronize on Initialization

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -987,7 +987,11 @@ int ft_accept_next_client() {
 		ret = ft_reset_oob();
 		if (ret)
 			return ret;
-	}
+
+		ret = ft_sock_sync(oob_sock, 0);
+		if (ret)
+			return ret;
+}
 	return ft_init_av();
 }
 
@@ -1305,6 +1309,12 @@ int ft_init_fabric(void)
 	if (ret)
 		return ret;
 
+	if (oob_sock >= 0 && opts.dst_addr) {
+		ret = ft_sock_sync(oob_sock, 0);
+		if (ret)
+			return ret;
+	}
+
 	ret = ft_getinfo(hints, &fi);
 	if (ret)
 		return ret;
@@ -1320,6 +1330,12 @@ int ft_init_fabric(void)
 	ret = ft_enable_ep_recv();
 	if (ret)
 		return ret;
+
+	if (oob_sock >= 0 && !opts.dst_addr) {
+		ret = ft_sock_sync(oob_sock, 0);
+		if (ret)
+			return ret;
+	}
 
 	ret = ft_init_av();
 	if (ret)

--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -3916,31 +3916,31 @@ int ft_sock_recv(int fd, void *msg, size_t len)
 	return err ? err: 0;
 }
 
-int ft_sock_sync(int value)
+int ft_sock_sync(int fd, int value)
 {
 	int result = -FI_EOTHER;
 	int ret;
 
 	if (listen_sock < 0) {
-		ret = ft_sock_send(sock, &value,  sizeof value);
+		ret = ft_sock_send(fd, &value,  sizeof value);
 		if (ret) {
 			FT_PRINTERR("ft_sock_send", ret);
 			return ret;
 		}
 
-		ret = ft_sock_recv(sock, &result, sizeof result);
+		ret = ft_sock_recv(fd, &result, sizeof result);
 		if (ret) {
 			FT_PRINTERR("ft_sock_recv", ret);
 			return ret;
 		}
 	} else {
-		ret = ft_sock_recv(sock, &result, sizeof result);
+		ret = ft_sock_recv(fd, &result, sizeof result);
 		if (ret) {
 			FT_PRINTERR("ft_sock_recv", ret);
 			return ret;
 		}
 
-		ret = ft_sock_send(sock, &value,  sizeof value);
+		ret = ft_sock_send(fd, &value,  sizeof value);
 		if (ret) {
 			FT_PRINTERR("ft_sock_send", ret);
 			return ret;

--- a/fabtests/functional/cm_data.c
+++ b/fabtests/functional/cm_data.c
@@ -440,7 +440,7 @@ static int run(void)
 		if (ret)
 			goto err1;
 
-		ret = ft_sock_sync(0);
+		ret = ft_sock_sync(sock, 0);
 		if (ret)
 			goto err1;
 	}

--- a/fabtests/functional/rdm.c
+++ b/fabtests/functional/rdm.c
@@ -49,9 +49,13 @@ static int run(void)
 
 	while (nconn && !ret) {
 		ret = ft_send_recv_greeting(ep);
+		if (ret)
+			return ret;
 
 		if (--nconn && !ret) {
 			ret = ft_accept_next_client();
+			if (ret)
+				return ret;
 		}
 	}
 

--- a/fabtests/functional/rdm_multi_client.c
+++ b/fabtests/functional/rdm_multi_client.c
@@ -125,6 +125,12 @@ static int run_client(int client_id, bool address_reuse)
 		return ret;
 	}
 
+	if (!client_id && oob_sock >= 0) {
+		ret = ft_sock_sync(oob_sock, 0);
+		if (ret)
+			return ret;
+	}
+
 	ret = ft_getinfo(hints, &fi);
 	if (ret) {
 		FT_PRINTERR("ft_getinfo", -ret);

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -269,7 +269,7 @@ int ft_sock_connect(char *node, char *service);
 int ft_sock_accept();
 int ft_sock_send(int fd, void *msg, size_t len);
 int ft_sock_recv(int fd, void *msg, size_t len);
-int ft_sock_sync(int value);
+int ft_sock_sync(int fd, int value);
 void ft_sock_shutdown(int fd);
 extern int (*ft_mr_alloc_func)(void);
 extern uint64_t ft_tag;

--- a/fabtests/ubertest/test_ctrl.c
+++ b/fabtests/ubertest/test_ctrl.c
@@ -401,7 +401,7 @@ static int ft_sync_test(int value)
 	if (ret)
 		return ret;
 
-	return ft_sock_sync(value);
+	return ft_sock_sync(sock, value);
 }
 
 static int ft_sync_manual()
@@ -444,7 +444,7 @@ static int ft_sync_progress(int value)
 {
 	if (test_info.progress == FI_PROGRESS_MANUAL)
 		return ft_sync_manual();
-	return ft_sock_sync(value);
+	return ft_sock_sync(sock, value);
 }
 
 static int ft_sync_msg_needed(void)
@@ -1134,7 +1134,7 @@ int ft_init_test()
 {
 	int ret;
 
-	ft_sock_sync(0);
+	ft_sock_sync(sock, 0);
 
 	ret = ft_enable_comm();
 	if (ret) {

--- a/fabtests/ubertest/verify.c
+++ b/fabtests/ubertest/verify.c
@@ -101,7 +101,7 @@ static const int integ_alphabet_length = (sizeof(integ_alphabet)/sizeof(*integ_a
 int ft_sync_fill_bufs(size_t size)
 {
 	int ret;
-	ft_sock_sync(0);
+	ft_sock_sync(sock, 0);
 
 	if (test_info.caps & FI_ATOMIC) {
 		SWITCH_TYPES(ft_atom_ctrl.datatype, FT_FILL, ft_tx_ctrl.buf,
@@ -126,7 +126,7 @@ int ft_sync_fill_bufs(size_t size)
 			return ret;
 	}
 
-	ft_sock_sync(0);
+	ft_sock_sync(sock, 0);
 
 	return 0;
 }


### PR DESCRIPTION
fabtests: Synchronize on Initialization
fabtests/functional: Add manual init sync to fi_rdm_multiclient

Some providers (verbs ud) might require the server to be fully initialized before the client process calls getinfo with the server address. This causes a No Data Available error due to the fi_info call failing during initialization by not being able to find the name on the server. This is seen most often in cases where a socket (usually oob [out of band]) is initialized before getinfo in the ft_init_fabric sequence. Adding a sync only if an oob socket has been initialized to order the initialization correctly will prevent this from happening.

The syncronization is for client to start getinfo only after the server is done initializing everything.

fi_rdm_multiclient test needs its client startup to have a manual sync since it does not follow the normal codepath of going through ft_init_fabric like the server and other tests do. This sync will only happen on the first client that connects because it is only necessary to give the server enough time to spin up all the resources. It is not necessary for future clients because the server has already started all of those resources.