### PR TITLE
prov/efa: Add unit-tests for lock types

### DIFF
--- a/prov/efa/test/efa_unit_test_cq.c
+++ b/prov/efa/test/efa_unit_test_cq.c
@@ -1837,3 +1837,40 @@ void test_efa_cq_control_invalid_command(struct efa_resource **state)
 	ret = fi_control(&resource->cq->fid, 999 /* invalid command */, &dummy_arg);
 	assert_int_equal(ret, -FI_ENOSYS);
 }
+
+/**
+ * @brief Verify CQ ep_list_lock uses no-op locking with FI_THREAD_COMPLETION and FI_PROGRESS_CONTROL_UNIFIED
+ *
+ * @param[in] state struct efa_resource managed by the framework
+ */
+void test_efa_cq_ep_list_lock_type_no_op(struct efa_resource **state)
+{
+	struct efa_resource *resource = *state;
+	struct efa_cq *efa_cq;
+	resource->hints = efa_unit_test_alloc_hints(FI_EP_RDM, EFA_DIRECT_FABRIC_NAME);
+	assert_non_null(resource->hints);
+	resource->hints->domain_attr->progress = FI_PROGRESS_CONTROL_UNIFIED;
+	resource->hints->domain_attr->threading = FI_THREAD_COMPLETION;
+	efa_unit_test_resource_construct_with_hints(resource, FI_EP_RDM, FI_VERSION(2, 0), resource->hints, false, true);
+
+	efa_cq = container_of(resource->cq, struct efa_cq, util_cq.cq_fid.fid);
+	assert_int_equal(efa_cq->util_cq.ep_list_lock.lock_type, OFI_LOCK_NOOP);
+}
+
+/**
+ * @brief Verify CQ ep_list_lock uses mutex locking with FI_THREAD_SAFE
+ *
+ * @param[in] state struct efa_resource managed by the framework
+ */
+void test_efa_cq_ep_list_lock_type_mutex(struct efa_resource **state)
+{
+	struct efa_resource *resource = *state;
+	struct efa_cq *efa_cq;
+	resource->hints = efa_unit_test_alloc_hints(FI_EP_RDM, EFA_DIRECT_FABRIC_NAME);
+	assert_non_null(resource->hints);
+	resource->hints->domain_attr->threading = FI_THREAD_SAFE;
+	efa_unit_test_resource_construct_with_hints(resource, FI_EP_RDM, FI_VERSION(2, 0), resource->hints, false, true);
+
+	efa_cq = container_of(resource->cq, struct efa_cq, util_cq.cq_fid.fid);
+	assert_int_equal(efa_cq->util_cq.ep_list_lock.lock_type, OFI_LOCK_MUTEX);
+}

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -1826,3 +1826,39 @@ void test_efa_rdm_ep_data_path_direct_disabled(struct efa_resource **state)
 
 	assert_false(efa_ep->qp->data_path_direct_enabled);
 }
+
+/**
+ * @brief Verify endpoint lock uses no-op locking with FI_THREAD_COMPLETION
+ *
+ * @param[in] state struct efa_resource managed by the framework
+ */
+void test_efa_ep_lock_type_no_op(struct efa_resource **state)
+{
+	struct efa_resource *resource = *state;
+	struct efa_base_ep *efa_base_ep;
+	resource->hints = efa_unit_test_alloc_hints(FI_EP_RDM, EFA_DIRECT_FABRIC_NAME);
+	assert_non_null(resource->hints);
+	resource->hints->domain_attr->threading = FI_THREAD_COMPLETION;
+	efa_unit_test_resource_construct_with_hints(resource, FI_EP_RDM, FI_VERSION(2, 0), resource->hints, false, true);
+
+	efa_base_ep = container_of(resource->ep, struct efa_base_ep, util_ep.ep_fid);
+	assert_int_equal(efa_base_ep->util_ep.lock.lock_type, OFI_LOCK_NOOP);
+}
+
+/**
+ * @brief Verify endpoint lock uses mutex locking with FI_THREAD_SAFE
+ *
+ * @param[in] state struct efa_resource managed by the framework
+ */
+void test_efa_ep_lock_type_mutex(struct efa_resource **state)
+{
+	struct efa_resource *resource = *state;
+	struct efa_base_ep *efa_base_ep;
+	resource->hints = efa_unit_test_alloc_hints(FI_EP_RDM, EFA_DIRECT_FABRIC_NAME);
+	assert_non_null(resource->hints);
+	resource->hints->domain_attr->threading = FI_THREAD_SAFE;
+	efa_unit_test_resource_construct_with_hints(resource, FI_EP_RDM, FI_VERSION(2, 0), resource->hints, false, true);
+
+	efa_base_ep = container_of(resource->ep, struct efa_base_ep, util_ep.ep_fid);
+	assert_int_equal(efa_base_ep->util_ep.lock.lock_type, OFI_LOCK_MUTEX);
+}

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -191,6 +191,8 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_ep_data_path_direct_equal_to_cq_data_path_direct_happy, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_ep_data_path_direct_equal_to_cq_data_path_direct_unhappy, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ep_data_path_direct_disabled, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_ep_lock_type_no_op, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_ep_lock_type_mutex, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 
 		/* begin efa_unit_test_cq.c */
 		cmocka_unit_test_setup_teardown(test_dgram_cq_read_empty_cq, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
@@ -388,6 +390,8 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_cq_control_getwait_no_channel, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_cq_control_getwaitobj, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_cq_control_invalid_command, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_cq_ep_list_lock_type_no_op, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_cq_ep_list_lock_type_mutex, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_ep_open, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_ep_cancel, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_ep_getopt, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -357,6 +357,8 @@ void test_efa_cq_control_getwait_with_channel();
 void test_efa_cq_control_getwait_no_channel();
 void test_efa_cq_control_getwaitobj();
 void test_efa_cq_control_invalid_command();
+void test_efa_cq_ep_list_lock_type_no_op();
+void test_efa_cq_ep_list_lock_type_mutex();
 
 void test_efa_ep_open();
 void test_efa_ep_cancel();
@@ -369,6 +371,8 @@ void test_efa_ep_bind_and_enable();
 void test_efa_ep_data_path_direct_equal_to_cq_data_path_direct_happy();
 void test_efa_ep_data_path_direct_equal_to_cq_data_path_direct_unhappy();
 void test_efa_rdm_ep_data_path_direct_disabled();
+void test_efa_ep_lock_type_no_op();
+void test_efa_ep_lock_type_mutex();
 
 
 void test_efa_cntr_ibv_cq_poll_list_same_tx_rx_cq_single_ep();


### PR DESCRIPTION
This is a follow up for the fix in

https://github.com/ofiwg/libfabric/commit/396cd4a38b680d0083536d85c3edae794316a97e