### PR TITLE
[v2.3.x]prov/efa: Rename efadv_cq_attr db to doorbell

### DIFF
--- a/prov/efa/configure.m4
+++ b/prov/efa/configure.m4
@@ -189,7 +189,7 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 			[have_efadv_query_cq=0],
 			[[#include <infiniband/efadv.h>]])
 
-		AC_CHECK_MEMBER([struct efadv_cq_attr.db],
+		AC_CHECK_MEMBER([struct efadv_cq_attr.doorbell],
 			[have_efadv_cq_attr_db=1],
 			[have_efadv_cq_attr_db=0],
 			[[#include <infiniband/efadv.h>]])
@@ -247,7 +247,7 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 		[Indicates if efadv_query_cq is available])
 	AC_DEFINE_UNQUOTED([HAVE_EFADV_CQ_ATTR_DB],
 		[$have_efadv_cq_attr_db],
-		[Indicates if efadv_cq_attr struct has db field])
+		[Indicates if efadv_cq_attr struct has doorbell field])
 	AS_IF([test "$have_efadv_query_qp_wqs" = "1" -a "$have_efadv_query_cq" = "1"],
 		[have_efa_data_path_direct=1],
 		[have_efa_data_path_direct=0])

--- a/prov/efa/src/efa_data_path_direct.c
+++ b/prov/efa/src/efa_data_path_direct.c
@@ -195,7 +195,7 @@ int efa_data_path_direct_cq_initialize(struct efa_cq *efa_cq)
 	data_path_direct->entry_size = attr.entry_size;   /* Size of each CQ entry */
 	data_path_direct->num_entries = attr.num_entries; /* Total number of entries */
 #if HAVE_EFADV_CQ_ATTR_DB
-	data_path_direct->db = attr.db;
+	data_path_direct->db = attr.doorbell;
 #else
 	data_path_direct->db = NULL;
 #endif


### PR DESCRIPTION
Make the name up to date with rdma core.


(cherry picked from commit fd6348c4a08eecf254445050be6e3d9a0010d246)