### PR TITLE
prov/efa: Take domain lock to protect concurrent access to domain fields

### DIFF
--- a/prov/efa/src/efa_user_info.c
+++ b/prov/efa/src/efa_user_info.c
@@ -616,11 +616,13 @@ int efa_get_user_info(uint32_t version, const char *node,
 			item = dlist_find_first_match(&fabric->domain_list, efa_find_domain, prov_info);
 			if (item) {
 				domain = container_of(item, struct util_domain, list_entry);
+				ofi_genlock_lock(&domain->lock);
 				dupinfo->domain_attr->domain = &domain->domain_fid;
 				EFA_INFO(FI_LOG_CORE, "Reusing open domain %s\n", domain->name);
 				domain->info_domain_caps |= dupinfo->caps | dupinfo->domain_attr->caps;
 				domain->info_domain_mode |= dupinfo->mode | dupinfo->domain_attr->mode;
 				domain->mr_mode |= dupinfo->domain_attr->mr_mode;
+				ofi_genlock_unlock(&domain->lock);
 			}
 			ofi_mutex_unlock(&fabric->lock);
 		}


### PR DESCRIPTION
Fix Data race undermines locking  (LOCK_EVASION)
The thread 1 sets "domain" to a new value. Now the two threads have an inconsistent view of "domain" and updates to fields of "domain" or fields correlated with "domain" may be lost.