### PR TITLE
fabtests/efa: Wait for send completion from each endpoint

### DIFF
--- a/fabtests/prov/efa/src/efa_implicit_av_test.c
+++ b/fabtests/prov/efa/src/efa_implicit_av_test.c
@@ -366,17 +366,19 @@ cleanup_client:
 		}
 
 		FT_INFO("Server: Step 1 - Send messages from all endpoints\n");
-		/* Send from all endpoints */
+		/*
+		 Send and wait for completion from each endpoint
+		 Waiting for a send completion from each endpoint is necessary
+		 to make sure that the packets from different endpoints do not
+		 get re-ordered
+		 */
 		for (i = 0; i < num_server_eps; i++) {
 			ret = server_post_send(i);
 			if (ret) {
 				FT_PRINTERR("server_post_send", ret);
 				goto cleanup_server;
 			}
-		}
 
-		/* Wait for all send completions */
-		for (i = 0; i < num_server_eps; i++) {
 			ret = get_one_comp(server_txcqs[i]);
 			if (ret) {
 				FT_PRINTERR("get_server_comp", ret);

--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -270,7 +270,7 @@ def test_implicit_av_limited_av_size_expected_path(cmdline_args, msg_size):
 # TODO: Add test with larger message size that uses the long read protocol after
 # fixing the test to poll CQ while waiting for the server to get send completions
 @pytest.mark.parametrize("msg_size", [1, 1024, 8192, 24756])
-def test_implicit_av_limited_av_size_unexpected_path(cmdline_args, msg_size, node_count):
+def test_implicit_av_limited_av_size_unexpected_path(cmdline_args, msg_size):
     import os
     binpath = cmdline_args.binpath or ""
     if not os.path.exists(os.path.join(binpath, "fi_efa_implicit_av_test")):


### PR DESCRIPTION
In the implicit AV test, if a message requires multiple packets and the packets get re-ordered, the receiver could evict the implicit AV entry before all of the packets have arrived. Waiting for a send completion before the next send makes sure that doesn't happen.