### PR TITLE
prov/efa: Only initialize devices that match FI_EFA_IFACE filter and avoid initializing non-EFA devices

### DIFF
--- a/prov/efa/docs/naming_convention.md
+++ b/prov/efa/docs/naming_convention.md
@@ -6,7 +6,7 @@ Libfabric provider.
 ## Variable naming conventions
 
 Global variables' names must start with `g_` prefix. For example,
-`g_device_list` is a global variable that is an array of `struct efa_device`.
+`g_efa_selected_device_list` is a global variable that is an array of `struct efa_device`.
 
 ## Function naming conventions
 
@@ -50,7 +50,7 @@ Typical actions include:
 - `release` works in the opposite direction of `alloc`, and is used on objects
   that `alloc` is used on.
 - `initialize` is used to initialize global variables. For example,
-  `efa_device_list_initialize` initializes the global variables `g_device_list`
-  and `g_device_cnt`.
+  `efa_device_list_initialize` initializes the global variables `g_efa_selected_device_list`
+  and `g_efa_selected_device_cnt`.
 - `finalize` works in the opposite direction of `initialize`, which means it is
   used to release resources associated with global variables.

--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -30,8 +30,8 @@ static bool efa_is_local_peer(struct efa_av *av, const void *addr)
 	}
 	EFA_INFO(FI_LOG_AV, "The peer's GID is %s.\n", raw_gid_str);
 #endif
-	for (i = 0; i < g_device_cnt; ++i) {
-		if (!memcmp(raw_gid, g_device_list[i].ibv_gid.raw, EFA_GID_LEN)) {
+	for (i = 0; i < g_efa_ibv_gid_cnt; ++i) {
+		if (!memcmp(raw_gid, g_efa_ibv_gid_list[i].raw, EFA_GID_LEN)) {
 			EFA_INFO(FI_LOG_AV, "The peer is local.\n");
 			return 1;
 		}

--- a/prov/efa/src/efa_device.c
+++ b/prov/efa/src/efa_device.c
@@ -61,7 +61,11 @@ int efa_device_construct_gid(struct efa_device *efa_device,
 				 sizeof(efa_device->efa_attr));
 	if (err) {
 		err = -err;
-		EFA_INFO_ERRNO(FI_LOG_FABRIC, "efadv_query_device", err);
+		if (err == -EOPNOTSUPP) {
+			EFA_INFO(FI_LOG_FABRIC, "Not an EFA device. Will not initialize.\n");
+		} else {
+			EFA_INFO_ERRNO(FI_LOG_FABRIC, "efadv_query_device", err);
+		}
 		goto err_close;
 	}
 
@@ -253,6 +257,11 @@ int efa_device_list_initialize(void)
 					   ibv_device_list[device_idx]);
 
 		if (err) {
+
+			/* efa_device_construct returns -EOPNOTSUPP for non-EFA devices */
+			if (err == -EOPNOTSUPP)
+				continue;
+
 			ret = err;
 			goto err_free;
 		}

--- a/prov/efa/src/efa_device.c
+++ b/prov/efa/src/efa_device.c
@@ -30,19 +30,15 @@
  * @brief initialize data members of a struct of efa_device
  *
  * @param	efa_device[in,out]	pointer to a struct efa_device
- * @param	device_idx[in]		device index
  * @param	ibv_device[in]		pointer to a struct ibv_device, which is used
  * 					to query attributes of the EFA device
  * @return	0 on success
  * 		a negative libfabric error code on failure.
  */
 int efa_device_construct(struct efa_device *efa_device,
-			 int device_idx,
 			 struct ibv_device *ibv_device)
 {
 	int err;
-
-	efa_device->device_idx = device_idx;
 
 	efa_device->ibv_ctx = ibv_open_device(ibv_device);
 	if (!efa_device->ibv_ctx) {
@@ -198,7 +194,7 @@ int efa_device_list_initialize(void)
 	}
 
 	for (device_idx = 0; device_idx < g_device_cnt; device_idx++) {
-		err = efa_device_construct(&g_device_list[device_idx], device_idx, ibv_device_list[device_idx]);
+		err = efa_device_construct(&g_device_list[device_idx], ibv_device_list[device_idx]);
 		if (err) {
 			ret = err;
 			goto err_free;

--- a/prov/efa/src/efa_device.h
+++ b/prov/efa/src/efa_device.h
@@ -10,7 +10,6 @@
 #include <stdbool.h>
 
 struct efa_device {
-	int			device_idx;
 	struct ibv_context	*ibv_ctx;
 	struct ibv_device_attr	ibv_attr;
 	struct efadv_device_attr efa_attr;

--- a/prov/efa/src/efa_device.h
+++ b/prov/efa/src/efa_device.h
@@ -26,9 +26,13 @@ int efa_device_list_initialize(void);
 
 void efa_device_list_finalize(void);
 
-extern struct efa_device *g_device_list;
+extern struct efa_device *g_efa_selected_device_list;
 
-extern int g_device_cnt;
+extern int g_efa_selected_device_cnt;
+
+extern union ibv_gid *g_efa_ibv_gid_list;
+
+extern int g_efa_ibv_gid_cnt;
 
 bool efa_device_support_rdma_read(void);
 

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -76,19 +76,19 @@ static int efa_domain_init_device_and_pd(struct efa_domain *efa_domain,
 	if (!domain_name)
 		return -FI_EINVAL;
 
-	for (i = 0; i < g_device_cnt; i++) {
-		device_name = g_device_list[i].ibv_ctx->device->name;
+	for (i = 0; i < g_efa_selected_device_cnt; i++) {
+		device_name = g_efa_selected_device_list[i].ibv_ctx->device->name;
 		if (strstr(domain_name, device_name) == domain_name &&
 		    strlen(domain_name) - strlen(device_name) ==
 		            strlen(domain_name_suffix) &&
 		    strcmp((const char *) (domain_name + strlen(device_name)),
 		           domain_name_suffix) == 0) {
-			efa_domain->device = &g_device_list[i];
+			efa_domain->device = &g_efa_selected_device_list[i];
 			break;
 		}
 	}
 
-	if (i == g_device_cnt)
+	if (i == g_efa_selected_device_cnt)
 		return -FI_ENODEV;
 
 	EFA_INFO(FI_LOG_DOMAIN, "Domain %s selected device %s\n", domain_name, device_name);

--- a/prov/efa/src/efa_env.c
+++ b/prov/efa/src/efa_env.c
@@ -41,29 +41,6 @@ struct efa_env efa_env = {
 	.internal_rx_refill_threshold = 8,
 };
 
-/**
- * @brief Define FI_EFA_USE_DEVICE_RDMA as a configuration parameter
- *
- * This function fetches the default value of using EFA device's
- * RDMA capability and defines it as a configuration parameter.
- */
-void efa_env_define_use_device_rdma()
-{
-	char *str = "";
-
-	/* Specify the help info about the usage of RDMA in the device. */
-	if (!efa_device_support_rdma_read()) {
-		str = "  EFA device on your system does not support RDMA,"
-			" so this variable cannot be set to 1.";
-	}
-
-	fi_param_define(&efa_prov, "use_device_rdma", FI_PARAM_BOOL,
-			"Specifies whether to use device's RDMA functionality"
-			" for one-sided and two-sided transfers.%s",
-			str);
-}
-
-
 /* @brief Read and store the FI_EFA_* environment variables.
  */
 void efa_env_param_get(void)
@@ -165,7 +142,10 @@ void efa_env_param_get(void)
 
 void efa_env_define()
 {
-	efa_env_define_use_device_rdma();
+	fi_param_define(&efa_prov, "use_device_rdma", FI_PARAM_BOOL,
+			"Specifies whether to use device's RDMA functionality"
+			" for one-sided and two-sided transfers if supported "
+			"by the EFA device on the instance.");
 	fi_param_define(&efa_prov, "iface", FI_PARAM_STRING,
 			"A comma delimited list of case-sensitive names to restrict eligible EFA NICs (Default: all).");
 	fi_param_define(&efa_prov, "tx_min_credits", FI_PARAM_INT,

--- a/prov/efa/src/efa_fork_support.c
+++ b/prov/efa/src/efa_fork_support.c
@@ -101,7 +101,7 @@ static int efa_fork_support_is_enabled()
 	if (!buf)
 		return -FI_ENOMEM;
 
-	mr = ibv_reg_mr(g_device_list[0].ibv_pd, buf, page_size, 0);
+	mr = ibv_reg_mr(g_efa_selected_device_list[0].ibv_pd, buf, page_size, 0);
 	if (mr == NULL) {
 		ret = errno;
 		goto out;

--- a/prov/efa/src/efa_prov.c
+++ b/prov/efa/src/efa_prov.c
@@ -93,8 +93,8 @@ static int efa_util_prov_initialize()
 	* Therefore, the efa-direct info objects should be returned _before_ efa rdm or dgram
 	* So we populate the efa-direct info objects first
 	*/
-	for (i = 0; i < g_device_cnt; ++i) {
-		prov_info_direct = fi_dupinfo(g_device_list[i].rdm_info);
+	for (i = 0; i < g_efa_selected_device_cnt; ++i) {
+		prov_info_direct = fi_dupinfo(g_efa_selected_device_list[i].rdm_info);
 		if (!prov_info_direct) {
 			EFA_WARN(FI_LOG_DOMAIN, "Failed to allocate prov_info for EFA direct\n");
 			continue;
@@ -116,8 +116,8 @@ static int efa_util_prov_initialize()
 		tail = prov_info_direct;
 	}
 
-	for (i = 0; i < g_device_cnt; ++i) {
-		err = efa_prov_info_alloc_for_rdm(&prov_info_rdm, &g_device_list[i]);
+	for (i = 0; i < g_efa_selected_device_cnt; ++i) {
+		err = efa_prov_info_alloc_for_rdm(&prov_info_rdm, &g_efa_selected_device_list[i]);
 		if (err) {
 			EFA_WARN(FI_LOG_DOMAIN, "Failed to allocate prov_info for rdm. error: %d\n",
 				 err);
@@ -140,8 +140,8 @@ static int efa_util_prov_initialize()
 		tail = prov_info_rdm;
 	}
 
-	for (i = 0; i < g_device_cnt; ++i) {
-		prov_info_dgram = fi_dupinfo(g_device_list[i].dgram_info);
+	for (i = 0; i < g_efa_selected_device_cnt; ++i) {
+		prov_info_dgram = fi_dupinfo(g_efa_selected_device_list[i].dgram_info);
 		if (!prov_info_dgram) {
 			EFA_WARN(FI_LOG_DOMAIN, "Failed to allocate prov_info for dgram\n");
 			continue;

--- a/prov/efa/src/efa_prov.c
+++ b/prov/efa/src/efa_prov.c
@@ -193,15 +193,16 @@ EFA_INI
 	if (err)
 		goto err_free;
 
+	efa_env_initialize();
+
+	/*
+	 * efa_device_list_initialize uses FI_EFA_IFACE, so
+	 * efa_device_list_initialize must be called after efa_env_initialize
+	 */
 	err = efa_device_list_initialize();
 	if (err)
 		return &efa_prov;
 
-	/*
-	 * efa_env_initialize uses g_efa_device_list
-	 * so it must be called after efa_device_list_initialize()
-	 */
-	efa_env_initialize();
 
 	/*
 	 * efa_fork_support_enable_if_requested must be called before

--- a/prov/efa/src/efa_prov_info.c
+++ b/prov/efa/src/efa_prov_info.c
@@ -471,12 +471,22 @@ int efa_prov_info_alloc(struct fi_info **prov_info_ptr,
 
 	if (ep_type == FI_EP_RDM) {
 		prov_info->caps	= EFA_RDM_CAPS;
+
 		/* Claim RMA support in the efa-direct path only if read, write
-		 *  and unsolicited write are all available */
-		if (efa_device_support_rdma_read() &&
-			efa_device_support_rdma_write() &&
-			efa_device_support_unsolicited_write_recv())
+		 * and unsolicited write are all available
+		 * Older versions of rdma-core do not contain the symbol
+		 * EFADV_DEVICE_ATTR_CAPS_UNSOLICITED_WRITE_RECV, so we only
+		 * check for the unsolicited write recv cap only when the
+		 * rdma-core is new enough
+		 */
+#if HAVE_CAPS_UNSOLICITED_WRITE_RECV
+		if (device->device_caps & EFADV_DEVICE_ATTR_CAPS_RDMA_READ &&
+		    device->device_caps & EFADV_DEVICE_ATTR_CAPS_RDMA_WRITE &&
+		    device->device_caps &
+			    EFADV_DEVICE_ATTR_CAPS_UNSOLICITED_WRITE_RECV)
 			prov_info->caps |= (OFI_TX_RMA_CAPS | OFI_RX_RMA_CAPS);
+#endif
+
 	} else {
 		if (ep_type != FI_EP_DGRAM) {
 			EFA_WARN(FI_LOG_DOMAIN, "Unsupported EFA info type: %d\n", ep_type);

--- a/prov/efa/src/efa_user_info.c
+++ b/prov/efa/src/efa_user_info.c
@@ -384,7 +384,7 @@ int efa_user_info_alter_direct(int version, struct fi_info *info, const struct f
 		 * as the MSG only as RMA will not be used.
 		 */
 		if (!(hints->caps & FI_RMA))
-			info->ep_attr->max_msg_size = g_device_list[0].ibv_port_attr.max_msg_sz;
+			info->ep_attr->max_msg_size = g_efa_selected_device_list[0].ibv_port_attr.max_msg_sz;
 	}
 
 	/* Print a warning and use FI_AV_TABLE if the app requests FI_AV_MAP */

--- a/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
@@ -72,7 +72,7 @@ ssize_t efa_rdm_pke_init_handshake(struct efa_rdm_pke *pkt_entry,
 	 * devices. I.e. the PCI bus will only contain EFA devices with the same
 	 * vendor_part_id (0xEFA0, 0xEFA1, etc)
 	 */
-	device_version_hdr->device_version = g_device_list[0].ibv_attr.vendor_part_id;
+	device_version_hdr->device_version = g_efa_selected_device_list[0].ibv_attr.vendor_part_id;
 	handshake_hdr->flags |= EFA_RDM_HANDSHAKE_DEVICE_VERSION_HDR;
 	pkt_entry->pkt_size += sizeof (struct efa_rdm_handshake_opt_device_version_hdr);
 

--- a/prov/efa/src/rdm/efa_rdm_util.c
+++ b/prov/efa/src/rdm/efa_rdm_util.c
@@ -29,7 +29,7 @@ bool efa_rdm_get_use_device_rdma(uint32_t fabric_api_version)
 	bool default_val;
 	uint32_t vendor_part_id;
 
-	vendor_part_id = g_device_list[0].ibv_attr.vendor_part_id;
+	vendor_part_id = g_efa_selected_device_list[0].ibv_attr.vendor_part_id;
 	hw_support = efa_device_support_rdma_read();
 
 	if (FI_VERSION_GE(fabric_api_version, FI_VERSION(1,18))) {

--- a/prov/efa/test/efa_unit_test_cq.c
+++ b/prov/efa/test/efa_unit_test_cq.c
@@ -496,7 +496,8 @@ void test_rdm_cq_create_error_handling(struct efa_resource **state)
 		skip();
 		return;
 	}
-	efa_device_construct(&efa_device, ibv_device_list[0]);
+	efa_device_construct_gid(&efa_device, ibv_device_list[0]);
+	efa_device_construct_pd(&efa_device, ibv_device_list[0]);
 
 	resource->hints = efa_unit_test_alloc_hints(FI_EP_RDM, EFA_FABRIC_NAME);
 	assert_non_null(resource->hints);

--- a/prov/efa/test/efa_unit_test_cq.c
+++ b/prov/efa/test/efa_unit_test_cq.c
@@ -496,7 +496,7 @@ void test_rdm_cq_create_error_handling(struct efa_resource **state)
 		skip();
 		return;
 	}
-	efa_device_construct(&efa_device, 0, ibv_device_list[0]);
+	efa_device_construct(&efa_device, ibv_device_list[0]);
 
 	resource->hints = efa_unit_test_alloc_hints(FI_EP_RDM, EFA_FABRIC_NAME);
 	assert_non_null(resource->hints);

--- a/prov/efa/test/efa_unit_test_cq.c
+++ b/prov/efa/test/efa_unit_test_cq.c
@@ -491,7 +491,7 @@ void test_rdm_cq_create_error_handling(struct efa_resource **state)
 	struct verbs_context *vctx = NULL;
 	struct fi_cq_attr cq_attr = {0};
 
-	ibv_device_list = ibv_get_device_list(&g_device_cnt);
+	ibv_device_list = ibv_get_device_list(&g_efa_selected_device_cnt);
 	if (ibv_device_list == NULL) {
 		skip();
 		return;

--- a/prov/efa/test/efa_unit_test_device.c
+++ b/prov/efa/test/efa_unit_test_device.c
@@ -21,7 +21,7 @@ void test_efa_device_construct_error_handling()
 	g_efa_unit_test_mocks.efadv_query_device = &efa_mock_efadv_query_device_return_mock;
 	will_return(efa_mock_efadv_query_device_return_mock, ibv_err);
 
-	efa_device_construct(&efa_device, ibv_device_list[0]);
+	efa_device_construct_gid(&efa_device, ibv_device_list[0]);
 
 	/* when error happend, resources in efa_device should be NULL */
 	assert_null(efa_device.ibv_ctx);

--- a/prov/efa/test/efa_unit_test_device.c
+++ b/prov/efa/test/efa_unit_test_device.c
@@ -21,7 +21,7 @@ void test_efa_device_construct_error_handling()
 	g_efa_unit_test_mocks.efadv_query_device = &efa_mock_efadv_query_device_return_mock;
 	will_return(efa_mock_efadv_query_device_return_mock, ibv_err);
 
-	efa_device_construct(&efa_device, 0, ibv_device_list[0]);
+	efa_device_construct(&efa_device, ibv_device_list[0]);
 
 	/* when error happend, resources in efa_device should be NULL */
 	assert_null(efa_device.ibv_ctx);

--- a/prov/efa/test/efa_unit_test_device.c
+++ b/prov/efa/test/efa_unit_test_device.c
@@ -12,7 +12,7 @@ void test_efa_device_construct_error_handling()
 	struct ibv_device **ibv_device_list;
 	struct efa_device efa_device = {0};
 
-	ibv_device_list = ibv_get_device_list(&g_device_cnt);
+	ibv_device_list = ibv_get_device_list(&g_efa_selected_device_cnt);
 	if (ibv_device_list == NULL) {
 		skip();
 		return;

--- a/prov/efa/test/efa_unit_test_hmem.c
+++ b/prov/efa/test/efa_unit_test_hmem.c
@@ -28,15 +28,15 @@ void test_efa_hmem_info_update_neuron(struct efa_resource **state)
 
         neuron_initialized_orig = hmem_ops[FI_HMEM_NEURON].initialized;
         hmem_ops[FI_HMEM_NEURON].initialized = true;
-        efa_device_caps_orig = g_device_list[0].device_caps;
-        g_device_list[0].device_caps |= EFADV_DEVICE_ATTR_CAPS_RDMA_READ;
+        efa_device_caps_orig = g_efa_selected_device_list[0].device_caps;
+        g_efa_selected_device_list[0].device_caps |= EFADV_DEVICE_ATTR_CAPS_RDMA_READ;
         g_efa_unit_test_mocks.neuron_alloc = &efa_mock_neuron_alloc_return_null;
 
         ret = efa_hmem_info_initialize();
 
         /* recover the modified global variables before doing check */
         hmem_ops[FI_HMEM_NEURON].initialized = neuron_initialized_orig;
-        g_device_list[0].device_caps = efa_device_caps_orig;
+        g_efa_selected_device_list[0].device_caps = efa_device_caps_orig;
 
         assert_int_equal(ret, 0);
         assert_false(g_efa_hmem_info[FI_HMEM_NEURON].initialized);
@@ -66,8 +66,8 @@ void test_efa_hmem_info_disable_p2p_neuron(struct efa_resource **state)
 
         neuron_initialized_orig = hmem_ops[FI_HMEM_NEURON].initialized;
         hmem_ops[FI_HMEM_NEURON].initialized = true;
-        efa_device_caps_orig = g_device_list[0].device_caps;
-        g_device_list[0].device_caps |= EFADV_DEVICE_ATTR_CAPS_RDMA_READ;
+        efa_device_caps_orig = g_efa_selected_device_list[0].device_caps;
+        g_efa_selected_device_list[0].device_caps |= EFADV_DEVICE_ATTR_CAPS_RDMA_READ;
         /* neuron_alloc should not be called when p2p is disabled. efa_mock_neuron_alloc_return_mock will fail the test when it is called. */
         g_efa_unit_test_mocks.neuron_alloc = efa_mock_neuron_alloc_return_mock;
 
@@ -75,7 +75,7 @@ void test_efa_hmem_info_disable_p2p_neuron(struct efa_resource **state)
 
         /* recover the modified global variables before doing check */
         ofi_hmem_disable_p2p = 0;
-        g_device_list[0].device_caps = efa_device_caps_orig;
+        g_efa_selected_device_list[0].device_caps = efa_device_caps_orig;
         hmem_ops[FI_HMEM_NEURON].initialized = neuron_initialized_orig;
 
         assert_int_equal(ret, 0);

--- a/prov/efa/test/efa_unit_test_info.c
+++ b/prov/efa/test/efa_unit_test_info.c
@@ -117,15 +117,15 @@ static void test_info_direct_attributes_impl(struct fi_info *hints,
 		assert_int_equal(info->domain_attr->progress, FI_PROGRESS_AUTO);
 		assert_int_equal(info->domain_attr->control_progress, FI_PROGRESS_AUTO);
 		assert_int_equal(
-			g_device_list[0].rdm_info->ep_attr->max_msg_size,
+			g_efa_selected_device_list[0].rdm_info->ep_attr->max_msg_size,
 			(info->caps & FI_RMA) ?
-				g_device_list[0].max_rdma_size :
-				g_device_list[0].ibv_port_attr.max_msg_sz);
+				g_efa_selected_device_list[0].max_rdma_size :
+				g_efa_selected_device_list[0].ibv_port_attr.max_msg_sz);
 		assert_int_equal(
 			info->ep_attr->max_msg_size,
 			(hints->caps & FI_RMA) ?
-				g_device_list[0].max_rdma_size :
-				g_device_list[0].ibv_port_attr.max_msg_sz);
+				g_efa_selected_device_list[0].max_rdma_size :
+				g_efa_selected_device_list[0].ibv_port_attr.max_msg_sz);
 	}
 
 	fi_freeinfo(info_head);
@@ -395,9 +395,9 @@ void test_info_max_order_size_rdm_with_atomic_no_order(struct efa_resource **sta
 void test_info_max_order_size_rdm_with_atomic_order(struct efa_resource **state)
 {
 	struct efa_resource *resource = *state;
-	size_t max_atomic_size = g_device_list[0].ibv_port_attr.max_msg_sz
+	size_t max_atomic_size = g_efa_selected_device_list[0].ibv_port_attr.max_msg_sz
 					- sizeof(struct efa_rdm_rta_hdr)
-					- g_device_list[0].rdm_info->src_addrlen
+					- g_efa_selected_device_list[0].rdm_info->src_addrlen
 					- EFA_RDM_IOV_LIMIT * sizeof(struct fi_rma_iov);
 
 	resource->hints = efa_unit_test_alloc_hints(FI_EP_RDM, EFA_FABRIC_NAME);

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -87,7 +87,6 @@ struct efa_unit_test_handshake_pkt_attr {
 };
 
 int efa_device_construct(struct efa_device *efa_device,
-			 int device_idx,
 			 struct ibv_device *ibv_device);
 
 void efa_unit_test_buff_construct(struct efa_unit_test_buff *buff, struct efa_resource *resource, size_t buff_size);

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -86,7 +86,10 @@ struct efa_unit_test_handshake_pkt_attr {
 	uint32_t device_version;
 };
 
-int efa_device_construct(struct efa_device *efa_device,
+int efa_device_construct_gid(struct efa_device *efa_device,
+			 struct ibv_device *ibv_device);
+
+int efa_device_construct_pd(struct efa_device *efa_device,
 			 struct ibv_device *ibv_device);
 
 void efa_unit_test_buff_construct(struct efa_unit_test_buff *buff, struct efa_resource *resource, size_t buff_size);


### PR DESCRIPTION
### prov/efa: Only initialize devices that match FI_EFA_IFACE filter

FI_EFA_IFACE is used to restrict the EFA devices that are visible to the
application. There is no need to initialize devices that the application
does not want to use.

However, we still want to keep track of all GIDs on the instance even if
they are not selected in FI_EFA_IFACE because we use that list to
determine if a peer is local and create SHM provider resources for such
local peers.

So this commit splits efa_device_construct into two parts: the first
part initializes efa_device fields up to and including the GID. The
second part initializes the protection domain and prov_info structs. The
second part is only executed for EFA devices that match the FI_EFA_IFACE
filter.

And it introduces g_efa_ibv_gid_list and g_efa_ibv_gid_cnt to keep track
of all EFA device GIDs on the instance irrespective of FI_EFA_IFACE

### prov/efa: Do not try to initialize non-EFA devices

On some instances, there can be non-EFA Infiniband-like devices that show
up in ibv_devinfo. We do not want to initialize those devices.