### PR TITLE
fabtests/pytest/efa: Avoid duiplicate completion semantic for RMA test

### DIFF
--- a/fabtests/pytest/efa/conftest.py
+++ b/fabtests/pytest/efa/conftest.py
@@ -28,10 +28,11 @@ def rma_operation_type(request):
     return request.param
 
 @pytest.fixture(scope="module")
-def check_rma_bw_memory_type(memory_type, rma_operation_type):
+def rma_bw_memory_type(memory_type, rma_operation_type):
     is_test_bi_dir = False if rma_operation_type == "writedata" else True
     if is_test_bi_dir and (memory_type not in [_.values[0] for _ in memory_type_list_bi_dir]):
         pytest.skip("Duplicated memory type for bi-directional test")
+    return memory_type
 
 
 @pytest.fixture(scope="module", params=["r:0,4,64",

--- a/fabtests/pytest/efa/test_rma_bw.py
+++ b/fabtests/pytest/efa/test_rma_bw.py
@@ -7,15 +7,15 @@ import copy
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rma_bw(cmdline_args, iteration_type, rma_operation_type, completion_semantic, rma_bw_memory_type):
+def test_rma_bw(cmdline_args, iteration_type, rma_operation_type, rma_bw_completion_semantic, rma_bw_memory_type):
     command = "fi_rma_bw -e rdm"
     command = command + " -o " + rma_operation_type + " " + perf_progress_model_cli
     # rma_bw test with data verification takes longer to finish
     timeout = max(540, cmdline_args.timeout)
-    efa_run_client_server_test(cmdline_args, command, iteration_type, completion_semantic, rma_bw_memory_type, "all", timeout=timeout)
+    efa_run_client_server_test(cmdline_args, command, iteration_type, rma_bw_completion_semantic, rma_bw_memory_type, "all", timeout=timeout)
 
 @pytest.mark.parametrize("env_vars", [["FI_EFA_TX_SIZE=64"], ["FI_EFA_RX_SIZE=64"], ["FI_EFA_TX_SIZE=64", "FI_EFA_RX_SIZE=64"]])
-def test_rma_bw_small_tx_rx(cmdline_args, rma_operation_type, completion_semantic, rma_bw_memory_type, env_vars):
+def test_rma_bw_small_tx_rx(cmdline_args, rma_operation_type, rma_bw_completion_semantic, rma_bw_memory_type, env_vars):
     cmdline_args_copy = copy.copy(cmdline_args)
     for env_var in env_vars:
         cmdline_args_copy.append_environ(env_var)
@@ -24,24 +24,24 @@ def test_rma_bw_small_tx_rx(cmdline_args, rma_operation_type, completion_semanti
     command = command + " -o " + rma_operation_type + " " + perf_progress_model_cli
     # rma_bw test with data verification takes longer to finish
     timeout = max(540, cmdline_args_copy.timeout)
-    efa_run_client_server_test(cmdline_args_copy, command, "short", completion_semantic, rma_bw_memory_type, "all", timeout=timeout)
+    efa_run_client_server_test(cmdline_args_copy, command, "short", rma_bw_completion_semantic, rma_bw_memory_type, "all", timeout=timeout)
 
 @pytest.mark.functional
-def test_rma_bw_range(cmdline_args, rma_operation_type, completion_semantic, message_size, rma_bw_memory_type):
+def test_rma_bw_range(cmdline_args, rma_operation_type, rma_bw_completion_semantic, message_size, rma_bw_memory_type):
     command = "fi_rma_bw -e rdm"
     command = command + " -o " + rma_operation_type
     # rma_bw test with data verification takes longer to finish
     timeout = max(540, cmdline_args.timeout)
-    efa_run_client_server_test(cmdline_args, command, "short", completion_semantic, rma_bw_memory_type, message_size, timeout=timeout)
+    efa_run_client_server_test(cmdline_args, command, "short", rma_bw_completion_semantic, rma_bw_memory_type, message_size, timeout=timeout)
 
 
 @pytest.mark.functional
-def test_rma_bw_range_no_inject(cmdline_args, rma_operation_type, completion_semantic, inject_message_size):
+def test_rma_bw_range_no_inject(cmdline_args, rma_operation_type, rma_bw_completion_semantic, inject_message_size):
     command = "fi_rma_bw -e rdm -j 0"
     command = command + " -o " + rma_operation_type
     # rma_bw test with data verification takes longer to finish
     timeout = max(540, cmdline_args.timeout)
-    efa_run_client_server_test(cmdline_args, command, "short", completion_semantic, "host_to_host", inject_message_size, timeout=timeout)
+    efa_run_client_server_test(cmdline_args, command, "short", rma_bw_completion_semantic, "host_to_host", inject_message_size, timeout=timeout)
 
 
 # This test is run in serial mode because it takes a lot of memory
@@ -49,22 +49,22 @@ def test_rma_bw_range_no_inject(cmdline_args, rma_operation_type, completion_sem
 @pytest.mark.functional
 # TODO Add "writedata", "write" back in when EFA firmware bug is fixed
 @pytest.mark.parametrize("operation_type", ["read"])
-def test_rma_bw_1G(cmdline_args, operation_type, completion_semantic):
+def test_rma_bw_1G(cmdline_args, operation_type, rma_bw_completion_semantic):
     # Default window size is 64 resulting in 128GB being registered, which
     # exceeds max number of registered host pages
     timeout = max(540, cmdline_args.timeout)
     command = "fi_rma_bw -e rdm -W 1"
     command = command + " -o " + operation_type
     efa_run_client_server_test(cmdline_args, command, 2,
-                               completion_semantic=completion_semantic, message_size=1073741824,
+                               completion_semantic=rma_bw_completion_semantic, message_size=1073741824,
                                memory_type="host_to_host", warmup_iteration_type=0, timeout=timeout)
 
 @pytest.mark.functional
 @pytest.mark.parametrize("operation_type", ["writedata", "write"])
-def test_rma_bw_use_fi_more(cmdline_args, operation_type, completion_semantic, inject_message_size):
+def test_rma_bw_use_fi_more(cmdline_args, operation_type, rma_bw_completion_semantic, inject_message_size):
     command = "fi_rma_bw -e rdm -j 0 --use-fi-more"
     command = command + " -o " + operation_type
     # rma_bw test with data verification takes longer to finish
     timeout = max(540, cmdline_args.timeout)
-    efa_run_client_server_test(cmdline_args, command, "short", completion_semantic,
+    efa_run_client_server_test(cmdline_args, command, "short", rma_bw_completion_semantic,
                                "host_to_host", inject_message_size, timeout=timeout)

--- a/fabtests/pytest/efa/test_rma_bw.py
+++ b/fabtests/pytest/efa/test_rma_bw.py
@@ -7,15 +7,15 @@ import copy
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rma_bw(cmdline_args, iteration_type, rma_operation_type, completion_semantic, memory_type, check_rma_bw_memory_type):
+def test_rma_bw(cmdline_args, iteration_type, rma_operation_type, completion_semantic, rma_bw_memory_type):
     command = "fi_rma_bw -e rdm"
     command = command + " -o " + rma_operation_type + " " + perf_progress_model_cli
     # rma_bw test with data verification takes longer to finish
     timeout = max(540, cmdline_args.timeout)
-    efa_run_client_server_test(cmdline_args, command, iteration_type, completion_semantic, memory_type, "all", timeout=timeout)
+    efa_run_client_server_test(cmdline_args, command, iteration_type, completion_semantic, rma_bw_memory_type, "all", timeout=timeout)
 
 @pytest.mark.parametrize("env_vars", [["FI_EFA_TX_SIZE=64"], ["FI_EFA_RX_SIZE=64"], ["FI_EFA_TX_SIZE=64", "FI_EFA_RX_SIZE=64"]])
-def test_rma_bw_small_tx_rx(cmdline_args, rma_operation_type, completion_semantic, memory_type, env_vars, check_rma_bw_memory_type):
+def test_rma_bw_small_tx_rx(cmdline_args, rma_operation_type, completion_semantic, rma_bw_memory_type, env_vars):
     cmdline_args_copy = copy.copy(cmdline_args)
     for env_var in env_vars:
         cmdline_args_copy.append_environ(env_var)
@@ -24,15 +24,15 @@ def test_rma_bw_small_tx_rx(cmdline_args, rma_operation_type, completion_semanti
     command = command + " -o " + rma_operation_type + " " + perf_progress_model_cli
     # rma_bw test with data verification takes longer to finish
     timeout = max(540, cmdline_args_copy.timeout)
-    efa_run_client_server_test(cmdline_args_copy, command, "short", completion_semantic, memory_type, "all", timeout=timeout)
+    efa_run_client_server_test(cmdline_args_copy, command, "short", completion_semantic, rma_bw_memory_type, "all", timeout=timeout)
 
 @pytest.mark.functional
-def test_rma_bw_range(cmdline_args, rma_operation_type, completion_semantic, message_size, memory_type, check_rma_bw_memory_type):
+def test_rma_bw_range(cmdline_args, rma_operation_type, completion_semantic, message_size, rma_bw_memory_type):
     command = "fi_rma_bw -e rdm"
     command = command + " -o " + rma_operation_type
     # rma_bw test with data verification takes longer to finish
     timeout = max(540, cmdline_args.timeout)
-    efa_run_client_server_test(cmdline_args, command, "short", completion_semantic, memory_type, message_size, timeout=timeout)
+    efa_run_client_server_test(cmdline_args, command, "short", completion_semantic, rma_bw_memory_type, message_size, timeout=timeout)
 
 
 @pytest.mark.functional

--- a/fabtests/pytest/efa/test_rma_pingpong.py
+++ b/fabtests/pytest/efa/test_rma_pingpong.py
@@ -14,23 +14,23 @@ def rma_pingpong_message_size(request):
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rma_pingpong(cmdline_args, iteration_type, operation_type, completion_semantic, memory_type_bi_dir):
+def test_rma_pingpong(cmdline_args, iteration_type, operation_type, rma_bw_completion_semantic, memory_type_bi_dir):
     command = "fi_rma_pingpong -e rdm"
     command = command + " -o " + operation_type + " " + perf_progress_model_cli
-    efa_run_client_server_test(cmdline_args, command, iteration_type, completion_semantic, memory_type_bi_dir, "all")
+    efa_run_client_server_test(cmdline_args, command, iteration_type, rma_bw_completion_semantic, memory_type_bi_dir, "all")
 
 
 @pytest.mark.functional
 @pytest.mark.parametrize("operation_type", ["writedata"])
-def test_rma_pingpong_range(cmdline_args, operation_type, completion_semantic, rma_pingpong_message_size, memory_type_bi_dir):
+def test_rma_pingpong_range(cmdline_args, operation_type, rma_bw_completion_semantic, rma_pingpong_message_size, memory_type_bi_dir):
     command = "fi_rma_pingpong -e rdm"
     command = command + " -o " + operation_type
-    efa_run_client_server_test(cmdline_args, command, "short", completion_semantic, memory_type_bi_dir, rma_pingpong_message_size)
+    efa_run_client_server_test(cmdline_args, command, "short", rma_bw_completion_semantic, memory_type_bi_dir, rma_pingpong_message_size)
 
 
 @pytest.mark.functional
 @pytest.mark.parametrize("operation_type", ["writedata"])
-def test_rma_pingpong_range_no_inject(cmdline_args, operation_type, completion_semantic, rma_pingpong_message_size, memory_type_bi_dir):
+def test_rma_pingpong_range_no_inject(cmdline_args, operation_type, rma_bw_completion_semantic, rma_pingpong_message_size, memory_type_bi_dir):
     command = "fi_rma_pingpong -e rdm -j 0"
     command = command + " -o " + operation_type
-    efa_run_client_server_test(cmdline_args, command, "short", completion_semantic, memory_type_bi_dir, rma_pingpong_message_size)
+    efa_run_client_server_test(cmdline_args, command, "short", rma_bw_completion_semantic, memory_type_bi_dir, rma_pingpong_message_size)


### PR DESCRIPTION
For fi_read, there is no difference between DC and non-DC as it's not
a transmission. For write and writedata, if device support rdma-write,
all the transmissions are DC already.


Also merge memory_type and check_rma_bw_memory_type to clean up the code.

