### PR TITLE
prov/shm: remove prefix from map inserts

### DIFF
--- a/prov/shm/src/smr_util.c
+++ b/prov/shm/src/smr_util.c
@@ -558,10 +558,11 @@ int smr_map_add(const struct fi_provider *prov, struct smr_map *map,
 		const char *name, int64_t *id)
 {
 	struct ofi_rbnode *node;
+	const char *shm_name = smr_no_prefix(name);
 	int tries = 0, ret = 0;
 
 	ofi_spin_lock(&map->lock);
-	ret = ofi_rbmap_insert(&map->rbmap, (void *) name,
+	ret = ofi_rbmap_insert(&map->rbmap, (void *) shm_name,
 			       (void *) (intptr_t) *id, &node);
 	if (ret) {
 		assert(ret == -FI_EALREADY);
@@ -580,7 +581,7 @@ int smr_map_add(const struct fi_provider *prov, struct smr_map *map,
 	if (++map->cur_id == SMR_MAX_PEERS)
 		map->cur_id = 0;
 	node->data = (void *) (intptr_t) *id;
-	strncpy(map->peers[*id].peer.name, name, SMR_NAME_MAX);
+	strncpy(map->peers[*id].peer.name, shm_name, SMR_NAME_MAX);
 	map->peers[*id].peer.name[SMR_NAME_MAX - 1] = '\0';
 	map->peers[*id].region = NULL;
 	map->num_peers++;


### PR DESCRIPTION
EP names have the format fi_shm://<shm_name> to be consistent with other provider formats. Since shared memory names cannot have slashes in them, the shm provider skips this prefix when creating the shared memory region. However, it does not do this when inserting the names into the map which causes an issue when comparing names in the map against region names.
This removes the prefix for map additions as well so that names match in both data structures.