### PR TITLE
rust: Add generated target and Cargo.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,7 @@ prov/efa/docs/doxygen/latex
 # Clang's compilation database file and directory.
 /.cache
 /compile_commands.json
+
+# Rust
+/target
+/Cargo.lock


### PR DESCRIPTION
`/target` should never be checked in, and `Cargo.lock` probably should not be given that `bindings/rust` is a library.