### PR TITLE
.github/workflow: Add auto release publish workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,88 @@
+name: Auto Release
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+  packages: read
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.base.ref }}
+        fetch-depth: 0
+
+    - name: Extract version
+      id: version
+      run: |
+        VERSION=$(grep 'AC_INIT' configure.ac | sed 's/.*\[libfabric\], \[\([^]]*\)\].*/\1/')
+        TAG="v$VERSION"
+        echo "Extracted version: $VERSION"
+        echo "Release tag: $TAG"
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "tag=$TAG" >> $GITHUB_OUTPUT
+
+    - name: Build libfabric
+      run: |
+        set -x
+        ./autogen.sh
+        ./configure --prefix=$PWD/install
+        make
+        make install
+        make dist
+
+    - name: Build fabtests
+      run: |
+        set -x
+        cd fabtests
+        ./autogen.sh
+        ./configure --with-libfabric=$PWD/../install
+        make dist
+
+    - name: Generate checksums
+      id: checksums
+      run: |
+        echo "sha512_sums<<EOF" >> $GITHUB_OUTPUT
+        sha512sum libfabric-*.tar.* fabtests/fabtests-*.tar.* >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
+        echo "md5_sums<<EOF" >> $GITHUB_OUTPUT
+        md5sum libfabric-*.tar.* fabtests/fabtests-*.tar.* >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
+
+    - name: Create Release
+      uses: softprops/action-gh-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ steps.version.outputs.tag }}
+        name: Libfabric ${{ steps.version.outputs.version }}
+        target_commitish: ${{ github.event.pull_request.base.ref }}
+        draft: true
+        body: |
+          The OpenFabrics Interfaces Working Group (OFIWG) and the libfabric open-source community are pleased to announce the release of version ${{ steps.version.outputs.version }} of libfabric. See [NEWS.md](https://github.com/${{ github.repository }}/blob/${{ steps.version.outputs.tag }}/NEWS.md) for the list of features and enhancements that have been added since the last release. Installation instructions are available in the [README.md](https://github.com/${{ github.repository }}/blob/${{ steps.version.outputs.tag }}/README.md) file in the source tree or at the project's homepage.
+
+          Download the distribution tarballs below to get started:
+
+          **sha512 sums**
+          ```
+          ${{ steps.checksums.outputs.sha512_sums }}
+          ```
+
+          **md5sums**
+          ```
+          ${{ steps.checksums.outputs.md5_sums }}
+          ```
+
+          ${{ github.event.pull_request.body }}
+        files: |
+          libfabric-*.tar.gz
+          libfabric-*.tar.bz2
+          fabtests/fabtests-*.tar.gz
+          fabtests/fabtests-*.tar.bz2


### PR DESCRIPTION
It is a workflow that automates the release process 

## Expected Workflow

### Trigger:
1. Create a PR with the `release` label
2. Merge the PR

### Automatic Actions:
1. **Extract Version** - Reads version from `configure.ac` AC_INIT line (e.g., `2.4.0a1`)
2. **Build** - Runs `./autogen.sh`, `./configure`, `make dist` to create tarballs
3. **Generate Checksums** - Calculates SHA256 and MD5 sums for all `.tar.gz` and `.tar.bz2` files
4. **Create Draft Release** - Creates GitHub draft release with:
   - **Tag**: Version from configure.ac (e.g., `2.4.0a1`)
   - **Title**: "Libfabric 2.4.0a1"
   - **Body**: Official OFIWG announcement text + checksums + PR description
   - **Assets**: Both `.tar.gz` and `.tar.bz2` files

### Result:
A professional libfabric draft release page matching the official OFIWG format with checksums and downloadable tarballs, ready for manual publishing.

### Usage:
1. Update version in `configure.ac` if needed
2. Add the `release` label to any PR
3. Merge the PR
4. Review the generated draft release
5. Manually publish when ready