### PR TITLE
[v2.1.x] prov/efa & prov/util: EFA Use Locks for FI_THREAD_COMPLETION

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -1403,6 +1403,8 @@ ofi_progress_lock_type(enum fi_threading threading, enum fi_progress control)
 		control == FI_PROGRESS_CONTROL_UNIFIED ? OFI_LOCK_NOOP : OFI_LOCK_MUTEX;
 }
 
+int ofi_thread_level(enum fi_threading thread_model);
+
 #ifdef __cplusplus
 }
 #endif

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -184,6 +184,7 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 {
 	struct efa_domain *efa_domain;
 	int ret = 0, err;
+	bool use_lock;
 
 	efa_domain = calloc(1, sizeof(struct efa_domain));
 	if (!efa_domain)
@@ -203,8 +204,8 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 	efa_domain->ibv_mr_reg_ct = 0;
 	efa_domain->ibv_mr_reg_sz = 0;
 
-	err = ofi_genlock_init(&efa_domain->srx_lock, efa_domain->util_domain.threading != FI_THREAD_SAFE ?
-			       OFI_LOCK_NOOP : OFI_LOCK_MUTEX);
+	use_lock = ofi_thread_level(efa_domain->util_domain.threading) <= ofi_thread_level(FI_THREAD_COMPLETION);
+	err = ofi_genlock_init(&efa_domain->srx_lock, use_lock ? OFI_LOCK_MUTEX : OFI_LOCK_NOOP);
 	if (err) {
 		EFA_WARN(FI_LOG_DOMAIN, "srx lock init failed! err: %d\n", err);
 		ret = err;

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -454,7 +454,7 @@ int ofi_check_fabric_attr(const struct fi_provider *prov,
 /*
  * Threading models ranked by order of parallelism.
  */
-static int fi_thread_level(enum fi_threading thread_model)
+int ofi_thread_level(enum fi_threading thread_model)
 {
 	switch (thread_model) {
 	case FI_THREAD_SAFE:
@@ -588,8 +588,8 @@ int ofi_check_domain_attr(const struct fi_provider *prov, uint32_t api_version,
 {
 	const struct fi_domain_attr *user_attr = user_info->domain_attr;
 
-	if (fi_thread_level(user_attr->threading) <
-	    fi_thread_level(prov_attr->threading)) {
+	if (ofi_thread_level(user_attr->threading) <
+	    ofi_thread_level(prov_attr->threading)) {
 		FI_INFO(prov, FI_LOG_CORE, "Invalid threading model\n");
 		return -FI_ENODATA;
 	}


### PR DESCRIPTION
Back Ports the two commits:

```
commit e6bec45f571e6434201f042056fe6c599c3bb710 (HEAD -> v2.1.x-backport-use-locks-for-fi-thread-completion, szegel/v2.1.x-backport-use-locks-for-fi-thread-completion)
Author: Seth Zegelstein <szegel@amazon.com>
Date:   Fri Apr 4 23:43:00 2025 +0000

    [v2.1.x]prov/efa: Use mutex locks for FI_THREAD_COMPLETE
    
    The EFA provider does not support the FI_THREAD_COMPLETE locking
    optimization. EFA attempts to lock the SRX lock in both the tx
    and completion path. This behavior leads to an ofi_genlock assertion
    being hit when a FI_THREAD_COMPLETE App runs with EFA compiled in
    debug mode. Switch EFA to use locking in order to provide the correct
    behavior for FI_THREAD_COMPLETE.
    
    Signed-off-by: Seth Zegelstein <szegel@amazon.com>
    (cherry picked from commit 0a63f00ccc7397f04c6f38fb7b0b5d255e87ded1)

commit 0726b8614b8bea519a624effafe2728efbe2d2ea
Author: Seth Zegelstein <szegel@amazon.com>
Date:   Fri Apr 4 23:35:23 2025 +0000

    [v2.1.x]prov/util: Move/Rename fi_thread_level() to header
    
    Allow libfabric providers to call fi_thread_level(). Rename
    fi_thread_level() to ofi_thread_level().
    
    Signed-off-by: Seth Zegelstein <szegel@amazon.com>
    (cherry picked from commit aeb254d62340615ec1f29e764897c5ea4f3b532f)

```