### PR TITLE
prov/tcp: Add FI_GET_FD support to tcp provider

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -691,6 +691,7 @@ enum {
 	FI_GET_VAL,		/* struct fi_fid_var */
 	FI_SET_VAL,		/* struct fi_fid_var */
 	FI_EXPORT_FID,		/* struct fi_fid_export */
+	FI_GET_FD, 		/* int */
 };
 
 static inline int fi_control(struct fid *fid, int command, void *arg)

--- a/man/fi_tcp.7.md
+++ b/man/fi_tcp.7.md
@@ -90,6 +90,16 @@ show all environment variables defined for the tcp provider.
   through the standard socket APIs (i.e. connect, accept, send, recv).
   Default: disabled.
 
+# CONTROL OPERATIONS
+
+The tcp provider supports the following control operations (see [`fi_control`(3)](fi_control.3.html)):
+
+*FI_GET_FD*
+: Retrieve the underlying socket file descriptor associated with an active endpoint.
+  The argument must point to an integer where the descriptor will be stored.
+  This allows applications to tune socket options not exposed through the
+  libfabric API (SO_SNDBUF, SO_RCVBUF, SO_BUSY_POLL, etc).
+
 # NOTES
 
 The tcp provider supports both msg and rdm endpoints directly.  Support

--- a/prov/tcp/src/xnet_ep.c
+++ b/prov/tcp/src/xnet_ep.c
@@ -620,6 +620,9 @@ static int xnet_ep_ctrl(struct fid *fid, int command, void *arg)
 
 	ep = container_of(fid, struct xnet_ep, util_ep.ep_fid.fid);
 	switch (command) {
+	case FI_GET_FD:
+		*((int *)arg) = ep->bsock.sock;
+		break;
 	case FI_ENABLE:
 		if ((ofi_needs_rx(ep->util_ep.caps) && !ep->util_ep.rx_cq) ||
 		    (ofi_needs_tx(ep->util_ep.caps) && !ep->util_ep.tx_cq)) {


### PR DESCRIPTION
Adds the ability to retrieve the underlying file descriptor associated with an active endpoint in the tcp provider. This functionality is exposed through `fi_control()` using the new `FI_GET_FD` command.

The primary motivation is to allow applications to tune socket options that are not exposed through the libfabric API, such as:
 - `SO_SNDBUF`: Control send buffer size
 - `SO_RCVBUF`: Control receive buffer size
 - `SO_BUSY_POLL`: Enable busy polling for lower latency
 - ...