### PR TITLE
prov/lnx: fix missing peer_entry field updates

### DIFF
--- a/prov/lnx/src/lnx_ops.c
+++ b/prov/lnx/src/lnx_ops.c
@@ -64,8 +64,10 @@ int lnx_queue_msg(struct fi_peer_rx_entry *entry)
 
 void lnx_free_entry(struct fi_peer_rx_entry *entry)
 {
-	struct lnx_rx_entry *rx_entry = (struct lnx_rx_entry *) entry;
+	struct lnx_rx_entry *rx_entry;
 	ofi_spin_t *bplock;
+
+	rx_entry = container_of(entry, struct lnx_rx_entry, rx_entry);
 
 	if (rx_entry->rx_global)
 		bplock = &global_bplock;


### PR DESCRIPTION
A recent commit removed the fi_peer_rx_entry next/prev fields disallowing casting from a dlist_entry to an rx_entry and moving the dlist_entry into the lnx_entry. Two containers/casts were missed