### PR TITLE
prov/efa: Make rxe_map part of the efa_rdm_peer struct

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -109,8 +109,6 @@ struct efa_rdm_ep {
 	struct ofi_bufpool *overflow_pke_pool;
 	/* data structure to maintain pkt rx map */
 	struct ofi_bufpool *map_entry_pool;
-	/** a map between sender address + msg_id to RX entry */
-	struct efa_rdm_rxe_map rxe_map;
 	/*
 	 * buffer pool for atomic response data, used by
 	 * emulated fetch and compare atomic.

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -242,7 +242,6 @@ int efa_rdm_ep_create_buffer_pools(struct efa_rdm_ep *ep)
 	if (ret)
 		goto err_free;
 
-	efa_rdm_rxe_map_construct(&ep->rxe_map);
 	return 0;
 
 err_free:

--- a/prov/efa/src/rdm/efa_rdm_msg.c
+++ b/prov/efa/src/rdm/efa_rdm_msg.c
@@ -738,6 +738,7 @@ struct efa_rdm_ope *efa_rdm_msg_alloc_matched_rxe_for_rtm(struct efa_rdm_ep *ep,
  * or #efa_rdm_msg_unexp_rxe_for_rtm().
  *
  * @param[in]		ep		endpoint
+ * @param[in]		peer		efa_rdm_peer struct of the sender
  * @param[in]		pkt_entry	RTM packet entry
  *
  * @returns
@@ -745,8 +746,10 @@ struct efa_rdm_ope *efa_rdm_msg_alloc_matched_rxe_for_rtm(struct efa_rdm_ep *ep,
  * If endpoint's operation entry pool (ope_pool) has been exhausted,
  * return NULL
  */
-struct efa_rdm_ope *efa_rdm_msg_alloc_rxe_for_msgrtm(struct efa_rdm_ep *ep,
-						     struct efa_rdm_pke **pkt_entry_ptr)
+struct efa_rdm_ope *
+efa_rdm_msg_alloc_rxe_for_msgrtm(struct efa_rdm_ep *ep,
+				 struct efa_rdm_peer *peer,
+				 struct efa_rdm_pke **pkt_entry_ptr)
 {
 	struct fid_peer_srx *peer_srx;
 	struct fi_peer_match_attr attr;
@@ -794,7 +797,7 @@ struct efa_rdm_ope *efa_rdm_msg_alloc_rxe_for_msgrtm(struct efa_rdm_ep *ep,
 
 	pkt_type = efa_rdm_pke_get_base_hdr(*pkt_entry_ptr)->type;
 	if (efa_rdm_pkt_type_is_mulreq(pkt_type))
-		efa_rdm_rxe_map_insert(&ep->rxe_map, efa_rdm_pke_get_rtm_msg_id(*pkt_entry_ptr), (*pkt_entry_ptr)->addr, rxe);
+		efa_rdm_rxe_map_insert(&peer->rxe_map, efa_rdm_pke_get_rtm_msg_id(*pkt_entry_ptr), rxe);
 
 	return rxe;
 }
@@ -807,6 +810,7 @@ struct efa_rdm_ope *efa_rdm_msg_alloc_rxe_for_msgrtm(struct efa_rdm_ep *ep,
  * or #efa_rdm_msg_unexp_rxe_for_rtm().
  *
  * @param[in]		ep		endpoint
+ * @param[in]		peer		efa_rdm_peer struct of the sender
  * @param[in]		pkt_entry	RTM packet entry
  *
  * @returns
@@ -814,8 +818,10 @@ struct efa_rdm_ope *efa_rdm_msg_alloc_rxe_for_msgrtm(struct efa_rdm_ep *ep,
  * If endpoint's operation entry pool (ope_pool) has been exhausted,
  * return NULL
  */
-struct efa_rdm_ope *efa_rdm_msg_alloc_rxe_for_tagrtm(struct efa_rdm_ep *ep,
-						     struct efa_rdm_pke **pkt_entry_ptr)
+struct efa_rdm_ope *
+efa_rdm_msg_alloc_rxe_for_tagrtm(struct efa_rdm_ep *ep,
+				 struct efa_rdm_peer *peer,
+				 struct efa_rdm_pke **pkt_entry_ptr)
 {
 	struct fid_peer_srx *peer_srx;
 	struct fi_peer_match_attr attr;
@@ -871,7 +877,7 @@ struct efa_rdm_ope *efa_rdm_msg_alloc_rxe_for_tagrtm(struct efa_rdm_ep *ep,
 
 	pkt_type = efa_rdm_pke_get_base_hdr(*pkt_entry_ptr)->type;
 	if (efa_rdm_pkt_type_is_mulreq(pkt_type))
-		efa_rdm_rxe_map_insert(&ep->rxe_map, efa_rdm_pke_get_rtm_msg_id(*pkt_entry_ptr), (*pkt_entry_ptr)->addr, rxe);
+		efa_rdm_rxe_map_insert(&peer->rxe_map, efa_rdm_pke_get_rtm_msg_id(*pkt_entry_ptr), rxe);
 
 	return rxe;
 }

--- a/prov/efa/src/rdm/efa_rdm_msg.h
+++ b/prov/efa/src/rdm/efa_rdm_msg.h
@@ -21,11 +21,15 @@ struct efa_rdm_ope *efa_rdm_msg_alloc_rxe(struct efa_rdm_ep *ep,
 					    uint32_t op, uint64_t flags,
 					    uint64_t tag, uint64_t ignore);
 
-struct efa_rdm_ope *efa_rdm_msg_alloc_rxe_for_msgrtm(struct efa_rdm_ep *ep,
-						     struct efa_rdm_pke **pkt_entry_ptr);
+struct efa_rdm_ope *
+efa_rdm_msg_alloc_rxe_for_msgrtm(struct efa_rdm_ep *ep,
+				 struct efa_rdm_peer *peer,
+				 struct efa_rdm_pke **pkt_entry_ptr);
 
-struct efa_rdm_ope *efa_rdm_msg_alloc_rxe_for_tagrtm(struct efa_rdm_ep *ep,
-						     struct efa_rdm_pke **pkt_entry_ptr);
+struct efa_rdm_ope *
+efa_rdm_msg_alloc_rxe_for_tagrtm(struct efa_rdm_ep *ep,
+				 struct efa_rdm_peer *peer,
+				 struct efa_rdm_pke **pkt_entry_ptr);
 
 struct efa_rdm_ope *efa_rdm_msg_split_rxe(struct efa_rdm_ep *ep,
 					    struct efa_rdm_ope *posted_entry,

--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -183,7 +183,7 @@ void efa_rdm_rxe_release_internal(struct efa_rdm_ope *rxe)
 		dlist_remove(&rxe->entry);
 
 	if (rxe->rxe_map)
-		efa_rdm_rxe_map_remove(rxe->rxe_map, rxe->msg_id, rxe->addr, rxe);
+		efa_rdm_rxe_map_remove(rxe->rxe_map, rxe->msg_id, rxe);
 
 	for (i = 0; i < rxe->iov_count; i++) {
 		if (rxe->mr[i]) {

--- a/prov/efa/src/rdm/efa_rdm_peer.c
+++ b/prov/efa/src/rdm/efa_rdm_peer.c
@@ -36,6 +36,8 @@ void efa_rdm_peer_construct(struct efa_rdm_peer *peer, struct efa_rdm_ep *ep, st
 		peer->shm_fiaddr = conn->shm_fi_addr;
 		peer->is_local = 1;
 	}
+
+	efa_rdm_rxe_map_construct(&peer->rxe_map);
 }
 
 /**

--- a/prov/efa/src/rdm/efa_rdm_peer.h
+++ b/prov/efa/src/rdm/efa_rdm_peer.h
@@ -7,6 +7,7 @@
 #include "ofi_recvwin.h"
 #include "efa_rdm_ope.h"
 #include "efa_rdm_protocol.h"
+#include "efa_rdm_rxe_map.h"
 
 #define EFA_RDM_PEER_DEFAULT_REORDER_BUFFER_SIZE	(16384)
 
@@ -61,7 +62,7 @@ struct efa_rdm_peer {
 	struct dlist_entry rnr_backoff_entry;	/**< linked to efa_domain->peer_backoff_list */
 	struct dlist_entry handshake_queued_entry; /**< linked with efa_domain->handshake_queued_peer_list */
 	struct dlist_entry txe_list; /**< a list of txe related to this peer */
-	struct dlist_entry rxe_list; /**< a list of rxe relased to this peer */
+	struct dlist_entry rxe_list; /**< a list of rxe related to this peer */
 	struct dlist_entry overflow_pke_list; /**< a list of out-of-order pke that overflow the current recvwin */
 
 	/**
@@ -73,6 +74,7 @@ struct efa_rdm_peer {
 	 * only valid when (extra_info[0] & EFA_RDM_EXTRA_FEATURE_REQUEST_USER_RECV_QP) is non-zero
 	 */
 	struct efa_rdm_peer_user_recv_qp user_recv_qp;
+	struct efa_rdm_rxe_map rxe_map; 	/**< Hashmap used to match received mulreq packets with RX entries */
 };
 
 /**

--- a/prov/efa/src/rdm/efa_rdm_pke_cmd.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_cmd.c
@@ -891,7 +891,7 @@ void efa_rdm_pke_proc_received(struct efa_rdm_pke *pkt_entry, struct efa_rdm_pee
 		efa_rdm_pke_handle_longcts_rtw_recv(pkt_entry);
 		return;
 	case EFA_RDM_LONGREAD_RTW_PKT:
-		efa_rdm_pke_handle_longread_rtw_recv(pkt_entry);
+		efa_rdm_pke_handle_longread_rtw_recv(pkt_entry, peer);
 		return;
 	case EFA_RDM_SHORT_RTR_PKT:
 	case EFA_RDM_LONGCTS_RTR_PKT:

--- a/prov/efa/src/rdm/efa_rdm_pke_rtm.h
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtm.h
@@ -220,7 +220,8 @@ ssize_t efa_rdm_pke_init_longread_msgrtm(struct efa_rdm_pke *pkt_entry,
 ssize_t efa_rdm_pke_init_longread_tagrtm(struct efa_rdm_pke *pkt_entry,
 					 struct efa_rdm_ope *txe);
 
-ssize_t efa_rdm_pke_proc_matched_longread_rtm(struct efa_rdm_pke *pkt_entry);
+ssize_t efa_rdm_pke_proc_matched_longread_rtm(struct efa_rdm_pke *pkt_entry,
+					      struct efa_rdm_peer *peer);
 
 void efa_rdm_pke_handle_longread_rtm_sent(struct efa_rdm_pke *pkt_entry);
 

--- a/prov/efa/src/rdm/efa_rdm_pke_rtw.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtw.c
@@ -520,7 +520,7 @@ ssize_t efa_rdm_pke_init_longread_rtw(struct efa_rdm_pke *pkt_entry,
  *
  * @param[in]		pkt_entry	received EFA_RDM_LONGREAD_RTA_PKT packet entry
  */
-void efa_rdm_pke_handle_longread_rtw_recv(struct efa_rdm_pke *pkt_entry)
+void efa_rdm_pke_handle_longread_rtw_recv(struct efa_rdm_pke *pkt_entry, struct efa_rdm_peer *peer)
 {
 	struct efa_rdm_ep *ep;
 	struct efa_rdm_ope *rxe;
@@ -567,7 +567,7 @@ void efa_rdm_pke_handle_longread_rtw_recv(struct efa_rdm_pke *pkt_entry)
 	memcpy(rxe->rma_iov, read_iov,
 	       rxe->rma_iov_count * sizeof(struct fi_rma_iov));
 
-	err = efa_rdm_pke_post_remote_read_or_nack(rxe->ep, pkt_entry, rxe);
+	err = efa_rdm_pke_post_remote_read_or_nack(rxe->ep, peer, pkt_entry, rxe);
 
 	efa_rdm_pke_release_rx(pkt_entry);
 

--- a/prov/efa/src/rdm/efa_rdm_pke_rtw.h
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtw.h
@@ -46,7 +46,7 @@ void efa_rdm_pke_handle_longcts_rtw_recv(struct efa_rdm_pke *pkt_entry);
 ssize_t efa_rdm_pke_init_longread_rtw(struct efa_rdm_pke *pkt_entry,
 				      struct efa_rdm_ope *txe);
 
-void efa_rdm_pke_handle_longread_rtw_recv(struct efa_rdm_pke *pkt_entry);
+void efa_rdm_pke_handle_longread_rtw_recv(struct efa_rdm_pke *pkt_entry, struct efa_rdm_peer *peer);
 
 struct efa_rdm_ope *efa_rdm_pke_alloc_rtw_rxe(struct efa_rdm_pke *pkt_entry);
 

--- a/prov/efa/src/rdm/efa_rdm_pke_utils.h
+++ b/prov/efa/src/rdm/efa_rdm_pke_utils.h
@@ -100,16 +100,16 @@ efa_rdm_pke_copy_from_hmem_iov(struct efa_mr *iov_mr, struct efa_rdm_pke *pke,
  * @brief This function either posts RDMA read, or sends a NACK packet when p2p
  * is not available or memory registration limit was reached on the receiver.
  *
- * @param[in]    ep         endpoint
- * @param[in]    pkt_entry  packet entry
- * @param[in]    rxe        RX entry
+ * @param[in]	ep		endpoint
+ * @param[in]	peer		efa_rdm_peer struct of the sender
+ * @param[in]	pkt_entry	packet entry
+ * @param[in]	rxe		RX entry
  *
  * @return 0 on success, or a negative error code.
  */
-static inline int
-efa_rdm_pke_post_remote_read_or_nack(struct efa_rdm_ep  *ep,
-                                     struct efa_rdm_pke *pkt_entry,
-                                     struct efa_rdm_ope *rxe)
+static inline int efa_rdm_pke_post_remote_read_or_nack(
+	struct efa_rdm_ep *ep, struct efa_rdm_peer *peer,
+	struct efa_rdm_pke *pkt_entry, struct efa_rdm_ope *rxe)
 {
 	int err = 0;
 	int pkt_type;
@@ -162,7 +162,7 @@ send_nack:
 	}
 
 	if (efa_rdm_pkt_type_is_rtm(pkt_type)) {
-		efa_rdm_rxe_map_insert(&ep->rxe_map, efa_rdm_pke_get_rtm_msg_id(pkt_entry), pkt_entry->addr, rxe);
+		efa_rdm_rxe_map_insert(&peer->rxe_map, efa_rdm_pke_get_rtm_msg_id(pkt_entry), rxe);
 	}
 
 	return efa_rdm_ope_post_send_or_queue(rxe, EFA_RDM_READ_NACK_PKT);

--- a/prov/efa/src/rdm/efa_rdm_rxe_map.c
+++ b/prov/efa/src/rdm/efa_rdm_rxe_map.c
@@ -7,23 +7,19 @@
 #include "efa_rdm_pke_rtm.h"
 
 /**
- * @brief find an RX entry for a received RTM packet entry's sender address and msg_id
+ * @brief find an RX entry for a received RTM packet entry's msg_id
  *
  * @param[in]		rxe_map		RX entry map
- * @param[in]		pkt_entry	received packet entry
+ * @param[in]		msg_id		message id of the received packet
  * @returns
  * pointer to an RX entry. If such RX entry does not exist, return NULL
 */
 struct efa_rdm_ope *efa_rdm_rxe_map_lookup(struct efa_rdm_rxe_map *rxe_map,
-					   uint64_t msg_id, fi_addr_t addr)
+					   uint64_t msg_id)
 {
 	struct efa_rdm_rxe_map_entry *entry = NULL;
-	struct efa_rdm_rxe_map_key key;
 
-	memset(&key, 0, sizeof(key));
-	key.msg_id = msg_id;
-	key.addr = addr;
-	HASH_FIND(hh, rxe_map->head, &key, sizeof(struct efa_rdm_rxe_map_key), entry);
+	HASH_FIND(hh, rxe_map->head, &msg_id, sizeof(msg_id), entry);
 	return entry ? entry->rxe : NULL;
 }
 
@@ -31,16 +27,15 @@ struct efa_rdm_ope *efa_rdm_rxe_map_lookup(struct efa_rdm_rxe_map *rxe_map,
  * @brief insert an RX entry into an RX entry map
  *
  * @details
- * the insertion will use the combination of packet entry sender address and msg_id as key.
+ * the insertion will use the msg_id as key.
  * Caller is responsible to make sure the key does not exist in the map.
  *
  * @param[in,out]	rxe_map		RX entry map
- * @param[in]		pkt_entry	received RTM packet
+ * @param[in]		msg_id		message id of the received packet
  * @param[in]		rxe		RX entry
 */
 void efa_rdm_rxe_map_insert(struct efa_rdm_rxe_map *rxe_map,
-			    uint64_t msg_id, fi_addr_t addr,
-			    struct efa_rdm_ope *rxe)
+			    uint64_t msg_id, struct efa_rdm_ope *rxe)
 {
 	struct efa_rdm_rxe_map_entry *entry;
 
@@ -52,21 +47,18 @@ void efa_rdm_rxe_map_insert(struct efa_rdm_rxe_map *rxe_map,
 		return;
 	}
 
-	memset(&entry->key, 0, sizeof(entry->key));
-	entry->key.msg_id = msg_id;
-	entry->key.addr = addr;
-
 #if ENABLE_DEBUG
 	{
 		struct efa_rdm_rxe_map_entry *existing_entry = NULL;
 
-		HASH_FIND(hh, rxe_map->head, &entry->key, sizeof(struct efa_rdm_rxe_map_key), existing_entry);
+		HASH_FIND(hh, rxe_map->head, &msg_id, sizeof(msg_id), existing_entry);
 		assert(!existing_entry);
 	}
 #endif
 
+	entry->msg_id = msg_id;
 	entry->rxe = rxe;
-	HASH_ADD(hh, rxe_map->head, key, sizeof(struct efa_rdm_rxe_map_key), entry);
+	HASH_ADD(hh, rxe_map->head, msg_id, sizeof(msg_id), entry);
 	rxe->rxe_map = rxe_map;
 }
 
@@ -74,25 +66,19 @@ void efa_rdm_rxe_map_insert(struct efa_rdm_rxe_map *rxe_map,
  * @brief remove an RX entry from the RX entry map
  *
  * @details
- * the removal will use the combination of packet entry sender address and msg_id as key.
+ * the removal will use msg_id as key.
  * Caller is responsible to make sure the key does exist in the map.
  *
  * @param[in,out]	rxe_map		RX entry map
  * @param[in]		msg_id		message ID
- * @param[in]		addr		peer address
  * @param[in]		rxe		RX entry
  */
 void efa_rdm_rxe_map_remove(struct efa_rdm_rxe_map *rxe_map, uint64_t msg_id,
-			    fi_addr_t addr, struct efa_rdm_ope *rxe)
+			    struct efa_rdm_ope *rxe)
 {
 	struct efa_rdm_rxe_map_entry *entry;
-	struct efa_rdm_rxe_map_key key;
 
-	memset(&key, 0, sizeof(key));
-	key.msg_id = msg_id;
-	key.addr = addr;
-
-	HASH_FIND(hh, rxe_map->head, &key, sizeof(key), entry);
+	HASH_FIND(hh, rxe_map->head, &msg_id, sizeof(msg_id), entry);
 	assert(entry && entry->rxe == rxe);
 	HASH_DEL(rxe_map->head, entry);
 	ofi_buf_free(entry);

--- a/prov/efa/src/rdm/efa_rdm_rxe_map.h
+++ b/prov/efa/src/rdm/efa_rdm_rxe_map.h
@@ -9,12 +9,6 @@
 #include "uthash.h"
 
 
-struct efa_rdm_rxe_map_key {
-	uint64_t msg_id;
-	fi_addr_t addr;
-};
-
-
 struct efa_rdm_rxe_map_entry;
 
 /**
@@ -35,7 +29,7 @@ struct efa_rdm_rxe_map {
 struct efa_rdm_ope;
 
 struct efa_rdm_rxe_map_entry {
-	struct efa_rdm_rxe_map_key key;
+	uint64_t msg_id;
 	struct efa_rdm_ope *rxe;
 	UT_hash_handle hh;
 };
@@ -49,12 +43,11 @@ void efa_rdm_rxe_map_construct(struct efa_rdm_rxe_map *rxe_map)
 struct efa_rdm_pke;
 
 struct efa_rdm_ope *efa_rdm_rxe_map_lookup(struct efa_rdm_rxe_map *rxe_map,
-					   uint64_t msg_id, fi_addr_t addr);
+					   uint64_t msg_id);
 
-void efa_rdm_rxe_map_insert(struct efa_rdm_rxe_map *rxe_map,
-			    uint64_t msg_id, fi_addr_t addr,
+void efa_rdm_rxe_map_insert(struct efa_rdm_rxe_map *rxe_map, uint64_t msg_id,
 			    struct efa_rdm_ope *rxe);
 
 void efa_rdm_rxe_map_remove(struct efa_rdm_rxe_map *rxe_map, uint64_t msg_id,
-			    fi_addr_t addr, struct efa_rdm_ope *rxe);
+			    struct efa_rdm_ope *rxe);
 #endif

--- a/prov/efa/test/efa_unit_test_ope.c
+++ b/prov/efa/test/efa_unit_test_ope.c
@@ -482,6 +482,7 @@ void test_efa_rdm_rxe_map(struct efa_resource **state)
 {
 	struct efa_resource *resource = *state;
 	struct efa_rdm_ope *rxe;
+	struct efa_rdm_peer *peer;
 	struct efa_rdm_ep *efa_rdm_ep;
 
 	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_FABRIC_NAME);
@@ -496,11 +497,14 @@ void test_efa_rdm_rxe_map(struct efa_resource **state)
 	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep,
 				  base_ep.util_ep.ep_fid);
 
-	efa_rdm_rxe_map_insert(&efa_rdm_ep->rxe_map, rxe->msg_id, rxe->addr,
-			       rxe);
-	assert_true(rxe->rxe_map == &efa_rdm_ep->rxe_map);
-	assert_true(rxe == efa_rdm_rxe_map_lookup(rxe->rxe_map, rxe->msg_id,
-						  rxe->addr));
+	/* efa_unit_test_alloc_rxe only inserts one address.
+	 * So fi_addr is guaranteed to be 0
+	 */
+	peer = efa_rdm_ep_get_peer(efa_rdm_ep, 0);
+
+	efa_rdm_rxe_map_insert(&peer->rxe_map, rxe->msg_id, rxe);
+	assert_true(rxe->rxe_map == &peer->rxe_map);
+	assert_true(rxe == efa_rdm_rxe_map_lookup(rxe->rxe_map, rxe->msg_id));
 
 	efa_rdm_rxe_release(rxe);
 


### PR DESCRIPTION
This change is necessary to implement an implicit AV.
With an implicit AV, using the fi_addr is no longer an option for
identifying different peers. All unknown peers will have fi_addr set
to -1. And the index in the implicit AV can be re-used, so it's not
guaranteed to be unique.

This commit makes the rxe_map part of the peer struct and only uses the
msg_id as the hash key