### PR TITLE
enchance performace of roundup_power_of_two

### DIFF
--- a/include/ofi.h
+++ b/include/ofi.h
@@ -368,7 +368,6 @@ static inline uint64_t roundup_power_of_two(uint64_t n)
 #else
 	if (!n || !(n & (n - 1)))
 		return n;
-	n--;
 	n |= n >> 1;
 	n |= n >> 2;
 	n |= n >> 4;

--- a/include/ofi.h
+++ b/include/ofi.h
@@ -361,6 +361,11 @@ struct ipc_info {
 
 static inline uint64_t roundup_power_of_two(uint64_t n)
 {
+#if defined(__GNUC__)
+	if (n < 2)
+		return n;
+	return 2ULL << (63 - __builtin_clzll(n - 1));
+#else
 	if (!n || !(n & (n - 1)))
 		return n;
 	n--;
@@ -372,6 +377,7 @@ static inline uint64_t roundup_power_of_two(uint64_t n)
 	n |= n >> 32;
 	n++;
 	return n;
+#endif
 }
 
 static inline uint64_t rounddown_power_of_two(uint64_t n)


### PR DESCRIPTION
Fixes #10634 .

First patch enhances performance for compilers that support `__builtin_clz`: these include GCC,Clang and their derivatives.
Some statistics for emitted code are shipped in the patch.
Many other architectures might get disparaged by patch, including RISC-V 64-bit without Zbb extension.

Second patch removes an unnecessary instruction from original roundup_power_of_two.