### PR TITLE
prov/efa: Fix iterator invalidation in efa_domain_progress_rdm_peers_and_queues()

### DIFF
--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -828,8 +828,8 @@ void efa_domain_progress_rdm_peers_and_queues(struct efa_domain *domain)
 	/*
 	 * Send data packets until window or data queue is exhausted.
 	 */
-	dlist_foreach_container(&domain->ope_longcts_send_list, struct efa_rdm_ope,
-				ope, entry) {
+	dlist_foreach_container_safe(&domain->ope_longcts_send_list, struct efa_rdm_ope,
+				ope, entry, tmp) {
 		peer = ope->peer;
 		assert(peer);
 		if (peer->flags & EFA_RDM_PEER_IN_BACKOFF)


### PR DESCRIPTION
efa_domain_progress_rdm_peers_and_queues() calls efa_rdm_txe_handle_error() while iterating over  ope_longcts_send_list.
efa_rdm_txe_handle_error() can ~release~ remove current list entry, therefore we have to use safe iteration