### PR TITLE
prov/efa: Fix uninitialized descriptor arrays causing segfault 

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_atomic.c
+++ b/prov/efa/src/rdm/efa_rdm_atomic.c
@@ -436,7 +436,7 @@ efa_rdm_atomic_compwritemsg(struct fid_ep *ep,
 	struct efa_rdm_atomic_ex atomic_ex = {
 		.resp_iov_count = result_count,
 		.comp_iov_count = compare_count,
-		.compare_desc = compare_desc,
+		
 	};
 	size_t datatype_size;
 	int err;
@@ -481,6 +481,9 @@ efa_rdm_atomic_compwritemsg(struct fid_ep *ep,
 
 	ofi_ioc_to_iov(resultv, atomic_ex.resp_iov, result_count, datatype_size);
 	ofi_ioc_to_iov(comparev, atomic_ex.comp_iov, compare_count, datatype_size);
+	memset(atomic_ex.compare_desc, 0, sizeof(atomic_ex.compare_desc));
+	if (compare_desc)
+		memcpy(atomic_ex.compare_desc, compare_desc, sizeof(void*) * compare_count);
 	memcpy(atomic_ex.result_desc, result_desc, sizeof(void*) * result_count);
 
 	return efa_rdm_atomic_generic_efa(efa_rdm_ep, msg, peer, &atomic_ex, ofi_op_atomic_compare, flags);

--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -46,10 +46,11 @@ void efa_rdm_txe_construct(struct efa_rdm_ope *txe,
 
 	memcpy(txe->iov, msg->msg_iov, sizeof(struct iovec) * msg->iov_count);
 	memset(txe->mr, 0, sizeof(*txe->mr) * msg->iov_count);
-	if (msg->desc)
+	if (msg->desc) {
 		memcpy(txe->desc, msg->desc, sizeof(*msg->desc) * msg->iov_count);
-	else
-		memset(txe->desc, 0, sizeof(txe->desc));
+	} else {
+		memset(txe->desc, 0, sizeof(*txe->desc) * msg->iov_count);
+	}
 
 	/* cq_entry on completion */
 	txe->cq_entry.op_context = msg->context;

--- a/prov/efa/src/rdm/efa_rdm_ope.h
+++ b/prov/efa/src/rdm/efa_rdm_ope.h
@@ -51,8 +51,7 @@ struct efa_rdm_atomic_ex {
 	struct iovec comp_iov[EFA_RDM_IOV_LIMIT];
 	int comp_iov_count;
 	void *result_desc[EFA_RDM_IOV_LIMIT];
-	/* compare_desc does not require persistence b/c it is only used to send the RTA */
-	void **compare_desc;
+	void *compare_desc[EFA_RDM_IOV_LIMIT];
 };
 
 /**

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -331,6 +331,7 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ope_eor_packet_tracking_wait_send, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ope_eor_packet_failed_posting, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ope_eor_packet_tracking_unresponsive_wait_send, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_rdm_atomic_compare_desc_persistence, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		/* end of efa_unit_test_ope.c */
 
 		cmocka_unit_test_setup_teardown(test_efa_rdm_msg_send_to_local_peer_with_null_desc, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -289,6 +289,7 @@ void test_efa_rdm_ope_eor_packet_tracking_cq_read();
 void test_efa_rdm_ope_eor_packet_tracking_wait_send();
 void test_efa_rdm_ope_eor_packet_failed_posting();
 void test_efa_rdm_ope_eor_packet_tracking_unresponsive_wait_send();
+void test_efa_rdm_atomic_compare_desc_persistence();
 
 
 /* end of efa_unit_test_ope.c */


### PR DESCRIPTION
This patch fixes two related bugs involving uninitialized descriptor arrays that cause segmentation faults when FI_EFA_ENABLE_SHM_TRANSFER=0 is set.

Bug 1: Incorrect sizeof() in efa_rdm_txe_construct() When msg->desc is NULL, the code attempted to zero the desc array with: memset(txe->desc, 0, sizeof(txe->desc));

This only zeros sizeof(void*) = 8 bytes instead of the entire array. The correct size should be sizeof(*txe->desc) * msg->iov_count to match the memcpy() branch and the parallel iov[] and mr[] arrays.

Bug 2: Dangling pointer in efa_rdm_atomic_ex
The compare_desc field was declared as void **compare_desc (pointer), which was set to point to the caller's stack memory. When the caller returned, this became a dangling pointer. Later access to compare_desc[i] would read garbage from reused stack memory.

The fix changes compare_desc to an array void *compare_desc[EFA_RDM_IOV_LIMIT] with its own persistent storage, and copies the data instead of storing a pointer.

Tested on c7i.48xlarge clusters with 96-192 ranks using IMB-EXT Accumulate benchmark in both debug and release builds.