### PR TITLE
fabtests/efa: add rdma check for unsolicited write recv

### DIFF
--- a/fabtests/prov/efa/configure.m4
+++ b/fabtests/prov/efa/configure.m4
@@ -28,5 +28,10 @@ AS_IF([test x"$have_efadv" = x"1"], [
             [],
             [efa_rdma_checker_happy=0],
             [[#include <infiniband/efadv.h>]])
+
+        AC_CHECK_DECL(EFADV_DEVICE_ATTR_CAPS_UNSOLICITED_WRITE_RECV,
+            [],
+            [efa_rdma_checker_happy=0],
+            [[#include <infiniband/efadv.h>]])
 ])
 AM_CONDITIONAL([BUILD_EFA_RDMA_CHECKER], [test $efa_rdma_checker_happy -eq 1])

--- a/fabtests/pytest/efa/efa_common.py
+++ b/fabtests/pytest/efa/efa_common.py
@@ -74,7 +74,7 @@ def has_rdma(cmdline_args, operation):
     operation: rdma operation name, allowed values are read and write
     return: a boolean
     """
-    assert operation in ["read", "write"]
+    assert operation in ["read", "write", "writedata"]
     binpath = cmdline_args.binpath or ""
     cmd = "timeout " + str(cmdline_args.timeout) \
           + " " + os.path.join(binpath, f"fi_efa_rdma_checker -o {operation}")


### PR DESCRIPTION
~~This includes 2 commits:~~
1. add rdma check for unsolicited write recv
~~2. Fix rx buf size to not exceed max_msg_size
When the option max_msg_size is set, the rx buf size should not exceed this limit.~~