### PR TITLE
prov/efa: Delete unused efa_conn_release prototype

### DIFF
--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -239,9 +239,6 @@ void efa_ah_release(struct efa_av *av, struct efa_ah *ah)
 	}
 }
 
-static
-void efa_conn_release(struct efa_av *av, struct efa_conn *conn);
-
 /**
  * @brief initialize the rdm related resources of an efa_conn object
  *


### PR DESCRIPTION
The actual function is declared below, with no callers in between.