### PR TITLE
Support read only memory registrations

### DIFF
--- a/prov/cxi/include/cxip.h
+++ b/prov/cxi/include/cxip.h
@@ -2477,7 +2477,7 @@ struct cxip_ep_obj {
 };
 
 int cxip_ep_obj_map(struct cxip_ep_obj *ep, const void *buf, unsigned long len,
-		    uint64_t flags, struct cxip_md **md);
+		    uint64_t access, uint64_t flags, struct cxip_md **md);
 
 static inline void
 cxip_ep_obj_copy_to_md(struct cxip_ep_obj *ep, struct cxip_md *md, void *dest,
@@ -3264,7 +3264,7 @@ int cxip_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 int cxip_iomm_init(struct cxip_domain *dom);
 void cxip_iomm_fini(struct cxip_domain *dom);
 int cxip_map(struct cxip_domain *dom, const void *buf, unsigned long len,
-	     uint64_t flags, struct cxip_md **md);
+	     uint64_t access, uint64_t flags, struct cxip_md **md);
 void cxip_unmap(struct cxip_md *md);
 
 int cxip_ctrl_msg_send(struct cxip_ctrl_req *req);
@@ -3713,8 +3713,8 @@ cxip_txc_copy_from_hmem(struct cxip_txc *txc, struct cxip_md *hmem_md,
 	 */
 	if (!cxip_env.fork_safe_requested) {
 		if (!hmem_md) {
-			ret = cxip_ep_obj_map(txc->ep_obj, hmem_src, size, 0,
-					      &hmem_md);
+			ret = cxip_ep_obj_map(txc->ep_obj, hmem_src, size,
+					      CXI_MAP_READ, 0, &hmem_md);
 			if (ret) {
 				TXC_WARN(txc, "cxip_ep_obj_map failed: %d:%s\n",
 					 ret, fi_strerror(-ret));

--- a/prov/cxi/include/cxip.h
+++ b/prov/cxi/include/cxip.h
@@ -820,6 +820,7 @@ struct cxip_md {
 	struct cxip_domain *dom;
 	struct cxi_md *md;
 	struct ofi_mr_info info;
+	uint64_t map_flags;
 	uint64_t handle;
 	int dmabuf_fd;
 	bool handle_valid;

--- a/prov/cxi/src/cxip_atomic.c
+++ b/prov/cxi/src/cxip_atomic.c
@@ -613,7 +613,8 @@ static int cxip_amo_emit_idc(struct cxip_txc *txc,
 				result_md = result_mr->md;
 			} else {
 				ret = cxip_ep_obj_map(txc->ep_obj, result,
-						      atomic_type_len, 0,
+						      atomic_type_len,
+						      CXI_MAP_WRITE, 0,
 						      &req->amo.result_md);
 				if (ret) {
 					TXC_WARN_RET(txc, ret,
@@ -932,7 +933,8 @@ static int cxip_amo_emit_dma(struct cxip_txc *txc,
 		if (result) {
 			if (!result_mr) {
 				ret = cxip_ep_obj_map(txc->ep_obj, result,
-						      atomic_type_len, 0,
+						      atomic_type_len,
+						      CXI_MAP_WRITE, 0,
 						      &req->amo.result_md);
 				if (ret) {
 					TXC_WARN(txc,
@@ -1020,7 +1022,7 @@ static int cxip_amo_emit_dma(struct cxip_txc *txc,
 		} else {
 			/* Map user operand buffer for DMA command. */
 			ret = cxip_ep_obj_map(txc->ep_obj, buf,
-					      atomic_type_len, 0,
+					      atomic_type_len, CXI_MAP_READ, 0,
 					      &req->amo.oper1_md);
 			if (ret) {
 				TXC_WARN(txc,

--- a/prov/cxi/src/cxip_coll.c
+++ b/prov/cxi/src/cxip_coll.c
@@ -1271,7 +1271,8 @@ static int _coll_add_buffers(struct cxip_coll_pte *coll_pte, size_t size,
 			goto out;
 		}
 		ret = cxip_ep_obj_map(coll_pte->ep_obj, (void *)buf->buffer,
-				      size, 0, &buf->cxi_md);
+				      size, CXI_MAP_READ | CXI_MAP_WRITE, 0,
+				      &buf->cxi_md);
 		if (ret)
 			goto del_msg;
 		buf->bufsiz = size;

--- a/prov/cxi/src/cxip_ep.c
+++ b/prov/cxi/src/cxip_ep.c
@@ -1502,12 +1502,12 @@ err:
 }
 
 int cxip_ep_obj_map(struct cxip_ep_obj *ep, const void *buf, unsigned long len,
-		    uint64_t flags, struct cxip_md **md)
+		    uint64_t access, uint64_t flags, struct cxip_md **md)
 {
 	struct cxip_domain *dom = ep->domain;
 	int ret;
 
-	ret = cxip_map(dom, buf, len, flags, md);
+	ret = cxip_map(dom, buf, len, access, flags, md);
 	if (ret != FI_SUCCESS)
 		return ret;
 

--- a/prov/cxi/src/cxip_iomm.c
+++ b/prov/cxi/src/cxip_iomm.c
@@ -388,10 +388,11 @@ static int cxip_map_cache(struct cxip_domain *dom, struct ofi_mr_info *info,
 }
 
 static int cxip_map_nocache(struct cxip_domain *dom, struct fi_mr_attr *attr,
-			    uint64_t hmem_flags, struct cxip_md **md)
+			    uint64_t access, uint64_t hmem_flags,
+			    struct cxip_md **md)
 {
 	struct cxip_md *uncached_md;
-	uint32_t map_flags = CXI_MAP_READ | CXI_MAP_WRITE;
+	uint32_t map_flags = access;
 	int ret;
 	struct cxi_md_hints hints;
 
@@ -517,7 +518,7 @@ static void cxip_map_get_mem_region_size(const void *buf, unsigned long len,
  * mapping has been established, create one and cache it.
  */
 int cxip_map(struct cxip_domain *dom, const void *buf, unsigned long len,
-	     uint64_t flags, struct cxip_md **md)
+	     uint64_t access, uint64_t flags, struct cxip_md **md)
 {
 	struct iovec iov = {
 		.iov_base = (void *)buf,
@@ -574,7 +575,7 @@ int cxip_map(struct cxip_domain *dom, const void *buf, unsigned long len,
 		return cxip_map_cache(dom, &mr_info, md);
 	}
 
-	return cxip_map_nocache(dom, &attr, flags, md);
+	return cxip_map_nocache(dom, &attr, access, flags, md);
 }
 
 static void cxip_unmap_cache(struct cxip_md *md)

--- a/prov/cxi/src/cxip_iomm.c
+++ b/prov/cxi/src/cxip_iomm.c
@@ -114,10 +114,9 @@ static int cxip_do_map(struct ofi_mr_cache *cache, struct ofi_mr_entry *entry)
 	}
 
 	/* If the md len is larger than the iov_len, the VA and len have
-	 * been aligned to a larger page size. Update the cache memory
-	 * region registered by returning -FI_EAGAIN. Note, that GPU memory
-	 * cannot be aligned since the aligned iov_base may fall outside the
-	 * valid device address.
+	 * been aligned to a larger page size. Note, that GPU memory cannot be
+	 * aligned since the aligned iov_base may fall outside the valid device
+	 * address.
 	 */
 	if (entry->info.iface == FI_HMEM_SYSTEM) {
 		entry->info.iov.iov_base = (void *)md->md->va;

--- a/prov/cxi/src/cxip_msg.c
+++ b/prov/cxi/src/cxip_msg.c
@@ -78,8 +78,8 @@ int cxip_recv_req_alloc(struct cxip_rxc *rxc, void *buf, size_t len,
 	if (len) {
 		/* If hybrid descriptor not passed, map for dma */
 		if (!md) {
-			ret = cxip_ep_obj_map(rxc->ep_obj, (void *)buf, len, 0,
-					      &recv_md);
+			ret = cxip_ep_obj_map(rxc->ep_obj, (void *)buf, len,
+					      CXI_MAP_WRITE, 0, &recv_md);
 			if (ret) {
 				RXC_WARN(rxc,
 					 "Map of recv buffer failed: %d, %s\n",
@@ -719,7 +719,8 @@ int cxip_send_buf_init(struct cxip_req *req)
 	/* Triggered operation always requires memory registration. */
 	if (req->triggered)
 		return cxip_ep_obj_map(txc->ep_obj, req->send.buf,
-				       req->send.len, 0, &req->send.send_md);
+				       req->send.len, CXI_MAP_READ, 0,
+				       &req->send.send_md);
 
 	/* FI_INJECT operations always require an internal bounce buffer. This
 	 * is needed to replay FI_INJECT operations which may experience flow
@@ -777,8 +778,8 @@ int cxip_send_buf_init(struct cxip_req *req)
 	}
 
 	/* Everything else requires memory registeration. */
-	return cxip_ep_obj_map(txc->ep_obj, req->send.buf, req->send.len, 0,
-			       &req->send.send_md);
+	return cxip_ep_obj_map(txc->ep_obj, req->send.buf, req->send.len,
+			       CXI_MAP_READ, 0, &req->send.send_md);
 
 err_buf_fini:
 	cxip_send_buf_fini(req);

--- a/prov/cxi/src/cxip_msg_rnr.c
+++ b/prov/cxi/src/cxip_msg_rnr.c
@@ -1176,6 +1176,7 @@ cxip_send_common(struct cxip_txc *txc, uint32_t tclass, const void *buf,
 		if (!mr) {
 			ret = cxip_ep_obj_map(txc->ep_obj, send_req->send.buf,
 					      send_req->send.len, 0,
+					      CXI_MAP_READ,
 					      &send_req->send.send_md);
 			if (ret) {
 				TXC_WARN(txc,

--- a/prov/cxi/src/cxip_ptelist_buf.c
+++ b/prov/cxi/src/cxip_ptelist_buf.c
@@ -133,7 +133,7 @@ cxip_ptelist_buf_alloc(struct cxip_ptelist_bufpool *pool)
 	}
 
 	ret = cxip_ep_obj_map(rxc->base.ep_obj, buf->data, pool->attr.buf_size,
-			      OFI_MR_NOCACHE, &buf->md);
+			      CXI_MAP_WRITE, OFI_MR_NOCACHE, &buf->md);
 	if (ret)
 		goto err_unreg_buf;
 

--- a/prov/cxi/src/cxip_rma.c
+++ b/prov/cxi/src/cxip_rma.c
@@ -209,6 +209,7 @@ static int cxip_rma_emit_dma(struct cxip_txc *txc, const void *buf, size_t len,
 	struct cxip_domain *dom = txc->domain;
 	struct cxip_cntr *cntr;
 	void *inject_req;
+	uint64_t access = write ? CXI_MAP_READ : CXI_MAP_WRITE;
 
 	/* MR desc cannot be value unless hybrid MR desc is enabled. */
 	if (!dom->hybrid_mr_desc)
@@ -269,7 +270,7 @@ static int cxip_rma_emit_dma(struct cxip_txc *txc, const void *buf, size_t len,
 		} else {
 			assert(req != NULL);
 
-			ret = cxip_ep_obj_map(txc->ep_obj, buf, len, 0,
+			ret = cxip_ep_obj_map(txc->ep_obj, buf, len, access, 0,
 					      &req->rma.local_md);
 			if (ret) {
 				TXC_WARN(txc, "Failed to map buffer: %d:%s\n",

--- a/prov/cxi/src/cxip_txc.c
+++ b/prov/cxi/src/cxip_txc.c
@@ -64,7 +64,9 @@ int cxip_ibuf_chunk_init(struct ofi_bufpool_region *region)
 	int ret;
 
 	ret = cxip_ep_obj_map(txc->ep_obj, region->mem_region,
-			      region->pool->region_size, OFI_MR_NOCACHE, &md);
+			      region->pool->region_size,
+			      CXI_MAP_WRITE | CXI_MAP_READ, OFI_MR_NOCACHE,
+			      &md);
 	if (ret != FI_SUCCESS) {
 		CXIP_WARN("Failed to map inject buffer chunk\n");
 		return ret;

--- a/prov/cxi/test/av.c
+++ b/prov/cxi/test/av.c
@@ -466,6 +466,7 @@ static double diff_timespec(const struct timespec *time1,
 Test(av, reverse_lookup)
 {
 	int i;
+	int j;
 	int ret;
 	struct cxip_av *av;
 	struct cxip_addr addr = {};
@@ -492,7 +493,8 @@ Test(av, reverse_lookup)
 	 */
 	addr.nic = 0;
 	clock_gettime(CLOCK_MONOTONIC, &start);
-	fi_addr = cxip_av_lookup_fi_addr(av, &addr);
+	for (j = 0; j < 20000; j++)
+		fi_addr = cxip_av_lookup_fi_addr(av, &addr);
 	clock_gettime(CLOCK_MONOTONIC, &end);
 
 	cr_assert_neq(fi_addr, FI_ADDR_NOTAVAIL,
@@ -501,14 +503,16 @@ Test(av, reverse_lookup)
 
 	addr.nic = i - 1;
 	clock_gettime(CLOCK_MONOTONIC, &start);
-	fi_addr = cxip_av_lookup_fi_addr(av, &addr);
+	for (j = 0; j < 20000; j++)
+		fi_addr = cxip_av_lookup_fi_addr(av, &addr);
 	clock_gettime(CLOCK_MONOTONIC, &end);
 
 	cr_assert_neq(fi_addr, FI_ADDR_NOTAVAIL,
 		      "cxip_av_lookup_fi_addr failed");
 	timestamp2 = diff_timespec(&end, &start);
 
-	cr_assert((timestamp1 * 1.05) > timestamp2, "O(1) verification failed");
+	cr_assert((timestamp1 * 1.25) > timestamp2,
+		  "O(1) verification failed %f %f", timestamp1, timestamp2);
 
 	cxit_destroy_av();
 }

--- a/prov/cxi/test/mr.c
+++ b/prov/cxi/test/mr.c
@@ -67,8 +67,13 @@ Test(mr, invalid_client_rkey)
 	attr.requested_key = ~1;
 
 	ret = fi_mr_regattr(cxit_domain, &attr, 0, &mr);
-	if ((cxit_fi->domain_attr->mr_mode & FI_MR_PROV_KEY) != FI_MR_PROV_KEY)
+	if ((cxit_fi->domain_attr->mr_mode & FI_MR_PROV_KEY) != FI_MR_PROV_KEY) {
 		cr_assert_eq(ret, -FI_EKEYREJECTED, "fi_mr_regattr failed: %d", ret);
+	} else {
+		cr_assert_eq(ret, FI_SUCCESS, "fi_mr_regattr failed: %d", ret);
+		ret = fi_close(&mr->fid);
+		cr_assert_eq(ret, FI_SUCCESS, "fi_close failed: %d", ret);
+	}
 }
 
 Test(mr, std_mrs, .timeout = 600, .disabled = true)

--- a/prov/cxi/test/mr_cache.c
+++ b/prov/cxi/test/mr_cache.c
@@ -71,8 +71,7 @@ Test(mr_cache, cache_full)
 	}
 
 	/* create the domain */
-	cxit_setup_domain();
-	cxit_create_domain();
+	cxit_setup_msg();
 
 	/* Register the max number of regions */
 	for (i = 0; i < num_regions; i++) {
@@ -117,5 +116,8 @@ Test(mr_cache, cache_full)
 		  "Cache has uncached entries: %zu",
 		  cache->uncached_cnt);
 
-	cxit_teardown_domain();
+	ret = fi_close(&region_data[num_regions].mr->fid);
+	cr_assert_eq(ret, FI_SUCCESS, "Failed to close mr: %d", ret);
+
+	cxit_teardown_msg();
 }


### PR DESCRIPTION
By default, for cached local memory registrations, the CXI provider would always set access control to read/write. This was resulting in read-only memory registration to fail.

This issue is resolved by having each libfabric RDMA operation implementation defining exactly the access control it requires. For example, fi_send() requires read and fi_recv() requires write. This information is then passed into the memory registration function. If caching is disable, the access control are passed into the kernel unmodified. If caching is enabled, the following happens during memory registration:
1. Evict any overlapping entries with access control mismatch.
2. Register memory as read/write.
3. If read/write memory registration fails, attempt read-only.