### PR TITLE
prov/efa: align efa_mr ref count to its own cache line

### DIFF
--- a/prov/efa/src/efa_mr.h
+++ b/prov/efa/src/efa_mr.h
@@ -29,10 +29,12 @@ struct efa_mr {
 	struct efa_mr_peer	peer;
 	bool			inserted_to_mr_map;
 	bool 			needs_sync;
-	ofi_atomic32_t ref;
 	/* Count of outstanding operations referencing this MR.
 	 * Incremented when an operation references the MR,
-	 * decremented when the operation completes. */
+	 * decremented when the operation completes.
+	 * Aligned to its own cache line to avoid false sharing. */
+	ofi_atomic32_t ref __attribute__((aligned(64)));
+	char ref_pad[64 - sizeof(ofi_atomic32_t)];
 };
 
 extern int efa_mr_cache_enable;


### PR DESCRIPTION
Align ofi_atomic32_t ref to a 64-byte boundary and pad the remainder of the cache line to prevent false sharing when the reference count is updated concurrently from multiple threads.

A single MR can be shared across multiple endpoints on different threads and NUMA nodes. Most of the struct fields (ibv_mr->lkey, mr_fid.key, peer.iface, peer.flags, shm_mr) are read-only after registration and are frequently accessed in the data path. Writes to ref from concurrent threads would otherwise cause false sharing with these read-heavy fields, bouncing the cache line across cores unnecessarily.

ref is written to via efa_mr_ref_inc/efa_mr_ref_dec on the following critical paths:

  Send/Recv (DGRAM):
    efa_msg.c - sendmsg, recvmsg, send_inject

  Send/Recv (RDM):
    efa_rdm_msg.c - sendmsg, recvmsg
    efa_rdm_srx.c - peer recv (shared rx)

  Read/Write (DGRAM):
    efa_rma.c - readmsg, writemsg

  Read/Write (RDM):
    efa_rdm_rma.c - readmsg, writemsg

  Atomic (RDM):
    efa_rdm_atomic.c - writemsg

  CQ polling / completion:
    efa_cq.c - send/recv/rdma completion handlers
    efa_rdm_ope.c - txe/rxe completion and error paths
    efa_rdm_pke_nonreq.c - CTS and read completion handlers