### PR TITLE
prov/efa: fix leak of dmabuf fd in cuda p2p probe

### DIFF
--- a/prov/efa/src/efa_hmem.c
+++ b/prov/efa/src/efa_hmem.c
@@ -129,6 +129,7 @@ static inline void efa_hmem_info_check_p2p_support_cuda(struct efa_hmem_info *in
 	if (ret == FI_SUCCESS) {
 		ibv_mr = ibv_reg_dmabuf_mr(g_device_list[0].ibv_pd, dmabuf_offset,
 					   len, (uint64_t)ptr, dmabuf_fd, ibv_access);
+		(void)close(dmabuf_fd);
 		if (!ibv_mr) {
 			EFA_INFO(FI_LOG_CORE,
 				"Unable to register CUDA device buffer via dmabuf: %s. "


### PR DESCRIPTION
prior to this patch, when efa_hmem_info_check_p2p_support_cuda elected to attempt dmabuf for p2p, we previously leaked the file descriptor returned by cuMemGetHandleForAddressRange in all cases. This ultimately meant the dmabuf stuck around for the lifetime of the process, even after dereg and after releasing the memory back to the device mempool.

All calls to cuda_get_dmabuf_fd need a corresponding close call.