### PR TITLE
man: Clarify parameter behavior for 0 byte operations

### DIFF
--- a/man/fi_msg.3.md
+++ b/man/fi_msg.3.md
@@ -55,20 +55,21 @@ ssize_t fi_injectdata(struct fid_ep *ep, const void *buf, size_t len,
 : Fabric endpoint on which to initiate send or post receive buffer.
 
 *buf*
-: Data buffer to send or receive.
+: Data buffer to send or receive. For 0-byte operations, buf may be ignored.
 
 *len*
 : Length of data buffer to send or receive, specified in bytes.  Valid
   transfers are from 0 bytes up to the endpoint's max_msg_size.
 
 *iov*
-: Vectored data buffer.
+: Vectored data buffer. For 0-byte operations, iov may be ignored.
 
 *count*
-: Count of vectored data entries.
+: Count of vectored data entries. For 0-byte operations, count may be 0.
 
 *desc*
-: Descriptor associated with the data buffer.  See [`fi_mr`(3)](fi_mr.3.html).
+: Descriptor associated with the data buffer. For 0-byte operations, desc
+  may be ignored even for FI_MR_LOCAL. See [`fi_mr`(3)](fi_mr.3.html).
 
 *data*
 : Remote CQ data to transfer with the sent message.
@@ -157,6 +158,8 @@ struct fi_msg {
 	uint64_t           data;     /* optional message data */
 };
 ```
+
+For 0-byte operations, msg_iov, desc (including FI_MR_LOCAL) and iov_count may be ignored.
 
 ## fi_inject
 

--- a/man/fi_rma.3.md
+++ b/man/fi_rma.3.md
@@ -60,17 +60,17 @@ ssize_t fi_inject_writedata(struct fid_ep *ep, const void *buf, size_t len,
 
 *buf*
 : Local data buffer to read into (read target) or write from (write
-  source)
+  source). For 0-byte operations, buf may be ignored.
 
 *len*
 : Length of data to read or write, specified in bytes.  Valid
   transfers are from 0 bytes up to the endpoint's max_msg_size.
 
 *iov*
-: Vectored data buffer.
+: Vectored data buffer. For 0-byte operations, iov may be ignored.
 
 *count*
-: Count of vectored data entries.
+: Count of vectored data entries. For 0-byte operations, count may be 0.
 
 *addr*
 : Address of remote memory to access.  This will be the virtual
@@ -81,8 +81,8 @@ ssize_t fi_inject_writedata(struct fid_ep *ep, const void *buf, size_t len,
 : Protection key associated with the remote memory.
 
 *desc*
-: Descriptor associated with the local data buffer
-  See [`fi_mr`(3)](fi_mr.3.html).
+: Descriptor associated with the local data buffer. For 0-byte operations,
+  desc may be ignored even for FI_MR_LOCAL. See [`fi_mr`(3)](fi_mr.3.html).
 
 *data*
 : Remote CQ data to transfer with the operation.
@@ -174,6 +174,8 @@ struct fi_rma_iov {
 	uint64_t           key;          /* access key */
 };
 ```
+
+For 0-byte operations, msg_iov, desc (including FI_MR_LOCAL), and iov_count may be ignored.
 
 ## fi_inject_write
 

--- a/man/fi_tagged.3.md
+++ b/man/fi_tagged.3.md
@@ -57,17 +57,17 @@ ssize_t fi_tinjectdata(struct fid_ep *ep, const void *buf, size_t len,
 : Fabric endpoint on which to initiate tagged communication operation.
 
 *buf*
-: Data buffer to send or receive.
+: Data buffer to send or receive. For 0-byte operations, buf may be ignored.
 
 *len*
 : Length of data buffer to send or receive, specified in bytes.  Valid
   transfers are from 0 bytes up to the endpoint's max_msg_size.
 
 *iov*
-: Vectored data buffer.
+: Vectored data buffer. For 0-byte operations, iov may be ignored.
 
 *count*
-: Count of vectored data entries.
+: Count of vectored data entries. For 0-byte operations, count may be 0.
 
 *tag*
 : Tag associated with the message.
@@ -76,8 +76,8 @@ ssize_t fi_tinjectdata(struct fid_ep *ep, const void *buf, size_t len,
 : Mask of bits to ignore applied to the tag for receive operations.
 
 *desc*
-: Memory descriptor associated with the data buffer.
-  See [`fi_mr`(3)](fi_mr.3.html).
+: Memory descriptor associated with the data buffer. For 0-byte operations,
+  desc may be ignored even for FI_MR_LOCAL. See [`fi_mr`(3)](fi_mr.3.html).
 
 *data*
 : Remote CQ data to transfer with the sent data.
@@ -190,6 +190,8 @@ struct fi_msg_tagged {
 	uint64_t           data;     /* optional immediate data */
 };
 ```
+
+For 0-byte operations, msg_iov, desc (including FI_MR_LOCAL) and iov_count may be ignored.
 
 ## fi_tinject
 


### PR DESCRIPTION
Note: This doc update outlines new behavior that not all providers might currently support (including efa-direct).

Clarify parameter behavior for 0 byte send/tagged/rma operations. The parameters that have been clarified are buf, iov, desc. Also clarify the parameters msg_iov, desc, and iov_count for the *msg api's.