### PR TITLE
prov/efa: do not ignore local read completion

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
@@ -577,7 +577,8 @@ void efa_rdm_pke_handle_rma_completion(struct efa_rdm_pke *context_pkt_entry)
 
 	assert(efa_rdm_pke_get_base_hdr(context_pkt_entry)->version == EFA_RDM_PROTOCOL_VERSION);
 
-	if (!context_pkt_entry->peer) {
+	/* pkt_entry->peer can be NULL for a local read operation, which shouldn't be ignored. */
+	if (!context_pkt_entry->peer && !(context_pkt_entry->flags & EFA_RDM_PKE_LOCAL_READ)) {
 		EFA_WARN(FI_LOG_CQ, "ignoring rma completion of a packet to a removed peer.\n");
 		efa_rdm_ep_record_tx_op_completed(context_pkt_entry->ep, context_pkt_entry);
 		efa_rdm_pke_release_tx(context_pkt_entry);


### PR DESCRIPTION
pkt_entry->peer can be NULL for a local read operation. In this case, the rma completion cannot be ignored. Similar to https://github.com/ofiwg/libfabric/pull/6976/commits/2eb975c59323e75395204d3ee9711f6ca4d748e0.