### PR TITLE
prov/cxi: Fix peer CQ support

### DIFF
--- a/prov/cxi/src/cxip_cq.c
+++ b/prov/cxi/src/cxip_cq.c
@@ -395,6 +395,10 @@ static int cxip_cq_verify_attr(struct fi_cq_attr *attr)
 	if (!attr)
 		return FI_SUCCESS;
 
+	if (attr->flags & FI_PEER &&
+	    attr->wait_obj != FI_WAIT_NONE)
+		return -FI_ENOSYS;
+
 	switch (attr->format) {
 	case FI_CQ_FORMAT_CONTEXT:
 	case FI_CQ_FORMAT_MSG:
@@ -511,7 +515,8 @@ int cxip_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	}
 
 	cxi_cq->util_cq.cq_fid.fid.ops = &cxip_cq_fi_ops;
-	cxi_cq->util_cq.cq_fid.ops = &cxip_cq_ops;
+	if (!(attr->flags & FI_PEER))
+		cxi_cq->util_cq.cq_fid.ops = &cxip_cq_ops;
 	cxi_cq->domain = cxi_dom;
 	cxi_cq->ack_batch_size = cxip_env.eq_ack_batch_size;
 	cxi_cq->ep_fd = -1;


### PR DESCRIPTION
cxi_cq->util_cq.cq_fid.ops is being overwritten after call to ofi_cq_init() which sets the ops to the peer callbacks. Update the code to only override this structure in the non-peer case.