### PR TITLE
xpmem,shm: prefix public xpmem symbols with ofi

### DIFF
--- a/include/ofi_shm_p2p.h
+++ b/include/ofi_shm_p2p.h
@@ -78,9 +78,9 @@ ofi_shm_p2p_no_copy(struct iovec *local, unsigned long local_cnt,
 static struct ofi_shm_p2p_ops p2p_ops[] = {
 	[FI_SHM_P2P_XPMEM] = {
 		.initialized = false,
-		.init = xpmem_init,
-		.cleanup = xpmem_cleanup,
-		.copy = xpmem_copy,
+		.init = ofi_xpmem_init,
+		.cleanup = ofi_xpmem_cleanup,
+		.copy = ofi_xpmem_copy,
 	},
 	[FI_SHM_P2P_CMA] = {
 		.initialized = false,

--- a/include/ofi_xpmem.h
+++ b/include/ofi_xpmem.h
@@ -47,13 +47,13 @@ typedef int64_t xpmem_apid_t;
 typedef int64_t xpmem_segid_t;
 #endif /* HAVE_XPMEM */
 
-struct xpmem_client {
+struct ofi_xpmem_client {
 	uint8_t cap;
 	xpmem_apid_t apid;
 	uintptr_t addr_max;
 };
 
-struct xpmem_pinfo {
+struct ofi_xpmem_pinfo {
 	/* XPMEM segment id for this process */
 	xpmem_segid_t seg_id;
 	/* maximum attachment address for this process. attempts to attach
@@ -61,31 +61,30 @@ struct xpmem_pinfo {
 	uintptr_t address_max;
 };
 
-struct xpmem {
-	struct xpmem_pinfo pinfo;
+struct ofi_xpmem {
+	struct ofi_xpmem_pinfo pinfo;
 	/* maximum size that will be used with a single memcpy call.
 	 * On some systems we see better peformance if we chunk the
 	 * copy into multiple memcpy calls. */
 	uint64_t memcpy_chunk_size;
 };
 
-extern struct xpmem *xpmem;
+extern struct ofi_xpmem *xpmem;
 
 int ofi_xpmem_cache_search(struct ofi_mr_cache *cache,
 			   struct iovec *iov, uint64_t peer_id,
 			   struct ofi_mr_entry **mr_entry,
-			   struct xpmem_client *xpmem);
+			   struct ofi_xpmem_client *xpmem);
 
 int ofi_xpmem_cache_open(struct ofi_mr_cache **cache);
 void ofi_xpmem_cache_destroy(struct ofi_mr_cache *cache);
 
-int xpmem_init(void);
-int xpmem_cleanup(void);
-int xpmem_copy(struct iovec *local, unsigned long local_cnt,
-	       struct iovec *remote, unsigned long remote_cnt,
-	       size_t total, pid_t pid, bool write, void *user_data);
-int ofi_xpmem_enable(struct xpmem_pinfo *peer,
-		     struct xpmem_client *xpmem);
-void ofi_xpmem_release(struct xpmem_client *xpmem);
+int ofi_xpmem_init(void);
+int ofi_xpmem_cleanup(void);
+int ofi_xpmem_copy(struct iovec *local, unsigned long local_cnt,
+		   struct iovec *remote, unsigned long remote_cnt, size_t total,
+		   pid_t pid, bool write, void *user_data);
+int ofi_xpmem_enable(struct ofi_xpmem_pinfo *peer, struct ofi_xpmem_client *xpmem);
+void ofi_xpmem_release(struct ofi_xpmem_client *xpmem);
 
 #endif /* OFI_XPMEM_H */

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -308,7 +308,7 @@ static int smr_progress_iov(struct smr_cmd *cmd, struct iovec *iov,
 			    struct smr_ep *ep, int err)
 {
 	struct smr_region *peer_smr;
-	struct xpmem_client *xpmem;
+	struct ofi_xpmem_client *xpmem;
 	struct smr_resp *resp;
 	int ret;
 

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -62,7 +62,7 @@ static ssize_t smr_rma_fast(struct smr_ep *ep, struct smr_region *peer_smr,
 			uint32_t op, uint64_t op_flags)
 {
 	struct iovec vma_iovec[SMR_IOV_LIMIT], rma_iovec[SMR_IOV_LIMIT];
-	struct xpmem_client *xpmem;
+	struct ofi_xpmem_client *xpmem;
 	struct smr_cmd_entry *ce;
 	size_t total_len;
 	int ret, i;

--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -179,7 +179,7 @@ struct smr_peer_data {
 	uint32_t		sar_status;
 	uint16_t		name_sent;
 	uint16_t		ipc_valid;
-	struct xpmem_client 	xpmem;
+	struct ofi_xpmem_client xpmem;
 };
 
 extern struct dlist_entry ep_name_list;
@@ -231,8 +231,8 @@ struct smr_region {
 	uint8_t		resv2;
 
 	uint32_t	max_sar_buf_per_peer;
-	struct xpmem_pinfo xpmem_self;
-	struct xpmem_pinfo xpmem_peer;
+	struct ofi_xpmem_pinfo	xpmem_self;
+	struct ofi_xpmem_pinfo	xpmem_peer;
 	void		*base_addr;
 	pthread_spinlock_t	lock; /* lock for shm access
 				 if both ep->tx_lock and this lock need to

--- a/src/xpmem.c
+++ b/src/xpmem.c
@@ -42,13 +42,13 @@
 #include <stdio.h>
 
 #define XPMEM_DEFAULT_MEMCPY_CHUNK_SIZE 262144
-struct xpmem *xpmem = NULL;
+struct ofi_xpmem *xpmem = NULL;
 
 #if HAVE_XPMEM
 /* global cache for use with xpmem */
 static struct ofi_mr_cache *xpmem_cache;
 
-int xpmem_init(void)
+int ofi_xpmem_init(void)
 {
 	/* Any attachment that goes past the Linux TASK_SIZE will always
 	 * fail. To prevent this we need to determine the value of
@@ -132,7 +132,7 @@ fail:
 	return ret;
 }
 
-int xpmem_cleanup(void)
+int ofi_xpmem_cleanup(void)
 {
 	int ret = 0;
 
@@ -158,9 +158,9 @@ static inline void xpmem_memcpy(void *dst, void *src, size_t size)
 	}
 }
 
-int xpmem_copy(struct iovec *local, unsigned long local_cnt,
-	       struct iovec *remote, unsigned long remote_cnt,
-	       size_t total, pid_t pid, bool write, void *user_data)
+int ofi_xpmem_copy(struct iovec *local, unsigned long local_cnt,
+                   struct iovec *remote, unsigned long remote_cnt,
+                   size_t total, pid_t pid, bool write, void *user_data)
 {
 	int ret, i;
 	struct iovec iov;
@@ -181,7 +181,7 @@ int xpmem_copy(struct iovec *local, unsigned long local_cnt,
 					(uintptr_t)iov.iov_base;
 
 		ret = ofi_xpmem_cache_search(xpmem_cache, &iov, pid, &mr_entry,
-					     (struct xpmem_client *)user_data);
+					     (struct ofi_xpmem_client *)user_data);
 		if (ret)
 			return ret;
 
@@ -209,8 +209,8 @@ int xpmem_copy(struct iovec *local, unsigned long local_cnt,
 	return 0;
 }
 
-int ofi_xpmem_enable(struct xpmem_pinfo *peer,
-		     struct xpmem_client *xpmem)
+int ofi_xpmem_enable(struct ofi_xpmem_pinfo *peer,
+		     struct ofi_xpmem_client *xpmem)
 {
 	xpmem->apid = xpmem_get(peer->seg_id,
 				XPMEM_RDWR, XPMEM_PERMIT_MODE, (void *) 0666);
@@ -220,37 +220,37 @@ int ofi_xpmem_enable(struct xpmem_pinfo *peer,
 	return FI_SUCCESS;
 }
 
-void ofi_xpmem_release(struct xpmem_client *xpmem)
+void ofi_xpmem_release(struct ofi_xpmem_client *xpmem)
 {
 	xpmem_release(xpmem->apid);
 }
 
 #else
 
-int xpmem_init(void)
+int ofi_xpmem_init(void)
 {
 	return -FI_ENOSYS;
 }
 
-int xpmem_cleanup(void)
+int ofi_xpmem_cleanup(void)
 {
 	return -FI_ENOSYS;
 }
 
-int xpmem_copy(struct iovec *local, unsigned long local_cnt,
-	       struct iovec *remote, unsigned long remote_cnt,
-	       size_t total, pid_t pid, bool write, void *user_data)
+int ofi_xpmem_copy(struct iovec *local, unsigned long local_cnt,
+                   struct iovec *remote, unsigned long remote_cnt,
+                   size_t total, pid_t pid, bool write, void *user_data)
 {
 	return -FI_ENOSYS;
 }
 
-int ofi_xpmem_enable(struct xpmem_pinfo *peer,
-		     struct xpmem_client *xpmem)
+int ofi_xpmem_enable(struct ofi_xpmem_pinfo *peer,
+		     struct ofi_xpmem_client *xpmem)
 {
 	return -FI_ENOSYS;
 }
 
-void ofi_xpmem_release(struct xpmem_client *xpmem)
+void ofi_xpmem_release(struct ofi_xpmem_client *xpmem)
 {
 }
 

--- a/src/xpmem_cache.c
+++ b/src/xpmem_cache.c
@@ -118,7 +118,7 @@ void ofi_xpmem_cache_destroy(struct ofi_mr_cache *cache)
  */
 int ofi_xpmem_cache_search(struct ofi_mr_cache *cache, struct iovec *iov,
 			   uint64_t peer_id, struct ofi_mr_entry **mr_entry,
-			   struct xpmem_client *xpmem)
+			   struct ofi_xpmem_client *xpmem)
 {
 	int ret;
 	struct ofi_mr_info info;
@@ -146,7 +146,7 @@ out:
 
 int ofi_xpmem_cache_search(struct ofi_mr_cache *cache, struct iovec *iov,
 			   uint64_t peer_id, struct ofi_mr_entry **mr_entry,
-			   struct xpmem_client *xpmem)
+			   struct ofi_xpmem_client *xpmem)
 {
 	return -FI_ENOSYS;
 }


### PR DESCRIPTION
libxpmem defines symbols such as xpmem_init(void) which conflict with ofi. Prefix public xpmem symbols in ofi to avoid interposition.