### PR TITLE
prov/cxi: Allow fi_close() to complete without error

### DIFF
--- a/prov/cxi/src/cxip_av.c
+++ b/prov/cxi/src/cxip_av.c
@@ -504,9 +504,12 @@ static int cxip_av_close(struct fid *fid)
 {
 	struct cxip_av *av = container_of(fid, struct cxip_av, av_fid.fid);
 	struct cxip_domain *dom = av->domain;
+	int count;
 
-	if (ofi_atomic_get32(&av->ref))
-		return -FI_EBUSY;
+	count = ofi_atomic_get32(&av->ref);
+	if (count) {
+		CXIP_WARN("AV refcount non-zero: %d\n", count);
+	}
 
 	HASH_CLEAR(hh, av->auth_key_entry_hash);
 	ofi_bufpool_destroy(av->auth_key_entry_pool);

--- a/prov/cxi/src/cxip_ep.c
+++ b/prov/cxi/src/cxip_ep.c
@@ -795,7 +795,6 @@ int cxip_free_endpoint(struct cxip_ep *ep)
 	count = ofi_atomic_get32(&ep_obj->coll.num_mc);
 	if (count) {
 		CXIP_WARN("EP num_mc non-zero: %d\n", count);
-		return -FI_EBUSY;
 	}
 
 	if (ep_obj->av)

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -502,8 +502,17 @@ void ofi_mr_cache_cleanup(struct ofi_mr_cache *cache)
 	if (cache->domain)
 		ofi_atomic_dec32(&cache->domain->ref);
 	ofi_bufpool_destroy(cache->entry_pool);
-	assert(cache->cached_cnt == 0);
-	assert(cache->cached_size == 0);
+
+	if (cache->cached_cnt) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+				"MR cache cached_cnt non-zero: %lu\n",
+				cache->cached_cnt);
+	}
+	if (cache->cached_size) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+				"MR cache cached_size non-zero: %lu\n",
+				cache->cached_size);
+	}
 	assert(cache->uncached_cnt == 0);
 	assert(cache->uncached_size == 0);
 }


### PR DESCRIPTION
Modified libfabric behavior to ensure that fi_close() calls on an endpoint complete successfully, even if an MCAST tree is still allocated. This change prevents errors in cases where the endpoint is being closed while retaining the MCAST tree.