### PR TITLE
prov/efa: efa-direct path fixes

### DIFF
--- a/prov/efa/src/efa_prov.c
+++ b/prov/efa/src/efa_prov.c
@@ -96,7 +96,11 @@ static int efa_util_prov_initialize()
 			continue;
 		}
 
-		efa_prov_info_set_fabric_name(prov_info_direct, EFA_DIRECT_FABRIC_NAME);
+		err = efa_prov_info_set_fabric_name(prov_info_direct, EFA_DIRECT_FABRIC_NAME);
+		if (err) {
+			EFA_WARN(FI_LOG_DOMAIN, "Failed to allocate fabric name. error: %d\n", err);
+			continue;
+		}
 
 		if (!head) {
 			head = prov_info_direct;
@@ -116,7 +120,11 @@ static int efa_util_prov_initialize()
 			continue;
 		}
 
-		efa_prov_info_set_fabric_name(prov_info_rdm, EFA_FABRIC_NAME);
+		err = efa_prov_info_set_fabric_name(prov_info_rdm, EFA_FABRIC_NAME);
+		if (err) {
+			EFA_WARN(FI_LOG_DOMAIN, "Failed to allocate fabric name. error: %d\n", err);
+			continue;
+		}
 
 		if (!head) {
 			head = prov_info_rdm;
@@ -135,7 +143,11 @@ static int efa_util_prov_initialize()
 			continue;
 		}
 
-		efa_prov_info_set_fabric_name(prov_info_dgram, EFA_FABRIC_NAME);
+		err = efa_prov_info_set_fabric_name(prov_info_dgram, EFA_FABRIC_NAME);
+		if (err) {
+			EFA_WARN(FI_LOG_DOMAIN, "Failed to allocate fabric name. error: %d\n", err);
+			continue;
+		}
 
 		if (!head) {
 			head = prov_info_dgram;


### PR DESCRIPTION
### prov/efa: Clean up efa_prov_info_set_hmem_flags

Remove bool enable_hmem and avoid checking system HMEM iface

### prov/efa: Check efa_prov_info_set_fabric_name return code
If efa_prov_info_set_fabric_name fails with ENOMEM, print a warning and continue

### prov/efa: Call efa_fork_support_enable_if_requested earlier
efa_hmem_info_initialize calls ibv_reg_mr to test for p2p support.

On older kernels (without support for IBV_FORK_UNNEEDED), efa_fork_support_enable_if_requested calls ibv_fork_init, when fork support is requested.

If ibv_fork_init is called, it must be called before any ibv_reg_mr calls. Otherwise, ibv_fork_init will return EINVAL.

Therefore, efa_fork_support_enable_if_requested must be called before efa_hmem_info_initialize.