### PR TITLE
prov/util: Fix flag initialization for generic receive of unexpected entry

### DIFF
--- a/prov/util/src/util_srx.c
+++ b/prov/util/src/util_srx.c
@@ -732,7 +732,7 @@ ssize_t util_srx_generic_trecv(struct fid_ep *ep_fid, const struct iovec *iov,
 		}
 	}
 	util_init_rx_entry(rx_entry, iov, desc, iov_count, addr, context, tag,
-			   flags);
+			   flags | FI_TAGGED | FI_RECV);
 
 	srx->update_func(srx, rx_entry);
 	ret = rx_entry->peer_entry.srx->peer_ops->start_tag(
@@ -778,7 +778,7 @@ ssize_t util_srx_generic_recv(struct fid_ep *ep_fid, const struct iovec *iov,
 	}
 
 	util_init_rx_entry(rx_entry, iov, desc, iov_count, addr, context, 0,
-			   flags);
+			   flags | FI_MSG | FI_RECV);
 
 	srx->update_func(srx, rx_entry);
 	ret = rx_entry->peer_entry.srx->peer_ops->start_msg(


### PR DESCRIPTION
The flags that are passed to util_init_rx_entry when called from util_srx_generic_trecv are not OR'ed with FI_TAGGED | FI_RECV. The function util_srx_generic_trecv is also called in a different flow from util_get_recv_entry with the flags OR'ed (working flow). The same issue is present in the util_srx_generic_recv function but instead of FI_TAGGED it should be FI_MSG.