### PR TITLE
prov/efa: tune recvwindow and peer reorder  buffer pool sizes

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -42,6 +42,7 @@ struct efa_rdm_ep_queued_copy {
 #define EFA_RDM_EP_MAX_WR_PER_IBV_POST_RECV (8192)
 
 #define EFA_RDM_EP_MIN_PEER_POOL_SIZE (1024)
+#define EFA_RDM_EP_MIN_PEER_REORDER_BUFFER_POOL_SIZE (16)
 
 struct efa_rdm_ep {
 	struct efa_base_ep base_ep;

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -250,7 +250,7 @@ int efa_rdm_ep_create_buffer_pools(struct efa_rdm_ep *ep)
 				(sizeof(struct efa_rdm_pke*) * (roundup_power_of_two(efa_env.recvwin_size)) +
 				sizeof(struct recvwin_cirq)),
 				EFA_RDM_BUFPOOL_ALIGNMENT, 0, /* no limit to max_cnt */
-				EFA_RDM_EP_MIN_PEER_POOL_SIZE,
+				EFA_RDM_EP_MIN_PEER_REORDER_BUFFER_POOL_SIZE,
 				0);
 
 	if (ret)

--- a/prov/efa/src/rdm/efa_rdm_peer.h
+++ b/prov/efa/src/rdm/efa_rdm_peer.h
@@ -10,7 +10,7 @@
 #include "efa_rdm_protocol.h"
 #include "efa_rdm_rxe_map.h"
 
-#define EFA_RDM_PEER_DEFAULT_REORDER_BUFFER_SIZE	(16384)
+#define EFA_RDM_PEER_DEFAULT_REORDER_BUFFER_SIZE	(8192)
 
 #define EFA_RDM_PEER_REQ_SENT BIT_ULL(0) /**< A REQ packet has been sent to the peer (peer should send a handshake back) */
 #define EFA_RDM_PEER_HANDSHAKE_SENT BIT_ULL(1) /**< a handshake packet has been sent to the peer */


### PR DESCRIPTION
changed the default recvwindow size from 16k to 8k and the peer reorder buffer pool size from 1024 to 16 to maintain the performance without adding too much of memory overhead.