### PR TITLE
fabtests/pytest/efa: Loose assertion for read request counters

### DIFF
--- a/fabtests/pytest/efa/test_runt.py
+++ b/fabtests/pytest/efa/test_runt.py
@@ -74,16 +74,15 @@ def test_runt_read_functional(cmdline_args, memory_type, copy_method):
     if copy_method == "localread":
         # when local read copy is used, server issue RDMA requests to copy received data
         #
-        # so in this case, total read wr is 11, which is
+        # so in this case, total read wr is at least 9, which is
         #    1 remote read of 192k
         #    8 local read for the 64k data transfer by send
-        #    2 local read for 2 fabtests control messages
+        #    More local reads for fabtests control messages
         #
-        # and total read_bytes will be 262149, which is:
-        #        256k message + 2 fabtests control messages (1 byte and 4 byte each)
+        # and total read_bytes will be >= 256K including the control messages
         #
-        assert server_read_wrs == 11
-        assert server_read_bytes == 262149
+        assert server_read_wrs >= 9
+        assert server_read_bytes >= 262144
     else:
         # The other 192 KB is transfer by RDMA read
         # for which the server (receiver) will issue 1 read request.


### PR DESCRIPTION
The current assertion check for send read wrs and bytes are based on the exact calculation of benchmark data size + fabtests control message size, which is too strict. Fabtests may change control message sizes which should not impact this test.

This patch looses the assertion for read request counters which make it have enough coverage for the benchmark data size.