### PR TITLE
prov/cxi: Added new configure option to enable dynamic binding of curl symbols

### DIFF
--- a/prov/cxi/include/cxip.h
+++ b/prov/cxi/include/cxip.h
@@ -3010,6 +3010,7 @@ enum curl_ops {
 	CURL_DELETE,
 	CURL_MAX
 };
+extern bool cxip_collectives_supported;
 int cxip_curl_init(void);
 void cxip_curl_fini(void);
 const char *cxip_curl_opname(enum curl_ops op);

--- a/prov/cxi/src/cxip_coll.c
+++ b/prov/cxi/src/cxip_coll.c
@@ -4022,6 +4022,14 @@ int cxip_join_collective(struct fid_ep *ep, fi_addr_t coll_addr,
 	struct cxip_zbcoll_obj *zb;
 	bool link_zb;
 	int ret;
+	
+	if(cxip_collectives_supported) {
+		TRACE_JOIN("%s: CXI Collectives are supported\n", __func__);
+	}
+	else {
+		TRACE_JOIN("%s: CXI Collectives are not supported\n", __func__);
+		return -FI_EOPNOTSUPP;
+	}
 
 	check_red_pkt();
 

--- a/prov/cxi/src/cxip_dom.c
+++ b/prov/cxi/src/cxip_dom.c
@@ -1641,6 +1641,14 @@ static int cxip_query_collective(struct fid_domain *domain,
 				 uint64_t flags)
 {
 	int ext_op;
+	
+	if(cxip_collectives_supported) {
+		CXIP_WARN("%s: CXI Collectives are supported\n", __func__);
+	}
+	else {
+		CXIP_WARN("%s: CXI Collectives are not supported\n", __func__);
+		return -FI_EOPNOTSUPP;
+	}
 
 	/* BARRIER does not require attr */
 	if (coll == FI_BARRIER && !attr)


### PR DESCRIPTION
Added new configure option to enable dynamic binding of curl symbols.
This option is needed to support static and dynamic binding of these symbols. The new configure option to enable dlopen during curl init is --enable-cxi-curl-dlopen.