### PR TITLE
prov/psm3: Internal polling must use timeout to prevent infinite loop…

### DIFF
--- a/prov/psm3/psm3/psm_ep.h
+++ b/prov/psm3/psm3/psm_ep.h
@@ -262,8 +262,9 @@ struct psm2_epaddr {
 /*
  * Users of BLOCKUNTIL should check the value of err upon return
  */
-#define PSMI_BLOCKUNTIL(ep, err, cond)	do {				\
+#define PSMI_BLOCKUNTIL_TO(ep, timeout, err, cond)	do {		\
 	int spin_cnt = 0;						\
+	uint64_t block_start = get_cycles();				\
 	PSMI_PROFILE_BLOCK();						\
 	while (!(cond)) {						\
 		err = psm3_poll_internal(ep, 1, 0);			\
@@ -271,6 +272,11 @@ struct psm2_epaddr {
 			PSMI_PROFILE_REBLOCK(1);			\
 			if (++spin_cnt == (ep)->yield_spin_cnt) {	\
 				spin_cnt = 0;				\
+				if (timeout && !psm3_cycles_left(block_start,	\
+					timeout)) {			\
+					err = PSM2_EP_NO_RESOURCES;	\
+					break;				\
+				}					\
 				PSMI_YIELD((ep)->mq->progress_lock);	\
 			}						\
 		}							\
@@ -283,6 +289,8 @@ struct psm2_epaddr {
 	}								\
 	PSMI_PROFILE_UNBLOCK();						\
 } while (0)
+
+#define PSMI_BLOCKUNTIL(ep, err, cond) PSMI_BLOCKUNTIL_TO(ep, 0, err, cond)
 
 void psm3_ep_init(void);
 void psm3_ep_fini(void);

--- a/prov/psm3/psm3/psm_mq.c
+++ b/prov/psm3/psm3/psm_mq.c
@@ -59,6 +59,7 @@
 #include "psm2_hal.h"
 #include "psm_mq_internal.h"
 #include "ips_proto_params.h"
+#include "ips_proto.h"
 
 /*
  * Functions to manipulate the expected queue in mq_ep.

--- a/prov/psm3/psm3/ptl_am/am_reqrep.c
+++ b/prov/psm3/psm3/ptl_am/am_reqrep.c
@@ -66,6 +66,7 @@ psm3_amsh_am_short_request(psm2_epaddr_t epaddr,
 			   void *completion_ctxt)
 {
 	psm2_amarg_t req_args[NSHORT_ARGS + NBULK_ARGS];
+	psm2_error_t res;
 
 	/* All sends are synchronous. Ignore PSM2_AM_FLAG_ASYNC.
 	 * Treat PSM2_AM_FLAG_NOREPLY as "advisory". This was mainly
@@ -82,13 +83,13 @@ psm3_amsh_am_short_request(psm2_epaddr_t epaddr,
 	req_args[0].u32w0 = (uint32_t) handler;
 	psm3_mq_mtucpy((void *)&req_args[1], (const void *)args,
 		       (nargs * sizeof(psm2_amarg_t)));
-	psm3_amsh_short_request(epaddr->ptlctl->ptl, epaddr, am_handler_hidx,
+	res = psm3_amsh_short_request(epaddr->ptlctl->ptl, epaddr, am_handler_hidx,
 				req_args, nargs + 1, src, len, 0);
 
 	if (completion_fn)
 		completion_fn(completion_ctxt);
 
-	return PSM2_OK;
+	return (res == PSM2_OK_NO_PROGRESS) ? PSM2_OK : res;
 }
 
 psm2_error_t
@@ -99,6 +100,7 @@ psm3_amsh_am_short_reply(psm2_am_token_t tok,
 			 void *completion_ctxt)
 {
 	psm2_amarg_t rep_args[NSHORT_ARGS + NBULK_ARGS];
+	psm2_error_t res;
 
 	/* For now less than NSHORT_ARGS+NBULK_ARGS-1. We use the first arg to carry
 	 * the handler index.
@@ -108,11 +110,11 @@ psm3_amsh_am_short_reply(psm2_am_token_t tok,
 	psm3_mq_mtucpy((void *)&rep_args[1], (const void *)args,
 		       (nargs * sizeof(psm2_amarg_t)));
 
-	psm3_amsh_short_reply((amsh_am_token_t *) tok, am_handler_hidx,
+	res = psm3_amsh_short_reply((amsh_am_token_t *) tok, am_handler_hidx,
 			      rep_args, nargs + 1, src, len, 0);
 
 	if (completion_fn)
 		completion_fn(completion_ctxt);
 
-	return PSM2_OK;
+	return (res == PSM2_OK_NO_PROGRESS) ? PSM2_OK : res;
 }

--- a/prov/psm3/psm3/ptl_am/am_reqrep_shmem.c
+++ b/prov/psm3/psm3/ptl_am/am_reqrep_shmem.c
@@ -1034,10 +1034,12 @@ amsh_ep_connreq_poll(ptl_t *ptl_gen, struct am_ptl_connection_req *req)
 					req->args[3].u64w0 = 0;
 				req->args[4].u64w0 = psm3_epid_w1(ptl->epid);
 				req->args[5].u64w0 = psm3_epid_w2(ptl->epid);
-				psm3_amsh_short_request(ptl_gen, epaddr,
+				err = psm3_amsh_short_request(ptl_gen, epaddr,
 							amsh_conn_handler_hidx,
 							req->args, 6, NULL, 0,
 							0);
+				if (err > PSM2_OK_NO_PROGRESS)
+					return err;
 				((am_epaddr_t *) epaddr)->cstate_outgoing =
 					AMSH_CSTATE_OUTGOING_DISC_REQUESTED;
 				/**
@@ -1178,10 +1180,12 @@ amsh_ep_connreq_poll(ptl_t *ptl_gen, struct am_ptl_connection_req *req)
 				req->args[4].u64w0 = psm3_epid_w1(ptl->epid);
 				req->args[5].u64w0 = psm3_epid_w2(ptl->epid);
 				req->epid_mask[i] = AMSH_CMASK_POSTREQ;
-				psm3_amsh_short_request(ptl_gen, epaddr,
+				err = psm3_amsh_short_request(ptl_gen, epaddr,
 							amsh_conn_handler_hidx,
 							req->args, 6, NULL, 0,
 							0);
+				if (err > PSM2_OK_NO_PROGRESS)
+					return err;
 				_HFI_CONNDBG("epaddr=%p, epid=%s at shmidx=%d\n",
 						   epaddr, psm3_epid_fmt_internal(epid, 0), shmidx);
 			}
@@ -1557,51 +1561,43 @@ amsh_poll_internal_inner(ptl_t *ptl_gen, int replyonly,
 	}
 
 	err = PSM3_GPU_SHM_DEV_FDS_POLL((struct ptl_am *)ptl_gen, err);
-
-	if (is_internal) {
-		if (err == PSM2_OK)	/* some progress, no yields */
-			ptl->zero_polls = 0;
-		else if (++ptl->zero_polls == AMSH_ZERO_POLLS_BEFORE_YIELD) {
-			/* no progress for AMSH_ZERO_POLLS_BEFORE_YIELD */
-			sched_yield();
-			ptl->zero_polls = 0;
-		}
-
-		if (++ptl->amsh_only_polls == AMSH_POLLS_BEFORE_PSM_POLL) {
-			psm3_poll_internal(ptl->ep, 0, 0);
-			ptl->amsh_only_polls = 0;
-		}
-	}
 	return err;		/* if we actually did something */
 }
 
-/* non-inlined version */
-static
-psm2_error_t
-amsh_poll_internal(ptl_t *ptl, int replyonly)
-{
-	return amsh_poll_internal_inner(ptl, replyonly, 1);
-}
-
-#ifdef PSM_PROFILE
-#define AMSH_POLL_UNTIL(ptl, isreply, cond) \
-	do {								\
-		PSMI_PROFILE_BLOCK();					\
-		while (!(cond)) {					\
-			PSMI_PROFILE_REBLOCK(				\
-				amsh_poll_internal(ptl, isreply) ==	\
-					PSM2_OK_NO_PROGRESS);		\
-		}							\
-		PSMI_PROFILE_UNBLOCK();					\
+/*
+ * Users of AMSH_POLL_UNTIL should check the value of err upon return
+ */
+#define AMSH_POLL_UNTIL(ptl, isreply, cond, err)									\
+	do {														\
+		uint64_t block_start = get_cycles();									\
+		struct ptl_am *ptlam = (struct ptl_am *)ptl;								\
+		ptlam->zero_polls = 0;											\
+		ptlam->amsh_only_polls = 0;										\
+		PSMI_PROFILE_BLOCK();											\
+		while (!(cond)) {											\
+			err = amsh_poll(ptl, isreply, 0);								\
+			if (err == PSM2_OK) {									\
+				PSMI_PROFILE_REBLOCK(0);								\
+				ptlam->zero_polls = 0;									\
+				block_start = get_cycles();								\
+			} else if (err == PSM2_OK_NO_PROGRESS) {								\
+				PSMI_PROFILE_REBLOCK(1);								\
+				if (++ptlam->zero_polls == AMSH_ZERO_POLLS_BEFORE_YIELD) {				\
+						ptlam->zero_polls = 0;							\
+						if (!psm3_cycles_left(block_start, PSMI_MIN_EP_CONNECT_TIMEOUT)) {	\
+							err = PSM2_EP_NO_RESOURCES;					\
+							break;								\
+					}										\
+						sched_yield();								\
+				}											\
+			}												\
+			if (++ptlam->amsh_only_polls == AMSH_POLLS_BEFORE_PSM_POLL) {					\
+				psm3_poll_internal(ptlam->ep, 0, 0);							\
+				ptlam->amsh_only_polls = 0;								\
+			}												\
+		}													\
+		PSMI_PROFILE_UNBLOCK();											\
 	} while (0)
-#else
-#define AMSH_POLL_UNTIL(ptl, isreply, cond)			\
-	do {							\
-		while (!(cond)) {				\
-			amsh_poll_internal(ptl, isreply);	\
-		}						\
-	} while (0)
-#endif
 
 static psm2_error_t amsh_poll(ptl_t *ptl, int replyonly, bool force)
 {
@@ -1609,7 +1605,7 @@ static psm2_error_t amsh_poll(ptl_t *ptl, int replyonly, bool force)
 }
 
 PSMI_ALWAYS_INLINE(
-void
+psm2_error_t
 am_send_pkt_short(ptl_t *ptl, uint32_t destidx, uint32_t returnidx,
 		  uint32_t bulkidx, uint16_t fmt, uint16_t nargs,
 		  uint16_t handleridx, psm2_amarg_t *args,
@@ -1618,10 +1614,13 @@ am_send_pkt_short(ptl_t *ptl, uint32_t destidx, uint32_t returnidx,
 	int i;
 	volatile am_pkt_short_t *pkt;
 	int copy_nargs;
+	psm2_error_t res = PSM2_OK_NO_PROGRESS;
 
 	AMSH_POLL_UNTIL(ptl, isreply,
 			(pkt =
-			 am_ctl_getslot_pkt(ptl, destidx, isreply)) != NULL);
+			 am_ctl_getslot_pkt(ptl, destidx, isreply)) != NULL, res);
+	if (res > PSM2_OK_NO_PROGRESS)
+		return res;
 
 	/* got a free pkt... fill it in */
 	pkt->bulkidx = bulkidx;
@@ -1651,6 +1650,7 @@ am_send_pkt_short(ptl_t *ptl, uint32_t destidx, uint32_t returnidx,
 		  pkt->flag, pkt->nargs, src, (int)len, (int)handleridx,
 		  src != NULL ? *((uint32_t *) src) : 0);
 	QMARKREADY(pkt);
+	return res;
 }
 
 #define amsh_shm_copy_short psm3_mq_mtucpy
@@ -1694,6 +1694,7 @@ psm3_amsh_generic_inner(uint32_t amtype, ptl_t *ptl_gen, psm2_epaddr_t epaddr,
 	int returnidx = ((am_epaddr_t *) epaddr)->return_shmidx;
 	int is_reply = AM_IS_REPLY(amtype);
 	volatile am_pkt_bulk_t *bulkpkt;
+	int res = PSM2_OK_NO_PROGRESS;
 
 	_HFI_VDBG("%s epaddr=%s, shmidx=%d, type=%d\n",
 		  is_reply ? "reply" : "request",
@@ -1719,7 +1720,9 @@ psm3_amsh_generic_inner(uint32_t amtype, ptl_t *ptl_gen, psm2_epaddr_t epaddr,
 					(bulkpkt =
 					 am_ctl_getslot_long(ptl_gen, destidx,
 							     is_reply)) !=
-					NULL);
+					NULL, res);
+			if (res > PSM2_OK_NO_PROGRESS)
+				break;
 
 			bulkidx = bulkpkt->idx;
 			bulkpkt->len = len;
@@ -1734,7 +1737,7 @@ psm3_amsh_generic_inner(uint32_t amtype, ptl_t *ptl_gen, psm2_epaddr_t epaddr,
 					    (uint32_t) len);
 			QMARKREADY(bulkpkt);
 		}
-		am_send_pkt_short(ptl_gen, destidx, returnidx, bulkidx, type,
+		res = am_send_pkt_short(ptl_gen, destidx, returnidx, bulkidx, type,
 				  nargs, hidx, args, src, len, is_reply);
 		break;
 
@@ -1762,7 +1765,9 @@ psm3_amsh_generic_inner(uint32_t amtype, ptl_t *ptl_gen, psm2_epaddr_t epaddr,
 						 am_ctl_getslot_long(ptl_gen,
 								     destidx,
 								     is_reply))
-						!= NULL);
+						!= NULL, res);
+				if (res > PSM2_OK_NO_PROGRESS)
+					break;
 				bytes_left -= bytes_this;
 				if (bytes_left == 0)
 					type = AMFMT_LONG_END;
@@ -1777,9 +1782,11 @@ psm3_amsh_generic_inner(uint32_t amtype, ptl_t *ptl_gen, psm2_epaddr_t epaddr,
 						(uintptr_t) dst);
 				bulkpkt->len = bytes_this;
 				QMARKREADY(bulkpkt);
-				am_send_pkt_short(ptl_gen, destidx, returnidx,
+				res = am_send_pkt_short(ptl_gen, destidx, returnidx,
 						  bulkidx, type, nargs, hidx,
 						  args, NULL, 0, is_reply);
+				if (res != PSM2_OK_NO_PROGRESS)
+					break;
 				src_this += bytes_this;
 				dst_this += bytes_this;
 			}
@@ -1788,7 +1795,8 @@ psm3_amsh_generic_inner(uint32_t amtype, ptl_t *ptl_gen, psm2_epaddr_t epaddr,
 	default:
 		break;
 	}
-	return 1;
+	psmi_assert(res < PSM2_ERROR_LAST); //!!!!
+	return res;
 }
 
 /* A generic version that's not inlined */
@@ -1819,24 +1827,22 @@ psm3_amsh_long_request(ptl_t *ptl, psm2_epaddr_t epaddr,
 				       args, nargs, src, len, dest, flags);
 }
 
-void
+int
 psm3_amsh_short_reply(amsh_am_token_t *tok,
 		      psm2_handler_t handler, psm2_amarg_t *args, int nargs,
 		      const void *src, size_t len, int flags)
 {
-	psm3_amsh_generic_inner(AMREPLY_SHORT, tok->ptl, tok->tok.epaddr_incoming,
+	return psm3_amsh_generic_inner(AMREPLY_SHORT, tok->ptl, tok->tok.epaddr_incoming,
 				handler, args, nargs, src, len, NULL, flags);
-	return;
 }
 
-void
+int
 psm3_amsh_long_reply(amsh_am_token_t *tok,
 		     psm2_handler_t handler, psm2_amarg_t *args, int nargs,
 		     const void *src, size_t len, void *dest, int flags)
 {
-	psm3_amsh_generic_inner(AMREPLY_LONG, tok->ptl, tok->tok.epaddr_incoming,
+	return psm3_amsh_generic_inner(AMREPLY_LONG, tok->ptl, tok->tok.epaddr_incoming,
 				handler, args, nargs, src, len, dest, flags);
-	return;
 }
 
 void psm3_am_reqq_init(ptl_t *ptl_gen)
@@ -1860,16 +1866,21 @@ psm2_error_t psm3_am_reqq_drain(ptl_t *ptl_gen)
 	ptl->psmi_am_reqq_fifo.lastp = &ptl->psmi_am_reqq_fifo.first;
 
 	while ((req = reqn) != NULL) {
-		err = PSM2_OK;
 		reqn = req->next;
 		_HFI_VDBG
 		    ("push of reqq=%p epaddr=%s localreq=%p remotereq=%p\n",
 		     req, psm3_epaddr_get_hostname(req->epaddr->epid, 0),
 		     (void *)(uintptr_t) req->args[1].u64w0,
 		     (void *)(uintptr_t) req->args[0].u64w0);
-		psm3_amsh_generic(req->amtype, req->ptl, req->epaddr,
+		err = psm3_amsh_generic(req->amtype, req->ptl, req->epaddr,
 				  req->handler, req->args, req->nargs, req->src,
 				  req->len, req->dest, req->amflags);
+		if (err > PSM2_OK_NO_PROGRESS)
+		{
+			/* remember last unprocessed request */
+			ptl->psmi_am_reqq_fifo.first = req;
+			return err;
+		}
 		if (req->flags & AM_FLAG_SRC_TEMP)
 			psmi_free(req->src);
 		psmi_free(req);
@@ -2082,8 +2093,10 @@ amsh_mq_rndv(ptl_t *ptl, psm2_mq_t mq, psm2_mq_req_t req,
 		psm3_am_reqq_add(AMREQUEST_SHORT, ptl, epaddr, mq_handler_hidx,
 					args, 5, NULL, 0, NULL, 0);
 	} else {
-		psm3_amsh_short_request(ptl, epaddr, mq_handler_hidx,
+		err = psm3_amsh_short_request(ptl, epaddr, mq_handler_hidx,
 					args, 5, NULL, 0, 0);
+		if (err > PSM2_OK_NO_PROGRESS)
+			return err;
 	}
 
 	mq->stats.tx_num++;
@@ -2136,8 +2149,12 @@ amsh_mq_send_inner_eager(psm2_mq_t mq, psm2_mq_req_t req, psm2_epaddr_t epaddr,
 					epaddr, handler, args, 3, (void *)ubuf,
 					bytes_this, NULL, 0);
 		} else {
-			psm3_amsh_short_request(ptl, epaddr,
+			psm2_error_t err;
+			err = psm3_amsh_short_request(ptl, epaddr,
 						handler, args, 3, ubuf, bytes_this, 0);
+			if (err > PSM2_OK_NO_PROGRESS)
+				psm3_handle_error(PSMI_EP_NORETURN, PSM2_INTERNAL_ERR,
+								  "mq send error");
 		}
 
 		ubuf = (void *)((uint8_t *)ubuf + bytes_this);
@@ -2261,6 +2278,7 @@ amsh_mq_isend(psm2_mq_t mq, psm2_epaddr_t epaddr, uint32_t flags_user,
 	      uint32_t len, void *context, psm2_mq_req_t *req_o)
 {
 	psm2_mq_req_t req = psm3_mq_req_alloc(mq, MQE_TYPE_SEND);
+	psm2_error_t err;
 	if_pf(req == NULL)
 	    return PSM2_NO_MEMORY;
 
@@ -2274,7 +2292,9 @@ amsh_mq_isend(psm2_mq_t mq, psm2_epaddr_t epaddr, uint32_t flags_user,
 		  psm3_epaddr_get_name(epaddr->epid, 1), ubuf, len,
 		  tag->tag[0], tag->tag[1], tag->tag[2]);
 
-	amsh_mq_send_inner(mq, req, epaddr, flags_user, flags_internal, tag, ubuf, len);
+	err = amsh_mq_send_inner(mq, req, epaddr, flags_user, flags_internal, tag, ubuf, len);
+	if (err > PSM2_OK_NO_PROGRESS)
+		return err;
 
 	*req_o = req;
 	return PSM2_OK;
@@ -2290,9 +2310,7 @@ amsh_mq_send(psm2_mq_t mq, psm2_epaddr_t epaddr, uint32_t flags,
 		  psm3_epaddr_get_name(epaddr->epid, 1), ubuf, len,
 		  tag->tag[0], tag->tag[1], tag->tag[2]);
 
-	amsh_mq_send_inner(mq, NULL, epaddr, flags, PSMI_REQ_FLAG_NORMAL, tag, ubuf, len);
-
-	return PSM2_OK;
+	return amsh_mq_send_inner(mq, NULL, epaddr, flags, PSMI_REQ_FLAG_NORMAL, tag, ubuf, len);
 }
 
 /* kassist-related handling */
@@ -2484,8 +2502,12 @@ amsh_conn_handler(void *toki, psm2_amarg_t *args, int narg, void *buf,
 			AMSH_CSTATE_INCOMING_ESTABLISHED;
 		((am_epaddr_t *) epaddr)->return_shmidx = return_shmidx;
 		tok->tok.epaddr_incoming = epaddr;	/* adjust token */
-		psm3_amsh_short_reply(tok, amsh_conn_handler_hidx,
-				      args, narg, NULL, 0, 0);
+		err = psm3_amsh_short_reply(tok, amsh_conn_handler_hidx,
+									args, narg, NULL, 0, 0);
+		if (err > PSM2_OK_NO_PROGRESS)
+			psm3_handle_error(PSMI_EP_NORETURN, err,
+							  "Fatal error "
+							  "in connecting to shm segment");
 		break;
 
 	case PSMI_AM_CONN_REP:
@@ -2532,8 +2554,12 @@ amsh_conn_handler(void *toki, psm2_amarg_t *args, int narg, void *buf,
 			is_valid = 1;
 
 		if (is_valid) {
-			psm3_amsh_short_reply(tok, amsh_conn_handler_hidx,
+			err = psm3_amsh_short_reply(tok, amsh_conn_handler_hidx,
 					      args, narg, NULL, 0, 0);
+			if (err > PSM2_OK_NO_PROGRESS)
+				psm3_handle_error(PSMI_EP_NORETURN, err,
+								  "Fatal error "
+								  "in disconnecting from shm segment");
 			/**
 			* Only munmap if we have nothing more to
 			* communicate with the other node, i.e. we are

--- a/prov/psm3/psm3/ptl_am/psm_am_internal.h
+++ b/prov/psm3/psm3/ptl_am/psm_am_internal.h
@@ -158,7 +158,7 @@ psm3_amsh_short_request(ptl_t *ptl, psm2_epaddr_t epaddr,
 			psm2_handler_t handler, psm2_amarg_t *args, int nargs,
 			const void *src, size_t len, int flags);
 
-void
+int
 psm3_amsh_short_reply(amsh_am_token_t *tok,
 		      psm2_handler_t handler, psm2_amarg_t *args, int nargs,
 		      const void *src, size_t len, int flags);
@@ -168,7 +168,7 @@ psm3_amsh_long_request(ptl_t *ptl, psm2_epaddr_t epaddr,
 		       psm2_handler_t handler, psm2_amarg_t *args, int nargs,
 		       const void *src, size_t len, void *dest, int flags);
 
-void
+int
 psm3_amsh_long_reply(amsh_am_token_t *tok,
 		     psm2_handler_t handler, psm2_amarg_t *args, int nargs,
 		     const void *src, size_t len, void *dest, int flags);

--- a/prov/psm3/psm3/ptl_ips/ips_proto_am.c
+++ b/prov/psm3/psm3/ptl_ips/ips_proto_am.c
@@ -328,7 +328,7 @@ psm3_ips_am_short_request(psm2_epaddr_t epaddr,
 		     void *completion_ctxt)
 {
 	struct ips_proto_am *proto_am = &epaddr->proto->proto_am;
-	psm2_error_t err;
+	psm2_error_t err = PSM2_OK;
 	ips_scb_t *scb;
 	ips_epaddr_t *ipsaddr;
 	int pad_bytes = calculate_pad_bytes(len);
@@ -343,7 +343,7 @@ psm3_ips_am_short_request(psm2_epaddr_t epaddr,
 		    ((nargs - IPS_AM_HDR_NARGS) << 3) : 0;
 
 		/* len + pad_bytes + overflow_args */
-		PSMI_BLOCKUNTIL(epaddr->ptlctl->ep,
+		PSMI_BLOCKUNTIL_TO(epaddr->ptlctl->ep, epaddr->proto->epinfo.ep_timeout_ack,
 				err,
 				((scb = psm3_ips_scbctrl_alloc(
 				      &proto_am->scbc_request,
@@ -351,11 +351,13 @@ psm3_ips_am_short_request(psm2_epaddr_t epaddr,
 				      len + pad_bytes + arg_sz,
 				      IPS_SCB_FLAG_ADD_BUFFER)) != NULL));
 	} else {
-		PSMI_BLOCKUNTIL(epaddr->ptlctl->ep,
+		PSMI_BLOCKUNTIL_TO(epaddr->ptlctl->ep, epaddr->proto->epinfo.ep_timeout_ack,
 				err,
 				((scb = psm3_ips_scbctrl_alloc_tiny(
 				      &proto_am->scbc_request, 0)) != NULL));
 	}
+	if (err > PSM2_OK_NO_PROGRESS)
+		return err;
 
 	psmi_assert_always(scb != NULL);
 	ips_am_scb_init(scb, handler, nargs, pad_bytes, true,

--- a/prov/psm3/psm3/ptl_ips/ips_proto_mq.c
+++ b/prov/psm3/psm3/ptl_ips/ips_proto_mq.c
@@ -67,7 +67,7 @@ PSMI_NEVER_INLINE(ips_scb_t *
 {
 	ips_scb_t *scb = NULL;
 	psmi_assert(npkts > 0);
-	psm2_error_t err;
+	psm2_error_t err = PSM2_OK;
 
 	proto->stats.scb_egr_unavail_cnt++;
 


### PR DESCRIPTION
… during resources acquiring

Due to a lack of resources, the AMSH_POLL_UNTIL() and PSMI_BLOCKUNTIL() may never complete. If resources polling was not finished within PSMI_MIN_EP_CONNECT_TIMEOUT, an interrupt will occur and error will be returned.

Fixes #11893 