### PR TITLE
fabtests: Add extra configure options for efa and lpp tests

### DIFF
--- a/fabtests/configure.ac
+++ b/fabtests/configure.ac
@@ -54,6 +54,13 @@ AS_IF([test x"$enable_debug" != x"no"],
 AC_DEFINE_UNQUOTED([ENABLE_DEBUG], [$dbg],
 	[defined to 1 if configured with --enable-debug])
 
+AC_ARG_ENABLE([efa],
+	[AS_HELP_STRING([--enable-efa],
+		[Enable efa provider specific tests - default YES])],
+	[], [enable_efa=yes])
+
+AM_CONDITIONAL([ENABLE_EFA], [test x"$enable_efa" = x"yes"])
+
 AC_DEFUN([FI_ARG_ENABLE_SANITIZER],[
         AC_ARG_ENABLE([$1],
                       [AS_HELP_STRING([--enable-$1],

--- a/fabtests/configure.ac
+++ b/fabtests/configure.ac
@@ -61,6 +61,13 @@ AC_ARG_ENABLE([efa],
 
 AM_CONDITIONAL([ENABLE_EFA], [test x"$enable_efa" = x"yes"])
 
+AC_ARG_ENABLE([lpp],
+	[AS_HELP_STRING([--enable-lpp],
+		[Enable lpp provider specific tests - default YES])],
+	[], [enable_lpp=yes])
+
+AM_CONDITIONAL([ENABLE_LPP], [test x"$enable_lpp" = x"yes"])
+
 AC_DEFUN([FI_ARG_ENABLE_SANITIZER],[
         AC_ARG_ENABLE([$1],
                       [AS_HELP_STRING([--enable-$1],

--- a/fabtests/prov/efa/Makefile.include
+++ b/fabtests/prov/efa/Makefile.include
@@ -30,6 +30,7 @@
 # SOFTWARE.
 #
 
+if ENABLE_EFA
 bin_PROGRAMS += prov/efa/src/fi_efa_rnr_read_cq_error \
 		prov/efa/src/fi_efa_rnr_queue_resend \
 		prov/efa/src/fi_efa_info_test
@@ -77,3 +78,4 @@ prov_efa_src_fi_efa_rdma_checker_LDFLAGS = -lefa
 endif BUILD_EFA_RDMA_CHECKER
 
 endif HAVE_VERBS_DEVEL
+endif ENABLE_EFA

--- a/fabtests/prov/lpp/Makefile.include
+++ b/fabtests/prov/lpp/Makefile.include
@@ -30,6 +30,8 @@
 # SOFTWARE.
 #
 
+if ENABLE_LPP
+
 LPP_REGRESSION_SRCS = prov/lpp/src/rcq_data.c \
                       prov/lpp/src/main.c \
                       prov/lpp/src/ipc.c \
@@ -64,3 +66,5 @@ endif
 
 prov_lpp_src_lpp_regression_SOURCES = $(LPP_REGRESSION_SRCS)
 prov_lpp_src_lpp_regression_LDADD = libfabtests.la
+
+endif ENABLE_LPP


### PR DESCRIPTION
add --enable-efa=yes/no --enable-lpp=yes/no, defaulted to yes to turn off these providers if they are not needed to be built.