### PR TITLE
fabtests/dmabuf-rdma: Fix uninitialized variable warning

### DIFF
--- a/fabtests/component/dmabuf-rdma/util.c
+++ b/fabtests/component/dmabuf-rdma/util.c
@@ -120,7 +120,7 @@ int connect_tcp(char *host, int port)
 
 void sync_tcp(int sockfd)
 {
-	int dummy1, dummy2;
+	int dummy1 = 1, dummy2;
 
 	(void)! write(sockfd, &dummy1, sizeof dummy1);
 	(void)! read(sockfd, &dummy2, sizeof dummy2);


### PR DESCRIPTION
```
component/dmabuf-rdma/util.c: In function ‘sync_tcp’: 
component/dmabuf-rdma/util.c:125:17: warning: ‘dummy1’ is used 
uninitialized [-Wuninitialized]
  125 |         (void)! write(sockfd, &dummy1, sizeof dummy1);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```