### PR TITLE
Revert "prov/cxi: added new optional feature to enable accelerated co…

### DIFF
--- a/prov/cxi/configure.m4
+++ b/prov/cxi/configure.m4
@@ -44,17 +44,6 @@ AC_DEFUN([FI_CXI_CONFIGURE],[
 	AC_ARG_WITH([json-c],
 		[AS_HELP_STRING([--with-json-c=DIR], [Install directory for json-c])])
 
-        # Support for collectives dlopen/dlsym of curl libs.
-        coll_enable=0
-        AC_ARG_ENABLE([cxi-collectives],
-        [AS_HELP_STRING([--enable-cxi-collectives], [Enable collectives and dlopen of required curl libraries @<:@default=no@:>@])],
-        [
-               AS_IF([test "$with_dlopen" = "no"], [AC_MSG_ERROR([dlopen not found.  libfabric requires libdl.])])
-               AS_IF([test "$enable_cxi_collectives" != "no"], [coll_enable=1])
-        ])
-        # define and set ENABLE_CXI_COLLECTIVES
-        AC_DEFINE_UNQUOTED([ENABLE_CXI_COLLECTIVES], [$coll_enable], [Enable collectives and dlopen curl libraries])
-
 	AS_IF([test x"$enable_cxi" != x"no"],
 		[
 			AC_CHECK_HEADER(cxi_prov_hw.h,

--- a/prov/cxi/src/cxip_coll.c
+++ b/prov/cxi/src/cxip_coll.c
@@ -4022,13 +4022,6 @@ int cxip_join_collective(struct fid_ep *ep, fi_addr_t coll_addr,
 	bool link_zb;
 	int ret;
 
-#if ENABLE_CXI_COLLECTIVES
-	TRACE_JOIN("%s: CXI Collectives are enabled\n", __func__);
-#else
-	TRACE_JOIN("%s: CXI Collectives are disabled, --enable-cxi-collectives needs to be set\n", __func__);
-	return -FI_EOPNOTSUPP;
-#endif
-
 	check_red_pkt();
 
 	TRACE_JOIN("%s: entry\n", __func__);

--- a/prov/cxi/src/cxip_curl.c
+++ b/prov/cxi/src/cxip_curl.c
@@ -177,9 +177,8 @@ struct curlfunc curlary[] = {
 	{NULL, NULL}
 };
 
-static int cxip_curl_load_symbols(void)
+int cxip_curl_load_symbols(void)
 {
-#if ENABLE_CXI_COLLECTIVES
 	struct curlfunc *funcptr;
 	char *libfile = NULL, *libpath;
 	int version;
@@ -264,11 +263,6 @@ static int cxip_curl_load_symbols(void)
 	}
 	/* record handle to prevent reloading */
 	cxip_curlhandle = h;
-#else	/* Collectives are disabled, log it */ 
-	TRACE_CURL("Accelerated collectives cannot be enabled, libcurl not supported\n");
-	CXIP_WARN("Accelerated collectives cannot be enabled, libcurl not supported\n");
-	return -FI_EOPNOTSUPP;
-#endif	/* end ENABLE_CXI_COLLECTIVES */
 	return 0;
 }
 

--- a/prov/cxi/src/cxip_dom.c
+++ b/prov/cxi/src/cxip_dom.c
@@ -1642,13 +1642,6 @@ static int cxip_query_collective(struct fid_domain *domain,
 {
 	int ext_op;
 
-#if ENABLE_CXI_COLLECTIVES
-	CXIP_WARN("%s: CXI Collectives are enabled\n", __func__);
-#else
-	CXIP_WARN("%s: CXI Collectives are disabled, --enable-collectives needs to be set\n", __func__);
-	return -FI_EOPNOTSUPP;
-#endif
-
 	/* BARRIER does not require attr */
 	if (coll == FI_BARRIER && !attr)
 		return FI_SUCCESS;


### PR DESCRIPTION
This reverts commit ea2d7f4f33299ed3d00f4a825511c48d5d321886. It was causing issues during cxi testing because collectives was disabled by default.