### PR TITLE
contrib/intel/jenkins: Update opt-out files

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -132,7 +132,7 @@ def skip() {
   }
 
   echo "Changeset is: ${changeStrings.toArray()}"
-  if (changeStrings.toArray().every { it =~ /(?:fabtests\/pytests|man|prov\/efa|prov\/opx|prov\/cxi|prov\/lpp|contrib\/aws|.github).*$/ }) {
+  if (changeStrings.toArray().every { it =~ /(?:fabtests\/pytest|man|prov\/efa|prov\/opx|prov\/cxi|prov\/lpp|contrib\/aws|.github).*$/ }) {
     echo "DONT RUN!"
     return true
   }


### PR DESCRIPTION
Fix fabtests/pytests to be fabtests/pytest so that PRs with changes only in files fabtests/pytest/* get properly skipped.