### PR TITLE
test_configs/ofi_rxm/tcp.test: remove cntr RMA testing

### DIFF
--- a/fabtests/test_configs/ofi_rxm/tcp.test
+++ b/fabtests/test_configs/ofi_rxm/tcp.test
@@ -59,7 +59,6 @@
 	],
 	comp_type: [
 		FT_COMP_QUEUE,
-		FT_COMP_CNTR,
 	],
 	mr_mode: [],
 	progress: [


### PR DESCRIPTION
ubertest implementation currently requires FI_RMA_EVENT when using RMA and counters This will cause tcp to return ENODATA for these combinations and cause runfabtests to fail.
This should get updated in ubertest to not require it but remove testing for now