### PR TITLE
[v1.22.x] fabtests, prov/efa: Add benchmark option for FI_OPT_MAX_MSG_SIZE

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -1427,6 +1427,14 @@ int ft_enable_ep(struct fid_ep *bind_ep, struct fid_eq *bind_eq, struct fid_av *
 		FT_EP_BIND(bind_ep, bind_rma_cntr, flags);
 	}
 
+	if (opts.max_msg_size) {
+		ret = fi_setopt(&bind_ep->fid, FI_OPT_ENDPOINT, FI_OPT_MAX_MSG_SIZE, &opts.max_msg_size, sizeof opts.max_msg_size);
+		if (ret && ret != -FI_EOPNOTSUPP) {
+			FT_PRINTERR("fi_setopt(FI_OPT_MAX_MSG_SIZE)", ret);
+			return ret;
+		}
+	}
+
 	ret = fi_enable(bind_ep);
 	if (ret) {
 		FT_PRINTERR("fi_enable", ret);
@@ -4173,6 +4181,8 @@ void ft_longopts_usage()
 		"manual, or auto");
 	FT_PRINT_OPTS_USAGE("--control-progress <progress_model>",
 		"manual, auto, or unified");
+	FT_PRINT_OPTS_USAGE("--max-msg-size <size>",
+		"maximum untagged message size");
 }
 
 int debug_assert;
@@ -4184,6 +4194,7 @@ struct option long_opts[] = {
 	{"debug-assert", no_argument, &debug_assert, LONG_OPT_DEBUG_ASSERT},
 	{"data-progress", required_argument, NULL, LONG_OPT_DATA_PROGRESS},
 	{"control-progress", required_argument, NULL, LONG_OPT_CONTROL_PROGRESS},
+	{"max-msg-size", required_argument, NULL, LONG_OPT_MAX_MSG_SIZE},
 	{NULL, 0, NULL, 0},
 };
 
@@ -4220,6 +4231,9 @@ int ft_parse_long_opts(int op, char *optarg)
 		hints->domain_attr->control_progress = ft_parse_progress_model_string(optarg);
 		if (hints->domain_attr->control_progress == -1)
 			return EXIT_FAILURE;
+		return 0;
+	case LONG_OPT_MAX_MSG_SIZE:
+		opts.max_msg_size = atoi(optarg);
 		return 0;
 	default:
 		return EXIT_FAILURE;

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -175,6 +175,7 @@ struct ft_opts {
 	int iterations;
 	int warmup_iterations;
 	size_t transfer_size;
+	size_t max_msg_size;
 	int window_size;
 	int av_size;
 	int verbose;
@@ -637,6 +638,7 @@ enum {
 	LONG_OPT_DEBUG_ASSERT,
 	LONG_OPT_DATA_PROGRESS,
 	LONG_OPT_CONTROL_PROGRESS,
+	LONG_OPT_MAX_MSG_SIZE,
 };
 
 extern int debug_assert;

--- a/fabtests/pytest/efa/conftest.py
+++ b/fabtests/pytest/efa/conftest.py
@@ -26,6 +26,16 @@ def message_size(request):
 def inject_message_size(request):
     return request.param
 
+
+@pytest.fixture(scope="module", params=["r:0,4,32",
+                                        "r:0,1024,8192",])
+def zcpy_recv_message_size(request):
+    return request.param
+
+@pytest.fixture(scope="module")
+def zcpy_recv_max_msg_size(request):
+    return 8192
+
 @pytest.hookimpl(hookwrapper=True)
 def pytest_collection_modifyitems(session, config, items):
     # Called after collection has been performed, may filter or re-order the items in-place

--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -109,3 +109,17 @@ def test_rdm_pingpong_1G(cmdline_args, completion_semantic):
     efa_run_client_server_test(cmdline_args, "fi_rdm_pingpong -W 1", 2,
                                completion_semantic=completion_semantic, message_size=1073741824,
                                memory_type="host_to_host", warmup_iteration_type=0)
+
+@pytest.mark.functional
+def test_rdm_pingpong_zcpy_recv(cmdline_args, memory_type, zcpy_recv_max_msg_size, zcpy_recv_message_size):
+    if cmdline_args.server_id == cmdline_args.client_id:
+        pytest.skip("no zero copy recv for intra-node communication")
+    efa_run_client_server_test(cmdline_args, f"fi_rdm_pingpong --max-msg-size {zcpy_recv_max_msg_size}",
+                               "short", "transmit_complete", memory_type, zcpy_recv_message_size)
+
+@pytest.mark.functional
+def test_rdm_bw_zcpy_recv(cmdline_args, memory_type, zcpy_recv_max_msg_size, zcpy_recv_message_size):
+    if cmdline_args.server_id == cmdline_args.client_id:
+        pytest.skip("no zero copy recv for intra-node communication")
+    efa_run_client_server_test(cmdline_args, f"fi_rdm_bw --max-msg-size {zcpy_recv_max_msg_size}",
+                               "short", "transmit_complete", memory_type, zcpy_recv_message_size)

--- a/prov/efa/src/rdm/efa_rdm_cq.c
+++ b/prov/efa/src/rdm/efa_rdm_cq.c
@@ -298,7 +298,6 @@ static void efa_rdm_cq_handle_recv_completion(struct efa_ibv_cq *ibv_cq, struct 
 	}
 
 	pkt_entry->pkt_size = ibv_wc_read_byte_len(ibv_cq_ex);
-	assert(pkt_entry->pkt_size > 0);
 	if (ibv_wc_read_wc_flags(ibv_cq_ex) & IBV_WC_WITH_IMM) {
 		has_imm_data = true;
 		imm_data = ibv_wc_read_imm_data(ibv_cq_ex);

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -780,6 +780,9 @@ static void efa_rdm_ep_destroy_buffer_pools(struct efa_rdm_ep *efa_rdm_ep)
 	if (efa_rdm_ep->rx_unexp_pkt_pool)
 		ofi_bufpool_destroy(efa_rdm_ep->rx_unexp_pkt_pool);
 
+	if (efa_rdm_ep->user_rx_pkt_pool)
+		ofi_bufpool_destroy(efa_rdm_ep->user_rx_pkt_pool);
+
 	if (efa_rdm_ep->efa_rx_pkt_pool)
 		ofi_bufpool_destroy(efa_rdm_ep->efa_rx_pkt_pool);
 

--- a/prov/efa/src/rdm/efa_rdm_ep_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_utils.c
@@ -214,6 +214,10 @@ int efa_rdm_ep_post_user_recv_buf(struct efa_rdm_ep *ep, struct efa_rdm_ope *rxe
 	assert(rxe->iov_count > 0  && rxe->iov_count <= ep->rx_iov_limit);
 	assert(rxe->iov[0].iov_len >= ep->msg_prefix_size);
 	pkt_entry = efa_rdm_pke_alloc(ep, ep->user_rx_pkt_pool, EFA_RDM_PKE_FROM_USER_RX_POOL);
+	if (OFI_UNLIKELY(!pkt_entry)) {
+		EFA_WARN(FI_LOG_EP_DATA, "Failed to allocate pkt_entry for user rx\n");
+		return -FI_ENOMEM;
+	}
 
 	pkt_entry->ope = rxe;
 	rxe->state = EFA_RDM_RXE_MATCHED;

--- a/prov/efa/src/rdm/efa_rdm_msg.c
+++ b/prov/efa/src/rdm/efa_rdm_msg.c
@@ -70,7 +70,7 @@ int efa_rdm_msg_select_rtm(struct efa_rdm_ep *efa_rdm_ep, struct efa_rdm_ope *tx
 	iface = txe->desc[0] ? ((struct efa_mr*) txe->desc[0])->peer.iface : FI_HMEM_SYSTEM;
 	hmem_info = efa_rdm_ep_domain(efa_rdm_ep)->hmem_info;
 
-	if (txe->fi_flags & FI_INJECT)
+	if (txe->fi_flags & FI_INJECT || efa_both_support_zero_hdr_data_transfer(efa_rdm_ep, txe->peer))
 		delivery_complete_requested = false;
 	else
 		delivery_complete_requested = txe->fi_flags & FI_DELIVERY_COMPLETE;

--- a/prov/efa/src/rdm/efa_rdm_pke.c
+++ b/prov/efa/src/rdm/efa_rdm_pke.c
@@ -209,7 +209,6 @@ void efa_rdm_pke_copy(struct efa_rdm_pke *dest,
 	dest->addr = src->addr;
 	dest->flags = EFA_RDM_PKE_IN_USE;
 	dest->next = NULL;
-	assert(dest->pkt_size > 0);
 	memcpy(dest->wiredata, src->wiredata + src_pkt_offset, dest->pkt_size);
 }
 
@@ -384,7 +383,6 @@ ssize_t efa_rdm_pke_sendv(struct efa_rdm_pke **pkt_entry_vec,
 	}
 	for (pkt_idx = 0; pkt_idx < pkt_entry_cnt; ++pkt_idx) {
 		pkt_entry = pkt_entry_vec[pkt_idx];
-		assert(pkt_entry->pkt_size);
 		assert(efa_rdm_ep_get_peer(ep, pkt_entry->addr) == peer);
 
 		qp->ibv_qp_ex->wr_id = (uintptr_t)pkt_entry;
@@ -640,7 +638,6 @@ ssize_t efa_rdm_pke_recvv(struct efa_rdm_pke **pke_vec,
 			ep->base_ep.efa_recv_wr_vec[i].wr.sg_list[0].length = pke_vec[i]->payload_size;
 			ep->base_ep.efa_recv_wr_vec[i].wr.sg_list[0].lkey = ((struct efa_mr *) pke_vec[i]->payload_mr)->ibv_mr->lkey;
 		} else {
-			assert(pke_vec[i]->pkt_size > 0);
 			ep->base_ep.efa_recv_wr_vec[i].wr.sg_list[0].length = pke_vec[i]->pkt_size;
 			ep->base_ep.efa_recv_wr_vec[i].wr.sg_list[0].lkey = ((struct efa_mr *) pke_vec[i]->mr)->ibv_mr->lkey;
 			ep->base_ep.efa_recv_wr_vec[i].wr.sg_list[0].addr = (uintptr_t)pke_vec[i]->wiredata;

--- a/prov/efa/src/rdm/efa_rdm_pke.c
+++ b/prov/efa/src/rdm/efa_rdm_pke.c
@@ -43,7 +43,7 @@ struct efa_rdm_pke *efa_rdm_pke_alloc(struct efa_rdm_ep *ep,
 		return NULL;
 
 #ifdef ENABLE_EFA_POISONING
-	efa_rdm_poison_mem_region(pkt_entry, sizeof(struct efa_rdm_pke) + ep->mtu_size);
+	efa_rdm_poison_mem_region(pkt_entry, pkt_pool->attr.size);
 #endif
 	dlist_init(&pkt_entry->entry);
 
@@ -82,7 +82,7 @@ struct efa_rdm_pke *efa_rdm_pke_alloc(struct efa_rdm_ep *ep,
 void efa_rdm_pke_release(struct efa_rdm_pke *pkt_entry)
 {
 #ifdef ENABLE_EFA_POISONING
-	efa_rdm_poison_mem_region(pkt_entry, sizeof(struct efa_rdm_pke) + pkt_entry->ep->mtu_size);
+	efa_rdm_poison_mem_region(pkt_entry, ofi_buf_pool(pkt_entry)->attr.size);
 #endif
 	pkt_entry->flags = 0;
 	ofi_buf_free(pkt_entry);


### PR DESCRIPTION
Re-open https://github.com/ofiwg/libfabric/pull/10179 to the correct branch