### PR TITLE
[v2.3.x]prov/efa: Update shared domain caps and modes

### DIFF
--- a/prov/efa/src/efa_user_info.c
+++ b/prov/efa/src/efa_user_info.c
@@ -167,6 +167,11 @@ int efa_user_info_check_domain_object(const struct fi_info *hints,
 	}
 
 	dupinfo->domain_attr->domain = hints->domain_attr->domain;
+
+	util_domain->info_domain_caps |= dupinfo->caps | dupinfo->domain_attr->caps;
+	util_domain->info_domain_mode |= dupinfo->mode | dupinfo->domain_attr->mode;
+	util_domain->mr_mode |= dupinfo->domain_attr->mr_mode;
+
 	return 0;
 }
 


### PR DESCRIPTION
When the application tries to reuse domain in fi_getinfo, add additional requested capabilities and modes to the domain as long as the provider supports them.


(cherry picked from commit fc77ea0600d4ed84147583f1eb937946f733413b)