### PR TITLE
prov/efa: Require FI_MSG_PREFIX mode for zero-copy receive.

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -452,6 +452,13 @@ void efa_rdm_ep_set_use_zcpy_rx(struct efa_rdm_ep *ep)
 		goto out;
 	}
 
+	/* Unsupported capabilities */
+	if (!(ep->user_info->mode & FI_MSG_PREFIX)) {
+		EFA_INFO(FI_LOG_EP_CTRL, "FI_MSG_PREFIX capability is not requested. Zero-copy receive protocol will be disabled\n");
+		ep->use_zcpy_rx = false;
+		goto out;
+	}
+
 	/* Max msg size is too large, turn off zcpy recv */
 	if (ep->max_msg_size > ep->mtu_size - ep->user_info->ep_attr->msg_prefix_size) {
 		EFA_INFO(FI_LOG_EP_CTRL, "max_msg_size (%zu) is greater than the mtu size limit: %zu. Zero-copy receive protocol will be disabled.\n",

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -1035,12 +1035,13 @@ void test_efa_rdm_ep_zcpy_recv_cancel(struct efa_resource **state)
 	resource->hints->tx_attr->msg_order = FI_ORDER_NONE;
 	resource->hints->rx_attr->msg_order = FI_ORDER_NONE;
 	resource->hints->caps = FI_MSG;
+	resource->hints->mode = FI_MSG_PREFIX;
 
 	/* enable zero-copy recv mode in ep */
 	test_efa_rdm_ep_use_zcpy_rx_impl(resource, true);
 
 	/* Construct a recv buffer with mr */
-	efa_unit_test_buff_construct(&recv_buff, resource, 16);
+	efa_unit_test_buff_construct(&recv_buff, resource, EFA_RDM_MSG_PREFIX_SIZE + 16);
 
 	assert_int_equal(fi_recv(resource->ep, recv_buff.buff, recv_buff.size, fi_mr_desc(recv_buff.mr), FI_ADDR_UNSPEC, &cancel_context), 0);
 


### PR DESCRIPTION
Due to the lack of recv cancel support on HW, it is not safe to enable zero copy receive. Add back the FI_MSG_PREFIX mode requirement to keep zero copy receive enabled only for the legacy prefix mode.