### PR TITLE
prov/efa, fabtests: Implement FI_MORE for fi_recv 

### DIFF
--- a/fabtests/benchmarks/benchmark_shared.c
+++ b/fabtests/benchmarks/benchmark_shared.c
@@ -511,10 +511,20 @@ int bandwidth(void)
 			if (i == opts.warmup_iterations)
 				ft_start();
 
-			ret = ft_post_rx_buf(ep, opts.transfer_size,
-					     &rx_ctx_arr[j].context,
-					     rx_ctx_arr[j].buf, mr_desc,
-					     ft_tag);
+			if (opts.use_fi_more) {
+				flags = set_fi_more_flag(i, j, flags);
+				ret = ft_recvmsg(ep, remote_fi_addr,
+						 rx_ctx_arr[j].buf,
+						 MAX(opts.transfer_size,
+						     FT_MAX_CTRL_MSG) +
+							 ft_rx_prefix_size(),
+						 &rx_ctx_arr[j].context, flags);
+			} else {
+				ret = ft_post_rx_buf(ep, opts.transfer_size,
+						     &rx_ctx_arr[j].context,
+						     rx_ctx_arr[j].buf, mr_desc,
+						     ft_tag);
+			}
 			if (ret)
 				return ret;
 

--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -2952,14 +2952,14 @@ int ft_sendmsg(struct fid_ep *ep, fi_addr_t fi_addr,
 }
 
 
-int ft_recvmsg(struct fid_ep *ep, fi_addr_t fi_addr,
+int ft_recvmsg(struct fid_ep *ep, fi_addr_t fi_addr, void *buf,
 	       size_t size, void *ctx, int flags)
 {
 	struct fi_msg msg;
 	struct fi_msg_tagged tagged_msg;
 	struct iovec msg_iov;
 
-	msg_iov.iov_base = rx_buf;
+	msg_iov.iov_base = (char *) buf;
 	msg_iov.iov_len = size;
 
 	if (hints->caps & FI_TAGGED) {
@@ -2969,7 +2969,7 @@ int ft_recvmsg(struct fid_ep *ep, fi_addr_t fi_addr,
 		tagged_msg.addr = fi_addr;
 		tagged_msg.data = NO_CQ_DATA;
 		tagged_msg.context = ctx;
-		tagged_msg.tag = ft_tag ? ft_tag : tx_seq;
+		tagged_msg.tag = ft_tag ? ft_tag : rx_seq;
 		tagged_msg.ignore = 0;
 
 		FT_POST(fi_trecvmsg, ft_progress, rxcq, rx_seq,

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -629,7 +629,7 @@ int ft_get_cq_comp(struct fid_cq *cq, uint64_t *cur, uint64_t total, int timeout
 int ft_get_cntr_comp(struct fid_cntr *cntr, uint64_t total, int timeout);
 
 int ft_recvmsg(struct fid_ep *ep, fi_addr_t fi_addr,
-		size_t size, void *ctx, int flags);
+	       void *buf, size_t size, void *ctx, int flags);
 int ft_sendmsg(struct fid_ep *ep, fi_addr_t fi_addr,
 	       void *buf, size_t size, void *ctx, int flags);
 int ft_writemsg(struct fid_ep *ep, fi_addr_t fi_addr, void *buf, size_t size,

--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -132,3 +132,12 @@ def test_rdm_bw_zcpy_recv(cmdline_args, memory_type, zcpy_recv_max_msg_size, zcp
     cmdline_args_copy.append_environ("FI_EFA_ENABLE_SHM_TRANSFER=0")
     efa_run_client_server_test(cmdline_args_copy, f"fi_rdm_bw --max-msg-size {zcpy_recv_max_msg_size}",
                                "short", "transmit_complete", memory_type, zcpy_recv_message_size)
+
+@pytest.mark.functional
+def test_rdm_bw_zcpy_recv_use_fi_more(cmdline_args, memory_type, zcpy_recv_max_msg_size, zcpy_recv_message_size):
+    if cmdline_args.server_id == cmdline_args.client_id:
+        pytest.skip("no zero copy recv for intra-node communication")
+    cmdline_args_copy = copy.copy(cmdline_args)
+    cmdline_args_copy.append_environ("FI_EFA_ENABLE_SHM_TRANSFER=0")
+    efa_run_client_server_test(cmdline_args_copy, f"fi_rdm_bw --use-fi-more --max-msg-size {zcpy_recv_max_msg_size}",
+                               "short", "transmit_complete", memory_type, zcpy_recv_message_size)

--- a/prov/efa/src/efa_base_ep.c
+++ b/prov/efa/src/efa_base_ep.c
@@ -86,6 +86,9 @@ int efa_base_ep_destruct(struct efa_base_ep *base_ep)
 
 	if (base_ep->efa_recv_wr_vec)
 		free(base_ep->efa_recv_wr_vec);
+	
+	if (base_ep->user_recv_wr_vec)
+		free(base_ep->user_recv_wr_vec);
 
 	return err;
 }
@@ -345,6 +348,12 @@ int efa_base_ep_construct(struct efa_base_ep *base_ep,
 		EFA_WARN(FI_LOG_EP_CTRL, "cannot alloc memory for base_ep->efa_recv_wr_vec!\n");
 		return -FI_ENOMEM;
 	}
+	base_ep->user_recv_wr_vec = calloc(sizeof(struct efa_recv_wr), EFA_RDM_EP_MAX_WR_PER_IBV_POST_RECV);
+	if (!base_ep->user_recv_wr_vec) {
+		EFA_WARN(FI_LOG_EP_CTRL, "cannot alloc memory for base_ep->user_recv_wr_vec!\n");
+		return -FI_ENOMEM;
+	}
+	base_ep->recv_wr_index = 0;
 	base_ep->efa_qp_enabled = false;
 	base_ep->qp = NULL;
 	base_ep->user_recv_qp = NULL;

--- a/prov/efa/src/efa_base_ep.h
+++ b/prov/efa/src/efa_base_ep.h
@@ -56,9 +56,11 @@ struct efa_base_ep {
 	struct ibv_recv_wr recv_more_wr_head;
 	struct ibv_recv_wr *recv_more_wr_tail;
 	struct efa_recv_wr *efa_recv_wr_vec;
+	size_t recv_wr_index;
 
 	/* Only used by RDM ep type */
 	struct efa_qp *user_recv_qp; /* Separate qp to receive pkts posted by users */
+	struct efa_recv_wr *user_recv_wr_vec;
 };
 
 int efa_base_ep_bind_av(struct efa_base_ep *base_ep, struct efa_av *av);

--- a/prov/efa/src/rdm/efa_rdm_ep_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_utils.c
@@ -205,7 +205,7 @@ struct efa_rdm_ope *efa_rdm_ep_alloc_rxe(struct efa_rdm_ep *ep, fi_addr_t addr, 
  * @param[in]	rxe	rxe that contain user buffer information
  * @param[in]	flags		user supplied flags passed to fi_recv
  */
-int efa_rdm_ep_post_user_recv_buf(struct efa_rdm_ep *ep, struct efa_rdm_ope *rxe, size_t flags)
+int efa_rdm_ep_post_user_recv_buf(struct efa_rdm_ep *ep, struct efa_rdm_ope *rxe, uint64_t flags)
 {
 	struct efa_rdm_pke *pkt_entry = NULL;
 	size_t rx_iov_offset = 0;
@@ -244,7 +244,7 @@ int efa_rdm_ep_post_user_recv_buf(struct efa_rdm_ep *ep, struct efa_rdm_ope *rxe
 	pkt_entry->payload_mr = rxe->desc[rx_iov_index];
 	pkt_entry->payload_size = ofi_total_iov_len(&rxe->iov[rx_iov_index], rxe->iov_count - rx_iov_index) - rx_iov_offset;
 
-	err = efa_rdm_pke_recvv(&pkt_entry, 1);
+	err = efa_rdm_pke_user_recvv(&pkt_entry, 1, flags);
 	if (OFI_UNLIKELY(err)) {
 		EFA_WARN(FI_LOG_EP_CTRL,
 			"failed to post user supplied buffer %d (%s)\n", -err,

--- a/prov/efa/src/rdm/efa_rdm_pke.h
+++ b/prov/efa/src/rdm/efa_rdm_pke.h
@@ -237,5 +237,8 @@ int efa_rdm_pke_read(struct efa_rdm_pke *pkt_entry,
 ssize_t efa_rdm_pke_recvv(struct efa_rdm_pke **pke_vec,
 			  int pke_cnt);
 
+ssize_t efa_rdm_pke_user_recvv(struct efa_rdm_pke **pke_vec,
+			  int pke_cnt, uint64_t flags);
+
 int efa_rdm_pke_write(struct efa_rdm_pke *pkt_entry);
 #endif


### PR DESCRIPTION
Implement FI_MORE for fi_recv in zero-copy recv mode.
Allow tests with FI_MORE flag by using fi_recvmsg.
Add FI_MORE pytest for fi_recv in test_rdm_bw_zcpy_recv_use_fi_more.