### PR TITLE
prov/cxi: Support cuda sync_memops pointer attribute

### DIFF
--- a/man/fi_cxi.7.md
+++ b/man/fi_cxi.7.md
@@ -1293,6 +1293,12 @@ The CXI provider checks for the following environment variables:
 :   Force the CXI provider to use the HMEM device register copy routines. If not
     supported, RDMA operations or memory registration will fail.
 
+*FI_CXI_DISABLE_CUDA_SYNC_MEMOPS*
+:   By default the CXI provider sets the CU_POINTER_ATTRIBUTE_SYNC_MEMOPS on
+    registered memory to ensure synchronous copies and RDMA do not overlap.
+    Setting this value can be used to disable this behavior if for instance
+    the application is managing syncing of buffers.
+
 Note: Use the fi_info utility to query provider environment variables:
 <code>fi_info -p cxi -e</code>
 

--- a/prov/cxi/include/cxip.h
+++ b/prov/cxi/include/cxip.h
@@ -341,6 +341,7 @@ struct cxip_environment {
 	size_t mr_cache_events_disable_le_poll_nsecs;
 	int force_dev_reg_copy;
 	enum cxip_mr_target_ordering mr_target_ordering;
+	int disable_cuda_sync_memops;
 };
 
 extern struct cxip_environment cxip_env;

--- a/prov/cxi/src/cxip_info.c
+++ b/prov/cxi/src/cxip_info.c
@@ -673,6 +673,7 @@ struct cxip_environment cxip_env = {
 		CXIP_MR_CACHE_EVENTS_DISABLE_LE_POLL_NSECS,
 	.force_dev_reg_copy = false,
 	.mr_target_ordering = MR_ORDER_DEFAULT,
+	.disable_cuda_sync_memops = false,
 };
 
 static void cxip_env_init(void)
@@ -1321,6 +1322,12 @@ static void cxip_env_init(void)
 
 		param_str = NULL;
 	}
+
+	fi_param_define(&cxip_prov, "disable_cuda_sync_memops", FI_PARAM_BOOL,
+			"Disable CUDA sync of memory operations. Default: %d",
+			cxip_env.disable_cuda_sync_memops);
+	fi_param_get_bool(&cxip_prov, "disable_cuda_sync_memops",
+			  &cxip_env.disable_cuda_sync_memops);
 
 	set_system_page_size();
 }


### PR DESCRIPTION
Add support to ensure that a user synchronous cuda GPU copy completes prior to RDMA
access to the region.