### PR TITLE
prov/util: Add uffd user mode flag for kernels

### DIFF
--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -43,6 +43,9 @@
 #include <ofi_enosys.h>
 #include <rdma/fi_ext.h>
 
+#ifndef UFFD_USER_MODE_ONLY
+#define UFFD_USER_MODE_ONLY 0
+#endif
 
 pthread_mutex_t mm_lock = PTHREAD_MUTEX_INITIALIZER;
 pthread_mutex_t mm_state_lock = PTHREAD_MUTEX_INITIALIZER;
@@ -701,7 +704,8 @@ static int ofi_uffd_start(struct ofi_mem_monitor *monitor)
 	if (!num_page_sizes)
 		return -FI_ENODATA;
 
-	uffd.fd = syscall(__NR_userfaultfd, O_CLOEXEC | O_NONBLOCK);
+	uffd.fd = syscall(__NR_userfaultfd,
+			  O_CLOEXEC | O_NONBLOCK | UFFD_USER_MODE_ONLY);
 	if (uffd.fd < 0) {
 		FI_WARN(&core_prov, FI_LOG_MR,
 			"syscall/userfaultfd %s\n", strerror(errno));


### PR DESCRIPTION
Linux kernels 5.11 and later introduced a UFFD_USER_MODE_ONLY. When set, the userfaultfd object will only be able to handle page faults originated from the user space on the registered regions.

If this is not set on kernels 5.11 or later, uffd will not work.