### PR TITLE
prov/cxi: Add FI_CXI_CURL_LIB_PATH #define from autoconf 

### DIFF
--- a/prov/cxi/configure.m4
+++ b/prov/cxi/configure.m4
@@ -35,8 +35,10 @@ AC_DEFUN([FI_CXI_CONFIGURE],[
 		[CPPFLAGS="-I$with_cxi_uapi_headers/include $CPPFLAGS"])
 
 	# Support non-standard install path for curl. This is needed by CXI provider.
+	# Add #define of the path to the curl library for use in the code
 	AC_ARG_WITH([curl],
-		[AS_HELP_STRING([--with-curl=DIR], [Install directory for curl])])
+		[AS_HELP_STRING([--with-curl=DIR], [Install directory for curl])],
+		[AC_DEFINE_UNQUOTED([FI_CXI_CURL_LIB_PATH], ["$with_curl"], [Path to the curl install root])])
 
 	# Support non-standard install path for json-c. This is needed by CXI provider.
 	AC_ARG_WITH([json-c],


### PR DESCRIPTION
fix #10710 

ensures libcurl dlopen path is correct

If the user passes '--with-curl=<path>' to configure, then the dlopen of libcurl should honor that selection and use the file path passed in