### PR TITLE
contrib/aws: Use AMI with pre-installed EFA and compiled NCCL tests

### DIFF
--- a/contrib/aws/Jenkinsfile
+++ b/contrib/aws/Jenkinsfile
@@ -179,7 +179,7 @@ pipeline {
                 script {
                     def stages = [:]
                     def timeout = "--timeout 300"
-                    def generic_pf = "--cluster-type manual_cluster --test-target libfabric --test-type pr --test-libfabric-pr $env.CHANGE_ID"
+                    def generic_pf = "--cluster-type manual_cluster --test-target libfabric --test-type pr --test-libfabric-pr $env.CHANGE_ID --use-prebuilt-ami-with-efa-installer true"
                     // onesided tests are covered by imb, collective tests are covered by omb
                     def mpi_collective_tests = "'test_omb and not onesided'"
                     def libfabric_tests = "test_efa_ut test_fabtests_functional test_fork_support test_backward_compatibility 'test_fabtests_performance and lttng'"


### PR DESCRIPTION
Using an AMI with EFA installer pre-installed will also save test time