### PR TITLE
fabtests: corrected flags argument type in ft_sendmsg/ft_recvmsg

### DIFF
--- a/fabtests/benchmarks/benchmark_shared.c
+++ b/fabtests/benchmarks/benchmark_shared.c
@@ -425,7 +425,7 @@ static int rma_bw_rx_comp()
 	return ft_tx(ep, remote_fi_addr, FT_RMA_SYNC_MSG_BYTES, &tx_ctx);
 }
 
-static int set_fi_more_flag(int i, int j, int flags)
+static uint64_t set_fi_more_flag(int i, int j, uint64_t flags)
 {
 	if (j < opts.window_size - 1 && i >= opts.warmup_iterations &&
 	    i < opts.iterations + opts.warmup_iterations - 1) {
@@ -438,7 +438,8 @@ static int set_fi_more_flag(int i, int j, int flags)
 
 int bandwidth(void)
 {
-	int ret, i, j, flags = 0;
+	int ret, i, j;
+	uint64_t flags = 0;
 	size_t inject_size = fi->tx_attr->inject_size;
 
 	ret = fi_getopt(&ep->fid, FI_OPT_ENDPOINT, FI_OPT_INJECT_MSG_SIZE,
@@ -579,7 +580,8 @@ static int bw_rma_comp(enum ft_rma_opcodes rma_op, int num_completions)
 
 int bandwidth_rma(enum ft_rma_opcodes rma_op, struct fi_rma_iov *remote)
 {
-	int ret, i, j, flags = 0;
+	int ret, i, j;
+	uint64_t flags = 0;
 	size_t offset, inject_size = fi->tx_attr->inject_size;
 
 	ret = fi_getopt(&ep->fid, FI_OPT_ENDPOINT, FI_OPT_INJECT_RMA_SIZE,

--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -2923,7 +2923,7 @@ int ft_tx_msg(struct fid_ep *ep, fi_addr_t fi_addr, void *buf, size_t size, void
 }
 
 int ft_sendmsg(struct fid_ep *ep, fi_addr_t fi_addr,
-		void *buf, size_t size, void *ctx, int flags)
+		void *buf, size_t size, void *ctx, uint64_t flags)
 {
 	struct fi_msg msg;
 	struct fi_msg_tagged tagged_msg;
@@ -2963,7 +2963,7 @@ int ft_sendmsg(struct fid_ep *ep, fi_addr_t fi_addr,
 
 
 int ft_recvmsg(struct fid_ep *ep, fi_addr_t fi_addr, void *buf,
-	       size_t size, void *ctx, int flags)
+	       size_t size, void *ctx, uint64_t flags)
 {
 	struct fi_msg msg;
 	struct fi_msg_tagged tagged_msg;

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -630,11 +630,9 @@ int ft_get_cq_comp(struct fid_cq *cq, uint64_t *cur, uint64_t total, int timeout
 int ft_get_cntr_comp(struct fid_cntr *cntr, uint64_t total, int timeout);
 
 int ft_recvmsg(struct fid_ep *ep, fi_addr_t fi_addr,
-	       void *buf, size_t size, void *ctx, int flags);
+	       void *buf, size_t size, void *ctx, uint64_t flags);
 int ft_sendmsg(struct fid_ep *ep, fi_addr_t fi_addr,
-	       void *buf, size_t size, void *ctx, int flags);
-int ft_writemsg(struct fid_ep *ep, fi_addr_t fi_addr, void *buf, size_t size,
-		void *ctx, struct fi_rma_iov *remote, int flags);
+	       void *buf, size_t size, void *ctx, uint64_t flags);
 int ft_tx_msg(struct fid_ep *ep, fi_addr_t fi_addr,
 	      void *buf, size_t size, void *ctx, uint64_t flags);
 int ft_cq_read_verify(struct fid_cq *cq, void *op_context);


### PR DESCRIPTION
fixed fabtests send and recv functions to use flags argument type as uint64_t instead of int as the underlying fi calls use uint64_t. removed declaration of unused function ft_writemsg from shared.h