### PR TITLE
[v2.4.x] prov/efa: Generation counter for release build

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -112,6 +112,11 @@
  */
 #define EFA_RDM_BUFPOOL_ALIGNMENT	(64)
 
+/*
+ * Define bitmask to compare packet generation
+ */
+#define EFA_RDM_PACKET_GEN_MASK (EFA_RDM_BUFPOOL_ALIGNMENT - 1)
+
 
 struct efa_fabric {
 	struct util_fabric	util_fabric;

--- a/prov/efa/src/rdm/efa_rdm_cq.h
+++ b/prov/efa/src/rdm/efa_rdm_cq.h
@@ -25,16 +25,28 @@ void efa_rdm_cq_wait_del_ibv_cq(struct efa_rdm_cq *cq, struct efa_ibv_cq *ibv_cq
 void efa_rdm_cq_poll_ibv_cq_closing_ep(struct efa_ibv_cq *ibv_cq, struct efa_rdm_ep *closing_ep);
 int efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq);
 
-#if ENABLE_DEBUG
-static inline struct efa_rdm_pke *efa_rdm_cq_get_pke_from_wr_id(uint64_t wr_id)
+static inline struct efa_rdm_pke *efa_rdm_cq_get_pke_from_wr_id_solicited(uint64_t wr_id)
 {
 	struct efa_rdm_pke *pkt_entry;
-	uint8_t gen = wr_id & (EFA_RDM_BUFPOOL_ALIGNMENT - 1);
-	wr_id &= ~(EFA_RDM_BUFPOOL_ALIGNMENT - 1);
+	uint8_t gen = wr_id & EFA_RDM_PACKET_GEN_MASK;
+
+	wr_id &= ~((uint64_t)EFA_RDM_PACKET_GEN_MASK);
 	pkt_entry = (struct efa_rdm_pke *) wr_id;
-	assert(pkt_entry->gen == gen);
+	if (OFI_UNLIKELY(pkt_entry->gen != gen)) {
+		EFA_WARN(FI_LOG_CQ, "Received packet from wrong generation! pkt_entry %p expected gen %d received gen %d\n", pkt_entry, pkt_entry->gen, gen);
+		assert(pkt_entry->gen == gen);
+	}
+
 	return pkt_entry;
 }
-#endif
+
+static inline struct efa_rdm_pke *efa_rdm_cq_get_pke_from_wr_id(struct efa_ibv_cq *ibv_cq, uint64_t wr_id)
+{
+	if (efa_cq_wc_is_unsolicited(ibv_cq)) {
+		return (struct efa_rdm_pke *) wr_id;
+	}
+
+	return efa_rdm_cq_get_pke_from_wr_id_solicited(wr_id);
+}
 
 #endif

--- a/prov/efa/src/rdm/efa_rdm_pke.h
+++ b/prov/efa/src/rdm/efa_rdm_pke.h
@@ -87,9 +87,6 @@ struct efa_rdm_pke {
 #if ENABLE_DEBUG
 	/** @brief entry to a linked list of posted buf list */
 	struct dlist_entry dbg_entry;
-
-	/**@brief Generation counter. It is incremented every time the packet is posted to rdma-core */
-	uint8_t gen;
 #endif
 	/** @brief pointer to #efa_rdm_ep */
 	struct efa_rdm_ep *ep;
@@ -183,6 +180,9 @@ struct efa_rdm_pke {
 	 */
 	size_t payload_size;
 
+	/**@brief Generation counter. It is incremented every time the packet is posted to rdma-core */
+	uint8_t gen;
+
 	/** @brief buffer that contains data that is going over wire
 	 *
 	 * @details
@@ -205,6 +205,8 @@ struct efa_rdm_pke {
 
 #if defined(static_assert)
 static_assert(sizeof (struct efa_rdm_pke) % EFA_RDM_PKE_ALIGNMENT == 0, "efa_rdm_pke alignment check");
+/* Checks if packet entry structure fits into two x86 cache lines */
+static_assert(sizeof (struct efa_rdm_pke) == EFA_RDM_PKE_ALIGNMENT, "efa_rdm_pke size check");
 #endif
 
 struct efa_rdm_ep;

--- a/prov/efa/test/efa_unit_test_mocks.c
+++ b/prov/efa/test/efa_unit_test_mocks.c
@@ -278,11 +278,7 @@ int efa_mock_efa_qp_post_send_verify_handshake_pkt_local_host_id_and_save_wr(str
 	struct efa_rdm_base_hdr *efa_rdm_base_hdr;
 	uint64_t *host_id_ptr;
 
-	pke = (struct efa_rdm_pke *) wr_id;
-#if ENABLE_DEBUG
-	pke = efa_rdm_cq_get_pke_from_wr_id(wr_id);
-#endif
-
+	pke = efa_rdm_cq_get_pke_from_wr_id_solicited(wr_id);
 	efa_rdm_base_hdr = efa_rdm_pke_get_base_hdr(pke);
 
 	assert_int_equal(efa_rdm_base_hdr->type, EFA_RDM_HANDSHAKE_PKT);

--- a/prov/efa/test/efa_unit_test_ope.c
+++ b/prov/efa/test/efa_unit_test_ope.c
@@ -286,11 +286,7 @@ void test_efa_rdm_ope_post_write_0_byte(struct efa_resource **state)
 	assert_int_equal(g_ibv_submitted_wr_id_cnt, 1);
 
 	wr_id = (uint64_t) g_ibv_submitted_wr_id_vec[0];
-
-	pkt_entry = (struct efa_rdm_pke *) wr_id;
-#if ENABLE_DEBUG
-	pkt_entry = efa_rdm_cq_get_pke_from_wr_id(wr_id);
-#endif
+	pkt_entry = efa_rdm_cq_get_pke_from_wr_id_solicited(wr_id);
 
 	efa_rdm_pke_release_tx(pkt_entry);
 	mock_txe.ep->efa_outstanding_tx_ops = 0;

--- a/prov/efa/test/efa_unit_test_rnr.c
+++ b/prov/efa/test/efa_unit_test_rnr.c
@@ -52,11 +52,7 @@ void test_efa_rnr_queue_and_resend_impl(struct efa_resource **state, uint32_t op
 
 	wr_id = (uint64_t) g_ibv_submitted_wr_id_vec[0];
 
-	pkt_entry = (struct efa_rdm_pke *) wr_id;
-#if ENABLE_DEBUG
-	if (!efa_cq_wc_is_unsolicited(ibv_cq))
-		pkt_entry = efa_rdm_cq_get_pke_from_wr_id(wr_id);
-#endif
+	pkt_entry = efa_rdm_cq_get_pke_from_wr_id(ibv_cq, wr_id);
 
 	pkt_entry->ope = txe;
 


### PR DESCRIPTION
The purpose of this commit is to  move generation counter out of debug build mode. The commit also adds a static assertion to ensure packet entry structure would not overflow to a new cache line.


(cherry picked from commit b48545262266a90b66c8d3996cdc2de591d3b280)