### PR TITLE
contrib/intel/jenkins: Modify env var withEnv instead of '='

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -4,6 +4,7 @@ properties([disableConcurrentBuilds(abortPrevious: true)])
 @Field def DO_RUN=true
 @Field def RELEASE=false
 @Field def weekly=false
+@Field def CTARGET="main"
 
 def checkout_upstream() {
   def loc = "${env.WORKSPACE}/upstream/libfabric"
@@ -14,7 +15,7 @@ def checkout_upstream() {
       rm -rf ${env.WORKSPACE}/upstream && mkdir -p ${loc}
     fi
 
-    git clone --branch ${env.TARGET} ${env.UPSTREAM} ${loc}
+    git clone --branch ${CTARGET} ${env.UPSTREAM} ${loc}
   """
 }
 
@@ -114,12 +115,12 @@ def checkout_tar(name) {
   weekly = env.WEEKLY != null ? env.WEEKLY.toBoolean() : false
   def weekly_target = env.WEEKLY_TARGET != null ? env.WEEKLY_TARGET : "main"
   def change_target = env.CHANGE_TARGET != null ? env.CHANGE_TARGET : "main"
+  CTARGET = weekly ? weekly_target : change_target
   dir ("${env.CUSTOM_WORKSPACE}/${name}/libfabric") {
     checkout scm
-    env.TARGET = weekly ? weekly_target : change_target
     sh """
       git remote add upstream ${env.UPSTREAM}
-      git pull --rebase upstream ${env.TARGET}
+      git pull --rebase upstream ${CTARGET}
     """
   }
   dir ("${env.CUSTOM_WORKSPACE}/${name}/") {
@@ -129,9 +130,9 @@ def checkout_tar(name) {
 
 def git_diffs() {
   dir ("${CUSTOM_WORKSPACE}/source/libfabric") {
-    sh "git diff --name-only HEAD..upstream/${env.TARGET} > ./commit_id"
-    sh "git diff upstream/${env.TARGET}:Makefile.am Makefile.am > ./Makefile.am.diff"
-    sh "git diff upstream/${env.TARGET}:configure.ac configure.ac > ./configure.ac.diff"
+    sh "git diff --name-only HEAD..upstream/${CTARGET} > ./commit_id"
+    sh "git diff upstream/${CTARGET}:Makefile.am Makefile.am > ./Makefile.am.diff"
+    sh "git diff upstream/${CTARGET}:configure.ac configure.ac > ./configure.ac.diff"
     sh "cat configure.ac | grep AC_INIT | cut -d ' ' -f 2 | cut -d '[' -f 2 | cut -d ']' -f 1 > ./release_num.txt"
   }
 }
@@ -854,15 +855,17 @@ pipeline {
         stage('CI_water_performance_regression') {
           steps {
             script {
-              dir (CI_LOCATION) {
-                def reg_file = "${env.LOG_DIR}/${env.WATER_REGRESSION_FILE}"
-                run_ci("CI_perf_regression_water", "pr_imb_perf_water.json")
-                sh """if [[ \$(wc -c < ${reg_file}) -gt 1 ]]; then \
-                      cat ${reg_file}
-                      echo \"Performance regression detected\"
-                      exit 1
-                    fi \
-                   """
+              withEnv(["TARGET=CTARGET"]) {
+                dir (CI_LOCATION) {
+                  def reg_file = "${env.LOG_DIR}/${env.WATER_REGRESSION_FILE}"
+                  run_ci("CI_perf_regression_water", "pr_imb_perf_water.json")
+                  sh """if [[ \$(wc -c < ${reg_file}) -gt 1 ]]; then \
+                        cat ${reg_file}
+                        echo \"Performance regression detected\"
+                        exit 1
+                      fi \
+                      """
+                }
               }
             }
           }


### PR DESCRIPTION
Jenkins doesn't let environment variables change with the '='. Instead we must use the withEnv block to update an environment variable for specific stages.