### PR TITLE
prov/efa: Ensure rx_readcopy_pkt_pool exists before cloning pkt_entry

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -1211,6 +1211,11 @@ ssize_t efa_rdm_txe_prepare_local_read_pkt_entry(struct efa_rdm_ope *txe)
 	       pkt_entry->alloc_type == EFA_RDM_PKE_FROM_UNEXP_POOL ||
 	       pkt_entry->alloc_type == EFA_RDM_PKE_FROM_EFA_RX_POOL);
 
+	if (!txe->ep->rx_readcopy_pkt_pool) {
+		EFA_WARN(FI_LOG_CQ, "readcopy pkt pool does not exist for cloning pkts!");
+		return -FI_EAGAIN;
+	}
+
 	pkt_entry_copy = efa_rdm_pke_clone(pkt_entry,
 					   txe->ep->rx_readcopy_pkt_pool,
 					   EFA_RDM_PKE_FROM_READ_COPY_POOL);


### PR DESCRIPTION
`rx_readcopy_pkt_pool` is not always created in all code paths, so I believe it could sometimes be `null`.

I am trying to trace down a segfault that seems to be related to this code (using libfabric v1.22.0):
```
(gdb) info symbol 0x89ffe
efa_rdm_msg_trecv + 126 in section .text of /usr/lib/debug/.build-id/a8/d32057bb67d88dfda215a8028d0359d862b601.debug
(gdb) info symbol 0x89c36
efa_rdm_msg_generic_recv + 326 in section .text of /usr/lib/debug/.build-id/a8/d32057bb67d88dfda215a8028d0359d862b601.debug
(gdb) info symbol 0x47ef7
util_srx_generic_trecv + 167 in section .text of /usr/lib/debug/.build-id/a8/d32057bb67d88dfda215a8028d0359d862b601.debug
(gdb) info symbol 0x98c4c
efa_rdm_srx_start + 44 in section .text of /usr/lib/debug/.build-id/a8/d32057bb67d88dfda215a8028d0359d862b601.debug
(gdb) info symbol 0x8d98a
efa_rdm_pke_proc_matched_rtm + 298 in section .text of /usr/lib/debug/.build-id/a8/d32057bb67d88dfda215a8028d0359d862b601.debug
(gdb) info symbol 0x8bcd6
efa_rdm_pke_copy_payload_to_ope + 1494 in section .text of /usr/lib/debug/.build-id/a8/d32057bb67d88dfda215a8028d0359d862b601.debug
(gdb) info symbol 0x95979
efa_rdm_rxe_post_local_read_or_queue + 345 in section .text of /usr/lib/debug/.build-id/a8/d32057bb67d88dfda215a8028d0359d862b601.debug
(gdb) info symbol 0x95706
efa_rdm_ope_post_remote_read_or_queue + 38 in section .text of /usr/lib/debug/.build-id/a8/d32057bb67d88dfda215a8028d0359d862b601.debug
(gdb) info symbol 0x94ff1
efa_rdm_ope_post_read + 1009 in section .text of /usr/lib/debug/.build-id/a8/d32057bb67d88dfda215a8028d0359d862b601.debug
(gdb) info symbol 0x8a786
efa_rdm_pke_clone + 38 in section .text of /usr/lib/debug/.build-id/a8/d32057bb67d88dfda215a8028d0359d862b601.debug
(gdb) info symbol 0x8a4d4
efa_rdm_pke_alloc + 4 in section .text of /usr/lib/debug/.build-id/a8/d32057bb67d88dfda215a8028d0359d862b601.debug
```

The stack trace seems to enter the `efa_rdm_pke_clone` in `efa_rdm_txe_prepare_local_read_pkt_entry`. The offending instruction in `efa_rdm_pke_alloc` seems to be
```asm
0x8a4d4:	mov    (%rsi),%rax
```
where I believe `%rsi` is `struct ofi_bufpool *pkt_pool`, so I believe some part of the code is trying to dereference this object, which is null.

I could have easily made a mistake in my analysis here, so any corrections or suggestions are very welcome.