### PR TITLE
fabtests: Disable fi_rdm_tagged_peek for cleanup failure for psm3 and ucx

### DIFF
--- a/fabtests/test_configs/psm3/psm3.exclude
+++ b/fabtests/test_configs/psm3/psm3.exclude
@@ -17,3 +17,4 @@ rdm_cntr_pingpong
 multi_recv
 dgram_waitset
 multinode
+rdm_tagged_peek

--- a/fabtests/test_configs/ucx/ucx.exclude
+++ b/fabtests/test_configs/ucx/ucx.exclude
@@ -43,3 +43,6 @@ writedata
 rdm_atomic
 # FI_INJECT_COMPLETE not supported
 -A inj_complete
+
+# Fails as a race condition because of segfault
+rdm_tagged_peek


### PR DESCRIPTION
fi_rdm_tagged_peek fails to cleanup with "munmap_chunk(): invalid pointer" when trying to free hfi_nids in psm_ep.c:1161.
This test is successful when FI_PROVIDER is unset and fails when it is set to "psm3" or "PSM3". There is an open issue in ofiwg/libfabric to track this bug. When it is resolved we can re-enable this test.

Issue opened: #10123

fi_rdm_tagged_peek fails to cleanup with "segmentation failt" when trying to cleanup the endpoint.
This failure is a race condition and has no known 100% fail case.

Issue opened: #10126 