### PR TITLE
prov/cxi: cxip_mr_init uses wrong length field from DMABUF structure

### DIFF
--- a/prov/cxi/src/cxip_mr.c
+++ b/prov/cxi/src/cxip_mr.c
@@ -1668,8 +1668,14 @@ static int cxip_mr_init(struct cxip_mr *mr, struct cxip_domain *dom,
 	mr->rma_events = flags & FI_RMA_EVENT;
 
 	/* Support length 1 IOV only for now */
-	mr->buf = mr->attr.mr_iov[0].iov_base;
-	mr->len = mr->attr.mr_iov[0].iov_len;
+	if (flags & FI_MR_DMABUF) {
+		mr->buf = (void *)((uintptr_t)attr->dmabuf->base_addr +
+				   attr->dmabuf->offset);
+		mr->len = attr->dmabuf->len;
+	} else {
+		mr->buf = mr->attr.mr_iov[0].iov_base;
+		mr->len = mr->attr.mr_iov[0].iov_len;
+	}
 
 	/* Allocate unique MR buffer ID if remote access MR */
 	if (mr->attr.access & (FI_REMOTE_READ | FI_REMOTE_WRITE)) {


### PR DESCRIPTION
When FI_MR_DMABUF is set, the mr_iov/dmabuf union contains a fi_mr_dmabuf pointer whose layout differs from iovec: reading mr_iov[0].iov_base yields the fd field (not the buffer address), and mr_iov[0].iov_len yields the offset field (not the length). Extract buf and len correctly from the dmabuf descriptor in this case. The CXI provider derives its DMA-BUF fd internally via cxip_do_map / cxip_dmabuf_hints, so only the virtual address and length are needed.