### PR TITLE
fabtests/build: fix build issues for MacOS

### DIFF
--- a/fabtests/functional/rdm_stress.c
+++ b/fabtests/functional/rdm_stress.c
@@ -28,6 +28,7 @@
  */
 
 #include <assert.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <getopt.h>
@@ -650,7 +651,7 @@ static bool get_uint64_val(const char *js, jsmntok_t *t, uint64_t *val)
 {
 	if (t->type != JSMN_PRIMITIVE)
 		return false;
-	return (sscanf(&js[t->start], "%lu", val) == 1);
+	return (sscanf(&js[t->start], "%" SCNu64, val) == 1);
 }
 
 static bool get_op_enum(const char *js, jsmntok_t *t, uint32_t *op)

--- a/fabtests/multinode/src/timing.c
+++ b/fabtests/multinode/src/timing.c
@@ -54,11 +54,14 @@ void multi_timer_stop(struct multi_timer *timer)
 		timer->end = ft_gettime_ns();
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
 static inline void print_timer(struct multi_timer timer, char* info)
 {
 	PRINTF("rank: %i, start: %ld, end: %ld, %s\n",
 		timer.rank, timer.start, timer.end, info);
 }
+#pragma GCC diagnostic pop
 
 int multi_timer_analyze(struct multi_timer *timers, int timer_count)
 {

--- a/fabtests/unit/mr_cache_evict.c
+++ b/fabtests/unit/mr_cache_evict.c
@@ -132,6 +132,9 @@ out:
 	return ret;
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 /* Sbrk/brk allocations are only intended to support a single outstanding
  * allocation at a time. Extra handling of the program break is needed to make
  * sbrk/brk allocations more flexible including making allocations thread safe.
@@ -192,7 +195,11 @@ static void brk_free(void *ptr)
 	int ret;
 
 	FT_DEBUG("Resetting program break from %p to %p", cur_brk, rewind_brk);
+#ifndef __GLIBC__
+	ret = (brk(rewind_brk) == (void*)-1) ? -1 : 0;
+#else
 	ret = brk(rewind_brk);
+#endif
 	if (ret) {
 		FT_UNIT_STRERR(err_buf, "brk failed", -errno);
 		return;
@@ -226,7 +233,11 @@ static void *brk_alloc(void)
 	}
 
 	cur_brk = (void *) ((intptr_t) prev_brk + mr_buf_size);
+#ifndef __GLIBC__
+	ret = (brk(cur_brk) == (void*)-1) ? -1 : 0;
+#else
 	ret = brk(cur_brk);
+#endif
 	if (ret) {
 		FT_UNIT_STRERR(err_buf, "brk failed", -errno);
 		return NULL;
@@ -245,6 +256,8 @@ static void *brk_alloc(void)
 
 	return prev_brk;
 }
+
+#pragma GCC diagnostic pop //-Wdeprecated-declarations
 
 /* Mmap allocations are only intended to support a single outstanding
  * allocation at a time. Extra handling of the mmap reuse address needs to occur


### PR DESCRIPTION
Fabtests fail to build at my laptop (M1 Pro, macOS Sequoia 15.7.1, Apple clang version 17.0.0 (clang-1700.3.19.1)).

The build error is caused by mismatch in definition of `brk()` standard library function. It returns `int` in GLIBC, but in BSD libraries it is defined with `void *` return type. Clang treats implicit cast from `void *` to `int` as an error.

```
unit/mr_cache_evict.c:195:6: error: incompatible pointer to integer conversion assigning to 'int' from 'void *' [-Wint-conversion]
  195 |         ret = brk(rewind_brk);
``` 

Also fixed warnings from build log:
- Non-portable scanf format string at rdm_stress.c:654
- unused function  `print_timer()`
- deprecated stdlib functions `brk` and `sbrk`