### PR TITLE
contrib/intel/jenkins: Uplevel pre-build, always cleanup, update slurm partition names

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -103,6 +103,14 @@ def run_ci(stage_name, config_name) {
      """
 }
 
+def build_ci(config_name) {
+  sh """source ${CI_LOCATION}/${env.CI_MODULE}/venv/bin/activate;\
+        python run.py \
+        --output=${env.CUSTOM_WORKSPACE}/pre-build \
+        --job=${config_name}
+     """
+}
+
 def gather_logs(cluster, key, dest, source) {
   def address = "${env.USER}@${cluster}"
 
@@ -441,7 +449,7 @@ pipeline {
           steps {
             script {
               dir (CI_LOCATION) {
-                run_ci("pre-build", "pr_build_water.json")
+                build_ci("pr_build_water.json")
               }
             }
           }
@@ -450,7 +458,7 @@ pipeline {
           steps {
             script {
               dir (CI_LOCATION) {
-                run_ci("pre-build", "pr_build_grass.json")
+                build_ci("pr_build_grass.json")
               }
             }
           }
@@ -459,7 +467,7 @@ pipeline {
           steps {
             script {
               dir (CI_LOCATION) {
-                run_ci("pre-build", "pr_build_electric.json")
+                build_ci("pr_build_electric.json")
               }
             }
           }
@@ -468,7 +476,7 @@ pipeline {
           steps {
             script {
               dir (CI_LOCATION) {
-                run_ci("pre-build", "pr_build_cyndaquil.json")
+                build_ci("pr_build_cyndaquil.json")
               }
             }
           }
@@ -477,7 +485,7 @@ pipeline {
           steps {
             script {
               dir (CI_LOCATION) {
-                run_ci("pre-build", "pr_build_quilava.json")
+                build_ci("pr_build_quilava.json")
               }
             }
           }
@@ -499,7 +507,7 @@ pipeline {
               }
               bootstrap_ci()
               dir (CI_LOCATION) {
-                run_ci("pre-build", "pr_build_daos.json")
+                build_ci("pr_build_daos.json")
               }
             }
           }
@@ -522,7 +530,7 @@ pipeline {
               }
               bootstrap_ci()
               dir (CI_LOCATION) {
-                run_ci("pre-build", "pr_build_fire.json")
+                build_ci("pr_build_fire.json")
               }
             }
           }
@@ -536,7 +544,7 @@ pipeline {
           steps {
             script {
               dir (CI_LOCATION) {
-                run_ci("pre-build", "pr_build_shmem_water.json")
+                build_ci("pr_build_shmem_water.json")
               }
             }
           }
@@ -545,7 +553,7 @@ pipeline {
           steps {
             script {
               dir (CI_LOCATION) {
-                run_ci("pre-build", "pr_build_shmem_grass.json")
+                build_ci("pr_build_shmem_grass.json")
               }
             }
           }
@@ -554,7 +562,7 @@ pipeline {
           steps {
             script {
               dir (CI_LOCATION) {
-                run_ci("pre-build", "pr_build_ompi_water.json")
+                build_ci("pr_build_ompi_water.json")
               }
             }
           }
@@ -563,7 +571,7 @@ pipeline {
           steps {
             script {
               dir (CI_LOCATION) {
-                run_ci("pre-build", "pr_build_ompi_grass.json")
+                build_ci("pr_build_ompi_grass.json")
               }
             }
           }

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -572,7 +572,7 @@ pipeline {
           steps {
             script {
               dir (CI_LOCATION) {
-                slurm_batch("totodile", "1",
+                slurm_batch("water", "1",
                             "${env.LOG_DIR}/build_mpich_water_log",
                             """python$PYTHON_VERSION ${RUN_LOCATION}/build.py \
                               --build_item=mpich --build_hw=water"""
@@ -761,7 +761,7 @@ pipeline {
                 }
                 for (def mpi in MPIS) {
                   run_middleware(providers, "mpichtestsuite", "mpichtestsuite",
-                                 "grass", "bulbasaur", "2", "${mpi}")
+                                 "grass", "bulbasaur,ivysaur", "2", "${mpi}")
                 }
               }
             }
@@ -778,7 +778,8 @@ pipeline {
                 }
                 for (def mpi in MPIS) {
                   run_middleware(providers, "mpichtestsuite", "mpichtestsuite",
-                                 "water", "totodile", "2", "${mpi}")
+                                 "water", "squirtle,wartortle,articuno", "2",
+                                 "${mpi}")
                 }
               }
             }
@@ -821,13 +822,15 @@ pipeline {
             script {
               dir (RUN_LOCATION) {
 		            run_middleware([["verbs", null]], "oneCCL",
-                               "oneccl", "water", "totodile", "2")
+                               "oneccl", "water",
+                               "squirtle,wartortle,articuno", "2")
 		            run_middleware([["shm", null]], "oneCCL",
-			                         "oneccl", "grass", "bulbasaur,chikorita", "1")
+			                         "oneccl", "grass", "bulbasaur,ivysaur", "1")
 		            run_middleware([["psm3", null]], "oneCCL",
-			                         "oneccl", "water", "totodile", "2")
+			                         "oneccl", "water",
+                               "squirtle,wartortle,articuno", "2")
 		            run_middleware([["tcp", null]], "oneCCL",
-			                         "oneccl", "grass", "bulbasaur,chikorita", "2")
+			                         "oneccl", "grass", "bulbasaur,ivysaur", "2")
                 run_middleware([["shm", null]], "oneCCL_DSA",
                                "oneccl", "electric", "pikachu", "1", null, null,
                                """CCL_ATL_SHM=1 FI_SHM_DISABLE_CMA=1 \

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -995,25 +995,6 @@ pipeline {
           summarize("all")
         }
       }
-    }
-    aborted {
-      node ('daos_head') {
-        dir ("${DELETE_LOCATION}/middlewares") { deleteDir() }
-      }
-      node ('ze') {
-        dir ("${DELETE_LOCATION}/middlewares") { deleteDir() }
-      }
-      sh "scancel --jobname=\"${SLURM_JOB_NAME}\""
-      dir ("${DELETE_LOCATION}/middlewares") { deleteDir() }
-    }
-    success {
-      script {
-        if (DO_RUN) {
-          CI_summarize(verbose=true)
-          summarize("all", verbose=true, release=false,
-          send_mail=env.WEEKLY.toBoolean())
-        }
-      }
       node ('daos_head') {
         dir("${env.WORKSPACE}") { deleteDir() }
         dir("${env.WORKSPACE}@tmp") { deleteDir() }

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -605,6 +605,41 @@ pipeline {
     stage('parallel-tests') {
       when { equals expected: true, actual: DO_RUN }
       parallel {
+        stage('mpichtestsuite-tcp') {
+          steps {
+            script {
+              dir (RUN_LOCATION) {
+                def providers = [['tcp', null]]
+                def MPIS = ["mpich"]
+                if (env.WEEKLY.toBoolean()) {
+                  MPIS = ["impi", "mpich"]
+                }
+                for (def mpi in MPIS) {
+                  run_middleware(providers, "mpichtestsuite", "mpichtestsuite",
+                                 "grass", "bulbasaur,ivysaur", "2", "${mpi}")
+                }
+              }
+            }
+          }
+        }
+        stage('mpichtestsuite-verbs') {
+          steps {
+            script {
+              dir (RUN_LOCATION) {
+                def providers = [["verbs","rxm"]]
+                def MPIS = ["mpich"]
+                if (env.WEEKLY.toBoolean()) {
+                  MPIS = ["impi", "mpich"]
+                }
+                for (def mpi in MPIS) {
+                  run_middleware(providers, "mpichtestsuite", "mpichtestsuite",
+                                 "water", "squirtle,wartortle,articuno", "2",
+                                 "${mpi}")
+                }
+              }
+            }
+          }
+        }
         stage ('CI_mpi_verbs-rxm_imb') {
           steps {
             script {
@@ -752,41 +787,6 @@ pipeline {
                 run_ci("CI_fabtests_ucx_reg", "pr_fabtests_ucx_reg.json")
                 run_ci("CI_fabtests_ucx_dbg", "pr_fabtests_ucx_dbg.json")
                 run_ci("CI_fabtests_ucx_dl", "pr_fabtests_ucx_dl.json")
-              }
-            }
-          }
-        }
-        stage('mpichtestsuite-tcp') {
-          steps {
-            script {
-              dir (RUN_LOCATION) {
-                def providers = [['tcp', null]]
-                def MPIS = ["mpich"]
-                if (env.WEEKLY.toBoolean()) {
-                  MPIS = ["impi", "mpich"]
-                }
-                for (def mpi in MPIS) {
-                  run_middleware(providers, "mpichtestsuite", "mpichtestsuite",
-                                 "grass", "bulbasaur,ivysaur", "2", "${mpi}")
-                }
-              }
-            }
-          }
-        }
-        stage('mpichtestsuite-verbs') {
-          steps {
-            script {
-              dir (RUN_LOCATION) {
-                def providers = [["verbs","rxm"]]
-                def MPIS = ["mpich"]
-                if (env.WEEKLY.toBoolean()) {
-                  MPIS = ["impi", "mpich"]
-                }
-                for (def mpi in MPIS) {
-                  run_middleware(providers, "mpichtestsuite", "mpichtestsuite",
-                                 "water", "squirtle,wartortle,articuno", "2",
-                                 "${mpi}")
-                }
               }
             }
           }

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -17,7 +17,6 @@ def run_python(version, command, output=null) {
 }
 
 def slurm_batch(partition, node_num, output, command) {
-  
   try {
     sh """sbatch --partition=${partition} -N ${node_num} \
           --wait -o ${output} --open-mode=append \
@@ -113,7 +112,6 @@ def build_ci(config_name) {
 
 def gather_logs(cluster, key, dest, source) {
   def address = "${env.USER}@${cluster}"
-
   try {
     sh "scp -r -i ${key} ${address}:${source}/* ${dest}/"
   } catch (Exception e) {


### PR DESCRIPTION
Uplevel pre-build so that it isn't copied over for summarizing
Always cleanup at the end of a pipeline
Update slurm partition names for new cluster
Put mpichtestsuite stage as first test to execute because it is the slowest. This allows other tests to complete in parallel on the other nodes while mpichtestsuite is running.