### PR TITLE
prov/efa: Update progress documentation in fi_efa.7.md

### DIFF
--- a/man/fi_efa.7.md
+++ b/man/fi_efa.7.md
@@ -85,12 +85,11 @@ The following features are supported:
   application. The `efa-direct` fabric of *FI_EP_RDM* endpint and the *FI_EP_DGRAM* endpoint only supports *FI_MR_LOCAL*.
 
 *Progress*
-: RDM and DGRAM endpoints support *FI_PROGRESS_MANUAL*.
-  EFA erroneously claims the support for *FI_PROGRESS_AUTO*, despite not properly
-  supporting automatic progress. Unfortunately, some Libfabric consumers also ask
-  for *FI_PROGRESS_AUTO* when they only require *FI_PROGRESS_MANUAL*, and fixing
-  this bug would break those applications. This will be fixed in a future version
-  of the EFA provider by adding proper support for *FI_PROGRESS_AUTO*.
+: The *FI_EP_RDM* endpoint in the `efa` fabric supports *FI_PROGRESS_MANUAL*.
+  The *FI_EP_RDM* and *FI_EP_DGRAM* endpoints in the `efa-direct` fabric
+  support *FI_PROGRESS_AUTO*. See
+  [efa_fabric_comparison](https://github.com/ofiwg/libfabric/blob/main/prov/efa/docs/efa_fabric_comparison.md)
+  for a detailed comparison of `efa` vs `efa-direct` fabrics.
 
 *Threading*
 : Both RDM and DGRAM endpoints supports *FI_THREAD_SAFE*.


### PR DESCRIPTION
Update the progress section to reflect that EFA Protocol endpoints (previously known as RDM) now correctly report FI_PROGRESS_MANUAL, and DGRAM and efa-direct endpoints support FI_PROGRESS_AUTO.

Remove outdated text about the FI_PROGRESS_AUTO bug that was fixed in commit 103f94f.