### PR TITLE
prov/efa: Abort for MR > 4GB

### DIFF
--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -831,6 +831,12 @@ static int efa_mr_reg_impl(struct efa_mr *efa_mr, uint64_t flags, const void *at
 		}
 		efa_mr->domain->ibv_mr_reg_ct++;
 		efa_mr->domain->ibv_mr_reg_sz += efa_mr->ibv_mr->length;
+		if (efa_mr->ibv_mr->length >= (size_t) BIT(32)) {
+			fprintf(stderr,
+			"mr >4GB.\n"
+			"Your application will now abort.\n");
+			abort();
+		}
 		EFA_INFO(FI_LOG_MR, "Registered memory of size %zu for ibv pd %p, total mr reg size %zu, mr reg count %zu\n",
 			 efa_mr->ibv_mr->length, efa_mr->domain->ibv_pd, efa_mr->domain->ibv_mr_reg_sz, efa_mr->domain->ibv_mr_reg_ct);
 		efa_mr->mr_fid.key = efa_mr->ibv_mr->rkey;


### PR DESCRIPTION
Find the test that registers memory > 4GB in PR CI.