### PR TITLE
prov/cxi: fix cxi driver paths for CI

### DIFF
--- a/prov/cxi/test/startvm-setup.sh
+++ b/prov/cxi/test/startvm-setup.sh
@@ -17,9 +17,9 @@ modprobe ptp
 modprobe iommu_v2 || modprobe amd_iommu_v2
 insmod $DBS_DIR/slingshot_base_link/cxi-sbl.ko
 insmod $DBS_DIR/sl-driver/knl/cxi-sl.ko
-insmod $DBS_DIR/cxi-driver/cxi/cxi-ss1.ko disable_default_svc=0
-insmod $DBS_DIR/cxi-driver/cxi/cxi-user.ko
-insmod $DBS_DIR/cxi-driver/cxi/cxi-eth.ko
+insmod $DBS_DIR/cxi-driver/drivers/net/ethernet/hpe/ss1/cxi-ss1.ko disable_default_svc=0
+insmod $DBS_DIR/cxi-driver/drivers/net/ethernet/hpe/ss1/cxi-user.ko
+insmod $DBS_DIR/cxi-driver/drivers/net/ethernet/hpe/ss1/cxi-eth.ko
 insmod $DBS_DIR/kdreg2/kdreg2.ko
 
 # Sleep to wait for Ethernet interface to come up


### PR DESCRIPTION
Adjust to latest cxi-driver paths to allow CI builds to load them properly.