### PR TITLE
prov/efa: Introduce pke generation counter for protocol path

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_cq.c
+++ b/prov/efa/src/rdm/efa_rdm_cq.c
@@ -86,13 +86,9 @@ static struct fi_ops efa_rdm_cq_fi_ops = {
  * @param[in]		ep	        efa_rdm_ep
  * @param[in]		pkt_entry	packet entry
  */
-static
-void efa_rdm_cq_proc_ibv_recv_rdma_with_imm_completion(
-						       struct efa_ibv_cq *ibv_cq,
-						       uint64_t flags,
-						       struct efa_rdm_ep *ep,
-						       struct efa_rdm_pke *pkt_entry
-						       )
+static void efa_rdm_cq_proc_ibv_recv_rdma_with_imm_completion(
+	struct efa_ibv_cq *ibv_cq, uint64_t flags, struct efa_rdm_ep *ep,
+	struct efa_rdm_pke *pkt_entry)
 {
 	struct util_cq *target_cq;
 	int ret;
@@ -602,6 +598,11 @@ enum ibv_wc_status efa_rdm_cq_process_wc_closing_ep(struct efa_ibv_cq *cq, struc
 	struct efa_rdm_pke *pkt_entry = (struct efa_rdm_pke *) wr_id;
 	int prov_errno;
 
+#if ENABLE_DEBUG
+	if (!efa_cq_wc_is_unsolicited(cq))
+		pkt_entry = efa_rdm_cq_get_pke_from_wr_id(wr_id);
+#endif
+
 #if HAVE_LTTNG
 	efa_rdm_tracepoint(poll_cq, (size_t) wr_id);
 	if (pkt_entry && pkt_entry->ope)
@@ -667,6 +668,12 @@ enum ibv_wc_status efa_rdm_cq_process_wc(struct efa_ibv_cq *cq, struct efa_rdm_e
 	enum ibv_wc_status status = cq->ibv_cq_ex->status;
 	enum ibv_wc_opcode opcode = efa_ibv_cq_wc_read_opcode(cq);
 	struct efa_rdm_pke *pkt_entry = (struct efa_rdm_pke *) wr_id;
+
+#if ENABLE_DEBUG
+	if (!efa_cq_wc_is_unsolicited(cq))
+		pkt_entry = efa_rdm_cq_get_pke_from_wr_id(wr_id);
+#endif
+
 	int prov_errno;
 
 #if HAVE_LTTNG

--- a/prov/efa/src/rdm/efa_rdm_cq.h
+++ b/prov/efa/src/rdm/efa_rdm_cq.h
@@ -5,6 +5,7 @@
 #define EFA_RDM_CQ_H
 
 #include "efa_cq.h"
+#include "efa_data_path_ops.h"
 #include <ofi_util.h>
 
 struct efa_rdm_cq {
@@ -19,5 +20,17 @@ int efa_rdm_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 
 void efa_rdm_cq_poll_ibv_cq_closing_ep(struct efa_ibv_cq *ibv_cq, struct efa_rdm_ep *closing_ep);
 int efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq);
+
+#if ENABLE_DEBUG
+static inline struct efa_rdm_pke *efa_rdm_cq_get_pke_from_wr_id(uint64_t wr_id)
+{
+	struct efa_rdm_pke *pkt_entry;
+	uint8_t gen = wr_id & (EFA_RDM_BUFPOOL_ALIGNMENT - 1);
+	wr_id &= ~(EFA_RDM_BUFPOOL_ALIGNMENT - 1);
+	pkt_entry = (struct efa_rdm_pke *) wr_id;
+	assert(pkt_entry->gen == gen);
+	return pkt_entry;
+}
+#endif
 
 #endif

--- a/prov/efa/src/rdm/efa_rdm_pke.h
+++ b/prov/efa/src/rdm/efa_rdm_pke.h
@@ -87,6 +87,9 @@ struct efa_rdm_pke {
 #if ENABLE_DEBUG
 	/** @brief entry to a linked list of posted buf list */
 	struct dlist_entry dbg_entry;
+
+	/**@brief Generation counter. It is incremented every time the packet is posted to rdma-core */
+	uint8_t gen;
 #endif
 	/** @brief pointer to #efa_rdm_ep */
 	struct efa_rdm_ep *ep;

--- a/prov/efa/test/efa_unit_test_cq.c
+++ b/prov/efa/test/efa_unit_test_cq.c
@@ -477,7 +477,7 @@ void test_ibv_cq_ex_read_bad_recv_status(struct efa_resource **state)
 #if HAVE_CAPS_UNSOLICITED_WRITE_RECV
 	if (ibv_cq->unsolicited_write_recv_enabled) {
 		g_efa_unit_test_mocks.efa_ibv_cq_wc_is_unsolicited = &efa_mock_efa_ibv_cq_wc_is_unsolicited_return_mock;
-		will_return(efa_mock_efa_ibv_cq_wc_is_unsolicited_return_mock, false);
+		will_return_always(efa_mock_efa_ibv_cq_wc_is_unsolicited_return_mock, false);
 	}
 #endif
 
@@ -556,7 +556,7 @@ void test_ibv_cq_ex_read_bad_recv_rdma_with_imm_status_impl(struct efa_resource 
 	if (use_unsolicited_recv) {
 		g_efa_unit_test_mocks.efa_ibv_cq_wc_is_unsolicited = &efa_mock_efa_ibv_cq_wc_is_unsolicited_return_mock;
 		ibv_cq->unsolicited_write_recv_enabled = true;
-		will_return(efa_mock_efa_ibv_cq_wc_is_unsolicited_return_mock, true);
+		will_return_always(efa_mock_efa_ibv_cq_wc_is_unsolicited_return_mock, true);
 		ibv_cq->ibv_cq_ex->wr_id = 0;
 	} else {
 		/*

--- a/prov/efa/test/efa_unit_test_mocks.c
+++ b/prov/efa/test/efa_unit_test_mocks.c
@@ -10,6 +10,7 @@
 #include <setjmp.h>
 #include <cmocka.h>
 #include "efa.h"
+#include "efa_rdm_cq.h"
 #include "efa_rdm_pke_utils.h"
 #include "efa_rdm_pke_nonreq.h"
 #include "efa_unit_test_mocks.h"
@@ -277,7 +278,11 @@ int efa_mock_efa_qp_post_send_verify_handshake_pkt_local_host_id_and_save_wr(str
 	struct efa_rdm_base_hdr *efa_rdm_base_hdr;
 	uint64_t *host_id_ptr;
 
-	pke = (struct efa_rdm_pke *)wr_id;
+	pke = (struct efa_rdm_pke *) wr_id;
+#if ENABLE_DEBUG
+	pke = efa_rdm_cq_get_pke_from_wr_id(wr_id);
+#endif
+
 	efa_rdm_base_hdr = efa_rdm_pke_get_base_hdr(pke);
 
 	assert_int_equal(efa_rdm_base_hdr->type, EFA_RDM_HANDSHAKE_PKT);

--- a/prov/efa/test/efa_unit_test_mocks.h
+++ b/prov/efa/test/efa_unit_test_mocks.h
@@ -5,6 +5,7 @@
 #define EFA_UNIT_TEST_RDMA_CORE_MOCKS_H
 
 #include "efa_cq.h"
+#include "efa_rdm_cq.h"
 #include "efa_base_ep.h"
 
 extern struct efa_unit_test_mocks g_efa_unit_test_mocks;

--- a/prov/efa/test/efa_unit_test_ope.c
+++ b/prov/efa/test/efa_unit_test_ope.c
@@ -245,6 +245,8 @@ void test_efa_rdm_ope_post_write_0_byte(struct efa_resource **state)
 	struct efa_rdm_ope mock_txe;
 	size_t raw_addr_len = sizeof(raw_addr);
 	fi_addr_t addr;
+	uint64_t wr_id;
+	struct efa_rdm_pke *pkt_entry;
 	int ret, err;
 
 	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_FABRIC_NAME);
@@ -283,7 +285,14 @@ void test_efa_rdm_ope_post_write_0_byte(struct efa_resource **state)
 	assert_int_equal(err, 0);
 	assert_int_equal(g_ibv_submitted_wr_id_cnt, 1);
 
-	efa_rdm_pke_release_tx((struct efa_rdm_pke *)g_ibv_submitted_wr_id_vec[0]);
+	wr_id = (uint64_t) g_ibv_submitted_wr_id_vec[0];
+
+	pkt_entry = (struct efa_rdm_pke *) wr_id;
+#if ENABLE_DEBUG
+	pkt_entry = efa_rdm_cq_get_pke_from_wr_id(wr_id);
+#endif
+
+	efa_rdm_pke_release_tx(pkt_entry);
 	mock_txe.ep->efa_outstanding_tx_ops = 0;
 	efa_unit_test_buff_destruct(&local_buff);
 }

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -230,7 +230,6 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_cq_data_path_direct_with_wait_obj, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_cq_data_path_direct_disabled_with_old_device, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_cq_data_path_direct_enabled_with_new_device, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
-		
 		/* end efa_unit_test_cq.c */
 
 		/* begin efa_unit_test_info.c */
@@ -275,7 +274,7 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_info_direct_rma_without_rx_cq_data_when_no_unsolicited_write_recv, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_info_direct_no_rma_no_rx_cq_data_when_no_unsolicited_write_recv, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_info_direct_rma_without_rx_cq_data_when_unsolicited_write_recv_supported, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
-/* end efa_unit_test_info.c */
+		/* end efa_unit_test_info.c */
 
 		cmocka_unit_test_setup_teardown(test_efa_hmem_info_update_neuron, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_hmem_info_disable_p2p_neuron, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
@@ -293,8 +292,7 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ope_prepare_to_post_send_host_memory_align128, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ope_prepare_to_post_send_cuda_memory, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ope_prepare_to_post_send_cuda_memory_align128, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
-		cmocka_unit_test_setup_teardown(test_efa_rdm_ope_post_write_0_byte,
-		efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_rdm_ope_post_write_0_byte, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_rxe_post_local_read_or_queue_unhappy, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_rxe_post_local_read_or_queue_happy, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_txe_handle_error_write_cq, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
@@ -309,7 +307,6 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_rdm_rxe_handle_error_queue_flags_cleanup, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_txe_handle_error_duplicate_prevention, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_rxe_handle_error_duplicate_prevention, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
-
 		/* end of efa_unit_test_ope.c */
 
 		cmocka_unit_test_setup_teardown(test_efa_rdm_msg_send_to_local_peer_with_null_desc, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),


### PR DESCRIPTION
This commit uses the last 5 bits of the pke pointer for a generation counter that is incremented every time the packet entry is posted to rdma-core. When we receive a completion from rdma-core, we verfiy that the completion is for the latest posted packet.