### PR TITLE
prov/efa: released matched rxe before destroying the srx rx_pool

### DIFF
--- a/fabtests/pytest/efa/test_remote_exit_early.py
+++ b/fabtests/pytest/efa/test_remote_exit_early.py
@@ -5,7 +5,7 @@ from common import ClientServerTest
 def remote_exit_early_message_size(request):
     # 64K use medium
     # 128K use long CTS
-    # 1M use runtread or longread
+    # 1M use runtread or longread if rdma read is available
     return request.param
 
 @pytest.mark.functional
@@ -26,4 +26,9 @@ def test_remote_exit_early_post_writedata(cmdline_args, remote_exit_early_messag
                             message_size=remote_exit_early_message_size)
     test.run()
 
-# TODO: add test with --post-rx after fixing the leak in srx->rx_pool
+@pytest.mark.functional
+def test_remote_exit_early_post_rx(cmdline_args, remote_exit_early_message_size):
+    test = ClientServerTest(cmdline_args,
+                            "fi_efa_rdm_remote_exit_early --post-rx",
+                            message_size=remote_exit_early_message_size)
+    test.run()


### PR DESCRIPTION
If the sender exits early, there may still be unreleased rxe in the srx->rx_pool during util_srx_close, which will cause an
assertion error when the pool is destroyed. Release the matched rxe before calling util_srx_close.

fabtests/efa: Add remote exit early test with post recv
When rdma read is available and message size >= 1M, long read or runt read protocol is used and server is expected to get a cq entry or cq error.
Otherwise, if long CTS is used and sender exits before sending CTS data, receiver is expected to timeout after sending the CTS packet without getting a cq entry or cq error.