### PR TITLE
[v1.22.x] fabtests: Utilize `fi_setopt`/`fi_getopt` sequence for inject size (`-j`)

### DIFF
--- a/fabtests/benchmarks/benchmark_shared.c
+++ b/fabtests/benchmarks/benchmark_shared.c
@@ -63,7 +63,8 @@ void ft_parse_benchmark_opts(int op, char *optarg)
 		ft_force_prefix(hints, &opts);
 		break;
 	case 'j':
-		hints->tx_attr->inject_size = atoi(optarg);
+		opts.inject_size = atoi(optarg);
+		hints->tx_attr->inject_size = opts.inject_size;
 		inject_size_set = 1;
 		break;
 	case 'W':
@@ -87,10 +88,18 @@ void ft_benchmark_usage(void)
 
 int pingpong(void)
 {
-	int ret, i, inject_size;
+	int ret, i;
+	size_t inject_size = fi->tx_attr->inject_size;
 
-	inject_size = inject_size_set ?
-			hints->tx_attr->inject_size : fi->tx_attr->inject_size;
+	ret = fi_getopt(&ep->fid, FI_OPT_ENDPOINT, FI_OPT_INJECT_MSG_SIZE,
+			&inject_size, &(size_t){sizeof inject_size});
+	if (ret && ret != -FI_ENOPROTOOPT) {
+		FT_PRINTERR("fi_getopt(FI_OPT_INJECT_MSG_SIZE)", ret);
+		return ret;
+	}
+
+	if (inject_size_set)
+		inject_size = opts.inject_size;
 
 	if (opts.options & FT_OPT_ENABLE_HMEM)
 		inject_size = 0;
@@ -145,10 +154,18 @@ int pingpong(void)
 
 int pingpong_rma(enum ft_rma_opcodes rma_op, struct fi_rma_iov *remote)
 {
-	int ret, i, inject_size;
+	int ret, i;
+	size_t inject_size = fi->tx_attr->inject_size;
 
-	inject_size = inject_size_set ?
-			hints->tx_attr->inject_size : fi->tx_attr->inject_size;
+	ret = fi_getopt(&ep->fid, FI_OPT_ENDPOINT, FI_OPT_INJECT_RMA_SIZE,
+			&inject_size, &(size_t){sizeof inject_size});
+	if (ret && ret != -FI_ENOPROTOOPT) {
+		FT_PRINTERR("fi_getopt(FI_OPT_INJECT_RMA_SIZE)", ret);
+		return ret;
+	}
+
+	if (inject_size_set)
+		inject_size = opts.inject_size;
 
 	if (ft_check_opts(FT_OPT_ENABLE_HMEM))
 		inject_size = 0;
@@ -276,10 +293,18 @@ static int rma_bw_rx_comp()
 
 int bandwidth(void)
 {
-	int ret, i, j, inject_size;
+	int ret, i, j, flags = 0;
+	size_t inject_size = fi->tx_attr->inject_size;
 
-	inject_size = inject_size_set ?
-			hints->tx_attr->inject_size : fi->tx_attr->inject_size;
+	ret = fi_getopt(&ep->fid, FI_OPT_ENDPOINT, FI_OPT_INJECT_MSG_SIZE,
+			&inject_size, &(size_t){sizeof inject_size});
+	if (ret && ret != -FI_ENOPROTOOPT) {
+		FT_PRINTERR("fi_getopt(FI_OPT_INJECT_MSG_SIZE)", ret);
+		return ret;
+	}
+
+	if (inject_size_set)
+		inject_size = opts.inject_size;
 
 	if (opts.options & FT_OPT_ENABLE_HMEM)
 		inject_size = 0;
@@ -393,11 +418,18 @@ static int bw_rma_comp(enum ft_rma_opcodes rma_op, int num_completions)
 
 int bandwidth_rma(enum ft_rma_opcodes rma_op, struct fi_rma_iov *remote)
 {
-	int ret, i, j, inject_size;
-	size_t offset;
+	int ret, i, j, flags = 0;
+	size_t offset, inject_size = fi->tx_attr->inject_size;
 
-	inject_size = inject_size_set ?
-			hints->tx_attr->inject_size: fi->tx_attr->inject_size;
+	ret = fi_getopt(&ep->fid, FI_OPT_ENDPOINT, FI_OPT_INJECT_RMA_SIZE,
+			&inject_size, &(size_t){sizeof inject_size});
+	if (ret && ret != -FI_ENOPROTOOPT) {
+		FT_PRINTERR("fi_getopt(FI_OPT_INJECT_RMA_SIZE)", ret);
+		return ret;
+	}
+
+	if (inject_size_set)
+		inject_size = opts.inject_size;
 
 	if (ft_check_opts(FT_OPT_ENABLE_HMEM))
 		inject_size = 0;

--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -1435,6 +1435,21 @@ int ft_enable_ep(struct fid_ep *bind_ep, struct fid_eq *bind_eq, struct fid_av *
 		}
 	}
 
+	if (opts.inject_size) {
+		ret = fi_setopt(&bind_ep->fid, FI_OPT_ENDPOINT, FI_OPT_INJECT_MSG_SIZE,
+				&opts.inject_size, sizeof opts.inject_size);
+		if (ret && ret != -FI_EOPNOTSUPP) {
+			FT_PRINTERR("fi_setopt(FI_OPT_INJECT_MSG_SIZE)", ret);
+			return ret;
+		}
+		ret = fi_setopt(&bind_ep->fid, FI_OPT_ENDPOINT, FI_OPT_INJECT_RMA_SIZE,
+				&opts.inject_size, sizeof opts.inject_size);
+		if (ret && ret != -FI_EOPNOTSUPP) {
+			FT_PRINTERR("fi_setopt(FI_OPT_INJECT_RMA_SIZE)", ret);
+			return ret;
+		}
+	}
+
 	ret = fi_enable(bind_ep);
 	if (ret) {
 		FT_PRINTERR("fi_enable", ret);

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -176,6 +176,7 @@ struct ft_opts {
 	int warmup_iterations;
 	size_t transfer_size;
 	size_t max_msg_size;
+	size_t inject_size;
 	int window_size;
 	int av_size;
 	int verbose;

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -1252,6 +1252,15 @@ static int efa_rdm_ep_ctrl(struct fid *fid, int command, void *arg)
 
 		efa_rdm_ep_set_use_zcpy_rx(ep);
 
+		/* In zero-copy mode, update inject_size to the size of the inline data
+		 * buffer of the NIC, unless the user already requested a smaller size
+		 *
+		 * TODO: Distinguish between inline data sizes for RDMA {send,write}
+		 * when supported
+		 */
+		if (ep->use_zcpy_rx)
+			ep->inject_size = MIN(ep->inject_size, efa_rdm_ep_domain(ep)->device->efa_attr.inline_buf_size);
+
 		ret = efa_rdm_ep_create_base_ep_ibv_qp(ep);
 		if (ret)
 			return ret;

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -950,6 +950,7 @@ static void test_efa_rdm_ep_use_zcpy_rx_impl(struct efa_resource *resource,
 	struct efa_domain *efa_domain;
 	struct efa_rdm_ep *ep;
 	size_t max_msg_size = 1000;
+	size_t inject_size = 0;
 	bool shm_permitted = false;
 
 	efa_unit_test_resource_construct_with_hints(resource, FI_EP_RDM, FI_VERSION(1, 14),
@@ -986,8 +987,18 @@ static void test_efa_rdm_ep_use_zcpy_rx_impl(struct efa_resource *resource,
 			&shm_permitted, sizeof shm_permitted), 0);
 
 	assert_true(ep->max_msg_size == max_msg_size);
+
+	/* Enable EP */
 	assert_int_equal(fi_enable(resource->ep), 0);
+
 	assert_true(ep->use_zcpy_rx == expected_use_zcpy_rx);
+	assert_int_equal(fi_getopt(&resource->ep->fid, FI_OPT_ENDPOINT, FI_OPT_INJECT_RMA_SIZE,
+			&inject_size, &(size_t){sizeof inject_size}), 0);
+	assert_int_equal(ep->inject_size, inject_size);
+	if (expected_use_zcpy_rx)
+		assert_int_equal(inject_size, efa_rdm_ep_domain(ep)->device->efa_attr.inline_buf_size);
+	else
+		assert_int_equal(inject_size, resource->info->tx_attr->inject_size);
 }
 
 /**


### PR DESCRIPTION
Backport of #10326 