### PR TITLE
prov/efa: refactor hmem interface initialization

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -158,6 +158,7 @@ prov_efa_test_efa_unit_test_LDFLAGS = $(cmocka_rpath) $(efa_LDFLAGS) $(cmocka_LD
 					-Wl,--wrap=ibv_create_ah \
 					-Wl,--wrap=ibv_is_fork_initialized \
 					-Wl,--wrap=efadv_query_device \
+					-Wl,--wrap=ofi_cudaMalloc \
 					-Wl,--wrap=ofi_copy_from_hmem_iov
 
 if HAVE_EFADV_CQ_EX

--- a/prov/efa/test/efa_unit_test_mocks.c
+++ b/prov/efa/test/efa_unit_test_mocks.c
@@ -203,6 +203,9 @@ struct efa_unit_test_mocks g_efa_unit_test_mocks = {
 #if HAVE_NEURON
 	.neuron_alloc = __real_neuron_alloc,
 #endif
+#if HAVE_CUDA
+	.ofi_cudaMalloc = __real_ofi_cudaMalloc,
+#endif
 	.ofi_copy_from_hmem_iov = __real_ofi_copy_from_hmem_iov,
 	.ibv_is_fork_initialized = __real_ibv_is_fork_initialized,
 #if HAVE_EFADV_QUERY_MR
@@ -303,6 +306,25 @@ void *__wrap_neuron_alloc(void **handle, size_t size)
 void *efa_mock_neuron_alloc_return_null(void **handle, size_t size)
 {
 	return NULL;
+}
+
+void *efa_mock_neuron_alloc_return_mock(void **handle, size_t size)
+{
+	/* Not mocking return value so this function will fail when it is called */
+	return (void *) mock();
+}
+#endif
+
+#if HAVE_CUDA
+cudaError_t __wrap_ofi_cudaMalloc(void **ptr, size_t size)
+{
+	return g_efa_unit_test_mocks.ofi_cudaMalloc(ptr, size);
+}
+
+cudaError_t efa_mock_ofi_cudaMalloc_return_mock(void **ptr, size_t size)
+{
+	/* Not mocking return value so this function will fail when it is called */
+	return (cudaError_t) mock();
 }
 #endif
 

--- a/prov/efa/test/efa_unit_test_mocks.h
+++ b/prov/efa/test/efa_unit_test_mocks.h
@@ -103,6 +103,10 @@ struct efa_unit_test_mocks
 	void *(*neuron_alloc)(void **handle, size_t size);
 #endif
 
+#if HAVE_CUDA
+	cudaError_t (*ofi_cudaMalloc)(void **ptr, size_t size);
+#endif
+
 	ssize_t (*ofi_copy_from_hmem_iov)(void *dest, size_t size,
 					  enum fi_hmem_iface hmem_iface, uint64_t device,
 					  const struct iovec *hmem_iov,
@@ -147,6 +151,12 @@ struct ibv_cq_ex *efa_mock_efadv_create_cq_set_eopnotsupp_and_return_null(struct
 #if HAVE_NEURON
 void *__real_neuron_alloc(void **handle, size_t size);
 void *efa_mock_neuron_alloc_return_null(void **handle, size_t size);
+void *efa_mock_neuron_alloc_return_mock(void **handle, size_t size);
+#endif
+
+#if HAVE_CUDA
+cudaError_t __real_ofi_cudaMalloc(void **ptr, size_t size);
+cudaError_t efa_mock_ofi_cudaMalloc_return_mock(void **ptr, size_t size);
 #endif
 
 #if HAVE_EFADV_QUERY_MR

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -56,6 +56,9 @@ static int efa_unit_test_mocks_teardown(void **state)
 #if HAVE_NEURON
 		.neuron_alloc = __real_neuron_alloc,
 #endif
+#if HAVE_CUDA
+		.ofi_cudaMalloc = __real_ofi_cudaMalloc,
+#endif
 		.ofi_copy_from_hmem_iov = __real_ofi_copy_from_hmem_iov,
 		.ibv_is_fork_initialized = __real_ibv_is_fork_initialized,
 	};
@@ -147,6 +150,8 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_use_device_rdma_opt0, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_use_device_rdma_opt_old, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_hmem_info_update_neuron, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_hmem_info_disable_p2p_neuron, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_hmem_info_disable_p2p_cuda, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_srx_min_multi_recv_size, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_srx_cq, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_srx_lock, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -147,6 +147,8 @@ void test_info_check_hmem_cuda_support_on_api_lt_1_18();
 void test_info_check_hmem_cuda_support_on_api_ge_1_18();
 void test_info_check_no_hmem_support_when_not_requested();
 void test_efa_hmem_info_update_neuron();
+void test_efa_hmem_info_disable_p2p_neuron();
+void test_efa_hmem_info_disable_p2p_cuda();
 void test_efa_nic_select_all_devices_matches();
 void test_efa_nic_select_first_device_matches();
 void test_efa_nic_select_first_device_with_surrounding_comma_matches();


### PR DESCRIPTION
Combine hmem init functions for different devices.
Avoid checking p2p support when p2p is disabled. FI_HMEM_DISABLE_P2P should take precedence if set.