### PR TITLE
fabtest: Fix compilation error with C99

### DIFF
--- a/fabtests/include/unix/osd.h
+++ b/fabtests/include/unix/osd.h
@@ -125,7 +125,7 @@ static inline void OFI_COMPLEX_OP(name, set)(OFI_COMPLEX(name) *v1, OFI_COMPLEX(
 }												      \
 static inline void OFI_COMPLEX_OP(name, fill)(OFI_COMPLEX(name) *v1, name v2)			      \
 {												      \
-	*v1 = CMPLX(v2, v2);							  		      \
+	*v1 = (OFI_COMPLEX(name))((name)(v2) + I * (name)(v2));			  		      \
 }
 
 OFI_COMPLEX_OPS(float)


### PR DESCRIPTION
CMPLX is introduced in C11, it may be undefined in C99. Compilation error was observed with Coverity scan.