### PR TITLE
av: introduce FI_FIREWALL_ADDR flag for insert operations

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -159,6 +159,7 @@ typedef struct fid *fid_t;
 #define FI_PEER_TRANSFER	(1ULL << 36)
 /* #define FI_MR_DMABUF		(1ULL << 40) */
 #define FI_AV_USER_ID		(1ULL << 41)
+#define FI_FIREWALL_ADDR	(1ULL << 42)
 #define FI_PEER			(1ULL << 43)
 /* #define FI_XPU_TRIGGER		(1ULL << 44) */
 

--- a/man/fi_av.3.md
+++ b/man/fi_av.3.md
@@ -436,6 +436,16 @@ fi_av_set_user_id.
 
   See the user ID section below.
 
+- *FI_FIREWALL_ADDR*
+: This flag indicates that the address is behind a firewall and outgoing
+  connections are not allowed. If there is not an existing connection and the
+  provider is unable to circumvent the firewall, an FI_EHOSTUNREACH error
+  should be expected. If multiple addresses are being inserted simultaneously,
+  the flag applies to all of them. Additionally, it is possible that a
+  connection is available at insertion time, but is later torn down. Future
+  reconnects triggered by operations on the ep (fi_send, for example) may also
+  fail with the same error.
+
 ## fi_av_insertsvc
 
 The fi_av_insertsvc call behaves similar to fi_av_insert, but allows the


### PR DESCRIPTION
FI_FIREWALL_ADDR indicates to the provider that the inserted addresses may be restricted by a firewall.