### PR TITLE
prov/shm: acquire ep lock when freeing entries

### DIFF
--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -807,6 +807,7 @@ static int smr_ep_close(struct fid *fid)
 		smr_free_sock_info(ep);
 	}
 
+	ofi_genlock_lock(&ep->util_ep.lock);
 	while (!dlist_empty(&ep->sar_list)) {
 		dlist_pop_front(&ep->sar_list, struct smr_pend_entry, pend,
 				entry);
@@ -821,6 +822,7 @@ static int smr_ep_close(struct fid *fid)
 		ep->srx->owner_ops->free_entry(cmd_ctx->rx_entry);
 		ofi_buf_free(cmd_ctx);
 	}
+	ofi_genlock_unlock(&ep->util_ep.lock);
 
 	if (ep->srx) {
 		/* shm is an owner provider */


### PR DESCRIPTION
When closing the shm ep, we have to free entries with the owner srx if there are any outstanding unexpected messages. When shm is the owner, that means we have to lock the srx (uses the ep lock) to avoid lock debug errors. When used as a peer it is expected that the owner lock the srx a peer EP is bound to when closing the endpoint

Fixes #11098 