### PR TITLE
prov/efa: configure: replace no-break space with regular space character

### DIFF
--- a/prov/efa/configure.m4
+++ b/prov/efa/configure.m4
@@ -286,7 +286,7 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 	AS_IF([test x"$efa_LIBDIR" != x""],
 	[
 		AC_MSG_NOTICE([Adding RUNPATH for EFA libraries: $efa_LIBDIR])
-		efa_LDFLAGS+=" -L$efa_LIBDIR -Wl,--enable-new-dtags,-rpath,$efa_LIBDIR"
+		efa_LDFLAGS+=" -L$efa_LIBDIR -Wl,--enable-new-dtags,-rpath,$efa_LIBDIR"
 	])
 	cmocka_rpath=""
 	AC_ARG_ENABLE([efa-unit-test],


### PR DESCRIPTION
Build with clang fails due to no-break space accidentally added to configure script. Replacing it with a regular space.

Issue: https://github.com/ofiwg/libfabric/issues/11572