### PR TITLE
prov/cxi: Report RMA ordering used in debug output

### DIFF
--- a/prov/cxi/src/cxip_rma.c
+++ b/prov/cxi/src/cxip_rma.c
@@ -658,12 +658,14 @@ ssize_t cxip_rma_common(enum fi_op_type op, struct cxip_txc *txc,
 
 	if (ret)
 		TXC_WARN(txc,
-			 "%s RMA %s failed: buf=%p len=%lu rkey=%#lx roffset=%#lx nic=%#x pid=%u pid_idx=%u\n",
+			 "%s %s RMA %s failed: buf=%p len=%lu rkey=%#lx roffset=%#lx nic=%#x pid=%u pid_idx=%u\n",
+			 unr ? "Ordered" : "Un-ordered",
 			 idc ? "IDC" : "DMA", write ? "write" : "read",
 			 buf, len, key, addr, caddr.nic, caddr.pid, pid_idx);
 	else
 		TXC_DBG(txc,
-			"%s RMA %s emitted: buf=%p len=%lu rkey=%#lx roffset=%#lx nic=%#x pid=%u pid_idx=%u\n",
+			"%s %s RMA %s emitted: buf=%p len=%lu rkey=%#lx roffset=%#lx nic=%#x pid=%u pid_idx=%u\n",
+			unr ? "Ordered" : "Un-ordered",
 			idc ? "IDC" : "DMA", write ? "write" : "read",
 			buf, len, key, addr, caddr.nic, caddr.pid, pid_idx);
 


### PR DESCRIPTION
Report order used for an RMA operation in debug
and error output.

Signed-off-by: Steve Welch <welch@hpe.com>