### PR TITLE
prov/efa: Move protection domain back to device level, move address handle to device level

### DIFF
--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -225,12 +225,12 @@ static inline int efa_av_is_valid_address(struct efa_ep_addr *addr)
  * This function use a hash map to store GID to ibv_ah map,
  * and re-use ibv_ah for same GID
  *
- * @param[in]	domain	efa_domain
+ * @param[in]	device	efa_device object pointer
  * @param[in]	gid	GID
  */
-struct efa_ah *efa_ah_alloc(struct efa_domain *domain, const uint8_t *gid)
+struct efa_ah *efa_ah_alloc(struct efa_device *device, const uint8_t *gid)
 {
-	struct ibv_pd *ibv_pd = domain->ibv_pd;
+	struct ibv_pd *ibv_pd = device->ibv_pd;
 	struct efa_ah *efa_ah;
 	struct ibv_ah_attr ibv_ah_attr = { 0 };
 	struct efadv_ah_attr efa_ah_attr = { 0 };
@@ -238,11 +238,12 @@ struct efa_ah *efa_ah_alloc(struct efa_domain *domain, const uint8_t *gid)
 
 	efa_ah = NULL;
 
-	ofi_genlock_lock(&domain->util_domain.lock);
-	HASH_FIND(hh, domain->ah_map, gid, EFA_GID_LEN, efa_ah);
+	ofi_genlock_lock(&device->lock);
+	HASH_FIND(hh, device->ah_map, gid, EFA_GID_LEN, efa_ah);
+
 	if (efa_ah) {
 		efa_ah->refcnt += 1;
-		ofi_genlock_unlock(&domain->util_domain.lock);
+		ofi_genlock_unlock(&device->lock);
 		return efa_ah;
 	}
 
@@ -250,6 +251,7 @@ struct efa_ah *efa_ah_alloc(struct efa_domain *domain, const uint8_t *gid)
 	if (!efa_ah) {
 		errno = FI_ENOMEM;
 		EFA_WARN(FI_LOG_AV, "cannot allocate memory for efa_ah\n");
+		ofi_genlock_unlock(&device->lock);
 		return NULL;
 	}
 
@@ -272,45 +274,45 @@ struct efa_ah *efa_ah_alloc(struct efa_domain *domain, const uint8_t *gid)
 	efa_ah->refcnt = 1;
 	efa_ah->ahn = efa_ah_attr.ahn;
 	memcpy(efa_ah->gid, gid, EFA_GID_LEN);
-	HASH_ADD(hh, domain->ah_map, gid, EFA_GID_LEN, efa_ah);
-	ofi_genlock_unlock(&domain->util_domain.lock);
+	HASH_ADD(hh, device->ah_map, gid, EFA_GID_LEN, efa_ah);
+	ofi_genlock_unlock(&device->lock);
 	return efa_ah;
 
 err_destroy_ibv_ah:
 	ibv_destroy_ah(efa_ah->ibv_ah);
 err_free_efa_ah:
 	free(efa_ah);
-	ofi_genlock_unlock(&domain->util_domain.lock);
+	ofi_genlock_unlock(&device->lock);
 	return NULL;
 }
 
 /**
  * @brief release an efa_ah object
  *
- * @param[in]	domain	efa_domain
+ * @param[in]	device	efa_device object pointer
  * @param[in]	ah	efa_ah object pointer
  */
-void efa_ah_release(struct efa_domain *domain, struct efa_ah *ah)
+void efa_ah_release(struct efa_device *device, struct efa_ah *ah)
 {
 	int err;
-	ofi_genlock_lock(&domain->util_domain.lock);
+	ofi_genlock_lock(&device->lock);
 #if ENABLE_DEBUG
 	struct efa_ah *tmp;
 
-	HASH_FIND(hh, domain->ah_map, ah->gid, EFA_GID_LEN, tmp);
+	HASH_FIND(hh, device->ah_map, ah->gid, EFA_GID_LEN, tmp);
 	assert(tmp == ah);
 #endif
 	assert(ah->refcnt > 0);
 	ah->refcnt -= 1;
 	if (ah->refcnt == 0) {
 		EFA_INFO(FI_LOG_AV, "Destroying AH for ahn %d\n", ah->ahn);
-		HASH_DEL(domain->ah_map, ah);
+		HASH_DEL(device->ah_map, ah);
 		err = ibv_destroy_ah(ah->ibv_ah);
 		if (err)
 			EFA_WARN(FI_LOG_AV, "ibv_destroy_ah failed! err=%d\n", err);
 		free(ah);
 	}
-	ofi_genlock_unlock(&domain->util_domain.lock);
+	ofi_genlock_unlock(&device->lock);
 }
 
 /**
@@ -608,7 +610,7 @@ struct efa_conn *efa_conn_alloc(struct efa_av *av, struct efa_ep_addr *raw_addr,
 		conn->implicit_fi_addr = FI_ADDR_NOTAVAIL;
 	}
 
-	conn->ah = efa_ah_alloc(av->domain, raw_addr->raw);
+	conn->ah = efa_ah_alloc(av->domain->device, raw_addr->raw);
 	if (!conn->ah)
 		goto err_release;
 
@@ -642,7 +644,7 @@ struct efa_conn *efa_conn_alloc(struct efa_av *av, struct efa_ep_addr *raw_addr,
 
 err_release:
 	if (conn->ah)
-		efa_ah_release(av->domain, conn->ah);
+		efa_ah_release(av->domain->device, conn->ah);
 
 	conn->ep_addr = NULL;
 	err = ofi_av_remove_addr(util_av, fi_addr);
@@ -690,7 +692,7 @@ void efa_conn_release(struct efa_av *av, struct efa_conn *conn, bool release_fro
 	if (av->domain->info_type == EFA_INFO_RDM)
 		efa_conn_rdm_deinit(av, conn);
 
-	efa_ah_release(av->domain, conn->ah);
+	efa_ah_release(av->domain->device, conn->ah);
 
 	util_av_entry = ofi_bufpool_get_ibuf(util_av->av_entry_pool, fi_addr);
 	assert(util_av_entry);

--- a/prov/efa/src/efa_av.h
+++ b/prov/efa/src/efa_av.h
@@ -8,6 +8,7 @@
 #include "ofi_util.h"
 #include "rdm/efa_rdm_protocol.h"
 #include "rdm/efa_rdm_peer.h"
+#include "efa_device.h"
 
 #define EFA_MIN_AV_SIZE (16384)
 #define EFA_SHM_MAX_AV_COUNT       (256)
@@ -29,7 +30,7 @@ struct efa_ah {
 	struct ibv_ah	*ibv_ah; /* created by ibv_create_ah() using GID */
 	uint16_t	ahn; /* adress handle number */
 	int		refcnt; /* reference counter. Multiple efa_conn can share an efa_ah */
-	UT_hash_handle	hh; /* hash map handle, link all efa_ah with efa_ep->ah_map */
+	UT_hash_handle	hh; /* hash map handle, link all efa_ah with efa_device->ah_map */
 };
 
 struct efa_conn {
@@ -118,8 +119,8 @@ int efa_av_reverse_av_add(struct efa_av *av,
 			  struct efa_prv_reverse_av **prv_reverse_av,
 			  struct efa_conn *conn);
 
-struct efa_ah *efa_ah_alloc(struct efa_domain *domain, const uint8_t *gid);
+struct efa_ah *efa_ah_alloc(struct efa_device *device, const uint8_t *gid);
 
-void efa_ah_release(struct efa_domain *domain, struct efa_ah *ah);
+void efa_ah_release(struct efa_device *device, struct efa_ah *ah);
 
 #endif

--- a/prov/efa/src/efa_base_ep.c
+++ b/prov/efa/src/efa_base_ep.c
@@ -106,7 +106,7 @@ int efa_base_ep_destruct(struct efa_base_ep *base_ep)
 	fi_freeinfo(base_ep->info);
 
 	if (base_ep->self_ah)
-		efa_ah_release(base_ep->domain, base_ep->self_ah);
+		efa_ah_release(base_ep->domain->device, base_ep->self_ah);
 
 	err = efa_base_ep_destruct_qp(base_ep);
 
@@ -300,7 +300,7 @@ static inline
 int efa_base_ep_create_self_ah(struct efa_base_ep *base_ep, struct ibv_pd *ibv_pd)
 {
 
-	base_ep->self_ah = efa_ah_alloc(base_ep->domain, base_ep->src_addr.raw);
+	base_ep->self_ah = efa_ah_alloc(base_ep->domain->device, base_ep->src_addr.raw);
 
 	return base_ep->self_ah ? 0 : -FI_EINVAL;
 }

--- a/prov/efa/src/efa_device.c
+++ b/prov/efa/src/efa_device.c
@@ -96,7 +96,7 @@ err_close:
 
 /**
  * @brief initialize data members of a struct of efa_device after the gid
- * including the prov info
+ * including the protection domain and prov info
  *
  * @param	efa_device[in,out]	pointer to a struct efa_device
  * @param	ibv_device[in]		pointer to a struct ibv_device, which is
@@ -104,12 +104,20 @@ err_close:
  * @return	0 on success
  * 		a negative libfabric error code on failure.
  */
-int efa_device_construct_data(struct efa_device *efa_device,
+int efa_device_construct_pd(struct efa_device *efa_device,
 			 struct ibv_device *ibv_device)
 {
 	int err;
 
 	assert(efa_device->ibv_ctx);
+
+	efa_device->ibv_pd = ibv_alloc_pd(efa_device->ibv_ctx);
+	if (!efa_device->ibv_pd) {
+		EFA_INFO_ERRNO(FI_LOG_DOMAIN, "ibv_alloc_pd",
+		               errno);
+		err = -errno;
+		goto err_close;
+	}
 
 #if HAVE_RDMA_SIZE
 	efa_device->max_rdma_size = efa_device->efa_attr.max_rdma_size;
@@ -137,6 +145,12 @@ int efa_device_construct_data(struct efa_device *efa_device,
 	return 0;
 
 err_close:
+	if (efa_device->ibv_pd) {
+		err = ibv_dealloc_pd(efa_device->ibv_pd);
+		if (err)
+			EFA_INFO_ERRNO(FI_LOG_DOMAIN, "ibv_dealloc_pd",
+			               err);
+	}
 
 	ibv_close_device(efa_device->ibv_ctx);
 	efa_device->ibv_ctx = NULL;
@@ -162,6 +176,15 @@ err_close:
 static void efa_device_destruct(struct efa_device *device)
 {
 	int err;
+
+	if (device->ibv_pd) {
+		err = ibv_dealloc_pd(device->ibv_pd);
+		if (err)
+			EFA_INFO_ERRNO(FI_LOG_DOMAIN, "ibv_dealloc_pd",
+			               err);
+	}
+
+	device->ibv_pd = NULL;
 
 	if (device->ibv_ctx) {
 		err = ibv_close_device(device->ibv_ctx);
@@ -268,7 +291,7 @@ int efa_device_list_initialize(void)
 
 		}
 
-		err = efa_device_construct_data(&cur_device, ibv_device_list[device_idx]);
+		err = efa_device_construct_pd(&cur_device, ibv_device_list[device_idx]);
 		if (err) {
 			EFA_WARN(FI_LOG_FABRIC,
 				 "efa_device_construct_data failed for device %s, err=%d\n",

--- a/prov/efa/src/efa_device.h
+++ b/prov/efa/src/efa_device.h
@@ -8,6 +8,7 @@
 #include <infiniband/verbs.h>
 #include <infiniband/efadv.h>
 #include <stdbool.h>
+#include <ofi_lock.h>
 
 struct efa_device {
 	struct ibv_context	*ibv_ctx;
@@ -18,6 +19,8 @@ struct efa_device {
 	uint32_t		device_caps;
 	uint32_t		max_rdma_size;
 	struct ibv_pd		*ibv_pd;
+	struct efa_ah		*ah_map;
+	struct ofi_genlock	lock;
 	struct fi_info		*rdm_info;
 	struct fi_info		*dgram_info;
 };

--- a/prov/efa/src/efa_device.h
+++ b/prov/efa/src/efa_device.h
@@ -17,6 +17,7 @@ struct efa_device {
 	union ibv_gid		ibv_gid;
 	uint32_t		device_caps;
 	uint32_t		max_rdma_size;
+	struct ibv_pd		*ibv_pd;
 	struct fi_info		*rdm_info;
 	struct fi_info		*dgram_info;
 };

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -91,13 +91,8 @@ static int efa_domain_init_device_and_pd(struct efa_domain *efa_domain,
 	if (i == g_efa_selected_device_cnt)
 		return -FI_ENODEV;
 
-	efa_domain->ibv_pd = ibv_alloc_pd(efa_domain->device->ibv_ctx);
-	if (!efa_domain->ibv_pd) {
-		EFA_WARN(FI_LOG_DOMAIN, "Failed to allocated ibv_pd: %d\n", errno);
-		return -FI_ENOMEM;
-	}
-
 	EFA_INFO(FI_LOG_DOMAIN, "Domain %s selected device %s\n", domain_name, device_name);
+	efa_domain->ibv_pd = efa_domain->device->ibv_pd;
 	return 0;
 }
 
@@ -374,9 +369,6 @@ static int efa_domain_close(fid_t fid)
 	ofi_genlock_unlock(&efa_domain->util_domain.lock);
 
 	if (efa_domain->ibv_pd) {
-		ret = ibv_dealloc_pd(efa_domain->ibv_pd);
-		if (ret)
-			EFA_WARN(FI_LOG_DOMAIN, "Failed to dealloc ibv_pd: %d\n", ret);
 		efa_domain->ibv_pd = NULL;
 	}
 

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -204,8 +204,6 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 	efa_domain->ibv_mr_reg_ct = 0;
 	efa_domain->ibv_mr_reg_sz = 0;
 
-	efa_domain->ah_map = NULL;
-
 	use_lock = ofi_thread_level(efa_domain->util_domain.threading) <= ofi_thread_level(FI_THREAD_COMPLETION);
 	err = ofi_genlock_init(&efa_domain->srx_lock, use_lock ? OFI_LOCK_MUTEX : OFI_LOCK_NOOP);
 	if (err) {
@@ -338,7 +336,6 @@ err_free:
 static int efa_domain_close(fid_t fid)
 {
 	struct efa_domain *efa_domain;
-	struct efa_ah *ah_entry, *tmp;
 	int ret;
 
 	efa_domain = container_of(fid, struct efa_domain,
@@ -353,20 +350,6 @@ static int efa_domain_close(fid_t fid)
 		free(efa_domain->cache);
 		efa_domain->cache = NULL;
 	}
-
-	/* Clean up ah_map if any entries remain */
-	ofi_genlock_lock(&efa_domain->util_domain.lock);
-	if (efa_domain->ah_map) {
-		EFA_WARN(FI_LOG_DOMAIN, "AH map not empty during domain close! Cleaning up ...\n");
-		HASH_ITER(hh, efa_domain->ah_map, ah_entry, tmp) {
-			ret = ibv_destroy_ah(ah_entry->ibv_ah);
-			if (ret)
-				EFA_WARN(FI_LOG_DOMAIN, "ibv_destroy_ah failed during cleanup! err=%d\n", ret);
-			HASH_DEL(efa_domain->ah_map, ah_entry);
-			free(ah_entry);
-		}
-	}
-	ofi_genlock_unlock(&efa_domain->util_domain.lock);
 
 	if (efa_domain->ibv_pd) {
 		efa_domain->ibv_pd = NULL;

--- a/prov/efa/src/efa_domain.h
+++ b/prov/efa/src/efa_domain.h
@@ -34,7 +34,6 @@ struct efa_domain {
 	bool 			mr_local;
 	struct dlist_entry	list_entry; /* linked to g_efa_domain_list */
 	struct ofi_genlock	srx_lock; /* shared among peer providers */
-	struct efa_ah		*ah_map;
 	/* Total count of ibv memory registrations */
 	size_t ibv_mr_reg_ct;
 	/* Total size of memory registrations (in bytes) */

--- a/prov/efa/test/efa_unit_test_cq.c
+++ b/prov/efa/test/efa_unit_test_cq.c
@@ -671,7 +671,7 @@ void test_rdm_cq_create_error_handling(struct efa_resource **state)
 		ret = efa_device_construct_gid(&efa_device, ibv_device_list[i]);
 		if (ret)
 			continue;
-		ret = efa_device_construct_data(&efa_device, ibv_device_list[i]);
+		ret = efa_device_construct_pd(&efa_device, ibv_device_list[i]);
 		if (!ret)
 			break;
 	}

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -89,7 +89,7 @@ struct efa_unit_test_handshake_pkt_attr {
 int efa_device_construct_gid(struct efa_device *efa_device,
 			 struct ibv_device *ibv_device);
 
-int efa_device_construct_data(struct efa_device *efa_device,
+int efa_device_construct_pd(struct efa_device *efa_device,
 			 struct ibv_device *ibv_device);
 
 void efa_unit_test_buff_construct(struct efa_unit_test_buff *buff, struct efa_resource *resource, size_t buff_size);


### PR DESCRIPTION
The earlier change that makes 1:1 relationship between PD and domain break the PD limit on platform that has high core count and limited max PD. This change moves the pd back to device level to lower the number of PDs libfabric can allocate.
Also moves the AH map resources to the device level from domain level, as AH is a PD level resources.