### PR TITLE
prov/efa: Add a domain operation to query address info

### DIFF
--- a/man/fi_efa.7.md
+++ b/man/fi_efa.7.md
@@ -197,6 +197,8 @@ the pointer to the function table `fi_efa_ops_domain` defined as follows:
 ```c
 struct fi_efa_ops_domain {
 	int (*query_mr)(struct fid_mr *mr, struct fi_efa_mr_attr *mr_attr);
+	int (*query_addr)(struct fid_ep *ep_fid, fi_addr_t addr, uint16_t *ahn,
+			  uint16_t *remote_qpn, uint32_t *remote_qkey);
 };
 ```
 
@@ -239,6 +241,21 @@ struct fi_efa_mr_attr {
 #### Return value
 **query_mr()** returns 0 on success, or the value of errno on failure
 (which indicates the failure reason).
+
+### query_addr
+This op queries the following address information for a given endpoint and destination address.
+
+*ahn*
+:	Address handle number.
+
+*remote_qpn*
+:	Remote queue pair Number.
+
+*remote_qkey*
+:	qkey for the remote queue pair.
+
+#### Return value
+**query_addr()** returns FI_SUCCESS on success, or -FI_EINVAL on failure.
 
 # Traffic Class (tclass) in EFA
 To prioritize the messages from a given endpoint, user can specify `fi_info->tx_attr->tclass = FI_TC_LOW_LATENCY` in the fi_endpoint() call to set the service level in rdma-core. All other tclass values will be ignored.

--- a/prov/efa/src/fi_ext_efa.h
+++ b/prov/efa/src/fi_ext_efa.h
@@ -23,6 +23,8 @@ enum {
 
 struct fi_efa_ops_domain {
 	int (*query_mr)(struct fid_mr *mr, struct fi_efa_mr_attr *mr_attr);
+	int (*query_addr)(struct fid_ep *ep_fid, fi_addr_t addr, uint16_t *ahn,
+			  uint16_t *remote_qpn, uint32_t *remote_qkey);
 };
 
 #endif /* _FI_EXT_EFA_H_ */

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -255,6 +255,7 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_domain_dgram_attr_mr_allocated, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_domain_direct_attr_mr_allocated, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_domain_peer_list_cleared, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_domain_open_ops_query_addr, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		/* end efa_unit_test_domain.c */
 
 		cmocka_unit_test_setup_teardown(test_efa_rdm_cq_ibv_cq_poll_list_same_tx_rx_cq_single_ep, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -268,6 +268,7 @@ void test_efa_domain_rdm_attr_mr_allocated();
 void test_efa_domain_dgram_attr_mr_allocated();
 void test_efa_domain_direct_attr_mr_allocated();
 void test_efa_domain_peer_list_cleared();
+void test_efa_domain_open_ops_query_addr();
 /* end efa_unit_test_domain.c */
 
 void test_efa_rdm_cq_ibv_cq_poll_list_same_tx_rx_cq_single_ep();


### PR DESCRIPTION
Add the domain operation query_addr to retrieve the ahn, remote_qpn, and remote_qkey for a given endpoint and destination address. This enables applications to construct the metadata of a wqe.