### PR TITLE
prov/cxi: use native curl timeout

### DIFF
--- a/prov/cxi/include/cxip.h
+++ b/prov/cxi/include/cxip.h
@@ -202,9 +202,6 @@
 #define CXIP_COLL_MAX_LEAF_TIMEOUT_MULT	50
 #define CXIP_COLL_MIN_TIMEOUT_USEC	1
 #define CXIP_COLL_MAX_TIMEOUT_USEC	20000000
-#define CXIP_COLL_MIN_FM_TIMEOUT_MSEC	1
-#define CXIP_COLL_DFL_FM_TIMEOUT_MSEC	100
-#define CXIP_COLL_MAX_FM_TIMEOUT_MSEC	1000000
 
 #define CXIP_REQ_BUF_HEADER_MAX_SIZE (sizeof(struct c_port_fab_hdr) + \
 	sizeof(struct c_port_unrestricted_hdr))
@@ -339,7 +336,6 @@ struct cxip_environment {
 	char *coll_job_step_id;
 	size_t coll_retry_usec;
 	size_t coll_timeout_usec;
-	size_t coll_fm_timeout_msec;
 	char *coll_fabric_mgr_url;
 	char *coll_mcast_token;
 	size_t hwcoll_addrs_per_job;

--- a/prov/cxi/src/cxip_info.c
+++ b/prov/cxi/src/cxip_info.c
@@ -662,7 +662,6 @@ struct cxip_environment cxip_env = {
 	.coll_fabric_mgr_url = NULL,
 	.coll_retry_usec = CXIP_COLL_MAX_RETRY_USEC,
 	.coll_timeout_usec = CXIP_COLL_MAX_TIMEOUT_USEC,
-	.coll_fm_timeout_msec = CXIP_COLL_DFL_FM_TIMEOUT_MSEC,
 	.coll_use_dma_put = false,
 	.telemetry_rgid = -1,
 	.disable_hmem_dev_register = 0,
@@ -1208,17 +1207,6 @@ static void cxip_env_init(void)
 		cxip_env.coll_timeout_usec = CXIP_COLL_MIN_TIMEOUT_USEC;
 	if (cxip_env.coll_timeout_usec > CXIP_COLL_MAX_TIMEOUT_USEC)
 		cxip_env.coll_timeout_usec = CXIP_COLL_MAX_TIMEOUT_USEC;
-
-	fi_param_define(&cxip_prov, "coll_fm_timeout_msec", FI_PARAM_SIZE_T,
-		"FM API timeout (msec) (default %d, min %d, max %d).",
-		cxip_env.coll_fm_timeout_msec, CXIP_COLL_MIN_FM_TIMEOUT_MSEC,
-		CXIP_COLL_MAX_FM_TIMEOUT_MSEC);
-	fi_param_get_size_t(&cxip_prov, "coll_fm_timeout_msec",
-			    &cxip_env.coll_fm_timeout_msec);
-	if (cxip_env.coll_fm_timeout_msec < CXIP_COLL_MIN_FM_TIMEOUT_MSEC)
-		cxip_env.coll_fm_timeout_msec = CXIP_COLL_MIN_FM_TIMEOUT_MSEC;
-	if (cxip_env.coll_fm_timeout_msec > CXIP_COLL_MAX_FM_TIMEOUT_MSEC)
-		cxip_env.coll_fm_timeout_msec = CXIP_COLL_MAX_FM_TIMEOUT_MSEC;
 
 	fi_param_define(&cxip_prov, "default_tx_size", FI_PARAM_SIZE_T,
 			"Default provider tx_attr.size (default: %lu).",


### PR DESCRIPTION
We were using a 100ms timeout mechanism out of band from normal curl timeout behavior. This can cause us to give up prematurely in the case of slow DNS resolution. Instead, we'll now use the normal curl timeout and set it to 5 seconds instead of the default of 300s.