### PR TITLE
prov/efa: Move fork handler installation to efa_domain_open

### DIFF
--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -290,6 +290,16 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 		efa_domain->util_domain.domain_fid.ops = &efa_ops_domain_dgram;
 	}
 
+#ifndef _WIN32
+	err = efa_fork_support_install_fork_handler();
+	if (err) {
+		EFA_WARN(FI_LOG_CORE,
+			 "Unable to install fork handler: %s\n",
+			 strerror(-err));
+		return err;
+	}
+#endif
+
 	dlist_insert_tail(&efa_domain->list_entry, &g_efa_domain_list);
 	return 0;
 

--- a/prov/efa/src/efa_user_info.c
+++ b/prov/efa/src/efa_user_info.c
@@ -610,24 +610,6 @@ int efa_getinfo(uint32_t version, const char *node,
 	struct fi_info *dgram_info_list, *rdm_info_list;
 	int err;
 
-#ifndef _WIN32
-	/*
-	 * TODO:
-	 * It'd be better to install this during provider init (since that's
-	 * only invoked once) but fork() is currently called by nvml_init in 
-	 * other provider's ini (which calls ofi_hmem_init) after efa provider init. 
-	 * This can move to the provider init after we get rid of that fork() in 
-	 * ofi_hmem_init().
-	 */
-	err = efa_fork_support_install_fork_handler();
-	if (err) {
-		EFA_WARN(FI_LOG_CORE,
-			 "Unable to install fork handler: %s\n",
-			 strerror(-err));
-		return err;
-	}
-#endif
-
 	if (hints && hints->ep_attr && hints->ep_attr->type == FI_EP_DGRAM)
 		return efa_user_info_get_dgram(version, node, service, flags, hints, info);
 


### PR DESCRIPTION
efa_fork_support_enable_if_requested was moved to EFA_INI, so efa_fork_support_install_fork_handler can be registered at any stage that is later. Move efa_fork_support_install_fork_handler back to efa_domain_open to avoid installing fork handler for non-EFA provider during fi_getinfo's provider discovery process.