### PR TITLE
[v2.4.x]fabtests/efa: Add nvcc flag for Blackwell sm_100

### DIFF
--- a/fabtests/prov/efa/src/efagda/Makefile
+++ b/fabtests/prov/efa/src/efagda/Makefile
@@ -1,6 +1,6 @@
 CC=gcc
 NVCC=nvcc
-NVCC_FLAGS=-G -arch=sm_90
+NVCC_FLAGS=-G -gencode arch=compute_90,code=sm_90 -gencode arch=compute_100,code=sm_100
 CFLAGS=-pthread
 CUDA_FLAGS=-Xcompiler -fPIC
 CUDA_INCLUDES=-I/usr/local/cuda/include


### PR DESCRIPTION
Add support for p6-b200 Blackwell architecture.


(cherry picked from commit f9d351161278ba7cd72dc482f59dc606eb7076f7)