### PR TITLE
prov/verbs: Enable logging of ibv_async_events

### DIFF
--- a/prov/verbs/src/verbs_ofi.h
+++ b/prov/verbs/src/verbs_ofi.h
@@ -329,6 +329,8 @@ struct vrb_eq {
 
 	ofi_epoll_t		epollfd;
 	enum fi_wait_obj	wait_obj;
+	ofi_atomic32_t		ref;
+
 
 	struct {
 		/* The connection key map is used during the XRC connection
@@ -435,6 +437,9 @@ struct vrb_domain {
 	/* for profiling */
 	vrb_profile_t		*profile;
 };
+
+int vrb_eq_attach_domain(struct vrb_eq *eq, struct vrb_domain *domain);
+int vrb_eq_detach_domain(struct vrb_domain *domain);
 
 struct vrb_cq;
 

--- a/prov/verbs/src/windows/verbs_nd_ibv.c
+++ b/prov/verbs/src/windows/verbs_nd_ibv.c
@@ -137,6 +137,33 @@ const char *ibv_get_device_name(struct ibv_device *device)
 	return device->name;
 }
 
+/*
+ * async event methods are implemented for compatibility
+ * but are not currently supported
+*/
+
+int ibv_get_async_event(struct ibv_context *context,
+			struct ibv_async_event *event)
+{
+	VRB_TRACE(FI_LOG_FABRIC, "\n");
+	/*
+	* Normally we use ENOSYS for unsupported features
+	* but ibv_get_async_event returns only -1 for any error.
+	*/
+	return -1;
+}
+
+void ibv_ack_async_event(struct ibv_async_event *event)
+{
+	VRB_TRACE(FI_LOG_FABRIC, "\n");
+}
+
+const char *ibv_event_type_str(enum ibv_event_type event)
+{
+	VRB_TRACE(FI_LOG_FABRIC, "\n");
+	return NULL;
+}
+
 // infiniband/verbs.h defines ibv_query_port to be ___ibv_query_port
 int ___ibv_query_port(struct ibv_context *context, uint8_t port_num,
 		      struct ibv_port_attr *port_attr)


### PR DESCRIPTION
This change enhances the verbs EQ to poll for ibv async events, which
notify the user of device state changes and errors.

As this is primarily focused on enhancing the debugging experience,
for now, events are only logged as they are read during EQ progress
and no action is taken.

(edit: PR summary updated to match commit message)

implements #10852 