### PR TITLE
Fabtests: Added inband sync to ft_init_fabric_cm.

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -1067,6 +1067,13 @@ int ft_init_fabric_cm(void)
 
 	ret = opts.dst_addr ? ft_client_connect() : ft_server_connect();
 
+	if (ft_check_opts(FT_OPT_NO_PRE_POSTED_RX) &&
+	    !ft_check_opts(FT_OPT_SKIP_MSG_ALLOC) &&
+	    (fi->caps & (FI_MSG | FI_TAGGED))) {
+		ret = ft_sync_inband(false);
+		if (ret)
+			return ret;
+	}
 	return ret;
 }
 


### PR DESCRIPTION
Added condition to make preposted rx buffers based on FT_OPT_NO_PRE_POSTED_RX in case of msg endpoint based init code in fabtests. Changes similar to https://github.com/ofiwg/libfabric/pull/10394