### PR TITLE
.github/workflows: Update rdma-core version to v35.0

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   contents: read
-  
+
 env:
   APT_PACKAGES: >-
     abi-compliance-checker
@@ -43,7 +43,7 @@ env:
     --enable-sm2
     --enable-lpp
   RDMA_CORE_PATH: 'rdma-core/build'
-  RDMA_CORE_VERSION: v34.1
+  RDMA_CORE_VERSION: v35.0
 jobs:
   coverity:
     runs-on: ubuntu-20.04

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -39,7 +39,7 @@ env:
     --enable-verbs=$PWD/rdma-core/build
     --enable-lpp
   RDMA_CORE_PATH: '$PWD/rdma-core/build'
-  RDMA_CORE_VERSION: v34.1
+  RDMA_CORE_VERSION: v35.0
 jobs:
   linux:
     runs-on: '${{ matrix.os }}'


### PR DESCRIPTION
v34.1 cannot build anymore because cmake version is too low. Update to latest v56.0 to fix this.