### PR TITLE
prov/verbs: Avoid holding vrb_info_mutex when reloading interfaces

### DIFF
--- a/prov/verbs/src/verbs_init.c
+++ b/prov/verbs/src/verbs_init.c
@@ -87,6 +87,7 @@ struct fi_provider vrb_prov = {
 	.cleanup = vrb_fini
 };
 
+/* mutex for guarding the initialization of vrb_util_prov.info */
 ofi_mutex_t vrb_info_mutex;
 
 struct util_prov vrb_util_prov = {
@@ -98,7 +99,8 @@ struct util_prov vrb_util_prov = {
 	.flags = 0,
 };
 
-/* mutex for guarding the initialization of vrb_util_prov.info */
+/* mutex for guarding concurrent calls to protect provider initialization */
+ofi_mutex_t vrb_init_mutex;
 DEFINE_LIST(vrb_devs);
 
 int vrb_sockaddr_len(struct sockaddr *addr)
@@ -799,6 +801,7 @@ static void vrb_fini(void)
 	ofi_mem_fini();
 #endif
 	ofi_mutex_destroy(&vrb_info_mutex);
+	ofi_mutex_destroy(&vrb_init_mutex);
 	fi_freeinfo(vrb_util_prov.info);
 	vrb_os_fini();
 	vrb_util_prov.info = NULL;
@@ -812,6 +815,7 @@ VERBS_INI
 	ofi_monitors_init();
 #endif
 	ofi_mutex_init(&vrb_info_mutex);
+	ofi_mutex_init(&vrb_init_mutex);
 
 	vrb_prof_init();
 

--- a/prov/verbs/src/verbs_ofi.h
+++ b/prov/verbs/src/verbs_ofi.h
@@ -173,6 +173,7 @@ typedef void  vrb_profile_t;
 extern struct fi_provider vrb_prov;
 extern struct util_prov vrb_util_prov;
 extern ofi_mutex_t vrb_info_mutex;
+extern ofi_mutex_t vrb_init_mutex;
 extern struct dlist_entry vrb_devs;
 
 extern struct vrb_gl_data {


### PR DESCRIPTION
Problem:
Currently, interfaces are reloaded while holding `vrb_info_mutex`.
Since reloading interfaces can take a significant amount of time,
this may block other threads attempting to acquire `vrb_info_mutex`,
leading to potential performance issues.

Solution:
This patch addresses the issue by moving the call to `vrb_init_info()`
(which reloads the list of interfaces) outside the critical section
protected by `vrb_info_mutex`. Once the new interface lists are prepared,
the lock is briefly acquired to safely swap `vrb_devs` and `vrb_util_prov.info`.

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>
