### PR TITLE
prov/efa: Clear domain level peer lists when closing endpoints

### DIFF
--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -246,6 +246,7 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_domain_rdm_attr_mr_allocated, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_domain_dgram_attr_mr_allocated, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_domain_direct_attr_mr_allocated, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_domain_peer_list_cleared, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		/* end efa_unit_test_domain.c */
 
 		cmocka_unit_test_setup_teardown(test_efa_rdm_cq_ibv_cq_poll_list_same_tx_rx_cq_single_ep, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -259,6 +259,7 @@ void test_efa_domain_open_ops_mr_query();
 void test_efa_domain_rdm_attr_mr_allocated();
 void test_efa_domain_dgram_attr_mr_allocated();
 void test_efa_domain_direct_attr_mr_allocated();
+void test_efa_domain_peer_list_cleared();
 /* end efa_unit_test_domain.c */
 
 void test_efa_rdm_cq_ibv_cq_poll_list_same_tx_rx_cq_single_ep();


### PR DESCRIPTION
When closing an endpoint, remove peers associated with that endpoint from domain level lists