### PR TITLE
prov/efa: Fix unittest build warnings

### DIFF
--- a/prov/efa/test/efa_unit_test_av.c
+++ b/prov/efa/test/efa_unit_test_av.c
@@ -24,8 +24,7 @@ void test_av_insert_duplicate_raw_addr(struct efa_resource **state)
 	int err, num_addr;
 
 	g_efa_unit_test_mocks.ibv_create_ah = &efa_mock_ibv_create_ah_check_mock;
-	/* the following will_return ensures ibv_create_ah is called exactly once */
-	will_return(efa_mock_ibv_create_ah_check_mock, 0);
+	expect_function_call(efa_mock_ibv_create_ah_check_mock);
 
 	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_FABRIC_NAME);
 
@@ -60,8 +59,7 @@ void test_av_insert_duplicate_gid(struct efa_resource **state)
 	int err, num_addr;
 
 	g_efa_unit_test_mocks.ibv_create_ah = &efa_mock_ibv_create_ah_check_mock;
-	/* the following will_return ensures ibv_create_ah is called exactly once */
-	will_return(efa_mock_ibv_create_ah_check_mock, 0);
+	expect_function_call(efa_mock_ibv_create_ah_check_mock);
 
 	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_FABRIC_NAME);
 

--- a/prov/efa/test/efa_unit_test_cq.c
+++ b/prov/efa/test/efa_unit_test_cq.c
@@ -24,14 +24,14 @@ void test_impl_cq_read_empty_cq(struct efa_resource *resource, enum fi_ep_type e
 	g_efa_unit_test_mocks.efa_ibv_cq_start_poll = &efa_mock_efa_ibv_cq_start_poll_return_mock;
 
 	/* ibv_start_poll to return ENOENT means device CQ is empty */
-	will_return(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
+	will_return_int(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
 
 	ret = fi_cq_read(resource->cq, &cq_entry, 1);
 
 	assert_int_equal(ret, -FI_EAGAIN);
 
 	/* reset the mocked cq before it's polled by ep close */
-	will_return_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
+	will_return_int_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
 	assert_int_equal(fi_close(&resource->ep->fid), 0);
 	resource->ep = NULL;
 }
@@ -109,7 +109,7 @@ static void test_rdm_cq_read_bad_send_status(struct efa_resource *resource,
 
 	/* Mock the general QP post send function to save work request IDs */
 	g_efa_unit_test_mocks.efa_qp_post_send = &efa_mock_efa_qp_post_send_return_mock;
-	will_return(efa_mock_efa_qp_post_send_return_mock, 0);
+	will_return_int(efa_mock_efa_qp_post_send_return_mock, 0);
 	assert_int_equal(g_ibv_submitted_wr_id_cnt, 0);
 
 	err = fi_send(resource->ep, send_buff.buff, send_buff.size, fi_mr_desc(send_buff.mr), addr, NULL /* context */);
@@ -124,11 +124,11 @@ static void test_rdm_cq_read_bad_send_status(struct efa_resource *resource,
 	g_efa_unit_test_mocks.efa_ibv_cq_wc_read_opcode = &efa_mock_efa_ibv_cq_wc_read_opcode_return_mock;
 	g_efa_unit_test_mocks.efa_ibv_cq_wc_read_vendor_err = &efa_mock_efa_ibv_cq_wc_read_vendor_err_return_mock;
 	g_efa_unit_test_mocks.efa_ibv_cq_wc_read_qp_num = &efa_mock_efa_ibv_cq_wc_read_qp_num_return_mock;
-	will_return(efa_mock_efa_ibv_cq_start_poll_use_saved_send_wr_with_mock_status, IBV_WC_GENERAL_ERR);
-	will_return(efa_mock_efa_ibv_cq_end_poll_check_mock, NULL);
-	will_return(efa_mock_efa_ibv_cq_wc_read_opcode_return_mock, IBV_WC_SEND);
-	will_return(efa_mock_efa_ibv_cq_wc_read_vendor_err_return_mock, vendor_error);
-	will_return(efa_mock_efa_ibv_cq_wc_read_qp_num_return_mock, efa_rdm_ep->base_ep.qp->qp_num);
+	will_return_int(efa_mock_efa_ibv_cq_start_poll_use_saved_send_wr_with_mock_status, IBV_WC_GENERAL_ERR);
+	expect_function_call(efa_mock_efa_ibv_cq_end_poll_check_mock);
+	will_return_int(efa_mock_efa_ibv_cq_wc_read_opcode_return_mock, IBV_WC_SEND);
+	will_return_uint(efa_mock_efa_ibv_cq_wc_read_vendor_err_return_mock, vendor_error);
+	will_return_uint(efa_mock_efa_ibv_cq_wc_read_qp_num_return_mock, efa_rdm_ep->base_ep.qp->qp_num);
 	ret = fi_cq_read(resource->cq, &cq_entry, 1);
 	/* fi_cq_read() called efa_mock_efa_ibv_cq_start_poll_use_saved_send_wr(), which pulled one send_wr from g_ibv_submitted_wr_idv=_vec */
 	assert_int_equal(g_ibv_submitted_wr_id_cnt, 0);
@@ -173,7 +173,7 @@ static void test_rdm_cq_read_bad_send_status(struct efa_resource *resource,
 	efa_unit_test_buff_destruct(&send_buff);
 
 	/* reset the mocked cq before it's polled by ep close */
-	will_return_always(efa_mock_efa_ibv_cq_start_poll_use_saved_send_wr_with_mock_status, ENOENT);
+	will_return_int_always(efa_mock_efa_ibv_cq_start_poll_use_saved_send_wr_with_mock_status, ENOENT);
 	assert_int_equal(fi_close(&resource->ep->fid), 0);
 	resource->ep = NULL;
 }
@@ -332,11 +332,11 @@ void test_rdm_cq_handshake_bad_send_status_impl(struct efa_resource **state, int
 	ibv_cq->ibv_cq_ex->wr_id = (uintptr_t)pkt_entry;
 
 	/* Mock cq to simulate the send comp error */
-	will_return(efa_mock_efa_ibv_cq_end_poll_check_mock, NULL);
-	will_return(efa_mock_efa_ibv_cq_wc_read_opcode_return_mock, IBV_WC_SEND);
-	will_return(efa_mock_efa_ibv_cq_wc_read_qp_num_return_mock, efa_rdm_ep->base_ep.qp->qp_num);
-	will_return(efa_mock_efa_ibv_cq_wc_read_vendor_err_return_mock, prov_errno);
-	will_return(efa_mock_efa_ibv_cq_start_poll_return_mock, IBV_WC_SUCCESS);
+	expect_function_call(efa_mock_efa_ibv_cq_end_poll_check_mock);
+	will_return_int(efa_mock_efa_ibv_cq_wc_read_opcode_return_mock, IBV_WC_SEND);
+	will_return_uint(efa_mock_efa_ibv_cq_wc_read_qp_num_return_mock, efa_rdm_ep->base_ep.qp->qp_num);
+	will_return_uint(efa_mock_efa_ibv_cq_wc_read_vendor_err_return_mock, prov_errno);
+	will_return_int(efa_mock_efa_ibv_cq_start_poll_return_mock, IBV_WC_SUCCESS);
 
 	efa_rdm_ep->efa_outstanding_tx_ops = 1;
 	ibv_cq->ibv_cq_ex->status = IBV_WC_GENERAL_ERR;
@@ -355,7 +355,7 @@ void test_rdm_cq_handshake_bad_send_status_impl(struct efa_resource **state, int
 	}
 
 	/* reset the mocked cq before it's polled by ep close */
-	will_return_always(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
+	will_return_int_always(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
 	assert_int_equal(fi_close(&resource->ep->fid), 0);
 	resource->ep = NULL;
 }
@@ -459,15 +459,15 @@ void test_ibv_cq_ex_read_bad_recv_status(struct efa_resource **state)
 	g_efa_unit_test_mocks.efa_ibv_cq_wc_read_vendor_err = &efa_mock_efa_ibv_cq_wc_read_vendor_err_return_mock;
 	g_efa_unit_test_mocks.efa_ibv_cq_wc_read_qp_num = &efa_mock_efa_ibv_cq_wc_read_qp_num_return_mock;
 
-	will_return(efa_mock_efa_ibv_cq_start_poll_return_mock, 0);
-	will_return(efa_mock_efa_ibv_cq_end_poll_check_mock, NULL);
+	will_return_int(efa_mock_efa_ibv_cq_start_poll_return_mock, 0);
+	expect_function_call(efa_mock_efa_ibv_cq_end_poll_check_mock);
 	/* efa_mock_efa_ibv_cq_wc_read_opcode_return_mock() will be called once in release mode,
 	 * but will be called twice in debug mode. because there is an assertion that called ibv_read_opcode(),
 	 * therefore use will_return_always()
 	 */
-	will_return_always(efa_mock_efa_ibv_cq_wc_read_opcode_return_mock, IBV_WC_RECV);
-	will_return_always(efa_mock_efa_ibv_cq_wc_read_qp_num_return_mock, efa_rdm_ep->base_ep.qp->qp_num);
-	will_return(efa_mock_efa_ibv_cq_wc_read_vendor_err_return_mock, EFA_IO_COMP_STATUS_LOCAL_ERROR_UNRESP_REMOTE);
+	will_return_int_always(efa_mock_efa_ibv_cq_wc_read_opcode_return_mock, IBV_WC_RECV);
+	will_return_uint_always(efa_mock_efa_ibv_cq_wc_read_qp_num_return_mock, efa_rdm_ep->base_ep.qp->qp_num);
+	will_return_uint(efa_mock_efa_ibv_cq_wc_read_vendor_err_return_mock, EFA_IO_COMP_STATUS_LOCAL_ERROR_UNRESP_REMOTE);
 	/* the recv error will not populate to application cq because it's an EFA internal error and
 	 * and not related to any application recv. Currently we can only read the error from eq.
 	 */
@@ -477,7 +477,7 @@ void test_ibv_cq_ex_read_bad_recv_status(struct efa_resource **state)
 #if HAVE_CAPS_UNSOLICITED_WRITE_RECV
 	if (ibv_cq->unsolicited_write_recv_enabled) {
 		g_efa_unit_test_mocks.efa_ibv_cq_wc_is_unsolicited = &efa_mock_efa_ibv_cq_wc_is_unsolicited_return_mock;
-		will_return_always(efa_mock_efa_ibv_cq_wc_is_unsolicited_return_mock, false);
+		will_return_uint_always(efa_mock_efa_ibv_cq_wc_is_unsolicited_return_mock, false);
 	}
 #endif
 
@@ -492,7 +492,7 @@ void test_ibv_cq_ex_read_bad_recv_status(struct efa_resource **state)
 	assert_int_equal(eq_err_entry.prov_errno, EFA_IO_COMP_STATUS_LOCAL_ERROR_UNRESP_REMOTE);
 
 	/* reset the mocked cq before it's polled by ep close */
-	will_return_always(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
+	will_return_int_always(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
 	assert_int_equal(fi_close(&resource->ep->fid), 0);
 	resource->ep = NULL;
 }
@@ -541,22 +541,22 @@ void test_ibv_cq_ex_read_bad_recv_rdma_with_imm_status_impl(struct efa_resource 
 	g_efa_unit_test_mocks.efa_ibv_cq_wc_read_vendor_err = &efa_mock_efa_ibv_cq_wc_read_vendor_err_return_mock;
 	g_efa_unit_test_mocks.efa_ibv_cq_wc_read_qp_num = &efa_mock_efa_ibv_cq_wc_read_qp_num_return_mock;
 
-	will_return(efa_mock_efa_ibv_cq_start_poll_return_mock, 0);
-	will_return(efa_mock_efa_ibv_cq_end_poll_check_mock, NULL);
+	will_return_int(efa_mock_efa_ibv_cq_start_poll_return_mock, 0);
+	expect_function_call(efa_mock_efa_ibv_cq_end_poll_check_mock);
 	/* efa_mock_efa_ibv_cq_wc_read_opcode_return_mock() will be called once in release mode,
 	 * but will be called twice in debug mode. because there is an assertion that called ibv_read_opcode(),
 	 * therefore use will_return_always()
 	 */
-	will_return_always(efa_mock_efa_ibv_cq_wc_read_opcode_return_mock, IBV_WC_RECV_RDMA_WITH_IMM);
-	will_return_always(efa_mock_efa_ibv_cq_wc_read_qp_num_return_mock, efa_rdm_ep->base_ep.qp->qp_num);
-	will_return(efa_mock_efa_ibv_cq_wc_read_vendor_err_return_mock, EFA_IO_COMP_STATUS_FLUSHED);
+	will_return_int_always(efa_mock_efa_ibv_cq_wc_read_opcode_return_mock, IBV_WC_RECV_RDMA_WITH_IMM);
+	will_return_uint_always(efa_mock_efa_ibv_cq_wc_read_qp_num_return_mock, efa_rdm_ep->base_ep.qp->qp_num);
+	will_return_uint(efa_mock_efa_ibv_cq_wc_read_vendor_err_return_mock, EFA_IO_COMP_STATUS_FLUSHED);
 
 
 #if HAVE_CAPS_UNSOLICITED_WRITE_RECV
 	if (use_unsolicited_recv) {
 		g_efa_unit_test_mocks.efa_ibv_cq_wc_is_unsolicited = &efa_mock_efa_ibv_cq_wc_is_unsolicited_return_mock;
 		ibv_cq->unsolicited_write_recv_enabled = true;
-		will_return_always(efa_mock_efa_ibv_cq_wc_is_unsolicited_return_mock, true);
+		will_return_uint_always(efa_mock_efa_ibv_cq_wc_is_unsolicited_return_mock, true);
 		ibv_cq->ibv_cq_ex->wr_id = 0;
 	} else {
 		/*
@@ -591,7 +591,7 @@ void test_ibv_cq_ex_read_bad_recv_rdma_with_imm_status_impl(struct efa_resource 
 	assert_int_equal(eq_err_entry.prov_errno, EFA_IO_COMP_STATUS_FLUSHED);
 
 	/* reset the mocked cq before it's polled by ep close */
-	will_return_always(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
+	will_return_int_always(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
 	assert_int_equal(fi_close(&resource->ep->fid), 0);
 	resource->ep = NULL;
 }
@@ -627,7 +627,7 @@ void test_ibv_cq_ex_read_failed_poll(struct efa_resource **state)
 	g_efa_unit_test_mocks.efa_ibv_cq_start_poll = &efa_mock_efa_ibv_cq_start_poll_return_mock;
 	g_efa_unit_test_mocks.efa_ibv_cq_end_poll = &efa_mock_efa_ibv_cq_end_poll_check_mock;
 
-	will_return(efa_mock_efa_ibv_cq_start_poll_return_mock, EINVAL);
+	will_return_int(efa_mock_efa_ibv_cq_start_poll_return_mock, EINVAL);
 
 	ret = fi_cq_read(resource->cq, &cq_entry, 1);
 	assert_int_equal(ret, -FI_EAGAIN);
@@ -636,7 +636,7 @@ void test_ibv_cq_ex_read_failed_poll(struct efa_resource **state)
 	assert_int_equal(ret, -FI_EAGAIN);
 
 	/* reset the mocked cq before it's polled by ep close */
-	will_return_always(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
+	will_return_int_always(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
 	assert_int_equal(fi_close(&resource->ep->fid), 0);
 	resource->ep = NULL;
 }
@@ -907,22 +907,24 @@ static void test_impl_ibv_cq_ex_read_unknow_peer_ah(struct efa_resource *resourc
 	if (support_efadv_cq) {
 		g_efa_unit_test_mocks.efa_ibv_cq_wc_read_sgid = &efa_mock_efa_ibv_cq_wc_read_sgid_return_zero_code_and_expect_next_poll_and_set_gid;
 
+		/* Make sure this mock is always called before ibv_next_poll */
+	        expect_function_call(efa_mock_efa_ibv_cq_next_poll_check_function_called_and_return_mock);
 		/* Return unknown AH from efadv */
-		will_return(efa_mock_efa_ibv_cq_wc_read_sgid_return_zero_code_and_expect_next_poll_and_set_gid, raw_addr.raw);
+		will_return_ptr(efa_mock_efa_ibv_cq_wc_read_sgid_return_zero_code_and_expect_next_poll_and_set_gid, raw_addr.raw);
 	} else {
 		expect_function_call(efa_mock_efa_ibv_cq_next_poll_check_function_called_and_return_mock);
 	}
 
 	/* Read 1 entry with unknown AH */
-	will_return(efa_mock_efa_ibv_cq_start_poll_return_mock, 0);
-	will_return(efa_mock_efa_ibv_cq_next_poll_check_function_called_and_return_mock, ENOENT);
-	will_return(efa_mock_efa_ibv_cq_end_poll_check_mock, NULL);
-	will_return(efa_mock_efa_ibv_cq_wc_read_slid_return_mock, 0xffff); // slid=0xffff(-1) indicates an unknown AH
-	will_return(efa_mock_efa_ibv_cq_wc_read_byte_len_return_mock, pkt_entry->pkt_size);
-	will_return_maybe(efa_mock_efa_ibv_cq_wc_read_opcode_return_mock, IBV_WC_RECV);
-	will_return_maybe(efa_mock_efa_ibv_cq_wc_read_qp_num_return_mock, efa_rdm_ep->base_ep.qp->qp_num);
-	will_return_maybe(efa_mock_efa_ibv_cq_wc_read_wc_flags_return_mock, 0);
-	will_return_maybe(efa_mock_efa_ibv_cq_wc_read_src_qp_return_mock, raw_addr.qpn);
+	will_return_int(efa_mock_efa_ibv_cq_start_poll_return_mock, 0);
+	will_return_int(efa_mock_efa_ibv_cq_next_poll_check_function_called_and_return_mock, ENOENT);
+	expect_function_call(efa_mock_efa_ibv_cq_end_poll_check_mock);
+	will_return_uint(efa_mock_efa_ibv_cq_wc_read_slid_return_mock, 0xffff); // slid=0xffff(-1) indicates an unknown AH
+	will_return_uint(efa_mock_efa_ibv_cq_wc_read_byte_len_return_mock, pkt_entry->pkt_size);
+	will_return_int_maybe(efa_mock_efa_ibv_cq_wc_read_opcode_return_mock, IBV_WC_RECV);
+	will_return_uint_maybe(efa_mock_efa_ibv_cq_wc_read_qp_num_return_mock, efa_rdm_ep->base_ep.qp->qp_num);
+	will_return_uint_maybe(efa_mock_efa_ibv_cq_wc_read_wc_flags_return_mock, 0);
+	will_return_uint_maybe(efa_mock_efa_ibv_cq_wc_read_src_qp_return_mock, raw_addr.qpn);
 
 	/* Post receive buffer */
 	ret = fi_recv(resource->ep, recv_buff.buff, recv_buff.size, fi_mr_desc(recv_buff.mr), peer_addr, NULL /* context */);
@@ -947,7 +949,7 @@ static void test_impl_ibv_cq_ex_read_unknow_peer_ah(struct efa_resource *resourc
 	efa_unit_test_buff_destruct(&recv_buff);
 
 	/* reset the mocked cq before it's polled by ep close */
-	will_return_always(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
+	will_return_int_always(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
 
 	/* When the peer is removed, we add it implicitly and try to send a
 	 * handshake packet. So we need to reset efa_outstanding_tx_ops before
@@ -1064,23 +1066,23 @@ static void test_efa_cq_read_prep(struct efa_resource *resource,
     g_efa_unit_test_mocks.efa_ibv_cq_wc_read_slid = &efa_mock_efa_ibv_cq_wc_read_slid_return_mock;
     g_efa_unit_test_mocks.efa_ibv_cq_wc_read_byte_len = &efa_mock_efa_ibv_cq_wc_read_byte_len_return_mock;
 
-    will_return(efa_mock_efa_ibv_cq_start_poll_return_mock, 0);
-    will_return_maybe(efa_mock_efa_ibv_cq_next_poll_return_mock, ENOENT);
-    will_return_maybe(efa_mock_efa_ibv_cq_end_poll_check_mock, NULL);
-    will_return_maybe(efa_mock_efa_ibv_cq_wc_read_opcode_return_mock, ibv_wc_opcode);
-    will_return_maybe(efa_mock_efa_ibv_cq_wc_read_vendor_err_return_mock, vendor_error);
-    will_return_maybe(efa_mock_efa_ibv_cq_wc_read_wc_flags_return_mock, wc_flags);
-    will_return_maybe(efa_mock_efa_ibv_cq_wc_read_imm_data_return_mock, 0x1);
-    will_return_maybe(efa_mock_efa_ibv_cq_wc_read_qp_num_return_mock, base_ep->qp->qp_num);
-    will_return_maybe(efa_mock_efa_ibv_cq_wc_read_byte_len_return_mock, 4096);
-    will_return_maybe(efa_mock_efa_ibv_cq_wc_read_slid_return_mock, efa_av_addr_to_conn(base_ep->av, addr)->ah->ahn);
-    will_return_maybe(efa_mock_efa_ibv_cq_wc_read_src_qp_return_mock, raw_addr.qpn);
+    will_return_int(efa_mock_efa_ibv_cq_start_poll_return_mock, 0);
+    will_return_int_maybe(efa_mock_efa_ibv_cq_next_poll_return_mock, ENOENT);
+    expect_function_call(efa_mock_efa_ibv_cq_end_poll_check_mock);
+    will_return_int_maybe(efa_mock_efa_ibv_cq_wc_read_opcode_return_mock, ibv_wc_opcode);
+    will_return_uint_maybe(efa_mock_efa_ibv_cq_wc_read_vendor_err_return_mock, vendor_error);
+    will_return_uint_maybe(efa_mock_efa_ibv_cq_wc_read_wc_flags_return_mock, wc_flags);
+    will_return_uint_maybe(efa_mock_efa_ibv_cq_wc_read_imm_data_return_mock, 0x1);
+    will_return_uint_maybe(efa_mock_efa_ibv_cq_wc_read_qp_num_return_mock, base_ep->qp->qp_num);
+    will_return_uint_maybe(efa_mock_efa_ibv_cq_wc_read_byte_len_return_mock, 4096);
+    will_return_uint_maybe(efa_mock_efa_ibv_cq_wc_read_slid_return_mock, efa_av_addr_to_conn(base_ep->av, addr)->ah->ahn);
+    will_return_uint_maybe(efa_mock_efa_ibv_cq_wc_read_src_qp_return_mock, raw_addr.qpn);
 
 
 #if HAVE_CAPS_UNSOLICITED_WRITE_RECV
     if (ibv_cq->unsolicited_write_recv_enabled) {
         g_efa_unit_test_mocks.efa_ibv_cq_wc_is_unsolicited = &efa_mock_efa_ibv_cq_wc_is_unsolicited_return_mock;
-        will_return_maybe(efa_mock_efa_ibv_cq_wc_is_unsolicited_return_mock, is_unsolicited_write_recv);
+        will_return_uint_maybe(efa_mock_efa_ibv_cq_wc_is_unsolicited_return_mock, is_unsolicited_write_recv);
     }
 #endif
 }
@@ -1103,7 +1105,7 @@ void test_efa_cq_read_no_completion(struct efa_resource **state)
 	assert_int_equal(ret, -FI_EAGAIN);
 
 	/* reset the mocked cq before it's polled by ep close */
-	will_return_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
+	will_return_int_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
 	assert_int_equal(fi_close(&resource->ep->fid), 0);
 	resource->ep = NULL;
 }
@@ -1133,7 +1135,7 @@ void test_efa_cq_read_send_success(struct efa_resource **state)
 	assert_true(cq_entry.flags == efa_context->completion_flags);
 
 	/* reset the mocked cq before it's polled by ep close */
-	will_return_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
+	will_return_int_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
 	assert_int_equal(fi_close(&resource->ep->fid), 0);
 	resource->ep = NULL;
 }
@@ -1163,7 +1165,7 @@ void test_efa_cq_read_senddata_success(struct efa_resource **state)
 	assert_true(cq_entry.flags == efa_context->completion_flags);
 
 	/* reset the mocked cq before it's polled by ep close */
-	will_return_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
+	will_return_int_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
 	assert_int_equal(fi_close(&resource->ep->fid), 0);
 	resource->ep = NULL;
 }
@@ -1193,7 +1195,7 @@ void test_efa_cq_read_recv_success(struct efa_resource **state)
 	assert_true(efa_context->completion_flags == cq_entry.flags);
 
 	/* reset the mocked cq before it's polled by ep close */
-	will_return_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
+	will_return_int_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
 	assert_int_equal(fi_close(&resource->ep->fid), 0);
 	resource->ep = NULL;
 }
@@ -1223,7 +1225,7 @@ void test_efa_cq_read_write_success(struct efa_resource **state)
 	assert_true(cq_entry.flags == efa_context->completion_flags);
 
 	/* reset the mocked cq before it's polled by ep close */
-	will_return_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
+	will_return_int_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
 	assert_int_equal(fi_close(&resource->ep->fid), 0);
 	resource->ep = NULL;
 }
@@ -1253,7 +1255,7 @@ void test_efa_cq_read_writedata_success(struct efa_resource **state)
 	assert_true(cq_entry.flags == efa_context->completion_flags);
 
 	/* reset the mocked cq before it's polled by ep close */
-	will_return_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
+	will_return_int_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
 	assert_int_equal(fi_close(&resource->ep->fid), 0);
 	resource->ep = NULL;
 }
@@ -1283,7 +1285,7 @@ void test_efa_cq_read_read_success(struct efa_resource **state)
 	assert_true(cq_entry.flags == efa_context->completion_flags);
 
 	/* reset the mocked cq before it's polled by ep close */
-	will_return_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
+	will_return_int_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
 	assert_int_equal(fi_close(&resource->ep->fid), 0);
 	resource->ep = NULL;
 }
@@ -1308,7 +1310,7 @@ void test_efa_cq_read_recv_rdma_with_imm_success(struct efa_resource **state)
 	assert_true(cq_entry.flags == (FI_REMOTE_WRITE | FI_REMOTE_CQ_DATA | FI_RMA));
 
 	/* reset the mocked cq before it's polled by ep close */
-	will_return_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
+	will_return_int_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
 	assert_int_equal(fi_close(&resource->ep->fid), 0);
 	resource->ep = NULL;
 }
@@ -1363,7 +1365,7 @@ void test_efa_cq_read_send_failure(struct efa_resource **state)
 				  EFA_IO_COMP_STATUS_LOCAL_ERROR_UNRESP_REMOTE);
 
 	/* reset the mocked cq before it's polled by ep close */
-	will_return_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
+	will_return_int_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
 	assert_int_equal(fi_close(&resource->ep->fid), 0);
 	resource->ep = NULL;
 }
@@ -1397,7 +1399,7 @@ void test_efa_cq_read_recv_failure(struct efa_resource **state)
 				  EFA_IO_COMP_STATUS_LOCAL_ERROR_UNRESP_REMOTE);
 
 	/* reset the mocked cq before it's polled by ep close */
-	will_return_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
+	will_return_int_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
 	assert_int_equal(fi_close(&resource->ep->fid), 0);
 	resource->ep = NULL;
 }
@@ -1426,7 +1428,7 @@ void test_efa_cq_recv_rdma_with_imm_failure(struct efa_resource **state)
 				  EFA_IO_COMP_STATUS_LOCAL_ERROR_UNRESP_REMOTE);
 
 	/* reset the mocked cq before it's polled by ep close */
-	will_return_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
+	will_return_int_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
 	assert_int_equal(fi_close(&resource->ep->fid), 0);
 	resource->ep = NULL;
 }
@@ -1639,8 +1641,8 @@ static int test_efa_cq_sread_prep(struct efa_resource *resource)
 
 	g_efa_unit_test_mocks.efa_ibv_req_notify_cq = efa_mock_ibv_req_notify_cq_return_mock;
 	g_efa_unit_test_mocks.efa_ibv_get_cq_event = efa_mock_ibv_get_cq_event_return_mock;
-	will_return_maybe(efa_mock_ibv_req_notify_cq_return_mock, 0);
-	will_return_maybe(efa_mock_ibv_get_cq_event_return_mock, -1);
+	will_return_int_maybe(efa_mock_ibv_req_notify_cq_return_mock, 0);
+	will_return_int_maybe(efa_mock_ibv_get_cq_event_return_mock, -1);
 
 	efa_unit_test_resource_construct_no_cq_and_ep_not_enabled(resource, FI_EP_RDM, EFA_DIRECT_FABRIC_NAME);
 
@@ -1946,13 +1948,13 @@ void test_efa_cq_readfrom_input_validation(struct efa_resource **state)
 
 	/* Test with valid parameters but empty CQ */
 	g_efa_unit_test_mocks.efa_ibv_cq_start_poll = &efa_mock_efa_ibv_cq_start_poll_return_mock;
-	will_return(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
+	will_return_int(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
 
 	ret = fi_cq_readfrom(resource->cq, &cq_entry, 1, &src_addr);
 	assert_int_equal(ret, -FI_EAGAIN);
 
 	/* Reset mocks */
-	will_return_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
+	will_return_int_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
 	assert_int_equal(fi_close(&resource->ep->fid), 0);
 	resource->ep = NULL;
 }
@@ -2005,7 +2007,7 @@ static void test_efa_cq_readerr_common(struct efa_resource *resource, bool user_
 		free(cq_err_entry.err_data);
 
 	/* Reset mocks */
-	will_return_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
+	will_return_int_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
 	assert_int_equal(fi_close(&resource->ep->fid), 0);
 	resource->ep = NULL;
 }
@@ -2046,7 +2048,7 @@ void test_efa_cq_readfrom_start_poll_error(struct efa_resource **state)
 	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_DIRECT_FABRIC_NAME);
 
 	g_efa_unit_test_mocks.efa_ibv_cq_start_poll = &efa_mock_efa_ibv_cq_start_poll_return_mock;
-	will_return(efa_mock_efa_ibv_cq_start_poll_return_mock, EINVAL);
+	will_return_int(efa_mock_efa_ibv_cq_start_poll_return_mock, EINVAL);
 
 	ret = fi_cq_readfrom(resource->cq, &cq_entry, 1, NULL);
 	assert_int_equal(ret, -FI_EAGAIN);
@@ -2067,7 +2069,7 @@ void test_efa_cq_readfrom_start_poll_error(struct efa_resource **state)
 	assert_int_equal(ibv_cq->poll_err, 0);
 
 	/* Reset mocks */
-	will_return_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
+	will_return_int_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
 	assert_int_equal(fi_close(&resource->ep->fid), 0);
 	resource->ep = NULL;
 }
@@ -2101,7 +2103,7 @@ void test_efa_cq_readfrom_util_cq_entries(struct efa_resource **state)
 
 	/* Mock empty device CQ */
 	g_efa_unit_test_mocks.efa_ibv_cq_start_poll = &efa_mock_efa_ibv_cq_start_poll_return_mock;
-	will_return(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
+	will_return_int(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
 
 	/* Read should get entry from util_cq */
 	ret = fi_cq_readfrom(resource->cq, &cq_entry, 1, NULL);
@@ -2109,7 +2111,7 @@ void test_efa_cq_readfrom_util_cq_entries(struct efa_resource **state)
 	assert_ptr_equal(cq_entry.op_context, util_entry.op_context);
 	assert_int_equal(cq_entry.flags, util_entry.flags);
 
-	will_return_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
+	will_return_int_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
 	assert_int_equal(fi_close(&resource->ep->fid), 0);
 	resource->ep = NULL;
 }
@@ -2143,7 +2145,7 @@ void test_efa_cq_readerr_util_cq_error(struct efa_resource **state)
 
 	/* Mock empty device CQ */
 	g_efa_unit_test_mocks.efa_ibv_cq_start_poll = &efa_mock_efa_ibv_cq_start_poll_return_mock;
-	will_return(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
+	will_return_int(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
 
 	/* Read should return error available */
 	ret = fi_cq_read(resource->cq, &cq_entry, 1);
@@ -2156,7 +2158,7 @@ void test_efa_cq_readerr_util_cq_error(struct efa_resource **state)
 	assert_int_equal(cq_err_entry.flags, util_err.flags);
 	assert_int_equal(cq_err_entry.err, util_err.err);
 
-	will_return_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
+	will_return_int_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
 	assert_int_equal(fi_close(&resource->ep->fid), 0);
 	resource->ep = NULL;
 }
@@ -2202,7 +2204,7 @@ void test_efa_cq_poll_active_no_restart(struct efa_resource **state)
 	assert_int_equal(cq_err_entry.prov_errno, EFA_IO_COMP_STATUS_LOCAL_ERROR_UNRESP_REMOTE);
 
 	/* Reset mocks */
-	will_return_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
+	will_return_int_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
 	assert_int_equal(fi_close(&resource->ep->fid), 0);
 	resource->ep = NULL;
 }
@@ -2268,24 +2270,24 @@ void test_efa_cq_read_mixed_success_error(struct efa_resource **state)
 	ibv_cqx->status = IBV_WC_SUCCESS;
 
 	/* Mock sequence for first fi_cq_read call */
-	will_return(efa_mock_efa_ibv_cq_start_poll_return_mock, 0);
+	will_return_int(efa_mock_efa_ibv_cq_start_poll_return_mock, 0);
 	/* Common CQE reads mocks shared by all 3 CQEs */
-	will_return_maybe(efa_mock_efa_ibv_cq_wc_read_opcode_return_mock, IBV_WC_SEND);
-	will_return_maybe(efa_mock_efa_ibv_cq_wc_read_wc_flags_return_mock, 0);
-	will_return_maybe(efa_mock_efa_ibv_cq_wc_read_qp_num_return_mock, base_ep->qp->qp_num);
-	will_return_maybe(efa_mock_efa_ibv_cq_wc_read_byte_len_return_mock, 1024);
+	will_return_int_maybe(efa_mock_efa_ibv_cq_wc_read_opcode_return_mock, IBV_WC_SEND);
+	will_return_uint_maybe(efa_mock_efa_ibv_cq_wc_read_wc_flags_return_mock, 0);
+	will_return_uint_maybe(efa_mock_efa_ibv_cq_wc_read_qp_num_return_mock, base_ep->qp->qp_num);
+	will_return_uint_maybe(efa_mock_efa_ibv_cq_wc_read_byte_len_return_mock, 1024);
 
 	/* CQE1 reads using common mocks */
 	/* Move to CQE2, set status to success, set wr_id to context2 */
-	will_return(efa_mock_efa_ibv_cq_next_poll_simulate_status_change, IBV_WC_SUCCESS);
-	will_return(efa_mock_efa_ibv_cq_next_poll_simulate_status_change, efa_context2);
-	will_return(efa_mock_efa_ibv_cq_next_poll_simulate_status_change, 0);
+	will_return_int(efa_mock_efa_ibv_cq_next_poll_simulate_status_change, IBV_WC_SUCCESS);
+	will_return_ptr(efa_mock_efa_ibv_cq_next_poll_simulate_status_change, efa_context2);
+	will_return_int(efa_mock_efa_ibv_cq_next_poll_simulate_status_change, 0);
 	/* CQE2 reads using common mocks */
 	/* Move to CQE3, set status to error, set wr_id to context3 */
-	will_return(efa_mock_efa_ibv_cq_next_poll_simulate_status_change, IBV_WC_GENERAL_ERR);
-	will_return(efa_mock_efa_ibv_cq_next_poll_simulate_status_change, efa_context3);
-	will_return(efa_mock_efa_ibv_cq_next_poll_simulate_status_change, 0);
-	will_return(efa_mock_efa_ibv_cq_end_poll_check_mock, NULL);
+	will_return_int(efa_mock_efa_ibv_cq_next_poll_simulate_status_change, IBV_WC_GENERAL_ERR);
+	will_return_ptr(efa_mock_efa_ibv_cq_next_poll_simulate_status_change, efa_context3);
+	will_return_int(efa_mock_efa_ibv_cq_next_poll_simulate_status_change, 0);
+	expect_function_call(efa_mock_efa_ibv_cq_end_poll_check_mock);
 
 	/* First fi_cq_read should return 2 successful entries, stop at error */
 	ret = fi_cq_read(resource->cq, cq_entries, 3);
@@ -2299,7 +2301,7 @@ void test_efa_cq_read_mixed_success_error(struct efa_resource **state)
 
 
 	/* CQE3 read err using common mocks + extra following */
-	will_return(efa_mock_efa_ibv_cq_wc_read_vendor_err_return_mock, EFA_IO_COMP_STATUS_LOCAL_ERROR_UNRESP_REMOTE);
+	will_return_uint(efa_mock_efa_ibv_cq_wc_read_vendor_err_return_mock, EFA_IO_COMP_STATUS_LOCAL_ERROR_UNRESP_REMOTE);
 
 	/* Verify error can be retrieved */
 	cq_err_entry.err_data_size = EFA_ERROR_MSG_BUFFER_LENGTH;
@@ -2313,7 +2315,7 @@ void test_efa_cq_read_mixed_success_error(struct efa_resource **state)
 	free(cq_err_entry.err_data);
 
 	/* Reset mocks */
-	will_return_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
+	will_return_int_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
 	assert_int_equal(fi_close(&resource->ep->fid), 0);
 	resource->ep = NULL;
 }

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -160,7 +160,7 @@ void test_efa_rdm_ep_handshake_exchange_host_id(struct efa_resource **state, uin
 	/* Mock general QP post send function for handshake operations */
 	g_efa_unit_test_mocks.efa_qp_post_send = &efa_mock_efa_qp_post_send_verify_handshake_pkt_local_host_id_and_save_wr;
 	expect_function_call(efa_mock_efa_qp_post_send_verify_handshake_pkt_local_host_id_and_save_wr);
-	will_return(efa_mock_efa_qp_post_send_verify_handshake_pkt_local_host_id_and_save_wr, 0);
+	will_return_int(efa_mock_efa_qp_post_send_verify_handshake_pkt_local_host_id_and_save_wr, 0);
 
 	/* Setup CQ mocks */
 	g_efa_unit_test_mocks.efa_ibv_cq_end_poll = &efa_mock_efa_ibv_cq_end_poll_check_mock;
@@ -178,25 +178,25 @@ void test_efa_rdm_ep_handshake_exchange_host_id(struct efa_resource **state, uin
 	expect_function_call(efa_mock_efa_ibv_cq_next_poll_check_function_called_and_return_mock);
 
 	/* Receive handshake packet */
-	will_return(efa_mock_efa_ibv_cq_end_poll_check_mock, NULL);
-	will_return(efa_mock_efa_ibv_cq_next_poll_check_function_called_and_return_mock, ENOENT);
-	will_return(efa_mock_efa_ibv_cq_wc_read_byte_len_return_mock, pkt_entry->pkt_size);
-	will_return(efa_mock_efa_ibv_cq_wc_read_opcode_return_mock, IBV_WC_RECV);
-	will_return(efa_mock_efa_ibv_cq_wc_read_qp_num_return_mock, efa_rdm_ep->base_ep.qp->qp_num);
-	will_return(efa_mock_efa_ibv_cq_wc_read_wc_flags_return_mock, 0);
-	will_return(efa_mock_efa_ibv_cq_wc_read_slid_return_mock, efa_rdm_ep_get_peer_ahn(efa_rdm_ep, peer_addr));
-	will_return(efa_mock_efa_ibv_cq_wc_read_src_qp_return_mock, raw_addr.qpn);
-	will_return(efa_mock_efa_ibv_cq_start_poll_return_mock, IBV_WC_SUCCESS);
+	expect_function_call(efa_mock_efa_ibv_cq_end_poll_check_mock);
+	will_return_int(efa_mock_efa_ibv_cq_next_poll_check_function_called_and_return_mock, ENOENT);
+	will_return_uint(efa_mock_efa_ibv_cq_wc_read_byte_len_return_mock, pkt_entry->pkt_size);
+	will_return_int(efa_mock_efa_ibv_cq_wc_read_opcode_return_mock, IBV_WC_RECV);
+	will_return_uint(efa_mock_efa_ibv_cq_wc_read_qp_num_return_mock, efa_rdm_ep->base_ep.qp->qp_num);
+	will_return_uint(efa_mock_efa_ibv_cq_wc_read_wc_flags_return_mock, 0);
+	will_return_uint(efa_mock_efa_ibv_cq_wc_read_slid_return_mock, efa_rdm_ep_get_peer_ahn(efa_rdm_ep, peer_addr));
+	will_return_uint(efa_mock_efa_ibv_cq_wc_read_src_qp_return_mock, raw_addr.qpn);
+	will_return_int(efa_mock_efa_ibv_cq_start_poll_return_mock, IBV_WC_SUCCESS);
 
 	/**
 	 * Fire away handshake packet.
 	 * Because we don't care if it fails(there is no receiver!), mark it as failed to make mocking simpler.
 	 */
-	will_return(efa_mock_efa_ibv_cq_end_poll_check_mock, NULL);
-	will_return(efa_mock_efa_ibv_cq_wc_read_opcode_return_mock, IBV_WC_SEND);
-	will_return(efa_mock_efa_ibv_cq_wc_read_qp_num_return_mock, efa_rdm_ep->base_ep.qp->qp_num);
-	will_return(efa_mock_efa_ibv_cq_wc_read_vendor_err_return_mock, FI_EFA_ERR_OTHER);
-	will_return(efa_mock_efa_ibv_cq_start_poll_return_mock, IBV_WC_SUCCESS);
+	expect_function_call(efa_mock_efa_ibv_cq_end_poll_check_mock);
+	will_return_int(efa_mock_efa_ibv_cq_wc_read_opcode_return_mock, IBV_WC_SEND);
+	will_return_uint(efa_mock_efa_ibv_cq_wc_read_qp_num_return_mock, efa_rdm_ep->base_ep.qp->qp_num);
+	will_return_uint(efa_mock_efa_ibv_cq_wc_read_vendor_err_return_mock, FI_EFA_ERR_OTHER);
+	will_return_int(efa_mock_efa_ibv_cq_start_poll_return_mock, IBV_WC_SUCCESS);
 
 	/* Progress the recv wr first to process the received handshake packet. */
 	cq_read_recv_ret = fi_cq_read(resource->cq, &cq_entry, 1);
@@ -224,7 +224,7 @@ void test_efa_rdm_ep_handshake_exchange_host_id(struct efa_resource **state, uin
 	assert_int_equal(peer->device_version, 0xefa0);
 
 	/* reset the mocked cq before it's polled by ep close */
-	will_return_always(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
+	will_return_int_always(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
 	assert_int_equal(fi_close(&resource->ep->fid), 0);
 	resource->ep = NULL;
 }
@@ -700,7 +700,7 @@ void test_efa_rdm_ep_trigger_handshake(struct efa_resource **state)
 	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
 
 	g_efa_unit_test_mocks.efa_qp_post_send = &efa_mock_efa_qp_post_send_return_mock;
-	will_return_always(efa_mock_efa_qp_post_send_return_mock, 0);
+	will_return_int_always(efa_mock_efa_qp_post_send_return_mock, 0);
 	/* Create and register a fake peer */
 	assert_int_equal(fi_getname(&resource->ep->fid, &raw_addr, &raw_addr_len), 0);
 	raw_addr.qpn = 0;

--- a/prov/efa/test/efa_unit_test_info.c
+++ b/prov/efa/test/efa_unit_test_info.c
@@ -951,7 +951,7 @@ static void test_info_direct_rma_common(bool mock_unsolicited_write_recv,
 
 	/* Mock unsolicited write recv */
 	g_efa_unit_test_mocks.efa_device_support_unsolicited_write_recv = &efa_mock_efa_device_support_unsolicited_write_recv;
-	will_return_maybe(efa_mock_efa_device_support_unsolicited_write_recv, mock_unsolicited_write_recv);
+	will_return_uint_maybe(efa_mock_efa_device_support_unsolicited_write_recv, mock_unsolicited_write_recv);
 
 	hints = efa_unit_test_alloc_hints(FI_EP_RDM, EFA_DIRECT_FABRIC_NAME);
 	assert_non_null(hints);

--- a/prov/efa/test/efa_unit_test_mocks.c
+++ b/prov/efa/test/efa_unit_test_mocks.c
@@ -31,23 +31,17 @@ void efa_ibv_ah_limit_cnt_reset()
 }
 
 /**
- * @brief call real ibv_create_ah and mock()
- *
- * When combined with will_return_count(), this mock of ibv_create_ah() can be used to verify
- * number of times ibv_create_ah() is called.
+ * @brief call real ibv_create_ah and record the function call
  */
 struct ibv_ah *efa_mock_ibv_create_ah_check_mock(struct ibv_pd *pd, struct ibv_ah_attr *attr)
 {
-	mock();
+	function_called();
 
 	return  __real_ibv_create_ah(pd, attr);
 }
 
 /**
- * @brief call real ibv_create_ah and mock()
- *
- * When combined with will_return_count(), this mock of ibv_create_ah() can be used to verify
- * number of times ibv_create_ah() is called.
+ * @brief call real ibv_create_ah
  */
 struct ibv_ah *efa_mock_ibv_create_ah_dont_create_self_ah(struct ibv_pd *pd, struct ibv_ah_attr *attr)
 {
@@ -61,10 +55,7 @@ struct ibv_ah *efa_mock_ibv_create_ah_dont_create_self_ah(struct ibv_pd *pd, str
 }
 
 /**
- * @brief call real ibv_destroy_ah and mock()
- *
- * When combined with will_return_count(), this mock of ibv_create_ah() can be used to verify
- * number of times ibv_create_ah() is called.
+ * @brief call real ibv_destroy_ah
  */
 int efa_mock_ibv_destroy_ah_dont_create_self_ah(struct ibv_ah *ibv_ah)
 {
@@ -127,7 +118,7 @@ void efa_ibv_submitted_wr_id_vec_clear()
 int efa_mock_efa_ibv_cq_start_poll_return_mock(struct efa_ibv_cq *ibv_cq,
 					struct ibv_poll_cq_attr *attr)
 {
-	return mock();
+	return mock_int();
 }
 
 static inline
@@ -151,7 +142,7 @@ int efa_mock_use_saved_send_wr(struct ibv_cq_ex *ibv_cqx, int status)
 int efa_mock_efa_ibv_cq_start_poll_use_saved_send_wr_with_mock_status(struct efa_ibv_cq *ibv_cq,
 							       struct ibv_poll_cq_attr *attr)
 {
-	return efa_mock_use_saved_send_wr(ibv_cq->ibv_cq_ex, mock());
+	return efa_mock_use_saved_send_wr(ibv_cq->ibv_cq_ex, mock_int());
 }
 
 int efa_mock_efa_ibv_cq_next_poll_return_mock(struct efa_ibv_cq *ibv_cq)
@@ -169,45 +160,45 @@ int efa_mock_efa_ibv_cq_next_poll_simulate_status_change(struct efa_ibv_cq *ibv_
 	struct ibv_cq_ex *ibv_cqx = ibv_cq->ibv_cq_ex;
 
 	/* Get status and context from mock parameters */
-	ibv_cqx->status = mock();
-	ibv_cqx->wr_id = (uintptr_t)mock();
+	ibv_cqx->status = mock_int();
+	ibv_cqx->wr_id = (uintptr_t)mock_ptr_type(struct efa_context *);
 
-	return mock();
+	return mock_int();
 }
 
 void efa_mock_efa_ibv_cq_end_poll_check_mock(struct efa_ibv_cq *ibv_cq)
 {
-	mock();
+	function_called();
 }
 
 enum ibv_wc_opcode efa_mock_efa_ibv_cq_wc_read_opcode_return_mock(struct efa_ibv_cq *current)
 {
-	return mock();
+	return mock_int();
 }
 
 uint32_t efa_mock_efa_ibv_cq_wc_read_vendor_err_return_mock(struct efa_ibv_cq *current)
 {
-	return mock();
+	return mock_uint();
 }
 
 uint32_t efa_mock_efa_ibv_cq_wc_read_qp_num_return_mock(struct efa_ibv_cq *current)
 {
-	return mock();
+	return mock_uint();
 }
 
 uint32_t efa_mock_efa_ibv_cq_wc_read_wc_flags_return_mock(struct efa_ibv_cq *current)
 {
-	return mock();
+	return mock_uint();
 }
 
 uint32_t efa_mock_efa_ibv_cq_wc_read_imm_data_return_mock(struct efa_ibv_cq *current)
 {
-	return mock();
+	return mock_uint();
 }
 
 bool efa_mock_efa_ibv_cq_wc_is_unsolicited_return_mock(struct efa_ibv_cq *ibv_cq)
 {
-	return mock();
+	return mock_uint();
 }
 
 int g_ofi_copy_from_hmem_iov_call_counter;
@@ -222,12 +213,12 @@ ssize_t efa_mock_ofi_copy_from_hmem_iov_inc_counter(void *dest, size_t size,
 
 int efa_mock_efa_rdm_pke_read_return_mock(struct efa_rdm_ope *ope)
 {
-	return mock();
+	return mock_int();
 }
 
 ssize_t efa_mock_efa_rdm_ope_post_send_return_mock(struct efa_rdm_ope *ope, int pkt_type)
 {
-	return mock();
+	return mock_int();
 }
 
 ssize_t efa_mock_efa_rdm_pke_proc_matched_rtm_no_op(struct efa_rdm_pke *pkt_entry)
@@ -237,13 +228,13 @@ ssize_t efa_mock_efa_rdm_pke_proc_matched_rtm_no_op(struct efa_rdm_pke *pkt_entr
 
 bool efa_mock_efa_device_support_unsolicited_write_recv()
 {
-	return mock();
+	return mock_uint();
 }
 
 int efa_mock_efa_qp_post_recv_return_mock(struct efa_qp *qp, struct ibv_recv_wr *wr,
 				struct ibv_recv_wr **bad_wr)
 {
-	return mock();
+	return mock_int();
 }
 
 static void efa_mock_efa_qp_post_save_wr_id(uintptr_t wr_id)
@@ -257,19 +248,19 @@ static void efa_mock_efa_qp_post_save_wr_id(uintptr_t wr_id)
 int efa_mock_efa_qp_post_send_return_mock(struct efa_qp *qp, const struct ibv_sge *sge_list, const struct ibv_data_buf *inline_data_list, size_t iov_count, bool use_inline, uintptr_t wr_id, uint64_t data, uint64_t flags, struct efa_ah *ah, uint32_t qpn, uint32_t qkey)
 {
 	efa_mock_efa_qp_post_save_wr_id(wr_id);
-	return mock();
+	return mock_int();
 }
 
 int efa_mock_efa_qp_post_read_return_mock(struct efa_qp *qp, const struct ibv_sge *sge_list, size_t sge_count, uint32_t remote_key, uint64_t remote_addr, uintptr_t wr_id, uint64_t flags, struct efa_ah *ah, uint32_t qpn, uint32_t qkey)
 {
 	efa_mock_efa_qp_post_save_wr_id(wr_id);
-	return mock();
+	return mock_int();
 }
 
 int efa_mock_efa_qp_post_write_return_mock(struct efa_qp *qp, const struct ibv_sge *sge_list, size_t sge_count, uint32_t remote_key, uint64_t remote_addr, uintptr_t wr_id, uint64_t data, uint64_t flags, struct efa_ah *ah, uint32_t qpn, uint32_t qkey)
 {
 	efa_mock_efa_qp_post_save_wr_id(wr_id);
-	return mock();
+	return mock_int();
 }
 
 int efa_mock_efa_qp_post_send_verify_handshake_pkt_local_host_id_and_save_wr(struct efa_qp *qp, const struct ibv_sge *sge_list, const struct ibv_data_buf *inline_data_list, size_t iov_count, bool use_inline, uintptr_t wr_id, uint64_t data, uint64_t flags, struct efa_ah *ah, uint32_t qpn, uint32_t qkey)
@@ -298,7 +289,7 @@ int efa_mock_efa_qp_post_send_verify_handshake_pkt_local_host_id_and_save_wr(str
 	function_called();
 
 	efa_mock_efa_qp_post_save_wr_id(wr_id);
-	return mock();
+	return mock_int();
 }
 
 struct efa_unit_test_mocks g_efa_unit_test_mocks = {
@@ -502,29 +493,27 @@ struct ibv_cq_ex *__wrap_efadv_create_cq(struct ibv_context *ibvctx,
 
 uint32_t efa_mock_efa_ibv_cq_wc_read_src_qp_return_mock(struct efa_ibv_cq *current)
 {
-	return mock();
+	return mock_uint();
 }
 
 uint32_t efa_mock_efa_ibv_cq_wc_read_byte_len_return_mock(struct efa_ibv_cq *current)
 {
-	return mock();
+	return mock_uint();
 };
 
 uint32_t efa_mock_efa_ibv_cq_wc_read_slid_return_mock(struct efa_ibv_cq *current)
 {
-	return mock();
+	return mock_uint();
 }
 
 int efa_mock_efa_ibv_cq_wc_read_sgid_return_mock(struct efa_ibv_cq *ibv_cq, union ibv_gid *sgid)
 {
-	return mock();
+	return mock_int();
 }
 
 int efa_mock_efa_ibv_cq_wc_read_sgid_return_zero_code_and_expect_next_poll_and_set_gid(struct efa_ibv_cq *ibv_cq, union ibv_gid *sgid)
 {
-	/* Make sure this mock is always called before ibv_next_poll */
-	expect_function_call(efa_mock_efa_ibv_cq_next_poll_check_function_called_and_return_mock);
-	memcpy(sgid->raw, (uint8_t *)mock(), sizeof(sgid->raw));
+	memcpy(sgid->raw, mock_ptr_type(uint8_t*), sizeof(sgid->raw));
 	/* Must return 0 for unknown AH */
 	return 0;
 };
@@ -532,7 +521,7 @@ int efa_mock_efa_ibv_cq_wc_read_sgid_return_zero_code_and_expect_next_poll_and_s
 int efa_mock_efa_ibv_cq_next_poll_check_function_called_and_return_mock(struct efa_ibv_cq *ibv_cq)
 {
 	function_called();
-	return mock();
+	return mock_int();
 };
 
 struct ibv_cq_ex *efa_mock_efadv_create_cq_with_ibv_create_cq_ex(struct ibv_context *ibvctx,
@@ -621,7 +610,7 @@ enum ibv_fork_status __wrap_ibv_is_fork_initialized(void)
 
 enum ibv_fork_status efa_mock_ibv_is_fork_initialized_return_mock(void)
 {
-	return mock();
+	return mock_int();
 }
 
 #if HAVE_EFADV_QUERY_MR
@@ -730,5 +719,5 @@ int efa_mock_ibv_req_notify_cq_return_mock(struct efa_ibv_cq *ibv_cq, int solici
 
 int efa_mock_ibv_get_cq_event_return_mock(struct efa_ibv_cq *ibv_cq, void **cq_context)
 {
-	return mock();
+	return mock_int();
 }

--- a/prov/efa/test/efa_unit_test_mocks.h
+++ b/prov/efa/test/efa_unit_test_mocks.h
@@ -296,3 +296,42 @@ enum ibv_fork_status efa_mock_ibv_is_fork_initialized_return_mock(void);
 bool __real_efa_ibv_cq_wc_is_unsolicited(struct efa_ibv_cq *ibv_cq);
 
 #endif
+
+/* Macroses below are workaround for RHEL8. Can be deleted after EOL of RHEL8. */
+
+#if !defined(mock_int)
+#define mock_int mock
+#endif
+#if !defined(mock_uint)
+#define mock_uint mock
+#endif
+#if !defined(mock_ptr_type)
+#define mock_ptr_type(type) mock()
+#endif
+#if !defined(will_return_int)
+#define will_return_int(function, value) will_return(function, value)
+#endif
+#if !defined(will_return_int_maybe)
+#define will_return_int_maybe(function, value) will_return_maybe(function, value)
+#endif
+#if !defined(will_return_int_always)
+#define will_return_int_always(function, value) will_return_always(function, value)
+#endif
+#if !defined(will_return_uint)
+#define will_return_uint(function, value) will_return(function, value)
+#endif
+#if !defined(will_return_uint_maybe)
+#define will_return_uint_maybe(function, value) will_return_maybe(function, value)
+#endif
+#if !defined(will_return_uint_always)
+#define will_return_uint_always(function, value) will_return_always(function, value)
+#endif
+#if !defined(will_return_ptr)
+#define will_return_ptr(function, value) will_return(function, value)
+#endif
+#if !defined(will_return_ptr_maybe)
+#define will_return_ptr_maybe(function, value) will_return_maybe(function, value)
+#endif
+#if !defined(will_return_ptr_always)
+#define will_return_ptr_always(function, value) will_return_always(function, value)
+#endif

--- a/prov/efa/test/efa_unit_test_msg.c
+++ b/prov/efa/test/efa_unit_test_msg.c
@@ -112,7 +112,7 @@ static void test_efa_msg_send_prep(struct efa_resource *resource,
 	g_efa_unit_test_mocks.efa_qp_post_recv = &efa_mock_efa_qp_post_recv_return_mock;
 	/* Mock general QP post send function to save work request IDs */
 	g_efa_unit_test_mocks.efa_qp_post_send = &efa_mock_efa_qp_post_send_return_mock;
-	will_return_always(efa_mock_efa_qp_post_send_return_mock, 0);
+	will_return_int_always(efa_mock_efa_qp_post_send_return_mock, 0);
 }
 
 void test_efa_msg_fi_send(struct efa_resource **state)

--- a/prov/efa/test/efa_unit_test_rma.c
+++ b/prov/efa/test/efa_unit_test_rma.c
@@ -24,8 +24,8 @@ static void test_efa_rma_prep(struct efa_resource *resource, fi_addr_t *addr)
 	/* Mock general QP post functions to save work request IDs */
 	g_efa_unit_test_mocks.efa_qp_post_read = &efa_mock_efa_qp_post_read_return_mock;
 	g_efa_unit_test_mocks.efa_qp_post_write = &efa_mock_efa_qp_post_write_return_mock;
-	will_return_maybe(efa_mock_efa_qp_post_read_return_mock, 0);
-	will_return_maybe(efa_mock_efa_qp_post_write_return_mock, 0);
+	will_return_int_maybe(efa_mock_efa_qp_post_read_return_mock, 0);
+	will_return_int_maybe(efa_mock_efa_qp_post_write_return_mock, 0);
 
 	ret = fi_getname(&resource->ep->fid, &raw_addr, &raw_addr_len);
 	assert_int_equal(ret, 0);

--- a/prov/efa/test/efa_unit_test_rnr.c
+++ b/prov/efa/test/efa_unit_test_rnr.c
@@ -34,7 +34,7 @@ void test_efa_rnr_queue_and_resend_impl(struct efa_resource **state, uint32_t op
 	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
 	/* Add mock for efa_qp_post_send */
 	g_efa_unit_test_mocks.efa_qp_post_send = &efa_mock_efa_qp_post_send_return_mock;
-	will_return_maybe(efa_mock_efa_qp_post_send_return_mock, 0);
+	will_return_int_maybe(efa_mock_efa_qp_post_send_return_mock, 0);
 	assert_true(dlist_empty(&efa_rdm_ep->txe_list));
 
 	if (op == ofi_op_msg)


### PR DESCRIPTION
EFA unittests use depricated functions from CMocka. That causes a lot of build warnings.
This commit updates function according to up-to-date recommendations.