### PR TITLE
prov/efa: Use dlist_foreach_container_safe to iterate progressed ep list

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_cq.c
+++ b/prov/efa/src/rdm/efa_rdm_cq.c
@@ -457,7 +457,7 @@ void efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq)
 	struct efa_rdm_cq *efa_rdm_cq;
 	struct efa_domain *efa_domain;
 	struct efa_qp *qp;
-	struct dlist_entry rx_progressed_ep_list, *item;
+	struct dlist_entry rx_progressed_ep_list, *tmp;
 
 	efa_rdm_cq = container_of(ibv_cq, struct efa_rdm_cq, ibv_cq);
 	efa_domain = container_of(efa_rdm_cq->util_cq.domain, struct efa_domain, util_domain);
@@ -550,8 +550,8 @@ void efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq)
 	if (should_end_poll)
 		ibv_end_poll(ibv_cq->ibv_cq_ex);
 
-	dlist_foreach(&rx_progressed_ep_list, item) {
-		ep = container_of(item, struct efa_rdm_ep, entry);
+	dlist_foreach_container_safe(
+		&rx_progressed_ep_list, struct efa_rdm_ep, ep, entry, tmp) {
 		efa_rdm_ep_post_internal_rx_pkts(ep);
 		dlist_remove(&ep->entry);
 	}


### PR DESCRIPTION
Currently, efa_rdm_cq_poll_ibv_cq used dlist_foreach to iterate the eps, which involves the removal of ep's dlist entry. It is recommended to use dlist_foreach_*safe method to have additional tmp variable to store the entry->next pointer before dlist_remove(ep->entry). Though Libfabric's current dlist implementation doesn't really destroy ep->entry in dlist_remove, it may cause use-after-free error when the behavior changes in the future.