### PR TITLE
prov/lnx: Initialize flags to 0

### DIFF
--- a/prov/lnx/include/lnx.h
+++ b/prov/lnx/include/lnx.h
@@ -343,7 +343,7 @@ int lnx_create_mr(const struct iovec *iov, fi_addr_t addr,
 	struct fi_mr_attr attr = {};
 	struct fi_mr_attr cur_abi_attr;
 	struct ofi_mr_info info = {};
-	uint64_t flags;
+	uint64_t flags = 0;
 	int rc;
 
 	attr.iov_count = 1;


### PR DESCRIPTION
flags is allocated on the stack which might have some random values. Ensure it's initialized to 0 because if sent to SHM provider uninitialized it could cause the provider to misbehave, since it's value is being checked.