### PR TITLE
prov/efa: Fix the rnr cq read error test for efa-direct

### DIFF
--- a/fabtests/prov/efa/Makefile.include
+++ b/fabtests/prov/efa/Makefile.include
@@ -42,6 +42,7 @@ endif BUILD_EFA_RDMA_CHECKER
 endif HAVE_VERBS_DEVEL
 
 efa_rnr_srcs = \
+	prov/efa/src/efa_shared.h \
 	prov/efa/src/efa_rnr_shared.h \
 	prov/efa/src/efa_rnr_shared.c
 

--- a/fabtests/prov/efa/src/efa_shared.h
+++ b/fabtests/prov/efa/src/efa_shared.h
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All
+ * rights reserved. */
+
+#ifndef _EFA_SHARED_H
+#define _EFA_SHARED_H
+
+#define EFA_FABRIC_NAME	       "efa"
+#define EFA_DIRECT_FABRIC_NAME "efa-direct"
+
+#define EFA_INFO_TYPE_IS_RDM(_info)                                        \
+	(_info && _info->ep_attr && (_info->ep_attr->type == FI_EP_RDM) && \
+	 !strcasecmp(_info->fabric_attr->name, EFA_FABRIC_NAME))
+
+#define EFA_INFO_TYPE_IS_DIRECT(_info)                                     \
+	(_info && _info->ep_attr && (_info->ep_attr->type == FI_EP_RDM) && \
+	 !strcasecmp(_info->fabric_attr->name, EFA_DIRECT_FABRIC_NAME))
+
+#endif /* _EFA_SHARED_H */

--- a/prov/efa/src/efa_msg.c
+++ b/prov/efa/src/efa_msg.c
@@ -281,6 +281,8 @@ static inline ssize_t efa_post_send(struct efa_base_ep *base_ep, const struct fi
 
 	if (!(flags & FI_MORE)) {
 		ret = ibv_wr_complete(qp->ibv_qp_ex);
+		if (OFI_UNLIKELY(ret))
+			ret = (ret == ENOMEM) ? -FI_EAGAIN : -ret;
 		base_ep->is_wr_started = false;
 	}
 

--- a/prov/efa/src/efa_rma.c
+++ b/prov/efa/src/efa_rma.c
@@ -121,6 +121,8 @@ static inline ssize_t efa_rma_post_read(struct efa_base_ep *base_ep,
 
 	if (!(flags & FI_MORE)) {
 		err = ibv_wr_complete(qp->ibv_qp_ex);
+		if (OFI_UNLIKELY(err))
+			err = (err == ENOMEM) ? -FI_EAGAIN : -err;
 		base_ep->is_wr_started = false;
 	}
 
@@ -265,6 +267,8 @@ static inline ssize_t efa_rma_post_write(struct efa_base_ep *base_ep,
 
 	if (!(flags & FI_MORE)) {
 		err = ibv_wr_complete(qp->ibv_qp_ex);
+		if (OFI_UNLIKELY(err))
+			err = (err == ENOMEM) ? -FI_EAGAIN : -err;
 		base_ep->is_wr_started = false;
 	}
 

--- a/prov/efa/src/rdm/efa_rdm_pke.c
+++ b/prov/efa/src/rdm/efa_rdm_pke.c
@@ -470,7 +470,7 @@ ssize_t efa_rdm_pke_sendv(struct efa_rdm_pke **pkt_entry_vec,
 	}
 
 	if (OFI_UNLIKELY(ret)) {
-		return ret;
+		return (ret == ENOMEM) ? -FI_EAGAIN : -ret;
 	}
 
 	for (pkt_idx = 0; pkt_idx < pkt_entry_cnt; ++pkt_idx)
@@ -537,7 +537,7 @@ int efa_rdm_pke_read(struct efa_rdm_pke *pkt_entry,
 	err = ibv_wr_complete(qp->ibv_qp_ex);
 
 	if (OFI_UNLIKELY(err))
-		return err;
+		return (err == ENOMEM) ? -FI_EAGAIN : -err;
 
 	efa_rdm_ep_record_tx_op_submitted(ep, pkt_entry);
 	return 0;
@@ -632,7 +632,7 @@ int efa_rdm_pke_write(struct efa_rdm_pke *pkt_entry)
 	}
 
 	if (OFI_UNLIKELY(err))
-		return err;
+		return (err == ENOMEM) ? -FI_EAGAIN : -err;
 
 	efa_rdm_ep_record_tx_op_submitted(ep, pkt_entry);
 	return 0;


### PR DESCRIPTION
This PR contains 2 changes to fix the rnr cq read error test for efa-direct:

1. The error code returned by efa-direct in the fi_send call is wrong when hitting resource exhaustion. It needs a conversion for ibv errno to fi errno
2. For the cq read error test, efa-direct doesn't prepost any rx buffer internally, it posts whatever application posts, the total_send needs to be adjusted to match this behavior difference. 