### PR TITLE
prov/cxi: Support auth_key ranges

### DIFF
--- a/prov/cxi/configure.m4
+++ b/prov/cxi/configure.m4
@@ -122,6 +122,25 @@ AC_DEFUN([FI_CXI_CONFIGURE],[
 				[],
 				[cxi_happy=0])
 
+			#Set CPPFLAGS to allow correct include path to be used by AC_CHECK_DECL()
+			cxi_configure_save_CPPFLAGS=$CPPFLAGS
+			CPPFLAGS="-I$cxi_PREFIX/include $cxi_configure_save_CPPFLAGS"
+
+			AC_CHECK_DECL([cxil_modify_cp],
+				[AC_DEFINE([CXI_HAVE_MODIFY_CP],[1],
+					[Whether libcxi.h has cxil_modify_cp() support])],
+				[],
+				[#include "libcxi/libcxi.h"]
+			)
+
+			AC_CHECK_DECL([cxil_svc_get_vni_range],
+				[AC_DEFINE([CXI_HAVE_SVC_GET_VNI_RANGE],[1],
+				    [Whether libcxi.h has cxil_svc_get_vni_range() support])],
+				[],
+				[#include "libcxi/libcxi.h"]
+			)
+
+			CPPFLAGS=$cxi_configure_save_CPPFLAGS
 			cxi_CPPFLAGS="$cxi_CPPFLAGS $libcurl_CPPFLAGS"
 			cxi_LDFLAGS="$cxi_LDFLAGS $libcurl_LDFLAGS"
 			# check to see if we are dynamically linking the curl symbols

--- a/prov/cxi/include/cxip.h
+++ b/prov/cxi/include/cxip.h
@@ -3204,6 +3204,8 @@ enum cxi_traffic_class cxip_ofi_to_cxi_tc(uint32_t ofi_tclass);
 int cxip_cmdq_cp_set(struct cxip_cmdq *cmdq, uint16_t vni,
 		     enum cxi_traffic_class tc,
 		     enum cxi_traffic_class_type tc_type);
+int cxip_cmdq_cp_modify(struct cxip_cmdq *cmdq, uint16_t vni,
+			enum cxi_traffic_class tc);
 void cxip_if_init(void);
 void cxip_if_fini(void);
 

--- a/prov/cxi/src/cxip_cmdq.c
+++ b/prov/cxi/src/cxip_cmdq.c
@@ -187,6 +187,48 @@ int cxip_cmdq_cp_set(struct cxip_cmdq *cmdq, uint16_t vni,
 	return ret;
 }
 
+int cxip_cmdq_cp_modify(struct cxip_cmdq *cmdq, uint16_t vni,
+			enum cxi_traffic_class tc)
+{
+	int ret;
+#if defined(CXI_HAVE_MODIFY_CP)
+	int i;
+	struct cxi_cp *hw_cp = NULL;
+	struct cxip_lni *lni = cmdq->lni;
+
+	pthread_rwlock_wrlock(&lni->cp_lock);
+
+	/* find the hw CP that matches the sw CP */
+	for (i = 0; i < lni->n_cps; i++) {
+		if (lni->hw_cps[i]->vni == cmdq->cur_cp->vni_pcp  &&
+		    lni->hw_cps[i]->tc == cmdq->cur_cp->tc &&
+		    lni->hw_cps[i]->tc_type == cmdq->cur_cp->tc_type) {
+			hw_cp = lni->hw_cps[i];
+			break;
+		}
+	}
+
+	if (hw_cp) {
+		ret = cxil_modify_cp(cmdq->lni->lni, hw_cp, vni);
+		if (!ret) {
+			hw_cp->vni_pcp = vni;
+			cmdq->cur_cp->vni_pcp = vni;
+			pthread_rwlock_unlock(&lni->cp_lock);
+
+			return FI_SUCCESS;
+		}
+	}
+
+	pthread_rwlock_unlock(&lni->cp_lock);
+#endif /* CXI_HAVE_MODIFY_CP */
+
+	ret = cxip_cmdq_cp_set(cmdq, vni, tc, CXI_TC_TYPE_DEFAULT);
+	if (ret)
+		CXIP_WARN("Failed to change communication profile: %d\n", ret);
+
+	return ret;
+}
+
 /*
  * cxip_cmdq_alloc() - Allocate a command queue.
  */

--- a/prov/cxi/src/cxip_dom.c
+++ b/prov/cxi/src/cxip_dom.c
@@ -111,13 +111,7 @@ static int cxip_domain_find_cmdq(struct cxip_domain *dom,
 	dlist_foreach_container(&dom->cmdq_list, struct cxip_domain_cmdq, cmdq,
 				entry) {
 		if (cxip_cmdq_empty(cmdq->cmdq)) {
-
-			/* TODO: This needs to use new direct CP profile feature
-			 * which disables sharing of communication profile
-			 * across TX command queues.
-			 */
-			ret = cxip_cmdq_cp_set(cmdq->cmdq, vni, tc,
-					       CXI_TC_TYPE_DEFAULT);
+			ret = cxip_cmdq_cp_modify(cmdq->cmdq, vni, tc);
 			if (ret) {
 				CXIP_WARN("Failed to change communication profile: %d\n",
 					  ret);
@@ -433,7 +427,7 @@ void cxip_domain_prov_mr_id_free(struct cxip_domain *dom,
 static int cxip_domain_enable(struct cxip_domain *dom)
 {
 	int ret = FI_SUCCESS;
-	struct cxi_svc_desc svc_desc;
+	struct cxi_svc_desc svc_desc = {};
 
 	ofi_spin_lock(&dom->lock);
 
@@ -458,11 +452,6 @@ static int cxip_domain_enable(struct cxip_domain *dom)
 
 	if (!svc_desc.restricted_members)
 		CXIP_WARN("Security Issue: Using unrestricted service ID %d for %s. "
-			  "Please provide a service ID via auth_key fields.\n",
-			  dom->auth_key.svc_id,
-			  dom->iface->dev->info.device_name);
-	if (!svc_desc.restricted_vnis)
-		CXIP_WARN("Security Issue: Using service ID %d with unrestricted VNI access %s. "
 			  "Please provide a service ID via auth_key fields.\n",
 			  dom->auth_key.svc_id,
 			  dom->iface->dev->info.device_name);

--- a/prov/cxi/src/cxip_info.c
+++ b/prov/cxi/src/cxip_info.c
@@ -21,6 +21,12 @@ struct fi_fabric_attr cxip_fabric_attr = {
 	.name = cxip_prov_name,
 };
 
+#ifdef CXI_HAVE_SVC_GET_VNI_RANGE
+#define MAX_VNIS (32768)
+#else
+#define MAX_VNIS (4)
+#endif
+
 /* No ODP, provider specified MR keys */
 struct fi_domain_attr cxip_prov_key_domain_attr = {
 	.name = NULL,
@@ -155,7 +161,7 @@ struct fi_domain_attr cxip_prov_key_multi_auth_key_domain_attr = {
 	.auth_key_size = sizeof(struct cxi_auth_key),
 
 	/* Set to the number of VNIs supported by a single CXI service. */
-	.max_ep_auth_key = 4,
+	.max_ep_auth_key = MAX_VNIS,
 };
 
 /* ODP, provider specified MR keys */
@@ -184,7 +190,7 @@ struct fi_domain_attr cxip_odp_prov_key_multi_auth_key_domain_attr = {
 	.auth_key_size = sizeof(struct cxi_auth_key),
 
 	/* Set to the number of VNIs supported by a single CXI service. */
-	.max_ep_auth_key = 4,
+	.max_ep_auth_key = MAX_VNIS,
 };
 
 /* No ODP, client specified MR keys */
@@ -213,7 +219,7 @@ struct fi_domain_attr cxip_client_key_multi_auth_key_domain_attr = {
 	.auth_key_size = sizeof(struct cxi_auth_key),
 
 	/* Set to the number of VNIs supported by a single CXI service. */
-	.max_ep_auth_key = 4,
+	.max_ep_auth_key = MAX_VNIS,
 };
 
 /* ODP, client specified MR keys */
@@ -242,7 +248,7 @@ struct fi_domain_attr cxip_odp_client_key_multi_auth_key_domain_attr = {
 	.auth_key_size = sizeof(struct cxi_auth_key),
 
 	/* Set to the number of VNIs supported by a single CXI service. */
-	.max_ep_auth_key = 4,
+	.max_ep_auth_key = MAX_VNIS,
 };
 
 struct fi_ep_attr cxip_ep_attr = {

--- a/prov/cxi/src/cxip_nic.c
+++ b/prov/cxi/src/cxip_nic.c
@@ -227,7 +227,17 @@ static int cxip_nic_get_best_rgroup_vni(struct cxip_if *nic_if,
 
 		*vni = (uint16_t)desc->vnis[0];
 	} else {
-		*vni = (uint16_t)cxip_env.default_vni;
+#ifdef CXI_HAVE_SVC_GET_VNI_RANGE
+		uint16_t vni_min;
+		uint16_t vni_max;
+
+		ret = cxil_svc_get_vni_range(nic_if->dev, desc->svc_id,
+					     &vni_min, &vni_max);
+		if (!ret)
+			*vni = vni_min;
+		else
+#endif /* CXI_HAVE_SVC_GET_VNI_RANGE */
+			*vni = (uint16_t)cxip_env.default_vni;
 	}
 
 	*rgroup = desc->svc_id;

--- a/prov/cxi/src/cxip_portals_table.c
+++ b/prov/cxi/src/cxip_portals_table.c
@@ -37,7 +37,10 @@ int cxip_portals_table_alloc(struct cxip_lni *lni, uint16_t *vni,
 
 	for (i = 0; i < vni_count; i++) {
 		ret = cxil_alloc_domain(lni->lni, vni[i], pid, &table->doms[i]);
-		if (ret) {
+		if (i && ret == -EEXIST) {
+			vni_count = i;
+			break;
+		} else if (ret) {
 			CXIP_WARN("Failed to allocate CXI Domain, ret: %d\n",
 				  ret);
 			ret = -FI_ENOSPC;

--- a/prov/cxi/test/auth_key.c
+++ b/prov/cxi/test/auth_key.c
@@ -1287,7 +1287,11 @@ Test(auth_key, default_service_id_disabled)
 	cxil_close_device(dev);
 }
 
-#define DEFAULT_MAX_EP_AUTH_KEY 4
+#ifdef CXI_HAVE_SVC_GET_VNI_RANGE
+#define DEFAULT_MAX_EP_AUTH_KEY (32768)
+#else
+#define DEFAULT_MAX_EP_AUTH_KEY (4)
+#endif
 
 Test(auth_key, max_ep_auth_key_null_hints)
 {


### PR DESCRIPTION
Configuration checks for cxil_modify_cp and cxil_svc_get_vni_range 
Add checking of an auth_key against a cxi service containing a range of VNIs.
Set max_ep_auth_key to max vnis supported

Support the modification of communication profile
Support vni range when allocating cxi domains
cxil_alloc_domain returns -EEXIST for VNIs in range