### PR TITLE
fabtests/efa: Fixes to multi_ep_mt test

### DIFF
--- a/fabtests/prov/efa/src/multi_ep_mt.c
+++ b/fabtests/prov/efa/src/multi_ep_mt.c
@@ -53,6 +53,7 @@ char remote_raw_addr[FT_MAX_CTRL_MSG];
 
 static bool shared_av = false;
 int num_avs;
+static time_t random_seed = -1;
 
 void close_client(int i);
 int open_client(int i);
@@ -213,15 +214,14 @@ static void *post_sends(void *context)
 	size_t len;
 	int num_transient_eps = 10;
 	int av_idx = 0;
+	int num_sends;
 
 	idx = ((struct thread_context *) context)->idx;
 	av_idx = shared_av ? 0 : idx;
 
-	srand(time(NULL));
-
 	random_sleep();
 
-	len = opts.transfer_size;
+	len = rand() % opts.transfer_size;
 	for (j = 0; j < num_transient_eps; j++) {
 		printf("Thread %d: opening client \n", idx);
 		ret = open_client(idx);
@@ -230,8 +230,9 @@ static void *post_sends(void *context)
 			return NULL;
 		}
 
-		for (i = 0; i < opts.iterations / num_transient_eps; i++) {
-			printf("Thread %d: post send for ep %d \n", idx, idx);
+		num_sends = opts.iterations / num_transient_eps;
+		printf("Thread %d: post %d sends for ep %d \n", num_sends, idx, idx);
+		for (i = 0; i < num_sends; i++) {
 			ret = ft_post_tx_buf(eps[idx], remote_fiaddr[idx], len, NO_CQ_DATA, &send_ctx[idx], send_bufs[idx], send_descs[idx], ft_tag);
 			if (ret) {
 				FT_PRINTERR("ft_post_tx_buf", ret);
@@ -275,7 +276,8 @@ static void *poll_tx_cq(void *context)
 		if (ret)
 			continue;
 		num_cqes++;
-		printf("Client: thread %d get %d completion from tx cq \n", i,
+		if (num_cqes % 100 == 0)
+			printf("Client: thread %d get %d completion from tx cq \n", i,
 		       num_cqes);
 		// This is the maximal number of sends client will do
 		if (num_cqes == num_eps * opts.iterations)
@@ -289,11 +291,13 @@ static int run_server(void)
 {
 	int i, ret;
 	int num_cqes = 0;
+	int num_recvs;
 
 	// posting enough recv buffers for each ep
 	// so the sent pkts can at least find a match
-	for (i = 0; i < opts.iterations * num_eps; i++) {
-		printf("Server: posting recv\n");
+	num_recvs = opts.iterations * num_eps;
+	printf("Server: posting %d recv\n", num_recvs);
+	for (i = 0; i < num_recvs; i++) {
 		ret = ft_post_rx_buf(ep, FI_ADDR_UNSPEC, opts.transfer_size, &rx_ctx, rx_buf, mr_desc, ft_tag);
 		if (ret) {
 			FT_PRINTERR("ft_post_rx_buf", ret);
@@ -316,7 +320,8 @@ static int run_server(void)
 		if (ret)
 			continue;
 		num_cqes++;
-		printf("Server: Get %d completions from rx cq\n", num_cqes);
+		if (num_cqes % 100 == 0)
+			printf("Server: Get %d completions from rx cq\n", num_cqes);
 		// This is the maximal number of sends client will do
 		if (num_cqes == num_eps * opts.iterations)
 			break;
@@ -502,6 +507,19 @@ static int run_test(void)
 	else
 		num_avs = num_eps;
 
+	if (random_seed != -1) {
+		printf("-------------------\n");
+		printf("Using random seed %ld\n", random_seed);
+		printf("-------------------\n");
+	} else {
+		random_seed = time(NULL);
+		printf("-------------------\n");
+		printf("Generated random seed %ld\n", random_seed);
+		printf("-------------------\n");
+	}
+
+	srand(random_seed);
+
 	opts.av_size = num_eps + 1;
 	ret = init_fabric();
 	if (ret)
@@ -543,7 +561,7 @@ int main(int argc, char **argv)
 		return EXIT_FAILURE;
 
 	while ((op = getopt_long(argc, argv,
-				 "c:hT:A" ADDR_OPTS INFO_OPTS CS_OPTS, long_opts,
+				 "c:hT:AN:" ADDR_OPTS INFO_OPTS CS_OPTS, long_opts,
 				 &lopt_idx)) != -1) {
 		switch (op) {
 		default:
@@ -561,6 +579,9 @@ int main(int argc, char **argv)
 			break;
 		case 'A':
 			shared_av = true;
+			break;
+		case 'N':
+			random_seed = atol(optarg);
 			break;
 		case '?':
 		case 'h':


### PR DESCRIPTION
This commit
(1) Logs the random seed and introduces an option to run the test with a
given random seed. It can help in reproducing test failures
(2) Chooses a random message size for each send with the maximum being
opts.transfer_size
(3) Reduces log noise