### PR TITLE
[v2.1.x] prov/efa: Change FI_AV_MAP logs to info

### DIFF
--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -897,7 +897,7 @@ int efa_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 		return -FI_ENOMEM;
 
 	if (attr->type == FI_AV_MAP) {
-		EFA_WARN(FI_LOG_AV, "FI_AV_MAP is deprecated in Libfabric 2.x. Please use FI_AV_TABLE. "
+		EFA_INFO(FI_LOG_AV, "FI_AV_MAP is deprecated in Libfabric 2.x. Please use FI_AV_TABLE. "
 					"EFA provider will now switch to using FI_AV_TABLE.\n");
 	}
 	attr->type = FI_AV_TABLE;

--- a/prov/efa/src/efa_user_info.c
+++ b/prov/efa/src/efa_user_info.c
@@ -313,7 +313,7 @@ int efa_user_info_alter_rdm(int version, struct fi_info *info, const struct fi_i
 
 	/* Print a warning and use FI_AV_TABLE if the app requests FI_AV_MAP */
 	if (hints && hints->domain_attr && hints->domain_attr->av_type == FI_AV_MAP)
-		EFA_WARN(FI_LOG_CORE, "FI_AV_MAP is deprecated in Libfabric 2.x. Please use FI_AV_TABLE. "
+		EFA_INFO(FI_LOG_CORE, "FI_AV_MAP is deprecated in Libfabric 2.x. Please use FI_AV_TABLE. "
 					"EFA provider will now switch to using FI_AV_TABLE.\n");
 	info->domain_attr->av_type = FI_AV_TABLE;
 
@@ -389,7 +389,7 @@ int efa_user_info_alter_direct(int version, struct fi_info *info, const struct f
 
 	/* Print a warning and use FI_AV_TABLE if the app requests FI_AV_MAP */
 	if (hints && hints->domain_attr && hints->domain_attr->av_type == FI_AV_MAP)
-		EFA_WARN(FI_LOG_CORE, "FI_AV_MAP is deprecated in Libfabric 2.x. Please use FI_AV_TABLE. "
+		EFA_INFO(FI_LOG_CORE, "FI_AV_MAP is deprecated in Libfabric 2.x. Please use FI_AV_TABLE. "
 					"EFA direct provider will now switch to using FI_AV_TABLE.\n");
 	info->domain_attr->av_type = FI_AV_TABLE;
 


### PR DESCRIPTION
Open MPI uses FI_AV_MAP and it's not nice to flood all Open MPI applications with these log lines


(cherry picked from commit 996a6c1911ca91a8cb9367da854c09086963303b)