### PR TITLE
prov/efa: Some cleanups

### DIFF
--- a/prov/efa/docs/efa_rdm_protocol_v4.md
+++ b/prov/efa/docs/efa_rdm_protocol_v4.md
@@ -414,7 +414,7 @@ Note, the field `extra_info` was named `features` when protocol v4 was initially
 only planned for extra features. Later, we discovered that the handshake subprotocol can also be used to pass
 additional request information, thus introduced the concept of "extra request" and renamed this field `extra_info`.
 
-`nextra_p3` is number of `extra_info` flags of the endpoint plus 3. The "plus 3" is for historical reasons.
+`nextra_p3` is number of 64-bit `extra_info` elements of the endpoint plus 3. The "plus 3" is for historical reasons.
 When protocol v4 was initially introduced, this field is named `maxproto`. The original plan was that protocol
 v4 can only have 64 extra features/requests. If the number of extra feature/request ever exceeds 64, the next
 feature/request will be defined as version 5 feature/request, (version 6 if the number exceeds 128, so on so

--- a/prov/efa/src/rdm/efa_rdm_peer.h
+++ b/prov/efa/src/rdm/efa_rdm_peer.h
@@ -60,8 +60,6 @@ struct efa_rdm_peer {
 	int rnr_queued_pkt_cnt;		/**< queued RNR packet count */
 	struct dlist_entry rnr_backoff_entry;	/**< linked to efa_domain->peer_backoff_list */
 	struct dlist_entry handshake_queued_entry; /**< linked with efa_domain->handshake_queued_peer_list */
-	struct dlist_entry rx_unexp_list; /**< a list of unexpected untagged rxe for this peer */
-	struct dlist_entry rx_unexp_tagged_list; /**< a list of unexpected tagged rxe for this peer */
 	struct dlist_entry txe_list; /**< a list of txe related to this peer */
 	struct dlist_entry rxe_list; /**< a list of rxe relased to this peer */
 	struct dlist_entry overflow_pke_list; /**< a list of out-of-order pke that overflow the current recvwin */

--- a/prov/efa/src/rdm/efa_rdm_protocol.h
+++ b/prov/efa/src/rdm/efa_rdm_protocol.h
@@ -41,7 +41,12 @@ struct efa_ep_addr {
 #define EFA_RDM_EXTRA_FEATURE_READ_NACK		BIT_ULL(6)
 #define EFA_RDM_EXTRA_FEATURE_REQUEST_USER_RECV_QP	BIT_ULL(7)
 #define EFA_RDM_NUM_EXTRA_FEATURE_OR_REQUEST		8
-#define EFA_RDM_MAX_NUM_EXINFO				(256)
+/*
+ * The length of 64-bit extra_info array used in efa_rdm_ep
+ * and efa_rdm_peer
+ * 4 means 64*4=256 bits of extra features or requests
+ */
+#define EFA_RDM_MAX_NUM_EXINFO				(4)
 
 /*
  * Packet type ID of each packet type (section 1.3)


### PR DESCRIPTION
This PR contains 2 commits that cleans up efa_rdm_ep and efa_rdm_peer structs.