### PR TITLE
prov/shm: fix srx entry cleanup

### DIFF
--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -141,7 +141,6 @@ struct smr_pend_entry {
 };
 
 struct smr_cmd_ctx {
-	struct dlist_entry entry;
 	struct fi_peer_rx_entry *rx_entry;
 	struct smr_ep *ep;
 	struct smr_cmd cmd;
@@ -230,7 +229,6 @@ struct smr_ep {
 	struct smr_tx_fs	*tx_fs;
 	struct dlist_entry	sar_list;
 	struct dlist_entry	ipc_cpy_pend_list;
-	struct dlist_entry	unexp_cmd_list;
 	size_t			min_multi_recv_size;
 
 	int			ep_idx;

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -852,7 +852,6 @@ int smr_unexp_start(struct fi_peer_rx_entry *rx_entry)
 	else
 		ret = smr_start_common(cmd_ctx->ep, &cmd_ctx->cmd, rx_entry);
 
-	dlist_remove(&cmd_ctx->entry);
 	ofi_buf_free(cmd_ctx);
 
 	return ret;
@@ -978,7 +977,6 @@ static int smr_alloc_cmd_ctx(struct smr_ep *ep,
 		memcpy(&cmd_ctx->cmd, cmd, sizeof(*cmd));
 	}
 
-	dlist_insert_tail(&cmd_ctx->entry, &ep->unexp_cmd_list);
 	rx_entry->peer_context = cmd_ctx;
 	return FI_SUCCESS;
 }


### PR DESCRIPTION
When cleaning up the srx (util_srx_close), the srx iterates through the list of unexpected messages and calls discard_msg/tag on each entry which means shm shouldn't have to iterate through the list of unexpected messages and free each one. The unexp_cmd_list was only there for cleanup so it can get removed.
The special case is unexpected SAR entries which also live in the sar list so the pend entry can get cleaned up. In this case, we can't free the srx entry but need to free the pend entry. This case is handled in the sar list cleanup so only the expected messages are freed. For the unexpected case, this will get triggered on the srx close

Fixes #11111 