### PR TITLE
fabtests/common: remove unused function get_cuda_memory_support_str

### DIFF
--- a/fabtests/common/hmem_cuda.c
+++ b/fabtests/common/hmem_cuda.c
@@ -77,22 +77,6 @@ static void *cuda_handle;
 static bool dmabuf_supported;
 static bool gdr_supported;
 static enum ft_cuda_memory_support cuda_memory_support = FT_CUDA_NOT_INITIALIZED;
-static const char* get_cuda_memory_support_str(enum ft_cuda_memory_support support) {
-    switch (support) {
-        case FT_CUDA_NOT_INITIALIZED:
-            return "NOT_INITIALIZED";
-        case FT_CUDA_NOT_SUPPORTED:
-            return "NOT_SUPPORTED";
-        case FT_CUDA_DMA_BUF_ONLY:
-            return "DMA_BUF_ONLY";
-        case FT_CUDA_GDR_ONLY:
-            return "GDR_ONLY";
-        case FT_CUDA_DMABUF_GDR_BOTH:
-            return "DMABUF_GDR_BOTH";
-        default:
-            return "INVALID";
-    }
-}
 
 /**
  * Since function names can get redefined in cuda.h/cuda_runtime.h files,


### PR DESCRIPTION
Fix the warning
common/hmem_cuda.c:80:20: warning: 'get_cuda_memory_support_str' defined but not used [-Wunused-function]

https://github.com/ofiwg/libfabric/commit/2a9edb24b7e98c764d27a5bf27cda0a2e786efd2 removed the log that called this function.