### PR TITLE
src/Makefile: Add version and commit startup log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,8 +61,11 @@ config/test-driver
 util/fi_info
 util/fi_strerror
 util/fi_pingpong
+util/fi_mon_sampler
 
 prov/*/*.spec
+
+src/fi_version_gen.h
 
 .vs
 fabtests.spec

--- a/Makefile.am
+++ b/Makefile.am
@@ -30,6 +30,33 @@ pkglib_LTLIBRARIES = $(DL_PROVIDERS)
 ACLOCAL_AMFLAGS = -I config
 AM_CFLAGS = -Wall
 
+if NEED_VERSION_GEN
+BUILT_SOURCES = src/fi_version_gen.h
+# Force regeneration every time
+.PHONY: FORCE
+FORCE:
+
+src/fi_version_gen.h: $(srcdir)/src/fi_version_gen.h.in FORCE
+	@echo "Generating fi_version_gen.h..."
+	@{ \
+		COMMIT_HASH=$$(cd $(srcdir) && git rev-parse HEAD 2>/dev/null || echo "unknown"); \
+		COMMIT_SHORT=$$(cd $(srcdir) && git rev-parse --short HEAD 2>/dev/null || echo "unknown"); \
+		MAKE_VERSION="$(PACKAGE_VERSION)"; \
+		sed -e "s|%%GIT_COMMIT_HASH%%|$$COMMIT_HASH|g" \
+			-e "s|%%GIT_COMMIT_SHORT%%|$$COMMIT_SHORT|g" \
+			-e "s|%%PACKAGE_VERSION%%|$$MAKE_VERSION|g" \
+			$(srcdir)/src/fi_version_gen.h.in > $@; \
+	}
+
+clean-local:
+	@if test -d "$(srcdir)/.git"; then \
+		echo "Cleaning generated version file in git repo"; \
+		rm -f src/fi_version_gen.h; \
+	fi
+else
+BUILT_SOURCES =
+endif
+
 if HAVE_LD_VERSION_SCRIPT
     libfabric_version_script = -Wl,--version-script=$(builddir)/libfabric.map
 else !HAVE_LD_VERSION_SCRIPT
@@ -221,6 +248,7 @@ src_libfabric_la_SOURCES =			\
 	src/log.c				\
 	src/var.c				\
 	src/abi_1_0.c				\
+	src/fi_version_gen.h			\
 	$(common_hook_srcs)			\
 	$(common_srcs)
 

--- a/configure.ac
+++ b/configure.ac
@@ -770,7 +770,7 @@ AS_IF([test x"$with_cuda" != x"no"],
 			[],
 			[have_cuda_dmabuf=0],
 			[[#include <cuda.h>]])
-	
+
 	have_cuda_dmabuf_mapping_type_pcie=1
 	AC_CHECK_DECL([CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE],
 			[],
@@ -1112,6 +1112,9 @@ AS_IF([test "$have_rocr" = "1" && test x"$with_rocr" != x"yes"],
 AC_DEFINE_UNQUOTED([HAVE_HSA_AMD_PORTABLE_EXPORT_DMABUF],[$have_hsa_amd_portable_export_dmabuf],[dmabuf handle support])
 
 AC_CHECK_SIZEOF([void *])
+
+AC_CHECK_FILE([src/fi_version_gen.h], [have_version_header=yes], [have_version_header=no])
+AM_CONDITIONAL([NEED_VERSION_GEN], [test -d "$srcdir/.git" -o "x$have_version_header" = "xno"])
 
 dnl patching ${archive_cmds} to affect generation of file "libtool" to fix linking with clang
 dnl allows for building with clang lto and fast linking with non gnu ld

--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -1028,6 +1028,29 @@
   <ItemGroup>
     <None Include="libfabric.def" />
   </ItemGroup>
+  <Target Name="GenerateVersionHeader" BeforeTargets="ClCompile">
+    <PropertyGroup>
+      <VersionHeaderFile>$(SolutionDir)src\fi_version_gen.h</VersionHeaderFile>
+    </PropertyGroup>
+    <WriteLinesToFile
+      File="$(VersionHeaderFile)"
+      Lines='/* Auto-generated version file for Windows build */;
+#ifndef FI_VERSION_GEN_H;
+#define FI_VERSION_GEN_H;
+;
+#define FI_GIT_COMMIT_HASH "unknown";
+#define FI_GIT_COMMIT_SHORT "unknown";
+#define FI_VERSION_STRING "unknown";
+;
+#endif /* FI_VERSION_GEN_H */;'
+      Overwrite="true"/>
+  </Target>
+
+  <ItemGroup>
+    <ClInclude Include="src\fi_version_gen.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/prov/psm3/Makefile.include
+++ b/prov/psm3/Makefile.include
@@ -303,7 +303,7 @@ chksum_srcs += \
 
 _psm3_LIBS = prov/psm3/psm3/libpsm3i.la
 
-BUILT_SOURCES = prov/psm3/src/psm3_src_chksum.h
+BUILT_SOURCES += prov/psm3/src/psm3_src_chksum.h
 CLEANFILES = prov/psm3/src/psm3_src_chksum.h
 DATE_FMT = +%Y-%m-%dT%H:%M:%S
 prov/psm3/src/psm3_src_chksum.h: Makefile $(chksum_srcs)

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -53,6 +53,7 @@
 #include "ofi_mr.h"
 #include <ofi_shm_p2p.h>
 #include <rdma/fi_ext.h>
+#include "fi_version_gen.h"
 
 #ifdef HAVE_LIBDL
 #include <dlfcn.h>
@@ -1009,6 +1010,10 @@ void fi_ini(void)
 	ofi_register_provider(COLL_INIT, NULL);
 
 	pthread_atfork(NULL, NULL, ofi_memhooks_atfork_handler);
+
+	FI_INFO(&core_prov, FI_LOG_CORE,
+		"Initialized libfabric %s - built from commit %s\n",
+		FI_VERSION_STRING, FI_GIT_COMMIT_SHORT);
 
 	ofi_init = 1;
 

--- a/src/fi_version_gen.h.in
+++ b/src/fi_version_gen.h.in
@@ -1,0 +1,9 @@
+/* Auto-generated from configure - do not edit */
+#ifndef FI_VERSION_GEN_H
+#define FI_VERSION_GEN_H
+
+#define FI_GIT_COMMIT_HASH "%%GIT_COMMIT_HASH%%"
+#define FI_GIT_COMMIT_SHORT "%%GIT_COMMIT_SHORT%%"
+#define FI_VERSION_STRING "%%PACKAGE_VERSION%%"
+
+#endif /* FI_VERSION_GEN_H */


### PR DESCRIPTION
This commit modifies the build system, as well as src/fabric.c and src/fi_version_gen.h.in to create a info log which outputs the version of libfabric that is running as well as the commit used to build.  The log message looks like:

libfabric:906569:1749843568::core:core:fi_ini():1014<info> Initialized \ libfabric 2.2.0rc1 - built from commit 7ef321d3

This log message will be helpful when trying to prove which version/commit of libfabric is being run. This is helpful when there are multiple versions installed on the system, and application startup is non-trivial (docker/enroot/slurm/etc...).

The src/fi_version_gen.h file gets generated on every make command (including make dist) if there is a .git folder in the source directory. The file is compiled into the library so it works for both .a/.so libs. This has implications for the development workflow and distribution users. When developers create a new commit, and rebuild it, the log message will be updated. When developers bump the libfabric version in configure.ac and configure/make, the log message will be updated. When a developer wishes to release, and they call ./autogen.sh && ./configure && make dist, they will get a src distribution tarball.  They can then go into that tarball and call configure/make and they will always get the version/commit that was used to make the tarball.

When the user calls make clean in a git repo src dir, the generated src/fi_version_gen.h gets deleted.  When the user calls make clean in a dist src dir (no .git), the src/fi_version_gen.h file does not get deleted.  This is required because the project will not build without src/fi_version_gen.h, and in a dist src dir, the file does not get generated.