### PR TITLE
include/fi_peer.h, prov/util,lnx: remove fi_peer_rx_entry dlist fields

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -1286,6 +1286,10 @@ struct ofi_ops_flow_ctrl {
 };
 
 struct util_rx_entry {
+	union {
+		struct dlist_entry	d_entry;
+		struct slist_entry	s_entry;
+	};
 	struct fi_peer_rx_entry	peer_entry;
 	uint64_t		seq_no;
 	uint64_t		ignore;

--- a/include/rdma/providers/fi_peer.h
+++ b/include/rdma/providers/fi_peer.h
@@ -159,10 +159,7 @@ struct fi_peer_eq_context {
  */
 struct fid_peer_srx;
 
-/* Castable to dlist_entry */
 struct fi_peer_rx_entry {
-	struct fi_peer_rx_entry *next;
-	struct fi_peer_rx_entry *prev;
 	struct fid_peer_srx *srx;
 	fi_addr_t addr;
 	size_t msg_size;

--- a/man/fi_peer.3.md
+++ b/man/fi_peer.3.md
@@ -424,10 +424,7 @@ The data structures to support peer SRXs are defined as follows:
 ```
 struct fid_peer_srx;
 
-/* Castable to dlist_entry */
 struct fi_peer_rx_entry {
-    struct fi_peer_rx_entry *next;
-    struct fi_peer_rx_entry *prev;
     struct fi_peer_srx *srx;
     fi_addr_t addr;
     size_t msg_size;

--- a/prov/lnx/include/lnx.h
+++ b/prov/lnx/include/lnx.h
@@ -197,6 +197,7 @@ struct lnx_address {
 };
 
 struct lnx_rx_entry {
+	struct dlist_entry entry;
 	struct fi_peer_rx_entry rx_entry;
 	struct iovec rx_iov[LNX_IOV_LIMIT];
 	void *rx_desc[LNX_IOV_LIMIT];

--- a/prov/lnx/src/lnx_ops.c
+++ b/prov/lnx/src/lnx_ops.c
@@ -175,16 +175,16 @@ lnx_remove_first_match(struct lnx_queue *q, struct lnx_match_attr *match)
 static inline void
 lnx_insert_rx_entry(struct lnx_queue *q, struct lnx_rx_entry *entry)
 {
-	dlist_insert_tail((struct dlist_entry *)(&entry->rx_entry),
-			  &q->lq_queue);
+	dlist_insert_tail(&entry->entry, &q->lq_queue);
 	lnx_update_queue_stats(q, false);
 }
 
 int lnx_queue_tag(struct fi_peer_rx_entry *entry)
 {
-	struct lnx_rx_entry *rx_entry = (struct lnx_rx_entry *)entry;
+	struct lnx_rx_entry *rx_entry;
 	struct lnx_peer_srq *lnx_srq = (struct lnx_peer_srq*)entry->owner_context;
 
+	rx_entry = container_of(entry, struct lnx_rx_entry, rx_entry);
 	FI_DBG(&lnx_prov, FI_LOG_CORE,
 		"addr = %lx tag = %lx ignore = 0 found\n",
 		entry->addr, entry->tag);


### PR DESCRIPTION
fi_peer_rx_entry has two internal fi_peer_rx_entry fields so the struct could be castable to a dlist_entry or slist_entry. This suggests a dependency between the external headers and the internal headers which if difficult to ensure. In addition, there is no real reason for the owner and peer to share an entry for tracking the peer entry. The owner and peer each have their own structs and mechanisms for tracking the entry when the resource is on their side so the extra fields can be removed completely.

Since there is a requirement for all peers/owners to use the same version of libfabric, there is no issue with backwards compatibility