### PR TITLE
[v2.1.x]prov/efa: Use Mutex when removing from g_efa_domain_list

### DIFF
--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -338,7 +338,9 @@ static int efa_domain_close(fid_t fid)
 	efa_domain = container_of(fid, struct efa_domain,
 				  util_domain.domain_fid.fid);
 
+	ofi_mutex_lock(&g_efa_domain_list_lock);
 	dlist_remove(&efa_domain->list_entry);
+	ofi_mutex_unlock(&g_efa_domain_list_lock);
 
 	if (efa_domain->cache) {
 		ofi_mr_cache_cleanup(efa_domain->cache);


### PR DESCRIPTION
Commit 633d2919 added a mutex lock around g_efa_domain_list list insertion in order to keep the EFA control interface thread safe, but forgot to add the mutex lock around the list item removal.  This commit fixes that mistake.


(cherry picked from commit 2015b6c6c3773bd8c6d4bd6bba3b3d5b741fbf29)