### PR TITLE
prov/efa: Add efa_mr_map_insert

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -293,6 +293,8 @@ int ofi_mr_map_init(const struct fi_provider *in_prov, int mode,
 		    struct ofi_mr_map *map);
 void ofi_mr_map_close(struct ofi_mr_map *map);
 
+struct fi_mr_attr *ofi_mr_dup_attr(const struct fi_mr_attr *attr,
+				   uint64_t flags);
 int ofi_mr_map_insert(struct ofi_mr_map *map,
 		      const struct fi_mr_attr *attr,
 		      uint64_t *key, void *context,

--- a/prov/util/src/util_mr_map.c
+++ b/prov/util/src/util_mr_map.c
@@ -37,9 +37,8 @@
 #include "ofi_hmem.h"
 #include <assert.h>
 
-
-static struct fi_mr_attr *
-dup_mr_attr(const struct fi_mr_attr *attr, uint64_t flags)
+struct fi_mr_attr *ofi_mr_dup_attr(const struct fi_mr_attr *attr,
+				   uint64_t flags)
 {
 	struct fi_mr_attr *dup_attr;
 
@@ -52,7 +51,7 @@ dup_mr_attr(const struct fi_mr_attr *attr, uint64_t flags)
 	dup_attr->mr_iov = (struct iovec *) (dup_attr + 1);
 
 	/*
-	 * dup_mr_attr is only used insided ofi_mr_map_insert.
+	 * ofi_mr_dup_attr is only used insided ofi_mr_map_insert.
 	 * dmabuf must be converted to iov before the attr
 	 * is inserted to the mr_map
 	 */
@@ -72,7 +71,7 @@ int ofi_mr_map_insert(struct ofi_mr_map *map, const struct fi_mr_attr *attr,
 	struct fi_mr_attr *item;
 	int ret;
 
-	item = dup_mr_attr(attr, flags);
+	item = ofi_mr_dup_attr(attr, flags);
 	if (!item)
 		return -FI_ENOMEM;
 


### PR DESCRIPTION
ofi_mr_map_insert ignores the mr if remote access permissions are
not asked for, but EFA provider needs to add all memory regions
to the util MR map because read based message protocols might be
used for local operations, where application does not set
FI_REMOTE_READ in mr_attr->access.
We also need it for cuda memory so that we can recover from the
FI_ENOKEY error after cudaFree.