### PR TITLE
fabtests/efa: Remove rnr cq error message check

### DIFF
--- a/fabtests/prov/efa/src/rdm_rnr_read_cq_error.c
+++ b/fabtests/prov/efa/src/rdm_rnr_read_cq_error.c
@@ -43,7 +43,6 @@ static int rnr_read_cq_error(void)
 {
 	int total_send, expected_rnr_error;
 	int ret, i, cnt, rnr_flag;
-	const char *prov_errmsg;
 
 	expected_rnr_error = fi->rx_attr->size;
 	rnr_flag = 0;
@@ -89,16 +88,6 @@ static int rnr_read_cq_error(void)
 					rnr_flag = 1;
 					printf("Got RNR error CQ entry as expected: %d, %s\n",
 						comp_err.err, fi_strerror(comp_err.err));
-					prov_errmsg = fi_cq_strerror(txcq, comp_err.prov_errno,
-								     comp_err.err_data,
-								     comp_err.buf,
-								     comp_err.len);
-					if (strstr(prov_errmsg, "Destination resource not ready") == NULL) {
-						printf("Got unexpected provider error message.\n");
-						printf("    Expected error message to have \"Destination resource not ready\" in it\n");
-						printf("    Got: %s\n", prov_errmsg);
-						return -FI_EINVAL;
-					}
 				} else {
 					printf("Got non-RNR error CQ entry: %d, %s\n",
 						comp_err.err, fi_strerror(comp_err.err));


### PR DESCRIPTION
The current check for rnr cq error message string
is unnecessary and fragile as we may adjust
the error message. This patch removes such error
message check and relies on the error code check.