### PR TITLE
[v1.22.x] prov/efa: Fix the read_bad_recv_status unit test

### DIFF
--- a/prov/efa/test/efa_unit_test_cq.c
+++ b/prov/efa/test/efa_unit_test_cq.c
@@ -319,6 +319,14 @@ void test_ibv_cq_ex_read_bad_recv_status(struct efa_resource **state)
 	 */
 	efa_rdm_cq->ibv_cq.ibv_cq_ex->wr_id = (uintptr_t)pkt_entry;
 	efa_rdm_cq->ibv_cq.ibv_cq_ex->status = IBV_WC_GENERAL_ERR;
+
+#if HAVE_CAPS_UNSOLICITED_WRITE_RECV
+	if (efa_rdm_use_unsolicited_write_recv()) {
+		efadv_cq_from_ibv_cq_ex(efa_rdm_cq->ibv_cq.ibv_cq_ex)->wc_is_unsolicited = &efa_mock_efadv_wc_is_unsolicited;
+		will_return(efa_mock_efadv_wc_is_unsolicited, false);
+	}
+#endif
+
 	ret = fi_cq_read(resource->cq, &cq_entry, 1);
 	assert_int_equal(ret, -FI_EAGAIN);
 


### PR DESCRIPTION
backport https://github.com/ofiwg/libfabric/pull/10556