### PR TITLE
prov/opx: fix compilation error

### DIFF
--- a/prov/opx/include/rdma/opx/opx_debug.h
+++ b/prov/opx/include/rdma/opx/opx_debug.h
@@ -44,7 +44,7 @@ struct opx_debug_ep_entry {
 };
 
 void opx_debug_ep_list_append(void *opx_ep);
-void opx_debug_ep_list_free();
+void opx_debug_ep_list_free(void *opx_ep);
 void opx_debug_install_handler();
 
 #endif


### PR DESCRIPTION
Commit 4c73112f0acb added a call to opx_debug_ep_list_free with arguments while it takes none. This triggers the following compilation error with GCC15 (comes with std=gnu23 as default): prov/opx/src/opx_debug.c:411:6: error: conflicting types for 'opx_debug_ep_list_free'; have 'void(void *)'
  411 | void opx_debug_ep_list_free(void *opx_ep)
      |      ^~~~~~~~~~~~~~~~~~~~~~
In file included from prov/opx/src/opx_debug.c:40:
./prov/opx/include/rdma/opx/opx_debug.h:47:6: note: previous declaration of 'opx_debug_ep_list_free' with type 'void(void)'
   47 | void opx_debug_ep_list_free();
      |      ^~~~~~~~~~~~~~~~~~~~~~

Remove the unneed argument to solve the issue.

Fixes: 4c73112f0acb ("prov/opx: Add debug dump of endpoint upon receiving SIGUSR2")