### PR TITLE
.github/pr_ci: update mac OS workflow

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -159,7 +159,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    runs-on: macos-13
+    runs-on: macos-latest
     steps:
       - name: Install dependencies (Mac OS)
         run: |


### PR DESCRIPTION
macos-13 is being deprecated
Update to always use latest