### PR TITLE
prov/cxi: Fix CQ wait FD logic

### DIFF
--- a/man/fi_cxi.7.md
+++ b/man/fi_cxi.7.md
@@ -80,7 +80,9 @@ The CXI provider supports FI_THREAD_SAFE and FI_THREAD_DOMAIN threading models.
 
 The CXI provider supports FI_WAIT_FD and FI_WAIT_POLLFD CQ wait object types.
 FI_WAIT_UNSPEC will default to FI_WAIT_FD. However FI_WAIT_NONE should achieve
-the lowest latency and reduce interrupt overhead.
+the lowest latency and reduce interrupt overhead. NOTE: A process may return
+from a epoll_wait/poll when provider progress is required and a CQ event may
+not be available.
 
 ## Additional Features
 

--- a/prov/cxi/include/cxip.h
+++ b/prov/cxi/include/cxip.h
@@ -1420,8 +1420,8 @@ struct cxip_cq {
 	 */
 	struct ofi_genlock ep_list_lock;
 
-	/* Internal CXI wait object allocated only if required. */
-	struct cxil_wait_obj *priv_wait;
+	/* CXI CQ wait object EPs are maintained in epoll FD */
+	int ep_fd;
 
 	/* CXI specific fields. */
 	struct cxip_domain *domain;
@@ -2428,6 +2428,10 @@ struct cxip_ep_obj {
 	struct cxip_txc *txc;
 	struct cxip_rxc *rxc;
 
+	/* Internal support for CQ wait object */
+	struct cxil_wait_obj *priv_wait;
+	int wait_fd;
+
 	/* ASIC version associated with EP/Domain */
 	enum cassini_version asic_ver;
 
@@ -3148,7 +3152,8 @@ static inline bool cxip_cmdq_match(struct cxip_cmdq *cmdq, uint16_t vni,
 }
 
 int cxip_evtq_init(struct cxip_evtq *evtq, struct cxip_cq *cq,
-		   size_t num_events, size_t num_fc_events);
+		   size_t num_events, size_t num_fc_events,
+		   struct cxil_wait_obj *priv_wait);
 void cxip_evtq_fini(struct cxip_evtq *eq);
 
 int cxip_domain(struct fid_fabric *fabric, struct fi_info *info,
@@ -3228,6 +3233,9 @@ int cxip_cq_req_complete_addr(struct cxip_req *req, fi_addr_t src);
 int cxip_cq_req_error(struct cxip_req *req, size_t olen,
 		      int err, int prov_errno, void *err_data,
 		      size_t err_data_size, fi_addr_t src_addr);
+int cxip_cq_add_wait_fd(struct cxip_cq *cq, int wait_fd, int events);
+void cxip_cq_del_wait_fd(struct cxip_cq *cq, int wait_fd);
+
 int proverr2errno(int err);
 struct cxip_req *cxip_evtq_req_alloc(struct cxip_evtq *evtq,
 				     int remap, void *req_ctx);
@@ -3235,9 +3243,9 @@ void cxip_evtq_req_free(struct cxip_req *req);
 void cxip_evtq_progress(struct cxip_evtq *evtq);
 
 void cxip_ep_progress(struct fid *fid);
-int cxip_ep_peek(struct fid *fid);
 void cxip_ep_flush_trig_reqs(struct cxip_ep_obj *ep_obj);
 
+int cxip_cq_trywait(struct cxip_cq *cq);
 void cxip_cq_progress(struct cxip_cq *cq);
 void cxip_util_cq_progress(struct util_cq *util_cq);
 int cxip_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
@@ -3266,8 +3274,7 @@ void cxip_ep_tgt_ctrl_progress(struct cxip_ep_obj *ep_obj);
 void cxip_ep_tgt_ctrl_progress_locked(struct cxip_ep_obj *ep_obj);
 int cxip_ep_ctrl_init(struct cxip_ep_obj *ep_obj);
 void cxip_ep_ctrl_fini(struct cxip_ep_obj *ep_obj);
-void cxip_ep_ctrl_del_wait(struct cxip_ep_obj *ep_obj);
-int cxip_ep_ctrl_trywait(void *arg);
+int cxip_ep_trywait(struct cxip_ep_obj *ep_obj, struct cxip_cq *cq);
 
 int cxip_av_set(struct fid_av *av, struct fi_av_set_attr *attr,
 	        struct fid_av_set **av_set_fid, void * context);

--- a/prov/cxi/src/cxip_evtq.c
+++ b/prov/cxi/src/cxip_evtq.c
@@ -457,7 +457,8 @@ static size_t cxip_evtq_get_queue_size(struct cxip_cq *cq, size_t num_events)
 
 #define MAP_HUGE_2MB    (21 << MAP_HUGE_SHIFT)
 int cxip_evtq_init(struct cxip_evtq *evtq, struct cxip_cq *cq,
-		   size_t num_events, size_t num_fc_events)
+		   size_t num_events, size_t num_fc_events,
+		   struct cxil_wait_obj *priv_wait)
 {
 	struct cxi_eq_attr eq_attr = {
 		.reserved_slots = num_fc_events,
@@ -561,7 +562,7 @@ mmap_success:
 
 	/* cq->priv_wait is NULL if not backed by wait object */
 	ret = cxil_alloc_evtq(cq->domain->lni->lni, evtq->md, &eq_attr,
-			      cq->priv_wait, NULL, &evtq->eq);
+			      priv_wait, NULL, &evtq->eq);
 	if (ret) {
 		CXIP_WARN("Failed to allocated EQ: %d\n", ret);
 		goto err_unmap_eq_buf;

--- a/prov/cxi/src/cxip_rxc.c
+++ b/prov/cxi/src/cxip_rxc.c
@@ -127,7 +127,8 @@ static int rxc_msg_init(struct cxip_rxc *rxc)
 
 	/* Base message initialization */
 	num_events = cxip_rxc_get_num_events(rxc);
-	ret = cxip_evtq_init(&rxc->rx_evtq, rxc->recv_cq, num_events, 1);
+	ret = cxip_evtq_init(&rxc->rx_evtq, rxc->recv_cq, num_events, 1,
+			     rxc->ep_obj->priv_wait);
 	if (ret) {
 		CXIP_WARN("Failed to initialize RXC event queue: %d, %s\n",
 			  ret, fi_strerror(-ret));

--- a/prov/cxi/src/cxip_txc.c
+++ b/prov/cxi/src/cxip_txc.c
@@ -328,7 +328,8 @@ int cxip_txc_enable(struct cxip_txc *txc)
 
 	num_events = cxip_txc_get_num_events(txc);
 
-	ret = cxip_evtq_init(&txc->tx_evtq, txc->send_cq, num_events, 0);
+	ret = cxip_evtq_init(&txc->tx_evtq, txc->send_cq, num_events, 0,
+			     txc->ep_obj->priv_wait);
 	if (ret) {
 		CXIP_WARN("Failed to initialize TX event queue: %d, %s\n",
 			  ret, fi_strerror(-ret));

--- a/prov/cxi/test/cxip_test_common.c
+++ b/prov/cxi/test/cxip_test_common.c
@@ -774,6 +774,7 @@ void cxit_setup_enabled_ep_fd(void)
 
 	cxit_fi_hints->domain_attr->data_progress = FI_PROGRESS_MANUAL;
 	cxit_fi_hints->domain_attr->data_progress = FI_PROGRESS_MANUAL;
+	cxit_fi_hints->domain_attr->threading = FI_THREAD_SAFE;
 
 	cxit_setup_ep();
 


### PR DESCRIPTION
Implement cxi managed internal wait FDs. EP bound to CQ(s) with wait_obj  will allocate
their own internal CXI wait object and add the sysfs_notify FD to the CQ. Fix CQ trywait logic
to correctly enable h/w EQ interrupts and include control EQ which may require progress be initiated.