### PR TITLE
fabtests/common: minor fabtest fixes

### DIFF
--- a/fabtests/benchmarks/msg_pingpong.c
+++ b/fabtests/benchmarks/msg_pingpong.c
@@ -79,6 +79,7 @@ int main(int argc, char **argv)
 	int op, ret;
 
 	opts = INIT_OPTS;
+	opts.options |= FT_OPT_NO_PREPOSTED_AUX_RX;
 
 	hints = fi_allocinfo();
 	if (!hints)

--- a/fabtests/benchmarks/rdm_bw.c
+++ b/fabtests/benchmarks/rdm_bw.c
@@ -47,6 +47,7 @@ int main(int argc, char **argv)
 
 	opts = INIT_OPTS;
 	opts.options |= FT_OPT_BW;
+	opts.options |= FT_OPT_NO_PREPOSTED_AUX_RX;
 
 	hints = fi_allocinfo();
 	if (!hints)

--- a/fabtests/benchmarks/rdm_bw_mt.c
+++ b/fabtests/benchmarks/rdm_bw_mt.c
@@ -617,6 +617,7 @@ int main(int argc, char **argv)
 
 	opts = INIT_OPTS;
 	opts.options |= FT_OPT_OOB_CTRL;
+	opts.options |= FT_OPT_NO_PREPOSTED_AUX_RX;
 
         hints = fi_allocinfo();
 	if (!hints)

--- a/fabtests/benchmarks/rdm_tagged_bw.c
+++ b/fabtests/benchmarks/rdm_tagged_bw.c
@@ -72,6 +72,7 @@ int main(int argc, char **argv)
 
 	opts = INIT_OPTS;
 	opts.options |= FT_OPT_BW;
+	opts.options |= FT_OPT_NO_PREPOSTED_AUX_RX;
 
 	hints = fi_allocinfo();
 	if (!hints)

--- a/fabtests/benchmarks/rdm_tagged_pingpong.c
+++ b/fabtests/benchmarks/rdm_tagged_pingpong.c
@@ -41,6 +41,7 @@ int main(int argc, char **argv)
 	int op, ret;
 
 	opts = INIT_OPTS;
+	opts.options |= FT_OPT_NO_PREPOSTED_AUX_RX;
 
 	hints = fi_allocinfo();
 	if (!hints)

--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -1519,8 +1519,13 @@ int ft_enable_ep_recv(void)
 	if (ret)
 		return ret;
 
-	if (!ft_check_opts(FT_OPT_SKIP_MSG_ALLOC) &&
-	    (fi->caps & (FI_MSG | FI_TAGGED))) {
+	if ((opts.options & FT_OPT_NO_PREPOSTED_AUX_RX) &&
+		(opts.options & FT_OPT_OOB_ADDR_EXCH)) {
+			return 0;
+	}
+
+	if ((!ft_check_opts(FT_OPT_SKIP_MSG_ALLOC) &&
+	    	(fi->caps & (FI_MSG | FI_TAGGED)))) {
 		/* Initial receive will get remote address for unconnected EPs */
 		ret = ft_post_rx(ep, MAX(rx_size, FT_MAX_CTRL_MSG), &rx_ctx);
 		if (ret)

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -150,6 +150,7 @@ enum {
 	FT_OPT_REG_DMABUF_MR		= 1 << 27,
 	FT_OPT_NO_PRE_POSTED_RX		= 1 << 28,
 	FT_OPT_OOB_CTRL			= FT_OPT_OOB_SYNC | FT_OPT_OOB_ADDR_EXCH,
+	FT_OPT_NO_PREPOSTED_AUX_RX = 1 << 29,
 };
 
 /* for RMA tests --- we want to be able to select fi_writedata, but there is no


### PR DESCRIPTION
Content:

1. "rocr" value is not properly handled by -D option.
2. Excessive recv prepost used for address exchange still occurs in case of out-of-band address exchange (-b/-E options).
    As soon as no corresponding send operation is issued for this scenario, preposted recv consumes one of later messages with matching tag. To reproduce issue:
    ```
   ~> fi_rdm_tagged_bw -p "tcp" -b &
   [1] 606285
   ~> fi_rdm_tagged_bw -p "tcp" -b 127.0.0.1
   ...
   [error] fabtests:common/shared.c:3046: cq_readerr 265 (Truncation error), provider errno: 11 (Resource temporarily unavailable)
   ```
   Problem is provider-agnostic.