### PR TITLE
core: Add endpoint option for traffic class

### DIFF
--- a/include/rdma/fi_endpoint.h
+++ b/include/rdma/fi_endpoint.h
@@ -78,6 +78,7 @@ enum {
 	FI_OPT_INJECT_TAGGED_SIZE,	/* size_t */
 	FI_OPT_INJECT_RMA_SIZE,		/* size_t */
 	FI_OPT_INJECT_ATOMIC_SIZE,	/* size_t */
+	FI_OPT_TRAFFIC_CLASS,		/* int */
 };
 
 /*

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -606,6 +606,12 @@ The following option levels and option names and parameters are defined.
   Providers that don't support this option will return -FI_ENOPROTOOPT. In that
   case, `tx_attr->inject_size` should be used.
 
+- *FI_OPT_TRAFFIC_CLASS - int *
+: Define the traffic class (tclass) for this endpoint. See the `Traffic Class (tclass)`
+  section for more information and allowed values.
+  Providers that don't support this option will return -FI_ENOPROTOOPT. In that
+  case, `tx_attr->tclass` should be used.
+
 ## fi_tc_dscp_set
 
 This call converts a DSCP defined value into a libfabric traffic class value.


### PR DESCRIPTION
Today, traffic class (tclass) is a global configuration per fi_info, which doesn't allow application to
configure it for certain endpoints. This patch removes such restriction by introducing a new endpoint option for traffic class, with allowed values inherited from the current tclass values.

A typical application will call fi_setopt() to set the tclass for a given endpoint, and call fi_getopt() to retrieve the tclass value.

Providers that don't support this option will return -FI_ENOPROTOOPT. In that case, `tx_attr->tclass` should be used.