### PR TITLE
fabtests/efa: Fix test _rmd_tagged_pingpong_truncate_error timeout

### DIFF
--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -317,4 +317,4 @@ def test_rdm_tagged_pingpong_truncate_error(cmdline_args, completion_semantic):
     efa_run_client_server_test(cmdline_args, executable, "short",
                                completion_semantic, "host_to_host",
                                message_size=message_size, fabric="efa",
-                               timeout=15, might_fail=might_fail)
+                               timeout=60, might_fail=might_fail)


### PR DESCRIPTION
- increase pytest timeout to 60 seconds
- fix typo in test name