### PR TITLE
prov/efa: Fix use-after-free bug in implicit AH eviction

### DIFF
--- a/prov/efa/src/efa_conn.c
+++ b/prov/efa/src/efa_conn.c
@@ -445,10 +445,10 @@ void efa_conn_release_ah_unsafe(struct efa_av *av, struct efa_conn *conn,
 	if (release_from_implicit_av)
 		dlist_remove(&conn->ah_implicit_conn_list_entry);
 
-	efa_ah_release_unsafe(av->domain, conn->ah, release_from_implicit_av);
-
 	efa_conn_release_util_av(av, conn, release_from_implicit_av);
 
+	release_from_implicit_av ? conn->ah->implicit_refcnt-- :
+				   conn->ah->explicit_refcnt--;
 	release_from_implicit_av ? av->used_implicit-- : av->used_explicit--;
 }
 


### PR DESCRIPTION
When evictiing the implicit AH, we have to iterate over the list of conns used by the AH. Previously, the conn_release function also released the AH if it was the last conn left - which causes a use-after-free bug in the next and final iteration of the loop.

This commit fixes that by only decrementing the counter in the conn_release function and releasing the AH after the iteration is complete.