### PR TITLE
fabtests/test_configs: io_uring disable multi_recv

### DIFF
--- a/fabtests/test_configs/tcp/io_uring.exclude
+++ b/fabtests/test_configs/tcp/io_uring.exclude
@@ -114,3 +114,6 @@ fi_multinode -x msg
 
 # fi_multinode -x rma fails with no output
 fi_multinode -x rma
+
+# multi_recv -e rdm fails by hanging
+multi_recv -e rdm


### PR DESCRIPTION
io_uring multi_recv fails intermittently by hanging. Adding it to the disable list until the kernel update comes in for CI to support it.