### PR TITLE
fabtests/efa: Initialize timespec as 0

### DIFF
--- a/fabtests/prov/efa/src/multi_ep_mt.c
+++ b/fabtests/prov/efa/src/multi_ep_mt.c
@@ -203,7 +203,7 @@ static void *post_sends(void *context)
 	size_t len;
 	// the range of the sleep time (in nanoseconds)
 	int sleep_time;
-	struct timespec ts;
+	struct timespec ts = {0};
 	int num_transient_eps = 10;
 
 	srand(time(NULL));


### PR DESCRIPTION
The current ts is not zeroed during definition,
which caused uninitialized ts.tv_sec that will
cause underministic behavior of nanosleep.

This patch fixes it