### PR TITLE
prov/hook: add include of prov/hook/perf/include to ofi_hook_profile if configured as DSO 

### DIFF
--- a/prov/hook/profile/Makefile.include
+++ b/prov/hook/profile/Makefile.include
@@ -15,6 +15,7 @@ libprofile_fi_la_SOURCES = $(_profilehook_files) \
         $(common_srcs)
 libprofile_fi_la_CPPFLAGS = $(AM_CPPFLAGS) \
         -I$(top_srcdir)/prov/hook/include  \
+        -I$(top_srcdir)/prov/hook/perf/include \
         -I$(top_srcdir)/prov/hook/profile/include 
 libprofile_fi_la_LIBADD = $(linkback) $(profilehook_shm_LIBS)
 libprofile_fi_la_LDFLAGS = -module -avoid-version -shared -export-dynamic


### PR DESCRIPTION
If the ofi_hook_profile provider is configured as a loadable library, then the file `hook_perf.h` will not be found during compilation:

```bash
$ ./configure --enable-profile=dl
[...]
***
*** Built-in providers:	lnx dmabuf_peer_mem hook_hmem hook_debug monitor trace perf sm2 shm rxd mrail rxm tcp udp sockets
*** DSO providers:	profile
***
$ make 
[...]
In file included from prov/hook/profile/src/hook_profile.c:36:
./prov/hook/include/hook_prov.h:14:10: fatal error: hook_perf.h: No such file or directory
   14 | #include "hook_perf.h"
      |          ^~~~~~~~~~~~~
compilation terminated.
```

This file is transitively included via [`hook_prov.h:14`](https://github.com/ofiwg/libfabric/blob/f8262817c337d615a1acceea6cd4ecb526ce548b/prov/hook/include/hook_prov.h#L14) in [`hook_profile.c:36`](https://github.com/ofiwg/libfabric/blob/f8262817c337d615a1acceea6cd4ecb526ce548b/prov/hook/profile/src/hook_profile.c#L36). The `#if HAVE_PERF` check passes by default since `ofi_hook_perf` is built by default.

This PR adds the missing include of prov/hook/perf/include in case the ofi_hook_profile provider is configured as a DSO.