### PR TITLE
[v1.22.x] prov/efa: Use emulated read or READ NACK protocol if P2P is not available for RDMA read

### DIFF
--- a/prov/efa/docs/efa_rdm_protocol_v4.md
+++ b/prov/efa/docs/efa_rdm_protocol_v4.md
@@ -1505,8 +1505,9 @@ in order to support CQ entry generation in case the sender uses
 ### 4.7 Long read and runting read nack protocol
 
 Long read and runting read protocols in Libfabric 1.20 and above use a nack protocol
-when the receiver is unable to register a memory region for the RDMA read operation.
-Failure to register the memory region is typically because of a hardware limitation.
+when the receiver is unable to register a memory region for the RDMA read operation 
+or P2P support is unavailable for the RDMA read operation, typically because of a 
+hardware limitation.
 
 Table: 4.2 Format of the READ_NACK packet
 
@@ -1521,12 +1522,14 @@ Table: 4.2 Format of the READ_NACK packet
 
 The nack protocols work as follows
 * Sender has decided to use the long read or runting read protocol
-* The receiver receives the RTM packet(s)
+* The receiver receives the RTM packet(s) or RTW packet
    - One LONGREAD_RTM packet in case of long read protocol
    - Multiple RUNTREAD_RTM packets in case of runting read protocol
-* The receiver attempts to register a memory region for the RDMA operation but fails
-* After all RTM packets have been processed, the receiver sends a READ_NACK packet to the sender 
-* The sender then switches to the long CTS protocol and sends a LONGCTS_RTM packet
+   - One LONGREAD_RTW packet in case of emulated long-read write protocol
+* The receiver attempts to register a memory region for the RDMA operation but fails, 
+or P2P is unavailable for the RDMA operation
+* After all RTM/RTW packets have been processed, the receiver sends a READ_NACK packet to the sender 
+* The sender then switches to the long CTS protocol and sends a LONGCTS_RTM/LONGCTS_RTW packet
 * The receiver sends a CTS packet and the data transfer continues as in the long CTS protocol
 
 The LONGCTS_RTM packet sent in the nack protocol does not contain any application data.

--- a/prov/efa/src/rdm/efa_rdm_msg.c
+++ b/prov/efa/src/rdm/efa_rdm_msg.c
@@ -88,7 +88,8 @@ int efa_rdm_msg_select_rtm(struct efa_rdm_ep *efa_rdm_ep, struct efa_rdm_ope *tx
 
 	readbase_rtm = efa_rdm_peer_select_readbase_rtm(txe->peer, efa_rdm_ep, txe);
 
-	if (txe->total_len >= hmem_info[iface].min_read_msg_size &&
+	if (use_p2p && 
+		txe->total_len >= hmem_info[iface].min_read_msg_size &&
 		efa_rdm_interop_rdma_read(efa_rdm_ep, txe->peer) &&
 		(txe->desc[0] || efa_is_cache_available(efa_rdm_ep_domain(efa_rdm_ep))))
 		return readbase_rtm;

--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -1773,7 +1773,7 @@ ssize_t efa_rdm_ope_post_send_fallback(struct efa_rdm_ope *ope,
 		switch (pkt_type) {
 		case EFA_RDM_LONGREAD_MSGRTM_PKT:
 		case EFA_RDM_RUNTREAD_MSGRTM_PKT:
-			EFA_WARN(FI_LOG_EP_CTRL,
+			EFA_INFO(FI_LOG_EP_CTRL,
 				 "Sender fallback to long CTS untagged "
 				 "protocol because memory registration limit "
 				 "was reached on the sender\n");
@@ -1781,7 +1781,7 @@ ssize_t efa_rdm_ope_post_send_fallback(struct efa_rdm_ope *ope,
 				ope, EFA_RDM_LONGCTS_MSGRTM_PKT);
 		case EFA_RDM_LONGREAD_TAGRTM_PKT:
 		case EFA_RDM_RUNTREAD_TAGRTM_PKT:
-			EFA_WARN(FI_LOG_EP_CTRL,
+			EFA_INFO(FI_LOG_EP_CTRL,
 				 "Sender fallback to long CTS tagged protocol "
 				 "because memory registration limit was "
 				 "reached on the sender\n");

--- a/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
@@ -700,14 +700,19 @@ void efa_rdm_pke_handle_read_nack_recv(struct efa_rdm_pke *pkt_entry)
 	efa_rdm_pke_release_rx(pkt_entry);
 	txe->internal_flags |= EFA_RDM_OPE_READ_NACK;
 
-	if (txe->op == ofi_op_tagged) {
-		EFA_WARN(FI_LOG_EP_CTRL,
+	if (txe->op == ofi_op_write) {
+		EFA_INFO(FI_LOG_EP_CTRL,
+			 "Sender fallback to emulated long CTS write "
+			 "protocol because p2p is not available\n");
+		efa_rdm_ope_post_send_or_queue(txe, EFA_RDM_LONGCTS_RTW_PKT);
+	} else if (txe->op == ofi_op_tagged) {
+		EFA_INFO(FI_LOG_EP_CTRL,
 			 "Sender fallback to long CTS tagged "
 			 "protocol because memory registration limit "
 			 "was reached on the receiver\n");
 		efa_rdm_ope_post_send_or_queue(txe, EFA_RDM_LONGCTS_TAGRTM_PKT);
 	} else {
-		EFA_WARN(FI_LOG_EP_CTRL,
+		EFA_INFO(FI_LOG_EP_CTRL,
 			 "Sender fallback to long CTS untagged "
 			 "protocol because memory registration limit "
 			 "was reached on the receiver\n");

--- a/prov/efa/src/rdm/efa_rdm_pke_rtw.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtw.c
@@ -557,14 +557,14 @@ void efa_rdm_pke_handle_longread_rtw_recv(struct efa_rdm_pke *pkt_entry)
 	memcpy(rxe->rma_iov, read_iov,
 	       rxe->rma_iov_count * sizeof(struct fi_rma_iov));
 
+	err = efa_rdm_pke_post_remote_read_or_nack(rxe->ep, pkt_entry, rxe);
+
 	efa_rdm_pke_release_rx(pkt_entry);
 
-	err = efa_rdm_ope_post_remote_read_or_queue(rxe);
 	if (OFI_UNLIKELY(err)) {
 		EFA_WARN(FI_LOG_CQ,
 			"RDMA post read or queue failed.\n");
 		efa_base_ep_write_eq_error(&ep->base_ep, err, FI_EFA_ERR_RDMA_READ_POST);
 		efa_rdm_rxe_release(rxe);
-		efa_rdm_pke_release_rx(pkt_entry);
 	}
 }

--- a/prov/efa/src/rdm/efa_rdm_pke_utils.h
+++ b/prov/efa/src/rdm/efa_rdm_pke_utils.h
@@ -58,6 +58,78 @@ size_t efa_rdm_pke_get_segment_offset(struct efa_rdm_pke *pke)
 	return 0;
 }
 
+/** 
+ * @brief This function either posts RDMA read, or sends a NACK packet when p2p
+ * is not available or memory registration limit was reached on the receiver.
+ *
+ * @param[in]    ep         endpoint
+ * @param[in]    pkt_entry  packet entry
+ * @param[in]    rxe        RX entry
+ *
+ * @return 0 on success, or a negative error code.
+ */
+static inline int
+efa_rdm_pke_post_remote_read_or_nack(struct efa_rdm_ep  *ep,
+                                     struct efa_rdm_pke *pkt_entry,
+                                     struct efa_rdm_ope *rxe)
+{
+	int err = 0;
+	int pkt_type;
+	int p2p_avail;
+
+	pkt_type = efa_rdm_pke_get_base_hdr(pkt_entry)->type;
+	err = efa_rdm_ep_use_p2p(ep, rxe->desc[0]);
+	if (err < 0)
+		return err;
+
+	p2p_avail = err;
+	if (p2p_avail) {
+		err = efa_rdm_ope_post_remote_read_or_queue(rxe);
+	} else if (efa_rdm_peer_support_read_nack(rxe->peer)) {
+		EFA_INFO(FI_LOG_EP_CTRL,
+			 "Receiver sending long read "
+			 "NACK packet because P2P is not available, "
+			 "unable to post RDMA read.\n");
+		goto send_nack;
+	} else {
+		EFA_INFO(FI_LOG_EP_CTRL, "P2P is not available, "
+					 "unable to post RDMA read.\n");
+		return -FI_EOPNOTSUPP;
+	}
+
+	if (err == -FI_ENOMR) {
+		if (efa_rdm_peer_support_read_nack(rxe->peer)) {
+			EFA_INFO(FI_LOG_EP_CTRL, "Receiver sending long read "
+						 "NACK packet because memory "
+						 "registration limit was "
+						 "reached on the receiver.\n");
+			goto send_nack;
+		} else {
+			/* Peer does not support the READ_NACK packet. So we
+			 * return EAGAIN and hope that the app runs progress
+			 * again which will free some MR registrations */
+			return -FI_EAGAIN;
+		}
+	}
+
+	return err;
+
+send_nack:
+	rxe->internal_flags |= EFA_RDM_OPE_READ_NACK;
+	/* Only set the flag for runting read. The NACK
+	 * packet is sent after all runting read
+	 * RTM packets have been received */
+	if (efa_rdm_pkt_type_is_runtread(pkt_type)) {
+		return 0;
+	}
+
+	if (efa_rdm_pkt_type_is_rtm(pkt_type)) {
+		efa_rdm_rxe_map_insert(&ep->rxe_map, pkt_entry, rxe);
+	}
+
+	return efa_rdm_ope_post_send_or_queue(rxe, EFA_RDM_READ_NACK_PKT);
+}
+
 size_t efa_rdm_pke_get_payload_offset(struct efa_rdm_pke *pkt_entry);
 
 ssize_t efa_rdm_pke_init_payload_from_ope(struct efa_rdm_pke *pke,

--- a/prov/efa/src/rdm/efa_rdm_rma.c
+++ b/prov/efa/src/rdm/efa_rdm_rma.c
@@ -117,7 +117,8 @@ ssize_t efa_rdm_rma_post_efa_emulated_read(struct efa_rdm_ep *ep, struct efa_rdm
 ssize_t efa_rdm_rma_post_read(struct efa_rdm_ep *ep, struct efa_rdm_ope *txe)
 {
 	bool use_device_read = false;
-	ssize_t ret;
+	int use_p2p;
+	ssize_t ret, err;
 
 	/*
 	 * A handshake is required to choose the correct protocol (whether to use device read).
@@ -127,7 +128,14 @@ ssize_t efa_rdm_rma_post_read(struct efa_rdm_ep *ep, struct efa_rdm_ope *txe)
 	if (!(txe->peer->is_self) && !(txe->peer->flags & EFA_RDM_PEER_HANDSHAKE_RECEIVED))
 		return efa_rdm_ep_enforce_handshake_for_txe(ep, txe);
 
-	if (efa_rdm_interop_rdma_read(ep, txe->peer)) {
+	/* Check p2p support. Cannot use device read when p2p is not available. */
+	err = efa_rdm_ep_use_p2p(ep, txe->desc[0]);
+	if (err < 0)
+		return err;
+
+	use_p2p = err;
+
+	if (use_p2p && efa_rdm_interop_rdma_read(ep, txe->peer)) {
 		/* RDMA read interoperability check also checks domain.use_device_rdma,
 		 * so we do not check it here
 		 */
@@ -137,11 +145,6 @@ ssize_t efa_rdm_rma_post_read(struct efa_rdm_ep *ep, struct efa_rdm_ope *txe)
 		return -FI_EOPNOTSUPP;
 	}
 
-	/*
-	 * Not going to check efa_ep->hmem_p2p_opt here, if the remote side
-	 * gave us a valid MR we should just honor the request even if p2p is
-	 * disabled.
-	 */
 	if (use_device_read) {
 		ret = efa_rdm_ope_prepare_to_post_read(txe);
 		if (ret)
@@ -351,7 +354,7 @@ ssize_t efa_rdm_rma_post_write(struct efa_rdm_ep *ep, struct efa_rdm_ope *txe)
 {
 	ssize_t err;
 	bool delivery_complete_requested;
-	int ctrl_type, iface;
+	int ctrl_type, iface, use_p2p;
 	size_t max_eager_rtw_data_size;
 
 	/*
@@ -388,9 +391,16 @@ ssize_t efa_rdm_rma_post_write(struct efa_rdm_ep *ep, struct efa_rdm_ope *txe)
 		max_eager_rtw_data_size = efa_rdm_txe_max_req_data_capacity(ep, txe, EFA_RDM_EAGER_RTW_PKT);
 	}
 
+	err = efa_rdm_ep_use_p2p(ep, txe->desc[0]);
+	if (err < 0)
+		return err;
+
+	use_p2p = err;
+
 	iface = txe->desc[0] ? ((struct efa_mr*) txe->desc[0])->peer.iface : FI_HMEM_SYSTEM;
 
-	if (txe->total_len >= efa_rdm_ep_domain(ep)->hmem_info[iface].min_read_write_size &&
+	if (use_p2p && 
+		txe->total_len >= efa_rdm_ep_domain(ep)->hmem_info[iface].min_read_write_size &&
 		efa_rdm_interop_rdma_read(ep, txe->peer) &&
 		(txe->desc[0] || efa_is_cache_available(efa_rdm_ep_domain(ep)))) {
 		err = efa_rdm_ope_post_send(txe, EFA_RDM_LONGREAD_RTW_PKT);


### PR DESCRIPTION
Backport https://github.com/ofiwg/libfabric/pull/10352 and  https://github.com/ofiwg/libfabric/pull/10363