### PR TITLE
fabtests/efa: Remove the skip for dmabuf_only

### DIFF
--- a/fabtests/pytest/efa/conftest.py
+++ b/fabtests/pytest/efa/conftest.py
@@ -147,11 +147,6 @@ def cuda_memory_type_validation(cmdline_args):
         pytest.fail("CUDA memory support never initialized")
     
     do_dmabuf = cmdline_args.do_dmabuf_reg_for_hmem
-    if (do_dmabuf is None and 
-        cuda_support == CudaMemorySupport.DMA_BUF_ONLY):
-        error = "User specified CUDA without dmabuf but hardware only supports DMA_BUF_ONLY"
-        print(f"CUDA validation failed: {error}")
-        pytest.skip(error)
     
     print(f"Correctly defined dma buf mode {do_dmabuf} and return {cuda_support}!")
     


### PR DESCRIPTION
Today, fabtests will skip test if the `check_cuda_hmem` binary thinks DMABUF is the only way to register cuda buffer, while test is not passing `--do-dmabuf-reg-for-hmem`, it will silently skip the test.

This is wrong because efa provider supports registering with dmabuf when it's supported, even if application is not using FI_MR_DMABUF API