### PR TITLE
.github/workflow: Fix Coverity scan issue

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -93,7 +93,7 @@ jobs:
             --form email=ofiwg@lists.openfabrics.org \
             --form file=@libfabric.tgz \
             --form version="main" \
-            --form description="`$PWD/install/bin/fi_info -l`" \
+            --form description="`$PWD/install/bin/fi_info --version`" \
             https://scan.coverity.com/builds?project=ofiwg%2Flibfabric
       - name: Upload build logs
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0


### PR DESCRIPTION
Coverity scan has been failing for a while, with the error message saying "due to an issue on the Coverity server". Feedback from the technical support indicates that the cause is the "Description" line being too long (exceeding the 512 character limit).

Update the action defintion to use a shorter "Description" line when submitting the Coverity scan job.