### PR TITLE
prov/shm: Fix shm not utilizing XPMEM when requested

### DIFF
--- a/prov/shm/src/smr_util.c
+++ b/prov/shm/src/smr_util.c
@@ -266,7 +266,7 @@ int smr_create(const struct fi_provider *prov, const struct smr_attr *attr,
 	(*smr)->flags = attr->flags;
 
 	if (xpmem && smr_env.use_xpmem &&
-	    !(attr->flags & SMR_FLAG_XPMEM_ENABLED)) {
+	    !(attr->flags & SMR_FLAG_HMEM_ENABLED)) {
 		smr_set_vma_cap(&(*smr)->self_vma_caps, FI_SHM_P2P_XPMEM, true);
 		(*smr)->xpmem_self = xpmem->pinfo;
 	}


### PR DESCRIPTION
SHM has a small error in smr_util when checking if requesting XPMEM. The not operator here prevents the code from enabling XPMEM when it is requested.