### PR TITLE
fabtests: Address integer overflow coverity issues in fabtests

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -3897,6 +3897,10 @@ int ft_sock_send(int fd, void *msg, size_t len)
 	for (sent = 0; sent < len; ) {
 		ret = ofi_send_socket(fd, ((char *) msg) + sent, len - sent, 0);
 		if (ret > 0) {
+			if (SIZE_MAX - sent < (size_t)ret) {
+				err = -1;
+				break;
+			}
 			sent += ret;
 		} else if (ofi_sockerr() == EAGAIN || ofi_sockerr() == EWOULDBLOCK) {
 			ft_force_progress();
@@ -3917,6 +3921,10 @@ int ft_sock_recv(int fd, void *msg, size_t len)
 	for (rcvd = 0; rcvd < len; ) {
 		ret = ofi_recv_socket(fd, ((char *) msg) + rcvd, len - rcvd, 0);
 		if (ret > 0) {
+			if (SIZE_MAX - rcvd < (size_t)ret || len - rcvd < (size_t)ret) {
+				err = -FI_EOTHER;
+				break;
+			}
 			rcvd += ret;
 		} else if (ret == 0) {
 			err = -FI_ENOTCONN;

--- a/fabtests/multinode/src/harness.c
+++ b/fabtests/multinode/src/harness.c
@@ -84,6 +84,10 @@ ssize_t socket_send(int sock, void *buf, size_t len, int flags)
 		if (ret < 0)
 			return ret;
 
+		if (SIZE_MAX - m < (size_t)ret || len - m < (size_t)ret) {
+			return -1;
+		}
+
 		m += ret;
 	} while (m != len);
 
@@ -100,6 +104,10 @@ int socket_recv(int sock, void *buf, size_t len, int flags)
 		ret = recv(sock, (void *) &ptr[m], len-m, flags);
 		if (ret <= 0)
 			return -1;
+
+		if (SIZE_MAX - m < (size_t)ret) {
+			return -1;
+		}
 
 		m += ret;
 	} while (m < len);


### PR DESCRIPTION
There are 4 integer overflow issues in fabtests. All of them need a check that ensures integer overflow does not oocur.

1. changes to harness.c: This modification includes a check to ensure that adding ret to m does not exceed SIZE_MAX.

2. changes to shared.c: This modification includes a check before the addition to ensure that (rcvd + ret) or (sent + ret) does not exceed SIZE_MAX. If the addition would exceed SIZE_MAX, it sets err to an error value and breaks from the loop, preventing overflow.