### PR TITLE
fabtests/benchmarks: Fix rdm_bw_mt unchecked fi_close return

### DIFF
--- a/fabtests/benchmarks/rdm_bw_mt.c
+++ b/fabtests/benchmarks/rdm_bw_mt.c
@@ -133,7 +133,7 @@ static void cleanup_ofi(void)
 	}
 
 	if (fabric) {
-		fi_close(&fabric->fid);
+		ret = fi_close(&fabric->fid);
 		if (ret)
 			printf("fi_close(fabric) failed: %d\n", ret);
 	}
@@ -545,10 +545,18 @@ static int run_size(void)
 
 out:
 	for (i = 0; i < num_eps; i++) {
-		if (targs[i].tx_mr)
-			fi_close(&targs[i].tx_mr->fid);
-		if (targs[i].rx_mr)
-			fi_close(&targs[i].rx_mr->fid);
+		if (targs[i].tx_mr) {
+			err = fi_close(&targs[i].tx_mr->fid);
+			if (err)
+				printf("fi_close(targs[%d].tx_mr) failed: %d\n",
+					i, err);
+		}
+		if (targs[i].rx_mr) {
+			err = fi_close(&targs[i].rx_mr->fid);
+			if (err)
+				printf("fi_close(targs[%d].rx_mr) failed: %d\n",
+					i, err);
+		}
 		if (targs[i].tx_buf) {
 			err = ft_hmem_free(opts.iface, targs[i].tx_buf);
 			if (err)


### PR DESCRIPTION
fi_close's return value isn't checked. Checking it and reporting as needed will satisfy coverity 459655, 459564, and 459563 issues.