### PR TITLE
prov/efa: Fix use-after-free in DC packet completion handling

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -1971,7 +1971,7 @@ ssize_t efa_rdm_ope_repost_ope_queued_before_handshake(struct efa_rdm_ope *ope)
 	}
 }
 
-int efa_rdm_ope_process_queued_ope(struct efa_rdm_ope *ope, uint16_t flag)
+int efa_rdm_ope_process_queued_ope(struct efa_rdm_ope *ope, uint32_t flag)
 {
 	int ret = 0;
 

--- a/prov/efa/src/rdm/efa_rdm_ope.h
+++ b/prov/efa/src/rdm/efa_rdm_ope.h
@@ -103,7 +103,7 @@ struct efa_rdm_ope {
 	 * This flag is different from #cq_entry.flags, which is
 	 * applied to CQ entry's returned to user.
 	 */
-	uint16_t internal_flags;
+	uint32_t internal_flags;
 
 	size_t iov_count;
 	struct iovec iov[EFA_RDM_IOV_LIMIT];
@@ -281,12 +281,17 @@ void efa_rdm_rxe_release_internal(struct efa_rdm_ope *rxe);
  * @brief flag to indicate that the ope was created
  * for internal operations, so it should not generate
  * any cq entry or err entry.
- * NOTICE: the ope->internal_flags is uint16_t, so
- * to introduce more bits for internal flags, the
- * internal_flags needs to be changed to uint32_t
- * or larger.
  */
 #define EFA_RDM_OPE_INTERNAL			BIT_ULL(15)
+
+/**
+ * @brief flag to indicate that a DC txe has received its receipt packet
+ *
+ * This flag is used to track when a delivery complete operation has
+ * received acknowledgment from the receiver, preventing premature
+ * completion before all TX operations finish.
+ */
+#define EFA_RDM_TXE_RECEIPT_RECEIVED		BIT_ULL(16)
 
 #define EFA_RDM_OPE_QUEUED_FLAGS (EFA_RDM_OPE_QUEUED_RNR | EFA_RDM_OPE_QUEUED_CTRL | EFA_RDM_OPE_QUEUED_READ | EFA_RDM_OPE_QUEUED_BEFORE_HANDSHAKE)
 
@@ -310,6 +315,27 @@ void efa_rdm_rxe_report_completion(struct efa_rdm_ope *rxe);
 void efa_rdm_ope_handle_recv_completed(struct efa_rdm_ope *ope);
 
 void efa_rdm_ope_handle_send_completed(struct efa_rdm_ope *ope);
+
+/**
+ * @brief Check if a delivery complete (DC) TXE is ready for release
+ *
+ * @details
+ * For DC packets, this function prevents use-after-free race conditions by
+ * ensuring the TXE is only released when both conditions are met:
+ * 1. All TX operations have completed (efa_outstanding_tx_ops == 0)
+ * 2. Receipt packet has been received (EFA_RDM_TXE_RECEIPT_RECEIVED flag set)
+ *
+ * This dual-condition check ensures proper synchronization between send
+ * completions and receipt acknowledgments in the delivery complete protocol.
+ *
+ * @param[in] txe TX operation entry to check
+ * @return true if TXE is ready for release, false otherwise
+ */
+static inline bool efa_rdm_txe_dc_ready_for_release(struct efa_rdm_ope *txe)
+{
+	return (txe->efa_outstanding_tx_ops == 0) &&
+	       (txe->internal_flags & EFA_RDM_TXE_RECEIPT_RECEIVED);
+}
 
 int efa_rdm_ope_prepare_to_post_read(struct efa_rdm_ope *ope);
 
@@ -342,6 +368,6 @@ ssize_t efa_rdm_ope_repost_ope_queued_before_handshake(struct efa_rdm_ope *ope);
 
 ssize_t efa_rdm_txe_prepare_local_read_pkt_entry(struct efa_rdm_ope *txe);
 
-int efa_rdm_ope_process_queued_ope(struct efa_rdm_ope *ope, uint16_t flag);
+int efa_rdm_ope_process_queued_ope(struct efa_rdm_ope *ope, uint32_t flag);
 
 #endif

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -333,6 +333,8 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ope_eor_packet_failed_posting, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ope_eor_packet_tracking_unresponsive_wait_send, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_atomic_compare_desc_persistence, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_rdm_txe_dc_send_first, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_rdm_txe_dc_receipt_first, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		/* end of efa_unit_test_ope.c */
 
 		cmocka_unit_test_setup_teardown(test_efa_rdm_msg_send_to_local_peer_with_null_desc, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -291,6 +291,8 @@ void test_efa_rdm_ope_eor_packet_tracking_wait_send();
 void test_efa_rdm_ope_eor_packet_failed_posting();
 void test_efa_rdm_ope_eor_packet_tracking_unresponsive_wait_send();
 void test_efa_rdm_atomic_compare_desc_persistence();
+void test_efa_rdm_txe_dc_send_first();
+void test_efa_rdm_txe_dc_receipt_first();
 
 
 /* end of efa_unit_test_ope.c */


### PR DESCRIPTION
DC packets had a race condition where RECEIPT acknowledgments could arrive before all TX completions, causing premature txe release and use-after-free errors when remaining TX completions accessed the freed memory.

Fix by using efa_outstanding_tx_ops for completion tracking:
- DC packets use efa_outstanding_tx_ops to track TX completion status
- RECEIPT handler writes completion immediately (preserves DC semantics)
- txe release delayed until both TX completions and receipt received
- Added EFA_RDM_TXE_RECEIPT_RECEIVED flag to track receipt arrival
- Added efa_rdm_txe_dc_ready_for_release() with proper documentation

This prevents the race condition while maintaining existing DC completion behavior for applications.