### PR TITLE
prov/usnic: Fix memory leak in usd_ib_get_devlist()

### DIFF
--- a/prov/usnic/src/usnic_direct/usd_ib_sysfs.c
+++ b/prov/usnic/src/usnic_direct/usd_ib_sysfs.c
@@ -111,8 +111,11 @@ usd_ib_get_devlist(
         }
 
         /* Must be a directory */
-        if (!S_ISDIR(sbuf.st_mode))
+        if (!S_ISDIR(sbuf.st_mode)) {
+            free(dev_path);
+            dev_path = NULL;
             continue;
+        }
 
         /* read the ibdev */
         if (asprintf(&ibdev_path, "%s/ibdev", dev_path) <= 0) {


### PR DESCRIPTION
ASAN detects the following memory leak in usdb_ib_get_devlist() when fi_info is executed with the usnic provider enabled:

```
Direct leak of 40 byte(s) in 1 object(s) allocated from:
    0 0xfffff78e76d0 in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    1 0xfffff6eb9954 in __vasprintf_internal libio/vasprintf.c:116
    2 0xfffff6eb99ac in __vasprintf libio/vasprintf.c:141
    3 0xfffff78bad14 in vasprintf ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:1680
    4 0xfffff78bc214 in asprintf ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:1732
    5 0xfffff73c873c in usd_ib_get_devlist prov/usnic/src/usnic_direct/usd_ib_sysfs.c:98
    6 0xfffff73c6468 in do_usd_init (/nfs_home/sdidelot/usr/libfabric/lib/libfabric.so.1+0x3c6468) (BuildId: 0d9aff96d8c9291e9159fc164323ce77744fcd75)
    7 0xfffff6ecabd8 in __pthread_once_slow nptl/pthread_once.c:116
    8 0xfffff73c65f4 in usd_get_device_list (/nfs_home/sdidelot/usr/libfabric/lib/libfabric.so.1+0x3c65f4) (BuildId: 0d9aff96d8c9291e9159fc164323ce77744fcd75)
    9 0xfffff73fd438 in usdf_get_devinfo prov/usnic/src/usdf_fabric.c:534
    10 0xfffff73fed78 in usdf_getinfo prov/usnic/src/usdf_fabric.c:775
    11 0xfffff710089c in fi_getinfo_ src/fabric.c:1377
    12 0xaaaaaaaa64cc in run util/info.c:316
    13 0xaaaaaaaa7008 in main util/info.c:440
    14 0xfffff6e684c0 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    15 0xfffff6e68594 in __libc_start_main_impl ../csu/libc-start.c:360
    16 0xaaaaaaaa3f2c in _start (/nfs_home/sdidelot/usr/libfabric/bin/fi_info+0x3f2c) (BuildId: fb9eab2601c4e46bd55735708fde59816861a709)
```