### PR TITLE
Revert "prov/cxi: Fix RMA/AMO network ordering"

### DIFF
--- a/prov/cxi/include/cxip.h
+++ b/prov/cxi/include/cxip.h
@@ -146,8 +146,9 @@
 #define CXIP_MSG_ORDER			(FI_ORDER_SAS | \
 					 FI_ORDER_WAW | \
 					 FI_ORDER_RMA_WAW | \
-					 FI_ORDER_RMA_RAR | \
 					 FI_ORDER_ATOMIC_WAW | \
+					 FI_ORDER_ATOMIC_WAR | \
+					 FI_ORDER_ATOMIC_RAW | \
 					 FI_ORDER_ATOMIC_RAR)
 
 #define CXIP_EP_CQ_FLAGS \


### PR DESCRIPTION
This reverts commit e5b8ad7f7b88229ae7644753c6e04a2ebd0f7be6.

Ordering will be deprecated in release notes.