### PR TITLE
prov/efa: Fix the hmem flags setting

### DIFF
--- a/prov/efa/src/efa_prov.c
+++ b/prov/efa/src/efa_prov.c
@@ -109,6 +109,9 @@ static int efa_util_prov_initialize()
 			continue;
 		}
 
+		/* This function must be called after efa_hmem_info_initialize() */
+		efa_prov_info_direct_set_hmem_flags(prov_info_direct);
+
 		if (!head) {
 			head = prov_info_direct;
 		} else {

--- a/prov/efa/src/efa_prov_info.c
+++ b/prov/efa/src/efa_prov_info.c
@@ -389,14 +389,13 @@ err_free:
 }
 
 #if HAVE_CUDA || HAVE_NEURON || HAVE_SYNAPSEAI
-void efa_prov_info_set_hmem_flags(struct fi_info *prov_info, enum fi_ep_type ep_type)
+void efa_prov_info_direct_set_hmem_flags(struct fi_info *prov_info)
 {
 	int i;
 	enum fi_hmem_iface iface;
 	struct efa_hmem_info *hmem_info;
 
-	if (ep_type != FI_EP_RDM)
-		return;
+	assert(prov_info->ep_attr->type == FI_EP_RDM);
 
 	/* Check if FI_HMEM_P2P_DISABLED is set */
 	if (ofi_hmem_p2p_disabled()) {
@@ -434,7 +433,7 @@ void efa_prov_info_set_hmem_flags(struct fi_info *prov_info, enum fi_ep_type ep_
 	prov_info->domain_attr->mr_mode	|= FI_MR_HMEM;
 }
 #else
-void efa_prov_info_set_hmem_flags(struct fi_info *prov_info, enum fi_ep_type ep_type)
+void efa_prov_info_direct_set_hmem_flags(struct fi_info *prov_info, enum fi_ep_type ep_type)
 {
 }
 #endif
@@ -522,8 +521,6 @@ int efa_prov_info_alloc(struct fi_info **prov_info_ptr,
 	if (err) {
 		goto err_free;
 	}
-
-	efa_prov_info_set_hmem_flags(prov_info, ep_type);
 
 	*prov_info_ptr = prov_info;
 	return 0;

--- a/prov/efa/src/efa_prov_info.h
+++ b/prov/efa/src/efa_prov_info.h
@@ -22,6 +22,6 @@ int efa_prov_info_compare_domain_name(const struct fi_info *hints,
 int efa_prov_info_compare_pci_bus_id(const struct fi_info *hints,
                                      const struct fi_info *info);
 
-void efa_prov_info_set_hmem_flags(struct fi_info *prov_info, enum fi_ep_type ep_type);
+void efa_prov_info_direct_set_hmem_flags(struct fi_info *prov_info);
 
 #endif

--- a/prov/efa/test/efa_unit_test_info.c
+++ b/prov/efa/test/efa_unit_test_info.c
@@ -171,6 +171,7 @@ void test_info_direct_hmem_support_p2p()
 	bool hmem_ops_cuda_init;
 
 	info = fi_allocinfo();
+	info->ep_attr->type = FI_EP_RDM;
 
 	memset(g_efa_hmem_info, 0, OFI_HMEM_MAX * sizeof(struct efa_hmem_info));
 
@@ -190,17 +191,18 @@ void test_info_direct_hmem_support_p2p()
 	g_efa_hmem_info[FI_HMEM_CUDA].initialized = true;
 	g_efa_hmem_info[FI_HMEM_CUDA].p2p_supported_by_device = true;
 
-	efa_prov_info_set_hmem_flags(info, FI_EP_RDM);
+	efa_prov_info_direct_set_hmem_flags(info);
 	assert_true(info->caps & FI_HMEM);
 	assert_true(info->tx_attr->caps & FI_HMEM);
 	assert_true(info->rx_attr->caps & FI_HMEM);
 	fi_freeinfo(info);
 
 	info = fi_allocinfo();
+	info->ep_attr->type = FI_EP_RDM;
 	g_efa_hmem_info[FI_HMEM_CUDA].initialized = true;
 	g_efa_hmem_info[FI_HMEM_CUDA].p2p_supported_by_device = false;
 
-	efa_prov_info_set_hmem_flags(info, FI_EP_RDM);
+	efa_prov_info_direct_set_hmem_flags(info);
 	assert_false(info->caps & FI_HMEM);
 	assert_false(info->tx_attr->caps & FI_HMEM);
 	assert_false(info->rx_attr->caps & FI_HMEM);


### PR DESCRIPTION
Currently, efa_prov_info_set_hmem_flags is called as part of device list initialization, which is before efa_hmem_info_initialize() is called. This will make the efa_prov_info_set_hmem_flags not work because the metadata in `g_efa_hmem_info` is not initialized yet.

This patch fixes this issue by moving efa_prov_info_set_hmem_flags to efa_util_prov_initialize()'s efa-direct prov_info construction, which happens after the efa_hmem_info_initialize() call.