### PR TITLE
core: Remove redundant windows.h

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -65,7 +65,6 @@
 
 #if defined(_WIN32)
 #include <BaseTsd.h>
-#include <windows.h>
 typedef SSIZE_T ssize_t;
 #endif
 


### PR DESCRIPTION
The windows.h header is not necessary for ssize_t definition on Windows platform since BaseTsd.h already provides the required SSIZE_T type definition. Remove this redundant include to reduce compilation dependencies.