### PR TITLE
prov/shm: don't run smr progress if region isn't initialized

### DIFF
--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -1457,6 +1457,9 @@ void smr_ep_progress(struct util_ep *util_ep)
 
 	ep = container_of(util_ep, struct smr_ep, util_ep);
 
+	if (!ep->region)
+		return;
+
 	if (smr_env.use_dsa_sar)
 		smr_dsa_progress(ep);
 	smr_progress_resp(ep);


### PR DESCRIPTION
If fi_cq_read is called before the EP has been enabled, the region has not been initialized and will segfault. Make sure the region is valid before progressing commands