### PR TITLE
[v2.2.x] prov/shm: add shm rename and retry

### DIFF
--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -232,6 +232,7 @@ struct smr_ep {
 	size_t			min_multi_recv_size;
 
 	int			ep_idx;
+	bool			user_setname;
 	enum ofi_shm_p2p_type	p2p_type;
 	struct smr_sock_info	*sock_info;
 	void			*dsa_context;

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -52,9 +52,8 @@ DEFINE_LIST(sock_name_list);
 pthread_mutex_t sock_list_lock = PTHREAD_MUTEX_INITIALIZER;
 int smr_global_ep_idx = 0;
 
-int smr_setname(fid_t fid, void *addr, size_t addrlen)
+static int smr_setname_internal(struct smr_ep *ep, void *addr, size_t addrlen)
 {
-	struct smr_ep *ep;
 	char *name;
 
 	if (addrlen > SMR_NAME_MAX) {
@@ -63,7 +62,6 @@ int smr_setname(fid_t fid, void *addr, size_t addrlen)
 		return -FI_EINVAL;
 	}
 
-	ep = container_of(fid, struct smr_ep, util_ep.ep_fid.fid);
 	if (ep->region) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"Cannot set name after EP has been enabled\n");
@@ -78,6 +76,16 @@ int smr_setname(fid_t fid, void *addr, size_t addrlen)
 		free((void *) ep->name);
 	ep->name = name;
 	return 0;
+}
+
+int smr_setname(fid_t fid, void *addr, size_t addrlen)
+{
+	struct smr_ep *ep;
+
+	ep = container_of(fid, struct smr_ep, util_ep.ep_fid.fid);
+	ep->user_setname = true;
+
+	return smr_setname_internal(ep, addr, addrlen);
 }
 
 int smr_getname(fid_t fid, void *addr, size_t *addrlen)
@@ -1116,6 +1124,7 @@ static int smr_ep_ctrl(struct fid *fid, int command, void *arg)
 	struct smr_ep *ep;
 	struct smr_av *av;
 	struct fid_ep *srx;
+	char tmp_name[SMR_NAME_MAX];
 	int ret;
 
 	ep = container_of(fid, struct smr_ep, util_ep.ep_fid.fid);
@@ -1129,15 +1138,25 @@ static int smr_ep_ctrl(struct fid *fid, int command, void *arg)
 		if (!ep->util_ep.av)
 			return -FI_ENOAV;
 
-		attr.name = smr_no_prefix(ep->name);
 		attr.rx_count = ep->rx_size;
 		attr.tx_count = ep->tx_size;
 		attr.flags = ep->util_ep.caps & FI_HMEM ?
 				SMR_FLAG_HMEM_ENABLED : 0;
 
+create_shm:
+		attr.name = smr_no_prefix(ep->name);
 		ret = smr_create(&smr_prov, &av->smr_map, &attr, &ep->region);
-		if (ret)
-			return ret;
+		if (ret == -FI_EBUSY && !ep->user_setname) {
+			snprintf(tmp_name, SMR_NAME_MAX - 1, "%s:%u",
+				 ep->name, ofi_generate_seed());
+			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+				"SMR %s busy, retry with name %s\n",
+				ep->name, tmp_name);
+
+			if (strcmp(tmp_name, ep->name) &&
+			    !smr_setname_internal(ep, tmp_name, SMR_NAME_MAX))
+				goto create_shm;
+		}
 
 		if (ep->util_ep.caps & FI_HMEM || smr_env.disable_cma) {
 			ep->region->cma_cap_peer = SMR_VMA_CAP_OFF;
@@ -1294,7 +1313,8 @@ int smr_endpoint(struct fid_domain *domain, struct fi_info *info,
 	ret = smr_endpoint_name(ep, name, info->src_addr, info->src_addrlen);
 	if (ret)
 		goto free;
-	ret = smr_setname(&ep->util_ep.ep_fid.fid, name, SMR_NAME_MAX);
+
+	ret = smr_setname_internal(ep, name, SMR_NAME_MAX);
 	if (ret)
 		goto free;
 

--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -228,6 +228,8 @@ struct smr_region {
 	uint8_t		resv;
 	uint16_t	flags;
 	int		pid;
+	/* Do not touch above fields. It might break backwards compatibility */
+
 	uint8_t		cma_cap_peer;
 	uint8_t		cma_cap_self;
 	uint8_t		xpmem_cap_self;


### PR DESCRIPTION
The shm provider does its best to randomize an EP name and make it unique by defaulting to "pid:domain_id:ep_id"
If there already exists a region with that name, the provider wil try to map to the existing region and see if the pid is alive and remap if the pid is dead.
This method doesn't work well with docker containers as the pids live within the container. This means you can have a docker pid 100 that coincides with a host system pid 100 running a root service OR you could have two docker containers running simultaneously that are trying to use the same pid (and therefore shm region name). This can result in a failure to create the shm region or failure to detect whether the pid is actually alive. To fix this, we can fallback to a retry of the shm create and append a random seed number to the shm region name to make sure it is unique in case a shm region already exists with that name.
There is a scenario where the app overrides the default shm name with a specific name. If that's the case, we shouldn't override the user-selected name and, instead, fail if it's not available.

cherry-picked from commit 0fb02def33cf1ad6551a7b775f285bfb6c5c2dcb