### PR TITLE
fabtests/scripts: use yaml safe_load

### DIFF
--- a/fabtests/scripts/runmultinode.py
+++ b/fabtests/scripts/runmultinode.py
@@ -24,7 +24,7 @@ def parse_args():
 
 def parse_config(config):
 	with open(config, "r") as f:
-		yconf = yaml.load(f, Loader=yaml.FullLoader)
+		yconf = yaml.safe_load(f)
 	return yconf
 
 def mpi_env(config):


### PR DESCRIPTION
Suppress warnings from Amazon security scan.
similar to https://github.com/ofiwg/libfabric/pull/9339