### PR TITLE
.gitignore: Add vscode clangd compilation database file and directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ fabtests/pytest/*/__pycache__
 prov/efa/docs/doxygen/html
 prov/efa/docs/doxygen/latex
 
+# Clang's compilation database file and directory.
+/.cache
+/compile_commands.json


### PR DESCRIPTION
The tool 'bear'[1] can be used to generate the C language server protocol database file while compiling: 'bear -- make -j $(nproc)'

The clangd will parse the compile_commands.json language metadata into the .cache directory. Add it for clean git status track.

[1]: https://github.com/rizsotto/Bear