### PR TITLE
fabtests: Fix rx msg size to not exceed FI_OPT_MAX_MSG_SIZE

### DIFF
--- a/fabtests/benchmarks/benchmark_shared.c
+++ b/fabtests/benchmarks/benchmark_shared.c
@@ -227,7 +227,7 @@ int pingpong(void)
 				return ret;
 		} else {
 			/* Repost RX buffers to support inband sync. */
-			ret = ft_post_rx(ep, rx_size, &rx_ctx);
+			ret = ft_post_rx(ep, rx_msg_size, &rx_ctx);
 			if (ret)
 				return ret;
 

--- a/fabtests/benchmarks/benchmark_shared.c
+++ b/fabtests/benchmarks/benchmark_shared.c
@@ -333,7 +333,7 @@ int pingpong_rma(enum ft_rma_opcodes rma_op, struct fi_rma_iov *remote)
 			if (rma_op == FT_RMA_WRITE)
 				*(tx_buf + opts.transfer_size - 1) = (char)i;
 
-			if (opts.transfer_size <= inject_size)
+			if (opts.transfer_size && opts.transfer_size <= inject_size)
 				ret = ft_inject_rma(rma_op, remote, ep,
 						    remote_fi_addr,
 						    opts.transfer_size);
@@ -359,7 +359,7 @@ int pingpong_rma(enum ft_rma_opcodes rma_op, struct fi_rma_iov *remote)
 			if (rma_op == FT_RMA_WRITE)
 				*(tx_buf + opts.transfer_size - 1) = (char)i;
 
-			if (opts.transfer_size <= inject_size)
+			if (opts.transfer_size && opts.transfer_size <= inject_size)
 				ret = ft_inject_rma(rma_op, remote, ep,
 						remote_fi_addr,
 						opts.transfer_size);
@@ -629,7 +629,7 @@ int bandwidth_rma(enum ft_rma_opcodes rma_op, struct fi_rma_iov *remote)
 		}
 		switch (rma_op) {
 		case FT_RMA_WRITE:
-			if (opts.transfer_size <= inject_size) {
+			if (opts.transfer_size && opts.transfer_size <= inject_size) {
 				ret = ft_post_rma_inject(FT_RMA_WRITE, tx_buf + offset,
 						opts.transfer_size, remote);
 			} else if (opts.use_fi_more) {
@@ -656,7 +656,7 @@ int bandwidth_rma(enum ft_rma_opcodes rma_op, struct fi_rma_iov *remote)
 					rx_seq++;
 
 			} else {
-				if (opts.transfer_size <= inject_size) {
+				if (opts.transfer_size && opts.transfer_size <= inject_size) {
 					ret = ft_post_rma_inject(FT_RMA_WRITEDATA,
 							tx_buf + offset,
 							opts.transfer_size,

--- a/fabtests/functional/flood.c
+++ b/fabtests/functional/flood.c
@@ -78,7 +78,7 @@ static int post_rx_sync(void)
 {
 	int ret;
 
-	ret = ft_post_rx(ep, rx_size, &rx_ctx);
+	ret = ft_post_rx(ep, rx_msg_size, &rx_ctx);
 	if (ret)
 		return ret;
 

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -247,7 +247,7 @@ extern char *buf, *tx_buf, *rx_buf;
 extern void *dev_host_buf;
 extern struct ft_context *tx_ctx_arr, *rx_ctx_arr;
 extern char **tx_mr_bufs, **rx_mr_bufs;
-extern size_t buf_size, tx_size, rx_size, tx_mr_size, rx_mr_size;
+extern size_t buf_size, tx_size, rx_size, tx_mr_size, rx_mr_size, rx_msg_size;
 extern int tx_fd, rx_fd;
 extern int timeout;
 


### PR DESCRIPTION
This includes 2 commits:
1. Fix rx msg size to not exceed FI_OPT_MAX_MSG_SIZE
2. Avoid testing inject rma with 0 byte message 