### PR TITLE
prov/efa: Add dependency header file in fi_ext_efa.h

### DIFF
--- a/prov/efa/src/fi_ext_efa.h
+++ b/prov/efa/src/fi_ext_efa.h
@@ -4,6 +4,8 @@
 #ifndef _FI_EXT_EFA_H_
 #define _FI_EXT_EFA_H_
 
+#include <rdma/fi_domain.h>
+
 #define FI_EFA_DOMAIN_OPS "efa domain ops"
 
 struct fi_efa_mr_attr {


### PR DESCRIPTION
fi_ext_efa.h uses fid_mr from fi_domain.h. Import
the dependency header for self-containing.