### PR TITLE
Opx bug fixes for 1.22.x

### DIFF
--- a/prov/opx/include/rdma/opx/fi_opx_hfi1_sdma.h
+++ b/prov/opx/include/rdma/opx/fi_opx_hfi1_sdma.h
@@ -508,8 +508,10 @@ int opx_hfi1_sdma_enqueue_request(struct fi_opx_ep *opx_ep,
 	request->fill_index = OPX_SDMA_FILL_INDEX_INVALID;
 	request->set_meminfo = set_meminfo;
 
+	/* Set the Acknowledge Request Bit if we're only sending one packet */
+	uint64_t set_ack_bit = (num_packets == 1) ? (uint64_t)htonl(0x80000000) : 0;
 	request->header_vec.scb = *source_scb;
-	request->header_vec.scb.hdr.qw[2] |= ((uint64_t)kdeth << 32);
+	request->header_vec.scb.hdr.qw[2] |= ((uint64_t)kdeth << 32) | set_ack_bit;
 	request->header_vec.scb.hdr.qw[4] |= (last_packet_bytes << 32);
 
 	request->iovecs[0].iov_len = OPX_SDMA_REQ_HDR_SIZE[set_meminfo];

--- a/prov/opx/src/fi_opx_hfi1.c
+++ b/prov/opx/src/fi_opx_hfi1.c
@@ -152,8 +152,9 @@ static int opx_open_hfi_and_context(struct _hfi_ctrl **ctrl,
 				"Unable to open a context on HFI unit %d.\n",
 				hfi_unit_number);
 			fd = -1;
+		} else {
+			assert((*ctrl)->__hfi_pg_sz == OPX_HFI1_TID_PAGESIZE);
 		}
-		assert((*ctrl)->__hfi_pg_sz == OPX_HFI1_TID_PAGESIZE);
 	}
 	return fd;
 }


### PR DESCRIPTION
Cornelis Networks bug fixes for v1.22.x:

- Improve performance by setting ACK bit when sending a single SDMA packet;
- Assert fix.