### PR TITLE
prov/cxi: check cmdq_ack_counter before selecting cmdq

### DIFF
--- a/prov/cxi/include/cxip.h
+++ b/prov/cxi/include/cxip.h
@@ -3213,6 +3213,7 @@ int cxip_cmdq_cp_set(struct cxip_cmdq *cmdq, uint16_t vni,
 		     enum cxi_traffic_class_type tc_type);
 int cxip_cmdq_cp_modify(struct cxip_cmdq *cmdq, uint16_t vni,
 			enum cxi_traffic_class tc);
+bool cxip_cmdq_active(struct cxip_cmdq *cmdq);
 void cxip_if_init(void);
 void cxip_if_fini(void);
 

--- a/prov/cxi/src/cxip_cmdq.c
+++ b/prov/cxi/src/cxip_cmdq.c
@@ -193,6 +193,21 @@ int cxip_cmdq_cp_set(struct cxip_cmdq *cmdq, uint16_t vni,
 	return ret;
 }
 
+bool cxip_cmdq_active(struct cxip_cmdq *cmdq)
+{
+	int ret;
+	unsigned int ack_counter;
+
+	if (!cxip_cmdq_empty(cmdq))
+		return true;
+
+	ret = cxil_cmdq_ack_counter(cmdq->dev_cmdq, &ack_counter);
+	if (ret)
+		return true;
+
+	return !!ack_counter;
+}
+
 int cxip_cmdq_cp_modify(struct cxip_cmdq *cmdq, uint16_t vni,
 			enum cxi_traffic_class tc)
 {

--- a/prov/cxi/src/cxip_dom.c
+++ b/prov/cxi/src/cxip_dom.c
@@ -110,7 +110,7 @@ static int cxip_domain_find_cmdq(struct cxip_domain *dom,
 	 */
 	dlist_foreach_container(&dom->cmdq_list, struct cxip_domain_cmdq, cmdq,
 				entry) {
-		if (cxip_cmdq_empty(cmdq->cmdq)) {
+		if (!cxip_cmdq_active(cmdq->cmdq)) {
 			ret = cxip_cmdq_cp_modify(cmdq->cmdq, vni, tc);
 			if (ret) {
 				CXIP_WARN("Failed to change communication profile: %d\n",


### PR DESCRIPTION
When looking for an idle cmdq, besides checking if the rd and wr pointers match, also check if the cq ack counter is 0.