### PR TITLE
fabtests/efa: Fix EFA device query 

### DIFF
--- a/fabtests/prov/efa/Makefile.include
+++ b/fabtests/prov/efa/Makefile.include
@@ -38,7 +38,9 @@ bin_PROGRAMS += prov/efa/src/fi_efa_rnr_read_cq_error \
 		prov/efa/src/fi_efa_multi_ep_mt
 
 if HAVE_VERBS_DEVEL
+if HAVE_EFA_DV
 bin_PROGRAMS += prov/efa/src/fi_efa_exhaust_mr_reg_rdm_pingpong
+endif HAVE_EFA_DV
 if BUILD_EFA_RDMA_CHECKER
 bin_PROGRAMS += prov/efa/src/fi_efa_rdma_checker
 endif BUILD_EFA_RDMA_CHECKER
@@ -74,6 +76,7 @@ prov_efa_src_fi_efa_multi_ep_mt_SOURCES = \
 prov_efa_src_fi_efa_multi_ep_mt_LDADD = libfabtests.la
 
 if HAVE_VERBS_DEVEL
+if HAVE_EFA_DV
 efa_exhaust_mr_reg_srcs = \
 	prov/efa/src/efa_exhaust_mr_reg_common.h \
 	prov/efa/src/efa_exhaust_mr_reg_common.c
@@ -83,6 +86,8 @@ prov_efa_src_fi_efa_exhaust_mr_reg_rdm_pingpong_SOURCES = \
 	$(efa_exhaust_mr_reg_srcs) \
 	$(benchmarks_srcs)
 prov_efa_src_fi_efa_exhaust_mr_reg_rdm_pingpong_LDADD = libfabtests.la
+prov_efa_src_fi_efa_exhaust_mr_reg_rdm_pingpong_LDFLAGS = -lefa
+endif HAVE_EFA_DV
 
 if BUILD_EFA_RDMA_CHECKER
 prov_efa_src_fi_efa_rdma_checker_SOURCES = \

--- a/fabtests/prov/efa/configure.m4
+++ b/fabtests/prov/efa/configure.m4
@@ -10,6 +10,7 @@ have_efadv=0
 AC_CHECK_HEADER([infiniband/efadv.h],
 		[AC_CHECK_LIB(efa, efadv_query_device,
                           [have_efadv=1])])
+AM_CONDITIONAL([HAVE_EFA_DV], [test $have_efadv -eq 1])
 
 efa_rdma_checker_happy=0
 AS_IF([test x"$have_efadv" = x"1"], [

--- a/fabtests/prov/efa/src/efa_exhaust_mr_reg_common.h
+++ b/fabtests/prov/efa/src/efa_exhaust_mr_reg_common.h
@@ -1,6 +1,7 @@
 /* Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
 
 #include <shared.h>
+#include <infiniband/efadv.h>
 #include <infiniband/verbs.h>
 
 #ifndef _EFA_EXHAUST_MR_REG_COMMON_H

--- a/fabtests/prov/efa/src/efa_rdma_checker.c
+++ b/fabtests/prov/efa/src/efa_rdma_checker.c
@@ -19,16 +19,15 @@ enum rdma_op {
 
 /*
  * Check whether rdma read/write is enabled on the instance by querying the rdma device.
- * Return 0 if rdma read/write is enabled, otherwise return -1.
+ * Return 0 if rdma read/write is enabled
  */
 int main(int argc, char *argv[])
 {
 	struct ibv_device **device_list;
 	struct ibv_context *ibv_ctx;
-	struct ibv_device_attr_ex ibv_dev_attr = {0};
 	struct efadv_device_attr efadv_attr = {0};
 	int dev_cnt;
-	int err, opt;
+	int err, opt, i;
 	enum rdma_op op = READ;
 
 	while ((opt = getopt(argc, argv, "ho:")) != -1) {
@@ -57,58 +56,66 @@ int main(int argc, char *argv[])
 	device_list = ibv_get_device_list(&dev_cnt);
 	if (dev_cnt <= 0) {
 		fprintf(stderr, "No ibv device found!\n");
-		return -ENODEV;
+		return -FI_ENODEV;
 	}
 
-	ibv_ctx = ibv_open_device(device_list[0]);
-	if (!ibv_ctx) {
-		fprintf(stderr, "cannot open device %d\n", 0);
-		return EXIT_FAILURE;
-	}
-
-	err = ibv_query_device_ex(ibv_ctx, NULL, &ibv_dev_attr);
-	if (!err) {
-		fprintf(stdout, "ibv_dev_attr.device_cap_flags_ex: %lx\n", ibv_dev_attr.device_cap_flags_ex);
-	}
-
-	err = efadv_query_device(ibv_ctx, (struct efadv_device_attr *)&efadv_attr, sizeof(efadv_attr));
-	ibv_close_device(ibv_ctx);
-	if (err) {
-		fprintf(stderr, "cannot query device\n");
-		goto out;
-	}
-
-	if (efadv_attr.max_rdma_size == 0) {
-		fprintf(stderr, "rdma is not enabled \n");
-		err = EXIT_FAILURE;
-		goto out;
-	}
-	fprintf(stdout, "rdma read is enabled \n");
-	fprintf(stdout, "efa_dev_attr.max_rdma_size: %d\n", efadv_attr.max_rdma_size);
-
-	if (op == READ)
-		goto out;
-
-	if (op == WRITE) {
-		if (efadv_attr.device_caps & EFADV_DEVICE_ATTR_CAPS_RDMA_WRITE) {
-			fprintf(stdout, "rdma write is enabled \n");
-		} else {
-			fprintf(stderr, "rdma write is NOT enabled \n");
-			err = 1;
+	for (i = 0; i < dev_cnt; i++) {
+		ibv_ctx = ibv_open_device(device_list[i]);
+		if (!ibv_ctx) {
+			fprintf(stderr, "cannot open device %d\n", i);
+			return EXIT_FAILURE;
 		}
+
+		memset(&efadv_attr, 0, sizeof(efadv_attr));
+		err = efadv_query_device(ibv_ctx, (struct efadv_device_attr *)&efadv_attr, sizeof(efadv_attr));
+		ibv_close_device(ibv_ctx);
+		if (err) {
+			if (err == EOPNOTSUPP) {
+				fprintf(stdout, "Not an EFA device. Continue to check the next device.\n");
+				continue;
+			} else {
+				fprintf(stderr, "cannot query device %d, err: %d\n", i, -err);
+				goto out;
+			}
+		}
+
+		fprintf(stdout, "Checking device %d: %s\n", i, ibv_get_device_name(device_list[i]));
+		if (efadv_attr.max_rdma_size == 0) {
+			fprintf(stderr, "rdma is not enabled \n");
+			err = EXIT_FAILURE;
+			goto out;
+		}
+
+		fprintf(stdout, "efa_dev_attr.max_rdma_size: %d\n", efadv_attr.max_rdma_size);
+
+		if (op == READ)
+			fprintf(stdout, "rdma read is enabled \n");
+
+		if (op == WRITE) {
+			if (efadv_attr.device_caps & EFADV_DEVICE_ATTR_CAPS_RDMA_WRITE) {
+				fprintf(stdout, "rdma write is enabled \n");
+			} else {
+				fprintf(stderr, "rdma write is NOT enabled \n");
+				err = 1;
+			}
+		}
+
+		if (op == UNSOLICITED_WRITE_RECV) {
+			if (efadv_attr.device_caps & EFADV_DEVICE_ATTR_CAPS_UNSOLICITED_WRITE_RECV) {
+				fprintf(stdout,
+					"rdma unsolicited write recv is enabled \n");
+			} else {
+				fprintf(stderr, "rdma unsolicited write recv is NOT "
+						"enabled \n");
+				err = 1;
+			}
+		}
+
 		goto out;
 	}
 
-	if (op == UNSOLICITED_WRITE_RECV) {
-		if (efadv_attr.device_caps & EFADV_DEVICE_ATTR_CAPS_UNSOLICITED_WRITE_RECV) {
-			fprintf(stdout,
-				"rdma unsolicited write recv is enabled \n");
-		} else {
-			fprintf(stderr, "rdma unsolicited write recv is NOT "
-					"enabled \n");
-			err = 1;
-		}
-	}
+	fprintf(stderr, "No EFA device found!\n");
+	err = -FI_ENODEV;
 
 out:
 	ibv_free_device_list(device_list);

--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -34,9 +34,13 @@ def test_rdm_pingpong(cmdline_args, iteration_type, completion_semantic,
 @pytest.mark.functional
 @pytest.mark.serial
 def test_mr_exhaustion_rdm_pingpong(cmdline_args, completion_semantic):
+    import os
+    binpath = cmdline_args.binpath or ""
+    if not os.path.exists(os.path.join(binpath, "fi_efa_exhaust_mr_reg_rdm_pingpong")):
+        pytest.skip("fi_efa_exhaust_mr_reg_rdm_pingpong requires efadv")
     efa_run_client_server_test(cmdline_args, "fi_efa_exhaust_mr_reg_rdm_pingpong", "short",
-                                completion_semantic, "host_to_host", "all", timeout=1000,
-                                fabric="efa")
+                               completion_semantic, "host_to_host", "all", timeout=1000,
+                               fabric="efa")
 
 @pytest.mark.parametrize("mr_cache", [True, False])
 @pytest.mark.parametrize("iteration_type",

--- a/prov/efa/test/efa_unit_test_cq.c
+++ b/prov/efa/test/efa_unit_test_cq.c
@@ -659,14 +659,22 @@ void test_rdm_cq_create_error_handling(struct efa_resource **state)
 	struct efa_domain *efa_domain = NULL;
 	struct verbs_context *vctx = NULL;
 	struct fi_cq_attr cq_attr = {0};
+	int ret, total_device_cnt, i;
 
-	ibv_device_list = ibv_get_device_list(&g_efa_selected_device_cnt);
+	ibv_device_list = ibv_get_device_list(&total_device_cnt);
 	if (ibv_device_list == NULL) {
 		skip();
 		return;
 	}
-	efa_device_construct_gid(&efa_device, ibv_device_list[0]);
-	efa_device_construct_data(&efa_device, ibv_device_list[0]);
+
+	for (i = 0; i < total_device_cnt; i++) {
+		ret = efa_device_construct_gid(&efa_device, ibv_device_list[i]);
+		if (ret)
+			continue;
+		ret = efa_device_construct_data(&efa_device, ibv_device_list[i]);
+		if (!ret)
+			break;
+	}
 
 	resource->hints = efa_unit_test_alloc_hints(FI_EP_RDM, EFA_FABRIC_NAME);
 	assert_non_null(resource->hints);
@@ -689,6 +697,8 @@ void test_rdm_cq_create_error_handling(struct efa_resource **state)
 	assert_int_not_equal(fi_cq_open(resource->domain, &cq_attr, &resource->cq, NULL), 0);
 	/* set cq as NULL to avoid double free by fi_close in cleanup stage */
 	resource->cq = NULL;
+	ibv_close_device(efa_device.ibv_ctx);
+	ibv_free_device_list(ibv_device_list);
 }
 
 /**


### PR DESCRIPTION
The first ibv device can be non-EFA. Loop through the device list and query the first EFA device.