### PR TITLE
prov/efa: Fix the clean up issue for efa_util_prov

### DIFF
--- a/prov/efa/src/efa_device.c
+++ b/prov/efa/src/efa_device.c
@@ -162,8 +162,8 @@ static void efa_device_destruct(struct efa_device *device)
 	device->ibv_ctx = NULL;
 }
 
-struct efa_device *g_device_list;
-int g_device_cnt;
+struct efa_device *g_device_list = NULL;
+int g_device_cnt = 0;
 
 /**
  * @brief initialize the global variables g_device_list and g_device_cnt
@@ -232,6 +232,7 @@ void efa_device_list_finalize(void)
 		free(g_device_list);
 	}
 
+	g_device_list = NULL;
 	g_device_cnt = 0;
 }
 

--- a/prov/efa/src/efa_prov.c
+++ b/prov/efa/src/efa_prov.c
@@ -23,6 +23,7 @@ int efa_win_lib_initialize(void)
 
 #include "efawin.h"
 
+static bool efa_win_initialized = false;
 /**
  * @brief open efawin.dll and load the symbols on windows platform
  *
@@ -37,10 +38,11 @@ int efa_win_lib_initialize(void)
 	* functions from efawin dll
 	*/
 	int err = efa_load_efawin_lib();
-	if (err) {
+	if (err)
 		EFA_WARN(FI_LOG_CORE, "Failed to load efawin dll. error: %d\n",
 			 err);
-	}
+	else
+		efa_win_initialized = true;
 	return err;
 }
 
@@ -50,7 +52,9 @@ int efa_win_lib_initialize(void)
  * This function is a no-op on windows
  */
 void efa_win_lib_finalize(void) {
-	efa_free_efawin_lib();
+	if (efa_win_initialized)
+		efa_free_efawin_lib();
+	efa_win_initialized = false;
 }
 
 #endif // _WIN32
@@ -171,7 +175,8 @@ static void efa_util_prov_finalize()
 	struct fi_info *prov_info;
 
 	prov_info = (struct fi_info *)efa_util_prov.info;
-	fi_freeinfo(prov_info);
+	if (prov_info)
+		fi_freeinfo(prov_info);
 	efa_util_prov.info = NULL;
 }
 


### PR DESCRIPTION
Commit b7b9dd6 makes efa_prov always returned
by EFA_INI, even when efa device is not available. Then in `fi_fini` the efa_prov_finialize` will be
triggered on non-EFA platform. However, the current efa_prov_finalize doesn't handle the case where
the resources were not created, and it will cause
a double free error.

This patch fixex this issue.