### PR TITLE
prov/efa: Zero the cq entry array in dgram ep progress

### DIFF
--- a/prov/efa/src/dgram/efa_dgram_ep.c
+++ b/prov/efa/src/dgram/efa_dgram_ep.c
@@ -282,7 +282,7 @@ static struct fi_ops efa_dgram_ep_ops = {
 static void efa_dgram_ep_progress_internal(struct efa_dgram_ep *ep, struct efa_dgram_cq *efa_dgram_cq)
 {
 	struct util_cq *cq;
-	struct fi_cq_tagged_entry cq_entry[efa_dgram_cq_PROGRESS_ENTRIES];
+	struct fi_cq_tagged_entry cq_entry[efa_dgram_cq_PROGRESS_ENTRIES] = {0};
 	struct fi_cq_tagged_entry *temp_cq_entry;
 	struct fi_cq_err_entry cq_err_entry = {0};
 	fi_addr_t src_addr[efa_dgram_cq_PROGRESS_ENTRIES];


### PR DESCRIPTION
In efa_dgram_ep_progress_internal, cq_entry was declared without initializing as 0. It casts this array's pointer into smaller structs like `fi_cq_entry` during the cq->read_entry call, which doesn't have the flags member, and then cast it back to fi_cq_tagged_entry which has flags. This finally makes the temp_cq_entry struct has a flags from uninitialized values and can cause illegal flags to be used in the cq write. This patch fixes issue by initializing the cq entry array as 0.