### PR TITLE
prov/efa: Decrement rx_pkts_posted before efa_rdm_pke_release_rx

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_cq.c
+++ b/prov/efa/src/rdm/efa_rdm_cq.c
@@ -620,6 +620,13 @@ enum ibv_wc_status efa_rdm_cq_process_wc_closing_ep(struct efa_ibv_cq *cq, struc
 			break;
 		case IBV_WC_RECV: /* fall through */
 		case IBV_WC_RECV_RDMA_WITH_IMM:
+			if (pkt_entry->alloc_type == EFA_RDM_PKE_FROM_USER_RX_POOL) {
+				assert(ep->user_rx_pkts_posted > 0);
+				ep->user_rx_pkts_posted--;
+			} else {
+				assert(ep->efa_rx_pkts_posted > 0);
+				ep->efa_rx_pkts_posted--;
+			}
 			efa_rdm_pke_release_rx(pkt_entry);
 			break;
 		default:


### PR DESCRIPTION
We need to decrement rx_pkts_posted when getting a recv completion before efa_rdm_pke_release_rx increments the efa_rx_pkts_to_post so that the assertion `ep->efa_rx_pkts_to_post + ep->efa_rx_pkts_posted
+ ep->efa_rx_pkts_held == efa_rdm_ep_get_rx_pool_size(ep)' holds.