### PR TITLE
prov/efa: Remove rx_msg_flags from efa_rdm_msg_recv/efa_rdm_msg_recvv

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_msg.c
+++ b/prov/efa/src/rdm/efa_rdm_msg.c
@@ -974,8 +974,7 @@ ssize_t efa_rdm_msg_recv(struct fid_ep *ep_fid, void *buf, size_t len,
 	iov.iov_len = len;
 
 	efa_rdm_msg_construct(&msg, &iov, &desc, 1, src_addr, context, 0);
-	return efa_rdm_msg_generic_recv(ep, &msg, 0, 0, ofi_op_msg,
-					efa_rdm_rx_flags(ep) | ep->base_ep.util_ep.rx_msg_flags);
+	return efa_rdm_msg_generic_recv(ep, &msg, 0, 0, ofi_op_msg, efa_rdm_rx_flags(ep));
 }
 
 static
@@ -989,8 +988,7 @@ ssize_t efa_rdm_msg_recvv(struct fid_ep *ep_fid, const struct iovec *iov,
 	ep = container_of(ep_fid, struct efa_rdm_ep, base_ep.util_ep.ep_fid.fid);
 
 	efa_rdm_msg_construct(&msg, iov, desc, count, src_addr, context, 0);
-	return efa_rdm_msg_generic_recv(ep, &msg, 0, 0, ofi_op_msg,
-					efa_rdm_rx_flags(ep) | ep->base_ep.util_ep.rx_msg_flags);
+	return efa_rdm_msg_generic_recv(ep, &msg, 0, 0, ofi_op_msg, efa_rdm_rx_flags(ep));
 }
 
 /**


### PR DESCRIPTION
rx_msg_flags only apply to fi_recvmsg/fi_trecvmsg. For fi_recv, use the default operational flags rx_op_flags.
