### PR TITLE
contrib/aws: Skip default checkout

### DIFF
--- a/contrib/aws/Jenkinsfile
+++ b/contrib/aws/Jenkinsfile
@@ -152,7 +152,6 @@ pipeline {
         stage("Download and extract PortaFiducia") {
             steps {
                 script {
-                    sh 'printenv'
                     download_and_extract_portafiducia('PortaFiducia')
                 }
             }

--- a/contrib/aws/Jenkinsfile
+++ b/contrib/aws/Jenkinsfile
@@ -131,6 +131,7 @@ pipeline {
     options {
         buildDiscarder(logRotator(daysToKeepStr: "90"))
         timeout(time: 10, unit: 'HOURS')
+        skipDefaultCheckout()
     }
     environment {
         // AWS region where the cluster is created


### PR DESCRIPTION
Skip the default checkout of the workspace because we explicitly checkout out the workspace after we clean it.