### PR TITLE
[v2.2.x] prov/cxi: Fix alt_read unit test to use rdzv_threshold

### DIFF
--- a/prov/cxi/test/tagged.c
+++ b/prov/cxi/test/tagged.c
@@ -357,8 +357,8 @@ static void simple_rdzv(bool check_invalid_length)
 	int i, ret;
 	uint8_t *recv_buf,
 		*send_buf;
-	int recv_len = 8192;
-	int send_len = 8192;
+	int recv_len = cxip_env.rdzv_threshold + 4096;
+	int send_len = cxip_env.rdzv_threshold + 4096;
 	struct fi_cq_tagged_entry tx_cqe,
 				  rx_cqe;
 	int err = 0;


### PR DESCRIPTION
For packet counts to be correct, must ensure the rendezvous threshold is met. Read threshold from environment.


(cherry picked from commit 0952f04a5eddd4a32ef43d5835864a895b13b730)