### PR TITLE
prov/cxi: added new optional feature to enable accelerated collectives when building libfabric

### DIFF
--- a/prov/cxi/configure.m4
+++ b/prov/cxi/configure.m4
@@ -44,6 +44,18 @@ AC_DEFUN([FI_CXI_CONFIGURE],[
 	AC_ARG_WITH([json-c],
 		[AS_HELP_STRING([--with-json-c=DIR], [Install directory for json-c])])
 
+	# Support for collectives dlopen/dlsym of curl libs.
+	coll_dlopen=0
+	AC_ARG_ENABLE([coll-dlopen],
+        [AS_HELP_STRING([--enable-coll-dlopen], [Enable collectives and dlopen of required curl libraries @<:@default=no@:>@])],
+        [
+               # Fail if --with_dlopen is not set
+               AS_IF([test "$with_dlopen" = "no"], [AC_MSG_ERROR([dlopen not found.  libfabric requires libdl.])])
+	       AS_IF([test "$enable_coll_dlopen" != "no"], [coll_dlopen=1])
+        ])
+        # define and set ENABLE_COLL_DLOPEN
+        AC_DEFINE_UNQUOTED([ENABLE_COLL_DLOPEN], [$coll_dlopen], [dlopen curl libraries for collectives])
+
 	AS_IF([test x"$enable_cxi" != x"no"],
 		[
 			AC_CHECK_HEADER(cxi_prov_hw.h,

--- a/prov/cxi/src/cxip_coll.c
+++ b/prov/cxi/src/cxip_coll.c
@@ -4022,6 +4022,13 @@ int cxip_join_collective(struct fid_ep *ep, fi_addr_t coll_addr,
 	bool link_zb;
 	int ret;
 
+#if ENABLE_COLL_DLOPEN
+	TRACE_JOIN("%s: Collectives are enabled\n", __func__);
+#else
+	TRACE_JOIN("%s: Collectives are disabled, --enable-coll-dlopen needs to be set to enable collectives\n", __func__);
+	return -FI_EOPNOTSUPP;
+#endif
+
 	check_red_pkt();
 
 	TRACE_JOIN("%s: entry\n", __func__);

--- a/prov/cxi/src/cxip_curl.c
+++ b/prov/cxi/src/cxip_curl.c
@@ -177,8 +177,9 @@ struct curlfunc curlary[] = {
 	{NULL, NULL}
 };
 
-int cxip_curl_load_symbols(void)
+static int cxip_curl_load_symbols(void)
 {
+#if ENABLE_COLL_DLOPEN
 	struct curlfunc *funcptr;
 	char *libfile = NULL, *libpath;
 	int version;
@@ -263,6 +264,12 @@ int cxip_curl_load_symbols(void)
 	}
 	/* record handle to prevent reloading */
 	cxip_curlhandle = h;
+#else	/* Collectives are disabled, log it */ 
+	TRACE_CURL("Accelerated collectives cannot be enabled, libcurl not supported\n");
+	CXIP_WARN("Accelerated collectives cannot be enabled, libcurl not supported\n");
+	CXIP_WARN("Accelerated collectives cannot be enabled, libcurl not supported\n");
+	return -FI_EOPNOTSUPP;
+#endif	/* end ENABLE_COLL_DLOPEN */
 	return 0;
 }
 

--- a/prov/cxi/src/cxip_dom.c
+++ b/prov/cxi/src/cxip_dom.c
@@ -1642,6 +1642,13 @@ static int cxip_query_collective(struct fid_domain *domain,
 {
 	int ext_op;
 
+#if ENABLE_COLL_DLOPEN
+	CXIP_WARN("%s: Collectives are enabled\n", __func__);
+#else
+	CXIP_WARN("%s: Collectives are disabled, --enable-coll-dlopen needs to be set to enable collectives\n", __func__);
+	return -FI_EOPNOTSUPP;
+#endif
+
 	/* BARRIER does not require attr */
 	if (coll == FI_BARRIER && !attr)
 		return FI_SUCCESS;


### PR DESCRIPTION
Disabled by default: This feature was needed to prevent curl lib dlopen/dlsym failures during collectives init and runtime errors when building a multicast address in the switch. If we do not have curl symbols to support accelerated collectives, the feature will be disabled.