### PR TITLE
[v2.5.x]prov/shm: Fix smr_unexp_ipc chunking for large buffered messages

### DIFF
--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -1004,6 +1004,7 @@ static int smr_unexp_ipc(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 {
 	struct smr_unexp_buf *buf;
 	size_t bytes = 0;
+	size_t total_size;
 	struct iovec iov;
 	int ret = FI_SUCCESS;;
 
@@ -1016,7 +1017,9 @@ static int smr_unexp_ipc(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 	memcpy(&cmd_ctx->cmd_cpy, cmd,
 		sizeof(cmd->hdr) + sizeof(cmd->data));
 
-	while (bytes < cmd_ctx->cmd->hdr.size) {
+	total_size = cmd_ctx->cmd->hdr.size;
+
+	while (bytes < total_size) {
 		buf = ofi_buf_alloc(ep->unexp_buf_pool);
 		if (!buf) {
 			ret = -FI_ENOMEM;
@@ -1026,20 +1029,25 @@ static int smr_unexp_ipc(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 		iov.iov_base = buf->buf;
 		iov.iov_len = SMR_SAR_SIZE;
 
-		cmd->hdr.size = MIN(cmd_ctx->cmd->hdr.size - bytes,
-				    SMR_SAR_SIZE);
+		cmd_ctx->cmd->hdr.size = MIN(total_size - bytes, SMR_SAR_SIZE);
+		cmd_ctx->cmd->data.ipc_info.offset = cmd->data.ipc_info.offset + bytes;
+
 		ret = smr_progress_ipc(ep, cmd_ctx->cmd, NULL, NULL, &iov, 1);
 		if (ret) {
 			ofi_buf_free(buf);
 			goto out;
 		}
 
-		bytes += cmd->hdr.size;
+		bytes += cmd_ctx->cmd->hdr.size;
 		ofi_consume_iov(cmd->data.iov, &cmd->data.iov_count,
 				SMR_SAR_SIZE);
 
 		slist_insert_tail(&buf->entry, &cmd_ctx->buf_list);
 	}
+
+	/* Restore original total size */
+	cmd_ctx->cmd->hdr.size = total_size;
+
 out:
 	cmd->hdr.status = ret;
 	smr_return_cmd(ep, cmd);


### PR DESCRIPTION
When handling large unexpected IPC messages with SMR_BUFFER_RECV flag set, the code must chunk the message into SMR_SAR_SIZE (32KB) pieces and buffer them locally. The original implementation had three bugs:

1. Modified cmd->hdr.size instead of cmd_ctx->cmd->hdr.size, causing smr_progress_ipc() to receive the full message size while only providing a 32KB buffer, resulting in truncation errors (-265).

2. Never updated cmd_ctx->cmd->data.ipc_info.offset, causing all chunks to read from the same GPU memory location instead of advancing through the source buffer.

3. After the loop, cmd_ctx->cmd->hdr.size contained the last chunk size instead of the total message size, causing smr_copy_saved() to only copy partial data to the receive buffer.

Fix by:
- Saving total_size before the chunking loop
- Modifying cmd_ctx->cmd->hdr.size (the copy) instead of cmd->hdr.size
- Updating cmd_ctx->cmd->data.ipc_info.offset for each chunk
- Restoring cmd_ctx->cmd->hdr.size to total_size after the loop

This fixes fi_unexpected_msg test failures with CUDA memory on single- node configurations.


(cherry picked from commit 36ff8e8026c9c46b429e8858354b674d832fbc03)