### PR TITLE
fabtests/efa/multi_ep_stress: remove the unused assignment

### DIFF
--- a/fabtests/prov/efa/src/multi_ep_stress.c
+++ b/fabtests/prov/efa/src/multi_ep_stress.c
@@ -824,7 +824,6 @@ static int notify_endpoint_update(struct receiver_context *ctx)
 					if (topts.verbose)
 						printf("Receiver %d: Sender %d disconnected\n",
 						       ctx->worker_id, i);
-					ret = 0;
 					break;
 				} else {
 					// Real error


### PR DESCRIPTION
Fix CID 501144 that ret will be overwritten by other assignment before it can be used. Remove the ret = 0 to fix this issue