### PR TITLE
prov/verbs: Fix coverity issue about overflowed return value

### DIFF
--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -620,7 +620,7 @@ err:
 	return -FI_EAGAIN;
 }
 
-static size_t
+static ssize_t
 vrb_eq_xrc_recip_conn_event(struct vrb_eq *eq,
 			       struct vrb_xrc_ep *ep,
 			       struct rdma_cm_event *cma_event,
@@ -787,7 +787,7 @@ vrb_eq_xrc_cm_err_event(struct vrb_eq *eq,
         return FI_SUCCESS;
 }
 
-static int
+static ssize_t
 vrb_eq_xrc_connected_event(struct vrb_eq *eq,
 			   struct rdma_cm_event *cma_event, int *acked,
 			   struct fi_eq_cm_entry *entry, size_t len,
@@ -795,7 +795,7 @@ vrb_eq_xrc_connected_event(struct vrb_eq *eq,
 {
 	struct vrb_xrc_ep *ep;
 	fid_t fid = cma_event->id->context;
-	int ret;
+	ssize_t ret;
 
 	ep = container_of(fid, struct vrb_xrc_ep, base_ep.util_ep.ep_fid);
 


### PR DESCRIPTION
The function `vrb_eq_xrc_recip_conn_event` was defined as size_t but can return a nagative value on error which would overflow when casted to int. Change the type to ssize_t.

Also change the return type of `vrb_eq_xrc_connected_event` to ssize_t to be consistent with its caller and the function it calls.