### PR TITLE
prov/efa: Move gda operations to FI_EFA_GDA_OPS

### DIFF
--- a/man/fi_efa.7.md
+++ b/man/fi_efa.7.md
@@ -191,24 +191,15 @@ Domain operation extension is obtained by calling `fi_open_ops`
 int fi_open_ops(struct fid *domain, const char *name, uint64_t flags,
     void **ops, void *context);
 ```
-and requesting `FI_EFA_DOMAIN_OPS` in `name`. `fi_open_ops` returns `ops` as
+
+Requesting `FI_EFA_DOMAIN_OPS` in `name` returns `ops` as
 the pointer to the function table `fi_efa_ops_domain` defined as follows:
 
 ```c
 struct fi_efa_ops_domain {
 	int (*query_mr)(struct fid_mr *mr, struct fi_efa_mr_attr *mr_attr);
-	int (*query_addr)(struct fid_ep *ep_fid, fi_addr_t addr, uint16_t *ahn,
-			  uint16_t *remote_qpn, uint32_t *remote_qkey);
-	int (*query_qp_wqs)(struct fid_ep *ep_fid, struct fi_efa_wq_attr *sq_attr, struct fi_efa_wq_attr *rq_attr);
-	int (*query_cq)(struct fid_cq *cq_fid, struct fi_efa_cq_attr *cq_attr);
-	int (*cq_open_ext)(struct fid_domain *domain_fid,
-			   struct fi_cq_attr *attr,
-			   struct fi_efa_cq_init_attr *efa_cq_init_attr,
-			   struct fid_cq **cq_fid, void *context);
 };
 ```
-
-It contains the following operations
 
 ### query_mr
 This op queries an existing memory registration as input, and outputs the efa
@@ -247,6 +238,24 @@ struct fi_efa_mr_attr {
 #### Return value
 **query_mr()** returns 0 on success, or the value of errno on failure
 (which indicates the failure reason).
+
+
+To enable GPU Direct Async (GDA), which allows the GPU to interact directly with the NIC, 
+request `FI_EFA_GDA_OPS` in the `name` parameter. This returns `ops` as a pointer to the 
+function table `fi_efa_ops_gda` defined as follows:
+
+```c
+struct fi_efa_ops_gda {
+	int (*query_addr)(struct fid_ep *ep_fid, fi_addr_t addr, uint16_t *ahn,
+			  uint16_t *remote_qpn, uint32_t *remote_qkey);
+	int (*query_qp_wqs)(struct fid_ep *ep_fid, struct fi_efa_wq_attr *sq_attr, struct fi_efa_wq_attr *rq_attr);
+	int (*query_cq)(struct fid_cq *cq_fid, struct fi_efa_cq_attr *cq_attr);
+	int (*cq_open_ext)(struct fid_domain *domain_fid,
+			   struct fi_cq_attr *attr,
+			   struct fi_efa_cq_init_attr *efa_cq_init_attr,
+			   struct fid_cq **cq_fid, void *context);
+};
+```
 
 ### query_addr
 This op queries the following address information for a given endpoint and destination address.

--- a/man/fi_efa.7.md
+++ b/man/fi_efa.7.md
@@ -254,6 +254,7 @@ struct fi_efa_ops_gda {
 			   struct fi_cq_attr *attr,
 			   struct fi_efa_cq_init_attr *efa_cq_init_attr,
 			   struct fid_cq **cq_fid, void *context);
+	uint64_t (*get_mr_lkey)(struct fid_mr *mr);
 };
 ```
 
@@ -371,6 +372,16 @@ struct fi_efa_cq_init_attr {
 #### Return value
 **cq_open_ext()** returns 0 on success, or the value of errno on failure
 (which indicates the failure reason).
+
+### get_mr_lkey
+Returns the local memory translation key associated with a MR. The memory registration must have completed successfully before invoking this.
+
+*lkey*
+:	local memory translation key used by TX/RX buffer descriptor.
+
+#### Return value
+**get_mr_lkey()** returns lkey on success, or FI_KEY_NOTAVAIL if the registration has not completed.
+
 
 # Traffic Class (tclass) in EFA
 To prioritize the messages from a given endpoint, user can specify `fi_info->tx_attr->tclass = FI_TC_LOW_LATENCY` in the fi_endpoint() call to set the service level in rdma-core. All other tclass values will be ignored.

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -699,6 +699,19 @@ static int efa_domain_cq_open_ext(struct fid_domain *domain_fid,
 }
 #endif
 
+static uint64_t efa_domain_get_mr_lkey(struct fid_mr *mr)
+{
+	struct efa_mr *efa_mr;
+
+	efa_mr = container_of(mr, struct efa_mr, mr_fid);
+	if (!efa_mr->ibv_mr) {
+		EFA_WARN(FI_LOG_DOMAIN, "MR not registered\n");
+		return FI_KEY_NOTAVAIL;
+	}
+
+	return efa_mr->ibv_mr->lkey;
+}
+
 static struct fi_efa_ops_domain efa_ops_domain = {
 	.query_mr = efa_domain_query_mr,
 };
@@ -708,6 +721,7 @@ static struct fi_efa_ops_gda efa_ops_gda = {
 	.query_qp_wqs = efa_domain_query_qp_wqs,
 	.query_cq = efa_domain_query_cq,
 	.cq_open_ext = efa_domain_cq_open_ext,
+	.get_mr_lkey = efa_domain_get_mr_lkey,
 };
 
 static int

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -701,6 +701,9 @@ static int efa_domain_cq_open_ext(struct fid_domain *domain_fid,
 
 static struct fi_efa_ops_domain efa_ops_domain = {
 	.query_mr = efa_domain_query_mr,
+};
+
+static struct fi_efa_ops_gda efa_ops_gda = {
 	.query_addr = efa_domain_query_addr,
 	.query_qp_wqs = efa_domain_query_qp_wqs,
 	.query_cq = efa_domain_query_cq,
@@ -715,11 +718,15 @@ efa_domain_ops_open(struct fid *fid, const char *ops_name, uint64_t flags,
 
 	if (strcmp(ops_name, FI_EFA_DOMAIN_OPS) == 0) {
 		*ops = &efa_ops_domain;
-	} else {
-		EFA_WARN(FI_LOG_DOMAIN,
-			"Unknown ops name: %s\n", ops_name);
-		ret = -FI_EINVAL;
+		return ret;
 	}
+	if (strcmp(ops_name, FI_EFA_GDA_OPS) == 0) {
+		*ops = &efa_ops_gda;
+		return ret;
+	}
+
+	EFA_WARN(FI_LOG_DOMAIN, "Unknown ops name: %s\n", ops_name);
+	ret = -FI_EINVAL;
 
 	return ret;
 }

--- a/prov/efa/src/fi_ext_efa.h
+++ b/prov/efa/src/fi_ext_efa.h
@@ -7,6 +7,7 @@
 #include <rdma/fi_domain.h>
 
 #define FI_EFA_DOMAIN_OPS "efa domain ops"
+#define FI_EFA_GDA_OPS "efa gda ops"
 
 struct fi_efa_mr_attr {
     uint16_t ic_id_validity;
@@ -51,6 +52,9 @@ struct fi_efa_cq_init_attr {
 
 struct fi_efa_ops_domain {
 	int (*query_mr)(struct fid_mr *mr, struct fi_efa_mr_attr *mr_attr);
+};
+
+struct fi_efa_ops_gda {
 	int (*query_addr)(struct fid_ep *ep_fid, fi_addr_t addr, uint16_t *ahn,
 			  uint16_t *remote_qpn, uint32_t *remote_qkey);
 	int (*query_qp_wqs)(struct fid_ep *ep_fid,

--- a/prov/efa/src/fi_ext_efa.h
+++ b/prov/efa/src/fi_ext_efa.h
@@ -65,6 +65,7 @@ struct fi_efa_ops_gda {
 			   struct fi_cq_attr *attr,
 			   struct fi_efa_cq_init_attr *efa_cq_init_attr,
 			   struct fid_cq **cq_fid, void *context);
+	uint64_t (*get_mr_lkey)(struct fid_mr *mr);
 };
 
 #endif /* _FI_EXT_EFA_H_ */

--- a/prov/efa/test/efa_unit_test_domain.c
+++ b/prov/efa/test/efa_unit_test_domain.c
@@ -420,3 +420,26 @@ void test_efa_domain_open_ops_cq_open_ext(struct efa_resource **state)
     assert_int_equal(ret, -FI_ENOSYS);
 #endif
 }
+
+void test_efa_domain_open_ops_get_mr_lkey(struct efa_resource **state)
+{
+    int ret;
+    struct efa_resource *resource = *state;
+    struct fi_efa_ops_gda *efa_gda_ops;
+    struct efa_mr mr = {0};
+    struct fid_mr mr_fid = {0};
+    struct ibv_mr ibv_mr = {0};
+    uint64_t lkey;
+
+    mr.mr_fid = mr_fid;
+    ibv_mr.lkey = 1234567;
+    mr.ibv_mr = &ibv_mr;
+
+    efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_DIRECT_FABRIC_NAME);
+    ret = fi_open_ops(&resource->domain->fid, FI_EFA_GDA_OPS, 0, (void **)&efa_gda_ops, NULL);
+    assert_int_equal(ret, 0);
+
+    lkey = efa_gda_ops->get_mr_lkey(&mr.mr_fid);
+    assert_int_equal(ret, FI_SUCCESS);
+    assert_true(lkey == mr.ibv_mr->lkey);
+}

--- a/prov/efa/test/efa_unit_test_domain.c
+++ b/prov/efa/test/efa_unit_test_domain.c
@@ -162,19 +162,19 @@ void test_efa_domain_open_ops_query_qp_wqs(struct efa_resource **state)
 {
     struct efa_resource *resource = *state;
     int ret;
-    struct fi_efa_ops_domain *efa_domain_ops;
+    struct fi_efa_ops_gda *efa_gda_ops;
     struct fi_efa_wq_attr sq_attr = {0};
     struct fi_efa_wq_attr rq_attr = {0};
 
     efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_DIRECT_FABRIC_NAME);
 
-    ret = fi_open_ops(&resource->domain->fid, FI_EFA_DOMAIN_OPS, 0, (void **)&efa_domain_ops, NULL);
+    ret = fi_open_ops(&resource->domain->fid, FI_EFA_GDA_OPS, 0, (void **)&efa_gda_ops, NULL);
     assert_int_equal(ret, 0);
 
 #if HAVE_EFADV_QUERY_QP_WQS
     g_efa_unit_test_mocks.efadv_query_qp_wqs = &efa_mock_efadv_query_qp_wqs;
 #endif
-    ret = efa_domain_ops->query_qp_wqs(resource->ep, &sq_attr, &rq_attr);
+    ret = efa_gda_ops->query_qp_wqs(resource->ep, &sq_attr, &rq_attr);
 
 #if HAVE_EFADV_QUERY_QP_WQS
     assert_int_equal(ret, FI_SUCCESS);
@@ -200,18 +200,18 @@ void test_efa_domain_open_ops_query_cq(struct efa_resource **state)
 {
     struct efa_resource *resource = *state;
     int ret;
-    struct fi_efa_ops_domain *efa_domain_ops;
+    struct fi_efa_ops_gda *efa_gda_ops;
     struct fi_efa_cq_attr cq_attr = {0};
 
     efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_DIRECT_FABRIC_NAME);
 
-    ret = fi_open_ops(&resource->domain->fid, FI_EFA_DOMAIN_OPS, 0, (void **)&efa_domain_ops, NULL);
+    ret = fi_open_ops(&resource->domain->fid, FI_EFA_GDA_OPS, 0, (void **)&efa_gda_ops, NULL);
     assert_int_equal(ret, 0);
 
 #if HAVE_EFADV_QUERY_CQ
     g_efa_unit_test_mocks.efadv_query_cq = &efa_mock_efadv_query_cq;
 #endif
-    ret = efa_domain_ops->query_cq(resource->cq, &cq_attr);
+    ret = efa_gda_ops->query_cq(resource->cq, &cq_attr);
 
 #if HAVE_EFADV_QUERY_CQ
     assert_int_equal(ret, FI_SUCCESS);
@@ -343,7 +343,7 @@ void test_efa_domain_open_ops_query_addr(struct efa_resource **state)
 	size_t raw_addr_len = sizeof(struct efa_ep_addr);
 	struct efa_ep_addr raw_addr;
 	fi_addr_t addr;
-	struct fi_efa_ops_domain *efa_domain_ops;
+	struct fi_efa_ops_gda *efa_gda_ops;
 	uint16_t ahn;
 	uint16_t remote_qpn;
 	uint32_t remote_qkey;
@@ -357,11 +357,11 @@ void test_efa_domain_open_ops_query_addr(struct efa_resource **state)
 	ret = fi_av_insert(resource->av, &raw_addr, 1, &addr, 0, NULL);
 	assert_int_equal(ret, 1);
 
-	ret = fi_open_ops(&resource->domain->fid, FI_EFA_DOMAIN_OPS, 0,
-			  (void **) &efa_domain_ops, NULL);
+	ret = fi_open_ops(&resource->domain->fid, FI_EFA_GDA_OPS, 0,
+			  (void **) &efa_gda_ops, NULL);
 	assert_int_equal(ret, 0);
 
-	ret = efa_domain_ops->query_addr(resource->ep, addr, &ahn,
+	ret = efa_gda_ops->query_addr(resource->ep, addr, &ahn,
 					    &remote_qpn, &remote_qkey);
 
 	assert_int_equal(ret, FI_SUCCESS);
@@ -372,7 +372,7 @@ void test_efa_domain_open_ops_query_addr(struct efa_resource **state)
 void test_efa_domain_open_ops_cq_open_ext(struct efa_resource **state)
 {
     struct efa_resource *resource = *state;
-    struct fi_efa_ops_domain *efa_domain_ops;
+    struct fi_efa_ops_gda *efa_gda_ops;
     struct fi_cq_attr attr = {0};
     struct fi_efa_cq_init_attr efa_cq_init_attr = {
 	    .flags = FI_EFA_CQ_INIT_FLAGS_EXT_MEM_DMABUF,
@@ -389,8 +389,8 @@ void test_efa_domain_open_ops_cq_open_ext(struct efa_resource **state)
 
     efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_DIRECT_FABRIC_NAME);
 
-    ret = fi_open_ops(&resource->domain->fid, FI_EFA_DOMAIN_OPS, 0,
-		      (void **) &efa_domain_ops, NULL);
+    ret = fi_open_ops(&resource->domain->fid, FI_EFA_GDA_OPS, 0,
+		      (void **) &efa_gda_ops, NULL);
     assert_int_equal(ret, 0);
 
 #if HAVE_CAPS_CQ_WITH_EXT_MEM_DMABUF && HAVE_EFADV_CQ_EX
@@ -398,10 +398,10 @@ void test_efa_domain_open_ops_cq_open_ext(struct efa_resource **state)
         g_efa_unit_test_mocks.efadv_create_cq = &efa_mock_efadv_create_cq_with_ibv_create_cq_ex;
         expect_function_call(efa_mock_efadv_create_cq_with_ibv_create_cq_ex);
     }
-    ret = efa_domain_ops->cq_open_ext(resource->domain, &attr,
+    ret = efa_gda_ops->cq_open_ext(resource->domain, &attr,
 				      &efa_cq_init_attr, &cq_fid, NULL);
 #else
-    ret = efa_domain_ops->cq_open_ext(resource->domain, &attr,
+    ret = efa_gda_ops->cq_open_ext(resource->domain, &attr,
 				      &efa_cq_init_attr, &cq_fid, NULL);
 #endif
 

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -271,6 +271,7 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_domain_open_ops_query_qp_wqs, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_domain_open_ops_query_cq, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_domain_open_ops_cq_open_ext, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_domain_open_ops_get_mr_lkey, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		/* end efa_unit_test_domain.c */
 
 		cmocka_unit_test_setup_teardown(test_efa_rdm_cq_ibv_cq_poll_list_same_tx_rx_cq_single_ep, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -269,6 +269,7 @@ void test_efa_domain_open_ops_query_addr();
 void test_efa_domain_open_ops_query_qp_wqs();
 void test_efa_domain_open_ops_query_cq();
 void test_efa_domain_open_ops_cq_open_ext();
+void test_efa_domain_open_ops_get_mr_lkey();
 /* end efa_unit_test_domain.c */
 
 void test_efa_rdm_cq_ibv_cq_poll_list_same_tx_rx_cq_single_ep();


### PR DESCRIPTION
prov/efa: Move gda operations to FI_EFA_GDA_OPS
Use a different key string for GDA related operations.

prov/efa: Add query_lkey to GDA ops
Expose lkey to enable applications to construct the TX/RX buffer descriptor in the wqe for send/recv operations.