### PR TITLE
fabtests/efa: Add pytest marker and fixture to GDA fabtest

### DIFF
--- a/fabtests/pytest/efa/test_gda.py
+++ b/fabtests/pytest/efa/test_gda.py
@@ -3,13 +3,12 @@ import pytest
 from common import ClientServerTest, has_cuda
 
 
+@pytest.mark.short
 @pytest.mark.functional
 @pytest.mark.cuda_memory
-def test_gda_send_recv(cmdline_args, direct_message_size):
-    fi_efa_gda_path = "fi_efa_gda"
-    if cmdline_args.binpath:
-        fi_efa_gda_path = os.path.join(cmdline_args.binpath, "fi_efa_gda")
-    if not os.path.exists(fi_efa_gda_path):
+def test_gda_send_recv(cmdline_args, direct_message_size, fabric):
+    binpath = cmdline_args.binpath or ""
+    if not os.path.exists(os.path.join(binpath, "fi_efa_gda")):
         pytest.skip("fi_efa_gda is not built")
 
     if not cmdline_args.do_dmabuf_reg_for_hmem:
@@ -18,9 +17,12 @@ def test_gda_send_recv(cmdline_args, direct_message_size):
     if not has_cuda(cmdline_args.client_id) or not has_cuda(cmdline_args.server_id):
         pytest.skip("Client and server both need a cuda device")
 
+    if fabric != "efa-direct":
+        pytest.skip("GDA only works for efa-direct fabric")
+
     test = ClientServerTest(cmdline_args, "fi_efa_gda",
                             message_size=direct_message_size,
                             iteration_type="short",
                             memory_type="cuda_to_cuda",
-                            fabric="efa-direct")
+                            fabric=fabric)
     test.run()


### PR DESCRIPTION
Add testset short and fabric so it will be picked up by our CI.