### PR TITLE
prov/efa: Add lkey to query_mr

### DIFF
--- a/man/fi_efa.7.md
+++ b/man/fi_efa.7.md
@@ -220,6 +220,7 @@ struct fi_efa_mr_attr {
     uint16_t recv_ic_id;
     uint16_t rdma_read_ic_id;
     uint16_t rdma_recv_ic_id;
+    uint32_t lkey;
 };
 ```
 
@@ -243,6 +244,9 @@ struct fi_efa_mr_attr {
 
 *rdma_recv_ic_id*
 :	Physical interconnect used by the device to reach the MR for RDMA write receive. It is only valid when `ic_id_validity` has the `FI_EFA_MR_ATTR_RDMA_RECV_IC_ID` bit.
+
+*lkey*
+:	local memory translation key used by TX/RX buffer descriptor.
 
 #### Return value
 **query_mr()** returns 0 on success, or the value of errno on failure

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -443,6 +443,8 @@ efa_domain_query_mr(struct fid_mr *mr_fid, struct fi_efa_mr_attr *mr_attr)
 		mr_attr->ic_id_validity |= FI_EFA_MR_ATTR_RDMA_RECV_IC_ID;
 	}
 
+	mr_attr->lkey = efa_mr->ibv_mr->lkey;
+
 	return FI_SUCCESS;
 }
 

--- a/prov/efa/src/fi_ext_efa.h
+++ b/prov/efa/src/fi_ext_efa.h
@@ -13,6 +13,7 @@ struct fi_efa_mr_attr {
     uint16_t recv_ic_id;
     uint16_t rdma_read_ic_id;
     uint16_t rdma_recv_ic_id;
+    uint32_t lkey;
 };
 
 enum {

--- a/prov/efa/test/efa_unit_test_domain.c
+++ b/prov/efa/test/efa_unit_test_domain.c
@@ -60,9 +60,11 @@ void test_efa_domain_open_ops_mr_query_common(
     struct fi_efa_mr_attr efa_mr_attr = {0};
     struct efa_mr mr = {0};
     struct fid_mr mr_fid = {0};
+    struct ibv_mr ibv_mr = {0};
 
     mr.mr_fid = mr_fid;
-    mr.ibv_mr = NULL;
+    ibv_mr.lkey = 1234567;
+    mr.ibv_mr = &ibv_mr;
 
     ret = fi_open_ops(&resource->domain->fid, FI_EFA_DOMAIN_OPS, 0, (void **)&efa_domain_ops, NULL);
     assert_int_equal(ret, 0);
@@ -83,6 +85,8 @@ void test_efa_domain_open_ops_mr_query_common(
 
     if (efa_mr_attr.ic_id_validity & FI_EFA_MR_ATTR_RDMA_RECV_IC_ID)
         assert_true(efa_mr_attr.rdma_recv_ic_id == expected_rdma_recv_ic_id);
+
+    assert_true(efa_mr_attr.lkey == mr.ibv_mr->lkey);
 }
 
 #if HAVE_EFADV_QUERY_MR


### PR DESCRIPTION
Expose lkey to enable applications to construct the TX/RX buffer descriptor in the wqe for send/recv operations.