### PR TITLE
man: Fix formatting for `FI_OPT_FI_HMEM_P2P` prose

### DIFF
--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -546,9 +546,10 @@ The following option levels and option names and parameters are defined.
 	  to copy the data to initiate the transfer if peer to peer support is
 	  unavailable.
 	* FI_HMEM_P2P_DISABLED: Peer to peer support should not be used.
-: fi_setopt() will return -FI_EOPNOTSUPP if the mode requested cannot be supported
+
+  fi_setopt() will return -FI_EOPNOTSUPP if the mode requested cannot be supported
   by the provider.
-: The FI_HMEM_DISABLE_P2P environment variable discussed in
+  The FI_HMEM_DISABLE_P2P environment variable discussed in
   [`fi_mr`(3)](fi_mr.3.html) takes precedence over this setopt option.
 
 - *FI_OPT_CUDA_API_PERMITTED - bool*


### PR DESCRIPTION
Otherwise, when rendered on the OFIWG site, it reads as if the restrictions only apply when the opt is set to `FI_HMEM_P2P_DISABLED`.

The formatting looks fine when previewed via GitHub - hopefully that carries over.