### PR TITLE
hmem/cuda: Add a flag for exporting dmabuf fd on GB200

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -708,6 +708,7 @@ AC_ARG_WITH([cuda],
 have_cuda=0
 cuda_dlopen=0
 have_cuda_dmabuf=0
+have_cuda_dmabuf_mapping_type_pcie=0
 AC_ARG_ENABLE([cuda-dlopen],
     [AS_HELP_STRING([--enable-cuda-dlopen],
         [Enable dlopen of CUDA libraries @<:@default=no@:>@])
@@ -754,6 +755,12 @@ AS_IF([test x"$with_cuda" != x"no"],
 			[],
 			[have_cuda_dmabuf=0],
 			[[#include <cuda.h>]])
+	
+	have_cuda_dmabuf_mapping_type_pcie=1
+	AC_CHECK_DECL([CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE],
+			[],
+			[have_cuda_dmabuf_mapping_type_pcie=0],
+			[[#include <cuda.h>]])
       ])
 
 AC_DEFINE_UNQUOTED([ENABLE_CUDA_DLOPEN], [$cuda_dlopen], [dlopen CUDA libraries])
@@ -764,6 +771,8 @@ AS_IF([test x"$with_cuda" != x"no" && test -n "$with_cuda" && test "$have_cuda" 
 AC_DEFINE_UNQUOTED([HAVE_CUDA], [$have_cuda], [CUDA support])
 
 AC_DEFINE_UNQUOTED([HAVE_CUDA_DMABUF], [$have_cuda_dmabuf], [CUDA dmabuf support])
+
+AC_DEFINE_UNQUOTED([HAVE_CUDA_DMABUF_MAPPING_TYPE_PCIE], [$have_cuda_dmabuf_mapping_type_pcie], [CUDA dmabuf PCIe BAR1 support])
 
 AS_IF([test "$cuda_dlopen" != "1"], [LIBS="$LIBS $cuda_LIBS"])
 AS_IF([test "$have_cuda" = "1" && test x"$with_cuda" != x"yes"],

--- a/fabtests/common/hmem_cuda.c
+++ b/fabtests/common/hmem_cuda.c
@@ -436,6 +436,7 @@ int ft_cuda_get_dmabuf_fd(void *buf, size_t len,
 	size_t host_page_size = sysconf(_SC_PAGESIZE);
 	void *base_addr;
 	size_t total_size;
+	unsigned long long flags;
 
 	if (!dmabuf_supported) {
 		FT_LOG("warn", "dmabuf is not supported\n");
@@ -450,11 +451,16 @@ int ft_cuda_get_dmabuf_fd(void *buf, size_t len,
 	aligned_size = (uintptr_t) ft_get_page_end((void *) ((uintptr_t) base_addr + total_size - 1),
 						    host_page_size) - (uintptr_t) aligned_ptr + 1;
 
+# if HAVE_CUDA_DMABUF_MAPPING_TYPE_PCIE
+	flags = CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE;
+# else
+	flags = 0;
+# endif /* HAVE_CUDA_DMABUF_MAPPING_TYPE_PCIE */
 	cuda_ret = cuda_ops.cuMemGetHandleForAddressRange(
 						(void *)dmabuf_fd,
 						aligned_ptr, aligned_size,
 						CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
-						0);
+						flags);
 	if (cuda_ret != CUDA_SUCCESS) {
 		ft_cuda_driver_api_print_error(cuda_ret,
 				"cuMemGetHandleForAddressRange");

--- a/fabtests/configure.ac
+++ b/fabtests/configure.ac
@@ -141,6 +141,7 @@ AC_ARG_WITH([libfabric],
 dnl Check for CUDA support. Require fabtests to dlopen CUDA runtime.
 have_cuda=0
 have_cuda_dmabuf=0
+have_cuda_dmabuf_mapping_type_pcie=0
 AC_ARG_WITH([cuda],
             [AS_HELP_STRING([--with-cuda=DIR],
                             [Provide path to where the CUDA development
@@ -176,9 +177,17 @@ AS_IF([test x"$have_cuda" = x"1"],
 		      [],
 		      [have_cuda_dmabuf=0],
 		      [[#include <cuda.h>]])
+            
+            have_cuda_dmabuf_mapping_type_pcie=1
+            AC_CHECK_DECL([CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE],
+			[],
+			[have_cuda_dmabuf_mapping_type_pcie=0],
+			[[#include <cuda.h>]])
       ])
 
 AC_DEFINE_UNQUOTED([HAVE_CUDA_DMABUF], [$have_cuda_dmabuf], [CUDA dmabuf support])
+
+AC_DEFINE_UNQUOTED([HAVE_CUDA_DMABUF_MAPPING_TYPE_PCIE], [$have_cuda_dmabuf_mapping_type_pcie], [CUDA dmabuf PCIe BAR1 support])
 
 dnl Check for ROCR support. Require fabtests to dlopen ROCR.
 have_rocr=0


### PR DESCRIPTION
On GB200 platform, when trying to allocate GPU memory using cuMemAlloc(), Nvidia driver only returns addresses from BAR4 which is intended for CPU access via C2C, and not from BAR1 which is intended for GPU direct.

Use the new flag CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE to cuMemGetHandleForAddressRange so it will force the use of BAR1 in Cuda 12.8 and Nvidia driver 570.86.15.