### PR TITLE
prov/verbs: Enable implicit dmabuf mr reg for more HMEM ifaces

### DIFF
--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -142,12 +142,9 @@ vrb_mr_reg_common(struct vrb_mem_desc *md, int vrb_access, const void *base_addr
 		md->mr = ibv_reg_dmabuf_mr(md->domain->pd, (uintptr_t) buf,
 					   len, (uintptr_t) base_addr + (uintptr_t) buf,
 					   (int) device, vrb_access);
-	else if (vrb_gl_data.dmabuf_support &&
-		 (iface == FI_HMEM_ZE ||
-		  iface == FI_HMEM_SYNAPSEAI ||
-		  iface == FI_HMEM_ROCR))
+	else if (vrb_gl_data.dmabuf_support && iface != FI_HMEM_SYSTEM)
 		md->mr = vrb_reg_hmem_dmabuf(iface, md->domain->pd, buf, len,
-						vrb_access);
+					     vrb_access);
 	else
 #endif
 		md->mr = ibv_reg_mr(md->domain->pd, (void *) buf, len,


### PR DESCRIPTION
Now all the non-system HMEM ifaces have get_dmabuf_fd method defined, it's safe to always try the dmabuf based memory registration first. If it fails for any reason (e.g. CUDA is not configured with dmabuf support), the failover path will try the peer memory approach when available.