### PR TITLE
.github/workflows: Pin all dependencies by hash instead of version number

### DIFF
--- a/.github/workflows/clang-format-check-cn.yml
+++ b/.github/workflows/clang-format-check-cn.yml
@@ -9,9 +9,9 @@ jobs:
         path:
           - 'prov/opx'
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Run clang-format style check for C/C++/Protobuf programs (Cornelis Networks-specific).
-      uses: jidicula/clang-format-action@v4.10.2
+      uses: jidicula/clang-format-action@81356ae1ab1ef29a26ff0409930e76f84b3a239b # v4.10.2
       with:
         clang-format-version: '15'
         check-path: ${{ matrix.path }}

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -11,9 +11,9 @@ jobs:
         path:
           - 'prov/sm2'
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Run clang-format style check for C/C++/Protobuf programs.
-      uses: jidicula/clang-format-action@v4.13.0
+      uses: jidicula/clang-format-action@c74383674bf5f7c69f60ce562019c1c94bc1421a # v4.13.0
       with:
         clang-format-version: '15'
         check-path: ${{ matrix.path }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,11 +48,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@b611370bb5703a7efb587f9d136a52ea24c5c38c # v3.25.11
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -66,7 +66,7 @@ jobs:
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@b611370bb5703a7efb587f9d136a52ea24c5c38c # v3.25.11
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -79,6 +79,6 @@ jobs:
     #     ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@b611370bb5703a7efb587f9d136a52ea24c5c38c # v3.25.11
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y ${{ env.APT_PACKAGES }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Download Coverity tools
         run: |
           wget https://scan.coverity.com/download/linux64 --post-data "token=${{ secrets.COVERITY_SCAN_TOKEN }}&project=ofiwg%2Flibfabric" -O coverity_tool.tgz
@@ -93,7 +93,7 @@ jobs:
             --form description="`$PWD/install/bin/fi_info -l`" \
             https://scan.coverity.com/builds?project=ofiwg%2Flibfabric
       - name: Upload build logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: coverity-build-log.txt
           path: cov-int/build-log.txt

--- a/.github/workflows/gh-man.yaml
+++ b/.github/workflows/gh-man.yaml
@@ -25,7 +25,7 @@ jobs:
               echo "$GITHUB_DATA"
 
           - name: Check out the git repo
-            uses: actions/checkout@v4
+            uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
           - name: Update the man pages in branch gh-pages
             run: .github/workflows/gh-man.sh

--- a/.github/workflows/nroff-elves.yaml
+++ b/.github/workflows/nroff-elves.yaml
@@ -23,7 +23,7 @@ jobs:
               echo "$GITHUB_DATA"
 
           - name: Check out the git repo
-            uses: actions/checkout@v4
+            uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
           - name: Get the required packages
             run: sudo apt install -y pandoc

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y ${{ env.APT_PACKAGES }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Build Check
         run: |
           set -x
@@ -69,7 +69,7 @@ jobs:
           $PWD/install/bin/fi_info -l
       - name: Upload build logs
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: ${{ matrix.os }}-${{ matrix.cc }}-config.log
           path: config.log
@@ -95,7 +95,7 @@ jobs:
           sudo apt-add-repository 'deb [arch=amd64] https://repositories.intel.com/graphics/ubuntu focal main'
           sudo apt-get update
           sudo apt-get install -y level-zero level-zero-dev
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: HMEM Checks
         run: |
           set -x
@@ -114,7 +114,7 @@ jobs:
           $PWD/install/bin/fi_info -c FI_HMEM
       - name: Upload build logs
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: hmem-config.log
           path: config.log
@@ -125,7 +125,7 @@ jobs:
         run: |
            brew install automake
            brew install libtool
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Build Check
         run: |
           ./autogen.sh
@@ -138,7 +138,7 @@ jobs:
           make -j2
       - name: Upload build logs
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: macos-12-config.log
           path: config.log

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v9
+    - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: 360


### PR DESCRIPTION
OSSF scorecard has 1/10 score for pinned-dependencies. To increase this score all dependencies have to be pinned by hash.

OSSF help suggests using StepSecurity Tool to update the dependency. For more information:
https://github.com/ossf/scorecard/blob/7ce8609469289d5f3b1bf5ee3122f42b4e3054fb/docs/checks.md#pinned-dependencies

To check the list of dependencies flagged in report, go to Pinned-Dependencies section:
https://securityscorecards.dev/viewer/?uri=github.com/ofiwg/libfabric