### PR TITLE
prov/efa: Implement FI_CONTEXT2 in EFA Direct

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -107,6 +107,41 @@ struct efa_fabric {
 #endif
 };
 
+struct efa_context {
+	uint64_t completion_flags;
+	fi_addr_t addr;
+};
+
+#if defined(static_assert)
+static_assert(sizeof(struct efa_context) <= sizeof(struct fi_context2),
+	      "efa_context must not be larger than fi_context2");
+#endif
+
+/**
+ * Prepare and return a pointer to an EFA context structure.
+ *
+ * @param context           Pointer to the msg context.
+ * @param addr              Peer address associated with the operation.
+ * @param flags             Operation flags (e.g., FI_COMPLETION).
+ * @param completion_flags  Completion flags reported in the cq entry.
+ * @return A pointer to an initialized EFA context structure,
+ *  or NULL if context is invalid or FI_COMPLETION is not set.
+ */
+static inline struct efa_context *efa_fill_context(const void *context,
+						   fi_addr_t addr,
+						   uint64_t flags,
+						   uint64_t completion_flags)
+{
+	if (!context || !(flags & FI_COMPLETION))
+		return NULL;
+
+	struct efa_context *efa_context = (struct efa_context *) context;
+	efa_context->completion_flags = completion_flags;
+	efa_context->addr = addr;
+
+	return efa_context;
+}
+
 static inline
 int efa_str_to_ep_addr(const char *node, const char *service, struct efa_ep_addr *addr)
 {

--- a/prov/efa/src/efa_msg.c
+++ b/prov/efa/src/efa_msg.c
@@ -101,7 +101,8 @@ static inline ssize_t efa_post_recv(struct efa_base_ep *base_ep, const struct fi
 	wr = &base_ep->efa_recv_wr_vec[wr_index].wr;
 	wr->num_sge = msg->iov_count;
 	wr->sg_list = base_ep->efa_recv_wr_vec[wr_index].sge;
-	wr->wr_id = (uintptr_t) ((flags & FI_COMPLETION) ? msg->context : NULL);
+	wr->wr_id = (uintptr_t) efa_fill_context(msg->context, msg->addr, flags,
+						 FI_RECV | FI_MSG);
 
 	for (i = 0; i < msg->iov_count; i++) {
 		addr = (uintptr_t)msg->msg_iov[i].iov_base;
@@ -224,7 +225,8 @@ static inline ssize_t efa_post_send(struct efa_base_ep *base_ep, const struct fi
 		base_ep->is_wr_started = true;
 	}
 
-	qp->ibv_qp_ex->wr_id = (uintptr_t) ((flags & FI_COMPLETION) ? msg->context : NULL);
+	qp->ibv_qp_ex->wr_id = (uintptr_t) efa_fill_context(
+		msg->context, msg->addr, flags, FI_SEND | FI_MSG);
 
 	if (flags & FI_REMOTE_CQ_DATA) {
 		ibv_wr_send_imm(qp->ibv_qp_ex, msg->data);

--- a/prov/efa/src/efa_rma.c
+++ b/prov/efa/src/efa_rma.c
@@ -90,7 +90,9 @@ static inline ssize_t efa_rma_post_read(struct efa_base_ep *base_ep,
 		ibv_wr_start(qp->ibv_qp_ex);
 		base_ep->is_wr_started = true;
 	}
-	qp->ibv_qp_ex->wr_id = (uintptr_t) ((flags & FI_COMPLETION) ? msg->context : NULL);
+
+	qp->ibv_qp_ex->wr_id = (uintptr_t) efa_fill_context(
+		msg->context, msg->addr, flags, FI_RMA | FI_READ);
 
 	/* ep->domain->info->tx_attr->rma_iov_limit is set to 1 */
 	ibv_wr_rdma_read(qp->ibv_qp_ex, msg->rma_iov[0].key, msg->rma_iov[0].addr);
@@ -225,7 +227,9 @@ static inline ssize_t efa_rma_post_write(struct efa_base_ep *base_ep,
 		ibv_wr_start(qp->ibv_qp_ex);
 		base_ep->is_wr_started = true;
 	}
-	qp->ibv_qp_ex->wr_id = (uintptr_t) ((flags & FI_COMPLETION) ? msg->context : NULL);
+
+	qp->ibv_qp_ex->wr_id = (uintptr_t) efa_fill_context(
+		msg->context, msg->addr, flags, FI_RMA | FI_WRITE);
 
 	if (flags & FI_REMOTE_CQ_DATA) {
 		ibv_wr_rdma_write_imm(qp->ibv_qp_ex, msg->rma_iov[0].key,

--- a/prov/efa/src/rdm/efa_rdm_pke.h
+++ b/prov/efa/src/rdm/efa_rdm_pke.h
@@ -195,7 +195,7 @@ struct efa_rdm_pke {
 	_Alignas(EFA_RDM_PKE_ALIGNMENT) char wiredata[0];
 };
 
-#if defined(static_assert) && defined(__x86_64__)
+#if defined(static_assert)
 static_assert(sizeof (struct efa_rdm_pke) % EFA_RDM_PKE_ALIGNMENT == 0, "efa_rdm_pke alignment check");
 #endif
 

--- a/prov/efa/src/rdm/efa_rdm_protocol.h
+++ b/prov/efa/src/rdm/efa_rdm_protocol.h
@@ -115,7 +115,7 @@ struct efa_ep_addr {
 #define EFA_RDM_RUNT_PKT_END		148
 #define EFA_RDM_EXTRA_REQ_PKT_END   	148
 
-#if defined(static_assert) && defined(__x86_64__)
+#if defined(static_assert)
 #define EFA_RDM_ENSURE_HEADER_SIZE(hdr, size)	\
 	static_assert(sizeof (struct hdr) == (size), #hdr " size check")
 #else

--- a/prov/efa/src/rdm/efa_rdm_util.h
+++ b/prov/efa/src/rdm/efa_rdm_util.h
@@ -10,7 +10,7 @@
 
 #define EFA_RDM_MSG_PREFIX_SIZE (sizeof(struct efa_rdm_pke) + sizeof(struct efa_rdm_eager_msgrtm_hdr) + EFA_RDM_REQ_OPT_RAW_ADDR_HDR_SIZE)
 
-#if defined(static_assert) && defined(__x86_64__)
+#if defined(static_assert)
 static_assert(EFA_RDM_MSG_PREFIX_SIZE % 8 == 0, "message prefix size alignment check");
 #endif
 


### PR DESCRIPTION
Store the completion flags and peer address in FI_CONTEXT2 and retrieve later when writing cq.