### PR TITLE
prov/efa: Post rx buffer in the first fi_cntr_read

### DIFF
--- a/prov/efa/src/efa_cntr.c
+++ b/prov/efa/src/efa_cntr.c
@@ -147,10 +147,28 @@ static void efa_rdm_cntr_progress(struct util_cntr *cntr)
 	struct efa_cntr *efa_cntr;
 	struct efa_domain *efa_domain;
 	struct efa_ibv_cq_poll_list_entry *poll_list_entry;
+	struct efa_rdm_ep *efa_rdm_ep;
+	struct fid_list_entry *fid_entry;
 
 	ofi_genlock_lock(&cntr->ep_list_lock);
 	efa_cntr = container_of(cntr, struct efa_cntr, util_cntr);
 	efa_domain = container_of(efa_cntr->util_cntr.domain, struct efa_domain, util_domain);
+
+	/**
+	 * TODO: It's better to just post the initial batch of internal rx pkts during ep enable
+	 * so we don't have to iterate cntr->ep_list here.
+	 * However, it is observed that doing that will hurt performance if application opens
+	 * some idle endpoints and never poll completions for them. Move these initial posts to
+	 * the first polling before having a long term fix.
+	 */
+	if (!efa_cntr->initial_rx_to_all_eps_posted) {
+		dlist_foreach(&cntr->ep_list, item) {
+			fid_entry = container_of(item, struct fid_list_entry, entry);
+			efa_rdm_ep = container_of(fid_entry->fid, struct efa_rdm_ep, base_ep.util_ep.ep_fid.fid);
+			efa_rdm_ep_post_internal_rx_pkts(efa_rdm_ep);
+		}
+		efa_cntr->initial_rx_to_all_eps_posted = true;
+	}
 
 	dlist_foreach(&efa_cntr->ibv_cq_poll_list, item) {
 		poll_list_entry = container_of(item, struct efa_ibv_cq_poll_list_entry, entry);
@@ -175,6 +193,7 @@ int efa_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 		return -FI_ENOMEM;
 
 	dlist_init(&cntr->ibv_cq_poll_list);
+	cntr->initial_rx_to_all_eps_posted = false;
 	efa_domain = container_of(domain, struct efa_domain,
 				  util_domain.domain_fid);
 

--- a/prov/efa/src/efa_cntr.h
+++ b/prov/efa/src/efa_cntr.h
@@ -12,6 +12,8 @@ struct efa_cntr {
 	struct util_cntr util_cntr;
 	struct fid_cntr *shm_cntr;
 	struct dlist_entry ibv_cq_poll_list;
+	/* Only used by RDM EP type */
+	bool initial_rx_to_all_eps_posted;
 };
 
 int efa_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -166,6 +166,7 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_rdm_cq_post_initial_rx_pkts, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_cntr_ibv_cq_poll_list_same_tx_rx_cq_single_ep, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_cntr_ibv_cq_poll_list_separate_tx_rx_cq_single_ep, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_cntr_post_initial_rx_pkts, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 	};
 
 	cmocka_set_message_output(CM_OUTPUT_XML);

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -180,6 +180,7 @@ void test_efa_rdm_cq_ibv_cq_poll_list_separate_tx_rx_cq_single_ep();
 void test_efa_rdm_cq_post_initial_rx_pkts();
 void test_efa_rdm_cntr_ibv_cq_poll_list_same_tx_rx_cq_single_ep();
 void test_efa_rdm_cntr_ibv_cq_poll_list_separate_tx_rx_cq_single_ep();
+void test_efa_cntr_post_initial_rx_pkts();
 
 static inline
 int efa_unit_test_get_dlist_length(struct dlist_entry *head)


### PR DESCRIPTION
It may be possible that application (currently fabtests)
only use fi_cntr_read to poll completions without calling fi_cq_read. In this case, the first fi_cntr_read should post rx buffers to all bounded eps as well.