### PR TITLE
fabtests/benchmark_shared:  Force sync after each warmup iteration for bandwidth_rma

### DIFF
--- a/fabtests/benchmarks/benchmark_shared.c
+++ b/fabtests/benchmarks/benchmark_shared.c
@@ -767,7 +767,7 @@ int bandwidth_rma(enum ft_rma_opcodes rma_op, struct fi_rma_iov *remote)
 		if (ret)
 			return ret;
 
-		if (++j == opts.window_size) {
+		if (++j == opts.window_size || i < opts.warmup_iterations) {
 			ret = bw_rma_comp(rma_op, j);
 			if (ret)
 				return ret;


### PR DESCRIPTION
Modify bandwidth_rma() to synchronize after every warmup iteration instead of only at window boundaries. This ensures proper warmup of the server->client connection path for unidirectinal mode

The writedata test asymmetry (client sends many writes, server replies with single send per window) means only the client->server path gets warmed up during normal iterations. Forcing sync during warmup ensures both directions are properly established before timing begins.

~Also increase default warmup iterations from 10 to 16.~