### PR TITLE
prov/efa: Log MR consumption

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -145,7 +145,8 @@ nodist_prov_efa_test_efa_unit_test_SOURCES = \
 	prov/efa/test/efa_unit_test_ope.c \
 	prov/efa/test/efa_unit_test_send.c \
 	prov/efa/test/efa_unit_test_fork_support.c \
-	prov/efa/test/efa_unit_test_runt.c
+	prov/efa/test/efa_unit_test_runt.c \
+	prov/efa/test/efa_unit_test_mr.c
 
 
 efa_CPPFLAGS += -I$(top_srcdir)/include -I$(top_srcdir)/prov/efa/test $(cmocka_CPPFLAGS)

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -201,6 +201,9 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 		goto err_free;
 	}
 
+	efa_domain->ibv_mr_reg_ct = 0;
+	efa_domain->ibv_mr_reg_sz = 0;
+
 	err = ofi_genlock_init(&efa_domain->srx_lock, efa_domain->util_domain.threading != FI_THREAD_SAFE ?
 			       OFI_LOCK_NOOP : OFI_LOCK_MUTEX);
 	if (err) {

--- a/prov/efa/src/efa_domain.h
+++ b/prov/efa/src/efa_domain.h
@@ -28,6 +28,10 @@ struct efa_domain {
 	bool 			mr_local;
 	struct dlist_entry	list_entry; /* linked to g_efa_domain_list */
 	struct ofi_genlock	srx_lock; /* shared among peer providers */
+	/* Total count of ibv memory registrations */
+	size_t ibv_mr_reg_ct;
+	/* Total size of memory registrations (in bytes) */
+	size_t ibv_mr_reg_sz;
 
 	/* Only valid for RDM EP type */
 	uint64_t		rdm_mode;

--- a/prov/efa/test/efa_unit_test_mr.c
+++ b/prov/efa/test/efa_unit_test_mr.c
@@ -1,0 +1,35 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#include "efa_unit_tests.h"
+
+void test_efa_mr_reg_counters(struct efa_resource **state)
+{
+    struct efa_resource *resource = *state;
+    struct efa_domain *efa_domain;
+    size_t mr_size = 64;
+    char *buf;
+    struct fid_mr *mr;
+
+    efa_unit_test_resource_construct(resource, FI_EP_RDM);
+
+    efa_domain = container_of(resource->domain, struct efa_domain, util_domain.domain_fid);
+    assert_true(efa_domain->ibv_mr_reg_ct == 0);
+    assert_true(efa_domain->ibv_mr_reg_sz == 0);
+
+
+    buf = malloc(mr_size);
+    assert_non_null(buf);
+
+    assert_int_equal(fi_mr_reg(resource->domain, buf, mr_size,
+            FI_SEND | FI_RECV, 0, 0, 0, &mr, NULL), 0);
+
+    assert_true(efa_domain->ibv_mr_reg_ct == 1);
+    assert_true(efa_domain->ibv_mr_reg_sz == mr_size);
+
+    assert_int_equal(fi_close(&mr->fid), 0);
+    assert_true(efa_domain->ibv_mr_reg_ct == 0);
+    assert_true(efa_domain->ibv_mr_reg_sz == 0);
+
+    free(buf);
+}

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -196,6 +196,7 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_neuron_dmabuf_support_mr_fail_no_fallback, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_neuron_dmabuf_support_require_dmabuf_fail_no_fallback, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_synapseai_dmabuf_support_fd_fail_no_fallback, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_mr_reg_counters, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 	};
 
 	cmocka_set_message_output(CM_OUTPUT_XML);

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -245,6 +245,7 @@ void test_efa_synapseai_dmabuf_support_fd_fail_no_fallback();
  */
 void test_efa_cuda_dmabuf_support_require_dmabuf_fail_no_fallback();
 void test_efa_neuron_dmabuf_support_require_dmabuf_fail_no_fallback();
+void test_efa_mr_reg_counters();
 
 static inline
 int efa_unit_test_get_dlist_length(struct dlist_entry *head)


### PR DESCRIPTION
Introduce ibv_mr_reg_cnt and ibv_mr_reg_sz in efa_domain to record the total count and size of mr within the efa domain (ibv pd). Print the total mr count and size as part of the warning message from failed mr reg. This will help troubleshoot the ENOMEM error hit by customers that can be caused by MR exceeding the limit.