### PR TITLE
prov/cxi: Fix validation of service id

### DIFF
--- a/prov/cxi/include/cxip.h
+++ b/prov/cxi/include/cxip.h
@@ -1050,7 +1050,8 @@ static inline bool cxip_domain_mr_cache_iface_enabled(struct cxip_domain *dom,
 	return cxip_domain_mr_cache_enabled(dom) && dom->iomm.monitors[iface];
 }
 
-int cxip_domain_valid_vni(struct cxip_domain *dom, unsigned int vni);
+int cxip_domain_valid_vni(struct cxip_domain *dom, struct cxi_auth_key *key);
+
 
 /* This structure implies knowledge about the breakdown of the NIC address,
  * which is taken from the AMA, that the provider does not know in a flexible

--- a/prov/cxi/src/cxip_av.c
+++ b/prov/cxi/src/cxip_av.c
@@ -557,7 +557,7 @@ static int cxip_av_insert_auth_key_validate_args(struct cxip_av *cxi_av,
 		return -FI_ENOSPC;
 	}
 
-	return cxip_domain_valid_vni(cxi_av->domain, key->vni);
+	return cxip_domain_valid_vni(cxi_av->domain, key);
 }
 
 static int cxip_av_insert_auth_key(struct fid_av *av, const void *auth_key,

--- a/prov/cxi/src/cxip_dom.c
+++ b/prov/cxi/src/cxip_dom.c
@@ -1945,11 +1945,16 @@ free_dom:
 	return -FI_EINVAL;
 }
 
-int cxip_domain_valid_vni(struct cxip_domain *dom, unsigned int vni)
+int cxip_domain_valid_vni(struct cxip_domain *dom, struct cxi_auth_key *key)
 {
-	/* Currently the auth_key.svc_id field contains the resource group ID.
-	*/
-	return cxip_if_valid_rgroup_vni(dom->iface, dom->auth_key.svc_id, vni);
+	unsigned int t_svc_id;
+
+	if (key->svc_id)
+		t_svc_id = key->svc_id;
+	else
+		t_svc_id = dom->auth_key.svc_id;
+
+	return cxip_if_valid_rgroup_vni(dom->iface, t_svc_id, key->vni);
 }
 
 #define SUPPORTED_DWQ_FLAGS (FI_MORE | FI_COMPLETION | FI_DELIVERY_COMPLETE | \

--- a/prov/cxi/test/auth_key.c
+++ b/prov/cxi/test/auth_key.c
@@ -1593,11 +1593,60 @@ void service_setup(struct cxil_dev *dev, struct cxi_svc_desc *svc_desc)
 #endif
 }
 
-void service_cleanup(struct cxil_dev *dev, struct cxi_svc_desc *svc_desc)
+Test(av_auth_key, service_id_validation_test)
 {
+	struct fi_info *hints;
+	struct fi_info *info;
 	int ret;
-	ret = cxil_destroy_svc(dev, svc_desc->svc_id);
-	cr_assert(ret, "cxil_destroy_svc failed:%d", ret);
+	struct fid_fabric *fab;
+	struct fid_domain *dom;
+	struct fid_av *av;
+	struct cxi_auth_key auth_key = {};
+	fi_addr_t addr_key;
+	struct cxil_dev *dev;
+	struct cxi_svc_desc svc_desc = {};
+	char svc_id_str[256];
+
+	ret = cxil_open_device(0, &dev);
+	cr_assert_eq(ret, 0, "cxil_open_device failed: %d", ret);
+
+	service_setup(dev, &svc_desc);
+
+	sprintf(svc_id_str, "%d", svc_desc.svc_id);
+	ret = setenv("SLINGSHOT_SVC_IDS", svc_id_str, 1);
+	cr_assert_eq(ret, 0, "setenv SLINGSHOT_SVC_IDS failed: %d", errno);
+
+	hints = fi_allocinfo();
+	cr_assert_not_null(hints, "fi_allocinfo failed");
+
+	hints->fabric_attr->prov_name = strdup("cxi");
+	cr_assert_not_null(hints, "strdup failed");
+
+	hints->domain_attr->mr_mode = FI_MR_ENDPOINT | FI_MR_ALLOCATED;
+	hints->domain_attr->auth_key_size = FI_AV_AUTH_KEY;
+	hints->domain_attr->max_ep_auth_key = NUM_VNIS;
+
+	ret = fi_getinfo(FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION), "cxi0",
+			 "255", FI_SOURCE, hints, &info);
+	cr_assert_eq(ret, FI_SUCCESS, "fi_getinfo failed: %d", ret);
+	open_av_auth_key(info, &fab, &dom, &av);
+
+	auth_key.vni = 1;
+	auth_key.svc_id = 1;
+
+	ret = fi_av_insert_auth_key(av, &auth_key, sizeof(auth_key),
+				    &addr_key, 0);
+	cr_assert_eq(ret, FI_SUCCESS,
+		     "fi_av_insert_auth_key failed: %d", ret);
+
+	close_av_auth_key(fab, dom, av);
+
+	fi_freeinfo(info);
+	fi_freeinfo(hints);
+
+	ret = cxil_destroy_svc(dev, svc_desc.svc_id);
+	cr_assert_eq(ret, 0, "cxil_destroy_svc failed: %d", ret);
+	cxil_close_device(dev);
 }
 
 Test(av_auth_key, insert_lookup_valid_auth_key)


### PR DESCRIPTION
Description
Account for the service ID that is not the same as what is defined in SLINGSHOT_SVC_IDS
