### PR TITLE
[v2.4.x] prov/efa: Use endpoint->peer hashmap at the AV level

### DIFF
--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -1024,6 +1024,7 @@
     <ClInclude Include="prov\efa\src\rdm\efa_rdm_atomic.h" />
     <ClInclude Include="prov\efa\src\rdm\efa_rdm_msg.h" />
     <ClInclude Include="prov\efa\src\rdm\efa_rdm_pke.h" />
+    <ClInclude Include="prov\efa\src\rdm\efa_rdm_peer.h" />
     <ClInclude Include="prov\efa\src\rdm\efa_rdm_pkt_type.h" />
     <ClInclude Include="prov\efa\src\rdm\rxr_pkt_type_req.h" />
     <ClInclude Include="prov\efa\src\rdm\efa_rdm_rma.h" />

--- a/prov/efa/src/efa_conn.h
+++ b/prov/efa/src/efa_conn.h
@@ -5,6 +5,7 @@
 #define EFA_CONN_H
 
 #include "ofi_util.h"
+#include "rdm/efa_rdm_peer.h"
 
 struct efa_conn {
 	struct efa_ah *ah;
@@ -15,7 +16,22 @@ struct efa_conn {
 	fi_addr_t		shm_fi_addr;
 	struct dlist_entry	implicit_av_lru_entry;
 	struct dlist_entry ah_implicit_conn_list_entry;
+	struct efa_conn_ep_peer_map_entry *ep_peer_map;
 };
+
+struct efa_conn_ep_peer_map_entry {
+	struct efa_rdm_ep *ep_ptr;
+	struct efa_rdm_peer peer;
+	UT_hash_handle hh;
+};
+
+void efa_conn_ep_peer_map_insert(struct efa_conn *conn,
+				struct efa_conn_ep_peer_map_entry *map_entry);
+
+struct efa_rdm_peer *efa_conn_ep_peer_map_lookup(struct efa_conn *conn,
+						 struct efa_rdm_ep *ep);
+
+void efa_conn_ep_peer_map_remove(struct efa_conn *conn, struct efa_rdm_ep *ep);
 
 int efa_conn_rdm_insert_shm_av(struct efa_av *av, struct efa_conn *conn);
 

--- a/prov/efa/src/rdm/efa_rdm_cq.c
+++ b/prov/efa/src/rdm/efa_rdm_cq.c
@@ -423,6 +423,8 @@ static void efa_rdm_cq_handle_recv_completion(struct efa_ibv_cq *ibv_cq, struct 
 	uint32_t imm_data = 0;
 	bool has_imm_data = false;
 
+	EFA_DBG(FI_LOG_CQ, "Processing receive completion for packet %p\n", pkt_entry);
+
 	if (pkt_entry->alloc_type == EFA_RDM_PKE_FROM_USER_RX_POOL) {
 		assert(ep->user_rx_pkts_posted > 0);
 		ep->user_rx_pkts_posted--;

--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -118,14 +118,11 @@ struct efa_rdm_ep {
 	/* list of pre-posted recv buffers */
 	struct dlist_entry rx_posted_buf_list;
 
-	/* Hashmap between fi_addr and efa_rdm_peer structs */
-	struct efa_rdm_ep_peer_map_entry *fi_addr_to_peer_map;
-
-	/* Hashmap between implicit peer id and efa_rdm_peer structs */
-	struct efa_rdm_ep_peer_map_entry *fi_addr_to_peer_map_implicit;
-
 	/* bufpool to hold the fi_addr->peer hashmap entries */
 	struct ofi_bufpool *peer_map_entry_pool;
+
+	/**< List of peers associated with this endpoint */
+	struct dlist_entry ep_peer_list;
 
 	/* buffer pool for peer reorder circular buffer */
 	struct ofi_bufpool *peer_robuf_pool;
@@ -555,27 +552,6 @@ bool efa_rdm_ep_support_unsolicited_write_recv(struct efa_rdm_ep *ep)
 {
 	return ep->extra_info[0] & EFA_RDM_EXTRA_FEATURE_UNSOLICITED_WRITE_RECV;
 }
-
-struct efa_rdm_ep_peer_map_entry {
-	fi_addr_t addr;
-	struct efa_rdm_peer peer;
-	UT_hash_handle hndl;
-};
-
-int
-efa_rdm_ep_peer_map_insert(struct efa_rdm_ep_peer_map_entry **peer_map,
-			   fi_addr_t addr,
-			   struct efa_rdm_ep_peer_map_entry *map_entry);
-struct efa_rdm_peer *
-efa_rdm_ep_peer_map_lookup(struct efa_rdm_ep_peer_map_entry **peer_map,
-			   fi_addr_t addr);
-void efa_rdm_ep_peer_map_remove(struct efa_rdm_ep_peer_map_entry **peer_map,
-				fi_addr_t addr);
-
-void efa_rdm_ep_peer_map_implicit_to_explicit(struct efa_rdm_ep *ep,
-					      struct efa_rdm_peer *peer,
-					      fi_addr_t implicit_fi_addr,
-					      fi_addr_t explicit_fi_addr);
 
 bool efa_rdm_ep_has_unfinished_send(struct efa_rdm_ep *efa_rdm_ep);
 

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -262,8 +262,9 @@ int efa_rdm_ep_create_buffer_pools(struct efa_rdm_ep *ep)
 		goto err_free;
 
 	ret = ofi_bufpool_create(&ep->peer_map_entry_pool,
-				 sizeof(struct efa_rdm_ep_peer_map_entry),
-				 EFA_RDM_BUFPOOL_ALIGNMENT, 0, /* no limit to max_cnt */
+				 sizeof(struct efa_conn_ep_peer_map_entry),
+				 EFA_RDM_BUFPOOL_ALIGNMENT,
+				 0, /* no limit to max_cnt */
 				 EFA_RDM_EP_MIN_PEER_POOL_SIZE,
 				 0);
 	if (ret)
@@ -642,6 +643,8 @@ int efa_rdm_ep_open(struct fid_domain *domain, struct fi_info *info,
 		goto err_close_shm_ep;
 	}
 
+	dlist_init(&efa_rdm_ep->ep_peer_list);
+
 	*ep = &efa_rdm_ep->base_ep.util_ep.ep_fid;
 	(*ep)->msg = &efa_rdm_msg_ops;
 	(*ep)->rma = &efa_rdm_rma_ops;
@@ -758,6 +761,10 @@ static void efa_rdm_ep_destroy_buffer_pools(struct efa_rdm_ep *efa_rdm_ep)
 	struct dlist_entry *entry, *tmp;
 	struct efa_rdm_ope *rxe;
 	struct efa_rdm_ope *txe;
+	struct efa_rdm_peer *peer;
+	struct util_av_entry *util_av_entry;
+	struct efa_av_entry *av_entry;
+	struct efa_conn_ep_peer_map_entry *peer_map_entry;
 
 #if ENABLE_DEBUG
 	struct efa_rdm_pke *pkt_entry;
@@ -803,23 +810,33 @@ static void efa_rdm_ep_destroy_buffer_pools(struct efa_rdm_ep *efa_rdm_ep)
 		efa_rdm_txe_release(txe);
 	}
 
-	/* Clean up any remaining peers in the hashmap before destroying buffer pools */
-	if (efa_rdm_ep->fi_addr_to_peer_map) {
-		struct efa_rdm_ep_peer_map_entry *map_entry, *map_tmp;
-		HASH_ITER(hndl, efa_rdm_ep->fi_addr_to_peer_map, map_entry, map_tmp) {
-			efa_rdm_peer_destruct(&map_entry->peer, efa_rdm_ep);
-			HASH_DELETE(hndl, efa_rdm_ep->fi_addr_to_peer_map, map_entry);
-			ofi_buf_free(map_entry);
-		}
-	}
+	/* Clean up any remaining peers before destroying buffer pools */
+	dlist_foreach_container_safe (&efa_rdm_ep->ep_peer_list,
+				      struct efa_rdm_peer, peer,
+				      ep_peer_list_entry, tmp) {
 
-	if (efa_rdm_ep->fi_addr_to_peer_map_implicit) {
-		struct efa_rdm_ep_peer_map_entry *map_entry, *map_tmp;
-		HASH_ITER(hndl, efa_rdm_ep->fi_addr_to_peer_map_implicit, map_entry, map_tmp) {
-			efa_rdm_peer_destruct(&map_entry->peer, efa_rdm_ep);
-			HASH_DELETE(hndl, efa_rdm_ep->fi_addr_to_peer_map_implicit, map_entry);
-			ofi_buf_free(map_entry);
+		if (peer->conn->fi_addr != FI_ADDR_UNSPEC) {
+			util_av_entry = ofi_bufpool_get_ibuf(
+				efa_rdm_ep->base_ep.av->util_av.av_entry_pool,
+				peer->conn->fi_addr);
+		} else {
+			assert(peer->conn->implicit_fi_addr != FI_ADDR_UNSPEC);
+
+			util_av_entry = ofi_bufpool_get_ibuf(
+				efa_rdm_ep->base_ep.av->util_av_implicit.av_entry_pool,
+				peer->conn->implicit_fi_addr);
 		}
+
+		dlist_remove(&peer->ep_peer_list_entry);
+
+		efa_rdm_peer_destruct(peer, efa_rdm_ep);
+
+		peer_map_entry = container_of(
+			peer, struct efa_conn_ep_peer_map_entry, peer);
+
+		av_entry = (struct efa_av_entry *) util_av_entry->data;
+		HASH_DEL(av_entry->conn.ep_peer_map, peer_map_entry);
+		ofi_buf_free(peer_map_entry);
 	}
 
 	if (efa_rdm_ep->ope_pool)

--- a/prov/efa/src/rdm/efa_rdm_peer.h
+++ b/prov/efa/src/rdm/efa_rdm_peer.h
@@ -5,7 +5,6 @@
 #define EFA_RDM_PEER_H
 
 #include "ofi_recvwin.h"
-#include "efa_av.h"
 #include "efa_rdm_ope.h"
 #include "efa_rdm_protocol.h"
 #include "efa_rdm_rxe_map.h"
@@ -112,7 +111,7 @@ struct efa_rdm_peer {
 	struct dlist_entry txe_list; /**< a list of txe related to this peer */
 	struct dlist_entry rxe_list; /**< a list of rxe related to this peer */
 	struct dlist_entry overflow_pke_list; /**< a list of out-of-order pke that overflow the current recvwin */
-
+	struct dlist_entry ep_peer_list_entry; /**< linked to efa_rdm_ep->ep_peer_list */
 	/**
 	 * @brief number of bytes that has been sent as part of runting protocols
 	 * @details this value is capped by efa_env.efa_runt_size


### PR DESCRIPTION
An fi_addr->peer  hashmap at the endpoint level grows with the number of peers. An endpoint->peer hashmap grows with the number of endpoints - which would be better for applications that create many peers but few endpoints per AV e.g. MPI applications which
only create a single endpoint per AV.


(cherry picked from commit 865ec28aef3d8fa9f37e45361e91989a30af4290)