### PR TITLE
prov/efa/test: Disable shm via fi_setopt

### DIFF
--- a/prov/efa/test/efa_unit_test_common.c
+++ b/prov/efa/test/efa_unit_test_common.c
@@ -166,6 +166,39 @@ err:
 }
 
 /**
+ * @brief Construct RDM ep type resources with shm disabled
+ */
+void efa_unit_test_resource_construct_rdm_shm_disabled(struct efa_resource *resource)
+{
+	int ret;
+	bool shm_permitted = false;
+
+	resource->hints = efa_unit_test_alloc_hints(FI_EP_RDM);
+	if (!resource->hints)
+		goto err;
+
+	efa_unit_test_resource_construct_with_hints(resource, FI_EP_RDM, FI_VERSION(1, 14),
+						    resource->hints, false, true);
+
+	ret = fi_setopt(&resource->ep->fid, FI_OPT_ENDPOINT,
+			FI_OPT_SHARED_MEMORY_PERMITTED, &shm_permitted,
+			sizeof(shm_permitted));
+	if (ret)
+		goto err;
+
+	ret = fi_enable(resource->ep);
+	if (ret)
+		goto err;
+
+	return;
+err:
+	efa_unit_test_resource_destruct(resource);
+
+	/* Fail test early if the resource struct fails to initialize */
+	fail();
+}
+
+/**
  * @brief Clean up test resources.
  * Note: Resources should be destroyed in order.
  * @param[in] resource	struct efa_resource to clean up.

--- a/prov/efa/test/efa_unit_test_cq.c
+++ b/prov/efa/test/efa_unit_test_cq.c
@@ -102,7 +102,8 @@ static void test_rdm_cq_read_bad_send_status(struct efa_resource *resource,
 	struct efa_rdm_peer *peer;
 	struct efa_rdm_cq *efa_rdm_cq;
 
-	efa_unit_test_resource_construct(resource, FI_EP_RDM);
+	/* disable shm to force using efa device to send */
+	efa_unit_test_resource_construct_rdm_shm_disabled(resource);
 	efa_unit_test_buff_construct(&send_buff, resource, 4096 /* buff_size */);
 
 	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
@@ -111,12 +112,6 @@ static void test_rdm_cq_read_bad_send_status(struct efa_resource *resource,
 
 	efa_rdm_cq = container_of(resource->cq, struct efa_rdm_cq, util_cq.cq_fid.fid);
 	ibv_cqx = efa_rdm_cq->ibv_cq.ibv_cq_ex;
-	/* close shm_ep to force efa_rdm_ep to use efa device to send */
-	if (efa_rdm_ep->shm_ep) {
-		err = fi_close(&efa_rdm_ep->shm_ep->fid);
-		assert_int_equal(err, 0);
-		efa_rdm_ep->shm_ep = NULL;
-	}
 
 	ret = fi_getname(&resource->ep->fid, &raw_addr, &raw_addr_len);
 	assert_int_equal(ret, 0);

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -45,6 +45,8 @@ void efa_unit_test_resource_construct_with_hints(struct efa_resource *resource,
 						 uint32_t fi_version, struct fi_info *hints,
 						 bool enable_ep, bool open_cq);
 
+void efa_unit_test_resource_construct_rdm_shm_disabled(struct efa_resource *resource);
+
 void efa_unit_test_resource_destruct(struct efa_resource *resource);
 
 void efa_unit_test_construct_msg(struct fi_msg *msg, struct iovec *iov,


### PR DESCRIPTION
Currently, all unit tests disable shm transfer by
closing the shm ep directly, which is a hacky
shortcut. This hack can cause trouble when more
procedure is needed for shm closure. This patch
fixes this issue by disabling shm via the public
fi_setopt API with FI_OPT_SHARED_MEMORY_PERMITTED
as false.

A common utility function
efa_unit_test_resource_construct_rdm_shm_disabled() is introduced and all test functions that need to
disable shm should use this common function instead.