### PR TITLE
prov/cxi: Add multi-thread wait_fd support for RNR protocol

### DIFF
--- a/man/fi_cxi.7.md
+++ b/man/fi_cxi.7.md
@@ -79,10 +79,20 @@ The CXI provider supports FI_THREAD_SAFE and FI_THREAD_DOMAIN threading models.
 ## Wait Objects
 
 The CXI provider supports FI_WAIT_FD and FI_WAIT_POLLFD CQ wait object types.
-FI_WAIT_UNSPEC will default to FI_WAIT_FD. However FI_WAIT_NONE should achieve
-the lowest latency and reduce interrupt overhead. NOTE: A process may return
-from a epoll_wait/poll when provider progress is required and a CQ event may
-not be available.
+Using FI_WAIT_UNSPEC will default to FI_WAIT_FD. When a wait object is not
+required FI_WAIT_NONE should be specified and will achieve the lowest latency
+and reduce interrupt overhead.
+
+It is intended the application marshal multi-thread access to waiting and CQ
+progress. There is a natural race window that can occur between the application
+fi_trywait() call and subsequent epoll_wait() call and another thread progressing
+events and creating a CQ entry. The provider implementation has chosen normal
+case performance over completely closing the race with internal progress, which
+could be done with updating another FD on every CQ write. Therefore, it is
+suggested the epoll_wait() timeout be reasonably small.
+
+NOTE: A process may return from a epoll_wait() when provider progress is
+required and a CQ event may not be available.
 
 ## Additional Features
 

--- a/prov/cxi/src/cxip_coll.c
+++ b/prov/cxi/src/cxip_coll.c
@@ -1335,7 +1335,7 @@ static int _coll_add_buffers(struct cxip_coll_pte *coll_pte, size_t size,
 	/* Block until PTE completes buffer appends */
 	do {
 		sched_yield();
-		cxip_evtq_progress(coll_pte->ep_obj->coll.rx_evtq);
+		cxip_evtq_progress(coll_pte->ep_obj->coll.rx_evtq, true);
 	} while (ofi_atomic_get32(&coll_pte->buf_cnt) < count);
 	coll_pte->buf_low_water = (int)count;
 

--- a/prov/cxi/src/cxip_ep.c
+++ b/prov/cxi/src/cxip_ep.c
@@ -170,7 +170,9 @@ struct fi_ops_cm cxip_ep_cm_ops = {
 };
 
 /*
- * cxip_ep_progress() - Progress an endpoint.
+ * cxip_ep_progress() - Progress an endpoint. Libfabric API calls
+ * that initiate/require progress call this routine to initiate
+ * progress of an endpoint.
  */
 void cxip_ep_progress(struct fid *fid)
 {
@@ -180,9 +182,9 @@ void cxip_ep_progress(struct fid *fid)
 	if (ep_obj->enabled) {
 
 		ofi_genlock_lock(&ep_obj->lock);
-		ep_obj->rxc->ops.progress(ep_obj->rxc);
-		ep_obj->txc->ops.progress(ep_obj->txc);
-		cxip_ep_ctrl_progress_locked(ep_obj);
+		ep_obj->rxc->ops.progress(ep_obj->rxc, false);
+		ep_obj->txc->ops.progress(ep_obj->txc, false);
+		cxip_ep_ctrl_progress_locked(ep_obj, false);
 		ofi_genlock_unlock(&ep_obj->lock);
 	}
 }

--- a/prov/cxi/src/cxip_mr.c
+++ b/prov/cxi/src/cxip_mr.c
@@ -130,7 +130,7 @@ static int cxip_mr_wait_append(struct cxip_ep_obj *ep_obj,
 	/* Wait for PTE LE append status update */
 	do {
 		sched_yield();
-		cxip_ep_tgt_ctrl_progress_locked(ep_obj);
+		cxip_ep_tgt_ctrl_progress_locked(ep_obj, true);
 	} while (mr->mr_state != CXIP_MR_LINKED &&
 		 mr->mr_state != CXIP_MR_LINK_ERR);
 
@@ -217,7 +217,7 @@ static bool cxip_mr_disable_check_count_events(struct cxip_mr *mr,
 			return false;
 
 		sched_yield();
-		cxip_ep_tgt_ctrl_progress_locked(ep_obj);
+		cxip_ep_tgt_ctrl_progress_locked(ep_obj, true);
 	}
 }
 
@@ -240,7 +240,7 @@ static int cxip_mr_disable_std(struct cxip_mr *mr)
 
 	do {
 		sched_yield();
-		cxip_ep_tgt_ctrl_progress_locked(ep_obj);
+		cxip_ep_tgt_ctrl_progress_locked(ep_obj, true);
 	} while (mr->mr_state != CXIP_MR_UNLINKED);
 
 	if (mr->count_events) {
@@ -411,7 +411,7 @@ static int cxip_mr_disable_opt(struct cxip_mr *mr)
 
 	do {
 		sched_yield();
-		cxip_ep_tgt_ctrl_progress_locked(ep_obj);
+		cxip_ep_tgt_ctrl_progress_locked(ep_obj, true);
 	} while (mr->mr_state != CXIP_MR_UNLINKED);
 
 cleanup:
@@ -1039,7 +1039,7 @@ void cxip_ctrl_mr_cache_flush(struct cxip_ep_obj *ep_obj)
 
 		do {
 			sched_yield();
-			cxip_ep_tgt_ctrl_progress_locked(ep_obj);
+			cxip_ep_tgt_ctrl_progress_locked(ep_obj, true);
 		} while (mr_cache->ctrl_req->mr.mr->mr_state !=
 			 CXIP_MR_UNLINKED);
 
@@ -1075,7 +1075,7 @@ void cxip_ctrl_mr_cache_flush(struct cxip_ep_obj *ep_obj)
 
 		do {
 			sched_yield();
-			cxip_ep_tgt_ctrl_progress_locked(ep_obj);
+			cxip_ep_tgt_ctrl_progress_locked(ep_obj, true);
 		} while (mr_cache->ctrl_req->mr.mr->mr_state !=
 			 CXIP_MR_UNLINKED);
 

--- a/prov/cxi/src/cxip_pte.c
+++ b/prov/cxi/src/cxip_pte.c
@@ -46,7 +46,7 @@ int cxip_pte_set_state_wait(struct cxip_pte *pte, struct cxip_cmdq *cmdq,
 	if (ret == FI_SUCCESS) {
 		do {
 			sched_yield();
-			cxip_evtq_progress(evtq);
+			cxip_evtq_progress(evtq, true);
 		} while (pte->state != new_state);
 	}
 

--- a/prov/cxi/src/cxip_ptelist_buf.c
+++ b/prov/cxi/src/cxip_ptelist_buf.c
@@ -355,7 +355,7 @@ void cxip_ptelist_bufpool_fini(struct cxip_ptelist_bufpool *pool)
 	}
 
 	do {
-		cxip_evtq_progress(&rxc->base.rx_evtq);
+		cxip_evtq_progress(&rxc->base.rx_evtq, true);
 	} while (ofi_atomic_get32(&pool->bufs_linked));
 
 	cxip_ptelist_buf_dlist_free(&pool->active_bufs);

--- a/prov/cxi/src/cxip_rdzv_pte.c
+++ b/prov/cxi/src/cxip_rdzv_pte.c
@@ -37,7 +37,7 @@ static int cxip_rdzv_pte_wait_append(struct cxip_rdzv_pte *pte,
 
 	/* Poll until the LE is linked or a failure occurs. */
 	do {
-		cxip_evtq_progress(&pte->txc->base.tx_evtq);
+		cxip_evtq_progress(&pte->txc->base.tx_evtq, true);
 		sched_yield();
 	} while (!cxip_rdzv_pte_append_done(pte, expected_count));
 
@@ -196,7 +196,7 @@ static void cxip_rdzv_pte_free(struct cxip_rdzv_pte *pte)
 	/* Flush the CQ to ensure any events referencing the rendezvous requests
 	 * are processed.
 	 */
-	cxip_evtq_progress(&pte->txc->base.tx_evtq);
+	cxip_evtq_progress(&pte->txc->base.tx_evtq, true);
 }
 
 void cxip_rdzv_match_pte_free(struct cxip_rdzv_match_pte *pte)

--- a/prov/cxi/src/cxip_rxc.c
+++ b/prov/cxi/src/cxip_rxc.c
@@ -245,7 +245,7 @@ void cxip_rxc_recv_req_cleanup(struct cxip_rxc *rxc)
 	start = ofi_gettime_ms();
 	while (cxip_rxc_orx_reqs_get(rxc)) {
 		sched_yield();
-		cxip_evtq_progress(&rxc->rx_evtq);
+		cxip_evtq_progress(&rxc->rx_evtq, false);
 
 		if (ofi_gettime_ms() - start > CXIP_REQ_CLEANUP_TO) {
 			CXIP_WARN("Timeout waiting for outstanding requests.\n");

--- a/prov/cxi/src/cxip_txc.c
+++ b/prov/cxi/src/cxip_txc.c
@@ -390,8 +390,8 @@ static void txc_cleanup(struct cxip_txc *txc)
 	while (cxip_txc_otx_reqs_get(txc)) {
 		sched_yield();
 
-		cxip_evtq_progress(&txc->tx_evtq);
-		cxip_ep_ctrl_progress_locked(txc->ep_obj);
+		cxip_evtq_progress(&txc->tx_evtq, false);
+		cxip_ep_ctrl_progress_locked(txc->ep_obj, false);
 
 		if (ofi_gettime_ms() - start > CXIP_REQ_CLEANUP_TO) {
 			CXIP_WARN("Timeout waiting for outstanding requests.\n");

--- a/prov/cxi/src/cxip_zbcoll.c
+++ b/prov/cxi/src/cxip_zbcoll.c
@@ -792,7 +792,7 @@ static void zbsend(struct cxip_ep_obj *ep_obj, uint32_t dstnic, uint32_t dstpid,
 	do {
 		ret =  cxip_ctrl_msg_send(req, 0);
 		if (ret == -FI_EAGAIN)
-			cxip_ep_ctrl_progress_locked(ep_obj);
+			cxip_ep_ctrl_progress_locked(ep_obj, true);
 	} while (ret == -FI_EAGAIN);
 	if (ret) {
 		CXIP_WARN("failed CTRL message send\n");
@@ -1609,7 +1609,7 @@ void cxip_ep_zbcoll_progress(struct cxip_ep_obj *ep_obj)
 	zbcoll = &ep_obj->zbcoll;
 	while (true) {
 		/* progress the underlying ctrl transfers */
-		cxip_ep_ctrl_progress_locked(ep_obj);
+		cxip_ep_ctrl_progress_locked(ep_obj, true);
 
 		/* see if there is a zb ready to be advanced */
 		zb = NULL;

--- a/prov/cxi/test/cxip_test_common.c
+++ b/prov/cxi/test/cxip_test_common.c
@@ -812,6 +812,48 @@ void cxit_setup_enabled_ep_fd(void)
 	cr_assert(addrlen == sizeof(cxit_ep_addr));
 }
 
+void cxit_setup_enabled_rnr_ep_fd(void)
+{
+	int ret;
+	size_t addrlen = sizeof(cxit_ep_addr);
+
+	cxit_setup_getinfo();
+
+	cxit_tx_cq_attr.format = FI_CQ_FORMAT_TAGGED;
+	cxit_rx_cq_attr.format = FI_CQ_FORMAT_TAGGED;
+	cxit_tx_cq_attr.wait_obj = FI_WAIT_FD;
+	cxit_rx_cq_attr.wait_obj = FI_WAIT_FD;
+	cxit_av_attr.type = FI_AV_TABLE;
+
+	cxit_fi_hints->domain_attr->data_progress = FI_PROGRESS_MANUAL;
+	cxit_fi_hints->domain_attr->data_progress = FI_PROGRESS_MANUAL;
+	cxit_fi_hints->domain_attr->threading = FI_THREAD_SAFE;
+
+	/* Indicate we want to use the CS protocol */
+	cxit_fi_hints->ep_attr->protocol = FI_PROTO_CXI_RNR;
+
+	cxit_setup_ep();
+
+	/* Set up RMA objects */
+	cxit_create_ep();
+	cxit_create_eq();
+	cxit_bind_eq();
+	cxit_create_cqs();
+	cxit_bind_cqs();
+	cxit_create_cntrs();
+	cxit_bind_cntrs();
+	cxit_create_av();
+	cxit_bind_av();
+
+	ret = fi_enable(cxit_ep);
+	cr_assert(ret == FI_SUCCESS, "ret is: %d\n", ret);
+
+	/* Find assigned Endpoint address. Address is assigned during enable. */
+	ret = fi_getname(&cxit_ep->fid, &cxit_ep_addr, &addrlen);
+	cr_assert(ret == FI_SUCCESS, "ret is %d\n", ret);
+	cr_assert(addrlen == sizeof(cxit_ep_addr));
+}
+
 void cxit_setup_enabled_ep_eq_yield(void)
 {
 	int ret;

--- a/prov/cxi/test/cxip_test_common.h
+++ b/prov/cxi/test/cxip_test_common.h
@@ -86,6 +86,7 @@ void cxit_teardown_ep(void);
 #define cxit_teardown_av cxit_teardown_ep
 void cxit_setup_enabled_ep(void);
 void cxit_setup_enabled_ep_fd(void);
+void cxit_setup_enabled_rnr_ep_fd(void);
 void cxit_setup_enabled_ep_eq_yield(void);
 void cxit_setup_rma(void);
 void cxit_setup_rma_fd(void);


### PR DESCRIPTION
When RNR messaging is used, a process should not block on a FD if a send is in retry time wait,
as manual progress is used. In addition, internal provider initiated progress should not disable
interrupts, e.g. RNR retry (to close race in multi-threaded environments).