### PR TITLE
fabtests/synapse - remove dependency of scal

### DIFF
--- a/fabtests/common/hmem_synapseai.c
+++ b/fabtests/common/hmem_synapseai.c
@@ -40,7 +40,31 @@
 
 #include "habanalabs/synapse_api.h"
 #include "habanalabs/hlthunk.h"
-#include "habanalabs/scal.h"
+
+#define SCAL_SUCCESS 0
+
+#define DECLARE_HANDLE(name) struct name##__ { int unused; }; \
+                             typedef struct name##__ *name
+
+DECLARE_HANDLE(scal_handle_t);
+DECLARE_HANDLE(scal_pool_handle_t);
+
+typedef struct _scal_memory_pool_infoV2
+{
+    scal_handle_t scal;
+    const char * name;
+    unsigned idx;
+    uint64_t device_base_address;
+    void *host_base_address;
+    uint32_t core_base_address;  // 0 when the pool is not mapped to the cores
+    uint64_t totalSize;
+    uint64_t freeSize;
+    uint64_t device_base_allocated_address;
+} scal_memory_pool_infoV2;
+
+int scal_get_handle_from_fd(int fd, scal_handle_t* scal);
+int scal_get_pool_handle_by_name(const scal_handle_t scal, const char *pool_name, scal_pool_handle_t *pool);
+int scal_pool_get_infoV2(const scal_pool_handle_t pool, scal_memory_pool_infoV2 *info);
 
 #define ACCEL_PAGE_SIZE 4096
 struct synapseai_ops {

--- a/fabtests/configure.ac
+++ b/fabtests/configure.ac
@@ -203,10 +203,7 @@ AC_ARG_WITH([synapseai],
              CPPFLAGS="-I$withval/include -I/usr/include/drm -I/usr/include/libdrm $CPPFLAGS"
              AC_CHECK_HEADER([habanalabs/synapse_api.h],
                         [AC_CHECK_HEADER([habanalabs/hlthunk.h],
-                              [AC_CHECK_HEADER([habanalabs/scal.h],
-                                    [AC_DEFINE([HAVE_SYNAPSEAI], [1], [Define to 1 if you have <synapse_api.h>, <hlthunk.h>, and <scal.h>])],
-                                    [AC_MSG_ERROR([<habanalabs/scal.h> not found])],
-                                    [-])],
+                              [AC_DEFINE([HAVE_SYNAPSEAI], [1], [Define to 1 if you have <synapse_api.h> and <hlthunk.h>])],
                               [AC_MSG_ERROR([<habanalabs/hlthunk.h> not found])])],
                   [AC_MSG_ERROR([<habanalabs/synapse_api.h> not found])])],
             [])


### PR DESCRIPTION
scal.h is not a public file. on next synapse release this commit will be updated to use a new synapse api.