### PR TITLE
prov/verbs: Reload the list of interfaces on each call to fi_getinfo()

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -159,7 +159,7 @@ typedef void (*ofi_alter_info_t)(uint32_t version,
 
 struct util_prov {
 	const struct fi_provider	*prov;
-	const struct fi_info		*info;
+	struct fi_info			*info;
 	ofi_alter_info_t		alter_defaults;
 	const int			flags;
 };

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -156,6 +156,7 @@ typedef struct fid *fid_t;
 #define FI_COMMIT_COMPLETE	(1ULL << 30)
 #define FI_MATCH_COMPLETE	(1ULL << 31)
 
+#define FI_RESCAN		(1ULL << 35)
 #define FI_PEER_TRANSFER	(1ULL << 36)
 /* #define FI_MR_DMABUF		(1ULL << 40) */
 #define FI_AV_USER_ID		(1ULL << 41)

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -691,6 +691,10 @@ input flags.  Valid flags include the following.
   the node and/or service parameter must be non-NULL.  This flag is
   often used with passive endpoints.
 
+*FI_RESCAN*
+: Indicates that the provider should rescan available network interfaces.
+  This operation may be computationally expensive.
+
 # RETURN VALUE
 
 fi_getinfo() returns 0 on success. On error, fi_getinfo() returns a

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -85,13 +85,14 @@
 #define RXD_INLINE		(1 << 5)
 #define RXD_MULTI_RECV		(1 << 6)
 
-#define RXD_IDX_OFFSET(x)	(x + 1)	
+#define RXD_IDX_OFFSET(x)	(x + 1)
 
 struct rxd_env {
 	int spin_count;
 	int retry;
 	int max_peers;
 	int max_unacked;
+	int rescan;
 };
 
 extern struct rxd_env rxd_env;
@@ -158,7 +159,7 @@ struct rxd_av {
 
 	int dg_av_used;
 	size_t dg_addrlen;
-	struct indexer fi_addr_idx;	
+	struct indexer fi_addr_idx;
 	struct indexer rxdaddr_dg_idx;
 	struct index_map rxdaddr_fi_idm;
 };

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -308,6 +308,18 @@ static struct fi_ops_domain vrb_dgram_domain_ops = {
 	.query_collective = fi_no_query_collective,
 };
 
+static struct fi_info *
+vrb_get_verbs_info(const char *domain_name)
+{
+	const struct fi_info *fi;
+
+	for (fi = vrb_util_prov.info; fi; fi = fi->next) {
+		if (!strcmp(fi->domain_attr->name, domain_name))
+			return fi_dupinfo(fi);
+	}
+
+	return NULL;
+}
 
 static int
 vrb_domain(struct fid_fabric *fabric, struct fi_info *info,
@@ -325,8 +337,7 @@ vrb_domain(struct fid_fabric *fabric, struct fi_info *info,
 	struct vrb_fabric *fab =
 		 container_of(fabric, struct vrb_fabric,
 			      util_fabric.fabric_fid);
-	struct fi_info *fi = vrb_get_verbs_info(vrb_util_prov.info,
-						info->domain_attr->name);
+	struct fi_info *fi = vrb_get_verbs_info(info->domain_attr->name);
 	if (!fi)
 		return -FI_EINVAL;
 

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -44,14 +44,14 @@ struct vrb_sidr_conn_key {
 	bool			recip;
 };
 
-const struct fi_info *
+struct fi_info *
 vrb_get_verbs_info(const struct fi_info *ilist, const char *domain_name)
 {
 	const struct fi_info *fi;
 
 	for (fi = ilist; fi; fi = fi->next) {
 		if (!strcmp(fi->domain_attr->name, domain_name))
-			return fi;
+			return fi_dupinfo(fi);
 	}
 
 	return NULL;

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -44,19 +44,6 @@ struct vrb_sidr_conn_key {
 	bool			recip;
 };
 
-struct fi_info *
-vrb_get_verbs_info(const struct fi_info *ilist, const char *domain_name)
-{
-	const struct fi_info *fi;
-
-	for (fi = ilist; fi; fi = fi->next) {
-		if (!strcmp(fi->domain_attr->name, domain_name))
-			return fi_dupinfo(fi);
-	}
-
-	return NULL;
-}
-
 static ssize_t
 vrb_eq_readerr(struct fid_eq *eq, struct fi_eq_err_entry *entry,
 		  uint64_t flags)

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -1818,13 +1818,13 @@ out:
 static int vrb_get_match_infos(uint32_t version, const char *node,
 				  const char *service, uint64_t flags,
 				  const struct fi_info *hints,
-				  const struct fi_info **raw_info,
+				  const struct fi_info *raw_info,
 				  struct fi_info **info)
 {
 	int ret, ret_sock_addr = -FI_ENODATA, ret_ib_ud_addr = -FI_ENODATA;
 
 	// TODO check for AF_IB addr
-	ret = vrb_get_matching_info(version, hints, info, *raw_info,
+	ret = vrb_get_matching_info(version, hints, info, raw_info,
 				       ofi_is_wildcard_listen_addr(node, service,
 								   flags, hints));
 	if (ret)
@@ -1927,7 +1927,7 @@ int vrb_getinfo(uint32_t version, const char *node, const char *service,
 
 	ret = vrb_get_match_infos(version, node, service,
 				     flags, hints,
-				     &vrb_util_prov.info, info);
+				     vrb_util_prov.info, info);
 	ofi_mutex_unlock(&vrb_info_mutex);
 	if (ret)
 		goto out;

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -1349,7 +1349,7 @@ static int vrb_device_has_ipoib_addr(const char *dev_name)
 
 #define VERBS_NUM_DOMAIN_TYPES		3
 
-static int vrb_init_info(const struct fi_info **all_infos)
+static int vrb_init_info(struct fi_info **all_infos)
 {
 	struct ibv_context **ctx_list;
 	struct fi_info *fi = NULL, *tail = NULL;

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -1358,7 +1358,7 @@ static int vrb_init_info(const struct fi_info **all_infos)
 	static bool initialized = false;
 
 	vrb_prof_func_start(__func__);
-	ofi_mutex_lock(&vrb_init_mutex);
+	ofi_mutex_lock(&vrb_info_mutex);
 
 	if (initialized)
 		goto done;
@@ -1487,7 +1487,7 @@ static int vrb_init_info(const struct fi_info **all_infos)
 	rdma_free_devices(ctx_list);
 done:
 	vrb_prof_func_end(__func__);
-	ofi_mutex_unlock(&vrb_init_mutex);
+	ofi_mutex_unlock(&vrb_info_mutex);
 	return ret;
 }
 

--- a/prov/verbs/src/verbs_init.c
+++ b/prov/verbs/src/verbs_init.c
@@ -96,7 +96,7 @@ struct util_prov vrb_util_prov = {
 };
 
 /* mutex for guarding the initialization of vrb_util_prov.info */
-ofi_mutex_t vrb_init_mutex;
+ofi_mutex_t vrb_info_mutex;
 
 int vrb_sockaddr_len(struct sockaddr *addr)
 {
@@ -791,7 +791,7 @@ static void vrb_fini(void)
 	ofi_hmem_cleanup();
 	ofi_mem_fini();
 #endif
-	ofi_mutex_destroy(&vrb_init_mutex);
+	ofi_mutex_destroy(&vrb_info_mutex);
 	fi_freeinfo((void *)vrb_util_prov.info);
 	verbs_devs_free();
 	vrb_os_fini();
@@ -805,7 +805,7 @@ VERBS_INI
 	ofi_hmem_init();
 	ofi_monitors_init();
 #endif
-	ofi_mutex_init(&vrb_init_mutex);
+	ofi_mutex_init(&vrb_info_mutex);
 
 	vrb_prof_init();
 

--- a/prov/verbs/src/verbs_init.c
+++ b/prov/verbs/src/verbs_init.c
@@ -792,7 +792,7 @@ static void vrb_fini(void)
 	ofi_mem_fini();
 #endif
 	ofi_mutex_destroy(&vrb_info_mutex);
-	fi_freeinfo((void *)vrb_util_prov.info);
+	fi_freeinfo(vrb_util_prov.info);
 	verbs_devs_free();
 	vrb_os_fini();
 	vrb_util_prov.info = NULL;

--- a/prov/verbs/src/verbs_ofi.h
+++ b/prov/verbs/src/verbs_ofi.h
@@ -173,7 +173,7 @@ typedef void  vrb_profile_t;
 extern struct fi_provider vrb_prov;
 extern struct util_prov vrb_util_prov;
 extern ofi_mutex_t vrb_info_mutex;
-extern struct dlist_entry verbs_devs;
+extern struct dlist_entry vrb_devs;
 
 extern struct vrb_gl_data {
 	int	def_tx_size;
@@ -858,7 +858,8 @@ int vrb_ep_destroy_xrc_qp(struct vrb_xrc_ep *ep);
 
 int vrb_xrc_close_srq(struct vrb_srx *srx);
 
-int vrb_read_params(void);
+int vrb_init(void);
+void vrb_devs_free(struct dlist_entry *verbs_devs);
 int vrb_getinfo(uint32_t version, const char *node, const char *service,
 		   uint64_t flags, const struct fi_info *hints,
 		   struct fi_info **info);

--- a/prov/verbs/src/verbs_ofi.h
+++ b/prov/verbs/src/verbs_ofi.h
@@ -270,10 +270,9 @@ struct verbs_dev_info {
 	struct dlist_entry addrs;
 };
 
-
 struct vrb_fabric {
 	struct util_fabric	util_fabric;
-	const struct fi_info	*info;
+	struct fi_info		*info;
 	struct util_ns		name_server;
 };
 
@@ -863,8 +862,8 @@ int vrb_read_params(void);
 int vrb_getinfo(uint32_t version, const char *node, const char *service,
 		   uint64_t flags, const struct fi_info *hints,
 		   struct fi_info **info);
-const struct fi_info *vrb_get_verbs_info(const struct fi_info *ilist,
-					    const char *domain_name);
+struct fi_info *vrb_get_verbs_info(const struct fi_info *ilist,
+				   const char *domain_name);
 int vrb_set_rai(uint32_t addr_format, void *src_addr, size_t src_addrlen,
 		void *dest_addr, size_t dest_addrlen, uint64_t flags,
 		struct rdma_addrinfo *rai);

--- a/prov/verbs/src/verbs_ofi.h
+++ b/prov/verbs/src/verbs_ofi.h
@@ -862,8 +862,6 @@ int vrb_read_params(void);
 int vrb_getinfo(uint32_t version, const char *node, const char *service,
 		   uint64_t flags, const struct fi_info *hints,
 		   struct fi_info **info);
-struct fi_info *vrb_get_verbs_info(const struct fi_info *ilist,
-				   const char *domain_name);
 int vrb_set_rai(uint32_t addr_format, void *src_addr, size_t src_addrlen,
 		void *dest_addr, size_t dest_addrlen, uint64_t flags,
 		struct rdma_addrinfo *rai);

--- a/prov/verbs/src/verbs_ofi.h
+++ b/prov/verbs/src/verbs_ofi.h
@@ -172,7 +172,7 @@ typedef void  vrb_profile_t;
 
 extern struct fi_provider vrb_prov;
 extern struct util_prov vrb_util_prov;
-extern ofi_mutex_t vrb_init_mutex;
+extern ofi_mutex_t vrb_info_mutex;
 extern struct dlist_entry verbs_devs;
 
 extern struct vrb_gl_data {


### PR DESCRIPTION
The verbs provider loads the list of verbs devices available on the node
only once, on the first call to fi_getinfo().
If a network device is added (hot-plugged) after this initial call to
fi_getinfo(), it won't be visible in libfabric.

A subsidiary problem is that fi_getinfo() only returns network
adapters with active links.
If the link is initially inactive and becomes active after the first call to
fi_getinfo(), this interface will not be visible in libfabric.

This is a particularly a problem for long-running services where restarting
a process to discover newly added network devices is not an option.

With this patch, the list of verbs interfaces is reloaded on each call
to fi_getinfo().

Fixes #10881

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>
