### PR TITLE
prov/efa: Add implicit AV and logic to move entries to explicit AV

### DIFF
--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -787,8 +787,11 @@ void efa_domain_progress_rdm_peers_and_queues(struct efa_domain *domain)
 
 		if (OFI_UNLIKELY(ret)) {
 			EFA_WARN(FI_LOG_EP_CTRL,
-				"Failed to post HANDSHAKE to peer %ld: %s\n",
-				peer->conn->fi_addr, fi_strerror(-ret));
+				 "Failed to post HANDSHAKE to peer fi_addr: "
+				 "%ld implicit fi_addr: %ld. %s\n",
+				 peer->conn->fi_addr,
+				 peer->conn->implicit_fi_addr,
+				 fi_strerror(-ret));
 			efa_base_ep_write_eq_error(&peer->ep->base_ep, -ret, FI_EFA_ERR_PEER_HANDSHAKE);
 			continue;
 		}

--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -119,6 +119,10 @@ struct efa_rdm_ep {
 
 	/* Hashmap between fi_addr and efa_rdm_peer structs */
 	struct efa_rdm_ep_peer_map_entry *fi_addr_to_peer_map;
+
+	/* Hashmap between implicit peer id and efa_rdm_peer structs */
+	struct efa_rdm_ep_peer_map_entry *fi_addr_to_peer_map_implicit;
+
 	/* bufpool to hold the fi_addr->peer hashmap entries */
 	struct ofi_bufpool *peer_map_entry_pool;
 
@@ -205,6 +209,7 @@ struct efa_ep_addr *efa_rdm_ep_raw_addr(struct efa_rdm_ep *ep);
 struct efa_rdm_peer *efa_rdm_ep_get_peer(struct efa_rdm_ep *ep, fi_addr_t addr);
 
 int32_t efa_rdm_ep_get_peer_ahn(struct efa_rdm_ep *ep, fi_addr_t addr);
+struct efa_rdm_peer *efa_rdm_ep_get_peer_implicit(struct efa_rdm_ep *ep, fi_addr_t addr);
 
 struct efa_rdm_ope *efa_rdm_ep_alloc_txe(struct efa_rdm_ep *efa_rdm_ep,
 					 struct efa_rdm_peer *peer,
@@ -550,10 +555,24 @@ bool efa_rdm_ep_support_unsolicited_write_recv(struct efa_rdm_ep *ep)
 struct efa_rdm_ep_peer_map_entry {
 	fi_addr_t addr;
 	struct efa_rdm_peer peer;
-	UT_hash_handle hh;
+	UT_hash_handle hndl;
 };
 
-int efa_rdm_ep_peer_map_insert(struct efa_rdm_ep *ep, fi_addr_t addr, struct efa_rdm_ep_peer_map_entry *map_entry);
-struct efa_rdm_peer *efa_rdm_ep_peer_map_lookup(struct efa_rdm_ep *ep, fi_addr_t addr);
-void efa_rdm_ep_peer_map_remove(struct efa_rdm_ep *ep, fi_addr_t addr);
+int
+efa_rdm_ep_peer_map_insert(struct efa_rdm_ep_peer_map_entry **peer_map,
+			   fi_addr_t addr,
+			   struct efa_rdm_ep_peer_map_entry *map_entry);
+struct efa_rdm_peer *
+efa_rdm_ep_peer_map_lookup(struct efa_rdm_ep_peer_map_entry **peer_map,
+			   fi_addr_t addr);
+void efa_rdm_ep_peer_map_remove(struct efa_rdm_ep_peer_map_entry **peer_map,
+				fi_addr_t addr);
+
+void efa_rdm_ep_peer_map_implicit_to_explicit(struct efa_rdm_ep *ep,
+					      struct efa_rdm_peer *peer,
+					      fi_addr_t implicit_fi_addr,
+					      fi_addr_t explicit_fi_addr);
+
+bool efa_rdm_ep_has_unfinished_send(struct efa_rdm_ep *efa_rdm_ep);
+
 #endif

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -796,7 +796,6 @@ static void efa_rdm_ep_destroy_buffer_pools(struct efa_rdm_ep *efa_rdm_ep)
  * @param[in]  efa_rdm_ep      endpoint
  * @return     a boolean
  */
-static
 bool efa_rdm_ep_has_unfinished_send(struct efa_rdm_ep *efa_rdm_ep)
 {
 	struct dlist_entry *entry, *tmp;

--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -797,10 +797,10 @@ void efa_rdm_rxe_report_completion(struct efa_rdm_ope *rxe)
 	if (OFI_UNLIKELY(rxe->cq_entry.len < rxe->total_len)) {
 		EFA_WARN(FI_LOG_CQ,
 			 "Message truncated! from peer %" PRIu64
-			 " rx_id: %" PRIu32 " msg_id: %" PRIu32 " tag: %" PRIu64
+			 " implicit fi_addr: %" PRIu64 " rx_id: %" PRIu32 " msg_id: %" PRIu32 " tag: %" PRIu64
 			 " incoming message size: %" PRIu64
 			 " receiving buffer size: %zu\n",
-			 rxe->peer->conn->fi_addr, rxe->rx_id, rxe->msg_id, rxe->cq_entry.tag,
+			 rxe->peer->conn->fi_addr, rxe->peer->conn->implicit_fi_addr, rxe->rx_id, rxe->msg_id, rxe->cq_entry.tag,
 			 rxe->total_len, rxe->cq_entry.len);
 
 		ret = ofi_cq_write_error_trunc(ep->base_ep.util_ep.rx_cq,
@@ -829,11 +829,13 @@ void efa_rdm_rxe_report_completion(struct efa_rdm_ope *rxe)
 	    (ofi_need_completion(cq_flags, rxe->fi_flags) ||
 	     (rxe->cq_entry.flags & FI_MULTI_RECV))) {
 		EFA_DBG(FI_LOG_CQ,
-		       "Writing recv completion for rxe from peer: %"
-		       PRIu64 " rx_id: %" PRIu32 " msg_id: %" PRIu32
-		       " tag: %lx total_len: %" PRIu64 "\n",
-		       rxe->peer->conn->fi_addr, rxe->rx_id, rxe->msg_id,
-		       rxe->cq_entry.tag, rxe->total_len);
+			"Writing recv completion for rxe from peer: %" PRIu64
+			" implicit fi_addr: %" PRIu64 " rx_id: %" PRIu32
+			" msg_id: %" PRIu32 " tag: %lx total_len: %" PRIu64
+			"\n",
+			rxe->peer->conn->fi_addr,
+			rxe->peer->conn->implicit_fi_addr, rxe->rx_id,
+			rxe->msg_id, rxe->cq_entry.tag, rxe->total_len);
 
 		efa_rdm_tracepoint(recv_end,
 			    rxe->msg_id, (size_t) rxe->cq_entry.op_context,

--- a/prov/efa/src/rdm/efa_rdm_pke.c
+++ b/prov/efa/src/rdm/efa_rdm_pke.c
@@ -124,8 +124,10 @@ void efa_rdm_pke_release_tx(struct efa_rdm_pke *pkt_entry)
 			peer->flags &= ~EFA_RDM_PEER_IN_BACKOFF;
 		}
 		EFA_DBG(FI_LOG_EP_DATA,
-		       "reset backoff timer for peer: %" PRIu64 "\n",
-		       pkt_entry->peer->conn->fi_addr);
+			"reset backoff timer for peer fi_addr: %" PRIu64
+			" implicit fi_addr: %" PRIu64 "\n",
+			pkt_entry->peer->conn->fi_addr,
+			pkt_entry->peer->conn->implicit_fi_addr);
 	}
 
 	efa_rdm_pke_release(pkt_entry);

--- a/prov/efa/src/rdm/efa_rdm_pke_cmd.h
+++ b/prov/efa/src/rdm/efa_rdm_pke_cmd.h
@@ -16,8 +16,6 @@ int efa_rdm_pke_fill_data(struct efa_rdm_pke *pke,
 
 void efa_rdm_pke_handle_sent(struct efa_rdm_pke *pke, int pkt_type, struct efa_rdm_peer *peer);
 
-fi_addr_t efa_rdm_pke_determine_addr(struct efa_rdm_pke *pkt_entry);
-
 void efa_rdm_pke_handle_data_copied(struct efa_rdm_pke *pkt_entry);
 
 void efa_rdm_pke_handle_tx_error(struct efa_rdm_pke *pkt_entry, int prov_errno);

--- a/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
@@ -96,12 +96,11 @@ void efa_rdm_pke_handle_handshake_recv(struct efa_rdm_pke *pkt_entry)
 	struct efa_rdm_peer *peer;
 	uint64_t *host_id_ptr;
 
-	assert(pkt_entry->peer->conn->fi_addr != FI_ADDR_NOTAVAIL);
-	EFA_DBG(FI_LOG_CQ,
-		"HANDSHAKE received from %" PRIu64 "\n", pkt_entry->peer->conn->fi_addr);
-
 	peer = pkt_entry->peer;
 	assert(peer);
+
+	EFA_DBG(FI_LOG_CQ,
+		"HANDSHAKE received from %" PRIu64 "\n", pkt_entry->peer->conn->fi_addr);
 
 	handshake_pkt = (struct efa_rdm_handshake_hdr *)pkt_entry->wiredata;
 

--- a/prov/efa/src/rdm/efa_rdm_pke_print.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_print.c
@@ -145,6 +145,7 @@ static void efa_rdm_pke_print_eager_tag_rtm(char *prefix,
 	size_t str_len = EFA_RDM_PKE_DUMP_DATA_LEN * 4, l;
 	char *opt_hdr;
 	uint8_t *data;
+	fi_addr_t fi_addr = FI_ADDR_NOTAVAIL;
 	int i;
 
 	str[str_len - 1] = '\0';
@@ -152,12 +153,15 @@ static void efa_rdm_pke_print_eager_tag_rtm(char *prefix,
 	base_hdr = (struct efa_rdm_rtm_base_hdr *) pkt_entry->wiredata;
 	tag_rtm_hdr = (struct efa_rdm_eager_tagrtm_hdr *) pkt_entry->wiredata;
 
+	if (pkt_entry->peer)
+		fi_addr = pkt_entry->peer->conn->fi_addr;
+
 	EFA_DBG(FI_LOG_EP_DATA,
 		"%s EFA RDM RTM packet - type: %" PRIu32 "  version: %" PRIu8
 		" flags: %x peer: %" PRIu64 " msg_id: %" PRIu32 " tag: %" PRIu64
 		"\n",
 		prefix, base_hdr->type, base_hdr->version, base_hdr->flags,
-		pkt_entry->peer->conn->fi_addr, base_hdr->msg_id, tag_rtm_hdr->tag);
+		fi_addr, base_hdr->msg_id, tag_rtm_hdr->tag);
 
     efa_rdm_pke_print_req_hdr(pkt_entry, base_hdr, &opt_hdr);
 

--- a/prov/efa/test/efa_unit_test_av.c
+++ b/prov/efa/test/efa_unit_test_av.c
@@ -2,6 +2,8 @@
 /* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
 
 #include "efa_unit_tests.h"
+#include "efa_rdm_cq.h"
+#include "efa_rdm_pke_req.h"
 #include "efa_av.h"
 
 /**
@@ -262,16 +264,31 @@ void test_av_multiple_ep_efa_direct(struct efa_resource **state)
 	return test_av_multiple_ep_impl(state, EFA_DIRECT_FABRIC_NAME);
 }
 
-static void test_av_verify_av_hash_cnt(struct efa_av *av, int cur_av_count, int prv_av_count) {
-	assert_int_equal(HASH_CNT(hh, av->util_av.hash), cur_av_count + prv_av_count);
-	assert_int_equal(HASH_CNT(hh, av->cur_reverse_av), cur_av_count);
-	assert_int_equal(HASH_CNT(hh, av->prv_reverse_av), prv_av_count);
+static void test_av_verify_av_hash_cnt(struct efa_av *av,
+				       int explicit_cur_av_count,
+				       int explicit_prv_av_count,
+				       int implicit_cur_av_count,
+				       int implicit_prv_av_count)
+{
+	assert_int_equal(HASH_CNT(hh, av->util_av.hash),
+			 explicit_cur_av_count + explicit_prv_av_count);
+	assert_int_equal(HASH_CNT(hh, av->cur_reverse_av),
+			 explicit_cur_av_count);
+	assert_int_equal(HASH_CNT(hh, av->prv_reverse_av),
+			 explicit_prv_av_count);
+
+	assert_int_equal(HASH_CNT(hh, av->util_av_implicit.hash),
+			 implicit_cur_av_count + implicit_prv_av_count);
+	assert_int_equal(HASH_CNT(hh, av->cur_reverse_av_implicit),
+			 implicit_cur_av_count);
+	assert_int_equal(HASH_CNT(hh, av->prv_reverse_av_implicit),
+			 implicit_prv_av_count);
 }
 
 /**
  * @brief This test removes a peer and inserts it again
  *
- * @param[in]	state		struct efa_resource that is managed by the framework
+ * @param[in]	state	struct efa_resource that is managed by the framework
  */
 void test_av_reinsertion(struct efa_resource **state)
 {
@@ -297,7 +314,7 @@ void test_av_reinsertion(struct efa_resource **state)
 	err = fi_av_insert(resource->av, &raw_addr, 1, &fi_addr, 0, NULL);
 	assert_int_equal(err, 1);
 	assert_int_equal(fi_addr, 0);
-	test_av_verify_av_hash_cnt(av, 1, 0);
+	test_av_verify_av_hash_cnt(av, 1, 0, 0, 0);
 
 	err = fi_av_lookup(resource->av, fi_addr, &raw_addr_2, &raw_addr_len);
 	assert_int_equal(err, 0);
@@ -305,15 +322,16 @@ void test_av_reinsertion(struct efa_resource **state)
 
 	peer = efa_rdm_ep_get_peer(efa_rdm_ep, fi_addr);
 	assert_int_equal(peer->conn->fi_addr, fi_addr);
+	assert_int_equal(efa_is_same_addr(&raw_addr, peer->conn->ep_addr), 1);
 
 	err = fi_av_remove(resource->av, &fi_addr, 1, 0);
 	assert_int_equal(err, 0);
-	test_av_verify_av_hash_cnt(av, 0, 0);
+	test_av_verify_av_hash_cnt(av, 0, 0, 0, 0);
 
 	err = fi_av_insert(resource->av, &raw_addr, 1, &fi_addr, 0, NULL);
 	assert_int_equal(err, 1);
 	assert_int_equal(fi_addr, 0);
-	test_av_verify_av_hash_cnt(av, 1, 0);
+	test_av_verify_av_hash_cnt(av, 1, 0, 0, 0);
 
 	err = fi_av_lookup(resource->av, fi_addr, &raw_addr_2, &raw_addr_len);
 	assert_int_equal(err, 0);
@@ -321,8 +339,121 @@ void test_av_reinsertion(struct efa_resource **state)
 
 	peer = efa_rdm_ep_get_peer(efa_rdm_ep, fi_addr);
 	assert_int_equal(peer->conn->fi_addr, fi_addr);
+	assert_int_equal(efa_is_same_addr(&raw_addr, peer->conn->ep_addr), 1);
 
 	err = fi_av_remove(resource->av, &fi_addr, 1, 0);
 	assert_int_equal(err, 0);
-	test_av_verify_av_hash_cnt(av, 0, 0);
+	test_av_verify_av_hash_cnt(av, 0, 0, 0, 0);
+}
+
+static struct efa_rdm_peer *test_av_get_peer_from_implicit_av(struct efa_resource *resource)
+{
+	struct efa_ep_addr raw_addr;
+	size_t raw_addr_len = sizeof(struct efa_ep_addr);
+	struct efa_rdm_ep *efa_rdm_ep;
+	struct efa_rdm_peer *peer;
+	fi_addr_t implicit_fi_addr, test_addr;
+	struct efa_av *av;
+	uint32_t ahn;
+	int err;
+
+	av = container_of(resource->av, struct efa_av, util_av.av_fid);
+	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
+
+	err = fi_getname(&resource->ep->fid, &raw_addr, &raw_addr_len);
+	assert_int_equal(err, 0);
+	raw_addr.qpn = 1;
+	raw_addr.qkey = 0x1234;
+	ahn = efa_rdm_ep->base_ep.self_ah->ahn;
+
+	/* Manually insert into implicit AV */
+	ofi_genlock_lock(&efa_rdm_ep->base_ep.domain->srx_lock);
+	err = efa_av_insert_one(av, &raw_addr, &implicit_fi_addr, 0, NULL, true, true);
+	ofi_genlock_unlock(&efa_rdm_ep->base_ep.domain->srx_lock);
+	test_av_verify_av_hash_cnt(av, 0, 0, 1, 0);
+
+	peer = efa_rdm_ep_get_peer_implicit(efa_rdm_ep, implicit_fi_addr);
+	assert_int_equal(peer->conn->implicit_fi_addr, implicit_fi_addr);
+	assert_int_equal(peer->conn->fi_addr, FI_ADDR_NOTAVAIL);
+	assert_int_equal(efa_is_same_addr(&raw_addr, peer->conn->ep_addr), 1);
+
+	test_addr = efa_av_reverse_lookup_rdm_implicit(av, ahn, raw_addr.qpn, NULL);
+	assert_int_equal(test_addr, implicit_fi_addr);
+
+	return peer;
+}
+
+/**
+ * @brief This test fakes a peer in the implicit AV and closes the AV with an
+ * implicit peer in it
+ *
+ * @param[in]	state	struct efa_resource that is managed by the framework
+ */
+void test_av_implicit(struct efa_resource **state)
+{
+	struct efa_resource *resource = *state;
+
+	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_FABRIC_NAME);
+	test_av_get_peer_from_implicit_av(resource);
+}
+
+/**
+ * @brief This test fakes a peer in the implicit AV and verifies that the peer
+ * is moved to the explicit AV when fi_av_insert is called
+ *
+ * @param[in]	state	struct efa_resource that is managed by the framework
+ */
+void test_av_implicit_to_explicit(struct efa_resource **state)
+{
+	struct efa_resource *resource = *state;
+	struct efa_ep_addr raw_addr, raw_addr_2;
+	size_t raw_addr_len = sizeof(struct efa_ep_addr);
+	struct efa_rdm_ep *efa_rdm_ep;
+	struct efa_rdm_peer *peer;
+	fi_addr_t explicit_fi_addr, test_addr;
+	struct efa_av *av;
+	uint32_t ahn;
+	int err;
+
+	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_FABRIC_NAME);
+	av = container_of(resource->av, struct efa_av, util_av.av_fid);
+	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
+
+	peer = test_av_get_peer_from_implicit_av(resource);
+
+	err = fi_getname(&resource->ep->fid, &raw_addr, &raw_addr_len);
+	assert_int_equal(err, 0);
+	raw_addr.qpn = 1;
+	raw_addr.qkey = 0x1234;
+	ahn = efa_rdm_ep->base_ep.self_ah->ahn;
+
+	/* Modify the peer and verify that the peer is moved as-is */
+	peer->next_msg_id = 355;
+	peer->flags |= EFA_RDM_PEER_IN_BACKOFF;
+
+	/* Insert explicitly */
+	err = fi_av_insert(resource->av, &raw_addr, 1, &explicit_fi_addr, 0, NULL);
+	test_av_verify_av_hash_cnt(av, 1, 0, 0, 0);
+
+	err = fi_av_lookup(resource->av, explicit_fi_addr, &raw_addr_2, &raw_addr_len);
+	assert_int_equal(err, 0);
+	assert_int_equal(efa_is_same_addr(&raw_addr, &raw_addr_2), 1);
+
+	peer = efa_rdm_ep_get_peer(efa_rdm_ep, explicit_fi_addr);
+	assert_int_equal(peer->conn->fi_addr, explicit_fi_addr);
+	assert_int_equal(peer->conn->implicit_fi_addr, FI_ADDR_NOTAVAIL);
+	assert_int_equal(efa_is_same_addr(&raw_addr, peer->conn->ep_addr), 1);
+
+	test_addr = efa_av_reverse_lookup_rdm(av, ahn, raw_addr.qpn, NULL);
+	assert_int_equal(test_addr, explicit_fi_addr);
+
+	/* Verify the manually set peer properties above */
+	assert_int_equal(peer->next_msg_id, 355);
+	assert_true(peer->flags & EFA_RDM_PEER_IN_BACKOFF);
+
+	peer->flags &= ~EFA_RDM_PEER_IN_BACKOFF;
+
+	err = fi_av_remove(resource->av, &explicit_fi_addr, 1, 0);
+	assert_int_equal(err, 0);
+	test_av_verify_av_hash_cnt(av, 0, 0, 0, 0);
 }

--- a/prov/efa/test/efa_unit_test_common.c
+++ b/prov/efa/test/efa_unit_test_common.c
@@ -327,6 +327,7 @@ void efa_unit_test_eager_msgrtm_pkt_construct(struct efa_rdm_pke *pkt_entry, str
 	struct efa_rdm_req_opt_connid_hdr opt_connid_hdr = {0};
 	uint32_t *connid = NULL;
 
+	base_hdr.hdr.version = EFA_RDM_PROTOCOL_VERSION;
 	base_hdr.hdr.type = EFA_RDM_EAGER_MSGRTM_PKT;
 	base_hdr.hdr.flags |= EFA_RDM_PKT_CONNID_HDR | EFA_RDM_REQ_MSG;
 	base_hdr.hdr.msg_id = attr->msg_id;

--- a/prov/efa/test/efa_unit_test_cq.c
+++ b/prov/efa/test/efa_unit_test_cq.c
@@ -803,6 +803,208 @@ void test_efa_rdm_cq_before_ep_enable(struct efa_resource **state)
 	assert_int_equal(fi_close(&ep->fid), 0);
 }
 
+#if HAVE_EFADV_CQ_EX
+/**
+ * @brief Construct an RDM endpoint and receive an eager MSG RTM packet.
+ * Simulate EFA device by setting peer AH to unknown and make sure the
+ * endpoint recovers the peer address iff(if and only if) the peer is
+ * inserted to AV.
+ *
+ * @param resource		struct efa_resource that is managed by the framework
+ * @param remove_peer	Boolean value that indicates if the peer was removed explicitly
+ * @param support_efadv_cq	Boolean value that indicates if EFA device supports EFA DV CQ
+ */
+static void test_impl_ibv_cq_ex_read_unknow_peer_ah(struct efa_resource *resource, bool remove_peer, bool support_efadv_cq)
+{
+	struct efa_rdm_ep *efa_rdm_ep;
+	struct efa_rdm_pke *pkt_entry;
+	struct efa_ep_addr raw_addr = {0};
+	size_t raw_addr_len = sizeof(raw_addr);
+	fi_addr_t peer_addr = 0;
+	struct fi_cq_data_entry cq_entry;
+	struct efa_unit_test_eager_rtm_pkt_attr pkt_attr = {0};
+	struct efadv_cq *efadv_cq;
+	struct efa_unit_test_buff recv_buff;
+	int ret;
+	struct efa_rdm_cq *efa_rdm_cq;
+	struct ibv_cq_ex *ibv_cqx;
+
+	/*
+	 * Always use mocked efadv_create_cq instead of the real one.
+	 * Otherwise the test is undeterministic depending on the host kernel:
+	 * - If the kernel supports EFA DV CQ and we set support_efadv_cq = true, then the test will pass
+	 * - If the kernel does NOT support EFA DV CQ and we set support_efadv_cq = true, then the test will fail
+	 */
+	if (support_efadv_cq) {
+		g_efa_unit_test_mocks.efadv_create_cq = &efa_mock_efadv_create_cq_with_ibv_create_cq_ex;
+		expect_function_call(efa_mock_efadv_create_cq_with_ibv_create_cq_ex);
+	} else {
+		g_efa_unit_test_mocks.efadv_create_cq = &efa_mock_efadv_create_cq_set_eopnotsupp_and_return_null;
+		expect_function_call(efa_mock_efadv_create_cq_set_eopnotsupp_and_return_null);
+	}
+
+	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_FABRIC_NAME);
+
+	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
+	efa_rdm_cq = container_of(resource->cq, struct efa_rdm_cq, efa_cq.util_cq.cq_fid.fid);
+	ibv_cqx = efa_rdm_cq->efa_cq.ibv_cq.ibv_cq_ex;
+
+	/* Construct a minimal recv buffer */
+	efa_unit_test_buff_construct(&recv_buff, resource, efa_rdm_ep->min_multi_recv_size);
+
+	/* Create and register a fake peer */
+	ret = fi_getname(&resource->ep->fid, &raw_addr, &raw_addr_len);
+	assert_int_equal(ret, 0);
+	raw_addr.qpn = 0;
+	raw_addr.qkey = 0x1234;
+
+	struct efa_rdm_peer *peer;
+	ret = fi_av_insert(resource->av, &raw_addr, 1, &peer_addr, 0, NULL);
+	assert_int_equal(ret, 1);
+
+	/* Skip handshake */
+	peer = efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr);
+	assert_non_null(peer);
+	peer->flags |= EFA_RDM_PEER_HANDSHAKE_SENT;
+
+	/*
+	 * The rx pkt entry should only be allocated and posted by the progress engine.
+	 * However, to mock a receive completion, we have to allocate an rx entry
+	 * and modify it out of band. The proess engine grow the rx pool in the first
+	 * call and set efa_rdm_ep->efa_rx_pkts_posted as the rx pool size. Here we
+	 * follow the progress engine to set the efa_rx_pkts_posted counter manually
+	 * TODO: modify the rx pkt as part of the ibv cq poll mock so we don't have to
+	 * allocate pkt entry and hack the pkt counters.
+	 */
+	pkt_entry = efa_rdm_pke_alloc(efa_rdm_ep, efa_rdm_ep->efa_rx_pkt_pool, EFA_RDM_PKE_FROM_EFA_RX_POOL);
+	assert_non_null(pkt_entry);
+	efa_rdm_ep->efa_rx_pkts_posted = efa_rdm_ep_get_rx_pool_size(efa_rdm_ep);
+
+	pkt_attr.msg_id = 0;
+	pkt_attr.connid = raw_addr.qkey;
+	/* Packet type must be in [EFA_RDM_REQ_PKT_BEGIN, EFA_RDM_EXTRA_REQ_PKT_END) */
+	efa_unit_test_eager_msgrtm_pkt_construct(pkt_entry, &pkt_attr);
+
+	/* Setup CQ */
+	ibv_cqx->wr_id = (uintptr_t)pkt_entry;
+	ibv_cqx->start_poll = &efa_mock_ibv_start_poll_return_mock;
+	ibv_cqx->next_poll = &efa_mock_ibv_next_poll_check_function_called_and_return_mock;
+	ibv_cqx->end_poll = &efa_mock_ibv_end_poll_check_mock;
+	ibv_cqx->read_slid = &efa_mock_ibv_read_slid_return_mock;
+	ibv_cqx->read_byte_len = &efa_mock_ibv_read_byte_len_return_mock;
+	ibv_cqx->read_opcode = &efa_mock_ibv_read_opcode_return_mock;
+	ibv_cqx->read_qp_num = &efa_mock_ibv_read_qp_num_return_mock;
+	ibv_cqx->read_wc_flags = &efa_mock_ibv_read_wc_flags_return_mock;
+	ibv_cqx->read_src_qp = &efa_mock_ibv_read_src_qp_return_mock;
+
+	if (support_efadv_cq) {
+		efadv_cq = efadv_cq_from_ibv_cq_ex(ibv_cqx);
+		assert_non_null(efadv_cq);
+		efadv_cq->wc_read_sgid = &efa_mock_efadv_wc_read_sgid_return_zero_code_and_expect_next_poll_and_set_gid;
+
+		/* Return unknown AH from efadv */
+		will_return(efa_mock_efadv_wc_read_sgid_return_zero_code_and_expect_next_poll_and_set_gid, raw_addr.raw);
+	} else {
+		expect_function_call(efa_mock_ibv_next_poll_check_function_called_and_return_mock);
+	}
+
+	/* Read 1 entry with unknown AH */
+	will_return(efa_mock_ibv_start_poll_return_mock, 0);
+	will_return(efa_mock_ibv_next_poll_check_function_called_and_return_mock, ENOENT);
+	will_return(efa_mock_ibv_end_poll_check_mock, NULL);
+	will_return(efa_mock_ibv_read_slid_return_mock, 0xffff); // slid=0xffff(-1) indicates an unknown AH
+	will_return(efa_mock_ibv_read_byte_len_return_mock, pkt_entry->pkt_size);
+	will_return_maybe(efa_mock_ibv_read_opcode_return_mock, IBV_WC_RECV);
+	will_return_maybe(efa_mock_ibv_read_qp_num_return_mock, efa_rdm_ep->base_ep.qp->qp_num);
+	will_return_maybe(efa_mock_ibv_read_wc_flags_return_mock, 0);
+	will_return_maybe(efa_mock_ibv_read_src_qp_return_mock, raw_addr.qpn);
+
+	/* Post receive buffer */
+	ret = fi_recv(resource->ep, recv_buff.buff, recv_buff.size, fi_mr_desc(recv_buff.mr), peer_addr, NULL /* context */);
+	assert_int_equal(ret, 0);
+
+	if (remove_peer) {
+		ret = fi_av_remove(resource->av, &peer_addr, 1, 0);
+		assert_int_equal(ret, 0);
+	}
+
+	ret = fi_cq_read(resource->cq, &cq_entry, 1);
+
+	if (remove_peer || !support_efadv_cq) {
+		/* Ignored WC because the peer is removed, or EFA device does not support extended CQ */
+		assert_int_equal(ret, -FI_EAGAIN);
+	}
+	else {
+		/* Found 1 matching rxe */
+		assert_int_equal(ret, 1);
+	}
+
+	efa_unit_test_buff_destruct(&recv_buff);
+
+	/* reset the mocked cq before it's polled by ep close */
+	will_return_always(efa_mock_ibv_start_poll_return_mock, ENOENT);
+	assert_int_equal(fi_close(&resource->ep->fid), 0);
+	resource->ep = NULL;
+}
+
+/**
+ * @brief Verify that RDM endpoint fi_cq_read recovers unknown peer AH
+ * by querying efadv to get raw address.
+ * A fake peer is registered in AV. The endpoint receives a packet from it,
+ * for which the EFA device returns an unknown AH. The endpoint will retrieve
+ * the peer's raw address using efadv verbs, and recover it's AH using
+ * Raw:QPN:QKey.
+ *
+ * @param[in]	state		struct efa_resource that is managed by the framework
+ */
+void test_ibv_cq_ex_read_recover_forgotten_peer_ah(struct efa_resource **state)
+{
+	struct efa_resource *resource = *state;
+	test_impl_ibv_cq_ex_read_unknow_peer_ah(resource, false, true);
+}
+
+/**
+ * @brief Verify that RDM endpoint falls back to ibv_create_cq_ex if rdma-core
+ * provides efadv_create_cq verb but EFA device does not support EFA DV CQ.
+ * In this case the endpoint will not attempt to recover a forgotten peer's address.
+ *
+ * @param[in]	state		struct efa_resource that is managed by the framework
+ */
+void test_rdm_fallback_to_ibv_create_cq_ex_cq_read_ignore_forgotton_peer(struct efa_resource **state)
+{
+	struct efa_resource *resource = *state;
+	test_impl_ibv_cq_ex_read_unknow_peer_ah(resource, false, false);
+}
+
+/**
+ * @brief Verify that RDM endpoint progress engine ignores unknown peer AH
+ * if the peer is not registered in AV, e.g. removed.
+ * The endpoint receives a packet from an alien peer, which corresponds to
+ * an unknown AH. The endpoint attempts to look up the AH for the peer but
+ * was rightly unable to, thus ignoring the packet.
+ *
+ * @param[in]	state		struct efa_resource that is managed by the framework
+ */
+void test_ibv_cq_ex_read_ignore_removed_peer(struct efa_resource **state)
+{
+	struct efa_resource *resource = *state;
+	test_impl_ibv_cq_ex_read_unknow_peer_ah(resource, true, true);
+}
+#else
+void test_ibv_cq_ex_read_recover_forgotten_peer_ah()
+{
+	skip();
+}
+void test_rdm_fallback_to_ibv_create_cq_ex_cq_read_ignore_forgotton_peer()
+{
+	skip();
+}
+void test_ibv_cq_ex_read_ignore_removed_peer()
+{
+	skip();
+}
+#endif
+
 static void test_efa_cq_read_prep(struct efa_resource *resource,
 			     int ibv_wc_opcode, int status, int vendor_error,
 			     struct efa_context *ctx, int wc_flags,

--- a/prov/efa/test/efa_unit_test_cq.c
+++ b/prov/efa/test/efa_unit_test_cq.c
@@ -943,6 +943,12 @@ static void test_impl_ibv_cq_ex_read_unknow_peer_ah(struct efa_resource *resourc
 
 	/* reset the mocked cq before it's polled by ep close */
 	will_return_always(efa_mock_ibv_start_poll_return_mock, ENOENT);
+
+	/* When the peer is removed, we add it implicitly and try to send a
+	 * handshake packet. So we need to reset efa_outstanding_tx_ops before
+	 * closing the endpoint. */
+	if (remove_peer)
+		efa_rdm_ep->efa_outstanding_tx_ops = 0;
 	assert_int_equal(fi_close(&resource->ep->fid), 0);
 	resource->ep = NULL;
 }
@@ -1413,4 +1419,3 @@ void test_efa_cq_recv_rdma_with_imm_failure(struct efa_resource **state)
 	assert_int_equal(fi_close(&resource->ep->fid), 0);
 	resource->ep = NULL;
 }
-

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -109,6 +109,8 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_av_multiple_ep_efa, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_av_multiple_ep_efa_direct, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_av_reinsertion, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_av_implicit, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_av_implicit_to_explicit, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		/* end efa_unit_test_av.c */
 
 		cmocka_unit_test_setup_teardown(test_efa_device_construct_error_handling, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
@@ -152,6 +154,8 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ep_rma_inconsistent_unsolicited_write_recv, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ep_support_unsolicited_write_recv, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ep_default_sizes, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+
+		/* begin efa_unit_test_cq.c */
 		cmocka_unit_test_setup_teardown(test_dgram_cq_read_empty_cq, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_ibv_cq_ex_read_empty_cq, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_ibv_cq_ex_read_failed_poll, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
@@ -170,9 +174,10 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_ibv_cq_ex_read_bad_recv_rdma_with_imm_status_use_unsolicited_recv, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_ibv_cq_ex_read_bad_recv_rdma_with_imm_status_use_solicited_recv, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_ibv_cq_ex_read_recover_forgotten_peer_ah, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
-		cmocka_unit_test_setup_teardown(test_ibv_cq_ex_read_ignore_removed_peer, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_rdm_fallback_to_ibv_create_cq_ex_cq_read_ignore_forgotton_peer, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_ibv_cq_ex_read_ignore_removed_peer, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_cq_before_ep_enable, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		/* end efa_unit_test_cq.c */
 
 		/* begin efa_unit_test_info.c */
 		cmocka_unit_test_setup_teardown(test_info_open_ep_with_wrong_info, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -152,8 +152,6 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ep_rma_inconsistent_unsolicited_write_recv, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ep_support_unsolicited_write_recv, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ep_default_sizes, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
-
-		/* begin efa_unit_test_cq.c */
 		cmocka_unit_test_setup_teardown(test_dgram_cq_read_empty_cq, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_ibv_cq_ex_read_empty_cq, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_ibv_cq_ex_read_failed_poll, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
@@ -171,8 +169,10 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_ibv_cq_ex_read_bad_recv_status, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_ibv_cq_ex_read_bad_recv_rdma_with_imm_status_use_unsolicited_recv, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_ibv_cq_ex_read_bad_recv_rdma_with_imm_status_use_solicited_recv, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_ibv_cq_ex_read_recover_forgotten_peer_ah, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_ibv_cq_ex_read_ignore_removed_peer, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_rdm_fallback_to_ibv_create_cq_ex_cq_read_ignore_forgotton_peer, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_cq_before_ep_enable, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
-		/* end efa_unit_test_cq.c */
 
 		/* begin efa_unit_test_info.c */
 		cmocka_unit_test_setup_teardown(test_info_open_ep_with_wrong_info, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -114,6 +114,8 @@ void test_efa_ah_cnt_multi_av();
 void test_av_multiple_ep_efa();
 void test_av_multiple_ep_efa_direct();
 void test_av_reinsertion();
+void test_av_implicit();
+void test_av_implicit_to_explicit();
 /* end efa_unit_test_av.c */
 
 void test_efa_device_construct_error_handling();

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -174,6 +174,9 @@ void test_rdm_cq_handshake_bad_send_status_unsupported_op();
 void test_ibv_cq_ex_read_bad_recv_status();
 void test_ibv_cq_ex_read_bad_recv_rdma_with_imm_status_use_unsolicited_recv();
 void test_ibv_cq_ex_read_bad_recv_rdma_with_imm_status_use_solicited_recv();
+void test_ibv_cq_ex_read_recover_forgotten_peer_ah();
+void test_rdm_fallback_to_ibv_create_cq_ex_cq_read_ignore_forgotton_peer();
+void test_ibv_cq_ex_read_ignore_removed_peer();
 void test_efa_rdm_cq_before_ep_enable();
 
 /* begin efa_unit_test_info.c */


### PR DESCRIPTION
This commit adds an implicit AV to store addressing information of peers
that have not been explicitly inserted into the AV by the application.
When an application calls fi_av_insert for a peer that is already
present in the implicit AV, the AV entry is moved to the explicit AV.