### PR TITLE
Cornelis Networks opx provider upstream 2025 03 13

### DIFF
--- a/man/fi_opx.7.md
+++ b/man/fi_opx.7.md
@@ -249,8 +249,7 @@ OPX is not compatible with Open MPI 4.1.x PML/BTL.
   no affinity is set.
 
 *FI_OPX_AUTO_PROGRESS_INTERVAL_USEC*
-: Integer. This setting controls the time (in usecs) between polls for auto progress threads.
-  Default is 1.
+: Deprecated/ignored. Auto progress threads are now interrupt-driven and only poll when data is available.
 
 *FI_OPX_PKEY*
 : Integer. Partition key, a 2 byte positive integer. Default is the Pkey in the index 0 of the

--- a/prov/opx/include/rdma/opx/fi_opx_domain.h
+++ b/prov/opx/include/rdma/opx/fi_opx_domain.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2016 by Argonne National Laboratory.
- * Copyright (C) 2021-2024 Cornelis Networks.
+ * Copyright (C) 2021-2025 Cornelis Networks.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -113,8 +113,6 @@ struct fi_opx_domain {
 	char   unique_job_key_str[OPX_JOB_KEY_STR_SIZE];
 
 	char *progress_affinity_str;
-
-	int auto_progress_interval;
 
 	uint32_t rx_count;
 	uint32_t tx_count;

--- a/prov/opx/include/rdma/opx/fi_opx_hfi1.h
+++ b/prov/opx/include/rdma/opx/fi_opx_hfi1.h
@@ -349,6 +349,11 @@ struct fi_opx_hfi1_txe_scb_9B {
 
 	uint64_t pad; /* 1 QW pad (to 16 QWs) */
 } __attribute__((__aligned__(8))) __attribute__((packed));
+static_assert(offsetof(struct fi_opx_hfi1_txe_scb_9B, qw0) == 0,
+	      "Offset of fi_opx_hfi1_txe_scb_9B.hdr.qw_9B[0] should immediately follow fi_opx_hfi1_txe_scb_9B.qw0!\n");
+static_assert(offsetof(struct fi_opx_hfi1_txe_scb_9B, hdr.qw_9B[0]) ==
+		      (offsetof(struct fi_opx_hfi1_txe_scb_9B, qw0) + sizeof(uint64_t)),
+	      "Offset of fi_opx_hfi1_txe_scb_9B.hdr.qw_9B[0] should immediately follow fi_opx_hfi1_txe_scb_9B.qw0!\n");
 
 /* 9 QWs valid in 16 QW storage.  */
 struct fi_opx_hfi1_txe_scb_16B {
@@ -362,14 +367,22 @@ static_assert((sizeof(struct fi_opx_hfi1_txe_scb_9B) == (sizeof(uint64_t) * 16))
 
 /* Storage for a scb. Use HFI1 type to access the correct structure */
 union opx_hfi1_txe_scb_union {
+	uint64_t		       qws[16];
 	struct fi_opx_hfi1_txe_scb_9B  scb_9B;
 	struct fi_opx_hfi1_txe_scb_16B scb_16B;
 } __attribute__((__aligned__(8))) __attribute__((packed));
-
 static_assert((sizeof(struct fi_opx_hfi1_txe_scb_9B) == sizeof(union opx_hfi1_txe_scb_union)),
 	      "storage for scbs should match");
 static_assert((sizeof(struct fi_opx_hfi1_txe_scb_16B) == sizeof(union opx_hfi1_txe_scb_union)),
 	      "storage for scbs should match");
+static_assert(offsetof(struct fi_opx_hfi1_txe_scb_9B, qw0) == offsetof(union opx_hfi1_txe_scb_union, qws[0]),
+	      "Offset of fi_opx_hfi1_txe_scb_9B.hdr.qw0 should be same as opx_hfi1_txe_scb_union.qws[0]!\n");
+static_assert(offsetof(struct fi_opx_hfi1_txe_scb_16B, qw0) == offsetof(union opx_hfi1_txe_scb_union, qws[0]),
+	      "Offset of fi_opx_hfi1_txe_scb_16B.hdr.qw0 should be same as opx_hfi1_txe_scb_union.qws[0]!\n");
+static_assert(offsetof(struct fi_opx_hfi1_txe_scb_9B, hdr.qw_9B[0]) == offsetof(union opx_hfi1_txe_scb_union, qws[1]),
+	      "Offset of fi_opx_hfi1_txe_scb_9B.hdr.qw_9B[0] should be same as opx_hfi1_txe_scb_union.qws[1]!\n");
+static_assert(offsetof(struct fi_opx_hfi1_txe_scb_16B, hdr.qw_16B[0]) == offsetof(union opx_hfi1_txe_scb_union, qws[1]),
+	      "Offset of fi_opx_hfi1_txe_scb_16B.hdr.qw_16B[0] should be same as opx_hfi1_txe_scb_union.qws[1]!\n");
 
 #define HFI_TXE_CREDITS_COUNTER(credits)	((credits.raw16b[0] >> 0) & 0x07FFu)
 #define HFI_TXE_CREDITS_STATUS(credits)		((credits.raw16b[0] >> 11) & 0x01u)

--- a/prov/opx/include/rdma/opx/fi_opx_hfi1_sdma.h
+++ b/prov/opx/include/rdma/opx/fi_opx_hfi1_sdma.h
@@ -351,7 +351,8 @@ struct fi_opx_hfi1_sdma_work_entry *opx_sdma_get_new_work_entry(struct fi_opx_ep
 	struct fi_opx_hfi1_sdma_work_entry *prev = NULL;
 
 	while (sdma_we && sdma_we != current) {
-		if (sdma_we->comp_state == OPX_SDMA_COMP_COMPLETE && !sdma_we->pending_bounce_buf) {
+		if ((sdma_we->comp_state == OPX_SDMA_COMP_COMPLETE || sdma_we->comp_state == OPX_SDMA_COMP_ERROR) &&
+		    !sdma_we->pending_bounce_buf) {
 			slist_remove(sdma_reqs, (struct slist_entry *) sdma_we, (struct slist_entry *) prev);
 			sdma_we->next	       = NULL;
 			sdma_we->comp_state    = OPX_SDMA_COMP_FREE;

--- a/prov/opx/include/rdma/opx/fi_opx_progress.h
+++ b/prov/opx/include/rdma/opx/fi_opx_progress.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Cornelis Networks.
+ * Copyright (C) 2022-2025 Cornelis Networks.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -34,31 +34,20 @@
 #define _FI_PROV_OPX_PROGRESS_H_
 
 #include <pthread.h>
-#include <stdbool.h>
-#include <stdint.h>
-#include "rdma/opx/fi_opx_compiler.h"
+#include "rdma/opx/fi_opx_eq.h"
 
-struct fi_opx_progress_track {
-	pthread_t *progress_thread;
-	bool	   keep_running;
-	void	  *returned_value;
+#define OPX_PROGRESS_CQ_WAIT_USEC (200)
+
+static const uint64_t OPX_PROGRESS_EVENT_TERMINATE = 0xD1Eul;
+
+struct opx_progress_thread {
+	struct fi_opx_cq *cq;
+	pthread_t	  p_thread;
+	int		  event_fd;
 };
 
-struct progress_func_args {
-	struct fid_cq		     *cq;
-	char			     *prog_affinity;
-	struct fi_opx_progress_track *progress_track;
-	int			      progress_interval;
-};
+void *opx_progress_init(struct fi_opx_cq *cq, char *affinity);
 
-// init progress_track
-__OPX_FORCE_INLINE__
-void fi_opx_progress_init(struct fi_opx_progress_track *progress)
-{
-	progress->progress_thread = NULL;
-	progress->returned_value  = NULL;
-}
-void fi_opx_start_progress(struct fi_opx_progress_track *progress_track, struct fid_cq *cq, char *prog_affinity,
-			   int progress_interval);
-void fi_opx_stop_progress(struct fi_opx_progress_track *progress_track);
+void opx_progress_stop(void *progress_thread_ptr);
+
 #endif

--- a/prov/opx/include/rdma/opx/fi_opx_reliability.h
+++ b/prov/opx/include/rdma/opx/fi_opx_reliability.h
@@ -767,7 +767,9 @@ struct fi_opx_reliability_flow *fi_opx_reliability_create_rx_flow(struct fi_opx_
 
 	if (OFI_UNLIKELY(rbt_rc != RBT_STATUS_OK)) {
 		void *itr = fi_opx_rbt_find(state->rx_flow_rbtree, (void *) key);
-		rbtErase(state->rx_flow_rbtree, itr);
+		if (itr) {
+			rbtErase(state->rx_flow_rbtree, itr);
+		}
 		free(flow);
 		FI_WARN(fi_opx_global.prov, FI_LOG_EP_DATA,
 			"Error creating RX Flow: Could not insert flow into rx.flow, rbtInsert() returned %d\n",

--- a/prov/opx/src/fi_opx_cntr.c
+++ b/prov/opx/src/fi_opx_cntr.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2016 by Argonne National Laboratory.
- * Copyright (C) 2021-2024 by Cornelis Networks.
+ * Copyright (C) 2021-2025 by Cornelis Networks.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -259,7 +259,7 @@ int fi_opx_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr, struc
 	opx_cntr->ep_bind_count	    = 0;
 	opx_cntr->progress.ep_count = 0;
 	unsigned i;
-	for (i = 0; i < 64; ++i) { /* TODO - check this array size */
+	for (i = 0; i < OPX_CNTR_MAX_ENDPOINTS; ++i) {
 		opx_cntr->ep[i]		 = NULL;
 		opx_cntr->progress.ep[i] = NULL;
 	}

--- a/prov/opx/src/fi_opx_domain.c
+++ b/prov/opx/src/fi_opx_domain.c
@@ -197,13 +197,13 @@ int fi_opx_choose_domain(uint64_t caps, struct fi_domain_attr *domain_attr, stru
 	domain_attr->mr_mode |= FI_MR_HMEM;
 #endif
 
-	if (hints->mr_mode & FI_MR_VIRT_ADDR) {
-		FI_INFO(fi_opx_global.prov, FI_LOG_DOMAIN,
-			"Application requests FI_MR_VIRT_ADDR, OPX is turning on that mr_mode bit\n");
-		domain_attr->mr_mode |= FI_MR_VIRT_ADDR;
-	}
-
 	if (hints) {
+		if (hints->mr_mode & FI_MR_VIRT_ADDR) {
+			FI_INFO(fi_opx_global.prov, FI_LOG_DOMAIN,
+				"Application requests FI_MR_VIRT_ADDR, OPX is turning on that mr_mode bit\n");
+			domain_attr->mr_mode |= FI_MR_VIRT_ADDR;
+		}
+
 		if (hints->domain) {
 			struct fi_opx_domain *opx_domain =
 				container_of(hints->domain, struct fi_opx_domain, domain_fid);

--- a/prov/opx/src/fi_opx_domain.c
+++ b/prov/opx/src/fi_opx_domain.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2016 by Argonne National Laboratory.
- * Copyright (C) 2021-2024 by Cornelis Networks.
+ * Copyright (C) 2021-2025 by Cornelis Networks.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -434,20 +434,6 @@ int fi_opx_domain(struct fid_fabric *fabric, struct fi_info *info, struct fid_do
 	opx_domain->threading	  = fi_opx_global.default_domain_attr->threading;
 	opx_domain->resource_mgmt = fi_opx_global.default_domain_attr->resource_mgmt;
 	opx_domain->data_progress = fi_opx_global.default_domain_attr->data_progress;
-
-	int env_var_progress_interval = 0;
-	get_param_check =
-		fi_param_get_int(fi_opx_global.prov, "auto_progress_interval_usec", &env_var_progress_interval);
-	if (get_param_check == FI_SUCCESS) {
-		if (env_var_progress_interval < 0) {
-			FI_WARN(fi_opx_global.prov, FI_LOG_DOMAIN,
-				"FI_OPX_AUTO_PROGRESS_INTERVAL_USEC must be an integer >= 0 using default value\n");
-			env_var_progress_interval = 0;
-		}
-	} else {
-		env_var_progress_interval = 0;
-	}
-	opx_domain->auto_progress_interval = env_var_progress_interval;
 
 	if (info->domain_attr) {
 		if (info->domain_attr->domain) {

--- a/prov/opx/src/fi_opx_ep.c
+++ b/prov/opx/src/fi_opx_ep.c
@@ -2273,7 +2273,7 @@ int fi_opx_check_tx_attr(struct fi_tx_attr *tx_attr, uint64_t hinted_caps)
 		goto err;
 	}
 
-	if ((tx_attr) && ((tx_attr->caps | hinted_caps) != hinted_caps)) {
+	if ((tx_attr->caps | hinted_caps) != hinted_caps) {
 		FI_DBG_TRACE(
 			fi_opx_global.prov, FI_LOG_EP_DATA,
 			"info->tx_attr->caps = 0x%016lx, info->caps = 0x%016lx, (info->tx_attr->caps | info->caps) = 0x%016lx, ((info->tx_attr->caps | info->caps) ^ info->caps) = 0x%016lx\n",

--- a/prov/opx/src/fi_opx_hfi1_sdma.c
+++ b/prov/opx/src/fi_opx_hfi1_sdma.c
@@ -138,8 +138,8 @@ void fi_opx_hfi1_sdma_handle_errors(struct fi_opx_ep *opx_ep, int writev_rc, str
 {
 	const pid_t pid = getpid();
 
-	if (errno == ECOMM || errno == EINTR) {
-		int err = fi_opx_context_check_status(opx_ep->hfi, OPX_HFI1_TYPE);
+	if (errno == ECOMM || errno == EINTR || errno == EFAULT) {
+		int err = fi_opx_context_check_status(opx_ep->hfi, OPX_HFI1_TYPE, opx_ep);
 		if (err != FI_SUCCESS) {
 			FI_WARN(fi_opx_global.prov, FI_LOG_EP_DATA, "Link down detected\n");
 			return;

--- a/prov/opx/src/fi_opx_init.c
+++ b/prov/opx/src/fi_opx_init.c
@@ -756,8 +756,9 @@ OPX_INI
 	fi_param_define(
 		&fi_opx_provider, "prog_affinity", FI_PARAM_STRING,
 		"When set, specify the set of CPU cores to set the progress thread affinity to. The format is <start>:<end>:<stride> where each triplet <start>:<end>:<stride> defines a block Both <start> and <end> is a core_id.");
-	fi_param_define(&fi_opx_provider, "auto_progress_interval_usec", FI_PARAM_INT,
-			"Number of usec that the progress thread waits between polling. Default is 1.");
+	fi_param_define(
+		&fi_opx_provider, "auto_progress_interval_usec", FI_PARAM_INT,
+		"Deprecated/ignored. Auto progress threads are now interrupt-driven and only poll when data is available.");
 	fi_param_define(
 		&fi_opx_provider, "pkey", FI_PARAM_INT,
 		"Partition key.  Should be a 2 byte positive integer. Default is the Pkey in the index 0 of the Pkey table of the unit and port on which context is created.");

--- a/prov/opx/src/fi_opx_progress.c
+++ b/prov/opx/src/fi_opx_progress.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Cornelis Networks.
+ * Copyright (C) 2022-2025 Cornelis Networks.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -31,17 +31,12 @@
  */
 
 #include "rdma/opx/fi_opx_progress.h"
-#include <ofi.h>
-
-#include "rdma/opx/fi_opx_internal.h"
-#include "rdma/opx/fi_opx_endpoint.h"
-#include "rdma/opx/fi_opx_hfi1.h"
-#include "rdma/fi_direct_eq.h"
-
-// based on psm2 implementation
+#include <sys/eventfd.h>
+#include <poll.h>
+#include <unistd.h>
 
 __OPX_FORCE_INLINE__
-int normalize_core_id(int core_id, int num_cores)
+int opx_progress_normalize_core_id(int core_id, int num_cores)
 {
 	if (core_id < 0) {
 		core_id += num_cores;
@@ -60,7 +55,7 @@ int normalize_core_id(int core_id, int num_cores)
 
 // Affinity for the progress thread based on value for FI_OPX_PROG_AFFINITY
 // No affinity is set by default
-void fi_opx_progress_set_affinity(char *affinity)
+void opx_progress_set_affinity(pthread_attr_t *thread_attr, char *affinity)
 {
 	int	  num_cores = sysconf(_SC_NPROCESSORS_ONLN);
 	int	  core_id;
@@ -95,8 +90,8 @@ void fi_opx_progress_set_affinity(char *affinity)
 			stride = 1;
 		}
 
-		start = normalize_core_id(start, num_cores);
-		end   = normalize_core_id(end, num_cores);
+		start = opx_progress_normalize_core_id(start, num_cores);
+		end   = opx_progress_normalize_core_id(end, num_cores);
 
 		for (core_id = start; core_id <= end; core_id += stride) {
 			CPU_SET(core_id, &cpuset);
@@ -108,102 +103,144 @@ void fi_opx_progress_set_affinity(char *affinity)
 	}
 
 	if (set_count) {
-		pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset);
+		pthread_attr_setaffinity_np(thread_attr, sizeof(cpu_set_t), &cpuset);
 	} else {
 		FI_INFO(fi_opx_global.prov, FI_LOG_CQ, "progress thread affinity not set due to invalid format\n");
 	}
 }
 
-// function the progress thread runs
-void *fi_opx_progress_func(void *args)
+__OPX_FORCE_INLINE__
+int opx_progress_set_poll_fds(struct fi_opx_cq *cq, int event_fd, struct pollfd *poll_fd)
 {
-	struct progress_func_args    *func_args		= (struct progress_func_args *) args;
-	struct fid_cq		     *cq		= func_args->cq;
-	char			     *prog_affinity	= func_args->prog_affinity;
-	struct fi_opx_progress_track *progress_track	= func_args->progress_track;
-	int			      progress_interval = func_args->progress_interval;
-	int			      sleep_usec;
-	struct timespec		      ts;
+	fi_opx_lock(&cq->lock);
 
-	fi_opx_progress_set_affinity(prog_affinity);
-
-	if (progress_interval == 0) {
-		sleep_usec = 1;
-	} else {
-		sleep_usec = progress_interval;
+	int i;
+	for (i = 0; i < cq->progress.ep_count; ++i) {
+		poll_fd[i].fd	   = cq->progress.ep[i]->hfi->fd;
+		poll_fd[i].events  = POLLIN;
+		poll_fd[i].revents = 0;
 	}
 
-	ts.tv_sec  = sleep_usec / 1000000;
-	ts.tv_nsec = (sleep_usec % 1000000) * 1000;
+	fi_opx_unlock(&cq->lock);
 
-	while (!cq || !cq->ops) {
-		usleep(200);
-	}
+	poll_fd[i].fd	   = event_fd;
+	poll_fd[i].events  = POLLIN;
+	poll_fd[i].revents = 0;
 
-	while (progress_track->keep_running) {
-		fi_cq_read(cq, NULL, 0);
-		nanosleep(&ts, NULL);
-	}
-
-	pthread_exit(args);
+	return i + 1;
 }
 
-// start the progress thread
-void fi_opx_start_progress(struct fi_opx_progress_track *progress_track, struct fid_cq *cq, char *prog_affinity,
-			   int progress_interval)
+void *opx_progress_func(void *args)
 {
-	progress_track->keep_running = true;
+	struct opx_progress_thread *progress_thr = (struct opx_progress_thread *) args;
+	struct fi_opx_cq	   *cq		 = progress_thr->cq;
+	struct pollfd		    poll_fds[OPX_CQ_MAX_ENDPOINTS + 1];
+	uint64_t		    event_buf = 0;
+	int			    event_fd  = progress_thr->event_fd;
+	ssize_t			    read_rc;
 
-	int			   err;
-	struct progress_func_args *args = malloc(sizeof(struct progress_func_args));
+	while (1) {
+		if (!cq->cq_fid.ops || cq->progress.ep_count == 0) {
+			usleep(OPX_PROGRESS_CQ_WAIT_USEC);
+			read_rc = read(event_fd, &event_buf, sizeof(event_buf));
+			if (read_rc != -1) {
+				assert(read_rc == sizeof(OPX_PROGRESS_EVENT_TERMINATE));
+				assert(event_buf == OPX_PROGRESS_EVENT_TERMINATE);
+				FI_DBG(fi_opx_global.prov, FI_LOG_CQ,
+				       "Auto progress thread received terminate signal\n");
+				break;
+			}
+			continue;
+		}
 
-	if (!args) {
-		FI_WARN(fi_opx_global.prov, FI_LOG_CQ, "Unable to create arguments needed for PROGRESS_AUTO");
-		goto err;
+		int poll_fd_count = opx_progress_set_poll_fds(cq, event_fd, poll_fds);
+		int poll_rc	  = poll(poll_fds, poll_fd_count, -1);
+
+		if (OFI_UNLIKELY(poll_rc < 0)) {
+			/* Poll error */
+			FI_WARN(fi_opx_global.prov, FI_LOG_CQ,
+				"Auto progress thread poll error: errno %d (%s), stopping thread\n", errno,
+				strerror(errno));
+			break;
+		} else if (OFI_UNLIKELY((poll_fds[poll_fd_count - 1].revents & POLLIN) != 0)) {
+			/* Parent thread signalled terminate, time to exit */
+			read_rc = read(event_fd, &event_buf, sizeof(event_buf));
+			assert(read_rc == sizeof(OPX_PROGRESS_EVENT_TERMINATE));
+			assert(event_buf == OPX_PROGRESS_EVENT_TERMINATE);
+
+			FI_DBG(fi_opx_global.prov, FI_LOG_CQ, "Auto progress thread received terminate signal\n");
+
+			break;
+		} else {
+			fi_opx_lock(&cq->lock);
+			fi_opx_cq_poll_inline(&cq->cq_fid, NULL, 0, NULL, FI_CQ_FORMAT_UNSPEC, FI_OPX_LOCK_REQUIRED,
+					      OFI_RELIABILITY_KIND_ONLOAD, FI_OPX_HDRQ_MASK_RUNTIME, 0UL,
+					      OPX_HFI1_TYPE);
+			fi_opx_unlock(&cq->lock);
+		}
 	}
 
-	args->cq		= cq;
-	args->progress_interval = progress_interval;
-	args->progress_track	= progress_track;
-	args->prog_affinity	= prog_affinity;
+	FI_DBG(fi_opx_global.prov, FI_LOG_CQ, "Auto progress thread terminating, stopping thread\n");
 
-	progress_track->progress_thread = malloc(sizeof(pthread_t));
-	if (!progress_track->progress_thread) {
-		FI_WARN(fi_opx_global.prov, FI_LOG_CQ, "Unable to created thread for PROGRESS_AUTO");
-		goto err;
-	}
-	err = pthread_create(progress_track->progress_thread, NULL, fi_opx_progress_func, (void *) args);
-	if (err) {
-		progress_track->keep_running = false;
-		FI_INFO(fi_opx_global.prov, FI_LOG_CQ, "pthread_create returns %d\n", err);
-		goto err;
-	} else {
-		FI_INFO(fi_opx_global.prov, FI_LOG_CQ, "progress thread started\n");
-	}
-
-	return;
-
-err:
-	if (args) {
-		free(args);
-		args = NULL;
-	}
-	if (progress_track->progress_thread) {
-		free(progress_track->progress_thread);
-		progress_track->progress_thread = NULL;
-	}
-	abort();
+	pthread_exit(NULL);
 }
 
-// Stop the progress thread
-void fi_opx_stop_progress(struct fi_opx_progress_track *progress_track)
+void *opx_progress_init(struct fi_opx_cq *cq, char *affinity)
 {
-	assert(progress_track && progress_track->progress_thread);
+	struct opx_progress_thread *progress_thr;
 
-	progress_track->keep_running = false;
-	pthread_join(*progress_track->progress_thread, &progress_track->returned_value);
-	free(progress_track->returned_value);
-	progress_track->returned_value = NULL;
-	free(progress_track->progress_thread);
-	progress_track->progress_thread = NULL;
+	if (posix_memalign((void **) &progress_thr, 64, sizeof(struct opx_progress_thread))) {
+		FI_WARN(fi_opx_global.prov, FI_LOG_CQ,
+			"Auto progress thread creation error: Memory allocation failed\n");
+		return NULL;
+	}
+	progress_thr->cq = cq;
+
+	progress_thr->event_fd = eventfd(0, EFD_NONBLOCK);
+	if (progress_thr->event_fd == -1) {
+		FI_WARN(fi_opx_global.prov, FI_LOG_CQ,
+			"Auto progress thread creation error: Error creating eventfd: errno=%d (%s)\n", errno,
+			strerror(errno));
+		goto init_err;
+	}
+	pthread_attr_t thread_attr;
+	pthread_attr_init(&thread_attr);
+	opx_progress_set_affinity(&thread_attr, affinity);
+
+	int thr_crt_rc =
+		pthread_create(&progress_thr->p_thread, &thread_attr, opx_progress_func, (void *) progress_thr);
+	if (thr_crt_rc) {
+		FI_WARN(fi_opx_global.prov, FI_LOG_CQ,
+			"Auto progress thread creation error: pthread_create returned %d\n", thr_crt_rc);
+		goto init_err;
+	}
+	FI_INFO(fi_opx_global.prov, FI_LOG_CQ, "Auto progress thread started\n");
+
+	return (void *) progress_thr;
+
+init_err:
+	free(progress_thr);
+	return NULL;
+}
+
+void opx_progress_stop(void *progress_thread_ptr)
+{
+	assert(progress_thread_ptr);
+	struct opx_progress_thread *progress_thread = (struct opx_progress_thread *) progress_thread_ptr;
+
+	FI_DBG(fi_opx_global.prov, FI_LOG_CQ, "Stopping Auto progress thread\n");
+	ssize_t rc =
+		write(progress_thread->event_fd, &OPX_PROGRESS_EVENT_TERMINATE, sizeof(OPX_PROGRESS_EVENT_TERMINATE));
+
+	if (OFI_UNLIKELY(rc != sizeof(OPX_PROGRESS_EVENT_TERMINATE))) {
+		FI_WARN(fi_opx_global.prov, FI_LOG_CQ,
+			"Auto progress thread termination error: Attempting to send terminate signal, write() returned %ld, errno=%d (%s)\n",
+			rc, errno, strerror(errno));
+	}
+
+	pthread_join(progress_thread->p_thread, NULL);
+
+	close(progress_thread->event_fd);
+
+	free(progress_thread);
 }

--- a/prov/opx/src/fi_opx_sep.c
+++ b/prov/opx/src/fi_opx_sep.c
@@ -358,11 +358,15 @@ err:
 	if (info.tx_attr) {
 		free(info.tx_attr);
 	}
+	if (info.rx_attr) {
+		free(info.rx_attr);
+	}
 
 	info.fabric_attr = NULL;
 	info.domain_attr = NULL;
 	info.ep_attr	 = NULL;
 	info.tx_attr	 = NULL;
+	info.rx_attr	 = NULL;
 
 	return -errno;
 }


### PR DESCRIPTION
Includes:
- Bug fixes for link bounce, SDMA error handling, and Coverity defects
- Change to auto progress to make it interrupt-driven
- Change to copy SCB header data directly to replay the SCB, along with a lot of consolidation this enabled