### PR TITLE
prov/efa: Grow efa_tx_pkt_pool and ope_pool during rdm ep creation

### DIFF
--- a/prov/efa/test/efa_unit_test_mr.c
+++ b/prov/efa/test/efa_unit_test_mr.c
@@ -31,26 +31,29 @@ void test_efa_rdm_mr_reg_host_memory(struct efa_resource **state)
 	size_t mr_size = 64;
 	void *buf;
 	struct fid_mr *mr = NULL;
+	int baseline_ct, baseline_sz;
 
 	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_FABRIC_NAME);
 
 	efa_domain = container_of(resource->domain, struct efa_domain,
 				  util_domain.domain_fid);
 
+	/* fi_endpoint calls ofi_bufpool_grow, which registers mr */
+	baseline_ct = efa_domain->ibv_mr_reg_ct;
+	baseline_sz = efa_domain->ibv_mr_reg_sz;
+
 	buf = malloc(mr_size);
 	assert_non_null(buf);
-
-	test_efa_mr_impl(efa_domain, mr, 0, 0, false);
 
 	assert_int_equal(fi_mr_reg(resource->domain, buf, mr_size,
 				   FI_SEND | FI_RECV, 0, 0, 0, &mr, NULL),
 			 0);
 
 	/* No GDRCopy registration for host memory */
-	test_efa_mr_impl(efa_domain, mr, 1, mr_size, false);
+	test_efa_mr_impl(efa_domain, mr, baseline_ct + 1, baseline_sz + mr_size, false);
 
 	assert_int_equal(fi_close(&mr->fid), 0);
-	test_efa_mr_impl(efa_domain, NULL, 0, 0, false);
+	test_efa_mr_impl(efa_domain, NULL, baseline_ct, baseline_sz, false);
 	free(buf);
 }
 
@@ -62,6 +65,7 @@ void test_efa_rdm_mr_reg_host_memory_no_mr_local(struct efa_resource **state)
 	size_t mr_size = 64;
 	void *buf;
 	struct fid_mr *mr = NULL;
+	int baseline_ct, baseline_sz;
 
 	hints = efa_unit_test_alloc_hints(FI_EP_RDM, EFA_FABRIC_NAME);
 	hints->domain_attr->mr_mode &= ~FI_MR_LOCAL;
@@ -72,20 +76,22 @@ void test_efa_rdm_mr_reg_host_memory_no_mr_local(struct efa_resource **state)
 	efa_domain = container_of(resource->domain, struct efa_domain,
 				  util_domain.domain_fid);
 
+	/* fi_endpoint calls ofi_bufpool_grow, which registers mr */
+	baseline_ct = efa_domain->ibv_mr_reg_ct;
+	baseline_sz = efa_domain->ibv_mr_reg_sz;
+
 	buf = malloc(mr_size);
 	assert_non_null(buf);
-
-	test_efa_mr_impl(efa_domain, mr, 0, 0, false);
 
 	assert_int_equal(fi_mr_reg(resource->domain, buf, mr_size,
 				   FI_SEND | FI_RECV, 0, 0, 0, &mr, NULL),
 			 0);
 
 	/* No GDRCopy registration for host memory */
-	test_efa_mr_impl(efa_domain, mr, 1, mr_size, false);
+	test_efa_mr_impl(efa_domain, mr, baseline_ct + 1, baseline_sz + mr_size, false);
 
 	assert_int_equal(fi_close(&mr->fid), 0);
-	test_efa_mr_impl(efa_domain, NULL, 0, 0, false);
+	test_efa_mr_impl(efa_domain, NULL, baseline_ct, baseline_sz, false);
 	free(buf);
 }
 
@@ -96,36 +102,38 @@ void test_efa_rdm_mr_reg_host_memory_overlapping_buffers(struct efa_resource **s
 	size_t mr_size = 1024;
 	void *buf;
 	struct fid_mr *mr_1 = NULL, *mr_2 = NULL;
+	int baseline_ct, baseline_sz;
 
 	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_FABRIC_NAME);
 
 	efa_domain = container_of(resource->domain, struct efa_domain,
 				  util_domain.domain_fid);
 
+	/* fi_endpoint calls ofi_bufpool_grow, which registers mr */
+	baseline_ct = efa_domain->ibv_mr_reg_ct;
+	baseline_sz = efa_domain->ibv_mr_reg_sz;
+
 	buf = malloc(mr_size);
 	assert_non_null(buf);
-
-	test_efa_mr_impl(efa_domain, mr_1, 0, 0, false);
-	test_efa_mr_impl(efa_domain, mr_2, 0, 0, false);
 
 	assert_int_equal(fi_mr_reg(resource->domain, buf, mr_size,
 				   FI_SEND | FI_RECV, 0, 0, 0, &mr_1, NULL),
 			 0);
 
 	/* No GDRCopy registration for host memory */
-	test_efa_mr_impl(efa_domain, mr_1, 1, mr_size, false);
+	test_efa_mr_impl(efa_domain, mr_1, baseline_ct + 1, baseline_sz + mr_size, false);
 
 	assert_int_equal(fi_mr_reg(resource->domain, buf, mr_size,
 				   FI_SEND | FI_RECV, 0, 0, 0, &mr_2, NULL),
 			 0);
 
-	test_efa_mr_impl(efa_domain, mr_2, 2, mr_size * 2, false);
+	test_efa_mr_impl(efa_domain, mr_2, baseline_ct + 2, baseline_sz + mr_size * 2, false);
 
 	assert_int_equal(fi_close(&mr_1->fid), 0);
-	test_efa_mr_impl(efa_domain, mr_2, 1, mr_size, false);
+	test_efa_mr_impl(efa_domain, mr_2, baseline_ct + 1, baseline_sz + mr_size, false);
 
 	assert_int_equal(fi_close(&mr_2->fid), 0);
-	test_efa_mr_impl(efa_domain, NULL, 0, 0, false);
+	test_efa_mr_impl(efa_domain, NULL, baseline_ct, baseline_sz, false);
 
 	free(buf);
 }


### PR DESCRIPTION
The memory pool allocation of efa_tx_pkt_pool and ope_pool are happening during the first handshake and add 6ms latency overhead to the communication. Fix it by eagerly allocating the pool during ep creation.