### PR TITLE
prov/cxi: correct reduction engine arming behavior

### DIFF
--- a/prov/cxi/include/cxip.h
+++ b/prov/cxi/include/cxip.h
@@ -2958,7 +2958,8 @@ struct cxip_coll_reduction {
 	bool drop_send;				// drop the next send operation
 	bool drop_recv;				// drop the next recv operation
 	enum cxip_coll_rc red_rc;		// set by first error
-	struct timespec tv_expires;		// reduction expiration time
+	struct timespec tv_expires;		// need to retry?
+	struct timespec arm_expires;		// RE expiration time for this red_id
 	struct dlist_entry tmout_link;		// link to timeout list
 	uint8_t tx_msg[64];			// static packet memory
 };


### PR DESCRIPTION
The first time a particular reduction ID is used is not the only time we may need to arm the reduction engine. We also need to re- arm if the 'next' reduction is initiated after the previous arming period has expired. Replace the "first send" logic with "need to arm" logic.