### PR TITLE
prov/efa: Fix double free in efa_rdm_pke_proc_matched_mulreq_rtm

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -185,6 +185,7 @@ prov_efa_test_efa_unit_test_LDFLAGS = $(cmocka_rpath) $(efa_LDFLAGS) $(cmocka_LD
 					-Wl,--wrap=efa_ah_release \
 					-Wl,--wrap=ofi_cudaMalloc \
 					-Wl,--wrap=ofi_copy_from_hmem_iov \
+					-Wl,--wrap=efa_rdm_pke_copy_payload_to_ope \
 					-Wl,--wrap=efa_rdm_pke_read \
 					-Wl,--wrap=efa_rdm_pke_proc_matched_rtm \
 					-Wl,--wrap=efa_rdm_ope_post_send \

--- a/prov/efa/src/rdm/efa_rdm_pke_rtm.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtm.c
@@ -926,7 +926,13 @@ ssize_t efa_rdm_pke_proc_matched_mulreq_rtm(struct efa_rdm_pke *pkt_entry)
 
 		err = efa_rdm_pke_copy_payload_to_ope(cur, rxe);
 		if (err) {
-			efa_rdm_pke_release_rx(cur);
+			/* On error,
+			 * If this is the first packet (cur == pkt_entry), caller will release it
+			 * If this is NOT the first packet, we release it here
+			 */
+			if (cur != pkt_entry) {
+				efa_rdm_pke_release_rx(cur);
+			}
 			ret = err;
 		}
 

--- a/prov/efa/test/efa_unit_test_mocks.c
+++ b/prov/efa/test/efa_unit_test_mocks.c
@@ -211,6 +211,11 @@ ssize_t efa_mock_ofi_copy_from_hmem_iov_inc_counter(void *dest, size_t size,
 	return __real_ofi_copy_from_hmem_iov(dest, size, hmem_iface, device, hmem_iov, hmem_iov_count, hmem_iov_offset);
 }
 
+ssize_t efa_mock_efa_rdm_pke_copy_payload_to_ope_return_mock(struct efa_rdm_pke *pke, struct efa_rdm_ope *ope)
+{
+	return mock_int();
+}
+
 int efa_mock_efa_rdm_pke_read_return_mock(struct efa_rdm_ope *ope)
 {
 	return mock_int();
@@ -306,6 +311,7 @@ struct efa_unit_test_mocks g_efa_unit_test_mocks = {
 	.ofi_cudaMalloc = __real_ofi_cudaMalloc,
 #endif
 	.ofi_copy_from_hmem_iov = __real_ofi_copy_from_hmem_iov,
+	.efa_rdm_pke_copy_payload_to_ope = __real_efa_rdm_pke_copy_payload_to_ope,
 	.efa_rdm_pke_read = __real_efa_rdm_pke_read,
 	.efa_rdm_pke_proc_matched_rtm = __real_efa_rdm_pke_proc_matched_rtm,
 	.efa_rdm_ope_post_send = __real_efa_rdm_ope_post_send,
@@ -577,6 +583,11 @@ ssize_t __wrap_ofi_copy_from_hmem_iov(void *dest, size_t size,
 				      size_t hmem_iov_count, uint64_t hmem_iov_offset)
 {
 	return g_efa_unit_test_mocks.ofi_copy_from_hmem_iov(dest, size, hmem_iface, device, hmem_iov, hmem_iov_count, hmem_iov_offset);
+}
+
+ssize_t __wrap_efa_rdm_pke_copy_payload_to_ope(struct efa_rdm_pke *pke, struct efa_rdm_ope *ope)
+{
+	return g_efa_unit_test_mocks.efa_rdm_pke_copy_payload_to_ope(pke, ope);
 }
 
 int __wrap_efa_rdm_pke_read(struct efa_rdm_ope *ope)

--- a/prov/efa/test/efa_unit_test_mocks.h
+++ b/prov/efa/test/efa_unit_test_mocks.h
@@ -75,6 +75,10 @@ ssize_t efa_mock_ofi_copy_from_hmem_iov_inc_counter(void *dest, size_t size,
 						    const struct iovec *hmem_iov,
 						    size_t hmem_iov_count, uint64_t hmem_iov_offset);
 
+ssize_t __real_efa_rdm_pke_copy_payload_to_ope(struct efa_rdm_pke *pke, struct efa_rdm_ope *ope);
+
+ssize_t efa_mock_efa_rdm_pke_copy_payload_to_ope_return_mock(struct efa_rdm_pke *pke, struct efa_rdm_ope *ope);
+
 int __real_efa_rdm_pke_read(struct efa_rdm_ope *ope);
 
 bool __real_efa_device_support_unsolicited_write_recv();
@@ -179,6 +183,8 @@ struct efa_unit_test_mocks
 					  enum fi_hmem_iface hmem_iface, uint64_t device,
 					  const struct iovec *hmem_iov,
 					  size_t hmem_iov_count, uint64_t hmem_iov_offset);
+
+	ssize_t (*efa_rdm_pke_copy_payload_to_ope)(struct efa_rdm_pke *pke, struct efa_rdm_ope *ope);
 
 	int (*efa_rdm_pke_read)(struct efa_rdm_ope *ope);
 

--- a/prov/efa/test/efa_unit_test_pke.c
+++ b/prov/efa/test/efa_unit_test_pke.c
@@ -382,7 +382,6 @@ void test_efa_rdm_pke_proc_matched_eager_rtm_error(struct efa_resource **state)
 	struct efa_rdm_pke *pkt_entry;
 	struct efa_rdm_ope *rxe;
 	struct efa_rdm_base_hdr *base_hdr;
-	struct efa_mr *efa_mr;
 	char buf[16];
 	int err;
 
@@ -405,23 +404,150 @@ void test_efa_rdm_pke_proc_matched_eager_rtm_error(struct efa_resource **state)
 	rxe->iov[0].iov_len = sizeof buf;
 	rxe->cq_entry.len = 1024;
 	rxe->total_len = 1024;
-
-	/* Mock efa_rdm_pke_copy_payload_to_ope failure with no available copy methods for CUDA */
-	efa_mr = calloc(1, sizeof(struct efa_mr));
-	assert_non_null(efa_mr);
-	efa_mr->peer.iface = FI_HMEM_CUDA;
-	efa_mr->peer.flags = 0;
-	rxe->desc[0] = efa_mr;
-	efa_rdm_ep->use_device_rdma = false;
-	efa_rdm_ep->cuda_api_permitted = false;
-	efa_rdm_ep->sendrecv_in_order_aligned_128_bytes = false;
 	pkt_entry->ope = rxe;
+
+	g_efa_unit_test_mocks.efa_rdm_pke_copy_payload_to_ope = &efa_mock_efa_rdm_pke_copy_payload_to_ope_return_mock;
+	will_return_int(efa_mock_efa_rdm_pke_copy_payload_to_ope_return_mock, -FI_EINVAL);
 
 	err = efa_rdm_pke_proc_matched_eager_rtm(pkt_entry);
 	assert_int_not_equal(err, 0);
 
 	/* Verify there is no double free */
 	efa_rdm_pke_release_rx(pkt_entry);
-	free(efa_mr);
+	efa_rdm_rxe_release(rxe);
+}
+
+/**
+ * @brief Helper function to create a medium RTM packet
+ */
+static struct efa_rdm_pke *create_medium_rtm_pkt(struct efa_rdm_ep *ep, uint32_t msg_id, 
+                                                 uint64_t msg_length, uint64_t seg_offset,
+                                                 size_t payload_size)
+{
+	struct efa_rdm_pke *pkt;
+	struct efa_rdm_base_hdr *base_hdr;
+	struct efa_rdm_medium_rtm_base_hdr *medium_hdr;
+	static char payload[1024];
+
+	pkt = efa_rdm_pke_alloc(ep, ep->efa_rx_pkt_pool, EFA_RDM_PKE_FROM_EFA_RX_POOL);
+	if (!pkt)
+		return NULL;
+
+	pkt->payload = payload;
+	pkt->payload_size = payload_size;
+	pkt->next = NULL;
+
+	base_hdr = efa_rdm_pke_get_base_hdr(pkt);
+	base_hdr->type = EFA_RDM_MEDIUM_MSGRTM_PKT;
+
+	medium_hdr = efa_rdm_pke_get_medium_rtm_base_hdr(pkt);
+	medium_hdr->hdr.flags = EFA_RDM_REQ_MSG;
+	medium_hdr->hdr.msg_id = msg_id;
+	medium_hdr->msg_length = msg_length;
+	medium_hdr->seg_offset = seg_offset;
+
+	return pkt;
+}
+
+/**
+ * @brief Test efa_rdm_pke_proc_matched_mulreq_rtm doesn't double free the first
+ * pkt_entry on error. The first packet should be released by the caller, not 
+ * by the function itself.
+ *
+ * @param state
+ */
+void test_efa_rdm_pke_proc_matched_mulreq_rtm_first_packet_error(struct efa_resource **state)
+{
+	struct efa_resource *resource = *state;
+	struct efa_rdm_ep *efa_rdm_ep;
+	struct efa_rdm_pke *pkt_entry;
+	struct efa_rdm_ope *rxe;
+	char buf[16];
+	int err;
+
+	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_FABRIC_NAME);
+	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
+
+	pkt_entry = create_medium_rtm_pkt(efa_rdm_ep, 1, 1024, 0, 512);
+	assert_non_null(pkt_entry);
+
+	rxe = efa_rdm_ep_alloc_rxe(efa_rdm_ep, NULL, ofi_op_msg);
+	assert_non_null(rxe);
+	rxe->state = EFA_RDM_RXE_MATCHED;
+	rxe->internal_flags = 0;
+	rxe->iov_count = 1;
+	rxe->iov[0].iov_base = buf;
+	rxe->iov[0].iov_len = sizeof buf;
+	rxe->cq_entry.len = 1024;
+	rxe->total_len = 1024;
+	rxe->bytes_received = 0;
+	rxe->bytes_received_via_mulreq = 0;
+	pkt_entry->ope = rxe;
+
+	g_efa_unit_test_mocks.efa_rdm_pke_copy_payload_to_ope = &efa_mock_efa_rdm_pke_copy_payload_to_ope_return_mock;
+	will_return_int(efa_mock_efa_rdm_pke_copy_payload_to_ope_return_mock, -FI_EINVAL);
+
+	err = efa_rdm_pke_proc_matched_mulreq_rtm(pkt_entry);
+	assert_int_not_equal(err, 0);
+
+	/* Verify there is no double free by releasing the first packet entry */
+	efa_rdm_pke_release_rx(pkt_entry);
+	efa_rdm_rxe_release(rxe);
+}
+
+/**
+ * @brief Test efa_rdm_pke_proc_matched_mulreq_rtm correctly handles selective
+ * packet failures using CMocka will_return. First packet succeeds, second fails.
+ *
+ * @param state
+ */
+void test_efa_rdm_pke_proc_matched_mulreq_rtm_second_packet_error(struct efa_resource **state)
+{
+	struct efa_resource *resource = *state;
+	struct efa_rdm_ep *efa_rdm_ep;
+	struct efa_rdm_pke *pkt_entry, *second_pkt;
+	struct efa_rdm_ope *rxe;
+	char buf[1024];
+	int err;
+
+	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_FABRIC_NAME);
+	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
+
+	pkt_entry = create_medium_rtm_pkt(efa_rdm_ep, 1, 1024, 0, 512);
+	assert_non_null(pkt_entry);
+
+	second_pkt = create_medium_rtm_pkt(efa_rdm_ep, 1, 1024, 512, 512);
+	assert_non_null(second_pkt);
+	pkt_entry->next = second_pkt;
+
+	rxe = efa_rdm_ep_alloc_rxe(efa_rdm_ep, NULL, ofi_op_msg);
+	assert_non_null(rxe);
+	rxe->state = EFA_RDM_RXE_MATCHED;
+	rxe->internal_flags = 0;
+	rxe->iov_count = 1;
+	rxe->iov[0].iov_base = buf;
+	rxe->iov[0].iov_len = sizeof buf;
+	rxe->cq_entry.len = 2048;
+	rxe->total_len = 2048;
+	rxe->bytes_received = 0;
+	rxe->bytes_received_via_mulreq = 0; 
+	pkt_entry->ope = rxe;
+
+	g_efa_unit_test_mocks.efa_rdm_pke_copy_payload_to_ope = &efa_mock_efa_rdm_pke_copy_payload_to_ope_return_mock;
+
+	will_return_int(efa_mock_efa_rdm_pke_copy_payload_to_ope_return_mock, 0);
+	will_return_int(efa_mock_efa_rdm_pke_copy_payload_to_ope_return_mock, -FI_EINVAL);
+
+	err = efa_rdm_pke_proc_matched_mulreq_rtm(pkt_entry);
+	assert_int_not_equal(err, 0);
+
+	/* The function should have:
+	 * 1. NOT released the first packet - caller's responsibility
+	 * 2. Released the second packet - function's responsibility
+	 * 
+	 * We only release the first packet here. The second packet should have
+	 * been released by the function when it failed.
+	 */
+	efa_rdm_pke_release_rx(pkt_entry);
 	efa_rdm_rxe_release(rxe);
 }

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -82,6 +82,7 @@ static int efa_unit_test_mocks_teardown(void **state)
 		.ofi_cudaMalloc = __real_ofi_cudaMalloc,
 #endif
 		.ofi_copy_from_hmem_iov = __real_ofi_copy_from_hmem_iov,
+		.efa_rdm_pke_copy_payload_to_ope = __real_efa_rdm_pke_copy_payload_to_ope,
 		.efa_rdm_pke_read = __real_efa_rdm_pke_read,
 		.efa_rdm_pke_proc_matched_rtm = __real_efa_rdm_pke_proc_matched_rtm,
 		.efa_rdm_ope_post_send = __real_efa_rdm_ope_post_send,
@@ -345,6 +346,8 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_rdm_pke_get_unexp, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_pke_flag_tracking, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_pke_proc_matched_eager_rtm_error, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_rdm_pke_proc_matched_mulreq_rtm_first_packet_error, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_rdm_pke_proc_matched_mulreq_rtm_second_packet_error, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		/* end of efa_unit_test_pke.c */
 
 		/* begin efa_unit_test_domain.c */

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -339,6 +339,8 @@ void test_efa_rdm_pke_alloc_rtr_rxe();
 void test_efa_rdm_pke_get_unexp();
 void test_efa_rdm_pke_flag_tracking();
 void test_efa_rdm_pke_proc_matched_eager_rtm_error();
+void test_efa_rdm_pke_proc_matched_mulreq_rtm_first_packet_error();
+void test_efa_rdm_pke_proc_matched_mulreq_rtm_second_packet_error();
 /* end of efa_unit_test_pke.c */
 
 void test_efa_msg_fi_recv();


### PR DESCRIPTION
efa_rdm_pke_proc_matched_mulreq_rtm shouldn't free the first pkt_entry on error because it will be released by the caller efa_rdm_pke_proc_tagrtm/efa_rdm_pke_proc_msgrtm.