### PR TITLE
prov/efa: Fix double free in efa_rdm_pke_proc_matched_eager_rtm

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_pke_rtm.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtm.c
@@ -673,10 +673,10 @@ ssize_t efa_rdm_pke_proc_matched_eager_rtm(struct efa_rdm_pke *pkt_entry)
 	/*
 	 * On success, efa_rdm_pke_copy_data_to_ope will write rx completion,
 	 * release pkt_entry and rxe
+	 * 
+	 * On error, pkt_entry and rxe are released by caller.
 	 */
 	err = efa_rdm_pke_copy_payload_to_ope(pkt_entry, rxe);
-	if (err)
-		efa_rdm_pke_release_rx(pkt_entry);
 
 	return err;
 }

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -344,7 +344,7 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_rdm_pke_alloc_rtr_rxe, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_pke_get_unexp, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_pke_flag_tracking, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
-		cmocka_unit_test_setup_teardown(test_efa_rdm_pke_flag_tracking, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_rdm_pke_proc_matched_eager_rtm_error, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		/* end of efa_unit_test_pke.c */
 
 		/* begin efa_unit_test_domain.c */

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -338,6 +338,7 @@ void test_efa_rdm_pke_alloc_rtw_rxe();
 void test_efa_rdm_pke_alloc_rtr_rxe();
 void test_efa_rdm_pke_get_unexp();
 void test_efa_rdm_pke_flag_tracking();
+void test_efa_rdm_pke_proc_matched_eager_rtm_error();
 /* end of efa_unit_test_pke.c */
 
 void test_efa_msg_fi_recv();


### PR DESCRIPTION
On error, the pkt_entry and rxe are released by efa_rdm_pke_proc_tagrtm/ efa_rdm_pke_proc_msgrtm. Remove efa_rdm_pke_release_rx to fix the double free.