### PR TITLE
github/workflows: Tighten the token permission settings

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,8 @@
 #
 name: "CodeQL"
 
+permissions: {}
+
 on:
   push:
     branches: [ "main" ]

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -4,8 +4,7 @@ on:
   # UTC time, 'minute hour day-of-month month day-of-week'
   - cron: '0 5 * * *'
 
-permissions:
-  contents: read
+permissions: {}
 
 env:
   APT_PACKAGES: >-
@@ -46,6 +45,9 @@ env:
   RDMA_CORE_VERSION: v35.0
 jobs:
   coverity:
+    permissions:
+      contents: read
+
     runs-on: ubuntu-22.04
     steps:
       - name: Install dependencies (Linux)

--- a/.github/workflows/gh-man.yaml
+++ b/.github/workflows/gh-man.yaml
@@ -1,5 +1,7 @@
 name: GH Man Page Updater
 
+permissions: {}
+
 on:
   push:
     branches:

--- a/.github/workflows/nroff-elves.yaml
+++ b/.github/workflows/nroff-elves.yaml
@@ -1,5 +1,7 @@
 name: Man Page Converter
 
+permissions: {}
+
 on:
     push:
         paths:

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,8 +1,6 @@
 name: Build Checks
 on: [push, pull_request]
-permissions:
-  contents: read
-  pull-requests: read
+permissions: {}
 env:
   APT_PACKAGES: >-
     abi-compliance-checker
@@ -42,6 +40,9 @@ env:
   RDMA_CORE_VERSION: v35.0
 jobs:
   linux:
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: '${{ matrix.os }}'
     strategy:
       matrix:
@@ -75,6 +76,9 @@ jobs:
           name: ${{ matrix.os }}-${{ matrix.cc }}-config.log
           path: config.log
   hmem:
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-22.04
     steps:
       - name: Install dependencies (Linux)
@@ -120,6 +124,9 @@ jobs:
           name: hmem-config.log
           path: config.log
   macos:
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: macos-13
     steps:
       - name: Install dependencies (Mac OS)

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,8 +15,8 @@ on:
   push:
     branches: [ "main" ]
 
-# Declare default permissions as read only.
-permissions: read-all
+# Declare default permissions as none.
+permissions: {}
 
 jobs:
   analysis:
@@ -27,9 +27,10 @@ jobs:
       security-events: write
       # Needed to publish results and get a badge (see publish_results below).
       id-token: write
-      # Uncomment the permissions below if installing in a private repository.
-      # contents: read
-      # actions: read
+      # Uncomment the permissions below if installing in a private repository
+      # or if the top level permission is set to none instead of read-all.
+      contents: read
+      actions: read
 
     steps:
       - name: "Checkout code"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,6 +5,8 @@
 # https://github.com/actions/stale
 name: Mark stale issues and pull requests
 
+permissions: {}
+
 on:
   schedule:
   - cron: '26 10 * * *'


### PR DESCRIPTION
Follow the principle of least privilege by setting the top level permissions to "none" and only granting needed permissions at the "run" level (i.e. for individual job).

Hopefully this can improve the OpenSFF scorecard number.