### PR TITLE
prov/efa: Always return efa_prov in EFA_INI

### DIFF
--- a/prov/efa/src/efa_prov.c
+++ b/prov/efa/src/efa_prov.c
@@ -190,10 +190,7 @@ EFA_INI
 
 	err = efa_device_list_initialize();
 	if (err)
-		return NULL;
-
-	if (g_device_cnt <= 0)
-		return NULL;
+		return &efa_prov;
 
 	/*
 	 * efa_env_initialize uses g_efa_device_list
@@ -236,7 +233,7 @@ EFA_INI
 
 err_free:
 	efa_prov_finalize();
-	return NULL;
+	return &efa_prov;
 }
 
 /**


### PR DESCRIPTION
Currently EFA_INI only return efa_prov
when there is efa device and the device info
setup correctly. This makes fi_getinfo
with FI_PROV_ATTR_ONLY not return efa
on non-efa instances. This patch
fixes it.