### PR TITLE
actions: Bump macOS version, ignore warning if `libtool` is already installed

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Install dependencies (Mac OS)
         run: |
            brew install automake
-           brew install libtool
+           brew install --quiet libtool
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Build Check
         run: |

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -120,7 +120,7 @@ jobs:
           name: hmem-config.log
           path: config.log
   macos:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Install dependencies (Mac OS)
         run: |
@@ -141,5 +141,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
-          name: macos-12-config.log
+          name: macos-config.log
           path: config.log


### PR DESCRIPTION
Note that the `[s]brk()` usage in `fabtests/unit/mr_cache_evict.c` currently precludes the macOS version from being bumped past 13. The "`int` from `void *`" warnings turn into errors in the newer XCode versions.