### PR TITLE
prov/efa: Do not claim support for FI_PROGRESS_AUTO in the RDM path

### DIFF
--- a/prov/efa/src/efa_prov_info.c
+++ b/prov/efa/src/efa_prov_info.c
@@ -44,7 +44,7 @@ const struct fi_domain_attr efa_domain_attr = {
 	.caps			= EFA_DOMAIN_CAPS,
 	.threading		= FI_THREAD_DOMAIN,
 	.control_progress	= FI_PROGRESS_AUTO,
-	.data_progress		= FI_PROGRESS_AUTO,
+	.progress		= FI_PROGRESS_AUTO,
 	.resource_mgmt		= FI_RM_DISABLED,
 	.mr_mode		= OFI_MR_BASIC_MAP | FI_MR_LOCAL | OFI_MR_BASIC,
 	.mr_key_size		= sizeof_field(struct ibv_sge, lkey),
@@ -583,6 +583,12 @@ int efa_prov_info_alloc_for_rdm(struct fi_info **prov_info_rdm_ptr,
 		 * buffer. EFA RDM endpoint does not have this requirement, hence unset the flag
 		 */
 		prov_info_rdm->domain_attr->mr_mode &= ~FI_MR_LOCAL;
+		/*
+		 * EFA RDM path requires manual progress for connection management
+		 * and data transfers
+		 */
+		prov_info_rdm->domain_attr->control_progress = FI_PROGRESS_MANUAL;
+		prov_info_rdm->domain_attr->progress = FI_PROGRESS_MANUAL;
 	}
 
 	/* update ep_attr */

--- a/prov/efa/src/efa_user_info.c
+++ b/prov/efa/src/efa_user_info.c
@@ -281,11 +281,6 @@ int efa_user_info_alter_rdm(int version, struct fi_info *info, const struct fi_i
 						 "Libfabric can proceed but it is recommended to align the tx and rx msg order.\n",
 						 info->tx_attr->msg_order, info->rx_attr->msg_order);
 
-		/* We only support manual progress for RMA operations */
-		if (hints->caps & FI_RMA) {
-			info->domain_attr->data_progress = FI_PROGRESS_MANUAL;
-		}
-
 		/*
 		 * The provider does not force applications to register buffers
 		 * with the device, but if an application is able to, reuse

--- a/prov/efa/test/efa_unit_test_info.c
+++ b/prov/efa/test/efa_unit_test_info.c
@@ -64,6 +64,8 @@ void test_info_rdm_attributes()
 		assert_true(!strcmp(info->fabric_attr->name, EFA_FABRIC_NAME));
 		assert_true(strstr(info->domain_attr->name, "rdm"));
 		assert_int_equal(info->ep_attr->max_msg_size, UINT64_MAX);
+		assert_int_equal(info->domain_attr->progress, FI_PROGRESS_MANUAL);
+		assert_int_equal(info->domain_attr->control_progress, FI_PROGRESS_MANUAL);
 #if HAVE_CUDA || HAVE_NEURON || HAVE_SYNAPSEAI
 		assert_true(info->caps | FI_HMEM);
 #endif


### PR DESCRIPTION
The RDM path requires manual progress for connection management (e.g. sending and receiving handshake packets) and for data transfers (e.g. long CTS protocol). So it cannot claim support for FI_PROGRESS_AUTO.