### PR TITLE
prov/cxi: Improve counter performance by spin waiting

### DIFF
--- a/man/fi_cxi.7.md
+++ b/man/fi_cxi.7.md
@@ -1210,6 +1210,9 @@ The CXI provider checks for the following environment variables:
 :   Number of micro-seconds to sleep before retrying a dropped side-band, flow
     control message. Setting to zero will disable any sleep.
 
+*FI_CXI_CNTR_SPIN_BEFORE_YIELD*
+:   Number of times to spin before yielding on counter operations.
+
 *FI_UNIVERSE_SIZE*
 :   Defines the maximum number of processes that will be used by distribute
     OFI application. Note that this value is used in setting the default

--- a/prov/cxi/include/cxip.h
+++ b/prov/cxi/include/cxip.h
@@ -211,6 +211,15 @@
 #define CXIP_REQ_BUF_HEADER_MIN_SIZE (sizeof(struct c_port_fab_hdr) + \
 	sizeof(struct c_port_small_msg_hdr))
 
+// Hints for spinloops
+#if defined(__aarch64__)
+#define CXIP_PAUSE() __asm__ __volatile__ ("YIELD" ::: "memory")
+#elif defined(__x86_64__)
+#define CXIP_PAUSE() __asm__ __volatile__ ("pause" ::: "memory")
+#else
+#define CXIP_PAUSE()
+#endif
+
 extern int sc_page_size;
 extern char cxip_prov_name[];
 extern struct fi_provider cxip_prov;
@@ -319,6 +328,7 @@ struct cxip_environment {
 
 	size_t eq_ack_batch_size;
 	int fc_retry_usec_delay;
+	int cntr_spin_before_yield;
 	size_t ctrl_rx_eq_max_size;
 	char *device_name;
 	size_t cq_fill_percent;

--- a/prov/cxi/src/cxip_info.c
+++ b/prov/cxi/src/cxip_info.c
@@ -644,6 +644,7 @@ struct cxip_environment cxip_env = {
 	.hybrid_posted_recv_preemptive = 0,
 	.hybrid_unexpected_msg_preemptive = 0,
 	.fc_retry_usec_delay = 1000,
+	.cntr_spin_before_yield = 1000,
 	.ctrl_rx_eq_max_size = 67108864,
 	.default_cq_size = CXIP_CQ_DEF_SZ,
 	.default_tx_size = CXIP_DEFAULT_TX_SIZE,
@@ -1076,6 +1077,12 @@ static void cxip_env_init(void)
 		CXIP_WARN("FC retry delay invalid. Setting to %d usecs\n",
 			  cxip_env.fc_retry_usec_delay);
 	}
+
+	fi_param_define(&cxip_prov, "cntr_spin_before_yield", FI_PARAM_INT,
+			"Number of times to spin in counter operations before yielding. Default: %d",
+			cxip_env.cntr_spin_before_yield);
+	fi_param_get_int(&cxip_prov, "cntr_spin_before_yield",
+			 &cxip_env.cntr_spin_before_yield);
 
 	fi_param_define(&cxip_prov, "sw_rx_tx_init_max", FI_PARAM_INT,
 			"Max TX S/W RX processing will initiate. Default: %d",


### PR DESCRIPTION
Improve fi_cntr_wait()/fi_cntr_read() performance by spin waiting and only periodically doing sched_yield().