### PR TITLE
Applied patch from later version to prevent errors returned when using fi_close

### DIFF
--- a/util/pingpong.c
+++ b/util/pingpong.c
@@ -1868,12 +1868,12 @@ static void pp_free_res(struct ct_pingpong *ct)
 {
 	PP_DEBUG("Freeing resources of test suite\n");
 
-	if (ct->mr != &(ct->no_mr))
-		PP_CLOSE_FID(ct->mr);
 	PP_CLOSE_FID(ct->ep);
 	PP_CLOSE_FID(ct->pep);
 	PP_CLOSE_FID(ct->rxcq);
 	PP_CLOSE_FID(ct->txcq);
+	if (ct->mr != &(ct->no_mr))
+		PP_CLOSE_FID(ct->mr);
 	PP_CLOSE_FID(ct->av);
 	PP_CLOSE_FID(ct->eq);
 	PP_CLOSE_FID(ct->domain);


### PR DESCRIPTION
[Patch](https://github.com/ofiwg/libfabric/blame/5dd902300d2c5cdf27f436ffe430d4217c093f5c/util/pingpong.c#L1882) from later version. [Commit](https://github.com/ofiwg/libfabric/commit/17d9cf2c5a168bc22b6e98d2220cd7f802861233) related to the patch. Description of the patch:

pingpong doesn't support FI_MR_ENDPOINT today, So the mr is associated with domain instead of ep. It is unsafe to close mr before closing ep because it can cause an EBUSY error when there are outstanding recvs of the mr posted to the ep/qp. This patch fixes this issue by moving the mr close after.