### PR TITLE
prov/tcp: Decrement subdomain ref count when key is not available

### DIFF
--- a/prov/tcp/src/xnet_domain.c
+++ b/prov/tcp/src/xnet_domain.c
@@ -67,7 +67,7 @@ static void xnet_subdomains_mr_close(struct xnet_domain *domain, uint64_t mr_key
 		ret = ofi_mr_map_remove(&subdomain->util_domain.mr_map, mr_key);
 		ofi_genlock_unlock(&subdomain->util_domain.lock);
 
-		if (!ret)
+		if (!ret || (mr_key == FI_KEY_NOTAVAIL))
 			ofi_atomic_dec32(&subdomain->util_domain.ref);
 	}
 }


### PR DESCRIPTION
The following callchain for fi_mr_reg causes reference count increment for the subdomain even in case of FI_KEY_NOTAVAIL.
  xnet_mplex_mr_regattr -> xnet_mr_regattr -> ofi_mr_regattr
Its counterpart does not decrement refcount for FI_KEY_NOTAVAIL as it cannot be found in the memory region map.
  xnet_mplex_mr_close -> xnet_subdomains_mr_close
As a result objects start to leak. The fix is to do the same as ofi_mr_close and decrement reference count for the domain in case of FI_KEY_NOTAVAIL.