### PR TITLE
prov/util: Change the order of setting default system memory monitor

### DIFF
--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -298,12 +298,12 @@ void ofi_monitors_init(void)
 	if (!default_monitor) {
 #if defined(HAVE_MR_CACHE_MONITOR_DEFAULT)
 		set_default_monitor(HAVE_MR_CACHE_MONITOR_DEFAULT);
-#elif HAVE_MEMHOOKS_MONITOR
-		default_monitor = memhooks_monitor;
 #elif HAVE_UFFD_MONITOR
 		default_monitor = uffd_monitor;
 #elif HAVE_KDREG2_MONITOR
 		default_monitor = kdreg2_monitor;
+#elif HAVE_MEMHOOKS_MONITOR
+		default_monitor = memhooks_monitor;
 #else
 		default_monitor = NULL;
 #endif


### PR DESCRIPTION
Default system memory monitor is set to the first available one based on a predetermined order. Previously the order was: memhooks, uffd, kdreg2. The new order is: uffd, kdreg2, memhooks.

The reason behind the change is that the code patching mechanism in the memhooks monitor has inherent thread safety issues and other security concerns. In addition, userfault fd support has become more common with wider adption of newer kernels. Leaving memhooks monitor as the last choice reduces the chance of multithreaded applications hitting the thread safety issue with default configuration.

Fixes #10943 