### PR TITLE
prov/efa: Only disable zcpy_rx when p2p is not available but FI_HMEM is requested

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -486,17 +486,20 @@ void efa_rdm_ep_set_use_zcpy_rx(struct efa_rdm_ep *ep)
 	}
 
 	/* Zero-copy receive requires P2P support. Disable it if any initialized HMEM iface does not support P2P. */
-	EFA_HMEM_IFACE_FOREACH_NON_SYSTEM(iface) {
-		if (g_efa_hmem_info[iface].initialized &&
-		    (ofi_hmem_p2p_disabled() ||
-		    ep->hmem_p2p_opt == FI_HMEM_P2P_DISABLED ||
-		    !g_efa_hmem_info[iface].p2p_supported_by_device)) {
-			EFA_INFO(FI_LOG_EP_CTRL,
-			         "%s does not support P2P, zero-copy receive "
-			         "protocol will be disabled\n",
-			         fi_tostr(&iface, FI_TYPE_HMEM_IFACE));
-			ep->use_zcpy_rx = false;
-			goto out;
+	/* Only check HMEM P2P support if the application is actually using HMEM capabilities. */
+	if (ep->base_ep.util_ep.caps & FI_HMEM) {
+		EFA_HMEM_IFACE_FOREACH_NON_SYSTEM(iface) {
+			if (g_efa_hmem_info[iface].initialized &&
+			    (ofi_hmem_p2p_disabled() ||
+			    ep->hmem_p2p_opt == FI_HMEM_P2P_DISABLED ||
+			    !g_efa_hmem_info[iface].p2p_supported_by_device)) {
+				EFA_INFO(FI_LOG_EP_CTRL,
+				         "%s does not support P2P, zero-copy receive "
+				         "protocol will be disabled\n",
+				         fi_tostr(&iface, FI_TYPE_HMEM_IFACE));
+				ep->use_zcpy_rx = false;
+				goto out;
+			}
 		}
 	}
 

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -1154,7 +1154,8 @@ void test_efa_rdm_ep_user_zcpy_rx_disabled(struct efa_resource **state)
 }
 
 /**
- * @brief Verify zcpy_rx is disabled if CUDA P2P is explictly disabled
+ * @brief Verify zcpy_rx is enabled for host-only workloads even when
+ *        HMEM P2P is globally disabled, since host memory doesn't use P2P
  */
 void test_efa_rdm_ep_user_disable_p2p_zcpy_rx_disabled(struct efa_resource **state)
 {
@@ -1166,7 +1167,8 @@ void test_efa_rdm_ep_user_disable_p2p_zcpy_rx_disabled(struct efa_resource **sta
 	resource->hints->mode = FI_MSG_PREFIX;
 	resource->hints->caps = FI_MSG;
 
-	test_efa_rdm_ep_use_zcpy_rx_impl(resource, true, false, false);
+	/* Global HMEM P2P disable doesn't affect host-only workloads */
+	test_efa_rdm_ep_use_zcpy_rx_impl(resource, true, false, true);
 }
 
 /**
@@ -1188,7 +1190,8 @@ void test_efa_rdm_ep_user_zcpy_rx_unhappy_due_to_sas(struct efa_resource **state
 }
 
 /**
- * @brief Verify zcpy_rx is disabled if CUDA P2P is enabled but not supported
+ * @brief Verify zcpy_rx is enabled even if CUDA P2P is not supported,
+ *        as long as FI_HMEM is not requested (host-only workload)
  */
 void test_efa_rdm_ep_user_p2p_not_supported_zcpy_rx_happy(struct efa_resource **state)
 {
@@ -1200,7 +1203,9 @@ void test_efa_rdm_ep_user_p2p_not_supported_zcpy_rx_happy(struct efa_resource **
 	resource->hints->mode = FI_MSG_PREFIX;
 	resource->hints->caps = FI_MSG;
 
-	test_efa_rdm_ep_use_zcpy_rx_impl(resource, false, false, false);
+	/* With the fix, zcpy_rx should be enabled for host-only workloads
+	 * even when CUDA P2P is not supported */
+	test_efa_rdm_ep_use_zcpy_rx_impl(resource, false, false, true);
 }
 
 /**


### PR DESCRIPTION
The current code disables zcpy_rx if any initialized HMEM interface lacks P2P support, even when the application is only using host memory.

This is overly conservative and impacts performance on instances with GPUs (e.g., g4dn) where CUDA HMEM initializes but doesn't support P2P with EFA. Host-only workloads on these instances cannot use zcpy_rx even though they don't need GPU P2P support.

Fix: Only check HMEM P2P support when the application has requested FI_HMEM capabilities. This allows host-only workloads to use zcpy_rx regardless of GPU P2P availability.

Impact: Enables zcpy_rx for host memory workloads on GPU instances where HMEM P2P is unavailable (e.g., g4dn with CUDA but no GPU-EFA P2P).