### PR TITLE
fabtests/common: Set the min of tx/rx_mr_size

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -540,6 +540,7 @@ static void ft_set_tx_rx_sizes(size_t *set_tx, size_t *set_rx)
 {
 	*set_tx = opts.options & FT_OPT_SIZE ?
 		  opts.transfer_size : test_size[TEST_CNT - 1].size;
+	*set_tx = MAX(*set_tx, FT_MAX_CTRL_MSG);
 	if (*set_tx > fi->ep_attr->max_msg_size)
 		*set_tx = fi->ep_attr->max_msg_size;
 	*set_rx = *set_tx + ft_rx_prefix_size();
@@ -600,8 +601,8 @@ int ft_alloc_msgs(void)
 		ft_set_tx_rx_sizes(&tx_size, &rx_size);
 		tx_mr_size = 0;
 		rx_mr_size = 0;
-		rx_buf_size = MAX(rx_size, FT_MAX_CTRL_MSG) * opts.window_size;
-		tx_buf_size = MAX(tx_size, FT_MAX_CTRL_MSG) * opts.window_size;
+		rx_buf_size = rx_size * opts.window_size;
+		tx_buf_size = tx_size * opts.window_size;
 	}
 
 	/* Allow enough space for RMA to operate in a distinct memory


### PR DESCRIPTION
In FT_OPT_ALLOC_MULT_MR mode, currently tx/rx_mr_size is set as the opts.transfer_size, and the subsequent ft_alloc_ctx_array will use this size to allocate
tx/rx buffers in the ctx array.

However, when test call ft_post_rx_buf, it will
finally post a size as MAX(opts.transfer_size, FT_MAX_CTRL_MSG). When opts.transfer_size is smaller than FT_MAX_CTRL_MSG, it will cause test call fi_recv of size larger than the actual buffer (and MR) size and cause error when the provider offload the recv directly to hardware.

This patch fixes this issue by making the tx/rx_mr_size has a min value as the FT_MAX_CTRL_MSG.