### PR TITLE
include/rdma, prov/shm,efa,util: fi_peer API changes

### DIFF
--- a/include/ofi.h
+++ b/include/ofi.h
@@ -161,7 +161,7 @@ ofi_poll_del(struct fid_poll *pollset, struct fid *event_fid, uint64_t flags)
 	(FI_MULTI_RECV | FI_TRIGGER | FI_RMA_PMEM | FI_SOURCE | \
 	 FI_RMA_EVENT | FI_SOURCE_ERR)
 
-#define OFI_DOMAIN_PRIMARY_CAPS FI_AV_USER_ID
+#define OFI_DOMAIN_PRIMARY_CAPS (FI_AV_USER_ID | FI_PEER)
 #define OFI_DOMAIN_SECONDARY_CAPS \
 	(FI_SHARED_AV | FI_REMOTE_COMM | FI_LOCAL_COMM)
 

--- a/include/rdma/providers/fi_peer.h
+++ b/include/rdma/providers/fi_peer.h
@@ -165,7 +165,7 @@ struct fi_peer_rx_entry {
 	struct fi_peer_rx_entry *prev;
 	struct fid_peer_srx *srx;
 	fi_addr_t addr;
-	size_t size;
+	size_t msg_size;
 	uint64_t tag;
 	uint64_t cq_data;
 	uint64_t flags;
@@ -177,12 +177,20 @@ struct fi_peer_rx_entry {
 	struct iovec *iov;
 };
 
+struct fi_peer_match_attr {
+	fi_addr_t addr;
+	size_t msg_size;
+	uint64_t tag;
+};
+
 struct fi_ops_srx_owner {
 	size_t	size;
-	int	(*get_msg)(struct fid_peer_srx *srx, fi_addr_t addr,
-			size_t size, struct fi_peer_rx_entry **entry);
-	int	(*get_tag)(struct fid_peer_srx *srx, fi_addr_t addr,
-			uint64_t tag, struct fi_peer_rx_entry **entry);
+	int	(*get_msg)(struct fid_peer_srx *srx,
+			   struct fi_peer_match_attr *attr,
+			   struct fi_peer_rx_entry **entry);
+	int	(*get_tag)(struct fid_peer_srx *srx,
+			   struct fi_peer_match_attr *attr,
+			   struct fi_peer_rx_entry **entry);
 	int	(*queue_msg)(struct fi_peer_rx_entry *entry);
 	int	(*queue_tag)(struct fi_peer_rx_entry *entry);
 	void	(*foreach_unspec_addr)(struct fid_peer_srx *srx,

--- a/man/fi_domain.3.md
+++ b/man/fi_domain.3.md
@@ -719,6 +719,11 @@ The following are support primary capabilities:
   FI_AV_USER_ID can still be supported through the AV insert calls without
   this domain capability set. See [`fi_av`(3)](fi_av.3.html).
 
+*FI_PEER*
+: Specifies that the domain must support importing resources to be used in the
+  the peer API flow. The domain must support importing owner_ops when opening
+  a CQ, counter, and shared receive queue.
+
 The following are supported secondary capabilities:
 
 *FI_LOCAL_COMM*

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -338,6 +338,11 @@ additional optimizations.
   allow an initiator to target (or name) a specific receive context as
   part of a data transfer operation.
 
+*FI_PEER*
+: Specifies that the provider must support being used as a peer provider in
+  the peer API flow. The provider must support importing owner_ops when opening
+  a CQ, counter, and shared receive queue.
+
 *FI_READ*
 : Indicates that the user requires an endpoint capable of initiating
   reads against remote memory regions.  This flag requires that FI_RMA
@@ -457,7 +462,8 @@ may optionally report non-selected secondary capabilities if doing so
 would not compromise performance or security.
 
 Primary capabilities: FI_MSG, FI_RMA, FI_TAGGED, FI_ATOMIC, FI_MULTICAST,
-FI_NAMED_RX_CTX, FI_DIRECTED_RECV, FI_HMEM, FI_COLLECTIVE, FI_XPU, FI_AV_USER_ID
+FI_NAMED_RX_CTX, FI_DIRECTED_RECV, FI_HMEM, FI_COLLECTIVE, FI_XPU,
+FI_AV_USER_ID, FI_PEER
 
 Primary modifiers: FI_READ, FI_WRITE, FI_RECV, FI_SEND,
 FI_REMOTE_READ, FI_REMOTE_WRITE

--- a/man/fi_peer.3.md
+++ b/man/fi_peer.3.md
@@ -416,7 +416,7 @@ struct fi_peer_rx_entry {
     struct fi_peer_rx_entry *prev;
     struct fi_peer_srx *srx;
     fi_addr_t addr;
-    size_t size;
+    size_t msg_size;
     uint64_t tag;
     uint64_t cq_data;
     uint64_t flags;
@@ -428,12 +428,20 @@ struct fi_peer_rx_entry {
     struct iovec *iov;
 };
 
+struct fi_peer_match_attr {
+    fi_addr_t addr;
+    size_t msg_size;
+    uint64_t tag;
+};
+
 struct fi_ops_srx_owner {
     size_t size;
-    int (*get_msg)(struct fid_peer_srx *srx, fi_addr_t addr,
-                   size_t size, struct fi_peer_rx_entry **entry);
-    int (*get_tag)(struct fid_peer_srx *srx, fi_addr_t addr,
-                   size_t size, uint64_t tag, struct fi_peer_rx_entry **entry);
+    int (*get_msg)(struct fid_peer_srx *srx,
+                   struct fi_peer_match_attr *attr,
+                   struct fi_peer_rx_entry **entry);
+    int (*get_tag)(struct fid_peer_srx *srx,
+                   struct fi_peer_match_attr *attr,
+                   uint64_t tag, struct fi_peer_rx_entry **entry);
     int (*queue_msg)(struct fi_peer_rx_entry *entry);
     int (*queue_tag)(struct fi_peer_rx_entry *entry);
     void (*foreach_unspec_addr)(struct fid_peer_srx *srx,
@@ -494,9 +502,18 @@ These calls are invoked by the peer provider to obtain the receive buffer(s)
 where an incoming message should be placed.  The peer provider will pass in
 the relevant fields to request a matching rx_entry from the owner.  If source
 addressing is required, the addr will be passed in; otherwise, the address will
-be set to FI_ADDR_NOT_AVAIL. The size parameter is needed by the owner for
-adjusting FI_MULTI_RECV entries. The peer provider is responsible for checking
-that an incoming message fits within the provided buffer space.
+be set to FI_ADDR_NOT_AVAIL.
+The msg_size field indicates the received message size.
+This field may be needed by the owner when handling FI_MULTI_RECV or FI_PEEK.
+The owner will set the peer_entry->msg_size field on get_msg/tag() for the owner
+and peer to use later, if needed. This field will be set on both the expected
+and unexpected paths.
+The returned rx_entry->iov returned from the owner refers to the full size of
+the posted receive passed to the peer. The peer provider is responsible for
+checking that an incoming message fits within the provided buffer space and
+generating truncation errors.
+The tag parameter is only used for tagged messages but must be set to 0 for
+the non-tagged cases.
 An fi_peer_rx_entry is allocated by the owner, whether or not a match was
 found. If a match was found, the owner will return FI_SUCCESS and the rx_entry will
 be filled in with the known receive fields for the peer to process accordingly.

--- a/prov/efa/src/efa_shm.c
+++ b/prov/efa/src/efa_shm.c
@@ -92,7 +92,7 @@ void efa_shm_info_create(const struct fi_info *app_info, struct fi_info **shm_in
 
 	shm_hints->domain_attr->threading = app_info->domain_attr->threading;
 	shm_hints->domain_attr->av_type = FI_AV_TABLE;
-	shm_hints->domain_attr->caps |= FI_LOCAL_COMM;
+	shm_hints->domain_attr->caps |= FI_LOCAL_COMM | FI_PEER | FI_AV_USER_ID;
 	shm_hints->tx_attr->msg_order = FI_ORDER_SAS;
 	shm_hints->rx_attr->msg_order = FI_ORDER_SAS;
 	/*

--- a/prov/shm/src/smr_attr.c
+++ b/prov/shm/src/smr_attr.c
@@ -36,6 +36,7 @@
 #define SMR_RX_CAPS (FI_SOURCE | FI_RMA_EVENT | OFI_RX_MSG_CAPS | FI_TAGGED | \
 		     OFI_RX_RMA_CAPS | FI_ATOMICS | FI_DIRECTED_RECV | \
 		     FI_MULTI_RECV)
+#define SMR_DOMAIN_CAPS (FI_LOCAL_COMM | FI_PEER | FI_AV_USER_ID)
 #define SMR_HMEM_TX_CAPS (SMR_TX_CAPS | FI_HMEM)
 #define SMR_HMEM_RX_CAPS (SMR_RX_CAPS | FI_HMEM)
 #define SMR_TX_OP_FLAGS (FI_COMPLETION | FI_INJECT_COMPLETE | \
@@ -108,7 +109,7 @@ struct fi_domain_attr smr_domain_attr = {
 	.max_ep_tx_ctx = 1,
 	.max_ep_rx_ctx = 1,
 	.mr_iov_limit = SMR_IOV_LIMIT,
-	.caps = FI_LOCAL_COMM,
+	.caps = SMR_DOMAIN_CAPS,
 };
 
 struct fi_domain_attr smr_hmem_domain_attr = {
@@ -128,7 +129,7 @@ struct fi_domain_attr smr_hmem_domain_attr = {
 	.max_ep_tx_ctx = 1,
 	.max_ep_rx_ctx = 1,
 	.mr_iov_limit = SMR_IOV_LIMIT,
-	.caps = FI_LOCAL_COMM,
+	.caps = SMR_DOMAIN_CAPS,
 };
 
 struct fi_fabric_attr smr_fabric_attr = {
@@ -137,7 +138,8 @@ struct fi_fabric_attr smr_fabric_attr = {
 };
 
 struct fi_info smr_hmem_info = {
-	.caps = SMR_HMEM_TX_CAPS | SMR_HMEM_RX_CAPS | FI_MULTI_RECV | FI_LOCAL_COMM,
+	.caps = SMR_HMEM_TX_CAPS | SMR_HMEM_RX_CAPS | FI_MULTI_RECV |
+		SMR_DOMAIN_CAPS,
 	.addr_format = FI_ADDR_STR,
 	.tx_attr = &smr_hmem_tx_attr,
 	.rx_attr = &smr_hmem_rx_attr,
@@ -148,6 +150,7 @@ struct fi_info smr_hmem_info = {
 
 struct fi_info smr_info = {
 	.caps = SMR_TX_CAPS | SMR_RX_CAPS | FI_MULTI_RECV | FI_LOCAL_COMM,
+		SMR_DOMAIN_CAPS,
 	.addr_format = FI_ADDR_STR,
 	.tx_attr = &smr_tx_attr,
 	.rx_attr = &smr_rx_attr,

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -212,6 +212,7 @@ static void ofi_tostr_caps(char *buf, size_t len, uint64_t caps)
 	IFFLAGSTRN(caps, FI_NAMED_RX_CTX, len);
 	IFFLAGSTRN(caps, FI_DIRECTED_RECV, len);
 	IFFLAGSTRN(caps, FI_AV_USER_ID, len);
+	IFFLAGSTRN(caps, FI_PEER, len);
 	IFFLAGSTRN(caps, FI_HMEM, len);
 
 	ofi_remove_comma(buf);

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -211,6 +211,7 @@ static void ofi_tostr_caps(char *buf, size_t len, uint64_t caps)
 	IFFLAGSTRN(caps, FI_SOURCE, len);
 	IFFLAGSTRN(caps, FI_NAMED_RX_CTX, len);
 	IFFLAGSTRN(caps, FI_DIRECTED_RECV, len);
+	IFFLAGSTRN(caps, FI_AV_USER_ID, len);
 	IFFLAGSTRN(caps, FI_HMEM, len);
 
 	ofi_remove_comma(buf);


### PR DESCRIPTION
Update srx flow to take in match attributes
Rename peer_rx_entry->size to msg_size and clarify usage in man pages
Update providers and implementation to match updates
Add FI_PEER as a primary capability which signals support for being used as a peer