### PR TITLE
[v1.22.x] fabtests: Pass `memory_type` to client server test

### DIFF
--- a/fabtests/pytest/efa/test_rma_pingpong.py
+++ b/fabtests/pytest/efa/test_rma_pingpong.py
@@ -33,4 +33,4 @@ def test_rma_pingpong_range(cmdline_args, operation_type, completion_semantic, r
 def test_rma_pingpong_range_no_inject(cmdline_args, operation_type, completion_semantic, rma_pingpong_message_size, memory_type):
     command = "fi_rma_pingpong -e rdm -j 0"
     command = command + " -o " + operation_type
-    efa_run_client_server_test(cmdline_args, command, "short", completion_semantic, "host_to_host", rma_pingpong_message_size)
+    efa_run_client_server_test(cmdline_args, command, "short", completion_semantic, memory_type, rma_pingpong_message_size)


### PR DESCRIPTION
Signed-off-by: Darryl Abbate <drl@amazon.com>
(cherry picked from commit 2abe00b62ccf37dc7d12afe3a5a23f2067f6b52a)