### PR TITLE
prov/cxi: Allow for passing opaque 64-bit data in ctrl_msg

### DIFF
--- a/prov/cxi/include/cxip.h
+++ b/prov/cxi/include/cxip.h
@@ -3045,7 +3045,7 @@ void cxip_tree_nodeidx(int radix, int row, int col, int *nodeidx);
 int cxip_tree_relatives(int radix, int nodeidx, int maxnodes, int *rels);
 
 int cxip_zbcoll_recv_cb(struct cxip_ep_obj *ep_obj, uint32_t init_nic,
-			uint32_t init_pid, uint64_t mbv);
+			uint32_t init_pid, uint64_t mbv, uint64_t data);
 void cxip_zbcoll_send(struct cxip_zbcoll_obj *zb, int srcidx, int dstidx,
 		      uint64_t payload);
 void cxip_zbcoll_free(struct cxip_zbcoll_obj *zb);
@@ -3275,7 +3275,7 @@ int cxip_map(struct cxip_domain *dom, const void *buf, unsigned long len,
 	     uint64_t access, uint64_t flags, struct cxip_md **md);
 void cxip_unmap(struct cxip_md *md);
 
-int cxip_ctrl_msg_send(struct cxip_ctrl_req *req);
+int cxip_ctrl_msg_send(struct cxip_ctrl_req *req, uint64_t data);
 void cxip_ep_ctrl_progress(struct cxip_ep_obj *ep_obj);
 void cxip_ep_ctrl_progress_locked(struct cxip_ep_obj *ep_obj);
 void cxip_ep_tx_ctrl_progress(struct cxip_ep_obj *ep_obj);

--- a/prov/cxi/src/cxip_msg_hpc.c
+++ b/prov/cxi/src/cxip_msg_hpc.c
@@ -1750,7 +1750,7 @@ int cxip_fc_resume_cb(struct cxip_ctrl_req *req, const union c_event *event)
 				 fc_drops->vni, cxip_env.fc_retry_usec_delay,
 				 fc_drops->retry_count);
 			usleep(cxip_env.fc_retry_usec_delay);
-			ret = cxip_ctrl_msg_send(req);
+			ret = cxip_ctrl_msg_send(req, 0);
 			break;
 		default:
 			RXC_FATAL(rxc, CXIP_UNEXPECTED_EVENT_STS,
@@ -1901,7 +1901,7 @@ int cxip_recv_resume(struct cxip_rxc_hpc *rxc)
 	dlist_foreach_container_safe(&rxc->fc_drops,
 				     struct cxip_fc_drops, fc_drops,
 				     rxc_entry, tmp) {
-		ret = cxip_ctrl_msg_send(&fc_drops->req);
+		ret = cxip_ctrl_msg_send(&fc_drops->req, 0);
 		if (ret)
 			return ret;
 
@@ -4863,7 +4863,7 @@ static int cxip_fc_peer_put(struct cxip_fc_peer *peer)
 	if (!--peer->pending) {
 		peer->req.send.mb.drops = peer->dropped;
 
-		ret = cxip_ctrl_msg_send(&peer->req);
+		ret = cxip_ctrl_msg_send(&peer->req, 0);
 		if (ret != FI_SUCCESS) {
 			peer->pending++;
 			return ret;
@@ -4931,7 +4931,7 @@ int cxip_fc_notify_cb(struct cxip_ctrl_req *req, const union c_event *event)
 				 peer->caddr.vni, cxip_env.fc_retry_usec_delay,
 				 peer->retry_count);
 			usleep(cxip_env.fc_retry_usec_delay);
-			return cxip_ctrl_msg_send(req);
+			return cxip_ctrl_msg_send(req, 0);
 		default:
 			TXC_FATAL(txc, CXIP_UNEXPECTED_EVENT_STS,
 				  cxi_event_to_str(event),

--- a/prov/cxi/src/cxip_zbcoll.c
+++ b/prov/cxi/src/cxip_zbcoll.c
@@ -790,7 +790,7 @@ static void zbsend(struct cxip_ep_obj *ep_obj, uint32_t dstnic, uint32_t dstpid,
 
 	/* If we can't send, collective cannot complete, just spin */
 	do {
-		ret =  cxip_ctrl_msg_send(req);
+		ret =  cxip_ctrl_msg_send(req, 0);
 		if (ret == -FI_EAGAIN)
 			cxip_ep_ctrl_progress_locked(ep_obj);
 	} while (ret == -FI_EAGAIN);
@@ -1052,10 +1052,11 @@ static void discard_msg(uint32_t inic, uint32_t ipid, char *msg)
  * @param init_nic  : received (actual) initiator NIC
  * @param init_pid  : received (actual) initiator PID
  * @param mbv       : received match bits
+ * @param data      : received ctrl msg user defined data
  * @return int : FI_SUCCESS (formal return)
  */
 int cxip_zbcoll_recv_cb(struct cxip_ep_obj *ep_obj, uint32_t init_nic,
-			uint32_t init_pid, uint64_t mbv)
+			uint32_t init_pid, uint64_t mbv, uint64_t data)
 {
 	struct cxip_ep_zbcoll_obj *zbcoll;
 	struct cxip_zbcoll_obj *zb;
@@ -1254,13 +1255,13 @@ static int zbdata_send_cb(struct cxip_ctrl_req *req, const union c_event *event)
 			/* likely a target queue is full, retry */
 			CXIP_WARN("Target dropped packet, retry\n");
 			usleep(cxip_env.fc_retry_usec_delay);
-			ret = cxip_ctrl_msg_send(req);
+			ret = cxip_ctrl_msg_send(req, 0);
 			break;
 		case C_RC_PTLTE_NOT_FOUND:
 			/* could be a race during setup, retry */
 			CXIP_WARN("Target connection failed, retry\n");
 			usleep(cxip_env.fc_retry_usec_delay);
-			ret = cxip_ctrl_msg_send(req);
+			ret = cxip_ctrl_msg_send(req, 0);
 			break;
 		default:
 			CXIP_WARN("ACK return code = %d, failed\n",


### PR DESCRIPTION
Extend side-band control message to pass 64-bits of opaque data from as part of control message. This data is completely opaque to control messaging. The source/target of the message may layer validity of the data using match bits appropriate for the usage.