### PR TITLE
prov/tcp: initialize addr_size when duplicating an av

### DIFF
--- a/prov/tcp/src/xnet_rdm.c
+++ b/prov/tcp/src/xnet_rdm.c
@@ -700,7 +700,7 @@ static int xnet_mplex_av_dup(struct util_ep *ep, struct xnet_mplex_av *mplex_av,
 {
 	int ret, i;
 	struct util_av *subav;
-	size_t addr_size;
+	size_t addr_size = sizeof(struct sockaddr_in6);
 	char addr[sizeof(struct sockaddr_in6)];
 	struct fi_av_attr av_attr = {
 		.type = ep->domain->av_type,


### PR DESCRIPTION
this would address https://scan4.scan.coverity.com/#/project-view/61734/10344?selectedIssue=441178