### PR TITLE
[v2.4.x]prov/efa: Unlink RX packet entries before releasing during ep cleanup

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -772,6 +772,8 @@ static void efa_rdm_ep_destroy_buffer_pools(struct efa_rdm_ep *efa_rdm_ep)
 		EFA_WARN(FI_LOG_EP_CTRL,
 			"Closing ep with unreleased RX pkt_entry: %p\n",
 			pkt_entry);
+		/* Unlink the packet entries before releasing */
+		pkt_entry->next = NULL;
 		efa_rdm_pke_release_rx(pkt_entry);
 	}
 


### PR DESCRIPTION
Packet entries in rx_pkt_list may be linked together when efa_rdm_pke_append() is called during packet processing. The efa_rdm_pke_release_rx() function asserts that pkt_entry->next is NULL, so we must unlink packet entries before releasing them during endpoint cleanup.


(cherry picked from commit 022bfa9e8f3703cc782c018fcb3a274ea9d10a8d)