### PR TITLE
contrib/intel/jenkins: Remove ParallelAlwaysFailFast

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -198,7 +198,6 @@ pipeline {
       timestamps()
       timeout(activity: true, time: 6, unit: 'HOURS')
       skipDefaultCheckout()
-      parallelsAlwaysFailFast()
   }
   environment {
       JOB_CADENCE = 'PR'


### PR DESCRIPTION
Remove this option so multiple stages can fail
It will also make finding failures much easier