### PR TITLE
fabtests: Do not require FI_TAGGED for fi_av_xfer test

### DIFF
--- a/fabtests/functional/av_xfer.c
+++ b/fabtests/functional/av_xfer.c
@@ -233,8 +233,7 @@ int main(int argc, char **argv)
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
 
-	hints->caps = hints->ep_attr->type == FI_EP_RDM ?
-		      FI_TAGGED : FI_MSG;
+	hints->caps = FI_MSG;
 	hints->mode = FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->addr_format = opts.address_format;


### PR DESCRIPTION
This test does not require tagged messaging