### PR TITLE
prov/lnx: Convert peer table to use buffer pools

### DIFF
--- a/prov/lnx/src/lnx_ops.c
+++ b/prov/lnx/src/lnx_ops.c
@@ -416,7 +416,7 @@ ssize_t lnx_trecv(struct fid_ep *ep, void *buf, size_t len, void *desc,
 	 * multiple endpoints. Each endpoint has its own fi_addr_t which is
 	 * core provider specific.
 	 */
-	lp = lnx_get_peer(peer_tbl->lpt_entries, src_addr);
+	lp = lnx_av_lookup_addr(peer_tbl, src_addr);
 	if (lp) {
 		rc = lnx_select_recv_pathway(lp, lep->le_domain, desc, &cep,
 					     &core_addr, &iov, 1, &mre, &mem_desc);
@@ -464,7 +464,7 @@ ssize_t lnx_trecvv(struct fid_ep *ep, const struct iovec *iov, void **desc,
 	peer_tbl = lep->le_peer_tbl;
 	lnx_get_core_desc(*desc, &mem_desc);
 
-	lp = lnx_get_peer(peer_tbl->lpt_entries, src_addr);
+	lp = lnx_av_lookup_addr(peer_tbl, src_addr);
 	if (lp) {
 		rc = lnx_select_recv_pathway(lp, lep->le_domain, *desc, &cep,
 					     &core_addr, iov, count, &mre, &mem_desc);
@@ -509,7 +509,7 @@ ssize_t lnx_trecvmsg(struct fid_ep *ep, const struct fi_msg_tagged *msg,
 
 	peer_tbl = lep->le_peer_tbl;
 
-	lp = lnx_get_peer(peer_tbl->lpt_entries, msg->addr);
+	lp = lnx_av_lookup_addr(peer_tbl, msg->addr);
 	if (lp) {
 		rc = lnx_select_recv_pathway(lp, lep->le_domain, *msg->desc,
 					&cep, &core_addr, msg->msg_iov,
@@ -549,6 +549,7 @@ ssize_t lnx_tsend(struct fid_ep *ep, const void *buf, size_t len, void *desc,
 {
 	int rc;
 	struct lnx_ep *lep;
+	struct lnx_peer *lp;
 	struct local_prov_ep *cep;
 	fi_addr_t core_addr;
 	struct lnx_peer_table *peer_tbl;
@@ -562,8 +563,8 @@ ssize_t lnx_tsend(struct fid_ep *ep, const void *buf, size_t len, void *desc,
 
 	peer_tbl = lep->le_peer_tbl;
 
-	rc = lnx_select_send_pathway(peer_tbl->lpt_entries[dest_addr],
-				     lep->le_domain, desc, &cep,
+	lp = lnx_av_lookup_addr(peer_tbl, dest_addr);
+	rc = lnx_select_send_pathway(lp, lep->le_domain, desc, &cep,
 				     &core_addr, &iov, 1, &mre, &mem_desc, NULL);
 	if (rc)
 		return rc;
@@ -585,6 +586,7 @@ ssize_t lnx_tsendv(struct fid_ep *ep, const struct iovec *iov, void **desc,
 {
 	int rc;
 	struct lnx_ep *lep;
+	struct lnx_peer *lp;
 	struct local_prov_ep *cep;
 	fi_addr_t core_addr;
 	struct lnx_peer_table *peer_tbl;
@@ -597,8 +599,8 @@ ssize_t lnx_tsendv(struct fid_ep *ep, const struct iovec *iov, void **desc,
 
 	peer_tbl = lep->le_peer_tbl;
 
-	rc = lnx_select_send_pathway(peer_tbl->lpt_entries[dest_addr],
-				lep->le_domain, (desc) ? *desc : NULL, &cep,
+	lp = lnx_av_lookup_addr(peer_tbl, dest_addr);
+	rc = lnx_select_send_pathway(lp, lep->le_domain, (desc) ? *desc : NULL, &cep,
 				&core_addr, iov, count, &mre, &mem_desc, NULL);
 	if (rc)
 		return rc;
@@ -619,6 +621,7 @@ ssize_t lnx_tsendmsg(struct fid_ep *ep, const struct fi_msg_tagged *msg,
 {
 	int rc;
 	struct lnx_ep *lep;
+	struct lnx_peer *lp;
 	struct local_prov_ep *cep;
 	fi_addr_t core_addr;
 	struct lnx_peer_table *peer_tbl;
@@ -632,8 +635,8 @@ ssize_t lnx_tsendmsg(struct fid_ep *ep, const struct fi_msg_tagged *msg,
 
 	peer_tbl = lep->le_peer_tbl;
 
-	rc = lnx_select_send_pathway(peer_tbl->lpt_entries[msg->addr],
-				lep->le_domain,
+	lp = lnx_av_lookup_addr(peer_tbl, msg->addr);
+	rc = lnx_select_send_pathway(lp, lep->le_domain,
 				(msg->desc) ? *msg->desc : NULL, &cep,
 				&core_addr, msg->msg_iov,
 				msg->iov_count, &mre, &mem_desc, NULL);
@@ -661,6 +664,7 @@ ssize_t lnx_tinject(struct fid_ep *ep, const void *buf, size_t len,
 {
 	int rc;
 	struct lnx_ep *lep;
+	struct lnx_peer *lp;
 	struct local_prov_ep *cep;
 	fi_addr_t core_addr;
 	struct lnx_peer_table *peer_tbl;
@@ -672,8 +676,8 @@ ssize_t lnx_tinject(struct fid_ep *ep, const void *buf, size_t len,
 
 	peer_tbl = lep->le_peer_tbl;
 
-	rc = lnx_select_send_pathway(peer_tbl->lpt_entries[dest_addr],
-				lep->le_domain, NULL, &cep,
+	lp = lnx_av_lookup_addr(peer_tbl, dest_addr);
+	rc = lnx_select_send_pathway(lp, lep->le_domain, NULL, &cep,
 				&core_addr, NULL, 0, &mre, NULL, NULL);
 	if (rc)
 		return rc;
@@ -695,6 +699,7 @@ ssize_t lnx_tsenddata(struct fid_ep *ep, const void *buf, size_t len, void *desc
 {
 	int rc;
 	struct lnx_ep *lep;
+	struct lnx_peer *lp;
 	struct local_prov_ep *cep;
 	fi_addr_t core_addr;
 	struct lnx_peer_table *peer_tbl;
@@ -708,8 +713,8 @@ ssize_t lnx_tsenddata(struct fid_ep *ep, const void *buf, size_t len, void *desc
 
 	peer_tbl = lep->le_peer_tbl;
 
-	rc = lnx_select_send_pathway(peer_tbl->lpt_entries[dest_addr],
-				lep->le_domain, desc, &cep,
+	lp = lnx_av_lookup_addr(peer_tbl, dest_addr);
+	rc = lnx_select_send_pathway(lp, lep->le_domain, desc, &cep,
 				&core_addr, &iov, 1, &mre, &mem_desc, NULL);
 	if (rc)
 		return rc;
@@ -732,6 +737,7 @@ ssize_t lnx_tinjectdata(struct fid_ep *ep, const void *buf, size_t len,
 {
 	int rc;
 	struct lnx_ep *lep;
+	struct lnx_peer *lp;
 	struct local_prov_ep *cep;
 	fi_addr_t core_addr;
 	struct lnx_peer_table *peer_tbl;
@@ -743,8 +749,8 @@ ssize_t lnx_tinjectdata(struct fid_ep *ep, const void *buf, size_t len,
 
 	peer_tbl = lep->le_peer_tbl;
 
-	rc = lnx_select_send_pathway(peer_tbl->lpt_entries[dest_addr],
-				     lep->le_domain, NULL, &cep,
+	lp = lnx_av_lookup_addr(peer_tbl, dest_addr);
+	rc = lnx_select_send_pathway(lp, lep->le_domain, NULL, &cep,
 				     &core_addr, NULL, 0, &mre, NULL, NULL);
 	if (rc)
 		return rc;
@@ -767,6 +773,7 @@ lnx_rma_read(struct fid_ep *ep, void *buf, size_t len, void *desc,
 {
 	int rc;
 	struct lnx_ep *lep;
+	struct lnx_peer *lp;
 	struct fid_ep *core_ep;
 	struct lnx_ctx *ctx;
 	struct local_prov_ep *cep;
@@ -783,8 +790,8 @@ lnx_rma_read(struct fid_ep *ep, void *buf, size_t len, void *desc,
 
 	peer_tbl = lep->le_peer_tbl;
 
-	rc = lnx_select_send_pathway(peer_tbl->lpt_entries[src_addr],
-				     lep->le_domain, desc, &cep,
+	lp = lnx_av_lookup_addr(peer_tbl, src_addr);
+	rc = lnx_select_send_pathway(lp, lep->le_domain, desc, &cep,
 				     &core_addr, &iov, 1, &mre, &mem_desc, &rkey);
 	if (rc)
 		goto out;
@@ -810,6 +817,7 @@ lnx_rma_write(struct fid_ep *ep, const void *buf, size_t len, void *desc,
 {
 	int rc;
 	struct lnx_ep *lep;
+	struct lnx_peer *lp;
 	struct fid_ep *core_ep;
 	struct lnx_ctx *ctx;
 	struct local_prov_ep *cep;
@@ -826,9 +834,9 @@ lnx_rma_write(struct fid_ep *ep, const void *buf, size_t len, void *desc,
 
 	peer_tbl = lep->le_peer_tbl;
 
-	rc = lnx_select_send_pathway(peer_tbl->lpt_entries[dest_addr],
-				     lep->le_domain, desc, &cep,
-				&core_addr, &iov, 1, &mre, &mem_desc, &rkey);
+	lp = lnx_av_lookup_addr(peer_tbl, dest_addr);
+	rc = lnx_select_send_pathway(lp, lep->le_domain, desc, &cep,
+				     &core_addr, &iov, 1, &mre, &mem_desc, &rkey);
 	if (rc)
 		goto out;
 
@@ -856,6 +864,7 @@ lnx_atomic_write(struct fid_ep *ep,
 {
 	int rc;
 	struct lnx_ep *lep;
+	struct lnx_peer *lp;
 	struct fid_ep *core_ep;
 	struct lnx_ctx *ctx;
 	struct local_prov_ep *cep;
@@ -872,8 +881,8 @@ lnx_atomic_write(struct fid_ep *ep,
 
 	peer_tbl = lep->le_peer_tbl;
 
-	rc = lnx_select_send_pathway(peer_tbl->lpt_entries[dest_addr],
-				lep->le_domain, desc, &cep,
+	lp = lnx_av_lookup_addr(peer_tbl, dest_addr);
+	rc = lnx_select_send_pathway(lp, lep->le_domain, desc, &cep,
 				&core_addr, &iov, 1, &mre, &mem_desc, &rkey);
 	if (rc)
 		goto out;
@@ -902,6 +911,7 @@ lnx_atomic_readwrite(struct fid_ep *ep,
 {
 	int rc;
 	struct lnx_ep *lep;
+	struct lnx_peer *lp;
 	struct fid_ep *core_ep;
 	struct lnx_ctx *ctx;
 	struct local_prov_ep *cep;
@@ -918,9 +928,10 @@ lnx_atomic_readwrite(struct fid_ep *ep,
 
 	peer_tbl = lep->le_peer_tbl;
 
-	rc = lnx_select_send_pathway(peer_tbl->lpt_entries[dest_addr],
-				lep->le_domain, result_desc, &cep, &core_addr, &iov, 1,
-				&mre, &mem_desc, &rkey);
+	lp = lnx_av_lookup_addr(peer_tbl, dest_addr);
+	rc = lnx_select_send_pathway(lp, lep->le_domain, result_desc,
+				     &cep, &core_addr, &iov, 1,
+				     &mre, &mem_desc, &rkey);
 	if (rc)
 		goto out;
 
@@ -950,6 +961,7 @@ lnx_atomic_compwrite(struct fid_ep *ep,
 {
 	int rc;
 	struct lnx_ep *lep;
+	struct lnx_peer *lp;
 	struct fid_ep *core_ep;
 	struct lnx_ctx *ctx;
 	struct local_prov_ep *cep;
@@ -966,9 +978,10 @@ lnx_atomic_compwrite(struct fid_ep *ep,
 
 	peer_tbl = lep->le_peer_tbl;
 
-	rc = lnx_select_send_pathway(peer_tbl->lpt_entries[dest_addr],
-				lep->le_domain, result_desc, &cep, &core_addr, &iov, 1,
-				&mre, &mem_desc, &rkey);
+	lp = lnx_av_lookup_addr(peer_tbl, dest_addr);
+	rc = lnx_select_send_pathway(lp, lep->le_domain, result_desc, &cep,
+				     &core_addr, &iov, 1,
+				     &mre, &mem_desc, &rkey);
 	if (rc)
 		goto out;
 


### PR DESCRIPTION
Convert peer table to use buffer pools in order to utilize the built-in capabilities of expanding the table as more peers are added dynamically.

The peer table is protected by a read/write lock. Locking/unlocking callbacks are set only if needed.