### PR TITLE
prov/efa: Stop setting qp->ibv_qp_ex->wr_id for data path direct

### DIFF
--- a/prov/efa/src/efa_data_path_direct_entry.h
+++ b/prov/efa/src/efa_data_path_direct_entry.h
@@ -411,12 +411,9 @@ static inline int efa_data_path_direct_post_send(
 		mmio_wc_start();
 	}
 
-	/* Set work request ID */
-	qp->ibv_qp_ex->wr_id = wr_id;
-
 	/* Build metadata in local stack variable */
 	efa_data_path_direct_set_ud_addr(meta_desc, ah, qpn, qkey);
-	meta_desc->req_id = efa_wq_get_next_wrid_idx(&sq->wq, qp->ibv_qp_ex->wr_id);
+	meta_desc->req_id = efa_wq_get_next_wrid_idx(&sq->wq, wr_id);
 
 	/* Set common control flags */
 	efa_set_common_ctrl_flags(meta_desc, sq, EFA_IO_SEND);
@@ -505,12 +502,9 @@ static inline int efa_data_path_direct_post_read(
 		mmio_wc_start();
 	}
 
-	/* Set work request ID */
-	qp->ibv_qp_ex->wr_id = wr_id;
-
 	/* Build metadata in local stack variable */
 	efa_data_path_direct_set_ud_addr(meta_desc, ah, qpn, qkey);
-	meta_desc->req_id = efa_wq_get_next_wrid_idx(&sq->wq, qp->ibv_qp_ex->wr_id);
+	meta_desc->req_id = efa_wq_get_next_wrid_idx(&sq->wq, wr_id);
 
 	/* Set common control flags for RDMA READ */
 	efa_set_common_ctrl_flags(meta_desc, sq, EFA_IO_RDMA_READ);
@@ -608,12 +602,9 @@ efa_data_path_direct_post_write(
 		mmio_wc_start();
 	}
 
-	/* Set work request ID */
-	qp->ibv_qp_ex->wr_id = wr_id;
-
 	/* Build metadata in local stack variable */
 	efa_data_path_direct_set_ud_addr(meta_desc, ah, qpn, qkey);
-	meta_desc->req_id = efa_wq_get_next_wrid_idx(&sq->wq, qp->ibv_qp_ex->wr_id);
+	meta_desc->req_id = efa_wq_get_next_wrid_idx(&sq->wq, wr_id);
 
 	/* Set common control flags for RDMA WRITE */
 	efa_set_common_ctrl_flags(meta_desc, sq, EFA_IO_RDMA_WRITE);

--- a/prov/efa/src/efa_msg.c
+++ b/prov/efa/src/efa_msg.c
@@ -275,7 +275,7 @@ static inline ssize_t efa_post_send(struct efa_base_ep *base_ep, const struct fi
 	if (OFI_UNLIKELY(ret))
 		ret = (ret == ENOMEM) ? -FI_EAGAIN : -ret;
 
-	efa_tracepoint(post_send, qp->ibv_qp_ex->wr_id, (uintptr_t)msg->context);
+	efa_tracepoint(post_send, wr_id, (uintptr_t)msg->context);
 
 out_err:
 	ofi_genlock_unlock(&base_ep->util_ep.lock);


### PR DESCRIPTION
The efa-data path direct code does not require qp->ibv_qp_ex->wr_id for userspace book keeping, and the efa-device is reading the wqe/db. We can get a micro optimization by not setting this value because it is not being used.