### PR TITLE
prov/efa: Add LLTng tracepoints for data path direct operations

### DIFF
--- a/prov/efa/src/efa_data_path_direct_entry.h
+++ b/prov/efa/src/efa_data_path_direct_entry.h
@@ -38,6 +38,7 @@
 #if HAVE_EFA_DATA_PATH_DIRECT
 
 #include <rdma/ib_user_verbs.h>
+#include "efa_tp.h"
 
 #include "efa_data_path_direct_internal.h"
 #include "efa_data_path_direct_structs.h"
@@ -108,6 +109,9 @@ static inline int efa_data_path_direct_post_recv(struct efa_qp *qp,
 			if (!(wq->pc & wq->desc_mask))
 				wq->phase++;
 		}
+#if HAVE_LTTNG
+		efa_data_path_direct_tracepoint_post_recv(qp, wr);
+#endif
 		wr = wr->next;
 	}
 
@@ -140,7 +144,7 @@ static inline int efa_data_path_direct_wr_complete(struct efa_qp *qp)
 	/* it should not be possible to get here with sq->num_wqe_pending==0 */
 	assert(sq->num_wqe_pending);
 
-	efa_data_path_direct_send_wr_post_working(sq, true);
+	efa_data_path_direct_send_wr_post_working(qp, sq, true);
 
 out:
 	return qp->data_path_direct_qp.wr_session_err;

--- a/prov/efa/src/efa_tp.h
+++ b/prov/efa/src/efa_tp.h
@@ -61,6 +61,76 @@ static inline void efa_rdm_tracepoint_wr_id_post_write(const void *wr_id)
 	efa_tracepoint(post_write, (size_t) wr_id, (size_t) ope->cq_entry.op_context);
 }
 
+#if HAVE_EFA_DATA_PATH_DIRECT
+
+static inline void efa_data_path_direct_tracepoint_post_send(
+		const struct efa_qp *qp,
+		const struct efa_data_path_direct_sq *sq)
+{
+	efa_tracepoint(data_path_direct_post_send,
+		       qp->base_ep->domain->device->ibv_ctx->device->name,
+		       sq->wq.wrid[sq->curr_tx_wqe.meta.req_id],
+		       EFA_GET(&sq->curr_tx_wqe.meta.ctrl1, EFA_IO_TX_META_DESC_OP_TYPE),
+		       qp->ibv_qp->qp_num,
+		       sq->curr_tx_wqe.meta.dest_qp_num,
+		       sq->curr_tx_wqe.meta.ah,
+		       sq->curr_tx_wqe.meta.length);
+}
+
+static inline void efa_data_path_direct_tracepoint_post_recv(
+		const struct efa_qp *qp,
+		const struct ibv_recv_wr *wr)
+{
+	efa_tracepoint(data_path_direct_post_recv,
+		qp->base_ep->domain->device->ibv_ctx->device->name,
+		wr->wr_id,
+		qp->ibv_qp->qp_num,
+		wr->num_sge);
+}
+
+static inline void efa_data_path_direct_tracepoint_process_completion(
+		const struct efa_qp *qp,
+		const struct ibv_cq_ex *ibvcqx,
+		const struct efa_io_cdesc_common *cqe)
+{
+	/* Extract opcode inline - similar to efa_data_path_direct_wc_read_opcode */
+	enum efa_io_send_op_type op_type = EFA_GET(&cqe->flags, EFA_IO_CDESC_COMMON_OP_TYPE);
+	int opcode;
+	uint32_t src_qp_num;
+	uint16_t ah_num;
+	uint32_t length = 0;
+
+	if (EFA_GET(&cqe->flags, EFA_IO_CDESC_COMMON_Q_TYPE) == EFA_IO_SEND_QUEUE) {
+		opcode = (op_type == EFA_IO_RDMA_WRITE) ? IBV_WC_RDMA_WRITE : IBV_WC_SEND;
+		src_qp_num = qp->ibv_qp->qp_num; /* For TX, src is our QP */
+		ah_num = UINT16_MAX; /* Not applicable for TX */
+	} else {
+		/* RX completion */
+		opcode = (op_type == EFA_IO_RDMA_WRITE) ? IBV_WC_RECV_RDMA_WITH_IMM : IBV_WC_RECV;
+		/* Extract src_qp and ah from RX completion - inline version of helper functions */
+		const struct efa_io_rx_cdesc *rcqe = container_of(cqe, struct efa_io_rx_cdesc, common);
+		src_qp_num = rcqe->src_qp_num;
+		ah_num = rcqe->ah;
+
+		/* Extract length for RX - inline version of efa_data_path_direct_wc_read_byte_len */
+		const struct efa_io_rx_cdesc_ex *rcqe_ex = container_of(cqe, struct efa_io_rx_cdesc_ex, base.common);
+		length = rcqe_ex->base.length;
+		if (op_type == EFA_IO_RDMA_WRITE)
+			length |= ((uint32_t)rcqe_ex->u.rdma_write.length_hi << 16);
+	}
+
+	efa_tracepoint(data_path_direct_process_completion,
+		qp->base_ep->domain->device->ibv_ctx->device->name,
+		ibvcqx,
+		opcode,
+		src_qp_num,
+		qp->ibv_qp->qp_num,
+		ah_num,
+		length);
+}
+
+#endif /* HAVE_EFA_DATA_PATH_DIRECT */
+
 #else
 
 #define efa_tracepoint(...)	do {} while(0)

--- a/prov/efa/src/efa_tp_def.h
+++ b/prov/efa/src/efa_tp_def.h
@@ -119,6 +119,120 @@ LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(EFA_TP_PROV, completion_with_opcode, EFA_TP_
 	LTTNG_UST_TP_ARGS(X_WR_ID_OPCODE_ARGS))
 LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_TP_PROV, handle_completion, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
 
+#if HAVE_EFA_DATA_PATH_DIRECT
+
+// Direct data path tracepoints - similar to rdma-core EFA provider
+#include "efa_io_defs.h"
+#include <infiniband/verbs.h>
+
+LTTNG_UST_TRACEPOINT_ENUM(efa, efa_io_send_op_type,
+	LTTNG_UST_TP_ENUM_VALUES(
+		lttng_ust_field_enum_value("EFA_IO_SEND", EFA_IO_SEND)
+		lttng_ust_field_enum_value("EFA_IO_RDMA_READ", EFA_IO_RDMA_READ)
+		lttng_ust_field_enum_value("EFA_IO_RDMA_WRITE", EFA_IO_RDMA_WRITE)
+	)
+)
+
+
+LTTNG_UST_TRACEPOINT_EVENT_CLASS(EFA_TP_PROV, data_path_direct_post_recv_class,
+	LTTNG_UST_TP_ARGS(
+		const char *, dev_name,
+		uint64_t, wr_id,
+		uint32_t, qp_num,
+		int, num_sge
+	),
+	LTTNG_UST_TP_FIELDS(
+		lttng_ust_field_string(dev_name, dev_name)
+		lttng_ust_field_integer(uint64_t, wr_id, wr_id)
+		lttng_ust_field_integer(uint32_t, qp_num, qp_num)
+		lttng_ust_field_integer(int, num_sge, num_sge)
+	)
+)
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(EFA_TP_PROV, data_path_direct_post_recv_class, EFA_TP_PROV,
+	data_path_direct_post_recv,
+	LTTNG_UST_TP_ARGS(
+		const char *, dev_name,
+		uint64_t, wr_id,
+		uint32_t, qp_num,
+		int, num_sge
+	)
+)
+LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_TP_PROV, data_path_direct_post_recv, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
+
+LTTNG_UST_TRACEPOINT_EVENT_CLASS(EFA_TP_PROV, data_path_direct_post_send_class,
+	LTTNG_UST_TP_ARGS(
+		const char *, dev_name,
+		uint64_t, wr_id,
+		uint8_t, op_type,
+		uint32_t, src_qp_num,
+		uint32_t, dst_qp_num,
+		uint16_t, ah_num,
+		uint32_t, length
+	),
+	LTTNG_UST_TP_FIELDS(
+		lttng_ust_field_string(dev_name, dev_name)
+		lttng_ust_field_integer(uint64_t, wr_id, wr_id)
+		lttng_ust_field_enum(efa, efa_io_send_op_type, uint8_t, op_type, op_type)
+		lttng_ust_field_integer(uint32_t, src_qp_num, src_qp_num)
+		lttng_ust_field_integer(uint32_t, dst_qp_num, dst_qp_num)
+		lttng_ust_field_integer(uint16_t, ah_num, ah_num)
+		lttng_ust_field_integer(uint32_t, length, length)
+	)
+)
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(EFA_TP_PROV, data_path_direct_post_send_class, EFA_TP_PROV,
+	data_path_direct_post_send,
+	LTTNG_UST_TP_ARGS(
+		const char *, dev_name,
+		uint64_t, wr_id,
+		uint8_t, op_type,
+		uint32_t, src_qp_num,
+		uint32_t, dst_qp_num,
+		uint16_t, ah_num,
+		uint32_t, length
+	)
+)
+LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_TP_PROV, data_path_direct_post_send, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
+
+LTTNG_UST_TRACEPOINT_EVENT_CLASS(EFA_TP_PROV, data_path_direct_process_completion_class,
+	LTTNG_UST_TP_ARGS(
+		const char *, dev_name,
+		const struct ibv_cq_ex *, ibvcqx,
+		int, opcode,
+		uint32_t, src_qp_num,
+		uint32_t, dst_qp_num,
+		uint16_t, ah_num,
+		uint32_t, length
+	),
+	LTTNG_UST_TP_FIELDS(
+		lttng_ust_field_string(dev_name, dev_name)
+		lttng_ust_field_integer(uint64_t, wr_id, ibvcqx->wr_id)
+		lttng_ust_field_integer(int, status, ibvcqx->status)
+		lttng_ust_field_integer(int, opcode, opcode)
+		lttng_ust_field_integer(uint32_t, src_qp_num, src_qp_num)
+		lttng_ust_field_integer(uint32_t, dst_qp_num, dst_qp_num)
+		lttng_ust_field_integer(uint16_t, ah_num, ah_num)
+		lttng_ust_field_integer(uint32_t, length, length)
+	)
+)
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(EFA_TP_PROV, data_path_direct_process_completion_class, EFA_TP_PROV,
+	data_path_direct_process_completion,
+	LTTNG_UST_TP_ARGS(
+		const char *, dev_name,
+		const struct ibv_cq_ex *, ibvcqx,
+		int, opcode,
+		uint32_t, src_qp_num,
+		uint32_t, dst_qp_num,
+		uint16_t, ah_num,
+		uint32_t, length
+	)
+)
+LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_TP_PROV, data_path_direct_process_completion, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
+
+#endif /* HAVE_EFA_DATA_PATH_DIRECT */
+
 #endif /* _EFA_TP_DEF_H */
 
 #include <lttng/tracepoint-event.h>


### PR DESCRIPTION
Add three LLTng tracepoints to the EFA data path direct under the 'efa' provider, mirroring the tracepoint implementation in rdma-core's EFA provider. These tracepoints provide visibility into send/receive operations and completion processing for performance analysis and debugging.

Tracepoints added:
- efa:data_path_direct_post_recv Traces receive work request posting with device name, wr_id, qp_num, and num_sge. Called in efa_data_path_direct_post_recv() after WR is posted.

- efa:data_path_direct_post_send Traces send work request posting with device name, wr_id, op_type, src_qp_num, dst_qp_num, ah_num, and length. Called in efa_data_path_direct_send_wr_post_working() after the WQE is fully populated, ensuring all parameters have meaningful values.

- efa:data_path_direct_process_completion Traces completion processing with device name, wr_id, status, opcode, src_qp_num, dst_qp_num, ah_num, and length. Called in efa_data_path_direct_process_ex_cqe() with context-aware parameter extraction that handles both TX and RX completions.

Implementation details:
- Added tracepoint definitions to prov/efa/src/efa_tp_def.h
- Modified efa_data_path_direct_send_wr_post_working() signature to accept qp parameter, enabling access to device name and queue pair information
- Wrapped process_completion tracepoint computation in #if HAVE_LTTNG to avoid unused variable warnings when compiled without LLTng support
- All tracepoint parameters match rdma-core's EFA provider field types and semantics

Usage:
  lttng enable-event --userspace efa:data_path_direct_*