### PR TITLE
prov/cxi: Add support for FI_ORDER_RMA_RAR

### DIFF
--- a/prov/cxi/include/cxip.h
+++ b/prov/cxi/include/cxip.h
@@ -146,6 +146,7 @@
 #define CXIP_MSG_ORDER			(FI_ORDER_SAS | \
 					 FI_ORDER_WAW | \
 					 FI_ORDER_RMA_WAW | \
+					 FI_ORDER_RMA_RAR | \
 					 FI_ORDER_ATOMIC_WAW | \
 					 FI_ORDER_ATOMIC_WAR | \
 					 FI_ORDER_ATOMIC_RAW | \


### PR DESCRIPTION
CXI provider supports FI_ORDER_RMA_RAR message order.