### PR TITLE
util: Use kdreg2 instead of memhooks as default when available

### DIFF
--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -298,12 +298,12 @@ void ofi_monitors_init(void)
 	if (!default_monitor) {
 #if defined(HAVE_MR_CACHE_MONITOR_DEFAULT)
 		set_default_monitor(HAVE_MR_CACHE_MONITOR_DEFAULT);
+#elif HAVE_KDREG2_MONITOR
+		default_monitor = kdreg2_monitor;
 #elif HAVE_MEMHOOKS_MONITOR
 		default_monitor = memhooks_monitor;
 #elif HAVE_UFFD_MONITOR
 		default_monitor = uffd_monitor;
-#elif HAVE_KDREG2_MONITOR
-		default_monitor = kdreg2_monitor;
 #else
 		default_monitor = NULL;
 #endif


### PR DESCRIPTION
The kdreg2 memory monitor has less issue than memhooks. Use kdreg2 by default if it is available.