### PR TITLE
prov/efa: Fix the queued ope progress in ep close

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -869,7 +869,7 @@ static inline void progress_queues_closing_ep(struct efa_rdm_ep *ep)
 					continue;
 				if (efa_rdm_ope_process_queued_ope(ope, EFA_RDM_OPE_QUEUED_CTRL))
 					continue;
-				/* fall-thru */
+				break;
 			default:
 				/* Release all other queued OPEs */
 				if (ope->type == EFA_RDM_TXE)


### PR DESCRIPTION
The current "fall-through" in the switch is wrong: when the repost of the queued ope succeeds, we shouldn't release the ope. The ope release should only happen for non-EOR/RECEIPT opes