### PR TITLE
core: 1.8 ABI compat

### DIFF
--- a/include/ofi_abi.h
+++ b/include/ofi_abi.h
@@ -111,7 +111,7 @@ extern "C" {
  * name appended with the ABI version that it is compatible with.
  */
 
-#define CURRENT_ABI "FABRIC_1.7"
+#define CURRENT_ABI "FABRIC_1.8"
 
 #if  HAVE_ALIAS_ATTRIBUTE == 1
 #define DEFAULT_SYMVER_PRE(a) a##_

--- a/man/fabric.7.md
+++ b/man/fabric.7.md
@@ -447,6 +447,14 @@ attributes:
 *fi_domain_attr*
 : Added max_ep_auth_key
 
+## ABI 1.8
+
+ABI version starting with libfabric 2.0. Added new fi_fabric2 API call.
+Added new fields to the following attributes:
+
+*fi_domain_attr*
+: Added max_group_id
+
 # SEE ALSO
 
 [`fi_info`(1)](fi_info.1.html),


### PR DESCRIPTION
ABI version is updated to 1.8 to accommodate fi_fabric2() API introduced in https://github.com/ofiwg/libfabric/pull/10279