### PR TITLE
prov/cxi: Fix use of hw_cps and memory leak

### DIFF
--- a/prov/cxi/include/cxip.h
+++ b/prov/cxi/include/cxip.h
@@ -708,6 +708,7 @@ union cxip_match_bits {
 #define CXI_PLATFORM_Z1 2
 #define CXI_PLATFORM_FPGA 3
 
+#define MAX_HW_CPS 16
 /*
  * CXI Device wrapper
  *
@@ -752,7 +753,7 @@ struct cxip_lni {
 	struct cxil_lni *lni;
 
 	/* Hardware communication profiles */
-	struct cxi_cp *hw_cps[16];
+	struct cxi_cp *hw_cps[MAX_HW_CPS];
 	int n_cps;
 
 	/* Software remapped communication profiles. */

--- a/prov/cxi/src/cxip_cmdq.c
+++ b/prov/cxi/src/cxip_cmdq.c
@@ -75,6 +75,12 @@ static int cxip_cp_get(struct cxip_lni *lni, uint16_t vni,
 	if (ret == FI_SUCCESS)
 		goto success_unlock;
 
+	if (lni->n_cps >= MAX_HW_CPS) {
+		CXIP_WARN("No room to allocate CP for VNI:%u\n", vni);
+		ret = -FI_ENOSPC;
+		goto err_unlock;
+	}
+
 	/* Allocate a new SW remapped CP entry and attempt to allocate the
 	 * user requested HW CP.
 	 */
@@ -211,7 +217,7 @@ int cxip_cmdq_alloc(struct cxip_lni *lni, struct cxi_eq *evtq,
 		ret = cxip_cp_get(lni, vni, tc, tc_type, &cp);
 		if (ret != FI_SUCCESS) {
 			CXIP_WARN("Failed to allocate CP: %d\n", ret);
-			return ret;
+			goto free_cmdq;
 		}
 		cq_opts->lcid = cp->lcid;
 


### PR DESCRIPTION
Check size of lni->hw_cps array before adding more entries 
Fix cxip_cmdq_alloc failure memory leak