### PR TITLE
prov/lnx: lnx_open_core_domains - Correctly track number of open domains

### DIFF
--- a/prov/lnx/src/lnx_init.c
+++ b/prov/lnx/src/lnx_init.c
@@ -279,7 +279,10 @@ insert:
 	dlist_init(&e->entry);
 	e->fi = info;
 
-	dlist_insert_tail(&e->entry, head);
+	if(!strncmp(e->fi->fabric_attr->prov_name, "shm", 3))
+		dlist_insert_head(&e->entry, head);
+	else
+		dlist_insert_tail(&e->entry, head);
 
 	return 0;
 }


### PR DESCRIPTION
Fixing lnx_open_core_domains to correctly track the number of open domains by decrementing by 1 when a domain fails to open. Removed an unnecessary null check in lnx_domain_close.