### PR TITLE
prov/tcp,rxm: Add a new error code for firewall

### DIFF
--- a/include/rdma/fi_errno.h
+++ b/include/rdma/fi_errno.h
@@ -195,6 +195,7 @@ enum {
 	FI_EOVERRUN	 = 268, /* Queue has been overrun */
 	FI_ENORX	 = 269, /* Receiver not ready, no receive buffers available */
 	FI_ENOMR	 = 270, /* No more memory registrations available */
+	FI_EFIREWALLADDR = 271, /* Host unreachable because it is behind firewall */
 	FI_ERRNO_MAX
 };
 

--- a/man/fi_av.3.md
+++ b/man/fi_av.3.md
@@ -439,7 +439,7 @@ fi_av_set_user_id.
 - *FI_FIREWALL_ADDR*
 : This flag indicates that the address is behind a firewall and outgoing
   connections are not allowed. If there is not an existing connection and the
-  provider is unable to circumvent the firewall, an FI_EHOSTUNREACH error
+  provider is unable to circumvent the firewall, an FI_EFIREWALLADDR error
   should be expected. If multiple addresses are being inserted simultaneously,
   the flag applies to all of them. Additionally, it is possible that a
   connection is available at insertion time, but is later torn down. Future

--- a/man/fi_errno.3.md
+++ b/man/fi_errno.3.md
@@ -187,6 +187,9 @@ const char *fi_strerror(int errno);
 *FI_ENOMR*
 : Memory registration limit exceeded
 
+*FI_EFIREWALLADDR*
+: Host address unreachable due to firewall
+
 # SEE ALSO
 
 [`fabric`(7)](fabric.7.html)

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -461,7 +461,7 @@ ssize_t rxm_get_conn(struct rxm_ep *ep, fi_addr_t addr, struct rxm_conn **conn)
 	}
 
 	if ((*peer)->firewall_addr)
-		return -FI_EHOSTUNREACH;
+		return -FI_EFIREWALLADDR;
 
 	ret = rxm_connect(*conn);
 

--- a/prov/tcp/src/xnet_rdm_cm.c
+++ b/prov/tcp/src/xnet_rdm_cm.c
@@ -375,7 +375,7 @@ ssize_t xnet_get_conn(struct xnet_rdm *rdm, fi_addr_t addr,
 				"warn: peer %s is behind firewall\n",
 				(*peer)->str_addr);
 
-			return -FI_EHOSTUNREACH;
+			return -FI_EFIREWALLADDR;
 		}
 
 		ret = xnet_rdm_connect(*conn);

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -1658,6 +1658,7 @@ static const char *const errstr[] = {
 	[FI_EOVERRUN - FI_ERRNO_OFFSET] = "Queue has been overrun",
 	[FI_ENORX - FI_ERRNO_OFFSET] = "Receiver not ready, no receive buffers available",
 	[FI_ENOMR - FI_ERRNO_OFFSET] = "Memory registration limit exceeded",
+	[FI_EFIREWALLADDR - FI_ERRNO_OFFSET] = "Host unreacheable due to firewall",
 };
 
 __attribute__((visibility ("default"),EXTERNALLY_VISIBLE))


### PR DESCRIPTION
This PR adds a new error code FI_EFIREWALLADDR to specify that the dest host is unreachable due to firewall.