### PR TITLE
prov/cxi: fix DEVICE in fi_info_test

### DIFF
--- a/prov/cxi/test/fi_info_test.sh
+++ b/prov/cxi/test/fi_info_test.sh
@@ -4,7 +4,7 @@
 SCRIPT=$(basename ${BASH_SOURCE[0]:-$0})
 FI_INFO="../../../util/fi_info"
 ENODATA=61
-DEVICE="cxi1"
+DEVICE="cxi99"
 
 usage() {
 cat <<EOF1


### PR DESCRIPTION
DEVICE is supposed to be non-existent for this test case. But many systems have multiple cxi devices, so cxi1 may exist. Update to one that definitely will not exist.