### PR TITLE
Fix some test function prototypes

### DIFF
--- a/fabtests/ubertest/config.c
+++ b/fabtests/ubertest/config.c
@@ -712,7 +712,7 @@ int fts_info_is_valid(void)
 			return 0;
 	}
 	if (test_info.test_class & (FI_MSG | FI_TAGGED) &&
-	    !ft_check_rx_completion(test_info) &&
+	    !ft_check_rx_completion() &&
 	    !ft_use_comp_cntr(test_info.comp_type))
 		return 0;
 	if (test_info.test_type == FT_TEST_UNIT &&

--- a/fabtests/ubertest/fabtest.h
+++ b/fabtests/ubertest/fabtest.h
@@ -362,7 +362,7 @@ int ft_check_rx_completion();
 int ft_check_tx_completion();
 
 int ft_send_sync_msg();
-int ft_recv_n_msg();
+int ft_recv_n_msg(int n);
 int ft_recv_msg();
 int ft_send_msg();
 int ft_send_dgram();


### PR DESCRIPTION
This fixes compilation with gcc 15 which is stricter about function arguments.