### PR TITLE
fabtests/prov/efa: Finalize the EP for RNR queue resend test

### DIFF
--- a/fabtests/prov/efa/src/rdm_rnr_queue_resend.c
+++ b/fabtests/prov/efa/src/rdm_rnr_queue_resend.c
@@ -347,6 +347,7 @@ static int run(int req_pkt, enum fi_op atomic_op)
 	}
 
 out:
+	ft_finalize();
 	free_atomic_res();
 	ft_free_res();
 	return ret;


### PR DESCRIPTION
Otherwise, a race condition can cause either the client or server to hang without invoking the EP close procedure.