### PR TITLE
prov/efa: Extend domain ops to allow querying of QP and CQ attributes

### DIFF
--- a/man/fi_efa.7.md
+++ b/man/fi_efa.7.md
@@ -201,6 +201,10 @@ struct fi_efa_ops_domain {
 			  uint16_t *remote_qpn, uint32_t *remote_qkey);
 	int (*query_qp_wqs)(struct fid_ep *ep_fid, struct fi_efa_wq_attr *sq_attr, struct fi_efa_wq_attr *rq_attr);
 	int (*query_cq)(struct fid_cq *cq_fid, struct fi_efa_cq_attr *cq_attr);
+	int (*cq_open_ext)(struct fid_domain *domain_fid,
+			   struct fi_cq_attr *attr,
+			   struct fi_efa_cq_init_attr *efa_cq_init_attr,
+			   struct fid_cq **cq_fid, void *context);
 };
 ```
 
@@ -314,6 +318,49 @@ struct fi_efa_cq_attr {
 
 #### Return value
 **query_cq()** returns 0 on success, or the value of errno on failure
+(which indicates the failure reason).
+
+### cq_open_ext
+This op creates a completion queue with external memory provided via dmabuf.
+The memory can be passed by supplying the following struct.
+
+```c
+struct fi_efa_cq_init_attr {
+	uint64_t flags;
+	struct {
+		uint8_t *buffer;
+		uint64_t length;
+		uint64_t offset;
+		uint32_t fd;
+	} ext_mem_dmabuf;
+};
+```
+
+*flags*
+:	A bitwise OR of the various values described below.
+
+	FI_EFA_CQ_INIT_FLAGS_EXT_MEM_DMABUF:
+		create CQ with external memory provided via dmabuf.
+
+*ext_mem_dmabuf*
+:	Structure containing information about external memory when using
+	FI_EFA_CQ_INIT_FLAGS_EXT_MEM_DMABUF flag.
+
+	*buffer*
+	:	Pointer to the memory mapped in the process's virtual address space. 
+		The field is optional, but if not provided, the use of CQ poll interfaces should be avoided.
+
+	*length*
+	:	Length of the memory region to use.
+
+	*offset*
+	:	Offset within the dmabuf.
+
+	*fd*
+	:	File descriptor of the dmabuf.
+
+#### Return value
+**cq_open_ext()** returns 0 on success, or the value of errno on failure
 (which indicates the failure reason).
 
 # Traffic Class (tclass) in EFA

--- a/man/fi_efa.7.md
+++ b/man/fi_efa.7.md
@@ -199,13 +199,15 @@ struct fi_efa_ops_domain {
 	int (*query_mr)(struct fid_mr *mr, struct fi_efa_mr_attr *mr_attr);
 	int (*query_addr)(struct fid_ep *ep_fid, fi_addr_t addr, uint16_t *ahn,
 			  uint16_t *remote_qpn, uint32_t *remote_qkey);
+	int (*query_qp_wqs)(struct fid_ep *ep_fid, struct fi_efa_wq_attr *sq_attr, struct fi_efa_wq_attr *rq_attr);
+	int (*query_cq)(struct fid_cq *cq_fid, struct fi_efa_cq_attr *cq_attr);
 };
 ```
 
 It contains the following operations
 
 ### query_mr
-This op query an existing memory registration as input, and outputs the efa
+This op queries an existing memory registration as input, and outputs the efa
 specific mr attribute which is defined as follows
 
 ```c
@@ -256,6 +258,63 @@ This op queries the following address information for a given endpoint and desti
 
 #### Return value
 **query_addr()** returns FI_SUCCESS on success, or -FI_EINVAL on failure.
+
+### query_qp_wqs
+This op queries EFA specific Queue Pair work queue attributes for a given endpoint.
+It retrieves the send queue attributes in sq_attr and receive queue attributes in rq_attr, which is defined as follows.
+
+```c
+struct fi_efa_wq_attr {
+    uint8_t *buffer;
+    uint32_t entry_size;
+    uint32_t num_entries;
+    uint32_t *doorbell;
+    uint32_t max_batch;
+};
+```
+
+*buffer*
+:	Queue buffer.
+
+*entry_size*
+:	Size of each entry in the queue.
+
+*num_entries*
+:	Maximal number of entries in the queue.
+
+*doorbell*
+:	Queue doorbell.
+
+*max_batch*
+:	Maximum batch size for queue submissions.
+
+#### Return value
+**query_qp_wqs()** returns 0 on success, or the value of errno on failure
+(which indicates the failure reason).
+
+### query_cq
+This op queries EFA specific Completion Queue attributes for a given cq.
+
+```c
+struct fi_efa_cq_attr {
+    uint8_t *buffer;
+    uint32_t entry_size;
+    uint32_t num_entries;
+};
+```
+
+*buffer*
+:	Completion queue buffer.
+
+*entry_size*
+:	Size of each completion queue entry.
+
+*num_entries*
+:	Maximal number of entries in the completion queue.
+
+#### Return value
+**query_cq()** returns 0 on success, or the value of errno on failure
+(which indicates the failure reason).
 
 # Traffic Class (tclass) in EFA
 To prioritize the messages from a given endpoint, user can specify `fi_info->tx_attr->tclass = FI_TC_LOW_LATENCY` in the fi_endpoint() call to set the service level in rdma-core. All other tclass values will be ignored.

--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -182,6 +182,14 @@ if HAVE_EFA_DATA_IN_ORDER_ALIGNED_128_BYTES
 prov_efa_test_efa_unit_test_LDFLAGS += -Wl,--wrap=ibv_query_qp_data_in_order
 endif
 
+if HAVE_EFADV_QUERY_QP_WQS
+prov_efa_test_efa_unit_test_LDFLAGS += -Wl,--wrap=efadv_query_qp_wqs
+endif HAVE_EFADV_QUERY_QP_WQS
+
+if HAVE_EFADV_QUERY_CQ
+prov_efa_test_efa_unit_test_LDFLAGS += -Wl,--wrap=efadv_query_cq
+endif HAVE_EFADV_QUERY_CQ
+
 prov_efa_test_efa_unit_test_LIBS = $(efa_LIBS) $(linkback)
 
 endif ENABLE_EFA_UNIT_TEST

--- a/prov/efa/configure.m4
+++ b/prov/efa/configure.m4
@@ -72,6 +72,7 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 	have_caps_rnr_retry=0
 	have_caps_rdma_write=0
 	have_caps_unsolicited_write_recv=0
+	have_caps_cq_with_ext_mem_dmabuf=0
 	have_ibv_is_fork_initialized=0
 	efa_support_data_in_order_aligned_128_byte=0
 	efadv_support_extended_cq=0
@@ -103,6 +104,11 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 		AC_CHECK_DECL(EFADV_DEVICE_ATTR_CAPS_UNSOLICITED_WRITE_RECV,
 			[have_caps_unsolicited_write_recv=1],
 			[have_caps_unsolicited_write_recv=0],
+			[[#include <infiniband/efadv.h>]])
+
+		AC_CHECK_DECL(EFADV_DEVICE_ATTR_CAPS_CQ_WITH_EXT_MEM_DMABUF,
+			[have_caps_cq_with_ext_mem_dmabuf=1],
+			[have_caps_cq_with_ext_mem_dmabuf=0],
 			[[#include <infiniband/efadv.h>]])
 
 		AC_CHECK_DECL([ibv_is_fork_initialized],
@@ -193,6 +199,9 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 	AC_DEFINE_UNQUOTED([HAVE_CAPS_UNSOLICITED_WRITE_RECV],
 		[$have_caps_unsolicited_write_recv],
 		[Indicates if EFADV_DEVICE_ATTR_CAPS_UNSOLICITED_WRITE_RECV is defined])
+	AC_DEFINE_UNQUOTED([HAVE_CAPS_CQ_WITH_EXT_MEM_DMABUF],
+		[$have_caps_cq_with_ext_mem_dmabuf],
+		[Indicates if EFADV_DEVICE_ATTR_CAPS_CQ_WITH_EXT_MEM_DMABUF is defined])
 	AC_DEFINE_UNQUOTED([HAVE_IBV_IS_FORK_INITIALIZED],
 		[$have_ibv_is_fork_initialized],
 		[Indicates if libibverbs has ibv_is_fork_initialized])

--- a/prov/efa/configure.m4
+++ b/prov/efa/configure.m4
@@ -78,6 +78,8 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 	have_efa_dmabuf_mr=0
 	have_efadv_query_mr=0
 	have_efadv_sl=0
+	have_efadv_query_qp_wqs=0
+	have_efadv_query_cq=0
 
 	dnl $have_neuron is defined at top-level configure.ac
 	AM_CONDITIONAL([HAVE_NEURON], [ test x"$have_neuron" = x1 ])
@@ -165,6 +167,18 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 			[have_efadv_sl=1],
 			[have_efadv_sl=0],
 			[[#include <infiniband/efadv.h>]])
+		
+		have_efadv_query_qp_wqs=1
+		AC_CHECK_DECL([efadv_query_qp_wqs],
+			[],
+			[have_efadv_query_qp_wqs=0],
+			[[#include <infiniband/efadv.h>]])
+	
+		have_efadv_query_cq=1
+		AC_CHECK_DECL([efadv_query_cq],
+			[],
+			[have_efadv_query_cq=0],
+			[[#include <infiniband/efadv.h>]])
 	])
 
 	AC_DEFINE_UNQUOTED([HAVE_RDMA_SIZE],
@@ -197,6 +211,12 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 	AC_DEFINE_UNQUOTED([HAVE_EFADV_SL],
 		[$have_efadv_sl],
 		[Indicates if efadv_qp_init_attr has sl])
+	AC_DEFINE_UNQUOTED([HAVE_EFADV_QUERY_QP_WQS],
+		[$have_efadv_query_qp_wqs],
+		[Indicates if efadv_query_qp_wqs is available])
+	AC_DEFINE_UNQUOTED([HAVE_EFADV_QUERY_CQ],
+		[$have_efadv_query_cq],
+		[Indicates if efadv_query_cq is available])
 
 
 	CPPFLAGS=$save_CPPFLAGS
@@ -242,6 +262,8 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 
 	AM_CONDITIONAL([HAVE_EFADV_CQ_EX], [ test $efadv_support_extended_cq = 1])
 	AM_CONDITIONAL([HAVE_EFADV_QUERY_MR], [ test $have_efadv_query_mr = 1])
+	AM_CONDITIONAL([HAVE_EFADV_QUERY_QP_WQS], [ test $have_efadv_query_qp_wqs = 1])
+	AM_CONDITIONAL([HAVE_EFADV_QUERY_CQ], [ test $have_efadv_query_cq = 1])
 	AM_CONDITIONAL([HAVE_EFA_DATA_IN_ORDER_ALIGNED_128_BYTES], [ test $efa_support_data_in_order_aligned_128_byte = 1])
 	AM_CONDITIONAL([ENABLE_EFA_UNIT_TEST], [ test x"$enable_efa_unit_test" != xno])
 

--- a/prov/efa/src/efa_base_ep.c
+++ b/prov/efa/src/efa_base_ep.c
@@ -614,8 +614,11 @@ int efa_base_ep_check_qp_in_order_aligned_128_bytes(struct efa_base_ep *ep,
 	struct ibv_cq_ex *ibv_cq_ex = NULL;
 	enum ibv_cq_ex_type ibv_cq_ex_type;
 	struct fi_cq_attr cq_attr = {0};
+	struct fi_efa_cq_init_attr efa_cq_init_attr = {0};
 
-	ret = efa_cq_ibv_cq_ex_open(&cq_attr, ep->domain->device->ibv_ctx, &ibv_cq_ex, &ibv_cq_ex_type);
+	ret = efa_cq_ibv_cq_ex_open(&cq_attr, ep->domain->device->ibv_ctx,
+				    &ibv_cq_ex, &ibv_cq_ex_type,
+				    &efa_cq_init_attr);
 	if (ret) {
 		EFA_WARN(FI_LOG_CQ, "Unable to create extended CQ: %d\n", ret);
 		ret = -FI_EINVAL;

--- a/prov/efa/src/efa_device.c
+++ b/prov/efa/src/efa_device.c
@@ -360,6 +360,27 @@ bool efa_device_support_unsolicited_write_recv(void)
 }
 #endif
 
+/**
+ * @brief check whether efa device has support for creating CQ with external memory
+ *
+ * @return a boolean indicating that creating CQs with external memory buffers
+ * by passing dmabuf is supported.
+ */
+#if HAVE_CAPS_CQ_WITH_EXT_MEM_DMABUF
+bool efa_device_support_cq_with_ext_mem_dmabuf(void)
+{
+	assert(g_efa_selected_device_cnt > 0);
+
+	return !!(g_efa_selected_device_list[0].device_caps &
+		  EFADV_DEVICE_ATTR_CAPS_CQ_WITH_EXT_MEM_DMABUF);
+}
+#else
+bool efa_device_support_cq_with_ext_mem_dmabuf(void)
+{
+	return false;
+}
+#endif
+
 #ifndef _WIN32
 
 static char *get_sysfs_path(void)

--- a/prov/efa/src/efa_device.h
+++ b/prov/efa/src/efa_device.h
@@ -39,6 +39,8 @@ bool efa_device_support_rdma_write(void);
 
 bool efa_device_support_unsolicited_write_recv(void);
 
+bool efa_device_support_cq_with_ext_mem_dmabuf(void);
+
 int efa_device_get_driver(struct efa_device *efa_device,
 			  char **efa_driver);
 

--- a/prov/efa/src/fi_ext_efa.h
+++ b/prov/efa/src/fi_ext_efa.h
@@ -21,10 +21,28 @@ enum {
     FI_EFA_MR_ATTR_RDMA_RECV_IC_ID = 1 << 2,
 };
 
+struct fi_efa_wq_attr {
+    uint8_t *buffer;
+    uint32_t entry_size;
+    uint32_t num_entries;
+    uint32_t *doorbell;
+    uint32_t max_batch;
+};
+
+struct fi_efa_cq_attr {
+    uint8_t *buffer;
+    uint32_t entry_size;
+    uint32_t num_entries;
+};
+
 struct fi_efa_ops_domain {
 	int (*query_mr)(struct fid_mr *mr, struct fi_efa_mr_attr *mr_attr);
 	int (*query_addr)(struct fid_ep *ep_fid, fi_addr_t addr, uint16_t *ahn,
 			  uint16_t *remote_qpn, uint32_t *remote_qkey);
+	int (*query_qp_wqs)(struct fid_ep *ep_fid,
+			    struct fi_efa_wq_attr *sq_attr,
+			    struct fi_efa_wq_attr *rq_attr);
+	int (*query_cq)(struct fid_cq *cq_fid, struct fi_efa_cq_attr *cq_attr);
 };
 
 #endif /* _FI_EXT_EFA_H_ */

--- a/prov/efa/src/fi_ext_efa.h
+++ b/prov/efa/src/fi_ext_efa.h
@@ -21,6 +21,10 @@ enum {
     FI_EFA_MR_ATTR_RDMA_RECV_IC_ID = 1 << 2,
 };
 
+enum {
+    FI_EFA_CQ_INIT_FLAGS_EXT_MEM_DMABUF = 1 << 0,
+};
+
 struct fi_efa_wq_attr {
     uint8_t *buffer;
     uint32_t entry_size;
@@ -35,6 +39,16 @@ struct fi_efa_cq_attr {
     uint32_t num_entries;
 };
 
+struct fi_efa_cq_init_attr {
+	uint64_t flags;
+	struct {
+		uint8_t  *buffer;
+		uint64_t length;
+		uint64_t offset;
+		uint32_t fd;
+	} ext_mem_dmabuf;
+};
+
 struct fi_efa_ops_domain {
 	int (*query_mr)(struct fid_mr *mr, struct fi_efa_mr_attr *mr_attr);
 	int (*query_addr)(struct fid_ep *ep_fid, fi_addr_t addr, uint16_t *ahn,
@@ -43,6 +57,10 @@ struct fi_efa_ops_domain {
 			    struct fi_efa_wq_attr *sq_attr,
 			    struct fi_efa_wq_attr *rq_attr);
 	int (*query_cq)(struct fid_cq *cq_fid, struct fi_efa_cq_attr *cq_attr);
+	int (*cq_open_ext)(struct fid_domain *domain_fid,
+			   struct fi_cq_attr *attr,
+			   struct fi_efa_cq_init_attr *efa_cq_init_attr,
+			   struct fid_cq **cq_fid, void *context);
 };
 
 #endif /* _FI_EXT_EFA_H_ */

--- a/prov/efa/src/rdm/efa_rdm_cq.c
+++ b/prov/efa/src/rdm/efa_rdm_cq.c
@@ -659,6 +659,7 @@ int efa_rdm_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	struct efa_domain *efa_domain;
 	struct fi_cq_attr shm_cq_attr = {0};
 	struct fi_peer_cq_context peer_cq_context = {0};
+	struct fi_efa_cq_init_attr efa_cq_init_attr = {0};
 
 	if (attr->wait_obj != FI_WAIT_NONE)
 		return -FI_ENOSYS;
@@ -680,7 +681,9 @@ int efa_rdm_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	if (ret)
 		goto free;
 
-	ret = efa_cq_ibv_cq_ex_open(attr, efa_domain->device->ibv_ctx, &cq->efa_cq.ibv_cq.ibv_cq_ex, &cq->efa_cq.ibv_cq.ibv_cq_ex_type);
+	ret = efa_cq_ibv_cq_ex_open(
+		attr, efa_domain->device->ibv_ctx, &cq->efa_cq.ibv_cq.ibv_cq_ex,
+		&cq->efa_cq.ibv_cq.ibv_cq_ex_type, &efa_cq_init_attr);
 	if (ret) {
 		EFA_WARN(FI_LOG_CQ, "Unable to create extended CQ: %s\n", fi_strerror(ret));
 		goto close_util_cq;

--- a/prov/efa/test/efa_unit_test_mocks.c
+++ b/prov/efa/test/efa_unit_test_mocks.c
@@ -275,6 +275,12 @@ struct efa_unit_test_mocks g_efa_unit_test_mocks = {
 #if HAVE_EFA_DATA_IN_ORDER_ALIGNED_128_BYTES
 	.ibv_query_qp_data_in_order = __real_ibv_query_qp_data_in_order,
 #endif
+#if HAVE_EFADV_QUERY_QP_WQS
+	.efadv_query_qp_wqs = __real_efadv_query_qp_wqs,
+#endif
+#if HAVE_EFADV_QUERY_CQ
+	.efadv_query_cq = __real_efadv_query_cq,
+#endif
 };
 
 struct ibv_ah *__wrap_ibv_create_ah(struct ibv_pd *pd, struct ibv_ah_attr *attr)
@@ -485,3 +491,43 @@ int efa_mock_ibv_query_qp_data_in_order_return_in_order_aligned_128_bytes(struct
 	return IBV_QUERY_QP_DATA_IN_ORDER_ALIGNED_128_BYTES;
 }
 #endif
+
+#if HAVE_EFADV_QUERY_QP_WQS
+int __wrap_efadv_query_qp_wqs(struct ibv_qp *ibvqp, struct efadv_wq_attr *sq_attr,
+			      struct efadv_wq_attr *rq_attr, uint32_t inlen)
+{
+	return g_efa_unit_test_mocks.efadv_query_qp_wqs(ibvqp, sq_attr, rq_attr, inlen);
+}
+
+int efa_mock_efadv_query_qp_wqs(struct ibv_qp *ibvqp, struct efadv_wq_attr *sq_attr,
+				struct efadv_wq_attr *rq_attr, uint32_t inlen)
+{
+	sq_attr->buffer = (uint8_t *) 0x12345678;
+	sq_attr->doorbell = (uint32_t *) 0x87654321;
+	sq_attr->entry_size = 64;
+	sq_attr->num_entries = 128;
+	sq_attr->max_batch = 16;
+
+	rq_attr->buffer = (uint8_t *) 0x12345678;
+	rq_attr->doorbell = (uint32_t *) 0x87654321;
+	rq_attr->entry_size = 64;
+	rq_attr->num_entries = 128;
+	rq_attr->max_batch = 16;
+	return 0;
+}
+#endif /* HAVE_EFADV_QUERY_QP_WQS */
+
+#if HAVE_EFADV_QUERY_CQ
+int __wrap_efadv_query_cq(struct ibv_cq *ibvcq, struct efadv_cq_attr *attr, uint32_t inlen)
+{
+	return g_efa_unit_test_mocks.efadv_query_cq(ibvcq, attr, inlen);
+}
+
+int efa_mock_efadv_query_cq(struct ibv_cq *ibvcq, struct efadv_cq_attr *attr, uint32_t inlen)
+{
+	attr->buffer = (uint8_t *) 0x12345678;
+	attr->entry_size = 64;
+	attr->num_entries = 128;
+	return 0;
+}
+#endif /* HAVE_EFADV_QUERY_CQ */

--- a/prov/efa/test/efa_unit_test_mocks.h
+++ b/prov/efa/test/efa_unit_test_mocks.h
@@ -161,6 +161,15 @@ struct efa_unit_test_mocks
 #if HAVE_EFA_DATA_IN_ORDER_ALIGNED_128_BYTES
 	int (*ibv_query_qp_data_in_order)(struct ibv_qp *qp, enum ibv_wr_opcode op, uint32_t flags);
 #endif
+
+#if HAVE_EFADV_QUERY_QP_WQS
+	int (*efadv_query_qp_wqs)(struct ibv_qp *ibvqp, struct efadv_wq_attr *sq_attr,
+				  struct efadv_wq_attr *rq_attr, uint32_t inlen);
+#endif
+
+#if HAVE_EFADV_QUERY_CQ
+	int (*efadv_query_cq)(struct ibv_cq *ibvcq, struct efadv_cq_attr *attr, uint32_t inlen);
+#endif
 };
 
 struct ibv_cq_ex *efa_mock_create_cq_ex_return_null(struct ibv_context *context, struct ibv_cq_init_attr_ex *init_attr);
@@ -211,6 +220,18 @@ int efa_mock_efadv_query_mr_recv_and_rdma_read_ic_id_0_1(struct ibv_mr *ibv_mr, 
 int __real_ibv_query_qp_data_in_order(struct ibv_qp *qp, enum ibv_wr_opcode op, uint32_t flags);
 int efa_mock_ibv_query_qp_data_in_order_return_0(struct ibv_qp *qp, enum ibv_wr_opcode op, uint32_t flags);
 int efa_mock_ibv_query_qp_data_in_order_return_in_order_aligned_128_bytes(struct ibv_qp *qp, enum ibv_wr_opcode op, uint32_t flags);
+#endif
+
+#if HAVE_EFADV_QUERY_QP_WQS
+int __real_efadv_query_qp_wqs(struct ibv_qp *ibvqp, struct efadv_wq_attr *sq_attr,
+			      struct efadv_wq_attr *rq_attr, uint32_t inlen);
+int efa_mock_efadv_query_qp_wqs(struct ibv_qp *ibvqp, struct efadv_wq_attr *sq_attr,
+				struct efadv_wq_attr *rq_attr, uint32_t inlen);
+#endif
+
+#if HAVE_EFADV_QUERY_CQ
+int __real_efadv_query_cq(struct ibv_cq *ibvcq, struct efadv_cq_attr *attr, uint32_t inlen);
+int efa_mock_efadv_query_cq(struct ibv_cq *ibvcq, struct efadv_cq_attr *attr, uint32_t inlen);
 #endif
 
 enum ibv_fork_status __real_ibv_is_fork_initialized(void);

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -256,6 +256,8 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_domain_direct_attr_mr_allocated, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_domain_peer_list_cleared, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_domain_open_ops_query_addr, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_domain_open_ops_query_qp_wqs, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_domain_open_ops_query_cq, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		/* end efa_unit_test_domain.c */
 
 		cmocka_unit_test_setup_teardown(test_efa_rdm_cq_ibv_cq_poll_list_same_tx_rx_cq_single_ep, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -74,6 +74,18 @@ static int efa_unit_test_mocks_teardown(void **state)
 		.efa_rdm_ope_post_send = __real_efa_rdm_ope_post_send,
 		.efa_device_support_unsolicited_write_recv = __real_efa_device_support_unsolicited_write_recv,
 		.ibv_is_fork_initialized = __real_ibv_is_fork_initialized,
+#if HAVE_EFADV_QUERY_MR
+		.efadv_query_mr = __real_efadv_query_mr,
+#endif
+#if HAVE_EFA_DATA_IN_ORDER_ALIGNED_128_BYTES
+		.ibv_query_qp_data_in_order = __real_ibv_query_qp_data_in_order,
+#endif
+#if HAVE_EFADV_QUERY_QP_WQS
+		.efadv_query_qp_wqs = __real_efadv_query_qp_wqs,
+#endif
+#if HAVE_EFADV_QUERY_CQ
+		.efadv_query_cq = __real_efadv_query_cq,
+#endif
 	};
 
 	/* Reset environment */
@@ -258,6 +270,7 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_domain_open_ops_query_addr, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_domain_open_ops_query_qp_wqs, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_domain_open_ops_query_cq, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_domain_open_ops_cq_open_ext, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		/* end efa_unit_test_domain.c */
 
 		cmocka_unit_test_setup_teardown(test_efa_rdm_cq_ibv_cq_poll_list_same_tx_rx_cq_single_ep, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -269,6 +269,8 @@ void test_efa_domain_dgram_attr_mr_allocated();
 void test_efa_domain_direct_attr_mr_allocated();
 void test_efa_domain_peer_list_cleared();
 void test_efa_domain_open_ops_query_addr();
+void test_efa_domain_open_ops_query_qp_wqs();
+void test_efa_domain_open_ops_query_cq();
 /* end efa_unit_test_domain.c */
 
 void test_efa_rdm_cq_ibv_cq_poll_list_same_tx_rx_cq_single_ep();

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -271,6 +271,7 @@ void test_efa_domain_peer_list_cleared();
 void test_efa_domain_open_ops_query_addr();
 void test_efa_domain_open_ops_query_qp_wqs();
 void test_efa_domain_open_ops_query_cq();
+void test_efa_domain_open_ops_cq_open_ext();
 /* end efa_unit_test_domain.c */
 
 void test_efa_rdm_cq_ibv_cq_poll_list_same_tx_rx_cq_single_ep();


### PR DESCRIPTION
Following rdma core changes, enable querying of QP work queue and completion queue's attributes in domain operations, which can be used for accelerator driven datapath.
Enable creation of CQs on top of pre-allocated memory buffers. The memory can be passed by supplying
the struct fi_efa_cq_init_attr with the flag FI_EFA_CQ_INIT_FLAGS_EXT_MEM_DMABUF.