### PR TITLE
prov/verbs: Fix resource leak in error handling path

### DIFF
--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -780,7 +780,8 @@ static int vrb_alloc_info(struct ibv_context *ctx, struct fi_info **info,
 		break;
 	default:
 		assert(0);
-		return -FI_EINVAL;
+		ret = -FI_EINVAL;
+		goto err;
 	}
 
 


### PR DESCRIPTION
Reported by Coverity:
"Variable fi going out of scope leaks the storage it points to."