### PR TITLE
[v1.21.x] .github/workflows: Update upload-artifacts version to v4

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -90,7 +90,7 @@ jobs:
             --form description="`$PWD/install/bin/fi_info -l`" \
             https://scan.coverity.com/builds?project=ofiwg%2Flibfabric
       - name: Upload build logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverity-build-log.txt
           path: cov-int/build-log.txt

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -70,7 +70,7 @@ jobs:
           $PWD/install/bin/fi_info -l
       - name: Upload build logs
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os }}-${{ matrix.cc }}-config.log
           path: config.log
@@ -116,7 +116,7 @@ jobs:
           $PWD/install/bin/fi_info -c FI_HMEM
       - name: Upload build logs
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: hmem-config.log
           path: config.log
@@ -140,7 +140,7 @@ jobs:
           make -j2
       - name: Upload build logs
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: macos-config.log
           path: config.log


### PR DESCRIPTION
Dependabot is not enabled on 1.21.x branch. This commit updates the upload-artifact version to v4.