### PR TITLE
hmem/cuda: Add env variable to enable/disable CUDA DMABUF

### DIFF
--- a/src/hmem_cuda.c
+++ b/src/hmem_cuda.c
@@ -763,6 +763,9 @@ int cuda_hmem_init(void)
 			"If libfabric is not compiled with gdrcopy support, "
 			"this variable is not checked. (default: true)");
 
+	fi_param_define(NULL, "hmem_cuda_use_dmabuf", FI_PARAM_BOOL,
+			"Use dma-buf for sharing buffer with hardware. (default:true)");
+
 	ret = cuda_hmem_dl_init();
 	if (ret != FI_SUCCESS)
 		return ret;
@@ -936,7 +939,11 @@ bool cuda_is_gdrcopy_enabled(void)
 
 bool cuda_is_dmabuf_supported(void)
 {
-	return cuda_attr.dmabuf_supported;
+	int use_dmabuf = 1;
+
+	fi_param_get_bool(NULL, "hmem_cuda_use_dmabuf", &use_dmabuf);
+
+	return use_dmabuf && cuda_attr.dmabuf_supported;
 }
 
 #else


### PR DESCRIPTION
Add FI_HMEM_CUDA_USE_DMABUF environment variable and default to enabled.

There are applications that can run out of GPU BAR space when using dmabuf and gdrcopy both register memory.