### PR TITLE
prov/efa: Deprecate FI_AV_MAP

### DIFF
--- a/man/fi_efa.7.md
+++ b/man/fi_efa.7.md
@@ -39,7 +39,9 @@ The following features are supported:
   message size of the MTU of the underlying hardware (approximately 8 KiB).
 
 *Address vectors*
-: The provider supports *FI_AV_TABLE* and *FI_AV_MAP* address vector types.
+: The provider supports *FI_AV_TABLE*. *FI_AV_MAP* was deprecated in Libfabric 2.x.
+  Applications can still use *FI_AV_MAP* to create an address vector. But the EFA
+  provider implementation will print a warning and switch to *FI_AV_TABLE*.
   *FI_EVENT* is unsupported.
 
 *Completion events*

--- a/prov/efa/src/efa_av.h
+++ b/prov/efa/src/efa_av.h
@@ -22,8 +22,6 @@ struct efa_ah {
 struct efa_conn {
 	struct efa_ah		*ah;
 	struct efa_ep_addr	*ep_addr;
-	/* for FI_AV_TABLE, fi_addr is same as util_av_fi_addr,
-	 * for FI_AV_MAP, fi_addr is pointer to efa_conn; */
 	fi_addr_t		fi_addr;
 	fi_addr_t		util_av_fi_addr;
 	struct efa_rdm_peer	rdm_peer;


### PR DESCRIPTION
FI_AV_MAP is deprecated in Libfabric 2.x. EFA provider was overriding AV type to FI_AV_TABLE even before this change. This change removes all references to FI_AV_MAP in the EFA provider. It will print a warning and switch to FI_AV_TABLE if the application requests FI_AV_MAP.