### PR TITLE
contrib/intel/jenkins: Migrate Fabtests to new CI model

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -428,9 +428,6 @@ pipeline {
           }
         }
         stage ('build-water') {
-          environment {
-            build_type = "water"
-          }
           steps {
             script {
               slurm_build(BUILD_MODES, "water", "water", "water")
@@ -448,9 +445,6 @@ pipeline {
           }
         }
         stage ('build-grass') {
-          environment {
-            build_type = "grass"
-          }
           steps {
             script {
               slurm_build(BUILD_MODES, "grass", "grass", "grass")
@@ -468,9 +462,6 @@ pipeline {
           }
         }
         stage ('build-electric') {
-          environment {
-            build_type = "electric"
-          }
           steps {
             script {
               slurm_build(BUILD_MODES, "electric", "electric", "electric")
@@ -487,9 +478,9 @@ pipeline {
         stage ('build-cuda') {
           steps {
             script {
-              slurm_build(BUILD_MODES, "cyndaquil", "cuda", "cyndaquil",
+              slurm_build(["reg"], "cyndaquil", "cuda", "cyndaquil",
                           "--cuda")
-              slurm_build(BUILD_MODES, "quilava", "cuda", "quilava",
+              slurm_build(["reg"], "quilava", "cuda", "quilava",
                           "--cuda")
             }
           }
@@ -536,6 +527,7 @@ pipeline {
               dir (CUSTOM_WORKSPACE) {
                 build("logdir")
                 build("builddir")
+                build_ci()
                 slurm_build(BUILD_MODES, "fabrics-ci", "source", "gpu", "--gpu")
               }
             }
@@ -547,9 +539,6 @@ pipeline {
       when { equals expected: true, actual: DO_RUN }
       parallel {
         stage ('CI_MPI_verbs-rxm_IMB') {
-          environment {
-            build_type = "water"
-          }
           steps {
             script {
               dir (CI_LOCATION) {
@@ -559,9 +548,6 @@ pipeline {
           }
         }
         stage ('CI_MPI_verbs-rxm_OSU') {
-          environment {
-            build_type = "water"
-          }
           steps {
             script {
               dir (CI_LOCATION) {
@@ -571,9 +557,6 @@ pipeline {
           }
         }
         stage ('CI_MPI_tcp_IMB') {
-          environment {
-            build_type = "grass"
-          }
           steps {
             script {
               dir (CI_LOCATION) {
@@ -583,9 +566,6 @@ pipeline {
           }
         }
         stage ('CI_MPI_tcp_OSU') {
-          environment {
-            build_type = "grass"
-          }
           steps {
             script {
               dir (CI_LOCATION) {
@@ -594,97 +574,101 @@ pipeline {
             }
           }
         }
-        stage('tcp') {
+        stage('CI_fabtests_tcp') {
            steps {
             script {
-              dir (RUN_LOCATION) {
-                run_fabtests("tcp", "grass", "bulbasaur", "2", "tcp")
+              dir (CI_LOCATION) {
+                run_ci("CI_fabtests_tcp_reg", "pr_fabtests_tcp_reg.json")
+                run_ci("CI_fabtests_tcp_dbg", "pr_fabtests_tcp_dbg.json")
+                run_ci("CI_fabtests_tcp_dl", "pr_fabtests_tcp_dl.json")
               }
             }
           }
         }
-        stage('tcp-iouring') {
-          steps {
+        stage('CI_fabtests_sockets') {
+           steps {
             script {
-              dir (RUN_LOCATION) {
-                run_fabtests("tcp-iouring", "ivysaur", "ivysaur", "2",
-                             "tcp", null, "FI_TCP_IO_URING=1")
+              dir (CI_LOCATION) {
+                run_ci("CI_fabtests_sockets_reg", "pr_fabtests_sockets_reg.json")
+                run_ci("CI_fabtests_sockets_dbg", "pr_fabtests_sockets_dbg.json")
+                run_ci("CI_fabtests_sockets_dl", "pr_fabtests_sockets_dl.json")
               }
             }
           }
         }
-        stage('verbs-rxm') {
-          steps {
+        stage('CI_fabtests_udp') {
+           steps {
             script {
-              dir (RUN_LOCATION) {
-                run_fabtests("verbs-rxm", "water", "squirtle,totodile", "2",
-                             "verbs", "rxm")
-                run_fabtests("verbs-rxm", "water", "squirtle,totodile", "2",
-                             "verbs", "rxm", "FI_MR_CACHE_MAX_COUNT=0")
-                run_fabtests("verbs-rxm", "water", "squirtle,totodile", "2",
-                             "verbs", "rxm", "FI_MR_CACHE_MONITOR=userfaultfd")
+              dir (CI_LOCATION) {
+                run_ci("CI_fabtests_udp_reg", "pr_fabtests_udp_reg.json")
+                run_ci("CI_fabtests_udp_dbg", "pr_fabtests_udp_dbg.json")
+                run_ci("CI_fabtests_udp_dl", "pr_fabtests_udp_dl.json")
               }
             }
           }
         }
-        stage('verbs-rxd') {
-          steps {
+        stage('CI_fabtests_shm') {
+           steps {
             script {
-              dir (RUN_LOCATION) {
-                run_fabtests("verbs-rxd", "water", "squirtle", "2", "verbs",
-                             "rxd")
-                run_fabtests("verbs-rxd", "water", "squirtle", "2", "verbs",
-                             "rxd", "FI_MR_CACHE_MAX_COUNT=0")
-                run_fabtests("verbs-rxd", "water", "squirtle", "2", "verbs",
-                             "rxd", "FI_MR_CACHE_MONITOR=userfaultfd")
+              dir (CI_LOCATION) {
+                run_ci("CI_fabtests_shm_reg", "pr_fabtests_shm_reg.json")
+                run_ci("CI_fabtests_shm_dbg", "pr_fabtests_shm_dbg.json")
+                run_ci("CI_fabtests_shm_dl", "pr_fabtests_shm_dl.json")
               }
             }
           }
         }
-        stage('udp') {
+        stage('CI_fabtests_ivysaur') {
           steps {
             script {
-              dir (RUN_LOCATION) {
-                run_fabtests("udp", "grass", "bulbasaur", "2", "udp")
+              dir (CI_LOCATION) {
+                run_ci("CI_fabtests_ivysaur_reg", "pr_fabtests_ivysaur_reg.json")
+                run_ci("CI_fabtests_ivysaur_dbg", "pr_fabtests_ivysaur_dbg.json")
+                run_ci("CI_fabtests_ivysaur_dl", "pr_fabtests_ivysaur_dl.json")
               }
             }
           }
         }
-        stage('shm') {
+        stage('CI_fabtests_verbs_rxm') {
           steps {
             script {
-              dir (RUN_LOCATION) {
-                run_fabtests("shm", "grass", "bulbasaur", "1", "shm")
-                run_fabtests("shm", "grass", "bulbasaur", "1", "shm", null,
-                            "FI_SHM_DISABLE_CMA=1")
+              dir (CI_LOCATION) {
+                run_ci("CI_fabtests_verbs_reg", "pr_fabtests_verbs_rxm_reg.json")
+                run_ci("CI_fabtests_verbs_dbg", "pr_fabtests_verbs_rxm_dbg.json")
+                run_ci("CI_fabtests_verbs_dl", "pr_fabtests_verbs_rxm_dl.json")
               }
             }
           }
         }
-        stage('sockets') {
+        stage('CI_fabtests_verbs_rxd') {
           steps {
             script {
-              dir (RUN_LOCATION) {
-                run_fabtests("sockets", "grass", "bulbasaur", "2", "sockets")
+              dir (CI_LOCATION) {
+                run_ci("CI_fabtests_verbs_reg", "pr_fabtests_verbs_rxd_reg.json")
+                run_ci("CI_fabtests_verbs_dbg", "pr_fabtests_verbs_rxd_dbg.json")
+                run_ci("CI_fabtests_verbs_dl", "pr_fabtests_verbs_rxd_dl.json")
               }
             }
           }
         }
-        stage('ucx') {
+        stage('CI_fabtests_psm3') {
           steps {
             script {
-              dir (RUN_LOCATION) {
-                run_fabtests("ucx", "ucx", "totodile", "2", "ucx")
+              dir (CI_LOCATION) {
+                run_ci("CI_fabtests_psm3_reg", "pr_fabtests_psm3_reg.json")
+                run_ci("CI_fabtests_psm3_dbg", "pr_fabtests_psm3_dbg.json")
+                run_ci("CI_fabtests_psm3_dl", "pr_fabtests_psm3_dl.json")
               }
             }
           }
         }
-        stage('psm3') {
+        stage('CI_fabtests_ucx') {
           steps {
             script {
-              dir (RUN_LOCATION) {
-                run_fabtests("psm3", "water", "squirtle", "2", "psm3", null,
-                             "PSM3_IDENTIFY=1")
+              dir (CI_LOCATION) {
+                run_ci("CI_fabtests_ucx_reg", "pr_fabtests_ucx_reg.json")
+                run_ci("CI_fabtests_ucx_dbg", "pr_fabtests_ucx_dbg.json")
+                run_ci("CI_fabtests_ucx_dl", "pr_fabtests_ucx_dl.json")
               }
             }
           }
@@ -823,58 +807,53 @@ pipeline {
             }
           }
         }
-        stage ('cuda-shm-v1') {
+        stage ('CI_fabtests_cyndaquil') {
           steps {
             script {
-              dir (RUN_LOCATION) {
-                run_fabtests("cuda_v1_shm", "cyndaquil", "cyndaquil", "1",
-                             "shm", null, null, "h2d")
-                run_fabtests("cuda_v1_shm", "cyndaquil", "cyndaquil", "1",
-                             "shm", null, null, "d2d")
-                // run_fabtests("cuda_v1_shm", "cyndaquil", "cyndaquil", "1",
-                //              "shm", null, null, "xd2d")
+              dir (CI_LOCATION) {
+                run_ci("CI_fabtests_cyndaquil_h2d_reg",
+                       "pr_fabtests_cyndaquil_h2d_reg.json")
+                run_ci("CI_fabtests_cyndaquil_d2d_reg",
+                       "pr_fabtests_cyndaquil_d2d_reg.json")
               }
             }
           }
         }
-        stage ('cuda-shm-v2') {
+        stage ('CI_fabtests_quilava') {
           steps {
             script {
-              dir (RUN_LOCATION) {
-                run_fabtests("cuda_v2_shm", "quilava", "quilava", "1", "shm",
-                             null, null, "h2d")
-                run_fabtests("cuda_v2_shm", "quilava", "quilava", "1", "shm",
-                             null, null, "d2d")
-                // run_fabtests("cuda_v2_shm", "quilava ", "quilava", "1", "shm",
-                //              null, null, "xd2d")
+              dir (CI_LOCATION) {
+                run_ci("CI_fabtests_quilava_h2d_reg",
+                       "pr_fabtests_quilava_h2d_reg.json")
+                run_ci("CI_fabtests_quilava_d2d_reg",
+                       "pr_fabtests_quilava_d2d_reg.json")
               }
             }
           }
         }
-        stage ('ze-shm-v3') {
+        stage ('CI_fabtests_charizard') {
           agent { node { label 'ze' } }
           options { skipDefaultCheckout() }
           steps {
             script {
-              dir (RUN_LOCATION) {
-                run_fabtests("ze_v3_shm", "gpu", "fabrics-ci", "1", "shm", null,
-                             "FI_HMEM_DISABLE_P2P=1", "h2d")
-                run_fabtests("ze_v3_shm", "gpu", "fabrics-ci", "1", "shm", null,
-                             "FI_HMEM_DISABLE_P2P=1", "d2d")
-                run_fabtests("ze_v3_shm", "gpu", "fabrics-ci", "1", "shm", null,
-                             "FI_HMEM_DISABLE_P2P=1", "xd2d")
+              dir (CI_LOCATION) {
+                run_ci("CI_fabtests_charizard_h2d_reg",
+                       "pr_fabtests_charizard_h2d_reg.json")
+                run_ci("CI_fabtests_charizard_d2d_reg",
+                       "pr_fabtests_charizard_d2d_reg.json")
+                run_ci("CI_fabtests_charizard_xd2d_reg",
+                       "pr_fabtests_charizard_xd2d_reg.json")
               }
             }
           }
         }
-        stage('dsa') {
-          when { equals expected: true, actual: DO_RUN }
+        stage('CI_fabtests_electric') {
           steps {
             script {
-              dir (RUN_LOCATION) {
-                run_fabtests("shm_dsa", "electric", "pikachu", "1", "shm", null,
-                             """FI_SHM_DISABLE_CMA=1 FI_SHM_USE_DSA_SAR=1 \
-                                FI_LOG_LEVEL=warn""")
+              dir (CI_LOCATION) {
+                run_ci("CI_fabtests_electric_reg", "pr_fabtests_electric_reg.json")
+                run_ci("CI_fabtests_electric_dbg", "pr_fabtests_electric_dbg.json")
+                run_ci("CI_fabtests_electric_dl", "pr_fabtests_electric_dl.json")
               }
             }
           }

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -536,8 +536,7 @@ pipeline {
               dir (CUSTOM_WORKSPACE) {
                 build("logdir")
                 build("builddir")
-                build("libfabric", "reg", "gpu", "--gpu")
-                build("fabtests", "reg", "gpu")
+                slurm_build(BUILD_MODES, "fabrics-ci", "source", "gpu", "--gpu")
               }
             }
           }

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -223,7 +223,7 @@ def generate_release_num(def branch_name, def output_loc) {
   """
 }
 
-def slurm_build(modes, partition, location, hw=null, additional_args=null) {
+def slurm_build(modes, partition, location, tag, hw=null, additional_args=null) {
   def cmd = "pwd; "
   def prefix = "python${PYTHON_VERSION} ${RUN_LOCATION}/build.py"
   def libfabric = "--build_item=libfabric --build_loc=${CUSTOM_WORKSPACE}/${location}/libfabric"
@@ -245,7 +245,7 @@ def slurm_build(modes, partition, location, hw=null, additional_args=null) {
     cmd = "${cmd} ${prefix} ${fabtests} --ofi_build_mode=${mode};"
   }
 
-  slurm_batch(partition, "1", "${env.LOG_DIR}/libfabric_${partition}", cmd)
+  slurm_batch(partition, "1", "${env.LOG_DIR}/libfabric_${tag}", cmd)
 }
 
 def build(item, mode=null, hw=null, additional_args=null) {
@@ -445,7 +445,7 @@ pipeline {
         stage ('build-water') {
           steps {
             script {
-              slurm_build(BUILD_MODES, "totodile", "water", "water")
+              slurm_build(BUILD_MODES, "totodile", "water", "water", "water")
               slurm_batch("totodile", "1",
                             "${env.LOG_DIR}/build_mpich_water_log",
                             """python$PYTHON_VERSION ${RUN_LOCATION}/build.py \
@@ -462,7 +462,7 @@ pipeline {
         stage ('build-grass') {
           steps {
             script {
-              slurm_build(BUILD_MODES, "grass", "grass", "grass")
+              slurm_build(BUILD_MODES, "grass", "grass", "grass", "grass")
               slurm_batch("grass", "1",
                             "${env.LOG_DIR}/build_mpich_grass_log",
                             """python$PYTHON_VERSION ${RUN_LOCATION}/build.py \
@@ -479,14 +479,15 @@ pipeline {
         stage ('build-electric') {
           steps {
             script {
-              slurm_build(BUILD_MODES, "electric", "electric", "electric")
+              slurm_build(BUILD_MODES, "electric", "electric", "electric",
+                          "electric")
             }
           }
         }
         stage ('build-ucx') {
           steps {
             script {
-              slurm_build(BUILD_MODES, "totodile", "ucx", "ucx")
+              slurm_build(BUILD_MODES, "totodile", "ucx", "ucx", "ucx")
             }
           }
         }
@@ -494,16 +495,17 @@ pipeline {
           steps {
             script {
               slurm_build(["reg"], "cyndaquil", "cuda", "cyndaquil",
-                          "--cuda")
+                          "cyndaquil", "--cuda")
               slurm_build(["reg"], "quilava", "cuda", "quilava",
-                          "--cuda")
+                          "quilava", "--cuda")
             }
           }
         }
         stage ('build-iouring') {
           steps {
             script {
-              slurm_build(BUILD_MODES, "ivysaur", "iouring", "ivysaur")
+              slurm_build(BUILD_MODES, "ivysaur", "iouring", "ivysaur",
+                          "ivysaur")
             }
           }
         }
@@ -543,7 +545,8 @@ pipeline {
                 build("logdir")
                 build("builddir")
                 build_ci()
-                slurm_build(BUILD_MODES, "fabrics-ci", "source", "gpu", "--gpu")
+                slurm_build(BUILD_MODES, "fabrics-ci", "source", "ze", "gpu",
+                            "--gpu")
               }
             }
           }

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -538,38 +538,38 @@ pipeline {
     stage('parallel-tests') {
       when { equals expected: true, actual: DO_RUN }
       parallel {
-        stage ('CI_MPI_verbs-rxm_IMB') {
+        stage ('CI_mpi_verbs-rxm_imb') {
           steps {
             script {
               dir (CI_LOCATION) {
-                run_ci("CI_MPI_verbs-rxm_IMB", "pr_imb_water.json")
+                run_ci("CI_mpi_verbs-rxm_imb", "pr_imb_water.json")
               }
             }
           }
         }
-        stage ('CI_MPI_verbs-rxm_OSU') {
+        stage ('CI_mpi_verbs-rxm_osu') {
           steps {
             script {
               dir (CI_LOCATION) {
-                run_ci("CI_MPI_verbs-rxm_OSU", "pr_osu_water.json")
+                run_ci("CI_mpi_verbs-rxm_osu", "pr_osu_water.json")
               }
             }
           }
         }
-        stage ('CI_MPI_tcp_IMB') {
+        stage ('CI_mpi_tcp_imb') {
           steps {
             script {
               dir (CI_LOCATION) {
-                run_ci("CI_MPI_tcp_IMB", "pr_imb_grass.json")
+                run_ci("CI_mpi_tcp_imb", "pr_imb_grass.json")
               }
             }
           }
         }
-        stage ('CI_MPI_tcp_OSU') {
+        stage ('CI_mpi_tcp_osu') {
           steps {
             script {
               dir (CI_LOCATION) {
-                run_ci("CI_MPI_tcp_OSU", "pr_osu_grass.json")
+                run_ci("CI_mpi_tcp_osu", "pr_osu_grass.json")
               }
             }
           }

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -445,13 +445,13 @@ pipeline {
         stage ('build-water') {
           steps {
             script {
-              slurm_build(BUILD_MODES, "water", "water", "water")
-              slurm_batch("squirtle,totodile", "1",
+              slurm_build(BUILD_MODES, "totodile", "water", "water")
+              slurm_batch("totodile", "1",
                             "${env.LOG_DIR}/build_mpich_water_log",
                             """python$PYTHON_VERSION ${RUN_LOCATION}/build.py \
                               --build_item=mpich --build_hw=water"""
                           )
-              slurm_batch("water", "1",
+              slurm_batch("totodile", "1",
                           "${env.LOG_DIR}/build_shmem_water_log",
                           """python$PYTHON_VERSION ${RUN_LOCATION}/build.py \
                               --build_item=shmem --build_hw=water"""
@@ -699,7 +699,7 @@ pipeline {
                 }
                 for (def mpi in MPIS) {
                   run_middleware(providers, "mpichtestsuite", "mpichtestsuite",
-                                 "water", "squirtle,totodile", "2", "${mpi}")
+                                 "water", "totodile", "2", "${mpi}")
                 }
               }
             }
@@ -720,7 +720,7 @@ pipeline {
             script {
               dir (RUN_LOCATION) {
                 run_middleware([["verbs", "rxm"], ["sockets", null]], "SHMEM",
-                                "shmem", "water", "squirtle,totodile", "2")
+                                "shmem", "water", "totodile", "2")
               }
             }
           }
@@ -732,7 +732,7 @@ pipeline {
                 run_middleware([["tcp", null],["sockets", null]],
 			       "multinode_performance", "multinode", "grass", "grass", "2")
 		run_middleware([["verbs", "rxm"]], "multinode_performance",
-			       "multinode", "water", "squirtle,totodile", "2")
+			       "multinode", "water", "totodile", "2")
               }
             }
           }
@@ -742,11 +742,11 @@ pipeline {
             script {
               dir (RUN_LOCATION) {
 		            run_middleware([["verbs", null]], "oneCCL",
-                               "oneccl", "water", "squirtle,totodile", "2")
+                               "oneccl", "water", "totodile", "2")
 		            run_middleware([["shm", null]], "oneCCL",
 			                         "oneccl", "grass", "bulbasaur", "1")
 		            run_middleware([["psm3", null]], "oneCCL",
-			                         "oneccl", "water", "squirtle", "2")
+			                         "oneccl", "water", "totodile", "2")
 		            run_middleware([["tcp", null]], "oneCCL",
 			                         "oneccl", "grass", "bulbasaur", "2")
                 run_middleware([["shm", null]], "oneCCL_DSA",

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -105,9 +105,24 @@ def gather_logs(cluster, key, dest, source) {
   def address = "${env.USER}@${cluster}"
 
   try {
-    sh "scp -i ${key} ${address}:${source}/* ${dest}/"
+    sh "scp -r -i ${key} ${address}:${source}/* ${dest}/"
   } catch (Exception e) {
     echo "Caught exception ${e} when transfering files from ${cluster}"
+  }
+}
+
+def CI_summarize(verbose=false) {
+  if (verbose) {
+    sh """source ${CI_LOCATION}/${env.CI_MODULE}/venv/bin/activate;\
+               python ${CI_LOCATION}/summarize.py \
+               --log_directory=${env.LOG_DIR} \
+               -v
+       """
+  } else {
+    sh """source ${CI_LOCATION}/${env.CI_MODULE}/venv/bin/activate;\
+               python ${CI_LOCATION}/summarize.py \
+               --log_directory=${env.LOG_DIR}
+       """
   }
 }
 
@@ -869,6 +884,7 @@ pipeline {
           gather_logs("${env.ZE_ADDR}", "${env.ZE_KEY}", "${env.LOG_DIR}",
                       "${env.LOG_DIR}")
 
+          CI_summarize(verbose=false)
           summarize("all", verbose=false, release=RELEASE,
                     send_mail=env.WEEKLY.toBoolean())
           if (RELEASE) {
@@ -882,11 +898,13 @@ pipeline {
   post {
     always {
       script {
+        CI_summarize()
         summarize("all")
       }
     }
     success {
       script {
+        CI_summarize(verbose=true)
         summarize("all", verbose=true, release=false,
         send_mail=env.WEEKLY.toBoolean())
       }


### PR DESCRIPTION
Migrate all of fabtests to using the new CI.
Add support for new CI's summarizer.
Use both old CI and new CI summarizers to report all the tests.
All stages with new CI will be using the convention CI_ prefix.