### PR TITLE
prov/util: Allow providers to update cache MR IOV

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -417,14 +417,15 @@ bool ofi_mr_cache_flush(struct ofi_mr_cache *cache, bool flush_lru);
  * a new ofi_mr_entry and assign it to entry.
  *
  * @param[in] cache     The cache the entry belongs to
- * @param[in] info      Information about the mr entry to search
+ * @param[in out] info  Information about the mr entry to search. Info IOV may
+ *			be updated by providers to reflect region registered by
+ *			the provider.
  * @param[out] entry    The registered entry corresponding to the
  *			region described in info.
  * @returns On success, returns 0. On failure, returns a negative error code.
  */
-int ofi_mr_cache_search(struct ofi_mr_cache *cache,
-			 const struct ofi_mr_info *info,
-			 struct ofi_mr_entry **entry);
+int ofi_mr_cache_search(struct ofi_mr_cache *cache, struct ofi_mr_info *info,
+			struct ofi_mr_entry **entry);
 
 /**
  * Given an attr (with an iov range), if the iov range is already registered,


### PR DESCRIPTION
    A provider may update the memory region that is added to accommodate
    for instance alignment of the region to a larger page boundary. In such
    cases, the MR cache info used to search the cache should use the updated
    region.

    This allows the provider to avoid walking /proc/pid/smaps if the
    underlying kernel component may more efficiently determine the backing
    page size.