### PR TITLE
prov/efa: refactor hmem interface initialization

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -156,15 +156,14 @@ prov_efa_test_efa_unit_test_LDFLAGS = $(cmocka_rpath) $(efa_LDFLAGS) $(cmocka_LD
 					-Wl,--wrap=ibv_create_ah \
 					-Wl,--wrap=ibv_is_fork_initialized \
 					-Wl,--wrap=efadv_query_device \
+					-Wl,--wrap=ibv_reg_mr \
+					-Wl,--wrap=ibv_reg_mr_iova2 \
+					-Wl,--wrap=ibv_dereg_mr \
 					-Wl,--wrap=ofi_copy_from_hmem_iov
 
 if HAVE_EFADV_CQ_EX
 prov_efa_test_efa_unit_test_LDFLAGS += -Wl,--wrap=efadv_create_cq
 endif HAVE_EFADV_CQ_EX
-
-if HAVE_NEURON
-prov_efa_test_efa_unit_test_LDFLAGS += -Wl,--wrap=neuron_alloc
-endif HAVE_NEURON
 
 if HAVE_EFADV_QUERY_MR
 prov_efa_test_efa_unit_test_LDFLAGS += -Wl,--wrap=efadv_query_mr
@@ -173,6 +172,10 @@ endif HAVE_EFADV_QUERY_MR
 if HAVE_EFA_DATA_IN_ORDER_ALIGNED_128_BYTES
 prov_efa_test_efa_unit_test_LDFLAGS += -Wl,--wrap=ibv_query_qp_data_in_order
 endif
+
+if HAVE_EFA_DMABUF_MR
+prov_efa_test_efa_unit_test_LDFLAGS += -Wl,--wrap=ibv_reg_dmabuf_mr
+endif HAVE_EFA_DMABUF_MR
 
 prov_efa_test_efa_unit_test_LIBS = $(efa_LIBS) $(linkback)
 

--- a/prov/efa/configure.m4
+++ b/prov/efa/configure.m4
@@ -234,6 +234,7 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 	AM_CONDITIONAL([HAVE_EFADV_CQ_EX], [ test $efadv_support_extended_cq = 1])
 	AM_CONDITIONAL([HAVE_EFADV_QUERY_MR], [ test $have_efadv_query_mr = 1])
 	AM_CONDITIONAL([HAVE_EFA_DATA_IN_ORDER_ALIGNED_128_BYTES], [ test $efa_support_data_in_order_aligned_128_byte = 1])
+	AM_CONDITIONAL([HAVE_EFA_DMABUF_MR], [ test $have_efa_dmabuf_mr = 1])
 	AM_CONDITIONAL([ENABLE_EFA_UNIT_TEST], [ test x"$enable_efa_unit_test" != xno])
 
 	AC_SUBST(efa_CPPFLAGS)

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -294,7 +294,7 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 		goto err_free;
 	}
 
-	err = efa_domain_hmem_info_init_all(efa_domain);
+	err = efa_domain_hmem_support_init_all(efa_domain);
 	if (err) {
 		ret = err;
 		EFA_WARN(FI_LOG_DOMAIN, "Failed to check hmem support status. err: %d\n", ret);

--- a/prov/efa/src/efa_env.c
+++ b/prov/efa/src/efa_env.c
@@ -37,6 +37,7 @@ struct efa_env efa_env = {
 	.host_id_file = "/sys/devices/virtual/dmi/id/board_asset_tag", /* Available on EC2 instances and containers */
 	.use_sm2 = false,
 	.huge_page_setting = EFA_ENV_HUGE_PAGE_UNSPEC,
+	.p2p_file_suffix= "/device/p2p",
 };
 
 /**

--- a/prov/efa/src/efa_env.h
+++ b/prov/efa/src/efa_env.h
@@ -77,6 +77,7 @@ struct efa_env {
 	char *host_id_file;
 	int use_sm2;
 	enum efa_env_huge_page_setting huge_page_setting;
+	char *p2p_file_suffix;
 };
 
 /**

--- a/prov/efa/src/efa_hmem.c
+++ b/prov/efa/src/efa_hmem.c
@@ -5,6 +5,8 @@
 #include "efa_hmem.h"
 #include "rdm/efa_rdm_pkt_type.h"
 
+#define P2P_PROV_MAX_LEN 32
+
 #if HAVE_CUDA || HAVE_NEURON
 static size_t efa_max_eager_msg_size_with_largest_header(struct efa_domain *efa_domain) {
 	int mtu_size;
@@ -31,6 +33,7 @@ static size_t efa_max_eager_msg_size_with_largest_header(struct efa_domain *efa_
 static int efa_domain_hmem_info_init_protocol_thresholds(struct efa_domain *efa_domain, enum fi_hmem_iface iface)
 {
 	struct efa_hmem_info *info = &efa_domain->hmem_info[iface];
+	size_t tmp_value;
 
 	/* Fall back to FI_HMEM_SYSTEM initialization logic when p2p is unavailable */
 	if (!info->p2p_supported_by_device)
@@ -56,6 +59,12 @@ static int efa_domain_hmem_info_init_protocol_thresholds(struct efa_domain *efa_
 		fi_param_get_size_t(&efa_prov, "runt_size", &info->runt_size);
 		fi_param_get_size_t(&efa_prov, "inter_min_read_message_size", &info->min_read_msg_size);
 		fi_param_get_size_t(&efa_prov, "inter_min_read_write_size", &info->min_read_write_size);
+		if (-FI_ENODATA != fi_param_get(&efa_prov, "inter_max_medium_message_size", &tmp_value)) {
+			EFA_WARN(FI_LOG_DOMAIN,
+			         "The environment variable FI_EFA_INTER_MAX_MEDIUM_MESSAGE_SIZE was set, "
+			         "but EFA HMEM via Cuda API only supports eager and runting read protocols. "
+			         "The variable will not modify CUDA memory run config.\n");
+		}
 		break;
 	case FI_HMEM_NEURON:
 		info->runt_size = EFA_NEURON_RUNT_SIZE;
@@ -65,12 +74,31 @@ static int efa_domain_hmem_info_init_protocol_thresholds(struct efa_domain *efa_
 		fi_param_get_size_t(&efa_prov, "runt_size", &info->runt_size);
 		fi_param_get_size_t(&efa_prov, "inter_min_read_message_size", &info->min_read_msg_size);
 		fi_param_get_size_t(&efa_prov, "inter_min_read_write_size", &info->min_read_write_size);
+		if (-FI_ENODATA != fi_param_get(&efa_prov, "inter_max_medium_message_size", &tmp_value)) {
+			EFA_WARN(FI_LOG_DOMAIN,
+			         "The environment variable FI_EFA_INTER_MAX_MEDIUM_MESSAGE_SIZE was set, "
+			         "but EFA HMEM via Neuron API only supports eager and runting read protocols. "
+			         "The variable will not modify CUDA memory run config.\n");
+		}
 		break;
 	case FI_HMEM_SYNAPSEAI:
 		info->runt_size = 0;
 		info->max_medium_msg_size = 0;
 		info->min_read_msg_size = 1;
 		info->min_read_write_size = 1;
+		if (-FI_ENODATA != fi_param_get_size_t(&efa_prov, "inter_max_medium_message_size", &tmp_value) ||
+		    -FI_ENODATA != fi_param_get_size_t(&efa_prov, "inter_min_read_message_size", &tmp_value) ||
+		    -FI_ENODATA != fi_param_get_size_t(&efa_prov, "inter_min_read_write_size", &tmp_value) ||
+		    -FI_ENODATA != fi_param_get_size_t(&efa_prov, "runt_size", &tmp_value)) {
+			EFA_WARN(FI_LOG_DOMAIN,
+			        "One or more of the following environment variable(s) were set: ["
+			        "FI_EFA_INTER_MAX_MEDIUM_MESSAGE_SIZE, "
+			        "FI_EFA_INTER_MIN_READ_MESSAGE_SIZE, "
+			        "FI_EFA_INTER_MIN_READ_WRITE_SIZE, "
+			        "FI_EFA_RUNT_SIZE"
+			        "], but EFA HMEM via Synapse only supports long read protocol. "
+			        "The variable(s) will not modify Synapse memory run config.\n");
+		}
 		break;
 	default:
 		break;
@@ -79,267 +107,151 @@ static int efa_domain_hmem_info_init_protocol_thresholds(struct efa_domain *efa_
 }
 
 /**
- * @brief          Initialize the efa_hmem_info state for FI_HMEM_SYSTEM
- *
- * @param[in,out]  efa_domain  Pointer to struct efa_domain
- *
- * @return         0
+ * @brief Retrieve the P2P capability provider name for the chosen domain
+ * 
+ * @param[in]		efa_domain	EFA domain
+ * @param[in,out]	name		The output string
+ * @param[in]		len		The expected provider name length
+ * @return		On success, return the (positive) length of the
+ * 			provider name; otherwise a negative error code.
  */
-static int efa_domain_hmem_info_init_system(struct efa_domain *efa_domain)
+static inline ssize_t
+efa_domain_hmem_p2p_prov_name(struct efa_domain *efa_domain, char *name, uint16_t len)
 {
-	struct efa_hmem_info *info = &efa_domain->hmem_info[FI_HMEM_SYSTEM];
+	FILE *fp = NULL;
+	char *ibdev_path, *p2p_path = NULL;
+	ssize_t ret = -FI_EINVAL;
 
-	info->initialized = true;
-	info->p2p_disabled_by_user = false;
-	info->p2p_required_by_impl = false;
-	info->p2p_supported_by_device = true;
-	efa_domain_hmem_info_init_protocol_thresholds(efa_domain, FI_HMEM_SYSTEM);
-	return 0;
+	ibdev_path = efa_domain->device->ibv_ctx->device->ibdev_path;
+	if (!ibdev_path) {
+		EFA_WARN(FI_LOG_DOMAIN, "IB device sysfs is not defined\n");
+		ret = -FI_EINVAL;
+		goto out;
+	}
+
+	p2p_path = malloc(strlen(ibdev_path) + strlen(efa_env.p2p_file_suffix) + 1);
+	if (!p2p_path) {
+		ret = -FI_ENOMEM;
+		goto out;
+	}
+
+	strcpy(p2p_path, ibdev_path);
+	strcat(p2p_path, efa_env.p2p_file_suffix);
+
+	fp = fopen(p2p_path, "r");
+	if (!fp) {
+		EFA_WARN(FI_LOG_DOMAIN, "Cannot open P2P file: %s\n", p2p_path);
+		ret = -FI_ENOENT;
+		goto out;
+	}
+
+	ret = (ssize_t) fread(name, 1, (size_t) len, fp);
+	if (ret <= 0) {
+		EFA_WARN(FI_LOG_DOMAIN, "P2P provider is not available\n");
+		ret = -FI_ENOSYS;
+		goto out;
+	} else if (ret >= (ssize_t) len) {
+		EFA_WARN(FI_LOG_DOMAIN, "Truncated P2P provider name\n");
+		ret = -FI_ETRUNC;
+		goto out;
+	}
+
+	name[ret] = '\0';
+	EFA_INFO(FI_LOG_DOMAIN, "P2P provider name: %s\n", name);
+out:
+	if (fp) {
+		fclose(fp);
+	}
+	if (p2p_path) {
+		free(p2p_path);
+	}
+	return ret;
 }
 
 /**
- * @brief          Initialize the efa_hmem_info state for FI_HMEM_CUDA
+ * @brief Determine if peer-to-peer capability is supported on the domain
+ *
+ * @param[in]	efa_domain	EFA domain
+ * @param[in]	iface		HMEM interface to check
+ * @return	true if P2P is supported, otherwise false
+ */
+static inline bool
+efa_domain_hmem_support_p2p(struct efa_domain *efa_domain, enum fi_hmem_iface iface)
+{
+	char p2p_prov[P2P_PROV_MAX_LEN];
+	const char *p2p_prov_prefix;
+
+	if (iface == FI_HMEM_SYSTEM || iface == FI_HMEM_SYNAPSEAI) {
+		return true;
+	}
+
+	assert(iface == FI_HMEM_CUDA || iface == FI_HMEM_NEURON);
+
+	p2p_prov_prefix = iface == FI_HMEM_CUDA ? "NVIDIA" : "NEURON";
+
+	if ((efa_domain_hmem_p2p_prov_name(efa_domain, p2p_prov,
+					   P2P_PROV_MAX_LEN)) <= 0) {
+		EFA_INFO(FI_LOG_DOMAIN, "Failed to get P2P provider\n");
+		return false;
+	}
+
+	if (strlen(p2p_prov) < strlen(p2p_prov_prefix) ||
+	    strncmp(p2p_prov, p2p_prov_prefix, strlen(p2p_prov_prefix))) {
+		EFA_INFO(FI_LOG_DOMAIN, "P2P provider does not support hmem interface: %d\n", iface);
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * @brief Initialize the efa_hmem_info state for iface
  *
  * @param[in,out]  efa_domain  Pointer to struct efa_domain
- *
- * @return         0 on success
- *                 negative libfabric error code on failure
+ * @param[in]      iface       HMEM interface
  */
-static int efa_domain_hmem_info_init_cuda(struct efa_domain *efa_domain)
+static void
+efa_domain_hmem_info_init_iface(struct efa_domain *efa_domain, enum fi_hmem_iface iface)
 {
-#if HAVE_CUDA
-	struct efa_hmem_info *info = &efa_domain->hmem_info[FI_HMEM_CUDA];
-	cudaError_t cuda_ret;
-	void *ptr = NULL;
-	struct ibv_mr *ibv_mr;
-	int ibv_access = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ;
-	size_t len = ofi_get_page_size() * 2, tmp_value;
-	int ret;
-	int dmabuf_fd;
-	uint64_t dmabuf_offset;
+	struct efa_hmem_info *info = &efa_domain->hmem_info[iface];
 
-	if (!ofi_hmem_is_initialized(FI_HMEM_CUDA)) {
-		EFA_INFO(FI_LOG_DOMAIN, "FI_HMEM_CUDA is not initialized\n");
-		return 0;
+	if (!ofi_hmem_is_initialized(iface)) {
+		EFA_INFO(FI_LOG_DOMAIN, "%s is not initialized\n",
+		         fi_tostr(&iface, FI_TYPE_HMEM_IFACE));
+		return;
 	}
 
-	cuda_ret = ofi_cudaMalloc(&ptr, len);
-	if (cuda_ret != cudaSuccess) {
-		EFA_WARN(FI_LOG_DOMAIN,
-			 "Failed to allocate CUDA buffer: %s\n",
-			 ofi_cudaGetErrorString(cuda_ret));
-		return 0;
-	}
-
-	info->initialized = true;
 	info->p2p_disabled_by_user = false;
+	info->p2p_supported_by_device = efa_domain_hmem_support_p2p(efa_domain, iface);
+	if (!info->p2p_supported_by_device) {
+		EFA_INFO(FI_LOG_DOMAIN, "%s P2P support is not available.\n",
+		         fi_tostr(&iface, FI_TYPE_HMEM_IFACE));
+	}
 
-	/* If user is using libfabric API 1.18 or later, by default EFA provider is permitted to
-	 * use CUDA library to support CUDA memory, therefore p2p is not required.
-	 */
-	if (FI_VERSION_GE(efa_domain->util_domain.fabric->fabric_fid.api_version, FI_VERSION(1,18)))
-		info->p2p_required_by_impl = !hmem_ops[FI_HMEM_CUDA].initialized;
-	else
+	switch (iface) {
+	case FI_HMEM_CUDA:
+		/* If user is using libfabric API 1.18 or later, by default EFA
+		 * provider is permitted to use CUDA library to support CUDA
+		 * memory, therefore p2p is not required.
+		 */
+		if (FI_VERSION_GE(efa_domain->util_domain.fabric->fabric_fid.api_version,
+				  FI_VERSION(1, 18)))
+			info->p2p_required_by_impl = !hmem_ops[iface].initialized;
+		else
+			info->p2p_required_by_impl = true;
+		break;
+	case FI_HMEM_NEURON:
+	case FI_HMEM_SYNAPSEAI:
 		info->p2p_required_by_impl = true;
-
-#if HAVE_EFA_DMABUF_MR
-	ret = cuda_get_dmabuf_fd(ptr, len, &dmabuf_fd, &dmabuf_offset);
-	if (ret == FI_SUCCESS) {
-		ibv_mr = ibv_reg_dmabuf_mr(g_device_list[0].ibv_pd, dmabuf_offset,
-					   len, (uint64_t)ptr, dmabuf_fd, ibv_access);
-		if (!ibv_mr) {
-			EFA_INFO(FI_LOG_DOMAIN,
-				"Unable to register CUDA device buffer via dmabuf: %s. "
-				"Fall back to ibv_reg_mr\n", fi_strerror(-errno));
-			ibv_mr = ibv_reg_mr(g_device_list[0].ibv_pd, ptr, len, ibv_access);
-		}
-	} else {
-		EFA_INFO(FI_LOG_DOMAIN,
-			"Unable to retrieve dmabuf fd of CUDA device buffer: %d. "
-			"Fall back to ibv_reg_mr\n", ret);
-		ibv_mr = ibv_reg_mr(g_device_list[0].ibv_pd, ptr, len, ibv_access);
-	}
-#else
-	ibv_mr = ibv_reg_mr(g_device_list[0].ibv_pd, ptr, len, ibv_access);
-#endif
-
-	if (!ibv_mr) {
-		info->p2p_supported_by_device = false;
-		efa_domain_hmem_info_init_protocol_thresholds(efa_domain, FI_HMEM_CUDA);
-		EFA_WARN(FI_LOG_DOMAIN,
-			 "Failed to register CUDA buffer with the EFA device, FI_HMEM transfers that require peer to peer support will fail.\n");
-		ofi_cudaFree(ptr);
-		return 0;
+		break;
+	default:
+		assert(iface == FI_HMEM_SYSTEM);
+		info->p2p_required_by_impl = false;
 	}
 
-	ret = ibv_dereg_mr(ibv_mr);
-	ofi_cudaFree(ptr);
-	if (ret) {
-		EFA_WARN(FI_LOG_DOMAIN,
-			 "Failed to deregister CUDA buffer: %s\n",
-			 fi_strerror(-ret));
-		return ret;
-	}
-
-	info->p2p_supported_by_device = true;
-	efa_domain_hmem_info_init_protocol_thresholds(efa_domain, FI_HMEM_CUDA);
-	if (-FI_ENODATA != fi_param_get(&efa_prov, "inter_max_medium_message_size", &tmp_value)) {
-		EFA_WARN(FI_LOG_DOMAIN,
-		         "The environment variable FI_EFA_INTER_MAX_MEDIUM_MESSAGE_SIZE was set, "
-		         "but EFA HMEM via Cuda API only supports eager and runting read protocols. "
-				 "The variable will not modify Cuda memory run config.\n");
-	}
-
-#endif
-	return 0;
-}
-
-/**
- * @brief          Initialize the efa_hmem_info state for FI_HMEM_NEURON
- *
- * @param[in,out]  efa_domain  Pointer to struct efa_domain
- *
- * @return         0 on success
- *                 negative libfabric error code on failure
- */
-static int efa_domain_hmem_info_init_neuron(struct efa_domain *efa_domain)
-{
-#if HAVE_NEURON
-	struct efa_hmem_info *info = &efa_domain->hmem_info[FI_HMEM_NEURON];
-	struct ibv_mr *ibv_mr = NULL;
-	int ibv_access = IBV_ACCESS_LOCAL_WRITE;
-	void *handle;
-	void *ptr = NULL;
-	size_t len = ofi_get_page_size() * 2, tmp_value;
-	int dmabuf_fd;
-	uint64_t offset;
-	int ret;
-
-	if (!ofi_hmem_is_initialized(FI_HMEM_NEURON)) {
-		EFA_INFO(FI_LOG_DOMAIN, "FI_HMEM_NEURON is not initialized\n");
-		return 0;
-	}
-
-	if (g_device_list[0].device_caps & EFADV_DEVICE_ATTR_CAPS_RDMA_READ) {
-		ibv_access |= IBV_ACCESS_REMOTE_READ;
-	} else {
-		EFA_WARN(FI_LOG_DOMAIN,
-			 "No EFA RDMA read support, transfers using AWS Neuron will fail.\n");
-		return 0;
-	}
-
-	ptr = neuron_alloc(&handle, len);
-	/*
-	 * neuron_alloc will fail if application did not call nrt_init,
-	 * which is ok if it's not running neuron workloads. libfabric
-	 * will move on and leave info->initialized as false.
-	 */
-	if (!ptr) {
-		EFA_INFO(FI_LOG_DOMAIN, "Cannot allocate Neuron buffer\n");
-		return 0;
-	}
+	efa_domain_hmem_info_init_protocol_thresholds(efa_domain, iface);
 
 	info->initialized = true;
-	info->p2p_disabled_by_user = false;
-	/* Neuron currently requires P2P */
-	info->p2p_required_by_impl = true;
-
-#if HAVE_EFA_DMABUF_MR
-	ret = neuron_get_dmabuf_fd(ptr, (uint64_t)len, &dmabuf_fd, &offset);
-	if (ret == FI_SUCCESS) {
-		ibv_mr = ibv_reg_dmabuf_mr(
-					g_device_list[0].ibv_pd, offset,
-					len, (uint64_t)ptr, dmabuf_fd, ibv_access);
-	} else if (ret == -FI_EOPNOTSUPP) {
-		EFA_INFO(FI_LOG_MR,
-			"Unable to retrieve dmabuf fd of Neuron device buffer, "
-			"Fall back to ibv_reg_mr\n");
-		ibv_mr = ibv_reg_mr(g_device_list[0].ibv_pd, ptr, len, ibv_access);
-	}
-#else
-	ibv_mr = ibv_reg_mr(g_device_list[0].ibv_pd, ptr, len, ibv_access);
-#endif
-
-	if (!ibv_mr) {
-		info->p2p_supported_by_device = false;
-		/* We do not expect to support Neuron on non p2p systems */
-		EFA_WARN(FI_LOG_DOMAIN,
-		         "Failed to register Neuron buffer with the EFA device, "
-		         "FI_HMEM transfers that require peer to peer support will fail.\n");
-		neuron_free(&handle);
-		return 0;
-	}
-
-	ret = ibv_dereg_mr(ibv_mr);
-	neuron_free(&handle);
-	if (ret) {
-		EFA_WARN(FI_LOG_DOMAIN,
-			 "Failed to deregister Neuron buffer: %s\n",
-			 fi_strerror(-ret));
-		return ret;
-	}
-
-	info->p2p_supported_by_device = true;
-	efa_domain_hmem_info_init_protocol_thresholds(efa_domain, FI_HMEM_NEURON);
-	if (-FI_ENODATA != fi_param_get(&efa_prov, "inter_max_medium_message_size", &tmp_value)) {
-		EFA_WARN(FI_LOG_DOMAIN,
-		         "The environment variable FI_EFA_INTER_MAX_MEDIUM_MESSAGE_SIZE was set, "
-		         "but EFA HMEM via Neuron API only supports eager and runting read protocols. "
-				 "The variable will not modify Neuron memory run config.\n");
-	}
-
-#endif
-	return 0;
-}
-
-/**
- * @brief          Initialize the efa_hmem_info state for FI_HMEM_SYNAPSEAI
- *
- * @param[in,out]  efa_domain  Pointer to struct efa_domain
- *
- * @return         0
- */
-static int efa_domain_hmem_info_init_synapseai(struct efa_domain *efa_domain)
-{
-#if HAVE_SYNAPSEAI
-	size_t tmp_value;
-	struct efa_hmem_info *info = &efa_domain->hmem_info[FI_HMEM_SYNAPSEAI];
-
-	if (!ofi_hmem_is_initialized(FI_HMEM_SYNAPSEAI)) {
-		EFA_INFO(FI_LOG_DOMAIN, "FI_HMEM_SYNAPSEAI is not initialized\n");
-		return 0;
-	}
-
-	if (!(g_device_list[0].device_caps & EFADV_DEVICE_ATTR_CAPS_RDMA_READ)) {
-		EFA_WARN(FI_LOG_DOMAIN,
-			 "No EFA RDMA read support, transfers using Habana Gaudi will fail.\n");
-		return 0;
-	}
-
-	info->initialized = true;
-	info->p2p_disabled_by_user = false;
-	/* SynapseAI currently requires P2P */
-	info->p2p_required_by_impl = true;
-	info->p2p_supported_by_device = true;
-	efa_domain_hmem_info_init_protocol_thresholds(efa_domain, FI_HMEM_SYNAPSEAI);
-
-	/*  Only the long read protocol is supported */
-	if (-FI_ENODATA != fi_param_get_size_t(&efa_prov, "inter_max_medium_message_size", &tmp_value) ||
-		-FI_ENODATA != fi_param_get_size_t(&efa_prov, "inter_min_read_message_size", &tmp_value) ||
-		-FI_ENODATA != fi_param_get_size_t(&efa_prov, "inter_min_read_write_size", &tmp_value) ||
-		-FI_ENODATA != fi_param_get_size_t(&efa_prov, "runt_size", &tmp_value)) {
-		EFA_WARN(FI_LOG_DOMAIN,
-				"One or more of the following environment variable(s) were set: ["
-				"FI_EFA_INTER_MAX_MEDIUM_MESSAGE_SIZE, "
-				"FI_EFA_INTER_MIN_READ_MESSAGE_SIZE, "
-				"FI_EFA_INTER_MIN_READ_WRITE_SIZE, "
-				"FI_EFA_RUNT_SIZE"
-				"], but EFA HMEM via Synapse only supports long read protocol. "
-				"The variable(s) will not modify Synapse memory run config.\n");
-	}
-
-#endif
-	return 0;
 }
 
 /**
@@ -397,7 +309,7 @@ int efa_domain_hmem_validate_p2p_opt(struct efa_domain *efa_domain, enum fi_hmem
 }
 
 /**
- * @brief Initialize the hmem_info structs for
+ * @brief Initialize the support status for
  * all of the HMEM devices. The device hmem_info
  * struct will be used to determine which efa transfer
  * protocol should be selected.
@@ -407,9 +319,11 @@ int efa_domain_hmem_validate_p2p_opt(struct efa_domain *efa_domain, enum fi_hmem
  * @return  0 on success
  *          negative libfabric error code on an unexpected error
  */
-int efa_domain_hmem_info_init_all(struct efa_domain *efa_domain)
+int efa_domain_hmem_support_init_all(struct efa_domain *efa_domain)
 {
-	int ret, err;
+	int ret = 0;
+	enum fi_hmem_iface ifaces[4] = {FI_HMEM_SYSTEM, FI_HMEM_CUDA,
+	                                FI_HMEM_NEURON, FI_HMEM_SYNAPSEAI};
 
 	if(g_device_cnt <= 0) {
 		return -FI_ENODEV;
@@ -417,34 +331,8 @@ int efa_domain_hmem_info_init_all(struct efa_domain *efa_domain)
 
 	memset(efa_domain->hmem_info, 0, OFI_HMEM_MAX * sizeof(struct efa_hmem_info));
 
-	ret = 0;
-
-	err = efa_domain_hmem_info_init_system(efa_domain);
-	if (err) {
-		ret = err;
-		EFA_WARN(FI_LOG_DOMAIN, "Failed to populate the System hmem_info struct! err: %d\n",
-			 err);
-	}
-
-	err = efa_domain_hmem_info_init_cuda(efa_domain);
-	if (err) {
-		ret = err;
-		EFA_WARN(FI_LOG_DOMAIN, "Failed to populate the Cuda hmem_info struct! err: %d\n",
-			 err);
-	}
-
-	err = efa_domain_hmem_info_init_neuron(efa_domain);
-	if (err) {
-		ret = err;
-		EFA_WARN(FI_LOG_DOMAIN, "Failed to populate the Neuron hmem_info struct! err: %d\n",
-			 err);
-	}
-
-	err = efa_domain_hmem_info_init_synapseai(efa_domain);
-	if (err) {
-		ret = err;
-		EFA_WARN(FI_LOG_DOMAIN, "Failed to populate the Synapseai hmem_info struct! err: %d\n",
-			 err);
+	for (int i = 0; i < sizeof(ifaces) / sizeof(enum fi_hmem_iface); ++i) {
+		efa_domain_hmem_info_init_iface(efa_domain, ifaces[i]);
 	}
 
 	return ret;

--- a/prov/efa/src/efa_hmem.h
+++ b/prov/efa/src/efa_hmem.h
@@ -36,7 +36,7 @@ struct efa_hmem_info {
 struct efa_domain;
 
 int efa_domain_hmem_validate_p2p_opt(struct efa_domain *efa_domain, enum fi_hmem_iface iface, int p2p_opt);
-int efa_domain_hmem_info_init_all(struct efa_domain *efa_domain);
+int efa_domain_hmem_support_init_all(struct efa_domain *efa_domain);
 
 /**
  * @brief Copy data from a hmem device to a system buffer

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -499,9 +499,20 @@ struct ibv_mr *efa_mr_reg_ibv_dmabuf_mr(struct ibv_pd *pd, uint64_t offset,
 }
 
 #endif
+
 /**
  * @brief Register a memory buffer with rdma-core api.
- *
+ * - If the application requests FI_MR_DMABUF, we will always use
+ *   ibv_reg_dmabuf_mr
+ * - If the memory region is on system or CUDA device, we will always use
+ *   ibv_reg_mr
+ * - If the memory region is on Gaudi device, we will always use
+ *   ibv_reg_dmabuf_mr
+ * - If the memory region is on Neuron device, we will first attempt to
+ *   export the dmabuf fd: 1) if fd is available we will proceed to use
+ *   ibv_reg_dmabuf_mr, 2) if dmabuf fd is not supported then we will
+ *   fallback to ibv_reg_mr
+ * 
  * @param efa_mr the ptr to the efa_mr object
  * @param mr_attr the ptr to the fi_mr_attr object
  * @param access the desired memory protection attributes
@@ -509,78 +520,51 @@ struct ibv_mr *efa_mr_reg_ibv_dmabuf_mr(struct ibv_pd *pd, uint64_t offset,
  * @return struct ibv_mr* the ptr to the registered MR
  */
 static struct ibv_mr *efa_mr_reg_ibv_mr(struct efa_mr *efa_mr, struct fi_mr_attr *mr_attr,
-					int access, const uint64_t flags)
+                                        int access, const uint64_t flags)
 {
-	if (flags & FI_MR_DMABUF)
-		return efa_mr_reg_ibv_dmabuf_mr(
-			efa_mr->domain->ibv_pd,
-			mr_attr->dmabuf->offset,
-			mr_attr->dmabuf->len,
-			(uintptr_t) mr_attr->dmabuf->base_addr + mr_attr->dmabuf->offset,
-			mr_attr->dmabuf->fd,
-			access
-		);
+	int ret, dmabuf_fd;
+	uint64_t offset;
 
-	/*
-	 * TODO: remove the synapseai and neuron blocks by onboarding the
-	 * ofi_hmem_get_dmabuf_fd API.
-	 */
-#if HAVE_SYNAPSEAI
-	if (efa_mr_is_synapseai(efa_mr)) {
-		int dmabuf_fd;
-		uint64_t offset;
-		int ret;
-
-		ret = synapseai_get_dmabuf_fd(mr_attr->mr_iov->iov_base,
-						(uint64_t) mr_attr->mr_iov->iov_len,
-						&dmabuf_fd, &offset);
-		if (ret != FI_SUCCESS) {
-			EFA_WARN(FI_LOG_MR, "Unable to get dmabuf fd for Gaudi device buffer \n");
-			return NULL;
-		}
-		return efa_mr_reg_ibv_dmabuf_mr(efa_mr->domain->ibv_pd, offset,
-					mr_attr->mr_iov->iov_len,
-					(uint64_t)mr_attr->mr_iov->iov_base,
-					dmabuf_fd, access);
+	if (flags & FI_MR_DMABUF) {
+		return efa_mr_reg_ibv_dmabuf_mr(efa_mr->domain->ibv_pd,
+		                                mr_attr->dmabuf->offset,
+		                                mr_attr->dmabuf->len,
+		                                (uintptr_t) mr_attr->dmabuf->base_addr + mr_attr->dmabuf->offset,
+		                                mr_attr->dmabuf->fd, access);
 	}
-#endif
 
-#if HAVE_NEURON
-	if (efa_mr_is_neuron(efa_mr)) {
-		int dmabuf_fd;
-		uint64_t offset;
-		int ret;
+	if (!efa_mr_is_hmem(efa_mr) || efa_mr_is_cuda(efa_mr)) {
+		return ibv_reg_mr(efa_mr->domain->ibv_pd,
+		                  (void *) mr_attr->mr_iov->iov_base,
+		                  mr_attr->mr_iov->iov_len, access);
+	}
 
-		ret = neuron_get_dmabuf_fd(
-				mr_attr->mr_iov->iov_base,
-				mr_attr->mr_iov->iov_len,
-				&dmabuf_fd,
-				&offset);
+	ret = ofi_hmem_get_dmabuf_fd(mr_attr->iface, mr_attr->mr_iov->iov_base,
+	                             mr_attr->mr_iov->iov_len, &dmabuf_fd,
+	                             &offset);
 
-		if (ret == FI_SUCCESS) {
-			/* Success => invoke ibv_reg_dmabuf_mr */
-			return efa_mr_reg_ibv_dmabuf_mr(
-					efa_mr->domain->ibv_pd, 0,
-					mr_attr->mr_iov->iov_len,
-					(uint64_t)mr_attr->mr_iov->iov_base,
-					dmabuf_fd, access);
-		} else if (ret == -FI_EOPNOTSUPP) {
-			/* Protocol not availabe => fallback */
-			EFA_INFO(FI_LOG_MR,
-				"Unable to get dmabuf fd for Neuron device buffer, "
-				"Fall back to ibv_reg_mr\n");
-			return ibv_reg_mr(
-				efa_mr->domain->ibv_pd,
-				(void *)mr_attr->mr_iov->iov_base,
-				mr_attr->mr_iov->iov_len, access);
+	if (ret != FI_SUCCESS) {
+		EFA_WARN(FI_LOG_MR,
+		         "Unable to get dmabuf fd for device buffer. "
+		         "iface: %s errno: %d, err_msg: %s\n",
+		         fi_tostr(&mr_attr->iface, FI_TYPE_HMEM_IFACE), ret,
+		         fi_strerror(-ret));
+		if (ret == -FI_EOPNOTSUPP && efa_mr_is_neuron(efa_mr)) {
+			return ibv_reg_mr(efa_mr->domain->ibv_pd,
+			                  (void *) mr_attr->mr_iov->iov_base,
+			                  mr_attr->mr_iov->iov_len, access);
 		}
 		return NULL;
 	}
-#endif
 
-	return ibv_reg_mr(efa_mr->domain->ibv_pd,
-			(void *)mr_attr->mr_iov->iov_base,
-			mr_attr->mr_iov->iov_len, access);
+	EFA_INFO(FI_LOG_MR,
+	         "Registering dmabuf mr with fd: %d, offset: %lu, len: %zu\n",
+	         dmabuf_fd, offset, mr_attr->mr_iov->iov_len);
+
+	return efa_mr_reg_ibv_dmabuf_mr(efa_mr->domain->ibv_pd, offset,
+	                                mr_attr->mr_iov->iov_len,
+	                                (uint64_t) mr_attr->mr_iov->iov_base,
+	                                dmabuf_fd, access);
 }
 
 #if HAVE_CUDA

--- a/prov/efa/test/efa_unit_test_common.c
+++ b/prov/efa/test/efa_unit_test_common.c
@@ -56,7 +56,7 @@ struct fi_info *efa_unit_test_alloc_hints(enum fi_ep_type ep_type)
 
 void efa_unit_test_resource_construct_with_hints(struct efa_resource *resource,
 						 enum fi_ep_type ep_type,
-						 struct fi_info *hints,
+						 uint32_t fi_version, struct fi_info *hints,
 						 bool enable_ep, bool open_cq)
 {
 	int ret = 0;
@@ -64,7 +64,7 @@ void efa_unit_test_resource_construct_with_hints(struct efa_resource *resource,
 	struct fi_cq_attr cq_attr = {0};
 	struct fi_eq_attr eq_attr = {0};
 
-	ret = fi_getinfo(FI_VERSION(1, 14), NULL, NULL, 0ULL, hints, &resource->info);
+	ret = fi_getinfo(fi_version, NULL, NULL, 0ULL, hints, &resource->info);
 	if (ret)
 		goto err;
 
@@ -120,8 +120,8 @@ void efa_unit_test_resource_construct(struct efa_resource *resource, enum fi_ep_
 	resource->hints = efa_unit_test_alloc_hints(ep_type);
 	if (!resource->hints)
 		goto err;
-	efa_unit_test_resource_construct_with_hints(resource, ep_type,
-						    resource->hints, true, true);
+	efa_unit_test_resource_construct_with_hints(resource, ep_type, FI_VERSION(1, 14),
+	                                            resource->hints, true, true);
 	return;
 
 err:
@@ -137,7 +137,7 @@ void efa_unit_test_resource_construct_ep_not_enabled(struct efa_resource *resour
 	resource->hints = efa_unit_test_alloc_hints(ep_type);
 	if (!resource->hints)
 		goto err;
-	efa_unit_test_resource_construct_with_hints(resource, ep_type,
+	efa_unit_test_resource_construct_with_hints(resource, ep_type, FI_VERSION(1, 14),
 						    resource->hints, false, true);
 	return;
 
@@ -154,7 +154,7 @@ void efa_unit_test_resource_construct_no_cq_and_ep_not_enabled(struct efa_resour
 	resource->hints = efa_unit_test_alloc_hints(ep_type);
 	if (!resource->hints)
 		goto err;
-	efa_unit_test_resource_construct_with_hints(resource, ep_type,
+	efa_unit_test_resource_construct_with_hints(resource, ep_type, FI_VERSION(1, 14),
 						    resource->hints, false, false);
 	return;
 

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -533,7 +533,8 @@ void test_efa_rdm_ep_rma_queue_before_handshake(struct efa_resource **state, int
 	resource->hints = efa_unit_test_alloc_hints(FI_EP_RDM);
 	resource->hints->caps |= FI_MSG | FI_TAGGED | FI_RMA;
 	resource->hints->domain_attr->mr_mode = FI_MR_BASIC;
-	efa_unit_test_resource_construct_with_hints(resource, FI_EP_RDM, resource->hints, true, true);
+	efa_unit_test_resource_construct_with_hints(resource, FI_EP_RDM, FI_VERSION(1, 14),
+	                                            resource->hints, true, true);
 
 	/* ensure we don't have RMA capability. */
 	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
@@ -656,7 +657,8 @@ void test_efa_rdm_ep_rma_without_caps(struct efa_resource **state)
 	resource->hints->caps |= FI_MSG | FI_TAGGED;
 	resource->hints->caps &= ~FI_RMA;
 	resource->hints->domain_attr->mr_mode = FI_MR_BASIC;
-	efa_unit_test_resource_construct_with_hints(resource, FI_EP_RDM, resource->hints, true, true);
+	efa_unit_test_resource_construct_with_hints(resource, FI_EP_RDM, FI_VERSION(1, 14),
+	                                            resource->hints, true, true);
 
 	/* ensure we don't have RMA capability. */
 	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
@@ -706,7 +708,8 @@ void test_efa_rdm_ep_atomic_without_caps(struct efa_resource **state)
 	resource->hints->caps |= FI_MSG | FI_TAGGED;
 	resource->hints->caps &= ~FI_ATOMIC;
 	resource->hints->domain_attr->mr_mode = FI_MR_BASIC;
-	efa_unit_test_resource_construct_with_hints(resource, FI_EP_RDM, resource->hints, true, true);
+	efa_unit_test_resource_construct_with_hints(resource, FI_EP_RDM, FI_VERSION(1, 14),
+	                                            resource->hints, true, true);
 
 	/* ensure we don't have ATOMIC capability. */
 	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
@@ -864,7 +867,8 @@ test_efa_rdm_ep_use_zcpy_rx_impl(struct efa_resource *resource, bool expected_us
 	struct efa_rdm_ep *ep;
 	size_t max_msg_size = 1000;
 
-	efa_unit_test_resource_construct_with_hints(resource, FI_EP_RDM, resource->hints, false, true);
+	efa_unit_test_resource_construct_with_hints(resource, FI_EP_RDM, FI_VERSION(1, 14),
+	                                            resource->hints, false, true);
 
 	ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
 

--- a/prov/efa/test/efa_unit_test_hmem.c
+++ b/prov/efa/test/efa_unit_test_hmem.c
@@ -3,55 +3,277 @@
 
 #include "efa_unit_tests.h"
 
-
-#if HAVE_NEURON
-/**
- * @brief Verify when neuron_alloc failed (return null),
- * efa_domain_open, which call efa_hmem_info_update_neuron
- * when HAVE_NEURON=1, will still return 0 but leave
- * efa_hmem_info[FI_HMEM_NEURON].initialized and
- * efa_hmem_info[FI_HMEM_NEURON].p2p_supported_by_device as false.
- *
- * @param[in]	state		struct efa_resource that is managed by the framework
- */
-void test_efa_hmem_info_update_neuron(struct efa_resource **state)
+void test_efa_hmem_p2p_support(struct efa_resource **state, bool file_exists,
+			       char *prov_name, enum fi_hmem_iface iface,
+			       bool expected_p2p_support)
 {
-        int ret;
-        struct efa_resource *resource = *state;
-        struct efa_domain *efa_domain;
-        uint32_t efa_device_caps_orig;
-        bool neuron_initialized_orig;
+	int fd = -1, ret;
+	bool iface_initialized;
+	uint32_t device_caps;
+	ssize_t written_len;
+	char p2p_file[] = "XXXXXXXXXX";
+	char ibdev_path[IBV_SYSFS_PATH_MAX] = {0};
+	char *p2p_file_suffix = NULL;
+	struct efa_resource *resource = *state;
+	struct efa_domain *efa_domain;
 
-        resource->hints = efa_unit_test_alloc_hints(FI_EP_RDM);
-        assert_non_null(resource->hints);
+	if (file_exists) {
+		fd = mkstemp(p2p_file);
+		if (fd < 0) {
+			fail();
+		}
 
-        ret = fi_getinfo(FI_VERSION(1, 14), NULL, NULL, 0ULL, resource->hints, &resource->info);
-        assert_int_equal(ret, 0);
+		written_len = write(fd, prov_name, strlen(prov_name));
+		if (written_len != strlen(prov_name)) {
+			close(fd);
+			fail();
+		}
+	}
 
-        ret = fi_fabric(resource->info->fabric_attr, &resource->fabric, NULL);
-        assert_int_equal(ret, 0);
+	resource->hints = efa_unit_test_alloc_hints(FI_EP_RDM);
+	assert_non_null(resource->hints);
 
-        neuron_initialized_orig = hmem_ops[FI_HMEM_NEURON].initialized;
-        hmem_ops[FI_HMEM_NEURON].initialized = true;
-        efa_device_caps_orig = g_device_list[0].device_caps;
-        g_device_list[0].device_caps |= EFADV_DEVICE_ATTR_CAPS_RDMA_READ;
-        g_efa_unit_test_mocks.neuron_alloc = &efa_mock_neuron_alloc_return_null;
+	ret = fi_getinfo(FI_VERSION(1, 20), NULL, NULL, 0ULL, resource->hints,
+			 &resource->info);
+	assert_int_equal(ret, FI_SUCCESS);
 
-        ret = fi_domain(resource->fabric, resource->info, &resource->domain, NULL);
+	ret = fi_fabric(resource->info->fabric_attr, &resource->fabric, NULL);
+	assert_int_equal(ret, FI_SUCCESS);
 
-        /* recover the modified global variables before doing check */
-        hmem_ops[FI_HMEM_NEURON].initialized = neuron_initialized_orig;
-        g_device_list[0].device_caps = efa_device_caps_orig;
+	/* Override global attributes */
+	strcpy(ibdev_path, g_device_list[0].ibv_ctx->device->ibdev_path);
+	strcpy(g_device_list[0].ibv_ctx->device->ibdev_path, p2p_file);
+	iface_initialized = hmem_ops[iface].initialized;
+	hmem_ops[iface].initialized = true;
+	device_caps = g_device_list[0].device_caps;
+	p2p_file_suffix = efa_env.p2p_file_suffix;
+	efa_env.p2p_file_suffix = "";
 
-        assert_int_equal(ret, 0);
-        efa_domain = container_of(resource->domain, struct efa_domain,
+	ret = fi_domain(resource->fabric, resource->info, &resource->domain,
+			NULL);
+
+	/* Reset global attributes */
+	strcpy(g_device_list[0].ibv_ctx->device->ibdev_path, ibdev_path);
+	hmem_ops[iface].initialized = iface_initialized;
+	g_device_list[0].device_caps = device_caps;
+	efa_env.p2p_file_suffix = p2p_file_suffix;
+
+	/* Remove the temporary file */
+	if (file_exists) {
+		unlink(p2p_file);
+		close(fd);
+	}
+
+	assert_int_equal(ret, FI_SUCCESS);
+	efa_domain = container_of(resource->domain, struct efa_domain,
 				  util_domain.domain_fid.fid);
-        assert_false(efa_domain->hmem_info[FI_HMEM_NEURON].initialized);
-        assert_false(efa_domain->hmem_info[FI_HMEM_NEURON].p2p_supported_by_device);
+
+	assert_true(efa_domain->hmem_info[iface].initialized);
+	assert_int_equal(efa_domain->hmem_info[iface].p2p_supported_by_device,
+			 expected_p2p_support);
 }
-#else
-void test_efa_hmem_info_update_neuron()
+
+void test_efa_dmabuf_support(struct efa_resource **state,
+                             enum fi_hmem_iface iface,
+                             bool require_dmabuf,
+                             bool dmabuf_fd_supported,
+                             bool dmabuf_mr_supported,
+			     bool expect_ibv_reg_mr,
+			     bool expect_ibv_reg_dmabuf_mr)
 {
-        skip();
+	bool iface_initialized;
+	const size_t bufsize = 4096;
+	const uint64_t buf = g_efa_unit_test_mocks.dummy_address;
+	int ret;
+	struct efa_domain *efa_domain;
+	struct efa_resource *resource = *state;
+	struct fi_mr_attr mr_attr = {0};
+	struct fi_mr_dmabuf mr_dmabuf = {0};
+	struct fid_mr *mr = NULL;
+	struct ibv_mr ibv_mr = {0};
+	struct iovec iov = {0};
+	uint64_t flags = 0;
+	get_dmabuf_fd_fn_t get_dmabuf_fd = NULL;
+
+	mr_attr.iface = iface;
+	mr_attr.access = FI_SEND | FI_RECV;
+
+	if (require_dmabuf) {
+		mr_dmabuf.base_addr = (void *) buf;
+		mr_dmabuf.len = bufsize;
+		mr_attr.dmabuf = &mr_dmabuf;
+		flags |= FI_MR_DMABUF;
+	} else {
+		iov.iov_base = (void *) buf;
+		iov.iov_len = bufsize;
+		mr_attr.iov_count = 1;
+		mr_attr.mr_iov = &iov;
+	}
+
+	/* Override global attributes */
+	get_dmabuf_fd = hmem_ops[iface].get_dmabuf_fd;
+	hmem_ops[iface].get_dmabuf_fd = efa_mock_get_dmabuf_fd_set_errno_return_mock;
+	iface_initialized = hmem_ops[iface].initialized;
+	hmem_ops[iface].initialized = true;
+
+	resource->hints = efa_unit_test_alloc_hints(FI_EP_RDM);
+	efa_unit_test_resource_construct_with_hints(resource, FI_EP_RDM, FI_VERSION(1, 20),
+	                                            resource->hints, true, true);
+
+	efa_domain = container_of(resource->domain, struct efa_domain,
+				  util_domain.domain_fid.fid);
+
+	efa_domain->hmem_info[iface].initialized = true;
+	efa_domain->hmem_info[iface].p2p_supported_by_device = true;
+	/* Force domain to support FI_HMEM so we can test on any platform */
+	efa_domain->util_domain.info_domain_caps |= FI_HMEM;
+
+	/* Required during cleanup */
+	g_efa_unit_test_mocks.ibv_dereg_mr = efa_mock_ibv_dereg_mr_return_mock_for_dummy_mr;
+	will_return_maybe(efa_mock_ibv_dereg_mr_return_mock_for_dummy_mr, 0);
+
+	if (expect_ibv_reg_dmabuf_mr && !require_dmabuf) {
+		will_return(efa_mock_get_dmabuf_fd_set_errno_return_mock,
+			    dmabuf_fd_supported ? FI_SUCCESS : -FI_EOPNOTSUPP);
+	}
+
+#if HAVE_EFA_DMABUF_MR
+	g_efa_unit_test_mocks.ibv_reg_dmabuf_mr =
+		efa_mock_ibv_reg_dmabuf_mr_set_eopnotsupp_and_return_mock;
+	if ((expect_ibv_reg_dmabuf_mr && dmabuf_fd_supported) || require_dmabuf) {
+		will_return(
+			efa_mock_ibv_reg_dmabuf_mr_set_eopnotsupp_and_return_mock,
+			dmabuf_mr_supported ? &ibv_mr : NULL);
+	}
+#else
+	assert_false(dmabuf_mr_supported);
+#endif /* HAVE_EFA_DMABUF_MR */
+
+	if (expect_ibv_reg_mr) {
+		/* Fallback to ibv_reg_mr */
+		g_efa_unit_test_mocks.ibv_reg_mr_iova2 =
+			efa_mock_ibv_reg_mr_iova2_return_mock_for_dummy_addr;
+		will_return_maybe(efa_mock_ibv_reg_mr_iova2_return_mock_for_dummy_addr, &ibv_mr);
+		g_efa_unit_test_mocks.ibv_reg_mr_fn =
+			efa_mock_ibv_reg_mr_return_mock_for_dummy_addr;
+		will_return_maybe(efa_mock_ibv_reg_mr_return_mock_for_dummy_addr, &ibv_mr);
+	}
+
+	assert_int_equal(0, g_efa_unit_test_mocks.ibv_reg_mr_calls);
+
+	ret = fi_mr_regattr(resource->domain, &mr_attr, flags, &mr);
+
+	if (expect_ibv_reg_mr) {
+		assert_int_equal(1, g_efa_unit_test_mocks.ibv_reg_mr_calls);
+	}
+
+	/* Reset global attributes */
+	hmem_ops[iface].get_dmabuf_fd = get_dmabuf_fd;
+	hmem_ops[iface].initialized = iface_initialized;
+
+	if (!expect_ibv_reg_mr && (!dmabuf_fd_supported || !dmabuf_mr_supported) ) {
+		assert_int_not_equal(ret, FI_SUCCESS);
+	} else {
+		/* Either ibv_reg_dmabuf_mr or ibv_reg_mr should work */
+		assert_int_equal(ret, FI_SUCCESS);
+	}
+
+	if (mr) {
+		fi_close((fid_t) &mr->fid);
+	}
 }
-#endif /* HAVE_NEURON */
+
+void test_efa_system_p2p_support_true_system_p2p_file_does_not_exist(struct efa_resource **state)
+{
+	test_efa_hmem_p2p_support(state, false, NULL, FI_HMEM_SYSTEM, true);
+}
+
+void test_efa_system_p2p_support_true_system_p2p_file_empty(struct efa_resource **state)
+{
+	test_efa_hmem_p2p_support(state, true, "", FI_HMEM_SYSTEM, true);
+}
+
+void test_efa_cuda_p2p_support_true_nvidia_prov(struct efa_resource **state)
+{
+	test_efa_hmem_p2p_support(state, true, "NVIDIA", FI_HMEM_CUDA, true);
+}
+
+void test_efa_cuda_p2p_support_true_nvidia_peermem_prov(struct efa_resource **state)
+{
+	test_efa_hmem_p2p_support(state, true, "NVIDIA peermem", FI_HMEM_CUDA, true);
+}
+
+void test_efa_cuda_p2p_support_false_p2p_file_does_not_exist(struct efa_resource **state)
+{
+	test_efa_hmem_p2p_support(state, false, NULL, FI_HMEM_CUDA, false);
+}
+
+void test_efa_cuda_p2p_support_false_p2p_file_empty(struct efa_resource **state)
+{
+	test_efa_hmem_p2p_support(state, true, "", FI_HMEM_CUDA, false);
+}
+
+void test_efa_neuron_p2p_support_true_neuron_prov(struct efa_resource **state)
+{
+	test_efa_hmem_p2p_support(state, true, "NEURON", FI_HMEM_NEURON, true);
+}
+
+void test_efa_neuron_p2p_support_false_p2p_file_does_not_exist(struct efa_resource **state)
+{
+	test_efa_hmem_p2p_support(state, false, NULL, FI_HMEM_NEURON, false);
+}
+
+void test_efa_neuron_p2p_support_false_p2p_file_empty(struct efa_resource **state)
+{
+	test_efa_hmem_p2p_support(state, true, "", FI_HMEM_NEURON, false);
+}
+
+void test_efa_synapseai_p2p_support_true_p2p_file_does_not_exist(struct efa_resource **state)
+{
+	test_efa_hmem_p2p_support(state, false, NULL, FI_HMEM_SYNAPSEAI, true);
+}
+
+void test_efa_synapseai_p2p_support_true_p2p_file_empty(struct efa_resource **state)
+{
+	test_efa_hmem_p2p_support(state, true, "", FI_HMEM_SYNAPSEAI, true);
+}
+
+void test_efa_system_always_ibv_reg_mr(struct efa_resource **state)
+{
+	test_efa_dmabuf_support(state, FI_HMEM_SYSTEM, false, false, false, true, false);
+}
+
+void test_efa_cuda_dmabuf_support_always_ibv_reg_mr(struct efa_resource **state)
+{
+	test_efa_dmabuf_support(state, FI_HMEM_CUDA, false, false, false, true, false);
+}
+
+void test_efa_cuda_dmabuf_support_require_dmabuf_fail_no_fallback(struct efa_resource **state)
+{
+	test_efa_dmabuf_support(state, FI_HMEM_CUDA, true, false, false, false, true);
+}
+
+void test_efa_neuron_dmabuf_support_dmabuf_success(struct efa_resource **state)
+{
+	test_efa_dmabuf_support(state, FI_HMEM_NEURON, false, true, true, false, true);
+}
+
+void test_efa_neuron_dmabuf_support_get_fd_fail_fallback(struct efa_resource **state)
+{
+	test_efa_dmabuf_support(state, FI_HMEM_NEURON, false, false, false, true, true);
+}
+
+void test_efa_neuron_dmabuf_support_mr_fail_no_fallback(struct efa_resource **state)
+{
+	test_efa_dmabuf_support(state, FI_HMEM_NEURON, false, true, false, false, true);
+}
+
+void test_efa_neuron_dmabuf_support_require_dmabuf_fail_no_fallback(struct efa_resource **state)
+{
+	test_efa_dmabuf_support(state, FI_HMEM_NEURON, true, false, false, false, true);
+}
+
+void test_efa_synapseai_dmabuf_support_fd_fail_no_fallback(struct efa_resource **state)
+{
+	test_efa_dmabuf_support(state, FI_HMEM_SYNAPSEAI, false, false, false, false, true);
+}

--- a/prov/efa/test/efa_unit_test_mocks.c
+++ b/prov/efa/test/efa_unit_test_mocks.c
@@ -35,6 +35,51 @@ int efa_mock_efadv_query_device_return_mock(struct ibv_context *ibv_ctx,
 	return mock();
 }
 
+struct ibv_mr *__wrap_ibv_reg_mr(struct ibv_pd *pd, void *addr, size_t length,
+                                 int access)
+{
+	return g_efa_unit_test_mocks.ibv_reg_mr_fn(pd, addr, length, access);
+}
+
+struct ibv_mr *efa_mock_ibv_reg_mr_return_mock_for_dummy_addr(struct ibv_pd *pd, void *addr,
+                                                              size_t length, int access)
+{
+	++g_efa_unit_test_mocks.ibv_reg_mr_calls;
+	if ((uint64_t) addr != g_efa_unit_test_mocks.dummy_address) {
+		return __real_ibv_reg_mr(pd, addr, length, access);
+	}
+	return (struct ibv_mr *) mock();
+}
+
+struct ibv_mr *__wrap_ibv_reg_mr_iova2(struct ibv_pd *pd, void *addr,
+				       size_t length, uint64_t iova,
+				       unsigned int access)
+{
+	return g_efa_unit_test_mocks.ibv_reg_mr_iova2(pd, addr, length, iova, access);
+}
+
+struct ibv_mr *efa_mock_ibv_reg_mr_iova2_return_mock_for_dummy_addr(struct ibv_pd *pd, void *addr,
+                                                                    size_t length, uint64_t iova,
+                                                                    unsigned int access)
+{
+	++g_efa_unit_test_mocks.ibv_reg_mr_calls;
+	if ((uint64_t) addr != g_efa_unit_test_mocks.dummy_address) {
+		return __real_ibv_reg_mr_iova2(pd, addr, length, iova, access);
+	}
+	return (struct ibv_mr *) mock();
+}
+
+int __wrap_ibv_dereg_mr(struct ibv_mr *ibv_mr) {
+	return g_efa_unit_test_mocks.ibv_dereg_mr(ibv_mr);
+}
+
+int efa_mock_ibv_dereg_mr_return_mock_for_dummy_mr(struct ibv_mr *ibv_mr)
+{
+	if (ibv_mr->pd) {
+		return __real_ibv_dereg_mr(ibv_mr);
+	}
+	return mock();
+}
 
 /**
  * @brief a list of work requests request's WR ID
@@ -193,15 +238,17 @@ ssize_t efa_mock_ofi_copy_from_hmem_iov_inc_counter(void *dest, size_t size,
 }
 
 struct efa_unit_test_mocks g_efa_unit_test_mocks = {
+	.dummy_address = -1,
 	.local_host_id = 0,
 	.peer_host_id = 0,
 	.ibv_create_ah = __real_ibv_create_ah,
 	.efadv_query_device = __real_efadv_query_device,
+	.ibv_reg_mr_calls = 0,
+	.ibv_reg_mr_fn = __real_ibv_reg_mr,
+	.ibv_reg_mr_iova2 = __real_ibv_reg_mr_iova2,
+	.ibv_dereg_mr = __real_ibv_dereg_mr,
 #if HAVE_EFADV_CQ_EX
 	.efadv_create_cq = __real_efadv_create_cq,
-#endif
-#if HAVE_NEURON
-	.neuron_alloc = __real_neuron_alloc,
 #endif
 	.ofi_copy_from_hmem_iov = __real_ofi_copy_from_hmem_iov,
 	.ibv_is_fork_initialized = __real_ibv_is_fork_initialized,
@@ -210,6 +257,9 @@ struct efa_unit_test_mocks g_efa_unit_test_mocks = {
 #endif
 #if HAVE_EFA_DATA_IN_ORDER_ALIGNED_128_BYTES
 	.ibv_query_qp_data_in_order = __real_ibv_query_qp_data_in_order,
+#endif
+#if HAVE_EFA_DMABUF_MR
+	.ibv_reg_dmabuf_mr = __real_ibv_reg_dmabuf_mr,
 #endif
 };
 
@@ -294,18 +344,6 @@ struct ibv_cq_ex *efa_mock_efadv_create_cq_set_eopnotsupp_and_return_null(struct
 }
 #endif
 
-#if HAVE_NEURON
-void *__wrap_neuron_alloc(void **handle, size_t size)
-{
-	return g_efa_unit_test_mocks.neuron_alloc(handle, size);
-}
-
-void *efa_mock_neuron_alloc_return_null(void **handle, size_t size)
-{
-	return NULL;
-}
-#endif
-
 ssize_t __wrap_ofi_copy_from_hmem_iov(void *dest, size_t size,
 				      enum fi_hmem_iface hmem_iface, uint64_t device,
 				      const struct iovec *hmem_iov,
@@ -380,5 +418,27 @@ int efa_mock_ibv_query_qp_data_in_order_return_0(struct ibv_qp *qp, enum ibv_wr_
 int efa_mock_ibv_query_qp_data_in_order_return_in_order_aligned_128_bytes(struct ibv_qp *qp, enum ibv_wr_opcode op, uint32_t flags)
 {
 	return IBV_QUERY_QP_DATA_IN_ORDER_ALIGNED_128_BYTES;
+}
+#endif
+
+int efa_mock_get_dmabuf_fd_set_errno_return_mock(const void *addr, uint64_t size, int *fd,
+				       uint64_t *offset)
+{
+	int ret = mock();
+	errno = ret;
+	*fd = 0;
+	*offset = 0;
+	return ret;
+}
+
+#if HAVE_EFA_DMABUF_MR
+struct ibv_mr *__wrap_ibv_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset, size_t length, uint64_t iova, int fd, int access)
+{
+	return g_efa_unit_test_mocks.ibv_reg_dmabuf_mr(pd, offset, length, iova, fd, access);
+}
+
+struct ibv_mr *efa_mock_ibv_reg_dmabuf_mr_set_eopnotsupp_and_return_mock(struct ibv_pd *pd, uint64_t offset, size_t length, uint64_t iova, int fd, int access) {
+	errno = -FI_EOPNOTSUPP;
+	return (struct ibv_mr *) mock();
 }
 #endif

--- a/prov/efa/test/efa_unit_test_mocks.h
+++ b/prov/efa/test/efa_unit_test_mocks.h
@@ -6,6 +6,8 @@
 
 extern struct efa_unit_test_mocks g_efa_unit_test_mocks;
 
+typedef int (*get_dmabuf_fd_fn_t)(const void *addr, uint64_t size, int *fd, uint64_t *offset);
+
 struct efa_mock_ibv_send_wr_list
 {
 	struct ibv_send_wr *head;
@@ -23,6 +25,21 @@ int __real_efadv_query_device(struct ibv_context *ibvctx, struct efadv_device_at
 
 int efa_mock_efadv_query_device_return_mock(struct ibv_context *ibvctx, struct efadv_device_attr *attr,
 					    uint32_t inlen);
+
+struct ibv_mr *__real_ibv_reg_mr(struct ibv_pd *pd, void *addr, size_t length,
+                                 int access);
+
+struct ibv_mr *efa_mock_ibv_reg_mr_return_mock_for_dummy_addr(struct ibv_pd *pd, void *addr,
+                                                              size_t length, int access);
+
+struct ibv_mr *__real_ibv_reg_mr_iova2(struct ibv_pd *pd, void *addr, size_t length, uint64_t iova,
+                                       unsigned int access);
+struct ibv_mr *efa_mock_ibv_reg_mr_iova2_return_mock_for_dummy_addr(struct ibv_pd *pd, void *addr,
+                                                                    size_t length, uint64_t iova,
+                                                                    unsigned int access);
+
+int __real_ibv_dereg_mr(struct ibv_mr *ibv_mr);
+int efa_mock_ibv_dereg_mr_return_mock_for_dummy_mr(struct ibv_mr *ibv_mr);
 
 extern void *g_ibv_submitted_wr_id_vec[EFA_RDM_EP_MAX_WR_PER_IBV_POST_SEND];
 
@@ -85,28 +102,35 @@ ssize_t efa_mock_ofi_copy_from_hmem_iov_inc_counter(void *dest, size_t size,
 
 struct efa_unit_test_mocks
 {
+	uint64_t dummy_address;
 	uint64_t local_host_id;
 	uint64_t peer_host_id;
 	struct ibv_ah *(*ibv_create_ah)(struct ibv_pd *pd, struct ibv_ah_attr *attr);
 
 	int (*efadv_query_device)(struct ibv_context *ibvctx, struct efadv_device_attr *attr,
 							  uint32_t inlen);
+	int ibv_reg_mr_calls;
+	struct ibv_mr *(*ibv_reg_mr_fn)(struct ibv_pd *pd, void *addr, size_t length,
+	                                int access);
+	struct ibv_mr *(*ibv_reg_mr_iova2)(struct ibv_pd *pd, void *addr, size_t length,
+	                                   uint64_t iova, unsigned int access);
+	int (*ibv_dereg_mr)(struct ibv_mr *mr);
 #if HAVE_EFADV_CQ_EX
 
 	struct ibv_cq_ex *(*efadv_create_cq)(struct ibv_context *ibvctx,
-										 struct ibv_cq_init_attr_ex *attr_ex,
-										 struct efadv_cq_init_attr *efa_attr,
-										 uint32_t inlen);
-#endif
-
-#if HAVE_NEURON
-	void *(*neuron_alloc)(void **handle, size_t size);
+	                                     struct ibv_cq_init_attr_ex *attr_ex,
+	                                     struct efadv_cq_init_attr *efa_attr,
+	                                     uint32_t inlen);
 #endif
 
 	ssize_t (*ofi_copy_from_hmem_iov)(void *dest, size_t size,
 					  enum fi_hmem_iface hmem_iface, uint64_t device,
 					  const struct iovec *hmem_iov,
 					  size_t hmem_iov_count, uint64_t hmem_iov_offset);
+
+	int (*ofi_hmem_get_dmabuf_fd)(enum fi_hmem_iface iface,
+				      const void *addr, uint64_t size, int *fd,
+				      uint64_t *offset);
 
 	enum ibv_fork_status (*ibv_is_fork_initialized)(void);
 
@@ -116,6 +140,11 @@ struct efa_unit_test_mocks
 
 #if HAVE_EFA_DATA_IN_ORDER_ALIGNED_128_BYTES
 	int (*ibv_query_qp_data_in_order)(struct ibv_qp *qp, enum ibv_wr_opcode op, uint32_t flags);
+#endif
+
+#if HAVE_EFA_DMABUF_MR
+	struct ibv_mr *(*ibv_reg_dmabuf_mr)(struct ibv_pd *pd, uint64_t offset, size_t length, uint64_t iova,
+	                                    int fd, int access);
 #endif
 };
 
@@ -144,11 +173,6 @@ struct ibv_cq_ex *efa_mock_efadv_create_cq_set_eopnotsupp_and_return_null(struct
 																		  uint32_t inlen);
 #endif
 
-#if HAVE_NEURON
-void *__real_neuron_alloc(void **handle, size_t size);
-void *efa_mock_neuron_alloc_return_null(void **handle, size_t size);
-#endif
-
 #if HAVE_EFADV_QUERY_MR
 int __real_efadv_query_mr(struct ibv_mr *ibv_mr, struct efadv_mr_attr *attr, uint32_t inlen);
 int efa_mock_efadv_query_mr_recv_ic_id_0(struct ibv_mr *ibv_mr, struct efadv_mr_attr *attr, uint32_t inlen);
@@ -161,6 +185,13 @@ int efa_mock_efadv_query_mr_recv_and_rdma_read_ic_id_0_1(struct ibv_mr *ibv_mr, 
 int __real_ibv_query_qp_data_in_order(struct ibv_qp *qp, enum ibv_wr_opcode op, uint32_t flags);
 int efa_mock_ibv_query_qp_data_in_order_return_0(struct ibv_qp *qp, enum ibv_wr_opcode op, uint32_t flags);
 int efa_mock_ibv_query_qp_data_in_order_return_in_order_aligned_128_bytes(struct ibv_qp *qp, enum ibv_wr_opcode op, uint32_t flags);
+#endif
+
+int efa_mock_get_dmabuf_fd_set_errno_return_mock(const void *addr, uint64_t size, int *fd, uint64_t *offset);
+
+#if HAVE_EFA_DMABUF_MR
+struct ibv_mr *__real_ibv_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset, size_t length, uint64_t iova, int fd, int access);
+struct ibv_mr *efa_mock_ibv_reg_dmabuf_mr_set_eopnotsupp_and_return_mock(struct ibv_pd *pd, uint64_t offset, size_t length, uint64_t iova, int fd, int access);
 #endif
 
 enum ibv_fork_status __real_ibv_is_fork_initialized(void);

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -142,7 +142,6 @@ void test_info_check_shm_info_threading();
 void test_info_check_hmem_cuda_support_on_api_lt_1_18();
 void test_info_check_hmem_cuda_support_on_api_ge_1_18();
 void test_info_check_no_hmem_support_when_not_requested();
-void test_efa_hmem_info_update_neuron();
 void test_efa_use_device_rdma_env1_opt1();
 void test_efa_use_device_rdma_env0_opt0();
 void test_efa_use_device_rdma_env1_opt0();
@@ -182,6 +181,64 @@ void test_efa_rdm_cq_post_initial_rx_pkts();
 void test_efa_rdm_cntr_ibv_cq_poll_list_same_tx_rx_cq_single_ep();
 void test_efa_rdm_cntr_ibv_cq_poll_list_separate_tx_rx_cq_single_ep();
 void test_efa_cntr_post_initial_rx_pkts();
+/**
+ * System memory always supports P2P
+ */
+void test_efa_system_p2p_support_true_system_p2p_file_does_not_exist();
+void test_efa_system_p2p_support_true_system_p2p_file_empty();
+/**
+ * CUDA P2P needs NVIDIA/NVIDIA peermem provider which can be verified
+ * in the sysfs file
+ */
+void test_efa_cuda_p2p_support_true_nvidia_prov();
+void test_efa_cuda_p2p_support_true_nvidia_peermem_prov();
+void test_efa_cuda_p2p_support_false_p2p_file_does_not_exist();
+void test_efa_cuda_p2p_support_false_p2p_file_empty();
+/**
+ * NEURON P2P needs NEURON provider which can be verified in the sysfs file
+ */
+void test_efa_neuron_p2p_support_true_neuron_prov();
+void test_efa_neuron_p2p_support_false_p2p_file_does_not_exist();
+void test_efa_neuron_p2p_support_false_p2p_file_empty();
+/**
+ * synapseai platforms always support P2P
+ */
+void test_efa_synapseai_p2p_support_true_p2p_file_does_not_exist();
+void test_efa_synapseai_p2p_support_true_p2p_file_empty();
+/**
+ * System memory does not support dmabuf so it should always use ibv_reg_mr
+ */
+void test_efa_system_always_ibv_reg_mr();
+/**
+ * Verify dmabuf is supported lazily for the HMEM iface
+ */
+void test_efa_neuron_dmabuf_support_dmabuf_success();
+/**
+ * If dmabuf fd cannot be retrieved, verify dmabuf is not supported lazily
+ * for the HMEM iface
+ */
+void test_efa_neuron_dmabuf_support_get_fd_fail_fallback();
+/**
+ * If ibv_reg_dmabuf_mr fails, verify dmabuf is not supported lazily
+ * for the HMEM iface
+ */
+void test_efa_neuron_dmabuf_support_mr_fail_no_fallback();
+/**
+ * Unless FI_MR_DMABUF is required CUDA should always use ibv_reg_mr
+ */
+void test_efa_cuda_dmabuf_support_always_ibv_reg_mr();
+/**
+ * If dmabuf is supported we should always use ibv_reg_dmabuf_mr,
+ * even if it fails unexpctedly
+ */
+void test_efa_synapseai_dmabuf_support_fd_fail_no_fallback();
+/**
+ * If dmabuf is NOT supported, but the application still requires FI_MR_DMABUF,
+ * we should respect application's request and use ibv_reg_dmabuf_mr.
+ * This is a theoretical corner case to allow application override.
+ */
+void test_efa_cuda_dmabuf_support_require_dmabuf_fail_no_fallback();
+void test_efa_neuron_dmabuf_support_require_dmabuf_fail_no_fallback();
 
 static inline
 int efa_unit_test_get_dlist_length(struct dlist_entry *head)

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -39,7 +39,7 @@ void efa_unit_test_resource_construct_no_cq_and_ep_not_enabled(
 	struct efa_resource *resource, enum fi_ep_type ep_type);
 void efa_unit_test_resource_construct_with_hints(struct efa_resource *resource,
 						 enum fi_ep_type ep_type,
-						 struct fi_info *hints,
+						 uint32_t fi_version, struct fi_info *hints,
 						 bool enable_ep, bool open_cq);
 
 void efa_unit_test_resource_destruct(struct efa_resource *resource);


### PR DESCRIPTION
This patch removes the trial device memory registration with EFA device during domain initialization; instead, we query the sysfs to retrieve the P2P provider information emitted by the kernel module.

As a result, we have to delay the dmabuf support status check to the 1st application fi_mr_reg* call:
- We always register the region via ibv_reg_dmabuf_mr if the application requests FI_MR_DMABUF
- We will disable dmabuf if the hmem interface does not have P2P support
- For the 1st fi_mr_reg* call, we will try ibv_reg_dmabuf_mr
- If the 1st fi_mr_reg* call failed via ibv_reg_dmabuf_mr, we will NOT try ibv_reg_dmabuf_mr again, but always fallback to ibv_reg_mr API for that hmem interface
- Otherwise we will always use ibv_reg_dmabuf_mr for that hmem interface