### PR TITLE
fabtests: Fix compiler warning about unitialized variable

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -3843,7 +3843,7 @@ int ft_check_atomic(enum ft_atomic_opcodes atomic, enum fi_op op,
 		    void *cmp, void *res, size_t count)
 {
 	int ret = 0;
-	void *check_res = res, *check_buf, *check_comp;
+	void *check_res = res, *check_buf, *check_comp = cmp;
 
 	/*
 	 * If we don't have the test function, return > 0 to indicate


### PR DESCRIPTION
The compiler can't properly follow the def-use chain guarded by the same condition and complains about the variable could be used w/o initialization:

    if (atomic == FI_ATOMIC_COMPARE) {
        check_cmp =  ...;
    }
    ......
    if (atomic == FI_ATOMIC_COMPARE) {
        use check_cmp in macro
    }