### PR TITLE
[v2.3.x] prov/efa: acquire the same lock for qp lifecycle

### DIFF
--- a/prov/efa/src/efa_base_ep.h
+++ b/prov/efa/src/efa_base_ep.h
@@ -151,8 +151,6 @@ void efa_base_ep_remove_cntr_ibv_cq_poll_list(struct efa_base_ep *ep);
 
 int efa_base_ep_create_and_enable_qp(struct efa_base_ep *ep, bool create_user_recv_qp);
 
-void efa_base_ep_flush_cq(struct efa_base_ep *base_ep);
-
 #if ENABLE_DEBUG
 void efa_ep_addr_print(char *prefix, struct efa_ep_addr *addr);
 #endif

--- a/prov/efa/src/efa_ep.c
+++ b/prov/efa/src/efa_ep.c
@@ -208,8 +208,6 @@ static int efa_ep_close(fid_t fid)
 		EFA_WARN(FI_LOG_EP_CTRL, "Unable to close base endpoint\n");
 	}
 
-	efa_base_ep_flush_cq(ep);
-
 	free(ep);
 
 	return 0;

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -1033,8 +1033,6 @@ static int efa_rdm_ep_close(struct fid *fid)
 		retv = ret;
 	}
 
-	efa_base_ep_flush_cq(&efa_rdm_ep->base_ep);
-
 	ret = efa_rdm_ep_close_shm_ep_resources(efa_rdm_ep);
 	if (ret)
 		retv = ret;


### PR DESCRIPTION
backport https://github.com/ofiwg/libfabric/pull/11439