### PR TITLE
prov/efa: Bug fix in the RDM path with FI_MSG_PREFIX mode

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -58,7 +58,17 @@ void efa_rdm_txe_construct(struct efa_rdm_ope *txe,
 	txe->cq_entry.len = ofi_total_iov_len(txe->iov, txe->iov_count);
 	txe->cq_entry.buf = OFI_LIKELY(txe->cq_entry.len > 0) ? txe->iov[0].iov_base : NULL;
 
-	if (ep->base_ep.info->mode & FI_MSG_PREFIX) {
+	/*
+	 * txe->iov_count is 0 only when posting handshake packets
+	 *
+	 * It's a bit silly to allocate extra header before the contents
+	 * of the handshake packet and then consume that here. So instead
+	 * just don't consume the prefix header if iov_count is 0.
+	 *
+	 * A send or RMA or atomic call from the application cannot have
+	 * iov_count 0, so this is safe.
+	 */
+	if (txe->iov_count && ep->base_ep.info->mode & FI_MSG_PREFIX) {
 		ofi_consume_iov_desc(txe->iov, txe->desc, &txe->iov_count, ep->msg_prefix_size);
 	}
 	txe->total_len = ofi_total_iov_len(txe->iov, txe->iov_count);
@@ -943,7 +953,7 @@ void efa_rdm_txe_report_completion(struct efa_rdm_ope *txe)
  * 	If the txe requested delivery complete, "all the data has been sent"
  *      happens when txe received a RECEIPT packet from receiver/write responder
  *
- * 	If the txe requested delivery complete, "all the data has been sent"
+ * 	If the txe requested transmit complete, "all the data has been sent"
  *      happens when the send completion of all packets that contains data has been
  *      received.
  *


### PR DESCRIPTION
efa_rdm_txe_construct is called to construct a txe for the handshake packet and to construct txes for send, RMA and atomic operations.

iov_count is 0 only in the handshake path. When efa_rdm_txe_construct is called as part of an fi_send or fi_read or fi_write call from the application, iov_count is never 0.

The handshake packet is posted internally by the EFA provider, so it does not make sense to allocate and consume prefix space. Instead just check for iov_count before consuming the prefix space.