### PR TITLE
[v2.3.x] prov/util: configure `control_progress` with the user provid…

### DIFF
--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -1264,8 +1264,10 @@ static void fi_alter_domain_attr(struct fi_domain_attr *attr,
 
 	if (hints->threading)
 		attr->threading = hints->threading;
-	if (hints->progress)
+	if (hints->progress) {
 		attr->progress = hints->progress;
+		attr->control_progress = hints->progress;
+	}
 	if (hints->av_type)
 		attr->av_type = hints->av_type;
 	if (hints->max_ep_auth_key)


### PR DESCRIPTION
backport https://github.com/ofiwg/libfabric/pull/11380