### PR TITLE
prov/cxi: evtq: fix logic in saturation check

### DIFF
--- a/prov/cxi/src/cxip_evtq.c
+++ b/prov/cxi/src/cxip_evtq.c
@@ -34,8 +34,10 @@ bool cxip_evtq_saturated(struct cxip_evtq *evtq)
 	 */
 	if (evtq->eq->status->timestamp_sec >
 	    evtq->prev_eq_status.timestamp_sec ||
-	    evtq->eq->status->timestamp_ns >
-	    evtq->prev_eq_status.timestamp_ns) {
+	    (evtq->eq->status->timestamp_sec ==
+	     evtq->prev_eq_status.timestamp_sec &&
+	     evtq->eq->status->timestamp_ns >
+	     evtq->prev_eq_status.timestamp_ns)) {
 		evtq->eq_saturated = true;
 		return true;
 	}


### PR DESCRIPTION
if (sec < prev_sec) but (ns > prev_ns), eg: wraparound on seconds occurs, this erroneously triggers.