### PR TITLE
fabtests: fix leak of dmabuf fd

### DIFF
--- a/fabtests/benchmarks/rdm_bw_mt.c
+++ b/fabtests/benchmarks/rdm_bw_mt.c
@@ -295,6 +295,8 @@ static int mt_reg_mr(struct fi_info *fi, void *buf, size_t size,
 	ft_fill_mr_attr(&iov, &dmabuf, 1, access, key, iface, device, &attr,
 			flags);
 	ret = fi_mr_regattr(dom, &attr, flags, mr);
+	if (opts.options & FT_OPT_REG_DMABUF_MR)
+		ft_hmem_put_dmabuf_fd(iface, dmabuf_fd);
 	if (ret)
 		return ret;
 

--- a/fabtests/common/hmem.c
+++ b/fabtests/common/hmem.c
@@ -50,6 +50,7 @@ struct ft_hmem_ops {
 			      size_t size);
 	int (*get_dmabuf_fd)(void *buf, size_t len,
 			     int *fd, uint64_t *offset);
+	int (*put_dmabuf_fd)(int fd);
 };
 
 static struct ft_hmem_ops hmem_ops[] = {
@@ -64,6 +65,7 @@ static struct ft_hmem_ops hmem_ops[] = {
 		.copy_to_hmem = ft_host_memcpy,
 		.copy_from_hmem = ft_host_memcpy,
 		.get_dmabuf_fd = ft_hmem_no_get_dmabuf_fd,
+		.put_dmabuf_fd = ft_hmem_no_put_dmabuf_fd,
 	},
 	[FI_HMEM_SYNAPSEAI] = {
 		.init = ft_synapseai_init,
@@ -76,6 +78,7 @@ static struct ft_hmem_ops hmem_ops[] = {
 		.copy_to_hmem = ft_synapseai_copy_to_hmem,
 		.copy_from_hmem = ft_synapseai_copy_from_hmem,
 		.get_dmabuf_fd = ft_synapseai_get_dmabuf_fd,
+		.put_dmabuf_fd = ft_hmem_no_put_dmabuf_fd,
 	},
 	[FI_HMEM_CUDA] = {
 		.init = ft_cuda_init,
@@ -88,6 +91,7 @@ static struct ft_hmem_ops hmem_ops[] = {
 		.copy_to_hmem = ft_cuda_copy_to_hmem,
 		.copy_from_hmem = ft_cuda_copy_from_hmem,
 		.get_dmabuf_fd = ft_cuda_get_dmabuf_fd,
+		.put_dmabuf_fd = ft_cuda_put_dmabuf_fd,
 	},
 	[FI_HMEM_ROCR] = {
 		.init = ft_rocr_init,
@@ -100,6 +104,7 @@ static struct ft_hmem_ops hmem_ops[] = {
 		.copy_to_hmem = ft_rocr_memcpy,
 		.copy_from_hmem = ft_rocr_memcpy,
 		.get_dmabuf_fd = ft_hmem_no_get_dmabuf_fd,
+		.put_dmabuf_fd = ft_hmem_no_put_dmabuf_fd,
 	},
 	[FI_HMEM_ZE] = {
 		.init = ft_ze_init,
@@ -112,6 +117,7 @@ static struct ft_hmem_ops hmem_ops[] = {
 		.copy_to_hmem = ft_ze_copy,
 		.copy_from_hmem = ft_ze_copy,
 		.get_dmabuf_fd = ft_hmem_no_get_dmabuf_fd,
+		.put_dmabuf_fd = ft_hmem_no_put_dmabuf_fd,
 	},
 	[FI_HMEM_NEURON] = {
 		.init = ft_neuron_init,
@@ -124,6 +130,7 @@ static struct ft_hmem_ops hmem_ops[] = {
 		.copy_to_hmem = ft_neuron_memcpy_to_hmem,
 		.copy_from_hmem = ft_neuron_memcpy_from_hmem,
 		.get_dmabuf_fd = ft_hmem_no_get_dmabuf_fd,
+		.put_dmabuf_fd = ft_hmem_no_put_dmabuf_fd,
 	},
 };
 
@@ -216,6 +223,16 @@ int ft_hmem_get_dmabuf_fd(enum fi_hmem_iface iface,
 
 int ft_hmem_no_get_dmabuf_fd(void *buf, size_t len,
 			      int *fd, uint64_t *offset)
+{
+	return -FI_ENOSYS;
+}
+
+int ft_hmem_put_dmabuf_fd(enum fi_hmem_iface iface, int fd)
+{
+	return hmem_ops[iface].put_dmabuf_fd(fd);
+}
+
+int ft_hmem_no_put_dmabuf_fd(int fd)
 {
 	return -FI_ENOSYS;
 }

--- a/fabtests/common/hmem_cuda.c
+++ b/fabtests/common/hmem_cuda.c
@@ -485,6 +485,16 @@ int ft_cuda_get_dmabuf_fd(void *buf, size_t len,
 #endif /* HAVE_CUDA_DMABUF */
 }
 
+int ft_cuda_put_dmabuf_fd(int fd)
+{
+#if HAVE_CUDA_DMABUF
+	(void)close(fd);
+	return FI_SUCCESS;
+#else
+	return -FI_EOPNOTSUPP;
+#endif /* HAVE_CUDA_DMABUF */
+}
+
 #else
 
 int ft_cuda_init(void)
@@ -540,4 +550,8 @@ int ft_cuda_get_dmabuf_fd(void *buf, size_t len,
 	return -FI_ENOSYS;
 }
 
+int ft_cuda_put_dmabuf_fd(int fd)
+{
+	return -FI_ENOSYS;
+}
 #endif /* HAVE_CUDA_RUNTIME_H */

--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -474,6 +474,8 @@ int ft_reg_mr(struct fi_info *fi, void *buf, size_t size, uint64_t access,
 
 	ft_fill_mr_attr(&iov, &dmabuf, 1, access, key, iface, device, &attr, flags);
 	ret = fi_mr_regattr(domain, &attr, flags, mr);
+	if (opts.options & FT_OPT_REG_DMABUF_MR)
+		ft_hmem_put_dmabuf_fd(iface, dmabuf_fd);
 	if (ret)
 		return ret;
 

--- a/fabtests/include/hmem.h
+++ b/fabtests/include/hmem.h
@@ -184,6 +184,8 @@ int ft_cuda_copy_from_hmem(uint64_t device, void *dst, const void *src,
 			   size_t size);
 int ft_cuda_get_dmabuf_fd(void *buf, size_t len,
 			  int *fd, uint64_t *offset);
+int ft_cuda_put_dmabuf_fd(int fd);
+
 int ft_rocr_init(void);
 int ft_rocr_cleanup(void);
 int ft_rocr_alloc(uint64_t device, void **buf, size_t size);
@@ -228,5 +230,7 @@ int ft_hmem_get_dmabuf_fd(enum fi_hmem_iface iface,
 			  int *fd, uint64_t *offset);
 int ft_hmem_no_get_dmabuf_fd(void *buf, size_t len,
 			     int *fd, uint64_t *offset);
+int ft_hmem_put_dmabuf_fd(enum fi_hmem_iface iface, int fd);
+int ft_hmem_no_put_dmabuf_fd(int fd);
 
 #endif /* _HMEM_H_ */


### PR DESCRIPTION
All calls to ft_hmem_get_dmabuf_fd need a corresponding close call. Or the dmabuf will stick around for the lifetime of the process, even after dereg and releasing the memory back to the device mempool.
similar to https://github.com/ofiwg/libfabric/pull/10708