### PR TITLE
core/common: Make common runtime parameters working for DL providers

### DIFF
--- a/include/ofi.h
+++ b/include/ofi.h
@@ -336,6 +336,7 @@ void fi_param_fini(void);
 void fi_param_undefine(const struct fi_provider *provider);
 void ofi_remove_comma(char *buffer);
 void ofi_dump_sysconfig(void);
+void ofi_params_init(void);
 
 const char *ofi_hex_str(const uint8_t *data, size_t len);
 
@@ -432,6 +433,7 @@ uint64_t ofi_tag_format(uint64_t max_tag);
 uint8_t ofi_msb(uint64_t num);
 uint8_t ofi_lsb(uint64_t num);
 
+extern int ofi_fork_unsafe;
 extern size_t ofi_universe_size;
 extern int ofi_av_remove_cleanup;
 extern char *ofi_offload_coll_prov_name;

--- a/prov/efa/src/efa_prov.c
+++ b/prov/efa/src/efa_prov.c
@@ -192,6 +192,7 @@ EFA_INI
 	ofi_mem_init();
 	ofi_hmem_init();
 	ofi_monitors_init();
+	ofi_params_init();
 #endif
 	int err;
 

--- a/prov/hook/hook_hmem/src/hook_hmem.c
+++ b/prov/hook/hook_hmem/src/hook_hmem.c
@@ -1916,6 +1916,7 @@ HOOK_HMEM_INI
 {
 #if HAVE_HOOK_HMEM_DL
 	ofi_hmem_init();
+	ofi_params_init();
 #endif
 	hook_hmem_fabric_ops = hook_fabric_ops;
 	hook_hmem_fabric_ops.domain = hook_hmem_domain;

--- a/prov/lpp/src/lpp_util.c
+++ b/prov/lpp/src/lpp_util.c
@@ -171,6 +171,7 @@ struct fi_provider *lpp_initialization(void)
 {
 	#if HAVE_LPP_DL
 	ofi_hmem_init();
+	ofi_params_init();
 	#endif
 	lpp_init_params();
 	lpp_init_memcpy();

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -744,6 +744,7 @@ RXM_INI
 #if HAVE_RXM_DL
 	ofi_mem_init();
 	ofi_hmem_init();
+	ofi_params_init();
 #endif
 
 	return &rxm_prov;

--- a/prov/shm/src/smr_init.c
+++ b/prov/shm/src/smr_init.c
@@ -204,6 +204,7 @@ SHM_INI
 {
 #if HAVE_SHM_DL
 	ofi_hmem_init();
+	ofi_params_init();
 #endif
 	fi_param_define(&smr_prov, "sar_threshold", FI_PARAM_SIZE_T,
 			"Max size to use for alternate SAR protocol if CMA \

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -342,6 +342,7 @@ SOCKETS_INI
 {
 #if HAVE_SOCKETS_DL
 	ofi_pmem_init();
+	ofi_params_init();
 #endif
 
 	fi_param_define(&sock_prov, "pe_waittime", FI_PARAM_INT,

--- a/prov/tcp/src/xnet_init.c
+++ b/prov/tcp/src/xnet_init.c
@@ -211,6 +211,7 @@ TCP_INI
 #if HAVE_TCP_DL
 	ofi_pmem_init();
 	ofi_mem_init();
+	ofi_params_init();
 #endif
 	xnet_init_env();
 	xnet_init_infos();

--- a/prov/ucx/src/ucx_init.c
+++ b/prov/ucx/src/ucx_init.c
@@ -399,7 +399,8 @@ struct fi_provider ucx_prov = {
 UCX_INI
 {
 #if HAVE_UCX_DL
-        ofi_hmem_init();
+	ofi_hmem_init();
+	ofi_params_init();
 #endif
 
 	ucx_init_errcodes();

--- a/prov/verbs/src/verbs_init.c
+++ b/prov/verbs/src/verbs_init.c
@@ -813,6 +813,7 @@ VERBS_INI
 	ofi_mem_init();
 	ofi_hmem_init();
 	ofi_monitors_init();
+	ofi_params_init();
 #endif
 	ofi_mutex_init(&vrb_info_mutex);
 	ofi_mutex_init(&vrb_init_mutex);

--- a/src/common.c
+++ b/src/common.c
@@ -85,10 +85,20 @@ struct ofi_common_locks common_locks = {
 	.util_fabric_lock = PTHREAD_MUTEX_INITIALIZER,
 };
 
+int ofi_fork_unsafe;
 size_t ofi_universe_size = 1024;
 int ofi_av_remove_cleanup;
 char *ofi_offload_coll_prov_name = NULL;
 
+
+void ofi_params_init(void)
+{
+	fi_param_get_bool(NULL, "fork_unsafe", &ofi_fork_unsafe);
+	fi_param_get_size_t(NULL, "universe_size", &ofi_universe_size);
+	fi_param_get_bool(NULL, "av_remove_cleanup", &ofi_av_remove_cleanup);
+	fi_param_get_str(NULL, "offload_coll_provider",
+			 &ofi_offload_coll_prov_name);
+}
 
 int ofi_genlock_init(struct ofi_genlock *lock,
 		     enum ofi_lock_type lock_type)

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -952,12 +952,12 @@ void fi_ini(void)
 			"(default: no). Setting this to yes could improve "
 			"performance at the expense of making fork() potentially "
 			"unsafe");
+
 	fi_param_define(NULL, "universe_size", FI_PARAM_SIZE_T,
 			"Defines the maximum number of processes that will be "
 			"used by distribute OFI application. The provider uses "
 			"this to optimize resource allocations "
 			"(default: provider specific)");
-	fi_param_get_size_t(NULL, "universe_size", &ofi_universe_size);
 
 	fi_param_define(NULL, "av_remove_cleanup", FI_PARAM_BOOL,
 			"When true, release any underlying resources, such as "
@@ -968,13 +968,12 @@ void fi_ini(void)
 			"from peers that are active at the time their "
 			"address is removed from the local AV.  "
 			"(default: false)");
-	fi_param_get_bool(NULL, "av_remove_cleanup", &ofi_av_remove_cleanup);
 
 	fi_param_define(NULL, "offload_coll_provider", FI_PARAM_STRING,
 			"The name of a colective offload provider (default: \
 			empty - no provider)");
-	fi_param_get_str(NULL, "offload_coll_provider",
-			    &ofi_offload_coll_prov_name);
+
+	ofi_params_init();
 
 	ofi_load_dl_prov();
 


### PR DESCRIPTION
Runtime parameters decalared in common.c weren't initialized for DL providers because the initialization was done in core-only code.

Move the initialization to a common function `ofi_params_init` which can be called from DL providers.

Fixes #11312 