### PR TITLE
prov/efa: dmabuf try / fallback logic

### DIFF
--- a/prov/efa/src/efa_hmem.c
+++ b/prov/efa/src/efa_hmem.c
@@ -118,6 +118,8 @@ static inline void efa_hmem_info_check_p2p_support_cuda(struct efa_hmem_info *in
 	int dmabuf_fd;
 	uint64_t dmabuf_offset;
 
+	info->dmabuf_supported_by_device_b = false;
+
 	cuda_ret = ofi_cudaMalloc(&ptr, len);
 	if (cuda_ret != cudaSuccess) {
 		info->initialized = false;
@@ -145,6 +147,7 @@ static inline void efa_hmem_info_check_p2p_support_cuda(struct efa_hmem_info *in
 				"Fall back to ibv_reg_mr\n", fi_strerror(-errno));
 			ibv_mr = ibv_reg_mr(ibv_pd, ptr, len, ibv_access);
 		}
+		info->dmabuf_supported_by_device_b = true;
 	} else {
 		EFA_INFO(FI_LOG_CORE,
 			"Unable to retrieve dmabuf fd of CUDA device buffer: %d. "
@@ -193,6 +196,8 @@ static inline void efa_hmem_info_check_p2p_support_neuron(struct efa_hmem_info *
 	uint64_t offset;
 	int ret;
 
+	info->dmabuf_supported_by_device_b = false;
+
 	if (g_efa_selected_device_list[0].device_caps & EFADV_DEVICE_ATTR_CAPS_RDMA_READ) {
 		ibv_access |= IBV_ACCESS_REMOTE_READ;
 	}
@@ -222,6 +227,7 @@ static inline void efa_hmem_info_check_p2p_support_neuron(struct efa_hmem_info *
 		ibv_mr = ibv_reg_dmabuf_mr(
 					ibv_pd, offset,
 					len, (uint64_t)ptr, dmabuf_fd, ibv_access);
+		info->dmabuf_supported_by_device_b = true;
 	} else if (ret == -FI_EOPNOTSUPP) {
 		EFA_INFO(FI_LOG_MR,
 			"Unable to retrieve dmabuf fd of Neuron device buffer, "
@@ -284,9 +290,14 @@ efa_hmem_info_init_iface(enum fi_hmem_iface iface)
 	}
 
 	info->initialized = true;
+	info->max_medium_msg_size = 0;
+	info->runt_size = 0;
+	info->min_read_msg_size = 0;
+	info->min_read_write_size = 0;
 
 	if (iface == FI_HMEM_SYNAPSEAI || iface == FI_HMEM_SYSTEM) {
 		info->p2p_supported_by_device = true;
+		info->dmabuf_supported_by_device_b = true;
 	} else if (ofi_hmem_p2p_disabled()) {
 		info->p2p_supported_by_device = false;
 	} else {

--- a/prov/efa/src/efa_hmem.h
+++ b/prov/efa/src/efa_hmem.h
@@ -24,6 +24,7 @@ static const enum fi_hmem_iface efa_hmem_ifaces[] = {
 struct efa_hmem_info {
 	bool initialized; 	/* do we support it at all */
 	bool p2p_supported_by_device;	/* do we support p2p with this device */
+	bool dmabuf_supported_by_device_b;	/* do we support dmabuf with this device */
 
 	size_t max_medium_msg_size;
 	size_t runt_size;

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -506,77 +506,82 @@ struct ibv_mr *efa_mr_reg_ibv_dmabuf_mr(struct ibv_pd *pd, uint64_t offset,
  * @param flags flags in fi_mr_reg/fi_mr_regattr
  * @return struct ibv_mr* the ptr to the registered MR
  */
-static struct ibv_mr *efa_mr_reg_ibv_mr(struct efa_mr *efa_mr, struct fi_mr_attr *mr_attr,
-					int access, const uint64_t flags)
+static struct ibv_mr *efa_mr_reg_ibv_mr(struct efa_mr *efa_mr,
+                                        struct fi_mr_attr *mr_attr,
+                                        int access, const uint64_t flags)
 {
-	int dmabuf_fd;
-	uint64_t offset;
-	int ret;
-	struct ibv_mr *ibv_mr;
+    int dmabuf_fd;
+    uint64_t offset;
+    int ret;
 
-	if (flags & FI_MR_DMABUF)
-		return efa_mr_reg_ibv_dmabuf_mr(
-			efa_mr->domain->ibv_pd,
-			mr_attr->dmabuf->offset,
-			mr_attr->dmabuf->len,
-			(uintptr_t) mr_attr->dmabuf->base_addr + mr_attr->dmabuf->offset,
-			mr_attr->dmabuf->fd,
-			access
-		);
+    /* Explicit dmabuf registration */
+    if (flags & FI_MR_DMABUF) {
+        if (!mr_attr->dmabuf) {
+            EFA_WARN(FI_LOG_MR, "FI_MR_DMABUF set but mr_attr->dmabuf == NULL\n");
+            return NULL;
+        }
+        if (!g_efa_hmem_info[mr_attr->iface].dmabuf_supported_by_device_b) {
+            EFA_WARN(FI_LOG_MR,
+                     "Requested FI_MR_DMABUF, but dmabuf not supported for iface=%d\n",
+                     mr_attr->iface);
+            return NULL;
+        }
 
-	if (efa_mr_is_synapseai(efa_mr)) {
-		ret = ofi_hmem_get_dmabuf_fd(efa_mr->peer.iface,
-					     mr_attr->mr_iov->iov_base,
-					     (uint64_t) mr_attr->mr_iov->iov_len,
-					     &dmabuf_fd, &offset);
-		if (ret != FI_SUCCESS) {
-			EFA_WARN(FI_LOG_MR, "Unable to get dmabuf fd for Gaudi device buffer \n");
-			return NULL;
-		}
-		return efa_mr_reg_ibv_dmabuf_mr(
-				efa_mr->domain->ibv_pd, offset,
-				mr_attr->mr_iov->iov_len,
-				(uint64_t)mr_attr->mr_iov->iov_base,
-				dmabuf_fd, access);
-	}
+        EFA_INFO(FI_LOG_MR,
+                 "FI_MR_DMABUF: fd=%d offset=%lu len=%zu\n",
+                 mr_attr->dmabuf->fd, mr_attr->dmabuf->offset,
+                 mr_attr->dmabuf->len);
 
-	/*
-	 * TODO: need such fallback for cuda as well when
-	 * FI_CUDA_API_PERMITTED is true
-	 */
-	if (efa_mr_is_neuron(efa_mr)) {
-		ret = ofi_hmem_get_dmabuf_fd(
-				efa_mr->peer.iface,
-				mr_attr->mr_iov->iov_base,
-				mr_attr->mr_iov->iov_len,
-				&dmabuf_fd,
-				&offset);
+        return efa_mr_reg_ibv_dmabuf_mr(
+            efa_mr->domain->ibv_pd,
+            mr_attr->dmabuf->offset,
+            mr_attr->dmabuf->len,
+            (uintptr_t) mr_attr->dmabuf->base_addr + mr_attr->dmabuf->offset,
+            mr_attr->dmabuf->fd,
+            access);
+    }
 
-		if (ret == FI_SUCCESS) {
-			/* Success => invoke ibv_reg_dmabuf_mr */
-			ibv_mr = efa_mr_reg_ibv_dmabuf_mr(
-					efa_mr->domain->ibv_pd, 0,
-					mr_attr->mr_iov->iov_len,
-					(uint64_t)mr_attr->mr_iov->iov_base,
-					dmabuf_fd, access);
-			(void) ofi_hmem_put_dmabuf_fd(efa_mr->peer.iface, dmabuf_fd);
-			return ibv_mr;
-		} else if (ret == -FI_EOPNOTSUPP) {
-			/* Protocol not available => fallback */
-			EFA_INFO(FI_LOG_MR,
-				"Unable to get dmabuf fd for Neuron device buffer, "
-				"Fall back to ibv_reg_mr\n");
-			return ibv_reg_mr(
-				efa_mr->domain->ibv_pd,
-				(void *)mr_attr->mr_iov->iov_base,
-				mr_attr->mr_iov->iov_len, access);
-		}
-		return NULL;
-	}
+    /* Implicit VA path with dmabuf-first */
+    if (g_efa_hmem_info[mr_attr->iface].dmabuf_supported_by_device_b) {
+        ret = ofi_hmem_get_dmabuf_fd(
+                mr_attr->iface,
+                mr_attr->mr_iov->iov_base,
+                (uint64_t) mr_attr->mr_iov->iov_len,
+                &dmabuf_fd, &offset);
 
-	return ibv_reg_mr(efa_mr->domain->ibv_pd,
-			(void *)mr_attr->mr_iov->iov_base,
-			mr_attr->mr_iov->iov_len, access);
+        if (ret == FI_SUCCESS) {
+            EFA_INFO(FI_LOG_MR,
+                     "Registering dmabuf MR: fd=%d offset=%lu len=%zu\n",
+                     dmabuf_fd, offset, mr_attr->mr_iov->iov_len);
+
+            return efa_mr_reg_ibv_dmabuf_mr(
+                efa_mr->domain->ibv_pd, offset,
+                mr_attr->mr_iov->iov_len,
+                (uint64_t)mr_attr->mr_iov->iov_base,
+                dmabuf_fd, access);
+        }
+
+        if (ret == -FI_EOPNOTSUPP || ret == -FI_ENOSYS) {
+            EFA_WARN(FI_LOG_MR,
+                     "dmabuf not supported at runtime for iface=%d, disabling\n",
+                     mr_attr->iface);
+			g_efa_hmem_info[mr_attr->iface].dmabuf_supported_by_device_b = false;
+        } else {
+            EFA_WARN(FI_LOG_MR,
+                     "ofi_hmem_get_dmabuf_fd failed: ret=%d (%s)\n",
+                     ret, fi_strerror(-ret));
+        }
+        /* fall through to ibv_reg_mr */
+    }
+
+    /* Fallback: plain ibv_reg_mr */
+    EFA_WARN(FI_LOG_MR,
+             "Fallback ibv_reg_mr: addr=%p len=%zu\n",
+             mr_attr->mr_iov->iov_base, mr_attr->mr_iov->iov_len);
+
+    return ibv_reg_mr(efa_mr->domain->ibv_pd,
+                      (void *)mr_attr->mr_iov->iov_base,
+                      mr_attr->mr_iov->iov_len, access);
 }
 
 #if HAVE_CUDA


### PR DESCRIPTION
feat: Adding default dmabuf attempt and fallback logic for all efa_hmem_ifaces

Problem:
  - How make dmabuf usage default going forward and have fallback mechanism if dmabuf not supported

Solution:
  - Modified initial PR from @jiaxiyan at https://github.com/ofiwg/libfabric/commit/6aa6708f99234ddef233182d656ec25eb1c5159b#diff-9b57a9410ed94ed1f1aea837412e68bbe9b49582edce813ba352fffb37dcc007
  - Added dmabuf_supported_by_device_b flag in efa_hmem_info structure in prov/efa/efa_hmem.h
  - Updated dmabuf_supported_by_device_b in each fi_hmem_iface type p2p_support fcn in prov/efa/efa_hmem.c
  - Removed per fi_hmem_iface type checks in prov/efa/efa_mr_reg_ibv_mr.c -

Testing:
  - Ran mpi perf tests on 2 nodes on p5en with dmabuf and fallback option hard set
  - Ran mpi perf tests on 16 nodes on p5en with dmabuf and fallback option hard set

Sim Issue:
  - N/A