### PR TITLE
prov/efa: Track cloned rx pkts

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -1233,7 +1233,6 @@ int efa_rdm_ope_prepare_to_post_read(struct efa_rdm_ope *ope)
  *     On success, return 0
  *     On pack entry allocation failure, return -FI_EAGAIN
  */
-static
 ssize_t efa_rdm_txe_prepare_local_read_pkt_entry(struct efa_rdm_ope *txe)
 {
 	struct efa_rdm_pke *pkt_entry;
@@ -1258,6 +1257,11 @@ ssize_t efa_rdm_txe_prepare_local_read_pkt_entry(struct efa_rdm_ope *txe)
 			"readcopy pkt pool exhausted! Set FI_EFA_READCOPY_POOL_SIZE to a higher value!");
 		return -FI_EAGAIN;
 	}
+
+#if ENABLE_DEBUG
+	/* readcopy pkt is also rx pkt, insert it to rx pkt list so we can track it and clean up during ep close */
+	dlist_insert_tail(&pkt_entry_copy->dbg_entry, &pkt_entry_copy->ep->rx_pkt_list);
+#endif
 
 	efa_rdm_pke_release_rx(pkt_entry);
 

--- a/prov/efa/src/rdm/efa_rdm_ope.h
+++ b/prov/efa/src/rdm/efa_rdm_ope.h
@@ -339,4 +339,5 @@ ssize_t efa_rdm_ope_post_send_or_queue(struct efa_rdm_ope *ope, int pkt_type);
 
 ssize_t efa_rdm_ope_repost_ope_queued_before_handshake(struct efa_rdm_ope *ope);
 
+ssize_t efa_rdm_txe_prepare_local_read_pkt_entry(struct efa_rdm_ope *txe);
 #endif

--- a/prov/efa/src/rdm/efa_rdm_peer.c
+++ b/prov/efa/src/rdm/efa_rdm_peer.c
@@ -216,6 +216,11 @@ int efa_rdm_peer_recvwin_queue_or_append_pke(struct efa_rdm_pke *pkt_entry,
 	if (OFI_LIKELY(efa_env.rx_copy_ooo)) {
 		assert(pkt_entry->alloc_type == EFA_RDM_PKE_FROM_EFA_RX_POOL);
 		ooo_entry = efa_rdm_pke_clone(pkt_entry, pkt_entry->ep->rx_ooo_pkt_pool, EFA_RDM_PKE_FROM_OOO_POOL);
+#if ENABLE_DEBUG
+		/* ooo pkt is also rx pkt, insert it to rx pkt list so we can track it and clean up during ep close */
+		dlist_insert_tail(&ooo_entry->dbg_entry, &ooo_entry->ep->rx_pkt_list);
+#endif
+
 		if (OFI_UNLIKELY(!ooo_entry)) {
 			EFA_WARN(FI_LOG_EP_CTRL,
 				"Unable to allocate rx_pkt_entry for OOO msg\n");

--- a/prov/efa/src/rdm/efa_rdm_pke.c
+++ b/prov/efa/src/rdm/efa_rdm_pke.c
@@ -268,6 +268,10 @@ struct efa_rdm_pke *efa_rdm_pke_get_unexp(struct efa_rdm_pke **pkt_entry_ptr)
 				"Unable to allocate rx_pkt_entry for unexp msg\n");
 			return NULL;
 		}
+#if ENABLE_DEBUG
+		/* unexp pkt is also rx pkt, insert it to rx pkt list so we can track it and clean up during ep close */
+		dlist_insert_tail(&unexp_pkt_entry->dbg_entry, &ep->rx_pkt_list);
+#endif
 		efa_rdm_pke_release_rx(*pkt_entry_ptr);
 		*pkt_entry_ptr = unexp_pkt_entry;
 	} else {

--- a/prov/efa/test/efa_unit_test_pke.c
+++ b/prov/efa/test/efa_unit_test_pke.c
@@ -246,3 +246,27 @@ void test_efa_rdm_pke_alloc_rtr_rxe(struct efa_resource **state)
 	efa_rdm_rxe_release(rxe);
 	efa_rdm_pke_release_rx(pke);
 }
+
+void test_efa_rdm_pke_get_unexp(struct efa_resource **state)
+{
+	struct efa_resource *resource = *state;
+	struct efa_rdm_pke *pkt_entry, *unexp_pkt_entry;
+	struct efa_rdm_ep *efa_rdm_ep;
+
+	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_FABRIC_NAME);
+
+	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
+
+	pkt_entry = efa_rdm_pke_alloc(efa_rdm_ep, efa_rdm_ep->efa_rx_pkt_pool,
+				      EFA_RDM_PKE_FROM_EFA_RX_POOL);
+	assert_non_null(pkt_entry);
+	efa_rdm_ep->efa_rx_pkts_posted = efa_rdm_ep_get_rx_pool_size(efa_rdm_ep);
+
+	unexp_pkt_entry = efa_rdm_pke_get_unexp(&pkt_entry);
+	assert_non_null(unexp_pkt_entry);
+
+#if ENABLE_DEBUG
+	/* The unexp pkt entry should be inserted to the rx_pkt_list */
+	assert_int_equal(efa_unit_test_get_dlist_length(&efa_rdm_ep->rx_pkt_list), 1);
+#endif
+}

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -199,6 +199,8 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_srx_unexp_pkt, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rnr_queue_and_resend_msg, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rnr_queue_and_resend_tagged, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+
+		/* begin of efa_unit_test_ope.c */
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ope_prepare_to_post_send_with_no_enough_tx_pkts, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ope_prepare_to_post_send_host_memory, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ope_prepare_to_post_send_host_memory_align128, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
@@ -215,6 +217,9 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_rdm_rxe_map, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_rxe_list_removal, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_txe_list_removal, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_rdm_txe_prepare_local_read_pkt_entry, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		/* end of efa_unit_test_ope.c */
+
 		cmocka_unit_test_setup_teardown(test_efa_rdm_msg_send_to_local_peer_with_null_desc, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_fork_support_request_initialize_when_ibv_fork_support_is_needed, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_fork_support_request_initialize_when_ibv_fork_support_is_unneeded, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
@@ -230,11 +235,15 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_rdm_peer_get_runt_size_cuda_memory_exceeding_total_len_128_alignment, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_peer_select_readbase_rtm_no_runt, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_peer_select_readbase_rtm_do_runt, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+
+		/* begin of efa_unit_test_pke.c */
 		cmocka_unit_test_setup_teardown(test_efa_rdm_pke_get_available_copy_methods_align128, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_pke_release_rx_list, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_pke_alloc_rta_rxe, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_pke_alloc_rtw_rxe, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_pke_alloc_rtr_rxe, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_rdm_pke_get_unexp, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		/* end of efa_unit_test_pke.c */
 
 		/* begin efa_unit_test_domain.c */
 		cmocka_unit_test_setup_teardown(test_efa_domain_info_type_efa_direct, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
@@ -260,6 +269,7 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_rdm_peer_move_overflow_pke_to_recvwin, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_peer_keep_pke_in_overflow_list, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_peer_append_overflow_pke_to_recvwin, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_rdm_peer_recvwin_queue_or_append_pke, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_pke_handle_longcts_rtm_send_completion, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_msg_fi_recv, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_msg_fi_recvv, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -221,6 +221,8 @@ void test_efa_srx_lock();
 void test_efa_srx_unexp_pkt();
 void test_efa_rnr_queue_and_resend_msg();
 void test_efa_rnr_queue_and_resend_tagged();
+
+/* begin of efa_unit_test_ope.c */
 void test_efa_rdm_ope_prepare_to_post_send_with_no_enough_tx_pkts();
 void test_efa_rdm_ope_prepare_to_post_send_host_memory();
 void test_efa_rdm_ope_prepare_to_post_send_host_memory_align128();
@@ -236,6 +238,8 @@ void test_efa_rdm_rxe_handle_error_not_write_cq();
 void test_efa_rdm_rxe_map();
 void test_efa_rdm_rxe_list_removal();
 void test_efa_rdm_txe_list_removal();
+void test_efa_rdm_txe_prepare_local_read_pkt_entry();
+/* end of efa_unit_test_ope.c */
 void test_efa_rdm_msg_send_to_local_peer_with_null_desc();
 void test_efa_fork_support_request_initialize_when_ibv_fork_support_is_needed();
 void test_efa_fork_support_request_initialize_when_ibv_fork_support_is_unneeded();
@@ -271,6 +275,7 @@ void test_efa_rdm_cq_post_initial_rx_pkts();
 void test_efa_rdm_cntr_ibv_cq_poll_list_same_tx_rx_cq_single_ep();
 void test_efa_rdm_cntr_ibv_cq_poll_list_separate_tx_rx_cq_single_ep();
 void test_efa_rdm_cntr_post_initial_rx_pkts();
+/* begin of efa_unit_test_rdm_peer.c */
 void test_efa_rdm_peer_reorder_expected_msg_id();
 void test_efa_rdm_peer_reorder_smaller_msg_id();
 void test_efa_rdm_peer_reorder_larger_msg_id();
@@ -278,11 +283,18 @@ void test_efa_rdm_peer_reorder_overflow_msg_id();
 void test_efa_rdm_peer_move_overflow_pke_to_recvwin();
 void test_efa_rdm_peer_keep_pke_in_overflow_list();
 void test_efa_rdm_peer_append_overflow_pke_to_recvwin();
+void test_efa_rdm_peer_recvwin_queue_or_append_pke();
+/* end of efa_unit_test_rdm_peer.c */
+
+/* begin of efa_unit_test_pke.c */
 void test_efa_rdm_pke_handle_longcts_rtm_send_completion();
 void test_efa_rdm_pke_release_rx_list();
 void test_efa_rdm_pke_alloc_rta_rxe();
 void test_efa_rdm_pke_alloc_rtw_rxe();
 void test_efa_rdm_pke_alloc_rtr_rxe();
+void test_efa_rdm_pke_get_unexp();
+/* end of efa_unit_test_pke.c */
+
 void test_efa_msg_fi_recv();
 void test_efa_msg_fi_recvv();
 void test_efa_msg_fi_recvmsg();


### PR DESCRIPTION
ooo, unexp, and readcopy rx pkts are cloned
from the original rx pkts allocated in the rx pkt pool, but they are not inserted to the rx pkt list when
they are created. This caused non-processed pkts
not cleaned up before creating the buffer pools
and cause assertion errors. This patch
fixes this issue by inserting them into
rx pkt list when they are cloned. So they
will be all cleaned during the scan of
rx_pkt_list during ep close.