### PR TITLE
contrib/intel/jenkins: Temporarily disable psm3 in onecclgpu

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -767,9 +767,9 @@ pipeline {
           steps {
             script {
               dir (RUN_LOCATION) {
-		            run_middleware([["psm3", null]], "oneCCL-GPU-v3", "onecclgpu",
-			       "gpu", "torchic", "1", null, null,
-                               "FI_HMEM_DISABLE_P2P=1")
+		        //     run_middleware([["psm3", null]], "oneCCL-GPU-v3", "onecclgpu",
+			      //  "gpu", "torchic", "1", null, null,
+            //                    "FI_HMEM_DISABLE_P2P=1")
 		            run_middleware([["verbs", null]], "oneCCL-GPU-v3", "onecclgpu",
                                "gpu", "torchic", "1", null, null,
                                "FI_HMEM_DISABLE_P2P=1")


### PR DESCRIPTION
psm3 is failing onecclgpu because of a missing package. Disable it until the package dependency is resolved.