### PR TITLE
fabtests/rdm_bw_mt: Fix performance timer in uni_bandwidth function

### DIFF
--- a/fabtests/benchmarks/rdm_bw_mt.c
+++ b/fabtests/benchmarks/rdm_bw_mt.c
@@ -440,6 +440,7 @@ static int bw_recv(void *context)
 static void *uni_bandwidth(void *context)
 {
 	int i, ret;
+	const struct thread_args *targs = context;
 
 	pthread_barrier_wait(&barrier);
 	for (i = 0; i < opts.warmup_iterations; i++) {


### PR DESCRIPTION
The `uni_bandwidth()` function was using the global `targs` variable instead of the thread-local context parameter when checking thread ID. This caused all threads to see `targs->id == 0` and call `ft_start()`/`ft_stop()`, resulting in multiple threads restarting the performance timer instead of only thread 0.

Fixed by adding a local `targs` variable that properly references the thread-specific context, ensuring only thread 0 controls the performance timer as intended. This corrects bandwidth measurement accuracy in unidirectional multi-threaded tests.