### PR TITLE
util/pingpong: close mr after ep close

### DIFF
--- a/util/pingpong.c
+++ b/util/pingpong.c
@@ -1875,12 +1875,12 @@ static void pp_free_res(struct ct_pingpong *ct)
 {
 	PP_DEBUG("Freeing resources of test suite\n");
 
-	if (ct->mr != &(ct->no_mr))
-		PP_CLOSE_FID(ct->mr);
 	PP_CLOSE_FID(ct->ep);
 	PP_CLOSE_FID(ct->pep);
 	PP_CLOSE_FID(ct->rxcq);
 	PP_CLOSE_FID(ct->txcq);
+	if (ct->mr != &(ct->no_mr))
+		PP_CLOSE_FID(ct->mr);
 	PP_CLOSE_FID(ct->av);
 	PP_CLOSE_FID(ct->eq);
 	PP_CLOSE_FID(ct->domain);


### PR DESCRIPTION
pingpong doesn't support FI_MR_ENDPOINT today,
so the mr is associated with domain instead of ep. It is unsafe to close mr before closing ep because it can cause an EBUSY error when there are outstanding recvs of the mr posted to the ep/qp. This patch fixes this issue by moving the mr close after the ep close.