### PR TITLE
prov/efa: allocate peer map entry pool during the rdm ep create

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -242,6 +242,10 @@ int efa_rdm_ep_create_buffer_pools(struct efa_rdm_ep *ep)
 	if (ret)
 		goto err_free;
 
+	ret = ofi_bufpool_grow(ep->peer_map_entry_pool);
+	if (ret)
+		goto err_free;
+
 	return 0;
 
 err_free:


### PR DESCRIPTION
the commit "4016fd5" has moved the peer map entry pool from av to endpoint but deferred the pool memory allocation till the remote requests for a peer. So, the acutal memory pool allocation was happening during the connection establishment request and hence adding latency overhead to the communication.

This commit is fixing the latency issue by eagerly allocating the pool during the endpoint create.