### PR TITLE
prov/util: configure control_progress with the user provided progress mode

### DIFF
--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -1264,8 +1264,10 @@ static void fi_alter_domain_attr(struct fi_domain_attr *attr,
 
 	if (hints->threading)
 		attr->threading = hints->threading;
-	if (hints->progress)
+	if (hints->progress) {
 		attr->progress = hints->progress;
+		attr->control_progress = hints->progress;
+	}
 	if (hints->av_type)
 		attr->av_type = hints->av_type;
 	if (hints->max_ep_auth_key)


### PR DESCRIPTION
Domain control_progress attribute was added earlier to provide a lockless statemachine in libfabric with FI_THREAD_DOMAIN threading and FI_PROGRESS_CONTROL_UNIFIED control_progress mode. However there was no way for a user to provide the required control_progress attribute. This patch is adding the support for allowing user to override the control_progress along with the other domain attributes.