### PR TITLE
contrib/intel/jenkins: Make stages turn red on fail

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -34,7 +34,7 @@ def initialize() {
 
 def run_red(config_name) {
   return sh (
-    returnStatus: true,
+    returnStatus: false,
     script: """PATH=${CI_LOCATION}/venv/bin/:${env.PATH} red \
                --output ${CUSTOM_WORKSPACE} \
                --config "${CI_LOCATION}/red_configs/${config_name}.json" \


### PR DESCRIPTION
If return status is true then errors will not get propogated up to the controller to fail a build. Switching it to false will allow the stages to properly fail.