### PR TITLE
cleanup mrecx entry if current rx processing failed

### DIFF
--- a/prov/tcp/src/xnet.h
+++ b/prov/tcp/src/xnet.h
@@ -228,6 +228,8 @@ struct xnet_srx {
 	xnet_profile_t *profile;
 };
 
+bool
+xnet_srx_cancel_rx(struct xnet_srx *srx, struct slist *queue, void *context);
 int xnet_srx_context(struct fid_domain *domain, struct fi_rx_attr *attr,
 		     struct fid_ep **rx_ep, void *context);
 

--- a/prov/tcp/src/xnet_progress.c
+++ b/prov/tcp/src/xnet_progress.c
@@ -1114,6 +1114,8 @@ static void xnet_complete_rx(struct xnet_ep *ep, ssize_t ret)
 cq_error:
 	FI_WARN(&xnet_prov, FI_LOG_EP_DATA,
 		"msg recv failed ret = %zd (%s)\n", ret, fi_strerror((int)-ret));
+	if (rx_entry->ctrl_flags & XNET_MULTI_RECV)
+		xnet_srx_cancel_rx(ep->srx, &ep->srx->rx_queue, rx_entry->context);
 	xnet_cntr_incerr(rx_entry);
 	xnet_report_error(rx_entry, (int) -ret);
 	xnet_free_xfer(xnet_ep2_progress(ep), rx_entry);

--- a/prov/tcp/src/xnet_srx.c
+++ b/prov/tcp/src/xnet_srx.c
@@ -712,7 +712,7 @@ found:
 	return rx_entry;
 }
 
-static bool
+bool
 xnet_srx_cancel_rx(struct xnet_srx *srx, struct slist *queue, void *context)
 {
 	struct slist_entry *cur, *prev;


### PR DESCRIPTION
mrecx entry should be removed if the current rx processing failed, otherwise the following process from the upper layer may pick up this stale rx.