### PR TITLE
include, prov: Change util_av lock to genlock

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -880,7 +880,7 @@ struct util_av {
 	struct fid_av		av_fid;
 	struct util_domain	*domain;
 	ofi_atomic32_t		ref;
-	ofi_mutex_t		lock;
+	struct ofi_genlock	lock;
 	const struct fi_provider *prov;
 
 	struct util_av_entry	*hash;

--- a/prov/coll/src/coll_coll.c
+++ b/prov/coll/src/coll_coll.c
@@ -931,10 +931,10 @@ int coll_join_collective(struct fid_ep *ep, const void *addr,
 	av_set = container_of(set, struct util_av_set, av_set_fid);
 
 	if (coll_addr == FI_ADDR_NOTAVAIL) {
-		ofi_mutex_lock(&av_set->av->lock);
+		ofi_genlock_lock(&av_set->av->lock);
 		assert(av_set->av->av_set);
 		coll_mc = &av_set->av->av_set->coll_mc;
-		ofi_mutex_unlock(&av_set->av->lock);
+		ofi_genlock_unlock(&av_set->av->lock);
 	} else {
 		coll_mc = (struct util_coll_mc*) ((uintptr_t) coll_addr);
 	}

--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -593,7 +593,7 @@ int efa_av_insert_one(struct efa_av *av, struct efa_ep_addr *addr,
 	if (av->ep_type == FI_EP_DGRAM)
 		addr->qkey = EFA_DGRAM_CONNID;
 
-	ofi_mutex_lock(&av->util_av.lock);
+	ofi_genlock_lock(&av->util_av.lock);
 	memset(raw_gid_str, 0, sizeof(raw_gid_str));
 	if (!inet_ntop(AF_INET6, addr->raw, raw_gid_str, INET6_ADDRSTRLEN)) {
 		EFA_WARN(FI_LOG_AV, "cannot convert address to string. errno: %d\n", errno);
@@ -629,7 +629,7 @@ int efa_av_insert_one(struct efa_av *av, struct efa_ep_addr *addr,
 		 raw_gid_str, addr->qpn, addr->qkey, *fi_addr);
 	ret = 0;
 out:
-	ofi_mutex_unlock(&av->util_av.lock);
+	ofi_genlock_unlock(&av->util_av.lock);
 	return ret;
 }
 
@@ -742,7 +742,7 @@ static int efa_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr,
 	if (av->type != FI_AV_TABLE)
 		return -FI_EINVAL;
 
-	ofi_mutex_lock(&av->util_av.lock);
+	ofi_genlock_lock(&av->util_av.lock);
 	for (i = 0; i < count; i++) {
 		conn = efa_av_addr_to_conn(av, fi_addr[i]);
 		if (!conn) {
@@ -758,7 +758,7 @@ static int efa_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr,
 		assert(err);
 	}
 
-	ofi_mutex_unlock(&av->util_av.lock);
+	ofi_genlock_unlock(&av->util_av.lock);
 	return err;
 }
 
@@ -783,7 +783,7 @@ static void efa_av_close_reverse_av(struct efa_av *av)
 	struct efa_cur_reverse_av *cur_entry, *curtmp;
 	struct efa_prv_reverse_av *prv_entry, *prvtmp;
 
-	ofi_mutex_lock(&av->util_av.lock);
+	ofi_genlock_lock(&av->util_av.lock);
 
 	HASH_ITER(hh, av->cur_reverse_av, cur_entry, curtmp) {
 		efa_conn_release(av, cur_entry->conn);
@@ -793,7 +793,7 @@ static void efa_av_close_reverse_av(struct efa_av *av)
 		efa_conn_release(av, prv_entry->conn);
 	}
 
-	ofi_mutex_unlock(&av->util_av.lock);
+	ofi_genlock_unlock(&av->util_av.lock);
 }
 
 static int efa_av_close(struct fid *fid)

--- a/prov/rxd/src/rxd_av.c
+++ b/prov/rxd/src/rxd_av.c
@@ -209,7 +209,7 @@ static int rxd_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 		memset(sync_err, 0, sizeof(*sync_err) * count);
 	}
 
-	ofi_mutex_lock(&av->util_av.lock);
+	ofi_genlock_lock(&av->util_av.lock);
 	if (!av->dg_addrlen) {
 		ret = rxd_av_set_addrlen(av, addr);
 		if (ret)
@@ -255,7 +255,7 @@ static int rxd_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 	}
 out:
 	av->dg_av_used += success_cnt;
-	ofi_mutex_unlock(&av->util_av.lock);
+	ofi_genlock_unlock(&av->util_av.lock);
 
 	for (; i < count; i++) {
 		if (fi_addr)
@@ -291,7 +291,7 @@ static int rxd_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr, size_t count
 	struct rxd_av *av;
 
 	av = container_of(av_fid, struct rxd_av, util_av.av_fid);
-	ofi_mutex_lock(&av->util_av.lock);
+	ofi_genlock_lock(&av->util_av.lock);
 	for (i = 0; i < count; i++) {
 		rxd_addr = (intptr_t)ofi_idx_lookup(&av->fi_addr_idx,
 						    (int) RXD_IDX_OFFSET(fi_addr[i]));
@@ -307,7 +307,7 @@ err:
 	if (ret)
 		FI_WARN(&rxd_prov, FI_LOG_AV, "Unable to remove address from AV\n");
 
-	ofi_mutex_unlock(&av->util_av.lock);
+	ofi_genlock_unlock(&av->util_av.lock);
 	return ret;
 }
 

--- a/prov/shm/src/smr_av.c
+++ b/prov/shm/src/smr_av.c
@@ -133,10 +133,10 @@ static int smr_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 			ret = smr_map_add(&smr_prov, &smr_av->smr_map,
 					  addr, &shm_id);
 			if (!ret) {
-				ofi_mutex_lock(&util_av->lock);
+				ofi_genlock_lock(&util_av->lock);
 				ret = ofi_av_insert_addr(util_av, &shm_id,
 							 &util_addr);
-				ofi_mutex_unlock(&util_av->lock);
+				ofi_genlock_unlock(&util_av->lock);
 			}
 		} else {
 			FI_WARN(&smr_prov, FI_LOG_AV,
@@ -198,7 +198,7 @@ static int smr_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr, size_t count
 	util_av = container_of(av_fid, struct util_av, av_fid);
 	smr_av = container_of(util_av, struct smr_av, util_av);
 
-	ofi_mutex_lock(&util_av->lock);
+	ofi_genlock_lock(&util_av->lock);
 	for (i = 0; i < count; i++) {
 		FI_INFO(&smr_prov, FI_LOG_AV, "%" PRIu64 "\n", fi_addr[i]);
 		id = smr_addr_lookup(util_av, fi_addr[i]);
@@ -224,7 +224,7 @@ static int smr_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr, size_t count
 		smr_av->used--;
 	}
 
-	ofi_mutex_unlock(&util_av->lock);
+	ofi_genlock_unlock(&util_av->lock);
 	return ret;
 }
 

--- a/prov/sm2/src/sm2_av.c
+++ b/prov/sm2/src/sm2_av.c
@@ -94,11 +94,11 @@ static int sm2_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 		if (ret)
 			continue;
 
-		ofi_mutex_lock(&util_av->lock);
+		ofi_genlock_lock(&util_av->lock);
 		ret = ofi_av_insert_addr(util_av, &gid, &util_addr);
 
 		if (ret) {
-			ofi_mutex_unlock(&util_av->lock);
+			ofi_genlock_unlock(&util_av->lock);
 			continue;
 		}
 
@@ -110,7 +110,7 @@ static int sm2_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 		if (fi_addr)
 			fi_addr[i] = util_addr;
 
-		ofi_mutex_unlock(&util_av->lock);
+		ofi_genlock_unlock(&util_av->lock);
 		succ_count++;
 	}
 
@@ -137,7 +137,7 @@ static int sm2_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr,
 	util_av = container_of(av_fid, struct util_av, av_fid);
 	sm2_av = container_of(util_av, struct sm2_av, util_av);
 
-	ofi_mutex_lock(&util_av->lock);
+	ofi_genlock_lock(&util_av->lock);
 	for (i = 0; i < count; i++) {
 		gid = *((sm2_gid_t *) ofi_av_get_addr(util_av, fi_addr[i]));
 		if (gid > 0 && gid < SM2_MAX_UNIVERSE_SIZE)
@@ -151,7 +151,7 @@ static int sm2_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr,
 		}
 	}
 
-	ofi_mutex_unlock(&util_av->lock);
+	ofi_genlock_unlock(&util_av->lock);
 	return ret;
 }
 
@@ -169,9 +169,9 @@ static int sm2_av_lookup(struct fid_av *av, fi_addr_t fi_addr, void *addr,
 	util_av = container_of(av, struct util_av, av_fid);
 	sm2_av = container_of(util_av, struct sm2_av, util_av);
 
-	ofi_mutex_lock(&util_av->lock);
+	ofi_genlock_lock(&util_av->lock);
 	gid = *((sm2_gid_t *) ofi_av_get_addr(util_av, fi_addr));
-	ofi_mutex_unlock(&util_av->lock);
+	ofi_genlock_unlock(&util_av->lock);
 
 	if (gid >= SM2_MAX_UNIVERSE_SIZE) {
 		FI_WARN(&sm2_prov, FI_LOG_EP_DATA,

--- a/prov/tcp/src/xnet_rdm.c
+++ b/prov/tcp/src/xnet_rdm.c
@@ -722,9 +722,9 @@ static int xnet_mplex_av_dup(struct util_ep *ep, struct xnet_mplex_av *mplex_av,
 		if (ret)
 			continue;
 
-		ofi_mutex_lock(&subav->lock);
+		ofi_genlock_lock(&subav->lock);
 		ret = ofi_av_insert_addr_at(subav, addr, i);
-		ofi_mutex_unlock(&subav->lock);
+		ofi_genlock_unlock(&subav->lock);
 		if (ret)
 			return ret;
 	}


### PR DESCRIPTION
The util_av lock will be held in the fast path in the EFA provider. With the correct threading and progress models
(FI_THREAD_DOMAIN/FI_THREAD_COMPLETION and FI_PROGRESS_CONTROL_UNIFIED), this lock should also be a no-op. Similar to the ep_list_lock.

This commit changes the mutex to a genlock that becomes a no-op for the correct threading and progress models and a mutex otherwise.