### PR TITLE
contrib/intel/jenkins: Separate tcp & tcp;ofi_rxm testing

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -93,11 +93,12 @@ def run_middleware(providers, stage_name, test, hw, partition, node_num,
   }
 }
 
-def run_ci(stage_name, config_name) {
+def run_ci(stage_name, config_name, additional_args=null) {
   sh """source ${CI_LOCATION}/${env.CI_MODULE}/venv/bin/activate;\
         python run.py \
         --output=${env.LOG_DIR}/${stage_name} \
-        --job=${config_name}
+        --job=${config_name} \
+        ${additional_args}
      """
 }
 
@@ -451,11 +452,7 @@ pipeline {
                             """python$PYTHON_VERSION ${RUN_LOCATION}/build.py \
                               --build_item=mpich --build_hw=water"""
                           )
-              slurm_batch("totodile", "1",
-                          "${env.LOG_DIR}/build_shmem_water_log",
-                          """python$PYTHON_VERSION ${RUN_LOCATION}/build.py \
-                              --build_item=shmem --build_hw=water"""
-                         )
+              run_ci("CI_shmem_grass", "pr_shmem_grass.json", "--build-only")
             }
           }
         }
@@ -468,11 +465,7 @@ pipeline {
                             """python$PYTHON_VERSION ${RUN_LOCATION}/build.py \
                               --build_item=mpich --build_hw=grass"""
                           )
-              slurm_batch("grass", "1",
-                          "${env.LOG_DIR}/build_shmem_grass_log",
-                          """python$PYTHON_VERSION ${RUN_LOCATION}/build.py \
-                              --build_item=shmem --build_hw=grass"""
-                         )
+              run_ci("CI_shmem_water", "pr_shmem_water.json", "--build-only")
             }
           }
         }
@@ -728,9 +721,8 @@ pipeline {
         stage('SHMEM_grass') {
           steps {
             script {
-              dir (RUN_LOCATION) {
-                run_middleware([["tcp", null]], "SHMEM", "shmem",
-                                "grass", "bulbasaur,chikorita", "2")
+              dir (CI_LOCATION) {
+                run_ci("CI_shmem_grass", "pr_shmem_grass.json")
               }
             }
           }
@@ -738,9 +730,8 @@ pipeline {
         stage('SHMEM_water') {
           steps {
             script {
-              dir (RUN_LOCATION) {
-                run_middleware([["verbs", "rxm"], ["sockets", null]], "SHMEM",
-                                "shmem", "water", "totodile", "2")
+              dir (CI_LOCATION) {
+                run_ci("CI_shmem_water", "pr_shmem_water.json")
               }
             }
           }

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -93,12 +93,20 @@ def run_middleware(providers, stage_name, test, hw, partition, node_num,
   }
 }
 
-def run_ci(stage_name, config_name, additional_args=null) {
+def run_ci(stage_name, config_name, additional_args="") {
   sh """source ${CI_LOCATION}/${env.CI_MODULE}/venv/bin/activate;\
         python run.py \
         --output=${env.LOG_DIR}/${stage_name} \
         --job=${config_name} \
         ${additional_args}
+     """
+}
+
+def build_ci(stage_name, config_name) {
+  sh """source ${CI_LOCATION}/${env.CI_MODULE}/venv/bin/activate;\
+        python build.py \
+        --output=${env.LOG_DIR}/${stage_name} \
+        --job=${config_name}
      """
 }
 
@@ -281,6 +289,13 @@ def bootstrap_ci() {
   sh "${CI_LOCATION}/${env.CI_MODULE}/bootstrap.sh"
 }
 
+def checkout_tar(name) {
+  dir ("${env.CUSTOM_WORKSPACE}/${name}/libfabric") { checkout scm }
+  dir ("${env.CUSTOM_WORKSPACE}/${name}/") {
+    sh "tar -cvf libfabric.tar.gz libfabric/*"
+  }
+}
+
 def check_target() {
   echo "CHANGE_TARGET = ${env.CHANGE_TARGET}"
   if (changeRequest()) {
@@ -370,27 +385,7 @@ pipeline {
     stage ('checkout') {
       steps {
         script {
-          dir ("${CUSTOM_WORKSPACE}/source/libfabric") {
-            checkout scm
-          }
-          dir ("${CUSTOM_WORKSPACE}/grass/libfabric") {
-            checkout scm
-          }
-          dir ("${CUSTOM_WORKSPACE}/water/libfabric") {
-            checkout scm
-          }
-          dir ("${CUSTOM_WORKSPACE}/electric/libfabric") {
-            checkout scm
-          }
-          dir ("${CUSTOM_WORKSPACE}/ucx/libfabric") {
-            checkout scm
-          }
-          dir ("${CUSTOM_WORKSPACE}/cuda/libfabric") {
-            checkout scm
-          }
-          dir ("${CUSTOM_WORKSPACE}/iouring/libfabric") {
-            checkout scm
-          }
+          checkout_tar("source")
           dir (CUSTOM_WORKSPACE) {
             checkout_external_resources()
           }
@@ -433,72 +428,88 @@ pipeline {
         }
       }
     }
+    stage ('bootstrap-ci') {
+      steps {
+        script {
+          bootstrap_ci()
+        }
+      }
+    }
     stage ('parallel-builds') {
       when { equals expected: true, actual: DO_RUN }
       parallel {
-        stage ('bootstrap-ci') {
-          steps {
-            script {
-              bootstrap_ci()
-            }
-          }
-        }
         stage ('build-water') {
           steps {
             script {
-              slurm_build(BUILD_MODES, "totodile", "water", "water", "water")
-              slurm_batch("totodile", "1",
+              dir (CI_LOCATION) {
+                build_ci("CI_build_water", "pr_build_water.json")
+                build_ci("CI_shmem_water", "pr_shmem_1n2ppn_water.json")
+                slurm_batch("totodile", "1",
                             "${env.LOG_DIR}/build_mpich_water_log",
                             """python$PYTHON_VERSION ${RUN_LOCATION}/build.py \
                               --build_item=mpich --build_hw=water"""
                           )
-              run_ci("CI_shmem_grass", "pr_shmem_grass.json", "--build-only")
+              }
             }
           }
         }
         stage ('build-grass') {
           steps {
             script {
-              slurm_build(BUILD_MODES, "grass", "grass", "grass", "grass")
-              slurm_batch("grass", "1",
+              dir (CI_LOCATION) {
+                build_ci("CI_build_grass", "pr_build_grass.json")
+                build_ci("CI_shmem_grass", "pr_shmem_1n2ppn_grass.json")
+                slurm_batch("grass", "1",
                             "${env.LOG_DIR}/build_mpich_grass_log",
                             """python$PYTHON_VERSION ${RUN_LOCATION}/build.py \
                               --build_item=mpich --build_hw=grass"""
                           )
-              run_ci("CI_shmem_water", "pr_shmem_water.json", "--build-only")
+              }
             }
           }
         }
         stage ('build-electric') {
           steps {
             script {
-              slurm_build(BUILD_MODES, "electric", "electric", "electric",
-                          "electric")
+              dir (CI_LOCATION) {
+                build_ci("CI_build_electric", "pr_build_electric.json")
+              }
             }
           }
         }
         stage ('build-ucx') {
           steps {
             script {
-              slurm_build(BUILD_MODES, "totodile", "ucx", "ucx", "ucx")
+              dir (CI_LOCATION) {
+                build_ci("CI_build_ucx", "pr_build_ucx.json")
+              }
             }
           }
         }
-        stage ('build-cuda') {
+        stage ('build-cyndaquil') {
           steps {
             script {
-              slurm_build(["reg"], "cyndaquil", "cuda", "cyndaquil",
-                          "cyndaquil", "--cuda")
-              slurm_build(["reg"], "quilava", "cuda", "quilava",
-                          "quilava", "--cuda")
+              dir (CI_LOCATION) {
+                build_ci("CI_build_cyndaquil", "pr_build_cyndaquil.json")
+              }
             }
           }
         }
-        stage ('build-iouring') {
+        stage ('build-quilava') {
           steps {
             script {
-              slurm_build(BUILD_MODES, "ivysaur", "iouring", "ivysaur",
-                          "ivysaur")
+              dir (CI_LOCATION) {
+                build_ci("CI_build_quilava", "pr_build_quilava.json")
+              }
+            }
+          }
+        }
+        stage ('build-ivysaur') {
+          steps {
+            script {
+              dir (CI_LOCATION) {
+                build_ci("CI_build_ivysaur", "pr_build_ivysaur.json")
+              }
             }
           }
         }
@@ -512,17 +523,21 @@ pipeline {
           options { skipDefaultCheckout() }
           steps {
             script {
-              dir ("${CUSTOM_WORKSPACE}/source/libfabric") { checkout scm }
+              checkout_tar("source")
               checkout_external_resources()
               dir (CUSTOM_WORKSPACE) {
                 build("logdir")
-                build("libfabric", "reg", "daos")
-                build("fabtests", "reg", "daos")
+                // build("libfabric", "reg", "daos")
+                // build("fabtests", "reg", "daos")
+              }
+              bootstrap_ci()
+              dir (CI_LOCATION) {
+                build_ci("CI_build_daos", "pr_build_daos.json")
               }
             }
           }
         }
-        stage ('build-gpu') {
+        stage ('build-fire') {
           agent {
             node {
               label 'ze'
@@ -532,14 +547,17 @@ pipeline {
           options { skipDefaultCheckout() }
           steps {
             script {
-              dir ("${CUSTOM_WORKSPACE}/source/libfabric") { checkout scm }
+              checkout_tar("source")
               checkout_external_resources()
               dir (CUSTOM_WORKSPACE) {
                 build("logdir")
                 build("builddir")
-                bootstrap_ci()
-                slurm_build(BUILD_MODES, "fabrics-ci", "source", "ze", "gpu",
-                            "--gpu")
+                // slurm_build(BUILD_MODES, "fabrics-ci", "source", "ze", "gpu",
+                //             "--gpu")
+              }
+              bootstrap_ci()
+              dir (CI_LOCATION) {
+                build_ci("CI_build_fire", "pr_build_fire.json")
               }
             }
           }
@@ -775,16 +793,16 @@ pipeline {
             script {
               dir (RUN_LOCATION) {
                 run_middleware([["psm3", null]], "oneCCL-GPU-v3", "onecclgpu",
-                               "gpu", "torchic", "1", null, null,
+                               "fire", "torchic", "1", null, null,
                                "FI_HMEM_DISABLE_P2P=1")
                 run_middleware([["verbs", null]], "oneCCL-GPU-v3", "onecclgpu",
-                                "gpu", "torchic", "1", null, null,
+                                "fire", "torchic", "1", null, null,
                                 "FI_HMEM_DISABLE_P2P=1")
                 run_middleware([["tcp", null]], "oneCCL-GPU-v3", "onecclgpu",
-                               "gpu", "torchic", "1", null, null,
+                               "fire", "torchic", "1", null, null,
                                "FI_HMEM_DISABLE_P2P=1")
                 run_middleware([["shm", null]], "oneCCL-GPU-v3", "onecclgpu",
-                               "gpu", "torchic", "1", null, null,
+                               "fire", "torchic", "1", null, null,
                                "FI_HMEM_DISABLE_P2P=1")
               }
             }

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -444,11 +444,11 @@ pipeline {
               dir (CI_LOCATION) {
                 build_ci("CI_build_water", "pr_build_water.json")
                 build_ci("CI_shmem_water", "pr_shmem_1n2ppn_water.json")
-                slurm_batch("totodile", "1",
-                            "${env.LOG_DIR}/build_mpich_water_log",
-                            """python$PYTHON_VERSION ${RUN_LOCATION}/build.py \
-                              --build_item=mpich --build_hw=water"""
-                          )
+                // slurm_batch("totodile", "1",
+                //             "${env.LOG_DIR}/build_mpich_water_log",
+                //             """python$PYTHON_VERSION ${RUN_LOCATION}/build.py \
+                //               --build_item=mpich --build_hw=water"""
+                //           )
               }
             }
           }
@@ -459,11 +459,11 @@ pipeline {
               dir (CI_LOCATION) {
                 build_ci("CI_build_grass", "pr_build_grass.json")
                 build_ci("CI_shmem_grass", "pr_shmem_1n2ppn_grass.json")
-                slurm_batch("grass", "1",
-                            "${env.LOG_DIR}/build_mpich_grass_log",
-                            """python$PYTHON_VERSION ${RUN_LOCATION}/build.py \
-                              --build_item=mpich --build_hw=grass"""
-                          )
+                // slurm_batch("grass", "1",
+                //             "${env.LOG_DIR}/build_mpich_grass_log",
+                //             """python$PYTHON_VERSION ${RUN_LOCATION}/build.py \
+                //               --build_item=mpich --build_hw=grass"""
+                //           )
               }
             }
           }

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -178,7 +178,7 @@ def checkout_ci_resources() {
       rm -rf ${env.WORKSPACE}/ci_resources && mkdir ${env.WORKSPACE}/ci_resources
     fi
 
-    git clone ${env.CI_RESOURCES} ${env.WORKSPACE}/ci_resources
+    git clone -b main ${env.ZDWORKIN_CI_RESOURCES} ${env.WORKSPACE}/ci_resources
 
   """
 }
@@ -191,7 +191,7 @@ def checkout_ci() {
       rm -rf ${env.WORKSPACE}/ci && mkdir ${env.WORKSPACE}/ci
     fi
 
-    git clone --recurse-submodules ${env.CI} ${env.WORKSPACE}/ci
+    git clone --recurse-submodules -b cloudbees ${env.ZDWORKIN_CI} ${env.WORKSPACE}/ci
   """
 }
 
@@ -348,7 +348,7 @@ def skip() {
 pipeline {
   agent {
     node {
-      label 'main'
+      label 'main-dev'
       customWorkspace "workspace/${JOB_NAME}/${env.BUILD_NUMBER}"
     }
   }
@@ -930,20 +930,9 @@ pipeline {
       script {
         if (DO_RUN) {
           CI_summarize(verbose=true)
-          summarize("all", verbose=true, release=false,
-          send_mail=env.WEEKLY.toBoolean())
+          summarize("all", verbose=true)
         }
       }
-      node ('daos_head') {
-        dir("${env.WORKSPACE}") { deleteDir() }
-        dir("${env.WORKSPACE}@tmp") { deleteDir() }
-      }
-      node ('ze') {
-        dir("${env.WORKSPACE}") { deleteDir() }
-        dir("${env.WORKSPACE}@tmp") { deleteDir() }
-      }
-      dir("${env.WORKSPACE}") { deleteDir() }
-      dir("${env.WORKSPACE}@tmp") { deleteDir() }
     }
   }
 }

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -277,7 +277,7 @@ def build(item, mode=null, hw=null, additional_args=null) {
   run_python(PYTHON_VERSION, cmd)
 }
 
-def build_ci() {
+def bootstrap_ci() {
   sh "${CI_LOCATION}/${env.CI_MODULE}/bootstrap.sh"
 }
 
@@ -436,10 +436,10 @@ pipeline {
     stage ('parallel-builds') {
       when { equals expected: true, actual: DO_RUN }
       parallel {
-        stage ('build-ci') {
+        stage ('bootstrap-ci') {
           steps {
             script {
-              build_ci()
+              bootstrap_ci()
             }
           }
         }
@@ -537,7 +537,7 @@ pipeline {
               dir (CUSTOM_WORKSPACE) {
                 build("logdir")
                 build("builddir")
-                build_ci()
+                bootstrap_ci()
                 slurm_build(BUILD_MODES, "fabrics-ci", "source", "ze", "gpu",
                             "--gpu")
               }


### PR DESCRIPTION
separate tcp and tcp;ofi_rxm testing so that both providers are covered. Previously tcp was testing everything and picking up rxm as needed. Instead it is better practice to separate them and just test both usecases entirely. Update both tcp ubertest lists to correctly run only supported tests.