### PR TITLE
prov/efa: Make efa_rdm_cq use efa_cq

### DIFF
--- a/prov/efa/src/efa_base_ep.c
+++ b/prov/efa/src/efa_base_ep.c
@@ -4,6 +4,7 @@
 #include <sys/time.h>
 #include "efa.h"
 #include "efa_av.h"
+#include "efa_cq.h"
 #include "rdm/efa_rdm_protocol.h"
 
 int efa_base_ep_bind_av(struct efa_base_ep *base_ep, struct efa_av *av)
@@ -519,4 +520,14 @@ struct efa_ep_addr *efa_base_ep_get_peer_raw_addr(struct efa_base_ep *base_ep, f
 const char *efa_base_ep_get_peer_raw_addr_str(struct efa_base_ep *base_ep, fi_addr_t addr, char *buf, size_t *buflen)
 {
 	return ofi_straddr(buf, buflen, FI_ADDR_EFA, efa_base_ep_get_peer_raw_addr(base_ep, addr));
+}
+
+struct efa_cq *efa_base_ep_get_tx_cq(struct efa_base_ep *ep)
+{
+	return ep->util_ep.tx_cq ? container_of(ep->util_ep.tx_cq, struct efa_cq, util_cq) : NULL;
+}
+
+struct efa_cq *efa_base_ep_get_rx_cq(struct efa_base_ep *ep)
+{
+	return ep->util_ep.rx_cq ? container_of(ep->util_ep.rx_cq, struct efa_cq, util_cq) : NULL;
 }

--- a/prov/efa/src/efa_base_ep.h
+++ b/prov/efa/src/efa_base_ep.h
@@ -109,4 +109,9 @@ struct efa_ep_addr *efa_base_ep_get_peer_raw_addr(struct efa_base_ep *base_ep,
 const char *efa_base_ep_get_peer_raw_addr_str(struct efa_base_ep *base_ep,
 					      fi_addr_t addr, char *buf,
 					      size_t *buflen);
+
+struct efa_cq *efa_base_ep_get_tx_cq(struct efa_base_ep *ep);
+
+struct efa_cq *efa_base_ep_get_rx_cq(struct efa_base_ep *ep);
+
 #endif

--- a/prov/efa/src/rdm/efa_rdm_cq.c
+++ b/prov/efa/src/rdm/efa_rdm_cq.c
@@ -36,16 +36,16 @@ int efa_rdm_cq_close(struct fid *fid)
 
 	retv = 0;
 
-	cq = container_of(fid, struct efa_rdm_cq, util_cq.cq_fid.fid);
+	cq = container_of(fid, struct efa_rdm_cq, efa_cq.util_cq.cq_fid.fid);
 
-	if (cq->ibv_cq.ibv_cq_ex) {
-		ret = -ibv_destroy_cq(ibv_cq_ex_to_cq(cq->ibv_cq.ibv_cq_ex));
+	if (cq->efa_cq.ibv_cq.ibv_cq_ex) {
+		ret = -ibv_destroy_cq(ibv_cq_ex_to_cq(cq->efa_cq.ibv_cq.ibv_cq_ex));
 		if (ret) {
 			EFA_WARN(FI_LOG_CQ, "Unable to close ibv cq: %s\n",
 				fi_strerror(-ret));
 			return ret;
 		}
-		cq->ibv_cq.ibv_cq_ex = NULL;
+		cq->efa_cq.ibv_cq.ibv_cq_ex = NULL;
 	}
 
 	if (cq->shm_cq) {
@@ -56,7 +56,7 @@ int efa_rdm_cq_close(struct fid *fid)
 		}
 	}
 
-	ret = ofi_cq_cleanup(&cq->util_cq);
+	ret = ofi_cq_cleanup(&cq->efa_cq.util_cq);
 	if (ret)
 		return ret;
 	free(cq);
@@ -435,13 +435,13 @@ void efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq)
 	int prov_errno;
 	struct efa_rdm_ep *ep = NULL;
 	struct fi_cq_err_entry err_entry;
-	struct efa_rdm_cq *efa_rdm_cq;
+	struct efa_cq *efa_cq;
 	struct efa_domain *efa_domain;
 	struct efa_qp *qp;
 	struct dlist_entry rx_progressed_ep_list, *tmp;
 
-	efa_rdm_cq = container_of(ibv_cq, struct efa_rdm_cq, ibv_cq);
-	efa_domain = container_of(efa_rdm_cq->util_cq.domain, struct efa_domain, util_domain);
+	efa_cq = container_of(ibv_cq, struct efa_cq, ibv_cq);
+	efa_domain = container_of(efa_cq->util_cq.domain, struct efa_domain, util_domain);
 	dlist_init(&rx_progressed_ep_list);
 
 	/* Call ibv_start_poll only once */
@@ -538,7 +538,7 @@ void efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq)
 			.prov_errno = prov_errno,
 			.op_context = NULL
 		};
-		ofi_cq_write_error(&efa_rdm_cq->util_cq, &err_entry);
+		ofi_cq_write_error(&efa_cq->util_cq, &err_entry);
 	}
 
 	if (should_end_poll)
@@ -559,9 +559,9 @@ static ssize_t efa_rdm_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t coun
 	ssize_t ret;
 	struct efa_domain *domain;
 
-	cq = container_of(cq_fid, struct efa_rdm_cq, util_cq.cq_fid.fid);
+	cq = container_of(cq_fid, struct efa_rdm_cq, efa_cq.util_cq.cq_fid.fid);
 
-	domain = container_of(cq->util_cq.domain, struct efa_domain, util_domain);
+	domain = container_of(cq->efa_cq.util_cq.domain, struct efa_domain, util_domain);
 
 	ofi_genlock_lock(&domain->srx_lock);
 
@@ -573,13 +573,13 @@ static ssize_t efa_rdm_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t coun
 		 * completion to efa. Use ofi_cq_read_entries to get the number of
 		 * shm completions without progressing efa ep again.
 		 */
-		ret = ofi_cq_read_entries(&cq->util_cq, buf, count, src_addr);
+		ret = ofi_cq_read_entries(&cq->efa_cq.util_cq, buf, count, src_addr);
 
 		if (ret > 0)
 			goto out;
 	}
 
-	ret = ofi_cq_readfrom(&cq->util_cq.cq_fid, buf, count, src_addr);
+	ret = ofi_cq_readfrom(&cq->efa_cq.util_cq.cq_fid, buf, count, src_addr);
 
 out:
 	ofi_genlock_unlock(&domain->srx_lock);
@@ -608,8 +608,8 @@ static void efa_rdm_cq_progress(struct util_cq *cq)
 	struct fid_list_entry *fid_entry;
 
 	ofi_genlock_lock(&cq->ep_list_lock);
-	efa_rdm_cq = container_of(cq, struct efa_rdm_cq, util_cq);
-	efa_domain = container_of(efa_rdm_cq->util_cq.domain, struct efa_domain, util_domain);
+	efa_rdm_cq = container_of(cq, struct efa_rdm_cq, efa_cq.util_cq);
+	efa_domain = container_of(efa_rdm_cq->efa_cq.util_cq.domain, struct efa_domain, util_domain);
 
 	/**
 	 * TODO: It's better to just post the initial batch of internal rx pkts during ep enable
@@ -671,19 +671,19 @@ int efa_rdm_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 
 	dlist_init(&cq->ibv_cq_poll_list);
 	cq->need_to_scan_ep_list = false;
-	ret = ofi_cq_init(&efa_prov, domain, attr, &cq->util_cq,
+	ret = ofi_cq_init(&efa_prov, domain, attr, &cq->efa_cq.util_cq,
 			  &efa_rdm_cq_progress, context);
 
 	if (ret)
 		goto free;
 
-	ret = efa_cq_ibv_cq_ex_open(attr, efa_domain->device->ibv_ctx, &cq->ibv_cq.ibv_cq_ex, &cq->ibv_cq.ibv_cq_ex_type);
+	ret = efa_cq_ibv_cq_ex_open(attr, efa_domain->device->ibv_ctx, &cq->efa_cq.ibv_cq.ibv_cq_ex, &cq->efa_cq.ibv_cq.ibv_cq_ex_type);
 	if (ret) {
 		EFA_WARN(FI_LOG_CQ, "Unable to create extended CQ: %s\n", fi_strerror(ret));
 		goto close_util_cq;
 	}
 
-	*cq_fid = &cq->util_cq.cq_fid;
+	*cq_fid = &cq->efa_cq.util_cq.cq_fid;
 	(*cq_fid)->fid.ops = &efa_rdm_cq_fi_ops;
 	(*cq_fid)->ops = &efa_rdm_cq_ops;
 
@@ -693,7 +693,7 @@ int efa_rdm_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		/* Bind ep with shm provider's cq */
 		shm_cq_attr.flags |= FI_PEER;
 		peer_cq_context.size = sizeof(peer_cq_context);
-		peer_cq_context.cq = cq->util_cq.peer_cq;
+		peer_cq_context.cq = cq->efa_cq.util_cq.peer_cq;
 		ret = fi_cq_open(efa_domain->shm_domain, &shm_cq_attr,
 				 &cq->shm_cq, &peer_cq_context);
 		if (ret) {
@@ -704,12 +704,12 @@ int efa_rdm_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 
 	return 0;
 destroy_ibv_cq:
-	retv = -ibv_destroy_cq(ibv_cq_ex_to_cq(cq->ibv_cq.ibv_cq_ex));
+	retv = -ibv_destroy_cq(ibv_cq_ex_to_cq(cq->efa_cq.ibv_cq.ibv_cq_ex));
 	if (retv)
 		EFA_WARN(FI_LOG_CQ, "Unable to close ibv cq: %s\n",
 			 fi_strerror(-retv));
 close_util_cq:
-	retv = ofi_cq_cleanup(&cq->util_cq);
+	retv = ofi_cq_cleanup(&cq->efa_cq.util_cq);
 	if (retv)
 		EFA_WARN(FI_LOG_CQ, "Unable to close util cq: %s\n",
 			 fi_strerror(-retv));

--- a/prov/efa/src/rdm/efa_rdm_cq.h
+++ b/prov/efa/src/rdm/efa_rdm_cq.h
@@ -8,8 +8,7 @@
 #include <ofi_util.h>
 
 struct efa_rdm_cq {
-	struct util_cq util_cq;
-	struct efa_ibv_cq ibv_cq;
+	struct efa_cq efa_cq;
 	struct fid_cq *shm_cq;
 	struct dlist_entry ibv_cq_poll_list;
 	bool need_to_scan_ep_list;

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -110,6 +110,7 @@ void test_efa_rdm_ep_handshake_exchange_host_id(struct efa_resource **state, uin
 	struct efa_rdm_pke *pkt_entry;
 	uint64_t actual_peer_host_id = UINT64_MAX;
 	struct efa_rdm_cq *efa_rdm_cq;
+	struct ibv_cq_ex *ibv_cqx;
 
 	g_efa_unit_test_mocks.local_host_id = local_host_id;
 	g_efa_unit_test_mocks.peer_host_id = peer_host_id;
@@ -120,7 +121,8 @@ void test_efa_rdm_ep_handshake_exchange_host_id(struct efa_resource **state, uin
 	efa_unit_test_resource_construct_rdm_shm_disabled(resource);
 
 	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
-	efa_rdm_cq = container_of(resource->cq, struct efa_rdm_cq, util_cq.cq_fid.fid);
+	efa_rdm_cq = container_of(resource->cq, struct efa_rdm_cq, efa_cq.util_cq.cq_fid.fid);
+	ibv_cqx = efa_rdm_cq->efa_cq.ibv_cq.ibv_cq_ex;
 
 	efa_rdm_ep->host_id = g_efa_unit_test_mocks.local_host_id;
 
@@ -166,18 +168,18 @@ void test_efa_rdm_ep_handshake_exchange_host_id(struct efa_resource **state, uin
 	expect_function_call(efa_mock_ibv_wr_send_verify_handshake_pkt_local_host_id_and_save_wr);
 
 	/* Setup CQ */
-	efa_rdm_cq->ibv_cq.ibv_cq_ex->end_poll = &efa_mock_ibv_end_poll_check_mock;
-	efa_rdm_cq->ibv_cq.ibv_cq_ex->next_poll = &efa_mock_ibv_next_poll_check_function_called_and_return_mock;
-	efa_rdm_cq->ibv_cq.ibv_cq_ex->read_byte_len = &efa_mock_ibv_read_byte_len_return_mock;
-	efa_rdm_cq->ibv_cq.ibv_cq_ex->read_opcode = &efa_mock_ibv_read_opcode_return_mock;
-	efa_rdm_cq->ibv_cq.ibv_cq_ex->read_slid = &efa_mock_ibv_read_slid_return_mock;
-	efa_rdm_cq->ibv_cq.ibv_cq_ex->read_src_qp = &efa_mock_ibv_read_src_qp_return_mock;
-	efa_rdm_cq->ibv_cq.ibv_cq_ex->read_qp_num = &efa_mock_ibv_read_qp_num_return_mock;
-	efa_rdm_cq->ibv_cq.ibv_cq_ex->read_wc_flags = &efa_mock_ibv_read_wc_flags_return_mock;
-	efa_rdm_cq->ibv_cq.ibv_cq_ex->read_vendor_err = &efa_mock_ibv_read_vendor_err_return_mock;
-	efa_rdm_cq->ibv_cq.ibv_cq_ex->start_poll = &efa_mock_ibv_start_poll_return_mock;
-	efa_rdm_cq->ibv_cq.ibv_cq_ex->status = IBV_WC_SUCCESS;
-	efa_rdm_cq->ibv_cq.ibv_cq_ex->wr_id = (uintptr_t)pkt_entry;
+	ibv_cqx->end_poll = &efa_mock_ibv_end_poll_check_mock;
+	ibv_cqx->next_poll = &efa_mock_ibv_next_poll_check_function_called_and_return_mock;
+	ibv_cqx->read_byte_len = &efa_mock_ibv_read_byte_len_return_mock;
+	ibv_cqx->read_opcode = &efa_mock_ibv_read_opcode_return_mock;
+	ibv_cqx->read_slid = &efa_mock_ibv_read_slid_return_mock;
+	ibv_cqx->read_src_qp = &efa_mock_ibv_read_src_qp_return_mock;
+	ibv_cqx->read_qp_num = &efa_mock_ibv_read_qp_num_return_mock;
+	ibv_cqx->read_wc_flags = &efa_mock_ibv_read_wc_flags_return_mock;
+	ibv_cqx->read_vendor_err = &efa_mock_ibv_read_vendor_err_return_mock;
+	ibv_cqx->start_poll = &efa_mock_ibv_start_poll_return_mock;
+	ibv_cqx->status = IBV_WC_SUCCESS;
+	ibv_cqx->wr_id = (uintptr_t)pkt_entry;
 	expect_function_call(efa_mock_ibv_next_poll_check_function_called_and_return_mock);
 
 	/* Receive handshake packet */
@@ -210,8 +212,8 @@ void test_efa_rdm_ep_handshake_exchange_host_id(struct efa_resource **state, uin
 	 * We need to poll the CQ twice explicitly to point the CQE
 	 * to the saved send wr in handshake
 	 */
-	efa_rdm_cq->ibv_cq.ibv_cq_ex->status = IBV_WC_GENERAL_ERR;
-	efa_rdm_cq->ibv_cq.ibv_cq_ex->wr_id = (uintptr_t)g_ibv_submitted_wr_id_vec[0];
+	ibv_cqx->status = IBV_WC_GENERAL_ERR;
+	ibv_cqx->wr_id = (uintptr_t)g_ibv_submitted_wr_id_vec[0];
 
 	/* Progress the send wr to clean up outstanding tx ops */
 	cq_read_send_ret = fi_cq_read(resource->cq, &cq_entry, 1);


### PR DESCRIPTION
The structs efa_rdm_cq and efa_cq share the
same members util_cq and ibv_cq. This patch makes efa_rdm_cq use efa_cq as a subset so we can convert between efa_rdm_cq and efa_cq via container_of, like efa_rdm_ep and efa_base_ep.