### PR TITLE
[v2.3.x] Backport implicit AV and efa-direct CQ size changes

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -81,7 +81,8 @@
 #define EFA_DEF_POOL_ALIGNMENT (8)
 #define EFA_MEM_ALIGNMENT (64)
 
-#define EFA_DEF_CQ_SIZE 1024
+/* 4k tx_attr.size + 8k rx_attr.size */
+#define EFA_DEF_CQ_SIZE 12288
 
 
 #define EFA_DEFAULT_RUNT_SIZE (307200)

--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -561,6 +561,11 @@ static inline int efa_av_implicit_av_lru_insert(struct efa_av *av,
 	struct efa_ep_addr_hashable *ep_addr_hashable;
 	struct efa_conn *conn_to_release;
 
+	/* Implicit AV size of 0 means we allow the implicit AV to grow without
+	 * bound */
+	if (av->implicit_av_size == 0)
+		goto out;
+
 	cur_size = HASH_CNT(hh, av->util_av_implicit.hash);
 	if (cur_size <= av->implicit_av_size)
 		goto out;
@@ -603,7 +608,8 @@ out:
 void efa_av_implicit_av_lru_move(struct efa_av *av,
 					struct efa_conn *conn)
 {
-	assert(HASH_CNT(hh, av->util_av_implicit.hash) <= av->implicit_av_size);
+	assert(av->implicit_av_size == 0 ||
+	       HASH_CNT(hh, av->util_av_implicit.hash) <= av->implicit_av_size);
 	assert(dlist_entry_in_list(&av->implicit_av_lru_list,
 				   &conn->implicit_av_lru_entry));
 

--- a/prov/efa/src/efa_env.c
+++ b/prov/efa/src/efa_env.c
@@ -40,7 +40,7 @@ struct efa_env efa_env = {
 	.use_unsolicited_write_recv = 1,
 	.internal_rx_refill_threshold = 8,
 	.use_data_path_direct = true,
-	.implicit_av_size = 1024,
+	.implicit_av_size = 0,
 };
 
 /* @brief Read and store the FI_EFA_* environment variables.
@@ -228,7 +228,10 @@ void efa_env_define()
 	fi_param_define(&efa_prov, "implicit_av_size", FI_PARAM_SIZE_T,
 			"The maximum size of the implicit AV used to store AV "
 			"entries of peers that were not explicitly inserted "
-			"into the AV by the application",
+			"into the AV by the application. Setting this variable "
+			"to a positive value will enforce the the maximum "
+			"size. Setting this value to 0 will allow unbounded "
+			"growth of the implicit AV. (Default: 0)",
 			efa_env.implicit_av_size);
 }
 

--- a/prov/efa/src/efa_env.h
+++ b/prov/efa/src/efa_env.h
@@ -71,7 +71,8 @@ struct efa_env {
 	int use_data_path_direct;
 	/**
 	 * The maximum size of the implicit AV used to store AV entries of peers
-	 * that were not explicitly inserted into the AV by the application
+	 * that were not explicitly inserted into the AV by the application.
+	 * Value of 0 means there is no limit on the size.
 	 */
 	size_t implicit_av_size;
 };

--- a/prov/efa/src/rdm/efa_rdm_cq.c
+++ b/prov/efa/src/rdm/efa_rdm_cq.c
@@ -247,7 +247,6 @@ efa_rdm_cq_lookup_raw_addr(struct efa_rdm_pke *pke,
 {
 	struct efa_rdm_ep *ep;
 	fi_addr_t addr;
-	union ibv_gid gid = {0};
 	struct efa_rdm_peer *peer = NULL;
 	bool implicit = false;
 	char gid_str_cdesc[INET6_ADDRSTRLEN];
@@ -278,7 +277,7 @@ efa_rdm_cq_lookup_raw_addr(struct efa_rdm_pke *pke,
 	return NULL;
 
 out:
-	inet_ntop(AF_INET6, gid.raw, gid_str_cdesc, INET6_ADDRSTRLEN);
+	inet_ntop(AF_INET6, efa_ep_addr->raw, gid_str_cdesc, INET6_ADDRSTRLEN);
 	EFA_WARN(FI_LOG_AV,
 		 "Recovered fi_addr for peer:[QPN]:[QKey] = "
 		 "[%s]:[%" PRIu16 "]:[%" PRIu32 "] fi_addr: %" PRIu64


### PR DESCRIPTION
Backport of https://github.com/ofiwg/libfabric/pull/11369, https://github.com/ofiwg/libfabric/pull/11337 and https://github.com/ofiwg/libfabric/pull/11401