### PR TITLE
prov/verbs: Always return vrb_prov in VERBS_INI

### DIFF
--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -1366,6 +1366,13 @@ static int vrb_init_info(const struct fi_info **all_infos)
 	initialized = true;
 	*all_infos = NULL;
 
+	if (vrb_os_ini()) {
+		FI_WARN(&vrb_prov, FI_LOG_FABRIC,
+			"failed in OS specific device initialization\n");
+		ret = -FI_ENODATA;
+		goto done;
+	}
+
 	vrb_prof_func_start("vrb_os_mem_support");
 	vrb_os_mem_support(&vrb_gl_data.peer_mem_support,
 			   &vrb_gl_data.dmabuf_support);

--- a/prov/verbs/src/verbs_init.c
+++ b/prov/verbs/src/verbs_init.c
@@ -807,9 +807,6 @@ VERBS_INI
 #endif
 	ofi_mutex_init(&vrb_init_mutex);
 
-	if (vrb_os_ini())
-		return NULL;
-
 	vrb_prof_init();
 
 	return &vrb_prov;


### PR DESCRIPTION
Previously NULL was returned if vrb_os_ini() failed. This mainly affected Windows because the function would always succeed on Linux. On Windows, the function would fail if the ND driver failed to initialize.

Returning NULL from VEBRS_INI prevents fi_getinfo() from working as expecetd when the FI_PROV_ATTR_ONLY flags is used. This patch moves the vrb_os_ini() check to vrb_init_info() which is invoked when fi_getinfo() is called the first time.

Similar to #10794 