### PR TITLE
[v2.1.x] contrib/intel/jenkins: Pick make stages turn red on fail from main

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -34,7 +34,7 @@ def initialize() {
 
 def run_red(config_name) {
   return sh (
-    returnStatus: true,
+    returnStatus: false,
     script: """PATH=${CI_LOCATION}/venv/bin/:${env.PATH} red \
                --output ${CUSTOM_WORKSPACE} \
                --config "${CI_LOCATION}/red_configs/${config_name}.json" \


### PR DESCRIPTION
If return status is true then errors will not get propogated up to the controller to fail a build. Switching it to false will allow the stages to properly fail.