### PR TITLE
github/actions: Change to manual merge for the man page converter

### DIFF
--- a/.github/workflows/gh-man.sh
+++ b/.github/workflows/gh-man.sh
@@ -79,9 +79,6 @@ done
 
 status=0
 if test $i -lt $i_max; then
-    # approve the PR
-    gh pr review $pr_num --approve
-
     # rebase the commit onto the base branch
     gh pr merge $pr_num -r
 

--- a/.github/workflows/nroff-elves.sh
+++ b/.github/workflows/nroff-elves.sh
@@ -51,7 +51,7 @@ done
 git config --global user.name "OFIWG Bot"
 git config --global user.email "ofiwg@lists.openfabrics.org"
 
-branch_name=pr/update-nroff-generated-man-pages-$BASE_REF
+branch_name=pr/update-nroff-generated-man-pages-$BASE_REF-`date +%s`
 git checkout -b $branch_name
 
 set +e
@@ -69,6 +69,10 @@ fi
 git push --set-upstream origin $branch_name
 url=`gh pr create --base $BASE_REF --title 'Update nroff-generated man pages' --body ''`
 pr_num=`echo $url | cut -d/ -f7`
+
+# skip the remaining steps for now since merge now requires
+# appproval which cannot be done automatically.
+exit 0
 
 # Wait for the required "DCO" CI to complete
 i=0

--- a/.github/workflows/nroff-elves.sh
+++ b/.github/workflows/nroff-elves.sh
@@ -92,9 +92,6 @@ done
 
 status=0
 if test $i -lt $i_max; then
-    # approve the PR
-    gh pr review $pr_num --approve
-
     # rebase the commit onto the base branch
     gh pr merge $pr_num -r
 


### PR DESCRIPTION
Merge cannot be done automatically due to the new review approval requirement on the main and stable branches.

Revert previous change about adding an approval review since self-approval is not allowed.

Add a random number to the temporary branch to avoid conflict among multiple action runs since now the temporary branches need to be deleted manually.