### PR TITLE
prov/efa, fabtests/efa: Only test inter_min_read_write_size for for emulated write path 

### DIFF
--- a/fabtests/prov/efa/Makefile.include
+++ b/fabtests/prov/efa/Makefile.include
@@ -34,7 +34,8 @@ bin_PROGRAMS += prov/efa/src/fi_efa_rnr_read_cq_error \
 		prov/efa/src/fi_efa_rnr_queue_resend \
 		prov/efa/src/fi_efa_info_test
 if HAVE_VERBS_DEVEL
-bin_PROGRAMS += prov/efa/src/fi_efa_exhaust_mr_reg_rdm_pingpong
+bin_PROGRAMS += prov/efa/src/fi_efa_exhaust_mr_reg_rdm_pingpong \
+		prov/efa/src/fi_efa_rdma_checker
 endif HAVE_VERBS_DEVEL
 
 efa_rnr_srcs = \
@@ -65,4 +66,10 @@ prov_efa_src_fi_efa_exhaust_mr_reg_rdm_pingpong_SOURCES = \
 	$(efa_exhaust_mr_reg_srcs) \
 	$(benchmarks_srcs)
 prov_efa_src_fi_efa_exhaust_mr_reg_rdm_pingpong_LDADD = libfabtests.la
+
+prov_efa_src_fi_efa_rdma_checker_SOURCES = \
+	prov/efa/src/efa_rdma_checker.c
+prov_efa_src_fi_efa_rdma_checker_LDADD = libfabtests.la
+prov_efa_src_fi_efa_rdma_checker_LDFLAGS = -lefa
+
 endif HAVE_VERBS_DEVEL

--- a/fabtests/prov/efa/src/efa_rdma_checker.c
+++ b/fabtests/prov/efa/src/efa_rdma_checker.c
@@ -1,0 +1,99 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+
+#include <infiniband/efadv.h>
+#include <infiniband/verbs.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <getopt.h>
+#include <shared.h>
+
+enum rdma_op {
+	READ,
+	WRITE,
+};
+
+/*
+ * Check whether rdma read/write is enabled on the instance by querying the rdma device.
+ * Return 0 if rdma read/write is enabled, otherwise return -1.
+ */
+int main(int argc, char *argv[])
+{
+	struct ibv_device **device_list;
+	struct ibv_context *ibv_ctx;
+	struct ibv_device_attr_ex ibv_dev_attr = {0};
+	struct efadv_device_attr efadv_attr = {0};
+	int dev_cnt;
+	int err, opt;
+	enum rdma_op op = READ;
+
+	while ((opt = getopt(argc, argv, "ho:")) != -1) {
+		switch (opt) {
+		case 'o':
+			if (!strcasecmp(optarg, "read")) {
+				op = READ;
+			} else if (!strcasecmp(optarg, "write")) {
+				op = WRITE;
+			} else {
+				fprintf(stderr, "Unknown operation '%s. Allowed: read | write'\n", optarg);
+				return EXIT_FAILURE;
+			}
+			break;
+		case '?':
+		case 'h':
+		default:
+			fprintf(stderr, "Usage:\n");
+			FT_PRINT_OPTS_USAGE("fi_efa_rdma_checker -o <op>", "rdma operation type: read|write");
+			return EXIT_FAILURE;
+        }
+	}
+
+	device_list = ibv_get_device_list(&dev_cnt);
+	if (dev_cnt <= 0) {
+		fprintf(stderr, "No ibv device found!\n");
+		return -ENODEV;
+	}
+
+	ibv_ctx = ibv_open_device(device_list[0]);
+	if (!ibv_ctx) {
+		fprintf(stderr, "cannot open device %d\n", 0);
+		return EXIT_FAILURE;
+	}
+
+	err = ibv_query_device_ex(ibv_ctx, NULL, &ibv_dev_attr);
+	if (!err) {
+		fprintf(stdout, "ibv_dev_attr.device_cap_flags_ex: %lx\n", ibv_dev_attr.device_cap_flags_ex);
+	}
+
+	err = efadv_query_device(ibv_ctx, (struct efadv_device_attr *)&efadv_attr, sizeof(efadv_attr));
+	ibv_close_device(ibv_ctx);
+	if (err) {
+		fprintf(stderr, "cannot query device\n");
+		goto out;
+	}
+
+	if (efadv_attr.max_rdma_size == 0) {
+		fprintf(stderr, "rdma is not enabled \n");
+		err = EXIT_FAILURE;
+		goto out;
+	}
+	fprintf(stdout, "rdma read is enabled \n");
+	fprintf(stdout, "efa_dev_attr.max_rdma_size: %d\n", efadv_attr.max_rdma_size);
+
+	if (op == READ)
+		goto out;
+
+	if (efadv_attr.device_caps & EFADV_DEVICE_ATTR_CAPS_RDMA_WRITE) {
+		fprintf(stdout, "rdma write is enabled \n");
+	} else {
+		fprintf(stderr, "rdma write is NOT enabled \n");
+		err = op == WRITE ? 1 : 0;
+	}
+
+out:
+	ibv_free_device_list(device_list);
+	return err;
+}

--- a/fabtests/pytest/efa/test_efa_protocol_selection.py
+++ b/fabtests/pytest/efa/test_efa_protocol_selection.py
@@ -1,6 +1,6 @@
 import pytest
 
-from efa.efa_common import has_gdrcopy
+from efa.efa_common import has_gdrcopy, has_rdma
 
 
 # TODO Expand this test to run on all memory types (and rename)
@@ -16,6 +16,9 @@ def test_transfer_with_read_protocol_cuda(cmdline_args, fabtest_name, cntrl_env_
     import copy
     from common import has_cuda, has_hmem_support
     from efa.efa_common import efa_run_client_server_test, efa_retrieve_hw_counter_value
+
+    if cntrl_env_var == "FI_EFA_INTER_MIN_READ_WRITE_SIZE" and has_rdma(cmdline_args, "write"):
+        pytest.skip("FI_EFA_INTER_MIN_READ_WRITE_SIZE is only applied to emulated write protocols")
 
     if cmdline_args.server_id == cmdline_args.client_id:
         pytest.skip("No read for intra-node communication")

--- a/prov/efa/src/efa_env.c
+++ b/prov/efa/src/efa_env.c
@@ -216,7 +216,7 @@ void efa_env_define()
 	fi_param_define(&efa_prov, "inter_max_gdrcopy_message_size", FI_PARAM_INT,
 			"The maximum message size to use gdrcopy. If instance support gdrcopy, messages whose size is smaller than this value will be sent by eager/longcts protocol (Default 32768).");
 	fi_param_define(&efa_prov, "inter_min_read_write_size", FI_PARAM_INT,
-			"The mimimum message size for inter EFA write to use read write protocol. If firmware support RDMA read, and FI_EFA_USE_DEVICE_RDMA is 1, write requests whose size is larger than this value will use the read write protocol (Default 65536).");
+			"The mimimum message size for inter EFA write to use read write protocol. If firmware support RDMA read, and FI_EFA_USE_DEVICE_RDMA is 1, write requests whose size is larger than this value will use the read write protocol (Default 65536). If the efa device supports RDMA write, device RDMA write will always be used.");
 	fi_param_define(&efa_prov, "inter_read_segment_size", FI_PARAM_INT,
 			"Calls to RDMA read is segmented using this value.");
 	fi_param_define(&efa_prov, "fork_safe", FI_PARAM_BOOL,


### PR DESCRIPTION
FI_EFA_INTER_MIN_READ_WRITE_SIZE is only applied to emulated write protocols. When efa device support rdma write,
rdma write will be always used.
This PR introduces a efa_rdma_checker.c code to check efa device's rdma read/write capability on a given platform, and
skip inter_min_read_write_size test in fabtests if the device support rdma-write.