### PR TITLE
fabtests/pingpong: EFA competition traces and a race condition fix

### DIFF
--- a/fabtests/benchmarks/benchmark_shared.c
+++ b/fabtests/benchmarks/benchmark_shared.c
@@ -283,6 +283,13 @@ int run_pingpong(void)
 			return ret;
 	}
 
+	/* ft_finalize() needs RX buffer to be posted for proper sync */
+	if (ft_check_opts(FT_OPT_NO_PRE_POSTED_RX)) {
+		ret = ft_post_rx(ep, rx_size, &rx_ctx);
+		if (ret)
+			return ret;
+	}
+
 	return ft_finalize();
 }
 

--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -3236,17 +3236,25 @@ int ft_finalize_ep(struct fid_ep *ep)
 	int ret;
 	struct fi_context2 ctx;
 
-	ret = ft_sendmsg(ep, remote_fi_addr, tx_buf, 4, &ctx, FI_TRANSMIT_COMPLETE);
-	if (ret)
-		return ret;
+	if (opts.dst_addr) {
+		ret = ft_tx_msg(ep, remote_fi_addr, tx_buf, 4, &ctx,
+				FI_TRANSMIT_COMPLETE);
+		if (ret)
+			return ret;
 
-	ret = ft_get_tx_comp(tx_seq);
-	if (ret)
-		return ret;
+		ret = ft_get_rx_comp(rx_seq);
+		if (ret)
+			return ret;
+	} else {
+		ret = ft_get_rx_comp(rx_seq);
+		if (ret)
+			return ret;
 
-	ret = ft_get_rx_comp(rx_seq);
-	if (ret)
-		return ret;
+		ret = ft_tx_msg(ep, remote_fi_addr, tx_buf, 4, &ctx,
+				FI_TRANSMIT_COMPLETE);
+		if (ret)
+			return ret;
+	}
 
 	return 0;
 }

--- a/prov/efa/src/efa_cq.c
+++ b/prov/efa/src/efa_cq.c
@@ -146,6 +146,8 @@ static void efa_cq_handle_tx_completion(struct efa_base_ep *base_ep,
 	if (!ibv_cq_ex->wr_id)
 		return;
 
+	efa_tracepoint(handle_tx_completion, ibv_cq_ex->wr_id);
+
 	/* TX completions should not send peer address to util_cq */
 	if (base_ep->util_ep.caps & FI_SOURCE)
 		ret = ofi_cq_write_src(tx_cq, cq_entry->op_context,
@@ -185,6 +187,8 @@ static void efa_cq_handle_rx_completion(struct efa_base_ep *base_ep,
 	/* NULL wr_id means no FI_COMPLETION flag */
 	if (!ibv_cq_ex->wr_id)
 		return;
+
+	efa_tracepoint(handle_rx_completion, ibv_cq_ex->wr_id);
 
 	if (base_ep->util_ep.caps & FI_SOURCE) {
 		src_addr = efa_av_reverse_lookup(base_ep->av,

--- a/prov/efa/src/efa_tp_def.h
+++ b/prov/efa/src/efa_tp_def.h
@@ -16,6 +16,12 @@
 
 /* Pre-defined tracepoints */
 
+#define X_WR_ID_ARGS \
+	size_t, wr_id
+
+#define X_WR_ID_FIELDS \
+	lttng_ust_field_integer_hex(size_t, wr_id, wr_id)
+
 #define X_PKT_ARGS \
 	size_t, wr_id, \
 	size_t, context
@@ -80,6 +86,20 @@ LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(EFA_TP_PROV, post_wr_id, EFA_TP_PROV,
 	post_write,
 	LTTNG_UST_TP_ARGS(X_PKT_ARGS))
 LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_TP_PROV, post_write, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
+
+LTTNG_UST_TRACEPOINT_EVENT_CLASS(EFA_TP_PROV, handle_completion,
+	LTTNG_UST_TP_ARGS(X_WR_ID_ARGS),
+	LTTNG_UST_TP_FIELDS(X_WR_ID_FIELDS))
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(EFA_TP_PROV, handle_completion, EFA_TP_PROV,
+	handle_rx_completion,
+	LTTNG_UST_TP_ARGS(X_WR_ID_ARGS))
+LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_TP_PROV, handle_rx_completion, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(EFA_TP_PROV, handle_completion, EFA_TP_PROV,
+	handle_tx_completion,
+	LTTNG_UST_TP_ARGS(X_WR_ID_ARGS))
+LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_TP_PROV, handle_tx_completion, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
 
 #endif /* _EFA_TP_DEF_H */
 


### PR DESCRIPTION
These changes should make AWS CI failures more informative and fix occasional client-side timeouts in 32 byte pingpong with efa-direct.

- **EFA RX/TX completions**
Currently we have traces for posting send and receive buffers with EFA provider. This change adds completion traces as well.

~~- **Unexpected completion check in `ft_finalize()`**~~
~~We have seen issues caused by duplicate EFA completions, adding check for unexpected ones to `ft_finalize()`.~~

~~- **Use `ft_sync()` instead of `ft_finalize_ep(ep)` if `ft_finalize()`**.~~
~~- **Call ft_sync() before ft_finalize()**~~
- **Follow `ft_sync_inband(false)` pattern in `ft_finalize()`**

There are two effects of this change:
1. If out-of-band sync was enabled it's going to be used for the final sync as well.
2. In case of inband sync server will wait for client to process all recv completions before it can exit.


