### PR TITLE
core,prov/efa: Regulate the usage of optnames

### DIFF
--- a/man/fi_efa.7.md
+++ b/man/fi_efa.7.md
@@ -115,7 +115,8 @@ provider for AWS Neuron or Habana SynapseAI.
   these operations are assisted by hardware support (return value is false).
 
 *FI_OPT_EFA_USE_DEVICE_RDMA - bool*
-: Only available if the application selects a libfabric API version >= 1.18.
+: These option only applies to the fi_setopt() call.
+  Only available if the application selects a libfabric API version >= 1.18.
   This option allows an application to change libfabric's behavior
   with respect to RDMA transfers.  Note that there is also an environment
   variable FI_EFA_USE_DEVICE_RDMA which the user may set as well.  If the
@@ -131,7 +132,8 @@ provider for AWS Neuron or Habana SynapseAI.
   revisions.
 
 *FI_OPT_EFA_SENDRECV_IN_ORDER_ALIGNED_128_BYTES - bool*
-: It is used to force the endpoint to use in-order send/recv operation for each 128 bytes
+: These option only applies to the fi_setopt() call.
+  It is used to force the endpoint to use in-order send/recv operation for each 128 bytes
   aligned block. Enabling the option will guarantee data inside each 128 bytes
   aligned block being sent and received in order, it will also guarantee data
   to be delivered to the receive buffer only once. If endpoint is not able to
@@ -139,7 +141,8 @@ provider for AWS Neuron or Habana SynapseAI.
 
 
 *FI_OPT_EFA_WRITE_IN_ORDER_ALIGNED_128_BYTES - bool*
-: It is used to set the endpoint to use in-order RDMA write operation for each 128 bytes
+: These option only applies to the fi_setopt() call..
+  It is used to set the endpoint to use in-order RDMA write operation for each 128 bytes
   aligned block. Enabling the option will guarantee data inside each 128 bytes
   aligned block being written in order, it will also guarantee data to be
   delivered to the target buffer only once. If endpoint is not able to support

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -537,7 +537,8 @@ The following option levels and option names and parameters are defined.
   All providers that support FI_HMEM capability implement this option.
 
 - *FI_OPT_SHARED_MEMORY_PERMITTED - bool*
-: This option controls the use of shared memory for intra-node communication.
+: This option only applies to the fi_setopt call.
+  This option controls the use of shared memory for intra-node communication.
   Setting it to true will allow the use of shared memory. When set to false,
   shared memory will not be used and the implementation of intra-node communication
   is provider dependent.

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -1883,24 +1883,6 @@ static int efa_rdm_ep_getopt(fid_t fid, int level, int optname, void *optval,
 		*(bool *)optval = true;
 		*optlen = sizeof(bool);
 		break;
-	case FI_OPT_EFA_USE_DEVICE_RDMA:
-		if (*optlen < sizeof(bool))
-			return -FI_ETOOSMALL;
-		*(bool *)optval = efa_rdm_ep->use_device_rdma;
-		*optlen = sizeof(bool);
-		break;
-	case FI_OPT_EFA_SENDRECV_IN_ORDER_ALIGNED_128_BYTES:
-		if (*optlen < sizeof(bool))
-			return -FI_ETOOSMALL;
-		*(bool *)optval = efa_rdm_ep->sendrecv_in_order_aligned_128_bytes;
-		*optlen = sizeof(bool);
-		break;
-	case FI_OPT_EFA_WRITE_IN_ORDER_ALIGNED_128_BYTES:
-		if (*optlen < sizeof(bool))
-			return -FI_ETOOSMALL;
-		*(bool *)optval = efa_rdm_ep->write_in_order_aligned_128_bytes;
-		*optlen = sizeof(bool);
-		break;
 	default:
 		EFA_INFO(FI_LOG_EP_CTRL, "Unknown endpoint option\n");
 		return -FI_ENOPROTOOPT;

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -892,9 +892,6 @@ void test_efa_rdm_ep_getopt(struct efa_resource **state, size_t opt_len, int exp
 		FI_OPT_EFA_EMULATED_READ,
 		FI_OPT_EFA_EMULATED_WRITE,
 		FI_OPT_EFA_EMULATED_ATOMICS,
-		FI_OPT_EFA_USE_DEVICE_RDMA,
-		FI_OPT_EFA_SENDRECV_IN_ORDER_ALIGNED_128_BYTES,
-		FI_OPT_EFA_WRITE_IN_ORDER_ALIGNED_128_BYTES
 	};
 	size_t num_opt_names = sizeof(opt_names) / sizeof(int);
 


### PR DESCRIPTION
This PR contains two commits to regulate the usage of some optnames for the fi_setopt/fi_getopt calls,
including the EFA specific ones:

FI_OPT_EFA_USE_DEVICE_RDMA, FI_OPT_EFA_SENDRECV_IN_ORDER_ALIGNED_128_BYTES,
and FI_OPT_EFA_WRITE_IN_ORDER_ALIGNED_128_BYTES

and the common one: FI_OPT_SHARED_MEMORY_PERMITTED

