### PR TITLE
prov/efa: Slide recv-win on RTM/RTA error

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_pke_rtm.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtm.c
@@ -507,11 +507,12 @@ void efa_rdm_pke_handle_rtm_rta_recv(struct efa_rdm_pke *pkt_entry)
 
 	/*
 	 * efa_rdm_pke_proc_rtm_rta() will write error cq entry if needed,
-	 * thus we do not write error cq entry
+	 * thus we do not write error cq entry.
+	 *
+	 * Even if we hit an error processing the packets contents, we still
+	 * need to slide the recv window so we can continue to do work.
 	 */
-	ret = efa_rdm_pke_proc_rtm_rta(pkt_entry, peer);
-	if (OFI_UNLIKELY(ret))
-		return;
+	(void) efa_rdm_pke_proc_rtm_rta(pkt_entry, peer);
 
 	if (slide_recvwin) {
 		ofi_recvwin_slide((&peer->robuf));


### PR DESCRIPTION
In order to continue processing future packets correctly, we need to progress the recv window when a RTM or RTA packet has been successfully delivered. If we fail processing a packet, we need to write the error to the CQ (when applicable), and continue to do work. Returning early here makes our recv window index be off by 1.