### PR TITLE
prov/efa: adjust the memory barrier positions

### DIFF
--- a/prov/efa/src/efa_data_path_direct_internal.h
+++ b/prov/efa/src/efa_data_path_direct_internal.h
@@ -585,7 +585,6 @@ efa_data_path_direct_send_wr_ring_db(struct efa_data_path_direct_sq *sq)
 {
 	mmio_flush_writes();
 	efa_sq_ring_doorbell(sq, sq->wq.pc);
-	mmio_wc_start();
 	sq->num_wqe_pending = 0;
 }
 


### PR DESCRIPTION
We need such barrier in two transitions:
1. from wqe write to doorbell ring
2. from doorbell ring to wqe write.

For #2, we currently have the barrier right after the doorbell ring, which is different from rdma-core implementation that has the doorbell right in the next wr_start, and according to benchmark such choice hurts performance on ARM platform. This patch moves the #2 barrier to the beginning of wr start, before the wqe write, to be consistent with rdma-core and improves the performance.