### PR TITLE
prov/cxi: Fix hang in MPI when using cxi with lnx

### DIFF
--- a/prov/cxi/src/cxip_dom.c
+++ b/prov/cxi/src/cxip_dom.c
@@ -2092,6 +2092,13 @@ int cxip_domain(struct fid_fabric *fabric, struct fi_info *info,
 		cxi_domain->prov_key_seqnum = ofi_xorshift_random(seed);
 	}
 
+	/* 
+	 * It's possible the owner provider decides to turn off
+	 * hardware offload in cxi. If that happens we need to update the
+	 * rx_match_mode.
+	 */
+	cxip_set_env_rx_match_mode();
+
 	cxi_domain->mr_match_events = cxip_env.mr_match_events;
 	cxi_domain->optimized_mrs = cxip_env.optimized_mrs;
 	cxi_domain->prov_key_cache = cxip_env.prov_key_cache;

--- a/prov/cxi/src/cxip_rxc.c
+++ b/prov/cxi/src/cxip_rxc.c
@@ -402,13 +402,6 @@ struct cxip_rxc *cxip_rxc_calloc(struct cxip_ep_obj *ep_obj, void *context)
 {
 	struct cxip_rxc *rxc = NULL;
 
-	/* 
-	 * It's possible the owner provider decides to turn off
-	 * hardware offload in cxi. If that happens we need to update the
-	 * rx_match_mode.
-	 */
-	cxip_set_env_rx_match_mode();
-
 	switch (ep_obj->protocol) {
 	case FI_PROTO_CXI:
 		rxc = calloc(1, sizeof(struct cxip_rxc_hpc));


### PR DESCRIPTION
LNX requires software tag matching mode in order to work as intended. Before commit: 82a87b1, refreshing of the `rx_match_mode` occured in `cxip_rxc_calloc()`. However, following 82a87b1, the `rx_match_mode` defined in the (global) `cxip_env` is stashed in the domain during domain creation. By that time, `cxip_env` has not been refreshed yet. Moving the update of `cxip_env` to occur during domain creation, resolves this issue. This is a proposed solution, any input is greatly appreciated. 

Tagging the author and committer of 82a87b1 here: @SeanP-2023  @swelch 