### PR TITLE
runfabtests.sh: cleanup after kill -9

### DIFF
--- a/fabtests/scripts/runfabtests.sh
+++ b/fabtests/scripts/runfabtests.sh
@@ -553,6 +553,7 @@ function cs_test {
 	        sleep 2
 	    fi
 	    kill -9 $s_pid 2> /dev/null
+	    cleanup
 	fi
 
 	wait $s_pid


### PR DESCRIPTION
In some cases, client exits with ENODATA but the server stays alive. runfabtests tries to kill it with a kill -9, but if the server is started through a ssh command, the spawned process sometime stays alive causing the following test(s) to fail. After a kill -9, call cleanup to make sure nothing is left behind.

/usr/bin/runfabtests.sh: line 558:  4972 Killed                  ${SERVER_CMD} "${EXPORT_ENV} $s_cmd" &> $s_outp
- name:   fi_rma_bw -e msg -o writedata -I 5 -p "verbs"
  timestamp: 20260312-185356+0000
  result: Fail
  time:   4
  server_cmd:  fi_rma_bw -e msg -o writedata -I 5 -p "verbs"   -s 192.168.20.180
  server_stdout: |
  client_cmd:  fi_rma_bw -e msg -o writedata -I 5 -p "verbs"   -s 192.168.20.181 192.168.20.180
  client_stdout: |
    fi_getinfo(): common/shared.c:2027, ret=-61 (No data available)
/usr/bin/runfabtests.sh: line 558:  5024 Killed                  ${SERVER_CMD} "${EXPORT_ENV} $s_cmd" &> $s_outp
- name:   fi_rma_bw -e rdm -o write -I 5 -p "verbs"
  timestamp: 20260312-185401+0000
  result: Fail
  time:   5
  server_cmd:  fi_rma_bw -e rdm -o write -I 5 -p "verbs"   -s 192.168.20.180
  server_stdout: |
  client_cmd:  fi_rma_bw -e rdm -o write -I 5 -p "verbs"   -s 192.168.20.181 192.168.20.180
  client_stdout: |
    [error] fabtests:common/shared.c:3064: cq_readerr 22 (Invalid argument), provider errno: -22 (unknown)
    [error] fabtests:common/shared.c:2264: Failed to get transmit completion