### PR TITLE
fabtests: implement pausable timer

### DIFF
--- a/fabtests/functional/multi_recv.c
+++ b/fabtests/functional/multi_recv.c
@@ -158,12 +158,13 @@ static int post_multi_recv_buffer()
 static int run_test(void)
 {
 	int ret, i;
+	union ft_timer timer;
 
 	ret = ft_sync();
 	if (ret)
 		return ret;
 
-	ft_start();
+	ft_start(&timer);
 	if (opts.dst_addr) {
 		for (i = 0; i < opts.iterations; i++) {
 			ret = ft_tx(ep, remote_fi_addr, opts.transfer_size, &tx_ctx);
@@ -175,14 +176,14 @@ static int run_test(void)
 		if (ret)
 			return ret;
 	}
-	ft_stop();
+	ft_stop(&timer);
 
 	if (opts.machr)
 		show_perf_mr(opts.transfer_size, opts.iterations,
-			&start, &end, 1, opts.argc, opts.argv);
+			timer, 1, opts.argc, opts.argv);
 	else
 		show_perf(NULL, opts.transfer_size, opts.iterations,
-			&start, &end, 1);
+			timer, 1);
 
 	return ret;
 }

--- a/fabtests/functional/rdm_atomic.c
+++ b/fabtests/functional/rdm_atomic.c
@@ -224,7 +224,7 @@ static int fill_data(enum ft_atomic_opcodes opcode)
 	return ret;
 }
 
-static void report_perf(void)
+static void report_perf(union ft_timer timer)
 {
 	int len;
 
@@ -234,15 +234,16 @@ static void report_perf(void)
 		 fi_tostr(&op_type, FI_TYPE_ATOMIC_OP));
 
 	if (opts.machr)
-		show_perf_mr(opts.transfer_size, opts.iterations, &start, &end, 1, opts.argc,
+		show_perf_mr(opts.transfer_size, opts.iterations, timer, 1, opts.argc,
 			opts.argv);
 	else
-		show_perf(test_name, opts.transfer_size, opts.iterations, &start, &end, 1);
+		show_perf(test_name, opts.transfer_size, opts.iterations, timer, 1);
 }
 
 static int handle_atomic_base_op(void)
 {
 	int ret = FI_SUCCESS, i;
+	union ft_timer timer;
 	size_t count = 0;
 
 	ret = check_base_atomic_op(ep, op_type, datatype, &count);
@@ -250,7 +251,7 @@ static int handle_atomic_base_op(void)
 		return ret;
 
 	opts.transfer_size = datatype_to_size(datatype);
-	ft_start();
+	ft_start(&timer);
 	for (i = 0; i < opts.iterations; i++) {
 		if (ft_check_opts(FT_OPT_VERIFY_DATA)) {
 			ret = fill_data(FT_ATOMIC_BASE);
@@ -271,14 +272,15 @@ static int handle_atomic_base_op(void)
 				return ret;
 		}
 	}
-	ft_stop();
-	report_perf();
+	ft_stop(&timer);
+	report_perf(timer);
 	return FI_SUCCESS;
 }
 
 static int handle_atomic_fetch_op(void)
 {
 	int ret = FI_SUCCESS, i;
+	union ft_timer timer;
 	size_t count = 0;
 
 	ret = check_fetch_atomic_op(ep, op_type, datatype, &count);
@@ -286,7 +288,7 @@ static int handle_atomic_fetch_op(void)
 		return ret;
 
 	opts.transfer_size = datatype_to_size(datatype);
-	ft_start();
+	ft_start(&timer);
 	for (i = 0; i < opts.iterations; i++) {
 		if (ft_check_opts(FT_OPT_VERIFY_DATA)) {
 			ret = fill_data(FT_ATOMIC_FETCH);
@@ -307,14 +309,15 @@ static int handle_atomic_fetch_op(void)
 				return ret;
 		}
 	}
-	ft_stop();
-	report_perf();
+	ft_stop(&timer);
+	report_perf(timer);
 	return FI_SUCCESS;
 }
 
 static int handle_atomic_compare_op(void)
 {
 	int ret = FI_SUCCESS, i;
+	union ft_timer timer;
 	size_t count = 0;
 
 	ret = check_compare_atomic_op(ep, op_type, datatype, &count);
@@ -322,7 +325,7 @@ static int handle_atomic_compare_op(void)
 		return ret;
 
 	opts.transfer_size = datatype_to_size(datatype);
-	ft_start();
+	ft_start(&timer);
 	for (i = 0; i < opts.iterations; i++) {
 		if (ft_check_opts(FT_OPT_VERIFY_DATA)) {
 			ret = fill_data(FT_ATOMIC_COMPARE);
@@ -343,8 +346,8 @@ static int handle_atomic_compare_op(void)
 				return ret;
 		}
 	}
-	ft_stop();
-	report_perf();
+	ft_stop(&timer);
+	report_perf(timer);
 	return FI_SUCCESS;
 }
 

--- a/fabtests/functional/unmap_mem.c
+++ b/fabtests/functional/unmap_mem.c
@@ -62,12 +62,13 @@ static void unmap_tx_buf(void)
 static int pingpong(void)
 {
 	int ret, i;
+	union ft_timer timer;
 
 	ret = ft_sync();
 	if (ret)
 		return ret;
 
-	ft_start();
+	ft_start(&timer);
 	if (opts.dst_addr) {
 		for (i = 0; i < opts.iterations; i++) {
 			ret = map_tx_buf();
@@ -99,9 +100,9 @@ static int pingpong(void)
 			unmap_tx_buf();
 		}
 	}
-	ft_stop();
+	ft_stop(&timer);
 
-	show_perf(NULL, opts.transfer_size, opts.iterations, &start, &end, 2);
+	show_perf(NULL, opts.transfer_size, opts.iterations, timer, 2);
 	return 0;
 }
 

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -109,6 +109,7 @@ enum precision {
 	NANO = 1,
 	MICRO = 1000,
 	MILLI = 1000000,
+	SECOND = 1000000000,
 };
 
 enum ft_comp_method {
@@ -225,6 +226,11 @@ struct ft_opts {
 	char **argv;
 };
 
+union ft_timer {
+	uint64_t elapsed;
+	uint64_t start;
+};
+
 extern struct fi_info *fi_pep, *fi, *hints;
 extern struct fid_fabric *fabric;
 extern struct fid_wait *waitset;
@@ -263,7 +269,6 @@ extern struct fi_cntr_attr cntr_attr;
 extern struct fi_rma_iov remote;
 
 extern char test_name[50];
-extern struct timespec start, end;
 extern struct ft_opts opts;
 
 void ft_parseinfo(int op, char *optarg, struct fi_info *hints,
@@ -520,14 +525,43 @@ static inline uint64_t ft_gettime_ms(void)
 	return ft_gettime_ns() / 1000000;
 }
 
-static inline void ft_start(void)
+static inline void ft_timer_start(union ft_timer *timer)
+{
+	timer->start = ft_gettime_ns();
+}
+static inline void ft_timer_pause(union ft_timer *timer)
+{
+	timer->elapsed = ft_gettime_ns() - timer->start;
+}
+static inline void ft_timer_resume(union ft_timer *timer)
+{
+	timer->start = ft_gettime_ns() - timer->elapsed;
+}
+static inline void ft_timer_stop(union ft_timer *timer)
+{
+	ft_timer_pause(timer);
+}
+static inline bool ft_timer_is_elapsed(union ft_timer timer, uint64_t timeout, enum precision p)
+{
+	// assuming timer is running
+	return ft_gettime_ns() - timer.start >= timeout * p;
+}
+static inline uint64_t ft_timer_get_elapsed(union ft_timer timer, enum precision p)
+{
+	// assiming timer is stopped
+	return timer.elapsed / p;
+}
+
+static inline void ft_start(union ft_timer *timer)
 {
 	opts.options |= FT_OPT_ACTIVE;
-	clock_gettime(CLOCK_MONOTONIC, &start);
+	if (timer)
+		ft_timer_start(timer);
 }
-static inline void ft_stop(void)
+static inline void ft_stop(union ft_timer *timer)
 {
-	clock_gettime(CLOCK_MONOTONIC, &end);
+	if (timer)
+		ft_timer_stop(timer);
 	opts.options &= ~FT_OPT_ACTIVE;
 }
 
@@ -644,12 +678,10 @@ int ft_cq_read_verify(struct fid_cq *cq, void *op_context);
 void eq_readerr(struct fid_eq *eq, const char *eq_str);
 int ft_poll_fd(int fd, int timeout);
 
-int64_t get_elapsed(const struct timespec *b, const struct timespec *a,
-		enum precision p);
-void show_perf(char *name, size_t tsize, int iters, struct timespec *start,
-		struct timespec *end, int xfers_per_iter);
-void show_perf_mr(size_t tsize, int iters, struct timespec *start,
-		struct timespec *end, int xfers_per_iter, int argc, char *argv[]);
+void show_perf(char *name, size_t tsize, int iters, union ft_timer timer,
+		int xfers_per_iter);
+void show_perf_mr(size_t tsize, int iters, union ft_timer timer,
+		int xfers_per_iter, int argc, char *argv[]);
 void ft_parse_opts_range(char *optarg);
 int ft_send_recv_greeting(struct fid_ep *ep);
 int ft_send_greeting(struct fid_ep *ep);

--- a/fabtests/prov/efa/src/efa_exhaust_mr_reg_common.c
+++ b/fabtests/prov/efa/src/efa_exhaust_mr_reg_common.c
@@ -151,6 +151,7 @@ void ft_efa_free_bufs(void **buffers, size_t count) {
 int ft_efa_unexpected_pingpong(void)
 {
 	int ret, i;
+	union ft_timer timer;
 
 	opts.options |= FT_OPT_OOB_CTRL;
 
@@ -160,7 +161,7 @@ int ft_efa_unexpected_pingpong(void)
 
 	for (i = 0; i < opts.iterations + opts.warmup_iterations; i++) {
 		if (i == opts.warmup_iterations)
-			ft_start();
+			ft_start(&timer);
 
 		ret = ft_post_tx(ep, remote_fi_addr, opts.transfer_size, NO_CQ_DATA, &tx_ctx);
 		if (ret)
@@ -181,14 +182,13 @@ int ft_efa_unexpected_pingpong(void)
 			return ret;
 	}
 
-	ft_stop();
+	ft_stop(&timer);
 
 	if (opts.machr)
-		show_perf_mr(opts.transfer_size, opts.iterations, &start, &end,
+		show_perf_mr(opts.transfer_size, opts.iterations, timer,
 			     2, opts.argc, opts.argv);
 	else
-		show_perf(NULL, opts.transfer_size, opts.iterations, &start,
-			  &end, 2);
+		show_perf(NULL, opts.transfer_size, opts.iterations, timer, 2);
 
 	return 0;
 }

--- a/fabtests/prov/efa/src/multi_ep_mt.c
+++ b/fabtests/prov/efa/src/multi_ep_mt.c
@@ -245,14 +245,13 @@ static void *poll_tx_cq(void *context)
 {
 	int i, ret;
 	int num_cqes = 0;
-	struct timespec a, b;
+	union ft_timer timer;
 
 	i = ((struct thread_context *) context)->idx;
 
-	clock_gettime(CLOCK_MONOTONIC, &a);
+	ft_timer_start(&timer);
 	while (true) {
-		clock_gettime(CLOCK_MONOTONIC, &b);
-		if ((b.tv_sec - a.tv_sec) > timeout) {
+		if (ft_timer_is_elapsed(timer, timeout, SECOND)) {
 			printf("%ds timeout expired, exiting \n", timeout);
 			break;
 		}
@@ -287,12 +286,11 @@ static int run_server(void)
 	}
 
 	printf("Server: wait for completions\n");
-	struct timespec a, b;
+	union ft_timer timer;
 
-	clock_gettime(CLOCK_MONOTONIC, &a);
+	ft_timer_start(&timer);
 	while (true) {
-		clock_gettime(CLOCK_MONOTONIC, &b);
-		if ((b.tv_sec - a.tv_sec) > timeout) {
+		if (ft_timer_is_elapsed(timer, timeout, SECOND)) {
 			printf("%ds timeout expired, exiting...\n", timeout);
 			break;
 		}

--- a/fabtests/ubertest/test_ctrl.c
+++ b/fabtests/ubertest/test_ctrl.c
@@ -599,6 +599,7 @@ static int ft_pingpong_dgram(void)
 static int ft_run_latency(void)
 {
 	int ret, i;
+	union ft_timer timer;
 
 	for (i = 0; i < ft_ctrl.size_cnt; i += ft_ctrl.inc_step) {
 		if (ft_ctrl.size_array[i] > fabric_info->ep_attr->max_msg_size)
@@ -626,10 +627,10 @@ static int ft_run_latency(void)
 		if (ret)
 			return ret;
 
-		clock_gettime(CLOCK_MONOTONIC, &start);
+		ft_timer_start(&timer);
 		ret = (test_info.ep_type == FI_EP_DGRAM) ?
 			ft_pingpong_dgram() : ft_pingpong();
-		clock_gettime(CLOCK_MONOTONIC, &end);
+		ft_timer_stop(&timer);
 		if (ret) {
 			FT_PRINTERR("latency test failed!", ret);
 			return ret;
@@ -639,7 +640,7 @@ static int ft_run_latency(void)
 		if (ret)
 			return ret;
 
-		show_perf("lat", ft_ctrl.size_array[i], ft_ctrl.xfer_iter, &start, &end, 2);
+		show_perf("lat", ft_ctrl.size_array[i], ft_ctrl.xfer_iter, timer, 2);
 	}
 
 	return 0;
@@ -777,6 +778,7 @@ static int ft_run_bandwidth(void)
 {
 	size_t recv_cnt;
 	int ret, i;
+	union ft_timer timer;
 
 	for (i = 0; i < ft_ctrl.size_cnt; i += ft_ctrl.inc_step) {
 		if (ft_ctrl.size_array[i] > fabric_info->ep_attr->max_msg_size)
@@ -805,10 +807,10 @@ static int ft_run_bandwidth(void)
 		if (ret)
 			return ret;
 
-		clock_gettime(CLOCK_MONOTONIC, &start);
+		ft_timer_start(&timer);
 		ret = (test_info.ep_type == FI_EP_DGRAM) ?
 			ft_bw_dgram(&recv_cnt) : ft_bw();
-		clock_gettime(CLOCK_MONOTONIC, &end);
+		ft_timer_stop(&timer);
 		if (ret) {
 			FT_PRINTERR("bw test failed!", ret);
 			return ret;
@@ -818,7 +820,7 @@ static int ft_run_bandwidth(void)
 		if (ret)
 			return ret;
 
-		show_perf("bw", ft_ctrl.size_array[i], recv_cnt, &start, &end, 1);
+		show_perf("bw", ft_ctrl.size_array[i], recv_cnt, timer, 1);
 	}
 
 	return 0;

--- a/fabtests/unit/cq_test.c
+++ b/fabtests/unit/cq_test.c
@@ -160,7 +160,7 @@ cq_signal()
 {
 	struct fid_cq *cq;
 	struct fi_cq_tagged_entry entry;
-	int64_t elapsed;
+	union ft_timer timer;
 	int testret;
 	int ret;
 
@@ -180,16 +180,15 @@ cq_signal()
 		goto fail2;
 	}
 
-	ft_start();
+	ft_timer_start(&timer);
 	ret = fi_cq_sread(cq, &entry, 1, NULL, 2000);
-	ft_stop();
-	elapsed = get_elapsed(&start, &end, MILLI);
+	ft_timer_stop(&timer);
 	if (ret != -FI_EAGAIN && ret != -FI_ECANCELED) {
 		sprintf(err_buf, "fi_cq_sread = %d %s", ret, fi_strerror(-ret));
 		goto fail2;
 	}
 
-	if (elapsed > 1000) {
+	if (ft_timer_get_elapsed(timer, MILLI) > 1000) {
 		sprintf(err_buf, "fi_cq_sread - signal ignored");
 		goto fail2;
 	}

--- a/fabtests/unit/mr_cache_evict.c
+++ b/fabtests/unit/mr_cache_evict.c
@@ -434,17 +434,18 @@ static int mr_register(const void *buf, struct fid_mr **mr, int64_t *elapsed,
 		.requested_key = FT_MR_KEY,
 		.iface = iface,
 	};
+	union ft_timer timer;
 
-	ft_start();
+	ft_timer_start(&timer);
 	ret = fi_mr_regattr(domain, &mr_attr, 0, mr);
-	ft_stop();
+	ft_timer_stop(&timer);
 
 	if (ret != FI_SUCCESS) {
 		FT_UNIT_STRERR(err_buf, "fi_mr_reg failed", -errno);
 		return -errno;
 	}
 
-	*elapsed = get_elapsed(&start, &end, NANO);
+	*elapsed = ft_timer_get_elapsed(timer, NANO);
 
 	return 0;
 }


### PR DESCRIPTION
Replace global timespec variables with a flexible ft_timer union that supports pause/resume functionality. This allows for more accurate timing measurements in tests by excluding client-server synchronization time.

In particular, this change fixes issue with `fi_rma_bw -o writedata -p efa -f efa-direct`.
Currently bandwidth numbers  produced by that benchmark are wrong. In case of `writedata` client sends a stream of write messages to server and server replies with a send after each window. The purpose of  the benchmark is to measure bandwidth of writedata operation, not the synchronization time. However in some cases synchronization time can take up to 30% of overall timing, therefore bandwidth calculation is off by the same 30%.

Key changes:
- Add ft_timer union with pause/resume capabilities
- Replace timespec usage across all test files with new timer API
- Update timing functions in benchmark and test utilities
- `bandwidth_rma -o writedata` excludes reverse sync time from total timing
- ~~`bandwidth_rma` starts timer only after all completions from warm-up iterations had been received~~
- ~~Enable payload validation for warm-up iterations~~
- ~~Increase default warmup iterations from 10 to 64 to mach default window size~~
- Fix a bug in `uni_bandwidth` due to dafaulting to a global var `targs`
- Fixed a bug with timing in `efa_gda` fabtest

This improves timing precision in fabtests by allowing tests to exclude non-measurement periods from their timing calculations.

*Edit: Crossed out changes caused increase in BW wall clock timings causing CI timeouts. Removing for now*
