### PR TITLE
prov/efa: Make DGRAM provider use new av_entry struct

### DIFF
--- a/prov/efa/src/efa_av.h
+++ b/prov/efa/src/efa_av.h
@@ -7,6 +7,7 @@
 #include <infiniband/verbs.h>
 #include "rdm/efa_rdm_protocol.h"
 #include "rdm/efa_rdm_peer.h"
+#include "efa_base_ep.h"
 
 #define EFA_MIN_AV_SIZE (16384)
 #define EFA_SHM_MAX_AV_COUNT       (256)
@@ -31,6 +32,12 @@ struct efa_av_entry {
 	struct efa_conn		conn;
 };
 
+struct efa_base_av_entry {
+	struct efa_ep_addr	ep_addr;
+	struct efa_ah		*ah;
+	fi_addr_t		fi_addr;
+};
+
 struct efa_cur_reverse_av_key {
 	uint16_t ahn;
 	uint16_t qpn;
@@ -39,6 +46,12 @@ struct efa_cur_reverse_av_key {
 struct efa_cur_reverse_av {
 	struct efa_cur_reverse_av_key key;
 	struct efa_conn *conn;
+	UT_hash_handle hh;
+};
+
+struct efa_dgram_reverse_av {
+	struct efa_cur_reverse_av_key key;
+	struct efa_base_av_entry *av_entry;
 	UT_hash_handle hh;
 };
 
@@ -67,6 +80,7 @@ struct efa_av {
 	 */
 	struct efa_cur_reverse_av *cur_reverse_av;
 	struct efa_prv_reverse_av *prv_reverse_av;
+	struct efa_dgram_reverse_av *dgram_reverse_av;
 	struct efa_ah *ah_map;
 	struct util_av util_av;
 	enum fi_ep_type ep_type;
@@ -80,6 +94,9 @@ int efa_av_insert_one(struct efa_av *av, struct efa_ep_addr *addr,
 		      bool insert_shm_av);
 
 struct efa_conn *efa_av_addr_to_conn(struct efa_av *av, fi_addr_t fi_addr);
+
+
+struct efa_base_av_entry *efa_av_addr_to_base_av_entry(struct efa_av *av, fi_addr_t fi_addr);
 
 fi_addr_t efa_av_reverse_lookup_rdm(struct efa_av *av, uint16_t ahn, uint16_t qpn, struct efa_rdm_pke *pkt_entry);
 

--- a/prov/efa/src/efa_base_ep.h
+++ b/prov/efa/src/efa_base_ep.h
@@ -27,6 +27,18 @@ struct efa_qp {
 	uint32_t qkey;
 };
 
+#define EFA_GID_LEN	16
+
+struct efa_ep_addr {
+	uint8_t			raw[EFA_GID_LEN];
+	uint16_t		qpn;
+	uint16_t		pad;
+	uint32_t		qkey;
+	struct efa_ep_addr	*next;
+};
+
+#define EFA_EP_ADDR_LEN sizeof(struct efa_ep_addr)
+
 struct efa_av;
 
 struct efa_recv_wr {

--- a/prov/efa/src/rdm/efa_rdm_protocol.h
+++ b/prov/efa/src/rdm/efa_rdm_protocol.h
@@ -16,18 +16,7 @@
 
 #define EFA_RDM_PROTOCOL_VERSION	(4)
 
-/* raw address format. (section 1.4) */
-#define EFA_GID_LEN	16
 
-struct efa_ep_addr {
-	uint8_t			raw[EFA_GID_LEN];
-	uint16_t		qpn;
-	uint16_t		pad;
-	uint32_t		qkey;
-	struct efa_ep_addr	*next;
-};
-
-#define EFA_EP_ADDR_LEN sizeof(struct efa_ep_addr)
 
 /*
  * Extra Feature/Request Flags (section 2.1)

--- a/prov/efa/test/efa_unit_test_cq.c
+++ b/prov/efa/test/efa_unit_test_cq.c
@@ -874,7 +874,7 @@ static void test_efa_cq_read(struct efa_resource *resource, fi_addr_t *addr,
 	ibv_cqx->read_src_qp = &efa_mock_ibv_read_src_qp_return_mock;
 	ibv_cqx->read_wc_flags = &efa_mock_ibv_read_wc_flags_return_mock;
 	will_return_maybe(efa_mock_ibv_read_byte_len_return_mock, 4096);
-	will_return_maybe(efa_mock_ibv_read_slid_return_mock, efa_av_addr_to_conn(base_ep->av, *addr)->ah->ahn);
+	will_return_maybe(efa_mock_ibv_read_slid_return_mock, efa_av_addr_to_base_av_entry(base_ep->av, *addr)->ah->ahn);
 	will_return_maybe(efa_mock_ibv_read_src_qp_return_mock, raw_addr.qpn);
 	will_return_maybe(efa_mock_ibv_read_wc_flags_return_mock, 0);
 #endif


### PR DESCRIPTION
Update the DGRAM provider to use the new efa_base_av_entry structure. This change splits the AV logic for the DGRAM and the RDM providers. Splitting the av logic for DGRAM makes DGRAM's AV logic simpler and faster in a few ways.

1. This change removes the efa_con struct from the av_entry because the DGRAM protocol does not maintain an idea of a connection to the endpoint receiving the messages. It does not matter if the remote endpoint we were previously communicating with exits, and a new QP opens with the same AH (NIC), and QPN (Endpoint). As long as someone is there to post recv buffers for our messages, DGRAM provider is happy.

2. This changes gets rid of the current/prev av reverse lookup map (ahn/qpn -> av_entry), and creates a single reverse look up map because the dgram provider does not care about old connections.