### PR TITLE
prov/cxi: FI_PATH_MAX is removed in 2.0 API

### DIFF
--- a/prov/cxi/include/cxip.h
+++ b/prov/cxi/include/cxip.h
@@ -66,6 +66,11 @@
 
 #define CXIP_REQ_CLEANUP_TO		3000
 
+/* PATH_MAX is generally 4K, when not required and variables
+ * are stack based use CXIP_PATH_MAX
+ */
+#define CXIP_PATH_MAX			256
+
 #define CXIP_BUFFER_ID_MAX		(1 << 16)
 
 /* Scalable EP not supported */

--- a/prov/cxi/src/cxip_if.c
+++ b/prov/cxi/src/cxip_if.c
@@ -301,11 +301,11 @@ void cxip_free_lni(struct cxip_lni *lni)
 static bool netdev_ama_check(char *netdev)
 {
 	int rc;
-	char addr_path[FI_PATH_MAX];
+	char addr_path[CXIP_PATH_MAX];
 	FILE *f;
 	int val;
 
-	rc = snprintf(addr_path, FI_PATH_MAX,
+	rc = snprintf(addr_path, CXIP_PATH_MAX,
 		      "/sys/class/net/%s/addr_assign_type",
 		      netdev);
 	if (rc < 0)
@@ -326,7 +326,7 @@ static bool netdev_ama_check(char *netdev)
 	if (val != 3)
 		return false;
 
-	rc = snprintf(addr_path, FI_PATH_MAX, "/sys/class/net/%s/address",
+	rc = snprintf(addr_path, CXIP_PATH_MAX, "/sys/class/net/%s/address",
 		      netdev);
 	if (rc < 0)
 		return false;
@@ -355,12 +355,12 @@ static bool netdev_ama_check(char *netdev)
 static int netdev_link(char *netdev, int *link)
 {
 	int rc;
-	char path[FI_PATH_MAX];
+	char path[CXIP_PATH_MAX];
 	FILE *f;
 	char state[20];
 	int carrier;
 
-	rc = snprintf(path, FI_PATH_MAX, "/sys/class/net/%s/operstate",
+	rc = snprintf(path, CXIP_PATH_MAX, "/sys/class/net/%s/operstate",
 		      netdev);
 	if (rc < 0)
 		return -1;
@@ -385,7 +385,7 @@ static int netdev_link(char *netdev, int *link)
 	}
 
 	/* operstate is unknown, must check carrier. */
-	rc = snprintf(path, FI_PATH_MAX, "/sys/class/net/%s/carrier",
+	rc = snprintf(path, CXIP_PATH_MAX, "/sys/class/net/%s/carrier",
 		      netdev);
 	if (rc < 0)
 		return -1;
@@ -412,11 +412,11 @@ static int netdev_link(char *netdev, int *link)
 static int netdev_speed(char *netdev, int *speed)
 {
 	int rc;
-	char path[FI_PATH_MAX];
+	char path[CXIP_PATH_MAX];
 	FILE *f;
 	int val;
 
-	rc = snprintf(path, FI_PATH_MAX, "/sys/class/net/%s/speed",
+	rc = snprintf(path, CXIP_PATH_MAX, "/sys/class/net/%s/speed",
 		      netdev);
 	if (rc < 0)
 		return -1;
@@ -446,8 +446,8 @@ static int netdev_lookup(struct cxil_devinfo *info, char **netdev)
 	int rc;
 	int count;
 	int i;
-	char if_path[FI_PATH_MAX];
-	char addr_path[FI_PATH_MAX];
+	char if_path[CXIP_PATH_MAX];
+	char addr_path[CXIP_PATH_MAX];
 	char *addr;
 	unsigned int dom;
 	unsigned int bus;
@@ -461,12 +461,12 @@ static int netdev_lookup(struct cxil_devinfo *info, char **netdev)
 	count = globbuf.gl_pathc;
 
 	for (i = 0; i < count; i++) {
-		rc = snprintf(if_path, FI_PATH_MAX, "%s/device",
+		rc = snprintf(if_path, CXIP_PATH_MAX, "%s/device",
 			      globbuf.gl_pathv[i]);
 		if (rc < 0)
 			goto free_glob;
 
-		rc = readlink(if_path, addr_path, FI_PATH_MAX-1);
+		rc = readlink(if_path, addr_path, CXIP_PATH_MAX-1);
 		if (rc < 0) {
 			/* A virtual device, like a bridge, doesn't have a
 			 * device link.

--- a/prov/cxi/src/cxip_telemetry.c
+++ b/prov/cxi/src/cxip_telemetry.c
@@ -10,13 +10,13 @@
 static long cxip_telemetry_entry_read_value(struct cxip_telemetry_entry *entry)
 {
 	long ret;
-	char path[FI_PATH_MAX];
+	char path[CXIP_PATH_MAX];
 	FILE *f;
 	long value;
 	long tstamp_sec;
 	long tstamp_nsec;
 
-	ret = snprintf(path, FI_PATH_MAX, TELEMETRY_FILE_FMT,
+	ret = snprintf(path, CXIP_PATH_MAX, TELEMETRY_FILE_FMT,
 		       entry->telemetry->dom->iface->info->dev_id, entry->name);
 	if (ret < 0)
 		return ret;
@@ -93,10 +93,10 @@ static bool
 cxip_telemetry_entry_validate_token_file(struct cxip_telemetry *telemetry,
 					 const char *telemetry_token)
 {
-	char path[FI_PATH_MAX];
+	char path[CXIP_PATH_MAX];
 	int ret;
 
-	ret = snprintf(path, FI_PATH_MAX, TELEMETRY_FILE_FMT,
+	ret = snprintf(path, CXIP_PATH_MAX, TELEMETRY_FILE_FMT,
 		       telemetry->dom->iface->info->dev_id, telemetry_token);
 	if (ret < 0)
 		return false;


### PR DESCRIPTION
Define cxi internal CXIP_PATH_MAX for use to avoid using PATH_MAX where appropriate for stack variables.

Signed-off-by: Steve Welch <welch@hpe.com>