### PR TITLE
prov/efa: Clean up efa_hmem_info_init_iface()

### DIFF
--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -1075,10 +1075,10 @@ static int efa_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 		return -FI_EINVAL;
 	}
 
-	if (!ofi_hmem_is_initialized(attr->iface)) {
+	if (attr->iface >= OFI_HMEM_MAX || !g_efa_hmem_info[attr->iface].initialized) {
 		EFA_WARN(FI_LOG_MR,
-			"Cannot register memory for uninitialized iface (%s)\n",
-			fi_tostr(&attr->iface, FI_TYPE_HMEM_IFACE));
+			 "Cannot register memory for uninitialized iface (%s)\n",
+			 fi_tostr(&attr->iface, FI_TYPE_HMEM_IFACE));
 		return -FI_ENOSYS;
 	}
 

--- a/prov/efa/test/efa_unit_test_hmem.c
+++ b/prov/efa/test/efa_unit_test_hmem.c
@@ -47,9 +47,87 @@ void test_efa_hmem_info_p2p_dmabuf_assumed_neuron()
 }
 #endif /* HAVE_NEURON */
 
+#if HAVE_NEURON
+/**
+ * @brief Verify that Neuron is not initialized when p2p is disabled.
+ *
+ * @param[in]	state		struct efa_resource that is managed by the framework
+ */
+void test_efa_hmem_info_p2p_disabled_neuron(struct efa_resource **state)
+{
+        int ret;
+        struct efa_resource *resource = *state;
+        bool neuron_initialized_orig;
+
+        ofi_hmem_disable_p2p = 1;
+
+	resource->hints = efa_unit_test_alloc_hints(FI_EP_RDM, EFA_FABRIC_NAME);
+        assert_non_null(resource->hints);
+
+        ret = fi_getinfo(FI_VERSION(1, 14), NULL, NULL, 0ULL, resource->hints, &resource->info);
+        assert_int_equal(ret, 0);
+
+        neuron_initialized_orig = hmem_ops[FI_HMEM_NEURON].initialized;
+        hmem_ops[FI_HMEM_NEURON].initialized = true;
+
+        ret = efa_hmem_info_initialize();
+
+        /* recover the modified global variables before doing check */
+        ofi_hmem_disable_p2p = 0;
+        hmem_ops[FI_HMEM_NEURON].initialized = neuron_initialized_orig;
+
+        assert_int_equal(ret, 0);
+        assert_false(g_efa_hmem_info[FI_HMEM_NEURON].initialized);
+}
+#else
+void test_efa_hmem_info_p2p_disabled_neuron()
+{
+        skip();
+}
+#endif /* HAVE_NEURON */
+
+#if HAVE_SYNAPSEAI
+/**
+ * @brief Verify that SynapseAI is not initialized when p2p is disabled.
+ *
+ * @param[in]	state		struct efa_resource that is managed by the framework
+ */
+void test_efa_hmem_info_p2p_disabled_synapse(struct efa_resource **state)
+{
+        int ret;
+        struct efa_resource *resource = *state;
+        bool synapse_initialized_orig;
+
+        ofi_hmem_disable_p2p = 1;
+
+	resource->hints = efa_unit_test_alloc_hints(FI_EP_RDM, EFA_FABRIC_NAME);
+        assert_non_null(resource->hints);
+
+        ret = fi_getinfo(FI_VERSION(1, 14), NULL, NULL, 0ULL, resource->hints, &resource->info);
+        assert_int_equal(ret, 0);
+
+        synapse_initialized_orig = hmem_ops[FI_HMEM_SYNAPSEAI].initialized;
+        hmem_ops[FI_HMEM_SYNAPSEAI].initialized = true;
+
+        ret = efa_hmem_info_initialize();
+
+        /* recover the modified global variables before doing check */
+        ofi_hmem_disable_p2p = 0;
+        hmem_ops[FI_HMEM_SYNAPSEAI].initialized = synapse_initialized_orig;
+
+        assert_int_equal(ret, 0);
+        assert_false(g_efa_hmem_info[FI_HMEM_SYNAPSEAI].initialized);
+}
+#else
+void test_efa_hmem_info_p2p_disabled_synapse()
+{
+        skip();
+}
+#endif /* HAVE_SYNAPSEAI */
+
 #if HAVE_CUDA
 /**
- * @brief Verify when p2p is disabled, we don't check p2p support with ofi_cudaMalloc. 
+ * @brief Verify when p2p is disabled, we don't check p2p support with ofi_cudaMalloc.
  * Just leave p2p_supported_by_device to false for cuda.
  *
  * @param[in]	state		struct efa_resource that is managed by the framework

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -295,6 +295,8 @@ int main(void)
 		/* end efa_unit_test_info.c */
 
 		cmocka_unit_test_setup_teardown(test_efa_hmem_info_p2p_dmabuf_assumed_neuron, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_hmem_info_p2p_disabled_neuron, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_hmem_info_p2p_disabled_synapse, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_hmem_info_disable_p2p_cuda, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_srx_min_multi_recv_size, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_srx_cq, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -232,6 +232,8 @@ void test_info_reuse_domain_via_domain_attr();
 void test_info_reuse_fabric_via_name();
 void test_info_reuse_domain_via_name();
 void test_efa_hmem_info_p2p_dmabuf_assumed_neuron();
+void test_efa_hmem_info_p2p_disabled_neuron();
+void test_efa_hmem_info_p2p_disabled_synapse();
 void test_efa_hmem_info_disable_p2p_cuda();
 void test_efa_nic_select_all_devices_matches();
 void test_efa_nic_select_first_device_matches();


### PR DESCRIPTION
Cleans up the logic so that the function is easier to read. Changes multiple nested if/else blocks to a single switch statement.

Also makes it so that if p2p is disabled via FI_HMEM_DISABLE_P2P=1, then neuron and synapse will not be initialized.

Furthermore, this is now checked during efa_mr_regattr(). This will make sure that memory registration happens only if the runtime is present AND the interface was successfully initialized by efa.

Adds unit tests for these two scenarios.


(cherry picked from commit cff899c9ef6dd823a1e3b35d3205622013c6eb6c)