### PR TITLE
Fix incorrect checking of client RKEY

### DIFF
--- a/prov/cxi/src/cxip_mr.c
+++ b/prov/cxi/src/cxip_mr.c
@@ -758,6 +758,14 @@ static void cxip_mr_domain_remove(struct cxip_mr *mr)
 	ofi_spin_unlock(&mr->domain->mr_domain.lock);
 }
 
+static bool cxip_is_valid_mr_key(uint64_t key)
+{
+	if (key & ~CXIP_MR_KEY_MASK)
+		return false;
+
+	return true;
+}
+
 /*
  * cxip_mr_domain_insert() - Validate uniqueness and insert
  * client key in the domain hash table.
@@ -777,7 +785,7 @@ static int cxip_mr_domain_insert(struct cxip_mr *mr)
 
 	mr->key = mr->attr.requested_key;
 
-	if (!cxip_generic_is_valid_mr_key(mr->key))
+	if (!cxip_is_valid_mr_key(mr->key))
 		return -FI_EKEYREJECTED;
 
 	bucket = fasthash64(&mr->key, sizeof(mr->key), 0) %
@@ -849,14 +857,6 @@ static int cxip_prov_cache_init_mr_key(struct cxip_mr *mr,
 		 key.raw, key.lac, (uint64_t)key.lac_off);
 
 	return FI_SUCCESS;
-}
-
-static bool cxip_is_valid_mr_key(uint64_t key)
-{
-	if (key & ~CXIP_MR_KEY_MASK)
-		return false;
-
-	return true;
 }
 
 static bool cxip_is_valid_prov_mr_key(uint64_t key)

--- a/prov/cxi/test/mr.c
+++ b/prov/cxi/test/mr.c
@@ -51,6 +51,25 @@ Test(mr, invalid_fi_directed_recv_flag)
 	cr_assert_eq(ret, -FI_EINVAL, "fi_mr_regattr failed: %d", ret);
 }
 
+Test(mr, invalid_client_rkey)
+{
+	int ret;
+	struct fi_mr_attr attr = {};
+	struct iovec iov = {};
+	struct fid_mr *mr;
+
+	iov.iov_len = sizeof(ret);
+	iov.iov_base = (void *)&ret;
+
+	attr.mr_iov = &iov;
+	attr.iov_count = 1;
+	attr.access = FI_REMOTE_READ | FI_REMOTE_WRITE;
+	attr.requested_key = ~1;
+
+	ret = fi_mr_regattr(cxit_domain, &attr, 0, &mr);
+	cr_assert_eq(ret, -FI_EKEYREJECTED, "fi_mr_regattr failed: %d", ret);
+}
+
 Test(mr, std_mrs, .timeout = 600, .disabled = true)
 {
 	int std_mr_cnt = 16*1024;


### PR DESCRIPTION
Clients could provider RKEYs greater than 4 bytes and the CXI provider would not detect it.