### PR TITLE
prov/psm2,psm3: fix incorrect unlock function

### DIFF
--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -1693,7 +1693,7 @@ STATIC ssize_t psmx2_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf,
 				  buf, &cq_priv->pending_error->cqe.err);
 		free(cq_priv->pending_error);
 		cq_priv->pending_error = NULL;
-		psmx2_unlock(&cq_priv->lock, 2);
+		cq_priv->domain->cq_unlock_fn(&cq_priv->lock, 2);
 		return 1;
 	}
 	cq_priv->domain->cq_unlock_fn(&cq_priv->lock, 2);

--- a/prov/psm3/src/psmx3_cq.c
+++ b/prov/psm3/src/psmx3_cq.c
@@ -967,7 +967,7 @@ STATIC ssize_t psmx3_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf,
 				  buf, &cq_priv->pending_error->cqe.err);
 		free(cq_priv->pending_error);
 		cq_priv->pending_error = NULL;
-		psmx3_unlock(&cq_priv->lock, 2);
+		cq_priv->domain->cq_unlock_fn(&cq_priv->lock, 2);
 		return 1;
 	}
 	cq_priv->domain->cq_unlock_fn(&cq_priv->lock, 2);


### PR DESCRIPTION
Use optimized lock function to unlock on CQ write error instead of direct unlock which causes an assert failure if FI_THREAD_DOMAIN is specified