### PR TITLE
fabtests/benchmarks: Add multi-threaded rdm bandwidth test

### DIFF
--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -52,6 +52,7 @@ bin_PROGRAMS = \
 	benchmarks/fi_rma_pingpong \
 	benchmarks/fi_rdm_tagged_pingpong \
 	benchmarks/fi_rdm_bw \
+	benchmarks/fi_rdm_bw_mt \
 	benchmarks/fi_rdm_tagged_bw \
 	unit/fi_eq_test \
 	unit/fi_cq_test \
@@ -422,6 +423,11 @@ benchmarks_fi_rdm_bw_SOURCES = \
 	benchmarks/rdm_bw.c \
 	$(benchmarks_srcs)
 benchmarks_fi_rdm_bw_LDADD = libfabtests.la
+
+benchmarks_fi_rdm_bw_mt_SOURCES = \
+	benchmarks/rdm_bw_mt.c \
+	$(benchmarks_srcs)
+benchmarks_fi_rdm_bw_mt_LDADD = libfabtests.la
 
 
 unit_fi_eq_test_SOURCES = \

--- a/fabtests/Makefile.win
+++ b/fabtests/Makefile.win
@@ -75,7 +75,8 @@ all: benchmarks functional unit multinode
 benchmarks: $(outdir)\dgram_pingpong.exe $(outdir)\msg_bw.exe \
 	$(outdir)\msg_pingpong.exe $(outdir)\rdm_cntr_pingpong.exe \
 	$(outdir)\rdm_pingpong.exe $(outdir)\rma_pingpong.exe $(outdir)\rdm_tagged_bw.exe \
-	$(outdir)\rdm_bw.exe $(outdir)\rdm_tagged_pingpong.exe $(outdir)\rma_bw.exe
+	$(outdir)\rdm_bw.exe $(outdir)\rdm_tagged_pingpong.exe \
+	$(outdir)\rma_bw.exe $(outdir)\rdm_bw_mt.exe
 
 functional: $(outdir)\av_xfer.exe $(outdir)\flood.exe $(outdir)\cm_data.exe $(outdir)\cq_data.exe \
 	$(outdir)\dgram.exe $(outdir)\msg.exe $(outdir)\msg_epoll.exe \
@@ -117,6 +118,7 @@ $(outdir)\rdm_tagged_pingpong.exe: {benchmarks}rdm_tagged_pingpong.c $(basedeps)
 
 $(outdir)\rma_bw.exe: {benchmarks}rma_bw.c $(basedeps) {benchmarks}benchmark_shared.c
 
+$(outdir)\rdm_bw_mt.exe: {benchmarks}rdm_bw_mt.c $(basedeps) {benchmarks}benchmark_shared.c
 
 $(outdir)\av_xfer.exe: {functional}av_xfer.c $(basedeps)
 

--- a/fabtests/benchmarks/rdm_bw_mt.c
+++ b/fabtests/benchmarks/rdm_bw_mt.c
@@ -1,0 +1,714 @@
+/*
+* Copyright (c) Intel Corporation. All rights reserved.
+*
+* This software is available to you under a choice of one of two
+* licenses.  You may choose to be licensed under the terms of the GNU
+* General Public License (GPL) Version 2, available from the file
+* COPYING in the main directory of this source tree, or the
+* BSD license below:
+*
+*     Redistribution and use in source and binary forms, with or
+*     without modification, are permitted provided that the following
+*     conditions are met:
+*
+*      - Redistributions of source code must retain the above
+*        copyright notice, this list of conditions and the following
+*        disclaimer.
+*
+*      - Redistributions in binary form must reproduce the above
+*        copyright notice, this list of conditions and the following
+*        disclaimer in the documentation and/or other materials
+*        provided with the distribution.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+* BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+* ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+* CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+/*
+ * rdm_bw_mt.c
+ * This is a mostly stand-alone test.
+ * It does not use any common fabtests init or destroy code but is intended to
+ * be run in the fabtest suite. In order to make this test use common code it
+ * must be refactored to remove the global fi resources and put them into
+ * objects. These objects can be struct ft_fabric_resources which will contain
+ * all resources that can be opened under a single fabtest and
+ * struct ft_buffer_resouces for all resources associated with a buffer.
+ * For the case of this test it will be:
+ *
+ * 				fabric
+ *			 _________|_________
+ * 			/	  |	    \
+ * 		    thread_0   thread_1   thread_n
+ *                 ____|____
+ *		  /	    \
+ *	fabric_resources buffer_resources
+ *         _____|_____	        _____|_____
+ * 	  /           \        /           \
+ * 	domain, ep, cq...     buf, mr_desc, mr...
+ *
+ * Each thread must have its own domain, ep, cq, av, cntr, buffer_reources, etc.
+ * The buffer_resources will contain the buffer, memory registration, and any
+ * other miscellaneous resources any buffer might need.
+ * There is an implicit 1:1 ratio where each thread's fabric resources are only
+ * associated with that thread's buffer resources. There are no resources other
+ * than fabric that are shared between threads.
+ * This test comes with a TODO to refactor the common code to support more tests
+ * of this type and enable easier development of future tests with more
+ * compatible objects instead of global variables.
+ * WARNING: Not all options are supported in this test!
+ */
+
+#include <pthread.h>
+#include <rdma/fi_cm.h>
+
+#include "shared.h"
+#include "benchmark_shared.h"
+#include "hmem.h"
+
+#define BUFFER_SIZE 1024
+static char oob_buffer[BUFFER_SIZE];
+
+static int num_eps = 1;
+static bool bidir = false;
+static ssize_t xfer_size = 1;
+pthread_barrier_t barrier;
+
+struct thread_args {
+	pthread_t thread;
+	fi_addr_t fiaddr;
+	struct fid_domain *domain;
+	struct fid_ep *ep;
+	struct fid_cq *cq;
+	struct fid_av *av;
+	struct fid_mr *tx_mr;
+	struct fid_mr *rx_mr;
+	void *tx_mr_desc;
+	void *rx_mr_desc;
+	struct fi_context2 send_ctx;
+	struct fi_context2 recv_ctx;
+	char *tx_buf;
+	char *rx_buf;
+	int id;
+	int ret;
+};
+
+static struct thread_args *targs = NULL;
+
+static void cleanup_ofi(void)
+{
+	int ret;
+	int i;
+
+	for (i = 0; i < num_eps; i++) {
+		if (targs[i].ep) {
+			ret = fi_close(&targs[i].ep->fid);
+			if (ret)
+				printf("fi_close(ep[%d]) failed: %d\n", i, ret);
+		}
+
+		if (targs[i].cq) {
+			ret = fi_close(&targs[i].cq->fid);
+			if (ret)
+				printf("fi_close(cq[%d]) failed: %d\n", i, ret);
+		}
+
+		if (targs[i].av) {
+			ret = fi_close(&targs[i].av->fid);
+			if (ret)
+				printf("fi_close(av[%d]) failed: %d\n", i, ret);
+		}
+
+		if (targs[i].domain) {
+			ret = fi_close(&targs[i].domain->fid);
+			if (ret)
+				printf("fi_close(domain[%d]) failed: %d\n", i,
+					ret);
+		}
+	}
+
+	if (fabric) {
+		fi_close(&fabric->fid);
+		if (ret)
+			printf("fi_close(fabric) failed: %d\n", ret);
+	}
+
+	if (fi)
+		fi_freeinfo(fi);
+	if (hints)
+		fi_freeinfo(hints);
+	if (targs)
+		free(targs);
+}
+
+static int init_av(int i)
+{
+	int ret;
+	size_t len = BUFFER_SIZE;
+	char print_buf[BUFFER_SIZE];
+
+	memset(print_buf, 0, BUFFER_SIZE);
+
+	ret = fi_getname(&targs[i].ep->fid, oob_buffer, &len);
+	if (ret) {
+		printf("fi_getname failed: %d\n", ret);
+		return ret;
+	}
+
+	len = BUFFER_SIZE;
+
+	ret = ft_sock_send(oob_sock, oob_buffer, len);
+	if (ret) {
+		printf("ft_sock_send failed: %d\n", ret);
+		return ret;
+	}
+
+	ret = ft_sock_recv(oob_sock, oob_buffer, len);
+	if (ret) {
+		printf("ft_sock_recv failed: %d\n", ret);
+		return ret;
+	}
+
+	ret = fi_av_insert(targs[i].av, oob_buffer, 1, &targs[i].fiaddr, 0, NULL);
+	if (ret != 1) {
+		printf("fi_av_insert failed: %d\n", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int init_ofi(void)
+{
+	struct fi_cq_attr cq_attr;
+	struct fi_av_attr av_attr;
+	struct fi_cntr_attr cntr_attr;
+	int ret = FI_SUCCESS, i;
+
+        ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
+        if (ret) {
+		printf("fi_fabric failed: %d\n", ret);
+                return ret;
+	}
+
+	targs = calloc(num_eps, sizeof(*targs));
+	if (!targs) {
+		printf("thread_args calloc failed\n");
+		return -FI_ENOMEM;
+	}
+
+	for (i = 0; i < num_eps; i++) {
+		memset(&cq_attr, 0, sizeof(cq_attr));
+		memset(&av_attr, 0, sizeof(av_attr));
+		memset(&cntr_attr, 0, sizeof(cntr_attr));
+
+		ret = fi_domain(fabric, fi, &targs[i].domain, NULL);
+		if (ret) {
+			printf("fi_domain failed ep[%d]: %d\n", i, ret);
+			return ret;
+		}
+
+		ret = fi_endpoint(targs[i].domain, fi, &targs[i].ep, NULL);
+		if (ret) {
+			printf("fi_endpoint failed: %d\n", ret);
+			return ret;
+		}
+
+		cq_attr.size = 128;
+		cq_attr.format = FI_CQ_FORMAT_CONTEXT;
+		ret = fi_cq_open(targs[i].domain, &cq_attr, &targs[i].cq, NULL);
+		if (ret) {
+			printf("fi_cq_open failed: %d\n", ret);
+			return ret;
+		}
+
+		av_attr.type = FI_AV_UNSPEC;
+		av_attr.count = 1;
+		ret = fi_av_open(targs[i].domain, &av_attr, &targs[i].av, NULL);
+		if (ret) {
+			printf("fi_av_open failed: %d\n", ret);
+			return ret;
+		}
+
+		ret = fi_ep_bind(targs[i].ep, &targs[i].av->fid, 0);
+		if (ret) {
+			printf("fi_ep_bind av failed: %d\n", ret);
+			return ret;
+		}
+
+		ret = fi_ep_bind(targs[i].ep, &targs[i].cq->fid, FI_TRANSMIT | FI_RECV);
+		if (ret) {
+			printf("fi_ep_bind cq failed: %d\n", ret);
+			return ret;
+		}
+
+		ret = fi_enable(targs[i].ep);
+		if (ret) {
+			printf("fi_enable failed: %d\n", ret);
+			return ret;
+		}
+	}
+
+	return ret;
+}
+
+
+static int mt_reg_mr(struct fi_info *fi, void *buf, size_t size,
+		     uint64_t access, uint64_t key, enum fi_hmem_iface iface,
+		     uint64_t device, struct fid_domain *dom,
+		     struct fid_ep *endpoint, struct fid_mr **mr, void **desc)
+{
+	struct fi_mr_attr attr = {0};
+	struct iovec iov = {0};
+	int ret;
+	uint64_t flags;
+	int dmabuf_fd;
+	uint64_t dmabuf_offset;
+	struct fi_mr_dmabuf dmabuf = {0};
+
+	if (!ft_need_mr_reg(fi))
+		return 0;
+
+	iov.iov_base = buf;
+	iov.iov_len = size;
+
+	flags = (iface) ? FI_HMEM_DEVICE_ONLY : 0;
+
+	if (opts.options & FT_OPT_REG_DMABUF_MR) {
+		ret = ft_hmem_get_dmabuf_fd(iface, buf, size,
+					    &dmabuf_fd, &dmabuf_offset);
+		if (ret)
+			return ret;
+
+		dmabuf.fd = dmabuf_fd;
+		dmabuf.offset = dmabuf_offset;
+		dmabuf.len = size;
+		dmabuf.base_addr = (void *)((uintptr_t) buf - dmabuf_offset);
+		flags |= FI_MR_DMABUF;
+	}
+
+	ft_fill_mr_attr(&iov, &dmabuf, 1, access, key, iface, device, &attr,
+			flags);
+	ret = fi_mr_regattr(dom, &attr, flags, mr);
+	if (ret)
+		return ret;
+
+	if (desc)
+		*desc = fi_mr_desc(*mr);
+
+	if (fi->domain_attr->mr_mode & FI_MR_ENDPOINT) {
+		ret = fi_mr_bind(*mr, &endpoint->fid, 0);
+		if (ret)
+			return ret;
+
+		ret = fi_mr_enable(*mr);
+		if (ret)
+			return ret;
+	}
+
+	return FI_SUCCESS;
+}
+
+static int reg_mrs(struct thread_args *targs)
+{
+	int ret = FI_SUCCESS;
+
+	ret = ft_hmem_alloc(opts.iface, opts.device, (void **) &(targs->tx_buf),
+			    xfer_size);
+	if (ret) {
+		printf("ft_hmem_alloc tx %d failed: %d\n", targs->id, ret);
+		return ret;
+	}
+
+	ret = ft_hmem_alloc(opts.iface, opts.device, (void **) &(targs->rx_buf),
+			    xfer_size);
+	if (ret) {
+		printf("ft_hmem_alloc rx %d failed: %d\n", targs->id, ret);
+		return ret;
+	}
+
+	ret = mt_reg_mr(fi, (void *) targs->tx_buf, xfer_size, FI_SEND,
+			targs->id, opts.iface, opts.device,
+			targs->domain, targs->ep,
+			&targs->tx_mr, &targs->tx_mr_desc);
+	if (ret) {
+		printf("fi_mr_reg tx %d failed: %d\n", targs->id, ret);
+		return ret;
+	}
+
+	ret = mt_reg_mr(fi, (void *) targs->rx_buf, xfer_size, FI_RECV,
+			targs->id + 0xDAD, opts.iface, opts.device,
+			targs->domain, targs->ep,
+			&targs->rx_mr, &targs->rx_mr_desc);
+	if (ret)
+		printf("fi_mr_reg rx %d failed: %d\n", targs->id, ret);
+
+	return ret;
+}
+
+static void force_progress(struct fid_cq *cq)
+{
+	(void) fi_cq_read(cq, NULL, 0);
+}
+
+static int read_cq(struct fid_cq *cqueue)
+{
+	struct fi_cq_entry cq_entry;
+	int ret;
+
+	do {
+		ret = fi_cq_read(cqueue, &cq_entry, 1);
+		if (ret < 0 && ret != -FI_EAGAIN)
+			return ret;
+		if (ret == 1)
+			return 0;
+	} while (1);
+}
+
+static int post_send(void *context)
+{
+	int ret;
+	struct thread_args *targs = context;
+
+	do {
+		ret = fi_send(targs->ep, targs->tx_buf, xfer_size,
+			      targs->tx_mr, targs->fiaddr, &targs->send_ctx);
+		if (ret != -FI_EAGAIN)
+			return ret;
+
+		force_progress(targs->cq);
+	} while (1);
+}
+
+static int post_recv(void *context)
+{
+	int ret;
+	struct thread_args *targs = context;
+
+	do {
+		ret = fi_recv(targs->ep, targs->rx_buf, xfer_size,
+			      targs->rx_mr, targs->fiaddr, &targs->recv_ctx);
+		if (ret != -FI_EAGAIN)
+			return ret;
+
+		force_progress(targs->cq);
+	} while (1);
+}
+
+static int bw_send(void *context)
+{
+	int ret;
+	struct thread_args *targs = context;
+
+	ret = post_send(context);
+	if (ret)
+		return ret;
+
+	ret = read_cq(targs->cq);
+	if (ret) {
+		printf("send read_cq error: %d\n", ret);
+		return ret;
+	}
+	return 0;
+}
+
+static int bw_recv(void *context)
+{
+	int ret = FI_SUCCESS;
+	struct thread_args *targs = context;
+
+	ret = post_recv(context);
+	if (ret)
+		return ret;
+
+	ret = read_cq(targs->cq);
+	if (ret) {
+		printf("recv read_cq error: %d\n", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+static void *uni_bandwidth(void *context)
+{
+	int i, ret;
+
+	pthread_barrier_wait(&barrier);
+	for (i = 0; i < opts.warmup_iterations; i++) {
+		ret = opts.dst_addr ? bw_send(context) : bw_recv(context);
+		if (ret) {
+			((struct thread_args *) context)->ret = ret;
+			printf("ep[%d] warmup failed iter %d\n", targs->id, i);
+			break;
+		}
+	}
+
+	pthread_barrier_wait(&barrier);
+	if (targs->id == 0)
+		ft_start();
+	for (i = 0; i < opts.iterations; i++) {
+		ret = opts.dst_addr ? bw_send(context) : bw_recv(context);
+		if (ret) {
+			((struct thread_args *) context)->ret = ret;
+			break;
+		}
+	}
+	pthread_barrier_wait(&barrier);
+	if (targs->id == 0)
+		ft_stop();
+
+	return  NULL;
+}
+
+static void *bi_bandwidth(void *context)
+{
+	int i, ret;
+	struct thread_args *targs = context;
+
+	pthread_barrier_wait(&barrier);
+	for (i = 0; i < opts.warmup_iterations; i++) {
+		ret = opts.dst_addr ? bw_send(context) : bw_recv(context);
+		if (ret) {
+			((struct thread_args *) context)->ret = ret;
+			printf("%d warmup failed iter %d\n", targs->id, i);
+			break;
+		}
+		ret = opts.dst_addr ? bw_recv(context) : bw_send(context);
+		if (ret) {
+			((struct thread_args *) context)->ret = ret;
+			printf("%d warmup failed iter %d\n", targs->id, i);
+			break;
+		}
+	}
+
+	pthread_barrier_wait(&barrier);
+	if (targs->id == 0)
+		ft_start();
+
+	for (i = 0; i < opts.iterations; i++) {
+		ret = opts.dst_addr ? bw_send(context) : bw_recv(context);
+		if (ret) {
+			((struct thread_args *) context)->ret = ret;
+			printf("%d warmup failed iter %d\n", targs->id, i);
+			break;
+		}
+		ret = opts.dst_addr ? bw_recv(context) : bw_send(context);
+		if (ret) {
+			((struct thread_args *) context)->ret = ret;
+			printf("%d warmup failed iter %d\n", targs->id, i);
+			break;
+		}
+	}
+	pthread_barrier_wait(&barrier);
+	if (targs->id == 0)
+		ft_stop();
+
+	return NULL;
+}
+
+static int run_size(void)
+{
+	int i, err, ret = FI_SUCCESS;
+
+	for (i = 0; i < num_eps; i++) {
+		targs[i].id = i;
+		targs[i].ret = FI_SUCCESS;
+		ret = reg_mrs(&targs[i]);
+		if (ret)
+			goto out;
+	}
+
+	for (i = 0; i < num_eps; i++) {
+		ret = pthread_create(&targs[i].thread, NULL,
+				     bidir ? bi_bandwidth : uni_bandwidth,
+				     &targs[i]);
+		if (ret) {
+			printf("pthread_create failed: %d\n", ret);
+			return ret;
+		}
+	}
+	for (i = 0; i < num_eps; i++) {
+		pthread_join(targs[i].thread, NULL);
+		if (targs[i].ret) {
+			ret = targs[i].ret;
+			goto out;
+		}
+	}
+
+	show_perf(NULL, xfer_size, opts.iterations, &start, &end, num_eps);
+
+out:
+	for (i = 0; i < num_eps; i++) {
+		if (targs[i].tx_mr)
+			fi_close(&targs[i].tx_mr->fid);
+		if (targs[i].rx_mr)
+			fi_close(&targs[i].rx_mr->fid);
+		if (targs[i].tx_buf) {
+			err = ft_hmem_free(opts.iface, targs[i].tx_buf);
+			if (err)
+				printf("ft_hmem_free tx %d failed: %d\n",
+				       i, err);
+		}
+		if (targs[i].rx_buf) {
+			err = ft_hmem_free(opts.iface, targs[i].rx_buf);
+			if (err)
+				printf("ft_hmem_free rx %d failed: %d\n",
+				       i, err);
+		}
+	}
+
+	return ret;
+}
+
+static int run_test(void)
+{
+	int i, ret;
+
+	if (!(opts.options & FT_OPT_SIZE)) {
+		for (i = 0; i < TEST_CNT; i++) {
+			if (!ft_use_size(i, opts.sizes_enabled))
+				continue;
+			xfer_size = test_size[i].size;
+			ret = run_size();
+			if (ret)
+				return ret;
+		}
+	} else {
+		xfer_size = opts.transfer_size;
+		ret = run_size();
+		if (ret)
+			return ret;
+	}
+
+	return FI_SUCCESS;
+}
+
+static void usage(void)
+{
+	fprintf(stderr, "\nrdm_bw_mt test options:\n");
+	FT_PRINT_OPTS_USAGE("-g", "enable bidirectional");
+	FT_PRINT_OPTS_USAGE("-n <num endpoints>",
+			    "number of endpoints (threads) to use");
+	FT_PRINT_OPTS_USAGE("-U", "enable FI_DELIVERY_COMPLETE");
+	fprintf(stderr, "Notice to user: Not all fabtests options are supported"
+		" by this test. If something isn't working check if the option"
+		" is supported before reporting a bug.\n");
+}
+
+int main(int argc, char **argv)
+{
+        int ret, op, i;
+
+	opts = INIT_OPTS;
+	opts.options |= FT_OPT_OOB_CTRL;
+
+        hints = fi_allocinfo();
+	if (!hints)
+		return EXIT_FAILURE;
+
+	while ((op = getopt_long(argc, argv, "gn:Uh" CS_OPTS INFO_OPTS API_OPTS
+		BENCHMARK_OPTS, long_opts, &lopt_idx)) != -1) {
+		switch (op) {
+		default:
+			if (!ft_parse_long_opts(op, optarg))
+				continue;
+			ft_parse_benchmark_opts(op, optarg);
+			ft_parseinfo(op, optarg, hints, &opts);
+			ft_parsecsopts(op, optarg, &opts);
+			ft_parse_api_opts(op, optarg, hints, &opts);
+			break;
+		case 'g':
+			bidir = true;
+			break;
+		case 'n':
+			num_eps = atoi(optarg);
+			break;
+		case 'U':
+			hints->tx_attr->op_flags |= FI_DELIVERY_COMPLETE;
+			break;
+		case '?':
+		case 'h':
+			ft_csusage(argv[0], "Multi-Threaded Bandwidth test for "
+				   "RDM endpoints.");
+			ft_benchmark_usage();
+			ft_longopts_usage();
+			usage();
+			return EXIT_FAILURE;
+		}
+	}
+
+	if (optind < argc)
+		opts.dst_addr = argv[optind];
+
+	hints->ep_attr->type = FI_EP_RDM;
+	hints->domain_attr->resource_mgmt = FI_RM_ENABLED;
+	hints->domain_attr->threading = FI_THREAD_DOMAIN;
+	hints->caps = FI_MSG;
+	hints->mode |= FI_CONTEXT | FI_CONTEXT2;
+	hints->domain_attr->mr_mode = opts.mr_mode;
+	hints->addr_format = opts.address_format;
+
+	if (opts.options & FT_OPT_ENABLE_HMEM) {
+		hints->caps |= FI_HMEM;
+		hints->domain_attr->mr_mode |= FI_MR_HMEM;
+	}
+
+        ret = ft_init_oob();
+        if (ret)
+                goto out;
+
+	if (oob_sock >= 0 && opts.dst_addr) {
+		ret = ft_sock_sync(oob_sock, 0);
+		if (ret)
+			return ret;
+	}
+
+	ret = ft_hmem_init(opts.iface);
+	if (ret)
+		FT_PRINTERR("ft_hmem_init", ret);
+
+	ret = fi_getinfo(FT_FIVERSION, NULL, NULL, 0, hints, &fi);
+	if (ret) {
+		printf("fi_getinfo() failed: %d\n", ret);
+		goto out;
+	}
+
+	ret = init_ofi();
+	if (ret) {
+		printf("init ofi failed\n");
+                goto out;
+	}
+
+	if (oob_sock >= 0 && !opts.dst_addr) {
+		ret = ft_sock_sync(oob_sock, 0);
+		if (ret)
+			return ret;
+	}
+
+	for (i = 0; i < num_eps; i++) {
+		ret = init_av(i);
+		if (ret) {
+			printf("init_av[%d] failed\n", i);
+			goto out;
+		}
+	}
+
+	ret = pthread_barrier_init(&barrier, NULL, num_eps);
+	if (ret)
+		goto out;
+
+	ret = run_test();
+
+	pthread_barrier_destroy(&barrier);
+
+out:
+	cleanup_ofi();
+	ft_close_oob();
+        return ret;
+}

--- a/fabtests/fabtests.vcxproj
+++ b/fabtests/fabtests.vcxproj
@@ -193,6 +193,7 @@
     <ClCompile Include="benchmarks\rdm_tagged_bw.c" />
     <ClCompile Include="benchmarks\rdm_tagged_pingpong.c" />
     <ClCompile Include="benchmarks\rma_bw.c" />
+    <ClCompile Include="benchmarks\rdm_bw_mt.c" />
     <ClCompile Include="common\hmem.c" />
     <ClCompile Include="common\hmem_cuda.c" />
     <ClCompile Include="common\hmem_rocr.c" />
@@ -269,6 +270,7 @@
     <ClInclude Include="include\windows\netinet\tcp.h" />
     <ClInclude Include="include\windows\osd.h" />
     <ClInclude Include="include\windows\poll.h" />
+    <ClInclude Include="include\windows\pthread.h" />
     <ClInclude Include="include\windows\sys\socket.h" />
     <ClInclude Include="include\windows\sys\uio.h" />
     <ClInclude Include="include\windows\sys\wait.h" />

--- a/fabtests/fabtests.vcxproj.filters
+++ b/fabtests/fabtests.vcxproj.filters
@@ -186,6 +186,9 @@
     <ClCompile Include="benchmarks\rma_bw.c">
       <Filter>Source Files\benchmarks</Filter>
     </ClCompile>
+    <ClCompile Include="benchmarks\rdm_bw_mt.c">
+      <Filter>Source Files\benchmarks</Filter>
+    </ClCompile>
     <ClCompile Include="functional\rdm_netdir.c">
       <Filter>Source Files\functional</Filter>
     </ClCompile>
@@ -279,6 +282,9 @@
       <Filter>Header Files\osd</Filter>
     </ClInclude>
     <ClInclude Include="include\windows\poll.h">
+      <Filter>Header Files\osd</Filter>
+    </ClInclude>
+    <ClInclude Include="include\windows\pthread.h">
       <Filter>Header Files\osd</Filter>
     </ClInclude>
     <ClInclude Include="include\windows\unistd.h">

--- a/fabtests/include/osx/osd.h
+++ b/fabtests/include/osx/osd.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2015 Los Alamos Nat. Security, LLC. All rights reserved.
+ * Copyright (c) Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -38,6 +39,8 @@
 #include <sys/time.h>
 #include <time.h>
 
+#include <pthread.h>
+
 #if !HAVE_CLOCK_GETTIME
 #define CLOCK_REALTIME 0
 #define CLOCK_REALTIME_COARSE 0
@@ -55,5 +58,51 @@ int clock_gettime(clockid_t clk_id, struct timespec *tp);
 }
 #endif
 #endif // !HAVE_CLOCK_GETTIME
+
+#if !defined(_POSIX_BARRIERS) || (_POSIX_BARRIERS < 0)
+
+typedef int pthread_barrierattr_t;
+
+typedef struct {
+	int count;
+	int called;
+	pthread_mutex_t mutex;
+	pthread_cond_t cond;
+} pthread_barrier_t;
+
+static inline int pthread_barrier_init(pthread_barrier_t *barrier,
+                        	       const pthread_barrierattr_t *attr,
+                        	       unsigned count)
+{
+	barrier->count = count;
+	barrier->called = 0;
+	pthread_mutex_init(&barrier->mutex, NULL);
+	pthread_cond_init(&barrier->cond, NULL);
+	return 0;
+}
+
+static inline int pthread_barrier_destroy(pthread_barrier_t *barrier)
+{
+	pthread_mutex_destroy(&barrier->mutex);
+	pthread_cond_destroy(&barrier->cond);
+	return 0;
+}
+
+static inline int pthread_barrier_wait(pthread_barrier_t *barrier)
+{
+	pthread_mutex_lock(&barrier->mutex);
+	barrier->called++;
+	if (barrier->called == barrier->count) {
+		barrier->called = 0;
+		pthread_cond_broadcast(&barrier->cond);
+	} else {
+		pthread_cond_wait(&barrier->cond, &barrier->mutex);
+	}
+
+	pthread_mutex_unlock(&barrier->mutex);
+	return 0;
+}
+
+#endif // _POSIX_BARRIERS
 
 #endif // FABTESTS_OSX_OSD_H

--- a/fabtests/include/windows/pthread.h
+++ b/fabtests/include/windows/pthread.h
@@ -1,0 +1,307 @@
+/*
+* Copyright (c) Intel Corporation. All rights reserved.
+* Copyright (c) 2020 Amazon.com, Inc. or its affiliates. All rights reserved.
+*
+* This software is available to you under a choice of one of two
+* licenses.  You may choose to be licensed under the terms of the GNU
+* General Public License (GPL) Version 2, available from the file
+* COPYING in the main directory of this source tree, or the
+* BSD license below:
+*
+*     Redistribution and use in source and binary forms, with or
+*     without modification, are permitted provided that the following
+*     conditions are met:
+*
+*      - Redistributions of source code must retain the above
+*        copyright notice, this list of conditions and the following
+*        disclaimer.
+*
+*      - Redistributions in binary form must reproduce the above
+*        copyright notice, this list of conditions and the following
+*        disclaimer in the documentation and/or other materials
+*        provided with the distribution.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+* BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+* ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+* CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#pragma once
+
+#include <WinSock2.h>
+#include <ws2tcpip.h>
+#include <windows.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#define PTHREAD_MUTEX_INITIALIZER {0}
+#define PTHREAD_RWLOCK_INITIALIZER {0}
+
+#define pthread_cond_signal WakeConditionVariable
+#define pthread_cond_broadcast WakeAllConditionVariable
+#define pthread_mutex_init(mutex, attr) (InitializeCriticalSection(mutex), 0)
+#define pthread_mutex_destroy(mutex) (DeleteCriticalSection(mutex), 0)
+#define pthread_cond_init(cond, attr) (InitializeConditionVariable(cond), 0)
+#define pthread_cond_destroy(x)	/* nothing to do */
+
+typedef CRITICAL_SECTION	pthread_mutex_t;
+typedef CONDITION_VARIABLE	pthread_cond_t;
+typedef HANDLE			pthread_t;
+
+static inline int pthread_mutex_lock(pthread_mutex_t* mutex)
+{
+	EnterCriticalSection(mutex);
+	return 0;
+}
+
+static inline int pthread_mutex_trylock(pthread_mutex_t* mutex)
+{
+	return !TryEnterCriticalSection(mutex);
+}
+
+static inline int pthread_mutex_unlock(pthread_mutex_t* mutex)
+{
+	LeaveCriticalSection(mutex);
+	return 0;
+}
+
+static inline int pthread_join(pthread_t thread, void** exit_code)
+{
+	if (WaitForSingleObject(thread, INFINITE) == WAIT_OBJECT_0) {
+		if (exit_code) {
+			DWORD ex = 0;
+			GetExitCodeThread(thread, &ex);
+			*exit_code = (void*)(uint64_t)ex;
+		}
+		CloseHandle(thread);
+		return 0;
+	}
+
+	return -1;
+}
+
+typedef struct fi_thread_arg
+{
+	void* (*routine)(void*);
+	void* arg;
+} fi_thread_arg;
+
+static DWORD WINAPI ofi_thread_starter(void* arg)
+{
+	fi_thread_arg data = *(fi_thread_arg*)arg;
+	free(arg);
+	return (DWORD)(uint64_t)data.routine(data.arg);
+}
+
+static inline int pthread_create(pthread_t* thread, void* attr, void *(*routine)(void*), void* arg)
+{
+	(void) attr;
+	fi_thread_arg* data = (fi_thread_arg*)malloc(sizeof(*data));
+	data->routine = routine;
+	data->arg = arg;
+	DWORD threadid;
+	*thread = CreateThread(0, 0, ofi_thread_starter, data, 0, &threadid);
+	return *thread == 0;
+}
+
+static inline int pthread_equal(pthread_t t1, pthread_t t2)
+{
+	(void)t1;
+	(void)t2;
+	/*
+	 * TODO: temporary solution
+	 * Need to implement
+	 */
+	return ENOSYS;
+}
+
+static inline int pthread_cancel(pthread_t thread)
+{
+	(void)thread;
+	/*
+	 * TODO: temporary solution
+	 * Need to implement
+	 */
+	return ENOSYS;
+}
+
+static inline pthread_t pthread_self(void)
+{
+	/*
+	 * TODO: temporary solution
+	 * Need to implement
+	 */
+	return (pthread_t) ENOSYS;
+}
+
+static inline int pthread_yield(void)
+{
+	(void) SwitchToThread();
+	return 0;
+}
+
+/*
+ * TODO: temporary solution
+ * Need to re-implement
+ */
+typedef void(*pthread_cleanup_callback_t)(void *);
+typedef struct pthread_cleanup_t
+{
+	pthread_cleanup_callback_t routine;
+	void *arg;
+} pthread_cleanup_t;
+
+/* Read-Write lock implementation */
+
+typedef struct {
+    SRWLOCK	lock; /* Windows Slim Reader Writer Lock */
+    bool	write_mode;
+} pthread_rwlock_t;
+typedef void pthread_rwlockattr_t;
+
+static inline int pthread_rwlock_init(pthread_rwlock_t *rwlock, const pthread_rwlockattr_t *attr)
+{
+	(void)attr;
+	if (rwlock) {
+		InitializeSRWLock(&(rwlock->lock));
+		rwlock->write_mode = false;
+		return 0;
+	}
+	return 1;
+}
+
+static inline int pthread_rwlock_destroy(pthread_rwlock_t *rwlock)
+{
+	/* No SRWLock cleanup function */
+	(void)rwlock;
+	return 0;
+}
+
+static inline int pthread_rwlock_rdlock(pthread_rwlock_t *rwlock)
+{
+	if (rwlock) {
+		AcquireSRWLockShared(&(rwlock->lock));
+		return 0;
+	}
+	return 1;
+}
+
+static inline int pthread_rwlock_tryrdlock(pthread_rwlock_t *rwlock)
+{
+	if (rwlock && TryAcquireSRWLockShared(&(rwlock->lock))) {
+		return 0;
+	}
+	return 1;
+}
+
+static inline int pthread_rwlock_wrlock(pthread_rwlock_t *rwlock)
+{
+	if (rwlock) {
+		AcquireSRWLockExclusive(&(rwlock->lock));
+		rwlock->write_mode = true;
+		return 0;
+	}
+	return 1;
+}
+
+static inline int pthread_rwlock_trywrlock(pthread_rwlock_t *rwlock)
+{
+	if (rwlock && TryAcquireSRWLockExclusive(&(rwlock->lock))) {
+		rwlock->write_mode = true;
+		return 0;
+	}
+	return 1;
+}
+
+
+static inline int pthread_rwlock_unlock(pthread_rwlock_t *rwlock)
+{
+	if (rwlock) {
+		if (rwlock->write_mode) {
+			rwlock->write_mode = false;
+			ReleaseSRWLockExclusive(&(rwlock->lock));
+		} else {
+			ReleaseSRWLockShared(&(rwlock->lock));
+		}
+		return 0;
+	}
+	return 1;
+}
+
+typedef int pthread_barrierattr_t;
+
+typedef struct {
+	int count;
+	int called;
+	pthread_mutex_t mutex;
+	pthread_cond_t cond;
+} pthread_barrier_t;
+
+static inline int pthread_barrier_init(pthread_barrier_t *barrier,
+                         const pthread_barrierattr_t *attr,
+                         unsigned count)
+{
+    barrier->count = count;
+    barrier->called = 0;
+    pthread_mutex_init(&barrier->mutex, NULL);
+    pthread_cond_init(&barrier->cond, NULL);
+    return 0;
+}
+
+static inline int pthread_barrier_destroy(pthread_barrier_t *barrier)
+{
+    pthread_mutex_destroy(&barrier->mutex);
+    pthread_cond_destroy(&barrier->cond);
+    return 0;
+}
+
+static inline int pthread_barrier_wait(pthread_barrier_t *barrier)
+{
+    pthread_mutex_lock(&barrier->mutex);
+    barrier->called++;
+    if (barrier->called == barrier->count) {
+        barrier->called = 0;
+        pthread_cond_broadcast(&barrier->cond);
+    } else {
+	SleepConditionVariableCS(&barrier->cond, &barrier->mutex, SIZE_MAX);
+    }
+    pthread_mutex_unlock(&barrier->mutex);
+    return 0;
+}
+
+#ifndef __cplusplus
+#define pthread_cleanup_push(_rout, _arg)				\
+{									\
+	pthread_cleanup_t _cleanup = {					\
+		.routine = (pthread_cleanup_callback_t) (_rout),	\
+		.arg = (_arg),						\
+	};								\
+
+#define pthread_cleanup_pop(_execute)					\
+	if (_execute)							\
+		(void) (*(_cleanup.routine))(_cleanup.arg);		\
+}
+#else
+#define pthread_cleanup_push(_rout, _arg)				\
+{									\
+	pthread_cleanup_t _cleanup;					\
+	_cleanup.routine = (pthread_cleanup_callback_t) _rout,		\
+	_cleanup.arg = (_arg);						\
+	__try								\
+	{								\
+
+#define pthread_cleanup_pop(_execute)					\
+	}								\
+	__finally {							\
+		if( _execute || AbnormalTermination())			\
+			(*(_cleanup.routine))(_cleanup.arg);		\
+	}								\
+}
+#endif

--- a/fabtests/pytest/default/test_rdm.py
+++ b/fabtests/pytest/default/test_rdm.py
@@ -87,4 +87,13 @@ def test_rdm_tagged_bw(cmdline_args, iteration_type, datacheck_type, completion_
                             completion_semantic, datacheck_type=datacheck_type)
     test.run()
 
+@pytest.mark.parametrize("iteration_type",
+                         [pytest.param("short", marks=pytest.mark.short),
+                          pytest.param("standard", marks=pytest.mark.standard)])
+def test_rdm_bw_mt(cmdline_args, iteration_type, datacheck_type, completion_semantic):
+    from common import ClientServerTest
+    test = ClientServerTest(cmdline_args, "fi_rdm_bw_mt -n 4", iteration_type,
+                            completion_semantic, datacheck_type=datacheck_type)
+    test.run()
+
 

--- a/fabtests/scripts/runfabtests.cmd
+++ b/fabtests/scripts/runfabtests.cmd
@@ -152,6 +152,9 @@ set multinode_tests=^
 	"multinode -x msg"^
 	"multinode -x rma"
 
+set threaded_tests=^
+	"fi_rdm_bw_mt -n 8"^
+	"fi_rdm_bw_mt -n 8 -g"
 
 goto :global_main
 
@@ -544,7 +547,7 @@ goto :global_main
 
 	set tests=
 	if /i "%~1" == "quick" set tests=unit,functional,short
-	if /i "%~1" == "all" set tests=unit,functional,standard,multinode
+	if /i "%~1" == "all" set tests=unit,functional,standard,multinode,threaded
 	if /i "%tests%" == "" set tests=%~1
 	set tests=%tests:,= %
 
@@ -583,6 +586,11 @@ goto :global_main
 :set-multinode
 			for %%t in (%multinode_tests%) do (
 				call :multinode_test %%t 3
+			)
+			goto :EOF
+:set-threaded
+			for %%t in (%threaded_tests%) do (
+				call :cs_test %%t
 			)
 			goto :EOF
 :set-
@@ -630,7 +638,7 @@ goto :global_main
 	echo.  -v       print output of failing 1>&2
 	echo.  -v -v    print output of failing/notrun 1>&2
 	echo.  -v -v -v print output of failing/notrun/passing 1>&2
-	echo.  -t       test set(s): all,quick,unit,functional,standard,short,complex (default quick) 1>&2
+	echo.  -t       test set(s): all,quick,unit,functional,standard,short,complex,threaded (default quick) 1>&2
 	echo.  -N       skip negative unit tests 1>&2
 	echo.  -p       path to test bins (default PATH) 1>&2
 	echo.  -c       client interface 1>&2

--- a/fabtests/scripts/runfabtests.sh
+++ b/fabtests/scripts/runfabtests.sh
@@ -262,6 +262,15 @@ multinode_tests=(
 	"fi_multinode_coll"
 )
 
+threaded_tests=(
+	"fi_rdm_bw_mt -n 8"
+	"fi_rdm_bw_mt -n 8 -g"
+	"fi_rdm_bw_mt -n 16"
+	"fi_rdm_bw_mt -n 16 -g"
+	"fi_rdm_bw_mt -n 32"
+	"fi_rdm_bw_mt -n 32 -g"
+)
+
 prov_efa_tests=( \
 	"fi_efa_rnr_read_cq_error"
 	"fi_efa_rnr_queue_resend -c 0 -S 1048576"
@@ -792,7 +801,7 @@ function main {
 		local -r tests="complex"
 		complex_type=$1
 	else
-		local -r tests=$(echo $1 | sed 's/all/unit,regression,functional,standard,complex,multinode/g' | tr ',' ' ')
+		local -r tests=$(echo $1 | sed 's/all/unit,regression,functional,standard,complex,multinode,threaded/g' | tr ',' ' ')
 		if [[ $1 == "all" || $1 == "complex" ]]; then
 			complex_type="all"
 		fi
@@ -850,6 +859,11 @@ function main {
 					multinode_test "$test" 3
 			done
 		;;
+		threaded)
+			for test in "${threaded_tests[@]}"; do
+				cs_test "$test"
+			done
+		;;
 		*)
 			errcho "Unknown test set: ${ts}"
 			exit 1
@@ -891,7 +905,7 @@ function usage {
 	errcho -e " -v\tprint output of failing"
 	errcho -e " -vv\tprint output of failing/notrun"
 	errcho -e " -vvv\tprint output of failing/notrun/passing"
-	errcho -e " -t\ttest set(s): all,quick,unit,functional,standard,short,complex (default quick)"
+	errcho -e " -t\ttest set(s): all,quick,unit,functional,standard,short,complex,threaded (default quick)"
 	errcho -e " -e\texclude tests: comma delimited list of test names /
 			 regex patterns e.g. \"dgram,rma.*write\""
 	errcho -e " -E\texport provided variable name and value to ssh client and server processes.

--- a/fabtests/test_configs/efa/efa.exclude
+++ b/fabtests/test_configs/efa/efa.exclude
@@ -86,3 +86,5 @@ dgram_bw
 # Multinode tests failing with an unsupported address format
 multinode
 
+# rdm_bw_mt not supported yet
+rdm_bw_mt

--- a/fabtests/test_configs/psm3/psm3.exclude
+++ b/fabtests/test_configs/psm3/psm3.exclude
@@ -16,3 +16,6 @@ shared_av
 rdm_cntr_pingpong
 multi_recv
 multinode
+
+# rdm_bw_mt disabled because of malloc(): corrupted top size
+fi_rdm_bw_mt

--- a/fabtests/test_configs/tcp/io_uring.exclude
+++ b/fabtests/test_configs/tcp/io_uring.exclude
@@ -117,3 +117,6 @@ fi_multinode -x rma
 
 # multi_recv -e rdm fails by hanging
 multi_recv -e rdm
+
+# rdm_bw_mt fails because io_uring is broken
+rdm_bw_mt


### PR DESCRIPTION
This test creates a 1:1 relationship of num_eps:num_threads
where parallel sends ep[n] <-> ep[n] happen on each thread.

This code also comes with a TODO detailed in rdm_bw_mt.c.
Essentially the fabtests common code needs to be refactored
to make all fabric_resouces and buffer_resources objectified
instead of global variables. Once this happens more tests like
this can use the common code and submit a fabric_resources
object with a buffer_resources object to a common call so it
uses the passed in resources instead of the global ones.

This refactoring will take place in a later Pull-Request but
for now it is important to get this test enabled in CI and
the refactoring can happen later.