### PR TITLE
prov/cxi: change cuda dmabuf default to enabled

### DIFF
--- a/man/fi_cxi.7.md
+++ b/man/fi_cxi.7.md
@@ -446,11 +446,10 @@ information.
 The CXI provider supports DMABUF for device memory registration.
 DMABUF is supported in ROCm 5.6+ and Cuda 11.7+ with nvidia open source driver
 525+.
-Both *FI_HMEM_ROCR_USE_DMABUF* and *FI_HMEM_CUDA_USE_DMABUF are disabled by
-default in libfabric core but the CXI provider enables
-*FI_HMEM_ROCR_USE_DMABUF* by default if not specifically set.
-There may be situations with CUDA that may double the BAR consumption.
-Until this is fixed in the CUDA stack, CUDA DMABUF will be disabled by default.
+Both *FI_HMEM_ROCR_USE_DMABUF* and *FI_HMEM_CUDA_USE_DMABUF* are disabled by
+default in libfabric core but the CXI provider enables both
+*FI_HMEM_ROCR_USE_DMABUF* and *FI_HMEM_CUDA_USE_DMABUF* by default if not
+specifically set.
 
 ## Translation Cache
 

--- a/prov/cxi/src/cxip_info.c
+++ b/prov/cxi/src/cxip_info.c
@@ -794,10 +794,10 @@ static void cxip_env_init(void)
 		CXIP_INFO("Could not enable FI_HMEM_ROCR_USE_DMABUF ret:%d %s\n",
 			  ret, fi_strerror(errno));
 
-	/* Disable cuda DMABUF by default - honors the env if already set */
-	ret = setenv("FI_HMEM_CUDA_USE_DMABUF", "0", 0);
+	/* Use cuda DMABUF by default - honors the env if already set */
+	ret = setenv("FI_HMEM_CUDA_USE_DMABUF", "1", 0);
 	if (ret)
-		CXIP_INFO("Could not disable FI_HMEM_CUDA_USE_DMABUF ret:%d %s\n",
+		CXIP_INFO("Could not enable FI_HMEM_CUDA_USE_DMABUF ret:%d %s\n",
 			  ret, fi_strerror(errno));
 
 	fi_param_define(&cxip_prov, "ats_mlock_mode", FI_PARAM_STRING,

--- a/prov/cxi/test/cuda.c
+++ b/prov/cxi/test/cuda.c
@@ -590,9 +590,6 @@ Test(cuda, dmabuf_stress)
 	struct fid_mr *mr;
 	cudaError_t cuda_ret;
 
-	ret = setenv("FI_HMEM_CUDA_USE_DMABUF", "1", 1);
-	cr_assert_eq(ret, 0, "setenv failed: %d", -errno);
-
 	ret = setenv("FI_MR_CUDA_CACHE_MONITOR_ENABLED", "0", 1);
 	cr_assert_eq(ret, 0, "setenv failed: %d", -errno);
 


### PR DESCRIPTION
Nvidia gpu driver 580 fully supports dmabuf so use dmabuf as the default.