### PR TITLE
prov/efa: Validate `buf` and `count` inputs in CQ sreadfrom

### DIFF
--- a/prov/efa/src/efa_cq.c
+++ b/prov/efa/src/efa_cq.c
@@ -519,6 +519,9 @@ static ssize_t efa_cq_sreadfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 	ssize_t threshold, num_completions;
 	uint8_t *buffer;
 
+	if (OFI_UNLIKELY(!buf || !count))
+		return -FI_EINVAL;
+
 	buffer = buf;
 	cq = container_of(cq_fid, struct efa_cq, util_cq.cq_fid);
 


### PR DESCRIPTION
Moved to dedicated PR from #11744 to capture discussion re: `-FI_EINVAL`.