### PR TITLE
prov/tcp: Add FI_RMA to cq_flags for rma inject

### DIFF
--- a/prov/tcp/src/xnet_rma.c
+++ b/prov/tcp/src/xnet_rma.c
@@ -409,7 +409,7 @@ xnet_rma_inject_common(struct fid_ep *ep_fid, const void *buf, size_t len,
 	send_entry->iov_cnt = 1;
 
 	send_entry->hdr.base_hdr.size = offset;
-	send_entry->cq_flags = FI_INJECT | FI_WRITE;
+	send_entry->cq_flags = FI_INJECT | FI_WRITE | FI_RMA;
 	send_entry->cntr = ep->util_ep.cntrs[CNTR_WR];
 	xnet_tx_queue_insert(ep, send_entry);
 unlock:


### PR DESCRIPTION
This is just for code completion and is helpful for logging/debugging.