### PR TITLE
prov/cxi: Improve counter performance

### DIFF
--- a/prov/cxi/include/cxip.h
+++ b/prov/cxi/include/cxip.h
@@ -1466,7 +1466,7 @@ struct cxip_cntr {
 	/* Contexts to which counter is bound */
 	struct dlist_entry ctx_list;
 
-	ofi_mutex_t lock;
+	struct ofi_genlock lock;
 
 	struct cxi_ct *ct;
 	struct c_ct_writeback *wb;

--- a/prov/cxi/src/cxip_atomic.c
+++ b/prov/cxi/src/cxip_atomic.c
@@ -404,13 +404,13 @@ static int _cxip_amo_cb(struct cxip_req *req, const union c_event *event)
 
 		event_rc = req->amo.fetching_amo_flush_event_rc;
 
-		if (req->amo.fetching_amo_flush_cntr) {
+		if (req->amo.cntr) {
 			if (event_rc == C_RC_OK)
-				ret = cxip_cntr_mod(req->amo.fetching_amo_flush_cntr,
-						    1, false, false);
+				ret = cxip_cntr_mod(req->amo.cntr, 1, false,
+						    false);
 			else
-				ret = cxip_cntr_mod(req->amo.fetching_amo_flush_cntr,
-						    1, false, true);
+				ret = cxip_cntr_mod(req->amo.cntr, 1, false,
+						    true);
 
 			if (ret != FI_SUCCESS) {
 				req->amo.fetching_amo_flush_event_count--;
@@ -420,6 +420,9 @@ static int _cxip_amo_cb(struct cxip_req *req, const union c_event *event)
 	} else {
 		event_rc = cxi_init_event_rc(event);
 	}
+
+	if (req->amo.cntr)
+		cxip_cntr_progress_dec(req->amo.cntr);
 
 	if (req->amo.result_md)
 		cxip_unmap(req->amo.result_md);
@@ -685,11 +688,21 @@ static int cxip_amo_emit_idc(struct cxip_txc *txc,
 			if (txc->write_cntr) {
 				cstate_cmd.event_ct_ack = 1;
 				cstate_cmd.ct = txc->write_cntr->ct->ctn;
+
+				if (req) {
+					req->amo.cntr = txc->write_cntr;
+					cxip_cntr_progress_inc(req->amo.cntr);
+				}
 			}
 		} else {
 			if (txc->read_cntr) {
 				cstate_cmd.event_ct_reply = 1;
 				cstate_cmd.ct = txc->read_cntr->ct->ctn;
+
+				if (req) {
+					req->amo.cntr = txc->read_cntr;
+					cxip_cntr_progress_inc(req->amo.cntr);
+				}
 			}
 		}
 	}
@@ -775,10 +788,13 @@ static int cxip_amo_emit_idc(struct cxip_txc *txc,
 	/* Optionally configure the flushing command used for fetching AMOs. */
 	if (fetching_amo_flush) {
 		assert(req != NULL);
-		if (req_type == CXIP_RQ_AMO)
-			req->amo.fetching_amo_flush_cntr = txc->write_cntr;
-		else
-			req->amo.fetching_amo_flush_cntr = txc->read_cntr;
+		if (req_type == CXIP_RQ_AMO) {
+			req->amo.cntr = txc->write_cntr;
+			cxip_cntr_progress_inc(req->amo.cntr);
+		} else {
+			req->amo.cntr = txc->read_cntr;
+			cxip_cntr_progress_inc(req->amo.cntr);
+		}
 	}
 
 	ret = cxip_txc_emit_idc_amo(txc, vni, cxip_ofi_to_cxi_tc(tclass),
@@ -1123,6 +1139,11 @@ static int cxip_amo_emit_dma(struct cxip_txc *txc,
 			if (cntr) {
 				dma_amo_cmd.event_ct_ack = 1;
 				dma_amo_cmd.ct = cntr->ct->ctn;
+
+				if (req) {
+					req->amo.cntr = txc->write_cntr;
+					cxip_cntr_progress_inc(req->amo.cntr);
+				}
 			}
 		} else {
 			cntr = triggered ? comp_cntr : txc->read_cntr;
@@ -1130,6 +1151,11 @@ static int cxip_amo_emit_dma(struct cxip_txc *txc,
 			if (cntr) {
 				dma_amo_cmd.event_ct_reply = 1;
 				dma_amo_cmd.ct = cntr->ct->ctn;
+
+				if (req) {
+					req->amo.cntr = txc->read_cntr;
+					cxip_cntr_progress_inc(req->amo.cntr);
+				}
 			}
 		}
 	}
@@ -1137,11 +1163,13 @@ static int cxip_amo_emit_dma(struct cxip_txc *txc,
 	/* Optionally configure the flushing command used for fetching AMOs. */
 	if (fetching_amo_flush) {
 		assert(req != NULL);
-
-		if (req_type == CXIP_RQ_AMO)
-			req->amo.fetching_amo_flush_cntr = txc->write_cntr;
-		else
-			req->amo.fetching_amo_flush_cntr = txc->read_cntr;
+		if (req_type == CXIP_RQ_AMO) {
+			req->amo.cntr = txc->write_cntr;
+			cxip_cntr_progress_inc(req->amo.cntr);
+		} else {
+			req->amo.cntr = txc->read_cntr;
+			cxip_cntr_progress_inc(req->amo.cntr);
+		}
 	}
 
 	ret = cxip_txc_emit_dma_amo(txc, vni, cxip_ofi_to_cxi_tc(tclass),

--- a/prov/cxi/src/cxip_ep.c
+++ b/prov/cxi/src/cxip_ep.c
@@ -267,23 +267,23 @@ void cxip_txc_close(struct cxip_ep *ep)
 	}
 
 	if (txc->send_cntr) {
-		fid_list_remove(&txc->send_cntr->ctx_list,
-				&txc->send_cntr->lock,
-				&ep->ep.fid);
+		fid_list_remove2(&txc->send_cntr->ctx_list,
+				 &txc->send_cntr->lock,
+				 &ep->ep.fid);
 		ofi_atomic_dec32(&txc->send_cntr->ref);
 	}
 
 	if (txc->read_cntr) {
-		fid_list_remove(&txc->read_cntr->ctx_list,
-				&txc->read_cntr->lock,
-				&ep->ep.fid);
+		fid_list_remove2(&txc->read_cntr->ctx_list,
+				 &txc->read_cntr->lock,
+				 &ep->ep.fid);
 		ofi_atomic_dec32(&txc->read_cntr->ref);
 	}
 
 	if (txc->write_cntr) {
-		fid_list_remove(&txc->write_cntr->ctx_list,
-				&txc->write_cntr->lock,
-				&ep->ep.fid);
+		fid_list_remove2(&txc->write_cntr->ctx_list,
+				 &txc->write_cntr->lock,
+				 &ep->ep.fid);
 		ofi_atomic_dec32(&txc->write_cntr->ref);
 	}
 
@@ -313,9 +313,9 @@ void cxip_rxc_close(struct cxip_ep *ep)
 	}
 
 	if (rxc->recv_cntr) {
-		fid_list_remove(&rxc->recv_cntr->ctx_list,
-				&rxc->recv_cntr->lock,
-				&ep->ep.fid);
+		fid_list_remove2(&rxc->recv_cntr->ctx_list,
+				 &rxc->recv_cntr->lock,
+				 &ep->ep.fid);
 		ofi_atomic_dec32(&rxc->recv_cntr->ref);
 	}
 
@@ -983,7 +983,7 @@ static int cxip_ep_bind_cntr(struct cxip_ep *ep, struct cxip_cntr *cntr,
 		return -FI_EINVAL;
 	}
 
-	ret = fid_list_insert(&cntr->ctx_list, &cntr->lock, &ep->ep.fid);
+	ret = fid_list_insert2(&cntr->ctx_list, &cntr->lock, &ep->ep.fid);
 	if (ret) {
 		CXIP_WARN("Add of EP to cntr EP list failed: %d:%s\n",
 			  ret, fi_strerror(-ret));

--- a/prov/cxi/src/cxip_msg_hpc.c
+++ b/prov/cxi/src/cxip_msg_hpc.c
@@ -3395,6 +3395,9 @@ cxip_recv_req_init(struct cxip_rxc *rxc, void *buf, size_t len, fi_addr_t addr,
 		req->flags |= FI_MSG;
 
 	req->recv.cntr = comp_cntr ? comp_cntr : rxc->recv_cntr;
+	if (req->recv.cntr)
+		cxip_cntr_progress_inc(req->recv.cntr);
+
 	req->recv.match_id = match_id;
 	req->recv.tag = tag;
 	req->recv.ignore = ignore;

--- a/prov/cxi/src/cxip_txc.c
+++ b/prov/cxi/src/cxip_txc.c
@@ -449,6 +449,10 @@ void cxip_txc_flush_msg_trig_reqs(struct cxip_txc *txc)
 			cxip_txc_otx_reqs_dec(txc);
 			dlist_remove(&req->send.txc_entry);
 			cxip_unmap(req->send.send_md);
+
+			if (req->send.cntr)
+				cxip_cntr_progress_dec(req->send.cntr);
+
 			cxip_evtq_req_free(req);
 		}
 	}


### PR DESCRIPTION
Improve fi_cntr_wait()/fi_cntr_read() performance by avoid potentially spinning, improve locking,
and only progress EP bound to a counter if an operation is outstanding for the counter.