### PR TITLE
fabtests/pytest: fix leaked remote processes

### DIFF
--- a/fabtests/pytest/common.py
+++ b/fabtests/pytest/common.py
@@ -271,6 +271,7 @@ class WaitableProcess:
         except Exception as e:
             exception = e
             self.process.terminate()
+            self.process.kill()
 
         if (self.output_file):
             self.output_file.close()
@@ -594,6 +595,7 @@ class ClientServerTest:
             print("Client error: {}".format(e))
             # Clean up server if client is terminated unexpectedly
             server_process.terminate()
+            server_process.kill()
 
         server_output = ""
         server_timed_out = False
@@ -602,6 +604,7 @@ class ClientServerTest:
                 timeout=self._timeout + SERVER_RESTART_DELAY_MS/1000)
         except TimeoutExpired:
             server_process.terminate()
+            server_process.kill()
             server_timed_out = True
 
         if has_ssh_connection_err_msg(server_output):

--- a/fabtests/pytest/conftest.py
+++ b/fabtests/pytest/conftest.py
@@ -2,6 +2,7 @@ import builtins
 import os
 import re
 import shlex
+import subprocess
 
 import yaml
 
@@ -38,7 +39,22 @@ def pytest_addoption(parser):
                              help=option_helpmsg, default=option_default)
 
 # base ssh command
-bssh = "ssh -n -o StrictHostKeyChecking=no -o ConnectTimeout=30 -o BatchMode=yes"
+bssh = "ssh -tt -o StrictHostKeyChecking=no -o ConnectTimeout=30 -o BatchMode=yes"
+
+@pytest.fixture(autouse=True, scope="session")
+def cleanup_remote_processes(request):
+    yield
+    server_id = request.config.getoption("--server-id")
+    client_id = request.config.getoption("--client-id")
+    binpath = request.config.getoption("--binpath")
+    if binpath:
+        for host in {server_id, client_id}:
+            subprocess.run(
+                f"ssh -o StrictHostKeyChecking=no -o ConnectTimeout=30 {host}"
+                f" pkill -9 -f {shlex.quote(binpath)}",
+                shell=True, timeout=10,
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            )
 
 class CmdlineArgs:
 
@@ -131,7 +147,7 @@ class CmdlineArgs:
 
         host_id = self.client_id if host_type == "client" else self.server_id
 
-        command = f"timeout {timeout} /bin/bash --login -c {shlex.quote(command)}"
+        command = f"timeout {timeout} /bin/bash -c {shlex.quote(command)}"
         command = f"{bssh} {host_id} {shlex.quote(command)}"
 
         return command

--- a/fabtests/pytest/efa/test_env.py
+++ b/fabtests/pytest/efa/test_env.py
@@ -33,8 +33,8 @@ def test_fork_huge_page_both_set(cmdline_args):
     process = subprocess.run(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if is_ibv_fork_support_needed():
         assert process.returncode != 0
-        err_msg = process.stderr.decode("utf-8")
-        assert "The usage of huge page is incompatible with rdma-core's fork support" in err_msg
-        assert "Your application will now abort" in err_msg
+        output = process.stdout.decode("utf-8") + process.stderr.decode("utf-8")
+        assert "The usage of huge page is incompatible with rdma-core's fork support" in output
+        assert "Your application will now abort" in output
     else:
         assert process.returncode == 0


### PR DESCRIPTION
When a fabtest is launched via SSH, the remote process can leak in several scenarios:

1. A test times out or fails, terminate() is called on the local SSH process but the remote fabtest keeps running.
2. The @retry decorator retries after a timeout — the retried test passes but the leaked process from the first attempt is still running on the remote host.
3. The client SSH fails and the server fabtest never receives a connection, sitting and waiting indefinitely. The client retries with a new server, but the old server is still alive.
4. The server SSH session doesn't close cleanly after the test completes (e.g. bash login profile side effects), communicate() times out, and terminate() leaks the remote process.

The root cause is that ssh -n does not allocate a PTY, so when the local SSH process dies the remote side receives no signal and the process gets reparented to init.

Fix by changing bssh from ssh -n to ssh -tt, which forces PTY allocation on the remote side. When the local SSH process is killed, the PTY is destroyed and the kernel sends SIGHUP to the remote process group, cleaning up bash, timeout, and the fabtest binary.

Also add process.kill() after process.terminate() on all error/timeout paths to ensure the local SSH process dies promptly, triggering the remote PTY teardown.