### PR TITLE
prov/efa: Remove efa_av->ep_type in favor of efa_domain->info_type

### DIFF
--- a/prov/efa/src/efa_av.h
+++ b/prov/efa/src/efa_av.h
@@ -23,7 +23,7 @@ struct efa_conn {
 	struct efa_ah		*ah;
 	struct efa_ep_addr	*ep_addr;
 	fi_addr_t		fi_addr;
-	struct efa_rdm_peer	rdm_peer;
+	struct efa_rdm_peer	*rdm_peer;
 };
 
 struct efa_av_entry {
@@ -69,6 +69,7 @@ struct efa_av {
 	struct efa_prv_reverse_av *prv_reverse_av;
 	struct efa_ah *ah_map;
 	struct util_av util_av;
+	struct ofi_bufpool *rdm_peer_pool;
 };
 
 int efa_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,

--- a/prov/efa/src/efa_av.h
+++ b/prov/efa/src/efa_av.h
@@ -69,7 +69,6 @@ struct efa_av {
 	struct efa_prv_reverse_av *prv_reverse_av;
 	struct efa_ah *ah_map;
 	struct util_av util_av;
-	enum fi_ep_type ep_type;
 };
 
 int efa_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,

--- a/prov/efa/src/efa_domain.h
+++ b/prov/efa/src/efa_domain.h
@@ -11,6 +11,12 @@
 #include "ofi_hmem.h"
 #include "ofi_util.h"
 
+enum efa_domain_info_type {
+	EFA_INFO_RDM,
+	EFA_INFO_DIRECT,
+	EFA_INFO_DGRAM,
+};
+
 struct efa_domain {
 	struct util_domain	util_domain;
 	struct fi_info		*shm_info;
@@ -31,9 +37,10 @@ struct efa_domain {
 	size_t ibv_mr_reg_ct;
 	/* Total size of memory registrations (in bytes) */
 	size_t ibv_mr_reg_sz;
+	/* info_type is used to distinguish between the rdm, dgram and
+	 * efa-direct paths */
+	enum efa_domain_info_type info_type;
 
-	/* Only valid for RDM EP type */
-	bool			rdm_ep;		/* Set to true for RDM domain. False otherwise. */
 	size_t			rdm_cq_size;
 	/* number of rdma-read messages in flight */
 	uint64_t		num_read_msg_in_flight;

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -222,7 +222,7 @@ static int efa_mr_hmem_setup(struct efa_mr *efa_mr,
 		efa_mr->peer.device.cuda = attr->device.cuda;
 
 		/* Only attempt GDRCopy registrations for efa rdm path */
-		if (efa_mr->domain->rdm_ep && !(flags & FI_MR_DMABUF) && cuda_is_gdrcopy_enabled()) {
+		if (efa_mr->domain->info_type == EFA_INFO_RDM && !(flags & FI_MR_DMABUF) && cuda_is_gdrcopy_enabled()) {
 			mr_iov = *attr->mr_iov;
 			err = ofi_hmem_dev_register(FI_HMEM_CUDA, mr_iov.iov_base, mr_iov.iov_len,
 						    (uint64_t *)&efa_mr->peer.hmem_data);

--- a/prov/efa/src/rdm/efa_rdm_ep_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_utils.c
@@ -63,7 +63,7 @@ struct efa_rdm_peer *efa_rdm_ep_get_peer(struct efa_rdm_ep *ep, fi_addr_t addr)
 	util_av_entry = ofi_bufpool_get_ibuf(ep->base_ep.util_ep.av->av_entry_pool,
 	                                     addr);
 	av_entry = (struct efa_av_entry *)util_av_entry->data;
-	return av_entry->conn.ep_addr ? &av_entry->conn.rdm_peer : NULL;
+	return av_entry->conn.ep_addr ? av_entry->conn.rdm_peer : NULL;
 }
 
 /**

--- a/prov/efa/test/efa_unit_test_av.c
+++ b/prov/efa/test/efa_unit_test_av.c
@@ -5,38 +5,6 @@
 #include "efa_av.h"
 
 /**
- * @brief Verify the ep type in struct efa_av for efa RDM path
- *
- * @param[in]	state		struct efa_resource that is managed by the framework
- */
-void test_av_ep_type_efa_rdm(struct efa_resource **state)
-{
-	struct efa_resource *resource = *state;
-	struct efa_av *efa_av;
-
-	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_FABRIC_NAME);
-	g_efa_unit_test_mocks.ibv_create_ah = &efa_mock_ibv_create_ah_check_mock;
-	efa_av = container_of(resource->av, struct efa_av, util_av.av_fid);
-	assert(efa_av->ep_type == FI_EP_RDM);
-}
-
-/**
- * @brief Verify the ep type in struct efa_av for efa direct path
- *
- * @param[in]	state		struct efa_resource that is managed by the framework
- */
-void test_av_ep_type_efa_direct(struct efa_resource **state)
-{
-	struct efa_resource *resource = *state;
-	struct efa_av *efa_av;
-
-	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_DIRECT_FABRIC_NAME);
-	g_efa_unit_test_mocks.ibv_create_ah = &efa_mock_ibv_create_ah_check_mock;
-	efa_av = container_of(resource->av, struct efa_av, util_av.av_fid);
-	assert(efa_av->ep_type == FI_EP_RDM);
-}
-
-/**
  * @brief Only works on nodes with EFA devices
  * This test calls fi_av_insert() twice with the same raw address,
  * and verifies that returned fi_addr is the same and

--- a/prov/efa/test/efa_unit_test_domain.c
+++ b/prov/efa/test/efa_unit_test_domain.c
@@ -3,6 +3,36 @@
 
 #include "efa_unit_tests.h"
 
+/**
+ * @brief Verify the info type in struct efa_domain for efa RDM path
+ *
+ * @param[in]	state		struct efa_resource that is managed by the framework
+ */
+void test_efa_domain_info_type_efa_rdm(struct efa_resource **state)
+{
+	struct efa_resource *resource = *state;
+	struct efa_domain *efa_domain;
+
+	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_FABRIC_NAME);
+	efa_domain = container_of(resource->domain, struct efa_domain, util_domain.domain_fid);
+	assert(efa_domain->info_type == EFA_INFO_RDM);
+}
+
+/**
+ * @brief Verify the info type in struct efa_domain for efa direct path
+ *
+ * @param[in]	state		struct efa_resource that is managed by the framework
+ */
+void test_efa_domain_info_type_efa_direct(struct efa_resource **state)
+{
+	struct efa_resource *resource = *state;
+	struct efa_domain *efa_domain;
+
+	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_DIRECT_FABRIC_NAME);
+	efa_domain = container_of(resource->domain, struct efa_domain, util_domain.domain_fid);
+	assert(efa_domain->info_type == EFA_INFO_DIRECT);
+}
+
 /* test fi_open_ops with a wrong name */
 void test_efa_domain_open_ops_wrong_name(struct efa_resource **state)
 {

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -90,8 +90,6 @@ int main(void)
 	/* Requires an EFA device to work */
 	const struct CMUnitTest efa_unit_tests[] = {
 		/* begin efa_unit_test_av.c */
-		cmocka_unit_test_setup_teardown(test_av_ep_type_efa_rdm, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
-		cmocka_unit_test_setup_teardown(test_av_ep_type_efa_direct, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_av_insert_duplicate_raw_addr, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_av_insert_duplicate_gid, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		/* end efa_unit_test_av.c */
@@ -234,8 +232,14 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_rdm_pke_alloc_rta_rxe, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_pke_alloc_rtw_rxe, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_pke_alloc_rtr_rxe, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+
+		/* begin efa_unit_test_domain.c */
+		cmocka_unit_test_setup_teardown(test_efa_domain_info_type_efa_direct, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_domain_info_type_efa_rdm, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_domain_open_ops_wrong_name, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_domain_open_ops_mr_query, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		/* end efa_unit_test_domain.c */
+
 		cmocka_unit_test_setup_teardown(test_efa_rdm_cq_ibv_cq_poll_list_same_tx_rx_cq_single_ep, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_cq_ibv_cq_poll_list_separate_tx_rx_cq_single_ep, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_cq_post_initial_rx_pkts, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -105,8 +105,6 @@ struct efa_rdm_ope *efa_unit_test_alloc_rxe(struct efa_resource *resource, uint3
 /* test cases */
 
 /* begin efa_unit_test_av.c */
-void test_av_ep_type_efa_rdm();
-void test_av_ep_type_efa_direct();
 void test_av_insert_duplicate_raw_addr();
 void test_av_insert_duplicate_gid();
 /* end efa_unit_test_av.c */
@@ -245,8 +243,14 @@ void test_efa_rdm_peer_get_runt_size_cuda_memory_exceeding_total_len_128_alignme
 void test_efa_rdm_peer_select_readbase_rtm_no_runt();
 void test_efa_rdm_peer_select_readbase_rtm_do_runt();
 void test_efa_rdm_pke_get_available_copy_methods_align128();
+
+/* begin efa_unit_test_domain.c */
+void test_efa_domain_info_type_efa_direct();
+void test_efa_domain_info_type_efa_rdm();
 void test_efa_domain_open_ops_wrong_name();
 void test_efa_domain_open_ops_mr_query();
+/* end efa_unit_test_domain.c */
+
 void test_efa_rdm_cq_ibv_cq_poll_list_same_tx_rx_cq_single_ep();
 void test_efa_rdm_cq_ibv_cq_poll_list_separate_tx_rx_cq_single_ep();
 void test_efa_rdm_cq_post_initial_rx_pkts();


### PR DESCRIPTION
### prov/efa: Do not allocate rdm_peer struct for efa-direct and dgram paths

### prov/efa: Remove efa_av->ep_type in favor of efa_domain->info_type

efa_av->ep_type was used to distinguish between the RDM path and the
DGRAM path. The efa-direct path has FI_EP_RDM ep type but it does not
require a efa_conn->rdm_peer. But the efa-direct path still uses unique connid
based on timestamp.

Use efa_domain->info_type to distinguish the three code paths.

### prov/efa: Replace domain->rdm_ep with domain->info_type

domain->rdm_ep can't distinguish between efa-direct and dgram code paths