### PR TITLE
[v2.2.x]prov/efa: Restrict GDA domain ops to efa-direct

### DIFF
--- a/man/fi_efa.7.md
+++ b/man/fi_efa.7.md
@@ -22,6 +22,7 @@ The `efa-direct` fabric, on the contrary, offloads all libfabric data plane call
 the device directly without wire protocols. Compared to the `efa` fabric, the `efa-direct`
 fabric supports fewer capabilities and has more mode requirements for applications.
 But it provides a fast path to hand off application requests to the device.
+To use `efa-direct`, set the name field in `fi_fabric_attr` to `efa-direct`.
 More details and difference between the two fabrics will be presented below.
 
 
@@ -241,8 +242,8 @@ struct fi_efa_mr_attr {
 
 
 To enable GPU Direct Async (GDA), which allows the GPU to interact directly with the NIC, 
-request `FI_EFA_GDA_OPS` in the `name` parameter. This returns `ops` as a pointer to the 
-function table `fi_efa_ops_gda` defined as follows:
+request `FI_EFA_GDA_OPS` in the `name` parameter with efa-direct fabirc.
+This returns `ops` as a pointer to the function table `fi_efa_ops_gda` defined as follows:
 
 ```c
 struct fi_efa_ops_gda {

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -736,12 +736,19 @@ efa_domain_ops_open(struct fid *fid, const char *ops_name, uint64_t flags,
 		     void **ops, void *context)
 {
 	int ret = FI_SUCCESS;
+	struct efa_domain *efa_domain;
 
 	if (strcmp(ops_name, FI_EFA_DOMAIN_OPS) == 0) {
 		*ops = &efa_ops_domain;
 		return ret;
 	}
 	if (strcmp(ops_name, FI_EFA_GDA_OPS) == 0) {
+		efa_domain = container_of(fid, struct efa_domain, util_domain.domain_fid.fid);
+		if (efa_domain->info_type != EFA_INFO_DIRECT) {
+			EFA_WARN(FI_LOG_DOMAIN, "Only efa direct supports FI_EFA_GDA_OPS\n");
+			return -FI_EOPNOTSUPP;
+		}
+
 		*ops = &efa_ops_gda;
 		return ret;
 	}


### PR DESCRIPTION
GPU Direct Async (GDA) is designed to minimize CPU intervention for optimal performance. Applications should use efa-direct fabric to open GDA domain ops. Return -FI_EOPNOTSUPP for non efa direct domains.


(cherry picked from commit a726b2507f4c7059a58cc4c58039f8b0e5c94951)