### PR TITLE
fabtests/pytest/shm: reduce the msg size in test_unexpected_msg

### DIFF
--- a/fabtests/pytest/shm/test_unexpected_msg.py
+++ b/fabtests/pytest/shm/test_unexpected_msg.py
@@ -6,7 +6,7 @@ SHM_DEFAULT_RX_SIZE = 1024
 
 
 @pytest.mark.functional
-@pytest.mark.parametrize("msg_size", [1, 512, 9000, 1048576]) # cover various switch points of shm/efa protocols
+@pytest.mark.parametrize("msg_size", [1, 512, 9000]) # cover various switch points of shm protocols
 @pytest.mark.parametrize("msg_count", [1, 1024, 2048]) # below and above shm's default rx size
 def test_unexpected_msg(cmdline_args, msg_size, msg_count, memory_type, completion_semantic):
     from common import ClientServerTest


### PR DESCRIPTION
It is observed 1M caused some OOM error for some cuda allocation, 9000 should be big enough as it exceeds the shm's inject size.