### PR TITLE
[v2.3.x] pick contrib/intel/jenkins: Properly do withEnv ${} & exclude contrib/cray

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -132,7 +132,7 @@ def skip() {
   }
 
   echo "Changeset is: ${changeStrings.toArray()}"
-  if (changeStrings.toArray().every { it =~ /(?:fabtests\/pytest|man|prov\/efa|prov\/opx|prov\/cxi|prov\/lpp|contrib\/aws|.github).*$/ }) {
+  if (changeStrings.toArray().every { it =~ /(?:fabtests\/pytest|man|prov\/efa|prov\/opx|prov\/cxi|prov\/lpp|contrib\/aws|contrib\/cray|.github).*$/ }) {
     echo "DONT RUN!"
     return true
   }


### PR DESCRIPTION
CTARGET was not protected with ${} and was being intepreted as a string when it should have been.
Add contrib/cray to opt-out path