### PR TITLE
gh-pages: Add a sitemap file

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,1 @@
+Sitemap: https://ofiwg.github.io/libfabric/sitemap.txt

--- a/sitemap.txt
+++ b/sitemap.txt
@@ -1,0 +1,1 @@
+https://ofiwg.github.io/libfabric/main/man/


### PR DESCRIPTION
Add a sitemap file so that web crawers can prioritize the latest man pages over older versions.