### PR TITLE
prov/efa: Verify QP number on CQE process

### DIFF
--- a/prov/efa/src/efa_data_path_direct_entry.h
+++ b/prov/efa/src/efa_data_path_direct_entry.h
@@ -157,7 +157,7 @@ static inline int efa_data_path_direct_start_poll(struct efa_ibv_cq *ibv_cq,
 	data_path_direct->cur_qp =
 		efa_domain->qp_table[qpn & efa_domain->qp_table_sz_m1];
 
-	if (!data_path_direct->cur_qp) {
+	if (!data_path_direct->cur_qp || qpn != data_path_direct->cur_qp->qp_num) {
 		data_path_direct->cur_wq = NULL;
 		EFA_DBG(FI_LOG_CQ, "QP[%u] does not exist in QP table\n", qpn);
 		return EINVAL;


### PR DESCRIPTION
When accessing the QP table with the masked QP number from the CQE, need to make sure the QP number still matches. Otherwise, the QP for which the work request had been completed was destroyed, and its table entry was subsequently re-occupied by another QP.