### PR TITLE
libfabric/core: Fix coverity issues 426807 and 426820

### DIFF
--- a/include/ofi_rbuf.h
+++ b/include/ofi_rbuf.h
@@ -116,6 +116,8 @@ struct ofi_ringbuf {
 
 static inline int ofi_rbinit(struct ofi_ringbuf *rb, size_t size)
 {
+	if (size == 0 || size > (SIZE_MAX / 2))
+		return -EINVAL;
 	rb->size = roundup_power_of_two(size);
 	rb->size_mask = rb->size - 1;
 	rb->rcnt = 0;

--- a/src/mem.c
+++ b/src/mem.c
@@ -115,6 +115,9 @@ size_t ofi_get_mem_size(void)
 	if (page_cnt <= 0 || page_size <= 0)
 		return 0;
 
+	if (page_cnt > SIZE_MAX / page_size)
+		return 0;
+
 	mem_size = (size_t) page_cnt * (size_t) page_size;
 	if (mem_size < page_cnt || mem_size < page_size)
 		return 0;


### PR DESCRIPTION
This commit fixes integer overflow issues detected by coverity.