### PR TITLE
Makefile.am: Keep using libfabric.so.1 as the soname

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -223,7 +223,7 @@ src_libfabric_la_LIBADD =
 src_libfabric_la_DEPENDENCIES = libfabric.map
 
 if !EMBEDDED
-src_libfabric_la_LDFLAGS += -version-info 2:0:0
+src_libfabric_la_LDFLAGS += -version-info 27:0:26
 endif
 src_libfabric_la_LDFLAGS += -export-dynamic \
 			   $(libfabric_version_script)
@@ -450,9 +450,6 @@ nroff:
 dist-hook: libfabric.spec
 	cp libfabric.spec $(distdir)
 	perl $(top_srcdir)/config/distscript.pl "$(distdir)" "$(PACKAGE_VERSION)"
-
-install-exec-hook:
-	ln -sf libfabric.so.2 $(DESTDIR)$(libdir)/libfabric.so.1
 
 TESTS = \
 	util/fi_info


### PR DESCRIPTION
Since the ABI is still backward compatible, there is no need to bump the library major version which unnecessarily introduces incompatibilty between RPM packages due to soname change.