### PR TITLE
prov/opx: Make room for new RPC field in fid_ep

### DIFF
--- a/prov/opx/include/rdma/opx/fi_opx_endpoint.h
+++ b/prov/opx/include/rdma/opx/fi_opx_endpoint.h
@@ -479,20 +479,20 @@ struct fi_opx_ep_daos_info {
 struct fi_opx_ep {
 	/* == CACHE LINE 0,1 == */
 	struct fid_ep		      ep_fid; /* 10 qws */
+	uint64_t		      rpc_reserved;
 	struct fi_opx_ep_tx	     *tx;
 	struct fi_opx_ep_rx	     *rx;
 	struct fi_opx_ep_reliability *reliability;
 	struct fi_opx_cntr	     *read_cntr;
 	struct fi_opx_cntr	     *write_cntr;
-	struct fi_opx_cntr	     *send_cntr;
 
 	/* == CACHE LINE 2 == */
 	struct fi_opx_cntr    *recv_cntr;
+	struct fi_opx_cntr    *send_cntr;
 	struct fi_opx_domain  *domain;
 	struct opx_tid_domain *tid_domain;
 	struct ofi_bufpool    *rma_counter_pool;
 	struct ofi_bufpool    *rzv_completion_pool;
-	void		      *mem;
 	struct fi_opx_av      *av;
 	struct fi_opx_sep     *sep;
 
@@ -541,6 +541,7 @@ struct fi_opx_ep {
 
 	FI_OPX_DEBUG_COUNTERS_DECLARE_COUNTERS;
 
+	void		      *mem;
 } __attribute((aligned(L2_CACHE_LINE_SIZE)));
 
 OPX_COMPILE_TIME_ASSERT(offsetof(struct fi_opx_ep, recv_cntr) == (FI_OPX_CACHE_LINE_SIZE * 2),


### PR DESCRIPTION
This change rearranges some fields in the fi_opx_endpoint struct to make room for a larger fid_ep. The rpc_reserved field added here can simply be removed to allow for a larger fid_ep without altering alignment of other struct members.