### PR TITLE
[v2.2.x] Cherry-picked bug fixes

### DIFF
--- a/libfabric.spec.in
+++ b/libfabric.spec.in
@@ -97,6 +97,7 @@ rm -rf %{buildroot}
 %{_bindir}/fi_info
 %{_bindir}/fi_strerror
 %{_bindir}/fi_pingpong
+%{_bindir}/fi_mon_sampler
 %if 0%{?_version_symbolic_link:1}
 %{_version_symbolic_link}
 %endif

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -141,7 +141,6 @@ struct smr_pend_entry {
 };
 
 struct smr_cmd_ctx {
-	struct dlist_entry entry;
 	struct fi_peer_rx_entry *rx_entry;
 	struct smr_ep *ep;
 	struct smr_cmd cmd;
@@ -230,7 +229,6 @@ struct smr_ep {
 	struct smr_tx_fs	*tx_fs;
 	struct dlist_entry	sar_list;
 	struct dlist_entry	ipc_cpy_pend_list;
-	struct dlist_entry	unexp_cmd_list;
 	size_t			min_multi_recv_size;
 
 	int			ep_idx;

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -852,7 +852,6 @@ int smr_unexp_start(struct fi_peer_rx_entry *rx_entry)
 	else
 		ret = smr_start_common(cmd_ctx->ep, &cmd_ctx->cmd, rx_entry);
 
-	dlist_remove(&cmd_ctx->entry);
 	ofi_buf_free(cmd_ctx);
 
 	return ret;
@@ -978,7 +977,6 @@ static int smr_alloc_cmd_ctx(struct smr_ep *ep,
 		memcpy(&cmd_ctx->cmd, cmd, sizeof(*cmd));
 	}
 
-	dlist_insert_tail(&cmd_ctx->entry, &ep->unexp_cmd_list);
 	rx_entry->peer_context = cmd_ctx;
 	return FI_SUCCESS;
 }

--- a/src/log.c
+++ b/src/log.c
@@ -100,7 +100,7 @@ static int fi_convert_log_str(const char *value)
 	if (!value)
 		return -1;
 
-	for (i = 0; log_levels[i]; i++) {
+	for (i = 0; i < OFI_LOG_MAX; i++) {
 		if (!strcasecmp(value, log_levels[i]))
 			return i;
 	}


### PR DESCRIPTION
- build: Add fi_mon_sampler to specfile's %files section 
- log: Fix buffer overrun when accessing the 'log_levels' array 
- prov/shm: fix srx entry cleanup 






