### PR TITLE
prov/efa: Use efa_rdm_pke_release_rx_list when pke could be linked

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_cq.c
+++ b/prov/efa/src/rdm/efa_rdm_cq.c
@@ -455,7 +455,7 @@ static void efa_rdm_cq_handle_recv_completion(struct efa_ibv_cq *ibv_cq, struct 
 			", packet flags: %x\n",
 			efa_rdm_pke_get_base_hdr(pkt_entry)->type,
 			efa_rdm_pke_get_base_hdr(pkt_entry)->flags);
-		efa_rdm_pke_release_rx(pkt_entry);
+		efa_rdm_pke_release_rx_list(pkt_entry);
 		return;
 	}
 
@@ -501,7 +501,7 @@ static void efa_rdm_cq_handle_recv_completion(struct efa_ibv_cq *ibv_cq, struct 
 
 		assert(0 && "invalid REQ packet type");
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_EIO, FI_EFA_ERR_INVALID_PKT_TYPE);
-		efa_rdm_pke_release_rx(pkt_entry);
+		efa_rdm_pke_release_rx_list(pkt_entry);
 		return;
 	}
 
@@ -519,7 +519,7 @@ static void efa_rdm_cq_handle_recv_completion(struct efa_ibv_cq *ibv_cq, struct 
 		if (!efa_rdm_write_error_msg(ep, pkt_entry->peer, FI_EFA_ERR_INVALID_PKT_TYPE_ZCPY_RX, errbuf, &errbuf_len))
 			EFA_WARN(FI_LOG_CQ, "Error: %s\n", (const char *) errbuf);
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_EINVAL, FI_EFA_ERR_INVALID_PKT_TYPE_ZCPY_RX);
-		efa_rdm_pke_release_rx(pkt_entry);
+		efa_rdm_pke_release_rx_list(pkt_entry);
 		return;
 	}
 

--- a/prov/efa/src/rdm/efa_rdm_pke.c
+++ b/prov/efa/src/rdm/efa_rdm_pke.c
@@ -286,7 +286,7 @@ struct efa_rdm_pke *efa_rdm_pke_get_unexp(struct efa_rdm_pke **pkt_entry_ptr)
 		/* unexp pkt is also rx pkt, insert it to rx pkt list so we can track it and clean up during ep close */
 		dlist_insert_tail(&unexp_pkt_entry->dbg_entry, &ep->rx_pkt_list);
 #endif
-		efa_rdm_pke_release_rx(*pkt_entry_ptr);
+		efa_rdm_pke_release_rx_list(*pkt_entry_ptr);
 		*pkt_entry_ptr = unexp_pkt_entry;
 	} else {
 		unexp_pkt_entry = *pkt_entry_ptr;

--- a/prov/efa/src/rdm/efa_rdm_pke_cmd.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_cmd.c
@@ -349,7 +349,7 @@ void efa_rdm_pke_handle_data_copied(struct efa_rdm_pke *pkt_entry)
 
 	ope->bytes_copied += pkt_entry->payload_size;
 	efa_rdm_tracepoint(rx_pke_proc_matched_msg_end, (size_t) pkt_entry, pkt_entry->payload_size, ope->msg_id, (size_t) ope->cq_entry.op_context, ope->total_len);
-	efa_rdm_pke_release_rx(pkt_entry);
+	efa_rdm_pke_release_rx_list(pkt_entry);
 
 	if (ope->total_len == ope->bytes_copied) {
 		if (ope->cuda_copy_method == EFA_RDM_CUDA_COPY_BLOCKING) {
@@ -714,7 +714,7 @@ void efa_rdm_pke_handle_rx_error(struct efa_rdm_pke *pkt_entry, int prov_errno)
 			ep_addr_str);
 
 		efa_base_ep_write_eq_error(&ep->base_ep, err, prov_errno);
-		efa_rdm_pke_release_rx(pkt_entry);
+		efa_rdm_pke_release_rx_list(pkt_entry);
 		return;
 	}
 
@@ -729,7 +729,7 @@ void efa_rdm_pke_handle_rx_error(struct efa_rdm_pke *pkt_entry, int prov_errno)
 		efa_base_ep_write_eq_error(&ep->base_ep, err, prov_errno);
 	}
 
-	efa_rdm_pke_release_rx(pkt_entry);
+	efa_rdm_pke_release_rx_list(pkt_entry);
 }
 
 void efa_rdm_pke_proc_received_no_hdr(struct efa_rdm_pke *pkt_entry, bool has_imm_data, uint32_t imm_data)
@@ -860,7 +860,7 @@ void efa_rdm_pke_proc_received(struct efa_rdm_pke *pkt_entry)
 			efa_rdm_pke_get_base_hdr(pkt_entry)->type);
 		assert(0 && "invalid control pkt type");
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_EIO, FI_EFA_ERR_INVALID_PKT_TYPE);
-		efa_rdm_pke_release_rx(pkt_entry);
+		efa_rdm_pke_release_rx_list(pkt_entry);
 		return;
 	}
 }

--- a/prov/efa/src/rdm/efa_rdm_pke_rtm.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtm.c
@@ -290,7 +290,7 @@ static ssize_t efa_rdm_pke_proc_msgrtm(struct efa_rdm_pke *pkt_entry)
 			efa_base_ep_write_eq_error(
 				&ep->base_ep, FI_ENOBUFS,
 				FI_EFA_ERR_RXE_POOL_EXHAUSTED);
-			efa_rdm_pke_release_rx(pkt_entry);
+			efa_rdm_pke_release_rx_list(pkt_entry);
 			return -FI_ENOBUFS;
 		}
 	}
@@ -301,7 +301,7 @@ static ssize_t efa_rdm_pke_proc_msgrtm(struct efa_rdm_pke *pkt_entry)
 		err = efa_rdm_pke_proc_matched_rtm(pkt_entry);
 		if (OFI_UNLIKELY(err)) {
 			efa_rdm_rxe_handle_error(rxe, -err, FI_EFA_ERR_PKT_PROC_MSGRTM);
-			efa_rdm_pke_release_rx(pkt_entry);
+			efa_rdm_pke_release_rx_list(pkt_entry);
 			efa_rdm_rxe_release(rxe);
 			return err;
 		}
@@ -338,7 +338,7 @@ static ssize_t efa_rdm_pke_proc_tagrtm(struct efa_rdm_pke *pkt_entry)
 			efa_base_ep_write_eq_error(
 				&ep->base_ep, FI_ENOBUFS,
 				FI_EFA_ERR_RXE_POOL_EXHAUSTED);
-			efa_rdm_pke_release_rx(pkt_entry);
+			efa_rdm_pke_release_rx_list(pkt_entry);
 			return -FI_ENOBUFS;
 		}
 	}
@@ -351,7 +351,7 @@ static ssize_t efa_rdm_pke_proc_tagrtm(struct efa_rdm_pke *pkt_entry)
 			if (err == -FI_ENOMR)
 				return err;
 			efa_rdm_rxe_handle_error(rxe, -err, FI_EFA_ERR_PKT_PROC_TAGRTM);
-			efa_rdm_pke_release_rx(pkt_entry);
+			efa_rdm_pke_release_rx_list(pkt_entry);
 			efa_rdm_rxe_release(rxe);
 			return err;
 		}
@@ -414,7 +414,7 @@ ssize_t efa_rdm_pke_proc_rtm_rta(struct efa_rdm_pke *pkt_entry, struct efa_rdm_p
 			"Unknown packet type ID: %d\n",
 		       base_hdr->type);
 		efa_base_ep_write_eq_error(&ep->base_ep, FI_EINVAL, FI_EFA_ERR_UNKNOWN_PKT_TYPE);
-		efa_rdm_pke_release_rx(pkt_entry);
+		efa_rdm_pke_release_rx_list(pkt_entry);
 	}
 
 	return -FI_EINVAL;
@@ -480,7 +480,7 @@ void efa_rdm_pke_handle_rtm_rta_recv(struct efa_rdm_pke *pkt_entry)
 				" robuf->exp_msg_id: %" PRIu32 "\n",
 			       msg_id, peer->robuf.exp_msg_id);
 			efa_base_ep_write_eq_error(&ep->base_ep, ret, FI_EFA_ERR_PKT_ALREADY_PROCESSED);
-			efa_rdm_pke_release_rx(pkt_entry);
+			efa_rdm_pke_release_rx_list(pkt_entry);
 			return;
 		}
 
@@ -1207,7 +1207,7 @@ ssize_t efa_rdm_pke_proc_matched_longread_rtm(struct efa_rdm_pke *pkt_entry)
 
 	err = efa_rdm_pke_post_remote_read_or_nack(ep, pkt_entry, rxe);
 
-	efa_rdm_pke_release_rx(pkt_entry);
+	efa_rdm_pke_release_rx_list(pkt_entry);
 	return err;
 }
 

--- a/prov/efa/src/rdm/efa_rdm_srx.c
+++ b/prov/efa/src/rdm/efa_rdm_srx.c
@@ -76,7 +76,7 @@ static int efa_rdm_srx_start(struct fi_peer_rx_entry *peer_rxe)
 			return 0;
 		efa_rdm_rxe_handle_error(rxe, -ret,
 			rxe->op == ofi_op_msg ? FI_EFA_ERR_PKT_PROC_MSGRTM : FI_EFA_ERR_PKT_PROC_TAGRTM);
-		efa_rdm_pke_release_rx(pkt_entry);
+		efa_rdm_pke_release_rx_list(pkt_entry);
 		efa_rdm_rxe_release(rxe);
 	}
 


### PR DESCRIPTION
Replace efa_rdm_pke_release_rx() with efa_rdm_pke_release_rx_list() where packet entries could be linked in medium/runting protocol.

This ensures packets are unlinked before releasing and prevents memory leak.