### PR TITLE
[v2.2.x]fabtests/efa: fix missing rdma check in test_rma_bw_sread

### DIFF
--- a/fabtests/pytest/efa/test_rma_bw.py
+++ b/fabtests/pytest/efa/test_rma_bw.py
@@ -84,13 +84,15 @@ def test_rma_bw_use_fi_more(cmdline_args, operation_type, rma_bw_completion_sema
 @pytest.mark.functional
 @pytest.mark.parametrize("comp_method", ["sread", "fd"])
 def test_rma_bw_sread(cmdline_args, rma_operation_type, rma_bw_completion_semantic,
-                      direct_rma_size, rma_bw_memory_type, support_sread, comp_method):
+                      direct_rma_size, rma_bw_memory_type, support_sread, comp_method, rma_fabric):
     if not support_sread:
         pytest.skip("sread not supported by efa device.")
+    if rma_fabric == "efa":
+        pytest.skip("sread not implemented in efa fabric yet.")
     command = f"fi_rma_bw -e rdm -c {comp_method}"
     command = command + " -o " + rma_operation_type
     # rma_bw test with data verification takes longer to finish
     timeout = max(1080, cmdline_args.timeout)
     efa_run_client_server_test(cmdline_args, command, "short", rma_bw_completion_semantic,
                                rma_bw_memory_type, direct_rma_size,
-                               timeout=timeout, fabric="efa-direct")
+                               timeout=timeout, fabric=rma_fabric)

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -631,6 +631,8 @@ static int efa_domain_cq_open_ext(struct fid_domain *domain_fid,
 	struct efa_domain *efa_domain;
 	int err, retv;
 
+	/* GPU cannot do a blocking wait on CQ entries because 
+	 * system FDs are only accessible to CPU. */
 	if (attr->wait_obj != FI_WAIT_NONE)
 		return -FI_ENOSYS;
 
@@ -677,6 +679,8 @@ static int efa_domain_cq_open_ext(struct fid_domain *domain_fid,
 		EFA_WARN(FI_LOG_CQ, "Unable to create extended CQ with external memory: %s\n", fi_strerror(err));
 		goto err_free_util_cq;
 	}
+
+	ofi_atomic_initialize32(&cq->nevents, 0);
 
 	*cq_fid = &cq->util_cq.cq_fid;
 	(*cq_fid)->fid.fclass = FI_CLASS_CQ;


### PR DESCRIPTION
Backport https://github.com/ofiwg/libfabric/pull/11330 and https://github.com/ofiwg/libfabric/pull/11326