### PR TITLE
prov/efa : Fix stale links in docs/overview.md

### DIFF
--- a/prov/efa/docs/overview.md
+++ b/prov/efa/docs/overview.md
@@ -10,7 +10,7 @@ throughput compared to TCP transports which provides better application
 performance for HPC and Machine Learning applications on Amazon EC2.
 
 Please see the [fi_efa(7) man
-page](https://ofiwg.github.io/libfabric/master/man/fi_efa.7.html) for more
+page](https://ofiwg.github.io/libfabric/main/man/fi_efa.7.html) for more
 information on the features and capabilities of the EFA Libfabric provider.
 
 ### Background information
@@ -25,7 +25,7 @@ For more information on EFA, SRD and the [AWS Nitro
 System](https://aws.amazon.com/ec2/nitro/), please refer to these resources:
 
 * [A Cloud-Optimized Transport Protocol for Elastic and Scalable
-  HPC](https://ieeexplore.ieee.org/document/91673990) whitepaper
+  HPC](https://ieeexplore.ieee.org/document/9167399) whitepaper
 * [AWS re:Invent 2019 - Monday Night Live with Peter
   DeSantis](https://www.youtube.com/watch?v=GPUWATKe15E&feature=youtu.be&t=228)
  keynote


### PR DESCRIPTION
Fixing non-working hyperlinks in prov/efa/docs/overview.md.