### PR TITLE
Support new Windows EFA driver v1.1.0 released in Q2 of 2025

### DIFF
--- a/.appveyor.ps1
+++ b/.appveyor.ps1
@@ -15,7 +15,7 @@ Write-Verbose "moving NetworkDirect headers.."
 move NetDirect\include\* prov\netdir\NetDirect
 Write-Verbose "done"
 
-$efaWinVersion="1.0.0"
+$efaWinVersion="1.1.0"
 Write-Verbose "downloading efawin version ${efaWinVersion} files.."
 Invoke-WebRequest -Uri "https://github.com/aws/efawin/archive/refs/tags/v${efaWinVersion}.zip" -OutFile "efawin.zip"
 Write-Verbose "done"


### PR DESCRIPTION
A new version of the Windows EFA driver has been officially released. It is now available using a new [tag v1.1.0](https://github.com/aws/efawin/tree/v1.1.0) in the efawin repository. The change is required on the v1.15.x branch, which is used by the [AWS CDI-SDK](https://github.com/aws/aws-cdi-sdk). The AWS CDI-SDK will be updated to use this branch and the new driver after this pull request has been merged.

This change updates the .appveyor.ps1 Windows install script to use the new tag.