### PR TITLE
prov/rxm: add FI_PEER support to rxm

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -955,12 +955,15 @@ struct rxm_av {
 	struct fid_peer_av peer_av;
 	struct fid_av *util_coll_av;
 	struct fid_av *offload_coll_av;
+	void (*foreach_ep)(struct util_av *av, struct util_ep *util_ep);
 };
 
 int rxm_util_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 		     struct fid_av **fid_av, void *context, size_t conn_size,
 		     void (*remove_handler)(struct util_ep *util_ep,
-					    struct util_peer_addr *peer));
+					    struct util_peer_addr *peer),
+		     void (*foreach_ep)(struct util_av *av,
+					struct util_ep *ep));
 size_t rxm_av_max_peers(struct rxm_av *av);
 void rxm_ref_peer(struct util_peer_addr *peer);
 void *rxm_av_alloc_conn(struct rxm_av *av);

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -417,13 +417,15 @@ struct rxm_pkt {
 	char data[];
 };
 
+enum rxm_sar_seg_type {
+	RXM_SAR_SEG_FIRST	= 1,
+	RXM_SAR_SEG_MIDDLE	= 2,
+	RXM_SAR_SEG_LAST	= 3,
+};
+
 union rxm_sar_ctrl_data {
 	struct {
-		enum rxm_sar_seg_type {
-			RXM_SAR_SEG_FIRST	= 1,
-			RXM_SAR_SEG_MIDDLE	= 2,
-			RXM_SAR_SEG_LAST	= 3,
-		} seg_type : 2;
+		enum rxm_sar_seg_type seg_type : 2;
 		uint32_t offset;
 	};
 	uint64_t align;

--- a/prov/rxm/src/rxm_attr.c
+++ b/prov/rxm/src/rxm_attr.c
@@ -40,7 +40,8 @@
 		     OFI_RX_RMA_CAPS | FI_ATOMICS | FI_DIRECTED_RECV | \
 		     FI_MULTI_RECV)
 
-#define RXM_DOMAIN_CAPS (FI_LOCAL_COMM | FI_REMOTE_COMM | FI_AV_USER_ID)
+#define RXM_DOMAIN_CAPS (FI_LOCAL_COMM | FI_REMOTE_COMM | FI_AV_USER_ID | \
+			 FI_PEER)
 
 
 /* Since we are a layering provider, the attributes for which we rely on the

--- a/prov/rxm/src/rxm_attr.c
+++ b/prov/rxm/src/rxm_attr.c
@@ -40,7 +40,7 @@
 		     OFI_RX_RMA_CAPS | FI_ATOMICS | FI_DIRECTED_RECV | \
 		     FI_MULTI_RECV)
 
-#define RXM_DOMAIN_CAPS (FI_LOCAL_COMM | FI_REMOTE_COMM)
+#define RXM_DOMAIN_CAPS (FI_LOCAL_COMM | FI_REMOTE_COMM | FI_AV_USER_ID)
 
 
 /* Since we are a layering provider, the attributes for which we rely on the

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -106,11 +106,12 @@ static void rxm_cq_write_recv_comp(struct rxm_rx_buf *rx_buf, void *context,
 {
 	int ret;
 
+	flags &= ~FI_COMPLETION;
 	if (rx_buf->ep->util_coll_peer_xfer_ops &&
 	    rx_buf->pkt.hdr.tag & RXM_PEER_XFER_TAG_FLAG) {
 		struct fi_cq_tagged_entry cqe = {
 			.tag = rx_buf->pkt.hdr.tag,
-			.op_context = rx_buf->recv_entry->context,
+			.op_context = rx_buf->peer_entry->context,
 		};
 		rx_buf->ep->util_coll_peer_xfer_ops->
 			complete(rx_buf->ep->util_coll_ep, &cqe, 0);
@@ -137,7 +138,7 @@ static void rxm_finish_buf_recv(struct rxm_rx_buf *rx_buf)
 
 	if ((rx_buf->pkt.ctrl_hdr.type == rxm_ctrl_seg) &&
 	    rxm_sar_get_seg_type(&rx_buf->pkt.ctrl_hdr) != RXM_SAR_SEG_FIRST) {
-		dlist_insert_tail(&rx_buf->unexp_msg.entry,
+		dlist_insert_tail(&rx_buf->unexp_entry,
 				  &rx_buf->conn->deferred_sar_segments);
 		rxm_replace_rx_buf(rx_buf);
 	}
@@ -172,10 +173,11 @@ static void rxm_cq_write_error_trunc(struct rxm_rx_buf *rx_buf, size_t done_len)
 		done_len, rx_buf->pkt.hdr.size);
 	ret = ofi_peer_cq_write_error_trunc(
 				rx_buf->ep->util_ep.rx_cq,
-				rx_buf->recv_entry->context,
-				rx_buf->recv_entry->comp_flags |
-				rx_buf->pkt.hdr.flags, rx_buf->pkt.hdr.size,
-				rx_buf->recv_entry->rxm_iov.iov[0].iov_base,
+				rx_buf->peer_entry->context,
+				rx_buf->peer_entry->flags |
+				rx_buf->pkt.hdr.flags,
+				rx_buf->pkt.hdr.size,
+				rx_buf->peer_entry->iov[0].iov_base,
 				rx_buf->pkt.hdr.data, rx_buf->pkt.hdr.tag,
 				rx_buf->pkt.hdr.size - done_len);
 	if (ret) {
@@ -186,27 +188,22 @@ static void rxm_cq_write_error_trunc(struct rxm_rx_buf *rx_buf, size_t done_len)
 
 static void rxm_finish_recv(struct rxm_rx_buf *rx_buf, size_t done_len)
 {
-	struct rxm_recv_entry *recv_entry = rx_buf->recv_entry;
-
 	if (done_len < rx_buf->pkt.hdr.size) {
 		rxm_cq_write_error_trunc(rx_buf, done_len);
 		goto release;
 	}
 
-	if (rx_buf->recv_entry->flags & FI_COMPLETION ||
+	if (rx_buf->peer_entry->flags & FI_COMPLETION ||
 	    rx_buf->ep->rxm_info->mode & OFI_BUFFERED_RECV) {
-		rxm_cq_write_recv_comp(
-				rx_buf, rx_buf->recv_entry->context,
-				rx_buf->recv_entry->comp_flags |
-				rx_buf->pkt.hdr.flags |
-				(rx_buf->recv_entry->flags & FI_MULTI_RECV),
-				rx_buf->pkt.hdr.size,
-				rx_buf->recv_entry->rxm_iov.
-				iov[0].iov_base);
+		rxm_cq_write_recv_comp(rx_buf, rx_buf->peer_entry->context,
+				       rx_buf->peer_entry->flags |
+				       rx_buf->pkt.hdr.flags,
+				       rx_buf->pkt.hdr.size,
+				       rx_buf->peer_entry->iov[0].iov_base);
 	}
 	ofi_ep_peer_rx_cntr_inc(&rx_buf->ep->util_ep, ofi_op_msg);
 release:
-	rxm_recv_entry_release(recv_entry);
+	rx_buf->ep->srx->owner_ops->free_entry(rx_buf->peer_entry);
 	rxm_free_rx_buf(rx_buf);
 }
 
@@ -294,18 +291,20 @@ static void rxm_handle_sar_comp(struct rxm_ep *rxm_ep,
 
 static void rxm_rndv_rx_finish(struct rxm_rx_buf *rx_buf)
 {
+	struct rxm_proto_info *proto_info;
+
 	RXM_UPDATE_STATE(FI_LOG_CQ, rx_buf, RXM_RNDV_FINISH);
 
-	if (rx_buf->recv_entry->rndv.tx_buf) {
-		ofi_buf_free(rx_buf->recv_entry->rndv.tx_buf);
-		rx_buf->recv_entry->rndv.tx_buf = NULL;
+	proto_info = rx_buf->proto_info;
+	if (proto_info->rndv.tx_buf) {
+		ofi_buf_free(proto_info);
+		ofi_buf_free(proto_info->rndv.tx_buf);
 	}
 
 	if (!rx_buf->ep->rdm_mr_local)
-		rxm_msg_mr_closev(rx_buf->mr,
-				  rx_buf->recv_entry->rxm_iov.count);
+		rxm_msg_mr_closev(rx_buf->mr, rx_buf->peer_entry->count);
 
-	rxm_finish_recv(rx_buf, rx_buf->recv_entry->total_len);
+	rxm_finish_recv(rx_buf, rx_buf->peer_entry->msg_size);
 }
 
 static void rxm_rndv_tx_finish(struct rxm_ep *rxm_ep,
@@ -398,94 +397,133 @@ static int rxm_rx_buf_match_msg_id(struct dlist_entry *item, const void *arg)
 	uint64_t msg_id = *((uint64_t *) arg);
 	struct rxm_rx_buf *rx_buf;
 
-	rx_buf = container_of(item, struct rxm_rx_buf, unexp_msg.entry);
+	rx_buf = container_of(item, struct rxm_rx_buf, unexp_entry);
 	return (msg_id == rx_buf->pkt.ctrl_hdr.msg_id);
 }
 
-static void rxm_process_seg_data(struct rxm_rx_buf *rx_buf, int *done)
+static void rxm_init_sar_proto(struct rxm_rx_buf *rx_buf)
+{
+	struct rxm_proto_info *proto_info;
+
+	proto_info = ofi_buf_alloc(rx_buf->ep->proto_info_pool);
+	if (!proto_info) {
+		FI_WARN(&rxm_prov, FI_LOG_CQ,
+			"Failed to allocate proto info buffer\n");
+		return;
+	}
+	if (!rx_buf->conn) {
+		rx_buf->conn = ofi_idm_at(&rx_buf->ep->conn_idx_map,
+				(int) rx_buf->pkt.ctrl_hdr.conn_id);
+	}
+
+	proto_info->sar.conn = rx_buf->conn;
+	proto_info->sar.msg_id = rx_buf->pkt.ctrl_hdr.msg_id;
+	proto_info->sar.total_recv_len = 0;
+	proto_info->sar.rx_entry = rx_buf->peer_entry;
+
+	dlist_insert_tail(&proto_info->sar.entry,
+			  &rx_buf->conn->deferred_sar_msgs);
+
+	dlist_init(&proto_info->sar.pkt_list);
+	if (rx_buf->peer_entry->peer_context)
+		dlist_insert_tail(&rx_buf->unexp_entry,
+				  &proto_info->sar.pkt_list);
+
+
+	rx_buf->proto_info = proto_info;
+}
+
+int rxm_process_seg_data(struct rxm_rx_buf *rx_buf)
 {
 	enum fi_hmem_iface iface;
+	struct rxm_proto_info *proto_info;
 	uint64_t device;
 	ssize_t done_len;
+	int done = 0;
 
-	iface = rxm_iov_desc_to_hmem_iface_dev(rx_buf->recv_entry->rxm_iov.iov,
-					       rx_buf->recv_entry->rxm_iov.desc,
-					       rx_buf->recv_entry->rxm_iov.count,
+	proto_info = rx_buf->proto_info;
+	iface = rxm_iov_desc_to_hmem_iface_dev(rx_buf->peer_entry->iov,
+					       rx_buf->peer_entry->desc,
+					       rx_buf->peer_entry->count,
 					       &device);
 
 	done_len = ofi_copy_to_hmem_iov(iface, device,
-					rx_buf->recv_entry->rxm_iov.iov,
-					rx_buf->recv_entry->rxm_iov.count,
-					rx_buf->recv_entry->sar.total_recv_len,
+					rx_buf->peer_entry->iov,
+					rx_buf->peer_entry->count,
+					proto_info->sar.total_recv_len,
 					rx_buf->pkt.data,
 					rx_buf->pkt.ctrl_hdr.seg_size);
 	assert(done_len == rx_buf->pkt.ctrl_hdr.seg_size);
 
-	rx_buf->recv_entry->sar.total_recv_len += done_len;
+	proto_info->sar.total_recv_len += done_len;
 
 	if ((rxm_sar_get_seg_type(&rx_buf->pkt.ctrl_hdr) == RXM_SAR_SEG_LAST) ||
 	    (done_len != rx_buf->pkt.ctrl_hdr.seg_size)) {
-
-		dlist_remove(&rx_buf->recv_entry->sar.entry);
-
-		/* Mark rxm_recv_entry::msg_id as unknown for futher re-use */
-		rx_buf->recv_entry->sar.msg_id = RXM_SAR_RX_INIT;
-
-		done_len = rx_buf->recv_entry->sar.total_recv_len;
-		rx_buf->recv_entry->sar.total_recv_len = 0;
-
-		*done = 1;
+		if (!rx_buf->peer_entry->peer_context)
+			dlist_remove(&proto_info->sar.entry);
+		done_len = proto_info->sar.total_recv_len;
+		done = 1;
+		ofi_buf_free(rx_buf->proto_info);
 		rxm_finish_recv(rx_buf, done_len);
 	} else {
-		if (rx_buf->recv_entry->sar.msg_id == RXM_SAR_RX_INIT) {
-			if (!rx_buf->conn) {
-				rx_buf->conn = ofi_idm_at(&rx_buf->ep->conn_idx_map,
-						(int) rx_buf->pkt.ctrl_hdr.conn_id);
-			}
-
-			rx_buf->recv_entry->sar.conn = rx_buf->conn;
-			rx_buf->recv_entry->sar.msg_id = rx_buf->pkt.ctrl_hdr.msg_id;
-
-			dlist_insert_tail(&rx_buf->recv_entry->sar.entry,
-					  &rx_buf->conn->deferred_sar_msgs);
-		}
-
 		/* The RX buffer can be reposted for further re-use */
-		rx_buf->recv_entry = NULL;
+		rx_buf->peer_entry = NULL;
 		rxm_free_rx_buf(rx_buf);
-
-		*done = 0;
 	}
+	return done;
 }
 
 static void rxm_handle_seg_data(struct rxm_rx_buf *rx_buf)
 {
-	struct rxm_recv_entry *recv_entry;
+	struct rxm_proto_info *proto_info;
+	struct fi_peer_rx_entry *rx_entry;
 	struct rxm_conn *conn;
 	uint64_t msg_id;
 	struct dlist_entry *entry;
-	int done;
 
-	rxm_process_seg_data(rx_buf, &done);
-	if (done || !(rx_buf->ep->rxm_info->mode & OFI_BUFFERED_RECV))
+	if (dlist_empty(&rx_buf->proto_info->sar.pkt_list)) {
+		rxm_process_seg_data(rx_buf);
 		return;
+	}
 
-	recv_entry = rx_buf->recv_entry;
+	proto_info = rx_buf->proto_info;
+	dlist_insert_tail(&rx_buf->unexp_entry, &proto_info->sar.pkt_list);
+
+	if ((rxm_sar_get_seg_type(&rx_buf->pkt.ctrl_hdr) == RXM_SAR_SEG_LAST))
+		dlist_remove(&proto_info->sar.entry);
+
+	rx_entry = rx_buf->peer_entry;
 	conn = rx_buf->conn;
 	msg_id = rx_buf->pkt.ctrl_hdr.msg_id;
 
 	dlist_foreach_container_safe(&conn->deferred_sar_segments,
 				     struct rxm_rx_buf, rx_buf,
-				     unexp_msg.entry, entry) {
-		if (!rxm_rx_buf_match_msg_id(&rx_buf->unexp_msg.entry, &msg_id))
+				     unexp_entry, entry) {
+		if (!rxm_rx_buf_match_msg_id(&rx_buf->unexp_entry, &msg_id))
 			continue;
 
-		dlist_remove(&rx_buf->unexp_msg.entry);
-		rx_buf->recv_entry = recv_entry;
-		rxm_process_seg_data(rx_buf, &done);
-		if (done)
+		dlist_remove(&rx_buf->unexp_entry);
+		rx_buf->peer_entry = rx_entry;
+		if (rxm_process_seg_data(rx_buf))
 			break;
 	}
+}
+
+ssize_t rxm_handle_unexp_sar(struct fi_peer_rx_entry *peer_entry)
+{
+	struct rxm_proto_info *proto_info;
+	struct rxm_rx_buf *rx_buf;
+
+	rx_buf = (struct rxm_rx_buf *) peer_entry->peer_context;
+	proto_info = rx_buf->proto_info;
+
+	while (!dlist_empty(&proto_info->sar.pkt_list)) {
+		dlist_pop_front(&proto_info->sar.pkt_list,
+				struct rxm_rx_buf, rx_buf, unexp_entry);
+		rxm_process_seg_data(rx_buf);
+	}
+	peer_entry->peer_context = NULL;
+	return FI_SUCCESS;
 }
 
 static ssize_t rxm_rndv_xfer(struct rxm_ep *rxm_ep, struct fid_ep *msg_ep,
@@ -538,14 +576,15 @@ ssize_t rxm_rndv_read(struct rxm_rx_buf *rx_buf)
 	ssize_t ret;
 	size_t total_len;
 
-	total_len = MIN(rx_buf->recv_entry->total_len, rx_buf->pkt.hdr.size);
+	total_len = MIN(rx_buf->peer_entry->msg_size, rx_buf->pkt.hdr.size);
+	rx_buf->peer_entry->msg_size = total_len;
 	RXM_UPDATE_STATE(FI_LOG_CQ, rx_buf, RXM_RNDV_READ);
 
 	ret = rxm_rndv_xfer(rx_buf->ep, rx_buf->conn->msg_ep,
 			    rx_buf->remote_rndv_hdr,
-			    rx_buf->recv_entry->rxm_iov.iov,
-			    rx_buf->recv_entry->rxm_iov.desc,
-			    rx_buf->recv_entry->rxm_iov.count, total_len,
+			    rx_buf->peer_entry->iov,
+			    rx_buf->peer_entry->desc,
+			    rx_buf->peer_entry->count, total_len,
 			    rx_buf);
 	if (ret) {
 		rxm_cq_write_rx_error(rx_buf->ep, ofi_op_msg, rx_buf,
@@ -621,28 +660,26 @@ static ssize_t rxm_handle_rndv(struct rxm_rx_buf *rx_buf)
 	rx_buf->rndv_rma_index = 0;
 
 	if (!rx_buf->ep->rdm_mr_local) {
-		total_recv_len = MIN(rx_buf->recv_entry->total_len,
+		total_recv_len = MIN(rx_buf->peer_entry->msg_size,
 				     rx_buf->pkt.hdr.size);
-		ret = rxm_msg_mr_regv(rx_buf->ep, rx_buf->recv_entry->rxm_iov.iov,
-				      rx_buf->recv_entry->rxm_iov.count,
+		ret = rxm_msg_mr_regv(rx_buf->ep, rx_buf->peer_entry->iov,
+				      rx_buf->peer_entry->count,
 				      total_recv_len,
 				      rx_buf->ep->rndv_ops->rx_mr_access,
 				      rx_buf->mr);
 		if (ret)
 			return ret;
 
-		for (i = 0; (i < rx_buf->recv_entry->rxm_iov.count &&
+		for (i = 0; (i < rx_buf->peer_entry->count &&
 			     rx_buf->mr[i]); i++) {
-			rx_buf->recv_entry->rxm_iov.desc[i] =
-						fi_mr_desc(rx_buf->mr[i]);
+			rx_buf->peer_entry->desc[i] = fi_mr_desc(rx_buf->mr[i]);
 		}
 	} else {
 		struct rxm_mr *mr;
 
-		for (i = 0; i < rx_buf->recv_entry->rxm_iov.count; i++) {
-			mr = rx_buf->recv_entry->rxm_iov.desc[i];
-			rx_buf->recv_entry->rxm_iov.desc[i] =
-				fi_mr_desc(mr->msg_mr);
+		for (i = 0; i < rx_buf->peer_entry->count; i++) {
+			mr = rx_buf->peer_entry->desc[i];
+			rx_buf->peer_entry->desc[i] = fi_mr_desc(mr->msg_mr);
 			rx_buf->mr[i] = mr->msg_mr;
 		}
 	}
@@ -656,9 +693,9 @@ static ssize_t rxm_handle_rndv(struct rxm_rx_buf *rx_buf)
 void rxm_handle_eager(struct rxm_rx_buf *rx_buf)
 {
 	ssize_t done_len = rxm_copy_to_hmem_iov(
-		rx_buf->recv_entry->rxm_iov.desc, rx_buf->data,
-		rx_buf->pkt.hdr.size, rx_buf->recv_entry->rxm_iov.iov,
-		rx_buf->recv_entry->rxm_iov.count, 0);
+		rx_buf->peer_entry->desc, rx_buf->data,
+		rx_buf->pkt.hdr.size, rx_buf->peer_entry->iov,
+		rx_buf->peer_entry->count, 0);
 
 	assert((size_t) done_len == rx_buf->pkt.hdr.size);
 
@@ -671,14 +708,14 @@ void rxm_handle_coll_eager(struct rxm_rx_buf *rx_buf)
 	uint64_t device;
 	ssize_t done_len;
 
-	iface = rxm_iov_desc_to_hmem_iface_dev(rx_buf->recv_entry->rxm_iov.iov,
-					       rx_buf->recv_entry->rxm_iov.desc,
-					       rx_buf->recv_entry->rxm_iov.count,
+	iface = rxm_iov_desc_to_hmem_iface_dev(rx_buf->peer_entry->iov,
+					       rx_buf->peer_entry->desc,
+					       rx_buf->peer_entry->count,
 					       &device);
 
 	done_len = ofi_copy_to_hmem_iov(iface, device,
-					rx_buf->recv_entry->rxm_iov.iov,
-					rx_buf->recv_entry->rxm_iov.count, 0,
+					rx_buf->peer_entry->iov,
+					rx_buf->peer_entry->count, 0,
 					rx_buf->data, rx_buf->pkt.hdr.size);
 	assert((size_t) done_len == rx_buf->pkt.hdr.size);
 
@@ -686,11 +723,11 @@ void rxm_handle_coll_eager(struct rxm_rx_buf *rx_buf)
 	    rx_buf->pkt.hdr.tag & RXM_PEER_XFER_TAG_FLAG) {
 		struct fi_cq_tagged_entry cqe = {
 			.tag = rx_buf->pkt.hdr.tag,
-			.op_context = rx_buf->recv_entry->context,
+			.op_context = rx_buf->peer_entry->context,
 		};
 		rx_buf->ep->util_coll_peer_xfer_ops->
 			complete(rx_buf->ep->util_coll_ep, &cqe, 0);
-		rxm_recv_entry_release(rx_buf->recv_entry);
+		rx_buf->ep->srx->owner_ops->free_entry(rx_buf->peer_entry);
 		rxm_free_rx_buf(rx_buf);
 	} else {
 		rxm_finish_recv(rx_buf, done_len);
@@ -715,73 +752,26 @@ ssize_t rxm_handle_rx_buf(struct rxm_rx_buf *rx_buf)
 	}
 }
 
-static void rxm_adjust_multi_recv(struct rxm_rx_buf *rx_buf)
+static inline void rxm_entry_prep_for_queue(struct fi_peer_rx_entry *rx_entry,
+					    struct rxm_rx_buf *rx_buf)
 {
-	struct rxm_recv_entry *recv_entry;
-	struct iovec new_iov;
-	size_t recv_size;
-
-	recv_size = rx_buf->pkt.hdr.size;
-
-	if (rx_buf->recv_entry->rxm_iov.iov[0].iov_len < recv_size ||
-	    rx_buf->recv_entry->rxm_iov.iov[0].iov_len - recv_size <
-	    rx_buf->ep->min_multi_recv_size)
-		return;
-
-	new_iov.iov_base = (uint8_t *)
-		rx_buf->recv_entry->rxm_iov.iov[0].iov_base + recv_size;
-	new_iov.iov_len = rx_buf->recv_entry->rxm_iov.iov[0].iov_len - recv_size;;
-
-	rx_buf->recv_entry->rxm_iov.iov[0].iov_len = recv_size;
-
-	recv_entry = rxm_multi_recv_entry_get(rx_buf->ep, &new_iov,
-					rx_buf->recv_entry->rxm_iov.desc, 1,
-					rx_buf->recv_entry->addr,
-					rx_buf->recv_entry->tag,
-					rx_buf->recv_entry->ignore,
-					rx_buf->recv_entry->context,
-					rx_buf->recv_entry->flags);
-
-	rx_buf->recv_entry->flags &= ~FI_MULTI_RECV;
-
-	dlist_insert_head(&recv_entry->entry, &rx_buf->ep->recv_queue.recv_list);
-}
-
-static ssize_t
-rxm_match_rx_buf(struct rxm_rx_buf *rx_buf,
-		 struct rxm_recv_queue *recv_queue,
-		 struct rxm_recv_match_attr *match_attr)
-{
-	struct dlist_entry *entry;
-
-	entry = dlist_remove_first_match(&recv_queue->recv_list,
-					 recv_queue->match_recv, match_attr);
-	if (entry) {
-		rx_buf->recv_entry = container_of(entry, struct rxm_recv_entry, entry);
-
-		if (rx_buf->recv_entry->flags & FI_MULTI_RECV)
-			rxm_adjust_multi_recv(rx_buf);
-
-		return rxm_handle_rx_buf(rx_buf);
+	rx_entry->peer_context = rx_buf;
+	rx_buf->peer_entry = rx_entry;
+	if (rx_buf->pkt.hdr.flags & FI_REMOTE_CQ_DATA) {
+		rx_entry->flags |= FI_REMOTE_CQ_DATA;
+		rx_entry->cq_data = rx_buf->pkt.hdr.data;
 	}
-
-	RXM_DBG_ADDR_TAG(FI_LOG_CQ, "No matching recv found for incoming msg",
-			 match_attr->addr, match_attr->tag);
-	FI_DBG(&rxm_prov, FI_LOG_CQ, "Enqueueing msg to unexpected msg queue\n");
-	rx_buf->unexp_msg.addr = match_attr->addr;
-	rx_buf->unexp_msg.tag = match_attr->tag;
-
-	dlist_insert_tail(&rx_buf->unexp_msg.entry,
-			  &recv_queue->unexp_msg_list);
+	if (rx_buf->pkt.ctrl_hdr.type == rxm_ctrl_seg)
+		rxm_init_sar_proto(rx_buf);
 	rxm_replace_rx_buf(rx_buf);
-	return 0;
 }
 
 static ssize_t rxm_handle_recv_comp(struct rxm_rx_buf *rx_buf)
 {
-	struct rxm_recv_match_attr match_attr = {
-		.addr = FI_ADDR_UNSPEC,
-	};
+	struct fid_peer_srx *srx = rx_buf->ep->srx;
+	struct fi_peer_rx_entry *rx_entry;
+	struct fi_peer_match_attr match = {0};
+	int ret;
 
 	if (rx_buf->ep->rxm_info->caps & (FI_SOURCE | FI_DIRECTED_RECV)) {
 		if (rx_buf->ep->msg_srx)
@@ -789,7 +779,9 @@ static ssize_t rxm_handle_recv_comp(struct rxm_rx_buf *rx_buf)
 					(int) rx_buf->pkt.ctrl_hdr.conn_id);
 		if (!rx_buf->conn)
 			return -FI_EOTHER;
-		match_attr.addr = rx_buf->conn->peer->fi_addr;
+		match.addr = rx_buf->conn->peer->fi_addr;
+	} else {
+		match.addr = FI_ADDR_UNSPEC;
 	}
 
 	if (rx_buf->ep->rxm_info->mode & OFI_BUFFERED_RECV) {
@@ -799,33 +791,52 @@ static ssize_t rxm_handle_recv_comp(struct rxm_rx_buf *rx_buf)
 
 	switch(rx_buf->pkt.hdr.op) {
 	case ofi_op_msg:
+		match.msg_size = rx_buf->pkt.hdr.size;
 		FI_DBG(&rxm_prov, FI_LOG_CQ, "Got MSG op\n");
-		return rxm_match_rx_buf(rx_buf, &rx_buf->ep->recv_queue,
-					&match_attr);
+		ret = srx->owner_ops->get_msg(srx, &match, &rx_entry);
+		if (ret == -FI_ENOENT) {
+			rxm_entry_prep_for_queue(rx_entry, rx_buf);
+			return srx->owner_ops->queue_msg(rx_entry);
+		}
+		rx_entry->peer_context = NULL;
+		break;
 	case ofi_op_tagged:
+		match.tag = rx_buf->pkt.hdr.tag;
+		match.msg_size = rx_buf->pkt.hdr.size;
 		FI_DBG(&rxm_prov, FI_LOG_CQ, "Got TAGGED op\n");
-		match_attr.tag = rx_buf->pkt.hdr.tag;
-		return rxm_match_rx_buf(rx_buf, &rx_buf->ep->trecv_queue,
-					&match_attr);
+		ret = srx->owner_ops->get_tag(srx, &match, &rx_entry);
+		if (ret == -FI_ENOENT) {
+			rxm_entry_prep_for_queue(rx_entry, rx_buf);
+			return srx->owner_ops->queue_tag(rx_entry);
+		}
+		rx_entry->peer_context = NULL;
+		break;
 	default:
 		FI_WARN(&rxm_prov, FI_LOG_CQ, "Unknown op!\n");
 		assert(0);
 		return -FI_EINVAL;
 	}
+	rx_buf->peer_entry = rx_entry;
+
+	if (rx_buf->pkt.ctrl_hdr.type == rxm_ctrl_seg)
+		rxm_init_sar_proto(rx_buf);
+
+	return rxm_handle_rx_buf(rx_buf);
 }
 
 static int rxm_sar_match_msg_id(struct dlist_entry *item, const void *arg)
 {
 	uint64_t msg_id = *((uint64_t *) arg);
-	struct rxm_recv_entry *recv_entry;
+	struct rxm_proto_info *proto_info;
 
-	recv_entry = container_of(item, struct rxm_recv_entry, sar.entry);
-	return (msg_id == recv_entry->sar.msg_id);
+	proto_info = container_of(item, struct rxm_proto_info, sar.entry);
+	return (msg_id == proto_info->sar.msg_id);
 }
 
 static ssize_t rxm_sar_handle_segment(struct rxm_rx_buf *rx_buf)
 {
 	struct dlist_entry *sar_entry;
+	struct rxm_proto_info *proto_info;
 
 	rx_buf->conn = ofi_idm_at(&rx_buf->ep->conn_idx_map,
 				  (int) rx_buf->pkt.ctrl_hdr.conn_id);
@@ -841,8 +852,9 @@ static ssize_t rxm_sar_handle_segment(struct rxm_rx_buf *rx_buf)
 	if (!sar_entry)
 		return rxm_handle_recv_comp(rx_buf);
 
-	rx_buf->recv_entry = container_of(sar_entry, struct rxm_recv_entry,
-					  sar.entry);
+	proto_info = container_of(sar_entry, struct rxm_proto_info, sar.entry);
+	rx_buf->peer_entry = proto_info->sar.rx_entry;
+	rx_buf->proto_info = proto_info;
 	rxm_handle_seg_data(rx_buf);
 	return 0;
 }
@@ -860,8 +872,15 @@ static void rxm_rndv_send_rd_done(struct rxm_rx_buf *rx_buf)
 		ret = -FI_ENOMEM;
 		goto err;
 	}
+	rx_buf->proto_info = ofi_buf_alloc(rx_buf->ep->proto_info_pool);
+	if (!rx_buf->proto_info) {
+		FI_WARN(&rxm_prov, FI_LOG_CQ,
+			"Failed to allocated proto info buf\n");
+		assert(0);
+		return;
+	}
 
-	rx_buf->recv_entry->rndv.tx_buf = buf;
+	rx_buf->proto_info->rndv.tx_buf = buf;
 
 	buf->pkt.ctrl_hdr.type = rxm_ctrl_rndv_rd_done;
 	buf->pkt.ctrl_hdr.conn_id = rx_buf->conn->remote_index;
@@ -888,8 +907,9 @@ static void rxm_rndv_send_rd_done(struct rxm_rx_buf *rx_buf)
 	return;
 
 free:
+	rx_buf->proto_info->rndv.tx_buf = NULL;
+	ofi_buf_free(rx_buf->proto_info);
 	ofi_buf_free(buf);
-	rx_buf->recv_entry->rndv.tx_buf = NULL;
 err:
 	FI_WARN(&rxm_prov, FI_LOG_CQ,
 		"unable to allocate/send rd rndv ack: %s\n",
@@ -968,14 +988,22 @@ ssize_t rxm_rndv_send_wr_data(struct rxm_rx_buf *rx_buf)
 		goto err;
 	}
 
-	rx_buf->recv_entry->rndv.tx_buf = buf;
+	rx_buf->proto_info = ofi_buf_alloc(rx_buf->ep->proto_info_pool);
+	if (!rx_buf->proto_info) {
+		FI_WARN(&rxm_prov, FI_LOG_CQ,
+			"Failed to allocated proto info buf\n");
+		return -FI_ENOMEM;
+	}
+
+	rx_buf->proto_info->rndv.tx_buf = buf;
+
 
 	buf->pkt.ctrl_hdr.type = rxm_ctrl_rndv_wr_data;
 	buf->pkt.ctrl_hdr.conn_id = rx_buf->conn->remote_index;
 	buf->pkt.ctrl_hdr.msg_id = rx_buf->pkt.ctrl_hdr.msg_id;
 	rxm_rndv_hdr_init(rx_buf->ep, buf->pkt.data,
-			  rx_buf->recv_entry->rxm_iov.iov,
-			  rx_buf->recv_entry->rxm_iov.count, rx_buf->mr);
+			  rx_buf->peer_entry->iov,
+			  rx_buf->peer_entry->count, rx_buf->mr);
 
 	ret = fi_send(rx_buf->conn->msg_ep, &buf->pkt, sizeof(buf->pkt) +
 		      sizeof(struct rxm_rndv_hdr), buf->hdr.desc, 0, rx_buf);
@@ -999,8 +1027,9 @@ ssize_t rxm_rndv_send_wr_data(struct rxm_rx_buf *rx_buf)
 	return 0;
 
 free:
+	rx_buf->proto_info->rndv.tx_buf = NULL;
+	ofi_buf_free(rx_buf->proto_info);
 	ofi_buf_free(buf);
-	rx_buf->recv_entry->rndv.tx_buf = NULL;
 err:
 	FI_WARN(&rxm_prov, FI_LOG_CQ,
 		"unable to allocate/send wr rndv ready: %s\n",
@@ -1638,7 +1667,7 @@ void rxm_handle_comp_error(struct rxm_ep *rxm_ep)
 		 * the event yet.
 		 */
 		rx_buf = (struct rxm_rx_buf *) err_entry.op_context;
-		if (!rx_buf->recv_entry) {
+		if (!rx_buf->peer_entry) {
 			ofi_buf_free((struct rxm_rx_buf *)err_entry.op_context);
 			return;
 		}
@@ -1647,9 +1676,9 @@ void rxm_handle_comp_error(struct rxm_ep *rxm_ep)
 	case RXM_RNDV_WRITE_DATA_SENT: /* BUG: should fail initial send */
 	case RXM_RNDV_READ:
 		rx_buf = (struct rxm_rx_buf *) err_entry.op_context;
-		assert(rx_buf->recv_entry);
-		err_entry.op_context = rx_buf->recv_entry->context;
-		err_entry.flags = rx_buf->recv_entry->comp_flags;
+		assert(rx_buf->peer_entry);
+		err_entry.op_context = rx_buf->peer_entry->context;
+		err_entry.flags = rx_buf->peer_entry->flags;
 
 		cq = rx_buf->ep->util_ep.rx_cq;
 		cntr = rx_buf->ep->util_ep.cntrs[CNTR_RX];
@@ -1780,7 +1809,8 @@ int rxm_post_recv(struct rxm_rx_buf *rx_buf)
 	if (rx_buf->ep->msg_srx)
 		rx_buf->conn = NULL;
 	rx_buf->hdr.state = RXM_RX;
-	rx_buf->recv_entry = NULL;
+	rx_buf->peer_entry = NULL;
+	rx_buf->proto_info = NULL;
 
 	domain = container_of(rx_buf->ep->util_ep.domain,
 			      struct rxm_domain, util_domain);
@@ -1858,7 +1888,7 @@ void rxm_ep_do_progress(struct util_ep *util_ep)
 					rxm_conn_progress(rxm_ep);
 				}
 			} else {
-					rxm_conn_progress(rxm_ep);
+				rxm_conn_progress(rxm_ep);
 			}
 		}
 	} while ((ret > 0) && (comp_read < rxm_ep->comp_per_progress));
@@ -1975,6 +2005,9 @@ int rxm_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	if (ret)
 		goto err1;
 
+	if (attr->flags & FI_PEER)
+		goto out;
+
 	rxm_domain = container_of(domain, struct rxm_domain,
 				  util_domain.domain_fid);
 
@@ -1996,11 +2029,12 @@ int rxm_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		if (ret)
 			goto err2;
 	}
+	rxm_cq->util_cq.cq_fid.ops = &rxm_cq_ops;
 
+out:
 	*cq_fid = &rxm_cq->util_cq.cq_fid;
 	/* Override util_cq_fi_ops */
 	(*cq_fid)->fid.ops = &rxm_cq_fi_ops;
-	(*cq_fid)->ops = &rxm_cq_ops;
 	return 0;
 
 err2:

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -221,6 +221,25 @@ static struct fi_ops_av_owner rxm_av_owner_ops = {
 	.ep_addr = rxm_peer_av_ep_addr,
 };
 
+static fi_addr_t rxm_get_addr(struct fi_peer_rx_entry *rx_entry)
+{
+	struct rxm_rx_buf *rx_buf = rx_entry->peer_context;
+
+	return rx_buf->conn->peer->fi_addr;
+}
+
+static void rxm_foreach_ep(struct util_av *av, struct util_ep *ep)
+{
+	struct rxm_ep *rxm_ep;
+	struct fid_peer_srx *peer_srx;
+
+	rxm_ep = container_of(ep, struct rxm_ep, util_ep);
+	peer_srx = container_of(rxm_ep->srx, struct fid_peer_srx, ep_fid);
+	if (peer_srx)
+		peer_srx->owner_ops->foreach_unspec_addr(peer_srx, &rxm_get_addr);
+}
+
+
 static int
 rxm_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 	    struct fid_av **fid_av, void *context)
@@ -236,7 +255,8 @@ rxm_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 
 	ret = rxm_util_av_open(domain_fid, attr, &fid_av_new,
 			context, sizeof(struct rxm_conn),
-			ofi_av_remove_cleanup ? rxm_av_remove_handler : NULL);
+			ofi_av_remove_cleanup ? rxm_av_remove_handler : NULL,
+			&rxm_foreach_ep);
 	if (ret)
 		return ret;
 
@@ -346,7 +366,7 @@ static struct fi_ops_domain rxm_domain_ops = {
 	.cntr_open = rxm_cntr_open,
 	.poll_open = fi_poll_create,
 	.stx_ctx = fi_no_stx_context,
-	.srx_ctx = fi_no_srx_context,
+	.srx_ctx = rxm_srx_context,
 	.query_atomic = rxm_ep_query_atomic,
 	.query_collective = rxm_query_collective,
 };

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -746,9 +746,8 @@ rxm_ep_sar_handle_segment_failure(struct rxm_deferred_tx_entry *def_tx_entry,
 {
 	rxm_ep_sar_tx_cleanup(def_tx_entry->rxm_ep, def_tx_entry->rxm_conn,
 			      def_tx_entry->sar_seg.cur_seg_tx_buf);
-	rxm_cq_write_error(def_tx_entry->rxm_ep->util_ep.tx_cq,
-			   def_tx_entry->rxm_ep->util_ep.cntrs[CNTR_TX],
-			   def_tx_entry->sar_seg.app_context, (int) ret);
+	rxm_cq_write_tx_error(def_tx_entry->rxm_ep, ofi_op_msg,
+			      def_tx_entry->sar_seg.app_context, (int) ret);
 }
 
 /* Returns FI_SUCCESS if the SAR deferred TX queue is empty,
@@ -843,10 +842,10 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 			if (ret) {
 				if (ret == -FI_EAGAIN)
 					return;
-				rxm_cq_write_error(def_tx_entry->rxm_ep->util_ep.rx_cq,
-						   def_tx_entry->rxm_ep->util_ep.cntrs[CNTR_RX],
-						   def_tx_entry->rndv_ack.rx_buf->
-						   recv_entry->context, (int) ret);
+				rxm_cq_write_rx_error(
+					def_tx_entry->rxm_ep, ofi_op_msg,
+					def_tx_entry->rndv_ack.rx_buf->
+					recv_entry->context, (int) ret);
 			}
 			if (def_tx_entry->rndv_ack.rx_buf->recv_entry->rndv
 				    .tx_buf->pkt.ctrl_hdr
@@ -868,9 +867,10 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 			if (ret) {
 				if (ret == -FI_EAGAIN)
 					return;
-				rxm_cq_write_error(def_tx_entry->rxm_ep->util_ep.tx_cq,
-						   def_tx_entry->rxm_ep->util_ep.cntrs[CNTR_TX],
-						   def_tx_entry->rndv_done.tx_buf, (int) ret);
+				rxm_cq_write_tx_error(def_tx_entry->rxm_ep,
+						ofi_op_msg,
+						def_tx_entry->rndv_done.tx_buf,
+						(int) ret);
 			}
 			RXM_UPDATE_STATE(FI_LOG_EP_DATA,
 					 def_tx_entry->rndv_done.tx_buf,
@@ -888,10 +888,10 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 			if (ret) {
 				if (ret == -FI_EAGAIN)
 					return;
-				rxm_cq_write_error(def_tx_entry->rxm_ep->util_ep.rx_cq,
-						   def_tx_entry->rxm_ep->util_ep.cntrs[CNTR_RX],
-						   def_tx_entry->rndv_read.rx_buf->
-							recv_entry->context, (int) ret);
+				rxm_cq_write_rx_error(
+					def_tx_entry->rxm_ep, ofi_op_msg,
+					def_tx_entry->rndv_read.rx_buf->
+					recv_entry->context, (int) ret);
 			}
 			break;
 		case RXM_DEFERRED_TX_RNDV_WRITE:
@@ -906,9 +906,10 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 			if (ret) {
 				if (ret == -FI_EAGAIN)
 					return;
-				rxm_cq_write_error(def_tx_entry->rxm_ep->util_ep.rx_cq,
-						   def_tx_entry->rxm_ep->util_ep.cntrs[CNTR_RX],
-						   def_tx_entry->rndv_write.tx_buf, (int) ret);
+				rxm_cq_write_rx_error(
+					def_tx_entry->rxm_ep, ofi_op_msg,
+					def_tx_entry->rndv_write.tx_buf,
+					(int) ret);
 			}
 			break;
 		case RXM_DEFERRED_TX_SAR_SEG:
@@ -939,11 +940,12 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 					 OFI_PRIORITY);
 			if (ret) {
 				if (ret != -FI_EAGAIN) {
-					rxm_cq_write_error(
-						def_tx_entry->rxm_ep->util_ep.rx_cq,
-						def_tx_entry->rxm_ep->util_ep.cntrs[CNTR_RX],
+					rxm_cq_write_rx_error(
+						def_tx_entry->rxm_ep,
+						ofi_op_msg,
 						def_tx_entry->rndv_read.rx_buf->
-							recv_entry->context, (int) ret);
+						recv_entry->context,
+						(int) ret);
 				}
 				return;
 			}

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -262,8 +262,8 @@ int rxm_info_to_core(uint32_t version, const struct fi_info *hints,
 
 	core_info->rx_attr->op_flags &= ~FI_MULTI_RECV;
 
-	core_info->domain_attr->caps &= ~(FI_AV_USER_ID);
-	core_info->caps &= ~(FI_AV_USER_ID);
+	core_info->domain_attr->caps &= ~(FI_AV_USER_ID | FI_PEER);
+	core_info->caps &= ~(FI_AV_USER_ID | FI_PEER);
 
 	return 0;
 }

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -262,6 +262,9 @@ int rxm_info_to_core(uint32_t version, const struct fi_info *hints,
 
 	core_info->rx_attr->op_flags &= ~FI_MULTI_RECV;
 
+	core_info->domain_attr->caps &= ~(FI_AV_USER_ID);
+	core_info->caps &= ~(FI_AV_USER_ID);
+
 	return 0;
 }
 

--- a/prov/rxm/src/rxm_msg.c
+++ b/prov/rxm/src/rxm_msg.c
@@ -140,8 +140,8 @@ rxm_post_mrecv(struct rxm_ep *ep, const struct iovec *iov,
 
 	if ((cur_iov.iov_len < ep->min_multi_recv_size) ||
 	    (ret && cur_iov.iov_len != iov->iov_len)) {
-		rxm_cq_write(ep->util_ep.rx_cq, context, FI_MULTI_RECV,
-			     0, NULL, 0, 0);
+		ofi_peer_cq_write(ep->util_ep.rx_cq, context, FI_MULTI_RECV,
+				  0, NULL, 0, 0, FI_ADDR_NOTAVAIL);
 	}
 
 	return ret;

--- a/prov/rxm/src/rxm_msg.c
+++ b/prov/rxm/src/rxm_msg.c
@@ -40,214 +40,16 @@
 
 #include "rxm.h"
 
-
-ssize_t rxm_handle_unexp_sar(struct rxm_recv_queue *recv_queue,
-			     struct rxm_recv_entry *recv_entry,
-			     struct rxm_rx_buf *rx_buf)
-{
-	struct rxm_recv_match_attr match_attr;
-	struct dlist_entry *entry;
-	bool last;
-	ssize_t ret;
-
-	ret = rxm_handle_rx_buf(rx_buf);
-	last = rxm_sar_get_seg_type(&rx_buf->pkt.ctrl_hdr) == RXM_SAR_SEG_LAST;
-	if (ret || last)
-		return ret;
-
-	match_attr.addr = recv_entry->addr;
-	match_attr.tag = recv_entry->tag;
-	match_attr.ignore = recv_entry->ignore;
-
-	dlist_foreach_container_safe(&recv_queue->unexp_msg_list,
-					struct rxm_rx_buf, rx_buf,
-					unexp_msg.entry, entry) {
-		if (!recv_queue->match_unexp(&rx_buf->unexp_msg.entry,
-						&match_attr))
-			continue;
-		/* Handle unordered completions from MSG provider */
-		if ((rx_buf->pkt.ctrl_hdr.msg_id != recv_entry->sar.msg_id) ||
-			((rx_buf->pkt.ctrl_hdr.type != rxm_ctrl_seg)))
-			continue;
-
-		if (!rx_buf->conn) {
-			rx_buf->conn = ofi_idm_at(&rx_buf->ep->conn_idx_map,
-					(int) rx_buf->pkt.ctrl_hdr.conn_id);
-		}
-		if (recv_entry->sar.conn != rx_buf->conn)
-			continue;
-		rx_buf->recv_entry = recv_entry;
-		dlist_remove(&rx_buf->unexp_msg.entry);
-		last = rxm_sar_get_seg_type(&rx_buf->pkt.ctrl_hdr) ==
-		       RXM_SAR_SEG_LAST;
-		ret = rxm_handle_rx_buf(rx_buf);
-		if (ret || last)
-			break;
-	}
-	return ret;
-}
-
-/*
- * We don't expect to have unexpected messages when the app is using
- * multi-recv buffers.  Optimize for that case.
- *
- * If there are unexpected messages waiting when we post a mult-recv buffer,
- * we trim off the start of the buffer, treat it as a normal buffer, and pair
- * it with an unexpected message.  We continue doing this until either no
- * unexpected messages are left or the multi-recv buffer has been consumed.
- */
-static ssize_t
-rxm_post_mrecv(struct rxm_ep *ep, const struct iovec *iov,
-	       void **desc, void *context, uint64_t op_flags)
-{
-	struct rxm_recv_entry *recv_entry;
-	struct rxm_rx_buf *rx_buf;
-	struct iovec cur_iov = *iov;
-	ssize_t ret;
-
-	do {
-		recv_entry = rxm_recv_entry_get(ep, &cur_iov, desc, 1,
-						FI_ADDR_UNSPEC, 0, 0, context,
-						op_flags, &ep->recv_queue);
-		if (!recv_entry) {
-			ret = -FI_ENOMEM;
-			break;
-		}
-
-		rx_buf = rxm_get_unexp_msg(&ep->recv_queue, recv_entry->addr, 0,  0);
-		if (!rx_buf) {
-			dlist_insert_tail(&recv_entry->entry,
-					  &ep->recv_queue.recv_list);
-			return 0;
-		}
-
-		dlist_remove(&rx_buf->unexp_msg.entry);
-		rx_buf->recv_entry = recv_entry;
-		recv_entry->flags &= ~FI_MULTI_RECV;
-		recv_entry->total_len = MIN(cur_iov.iov_len, rx_buf->pkt.hdr.size);
-		recv_entry->rxm_iov.iov[0].iov_len = recv_entry->total_len;
-
-		cur_iov.iov_base = (uint8_t *) cur_iov.iov_base + recv_entry->total_len;
-		cur_iov.iov_len -= recv_entry->total_len;
-
-		if (rx_buf->pkt.ctrl_hdr.type != rxm_ctrl_seg)
-			ret = rxm_handle_rx_buf(rx_buf);
-		else
-			ret = rxm_handle_unexp_sar(&ep->recv_queue, recv_entry,
-						   rx_buf);
-
-	} while (!ret && cur_iov.iov_len >= ep->min_multi_recv_size);
-
-	if ((cur_iov.iov_len < ep->min_multi_recv_size) ||
-	    (ret && cur_iov.iov_len != iov->iov_len)) {
-		ofi_peer_cq_write(ep->util_ep.rx_cq, context, FI_MULTI_RECV,
-				  0, NULL, 0, 0, FI_ADDR_NOTAVAIL);
-	}
-
-	return ret;
-}
-
-static ssize_t
-rxm_recv_common(struct rxm_ep *rxm_ep, const struct iovec *iov,
-		void **desc, size_t count, fi_addr_t src_addr,
-		void *context, uint64_t op_flags)
-{
-	struct rxm_recv_entry *recv_entry;
-	struct rxm_rx_buf *rx_buf;
-	ssize_t ret;
-
-	assert(rxm_ep->util_ep.rx_cq);
-	assert(count <= rxm_ep->rxm_info->rx_attr->iov_limit);
-
-	ofi_genlock_lock(&rxm_ep->util_ep.lock);
-	if (op_flags & FI_MULTI_RECV) {
-		ret = rxm_post_mrecv(rxm_ep, iov, desc, context, op_flags);
-		goto release;
-	}
-
-	recv_entry = rxm_recv_entry_get(rxm_ep, iov, desc, count, src_addr,
-					0, 0, context, op_flags,
-					&rxm_ep->recv_queue);
-	if (!recv_entry) {
-		ret = -FI_EAGAIN;
-		goto release;
-	}
-
-	rx_buf = rxm_get_unexp_msg(&rxm_ep->recv_queue, recv_entry->addr, 0, 0);
-	if (!rx_buf) {
-		dlist_insert_tail(&recv_entry->entry,
-				  &rxm_ep->recv_queue.recv_list);
-		ret = FI_SUCCESS;
-		goto release;
-	}
-
-	dlist_remove(&rx_buf->unexp_msg.entry);
-	rx_buf->recv_entry = recv_entry;
-
-	ret = (rx_buf->pkt.ctrl_hdr.type != rxm_ctrl_seg) ?
-		rxm_handle_rx_buf(rx_buf) :
-		rxm_handle_unexp_sar(&rxm_ep->recv_queue, recv_entry, rx_buf);
-
-release:
-	ofi_genlock_unlock(&rxm_ep->util_ep.lock);
-	return ret;
-}
-
-static ssize_t
-rxm_buf_recv(struct rxm_ep *rxm_ep, const struct iovec *iov,
-	     void **desc, size_t count, fi_addr_t src_addr,
-	     void *context, uint64_t flags)
-{
-	struct rxm_recv_entry *recv_entry;
-	struct fi_recv_context *recv_ctx = context;
-	struct rxm_rx_buf *rx_buf;
-	ssize_t ret = 0;
-
-	context = recv_ctx->context;
-	rx_buf = container_of(recv_ctx, struct rxm_rx_buf, recv_context);
-
-	ofi_genlock_lock(&rxm_ep->util_ep.lock);
-	if (flags & FI_CLAIM) {
-		FI_DBG(&rxm_prov, FI_LOG_EP_DATA,
-			"Claiming buffered receive\n");
-
-		recv_entry = rxm_recv_entry_get(rxm_ep, iov, desc, count,
-						src_addr, 0, 0, context,
-						flags, &rxm_ep->recv_queue);
-		if (!recv_entry) {
-			ret = -FI_EAGAIN;
-			goto unlock;
-		}
-
-		recv_entry->comp_flags |= FI_CLAIM;
-
-		rx_buf->recv_entry = recv_entry;
-		ret = rxm_handle_rx_buf(rx_buf);
-	} else {
-		assert(flags & FI_DISCARD);
-		FI_DBG(&rxm_prov, FI_LOG_EP_DATA,
-		       "Discarding buffered receive\n");
-		rxm_free_rx_buf(rx_buf);
-	}
-unlock:
-	ofi_genlock_unlock(&rxm_ep->util_ep.lock);
-	return ret;
-}
-
 static ssize_t
 rxm_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t flags)
 {
 	struct rxm_ep *rxm_ep = container_of(ep_fid, struct rxm_ep,
 					     util_ep.ep_fid.fid);
 
-	if (rxm_ep->rxm_info->mode & OFI_BUFFERED_RECV)
-		return rxm_buf_recv(rxm_ep, msg->msg_iov, msg->desc,
-				    msg->iov_count, msg->addr, msg->context,
-				    flags | rxm_ep->util_ep.rx_msg_flags);
-
-	return rxm_recv_common(rxm_ep, msg->msg_iov, msg->desc,
-			       msg->iov_count, msg->addr, msg->context,
-			       flags | rxm_ep->util_ep.rx_msg_flags);
+	return util_srx_generic_recv(&rxm_ep->srx->ep_fid, msg->msg_iov,
+				     msg->desc, msg->iov_count, msg->addr,
+				     msg->context,
+				     flags | rxm_ep->util_ep.rx_msg_flags);
 
 }
 
@@ -262,8 +64,9 @@ rxm_recv(struct fid_ep *ep_fid, void *buf, size_t len,
 		.iov_len	= len,
 	};
 
-	return rxm_recv_common(rxm_ep, &iov, &desc, 1, src_addr,
-			       context, rxm_ep->util_ep.rx_op_flags);
+	return util_srx_generic_recv(&rxm_ep->srx->ep_fid, &iov, &desc, 1,
+				     src_addr, context,
+				     rxm_ep->util_ep.rx_op_flags);
 }
 
 static ssize_t
@@ -273,8 +76,9 @@ rxm_recvv(struct fid_ep *ep_fid, const struct iovec *iov,
 	struct rxm_ep *rxm_ep = container_of(ep_fid, struct rxm_ep,
 					     util_ep.ep_fid.fid);
 
-	return rxm_recv_common(rxm_ep, iov, desc, count, src_addr,
-			       context, rxm_ep->util_ep.rx_op_flags);
+	return util_srx_generic_recv(&rxm_ep->srx->ep_fid, iov, desc, count,
+				     src_addr, context,
+				     rxm_ep->util_ep.rx_op_flags);
 }
 
 static ssize_t
@@ -661,15 +465,13 @@ rxm_send_eager(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	eager_buf->app_context = context;
 	eager_buf->flags = flags;
 
+	rxm_ep_format_tx_buf_pkt(rxm_conn, data_len, op, data, tag,
+				 flags, &eager_buf->pkt);
 	if (rxm_use_direct_send(rxm_ep, count, flags)) {
-		rxm_ep_format_tx_buf_pkt(rxm_conn, data_len, op, data, tag,
-					 flags, &eager_buf->pkt);
 
 		ret = rxm_direct_send(rxm_ep, rxm_conn, eager_buf,
 				      iov, desc, count);
 	} else {
-		rxm_ep_format_tx_buf_pkt(rxm_conn, data_len, op, data, tag,
-					 flags, &eager_buf->pkt);
 		ret = rxm_copy_from_hmem_iov(desc, eager_buf->pkt.data,
 					     eager_buf->pkt.hdr.size, iov,
 					     count, 0);
@@ -883,6 +685,19 @@ struct fi_ops_msg rxm_msg_ops = {
 	.recv = rxm_recv,
 	.recvv = rxm_recvv,
 	.recvmsg = rxm_recvmsg,
+	.send = rxm_send,
+	.sendv = rxm_sendv,
+	.sendmsg = rxm_sendmsg,
+	.inject = rxm_inject,
+	.senddata = rxm_senddata,
+	.injectdata = rxm_injectdata,
+};
+
+struct fi_ops_msg rxm_no_recv_msg_ops = {
+	.size = sizeof(struct fi_ops_msg),
+	.recv = fi_no_msg_recv,
+	.recvv = fi_no_msg_recvv,
+	.recvmsg = fi_no_msg_recvmsg,
 	.send = rxm_send,
 	.sendv = rxm_sendv,
 	.sendmsg = rxm_sendmsg,

--- a/prov/rxm/src/rxm_tagged.c
+++ b/prov/rxm/src/rxm_tagged.c
@@ -50,8 +50,9 @@ rxm_discard_recv(struct rxm_ep *rxm_ep, struct rxm_rx_buf *rx_buf,
 	RXM_DBG_ADDR_TAG(FI_LOG_EP_DATA, "Discarding message",
 			 rx_buf->unexp_msg.addr, rx_buf->unexp_msg.tag);
 
-	rxm_cq_write(rxm_ep->util_ep.rx_cq, context, FI_TAGGED | FI_RECV,
-		     0, NULL, rx_buf->pkt.hdr.data, rx_buf->pkt.hdr.tag);
+	ofi_peer_cq_write(rxm_ep->util_ep.rx_cq, context, FI_TAGGED | FI_RECV,
+			  0, NULL, rx_buf->pkt.hdr.data,
+			  rx_buf->pkt.hdr.tag, FI_ADDR_NOTAVAIL);
 	rxm_free_rx_buf(rx_buf);
 }
 
@@ -73,8 +74,8 @@ rxm_peek_recv(struct rxm_ep *rxm_ep, fi_addr_t addr, uint64_t tag,
 	rx_buf = rxm_get_unexp_msg(recv_queue, addr, tag, ignore);
 	if (!rx_buf) {
 		FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Message not found\n");
-		ret = ofi_cq_write_error_peek(rxm_ep->util_ep.rx_cq, tag,
-					      context);
+		ret = ofi_peer_cq_write_error_peek(
+					rxm_ep->util_ep.rx_cq, tag, context);
 		if (ret)
 			FI_WARN(&rxm_prov, FI_LOG_CQ, "Error writing to CQ\n");
 		return;
@@ -94,9 +95,9 @@ rxm_peek_recv(struct rxm_ep *rxm_ep, fi_addr_t addr, uint64_t tag,
 		dlist_remove(&rx_buf->unexp_msg.entry);
 	}
 
-	rxm_cq_write(rxm_ep->util_ep.rx_cq, context, FI_TAGGED | FI_RECV,
-		     rx_buf->pkt.hdr.size, NULL,
-		     rx_buf->pkt.hdr.data, rx_buf->pkt.hdr.tag);
+	ofi_peer_cq_write(rxm_ep->util_ep.rx_cq, context, FI_TAGGED | FI_RECV,
+			  rx_buf->pkt.hdr.size, NULL, rx_buf->pkt.hdr.data,
+			  rx_buf->pkt.hdr.tag, FI_ADDR_NOTAVAIL);
 }
 
 static ssize_t

--- a/prov/rxm/src/rxm_tagged.c
+++ b/prov/rxm/src/rxm_tagged.c
@@ -43,189 +43,21 @@
 #include "rxm.h"
 
 
-static void
-rxm_discard_recv(struct rxm_ep *rxm_ep, struct rxm_rx_buf *rx_buf,
-		 void *context)
-{
-	RXM_DBG_ADDR_TAG(FI_LOG_EP_DATA, "Discarding message",
-			 rx_buf->unexp_msg.addr, rx_buf->unexp_msg.tag);
-
-	ofi_peer_cq_write(rxm_ep->util_ep.rx_cq, context, FI_TAGGED | FI_RECV,
-			  0, NULL, rx_buf->pkt.hdr.data,
-			  rx_buf->pkt.hdr.tag, FI_ADDR_NOTAVAIL);
-	rxm_free_rx_buf(rx_buf);
-}
-
-static void
-rxm_peek_recv(struct rxm_ep *rxm_ep, fi_addr_t addr, uint64_t tag,
-	      uint64_t ignore, void *context, uint64_t flags,
-	      struct rxm_recv_queue *recv_queue)
-{
-	struct rxm_rx_buf *rx_buf;
-	int ret;
-
-	RXM_DBG_ADDR_TAG(FI_LOG_EP_DATA, "Peeking message", addr, tag);
-
-	/* peek doesn't support peer transfer at this moment */
-	assert(!(flags & FI_PEER_TRANSFER));
-
-	rxm_ep_do_progress(&rxm_ep->util_ep);
-
-	rx_buf = rxm_get_unexp_msg(recv_queue, addr, tag, ignore);
-	if (!rx_buf) {
-		FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Message not found\n");
-		ret = ofi_peer_cq_write_error_peek(
-					rxm_ep->util_ep.rx_cq, tag, context);
-		if (ret)
-			FI_WARN(&rxm_prov, FI_LOG_CQ, "Error writing to CQ\n");
-		return;
-	}
-
-	FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Message found\n");
-
-	if (flags & FI_DISCARD) {
-		dlist_remove(&rx_buf->unexp_msg.entry);
-		rxm_discard_recv(rxm_ep, rx_buf, context);
-		return;
-	}
-
-	if (flags & FI_CLAIM) {
-		FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Marking message for Claim\n");
-		((struct fi_context *)context)->internal[0] = rx_buf;
-		dlist_remove(&rx_buf->unexp_msg.entry);
-	}
-
-	ofi_peer_cq_write(rxm_ep->util_ep.rx_cq, context, FI_TAGGED | FI_RECV,
-			  rx_buf->pkt.hdr.size, NULL, rx_buf->pkt.hdr.data,
-			  rx_buf->pkt.hdr.tag, FI_ADDR_NOTAVAIL);
-}
-
-static ssize_t
-rxm_post_trecv(struct rxm_ep *rxm_ep, const struct iovec *iov,
-	       void **desc, size_t count, fi_addr_t src_addr,
-	       uint64_t tag, uint64_t ignore, void *context, uint64_t op_flags)
-{
-	struct rxm_recv_entry *recv_entry;
-	struct rxm_rx_buf *rx_buf;
-
-	assert(count <= rxm_ep->rxm_info->rx_attr->iov_limit);
-
-	recv_entry = rxm_recv_entry_get(rxm_ep, iov, desc, count, src_addr,
-					tag, ignore, context, op_flags,
-					&rxm_ep->trecv_queue);
-	if (!recv_entry)
-		return -FI_EAGAIN;
-
-	rx_buf = rxm_get_unexp_msg(&rxm_ep->trecv_queue, recv_entry->addr,
-				   recv_entry->tag, recv_entry->ignore);
-	if (!rx_buf) {
-		dlist_insert_tail(&recv_entry->entry,
-				  &rxm_ep->trecv_queue.recv_list);
-		return FI_SUCCESS;
-	}
-
-	dlist_remove(&rx_buf->unexp_msg.entry);
-	rx_buf->recv_entry = recv_entry;
-
-	if (rx_buf->pkt.ctrl_hdr.type != rxm_ctrl_seg)
-		return rxm_handle_rx_buf(rx_buf);
-	else
-		return rxm_handle_unexp_sar(&rxm_ep->trecv_queue, recv_entry,
-					    rx_buf);
-}
-
-static ssize_t
-rxm_trecv_common(struct rxm_ep *rxm_ep, const struct iovec *iov,
-		 void **desc, size_t count, fi_addr_t src_addr,
-		 uint64_t tag, uint64_t ignore, void *context,
-		 uint64_t op_flags)
-{
-	ssize_t ret;
-
-	if (op_flags & FI_PEER_TRANSFER)
-		tag |= RXM_PEER_XFER_TAG_FLAG;
-
-	ofi_genlock_lock(&rxm_ep->util_ep.lock);
-	ret = rxm_post_trecv(rxm_ep, iov, desc, count, src_addr,
-			     tag, ignore, context, op_flags);
-	ofi_genlock_unlock(&rxm_ep->util_ep.lock);
-	return ret;
-}
-
 static ssize_t
 rxm_trecvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
 	     uint64_t flags)
 {
-	struct rxm_ep *rxm_ep;
-	struct rxm_recv_entry *recv_entry;
-	struct fi_recv_context *recv_ctx;
-	struct rxm_rx_buf *rx_buf;
-	void *context = msg->context;
-	ssize_t ret = 0;
+	uint64_t tag = msg->tag;
+	struct rxm_ep *rxm_ep = container_of(ep_fid, struct rxm_ep,
+					     util_ep.ep_fid.fid);
 
-	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
-	flags |= rxm_ep->util_ep.rx_msg_flags;
+	if (flags & FI_PEER_TRANSFER)
+		tag |= RXM_PEER_XFER_TAG_FLAG;
 
-	if (!(flags & (FI_CLAIM | FI_PEEK)) &&
-	    !(rxm_ep->rxm_info->mode & OFI_BUFFERED_RECV)) {
-		return rxm_trecv_common(rxm_ep, msg->msg_iov, msg->desc,
-					msg->iov_count, msg->addr,
-					msg->tag, msg->ignore, context, flags);
-	}
-
-	ofi_genlock_lock(&rxm_ep->util_ep.lock);
-	if (rxm_ep->rxm_info->mode & OFI_BUFFERED_RECV) {
-		recv_ctx = msg->context;
-		context = recv_ctx->context;
-		rx_buf = container_of(recv_ctx, struct rxm_rx_buf, recv_context);
-
-		if (flags & FI_CLAIM) {
-			FI_DBG(&rxm_prov, FI_LOG_EP_DATA,
-			       "Claiming buffered receive\n");
-			goto claim;
-		}
-
-		assert(flags & FI_DISCARD);
-		FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Discarding buffered receive\n");
-		rxm_free_rx_buf(rx_buf);
-		goto unlock;
-	}
-
-	if (flags & FI_PEEK) {
-		rxm_peek_recv(rxm_ep, msg->addr, msg->tag, msg->ignore,
-			      context, flags, &rxm_ep->trecv_queue);
-		goto unlock;
-	}
-
-	rx_buf = ((struct fi_context *) context)->internal[0];
-	assert(rx_buf);
-	FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Claim message\n");
-
-	if (flags & FI_DISCARD) {
-		rxm_discard_recv(rxm_ep, rx_buf, context);
-		goto unlock;
-	}
-
-claim:
-	assert (flags & FI_CLAIM);
-	recv_entry = rxm_recv_entry_get(rxm_ep, msg->msg_iov, msg->desc,
-					msg->iov_count, msg->addr,
-					msg->tag, msg->ignore, context, flags,
-					&rxm_ep->trecv_queue);
-	if (!recv_entry) {
-		ret = -FI_EAGAIN;
-		goto unlock;
-	}
-
-	if (rxm_ep->rxm_info->mode & OFI_BUFFERED_RECV)
-		recv_entry->comp_flags |= FI_CLAIM;
-
-	rx_buf->recv_entry = recv_entry;
-	ret = rxm_handle_rx_buf(rx_buf);
-
-unlock:
-	ofi_genlock_unlock(&rxm_ep->util_ep.lock);
-	return ret;
+	return util_srx_generic_trecv(&rxm_ep->srx->ep_fid, msg->msg_iov,
+				      msg->desc, msg->iov_count, msg->addr,
+				      msg->context, tag, msg->ignore,
+				      flags | rxm_ep->util_ep.rx_msg_flags);
 }
 
 static ssize_t
@@ -240,8 +72,9 @@ rxm_trecv(struct fid_ep *ep_fid, void *buf, size_t len,
 	};
 
 	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
-	return rxm_trecv_common(rxm_ep, &iov, &desc, 1, src_addr, tag, ignore,
-				context, rxm_ep->util_ep.rx_op_flags);
+	return util_srx_generic_trecv(&rxm_ep->srx->ep_fid, &iov, &desc, 1,
+				      src_addr, context, tag, ignore,
+				      rxm_ep->util_ep.rx_op_flags);
 }
 
 static ssize_t
@@ -252,8 +85,9 @@ rxm_trecvv(struct fid_ep *ep_fid, const struct iovec *iov,
 	struct rxm_ep *rxm_ep;
 
 	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
-	return rxm_trecv_common(rxm_ep, iov, desc, count, src_addr, tag,
-				ignore, context, rxm_ep->util_ep.rx_op_flags);
+	return util_srx_generic_trecv(&rxm_ep->srx->ep_fid, iov, desc, count,
+				      src_addr, context, tag, ignore,
+				      rxm_ep->util_ep.rx_op_flags);
 }
 
 static ssize_t
@@ -372,7 +206,7 @@ rxm_tsenddata(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	ret = rxm_send_common(rxm_ep, rxm_conn, &iov, &desc, 1, context, data,
 			      rxm_ep->util_ep.tx_op_flags | FI_REMOTE_CQ_DATA,
-			tag, ofi_op_tagged);
+			      tag, ofi_op_tagged);
 unlock:
 	ofi_genlock_unlock(&rxm_ep->util_ep.lock);
 	return ret;
@@ -416,6 +250,18 @@ struct fi_ops_tagged rxm_tagged_ops = {
 	.injectdata = rxm_tinjectdata,
 };
 
+struct fi_ops_tagged rxm_no_recv_tagged_ops = {
+	.size = sizeof(struct fi_ops_tagged),
+	.recv = fi_no_tagged_recv,
+	.recvv = fi_no_tagged_recvv,
+	.recvmsg = fi_no_tagged_recvmsg,
+	.send = rxm_tsend,
+	.sendv = rxm_tsendv,
+	.sendmsg = rxm_tsendmsg,
+	.inject = rxm_tinject,
+	.senddata = rxm_tsenddata,
+	.injectdata = rxm_tinjectdata,
+};
 
 static ssize_t
 rxm_trecv_thru(struct fid_ep *ep_fid, void *buf, size_t len,

--- a/prov/tcp/src/xnet_av.c
+++ b/prov/tcp/src/xnet_av.c
@@ -38,7 +38,7 @@ int xnet_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 		 struct fid_av **fid_av, void *context)
 {
 	return rxm_util_av_open(domain_fid, attr, fid_av, context,
-				sizeof(struct xnet_conn), NULL);
+				sizeof(struct xnet_conn), NULL, NULL);
 }
 
 static int xnet_mplex_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr,

--- a/prov/util/src/rxm_av.c
+++ b/prov/util/src/rxm_av.c
@@ -165,7 +165,7 @@ rxm_put_peer_addr(struct rxm_av *av, fi_addr_t fi_addr)
 
 static int
 rxm_av_add_peers(struct rxm_av *av, const void *addr, size_t count,
-		 fi_addr_t *fi_addr)
+		 fi_addr_t *fi_addr, fi_addr_t *user_ids)
 {
 	struct util_peer_addr *peer;
 	const void *cur_addr;
@@ -178,8 +178,12 @@ rxm_av_add_peers(struct rxm_av *av, const void *addr, size_t count,
 		if (!peer)
 			goto err;
 
-		peer->fi_addr = fi_addr ? fi_addr[i] :
+		if (user_ids) {
+			peer->fi_addr = user_ids[i];
+		} else {
+			peer->fi_addr = fi_addr ? fi_addr[i] :
 				ofi_av_lookup_fi_addr(&av->util_av, cur_addr);
+		}
 
 		/* lookup can fail if prior AV insertion failed */
 		if (peer->fi_addr != FI_ADDR_NOTAVAIL)
@@ -276,21 +280,33 @@ static int rxm_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 			 fi_addr_t *fi_addr, uint64_t flags, void *context)
 {
 	struct rxm_av *av;
+	fi_addr_t *user_ids = NULL;
 	int ret;
+
+	if (flags & FI_AV_USER_ID) {
+		assert(fi_addr);
+		user_ids = calloc(count, sizeof(*user_ids));
+		assert(user_ids);
+		memcpy(user_ids, fi_addr, sizeof(*fi_addr) * count);
+	}
 
 	av = container_of(av_fid, struct rxm_av, util_av.av_fid.fid);
 	ret = ofi_ip_av_insert(av_fid, addr, count, fi_addr, flags, context);
 	if (ret < 0)
-		return ret;
+		goto out;
 
 	count = ret;
 
-	ret = rxm_av_add_peers(av, addr, count, fi_addr);
+	ret = rxm_av_add_peers(av, addr, count, fi_addr, user_ids);
 	if (ret) {
 		rxm_av_remove(av_fid, fi_addr, count, flags);
-		return ret;
+		goto out;
 	}
 
+out:
+	free(user_ids);
+	if (ret)
+		return ret;
 	return (int) count;
 }
 
@@ -319,7 +335,7 @@ static int rxm_av_insertsym(struct fid_av *av_fid, const char *node,
 	if (ret > 0 && ret < count)
 		count = ret;
 
-	ret = rxm_av_add_peers(av, addr, count, fi_addr);
+	ret = rxm_av_add_peers(av, addr, count, fi_addr, NULL);
 	if (ret) {
 		rxm_av_remove(av_fid, fi_addr, count, flags);
 		return ret;


### PR DESCRIPTION
Add rxm support for FI_PEER (srx, cq, and cntr) and FI_AV_USER_ID to be used with the link provider