### PR TITLE
prov/lnx: Add Multi-Rail selection policy

### DIFF
--- a/man/fi_lnx.7.md
+++ b/man/fi_lnx.7.md
@@ -155,6 +155,21 @@ The *LNX* provider checks for the following environment variables:
   On a system with four cxi domains, the last example is equivalent to:
      - shm+cxi:cxi0,cxi1,cxi2,cxi3
 
+*FI_LNX_MULTI_RAIL_SELECTION*
+: This environment variable is used to specify the multi-rail selection
+  policy LNX will use. LNX selects a local endpoint and a remote peer
+  address when sending messages. There are currently two supported methods.
+  1) PER_MSG: This policy round robins over the local endpoint and remote
+     peer addresses per message sent. This policy doesn't support send after
+     send capability, as sent messages can arrive in a different order.
+  2) PER_PEER: This policy round robins per peer. On the first message sent
+     to the peer a local endpoint and a peer address are selected and
+     henceforth used for all messages to that peer. The local endpoints
+     are round robined over per peer. This policy ensures messages sent
+     are received in the same order.
+  The environment variable can be set to one of PER_MSG or PER_PEER. If the
+  environment variable is not set the policy defaults to PER_PEER.
+
 *FI_LNX_DISABLE_SHM*
 : By default this environment variable is set to 0. However, the user can
   set it to one and then the SHM provider will not be used. This can be

--- a/prov/lnx/src/lnx_av.c
+++ b/prov/lnx/src/lnx_av.c
@@ -423,6 +423,7 @@ skip:
 						&lp->lp_addr, 1, 0);
 			return rc;
 		}
+
 		la = (struct lnx_address *) lea;
 	}
 

--- a/prov/lnx/src/lnx_init.c
+++ b/prov/lnx/src/lnx_init.c
@@ -761,6 +761,11 @@ LNX_INI
 	struct ofi_bufpool_attr bp_attrs = {};
 	int ret;
 
+	fi_param_define(&lnx_prov, "multi_rail_selection", FI_PARAM_STRING,
+			"Specify which Multi-Rail endpoint selection "
+			"algorithm to use. One of: PER_MSG, PER_PEER. "
+			"Defaults to PER_PEER");
+
 	fi_param_define(&lnx_prov, "prov_links", FI_PARAM_STRING,
 			"Specify which providers LNX will link together. Format: "
 			"<prov 1>+<prov 2>+...+<prov N>. EX: shm+cxi");


### PR DESCRIPTION
Add two Multi-Rail selection policies:

1. PER_MSG: This is what was originally implemented. This method round robins over the local endpoints and peer addresses on every sent message. It doesn't support send after send requirements.
2. PER_PEER: In this method the local end points are round robined over per peer. This way all local endpoints are used across the peers, however, each peer is assigned exactly one local endpoint which sends to one of its addresses. This ensures send after send is satisfied.

A new environment variable, FI_LNX_MULTI_RAIL_SELECTION, can be set to either PER_MSG or PER_PEER. If the environment variable is not set it defaults to PER_PEER.