### PR TITLE
prov/cxi: Fix uninitialized padding in cxip_addr structure causing hash mismatches

### DIFF
--- a/prov/cxi/include/cxip.h
+++ b/prov/cxi/include/cxip.h
@@ -362,6 +362,7 @@ static inline bool cxip_software_pte_allowed(void)
 struct cxip_addr {
 	uint32_t pid		: C_DFA_PID_BITS_MAX;
 	uint32_t nic		: C_DFA_NIC_BITS;
+	uint32_t pad		: 3;
 	uint16_t vni;
 };
 

--- a/prov/cxi/src/cxip_av.c
+++ b/prov/cxi/src/cxip_av.c
@@ -85,10 +85,9 @@ static int cxip_av_insert_addr(struct cxip_av *av, struct cxip_addr *addr,
 {
 	struct cxip_av_entry *entry;
 	struct cxip_av_auth_key_entry *auth_key_entry = NULL;
-	struct cxip_addr auth_key_addr = {
-		.nic = addr->nic,
-		.pid = addr->pid
-	};
+	struct cxip_addr auth_key_addr = {0};
+	auth_key_addr.nic = addr->nic;
+	auth_key_addr.pid = addr->pid;
 
 	if (flags & FI_AUTH_KEY) {
 		auth_key_entry =

--- a/prov/cxi/src/cxip_msg.c
+++ b/prov/cxi/src/cxip_msg.c
@@ -34,7 +34,7 @@ fi_addr_t cxip_recv_req_src_addr(struct cxip_rxc *rxc,
 	 * physical address in the EQ event to logical FI address.
 	 */
 	if ((rxc->attr.caps & FI_SOURCE) || force) {
-		struct cxip_addr addr = {};
+		struct cxip_addr addr = {0};
 
 		if (rxc->ep_obj->av->symmetric)
 			return CXI_MATCH_ID_EP(rxc->pid_bits, init);


### PR DESCRIPTION
The cxip_addr structure uses bit fields: a 9-bit `pid` and a 20-bit `nic`, both packed into a single uint32_t, leaving 3 bits of padding. When initializing an auth_key_addr variable on the stack using:

    auth_key_addr = {
        .nic = addr->nic,
        .pid = addr->pid,
    };

the 3 padding bits may remain uninitialized.
Since auth_key_addr is then passed to HASH_ADD(), the HASH_VALUE() function computes the hash based on *all* bits in the structure, including the padding.

Later, during a lookup with HASH_FIND() in cxip_av_lookup_fi_addr(), a new cxip_addr structure is *explicitly zeroed* before setting fields. This discrepancy causes the hash values to mismatch: the original entry (with garbage padding) and the lookup key (with zeroed padding) produce different hashes. As a result, the lookup fails, causing unmatched messages and eventually hanging the application as it waits indefinitely for a posted receive.

This issue only occurs in the FI_PEER case and was exposed while testing on LNX. Relevant call path:

    cxip_recv_ux_sw_matcher()
        -> cxip_process_srx_ux_matcher()
        -> cxip_recv_req_src_addr()
        -> cxip_av_lookup_fi_addr()

In this flow, the message's cxi address is used to derive a fi_addr_t. Due to the failed hash lookup, the fi_addr_t is left unspecified (-1), causing get_tag()/get_msg() to fail matching the message to any receive queue entry.

This patch ensures that all bits, including padding, are properly initialized.