### PR TITLE
prov/efa: Fill the gap in Read NACK protocol 

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -1066,6 +1066,12 @@ void efa_rdm_ope_handle_recv_completed(struct efa_rdm_ope *ope)
 		efa_rdm_rxe_report_completion(rxe);
 	}
 
+	if (ope->internal_flags & EFA_RDM_OPE_READ_NACK) {
+		assert(ope->type == EFA_RDM_RXE);
+		/* Apply to both DC and non-DC */
+		efa_rdm_rxe_map_remove(&ope->ep->rxe_map, ope->msg_id, ope->peer->efa_fiaddr, ope);
+	}
+
 	/* As can be seen, this function does not release rxe when
 	 * efa_rdm_ope_post_send_or_queue() was successful.
 	 *
@@ -1105,9 +1111,6 @@ void efa_rdm_ope_handle_recv_completed(struct efa_rdm_ope *ope)
 	if (ope->internal_flags & EFA_RDM_RXE_EOR_IN_FLIGHT) {
 		return;
 	}
-
-	if (ope->internal_flags & EFA_RDM_OPE_READ_NACK)
-		efa_rdm_rxe_map_remove(&ope->ep->rxe_map, ope->msg_id, ope->peer->efa_fiaddr, ope);
 
 	if (ope->type == EFA_RDM_TXE) {
 		efa_rdm_txe_release(ope);

--- a/prov/efa/src/rdm/efa_rdm_pke_rtw.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtw.c
@@ -12,6 +12,7 @@
 #include "efa_rdm_rma.h"
 #include "efa_rdm_ope.h"
 #include "efa_rdm_pke.h"
+#include "efa_rdm_pke_rtw.h"
 #include "efa_rdm_pke_utils.h"
 #include "efa_rdm_protocol.h"
 #include "efa_rdm_pke_req.h"
@@ -347,6 +348,18 @@ void efa_rdm_pke_handle_longcts_rtw_sent(struct efa_rdm_pke *pkt_entry)
 void efa_rdm_pke_handle_longcts_rtw_send_completion(struct efa_rdm_pke *pkt_entry)
 {
 	struct efa_rdm_ope *txe;
+
+	/**
+	 * A zero-payload longcts rtw pkt currently should only happen when it's
+	 * used for the READ NACK protocol. In this case, this pkt doesn't
+	 * contribute to the send completion, and the associated tx entry
+	 * may be released earlier as the CTSDATA pkts have already kicked off
+	 * and finished the send.
+	 */
+	if (pkt_entry->payload_size == 0) {
+		assert(efa_rdm_pke_get_rtw_base_hdr(pkt_entry)->flags & EFA_RDM_REQ_READ_NACK);
+		return;
+	}
 
 	txe = pkt_entry->ope;
 	txe->bytes_acked += pkt_entry->payload_size;


### PR DESCRIPTION
1. Correctly handle fallback longcts-rtw send completion
2. When FI_DELIVERY_COMPLETE is requested, also remove NACK packet from rxe map after recv completed