### PR TITLE
github/actions: Approve PR before merge

### DIFF
--- a/.github/workflows/gh-man.sh
+++ b/.github/workflows/gh-man.sh
@@ -79,6 +79,9 @@ done
 
 status=0
 if test $i -lt $i_max; then
+    # approve the PR
+    gh pr review $pr_num --approve
+
     # rebase the commit onto the base branch
     gh pr merge $pr_num -r
 

--- a/.github/workflows/nroff-elves.sh
+++ b/.github/workflows/nroff-elves.sh
@@ -92,6 +92,9 @@ done
 
 status=0
 if test $i -lt $i_max; then
+    # approve the PR
+    gh pr review $pr_num --approve
+
     # rebase the commit onto the base branch
     gh pr merge $pr_num -r
 


### PR DESCRIPTION
The man page converter action would fail w/o approval due to updated branch merge policy.

Update the GH man page updater similarly even if current branch policy is different. The policy can be changed in the future.