### PR TITLE
Update build.rs to support both cargo build & cargo publish work directories.

### DIFF
--- a/.github/workflows/binding-checks.yaml
+++ b/.github/workflows/binding-checks.yaml
@@ -19,7 +19,10 @@ jobs:
       run: cargo fmt --check
     - name: Build Rust binding
       run: |
-        cargo build --features vendored
+        cargo clean && cargo build --features vendored
     - name: Test Rust binding
       run: |
-        cargo test --features vendored
+        cargo clean && cargo test --features vendored
+    - name: Dry-run publish Rust binding
+      run: |
+        cargo clean && cargo publish --dry-run -p ofi-libfabric-sys --features vendored


### PR DESCRIPTION
### Motivation

For the case of `cargo publish` (which is required to publish the Rust library crate), it performs a clean isolated build under a folder directory one level deeper than `cargo build`. Namely;

```rust
// For the case of cargo build:
// manifest_dir = {your_libfabric_directory}/bindings/rust
//
// For the case of cargo publish:
// manifest_dir = {your_libfabric_directory}/target/package/ofi-libfabric-sys-x.y.z
```

Unfortunately, the existing `build.rs` cannot support both, as it performs a fixed "3 step" ancestor directory walking via;
```rust
// Fixed 3 steps walking.
// This will not work for both `cargo build` & `cargo publish`.
let libfabric_par_dir = Path::new("../../../"); 
```

To support compilation for both environments, `CARGO_WORKSPACE_DIR` is introduced to conditionally walk over ancestry directory.

### Changes
- Two new global variables, `CARGO_MANIFEST_DIR` and `CARGO_WORKSPACE_DIR`.
    - `OnceLock` used over `static mut`, as globally mutable variable `static mut` is not recommended [[source](https://internals.rust-lang.org/t/pre-rfc-deprecate-then-remove-static-mut/20072)].
- Add a new Github workflow step for `cargo publish --dry-run` to catch this scenario moving forward.
- (Minor change) cargo clean before every binding check, such that it restarts from a clean slate.

### Tests
- Confirmed new Github workflow passing; https://github.com/kyle-yh-kim/libfabric/actions/runs/19585546689