### PR TITLE
prov/lnx: Add CPPFLAGS to build as DSO 

### DIFF
--- a/prov/lnx/Makefile.include
+++ b/prov/lnx/Makefile.include
@@ -47,7 +47,7 @@ _lnx_headers = \
 if HAVE_LNX_DL
 pkglib_LTLIBRARIES += liblnx-fi.la
 liblnx_fi_la_SOURCES = $(_lnx_files) $(_lnx_headers)
-liblnx_fi_la_CPPFLAGS = -I$(top_srcdir)/prov/lnx/include -I$(top_srcdir)/include
+liblnx_fi_la_CPPFLAGS = -I$(top_srcdir)/prov/lnx/include -I$(top_srcdir)/include -D_GNU_SOURCE
 liblnx_fi_la_LIBADD = $(linkback) $(lnx_LIBS)
 liblnx_fi_la_LDFLAGS = -module -avoid-version -shared -export-dynamic
 liblnx_fi_la_DEPENDENCIES = $(linkback)


### PR DESCRIPTION
When attempting to build the LNX provider as DSO (i.e. using the `--enable-lnx=dl` configure flag), the build fails with errors related to missing headers and GNU macros.

Setting `CPPFLAGS` for the `liblnx-fi` object to expose the missing resources during compilation makes the build succeed.