### PR TITLE
prov/ucx: Fix ops structs initialization

### DIFF
--- a/prov/ucx/src/ucx_av.c
+++ b/prov/ucx/src/ucx_av.c
@@ -245,6 +245,10 @@ static struct fi_ops ucx_fi_ops = {
 	.size = sizeof(struct fi_ops),
 	.close = ucx_av_close,
 	.bind = ucx_av_bind,
+	.control = fi_no_control,
+	.ops_open = fi_no_ops_open,
+	.tostr = fi_no_tostr,
+	.ops_set = fi_no_ops_set
 };
 
 static struct fi_ops_av ucx_av_ops = {
@@ -252,6 +256,10 @@ static struct fi_ops_av ucx_av_ops = {
 	.insert = ucx_av_insert,
 	.remove = ucx_av_remove,
 	.lookup = ucx_av_lookup,
+	.insertsvc = fi_no_av_insertsvc,
+	.insertsym = fi_no_av_insertsym,
+	.straddr = fi_no_av_straddr,
+	.av_set = fi_no_av_set,
 };
 
 int ucx_av_open(struct fid_domain *fi_domain, struct fi_av_attr *attr,

--- a/prov/ucx/src/ucx_cm.c
+++ b/prov/ucx/src/ucx_cm.c
@@ -140,10 +140,12 @@ static int ucx_cm_getname(fid_t fid, void *addr, size_t *addrlen)
 struct fi_ops_cm ucx_cm_ops = {
 	.size = sizeof(struct fi_ops_cm),
 	.getname = ucx_cm_getname,
+	.setname = fi_no_setname,
 	.getpeer = fi_no_getpeer,
 	.connect = fi_no_connect,
 	.listen = fi_no_listen,
 	.accept = fi_no_accept,
 	.reject = fi_no_reject,
 	.shutdown = fi_no_shutdown,
+	.join = fi_no_join,
 };

--- a/prov/ucx/src/ucx_domain.c
+++ b/prov/ucx/src/ucx_domain.c
@@ -105,7 +105,11 @@ static int ucx_dom_control(struct fid *fid, int command, void *arg)
 static struct fi_ops ucx_fi_ops = {
 	.size = sizeof(struct fi_ops),
 	.close = ucx_domain_close,
+	.bind = fi_no_bind,
 	.control = ucx_dom_control,
+	.ops_open = fi_no_ops_open,
+	.tostr = fi_no_tostr,
+	.ops_set = fi_no_ops_set,
 };
 
 struct fi_ops_domain ucx_domain_ops = {
@@ -119,6 +123,7 @@ struct fi_ops_domain ucx_domain_ops = {
 	.stx_ctx = fi_no_stx_context,
 	.srx_ctx = fi_no_srx_context,
 	.query_atomic = fi_no_query_atomic,
+	.query_collective = fi_no_query_collective,
 };
 
 

--- a/prov/ucx/src/ucx_ep.c
+++ b/prov/ucx/src/ucx_ep.c
@@ -233,6 +233,10 @@ struct fi_ops_ep ucx_ep_ops = {
 	.cancel = ucx_ep_cancel,
 	.getopt = ucx_ep_getopt,
 	.setopt = ucx_ep_setopt,
+	.tx_ctx = fi_no_tx_ctx,
+	.rx_ctx = fi_no_rx_ctx,
+	.rx_size_left = fi_no_rx_size_left,
+	.tx_size_left = fi_no_tx_size_left,
 };
 
 static struct fi_ops ucx_fi_ops = {
@@ -240,6 +244,9 @@ static struct fi_ops ucx_fi_ops = {
 	.close = ucx_ep_close,
 	.bind = ucx_ep_bind,
 	.control = ucx_ep_control,
+	.ops_open = fi_no_ops_open,
+	.tostr = fi_no_tostr,
+	.ops_set = fi_no_ops_set,
 };
 
 extern struct fi_ops_cm ucx_cm_ops;

--- a/prov/ucx/src/ucx_fabric.c
+++ b/prov/ucx/src/ucx_fabric.c
@@ -51,6 +51,8 @@ static struct fi_ops ucx_fabric_fi_ops = {
 	.bind = fi_no_bind,
 	.control = fi_no_control,
 	.ops_open = fi_no_ops_open,
+	.tostr = fi_no_tostr,
+	.ops_set = fi_no_ops_set,
 };
 
 static struct fi_ops_fabric ucx_fabric_ops = {


### PR DESCRIPTION
Use of non initialized operations lead to a segmentation fault