### PR TITLE
prov/efa: Add lock around g_efa_domain_list

### DIFF
--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -308,7 +308,10 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 	}
 #endif
 
+	ofi_mutex_lock(&g_efa_domain_list_lock);
 	dlist_insert_tail(&efa_domain->list_entry, &g_efa_domain_list);
+	ofi_mutex_unlock(&g_efa_domain_list_lock);
+
 	return 0;
 
 err_free:

--- a/prov/efa/src/efa_domain.h
+++ b/prov/efa/src/efa_domain.h
@@ -10,6 +10,7 @@
 #include "efa_env.h"
 #include "ofi_hmem.h"
 #include "ofi_util.h"
+#include "ofi_lock.h"
 
 enum efa_domain_info_type {
 	EFA_INFO_RDM,
@@ -56,6 +57,7 @@ struct efa_domain {
 };
 
 extern struct dlist_entry g_efa_domain_list;
+extern ofi_mutex_t g_efa_domain_list_lock;
 
 /*
  * efa_is_cache_available() is a check to see whether a memory registration

--- a/prov/efa/src/efa_fork_support.c
+++ b/prov/efa/src/efa_fork_support.c
@@ -196,6 +196,7 @@ void efa_atfork_callback_flush_mr_cache()
 	struct efa_domain *efa_domain;
 	bool flush_lru = true;
 
+	ofi_mutex_lock(&g_efa_domain_list_lock);
 	dlist_foreach_container_safe(&g_efa_domain_list,
 				     struct efa_domain,
 				     efa_domain, list_entry, tmp) {
@@ -203,6 +204,7 @@ void efa_atfork_callback_flush_mr_cache()
 			while(ofi_mr_cache_flush(efa_domain->cache, flush_lru));
 		}
 	}
+	ofi_mutex_unlock(&g_efa_domain_list_lock);
 }
 
 #ifndef _WIN32

--- a/prov/efa/src/efa_prov.c
+++ b/prov/efa/src/efa_prov.c
@@ -2,6 +2,7 @@
 /* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
 
 #include <ofi_prov.h>
+#include <ofi_lock.h>
 #include "efa.h"
 #include "efa_prov.h"
 #include "efa_prov_info.h"
@@ -73,6 +74,8 @@ struct fi_provider efa_prov = {
 struct util_prov efa_util_prov = {
 	.prov = &efa_prov,
 };
+
+ofi_mutex_t g_efa_domain_list_lock;
 
 /**
  * @brief initialize global variable: efa_util_prov
@@ -232,6 +235,7 @@ EFA_INI
 	if (err)
 		goto err_free;
 
+	ofi_mutex_init(&g_efa_domain_list_lock);
 	dlist_init(&g_efa_domain_list);
 
 	return &efa_prov;


### PR DESCRIPTION
A race condition was discovered when initializing EFA using multiple threads. The EFA Provider has a global variable called g_efa_domain_list, which holds a list of all the EFA domains in a fabric. The list is initialized in efa_prov.c in the fi_info path, and then used in domain open path (fork support, and adding a domain to the list). The list needs to be protected by a mutex so that we don't have a race condition of two threads trying to modify the list at the same time. The libfabric man pages state that all control interfaces will always be thread safe unless control progress model is FI_PROGRESS_CONTROL_UNIFIED.