### PR TITLE
prov/cxi: reset timer on rx of ARM packet

### DIFF
--- a/prov/cxi/src/cxip_coll.c
+++ b/prov/cxi/src/cxip_coll.c
@@ -54,6 +54,8 @@
 #define	MAGIC		0x677d
 #define	TIMER_UNSET	-1
 
+static inline void _set_arm_expires(struct cxip_coll_reduction *reduction);
+
 /****************************************************************************
  * Metrics for evaluating collectives
  */
@@ -1061,6 +1063,7 @@ static void _coll_rx_progress(struct cxip_req *req,
 	if (pkt->hdr.seqno == CXIP_COLL_MOD_SEQNO) {
 		TRACE_PKT("pre-rearm pkt dropped\n");
 		CXIP_INFO("pre-rearm pkt dropped\n");
+		_set_arm_expires(reduction);
 		return;
 	}
 


### PR DESCRIPTION
We were not (re)setting the timer for the "need to re-arm" logic on the leaf side. This resulted in a performance blip when the timer eventually expired. We now reset this timer as soon as the leaf sees an ARM packet.