### PR TITLE
man/verbs: clarify little endian limitation for verbs atomics

### DIFF
--- a/man/fi_verbs.7.md
+++ b/man/fi_verbs.7.md
@@ -151,6 +151,15 @@ requires the use of shared receive contexts. See [`fi_rxm`(7)](fi_rxm.7.html).
 To enable XRC, the following environment variables must usually be set:
 FI_VERBS_PREFER_XRC and FI_OFI_RXM_USE_SRX.
 
+### Atomics
+Mellanox hardware has limited support for atomics on little-endian machines as
+the result buffer will be delivered back to the caller in big-endian, requiring
+the caller to handle the conversion back into little-endian for use. This
+limitation is exposed in OFI as well which uses the verbs atomic support
+directly. Use of atomics on Mellanox cards on little-endian machines is allowed
+but users should make note of this verbs limitation and do any conversion
+necessary.
+
 # RUNTIME PARAMETERS
 
 The verbs provider checks for the following environment variables.


### PR DESCRIPTION
According to Mellanox documentation, atomics have limited support on little endian machines and the result buffer will remain in big endian, requiring the caller to handle conversion. Document this limitation in the man pages as this will show up in OFI verbs atomics results as well

Fixes #10911 10911