### PR TITLE
prov/verbs: Fix unprotected access to vrb_util_prov.info

### DIFF
--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -201,8 +201,10 @@ vrb_eq_cm_getinfo(struct rdma_cm_event *event, struct fi_info *pep_info,
 		hints->fabric_attr->name = NULL;
 	}
 
+	ofi_mutex_lock(&vrb_info_mutex);
 	ret = vrb_get_matching_info(hints->fabric_attr->api_version, hints,
 				    info, vrb_util_prov.info, 0);
+	ofi_mutex_unlock(&vrb_info_mutex);
 	if (ret)
 		goto err1;
 


### PR DESCRIPTION
Access to vrb_util_prov.info is now guarded by the vrb_info_mutex mutex, as the list it references may change if the application triggers an interface rescan using the FI_RESCAN flag.

This issue was discovered during internal testing at DDN with FI_RESCAN enabled.