### PR TITLE
fabtests/configure, efa: call provider specific configure

### DIFF
--- a/fabtests/configure.ac
+++ b/fabtests/configure.ac
@@ -80,6 +80,9 @@ AS_IF([test -z "$CFLAGS"],
 # <3), but it is necessary in AM 1.12.x.
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 
+dnl Call the provider's CONFIGURE and CONDITIONALS macros
+m4_include([prov/efa/configure.m4])
+
 AM_PROG_LIBTOOL
 
 AC_ARG_WITH([valgrind],

--- a/fabtests/prov/efa/Makefile.include
+++ b/fabtests/prov/efa/Makefile.include
@@ -34,8 +34,10 @@ bin_PROGRAMS += prov/efa/src/fi_efa_rnr_read_cq_error \
 		prov/efa/src/fi_efa_rnr_queue_resend \
 		prov/efa/src/fi_efa_info_test
 if HAVE_VERBS_DEVEL
-bin_PROGRAMS += prov/efa/src/fi_efa_exhaust_mr_reg_rdm_pingpong \
-		prov/efa/src/fi_efa_rdma_checker
+bin_PROGRAMS += prov/efa/src/fi_efa_exhaust_mr_reg_rdm_pingpong
+if BUILD_EFA_RDMA_CHECKER
+bin_PROGRAMS += prov/efa/src/fi_efa_rdma_checker
+endif BUILD_EFA_RDMA_CHECKER
 endif HAVE_VERBS_DEVEL
 
 efa_rnr_srcs = \
@@ -67,9 +69,11 @@ prov_efa_src_fi_efa_exhaust_mr_reg_rdm_pingpong_SOURCES = \
 	$(benchmarks_srcs)
 prov_efa_src_fi_efa_exhaust_mr_reg_rdm_pingpong_LDADD = libfabtests.la
 
+if BUILD_EFA_RDMA_CHECKER
 prov_efa_src_fi_efa_rdma_checker_SOURCES = \
 	prov/efa/src/efa_rdma_checker.c
 prov_efa_src_fi_efa_rdma_checker_LDADD = libfabtests.la
 prov_efa_src_fi_efa_rdma_checker_LDFLAGS = -lefa
+endif BUILD_EFA_RDMA_CHECKER
 
 endif HAVE_VERBS_DEVEL

--- a/fabtests/prov/efa/configure.m4
+++ b/fabtests/prov/efa/configure.m4
@@ -1,0 +1,32 @@
+dnl
+dnl SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only
+dnl SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved.
+dnl
+dnl Configure specific to the fabtests Amazon EFA provider
+
+
+dnl Checks for presence of efadv verbs. Needed for building tests that calls efadv verbs.
+have_efadv=0
+AC_CHECK_HEADER([infiniband/efadv.h],
+		[AC_CHECK_LIB(efa, efadv_query_device,
+                          [have_efadv=1])])
+
+efa_rdma_checker_happy=0
+AS_IF([test x"$have_efadv" = x"1"], [
+        efa_rdma_checker_happy=1
+        AC_CHECK_MEMBER(struct efadv_device_attr.max_rdma_size,
+            [],
+            [efa_rdma_checker_happy=0],
+            [[#include <infiniband/efadv.h>]])
+
+        AC_CHECK_MEMBER(struct efadv_device_attr.device_caps,
+            [],
+            [efa_rdma_checker_happy=0],
+            [[#include <infiniband/efadv.h>]])
+
+        AC_CHECK_DECL(EFADV_DEVICE_ATTR_CAPS_RDMA_WRITE,
+            [],
+            [efa_rdma_checker_happy=0],
+            [[#include <infiniband/efadv.h>]])
+])
+AM_CONDITIONAL([BUILD_EFA_RDMA_CHECKER], [test $efa_rdma_checker_happy -eq 1])


### PR DESCRIPTION
Create efa provider's own configure.m4 and make configure.ac call it.
Build efa_rdma_checker conditionally when all symbols are available.