### PR TITLE
Lnx refactor main

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -1199,11 +1199,6 @@ static inline int ofi_is_lnx(const char *str)
 	return !strncasecmp(str, OFI_LNX, strlen(OFI_LNX));
 }
 
-static inline int ofi_is_linked(const char *str)
-{
-	return (strcasestr(str, OFI_LNX)) ? 1 : 0;
-}
-
 int ofi_get_core_info(uint32_t version, const char *node, const char *service,
 		      uint64_t flags, const struct util_prov *util_prov,
 		      const struct fi_info *util_hints,

--- a/man/fi_lnx.7.md
+++ b/man/fi_lnx.7.md
@@ -12,13 +12,11 @@ fi_lnx \- The LINKx (LNX) Provider
 # OVERVIEW
 
 The LNX provider is designed to link two or more providers, allowing
-applications to seamlessly use multiple providers or NICs. This provider uses
-the libfabric peer infrastructure to aid in the use of the underlying providers.
-This version of the provider currently supports linking the libfabric
-shared memory provider for intra-node traffic and another provider for
-inter-node traffic. Future releases of the provider will allow linking any
-number of providers and provide the users with the ability to influence
-the way the providers are utilized for traffic load.
+applications to seamlessly use multiple providers or NICs. This provider
+uses the libfabric peer infrastructure to aid in the use of the underlying
+providers.  This version of the provider is able to link any libfabric
+provider which supports the FI_PEER capability.
+
 
 # SUPPORTED FEATURES
 
@@ -36,7 +34,7 @@ offers the following support:
   a match. If one is found the receive request is completed, otherwise the
   message is placed on the LNX shared unexpected queue (SUQ). Further receive
   requests query the SUQ for matches.
-  The first release of the provider only supports tagged and RMA operations.
+  The first release of the provider only supports tagged operations.
   Other message types will be supported in future releases.
 
 *Modes*
@@ -56,32 +54,35 @@ offers the following support:
   is able to parse the flattened format and operate on the different links.
   This assumes that nodes in the same group are all using the same version of
   the provider with the exact same links. IE: you can't have one node linking
-  SHM+CXI while another linking SHM+RXM.
+  shm+cxi while another linking shm+rxm.
 
 *Message Operations*
 : LNX is designed to intercept message operations such as fi_tsenddata
   and based on specific criteria forward the operation to the appropriate
-  provider. For the first release, LNX will only support linking SHM
-  provider for intra-node traffic and another provider (ex: CXI) for inter
-  node traffic. LNX send operation looks at the destination and based on
-  whether the destination is local or remote it will select the provider to
-  forward the operation to. The receive case has been described earlier.
+  provider. LNX can link any provider which supports the FI_PEER
+  capability. SHM provider is special cased in the sense that it's always
+  used for intra-node communication if it's part of the link. Otherwise
+  all other providers in the link are used in round robin.
 
 *Using the Provider*
 : In order to use the provider the user needs to set FI_LNX_PROV_LINKS
-  environment variable to the linked providers in the following format
-  shm+<prov>. This will allow LNX to report back to the application in the
-  fi_getinfo() call the different links which can be selected. Since there are
-  multiple domains per provider LNX reports a permutation of all the
-  possible links. For example if there are two CXI interfaces on the machine
-  LNX will report back shm+cxi0 and shm+cxi1. The application can then
-  select based on its own criteria the link it wishes to use.
-  The application typically uses the PCI information in the fi_info
-  structure to select the interface to use. A common selection criteria is
-  the interface nearest the core the process is bound to. In order to make
-  this determination, the application requires the PCI information about the
-  interface. For this reason LNX forwards the PCI information for the
-  inter-node provider in the link to the application.
+  environment variable to the linked providers; see syntax under variable
+  description. This allows the definition of multiple links. Each link
+  defines the provider to add to the link along with an explicit list of
+  domains. If only the provider name is specified then all the domains are
+  added to the link.
+  The provider returns the list of links specified to the application in
+  the fi_getinfo() call. Since there could be multiple providers in the
+  link, the first domain of the first non-shm provider fi_info is used as
+  the link info. This means that if a link is defined as follows:
+     - shm+cxi:cxi0,cxi1
+  The cxi0 fi_info information is used as the link fi_info with the
+  modification of the provider and domain names. This is important since the
+  PCI information is part of the fi_info and some applications might use the
+  PCI information to decide which link to use. A common selection criteria
+  is the interface nearest the core the process is bound to. In order to
+  make this determination, the application requires the interface's PCI
+  information
 
 # LIMITATIONS AND FUTURE WORK
 
@@ -98,12 +99,6 @@ offers the following support:
   a future effort to determine a way to use hardware tag matching and other
   hardware offload capability with LNX
 
-*Limited Linking*
-: This release of the provider supports linking SHM provider for intra-node
-  operations and another provider which supports the FI_PEER capability for
-  inter-node operations. It is a future effort to expand to link any
-  multiple sets of providers.
-
 *Memory Registration*
 : As part of the memory registration operation, varying hardware can perform
   hardware specific steps such as memory pinning. Due to the fact that
@@ -116,13 +111,29 @@ offers the following support:
   to avoid expensive operations.
 
 *Operation Types*
-: This release of LNX supports tagged and RMA operations only. Future
+: This release of LNX supports tagged operations only. Future
   releases will expand the support to other operation types.
 
 *Multi-Rail*
-: Future design effort is being planned to support utilizing multiple interfaces
-  for traffic simultaneously. This can be over homogeneous interfaces or over
-  heterogeneous interfaces.
+: LNX implements a multi-rail feature that enables messages to be
+  transmitted across multiple interfaces, driven by the link configuration.
+  It supports configuring multiple provider domains within a single link.
+  For example, the following configuration:
+       FI_LNX_PROV_LINKS="cxi:cxi0,cxi1"
+  Defines a link that includes the cxi0 and cxi1 domains. When an
+  application utilizes this link, messages are distributed in a round-robin
+  fashion across both domains. Similarly, all available peer addresses are
+  used in a round-robin manner, ensuring balanced communication.
+  An exception applies to the shm provider: if included in the link, all
+  intra-node traffic is routed through the shm provider.
+  For the following configuration:
+      FI_LNX_PROV_LINKS="tcp;ofi_rxm+cxi:cxi0"
+  The link consists of all tcp domains associated with the tcp;ofi_rxm
+  provider, along with cxi0. Messages are evenly distributed across all
+  domain endpoints and peer addresses. The provider ensures that local
+  endpoint types match corresponding remote addresses—for instance, if the
+  tcp provider is used, messages are directed to the peer's tcp address.
+
 
 # RUNTIME PARAMETERS
 
@@ -132,9 +143,17 @@ The *LNX* provider checks for the following environment variables:
 : This environment variable is used to specify which providers to link. This
   must be set in order for the LNX provider to return a list of fi_info
   blocks in the fi_getinfo() call. The format which must be used is:
-  \<prov1>+\<prov2>+... As mentioned earlier currently LNX supports linking
-  only two providers the first of which is SHM followed by one other
-  provider for inter-node operations
+       link ::= group ['|' group]*
+       group ::= provider ['+' provider [':' provider_list]]
+       provider_list ::= provider [',' provider]*
+       provider ::= [a-zA-Z0-9_]+
+  Examples:
+     - shm+cxi:cxi0
+     - shm+cxi:cxi0,cxi1
+     - shm+cxi:cxi0|shm+cxi:cxi1
+     - shm+cxi
+  On a system with four cxi domains, the last example is equivalent to:
+     - shm+cxi:cxi0,cxi1,cxi2,cxi3
 
 *FI_LNX_DISABLE_SHM*
 : By default this environment variable is set to 0. However, the user can
@@ -142,13 +161,6 @@ The *LNX* provider checks for the following environment variables:
   useful for debugging and performance analysis. The SHM provider will
   naturally be used for all intra-node operations. Therefore, to test SHM in
   isolation with LNX, the processes can be limited to the same node only.
-
-*FI_LNX_USE_SRQ*
-: Shared Receive Queues are integral part of the peer infrastructure, but
-  they have the limitation of not using hardware offload, such as tag
-  matching. SRQ is needed to support the FI_ADDR_UNSPEC case. If the application
-  is sure this will never be the case, then it can turn off SRQ support by
-  setting this environment variable to 0. It is 1 by default.
 
 # SEE ALSO
 

--- a/prov/cxi/src/cxip_msg_hpc.c
+++ b/prov/cxi/src/cxip_msg_hpc.c
@@ -3468,6 +3468,7 @@ static int cxip_process_srx_ux_matcher(struct cxip_rxc *rxc,
 	vni = ux->put_ev.tgt_long.vni;
 
 	match.addr = cxip_recv_req_src_addr(rxc, ux_init, vni, true);
+	match.msg_size = ux->put_ev.tgt_long.rlength;
 
 	ux_mb.raw = ux->put_ev.tgt_long.match_bits;
 
@@ -3484,6 +3485,10 @@ static int cxip_process_srx_ux_matcher(struct cxip_rxc *rxc,
 	if (ret == -FI_ENOENT) {
 		/* this is used when the owner calls start_msg */
 		rx_entry->peer_context = ux;
+		if (ux_mb.cq_data) {
+			rx_entry->flags |= FI_REMOTE_CQ_DATA;
+			rx_entry->cq_data = ux->put_ev.tgt_long.header_data;
+		}
 		return -FI_ENOMSG;
 	} else if (ret) {
 		return ret;

--- a/prov/lnx/Makefile.include
+++ b/prov/lnx/Makefile.include
@@ -38,6 +38,7 @@ _lnx_files = \
 	prov/lnx/src/lnx_ep.c		\
 	prov/lnx/src/lnx_init.c		\
 	prov/lnx/src/lnx_ops.c		\
+	prov/lnx/src/lnx_mr.c		\
 	prov/lnx/src/lnx_av.c
 
 _lnx_headers = \

--- a/prov/lnx/include/lnx.h
+++ b/prov/lnx/include/lnx.h
@@ -33,31 +33,22 @@
 #ifndef LNX_H
 #define LNX_H
 
-#define LNX_MAX_LOCAL_EPS 16
-#define LNX_IOV_LIMIT 4
+#define LNX_MAX_LOCAL_EPS 	16
+#define LNX_IOV_LIMIT 		4
+#define LNX_MAX_PRIMARY_ID	((1ULL << 56) - 1)
+#define LNX_MAX_SUB_ID 		((1ULL << 8) - 1)
 
 #define lnx_ep_rx_flags(lnx_ep) ((lnx_ep)->le_ep.rx_op_flags)
-
-struct local_prov_ep;
 
 struct lnx_match_attr {
 	fi_addr_t lm_addr;
 	uint64_t lm_tag;
 	uint64_t lm_ignore;
-	struct lnx_peer *lm_peer;
-	struct local_prov_ep *lm_cep;
-};
-
-struct lnx_peer_cq {
-	struct lnx_cq *lpc_shared_cq;
-	struct fid_peer_cq lpc_cq;
-	struct fid_cq *lpc_core_cq;
 };
 
 struct lnx_queue {
 	struct dlist_entry lq_queue;
 	dlist_func_t *lq_match_func;
-	ofi_spin_t lq_qlock;
 };
 
 struct lnx_qpair {
@@ -70,208 +61,141 @@ struct lnx_peer_srq {
 	struct lnx_qpair lps_recv;
 };
 
-struct local_prov_ep {
-	struct dlist_entry entry;
-	bool lpe_local;
-	char lpe_fabric_name[FI_NAME_MAX];
-	struct fid_fabric *lpe_fabric;
-	struct fid_domain *lpe_domain;
-	struct fid_ep *lpe_ep;
-	struct fid_ep **lpe_txc;
-	struct fid_ep **lpe_rxc;
-	struct fid_av *lpe_av;
-	struct fid_ep *lpe_srx_ep;
-	struct lnx_peer_cq lpe_cq;
-	struct fi_info *lpe_fi_info;
-	struct fid_peer_srx lpe_srx;
-	struct ofi_bufpool *lpe_recv_bp;
-	ofi_spin_t lpe_bplock;
-	struct local_prov *lpe_parent;
+struct lnx_core_fabric {
+	struct fi_info *cf_info;
+	struct fid_fabric *cf_fabric;
+};
+
+struct lnx_core_domain {
+	struct fid_domain *cd_domain;
+	struct lnx_core_fabric *cd_fabric;
+	struct fi_info *cd_info;
+	uint64_t cd_num_sends;
+};
+
+struct lnx_core_av {
+	/* on the lnx_av list */
+	struct dlist_entry cav_peer_entry;
+	struct fid_av *cav_av;
+	struct lnx_core_domain *cav_domain;
+	struct ofi_bufpool *cav_map;
+	struct dlist_entry cav_endpoints;
+};
+
+struct lnx_core_ep {
+	struct dlist_entry cep_av_entry;
+	struct fid_peer_srx cep_srx;
+	struct fid_ep *cep_ep;
+	struct fid_ep *cep_srx_ep;
+	struct lnx_core_domain *cep_domain;
+	struct lnx_core_av *cep_cav;
+	struct lnx_ep *cep_parent;
+	uint64_t cep_num_sends;
+	uint64_t cep_num_posted_recvs;
+};
+
+struct lnx_core_cq {
+	struct fid_cq *cc_cq;
+	struct lnx_core_domain *cc_domain;
+};
+
+struct lnx_peer_map {
+	int map_count;
+	ofi_atomic32_t map_rr;
+	fi_addr_t map_addrs[LNX_MAX_LOCAL_EPS];
+};
+
+struct lnx_peer_ep_map {
+	struct lnx_core_ep **pem_eps;
+	int pem_num_eps;
+};
+
+struct lnx_peer {
+	fi_addr_t lp_addr;
+	int lp_ep_count;
+	int lp_av_count;
+	ofi_atomic32_t lp_ep_rr;
+	struct lnx_core_av **lp_avs;
+	struct lnx_peer_ep_map *lp_src_eps;
+};
+
+struct lnx_av {
+	struct util_av lav_av;
+	int lav_max_count;
+	struct lnx_domain *lav_domain;
+	struct lnx_core_av *lav_core_avs;
+};
+
+struct lnx_mr {
+	struct ofi_mr lm_mr;
+	struct fi_mr_attr lm_attr;
+	struct fid_mr *lm_core_mr;
+	struct iovec lm_iov[LNX_IOV_LIMIT];
+};
+
+struct lnx_domain {
+	struct util_domain ld_domain;
+	struct ofi_bufpool *ld_mem_reg_bp;
+	struct lnx_core_domain *ld_core_domains;
+	size_t ld_iov_limit;
+	int ld_num_doms;
+	int ld_ep_idx;
+};
+
+struct lnx_ep {
+	int le_idx;
+	struct util_ep le_ep;
+	struct lnx_core_ep *le_core_eps;
+	struct ofi_bufpool *le_recv_bp;
+	ofi_spin_t le_bplock;
+	struct lnx_domain *le_domain;
+	size_t le_fclass;
+	struct lnx_peer_srq le_srq;
+	struct lnx_av *le_lav;
+};
+
+struct lnx_cq {
+	struct util_cq lcq_util_cq;
+	struct lnx_core_cq *lcq_core_cqs;
+	struct lnx_domain *lcq_lnx_domain;
+};
+
+struct lnx_fabric {
+	struct util_fabric lf_util_fabric;
+	struct lnx_core_fabric *lf_core_fabrics;
+	bool lf_fab_setup_complete;
+	int lf_num_fabs;
+};
+
+struct lnx_ep_addr {
+	char lea_prov[FI_NAME_MAX];
+	size_t lea_addr_size;
+	char lea_addr[];
+};
+
+struct lnx_address {
+	char la_hostname[FI_NAME_MAX];
+	int la_ep_count;
+	struct lnx_ep_addr la_addrs[];
 };
 
 struct lnx_rx_entry {
-	/* the entry which will be passed to the core provider */
 	struct fi_peer_rx_entry rx_entry;
-	/* iovec to use to point to receive buffers */
 	struct iovec rx_iov[LNX_IOV_LIMIT];
-	/* desc array to be used to point to the descs passed by the user */
 	void *rx_desc[LNX_IOV_LIMIT];
-	/* peer we expect messages from.
-	 * This is available if the receive request provided a source address.
-	 * Otherwise it will be NULL
-	 */
-	struct lnx_peer *rx_peer;
-	/* local prov endpoint receiving the message if this entry is
-	 * added to the SUQ
-	 */
-	struct local_prov_ep *rx_cep;
-	/* match information which will be given to us by the core provider */
-	struct fi_peer_match_attr rx_match_info;
-	/* ignore bit passed in by the user */
+	struct lnx_ep *rx_lep;
+	struct lnx_core_ep *rx_cep;
 	uint64_t rx_ignore;
-	/* which pool this rx_entry came from. It's either from the global
-	 * pool or some core provider pool
-	 */
 	bool rx_global;
 };
 
 OFI_DECLARE_FREESTACK(struct lnx_rx_entry, lnx_recv_fs);
 
-struct local_prov {
-	struct dlist_entry lpv_entry;
-	char lpv_prov_name[FI_NAME_MAX];
-	int lpv_ep_count;
-	struct dlist_entry lpv_prov_eps;
-};
-
-struct lnx_address_prov {
-	char lap_prov[FI_NAME_MAX];
-	/* an array of addresses of size count. */
-	/* entry 0 is shm if available */
-	/* array can't be larger than LNX_MAX_LOCAL_EPS */
-	int lap_addr_count;
-	/* size as specified by the provider */
-	int lap_addr_size;
-	/* payload */
-	char lap_addrs[];
-};
-
-struct lnx_addresses {
-	/* used to determine if the address is node local or node remote */
-	char la_hostname[FI_NAME_MAX];
-	/* number of providers <= LNX_MAX_LOCAL_EPS */
-	int la_prov_count;
-	struct lnx_address_prov la_addr_prov[];
-};
-
-struct lnx_local2peer_map {
-	struct dlist_entry entry;
-	struct local_prov_ep *local_ep;
-	int addr_count;
-	fi_addr_t peer_addrs[LNX_MAX_LOCAL_EPS];
-};
-
-struct lnx_peer_prov {
-	struct dlist_entry entry;
-
-	/* provider name */
-	char lpp_prov_name[FI_NAME_MAX];
-
-	uint64_t lpp_flags;
-
-	/* pointer to the local endpoint information to be used for
-	 * communication with this peer.
-	 *
-	 * If the peer is on-node, then lp_endpoints[0] = shm
-	 *
-	 * if peer is off-node, then there could be up to LNX_MAX_LOCAL_EPS
-	 * local endpoints we can use to reach that peer.
-	 */
-	struct local_prov *lpp_prov;
-
-	/* each peer can be reached from any of the local provider endpoints
-	 * on any of the addresses which are given to us. It's an N:N
-	 * relationship
-	 */
-	struct dlist_entry lpp_map;
-};
-
-struct lnx_peer {
-	/* true if peer can be reached over shared memory, false otherwise */
-	bool lp_local;
-	fi_addr_t lp_fi_addr;
-
-	/* Each provider that we can reach the peer on will have an entry
-	 * below. Each entry will contain all the local provider endpoints we
-	 * can reach the peer through, as well as all the peer addresses on that
-	 * provider.
-	 *
-	 * We can potentially multi-rail between the interfaces on the same
-	 * provider, both local and remote.
-	 *
-	 * Or we can multi-rail across different providers. Although this
-	 * might be more complicated due to the differences in provider
-	 * capabilities.
-	 */
-	struct lnx_peer_prov *lp_shm_prov;
-	struct dlist_entry lp_provs;
-};
-
-struct lnx_peer_table {
-	struct util_av lpt_av;
-	int lpt_max_count;
-	struct lnx_domain *lpt_domain;
-	/* an array of peer entries of type struct lnx_peer */
-	struct ofi_bufpool *lpt_entries;
-};
-
-struct lnx_ctx {
-	struct dlist_entry ctx_head;
-	int ctx_idx;
-	struct lnx_ep *ctx_parent;
-	struct fid_ep ctx_ep;
-};
-
-struct lnx_ep {
-	struct util_ep le_ep;
-	struct dlist_entry le_tx_ctx;
-	struct dlist_entry le_rx_ctx;
-	struct lnx_domain *le_domain;
-	size_t le_fclass;
-	struct lnx_peer_table *le_peer_tbl;
-	struct lnx_peer_srq le_srq;
-};
-
-struct lnx_srx_context {
-	struct lnx_ep *srx_lep;
-	struct local_prov_ep *srx_cep;
-};
-
-struct lnx_mem_desc_prov {
-	struct local_prov *prov;
-	struct fid_mr *core_mr;
-};
-
-struct lnx_mem_desc {
-	struct lnx_mem_desc_prov desc[LNX_MAX_LOCAL_EPS];
-	int desc_count;
-};
-
-struct lnx_mr {
-	struct ofi_mr mr;
-	struct lnx_mem_desc desc;
-};
-
-struct lnx_domain {
-	struct util_domain ld_domain;
-	struct lnx_fabric *ld_fabric;
-	bool ld_srx_supported;
-	struct ofi_mr_cache ld_mr_cache;
-};
-
-struct lnx_cq {
-	struct util_cq util_cq;
-	struct lnx_domain *lnx_domain;
-};
-
-struct lnx_fabric {
-	struct util_fabric	util_fabric;
-	/* providers linked by this fabric */
-	struct dlist_entry local_prov_table;
-	/* memory registration buffer pool */
-	struct ofi_bufpool *mem_reg_bp;
-	/* shared memory provider used in this link */
-	struct local_prov *shm_prov;
-	/* peers associated with this link */
-	struct lnx_peer_table *lnx_peer_tbl;
-};
 
 extern struct util_prov lnx_util_prov;
 extern struct fi_provider lnx_prov;
 extern struct ofi_bufpool *global_recv_bp;
 extern ofi_spin_t global_bplock;
-
-struct fi_info *lnx_get_link_by_dom(char *domain_name);
 
 int lnx_getinfo(uint32_t version, const char *node, const char *service,
 				uint64_t flags, const struct fi_info *hints,
@@ -279,8 +203,7 @@ int lnx_getinfo(uint32_t version, const char *node, const char *service,
 
 int lnx_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 		void *context);
-int lnx_setup_core_fabrics(char *name, struct lnx_fabric *lnx_fab,
-			   void *context);
+int lnx_setup_fabrics(char *name, struct lnx_fabric *lnx_fab, void *context);
 
 void lnx_fini(void);
 
@@ -293,16 +216,13 @@ int lnx_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 		struct fid_av **av, void *context);
 
 struct lnx_peer *
-lnx_av_lookup_addr(struct lnx_peer_table *peer_tbl, fi_addr_t addr);
+lnx_av_lookup_addr(struct lnx_av *av, fi_addr_t addr);
 
 int lnx_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		struct fid_cq **cq, void *context);
 
 int lnx_endpoint(struct fid_domain *domain, struct fi_info *info,
 		 struct fid_ep **ep, void *context);
-
-int lnx_scalable_ep(struct fid_domain *domain, struct fi_info *info,
-		    struct fid_ep **ep, void *context);
 
 int lnx_cq2ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags);
 
@@ -316,156 +236,85 @@ void lnx_free_entry(struct fi_peer_rx_entry *entry);
 void lnx_foreach_unspec_addr(struct fid_peer_srx *srx,
 	fi_addr_t (*get_addr)(struct fi_peer_rx_entry *));
 
-static inline
-void lnx_get_core_desc(struct lnx_mem_desc *desc, void **mem_desc)
-{
-	if (desc && desc->desc[0].core_mr) {
-		if (mem_desc)
-			*mem_desc = desc->desc[0].core_mr->mem_desc;
-		return;
-	}
+int lnx_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
+		   uint64_t flags, struct fid_mr **mr_fid);
+int lnx_mr_regattr_core(struct lnx_core_domain *cd, void *desc,
+			void **core_desc);
 
-	*mem_desc = NULL;
+static inline fi_addr_t
+lnx_encode_fi_addr(uint64_t primary_id, uint8_t sub_id)
+{
+	return (primary_id << 8) | sub_id;
 }
 
-static inline
-int lnx_create_mr(const struct iovec *iov, fi_addr_t addr,
-		  struct lnx_domain *lnx_dom, struct ofi_mr_entry **mre)
+static inline fi_addr_t lnx_decode_primary_id(uint64_t fi_addr)
 {
-	struct ofi_mr *mr;
-	struct fi_mr_attr attr = {};
-	struct fi_mr_attr cur_abi_attr;
-	struct ofi_mr_info info = {};
-	uint64_t flags = 0;
-	int rc;
-
-	attr.iov_count = 1;
-	attr.mr_iov = iov;
-	*mre = ofi_mr_cache_find(&lnx_dom->ld_mr_cache, &attr, 0);
-	if (*mre) {
-		mr = (struct ofi_mr *)(*mre)->data;
-		goto out;
-	}
-
-	attr.iface = ofi_get_hmem_iface(iov->iov_base,
-			&attr.device.reserved, &flags);
-	info.iov = *iov;
-	info.iface = attr.iface;
-	rc = ofi_hmem_dev_register(attr.iface, iov->iov_base, iov->iov_len,
-				   (uint64_t *) &attr.hmem_data);
-	if (rc)
-		return rc;
-
-	rc = ofi_mr_cache_search(&lnx_dom->ld_mr_cache, &info, mre);
-	if (rc) {
-		ofi_hmem_dev_unregister(attr.iface, (uint64_t)attr.hmem_data);
-		return rc;
-	}
-
-	mr = (struct ofi_mr *)(*mre)->data;
-	ofi_mr_update_attr(lnx_dom->ld_domain.fabric->fabric_fid.api_version,
-			   lnx_dom->ld_domain.info_domain_caps, &attr, &cur_abi_attr, 0);
-
-	mr->mr_fid.fid.fclass = FI_CLASS_MR;
-	mr->mr_fid.fid.context = attr.context;
-	mr->domain = &lnx_dom->ld_domain;
-	mr->flags = flags;
-	mr->iface = cur_abi_attr.iface;
-	mr->device = cur_abi_attr.device.reserved;
-	mr->hmem_data = cur_abi_attr.hmem_data;
-	mr->mr_fid.mem_desc = (void*) mr;
-
-out:
-	return FI_SUCCESS;
+	return (fi_addr == FI_ADDR_UNSPEC) ? fi_addr : fi_addr >> 8;
 }
 
-static inline
-int lnx_select_send_pathway(struct lnx_peer *lp, struct lnx_domain *lnx_dom,
-			    struct lnx_mem_desc *desc, struct local_prov_ep **cep,
-			    fi_addr_t *addr, const struct iovec *iov, size_t iov_count,
-			    struct ofi_mr_entry **mre, void **mem_desc, uint64_t *rkey)
+static inline uint8_t lnx_decode_sub_id(uint64_t fi_addr)
 {
-	int idx = 0;
-	int rc;
-	struct lnx_peer_prov *prov;
-	struct lnx_local2peer_map *lpm;
-	struct ofi_mr *mr = NULL;
-
-	if (lp->lp_local) {
-		prov = lp->lp_shm_prov;
-	} else {
-		prov = dlist_first_entry_or_null(
-			&lp->lp_provs, struct lnx_peer_prov, entry);
-		idx = 1;
-	}
-
-	/* TODO when we support multi-rail we can have multiple maps */
-	lpm = dlist_first_entry_or_null(&prov->lpp_map,
-					struct lnx_local2peer_map, entry);
-	*addr = lpm->peer_addrs[0];
-
-	/* TODO this will need to be expanded to handle Multi-Rail. For now
-	 * the assumption is that local peers can be reached on shm and remote
-	 * peers have only one interface, hence indexing on 0 and 1
-	 *
-	 * If we did memory registration, then we've already figured out the
-	 * pathway
-	 */
-	if (desc && desc->desc[idx].core_mr) {
-		*cep = dlist_first_entry_or_null(
-				&desc->desc[idx].prov->lpv_prov_eps,
-				struct local_prov_ep, entry);
-		if (mem_desc)
-			*mem_desc = fi_mr_desc(desc->desc[idx].core_mr);
-		if (rkey)
-			*rkey = fi_mr_key(desc->desc[idx].core_mr);
-		return 0;
-	}
-
-	*cep = lpm->local_ep;
-	if (mem_desc)
-		*mem_desc = NULL;
-
-	if (!lp->lp_local || !mem_desc || (mem_desc && *mem_desc) ||
-	    !iov || (iov && iov->iov_base == NULL))
-		return 0;
-
-	/* Look up the address in the cache:
-	 *  - if it's found then use the cached fid_mr
-	 *     - This will include the iface, which is really all we need
-	 *  - if it's not then lookup the iface, create the fid_mr and
-	 *    cache it.
-	 */
-	rc = lnx_create_mr(iov, *addr, lnx_dom, mre);
-	if (!rc && mre) {
-		mr = (struct ofi_mr *)(*mre)->data;
-		*mem_desc = mr->mr_fid.mem_desc;
-	}
-
-	return rc;
+	return (fi_addr == FI_ADDR_UNSPEC) ? fi_addr : fi_addr & LNX_MAX_SUB_ID;
 }
 
-static inline
-int lnx_select_recv_pathway(struct lnx_peer *lp, struct lnx_domain *lnx_dom,
-			    struct lnx_mem_desc *desc, struct local_prov_ep **cep,
-			    fi_addr_t *addr, const struct iovec *iov, size_t iov_count,
-			    struct ofi_mr_entry **mre, void **mem_desc)
+static inline fi_addr_t
+lnx_get_core_addr(struct lnx_core_ep *cep, fi_addr_t addr)
 {
-	/* if the src address is FI_ADDR_UNSPEC, then we'll need to trigger
-	 * all core providers to listen for a receive, since we don't know
-	 * which one will endup getting the message.
-	 *
-	 * For each core provider we're tracking, trigger the recv operation
-	 * on it.
-	 *
-	 * if the src address is specified then we just need to select and
-	 * exact core endpoint to trigger the recv on.
-	 */
+	struct lnx_peer_map *map_addr;
+	uint8_t idx = lnx_decode_sub_id(addr);
+	fi_addr_t primary = lnx_decode_primary_id(addr);
+
+	if (addr == FI_ADDR_UNSPEC)
+		return addr;
+
+	map_addr = ofi_bufpool_get_ibuf(cep->cep_cav->cav_map, primary);
+	return map_addr->map_addrs[idx];
+}
+
+/* TODO:
+ * Make this function a callback. Intent is to be able to have different
+ * ways to select the endpoints. This is useful to try different methods
+ * of selecting the endpoint <-> peer addr pairing.
+ */
+static inline int
+lnx_select_send_endpoints(struct lnx_ep *lep, fi_addr_t lnx_addr,
+		struct lnx_core_ep **cep_out, fi_addr_t *core_addr)
+{
+	int idx, rr;
+	struct lnx_peer *lp;
+	struct lnx_core_ep *cep;
+	struct lnx_peer_map *map_addr;
+	struct lnx_peer_ep_map *ep_map;
+
+	lp = lnx_av_lookup_addr(lep->le_lav, lnx_addr);
 	if (!lp)
 		return -FI_ENOSYS;
 
-	return lnx_select_send_pathway(lp, lnx_dom, desc, cep, addr, iov,
-				       iov_count, mre, mem_desc, NULL);
+	/* round robin over the endpoints which can reach this peer */
+	rr = ofi_atomic_get32(&lp->lp_ep_rr);
+	ofi_atomic_inc32(&lp->lp_ep_rr);
+	ep_map = &lp->lp_src_eps[lep->le_idx];
+	idx = rr % ep_map->pem_num_eps;
+	cep = ep_map->pem_eps[idx];
+
+	map_addr = ofi_bufpool_get_ibuf(cep->cep_cav->cav_map, lp->lp_addr);
+
+	/* round robin over available peer addresses */
+	rr = ofi_atomic_get32(&map_addr->map_rr);
+	ofi_atomic_inc32(&map_addr->map_rr);
+	idx = rr % (map_addr->map_count);
+
+	*core_addr = map_addr->map_addrs[idx];
+
+	*cep_out = cep;
+
+	/* keep statistics. Sends per domain that could have multiple
+	 * endpoints as well as sends on this specific endpoint
+	 */
+	cep->cep_domain->cd_num_sends++;
+	cep->cep_num_sends++;
+
+	return FI_SUCCESS;
 }
 
 #endif /* LNX_H */

--- a/prov/lnx/src/lnx_domain.c
+++ b/prov/lnx/src/lnx_domain.c
@@ -71,12 +71,11 @@ static int lnx_domain_close(struct fid *fid)
 
 	domain = container_of(fid, struct lnx_domain, ld_domain.domain_fid.fid);
 
+
 	/* close all the open core domains */
 	for (i = 0; i < domain->ld_num_doms; i++) {
 		cd = &domain->ld_core_domains[i];
 
-		if (dump_stats)
-			lnx_dump_core_domain_stats(cd);
 		rc = fi_close(&cd->cd_domain->fid);
 		if (rc)
 			frc = rc;

--- a/prov/lnx/src/lnx_domain.c
+++ b/prov/lnx/src/lnx_domain.c
@@ -54,7 +54,7 @@ static struct fi_ops_domain lnx_domain_ops = {
 	.av_open = lnx_av_open,
 	.cq_open = lnx_cq_open,
 	.endpoint = lnx_endpoint,
-	.scalable_ep = lnx_scalable_ep,
+	.scalable_ep = fi_no_scalable_ep,
 	.cntr_open = fi_no_cntr_open,
 	.poll_open = fi_no_poll_open,
 	.stx_ctx = fi_no_stx_context,
@@ -63,317 +63,35 @@ static struct fi_ops_domain lnx_domain_ops = {
 	.query_collective = fi_no_query_collective,
 };
 
-static int lnx_cleanup_domains(struct local_prov *prov)
+static int lnx_domain_close(struct fid *fid)
 {
-	int rc, frc = 0;
-	struct local_prov_ep *ep;
-
-	dlist_foreach_container(&prov->lpv_prov_eps,
-				struct local_prov_ep, ep, entry) {
-		if (!ep->lpe_domain)
-			continue;
-
-		rc = fi_close(&ep->lpe_srx_ep->fid);
-		if (rc)
-			frc = rc;
-
-		rc = fi_close(&ep->lpe_domain->fid);
-		if (rc)
-			frc = rc;
-	}
-
-	return frc;
-}
-
-static int lnx_domain_close(fid_t fid)
-{
-	int rc = 0;
-	struct local_prov *entry;
+	int i, rc, frc = 0;
 	struct lnx_domain *domain;
+	struct lnx_core_domain *cd;
 
 	domain = container_of(fid, struct lnx_domain, ld_domain.domain_fid.fid);
 
 	/* close all the open core domains */
-	dlist_foreach_container(&domain->ld_fabric->local_prov_table,
-				struct local_prov,
-				entry, lpv_entry) {
-		rc = lnx_cleanup_domains(entry);
+	for (i = 0; i < domain->ld_num_doms; i++) {
+		cd = &domain->ld_core_domains[i];
+
+		if (dump_stats)
+			lnx_dump_core_domain_stats(cd);
+		rc = fi_close(&cd->cd_domain->fid);
 		if (rc)
-			FI_WARN(&lnx_prov, FI_LOG_CORE, "Failed to close domain for %s\n",
-					entry->lpv_prov_name);
+			frc = rc;
 	}
 
-	ofi_mr_cache_cleanup(&domain->ld_mr_cache);
+	ofi_bufpool_destroy(domain->ld_mem_reg_bp);
 
 	rc = ofi_domain_close(&domain->ld_domain);
+	if (rc)
+		frc = rc;
 
+	free(domain->ld_core_domains);
 	free(domain);
 
-	return rc;
-}
-
-static int
-lnx_mr_regattrs_all(struct local_prov *prov, const struct fi_mr_attr *attr,
-		    uint64_t flags, struct lnx_mem_desc_prov *desc)
-{
-	int rc = 0;
-	struct local_prov_ep *ep;
-
-	desc->prov = prov;
-
-	/* TODO: This is another issue here because MR registration can happen
-	 * quiet often
-	 */
-	dlist_foreach_container(&prov->lpv_prov_eps,
-				struct local_prov_ep, ep, entry) {
-		rc = fi_mr_regattr(ep->lpe_domain, attr,
-				flags, &desc->core_mr);
-
-		/* TODO: SHM provider returns FI_ENOKEY if requested_key is the
-		 * same as the previous call. Application, like OMPI, might not
-		 * specify the requested key in fi_mr_attr, so for now ignore that
-		 * error.
-		 * We need a better way of handling this.
-		 * if (rc == -FI_ENOKEY)
-		 *		rc = 0;
-		 * I made a change in SHM to support FI_MR_PROV_KEY if set by the
-		 * application. This tells ofi to generate its own requested_key
-		 * for each fi_mr_regattr call
-		*/
-		if (rc) {
-			FI_WARN(&lnx_prov, FI_LOG_CORE, "%s mr_regattr() failed: %d\n",
-				ep->lpe_fabric_name, rc);
-			return rc;
-		}
-	}
-
-	return rc;
-}
-
-static int
-lnx_mr_close_all(struct lnx_mem_desc *mem_desc)
-{
-	int i, rc, frc = 0;
-	struct fid_mr *mr;
-
-	for (i = 0; i < mem_desc->desc_count; i++) {
-		mr = mem_desc->desc[i].core_mr;
-		if (!mr)
-			continue;
-		rc = fi_close(&mr->fid);
-		if (rc) {
-			FI_WARN(&lnx_prov, FI_LOG_CORE, "%s mr_close() failed: %d\n",
-					mem_desc->desc[i].prov->lpv_prov_name, rc);
-			frc = rc;
-		}
-	}
-
 	return frc;
-}
-
-int lnx_mr_close(struct fid *fid)
-{
-	struct lnx_mr *lnx_mr;
-	struct ofi_mr *mr;
-	int rc, frc = 0;
-
-	mr = container_of(fid, struct ofi_mr, mr_fid.fid);
-	lnx_mr = container_of(mr, struct lnx_mr, mr);
-
-	rc = lnx_mr_close_all(mr->mr_fid.mem_desc);
-	if (rc) {
-		FI_WARN(&lnx_prov, FI_LOG_CORE, "Failed to complete Memory Deregistration\n");
-		frc = rc;
-	}
-
-	ofi_atomic_dec32(&mr->domain->ref);
-
-	ofi_buf_free(lnx_mr);
-
-	return frc;
-}
-
-static int lnx_mr_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
-{
-	int i, rc, frc = 0;
-	struct local_prov_ep *ep;
-	struct fid_mr *mr, *cmr;
-	struct lnx_mem_desc *mem_desc;
-	struct lnx_mem_desc_prov *desc;
-
-	mr = container_of(fid, struct fid_mr, fid);
-
-	mem_desc = mr->mem_desc;
-
-	/* TODO: This is another issue here because MR registration can happen
-	 * quiet often
-	 */
-	for (i = 0; i < mem_desc->desc_count; i++) {
-		desc = &mem_desc->desc[i];
-		cmr = desc->core_mr;
-		if (!cmr)
-			continue;
-		dlist_foreach_container(&desc->prov->lpv_prov_eps,
-					struct local_prov_ep, ep, entry) {
-			rc = fi_mr_bind(cmr, &ep->lpe_ep->fid, flags);
-			if (rc) {
-				FI_WARN(&lnx_prov, FI_LOG_CORE,
-					"%s lnx_mr_bind() failed: %d\n",
-					mem_desc->desc[i].prov->lpv_prov_name, rc);
-				frc = rc;
-			}
-		}
-	}
-
-	return frc;
-}
-
-static int lnx_mr_control(struct fid *fid, int command, void *arg)
-{
-	int i, rc, frc = 0;
-	struct fid_mr *mr, *cmr;
-	struct lnx_mem_desc *mem_desc;
-	struct lnx_mem_desc_prov *desc;
-
-	if (command != FI_ENABLE)
-		return -FI_ENOSYS;
-
-	mr = container_of(fid, struct fid_mr, fid);
-
-	mem_desc = mr->mem_desc;
-
-	/* TODO: This is another issue here because MR registration can happen
-	 * quiet often
-	 */
-	for (i = 0; i < mem_desc->desc_count; i++) {
-		desc = &mem_desc->desc[i];
-		cmr = desc->core_mr;
-		if (!cmr)
-			continue;
-		rc = fi_mr_enable(cmr);
-		if (rc) {
-			FI_WARN(&lnx_prov, FI_LOG_CORE, "%s lnx_mr_control() failed: %d\n",
-				mem_desc->desc[i].prov->lpv_prov_name, rc);
-			frc = rc;
-		}
-	}
-
-	return frc;
-}
-
-static struct fi_ops lnx_mr_fi_ops = {
-	.size = sizeof(struct fi_ops),
-	.close = lnx_mr_close,
-	.bind = lnx_mr_bind,
-	.control = lnx_mr_control,
-	.ops_open = fi_no_ops_open
-};
-
-static int
-lnx_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
-	       uint64_t flags, struct fid_mr **mr_fid)
-{
-	/*
-	 * If the address is specified then use it to find out which
-	 * domain to register the memory against. LNX can be managing
-	 * multiple underlying core provider endpoints, I need to register the
-	 * memory against the correct one.
-	 *
-	 * Once the domain is determined, I need to set the mr->mem_desc to
-	 * point to a structure which contains my local endpoint I'll end up
-	 * using (which is the same one that I registered the memory against)
-	 * and the associate fid_mr which the core provider set for me.
-	 *
-	 * I return that to the application.
-	 *
-	 * When the application calls back into the data operations API it'll
-	 * pass the mr. I can then pull out a pointer to my local endpoint
-	 * which I'll use in the data operation and pass it the correct mr.
-	 *
-	 * If the address is not provided, then I'll register the memory
-	 * buffer against all my core domains, store those and return them to
-	 * the user
-	 */
-
-	struct lnx_domain *domain;
-	struct lnx_fabric *fabric;
-	struct lnx_mr *lnx_mr = NULL;;
-	struct ofi_mr *mr;
-	struct lnx_mem_desc *mem_desc;
-	struct local_prov *entry;
-	int rc = 0, i = 1;
-	bool shm = false;
-
-	if (fid->fclass != FI_CLASS_DOMAIN || !attr || attr->iov_count <= 0)
-		return -FI_EINVAL;
-
-	domain = container_of(fid, struct lnx_domain, ld_domain.domain_fid.fid);
-	fabric = domain->ld_fabric;
-
-	lnx_mr = ofi_buf_alloc(fabric->mem_reg_bp);
-	if (!lnx_mr) {
-		rc = -FI_ENOMEM;
-		goto fail;
-	}
-
-	mr = &lnx_mr->mr;
-	mem_desc = &lnx_mr->desc;
-
-	mr->mr_fid.fid.fclass = FI_CLASS_MR;
-	mr->mr_fid.fid.context = attr->context;
-	mr->mr_fid.fid.ops = &lnx_mr_fi_ops;
-	mr->mr_fid.mem_desc = mem_desc;
-	mr->domain = &domain->ld_domain;
-	mr->flags = flags;
-
-	/* TODO: What's gonna happen if you try to register the same piece
-	 * of memory via multiple providers?
-	 * TODO 2: We need a better way to handle memory registration.
-	 * This is simply not very good. We need to have a peer interface
-	 * to memory registration
-	 */
-	/* register against all domains */
-	dlist_foreach_container(&fabric->local_prov_table,
-				struct local_prov,
-				entry, lpv_entry) {
-		if (!strcmp(entry->lpv_prov_name, "shm"))
-			shm = true;
-		else
-			shm = false;
-		if (i >= LNX_MAX_LOCAL_EPS) {
-			FI_WARN(&lnx_prov, FI_LOG_CORE,
-				"Exceeded number of allowed memory registrations %s\n",
-				entry->lpv_prov_name);
-			rc = -FI_ENOSPC;
-			goto fail;
-		}
-		rc = lnx_mr_regattrs_all(entry, attr, flags,
-					 (shm) ? &mem_desc->desc[0] :
-					 &mem_desc->desc[i]);
-		if (rc) {
-			FI_WARN(&lnx_prov, FI_LOG_CORE,
-				"Failed to complete Memory Registration %s\n",
-				entry->lpv_prov_name);
-			goto fail;
-		}
-		if (!shm)
-			i++;
-	}
-
-	mem_desc->desc_count = i;
-	if (shm)
-		mr->mr_fid.key = mem_desc->desc[0].core_mr->key;
-	else
-		mr->mr_fid.key = mem_desc->desc[1].core_mr->key;
-	*mr_fid = &mr->mr_fid;
-	ofi_atomic_inc32(&domain->ld_domain.ref);
-
-	return 0;
-
-fail:
-	if (lnx_mr)
-		ofi_buf_free(lnx_mr);
-	return rc;
 }
 
 static struct fi_ops lnx_domain_fi_ops = {
@@ -391,197 +109,144 @@ static struct fi_ops_mr lnx_mr_ops = {
 	.regattr = lnx_mr_regattr,
 };
 
-static int lnx_setup_core_domain(struct local_prov_ep *ep, struct fi_info *info)
+static int lnx_open_core_domains(struct lnx_fabric *lnx_fab,
+				void *context, struct lnx_domain *lnx_domain)
 {
-	struct fi_info *fi, *itr;
+	int rc, i, num_shm_dom = 0, inter_dom_start;
+	char *prov_name;
+	bool local;
+	struct fi_info *itr;
+	struct lnx_core_fabric *cf;
+	struct lnx_core_domain *cd;
 
-	fi = lnx_get_link_by_dom(info->domain_attr->name);
-	if (!fi)
-		return -FI_ENODATA;
-
-	for (itr = fi; itr; itr = itr->next) {
-		if (!strcmp(itr->fabric_attr->name, ep->lpe_fabric_name)) {
-			ep->lpe_fi_info = fi_dupinfo(itr);
-			return FI_SUCCESS;
+	for (i = 0; i < lnx_fab->lf_num_fabs; i++) {
+		cf = &lnx_fab->lf_core_fabrics[i];
+		local = false;
+		prov_name = cf->cf_info->fabric_attr->name;
+		if (!strcmp(prov_name, "shm"))
+			local = true;
+		for (itr = cf->cf_info; itr; itr = itr->next) {
+			if (local)
+				num_shm_dom++;
+			lnx_domain->ld_num_doms++;
 		}
 	}
 
-	ep->lpe_fi_info = NULL;
+	if (lnx_domain->ld_num_doms >= LNX_MAX_LOCAL_EPS) {
+		FI_WARN(&lnx_prov, FI_LOG_FABRIC,
+			"Too many domains to link. Maximum allowed: %d\n",
+			LNX_MAX_LOCAL_EPS);
+		return -FI_E2BIG;
+	}
 
-	return -FI_ENOENT;
-}
+	inter_dom_start = num_shm_dom;
 
-static struct fi_ops_srx_owner lnx_srx_ops = {
-	.size = sizeof(struct fi_ops_srx_owner),
-	.get_msg = lnx_get_msg,
-	.get_tag = lnx_get_tag,
-	.queue_msg = lnx_queue_msg,
-	.queue_tag = lnx_queue_tag,
-	.free_entry = lnx_free_entry,
-	.foreach_unspec_addr = lnx_foreach_unspec_addr,
-};
+	lnx_domain->ld_core_domains = calloc(sizeof(*lnx_domain->ld_core_domains),
+					     lnx_domain->ld_num_doms);
+	if (!lnx_domain->ld_core_domains)
+		return -FI_ENOMEM;
 
-static int lnx_open_core_domains(struct local_prov *prov,
-				void *context, struct lnx_domain *lnx_domain,
-				struct fi_info *info)
-{
-	int rc;
-	struct local_prov_ep *ep;
-	struct fi_rx_attr attr = {0};
-	struct fi_peer_srx_context peer_srx;
-	struct dlist_entry *tmp;
-	int srq_support = 1;
+	for (i = 0; i < lnx_fab->lf_num_fabs; i++) {
+		cf = &lnx_fab->lf_core_fabrics[i];
 
-	fi_param_get_bool(&lnx_prov, "use_srq", &srq_support);
-
-	attr.op_flags = FI_PEER;
-	peer_srx.size = sizeof(peer_srx);
-
-	if (srq_support)
-		lnx_domain->ld_srx_supported = true;
-	else
-		lnx_domain->ld_srx_supported = false;
-
-	dlist_foreach_container_safe(&prov->lpv_prov_eps,
-		struct local_prov_ep, ep, entry, tmp) {
-		/* the fi_info we setup when we created the fabric might not
-		 * necessarily be the correct one. It'll have the same fabric
-		 * information, since the fabric information is common among all
-		 * the domains the provider manages. However at this point we need
-		 * to get the fi_info that the application is requesting */
-		rc = lnx_setup_core_domain(ep, info);
-		if (rc)
-			return rc;
-
-		if (srq_support) {
-			/* special case for CXI provider. We need to turn off tag
-			 * matching HW offload if we're going to support shared
-			 * receive queues.
-			 */
-			if (strstr(ep->lpe_fabric_name, "cxi"))
-				setenv("FI_CXI_RX_MATCH_MODE", "software", 1);
-		}
-
-		rc = fi_domain(ep->lpe_fabric, ep->lpe_fi_info,
-			       &ep->lpe_domain, context);
-
-		if (!rc && srq_support) {
-			ep->lpe_srx.owner_ops = &lnx_srx_ops;
-			peer_srx.srx = &ep->lpe_srx;
-			rc = fi_srx_context(ep->lpe_domain, &attr,
-					    &ep->lpe_srx_ep, &peer_srx);
-		}
-
-		/* if one of the constituent endpoints doesn't support shared
-		 * receive context, then fail, as we can't continue with this
-		 * inconsistency
+		local = false;
+		prov_name = cf->cf_info->fabric_attr->name;
+		/* special case for CXI provider. We need to turn off tag
+		 * matching HW offload if we're going to support shared
+		 * receive queues.
 		 */
-		if (rc) {
-			FI_WARN(&lnx_prov, FI_LOG_CORE, "%s does not support shared"
-				" receive queues. Failing\n", ep->lpe_fabric_name);
-			return rc;
+		if (strstr(prov_name, "cxi"))
+			setenv("FI_CXI_RX_MATCH_MODE", "software", 1);
+		else if (!strcmp(prov_name, "shm"))
+			local = true;
+
+		for (itr = cf->cf_info; itr; itr = itr->next) {
+			/* keep the shm domain at the head of the list.
+			 * This will cause all the other shm constructs to
+			 * be the head of their respective lists, ex: av.
+			 * The purpose is to optimize the shm path for
+			 * local peers.
+			 */
+			if (local) {
+				num_shm_dom--;
+				cd = &lnx_domain->ld_core_domains[num_shm_dom];
+			} else {
+				cd = &lnx_domain->ld_core_domains[inter_dom_start];
+				inter_dom_start++;
+			}
+
+			cd->cd_info = itr;
+
+			rc = fi_domain(cf->cf_fabric, cd->cd_info,
+				       &cd->cd_domain, context);
+			if (rc) {
+				free(cd);
+				return rc;
+			}
+			cd->cd_fabric = cf;
 		}
 	}
 
 	return 0;
 }
 
-static int lnx_addr_add_region_noop(struct ofi_mr_cache *cache,
-			     struct ofi_mr_entry *entry)
-{
-	return FI_SUCCESS;
-}
-
-static void lnx_addr_del_region(struct ofi_mr_cache *cache,
-			 struct ofi_mr_entry *entry)
-{
-	struct ofi_mr *mr = (struct ofi_mr *)entry->data;
-
-	ofi_hmem_dev_unregister(mr->iface, (uint64_t) mr->hmem_data);
-}
-
-/*
- * provider: shm+cxi:lnx
- *     fabric: ofi_lnx_fabric
- *     domain: shm+cxi3:ofi_lnx_domain
- *     version: 120.0
- *     type: FI_EP_RDM
- *     protocol: FI_PROTO_LNX
- *
- * Parse out the provider name. It should be shm+<prov>
- *
- * Create a fabric for shm and one for the other provider.
- *
- * When fi_domain() is called, we get the fi_info for the
- * second provider, which we should've returned as part of the
- * fi_getinfo() call.
- */
 int lnx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		struct fid_domain **domain, void *context)
 {
 	int rc = 0;
-	struct local_prov *entry;
 	struct lnx_domain *lnx_domain;
-	struct util_domain *lnx_domain_info;
+	struct util_domain *dom;
+	struct ofi_bufpool_attr bp_attrs = {0};
 	struct lnx_fabric *lnx_fab = container_of(fabric, struct lnx_fabric,
-					util_fabric.fabric_fid);
-	struct ofi_mem_monitor *memory_monitors[OFI_HMEM_MAX] = {
-		[FI_HMEM_SYSTEM] = default_monitor,
-		[FI_HMEM_CUDA] = default_cuda_monitor,
-		[FI_HMEM_ROCR] = default_rocr_monitor,
-		[FI_HMEM_ZE] = default_ze_monitor,
-	};
-
-	/* create a new entry for shm.
-	 * Create its fabric.
-	 * insert fabric in the global table
-	 */
-	rc = lnx_setup_core_fabrics(info->domain_attr->name, lnx_fab, context);
-	if (rc)
-		goto fail;
+					lf_util_fabric.fabric_fid);
 
 	rc = -FI_ENOMEM;
 	lnx_domain = calloc(sizeof(*lnx_domain), 1);
 	if (!lnx_domain)
+		goto out;
+
+	bp_attrs.size = sizeof(struct lnx_mr);
+	bp_attrs.alignment = 8;
+	bp_attrs.max_cnt = UINT32_MAX;
+	bp_attrs.chunk_cnt = 256;
+	bp_attrs.flags = OFI_BUFPOOL_NO_TRACK;
+	rc = ofi_bufpool_create_attr(&bp_attrs, &lnx_domain->ld_mem_reg_bp);
+	if (rc)
+		goto out;
+
+	rc = lnx_setup_fabrics(info->domain_attr->name, lnx_fab, context);
+	if (rc)
 		goto fail;
 
-	lnx_domain_info = &lnx_domain->ld_domain;
-	lnx_domain->ld_fabric = lnx_fab;
-
-	rc = ofi_domain_init(fabric, info, lnx_domain_info, context,
+	lnx_domain->ld_iov_limit = info->tx_attr->iov_limit;
+	dom = &lnx_domain->ld_domain;
+	rc = ofi_domain_init(fabric, info, dom, context,
 			     OFI_LOCK_SPINLOCK);
 	if (rc)
 		goto fail;
 
-	dlist_foreach_container(&lnx_domain->ld_fabric->local_prov_table,
-				struct local_prov, entry, lpv_entry) {
-		rc = lnx_open_core_domains(entry, context, lnx_domain, info);
-		if (rc) {
-			FI_INFO(&lnx_prov, FI_LOG_CORE, "Failed to initialize domain for %s\n",
-				entry->lpv_prov_name);
-			goto close_domain;
-		}
+	rc = lnx_open_core_domains(lnx_fab, context, lnx_domain);
+	if (rc) {
+		FI_INFO(&lnx_prov, FI_LOG_CORE, "Failed to initialize domain for %s\n",
+			info->domain_attr->name);
+		goto close_domain;
 	}
 
-	lnx_domain_info->domain_fid.fid.ops = &lnx_domain_fi_ops;
-	lnx_domain_info->domain_fid.ops = &lnx_domain_ops;
-	lnx_domain_info->domain_fid.mr = &lnx_mr_ops;
+	dom->domain_fid.fid.ops = &lnx_domain_fi_ops;
+	dom->domain_fid.ops = &lnx_domain_ops;
+	dom->domain_fid.mr = &lnx_mr_ops;
 
-	lnx_domain->ld_mr_cache.add_region = lnx_addr_add_region_noop;
-	lnx_domain->ld_mr_cache.delete_region = lnx_addr_del_region;
-	lnx_domain->ld_mr_cache.entry_data_size = sizeof(struct ofi_mr);
-	rc = ofi_mr_cache_init(&lnx_domain->ld_domain, memory_monitors,
-			       &lnx_domain->ld_mr_cache);
-	if (rc)
-		goto close_domain;
-
-	*domain = &lnx_domain_info->domain_fid;
+	*domain = &dom->domain_fid;
 
 	return 0;
 
 close_domain:
-	lnx_domain_close(&(lnx_domain_info->domain_fid.fid));
+	lnx_domain_close(&(dom->domain_fid.fid));
+	return rc;
+
 fail:
+	free(lnx_domain);
+out:
 	return rc;
 }
 

--- a/prov/lnx/src/lnx_ep.c
+++ b/prov/lnx/src/lnx_ep.c
@@ -55,83 +55,77 @@ extern struct fi_ops_tagged lnx_tagged_ops;
 extern struct fi_ops_rma lnx_rma_ops;
 extern struct fi_ops_atomic lnx_atomic_ops;
 
-static void lnx_init_ctx(struct fid_ep *ctx, size_t fclass);
+static struct fi_ops_srx_owner lnx_srx_ops = {
+	.size = sizeof(struct fi_ops_srx_owner),
+	.get_msg = lnx_get_msg,
+	.get_tag = lnx_get_tag,
+	.queue_msg = lnx_queue_msg,
+	.queue_tag = lnx_queue_tag,
+	.free_entry = lnx_free_entry,
+	.foreach_unspec_addr = lnx_foreach_unspec_addr,
+};
 
-static int lnx_close_ceps(struct local_prov *prov)
+int lnx_ep_close(struct fid *fid)
 {
-	int rc, frc = 0;
-	struct local_prov_ep *ep;
+	int i, rc, frc = FI_SUCCESS;
+	struct lnx_ep *lep;
+	struct lnx_core_ep *cep;
 
-	dlist_foreach_container(&prov->lpv_prov_eps,
-		struct local_prov_ep, ep, entry) {
+	lep = container_of(fid, struct lnx_ep, le_ep.ep_fid.fid);
 
-		if (ep->lpe_srx.ep_fid.fid.context)
-			free(ep->lpe_srx.ep_fid.fid.context);
+	for (i = 0; i < lep->le_domain->ld_num_doms; i++) {
+		cep = &lep->le_core_eps[i];
 
-		rc = fi_close(&ep->lpe_ep->fid);
+		rc = fi_close(&cep->cep_ep->fid);
 		if (rc)
 			frc = rc;
-		ofi_bufpool_destroy(ep->lpe_recv_bp);
+		if (cep->cep_srx_ep) {
+			rc = fi_close(&cep->cep_srx_ep->fid);
+			if (rc)
+				frc = rc;
+		}
 	}
+
+	ofi_endpoint_close(&lep->le_ep);
+	ofi_bufpool_destroy(lep->le_recv_bp);
+	free(lep->le_core_eps);
+	free(lep);
 
 	return frc;
 }
 
-int lnx_ep_close(struct fid *fid)
-{
-	int rc = 0;
-	struct local_prov *entry;
-	struct lnx_ep *ep;
-	struct lnx_fabric *fabric;
-
-	ep = container_of(fid, struct lnx_ep, le_ep.ep_fid.fid);
-	fabric = ep->le_domain->ld_fabric;
-
-	dlist_foreach_container(&fabric->local_prov_table,
-				struct local_prov,
-				entry, lpv_entry) {
-		lnx_close_ceps(entry);
-		if (rc)
-			FI_WARN(&lnx_prov, FI_LOG_CORE,
-				"Failed to close endpoint for %s\n",
-				entry->lpv_prov_name);
-	}
-
-	ofi_endpoint_close(&ep->le_ep);
-	free(ep);
-
-	return rc;
-}
-
 static int lnx_enable_core_eps(struct lnx_ep *lep)
 {
-	int rc;
-	struct local_prov *entry;
-	struct local_prov_ep *ep;
-	int srq_support = 1;
-	struct lnx_fabric *fabric = lep->le_domain->ld_fabric;
+	int i, rc;
+	struct lnx_core_domain *cd;
+	struct lnx_core_ep *cep;
+	struct fi_rx_attr attr = {0};
+	struct fi_peer_srx_context peer_srx;
 
-	fi_param_get_bool(&lnx_prov, "use_srq", &srq_support);
+	attr.op_flags = FI_PEER;
+	peer_srx.size = sizeof(peer_srx);
 
-	dlist_foreach_container(&fabric->local_prov_table, struct local_prov,
-				entry, lpv_entry) {
-		dlist_foreach_container(&entry->lpv_prov_eps,
-			struct local_prov_ep, ep, entry) {
-			if (srq_support) {
-				rc = fi_ep_bind(ep->lpe_ep,
-						&ep->lpe_srx_ep->fid, 0);
-				if (rc) {
-					FI_INFO(&lnx_prov, FI_LOG_CORE,
-						"%s doesn't support SRX (%d)\n",
-						ep->lpe_fabric_name, rc);
-					return rc;
-				}
-			}
+	for (i = 0; i < lep->le_domain->ld_num_doms; i++) {
+		cep = &lep->le_core_eps[i];
+		cd = cep->cep_domain;
 
-			rc = fi_enable(ep->lpe_ep);
-			if (rc)
-				return rc;
-		}
+		cep->cep_srx.owner_ops = &lnx_srx_ops;
+		cep->cep_srx.ep_fid.fid.context = cep;
+		peer_srx.srx = &cep->cep_srx;
+
+		rc = fi_srx_context(cd->cd_domain, &attr,
+				    &cep->cep_srx_ep, &peer_srx);
+		if (rc)
+			return rc;
+
+		rc = fi_ep_bind(cep->cep_ep,
+				&cep->cep_srx_ep->fid, 0);
+		if (rc)
+			return rc;
+
+		rc = fi_enable(cep->cep_ep);
+		if (rc)
+			return rc;
 	}
 
 	return 0;
@@ -139,20 +133,20 @@ static int lnx_enable_core_eps(struct lnx_ep *lep)
 
 static int lnx_ep_control(struct fid *fid, int command, void *arg)
 {
-	struct lnx_ep *ep;
+	struct lnx_ep *lep;
 	int rc;
 
-	ep = container_of(fid, struct lnx_ep, le_ep.ep_fid.fid);
+	lep = container_of(fid, struct lnx_ep, le_ep.ep_fid.fid);
 
 	switch (command) {
 	case FI_ENABLE:
-		if (ep->le_fclass == FI_CLASS_EP &&
-		    ((ofi_needs_rx(ep->le_ep.caps) && !ep->le_ep.rx_cq) ||
-		    (ofi_needs_tx(ep->le_ep.caps) && !ep->le_ep.tx_cq)))
+		if (lep->le_fclass == FI_CLASS_EP &&
+		    ((ofi_needs_rx(lep->le_ep.caps) && !lep->le_ep.rx_cq) ||
+		    (ofi_needs_tx(lep->le_ep.caps) && !lep->le_ep.tx_cq)))
 			return -FI_ENOCQ;
-		if (!ep->le_peer_tbl)
+		if (!lep->le_lav)
 			return -FI_ENOAV;
-		rc = lnx_enable_core_eps(ep);
+		rc = lnx_enable_core_eps(lep);
 		break;
 	default:
 		return -FI_ENOSYS;
@@ -161,70 +155,66 @@ static int lnx_ep_control(struct fid *fid, int command, void *arg)
 	return rc;
 }
 
-int lnx_cq_bind_core_prov(struct fid *fid, struct fid *bfid, uint64_t flags)
+static int lnx_bind_core_cqs(struct lnx_ep *lep, struct lnx_cq *lcq,
+			     uint64_t flags)
 {
-	int rc;
-	struct lnx_ep *lep;
-	struct util_cq *cq;
-	struct local_prov_ep *ep;
-	struct local_prov *entry;
-	struct lnx_fabric *fabric;
+	int i, rc;
+	struct lnx_core_domain *cd;
+	struct lnx_core_cq *core_cq;
+	struct lnx_core_ep *cep;
 
-	lep = container_of(fid, struct lnx_ep, le_ep.ep_fid.fid);
-	cq = container_of(bfid, struct util_cq, cq_fid.fid);
-	fabric = lep->le_domain->ld_fabric;
+	for (i = 0; i < lep->le_domain->ld_num_doms; i++) {
+		core_cq = &lcq->lcq_core_cqs[i];
+		cd = core_cq->cc_domain;
+		cep = &lep->le_core_eps[i];
 
-	rc = ofi_ep_bind_cq(&lep->le_ep, cq, flags);
-	if (rc)
-		return rc;
-
-	/* bind the core providers to their respective CQs */
-	dlist_foreach_container(&fabric->local_prov_table, struct local_prov,
-				entry, lpv_entry) {
-		dlist_foreach_container(&entry->lpv_prov_eps,
-			struct local_prov_ep, ep, entry) {
-			rc = fi_ep_bind(ep->lpe_ep,
-					&ep->lpe_cq.lpc_core_cq->fid, flags);
-			if (rc)
-				return rc;
-		}
+		if (cep->cep_domain != cd)
+			continue;
+		rc = fi_ep_bind(cep->cep_ep,
+				&core_cq->cc_cq->fid, flags);
+		if (rc)
+			return rc;
 	}
 
 	return 0;
 }
 
-static int lnx_ep_bind_core_prov(struct lnx_fabric *fabric, uint64_t flags)
+int lnx_bind_core_avs(struct lnx_ep *lep, struct lnx_av *lav, uint64_t flags)
 {
-	struct local_prov *entry;
-	struct local_prov_ep *ep;
-	int rc;
+	int rc, i;
+	struct lnx_core_ep *cep;
+	struct lnx_core_av *cav;
 
-	dlist_foreach_container(&fabric->local_prov_table, struct local_prov,
-				entry, lpv_entry) {
-		dlist_foreach_container(&entry->lpv_prov_eps,
-			struct local_prov_ep, ep, entry) {
-			rc = fi_ep_bind(ep->lpe_ep, &ep->lpe_av->fid, flags);
-			if (rc)
-				return rc;
-		}
+	for (i = 0; i < lav->lav_domain->ld_num_doms; i++) {
+		cav = &lav->lav_core_avs[i];
+		cep = &lep->le_core_eps[i];
+
+		if (cep->cep_cav)
+			return -FI_EALREADY;
+		rc = fi_ep_bind(cep->cep_ep, &cav->cav_av->fid, flags);
+		if (rc)
+			return rc;
+		cep->cep_cav = cav;
+		dlist_insert_tail(&cep->cep_av_entry, &cav->cav_endpoints);
 	}
 
-	return rc;
+	return 0;
 }
 
 static int
 lnx_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 {
 	int rc = 0;
-	struct lnx_ep *ep;
-	struct lnx_peer_table *peer_tbl;
+	struct lnx_ep *lep;
+	struct lnx_cq *lcq;
+	struct lnx_av *lav;
 
 	switch (fid->fclass) {
-	case FI_CLASS_EP:	/* Standard EP */
-	case FI_CLASS_SEP:	/* Scalable EP */
-		ep = container_of(fid, struct lnx_ep, le_ep.ep_fid.fid);
+	case FI_CLASS_EP:
+		lep = container_of(fid, struct lnx_ep, le_ep.ep_fid.fid);
 		break;
 
+	case FI_CLASS_SEP:
 	default:
 		return -FI_EINVAL;
 	}
@@ -234,20 +224,32 @@ lnx_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 		return -FI_ENOSYS;
 
 	case FI_CLASS_CQ:
-		rc = lnx_cq_bind_core_prov(fid, bfid, flags);
+		lcq = container_of(bfid, struct lnx_cq, lcq_util_cq.cq_fid.fid);
+		rc = lnx_bind_core_cqs(lep, lcq, flags);
+		if (rc)
+			goto out;
+		rc = ofi_ep_bind_cq(&lep->le_ep, &lcq->lcq_util_cq, flags);
+		if (rc)
+			goto out;
 		break;
 
 	case FI_CLASS_CNTR:
 		return -FI_ENOSYS;
 
 	case FI_CLASS_AV:
-		peer_tbl = container_of(bfid, struct lnx_peer_table,
-					lpt_av.av_fid.fid);
-		if (peer_tbl->lpt_domain != ep->le_domain)
+		if (lep->le_lav) {
+			FI_WARN(&lnx_prov, FI_LOG_CORE,
+				"AV already bound\n");
 			return -FI_EINVAL;
-		ep->le_peer_tbl = peer_tbl;
-		/* forward the bind to the core provider endpoints */
-		rc = lnx_ep_bind_core_prov(ep->le_domain->ld_fabric, flags);
+		}
+		lav = container_of(bfid, struct lnx_av, lav_av.av_fid.fid);
+		rc = lnx_bind_core_avs(lep, lav, flags);
+		if (rc)
+			goto out;
+		rc = ofi_ep_bind_av(&lep->le_ep, &lav->lav_av);
+		if (rc)
+			goto out;
+		lep->le_lav = lav;
 		break;
 
 	case FI_CLASS_STX_CTX:	/* shared TX context */
@@ -260,58 +262,45 @@ lnx_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 		return -FI_EINVAL;
 	}
 
+out:
 	return rc;
 }
 
 int lnx_getname(fid_t fid, void *addr, size_t *addrlen)
 {
-	struct local_prov *entry;
-	size_t size = sizeof(struct lnx_addresses);
-	/* initial location to put the address */
-	char ep_addr[FI_NAME_MAX];
-	char *tmp = NULL;
-	struct lnx_addresses *la;
-	struct lnx_address_prov *lap;
+	int i, rc;
 	char hostname[FI_NAME_MAX];
-	size_t prov_addrlen;
-	size_t addrlen_list[LNX_MAX_LOCAL_EPS];
-	int rc, j = 0;
-	struct lnx_ep *lnx_ep;
-	struct lnx_fabric *fabric;
-	struct local_prov_ep *ep;
+	struct lnx_core_ep *cep;
+	struct lnx_ep *lep;
+	struct lnx_ep_addr *ep_addr;
+	struct lnx_address *lnx_addr;
+	char *cep_addr, *prov_name;
+	size_t size;
+	size_t eps_addrlen[LNX_MAX_LOCAL_EPS] = {0};
 
-	lnx_ep = container_of(fid, struct lnx_ep, le_ep.ep_fid.fid);
-	fabric = lnx_ep->le_domain->ld_fabric;
+	lep = container_of(fid, struct lnx_ep, le_ep.ep_fid.fid);
 
-	/* check the hostname and compare it to mine
-	 * TODO: Is this good enough? or do we need a better way of
-	 * determining if the address is local?
-	 */
 	rc = gethostname(hostname, FI_NAME_MAX);
 	if (rc == -1) {
 		FI_WARN(&lnx_prov, FI_LOG_CORE, "failed to get hostname\n");
 		return -FI_EPERM;
 	}
 
-	addrlen_list[0] = 0;
+	size = sizeof(*lnx_addr);
 
-	/* calculate the size of the address */
-	dlist_foreach_container(&fabric->local_prov_table, struct local_prov,
-				entry, lpv_entry) {
-		size += sizeof(struct lnx_address_prov);
-		prov_addrlen = 0;
+	for (i = 0; i < lep->le_domain->ld_num_doms; i++) {
+		cep = &lep->le_core_eps[i];
 
-		dlist_foreach_container(&entry->lpv_prov_eps,
-			struct local_prov_ep, ep, entry) {
-			rc = fi_getname(&ep->lpe_ep->fid, (void*)ep_addr, &prov_addrlen);
-			if (rc == -FI_ETOOSMALL) {
-				size += prov_addrlen * entry->lpv_ep_count;
-				addrlen_list[j] = prov_addrlen;
-				j++;
-				break;
-			} else {
-				return -FI_EINVAL;
-			}
+		if (i > LNX_MAX_LOCAL_EPS)
+			return -FI_E2BIG;
+		eps_addrlen[i] = 0;
+		/* query the core address size and use it to calculate the
+		 * total size of the lnx address */
+		rc = fi_getname(&cep->cep_ep->fid, NULL, &eps_addrlen[i]);
+		if (rc == -FI_ETOOSMALL) {
+			size += (sizeof(*ep_addr)) + eps_addrlen[i];
+		} else {
+			return -FI_EINVAL;
 		}
 	}
 
@@ -320,214 +309,89 @@ int lnx_getname(fid_t fid, void *addr, size_t *addrlen)
 		return -FI_ETOOSMALL;
 	}
 
-	la = addr;
+	lnx_addr = (struct lnx_address *) addr;
+	ep_addr = (struct lnx_ep_addr *)((char*)lnx_addr + sizeof(*lnx_addr));
 
-	lap = (struct lnx_address_prov *)((char*)la + sizeof(*la));
+	memcpy(lnx_addr->la_hostname, hostname, FI_NAME_MAX - 1);
+	lnx_addr->la_ep_count = i;
 
-	j = 0;
-	dlist_foreach_container(&fabric->local_prov_table, struct local_prov,
-							entry, lpv_entry) {
-		memcpy(lap->lap_prov, entry->lpv_prov_name, FI_NAME_MAX - 1);
-		lap->lap_addr_count = entry->lpv_ep_count;
-		lap->lap_addr_size = addrlen_list[j];
+	for (i = 0; i < lep->le_domain->ld_num_doms; i++) {
+		cep = &lep->le_core_eps[i];
 
-		dlist_foreach_container(&entry->lpv_prov_eps,
-			struct local_prov_ep, ep, entry) {
-			tmp = (char*)lap + sizeof(*lap);
-
-			rc = fi_getname(&ep->lpe_ep->fid, (void*)tmp, &addrlen_list[j]);
-			if (rc)
-				return rc;
-
-			if (lap->lap_addr_size != addrlen_list[j])
-				return -FI_EINVAL;
-
-			tmp += addrlen_list[j];
-		}
-
-		lap = (struct lnx_address_prov *)tmp;
-		j++;
+		prov_name = cep->cep_domain->cd_info->fabric_attr->name;
+		memcpy(ep_addr->lea_prov, prov_name, strlen(prov_name)+1);
+		cep_addr = (char*)ep_addr + sizeof(*ep_addr);
+		rc = fi_getname(&cep->cep_ep->fid, (void*)cep_addr, &eps_addrlen[i]);
+		if (rc)
+			return rc;
+		ep_addr->lea_addr_size = eps_addrlen[i];
+		ep_addr = (struct lnx_ep_addr *) (cep_addr + eps_addrlen[i]);
 	}
 
-	la->la_prov_count = j;
-	memcpy(la->la_hostname, hostname, FI_NAME_MAX - 1);
-
-	return 0;
+	return FI_SUCCESS;
 }
 
 static ssize_t lnx_ep_cancel(fid_t fid, void *context)
 {
-	int rc = 0;
+	int i, rc = 0;
+	char *prov_name;
 	struct lnx_ep *lep;
-	struct lnx_ctx *ctx;
-	struct local_prov_ep *ep;
-	struct local_prov *entry;
-	struct lnx_fabric *fabric;
+	struct lnx_core_ep *cep;
 
 	switch (fid->fclass) {
 	case FI_CLASS_EP:
 		lep = container_of(fid, struct lnx_ep, le_ep.ep_fid.fid);
 		break;
-	case FI_CLASS_RX_CTX:
-		ctx = container_of(fid, struct lnx_ctx, ctx_ep.fid);
-		lep = ctx->ctx_parent;
-		break;
-	case FI_CLASS_TX_CTX:
-		return -FI_ENOENT;
 	default:
 		return -FI_EINVAL;
 	}
 
-	fabric = lep->le_domain->ld_fabric;
+	for (i = 0; i < lep->le_domain->ld_num_doms; i++) {
+		cep = &lep->le_core_eps[i];
 
-	dlist_foreach_container(&fabric->local_prov_table, struct local_prov,
-				entry, lpv_entry) {
-		dlist_foreach_container(&entry->lpv_prov_eps,
-			struct local_prov_ep, ep, entry) {
-			rc = fi_cancel(&ep->lpe_ep->fid, context);
-			if (rc == -FI_ENOSYS) {
-				FI_WARN(&lnx_prov, FI_LOG_CORE,
-				 "%s: Operation not supported by provider. "
-				 "Ignoring\n", ep->lpe_fabric_name);
-				rc = 0;
-				continue;
-			} else if (rc != FI_SUCCESS) {
-				return rc;
-			}
+		prov_name = cep->cep_domain->cd_info->domain_attr->name;
+		rc = fi_cancel(&cep->cep_ep->fid, context);
+		if (rc == -FI_ENOSYS) {
+			FI_WARN(&lnx_prov, FI_LOG_CORE,
+				"%s: Operation not supported by provider. "
+				"Ignoring\n", prov_name);
+			rc = 0;
+			continue;
 		}
+		if (rc != FI_SUCCESS)
+			return rc;
 	}
 
 	return rc;
+}
+
+static int lnx_ep_getopt(fid_t fid, int level, int optname,
+			  void *optval, size_t *optlen)
+{
+	return -FI_ENOPROTOOPT;
 }
 
 static int lnx_ep_setopt(fid_t fid, int level, int optname, const void *optval,
 			  size_t optlen)
 {
-	int rc = 0;
 	struct lnx_ep *lep;
-	struct local_prov_ep *ep;
-	struct local_prov *entry;
-	struct lnx_fabric *fabric;
+	struct lnx_core_ep *cep;
+	int i, rc;
 
 	lep = container_of(fid, struct lnx_ep, le_ep.ep_fid.fid);
-	fabric = lep->le_domain->ld_fabric;
 
-	dlist_foreach_container(&fabric->local_prov_table, struct local_prov,
-				entry, lpv_entry) {
-		dlist_foreach_container(&entry->lpv_prov_eps,
-			struct local_prov_ep, ep, entry) {
-			rc = fi_setopt(&ep->lpe_ep->fid, level, optname,
-				       optval, optlen);
-			if (rc == -FI_ENOSYS) {
-				FI_WARN(&lnx_prov, FI_LOG_CORE,
-				 "%s: Operation not supported by provider. "
-				 "Ignoring\n", ep->lpe_fabric_name);
-				rc = 0;
-				continue;
-			} else if (rc != FI_SUCCESS) {
-				return rc;
-			}
+	for (i = 0; i < lep->le_domain->ld_num_doms; i++) {
+		cep = &lep->le_core_eps[i];
+
+		rc = fi_setopt(&cep->cep_ep->fid, level, optname,
+				optval, optlen);
+		if (rc == -FI_ENOSYS) {
+			rc = 0;
+			continue;
 		}
+		if (rc != FI_SUCCESS)
+			return rc;
 	}
-
-	return rc;
-}
-
-
-static int lnx_ep_txc(struct fid_ep *fid, int index, struct fi_tx_attr *attr,
-		      struct fid_ep **tx_ep, void *context)
-{
-	int rc = 0;
-	struct lnx_ep *lep;
-	struct lnx_ctx *ctx;
-	struct local_prov_ep *ep;
-	struct local_prov *entry;
-	struct lnx_fabric *fabric;
-
-	ctx = calloc(sizeof(*ctx), 1);
-	if (!ctx)
-		return -FI_ENOMEM;
-
-	lep = container_of(fid, struct lnx_ep, le_ep.ep_fid.fid);
-	fabric = lep->le_domain->ld_fabric;
-
-	dlist_foreach_container(&fabric->local_prov_table, struct local_prov,
-				entry, lpv_entry) {
-		dlist_foreach_container(&entry->lpv_prov_eps,
-			struct local_prov_ep, ep, entry) {
-			if (index >= ep->lpe_fi_info->ep_attr->tx_ctx_cnt)
-				continue;
-
-			rc = fi_tx_context(ep->lpe_ep, index, attr,
-					   &ep->lpe_txc[index], context);
-			if (rc == -FI_ENOSYS) {
-				FI_WARN(&lnx_prov, FI_LOG_CORE,
-				 "%s: Operation not supported by provider. "
-				 "Ignoring\n", ep->lpe_fabric_name);
-				rc = 0;
-				continue;
-			} else if (rc != FI_SUCCESS) {
-				return rc;
-			}
-		}
-	}
-
-	dlist_init(&ctx->ctx_head);
-	ctx->ctx_idx = index;
-	ctx->ctx_parent = lep;
-	lnx_init_ctx(&ctx->ctx_ep, FI_CLASS_TX_CTX);
-	dlist_insert_tail(&ctx->ctx_head, &lep->le_tx_ctx);
-	/* set the callbacks for the transmit context */
-	*tx_ep = &ctx->ctx_ep;
-
-	return rc;
-}
-
-static int lnx_ep_rxc(struct fid_ep *fid, int index, struct fi_rx_attr *attr,
-		      struct fid_ep **rx_ep, void *context)
-{
-	int rc = 0;
-	struct lnx_ep *lep;
-	struct lnx_ctx *ctx;
-	struct local_prov_ep *ep;
-	struct local_prov *entry;
-	struct lnx_fabric *fabric;
-
-	ctx = calloc(sizeof(*ctx), 1);
-	if (!ctx)
-		return -FI_ENOMEM;
-
-	lep = container_of(fid, struct lnx_ep, le_ep.ep_fid.fid);
-	fabric = lep->le_domain->ld_fabric;
-
-	dlist_foreach_container(&fabric->local_prov_table, struct local_prov,
-				entry, lpv_entry) {
-		dlist_foreach_container(&entry->lpv_prov_eps,
-			struct local_prov_ep, ep, entry) {
-			if (index >= ep->lpe_fi_info->ep_attr->rx_ctx_cnt)
-				continue;
-
-			rc = fi_rx_context(ep->lpe_ep, index, attr,
-					   &ep->lpe_rxc[index], context);
-			if (rc == -FI_ENOSYS) {
-				FI_WARN(&lnx_prov, FI_LOG_CORE,
-					"%s: Operation not supported by provider. "
-					"Ignoring\n", ep->lpe_fabric_name);
-				rc = 0;
-				continue;
-			} else if (rc != FI_SUCCESS) {
-				return rc;
-			}
-		}
-	}
-
-	dlist_init(&ctx->ctx_head);
-	ctx->ctx_idx = index;
-	ctx->ctx_parent = lep;
-	lnx_init_ctx(&ctx->ctx_ep, FI_CLASS_RX_CTX);
-	dlist_insert_tail(&ctx->ctx_head, &lep->le_rx_ctx);
-	/* set the callbacks for the receive context */
-	*rx_ep = &ctx->ctx_ep;
 
 	return rc;
 }
@@ -537,10 +401,10 @@ struct fi_ops_ep lnx_ep_ops = {
 	.cancel = lnx_ep_cancel,
 	/* can't get opt, because there is no way to report multiple
 	 * options for the different links */
-	.getopt = fi_no_getopt,
+	.getopt = lnx_ep_getopt,
 	.setopt = lnx_ep_setopt,
-	.tx_ctx = lnx_ep_txc,
-	.rx_ctx = lnx_ep_rxc,
+	.tx_ctx = fi_no_tx_ctx,
+	.rx_ctx = fi_no_rx_ctx,
 	.rx_size_left = fi_no_rx_size_left,
 	.tx_size_left = fi_no_tx_size_left,
 };
@@ -565,69 +429,40 @@ struct fi_ops_cm lnx_cm_ops = {
 	.shutdown = fi_no_shutdown,
 };
 
-static int lnx_open_eps(struct local_prov *prov, struct fi_info *info,
-			void *context, size_t fclass, struct lnx_ep *lep)
+static int
+lnx_open_core_eps(struct lnx_ep *lep, void *context)
 {
-	int rc = 0;
-	struct local_prov_ep *ep;
-	struct dlist_entry *tmp;
-	struct ofi_bufpool_attr bp_attrs = {};
-	struct lnx_srx_context *ctxt;
+	int i, rc = 0;
+	struct lnx_core_domain *cd;
+	struct lnx_core_ep *cep;
 
-	ctxt = calloc(1, sizeof(*ctxt));
-	if (!ctxt)
-		return -FI_ENOMEM;
+	/* Since we kept the shm domain at the head of the array, the shm
+	 * endpoints will be at the head of the endpoint array
+	 */
+	for (i = 0; i < lep->le_domain->ld_num_doms; i++) {
+		cd = &lep->le_domain->ld_core_domains[i];
 
-	dlist_foreach_container_safe(&prov->lpv_prov_eps,
-		struct local_prov_ep, ep, entry, tmp) {
-		if (fclass == FI_CLASS_EP) {
-			rc = fi_endpoint(ep->lpe_domain, ep->lpe_fi_info,
-					 &ep->lpe_ep, context);
-		} else {
-			/* update endpoint attributes with whatever is being
-			 * passed from the application
-			 */
-			if (ep->lpe_fi_info && info) {
-				ep->lpe_fi_info->ep_attr->tx_ctx_cnt =
-					info->ep_attr->tx_ctx_cnt;
-				ep->lpe_fi_info->ep_attr->rx_ctx_cnt =
-					info->ep_attr->rx_ctx_cnt;
-			}
+		cep = &lep->le_core_eps[i];
 
-			ep->lpe_txc = calloc(info->ep_attr->tx_ctx_cnt,
-					sizeof(*ep->lpe_txc));
-			ep->lpe_rxc = calloc(info->ep_attr->rx_ctx_cnt,
-					sizeof(*ep->lpe_rxc));
-			if (!ep->lpe_txc || !ep->lpe_rxc)
-				return -FI_ENOMEM;
+		dlist_init(&cep->cep_av_entry);
+		cep->cep_domain = cd;
+		cep->cep_parent = lep;
 
-			rc = fi_scalable_ep(ep->lpe_domain, ep->lpe_fi_info,
-					    &ep->lpe_ep, context);
-		}
+		rc = fi_endpoint(cd->cd_domain, cd->cd_info,
+					&cep->cep_ep, context);
 		if (rc)
-			return rc;
-
-		ctxt->srx_lep = lep;
-		ctxt->srx_cep = ep;
-
-		ep->lpe_srx.ep_fid.fid.context = ctxt;
-		ep->lpe_srx.ep_fid.fid.fclass = FI_CLASS_SRX_CTX;
-		ofi_spin_init(&ep->lpe_bplock);
-		/* create a buffer pool for the receive requests */
-		bp_attrs.size = sizeof(struct lnx_rx_entry);
-		bp_attrs.alignment = 8;
-		bp_attrs.max_cnt = UINT16_MAX;
-		bp_attrs.chunk_cnt = 64;
-		bp_attrs.flags = OFI_BUFPOOL_NO_TRACK;
-		rc = ofi_bufpool_create_attr(&bp_attrs, &ep->lpe_recv_bp);
-		if (rc) {
-			FI_WARN(&lnx_prov, FI_LOG_FABRIC,
-				"Failed to create receive buffer pool");
-			return -FI_ENOMEM;
-		}
+			goto fail;
 	}
 
 	return 0;
+
+fail:
+	for (i = i - 1; i >= 0; i--) {
+		cep = &lep->le_core_eps[i];
+		(void) fi_close(&cep->cep_ep->fid);
+	}
+
+	return rc;
 }
 
 static void
@@ -636,453 +471,49 @@ lnx_ep_nosys_progress(struct util_ep *util_ep)
 	assert(0);
 }
 
-static inline int
-match_tag(uint64_t tag, uint64_t match_tag, uint64_t ignore)
+static int lnx_common_match(uint64_t tag, uint64_t match_tag,
+			    fi_addr_t recv_addr, fi_addr_t addr,
+			    uint64_t ignore)
 {
-	return ((tag | ignore) == (match_tag | ignore));
-}
+	fi_addr_t addr1 = lnx_decode_primary_id(recv_addr);
+	fi_addr_t addr2 = lnx_decode_primary_id(addr);
 
-static inline bool
-lnx_addr_match(fi_addr_t addr1, fi_addr_t addr2)
-{
-	return (addr1 == addr2);
-}
+	bool tmatch = ((tag | ignore) == (match_tag | ignore));
 
-static inline bool
-lnx_search_addr_match(fi_addr_t cep_addr, struct lnx_peer_prov *lpp)
-{
-	struct lnx_local2peer_map *lpm;
-	fi_addr_t peer_addr;
-	int i;
-
-	dlist_foreach_container(&lpp->lpp_map,
-				struct lnx_local2peer_map,
-				lpm, entry) {
-		for (i = 0; i < LNX_MAX_LOCAL_EPS; i++) {
-			peer_addr = lpm->peer_addrs[i];
-			if (peer_addr == FI_ADDR_NOTAVAIL)
-				break;
-			if (lnx_addr_match(peer_addr, cep_addr))
-				return true;
-		}
-	}
-
-	return false;
-}
-
-static int lnx_match_common(uint64_t tag1, uint64_t tag2, uint64_t ignore,
-		fi_addr_t cep_addr, fi_addr_t lnx_addr, struct lnx_peer *peer,
-		struct local_prov_ep *cep)
-{
-	struct lnx_peer_prov *lpp;
-	struct local_prov *lp;
-	bool tmatch;
-
-	/* if a request has no address specified it'll match against any
-	 * rx_entry with a matching tag
-	 *  or
-	 * if an rx_entry has no address specified, it'll match against any
-	 * request with a matching tag
-	 *
-	 * for non tagged messages tags will be set to TAG_ANY so they will
-	 * always match and decision will be made on address only.
-	 */
-	tmatch = match_tag(tag1, tag2, ignore);
-	if (!tmatch)
+	if (recv_addr == FI_ADDR_UNSPEC)
 		return tmatch;
 
-	FI_DBG(&lnx_prov, FI_LOG_CORE,
-	       "tag1=%lx tag2=%lx ignore=%lx cep_addr=%lx lnx_addr=%lx tmatch=%d\n",
-	       tag1, tag2, ignore, cep_addr, lnx_addr, tmatch);
-
-	/* if we're requested to receive from any peer, then tag maching is
-	 * enough. None tagged message will match irregardless.
-	 */
-	if (lnx_addr == FI_ADDR_UNSPEC)
-		return tmatch;
-
-	/* if the address is specified, then we should have a peer and
-	 * a receiving core endpoint and a provider parent
-	 */
-	assert(peer && cep && cep->lpe_parent);
-
-	lp = cep->lpe_parent;
-
-	/* if this is a shm core provider, then only go through lnx
-	 * shm provider
-	 */
-	if (cep->lpe_local)
-		return lnx_search_addr_match(cep_addr, peer->lp_shm_prov);
-
-	/* check if we already have a peer provider.
-	 * A peer can receive messages from multiple providers, we need to
-	 * find the provider which maps to the provider we're currently
-	 * checking. The map looked up can have multiple addresses which
-	 * we can receive from, so we need to check which one of those is
-	 * the correct match.
-	 *
-	 * Note: we're trying to make this loop as efficient as possible,
-	 * because it's executed on the message matching path, which is
-	 * heavily hit.
-	 *
-	 * The theory is in most use cases:
-	 *   - There will be only two providers to check
-	 *   - Each provider will have 1 endpoint, and therefore only one map
-	 *   - Each peer will only have 1 address.
-	 *
-	 */
-	dlist_foreach_container(&peer->lp_provs,
-			struct lnx_peer_prov, lpp, entry) {
-		if (lpp->lpp_prov == lp)
-			return lnx_search_addr_match(cep_addr, lpp);
-	}
-
-	return false;
-}
-
-static int lnx_match_unexq(struct dlist_entry *item, const void *args)
-{
-	/* this entry is placed on the SUQ via the lnx_get_tag() path
-	 * and examined in the lnx_process_tag() path */
-	struct lnx_match_attr *match_attr = (struct lnx_match_attr *) args;
-	struct lnx_rx_entry *entry = (struct lnx_rx_entry *) item;
-	struct lnx_peer *peer = match_attr->lm_peer;
-
-	/* entry refers to the unexpected message received
-	 * entry->rx_entry.tag will be the tag of the message or TAG_UNSPEC
-	 * otherwise
-	 *
-	 * entry->rx_entry.addr will be the address of the peer which sent the
-	 * message or ADDR_UNSPEC if the core provider didn't do a reverse
-	 * lookup.
-	 *
-	 * entry->rx_cep will be set to the core endpoint which received the
-	 * message.
-	 *
-	 * match_attr is filled in by the lnx_process_tag() and contains
-	 * information passed to us by the application
-	 *
-	 * match_attr->lm_peer is the peer looked up via the addr passed by
-	 * the application to LNX. It is NULL if the addr is ADDR_UNSPEC.
-	 *
-	 * match_attr->lm_tag, match_attr->lm_ignore are the tag and ignore
-	 * bits passed by the application to LNX via the receive API.
-	 *
-	 * match_attr->lm_addr is the only significant if it's set to
-	 * FI_ADDR_UNSPEC, otherwise it's not used in matching because it's
-	 * the LNX level address and we need to compare the core level address.
-	 */
-	return lnx_match_common(entry->rx_entry.tag, match_attr->lm_tag,
-			match_attr->lm_ignore, entry->rx_entry.addr,
-			match_attr->lm_addr, peer, entry->rx_cep);
+	return tmatch && (addr1 == addr2);
 }
 
 static int lnx_match_recvq(struct dlist_entry *item, const void *args)
 {
-	struct lnx_match_attr *match_attr = (struct lnx_match_attr *) args;
-	/* this entry is placed on the recvq via the lnx_process_tag() path
-	 * and examined in the lnx_get_tag() path */
+	struct lnx_match_attr *attr = (struct lnx_match_attr *) args;
 	struct lnx_rx_entry *entry = (struct lnx_rx_entry *) item;
 
-	/* entry refers to the receive request waiting for a message
-	 * entry->rx_entry.tag is the tag passed in by the application.
-	 *
-	 * entry->rx_entry.addr is the address passed in by the application.
-	 * This is the LNX level address. It's only significant if it's set
-	 * to ADDR_UNSPEC. Otherwise, it has already been used to look up the
-	 * peer.
-	 *
-	 * entry->rx_cep is always NULL in this case, as this will only be
-	 * known when the message is received.
-	 *
-	 * entry->rx_peer is the LNX peer looked up if a valid address is
-	 * given by the application, otherwise it's NULL.
-	 *
-	 * match_attr information is filled by the lnx_get_tag() callback and
-	 * contains information passed to us by the core endpoint receiving
-	 * the message.
-	 *
-	 * match_attr->rx_peer is not significant because at the lnx_get_tag()
-	 * call there isn't enough information to find what the peer is.
-	 *
-	 * match_attr->lm_tag, match_attr->lm_ignore are the tag and ignore
-	 * bits passed up by the core endpoint receiving the message.
-	 *
-	 * match_attr->lm_addr is the address of the peer which sent the
-	 * message. Set if the core endpoint has done a reverse lookup,
-	 * otherwise set to ADDR_UNSPEC.
-	 *
-	 * match_attr->lm_cep is the core endpoint which received the message.
-	 */
-	return lnx_match_common(entry->rx_entry.tag, match_attr->lm_tag,
-			entry->rx_ignore, match_attr->lm_addr,
-			entry->rx_entry.addr, entry->rx_peer, match_attr->lm_cep);
+	return lnx_common_match(entry->rx_entry.tag, attr->lm_tag,
+				entry->rx_entry.addr, attr->lm_addr,
+				entry->rx_ignore);
 }
 
-static inline int
-lnx_init_queue(struct lnx_queue *q, dlist_func_t *match_func)
+static int lnx_match_unexq(struct dlist_entry *item, const void *args)
 {
-	int rc;
+	struct lnx_match_attr *attr = (struct lnx_match_attr *) args;
+	struct lnx_rx_entry *entry = (struct lnx_rx_entry *) item;
 
-	rc = ofi_spin_init(&q->lq_qlock);
-	if (rc)
-		return rc;
-
-	dlist_init(&q->lq_queue);
-
-	q->lq_match_func = match_func;
-
-	return 0;
+	return lnx_common_match(attr->lm_tag, entry->rx_entry.tag,
+				attr->lm_addr, entry->rx_entry.addr,
+				attr->lm_ignore);
 }
 
-static inline int
-lnx_init_qpair(struct lnx_qpair *qpair, dlist_func_t *recvq_match_func,
-			   dlist_func_t *unexq_match_func)
+static inline void
+lnx_init_qpair(struct lnx_qpair *qp, dlist_func_t *recvq_match_func,
+	       dlist_func_t *unexq_match_func)
 {
-	int rc = 0;
-
-	rc = lnx_init_queue(&qpair->lqp_recvq, recvq_match_func);
-	if (rc)
-		goto out;
-	rc = lnx_init_queue(&qpair->lqp_unexq, unexq_match_func);
-	if (rc)
-		goto out;
-
-out:
-	return rc;
-}
-
-static inline int
-lnx_init_srq(struct lnx_peer_srq *srq)
-{
-	int rc;
-
-	rc = lnx_init_qpair(&srq->lps_trecv, lnx_match_recvq, lnx_match_unexq);
-	if (rc)
-		return rc;
-	rc = lnx_init_qpair(&srq->lps_recv, lnx_match_recvq, lnx_match_unexq);
-	if (rc)
-		return rc;
-
-	return rc;
-}
-
-static int lnx_get_ctx(struct local_prov_ep *ep, size_t fclass,
-		       struct fid_ep ***ep_ctx, size_t *size)
-{
-	switch (fclass) {
-	case FI_CLASS_RX_CTX:
-		*ep_ctx = ep->lpe_rxc;
-		*size = ep->lpe_fi_info->ep_attr->rx_ctx_cnt;
-		break;
-	case FI_CLASS_TX_CTX:
-		*ep_ctx = ep->lpe_txc;
-		*size = ep->lpe_fi_info->ep_attr->tx_ctx_cnt;
-		break;
-	default:
-		return -FI_EINVAL;
-	}
-
-	return FI_SUCCESS;
-}
-
-static void lnx_close_ep_ctx(struct local_prov_ep *ep, size_t fclass)
-{
-	struct fid_ep **ep_ctx;
-	size_t size;
-	size_t i;
-	int rc;
-
-	rc = lnx_get_ctx(ep, fclass, &ep_ctx, &size);
-	if (rc)
-		return;
-
-	for (i = 0; i < size; i++) {
-		rc = fi_close(&ep_ctx[i]->fid);
-		if (rc)
-			FI_WARN(&lnx_prov, FI_LOG_CORE,
-				"Failed to close ep context %lu with %d\n",
-				fclass, rc);
-	}
-}
-
-static int lnx_ctx_close(struct fid *fid)
-{
-	struct lnx_ep *lep;
-	struct lnx_ctx *ctx;
-	struct local_prov_ep *ep;
-	struct local_prov *entry;
-	struct lnx_fabric *fabric;
-
-	if (fid->fclass != FI_CLASS_RX_CTX &&
-	    fid->fclass != FI_CLASS_TX_CTX)
-		return -FI_EINVAL;
-
-	ctx = container_of(fid, struct lnx_ctx, ctx_ep.fid);
-	lep = ctx->ctx_parent;
-
-	fabric = lep->le_domain->ld_fabric;
-
-	dlist_foreach_container(&fabric->local_prov_table, struct local_prov,
-				entry, lpv_entry) {
-		dlist_foreach_container(&entry->lpv_prov_eps,
-					struct local_prov_ep, ep, entry)
-			lnx_close_ep_ctx(ep, fid->fclass);
-	}
-
-	return FI_SUCCESS;
-}
-
-static int lnx_ctx_bind_cq(struct local_prov_ep *ep, size_t fclass,
-			   struct fid *bfid, uint64_t flags)
-{
-	struct fid_ep **ep_ctx;
-	size_t size;
-	size_t i;
-	int rc;
-
-	rc = lnx_get_ctx(ep, fclass, &ep_ctx, &size);
-	if (rc)
-		return rc;
-
-	for (i = 0; i < size; i++) {
-		rc = fi_ep_bind(ep_ctx[i], bfid, flags);
-		if (rc)
-			return rc;
-	}
-
-	return FI_SUCCESS;
-}
-
-static int
-lnx_ctx_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
-{
-	int rc;
-	struct lnx_ep *lep;
-	struct lnx_ctx *ctx;
-	struct local_prov_ep *ep;
-	struct local_prov *entry;
-	struct lnx_fabric *fabric;
-
-	if (fid->fclass != FI_CLASS_RX_CTX &&
-	    fid->fclass != FI_CLASS_TX_CTX)
-		return -FI_EINVAL;
-
-	ctx = container_of(fid, struct lnx_ctx, ctx_ep.fid);
-	lep = ctx->ctx_parent;
-
-	fabric = lep->le_domain->ld_fabric;
-
-	dlist_foreach_container(&fabric->local_prov_table, struct local_prov,
-				entry, lpv_entry) {
-		dlist_foreach_container(&entry->lpv_prov_eps,
-			struct local_prov_ep, ep, entry) {
-			if (bfid->fclass == FI_CLASS_CQ)
-				/* bind the context to the shared cq */
-				rc = lnx_ctx_bind_cq(ep, fid->fclass,
-						&ep->lpe_cq.lpc_core_cq->fid,
-						flags);
-			else
-				return -FI_ENOSYS;
-
-			if (rc)
-				return rc;
-		}
-	}
-
-	return FI_SUCCESS;
-}
-
-static int
-lnx_enable_ctx_eps(struct local_prov_ep *ep, size_t fclass)
-{
-	struct fid_ep **ep_ctx;
-	size_t size;
-	size_t i;
-	int rc;
-
-	rc = lnx_get_ctx(ep, fclass, &ep_ctx, &size);
-	if (rc)
-		return rc;
-
-	for (i = 0; i < size; i++) {
-		rc = fi_enable(ep_ctx[i]);
-		if (rc)
-			return rc;
-	}
-
-	return FI_SUCCESS;
-}
-
-static int
-lnx_ctx_control(struct fid *fid, int command, void *arg)
-{
-	int rc;
-	struct lnx_ep *lep;
-	struct lnx_ctx *ctx;
-	struct local_prov_ep *ep;
-	struct local_prov *entry;
-	struct lnx_fabric *fabric;
-
-	if (fid->fclass != FI_CLASS_RX_CTX &&
-	    fid->fclass != FI_CLASS_TX_CTX)
-		return -FI_EINVAL;
-
-	ctx = container_of(fid, struct lnx_ctx, ctx_ep.fid);
-	lep = ctx->ctx_parent;
-
-	fabric = lep->le_domain->ld_fabric;
-
-	switch (command) {
-	case FI_ENABLE:
-		if (!lep->le_peer_tbl)
-			return -FI_ENOAV;
-		dlist_foreach_container(&fabric->local_prov_table, struct local_prov,
-					entry, lpv_entry) {
-			dlist_foreach_container(&entry->lpv_prov_eps,
-				struct local_prov_ep, ep, entry) {
-				rc = lnx_enable_ctx_eps(ep, fid->fclass);
-				if (rc)
-					return rc;
-			}
-		}
-		break;
-	default:
-		return -FI_ENOSYS;
-	}
-
-	return rc;
-}
-
-static struct fi_ops lnx_ctx_ops = {
-	.size = sizeof(struct fi_ops),
-	.close = lnx_ctx_close,
-	.bind = lnx_ctx_bind,
-	.control = lnx_ctx_control,
-	.ops_open = fi_no_ops_open,
-};
-
-struct fi_ops_ep lnx_ctx_ep_ops = {
-	.size = sizeof(struct fi_ops_ep),
-	.cancel = lnx_ep_cancel,
-	.getopt = fi_no_getopt,
-	.setopt = fi_no_setopt,
-	.tx_ctx = fi_no_tx_ctx,
-	.rx_ctx = fi_no_rx_ctx,
-	.rx_size_left = fi_no_rx_size_left,
-	.tx_size_left = fi_no_tx_size_left,
-};
-
-static void
-lnx_init_ctx(struct fid_ep *ctx, size_t fclass)
-{
-	ctx->fid.fclass = fclass;
-	ctx->fid.ops = &lnx_ctx_ops;
-	ctx->ops = &lnx_ctx_ep_ops;
-	ctx->msg = &lnx_msg_ops;
-	ctx->tagged = &lnx_tagged_ops;
-	ctx->rma = &lnx_rma_ops;
-	ctx->atomic = &lnx_atomic_ops;
+	dlist_init(&qp->lqp_recvq.lq_queue);
+	dlist_init(&qp->lqp_unexq.lq_queue);
+	qp->lqp_recvq.lq_match_func = recvq_match_func;
+	qp->lqp_unexq.lq_match_func = unexq_match_func;
 }
 
 static int
@@ -1090,77 +521,73 @@ lnx_alloc_endpoint(struct fid_domain *domain, struct fi_info *info,
 		   struct lnx_ep **out_ep, void *context, size_t fclass)
 {
 	int rc;
-	struct lnx_ep *ep;
-	struct local_prov *entry;
-	struct lnx_fabric *fabric;
-	uint64_t mr_mode;
+	struct lnx_ep *lep;
+	struct ofi_bufpool_attr bp_attrs = {0};
 
-	ep = calloc(1, sizeof(*ep));
-	if (!ep)
+	lep = calloc(1, sizeof(*lep));
+	if (!lep)
 		return -FI_ENOMEM;
 
-	ep->le_fclass = fclass;
-	ep->le_ep.ep_fid.fid.fclass = fclass;
+	lep->le_fclass = fclass;
+	lep->le_ep.ep_fid.fid.fclass = fclass;
 
-	ep->le_ep.ep_fid.fid.ops = &lnx_ep_fi_ops;
-	ep->le_ep.ep_fid.ops = &lnx_ep_ops;
-	ep->le_ep.ep_fid.cm = &lnx_cm_ops;
-	ep->le_ep.ep_fid.msg = &lnx_msg_ops;
-	ep->le_ep.ep_fid.tagged = &lnx_tagged_ops;
-	ep->le_ep.ep_fid.rma = &lnx_rma_ops;
-	ep->le_ep.ep_fid.atomic = &lnx_atomic_ops;
-	ep->le_domain = container_of(domain, struct lnx_domain,
+	lep->le_ep.ep_fid.fid.ops = &lnx_ep_fi_ops;
+	lep->le_ep.ep_fid.ops = &lnx_ep_ops;
+	lep->le_ep.ep_fid.cm = &lnx_cm_ops;
+	lep->le_ep.ep_fid.msg = &lnx_msg_ops;
+	lep->le_ep.ep_fid.tagged = &lnx_tagged_ops;
+	lep->le_ep.ep_fid.rma = &lnx_rma_ops;
+	lep->le_ep.ep_fid.atomic = &lnx_atomic_ops;
+	lep->le_domain = container_of(domain, struct lnx_domain,
 				     ld_domain.domain_fid);
-	lnx_init_srq(&ep->le_srq);
+	lnx_init_qpair(&lep->le_srq.lps_trecv, lnx_match_recvq, lnx_match_unexq);
+	lnx_init_qpair(&lep->le_srq.lps_recv, lnx_match_recvq, lnx_match_unexq);
 
-	dlist_init(&ep->le_rx_ctx);
-	dlist_init(&ep->le_tx_ctx);
+	ofi_genlock_lock(&lep->le_domain->ld_domain.lock);
+	lep->le_idx = lep->le_domain->ld_ep_idx++;
+	ofi_genlock_unlock(&lep->le_domain->ld_domain.lock);
 
-	fabric = ep->le_domain->ld_fabric;
-
-	/* create all the core provider endpoints */
-	dlist_foreach_container(&fabric->local_prov_table, struct local_prov,
-				entry, lpv_entry) {
-		rc = lnx_open_eps(entry, info, context, fclass, ep);
-		if (rc) {
-			FI_WARN(&lnx_prov, FI_LOG_CORE,
-				"Failed to create ep for %s\n",
-				entry->lpv_prov_name);
-			goto fail;
-		}
+	lep->le_core_eps = calloc(sizeof(*lep->le_core_eps),
+				  lep->le_domain->ld_num_doms);
+	if (!lep->le_core_eps) {
+		free(lep);
+		return -FI_ENOMEM;
 	}
 
-	mr_mode = lnx_util_prov.info->domain_attr->mr_mode;
-	lnx_util_prov.info->domain_attr->mr_mode = 0;
+	/* create a buffer pool for the receive requests */
+	bp_attrs.size = sizeof(struct lnx_rx_entry);
+	bp_attrs.alignment = 8;
+	bp_attrs.max_cnt = UINT16_MAX;
+	bp_attrs.chunk_cnt = 64;
+	bp_attrs.flags = OFI_BUFPOOL_NO_TRACK;
+	rc = ofi_bufpool_create_attr(&bp_attrs, &lep->le_recv_bp);
+	if (rc) {
+		FI_WARN(&lnx_prov, FI_LOG_FABRIC,
+			"Failed to create receive buffer pool");
+		goto fail;
+	}
+	rc = ofi_spin_init(&lep->le_bplock);
+	if (rc)
+		goto fail;
+
+	rc = lnx_open_core_eps(lep, context);
+	if (rc) 
+		goto fail;
+
 	rc = ofi_endpoint_init(domain, (const struct util_prov *)&lnx_util_prov,
-			       (struct fi_info *)lnx_util_prov.info, &ep->le_ep,
+			       info, &lep->le_ep,
 			       context, lnx_ep_nosys_progress);
 	if (rc)
 		goto fail;
 
-	lnx_util_prov.info->domain_attr->mr_mode = mr_mode;
-	*out_ep = ep;
+	*out_ep = lep;
 
 	return 0;
 
 fail:
-	free(ep);
+	free(lep->le_core_eps);
+	free(lep);
 	return rc;
-}
-
-int lnx_scalable_ep(struct fid_domain *domain, struct fi_info *info,
-		    struct fid_ep **ep, void *context)
-{
-	int rc;
-	struct lnx_ep *my_ep;
-
-	rc = lnx_alloc_endpoint(domain, info, &my_ep, context, FI_CLASS_SEP);
-	if (rc)
-		return rc;
-
-	*ep = &my_ep->le_ep.ep_fid;
-
-	return 0;
 }
 
 int lnx_endpoint(struct fid_domain *domain, struct fi_info *info,

--- a/prov/lnx/src/lnx_init.c
+++ b/prov/lnx/src/lnx_init.c
@@ -751,6 +751,9 @@ LNX_INI
 	fi_param_define(&lnx_prov, "disable_shm", FI_PARAM_BOOL,
 			"Turn off SHM support. Defaults to 0");
 
+	fi_param_define(&lnx_prov, "dump_stats", FI_PARAM_BOOL,
+			"Dump LNX stats on shutdown. Defaults to 0");
+
 	dlist_init(&lnx_links);
 
 	if (!global_recv_bp) {

--- a/prov/lnx/src/lnx_mr.c
+++ b/prov/lnx/src/lnx_mr.c
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2025 ORNL. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "config.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <dirent.h>
+#include <ctype.h>
+
+#include <rdma/fi_errno.h>
+#include "ofi_util.h"
+#include "ofi.h"
+#include "ofi_str.h"
+#include "ofi_prov.h"
+#include "ofi_perf.h"
+#include "ofi_hmem.h"
+#include "rdma/fi_ext.h"
+#include "lnx.h"
+
+/*
+ * 1. On MR registration we store the information passed in the fi_mr_attr
+ * 2. If we get a bind, we flag it and store the flags and fid pointer
+ * 3. If we get a control command we flag it and store the command
+ * 4. When a data operation we're passed the descriptor, using that we can
+ * find out the information we stored, and since we already know the
+ * target core provider we can do memory registration at that point
+ */
+
+int lnx_mr_regattr_core(struct lnx_core_domain *cd, void *desc, void **core_desc)
+{
+	int rc;
+	struct lnx_mr *lm;
+
+	lm = (struct lnx_mr *)desc;
+	if (lm->lm_core_mr)
+		goto out;
+
+	rc = fi_mr_regattr(cd->cd_domain, &lm->lm_attr, lm->lm_mr.flags,
+			   &lm->lm_core_mr);
+	if (rc)
+		return rc;
+
+out:
+	*core_desc = lm->lm_core_mr->mem_desc;
+	return FI_SUCCESS;
+}
+
+static int lnx_mr_close(struct fid *fid)
+{
+	int rc, frc = FI_SUCCESS;
+	struct lnx_mr *lm;
+
+	lm = container_of(fid, struct lnx_mr, lm_mr.mr_fid.fid);
+
+	if (lm->lm_core_mr) {
+		rc = fi_close(&lm->lm_core_mr->fid);
+		if (rc)
+			frc = rc;
+	}
+
+	ofi_atomic_dec32(&lm->lm_mr.domain->ref);
+
+	ofi_buf_free(lm);
+
+	return frc;
+}
+
+static int lnx_mr_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
+{
+	return -FI_ENOSYS;
+}
+
+static int lnx_mr_control(struct fid *fid, int command, void *arg)
+{
+	return -FI_ENOSYS;
+}
+
+static struct fi_ops lnx_mr_fi_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = lnx_mr_close,
+	.bind = lnx_mr_bind,
+	.control = lnx_mr_control,
+	.ops_open = fi_no_ops_open
+};
+
+int lnx_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
+		   uint64_t flags, struct fid_mr **mr_fid)
+{
+	struct lnx_domain *domain;
+	struct ofi_mr *mr;
+	struct lnx_mr *lm = NULL;
+
+	if (fid->fclass != FI_CLASS_DOMAIN || !attr ||
+	    attr->iov_count <= 0 || attr->iov_count > LNX_IOV_LIMIT)
+		return -FI_EINVAL;
+
+	domain = container_of(fid, struct lnx_domain, ld_domain.domain_fid.fid);
+
+	lm = ofi_buf_alloc(domain->ld_mem_reg_bp);
+	if (!lm)
+		return -FI_ENOMEM;
+
+	memset(lm, 0, sizeof(*lm));
+
+	lm->lm_attr = *attr;
+	memcpy(lm->lm_iov, attr->mr_iov, sizeof(struct iovec) * attr->iov_count);
+	lm->lm_attr.mr_iov = lm->lm_iov;
+	mr = &lm->lm_mr;
+	mr->mr_fid.fid.fclass = FI_CLASS_MR;
+	mr->mr_fid.fid.ops = &lnx_mr_fi_ops;
+	mr->mr_fid.mem_desc = lm;
+	mr->domain = &domain->ld_domain;
+	mr->flags = flags | FI_HMEM_DEVICE_ONLY;
+
+	*mr_fid = &mr->mr_fid;
+	ofi_atomic_inc32(&domain->ld_domain.ref);
+
+	return FI_SUCCESS;
+}
+
+

--- a/prov/lnx/src/lnx_ops.c
+++ b/prov/lnx/src/lnx_ops.c
@@ -70,61 +70,20 @@ void lnx_free_entry(struct fi_peer_rx_entry *entry)
 	if (rx_entry->rx_global)
 		bplock = &global_bplock;
 	else
-		bplock = &rx_entry->rx_cep->lpe_bplock;
+		bplock = &rx_entry->rx_lep->le_bplock;
 
 	ofi_spin_lock(bplock);
 	ofi_buf_free(rx_entry);
 	ofi_spin_unlock(bplock);
 }
 
-static struct lnx_ep *lnx_get_lep(struct fid_ep *ep, struct lnx_ctx **ctx)
-{
-	struct lnx_ep *lep;
-
-	if (ctx)
-		*ctx = NULL;
-
-	switch (ep->fid.fclass) {
-	case FI_CLASS_RX_CTX:
-	case FI_CLASS_TX_CTX:
-		*ctx = container_of(ep, struct lnx_ctx, ctx_ep.fid);
-		lep = (*ctx)->ctx_parent;
-		break;
-	case FI_CLASS_EP:
-	case FI_CLASS_SEP:
-		lep = container_of(ep, struct lnx_ep, le_ep.ep_fid.fid);
-		break;
-	default:
-		lep = NULL;
-	}
-
-	return lep;
-}
-
-static struct fid_ep *lnx_get_core_ep(struct local_prov_ep *cep, int idx,
-				      size_t fclass)
-{
-	switch (fclass) {
-	case FI_CLASS_RX_CTX:
-		return cep->lpe_rxc[idx];
-	case FI_CLASS_TX_CTX:
-		return cep->lpe_txc[idx];
-	case FI_CLASS_EP:
-	case FI_CLASS_SEP:
-		return cep->lpe_ep;
-	default:
-		return NULL;
-	}
-
-	return NULL;
-}
-
 static void
-lnx_init_rx_entry(struct lnx_rx_entry *entry, struct iovec *iov, void **desc,
-		  size_t count, fi_addr_t addr, uint64_t tag,
+lnx_init_rx_entry(struct lnx_rx_entry *entry, const struct iovec *iov,
+		  void **desc, size_t count, fi_addr_t addr, uint64_t tag,
 		  uint64_t ignore, void *context, uint64_t flags)
 {
-	memcpy(&entry->rx_iov, iov, sizeof(*iov) * count);
+	if (iov)
+		memcpy(&entry->rx_iov, iov, sizeof(*iov) * count);
 	if (desc)
 		memcpy(entry->rx_desc, desc, sizeof(*desc) * count);
 
@@ -134,14 +93,15 @@ lnx_init_rx_entry(struct lnx_rx_entry *entry, struct iovec *iov, void **desc,
 	entry->rx_entry.addr = addr;
 	entry->rx_entry.context = context;
 	entry->rx_entry.tag = tag;
-	entry->rx_entry.flags = flags;
+	entry->rx_entry.flags = flags | FI_TAGGED | FI_RECV;
 	entry->rx_ignore = ignore;
 }
 
 static struct lnx_rx_entry *
-get_rx_entry(struct local_prov_ep *cep, struct iovec *iov, void **desc,
-	size_t count, fi_addr_t addr, uint64_t tag,
-	uint64_t ignore, void *context, uint64_t flags)
+get_rx_entry(struct lnx_ep *lep, const struct iovec *iov,
+	     void **desc, size_t count, fi_addr_t addr,
+	     uint64_t tag, uint64_t ignore, void *context,
+	     uint64_t flags)
 {
 	struct lnx_rx_entry *rx_entry = NULL;
 	ofi_spin_t *bplock;
@@ -150,12 +110,12 @@ get_rx_entry(struct local_prov_ep *cep, struct iovec *iov, void **desc,
 	/* if lp is NULL, then we don't know where the message is going to
 	 * come from, so allocate the rx_entry from a global pool
 	 */
-	if (!cep) {
+	if (!lep) {
 		bp = global_recv_bp;
 		bplock = &global_bplock;
 	} else {
-		bp = cep->lpe_recv_bp;
-		bplock = &cep->lpe_bplock;
+		bp = lep->le_recv_bp;
+		bplock = &lep->le_bplock;
 	}
 
 	ofi_spin_lock(bplock);
@@ -163,12 +123,23 @@ get_rx_entry(struct local_prov_ep *cep, struct iovec *iov, void **desc,
 	ofi_spin_unlock(bplock);
 	if (rx_entry) {
 		memset(rx_entry, 0, sizeof(*rx_entry));
-		if (!cep)
+		if (!lep)
 			rx_entry->rx_global = true;
-		rx_entry->rx_cep = cep;
+		rx_entry->rx_lep = lep;
 		lnx_init_rx_entry(rx_entry, iov, desc, count, addr, tag,
 				  ignore, context, flags);
 	}
+
+	return rx_entry;
+}
+
+static inline struct lnx_rx_entry *
+lnx_find_first_match(struct lnx_queue *q, struct lnx_match_attr *match)
+{
+	struct lnx_rx_entry *rx_entry;
+
+	rx_entry = (struct lnx_rx_entry *) dlist_find_first_match(
+			&q->lq_queue, q->lq_match_func, match);
 
 	return rx_entry;
 }
@@ -178,10 +149,8 @@ lnx_remove_first_match(struct lnx_queue *q, struct lnx_match_attr *match)
 {
 	struct lnx_rx_entry *rx_entry;
 
-	ofi_spin_lock(&q->lq_qlock);
 	rx_entry = (struct lnx_rx_entry *) dlist_remove_first_match(
 			&q->lq_queue, q->lq_match_func, match);
-	ofi_spin_unlock(&q->lq_qlock);
 
 	return rx_entry;
 }
@@ -189,10 +158,8 @@ lnx_remove_first_match(struct lnx_queue *q, struct lnx_match_attr *match)
 static inline void
 lnx_insert_rx_entry(struct lnx_queue *q, struct lnx_rx_entry *entry)
 {
-	ofi_spin_lock(&q->lq_qlock);
 	dlist_insert_tail((struct dlist_entry *)(&entry->rx_entry),
 			  &q->lq_queue);
-	ofi_spin_unlock(&q->lq_qlock);
 }
 
 int lnx_queue_tag(struct fi_peer_rx_entry *entry)
@@ -212,75 +179,123 @@ int lnx_queue_tag(struct fi_peer_rx_entry *entry)
 int lnx_get_tag(struct fid_peer_srx *srx, struct fi_peer_match_attr *match,
 		struct fi_peer_rx_entry **entry)
 {
-	struct lnx_match_attr match_attr;
+	struct lnx_match_attr match_attr = {0};
 	struct lnx_peer_srq *lnx_srq;
-	struct local_prov_ep *cep;
+	struct lnx_core_ep *cep;
 	struct lnx_ep *lep;
 	struct lnx_rx_entry *rx_entry;
 	fi_addr_t addr = match->addr;
-	struct lnx_srx_context *srx_ctxt;
 	uint64_t tag = match->tag;
 	int rc = 0;
 
-	/* get the endpoint */
-	cep = container_of(srx, struct local_prov_ep, lpe_srx);
-	srx_ctxt = cep->lpe_srx.ep_fid.fid.context;
-	cep = srx_ctxt->srx_cep;
-	lep = srx_ctxt->srx_lep;
+	cep = srx->ep_fid.fid.context;
+	lep = cep->cep_parent;
 	lnx_srq = &lep->le_srq;
 
-	/* The fi_addr_t is a generic address returned by the provider. It's usually
-	 * just an index or id in their AV table. When I get it here, I could have
-	 * duplicates if multiple providers are using the same scheme to
-	 * insert in the AV table. I need to be able to identify the provider
-	 * in this function so I'm able to correctly match this message to
-	 * a possible rx entry on my receive queue. That's why we need to make
-	 * sure we use the core endpoint as part of the matching key.
-	 */
-	memset(&match_attr, 0, sizeof(match_attr));
-
 	match_attr.lm_addr = addr;
-	match_attr.lm_ignore = 0;
 	match_attr.lm_tag = tag;
-	match_attr.lm_cep = cep;
 
-	/*  1. Find a matching request to the message received.
-	 *  2. Return the receive request.
-	 *  3. If there are no matching requests, then create a new one
-	 *     and return it to the core provider. The core provider will turn
-	 *     around and tell us to queue it. Return -FI_ENOENT.
-	 */
 	rx_entry = lnx_remove_first_match(&lnx_srq->lps_trecv.lqp_recvq,
 					  &match_attr);
 	if (rx_entry) {
 		FI_DBG(&lnx_prov, FI_LOG_CORE,
 		       "addr = %lx tag = %lx ignore = 0 found\n",
-		       addr, tag);
+		       match_attr.lm_addr, tag);
 
 		goto assign;
 	}
 
 	FI_DBG(&lnx_prov, FI_LOG_CORE,
 	       "addr = %lx tag = %lx ignore = 0 not found\n",
-	       addr, tag);
+	       match_attr.lm_addr, tag);
 
-	rx_entry = get_rx_entry(cep, NULL, NULL, 0, addr, tag, 0, NULL,
-				lnx_ep_rx_flags(lep));
+	rx_entry = get_rx_entry(lep, NULL, NULL, 0, addr, tag, 0, NULL,
+				FI_TAGGED | FI_RECV);
 	if (!rx_entry) {
 		rc = -FI_ENOMEM;
 		goto out;
 	}
 
-	rx_entry->rx_match_info = *match;
 	rx_entry->rx_entry.owner_context = lnx_srq;
-	rx_entry->rx_entry.msg_size = match->msg_size;
+	rx_entry->rx_cep = cep;
 
 	rc = -FI_ENOENT;
 
+	goto finalize;
+
 assign:
-	rx_entry->rx_entry.msg_size = MIN(rx_entry->rx_entry.msg_size,
-				      match->msg_size);
+	rx_entry->rx_entry.addr = lnx_get_core_addr(cep, addr);
+	if (rx_entry->rx_entry.desc && *rx_entry->rx_entry.desc) {
+		rc = lnx_mr_regattr_core(cep->cep_domain,
+					 *rx_entry->rx_entry.desc,
+					 rx_entry->rx_entry.desc);
+		if (rc)
+			return rc;
+	}
+finalize:
+	rx_entry->rx_entry.msg_size = match->msg_size;
 	*entry = &rx_entry->rx_entry;
+
+out:
+	return rc;
+}
+
+static int
+lnx_discard(struct lnx_ep *lep, struct lnx_rx_entry *rx_entry, void *context)
+{
+	struct lnx_core_ep *cep = rx_entry->rx_cep;
+	int rc;
+
+	rc = cep->cep_srx.peer_ops->discard_tag(&rx_entry->rx_entry);
+	if (rc) {
+		FI_WARN(&lnx_prov, FI_LOG_CORE,
+			"Error discarding message from %s\n",
+			cep->cep_domain->cd_info->fabric_attr->name);
+	}
+
+	rc = ofi_cq_write(lep->le_ep.rx_cq, context,
+			  rx_entry->rx_entry.flags,
+			  rx_entry->rx_entry.msg_size, NULL,
+			  rx_entry->rx_entry.cq_data,
+			  rx_entry->rx_entry.tag);
+
+	lnx_free_entry(&rx_entry->rx_entry);
+
+	return rc;
+}
+
+static int
+lnx_peek(struct lnx_ep *lep, struct lnx_match_attr *match_attr, void *context,
+	 uint64_t flags)
+{
+	int rc;
+	struct lnx_rx_entry *rx_entry;
+	struct lnx_peer_srq *lnx_srq = &lep->le_srq;
+
+	rx_entry = lnx_find_first_match(&lnx_srq->lps_trecv.lqp_unexq,
+					match_attr);
+	if (!rx_entry) {
+		FI_DBG(&lnx_prov, FI_LOG_CORE,
+			"PEEK addr=%lx tag=%lx ignore=%lx\n",
+			match_attr->lm_addr, match_attr->lm_tag,
+			match_attr->lm_ignore);
+		return ofi_cq_write_error_peek(lep->le_ep.rx_cq,
+				match_attr->lm_tag, context);
+	}
+
+	rc = ofi_cq_write(lep->le_ep.rx_cq, context,
+			  rx_entry->rx_entry.flags,
+			  rx_entry->rx_entry.msg_size, NULL,
+			  rx_entry->rx_entry.cq_data,
+			  rx_entry->rx_entry.tag);
+
+	if (flags & FI_DISCARD) {
+		lnx_free_entry(&rx_entry->rx_entry);
+		goto out;
+	}
+
+	if (flags & FI_CLAIM)
+		((struct fi_context *)context)->internal[0] = rx_entry;
 
 out:
 	return rc;
@@ -302,54 +317,75 @@ out:
  * If nothing is found on the unexpected messages, then add a receive
  * request on the SRQ; happens in the lnx_process_recv()
  */
-static int lnx_process_recv(struct lnx_ep *lep, struct iovec *iov, void **desc,
-			fi_addr_t addr, size_t count, struct lnx_peer *lp, uint64_t tag,
+static int lnx_process_recv(struct lnx_ep *lep, const struct iovec *iov, void *desc,
+			fi_addr_t addr, size_t count, uint64_t tag,
 			uint64_t ignore, void *context, uint64_t flags,
 			bool tagged)
 {
 	struct lnx_peer_srq *lnx_srq = &lep->le_srq;
-	struct local_prov_ep *cep;
 	struct lnx_rx_entry *rx_entry;
 	struct lnx_match_attr match_attr;
+	struct lnx_core_ep *cep;
 	int rc = 0;
+	fi_addr_t sub_addr, encoded_addr = lnx_encode_fi_addr(addr, 0);
 
-	match_attr.lm_addr = addr;
+	/* Matching format should always be in the encoded form */
+	match_attr.lm_addr = (addr == FI_ADDR_UNSPEC) ||
+		!(lep->le_ep.caps & FI_DIRECTED_RECV) ? FI_ADDR_UNSPEC :
+		encoded_addr;
 	match_attr.lm_ignore = ignore;
 	match_attr.lm_tag = tag;
-	match_attr.lm_cep = NULL;
-	match_attr.lm_peer = lp;
 
-	/* if support is turned off, don't go down the SRQ path */
-	if (!lep->le_domain->ld_srx_supported)
-		return -FI_ENOSYS;
+	if (flags & FI_PEEK)
+		return lnx_peek(lep, &match_attr, context, flags);
 
-	rx_entry = lnx_remove_first_match(&lnx_srq->lps_trecv.lqp_unexq,
-					  &match_attr);
-	if (!rx_entry) {
-		FI_DBG(&lnx_prov, FI_LOG_CORE,
-		       "addr=%lx tag=%lx ignore=%lx buf=%p len=%lx not found\n",
-		       addr, tag, ignore, iov->iov_base, iov->iov_len);
+	if (flags & FI_DISCARD) {
+		rx_entry = (struct lnx_rx_entry *)
+			(((struct fi_context *)context)->internal[0]);
+		return lnx_discard(lep, rx_entry, context);
+	}
 
-		goto nomatch;
+	if (flags & FI_CLAIM) {
+		rx_entry = (struct lnx_rx_entry *)
+			(((struct fi_context *)context)->internal[0]);
+	} else {
+		rx_entry = lnx_remove_first_match(&lnx_srq->lps_trecv.lqp_unexq,
+						&match_attr);
+		if (!rx_entry) {
+			FI_DBG(&lnx_prov, FI_LOG_CORE,
+			"addr=%lx tag=%lx ignore=%lx buf=%p len=%lx not found\n",
+			addr, tag, ignore, iov->iov_base, iov->iov_len);
+
+			goto nomatch;
+		}
 	}
 
 	FI_DBG(&lnx_prov, FI_LOG_CORE,
 	       "addr=%lx tag=%lx ignore=%lx buf=%p len=%lx found\n",
 	       addr, tag, ignore, iov->iov_base, iov->iov_len);
 
-	cep = rx_entry->rx_cep;
-
 	/* match is found in the unexpected queue. call into the core
 	 * provider to complete this message
 	 */
-	lnx_init_rx_entry(rx_entry, iov, desc, count, addr, tag, ignore,
-			  context, lnx_ep_rx_flags(lep));
+	cep = rx_entry->rx_cep;
+	sub_addr = lnx_get_core_addr(cep, rx_entry->rx_entry.addr);
+	lnx_init_rx_entry(rx_entry, iov, desc, count, sub_addr,
+			  tag, ignore, context,
+			  rx_entry->rx_entry.flags | flags);
 	rx_entry->rx_entry.msg_size = MIN(ofi_total_iov_len(iov, count),
-				      rx_entry->rx_entry.msg_size);
+				          rx_entry->rx_entry.msg_size);
+
+	if (desc) {
+		rc = lnx_mr_regattr_core(cep->cep_domain, desc,
+					 rx_entry->rx_entry.desc);
+		if (rc)
+			return rc;
+	}
+
 	if (tagged)
-		rc = cep->lpe_srx.peer_ops->start_tag(&rx_entry->rx_entry);
+		rc = cep->cep_srx.peer_ops->start_tag(&rx_entry->rx_entry);
 	else
-		rc = cep->lpe_srx.peer_ops->start_msg(&rx_entry->rx_entry);
+		rc = cep->cep_srx.peer_ops->start_msg(&rx_entry->rx_entry);
 
 	if (rc == -FI_EINPROGRESS) {
 		/* this is telling me that more messages can match the same
@@ -374,14 +410,13 @@ nomatch:
 	/* nothing on the unexpected queue, then allocate one and put it on
 	 * the receive queue
 	 */
-	rx_entry = get_rx_entry(NULL, iov, desc, count, addr, tag, ignore,
-				context, lnx_ep_rx_flags(lep));
-	rx_entry->rx_entry.msg_size = ofi_total_iov_len(iov, count);
+	rx_entry = get_rx_entry(NULL, iov, (desc) ? &desc : NULL, count,
+				match_attr.lm_addr, tag, ignore, context,
+				flags);
 	if (!rx_entry) {
 		rc = -FI_ENOMEM;
 		goto out;
 	}
-	rx_entry->rx_peer = lp;
 
 insert_recvq:
 	lnx_insert_rx_entry(&lnx_srq->lps_trecv.lqp_recvq, rx_entry);
@@ -393,155 +428,66 @@ out:
 ssize_t lnx_trecv(struct fid_ep *ep, void *buf, size_t len, void *desc,
 		fi_addr_t src_addr, uint64_t tag, uint64_t ignore, void *context)
 {
-	int rc;
 	struct lnx_ep *lep;
-	struct local_prov_ep *cep = NULL;
-	fi_addr_t core_addr = FI_ADDR_UNSPEC;
-	struct lnx_peer_table *peer_tbl;
-	void *mem_desc;
-	struct iovec iov = {.iov_base = buf, .iov_len = len};
-	struct lnx_peer *lp;
-	struct ofi_mr_entry *mre = NULL;
+	const struct iovec iov = {.iov_base = buf, .iov_len = len};
 
-	lep = lnx_get_lep(ep, NULL);
+	lep = container_of(ep, struct lnx_ep, le_ep.ep_fid.fid);
 	if (!lep)
 		return -FI_ENOSYS;
 
-	peer_tbl = lep->le_peer_tbl;
-
-	lnx_get_core_desc(desc, &mem_desc);
-
-	/* addr is an index into the peer table.
-	 * This gets us to a peer. Each peer can be reachable on
-	 * multiple endpoints. Each endpoint has its own fi_addr_t which is
-	 * core provider specific.
-	 */
-	lp = lnx_av_lookup_addr(peer_tbl, src_addr);
-	if (lp) {
-		rc = lnx_select_recv_pathway(lp, lep->le_domain, desc, &cep,
-					     &core_addr, &iov, 1, &mre, &mem_desc);
-		if (rc)
-			goto out;
-	}
-
-	rc = lnx_process_recv(lep, &iov, &mem_desc, src_addr, 1, lp, tag, ignore,
-			      context, 0, true);
-	if (rc == -FI_ENOSYS)
-		goto do_recv;
-	else if (rc)
-		FI_WARN(&lnx_prov, FI_LOG_CORE, "lnx_process_recv failed with %d\n", rc);
-
-	goto out;
-
-do_recv:
-	if (lp)
-		rc = fi_trecv(cep->lpe_ep, buf, len, mem_desc, core_addr, tag, ignore, context);
-
-out:
-	if (mre)
-		ofi_mr_cache_delete(&lep->le_domain->ld_mr_cache, mre);
-
-	return rc;
+	return lnx_process_recv(lep, &iov, desc, src_addr, 1, tag, ignore,
+				context, lnx_ep_rx_flags(lep), true);
 }
 
 ssize_t lnx_trecvv(struct fid_ep *ep, const struct iovec *iov, void **desc,
 		size_t count, fi_addr_t src_addr, uint64_t tag, uint64_t ignore,
 		void *context)
 {
-	int rc;
+	void *mr_desc;
 	struct lnx_ep *lep;
-	struct local_prov_ep *cep = NULL;
-	fi_addr_t core_addr = FI_ADDR_UNSPEC;
-	struct lnx_peer_table *peer_tbl;
-	void *mem_desc;
-	struct lnx_peer *lp;
-	struct ofi_mr_entry *mre = NULL;
 
-	lep = lnx_get_lep(ep, NULL);
+	lep = container_of(ep, struct lnx_ep, le_ep.ep_fid.fid);
 	if (!lep)
 		return -FI_ENOSYS;
 
-	peer_tbl = lep->le_peer_tbl;
-	lnx_get_core_desc(*desc, &mem_desc);
 
-	lp = lnx_av_lookup_addr(peer_tbl, src_addr);
-	if (lp) {
-		rc = lnx_select_recv_pathway(lp, lep->le_domain, *desc, &cep,
-					     &core_addr, iov, count, &mre, &mem_desc);
-		if (rc)
-			goto out;
+	if (count == 0) {
+		mr_desc = NULL;
+	} else if (iov && count >= 1 &&
+		   count <= lep->le_domain->ld_iov_limit) {
+		mr_desc = desc ? desc[0] : NULL;
+	} else {
+		FI_WARN(&lnx_prov, FI_LOG_CORE, "Invalid IOV\n");
+		return -FI_EINVAL;
 	}
 
-	rc = lnx_process_recv(lep, (struct iovec *)iov, &mem_desc, src_addr,
-			      1, lp, tag, ignore, context, 0, true);
-	if (rc == -FI_ENOSYS)
-		goto do_recv;
-
-	goto out;
-
-do_recv:
-	if (lp)
-		rc = fi_trecvv(cep->lpe_ep, iov, &mem_desc, count, core_addr, tag, ignore, context);
-
-out:
-	if (mre)
-		ofi_mr_cache_delete(&lep->le_domain->ld_mr_cache, mre);
-
-	return rc;
+	return lnx_process_recv(lep, iov, mr_desc, src_addr, count, tag, ignore,
+				context, lnx_ep_rx_flags(lep), true);
 }
 
 ssize_t lnx_trecvmsg(struct fid_ep *ep, const struct fi_msg_tagged *msg,
 		     uint64_t flags)
 {
-	int rc;
+	void *mr_desc;
 	struct lnx_ep *lep;
-	struct local_prov_ep *cep = NULL;
-	fi_addr_t core_addr = FI_ADDR_UNSPEC;
-	struct lnx_peer_table *peer_tbl;
-	void *mem_desc;
-	struct lnx_peer *lp;
-	struct fi_msg_tagged core_msg;
-	struct ofi_mr_entry *mre = NULL;
 
-	lep = lnx_get_lep(ep, NULL);
+	lep = container_of(ep, struct lnx_ep, le_ep.ep_fid.fid);
 	if (!lep)
 		return -FI_ENOSYS;
 
-	peer_tbl = lep->le_peer_tbl;
-
-	lp = lnx_av_lookup_addr(peer_tbl, msg->addr);
-	if (lp) {
-		rc = lnx_select_recv_pathway(lp, lep->le_domain, *msg->desc,
-					&cep, &core_addr, msg->msg_iov,
-					msg->iov_count, &mre, &mem_desc);
-		if (rc)
-			goto out;
-	}
-	lnx_get_core_desc(*msg->desc, &mem_desc);
-
-	rc = lnx_process_recv(lep, (struct iovec *)msg->msg_iov, &mem_desc,
-			msg->addr, msg->iov_count, lp, msg->tag, msg->ignore,
-			msg->context, flags, true);
-	if (rc == -FI_ENOSYS)
-		goto do_recv;
-
-	goto out;
-
-do_recv:
-	if (lp) {
-		memcpy(&core_msg, msg, sizeof(*msg));
-
-		core_msg.desc = mem_desc;
-		core_msg.addr = core_addr;
-
-		rc = fi_trecvmsg(cep->lpe_ep, &core_msg, flags);
+	if (msg->iov_count == 0) {
+		mr_desc = NULL;
+	} else if (msg->msg_iov && msg->iov_count >= 1 &&
+		   msg->iov_count <= lep->le_domain->ld_iov_limit) {
+		mr_desc = msg->desc ? msg->desc[0] : NULL;
+	} else {
+		FI_WARN(&lnx_prov, FI_LOG_CORE, "Invalid IOV\n");
+		return -FI_EINVAL;
 	}
 
-out:
-	if (mre)
-		ofi_mr_cache_delete(&lep->le_domain->ld_mr_cache, mre);
-
-	return rc;
+	return lnx_process_recv(lep, msg->msg_iov, mr_desc, msg->addr, msg->iov_count,
+				msg->tag, msg->ignore, msg->context,
+				flags | lep->le_ep.rx_msg_flags, true);
 }
 
 ssize_t lnx_tsend(struct fid_ep *ep, const void *buf, size_t len, void *desc,
@@ -549,23 +495,15 @@ ssize_t lnx_tsend(struct fid_ep *ep, const void *buf, size_t len, void *desc,
 {
 	int rc;
 	struct lnx_ep *lep;
-	struct lnx_peer *lp;
-	struct local_prov_ep *cep;
+	void *core_desc = NULL;
+	struct lnx_core_ep *cep;
 	fi_addr_t core_addr;
-	struct lnx_peer_table *peer_tbl;
-	void *mem_desc;
-	struct ofi_mr_entry *mre = NULL;
-	struct iovec iov = {.iov_base = (void*) buf, .iov_len = len};
 
-	lep = lnx_get_lep(ep, NULL);
+	lep = container_of(ep, struct lnx_ep, le_ep.ep_fid.fid);
 	if (!lep)
 		return -FI_ENOSYS;
 
-	peer_tbl = lep->le_peer_tbl;
-
-	lp = lnx_av_lookup_addr(peer_tbl, dest_addr);
-	rc = lnx_select_send_pathway(lp, lep->le_domain, desc, &cep,
-				     &core_addr, &iov, 1, &mre, &mem_desc, NULL);
+	rc = lnx_select_send_endpoints(lep, dest_addr, &cep, &core_addr);
 	if (rc)
 		return rc;
 
@@ -573,10 +511,13 @@ ssize_t lnx_tsend(struct fid_ep *ep, const void *buf, size_t len, void *desc,
 	       "sending to %lx tag %lx buf %p len %ld\n",
 	       core_addr, tag, buf, len);
 
-	rc = fi_tsend(cep->lpe_ep, buf, len, mem_desc, core_addr, tag, context);
+	if (desc) {
+		rc = lnx_mr_regattr_core(cep->cep_domain, desc, &core_desc);
+		if (rc)
+			return rc;
+	}
 
-	if (mre)
-		ofi_mr_cache_delete(&lep->le_domain->ld_mr_cache, mre);
+	rc = fi_tsend(cep->cep_ep, buf, len, core_desc, core_addr, tag, context);
 
 	return rc;
 }
@@ -586,32 +527,33 @@ ssize_t lnx_tsendv(struct fid_ep *ep, const struct iovec *iov, void **desc,
 {
 	int rc;
 	struct lnx_ep *lep;
-	struct lnx_peer *lp;
-	struct local_prov_ep *cep;
+	void *core_desc = NULL;
+	struct lnx_core_ep *cep;
 	fi_addr_t core_addr;
-	struct lnx_peer_table *peer_tbl;
-	struct ofi_mr_entry *mre = NULL;
-	void *mem_desc;
 
-	lep = lnx_get_lep(ep, NULL);
+	if (count > 1)
+		return -FI_EINVAL;
+
+	lep = container_of(ep, struct lnx_ep, le_ep.ep_fid.fid);
 	if (!lep)
 		return -FI_ENOSYS;
 
-	peer_tbl = lep->le_peer_tbl;
-
-	lp = lnx_av_lookup_addr(peer_tbl, dest_addr);
-	rc = lnx_select_send_pathway(lp, lep->le_domain, (desc) ? *desc : NULL, &cep,
-				&core_addr, iov, count, &mre, &mem_desc, NULL);
+	rc = lnx_select_send_endpoints(lep, dest_addr, &cep, &core_addr);
 	if (rc)
 		return rc;
 
 	FI_DBG(&lnx_prov, FI_LOG_CORE,
-	       "sending to %lx tag %lx\n", core_addr, tag);
+	       "sending to %lx tag %lx buf %p len %ld\n",
+	       core_addr, tag, iov->iov_base, iov->iov_len);
 
-	rc = fi_tsendv(cep->lpe_ep, iov, &mem_desc, count, core_addr, tag, context);
+	if (desc && *desc) {
+		rc = lnx_mr_regattr_core(cep->cep_domain, *desc, &core_desc);
+		if (rc)
+			return rc;
+	}
 
-	if (mre)
-		ofi_mr_cache_delete(&lep->le_domain->ld_mr_cache, mre);
+	rc = fi_tsendv(cep->cep_ep, iov, (core_desc) ? &core_desc : NULL,
+		       count, core_addr, tag, context);
 
 	return rc;
 }
@@ -621,40 +563,35 @@ ssize_t lnx_tsendmsg(struct fid_ep *ep, const struct fi_msg_tagged *msg,
 {
 	int rc;
 	struct lnx_ep *lep;
-	struct lnx_peer *lp;
-	struct local_prov_ep *cep;
-	fi_addr_t core_addr;
-	struct lnx_peer_table *peer_tbl;
-	void *mem_desc;
+	void *core_desc = NULL;
+	struct lnx_core_ep *cep;
 	struct fi_msg_tagged core_msg;
-	struct ofi_mr_entry *mre = NULL;
 
-	lep = lnx_get_lep(ep, NULL);
-	if (!lep)
-		return -FI_ENOSYS;
-
-	peer_tbl = lep->le_peer_tbl;
-
-	lp = lnx_av_lookup_addr(peer_tbl, msg->addr);
-	rc = lnx_select_send_pathway(lp, lep->le_domain,
-				(msg->desc) ? *msg->desc : NULL, &cep,
-				&core_addr, msg->msg_iov,
-				msg->iov_count, &mre, &mem_desc, NULL);
-	if (rc)
-		return rc;
+	if (msg->iov_count > 1)
+		return -FI_EINVAL;
 
 	memcpy(&core_msg, msg, sizeof(*msg));
 
-	core_msg.desc = mem_desc;
-	core_msg.addr = core_addr;
+	lep = container_of(ep, struct lnx_ep, le_ep.ep_fid.fid);
+	if (!lep)
+		return -FI_ENOSYS;
+
+	rc = lnx_select_send_endpoints(lep, core_msg.addr, &cep, &core_msg.addr);
+	if (rc)
+		return rc;
 
 	FI_DBG(&lnx_prov, FI_LOG_CORE,
-	       "sending to %lx tag %lx\n", core_msg.addr, core_msg.tag);
+	       "sending to %lx tag %lx\n",
+	       core_msg.addr, core_msg.tag);
 
-	rc = fi_tsendmsg(cep->lpe_ep, &core_msg, flags);
+	if (core_msg.desc && *core_msg.desc) {
+		rc = lnx_mr_regattr_core(cep->cep_domain, *core_msg.desc, &core_desc);
+		if (rc)
+			return rc;
+		core_msg.desc = &core_desc;
+	}
 
-	if (mre)
-		ofi_mr_cache_delete(&lep->le_domain->ld_mr_cache, mre);
+	rc = fi_tsendmsg(cep->cep_ep, &core_msg, flags);
 
 	return rc;
 }
@@ -664,21 +601,14 @@ ssize_t lnx_tinject(struct fid_ep *ep, const void *buf, size_t len,
 {
 	int rc;
 	struct lnx_ep *lep;
-	struct lnx_peer *lp;
-	struct local_prov_ep *cep;
+	struct lnx_core_ep *cep;
 	fi_addr_t core_addr;
-	struct lnx_peer_table *peer_tbl;
-	struct ofi_mr_entry *mre = NULL;
 
-	lep = lnx_get_lep(ep, NULL);
+	lep = container_of(ep, struct lnx_ep, le_ep.ep_fid.fid);
 	if (!lep)
 		return -FI_ENOSYS;
 
-	peer_tbl = lep->le_peer_tbl;
-
-	lp = lnx_av_lookup_addr(peer_tbl, dest_addr);
-	rc = lnx_select_send_pathway(lp, lep->le_domain, NULL, &cep,
-				&core_addr, NULL, 0, &mre, NULL, NULL);
+	rc = lnx_select_send_endpoints(lep, dest_addr, &cep, &core_addr);
 	if (rc)
 		return rc;
 
@@ -686,10 +616,7 @@ ssize_t lnx_tinject(struct fid_ep *ep, const void *buf, size_t len,
 	       "sending to %lx tag %lx buf %p len %ld\n",
 	       core_addr, tag, buf, len);
 
-	rc = fi_tinject(cep->lpe_ep, buf, len, core_addr, tag);
-
-	if (mre)
-		ofi_mr_cache_delete(&lep->le_domain->ld_mr_cache, mre);
+	rc = fi_tinject(cep->cep_ep, buf, len, core_addr, tag);
 
 	return rc;
 }
@@ -699,23 +626,15 @@ ssize_t lnx_tsenddata(struct fid_ep *ep, const void *buf, size_t len, void *desc
 {
 	int rc;
 	struct lnx_ep *lep;
-	struct lnx_peer *lp;
-	struct local_prov_ep *cep;
+	struct lnx_core_ep *cep;
 	fi_addr_t core_addr;
-	struct lnx_peer_table *peer_tbl;
-	void *mem_desc;
-	struct ofi_mr_entry *mre = NULL;
-	struct iovec iov = {.iov_base = (void*)buf, .iov_len = len};
+	void *core_desc = desc;
 
-	lep = lnx_get_lep(ep, NULL);
+	lep = container_of(ep, struct lnx_ep, le_ep.ep_fid.fid);
 	if (!lep)
 		return -FI_ENOSYS;
 
-	peer_tbl = lep->le_peer_tbl;
-
-	lp = lnx_av_lookup_addr(peer_tbl, dest_addr);
-	rc = lnx_select_send_pathway(lp, lep->le_domain, desc, &cep,
-				&core_addr, &iov, 1, &mre, &mem_desc, NULL);
+	rc = lnx_select_send_endpoints(lep, dest_addr, &cep, &core_addr);
 	if (rc)
 		return rc;
 
@@ -723,11 +642,14 @@ ssize_t lnx_tsenddata(struct fid_ep *ep, const void *buf, size_t len, void *desc
 	       "sending to %lx tag %lx buf %p len %ld\n",
 	       core_addr, tag, buf, len);
 
-	rc = fi_tsenddata(cep->lpe_ep, buf, len, mem_desc,
-			  data, core_addr, tag, context);
+	if (desc) {
+		rc = lnx_mr_regattr_core(cep->cep_domain, desc, &core_desc);
+		if (rc)
+			return rc;
+	}
 
-	if (mre)
-		ofi_mr_cache_delete(&lep->le_domain->ld_mr_cache, mre);
+	rc = fi_tsenddata(cep->cep_ep, buf, len, core_desc,
+			  data, core_addr, tag, context);
 
 	return rc;
 }
@@ -737,21 +659,14 @@ ssize_t lnx_tinjectdata(struct fid_ep *ep, const void *buf, size_t len,
 {
 	int rc;
 	struct lnx_ep *lep;
-	struct lnx_peer *lp;
-	struct local_prov_ep *cep;
+	struct lnx_core_ep *cep;
 	fi_addr_t core_addr;
-	struct lnx_peer_table *peer_tbl;
-	struct ofi_mr_entry *mre = NULL;
 
-	lep = lnx_get_lep(ep, NULL);
+	lep = container_of(ep, struct lnx_ep, le_ep.ep_fid.fid);
 	if (!lep)
 		return -FI_ENOSYS;
 
-	peer_tbl = lep->le_peer_tbl;
-
-	lp = lnx_av_lookup_addr(peer_tbl, dest_addr);
-	rc = lnx_select_send_pathway(lp, lep->le_domain, NULL, &cep,
-				     &core_addr, NULL, 0, &mre, NULL, NULL);
+	rc = lnx_select_send_endpoints(lep, dest_addr, &cep, &core_addr);
 	if (rc)
 		return rc;
 
@@ -759,245 +674,8 @@ ssize_t lnx_tinjectdata(struct fid_ep *ep, const void *buf, size_t len,
 	       "sending to %lx tag %lx buf %p len %ld\n",
 	       core_addr, tag, buf, len);
 
-	rc = fi_tinjectdata(cep->lpe_ep, buf, len, data, core_addr, tag);
+	rc = fi_tinjectdata(cep->cep_ep, buf, len, data, core_addr, tag);
 
-	if (mre)
-		ofi_mr_cache_delete(&lep->le_domain->ld_mr_cache, mre);
-
-	return rc;
-}
-
-static inline ssize_t
-lnx_rma_read(struct fid_ep *ep, void *buf, size_t len, void *desc,
-	fi_addr_t src_addr, uint64_t addr, uint64_t key, void *context)
-{
-	int rc;
-	struct lnx_ep *lep;
-	struct lnx_peer *lp;
-	struct fid_ep *core_ep;
-	struct lnx_ctx *ctx;
-	struct local_prov_ep *cep;
-	fi_addr_t core_addr;
-	struct lnx_peer_table *peer_tbl;
-	void *mem_desc;
-	uint64_t rkey;
-	struct ofi_mr_entry *mre = NULL;
-	struct iovec iov = {.iov_base = (void*)buf, .iov_len = len};
-
-	lep = lnx_get_lep(ep, &ctx);
-	if (!lep)
-		return -FI_ENOSYS;
-
-	peer_tbl = lep->le_peer_tbl;
-
-	lp = lnx_av_lookup_addr(peer_tbl, src_addr);
-	rc = lnx_select_send_pathway(lp, lep->le_domain, desc, &cep,
-				     &core_addr, &iov, 1, &mre, &mem_desc, &rkey);
-	if (rc)
-		goto out;
-
-	FI_DBG(&lnx_prov, FI_LOG_CORE,
-	       "rma read from %lx key %lx buf %p len %ld\n",
-	       core_addr, key, buf, len);
-
-	core_ep = lnx_get_core_ep(cep, ctx->ctx_idx, ep->fid.fclass);
-
-	rc = fi_read(core_ep, buf, len, mem_desc,
-		     core_addr, addr, key, context);
-
-	if (mre)
-		ofi_mr_cache_delete(&lep->le_domain->ld_mr_cache, mre);
-out:
-	return rc;
-}
-
-static inline ssize_t
-lnx_rma_write(struct fid_ep *ep, const void *buf, size_t len, void *desc,
-	 fi_addr_t dest_addr, uint64_t addr, uint64_t key, void *context)
-{
-	int rc;
-	struct lnx_ep *lep;
-	struct lnx_peer *lp;
-	struct fid_ep *core_ep;
-	struct lnx_ctx *ctx;
-	struct local_prov_ep *cep;
-	fi_addr_t core_addr;
-	struct lnx_peer_table *peer_tbl;
-	void *mem_desc;
-	uint64_t rkey;
-	struct ofi_mr_entry *mre = NULL;
-	struct iovec iov = {.iov_base = (void*)buf, .iov_len = len};
-
-	lep = lnx_get_lep(ep, &ctx);
-	if (!lep)
-		return -FI_ENOSYS;
-
-	peer_tbl = lep->le_peer_tbl;
-
-	lp = lnx_av_lookup_addr(peer_tbl, dest_addr);
-	rc = lnx_select_send_pathway(lp, lep->le_domain, desc, &cep,
-				     &core_addr, &iov, 1, &mre, &mem_desc, &rkey);
-	if (rc)
-		goto out;
-
-	FI_DBG(&lnx_prov, FI_LOG_CORE,
-	       "rma write to %lx key %lx buf %p len %ld\n",
-	       core_addr, key, buf, len);
-
-	core_ep = lnx_get_core_ep(cep, ctx->ctx_idx, ep->fid.fclass);
-
-	rc = fi_write(core_ep, buf, len, mem_desc,
-		      core_addr, addr, key, context);
-
-	if (mre)
-		ofi_mr_cache_delete(&lep->le_domain->ld_mr_cache, mre);
-out:
-	return rc;
-}
-
-static inline ssize_t
-lnx_atomic_write(struct fid_ep *ep,
-	  const void *buf, size_t count, void *desc,
-	  fi_addr_t dest_addr,
-	  uint64_t addr, uint64_t key,
-	  enum fi_datatype datatype, enum fi_op op, void *context)
-{
-	int rc;
-	struct lnx_ep *lep;
-	struct lnx_peer *lp;
-	struct fid_ep *core_ep;
-	struct lnx_ctx *ctx;
-	struct local_prov_ep *cep;
-	fi_addr_t core_addr;
-	struct lnx_peer_table *peer_tbl;
-	void *mem_desc;
-	uint64_t rkey;
-	struct ofi_mr_entry *mre = NULL;
-	struct iovec iov = {.iov_base = (void*)buf, .iov_len = count};
-
-	lep = lnx_get_lep(ep, &ctx);
-	if (!lep)
-		return -FI_ENOSYS;
-
-	peer_tbl = lep->le_peer_tbl;
-
-	lp = lnx_av_lookup_addr(peer_tbl, dest_addr);
-	rc = lnx_select_send_pathway(lp, lep->le_domain, desc, &cep,
-				&core_addr, &iov, 1, &mre, &mem_desc, &rkey);
-	if (rc)
-		goto out;
-
-	FI_DBG(&lnx_prov, FI_LOG_CORE,
-	       "sending to %lx\n", core_addr);
-
-	core_ep = lnx_get_core_ep(cep, ctx->ctx_idx, ep->fid.fclass);
-
-	rc = fi_atomic(core_ep, buf, count, mem_desc,
-		      core_addr, addr, key, datatype, op, context);
-
-	if (mre)
-		ofi_mr_cache_delete(&lep->le_domain->ld_mr_cache, mre);
-out:
-	return rc;
-}
-
-static inline ssize_t
-lnx_atomic_readwrite(struct fid_ep *ep,
-		const void *buf, size_t count, void *desc,
-		void *result, void *result_desc,
-		fi_addr_t dest_addr,
-		uint64_t addr, uint64_t key,
-		enum fi_datatype datatype, enum fi_op op, void *context)
-{
-	int rc;
-	struct lnx_ep *lep;
-	struct lnx_peer *lp;
-	struct fid_ep *core_ep;
-	struct lnx_ctx *ctx;
-	struct local_prov_ep *cep;
-	fi_addr_t core_addr;
-	struct lnx_peer_table *peer_tbl;
-	void *mem_desc;
-	uint64_t rkey;
-	struct ofi_mr_entry *mre = NULL;
-	struct iovec iov = {.iov_base = (void*)buf, .iov_len = count};
-
-	lep = lnx_get_lep(ep, &ctx);
-	if (!lep)
-		return -FI_ENOSYS;
-
-	peer_tbl = lep->le_peer_tbl;
-
-	lp = lnx_av_lookup_addr(peer_tbl, dest_addr);
-	rc = lnx_select_send_pathway(lp, lep->le_domain, result_desc,
-				     &cep, &core_addr, &iov, 1,
-				     &mre, &mem_desc, &rkey);
-	if (rc)
-		goto out;
-
-	FI_DBG(&lnx_prov, FI_LOG_CORE,
-	       "sending to %lx\n", core_addr);
-
-	core_ep = lnx_get_core_ep(cep, ctx->ctx_idx, ep->fid.fclass);
-
-	rc = fi_fetch_atomic(core_ep, buf, count, desc,
-		      result, mem_desc, core_addr, addr, key,
-		      datatype, op, context);
-
-	if (mre)
-		ofi_mr_cache_delete(&lep->le_domain->ld_mr_cache, mre);
-out:
-	return rc;
-}
-
-static inline ssize_t
-lnx_atomic_compwrite(struct fid_ep *ep,
-		  const void *buf, size_t count, void *desc,
-		  const void *compare, void *compare_desc,
-		  void *result, void *result_desc,
-		  fi_addr_t dest_addr,
-		  uint64_t addr, uint64_t key,
-		  enum fi_datatype datatype, enum fi_op op, void *context)
-{
-	int rc;
-	struct lnx_ep *lep;
-	struct lnx_peer *lp;
-	struct fid_ep *core_ep;
-	struct lnx_ctx *ctx;
-	struct local_prov_ep *cep;
-	fi_addr_t core_addr;
-	struct lnx_peer_table *peer_tbl;
-	void *mem_desc;
-	uint64_t rkey;
-	struct ofi_mr_entry *mre = NULL;
-	struct iovec iov = {.iov_base = (void*)buf, .iov_len = count};
-
-	lep = lnx_get_lep(ep, &ctx);
-	if (!lep)
-		return -FI_ENOSYS;
-
-	peer_tbl = lep->le_peer_tbl;
-
-	lp = lnx_av_lookup_addr(peer_tbl, dest_addr);
-	rc = lnx_select_send_pathway(lp, lep->le_domain, result_desc, &cep,
-				     &core_addr, &iov, 1,
-				     &mre, &mem_desc, &rkey);
-	if (rc)
-		goto out;
-
-	FI_DBG(&lnx_prov, FI_LOG_CORE,
-	       "sending to %lx\n", core_addr);
-
-	core_ep = lnx_get_core_ep(cep, ctx->ctx_idx, ep->fid.fclass);
-
-	rc = fi_compare_atomic(core_ep, buf, count, desc,
-		      compare, compare_desc, result, mem_desc,
-		      core_addr, addr, key, datatype, op, context);
-
-	if (mre)
-		ofi_mr_cache_delete(&lep->le_domain->ld_mr_cache, mre);
-
-out:
 	return rc;
 }
 
@@ -1029,10 +707,10 @@ struct fi_ops_msg lnx_msg_ops = {
 
 struct fi_ops_rma lnx_rma_ops = {
 	.size = sizeof(struct fi_ops_rma),
-	.read = lnx_rma_read,
+	.read = fi_no_rma_read,
 	.readv = fi_no_rma_readv,
 	.readmsg = fi_no_rma_readmsg,
-	.write = lnx_rma_write,
+	.write = fi_no_rma_write,
 	.writev = fi_no_rma_writev,
 	.writemsg = fi_no_rma_writemsg,
 	.inject = fi_no_rma_inject,
@@ -1042,14 +720,14 @@ struct fi_ops_rma lnx_rma_ops = {
 
 struct fi_ops_atomic lnx_atomic_ops = {
 	.size = sizeof(struct fi_ops_atomic),
-	.write = lnx_atomic_write,
+	.write = fi_no_atomic_write,
 	.writev = fi_no_atomic_writev,
 	.writemsg = fi_no_atomic_writemsg,
 	.inject = fi_no_atomic_inject,
-	.readwrite = lnx_atomic_readwrite,
+	.readwrite = fi_no_atomic_readwrite,
 	.readwritev = fi_no_atomic_readwritev,
 	.readwritemsg = fi_no_atomic_readwritemsg,
-	.compwrite = lnx_atomic_compwrite,
+	.compwrite = fi_no_atomic_compwrite,
 	.compwritev = fi_no_atomic_compwritev,
 	.compwritemsg = fi_no_atomic_compwritemsg,
 	.writevalid = fi_no_atomic_writevalid,

--- a/prov/util/src/rxm_av.c
+++ b/prov/util/src/rxm_av.c
@@ -184,18 +184,17 @@ static int rxm_av_add_peers(struct rxm_av *av, const void *addr, size_t count,
 		if (!peer)
 			goto err;
 
-		if (user_ids) {
+		cur_fi_addr = (fi_addr) ? fi_addr[i] :
+			ofi_av_lookup_fi_addr(&av->util_av, cur_addr);
+
+		if (user_ids)
 			peer->fi_addr = user_ids[i];
-		} else {
-			peer->fi_addr =
-				fi_addr ? fi_addr[i] :
-					  ofi_av_lookup_fi_addr(&av->util_av,
-								cur_addr);
-		}
+		else
+			peer->fi_addr = cur_fi_addr;
 
 		/* lookup can fail if prior AV insertion failed */
 		if (peer->fi_addr != FI_ADDR_NOTAVAIL)
-			rxm_set_av_context(av, peer->fi_addr, peer);
+			rxm_set_av_context(av, cur_fi_addr, peer);
 	}
 	return 0;
 

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -258,7 +258,7 @@ void *ofi_av_addr_context(struct util_av *av, fi_addr_t fi_addr)
 
 int ofi_verify_av_insert(struct util_av *av, uint64_t flags, void *context)
 {
-	if (flags & ~(FI_MORE | FI_SYNC_ERR | FI_FIREWALL_ADDR)) {
+	if (flags & ~(FI_MORE | FI_SYNC_ERR | FI_FIREWALL_ADDR | FI_AV_USER_ID)) {
 		FI_WARN(av->prov, FI_LOG_AV, "unsupported flags\n");
 		return -FI_EBADFLAGS;
 	}

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -1215,13 +1215,11 @@ static void ofi_set_prov_attr(struct fi_fabric_attr *attr,
 
 	core_name = attr->prov_name;
 	if (core_name) {
-		if (ofi_is_lnx_prov(prov)) {
-			attr->prov_name = ofi_strdup_link_append(core_name, prov->name);
-		} else {
+		if (!ofi_is_lnx_prov(prov)) {
 			assert(ofi_is_util_prov(prov));
 			attr->prov_name = ofi_strdup_append(core_name, prov->name);
+			free(core_name);
 		}
-		free(core_name);
 	} else {
 		attr->prov_name = strdup(prov->name);
 	}
@@ -1569,9 +1567,7 @@ int DEFAULT_SYMVER_PRE(fi_fabric)(struct fi_fabric_attr *attr,
 
 	fi_ini();
 
-	ret = ofi_is_linked(attr->prov_name);
-	top_name = strrchr(attr->prov_name,
-			   ret ? OFI_NAME_LNX_DELIM : OFI_NAME_DELIM);
+	top_name = strrchr(attr->prov_name, OFI_NAME_DELIM);
 	if (top_name)
 		top_name++;
 	else


### PR DESCRIPTION
Refactor LNX to allows for:
- multiple domains per fabric
- multiple endpoints per domain
- multiple completion queues per domain
- multiple address vectors per domain
    
Remove all extra functionality except for tagged messages. Other
functionality will be added in follow up patches.
    
Add support for fi_mr_regattr. This patch doesn't support memory
registration for RMA operations.
    
Add support for FI_CLAIM, FI_DISCARD and FI_PEEK on the receive path.

Beside the above changes. The PR addresses some bugs found in the lnx FI_PEER
path in the rxm and cxi providers
