### PR TITLE
prov/efa: Allocate cq err_buf on demand

### DIFF
--- a/prov/efa/src/efa_cq.h
+++ b/prov/efa/src/efa_cq.h
@@ -39,8 +39,9 @@ struct efa_cq {
 	ofi_atomic32_t			nevents;
 	enum fi_wait_obj		wait_obj;
 	enum fi_cq_wait_cond	wait_cond;
+	/* Only used by efa-direct cq on util cq bypass path */
 	void (*read_entry)(struct efa_ibv_cq *ibv_cq, void *buf, int opcode);
-	char err_buf[EFA_ERROR_MSG_BUFFER_LENGTH];
+	char *err_buf;
 };
 
 extern struct fi_ops_cq efa_cq_ops;


### PR DESCRIPTION
efa_cq->err_buf is only needed by efa-direct cq which can store the err data on the util cq bypass path. Make it allocated on demand during the efa-direct
cq open to save memory.