### PR TITLE
.github/workflows: Update Coverity runner to ubuntu 22.04

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -46,7 +46,7 @@ env:
   RDMA_CORE_VERSION: v35.0
 jobs:
   coverity:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Install dependencies (Linux)
         run: |


### PR DESCRIPTION
Ubuntu 20.04 LTS runner was retired on 4/15/2025.