### PR TITLE
prov/cxi: Fix compiler warnings related to curl/json dl_open

### DIFF
--- a/prov/cxi/include/cxip.h
+++ b/prov/cxi/include/cxip.h
@@ -3034,7 +3034,7 @@ int cxip_json_double(const char *desc, struct json_object *jobj, double *val);
 int cxip_json_string(const char *desc, struct json_object *jobj,
 		     const char **val);
 struct json_object *cxip_json_tokener_parse(const char *str);
-void cxip_json_object_put(struct json_object *obj);
+int cxip_json_object_put(struct json_object *obj);
 
 /* Perform zero-buffer collectives */
 void cxip_tree_rowcol(int radix, int nodeidx, int *row, int *col, int *siz);

--- a/prov/cxi/src/cxip_curl.c
+++ b/prov/cxi/src/cxip_curl.c
@@ -15,8 +15,12 @@
 #include <ofi.h>
 #include "cxip.h"
 
+#if ENABLE_CXI_CURL_DLOPEN
 static void *cxip_curlhandle;
+#endif
+#if ENABLE_CXI_JSON_DLOPEN
 static void *cxip_jsonhandle;
+#endif
 static CURLM *cxip_curlm;
 static int cxip_curl_count;
 static int cxip_json_dl_init(void);
@@ -699,7 +703,7 @@ struct jsondl_ops {
         double  (*dl_json_object_get_double)(const struct json_object *);
         const char * (*dl_json_object_get_string)(struct json_object *);
 	struct json_object * (*dl_json_tokener_parse)(const char *);
-	void (*dl_json_object_put)(struct json_object *);
+	int (*dl_json_object_put)(struct json_object *);
 };
 
 /* dynamic bind of symbols with dlopen()/dlsym() */
@@ -985,7 +989,7 @@ struct json_object *cxip_json_tokener_parse(const char *str)
 	return jsondl_ops.dl_json_tokener_parse(str);
 }
 
-void cxip_json_object_put(struct json_object *obj)
+int cxip_json_object_put(struct json_object *obj)
 {
-	jsondl_ops.dl_json_object_put(obj);
+	return jsondl_ops.dl_json_object_put(obj);
 }

--- a/prov/cxi/src/cxip_info.c
+++ b/prov/cxi/src/cxip_info.c
@@ -1325,8 +1325,8 @@ CXI_INI
 	 */
 	ret = cxip_curl_init();
 	if(ret != FI_SUCCESS) {
-		CXIP_WARN("cxip_curl_init() failed! in %s()\n", __func__);
-		CXIP_WARN("removing collective support from CXI prov fi_getinfo()", __func__);
+		CXIP_WARN("cxip_curl_init() failed!\n");
+		CXIP_WARN("removing collective support from CXI prov fi_getinfo()\n");
 		cxip_collectives_supported = false;
 	}
 


### PR DESCRIPTION
Fix compiler warnings for when curl/json DL open is not enabled (wrong function return type and unused variables, improper log statement).