### PR TITLE
prov/efa: Set larger CQ size for efa-direct and dgram paths

### DIFF
--- a/prov/efa/src/efa_cq.c
+++ b/prov/efa/src/efa_cq.c
@@ -429,6 +429,11 @@ int efa_cq_open(struct fid_domain *domain_fid, struct fi_cq_attr *attr,
 	if (!cq)
 		return -FI_ENOMEM;
 
+	efa_domain = container_of(domain_fid, struct efa_domain,
+				  util_domain.domain_fid);
+	/* Override user cq size if it's less than recommended cq size */
+	attr->size = MAX(efa_domain->cq_size, attr->size);
+
 	err = ofi_cq_init(&efa_prov, domain_fid, attr, &cq->util_cq,
 			  &efa_cq_progress, context);
 	if (err) {
@@ -436,8 +441,6 @@ int efa_cq_open(struct fid_domain *domain_fid, struct fi_cq_attr *attr,
 		goto err_free_cq;
 	}
 
-	efa_domain = container_of(cq->util_cq.domain, struct efa_domain,
-				  util_domain);
 	err = efa_cq_ibv_cq_ex_open(attr, efa_domain->device->ibv_ctx,
 				    &cq->ibv_cq.ibv_cq_ex,
 				    &cq->ibv_cq.ibv_cq_ex_type);

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -156,8 +156,6 @@ static int efa_domain_init_rdm(struct efa_domain *efa_domain, struct fi_info *in
 
 	efa_domain->mtu_size = efa_domain->device->ibv_port_attr.max_msg_sz;
 	efa_domain->addrlen = (info->src_addr) ? info->src_addrlen : info->dest_addrlen;
-	efa_domain->rdm_cq_size = MAX(info->rx_attr->size + info->tx_attr->size,
-				  efa_env.cq_size);
 	efa_domain->num_read_msg_in_flight = 0;
 
 	dlist_init(&efa_domain->ope_queued_list);
@@ -282,6 +280,9 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 		assert(EFA_INFO_TYPE_IS_DGRAM(info));
 		efa_domain->info_type = EFA_INFO_DGRAM;
 	}
+
+	efa_domain->cq_size = MAX(info->rx_attr->size + info->tx_attr->size,
+				  efa_env.cq_size);
 
 	efa_domain->util_domain.domain_fid.fid.ops = &efa_ops_domain_fid;
 	if (efa_domain->info_type == EFA_INFO_RDM) {

--- a/prov/efa/src/efa_domain.h
+++ b/prov/efa/src/efa_domain.h
@@ -41,7 +41,7 @@ struct efa_domain {
 	 * efa-direct paths */
 	enum efa_domain_info_type info_type;
 
-	size_t			rdm_cq_size;
+	size_t			cq_size;
 	/* number of rdma-read messages in flight */
 	uint64_t		num_read_msg_in_flight;
 	/* queued op entries */

--- a/prov/efa/src/rdm/efa_rdm_cq.c
+++ b/prov/efa/src/rdm/efa_rdm_cq.c
@@ -667,7 +667,7 @@ int efa_rdm_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	efa_domain = container_of(domain, struct efa_domain,
 				  util_domain.domain_fid);
 	/* Override user cq size if it's less than recommended cq size */
-	attr->size = MAX(efa_domain->rdm_cq_size, attr->size);
+	attr->size = MAX(efa_domain->cq_size, attr->size);
 
 	dlist_init(&cq->ibv_cq_poll_list);
 	cq->need_to_scan_ep_list = false;

--- a/prov/efa/test/efa_unit_test_domain.c
+++ b/prov/efa/test/efa_unit_test_domain.c
@@ -16,6 +16,8 @@ void test_efa_domain_info_type_efa_rdm(struct efa_resource **state)
 	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_FABRIC_NAME);
 	efa_domain = container_of(resource->domain, struct efa_domain, util_domain.domain_fid);
 	assert(efa_domain->info_type == EFA_INFO_RDM);
+	assert(efa_domain->cq_size == (efa_domain->info->rx_attr->size +
+				       efa_domain->info->tx_attr->size));
 }
 
 /**
@@ -31,6 +33,8 @@ void test_efa_domain_info_type_efa_direct(struct efa_resource **state)
 	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_DIRECT_FABRIC_NAME);
 	efa_domain = container_of(resource->domain, struct efa_domain, util_domain.domain_fid);
 	assert(efa_domain->info_type == EFA_INFO_DIRECT);
+	assert(efa_domain->cq_size == (efa_domain->info->rx_attr->size +
+				       efa_domain->info->tx_attr->size));
 }
 
 /* test fi_open_ops with a wrong name */


### PR DESCRIPTION
This change also allows the CQ size in the efa-direct and dgram paths to be controlled by FI_EFA_CQ_SIZE environment variable