### PR TITLE
prov/efa: refactor hmem interface initialization

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -157,15 +157,14 @@ prov_efa_test_efa_unit_test_LDFLAGS = $(cmocka_rpath) $(efa_LDFLAGS) $(cmocka_LD
 					-Wl,--wrap=ibv_create_ah \
 					-Wl,--wrap=ibv_is_fork_initialized \
 					-Wl,--wrap=efadv_query_device \
+					-Wl,--wrap=ibv_reg_mr \
+					-Wl,--wrap=ibv_reg_mr_iova2 \
+					-Wl,--wrap=ibv_dereg_mr \
 					-Wl,--wrap=ofi_copy_from_hmem_iov
 
 if HAVE_EFADV_CQ_EX
 prov_efa_test_efa_unit_test_LDFLAGS += -Wl,--wrap=efadv_create_cq
 endif HAVE_EFADV_CQ_EX
-
-if HAVE_NEURON
-prov_efa_test_efa_unit_test_LDFLAGS += -Wl,--wrap=neuron_alloc
-endif HAVE_NEURON
 
 if HAVE_EFADV_QUERY_MR
 prov_efa_test_efa_unit_test_LDFLAGS += -Wl,--wrap=efadv_query_mr
@@ -174,6 +173,10 @@ endif HAVE_EFADV_QUERY_MR
 if HAVE_EFA_DATA_IN_ORDER_ALIGNED_128_BYTES
 prov_efa_test_efa_unit_test_LDFLAGS += -Wl,--wrap=ibv_query_qp_data_in_order
 endif
+
+if HAVE_EFA_DMABUF_MR
+prov_efa_test_efa_unit_test_LDFLAGS += -Wl,--wrap=ibv_reg_dmabuf_mr
+endif HAVE_EFA_DMABUF_MR
 
 prov_efa_test_efa_unit_test_LIBS = $(efa_LIBS) $(linkback)
 

--- a/prov/efa/configure.m4
+++ b/prov/efa/configure.m4
@@ -234,6 +234,7 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 	AM_CONDITIONAL([HAVE_EFADV_CQ_EX], [ test $efadv_support_extended_cq = 1])
 	AM_CONDITIONAL([HAVE_EFADV_QUERY_MR], [ test $have_efadv_query_mr = 1])
 	AM_CONDITIONAL([HAVE_EFA_DATA_IN_ORDER_ALIGNED_128_BYTES], [ test $efa_support_data_in_order_aligned_128_byte = 1])
+	AM_CONDITIONAL([HAVE_EFA_DMABUF_MR], [ test $have_efa_dmabuf_mr = 1])
 	AM_CONDITIONAL([ENABLE_EFA_UNIT_TEST], [ test x"$enable_efa_unit_test" != xno])
 
 	AC_SUBST(efa_CPPFLAGS)

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -297,7 +297,7 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 		goto err_free;
 	}
 
-	err = efa_domain_hmem_info_init_all(efa_domain);
+	err = efa_domain_hmem_support_init_all(efa_domain);
 	if (err) {
 		ret = err;
 		EFA_WARN(FI_LOG_DOMAIN, "Failed to check hmem support status. err: %d\n", ret);

--- a/prov/efa/src/efa_hmem.c
+++ b/prov/efa/src/efa_hmem.c
@@ -31,6 +31,7 @@ static size_t efa_max_eager_msg_size_with_largest_header(struct efa_domain *efa_
 static int efa_domain_hmem_info_init_protocol_thresholds(struct efa_domain *efa_domain, enum fi_hmem_iface iface)
 {
 	struct efa_hmem_info *info = &efa_domain->hmem_info[iface];
+	size_t tmp_value;
 
 	/* Fall back to FI_HMEM_SYSTEM initialization logic when p2p is unavailable */
 	if (!info->p2p_supported_by_device)
@@ -56,6 +57,12 @@ static int efa_domain_hmem_info_init_protocol_thresholds(struct efa_domain *efa_
 		fi_param_get_size_t(&efa_prov, "runt_size", &info->runt_size);
 		fi_param_get_size_t(&efa_prov, "inter_min_read_message_size", &info->min_read_msg_size);
 		fi_param_get_size_t(&efa_prov, "inter_min_read_write_size", &info->min_read_write_size);
+		if (-FI_ENODATA != fi_param_get(&efa_prov, "inter_max_medium_message_size", &tmp_value)) {
+			EFA_WARN(FI_LOG_DOMAIN,
+			         "The environment variable FI_EFA_INTER_MAX_MEDIUM_MESSAGE_SIZE was set, "
+			         "but EFA HMEM via Cuda API only supports eager and runting read protocols. "
+			         "The variable will not modify CUDA memory run config.\n");
+		}
 		break;
 	case FI_HMEM_NEURON:
 		info->runt_size = EFA_NEURON_RUNT_SIZE;
@@ -65,12 +72,31 @@ static int efa_domain_hmem_info_init_protocol_thresholds(struct efa_domain *efa_
 		fi_param_get_size_t(&efa_prov, "runt_size", &info->runt_size);
 		fi_param_get_size_t(&efa_prov, "inter_min_read_message_size", &info->min_read_msg_size);
 		fi_param_get_size_t(&efa_prov, "inter_min_read_write_size", &info->min_read_write_size);
+		if (-FI_ENODATA != fi_param_get(&efa_prov, "inter_max_medium_message_size", &tmp_value)) {
+			EFA_WARN(FI_LOG_DOMAIN,
+			         "The environment variable FI_EFA_INTER_MAX_MEDIUM_MESSAGE_SIZE was set, "
+			         "but EFA HMEM via Neuron API only supports eager and runting read protocols. "
+			         "The variable will not modify CUDA memory run config.\n");
+		}
 		break;
 	case FI_HMEM_SYNAPSEAI:
 		info->runt_size = 0;
 		info->max_medium_msg_size = 0;
 		info->min_read_msg_size = 1;
 		info->min_read_write_size = 1;
+		if (-FI_ENODATA != fi_param_get_size_t(&efa_prov, "inter_max_medium_message_size", &tmp_value) ||
+		    -FI_ENODATA != fi_param_get_size_t(&efa_prov, "inter_min_read_message_size", &tmp_value) ||
+		    -FI_ENODATA != fi_param_get_size_t(&efa_prov, "inter_min_read_write_size", &tmp_value) ||
+		    -FI_ENODATA != fi_param_get_size_t(&efa_prov, "runt_size", &tmp_value)) {
+			EFA_WARN(FI_LOG_DOMAIN,
+			        "One or more of the following environment variable(s) were set: ["
+			        "FI_EFA_INTER_MAX_MEDIUM_MESSAGE_SIZE, "
+			        "FI_EFA_INTER_MIN_READ_MESSAGE_SIZE, "
+			        "FI_EFA_INTER_MIN_READ_WRITE_SIZE, "
+			        "FI_EFA_RUNT_SIZE"
+			        "], but EFA HMEM via Synapse only supports long read protocol. "
+			        "The variable(s) will not modify Synapse memory run config.\n");
+		}
 		break;
 	default:
 		break;
@@ -79,267 +105,53 @@ static int efa_domain_hmem_info_init_protocol_thresholds(struct efa_domain *efa_
 }
 
 /**
- * @brief          Initialize the efa_hmem_info state for FI_HMEM_SYSTEM
+ * @brief Initialize the efa_hmem_info state for iface
  *
  * @param[in,out]  efa_domain  Pointer to struct efa_domain
- *
- * @return         0
+ * @param[in]      iface       HMEM interface
  */
-static int efa_domain_hmem_info_init_system(struct efa_domain *efa_domain)
+static void
+efa_domain_hmem_info_init_iface(struct efa_domain *efa_domain, enum fi_hmem_iface iface)
 {
-	struct efa_hmem_info *info = &efa_domain->hmem_info[FI_HMEM_SYSTEM];
+	struct efa_hmem_info *info = &efa_domain->hmem_info[iface];
 
-	info->initialized = true;
+	if (!ofi_hmem_is_initialized(iface)) {
+		EFA_INFO(FI_LOG_DOMAIN, "%s is not initialized\n",
+		         fi_tostr(&iface, FI_TYPE_HMEM_IFACE));
+		return;
+	}
+
 	info->p2p_disabled_by_user = false;
-	info->p2p_required_by_impl = false;
 	info->p2p_supported_by_device = true;
-	efa_domain_hmem_info_init_protocol_thresholds(efa_domain, FI_HMEM_SYSTEM);
-	return 0;
-}
-
-/**
- * @brief          Initialize the efa_hmem_info state for FI_HMEM_CUDA
- *
- * @param[in,out]  efa_domain  Pointer to struct efa_domain
- *
- * @return         0 on success
- *                 negative libfabric error code on failure
- */
-static int efa_domain_hmem_info_init_cuda(struct efa_domain *efa_domain)
-{
-#if HAVE_CUDA
-	struct efa_hmem_info *info = &efa_domain->hmem_info[FI_HMEM_CUDA];
-	cudaError_t cuda_ret;
-	void *ptr = NULL;
-	struct ibv_mr *ibv_mr;
-	int ibv_access = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ;
-	size_t len = ofi_get_page_size() * 2, tmp_value;
-	int ret;
-	int dmabuf_fd;
-	uint64_t dmabuf_offset;
-
-	if (!ofi_hmem_is_initialized(FI_HMEM_CUDA)) {
-		EFA_INFO(FI_LOG_DOMAIN, "FI_HMEM_CUDA is not initialized\n");
-		return 0;
+	if (!info->p2p_supported_by_device) {
+		EFA_INFO(FI_LOG_DOMAIN, "%s P2P support is not available.\n",
+		         fi_tostr(&iface, FI_TYPE_HMEM_IFACE));
 	}
 
-	cuda_ret = ofi_cudaMalloc(&ptr, len);
-	if (cuda_ret != cudaSuccess) {
-		EFA_WARN(FI_LOG_DOMAIN,
-			 "Failed to allocate CUDA buffer: %s\n",
-			 ofi_cudaGetErrorString(cuda_ret));
-		return 0;
-	}
-
-	info->initialized = true;
-	info->p2p_disabled_by_user = false;
-
-	/* If user is using libfabric API 1.18 or later, by default EFA provider is permitted to
-	 * use CUDA library to support CUDA memory, therefore p2p is not required.
-	 */
-	if (FI_VERSION_GE(efa_domain->util_domain.fabric->fabric_fid.api_version, FI_VERSION(1,18)))
-		info->p2p_required_by_impl = !hmem_ops[FI_HMEM_CUDA].initialized;
-	else
+	switch (iface) {
+	case FI_HMEM_CUDA:
+		/* If user is using libfabric API 1.18 or later, by default EFA
+		 * provider is permitted to use CUDA library to support CUDA
+		 * memory, therefore p2p is not required.
+		 */
+		if (FI_VERSION_GE(efa_domain->util_domain.fabric->fabric_fid.api_version,
+				  FI_VERSION(1, 18)))
+			info->p2p_required_by_impl = !hmem_ops[iface].initialized;
+		else
+			info->p2p_required_by_impl = true;
+		break;
+	case FI_HMEM_NEURON:
+	case FI_HMEM_SYNAPSEAI:
 		info->p2p_required_by_impl = true;
-
-#if HAVE_EFA_DMABUF_MR
-	ret = cuda_get_dmabuf_fd(ptr, len, &dmabuf_fd, &dmabuf_offset);
-	if (ret == FI_SUCCESS) {
-		ibv_mr = ibv_reg_dmabuf_mr(g_device_list[0].ibv_pd, dmabuf_offset,
-					   len, (uint64_t)ptr, dmabuf_fd, ibv_access);
-		if (!ibv_mr) {
-			EFA_INFO(FI_LOG_DOMAIN,
-				"Unable to register CUDA device buffer via dmabuf: %s. "
-				"Fall back to ibv_reg_mr\n", fi_strerror(-errno));
-			ibv_mr = ibv_reg_mr(g_device_list[0].ibv_pd, ptr, len, ibv_access);
-		}
-	} else {
-		EFA_INFO(FI_LOG_DOMAIN,
-			"Unable to retrieve dmabuf fd of CUDA device buffer: %d. "
-			"Fall back to ibv_reg_mr\n", ret);
-		ibv_mr = ibv_reg_mr(g_device_list[0].ibv_pd, ptr, len, ibv_access);
-	}
-#else
-	ibv_mr = ibv_reg_mr(g_device_list[0].ibv_pd, ptr, len, ibv_access);
-#endif
-
-	if (!ibv_mr) {
-		info->p2p_supported_by_device = false;
-		efa_domain_hmem_info_init_protocol_thresholds(efa_domain, FI_HMEM_CUDA);
-		EFA_WARN(FI_LOG_DOMAIN,
-			 "Failed to register CUDA buffer with the EFA device, FI_HMEM transfers that require peer to peer support will fail.\n");
-		ofi_cudaFree(ptr);
-		return 0;
+		break;
+	default:
+		assert(iface == FI_HMEM_SYSTEM);
+		info->p2p_required_by_impl = false;
 	}
 
-	ret = ibv_dereg_mr(ibv_mr);
-	ofi_cudaFree(ptr);
-	if (ret) {
-		EFA_WARN(FI_LOG_DOMAIN,
-			 "Failed to deregister CUDA buffer: %s\n",
-			 fi_strerror(-ret));
-		return ret;
-	}
-
-	info->p2p_supported_by_device = true;
-	efa_domain_hmem_info_init_protocol_thresholds(efa_domain, FI_HMEM_CUDA);
-	if (-FI_ENODATA != fi_param_get(&efa_prov, "inter_max_medium_message_size", &tmp_value)) {
-		EFA_WARN(FI_LOG_DOMAIN,
-		         "The environment variable FI_EFA_INTER_MAX_MEDIUM_MESSAGE_SIZE was set, "
-		         "but EFA HMEM via Cuda API only supports eager and runting read protocols. "
-				 "The variable will not modify Cuda memory run config.\n");
-	}
-
-#endif
-	return 0;
-}
-
-/**
- * @brief          Initialize the efa_hmem_info state for FI_HMEM_NEURON
- *
- * @param[in,out]  efa_domain  Pointer to struct efa_domain
- *
- * @return         0 on success
- *                 negative libfabric error code on failure
- */
-static int efa_domain_hmem_info_init_neuron(struct efa_domain *efa_domain)
-{
-#if HAVE_NEURON
-	struct efa_hmem_info *info = &efa_domain->hmem_info[FI_HMEM_NEURON];
-	struct ibv_mr *ibv_mr = NULL;
-	int ibv_access = IBV_ACCESS_LOCAL_WRITE;
-	void *handle;
-	void *ptr = NULL;
-	size_t len = ofi_get_page_size() * 2, tmp_value;
-	int dmabuf_fd;
-	uint64_t offset;
-	int ret;
-
-	if (!ofi_hmem_is_initialized(FI_HMEM_NEURON)) {
-		EFA_INFO(FI_LOG_DOMAIN, "FI_HMEM_NEURON is not initialized\n");
-		return 0;
-	}
-
-	if (g_device_list[0].device_caps & EFADV_DEVICE_ATTR_CAPS_RDMA_READ) {
-		ibv_access |= IBV_ACCESS_REMOTE_READ;
-	} else {
-		EFA_WARN(FI_LOG_DOMAIN,
-			 "No EFA RDMA read support, transfers using AWS Neuron will fail.\n");
-		return 0;
-	}
-
-	ptr = neuron_alloc(&handle, len);
-	/*
-	 * neuron_alloc will fail if application did not call nrt_init,
-	 * which is ok if it's not running neuron workloads. libfabric
-	 * will move on and leave info->initialized as false.
-	 */
-	if (!ptr) {
-		EFA_INFO(FI_LOG_DOMAIN, "Cannot allocate Neuron buffer\n");
-		return 0;
-	}
+	efa_domain_hmem_info_init_protocol_thresholds(efa_domain, iface);
 
 	info->initialized = true;
-	info->p2p_disabled_by_user = false;
-	/* Neuron currently requires P2P */
-	info->p2p_required_by_impl = true;
-
-#if HAVE_EFA_DMABUF_MR
-	ret = neuron_get_dmabuf_fd(ptr, (uint64_t)len, &dmabuf_fd, &offset);
-	if (ret == FI_SUCCESS) {
-		ibv_mr = ibv_reg_dmabuf_mr(
-					g_device_list[0].ibv_pd, offset,
-					len, (uint64_t)ptr, dmabuf_fd, ibv_access);
-	} else if (ret == -FI_EOPNOTSUPP) {
-		EFA_INFO(FI_LOG_MR,
-			"Unable to retrieve dmabuf fd of Neuron device buffer, "
-			"Fall back to ibv_reg_mr\n");
-		ibv_mr = ibv_reg_mr(g_device_list[0].ibv_pd, ptr, len, ibv_access);
-	}
-#else
-	ibv_mr = ibv_reg_mr(g_device_list[0].ibv_pd, ptr, len, ibv_access);
-#endif
-
-	if (!ibv_mr) {
-		info->p2p_supported_by_device = false;
-		/* We do not expect to support Neuron on non p2p systems */
-		EFA_WARN(FI_LOG_DOMAIN,
-		         "Failed to register Neuron buffer with the EFA device, "
-		         "FI_HMEM transfers that require peer to peer support will fail.\n");
-		neuron_free(&handle);
-		return 0;
-	}
-
-	ret = ibv_dereg_mr(ibv_mr);
-	neuron_free(&handle);
-	if (ret) {
-		EFA_WARN(FI_LOG_DOMAIN,
-			 "Failed to deregister Neuron buffer: %s\n",
-			 fi_strerror(-ret));
-		return ret;
-	}
-
-	info->p2p_supported_by_device = true;
-	efa_domain_hmem_info_init_protocol_thresholds(efa_domain, FI_HMEM_NEURON);
-	if (-FI_ENODATA != fi_param_get(&efa_prov, "inter_max_medium_message_size", &tmp_value)) {
-		EFA_WARN(FI_LOG_DOMAIN,
-		         "The environment variable FI_EFA_INTER_MAX_MEDIUM_MESSAGE_SIZE was set, "
-		         "but EFA HMEM via Neuron API only supports eager and runting read protocols. "
-				 "The variable will not modify Neuron memory run config.\n");
-	}
-
-#endif
-	return 0;
-}
-
-/**
- * @brief          Initialize the efa_hmem_info state for FI_HMEM_SYNAPSEAI
- *
- * @param[in,out]  efa_domain  Pointer to struct efa_domain
- *
- * @return         0
- */
-static int efa_domain_hmem_info_init_synapseai(struct efa_domain *efa_domain)
-{
-#if HAVE_SYNAPSEAI
-	size_t tmp_value;
-	struct efa_hmem_info *info = &efa_domain->hmem_info[FI_HMEM_SYNAPSEAI];
-
-	if (!ofi_hmem_is_initialized(FI_HMEM_SYNAPSEAI)) {
-		EFA_INFO(FI_LOG_DOMAIN, "FI_HMEM_SYNAPSEAI is not initialized\n");
-		return 0;
-	}
-
-	if (!(g_device_list[0].device_caps & EFADV_DEVICE_ATTR_CAPS_RDMA_READ)) {
-		EFA_WARN(FI_LOG_DOMAIN,
-			 "No EFA RDMA read support, transfers using Habana Gaudi will fail.\n");
-		return 0;
-	}
-
-	info->initialized = true;
-	info->p2p_disabled_by_user = false;
-	/* SynapseAI currently requires P2P */
-	info->p2p_required_by_impl = true;
-	info->p2p_supported_by_device = true;
-	efa_domain_hmem_info_init_protocol_thresholds(efa_domain, FI_HMEM_SYNAPSEAI);
-
-	/*  Only the long read protocol is supported */
-	if (-FI_ENODATA != fi_param_get_size_t(&efa_prov, "inter_max_medium_message_size", &tmp_value) ||
-		-FI_ENODATA != fi_param_get_size_t(&efa_prov, "inter_min_read_message_size", &tmp_value) ||
-		-FI_ENODATA != fi_param_get_size_t(&efa_prov, "inter_min_read_write_size", &tmp_value) ||
-		-FI_ENODATA != fi_param_get_size_t(&efa_prov, "runt_size", &tmp_value)) {
-		EFA_WARN(FI_LOG_DOMAIN,
-				"One or more of the following environment variable(s) were set: ["
-				"FI_EFA_INTER_MAX_MEDIUM_MESSAGE_SIZE, "
-				"FI_EFA_INTER_MIN_READ_MESSAGE_SIZE, "
-				"FI_EFA_INTER_MIN_READ_WRITE_SIZE, "
-				"FI_EFA_RUNT_SIZE"
-				"], but EFA HMEM via Synapse only supports long read protocol. "
-				"The variable(s) will not modify Synapse memory run config.\n");
-	}
-
-#endif
-	return 0;
 }
 
 /**
@@ -397,7 +209,7 @@ int efa_domain_hmem_validate_p2p_opt(struct efa_domain *efa_domain, enum fi_hmem
 }
 
 /**
- * @brief Initialize the hmem_info structs for
+ * @brief Initialize the support status for
  * all of the HMEM devices. The device hmem_info
  * struct will be used to determine which efa transfer
  * protocol should be selected.
@@ -407,9 +219,11 @@ int efa_domain_hmem_validate_p2p_opt(struct efa_domain *efa_domain, enum fi_hmem
  * @return  0 on success
  *          negative libfabric error code on an unexpected error
  */
-int efa_domain_hmem_info_init_all(struct efa_domain *efa_domain)
+int efa_domain_hmem_support_init_all(struct efa_domain *efa_domain)
 {
-	int ret, err;
+	int ret = 0;
+	enum fi_hmem_iface ifaces[4] = {FI_HMEM_SYSTEM, FI_HMEM_CUDA,
+	                                FI_HMEM_NEURON, FI_HMEM_SYNAPSEAI};
 
 	if(g_device_cnt <= 0) {
 		return -FI_ENODEV;
@@ -417,34 +231,8 @@ int efa_domain_hmem_info_init_all(struct efa_domain *efa_domain)
 
 	memset(efa_domain->hmem_info, 0, OFI_HMEM_MAX * sizeof(struct efa_hmem_info));
 
-	ret = 0;
-
-	err = efa_domain_hmem_info_init_system(efa_domain);
-	if (err) {
-		ret = err;
-		EFA_WARN(FI_LOG_DOMAIN, "Failed to populate the System hmem_info struct! err: %d\n",
-			 err);
-	}
-
-	err = efa_domain_hmem_info_init_cuda(efa_domain);
-	if (err) {
-		ret = err;
-		EFA_WARN(FI_LOG_DOMAIN, "Failed to populate the Cuda hmem_info struct! err: %d\n",
-			 err);
-	}
-
-	err = efa_domain_hmem_info_init_neuron(efa_domain);
-	if (err) {
-		ret = err;
-		EFA_WARN(FI_LOG_DOMAIN, "Failed to populate the Neuron hmem_info struct! err: %d\n",
-			 err);
-	}
-
-	err = efa_domain_hmem_info_init_synapseai(efa_domain);
-	if (err) {
-		ret = err;
-		EFA_WARN(FI_LOG_DOMAIN, "Failed to populate the Synapseai hmem_info struct! err: %d\n",
-			 err);
+	for (int i = 0; i < sizeof(ifaces) / sizeof(enum fi_hmem_iface); ++i) {
+		efa_domain_hmem_info_init_iface(efa_domain, ifaces[i]);
 	}
 
 	return ret;

--- a/prov/efa/src/efa_hmem.h
+++ b/prov/efa/src/efa_hmem.h
@@ -36,7 +36,7 @@ struct efa_hmem_info {
 struct efa_domain;
 
 int efa_domain_hmem_validate_p2p_opt(struct efa_domain *efa_domain, enum fi_hmem_iface iface, int p2p_opt);
-int efa_domain_hmem_info_init_all(struct efa_domain *efa_domain);
+int efa_domain_hmem_support_init_all(struct efa_domain *efa_domain);
 
 /**
  * @brief Copy data from a hmem device to a system buffer

--- a/prov/efa/test/efa_unit_test_hmem.c
+++ b/prov/efa/test/efa_unit_test_hmem.c
@@ -3,55 +3,213 @@
 
 #include "efa_unit_tests.h"
 
-
-#if HAVE_NEURON
-/**
- * @brief Verify when neuron_alloc failed (return null),
- * efa_domain_open, which call efa_hmem_info_update_neuron
- * when HAVE_NEURON=1, will still return 0 but leave
- * efa_hmem_info[FI_HMEM_NEURON].initialized and
- * efa_hmem_info[FI_HMEM_NEURON].p2p_supported_by_device as false.
- *
- * @param[in]	state		struct efa_resource that is managed by the framework
- */
-void test_efa_hmem_info_update_neuron(struct efa_resource **state)
+void test_efa_dmabuf_support(struct efa_resource **state,
+                             enum fi_hmem_iface iface,
+                             bool require_dmabuf,
+                             bool dmabuf_fd_supported,
+                             bool dmabuf_mr_supported,
+                             bool ibv_reg_mr_supported,
+                             bool expect_ibv_reg_mr,
+                             bool expect_ibv_reg_dmabuf_mr,
+                             bool expect_p2p_support,
+                             bool should_succeed)
 {
-        int ret;
-        struct efa_resource *resource = *state;
-        struct efa_domain *efa_domain;
-        uint32_t efa_device_caps_orig;
-        bool neuron_initialized_orig;
+	bool iface_initialized;
+	const size_t bufsize = 4096;
+	const uint64_t buf = g_efa_unit_test_mocks.dummy_address;
+	int ret;
+	struct efa_domain *efa_domain;
+	struct efa_resource *resource = *state;
+	struct fi_mr_attr mr_attr = {0};
+	struct fi_mr_dmabuf mr_dmabuf = {0};
+	struct fid_mr *mr = NULL;
+	struct ibv_mr ibv_mr = {0};
+	struct iovec iov = {0};
+	uint64_t flags = 0;
+	get_dmabuf_fd_fn_t get_dmabuf_fd = NULL;
 
-        resource->hints = efa_unit_test_alloc_hints(FI_EP_RDM);
-        assert_non_null(resource->hints);
+	mr_attr.iface = iface;
+	mr_attr.access = FI_SEND | FI_RECV;
 
-        ret = fi_getinfo(FI_VERSION(1, 14), NULL, NULL, 0ULL, resource->hints, &resource->info);
-        assert_int_equal(ret, 0);
+	if (require_dmabuf) {
+		mr_dmabuf.base_addr = (void *) buf;
+		mr_dmabuf.len = bufsize;
+		mr_attr.dmabuf = &mr_dmabuf;
+		flags |= FI_MR_DMABUF;
+	} else {
+		iov.iov_base = (void *) buf;
+		iov.iov_len = bufsize;
+		mr_attr.iov_count = 1;
+		mr_attr.mr_iov = &iov;
+	}
 
-        ret = fi_fabric(resource->info->fabric_attr, &resource->fabric, NULL);
-        assert_int_equal(ret, 0);
+	/* Override global attributes */
+	get_dmabuf_fd = hmem_ops[iface].get_dmabuf_fd;
+	hmem_ops[iface].get_dmabuf_fd = efa_mock_get_dmabuf_fd_set_errno_return_mock;
+	iface_initialized = hmem_ops[iface].initialized;
+	hmem_ops[iface].initialized = true;
 
-        neuron_initialized_orig = hmem_ops[FI_HMEM_NEURON].initialized;
-        hmem_ops[FI_HMEM_NEURON].initialized = true;
-        efa_device_caps_orig = g_device_list[0].device_caps;
-        g_device_list[0].device_caps |= EFADV_DEVICE_ATTR_CAPS_RDMA_READ;
-        g_efa_unit_test_mocks.neuron_alloc = &efa_mock_neuron_alloc_return_null;
+	resource->hints = efa_unit_test_alloc_hints(FI_EP_RDM);
+	efa_unit_test_resource_construct_with_hints(resource, FI_EP_RDM, FI_VERSION(1, 20),
+	                                            resource->hints, true, true);
 
-        ret = fi_domain(resource->fabric, resource->info, &resource->domain, NULL);
-
-        /* recover the modified global variables before doing check */
-        hmem_ops[FI_HMEM_NEURON].initialized = neuron_initialized_orig;
-        g_device_list[0].device_caps = efa_device_caps_orig;
-
-        assert_int_equal(ret, 0);
-        efa_domain = container_of(resource->domain, struct efa_domain,
+	efa_domain = container_of(resource->domain, struct efa_domain,
 				  util_domain.domain_fid.fid);
-        assert_false(efa_domain->hmem_info[FI_HMEM_NEURON].initialized);
-        assert_false(efa_domain->hmem_info[FI_HMEM_NEURON].p2p_supported_by_device);
-}
+
+	assert_true(efa_domain->hmem_info[iface].initialized);
+	assert_true(efa_domain->hmem_info[iface].p2p_supported_by_device);
+	/* Force domain to support FI_HMEM so we can test on any platform */
+	efa_domain->util_domain.info_domain_caps |= FI_HMEM;
+
+	/* Required during cleanup */
+	g_efa_unit_test_mocks.ibv_dereg_mr = efa_mock_ibv_dereg_mr_return_mock_for_dummy_mr;
+	will_return_maybe(efa_mock_ibv_dereg_mr_return_mock_for_dummy_mr, 0);
+
+	if (expect_ibv_reg_dmabuf_mr && !require_dmabuf) {
+		will_return(efa_mock_get_dmabuf_fd_set_errno_return_mock,
+			    dmabuf_fd_supported ? FI_SUCCESS : -FI_EOPNOTSUPP);
+	}
+
+#if HAVE_EFA_DMABUF_MR
+	g_efa_unit_test_mocks.ibv_reg_dmabuf_mr =
+		efa_mock_ibv_reg_dmabuf_mr_set_eopnotsupp_and_return_mock;
+	if ((expect_ibv_reg_dmabuf_mr && dmabuf_fd_supported) || require_dmabuf) {
+		will_return(
+			efa_mock_ibv_reg_dmabuf_mr_set_eopnotsupp_and_return_mock,
+			dmabuf_mr_supported ? &ibv_mr : NULL);
+	}
 #else
-void test_efa_hmem_info_update_neuron()
-{
-        skip();
+	assert_false(dmabuf_mr_supported);
+#endif /* HAVE_EFA_DMABUF_MR */
+
+	if (expect_ibv_reg_mr) {
+		/* Fallback to ibv_reg_mr */
+		if (ibv_reg_mr_supported) {
+			g_efa_unit_test_mocks.ibv_reg_mr_iova2 =
+					efa_mock_ibv_reg_mr_iova2_success_return_mock_for_dummy_addr;
+			will_return_maybe(
+				efa_mock_ibv_reg_mr_iova2_success_return_mock_for_dummy_addr,
+				&ibv_mr);
+			g_efa_unit_test_mocks.ibv_reg_mr_fn =
+				efa_mock_ibv_reg_mr_success_return_mock_for_dummy_addr;
+			will_return_maybe(
+				efa_mock_ibv_reg_mr_return_mock_for_dummy_addr,
+				&ibv_mr);
+		} else {
+			g_efa_unit_test_mocks.ibv_reg_mr_iova2 =
+					efa_mock_ibv_reg_mr_iova2_einval_return_mock_for_dummy_addr;
+			will_return_maybe(
+				efa_mock_ibv_reg_mr_iova2_einval_return_mock_for_dummy_addr,
+				NULL);
+			g_efa_unit_test_mocks.ibv_reg_mr_fn =
+				efa_mock_ibv_reg_mr_einval_return_mock_for_dummy_addr;
+			will_return_maybe(
+				efa_mock_ibv_reg_mr_einval_return_mock_for_dummy_addr,
+				NULL);
+		}
+	}
+
+	assert_int_equal(0, g_efa_unit_test_mocks.ibv_reg_mr_calls);
+
+	ret = fi_mr_regattr(resource->domain, &mr_attr, flags, &mr);
+
+	if (expect_ibv_reg_mr) {
+		assert_int_equal(1, g_efa_unit_test_mocks.ibv_reg_mr_calls);
+	}
+
+	assert_int_equal(expect_p2p_support, efa_domain->hmem_info[iface].p2p_supported_by_device);
+
+	/* Reset global attributes */
+	hmem_ops[iface].get_dmabuf_fd = get_dmabuf_fd;
+	hmem_ops[iface].initialized = iface_initialized;
+
+	if (should_succeed) {
+		assert_int_equal(ret, FI_SUCCESS);
+	} else {
+		assert_int_not_equal(ret, FI_SUCCESS);
+	}
+
+	if (mr) {
+		fi_close((fid_t) &mr->fid);
+	}
 }
-#endif /* HAVE_NEURON */
+
+/**
+ * System memory does not support dmabuf so it should always use ibv_reg_mr
+ */
+void test_efa_system_always_ibv_reg_mr(struct efa_resource **state)
+{
+	test_efa_dmabuf_support(state, FI_HMEM_SYSTEM, false, false, false, true, true, false, true, true);
+}
+
+/**
+ * Unless FI_MR_DMABUF is required CUDA should always use ibv_reg_mr
+ */
+void test_efa_cuda_dmabuf_support_always_ibv_reg_mr(struct efa_resource **state)
+{
+	test_efa_dmabuf_support(state, FI_HMEM_CUDA, false, false, false, true, true, false, true, true);
+}
+
+/**
+ * P2P is not required for FI_VERSION >= 1.18, and CUDA ibv_reg_mr
+ * is allowed to fail and fallback to keygen.
+ */
+void test_efa_cuda_dmabuf_support_ibv_reg_mr_fail_fallback_keygen(struct efa_resource **state)
+{
+	test_efa_dmabuf_support(state, FI_HMEM_CUDA, false, false, false, false, true, false, false, true);
+}
+
+/**
+ * If dmabuf is NOT supported, but the application still requires FI_MR_DMABUF,
+ * we should respect application's request and use ibv_reg_dmabuf_mr.
+ * This is a theoretical corner case to allow application override.
+ */
+void test_efa_cuda_dmabuf_support_require_dmabuf_fail_no_fallback(struct efa_resource **state)
+{
+	test_efa_dmabuf_support(state, FI_HMEM_CUDA, true, false, false, true, false, true, false, false);
+}
+
+/**
+ * Verify dmabuf is supported lazily for the HMEM iface
+ */
+void test_efa_neuron_dmabuf_support_dmabuf_success(struct efa_resource **state)
+{
+	test_efa_dmabuf_support(state, FI_HMEM_NEURON, false, true, true, true, false, true, true, true);
+}
+
+/**
+ * If dmabuf fd cannot be retrieved, verify dmabuf is not supported lazily
+ * for the HMEM iface
+ */
+void test_efa_neuron_dmabuf_support_get_fd_fail_fallback(struct efa_resource **state)
+{
+	test_efa_dmabuf_support(state, FI_HMEM_NEURON, false, false, false, true, true, true, true, true);
+}
+
+/**
+ * If ibv_reg_dmabuf_mr fails, verify dmabuf is not supported lazily
+ * for the HMEM iface
+ */
+void test_efa_neuron_dmabuf_support_mr_fail_no_fallback(struct efa_resource **state)
+{
+	test_efa_dmabuf_support(state, FI_HMEM_NEURON, false, true, false, true, false, true, true, false);
+}
+
+/**
+ * If dmabuf is NOT supported, but the application still requires FI_MR_DMABUF,
+ * we should respect application's request and use ibv_reg_dmabuf_mr.
+ * This is a theoretical corner case to allow application override.
+ */
+void test_efa_neuron_dmabuf_support_require_dmabuf_fail_no_fallback(struct efa_resource **state)
+{
+	test_efa_dmabuf_support(state, FI_HMEM_NEURON, true, false, false, true, false, true, true, false);
+}
+
+/**
+ * If dmabuf is supported we should always use ibv_reg_dmabuf_mr,
+ * even if it fails unexpctedly
+ */
+void test_efa_synapseai_dmabuf_support_fd_fail_no_fallback(struct efa_resource **state)
+{
+	test_efa_dmabuf_support(state, FI_HMEM_SYNAPSEAI, false, false, false, true, false, true, true, false);
+}

--- a/prov/efa/test/efa_unit_test_mocks.c
+++ b/prov/efa/test/efa_unit_test_mocks.c
@@ -35,6 +35,74 @@ int efa_mock_efadv_query_device_return_mock(struct ibv_context *ibv_ctx,
 	return mock();
 }
 
+struct ibv_mr *__wrap_ibv_reg_mr(struct ibv_pd *pd, void *addr, size_t length,
+                                 int access)
+{
+	return g_efa_unit_test_mocks.ibv_reg_mr_fn(pd, addr, length, access);
+}
+
+struct ibv_mr *efa_mock_ibv_reg_mr_success_return_mock_for_dummy_addr(struct ibv_pd *pd, void *addr,
+                                                                      size_t length, int access)
+{
+	++g_efa_unit_test_mocks.ibv_reg_mr_calls;
+	if ((uint64_t) addr != g_efa_unit_test_mocks.dummy_address) {
+		return __real_ibv_reg_mr(pd, addr, length, access);
+	}
+	return (struct ibv_mr *) mock();
+}
+
+struct ibv_mr *efa_mock_ibv_reg_mr_einval_return_mock_for_dummy_addr(struct ibv_pd *pd, void *addr,
+                                                                     size_t length, int access)
+{
+	++g_efa_unit_test_mocks.ibv_reg_mr_calls;
+	if ((uint64_t) addr != g_efa_unit_test_mocks.dummy_address) {
+		return __real_ibv_reg_mr(pd, addr, length, access);
+	}
+	errno = EINVAL;
+	return (struct ibv_mr *) mock();
+}
+
+struct ibv_mr *__wrap_ibv_reg_mr_iova2(struct ibv_pd *pd, void *addr,
+				       size_t length, uint64_t iova,
+				       unsigned int access)
+{
+	return g_efa_unit_test_mocks.ibv_reg_mr_iova2(pd, addr, length, iova, access);
+}
+
+struct ibv_mr *efa_mock_ibv_reg_mr_iova2_success_return_mock_for_dummy_addr(struct ibv_pd *pd, void *addr,
+                                                                            size_t length, uint64_t iova,
+                                                                            unsigned int access)
+{
+	++g_efa_unit_test_mocks.ibv_reg_mr_calls;
+	if ((uint64_t) addr != g_efa_unit_test_mocks.dummy_address) {
+		return __real_ibv_reg_mr_iova2(pd, addr, length, iova, access);
+	}
+	return (struct ibv_mr *) mock();
+}
+
+struct ibv_mr *efa_mock_ibv_reg_mr_iova2_einval_return_mock_for_dummy_addr(struct ibv_pd *pd, void *addr,
+                                                                         size_t length, uint64_t iova,
+                                                                         unsigned int access)
+{
+	++g_efa_unit_test_mocks.ibv_reg_mr_calls;
+	if ((uint64_t) addr != g_efa_unit_test_mocks.dummy_address) {
+		return __real_ibv_reg_mr_iova2(pd, addr, length, iova, access);
+	}
+	errno = EINVAL;
+	return (struct ibv_mr *) mock();
+}
+
+int __wrap_ibv_dereg_mr(struct ibv_mr *ibv_mr) {
+	return g_efa_unit_test_mocks.ibv_dereg_mr(ibv_mr);
+}
+
+int efa_mock_ibv_dereg_mr_return_mock_for_dummy_mr(struct ibv_mr *ibv_mr)
+{
+	if (ibv_mr->pd) {
+		return __real_ibv_dereg_mr(ibv_mr);
+	}
+	return mock();
+}
 
 /**
  * @brief a list of work requests request's WR ID
@@ -193,15 +261,17 @@ ssize_t efa_mock_ofi_copy_from_hmem_iov_inc_counter(void *dest, size_t size,
 }
 
 struct efa_unit_test_mocks g_efa_unit_test_mocks = {
+	.dummy_address = -1,
 	.local_host_id = 0,
 	.peer_host_id = 0,
 	.ibv_create_ah = __real_ibv_create_ah,
 	.efadv_query_device = __real_efadv_query_device,
+	.ibv_reg_mr_calls = 0,
+	.ibv_reg_mr_fn = __real_ibv_reg_mr,
+	.ibv_reg_mr_iova2 = __real_ibv_reg_mr_iova2,
+	.ibv_dereg_mr = __real_ibv_dereg_mr,
 #if HAVE_EFADV_CQ_EX
 	.efadv_create_cq = __real_efadv_create_cq,
-#endif
-#if HAVE_NEURON
-	.neuron_alloc = __real_neuron_alloc,
 #endif
 	.ofi_copy_from_hmem_iov = __real_ofi_copy_from_hmem_iov,
 	.ibv_is_fork_initialized = __real_ibv_is_fork_initialized,
@@ -210,6 +280,9 @@ struct efa_unit_test_mocks g_efa_unit_test_mocks = {
 #endif
 #if HAVE_EFA_DATA_IN_ORDER_ALIGNED_128_BYTES
 	.ibv_query_qp_data_in_order = __real_ibv_query_qp_data_in_order,
+#endif
+#if HAVE_EFA_DMABUF_MR
+	.ibv_reg_dmabuf_mr = __real_ibv_reg_dmabuf_mr,
 #endif
 };
 
@@ -294,18 +367,6 @@ struct ibv_cq_ex *efa_mock_efadv_create_cq_set_eopnotsupp_and_return_null(struct
 }
 #endif
 
-#if HAVE_NEURON
-void *__wrap_neuron_alloc(void **handle, size_t size)
-{
-	return g_efa_unit_test_mocks.neuron_alloc(handle, size);
-}
-
-void *efa_mock_neuron_alloc_return_null(void **handle, size_t size)
-{
-	return NULL;
-}
-#endif
-
 ssize_t __wrap_ofi_copy_from_hmem_iov(void *dest, size_t size,
 				      enum fi_hmem_iface hmem_iface, uint64_t device,
 				      const struct iovec *hmem_iov,
@@ -380,5 +441,27 @@ int efa_mock_ibv_query_qp_data_in_order_return_0(struct ibv_qp *qp, enum ibv_wr_
 int efa_mock_ibv_query_qp_data_in_order_return_in_order_aligned_128_bytes(struct ibv_qp *qp, enum ibv_wr_opcode op, uint32_t flags)
 {
 	return IBV_QUERY_QP_DATA_IN_ORDER_ALIGNED_128_BYTES;
+}
+#endif
+
+int efa_mock_get_dmabuf_fd_set_errno_return_mock(const void *addr, uint64_t size, int *fd,
+				       uint64_t *offset)
+{
+	int ret = mock();
+	errno = ret;
+	*fd = 0;
+	*offset = 0;
+	return ret;
+}
+
+#if HAVE_EFA_DMABUF_MR
+struct ibv_mr *__wrap_ibv_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset, size_t length, uint64_t iova, int fd, int access)
+{
+	return g_efa_unit_test_mocks.ibv_reg_dmabuf_mr(pd, offset, length, iova, fd, access);
+}
+
+struct ibv_mr *efa_mock_ibv_reg_dmabuf_mr_set_eopnotsupp_and_return_mock(struct ibv_pd *pd, uint64_t offset, size_t length, uint64_t iova, int fd, int access) {
+	errno = -FI_EOPNOTSUPP;
+	return (struct ibv_mr *) mock();
 }
 #endif

--- a/prov/efa/test/efa_unit_test_mocks.h
+++ b/prov/efa/test/efa_unit_test_mocks.h
@@ -6,6 +6,8 @@
 
 extern struct efa_unit_test_mocks g_efa_unit_test_mocks;
 
+typedef int (*get_dmabuf_fd_fn_t)(const void *addr, uint64_t size, int *fd, uint64_t *offset);
+
 struct efa_mock_ibv_send_wr_list
 {
 	struct ibv_send_wr *head;
@@ -23,6 +25,26 @@ int __real_efadv_query_device(struct ibv_context *ibvctx, struct efadv_device_at
 
 int efa_mock_efadv_query_device_return_mock(struct ibv_context *ibvctx, struct efadv_device_attr *attr,
 					    uint32_t inlen);
+
+struct ibv_mr *__real_ibv_reg_mr(struct ibv_pd *pd, void *addr, size_t length,
+                                 int access);
+
+struct ibv_mr *efa_mock_ibv_reg_mr_success_return_mock_for_dummy_addr(struct ibv_pd *pd, void *addr,
+                                                                      size_t length, int access);
+struct ibv_mr *efa_mock_ibv_reg_mr_einval_return_mock_for_dummy_addr(struct ibv_pd *pd, void *addr,
+                                                                     size_t length, int access);
+
+struct ibv_mr *__real_ibv_reg_mr_iova2(struct ibv_pd *pd, void *addr, size_t length, uint64_t iova,
+                                       unsigned int access);
+struct ibv_mr *efa_mock_ibv_reg_mr_iova2_success_return_mock_for_dummy_addr(struct ibv_pd *pd, void *addr,
+                                                                            size_t length, uint64_t iova,
+                                                                            unsigned int access);
+struct ibv_mr *efa_mock_ibv_reg_mr_iova2_einval_return_mock_for_dummy_addr(struct ibv_pd *pd, void *addr,
+                                                                           size_t length, uint64_t iova,
+                                                                           unsigned int access);
+
+int __real_ibv_dereg_mr(struct ibv_mr *ibv_mr);
+int efa_mock_ibv_dereg_mr_return_mock_for_dummy_mr(struct ibv_mr *ibv_mr);
 
 extern void *g_ibv_submitted_wr_id_vec[EFA_RDM_EP_MAX_WR_PER_IBV_POST_SEND];
 
@@ -85,28 +107,35 @@ ssize_t efa_mock_ofi_copy_from_hmem_iov_inc_counter(void *dest, size_t size,
 
 struct efa_unit_test_mocks
 {
+	uint64_t dummy_address;
 	uint64_t local_host_id;
 	uint64_t peer_host_id;
 	struct ibv_ah *(*ibv_create_ah)(struct ibv_pd *pd, struct ibv_ah_attr *attr);
 
 	int (*efadv_query_device)(struct ibv_context *ibvctx, struct efadv_device_attr *attr,
 							  uint32_t inlen);
+	int ibv_reg_mr_calls;
+	struct ibv_mr *(*ibv_reg_mr_fn)(struct ibv_pd *pd, void *addr, size_t length,
+	                                int access);
+	struct ibv_mr *(*ibv_reg_mr_iova2)(struct ibv_pd *pd, void *addr, size_t length,
+	                                   uint64_t iova, unsigned int access);
+	int (*ibv_dereg_mr)(struct ibv_mr *mr);
 #if HAVE_EFADV_CQ_EX
 
 	struct ibv_cq_ex *(*efadv_create_cq)(struct ibv_context *ibvctx,
-										 struct ibv_cq_init_attr_ex *attr_ex,
-										 struct efadv_cq_init_attr *efa_attr,
-										 uint32_t inlen);
-#endif
-
-#if HAVE_NEURON
-	void *(*neuron_alloc)(void **handle, size_t size);
+	                                     struct ibv_cq_init_attr_ex *attr_ex,
+	                                     struct efadv_cq_init_attr *efa_attr,
+	                                     uint32_t inlen);
 #endif
 
 	ssize_t (*ofi_copy_from_hmem_iov)(void *dest, size_t size,
 					  enum fi_hmem_iface hmem_iface, uint64_t device,
 					  const struct iovec *hmem_iov,
 					  size_t hmem_iov_count, uint64_t hmem_iov_offset);
+
+	int (*ofi_hmem_get_dmabuf_fd)(enum fi_hmem_iface iface,
+				      const void *addr, uint64_t size, int *fd,
+				      uint64_t *offset);
 
 	enum ibv_fork_status (*ibv_is_fork_initialized)(void);
 
@@ -116,6 +145,11 @@ struct efa_unit_test_mocks
 
 #if HAVE_EFA_DATA_IN_ORDER_ALIGNED_128_BYTES
 	int (*ibv_query_qp_data_in_order)(struct ibv_qp *qp, enum ibv_wr_opcode op, uint32_t flags);
+#endif
+
+#if HAVE_EFA_DMABUF_MR
+	struct ibv_mr *(*ibv_reg_dmabuf_mr)(struct ibv_pd *pd, uint64_t offset, size_t length, uint64_t iova,
+	                                    int fd, int access);
 #endif
 };
 
@@ -144,11 +178,6 @@ struct ibv_cq_ex *efa_mock_efadv_create_cq_set_eopnotsupp_and_return_null(struct
 																		  uint32_t inlen);
 #endif
 
-#if HAVE_NEURON
-void *__real_neuron_alloc(void **handle, size_t size);
-void *efa_mock_neuron_alloc_return_null(void **handle, size_t size);
-#endif
-
 #if HAVE_EFADV_QUERY_MR
 int __real_efadv_query_mr(struct ibv_mr *ibv_mr, struct efadv_mr_attr *attr, uint32_t inlen);
 int efa_mock_efadv_query_mr_recv_ic_id_0(struct ibv_mr *ibv_mr, struct efadv_mr_attr *attr, uint32_t inlen);
@@ -161,6 +190,13 @@ int efa_mock_efadv_query_mr_recv_and_rdma_read_ic_id_0_1(struct ibv_mr *ibv_mr, 
 int __real_ibv_query_qp_data_in_order(struct ibv_qp *qp, enum ibv_wr_opcode op, uint32_t flags);
 int efa_mock_ibv_query_qp_data_in_order_return_0(struct ibv_qp *qp, enum ibv_wr_opcode op, uint32_t flags);
 int efa_mock_ibv_query_qp_data_in_order_return_in_order_aligned_128_bytes(struct ibv_qp *qp, enum ibv_wr_opcode op, uint32_t flags);
+#endif
+
+int efa_mock_get_dmabuf_fd_set_errno_return_mock(const void *addr, uint64_t size, int *fd, uint64_t *offset);
+
+#if HAVE_EFA_DMABUF_MR
+struct ibv_mr *__real_ibv_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset, size_t length, uint64_t iova, int fd, int access);
+struct ibv_mr *efa_mock_ibv_reg_dmabuf_mr_set_eopnotsupp_and_return_mock(struct ibv_pd *pd, uint64_t offset, size_t length, uint64_t iova, int fd, int access);
 #endif
 
 enum ibv_fork_status __real_ibv_is_fork_initialized(void);

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -46,18 +46,23 @@ static int efa_unit_test_mocks_teardown(void **state)
 	efa_ibv_submitted_wr_id_vec_clear();
 
 	g_efa_unit_test_mocks = (struct efa_unit_test_mocks) {
+		.dummy_address = -1,
 		.local_host_id = 0,
 		.peer_host_id = 0,
 		.ibv_create_ah = __real_ibv_create_ah,
 		.efadv_query_device = __real_efadv_query_device,
+		.ibv_reg_mr_calls = 0,
+		.ibv_reg_mr_fn = __real_ibv_reg_mr,
+		.ibv_reg_mr_iova2 = __real_ibv_reg_mr_iova2,
+		.ibv_dereg_mr = __real_ibv_dereg_mr,
 #if HAVE_EFADV_CQ_EX
 		.efadv_create_cq = __real_efadv_create_cq,
 #endif
-#if HAVE_NEURON
-		.neuron_alloc = __real_neuron_alloc,
-#endif
 		.ofi_copy_from_hmem_iov = __real_ofi_copy_from_hmem_iov,
 		.ibv_is_fork_initialized = __real_ibv_is_fork_initialized,
+#if HAVE_EFA_DMABUF_MR
+		.ibv_reg_dmabuf_mr = __real_ibv_reg_dmabuf_mr,
+#endif
 	};
 
 	/* Reset environment */
@@ -138,7 +143,6 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_use_device_rdma_opt1, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_use_device_rdma_opt0, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_use_device_rdma_opt_old, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
-		cmocka_unit_test_setup_teardown(test_efa_hmem_info_update_neuron, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_srx_min_multi_recv_size, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_srx_cq, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_srx_lock, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
@@ -148,8 +152,7 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ope_prepare_to_post_send_host_memory_align128, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ope_prepare_to_post_send_cuda_memory, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ope_prepare_to_post_send_cuda_memory_align128, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
-		cmocka_unit_test_setup_teardown(test_efa_rdm_ope_post_write_0_byte,
-		efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_rdm_ope_post_write_0_byte, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_msg_send_to_local_peer_with_null_desc, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_fork_support_request_initialize_when_ibv_fork_support_is_needed, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_fork_support_request_initialize_when_ibv_fork_support_is_unneeded, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
@@ -174,6 +177,15 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_rdm_cntr_ibv_cq_poll_list_same_tx_rx_cq_single_ep, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_cntr_ibv_cq_poll_list_separate_tx_rx_cq_single_ep, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_cntr_post_initial_rx_pkts, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_system_always_ibv_reg_mr, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_cuda_dmabuf_support_always_ibv_reg_mr, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_cuda_dmabuf_support_ibv_reg_mr_fail_fallback_keygen, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_cuda_dmabuf_support_require_dmabuf_fail_no_fallback, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_neuron_dmabuf_support_dmabuf_success, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_neuron_dmabuf_support_get_fd_fail_fallback, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_neuron_dmabuf_support_mr_fail_no_fallback, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_neuron_dmabuf_support_require_dmabuf_fail_no_fallback, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_synapseai_dmabuf_support_fd_fail_no_fallback, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 	};
 
 	cmocka_set_message_output(CM_OUTPUT_XML);

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -143,7 +143,6 @@ void test_info_check_shm_info_threading();
 void test_info_check_hmem_cuda_support_on_api_lt_1_18();
 void test_info_check_hmem_cuda_support_on_api_ge_1_18();
 void test_info_check_no_hmem_support_when_not_requested();
-void test_efa_hmem_info_update_neuron();
 void test_efa_use_device_rdma_env1_opt1();
 void test_efa_use_device_rdma_env0_opt0();
 void test_efa_use_device_rdma_env1_opt0();
@@ -188,6 +187,15 @@ void test_efa_rdm_cq_post_initial_rx_pkts();
 void test_efa_rdm_cntr_ibv_cq_poll_list_same_tx_rx_cq_single_ep();
 void test_efa_rdm_cntr_ibv_cq_poll_list_separate_tx_rx_cq_single_ep();
 void test_efa_cntr_post_initial_rx_pkts();
+void test_efa_system_always_ibv_reg_mr();
+void test_efa_neuron_dmabuf_support_dmabuf_success();
+void test_efa_neuron_dmabuf_support_get_fd_fail_fallback();
+void test_efa_neuron_dmabuf_support_mr_fail_no_fallback();
+void test_efa_cuda_dmabuf_support_always_ibv_reg_mr();
+void test_efa_cuda_dmabuf_support_ibv_reg_mr_fail_fallback_keygen();
+void test_efa_synapseai_dmabuf_support_fd_fail_no_fallback();
+void test_efa_cuda_dmabuf_support_require_dmabuf_fail_no_fallback();
+void test_efa_neuron_dmabuf_support_require_dmabuf_fail_no_fallback();
 
 static inline
 int efa_unit_test_get_dlist_length(struct dlist_entry *head)


### PR DESCRIPTION
This patch removes the eager device memory registration with EFA device during domain initialization; instead, we assume P2P is supported by the device, and delay the check until the 1st fi_mr_reg* API call.

As a result, we have to delay the dmabuf support status check to the 1st
application fi_mr_reg* call:
- If the application requests FI_MR_DMABUF, we will always use ibv_reg_dmabuf_mr
- If the memory region is on system or CUDA device, we will always use ibv_reg_mr
- If the memory region is on Gaudi device, we will always use ibv_reg_dmabuf_mr
- If the memory region is on Neuron device, we will first attempt to export the dmabuf fd: 1) if fd is available we will proceed to use ibv_reg_dmabuf_mr, 2) if dmabuf fd is not supported then we will fallback to ibv_reg_mr

There is a special case for FI_HMEM_CUDA. For FI_VERSION >= 1.18, P2P is no longer required, and therefore ibv_reg_{dmabuf_}mr is allowed to fail. EFA provider will fallback to generate a MR key, and continue to support CUDA memory copies.