### PR TITLE
prov/cxi: synchronous fi_close on collective multicast

### DIFF
--- a/prov/cxi/include/cxip.h
+++ b/prov/cxi/include/cxip.h
@@ -2957,6 +2957,9 @@ struct cxip_coll_mc {
 	int next_red_id;			// next available red_id
 	int max_red_id;				// limit total concurrency
 	int seqno;				// rolling seqno for packets
+	int close_state;			// the state of the close operation
+	bool has_closed;			// true after a mc close call
+	bool has_error;				// true if any error
 	bool is_multicast;			// true if multicast address
 	bool arm_disable;			// arm-disable for testing
 	bool retry_disable;			// retry-disable for testing


### PR DESCRIPTION
The fi_close() operation manages its internal state and return FI_SUCCESS, or a fatal error code on error.