### PR TITLE
fabtests/efa: BUG: efa_gda: recv buffer verification is skipped silently

### DIFF
--- a/fabtests/prov/efa/src/efa_gda.c
+++ b/fabtests/prov/efa/src/efa_gda.c
@@ -227,7 +227,7 @@ static int run()
 			return ret;
 		}
 
-		if (ft_check_opts(FT_OPT_VERIFY_DATA | FT_OPT_ACTIVE)) {
+		if (ft_check_opts(FT_OPT_VERIFY_DATA)) {
 			ret = ft_fill_buf((char *) tx_buf + ft_tx_prefix_size(),
 					  opts.transfer_size);
 			if (ret)
@@ -310,7 +310,7 @@ static int run()
 			} while (ret == 0);
 
 		verify_data:
-			if (ft_check_opts(FT_OPT_VERIFY_DATA | FT_OPT_ACTIVE)) {
+			if (ft_check_opts(FT_OPT_VERIFY_DATA)) {
 				ret = ft_check_buf((char *) rx_buf,
 						   opts.transfer_size);
 				if (ret)
@@ -348,7 +348,7 @@ int main(int argc, char **argv)
 			ft_parse_api_opts(op, optarg, hints, &opts);
 			break;
 		case 'v':
-			opts.options |= FT_OPT_VERIFY_DATA | FT_OPT_ACTIVE;
+			opts.options |= FT_OPT_VERIFY_DATA;
 			break;
 		case '?':
 		case 'h':


### PR DESCRIPTION
Problem:

efa_gda fabtest had a logical bug. When verifying rx_buf contents, we checked if both `FT_OPT_VERIFY_DATA` and `FT_OPT_ACTIVE` options were set. However, `FT_OPT_ACTIVE` is unset by `ft_stop()`, which is called in the main loop to check for timeout.

Fix:

Check only for `FT_OPT_VERIFY_DATA` option.