### PR TITLE
prov/hook: Harden hook monitor provider initalization

### DIFF
--- a/prov/hook/monitor/src/hook_monitor.c
+++ b/prov/hook/monitor/src/hook_monitor.c
@@ -1151,12 +1151,13 @@ static int monitor_env_init(void)
 			"Number of API calls before synchronisation files are checked for data request. (default: %d)",
 			mon_env.tick_max);
 
-	fi_param_get_int(prov, "tick_max", &signed_tick_max);
-	if (signed_tick_max < 0) {
-		FI_WARN(prov, FI_LOG_CORE, "Tick is negative!\n");
-		return -EOVERFLOW;
+	if (fi_param_get_int(prov, "tick_max", &signed_tick_max) == FI_SUCCESS) {
+		if (signed_tick_max < 0) {
+			FI_WARN(prov, FI_LOG_CORE, "Tick is negative!\n");
+			return -EOVERFLOW;
+		}
+		mon_env.tick_max = (unsigned int)signed_tick_max;
 	}
-	mon_env.tick_max = (unsigned int)signed_tick_max;
 
 	fi_param_define(prov, "file_mode", FI_PARAM_INT,
 			"POSIX mode/permission for synchronisation files. (default: %04o)",


### PR DESCRIPTION
We randomly see warning message about tick being negative from hook monitor. Valgrind detects branch depending on uninitialized value `signed_tick_max` in `monitor_env_init()`.

Looking closely at `monitor_env_init()` I noticed `signed_tick_max` is going to contain garbage if env variable `tick_max` was not defined. The garbage is going to be coped over to global variable `mon_env.tick_max`.

This PR adds handling for return values of `fi_param_*` functions and better logging for monitor hook initialization.