### PR TITLE
common: ofi_ifname_toaddr check ifa->ifa_addr for null

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -847,8 +847,9 @@ static int ofi_ifname_toaddr(const char *name, uint32_t *addr_format,
 		return ret;
 
 	for (ifa = ifaddrs; ifa; ifa = ifa->ifa_next) {
-		if (ifa->ifa_addr->sa_family != AF_INET &&
-		    ifa->ifa_addr->sa_family != AF_INET6)
+		if (ifa->ifa_addr == NULL ||
+		    (ifa->ifa_addr->sa_family != AF_INET &&
+		     ifa->ifa_addr->sa_family != AF_INET6))
 			continue;
 		if (!strcmp(name, ifa->ifa_name))
 			break;


### PR DESCRIPTION
ifa->ifa_addr might be NULL, thus led to crash.

Fixes #10674 