### PR TITLE
prov/efa: Update tracepoints in the receive path

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_msg.c
+++ b/prov/efa/src/rdm/efa_rdm_msg.c
@@ -755,6 +755,9 @@ efa_rdm_msg_alloc_rxe_for_msgrtm(struct efa_rdm_ep *ep,
 	struct efa_rdm_ope *rxe;
 	int ret;
 	int pkt_type;
+#if HAVE_LTTNG
+	struct efa_rdm_pke *orig_pke_ptr;
+#endif
 
 	peer_srx = util_get_peer_srx(ep->peer_srx_ep);
 
@@ -770,9 +773,16 @@ efa_rdm_msg_alloc_rxe_for_msgrtm(struct efa_rdm_ep *ep,
 			efa_base_ep_write_eq_error(&ep->base_ep, FI_ENOBUFS, FI_EFA_ERR_RXE_POOL_EXHAUSTED);
 			return NULL;
 		}
-		efa_rdm_tracepoint(msg_match_expected_nontagged, rxe->msg_id,
-			    (size_t) rxe->cq_entry.op_context, rxe->total_len);
+		efa_rdm_tracepoint(
+			msg_match_expected_nontagged, (uint64_t) *pkt_entry_ptr,
+			(*pkt_entry_ptr)->pkt_size, rxe->msg_id,
+			(size_t) rxe->cq_entry.op_context, rxe->total_len);
 	} else if (ret == -FI_ENOENT) { /* No matched rxe is found */
+
+#if HAVE_LTTNG
+		orig_pke_ptr = *pkt_entry_ptr;
+#endif
+
 		/*
 		 * efa_rdm_msg_alloc_unexp_rxe_for_rtm() might release pkt_entry,
 		 * thus we have to use pkt_entry_ptr here
@@ -785,8 +795,14 @@ efa_rdm_msg_alloc_rxe_for_msgrtm(struct efa_rdm_ep *ep,
 		(*pkt_entry_ptr)->ope = rxe;
 		peer_rxe->peer_context = (*pkt_entry_ptr);
 		rxe->peer_rxe = peer_rxe;
-		efa_rdm_tracepoint(msg_recv_unexpected_nontagged, rxe->msg_id,
-			    (size_t) rxe->cq_entry.op_context, rxe->total_len);
+
+#if HAVE_LTTNG
+		efa_rdm_tracepoint(msg_recv_unexpected_nontagged, (uint64_t) orig_pke_ptr,
+				   (*pkt_entry_ptr)->pkt_size, rxe->msg_id,
+				   (size_t) rxe->cq_entry.op_context,
+				   rxe->total_len, rxe->tag, rxe->addr);
+#endif
+
 	} else { /* Unexpected errors */
 		EFA_WARN(FI_LOG_EP_CTRL,
 			"get_msg failed, error: %d\n",
@@ -827,6 +843,9 @@ efa_rdm_msg_alloc_rxe_for_tagrtm(struct efa_rdm_ep *ep,
 	struct efa_rdm_ope *rxe;
 	int ret;
 	int pkt_type;
+#if HAVE_LTTNG
+	struct efa_rdm_pke *orig_pke_ptr;
+#endif
 
 	peer = (*pkt_entry_ptr)->peer;
 
@@ -843,9 +862,15 @@ efa_rdm_msg_alloc_rxe_for_tagrtm(struct efa_rdm_ep *ep,
 			efa_base_ep_write_eq_error(&ep->base_ep, FI_ENOBUFS, FI_EFA_ERR_RXE_POOL_EXHAUSTED);
 			return NULL;
 		}
-		efa_rdm_tracepoint(msg_match_expected_tagged, rxe->msg_id,
-			    (size_t) rxe->cq_entry.op_context, rxe->total_len);
+		efa_rdm_tracepoint(
+			msg_match_expected_tagged, (uint64_t) *pkt_entry_ptr,
+			(*pkt_entry_ptr)->pkt_size, rxe->msg_id,
+			(size_t) rxe->cq_entry.op_context, rxe->total_len);
 	} else if (ret == -FI_ENOENT) { /* No matched rxe is found */
+
+#if HAVE_LTTNG
+		orig_pke_ptr = *pkt_entry_ptr;
+#endif
 		/*
 		 * efa_rdm_msg_alloc_unexp_rxe_for_rtm() might release pkt_entry,
 		 * thus we have to use pkt_entry_ptr here
@@ -865,9 +890,14 @@ efa_rdm_msg_alloc_rxe_for_tagrtm(struct efa_rdm_ep *ep,
 
 		peer_rxe->peer_context = *pkt_entry_ptr;
 		rxe->peer_rxe = peer_rxe;
-		efa_rdm_tracepoint(msg_recv_unexpected_tagged, rxe->msg_id,
-			    (size_t) rxe->cq_entry.op_context, rxe->total_len,
-			    rxe->tag, rxe->peer->conn->fi_addr);
+
+#if HAVE_LTTNG
+		efa_rdm_tracepoint(msg_recv_unexpected_tagged, (uint64_t) orig_pke_ptr,
+				   (*pkt_entry_ptr)->pkt_size, rxe->msg_id,
+				   (size_t) rxe->cq_entry.op_context,
+				   rxe->total_len, rxe->tag, rxe->addr);
+#endif
+
 	} else { /* Unexpected errors */
 		EFA_WARN(FI_LOG_EP_CTRL,
 			"get_tag failed, error: %d\n",

--- a/prov/efa/src/rdm/efa_rdm_srx.c
+++ b/prov/efa/src/rdm/efa_rdm_srx.c
@@ -7,6 +7,7 @@
 #include "efa_rdm_pke_rtm.h"
 #include "efa_rdm_pke_req.h"
 #include "efa_rdm_ope.h"
+#include "efa_rdm_tracepoint.h"
 
 /**
  * @brief update an rxe for a peer rx entry.
@@ -59,6 +60,10 @@ static int efa_rdm_srx_start(struct fi_peer_rx_entry *peer_rxe)
 	assert(pkt_entry);
 	rxe = pkt_entry->ope;
 	efa_rdm_srx_update_rxe(peer_rxe, rxe);
+
+	efa_rdm_tracepoint(recv_unexp_match_found, (size_t) pkt_entry,
+			   pkt_entry->payload_size, rxe->msg_id,
+			   (size_t) rxe->cq_entry.op_context, rxe->total_len);
 
 	rxe->state = EFA_RDM_RXE_MATCHED;
 

--- a/prov/efa/src/rdm/efa_rdm_tracepoint_def.h
+++ b/prov/efa/src/rdm/efa_rdm_tracepoint_def.h
@@ -26,6 +26,46 @@
 	lttng_ust_field_integer_hex(size_t, ctx, ctx) \
 	lttng_ust_field_integer(int, total_len, total_len)
 
+#define RDM_MSG_ARGS \
+	size_t, msg_ctx, \
+	size_t, addr
+
+#define RDM_MSG_FIELDS \
+	lttng_ust_field_integer_hex(size_t, msg_ctx, msg_ctx) \
+	lttng_ust_field_integer_hex(size_t, addr, addr)
+
+#define CQ_ENTRY_ARGS \
+	int, tag, \
+	size_t, addr
+
+#define CQ_ENTRY_FIELDS \
+	lttng_ust_field_integer(int, tag, tag) \
+	lttng_ust_field_integer_hex(size_t, addr, addr)
+
+#define PKE_ARGS \
+	size_t, wr_id
+
+#define PKE_FIELDS \
+	lttng_ust_field_integer_hex(size_t, wr_id, wr_id)
+
+#define PKE_OPE_ARGS \
+	PKE_ARGS , \
+	int, size, \
+	X_ENTRY_ARGS
+
+#define PKE_OPE_FIELDS \
+	PKE_FIELDS \
+	lttng_ust_field_integer(int, size, size) \
+	X_ENTRY_FIELDS
+
+#define PKE_OPE_CQ_ENTRY_ARGS \
+	PKE_OPE_ARGS , \
+	CQ_ENTRY_ARGS
+
+#define PKE_OPE_CQ_ENTRY_FIELDS \
+	PKE_OPE_FIELDS \
+	CQ_ENTRY_FIELDS
+
 LTTNG_UST_TRACEPOINT_EVENT_CLASS(EFA_RDM_TP_PROV, x_entry,
 	LTTNG_UST_TP_ARGS(X_ENTRY_ARGS),
 	LTTNG_UST_TP_FIELDS(X_ENTRY_FIELDS))
@@ -45,14 +85,14 @@ LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(EFA_RDM_TP_PROV, x_entry, EFA_RDM_TP_PROV,
 	LTTNG_UST_TP_ARGS(X_ENTRY_ARGS))
 LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_RDM_TP_PROV, msg_recv_unexpected_nontagged, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
 
-LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(EFA_RDM_TP_PROV, x_entry, EFA_RDM_TP_PROV,
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(EFA_RDM_TP_PROV, pke_ope, EFA_RDM_TP_PROV,
 	msg_match_expected_tagged,
-	LTTNG_UST_TP_ARGS(X_ENTRY_ARGS))
+	LTTNG_UST_TP_ARGS(PKE_OPE_ARGS))
 LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_RDM_TP_PROV, msg_match_expected_tagged, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
 
-LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(EFA_RDM_TP_PROV, x_entry, EFA_RDM_TP_PROV,
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(EFA_RDM_TP_PROV, pke_ope, EFA_RDM_TP_PROV,
 	msg_match_expected_nontagged,
-	LTTNG_UST_TP_ARGS(X_ENTRY_ARGS))
+	LTTNG_UST_TP_ARGS(PKE_OPE_ARGS))
 LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_RDM_TP_PROV, msg_match_expected_nontagged, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(EFA_RDM_TP_PROV, x_entry, EFA_RDM_TP_PROV,
@@ -64,14 +104,6 @@ LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(EFA_RDM_TP_PROV, x_entry, EFA_RDM_TP_PROV,
 	runtread_read_posted,
 	LTTNG_UST_TP_ARGS(X_ENTRY_ARGS))
 LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_RDM_TP_PROV, runtread_read_posted, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
-
-#define RDM_MSG_ARGS \
-	size_t, msg_ctx, \
-	size_t, addr
-
-#define RDM_MSG_FIELDS \
-	lttng_ust_field_integer_hex(size_t, msg_ctx, msg_ctx) \
-	lttng_ust_field_integer_hex(size_t, addr, addr)
 
 LTTNG_UST_TRACEPOINT_EVENT_CLASS(EFA_RDM_TP_PROV, msg_context,
 	LTTNG_UST_TP_ARGS(RDM_MSG_ARGS),
@@ -97,14 +129,6 @@ LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(EFA_RDM_TP_PROV, msg_context, EFA_RDM_TP_PRO
 	LTTNG_UST_TP_ARGS(RDM_MSG_ARGS))
 LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_RDM_TP_PROV, write_begin_msg_context, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
 
-#define CQ_ENTRY_ARGS \
-	int, tag, \
-	size_t, addr
-
-#define CQ_ENTRY_FIELDS \
-	lttng_ust_field_integer(int, tag, tag) \
-	lttng_ust_field_integer_hex(size_t, addr, addr)
-
 LTTNG_UST_TRACEPOINT_EVENT_CLASS(EFA_RDM_TP_PROV, x_entry_cq_entry,
 	LTTNG_UST_TP_ARGS(X_ENTRY_ARGS, CQ_ENTRY_ARGS),
 	LTTNG_UST_TP_FIELDS(X_ENTRY_FIELDS CQ_ENTRY_FIELDS))
@@ -124,9 +148,13 @@ LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(EFA_RDM_TP_PROV, x_entry_cq_entry, EFA_RDM_T
 	LTTNG_UST_TP_ARGS(X_ENTRY_ARGS, CQ_ENTRY_ARGS))
 LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_RDM_TP_PROV, recv_end, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
 
-LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(EFA_RDM_TP_PROV, x_entry_cq_entry, EFA_RDM_TP_PROV,
+LTTNG_UST_TRACEPOINT_EVENT_CLASS(EFA_RDM_TP_PROV, pke_ope_cq_entry,
+	LTTNG_UST_TP_ARGS(PKE_OPE_CQ_ENTRY_ARGS),
+	LTTNG_UST_TP_FIELDS(PKE_OPE_CQ_ENTRY_FIELDS))
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(EFA_RDM_TP_PROV, pke_ope_cq_entry, EFA_RDM_TP_PROV,
 	msg_recv_unexpected_tagged,
-	LTTNG_UST_TP_ARGS(X_ENTRY_ARGS, CQ_ENTRY_ARGS))
+	LTTNG_UST_TP_ARGS(PKE_OPE_CQ_ENTRY_ARGS))
 LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_RDM_TP_PROV, msg_recv_unexpected_tagged, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(EFA_RDM_TP_PROV, x_entry_cq_entry, EFA_RDM_TP_PROV,
@@ -147,31 +175,20 @@ LTTNG_UST_TRACEPOINT_EVENT(EFA_RDM_TP_PROV,
 )
 LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_RDM_TP_PROV, read_completed, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
 
-#define PKE_ARGS \
-	size_t, wr_id
-
-#define PKE_FIELDS \
-	lttng_ust_field_integer_hex(size_t, wr_id, wr_id)
-
 LTTNG_UST_TRACEPOINT_EVENT(EFA_RDM_TP_PROV,
 	poll_cq,
 	LTTNG_UST_TP_ARGS(PKE_ARGS),
 	LTTNG_UST_TP_FIELDS(PKE_FIELDS))
 LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_RDM_TP_PROV, poll_cq, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
 
-#define PKE_OPE_ARGS \
-	PKE_ARGS , \
-	int, size, \
-	X_ENTRY_ARGS
-
-#define PKE_OPE_FIELDS \
-	PKE_FIELDS \
-	lttng_ust_field_integer(int, size, size) \
-	X_ENTRY_FIELDS
-
 LTTNG_UST_TRACEPOINT_EVENT_CLASS(EFA_RDM_TP_PROV, pke_ope,
 	LTTNG_UST_TP_ARGS(PKE_OPE_ARGS),
 	LTTNG_UST_TP_FIELDS(PKE_OPE_FIELDS))
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(EFA_RDM_TP_PROV, pke_ope, EFA_RDM_TP_PROV,
+	recv_unexp_match_found,
+	LTTNG_UST_TP_ARGS(PKE_OPE_ARGS))
+LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_RDM_TP_PROV, recv_unexp_match_found, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(EFA_RDM_TP_PROV, pke_ope, EFA_RDM_TP_PROV,
 	rx_pke_proc_matched_msg_begin,


### PR DESCRIPTION
This commit adds the pkt_entry to tracepoints in the receive path allowing match with tracepoints from the CQ read

It also adds an extra tracepoint for the unexpected receive path