### PR TITLE
prov/hook: Fix the preprocessor

### DIFF
--- a/prov/hook/hook_hmem/src/hook_hmem.c
+++ b/prov/hook/hook_hmem/src/hook_hmem.c
@@ -1914,7 +1914,7 @@ out:
 
 HOOK_HMEM_INI
 {
-#ifdef HAVE_HOOK_HMEM_DL
+#if HAVE_HOOK_HMEM_DL
 	ofi_hmem_init();
 #endif
 	hook_hmem_fabric_ops = hook_fabric_ops;


### PR DESCRIPTION
ifdef should be if here, as HAVE_HOOK_HMEM_DL is defined anyway.