### PR TITLE
prov/shm,rxm,efa, fabtests: fix min multi recv size setting

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -1463,7 +1463,8 @@ int ft_enable_ep(struct fid_ep *bind_ep, struct fid_eq *bind_eq, struct fid_av *
 	}
 
 	if (opts.max_msg_size) {
-		ret = fi_setopt(&bind_ep->fid, FI_OPT_ENDPOINT, FI_OPT_MAX_MSG_SIZE, &opts.max_msg_size, sizeof opts.max_msg_size);
+		ret = fi_setopt(&bind_ep->fid, FI_OPT_ENDPOINT, FI_OPT_MAX_MSG_SIZE,
+				&opts.max_msg_size, sizeof opts.max_msg_size);
 		if (ret && ret != -FI_EOPNOTSUPP) {
 			FT_PRINTERR("fi_setopt(FI_OPT_MAX_MSG_SIZE)", ret);
 			return ret;
@@ -1481,6 +1482,15 @@ int ft_enable_ep(struct fid_ep *bind_ep, struct fid_eq *bind_eq, struct fid_av *
 				&opts.inject_size, sizeof opts.inject_size);
 		if (ret && ret != -FI_EOPNOTSUPP) {
 			FT_PRINTERR("fi_setopt(FI_OPT_INJECT_RMA_SIZE)", ret);
+			return ret;
+		}
+	}
+
+	if (opts.min_multi_recv_size) {
+		ret = fi_setopt(&bind_ep->fid, FI_OPT_ENDPOINT, FI_OPT_MIN_MULTI_RECV,
+				&opts.min_multi_recv_size, sizeof opts.min_multi_recv_size);
+		if (ret && ret != -FI_EOPNOTSUPP) {
+			FT_PRINTERR("fi_setopt(FI_OPT_MIN_MULTI_RECV_SIZE)", ret);
 			return ret;
 		}
 	}

--- a/fabtests/functional/multi_recv.c
+++ b/fabtests/functional/multi_recv.c
@@ -263,11 +263,6 @@ static int run(void)
 	if (ret)
 		return ret;
 
-	ret = fi_setopt(&ep->fid, FI_OPT_ENDPOINT, FI_OPT_MIN_MULTI_RECV,
-			&tx_size, sizeof(tx_size));
-	if (ret)
-		return ret;
-
 	ret = post_multi_recv_buffer();
 	if (ret)
 		return ret;
@@ -327,6 +322,7 @@ int main(int argc, char **argv)
 		return EIO;
 	}
 
+	opts.min_multi_recv_size = opts.transfer_size;
 	hints->caps = FI_MSG | FI_MULTI_RECV;
 	hints->mode = FI_CONTEXT;
 	hints->domain_attr->mr_mode = opts.mr_mode;

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -191,6 +191,7 @@ struct ft_opts {
 	size_t transfer_size;
 	size_t max_msg_size;
 	size_t inject_size;
+	size_t min_multi_recv_size;
 	int window_size;
 	int av_size;
 	int verbose;

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -1650,7 +1650,6 @@ static int efa_rdm_ep_setopt(fid_t fid, int level, int optname,
 {
 	struct efa_rdm_ep *efa_rdm_ep;
 	int intval, ret;
-	struct util_srx_ctx *srx;
 
 	efa_rdm_ep = container_of(fid, struct efa_rdm_ep, base_ep.util_ep.ep_fid.fid);
 
@@ -1663,8 +1662,6 @@ static int efa_rdm_ep_setopt(fid_t fid, int level, int optname,
 			return -FI_EINVAL;
 
 		efa_rdm_ep->min_multi_recv_size = *(size_t *)optval;
-		srx = util_get_peer_srx(efa_rdm_ep->peer_srx_ep)->ep_fid.fid.context;
-		srx->min_multi_recv_size = *(size_t *)optval;
 		break;
 	case FI_OPT_EFA_RNR_RETRY:
 		if (optlen != sizeof(size_t))

--- a/prov/efa/test/efa_unit_test_srx.c
+++ b/prov/efa/test/efa_unit_test_srx.c
@@ -18,21 +18,19 @@ void test_efa_srx_min_multi_recv_size(struct efa_resource **state)
         struct util_srx_ctx *srx_ctx;
         size_t min_multi_recv_size_new;
 
-        efa_unit_test_resource_construct(resource, FI_EP_RDM);
+        efa_unit_test_resource_construct_ep_not_enabled(resource, FI_EP_RDM);
 
         efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
-        srx_ctx = efa_rdm_ep_get_peer_srx_ctx(efa_rdm_ep);
-        /*
-         * After ep is enabled, the srx->min_multi_recv_size should be
-         * exactly the same with ep->min_multi_recv_size
-         */
-        assert_true(efa_rdm_ep->min_multi_recv_size == srx_ctx->min_multi_recv_size);
         /* Set a new min_multi_recv_size via setopt*/
         min_multi_recv_size_new = 1024;
         assert_int_equal(fi_setopt(&resource->ep->fid, FI_OPT_ENDPOINT, FI_OPT_MIN_MULTI_RECV,
 			&min_multi_recv_size_new, sizeof(min_multi_recv_size_new)), 0);
 
+        /* Enable EP */
+        assert_int_equal(fi_enable(resource->ep), FI_SUCCESS);
+
         /* Check whether srx->min_multi_recv_size is set correctly */
+        srx_ctx = efa_rdm_ep_get_peer_srx_ctx(efa_rdm_ep);
         assert_true(srx_ctx->min_multi_recv_size == min_multi_recv_size_new);
 }
 

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -677,6 +677,7 @@ struct rxm_ep {
 	size_t			eager_limit;
 	size_t			sar_limit;
 	size_t			tx_credit;
+	size_t			min_multi_recv_size;
 
 	struct ofi_bufpool	*rx_pool;
 	struct ofi_bufpool	*tx_pool;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -295,8 +295,8 @@ static int rxm_ep_setopt(fid_t fid, int level, int optname,
 
 	switch (optname) {
 	case FI_OPT_MIN_MULTI_RECV:
-		return rxm_ep->srx->ep_fid.ops->setopt(&rxm_ep->srx->ep_fid.fid,
-						level, optname, optval, optlen);
+		rxm_ep->min_multi_recv_size = *(size_t *)optval;
+		return ret;
 	case FI_OPT_BUFFERED_MIN:
 		if (rxm_ep->rx_pool) {
 			FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
@@ -1144,6 +1144,7 @@ static void rxm_ep_settings_init(struct rxm_ep *rxm_ep)
 
 	assert(!rxm_ep->buffered_limit);
 	rxm_ep->buffered_limit = rxm_buffer_size;
+	rxm_ep->min_multi_recv_size = rxm_buffer_size;
 
 	rxm_config_direct_send(rxm_ep);
 	rxm_ep_init_proto(rxm_ep);
@@ -1364,7 +1365,7 @@ static int rxm_ep_ctrl(struct fid *fid, int command, void *arg)
 					      util_domain.domain_fid);
 			ret = util_ep_srx_context(&domain->util_domain,
 					ep->rxm_info->rx_attr->size,
-					RXM_IOV_LIMIT, rxm_buffer_size,
+					RXM_IOV_LIMIT, ep->min_multi_recv_size,
 					&rxm_update, &ep->util_ep.lock,
 					&srx);
 			if (ret)

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -229,6 +229,7 @@ struct smr_ep {
 	struct smr_tx_fs	*tx_fs;
 	struct dlist_entry	sar_list;
 	struct dlist_entry	ipc_cpy_pend_list;
+	size_t			min_multi_recv_size;
 
 	int			ep_idx;
 	enum ofi_shm_p2p_type	p2p_type;

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -128,14 +128,12 @@ int smr_ep_setopt(fid_t fid, int level, int optname, const void *optval,
 {
 	struct smr_ep *smr_ep =
 		container_of(fid, struct smr_ep, util_ep.ep_fid);
-	struct util_srx_ctx *srx;
 
 	if (level != FI_OPT_ENDPOINT)
 		return -FI_ENOPROTOOPT;
 
 	if (optname == FI_OPT_MIN_MULTI_RECV) {
-		srx = smr_ep->srx->ep_fid.fid.context;
-		srx->min_multi_recv_size = *(size_t *)optval;
+		smr_ep->min_multi_recv_size = *(size_t *)optval;
 		return FI_SUCCESS;
 	}
 
@@ -1146,7 +1144,7 @@ static int smr_ep_ctrl(struct fid *fid, int command, void *arg)
 					      util_domain.domain_fid);
 			ret = util_ep_srx_context(&domain->util_domain,
 					ep->rx_size, SMR_IOV_LIMIT,
-					SMR_INJECT_SIZE, &smr_update,
+					ep->min_multi_recv_size, &smr_update,
 					&ep->util_ep.lock, &srx);
 			if (ret)
 				return ret;
@@ -1307,6 +1305,8 @@ int smr_endpoint(struct fid_domain *domain, struct fi_info *info,
 
 	dlist_init(&ep->sar_list);
 	dlist_init(&ep->ipc_cpy_pend_list);
+
+	ep->min_multi_recv_size = SMR_INJECT_SIZE;
 
 	ep->util_ep.ep_fid.fid.ops = &smr_ep_fi_ops;
 	ep->util_ep.ep_fid.ops = &smr_ep_ops;


### PR DESCRIPTION
Fixes #10591
