### PR TITLE
prov/efa: fix memory leak from `efa_srx_unexp_pkt` unit test

### DIFF
--- a/prov/efa/test/efa_unit_test_srx.c
+++ b/prov/efa/test/efa_unit_test_srx.c
@@ -131,4 +131,7 @@ void test_efa_srx_unexp_pkt(struct efa_resource **state)
         efa_rdm_pke_release_rx(pke);
         efa_rdm_rxe_release(rxe);
         ofi_genlock_unlock(srx_ctx->lock);
+
+        /* Destroy the fake peer constructed above */
+        efa_rdm_peer_destruct(&peer, efa_rdm_ep);
 }


### PR DESCRIPTION
efa_srx_unexp_pkt test is creating a fake peer explicitly to emualte an unexpeted rxe scenario. But it wasn't destroying the fake peer at the end, so, leaking the buffers and causing memory faults when the endpoint is closed.