### PR TITLE
prov/efa: Hold domain lock during implicit->explicit AH refcnt change

### DIFF
--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -430,11 +430,13 @@ static int efa_conn_implicit_to_explicit(struct efa_av *av,
 	av->used_explicit++;
 
 	/* Handle AH LRU list and refcnt */
+	ofi_genlock_lock(&av->domain->util_domain.lock);
 	assert(!dlist_empty(&ah->implicit_conn_list));
 	dlist_remove(&implicit_conn->ah_implicit_conn_list_entry);
 	efa_ah_implicit_av_lru_ah_move(av->domain, ah);
 	ah->implicit_refcnt--;
 	ah->explicit_refcnt++;
+	ofi_genlock_unlock(&av->domain->util_domain.lock);
 
 	EFA_INFO(FI_LOG_AV,
 		 "Peer with implicit fi_addr %" PRIu64


### PR DESCRIPTION
This addresses this assertion error:
> efa_ah_release: Assertion `(release_from_implicit_av && ah->implicit_refcnt > 0) || (!release_from_implicit_av && ah->explicit_refcnt > 0)' failed.