### PR TITLE
Make util_ns fileds: run and is_initialized atomics

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -1243,8 +1243,8 @@ struct util_ns {
 	size_t		name_len;
 	size_t		service_len;
 
-	int		run;
-	int		is_initialized;
+	ofi_atomic32_t	run;
+	ofi_atomic32_t	is_initialized;
 	ofi_atomic32_t	ref;
 
 	ofi_ns_service_cmp_func_t	service_cmp;


### PR DESCRIPTION
Values of util_ns fields can be read/write in parallel from multiple threads. Making them atomics secures these kind of access.

Signed-off-by: Dariusz Sciebura <dariusz.sciebura@gmail.com>