### PR TITLE
prov/efa: Fix the race condition of efa_rdm_ep_get_peer

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_cq.c
+++ b/prov/efa/src/rdm/efa_rdm_cq.c
@@ -361,7 +361,7 @@ efa_rdm_cq_lookup_raw_addr(struct efa_rdm_pke *pke,
 				     (void *) efa_ep_addr);
 	if (addr != FI_ADDR_NOTAVAIL) {
 		implicit = false;
-		peer = efa_rdm_ep_get_peer(ep, addr);
+		peer = efa_rdm_ep_get_peer_explicit(ep, addr);
 		assert(peer);
 		goto out;
 	}
@@ -446,7 +446,7 @@ efa_rdm_cq_get_peer_for_pkt_entry(struct efa_rdm_ep *ep,
 			"Peer with gid %d and qpn %d found in explicit AV with "
 			"fi_addr %ld\n",
 			gid, qpn, explicit_fi_addr);
-		peer = efa_rdm_ep_get_peer(ep, explicit_fi_addr);
+		peer = efa_rdm_ep_get_peer_explicit(ep, explicit_fi_addr);
 		goto out;
 	}
 

--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -218,6 +218,8 @@ struct efa_ep_addr *efa_rdm_ep_raw_addr(struct efa_rdm_ep *ep);
 
 struct efa_rdm_peer *efa_rdm_ep_get_peer(struct efa_rdm_ep *ep, fi_addr_t addr);
 
+struct efa_rdm_peer *efa_rdm_ep_get_peer_explicit(struct efa_rdm_ep *ep, fi_addr_t addr);
+
 int32_t efa_rdm_ep_get_peer_ahn(struct efa_rdm_ep *ep, fi_addr_t addr);
 struct efa_rdm_peer *efa_rdm_ep_get_peer_implicit(struct efa_rdm_ep *ep, fi_addr_t addr);
 


### PR DESCRIPTION
efa_rdm_ep_get_peer is not acquiring a lock when it's called on the send calls. This will cause a race condition that can result the following trouble:

When multiple threads are calling fi_*send, they can finally create multiple peer objects against the same EP + fi_addr_t combo. This will results fi_*send sends multiple messages of the same msg_id=0 towards the same remote addr. This will finally caused the packet already progressed error on the the remote receiver side because it expects to get the messages from the same sender with msg_id 0,1... in sequence. After it gets msg_id 0 and shifts the receive window, another packet of msg_id 0 came in and cause the error. Same race can also happen when concurrent fi_*send and fi_cq_read are called which can create multiple peers against the same EP + fi_addr_t combo and cause the same trouble.

This patch fixes this issue by forcing efa_rdm_ep_get_peer called inside the srx lock which is acquired in both send calls and cq read calls.