### PR TITLE
prov/efa: Move inject sizes from rdm ep to base ep

### DIFF
--- a/prov/efa/src/efa_base_ep.c
+++ b/prov/efa/src/efa_base_ep.c
@@ -348,6 +348,11 @@ int efa_base_ep_construct(struct efa_base_ep *base_ep,
 	base_ep->efa_qp_enabled = false;
 	base_ep->qp = NULL;
 	base_ep->user_recv_qp = NULL;
+
+	base_ep->max_msg_size = info->ep_attr->max_msg_size;
+	base_ep->max_rma_size = info->ep_attr->max_msg_size;
+	base_ep->inject_msg_size = info->tx_attr->inject_size;
+	base_ep->inject_rma_size = info->tx_attr->inject_size;
 	return 0;
 }
 

--- a/prov/efa/src/efa_base_ep.h
+++ b/prov/efa/src/efa_base_ep.h
@@ -57,6 +57,11 @@ struct efa_base_ep {
 	struct ibv_recv_wr *recv_more_wr_tail;
 	struct efa_recv_wr *efa_recv_wr_vec;
 
+	size_t max_msg_size;		/**< #FI_OPT_MAX_MSG_SIZE */
+	size_t max_rma_size;		/**< #FI_OPT_MAX_RMA_SIZE */
+	size_t inject_msg_size;		/**< #FI_OPT_INJECT_MSG_SIZE */
+	size_t inject_rma_size;		/**< #FI_OPT_INJECT_RMA_SIZE */
+
 	/* Only used by RDM ep type */
 	struct efa_qp *user_recv_qp; /* Separate qp to receive pkts posted by users */
 };

--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -60,13 +60,9 @@ struct efa_rdm_ep {
 	struct fid_peer_srx *shm_peer_srx;
 
 	size_t mtu_size;
-	size_t max_msg_size;		/**< #FI_OPT_MAX_MSG_SIZE */
 	size_t max_tagged_size;		/**< #FI_OPT_MAX_TAGGED_SIZE */
-	size_t max_rma_size;		/**< #FI_OPT_MAX_RMA_SIZE */
 	size_t max_atomic_size;		/**< #FI_OPT_MAX_ATOMIC_SIZE */
-	size_t inject_msg_size;		/**< #FI_OPT_INJECT_MSG_SIZE */
 	size_t inject_tagged_size;	/**< #FI_OPT_INJECT_TAGGED_SIZE */
-	size_t inject_rma_size;		/**< #FI_OPT_INJECT_RMA_SIZE */
 	size_t inject_atomic_size;	/**< #FI_OPT_INJECT_ATOMIC_SIZE */
 
 	/* Endpoint's capability to support zero-copy rx */

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -453,9 +453,12 @@ void efa_rdm_ep_set_use_zcpy_rx(struct efa_rdm_ep *ep)
 	}
 
 	/* Max msg size is too large, turn off zcpy recv */
-	if (ep->max_msg_size > ep->mtu_size - ep->base_ep.info->ep_attr->msg_prefix_size) {
-		EFA_INFO(FI_LOG_EP_CTRL, "max_msg_size (%zu) is greater than the mtu size limit: %zu. Zero-copy receive protocol will be disabled.\n",
-			ep->max_msg_size, ep->mtu_size - ep->base_ep.info->ep_attr->msg_prefix_size);
+	if (ep->base_ep.max_msg_size > ep->mtu_size - ep->base_ep.info->ep_attr->msg_prefix_size) {
+		EFA_INFO(FI_LOG_EP_CTRL,
+			 "max_msg_size (%zu) is greater than the mtu size limit: %zu. "
+			 "Zero-copy receive protocol will be disabled.\n",
+			 ep->base_ep.max_msg_size,
+			 ep->mtu_size - ep->base_ep.info->ep_attr->msg_prefix_size);
 		ep->use_zcpy_rx = false;
 		goto out;
 	}
@@ -557,13 +560,9 @@ int efa_rdm_ep_open(struct fid_domain *domain, struct fi_info *info,
 		EFA_INFO(FI_LOG_EP_CTRL, "efa_rdm_ep->host_id: i-%017lx\n", efa_rdm_ep->host_id);
 	}
 
-	efa_rdm_ep->max_msg_size = info->ep_attr->max_msg_size;
 	efa_rdm_ep->max_tagged_size = info->ep_attr->max_msg_size;
-	efa_rdm_ep->max_rma_size = info->ep_attr->max_msg_size;
 	efa_rdm_ep->max_atomic_size = info->ep_attr->max_msg_size;
-	efa_rdm_ep->inject_msg_size = info->tx_attr->inject_size;
 	efa_rdm_ep->inject_tagged_size = info->tx_attr->inject_size;
-	efa_rdm_ep->inject_rma_size = info->tx_attr->inject_size;
 	efa_rdm_ep->inject_atomic_size = info->tx_attr->inject_size;
 	efa_rdm_ep->efa_max_outstanding_tx_ops = efa_domain->device->rdm_info->tx_attr->size;
 	efa_rdm_ep->efa_max_outstanding_rx_ops = efa_domain->device->rdm_info->rx_attr->size;
@@ -1289,8 +1288,12 @@ static int efa_rdm_ep_ctrl(struct fid *fid, int command, void *arg)
 		 * when supported
 		 */
 		if (ep->use_zcpy_rx) {
-			ep->inject_msg_size = MIN(ep->inject_msg_size, efa_rdm_ep_domain(ep)->device->efa_attr.inline_buf_size);
-			ep->inject_rma_size = MIN(ep->inject_rma_size, efa_rdm_ep_domain(ep)->device->efa_attr.inline_buf_size);
+			ep->base_ep.inject_msg_size =
+				MIN(ep->base_ep.inject_msg_size,
+				    efa_rdm_ep_domain(ep)->device->efa_attr.inline_buf_size);
+			ep->base_ep.inject_rma_size =
+				MIN(ep->base_ep.inject_rma_size,
+				    efa_rdm_ep_domain(ep)->device->efa_attr.inline_buf_size);
 		}
 
 		ret = efa_rdm_ep_create_base_ep_ibv_qp(ep);
@@ -1711,25 +1714,25 @@ static int efa_rdm_ep_setopt(fid_t fid, int level, int optname,
 			return ret;
 		break;
 	case FI_OPT_MAX_MSG_SIZE:
-		EFA_RDM_EP_SETOPT_THRESHOLD(MAX_MSG_SIZE, efa_rdm_ep->max_msg_size, efa_rdm_ep->base_ep.info->ep_attr->max_msg_size)
+		EFA_RDM_EP_SETOPT_THRESHOLD(MAX_MSG_SIZE, efa_rdm_ep->base_ep.max_msg_size, efa_rdm_ep->base_ep.info->ep_attr->max_msg_size)
 		break;
 	case FI_OPT_MAX_TAGGED_SIZE:
 		EFA_RDM_EP_SETOPT_THRESHOLD(MAX_TAGGED_SIZE, efa_rdm_ep->max_tagged_size, efa_rdm_ep->base_ep.info->ep_attr->max_msg_size)
 		break;
 	case FI_OPT_MAX_RMA_SIZE:
-		EFA_RDM_EP_SETOPT_THRESHOLD(MAX_RMA_SIZE, efa_rdm_ep->max_rma_size, efa_rdm_ep->base_ep.info->ep_attr->max_msg_size)
+		EFA_RDM_EP_SETOPT_THRESHOLD(MAX_RMA_SIZE, efa_rdm_ep->base_ep.max_rma_size, efa_rdm_ep->base_ep.info->ep_attr->max_msg_size)
 		break;
 	case FI_OPT_MAX_ATOMIC_SIZE:
 		EFA_RDM_EP_SETOPT_THRESHOLD(MAX_ATOMIC_SIZE, efa_rdm_ep->max_atomic_size, efa_rdm_ep->base_ep.info->ep_attr->max_msg_size)
 		break;
 	case FI_OPT_INJECT_MSG_SIZE:
-		EFA_RDM_EP_SETOPT_THRESHOLD(INJECT_MSG_SIZE, efa_rdm_ep->inject_msg_size, efa_rdm_ep->base_ep.info->tx_attr->inject_size)
+		EFA_RDM_EP_SETOPT_THRESHOLD(INJECT_MSG_SIZE, efa_rdm_ep->base_ep.inject_msg_size, efa_rdm_ep->base_ep.info->tx_attr->inject_size)
 		break;
 	case FI_OPT_INJECT_TAGGED_SIZE:
 		EFA_RDM_EP_SETOPT_THRESHOLD(INJECT_TAGGED_SIZE, efa_rdm_ep->inject_tagged_size, efa_rdm_ep->base_ep.info->tx_attr->inject_size)
 		break;
 	case FI_OPT_INJECT_RMA_SIZE:
-		EFA_RDM_EP_SETOPT_THRESHOLD(INJECT_RMA_SIZE, efa_rdm_ep->inject_rma_size, efa_rdm_ep->base_ep.info->tx_attr->inject_size)
+		EFA_RDM_EP_SETOPT_THRESHOLD(INJECT_RMA_SIZE, efa_rdm_ep->base_ep.inject_rma_size, efa_rdm_ep->base_ep.info->tx_attr->inject_size)
 		break;
 	case FI_OPT_INJECT_ATOMIC_SIZE:
 		EFA_RDM_EP_SETOPT_THRESHOLD(INJECT_ATOMIC_SIZE, efa_rdm_ep->inject_atomic_size, efa_rdm_ep->base_ep.info->tx_attr->inject_size)
@@ -1813,7 +1816,7 @@ static int efa_rdm_ep_getopt(fid_t fid, int level, int optname, void *optval,
 	case FI_OPT_MAX_MSG_SIZE:
 		if (*optlen < sizeof (size_t))
 			return -FI_ETOOSMALL;
-		*(size_t *) optval = efa_rdm_ep->max_msg_size;
+		*(size_t *) optval = efa_rdm_ep->base_ep.max_msg_size;
 		*optlen = sizeof (size_t);
 		break;
 	case FI_OPT_MAX_TAGGED_SIZE:
@@ -1825,7 +1828,7 @@ static int efa_rdm_ep_getopt(fid_t fid, int level, int optname, void *optval,
 	case FI_OPT_MAX_RMA_SIZE:
 		if (*optlen < sizeof (size_t))
 			return -FI_ETOOSMALL;
-		*(size_t *) optval = efa_rdm_ep->max_rma_size;
+		*(size_t *) optval = efa_rdm_ep->base_ep.max_rma_size;
 		*optlen = sizeof (size_t);
 		break;
 	case FI_OPT_MAX_ATOMIC_SIZE:
@@ -1837,7 +1840,7 @@ static int efa_rdm_ep_getopt(fid_t fid, int level, int optname, void *optval,
 	case FI_OPT_INJECT_MSG_SIZE:
 		if (*optlen < sizeof (size_t))
 			return -FI_ETOOSMALL;
-		*(size_t *) optval = efa_rdm_ep->inject_msg_size;
+		*(size_t *) optval = efa_rdm_ep->base_ep.inject_msg_size;
 		*optlen = sizeof (size_t);
 		break;
 	case FI_OPT_INJECT_TAGGED_SIZE:
@@ -1849,7 +1852,7 @@ static int efa_rdm_ep_getopt(fid_t fid, int level, int optname, void *optval,
 	case FI_OPT_INJECT_RMA_SIZE:
 		if (*optlen < sizeof (size_t))
 			return -FI_ETOOSMALL;
-		*(size_t *) optval = efa_rdm_ep->inject_rma_size;
+		*(size_t *) optval = efa_rdm_ep->base_ep.inject_rma_size;
 		*optlen = sizeof (size_t);
 		break;
 	case FI_OPT_INJECT_ATOMIC_SIZE:

--- a/prov/efa/src/rdm/efa_rdm_msg.c
+++ b/prov/efa/src/rdm/efa_rdm_msg.c
@@ -290,7 +290,7 @@ ssize_t efa_rdm_msg_send(struct fid_ep *ep, const void *buf, size_t len,
 	int ret;
 
 	efa_rdm_ep = container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid.fid);
-	assert(len <= efa_rdm_ep->max_msg_size);
+	assert(len <= efa_rdm_ep->base_ep.max_msg_size);
 
 	ret = efa_rdm_attempt_to_sync_memops(efa_rdm_ep, (void *)buf, desc);
 	if (ret)
@@ -322,7 +322,7 @@ ssize_t efa_rdm_msg_senddata(struct fid_ep *ep, const void *buf, size_t len,
 	int ret;
 
 	efa_rdm_ep = container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid.fid);
-	assert(len <= efa_rdm_ep->max_msg_size);
+	assert(len <= efa_rdm_ep->base_ep.max_msg_size);
 
 	ret = efa_rdm_attempt_to_sync_memops(efa_rdm_ep, (void *)buf, desc);
 	if (ret)
@@ -354,7 +354,7 @@ ssize_t efa_rdm_msg_inject(struct fid_ep *ep, const void *buf, size_t len,
 	struct efa_rdm_peer *peer;
 
 	efa_rdm_ep = container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid.fid);
-	assert(len <= efa_rdm_ep->inject_msg_size);
+	assert(len <= efa_rdm_ep->base_ep.inject_msg_size);
 
 	peer = efa_rdm_ep_get_peer(efa_rdm_ep, dest_addr);
 	assert(peer);
@@ -382,7 +382,7 @@ ssize_t efa_rdm_msg_injectdata(struct fid_ep *ep, const void *buf,
 	struct efa_rdm_peer *peer;
 
 	efa_rdm_ep = container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid.fid);
-	assert(len <= efa_rdm_ep->inject_msg_size);
+	assert(len <= efa_rdm_ep->base_ep.inject_msg_size);
 
 	peer = efa_rdm_ep_get_peer(efa_rdm_ep, dest_addr);
 	assert(peer);
@@ -492,7 +492,7 @@ ssize_t efa_rdm_msg_tsend(struct fid_ep *ep_fid, const void *buf, size_t len,
 	int ret;
 
 	efa_rdm_ep = container_of(ep_fid, struct efa_rdm_ep, base_ep.util_ep.ep_fid.fid);
-	assert(len <= efa_rdm_ep->max_msg_size);
+	assert(len <= efa_rdm_ep->base_ep.max_msg_size);
 
 	ret = efa_rdm_attempt_to_sync_memops(efa_rdm_ep, (void *)buf, desc);
 	if (ret)
@@ -525,7 +525,7 @@ ssize_t efa_rdm_msg_tsenddata(struct fid_ep *ep_fid, const void *buf, size_t len
 	int ret;
 
 	efa_rdm_ep = container_of(ep_fid, struct efa_rdm_ep, base_ep.util_ep.ep_fid.fid);
-	assert(len <= efa_rdm_ep->max_msg_size);
+	assert(len <= efa_rdm_ep->base_ep.max_msg_size);
 
 	ret = efa_rdm_attempt_to_sync_memops(efa_rdm_ep, (void *)buf, desc);
 	if (ret)

--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -1509,7 +1509,7 @@ int efa_rdm_ope_post_remote_write(struct efa_rdm_ope *ope)
 
 		if (ope->fi_flags & FI_INJECT) {
 			assert(ope->iov_count == 1);
-			assert(ope->total_len <= ep->inject_rma_size);
+			assert(ope->total_len <= ep->base_ep.inject_rma_size);
 			copied = efa_rdm_pke_copy_from_hmem_iov(
 				ope->desc[iov_idx], pkt_entry, ope,
 				sizeof(struct efa_rdm_rma_context_pkt), 0,

--- a/prov/efa/src/rdm/efa_rdm_rma.c
+++ b/prov/efa/src/rdm/efa_rdm_rma.c
@@ -292,7 +292,7 @@ ssize_t efa_rdm_rma_read(struct fid_ep *ep, void *buf, size_t len, void *desc,
 	int err;
 
 	efa_rdm_ep = container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid.fid);
-	assert(len <= efa_rdm_ep->max_rma_size);
+	assert(len <= efa_rdm_ep->base_ep.max_rma_size);
 	err = efa_rdm_ep_cap_check_rma(efa_rdm_ep);
 	if (err)
 		return err;
@@ -560,7 +560,7 @@ ssize_t efa_rdm_rma_write(struct fid_ep *ep, const void *buf, size_t len, void *
 	int err;
 
 	efa_rdm_ep = container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid.fid);
-	assert(len <= efa_rdm_ep->max_rma_size);
+	assert(len <= efa_rdm_ep->base_ep.max_rma_size);
 	err = efa_rdm_ep_cap_check_rma(efa_rdm_ep);
 	if (err)
 		return err;
@@ -595,7 +595,7 @@ ssize_t efa_rdm_rma_writedata(struct fid_ep *ep, const void *buf, size_t len,
 	int err;
 
 	efa_rdm_ep = container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid.fid);
-	assert(len <= efa_rdm_ep->max_rma_size);
+	assert(len <= efa_rdm_ep->base_ep.max_rma_size);
 	err = efa_rdm_ep_cap_check_rma(efa_rdm_ep);
 	if (err)
 		return err;
@@ -642,7 +642,7 @@ ssize_t efa_rdm_rma_inject_write(struct fid_ep *ep, const void *buf, size_t len,
 	int err;
 
 	efa_rdm_ep = container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid.fid);
-	assert(len <= efa_rdm_ep->inject_rma_size);
+	assert(len <= efa_rdm_ep->base_ep.inject_rma_size);
 	err = efa_rdm_ep_cap_check_rma(efa_rdm_ep);
 	if (err)
 		return err;
@@ -679,7 +679,7 @@ ssize_t efa_rdm_rma_inject_writedata(struct fid_ep *ep, const void *buf, size_t 
 	int err;
 
 	efa_rdm_ep = container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid.fid);
-	assert(len <= efa_rdm_ep->inject_rma_size);
+	assert(len <= efa_rdm_ep->base_ep.inject_rma_size);
 	err = efa_rdm_ep_cap_check_rma(efa_rdm_ep);
 	if (err)
 		return err;

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -959,7 +959,7 @@ static void test_efa_rdm_ep_use_zcpy_rx_impl(struct efa_resource *resource,
 	assert_int_equal(fi_setopt(&resource->ep->fid, FI_OPT_ENDPOINT, FI_OPT_SHARED_MEMORY_PERMITTED,
 			&shm_permitted, sizeof shm_permitted), 0);
 
-	assert_true(ep->max_msg_size == max_msg_size);
+	assert_true(ep->base_ep.max_msg_size == max_msg_size);
 
 	/* Enable EP */
 	assert_int_equal(fi_enable(resource->ep), 0);
@@ -968,11 +968,11 @@ static void test_efa_rdm_ep_use_zcpy_rx_impl(struct efa_resource *resource,
 
 	assert_int_equal(fi_getopt(&resource->ep->fid, FI_OPT_ENDPOINT, FI_OPT_INJECT_MSG_SIZE,
 			&inject_msg_size, &(size_t){sizeof inject_msg_size}), 0);
-	assert_int_equal(ep->inject_msg_size, inject_msg_size);
+	assert_int_equal(ep->base_ep.inject_msg_size, inject_msg_size);
 
 	assert_int_equal(fi_getopt(&resource->ep->fid, FI_OPT_ENDPOINT, FI_OPT_INJECT_RMA_SIZE,
 			&inject_rma_size, &(size_t){sizeof inject_rma_size}), 0);
-	assert_int_equal(ep->inject_rma_size, inject_rma_size);
+	assert_int_equal(ep->base_ep.inject_rma_size, inject_rma_size);
 
 	if (expected_use_zcpy_rx) {
 		assert_int_equal(inject_msg_size, efa_rdm_ep_domain(ep)->device->efa_attr.inline_buf_size);


### PR DESCRIPTION
Move these fields to base ep so they can be accessed by efa-raw.