### PR TITLE
build: Add fi_mon_sampler to specfile's %files section

### DIFF
--- a/libfabric.spec.in
+++ b/libfabric.spec.in
@@ -97,6 +97,7 @@ rm -rf %{buildroot}
 %{_bindir}/fi_info
 %{_bindir}/fi_strerror
 %{_bindir}/fi_pingpong
+%{_bindir}/fi_mon_sampler
 %if 0%{?_version_symbolic_link:1}
 %{_version_symbolic_link}
 %endif


### PR DESCRIPTION
Commit https://github.hpe.com/hpe/hpc-shs-libfabric-netc/commit/b690555e2998fa9cfe6cebc874f42c9281887610 broke the specfile. This is the fix.

Signed-off-by: Terrence Mitchem <terrence.mitchem@hpe.com>