### PR TITLE
prov/efa: Fix the wait_send procedure

### DIFF
--- a/prov/efa/src/efa_cq.h
+++ b/prov/efa/src/efa_cq.h
@@ -16,10 +16,11 @@ struct efa_ibv_cq {
 	struct ibv_cq_ex *ibv_cq_ex;
 	enum ibv_cq_ex_type ibv_cq_ex_type;
 	bool data_path_direct_enabled;
+	bool poll_active;
+	int poll_err;
 #if HAVE_EFADV_QUERY_CQ
 	struct efa_data_path_direct_cq data_path_direct;
 #endif
-
 };
 
 struct efa_ibv_cq_poll_list_entry {

--- a/prov/efa/src/rdm/efa_rdm_cq.c
+++ b/prov/efa/src/rdm/efa_rdm_cq.c
@@ -557,73 +557,129 @@ static int efa_rdm_cq_match_ep(struct dlist_entry *item, const void *ep)
 	return (container_of(item, struct efa_rdm_ep, entry) == ep) ;
 }
 
-/**
- * @brief poll rdma-core cq and process the cq entry
- *
- * @param[in]	ep_poll	the RDM endpoint that polls ibv cq. Note this polling endpoint can be different
- * from the endpoint that the completed packet entry was posted from (pkt_entry->ep).
- * @param[in]	cqe_to_process	Max number of cq entry to poll and process. A negative number means to poll until cq empty
- */
-int efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq)
+static inline struct efa_rdm_ep *efa_rdm_cq_get_rdm_ep(struct efa_ibv_cq *cq, struct efa_domain *efa_domain)
 {
-	struct efa_rdm_pke *pkt_entry;
-	int err;
-	int opcode;
-	size_t i = 0;
+	struct efa_base_ep *base_ep = efa_domain->qp_table[efa_ibv_cq_wc_read_qp_num(cq) & efa_domain->qp_table_sz_m1]->base_ep;
+	return container_of(base_ep, struct efa_rdm_ep, base_ep);
+}
+
+/**
+ * @brief Process work completions for a closing endpoint
+ *
+ * This is a lighter-weight counterpart to #efa_rdm_cq_process_wc(); avoiding
+ * unnecessary overhead for processing completions for an endpoint that's
+ * closing anyway by simply releasing the packet entries. Exceptions include
+ * RECEIPT and EOR packets when a completion fails due to RNR and resource
+ * management is enabled by the user (FI_RM_ENABLED). In this case, packets are
+ * queued to be reposted.
+ *
+ * @param[in]	cq	IBV CQ
+ * @param[in]	ep	EFA RDM endpoint (to be closed)
+ * @return	Status code for the work completion
+ */
+static inline
+enum ibv_wc_status efa_rdm_cq_process_wc_closing_ep(struct efa_ibv_cq *cq, struct efa_rdm_ep *ep)
+{
+	uint64_t wr_id = cq->ibv_cq_ex->wr_id;
+	enum ibv_wc_status status = cq->ibv_cq_ex->status;
+	enum ibv_wc_opcode opcode = efa_ibv_cq_wc_read_opcode(cq);
+	struct efa_rdm_pke *pkt_entry = (struct efa_rdm_pke *) wr_id;
 	int prov_errno;
-	struct efa_rdm_ep *ep = NULL;
-	struct efa_cq *efa_cq;
-	struct efa_domain *efa_domain;
-	struct efa_qp *qp;
-	struct efa_rdm_peer *peer = NULL;
-	struct dlist_entry rx_progressed_ep_list, *tmp;
 
-	efa_cq = container_of(ibv_cq, struct efa_cq, ibv_cq);
-	efa_domain = container_of(efa_cq->util_cq.domain, struct efa_domain, util_domain);
-	dlist_init(&rx_progressed_ep_list);
-
-	/* Call ibv_start_poll only once */
-	efa_cq_start_poll(ibv_cq);
-
-	while (efa_cq_wc_available(ibv_cq)) {
-		pkt_entry = (void *)(uintptr_t)ibv_cq->ibv_cq_ex->wr_id;
-		qp = efa_domain->qp_table[efa_ibv_cq_wc_read_qp_num(ibv_cq) & efa_domain->qp_table_sz_m1];
-		ep = container_of(qp->base_ep, struct efa_rdm_ep, base_ep);
 #if HAVE_LTTNG
-		efa_rdm_tracepoint(poll_cq, (size_t) ibv_cq->ibv_cq_ex->wr_id);
-		if (pkt_entry && pkt_entry->ope)
-			efa_rdm_tracepoint(poll_cq_ope, pkt_entry->ope->msg_id,
-					   (size_t) pkt_entry->ope->cq_entry.op_context,
-					   pkt_entry->ope->total_len, pkt_entry->ope->cq_entry.tag,
-					   pkt_entry->ope->peer ? pkt_entry->ope->peer->conn->fi_addr : FI_ADDR_NOTAVAIL);
+	efa_rdm_tracepoint(poll_cq, (size_t) wr_id);
+	if (pkt_entry && pkt_entry->ope)
+		efa_rdm_tracepoint(poll_cq_ope, pkt_entry->ope->msg_id,
+				   (size_t) pkt_entry->ope->cq_entry.op_context,
+				   pkt_entry->ope->total_len, pkt_entry->ope->cq_entry.tag,
+				   pkt_entry->ope->peer ? pkt_entry->ope->peer->conn->fi_addr : FI_ADDR_NOTAVAIL);
 #endif
-		opcode = efa_ibv_cq_wc_read_opcode(ibv_cq);
-		if (ibv_cq->ibv_cq_ex->status) {
-			if (pkt_entry)
-				peer = pkt_entry->peer;
-			prov_errno = efa_rdm_cq_get_prov_errno(ibv_cq, peer);
-			switch (opcode) {
-			case IBV_WC_SEND: /* fall through */
-			case IBV_WC_RDMA_WRITE: /* fall through */
-			case IBV_WC_RDMA_READ:
-				efa_rdm_pke_handle_tx_error(pkt_entry, prov_errno);
-				break;
-			case IBV_WC_RECV: /* fall through */
-			case IBV_WC_RECV_RDMA_WITH_IMM:
-				if (efa_cq_wc_is_unsolicited(ibv_cq)) {
-					EFA_WARN(FI_LOG_CQ, "Receive error %s (%d) for unsolicited write recv",
-						efa_strerror(prov_errno), prov_errno);
-					efa_base_ep_write_eq_error(&ep->base_ep, to_fi_errno(prov_errno), prov_errno);
+
+	if (!efa_cq_wc_is_unsolicited(cq)) {
+		if (OFI_UNLIKELY(status != IBV_WC_SUCCESS)) {
+			prov_errno = efa_rdm_cq_get_prov_errno(cq, pkt_entry->peer);
+			if (prov_errno == EFA_IO_COMP_STATUS_REMOTE_ERROR_RNR &&
+				ep->handle_resource_management == FI_RM_ENABLED) {
+				switch(efa_rdm_pkt_type_of(pkt_entry)) {
+				case EFA_RDM_RECEIPT_PKT:
+				case EFA_RDM_EOR_PKT:
+					efa_rdm_ep_record_tx_op_completed(ep, pkt_entry);
+					efa_rdm_ep_queue_rnr_pkt(ep, pkt_entry);
+					return status;
+				default:
 					break;
 				}
-				efa_rdm_pke_handle_rx_error(pkt_entry, prov_errno);
-				break;
-			default:
-				EFA_WARN(FI_LOG_EP_CTRL, "Unhandled op code %d\n", opcode);
-				assert(0 && "Unhandled op code");
 			}
-			break;
 		}
+		switch (opcode) {
+		case IBV_WC_SEND: /* fall through */
+		case IBV_WC_RDMA_WRITE: /* fall through */
+		case IBV_WC_RDMA_READ:
+			efa_rdm_ep_record_tx_op_completed(ep, pkt_entry);
+			efa_rdm_pke_release_tx(pkt_entry);
+			break;
+		case IBV_WC_RECV: /* fall through */
+		case IBV_WC_RECV_RDMA_WITH_IMM:
+			efa_rdm_pke_release_rx(pkt_entry);
+			break;
+		default:
+			EFA_WARN(FI_LOG_EP_CTRL, "Unhandled opcode: %d\n", opcode);
+			assert(0 && "Unhandled opcode");
+		}
+	}
+	return status;
+}
+
+/**
+ * @brief Process work completions
+ *
+ * @param[in]	cq	IBV CQ
+ * @param[in]	ep	EFA RDM endpoint
+ * @return	Status code for the work completion
+ */
+static inline
+enum ibv_wc_status efa_rdm_cq_process_wc(struct efa_ibv_cq *cq, struct efa_rdm_ep *ep)
+{
+	uint64_t wr_id = cq->ibv_cq_ex->wr_id;
+	enum ibv_wc_status status = cq->ibv_cq_ex->status;
+	enum ibv_wc_opcode opcode = efa_ibv_cq_wc_read_opcode(cq);
+	struct efa_rdm_pke *pkt_entry = (struct efa_rdm_pke *) wr_id;
+	int prov_errno;
+
+#if HAVE_LTTNG
+	efa_rdm_tracepoint(poll_cq, (size_t) wr_id);
+	if (pkt_entry && pkt_entry->ope)
+		efa_rdm_tracepoint(poll_cq_ope, pkt_entry->ope->msg_id,
+				   (size_t) pkt_entry->ope->cq_entry.op_context,
+				   pkt_entry->ope->total_len, pkt_entry->ope->cq_entry.tag,
+				   pkt_entry->ope->peer ? pkt_entry->ope->peer->conn->fi_addr : FI_ADDR_NOTAVAIL);
+#endif
+
+	if (OFI_UNLIKELY(status != IBV_WC_SUCCESS)) {
+		prov_errno = efa_rdm_cq_get_prov_errno(cq, pkt_entry ? pkt_entry->peer : NULL);
+		switch (opcode) {
+		case IBV_WC_SEND: /* fall through */
+		case IBV_WC_RDMA_WRITE: /* fall through */
+		case IBV_WC_RDMA_READ:
+			assert(pkt_entry);
+			efa_rdm_pke_handle_tx_error(pkt_entry, prov_errno);
+			break;
+		case IBV_WC_RECV: /* fall through */
+		case IBV_WC_RECV_RDMA_WITH_IMM:
+			if (efa_cq_wc_is_unsolicited(cq)) {
+				EFA_WARN(FI_LOG_CQ, "Receive error %s (%d) for unsolicited write recv",
+					efa_strerror(prov_errno), prov_errno);
+				efa_base_ep_write_eq_error(&ep->base_ep, to_fi_errno(prov_errno), prov_errno);
+				break;
+			}
+			assert(pkt_entry);
+			efa_rdm_pke_handle_rx_error(pkt_entry, prov_errno);
+			break;
+		default:
+			EFA_WARN(FI_LOG_EP_CTRL, "Unhandled opcode: %d\n", opcode);
+			assert(0 && "Unhandled opcode");
+		}
+	} else {
 		switch (opcode) {
 		case IBV_WC_SEND:
 #if ENABLE_DEBUG
@@ -634,7 +690,7 @@ int efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq)
 		case IBV_WC_RECV:
 			/* efa_rdm_cq_handle_recv_completion does additional work to determine the source
 			 * address and the peer struct. So do not try to identify the peer here. */
-			efa_rdm_cq_handle_recv_completion(ibv_cq, pkt_entry, ep);
+			efa_rdm_cq_handle_recv_completion(cq, pkt_entry, ep);
 #if ENABLE_DEBUG
 			ep->recv_comps++;
 #endif
@@ -645,7 +701,7 @@ int efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq)
 			break;
 		case IBV_WC_RECV_RDMA_WITH_IMM:
 			efa_rdm_cq_proc_ibv_recv_rdma_with_imm_completion(
-				ibv_cq,
+				cq,
 				FI_REMOTE_CQ_DATA | FI_RMA | FI_REMOTE_WRITE,
 				ep, pkt_entry);
 			break;
@@ -654,13 +710,73 @@ int efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq)
 				"Unhandled cq type\n");
 			assert(0 && "Unhandled cq type");
 		}
+	}
+	return status;
+}
 
+void efa_rdm_cq_poll_ibv_cq_closing_ep(struct efa_ibv_cq *ibv_cq, struct efa_rdm_ep *closing_ep)
+{
+
+	struct efa_rdm_ep *ep = NULL;
+	struct efa_cq *efa_cq = container_of(ibv_cq, struct efa_cq, ibv_cq);
+	struct efa_domain *efa_domain = container_of(efa_cq->util_cq.domain, struct efa_domain, util_domain);
+	struct dlist_entry rx_progressed_ep_list, *tmp;
+
+	dlist_init(&rx_progressed_ep_list);
+
+	efa_cq_start_poll(ibv_cq);
+	while (efa_cq_wc_available(ibv_cq)) {
+		ep = efa_rdm_cq_get_rdm_ep(ibv_cq, efa_domain);
+		if (ep == closing_ep) {
+			if (OFI_UNLIKELY(efa_rdm_cq_process_wc_closing_ep(ibv_cq, ep) != IBV_WC_SUCCESS))
+				break;
+		} else {
+			if (OFI_UNLIKELY(efa_rdm_cq_process_wc(ibv_cq, ep) != IBV_WC_SUCCESS))
+				break;
+			if (ep->efa_rx_pkts_to_post > 0 && !dlist_find_first_match(&rx_progressed_ep_list, &efa_rdm_cq_match_ep, ep))
+				dlist_insert_tail(&ep->entry, &rx_progressed_ep_list);
+		}
+		efa_cq_next_poll(ibv_cq);
+	}
+	efa_cq_end_poll(ibv_cq);
+	dlist_foreach_container_safe(
+		&rx_progressed_ep_list, struct efa_rdm_ep, ep, entry, tmp) {
+		efa_rdm_ep_post_internal_rx_pkts(ep);
+		dlist_remove(&ep->entry);
+	}
+	assert(dlist_empty(&rx_progressed_ep_list));
+}
+
+/**
+ * @brief poll rdma-core cq and process the cq entry
+ *
+ * @param[in]	ep_poll	the RDM endpoint that polls ibv cq. Note this polling endpoint can be different
+ * from the endpoint that the completed packet entry was posted from (pkt_entry->ep).
+ * @param[in]	cqe_to_process	Max number of cq entry to poll and process. A negative number means to poll until cq empty
+ */
+int efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq)
+{
+	int err;
+	size_t i = 0;
+	struct efa_rdm_ep *ep = NULL;
+	struct efa_cq *efa_cq = container_of(ibv_cq, struct efa_cq, ibv_cq);
+	struct efa_domain *efa_domain = container_of(efa_cq->util_cq.domain, struct efa_domain, util_domain);
+
+	struct dlist_entry rx_progressed_ep_list, *tmp;
+
+	dlist_init(&rx_progressed_ep_list);
+
+	/* Call ibv_start_poll only once */
+	efa_cq_start_poll(ibv_cq);
+
+	while (efa_cq_wc_available(ibv_cq)) {
+		ep = efa_rdm_cq_get_rdm_ep(ibv_cq, efa_domain);
+		if (OFI_UNLIKELY(efa_rdm_cq_process_wc(ibv_cq, ep) != IBV_WC_SUCCESS))
+			break;
 		if (ep->efa_rx_pkts_to_post > 0 && !dlist_find_first_match(&rx_progressed_ep_list, &efa_rdm_cq_match_ep, ep))
 			dlist_insert_tail(&ep->entry, &rx_progressed_ep_list);
-		i++;
-		if (i == cqe_to_process) {
+		if (++i >= cqe_to_process)
 			break;
-		}
 
 		/*
 		 * ibv_next_poll MUST be call after the current WC is fully processed,
@@ -671,7 +787,6 @@ int efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq)
 
 	err = ibv_cq->poll_err;
 	efa_cq_end_poll(ibv_cq);
-
 	dlist_foreach_container_safe(
 		&rx_progressed_ep_list, struct efa_rdm_ep, ep, entry, tmp) {
 		efa_rdm_ep_post_internal_rx_pkts(ep);

--- a/prov/efa/src/rdm/efa_rdm_cq.c
+++ b/prov/efa/src/rdm/efa_rdm_cq.c
@@ -566,18 +566,12 @@ static int efa_rdm_cq_match_ep(struct dlist_entry *item, const void *ep)
  */
 int efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq)
 {
-	bool should_end_poll = false;
-	/* Initialize an empty ibv_poll_cq_attr struct for ibv_start_poll.
-	 * EFA expects .comp_mask = 0, or otherwise returns EINVAL.
-	 */
-	struct ibv_poll_cq_attr poll_cq_attr = {.comp_mask = 0};
 	struct efa_rdm_pke *pkt_entry;
 	int err;
 	int opcode;
 	size_t i = 0;
 	int prov_errno;
 	struct efa_rdm_ep *ep = NULL;
-	struct fi_cq_err_entry err_entry;
 	struct efa_cq *efa_cq;
 	struct efa_domain *efa_domain;
 	struct efa_qp *qp;
@@ -589,10 +583,9 @@ int efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq)
 	dlist_init(&rx_progressed_ep_list);
 
 	/* Call ibv_start_poll only once */
-	err = efa_ibv_cq_start_poll(ibv_cq, &poll_cq_attr);
-	should_end_poll = !err;
+	efa_cq_start_poll(ibv_cq);
 
-	while (!err) {
+	while (efa_cq_wc_available(ibv_cq)) {
 		pkt_entry = (void *)(uintptr_t)ibv_cq->ibv_cq_ex->wr_id;
 		qp = efa_domain->qp_table[efa_ibv_cq_wc_read_qp_num(ibv_cq) & efa_domain->qp_table_sz_m1];
 		ep = container_of(qp->base_ep, struct efa_rdm_ep, base_ep);
@@ -673,24 +666,11 @@ int efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq)
 		 * ibv_next_poll MUST be call after the current WC is fully processed,
 		 * which prevents later calls on ibv_cq_ex from reading the wrong WC.
 		 */
-		err = efa_ibv_cq_next_poll(ibv_cq);
+		efa_cq_next_poll(ibv_cq);
 	}
 
-	if (err && err != ENOENT) {
-		err = err > 0 ? err : -err;
-		prov_errno = efa_ibv_cq_wc_read_vendor_err(ibv_cq);
-		EFA_WARN(FI_LOG_CQ, "Unexpected error when polling ibv cq, err: %s (%d) prov_errno: %s (%d)\n", fi_strerror(err), err, efa_strerror(prov_errno), prov_errno);
-		efa_show_help(prov_errno);
-		err_entry = (struct fi_cq_err_entry) {
-			.err = err,
-			.prov_errno = prov_errno,
-			.op_context = NULL
-		};
-		ofi_cq_write_error(&efa_cq->util_cq, &err_entry);
-	}
-
-	if (should_end_poll)
-		efa_ibv_cq_end_poll(ibv_cq);
+	err = ibv_cq->poll_err;
+	efa_cq_end_poll(ibv_cq);
 
 	dlist_foreach_container_safe(
 		&rx_progressed_ep_list, struct efa_rdm_ep, ep, entry, tmp) {

--- a/prov/efa/src/rdm/efa_rdm_cq.h
+++ b/prov/efa/src/rdm/efa_rdm_cq.h
@@ -17,6 +17,7 @@ struct efa_rdm_cq {
 int efa_rdm_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		    struct fid_cq **cq_fid, void *context);
 
+void efa_rdm_cq_poll_ibv_cq_closing_ep(struct efa_ibv_cq *ibv_cq, struct efa_rdm_ep *closing_ep);
 int efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq);
 
 void efa_rdm_cq_progress_peers_and_queues(struct efa_rdm_cq *efa_rdm_cq);

--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -251,8 +251,7 @@ int efa_rdm_ep_post_user_recv_buf(struct efa_rdm_ep *ep, struct efa_rdm_ope *rxe
 
 struct efa_rdm_peer;
 
-void efa_rdm_ep_queue_rnr_pkt(struct efa_rdm_ep *ep, struct dlist_entry *list,
-			      struct efa_rdm_pke *pkt_entry);
+void efa_rdm_ep_queue_rnr_pkt(struct efa_rdm_ep *ep, struct efa_rdm_pke *pkt_entry);
 
 ssize_t efa_rdm_ep_post_queued_pkts(struct efa_rdm_ep *ep,
 				    struct dlist_entry *pkts);

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -12,6 +12,7 @@
 #include "efa_rdm_rxe_map.h"
 #include "efa_rdm_pkt_type.h"
 #include "efa_rdm_pke_req.h"
+#include "efa_rdm_pke_utils.h"
 #include "efa_cntr.h"
 
 
@@ -817,6 +818,48 @@ bool efa_rdm_ep_has_unfinished_send(struct efa_rdm_ep *efa_rdm_ep)
     return false;
 }
 
+static inline void progress_queues_closing_ep(struct efa_rdm_ep *ep)
+{
+	struct efa_rdm_peer *peer;
+	struct dlist_entry *tmp;
+	struct efa_rdm_ope *ope;
+	struct efa_domain *domain = efa_rdm_ep_domain(ep);
+
+	assert(domain->info->ep_attr->type == FI_EP_RDM);
+
+	/* Update timers for peers that are in backoff list*/
+	dlist_foreach_container_safe(&domain->peer_backoff_list,
+			struct efa_rdm_peer, peer, rnr_backoff_entry, tmp) {
+		if (ofi_gettime_us() >= peer->rnr_backoff_begin_ts +
+					peer->rnr_backoff_wait_time) {
+			peer->flags &= ~EFA_RDM_PEER_IN_BACKOFF;
+			dlist_remove(&peer->rnr_backoff_entry);
+		}
+	}
+
+	dlist_foreach_container_safe(&domain->ope_queued_list,
+			struct efa_rdm_ope, ope, queued_entry, tmp) {
+		if (ope->ep == ep) {
+			switch (efa_rdm_pkt_type_of(ope)) {
+			case EFA_RDM_RECEIPT_PKT:
+			case EFA_RDM_EOR_PKT:
+				if (efa_rdm_ope_process_queued_ope(ope, EFA_RDM_OPE_QUEUED_RNR))
+					continue;
+				if (efa_rdm_ope_process_queued_ope(ope, EFA_RDM_OPE_QUEUED_CTRL))
+					continue;
+				/* fall-thru */
+			default:
+				/* Release all other queued OPEs */
+				if (ope->type == EFA_RDM_TXE)
+					efa_rdm_txe_release(ope);
+				else
+					efa_rdm_rxe_release(ope);
+				break;
+			}
+		}
+	}
+}
+
 /*
  * @brief wait for send to finish
  *
@@ -839,10 +882,10 @@ void efa_rdm_ep_wait_send(struct efa_rdm_ep *efa_rdm_ep)
 	while (efa_rdm_ep_has_unfinished_send(efa_rdm_ep)) {
 		/* poll cq until empty */
 		if (tx_cq)
-			(void) efa_rdm_cq_poll_ibv_cq(-1, &tx_cq->ibv_cq);
+			efa_rdm_cq_poll_ibv_cq_closing_ep(&tx_cq->ibv_cq, efa_rdm_ep);
 		if (rx_cq)
-			(void) efa_rdm_cq_poll_ibv_cq(-1, &rx_cq->ibv_cq);
-		efa_domain_progress_rdm_peers_and_queues(efa_rdm_ep_domain(efa_rdm_ep));
+			efa_rdm_cq_poll_ibv_cq_closing_ep(&rx_cq->ibv_cq, efa_rdm_ep);
+		progress_queues_closing_ep(efa_rdm_ep);
 	}
 
 	ofi_genlock_unlock(&efa_rdm_ep_domain(efa_rdm_ep)->srx_lock);

--- a/prov/efa/src/rdm/efa_rdm_ep_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_utils.c
@@ -502,21 +502,26 @@ void efa_rdm_ep_record_tx_op_completed(struct efa_rdm_ep *ep, struct efa_rdm_pke
  * @param[in]	pkt_entry	packet entry that encounter RNR
  * @param[in]	peer	efa_rdm_peer struct of the receiver
  */
-void efa_rdm_ep_queue_rnr_pkt(struct efa_rdm_ep *ep, struct dlist_entry *list,
-			      struct efa_rdm_pke *pkt_entry)
+void efa_rdm_ep_queue_rnr_pkt(struct efa_rdm_ep *ep, struct efa_rdm_pke *pkt_entry)
 {
 	static const int random_min_timeout = 40;
 	static const int random_max_timeout = 120;
 	struct efa_rdm_peer *peer;
+	struct efa_rdm_ope *ope = pkt_entry->ope;
 
 #if ENABLE_DEBUG
 	dlist_remove(&pkt_entry->dbg_entry);
 #endif
 	peer = pkt_entry->peer;
 
-	dlist_insert_tail(&pkt_entry->entry, list);
+	assert(ope);
+	dlist_insert_tail(&pkt_entry->entry, &ope->queued_pkts);
 	ep->efa_rnr_queued_pkt_cnt += 1;
 	assert(peer);
+	if (!(ope->internal_flags & EFA_RDM_OPE_QUEUED_RNR)) {
+		ope->internal_flags |= EFA_RDM_OPE_QUEUED_RNR;
+		dlist_insert_tail(&ope->queued_entry, &efa_rdm_ep_domain(ep)->ope_queued_list);
+	}
 	if (!(pkt_entry->flags & EFA_RDM_PKE_RNR_RETRANSMIT)) {
 		/* This is the first time this packet encountered RNR,
 		 * we are NOT going to put the peer in backoff mode just yet.

--- a/prov/efa/src/rdm/efa_rdm_ep_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_utils.c
@@ -741,7 +741,6 @@ ssize_t efa_rdm_ep_post_queued_pkts(struct efa_rdm_ep *ep,
 {
 	struct dlist_entry *tmp;
 	struct efa_rdm_pke *pkt_entry;
-	struct efa_rdm_base_hdr *base_hdr;
 	ssize_t ret;
 
 	dlist_foreach_container_safe(pkts, struct efa_rdm_pke,
@@ -753,16 +752,14 @@ ssize_t efa_rdm_ep_post_queued_pkts(struct efa_rdm_ep *ep,
 		 */
 		dlist_remove(&pkt_entry->entry);
 
-		if (pkt_entry->flags & EFA_RDM_PKE_SEND_TO_USER_RECV_QP) {
+		switch (efa_rdm_pkt_type_of(pkt_entry)) {
+		case EFA_RDM_RMA_CONTEXT_PKT:
+			assert(((struct efa_rdm_rma_context_pkt *)pkt_entry->wiredata)->context_type == EFA_RDM_RDMA_WRITE_CONTEXT);
+			ret = efa_rdm_pke_write(pkt_entry);
+			break;
+		default:
 			ret = efa_rdm_pke_sendv(&pkt_entry, 1, 0);
-		} else {
-			base_hdr = efa_rdm_pke_get_base_hdr(pkt_entry);
-			if (base_hdr->type == EFA_RDM_RMA_CONTEXT_PKT) {
-				assert(((struct efa_rdm_rma_context_pkt *)pkt_entry->wiredata)->context_type == EFA_RDM_RDMA_WRITE_CONTEXT);
-				ret = efa_rdm_pke_write(pkt_entry);
-			} else {
-				ret = efa_rdm_pke_sendv(&pkt_entry, 1, 0);
-			}
+			break;
 		}
 
 		if (ret) {

--- a/prov/efa/src/rdm/efa_rdm_ope.h
+++ b/prov/efa/src/rdm/efa_rdm_ope.h
@@ -338,4 +338,7 @@ ssize_t efa_rdm_ope_post_send_or_queue(struct efa_rdm_ope *ope, int pkt_type);
 ssize_t efa_rdm_ope_repost_ope_queued_before_handshake(struct efa_rdm_ope *ope);
 
 ssize_t efa_rdm_txe_prepare_local_read_pkt_entry(struct efa_rdm_ope *txe);
+
+int efa_rdm_ope_process_queued_ope(struct efa_rdm_ope *ope, uint16_t flag);
+
 #endif

--- a/prov/efa/src/rdm/efa_rdm_pke.c
+++ b/prov/efa/src/rdm/efa_rdm_pke.c
@@ -73,6 +73,15 @@ struct efa_rdm_pke *efa_rdm_pke_alloc(struct efa_rdm_ep *ep,
 	pkt_entry->payload_size = 0;
 	pkt_entry->payload_mr = NULL;
 	pkt_entry->peer = NULL;
+
+	switch (alloc_type) {
+	case EFA_RDM_PKE_FROM_USER_RX_POOL:
+	case EFA_RDM_PKE_FROM_READ_COPY_POOL:
+		pkt_entry->flags |= EFA_RDM_PKE_HAS_NO_BASE_HDR;
+		break;
+	default:
+		break;
+	}
 	return pkt_entry;
 }
 

--- a/prov/efa/src/rdm/efa_rdm_pke.h
+++ b/prov/efa/src/rdm/efa_rdm_pke.h
@@ -15,6 +15,7 @@
 #define EFA_RDM_PKE_DC_LONGCTS_DATA	BIT_ULL(3) /**< this DATA packet entry is used by a delivery complete LONGCTS send/write protocol*/
 #define EFA_RDM_PKE_LOCAL_WRITE		BIT_ULL(4) /**< this packet entry is used as context of an RDMA Write to self */
 #define EFA_RDM_PKE_SEND_TO_USER_RECV_QP	BIT_ULL(5) /**< this packet entry is used for posting send to a dedicated QP that doesn't expect any pkt hdrs */
+#define EFA_RDM_PKE_HAS_NO_BASE_HDR	BIT_ULL(6)	/**< This packet entry's wiredata contains no base header */
 
 #define EFA_RDM_PKE_ALIGNMENT		128
 
@@ -129,9 +130,13 @@ struct efa_rdm_pke {
 	/** 
 	 * @brief flags indicating the status of the packet entry
 	 * 
-	 * @details
-	 * Possible flags include  #EFA_RDM_PKE_IN_USE #EFA_RDM_PKE_RNR_RETRANSMIT,
-	 * #EFA_RDM_PKE_LOCAL_READ, and #EFA_RDM_PKE_DC_LONGCTS_DATA
+	 * @see #EFA_RDM_PKE_IN_USE
+	 * @see #EFA_RDM_PKE_RNR_RETRANSMIT
+	 * @see #EFA_RDM_PKE_LOCAL_READ
+	 * @see #EFA_RDM_PKE_DC_LONGCTS_DATA 
+	 * @see #EFA_RDM_PKE_LOCAL_WRITE
+	 * @see #EFA_RDM_PKE_SEND_TO_USER_RECV_QP
+	 * @see #EFA_RDM_PKE_HAS_NO_BASE_HDR
 	 */
 	uint32_t flags;
 

--- a/prov/efa/src/rdm/efa_rdm_pke_cmd.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_cmd.c
@@ -55,7 +55,7 @@ int efa_rdm_pke_fill_data(struct efa_rdm_pke *pkt_entry,
 	if (efa_both_support_zero_hdr_data_transfer(pkt_entry->ep, ope->peer)) {
 		/* zero hdr transfer only happens for eager msg (non-tagged) pkt */
 		assert(pkt_type == EFA_RDM_EAGER_MSGRTM_PKT);
-		pkt_entry->flags |= EFA_RDM_PKE_SEND_TO_USER_RECV_QP;
+		pkt_entry->flags |= EFA_RDM_PKE_SEND_TO_USER_RECV_QP | EFA_RDM_PKE_HAS_NO_BASE_HDR;
 	}
 
 	/* Only 3 categories of packets has data_size and data_offset:
@@ -426,7 +426,7 @@ void efa_rdm_pke_handle_tx_error(struct efa_rdm_pke *pkt_entry, int prov_errno)
 	switch (pkt_entry->ope->type) {
 	case EFA_RDM_TXE:
 		txe = pkt_entry->ope;
-		if (!(pkt_entry->flags & EFA_RDM_PKE_SEND_TO_USER_RECV_QP) && efa_rdm_pke_get_base_hdr(pkt_entry)->type == EFA_RDM_HANDSHAKE_PKT) {
+		if (efa_rdm_pkt_type_of(pkt_entry) == EFA_RDM_HANDSHAKE_PKT) {
 			switch (prov_errno) {
 				case EFA_IO_COMP_STATUS_REMOTE_ERROR_RNR:
 					/**
@@ -582,7 +582,7 @@ void efa_rdm_pke_handle_send_completion(struct efa_rdm_pke *pkt_entry)
 	}
 
 	/* Start handling pkts with hdrs */
-	switch (efa_rdm_pke_get_base_hdr(pkt_entry)->type) {
+	switch (efa_rdm_pkt_type_of(pkt_entry)) {
 	case EFA_RDM_HANDSHAKE_PKT:
 		efa_rdm_txe_release(pkt_entry->ope);
 		break;
@@ -748,7 +748,7 @@ void efa_rdm_pke_proc_received_no_hdr(struct efa_rdm_pke *pkt_entry, bool has_im
 {
 	struct efa_rdm_ope *rxe = pkt_entry->ope;
 
-	assert(pkt_entry->alloc_type == EFA_RDM_PKE_FROM_USER_RX_POOL);
+	assert(pkt_entry->flags & EFA_RDM_PKE_HAS_NO_BASE_HDR);
 	assert(rxe);
 
 	if (has_imm_data) {

--- a/prov/efa/src/rdm/efa_rdm_pke_rtm.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtm.c
@@ -552,7 +552,7 @@ ssize_t efa_rdm_pke_init_eager_msgrtm(struct efa_rdm_pke *pkt_entry,
 {
 	int ret;
 
-	if (pkt_entry->flags & EFA_RDM_PKE_SEND_TO_USER_RECV_QP)
+	if (pkt_entry->flags & EFA_RDM_PKE_HAS_NO_BASE_HDR)
 		ret = efa_rdm_pke_init_eager_msgrtm_zero_hdr(pkt_entry, txe);
 	else
 		ret = efa_rdm_pke_init_rtm_with_payload(pkt_entry,

--- a/prov/efa/src/rdm/efa_rdm_protocol.h
+++ b/prov/efa/src/rdm/efa_rdm_protocol.h
@@ -38,6 +38,8 @@
  */
 #define EFA_RDM_MAX_NUM_EXINFO				(4)
 
+#define EFA_RDM_HEADERLESS_PKT 0 /**< Sentinel value for headerless packets */
+
 /*
  * Packet type ID of each packet type (section 1.3)
  *

--- a/prov/efa/test/efa_unit_test_rnr.c
+++ b/prov/efa/test/efa_unit_test_rnr.c
@@ -46,10 +46,11 @@ void test_efa_rnr_queue_and_resend_impl(struct efa_resource **state, uint32_t op
 
 	txe = container_of(efa_rdm_ep->txe_list.next, struct efa_rdm_ope, ep_entry);
 	pkt_entry = (struct efa_rdm_pke *)g_ibv_submitted_wr_id_vec[0];
+	pkt_entry->ope = txe;
 
 	efa_rdm_ep_record_tx_op_completed(efa_rdm_ep, pkt_entry);
 
-	efa_rdm_ep_queue_rnr_pkt(efa_rdm_ep, &txe->queued_pkts, pkt_entry);
+	efa_rdm_ep_queue_rnr_pkt(efa_rdm_ep, pkt_entry);
 	assert_int_equal(pkt_entry->flags & EFA_RDM_PKE_RNR_RETRANSMIT, EFA_RDM_PKE_RNR_RETRANSMIT);
 	assert_int_equal(efa_rdm_ep->efa_rnr_queued_pkt_cnt, 1);
 	assert_int_equal(efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr)->rnr_queued_pkt_cnt, 1);


### PR DESCRIPTION
This silently drops applicable outstanding operations for a closing EP, instead of reporting completions. Exceptions are RECEIPT and EOR packets when `FI_RM_ENABLED` is set - these packets will be reposted when RNR is encountered.