### PR TITLE
prov/efa: Increase default efa-direct ibvcq size

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -81,7 +81,8 @@
 #define EFA_DEF_POOL_ALIGNMENT (8)
 #define EFA_MEM_ALIGNMENT (64)
 
-#define EFA_DEF_CQ_SIZE 1024
+/* 4k tx_attr.size + 8k rx_attr.size */
+#define EFA_DEF_CQ_SIZE 12288
 
 
 #define EFA_DEFAULT_RUNT_SIZE (307200)


### PR DESCRIPTION
Increase default ibv_cq size on efa-direct from 1k to 16k.  Having too small of a cq can lead to cq overflow, which will cause completions to be dropped. Users can choose to specify cq size in cq_attr which will override this number.