### PR TITLE
prov/cxi: Fix regression which could cause FI_THREAD_SAFE deadlock

### DIFF
--- a/prov/cxi/src/cxip_msg_hpc.c
+++ b/prov/cxi/src/cxip_msg_hpc.c
@@ -3352,7 +3352,8 @@ cxip_recv_req_init(struct cxip_rxc *rxc, void *buf, size_t len, fi_addr_t addr,
 
 	/* HW to SW PtlTE transition, ensure progress is made */
 	if (rxc->state != RXC_ENABLED && rxc->state != RXC_ENABLED_SOFTWARE) {
-		cxip_cq_progress(rxc->recv_cq);
+		/* EP lock is held */
+		rxc->ops.progress(rxc);
 		ret = -FI_EAGAIN;
 		goto err;
 	}


### PR DESCRIPTION
The following community upstream commit: fb928f48f27dc1591781101aa55d7cb8b026b693 locking changes opens a window for FI_THREAD_SAFE locking to deadlock should portals flow control occur and a receive buffer is posted. Fix buy progressing without taking the lock now held.