### PR TITLE
prov/util,rxm,shm,sm2: Get srx lock in the caller of util_foreach_unspec

### DIFF
--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -684,7 +684,10 @@ int efa_av_insert(struct fid_av *av_fid, const void *addr,
 	for (i = 0; i < count; i++) {
 		addr_i = (struct efa_ep_addr *) ((uint8_t *)addr + i * EFA_EP_ADDR_LEN);
 
+		ofi_genlock_lock(&av->domain->srx_lock);
 		ret = efa_av_insert_one(av, addr_i, &fi_addr_res, flags, context, true);
+		ofi_genlock_unlock(&av->domain->srx_lock);
+
 		if (ret) {
 			EFA_WARN(FI_LOG_AV, "insert raw_addr to av failed! ret=%d\n",
 				 ret);

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -235,8 +235,11 @@ static void rxm_foreach_ep(struct util_av *av, struct util_ep *ep)
 
 	rxm_ep = container_of(ep, struct rxm_ep, util_ep);
 	peer_srx = container_of(rxm_ep->srx, struct fid_peer_srx, ep_fid);
-	if (peer_srx)
+	if (peer_srx) {
+		ofi_genlock_lock(&rxm_ep->util_ep.lock);
 		peer_srx->owner_ops->foreach_unspec_addr(peer_srx, &rxm_get_addr);
+		ofi_genlock_unlock(&rxm_ep->util_ep.lock);
+	}
 }
 
 

--- a/prov/shm/src/smr_av.c
+++ b/prov/shm/src/smr_av.c
@@ -175,10 +175,11 @@ static int smr_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
         		smr_ep = container_of(util_ep, struct smr_ep, util_ep);
 			smr_ep->region->max_sar_buf_per_peer =
 				SMR_MAX_PEERS / smr_av->smr_map.num_peers;
+			ofi_genlock_lock(&util_ep->lock);
 			smr_ep->srx->owner_ops->foreach_unspec_addr(smr_ep->srx,
 								&smr_get_addr);
+			ofi_genlock_unlock(&util_ep->lock);
 		}
-
 	}
 
 	return succ_count;

--- a/prov/sm2/src/sm2_av.c
+++ b/prov/sm2/src/sm2_av.c
@@ -120,7 +120,9 @@ static int sm2_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 		util_ep = container_of(av_entry, struct util_ep, av_entry);
 		sm2_ep = container_of(util_ep, struct sm2_ep, util_ep);
 		srx = sm2_get_peer_srx(sm2_ep);
+		ofi_genlock_lock(&sm2_ep->util_ep.lock);
 		srx->owner_ops->foreach_unspec_addr(srx, &sm2_get_addr);
+		ofi_genlock_unlock(&sm2_ep->util_ep.lock);
 	}
 
 	return succ_count;

--- a/prov/util/src/util_srx.c
+++ b/prov/util/src/util_srx.c
@@ -412,7 +412,8 @@ static void util_foreach_unspec(struct fid_peer_srx *srx,
 
 	srx_ctx = srx->ep_fid.fid.context;
 
-	ofi_genlock_lock(srx_ctx->lock);
+	assert(ofi_genlock_held(srx_ctx->lock));
+
 	dlist_foreach_safe(&srx_ctx->unspec_unexp_msg_queue, item, tmp) {
 		rx_entry = (struct fi_peer_rx_entry *) item;
 		rx_entry->addr = get_addr(rx_entry);
@@ -446,7 +447,6 @@ static void util_foreach_unspec(struct fid_peer_srx *srx,
 			dlist_insert_tail(&unexp_peer->entry,
 					  &srx_ctx->unexp_peers);
 	}
-	ofi_genlock_unlock(srx_ctx->lock);
 }
 
 static struct fi_ops_srx_owner util_srx_owner_ops = {


### PR DESCRIPTION
util_queue_[msg,tag] and util_get_[msg,tag] expect the caller to acquire the SRX lock. This commit requires the callers of util_foreach_unspec to also do the same.