### PR TITLE
prov/lnx: Fix ld_core_domains cleanup on init fail

### DIFF
--- a/prov/lnx/src/lnx_domain.c
+++ b/prov/lnx/src/lnx_domain.c
@@ -76,9 +76,11 @@ static int lnx_domain_close(struct fid *fid)
 	for (i = 0; i < domain->ld_num_doms; i++) {
 		cd = &domain->ld_core_domains[i];
 
-		rc = fi_close(&cd->cd_domain->fid);
-		if (rc)
-			frc = rc;
+		if (cd->cd_domain) {
+			rc = fi_close(&cd->cd_domain->fid);
+			if (rc)
+				frc = rc;
+		}
 	}
 
 	ofi_bufpool_destroy(domain->ld_mem_reg_bp);
@@ -178,10 +180,9 @@ static int lnx_open_core_domains(struct lnx_fabric *lnx_fab,
 
 			rc = fi_domain(cf->cf_fabric, cd->cd_info,
 				       &cd->cd_domain, context);
-			if (rc) {
-				free(cd);
+			if (rc)
 				return rc;
-			}
+
 			cd->cd_fabric = cf;
 		}
 	}


### PR DESCRIPTION
Hi all, I was trying to set up libfabric v2.4.0 with lnx, when I encountered a segfault in lnx, which occured when initialization failed.

I was originally going to open an issue, but since I stumbled myself upon a probable fix, thought I'd put it in a PR instead. Of course I'm not familiar with libfabric, so I might be missing something here. Feel free to close, and implement a fix in your preferred way.

The error from what I understand occurs when `fi_domain()` fails. There is a `free()` for `cd`, which there shouldn't be because `cd` is a pointer to an element of `ld_core_domains`. After `fi_domain()` fails, the cleanup code calls `lnx_domain_close()`, which attempts to close all domains, without checking if one of them is not open -- like the one that just failed to open.