### PR TITLE
hmem,prov/efa: change neuron get_dmabuf_fd error code

### DIFF
--- a/prov/efa/src/efa_hmem.c
+++ b/prov/efa/src/efa_hmem.c
@@ -250,7 +250,7 @@ static int efa_domain_hmem_info_init_neuron(struct efa_domain *efa_domain)
 		ibv_mr = ibv_reg_dmabuf_mr(
 					g_device_list[0].ibv_pd, offset,
 					len, (uint64_t)ptr, dmabuf_fd, ibv_access);
-	} else if (ret == -FI_ENOPROTOOPT) {
+	} else if (ret == -FI_EOPNOTSUPP) {
 		EFA_INFO(FI_LOG_MR,
 			"Unable to retrieve dmabuf fd of Neuron device buffer, "
 			"Fall back to ibv_reg_mr\n");

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -564,7 +564,7 @@ static struct ibv_mr *efa_mr_reg_ibv_mr(struct efa_mr *efa_mr, struct fi_mr_attr
 					mr_attr->mr_iov->iov_len,
 					(uint64_t)mr_attr->mr_iov->iov_base,
 					dmabuf_fd, access);
-		} else if (ret == -FI_ENOPROTOOPT) {
+		} else if (ret == -FI_EOPNOTSUPP) {
 			/* Protocol not availabe => fallback */
 			EFA_INFO(FI_LOG_MR,
 				"Unable to get dmabuf fd for Neuron device buffer, "

--- a/src/hmem_neuron.c
+++ b/src/hmem_neuron.c
@@ -222,7 +222,7 @@ int neuron_get_dmabuf_fd(const void *addr, uint64_t size, int *fd,
 
 	/* nrt_get_dmabuf_fd symbol doesn't exist in Neuron Runtime */
 	if (!neuron_ops.nrt_get_dmabuf_fd) {
-		return -FI_ENOPROTOOPT;
+		return -FI_EOPNOTSUPP;
 	}
 
 	ret = neuron_ops.nrt_get_dmabuf_fd((uintptr_t)addr, size, fd);
@@ -245,7 +245,7 @@ int neuron_get_dmabuf_fd(const void *addr, uint64_t size, int *fd,
 		/* fallback to mem registration using ibv_reg_mr */
 		FI_INFO(&core_prov, FI_LOG_CORE,
 			"Failed to retrieve dmabuf_fd: %d\n", ret);
-		return -FI_ENOPROTOOPT;
+		return -FI_EOPNOTSUPP;
 	}
 }
 


### PR DESCRIPTION
If dmabuf is not supported, get_dmabuf_fd should return -FI_EOPNOTSUPP