### PR TITLE
Fix efa_mr_reg_impl/fa_mr_dereg_impl race condition

### DIFF
--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -201,8 +201,8 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 		goto err_free;
 	}
 
-	efa_domain->ibv_mr_reg_ct = 0;
-	efa_domain->ibv_mr_reg_sz = 0;
+	ofi_atomic_initialize64(&efa_domain->ibv_mr_reg_ct, 0);
+	ofi_atomic_initialize64(&efa_domain->ibv_mr_reg_sz, 0);
 
 	efa_domain->ah_map = NULL;
 

--- a/prov/efa/src/efa_domain.h
+++ b/prov/efa/src/efa_domain.h
@@ -11,6 +11,7 @@
 #include "ofi_hmem.h"
 #include "ofi_util.h"
 #include "ofi_lock.h"
+#include "ofi_atom.h"
 
 enum efa_domain_info_type {
 	EFA_INFO_RDM,
@@ -35,9 +36,9 @@ struct efa_domain {
 	struct ofi_genlock	srx_lock; /* shared among peer providers */
 	struct efa_ah		*ah_map;
 	/* Total count of ibv memory registrations */
-	size_t ibv_mr_reg_ct;
+	ofi_atomic64_t ibv_mr_reg_ct;
 	/* Total size of memory registrations (in bytes) */
-	size_t ibv_mr_reg_sz;
+	ofi_atomic64_t ibv_mr_reg_sz;
 	/* info_type is used to distinguish between the rdm, dgram and
 	 * efa-direct paths */
 	enum efa_domain_info_type info_type;

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -392,6 +392,7 @@ static int efa_mr_dereg_impl(struct efa_mr *efa_mr)
 	int ret = 0;
 	int err;
 	size_t ibv_mr_size;
+	int64_t reg_ct, reg_sz;
 
 	efa_domain = efa_mr->domain;
 	if (efa_mr->ibv_mr) {
@@ -402,10 +403,10 @@ static int efa_mr_dereg_impl(struct efa_mr *efa_mr)
 				"Unable to deregister memory registration\n");
 			ret = err;
 		} else {
-			efa_mr->domain->ibv_mr_reg_ct--;
-			efa_mr->domain->ibv_mr_reg_sz -= ibv_mr_size;
-			EFA_INFO(FI_LOG_MR, "Deregistered memory of size %zu for ibv pd %p, total mr reg size %zu, mr reg count %zu\n",
-				 efa_mr->ibv_mr->length, efa_mr->domain->ibv_pd, efa_mr->domain->ibv_mr_reg_sz, efa_mr->domain->ibv_mr_reg_ct);
+			reg_ct = ofi_atomic_dec64(&efa_mr->domain->ibv_mr_reg_ct);
+			reg_sz = ofi_atomic_sub64(&efa_mr->domain->ibv_mr_reg_sz, ibv_mr_size);
+			EFA_INFO(FI_LOG_MR, "Deregistered memory of size %zu for ibv pd %p, total mr reg size %zd, mr reg count %zd\n",
+				 efa_mr->ibv_mr->length, efa_mr->domain->ibv_pd, reg_sz, reg_ct);
 		}
 	}
 
@@ -830,6 +831,7 @@ static int efa_mr_reg_impl(struct efa_mr *efa_mr, uint64_t flags, const void *at
 	uint64_t original_access;
 	struct fi_mr_attr mr_attr = {0};
 	uint64_t shm_flags;
+	int64_t reg_sz, reg_ct;
 	int ret = 0;
 	bool device_support_rdma_read = false;
 	bool device_support_rdma_write = false;
@@ -894,14 +896,14 @@ static int efa_mr_reg_impl(struct efa_mr *efa_mr, uint64_t flags, const void *at
 			EFA_WARN(FI_LOG_MR,
 				 "Unable to register MR of %zu bytes: %s, "
 				 "flags %ld, ibv pd: %p, total mr "
-				 "reg size %zu, mr reg count %zu\n",
+				 "reg size %zd, mr reg count %zd\n",
 				 (flags & FI_MR_DMABUF) ?
 					 mr_attr.dmabuf->len :
 					 mr_attr.mr_iov->iov_len,
 				 fi_strerror(-errno), flags,
 				 efa_mr->domain->ibv_pd,
-				 efa_mr->domain->ibv_mr_reg_sz,
-				 efa_mr->domain->ibv_mr_reg_ct);
+				 ofi_atomic_get64(&efa_mr->domain->ibv_mr_reg_sz),
+				 ofi_atomic_get64(&efa_mr->domain->ibv_mr_reg_ct));
 			if (efa_mr->peer.iface == FI_HMEM_CUDA &&
 			    (efa_mr->peer.flags & OFI_HMEM_DATA_DEV_REG_HANDLE)) {
 				assert(efa_mr->peer.hmem_data);
@@ -910,16 +912,16 @@ static int efa_mr_reg_impl(struct efa_mr *efa_mr, uint64_t flags, const void *at
 
 			return -errno;
 		}
-		efa_mr->domain->ibv_mr_reg_ct++;
-		efa_mr->domain->ibv_mr_reg_sz += efa_mr->ibv_mr->length;
+		reg_ct = ofi_atomic_inc64(&efa_mr->domain->ibv_mr_reg_ct);
+		reg_sz = ofi_atomic_add64(&efa_mr->domain->ibv_mr_reg_sz, efa_mr->ibv_mr->length);
 		EFA_INFO(FI_LOG_MR,
 			 "Registered memory at %p of size %zu"
 			 "flags %ld for ibv pd %p, "
-			 "total mr reg size %zu, mr reg count %zu\n",
+			 "total mr reg size %zd, mr reg count %zd\n",
 			 efa_mr->ibv_mr->addr, efa_mr->ibv_mr->length,
 			 flags, efa_mr->domain->ibv_pd,
-			 efa_mr->domain->ibv_mr_reg_sz,
-			 efa_mr->domain->ibv_mr_reg_ct);
+			 reg_sz,
+			 reg_ct);
 		efa_mr->mr_fid.key = efa_mr->ibv_mr->rkey;
 	}
 	efa_mr->mr_fid.mem_desc = efa_mr;

--- a/prov/efa/test/efa_unit_test_mr.c
+++ b/prov/efa/test/efa_unit_test_mr.c
@@ -8,8 +8,8 @@ static void test_efa_mr_impl(struct efa_domain *efa_domain, struct fid_mr *mr,
 {
 	struct efa_mr *efa_mr;
 
-	assert_int_equal(efa_domain->ibv_mr_reg_ct, mr_reg_count);
-	assert_int_equal(efa_domain->ibv_mr_reg_sz, mr_reg_size);
+	assert_int_equal(ofi_atomic_get64(&efa_domain->ibv_mr_reg_ct), (int64_t)mr_reg_count);
+	assert_int_equal(ofi_atomic_get64(&efa_domain->ibv_mr_reg_sz), (int64_t)mr_reg_size);
 
 	if (mr) {
 		efa_mr = container_of(mr, struct efa_mr, mr_fid);
@@ -39,8 +39,8 @@ void test_efa_rdm_mr_reg_host_memory(struct efa_resource **state)
 				  util_domain.domain_fid);
 
 	/* fi_endpoint calls ofi_bufpool_grow, which registers mr */
-	baseline_ct = efa_domain->ibv_mr_reg_ct;
-	baseline_sz = efa_domain->ibv_mr_reg_sz;
+	baseline_ct = ofi_atomic_get64(&efa_domain->ibv_mr_reg_ct);
+	baseline_sz = ofi_atomic_get64(&efa_domain->ibv_mr_reg_sz);
 
 	buf = malloc(mr_size);
 	assert_non_null(buf);
@@ -77,8 +77,8 @@ void test_efa_rdm_mr_reg_host_memory_no_mr_local(struct efa_resource **state)
 				  util_domain.domain_fid);
 
 	/* fi_endpoint calls ofi_bufpool_grow, which registers mr */
-	baseline_ct = efa_domain->ibv_mr_reg_ct;
-	baseline_sz = efa_domain->ibv_mr_reg_sz;
+	baseline_ct = ofi_atomic_get64(&efa_domain->ibv_mr_reg_ct);
+	baseline_sz = ofi_atomic_get64(&efa_domain->ibv_mr_reg_sz);
 
 	buf = malloc(mr_size);
 	assert_non_null(buf);
@@ -110,8 +110,8 @@ void test_efa_rdm_mr_reg_host_memory_overlapping_buffers(struct efa_resource **s
 				  util_domain.domain_fid);
 
 	/* fi_endpoint calls ofi_bufpool_grow, which registers mr */
-	baseline_ct = efa_domain->ibv_mr_reg_ct;
-	baseline_sz = efa_domain->ibv_mr_reg_sz;
+	baseline_ct = ofi_atomic_get64(&efa_domain->ibv_mr_reg_ct);
+	baseline_sz = ofi_atomic_get64(&efa_domain->ibv_mr_reg_sz);
 
 	buf = malloc(mr_size);
 	assert_non_null(buf);
@@ -162,8 +162,8 @@ void test_efa_rdm_mr_reg_cuda_memory(struct efa_resource **state)
 		efa_domain = container_of(resource->domain, struct efa_domain,
 					  util_domain.domain_fid);
 		/* fi_endpoint calls ofi_bufpool_grow, which registers mr */
-		baseline_ct = efa_domain->ibv_mr_reg_ct;
-		baseline_sz = efa_domain->ibv_mr_reg_sz;
+		baseline_ct = ofi_atomic_get64(&efa_domain->ibv_mr_reg_ct);
+		baseline_sz = ofi_atomic_get64(&efa_domain->ibv_mr_reg_sz);
 
 		err = ofi_cudaMalloc(&buf, mr_size);
 		assert_int_equal(err, 0);
@@ -220,8 +220,8 @@ void test_efa_direct_mr_reg_no_gdrcopy(struct efa_resource **state)
 		efa_domain = container_of(resource->domain, struct efa_domain,
 					  util_domain.domain_fid);
 		/* fi_endpoint calls ofi_bufpool_grow, which registers mr */
-		baseline_ct = efa_domain->ibv_mr_reg_ct;
-		baseline_sz = efa_domain->ibv_mr_reg_sz;
+		baseline_ct = ofi_atomic_get64(&efa_domain->ibv_mr_reg_ct);
+		baseline_sz = ofi_atomic_get64(&efa_domain->ibv_mr_reg_sz);
 
 		err = ofi_cudaMalloc(&buf, mr_size);
 		assert_int_equal(err, 0);


### PR DESCRIPTION
- Converted `ibv_mr_reg_ct` and `ibv_mr_reg_sz` to `ofi_atomic64`
- Updated MR registration/deregistration code to use atomic operations
- Maintained existing logging functionality with thread-safe counter reads