### PR TITLE
[v2.2.x] prov/efa: Drain cq after qp destroy

### DIFF
--- a/prov/efa/src/efa_base_ep.c
+++ b/prov/efa/src/efa_base_ep.c
@@ -772,3 +772,28 @@ int efa_base_ep_create_and_enable_qp(struct efa_base_ep *ep, bool create_user_re
 
 	return efa_base_ep_enable(ep);
 }
+
+void efa_base_ep_flush_cq(struct efa_base_ep *base_ep)
+{
+	struct efa_cq *tx_cq, *rx_cq;
+	int err;
+
+	efa_base_ep_lock_cq(base_ep);
+	tx_cq = efa_base_ep_get_tx_cq(base_ep);
+	rx_cq = efa_base_ep_get_rx_cq(base_ep);
+
+	if (tx_cq) {
+		err = 0;
+		while (err != ENOENT) {
+			err = tx_cq->poll_ibv_cq(-1, &tx_cq->ibv_cq);
+		}
+	}
+
+	if (rx_cq && rx_cq != tx_cq) {
+		err = 0;
+		while (err != ENOENT) {
+			err = rx_cq->poll_ibv_cq(-1, &rx_cq->ibv_cq);
+		}
+	}
+	efa_base_ep_unlock_cq(base_ep);
+}

--- a/prov/efa/src/efa_base_ep.h
+++ b/prov/efa/src/efa_base_ep.h
@@ -158,4 +158,6 @@ void efa_base_ep_remove_cntr_ibv_cq_poll_list(struct efa_base_ep *ep);
 
 int efa_base_ep_create_and_enable_qp(struct efa_base_ep *ep, bool create_user_recv_qp);
 
+void efa_base_ep_flush_cq(struct efa_base_ep *base_ep);
+
 #endif

--- a/prov/efa/src/efa_cntr.c
+++ b/prov/efa/src/efa_cntr.c
@@ -173,7 +173,7 @@ static void efa_rdm_cntr_progress(struct util_cntr *cntr)
 
 	dlist_foreach(&efa_cntr->ibv_cq_poll_list, item) {
 		poll_list_entry = container_of(item, struct efa_ibv_cq_poll_list_entry, entry);
-		efa_rdm_cq_poll_ibv_cq(efa_env.efa_cq_read_size, poll_list_entry->cq);
+		(void) efa_rdm_cq_poll_ibv_cq(efa_env.efa_cq_read_size, poll_list_entry->cq);
 	}
 	efa_domain_progress_rdm_peers_and_queues(efa_domain);
 	ofi_genlock_unlock(&cntr->ep_list_lock);
@@ -190,7 +190,7 @@ static void efa_cntr_progress(struct util_cntr *cntr)
 	ofi_genlock_lock(&cntr->ep_list_lock);
 	dlist_foreach(&efa_cntr->ibv_cq_poll_list, item) {
 		poll_list_entry = container_of(item, struct efa_ibv_cq_poll_list_entry, entry);
-		efa_cq_poll_ibv_cq(efa_env.efa_cq_read_size, poll_list_entry->cq);
+		(void) efa_cq_poll_ibv_cq(efa_env.efa_cq_read_size, poll_list_entry->cq);
 	}
 	ofi_genlock_unlock(&cntr->ep_list_lock);
 }

--- a/prov/efa/src/efa_cq.h
+++ b/prov/efa/src/efa_cq.h
@@ -24,6 +24,7 @@ struct efa_ibv_cq_poll_list_entry {
 struct efa_cq {
 	struct util_cq		util_cq;
 	struct efa_ibv_cq	ibv_cq;
+	int	(*poll_ibv_cq)(ssize_t cqe_to_progress, struct efa_ibv_cq *ibv_cq);
 };
 
 extern struct fi_ops_cq efa_cq_ops;
@@ -302,6 +303,6 @@ static inline int efa_write_error_msg(struct efa_base_ep *ep, fi_addr_t addr,
 	return 0;
 }
 
-void efa_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq);
+int efa_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq);
 
 #endif /* end of _EFA_CQ_H*/

--- a/prov/efa/src/efa_ep.c
+++ b/prov/efa/src/efa_ep.c
@@ -208,6 +208,8 @@ static int efa_ep_close(fid_t fid)
 		EFA_WARN(FI_LOG_EP_CTRL, "Unable to close base endpoint\n");
 	}
 
+	efa_base_ep_flush_cq(ep);
+
 	free(ep);
 
 	return 0;

--- a/prov/efa/src/rdm/efa_rdm_cq.c
+++ b/prov/efa/src/rdm/efa_rdm_cq.c
@@ -417,7 +417,7 @@ static int efa_rdm_cq_match_ep(struct dlist_entry *item, const void *ep)
  * from the endpoint that the completed packet entry was posted from (pkt_entry->ep).
  * @param[in]	cqe_to_process	Max number of cq entry to poll and process. A negative number means to poll until cq empty
  */
-void efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq)
+int efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq)
 {
 	bool should_end_poll = false;
 	/* Initialize an empty ibv_poll_cq_attr struct for ibv_start_poll.
@@ -425,7 +425,7 @@ void efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq)
 	 */
 	struct ibv_poll_cq_attr poll_cq_attr = {.comp_mask = 0};
 	struct efa_rdm_pke *pkt_entry;
-	ssize_t err;
+	int err;
 	int opcode;
 	size_t i = 0;
 	int prov_errno;
@@ -534,7 +534,7 @@ void efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq)
 	if (err && err != ENOENT) {
 		err = err > 0 ? err : -err;
 		prov_errno = ibv_wc_read_vendor_err(ibv_cq->ibv_cq_ex);
-		EFA_WARN(FI_LOG_CQ, "Unexpected error when polling ibv cq, err: %s (%zd) prov_errno: %s (%d)\n", fi_strerror(err), err, efa_strerror(prov_errno), prov_errno);
+		EFA_WARN(FI_LOG_CQ, "Unexpected error when polling ibv cq, err: %s (%d) prov_errno: %s (%d)\n", fi_strerror(err), err, efa_strerror(prov_errno), prov_errno);
 		efa_show_help(prov_errno);
 		err_entry = (struct fi_cq_err_entry) {
 			.err = err,
@@ -554,6 +554,7 @@ void efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq)
 	}
 	assert(dlist_empty(&rx_progressed_ep_list));
 
+	return err;
 }
 
 static ssize_t efa_rdm_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t count, fi_addr_t *src_addr)
@@ -633,7 +634,7 @@ static void efa_rdm_cq_progress(struct util_cq *cq)
 
 	dlist_foreach(&efa_rdm_cq->ibv_cq_poll_list, item) {
 		poll_list_entry = container_of(item, struct efa_ibv_cq_poll_list_entry, entry);
-		efa_rdm_cq_poll_ibv_cq(efa_env.efa_cq_read_size, poll_list_entry->cq);
+		(void) efa_rdm_cq_poll_ibv_cq(efa_env.efa_cq_read_size, poll_list_entry->cq);
 	}
 	efa_domain_progress_rdm_peers_and_queues(efa_domain);
 	ofi_genlock_unlock(&cq->ep_list_lock);
@@ -689,6 +690,8 @@ int efa_rdm_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		EFA_WARN(FI_LOG_CQ, "Unable to create extended CQ: %s\n", fi_strerror(ret));
 		goto close_util_cq;
 	}
+
+	cq->efa_cq.poll_ibv_cq = efa_rdm_cq_poll_ibv_cq;
 
 	*cq_fid = &cq->efa_cq.util_cq.cq_fid;
 	(*cq_fid)->fid.ops = &efa_rdm_cq_fi_ops;

--- a/prov/efa/src/rdm/efa_rdm_cq.h
+++ b/prov/efa/src/rdm/efa_rdm_cq.h
@@ -17,7 +17,7 @@ struct efa_rdm_cq {
 int efa_rdm_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		    struct fid_cq **cq_fid, void *context);
 
-void efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq);
+int efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq);
 
 void efa_rdm_cq_progress_peers_and_queues(struct efa_rdm_cq *efa_rdm_cq);
 #endif

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -846,9 +846,9 @@ void efa_rdm_ep_wait_send(struct efa_rdm_ep *efa_rdm_ep)
 	while (efa_rdm_ep_has_unfinished_send(efa_rdm_ep)) {
 		/* poll cq until empty */
 		if (tx_cq)
-			efa_rdm_cq_poll_ibv_cq(-1, &tx_cq->ibv_cq);
+			(void) efa_rdm_cq_poll_ibv_cq(-1, &tx_cq->ibv_cq);
 		if (rx_cq)
-			efa_rdm_cq_poll_ibv_cq(-1, &rx_cq->ibv_cq);
+			(void) efa_rdm_cq_poll_ibv_cq(-1, &rx_cq->ibv_cq);
 		efa_domain_progress_rdm_peers_and_queues(efa_rdm_ep_domain(efa_rdm_ep));
 	}
 
@@ -996,6 +996,8 @@ static int efa_rdm_ep_close(struct fid *fid)
 		EFA_WARN(FI_LOG_EP_CTRL, "Unable to close base endpoint\n");
 		retv = ret;
 	}
+
+	efa_base_ep_flush_cq(&efa_rdm_ep->base_ep);
 
 	ret = efa_rdm_ep_close_shm_ep_resources(efa_rdm_ep);
 	if (ret)

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -711,7 +711,6 @@ static void efa_rdm_ep_destroy_buffer_pools(struct efa_rdm_ep *efa_rdm_ep)
 	struct efa_rdm_ope *rxe;
 	struct efa_rdm_ope *txe;
 
-	ofi_genlock_lock(&efa_rdm_ep_domain(efa_rdm_ep)->srx_lock);
 #if ENABLE_DEBUG
 	struct efa_rdm_pke *pkt_entry;
 
@@ -753,8 +752,6 @@ static void efa_rdm_ep_destroy_buffer_pools(struct efa_rdm_ep *efa_rdm_ep)
 			txe);
 		efa_rdm_txe_release(txe);
 	}
-
-	ofi_genlock_unlock(&efa_rdm_ep_domain(efa_rdm_ep)->srx_lock);
 
 	if (efa_rdm_ep->ope_pool)
 		ofi_bufpool_destroy(efa_rdm_ep->ope_pool);
@@ -964,8 +961,14 @@ static int efa_rdm_ep_close(struct fid *fid)
 		efa_rdm_ep->peer_srx_ep = NULL;
 	}
 
-	/* Remove all peers associated with this endpoint in domain level peer lists */
+	/**
+	 * The QP destroy and op entries clean up must be in the same lock,
+	 * otherwise there can be race condition that efa_domain_progress_rdm_peers_and_queues
+	 * (part of fi_cq_read) can access entries that are from a closed QP.
+	 */
 	ofi_genlock_lock(&domain->srx_lock);
+
+	/* Remove all peers associated with this endpoint in domain level peer lists */
 	dlist_foreach_container_safe(&domain->peer_backoff_list, struct efa_rdm_peer,
 				     peer, rnr_backoff_entry, tmp) {
 		if (peer->ep == efa_rdm_ep) {
@@ -979,7 +982,6 @@ static int efa_rdm_ep_close(struct fid *fid)
 			dlist_remove(&peer->handshake_queued_entry);
 		}
 	}
-	ofi_genlock_unlock(&domain->srx_lock);
 
 	/* We need to free the util_ep first to avoid race conditions
 	 * with other threads progressing the cq. */
@@ -1003,6 +1005,8 @@ static int efa_rdm_ep_close(struct fid *fid)
 
 	if (efa_rdm_ep->pke_vec)
 		free(efa_rdm_ep->pke_vec);
+
+	ofi_genlock_unlock(&domain->srx_lock);
 
 	free(efa_rdm_ep);
 	return retv;

--- a/prov/efa/test/efa_unit_test_cq.c
+++ b/prov/efa/test/efa_unit_test_cq.c
@@ -33,6 +33,11 @@ void test_impl_cq_read_empty_cq(struct efa_resource *resource, enum fi_ep_type e
 	ret = fi_cq_read(resource->cq, &cq_entry, 1);
 
 	assert_int_equal(ret, -FI_EAGAIN);
+
+	/* reset the mocked cq before it's polled by ep close */
+	will_return_maybe(efa_mock_ibv_start_poll_return_mock, ENOENT);
+	assert_int_equal(fi_close(&resource->ep->fid), 0);
+	resource->ep = NULL;
 }
 
 /**
@@ -180,6 +185,11 @@ static void test_rdm_cq_read_bad_send_status(struct efa_resource *resource,
 	/* Look for peer host id */
 	assert_non_null(strstr(strerror, host_id_str));
 	efa_unit_test_buff_destruct(&send_buff);
+
+	/* reset the mocked cq before it's polled by ep close */
+	will_return_always(efa_mock_ibv_start_poll_use_saved_send_wr_with_mock_status, ENOENT);
+	assert_int_equal(fi_close(&resource->ep->fid), 0);
+	resource->ep = NULL;
 }
 
 /**
@@ -353,6 +363,11 @@ void test_ibv_cq_ex_read_bad_recv_status(struct efa_resource **state)
 	assert_int_equal(ret, sizeof(eq_err_entry));
 	assert_int_not_equal(eq_err_entry.err, FI_SUCCESS);
 	assert_int_equal(eq_err_entry.prov_errno, FI_EFA_ERR_UNESTABLISHED_RECV_UNRESP);
+
+	/* reset the mocked cq before it's polled by ep close */
+	will_return_always(efa_mock_ibv_start_poll_return_mock, ENOENT);
+	assert_int_equal(fi_close(&resource->ep->fid), 0);
+	resource->ep = NULL;
 }
 
 /**
@@ -448,6 +463,11 @@ void test_ibv_cq_ex_read_bad_recv_rdma_with_imm_status_impl(struct efa_resource 
 	assert_int_equal(ret, sizeof(eq_err_entry));
 	assert_int_not_equal(eq_err_entry.err, FI_SUCCESS);
 	assert_int_equal(eq_err_entry.prov_errno, EFA_IO_COMP_STATUS_FLUSHED);
+
+	/* reset the mocked cq before it's polled by ep close */
+	will_return_always(efa_mock_ibv_start_poll_return_mock, ENOENT);
+	assert_int_equal(fi_close(&resource->ep->fid), 0);
+	resource->ep = NULL;
 }
 
 void test_ibv_cq_ex_read_bad_recv_rdma_with_imm_status_use_unsolicited_recv(struct efa_resource **state)
@@ -495,6 +515,11 @@ void test_ibv_cq_ex_read_failed_poll(struct efa_resource **state)
 	assert_int_equal(ret, 1);
 	assert_int_not_equal(cq_err_entry.err, FI_ENOENT);
 	assert_int_equal(cq_err_entry.prov_errno, EFA_IO_COMP_STATUS_LOCAL_ERROR_UNRESP_REMOTE);
+
+	/* reset the mocked cq before it's polled by ep close */
+	will_return_always(efa_mock_ibv_start_poll_return_mock, ENOENT);
+	assert_int_equal(fi_close(&resource->ep->fid), 0);
+	resource->ep = NULL;
 }
 
 /**
@@ -792,6 +817,11 @@ static void test_impl_ibv_cq_ex_read_unknow_peer_ah(struct efa_resource *resourc
 	}
 
 	efa_unit_test_buff_destruct(&recv_buff);
+
+	/* reset the mocked cq before it's polled by ep close */
+	will_return_always(efa_mock_ibv_start_poll_return_mock, ENOENT);
+	assert_int_equal(fi_close(&resource->ep->fid), 0);
+	resource->ep = NULL;
 }
 
 /**
@@ -931,6 +961,11 @@ void test_efa_cq_read_no_completion(struct efa_resource **state)
 
 	ret = fi_cq_read(resource->cq, &cq_entry, 1);
 	assert_int_equal(ret, -FI_EAGAIN);
+
+	/* reset the mocked cq before it's polled by ep close */
+	will_return_maybe(efa_mock_ibv_start_poll_return_mock, ENOENT);
+	assert_int_equal(fi_close(&resource->ep->fid), 0);
+	resource->ep = NULL;
 }
 
 /**
@@ -956,6 +991,11 @@ void test_efa_cq_read_send_success(struct efa_resource **state)
 
 	assert_true(efa_context == cq_entry.op_context);
 	assert_true(cq_entry.flags == efa_context->completion_flags);
+
+	/* reset the mocked cq before it's polled by ep close */
+	will_return_maybe(efa_mock_ibv_start_poll_return_mock, ENOENT);
+	assert_int_equal(fi_close(&resource->ep->fid), 0);
+	resource->ep = NULL;
 }
 
 /**
@@ -981,6 +1021,11 @@ void test_efa_cq_read_senddata_success(struct efa_resource **state)
 
 	assert_true(efa_context == cq_entry.op_context);
 	assert_true(cq_entry.flags == efa_context->completion_flags);
+
+	/* reset the mocked cq before it's polled by ep close */
+	will_return_maybe(efa_mock_ibv_start_poll_return_mock, ENOENT);
+	assert_int_equal(fi_close(&resource->ep->fid), 0);
+	resource->ep = NULL;
 }
 
 /**
@@ -1006,6 +1051,11 @@ void test_efa_cq_read_recv_success(struct efa_resource **state)
 
 	assert_true(efa_context == cq_entry.op_context);
 	assert_true(efa_context->completion_flags == cq_entry.flags);
+
+	/* reset the mocked cq before it's polled by ep close */
+	will_return_maybe(efa_mock_ibv_start_poll_return_mock, ENOENT);
+	assert_int_equal(fi_close(&resource->ep->fid), 0);
+	resource->ep = NULL;
 }
 
 /**
@@ -1031,6 +1081,11 @@ void test_efa_cq_read_write_success(struct efa_resource **state)
 
 	assert_true(efa_context == cq_entry.op_context);
 	assert_true(cq_entry.flags == efa_context->completion_flags);
+
+	/* reset the mocked cq before it's polled by ep close */
+	will_return_maybe(efa_mock_ibv_start_poll_return_mock, ENOENT);
+	assert_int_equal(fi_close(&resource->ep->fid), 0);
+	resource->ep = NULL;
 }
 
 /**
@@ -1056,6 +1111,11 @@ void test_efa_cq_read_writedata_success(struct efa_resource **state)
 
 	assert_true(efa_context == cq_entry.op_context);
 	assert_true(cq_entry.flags == efa_context->completion_flags);
+
+	/* reset the mocked cq before it's polled by ep close */
+	will_return_maybe(efa_mock_ibv_start_poll_return_mock, ENOENT);
+	assert_int_equal(fi_close(&resource->ep->fid), 0);
+	resource->ep = NULL;
 }
 
 /**
@@ -1081,6 +1141,11 @@ void test_efa_cq_read_read_success(struct efa_resource **state)
 
 	assert_true(efa_context == cq_entry.op_context);
 	assert_true(cq_entry.flags == efa_context->completion_flags);
+
+	/* reset the mocked cq before it's polled by ep close */
+	will_return_maybe(efa_mock_ibv_start_poll_return_mock, ENOENT);
+	assert_int_equal(fi_close(&resource->ep->fid), 0);
+	resource->ep = NULL;
 }
 
 /**
@@ -1101,6 +1166,11 @@ void test_efa_cq_read_recv_rdma_with_imm_success(struct efa_resource **state)
 
 	assert_true(cq_entry.op_context == NULL);
 	assert_true(cq_entry.flags == (FI_REMOTE_WRITE | FI_REMOTE_CQ_DATA | FI_RMA));
+
+	/* reset the mocked cq before it's polled by ep close */
+	will_return_maybe(efa_mock_ibv_start_poll_return_mock, ENOENT);
+	assert_int_equal(fi_close(&resource->ep->fid), 0);
+	resource->ep = NULL;
 }
 
 static void efa_cq_check_cq_err_entry(struct efa_resource *resource, int vendor_error) {
@@ -1151,6 +1221,11 @@ void test_efa_cq_read_send_failure(struct efa_resource **state)
 
 	efa_cq_check_cq_err_entry(resource,
 				  EFA_IO_COMP_STATUS_LOCAL_ERROR_UNRESP_REMOTE);
+
+	/* reset the mocked cq before it's polled by ep close */
+	will_return_maybe(efa_mock_ibv_start_poll_return_mock, ENOENT);
+	assert_int_equal(fi_close(&resource->ep->fid), 0);
+	resource->ep = NULL;
 }
 
 /**
@@ -1180,6 +1255,11 @@ void test_efa_cq_read_recv_failure(struct efa_resource **state)
 
 	efa_cq_check_cq_err_entry(resource,
 				  EFA_IO_COMP_STATUS_LOCAL_ERROR_UNRESP_REMOTE);
+
+	/* reset the mocked cq before it's polled by ep close */
+	will_return_maybe(efa_mock_ibv_start_poll_return_mock, ENOENT);
+	assert_int_equal(fi_close(&resource->ep->fid), 0);
+	resource->ep = NULL;
 }
 
 /**
@@ -1204,5 +1284,10 @@ void test_efa_cq_recv_rdma_with_imm_failure(struct efa_resource **state)
 
 	efa_cq_check_cq_err_entry(resource,
 				  EFA_IO_COMP_STATUS_LOCAL_ERROR_UNRESP_REMOTE);
+
+	/* reset the mocked cq before it's polled by ep close */
+	will_return_maybe(efa_mock_ibv_start_poll_return_mock, ENOENT);
+	assert_int_equal(fi_close(&resource->ep->fid), 0);
+	resource->ep = NULL;
 }
 

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -226,7 +226,12 @@ void test_efa_rdm_ep_handshake_exchange_host_id(struct efa_resource **state, uin
 	assert_true(actual_peer_host_id == g_efa_unit_test_mocks.peer_host_id);
 
 	/* Device version should be stored after handshake */
-        assert_int_equal(peer->device_version, 0xefa0);
+	assert_int_equal(peer->device_version, 0xefa0);
+
+	/* reset the mocked cq before it's polled by ep close */
+	will_return_always(efa_mock_ibv_start_poll_return_mock, ENOENT);
+	assert_int_equal(fi_close(&resource->ep->fid), 0);
+	resource->ep = NULL;
 }
 #else
 void test_efa_rdm_ep_handshake_exchange_host_id() {


### PR DESCRIPTION
Backport https://github.com/ofiwg/libfabric/pull/11151