### PR TITLE
prov/verbs: Fix (yet another) unprotected access to vrb_util_prov.info

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -160,6 +160,7 @@ typedef void (*ofi_alter_info_t)(uint32_t version,
 struct util_prov {
 	const struct fi_provider	*prov;
 	struct fi_info			*info;
+	ofi_mutex_t			*info_lock;
 	ofi_alter_info_t		alter_defaults;
 	const int			flags;
 };

--- a/prov/verbs/src/verbs_init.c
+++ b/prov/verbs/src/verbs_init.c
@@ -87,16 +87,18 @@ struct fi_provider vrb_prov = {
 	.cleanup = vrb_fini
 };
 
+ofi_mutex_t vrb_info_mutex;
+
 struct util_prov vrb_util_prov = {
 	.prov = &vrb_prov,
 	.info = NULL,
+	.info_lock = &vrb_info_mutex,
 	/* The support of the shared recieve contexts
 	 * is dynamically calculated */
 	.flags = 0,
 };
 
 /* mutex for guarding the initialization of vrb_util_prov.info */
-ofi_mutex_t vrb_info_mutex;
 DEFINE_LIST(vrb_devs);
 
 int vrb_sockaddr_len(struct sockaddr *addr)


### PR DESCRIPTION
Access to vrb_util_prov.info is now guarded by the vrb_info_mutex mutex, as the list it references may change if the application triggers an interface rescan using the FI_RESCAN flag.

This issue was discovered during internal testing at DDN with FI_RESCAN enabled.