### PR TITLE
prov/opx: Use getpid() instead of gettid() for POSIX compliancy.

### DIFF
--- a/prov/opx/src/opx_debug.c
+++ b/prov/opx/src/opx_debug.c
@@ -228,7 +228,7 @@ static void opx_debug_dump_backtrace(FILE *output)
 static void opx_debug_dump_endpoint(struct fi_opx_ep *opx_ep)
 {
 	char  hostname[HOST_NAME_MAX + 1];
-	pid_t my_pid = gettid();
+	pid_t my_pid = getpid();
 
 	int rc = gethostname(hostname, HOST_NAME_MAX);
 	if (rc != 0) {


### PR DESCRIPTION
The 'gettid()' function is not POSIX compliant, and older versions of glibc may not have that function available in unistd.h, causing a compile failure. This changes the call to 'getpid()', which is POSIX compliant and should always be present in glibc.