### PR TITLE
fabtests/efa/multi_ep_stress: Add missing locking

### DIFF
--- a/fabtests/prov/efa/src/multi_ep_stress.c
+++ b/fabtests/prov/efa/src/multi_ep_stress.c
@@ -751,7 +751,9 @@ static void *run_sender_worker(void *arg)
 
 	cleanup:
 		// Cleanup endpoint before next cycle
+		pthread_mutex_lock(&ctx->status.mutex);
 		cleanup_endpoint(&ctx->common);
+		pthread_mutex_unlock(&ctx->status.mutex);
 
 		if (ret) {
 			goto out;


### PR DESCRIPTION
cleanup_endpoint can close av and set it to NULL,
which should be protected with the same lock as
the notification_handler when it tries
to check av is still active