### PR TITLE
[v2.1.x] prov/efa: Clear cur_device when filtering EFA devices with FI_EFA_IFACE

### DIFF
--- a/prov/efa/src/efa_device.c
+++ b/prov/efa/src/efa_device.c
@@ -230,6 +230,8 @@ int efa_device_list_initialize(void)
 	}
 
 	for (device_idx = 0; device_idx < total_device_cnt; device_idx++) {
+		memset(&cur_device, 0, sizeof(struct efa_device));
+
 		err = efa_device_construct_gid(&cur_device,
 					   ibv_device_list[device_idx]);
 


### PR DESCRIPTION
This commit fixes a bug that happens on instances with multiple EFA devices and the FI_EFA_IFACE filter is used to select any EFA device except the last one.


(cherry picked from commit 938635ef52d0d279a34ead381ee50c6b095cf4b6)