### PR TITLE
bindings(rust): fix fi_read buffer signature

### DIFF
--- a/bindings/rust/wrapper.c
+++ b/bindings/rust/wrapper.c
@@ -975,7 +975,7 @@ int wrap_fi_profile_close(struct fid_profile *prof_fid)
 
 /* Static inline function declarations from fi_rma.h */
 
-ssize_t wrap_fi_read(struct fid_ep *ep, const void *buf, size_t len, void *desc,
+ssize_t wrap_fi_read(struct fid_ep *ep, void *buf, size_t len, void *desc,
 		     fi_addr_t src_addr, uint64_t addr, uint64_t key,
 		     void *context)
 {

--- a/bindings/rust/wrapper.h
+++ b/bindings/rust/wrapper.h
@@ -362,7 +362,7 @@ int wrap_fi_profile_open(struct fid *fid, uint64_t flags,
 int wrap_fi_profile_close(struct fid_profile *prof_fid);
 
 /* Static inline function declarations from fi_rma.h */
-ssize_t wrap_fi_read(struct fid_ep *ep, const void *buf, size_t len, void *desc,
+ssize_t wrap_fi_read(struct fid_ep *ep, void *buf, size_t len, void *desc,
 		     fi_addr_t src_addr, uint64_t addr, uint64_t key,
 		     void *context);
 ssize_t wrap_fi_readv(struct fid_ep *ep, const struct iovec *iov, void **desc,


### PR DESCRIPTION
The signature for `fi_read` is:

```c
static inline ssize_t
fi_read(struct fid_ep *ep, void *buf, size_t len, void *desc,
	fi_addr_t src_addr, uint64_t addr, uint64_t key, void *context)
```

However the rust wrapper currently specifies the `buf` as `const void*`, which doesn't match the original

```c
ssize_t wrap_fi_read(struct fid_ep *ep, const void *buf, size_t len, void *desc,
		     fi_addr_t src_addr, uint64_t addr, uint64_t key,
		     void *context)
```

You can also see this in the build log:

```
warning: ofi-libfabric-sys@0.1.0: libfabric/bindings/rust/wrapper.c:982:21: warning: passing 'const void *' to parameter of type 'void *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
warning: ofi-libfabric-sys@0.1.0:   982 |         return fi_read(ep, buf, len, desc, src_addr, addr, key, context);
warning: ofi-libfabric-sys@0.1.0:       |                            ^~~
warning: ofi-libfabric-sys@0.1.0: libfabric/include/rdma/fi_rma.h:98:34: note: passing argument to parameter 'buf' here
warning: ofi-libfabric-sys@0.1.0:    98 | fi_read(struct fid_ep *ep, void *buf, size_t len, void *desc,
```