### PR TITLE
man: Fix mark-down formats

### DIFF
--- a/man/fi_domain.3.md
+++ b/man/fi_domain.3.md
@@ -518,7 +518,7 @@ Specifies the type of address vectors that are usable with this domain.
 For additional details on AV type, see [`fi_av`(3)](fi_av.3.html).
 The following values may be specified.
 
-*FI_AV_MAP*
+*FI_AV_MAP* (deprecated)
 : Only address vectors of type AV map are requested or supported.
 
 *FI_AV_TABLE*
@@ -767,9 +767,10 @@ Providers which support authorization keys and connectionless endpoint must
 support this option.
 
 ## Max Error Data Size (max_err_data)
-: The maximum amount of error data, in bytes, that may be returned as part of
-  a completion or event queue error.  This value corresponds to the
-  err_data_size field in struct fi_cq_err_entry and struct fi_eq_err_entry.
+
+The maximum amount of error data, in bytes, that may be returned as part of
+a completion or event queue error.  This value corresponds to the
+err_data_size field in struct fi_cq_err_entry and struct fi_eq_err_entry.
 
 ## Memory Regions Count (mr_cnt)
 
@@ -790,8 +791,8 @@ for additional information.
 
 ## Max Authorization Keys per Endpoint (max_ep_auth_key)
 
-: The maximum number of authorization keys which can be supported per connectionless
-  endpoint.
+The maximum number of authorization keys which can be supported per connectionless
+endpoint.
 
 ## Maximum Peer Group Id (max_group_id)
 

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -446,18 +446,18 @@ The base operation of an endpoint is selected during creation using
 struct fi_info.  The following control commands and arguments may be
 assigned to an endpoint.
 
-**FI_BACKLOG - int *value**
+*FI_BACKLOG - int \*value*
 : This option only applies to passive endpoints.  It is used to set the
   connection request backlog for listening endpoints.
 
-**FI_GETOPSFLAG -- uint64_t *flags**
+*FI_GETOPSFLAG -- uint64_t \*flags*
 : Used to retrieve the current value of flags associated with the data
   transfer operations initiated on the endpoint. The control argument must
   include FI_TRANSMIT or FI_RECV (not both) flags to indicate the type of
   data transfer flags to be returned.
   See below for a list of control flags.
 
-**FI_GETWAIT -- void \*\***
+*FI_GETWAIT -- void \*\**
 : This command allows the user to retrieve the file descriptor associated
   with a socket endpoint.  The fi_control arg parameter should be an address
   where a pointer to the returned file descriptor will be written.  See fi_eq.3
@@ -465,7 +465,7 @@ assigned to an endpoint.
   may be used for notification that the endpoint is ready to send or receive
   data.
 
-**FI_SETOPSFLAG -- uint64_t *flags**
+*FI_SETOPSFLAG -- uint64_t \*flags*
 : Used to change the data transfer operation flags associated with an
   endpoint. The control argument must include FI_TRANSMIT or FI_RECV (not both)
   to indicate the type of data transfer that the flags should apply to, with other


### PR DESCRIPTION
Replace a few occurences of '**text**' with '*text*' for consistency. Remove unnecessary ':'s.

Also add a missing "deprecated" note.