### PR TITLE
Support 32-bit architectures

### DIFF
--- a/include/ofi_atom.h
+++ b/include/ofi_atom.h
@@ -73,10 +73,10 @@ typedef atomic_long	ofi_atomic_int64_t;
 #endif
 
 #define OFI_ATOMIC_DEFINE(radix)									\
-	typedef struct {										\
-		ofi_atomic_int##radix##_t val;								\
-		ATOMIC_DEF_INIT;									\
-	} ofi_atomic##radix##_t;									\
+	 typedef struct {                                                  \
+		ofi_atomic_int##radix##_t val __attribute__((aligned((radix)/8))); \
+		ATOMIC_DEF_INIT;                                                \
+	 } ofi_atomic##radix##_t;									\
 													\
 	static inline											\
 	int##radix##_t ofi_atomic_inc##radix(ofi_atomic##radix##_t *atomic)				\

--- a/include/ofi_cma.h
+++ b/include/ofi_cma.h
@@ -64,8 +64,14 @@ static inline int cma_copy(struct iovec *local, unsigned long local_cnt,
 		if (!total)
 			return FI_SUCCESS;
 
-		ofi_consume_iov(local, &local_cnt, (size_t) ret);
-		ofi_consume_iov(remote, &remote_cnt, (size_t) ret);
+		size_t local_size = local_cnt;
+		size_t remote_size = remote_cnt;
+
+		ofi_consume_iov(local, &local_size, (size_t)ret);
+		ofi_consume_iov(remote, &remote_size, (size_t)ret);
+
+		local_cnt = local_size;
+		remote_cnt = remote_size;
 	}
 }
 

--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -278,9 +278,9 @@ static inline void smr_freestack_init(struct smr_freestack *fs, size_t elem_coun
 	fs->entry_base_offset =
 		((char*) &fs->entry_next[0] - (char*) fs) +
 		fs->size * sizeof(fs->top);
-	next_aligned_addr = ofi_get_aligned_size((( (uint64_t) fs) +
+	next_aligned_addr = ofi_get_aligned_size((( (uintptr_t) fs) +
 			fs->entry_base_offset), SMR_ALIGN_BOUNDARY);
-	fs->entry_base_offset = next_aligned_addr - ((uint64_t) fs);
+	fs->entry_base_offset = next_aligned_addr - ((uintptr_t) fs);
 	for (i = elem_count - 1; i >= 0; i--)
 		smr_freestack_push_by_index(fs, i);
 }

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -346,7 +346,7 @@ void ofi_mr_get_iov_from_dmabuf(struct iovec *iov,
 
 	for (i = 0; i < count; i++) {
 		iov[i].iov_base = (void *) (
-			(uintptr_t) dmabuf[i].base_addr + dmabuf[i].offset);
+			(char *) dmabuf[i].base_addr + dmabuf[i].offset);
 		iov[i].iov_len = dmabuf[i].len;
 	}
 }

--- a/prov/hook/hook_hmem/src/hook_hmem.c
+++ b/prov/hook/hook_hmem/src/hook_hmem.c
@@ -81,7 +81,7 @@ static int hook_hmem_add_region(struct hook_hmem_domain *domain,
 	attr.access = FI_SEND | FI_RECV | FI_READ | FI_WRITE |
 		      FI_REMOTE_READ | FI_REMOTE_WRITE;
 	attr.offset = 0;
-	attr.requested_key = (uint64_t) *hmem_desc;
+	attr.requested_key = (uintptr_t) *hmem_desc;
 	attr.iface = iface;
 	attr.device.reserved = device;
 

--- a/prov/hook/trace/src/hook_trace.c
+++ b/prov/hook/trace/src/hook_trace.c
@@ -33,6 +33,7 @@
 #include "ofi_prov.h"
 #include "ofi_iov.h"
 #include <config.h>
+#include <inttypes.h>
 
 #include <rdma/fi_profile.h>
 struct hook_trace_ep {
@@ -205,7 +206,7 @@ static void hook_trace_prof_init(void *context)
 	if (!(ret)) { \
 		if ((flags)) \
 			FI_TRACE((fabric)->hprov, FI_LOG_EP_CTRL, \
-				 "ep/pep %p flags 0x%lx\n", \
+				 "ep/pep %p flags 0x%" PRIx64 "\n", \
 				 (void *)(ep), (uint64_t)(flags)); \
 		else \
 			FI_TRACE((fabric)->hprov, FI_LOG_EP_CTRL, \
@@ -221,35 +222,36 @@ static void hook_trace_prof_init(void *context)
 #define TRACE_EP_MSG(ret, ep, buf, len, addr, data, flags, context) \
 	if (!(ret)) { \
 		FI_TRACE((ep)->domain->fabric->hprov, FI_LOG_EP_DATA, \
-			"buf %p len %zu addr %zu data %lu " \
-			"flags 0x%zx ctx %p\n", \
-			buf, len, addr, (uint64_t)data, \
-			(uint64_t)flags, context); \
+			"buf %p len %zu addr %" PRIuPTR " data 0x%" PRIx64 " " \
+			"flags 0x%" PRIxPTR " ctx %p\n", \
+			(void *)(buf), (size_t)(len), (uintptr_t)(addr), (uint64_t)(data), \
+			(uintptr_t)flags, (void *)(context)); \
 	}
 
 #define TRACE_EP_RMA(ret, ep, buf, len, addr, raddr, data, flags, key, context) \
 	if (!(ret)) { \
 		FI_TRACE((ep)->domain->fabric->hprov, FI_LOG_EP_DATA, \
-			"buf %p len %zu addr %zu raddr %lu data %lu " \
-			"flags 0x%zx key 0x%zx ctx %p\n", \
-			buf, len, addr, (uint64_t)raddr, (uint64_t)data, \
-			(uint64_t)flags, (uint64_t)key, context); \
+			"buf %p len %zu addr %" PRIuPTR " raddr %" PRIu64 " data %" PRIu64 " " \
+			"flags 0x%" PRIxPTR " key 0x%" PRIxPTR " ctx %p\n", \
+			(void *)(buf), (size_t)(len), (uintptr_t)(addr), (uint64_t)(raddr),  \
+			(uint64_t)(data), (uintptr_t)(flags), (uintptr_t)(key), (void *)(context)); \
 	}
 
 #define TRACE_EP_TAGGED(ret, ep, buf, len, addr, data, flags, tag, ignore, context) \
 	if (!(ret)) { \
 		FI_TRACE((ep)->domain->fabric->hprov, FI_LOG_EP_DATA, \
-			"buf %p len %zu addr %zu data %lu " \
-			"flags 0x%zx tag 0x%lx ignore 0x%zx ctx %p\n", \
-			buf, len, addr, (uint64_t)data, (uint64_t)flags, \
-			(uint64_t)tag, (uint64_t)ignore, context); \
+			"buf %p len %zu addr %" PRIuPTR " data %" PRIu64 " " \
+			"flags 0x%" PRIxPTR " tag 0x%" PRIxPTR " ignore 0x%" PRIxPTR " ctx %p\n", \
+			(void *)(buf), (size_t)(len), (uintptr_t)(addr), (uint64_t)(data),  \
+			(uintptr_t)(flags), (uintptr_t)tag, (uintptr_t)ignore, (void *)(context)); \
 	}
 
 #define TRACE_MR_ATTR(ret, buf, size, dom, mr, len, flags, attr)    \
 	if (!(ret)) { \
-		FI_TRACE(dom->fabric->hprov, FI_LOG_DOMAIN, \
-		     "mr %p len %lu flags 0x%lx\n%s",  mr, (len), (flags), \
-		      fi_tostr_r(buf, size, (void *)attr, FI_TYPE_MR_ATTR)); \
+		FI_TRACE(dom->fabric->hprov, FI_LOG_DOMAIN,									\
+		     "mr %p len %zu flags 0x%" PRIx64 "\n%s",  (void *)(mr), (size_t)(len),	\
+		      (uint64_t)(flags), fi_tostr_r(buf, size, (void *)attr,				\
+				  FI_TYPE_MR_ATTR));												\
 	}
 
 #define TRACE_ENDPOINT(buf, len, dom, name, ep, context, info)  \
@@ -300,12 +302,12 @@ trace_cq_msg_entry(const struct fi_provider *prov, const char *func,
 	for (i = 0; i < count; i++) {
 		if (entry[i].flags & FI_RECV) {
 			fi_log(prov, FI_LOG_TRACE, FI_LOG_CQ, func, line,
-			       "ctx %p flags 0x%lx len %zu\n",
-			       entry[i].op_context, entry[i].flags,  entry[i].len);
+			       "ctx %p flags 0x%" PRIx64 " len %zu\n",
+			       entry[i].op_context, (uint64_t)entry[i].flags,  entry[i].len);
 		} else {
 			fi_log(prov, FI_LOG_TRACE, FI_LOG_CQ, func, line,
-			       "ctx %p flags 0x%lx\n",
-			       entry[i].op_context, entry[i].flags);
+			       "ctx %p flags 0x%" PRIx64 "\n",
+			       entry[i].op_context, (uint64_t)entry[i].flags);
 		}
 	}
 }
@@ -320,14 +322,14 @@ trace_cq_data_entry(const struct fi_provider *prov, const char *func,
 	for (i = 0; i < count; i++) {
 		if (entry[i].flags & FI_RECV) {
 			fi_log(prov, FI_LOG_TRACE, FI_LOG_CQ, func, line,
-			       "ctx %p flags 0x%lx len %zu buf %p, data %lu\n",
-			       entry[i].op_context, entry[i].flags,
+			       "ctx %p flags 0x%" PRIx64 " len %zu buf %p, data %" PRIu64 "\n",
+			       entry[i].op_context, (uint64_t)entry[i].flags,
 			       entry[i].len, entry[i].buf,
-			       (entry[i].flags & FI_REMOTE_CQ_DATA) ? entry[i].data : 0);
+			       (entry[i].flags & FI_REMOTE_CQ_DATA) ? (uint64_t)entry[i].data : 0);
 		} else {
 			fi_log(prov, FI_LOG_TRACE, FI_LOG_CQ, func, line,
-			       "ctx %p flags 0x%lx\n",
-			       entry[i].op_context, entry[i].flags);
+			       "ctx %p flags 0x%" PRIx64 "\n",
+			       entry[i].op_context, (uint64_t)entry[i].flags);
 		}
 	}
 }
@@ -342,15 +344,15 @@ trace_cq_tagged_entry(const struct fi_provider *prov, const char *func,
 	for (i = 0; i < count; i++) {
 		if (entry[i].flags & FI_RECV) {
 			fi_log(prov, FI_LOG_TRACE, FI_LOG_CQ, func, line,
-			       "ctx %p flags 0x%lx len %zu buf %p, data %lu tag 0x%lx\n",
-			       entry[i].op_context, entry[i].flags,
+			       "ctx %p flags 0x%" PRIx64 " len %zu buf %p, data %" PRIu64 " tag 0x%" PRIx64 "\n",
+			       entry[i].op_context, (uint64_t)entry[i].flags,
 			       entry[i].len, entry[i].buf,
-			       (entry[i].flags & FI_REMOTE_CQ_DATA) ? entry[i].data : 0,
-			       entry[i].tag);
+			       (uint64_t)(entry[i].flags & FI_REMOTE_CQ_DATA) ? entry[i].data : 0,
+			       (uint64_t)entry[i].tag);
 		} else {
 			fi_log(prov, FI_LOG_TRACE, FI_LOG_CQ, func, line,
-			       "ctx %p flags 0x%lx\n",
-			       entry[i].op_context, entry[i].flags);
+			       "ctx %p flags 0x%" PRIx64 "\n",
+			       entry[i].op_context, (uint64_t)entry[i].flags);
 		}
 	}
 }
@@ -387,16 +389,16 @@ trace_cq_err(struct hook_cq *cq, const char *func, int line,
 	if (entry->flags & FI_RECV) {
 		fi_log(cq->domain->fabric->hprov, FI_LOG_TRACE, FI_LOG_CQ,
 		       func, line,
-		       "ctx %p flags 0x%lx, len %zu buf %p data %lu tag 0x%lx "
+		       "ctx %p flags 0x%" PRIx64 ", len %zu buf %p data 0x%" PRIx64 " tag 0x%" PRIx64 " "
 		       "olen %zu err %d (%s) prov_errno %d (%s)\n",
-		       entry->op_context, entry->flags, entry->len, entry->buf,
-		       entry->data, entry->tag, entry->olen,  
+		       entry->op_context, (uint64_t)entry->flags, entry->len, entry->buf,
+		       (uint64_t)entry->data, (uint64_t)entry->tag, entry->olen,  
 		       entry->err, fi_strerror(entry->err),
 		       entry->prov_errno, err_buf);
 	} else {
 		fi_log(cq->domain->fabric->hprov, FI_LOG_TRACE, FI_LOG_CQ,
 		       func, line,
-		       "ctx %p flags 0x%lx, data %lu tag 0x%lx "
+		       "ctx %p flags 0x%" PRIx64 ", data %" PRIu64 " tag 0x%" PRIx64 " "
 		       "olen %zu err %d (%s) prov_errno %d (%s)\n",
 		       entry->op_context, entry->flags,
 		       entry->data, entry->tag, entry->olen,

--- a/prov/lnx/include/lnx.h
+++ b/prov/lnx/include/lnx.h
@@ -358,7 +358,7 @@ int lnx_create_mr(const struct iovec *iov, fi_addr_t addr,
 
 	rc = ofi_mr_cache_search(&lnx_dom->ld_mr_cache, &info, mre);
 	if (rc) {
-		ofi_hmem_dev_unregister(attr.iface, (uint64_t)attr.hmem_data);
+		ofi_hmem_dev_unregister(attr.iface, (uintptr_t)attr.hmem_data);
 		return rc;
 	}
 

--- a/prov/lnx/src/lnx_av.c
+++ b/prov/lnx/src/lnx_av.c
@@ -74,7 +74,7 @@ lnx_av_lookup_addr(struct lnx_peer_table *peer_tbl, fi_addr_t addr)
 
 	if (!entry)
 		FI_WARN(&lnx_prov, FI_LOG_CORE,
-			"Invalid fi_addr %#lx\n", addr);
+			"Invalid fi_addr %#" PRIx64 "\n", addr);
 
 	return entry;
 }

--- a/prov/lnx/src/lnx_domain.c
+++ b/prov/lnx/src/lnx_domain.c
@@ -497,7 +497,7 @@ static void lnx_addr_del_region(struct ofi_mr_cache *cache,
 {
 	struct ofi_mr *mr = (struct ofi_mr *)entry->data;
 
-	ofi_hmem_dev_unregister(mr->iface, (uint64_t) mr->hmem_data);
+	ofi_hmem_dev_unregister(mr->iface, (uintptr_t) mr->hmem_data);
 }
 
 /*

--- a/prov/lnx/src/lnx_ep.c
+++ b/prov/lnx/src/lnx_ep.c
@@ -901,7 +901,7 @@ static void lnx_close_ep_ctx(struct local_prov_ep *ep, size_t fclass)
 		rc = fi_close(&ep_ctx[i]->fid);
 		if (rc)
 			FI_WARN(&lnx_prov, FI_LOG_CORE,
-				"Failed to close ep context %lu with %d\n",
+				"Failed to close ep context %zu with %d\n",
 				fclass, rc);
 	}
 }

--- a/prov/lpp/src/lpp_completion.c
+++ b/prov/lpp/src/lpp_completion.c
@@ -89,7 +89,7 @@ void lpp_completion_recv(struct lpp_ep *lpp_epp, uint64_t flags, uint64_t data,
 
 	if (status)
 		FI_WARN(&lpp_prov, FI_LOG_CQ,
-			"RECV error code: %d (buf: %p, len: %ld)\n", status, buf, len);
+			"RECV error code: %d (buf: %p, len: %zu)\n", status, buf, len);
 
 	if (status == 0 && olen != 0) {
 		status = EMSGSIZE;

--- a/prov/lpp/src/lpp_cq.c
+++ b/prov/lpp/src/lpp_cq.c
@@ -30,6 +30,8 @@
  * SOFTWARE.
  */
 
+#include <inttypes.h>
+
 #include "lpp.h"
 
 static const struct fi_ops lpp_fi_cq_ops = {
@@ -66,7 +68,7 @@ static int lpp_cq_verify_attr(struct fi_cq_attr *attr)
 
 #define CHECK_ATTR(actual, op, desired)													\
 	if (actual op desired) {													\
-		FI_INFO(&lpp_prov, FI_LOG_CQ, #actual " (%ld) " #op " " #desired " (%ld)\n", (uint64_t)actual, (uint64_t)desired);	\
+		FI_INFO(&lpp_prov, FI_LOG_CQ, #actual " (%" PRIuPTR ") " #op " " #desired " (%" PRIuPTR ")\n", (uintptr_t)actual, (uintptr_t)desired);	\
 		return -FI_EINVAL;													\
 	}
 
@@ -336,12 +338,12 @@ void lpp_cq_enqueue_entry(struct lpp_cq *lpp_cqp, struct klpp_cq_tagged_entry *e
 {
 	if (lpp_cqp->header->overrun) {
 		FI_WARN(&lpp_prov, FI_LOG_CQ,
-			"CQ in overrun state, dropping completion (flags %lx)\n",
-			entry->generic.flags);
+			"CQ in overrun state, dropping completion (flags %" PRIx64 ")\n",
+			(uint64_t)entry->generic.flags);
 	} else if (klpp_ringbuf_enqueue_cq(lpp_cqp->cq, lpp_cqp->num_entries, entry) != 0) {
 		FI_WARN(&lpp_prov, FI_LOG_CQ,
-			"Unable to enqueue CQ entry, setting overrun (flags %lx)\n",
-			entry->generic.flags);
+			"Unable to enqueue CQ entry, setting overrun (flags %" PRIx64 ")\n",
+			(uint64_t)entry->generic.flags);
 		lpp_cqp->header->overrun = 1;
 	}
 }

--- a/prov/lpp/src/lpp_domain.c
+++ b/prov/lpp/src/lpp_domain.c
@@ -337,16 +337,16 @@ int lpp_domain_verify_attrs(const struct klppioc_lf *klpp_devinfo,
 		return -FI_ENODATA;											\
 	}
 
-	CHECK_ATTR(mr_key_size, attr->mr_key_size, >, fi_domain_default_attrs.mr_key_size, "%ld");
-	CHECK_ATTR(cq_data_size, attr->cq_data_size, >, fi_domain_default_attrs.cq_data_size, "%ld");
-	CHECK_ATTR(cq_cnt, attr->cq_cnt, >, fi_domain_default_attrs.cq_cnt, "%ld");
-	CHECK_ATTR(ep_cnt, attr->ep_cnt, >, fi_domain_default_attrs.ep_cnt, "%ld");
-	CHECK_ATTR(max_ep_tx_ctx, attr->max_ep_tx_ctx, >, fi_domain_default_attrs.max_ep_tx_ctx, "%ld");
-	CHECK_ATTR(max_ep_rx_ctx, attr->max_ep_rx_ctx, >, fi_domain_default_attrs.max_ep_rx_ctx, "%ld");
-	CHECK_ATTR(cntr_cnt, attr->cntr_cnt, >, fi_domain_default_attrs.cntr_cnt, "%ld");
-	CHECK_ATTR(mr_iov_limit, attr->mr_iov_limit, >, fi_domain_default_attrs.mr_iov_limit, "%ld");
-	CHECK_ATTR(max_err_data, attr->max_err_data, >, fi_domain_default_attrs.max_err_data, "%ld");
-	CHECK_ATTR(mr_cnt, attr->mr_cnt, >, fi_domain_default_attrs.mr_cnt, "%ld");
+	CHECK_ATTR(mr_key_size, attr->mr_key_size, >, fi_domain_default_attrs.mr_key_size, "%zu");
+	CHECK_ATTR(cq_data_size, attr->cq_data_size, >, fi_domain_default_attrs.cq_data_size, "%zu");
+	CHECK_ATTR(cq_cnt, attr->cq_cnt, >, fi_domain_default_attrs.cq_cnt, "%zu");
+	CHECK_ATTR(ep_cnt, attr->ep_cnt, >, fi_domain_default_attrs.ep_cnt, "%zu");
+	CHECK_ATTR(max_ep_tx_ctx, attr->max_ep_tx_ctx, >, fi_domain_default_attrs.max_ep_tx_ctx, "%zu");
+	CHECK_ATTR(max_ep_rx_ctx, attr->max_ep_rx_ctx, >, fi_domain_default_attrs.max_ep_rx_ctx, "%zu");
+	CHECK_ATTR(cntr_cnt, attr->cntr_cnt, >, fi_domain_default_attrs.cntr_cnt, "%zu");
+	CHECK_ATTR(mr_iov_limit, attr->mr_iov_limit, >, fi_domain_default_attrs.mr_iov_limit, "%zu");
+	CHECK_ATTR(max_err_data, attr->max_err_data, >, fi_domain_default_attrs.max_err_data, "%zu");
+	CHECK_ATTR(mr_cnt, attr->mr_cnt, >, fi_domain_default_attrs.mr_cnt, "%zu");
 
 #undef CHECK_ATTR
 

--- a/prov/lpp/src/lpp_ep.c
+++ b/prov/lpp/src/lpp_ep.c
@@ -176,14 +176,14 @@ int lpp_verify_ep_attrs(const struct klppioc_lf *klpp_devinfo, struct fi_ep_attr
 	}
 
 	if ((ep_attrs->rx_ctx_cnt != 0) && (ep_attrs->rx_ctx_cnt != 1)) {
-		FI_INFO(&lpp_prov, FI_LOG_EP_CTRL, "invalid rx_ctx_cnt: %lu\n",
+		FI_INFO(&lpp_prov, FI_LOG_EP_CTRL, "invalid rx_ctx_cnt: %zu\n",
 				ep_attrs->tx_ctx_cnt);
 		return -FI_EINVAL;
 	}
 
 	if ((ep_attrs->tx_ctx_cnt != 0) && (ep_attrs->tx_ctx_cnt != 1) &&
 	    (ep_attrs->tx_ctx_cnt != FI_SHARED_CONTEXT)) {
-		FI_INFO(&lpp_prov, FI_LOG_EP_CTRL, "invalid tx_ctx_cnt: %lu\n",
+		FI_INFO(&lpp_prov, FI_LOG_EP_CTRL, "invalid tx_ctx_cnt: %zu\n",
 				ep_attrs->tx_ctx_cnt);
 		return -FI_EINVAL;
 	}
@@ -635,7 +635,7 @@ int lpp_fi_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 		status = lpp_ep_bind_stx(fid, bfid, flags);
 		break;
 	default:
-		FI_WARN(&lpp_prov, FI_LOG_EP_CTRL, "invalid bind class %ld\n",
+		FI_WARN(&lpp_prov, FI_LOG_EP_CTRL, "invalid bind class %zu\n",
 			bfid->fclass);
 		status = -FI_EINVAL;
 		break;

--- a/prov/lpp/src/lpp_getinfo.c
+++ b/prov/lpp/src/lpp_getinfo.c
@@ -54,13 +54,13 @@ static int lpp_getinfo_match(const struct klppioc_lf *klpp_devinfo,
 		return 0;
 	// Compare the modes the application supports to those we require.
 	if ((hints->mode & LPP_MODE) != LPP_MODE) {
-		FI_INFO(&lpp_prov, FI_LOG_FABRIC, "hint mode %lx invalid for LPP mode %x\n", hints->mode, LPP_MODE);
+		FI_INFO(&lpp_prov, FI_LOG_FABRIC, "hint mode %" PRIx64 " invalid for LPP mode %x\n", (uint64_t)hints->mode, LPP_MODE);
 		return -FI_ENODATA;
 	}
 
 	// Compare the capabilities requested to those we can provide.
 	if ((hints->caps & LPP_CAPS) != hints->caps) {
-		FI_INFO(&lpp_prov, FI_LOG_FABRIC, "hint caps %lx invalid for LPP caps %llx\n", hints->caps, LPP_CAPS);
+		FI_INFO(&lpp_prov, FI_LOG_FABRIC, "hint caps %" PRIx64 " invalid for LPP caps %llx\n", (uint64_t)hints->caps, LPP_CAPS);
 		return -FI_ENODATA;
 	}
 
@@ -222,7 +222,7 @@ int lpp_fi_getinfo(uint32_t version, const char *node, const char *service,
 			continue;
 		}
 		if (klpp_getdevice(klpp_fd, &klpp_devinfo) < 0) {
-			FI_WARN(&lpp_prov, FI_LOG_FABRIC, "failed to query KLPP device %ld\n", i);
+			FI_WARN(&lpp_prov, FI_LOG_FABRIC, "failed to query KLPP device %zu\n", i);
 			continue;
 		}
 		close(klpp_fd);

--- a/prov/lpp/src/lpp_io.c
+++ b/prov/lpp/src/lpp_io.c
@@ -31,6 +31,7 @@
  */
 
 #include <stdatomic.h>
+#include <inttypes.h>
 
 #include "lpp.h"
 
@@ -94,8 +95,8 @@ static int lpp_try_pio(struct lpp_domain *lpp_domainp, struct lpp_ep *lpp_epp,
 
 	if (dst_addr < rmr_meta->legal_remote_start_uaddr) {
 		FI_WARN(&lpp_prov, FI_LOG_EP_DATA,
-			"PIO start out of bounds %lx %lx\n", dst_addr,
-			rmr_meta->legal_remote_start_uaddr);
+			"PIO start out of bounds %" PRIx64 " %" PRIx64 "\n", (uint64_t)dst_addr,
+			(uint64_t)rmr_meta->legal_remote_start_uaddr);
 		return -1;
 	}
 
@@ -104,13 +105,13 @@ static int lpp_try_pio(struct lpp_domain *lpp_domainp, struct lpp_ep *lpp_epp,
 
 	if (rmr_meta->legal_length < legal_offset + write_length) {
 		FI_WARN(&lpp_prov, FI_LOG_EP_DATA,
-			"PIO write out of range (region len: %ld offset: %ld len:%ld\n",
+			"PIO write out of range (region len: %" PRIu64 " offset: %" PRIu64 " len:%zu\n",
 			rmr_meta->legal_length, legal_offset, write_length);
 		return -1;
 	}
 
 	baseaddr = (rmr_meta->region == KLPP_RMR_RW) ? lpp_domainp->rmr_rw : lpp_domainp->rmr_ro;
-	rmr_buf = (void *)((uintptr_t)baseaddr + rmr_meta->offset + offset_in_region);
+	rmr_buf = (void *)((uintptr_t)baseaddr + (uintptr_t)rmr_meta->offset + (uintptr_t)offset_in_region);
 
 	if (flags & FI_WRITE) {
 		memcpy(rmr_buf, src_buf, write_length);
@@ -171,26 +172,26 @@ ssize_t lpp_rma_common(struct fid_ep *ep, const struct iovec *local_iovp,
 	}
 
 	if ((lpp_stxp->attr.caps & flags & LPP_CAPS_OPS) != (flags & LPP_CAPS_OPS)) {
-		FI_WARN(&lpp_prov, FI_LOG_EP_DATA, "TX attr caps (%lx) incorrect for requested op (%lx)\n",
-			lpp_stxp->attr.caps, flags);
+		FI_WARN(&lpp_prov, FI_LOG_EP_DATA, "TX attr caps (0%" PRIx64 ") incorrect for requested op (%" PRIx64 ")\n",
+			(uint64_t)lpp_stxp->attr.caps, (uint64_t)flags);
 		return -FI_EINVAL;
 	}
 
 	// Make sure that we won't overrun our IOVs in the descriptors.
 	if (local_iov_count > lpp_stxp->attr.rma_iov_limit) {
-		FI_WARN(&lpp_prov, FI_LOG_EP_DATA, "local iov count out of range, (%lu/%lu)\n",
+		FI_WARN(&lpp_prov, FI_LOG_EP_DATA, "local iov count out of range, (%zu/%zu)\n",
 		    local_iov_count, lpp_stxp->attr.rma_iov_limit);
 		return -FI_EINVAL;
 	}
 	if (remote_iov_count > lpp_stxp->attr.rma_iov_limit) {
-		FI_WARN(&lpp_prov, FI_LOG_EP_DATA, "remote iov count out of range, (%lu/%lu)\n",
+		FI_WARN(&lpp_prov, FI_LOG_EP_DATA, "remote iov count out of range, (%zu/%zu)\n",
 		    remote_iov_count, lpp_stxp->attr.rma_iov_limit);
 		return -FI_EINVAL;
 	}
 
 	// Make sure that the inject data isn't too big.
 	if (((flags & FI_INJECT) != 0) && (local_iovp->iov_len > lpp_stxp->attr.inject_size)) {
-		FI_WARN(&lpp_prov, FI_LOG_EP_DATA, "inject size %ld exceeds maximum %ld\n",
+		FI_WARN(&lpp_prov, FI_LOG_EP_DATA, "inject size %zu exceeds maximum %zu\n",
 		    local_iovp->iov_len, lpp_stxp->attr.inject_size);
 		return -FI_EINVAL;
 	}
@@ -218,11 +219,11 @@ ssize_t lpp_rma_common(struct fid_ep *ep, const struct iovec *local_iovp,
 	}
 
 	if (local_iov_count > lpp_stxp->attr.rma_iov_limit) {
-		FI_WARN(&lpp_prov, FI_LOG_EP_DATA, "local iov_count %ld exceeds max %ld\n",
+		FI_WARN(&lpp_prov, FI_LOG_EP_DATA, "local iov_count %zu exceeds max %zu\n",
 		    local_iov_count, lpp_stxp->attr.rma_iov_limit);
 	}
 	if (remote_iov_count > lpp_stxp->attr.rma_iov_limit) {
-		FI_WARN(&lpp_prov, FI_LOG_EP_DATA, "remote iov_count %ld exceeds max %ld\n",
+		FI_WARN(&lpp_prov, FI_LOG_EP_DATA, "remote iov_count %zu exceeds max %zu\n",
 		    remote_iov_count, lpp_stxp->attr.rma_iov_limit);
 	}
 

--- a/prov/lpp/src/lpp_klpp.c
+++ b/prov/lpp/src/lpp_klpp.c
@@ -280,7 +280,7 @@ int klpp_ep_enable(struct lpp_ep *lpp_epp)
 	klppioc.cntr_remote_read_id	= PTR_TO_ID(lpp_epp->cntr_remote_read);
 	klppioc.cntr_remote_write_id	= PTR_TO_ID(lpp_epp->cntr_remote_write);
 
-	klppioc.io_stat_uaddr = (uint64_t)lpp_epp->io_stat;
+	klppioc.io_stat_uaddr = (uint64_t)(uintptr_t)lpp_epp->io_stat;
 
 	status = KLPP_IOCTL(lpp_epp->domain->fd, KLPPIOC_EP_ENABLE, &klppioc);
 
@@ -357,12 +357,12 @@ int klpp_readwrite(struct lpp_ep *lpp_epp, fi_addr_t addr, uint64_t length,
 
 	ioc_readwrite.ep_id = lpp_epp->id;
 	ioc_readwrite.fi_addr = addrstor.fi_addr;
-	ioc_readwrite.local_uaddr = (uint64_t)local_uaddr;
+	ioc_readwrite.local_uaddr = (uint64_t)(uintptr_t)local_uaddr;
 	ioc_readwrite.remote_uaddr = remote_uaddr;
 	ioc_readwrite.remote_key = remote_key;
 	ioc_readwrite.length = length;
 	ioc_readwrite.flags = flags;
-	ioc_readwrite.context = (uint64_t)context;
+	ioc_readwrite.context = (uint64_t)(uintptr_t)context;
 
 	return KLPP_IOCTL(lpp_epp->domain->fd, KLPPIOC_READWRITE, &ioc_readwrite);
 }
@@ -375,10 +375,10 @@ int klpp_umc_acquire(struct lpp_domain *lpp_domain, klpp_id_t *umc_id,
 	struct klpp_ioc_umc ioc;
 	int ret;
 
-	ioc.rx_base_uaddr = (uint64_t)rx_base;
-	ioc.tx_base_uaddr = (uint64_t)tx_base;
-	ioc.k2u_base_uaddr = (uint64_t)k2u_base;
-	ioc.u2k_base_uaddr = (uint64_t)u2k_base;
+	ioc.rx_base_uaddr = (uint64_t)(uintptr_t)rx_base;
+	ioc.tx_base_uaddr = (uint64_t)(uintptr_t)tx_base;
+	ioc.k2u_base_uaddr = (uint64_t)(uintptr_t)k2u_base;
+	ioc.u2k_base_uaddr = (uint64_t)(uintptr_t)u2k_base;
 	ioc.ep_addr = ep_addr;
 	ioc.port = *port;
 
@@ -412,7 +412,7 @@ int klpp_kmc_send_one(struct lpp_ep *lpp_epp, struct lpp_fi_addr dst_addr,
 
 	ioc.dst_addr = dst_addr;
 	ioc.msg_hdr = *hdr;
-	ioc.iov_ptr = (__u64)iov;
+	ioc.iov_ptr = (__u64)(uintptr_t)iov;
 	ioc.iov_cnt = (__u64)iov_count;
 	ioc.kmc_flags = lpp_disable_dqp ? KLPPIOCF_KMC_NODQP : 0;
 	ioc.next_ptr = 0;

--- a/prov/lpp/src/lpp_rx.c
+++ b/prov/lpp/src/lpp_rx.c
@@ -489,9 +489,9 @@ static void recv_rdzv(struct lpp_ep *lpp_epp, struct lpp_rx_entry *rx_entry,
 	}
 
 	u2k.type = KLPP_U2K_RDZV_RECV;
-	u2k.rdzv_recv.rx_op_ptr = (__u64)rx_op;
+	u2k.rdzv_recv.rx_op_ptr = (__u64)(uintptr_t)rx_op;
 	u2k.rdzv_recv.token = hdr->token;
-	u2k.rdzv_recv.base_uaddr = (__u64)rx_entry->msg_iov[0].iov_base;
+	u2k.rdzv_recv.base_uaddr = (__u64)(uintptr_t)rx_entry->msg_iov[0].iov_base;
 	u2k.rdzv_recv.base_length = rx_entry->msg_iov[0].iov_len;
 	u2k.rdzv_recv.offset = rx_op->offset;
 	u2k.rdzv_recv.length = rx_op->length;
@@ -543,7 +543,7 @@ ssize_t lpp_rx_verify_iov_count(struct lpp_rx *lpp_rxp, size_t iov_count)
 {
 	if (iov_count > lpp_rxp->attr.iov_limit) {
 		FI_WARN(&lpp_prov, FI_LOG_EP_DATA,
-		    "iov_count out of range (%ld/%ld)\n",
+		    "iov_count out of range (%zu/%zu)\n",
 		    iov_count, lpp_rxp->attr.iov_limit);
 		return -FI_EINVAL;
 	}
@@ -555,8 +555,8 @@ ssize_t lpp_rx_verify_flags(struct lpp_rx *lpp_rxp, uint64_t flags)
 	if ((lpp_rxp->attr.caps & flags & LPP_CAPS_OPS) !=
 	    (flags & LPP_CAPS_OPS)) {
 		FI_WARN(&lpp_prov, FI_LOG_EP_DATA,
-		    "RX attr caps (%lx) incorrect for requested op (%lx)\n",
-		    lpp_rxp->attr.caps, flags);
+		    "RX attr caps (0x%" PRIx64 ") incorrect for requested op (0x%" PRIx64 ")\n",
+		    (uint64_t)lpp_rxp->attr.caps, (uint64_t)flags);
 		return -FI_EINVAL;
 	}
 	return 0;
@@ -769,7 +769,7 @@ void lpp_rx_rdzv_done(struct lpp_ep *lpp_epp, struct klpp_umc_k2u *k2u)
 	struct iovec *iov;
 	size_t offset;
 
-	rx_op = (struct lpp_rx_op*)k2u->rdzv_recv_done.rx_op_ptr;
+	rx_op = (struct lpp_rx_op*)(uintptr_t)k2u->rdzv_recv_done.rx_op_ptr;
 	rx_entry = rx_op->rx_entry;
 
 	/* TODO is this a redundant computation? Kernel needs to do something

--- a/prov/lpp/src/lpp_stx.c
+++ b/prov/lpp/src/lpp_stx.c
@@ -195,7 +195,7 @@ struct lpp_stx *lpp_stx_alloc(struct lpp_domain *lpp_domainp, struct fi_tx_attr 
 
 	if (lpp_max_eager_size > lpp_tx_max_eager(&lpp_domainp->devinfo)) {
 		FI_WARN(&lpp_prov, FI_LOG_DOMAIN,
-		    "requested max eager size %ld exceeds max possible %ld\n",
+		    "requested max eager size %zu exceeds max possible %zu\n",
 		    lpp_max_eager_size, lpp_tx_max_eager(&lpp_domainp->devinfo));
 		lpp_max_eager_size = lpp_tx_max_eager(&lpp_domainp->devinfo);
 	}
@@ -393,7 +393,7 @@ static struct lpp_tx_entry *lpp_token_to_tx_entry(struct lpp_stx *lpp_stxp,
 
 	if (idx > lpp_stxp->attr.size) {
 		FI_WARN(&lpp_prov, FI_LOG_EP_DATA,
-		    "Out of bounds idx: %u (max %ld)\n",
+		    "Out of bounds idx: %u (max %zu)\n",
 		    idx, lpp_stxp->attr.size);
 		return NULL;
 	}
@@ -480,8 +480,8 @@ ssize_t lpp_tx_verify_flags(struct lpp_stx *lpp_stxp, uint64_t flags)
 	if ((lpp_stxp->attr.caps & flags & LPP_CAPS_OPS) !=
 	    (flags & LPP_CAPS_OPS)) {
 		FI_WARN(&lpp_prov, FI_LOG_EP_DATA,
-			"TX attr caps (%lx) incorrect for requested op (%lx)\n",
-			lpp_stxp->attr.caps, flags);
+			"TX attr caps (0x%" PRIx64 ") incorrect for requested op (0x%" PRIx64 ")\n",
+			(uint64_t)lpp_stxp->attr.caps, (uint64_t)flags);
 		return -FI_EINVAL;
 	}
 	return 0;
@@ -491,7 +491,7 @@ ssize_t lpp_tx_verify_rma_iov_count(struct lpp_stx *lpp_stxp, size_t iov_count)
 {
 	if (iov_count > lpp_stxp->attr.rma_iov_limit) {
 		FI_WARN(&lpp_prov, FI_LOG_EP_DATA,
-			"iov_count out of range (%ld/%ld)\n", iov_count,
+			"iov_count out of range (%zu/%zu)\n", iov_count,
 			lpp_stxp->attr.rma_iov_limit);
 		return -FI_EINVAL;
 	}
@@ -502,7 +502,7 @@ ssize_t lpp_tx_verify_iov_count(struct lpp_stx *lpp_stxp, size_t iov_count)
 {
 	if (iov_count > lpp_stxp->attr.iov_limit) {
 		FI_WARN(&lpp_prov, FI_LOG_EP_DATA,
-			"iov_count out of range (%ld/%ld)\n", iov_count,
+			"iov_count out of range (%zu/%zu)\n", iov_count,
 			lpp_stxp->attr.iov_limit);
 		return -FI_EINVAL;
 	}
@@ -772,7 +772,7 @@ ssize_t lpp_send_common(struct lpp_ep *lpp_epp, struct lpp_tx_entry *tx_entry)
 	if (tx_entry->flags & FI_INJECT) {
 		if (tx_entry->msg_hdr.data_length > lpp_stxp->attr.inject_size) {
 			FI_WARN(&lpp_prov, FI_LOG_EP_DATA,
-				"length %u exceeds max inject size %ld\n",
+				"length %u exceeds max inject size %zu\n",
 				tx_entry->msg_hdr.data_length,
 				lpp_stxp->attr.inject_size);
 			ret = -FI_EINVAL;
@@ -1020,7 +1020,7 @@ ssize_t lpp_atomic_common(struct lpp_ep *lpp_epp, struct lpp_tx_entry *tx_entry)
 	if (tx_entry->flags & FI_INJECT) {
 		if (tx_entry->msg_hdr.data_length > lpp_stxp->attr.inject_size) {
 			FI_WARN(&lpp_prov, FI_LOG_EP_DATA,
-				"length %u exceeds max inject size %ld\n",
+				"length %u exceeds max inject size %zu\n",
 				tx_entry->msg_hdr.data_length, lpp_stxp->attr.inject_size);
 			ret = -FI_EINVAL;
 			goto err_no_spool;

--- a/prov/lpp/src/lpp_umc.c
+++ b/prov/lpp/src/lpp_umc.c
@@ -201,7 +201,7 @@ static void lpp_umc_free_srq_spool(struct lpp_ep *lpp_epp)
 
 	for (ioc = spool->head; ioc != NULL; ioc = spool->head) {
 		smsg = container_of(ioc, struct lpp_spooled_msg_srq, ioc);
-		spool->head = (struct klpp_ioc_kmc_send *)ioc->next_ptr;
+		spool->head = (struct klpp_ioc_kmc_send *)(uintptr_t)ioc->next_ptr;
 		if (smsg->callback != NULL)
 			smsg->callback(lpp_epp, smsg + 1, -FI_ESHUTDOWN);
 
@@ -470,7 +470,7 @@ static void lpp_cmpl_srq_add(struct lpp_ep *lpp_epp, struct klpp_ioc_kmc_send *i
 		spool->head = ioc;
 		spool->tail = ioc;
 	} else {
-		spool->tail->next_ptr = (__u64)ioc;
+		spool->tail->next_ptr = (__u64)(uintptr_t)ioc;
 		spool->tail = ioc;
 	}
 	spool->size++;
@@ -508,7 +508,7 @@ static void lpp_cmpl_srq_flush(struct lpp_ep *lpp_epp)
 					"failed to srq send completion %lld\n",
 					ioc->errval);
 			}
-			spool->head = (struct klpp_ioc_kmc_send *)ioc->next_ptr;
+			spool->head = (struct klpp_ioc_kmc_send *)(uintptr_t)ioc->next_ptr;
 			if (spool->head == NULL)
 				spool->tail = NULL;
 
@@ -625,7 +625,7 @@ int lpp_umc_tx_cmpl(struct lpp_ep *lpp_epp, struct lpp_fi_addr addr,
 		ioc = &smsg->ioc;
 		ioc->dst_addr = addr;
 		ioc->kmc_flags = lpp_disable_dqp ? KLPPIOCF_KMC_NODQP : 0;
-		ioc->iov_ptr = (__u64)&smsg->iov;
+		ioc->iov_ptr = (__u64)(uintptr_t)&smsg->iov;
 		ioc->iov_cnt = iov_count;
 		hdr->src_ep = lpp_epp->addr;
 		ioc->msg_hdr = *hdr;
@@ -1026,7 +1026,7 @@ static void lpp_umc_check_keep_alive(struct lpp_ep *lpp_epp)
 			     lpp_keep_alive_msec)) {
 			if (rumc->keep_alive_cnt >= lpp_keep_alive_retries) {
 				FI_INFO(&lpp_prov, FI_LOG_EP_CTRL,
-					"%u:%u path down; failed to reply to %ld keep alives\n",
+					"%u:%u path down; failed to reply to %zu keep alives\n",
 					rumc->node_id, rumc->umc_id,
 					lpp_keep_alive_retries);
 				lpp_stx_path_down(lpp_epp, rumc->node_id,

--- a/prov/mrail/src/mrail_cq.c
+++ b/prov/mrail/src/mrail_cq.c
@@ -145,7 +145,7 @@ static int mrail_cq_process_rndv_req(struct fi_cq_tagged_entry *comp,
 	mrail_pkt = (struct mrail_pkt *)comp->buf;
 	rndv_hdr = (struct mrail_rndv_hdr *)&mrail_pkt[1];
 	rndv_req = (struct mrail_rndv_req *)&rndv_hdr[1];
-	recv->rndv.context = (void *)rndv_hdr->context;
+	recv->rndv.context = (void *)(uintptr_t)rndv_hdr->context;
 	recv->rndv.flags = comp->flags & FI_REMOTE_CQ_DATA;
 	recv->rndv.len = rndv_req->len;
 	recv->rndv.tag = mrail_pkt->hdr.tag;
@@ -204,7 +204,7 @@ static int mrail_cq_process_rndv_ack(struct fi_cq_tagged_entry *comp)
 
 	mrail_pkt = (struct mrail_pkt *)comp->buf;
 	rndv_hdr = (struct mrail_rndv_hdr *)&mrail_pkt[1];
-	tx_buf = (struct mrail_tx_buf *)rndv_hdr->context;
+	tx_buf = (struct mrail_tx_buf *)(uintptr_t)rndv_hdr->context;
 	ret = mrail_cq_write_send_comp(tx_buf->ep->util_ep.tx_cq, tx_buf);
 	if (ret)
 		retv = ret;

--- a/prov/mrail/src/mrail_domain.c
+++ b/prov/mrail/src/mrail_domain.c
@@ -68,7 +68,7 @@ static int mrail_domain_map_raw(struct mrail_domain *mrail_domain,
 
 	memcpy(mr_map, map->raw_key, map->key_size);
 
-	*(map->key) = (uint64_t)mr_map;
+	*(map->key) = (uintptr_t)mr_map;
 
 	return 0;
 }
@@ -196,7 +196,7 @@ static int mrail_mr_reg(struct fid *domain_fid, const void *buf, size_t len,
 		}
 		mrail_mr->rails[rail].base_addr =
 			(fi->domain_attr->mr_mode & FI_MR_VIRT_ADDR) ?
-			(uint64_t)buf : 0;
+			(uintptr_t)buf : 0;
 	}
 
 	mrail_mr->mr_fid.fid.fclass = FI_CLASS_MR;
@@ -247,7 +247,7 @@ static int mrail_mr_regv(struct fid *domain_fid, const struct iovec *iov,
 		}
 		mrail_mr->rails[rail].base_addr =
 			(fi->domain_attr->mr_mode & FI_MR_VIRT_ADDR) ?
-			(uint64_t)iov[0].iov_base : 0;
+			(uintptr_t)iov[0].iov_base : 0;
 	}
 
 	mrail_mr->mr_fid.fid.fclass = FI_CLASS_MR;
@@ -295,7 +295,7 @@ static int mrail_mr_regattr(struct fid *domain_fid, const struct fi_mr_attr *att
 		}
 		mrail_mr->rails[rail].base_addr =
 			(fi->domain_attr->mr_mode & FI_MR_VIRT_ADDR) ?
-			(uint64_t)attr->mr_iov[0].iov_base : 0;
+			(uintptr_t)attr->mr_iov[0].iov_base : 0;
 	}
 
 	mrail_mr->mr_fid.fid.fclass = FI_CLASS_MR;

--- a/prov/mrail/src/mrail_ep.c
+++ b/prov/mrail/src/mrail_ep.c
@@ -363,7 +363,7 @@ int mrail_send_rndv_ack_blocking(struct mrail_ep *mrail_ep,
 
 	tx_buf->hdr.protocol = MRAIL_PROTO_RNDV;
 	tx_buf->hdr.protocol_cmd = MRAIL_RNDV_ACK;
-	tx_buf->rndv_hdr.context = (uint64_t)context;
+	tx_buf->rndv_hdr.context = (uintptr_t)context;
 
 	iov_dest.iov_base = &tx_buf->hdr;
 	iov_dest.iov_len = rndv_pkt_size;
@@ -415,7 +415,7 @@ mrail_prepare_rndv_req(struct mrail_ep *mrail_ep, struct mrail_tx_buf *tx_buf,
 
 	tx_buf->hdr.protocol = MRAIL_PROTO_RNDV;
 	tx_buf->hdr.protocol_cmd = MRAIL_RNDV_REQ;
-	tx_buf->rndv_hdr.context = (uint64_t)tx_buf;
+	tx_buf->rndv_hdr.context = (uintptr_t)tx_buf;
 	tx_buf->rndv_req = NULL;
 
 	if (!desc || !desc[0]) {
@@ -463,7 +463,7 @@ mrail_prepare_rndv_req(struct mrail_ep *mrail_ep, struct mrail_tx_buf *tx_buf,
 			assert(!ret);
 			offset += key_size;
 		}
-		tx_buf->rndv_req->rma_iov[i].addr = (uint64_t)iov[i].iov_base;
+		tx_buf->rndv_req->rma_iov[i].addr = (uintptr_t)iov[i].iov_base;
 		tx_buf->rndv_req->rma_iov[i].len = iov[i].iov_len;
 		tx_buf->rndv_req->rma_iov[i].key = key_size; /* otherwise unused */
 	}

--- a/prov/mrail/src/mrail_rma.c
+++ b/prov/mrail/src/mrail_rma.c
@@ -52,7 +52,7 @@ static void mrail_subreq_to_rail(struct mrail_subreq *subreq, uint32_t rail,
 	}
 
 	for (i = 0; i < subreq->rma_iov_count; ++i) {
-		mr_map = (struct mrail_addr_key *)subreq->rma_iov[i].key;
+		mr_map = (struct mrail_addr_key *)(uintptr_t)subreq->rma_iov[i].key;
 		//TODO: add base address from mrail_addr_key
 		out_rma_iovs[i].addr 	= subreq->rma_iov[i].addr;
 		out_rma_iovs[i].len	= subreq->rma_iov[i].len;
@@ -391,7 +391,7 @@ static ssize_t mrail_ep_inject_write(struct fid_ep *ep_fid, const void *buf,
 	ssize_t ret;
 
 	mrail_ep = container_of(ep_fid, struct mrail_ep, util_ep.ep_fid.fid);
-	mr_map = (struct mrail_addr_key *) key;
+	mr_map = (struct mrail_addr_key *)(uintptr_t) key;
 
 	rail = mrail_get_tx_rail_rr(mrail_ep);
 	ret = fi_inject_write(mrail_ep->rails[rail].ep, buf, len,

--- a/prov/rxd/src/rxd_av.c
+++ b/prov/rxd/src/rxd_av.c
@@ -175,7 +175,7 @@ int rxd_av_insert_dg_addr(struct rxd_av *av, const void *addr,
 		goto nomem;
 	}
 
-	ret = ofi_rbmap_insert(&av->rbmap, (void *)addr, (void *)(*rxd_addr),
+	ret = ofi_rbmap_insert(&av->rbmap, (void *)addr, (void *)(uintptr_t)(*rxd_addr),
 			       NULL);
 	if (ret) {
 		assert(ret != -FI_EALREADY);
@@ -219,7 +219,7 @@ static int rxd_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 	for (; i < count; i++, addr = (uint8_t *) addr + av->dg_addrlen) {
 		node = ofi_rbmap_find(&av->rbmap, (void *) addr);
 		if (node) {
-			rxd_addr = (fi_addr_t) node->data;
+			rxd_addr = (fi_addr_t)(uintptr_t) node->data;
 		} else {
 			ret = rxd_av_insert_dg_addr(av, addr, &rxd_addr,
 						    flags, sync_err ?
@@ -357,7 +357,7 @@ static int rxd_av_close(struct fid *fid)
 		return ret;
 
 	while ((node = ofi_rbmap_get_root(&av->rbmap))) {
-		rxd_addr = (fi_addr_t) node->data;
+		rxd_addr = (fi_addr_t)(uintptr_t) node->data;
 		dg_addr = (intptr_t)ofi_idx_lookup(&av->rxdaddr_dg_idx,
 						   (int) rxd_addr);
 

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -432,7 +432,7 @@ static void rxd_handle_rts(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
 	node = ofi_rbmap_find(&rxd_av->rbmap, pkt->source);
 
 	if (node) {
-		rxd_addr = (fi_addr_t) node->data;
+		rxd_addr = (fi_addr_t)(uintptr_t) node->data;
 	} else {
 		ret = rxd_av_insert_dg_addr(rxd_av, (void *) pkt->source,
 					    &rxd_addr, 0, NULL);
@@ -558,7 +558,7 @@ static int rxd_verify_iov(struct rxd_ep *ep, struct ofi_rma_iov *rma,
 		ret = ofi_mr_verify(&util_domain->mr_map, rma[i].len,
 			(uintptr_t *)(&rma[i].addr), rma[i].key,
 			ofi_rx_mr_reg_flags(type, 0));
-		iov[i].iov_base = (void *) rma[i].addr;
+		iov[i].iov_base = (void *)(uintptr_t) rma[i].addr;
 		iov[i].iov_len = rma[i].len;
 		if (ret) {
 			FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "could not verify MR\n");

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1238,7 +1238,7 @@ static ssize_t rxm_handle_atomic_req(struct rxm_ep *rxm_ep,
 							atomic_op));
 		if (ret) {
 			FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
-				"Atomic RMA MR verify error %ld\n", ret);
+				"Atomic RMA MR verify error %zd\n", ret);
 			return rxm_atomic_send_resp(rxm_ep, rx_buf, resp_buf, 0,
 						    (uint32_t) -FI_EACCES);
 		}
@@ -1256,7 +1256,9 @@ static ssize_t rxm_handle_atomic_req(struct rxm_ep *rxm_ep,
 		void *src_buf = req_hdr->data + offset;
 		void *cmp_buf = req_hdr->data + len + offset;
 		void *res_buf = resp_hdr->data + offset;
-		void *dst_buf = (void *) req_hdr->rma_ioc[i].addr;
+		void *dst_buf;
+		uintptr_t addr = (uintptr_t) req_hdr->rma_ioc[i].addr;
+		dst_buf = (void *) addr;
 
 		if (mr->iface != FI_HMEM_SYSTEM) {
 			ret = rxm_do_device_mem_atomic(mr, op, dst_buf, src_buf,
@@ -1265,7 +1267,7 @@ static ssize_t rxm_handle_atomic_req(struct rxm_ep *rxm_ep,
 						       atomic_op, amo_op_size);
 			if (ret) {
 				FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
-					"Atomic operation failed %ld\n", ret);
+					"Atomic operation failed %zd\n", ret);
 
 				return rxm_atomic_send_resp(rxm_ep, rx_buf,
 							    resp_buf, 0,

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -470,7 +470,7 @@ static int rxm_mr_close(fid_t fid)
 
 	if (rxm_mr->hmem_handle) {
 		ofi_hmem_dev_unregister(rxm_mr->iface,
-					(uint64_t) rxm_mr->hmem_handle);
+					(uintptr_t) rxm_mr->hmem_handle);
 	}
 
 	ret = fi_close(&rxm_mr->msg_mr->fid);

--- a/prov/rxm/src/rxm_hmem.c
+++ b/prov/rxm/src/rxm_hmem.c
@@ -62,11 +62,11 @@ ssize_t rxm_copy_hmem(void *desc, char *host_buf, void *dev_buf, size_t size,
 		 * to ofi_hmem regular copy */
 		if (dir == OFI_COPY_IOV_TO_BUF) {
 			ofi_hmem_dev_reg_copy_from_hmem(
-				iface, (uint64_t) hmem_handle, host_buf,
+				iface, (uintptr_t) hmem_handle, host_buf,
 				dev_buf, size);
 		} else {
 			ofi_hmem_dev_reg_copy_to_hmem(iface,
-						      (uint64_t) hmem_handle,
+						      (uintptr_t) hmem_handle,
 						      dev_buf, host_buf, size);
 		}
 		return FI_SUCCESS;

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -246,8 +246,8 @@ struct smr_ep {
 static inline int smr_mmap_name(char *shm_name, const char *ep_name,
 				uint64_t msg_id)
 {
-	return snprintf(shm_name, SMR_NAME_MAX - 1, "%s_%ld",
-			ep_name, msg_id);
+	return snprintf(shm_name, SMR_NAME_MAX - 1, "%s_%" PRIu64,
+			ep_name, (uint64_t)(msg_id));
 }
 
 int smr_endpoint(struct fid_domain *domain, struct fi_info *info,

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -308,6 +308,7 @@ static int smr_format_ipc(struct smr_cmd *cmd, void *ptr, size_t len,
 {
 	int ret;
 	void *base;
+	size_t tmp_base_length;
 
 	cmd->msg.hdr.op_src = smr_src_ipc;
 	cmd->msg.hdr.src_data = smr_get_offset(smr, resp);
@@ -317,9 +318,11 @@ static int smr_format_ipc(struct smr_cmd *cmd, void *ptr, size_t len,
 
 	ret = ofi_hmem_get_base_addr(cmd->msg.data.ipc_info.iface, ptr,
 				     len, &base,
-				     &cmd->msg.data.ipc_info.base_length);
+				     &tmp_base_length);
 	if (ret)
 		return ret;
+	
+	cmd->msg.data.ipc_info.base_length = (uint64_t)tmp_base_length;
 
 	ret = ofi_hmem_get_handle(cmd->msg.data.ipc_info.iface, base,
 				  cmd->msg.data.ipc_info.base_length,

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -218,7 +218,7 @@ static void smr_progress_resp(struct smr_ep *ep)
 		if (resp->status == SMR_STATUS_BUSY)
 			break;
 
-		pending = (struct smr_tx_entry *) resp->msg_id;
+		pending = (struct smr_tx_entry *)(uintptr_t) resp->msg_id;
 		if (smr_progress_resp_entry(ep, resp, pending, &resp->status))
 			break;
 
@@ -1061,7 +1061,7 @@ static int smr_progress_cmd_rma(struct smr_ep *ep, struct smr_cmd *cmd,
 		if (ret)
 			break;
 
-		iov[iov_count].iov_base = (void *) rma_cmd->rma.rma_iov[iov_count].addr;
+		iov[iov_count].iov_base = (void *)(uintptr_t) rma_cmd->rma.rma_iov[iov_count].addr;
 		iov[iov_count].iov_len = rma_cmd->rma.rma_iov[iov_count].len;
 	}
 	ofi_genlock_unlock(&domain->util_domain.lock);
@@ -1112,7 +1112,7 @@ static int smr_progress_cmd_rma(struct smr_ep *ep, struct smr_cmd *cmd,
 				smr_rx_cq_flags(0, cmd->msg.hdr.op_flags),
 				0, -err);
 	} else {
-		ret = smr_complete_rx(ep, (void *) cmd->msg.hdr.msg_id,
+		ret = smr_complete_rx(ep, (void *)(uintptr_t) cmd->msg.hdr.msg_id,
 				cmd->msg.hdr.op, smr_rx_cq_flags(0,
 				cmd->msg.hdr.op_flags), total_len,
 				iov_count ? iov[0].iov_base : NULL,
@@ -1155,7 +1155,7 @@ static int smr_progress_cmd_atomic(struct smr_ep *ep, struct smr_cmd *cmd,
 		if (ret)
 			break;
 
-		ioc[ioc_count].addr = (void *) rma_cmd->rma.rma_ioc[ioc_count].addr;
+		ioc[ioc_count].addr = (void *)(uintptr_t) rma_cmd->rma.rma_ioc[ioc_count].addr;
 		ioc[ioc_count].count = rma_cmd->rma.rma_ioc[ioc_count].count;
 	}
 	ofi_genlock_unlock(&domain->util_domain.lock);

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -74,7 +74,7 @@ static ssize_t smr_rma_fast(struct smr_ep *ep, struct smr_region *peer_smr,
 
 	memcpy(vma_iovec, iov, sizeof(*iov) * iov_count);
 	for (i = 0; i < rma_count; i++) {
-		rma_iovec[i].iov_base = (void *) rma_iov[i].addr;
+		rma_iovec[i].iov_base = (void *)(uintptr_t) rma_iov[i].addr;
 		rma_iovec[i].iov_len = rma_iov[i].len;
 	}
 

--- a/prov/sm2/src/sm2.h
+++ b/prov/sm2/src/sm2.h
@@ -242,7 +242,7 @@ static inline void sm2_generic_format(struct sm2_xfer_entry *xfer_entry,
 	xfer_entry->hdr.tag = tag;
 	xfer_entry->hdr.sender_gid = self_gid;
 	xfer_entry->hdr.cq_data = cq_data;
-	xfer_entry->hdr.context = (uint64_t) context;
+	xfer_entry->hdr.context = (uintptr_t) context;
 }
 
 struct sm2_xfer_ctx {

--- a/prov/sm2/src/sm2_coordination.c
+++ b/prov/sm2/src/sm2_coordination.c
@@ -563,8 +563,8 @@ static void *sm2_mmap_shrink_to_size(struct sm2_mmap *map, size_t shrink_size)
 		if (map->base == MAP_FAILED) {
 			FI_WARN(&sm2_prov, FI_LOG_AV,
 				"Failed to remap when decreasing the map size. "
-				"st.st_size=%ld shrink_size=%ld\n",
-				st.st_size, shrink_size);
+				"st.st_size=%jd shrink_size=%zu\n",
+				(intmax_t)st.st_size, shrink_size);
 			map->base = NULL;
 		}
 		map->size = shrink_size;

--- a/prov/sm2/src/sm2_ep.c
+++ b/prov/sm2/src/sm2_ep.c
@@ -253,6 +253,7 @@ static ssize_t sm2_format_ipc(struct sm2_xfer_entry *xfer_entry, void *ptr,
 {
 	void *base;
 	ssize_t ret;
+	size_t tmp_base_lenght;
 	struct ipc_info *ipc_info = (struct ipc_info *) xfer_entry->user_data;
 
 	xfer_entry->hdr.proto = sm2_proto_ipc;
@@ -261,9 +262,11 @@ static ssize_t sm2_format_ipc(struct sm2_xfer_entry *xfer_entry, void *ptr,
 	ipc_info->device = device;
 
 	ret = ofi_hmem_get_base_addr(ipc_info->iface, ptr, len, &base,
-				     &ipc_info->base_length);
+				     &tmp_base_lenght);
 	if (ret)
 		return ret;
+
+	ipc_info->base_length = (uint64_t)tmp_base_lenght;
 
 	ret = ofi_hmem_get_handle(ipc_info->iface, base, ipc_info->base_length,
 				  (void **) &ipc_info->ipc_handle);

--- a/prov/sm2/src/sm2_progress.c
+++ b/prov/sm2/src/sm2_progress.c
@@ -52,6 +52,7 @@ static int sm2_cma_send_ipc_handle(struct sm2_ep *ep,
 	struct sm2_cma_data *cma_data =
 		((struct sm2_cma_data *) xfer_entry->user_data);
 	struct ipc_info *ipc_info;
+	size_t tmp_base_lenght;
 	void *device_ptr, *base;
 	int ret;
 
@@ -73,7 +74,7 @@ static int sm2_cma_send_ipc_handle(struct sm2_ep *ep,
 
 	ret = ofi_hmem_get_base_addr(ipc_info->iface, device_ptr,
 				     xfer_entry->hdr.size, &base,
-				     &ipc_info->base_length);
+				     &tmp_base_lenght);
 	if (ret) {
 		FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,
 			"Failed to get device memory base address. Error code: "
@@ -81,6 +82,8 @@ static int sm2_cma_send_ipc_handle(struct sm2_ep *ep,
 			ret);
 		return ret;
 	}
+
+	ipc_info->base_length = (uint64_t)tmp_base_lenght;
 
 	ret = ofi_hmem_get_handle(ipc_info->iface, base, ipc_info->base_length,
 				  (void **) &ipc_info->ipc_handle);
@@ -462,7 +465,7 @@ sm2_progress_cma_host_to_dev(struct sm2_ep *ep,
 		return;
 	}
 
-	ret = sm2_complete_tx(ep, (void *) xfer_entry->hdr.context,
+	ret = sm2_complete_tx(ep, (void *)(uintptr_t) xfer_entry->hdr.context,
 			      xfer_entry->hdr.op, xfer_entry->hdr.op_flags);
 
 	if (ret) {
@@ -673,7 +676,7 @@ static int sm2_progress_atomic(struct sm2_ep *ep,
 		if (ret)
 			break;
 
-		ioc[i].addr = (void *) ioc_ptr->addr;
+		ioc[i].addr = (void *)(uintptr_t) ioc_ptr->addr;
 		ioc[i].count = ioc_ptr->count;
 	}
 
@@ -741,7 +744,7 @@ static inline void sm2_progress_return(struct sm2_ep *ep,
 	}
 
 	if (xfer_entry->hdr.proto_flags & SM2_GENERATE_COMPLETION) {
-		ret = sm2_complete_tx(ep, (void *) xfer_entry->hdr.context,
+		ret = sm2_complete_tx(ep, (void *)(uintptr_t) xfer_entry->hdr.context,
 				      xfer_entry->hdr.op,
 				      xfer_entry->hdr.op_flags);
 		if (ret)

--- a/prov/tcp/src/xnet_domain.c
+++ b/prov/tcp/src/xnet_domain.c
@@ -196,7 +196,7 @@ xnet_mplex_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 		ret = xnet_mr_regattr(item->fid, attr, flags, &sub_mr_fid);
 		if (ret) {
 			FI_WARN(&xnet_prov, FI_LOG_MR,
-				"Failed to reg mr (%ld) from subdomain (%p)\n",
+				"Failed to reg mr (%" PRIu64 ") from subdomain (%p)\n",
 				mr->key, item->fid);
 
 			xnet_subdomains_mr_close(domain, mr->key);

--- a/prov/tcp/src/xnet_ep.c
+++ b/prov/tcp/src/xnet_ep.c
@@ -96,8 +96,8 @@ void xnet_hdr_trace(struct xnet_ep *ep, struct xnet_base_hdr *hdr)
 
 	dir = (hdr == &ep->cur_rx.hdr.base_hdr) ? "Rx" : "Tx";
 
-	FI_TRACE(&xnet_prov, FI_LOG_EP_DATA, "%s op:%s tag:0x%zx flags:0x%x "
-		 "op_data:0x%x hdr_size:%d data_size:%zu\n", dir,
+	FI_TRACE(&xnet_prov, FI_LOG_EP_DATA, "%s op:%s tag:0x%" PRIu64 " flags:0x%x "
+		 "op_data:0x%x hdr_size:%d data_size:%" PRIu64 "\n", dir,
 		 xnet_op_str(hdr->op), tag, hdr->flags, hdr->op_data,
 		 hdr->hdr_size, hdr->size - hdr->hdr_size);
 }

--- a/prov/tcp/src/xnet_progress.c
+++ b/prov/tcp/src/xnet_progress.c
@@ -1330,7 +1330,7 @@ static void xnet_progress_cqe(struct xnet_progress *progress,
 	struct xnet_pep *pep;
 
 	assert(xnet_io_uring);
-	sockctx = (struct ofi_sockctx *) cqe->user_data;
+	sockctx = (struct ofi_sockctx *)(uintptr_t) cqe->user_data;
 	assert(sockctx);
 	assert(sockctx->uring_sqe_inuse);
 	if (!(cqe ->flags & IORING_CQE_F_MORE))

--- a/prov/usnic/src/usdf_av.c
+++ b/prov/usnic/src/usdf_av.c
@@ -481,7 +481,7 @@ usdf_am_insert_sync(struct fid_av *fav, const void *addr, size_t count,
 			u_dest->ds_dest.ds_udp.u_hdr.uh_ip.frag_off |=
 				htons(IP_DF);
 			dest->ds_dest = *u_dest;
-			fi_addr[i] = (fi_addr_t)dest;
+			fi_addr[i] = (fi_addr_t)(uintptr_t)dest;
 			LIST_INSERT_HEAD(&av->av_addresses, dest,
 					 ds_addresses_entry);
 			++ret_count;

--- a/prov/usnic/src/usdf_dgram.c
+++ b/prov/usnic/src/usdf_dgram.c
@@ -198,7 +198,7 @@ usdf_dgram_recvmsg(struct fid_ep *fep, const struct fi_msg *msg, uint64_t flags)
 	rq->urq_context[index] = msg->context;
 	hdr_ptr = ((uint8_t *)ep->e.dg.ep_hdr_buf) +
 			(index * USDF_HDR_BUF_ENTRY);
-	rq_enet_desc_enc(desc, (dma_addr_t) hdr_ptr,
+	rq_enet_desc_enc(desc, (dma_addr_t)(uintptr_t) hdr_ptr,
 			RQ_ENET_TYPE_ONLY_SOP, sizeof(struct usd_udp_hdr));
 	ep->e.dg.ep_hdr_ptr[index] = (struct usd_udp_hdr *) hdr_ptr;
 
@@ -208,7 +208,7 @@ usdf_dgram_recvmsg(struct fid_ep *fep, const struct fi_msg *msg, uint64_t flags)
 
 	for (i = 0; i < msg->iov_count; ++i) {
 		rq->urq_context[index] = msg->context;
-		rq_enet_desc_enc(desc, (dma_addr_t) iovp[i].iov_base,
+		rq_enet_desc_enc(desc, (dma_addr_t)(uintptr_t) iovp[i].iov_base,
 			     RQ_ENET_TYPE_NOT_SOP, iovp[i].iov_len);
 		ep->e.dg.ep_hdr_ptr[index] = (struct usd_udp_hdr *) hdr_ptr;
 
@@ -552,7 +552,7 @@ usdf_dgram_prefix_recvmsg(struct fid_ep *fep, const struct fi_msg *msg, uint64_t
 	rq->urq_context[index] = msg->context;
 	hdr_ptr = ((uint8_t *)iovp[0].iov_base) +
 		(USDF_HDR_BUF_ENTRY - sizeof(struct usd_udp_hdr));
-	rq_enet_desc_enc(desc, (dma_addr_t) hdr_ptr,
+	rq_enet_desc_enc(desc, (dma_addr_t)(uintptr_t) hdr_ptr,
 			 RQ_ENET_TYPE_ONLY_SOP,
 			 iovp[0].iov_len -
 			  (USDF_HDR_BUF_ENTRY - sizeof(struct usd_udp_hdr)));
@@ -564,7 +564,7 @@ usdf_dgram_prefix_recvmsg(struct fid_ep *fep, const struct fi_msg *msg, uint64_t
 
 	for (i = 1; i < msg->iov_count; ++i) {
 		rq->urq_context[index] = msg->context;
-		rq_enet_desc_enc(desc, (dma_addr_t) iovp[i].iov_base,
+		rq_enet_desc_enc(desc, (dma_addr_t)(uintptr_t) iovp[i].iov_base,
 			     RQ_ENET_TYPE_NOT_SOP, iovp[i].iov_len);
 		ep->e.dg.ep_hdr_ptr[index] = (struct usd_udp_hdr *) hdr_ptr;
 

--- a/prov/usnic/src/usnic_direct/kcompat_priv.h
+++ b/prov/usnic/src/usnic_direct/kcompat_priv.h
@@ -63,7 +63,7 @@ static inline void *pci_alloc_consistent(struct pci_dev *hwdev,
 
     ret = usd_alloc_mr((struct usd_device *) hwdev, size, &va);
     if (ret == 0) {
-        *dma_handle = (dma_addr_t) va;
+        *dma_handle = (dma_addr_t)(uintptr_t) va;
         return va;
     } else {
         return NULL;

--- a/prov/usnic/src/usnic_direct/usd_ib_cmd.c
+++ b/prov/usnic/src/usnic_direct/usd_ib_cmd.c
@@ -489,11 +489,11 @@ usd_ib_cmd_create_cq(
             sched_getaffinity(getpid(),
                         CPU_ALLOC_SIZE(sysconf(_SC_NPROCESSORS_ONLN)),
                         affinity_mask) == 0) {
-            cmd.usnic_cmd.cur.affinity_mask_ptr = (u64)affinity_mask;
+            cmd.usnic_cmd.cur.affinity_mask_ptr = (uint64_t)(uintptr_t)affinity_mask;
             cmd.usnic_cmd.cur.affinity_mask_len =
                             CPU_ALLOC_SIZE(sysconf(_SC_NPROCESSORS_ONLN));
         } else {
-            cmd.usnic_cmd.cur.affinity_mask_ptr = (u64)NULL;
+            cmd.usnic_cmd.cur.affinity_mask_ptr = (uint64_t)(uintptr_t) 0;
             cmd.usnic_cmd.cur.affinity_mask_len = 0;
         }
     } else {

--- a/prov/usnic/src/usnic_direct/usd_mem.c
+++ b/prov/usnic/src/usnic_direct/usd_mem.c
@@ -131,7 +131,7 @@ usd_alloc_mr(
     base_addr = mmap(NULL, true_size, PROT_READ | PROT_WRITE,
                      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     if (base_addr == NULL || base_addr == MAP_FAILED) {
-        usd_err("Failed to mmap region of size %lu\n", true_size);
+        usd_err("Failed to mmap region of size %zu\n", true_size);
         return -errno;
     }
     mr = base_addr;
@@ -155,7 +155,7 @@ usd_alloc_mr(
      */
     ret = madvise(vaddr, madv_size, MADV_DONTFORK);
     if (ret != 0) {
-        usd_err("Failed to disable child's access to memory %p size %lu\n",
+        usd_err("Failed to disable child's access to memory %p size %zu\n",
                 vaddr, size);
         ret = errno;
         goto err_unmap;
@@ -163,7 +163,7 @@ usd_alloc_mr(
 
     ret = usd_ib_cmd_reg_mr(dev, vaddr, size, mr);
     if (ret != 0) {
-        usd_err("Failed to register memory region %p, size %lu\n",
+        usd_err("Failed to register memory region %p, size %zu\n",
                 vaddr, size);
         goto err_madvise;
     }

--- a/prov/usnic/src/usnic_direct/usd_poll.c
+++ b/prov/usnic/src/usnic_direct/usd_poll.c
@@ -71,7 +71,7 @@ find_rx_lengths(
     } while (type == RQ_ENET_TYPE_NOT_SOP);
 
     *posted_len_o = rcvbuf_len;
-    *len_in_pkt_o = ntohs(((struct usd_udp_hdr *)bus_addr)->uh_ip.tot_len) +
+    *len_in_pkt_o = ntohs(((struct usd_udp_hdr *)(uintptr_t)bus_addr)->uh_ip.tot_len) +
                           sizeof(struct ether_header);
 }
 

--- a/prov/usnic/src/usnic_direct/usd_post.c
+++ b/prov/usnic/src/usnic_direct/usd_post.c
@@ -90,7 +90,7 @@ usd_post_recv(
     while (recv_list != NULL) {
         iovp = recv_list->urd_iov;
         rq->urq_context[index] = recv_list->urd_context;
-        rq_enet_desc_enc(desc, (dma_addr_t) iovp[0].iov_base,
+        rq_enet_desc_enc(desc, (dma_addr_t)(uintptr_t) iovp[0].iov_base,
                          RQ_ENET_TYPE_ONLY_SOP, iovp[0].iov_len);
         count++;
 
@@ -100,7 +100,7 @@ usd_post_recv(
 
         for (i = 1; i < recv_list->urd_iov_cnt; ++i) {
             rq->urq_context[index] = recv_list->urd_context;
-            rq_enet_desc_enc(desc, (dma_addr_t) iovp[i].iov_base,
+            rq_enet_desc_enc(desc, (dma_addr_t)(uintptr_t) iovp[i].iov_base,
                              RQ_ENET_TYPE_NOT_SOP, iovp[i].iov_len);
             count++;
 

--- a/prov/usnic/src/usnic_direct/usd_post.h
+++ b/prov/usnic/src/usnic_direct/usd_post.h
@@ -73,7 +73,7 @@ _usd_post_send_one(
         vlan_tag_insert, vlan_tag, loopback);
     wmb();
 
-    wr = vnic_cached_posted_index((dma_addr_t)packet, length, index);
+    wr = vnic_cached_posted_index((dma_addr_t)(uintptr_t)packet, length, index);
     iowrite64(wr, &vwq->ctrl->posted_index);
 
     wq->uwq_next_desc = (struct wq_enet_desc *)

--- a/prov/util/src/uffd_mem_monitor.c
+++ b/prov/util/src/uffd_mem_monitor.c
@@ -178,12 +178,12 @@ static void ofi_uffd_pagefault_handler(struct uffd_msg *msg)
 	if (flags != UFFD_PAGEFAULT_FLAG_WRITE) {
 #if HAVE_UFFD_THREAD_ID
 		FI_WARN(&core_prov, FI_LOG_MR,
-			"UFFD pagefault with unrecognized flags: %lu, address %p, thread %u\n",
-			flags, address, ptid);
+			"UFFD pagefault with unrecognized flags: %" PRIu64 ", address %p, thread %u\n",
+			(uint64_t)flags, address, ptid);
 #else
 		FI_WARN(&core_prov, FI_LOG_MR,
-			"UFFD pagefault with unrecognized flags: %lu, address %p\n",
-			flags, address);
+			"UFFD pagefault with unrecognized flags: %" PRIu64 ", address %p\n",
+			(uint64_t)flags, address);
 #endif
 		/* The faulting thread is halted at this point. In
 		 * theory we could wake it up with UFFDIO_WAKE. In

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -293,7 +293,7 @@ int ofi_av_insert_addr_at(struct util_av *av, const void *addr, fi_addr_t fi_add
 	memcpy(entry->data, addr, av->addrlen);
 	ofi_atomic_initialize32(&entry->use_cnt, 1);
 	HASH_ADD(hh, av->hash, data, av->addrlen, entry);
-	FI_INFO(av->prov, FI_LOG_AV, "fi_addr: %" PRIu64 "\n",
+	FI_INFO(av->prov, FI_LOG_AV, "fi_addr: %zu\n",
 		ofi_buf_index(entry));
 	return 0;
 }
@@ -324,7 +324,7 @@ int ofi_av_insert_addr(struct util_av *av, const void *addr, fi_addr_t *fi_addr)
 		memcpy(entry->data, addr, av->addrlen);
 		ofi_atomic_initialize32(&entry->use_cnt, 1);
 		HASH_ADD(hh, av->hash, data, av->addrlen, entry);
-		FI_INFO(av->prov, FI_LOG_AV, "fi_addr: %" PRIu64 "\n",
+		FI_INFO(av->prov, FI_LOG_AV, "fi_addr: %zu\n",
 			ofi_buf_index(entry));
 	}
 	return 0;

--- a/prov/verbs/src/verbs_init.c
+++ b/prov/verbs/src/verbs_init.c
@@ -369,14 +369,13 @@ static int vrb_param_define(const char *param_name, const char *param_str,
 	if (param_default != NULL) {
 		switch (type) {
 		case FI_PARAM_STRING:
-			if (*(char **)param_default != NULL) {
-				param_default_sz =
-					MIN(strlen(*(char **)param_default),
-					    254);
-				strncpy(param_default_str, *(char **)param_default,
-					param_default_sz);
-				param_default_str[param_default_sz + 1] = '\0';
-			}
+			const char *src = *(char **)param_default;
+			snprintf(param_default_str,
+				sizeof(param_default_str),
+				"%.*s",
+				(int)(sizeof(param_default_str) - 1),
+				src);
+			param_default_sz = strlen(param_default_str);
 			break;
 		case FI_PARAM_INT:
 		case FI_PARAM_BOOL:
@@ -635,112 +634,124 @@ static int vrb_get_param_str(const char *param_name,
 	return 0;
 }
 
+static int vrb_read_param_bool(const char *name, const char *desc, int *field)
+{
+	int tmp = *field;
+	int ret;
+	ret = vrb_get_param_bool(name, desc, &tmp);
+	if (ret)
+		return ret;
+	if (tmp != 0 && tmp != 1)
+		return -FI_EINVAL;
+	*field = tmp;
+	return 0;
+}
+
 static int vrb_read_params(void)
 {
 	/* Common parameters */
 	if (vrb_get_param_int("tx_size", "Default maximum tx context size",
-			      &vrb_gl_data.def_tx_size) ||
-	    (vrb_gl_data.def_tx_size < 0)) {
+			&vrb_gl_data.def_tx_size) ||
+			vrb_gl_data.def_tx_size < 0) {
 		VRB_WARN(FI_LOG_CORE, "Invalid value of tx_size\n");
 		return -FI_EINVAL;
 	}
+
 	if (vrb_get_param_int("rx_size", "Default maximum rx context size",
-			      &vrb_gl_data.def_rx_size) ||
-	    (vrb_gl_data.def_rx_size < 0)) {
+			&vrb_gl_data.def_rx_size) ||
+			vrb_gl_data.def_rx_size < 0) {
 		VRB_WARN(FI_LOG_CORE, "Invalid value of rx_size\n");
 		return -FI_EINVAL;
 	}
+
 	if (vrb_get_param_int("tx_iov_limit", "Default maximum tx iov_limit",
-			      &vrb_gl_data.def_tx_iov_limit) ||
-	    (vrb_gl_data.def_tx_iov_limit < 0)) {
+			&vrb_gl_data.def_tx_iov_limit) ||
+			vrb_gl_data.def_tx_iov_limit < 0) {
 		VRB_WARN(FI_LOG_CORE, "Invalid value of tx_iov_limit\n");
 		return -FI_EINVAL;
 	}
+
 	if (vrb_get_param_int("rx_iov_limit", "Default maximum rx iov_limit",
-			      &vrb_gl_data.def_rx_iov_limit) ||
-	    (vrb_gl_data.def_rx_iov_limit < 0)) {
+			&vrb_gl_data.def_rx_iov_limit) ||
+			vrb_gl_data.def_rx_iov_limit < 0) {
 		VRB_WARN(FI_LOG_CORE, "Invalid value of rx_iov_limit\n");
 		return -FI_EINVAL;
 	}
-	if (vrb_get_param_int("inline_size", "Maximum inline size for the "
-			      "verbs device. Actual inline size returned may "
-			      "be different depending on device capability. "
-			      "This value will be returned by fi_info as the "
-			      "inject size for the application to use. Set to "
-			      "0 for the maximum device inline size to be "
-			      "used. (default: 256).",
-			      &vrb_gl_data.def_inline_size) ||
-	    (vrb_gl_data.def_inline_size < 0)) {
+
+	if (vrb_get_param_int("inline_size",
+			"Maximum inline size for the verbs device…",
+			&vrb_gl_data.def_inline_size) ||
+			vrb_gl_data.def_inline_size < 0) {
 		VRB_WARN(FI_LOG_CORE, "Invalid value of inline_size\n");
 		return -FI_EINVAL;
 	}
-	if (vrb_get_param_int("min_rnr_timer", "Set min_rnr_timer QP "
-			      "attribute (0 - 31)",
-			      &vrb_gl_data.min_rnr_timer) ||
-	    ((vrb_gl_data.min_rnr_timer < 0) ||
-	     (vrb_gl_data.min_rnr_timer > 31))) {
+
+	if (vrb_get_param_int("min_rnr_timer", "Set min_rnr_timer QP attribute (0 - 31)",
+			&vrb_gl_data.min_rnr_timer) ||
+			vrb_gl_data.min_rnr_timer < 0 ||
+			vrb_gl_data.min_rnr_timer > 31) {
 		VRB_WARN(FI_LOG_CORE, "Invalid value of min_rnr_timer\n");
 		return -FI_EINVAL;
 	}
 
-	if (vrb_get_param_bool("use_odp", "Enable on-demand paging memory "
-			       "registrations, if supported.  This is "
-			       "currently required to register DAX file system "
-			       "mmapped memory.", &vrb_gl_data.use_odp)) {
+	if (vrb_read_param_bool("use_odp",
+			"Enable on-demand paging memory registrations…",
+			&vrb_gl_data.use_odp)) {
 		VRB_WARN(FI_LOG_CORE, "Invalid value of use_odp\n");
 		return -FI_EINVAL;
 	}
 
-	if (vrb_get_param_bool("prefer_xrc", "Order XRC transport fi_infos "
-			       "ahead of RC.  Default orders RC first.  This "
-			       "setting must usually be combined with setting "
-			       "FI_OFI_RXM_USE_SRX.  See fi_verbs.7 man page.",
-				&vrb_gl_data.msg.prefer_xrc)) {
+	if (vrb_read_param_bool("prefer_xrc",
+			"Order XRC transport fi_infos ahead of RC…",
+			&vrb_gl_data.msg.prefer_xrc)) {
 		VRB_WARN(FI_LOG_CORE, "Invalid value of prefer_xrc\n");
 		return -FI_EINVAL;
 	}
 
-	if (vrb_get_param_str("xrcd_filename", "A file to "
-			      "associate with the XRC domain.",
-			      &vrb_gl_data.msg.xrcd_filename)) {
+	if (vrb_get_param_str("xrcd_filename", "A file to associate with the XRC domain",
+			&vrb_gl_data.msg.xrcd_filename)) {
 		VRB_WARN(FI_LOG_CORE, "Invalid value of xrcd_filename\n");
 		return -FI_EINVAL;
 	}
-	if (vrb_get_param_int("cqread_bunch_size", "The number of entries to "
-			      "be read from the verbs completion queue at a time",
-			      &vrb_gl_data.cqread_bunch_size) ||
-	    (vrb_gl_data.cqread_bunch_size <= 0)) {
+
+	if (vrb_get_param_int("cqread_bunch_size",
+			"The number of entries to read from the verbs CQ at a time",
+			&vrb_gl_data.cqread_bunch_size) ||
+			vrb_gl_data.cqread_bunch_size <= 0) {
 		VRB_WARN(FI_LOG_CORE, "Invalid value of cqread_bunch_size\n");
 		return -FI_EINVAL;
 	}
-	if (vrb_get_param_int("gid_idx", "Set which gid index to use "
-			      "attribute (0 - 255)", &vrb_gl_data.gid_idx) ||
-	    (vrb_gl_data.gid_idx < 0 || vrb_gl_data.gid_idx > 255)) {
-		VRB_WARN(FI_LOG_CORE, "Invalid value of gid index\n");
+
+	if (vrb_get_param_int("gid_idx", "Set which gid index to use (0 - 255)",
+			&vrb_gl_data.gid_idx) ||
+			vrb_gl_data.gid_idx < 0 ||
+			vrb_gl_data.gid_idx > 255) {
+		VRB_WARN(FI_LOG_CORE, "Invalid value of gid_idx\n");
 		return -FI_EINVAL;
 	}
 
-	if (vrb_get_param_str("device_name", "The prefix or the full name of the "
-			      "verbs device to use", &vrb_gl_data.device_name)) {
+	if (vrb_get_param_str("device_name",
+			"The prefix or full name of the verbs device to use",
+			&vrb_gl_data.device_name)) {
 		VRB_WARN(FI_LOG_CORE, "Invalid value of device_name\n");
 		return -FI_EINVAL;
 	}
 
 	if (vrb_gl_data.dmabuf_support) {
-		if (vrb_get_param_bool("use_dmabuf", "Enable dmabuf based memory "
-				       "registrations, if supported. Yes by default.",
-				       (int *)&vrb_gl_data.dmabuf_support)) {
+		if (vrb_read_param_bool("use_dmabuf",
+				"Enable dmabuf based memory registrations, if supported",
+				(int *)&vrb_gl_data.dmabuf_support)) {
 			VRB_WARN(FI_LOG_CORE, "Invalid value of use_dmabuf\n");
 			return -FI_EINVAL;
 		}
 	}
 	VRB_INFO(FI_LOG_CORE, "dmabuf support is %s\n",
-		 vrb_gl_data.dmabuf_support ? "enabled" : "disabled");
+			vrb_gl_data.dmabuf_support ? "enabled" : "disabled");
 
 	/* MSG-specific parameter */
-	if (vrb_get_param_str("iface", "The prefix or the full name of the "
-			      "network interface associated with the verbs "
-			      "device", &vrb_gl_data.iface)) {
+	if (vrb_get_param_str("iface",
+			"Network interface prefix or full name",
+			&vrb_gl_data.iface)) {
 		VRB_WARN(FI_LOG_CORE, "Invalid value of iface\n");
 		return -FI_EINVAL;
 	}
@@ -748,19 +759,19 @@ static int vrb_read_params(void)
 	/* DGRAM-specific parameters */
 	if (getenv("OMPI_COMM_WORLD_RANK") || getenv("PMI_RANK"))
 		vrb_gl_data.dgram.use_name_server = 0;
-	if (vrb_get_param_bool("dgram_use_name_server", "The option that "
-			       "enables/disables OFI Name Server thread used "
-			       "to resolve IP-addresses to provider specific "
-			       "addresses. If MPI is used, the NS is disabled "
-			       "by default.", &vrb_gl_data.dgram.use_name_server)) {
+
+	if (vrb_read_param_bool("dgram_use_name_server",
+			"Enable/disable OFI Name Server thread",
+			&vrb_gl_data.dgram.use_name_server)) {
 		VRB_WARN(FI_LOG_CORE, "Invalid dgram_use_name_server\n");
 		return -FI_EINVAL;
 	}
-	if (vrb_get_param_int("dgram_name_server_port", "The port on which "
-			      "the name server thread listens incoming "
-			      "requests.", &vrb_gl_data.dgram.name_server_port) ||
-	    (vrb_gl_data.dgram.name_server_port < 0 ||
-	     vrb_gl_data.dgram.name_server_port > 65535)) {
+
+	if (vrb_get_param_int("dgram_name_server_port",
+			"Port for name server thread",
+			&vrb_gl_data.dgram.name_server_port) ||
+			vrb_gl_data.dgram.name_server_port < 0 ||
+			vrb_gl_data.dgram.name_server_port > 65535) {
 		VRB_WARN(FI_LOG_CORE, "Invalid dgram_name_server_port\n");
 		return -FI_EINVAL;
 	}

--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -84,8 +84,13 @@ static struct ibv_mr *vrb_reg_hmem_dmabuf(enum fi_hmem_iface iface,
 	if (err)
 		goto failover;
 
-	mr = ibv_reg_dmabuf_mr(pd, offset, len, (uint64_t)buf/* iova */,
-			       fd, vrb_access);
+	{
+		uintptr_t buf_addr = (uintptr_t)buf;
+		uint64_t iova = (uint64_t)buf_addr;
+		mr = ibv_reg_dmabuf_mr(pd, offset, len, iova,
+								fd, vrb_access);
+	}
+
 	if (!mr && failover_policy[iface] == TRY &&
 	    vrb_gl_data.peer_mem_support) {
 		saved_errno = errno;

--- a/src/common.c
+++ b/src/common.c
@@ -444,7 +444,7 @@ sa_sin6:
 			     *((uint64_t *)addr + 2), *((uint64_t *)addr + 3));
 		break;
 	case FI_ADDR_OPX:
-		size = snprintf(buf, *len, "fi_addr_opx://%016lx", *(uint64_t *)addr);
+		size = snprintf(buf, *len, "fi_addr_opx://%016" PRIx64, *(uint64_t *)addr);
 		break;
 	case FI_ADDR_MLX:
 		size = snprintf(buf, *len, "fi_addr_mlx://%p", addr);

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -100,7 +100,7 @@ static int ofi_hmem_no_dev_reg_copy_from_hmem(uint64_t handle, void *dest,
 static int ofi_hmem_system_dev_register(const void *addr, size_t size,
 					uint64_t *handle)
 {
-	*handle = (uint64_t) addr;
+	*handle = (uint64_t)(uintptr_t) addr;
 	return FI_SUCCESS;
 }
 
@@ -450,11 +450,11 @@ static ssize_t ofi_copy_mr_iov(struct ofi_mr **mr, const struct iovec *iov,
 		if (hmem_flags & OFI_HMEM_DATA_DEV_REG_HANDLE) {
 			if (dir == OFI_COPY_BUF_TO_IOV)
 				ofi_hmem_dev_reg_copy_to_hmem(
-					hmem_iface, (uint64_t) hmem_data,
+					hmem_iface, (uint64_t)(uintptr_t) hmem_data,
 					hmem_buf, (char *) buf + done, len);
 			else
 				ofi_hmem_dev_reg_copy_from_hmem(
-					hmem_iface, (uint64_t) hmem_data,
+					hmem_iface, (uint64_t)(uintptr_t) hmem_data,
 					(char *) buf + done, hmem_buf, len);
 			ret = FI_SUCCESS;
 		} else if (dir == OFI_COPY_BUF_TO_IOV)

--- a/src/hmem_ipc_cache.c
+++ b/src/hmem_ipc_cache.c
@@ -65,7 +65,7 @@ static int ipc_cache_add_region(struct ofi_mr_cache *cache, struct ofi_mr_entry 
 	}
 	if (ret) {
 		FI_WARN(&core_prov, FI_LOG_CORE,
-			"Failed to open hmem handle, addr: %p, len: %lu\n",
+			"Failed to open hmem handle, addr: %p, len: %zu\n",
 			entry->info.iov.iov_base, entry->info.iov.iov_len);
 	}
 	return ret;


### PR DESCRIPTION
## Summary
This Merge Request enhances libfabric’s portability on 32-bit systems by:
- Replacing hard-coded format specifiers (`%lx`, `%zx`, etc.) with the corresponding `<inttypes.h>` macros (`PRIuPTR`, `PRIxPTR`, `PRIx64`, `PRIu64`, etc.).
- Adjusting pointer and integer casts to use `uintptr_t` instead of fixed-width types (e.g. `uint64_t`) for address arithmetic.
- Introducing `size_t` temporaries when consuming I/O vectors to ensure correct sizing on all architectures.
- Format specifier correction: Fixed error messages that used `%lu` for `size_t`, replacing them with `%zu`.
## Types of changes

```diff
- "buf %p len %zu addr %zu data %lu " \
- "flags 0x%zx ctx %p\n", \
- buf, len, addr, (uint64_t)data, \
- (uint64_t)flags, context); \
+ "buf %p len %zu addr %" PRIuPTR " data 0x%" PRIx64 " " \
+ "flags 0x%" PRIxPTR " ctx %p\n", \
+ (void *)(buf), (size_t)(len), (uintptr_t)(addr), (uint64_t)(data), \
+ (uintptr_t)flags, (void *)(context)); \
```

```diff
- ofi_hmem_dev_unregister(attr.iface, (uint64_t)attr.hmem_data);
+ ofi_hmem_dev_unregister(attr.iface, (uintptr_t)attr.hmem_data);
```
## References

- Github issue #9763 (https://github.com/ofiwg/libfabric/issues/9763)
- Debian bug #1102068 (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1102068)
- This Merge request is based on the Salsa patch (https://salsa.debian.org/hpc-team/libfabric/-/commit/4260159f6cccb80113c85eb909d8f759122710fe)