### PR TITLE
prov/efa: refactor hmem interface initialization

### DIFF
--- a/prov/efa/src/efa_env.c
+++ b/prov/efa/src/efa_env.c
@@ -37,6 +37,7 @@ struct efa_env efa_env = {
 	.host_id_file = "/sys/devices/virtual/dmi/id/board_asset_tag", /* Available on EC2 instances and containers */
 	.use_sm2 = false,
 	.huge_page_setting = EFA_ENV_HUGE_PAGE_UNSPEC,
+	.p2p_file_suffix= "/device/p2p",
 };
 
 /**

--- a/prov/efa/src/efa_env.h
+++ b/prov/efa/src/efa_env.h
@@ -77,6 +77,7 @@ struct efa_env {
 	char *host_id_file;
 	int use_sm2;
 	enum efa_env_huge_page_setting huge_page_setting;
+	char *p2p_file_suffix;
 };
 
 /**

--- a/prov/efa/src/efa_hmem.h
+++ b/prov/efa/src/efa_hmem.h
@@ -21,11 +21,24 @@ static const enum fi_hmem_iface efa_hmem_ifaces[] = {
 	FI_HMEM_SYNAPSEAI
 };
 
+enum efa_dmabuf_support_status {
+	EFA_DMABUF_UNINITIALIZED,
+	EFA_DMABUF_NOT_SUPPORTED,
+	EFA_DMABUF_SUPPORTED,
+};
+
+enum efa_hmem_p2p_prov {
+	EFA_HMEM_P2P_NULL,
+	EFA_HMEM_P2P_NVIDIA,
+	EFA_HMEM_P2P_NEURON,
+};
+
 struct efa_hmem_info {
 	bool initialized; 	/* do we support it at all */
 	bool p2p_disabled_by_user;	/* Did the user disable p2p via FI_OPT_FI_HMEM_P2P? */
 	bool p2p_required_by_impl;	/* Is p2p required for this interface? */
 	bool p2p_supported_by_device;	/* do we support p2p with this device */
+	enum efa_dmabuf_support_status dmabuf_support_status;
 
 	size_t max_medium_msg_size;
 	size_t runt_size;


### PR DESCRIPTION
This patch removes the trial device memory registration with EFA device during domain initialization; instead, we query the sysfs to retrieve the P2P provider information emitted by the kernel module.

As a result, we have to delay the dmabuf support status check to the 1st application fi_mr_reg* call:
- We always register the region via ibv_reg_dmabuf_mr if the application requests FI_MR_DMABUF
- We will disable dmabuf if the hmem interface does not have P2P support
- For the 1st fi_mr_reg* call, we will try ibv_reg_dmabuf_mr
- If the 1st fi_mr_reg* call failed via ibv_reg_dmabuf_mr, we will NOT try ibv_reg_dmabuf_mr again, but always fallback to ibv_reg_mr API for that hmem interface
- Otherwise we will always use ibv_reg_dmabuf_mr for that hmem interface