### PR TITLE
prov/efa: Open mr cache when it is enabled

### DIFF
--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -262,13 +262,12 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 	}
 
 	/*
-	 * Open the MR cache if application did not set FI_MR_LOCAL
-	 * and the cache is enabled
+	 * Open the MR cache if the cache is enabled
 	 * 
 	 * Explicit memory registrations from external application
 	 * should never go in the MR cache
 	 */
-	if (!efa_domain->mr_local && efa_mr_cache_enable) {
+	if (efa_mr_cache_enable) {
 		err = efa_mr_cache_open(&efa_domain->cache, efa_domain);
 		if (err) {
 			ret = err;

--- a/prov/efa/test/efa_unit_test_domain.c
+++ b/prov/efa/test/efa_unit_test_domain.c
@@ -471,3 +471,32 @@ void test_efa_domain_open_ops_get_mr_lkey(struct efa_resource **state)
     assert_int_equal(ret, FI_SUCCESS);
     assert_true(lkey == mr.ibv_mr->lkey);
 }
+
+void test_efa_domain_mr_cache_enabled(struct efa_resource **state)
+{
+	struct efa_resource *resource = *state;
+	struct efa_domain *efa_domain;
+	struct fi_info *hints;
+	int saved_mr_cache_enable = efa_mr_cache_enable;
+
+	hints = efa_unit_test_alloc_hints(FI_EP_RDM, EFA_FABRIC_NAME);
+	hints->domain_attr->mr_mode |= FI_MR_LOCAL;
+	efa_mr_cache_enable = 1;
+	efa_unit_test_resource_construct_with_hints(resource, FI_EP_RDM, FI_VERSION(1, 14), hints, true, true);
+	efa_domain = container_of(resource->domain, struct efa_domain, util_domain.domain_fid);
+	assert_non_null(efa_domain->cache);
+	efa_mr_cache_enable = saved_mr_cache_enable;
+}
+
+void test_efa_domain_mr_cache_disabled(struct efa_resource **state)
+{
+	struct efa_resource *resource = *state;
+	struct efa_domain *efa_domain;
+	int saved_mr_cache_enable = efa_mr_cache_enable;
+
+	efa_mr_cache_enable = 0;
+	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_FABRIC_NAME);
+	efa_domain = container_of(resource->domain, struct efa_domain, util_domain.domain_fid);
+	assert_null(efa_domain->cache);
+	efa_mr_cache_enable = saved_mr_cache_enable;
+}

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -368,6 +368,8 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_domain_open_ops_query_cq, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_domain_open_ops_cq_open_ext, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_domain_open_ops_get_mr_lkey, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_domain_mr_cache_enabled, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_domain_mr_cache_disabled, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		/* end efa_unit_test_domain.c */
 
 		cmocka_unit_test_setup_teardown(test_efa_rdm_cq_ibv_cq_poll_list_same_tx_rx_cq_single_ep, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -312,6 +312,8 @@ void test_efa_domain_open_ops_query_qp_wqs();
 void test_efa_domain_open_ops_query_cq();
 void test_efa_domain_open_ops_cq_open_ext();
 void test_efa_domain_open_ops_get_mr_lkey();
+void test_efa_domain_mr_cache_enabled();
+void test_efa_domain_mr_cache_disabled();
 /* end efa_unit_test_domain.c */
 
 void test_efa_rdm_cq_ibv_cq_poll_list_same_tx_rx_cq_single_ep();


### PR DESCRIPTION
MR cache should only be used for internal MR
registration which doesn't depend on application
behavior. And explicit fi_mr_reg is not using mr cache anyway.