### PR TITLE
prov/cxi: Add env vars to disable non-inject IDC for RMA/AMO

### DIFF
--- a/man/fi_cxi.7.md
+++ b/man/fi_cxi.7.md
@@ -1036,6 +1036,19 @@ The CXI provider checks for the following environment variables:
     to avoid the host copy in cases a performant copy can not be used. The default
     is to use IDC for all messages less than IDC size.
 
+*FI_CXI_DISABLE_NON_INJECT_RMA_IDC*
+:   Experimental option to disable favoring IDC for transmit of small RMA
+    when FI_INJECT is not specified. This can be useful with GPU source buffers
+    to avoid the host copy in cases a performant copy can not be used. The default
+    is to use IDC for non-triggered RMA writes that are less than IDC size and
+    target an optimized MR.
+
+*FI_CXI_DISABLE_NON_INJECT_AMO_IDC*
+:   Experimental option to disable favoring IDC for transmit of atomics
+    when FI_INJECT is not specified. This can be useful with GPU source buffers
+    to avoid the host copy in cases a performant copy can not be used. The default
+    is to use IDC for non-triggered AMOs that target an optimized MR.
+
 *FI_CXI_DISABLE_HOST_REGISTER*
 :   Disable registration of host buffers (overflow and request) with GPU. There
     are scenarios where using a large number of processes per GPU results in page

--- a/prov/cxi/include/cxip.h
+++ b/prov/cxi/include/cxip.h
@@ -283,6 +283,8 @@ struct cxip_environment {
 	int rdzv_aligned_sw_rget;
 	int rnr_max_timeout_us;
 	int disable_non_inject_msg_idc;
+	int disable_non_inject_rma_idc;
+	int disable_non_inject_amo_idc;
 	int disable_host_register;
 	size_t oflow_buf_size;
 	size_t oflow_buf_min_posted;

--- a/prov/cxi/src/cxip_atomic.c
+++ b/prov/cxi/src/cxip_atomic.c
@@ -1182,10 +1182,15 @@ err:
 	return ret;
 }
 
-static bool cxip_amo_is_idc(struct cxip_txc *txc, uint64_t key, bool triggered)
+static bool cxip_amo_is_idc(struct cxip_txc *txc, uint64_t key, bool triggered,
+			    uint64_t flags)
 {
 	/* Triggered AMOs can never be IDCs. */
 	if (triggered)
+		return false;
+
+	/* Don't issue non-inject operation as IDC if disabled by env */
+	if (!(flags & FI_INJECT) && cxip_env.disable_non_inject_amo_idc)
 		return false;
 
 	/* Only optimized MR can be used for IDCs. */
@@ -1290,7 +1295,7 @@ int cxip_amo_common(enum cxip_amo_req_type req_type, struct cxip_txc *txc,
 		return -FI_EKEYREJECTED;
 	}
 
-	idc = cxip_amo_is_idc(txc, key, triggered);
+	idc = cxip_amo_is_idc(txc, key, triggered, flags);
 
 	/* Convert FI to CXI codes, fail if operation not supported */
 	ret = _cxip_atomic_opcode(req_type, msg->datatype, msg->op,

--- a/prov/cxi/src/cxip_info.c
+++ b/prov/cxi/src/cxip_info.c
@@ -618,6 +618,8 @@ struct cxip_environment cxip_env = {
 	.rdzv_aligned_sw_rget = 1,
 	.rnr_max_timeout_us = CXIP_RNR_TIMEOUT_US,
 	.disable_non_inject_msg_idc = 0,
+	.disable_non_inject_rma_idc = 0,
+	.disable_non_inject_amo_idc = 0,
 	.disable_host_register = 0,
 	.oflow_buf_size = CXIP_OFLOW_BUF_SIZE,
 	.oflow_buf_min_posted = CXIP_OFLOW_BUF_MIN_POSTED,
@@ -739,6 +741,18 @@ static void cxip_env_init(void)
 			cxip_env.disable_non_inject_msg_idc);
 	fi_param_get_bool(&cxip_prov, "disable_non_inject_msg_idc",
 			  &cxip_env.disable_non_inject_msg_idc);
+
+	fi_param_define(&cxip_prov, "disable_non_inject_rma_idc", FI_PARAM_BOOL,
+			"Disables IDC for non-inject RMA (default: %d).",
+			cxip_env.disable_non_inject_rma_idc);
+	fi_param_get_bool(&cxip_prov, "disable_non_inject_rma_idc",
+			  &cxip_env.disable_non_inject_rma_idc);
+
+	fi_param_define(&cxip_prov, "disable_non_inject_amo_idc", FI_PARAM_BOOL,
+			"Disables IDC for non-inject atomics (default: %d).",
+			cxip_env.disable_non_inject_amo_idc);
+	fi_param_get_bool(&cxip_prov, "disable_non_inject_amo_idc",
+			  &cxip_env.disable_non_inject_amo_idc);
 
 	fi_param_define(&cxip_prov, "disable_host_register", FI_PARAM_BOOL,
 			"Disables host buffer GPU registration (default: %d).",


### PR DESCRIPTION
Add new vars to disable IDC for non-inject RMA and AMO messages similar to the existing option to disable for MSG.