### PR TITLE
prov/verbs: Memory leak for address formats different than FI_ADDR_IB_UD

### DIFF
--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -1727,18 +1727,21 @@ static int vrb_handle_ib_ud_addr(const char *node, const char *service,
 	uint32_t fmt = FI_FORMAT_UNSPEC;
 	int svc = VERBS_IB_UD_NS_ANY_SERVICE, ret = FI_SUCCESS;
 
-	if (node && !ofi_str_toaddr(node, &fmt, &addr, &len) &&
-	    fmt == FI_ADDR_IB_UD) {
-		if (flags & FI_SOURCE) {
-			src_addr = addr;
-			VERBS_INFO_NODE_2_UD_ADDR(FI_LOG_CORE, node,
-						  svc, src_addr);
+	if (node && !ofi_str_toaddr(node, &fmt, &addr, &len)) {
+		if (fmt == FI_ADDR_IB_UD) {
+			if (flags & FI_SOURCE) {
+				src_addr = addr;
+				VERBS_INFO_NODE_2_UD_ADDR(FI_LOG_CORE, node,
+							  svc, src_addr);
+			} else {
+				dest_addr = addr;
+				VERBS_INFO_NODE_2_UD_ADDR(FI_LOG_CORE, node,
+							  svc, dest_addr);
+			}
+			node = NULL;
 		} else {
-			dest_addr = addr;
-			VERBS_INFO_NODE_2_UD_ADDR(FI_LOG_CORE, node,
-						  svc, dest_addr);
+			free(addr);
 		}
-		node = NULL;
 	}
 
 	if (!src_addr) {


### PR DESCRIPTION
ofi_str_toaddr() allocates memory to store the address (pointed by 'addr'),
but this memory is not freed if the address format is different than FI_ADDR_IB_UD.

Leak detected by ASAN:
```
Direct leak of 16 byte(s) in 1 object(s) allocated from:
0 0xfffff78e095c in calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:77
1 0xfffff712d700 in ofi_hostname_toaddr src/common.c:825
2 0xfffff712dfbc in ofi_str_toaddr src/common.c:895
3 0xfffff72ced04 in vrb_handle_ib_ud_addr prov/verbs/src/verbs_info.c:1730
4 0xfffff72d018c in vrb_get_match_infos prov/verbs/src/verbs_info.c:1847
5 0xfffff72d0ab0 in vrb_getinfo prov/verbs/src/verbs_info.c:1924
6 0xfffff7102758 in fi_getinfo_ src/fabric.c:1377
7 0xfffff718b988 in ofi_get_core_info prov/util/src/util_attr.c:330
8 0xfffff718bbdc in ofix_getinfo prov/util/src/util_attr.c:353
9 0xfffff74aed78 in rxd_getinfo prov/rxd/src/rxd_init.c:122
10 0xfffff7102758 in fi_getinfo_ src/fabric.c:1377
11 0xaaaaaaaa5ebc in getinfo_unit_test unit/getinfo_test.c:714
12 0xaaaaaaaa6aa4 in getinfo_no_hints2 unit/getinfo_test.c:782
13 0xaaaaaaaa7ac4 in run_tests unit/common.c:66
14 0xaaaaaaaa5750 in main unit/getinfo_test.c:1007
15 0xfffff6e684c0 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
16 0xfffff6e68594 in __libc_start_main_impl ../csu/libc-start.c:360
```

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>
