### PR TITLE
man: Clarify fi_close behavior on FI_ENDPOINT

### DIFF
--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -264,9 +264,12 @@ return -FI_EBUSY.
 
 Outstanding operations posted to the endpoint when fi_close is
 called will be discarded.  Discarded operations will silently be dropped,
-with no completions reported.  Additionally, a provider may discard previously
-completed operations from the associated completion queue(s).  The
-behavior to discard completed operations is provider specific.
+with no completions reported. Memory buffers that the user associated with
+the endpoint by calling libfabric's transmission interfaces must not be released,
+deregistered, or reused until either a completion is generated or fi_close on the
+respective endpoint returns. Additionally, a provider may discard
+previously completed operations from the associated completion queue(s).
+The behavior to discard completed operations is provider specific.
 
 ## fi_ep_bind
 


### PR DESCRIPTION
Libfabric's memory model is valid until after fi_close(ep) returns or a completion is generated for a buffer given to libfabric via a data transfer API.