### PR TITLE
hmem: Define ofi_hmem_put_dmabuf_fd

### DIFF
--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -168,6 +168,7 @@ int rocr_dev_reg_copy_from_hmem(uint64_t handle, void *dest, const void *src,
 				size_t size);
 int rocr_hmem_get_dmabuf_fd(const void *addr, uint64_t size, int *dmabuf_fd,
 			    uint64_t *offset);
+int rocr_hmem_put_dmabuf_fd(int fd);
 
 int cuda_copy_to_dev(uint64_t device, void *dev, const void *host, size_t size);
 int cuda_copy_from_dev(uint64_t device, void *host, const void *dev, size_t size);

--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -131,6 +131,7 @@ struct ofi_hmem_ops {
 				      const void *src, size_t size);
 	int (*get_dmabuf_fd)(const void *addr, uint64_t size, int *fd,
 			     uint64_t *offset);
+	int (*put_dmabuf_fd)(int fd);
 };
 
 extern struct ofi_hmem_ops hmem_ops[];
@@ -357,6 +358,11 @@ static inline int ofi_hmem_no_get_dmabuf_fd(const void *addr, uint64_t size,
 	return -FI_ENOSYS;
 }
 
+static inline int ofi_hmem_no_put_dmabuf_fd(int fd)
+{
+	return -FI_ENOSYS;
+}
+
 static inline bool ofi_hmem_p2p_disabled(void)
 {
 	return ofi_hmem_disable_p2p;
@@ -450,5 +456,6 @@ int ofi_hmem_dev_reg_copy_from_hmem(enum fi_hmem_iface iface, uint64_t handle,
 				    void *dest, const void *src, size_t size);
 int ofi_hmem_get_dmabuf_fd(enum fi_hmem_iface, const void *addr, uint64_t size,
 			   int *fd, uint64_t *offset);
+int ofi_hmem_put_dmabuf_fd(enum fi_hmem_iface iface, int fd);
 
 #endif /* _OFI_HMEM_H_ */

--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -195,6 +195,7 @@ bool cuda_is_gdrcopy_enabled(void);
 bool cuda_is_dmabuf_supported(void);
 int cuda_get_dmabuf_fd(const void *addr, uint64_t size, int *fd,
 		       uint64_t *offset);
+int cuda_put_dmabuf_fd(int fd);
 
 void cuda_gdrcopy_to_dev(uint64_t handle, void *dev,
 			 const void *host, size_t size);

--- a/prov/cxi/include/cxip.h
+++ b/prov/cxi/include/cxip.h
@@ -821,8 +821,10 @@ struct cxip_md {
 	struct cxi_md *md;
 	struct ofi_mr_info info;
 	uint64_t handle;
+	int dmabuf_fd;
 	bool handle_valid;
 	bool cached;
+	bool dmabuf_fd_valid;
 };
 
 #define CXIP_MR_DOMAIN_HT_BUCKETS 16

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -141,6 +141,7 @@ struct ofi_hmem_ops hmem_ops[] = {
 		.dev_reg_copy_to_hmem = ofi_hmem_system_dev_reg_copy,
 		.dev_reg_copy_from_hmem = ofi_hmem_system_dev_reg_copy,
 		.get_dmabuf_fd = ofi_hmem_no_get_dmabuf_fd,
+		.put_dmabuf_fd = ofi_hmem_no_put_dmabuf_fd,
 	},
 	[FI_HMEM_CUDA] = {
 		.initialized = false,
@@ -167,6 +168,7 @@ struct ofi_hmem_ops hmem_ops[] = {
 		.dev_reg_copy_to_hmem = cuda_dev_reg_copy_to_hmem,
 		.dev_reg_copy_from_hmem = cuda_dev_reg_copy_from_hmem,
 		.get_dmabuf_fd = cuda_get_dmabuf_fd,
+		.put_dmabuf_fd = ofi_hmem_no_put_dmabuf_fd,
 	},
 	[FI_HMEM_ROCR] = {
 		.initialized = false,
@@ -193,6 +195,7 @@ struct ofi_hmem_ops hmem_ops[] = {
 		.dev_reg_copy_to_hmem = rocr_dev_reg_copy_to_hmem,
 		.dev_reg_copy_from_hmem = rocr_dev_reg_copy_from_hmem,
 		.get_dmabuf_fd = rocr_hmem_get_dmabuf_fd,
+		.put_dmabuf_fd = ofi_hmem_no_put_dmabuf_fd,
 	},
 	[FI_HMEM_ZE] = {
 		.initialized = false,
@@ -219,6 +222,7 @@ struct ofi_hmem_ops hmem_ops[] = {
 		.dev_reg_copy_to_hmem = ze_dev_reg_copy_to_hmem,
 		.dev_reg_copy_from_hmem = ze_dev_reg_copy_from_hmem,
 		.get_dmabuf_fd = ze_hmem_get_dmabuf_fd,
+		.put_dmabuf_fd = ofi_hmem_no_put_dmabuf_fd,
 	},
 	[FI_HMEM_NEURON] = {
 		.initialized = false,
@@ -244,6 +248,7 @@ struct ofi_hmem_ops hmem_ops[] = {
 		.dev_reg_copy_to_hmem = ofi_hmem_no_dev_reg_copy_to_hmem,
 		.dev_reg_copy_from_hmem = ofi_hmem_no_dev_reg_copy_from_hmem,
 		.get_dmabuf_fd = neuron_get_dmabuf_fd,
+		.put_dmabuf_fd = ofi_hmem_no_put_dmabuf_fd,
 	},
 	[FI_HMEM_SYNAPSEAI] = {
 		.initialized = false,
@@ -269,6 +274,7 @@ struct ofi_hmem_ops hmem_ops[] = {
 		.dev_reg_copy_to_hmem = ofi_hmem_no_dev_reg_copy_to_hmem,
 		.dev_reg_copy_from_hmem = ofi_hmem_no_dev_reg_copy_from_hmem,
 		.get_dmabuf_fd = synapseai_get_dmabuf_fd,
+		.put_dmabuf_fd = ofi_hmem_no_put_dmabuf_fd,
 	},
 };
 
@@ -819,4 +825,9 @@ int ofi_hmem_get_dmabuf_fd(enum fi_hmem_iface iface, const void *addr,
 			   uint64_t size, int *fd, uint64_t *offset)
 {
 	return hmem_ops[iface].get_dmabuf_fd(addr, size, fd, offset);
+}
+
+int ofi_hmem_put_dmabuf_fd(enum fi_hmem_iface iface, int fd)
+{
+	return hmem_ops[iface].put_dmabuf_fd(fd);
 }

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -168,7 +168,7 @@ struct ofi_hmem_ops hmem_ops[] = {
 		.dev_reg_copy_to_hmem = cuda_dev_reg_copy_to_hmem,
 		.dev_reg_copy_from_hmem = cuda_dev_reg_copy_from_hmem,
 		.get_dmabuf_fd = cuda_get_dmabuf_fd,
-		.put_dmabuf_fd = ofi_hmem_no_put_dmabuf_fd,
+		.put_dmabuf_fd = cuda_put_dmabuf_fd,
 	},
 	[FI_HMEM_ROCR] = {
 		.initialized = false,

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -195,7 +195,7 @@ struct ofi_hmem_ops hmem_ops[] = {
 		.dev_reg_copy_to_hmem = rocr_dev_reg_copy_to_hmem,
 		.dev_reg_copy_from_hmem = rocr_dev_reg_copy_from_hmem,
 		.get_dmabuf_fd = rocr_hmem_get_dmabuf_fd,
-		.put_dmabuf_fd = ofi_hmem_no_put_dmabuf_fd,
+		.put_dmabuf_fd = rocr_hmem_put_dmabuf_fd,
 	},
 	[FI_HMEM_ZE] = {
 		.initialized = false,

--- a/src/hmem_cuda.c
+++ b/src/hmem_cuda.c
@@ -748,6 +748,16 @@ int cuda_get_dmabuf_fd(const void *addr, uint64_t size, int *fd,
 #endif /* HAVE_CUDA_DMABUF */
 }
 
+int cuda_put_dmabuf_fd(int fd)
+{
+#if HAVE_CUDA_DMABUF
+	close(fd);
+	return FI_SUCCESS;
+#else
+	return -FI_ENOSYS;
+#endif /* HAVE_CUDA_DMABUF */
+}
+
 int cuda_hmem_init(void)
 {
 	int ret;
@@ -1043,6 +1053,11 @@ bool cuda_is_dmabuf_supported(void)
 
 int cuda_get_dmabuf_fd(const void *addr, uint64_t size, int *fd,
 		       uint64_t *offset)
+{
+	return -FI_ENOSYS;
+}
+
+int cuda_put_dmabuf_fd(int fd)
 {
 	return -FI_ENOSYS;
 }


### PR DESCRIPTION
For some HMEM ifaces, ofi_hmem_get_dmabuf_fd() may result in a new FD being allocated. Define ofi_hmem_put_dmabuf_fd() to close FD.

Support ofi_hmem_get_dmabuf_fd() with ROCR.

Update CXI provider accordingly.
