### PR TITLE
configure: Improve restricted-dl help text

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -607,7 +607,7 @@ dnl restricted DL open
 restricted_dl=0
 AC_ARG_ENABLE([restricted_dl],
               [AC_HELP_STRING([--enable-restricted-dl],
-                              [only look for dl providers under default location if FI_PROVIDER_PATH is not set])],
+                              [only look for dl providers under default location if FI_PROVIDER_PATH is not set.  Enable this for large systems to reduce dlopen() traffic during job startup.])],
               [restricted_dl=1],
               [])
 AC_DEFINE_UNQUOTED([HAVE_RESTRICTED_DL], [$restricted_dl],


### PR DESCRIPTION
The original text as not as clear as it could be why this option is useful. This commit amends the text to make it clearer. 

I've tested this by running autogen.sh to generate the configuration files from a clean build, and run ./configure to ensure everything looks fine, including the help text. 