### PR TITLE
prov/tcp: fix flag and memory out of bound access

### DIFF
--- a/prov/tcp/src/xnet.h
+++ b/prov/tcp/src/xnet.h
@@ -270,6 +270,13 @@ struct xnet_ep {
 	xnet_profile_t *profile;
 };
 
+/* Must be castable to struct fi_eq_cm_entry */
+struct xnet_cm_entry {
+	fid_t fid;
+	struct fi_info *info;
+	uint8_t data[XNET_MAX_CM_DATA_SIZE];
+};
+
 struct xnet_event {
 	struct slist_entry list_entry;
 	struct xnet_rdm *rdm;

--- a/prov/tcp/src/xnet_cm.c
+++ b/prov/tcp/src/xnet_cm.c
@@ -38,14 +38,6 @@
 #include <sys/types.h>
 #include <ofi_util.h>
 
-
-/* Must be castable to struct fi_eq_cm_entry */
-struct xnet_cm_entry {
-	fid_t			fid;
-	struct fi_info		*info;
-	uint8_t			data[XNET_MAX_CM_DATA_SIZE];
-};
-
 /* The underlying socket has the POLLIN event set.  The entire
  * CM message should be readable, as it fits within a single MTU
  * and is the first data transferred over the socket.

--- a/prov/tcp/src/xnet_ep.c
+++ b/prov/tcp/src/xnet_ep.c
@@ -272,7 +272,7 @@ xnet_ep_accept(struct fid_ep *ep_fid, const void *param, size_t paramlen)
 	struct xnet_progress *progress;
 	struct xnet_ep *ep;
 	struct xnet_conn_handle *conn;
-	struct fi_eq_cm_entry cm_entry;
+	struct xnet_cm_entry cm_entry;
 	int ret;
 
 	FI_DBG(&xnet_prov, FI_LOG_EP_CTRL, "accepting endpoint connection\n");
@@ -313,6 +313,8 @@ xnet_ep_accept(struct fid_ep *ep_fid, const void *param, size_t paramlen)
 
 	cm_entry.fid = &ep->util_ep.ep_fid.fid;
 	cm_entry.info = NULL;
+	if (paramlen)
+		memcpy(cm_entry.data, param, paramlen);
 	ret = xnet_eq_write(ep->util_ep.eq, FI_CONNECTED, &cm_entry,
 			    sizeof(cm_entry), 0);
 	if (ret < 0) {

--- a/prov/tcp/src/xnet_rdm_cm.c
+++ b/prov/tcp/src/xnet_rdm_cm.c
@@ -575,7 +575,7 @@ static void xnet_process_connected(struct fi_eq_cm_entry *cm_entry)
 	conn->remote_pid = ntohl(msg->pid);
 	xnet_set_protocol(conn->ep, msg);
 
-	FI_INFO(&xnet_prov, FI_LOG_EP_CTRL, "peer %s feautre supported: %x\n",
+	FI_INFO(&xnet_prov, FI_LOG_EP_CTRL, "peer %s feature supported: %x\n",
 		conn->peer->str_addr, msg->features);
 }
 

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -258,7 +258,7 @@ void *ofi_av_addr_context(struct util_av *av, fi_addr_t fi_addr)
 
 int ofi_verify_av_insert(struct util_av *av, uint64_t flags, void *context)
 {
-	if (flags & ~(FI_MORE | FI_SYNC_ERR)) {
+	if (flags & ~(FI_MORE | FI_SYNC_ERR | FI_FIREWALL_ADDR)) {
 		FI_WARN(av->prov, FI_LOG_AV, "unsupported flags\n");
 		return -FI_EBADFLAGS;
 	}


### PR DESCRIPTION
A change in ofi_verify_av_insert() is missed from the first PR. Without that change, mercury won't be able to insert or change flags for FI_FIREWALL_ADDR.

This PR also fixes an issue of out of bound memory access. In xnet_ep_accept(), it allocates the size of data structure `fi_eq_cm_entry{}` but `xnet_process_connected()` accesses it as `xnet_cm_entry{}` that is larger in size. This is not introduced by this series of PR but found it when I am doing the tests.