### PR TITLE
prov/efa: Minimize calls to efa_rdm_ep_get_peer in the CQ read path

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -217,7 +217,7 @@ struct efa_rdm_ope *efa_rdm_ep_alloc_rxe(struct efa_rdm_ep *ep,
 
 void efa_rdm_ep_record_tx_op_submitted(struct efa_rdm_ep *ep, struct efa_rdm_pke *pkt_entry);
 
-void efa_rdm_ep_record_tx_op_completed(struct efa_rdm_ep *ep, struct efa_rdm_pke *pkt_entry);
+void efa_rdm_ep_record_tx_op_completed(struct efa_rdm_ep *ep, struct efa_rdm_pke *pkt_entry, struct efa_rdm_peer *peer);
 
 static inline size_t efa_rdm_ep_get_rx_pool_size(struct efa_rdm_ep *ep)
 {
@@ -245,9 +245,9 @@ int efa_rdm_ep_post_user_recv_buf(struct efa_rdm_ep *ep, struct efa_rdm_ope *rxe
 
 struct efa_rdm_peer;
 
-void efa_rdm_ep_queue_rnr_pkt(struct efa_rdm_ep *ep,
-			      struct dlist_entry *list,
-			      struct efa_rdm_pke *pkt_entry);
+void efa_rdm_ep_queue_rnr_pkt(struct efa_rdm_ep *ep, struct dlist_entry *list,
+			      struct efa_rdm_pke *pkt_entry,
+			      struct efa_rdm_peer *peer);
 
 ssize_t efa_rdm_ep_post_queued_pkts(struct efa_rdm_ep *ep,
 				    struct dlist_entry *pkts);

--- a/prov/efa/src/rdm/efa_rdm_ep_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_utils.c
@@ -394,11 +394,11 @@ void efa_rdm_ep_record_tx_op_submitted(struct efa_rdm_ep *ep, struct efa_rdm_pke
  * @param[in,out]	ep		endpoint
  * @param[in]		pkt_entry	TX pkt_entry, which contains
  * 					the info of the TX op
+ * @param[in]	peer		efa_rdm_peer struct for the receiver
  */
-void efa_rdm_ep_record_tx_op_completed(struct efa_rdm_ep *ep, struct efa_rdm_pke *pkt_entry)
+void efa_rdm_ep_record_tx_op_completed(struct efa_rdm_ep *ep, struct efa_rdm_pke *pkt_entry, struct efa_rdm_peer *peer)
 {
 	struct efa_rdm_ope *ope = NULL;
-	struct efa_rdm_peer *peer;
 
 	ope = pkt_entry->ope;
 	/*
@@ -410,7 +410,6 @@ void efa_rdm_ep_record_tx_op_completed(struct efa_rdm_ep *ep, struct efa_rdm_pke
 	 *    a new peer has the same GID+QPN was inserted to address, or because
 	 *    application removed the peer from address vector.
 	 */
-	peer = efa_rdm_ep_get_peer(ep, pkt_entry->addr);
 	if (peer)
 		dlist_remove(&pkt_entry->entry);
 
@@ -467,12 +466,12 @@ void efa_rdm_ep_record_tx_op_completed(struct efa_rdm_ep *ep, struct efa_rdm_pke
  * @param[in]	ep		endpoint
  * @param[in]	list		queued RNR packet list
  * @param[in]	pkt_entry	packet entry that encounter RNR
+ * @param[in]	peer	efa_rdm_peer struct of the receiver
  */
-void efa_rdm_ep_queue_rnr_pkt(struct efa_rdm_ep *ep,
-			  struct dlist_entry *list,
-			  struct efa_rdm_pke *pkt_entry)
+void efa_rdm_ep_queue_rnr_pkt(struct efa_rdm_ep *ep, struct dlist_entry *list,
+			      struct efa_rdm_pke *pkt_entry,
+			      struct efa_rdm_peer *peer)
 {
-	struct efa_rdm_peer *peer;
 	static const int random_min_timeout = 40;
 	static const int random_max_timeout = 120;
 
@@ -481,7 +480,6 @@ void efa_rdm_ep_queue_rnr_pkt(struct efa_rdm_ep *ep,
 #endif
 	dlist_insert_tail(&pkt_entry->entry, list);
 	ep->efa_rnr_queued_pkt_cnt += 1;
-	peer = efa_rdm_ep_get_peer(ep, pkt_entry->addr);
 	assert(peer);
 	if (!(pkt_entry->flags & EFA_RDM_PKE_RNR_RETRANSMIT)) {
 		/* This is the first time this packet encountered RNR,

--- a/prov/efa/src/rdm/efa_rdm_peer.c
+++ b/prov/efa/src/rdm/efa_rdm_peer.c
@@ -312,7 +312,7 @@ void efa_rdm_peer_proc_pending_items_in_robuf(struct efa_rdm_peer *peer, struct 
 		EFA_DBG(FI_LOG_EP_CTRL,
 		       "Processing msg_id %d from robuf\n", msg_id);
 		/* efa_rdm_pke_proc_rtm_rta will write error cq entry if needed */
-		ret = efa_rdm_pke_proc_rtm_rta(pending_pkt);
+		ret = efa_rdm_pke_proc_rtm_rta(pending_pkt, peer);
 		*ofi_recvwin_get_next_msg((&peer->robuf)) = NULL;
 
 		exp_msg_id = ofi_recvwin_next_exp_id((&peer->robuf));

--- a/prov/efa/src/rdm/efa_rdm_pke_cmd.h
+++ b/prov/efa/src/rdm/efa_rdm_pke_cmd.h
@@ -20,15 +20,15 @@ fi_addr_t efa_rdm_pke_determine_addr(struct efa_rdm_pke *pkt_entry);
 
 void efa_rdm_pke_handle_data_copied(struct efa_rdm_pke *pkt_entry);
 
-void efa_rdm_pke_handle_tx_error(struct efa_rdm_pke *pkt_entry, int prov_errno);
+void efa_rdm_pke_handle_tx_error(struct efa_rdm_pke *pkt_entry, int prov_errno, struct efa_rdm_peer *peer);
 
-void efa_rdm_pke_handle_send_completion(struct efa_rdm_pke *pkt_entry);
+void efa_rdm_pke_handle_send_completion(struct efa_rdm_pke *pkt_entry, struct efa_rdm_peer *peer);
 
 void efa_rdm_pke_handle_rx_error(struct efa_rdm_pke *pkt_entry, int prov_errno);
 
 void efa_rdm_pke_handle_recv_completion(struct efa_rdm_pke *pkt_entry);
 
-void efa_rdm_pke_proc_received(struct efa_rdm_pke *pkt_entry);
+void efa_rdm_pke_proc_received(struct efa_rdm_pke *pkt_entry, struct efa_rdm_peer *peer);
 
 void efa_rdm_pke_proc_received_no_hdr(struct efa_rdm_pke *pkt_entry, bool has_imm_data, uint32_t imm_data);
 

--- a/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
@@ -90,9 +90,8 @@ ssize_t efa_rdm_pke_init_handshake(struct efa_rdm_pke *pkt_entry,
 	return 0;
 }
 
-void efa_rdm_pke_handle_handshake_recv(struct efa_rdm_pke *pkt_entry)
+void efa_rdm_pke_handle_handshake_recv(struct efa_rdm_pke *pkt_entry, struct efa_rdm_peer *peer)
 {
-	struct efa_rdm_peer *peer;
 	struct efa_rdm_handshake_hdr *handshake_pkt;
 	uint64_t *host_id_ptr;
 
@@ -100,7 +99,6 @@ void efa_rdm_pke_handle_handshake_recv(struct efa_rdm_pke *pkt_entry)
 	EFA_DBG(FI_LOG_CQ,
 		"HANDSHAKE received from %" PRIu64 "\n", pkt_entry->addr);
 
-	peer = efa_rdm_ep_get_peer(pkt_entry->ep, pkt_entry->addr);
 	assert(peer);
 
 	handshake_pkt = (struct efa_rdm_handshake_hdr *)pkt_entry->wiredata;
@@ -568,8 +566,9 @@ void efa_rdm_pke_handle_rma_read_completion(struct efa_rdm_pke *context_pkt_entr
  *
  * @param ep[in,out]			Endpoint
  * @param context_pkt_entry[in,out]	The "Packet" which serves as context
+ * @param peer[in]			struct efa_rdm_peer of peer
  */
-void efa_rdm_pke_handle_rma_completion(struct efa_rdm_pke *context_pkt_entry)
+void efa_rdm_pke_handle_rma_completion(struct efa_rdm_pke *context_pkt_entry, struct efa_rdm_peer *peer)
 {
 	struct efa_rdm_ope *txe = NULL;
 	struct efa_rdm_rma_context_pkt *rma_context_pkt;
@@ -599,7 +598,7 @@ void efa_rdm_pke_handle_rma_completion(struct efa_rdm_pke *context_pkt_entry)
 		assert(0 && "invalid EFA_RDM_RMA_CONTEXT_PKT rma_context_type\n");
 	}
 
-	efa_rdm_ep_record_tx_op_completed(context_pkt_entry->ep, context_pkt_entry);
+	efa_rdm_ep_record_tx_op_completed(context_pkt_entry->ep, context_pkt_entry, peer);
 	efa_rdm_pke_release_tx(context_pkt_entry);
 }
 

--- a/prov/efa/src/rdm/efa_rdm_pke_nonreq.h
+++ b/prov/efa/src/rdm/efa_rdm_pke_nonreq.h
@@ -118,7 +118,7 @@ struct efa_rdm_handshake_opt_user_recv_qp_hdr *efa_rdm_pke_get_handshake_opt_use
 ssize_t efa_rdm_pke_init_handshake(struct efa_rdm_pke *pkt_entry,
 				   fi_addr_t addr);
 
-void efa_rdm_pke_handle_handshake_recv(struct efa_rdm_pke *pkt_entry);
+void efa_rdm_pke_handle_handshake_recv(struct efa_rdm_pke *pkt_entry, struct efa_rdm_peer *peer);
 
 /* CTS packet related functions */
 static inline
@@ -210,7 +210,7 @@ void efa_rdm_pke_init_read_context(struct efa_rdm_pke *pkt_entry,
 				   int read_id,
 				   size_t seg_size);
 
-void efa_rdm_pke_handle_rma_completion(struct efa_rdm_pke *pkt_entry);
+void efa_rdm_pke_handle_rma_completion(struct efa_rdm_pke *pkt_entry, struct efa_rdm_peer *peer);
 
 /* EOR packet related functions */
 static inline

--- a/prov/efa/src/rdm/efa_rdm_pke_rtm.h
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtm.h
@@ -90,11 +90,11 @@ void efa_rdm_pke_set_rtm_tag(struct efa_rdm_pke *pkt_entry, uint64_t tag)
 void efa_rdm_pke_rtm_update_rxe(struct efa_rdm_pke *pkt_entry,
 				struct efa_rdm_ope *rxe);
 
-ssize_t efa_rdm_pke_proc_matched_rtm(struct efa_rdm_pke *pkt_entry);
+ssize_t efa_rdm_pke_proc_matched_rtm(struct efa_rdm_pke *pkt_entry, struct efa_rdm_peer *peer);
 
-ssize_t efa_rdm_pke_proc_rtm_rta(struct efa_rdm_pke *pkt_entry);
+ssize_t efa_rdm_pke_proc_rtm_rta(struct efa_rdm_pke *pkt_entry, struct efa_rdm_peer *peer);
 
-void efa_rdm_pke_handle_rtm_rta_recv(struct efa_rdm_pke *pkt_entry);
+void efa_rdm_pke_handle_rtm_rta_recv(struct efa_rdm_pke *pkt_entry, struct efa_rdm_peer *peer);
 
 static inline
 struct efa_rdm_dc_eager_rtm_base_hdr *efa_rdm_pke_get_dc_eager_rtm_base_hdr(struct efa_rdm_pke *pke)
@@ -196,7 +196,7 @@ void efa_rdm_pke_handle_medium_rtm_sent(struct efa_rdm_pke *pkt_entry);
 
 void efa_rdm_pke_handle_medium_rtm_send_completion(struct efa_rdm_pke *pkt_entry);
 
-ssize_t efa_rdm_pke_proc_matched_mulreq_rtm(struct efa_rdm_pke *pkt_entry);
+ssize_t efa_rdm_pke_proc_matched_mulreq_rtm(struct efa_rdm_pke *pkt_entry, struct efa_rdm_peer *peer);
 
 ssize_t efa_rdm_pke_init_longcts_msgrtm(struct efa_rdm_pke *pkt_entry,
 					struct efa_rdm_ope *txe);

--- a/prov/efa/src/rdm/efa_rdm_srx.c
+++ b/prov/efa/src/rdm/efa_rdm_srx.c
@@ -52,6 +52,7 @@ static int efa_rdm_srx_start(struct fi_peer_rx_entry *peer_rxe)
 	int ret;
 	struct efa_rdm_pke *pkt_entry;
 	struct efa_rdm_ope *rxe;
+	struct efa_rdm_peer *peer;
 
 	assert(ofi_genlock_held(efa_rdm_srx_get_srx_ctx(peer_rxe)->lock));
 
@@ -68,7 +69,8 @@ static int efa_rdm_srx_start(struct fi_peer_rx_entry *peer_rxe)
 	 */
 	rxe->unexp_pkt = NULL;
 
-	ret = efa_rdm_pke_proc_matched_rtm(pkt_entry);
+	peer = efa_rdm_ep_get_peer(pkt_entry->ep, rxe->addr);
+	ret = efa_rdm_pke_proc_matched_rtm(pkt_entry, peer);
 	if (OFI_UNLIKELY(ret)) {
 		/* If we run out of memory registrations, we fall back to
 		 * emulated protocols */

--- a/prov/efa/test/efa_unit_test_mocks.c
+++ b/prov/efa/test/efa_unit_test_mocks.c
@@ -218,7 +218,7 @@ ssize_t efa_mock_efa_rdm_ope_post_send_return_mock(struct efa_rdm_ope *ope, int 
 	return mock();
 }
 
-ssize_t efa_mock_efa_rdm_pke_proc_matched_rtm_no_op(struct efa_rdm_pke *pkt_entry)
+ssize_t efa_mock_efa_rdm_pke_proc_matched_rtm_no_op(struct efa_rdm_pke *pkt_entry, struct efa_rdm_peer *peer)
 {
 	return FI_SUCCESS;
 }
@@ -402,9 +402,9 @@ int __wrap_efa_rdm_pke_read(struct efa_rdm_ope *ope)
 	return g_efa_unit_test_mocks.efa_rdm_pke_read(ope);
 }
 
-int __wrap_efa_rdm_pke_proc_matched_rtm(struct efa_rdm_pke *pkt_entry)
+int __wrap_efa_rdm_pke_proc_matched_rtm(struct efa_rdm_pke *pkt_entry, struct efa_rdm_peer *peer)
 {
-	return g_efa_unit_test_mocks.efa_rdm_pke_proc_matched_rtm(pkt_entry);
+	return g_efa_unit_test_mocks.efa_rdm_pke_proc_matched_rtm(pkt_entry, peer);
 }
 
 int __wrap_efa_rdm_ope_post_send(struct efa_rdm_ope *ope, int pkt_type)

--- a/prov/efa/test/efa_unit_test_mocks.h
+++ b/prov/efa/test/efa_unit_test_mocks.h
@@ -95,9 +95,9 @@ bool __real_efa_device_support_unsolicited_write_recv();
 
 int efa_mock_efa_rdm_pke_read_return_mock(struct efa_rdm_ope *ope);
 
-ssize_t __real_efa_rdm_pke_proc_matched_rtm(struct efa_rdm_pke *pkt_entry);
+ssize_t __real_efa_rdm_pke_proc_matched_rtm(struct efa_rdm_pke *pkt_entry, struct efa_rdm_peer *peer);
 
-ssize_t efa_mock_efa_rdm_pke_proc_matched_rtm_no_op(struct efa_rdm_pke *pkt_entry);
+ssize_t efa_mock_efa_rdm_pke_proc_matched_rtm_no_op(struct efa_rdm_pke *pkt_entry, struct efa_rdm_peer *peer);
 
 ssize_t __real_efa_rdm_ope_post_send(struct efa_rdm_ope *ope, int pkt_type);
 
@@ -146,7 +146,7 @@ struct efa_unit_test_mocks
 
 	int (*efa_rdm_pke_read)(struct efa_rdm_ope *ope);
 
-	ssize_t (*efa_rdm_pke_proc_matched_rtm)(struct efa_rdm_pke *pkt_entry);
+	ssize_t (*efa_rdm_pke_proc_matched_rtm)(struct efa_rdm_pke *pkt_entry, struct efa_rdm_peer *peer);
 
 	ssize_t (*efa_rdm_ope_post_send)(struct efa_rdm_ope *ope, int pkt_type);
 


### PR DESCRIPTION
This change is useful for two reasons
(1) The efa_rdm_ep_get_peer function accesses the AV and it's easier to
lock access to the AV when the call happens in fewer places
(2) With an implicit AV, the fi_addr will always be -1 for peers not
explicitly inserted to the AV. So efa_rdm_ep_get_peer will need to do
a reverse hashmap lookup with a significant performance cost for such
peers. So minimizing the number of calls to efa_rdm_ep_get_peer is more
performant.