### PR TITLE
prov/efa: fix unit test linking to not affect libfabric.so

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -184,8 +184,9 @@ nodist_prov_efa_test_efa_unit_test_SOURCES = \
 efa_CPPFLAGS += -I$(top_srcdir)/include -I$(top_srcdir)/prov/efa/test $(cmocka_CPPFLAGS)
 
 prov_efa_test_efa_unit_test_CPPFLAGS = $(efa_CPPFLAGS)
-prov_efa_test_efa_unit_test_LDADD = $(cmocka_LIBS) $(linkback)
-prov_efa_test_efa_unit_test_LDFLAGS = $(cmocka_rpath) $(efa_LDFLAGS) $(cmocka_LDFLAGS) \
+prov_efa_test_efa_unit_test_LDADD = $(efa_LIBS) -lrdmacm -libverbs -lpthread -ldl
+prov_efa_test_efa_unit_test_LDFLAGS = $(efa_LDFLAGS) $(cmocka_rpath) $(cmocka_LIBS_STATIC) \
+					-Wl,--whole-archive,$(top_builddir)/src/.libs/libfabric.a,--no-whole-archive \
 					-Wl,--wrap=ibv_create_ah \
 					-Wl,--wrap=ibv_destroy_ah \
 					-Wl,--wrap=ibv_is_fork_initialized \
@@ -257,7 +258,8 @@ prov_efa_test_efa_unit_test_LDFLAGS += -Wl,--wrap=efadv_create_comp_cntr \
 					-Wl,--wrap=ibv_qp_attach_comp_cntr
 endif HAVE_EFADV_CREATE_COMP_CNTR
 
-prov_efa_test_efa_unit_test_LIBS = $(efa_LIBS) $(linkback)
+prov_efa_test_efa_unit_test_LIBS = $(efa_LIBS)
+prov_efa_test_efa_unit_test_DEPENDENCIES = $(top_builddir)/src/libfabric.la
 
 endif ENABLE_EFA_UNIT_TEST
 

--- a/prov/efa/configure.m4
+++ b/prov/efa/configure.m4
@@ -368,7 +368,7 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 			[],
 			[$cmocka_dir],
 			[],
-			[efa_LIBS+=" $cmocka_LDFLAGS $cmocka_LIBS -static"],
+			[cmocka_LIBS_STATIC="$cmocka_LDFLAGS $cmocka_LIBS"],
 			[AC_MSG_ERROR([Cannot compile EFA unit tests without a valid Cmocka installation directory.])],
 			[
 				#include <stdarg.h>
@@ -383,6 +383,7 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 	])
 
 	AC_SUBST(cmocka_rpath)
+	AC_SUBST(cmocka_LIBS_STATIC)
 	AC_DEFINE_UNQUOTED([EFA_UNIT_TEST], [$efa_unit_test], [EFA unit testing])
 
 	AM_CONDITIONAL([HAVE_EFADV_CQ_EX], [ test $efadv_support_extended_cq = 1])


### PR DESCRIPTION
The previous implementation added "-static" to efa_LIBS when unit tests were enabled, which caused static linking flags to propagate into the main libfabric.so build. This resulted in a shared library with embedded static dependencies, causing symbol conflicts and breaking compatibility with other tests and applications.

The fix isolates static linking to only the unit test binary by:

1. Removing "-static" from efa_LIBS in configure.m4 and storing cmocka flags in a separate cmocka_LIBS_STATIC variable

2. Linking the unit test binary against libfabric.a using --whole-archive to include all internal symbols (like efa_env) needed for mocking

3. Explicitly adding transitive dependencies (-lrdmacm, -libverbs, etc.) required when statically linking libfabric

4. Adding a dependency on libfabric.la to ensure proper build ordering

This change requires --enable-static when building with unit tests to generate libfabric.a.