### PR TITLE
fabtests/benchmarks: Separate warmup and measurement phases in RMA ba…

### DIFF
--- a/fabtests/benchmarks/benchmark_shared.h
+++ b/fabtests/benchmarks/benchmark_shared.h
@@ -49,7 +49,7 @@ int pingpong(void);
 int run_pingpong(void);
 int bandwidth(void);
 int pingpong_rma(enum ft_rma_opcodes rma_op, struct fi_rma_iov *remote);
-int bandwidth_rma(enum ft_rma_opcodes op, struct fi_rma_iov *remote);
+int bandwidth_rma(enum ft_rma_opcodes op, struct fi_rma_iov *remote, bool is_warmup);
 int rma_tx_completion(enum ft_rma_opcodes rma_op, struct fi_rma_iov *remote);
 
 #ifdef __cplusplus

--- a/fabtests/benchmarks/rma_bw.c
+++ b/fabtests/benchmarks/rma_bw.c
@@ -58,19 +58,23 @@ static int run(void)
 	if (ret)
 		return ret;
 
+	ret = bandwidth_rma(opts.rma_op, &remote, true);
+	if (ret)
+		goto out;
+
 	if (!(opts.options & FT_OPT_SIZE)) {
 		for (i = 0; i < TEST_CNT; i++) {
 			if (!ft_use_size(i, opts.sizes_enabled))
 				continue;
 			opts.transfer_size = test_size[i].size;
 			init_test(&opts, test_name, sizeof(test_name));
-			ret = bandwidth_rma(opts.rma_op, &remote);
+			ret = bandwidth_rma(opts.rma_op, &remote, false);
 			if (ret)
 				goto out;
 		}
 	} else {
 		init_test(&opts, test_name, sizeof(test_name));
-		ret = bandwidth_rma(opts.rma_op, &remote);
+		ret = bandwidth_rma(opts.rma_op, &remote, false);
 		if (ret)
 			goto out;
 	}


### PR DESCRIPTION
…ndwidth tests

- Add is_warmup parameter to bandwidth_rma() function to distinguish between warmup and measurement phases
- Add explicit warmup run before the main benchmark loop in rma_bw.c
- Ensure accurate bandwidth measurements by isolating warmup overhead
- Add warmup for server->client connection for `writedata` mode
- Skip perf stats printing for warmup pass

This change improves the accuracy of RMA bandwidth measurements by clearly separating the warmup phase from the actual performance measurement phase.