### PR TITLE
[v2.1.x]fabtests/prov/efa: Bind eq to ep in remote exits early test

### DIFF
--- a/fabtests/prov/efa/src/rdm_remote_exit_early.c
+++ b/fabtests/prov/efa/src/rdm_remote_exit_early.c
@@ -55,6 +55,9 @@ static int run()
 		return ret;
 	}
 
+	/* Bind eq to ep so it can write eq error for EFA_RDM_OPE_INTERNAL */
+	FT_EP_BIND(ep, eq, 0);
+
 	ret = fi_getopt(&ep->fid, FI_OPT_ENDPOINT, FI_OPT_EFA_EMULATED_READ,
 			&use_emulated_read, &(size_t) {sizeof use_emulated_read});
 	if (ret) {


### PR DESCRIPTION
Backport bugfix https://github.com/ofiwg/libfabric/pull/10859
Bind eq to ep so it can write eq error for internal ope instead of aborting application.

Signed-off-by: Jessie Yang <jiaxiyan@amazon.com>
(cherry picked from commit fb04567ed4830859d77649b2bc9545339e64012e)