### PR TITLE
 prov/efa: Post user recv buffer to user recv QP

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -96,6 +96,7 @@ struct efa_rdm_ep {
 	/* buffer pool for send & recv */
 	struct ofi_bufpool *efa_tx_pkt_pool;
 	struct ofi_bufpool *efa_rx_pkt_pool;
+	struct ofi_bufpool *user_rx_pkt_pool;
 
 	/* staging area for unexpected and out-of-order packets */
 	struct ofi_bufpool *rx_unexp_pkt_pool;
@@ -155,6 +156,11 @@ struct efa_rdm_ep {
 	 * due to queued hmem copy or local read.
 	 */
 	size_t efa_rx_pkts_held;
+
+	/*
+	 * number of RX pkts posted by user (for zero-copy recv)
+	 */
+	size_t user_rx_pkts_posted;
 
 	/* number of outstanding tx ops on efa device */
 	size_t efa_outstanding_tx_ops;

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -233,6 +233,13 @@ int efa_rdm_ep_create_buffer_pools(struct efa_rdm_ep *ep)
 	if (ret)
 		goto err_free;
 
+	ret = ofi_bufpool_create(&ep->user_rx_pkt_pool,
+			sizeof(struct efa_rdm_pke),
+			EFA_RDM_BUFPOOL_ALIGNMENT,
+			0,ep->rx_size,0);
+	if (ret)
+		goto err_free;
+
 	if (efa_env.rx_copy_unexp) {
 		ret = efa_rdm_ep_create_pke_pool(
 			ep,
@@ -319,6 +326,9 @@ err_free:
 
 	if (efa_env.rx_copy_unexp && ep->rx_unexp_pkt_pool)
 		ofi_bufpool_destroy(ep->rx_unexp_pkt_pool);
+
+	if (ep->user_rx_pkt_pool)
+		ofi_bufpool_destroy(ep->user_rx_pkt_pool);
 
 	if (ep->efa_rx_pkt_pool)
 		ofi_bufpool_destroy(ep->efa_rx_pkt_pool);

--- a/prov/efa/src/rdm/efa_rdm_msg.c
+++ b/prov/efa/src/rdm/efa_rdm_msg.c
@@ -751,7 +751,7 @@ struct efa_rdm_ope *efa_rdm_msg_alloc_rxe_for_msgrtm(struct efa_rdm_ep *ep,
 	int ret;
 	int pkt_type;
 
-	if ((*pkt_entry_ptr)->alloc_type == EFA_RDM_PKE_FROM_USER_BUFFER) {
+	if ((*pkt_entry_ptr)->alloc_type == EFA_RDM_PKE_FROM_USER_RX_POOL) {
 		/* If a pkt_entry is constructred from user supplied buffer,
 		 * the endpoint must be in zero copy receive mode.
 		 */

--- a/prov/efa/src/rdm/efa_rdm_pke.h
+++ b/prov/efa/src/rdm/efa_rdm_pke.h
@@ -25,7 +25,7 @@ enum efa_rdm_pke_alloc_type {
 	EFA_RDM_PKE_FROM_EFA_RX_POOL,     /**< packet is allocated from `ep->efa_rx_pkt_pool` */
 	EFA_RDM_PKE_FROM_UNEXP_POOL,      /**< packet is allocated from `ep->rx_unexp_pkt_pool` */
 	EFA_RDM_PKE_FROM_OOO_POOL,	      /**< packet is allocated from `ep->rx_ooo_pkt_pool` */
-	EFA_RDM_PKE_FROM_USER_BUFFER,     /**< packet is from user provided buffer` */
+	EFA_RDM_PKE_FROM_USER_RX_POOL,     /**< packet is allocated from `ep->user_rx_pkt_pool` */
 	EFA_RDM_PKE_FROM_READ_COPY_POOL,  /**< packet is allocated from `ep->rx_readcopy_pkt_pool` */
 };
 

--- a/prov/efa/src/rdm/efa_rdm_pke_cmd.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_cmd.c
@@ -956,7 +956,7 @@ void efa_rdm_pke_handle_recv_completion(struct efa_rdm_pke *pkt_entry)
 	efa_rdm_ep_post_handshake_or_queue(ep, peer);
 
 
-	if (pkt_entry->alloc_type == EFA_RDM_PKE_FROM_USER_BUFFER) {
+	if (pkt_entry->alloc_type == EFA_RDM_PKE_FROM_USER_RX_POOL) {
 		assert(pkt_entry->ope);
 		zcpy_rxe = pkt_entry->ope;
 	}

--- a/prov/efa/src/rdm/efa_rdm_pke_rtm.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtm.c
@@ -643,7 +643,7 @@ ssize_t efa_rdm_pke_proc_matched_eager_rtm(struct efa_rdm_pke *pkt_entry)
 
 	rxe = pkt_entry->ope;
 
-	if (pkt_entry->alloc_type != EFA_RDM_PKE_FROM_USER_BUFFER) {
+	if (pkt_entry->alloc_type != EFA_RDM_PKE_FROM_USER_RX_POOL) {
 		/*
 		 * On success, efa_rdm_pke_copy_data_to_ope will write rx completion,
 		 * release pkt_entry and rxe


### PR DESCRIPTION
Allocate user posted rx pkts from a separate user_rx_pkt_pool.
Posting user recv buffer to user recv QP without prefix.