### PR TITLE
hmem_cuda: Add fallback for dmabuf flag with CUDA_ERROR_NOT_SUPPORTED

### DIFF
--- a/fabtests/common/hmem_cuda.c
+++ b/fabtests/common/hmem_cuda.c
@@ -461,7 +461,7 @@ int ft_cuda_get_dmabuf_fd(void *buf, size_t len,
 						CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
 						flags);
 
-	if (cuda_ret == CUDA_ERROR_INVALID_VALUE && flags != 0) {
+	if ((cuda_ret == CUDA_ERROR_INVALID_VALUE || cuda_ret == CUDA_ERROR_NOT_SUPPORTED) && flags != 0) {
 		FT_WARN("cuMemGetHandleForAddressRange failed with flags: %llu, "
 		       "invalid argument. Retrying with no flags.\n", flags);
 		cuda_ret = cuda_ops.cuMemGetHandleForAddressRange(

--- a/src/hmem_cuda.c
+++ b/src/hmem_cuda.c
@@ -732,7 +732,7 @@ int cuda_get_dmabuf_fd(const void *addr, uint64_t size, int *fd,
 						CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
 						flags);
 
-	if (cuda_ret == CUDA_ERROR_INVALID_VALUE && flags != 0) {
+	if ((cuda_ret == CUDA_ERROR_INVALID_VALUE || cuda_ret == CUDA_ERROR_NOT_SUPPORTED) && flags != 0) {
 		FI_INFO(&core_prov, FI_LOG_CORE,
 			"cuMemGetHandleForAddressRange failed with flags: %llu, "
 			"invalid argument. Retrying with no flags.\n", flags);


### PR DESCRIPTION
cuMemGetHandleForAddressRange will return CUDA_ERROR_NOT_SUPPORTED on platforms where GPU memory is not cache coherent with the CPU. Also add runtime fallback for this error code.