### PR TITLE
prov/cxi: Fix dlopen using default value for json-c library

### DIFF
--- a/prov/cxi/src/cxip_curl.c
+++ b/prov/cxi/src/cxip_curl.c
@@ -747,9 +747,9 @@ static int cxip_json_dl_init(void)
         json_libpath = strdup(lib_name);
         TRACE_CURL("libjson-c path set to %s\n", json_libpath);
 #endif
-	cxip_jsonhandle = dlopen(lib_name, RTLD_NOW);
+	cxip_jsonhandle = dlopen(json_libpath, RTLD_NOW);
 	if (!cxip_jsonhandle) {
-		TRACE_CURL("Unable to dlopen libjson - lib_name = %s\n", lib_name);
+		TRACE_CURL("Unable to dlopen libjson - file path = %s\n", json_libpath);
 		free(json_libpath);
 		return -FI_ENOSYS;
 	}


### PR DESCRIPTION
The current version of Libfabric does not consider a custom installation of the json-c dependency.

When providing the option `--with-json-c=DIR`, the selected json-c library is the system default and not the one located at DIR.

This is because `prov/cxi/src/cxip_curl.c` is using `lib_name` (with default value "libjson-c.so") instead of `json_libpath`.

