### PR TITLE
log: Fix buffer overrun when accessing the 'log_levels' array

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -100,7 +100,7 @@ static int fi_convert_log_str(const char *value)
 	if (!value)
 		return -1;
 
-	for (i = 0; log_levels[i]; i++) {
+	for (i = 0; i < OFI_LOG_MAX; i++) {
 		if (!strcasecmp(value, log_levels[i]))
 			return i;
 	}


### PR DESCRIPTION
The array is no longer terminated with a NULL pointer. Check the array boundary instead.

Fixes #11116 