### PR TITLE
prov/rxm,verbs: fix the flow control enabling checking

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -241,8 +241,8 @@ struct rxm_conn {
 	int remote_index;
 	uint32_t remote_pid;
 	uint8_t flags;
-	uint8_t flow_ctrl;
-	uint8_t peer_flow_ctrl;
+	bool flow_ctrl;
+	bool peer_flow_ctrl;
 
 	struct dlist_entry deferred_entry;
 	struct dlist_entry deferred_tx_queue;

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -399,6 +399,8 @@ rxm_alloc_conn(struct rxm_ep *ep, struct util_peer_addr *peer)
 	conn->state = RXM_CM_IDLE;
 	conn->remote_index = -1;
 	conn->flags = 0;
+	conn->flow_ctrl = false;
+	conn->peer_flow_ctrl = false;
 	dlist_init(&conn->deferred_entry);
 	dlist_init(&conn->deferred_tx_queue);
 	dlist_init(&conn->deferred_sar_msgs);
@@ -484,11 +486,11 @@ static void rxm_set_peer_flow_ctrl(struct rxm_conn *conn, int cm_flow_ctrl_flag)
 		break;
 
 	case RXM_CM_FLOW_CTRL_PEER_ON:
-		conn->peer_flow_ctrl = 1;
+		conn->peer_flow_ctrl = true;
 		break;
 
 	case RXM_CM_FLOW_CTRL_PEER_OFF:
-		conn->peer_flow_ctrl = 0;
+		conn->peer_flow_ctrl = false;
 		break;
 	}
 }
@@ -511,7 +513,7 @@ void rxm_process_connect(struct rxm_eq_cm_entry *cm_entry)
 		rxm_set_peer_flow_ctrl(conn, cm_entry->data.accept.flow_ctrl);
 	}
 
-	if (conn->flow_ctrl & conn->peer_flow_ctrl) {
+	if (conn->flow_ctrl && conn->peer_flow_ctrl) {
 		domain = container_of(conn->ep->util_ep.domain,
 				      struct rxm_domain, util_domain);
 		domain->flow_ctrl_ops->enable(conn->msg_ep,

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -54,7 +54,7 @@ static bool vrb_flow_ctrl_available(struct fid_ep *ep_fid)
 	struct vrb_ep *ep = container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 
 	// only enable if we are not using SRQ
-	return (!ep->srx && ep->ibv_qp && ep->ibv_qp->qp_type == IBV_QPT_RC);
+	return (!ep->srx && ep->util_ep.type == FI_EP_MSG);
 }
 
 static int vrb_enable_ep_flow_ctrl(struct fid_ep *ep_fid, uint64_t threshold)


### PR DESCRIPTION
verbs provider enabled the flow control by checking qp type (IBV_QPT_RC), but the qp might not be created when the checking happened. Change to check ep type to ensure flow control is enabled for FI_EP_MSG.