### PR TITLE
prov/ucx: Fix incorrect return value checking for fi_param_get()

### DIFF
--- a/prov/ucx/src/ucx_domain.c
+++ b/prov/ucx/src/ucx_domain.c
@@ -368,7 +368,7 @@ int ucx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		return -ENOMEM;
 
 	ofi_status = fi_param_get_size_t(NULL, "universe_size", &univ_size);
-	if (ofi_status) {
+	if (ofi_status == FI_SUCCESS) {
 		params.estimated_num_eps = univ_size;
 		params.field_mask |= UCP_PARAM_FIELD_ESTIMATED_NUM_EPS;
 	}

--- a/prov/ucx/src/ucx_fabric.c
+++ b/prov/ucx/src/ucx_fabric.c
@@ -87,7 +87,7 @@ static char* ucx_local_host_resolve()
 	char *result = NULL;
 
 	status = fi_param_get(&ucx_prov, "ns_iface", &iface);
-	if (!status)
+	if (status != FI_SUCCESS)
 		iface = NULL;
 
 	if (getifaddrs(&ifaddr) == -1) {


### PR DESCRIPTION
When reading the two runtime parameters the condition for the actions was inverted by mistake.