### PR TITLE
prov/verbs: Optimize search for device max inline size

### DIFF
--- a/man/fi_verbs.7.md
+++ b/man/fi_verbs.7.md
@@ -177,8 +177,10 @@ The verbs provider checks for the following environment variables.
   deprecated) EP type supports only 1
 
 *FI_VERBS_INLINE_SIZE*
-: Default maximum inline size. Actual inject size returned in fi_info
-  may be greater (default: 64)
+: Maximum inline size for the verbs device. Actual inline size returned may be
+  different depending on device capability. This value will be returned by
+  fi_info as the inject size for the application to use. Set to 0 for the
+  maximum device inline size to be used. (default: 256).
 
 *FI_VERBS_MIN_RNR_TIMER*
 : Set min_rnr_timer QP attribute (0 - 31) (default: 12)


### PR DESCRIPTION
Let the user set the FI_VERBS_INLINE_SIZE environment variable to decide the maximum size of an inline transfer. The getinfo call will check if the device is capable of this size. If it is capable it will use it. If it not capable then the size is too big and we can goto the backwards search to find the largest inline size that is smaller than the FI_VERBS_INLINE_SIZE variable.

If a user wants the maximum inject size that a device can do then they should set this FI_VERBS_INLINE_SIZE variable to 0 so that the device can find its largest inject size.