### PR TITLE
fabtests: fix type mismatch build warning

### DIFF
--- a/fabtests/benchmarks/rdm_bw_mt.c
+++ b/fabtests/benchmarks/rdm_bw_mt.c
@@ -74,7 +74,7 @@
 #define BUFFER_SIZE 1024
 static char oob_buffer[BUFFER_SIZE];
 
-static int num_eps = 1;
+static size_t num_eps = 1;
 static bool bidir = false;
 static ssize_t xfer_size = 1;
 pthread_barrier_t barrier;

--- a/fabtests/prov/efa/src/multi_ep_mt.c
+++ b/fabtests/prov/efa/src/multi_ep_mt.c
@@ -48,7 +48,7 @@ static struct fi_context2 *recv_ctx;
 static struct fi_context2 *send_ctx;
 static struct fid_av **avs;
 static fi_addr_t *remote_fiaddr;
-int num_eps = 3;
+static size_t num_eps = 3;
 char remote_raw_addr[FT_MAX_CTRL_MSG];
 
 void close_client(int i);


### PR DESCRIPTION
Fix build error:
argument 1 range [18446744071562067968, 18446744073709551615] exceeds maximum object size 9223372036854775807 [-Walloc-size-larger-than=]

Change num_ep type to size_t to suppress warning