### PR TITLE
prov/util: Change uffd stop routine to use pipe

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -231,6 +231,7 @@ struct ofi_uffd {
 	struct ofi_mem_monitor		monitor;
 	pthread_t			thread;
 	int				fd;
+	int                             exit_pipe[2];
 };
 
 extern struct ofi_mem_monitor *uffd_monitor;


### PR DESCRIPTION
Without this change, the following segfault can happen.

#0  0x00001555546a66de in malloc () from /lib64/libc.so.6
#1  0x00001555555351f8 in _dl_new_object () from /lib64/ld-linux-x86-64.so.2
#2  0x000015555552f413 in _dl_map_object_from_fd () from /lib64/ld-linux-x86-64.so.2
#3  0x000015555553252a in _dl_map_object () from /lib64/ld-linux-x86-64.so.2
#4  0x000015555553d700 in dl_open_worker () from /lib64/ld-linux-x86-64.so.2
#5  0x000015555476002d in _dl_catch_exception () from /lib64/libc.so.6
#6  0x000015555553d28b in _dl_open () from /lib64/ld-linux-x86-64.so.2
#7  0x000015555475f37d in do_dlopen () from /lib64/libc.so.6
#8  0x000015555476002d in _dl_catch_exception () from /lib64/libc.so.6
#9  0x00001555547600bf in _dl_catch_error () from /lib64/libc.so.6
#10 0x000015555475f497 in dlerror_run () from /lib64/libc.so.6
#11 0x000015555475f567 in __libc_dlopen_mode () from /lib64/libc.so.6
#12 0x0000155555409fbb in pthread_cancel_init () from /lib64/libpthread.so.0
#13 0x00001555554062b7 in pthread_cancel () from /lib64/libpthread.so.0
#14 0x00000000005b66eb in ofi_uffd_stop (monitor=0x70f3e0 <uffd>) at prov/util/src/util_mem_monitor.c:887
#15 0x00000000005b4c25 in ofi_monitors_update (monitors=0x7fffffffe070) at prov/util/src/util_mem_monitor.c:154
#16 0x00000000005b5828 in ofi_monitors_del_cache (cache=0x74a428) at prov/util/src/util_mem_monitor.c:485
#17 0x00000000005b9956 in ofi_mr_cache_cleanup (cache=0x74a428) at prov/util/src/util_mr_cache.c:502
#18 0x00000000005e8cb1 in cxip_iomm_fini (dom=0x746250) at prov/cxi/src/cxip_iomm.c:368
#19 0x0000000000617494 in cxip_domain_disable (dom=0x746250) at prov/cxi/src/cxip_dom.c:540
#20 0x000000000061755f in cxip_dom_close (fid=0x746250) at prov/cxi/src/cxip_dom.c:568
#21 0x000000000054da04 in fi_close (fid=0x746250) at ./include/rdma/fabric.h:632
#22 0x0000000000570df9 in av_auth_key_test_rx_ep_fini () at prov/cxi/test/auth_key.c:2495
#23 0x0000000000575efa in data_transfer_av_auth_key_av_user_id_source_err_auth_key_user_id_impl () at prov/cxi/test/auth_key.c:2802
#24 0x0000155555017f50 in criterion_internal_test_main (fn=0x5751ad <data_transfer_av_auth_key_av_user_id_source_err_auth_key_user_id_impl>) at ../src/core/test.c:94
#25 0x00000000005751a5 in data_transfer_av_auth_key_av_user_id_source_err_auth_key_user_id_jmp () at prov/cxi/test/auth_key.c:2754
#26 0x0000155555016823 in run_test_child () at ../src/core/runner_coroutine.c:230
#27 0x00001555550268b1 in bxfi_main () at ../subprojects/boxfort/src/sandbox.c:57
#28 0x000015555463e24d in __libc_start_main () from /lib64/libc.so.6
#29 0x0000000000405bea in _start () at ../sysdeps/x86_64/start.S:120