### PR TITLE
prov/efa:  Fix fi_sendmsg/fi_writemsg with FI_INJECT

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -1501,8 +1501,10 @@ int efa_rdm_ope_post_remote_write(struct efa_rdm_ope *ope)
 		if (ope->fi_flags & FI_INJECT) {
 			assert(ope->iov_count == 1);
 			assert(ope->total_len <= ep->inject_size);
-			copied = ofi_copy_from_hmem_iov(pkt_entry->wiredata + sizeof(struct efa_rdm_rma_context_pkt),
-				ope->total_len, FI_HMEM_SYSTEM, 0, ope->iov, ope->iov_count, 0);
+			copied = efa_rdm_pke_copy_from_hmem_iov(
+				ope->desc[iov_idx], pkt_entry, ope,
+				sizeof(struct efa_rdm_rma_context_pkt), 0,
+				ope->total_len);
 			assert(copied == ope->total_len);
 			(void) copied; /* suppress compiler warning for non-debug build */
 			ope->desc[0] = fi_mr_desc(pkt_entry->mr);

--- a/prov/efa/src/rdm/efa_rdm_pke_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_utils.c
@@ -93,20 +93,8 @@ ssize_t efa_rdm_pke_init_payload_from_ope(struct efa_rdm_pke *pke,
 		return 0;
 	}
 
-	if (iov_mr && (iov_mr->peer.flags & OFI_HMEM_DATA_DEV_REG_HANDLE)) {
-		assert(iov_mr->peer.hmem_data);
-		copied = ofi_dev_reg_copy_from_hmem_iov(pke->wiredata + payload_offset,
-							data_size, iov_mr->peer.iface,
-							(uint64_t)iov_mr->peer.hmem_data,
-							ope->iov, ope->iov_count,
-							segment_offset);
-	} else {
-		copied = ofi_copy_from_hmem_iov(pke->wiredata + payload_offset,
-						data_size,
-		                                iov_mr ? iov_mr->peer.iface : FI_HMEM_SYSTEM,
-		                                iov_mr ? iov_mr->peer.device.reserved : 0,
-		                                ope->iov, ope->iov_count, segment_offset);
-	}
+	copied = efa_rdm_pke_copy_from_hmem_iov(
+		iov_mr, pke, ope, payload_offset, segment_offset, data_size);
 
 	assert(copied == data_size);
 	pke->payload = pke->wiredata + payload_offset;


### PR DESCRIPTION
Currently EFA provider doesn't handle the *msg call with FI_INJECT flags correctly. It allows user to pass in a buffer with valid MR while doing inject - outbound buffer should be reusable immediately after function returns.
That being said, without the inline HW support, EFA provider should do a copy from the user buffer to the internal bounce buffer even if application provides a valid MR for the buffer.
The inject rdma write path assumes the outbound buffer is always FI_HMEM_SYSTEM, but it doesn't have to.