### PR TITLE
prov/efa: Improve the zero-copy recv error message.

### DIFF
--- a/prov/efa/src/efa_errno.h
+++ b/prov/efa/src/efa_errno.h
@@ -104,7 +104,8 @@
 	_(4121,	DGRAM_CQ_READ,			Error reading from DGRAM CQ)			\
 	_(4122,	SHM_INTERNAL_ERROR,		SHM internal error)				\
 	_(4123,	WRITE_SHM_CQ_ENTRY,		Failure to write CQ entry for SHM operation)	\
-	_(4124, ESTABLISHED_RECV_UNRESP,	Unresponsive receiver (connection previously established))
+	_(4124, ESTABLISHED_RECV_UNRESP,	Unresponsive receiver (connection previously established))	\
+	_(4125,	INVALID_PKT_TYPE_ZCPY_RX,	Invalid packet type received when zero copy recv mode is ON)
 
 /** @} */
 

--- a/prov/efa/src/efa_strerror.c
+++ b/prov/efa/src/efa_strerror.c
@@ -83,6 +83,11 @@ void efa_show_help(enum efa_errno err) {
 		"which indicates the error is likely due to the peer process no "
 		"longer being present.";
 		break;
+	case FI_EFA_ERR_INVALID_PKT_TYPE_ZCPY_RX:
+		help = "This error is detected locally. "
+		"Please consider matching the local and remote libfabric versions, or turning off "
+		"the zero-copy recv feature by setting FI_EFA_USE_ZCPY_RX=0 in the environment";
+		break;
 	default:
 		return;
 	}

--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -602,7 +602,7 @@ void efa_rdm_rxe_handle_error(struct efa_rdm_ope *rxe, int err, int prov_errno)
 	err_entry.buf = rxe->cq_entry.buf;
 	err_entry.data = rxe->cq_entry.data;
 	err_entry.tag = rxe->cq_entry.tag;
-	if (OFI_UNLIKELY(efa_rdm_write_error_msg(ep, rxe->addr, err, prov_errno,
+	if (OFI_UNLIKELY(efa_rdm_write_error_msg(ep, rxe->addr, prov_errno,
 	                                         &err_entry.err_data, &err_entry.err_data_size))) {
 		err_entry.err_data_size = 0;
 	}
@@ -694,7 +694,7 @@ void efa_rdm_txe_handle_error(struct efa_rdm_ope *txe, int err, int prov_errno)
 	err_entry.buf = txe->cq_entry.buf;
 	err_entry.data = txe->cq_entry.data;
 	err_entry.tag = txe->cq_entry.tag;
-	if (OFI_UNLIKELY(efa_rdm_write_error_msg(ep, txe->addr, err, prov_errno,
+	if (OFI_UNLIKELY(efa_rdm_write_error_msg(ep, txe->addr, prov_errno,
 	                                         &err_entry.err_data, &err_entry.err_data_size))) {
 		err_entry.err_data_size = 0;
 	}

--- a/prov/efa/src/rdm/efa_rdm_util.c
+++ b/prov/efa/src/rdm/efa_rdm_util.c
@@ -101,13 +101,12 @@ void efa_rdm_get_desc_for_shm(int numdesc, void **efa_desc, void **shm_desc)
  * @brief Write the error message and return its byte length
  * @param[in]    ep          EFA RDM endpoint
  * @param[in]    addr        Remote peer fi_addr_t
- * @param[in]    err         FI_* error code(must be positive)
  * @param[in]    prov_errno  EFA provider * error code(must be positive)
  * @param[out]   buf         Pointer to the address of error data written by this function
  * @param[out]   buflen      Pointer to the returned error data size
  * @return       A status code. 0 if the error data was written successfully, otherwise a negative FI error code.
  */
-int efa_rdm_write_error_msg(struct efa_rdm_ep *ep, fi_addr_t addr, int err, int prov_errno, void **buf, size_t *buflen)
+int efa_rdm_write_error_msg(struct efa_rdm_ep *ep, fi_addr_t addr, int prov_errno, void **buf, size_t *buflen)
 {
     char ep_addr_str[OFI_ADDRSTRLEN] = {0}, peer_addr_str[OFI_ADDRSTRLEN] = {0};
     char peer_host_id_str[EFA_HOST_ID_STRING_LENGTH + 1] = {0};

--- a/prov/efa/src/rdm/efa_rdm_util.h
+++ b/prov/efa/src/rdm/efa_rdm_util.h
@@ -19,7 +19,7 @@ bool efa_rdm_get_use_device_rdma(uint32_t fabric_api_version);
 
 void efa_rdm_get_desc_for_shm(int numdesc, void **efa_desc, void **shm_desc);
 
-int efa_rdm_write_error_msg(struct efa_rdm_ep *ep, fi_addr_t addr, int err, int prov_errno, void **buf, size_t *buflen);
+int efa_rdm_write_error_msg(struct efa_rdm_ep *ep, fi_addr_t addr, int prov_errno, void **buf, size_t *buflen);
 
 #ifdef ENABLE_EFA_POISONING
 static inline void efa_rdm_poison_mem_region(void *ptr, size_t size)


### PR DESCRIPTION
Extend the error message when the receiver has zcpy recv turned on but get a rtm pkt that it cannot handle. The extended error message includes possible root causes and the potential mitigations.