### PR TITLE
prov/efa: Bypass rdma-core in blocking cq read path

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -102,6 +102,7 @@ _efa_headers = \
 	prov/efa/src/fi_ext_efa.h \
 	prov/efa/src/efa_data_path_ops.h \
 	prov/efa/src/efa_io_defs.h \
+	prov/efa/src/efa_io_regs_defs.h \
 	prov/efa/src/efa_data_path_direct_structs.h \
 	prov/efa/src/efa_data_path_direct_entry.h \
 	prov/efa/src/efa_data_path_direct.h \
@@ -202,7 +203,9 @@ prov_efa_test_efa_unit_test_LDFLAGS = $(cmocka_rpath) $(efa_LDFLAGS) $(cmocka_LD
 					-Wl,--wrap=efa_ibv_cq_wc_read_wc_flags \
 					-Wl,--wrap=efa_ibv_cq_wc_read_imm_data \
 					-Wl,--wrap=efa_ibv_cq_wc_is_unsolicited \
-					-Wl,--wrap=efa_ibv_cq_wc_read_sgid
+					-Wl,--wrap=efa_ibv_cq_wc_read_sgid \
+					-Wl,--wrap=efa_ibv_get_cq_event \
+					-Wl,--wrap=efa_ibv_req_notify_cq
 
 if HAVE_EFADV_CQ_EX
 prov_efa_test_efa_unit_test_LDFLAGS += -Wl,--wrap=efadv_create_cq

--- a/prov/efa/configure.m4
+++ b/prov/efa/configure.m4
@@ -81,6 +81,7 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 	have_efadv_sl=0
 	have_efadv_query_qp_wqs=0
 	have_efadv_query_cq=0
+	have_efadv_cq_attr_db=0
 	have_ibv_create_comp_channel=0
 	have_ibv_get_cq_event=0
 
@@ -188,6 +189,11 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 			[have_efadv_query_cq=0],
 			[[#include <infiniband/efadv.h>]])
 
+		AC_CHECK_MEMBER([struct efadv_cq_attr.db],
+			[have_efadv_cq_attr_db=1],
+			[have_efadv_cq_attr_db=0],
+			[[#include <infiniband/efadv.h>]])
+
 		dnl Check for CQ notification functions
 		AC_CHECK_DECL([ibv_create_comp_channel],
 			[have_ibv_create_comp_channel=1],
@@ -239,6 +245,9 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 	AC_DEFINE_UNQUOTED([HAVE_EFADV_QUERY_CQ],
 		[$have_efadv_query_cq],
 		[Indicates if efadv_query_cq is available])
+	AC_DEFINE_UNQUOTED([HAVE_EFADV_CQ_ATTR_DB],
+		[$have_efadv_cq_attr_db],
+		[Indicates if efadv_cq_attr struct has db field])
 	AS_IF([test "$have_efadv_query_qp_wqs" = "1" -a "$have_efadv_query_cq" = "1"],
 		[have_efa_data_path_direct=1],
 		[have_efa_data_path_direct=0])

--- a/prov/efa/src/efa_data_path_direct.c
+++ b/prov/efa/src/efa_data_path_direct.c
@@ -194,6 +194,11 @@ int efa_data_path_direct_cq_initialize(struct efa_cq *efa_cq)
 	data_path_direct->buffer = attr.buffer;           /* Hardware CQ buffer */
 	data_path_direct->entry_size = attr.entry_size;   /* Size of each CQ entry */
 	data_path_direct->num_entries = attr.num_entries; /* Total number of entries */
+#if HAVE_EFADV_CQ_ATTR_DB
+	data_path_direct->db = attr.db;
+#else
+	data_path_direct->db = NULL;
+#endif
 
 	/* Initialize completion processing state */
 	data_path_direct->phase = 1;                      /* Start with phase 1 */

--- a/prov/efa/src/efa_data_path_direct_structs.h
+++ b/prov/efa/src/efa_data_path_direct_structs.h
@@ -32,6 +32,7 @@
 #if HAVE_EFA_DATA_PATH_DIRECT
 
 #include "efa_io_defs.h"
+#include "efa_io_regs_defs.h"
 
 /**
  * The contents of this file only make sense if we can query rdma-core for QP
@@ -104,6 +105,10 @@ struct efa_data_path_direct_cq {
 	int phase;                                /**< Current phase bit for queue wrapping */
 	int qmask;                                /**< Mask for queue index wrapping */
 	uint16_t consumed_cnt;                    /**< Number of completions consumed */
+
+	uint32_t *db; /**< Doorbell */
+	uint16_t cc; /**< Consumer Counter */
+	uint8_t cmd_sn;
 };
 
 /**

--- a/prov/efa/src/efa_io_regs_defs.h
+++ b/prov/efa/src/efa_io_regs_defs.h
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#ifndef _EFA_IO_REGS_H_
+#define _EFA_IO_REGS_H_
+
+/* cq_db register */
+#define EFA_IO_REGS_CQ_DB_CONSUMER_INDEX_MASK               0xffff
+#define EFA_IO_REGS_CQ_DB_CMD_SN_MASK                       0x60000000
+#define EFA_IO_REGS_CQ_DB_ARM_MASK                          0x80000000
+
+#endif /* _EFA_IO_REGS_H_ */

--- a/prov/efa/test/efa_unit_test_data_path_ops.c
+++ b/prov/efa/test/efa_unit_test_data_path_ops.c
@@ -127,3 +127,13 @@ int efa_ibv_cq_wc_read_sgid(struct efa_ibv_cq *ibv_cq, union ibv_gid *sgid)
 {
 	return ENOSYS;
 }
+
+int efa_ibv_get_cq_event(struct efa_ibv_cq *ibv_cq, void **cq_context)
+{
+	return 0;
+}
+
+int efa_ibv_req_notify_cq(struct efa_ibv_cq *ibv_cq, int solicited_only)
+{
+	return 0;
+}

--- a/prov/efa/test/efa_unit_test_mocks.c
+++ b/prov/efa/test/efa_unit_test_mocks.c
@@ -295,6 +295,8 @@ struct efa_unit_test_mocks g_efa_unit_test_mocks = {
 	.efa_ibv_cq_wc_read_imm_data = __real_efa_ibv_cq_wc_read_imm_data,
 	.efa_ibv_cq_wc_is_unsolicited = __real_efa_ibv_cq_wc_is_unsolicited,
 	.efa_ibv_cq_wc_read_sgid = __real_efa_ibv_cq_wc_read_sgid,
+	.efa_ibv_get_cq_event = __real_efa_ibv_get_cq_event,
+	.efa_ibv_req_notify_cq = __real_efa_ibv_req_notify_cq,
 
 #if HAVE_EFADV_QUERY_MR
 	.efadv_query_mr = __real_efadv_query_mr,
@@ -429,6 +431,16 @@ bool __wrap_efa_ibv_cq_wc_is_unsolicited(struct efa_ibv_cq *ibv_cq)
 int __wrap_efa_ibv_cq_wc_read_sgid(struct efa_ibv_cq *ibv_cq, union ibv_gid *sgid)
 {
 	return g_efa_unit_test_mocks.efa_ibv_cq_wc_read_sgid(ibv_cq, sgid);
+}
+
+int __wrap_efa_ibv_get_cq_event(struct efa_ibv_cq *ibv_cq, void **cq_context)
+{
+	return g_efa_unit_test_mocks.efa_ibv_get_cq_event(ibv_cq, cq_context);
+}
+
+int __wrap_efa_ibv_req_notify_cq(struct efa_ibv_cq *ibv_cq, int solicited_only)
+{
+	return g_efa_unit_test_mocks.efa_ibv_req_notify_cq(ibv_cq, solicited_only);
 }
 
 struct ibv_ah *__wrap_ibv_create_ah(struct ibv_pd *pd, struct ibv_ah_attr *attr)
@@ -679,3 +691,13 @@ int efa_mock_efadv_query_cq(struct ibv_cq *ibvcq, struct efadv_cq_attr *attr, ui
 	return 0;
 }
 #endif /* HAVE_EFADV_QUERY_CQ */
+ 
+int efa_mock_ibv_req_notify_cq_return_mock(struct efa_ibv_cq *ibv_cq, int solicited_only)
+{
+	return 0;
+}
+
+int efa_mock_ibv_get_cq_event_return_mock(struct efa_ibv_cq *ibv_cq, void **cq_context)
+{
+	return mock();
+}

--- a/prov/efa/test/efa_unit_test_mocks.h
+++ b/prov/efa/test/efa_unit_test_mocks.h
@@ -90,6 +90,8 @@ unsigned int __real_efa_ibv_cq_wc_read_wc_flags(struct efa_ibv_cq *ibv_cq);
 __be32 __real_efa_ibv_cq_wc_read_imm_data(struct efa_ibv_cq *ibv_cq);
 bool __real_efa_ibv_cq_wc_is_unsolicited(struct efa_ibv_cq *ibv_cq);
 int __real_efa_ibv_cq_wc_read_sgid(struct efa_ibv_cq *ibv_cq, union ibv_gid *sgid);
+int __real_efa_ibv_get_cq_event(struct efa_ibv_cq *ibv_cq, void **cq_context);
+int __real_efa_ibv_req_notify_cq(struct efa_ibv_cq *ibv_cq, int solicited_only);
 
 bool efa_mock_efa_device_support_unsolicited_write_recv(void);
 
@@ -121,6 +123,9 @@ uint32_t efa_mock_efa_ibv_cq_wc_read_byte_len_return_mock(struct efa_ibv_cq *ibv
 unsigned int efa_mock_efa_ibv_cq_wc_read_wc_flags_return_mock(struct efa_ibv_cq *ibv_cq);
 __be32 efa_mock_efa_ibv_cq_wc_read_imm_data_return_mock(struct efa_ibv_cq *ibv_cq);
 bool efa_mock_efa_ibv_cq_wc_is_unsolicited_return_mock(struct efa_ibv_cq *ibv_cq);
+
+int efa_mock_ibv_req_notify_cq_return_mock(struct efa_ibv_cq *ibv_cq, int solicited_only);
+int efa_mock_ibv_get_cq_event_return_mock(struct efa_ibv_cq *ibv_cq, void **cq_context);
 
 void efa_mock_ibv_wr_rdma_read_save_wr(struct ibv_qp_ex *qp, uint32_t rkey,
 				       uint64_t remote_addr);
@@ -194,6 +199,8 @@ struct efa_unit_test_mocks
 	bool (*efa_ibv_cq_wc_is_unsolicited)(struct efa_ibv_cq *ibv_cq);
 
 	int (*efa_ibv_cq_wc_read_sgid)(struct efa_ibv_cq *ibv_cq, union ibv_gid *sgid);
+	int (*efa_ibv_get_cq_event)(struct efa_ibv_cq *ibv_cq, void **cq_context);
+	int (*efa_ibv_req_notify_cq)(struct efa_ibv_cq *ibv_cq, int solicited_only);
 
 #if HAVE_EFADV_QUERY_MR
 	int (*efadv_query_mr)(struct ibv_mr *ibv_mr, struct efadv_mr_attr *attr, uint32_t inlen);

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -100,6 +100,8 @@ static int efa_unit_test_mocks_teardown(void **state)
 		.efa_ibv_cq_wc_read_imm_data = __real_efa_ibv_cq_wc_read_imm_data,
 		.efa_ibv_cq_wc_is_unsolicited = __real_efa_ibv_cq_wc_is_unsolicited,
 		.efa_ibv_cq_wc_read_sgid = __real_efa_ibv_cq_wc_read_sgid,
+		.efa_ibv_get_cq_event = __real_efa_ibv_get_cq_event,
+		.efa_ibv_req_notify_cq = __real_efa_ibv_req_notify_cq,
 
 #if HAVE_EFADV_QUERY_MR
 		.efadv_query_mr = __real_efadv_query_mr,
@@ -212,6 +214,8 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_cq_data_path_direct_disabled_with_old_device, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_cq_data_path_direct_enabled_with_new_device, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_cq_data_path_direct_disabled, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_cq_data_path_direct_with_wait_obj, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		
 		/* end efa_unit_test_cq.c */
 
 		/* begin efa_unit_test_info.c */

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -344,6 +344,7 @@ void test_efa_cq_recv_rdma_with_imm_failure();
 void test_efa_cq_data_path_direct_disabled_by_env();
 void test_efa_cq_data_path_direct_disabled_with_old_device();
 void test_efa_cq_data_path_direct_enabled_with_new_device();
+void test_efa_cq_data_path_direct_with_wait_obj();
 void test_efa_rdm_cq_data_path_direct_disabled();
 void test_efa_cq_trywait_no_channel();
 void test_efa_cq_trywait_completions_available();


### PR DESCRIPTION
Bypass ibv_get_cq_event and ibv_req_notify_cq.
Turn off direct cq data path when wait is requested during fi_cq_open and doorbell is not exposed in efadv_cq_attr.