### PR TITLE
contrib/aws: Make Jenkins failures happen in place

### DIFF
--- a/contrib/aws/Jenkinsfile
+++ b/contrib/aws/Jenkinsfile
@@ -5,11 +5,6 @@ def buildNumber = env.BUILD_NUMBER as int
 if (buildNumber > 1) milestone(buildNumber - 1)
 milestone(buildNumber)
 
-
-import groovy.transform.Field
-@Field boolean build_ok = true
-
-
 def get_portafiducia_download_path() {
     /* Stable Portafiducia tarball */
     def AWS_ACCOUNT_ID = sh (
@@ -54,17 +49,12 @@ def run_test_orchestrator_once(run_name, build_tag, os, instance_type, instance_
      * param@ args: str, the command line arguments
      */
     def cluster_name = get_cluster_name(build_tag, os, instance_type)
-    def args = "--config configs/${test_config_file} --os ${os} --instance-type ${instance_type} --instance-count ${instance_count} --region ${region} --cluster-name ${cluster_name} ${addl_args} --junit-xml outputs/${cluster_name}.xml"
-    def ret = sh (
-                    script: ". venv/bin/activate; cd PortaFiducia/tests && ./test_orchestrator.py ${args}",
-                    returnStatus: true
-                  )
-    if (ret == 65)
-        unstable('Scripts exited with status 65')
-    else if (ret != 0)
-        build_ok = false
-    catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-        sh "exit ${ret}"
+    def args = "--config PortaFiducia/tests/configs/${test_config_file} --os ${os} --instance-type ${instance_type} --instance-count ${instance_count} --region ${region} --cluster-name ${cluster_name} ${addl_args} --junit-xml outputs/${cluster_name}.xml"
+    try {
+        sh ". venv/bin/activate; ./PortaFiducia/tests/test_orchestrator.py ${args}"
+    } catch (Exception e){
+        currentBuild.result = "FAILURE"
+        throw e
     }
 }
 
@@ -102,21 +92,16 @@ def get_single_node_windows_test_stage(stage_name) {
      */
     return {
         stage("${stage_name}") {
-            def ret = sh (
-                            script: """
-                                . venv/bin/activate;
-                                cd PortaFiducia/scripts;
-                                export PULL_REQUEST_ID=${env.CHANGE_ID};
-                                env AWS_DEFAULT_REGION=us-west-2 ./test_orchestrator_windows.py --ci public --s3-bucket-name libfabric-ci-windows-prod-test-output --pull-request-id ${env.CHANGE_ID};
-                            """,
-                            returnStatus: true
-                         )
-            if (ret == 65)
-                unstable('Scripts exited with status 65')
-            else if (ret != 0)
-                build_ok = false
-            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                sh "exit ${ret}"
+            try {
+                sh """
+                    . venv/bin/activate;
+                    cd PortaFiducia/scripts;
+                    export PULL_REQUEST_ID=${env.CHANGE_ID};
+                    env AWS_DEFAULT_REGION=us-west-2 ./test_orchestrator_windows.py --ci public --s3-bucket-name libfabric-ci-windows-prod-test-output --pull-request-id ${env.CHANGE_ID};
+                """
+            } catch (Exception e){
+                currentBuild.result = "FAILURE"
+                throw e
             }
         }
     }
@@ -231,18 +216,6 @@ pipeline {
                     stages["2_c6g_rhel8_sockets"] = get_test_stage("2_c6g_rhel8_sockets", env.BUILD_TAG, "rhel8", "c6g.2xlarge", 2, "us-west-2", "libfabric_pr_test.yaml", addl_args_pr + "--test-libfabric-provider sockets --enable-efa false")
 
                     parallel stages
-                }
-            }
-        }
-        stage('check build_ok') {
-            steps {
-                script {
-                    if (build_ok) {
-                        currentBuild.result = "SUCCESS"
-                    }
-                    else {
-                        currentBuild.result = "FAILURE"
-                    }
                 }
             }
         }


### PR DESCRIPTION
Before this commit, when Jenkins used to have a failure, Jenkins would make a big red box (mark the failure) around the cleanup shell script. This change moves the big red box to be around the execution logs holding the job error. This is a cosmetic fix.