### PR TITLE
core: fix OFI_KEEPALIVE macro redefinition on macOS

### DIFF
--- a/include/osx/osd.h
+++ b/include/osx/osd.h
@@ -173,6 +173,7 @@ ssize_t ofi_readv_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt);
 ssize_t ofi_sendmsg_tcp(SOCKET fd, const struct msghdr *msg, int flags);
 ssize_t ofi_recvmsg_tcp(SOCKET fd, struct msghdr *msg, int flags);
 
+#undef OFI_KEEPALIVE
 #define OFI_KEEPALIVE	TCP_KEEPALIVE
 /*
  * pthread_spinlock is not available on Mac OS X, the following code


### PR DESCRIPTION
The OFI_KEEPALIVE macro in `include/osx/osd.h` conflicted with the definition in `include/unix/osd.h`, which is a dependency.

This commit adds an #undef before the redefinition in the macOS-specific header to suppress compiler warnings and ensure the correct platform value is used.