### PR TITLE
prov/ucx: Fix completion entries insertion for RMA operations.

### DIFF
--- a/prov/ucx/src/ucx_msg.c
+++ b/prov/ucx/src/ucx_msg.c
@@ -120,6 +120,9 @@ static ssize_t ucx_mrecvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 static ssize_t ucx_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 			   uint64_t flags)
 {
+	struct ucx_ep *u_ep = container_of(ep, struct ucx_ep, ep.ep_fid);
+
+	flags |= u_ep->ep.rx_msg_flags;
 	if (flags & (FI_REMOTE_CQ_DATA | FI_PEEK | FI_CLAIM))
 		return -FI_EBADFLAGS;
 
@@ -227,11 +230,12 @@ ssize_t ucx_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 		.context = msg->context,
 		.data = 0,
 	};
+	struct ucx_ep *u_ep = container_of(ep, struct ucx_ep, ep.ep_fid);
 
 	if(flags & FI_REMOTE_CQ_DATA)
 		return -FI_EBADFLAGS;
 
-	return ucx_do_sendmsg(ep, &tmsg, flags, UCX_MSG);
+	return ucx_do_sendmsg(ep, &tmsg, flags | u_ep->ep.tx_msg_flags, UCX_MSG);
 }
 
 

--- a/prov/ucx/src/ucx_tagged.c
+++ b/prov/ucx/src/ucx_tagged.c
@@ -81,6 +81,9 @@ static ssize_t ucx_tagged_recvmsg(struct fid_ep *ep,
 				  const struct fi_msg_tagged *msg,
 				  uint64_t flags)
 {
+	struct ucx_ep *u_ep = container_of(ep, struct ucx_ep, ep.ep_fid);
+
+	flags |= u_ep->ep.rx_msg_flags;
 	if (flags & FI_REMOTE_CQ_DATA)
 		return -FI_EBADFLAGS;
 
@@ -101,6 +104,8 @@ static ssize_t ucx_tagged_sendmsg(struct fid_ep *ep,
 				  const struct fi_msg_tagged *msg,
 				  uint64_t flags)
 {
+	struct ucx_ep *u_ep = container_of(ep, struct ucx_ep, ep.ep_fid);
+
 	if(flags & FI_REMOTE_CQ_DATA)
 		return -FI_EBADFLAGS;
 
@@ -111,7 +116,7 @@ static ssize_t ucx_tagged_sendmsg(struct fid_ep *ep,
 	}
 #endif
 
-	return ucx_do_sendmsg(ep, msg, flags, UCX_TAGGED);
+	return ucx_do_sendmsg(ep, msg, flags | u_ep->ep.tx_msg_flags, UCX_TAGGED);
 }
 
 static ssize_t ucx_tagged_inject(struct fid_ep *ep, const void *buf,


### PR DESCRIPTION
- Ignore the absence of the FI_COMPLETION flag if CQ configured without FI_SELECTIVE_COMPLETION flag.
- Error completions must generated for all operations, including those for which a completion was not requested