### PR TITLE
fabtests: Add option for FI_MORE and fabtests with FI_MORE

### DIFF
--- a/fabtests/benchmarks/benchmark_shared.c
+++ b/fabtests/benchmarks/benchmark_shared.c
@@ -274,9 +274,21 @@ static int rma_bw_rx_comp()
 	return ft_tx(ep, remote_fi_addr, FT_RMA_SYNC_MSG_BYTES, &tx_ctx);
 }
 
+static int set_fi_more_flag(int i, int j, int flags)
+{
+	if (j < opts.window_size - 1 && i >= opts.warmup_iterations &&
+	    i < opts.iterations + opts.warmup_iterations - 1) {
+		flags |= FI_MORE;
+	} else {
+		flags &= ~FI_MORE;
+	}
+	return flags;
+}
+
 int bandwidth(void)
 {
 	int ret, i, j, inject_size;
+	int flags = 0;
 
 	inject_size = inject_size_set ?
 			hints->tx_attr->inject_size : fi->tx_attr->inject_size;
@@ -310,6 +322,12 @@ int bandwidth(void)
 				ret = ft_post_inject_buf(ep, remote_fi_addr,
 						opts.transfer_size, NO_CQ_DATA,
 						tx_ctx_arr[j].buf, tx_seq);
+			} else if (opts.use_fi_more) {
+				flags = set_fi_more_flag(i, j, flags);
+				ret = ft_sendmsg(ep, remote_fi_addr,
+						tx_ctx_arr[j].buf,
+						opts.transfer_size,
+						&tx_ctx_arr[j].context, flags);
 			} else {
 				ret = ft_post_tx_buf(ep, remote_fi_addr,
 						opts.transfer_size, NO_CQ_DATA,

--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -4183,6 +4183,8 @@ void ft_longopts_usage()
 		"manual, auto, or unified");
 	FT_PRINT_OPTS_USAGE("--max-msg-size <size>",
 		"maximum untagged message size");
+	FT_PRINT_OPTS_USAGE("--use-fi-more",
+		"Run tests with FI_MORE");
 }
 
 int debug_assert;
@@ -4195,6 +4197,7 @@ struct option long_opts[] = {
 	{"data-progress", required_argument, NULL, LONG_OPT_DATA_PROGRESS},
 	{"control-progress", required_argument, NULL, LONG_OPT_CONTROL_PROGRESS},
 	{"max-msg-size", required_argument, NULL, LONG_OPT_MAX_MSG_SIZE},
+	{"use-fi-more", no_argument, NULL, LONG_OPT_USE_FI_MORE},
 	{NULL, 0, NULL, 0},
 };
 
@@ -4234,6 +4237,9 @@ int ft_parse_long_opts(int op, char *optarg)
 		return 0;
 	case LONG_OPT_MAX_MSG_SIZE:
 		opts.max_msg_size = atoi(optarg);
+		return 0;
+	case LONG_OPT_USE_FI_MORE:
+		opts.use_fi_more = 1;
 		return 0;
 	default:
 		return EXIT_FAILURE;

--- a/fabtests/functional/inject_test.c
+++ b/fabtests/functional/inject_test.c
@@ -52,7 +52,7 @@ static int send_msg(int sendmsg, size_t size)
 	}
 
 	if (sendmsg) {
-		ret = ft_sendmsg(ep, remote_fi_addr, size, &tx_ctx, flag);
+		ret = ft_sendmsg(ep, remote_fi_addr, tx_buf, size, &tx_ctx, flag);
 		if (ret)
 			return ret;
 	} else {

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -606,9 +606,9 @@ int ft_get_cntr_comp(struct fid_cntr *cntr, uint64_t total, int timeout);
 int ft_recvmsg(struct fid_ep *ep, fi_addr_t fi_addr,
 		size_t size, void *ctx, int flags);
 int ft_sendmsg(struct fid_ep *ep, fi_addr_t fi_addr,
-		size_t size, void *ctx, int flags);
+	       void *buf, size_t size, void *ctx, int flags);
 int ft_tx_msg(struct fid_ep *ep, fi_addr_t fi_addr,
-	      size_t size, void *ctx, uint64_t flags);
+	      void *buf, size_t size, void *ctx, uint64_t flags);
 int ft_cq_read_verify(struct fid_cq *cq, void *op_context);
 
 void eq_readerr(struct fid_eq *eq, const char *eq_str);

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -192,6 +192,7 @@ struct ft_opts {
 	char *dst_addr;
 	char *av_name;
 	int sizes_enabled;
+	int use_fi_more;
 	int options;
 	enum ft_comp_method comp_method;
 	int machr;
@@ -644,6 +645,7 @@ enum {
 	LONG_OPT_DATA_PROGRESS,
 	LONG_OPT_CONTROL_PROGRESS,
 	LONG_OPT_MAX_MSG_SIZE,
+	LONG_OPT_USE_FI_MORE,
 };
 
 extern int debug_assert;

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -583,6 +583,8 @@ ssize_t ft_post_rma(enum ft_rma_opcodes op, char *buf, size_t size,
 		struct fi_rma_iov *remote, void *context);
 ssize_t ft_post_rma_inject(enum ft_rma_opcodes op, char *buf, size_t size,
 		struct fi_rma_iov *remote);
+ssize_t ft_post_rma_writemsg(char *buf, size_t size, struct fi_rma_iov *remote,
+		void *context, uint64_t flags);
 int ft_rma_poll_buf(void *buf, int iter, size_t size);
 
 ssize_t ft_post_atomic(enum ft_atomic_opcodes opcode, struct fid_ep *ep,
@@ -607,6 +609,8 @@ int ft_recvmsg(struct fid_ep *ep, fi_addr_t fi_addr,
 		size_t size, void *ctx, int flags);
 int ft_sendmsg(struct fid_ep *ep, fi_addr_t fi_addr,
 	       void *buf, size_t size, void *ctx, int flags);
+int ft_writemsg(struct fid_ep *ep, fi_addr_t fi_addr, void *buf, size_t size,
+		void *ctx, struct fi_rma_iov *remote, int flags);
 int ft_tx_msg(struct fid_ep *ep, fi_addr_t fi_addr,
 	      void *buf, size_t size, void *ctx, uint64_t flags);
 int ft_cq_read_verify(struct fid_cq *cq, void *op_context);

--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -71,6 +71,11 @@ def test_rdm_tagged_bw_small_tx_rx(cmdline_args, completion_semantic, memory_typ
     efa_run_client_server_test(cmdline_args_copy, "fi_rdm_tagged_bw -W 128", "short",
                                completion_semantic, memory_type, "all", completion_type=completion_type)
 
+@pytest.mark.functional
+def test_rdm_tagged_bw_use_fi_more(cmdline_args, completion_semantic, memory_type, message_size):
+    efa_run_client_server_test(cmdline_args, "fi_rdm_tagged_bw --use-fi-more",
+                               "short", completion_semantic, memory_type, message_size)
+
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])

--- a/fabtests/pytest/efa/test_rma_bw.py
+++ b/fabtests/pytest/efa/test_rma_bw.py
@@ -62,3 +62,13 @@ def test_rma_bw_1G(cmdline_args, operation_type, completion_semantic):
     efa_run_client_server_test(cmdline_args, command, 2,
                                completion_semantic=completion_semantic, message_size=1073741824,
                                memory_type="host_to_host", warmup_iteration_type=0, timeout=timeout)
+
+@pytest.mark.functional
+@pytest.mark.parametrize("operation_type", ["writedata", "write"])
+def test_rma_bw_use_fi_more(cmdline_args, operation_type, completion_semantic, inject_message_size):
+    command = "fi_rma_bw -e rdm -j 0 --use-fi-more"
+    command = command + " -o " + operation_type
+    # rma_bw test with data verification takes longer to finish
+    timeout = max(540, cmdline_args.timeout)
+    efa_run_client_server_test(cmdline_args, command, "short", completion_semantic,
+                               "host_to_host", inject_message_size, timeout=timeout)


### PR DESCRIPTION
- Add the option `--use-fi-more` to allow tests with FI_MORE flag set
- Run rdm_tagged_bw with `fi_sendmsg/fi_tsendmsg`, run rma write/writedata with `fi_writemsg` to allow testing with customized flags
- Add efa pytests with FI_MORE for `fi_rma_bw` and `fi_rdm_tagged_bw`
