### PR TITLE
Introduce a lightweight Rust bindings for Libfabric, using bindgen.

### DIFF
--- a/.github/workflows/binding-checks.yaml
+++ b/.github/workflows/binding-checks.yaml
@@ -1,0 +1,25 @@
+name: Binding Checks
+on: [push, pull_request]
+permissions:
+  contents: read
+jobs:
+  rust:
+    name: Rust binding check (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: 
+          - ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./bindings/rust
+    steps:
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+    - name: Check Rust formatting
+      run: cargo fmt --check
+    - name: Build Rust binding
+      run: |
+        cargo build --features vendored
+    - name: Test Rust binding
+      run: |
+        cargo test --features vendored

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -10,6 +10,7 @@ jobs:
       matrix:
         path:
           - 'prov/sm2'
+          - 'bindings/rust'
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Run clang-format style check for C/C++/Protobuf programs.

--- a/bindings/rust/.gitignore
+++ b/bindings/rust/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "rust"
+version = "0.1.0"
+edition = "2024"
+
+[features]
+vendored = []
+asan = []
+
+[build-dependencies]
+bindgen = "0.72.0"
+cc = "1.2.26"
+walkdir = "2.3.2"
+pkg-config = "0.3.32"
+
+[dependencies]
+paste = "1.0.15"

--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -1,0 +1,87 @@
+### Motivation
+
+Increasing number of HPC networking code is being written in Rust. Naturally, to
+support Libfabric usage in Rust, there needs a proper Rust library that wraps
+Libfabric APIs written in C. This practice is commonly referred as a Rust
+binding / FFI (foreign function interface).
+
+This library builds a lightweight Rust binding via bindgen. Lightweight, meaning
+there's no additional abstraction on top of the automatically generated code via
+bindgen, aside from the `wrapper.[ch]` which is strictly used to support
+`static inline` functions to be properly bound, by introducing a new translation
+unit upon compilation.
+
+### Build
+
+```
+// Clean the existing build.
+cargo clean
+
+// Build, using the Libfabric binary that is compiled on-the-fly.
+cargo build --features vendored
+
+// Build, using the already installed Libfabric.
+// You may be required to set `PKG_CONFIG_PATH` env variable to point towards `libfabric.pkg` file.
+cargo build
+
+// Unit-tests.
+cargo test
+
+// Unit-tests with ASAN enabled.
+cargo test --features asan
+```
+
+### How to use the library
+
+Add the crate dependency under your Rust application's `Cargo.toml` file. Then;
+
+```rust
+use bindings as ffi;
+
+fn test_get_info() {
+    unsafe {
+        // Configure hints.
+        let hints = ffi::fi_allocinfo();
+        assert_eq!(hints.is_null(), false);
+
+        (*hints).caps = ffi::FI_MSG as u64;
+        (*hints).mode = ff::FI_CONTEXT;
+        (*(*hints).ep_attr).type_ = ffi::fi_ep_type_FI_EP_RDM;
+        (*(*hints).domain_attr).mr_mode = ffi::FI_MR_LOCAL as i32;
+        let prov_name = CString::new("efa").unwrap();
+        (*(*hints).fabric_attr).prov_name = prov_name.into_raw() as *mut i8;
+
+        // Get Fabric info based on the hints.
+        let mut info_ptr = ptr::null_mut();
+        let version = ffi::fi_version();
+        let ret = ffi::fi_getinfo(
+            version,
+            ptr::null_mut(),
+            ptr::null_mut(),
+            0,
+            hints,
+            &mut info_ptr,
+        );
+
+        assert_eq!(ret, 0);
+
+        // Free the info structure returned by fi_getinfo.
+        if !info_ptr.is_null() {
+            ffi::fi_freeinfo(info_ptr);
+        }
+
+        // Free the hints structure we allocated.
+        ffi::fi_freeinfo(hints);
+    }
+}
+```
+
+### Files
+
+- `build.rs`: The actual build script for the bindgen.
+- `src/lib.rs`: The generated binding is copy-pasted programmatically and
+  publicly exported under `bindings` namespace.
+- `wrapper.[ch]`: Wrapper source files that simply calls the static inline
+  functions. This way, an isolated translation unit for each static inline
+  function is made, for which the Rust bindgen is able to link against it.
+- `tests/unit_test.rs`: Unit tests.

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -1,0 +1,226 @@
+use bindgen::callbacks::ItemInfo;
+use bindgen::callbacks::ItemKind;
+use bindgen::callbacks::ParseCallbacks;
+use std::env;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+
+#[derive(Debug)]
+struct RenameFunctions;
+
+// Rename function callback, such that those static inline functions are replaced without the "wrap_" prefix.
+// This way, the library is able to export such functions under `fi_xyz()`, rather than `wrap_fi_xyz()`.
+impl ParseCallbacks for RenameFunctions {
+    // This is to remove the prefix, from `wrap_fi_send()` --> `fi_send()` for Rust function.
+    fn item_name(&self, original_name: ItemInfo<'_>) -> Option<String> {
+        original_name.name.strip_prefix("wrap_").map(String::from)
+    }
+
+    // Explicitly use link_name for those marked with "wrap_" prefix, which indicates for static inline wrapper.
+    fn generated_link_name_override(&self, item_info: ItemInfo<'_>) -> Option<String> {
+        match item_info.kind {
+            ItemKind::Function => {
+                if item_info.name.starts_with("wrap_") {
+                    return Some(String::from(item_info.name));
+                }
+                None
+            }
+            _ => None,
+        }
+    }
+}
+
+fn build_libfabric(install_dir: &PathBuf) {
+    // Build the libfabric.so on the fly, such that its symbols can be accessed during the Rust binding compilation.
+    // This way, the libfabric.so library can later be dynamically linked during run-time.
+    // Else, you will receive the following error; = note: ld: cannot find -lfabric
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let libfabric_rsync_dir = out_dir.join("vendored");
+    let libfabric_par_dir = Path::new("../../../");
+    println!(
+        "cargo:warning=libfabric_rsync_dir {}",
+        libfabric_rsync_dir.display()
+    );
+    println!(
+        "cargo:warning=libfabric_par_dir {}",
+        libfabric_par_dir.display()
+    );
+    println!("cargo:warning=install_dir {}", install_dir.display());
+    println!("cargo:warning=out_dir {}", out_dir.display());
+
+    // Rsync the libfabric codebase into OUT_DIR, as the compilation process should never modify the source directory.
+    if !libfabric_rsync_dir.exists() {
+        println!("cargo:warning=Running rsync as part of libfabric compilation.");
+        Command::new("rsync")
+            .arg("-av")
+            .arg("--exclude=vendored")
+            .arg(format!(
+                "{}/",
+                libfabric_par_dir.join("libfabric").display()
+            ))
+            .arg(&libfabric_rsync_dir)
+            .status()
+            .expect("Failed to copy vendor directory");
+    }
+
+    // Run autogen.
+    println!("cargo:warning=Running autogen.sh as part of libfabric compilation.");
+    assert!(
+        Command::new("sh")
+            .current_dir(&libfabric_rsync_dir)
+            .arg("autogen.sh")
+            .status()
+            .unwrap()
+            .success()
+    );
+
+    // Run configure.
+    //
+    // Note that the binary is compiled on-the-fly to extract relevant header files under the compilation folder.
+    // The arguments provided for such compilation is not important, as the Libfabric API interface stays the same.
+    // During run-time, a separate user compiled library should be dynamically loaded via exporting the 'LD_LIBRARY_PATH' environment variable.
+    println!("cargo:warning=Running configure as part of libfabric compilation.");
+    assert!(
+        Command::new("sh")
+            .current_dir(&libfabric_rsync_dir)
+            .arg("configure")
+            .arg(format!("--prefix={}", install_dir.display()))
+            .status()
+            .unwrap()
+            .success()
+    );
+
+    // Run make install.
+    println!("cargo:warning=Running make install as part of libfabric compilation.");
+    assert!(
+        Command::new("make")
+            .current_dir(&libfabric_rsync_dir)
+            .arg("-j")
+            .arg("install")
+            .status()
+            .unwrap()
+            .success()
+    );
+
+    println!("cargo:warning=Libfabric successfully compiled.");
+}
+
+fn main() {
+    #[cfg(not(target_os = "linux"))]
+    compile_error!("This binding is only compatible with Linux.");
+
+    // Link asan library.
+    let asan = cfg!(feature = "asan");
+    if asan {
+        println!("cargo:rustc-link-lib=asan");
+    }
+
+    // Link libfabric library.
+    println!("cargo:rustc-link-lib=fabric");
+
+    // Conditional reference of header files from the source code, versus from the already installed library,
+    // based on the vendor feature flag (ex: cargo build --features vendored).
+    let vendored = cfg!(feature = "vendored");
+    println!(
+        "cargo:warning=Building the binding with vendored: {}",
+        vendored
+    );
+
+    let (lib_path, include_paths) = match vendored {
+        true => {
+            // Vendored option, build the libfabric based on the available source code.
+            let install_dir = PathBuf::from(env::var("OUT_DIR").unwrap()).join("install");
+            build_libfabric(&install_dir);
+
+            // Return relevant paths.
+            let libfabric_par_dir = Path::new("../../../");
+            (
+                // Provide static link search path.
+                // Vendored option, thus should refer to the compiled library's installation path.
+                install_dir.join("lib"),
+                vec![
+                    libfabric_par_dir.join("libfabric"),
+                    libfabric_par_dir.join("libfabric").join("include"),
+                    libfabric_par_dir
+                        .join("libfabric")
+                        .join("include")
+                        .join("rdma"),
+                    libfabric_par_dir
+                        .join("libfabric")
+                        .join("include")
+                        .join("rdma")
+                        .join("providers"),
+                ],
+            )
+        }
+        false => {
+            // Non-vendored option, and thus should refer to the already installed library's path.
+            let lib = pkg_config::Config::new().probe("libfabric").unwrap();
+            assert_eq!(1, lib.include_paths.len());
+            assert_eq!(1, lib.link_paths.len());
+
+            // Return relevant paths.
+            (
+                // Provide static link search path.
+                // Non-vendored option, and thus should refer to the already installed library's path.
+                lib.link_paths[0].clone(),
+                vec![
+                    lib.include_paths[0].clone(),
+                    lib.include_paths[0].join("rdma"),
+                    lib.include_paths[0].join("rdma").join("providers"),
+                ],
+            )
+        }
+    };
+
+    println!("cargo:rustc-link-search=native={}", lib_path.display());
+    println!("cargo:warning=Library link path: {}", lib_path.display());
+    include_paths
+        .iter()
+        .enumerate()
+        .for_each(|(i, x)| println!("cargo:warning=include_paths[{}]: {}", i, x.display()));
+
+    // Compiles the wrapper.[ch].
+    //
+    // This generates a libwrapper.a, which is statically linked against your Rust application code.
+    // Then, from the statically linked single executable, libfabric.so is dynamically called via libwrapper.
+    //
+    // The goal of the wrapper.[ch] is to create translation unit for "static inline" functions, such that they can be properly FFI'ed.
+    // TODO: https://github.com/rust-lang/rust-bindgen/discussions/2405
+    let mut builder = cc::Build::new();
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("failed to get current directory");
+    builder.file(format!("{manifest_dir}/wrapper.c"));
+    for path in &include_paths {
+        builder.include(format!("{}", path.display()));
+    }
+    if asan {
+        builder.flag("-fsanitize=address");
+        builder.flag("-fsanitize-recover=address");
+    }
+    builder.compile("wrapper");
+
+    // Finally, build the Rust binding.
+    let builder = bindgen::Builder::default().header("wrapper.h").clang_args(
+        include_paths
+            .iter()
+            .map(|dir| format!("-I{}", dir.display())),
+    );
+    let bindings = builder
+        .clang_arg("-fno-inline-functions")
+        .clang_arg("-Wno-error=implicit-function-declaration")
+        .clang_arg("-Wno-error=int-conversion")
+        .parse_callbacks(Box::new(RenameFunctions))
+        .generate_inline_functions(false)
+        .wrap_static_fns(false)
+        .derive_default(true)
+        .derive_debug(true)
+        .generate()
+        .expect("Unable to generate bindings");
+
+    // Write the bindings to the $OUT_DIR/bindings.rs file.
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("Couldn't write bindings!");
+}

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -1,0 +1,14 @@
+// Suppress expected warnings from bindgen-generated code.
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(missing_docs)]
+#![allow(deref_nullptr)]
+#![allow(improper_ctypes)]
+#![allow(unnecessary_transmutes)]
+#![allow(unsafe_op_in_unsafe_fn)]
+
+// Dump the bindgen generated code, and export as public module named "bindings".
+pub mod bindings {
+    include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+}

--- a/bindings/rust/tests/unit_test.rs
+++ b/bindings/rust/tests/unit_test.rs
@@ -1,0 +1,266 @@
+#[cfg(test)]
+mod unit_tests {
+    use paste;
+    use rust::bindings::*;
+    use std::ffi::CString;
+    use std::ptr;
+
+    /// Macro to generate dynamic linkage tests for Libfabric functions.
+    ///
+    /// This macro creates a test function which verifies that a provided function pointer
+    /// (ex: fi_send) is not null, nor errors out with "ld: symbol(s) not found" upon its reference.
+    macro_rules! test_function_linkage {
+        ($func_name:ident) => {
+            paste::paste! {
+                #[test]
+                fn [<test_ $func_name _linkage>]() {
+                    let func_ptr = $func_name as *const ();
+                    assert!(!func_ptr.is_null(),
+                           concat!(stringify!($func_name), " function pointer should not be null."));
+                }
+            }
+        };
+        // Support for multiple functions at once.
+        ($($func_name:ident),+ $(,)?) => {
+            $(test_function_linkage!($func_name);)+
+        };
+    }
+
+    /// Test core libfabric API function linkage, via the above macro.
+    test_function_linkage!(
+        get_fid_ptr,
+        fi_getinfo,
+        fi_freeinfo,
+        fi_dupinfo,
+        fi_param_get_str,
+        fi_param_get_int,
+        fi_param_get_bool,
+        fi_param_get_size_t,
+        fi_allocinfo,
+        fi_close,
+        fi_control,
+        fi_alias,
+        fi_get_val,
+        fi_set_val,
+        fi_open_ops,
+        fi_set_ops,
+        fi_passive_ep,
+        fi_endpoint,
+        fi_endpoint2,
+        fi_scalable_ep,
+        fi_ep_bind,
+        fi_pep_bind,
+        fi_scalable_ep_bind,
+        fi_enable,
+        fi_cancel,
+        fi_setopt,
+        fi_getopt,
+        fi_ep_alias,
+        fi_tx_context,
+        fi_rx_context,
+        fi_rx_size_left,
+        fi_tx_size_left,
+        fi_stx_context,
+        fi_srx_context,
+        fi_recv,
+        fi_recvv,
+        fi_recvmsg,
+        fi_send,
+        fi_sendv,
+        fi_sendmsg,
+        fi_inject,
+        fi_senddata,
+        fi_injectdata,
+        fi_atomic,
+        fi_atomicv,
+        fi_atomicmsg,
+        fi_inject_atomic,
+        fi_fetch_atomic,
+        fi_fetch_atomicv,
+        fi_fetch_atomicmsg,
+        fi_compare_atomic,
+        fi_compare_atomicv,
+        fi_compare_atomicmsg,
+        fi_atomicvalid,
+        fi_fetch_atomicvalid,
+        fi_compare_atomicvalid,
+        fi_query_atomic,
+        fi_domain,
+        fi_domain2,
+        fi_domain_bind,
+        fi_cq_open,
+        fi_cntr_open,
+        fi_wait_open,
+        fi_poll_open,
+        fi_mr_reg,
+        fi_mr_regv,
+        fi_mr_regattr,
+        fi_mr_desc,
+        fi_mr_key,
+        fi_mr_raw_attr,
+        fi_mr_map_raw,
+        fi_mr_unmap_key,
+        fi_mr_bind,
+        fi_mr_refresh,
+        fi_mr_enable,
+        fi_av_open,
+        fi_av_bind,
+        fi_av_insert,
+        fi_av_insertsvc,
+        fi_av_insertsym,
+        fi_av_remove,
+        fi_av_lookup,
+        fi_av_straddr,
+        fi_av_insert_auth_key,
+        fi_av_lookup_auth_key,
+        fi_av_set_user_id,
+        fi_rx_addr,
+        fi_group_addr,
+        fi_setname,
+        fi_getname,
+        fi_getpeer,
+        fi_listen,
+        fi_connect,
+        fi_accept,
+        fi_reject,
+        fi_shutdown,
+        fi_join,
+        fi_mc_addr,
+        fi_av_set,
+        fi_av_set_union,
+        fi_av_set_intersect,
+        fi_av_set_diff,
+        fi_av_set_insert,
+        fi_av_set_remove,
+        fi_av_set_addr,
+        fi_join_collective,
+        fi_barrier,
+        fi_barrier2,
+        fi_broadcast,
+        fi_alltoall,
+        fi_allreduce,
+        fi_allgather,
+        fi_reduce_scatter,
+        fi_reduce,
+        fi_scatter,
+        fi_gather,
+        fi_query_collective,
+        fi_trywait,
+        fi_wait,
+        fi_poll,
+        fi_poll_add,
+        fi_poll_del,
+        fi_eq_open,
+        fi_eq_read,
+        fi_eq_readerr,
+        fi_eq_write,
+        fi_eq_sread,
+        fi_eq_strerror,
+        fi_cq_read,
+        fi_cq_readfrom,
+        fi_cq_readerr,
+        fi_cq_sread,
+        fi_cq_sreadfrom,
+        fi_cq_signal,
+        fi_cq_strerror,
+        fi_cntr_read,
+        fi_cntr_readerr,
+        fi_cntr_add,
+        fi_cntr_adderr,
+        fi_cntr_set,
+        fi_cntr_seterr,
+        fi_cntr_wait,
+        fi_export_fid,
+        fi_import_fid,
+        fi_import,
+        fi_import_log,
+        fi_profile_reset,
+        fi_profile_query_vars,
+        fi_profile_query_events,
+        fi_profile_read_u64,
+        fi_profile_register_callback,
+        fi_profile_start_reads,
+        fi_profile_end_reads,
+        fi_profile_open,
+        fi_profile_close,
+        fi_read,
+        fi_readv,
+        fi_readmsg,
+        fi_write,
+        fi_writev,
+        fi_writemsg,
+        fi_inject_write,
+        fi_writedata,
+        fi_inject_writedata,
+        fi_trecv,
+        fi_trecvv,
+        fi_trecvmsg,
+        fi_tsend,
+        fi_tsendv,
+        fi_tsendmsg,
+        fi_tinject,
+        fi_tsenddata,
+        fi_tinjectdata,
+    );
+
+    /// Test successful instantiation of core Libfabric structures.
+    #[test]
+    fn test_struct_definitions() {
+        // FI info.
+        let _info: fi_info = unsafe { std::mem::zeroed() };
+
+        // Control resources.
+        let _fid_fabric: fid_fabric = unsafe { std::mem::zeroed() };
+        let _fid_domain: fid_domain = unsafe { std::mem::zeroed() };
+        let _fid_ep: fid_ep = unsafe { std::mem::zeroed() };
+        let _fid_cq: fid_cq = unsafe { std::mem::zeroed() };
+        let _fid_eq: fid_eq = unsafe { std::mem::zeroed() };
+        let _fid_mr: fid_mr = unsafe { std::mem::zeroed() };
+
+        // Control resource attributes.
+        let _fabric_attr: fi_fabric_attr = unsafe { std::mem::zeroed() };
+        let _domain_attr: fi_domain_attr = unsafe { std::mem::zeroed() };
+        let _ep_attr: fi_ep_attr = unsafe { std::mem::zeroed() };
+        let _cq_attr: fi_cq_attr = unsafe { std::mem::zeroed() };
+        let _eq_attr: fi_eq_attr = unsafe { std::mem::zeroed() };
+        let _fi_mr_attr: fi_mr_attr = unsafe { std::mem::zeroed() };
+    }
+
+    /// Example use case of the library.
+    #[test]
+    fn test_get_info() {
+        unsafe {
+            // Configure hints.
+            let hints = fi_allocinfo();
+            assert_eq!(hints.is_null(), false);
+
+            (*hints).caps = FI_MSG as u64;
+            (*hints).mode = FI_CONTEXT;
+            (*(*hints).ep_attr).type_ = fi_ep_type_FI_EP_RDM;
+            (*(*hints).domain_attr).mr_mode = FI_MR_LOCAL as i32;
+            let prov_name = CString::new("tcp").unwrap();
+            (*(*hints).fabric_attr).prov_name = prov_name.into_raw() as *mut i8;
+
+            // Get Fabric info based on the hints.
+            let mut info_ptr = ptr::null_mut();
+            let version = fi_version();
+            let ret = fi_getinfo(
+                version,
+                ptr::null_mut(),
+                ptr::null_mut(),
+                0,
+                hints,
+                &mut info_ptr,
+            );
+            assert_eq!(ret, 0);
+
+            // Free the info structure returned by fi_getinfo.
+            if !info_ptr.is_null() {
+                fi_freeinfo(info_ptr);
+            }
+
+            // Free the hints structure we allocated.
+            fi_freeinfo(hints);
+        }
+    }
+}

--- a/bindings/rust/wrapper.c
+++ b/bindings/rust/wrapper.c
@@ -1,0 +1,1098 @@
+#include "wrapper.h"
+
+/* Proprietary helper function declarations. */
+
+fid_t get_fid_ptr(void *ptr)
+{
+	return (fid_t) ptr;
+}
+
+/* Static inline function declarations from fi_prov.h */
+
+int wrap_fi_param_get_str(struct fi_provider *provider, const char *param_name,
+			  char **value)
+{
+	return fi_param_get_str(provider, param_name, value);
+}
+
+int wrap_fi_param_get_int(struct fi_provider *provider, const char *param_name,
+			  int *value)
+{
+	return fi_param_get_int(provider, param_name, value);
+}
+
+int wrap_fi_param_get_bool(struct fi_provider *provider, const char *param_name,
+			   int *value)
+{
+	return fi_param_get_bool(provider, param_name, value);
+}
+
+int wrap_fi_param_get_size_t(struct fi_provider *provider,
+			     const char *param_name, size_t *value)
+{
+	return fi_param_get_size_t(provider, param_name, value);
+}
+
+/* Static inline function declarations from fabric.h */
+
+struct fi_info *wrap_fi_allocinfo(void)
+{
+	return fi_allocinfo();
+}
+
+int wrap_fi_close(struct fid *fid)
+{
+	return fi_close(fid);
+}
+
+int wrap_fi_control(struct fid *fid, int command, void *arg)
+{
+	return fi_control(fid, command, arg);
+}
+
+int wrap_fi_alias(struct fid *fid, struct fid **alias_fid, uint64_t flags)
+{
+	return fi_alias(fid, alias_fid, flags);
+}
+
+int wrap_fi_get_val(struct fid *fid, int name, void *val)
+{
+	return fi_get_val(fid, name, val);
+}
+
+int wrap_fi_set_val(struct fid *fid, int name, void *val)
+{
+	return fi_set_val(fid, name, val);
+}
+
+int wrap_fi_open_ops(struct fid *fid, const char *name, uint64_t flags,
+		     void **ops, void *context)
+{
+	return fi_open_ops(fid, name, flags, ops, context);
+}
+
+int wrap_fi_set_ops(struct fid *fid, const char *name, uint64_t flags,
+		    void *ops, void *context)
+{
+	return fi_set_ops(fid, name, flags, ops, context);
+}
+
+/* Static inline function declarations from fi_endpoint.h */
+
+int wrap_fi_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
+		       struct fid_pep **pep, void *context)
+{
+	return fi_passive_ep(fabric, info, pep, context);
+}
+
+int wrap_fi_endpoint(struct fid_domain *domain, struct fi_info *info,
+		     struct fid_ep **ep, void *context)
+{
+	return fi_endpoint(domain, info, ep, context);
+}
+
+int wrap_fi_endpoint2(struct fid_domain *domain, struct fi_info *info,
+		      struct fid_ep **ep, uint64_t flags, void *context)
+{
+	return fi_endpoint2(domain, info, ep, flags, context);
+}
+
+int wrap_fi_scalable_ep(struct fid_domain *domain, struct fi_info *info,
+			struct fid_ep **sep, void *context)
+{
+	return fi_scalable_ep(domain, info, sep, context);
+}
+
+int wrap_fi_ep_bind(struct fid_ep *ep, struct fid *bfid, uint64_t flags)
+{
+	return fi_ep_bind(ep, bfid, flags);
+}
+
+int wrap_fi_pep_bind(struct fid_pep *pep, struct fid *bfid, uint64_t flags)
+{
+	return fi_pep_bind(pep, bfid, flags);
+}
+
+int wrap_fi_scalable_ep_bind(struct fid_ep *sep, struct fid *bfid,
+			     uint64_t flags)
+{
+	return fi_scalable_ep_bind(sep, bfid, flags);
+}
+
+int wrap_fi_enable(struct fid_ep *ep)
+{
+	return fi_enable(ep);
+}
+
+ssize_t wrap_fi_cancel(fid_t fid, void *context)
+{
+	return fi_cancel(fid, context);
+}
+
+int wrap_fi_setopt(fid_t fid, int level, int optname, const void *optval,
+		   size_t optlen)
+{
+	return fi_setopt(fid, level, optname, optval, optlen);
+}
+
+int wrap_fi_getopt(fid_t fid, int level, int optname, void *optval,
+		   size_t *optlen)
+{
+	return fi_getopt(fid, level, optname, optval, optlen);
+}
+
+int wrap_fi_ep_alias(struct fid_ep *ep, struct fid_ep **alias_ep,
+		     uint64_t flags)
+{
+	return fi_ep_alias(ep, alias_ep, flags);
+}
+
+int wrap_fi_tx_context(struct fid_ep *ep, int idx, struct fi_tx_attr *attr,
+		       struct fid_ep **tx_ep, void *context)
+{
+	return fi_tx_context(ep, idx, attr, tx_ep, context);
+}
+
+int wrap_fi_rx_context(struct fid_ep *ep, int idx, struct fi_rx_attr *attr,
+		       struct fid_ep **rx_ep, void *context)
+{
+	return fi_rx_context(ep, idx, attr, rx_ep, context);
+}
+
+ssize_t wrap_fi_rx_size_left(struct fid_ep *ep)
+{
+	return fi_rx_size_left(ep);
+}
+
+ssize_t wrap_fi_tx_size_left(struct fid_ep *ep)
+{
+	return fi_tx_size_left(ep);
+}
+
+int wrap_fi_stx_context(struct fid_domain *domain, struct fi_tx_attr *attr,
+			struct fid_stx **stx, void *context)
+{
+	return fi_stx_context(domain, attr, stx, context);
+}
+
+int wrap_fi_srx_context(struct fid_domain *domain, struct fi_rx_attr *attr,
+			struct fid_ep **rx_ep, void *context)
+{
+	return fi_srx_context(domain, attr, rx_ep, context);
+}
+
+ssize_t wrap_fi_recv(struct fid_ep *ep, void *buf, size_t len, void *desc,
+		     fi_addr_t src_addr, void *context)
+{
+	return fi_recv(ep, buf, len, desc, src_addr, context);
+}
+
+ssize_t wrap_fi_recvv(struct fid_ep *ep, const struct iovec *iov, void **desc,
+		      size_t count, fi_addr_t src_addr, void *context)
+{
+	return fi_recvv(ep, iov, desc, count, src_addr, context);
+}
+
+ssize_t wrap_fi_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
+			uint64_t flags)
+{
+	return fi_recvmsg(ep, msg, flags);
+}
+
+ssize_t wrap_fi_send(struct fid_ep *ep, const void *buf, size_t len, void *desc,
+		     fi_addr_t dest_addr, void *context)
+{
+	return fi_send(ep, buf, len, desc, dest_addr, context);
+}
+
+ssize_t wrap_fi_sendv(struct fid_ep *ep, const struct iovec *iov, void **desc,
+		      size_t count, fi_addr_t dest_addr, void *context)
+{
+	return fi_sendv(ep, iov, desc, count, dest_addr, context);
+}
+
+ssize_t wrap_fi_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
+			uint64_t flags)
+{
+	return fi_sendmsg(ep, msg, flags);
+}
+
+ssize_t wrap_fi_inject(struct fid_ep *ep, const void *buf, size_t len,
+		       fi_addr_t dest_addr)
+{
+	return fi_inject(ep, buf, len, dest_addr);
+}
+
+ssize_t wrap_fi_senddata(struct fid_ep *ep, const void *buf, size_t len,
+			 void *desc, uint64_t data, fi_addr_t dest_addr,
+			 void *context)
+{
+	return fi_senddata(ep, buf, len, desc, data, dest_addr, context);
+}
+
+ssize_t wrap_fi_injectdata(struct fid_ep *ep, const void *buf, size_t len,
+			   uint64_t data, fi_addr_t dest_addr)
+{
+	return fi_injectdata(ep, buf, len, data, dest_addr);
+}
+
+/* Static inline function declarations from fi_atomic.h */
+
+ssize_t wrap_fi_atomic(struct fid_ep *ep, const void *buf, size_t count,
+		       void *desc, fi_addr_t dest_addr, uint64_t addr,
+		       uint64_t key, enum fi_datatype datatype, enum fi_op op,
+		       void *context)
+{
+	return fi_atomic(ep, buf, count, desc, dest_addr, addr, key, datatype,
+			 op, context);
+}
+
+ssize_t wrap_fi_atomicv(struct fid_ep *ep, const struct fi_ioc *iov,
+			void **desc, size_t count, fi_addr_t dest_addr,
+			uint64_t addr, uint64_t key, enum fi_datatype datatype,
+			enum fi_op op, void *context)
+{
+	return fi_atomicv(ep, iov, desc, count, dest_addr, addr, key, datatype,
+			  op, context);
+}
+
+ssize_t wrap_fi_atomicmsg(struct fid_ep *ep, const struct fi_msg_atomic *msg,
+			  uint64_t flags)
+{
+	return fi_atomicmsg(ep, msg, flags);
+}
+
+ssize_t wrap_fi_inject_atomic(struct fid_ep *ep, const void *buf, size_t count,
+			      fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+			      enum fi_datatype datatype, enum fi_op op)
+{
+	return fi_inject_atomic(ep, buf, count, dest_addr, addr, key, datatype,
+				op);
+}
+
+ssize_t wrap_fi_fetch_atomic(struct fid_ep *ep, const void *buf, size_t count,
+			     void *desc, void *result, void *result_desc,
+			     fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+			     enum fi_datatype datatype, enum fi_op op,
+			     void *context)
+{
+	return fi_fetch_atomic(ep, buf, count, desc, result, result_desc,
+			       dest_addr, addr, key, datatype, op, context);
+}
+
+ssize_t wrap_fi_fetch_atomicv(struct fid_ep *ep, const struct fi_ioc *iov,
+			      void **desc, size_t count, struct fi_ioc *resultv,
+			      void **result_desc, size_t result_count,
+			      fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+			      enum fi_datatype datatype, enum fi_op op,
+			      void *context)
+{
+	return fi_fetch_atomicv(ep, iov, desc, count, resultv, result_desc,
+				result_count, dest_addr, addr, key, datatype,
+				op, context);
+}
+
+ssize_t wrap_fi_fetch_atomicmsg(struct fid_ep *ep,
+				const struct fi_msg_atomic *msg,
+				struct fi_ioc *resultv, void **result_desc,
+				size_t result_count, uint64_t flags)
+{
+	return fi_fetch_atomicmsg(ep, msg, resultv, result_desc, result_count,
+				  flags);
+}
+
+ssize_t wrap_fi_compare_atomic(struct fid_ep *ep, const void *buf, size_t count,
+			       void *desc, const void *compare,
+			       void *compare_desc, void *result,
+			       void *result_desc, fi_addr_t dest_addr,
+			       uint64_t addr, uint64_t key,
+			       enum fi_datatype datatype, enum fi_op op,
+			       void *context)
+{
+	return fi_compare_atomic(ep, buf, count, desc, compare, compare_desc,
+				 result, result_desc, dest_addr, addr, key,
+				 datatype, op, context);
+}
+
+ssize_t wrap_fi_compare_atomicv(
+	struct fid_ep *ep, const struct fi_ioc *iov, void **desc, size_t count,
+	const struct fi_ioc *comparev, void **compare_desc,
+	size_t compare_count, struct fi_ioc *resultv, void **result_desc,
+	size_t result_count, fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+	enum fi_datatype datatype, enum fi_op op, void *context)
+{
+	return fi_compare_atomicv(ep, iov, desc, count, comparev, compare_desc,
+				  compare_count, resultv, result_desc,
+				  result_count, dest_addr, addr, key, datatype,
+				  op, context);
+}
+
+ssize_t wrap_fi_compare_atomicmsg(struct fid_ep *ep,
+				  const struct fi_msg_atomic *msg,
+				  const struct fi_ioc *comparev,
+				  void **compare_desc, size_t compare_count,
+				  struct fi_ioc *resultv, void **result_desc,
+				  size_t result_count, uint64_t flags)
+{
+	return fi_compare_atomicmsg(ep, msg, comparev, compare_desc,
+				    compare_count, resultv, result_desc,
+				    result_count, flags);
+}
+
+int wrap_fi_atomicvalid(struct fid_ep *ep, enum fi_datatype datatype,
+			enum fi_op op, size_t *count)
+{
+	return fi_atomicvalid(ep, datatype, op, count);
+}
+
+int wrap_fi_fetch_atomicvalid(struct fid_ep *ep, enum fi_datatype datatype,
+			      enum fi_op op, size_t *count)
+{
+	return fi_fetch_atomicvalid(ep, datatype, op, count);
+}
+
+int wrap_fi_compare_atomicvalid(struct fid_ep *ep, enum fi_datatype datatype,
+				enum fi_op op, size_t *count)
+{
+	return fi_compare_atomicvalid(ep, datatype, op, count);
+}
+
+int wrap_fi_query_atomic(struct fid_domain *domain, enum fi_datatype datatype,
+			 enum fi_op op, struct fi_atomic_attr *attr,
+			 uint64_t flags)
+{
+	return fi_query_atomic(domain, datatype, op, attr, flags);
+}
+
+/* Static inline function declarations from fi_domain.h */
+
+int wrap_fi_domain(struct fid_fabric *fabric, struct fi_info *info,
+		   struct fid_domain **domain, void *context)
+{
+	return fi_domain(fabric, info, domain, context);
+}
+
+int wrap_fi_domain2(struct fid_fabric *fabric, struct fi_info *info,
+		    struct fid_domain **domain, uint64_t flags, void *context)
+{
+	return fi_domain2(fabric, info, domain, flags, context);
+}
+
+int wrap_fi_domain_bind(struct fid_domain *domain, struct fid *fid,
+			uint64_t flags)
+{
+	return fi_domain_bind(domain, fid, flags);
+}
+
+int wrap_fi_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
+		    struct fid_cq **cq, void *context)
+{
+	return fi_cq_open(domain, attr, cq, context);
+}
+
+int wrap_fi_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
+		      struct fid_cntr **cntr, void *context)
+{
+	return fi_cntr_open(domain, attr, cntr, context);
+}
+
+int wrap_fi_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
+		      struct fid_wait **waitset)
+{
+	return fi_wait_open(fabric, attr, waitset);
+}
+
+int wrap_fi_poll_open(struct fid_domain *domain, struct fi_poll_attr *attr,
+		      struct fid_poll **pollset)
+{
+	return fi_poll_open(domain, attr, pollset);
+}
+
+int wrap_fi_mr_reg(struct fid_domain *domain, const void *buf, size_t len,
+		   uint64_t acs, uint64_t offset, uint64_t requested_key,
+		   uint64_t flags, struct fid_mr **mr, void *context)
+{
+	return fi_mr_reg(domain, buf, len, acs, offset, requested_key, flags,
+			 mr, context);
+}
+
+int wrap_fi_mr_regv(struct fid_domain *domain, const struct iovec *iov,
+		    size_t count, uint64_t acs, uint64_t offset,
+		    uint64_t requested_key, uint64_t flags, struct fid_mr **mr,
+		    void *context)
+{
+	return fi_mr_regv(domain, iov, count, acs, offset, requested_key, flags,
+			  mr, context);
+}
+
+int wrap_fi_mr_regattr(struct fid_domain *domain, const struct fi_mr_attr *attr,
+		       uint64_t flags, struct fid_mr **mr)
+{
+	return fi_mr_regattr(domain, attr, flags, mr);
+}
+
+void *wrap_fi_mr_desc(struct fid_mr *mr)
+{
+	return fi_mr_desc(mr);
+}
+
+uint64_t wrap_fi_mr_key(struct fid_mr *mr)
+{
+	return fi_mr_key(mr);
+}
+
+int wrap_fi_mr_raw_attr(struct fid_mr *mr, uint64_t *base_addr,
+			uint8_t *raw_key, size_t *key_size, uint64_t flags)
+{
+	return fi_mr_raw_attr(mr, base_addr, raw_key, key_size, flags);
+}
+
+int wrap_fi_mr_map_raw(struct fid_domain *domain, uint64_t base_addr,
+		       uint8_t *raw_key, size_t key_size, uint64_t *key,
+		       uint64_t flags)
+{
+	return fi_mr_map_raw(domain, base_addr, raw_key, key_size, key, flags);
+}
+
+int wrap_fi_mr_unmap_key(struct fid_domain *domain, uint64_t key)
+{
+	return fi_mr_unmap_key(domain, key);
+}
+
+int wrap_fi_mr_bind(struct fid_mr *mr, struct fid *bfid, uint64_t flags)
+{
+	return fi_mr_bind(mr, bfid, flags);
+}
+
+int wrap_fi_mr_refresh(struct fid_mr *mr, const struct iovec *iov, size_t count,
+		       uint64_t flags)
+{
+	return fi_mr_refresh(mr, iov, count, flags);
+}
+
+int wrap_fi_mr_enable(struct fid_mr *mr)
+{
+	return fi_mr_enable(mr);
+}
+
+int wrap_fi_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
+		    struct fid_av **av, void *context)
+{
+	return fi_av_open(domain, attr, av, context);
+}
+
+int wrap_fi_av_bind(struct fid_av *av, struct fid *fid, uint64_t flags)
+{
+	return fi_av_bind(av, fid, flags);
+}
+
+int wrap_fi_av_insert(struct fid_av *av, const void *addr, size_t count,
+		      fi_addr_t *fi_addr, uint64_t flags, void *context)
+{
+	return fi_av_insert(av, addr, count, fi_addr, flags, context);
+}
+
+int wrap_fi_av_insertsvc(struct fid_av *av, const char *node,
+			 const char *service, fi_addr_t *fi_addr,
+			 uint64_t flags, void *context)
+{
+	return fi_av_insertsvc(av, node, service, fi_addr, flags, context);
+}
+
+int wrap_fi_av_insertsym(struct fid_av *av, const char *node, size_t nodecnt,
+			 const char *service, size_t svccnt, fi_addr_t *fi_addr,
+			 uint64_t flags, void *context)
+{
+	return fi_av_insertsym(av, node, nodecnt, service, svccnt, fi_addr,
+			       flags, context);
+}
+
+int wrap_fi_av_remove(struct fid_av *av, fi_addr_t *fi_addr, size_t count,
+		      uint64_t flags)
+{
+	return fi_av_remove(av, fi_addr, count, flags);
+}
+
+int wrap_fi_av_lookup(struct fid_av *av, fi_addr_t fi_addr, void *addr,
+		      size_t *addrlen)
+{
+	return fi_av_lookup(av, fi_addr, addr, addrlen);
+}
+
+const char *wrap_fi_av_straddr(struct fid_av *av, const void *addr, char *buf,
+			       size_t *len)
+{
+	return fi_av_straddr(av, addr, buf, len);
+}
+
+int wrap_fi_av_insert_auth_key(struct fid_av *av, const void *auth_key,
+			       size_t auth_key_size, fi_addr_t *fi_addr,
+			       uint64_t flags)
+{
+	return fi_av_insert_auth_key(av, auth_key, auth_key_size, fi_addr,
+				     flags);
+}
+
+int wrap_fi_av_lookup_auth_key(struct fid_av *av, fi_addr_t addr,
+			       void *auth_key, size_t *auth_key_size)
+{
+	return fi_av_lookup_auth_key(av, addr, auth_key, auth_key_size);
+}
+
+int wrap_fi_av_set_user_id(struct fid_av *av, fi_addr_t fi_addr,
+			   fi_addr_t user_id, uint64_t flags)
+{
+	return fi_av_set_user_id(av, fi_addr, user_id, flags);
+}
+
+fi_addr_t wrap_fi_rx_addr(fi_addr_t fi_addr, int rx_index, int rx_ctx_bits)
+{
+	return fi_rx_addr(fi_addr, rx_index, rx_ctx_bits);
+}
+
+fi_addr_t wrap_fi_group_addr(fi_addr_t fi_addr, uint32_t group_id)
+{
+	return fi_group_addr(fi_addr, group_id);
+}
+
+/* Static inline function declarations from fi_cm.h */
+
+int wrap_fi_setname(fid_t fid, void *addr, size_t addrlen)
+{
+	return fi_setname(fid, addr, addrlen);
+}
+
+int wrap_fi_getname(fid_t fid, void *addr, size_t *addrlen)
+{
+	return fi_getname(fid, addr, addrlen);
+}
+
+int wrap_fi_getpeer(struct fid_ep *ep, void *addr, size_t *addrlen)
+{
+	return fi_getpeer(ep, addr, addrlen);
+}
+
+int wrap_fi_listen(struct fid_pep *pep)
+{
+	return fi_listen(pep);
+}
+
+int wrap_fi_connect(struct fid_ep *ep, const void *addr, const void *param,
+		    size_t paramlen)
+{
+	return fi_connect(ep, addr, param, paramlen);
+}
+
+int wrap_fi_accept(struct fid_ep *ep, const void *param, size_t paramlen)
+{
+	return fi_accept(ep, param, paramlen);
+}
+
+int wrap_fi_reject(struct fid_pep *pep, fid_t handle, const void *param,
+		   size_t paramlen)
+{
+	return fi_reject(pep, handle, param, paramlen);
+}
+
+int wrap_fi_shutdown(struct fid_ep *ep, uint64_t flags)
+{
+	return fi_shutdown(ep, flags);
+}
+
+int wrap_fi_join(struct fid_ep *ep, const void *addr, uint64_t flags,
+		 struct fid_mc **mc, void *context)
+{
+	return fi_join(ep, addr, flags, mc, context);
+}
+
+fi_addr_t wrap_fi_mc_addr(struct fid_mc *mc)
+{
+	return fi_mc_addr(mc);
+}
+
+/* Static inline function declarations from fi_collective.h */
+
+int wrap_fi_av_set(struct fid_av *av, struct fi_av_set_attr *attr,
+		   struct fid_av_set **set, void *context)
+{
+	return fi_av_set(av, attr, set, context);
+}
+
+int wrap_fi_av_set_union(struct fid_av_set *dst, const struct fid_av_set *src)
+{
+	return fi_av_set_union(dst, src);
+}
+
+int wrap_fi_av_set_intersect(struct fid_av_set *dst,
+			     const struct fid_av_set *src)
+{
+	return fi_av_set_intersect(dst, src);
+}
+
+int wrap_fi_av_set_diff(struct fid_av_set *dst, const struct fid_av_set *src)
+{
+	return fi_av_set_diff(dst, src);
+}
+
+int wrap_fi_av_set_insert(struct fid_av_set *set, fi_addr_t addr)
+{
+	return fi_av_set_insert(set, addr);
+}
+
+int wrap_fi_av_set_remove(struct fid_av_set *set, fi_addr_t addr)
+{
+	return fi_av_set_remove(set, addr);
+}
+
+int wrap_fi_av_set_addr(struct fid_av_set *set, fi_addr_t *coll_addr)
+{
+	return fi_av_set_addr(set, coll_addr);
+}
+
+int wrap_fi_join_collective(struct fid_ep *ep, fi_addr_t coll_addr,
+			    const struct fid_av_set *set, uint64_t flags,
+			    struct fid_mc **mc, void *context)
+{
+	return fi_join_collective(ep, coll_addr, set, flags, mc, context);
+}
+
+ssize_t wrap_fi_barrier(struct fid_ep *ep, fi_addr_t coll_addr, void *context)
+{
+	return fi_barrier(ep, coll_addr, context);
+}
+
+ssize_t wrap_fi_barrier2(struct fid_ep *ep, fi_addr_t coll_addr, uint64_t flags,
+			 void *context)
+{
+	return fi_barrier2(ep, coll_addr, flags, context);
+}
+
+ssize_t wrap_fi_broadcast(struct fid_ep *ep, void *buf, size_t count,
+			  void *desc, fi_addr_t coll_addr, fi_addr_t root_addr,
+			  enum fi_datatype datatype, uint64_t flags,
+			  void *context)
+{
+	return fi_broadcast(ep, buf, count, desc, coll_addr, root_addr,
+			    datatype, flags, context);
+}
+
+ssize_t wrap_fi_alltoall(struct fid_ep *ep, const void *buf, size_t count,
+			 void *desc, void *result, void *result_desc,
+			 fi_addr_t coll_addr, enum fi_datatype datatype,
+			 uint64_t flags, void *context)
+{
+	return fi_alltoall(ep, buf, count, desc, result, result_desc, coll_addr,
+			   datatype, flags, context);
+}
+
+ssize_t wrap_fi_allreduce(struct fid_ep *ep, const void *buf, size_t count,
+			  void *desc, void *result, void *result_desc,
+			  fi_addr_t coll_addr, enum fi_datatype datatype,
+			  enum fi_op op, uint64_t flags, void *context)
+{
+	return fi_allreduce(ep, buf, count, desc, result, result_desc,
+			    coll_addr, datatype, op, flags, context);
+}
+
+ssize_t wrap_fi_allgather(struct fid_ep *ep, const void *buf, size_t count,
+			  void *desc, void *result, void *result_desc,
+			  fi_addr_t coll_addr, enum fi_datatype datatype,
+			  uint64_t flags, void *context)
+{
+	return fi_allgather(ep, buf, count, desc, result, result_desc,
+			    coll_addr, datatype, flags, context);
+}
+
+ssize_t wrap_fi_reduce_scatter(struct fid_ep *ep, const void *buf, size_t count,
+			       void *desc, void *result, void *result_desc,
+			       fi_addr_t coll_addr, enum fi_datatype datatype,
+			       enum fi_op op, uint64_t flags, void *context)
+{
+	return fi_reduce_scatter(ep, buf, count, desc, result, result_desc,
+				 coll_addr, datatype, op, flags, context);
+}
+
+ssize_t wrap_fi_reduce(struct fid_ep *ep, const void *buf, size_t count,
+		       void *desc, void *result, void *result_desc,
+		       fi_addr_t coll_addr, fi_addr_t root_addr,
+		       enum fi_datatype datatype, enum fi_op op, uint64_t flags,
+		       void *context)
+{
+	return fi_reduce(ep, buf, count, desc, result, result_desc, coll_addr,
+			 root_addr, datatype, op, flags, context);
+}
+
+ssize_t wrap_fi_scatter(struct fid_ep *ep, const void *buf, size_t count,
+			void *desc, void *result, void *result_desc,
+			fi_addr_t coll_addr, fi_addr_t root_addr,
+			enum fi_datatype datatype, uint64_t flags,
+			void *context)
+{
+	return fi_scatter(ep, buf, count, desc, result, result_desc, coll_addr,
+			  root_addr, datatype, flags, context);
+}
+
+ssize_t wrap_fi_gather(struct fid_ep *ep, const void *buf, size_t count,
+		       void *desc, void *result, void *result_desc,
+		       fi_addr_t coll_addr, fi_addr_t root_addr,
+		       enum fi_datatype datatype, uint64_t flags, void *context)
+{
+	return fi_gather(ep, buf, count, desc, result, result_desc, coll_addr,
+			 root_addr, datatype, flags, context);
+}
+
+int wrap_fi_query_collective(struct fid_domain *domain,
+			     enum fi_collective_op coll,
+			     struct fi_collective_attr *attr, uint64_t flags)
+{
+	return fi_query_collective(domain, coll, attr, flags);
+}
+
+/* Static inline function declarations from fi_eq.h */
+
+int wrap_fi_trywait(struct fid_fabric *fabric, struct fid **fids, int count)
+{
+	return fi_trywait(fabric, fids, count);
+}
+
+int wrap_fi_wait(struct fid_wait *waitset, int timeout)
+{
+	return fi_wait(waitset, timeout);
+}
+
+int wrap_fi_poll(struct fid_poll *pollset, void **context, int count)
+{
+	return fi_poll(pollset, context, count);
+}
+
+int wrap_fi_poll_add(struct fid_poll *pollset, struct fid *event_fid,
+		     uint64_t flags)
+{
+	return fi_poll_add(pollset, event_fid, flags);
+}
+
+int wrap_fi_poll_del(struct fid_poll *pollset, struct fid *event_fid,
+		     uint64_t flags)
+{
+	return fi_poll_del(pollset, event_fid, flags);
+}
+
+int wrap_fi_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
+		    struct fid_eq **eq, void *context)
+{
+	return fi_eq_open(fabric, attr, eq, context);
+}
+
+ssize_t wrap_fi_eq_read(struct fid_eq *eq, uint32_t *event, void *buf,
+			size_t len, uint64_t flags)
+{
+	return fi_eq_read(eq, event, buf, len, flags);
+}
+
+ssize_t wrap_fi_eq_readerr(struct fid_eq *eq, struct fi_eq_err_entry *buf,
+			   uint64_t flags)
+{
+	return fi_eq_readerr(eq, buf, flags);
+}
+
+ssize_t wrap_fi_eq_write(struct fid_eq *eq, uint32_t event, const void *buf,
+			 size_t len, uint64_t flags)
+{
+	return fi_eq_write(eq, event, buf, len, flags);
+}
+
+ssize_t wrap_fi_eq_sread(struct fid_eq *eq, uint32_t *event, void *buf,
+			 size_t len, int timeout, uint64_t flags)
+{
+	return fi_eq_sread(eq, event, buf, len, timeout, flags);
+}
+
+const char *wrap_fi_eq_strerror(struct fid_eq *eq, int prov_errno,
+				const void *err_data, char *buf, size_t len)
+{
+	return fi_eq_strerror(eq, prov_errno, err_data, buf, len);
+}
+
+ssize_t wrap_fi_cq_read(struct fid_cq *cq, void *buf, size_t count)
+{
+	return fi_cq_read(cq, buf, count);
+}
+
+ssize_t wrap_fi_cq_readfrom(struct fid_cq *cq, void *buf, size_t count,
+			    fi_addr_t *src_addr)
+{
+	return fi_cq_readfrom(cq, buf, count, src_addr);
+}
+
+ssize_t wrap_fi_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf,
+			   uint64_t flags)
+{
+	return fi_cq_readerr(cq, buf, flags);
+}
+
+ssize_t wrap_fi_cq_sread(struct fid_cq *cq, void *buf, size_t count,
+			 const void *cond, int timeout)
+{
+	return fi_cq_sread(cq, buf, count, cond, timeout);
+}
+
+ssize_t wrap_fi_cq_sreadfrom(struct fid_cq *cq, void *buf, size_t count,
+			     fi_addr_t *src_addr, const void *cond, int timeout)
+{
+	return fi_cq_sreadfrom(cq, buf, count, src_addr, cond, timeout);
+}
+
+int wrap_fi_cq_signal(struct fid_cq *cq)
+{
+	return fi_cq_signal(cq);
+}
+
+const char *wrap_fi_cq_strerror(struct fid_cq *cq, int prov_errno,
+				const void *err_data, char *buf, size_t len)
+{
+	return fi_cq_strerror(cq, prov_errno, err_data, buf, len);
+}
+
+uint64_t wrap_fi_cntr_read(struct fid_cntr *cntr)
+{
+	return fi_cntr_read(cntr);
+}
+
+uint64_t wrap_fi_cntr_readerr(struct fid_cntr *cntr)
+{
+	return fi_cntr_readerr(cntr);
+}
+
+int wrap_fi_cntr_add(struct fid_cntr *cntr, uint64_t value)
+{
+	return fi_cntr_add(cntr, value);
+}
+
+int wrap_fi_cntr_adderr(struct fid_cntr *cntr, uint64_t value)
+{
+	return fi_cntr_adderr(cntr, value);
+}
+
+int wrap_fi_cntr_set(struct fid_cntr *cntr, uint64_t value)
+{
+	return fi_cntr_set(cntr, value);
+}
+
+int wrap_fi_cntr_seterr(struct fid_cntr *cntr, uint64_t value)
+{
+	return fi_cntr_seterr(cntr, value);
+}
+
+int wrap_fi_cntr_wait(struct fid_cntr *cntr, uint64_t threshold, int timeout)
+{
+	return fi_cntr_wait(cntr, threshold, timeout);
+}
+
+/* Static inline function declarations from fi_ext.h */
+
+int wrap_fi_export_fid(struct fid *fid, uint64_t flags, struct fid **expfid,
+		       void *context)
+{
+	return fi_export_fid(fid, flags, expfid, context);
+}
+
+int wrap_fi_import_fid(struct fid *fid, struct fid *expfid, uint64_t flags)
+{
+	return fi_import_fid(fid, expfid, flags);
+}
+
+int wrap_fi_import(uint32_t version, const char *name, void *attr,
+		   size_t attr_len, uint64_t flags, struct fid *fid,
+		   void *context)
+{
+	return fi_import(version, name, attr, attr_len, flags, fid, context);
+}
+
+int wrap_fi_import_log(uint32_t version, uint64_t flags,
+		       struct fid_logging *log_fid)
+{
+	return fi_import_log(version, flags, log_fid);
+}
+
+/* Static inline function declarations from fi_ext.h */
+
+void wrap_fi_profile_reset(struct fid_profile *prof_fid, uint64_t flags)
+{
+	return fi_profile_reset(prof_fid, flags);
+}
+
+ssize_t wrap_fi_profile_query_vars(struct fid_profile *prof_fid,
+				   struct fi_profile_desc *varlist,
+				   size_t *count)
+{
+	return fi_profile_query_vars(prof_fid, varlist, count);
+}
+
+ssize_t wrap_fi_profile_query_events(struct fid_profile *prof_fid,
+				     struct fi_profile_desc *eventlist,
+				     size_t *count)
+{
+	return fi_profile_query_events(prof_fid, eventlist, count);
+}
+
+ssize_t wrap_fi_profile_read_u64(struct fid_profile *prof_fid, uint32_t var_id,
+				 uint64_t *data)
+{
+	return fi_profile_read_u64(prof_fid, var_id, data);
+}
+
+int wrap_fi_profile_register_callback(
+	struct fid_profile *prof_fid, uint32_t event_id,
+	int (*callback)(struct fid_profile *prof_fid,
+			struct fi_profile_desc *event, void *param, size_t size,
+			void *context),
+	void *context)
+{
+	return fi_profile_register_callback(prof_fid, event_id, callback,
+					    context);
+}
+
+void wrap_fi_profile_start_reads(struct fid_profile *prof_fid, uint64_t flags)
+{
+	return fi_profile_start_reads(prof_fid, flags);
+}
+
+void wrap_fi_profile_end_reads(struct fid_profile *prof_fid, uint64_t flags)
+{
+	return fi_profile_end_reads(prof_fid, flags);
+}
+
+int wrap_fi_profile_open(struct fid *fid, uint64_t flags,
+			 struct fid_profile **prof_fid, void *context)
+{
+	return fi_profile_open(fid, flags, prof_fid, context);
+}
+
+int wrap_fi_profile_close(struct fid_profile *prof_fid)
+{
+	return fi_profile_close(prof_fid);
+}
+
+/* Static inline function declarations from fi_rma.h */
+
+ssize_t wrap_fi_read(struct fid_ep *ep, const void *buf, size_t len, void *desc,
+		     fi_addr_t src_addr, uint64_t addr, uint64_t key,
+		     void *context)
+{
+	return fi_read(ep, buf, len, desc, src_addr, addr, key, context);
+}
+
+ssize_t wrap_fi_readv(struct fid_ep *ep, const struct iovec *iov, void **desc,
+		      size_t count, fi_addr_t src_addr, uint64_t addr,
+		      uint64_t key, void *context)
+{
+	return fi_readv(ep, iov, desc, count, src_addr, addr, key, context);
+}
+
+ssize_t wrap_fi_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
+			uint64_t flags)
+{
+	return fi_readmsg(ep, msg, flags);
+}
+
+ssize_t wrap_fi_write(struct fid_ep *ep, const void *buf, size_t len,
+		      void *desc, fi_addr_t dest_addr, uint64_t addr,
+		      uint64_t key, void *context)
+{
+	return fi_write(ep, buf, len, desc, dest_addr, addr, key, context);
+}
+
+ssize_t wrap_fi_writev(struct fid_ep *ep, const struct iovec *iov, void **desc,
+		       size_t count, fi_addr_t dest_addr, uint64_t addr,
+		       uint64_t key, void *context)
+{
+	return fi_writev(ep, iov, desc, count, dest_addr, addr, key, context);
+}
+
+ssize_t wrap_fi_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
+			 uint64_t flags)
+{
+	return fi_writemsg(ep, msg, flags);
+}
+
+ssize_t wrap_fi_inject_write(struct fid_ep *ep, const void *buf, size_t len,
+			     fi_addr_t dest_addr, uint64_t addr, uint64_t key)
+{
+	return fi_inject_write(ep, buf, len, dest_addr, addr, key);
+}
+
+ssize_t wrap_fi_writedata(struct fid_ep *ep, const void *buf, size_t len,
+			  void *desc, uint64_t data, fi_addr_t dest_addr,
+			  uint64_t addr, uint64_t key, void *context)
+{
+	return fi_writedata(ep, buf, len, desc, data, dest_addr, addr, key,
+			    context);
+}
+
+ssize_t wrap_fi_inject_writedata(struct fid_ep *ep, const void *buf, size_t len,
+				 uint64_t data, fi_addr_t dest_addr,
+				 uint64_t addr, uint64_t key)
+{
+	return fi_inject_writedata(ep, buf, len, data, dest_addr, addr, key);
+}
+
+/* Static inline function declarations from fi_tagged.h */
+
+ssize_t wrap_fi_trecv(struct fid_ep *ep, void *buf, size_t len, void *desc,
+		      fi_addr_t src_addr, uint64_t tag, uint64_t ignore,
+		      void *context)
+{
+	return fi_trecv(ep, buf, len, desc, src_addr, tag, ignore, context);
+}
+
+ssize_t wrap_fi_trecvv(struct fid_ep *ep, const struct iovec *iov, void **desc,
+		       size_t count, fi_addr_t src_addr, uint64_t tag,
+		       uint64_t ignore, void *context)
+{
+	return fi_trecvv(ep, iov, desc, count, src_addr, tag, ignore, context);
+}
+
+ssize_t wrap_fi_trecvmsg(struct fid_ep *ep, const struct fi_msg_tagged *msg,
+			 uint64_t flags)
+{
+	return fi_trecvmsg(ep, msg, flags);
+}
+
+ssize_t wrap_fi_tsend(struct fid_ep *ep, const void *buf, size_t len,
+		      void *desc, fi_addr_t dest_addr, uint64_t tag,
+		      void *context)
+{
+	return fi_tsend(ep, buf, len, desc, dest_addr, tag, context);
+}
+
+ssize_t wrap_fi_tsendv(struct fid_ep *ep, const struct iovec *iov, void **desc,
+		       size_t count, fi_addr_t dest_addr, uint64_t tag,
+		       void *context)
+{
+	return fi_tsendv(ep, iov, desc, count, dest_addr, tag, context);
+}
+
+ssize_t wrap_fi_tsendmsg(struct fid_ep *ep, const struct fi_msg_tagged *msg,
+			 uint64_t flags)
+{
+	return fi_tsendmsg(ep, msg, flags);
+}
+
+ssize_t wrap_fi_tinject(struct fid_ep *ep, const void *buf, size_t len,
+			fi_addr_t dest_addr, uint64_t tag)
+{
+	return fi_tinject(ep, buf, len, dest_addr, tag);
+}
+
+ssize_t wrap_fi_tsenddata(struct fid_ep *ep, const void *buf, size_t len,
+			  void *desc, uint64_t data, fi_addr_t dest_addr,
+			  uint64_t tag, void *context)
+{
+	return fi_tsenddata(ep, buf, len, desc, data, dest_addr, tag, context);
+}
+
+ssize_t wrap_fi_tinjectdata(struct fid_ep *ep, const void *buf, size_t len,
+			    uint64_t data, fi_addr_t dest_addr, uint64_t tag)
+{
+	return fi_tinjectdata(ep, buf, len, data, dest_addr, tag);
+}

--- a/bindings/rust/wrapper.h
+++ b/bindings/rust/wrapper.h
@@ -1,0 +1,415 @@
+#ifndef __WRAPPER_H__
+#define __WRAPPER_H__
+
+#ifndef container_of
+#define container_of(ptr, type, field) \
+	((type *) ((char *) ptr - offsetof(type, field)))
+#endif
+
+#include <stdio.h>
+
+#include "fi_atomic.h"
+#include "fi_cm.h"
+#include "fi_collective.h"
+#include "fi_domain.h"
+#include "fi_endpoint.h"
+#include "fi_eq.h"
+#include "fi_errno.h"
+#include "fi_ext.h"
+#include "fi_profile.h"
+#include "fi_rma.h"
+#include "fi_tagged.h"
+#include "fi_trigger.h"
+
+/* Proprietary helper function declarations. */
+fid_t get_fid_ptr(void *ptr);
+
+/* Static inline function declarations from fi_prov.h */
+int wrap_fi_param_get_str(struct fi_provider *provider, const char *param_name,
+			  char **value);
+int wrap_fi_param_get_int(struct fi_provider *provider, const char *param_name,
+			  int *value);
+int wrap_fi_param_get_bool(struct fi_provider *provider, const char *param_name,
+			   int *value);
+int wrap_fi_param_get_size_t(struct fi_provider *provider,
+			     const char *param_name, size_t *value);
+
+/* Static inline function declarations from fabric.h */
+struct fi_info *wrap_fi_allocinfo(void);
+int wrap_fi_close(struct fid *fid);
+int wrap_fi_control(struct fid *fid, int command, void *arg);
+int wrap_fi_alias(struct fid *fid, struct fid **alias_fid, uint64_t flags);
+int wrap_fi_get_val(struct fid *fid, int name, void *val);
+int wrap_fi_set_val(struct fid *fid, int name, void *val);
+int wrap_fi_open_ops(struct fid *fid, const char *name, uint64_t flags,
+		     void **ops, void *context);
+int wrap_fi_set_ops(struct fid *fid, const char *name, uint64_t flags,
+		    void *ops, void *context);
+
+/* Static inline function declarations from fi_endpoint.h */
+int wrap_fi_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
+		       struct fid_pep **pep, void *context);
+int wrap_fi_endpoint(struct fid_domain *domain, struct fi_info *info,
+		     struct fid_ep **ep, void *context);
+int wrap_fi_endpoint2(struct fid_domain *domain, struct fi_info *info,
+		      struct fid_ep **ep, uint64_t flags, void *context);
+int wrap_fi_scalable_ep(struct fid_domain *domain, struct fi_info *info,
+			struct fid_ep **sep, void *context);
+int wrap_fi_ep_bind(struct fid_ep *ep, struct fid *bfid, uint64_t flags);
+int wrap_fi_pep_bind(struct fid_pep *pep, struct fid *bfid, uint64_t flags);
+int wrap_fi_scalable_ep_bind(struct fid_ep *sep, struct fid *bfid,
+			     uint64_t flags);
+int wrap_fi_enable(struct fid_ep *ep);
+ssize_t wrap_fi_cancel(fid_t fid, void *context);
+int wrap_fi_setopt(fid_t fid, int level, int optname, const void *optval,
+		   size_t optlen);
+int wrap_fi_getopt(fid_t fid, int level, int optname, void *optval,
+		   size_t *optlen);
+int wrap_fi_ep_alias(struct fid_ep *ep, struct fid_ep **alias_ep,
+		     uint64_t flags);
+int wrap_fi_tx_context(struct fid_ep *ep, int idx, struct fi_tx_attr *attr,
+		       struct fid_ep **tx_ep, void *context);
+int wrap_fi_rx_context(struct fid_ep *ep, int idx, struct fi_rx_attr *attr,
+		       struct fid_ep **rx_ep, void *context);
+ssize_t wrap_fi_rx_size_left(struct fid_ep *ep);
+ssize_t wrap_fi_tx_size_left(struct fid_ep *ep);
+int wrap_fi_stx_context(struct fid_domain *domain, struct fi_tx_attr *attr,
+			struct fid_stx **stx, void *context);
+int wrap_fi_srx_context(struct fid_domain *domain, struct fi_rx_attr *attr,
+			struct fid_ep **rx_ep, void *context);
+ssize_t wrap_fi_recv(struct fid_ep *ep, void *buf, size_t len, void *desc,
+		     fi_addr_t src_addr, void *context);
+ssize_t wrap_fi_recvv(struct fid_ep *ep, const struct iovec *iov, void **desc,
+		      size_t count, fi_addr_t src_addr, void *context);
+ssize_t wrap_fi_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
+			uint64_t flags);
+ssize_t wrap_fi_send(struct fid_ep *ep, const void *buf, size_t len, void *desc,
+		     fi_addr_t dest_addr, void *context);
+ssize_t wrap_fi_sendv(struct fid_ep *ep, const struct iovec *iov, void **desc,
+		      size_t count, fi_addr_t dest_addr, void *context);
+ssize_t wrap_fi_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
+			uint64_t flags);
+ssize_t wrap_fi_inject(struct fid_ep *ep, const void *buf, size_t len,
+		       fi_addr_t dest_addr);
+ssize_t wrap_fi_senddata(struct fid_ep *ep, const void *buf, size_t len,
+			 void *desc, uint64_t data, fi_addr_t dest_addr,
+			 void *context);
+ssize_t wrap_fi_injectdata(struct fid_ep *ep, const void *buf, size_t len,
+			   uint64_t data, fi_addr_t dest_addr);
+
+/* Static inline function declarations from fi_atomic.h */
+ssize_t wrap_fi_atomic(struct fid_ep *ep, const void *buf, size_t count,
+		       void *desc, fi_addr_t dest_addr, uint64_t addr,
+		       uint64_t key, enum fi_datatype datatype, enum fi_op op,
+		       void *context);
+ssize_t wrap_fi_atomicv(struct fid_ep *ep, const struct fi_ioc *iov,
+			void **desc, size_t count, fi_addr_t dest_addr,
+			uint64_t addr, uint64_t key, enum fi_datatype datatype,
+			enum fi_op op, void *context);
+ssize_t wrap_fi_atomicmsg(struct fid_ep *ep, const struct fi_msg_atomic *msg,
+			  uint64_t flags);
+ssize_t wrap_fi_inject_atomic(struct fid_ep *ep, const void *buf, size_t count,
+			      fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+			      enum fi_datatype datatype, enum fi_op op);
+ssize_t wrap_fi_fetch_atomic(struct fid_ep *ep, const void *buf, size_t count,
+			     void *desc, void *result, void *result_desc,
+			     fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+			     enum fi_datatype datatype, enum fi_op op,
+			     void *context);
+ssize_t wrap_fi_fetch_atomicv(struct fid_ep *ep, const struct fi_ioc *iov,
+			      void **desc, size_t count, struct fi_ioc *resultv,
+			      void **result_desc, size_t result_count,
+			      fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+			      enum fi_datatype datatype, enum fi_op op,
+			      void *context);
+ssize_t wrap_fi_fetch_atomicmsg(struct fid_ep *ep,
+				const struct fi_msg_atomic *msg,
+				struct fi_ioc *resultv, void **result_desc,
+				size_t result_count, uint64_t flags);
+ssize_t wrap_fi_compare_atomic(struct fid_ep *ep, const void *buf, size_t count,
+			       void *desc, const void *compare,
+			       void *compare_desc, void *result,
+			       void *result_desc, fi_addr_t dest_addr,
+			       uint64_t addr, uint64_t key,
+			       enum fi_datatype datatype, enum fi_op op,
+			       void *context);
+ssize_t wrap_fi_compare_atomicv(
+	struct fid_ep *ep, const struct fi_ioc *iov, void **desc, size_t count,
+	const struct fi_ioc *comparev, void **compare_desc,
+	size_t compare_count, struct fi_ioc *resultv, void **result_desc,
+	size_t result_count, fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+	enum fi_datatype datatype, enum fi_op op, void *context);
+ssize_t wrap_fi_compare_atomicmsg(struct fid_ep *ep,
+				  const struct fi_msg_atomic *msg,
+				  const struct fi_ioc *comparev,
+				  void **compare_desc, size_t compare_count,
+				  struct fi_ioc *resultv, void **result_desc,
+				  size_t result_count, uint64_t flags);
+int wrap_fi_atomicvalid(struct fid_ep *ep, enum fi_datatype datatype,
+			enum fi_op op, size_t *count);
+int wrap_fi_fetch_atomicvalid(struct fid_ep *ep, enum fi_datatype datatype,
+			      enum fi_op op, size_t *count);
+int wrap_fi_compare_atomicvalid(struct fid_ep *ep, enum fi_datatype datatype,
+				enum fi_op op, size_t *count);
+int wrap_fi_query_atomic(struct fid_domain *domain, enum fi_datatype datatype,
+			 enum fi_op op, struct fi_atomic_attr *attr,
+			 uint64_t flags);
+
+/* Static inline function declarations from fi_domain.h */
+int wrap_fi_domain(struct fid_fabric *fabric, struct fi_info *info,
+		   struct fid_domain **domain, void *context);
+int wrap_fi_domain2(struct fid_fabric *fabric, struct fi_info *info,
+		    struct fid_domain **domain, uint64_t flags, void *context);
+int wrap_fi_domain_bind(struct fid_domain *domain, struct fid *fid,
+			uint64_t flags);
+int wrap_fi_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
+		    struct fid_cq **cq, void *context);
+int wrap_fi_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
+		      struct fid_cntr **cntr, void *context);
+int wrap_fi_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
+		      struct fid_wait **waitset);
+int wrap_fi_poll_open(struct fid_domain *domain, struct fi_poll_attr *attr,
+		      struct fid_poll **pollset);
+int wrap_fi_mr_reg(struct fid_domain *domain, const void *buf, size_t len,
+		   uint64_t acs, uint64_t offset, uint64_t requested_key,
+		   uint64_t flags, struct fid_mr **mr, void *context);
+int wrap_fi_mr_regv(struct fid_domain *domain, const struct iovec *iov,
+		    size_t count, uint64_t acs, uint64_t offset,
+		    uint64_t requested_key, uint64_t flags, struct fid_mr **mr,
+		    void *context);
+int wrap_fi_mr_regattr(struct fid_domain *domain, const struct fi_mr_attr *attr,
+		       uint64_t flags, struct fid_mr **mr);
+void *wrap_fi_mr_desc(struct fid_mr *mr);
+uint64_t wrap_fi_mr_key(struct fid_mr *mr);
+int wrap_fi_mr_raw_attr(struct fid_mr *mr, uint64_t *base_addr,
+			uint8_t *raw_key, size_t *key_size, uint64_t flags);
+int wrap_fi_mr_map_raw(struct fid_domain *domain, uint64_t base_addr,
+		       uint8_t *raw_key, size_t key_size, uint64_t *key,
+		       uint64_t flags);
+int wrap_fi_mr_unmap_key(struct fid_domain *domain, uint64_t key);
+int wrap_fi_mr_bind(struct fid_mr *mr, struct fid *bfid, uint64_t flags);
+int wrap_fi_mr_refresh(struct fid_mr *mr, const struct iovec *iov, size_t count,
+		       uint64_t flags);
+int wrap_fi_mr_enable(struct fid_mr *mr);
+int wrap_fi_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
+		    struct fid_av **av, void *context);
+int wrap_fi_av_bind(struct fid_av *av, struct fid *fid, uint64_t flags);
+int wrap_fi_av_insert(struct fid_av *av, const void *addr, size_t count,
+		      fi_addr_t *fi_addr, uint64_t flags, void *context);
+int wrap_fi_av_insertsvc(struct fid_av *av, const char *node,
+			 const char *service, fi_addr_t *fi_addr,
+			 uint64_t flags, void *context);
+int wrap_fi_av_insertsym(struct fid_av *av, const char *node, size_t nodecnt,
+			 const char *service, size_t svccnt, fi_addr_t *fi_addr,
+			 uint64_t flags, void *context);
+int wrap_fi_av_remove(struct fid_av *av, fi_addr_t *fi_addr, size_t count,
+		      uint64_t flags);
+int wrap_fi_av_lookup(struct fid_av *av, fi_addr_t fi_addr, void *addr,
+		      size_t *addrlen);
+const char *wrap_fi_av_straddr(struct fid_av *av, const void *addr, char *buf,
+			       size_t *len);
+int wrap_fi_av_insert_auth_key(struct fid_av *av, const void *auth_key,
+			       size_t auth_key_size, fi_addr_t *fi_addr,
+			       uint64_t flags);
+int wrap_fi_av_lookup_auth_key(struct fid_av *av, fi_addr_t addr,
+			       void *auth_key, size_t *auth_key_size);
+int wrap_fi_av_set_user_id(struct fid_av *av, fi_addr_t fi_addr,
+			   fi_addr_t user_id, uint64_t flags);
+fi_addr_t wrap_fi_rx_addr(fi_addr_t fi_addr, int rx_index, int rx_ctx_bits);
+fi_addr_t wrap_fi_group_addr(fi_addr_t fi_addr, uint32_t group_id);
+
+/* Static inline function declarations from fi_cm.h */
+int wrap_fi_setname(fid_t fid, void *addr, size_t addrlen);
+int wrap_fi_getname(fid_t fid, void *addr, size_t *addrlen);
+int wrap_fi_getpeer(struct fid_ep *ep, void *addr, size_t *addrlen);
+int wrap_fi_listen(struct fid_pep *pep);
+int wrap_fi_connect(struct fid_ep *ep, const void *addr, const void *param,
+		    size_t paramlen);
+int wrap_fi_accept(struct fid_ep *ep, const void *param, size_t paramlen);
+int wrap_fi_reject(struct fid_pep *pep, fid_t handle, const void *param,
+		   size_t paramlen);
+int wrap_fi_shutdown(struct fid_ep *ep, uint64_t flags);
+int wrap_fi_join(struct fid_ep *ep, const void *addr, uint64_t flags,
+		 struct fid_mc **mc, void *context);
+fi_addr_t wrap_fi_mc_addr(struct fid_mc *mc);
+
+/* Static inline function declarations from fi_collective.h */
+int wrap_fi_av_set(struct fid_av *av, struct fi_av_set_attr *attr,
+		   struct fid_av_set **set, void *context);
+int wrap_fi_av_set_union(struct fid_av_set *dst, const struct fid_av_set *src);
+int wrap_fi_av_set_intersect(struct fid_av_set *dst,
+			     const struct fid_av_set *src);
+int wrap_fi_av_set_diff(struct fid_av_set *dst, const struct fid_av_set *src);
+int wrap_fi_av_set_insert(struct fid_av_set *set, fi_addr_t addr);
+int wrap_fi_av_set_remove(struct fid_av_set *set, fi_addr_t addr);
+int wrap_fi_av_set_addr(struct fid_av_set *set, fi_addr_t *coll_addr);
+int wrap_fi_join_collective(struct fid_ep *ep, fi_addr_t coll_addr,
+			    const struct fid_av_set *set, uint64_t flags,
+			    struct fid_mc **mc, void *context);
+ssize_t wrap_fi_barrier(struct fid_ep *ep, fi_addr_t coll_addr, void *context);
+ssize_t wrap_fi_barrier2(struct fid_ep *ep, fi_addr_t coll_addr, uint64_t flags,
+			 void *context);
+ssize_t wrap_fi_broadcast(struct fid_ep *ep, void *buf, size_t count,
+			  void *desc, fi_addr_t coll_addr, fi_addr_t root_addr,
+			  enum fi_datatype datatype, uint64_t flags,
+			  void *context);
+ssize_t wrap_fi_alltoall(struct fid_ep *ep, const void *buf, size_t count,
+			 void *desc, void *result, void *result_desc,
+			 fi_addr_t coll_addr, enum fi_datatype datatype,
+			 uint64_t flags, void *context);
+ssize_t wrap_fi_allreduce(struct fid_ep *ep, const void *buf, size_t count,
+			  void *desc, void *result, void *result_desc,
+			  fi_addr_t coll_addr, enum fi_datatype datatype,
+			  enum fi_op op, uint64_t flags, void *context);
+ssize_t wrap_fi_allgather(struct fid_ep *ep, const void *buf, size_t count,
+			  void *desc, void *result, void *result_desc,
+			  fi_addr_t coll_addr, enum fi_datatype datatype,
+			  uint64_t flags, void *context);
+ssize_t wrap_fi_reduce_scatter(struct fid_ep *ep, const void *buf, size_t count,
+			       void *desc, void *result, void *result_desc,
+			       fi_addr_t coll_addr, enum fi_datatype datatype,
+			       enum fi_op op, uint64_t flags, void *context);
+ssize_t wrap_fi_reduce(struct fid_ep *ep, const void *buf, size_t count,
+		       void *desc, void *result, void *result_desc,
+		       fi_addr_t coll_addr, fi_addr_t root_addr,
+		       enum fi_datatype datatype, enum fi_op op, uint64_t flags,
+		       void *context);
+ssize_t wrap_fi_scatter(struct fid_ep *ep, const void *buf, size_t count,
+			void *desc, void *result, void *result_desc,
+			fi_addr_t coll_addr, fi_addr_t root_addr,
+			enum fi_datatype datatype, uint64_t flags,
+			void *context);
+ssize_t wrap_fi_gather(struct fid_ep *ep, const void *buf, size_t count,
+		       void *desc, void *result, void *result_desc,
+		       fi_addr_t coll_addr, fi_addr_t root_addr,
+		       enum fi_datatype datatype, uint64_t flags,
+		       void *context);
+int wrap_fi_query_collective(struct fid_domain *domain,
+			     enum fi_collective_op coll,
+			     struct fi_collective_attr *attr, uint64_t flags);
+
+/* Static inline function declarations from fi_eq.h */
+int wrap_fi_trywait(struct fid_fabric *fabric, struct fid **fids, int count);
+int wrap_fi_wait(struct fid_wait *waitset, int timeout);
+int wrap_fi_poll(struct fid_poll *pollset, void **context, int count);
+int wrap_fi_poll_add(struct fid_poll *pollset, struct fid *event_fid,
+		     uint64_t flags);
+int wrap_fi_poll_del(struct fid_poll *pollset, struct fid *event_fid,
+		     uint64_t flags);
+int wrap_fi_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
+		    struct fid_eq **eq, void *context);
+ssize_t wrap_fi_eq_read(struct fid_eq *eq, uint32_t *event, void *buf,
+			size_t len, uint64_t flags);
+ssize_t wrap_fi_eq_readerr(struct fid_eq *eq, struct fi_eq_err_entry *buf,
+			   uint64_t flags);
+ssize_t wrap_fi_eq_write(struct fid_eq *eq, uint32_t event, const void *buf,
+			 size_t len, uint64_t flags);
+ssize_t wrap_fi_eq_sread(struct fid_eq *eq, uint32_t *event, void *buf,
+			 size_t len, int timeout, uint64_t flags);
+const char *wrap_fi_eq_strerror(struct fid_eq *eq, int prov_errno,
+				const void *err_data, char *buf, size_t len);
+ssize_t wrap_fi_cq_read(struct fid_cq *cq, void *buf, size_t count);
+ssize_t wrap_fi_cq_readfrom(struct fid_cq *cq, void *buf, size_t count,
+			    fi_addr_t *src_addr);
+ssize_t wrap_fi_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf,
+			   uint64_t flags);
+ssize_t wrap_fi_cq_sread(struct fid_cq *cq, void *buf, size_t count,
+			 const void *cond, int timeout);
+ssize_t wrap_fi_cq_sreadfrom(struct fid_cq *cq, void *buf, size_t count,
+			     fi_addr_t *src_addr, const void *cond,
+			     int timeout);
+int wrap_fi_cq_signal(struct fid_cq *cq);
+const char *wrap_fi_cq_strerror(struct fid_cq *cq, int prov_errno,
+				const void *err_data, char *buf, size_t len);
+uint64_t wrap_fi_cntr_read(struct fid_cntr *cntr);
+uint64_t wrap_fi_cntr_readerr(struct fid_cntr *cntr);
+int wrap_fi_cntr_add(struct fid_cntr *cntr, uint64_t value);
+int wrap_fi_cntr_adderr(struct fid_cntr *cntr, uint64_t value);
+int wrap_fi_cntr_set(struct fid_cntr *cntr, uint64_t value);
+int wrap_fi_cntr_seterr(struct fid_cntr *cntr, uint64_t value);
+int wrap_fi_cntr_wait(struct fid_cntr *cntr, uint64_t threshold, int timeout);
+
+/* Static inline function declarations from fi_ext.h */
+int wrap_fi_export_fid(struct fid *fid, uint64_t flags, struct fid **expfid,
+		       void *context);
+int wrap_fi_import_fid(struct fid *fid, struct fid *expfid, uint64_t flags);
+int wrap_fi_import(uint32_t version, const char *name, void *attr,
+		   size_t attr_len, uint64_t flags, struct fid *fid,
+		   void *context);
+int wrap_fi_import_log(uint32_t version, uint64_t flags,
+		       struct fid_logging *log_fid);
+
+/* Static inline function declarations from fi_ext.h */
+void wrap_fi_profile_reset(struct fid_profile *prof_fid, uint64_t flags);
+ssize_t wrap_fi_profile_query_vars(struct fid_profile *prof_fid,
+				   struct fi_profile_desc *varlist,
+				   size_t *count);
+ssize_t wrap_fi_profile_query_events(struct fid_profile *prof_fid,
+				     struct fi_profile_desc *eventlist,
+				     size_t *count);
+ssize_t wrap_fi_profile_read_u64(struct fid_profile *prof_fid, uint32_t var_id,
+				 uint64_t *data);
+int wrap_fi_profile_register_callback(
+	struct fid_profile *prof_fid, uint32_t event_id,
+	int (*callback)(struct fid_profile *prof_fid,
+			struct fi_profile_desc *event, void *param, size_t size,
+			void *context),
+	void *context);
+void wrap_fi_profile_start_reads(struct fid_profile *prof_fid, uint64_t flags);
+void wrap_fi_profile_end_reads(struct fid_profile *prof_fid, uint64_t flags);
+int wrap_fi_profile_open(struct fid *fid, uint64_t flags,
+			 struct fid_profile **prof_fid, void *context);
+int wrap_fi_profile_close(struct fid_profile *prof_fid);
+
+/* Static inline function declarations from fi_rma.h */
+ssize_t wrap_fi_read(struct fid_ep *ep, const void *buf, size_t len, void *desc,
+		     fi_addr_t src_addr, uint64_t addr, uint64_t key,
+		     void *context);
+ssize_t wrap_fi_readv(struct fid_ep *ep, const struct iovec *iov, void **desc,
+		      size_t count, fi_addr_t src_addr, uint64_t addr,
+		      uint64_t key, void *context);
+ssize_t wrap_fi_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
+			uint64_t flags);
+ssize_t wrap_fi_write(struct fid_ep *ep, const void *buf, size_t len,
+		      void *desc, fi_addr_t dest_addr, uint64_t addr,
+		      uint64_t key, void *context);
+ssize_t wrap_fi_writev(struct fid_ep *ep, const struct iovec *iov, void **desc,
+		       size_t count, fi_addr_t dest_addr, uint64_t addr,
+		       uint64_t key, void *context);
+ssize_t wrap_fi_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
+			 uint64_t flags);
+ssize_t wrap_fi_inject_write(struct fid_ep *ep, const void *buf, size_t len,
+			     fi_addr_t dest_addr, uint64_t addr, uint64_t key);
+ssize_t wrap_fi_writedata(struct fid_ep *ep, const void *buf, size_t len,
+			  void *desc, uint64_t data, fi_addr_t dest_addr,
+			  uint64_t addr, uint64_t key, void *context);
+ssize_t wrap_fi_inject_writedata(struct fid_ep *ep, const void *buf, size_t len,
+				 uint64_t data, fi_addr_t dest_addr,
+				 uint64_t addr, uint64_t key);
+
+/* Static inline function declarations from fi_tagged.h */
+ssize_t wrap_fi_trecv(struct fid_ep *ep, void *buf, size_t len, void *desc,
+		      fi_addr_t src_addr, uint64_t tag, uint64_t ignore,
+		      void *context);
+ssize_t wrap_fi_trecvv(struct fid_ep *ep, const struct iovec *iov, void **desc,
+		       size_t count, fi_addr_t src_addr, uint64_t tag,
+		       uint64_t ignore, void *context);
+ssize_t wrap_fi_trecvmsg(struct fid_ep *ep, const struct fi_msg_tagged *msg,
+			 uint64_t flags);
+ssize_t wrap_fi_tsend(struct fid_ep *ep, const void *buf, size_t len,
+		      void *desc, fi_addr_t dest_addr, uint64_t tag,
+		      void *context);
+ssize_t wrap_fi_tsendv(struct fid_ep *ep, const struct iovec *iov, void **desc,
+		       size_t count, fi_addr_t dest_addr, uint64_t tag,
+		       void *context);
+ssize_t wrap_fi_tsendmsg(struct fid_ep *ep, const struct fi_msg_tagged *msg,
+			 uint64_t flags);
+ssize_t wrap_fi_tinject(struct fid_ep *ep, const void *buf, size_t len,
+			fi_addr_t dest_addr, uint64_t tag);
+ssize_t wrap_fi_tsenddata(struct fid_ep *ep, const void *buf, size_t len,
+			  void *desc, uint64_t data, fi_addr_t dest_addr,
+			  uint64_t tag, void *context);
+ssize_t wrap_fi_tinjectdata(struct fid_ep *ep, const void *buf, size_t len,
+			    uint64_t data, fi_addr_t dest_addr, uint64_t tag);
+
+#endif /* __WRAPPER_H */


### PR DESCRIPTION
### Motivation
Increasing number of HPC networking code is being written in Rust. Naturally, to support Libfabric usage in Rust, there needs a proper Rust library that wraps Libfabric APIs written in C. This practice is commonly referred as a Rust binding / FFI (foreign function interface).

This library builds a lightweight Rust binding via bindgen. Lightweight, meaning there's no additional abstraction on top of the automaticallhy generated code via bindgen, aside from the `wrapper.c/h` which is strictly used to support `static inline` functions to be properly binded, by introducing a new translation unit upon compilation.

### Build
```
// Clean the existing build.
cargo clean

// Build, using the Libfabric binary that is compiled on-the-fly.
cargo build --features vendored

// Build, using the already installed Libfabric.
// You may be required to set `PKG_CONFIG_PATH` env variable to point towards `libfabric.pkg` file.
cargo build

// Unit-tests.
cargo test

// Unit-tests with ASAN enabled.
cargo test --features asan
```

### How to use the library

Add the crate dependency under your Rust application's `Cargo.toml` file. Then;

```rust
use bindings as ffi;

fn test_get_info() {
    unsafe {
        // Configure hints.
        let hints = ffi::fi_allocinfo();
        assert_eq!(hints.is_null(), false);

        (*hints).caps = ffi::FI_MSG as u64;
        (*hints).mode = ff::FI_CONTEXT;
        (*(*hints).ep_attr).type_ = ffi::fi_ep_type_FI_EP_RDM;
        (*(*hints).domain_attr).mr_mode = ffi::FI_MR_LOCAL as i32;
        let prov_name = CString::new("efa").unwrap();
        (*(*hints).fabric_attr).prov_name = prov_name.into_raw() as *mut i8;

        // Get Fabric info based on the hints.
        let mut info_ptr = ptr::null_mut();
        let version = ffi::fi_version();
        let ret = ffi::fi_getinfo(
            version,
            ptr::null_mut(),
            ptr::null_mut(),
            0,
            hints,
            &mut info_ptr,
        );

        assert_eq!(ret, 0);

        // Free the info structure returned by fi_getinfo.
        if !info_ptr.is_null() {
            ffi::fi_freeinfo(info_ptr);
        }

        // Free the hints structure we allocated.
        ffi::fi_freeinfo(hints);
    }
}
```

### Files
- `build.rs`: The actual build script for the bindgen.
- `src/lib.rs`: The generated binding is copy-pasted programmatically and publicly exported under `bindings` namespace.
- `wrapper.c/h`: Wrapper source files that simply calls the static inline functions. This way, an isolated translation unit for each static inline function is made, for which the Rust bindgen is able to link against it.
- `tests/unit_test.rs`: Unit tests.