### PR TITLE
configure: Fix clang checking

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1117,7 +1117,7 @@ dnl patching ${archive_cmds} to affect generation of file "libtool" to fix linki
 dnl allows for building with clang lto and fast linking with non gnu ld
 dnl --> checking if the linker (clang) is GNU ld... no
 AS_CASE(["$LD"],
-    [*clang*],
+    [*clang[^/]*],
         [AS_CASE(["${host_os}"],
             [*linux*],
             [archive_cmds='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags $wl-soname $wl$soname $wl-version-script $wl$libname.map -o $lib'])])


### PR DESCRIPTION
When checking if clang is being used for linking, the pattern `*clang*` may incorrectly match a non-clang loader that is located under a path containing `clang`.

Fix by making sure the pattern only matches the filename part of a path.

Fix #11138 