### PR TITLE
[v2.4.x] prov/tcp: move keepalive to connect done

### DIFF
--- a/prov/tcp/src/xnet.h
+++ b/prov/tcp/src/xnet.h
@@ -791,4 +791,5 @@ int xnet_rdm_ops_open(struct fid *fid, const char *name,
 		fi_strerror((int) -(err)), (int) err)
 
 void xnet_disable_keepalive(struct xnet_ep *ep);
+int xnet_enable_keepalive(struct xnet_ep *ep);
 #endif //_XNET_H_

--- a/prov/tcp/src/xnet_cm.c
+++ b/prov/tcp/src/xnet_cm.c
@@ -336,6 +336,16 @@ void xnet_connect_done(struct xnet_ep *ep)
 		goto disable;
 	}
 
+	/* Enable keepalive to make sure the socket status can be reset in time
+	 * if the remote peer is restarted after it gets connreq but not replies.
+	 */
+	ret = xnet_enable_keepalive(ep);
+	if (ret) {
+		FI_WARN(&xnet_prov, FI_LOG_EP_CTRL, "%p set tcp keepalive failure:%d\n",
+			ep, ret);
+		goto disable;
+	}
+
 	ret = xnet_send_cm_msg(ep);
 	if (ret)
 		goto disable;

--- a/prov/tcp/src/xnet_ep.c
+++ b/prov/tcp/src/xnet_ep.c
@@ -172,7 +172,7 @@ xnet_disable_keepalive(struct xnet_ep *ep)
 	FI_INFO(&xnet_prov, FI_LOG_EP_CTRL, "ep %p KEEPALIVE is disabled.\n", ep);
 }
 
-static int
+int
 xnet_enable_keepalive(struct xnet_ep *ep)
 {
 	int optval = 1;
@@ -361,16 +361,6 @@ xnet_ep_accept(struct fid_ep *ep_fid, const void *param, size_t paramlen)
 	if (paramlen) {
 		memcpy(ep->cm_msg->data, param, paramlen);
 		ep->cm_msg->hdr.seg_size = htons((uint16_t) paramlen);
-	}
-
-	/* Enable keepalive to make sure the socket status can be reset in time
-	 * if the remote peer is restarted after it gets connreq but not replies.
-	 */
-	ret = xnet_enable_keepalive(ep);
-	if (ret) {
-		FI_WARN(&xnet_prov, FI_LOG_EP_CTRL, "%p set tcp keepalive failure:%d\n",
-			ep, ret);
-		return ret;
 	}
 
 	ret = xnet_send_cm_msg(ep);


### PR DESCRIPTION
Move the TCP keepalive setup from the accept to
connect_done, because keepalive is intended to
be enabled on the client side during connect
request processing to ensures the client can
detect a hang in the case where the remote peer
restarts after receiving the connect request but
before sending the reply.


(cherry picked from commit a2496c1797f4629f0a5495f5519f7493313183d4)