### PR TITLE
prov/efa: Remove util_av_fi_addr from efa_conn

### DIFF
--- a/prov/efa/src/efa_av.h
+++ b/prov/efa/src/efa_av.h
@@ -23,7 +23,6 @@ struct efa_conn {
 	struct efa_ah		*ah;
 	struct efa_ep_addr	*ep_addr;
 	fi_addr_t		fi_addr;
-	fi_addr_t		util_av_fi_addr;
 	struct efa_rdm_peer	rdm_peer;
 };
 


### PR DESCRIPTION
71dd1a12 deprecates FI_AV_MAP support for the EFA provider.  With this deprecation, we no longer need to maintain util_av_fi_addr and fi_addr in the efa_conn struct b/c they will always be equal.