### PR TITLE
efa/cq: Add traces for completions bypassing util-cq

### DIFF
--- a/prov/efa/src/efa_cq.c
+++ b/prov/efa/src/efa_cq.c
@@ -705,6 +705,7 @@ ssize_t efa_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 		 * 2. It is a solicited wc and having wr_id (efa_context) which means it needs a completion.
 		 */
 		if ((!efa_cq_wc_is_unsolicited(ibv_cq) && ibv_cq->ibv_cq_ex->wr_id ) || opcode == IBV_WC_RECV_RDMA_WITH_IMM) {
+			efa_tracepoint(handle_completion, ibv_cq->ibv_cq_ex->wr_id, opcode);
 			efa_cq->read_entry(ibv_cq, (void *)((uintptr_t) buf + num_cqe * efa_cq->entry_size), opcode);
 			if (src_addr)
 				src_addr[num_cqe] = efa_cq_get_src_addr(ibv_cq, opcode);

--- a/prov/efa/src/efa_tp_def.h
+++ b/prov/efa/src/efa_tp_def.h
@@ -22,6 +22,14 @@
 #define X_WR_ID_FIELDS \
 	lttng_ust_field_integer_hex(size_t, wr_id, wr_id)
 
+#define X_WR_ID_OPCODE_ARGS \
+	size_t, wr_id, \
+	int, opcode
+
+#define X_WR_ID_OPCODE_FIELDS \
+	lttng_ust_field_integer_hex(size_t, wr_id, wr_id) \
+	lttng_ust_field_integer_hex(int, opcode, opcode)
+
 #define X_PKT_ARGS \
 	size_t, wr_id, \
 	size_t, context
@@ -37,6 +45,7 @@
 #define MSG_FIELDS \
 	lttng_ust_field_integer_hex(size_t, msg_ctx, msg_ctx) \
 	lttng_ust_field_integer_hex(size_t, addr, addr)
+
 
 LTTNG_UST_TRACEPOINT_EVENT_CLASS(EFA_TP_PROV, msg_context,
 	LTTNG_UST_TP_ARGS(MSG_ARGS),
@@ -100,6 +109,15 @@ LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(EFA_TP_PROV, handle_completion, EFA_TP_PROV,
 	handle_tx_completion,
 	LTTNG_UST_TP_ARGS(X_WR_ID_ARGS))
 LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_TP_PROV, handle_tx_completion, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
+
+LTTNG_UST_TRACEPOINT_EVENT_CLASS(EFA_TP_PROV, completion_with_opcode,
+	LTTNG_UST_TP_ARGS(X_WR_ID_OPCODE_ARGS),
+	LTTNG_UST_TP_FIELDS(X_WR_ID_OPCODE_FIELDS))
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(EFA_TP_PROV, completion_with_opcode, EFA_TP_PROV,
+	handle_completion,
+	LTTNG_UST_TP_ARGS(X_WR_ID_OPCODE_ARGS))
+LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_TP_PROV, handle_completion, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
 
 #endif /* _EFA_TP_DEF_H */
 


### PR DESCRIPTION
This patch adds LTTng tracepoint for util cq bypass path introduced in commit https://github.com/ofiwg/libfabric/commit/b3abf8a40e185f7db239aeab2cb37251e183106f

This tracepoint allows to trace latency of efa-direct operations.
