### PR TITLE
fabtests/efa: cuda dmabuf validation logic

### DIFF
--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -69,7 +69,8 @@ bin_PROGRAMS = \
 	multinode/fi_multinode_coll \
 	component/sock_test \
 	regression/sighandler_test \
-	common/check_hmem
+	common/check_hmem \
+	common/check_cuda_dmabuf
 
 if HAVE_ZE_DEVEL
 if HAVE_VERBS_DEVEL
@@ -617,6 +618,14 @@ common_check_hmem_SOURCES = \
 common_check_hmem_LDADD = libfabtests.la
 
 common_checK_hmem_CFLAGS = \
+	$(AM_CFLAGS)
+
+common_check_cuda_dmabuf_SOURCES = \
+	common/check_cuda_dmabuf.c
+
+common_check_cuda_dmabuf_LDADD = libfabtests.la
+
+common_check_cuda_dmabuf_CFLAGS = \
 	$(AM_CFLAGS)
 
 real_man_pages = \

--- a/fabtests/common/check_cuda_dmabuf.c
+++ b/fabtests/common/check_cuda_dmabuf.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024, Amazon.com, Inc.  All rights reserved.
+ *
+ * This software is available to you under the BSD license
+ * below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * This test returns whether or not dmabuf is viable and supported
+ * based on aws-ofi-nccl logic
+ *
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <getopt.h>
+#include <string.h>
+#include <shared.h>
+#include <hmem.h>
+
+static cuda_memory_support_e dmabuf_viable_and_supported( void )
+{
+	cuda_memory_support_e cuda_memory_support = ft_cuda_memory_support();
+
+	return cuda_memory_support;
+}
+
+int main(int argc, char **argv)
+{
+    int ret;
+
+    /* Make sure default CUDA device is sane for ft_cuda_init() */
+    opts = INIT_OPTS;
+    opts.device = 0;   /* cuda device 0 */
+
+    /* Initialize CUDA side only; avoid ft_init_fabric() */
+    ret = ft_cuda_init();
+    if (ret != FI_SUCCESS) {
+        FT_ERR("ft_cuda_init failed: %d", ret);
+        return CUDA_MEMORY_SUPPORT__UNKNOWN;
+    }
+
+    cuda_memory_support_e cuda_memory_support = dmabuf_viable_and_supported();
+    FT_INFO("dmabuf: ft_cuda_memory_support() -> %d", cuda_memory_support);
+
+    ft_cuda_cleanup();
+    return cuda_memory_support;
+}

--- a/fabtests/include/hmem.h
+++ b/fabtests/include/hmem.h
@@ -35,6 +35,14 @@
 #include <rdma/fi_domain.h>
 #include <rdma/fi_errno.h>
 
+typedef enum {
+	CUDA_MEMORY_SUPPORT__NOT_INITIALIZED = -1,
+    CUDA_MEMORY_SUPPORT__UNKNOWN = 0,
+    CUDA_MEMORY_SUPPORT__DMA_BUF_ONLY = 1,
+    CUDA_MEMORY_SUPPORT__P2P_ONLY= 2, 
+    CUDA_MEMORY_SUPPORT__DMA_P2P_BOTH = 3,
+} cuda_memory_support_e;
+
 #if HAVE_ZE
 #include <level_zero/ze_api.h>
 extern struct libze_ops {
@@ -185,6 +193,7 @@ int ft_cuda_copy_from_hmem(uint64_t device, void *dst, const void *src,
 int ft_cuda_get_dmabuf_fd(void *buf, size_t len,
 			  int *fd, uint64_t *offset);
 int ft_cuda_put_dmabuf_fd(int fd);
+cuda_memory_support_e ft_cuda_memory_support(void);
 
 int ft_rocr_init(void);
 int ft_rocr_cleanup(void);

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -369,8 +369,9 @@ static inline int ft_use_size(int index, int enable_flags)
 #define FT_LOG(level, fmt, ...)						\
 	do {								\
 		int saved_errno = errno;				\
-		fprintf(stderr, "[%s] fabtests:%s:%d: " fmt "\n",	\
-			level, __FILE__, __LINE__, ##__VA_ARGS__);	\
+		int64_t ns = ft_gettime_ns();				\
+		fprintf(stderr, "[%s] %lu.%06lu fabtests:%s:%d: " fmt "\n",	\
+			level, ns/1000000000UL, (ns%1000000000UL)/1000UL, __FILE__, __LINE__, ##__VA_ARGS__);	\
 		errno = saved_errno;					\
 	} while (0)
 

--- a/fabtests/pytest/efa/efa_common.py
+++ b/fabtests/pytest/efa/efa_common.py
@@ -1,8 +1,66 @@
 import os
 import subprocess
 import functools
+import pytest
+from enum import IntEnum
 from common import SshConnectionError, is_ssh_connection_error, has_ssh_connection_err_msg, ClientServerTest
 from retrying import retry
+
+
+class CudaMemorySupport(IntEnum):
+    NOT_INITIALIZED = -1
+    UNKNOWN = 0
+    DMA_BUF_ONLY = 1
+    P2P_ONLY = 2
+    DMA_P2P_BOTH = 3
+
+@retry(retry_on_exception=is_ssh_connection_error, stop_max_attempt_number=3, wait_fixed=5000)
+def get_cuda_memory_support(cmdline_args, ip):
+    """
+    Execute check_dmabuf binary to determine CUDA memory support capabilities.
+    
+    Args:
+        cmdline_args: Command line arguments containing binpath, timeout, provider, and environments.
+        ip: IP address or hostname of the target machine.
+        
+    Returns:
+        CudaMemorySupport: Enum value indicating hardware CUDA memory support type.
+        
+    Notes:
+        - Executes check_dmabuf binary remotely via SSH with timeout
+        - Maps return code directly to CudaMemorySupport enum values
+        - Returns UNKNOWN for negative return codes indicating errors
+        - Retries on SSH connection errors up to 3 times
+    """
+    binpath = cmdline_args.binpath or ""
+    cmd = "timeout " + str(cmdline_args.timeout) \
+          + " " + os.path.join(binpath, "check_cuda_dmabuf") \
+          + " -p " + cmdline_args.provider
+    if cmdline_args.environments:
+        cmd = cmdline_args.environments + " " + cmd
+    
+    proc = subprocess.run("ssh {} {}".format(ip, cmd),
+               stdout=subprocess.PIPE,
+               stderr=subprocess.STDOUT,
+               shell=True,
+               universal_newlines=True)
+    
+    if has_ssh_connection_err_msg(proc.stdout):
+        raise SshConnectionError()
+    
+    if proc.returncode < 0:
+        return CudaMemorySupport.UNKNOWN
+    
+    print(f"The ssh return is {proc}")
+    rc = proc.returncode
+    if rc not in (CudaMemorySupport.UNKNOWN,
+                  CudaMemorySupport.DMA_BUF_ONLY,
+                  CudaMemorySupport.P2P_ONLY,
+                  CudaMemorySupport.DMA_P2P_BOTH):
+        print(f"[warn] check_dmabuf returned unexpected code {rc}, treating as NOT_INITIALIZED")
+        return CudaMemorySupport.NOT_INITIALIZED
+
+    return CudaMemorySupport(rc)
 
 def efa_run_client_server_test(cmdline_args, executable, iteration_type,
                                completion_semantic, memory_type, message_size,


### PR DESCRIPTION
test: Adding cuda dmabuf validation logic

Problem:
  - Users was submitting fabtests without the --do-dmabuf-reg-for-hmem flag

Solution:
  - Added hmem cuda logic changes based on nvidia manual [https://docs.nvidia.com/cuda/gpudirect-rdma/ here]
  - Added check_dmabuf to init cuda internals and get dmabuf support information
  - Added conftest to validate these checks if a user specifies cuda command in fabtests
  - Updated fabtest logger statements to include timestamp

Testing:
  - Validated tests with --do-dmabuf-reg-for-hmem flag and without it on p6-gb200 cluster
  - All tests skipped with cuda command
  - make -j install && python3 install/bin/runfabtests.py --expression "cuda" -vvv -p /home/nmazzill/libfabric/fabtests/install/bin/ --junit-xml ft_`git branch --show-current`_`git rev-parse HEAD`_all_junit.xml --nworkers 16 -b efa 10.0.123.149 10.0.121.190 | tee ft_`git branch --show-current`_`git rev-parse HEAD`_all_stdout
  - All tests passed with this cuda command
  - make -j install && python3 install/bin/runfabtests.py --expression "cuda" --do-dmabuf-reg-for-hmem -vvv -p /home/nmazzill/libfabric/fabtests/install/bin/ --junit-xml ft_`git branch --show-current`_`git rev-parse HEAD`_all_junit.xml --nworkers 16 -b efa 10.0.123.149 10.0.121.190 | tee ft_`git branch --show-current`_`git rev-parse HEAD`_all_stdout