### PR TITLE
fabtests: Support customized fi_addr for ft_post_rx_buf

### DIFF
--- a/fabtests/benchmarks/benchmark_shared.c
+++ b/fabtests/benchmarks/benchmark_shared.c
@@ -594,7 +594,7 @@ int bandwidth(void)
 							 ft_rx_prefix_size(),
 						 &rx_ctx_arr[j].context, flags);
 			} else {
-				ret = ft_post_rx_buf(ep, opts.transfer_size,
+				ret = ft_post_rx_buf(ep, remote_fi_addr, opts.transfer_size,
 						     &rx_ctx_arr[j].context,
 						     rx_ctx_arr[j].buf, mr_desc,
 						     ft_tag);

--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -2564,7 +2564,7 @@ int check_compare_atomic_op(struct fid_ep *endpoint, enum fi_op op,
 	return check_atomic_attr(op, datatype, FI_COMPARE_ATOMIC);
 }
 
-ssize_t ft_post_rx_buf(struct fid_ep *ep, size_t size, void *ctx,
+ssize_t ft_post_rx_buf(struct fid_ep *ep, fi_addr_t fi_addr, size_t size, void *ctx,
 		       void *op_buf, void *op_mr_desc, uint64_t op_tag)
 {
 	size = MAX(size, FT_MAX_CTRL_MSG) + ft_rx_prefix_size();
@@ -2572,17 +2572,17 @@ ssize_t ft_post_rx_buf(struct fid_ep *ep, size_t size, void *ctx,
 		op_tag = op_tag ? op_tag : rx_seq;
 		FT_POST(fi_trecv, ft_progress, rxcq, rx_seq, &rx_cq_cntr,
 			"receive", ep, op_buf, size, op_mr_desc,
-			remote_fi_addr, op_tag, 0, ctx);
+			fi_addr, op_tag, 0, ctx);
 	} else {
 		FT_POST(fi_recv, ft_progress, rxcq, rx_seq, &rx_cq_cntr,
-			"receive", ep, op_buf, size, op_mr_desc, remote_fi_addr, ctx);
+			"receive", ep, op_buf, size, op_mr_desc, fi_addr, ctx);
 	}
 	return 0;
 }
 
 ssize_t ft_post_rx(struct fid_ep *ep, size_t size, void *ctx)
 {
-	return ft_post_rx_buf(ep, size, ctx, rx_buf, mr_desc, ft_tag);
+	return ft_post_rx_buf(ep, remote_fi_addr, size, ctx, rx_buf, mr_desc, ft_tag);
 }
 
 ssize_t ft_rx(struct fid_ep *ep, size_t size)

--- a/fabtests/functional/flood.c
+++ b/fabtests/functional/flood.c
@@ -144,7 +144,7 @@ static int run_seq_mr_send(void) {
 			if (ret)
 				goto out;
 
-			ret = ft_post_rx_buf(ep, opts.transfer_size,
+			ret = ft_post_rx_buf(ep, remote_fi_addr, opts.transfer_size,
 				             &(rx_ctx_arr[i].context),
 					     rx_ctx_arr[i].buf,
 					     rx_ctx_arr[i].desc, ft_tag);
@@ -191,7 +191,7 @@ static int run_batch_mr_send(void)
 			goto out;
 	} else {
 		for (i = 0; i < opts.window_size; i++) {
-			ret = ft_post_rx_buf(ep, opts.transfer_size,
+			ret = ft_post_rx_buf(ep, remote_fi_addr, opts.transfer_size,
 					     &rx_ctx_arr[i].context,
 					     rx_ctx_arr[i].buf,
 					     rx_ctx_arr[i].desc, 0);

--- a/fabtests/functional/unexpected_msg.c
+++ b/fabtests/functional/unexpected_msg.c
@@ -166,7 +166,7 @@ static int run_test_loop(void)
 
 		for (j = 0; j < concurrent_msgs; j++) {
 			op_buf = get_rx_buf(j);
-			ret = ft_post_rx_buf(ep, opts.transfer_size,
+			ret = ft_post_rx_buf(ep, remote_fi_addr, opts.transfer_size,
 					     &rx_ctx_arr[j].context, op_buf,
 					     mr_desc,
 					     op_tag + (concurrent_msgs - 1) - j);

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -584,7 +584,7 @@ size_t ft_tx_prefix_size(void);
 void ft_force_progress(void);
 int ft_progress(struct fid_cq *cq, uint64_t total, uint64_t *cq_cntr);
 ssize_t ft_post_rx(struct fid_ep *ep, size_t size, void *ctx);
-ssize_t ft_post_rx_buf(struct fid_ep *ep, size_t size, void *ctx,
+ssize_t ft_post_rx_buf(struct fid_ep *ep, fi_addr_t fi_addr, size_t size, void *ctx,
 		       void *op_buf, void *op_mr_desc, uint64_t op_tag);
 ssize_t ft_post_tx(struct fid_ep *ep, fi_addr_t fi_addr, size_t size,
 		uint64_t data, void *ctx);

--- a/fabtests/multinode/src/core.c
+++ b/fabtests/multinode/src/core.c
@@ -224,7 +224,7 @@ int multi_msg_recv(void)
 		assert(rx_ctx_arr[offset].state == OP_DONE);
 
 		remote_fi_addr = pm_job.fi_addrs[state.cur_source];
-		ret = ft_post_rx_buf(ep, opts.transfer_size,
+		ret = ft_post_rx_buf(ep, remote_fi_addr, opts.transfer_size,
 				     &rx_ctx_arr[offset].context,
 				     rx_ctx_arr[offset].buf,
 				     rx_ctx_arr[offset].desc, 1);


### PR DESCRIPTION
Use the default remote_fi_addr explicitly for current callers.