### PR TITLE
[v2.1.x] contrib/intel/jenkins: Pick add back auth stage from main

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -193,6 +193,10 @@ pipeline {
           git_diffs()
           RELEASE = release()
           DO_RUN = skip() && !weekly ? false : true
+          sh """PATH=${CI_LOCATION}/venv/bin/:${env.PATH} \
+                python ${CI_LOCATION}/authorize.py \
+                --author=${env.CHANGE_AUTHOR}
+          """
         }
       }
     }


### PR DESCRIPTION
Auth stage got removed by accident.
This adds it back.