### PR TITLE
prov/cxi: Fix bug in constrained LE test cases in test.sh and test_sw.sh

### DIFF
--- a/prov/cxi/test/test.sh
+++ b/prov/cxi/test/test.sh
@@ -74,18 +74,20 @@ basic_test=("./cxitest --verbose --tap=cxitest.tap -j 1")
 
 swget_test=(
 	"FI_CXI_RGET_TC=BULK_DATA ./cxitest --verbose --filter=\"@(tagged|msg)/*\" --tap=cxitest-swget.tap -j1"
-	"csrutil store csr C_LPE_CFG_GET_CTRL get_en=0 > /dev/null"
-	"csrutil store csr C_LPE_CFG_GET_CTRL get_en=1 > /dev/null")
+	"cxiutil store csr C_LPE_CFG_GET_CTRL get_en=0 > /dev/null"
+	"cxiutil store csr C_LPE_CFG_GET_CTRL get_en=1 > /dev/null")
 
 swget_unaligned_test=(
 	"FI_CXI_RDZV_THRESHOLD=2036 ./cxitest --verbose --filter=\"@(tagged|msg)/*\" --tap=cxitest-swget-unaligned.tap -j1"
-	"csrutil store csr C_LPE_CFG_GET_CTRL get_en=0 > /dev/null"
-	"csrutil store csr C_LPE_CFG_GET_CTRL get_en=1 > /dev/null")
+	"cxiutil store csr C_LPE_CFG_GET_CTRL get_en=0 > /dev/null"
+	"cxiutil store csr C_LPE_CFG_GET_CTRL get_en=1 > /dev/null")
 
 constrained_le_test=(
 	"FI_CXI_DEFAULT_CQ_SIZE=16384 ./cxitest --verbose --filter=\"@(tagged|msg)/fc*\" --tap=cxitest-constrained-le.tap -j1"
-	"MAX_ALLOC=\$(csrutil dump csr le_pools[63] | grep max_alloc | awk '{print \$3}'); echo \"Saving MAX_ALLOC=\$MAX_ALLOC\"; csrutil store csr le_pools[] max_alloc=10 > /dev/null"
-	"echo \"Restoring MAX_ALLOC=\$MAX_ALLOC\"; csrutil store csr le_pools[] max_alloc=\$MAX_ALLOC > /dev/null")
+	"MAX_ALLOC=\$(cxiutil dump csr le_pools[63] | grep max_alloc | awk '{print \$3}'); echo \"Saving MAX_ALLOC=\$MAX_ALLOC\"; 
+	cxiutil store csr le_pools[0] max_alloc=10 > /dev/null; cxiutil store csr le_pools[16] max_alloc=10 > /dev/null;
+	cxiutil store csr le_pools[32] max_alloc=10 > /dev/null; cxiutil store csr le_pools[48] max_alloc=10 > /dev/null"
+	"echo \"Restoring MAX_ALLOC=\$MAX_ALLOC\"; cxiutil store csr le_pools[] max_alloc=\$MAX_ALLOC > /dev/null")
 
 hw_matching_rendezvous_test=(
 	"FI_CXI_DEVICE_NAME=\"cxi1,cxi0\" FI_CXI_RDZV_GET_MIN=0 FI_CXI_RDZV_THRESHOLD=2048 ./cxitest --verbose -j 1 --filter=\"tagged_directed/*\" --tap=cxitest-hw-rdzv-tag-matching.tap")
@@ -119,8 +121,8 @@ zero_eager_size_test=(
 
 alt_read_rendezvous_test=(
 	"FI_CXI_RDZV_PROTO=\"alt_read\" ./cxitest --filter=\"tagged/*rdzv\" -j 1 -f --verbose --tap=cxitest-alt-read-rdzv.tap"
-	"csrutil store csr C_LPE_CFG_GET_CTRL get_en=0 > /dev/null"
-	"csrutil store csr C_LPE_CFG_GET_CTRL get_en=1 > /dev/null")
+	"cxiutil store csr C_LPE_CFG_GET_CTRL get_en=0 > /dev/null"
+	"cxiutil store csr C_LPE_CFG_GET_CTRL get_en=1 > /dev/null")
 
 mr_mode_no_compat_test=(
 	"FI_CXI_COMPAT=0 ./cxitest -j 1 --filter=\"getinfo_infos/*\" -f --verbose --tap=cxitest-mr-mode-no-compat.tap")

--- a/prov/cxi/test/test_sw.sh
+++ b/prov/cxi/test/test_sw.sh
@@ -22,12 +22,15 @@ export FI_LOG_PROV=cxi
 #fi
 
 # Run tests with constrained LE count - Using Flow Control recovery
-MAX_ALLOC=`csrutil dump csr le_pools[63] |grep max_alloc |awk '{print $3}'`
-csrutil store csr le_pools[] max_alloc=10 > /dev/null
+MAX_ALLOC=`cxiutil dump csr le_pools[63] |grep max_alloc |awk '{print $3}'`
+cxiutil store csr le_pools[0] max_alloc=10 > /dev/null  
+cxiutil store csr le_pools[16] max_alloc=10 > /dev/null 
+cxiutil store csr le_pools[32] max_alloc=10 > /dev/null  
+cxiutil store csr le_pools[48] max_alloc=10 > /dev/null
 echo "running;FI_CXI_RX_MATCH_MODE=hardware ./cxitest --verbose --filter=\"tagged/fc*\" --tap=cxitest-fc.tap -j1 > $TEST_OUTPUT 2>&1"
 FI_CXI_RX_MATCH_MODE=hardware ./cxitest --verbose --filter="tagged/fc*" --tap=cxitest-fc.tap -j1 > $TEST_OUTPUT 2>&1
 cxitest_exit_status=$?
-csrutil store csr le_pools[] max_alloc=$MAX_ALLOC > /dev/null
+cxiutil store csr le_pools[] max_alloc=$MAX_ALLOC > /dev/null
 if [[ $cxitest_exit_status -ne 0 ]]; then
     echo "cxitest return non-zero exit code. Possible failures in test teardown"
     exit 1
@@ -35,12 +38,15 @@ fi
 
 # Run tests with constrained LE count - Using hybrid operation instead
 # of flow control recovery
-MAX_ALLOC=`csrutil dump csr le_pools[63] |grep max_alloc |awk '{print $3}'`
-csrutil store csr le_pools[] max_alloc=10 > /dev/null
+MAX_ALLOC=`cxiutil dump csr le_pools[63] |grep max_alloc |awk '{print $3}'`
+cxiutil store csr le_pools[0] max_alloc=10 > /dev/null  
+cxiutil store csr le_pools[16] max_alloc=10 > /dev/null 
+cxiutil store csr le_pools[32] max_alloc=10 > /dev/null  
+cxiutil store csr le_pools[48] max_alloc=10 > /dev/null
 echo "running;FI_CXI_RX_MATCH_MODE=hybrid FI_CXI_RDZV_GET_MIN=0 ./cxitest --verbose --filter=\"tagged/fc*\" --tap=cxitest-sw-transition.tap -j1 >> $TEST_OUTPUT 2>&1"
 FI_CXI_RX_MATCH_MODE=hybrid FI_CXI_RDZV_GET_MIN=0 ./cxitest --verbose --filter="tagged/fc*" --tap=cxitest-sw-transition.tap -j1 >> $TEST_OUTPUT 2>&1
 cxitest_exit_status=$?
-csrutil store csr le_pools[] max_alloc=$MAX_ALLOC > /dev/null
+cxiutil store csr le_pools[] max_alloc=$MAX_ALLOC > /dev/null
 if [[ $cxitest_exit_status -ne 0 ]]; then
     echo "cxitest return non-zero exit code. Possible failures in test teardown"
     exit 1
@@ -48,22 +54,29 @@ fi
 
 # Run HW to SW hybrid test with constrained LE count and forcing both
 # eager and rendezvous processing
-MAX_ALLOC=`csrutil dump csr le_pools[63] |grep max_alloc |awk '{print $3}'`
-csrutil store csr le_pools[] max_alloc=60 > /dev/null
+MAX_ALLOC=`cxiutil dump csr le_pools[63] |grep max_alloc |awk '{print $3}'`
+cxiutil store csr le_pools[0] max_alloc=60 > /dev/null  
+cxiutil store csr le_pools[16] max_alloc=60 > /dev/null 
+cxiutil store csr le_pools[32] max_alloc=60 > /dev/null  
+cxiutil store csr le_pools[48] max_alloc=60 > /dev/null
 echo "running;FI_CXI_RX_MATCH_MODE=hybrid FI_CXI_RDZV_GET_MIN=0 FI_CXI_RDZV_THRESHOLD=2048 ./cxitest --verbose --filter=\"tagged/hw2sw_*\" --tap=cxitest-hw2sw-transition.tap -j1 >> $TEST_OUTPUT 2>&1"
 FI_CXI_RX_MATCH_MODE=hybrid FI_CXI_RDZV_GET_MIN=0 FI_CXI_RDZV_THRESHOLD=2048 ./cxitest --verbose --filter="tagged/hw2sw_*" --tap=cxitest-hw2sw-transition.tap -j1 >> $TEST_OUTPUT 2>&1
-csrutil store csr le_pools[] max_alloc=$MAX_ALLOC > /dev/null
+cxiutil store csr le_pools[] max_alloc=$MAX_ALLOC > /dev/null
 if [[ $cxitest_exit_status -ne 0 ]]; then
     echo "cxitest return non-zero exit code. Possible failures in test teardown"
     exit 1
 fi
 
 # Run HW to SW hybrid test with constrained LE count and forcing only eager processing
-MAX_ALLOC=`csrutil dump csr le_pools[63] |grep max_alloc |awk '{print $3}'`
+MAX_ALLOC=`cxiutil dump csr le_pools[63] |grep max_alloc |awk '{print $3}'`
+cxiutil store csr le_pools[0] max_alloc=60 > /dev/null  
+cxiutil store csr le_pools[16] max_alloc=60 > /dev/null 
+cxiutil store csr le_pools[32] max_alloc=60 > /dev/null  
+cxiutil store csr le_pools[48] max_alloc=60 > /dev/null
 echo "running;FI_CXI_RX_MATCH_MODE=hybrid FI_CXI_RDZV_GET_MIN=0 FI_CXI_RDZV_THRESHOLD=16384 ./cxitest --verbose --filter=\"tagged/hw2sw_*\" --tap=cxitest-hw2sw-eager-transition.tap -j1 >> $TEST_OUTPUT 2>&1"
 FI_CXI_RX_MATCH_MODE=hybrid FI_CXI_RDZV_GET_MIN=0 FI_CXI_RDZV_THRESHOLD=16384 ./cxitest --verbose --filter="tagged/hw2sw_*" --tap=cxitest-hw2sw-transition.tap -j1 >> $TEST_OUTPUT 2>&1
 cxitest_exit_status=$?
-csrutil store csr le_pools[] max_alloc=$MAX_ALLOC > /dev/null
+cxiutil store csr le_pools[] max_alloc=$MAX_ALLOC > /dev/null
 if [[ $cxitest_exit_status -ne 0 ]]; then
     echo "cxitest return non-zero exit code. Possible failures in test teardown"
     exit 1


### PR DESCRIPTION
This commit resolves a bug in certain CXI criterion test cases where the le_pools[] max_alloc value was being decreased for all LE pool entries.  This resulted in unintended LE append failures + NMIs + inbound wait timeouts related to the CXI eth driver.  Now, the test only lowers the max_alloc value for LE pools associated with the default CXI service, which is used during the criterion tests.  Additionally, instances of csrutil have been replaced with cxiutil.