### PR TITLE
fabtests/configure: Restrict EFA provider fabtests to 64-bit Linux

### DIFF
--- a/fabtests/configure.ac
+++ b/fabtests/configure.ac
@@ -54,10 +54,17 @@ AS_IF([test x"$enable_debug" != x"no"],
 AC_DEFINE_UNQUOTED([ENABLE_DEBUG], [$dbg],
 	[defined to 1 if configured with --enable-debug])
 
+AC_CHECK_SIZEOF([void *])
+
 AC_ARG_ENABLE([efa],
 	[AS_HELP_STRING([--enable-efa],
 		[Enable efa provider specific tests - default YES])],
 	[], [enable_efa=yes])
+
+AS_IF([test x"$enable_efa" = x"yes"],
+      [AS_IF([test "$linux" -eq 0 -o "$ac_cv_sizeof_void_p" -ne 8],
+             [enable_efa=no
+             AC_MSG_NOTICE([EFA fabtests are disabled: require 64-bit Linux])])])
 
 AM_CONDITIONAL([ENABLE_EFA], [test x"$enable_efa" = x"yes"])
 


### PR DESCRIPTION
The EFA provider tests in prov/efa are only applicable to 64-bit Linux systems. This change automatically disables EFA tests on:
- 32-bit systems (any architecture)
- macOS
- FreeBSD

The check uses AC_CHECK_SIZEOF to detect pointer size (8 bytes = 64-bit) and the existing $linux variable to detect the operating system.

When EFA is disabled, a notice is printed during configure to inform the user that EFA tests require 64-bit Linux.