### PR TITLE
prov/efa: Remove the incorrect check for device max_msg_size

### DIFF
--- a/prov/efa/test/efa_unit_test_info.c
+++ b/prov/efa/test/efa_unit_test_info.c
@@ -117,11 +117,6 @@ static void test_info_direct_attributes_impl(struct fi_info *hints,
 		assert_int_equal(info->domain_attr->progress, FI_PROGRESS_AUTO);
 		assert_int_equal(info->domain_attr->control_progress, FI_PROGRESS_AUTO);
 		assert_int_equal(
-			g_efa_selected_device_list[0].rdm_info->ep_attr->max_msg_size,
-			(info->caps & FI_RMA) ?
-				g_efa_selected_device_list[0].max_rdma_size :
-				g_efa_selected_device_list[0].ibv_port_attr.max_msg_sz);
-		assert_int_equal(
 			info->ep_attr->max_msg_size,
 			(hints->caps & FI_RMA) ?
 				g_efa_selected_device_list[0].max_rdma_size :


### PR DESCRIPTION
Device rdm_info is different from the info returned by fi_getinfo. Its max_msg_size is determined by g_efa_selected_device_list[0].rdm_info->caps so we shouldn't check it with info->caps here.