### PR TITLE
prov/efa: Clear cur_device when filtering EFA devices with FI_EFA_IFACE

### DIFF
--- a/prov/efa/src/efa_device.c
+++ b/prov/efa/src/efa_device.c
@@ -253,6 +253,8 @@ int efa_device_list_initialize(void)
 	}
 
 	for (device_idx = 0; device_idx < total_device_cnt; device_idx++) {
+		memset(&cur_device, 0, sizeof(struct efa_device));
+
 		err = efa_device_construct_gid(&cur_device,
 					   ibv_device_list[device_idx]);
 


### PR DESCRIPTION
This commit fixes a bug that happens on instances with multiple EFA devices and the FI_EFA_IFACE filter is used to select any EFA device except the last one.