### PR TITLE
include/unix/osd.h: Remove duplicated OFI_KEEPALIVE definition

### DIFF
--- a/include/unix/osd.h
+++ b/include/unix/osd.h
@@ -70,8 +70,6 @@
 #define OFI_UNUSED UNREFERENCED_PARAMETER
 #endif
 
-#define OFI_KEEPALIVE	TCP_KEEPIDLE
-
 #define OFI_SOCK_TRY_SND_RCV_AGAIN(err)		\
 	(((err) == EAGAIN)	||		\
 	 ((err) == EWOULDBLOCK))


### PR DESCRIPTION
The macro is defined for linux/freebsd/osx with slight variations. There is no need to define for unix, which not only is redundant but also creates conflict with the osx definition.

Replaces #11922 