### PR TITLE
xpmem: Change the log level to info

### DIFF
--- a/src/xpmem.c
+++ b/src/xpmem.c
@@ -108,7 +108,7 @@ int ofi_xpmem_init(void)
 	xpmem->pinfo.seg_id = xpmem_make(0, XPMEM_MAXADDR_SIZE, XPMEM_PERMIT_MODE,
 					 (void *) 0666);
 	if (xpmem->pinfo.seg_id == -1) {
-		FI_WARN(&core_prov, FI_LOG_CORE,
+		FI_INFO(&core_prov, FI_LOG_CORE,
 			"Failed to export process virtual address space for use with xpmem\n");
 		ret = -FI_ENODATA;
 		goto fail;


### PR DESCRIPTION
We build libfabric with xpmem support but we may run it on a OS without the kernel module loaded.
Change FI_WARN to FI_INFO to reduce the noise in the log following the same model as cuda dlopen: https://github.com/ofiwg/libfabric/blob/main/src/hmem_cuda.c#L483-L487