### PR TITLE
prov/efa: Remove duplicate macro for rdma sge limit

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -113,14 +113,6 @@
 #define EFA_RDM_BUFPOOL_ALIGNMENT	(64)
 
 
-/**
- * The hard-coded rdma sge num limit
- * due to the structs layout rdma wqes.
- * See `struct efa_io_rdma_req` in efa_io_defs.h
- */
-#define EFA_DEVICE_MAX_RDMA_SGE 1
-
-
 struct efa_fabric {
 	struct util_fabric	util_fabric;
 	struct fid_fabric *shm_fabric;

--- a/prov/efa/src/efa_data_path_direct_entry.h
+++ b/prov/efa/src/efa_data_path_direct_entry.h
@@ -318,8 +318,8 @@ static inline void efa_data_path_direct_wr_set_sge_list(struct efa_qp *efa_qp,
 		break;
 	case EFA_IO_RDMA_READ:
 	case EFA_IO_RDMA_WRITE:
-		if (OFI_UNLIKELY(num_sge > EFA_DEVICE_MAX_RDMA_SGE)) {
-			EFA_WARN(FI_LOG_EP_DATA, "EFA device doesn't support > %d iov for rdma operations\n", EFA_DEVICE_MAX_RDMA_SGE);
+		if (OFI_UNLIKELY(num_sge > EFA_IO_TX_DESC_NUM_RDMA_BUFS)) {
+			EFA_WARN(FI_LOG_EP_DATA, "EFA device doesn't support > %d iov for rdma operations\n", EFA_IO_TX_DESC_NUM_RDMA_BUFS);
 			qp->wr_session_err = EINVAL;
 			return;
 		}

--- a/prov/efa/test/efa_unit_test_data_path_direct.c
+++ b/prov/efa/test/efa_unit_test_data_path_direct.c
@@ -32,7 +32,7 @@ static void test_efa_data_path_direct_multiple_sge_fail_impl(struct efa_resource
 	efa_unit_test_buff_construct(&local_buff1, resource, 2048);
 	efa_unit_test_buff_construct(&local_buff2, resource, 2048);
 
-	/* Setup SGE list with 2 elements (exceeds EFA_DEVICE_MAX_RDMA_SGE=1) */
+	/* Setup SGE list with 2 elements (exceeds EFA_IO_TX_DESC_NUM_RDMA_BUFS=1) */
 	sge_list[0].addr = (uintptr_t)local_buff1.buff;
 	sge_list[0].length = local_buff1.size;
 	sge_list[0].lkey = ((struct efa_mr *)fi_mr_desc(local_buff1.mr))->ibv_mr->lkey;


### PR DESCRIPTION
Reuse the existing EFA_IO_TX_DESC_NUM_RDMA_BUFS