### PR TITLE
fabtests/test_configs/psm3: Re-enable psm3 rdm_tagged_peek

### DIFF
--- a/fabtests/test_configs/psm3/psm3.exclude
+++ b/fabtests/test_configs/psm3/psm3.exclude
@@ -16,4 +16,3 @@ shared_av
 rdm_cntr_pingpong
 multi_recv
 multinode
-rdm_tagged_peek


### PR DESCRIPTION
Issue #10123 is resolved and this test can be re-enabled.