### PR TITLE
contrib/aws: Fix bug in kill_all_clusters() logic

### DIFF
--- a/contrib/aws/Jenkinsfile
+++ b/contrib/aws/Jenkinsfile
@@ -45,7 +45,7 @@ def install_porta_fiducia() {
 
 def kill_all_clusters(instance_type, region) {
     def instance_type_without_period = sh(
-        script: "echo ${instance_type} | tr -d '.\\n'",
+        script: "echo ${instance_type.take(10)} | tr -d '.\\n'",
         returnStdout: true
     )
     sh ". venv/bin/activate; ./PortaFiducia/scripts/delete_manual_cluster.py --cluster-name \'*${instance_type_without_period}*\' --region ${region} || true"


### PR DESCRIPTION
The get_cluster_name() function only takes 10 characters of the instance type. The kill_all_clusters() method was not previously working because it was REGEX string search was failing due to providing the entire instance type, instead of 10 characters.