### PR TITLE
gh-pages: Add canonical page link to the HTML page template

### DIFF
--- a/_includes/themes/twitter/default.html
+++ b/_includes/themes/twitter/default.html
@@ -31,6 +31,13 @@
     <link href="{{ BASE_PATH }}{{ site.JB.atom_path }}" type="application/atom+xml" rel="alternate" title="Sitewide ATOM Feed">
     <link href="{{ BASE_PATH }}{{ site.JB.rss_path }}" type="application/rss+xml" rel="alternate" title="Sitewide RSS Feed">
 
+    <!-- canonical page link -->
+    <link rel="canonical"
+	  href="https://ofiwg.github.io/libfabric/main/man/{{ page.title
+				| replace: '(', '.'
+				| replace: ')', ''
+				| replace: 'Libfabric man pages', 'index'
+				| replace: 'All-in-one Man Page', 'onepage' }}.html">
   </head>
 
   <body>


### PR DESCRIPTION
The canonial link points to the correspoding page in the main branch. This should help promote the main branch man pages over older versions.