### PR TITLE
[v2.1.x] prov/cxi: decouple existence CXI_MAP_IOVA_ALLOC for build

### DIFF
--- a/prov/cxi/include/cxip.h
+++ b/prov/cxi/include/cxip.h
@@ -1077,8 +1077,11 @@ struct cxip_eq {
 	ofi_mutex_t list_lock;
 };
 
-#define CXIP_EQ_MAP_FLAGS \
-	(CXI_MAP_WRITE | CXI_MAP_PIN)
+#ifdef CXI_MAP_IOVA_ALLOC
+#define CXIP_EQ_MAP_FLAGS (CXI_MAP_WRITE | CXI_MAP_PIN | CXI_MAP_IOVA_ALLOC)
+#else
+#define CXIP_EQ_MAP_FLAGS (CXI_MAP_WRITE | CXI_MAP_PIN)
+#endif
 
 /*
  * RMA request


### PR DESCRIPTION
Allow libfabric to build with both new and older drivers passing CXI_MAP_IOVA_ALLOC on event queue allocation if defined. This is to facilitate upstream builds independent of SHS release.

(cherry picked from commit d56969009907c35842011708ae55373a85cce8c3)