### PR TITLE
prov/efa: Ignore rma completion to a removed peer

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
@@ -577,6 +577,13 @@ void efa_rdm_pke_handle_rma_completion(struct efa_rdm_pke *context_pkt_entry)
 
 	assert(efa_rdm_pke_get_base_hdr(context_pkt_entry)->version == EFA_RDM_PROTOCOL_VERSION);
 
+	if (!context_pkt_entry->peer) {
+		EFA_WARN(FI_LOG_CQ, "ignoring rma completion of a packet to a removed peer.\n");
+		efa_rdm_ep_record_tx_op_completed(context_pkt_entry->ep, context_pkt_entry);
+		efa_rdm_pke_release_tx(context_pkt_entry);
+		return;
+	}
+
 	rma_context_pkt = (struct efa_rdm_rma_context_pkt *)context_pkt_entry->wiredata;
 
 	switch (rma_context_pkt->context_type) {


### PR DESCRIPTION
The rma completion should be ignored if application removed the peer's address from av. This prevents double free of the txe since it is already released in efa_rdm_peer_destruct.