### PR TITLE
prov/verbs: Replace __BITS_PER_LONG with LONG_WIDTH

### DIFF
--- a/prov/verbs/configure.m4
+++ b/prov/verbs/configure.m4
@@ -44,6 +44,8 @@ AC_DEFUN([FI_VERBS_CONFIGURE],[
 
 	      ])
 
+	AC_CHECK_HEADERS([asm/types.h])
+
 	AS_IF([test $verbs_ibverbs_happy -eq 1 && \
 	       test $verbs_rdmacm_happy -eq 1], [$1], [$2])
 

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -1999,7 +1999,7 @@ check_datatype:
 	switch (datatype) {
 	case FI_INT64:
 	case FI_UINT64:
-#if __BITS_PER_LONG == 64
+#if LONG_WIDTH == 64
 	case FI_DOUBLE:
 	case FI_FLOAT:
 #endif

--- a/prov/verbs/src/verbs_ofi.h
+++ b/prov/verbs/src/verbs_ofi.h
@@ -39,7 +39,6 @@
 
 #include "config.h"
 
-#include <asm/types.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <arpa/inet.h>
@@ -79,6 +78,22 @@
 
 #include "ofi_verbs_compat.h"
 
+/* define LONG_WIDTH used by atomics */
+#include <limits.h>
+#ifndef LONG_WIDTH
+#ifdef LONG_BIT
+#define LONG_WIDTH LONG_BIT
+#elif defined(HAVE_ASM_TYPES_H)
+#include <asm/types.h>
+#define LONG_WIDTH __BITS_PER_LONG
+#elif defined(__x86_64__) || defined(__aarch64__)
+#ifndef __ILP32__
+#define LONG_WIDTH 64
+#else
+#define LONG_WIDTH 32
+#endif
+#endif
+#endif
 
 #ifndef AF_IB
 #define AF_IB 27


### PR DESCRIPTION
~The checks for the verbs provider can pass on a FreeBSD system, but will fail to compile because asm/types.h is not available.~

Updated description: 2024-08-01
The verbs provider uses asm/types.h for __BITS_PER_LONG, but that header
is limited to Linux systems. LONG_WIDTH is defined in C23 in
limits.h. Use it instead, and add logic to define it if not
available. This will allow the verbs provider to compile on FreeBSD
systems.