### PR TITLE
prov/efa: Set g_device_list to NULL after free

### DIFF
--- a/prov/efa/src/efa_device.c
+++ b/prov/efa/src/efa_device.c
@@ -230,6 +230,7 @@ void efa_device_list_finalize(void)
 			efa_device_destruct(&g_device_list[i]);
 
 		free(g_device_list);
+		g_device_list = NULL;
 	}
 
 	g_device_cnt = 0;


### PR DESCRIPTION
fi_info has a double free issue. The efa g_device_list isn't being set to NULL after being freed so the next time efa_device_list_finalize is called it will be freed again (double free). Setting it to NULL removes this.