### PR TITLE
[v1.22.x] prov/efa: Backport recent changes

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_atomic.c
+++ b/prov/efa/src/rdm/efa_rdm_atomic.c
@@ -148,7 +148,7 @@ ssize_t efa_rdm_atomic_generic_efa(struct efa_rdm_ep *efa_rdm_ep,
 	ssize_t err;
 	struct util_srx_ctx *srx_ctx;
 
-	assert(msg->iov_count <= efa_rdm_ep->tx_iov_limit);
+	assert(msg->iov_count <= efa_rdm_ep->base_ep.info->tx_attr->iov_limit);
 	efa_perfset_start(efa_rdm_ep, perf_efa_tx);
 
 	srx_ctx = efa_rdm_ep_get_peer_srx_ctx(efa_rdm_ep);

--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -55,13 +55,6 @@ struct efa_rdm_ep {
 	/* shm provider fid */
 	struct fid_ep *shm_ep;
 
-	/*
-	 * EFA RDM endpoint rx/tx queue sizes. These may be different from the core
-	 * provider's rx/tx size and will either limit the number of possible
-	 * receives/sends or allow queueing.
-	 */
-	size_t rx_size;
-	size_t tx_size;
 	size_t mtu_size;
 	size_t inject_size;
 
@@ -227,12 +220,12 @@ void efa_rdm_ep_record_tx_op_completed(struct efa_rdm_ep *ep, struct efa_rdm_pke
 
 static inline size_t efa_rdm_ep_get_rx_pool_size(struct efa_rdm_ep *ep)
 {
-	return MIN(ep->efa_max_outstanding_rx_ops, ep->rx_size);
+	return MIN(ep->efa_max_outstanding_rx_ops, ep->base_ep.info->rx_attr->size);
 }
 
 static inline size_t efa_rdm_ep_get_tx_pool_size(struct efa_rdm_ep *ep)
 {
-	return MIN(ep->efa_max_outstanding_tx_ops, ep->tx_size);
+	return MIN(ep->efa_max_outstanding_tx_ops, ep->base_ep.info->tx_attr->size);
 }
 
 static inline int efa_rdm_ep_need_sas(struct efa_rdm_ep *ep)

--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -57,9 +57,13 @@ struct efa_rdm_ep {
 
 	size_t mtu_size;
 	size_t max_msg_size;		/**< #FI_OPT_MAX_MSG_SIZE */
+	size_t max_tagged_size;		/**< #FI_OPT_MAX_TAGGED_SIZE */
 	size_t max_rma_size;		/**< #FI_OPT_MAX_RMA_SIZE */
+	size_t max_atomic_size;		/**< #FI_OPT_MAX_ATOMIC_SIZE */
 	size_t inject_msg_size;		/**< #FI_OPT_INJECT_MSG_SIZE */
+	size_t inject_tagged_size;	/**< #FI_OPT_INJECT_TAGGED_SIZE */
 	size_t inject_rma_size;		/**< #FI_OPT_INJECT_RMA_SIZE */
+	size_t inject_atomic_size;	/**< #FI_OPT_INJECT_ATOMIC_SIZE */
 
 	/* Endpoint's capability to support zero-copy rx */
 	bool use_zcpy_rx;

--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -56,7 +56,10 @@ struct efa_rdm_ep {
 	struct fid_ep *shm_ep;
 
 	size_t mtu_size;
-	size_t inject_size;
+	size_t max_msg_size;		/**< #FI_OPT_MAX_MSG_SIZE */
+	size_t max_rma_size;		/**< #FI_OPT_MAX_RMA_SIZE */
+	size_t inject_msg_size;		/**< #FI_OPT_INJECT_MSG_SIZE */
+	size_t inject_rma_size;		/**< #FI_OPT_INJECT_RMA_SIZE */
 
 	/* Endpoint's capability to support zero-copy rx */
 	bool use_zcpy_rx;
@@ -73,11 +76,6 @@ struct efa_rdm_ep {
 	/* Resource management flag */
 	uint64_t rm_full;
 
-	/* Application's maximum msg size hint */
-	size_t max_msg_size;
-
-	/** Application's maximum RMA size */
-	size_t max_rma_size;
 
 	/* Applicaiton's message prefix size. */
 	size_t msg_prefix_size;

--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -63,8 +63,6 @@ struct efa_rdm_ep {
 	size_t rx_size;
 	size_t tx_size;
 	size_t mtu_size;
-	size_t rx_iov_limit;
-	size_t tx_iov_limit;
 	size_t inject_size;
 
 	/* Endpoint's capability to support zero-copy rx */

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -1255,8 +1255,10 @@ static int efa_rdm_ep_ctrl(struct fid *fid, int command, void *arg)
 		 * TODO: Distinguish between inline data sizes for RDMA {send,write}
 		 * when supported
 		 */
-		if (ep->use_zcpy_rx)
+		if (ep->use_zcpy_rx) {
+			ep->inject_msg_size = MIN(ep->inject_msg_size, efa_rdm_ep_domain(ep)->device->efa_attr.inline_buf_size);
 			ep->inject_rma_size = MIN(ep->inject_rma_size, efa_rdm_ep_domain(ep)->device->efa_attr.inline_buf_size);
+		}
 
 		ret = efa_rdm_ep_create_base_ep_ibv_qp(ep);
 		if (ret)

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -559,8 +559,6 @@ int efa_rdm_ep_open(struct fid_domain *domain, struct fi_info *info,
 
 	efa_rdm_ep->rx_size = info->rx_attr->size;
 	efa_rdm_ep->tx_size = info->tx_attr->size;
-	efa_rdm_ep->rx_iov_limit = info->rx_attr->iov_limit;
-	efa_rdm_ep->tx_iov_limit = info->tx_attr->iov_limit;
 	efa_rdm_ep->inject_size = info->tx_attr->inject_size;
 	efa_rdm_ep->efa_max_outstanding_tx_ops = efa_domain->device->rdm_info->tx_attr->size;
 	efa_rdm_ep->efa_max_outstanding_rx_ops = efa_domain->device->rdm_info->rx_attr->size;

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -236,7 +236,7 @@ int efa_rdm_ep_create_buffer_pools(struct efa_rdm_ep *ep)
 	ret = ofi_bufpool_create(&ep->user_rx_pkt_pool,
 			sizeof(struct efa_rdm_pke),
 			EFA_RDM_BUFPOOL_ALIGNMENT,
-			0,ep->rx_size,0);
+			0, ep->base_ep.info->rx_attr->size, 0);
 	if (ret)
 		goto err_free;
 
@@ -285,7 +285,7 @@ int efa_rdm_ep_create_buffer_pools(struct efa_rdm_ep *ep)
 				 sizeof(struct efa_rdm_rxe_map_entry),
 				 EFA_RDM_BUFPOOL_ALIGNMENT,
 				 0, /* no limit for max_cnt */
-				 ep->rx_size, 0);
+				 ep->base_ep.info->rx_attr->size, 0);
 
 	if (ret)
 		goto err_free;
@@ -301,7 +301,7 @@ int efa_rdm_ep_create_buffer_pools(struct efa_rdm_ep *ep)
 				 sizeof(struct efa_rdm_ope),
 				 EFA_RDM_BUFPOOL_ALIGNMENT,
 				 0, /* no limit for max_cnt */
-				 ep->tx_size + ep->rx_size, 0);
+				 ep->base_ep.info->tx_attr->size + ep->base_ep.info->rx_attr->size, 0);
 	if (ret)
 		goto err_free;
 
@@ -309,7 +309,7 @@ int efa_rdm_ep_create_buffer_pools(struct efa_rdm_ep *ep)
 				 sizeof(struct efa_rdm_peer_overflow_pke_list_entry),
 				 EFA_RDM_BUFPOOL_ALIGNMENT,
 				 0, /* no limit for max_cnt */
-				 ep->rx_size, 0);
+				 ep->base_ep.info->rx_attr->size, 0);
 	if (ret)
 		goto err_free;
 
@@ -557,8 +557,6 @@ int efa_rdm_ep_open(struct fid_domain *domain, struct fi_info *info,
 		EFA_INFO(FI_LOG_EP_CTRL, "efa_rdm_ep->host_id: i-%017lx\n", efa_rdm_ep->host_id);
 	}
 
-	efa_rdm_ep->rx_size = info->rx_attr->size;
-	efa_rdm_ep->tx_size = info->tx_attr->size;
 	efa_rdm_ep->inject_size = info->tx_attr->inject_size;
 	efa_rdm_ep->efa_max_outstanding_tx_ops = efa_domain->device->rdm_info->tx_attr->size;
 	efa_rdm_ep->efa_max_outstanding_rx_ops = efa_domain->device->rdm_info->rx_attr->size;

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -558,9 +558,13 @@ int efa_rdm_ep_open(struct fid_domain *domain, struct fi_info *info,
 	}
 
 	efa_rdm_ep->max_msg_size = info->ep_attr->max_msg_size;
+	efa_rdm_ep->max_tagged_size = info->ep_attr->max_msg_size;
 	efa_rdm_ep->max_rma_size = info->ep_attr->max_msg_size;
+	efa_rdm_ep->max_atomic_size = info->ep_attr->max_msg_size;
 	efa_rdm_ep->inject_msg_size = info->tx_attr->inject_size;
+	efa_rdm_ep->inject_tagged_size = info->tx_attr->inject_size;
 	efa_rdm_ep->inject_rma_size = info->tx_attr->inject_size;
+	efa_rdm_ep->inject_atomic_size = info->tx_attr->inject_size;
 	efa_rdm_ep->efa_max_outstanding_tx_ops = efa_domain->device->rdm_info->tx_attr->size;
 	efa_rdm_ep->efa_max_outstanding_rx_ops = efa_domain->device->rdm_info->rx_attr->size;
 	efa_rdm_ep->use_device_rdma = efa_rdm_get_use_device_rdma(info->fabric_attr->api_version);
@@ -1661,14 +1665,26 @@ static int efa_rdm_ep_setopt(fid_t fid, int level, int optname,
 	case FI_OPT_MAX_MSG_SIZE:
 		EFA_RDM_EP_SETOPT_THRESHOLD(MAX_MSG_SIZE, efa_rdm_ep->max_msg_size, efa_rdm_ep->base_ep.info->ep_attr->max_msg_size)
 		break;
+	case FI_OPT_MAX_TAGGED_SIZE:
+		EFA_RDM_EP_SETOPT_THRESHOLD(MAX_TAGGED_SIZE, efa_rdm_ep->max_tagged_size, efa_rdm_ep->base_ep.info->ep_attr->max_msg_size)
+		break;
 	case FI_OPT_MAX_RMA_SIZE:
 		EFA_RDM_EP_SETOPT_THRESHOLD(MAX_RMA_SIZE, efa_rdm_ep->max_rma_size, efa_rdm_ep->base_ep.info->ep_attr->max_msg_size)
+		break;
+	case FI_OPT_MAX_ATOMIC_SIZE:
+		EFA_RDM_EP_SETOPT_THRESHOLD(MAX_ATOMIC_SIZE, efa_rdm_ep->max_atomic_size, efa_rdm_ep->base_ep.info->ep_attr->max_msg_size)
 		break;
 	case FI_OPT_INJECT_MSG_SIZE:
 		EFA_RDM_EP_SETOPT_THRESHOLD(INJECT_MSG_SIZE, efa_rdm_ep->inject_msg_size, efa_rdm_ep->base_ep.info->tx_attr->inject_size)
 		break;
+	case FI_OPT_INJECT_TAGGED_SIZE:
+		EFA_RDM_EP_SETOPT_THRESHOLD(INJECT_TAGGED_SIZE, efa_rdm_ep->inject_tagged_size, efa_rdm_ep->base_ep.info->tx_attr->inject_size)
+		break;
 	case FI_OPT_INJECT_RMA_SIZE:
 		EFA_RDM_EP_SETOPT_THRESHOLD(INJECT_RMA_SIZE, efa_rdm_ep->inject_rma_size, efa_rdm_ep->base_ep.info->tx_attr->inject_size)
+		break;
+	case FI_OPT_INJECT_ATOMIC_SIZE:
+		EFA_RDM_EP_SETOPT_THRESHOLD(INJECT_ATOMIC_SIZE, efa_rdm_ep->inject_atomic_size, efa_rdm_ep->base_ep.info->tx_attr->inject_size)
 		break;
 	case FI_OPT_EFA_USE_DEVICE_RDMA:
 		if (optlen != sizeof(bool))
@@ -1752,10 +1768,22 @@ static int efa_rdm_ep_getopt(fid_t fid, int level, int optname, void *optval,
 		*(size_t *) optval = efa_rdm_ep->max_msg_size;
 		*optlen = sizeof (size_t);
 		break;
+	case FI_OPT_MAX_TAGGED_SIZE:
+		if (*optlen < sizeof (size_t))
+			return -FI_ETOOSMALL;
+		*(size_t *) optval = efa_rdm_ep->max_tagged_size;
+		*optlen = sizeof (size_t);
+		break;
 	case FI_OPT_MAX_RMA_SIZE:
 		if (*optlen < sizeof (size_t))
 			return -FI_ETOOSMALL;
 		*(size_t *) optval = efa_rdm_ep->max_rma_size;
+		*optlen = sizeof (size_t);
+		break;
+	case FI_OPT_MAX_ATOMIC_SIZE:
+		if (*optlen < sizeof (size_t))
+			return -FI_ETOOSMALL;
+		*(size_t *) optval = efa_rdm_ep->max_atomic_size;
 		*optlen = sizeof (size_t);
 		break;
 	case FI_OPT_INJECT_MSG_SIZE:
@@ -1764,10 +1792,22 @@ static int efa_rdm_ep_getopt(fid_t fid, int level, int optname, void *optval,
 		*(size_t *) optval = efa_rdm_ep->inject_msg_size;
 		*optlen = sizeof (size_t);
 		break;
+	case FI_OPT_INJECT_TAGGED_SIZE:
+		if (*optlen < sizeof (size_t))
+			return -FI_ETOOSMALL;
+		*(size_t *) optval = efa_rdm_ep->inject_tagged_size;
+		*optlen = sizeof (size_t);
+		break;
 	case FI_OPT_INJECT_RMA_SIZE:
 		if (*optlen < sizeof (size_t))
 			return -FI_ETOOSMALL;
 		*(size_t *) optval = efa_rdm_ep->inject_rma_size;
+		*optlen = sizeof (size_t);
+		break;
+	case FI_OPT_INJECT_ATOMIC_SIZE:
+		if (*optlen < sizeof (size_t))
+			return -FI_ETOOSMALL;
+		*(size_t *) optval = efa_rdm_ep->inject_atomic_size;
 		*optlen = sizeof (size_t);
 		break;
 	case FI_OPT_EFA_EMULATED_READ:

--- a/prov/efa/src/rdm/efa_rdm_ep_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_utils.c
@@ -211,7 +211,7 @@ int efa_rdm_ep_post_user_recv_buf(struct efa_rdm_ep *ep, struct efa_rdm_ope *rxe
 	size_t rx_iov_offset = 0;
 	int err, rx_iov_index = 0;
 
-	assert(rxe->iov_count > 0  && rxe->iov_count <= ep->rx_iov_limit);
+	assert(rxe->iov_count > 0  && rxe->iov_count <= ep->base_ep.info->rx_attr->iov_limit);
 	assert(rxe->iov[0].iov_len >= ep->msg_prefix_size);
 	pkt_entry = efa_rdm_pke_alloc(ep, ep->user_rx_pkt_pool, EFA_RDM_PKE_FROM_USER_RX_POOL);
 	if (OFI_UNLIKELY(!pkt_entry)) {

--- a/prov/efa/src/rdm/efa_rdm_msg.c
+++ b/prov/efa/src/rdm/efa_rdm_msg.c
@@ -559,6 +559,7 @@ ssize_t efa_rdm_msg_tinject(struct fid_ep *ep_fid, const void *buf, size_t len,
 	struct efa_rdm_peer *peer;
 
 	efa_rdm_ep = container_of(ep_fid, struct efa_rdm_ep, base_ep.util_ep.ep_fid.fid);
+	assert(len <= efa_rdm_ep->inject_tagged_size);
 
 	peer = efa_rdm_ep_get_peer(efa_rdm_ep, dest_addr);
 	assert(peer);
@@ -585,6 +586,7 @@ ssize_t efa_rdm_msg_tinjectdata(struct fid_ep *ep_fid, const void *buf, size_t l
 	struct efa_rdm_peer *peer;
 
 	efa_rdm_ep = container_of(ep_fid, struct efa_rdm_ep, base_ep.util_ep.ep_fid.fid);
+	assert(len <= efa_rdm_ep->inject_tagged_size);
 
 	peer = efa_rdm_ep_get_peer(efa_rdm_ep, dest_addr);
 	assert(peer);

--- a/prov/efa/src/rdm/efa_rdm_msg.c
+++ b/prov/efa/src/rdm/efa_rdm_msg.c
@@ -356,7 +356,7 @@ ssize_t efa_rdm_msg_inject(struct fid_ep *ep, const void *buf, size_t len,
 	struct efa_rdm_peer *peer;
 
 	efa_rdm_ep = container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid.fid);
-	assert(len <= efa_rdm_ep->inject_size);
+	assert(len <= efa_rdm_ep->inject_msg_size);
 
 	peer = efa_rdm_ep_get_peer(efa_rdm_ep, dest_addr);
 	assert(peer);
@@ -384,7 +384,7 @@ ssize_t efa_rdm_msg_injectdata(struct fid_ep *ep, const void *buf,
 	struct efa_rdm_peer *peer;
 
 	efa_rdm_ep = container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid.fid);
-	assert(len <= efa_rdm_ep->inject_size);
+	assert(len <= efa_rdm_ep->inject_msg_size);
 
 	peer = efa_rdm_ep_get_peer(efa_rdm_ep, dest_addr);
 	assert(peer);
@@ -559,7 +559,6 @@ ssize_t efa_rdm_msg_tinject(struct fid_ep *ep_fid, const void *buf, size_t len,
 	struct efa_rdm_peer *peer;
 
 	efa_rdm_ep = container_of(ep_fid, struct efa_rdm_ep, base_ep.util_ep.ep_fid.fid);
-	assert(len <= efa_rdm_ep->inject_size);
 
 	peer = efa_rdm_ep_get_peer(efa_rdm_ep, dest_addr);
 	assert(peer);
@@ -586,7 +585,6 @@ ssize_t efa_rdm_msg_tinjectdata(struct fid_ep *ep_fid, const void *buf, size_t l
 	struct efa_rdm_peer *peer;
 
 	efa_rdm_ep = container_of(ep_fid, struct efa_rdm_ep, base_ep.util_ep.ep_fid.fid);
-	assert(len <= efa_rdm_ep->inject_size);
 
 	peer = efa_rdm_ep_get_peer(efa_rdm_ep, dest_addr);
 	assert(peer);

--- a/prov/efa/src/rdm/efa_rdm_msg.c
+++ b/prov/efa/src/rdm/efa_rdm_msg.c
@@ -167,7 +167,7 @@ ssize_t efa_rdm_msg_generic_send(struct efa_rdm_ep *ep, struct efa_rdm_peer *pee
 
 	srx_ctx = efa_rdm_ep_get_peer_srx_ctx(ep);
 
-	assert(msg->iov_count <= ep->tx_iov_limit);
+	assert(msg->iov_count <= ep->base_ep.info->tx_attr->iov_limit);
 
 	efa_perfset_start(ep, perf_efa_tx);
 	ofi_genlock_lock(srx_ctx->lock);
@@ -890,7 +890,7 @@ ssize_t efa_rdm_msg_generic_recv(struct efa_rdm_ep *ep, const struct fi_msg *msg
 	struct efa_rdm_ope *rxe;
 	struct util_srx_ctx *srx_ctx;
 
-	assert(msg->iov_count <= ep->rx_iov_limit);
+	assert(msg->iov_count <= ep->base_ep.info->rx_attr->iov_limit);
 
 	efa_perfset_start(ep, perf_efa_recv);
 

--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -1503,7 +1503,7 @@ int efa_rdm_ope_post_remote_write(struct efa_rdm_ope *ope)
 
 		if (ope->fi_flags & FI_INJECT) {
 			assert(ope->iov_count == 1);
-			assert(ope->total_len <= ep->inject_size);
+			assert(ope->total_len <= ep->inject_rma_size);
 			copied = efa_rdm_pke_copy_from_hmem_iov(
 				ope->desc[iov_idx], pkt_entry, ope,
 				sizeof(struct efa_rdm_rma_context_pkt), 0,

--- a/prov/efa/src/rdm/efa_rdm_rma.c
+++ b/prov/efa/src/rdm/efa_rdm_rma.c
@@ -189,7 +189,7 @@ ssize_t efa_rdm_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uin
 	if (err)
 		return err;
 
-	assert(msg->iov_count <= efa_rdm_ep->tx_iov_limit);
+	assert(msg->iov_count <= efa_rdm_ep->base_ep.info->tx_attr->iov_limit);
 
 	efa_perfset_start(efa_rdm_ep, perf_efa_tx);
 	ofi_genlock_lock(srx_ctx->lock);
@@ -480,7 +480,7 @@ ssize_t efa_rdm_rma_writemsg(struct fid_ep *ep,
 	if (err)
 		return err;
 
-	assert(msg->iov_count <= efa_rdm_ep->tx_iov_limit);
+	assert(msg->iov_count <= efa_rdm_ep->base_ep.info->tx_attr->iov_limit);
 
 	peer = efa_rdm_ep_get_peer(efa_rdm_ep, msg->addr);
 	assert(peer);

--- a/prov/efa/src/rdm/efa_rdm_rma.c
+++ b/prov/efa/src/rdm/efa_rdm_rma.c
@@ -642,7 +642,7 @@ ssize_t efa_rdm_rma_inject_write(struct fid_ep *ep, const void *buf, size_t len,
 	int err;
 
 	efa_rdm_ep = container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid.fid);
-	assert(len <= efa_rdm_ep->inject_size);
+	assert(len <= efa_rdm_ep->inject_rma_size);
 	err = efa_rdm_ep_cap_check_rma(efa_rdm_ep);
 	if (err)
 		return err;
@@ -679,7 +679,7 @@ ssize_t efa_rdm_rma_inject_writedata(struct fid_ep *ep, const void *buf, size_t 
 	int err;
 
 	efa_rdm_ep = container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid.fid);
-	assert(len <= efa_rdm_ep->inject_size);
+	assert(len <= efa_rdm_ep->inject_rma_size);
 	err = efa_rdm_ep_cap_check_rma(efa_rdm_ep);
 	if (err)
 		return err;

--- a/prov/efa/src/rdm/efa_rdm_srx.c
+++ b/prov/efa/src/rdm/efa_rdm_srx.c
@@ -151,7 +151,7 @@ int efa_rdm_peer_srx_construct(struct efa_rdm_ep *ep)
 {
 	int ret;
 	ret = util_ep_srx_context(&efa_rdm_ep_domain(ep)->util_domain,
-				ep->rx_size, EFA_RDM_IOV_LIMIT,
+				ep->base_ep.info->rx_attr->size, EFA_RDM_IOV_LIMIT,
 				ep->min_multi_recv_size,
 				&efa_rdm_srx_update_mr,
 				&efa_rdm_ep_domain(ep)->srx_lock,

--- a/prov/efa/test/efa_unit_test_common.c
+++ b/prov/efa/test/efa_unit_test_common.c
@@ -166,6 +166,39 @@ err:
 }
 
 /**
+ * @brief Construct RDM ep type resources with shm disabled
+ */
+void efa_unit_test_resource_construct_rdm_shm_disabled(struct efa_resource *resource)
+{
+	int ret;
+	bool shm_permitted = false;
+
+	resource->hints = efa_unit_test_alloc_hints(FI_EP_RDM);
+	if (!resource->hints)
+		goto err;
+
+	efa_unit_test_resource_construct_with_hints(resource, FI_EP_RDM, FI_VERSION(1, 14),
+						    resource->hints, false, true);
+
+	ret = fi_setopt(&resource->ep->fid, FI_OPT_ENDPOINT,
+			FI_OPT_SHARED_MEMORY_PERMITTED, &shm_permitted,
+			sizeof(shm_permitted));
+	if (ret)
+		goto err;
+
+	ret = fi_enable(resource->ep);
+	if (ret)
+		goto err;
+
+	return;
+err:
+	efa_unit_test_resource_destruct(resource);
+
+	/* Fail test early if the resource struct fails to initialize */
+	fail();
+}
+
+/**
  * @brief Clean up test resources.
  * Note: Resources should be destroyed in order.
  * @param[in] resource	struct efa_resource to clean up.

--- a/prov/efa/test/efa_unit_test_cq.c
+++ b/prov/efa/test/efa_unit_test_cq.c
@@ -102,7 +102,8 @@ static void test_rdm_cq_read_bad_send_status(struct efa_resource *resource,
 	struct efa_rdm_peer *peer;
 	struct efa_rdm_cq *efa_rdm_cq;
 
-	efa_unit_test_resource_construct(resource, FI_EP_RDM);
+	/* disable shm to force using efa device to send */
+	efa_unit_test_resource_construct_rdm_shm_disabled(resource);
 	efa_unit_test_buff_construct(&send_buff, resource, 4096 /* buff_size */);
 
 	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
@@ -111,12 +112,6 @@ static void test_rdm_cq_read_bad_send_status(struct efa_resource *resource,
 
 	efa_rdm_cq = container_of(resource->cq, struct efa_rdm_cq, util_cq.cq_fid.fid);
 	ibv_cqx = efa_rdm_cq->ibv_cq.ibv_cq_ex;
-	/* close shm_ep to force efa_rdm_ep to use efa device to send */
-	if (efa_rdm_ep->shm_ep) {
-		err = fi_close(&efa_rdm_ep->shm_ep->fid);
-		assert_int_equal(err, 0);
-		efa_rdm_ep->shm_ep = NULL;
-	}
 
 	ret = fi_getname(&resource->ep->fid, &raw_addr, &raw_addr_len);
 	assert_int_equal(ret, 0);

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -924,7 +924,7 @@ static void test_efa_rdm_ep_use_zcpy_rx_impl(struct efa_resource *resource,
 	struct efa_domain *efa_domain;
 	struct efa_rdm_ep *ep;
 	size_t max_msg_size = 1000;
-	size_t inject_size = 0;
+	size_t inject_rma_size = 0;
 	bool shm_permitted = false;
 
 	efa_unit_test_resource_construct_with_hints(resource, FI_EP_RDM, FI_VERSION(1, 14),
@@ -967,12 +967,12 @@ static void test_efa_rdm_ep_use_zcpy_rx_impl(struct efa_resource *resource,
 
 	assert_true(ep->use_zcpy_rx == expected_use_zcpy_rx);
 	assert_int_equal(fi_getopt(&resource->ep->fid, FI_OPT_ENDPOINT, FI_OPT_INJECT_RMA_SIZE,
-			&inject_size, &(size_t){sizeof inject_size}), 0);
-	assert_int_equal(ep->inject_size, inject_size);
+			&inject_rma_size, &(size_t){sizeof inject_rma_size}), 0);
+	assert_int_equal(ep->inject_rma_size, inject_rma_size);
 	if (expected_use_zcpy_rx)
-		assert_int_equal(inject_size, efa_rdm_ep_domain(ep)->device->efa_attr.inline_buf_size);
+		assert_int_equal(inject_rma_size, efa_rdm_ep_domain(ep)->device->efa_attr.inline_buf_size);
 	else
-		assert_int_equal(inject_size, resource->info->tx_attr->inject_size);
+		assert_int_equal(inject_rma_size, resource->info->tx_attr->inject_size);
 }
 
 /**

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -109,7 +109,6 @@ void test_efa_rdm_ep_handshake_exchange_host_id(struct efa_resource **state, uin
 	struct efa_rdm_ep *efa_rdm_ep;
 	struct efa_rdm_pke *pkt_entry;
 	uint64_t actual_peer_host_id = UINT64_MAX;
-	int ret;
 	struct efa_rdm_cq *efa_rdm_cq;
 
 	g_efa_unit_test_mocks.local_host_id = local_host_id;
@@ -117,19 +116,13 @@ void test_efa_rdm_ep_handshake_exchange_host_id(struct efa_resource **state, uin
 
 	assert_false(actual_peer_host_id == g_efa_unit_test_mocks.peer_host_id);
 
-	efa_unit_test_resource_construct(resource, FI_EP_RDM);
+	/* disable shm to force using efa device to send */
+	efa_unit_test_resource_construct_rdm_shm_disabled(resource);
 
 	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
 	efa_rdm_cq = container_of(resource->cq, struct efa_rdm_cq, util_cq.cq_fid.fid);
 
 	efa_rdm_ep->host_id = g_efa_unit_test_mocks.local_host_id;
-	/* close shm_ep to force efa_rdm_ep to use efa device to send */
-	if (efa_rdm_ep->shm_ep) {
-		ret = fi_close(&efa_rdm_ep->shm_ep->fid);
-		assert_int_equal(ret, 0);
-		efa_rdm_ep->shm_ep = NULL;
-	}
-
 
 	/* Create and register a fake peer */
 	assert_int_equal(fi_getname(&resource->ep->fid, &raw_addr, &raw_addr_len), 0);
@@ -411,7 +404,8 @@ void test_efa_rdm_ep_dc_atomic_queue_before_handshake(struct efa_resource **stat
 	int buf[1] = {0}, err, numaddr;
 	struct efa_rdm_ope *txe;
 
-	efa_unit_test_resource_construct(resource, FI_EP_RDM);
+	/* disable shm to force using efa device to send */
+	efa_unit_test_resource_construct_rdm_shm_disabled(resource);
 
 	/* create a fake peer */
 	err = fi_getname(&resource->ep->fid, &raw_addr, &raw_addr_len);
@@ -434,12 +428,7 @@ void test_efa_rdm_ep_dc_atomic_queue_before_handshake(struct efa_resource **stat
 	msg.op = FI_SUM;
 
 	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
-	/* close shm_ep to force efa_rdm_ep to use efa device to send */
-	if (efa_rdm_ep->shm_ep) {
-		err = fi_close(&efa_rdm_ep->shm_ep->fid);
-		assert_int_equal(err, 0);
-		efa_rdm_ep->shm_ep = NULL;
-	}
+
 	/* set peer->flag to EFA_RDM_PEER_REQ_SENT will make efa_rdm_atomic() think
 	 * a REQ packet has been sent to the peer (so no need to send again)
 	 * handshake has not been received, so we do not know whether the peer support DC
@@ -480,7 +469,8 @@ void test_efa_rdm_ep_dc_send_queue_before_handshake(struct efa_resource **state)
 	int err, numaddr;
 	struct efa_rdm_ope *txe;
 
-	efa_unit_test_resource_construct(resource, FI_EP_RDM);
+	/* disable shm to force using efa device to send */
+	efa_unit_test_resource_construct_rdm_shm_disabled(resource);
 
 	/* create a fake peer */
 	err = fi_getname(&resource->ep->fid, &raw_addr, &raw_addr_len);
@@ -498,12 +488,7 @@ void test_efa_rdm_ep_dc_send_queue_before_handshake(struct efa_resource **state)
 	msg.desc = NULL;
 
 	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
-	/* close shm_ep to force efa_rdm_ep to use efa device to send */
-	if (efa_rdm_ep->shm_ep) {
-		err = fi_close(&efa_rdm_ep->shm_ep->fid);
-		assert_int_equal(err, 0);
-		efa_rdm_ep->shm_ep = NULL;
-	}
+
 	/* set peer->flag to EFA_RDM_PEER_REQ_SENT will make efa_rdm_atomic() think
 	 * a REQ packet has been sent to the peer (so no need to send again)
 	 * handshake has not been received, so we do not know whether the peer support DC
@@ -545,7 +530,8 @@ void test_efa_rdm_ep_dc_send_queue_limit_before_handshake(struct efa_resource **
 	int err, numaddr;
 	int i;
 
-	efa_unit_test_resource_construct(resource, FI_EP_RDM);
+	/* disable shm to force using efa device to send */
+	efa_unit_test_resource_construct_rdm_shm_disabled(resource);
 
 	/* create a fake peer */
 	err = fi_getname(&resource->ep->fid, &raw_addr, &raw_addr_len);
@@ -563,12 +549,7 @@ void test_efa_rdm_ep_dc_send_queue_limit_before_handshake(struct efa_resource **
 	msg.desc = NULL;
 
 	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
-	/* close shm_ep to force efa_rdm_ep to use efa device to send */
-	if (efa_rdm_ep->shm_ep) {
-		err = fi_close(&efa_rdm_ep->shm_ep->fid);
-		assert_int_equal(err, 0);
-		efa_rdm_ep->shm_ep = NULL;
-	}
+
 	/* set peer->flag to EFA_RDM_PEER_REQ_SENT will make efa_rdm_atomic() think
 	 * a REQ packet has been sent to the peer (so no need to send again)
 	 * handshake has not been received, so we do not know whether the peer support DC
@@ -867,19 +848,12 @@ void test_efa_rdm_ep_setopt_shared_memory_permitted(struct efa_resource **state)
 {
 	struct efa_resource *resource = *state;
 	struct efa_rdm_ep *ep;
-	bool optval = false;
 
-	efa_unit_test_resource_construct_ep_not_enabled(resource, FI_EP_RDM);
+	/* disable shm to force using efa device to send */
+	efa_unit_test_resource_construct_rdm_shm_disabled(resource);
 
 	ep = container_of(resource->ep, struct efa_rdm_ep,
 			  base_ep.util_ep.ep_fid);
-
-	assert_int_equal(fi_setopt(&resource->ep->fid, FI_OPT_ENDPOINT,
-				   FI_OPT_SHARED_MEMORY_PERMITTED, &optval,
-				   sizeof(optval)),
-			 0);
-
-	assert_int_equal(fi_enable(resource->ep), 0);
 
 	assert_null(ep->shm_ep);
 }
@@ -1161,7 +1135,8 @@ void test_efa_rdm_ep_post_handshake_error_handling_pke_exhaustion(struct efa_res
 	struct efa_rdm_pke **pkt_entry_vec;
 	int i;
 
-	efa_unit_test_resource_construct(resource, FI_EP_RDM);
+	/* disable shm to force using efa device to send */
+	efa_unit_test_resource_construct_rdm_shm_disabled(resource);
 
 	/* create a fake peer */
 	err = fi_getname(&resource->ep->fid, &raw_addr, &raw_addr_len);
@@ -1172,12 +1147,7 @@ void test_efa_rdm_ep_post_handshake_error_handling_pke_exhaustion(struct efa_res
 	assert_int_equal(numaddr, 1);
 
 	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
-	/* close shm_ep to force efa_rdm_ep to use efa device to send */
-	if (efa_rdm_ep->shm_ep) {
-		err = fi_close(&efa_rdm_ep->shm_ep->fid);
-		assert_int_equal(err, 0);
-		efa_rdm_ep->shm_ep = NULL;
-	}
+
 	/* set peer->flag to EFA_RDM_PEER_REQ_SENT will make efa_rdm_atomic() think
 	 * a REQ packet has been sent to the peer (so no need to send again)
 	 * handshake has not been received, so we do not know whether the peer support DC

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -42,6 +42,8 @@ void efa_unit_test_resource_construct_with_hints(struct efa_resource *resource,
 						 uint32_t fi_version, struct fi_info *hints,
 						 bool enable_ep, bool open_cq);
 
+void efa_unit_test_resource_construct_rdm_shm_disabled(struct efa_resource *resource);
+
 void efa_unit_test_resource_destruct(struct efa_resource *resource);
 
 void efa_unit_test_construct_msg(struct fi_msg *msg, struct iovec *iov,


### PR DESCRIPTION
a443ad6ce9d2c49371c85523dd7f598f5d109f2b, 49922d1740ab30eea1c560da9ab7b386a5298e32 and ee37cbfe14f4e934e271bb4c371579b50890ba5e were all necessary in order to cleanly backport changes from #10413.