### PR TITLE
actions: Split auto-release into separate build and release workflows

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
     uses: ./.github/workflows/build-dist-tarballs.yml
     with:
-      source_ref: ${{ github.event.pull_request.base.ref }}
+      source_ref: ${{ github.event.pull_request.merge_commit_sha || github.event.pull_request.base.sha }}
       build_fabtests: true
     permissions:
       contents: read
@@ -38,7 +38,7 @@ jobs:
       with:
         tag_name: ${{ needs.release-build.outputs.tag }}
         name: Libfabric ${{ needs.release-build.outputs.version }}
-        target_commitish: ${{ github.event.pull_request.base.ref }}
+        target_commitish: ${{ needs.release-build.outputs.source_sha }}
         draft: true
         body: |
           The OpenFabrics Interfaces Working Group (OFIWG) and the libfabric open-source community are pleased to announce the release of version ${{ needs.release-build.outputs.version }} of libfabric. See [NEWS.md](https://github.com/${{ github.repository }}/blob/${{ needs.release-build.outputs.tag }}/NEWS.md) for the list of features and enhancements that have been added since the last release. Installation instructions are available in the [README.md](https://github.com/${{ github.repository }}/blob/${{ needs.release-build.outputs.tag }}/README.md) file in the source tree or at the project's homepage.

--- a/.github/workflows/build-dist-tarballs.yml
+++ b/.github/workflows/build-dist-tarballs.yml
@@ -13,6 +13,9 @@ on:
         type: boolean
         default: true
     outputs:
+      source_sha:
+        description: Exact commit SHA checked out for the build
+        value: ${{ jobs.build.outputs.source_sha }}
       version:
         description: Resolved release version
         value: ${{ jobs.build.outputs.version }}
@@ -34,6 +37,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     outputs:
+      source_sha: ${{ steps.source.outputs.source_sha }}
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
       sha512_sums: ${{ steps.checksums.outputs.sha512_sums }}
@@ -44,6 +48,11 @@ jobs:
       with:
         ref: ${{ inputs.source_ref }}
         fetch-depth: 0
+
+    - name: Capture source SHA
+      id: source
+      run: |
+        echo "source_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
     - name: Resolve version
       id: version


### PR DESCRIPTION
This deconstructs the workflow a bit s.t. downstream consumers can e.g. make use of the dedicated build workflow in their CI/CD.

This PR also includes a fix for mutable ref drift, which can occur when the release branch changes between building and tagging.