### PR TITLE
[v1.22.x] include/windows/osd.h: remove duplicate strtok_r definition

### DIFF
--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -930,11 +930,6 @@ static inline char *strcasestr(const char *haystack, const char *needle)
 	return pos;
 }
 
-static inline char *strtok_r(char *str, const char *delimiters, char **saveptr)
-{
-	return strtok_s(str, delimiters, saveptr);
-}
-
 #ifndef _SC_PAGESIZE
 #define _SC_PAGESIZE	0
 #endif


### PR DESCRIPTION
The duplicate definition was causing hangs due to a loop

Cherry-pick 6f245834b156763b8ad3f480cf0708cfde5df5c1