### PR TITLE
prov/efa: Track mr status

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_ep_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_utils.c
@@ -250,14 +250,6 @@ int efa_rdm_ep_post_user_recv_buf(struct efa_rdm_ep *ep, struct efa_rdm_ope *rxe
 	assert(rx_iov_offset < rxe->iov[rx_iov_index].iov_len);
 	assert(ep->base_ep.domain->mr_local);
 
-	if (!rxe->desc[rx_iov_index]) {
-		err = -FI_EINVAL;
-		EFA_WARN(FI_LOG_EP_CTRL,
-			 "No valid desc is provided, not complied with FI_MR_LOCAL: %s (%d)\n",
-			 fi_strerror(-err), -err);
-		goto err_free;
-	}
-
 	pkt_entry->payload = (char *) rxe->iov[rx_iov_index].iov_base + rx_iov_offset;
 	pkt_entry->payload_mr = rxe->desc[rx_iov_index];
 	pkt_entry->payload_size = ofi_total_iov_len(&rxe->iov[rx_iov_index], rxe->iov_count - rx_iov_index) - rx_iov_offset;
@@ -732,7 +724,6 @@ ssize_t efa_rdm_ep_post_queued_pkts(struct efa_rdm_ep *ep,
 				/* add the pkt back to pkts, so it can be resent again */
 				dlist_insert_tail(&pkt_entry->entry, pkts);
 			}
-
 			return ret;
 		}
 

--- a/prov/efa/src/rdm/efa_rdm_ep_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_utils.c
@@ -723,6 +723,9 @@ ssize_t efa_rdm_ep_post_queued_pkts(struct efa_rdm_ep *ep,
 			if (ret == -FI_EAGAIN) {
 				/* add the pkt back to pkts, so it can be resent again */
 				dlist_insert_tail(&pkt_entry->entry, pkts);
+			} else {
+				EFA_WARN(FI_LOG_EP_DATA, "queued pkt entry post failed: %ld\n", ret);
+				efa_rdm_pke_release_tx(pkt_entry);
 			}
 			return ret;
 		}

--- a/prov/efa/src/rdm/efa_rdm_pke.c
+++ b/prov/efa/src/rdm/efa_rdm_pke.c
@@ -106,6 +106,7 @@ void efa_rdm_pke_release_tx(struct efa_rdm_pke *pkt_entry)
 #if ENABLE_DEBUG
 	dlist_remove(&pkt_entry->dbg_entry);
 #endif
+	dlist_remove(&pkt_entry->entry);
 	/*
 	 * Decrement rnr_queued_pkts counter and reset backoff for this peer if
 	 * we get a send completion for a retransmitted packet.

--- a/prov/efa/test/efa_unit_test_ope.c
+++ b/prov/efa/test/efa_unit_test_ope.c
@@ -327,6 +327,8 @@ void test_efa_rdm_rxe_post_local_read_or_queue_impl(struct efa_resource *resourc
 
 	rxe = efa_rdm_ep_alloc_rxe(efa_rdm_ep, FI_ADDR_UNSPEC, ofi_op_tagged);
 	cuda_mr.peer.iface = FI_HMEM_CUDA;
+	ofi_atomic_initialize32(&cuda_mr.active, 1);
+	ofi_atomic_initialize32(&cuda_mr.ref, 0);
 
 	rxe->desc[0] = &cuda_mr;
 	rxe->iov_count = 1;


### PR DESCRIPTION
Currently, there is no track for the reg/dereg status of
an MR in efa provider, because `fi_close(mr)` will simply
free all the `efa_mr` object. This will cause crash or other
undeterministic when an application close a mr when there
are outstanding operations still reference it.

This patch resolves this problem by introducing two fields
in efa_mr structure: active and ref.

ref is the count of operations (op entries) that an mr
is referenced. It is initialized as 0 during mr registration,
, incremented when the mr is referenced by an operation,
and decremented when the operation is resolved.

active is a simple boolean that is toggled as true when
mr is registered and toggled as false when mr is deregistered
by fi_close.

The lifecycle or an efa_mr object behaves as:

1. Allocated during fi_mr_reg*, initialize active as 1, ref as 0
2. op 1 referenced the mr, ref++
3. op 2 referenced the mr, ref--
4. fi_close dereg the mr, active is set as 0, while the object is
not freed.
5. op 1 completes, ref--
6. op 2 completes, ref--, now ref is 0 and active is 0, object is
freed.

The sequence of 4, 5, 6 can be any order, and the object will be
freed only when active is 0 && ref is 0

Also introduce a check in the operation calls that any access to
inactive mr will fail with -FI_EINVAL.
