### PR TITLE
[v1.21.x] prov/efa: Use emulated read or READ NACK protocol if P2P is not available for RDMA read

### DIFF
--- a/prov/efa/docs/efa_rdm_protocol_v4.md
+++ b/prov/efa/docs/efa_rdm_protocol_v4.md
@@ -1497,8 +1497,9 @@ in order to support CQ entry generation in case the sender uses
 ### 4.7 Long read and runting read nack protocol
 
 Long read and runting read protocols in Libfabric 1.20 and above use a nack protocol
-when the receiver is unable to register a memory region for the RDMA read operation.
-Failure to register the memory region is typically because of a hardware limitation.
+when the receiver is unable to register a memory region for the RDMA read operation 
+or P2P support is unavailable for the RDMA read operation, typically because of a 
+hardware limitation.
 
 Table: 4.2 Format of the READ_NACK packet
 
@@ -1513,12 +1514,14 @@ Table: 4.2 Format of the READ_NACK packet
 
 The nack protocols work as follows
 * Sender has decided to use the long read or runting read protocol
-* The receiver receives the RTM packet(s)
+* The receiver receives the RTM packet(s) or RTW packet
    - One LONGREAD_RTM packet in case of long read protocol
    - Multiple RUNTREAD_RTM packets in case of runting read protocol
-* The receiver attempts to register a memory region for the RDMA operation but fails
-* After all RTM packets have been processed, the receiver sends a READ_NACK packet to the sender 
-* The sender then switches to the long CTS protocol and sends a LONGCTS_RTM packet
+   - One LONGREAD_RTW packet in case of emulated long-read write protocol
+* The receiver attempts to register a memory region for the RDMA operation but fails, 
+or P2P is unavailable for the RDMA operation
+* After all RTM/RTW packets have been processed, the receiver sends a READ_NACK packet to the sender 
+* The sender then switches to the long CTS protocol and sends a LONGCTS_RTM/LONGCTS_RTW packet
 * The receiver sends a CTS packet and the data transfer continues as in the long CTS protocol
 
 The LONGCTS_RTM packet sent in the nack protocol does not contain any application data.

--- a/prov/efa/src/rdm/efa_rdm_msg.c
+++ b/prov/efa/src/rdm/efa_rdm_msg.c
@@ -88,7 +88,8 @@ int efa_rdm_msg_select_rtm(struct efa_rdm_ep *efa_rdm_ep, struct efa_rdm_ope *tx
 
 	readbase_rtm = efa_rdm_peer_select_readbase_rtm(txe->peer, efa_rdm_ep, txe);
 
-	if (txe->total_len >= hmem_info[iface].min_read_msg_size &&
+	if (use_p2p && 
+		txe->total_len >= hmem_info[iface].min_read_msg_size &&
 		efa_rdm_interop_rdma_read(efa_rdm_ep, txe->peer) &&
 		(txe->desc[0] || efa_is_cache_available(efa_rdm_ep_domain(efa_rdm_ep))))
 		return readbase_rtm;

--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -1768,7 +1768,7 @@ ssize_t efa_rdm_ope_post_send_fallback(struct efa_rdm_ope *ope,
 		switch (pkt_type) {
 		case EFA_RDM_LONGREAD_MSGRTM_PKT:
 		case EFA_RDM_RUNTREAD_MSGRTM_PKT:
-			EFA_WARN(FI_LOG_EP_CTRL,
+			EFA_INFO(FI_LOG_EP_CTRL,
 				 "Sender fallback to long CTS untagged "
 				 "protocol because memory registration limit "
 				 "was reached on the sender\n");
@@ -1776,7 +1776,7 @@ ssize_t efa_rdm_ope_post_send_fallback(struct efa_rdm_ope *ope,
 				ope, EFA_RDM_LONGCTS_MSGRTM_PKT);
 		case EFA_RDM_LONGREAD_TAGRTM_PKT:
 		case EFA_RDM_RUNTREAD_TAGRTM_PKT:
-			EFA_WARN(FI_LOG_EP_CTRL,
+			EFA_INFO(FI_LOG_EP_CTRL,
 				 "Sender fallback to long CTS tagged protocol "
 				 "because memory registration limit was "
 				 "reached on the sender\n");

--- a/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
@@ -682,14 +682,19 @@ void efa_rdm_pke_handle_read_nack_recv(struct efa_rdm_pke *pkt_entry)
 	efa_rdm_pke_release_rx(pkt_entry);
 	txe->internal_flags |= EFA_RDM_OPE_READ_NACK;
 
-	if (txe->op == ofi_op_tagged) {
-		EFA_WARN(FI_LOG_EP_CTRL,
+	if (txe->op == ofi_op_write) {
+		EFA_INFO(FI_LOG_EP_CTRL,
+			 "Sender fallback to emulated long CTS write "
+			 "protocol because p2p is not available\n");
+		efa_rdm_ope_post_send_or_queue(txe, EFA_RDM_LONGCTS_RTW_PKT);
+	} else if (txe->op == ofi_op_tagged) {
+		EFA_INFO(FI_LOG_EP_CTRL,
 			 "Sender fallback to long CTS tagged "
 			 "protocol because memory registration limit "
 			 "was reached on the receiver\n");
 		efa_rdm_ope_post_send_or_queue(txe, EFA_RDM_LONGCTS_TAGRTM_PKT);
 	} else {
-		EFA_WARN(FI_LOG_EP_CTRL,
+		EFA_INFO(FI_LOG_EP_CTRL,
 			 "Sender fallback to long CTS untagged "
 			 "protocol because memory registration limit "
 			 "was reached on the receiver\n");

--- a/prov/efa/src/rdm/efa_rdm_pke_rtm.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtm.c
@@ -862,14 +862,12 @@ ssize_t efa_rdm_pke_proc_matched_mulreq_rtm(struct efa_rdm_pke *pkt_entry)
 	struct efa_rdm_ep *ep;
 	struct efa_rdm_ope *rxe;
 	struct efa_rdm_pke *cur, *nxt;
-	struct efa_rdm_peer *peer;
 	int pkt_type;
 	ssize_t ret, err;
 	uint64_t msg_id;
 
 	ep = pkt_entry->ep;
 	rxe = pkt_entry->ope;
-	peer = rxe->peer;
 	pkt_type = efa_rdm_pke_get_base_hdr(pkt_entry)->type;
 
 	ret = 0;
@@ -888,20 +886,9 @@ ssize_t efa_rdm_pke_proc_matched_mulreq_rtm(struct efa_rdm_pke *pkt_entry)
 			efa_rdm_tracepoint(runtread_read_posted, rxe->msg_id,
 				    (size_t) rxe->cq_entry.op_context, rxe->total_len);
 
-			err = efa_rdm_ope_post_remote_read_or_queue(rxe);
-			if (err) {
-				if (err == -FI_ENOMR) {
-					if (efa_rdm_peer_support_read_nack(peer))
-						/* Only set the flag here. The NACK
-						 * packet is sent after all runting read
-						 * RTM packets have been received */
-						rxe->internal_flags |= EFA_RDM_OPE_READ_NACK;
-					else
-						ret = -FI_EAGAIN;
-				} else {
-					return err;
-				}
-			}
+			err = efa_rdm_pke_post_remote_read_or_nack(ep, pkt_entry, rxe);
+			if (err)
+				return err;
 		}
 	}
 
@@ -917,7 +904,7 @@ ssize_t efa_rdm_pke_proc_matched_mulreq_rtm(struct efa_rdm_pke *pkt_entry)
 		if (efa_rdm_ope_mulreq_total_data_size(rxe, pkt_type) ==
 		    rxe->bytes_received_via_mulreq) {
 			if (rxe->internal_flags & EFA_RDM_OPE_READ_NACK) {
-				EFA_WARN(FI_LOG_EP_CTRL,
+				EFA_INFO(FI_LOG_EP_CTRL,
 					 "Receiver sending long read NACK "
 					 "packet because memory registration "
 					 "limit was reached on the receiver\n");
@@ -1191,12 +1178,10 @@ ssize_t efa_rdm_pke_proc_matched_longread_rtm(struct efa_rdm_pke *pkt_entry)
 	struct efa_rdm_longread_rtm_base_hdr *rtm_hdr;
 	struct fi_rma_iov *read_iov;
 	struct efa_rdm_ep *ep;
-	struct efa_rdm_peer *peer;
 	int err;
 
 	rxe = pkt_entry->ope;
 	ep = rxe->ep;
-	peer = rxe->peer;
 
 	rtm_hdr = efa_rdm_pke_get_longread_rtm_base_hdr(pkt_entry);
 	read_iov = (struct fi_rma_iov *)(pkt_entry->wiredata + efa_rdm_pke_get_req_hdr_size(pkt_entry));
@@ -1209,24 +1194,8 @@ ssize_t efa_rdm_pke_proc_matched_longread_rtm(struct efa_rdm_pke *pkt_entry)
 	efa_rdm_tracepoint(longread_read_posted, rxe->msg_id,
 		    (size_t) rxe->cq_entry.op_context, rxe->total_len);
 
-	err = efa_rdm_ope_post_remote_read_or_queue(rxe);
-	if (err == -FI_ENOMR) {
-		if (efa_rdm_peer_support_read_nack(peer)) {
-			EFA_WARN(FI_LOG_EP_CTRL, "Receiver sending long read "
-						 "NACK packet because memory "
-						 "registration limit was "
-						 "reached on the receiver\n");
-			efa_rdm_rxe_map_insert(&ep->rxe_map, pkt_entry, rxe);
-			rxe->internal_flags |= EFA_RDM_OPE_READ_NACK;
-			err = efa_rdm_ope_post_send_or_queue(
-				rxe, EFA_RDM_READ_NACK_PKT);
-		} else {
-			/* Peer does not support the READ_NACK packet. So we
-			 * return EAGAIN and hope that the app runs progress
-			 * again which will free some MR registrations */
-			err = -FI_EAGAIN;
-		}
-	}
+	err = efa_rdm_pke_post_remote_read_or_nack(ep, pkt_entry, rxe);
+
 	efa_rdm_pke_release_rx(pkt_entry);
 	return err;
 }

--- a/prov/efa/src/rdm/efa_rdm_pke_rtw.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtw.c
@@ -557,14 +557,14 @@ void efa_rdm_pke_handle_longread_rtw_recv(struct efa_rdm_pke *pkt_entry)
 	memcpy(rxe->rma_iov, read_iov,
 	       rxe->rma_iov_count * sizeof(struct fi_rma_iov));
 
+	err = efa_rdm_pke_post_remote_read_or_nack(rxe->ep, pkt_entry, rxe);
+
 	efa_rdm_pke_release_rx(pkt_entry);
 
-	err = efa_rdm_ope_post_remote_read_or_queue(rxe);
 	if (OFI_UNLIKELY(err)) {
 		EFA_WARN(FI_LOG_CQ,
 			"RDMA post read or queue failed.\n");
 		efa_base_ep_write_eq_error(&ep->base_ep, err, FI_EFA_ERR_RDMA_READ_POST);
 		efa_rdm_rxe_release(rxe);
-		efa_rdm_pke_release_rx(pkt_entry);
 	}
 }

--- a/prov/efa/src/rdm/efa_rdm_pkt_type.h
+++ b/prov/efa/src/rdm/efa_rdm_pkt_type.h
@@ -122,6 +122,38 @@ bool efa_rdm_pkt_type_is_longcts_req(int pkt_type)
 }
 
 /**
+ * @brief determine whether a req pkt type is RTM
+ *
+ * @param[in]		pkt_type		REQ packet type
+ * @return		a boolean
+ */
+static inline
+bool efa_rdm_pkt_type_is_rtm(int pkt_type)
+{
+	switch(pkt_type) {
+	case EFA_RDM_EAGER_MSGRTM_PKT:
+	case EFA_RDM_EAGER_TAGRTM_PKT:
+	case EFA_RDM_DC_EAGER_MSGRTM_PKT:
+	case EFA_RDM_DC_EAGER_TAGRTM_PKT:
+	case EFA_RDM_MEDIUM_MSGRTM_PKT:
+	case EFA_RDM_MEDIUM_TAGRTM_PKT:
+	case EFA_RDM_DC_MEDIUM_MSGRTM_PKT:
+	case EFA_RDM_DC_MEDIUM_TAGRTM_PKT:
+	case EFA_RDM_LONGCTS_MSGRTM_PKT:
+	case EFA_RDM_LONGCTS_TAGRTM_PKT:
+	case EFA_RDM_DC_LONGCTS_MSGRTM_PKT:
+	case EFA_RDM_DC_LONGCTS_TAGRTM_PKT:
+	case EFA_RDM_LONGREAD_MSGRTM_PKT:
+	case EFA_RDM_LONGREAD_TAGRTM_PKT:
+	case EFA_RDM_RUNTREAD_MSGRTM_PKT:
+	case EFA_RDM_RUNTREAD_TAGRTM_PKT:
+		return 1;
+	default:
+		return 0;
+	}
+}
+
+/**
  * @brief determine whether a req pkt type is RTA
  *
  * @param[in]		pkt_type		REQ packet type


### PR DESCRIPTION
Backport https://github.com/ofiwg/libfabric/pull/10352 and https://github.com/ofiwg/libfabric/pull/10363