### PR TITLE
Include Capacity Reservation when testing on windows instance

### DIFF
--- a/contrib/aws/Jenkinsfile
+++ b/contrib/aws/Jenkinsfile
@@ -107,7 +107,7 @@ def get_single_node_windows_test_stage_with_lock(stage_name, lock_label) {
                     . venv/bin/activate;
                     cd PortaFiducia/scripts;
                     export PULL_REQUEST_ID=${env.CHANGE_ID};
-                    env AWS_DEFAULT_REGION=us-west-2 ./test_orchestrator_windows.py --ci public --s3-bucket-name libfabric-ci-windows-prod-test-output --pull-request-id ${env.CHANGE_ID};
+                    env AWS_DEFAULT_REGION=us-west-2 ./test_orchestrator_windows.py --odcr cr-096ce0beefcc82b44 --ci public --s3-bucket-name libfabric-ci-windows-prod-test-output --pull-request-id ${env.CHANGE_ID};
                 """
             }
         }


### PR DESCRIPTION
This PR includes the change to attach an EC2 Capacity Reservation for allocating windows instance

Will flip this PR once the backend changes are deployed