### PR TITLE
xpmem: Cleanup xpmem before monitors

### DIFF
--- a/src/fabric.c
+++ b/src/fabric.c
@@ -1030,9 +1030,9 @@ FI_DESTRUCTOR(fi_fini(void))
 	}
 
 	ofi_free_filter(&prov_filter);
+	ofi_shm_p2p_cleanup();
 	ofi_monitors_cleanup();
 	ofi_hmem_cleanup();
-	ofi_shm_p2p_cleanup();
 	ofi_hook_fini();
 	ofi_mem_fini();
 	fi_log_fini();


### PR DESCRIPTION
Since xpmem installs memory monitors, these need to be cleaned up before cleaning up the monitors to avoid an assert in debug mode.