### PR TITLE
prov/verbs: bug fix and optimize init info.

### DIFF
--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -1414,6 +1414,12 @@ static int vrb_init_info(struct dlist_entry *verbs_devs,
 			continue;
 		}
 
+		if (vrb_gl_data.device_name &&
+		    strncasecmp(ctx_list[i]->device->name,
+				vrb_gl_data.device_name,
+				strlen(vrb_gl_data.device_name)))
+			continue;
+
 		for (j = 0; j < dom_count; j++) {
 			if (ep_type[j]->type == FI_EP_MSG &&
 			    !vrb_device_has_ipoib_addr(verbs_devs, ctx_list[i]->device->name)) {
@@ -1425,11 +1431,6 @@ static int vrb_init_info(struct dlist_entry *verbs_devs,
 					ctx_list[i]->device->name);
 				continue;
 			}
-			if (vrb_gl_data.device_name &&
-			    strncasecmp(ctx_list[i]->device->name,
-					vrb_gl_data.device_name,
-					strlen(vrb_gl_data.device_name)))
-				continue;
 
 			ret = vrb_alloc_info(ctx_list[i], &fi, ep_type[j]);
 			if (ret)

--- a/prov/verbs/src/verbs_msg.c
+++ b/prov/verbs/src/verbs_msg.c
@@ -196,7 +196,6 @@ vrb_msg_inject_fast(struct fid_ep *ep_fid, const void *buf, size_t len,
 static ssize_t vrb_msg_ep_injectdata_fast(struct fid_ep *ep_fid, const void *buf, size_t len,
 					     uint64_t data, fi_addr_t dest_addr)
 {
-	ssize_t ret;
 	struct vrb_ep *ep =
 		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 
@@ -206,9 +205,7 @@ static ssize_t vrb_msg_ep_injectdata_fast(struct fid_ep *ep_fid, const void *buf
 	ep->wrs->sge.addr = (uintptr_t) buf;
 	ep->wrs->sge.length = (uint32_t) len;
 
-	ret = vrb_post_send(ep, &ep->wrs->msg_wr, 0);
-	ep->wrs->msg_wr.opcode = IBV_WR_SEND;
-	return ret;
+	return vrb_post_send(ep, &ep->wrs->msg_wr, 0);
 }
 
 const struct fi_ops_msg vrb_msg_ep_msg_ops_ts = {


### PR DESCRIPTION
In init info, move device name checking before iterating on domain types to reduce un-necessary checking.