### PR TITLE
prov/cxi: Ignore drop count during init

### DIFF
--- a/prov/cxi/src/cxip_ctrl.c
+++ b/prov/cxi/src/cxip_ctrl.c
@@ -694,7 +694,7 @@ int cxip_ep_ctrl_init(struct cxip_ep_obj *ep_obj)
 	}
 
 	ret = cxip_pte_set_state(ep_obj->ctrl.pte, ep_obj->ctrl.tgq,
-				 C_PTLTE_ENABLED, 0);
+				 C_PTLTE_ENABLED, CXIP_PTE_IGNORE_DROPS);
 	if (ret) {
 		/* This is a bug, we have exclusive access to this CMDQ. */
 		CXIP_WARN("Failed to enqueue command: %d\n", ret);

--- a/prov/cxi/src/cxip_mr.c
+++ b/prov/cxi/src/cxip_mr.c
@@ -342,7 +342,8 @@ static int cxip_mr_enable_opt(struct cxip_mr *mr)
 		goto err_pte_free;
 	}
 
-	ret = cxip_pte_set_state(mr->pte, ep_obj->ctrl.tgq, C_PTLTE_ENABLED, 0);
+	ret = cxip_pte_set_state(mr->pte, ep_obj->ctrl.tgq, C_PTLTE_ENABLED,
+				 CXIP_PTE_IGNORE_DROPS);
 	if (ret != FI_SUCCESS) {
 		/* This is a bug, we have exclusive access to this CMDQ. */
 		CXIP_WARN("Failed to enqueue command: %d\n", ret);
@@ -532,7 +533,7 @@ static int cxip_mr_prov_cache_enable_opt(struct cxip_mr *mr)
 	}
 
 	ret = cxip_pte_set_state(_mr->pte, ep_obj->ctrl.tgq,
-				 C_PTLTE_ENABLED, 0);
+				 C_PTLTE_ENABLED, CXIP_PTE_IGNORE_DROPS);
 	if (ret != FI_SUCCESS) {
 		/* This is a bug, we have exclusive access to this CMDQ. */
 		CXIP_WARN("Failed to enqueue command: %d\n", ret);

--- a/prov/cxi/src/cxip_msg_hpc.c
+++ b/prov/cxi/src/cxip_msg_hpc.c
@@ -3930,7 +3930,8 @@ static int cxip_rxc_hpc_msg_init(struct cxip_rxc *rxc_base)
 	}
 
 	/* Start accepting Puts. */
-	ret = cxip_pte_set_state(rxc->base.rx_pte, rxc->base.rx_cmdq, state, 0);
+	ret = cxip_pte_set_state(rxc->base.rx_pte, rxc->base.rx_cmdq, state,
+				 CXIP_PTE_IGNORE_DROPS);
 	if (ret != FI_SUCCESS) {
 		CXIP_WARN("cxip_pte_set_state returned: %d\n", ret);
 		goto free_oflow_buf;

--- a/prov/cxi/src/cxip_msg_rnr.c
+++ b/prov/cxi/src/cxip_msg_rnr.c
@@ -382,7 +382,7 @@ static int cxip_rxc_rnr_msg_init(struct cxip_rxc *rxc_base)
 
 	/* Start accepting Puts. */
 	ret = cxip_pte_set_state(rxc->base.rx_pte, rxc->base.rx_cmdq,
-				 C_PTLTE_ENABLED, 0);
+				 C_PTLTE_ENABLED, CXIP_PTE_IGNORE_DROPS);
 	if (ret != FI_SUCCESS) {
 		CXIP_WARN("cxip_pte_set_state returned: %d\n", ret);
 		goto free_pte;

--- a/prov/cxi/src/cxip_rdzv_pte.c
+++ b/prov/cxi/src/cxip_rdzv_pte.c
@@ -265,7 +265,7 @@ static int cxip_rdzv_base_pte_alloc(struct cxip_txc_hpc *txc,
 
 	/* Set to enable, event will be processed on link */
 	ret = cxip_pte_set_state(base_pte->pte, txc->rx_cmdq,
-				 C_PTLTE_ENABLED, 0);
+				 C_PTLTE_ENABLED, CXIP_PTE_IGNORE_DROPS);
 	if (ret != FI_SUCCESS) {
 		CXIP_WARN("Failed to enqueue enable command: %d:%s\n", ret,
 			  fi_strerror(-ret));


### PR DESCRIPTION
When MRs and EPs should ignore drop count during init. Failing to do this may result in enable hangs.