### PR TITLE
fabtests: Add benchmark option for `FI_OPT_MAX_MSG_SIZE`

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -1427,6 +1427,14 @@ int ft_enable_ep(struct fid_ep *bind_ep, struct fid_eq *bind_eq, struct fid_av *
 		FT_EP_BIND(bind_ep, bind_rma_cntr, flags);
 	}
 
+	if (opts.max_msg_size) {
+		ret = fi_setopt(&bind_ep->fid, FI_OPT_ENDPOINT, FI_OPT_MAX_MSG_SIZE, &opts.max_msg_size, sizeof opts.max_msg_size);
+		if (ret && ret != -FI_EOPNOTSUPP) {
+			FT_PRINTERR("fi_setopt(FI_OPT_MAX_MSG_SIZE)", ret);
+			return ret;
+		}
+	}
+
 	ret = fi_enable(bind_ep);
 	if (ret) {
 		FT_PRINTERR("fi_enable", ret);
@@ -4169,6 +4177,8 @@ void ft_longopts_usage()
 		"manual, or auto");
 	FT_PRINT_OPTS_USAGE("--control-progress <progress_model>",
 		"manual, auto, or unified");
+	FT_PRINT_OPTS_USAGE("--max-msg-size <size>",
+		"maximum untagged message size");
 }
 
 int debug_assert;
@@ -4180,6 +4190,7 @@ struct option long_opts[] = {
 	{"debug-assert", no_argument, &debug_assert, LONG_OPT_DEBUG_ASSERT},
 	{"data-progress", required_argument, NULL, LONG_OPT_DATA_PROGRESS},
 	{"control-progress", required_argument, NULL, LONG_OPT_CONTROL_PROGRESS},
+	{"max-msg-size", required_argument, NULL, LONG_OPT_MAX_MSG_SIZE},
 	{NULL, 0, NULL, 0},
 };
 
@@ -4216,6 +4227,9 @@ int ft_parse_long_opts(int op, char *optarg)
 		hints->domain_attr->control_progress = ft_parse_progress_model_string(optarg);
 		if (hints->domain_attr->control_progress == -1)
 			return EXIT_FAILURE;
+		return 0;
+	case LONG_OPT_MAX_MSG_SIZE:
+		opts.max_msg_size = atoi(optarg);
 		return 0;
 	default:
 		return EXIT_FAILURE;

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -175,6 +175,7 @@ struct ft_opts {
 	int iterations;
 	int warmup_iterations;
 	size_t transfer_size;
+	size_t max_msg_size;
 	int window_size;
 	int av_size;
 	int verbose;
@@ -637,6 +638,7 @@ enum {
 	LONG_OPT_DEBUG_ASSERT,
 	LONG_OPT_DATA_PROGRESS,
 	LONG_OPT_CONTROL_PROGRESS,
+	LONG_OPT_MAX_MSG_SIZE,
 };
 
 extern int debug_assert;

--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -109,3 +109,13 @@ def test_rdm_pingpong_1G(cmdline_args, completion_semantic):
     efa_run_client_server_test(cmdline_args, "fi_rdm_pingpong -W 1", 2,
                                completion_semantic=completion_semantic, message_size=1073741824,
                                memory_type="host_to_host", warmup_iteration_type=0)
+
+@pytest.mark.functional
+def test_rdm_pingpong_zcpy_recv(cmdline_args, memory_type, message_size):
+    efa_run_client_server_test(cmdline_args, "fi_rdm_pingpong --max-msg-size 8192",
+                               "short", "transmit_complete", memory_type, message_size)
+
+@pytest.mark.functional
+def test_rdm_bw_zcpy_recv(cmdline_args, memory_type, message_size):
+    efa_run_client_server_test(cmdline_args, "fi_rdm_bw --max-msg-size 8192",
+                               "short", "transmit_complete", memory_type, message_size)

--- a/prov/efa/src/rdm/efa_rdm_cq.c
+++ b/prov/efa/src/rdm/efa_rdm_cq.c
@@ -298,7 +298,6 @@ static void efa_rdm_cq_handle_recv_completion(struct efa_ibv_cq *ibv_cq, struct 
 	}
 
 	pkt_entry->pkt_size = ibv_wc_read_byte_len(ibv_cq_ex);
-	assert(pkt_entry->pkt_size > 0);
 	if (ibv_wc_read_wc_flags(ibv_cq_ex) & IBV_WC_WITH_IMM) {
 		has_imm_data = true;
 		imm_data = ibv_wc_read_imm_data(ibv_cq_ex);

--- a/prov/efa/src/rdm/efa_rdm_msg.c
+++ b/prov/efa/src/rdm/efa_rdm_msg.c
@@ -70,7 +70,7 @@ int efa_rdm_msg_select_rtm(struct efa_rdm_ep *efa_rdm_ep, struct efa_rdm_ope *tx
 	iface = txe->desc[0] ? ((struct efa_mr*) txe->desc[0])->peer.iface : FI_HMEM_SYSTEM;
 	hmem_info = efa_rdm_ep_domain(efa_rdm_ep)->hmem_info;
 
-	if (txe->fi_flags & FI_INJECT)
+	if (txe->fi_flags & FI_INJECT || efa_both_support_zero_hdr_data_transfer(efa_rdm_ep, txe->peer))
 		delivery_complete_requested = false;
 	else
 		delivery_complete_requested = txe->fi_flags & FI_DELIVERY_COMPLETE;

--- a/prov/efa/src/rdm/efa_rdm_pke.c
+++ b/prov/efa/src/rdm/efa_rdm_pke.c
@@ -209,7 +209,6 @@ void efa_rdm_pke_copy(struct efa_rdm_pke *dest,
 	dest->addr = src->addr;
 	dest->flags = EFA_RDM_PKE_IN_USE;
 	dest->next = NULL;
-	assert(dest->pkt_size > 0);
 	memcpy(dest->wiredata, src->wiredata + src_pkt_offset, dest->pkt_size);
 }
 
@@ -384,7 +383,6 @@ ssize_t efa_rdm_pke_sendv(struct efa_rdm_pke **pkt_entry_vec,
 	}
 	for (pkt_idx = 0; pkt_idx < pkt_entry_cnt; ++pkt_idx) {
 		pkt_entry = pkt_entry_vec[pkt_idx];
-		assert(pkt_entry->pkt_size);
 		assert(efa_rdm_ep_get_peer(ep, pkt_entry->addr) == peer);
 
 		qp->ibv_qp_ex->wr_id = (uintptr_t)pkt_entry;
@@ -640,7 +638,6 @@ ssize_t efa_rdm_pke_recvv(struct efa_rdm_pke **pke_vec,
 			ep->base_ep.efa_recv_wr_vec[i].wr.sg_list[0].length = pke_vec[i]->payload_size;
 			ep->base_ep.efa_recv_wr_vec[i].wr.sg_list[0].lkey = ((struct efa_mr *) pke_vec[i]->payload_mr)->ibv_mr->lkey;
 		} else {
-			assert(pke_vec[i]->pkt_size > 0);
 			ep->base_ep.efa_recv_wr_vec[i].wr.sg_list[0].length = pke_vec[i]->pkt_size;
 			ep->base_ep.efa_recv_wr_vec[i].wr.sg_list[0].lkey = ((struct efa_mr *) pke_vec[i]->mr)->ibv_mr->lkey;
 			ep->base_ep.efa_recv_wr_vec[i].wr.sg_list[0].addr = (uintptr_t)pke_vec[i]->wiredata;


### PR DESCRIPTION
This adds an option (`-X`) for benchmark tests; corresponding to the endpoint options `FI_OPT_MAX_MSG_SIZE`. `fi_setopt()` is called during EP enable with the value requested by the user.

This also includes a few related minor changes to the EFA provider.