### PR TITLE
fabtests/prov/lpp: fix compile warnings

### DIFF
--- a/fabtests/prov/lpp/src/atomic.c
+++ b/fabtests/prov/lpp/src/atomic.c
@@ -32,7 +32,7 @@
 
 #include "test_util.h"
 
-const static uint64_t context = 0xabce;
+static const uint64_t context = 0xabce;
 
 int run_simple_atomic_write(struct rank_info *ri)
 {

--- a/fabtests/prov/lpp/src/main.c
+++ b/fabtests/prov/lpp/src/main.c
@@ -78,7 +78,7 @@ enum node_id my_node;
 // Note: the two large RMA tests are intentionally far apart to reduce the
 // chances they run simultaneously. On configs with small IOVAs spaces, this
 // can be a problem. This only matters when running with -p > 1, of course.
-const static struct test testlist[] = {
+static const struct test testlist[] = {
 	{ run_simple_rma_write,                    "simple_rma_write" },
 	{ run_offset_rma_write,                    "offset_rma_write" },
 	{ run_inject_rma_write,                    "inject_rma_write" },
@@ -273,7 +273,7 @@ static void *worker_thread(void *arg)
 	return (void*)1;
 }
 
-static void inline populate_filtered_testlist(const struct test* tlist,
+static inline void populate_filtered_testlist(const struct test* tlist,
 							size_t num_tests)
 {
 	for (int i = 0; i < num_tests; i++) {

--- a/fabtests/prov/lpp/src/msg.c
+++ b/fabtests/prov/lpp/src/msg.c
@@ -34,7 +34,7 @@
 
 #include "test_util.h"
 
-const static uint64_t context = 0xabcd;
+static const uint64_t context = 0xabcd;
 
 int run_simple_msg(struct rank_info *ri)
 {

--- a/fabtests/prov/lpp/src/rcq_data.c
+++ b/fabtests/prov/lpp/src/rcq_data.c
@@ -1,6 +1,6 @@
 #include "test_util.h"
 
-const static uint64_t context = 0xabcd;
+static const uint64_t context = 0xabcd;
 
 int run_fi_tsenddata(struct rank_info *ri){
 	struct wait_tx_cq_params wait_tx_cq_params = { 0 };

--- a/fabtests/prov/lpp/src/rma.c
+++ b/fabtests/prov/lpp/src/rma.c
@@ -32,7 +32,7 @@
 
 #include "test_util.h"
 
-const static uint64_t context = 0xabcd;
+static const uint64_t context = 0xabcd;
 
 static int simple_rma_write_common(struct rank_info *ri, size_t buffer_len)
 {

--- a/fabtests/prov/lpp/src/test_util.h
+++ b/fabtests/prov/lpp/src/test_util.h
@@ -167,8 +167,8 @@ static inline struct fi_context *get_ctx_simple(struct rank_info *ri,
 }
 void free_ctx_tree(struct rank_info *ri);
 
-const static unsigned int seed_node_a = 1234;
-const static unsigned int seed_node_b = 9876;
+static const unsigned int seed_node_a = 1234;
+static const unsigned int seed_node_b = 9876;
 
 #ifdef USE_HMEM
 void hmem_init(void);


### PR DESCRIPTION
Fix compiler warnings about incorrect placement of const and inline identifiers