### PR TITLE
prov/util: configure domain `control_progress` with user provided `progress` hint

### DIFF
--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -1264,8 +1264,10 @@ static void fi_alter_domain_attr(struct fi_domain_attr *attr,
 
 	if (hints->threading)
 		attr->threading = hints->threading;
-	if (hints->progress)
+	if (hints->progress) {
 		attr->progress = hints->progress;
+		attr->control_progress = hints->progress;
+	}
 	if (hints->av_type)
 		attr->av_type = hints->av_type;
 	if (hints->max_ep_auth_key)


### PR DESCRIPTION
EFA provider supports lockless statemachine when threading=`FI_THREAD_DOMAIN` and control_progress=`FI_PROGRESS_CONTROL_UNIFIED`. However neither the progress nor the control_progress from user hints were propogated to domain `control_progress` attribute and hence there was no way to enable the lockless state from user. This patch is updating the domain control_progress attribute with the user progress hints.

This is the resubmit of https://github.com/ofiwg/libfabric/pull/11380