### PR TITLE
contrib/intel/jenkins: Split jobs across nodes better & fail run_ci using script exit

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -94,13 +94,11 @@ def run_middleware(providers, stage_name, test, hw, partition, node_num,
 }
 
 def run_ci(stage_name, config_name) {
-  return sh(returnStatus: true,
-            script: """source ${CI_LOCATION}/${env.CI_MODULE}/venv/bin/activate;\
-                      python run.py \
-                      --output=${env.LOG_DIR}/${stage_name} \
-                      --job=${config_name}
-                    """
-  )
+  sh """source ${CI_LOCATION}/${env.CI_MODULE}/venv/bin/activate;\
+        python run.py \
+        --output=${env.LOG_DIR}/${stage_name} \
+        --job=${config_name}
+     """
 }
 
 def gather_logs(cluster, key, dest, source) {

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -713,7 +713,7 @@ pipeline {
             script {
               dir (RUN_LOCATION) {
                 run_middleware([["tcp", null]], "SHMEM", "shmem",
-                                "grass", "grass", "2")
+                                "grass", "bulbasaur,chikorita", "2")
               }
             }
           }
@@ -733,9 +733,10 @@ pipeline {
             script {
               dir (RUN_LOCATION) {
                 run_middleware([["tcp", null],["sockets", null]],
-			       "multinode_performance", "multinode", "grass", "grass", "2")
-		run_middleware([["verbs", "rxm"]], "multinode_performance",
-			       "multinode", "water", "totodile", "2")
+                               "multinode_performance", "multinode", "grass",
+                               "bulbasaur,chikorita", "2")
+                run_middleware([["verbs", "rxm"]], "multinode_performance",
+                               "multinode", "water", "totodile", "2")
               }
             }
           }
@@ -747,11 +748,11 @@ pipeline {
 		            run_middleware([["verbs", null]], "oneCCL",
                                "oneccl", "water", "totodile", "2")
 		            run_middleware([["shm", null]], "oneCCL",
-			                         "oneccl", "grass", "bulbasaur", "1")
+			                         "oneccl", "grass", "bulbasaur,chikorita", "1")
 		            run_middleware([["psm3", null]], "oneCCL",
 			                         "oneccl", "water", "totodile", "2")
 		            run_middleware([["tcp", null]], "oneCCL",
-			                         "oneccl", "grass", "bulbasaur", "2")
+			                         "oneccl", "grass", "bulbasaur,chikorita", "2")
                 run_middleware([["shm", null]], "oneCCL_DSA",
                                "oneccl", "electric", "pikachu", "1", null, null,
                                """CCL_ATL_SHM=1 FI_SHM_DISABLE_CMA=1 \


### PR DESCRIPTION
Let run ci script properly sys.exit(error_code) instead of using Jenkins shell command to return the error code. This will make new CI stages properly fail when a test fails or if a job config is invalid.

Separate grass tests to be on different partitions. This will prevent tests from using a node from set one with a node from set two. These sets are going to be called bulbasaur and chikorita.