### PR TITLE
prov/ucx: Fix multi-threading support

### DIFF
--- a/man/fi_ucx.7.md
+++ b/man/fi_ucx.7.md
@@ -56,6 +56,9 @@ Threading
 *FI_UCX_CHECK_REQ_LEAK*
 : Check request leak (default: disabled).
 
+*FI_UCX_SINGLE_THREAD*
+: Only use a single thread for all UCX operations (default: disabled).
+
 # SEE ALSO
 
 [`fabric`(7)](fabric.7.html),

--- a/prov/ucx/src/ucx.h
+++ b/prov/ucx/src/ucx.h
@@ -104,6 +104,7 @@ struct ucx_global_descriptor{
 	int ep_flush;
 	int enable_spawn;
 	int check_req_leak;
+	int single_thread;
 };
 
 struct ucx_fabric {

--- a/prov/ucx/src/ucx_ep.c
+++ b/prov/ucx/src/ucx_ep.c
@@ -263,7 +263,6 @@ int ucx_ep_open(struct fid_domain *domain, struct fi_info *info,
 	ucs_status_t status = UCS_OK;
 	ucp_worker_params_t worker_params = {
 		.field_mask = UCP_WORKER_PARAM_FIELD_THREAD_MODE,
-		.thread_mode = UCS_THREAD_MODE_SINGLE,
 	};
 	void *addr_local = NULL;
 	size_t addr_len_local;
@@ -278,6 +277,13 @@ int ucx_ep_open(struct fid_domain *domain, struct fi_info *info,
 				       context, ucx_ep_progress);
 	if (ofi_status)
 		goto free_ep;
+
+	if (ucx_descriptor.single_thread)
+		worker_params.thread_mode = UCS_THREAD_MODE_SINGLE;
+	else if (info->domain_attr->threading == FI_THREAD_SAFE)
+		worker_params.thread_mode = UCS_THREAD_MODE_MULTI;
+	else
+		worker_params.thread_mode = UCS_THREAD_MODE_SERIALIZED;
 
 #if HAVE_DECL_UCP_WORKER_FLAG_IGNORE_REQUEST_LEAK
 	if (!ucx_descriptor.check_req_leak) {


### PR DESCRIPTION
The threading mode was set to `FI_THREAD_SAFE`, but the UCX threading mode was set to `UCS_THREAD_MODE_SINGLE` which only allowed a single thread to access UCX objects. Trying to access an EP (which hosts the UCX worker) from multiple threads may cause the following error:

`ucp_ep.c:1808 Assertion 'ucs_async_check_owner_thread(&(worker)->async)' failed`

Changes made:

(1) Allow threading mode be set based on application hints.

(2) Use proper UCX threading mode based on OFI threading mode.

(3) Add a runtime parameter to force single thread mode. This is for the
    purpose of evaluating the performance impact of supporting multiple
    threads since the default setting has changed.

Fix #11651 