### PR TITLE
prov/efa: Move struct efa_ep_addr to efa_base_ep

### DIFF
--- a/prov/efa/src/efa_base_ep.h
+++ b/prov/efa/src/efa_base_ep.h
@@ -27,6 +27,18 @@ struct efa_qp {
 	uint32_t qkey;
 };
 
+#define EFA_GID_LEN	16
+
+struct efa_ep_addr {
+	uint8_t			raw[EFA_GID_LEN];
+	uint16_t		qpn;
+	uint16_t		pad;
+	uint32_t		qkey;
+	struct efa_ep_addr	*next;
+};
+
+#define EFA_EP_ADDR_LEN sizeof(struct efa_ep_addr)
+
 struct efa_av;
 
 struct efa_recv_wr {

--- a/prov/efa/src/rdm/efa_rdm_protocol.h
+++ b/prov/efa/src/rdm/efa_rdm_protocol.h
@@ -16,18 +16,7 @@
 
 #define EFA_RDM_PROTOCOL_VERSION	(4)
 
-/* raw address format. (section 1.4) */
-#define EFA_GID_LEN	16
 
-struct efa_ep_addr {
-	uint8_t			raw[EFA_GID_LEN];
-	uint16_t		qpn;
-	uint16_t		pad;
-	uint32_t		qkey;
-	struct efa_ep_addr	*next;
-};
-
-#define EFA_EP_ADDR_LEN sizeof(struct efa_ep_addr)
 
 /*
  * Extra Feature/Request Flags (section 2.1)


### PR DESCRIPTION
struct efa_ep_addr is used in both the DGRAM and RDM providers, so the structure definition should be in a common file, and not an RDM only file.