### PR TITLE
contrib/intel/jenkins: Minor Pipeline bugfixes

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -901,10 +901,12 @@ pipeline {
   post {
     always {
       script {
-        CI_summarize(verbose=true)
-        CI_summarize()
-        summarize("all", verbose=true)
-        summarize("all")
+        if (DO_RUN) {
+          CI_summarize(verbose=true)
+          CI_summarize()
+          summarize("all", verbose=true)
+          summarize("all")
+        }
       }
     }
     aborted {
@@ -918,9 +920,11 @@ pipeline {
     }
     success {
       script {
-        CI_summarize(verbose=true)
-        summarize("all", verbose=true, release=false,
-        send_mail=env.WEEKLY.toBoolean())
+        if (DO_RUN) {
+          CI_summarize(verbose=true)
+          summarize("all", verbose=true, release=false,
+          send_mail=env.WEEKLY.toBoolean())
+        }
       }
       node ('daos_head') {
         dir("${env.WORKSPACE}") { deleteDir() }

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -94,11 +94,13 @@ def run_middleware(providers, stage_name, test, hw, partition, node_num,
 }
 
 def run_ci(stage_name, config_name) {
-  sh """source ${CI_LOCATION}/${env.CI_MODULE}/venv/bin/activate;\
-        python run.py \
-        --output=${env.LOG_DIR}/${stage_name} \
-        --job=${config_name}
-  """
+  return sh(returnStatus: true,
+            script: """source ${CI_LOCATION}/${env.CI_MODULE}/venv/bin/activate;\
+                      python run.py \
+                      --output=${env.LOG_DIR}/${stage_name} \
+                      --job=${config_name}
+                    """
+  )
 }
 
 def gather_logs(cluster, key, dest, source) {

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -901,7 +901,9 @@ pipeline {
   post {
     always {
       script {
+        CI_summarize(verbose=true)
         CI_summarize()
+        summarize("all", verbose=true)
         summarize("all")
       }
     }

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -905,13 +905,6 @@ pipeline {
         summarize("all")
       }
     }
-    success {
-      script {
-        CI_summarize(verbose=true)
-        summarize("all", verbose=true, release=false,
-        send_mail=env.WEEKLY.toBoolean())
-      }
-    }
     aborted {
       node ('daos_head') {
         dir ("${DELETE_LOCATION}/middlewares") { deleteDir() }
@@ -921,7 +914,12 @@ pipeline {
       }
       dir ("${DELETE_LOCATION}/middlewares") { deleteDir() }
     }
-    cleanup {
+    success {
+      script {
+        CI_summarize(verbose=true)
+        summarize("all", verbose=true, release=false,
+        send_mail=env.WEEKLY.toBoolean())
+      }
       node ('daos_head') {
         dir("${env.WORKSPACE}") { deleteDir() }
         dir("${env.WORKSPACE}@tmp") { deleteDir() }


### PR DESCRIPTION
Keep job logs on failure
Make summary in post always do verbose first to properly view failing tests
Only run summary in post if opt-out path is not taken
Return shell error code properly for CI runner stages