### PR TITLE
core: Fix an error in the error handling path of fi_param_define()

### DIFF
--- a/src/var.c
+++ b/src/var.c
@@ -226,7 +226,7 @@ int DEFAULT_SYMVER_PRE(fi_param_define)(const struct fi_provider *provider,
 		ret = asprintf(&tmp_str, "%s: %s", provider->name, v->help_string);
 		free(v->help_string);
 		if (ret < 0)
-			v->help_string = NULL;
+			tmp_str = NULL;
 		v->help_string = tmp_str;
 		ret = asprintf(&v->env_var_name, "FI_%s_%s", provider->name, param_name);
 		if (ret < 0)


### PR DESCRIPTION
The wrong string was set to NULL when asprintf failed. This could cause undefined pointer being used later.