### PR TITLE
prov/efa: Remove free ope state

### DIFF
--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -583,15 +583,6 @@ void efa_domain_progress_rdm_peers_and_queues(struct efa_domain *domain)
 				continue;
 			}
 
-			/* it can happen that efa_rdm_ope_post_send() released ope
-			 * (if the ope is rxe and packet type is EOR and inject is used). In
-			 * that case rxe's state has been set to EFA_RDM_OPE_FREE and
-			 * it has been removed from ep->op_queued_entry_list, so nothing
-			 * is left to do.
-			 */
-			if (ope->state == EFA_RDM_OPE_FREE)
-				continue;
-
 			ope->internal_flags &= ~EFA_RDM_OPE_QUEUED_CTRL;
 			dlist_remove(&ope->queued_entry);
 		}

--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -155,7 +155,6 @@ void efa_rdm_txe_release(struct efa_rdm_ope *txe)
 	efa_rdm_poison_mem_region(txe,
 			      sizeof(struct efa_rdm_ope));
 #endif
-	txe->state = EFA_RDM_OPE_FREE;
 	ofi_buf_free(txe);
 }
 
@@ -210,7 +209,6 @@ void efa_rdm_rxe_release_internal(struct efa_rdm_ope *rxe)
 	efa_rdm_poison_mem_region(rxe,
 			      sizeof(struct efa_rdm_ope));
 #endif
-	rxe->state = EFA_RDM_OPE_FREE;
 	ofi_buf_free(rxe);
 }
 

--- a/prov/efa/src/rdm/efa_rdm_ope.h
+++ b/prov/efa/src/rdm/efa_rdm_ope.h
@@ -20,8 +20,7 @@ enum efa_rdm_ope_type {
  * @brief EFA RDM operation entry (ope)'s state
  */
 enum efa_rdm_ope_state {
-	EFA_RDM_OPE_FREE = 0,	/**< txe/rxe free state */
-	EFA_RDM_TXE_REQ,	/**< txe sending REQ packet */
+	EFA_RDM_TXE_REQ = 1,	/**< txe sending REQ packet */
 	EFA_RDM_OPE_SEND,	/**< ope sending data in progress */
 	EFA_RDM_RXE_INIT,	/**< rxe ready to recv RTM */
 	EFA_RDM_RXE_UNEXP,	/**< rxe unexp msg waiting for post recv */


### PR DESCRIPTION
EFA_RDM_OPE_FREE is not a legal state.
It is currently set before the ope is freed,
but we should not access the ope after
its freed. This patch removes this
enum and its references. It keeps the enum
of EFA_RDM_TXE_REQ to be 1 because otherwise
the fresh allocated OPEs will have a state
as EFA_RDM_TXE_REQ (0).