### PR TITLE
prov/efa: Create 1:1 relationship between domain and PD, move address handle to domain level

### DIFF
--- a/prov/efa/src/efa_av.h
+++ b/prov/efa/src/efa_av.h
@@ -67,7 +67,6 @@ struct efa_av {
 	 */
 	struct efa_cur_reverse_av *cur_reverse_av;
 	struct efa_prv_reverse_av *prv_reverse_av;
-	struct efa_ah *ah_map;
 	struct util_av util_av;
 	struct ofi_bufpool *rdm_peer_pool;
 };
@@ -84,5 +83,9 @@ struct efa_conn *efa_av_addr_to_conn(struct efa_av *av, fi_addr_t fi_addr);
 fi_addr_t efa_av_reverse_lookup_rdm(struct efa_av *av, uint16_t ahn, uint16_t qpn, struct efa_rdm_pke *pkt_entry);
 
 fi_addr_t efa_av_reverse_lookup(struct efa_av *av, uint16_t ahn, uint16_t qpn);
+
+struct efa_ah *efa_ah_alloc(struct efa_domain *domain, const uint8_t *gid);
+
+void efa_ah_release(struct efa_domain *domain, struct efa_ah *ah);
 
 #endif

--- a/prov/efa/src/efa_base_ep.c
+++ b/prov/efa/src/efa_base_ep.c
@@ -113,7 +113,7 @@ int efa_base_ep_destruct(struct efa_base_ep *base_ep)
 	fi_freeinfo(base_ep->info);
 
 	if (base_ep->self_ah)
-		ibv_destroy_ah(base_ep->self_ah);
+		efa_ah_release(base_ep->domain, base_ep->self_ah);
 
 	err = efa_base_ep_destruct_qp(base_ep);
 
@@ -306,13 +306,9 @@ int efa_base_ep_enable_qp(struct efa_base_ep *base_ep, struct efa_qp *qp)
 static inline
 int efa_base_ep_create_self_ah(struct efa_base_ep *base_ep, struct ibv_pd *ibv_pd)
 {
-	struct ibv_ah_attr ah_attr;
 
-	memset(&ah_attr, 0, sizeof(ah_attr));
-	ah_attr.port_num = 1;
-	ah_attr.is_global = 1;
-	memcpy(ah_attr.grh.dgid.raw, base_ep->src_addr.raw, EFA_GID_LEN);
-	base_ep->self_ah = ibv_create_ah(ibv_pd, &ah_attr);
+	base_ep->self_ah = efa_ah_alloc(base_ep->domain, base_ep->src_addr.raw);
+
 	return base_ep->self_ah ? 0 : -FI_EINVAL;
 }
 

--- a/prov/efa/src/efa_base_ep.h
+++ b/prov/efa/src/efa_base_ep.h
@@ -81,7 +81,7 @@ struct efa_base_ep {
 	struct fi_info *info;
 	size_t rnr_retry;
 	struct efa_ep_addr src_addr;
-	struct ibv_ah *self_ah;
+	struct efa_ah *self_ah;
 
 	bool util_ep_initialized;
 	bool efa_qp_enabled;

--- a/prov/efa/src/efa_device.h
+++ b/prov/efa/src/efa_device.h
@@ -17,7 +17,6 @@ struct efa_device {
 	union ibv_gid		ibv_gid;
 	uint32_t		device_caps;
 	uint32_t		max_rdma_size;
-	struct ibv_pd		*ibv_pd;
 	struct fi_info		*rdm_info;
 	struct fi_info		*dgram_info;
 };

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -91,8 +91,13 @@ static int efa_domain_init_device_and_pd(struct efa_domain *efa_domain,
 	if (i == g_efa_selected_device_cnt)
 		return -FI_ENODEV;
 
+	efa_domain->ibv_pd = ibv_alloc_pd(efa_domain->device->ibv_ctx);
+	if (!efa_domain->ibv_pd) {
+		EFA_WARN(FI_LOG_DOMAIN, "Failed to allocated ibv_pd: %d\n", errno);
+		return -FI_ENOMEM;
+	}
+
 	EFA_INFO(FI_LOG_DOMAIN, "Domain %s selected device %s\n", domain_name, device_name);
-	efa_domain->ibv_pd = efa_domain->device->ibv_pd;
 	return 0;
 }
 
@@ -347,6 +352,9 @@ static int efa_domain_close(fid_t fid)
 	}
 
 	if (efa_domain->ibv_pd) {
+		ret = ibv_dealloc_pd(efa_domain->ibv_pd);
+		if (ret)
+			EFA_WARN(FI_LOG_DOMAIN, "Failed to dealloc ibv_pd: %d\n", ret);
 		efa_domain->ibv_pd = NULL;
 	}
 

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -209,6 +209,8 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 	efa_domain->ibv_mr_reg_ct = 0;
 	efa_domain->ibv_mr_reg_sz = 0;
 
+	efa_domain->ah_map = NULL;
+
 	use_lock = ofi_thread_level(efa_domain->util_domain.threading) <= ofi_thread_level(FI_THREAD_COMPLETION);
 	err = ofi_genlock_init(&efa_domain->srx_lock, use_lock ? OFI_LOCK_MUTEX : OFI_LOCK_NOOP);
 	if (err) {
@@ -338,6 +340,7 @@ err_free:
 static int efa_domain_close(fid_t fid)
 {
 	struct efa_domain *efa_domain;
+	struct efa_ah *ah_entry, *tmp;
 	int ret;
 
 	efa_domain = container_of(fid, struct efa_domain,
@@ -350,6 +353,20 @@ static int efa_domain_close(fid_t fid)
 		free(efa_domain->cache);
 		efa_domain->cache = NULL;
 	}
+
+	/* Clean up ah_map if any entries remain */
+	ofi_genlock_lock(&efa_domain->util_domain.lock);
+	if (efa_domain->ah_map) {
+		EFA_WARN(FI_LOG_DOMAIN, "AH map not empty during domain close! Cleaning up ...\n");
+		HASH_ITER(hh, efa_domain->ah_map, ah_entry, tmp) {
+			ret = ibv_destroy_ah(ah_entry->ibv_ah);
+			if (ret)
+				EFA_WARN(FI_LOG_DOMAIN, "ibv_destroy_ah failed during cleanup! err=%d\n", ret);
+			HASH_DEL(efa_domain->ah_map, ah_entry);
+			free(ah_entry);
+		}
+	}
+	ofi_genlock_unlock(&efa_domain->util_domain.lock);
 
 	if (efa_domain->ibv_pd) {
 		ret = ibv_dealloc_pd(efa_domain->ibv_pd);

--- a/prov/efa/src/efa_domain.h
+++ b/prov/efa/src/efa_domain.h
@@ -34,6 +34,7 @@ struct efa_domain {
 	bool 			mr_local;
 	struct dlist_entry	list_entry; /* linked to g_efa_domain_list */
 	struct ofi_genlock	srx_lock; /* shared among peer providers */
+	struct efa_ah		*ah_map;
 	/* Total count of ibv memory registrations */
 	size_t ibv_mr_reg_ct;
 	/* Total size of memory registrations (in bytes) */

--- a/prov/efa/src/efa_fork_support.c
+++ b/prov/efa/src/efa_fork_support.c
@@ -86,6 +86,7 @@ static int efa_fork_support_is_enabled()
 	return fork_status != IBV_FORK_DISABLED;
 #else
 	struct ibv_mr *mr = NULL;
+	struct ibv_pd *ibv_pd;
 	char *buf = NULL;
 	int ret=0, ret_init=0;
 	long page_size;
@@ -101,7 +102,14 @@ static int efa_fork_support_is_enabled()
 	if (!buf)
 		return -FI_ENOMEM;
 
-	mr = ibv_reg_mr(g_efa_selected_device_list[0].ibv_pd, buf, page_size, 0);
+	ibv_pd = ibv_alloc_pd(g_efa_selected_device_list[0].ibv_ctx);
+	if (!ibv_pd) {
+		EFA_WARN(FI_LOG_CORE, "Failed to allocate ibv pd: %d\n", errno);
+		free(buf);
+		return -FI_ENOMEM;
+	}
+
+	mr = ibv_reg_mr(ibv_pd, buf, page_size, 0);
 	if (mr == NULL) {
 		ret = errno;
 		goto out;
@@ -119,6 +127,7 @@ static int efa_fork_support_is_enabled()
 out:
 	if(buf) free(buf);
 	if(mr) ibv_dereg_mr(mr);
+	if(ibv_pd) ibv_dealloc_pd(ibv_pd);
 	if (ret) {
 		EFA_WARN(FI_LOG_CORE,
 			"Unexpected error during ibv_reg_mr in "

--- a/prov/efa/src/efa_hmem.c
+++ b/prov/efa/src/efa_hmem.c
@@ -111,6 +111,7 @@ static inline void efa_hmem_info_check_p2p_support_cuda(struct efa_hmem_info *in
 	cudaError_t cuda_ret;
 	void *ptr = NULL;
 	struct ibv_mr *ibv_mr;
+	struct ibv_pd *ibv_pd;
 	int ibv_access = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ;
 	size_t len = ofi_get_page_size() * 2;
 	int ret;
@@ -124,26 +125,34 @@ static inline void efa_hmem_info_check_p2p_support_cuda(struct efa_hmem_info *in
 			 ofi_cudaGetErrorString(cuda_ret));
 		return;
 	}
+
+	ibv_pd = ibv_alloc_pd(g_efa_selected_device_list[0].ibv_ctx);
+	if (!ibv_pd) {
+		EFA_WARN(FI_LOG_CORE, "failed to allocate ibv_pd: %d", errno);
+		ofi_cudaFree(ptr);
+		return;
+	}
+
 #if HAVE_EFA_DMABUF_MR
 	ret = cuda_get_dmabuf_fd(ptr, len, &dmabuf_fd, &dmabuf_offset);
 	if (ret == FI_SUCCESS) {
-		ibv_mr = ibv_reg_dmabuf_mr(g_efa_selected_device_list[0].ibv_pd, dmabuf_offset,
+		ibv_mr = ibv_reg_dmabuf_mr(ibv_pd, dmabuf_offset,
 					   len, (uint64_t)ptr, dmabuf_fd, ibv_access);
 		(void)cuda_put_dmabuf_fd(dmabuf_fd);
 		if (!ibv_mr) {
 			EFA_INFO(FI_LOG_CORE,
 				"Unable to register CUDA device buffer via dmabuf: %s. "
 				"Fall back to ibv_reg_mr\n", fi_strerror(-errno));
-			ibv_mr = ibv_reg_mr(g_efa_selected_device_list[0].ibv_pd, ptr, len, ibv_access);
+			ibv_mr = ibv_reg_mr(ibv_pd, ptr, len, ibv_access);
 		}
 	} else {
 		EFA_INFO(FI_LOG_CORE,
 			"Unable to retrieve dmabuf fd of CUDA device buffer: %d. "
 			"Fall back to ibv_reg_mr\n", ret);
-		ibv_mr = ibv_reg_mr(g_efa_selected_device_list[0].ibv_pd, ptr, len, ibv_access);
+		ibv_mr = ibv_reg_mr(ibv_pd, ptr, len, ibv_access);
 	}
 #else
-	ibv_mr = ibv_reg_mr(g_efa_selected_device_list[0].ibv_pd, ptr, len, ibv_access);
+	ibv_mr = ibv_reg_mr(ibv_pd, ptr, len, ibv_access);
 #endif
 
 	if (!ibv_mr) {
@@ -151,11 +160,13 @@ static inline void efa_hmem_info_check_p2p_support_cuda(struct efa_hmem_info *in
 		EFA_WARN(FI_LOG_CORE,
 			 "Failed to register CUDA buffer with the EFA device, FI_HMEM transfers that require peer to peer support will fail.\n");
 		ofi_cudaFree(ptr);
+		(void) ibv_dealloc_pd(ibv_pd);
 		return;
 	}
 
 	ret = ibv_dereg_mr(ibv_mr);
 	ofi_cudaFree(ptr);
+	(void) ibv_dealloc_pd(ibv_pd);
 	if (ret) {
 		EFA_WARN(FI_LOG_CORE,
 			 "Failed to deregister CUDA buffer: %s\n",
@@ -173,6 +184,7 @@ static inline void efa_hmem_info_check_p2p_support_cuda(struct efa_hmem_info *in
 static inline void efa_hmem_info_check_p2p_support_neuron(struct efa_hmem_info *info) {
 #if HAVE_NEURON
 	struct ibv_mr *ibv_mr = NULL;
+	struct ibv_pd *ibv_pd;
 	int ibv_access = IBV_ACCESS_LOCAL_WRITE;
 	void *handle;
 	void *ptr = NULL;
@@ -197,20 +209,27 @@ static inline void efa_hmem_info_check_p2p_support_neuron(struct efa_hmem_info *
 		return;
 	}
 
+	ibv_pd = ibv_alloc_pd(g_efa_selected_device_list[0].ibv_ctx);
+	if (!ibv_pd) {
+		EFA_WARN(FI_LOG_CORE, "failed to allocate ibv_pd: %d", errno);
+		neuron_free(&handle);
+		return;
+	}
+
 #if HAVE_EFA_DMABUF_MR
 	ret = neuron_get_dmabuf_fd(ptr, (uint64_t)len, &dmabuf_fd, &offset);
 	if (ret == FI_SUCCESS) {
 		ibv_mr = ibv_reg_dmabuf_mr(
-					g_efa_selected_device_list[0].ibv_pd, offset,
+					ibv_pd, offset,
 					len, (uint64_t)ptr, dmabuf_fd, ibv_access);
 	} else if (ret == -FI_EOPNOTSUPP) {
 		EFA_INFO(FI_LOG_MR,
 			"Unable to retrieve dmabuf fd of Neuron device buffer, "
 			"Fall back to ibv_reg_mr\n");
-		ibv_mr = ibv_reg_mr(g_efa_selected_device_list[0].ibv_pd, ptr, len, ibv_access);
+		ibv_mr = ibv_reg_mr(ibv_pd, ptr, len, ibv_access);
 	}
 #else
-	ibv_mr = ibv_reg_mr(g_efa_selected_device_list[0].ibv_pd, ptr, len, ibv_access);
+	ibv_mr = ibv_reg_mr(ibv_pd, ptr, len, ibv_access);
 #endif
 
 	if (!ibv_mr) {
@@ -220,11 +239,13 @@ static inline void efa_hmem_info_check_p2p_support_neuron(struct efa_hmem_info *
 		         "Failed to register Neuron buffer with the EFA device, "
 		         "FI_HMEM transfers that require peer to peer support will fail.\n");
 		neuron_free(&handle);
+		(void) ibv_dealloc_pd(ibv_pd);
 		return;
 	}
 
 	ret = ibv_dereg_mr(ibv_mr);
 	neuron_free(&handle);
+	(void) ibv_dealloc_pd(ibv_pd);
 	if (ret) {
 		EFA_WARN(FI_LOG_CORE,
 			 "Failed to deregister Neuron buffer: %s\n",

--- a/prov/efa/src/rdm/efa_rdm_pke.c
+++ b/prov/efa/src/rdm/efa_rdm_pke.c
@@ -521,7 +521,7 @@ int efa_rdm_pke_read(struct efa_rdm_pke *pkt_entry,
 
 	ibv_wr_set_sge_list(qp->ibv_qp_ex, 1, &sge);
 	if (txe->peer == NULL) {
-		ibv_wr_set_ud_addr(qp->ibv_qp_ex, ep->base_ep.self_ah,
+		ibv_wr_set_ud_addr(qp->ibv_qp_ex, ep->base_ep.self_ah->ibv_ah,
 				   qp->qp_num, qp->qkey);
 	} else {
 		conn = efa_av_addr_to_conn(ep->base_ep.av, pkt_entry->addr);
@@ -613,7 +613,7 @@ int efa_rdm_pke_write(struct efa_rdm_pke *pkt_entry)
 		   For now, each WR contains only one sge. */
 	ibv_wr_set_sge_list(qp->ibv_qp_ex, 1, &sge);
 	if (self_comm) {
-		ibv_wr_set_ud_addr(qp->ibv_qp_ex, ep->base_ep.self_ah,
+		ibv_wr_set_ud_addr(qp->ibv_qp_ex, ep->base_ep.self_ah->ibv_ah,
 				   qp->qp_num, qp->qkey);
 	} else {
 		conn = efa_av_addr_to_conn(ep->base_ep.av, pkt_entry->addr);

--- a/prov/efa/test/efa_unit_test_av.c
+++ b/prov/efa/test/efa_unit_test_av.c
@@ -7,8 +7,9 @@
 /**
  * @brief Only works on nodes with EFA devices
  * This test calls fi_av_insert() twice with the same raw address,
- * and verifies that returned fi_addr is the same and
- * ibv_create_ah only gets called once.
+ * and verifies that returned fi_addr is the same.
+ * Since the addresses to be inserted have the same GID with the ep's self ah,
+ * there should be only 1 ibv_create_ah call in the whole test.
  *
  * @param[in]	state		struct efa_resource that is managed by the framework
  */
@@ -20,16 +21,16 @@ void test_av_insert_duplicate_raw_addr(struct efa_resource **state)
 	fi_addr_t addr1, addr2;
 	int err, num_addr;
 
-	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_FABRIC_NAME);
 	g_efa_unit_test_mocks.ibv_create_ah = &efa_mock_ibv_create_ah_check_mock;
+	/* the following will_return ensures ibv_create_ah is called exactly once */
+	will_return(efa_mock_ibv_create_ah_check_mock, 0);
+
+	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_FABRIC_NAME);
 
 	err = fi_getname(&resource->ep->fid, &raw_addr, &raw_addr_len);
 	assert_int_equal(err, 0);
 	raw_addr.qpn = 1;
 	raw_addr.qkey = 0x1234;
-
-	/* the following will_return ensures ibv_create_ah is called exactly once */
-	will_return(efa_mock_ibv_create_ah_check_mock, 0);
 
 	num_addr = fi_av_insert(resource->av, &raw_addr, 1, &addr1, 0 /* flags */, NULL /* context */);
 	assert_int_equal(num_addr, 1);
@@ -42,8 +43,9 @@ void test_av_insert_duplicate_raw_addr(struct efa_resource **state)
 /**
  * @brief Only works on nodes with EFA devices
  * This test calls fi_av_insert() twice with two difference raw address with same GID,
- * and verifies that returned fi_addr is different and ibv_create_ah only gets called once.
- * this is because libfabric EFA provider has a cache for address handle (AH).
+ * and verifies that returned fi_addr is different.
+ * Since the addresses to be inserted have the same GID with the ep's self ah,
+ * there should be only 1 ibv_create_ah call in the whole test.
  *
  * @param[in]	state		struct efa_resource that is managed by the framework
  */
@@ -55,16 +57,16 @@ void test_av_insert_duplicate_gid(struct efa_resource **state)
 	fi_addr_t addr1, addr2;
 	int err, num_addr;
 
-	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_FABRIC_NAME);
 	g_efa_unit_test_mocks.ibv_create_ah = &efa_mock_ibv_create_ah_check_mock;
+	/* the following will_return ensures ibv_create_ah is called exactly once */
+	will_return(efa_mock_ibv_create_ah_check_mock, 0);
+
+	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_FABRIC_NAME);
 
 	err = fi_getname(&resource->ep->fid, &raw_addr, &raw_addr_len);
 	assert_int_equal(err, 0);
 	raw_addr.qpn = 1;
 	raw_addr.qkey = 0x1234;
-
-	/* the following will_return ensures ibv_create_ah is called exactly once */
-	will_return(efa_mock_ibv_create_ah_check_mock, 0);
 
 	num_addr = fi_av_insert(resource->av, &raw_addr, 1, &addr1, 0 /* flags */, NULL /* context */);
 	assert_int_equal(num_addr, 1);
@@ -74,4 +76,129 @@ void test_av_insert_duplicate_gid(struct efa_resource **state)
 	num_addr = fi_av_insert(resource->av, &raw_addr, 1, &addr2, 0 /* flags */, NULL /* context */);
 	assert_int_equal(num_addr, 1);
 	assert_int_not_equal(addr1, addr2);
+}
+
+void test_efa_ah_cnt_one_av(struct efa_resource **state)
+{
+	struct efa_resource *resource = *state;
+	struct efa_ep_addr raw_addr = {0};
+	size_t raw_addr_len = sizeof(struct efa_ep_addr);
+	fi_addr_t addr1, addr2;
+	int err, num_addr;
+	struct efa_domain *efa_domain;
+	struct efa_ah *efa_ah = NULL;
+
+	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_FABRIC_NAME);
+
+	efa_domain = container_of(resource->domain, struct efa_domain, util_domain.domain_fid);
+
+	err = fi_getname(&resource->ep->fid, &raw_addr, &raw_addr_len);
+	assert_int_equal(err, 0);
+
+	/* So far we should only have 1 ah from ep self ah, and its refcnt is 1 */
+	assert_int_equal(HASH_CNT(hh, efa_domain->ah_map), 1);
+	HASH_FIND(hh, efa_domain->ah_map, raw_addr.raw, EFA_GID_LEN, efa_ah);
+	assert_non_null(efa_ah);
+	assert_int_equal(efa_ah->refcnt, 1);
+
+	raw_addr.qpn = 1;
+	raw_addr.qkey = 0x1234;
+
+	num_addr = fi_av_insert(resource->av, &raw_addr, 1, &addr1, 0 /* flags */, NULL /* context */);
+	assert_int_equal(num_addr, 1);
+
+	raw_addr.qpn = 2;
+	raw_addr.qkey = 0x5678;
+	num_addr = fi_av_insert(resource->av, &raw_addr, 1, &addr2, 0 /* flags */, NULL /* context */);
+	assert_int_equal(num_addr, 1);
+	assert_int_not_equal(addr1, addr2);
+
+	/* So far we should still have 1 ah, and its refcnt is 3 (plus the 2 av entries) */
+	assert_int_equal(HASH_CNT(hh, efa_domain->ah_map), 1);
+	assert_int_equal(efa_ah->refcnt, 3);
+
+	/* ah refcnt should be decremented to 1 after av entry removals */
+	assert_int_equal(fi_av_remove(resource->av, &addr1, 1, 0), 0);
+	assert_int_equal(fi_av_remove(resource->av, &addr2, 1, 0), 0);
+
+	assert_int_equal(HASH_CNT(hh, efa_domain->ah_map), 1);
+	assert_int_equal(efa_ah->refcnt, 1);
+
+	/* ah map should be empty now after closing ep which destroys the self ah */
+	assert_int_equal(fi_close(&resource->ep->fid), 0);
+	assert_int_equal(HASH_CNT(hh, efa_domain->ah_map), 0);
+	/* Reset to NULL to avoid test reaper closing again */
+	resource->ep = NULL;
+}
+
+void test_efa_ah_cnt_multi_av(struct efa_resource **state)
+{
+	struct efa_resource *resource = *state;
+	struct efa_ep_addr raw_addr = {0};
+	size_t raw_addr_len = sizeof(struct efa_ep_addr);
+	fi_addr_t addr1, addr2;
+	int err, num_addr;
+	struct efa_domain *efa_domain;
+	struct efa_ah *efa_ah = NULL;
+	struct fi_av_attr av_attr = {0};
+	struct fid_av *av1, *av2;
+	struct fid_ep *ep1, *ep2;
+
+	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_DIRECT_FABRIC_NAME);
+
+	efa_domain = container_of(resource->domain, struct efa_domain, util_domain.domain_fid);
+
+	err = fi_getname(&resource->ep->fid, &raw_addr, &raw_addr_len);
+	assert_int_equal(err, 0);
+
+	/* So far we should only have 1 ah from ep self ah, and its refcnt is 1 */
+	assert_int_equal(HASH_CNT(hh, efa_domain->ah_map), 1);
+	HASH_FIND(hh, efa_domain->ah_map, raw_addr.raw, EFA_GID_LEN, efa_ah);
+	assert_non_null(efa_ah);
+	assert_int_equal(efa_ah->refcnt, 1);
+
+
+	/* We open 2 avs with the same domain (PD) so they should share same AH given the same GID */
+	assert_int_equal(fi_av_open(resource->domain, &av_attr, &av1, NULL), 0);
+	assert_int_equal(fi_av_open(resource->domain, &av_attr, &av2, NULL), 0);
+
+	/* Due to the current restriction in efa provider, we have to bind av to ep before inserting av entry */
+	/* These eps will not create self ah as they are not enabled */
+	assert_int_equal(fi_endpoint(resource->domain, resource->info, &ep1, NULL), 0);
+	assert_int_equal(fi_endpoint(resource->domain, resource->info, &ep2, NULL), 0);
+
+	assert_int_equal(fi_ep_bind(ep1, &av1->fid, 0), 0);
+	assert_int_equal(fi_ep_bind(ep2, &av2->fid, 0), 0);
+
+	raw_addr.qpn = 1;
+	raw_addr.qkey = 0x1234;
+
+	num_addr = fi_av_insert(av1, &raw_addr, 1, &addr1, 0 /* flags */, NULL /* context */);
+	assert_int_equal(num_addr, 1);
+
+	raw_addr.qpn = 2;
+	raw_addr.qkey = 0x5678;
+	num_addr = fi_av_insert(av2, &raw_addr, 1, &addr2, 0 /* flags */, NULL /* context */);
+	assert_int_equal(num_addr, 1);
+	/* They should be as equal as 0 they are in different avs */
+	assert_int_equal(addr1, addr2);
+
+	/* So far we should still have 1 ah, and its refcnt is 3 (plus the 2 av entries) */
+	assert_int_equal(HASH_CNT(hh, efa_domain->ah_map), 1);
+	assert_int_equal(efa_ah->refcnt, 3);
+
+	/* ah refcnt should be decremented to 1 after av close */
+	assert_int_equal(fi_close(&ep1->fid), 0);
+	assert_int_equal(fi_close(&ep2->fid), 0);
+	assert_int_equal(fi_close(&av1->fid), 0);
+	assert_int_equal(fi_close(&av2->fid), 0);
+
+	assert_int_equal(HASH_CNT(hh, efa_domain->ah_map), 1);
+	assert_int_equal(efa_ah->refcnt, 1);
+
+	/* ah map should be empty now after closing ep which destroys the self ah */
+	assert_int_equal(fi_close(&resource->ep->fid), 0);
+	assert_int_equal(HASH_CNT(hh, efa_domain->ah_map), 0);
+	/* Reset to NULL to avoid test reaper closing again */
+	resource->ep = NULL;
 }

--- a/prov/efa/test/efa_unit_test_cq.c
+++ b/prov/efa/test/efa_unit_test_cq.c
@@ -497,7 +497,7 @@ void test_rdm_cq_create_error_handling(struct efa_resource **state)
 		return;
 	}
 	efa_device_construct_gid(&efa_device, ibv_device_list[0]);
-	efa_device_construct_pd(&efa_device, ibv_device_list[0]);
+	efa_device_construct_data(&efa_device, ibv_device_list[0]);
 
 	resource->hints = efa_unit_test_alloc_hints(FI_EP_RDM, EFA_FABRIC_NAME);
 	assert_non_null(resource->hints);

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -92,6 +92,8 @@ int main(void)
 		/* begin efa_unit_test_av.c */
 		cmocka_unit_test_setup_teardown(test_av_insert_duplicate_raw_addr, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_av_insert_duplicate_gid, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_ah_cnt_one_av, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_ah_cnt_multi_av, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		/* end efa_unit_test_av.c */
 
 		cmocka_unit_test_setup_teardown(test_efa_device_construct_error_handling, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -109,6 +109,8 @@ struct efa_rdm_ope *efa_unit_test_alloc_rxe(struct efa_resource *resource, uint3
 /* begin efa_unit_test_av.c */
 void test_av_insert_duplicate_raw_addr();
 void test_av_insert_duplicate_gid();
+void test_efa_ah_cnt_one_av();
+void test_efa_ah_cnt_multi_av();
 /* end efa_unit_test_av.c */
 
 void test_efa_device_construct_error_handling();

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -89,7 +89,7 @@ struct efa_unit_test_handshake_pkt_attr {
 int efa_device_construct_gid(struct efa_device *efa_device,
 			 struct ibv_device *ibv_device);
 
-int efa_device_construct_pd(struct efa_device *efa_device,
+int efa_device_construct_data(struct efa_device *efa_device,
 			 struct ibv_device *ibv_device);
 
 void efa_unit_test_buff_construct(struct efa_unit_test_buff *buff, struct efa_resource *resource, size_t buff_size);


### PR DESCRIPTION
This PR has 2 changes:

1. Make 1:1 relationship between efa domain and pd: Today, protection domain (PD) is created in efa_device discovery, when
    multiple domains are created against the same efa_device in the
    same process, there will share the same PD. Such implementation breaks
    the boundary of domain that resources created in different
    domains can finally interfere with each other, such as MR and AH.
    
    This patch fixes this issue by making PD created/destroyed by domain
    open and close, so there is a 1:1 relationship between domain
    and PD.

2. Move address handle to domain level: Today, the efa address handle (AH) resources are
    created and tracked in the AV level. This is wrong because for multiple AVs created in the same domain, they share the same PD and the created AHs will not be independent. When one AV gets closed and destroyed its AHs, WQEs posted via other AHs that share the same PD and GID will get aborted.
    
    This patch fixes this issue by doing the following:
    
    1. Move ah_map (hash map, key is GID, value is AH) from efa_av to efa_domain which now has a 1:1 map to PD. The map is protected by the domain lock.
    2. When fi_av_insert decide to create a new av entry, look up the AH in the device ah_map (in the locking), if it's not found, create AH and initialize its refcnt as 1 and insert to hashmap. If it's found, return the AH and increment its refcnt.
    3. In fi_av_remove, do the look up again in ah_map, decrement the refcnt of the returned AH. If the refcnt is 0, destroy the AH and delete it from the hashmap
    4. In efa_domain close, iterate the ah map again and destroy all uncleaned AHs (with warning).