### PR TITLE
prov/sockets: fix rx_buffered arrived befor fi_av_insert

### DIFF
--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -611,6 +611,7 @@ struct sock_rx_entry {
 	uint64_t flags;
 	uint64_t context;
 	uint64_t addr;
+	union ofi_sock_ip sock_addr;
 	uint64_t data;
 	uint64_t tag;
 	uint64_t ignore;

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -1216,6 +1216,12 @@ static int sock_pe_progress_buffered_rx(struct sock_rx_ctx *rx_ctx,
 		if (!rx_buffered->is_complete || rx_buffered->is_claimed)
 			continue;
 
+		if (rx_buffered->addr == FI_ADDR_NOTAVAIL) {
+			rx_buffered->addr = sock_av_get_addr_index(rx_ctx->av, &rx_buffered->sock_addr);
+			if (rx_buffered->addr == FI_ADDR_NOTAVAIL) {
+				continue;
+			}
+		}
 		rx_posted = sock_rx_get_entry(rx_ctx, rx_buffered->addr,
 						rx_buffered->tag,
 						rx_buffered->is_tagged);
@@ -1375,6 +1381,9 @@ static int sock_pe_process_rx_send(struct sock_pe *pe,
 			}
 
 			rx_entry->addr = pe_entry->addr;
+			if (rx_entry->addr == FI_ADDR_NOTAVAIL) {
+				rx_entry->sock_addr = pe_entry->conn->addr;
+			}
 			rx_entry->tag = pe_entry->tag;
 			rx_entry->data = pe_entry->data;
 			rx_entry->ignore = 0;


### PR DESCRIPTION
When an unexpected message arrive before fi_av_insert, the av_index won't be available and was set to FI_ADDR_NOTAVAIL. It eventually may get mismatched to a wrong receive entry. Store the raw ip address for this case and try to recover the av_index at match time.

This bug is triggered in MPICH recent CI testing after we revamped support for MPI Sessions. With world model, we have a barrier at the end of MPI_Init, preventing messages to arrive before all `fi_av_inserts` completes. With sessions, we no longer have such barriers.