### PR TITLE
prov/tcp: drop stale messages for new endpoint

### DIFF
--- a/prov/tcp/src/xnet.h
+++ b/prov/tcp/src/xnet.h
@@ -428,6 +428,7 @@ static inline void xnet_signal_progress(struct xnet_progress *progress)
 #define XNET_COPY_RECV		BIT(9)
 #define XNET_CLAIM_RECV		BIT(10)
 #define XNET_NEED_CTS		BIT(11)
+#define XNET_UNEXP_XFER		BIT(12)
 #define XNET_MULTI_RECV		FI_MULTI_RECV /* BIT(16) */
 
 struct xnet_mrecv {

--- a/prov/tcp/src/xnet_cq.c
+++ b/prov/tcp/src/xnet_cq.c
@@ -130,7 +130,7 @@ void xnet_report_success(struct xnet_xfer_entry *xfer_entry)
 	uint64_t flags, data, tag;
 	size_t len;
 
-	if (xfer_entry->ctrl_flags & (XNET_INTERNAL_XFER | XNET_SAVED_XFER))
+	if (xfer_entry->ctrl_flags & (XNET_INTERNAL_XFER | XNET_SAVED_XFER | XNET_UNEXP_XFER))
 		return;
 
 	if (xfer_entry->cntr)


### PR DESCRIPTION
When an communication instance is restarted, the new instance may still receive 'stale' tagged replies that belong to the previous instance. In the current implementation, it will disable the polling against the new endpoint and then leave lots of normal messages unprocessed.

This PR is trying to fix the issue by dropping those messages with unmatched tag and if the endpoint is entirely new.

DAOS ticket: https://daosio.atlassian.net/browse/DAOS-17103