### PR TITLE
prov/efa: Use EFA_WARN in efa_show_help

### DIFF
--- a/prov/efa/src/efa_strerror.c
+++ b/prov/efa/src/efa_strerror.c
@@ -1,9 +1,8 @@
 /* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
 /* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
 
+#include "efa.h"
 #include "efa_errno.h"
-
-#include <stdio.h>
 
 #define IO_COMP_STATUS_MESSAGES(code, suffix, ...)	[EFA_IO_COMP_STATUS_##suffix] = #__VA_ARGS__,
 #define PROV_ERRNO_MESSAGES(code, suffix, ...)		[FI_EFA_ERR_##suffix - EFA_PROV_ERRNO_START] = #__VA_ARGS__,
@@ -87,5 +86,5 @@ void efa_show_help(enum efa_errno err) {
 	default:
 		return;
 	}
-	fprintf(stderr, "%s\n", help);
+	EFA_WARN(FI_LOG_CQ, "%s\n", help);
 }


### PR DESCRIPTION
efa_show_help() calls fprintf() to always print the error string. However, the context needed for that help to make any sense (the real error message) is in an EFA_WARN() block, so it doesn't print by default. This leads to some really weird log files, where only the show help string appears.