### PR TITLE
prov/efa: Fix unit test build warnings

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_pkt_type.h
+++ b/prov/efa/src/rdm/efa_rdm_pkt_type.h
@@ -6,7 +6,7 @@
 
 #include <assert.h>
 #include <stdint.h>
-#include "efa_rdm_protocol.h"
+#include "efa_rdm_peer.h"
 
 /**
  * @brief information of a REQ packet type

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -342,6 +342,7 @@ void test_efa_rdm_read_copy_pkt_pool_128_alignment(struct efa_resource **state)
 		efa_rdm_pke_alloc(efa_rdm_ep, efa_rdm_ep->rx_readcopy_pkt_pool,
 				  EFA_RDM_PKE_FROM_READ_COPY_POOL);
 	assert_non_null(pkt_entry);
+	efa_rdm_ep->rx_readcopy_pkt_pool_used++;
 	assert(ofi_is_addr_aligned((void *) pkt_entry->wiredata,
 				   EFA_RDM_IN_ORDER_ALIGNMENT));
 	efa_rdm_pke_release_rx(pkt_entry);

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -1,9 +1,9 @@
 /* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
 /* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
 
-#include "efa_rdm_pke_utils.h"
 #include "efa_unit_tests.h"
 #include "rdm/efa_rdm_cq.h"
+#include "efa_rdm_pke_utils.h"
 
 /**
  * @brief Verify the EFA RDM endpoint correctly parses the host id string


### PR DESCRIPTION
Fix some unit test build warnings caused by https://github.com/ofiwg/libfabric/commit/94245648abed71e5a55c92cfeee682c3ba984821