### PR TITLE
fabtests: Add support for FI_CONTEXT2

### DIFF
--- a/fabtests/benchmarks/dgram_pingpong.c
+++ b/fabtests/benchmarks/dgram_pingpong.c
@@ -127,7 +127,7 @@ int main(int argc, char **argv)
 	if (opts.options & FT_OPT_SIZE)
 		hints->ep_attr->max_msg_size = opts.transfer_size;
 	hints->caps = FI_MSG;
-	hints->mode |= FI_CONTEXT;
+	hints->mode |= FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->tx_attr->tclass = FI_TC_LOW_LATENCY;
 	hints->addr_format = opts.address_format;

--- a/fabtests/benchmarks/rdm_bw.c
+++ b/fabtests/benchmarks/rdm_bw.c
@@ -80,7 +80,7 @@ int main(int argc, char **argv)
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->domain_attr->resource_mgmt = FI_RM_ENABLED;
 	hints->caps = FI_MSG;
-	hints->mode |= FI_CONTEXT;
+	hints->mode |= FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->tx_attr->tclass = FI_TC_BULK_DATA;
 	hints->addr_format = opts.address_format;

--- a/fabtests/benchmarks/rdm_cntr_pingpong.c
+++ b/fabtests/benchmarks/rdm_cntr_pingpong.c
@@ -106,7 +106,7 @@ int main(int argc, char **argv)
 	hints->domain_attr->threading = FI_THREAD_DOMAIN;
 	hints->tx_attr->tclass = FI_TC_LOW_LATENCY;
 	hints->addr_format = opts.address_format;
-	hints->mode |= FI_CONTEXT;
+	hints->mode |= FI_CONTEXT | FI_CONTEXT2;
 
 	ret = run();
 

--- a/fabtests/benchmarks/rdm_pingpong.c
+++ b/fabtests/benchmarks/rdm_pingpong.c
@@ -73,7 +73,7 @@ int main(int argc, char **argv)
 
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_MSG;
-	hints->mode |= FI_CONTEXT;
+	hints->mode |= FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->tx_attr->tclass = FI_TC_LOW_LATENCY;
 	hints->addr_format = opts.address_format;

--- a/fabtests/benchmarks/rdm_tagged_bw.c
+++ b/fabtests/benchmarks/rdm_tagged_bw.c
@@ -105,7 +105,7 @@ int main(int argc, char **argv)
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->domain_attr->resource_mgmt = FI_RM_ENABLED;
 	hints->caps = FI_TAGGED;
-	hints->mode |= FI_CONTEXT;
+	hints->mode |= FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->tx_attr->tclass = FI_TC_BULK_DATA;
 	hints->addr_format = opts.address_format;

--- a/fabtests/benchmarks/rdm_tagged_pingpong.c
+++ b/fabtests/benchmarks/rdm_tagged_pingpong.c
@@ -73,7 +73,7 @@ int main(int argc, char **argv)
 
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_TAGGED;
-	hints->mode |= FI_CONTEXT;
+	hints->mode |= FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->tx_attr->tclass = FI_TC_LOW_LATENCY;
 	hints->addr_format = opts.address_format;

--- a/fabtests/benchmarks/rma_bw.c
+++ b/fabtests/benchmarks/rma_bw.c
@@ -93,7 +93,7 @@ int main(int argc, char **argv)
 
 	hints->caps = FI_MSG | FI_RMA;
 	hints->domain_attr->resource_mgmt = FI_RM_ENABLED;
-	hints->mode = FI_CONTEXT;
+	hints->mode = FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->threading = FI_THREAD_DOMAIN;
 	hints->addr_format = opts.address_format;
 

--- a/fabtests/benchmarks/rma_pingpong.c
+++ b/fabtests/benchmarks/rma_pingpong.c
@@ -93,7 +93,7 @@ int main(int argc, char **argv)
 
 	hints->caps = FI_MSG | FI_RMA | FI_WRITE | FI_REMOTE_WRITE;
 	hints->domain_attr->resource_mgmt = FI_RM_ENABLED;
-	hints->mode = FI_CONTEXT;
+	hints->mode = FI_CONTEXT | FI_CONTEXT2;
 	hints->addr_format = opts.address_format;
 
 	while ((op = getopt_long(argc, argv, "Uh" CS_OPTS INFO_OPTS API_OPTS

--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -73,7 +73,7 @@ struct fid_eq *eq;
 struct fid_mc *mc;
 
 struct fid_mr no_mr;
-struct fi_context tx_ctx, rx_ctx;
+struct fi_context2 tx_ctx, rx_ctx;
 struct ft_context *tx_ctx_arr = NULL, *rx_ctx_arr = NULL;
 uint64_t remote_cq_data = 0;
 
@@ -3231,7 +3231,7 @@ int ft_wait_child(void)
 int ft_finalize_ep(struct fid_ep *ep)
 {
 	int ret;
-	struct fi_context ctx;
+	struct fi_context2 ctx;
 
 	ret = ft_sendmsg(ep, remote_fi_addr, tx_buf, 4, &ctx, FI_TRANSMIT_COMPLETE);
 	if (ret)

--- a/fabtests/functional/av_xfer.c
+++ b/fabtests/functional/av_xfer.c
@@ -235,7 +235,7 @@ int main(int argc, char **argv)
 
 	hints->caps = hints->ep_attr->type == FI_EP_RDM ?
 		      FI_TAGGED : FI_MSG;
-	hints->mode = FI_CONTEXT;
+	hints->mode = FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->addr_format = opts.address_format;
 	base_hints = hints;

--- a/fabtests/functional/cq_data.c
+++ b/fabtests/functional/cq_data.c
@@ -164,7 +164,7 @@ int main(int argc, char **argv)
 		opts.dst_addr = argv[optind];
 
 	hints->domain_attr->cq_data_size = 4;  /* required minimum */
-	hints->mode |= FI_CONTEXT | FI_RX_CQ_DATA;
+	hints->mode |= FI_CONTEXT | FI_CONTEXT2 | FI_RX_CQ_DATA;
 
 	hints->caps = FI_MSG;
 	if (opts.cqdata_op == FT_CQDATA_WRITEDATA)

--- a/fabtests/functional/dgram.c
+++ b/fabtests/functional/dgram.c
@@ -74,7 +74,7 @@ int main(int argc, char **argv)
 
 	hints->ep_attr->type		= FI_EP_DGRAM;
 	hints->caps			= FI_MSG;
-	hints->mode			= FI_CONTEXT;
+	hints->mode			= FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->mr_mode 	= opts.mr_mode;
 	hints->addr_format		= opts.address_format;
 

--- a/fabtests/functional/flood.c
+++ b/fabtests/functional/flood.c
@@ -283,7 +283,7 @@ int main(int argc, char **argv)
 		opts.dst_addr = argv[optind];
 
 	hints->caps = FI_MSG;
-	hints->mode = FI_CONTEXT;
+	hints->mode = FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->addr_format = opts.address_format;
 

--- a/fabtests/functional/inject_test.c
+++ b/fabtests/functional/inject_test.c
@@ -86,7 +86,7 @@ static int send_msg(int sendmsg, size_t size)
 static int receive_msg(size_t size)
 {
 	int ret;
-	struct fi_context inj_ctx;
+	struct fi_context2 inj_ctx;
 	ft_tag = 0xabcd;
 
 	ret = ft_post_rx(ep, size, &inj_ctx);
@@ -194,7 +194,7 @@ int main(int argc, char **argv)
 		opts.dst_addr = argv[optind];
 
 	hints->ep_attr->type = FI_EP_RDM;
-	hints->mode = FI_CONTEXT;
+	hints->mode = FI_CONTEXT | FI_CONTEXT2;
 	hints->caps = FI_TAGGED;
 	hints->domain_attr->resource_mgmt = FI_RM_ENABLED;
 	hints->domain_attr->mr_mode = opts.mr_mode;

--- a/fabtests/functional/loopback.c
+++ b/fabtests/functional/loopback.c
@@ -90,7 +90,7 @@ int main(int argc, char **argv)
 	opts.src_addr = "127.0.0.1";
 	hints->caps = FI_LOCAL_COMM | FI_MSG | FI_TAGGED;
 	hints->ep_attr->type = FI_EP_RDM;
-	hints->mode = FI_CONTEXT;
+	hints->mode = FI_CONTEXT | FI_CONTEXT2;
 
 	while ((op = getopt(argc, argv, "h" INFO_OPTS)) != -1) {
 		switch (op) {

--- a/fabtests/functional/mcast.c
+++ b/fabtests/functional/mcast.c
@@ -102,7 +102,7 @@ int main(int argc, char **argv)
 
 	hints->ep_attr->type		= FI_EP_DGRAM;
 	hints->caps			= FI_MSG | FI_MULTICAST;
-	hints->mode			= FI_CONTEXT;
+	hints->mode			= FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->mr_mode 	= opts.mr_mode;
 	hints->addr_format		= opts.address_format;
 

--- a/fabtests/functional/multi_ep.c
+++ b/fabtests/functional/multi_ep.c
@@ -53,8 +53,8 @@ static char **send_bufs, **recv_bufs;
 static struct fid_mr **send_mrs, **recv_mrs;
 static void **send_descs, **recv_descs;
 static struct fi_rma_iov *peer_iovs;
-static struct fi_context *recv_ctx;
-static struct fi_context *send_ctx;
+static struct fi_context2 *recv_ctx;
+static struct fi_context2 *send_ctx;
 static struct fid_cq **txcqs, **rxcqs;
 static struct fid_av **avs;
 static fi_addr_t *remote_fiaddr;
@@ -657,7 +657,7 @@ int main(int argc, char **argv)
 		opts.dst_addr = argv[optind];
 
 	hints->caps = FI_MSG | FI_RMA;
-	hints->mode = FI_CONTEXT;
+	hints->mode = FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->addr_format = opts.address_format;
 

--- a/fabtests/functional/multi_mr.c
+++ b/fabtests/functional/multi_mr.c
@@ -178,7 +178,7 @@ static int init_multi_mr_res(void)
 static int mr_key_test()
 {
 	int i, ret = 0;
-	struct fi_context rma_ctx;
+	struct fi_context2 rma_ctx;
 
 	for (i = 0; i < mr_count; i++) {
 		tx_buf = (char *)mr_res_array[i].buf;
@@ -319,7 +319,7 @@ int main(int argc, char **argv)
 		opts.dst_addr = argv[optind];
 
 	hints->caps = FI_RMA | FI_RMA_EVENT | FI_MSG;
-	hints->mode = FI_CONTEXT;
+	hints->mode = FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->addr_format = opts.address_format;
 

--- a/fabtests/functional/multi_recv.c
+++ b/fabtests/functional/multi_recv.c
@@ -41,7 +41,7 @@
 #define MAX_XFER_SIZE (1 << 20)
 
 static struct fid_mr *mr_multi_recv;
-struct fi_context ctx_multi_recv[2];
+struct fi_context2 ctx_multi_recv[2];
 static int use_recvmsg, comp_per_buf;
 
 
@@ -324,7 +324,7 @@ int main(int argc, char **argv)
 
 	opts.min_multi_recv_size = opts.transfer_size;
 	hints->caps = FI_MSG | FI_MULTI_RECV;
-	hints->mode = FI_CONTEXT;
+	hints->mode = FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->rx_attr->op_flags = FI_MULTI_RECV;
 	hints->addr_format = opts.address_format;

--- a/fabtests/functional/rdm.c
+++ b/fabtests/functional/rdm.c
@@ -94,7 +94,7 @@ int main(int argc, char **argv)
 
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_MSG;
-	hints->mode = FI_CONTEXT;
+	hints->mode = FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->addr_format = opts.address_format;
 

--- a/fabtests/functional/rdm_atomic.c
+++ b/fabtests/functional/rdm_atomic.c
@@ -44,7 +44,7 @@ static void *cpy_dst;
 
 static struct fid_mr *mr_result;
 static struct fid_mr *mr_compare;
-static struct fi_context fi_ctx_atomic;
+static struct fi_context2 fi_ctx_atomic;
 
 static enum fi_datatype datatype;
 static int run_all_ops = 1, run_all_datatypes = 1;
@@ -591,7 +591,7 @@ int main(int argc, char **argv)
 
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_MSG | FI_ATOMICS;
-	hints->mode = FI_CONTEXT;
+	hints->mode = FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 
 	ret = run();

--- a/fabtests/functional/rdm_deferred_wq.c
+++ b/fabtests/functional/rdm_deferred_wq.c
@@ -633,7 +633,7 @@ int main(int argc, char **argv)
 		 tested_op == FI_OP_COMPARE_ATOMIC)
 		hints->caps |= FI_ATOMIC;
 
-	hints->mode = FI_CONTEXT;
+	hints->mode = FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->addr_format = opts.address_format;
 

--- a/fabtests/functional/rdm_multi_client.c
+++ b/fabtests/functional/rdm_multi_client.c
@@ -222,7 +222,7 @@ int main(int argc, char **argv)
 
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_MSG;
-	hints->mode = FI_CONTEXT;
+	hints->mode = FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->addr_format = opts.address_format;
 

--- a/fabtests/functional/rdm_multi_domain.c
+++ b/fabtests/functional/rdm_multi_domain.c
@@ -55,7 +55,7 @@ struct test_domain {
 	struct fid_av *av;
 	struct fid_mr *mr;
 	struct fid_cq *tx_cq;
-	struct fi_context *rma_ctx;
+	struct fi_context2 *rma_ctx;
 };
 
 struct test_domain *domain_res_array;
@@ -274,7 +274,7 @@ static void free_domain_res()
 }
 
 static int write_data(void *buffer, size_t size, int dom_idx,
-		int remote_dom_idx, struct fi_context *rma_ctx)
+		int remote_dom_idx, struct fi_context2 *rma_ctx)
 {
 	int ret = -FI_EAGAIN;
 
@@ -427,7 +427,7 @@ int main(int argc, char **argv)
 
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_RMA | FI_RMA_EVENT | FI_MSG;
-	hints->mode = FI_CONTEXT;
+	hints->mode = FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->addr_format = opts.address_format;
 

--- a/fabtests/functional/rdm_rma_event.c
+++ b/fabtests/functional/rdm_rma_event.c
@@ -39,8 +39,8 @@
 
 struct fi_rma_iov local;
 
-struct fi_context fi_ctx_write;
-struct fi_context fi_ctx_read;
+struct fi_context2 fi_ctx_write;
+struct fi_context2 fi_ctx_read;
 
 static int run_test(void)
 {
@@ -126,7 +126,7 @@ int main(int argc, char **argv)
 
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_MSG | FI_RMA | FI_RMA_EVENT;
-	hints->mode = FI_CONTEXT;
+	hints->mode = FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->addr_format = opts.address_format;
 

--- a/fabtests/functional/rdm_rma_trigger.c
+++ b/fabtests/functional/rdm_rma_trigger.c
@@ -154,7 +154,7 @@ int main(int argc, char **argv)
 
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_MSG | FI_RMA | FI_RMA_EVENT | FI_TRIGGER;
-	hints->mode = FI_CONTEXT;
+	hints->mode = FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->addr_format = opts.address_format;
 

--- a/fabtests/functional/rdm_shared_av.c
+++ b/fabtests/functional/rdm_shared_av.c
@@ -189,7 +189,7 @@ int main(int argc, char **argv)
 
 	hints->ep_attr->type	= FI_EP_RDM;
 	hints->caps		= FI_MSG | FI_SHARED_AV;
-	hints->mode		= FI_CONTEXT;
+	hints->mode		= FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->addr_format = opts.address_format;
 

--- a/fabtests/functional/rdm_tagged_peek.c
+++ b/fabtests/functional/rdm_tagged_peek.c
@@ -42,7 +42,7 @@
 #define BASE_TAG 0x900d
 #define SEND_CNT 10
 
-static struct fi_context fi_context;
+static struct fi_context2 fi_context;
 
 static int wait_for_send_comp(int count)
 {
@@ -355,7 +355,7 @@ int main(int argc, char **argv)
 	hints->rx_attr->msg_order = FI_ORDER_SAS;
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_TAGGED;
-	hints->mode = FI_CONTEXT;
+	hints->mode = FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->addr_format = opts.address_format;
 

--- a/fabtests/functional/recv_cancel.c
+++ b/fabtests/functional/recv_cancel.c
@@ -76,7 +76,7 @@ static int recv_cancel_host(void)
 	int ret = 0;
 	int retries = 0;
 	struct fi_cq_err_entry recv_completion, cancel_error_entry;
-	struct fi_context cancel_recv_ctx, standard_recv_ctx;
+	struct fi_context2 cancel_recv_ctx, standard_recv_ctx;
 
 	memset(&cancel_error_entry, 0, sizeof(cancel_error_entry));
 
@@ -246,7 +246,7 @@ int main(int argc, char **argv)
 		opts.dst_addr = argv[optind];
 
 	hints->caps = FI_TAGGED;
-	hints->mode = FI_CONTEXT;
+	hints->mode = FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->addr_format = opts.address_format;
 

--- a/fabtests/functional/resmgmt_test.c
+++ b/fabtests/functional/resmgmt_test.c
@@ -47,7 +47,7 @@ int delay, tagged;
 static int send_loop(size_t size) {
 	int q_opts = 0;
 	int ret;
-	struct fi_context send_ctx[max_opts];
+	struct fi_context2 send_ctx[max_opts];
 
 	while (q_opts < max_opts) {
 		do {
@@ -91,7 +91,7 @@ static int receive_loop(size_t size)
 {
 	int ret;
 	int q_opts = 0;
-	struct fi_context recv_ctx[max_opts];
+	struct fi_context2 recv_ctx[max_opts];
 
 	while (q_opts < max_opts) {
 		do {
@@ -262,7 +262,7 @@ int main(int argc, char **argv)
 		opts.dst_addr = argv[optind];
 
 	hints->caps = FI_MSG;
-	hints->mode = FI_CONTEXT;
+	hints->mode = FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->resource_mgmt = FI_RM_ENABLED;
 	hints->addr_format = opts.address_format;
 

--- a/fabtests/functional/shared_ctx.c
+++ b/fabtests/functional/shared_ctx.c
@@ -613,7 +613,7 @@ int main(int argc, char **argv)
 
 	if (!(hints->caps & FI_TAGGED))
 		hints->caps = FI_MSG;
-	hints->mode = FI_CONTEXT;
+	hints->mode = FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->addr_format = opts.address_format;
 

--- a/fabtests/functional/unexpected_msg.c
+++ b/fabtests/functional/unexpected_msg.c
@@ -369,7 +369,7 @@ int main(int argc, char **argv)
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
 
-	hints->mode = FI_CONTEXT;
+	hints->mode = FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->domain_attr->resource_mgmt = FI_RM_ENABLED;
 	hints->caps = FI_TAGGED;

--- a/fabtests/functional/unmap_mem.c
+++ b/fabtests/functional/unmap_mem.c
@@ -170,7 +170,7 @@ int main(int argc, char **argv)
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
 
-	hints->mode = FI_CONTEXT;
+	hints->mode = FI_CONTEXT | FI_CONTEXT2;
 	hints->caps = FI_MSG;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -251,7 +251,7 @@ extern size_t buf_size, tx_size, rx_size, tx_mr_size, rx_mr_size;
 extern int tx_fd, rx_fd;
 extern int timeout;
 
-extern struct fi_context tx_ctx, rx_ctx;
+extern struct fi_context2 tx_ctx, rx_ctx;
 extern uint64_t remote_cq_data;
 
 extern uint64_t tx_seq, rx_seq, tx_cq_cntr, rx_cq_cntr;

--- a/fabtests/man/fabtests.7.md
+++ b/fabtests/man/fabtests.7.md
@@ -339,7 +339,7 @@ The following keys and respective key values may be used in the config file.
   FI_WRITE, FI_REMOTE_READ, FI_REMOTE_WRITE, FI_TAGGED, FI_DIRECTED_RECV
 
 *mode - values OR'ed together*
-: FI_CONTEXT, FI_RX_CQ_DATA
+: FI_CONTEXT, FI_CONTEXT2, FI_RX_CQ_DATA
 
 *ep_type*
 : FI_EP_MSG, FI_EP_DGRAM, FI_EP_RDM

--- a/fabtests/multinode/src/core.c
+++ b/fabtests/multinode/src/core.c
@@ -87,7 +87,7 @@ static int multi_setup_fabric(int argc, char **argv)
 	struct fi_rma_iov remote;
 
 	hints->ep_attr->type = FI_EP_RDM;
-	hints->mode = FI_CONTEXT;
+	hints->mode = FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 
 	if (pm_job.transfer_method == multi_msg) {

--- a/fabtests/multinode/src/core_coll.c
+++ b/fabtests/multinode/src/core_coll.c
@@ -524,7 +524,7 @@ static inline void setup_hints(void)
 {
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_MSG | FI_COLLECTIVE;
-	hints->mode = FI_CONTEXT;
+	hints->mode = FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->data_progress = FI_PROGRESS_MANUAL;
 }
 

--- a/fabtests/prov/efa/src/efa_exhaust_mr_reg_rdm_pingpong.c
+++ b/fabtests/prov/efa/src/efa_exhaust_mr_reg_rdm_pingpong.c
@@ -79,7 +79,7 @@ int main(int argc, char **argv)
 
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_MSG;
-	hints->mode |= FI_CONTEXT;
+	hints->mode |= FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->addr_format = opts.address_format;
 

--- a/fabtests/prov/efa/src/rdm_rnr_queue_resend.c
+++ b/fabtests/prov/efa/src/rdm_rnr_queue_resend.c
@@ -146,7 +146,7 @@ static int trigger_rnr_queue_resend(enum fi_op atomic_op, void *result, void *co
 				    struct fid_mr *mr_result, struct fid_mr *mr_compare)
 {
 	int i, ret;
-	struct fi_context fi_ctx_atomic;
+	struct fi_context2 fi_ctx_atomic;
 
 	if (opts.rma_op) {
 		for (i = 0; i < global_expected_rnr_error; i++) {
@@ -434,7 +434,7 @@ int main(int argc, char **argv)
 
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps |= FI_MSG | FI_RMA | FI_ATOMICS;
-	hints->mode |= FI_CONTEXT;
+	hints->mode |= FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 
 	/* FI_RM_ENABLED to is required for queue/resend logic to happen in RNR case */

--- a/fabtests/prov/efa/src/rdm_rnr_read_cq_error.c
+++ b/fabtests/prov/efa/src/rdm_rnr_read_cq_error.c
@@ -176,7 +176,7 @@ int main(int argc, char **argv)
 
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_MSG;
-	hints->mode |= FI_CONTEXT;
+	hints->mode |= FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 
 	/* FI_RM_DISABLED is required to get RNR error CQ entry */

--- a/fabtests/regression/sighandler_test.c
+++ b/fabtests/regression/sighandler_test.c
@@ -80,7 +80,7 @@ int main(int argc, char **argv)
 			}
 		}
 		hints->caps = FI_MSG;
-		hints->mode = FI_CONTEXT;
+		hints->mode = FI_CONTEXT | FI_CONTEXT2;
 		if (ft_init_fabric()) {
 			ft_freehints(hints);
 			exit(EXIT_FAILURE);

--- a/fabtests/unit/getinfo_test.c
+++ b/fabtests/unit/getinfo_test.c
@@ -645,7 +645,7 @@ static int test_caps_regression(char *node, char *service, uint64_t flags,
 
 	/* Limit mode bits to common, older options only */
 	hints->caps |= fi->caps;
-	hints->mode = FI_CONTEXT;
+	hints->mode = FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->mr_mode = FI_MR_LOCAL | OFI_MR_BASIC_MAP;
 
 	fi_freeinfo(*info);


### PR DESCRIPTION
This allows testing FI_CONTEXT2 in providers that require this mode bit.