### PR TITLE
libfabric: Allow peer mem support for bnxt_re devices also

### DIFF
--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -727,10 +727,12 @@ static bool vrb_hmem_supported(const char *dev_name)
 	if (ofi_hmem_p2p_disabled())
 		return false;
 
-	if (vrb_gl_data.peer_mem_support && strstr(dev_name, "mlx"))
+	if (vrb_gl_data.peer_mem_support && (strstr(dev_name, "mlx") ||
+					     strstr(dev_name, "bnxt_re")))
 		return true;
 
-	if (vrb_gl_data.dmabuf_support && strstr(dev_name, "mlx5"))
+	if (vrb_gl_data.dmabuf_support && (strstr(dev_name, "mlx") ||
+					   strstr(dev_name, "bnxt_re")))
 		return true;
 
 	return false;


### PR DESCRIPTION
bnxt_re also supports peermem access. Allow peermem access if the device name matches with bnxt_re.