### PR TITLE
util/av: Log AV insert with AV's specified address format

### DIFF
--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -903,14 +903,14 @@ uint32_t ofi_addr_format(const char *str);
 int ofi_str_toaddr(const char *str, uint32_t *addr_format,
 		   void **addr, size_t *len);
 
-void ofi_straddr_log_internal(const char *func, int line,
+void ofi_straddr_log_internal(const char *func, int line, uint32_t addr_format,
 			      const struct fi_provider *prov,
 			      enum fi_log_level level,
 			      enum fi_log_subsys subsys, char *log_str,
 			      const void *addr);
 
 #define ofi_straddr_log(...) \
-	ofi_straddr_log_internal(__func__, __LINE__, __VA_ARGS__)
+	ofi_straddr_log_internal(__func__, __LINE__, FI_FORMAT_UNSPEC, __VA_ARGS__)
 
 #if ENABLE_DEBUG
 #define ofi_straddr_dbg(prov, subsystem, ...) \

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -835,6 +835,10 @@ static inline void ofi_ep_peer_rx_cntr_incerr(struct util_ep *ep, uint8_t op)
  * AV / addressing
  */
 
+#define ofi_av_straddr_log(av, level, ...) \
+	ofi_straddr_log_internal(__func__, __LINE__, av->domain->addr_format, \
+			av->prov, level, FI_LOG_AV, __VA_ARGS__)
+
 struct util_av;
 struct util_av_set;
 struct util_peer_addr;

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -276,14 +276,13 @@ int ofi_av_insert_addr_at(struct util_av *av, const void *addr, fi_addr_t fi_add
 	struct util_av_entry *entry = NULL;
 
 	assert(ofi_mutex_held(&av->lock));
-	ofi_straddr_log(av->prov, FI_LOG_INFO, FI_LOG_AV, "inserting addr", addr);
+	ofi_av_straddr_log(av, FI_LOG_INFO, "inserting addr", addr);
 	HASH_FIND(hh, av->hash, addr, av->addrlen, entry);
 	if (entry) {
 		if (fi_addr == ofi_buf_index(entry))
 			return FI_SUCCESS;
 
-		ofi_straddr_log(av->prov, FI_LOG_WARN, FI_LOG_AV,
-						"addr already in AV", addr);
+		ofi_av_straddr_log(av, FI_LOG_WARN, "addr already in AV", addr);
 		return -FI_EALREADY;
 	}
 
@@ -304,14 +303,13 @@ int ofi_av_insert_addr(struct util_av *av, const void *addr, fi_addr_t *fi_addr)
 	struct util_av_entry *entry = NULL;
 
 	assert(ofi_mutex_held(&av->lock));
-	ofi_straddr_log(av->prov, FI_LOG_INFO, FI_LOG_AV, "inserting addr", addr);
+	ofi_av_straddr_log(av, FI_LOG_INFO, "inserting addr", addr);
 	HASH_FIND(hh, av->hash, addr, av->addrlen, entry);
 	if (entry) {
 		if (fi_addr)
 			*fi_addr = ofi_buf_index(entry);
 		if (ofi_atomic_inc32(&entry->use_cnt) > 1) {
-			ofi_straddr_log(av->prov, FI_LOG_WARN, FI_LOG_AV,
-							"addr already in AV", addr);
+			ofi_av_straddr_log(av, FI_LOG_WARN, "addr already in AV", addr);
 		}
 	} else {
 		entry = ofi_ibuf_alloc(av->av_entry_pool);

--- a/src/common.c
+++ b/src/common.c
@@ -1053,19 +1053,19 @@ size_t ofi_mask_addr(struct sockaddr *maskaddr, const struct sockaddr *srcaddr,
 	return len;
 }
 
-void ofi_straddr_log_internal(const char *func, int line,
+void ofi_straddr_log_internal(const char *func, int line, uint32_t addr_format,
 			      const struct fi_provider *prov,
 			      enum fi_log_level level,
 			      enum fi_log_subsys subsys, char *log_str,
 			      const void *addr)
 {
 	char buf[OFI_ADDRSTRLEN];
-	uint32_t addr_format;
 	size_t len = sizeof(buf);
 
 	if (fi_log_enabled(prov, level, subsys)) {
 		if (addr) {
-			addr_format = ofi_translate_addr_format(ofi_sa_family(addr));
+			if (addr_format == FI_FORMAT_UNSPEC)
+				addr_format = ofi_translate_addr_format(ofi_sa_family(addr));
 			fi_log(prov, level, subsys, func, line, "%s: %s\n", log_str,
 			       ofi_straddr(buf, &len, addr_format, addr));
 		} else {


### PR DESCRIPTION
This prevents `(null)` from being logged when addr isn't compatible with `struct sockaddr`