### PR TITLE
prov/efa: Don't release RXE during EP close for in-flight EOR

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -849,11 +849,11 @@ static inline void progress_queues_closing_ep(struct efa_rdm_ep *ep)
 					continue;
 				/* fall-thru */
 			default:
-				/* Release all other queued OPEs */
-				if (ope->type == EFA_RDM_TXE)
-					efa_rdm_txe_release(ope);
-				else
+				/* Release all other queued OPEs, except for in-flight EOR RXEs */
+				if (ope->type == EFA_RDM_RXE && !(ope->internal_flags & EFA_RDM_RXE_EOR_IN_FLIGHT))
 					efa_rdm_rxe_release(ope);
+				else
+					efa_rdm_txe_release(ope);
 				break;
 			}
 		}


### PR DESCRIPTION
This feels like a glaring correctness miss, though I haven't yet proven this resolves the `test_rnr_queue_resend` failures we're currently seeing in the CI. Want to let the CI run against this first.