### PR TITLE
.github/workflows: Add PR character safety check workflow

### DIFF
--- a/.github/workflows/pr-character-safety.yml
+++ b/.github/workflows/pr-character-safety.yml
@@ -1,0 +1,35 @@
+name: PR Character Safety Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  character-safety:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run PR character safety check
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+
+          cd .github/workflows/scripts
+          ./test_pr_character_safety.sh "$BASE_SHA" "$HEAD_SHA"
+
+      - name: Upload scan results (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-character-safety-results
+          path: |
+            .github/workflows/scripts/changed_files.txt
+            .github/workflows/scripts/text_files.txt
+            .github/workflows/scripts/text_to_binary_files.txt
+            .github/workflows/scripts/pr_added_lines.txt
+            .github/workflows/scripts/hits.txt

--- a/.github/workflows/scripts/check_nonprintable.sh
+++ b/.github/workflows/scripts/check_nonprintable.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+BASE_SHA="$1"
+HEAD_SHA="$2"
+
+if [ -z "$BASE_SHA" ] || [ -z "$HEAD_SHA" ]; then
+    echo "Usage: $0 <base_sha> <head_sha>"
+    exit 1
+fi
+
+echo "Checking for non-printable characters..."
+
+# Store current directory and change to git root for proper file paths
+SCRIPT_DIR="$(pwd)"
+cd "$(git rev-parse --show-toplevel)"
+
+# Get added lines from text files only
+if [ -s "$SCRIPT_DIR/text_files.txt" ]; then
+    # Build file list manually for compatibility
+    files=""
+    while IFS= read -r file; do
+        files="$files $file"
+    done < "$SCRIPT_DIR/text_files.txt"
+
+    if [ -n "$files" ]; then
+        git diff --no-color --unified=0 "$BASE_SHA..$HEAD_SHA" -- $files | \
+          grep '^+' | grep -v '^+++' > "$SCRIPT_DIR/pr_added_lines.txt" || true
+    else
+        touch "$SCRIPT_DIR/pr_added_lines.txt"
+    fi
+else
+    touch "$SCRIPT_DIR/pr_added_lines.txt"
+fi
+
+# Change back to script directory for the rest of the script
+cd "$SCRIPT_DIR"
+
+if [ ! -s pr_added_lines.txt ]; then
+    echo "No added lines to scan."
+    exit 0
+fi
+
+# Check for control characters and problematic Unicode whitespace
+# Control chars, no-break space, zero-width space, etc.
+if LC_ALL=C grep -nP '[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]|\xC2\xA0|\xE2\x80\x8B' pr_added_lines.txt > hits.txt 2>/dev/null; then
+    echo "Non-printable or problematic characters detected:"
+    while IFS= read -r line; do
+        echo "$line"
+        echo "$line" | sed 's/^[0-9]*://' | hexdump -C
+        echo ""
+    done < hits.txt
+    exit 1
+else
+    echo "No problematic characters found."
+    exit 0
+fi

--- a/.github/workflows/scripts/check_text_to_binary.sh
+++ b/.github/workflows/scripts/check_text_to_binary.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+BASE_SHA="$1"
+HEAD_SHA="$2"
+
+if [ -z "$BASE_SHA" ] || [ -z "$HEAD_SHA" ]; then
+    echo "Usage: $0 <base_sha> <head_sha>"
+    exit 1
+fi
+
+echo "Checking for files converted from text to binary between $BASE_SHA and $HEAD_SHA..."
+
+git diff --name-only "$BASE_SHA..$HEAD_SHA" > changed_files.txt
+
+FAILED=0
+> text_files.txt
+> text_to_binary_files.txt
+
+while IFS= read -r file; do
+    if git cat-file -e "$HEAD_SHA:$file" 2>/dev/null; then
+        git show "$HEAD_SHA:$file" | file - | grep -q "text\|empty"
+        head_is_text=$?
+
+        if git cat-file -e "$BASE_SHA:$file" 2>/dev/null; then
+            git show "$BASE_SHA:$file" | file - | grep -q "text\|empty"
+            base_is_text=$?
+
+            if [ $base_is_text -eq 0 ] && [ $head_is_text -ne 0 ]; then
+                echo "$file" >> text_to_binary_files.txt
+                FAILED=1
+            fi
+        fi
+
+        if [ $head_is_text -eq 0 ]; then
+            echo "$file" >> text_files.txt
+        fi
+    fi
+done < changed_files.txt
+
+if [ -s text_to_binary_files.txt ]; then
+    echo "Files converted from text to binary:"
+    cat text_to_binary_files.txt
+fi
+
+exit $FAILED

--- a/.github/workflows/scripts/test_pr_character_safety.sh
+++ b/.github/workflows/scripts/test_pr_character_safety.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+BASE_SHA="$1"
+HEAD_SHA="$2"
+
+if [ -z "$BASE_SHA" ] || [ -z "$HEAD_SHA" ]; then
+    echo "Usage: $0 <base_sha> <head_sha>"
+    echo "Example: $0 HEAD~1 HEAD"
+    exit 1
+fi
+
+echo "Running PR character safety check..."
+
+./check_text_to_binary.sh "$BASE_SHA" "$HEAD_SHA"
+TEXT_TO_BINARY=$?
+
+./check_nonprintable.sh "$BASE_SHA" "$HEAD_SHA"
+NONPRINTABLE=$?
+
+if [ $TEXT_TO_BINARY -ne 0 ] || [ $NONPRINTABLE -ne 0 ]; then
+    echo "❌ PR character safety check failed"
+    exit 1
+else
+    echo "✅ PR character safety check passed"
+    exit 0
+fi


### PR DESCRIPTION
This PR adds a GitHub actions workflow to block PRs with non-printable unicode characters.
Tested bash scripts on a past commit with a non-printable character.

```
Running PR character safety check...
Checking for files converted from text to binary between ff97cc7efcfc303185b8bcb782eb8e3e79be3f2b~1 and ff97cc7efcfc303185b8bcb782eb8e3e79be3f2b...
Checking for non-printable characters...
Non-printable or problematic characters detected:
8:+		efa_LDFLAGS+=" -L$efa_LIBDIR -Wl,--enable-new-dtags,-rpath,$efa_LIBDIR"
00000000  2b 09 09 65 66 61 5f 4c  44 46 4c 41 47 53 2b 3d  |+..efa_LDFLAGS+=|
00000010  22 c2 a0 2d 4c 24 65 66  61 5f 4c 49 42 44 49 52  |"..-L$efa_LIBDIR|
00000020  20 2d 57 6c 2c 2d 2d 65  6e 61 62 6c 65 2d 6e 65  | -Wl,--enable-ne|
00000030  77 2d 64 74 61 67 73 2c  2d 72 70 61 74 68 2c 24  |w-dtags,-rpath,$|
00000040  65 66 61 5f 4c 49 42 44  49 52 22 0a              |efa_LIBDIR".|
0000004c

❌ PR character safety check failed
```