### PR TITLE
prov/util: Initialize ROCR name in memory monitor struct

### DIFF
--- a/prov/util/src/rocr_mem_monitor.c
+++ b/prov/util/src/rocr_mem_monitor.c
@@ -72,6 +72,7 @@ static struct rocr_mm rocr_mm = {
 		.subscribe = rocr_mm_subscribe,
 		.unsubscribe = rocr_mm_unsubscribe,
 		.valid = rocr_mm_valid,
+		.name = "rocr",
 	},
 };
 


### PR DESCRIPTION
The name field in struct ofi_mem_monitor was not set in the #HAVE_ROCR case.  This update initializes the name to "rocr" in the rocr_monitor.