### PR TITLE
prov/efa: Various bugfixes for EFA-direct's blocking CQ read

### DIFF
--- a/prov/efa/src/efa_cq.c
+++ b/prov/efa/src/efa_cq.c
@@ -516,6 +516,7 @@ static ssize_t efa_cq_sreadfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 {
 	struct efa_cq *cq;
 	ssize_t ret = 0;
+	uint64_t endtime = ofi_timeout_time(timeout);
 	ssize_t threshold = 1, num_completions;
 	uint8_t *buffer;
 
@@ -537,6 +538,8 @@ static ssize_t efa_cq_sreadfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 
 	for (num_completions = 0; num_completions < threshold; ) {
 		if (efa_cq_trywait(cq) == FI_SUCCESS) {
+			if (ofi_adjust_timeout(endtime, &timeout))
+				return num_completions ? num_completions : -FI_EAGAIN;
 			/* CQ is empty, wait for events */
 			ret = efa_poll_events(cq, timeout);
 			if (ret)


### PR DESCRIPTION
This smooths a few edges, but also fixes a couple critical bugs:
- Using `cond` directly for the threshold instead of dereferencing it (effectively ignores `cond` unless it's null)
- Not adjusting the timeout before polling the comp channel in each iteration.
