### PR TITLE
prov/udp: detect and use interface MTU to support large messages over UDP

### DIFF
--- a/include/freebsd/osd.h
+++ b/include/freebsd/osd.h
@@ -76,6 +76,11 @@ static inline size_t ofi_ifaddr_get_speed(struct ifaddrs *ifa)
 	return 0;
 }
 
+static inline int ofi_ifaddr_get_mtu(const struct ifaddrs *ifa)
+{
+	return -1;
+}
+
 static inline ssize_t ofi_process_vm_readv(pid_t pid,
 			const struct iovec *local_iov,
 			unsigned long liovcnt,
@@ -185,5 +190,3 @@ ofi_recvv_socket(SOCKET fd, const struct iovec *iov, size_t cnt, int flags)
 }
 
 #endif /* _FREEBSD_OSD_H_ */
-
-

--- a/include/linux/osd.h
+++ b/include/linux/osd.h
@@ -92,6 +92,8 @@ static inline int ofi_hugepage_enabled(void)
 
 size_t ofi_ifaddr_get_speed(struct ifaddrs *ifa);
 
+int ofi_ifaddr_get_mtu(const struct ifaddrs *ifa);
+
 #ifndef __NR_process_vm_readv
 # define __NR_process_vm_readv 310
 #endif

--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -655,6 +655,7 @@ struct ofi_addr_list_entry {
 	char			ipstr[INET6_ADDRSTRLEN];
 	union ofi_sock_ip	ipaddr;
 	size_t			speed;
+	int			mtu;
 	char			net_name[OFI_ADDRSTRLEN];
 	char			ifa_name[OFI_ADDRSTRLEN];
 	uint64_t		comm_caps;

--- a/include/osx/osd.h
+++ b/include/osx/osd.h
@@ -99,6 +99,11 @@ static inline size_t ofi_ifaddr_get_speed(struct ifaddrs *ifa)
 	return 0;
 }
 
+static inline int ofi_ifaddr_get_mtu(const struct ifaddrs *ifa)
+{
+	return -1;
+}
+
 static inline int ofi_hugepage_enabled(void)
 {
 	return 0;

--- a/include/windows/ifaddrs.h
+++ b/include/windows/ifaddrs.h
@@ -34,8 +34,8 @@ struct ifaddrs {
 
 	char		   ad_name[16];
 	size_t		   speed;
+	int		   mtu;
 };
 
 int getifaddrs(struct ifaddrs **ifap);
 void freeifaddrs(struct ifaddrs *ifa);
-

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -1006,6 +1006,8 @@ static inline int ofi_is_loopback_addr(struct sockaddr *addr) {
 
 size_t ofi_ifaddr_get_speed(struct ifaddrs *ifa);
 
+int ofi_ifaddr_get_mtu(const struct ifaddrs *ifa);
+
 #define file2unix_time	10000000i64
 #define win2unix_epoch	116444736000000000i64
 #define CLOCK_REALTIME 0

--- a/man/fi_udp.7.md
+++ b/man/fi_udp.7.md
@@ -41,9 +41,10 @@ receiving datagram messages over an unreliable endpoint.
 
 # LIMITATIONS
 
-The UDP provider has hard-coded maximums for supported queue sizes and data
-transfers.  These values are reflected in the related fabric attribute
-structures
+The UDP provider has a hard-coded maximum for supported queue sizes,
+which is reflected in the related fabric attribute structures. Maximum
+size of data transfers is limited by the MTU size of an interface, and
+is also reflected in the related fabric attribute structures.
 
 EPs must be bound to both RX and TX CQs.
 
@@ -53,7 +54,10 @@ No support for counters.
 
 # RUNTIME PARAMETERS
 
-No runtime parameters are currently defined.
+The UDP provider checks for the following environment variables -
+
+*FI_UDP_IFACE*
+: An string value that specifies the name of the interface.
 
 # SEE ALSO
 

--- a/prov/udp/src/udpx.h
+++ b/prov/udp/src/udpx.h
@@ -63,11 +63,9 @@
 #ifndef _UDPX_H_
 #define _UDPX_H_
 
-
 extern struct fi_provider udpx_prov;
 extern struct util_prov udpx_util_prov;
 extern struct fi_info udpx_info;
-
 
 int udpx_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 		void *context);
@@ -75,10 +73,12 @@ int udpx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		struct fid_domain **dom, void *context);
 int udpx_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 		struct fid_eq **eq, void *context);
-
+void udpx_util_prov_init(uint32_t version);
+void udpx_util_prov_fini();
 
 #define UDPX_FLAG_MULTI_RECV	1
 #define UDPX_IOV_LIMIT		4
+#define UDPX_MTU		1500
 
 struct udpx_ep_entry {
 	void			*context;
@@ -87,6 +87,10 @@ struct udpx_ep_entry {
 	uint8_t			flags;
 	uint8_t			resv[sizeof(size_t) - 2];
 };
+
+#define UDPX_UDP_HEADER_SIZE	8
+#define UDPX_IP_HEADER_SIZE	20
+#define UDPX_MAX_MSG_SIZE(mtu) ((mtu) - (UDPX_UDP_HEADER_SIZE + UDPX_IP_HEADER_SIZE))
 
 OFI_DECLARE_CIRQUE(struct udpx_ep_entry, udpx_rx_cirq);
 

--- a/src/linux/osd.c
+++ b/src/linux/osd.c
@@ -257,3 +257,31 @@ err1:
 }
 
 #endif /* HAVE_ETHTOOL */
+
+int ofi_ifaddr_get_mtu(const struct ifaddrs *ifa)
+{
+	FILE *fp;
+        char *mtu_filename;
+        int mtu;
+
+	if (asprintf(&mtu_filename, "/sys/class/net/%s/mtu",
+		     ifa->ifa_name) == -1)
+		return 0;
+
+	fp = fopen(mtu_filename, "r");
+	if (!fp)
+		goto err1;
+
+	if (fscanf(fp, "%d", &mtu) != 1)
+		goto err2;
+
+        fclose(fp);
+	free(mtu_filename);
+
+	return mtu;
+ err2:
+	fclose(fp);
+ err1:
+	free(mtu_filename);
+	return 0;
+}

--- a/src/windows/osd.c
+++ b/src/windows/osd.c
@@ -477,6 +477,7 @@ int getifaddrs(struct ifaddrs **ifap)
 				(*addr6) = *(struct sockaddr_in6 *) pSockAddr;
 			}
 			fa->speed = aa->TransmitLinkSpeed;
+			fa->mtu = (int)aa->Mtu;
 			/* Generate fake Unix-like device names */
 			sprintf_s(fa->ad_name, sizeof(fa->ad_name), "eth%d", i++);
 		}
@@ -495,6 +496,11 @@ out:
 size_t ofi_ifaddr_get_speed(struct ifaddrs *ifa)
 {
 	return ifa->speed;
+}
+
+int ofi_ifaddr_get_mtu(const struct ifaddrs *ifa)
+{
+  return ifa->mtu;
 }
 
 void freeifaddrs(struct ifaddrs *ifa)


### PR DESCRIPTION
This commit supports a maximum UDP message size that depends on the MTU size of the interface. The use case is UDP messaging on an Ethernet network configured to use jumbo frames.

For each interface detected by the udp provider, determine the MTU of the interface, and use that value to set the `max_msg_size` field of the `fi_ep_attr` and `fi_tx_attr `values of the fi_info element. When the MTU cannot be determined, the MTU value assumed by previous code versions (1500) is used.
