### PR TITLE
fabtests/efa: Do not set multinode marker for test_efa_shm_addr

### DIFF
--- a/fabtests/pytest/efa/test_efa_shm_addr.py
+++ b/fabtests/pytest/efa/test_efa_shm_addr.py
@@ -2,7 +2,6 @@ from common import MultinodeTest
 import pytest
 
 
-@pytest.mark.multinode
 def test_efa_shm_addr(cmdline_args, fabric):
     server_id = cmdline_args.server_id
     client_id = cmdline_args.client_id


### PR DESCRIPTION
The test only uses 2 nodes, so it's not a multinode test