### PR TITLE
prov/shm: Fix progress error cases and init id paths

### DIFF
--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -91,7 +91,7 @@ int smr_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 
 struct smr_av {
 	struct util_av		util_av;
-	struct smr_map		*smr_map;
+	struct smr_map		smr_map;
 	size_t			used;
 };
 

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -290,7 +290,7 @@ typedef ssize_t (*smr_proto_func)(struct smr_ep *ep, struct smr_region *peer_smr
 extern smr_proto_func smr_proto_ops[smr_src_max];
 
 int smr_write_err_comp(struct util_cq *cq, void *context,
-		       uint64_t flags, uint64_t tag, uint64_t err);
+		       uint64_t flags, uint64_t tag, int err);
 int smr_complete_tx(struct smr_ep *ep, void *context, uint32_t op,
 		    uint64_t flags);
 int smr_complete_rx(struct smr_ep *ep, void *context, uint32_t op,

--- a/prov/shm/src/smr_av.c
+++ b/prov/shm/src/smr_av.c
@@ -167,16 +167,16 @@ static int smr_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 			fi_addr[i] = util_addr;
 
 		assert(smr_av->smr_map.num_peers > 0);
-
 		dlist_foreach(&util_av->ep_list, av_entry) {
-			util_ep = container_of(av_entry, struct util_ep, av_entry);
-			smr_ep = container_of(util_ep, struct smr_ep, util_ep);
-			smr_map_to_endpoint(smr_ep->region, shm_id);
+        		util_ep = container_of(av_entry, struct util_ep,
+					       av_entry);
+        		smr_ep = container_of(util_ep, struct smr_ep, util_ep);
 			smr_ep->region->max_sar_buf_per_peer =
 				SMR_MAX_PEERS / smr_av->smr_map.num_peers;
 			srx = smr_get_peer_srx(smr_ep);
 			srx->owner_ops->foreach_unspec_addr(srx, &smr_get_addr);
 		}
+
 	}
 
 	return succ_count;

--- a/prov/shm/src/smr_comp.c
+++ b/prov/shm/src/smr_comp.c
@@ -51,7 +51,7 @@ int smr_complete_tx(struct smr_ep *ep, void *context, uint32_t op,
 }
 
 int smr_write_err_comp(struct util_cq *cq, void *context,
-		       uint64_t flags, uint64_t tag, uint64_t err)
+		       uint64_t flags, uint64_t tag, int err)
 {
 	struct fi_cq_err_entry err_entry;
 

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -216,13 +216,15 @@ int64_t smr_verify_peer(struct smr_ep *ep, fi_addr_t fi_addr)
 
 	id = smr_addr_lookup(ep->util_ep.av, fi_addr);
 	assert(id < SMR_MAX_PEERS);
+	if (id < 0)
+		return -1;
 
 	if (smr_peer_data(ep->region)[id].addr.id >= 0)
 		return id;
 
-	if (ep->region->map->peers[id].peer.id < 0) {
+	if (!ep->region->map->peers[id].region) {
 		ret = smr_map_to_region(&smr_prov, ep->region->map, id);
-		if (ret == -ENOENT)
+		if (ret)
 			return -1;
 	}
 

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -1148,7 +1148,7 @@ static int smr_ep_ctrl(struct fid *fid, int command, void *arg)
 		attr.flags = ep->util_ep.caps & FI_HMEM ?
 				SMR_FLAG_HMEM_ENABLED : 0;
 
-		ret = smr_create(&smr_prov, av->smr_map, &attr, &ep->region);
+		ret = smr_create(&smr_prov, &av->smr_map, &attr, &ep->region);
 		if (ret)
 			return ret;
 

--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -350,17 +350,14 @@ size_t smr_calculate_size_offsets(size_t tx_count, size_t rx_count,
 				  size_t *sock_offset);
 void	smr_cma_check(struct smr_region *region, struct smr_region *peer_region);
 void	smr_cleanup(void);
-int	smr_map_create(const struct fi_provider *prov, int peer_count,
-		       uint16_t caps, struct smr_map **map);
 int	smr_map_to_region(const struct fi_provider *prov, struct smr_map *map,
 			  int64_t id);
 void	smr_map_to_endpoint(struct smr_region *region, int64_t id);
 void	smr_unmap_from_endpoint(struct smr_region *region, int64_t id);
 void	smr_exchange_all_peers(struct smr_region *region);
-int	smr_map_add(const struct fi_provider *prov,
-		    struct smr_map *map, const char *name, int64_t *id);
+int	smr_map_add(const struct fi_provider *prov, struct smr_map *map,
+		    const char *name, int64_t *id);
 void	smr_map_del(struct smr_map *map, int64_t id);
-void	smr_map_free(struct smr_map *map);
 
 struct smr_region *smr_map_get(struct smr_map *map, int64_t id);
 

--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -169,6 +169,9 @@ struct smr_cmd {
 #define SMR_PATH_MAX	(SMR_NAME_MAX + sizeof(SMR_DIR))
 #define SMR_SOCK_NAME_MAX sizeof(((struct sockaddr_un *)0)->sun_path)
 
+/* On next version update remove this struct to make id a bool in the smr_peer
+ * remove name from smr_peer_data because it is unused.
+ */
 struct smr_addr {
 	char		name[SMR_NAME_MAX];
 	int64_t		id;


### PR DESCRIPTION
Fix progress error cases to always be positive ints when calling write_err_comp
Make id always be valid when looking up if pid_fd has been set for level-zero