### PR TITLE
Fix build with GCC 15

### DIFF
--- a/prov/opx/include/fi_opx_tid_cache.h
+++ b/prov/opx/include/fi_opx_tid_cache.h
@@ -47,8 +47,8 @@
  */
 int opx_tid_cache_setup(struct ofi_mr_cache **cache, struct opx_tid_domain *domain);
 
-int  opx_tid_cache_add_abort();
-void opx_tid_cache_delete_abort();
+int  opx_tid_cache_add_abort(struct ofi_mr_cache *cache, struct ofi_mr_entry *entry);
+void opx_tid_cache_delete_abort(struct ofi_mr_cache *cache, struct ofi_mr_entry *entry);
 
 enum opx_tid_cache_entry_status {
 	OPX_TID_CACHE_ENTRY_NOT_FOUND = 0,

--- a/prov/opx/include/rdma/opx/fi_opx.h
+++ b/prov/opx/include/rdma/opx/fi_opx.h
@@ -94,7 +94,7 @@
 // Useful for checking that structures are the correct size and other
 // compile-time tests. static_assert has existed since C11 so this
 // should be safe, but we have an else clause just in case.
-#if defined(static_assert)
+#if __STDC_VERSION__ >= 201112L
 #define OPX_COMPILE_TIME_ASSERT(cond, msg) static_assert(cond, msg)
 #else
 #define OPX_COMPILE_TIME_ASSERT(cond, msg) \

--- a/prov/opx/src/fi_opx_tid_cache.c
+++ b/prov/opx/src/fi_opx_tid_cache.c
@@ -1787,15 +1787,19 @@ void opx_tid_cache_cleanup(struct ofi_mr_cache *cache)
 	assert(cache->uncached_size == 0);
 }
 
-int opx_tid_cache_add_abort()
+int opx_tid_cache_add_abort(struct ofi_mr_cache *cache, struct ofi_mr_entry *entry)
 {
+	OFI_UNUSED(cache);
+	OFI_UNUSED(entry);
 	fprintf(stderr, "%s unexpected function call\n", __func__);
 	abort();
 	return 0;
 }
 
-void opx_tid_cache_delete_abort()
+void opx_tid_cache_delete_abort(struct ofi_mr_cache *cache, struct ofi_mr_entry *entry)
 {
+	OFI_UNUSED(cache);
+	OFI_UNUSED(entry);
 	fprintf(stderr, "%s unexpected function call\n", __func__);
 	abort();
 }


### PR DESCRIPTION
GCC 15 defaults to C23, in which `static_assert` is a keyword (rather than an alias to `_Static_assert`), and the interpretation of function declarations without parameters changed from unspecified (as in K&R) to `void`.

Fixes: #10796
