### PR TITLE
core: Introduce new tag FI_TAG_RPC

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -346,6 +346,7 @@ enum {
 	FI_TAG_BITS,
 	FI_TAG_MPI,
 	FI_TAG_CCL,
+	FI_TAG_RPC,
 	FI_TAG_MAX_FORMAT = (1ULL << 16),
 };
 

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -919,6 +919,16 @@ wire protocols.  The following tag formats are defined:
   Applications that use the CCL format pass in the payload identifier
   directly as the tag and set ignore bits to 0.
 
+*FI_TAG_RPC*
+
+: The FI_TAG_RPC flag is used to indicate that tags are being utilized to match RPC
+  replies with requests. When specified via fi_getinfo, the caller ensures that
+  a receive buffer with a corresponding tag to receive an RPC reply has been posted
+  prior to sending an RPC request.  As a result, unexpected message handling may be
+  optimized.
+
+  When FI_TAG_RPC is specified, unmatched received messages must be discarded.
+
 *FI_TAG_MAX_FORMAT*
 : If the value of mem_tag_format is >= FI_TAG_MAX_FORMAT, the tag format
   is treated as a set of bit fields.  The behavior is functionally the same


### PR DESCRIPTION
This new mem_tag_format tells libfabric tha tags are being used to match RPC requests and replies. Therefore, messages with unmatched tags are stale and can be discarded by libfabric.