### PR TITLE
Storage/RPC Related Resource Management Updates for Connectionless EPs

### DIFF
--- a/man/fi_domain.3.md
+++ b/man/fi_domain.3.md
@@ -413,17 +413,18 @@ the endpoint is reliable or unreliable, as well as provider and protocol
 specific implementation details, as shown in the following table.  The
 table assumes that all peers enable or disable RM the same.
 
-| Resource | DGRAM EP-no RM | DGRAM EP-with RM | RDM/MSG EP-no RM | RDM/MSG EP-with RM |
-|:--------:|:-------------------:|:-------------------:|:------------------:|:-----------------:|
-| Tx Ctx         | undefined error  | EAGAIN           | undefined error   | EAGAIN             |
-| Rx Ctx         | undefined error  | EAGAIN           | undefined error   | EAGAIN             |
-| Tx CQ          | undefined error  | EAGAIN           | undefined error   | EAGAIN             |
-| Rx CQ          | undefined error  | EAGAIN           | undefined error   | EAGAIN             |
-| Target EP      | dropped          | dropped          | transmit error    | retried            |
-| No Rx Buffer   | dropped          | dropped          | transmit error    | retried            |
-| Rx Buf Overrun | truncate or drop | truncate or drop | truncate or error | truncate or error  |
-| Unmatched RMA  | not applicable   | not applicable   | transmit error    | transmit error     |
-| RMA Overrun    | not applicable   | not applicable   | transmit error    | transmit error     |
+| Resource | DGRAM EP-no RM | DGRAM EP-with RM | MSG EP-no RM | MSG EP-with RM | RDM EP-no RM | RDM EP-with RM |
+|:--------:|:-------------------:|:-------------------:|:------------------:|:-----------------:| :------------------:|:-----------------:|
+| Tx Ctx         | undefined error  | EAGAIN           | undefined error   | EAGAIN             | undefined error   | EAGAIN             |
+| Rx Ctx         | undefined error  | EAGAIN           | undefined error   | EAGAIN             | undefined error   | EAGAIN             |
+| Tx CQ          | undefined error  | EAGAIN           | undefined error   | EAGAIN             | undefined error   | EAGAIN             |
+| Rx CQ          | undefined error  | EAGAIN           | undefined error   | EAGAIN             | undefined error   | EAGAIN             |
+| Target EP      | dropped          | dropped          | transmit error    | retried            | transmit error    | retried            |
+| No Rx Buffer   | dropped          | dropped          | transmit error    | retried            | transmit error    | retried            |
+| Rx Buf Overrun | truncate or drop | truncate or drop | truncate or error | truncate or error  | truncate or error | truncate or error  |
+| Unmatched RMA  | not applicable   | not applicable   | transmit error    | transmit error     | transmit error    | transmit error     |
+| RMA Overrun    | not applicable   | not applicable   | transmit error    | transmit error     | transmit error    | transmit error     |
+| Unreachable EP | dropped          | dropped          | not applicable    | not applicable     | transmit error    | transmit error     |
 
 The resource column indicates the resource being accessed by a data
 transfer operation.
@@ -481,6 +482,14 @@ transfer operation.
   to access a memory address that is either not registered for such
   operations, or attempt to access outside of the target memory region
   will fail, resulting in a transmit error.
+
+*Unreachable EP*
+: Unreachable endpoint is a connectionless specific scenario where transmit
+  operations are issued to unreachable target endpoints. Such scenarios include
+  no-route-to-host or down target NIC. For FI_EP_DGRAM endpoints, transmit
+  operations targeting an unreachable endpoint will have operation dropped. For
+  FI_EP_RDM, target operations targeting an unreachable endpoint will result in
+  a transmit error.
 
 When a resource management error occurs on an a connected endpoint, the endpoint
 will transition into a disabled state and the connection torn down. A disabled


### PR DESCRIPTION
Storage libfabric users using a connectionless EP do not expect the EP to become disabled if an RDMA operation fails. The current libfabric documentation states that if various resource management enabled errors occur on an endpoint, the endpoint becomes disabled and must be re-enabled to be reusable. While this makes sense for a connected endpoint (e.g., TCP socket and IB RC QP), this does not make sense for connectionless endpoints. Consider the following RDM EP example:

1. RPC client sends RKEY to RPC server.
2. RPC client dies resulting in RKEY now being invalid.
3. RPC server issues RMA to RPC client.
4. RMA operation fails due to unmatched RMA.
5. RPC server RDM EP is disabled.

The above shows that a single RPC client crashing can trigger server endpoint becoming disabled. This would impact RPC server connectivity to all other up RPC clients.

This PR addresses this problem by

- Clarifying what resource management errors disable connected and connectionless
- Defining unreachable EP resource management scenario