### PR TITLE
prov/efa: Use dmabuf by default for neuron mr

### DIFF
--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -256,6 +256,7 @@ void *neuron_alloc(void **handle, size_t size);
 void neuron_free(void **handle);
 int neuron_get_dmabuf_fd(const void *addr, uint64_t size, int *fd,
 			 uint64_t *offset);
+int neuron_put_dmabuf_fd(int fd);
 
 int synapseai_init(void);
 int synapseai_cleanup(void);

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -509,6 +509,11 @@ struct ibv_mr *efa_mr_reg_ibv_dmabuf_mr(struct ibv_pd *pd, uint64_t offset,
 static struct ibv_mr *efa_mr_reg_ibv_mr(struct efa_mr *efa_mr, struct fi_mr_attr *mr_attr,
 					int access, const uint64_t flags)
 {
+	int dmabuf_fd;
+	uint64_t offset;
+	int ret;
+	struct ibv_mr *ibv_mr;
+
 	if (flags & FI_MR_DMABUF)
 		return efa_mr_reg_ibv_dmabuf_mr(
 			efa_mr->domain->ibv_pd,
@@ -519,20 +524,8 @@ static struct ibv_mr *efa_mr_reg_ibv_mr(struct efa_mr *efa_mr, struct fi_mr_attr
 			access
 		);
 
-	/*
-	 * When FI_MR_DMABUF flag is not set,
-	 * only do ibv_reg_mr.
-	 * The only exception is synapseai,
-	 * because dmabuf is the only way
-	 * to register Gaudi device buffer and
-	 * it was implemented before the FI_MR_DMABUF API.
-	 */
 	if (efa_mr_is_synapseai(efa_mr)) {
-		int dmabuf_fd;
-		uint64_t offset;
-		int ret;
-
-		ret = ofi_hmem_get_dmabuf_fd(FI_HMEM_SYNAPSEAI,
+		ret = ofi_hmem_get_dmabuf_fd(efa_mr->peer.iface,
 					     mr_attr->mr_iov->iov_base,
 					     (uint64_t) mr_attr->mr_iov->iov_len,
 					     &dmabuf_fd, &offset);
@@ -540,11 +533,45 @@ static struct ibv_mr *efa_mr_reg_ibv_mr(struct efa_mr *efa_mr, struct fi_mr_attr
 			EFA_WARN(FI_LOG_MR, "Unable to get dmabuf fd for Gaudi device buffer \n");
 			return NULL;
 		}
+		return efa_mr_reg_ibv_dmabuf_mr(
+				efa_mr->domain->ibv_pd, offset,
+				mr_attr->mr_iov->iov_len,
+				(uint64_t)mr_attr->mr_iov->iov_base,
+				dmabuf_fd, access);
+	}
 
-		return efa_mr_reg_ibv_dmabuf_mr(efa_mr->domain->ibv_pd, offset,
+	/*
+	 * TODO: need such fallback for cuda as well when
+	 * FI_CUDA_API_PERMITTED is true
+	 */
+	if (efa_mr_is_neuron(efa_mr)) {
+		ret = ofi_hmem_get_dmabuf_fd(
+				efa_mr->peer.iface,
+				mr_attr->mr_iov->iov_base,
+				mr_attr->mr_iov->iov_len,
+				&dmabuf_fd,
+				&offset);
+
+		if (ret == FI_SUCCESS) {
+			/* Success => invoke ibv_reg_dmabuf_mr */
+			ibv_mr = efa_mr_reg_ibv_dmabuf_mr(
+					efa_mr->domain->ibv_pd, 0,
 					mr_attr->mr_iov->iov_len,
 					(uint64_t)mr_attr->mr_iov->iov_base,
 					dmabuf_fd, access);
+			(void) ofi_hmem_put_dmabuf_fd(efa_mr->peer.iface, dmabuf_fd);
+			return ibv_mr;
+		} else if (ret == -FI_EOPNOTSUPP) {
+			/* Protocol not available => fallback */
+			EFA_INFO(FI_LOG_MR,
+				"Unable to get dmabuf fd for Neuron device buffer, "
+				"Fall back to ibv_reg_mr\n");
+			return ibv_reg_mr(
+				efa_mr->domain->ibv_pd,
+				(void *)mr_attr->mr_iov->iov_base,
+				mr_attr->mr_iov->iov_len, access);
+		}
+		return NULL;
 	}
 
 	return ibv_reg_mr(efa_mr->domain->ibv_pd,

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -248,7 +248,7 @@ struct ofi_hmem_ops hmem_ops[] = {
 		.dev_reg_copy_to_hmem = ofi_hmem_no_dev_reg_copy_to_hmem,
 		.dev_reg_copy_from_hmem = ofi_hmem_no_dev_reg_copy_from_hmem,
 		.get_dmabuf_fd = neuron_get_dmabuf_fd,
-		.put_dmabuf_fd = ofi_hmem_no_put_dmabuf_fd,
+		.put_dmabuf_fd = neuron_put_dmabuf_fd,
 	},
 	[FI_HMEM_SYNAPSEAI] = {
 		.initialized = false,

--- a/src/hmem_neuron.c
+++ b/src/hmem_neuron.c
@@ -249,6 +249,12 @@ int neuron_get_dmabuf_fd(const void *addr, uint64_t size, int *fd,
 	}
 }
 
+int neuron_put_dmabuf_fd(int fd)
+{
+	close(fd);
+	return FI_SUCCESS;
+}
+
 #else
 
 int neuron_copy_to_dev(uint64_t device, void *dev, const void *host, size_t size)
@@ -293,6 +299,11 @@ void neuron_free(void **handle)
 
 int neuron_get_dmabuf_fd(const void *addr, uint64_t size, int *fd,
 			 uint64_t *offset)
+{
+	return -FI_ENOSYS;
+}
+
+int neuron_put_dmabuf_fd(int fd)
 {
 	return -FI_ENOSYS;
 }


### PR DESCRIPTION
This patch reverts an earlier change that aims to do dmabuf reg only when FI_MR_DMABUF flag is set.
We still want to use dmabuf by default even when this flag is not set.

It also adds the clean up of the dmabuf fd after the ibv_reg_dmabuf_fd to fix the fd leak.

This reverts commit 043e968534491319d1b9afc22e482783d5779677.