### PR TITLE
[v1.22.x] fabtests/pytest/efa: Skip memory registration that hit device limit

### DIFF
--- a/fabtests/pytest/efa/test_unexpected_msg.py
+++ b/fabtests/pytest/efa/test_unexpected_msg.py
@@ -20,6 +20,12 @@ def test_unexpected_msg(cmdline_args, msg_size, msg_count, memory_type, completi
     neuron_maximal_buffer_size = 2**32
     if "neuron" in memory_type and allocated_memory >= neuron_maximal_buffer_size:
         pytest.skip("Cannot hit neuron allocation limit")
+
+     # The EFA limit for single MR that enables remote write is 1M pages aka 4GB for regular pages
+    maximal_mr_size = 2**32
+    if allocated_memory >= maximal_mr_size:
+        pytest.skip("Cannot hit EFA MR limit")
+
     efa_run_client_server_test(cmdline_args, f"fi_unexpected_msg -e rdm -M {msg_count}", iteration_type="short",
                                completion_semantic=completion_semantic, memory_type=memory_type,
                                message_size=msg_size, completion_type="queue", timeout=1800)


### PR DESCRIPTION
backport https://github.com/ofiwg/libfabric/pull/10402