### PR TITLE
prov/efa: fix zero-length VLA stack overflow in RMA paths

### DIFF
--- a/prov/efa/src/efa_rma.c
+++ b/prov/efa/src/efa_rma.c
@@ -40,14 +40,7 @@ static inline ssize_t efa_rma_post_read(struct efa_base_ep *base_ep,
 	struct efa_mr *efa_mr;
 	struct efa_conn *conn;
 	size_t iov_count = msg->iov_count;
-#ifndef _WIN32
-	struct ibv_sge sge_list[msg->iov_count];
-#else
-	/* MSVC compiler does not support array declarations with runtime size, so hardcode
-	 * the expected iov_limit/max_sq_sge from the lower-level efa provider.
-	 */
-	struct ibv_sge sge_list[EFA_DEV_ATTR_MAX_WR_SGE];
-#endif
+	struct ibv_sge sge_list[2];  /* efa device support up to 2 iov */
 	uintptr_t wr_id;
 	int i, err = 0;
 	size_t total_len;
@@ -191,14 +184,7 @@ static inline ssize_t efa_rma_post_write(struct efa_base_ep *base_ep,
 	struct efa_domain *domain = base_ep->domain;
 	struct efa_conn *conn;
 	size_t iov_count = msg->iov_count;
-#ifndef _WIN32
-	struct ibv_sge sge_list[msg->iov_count];
-#else
-	/* MSVC compiler does not support array declarations with runtime size, so hardcode
-	 * the expected iov_limit/max_sq_sge from the lower-level efa provider.
-	 */
-	struct ibv_sge sge_list[EFA_DEV_ATTR_MAX_WR_SGE];
-#endif
+	struct ibv_sge sge_list[2];  /* efa device support up to 2 iov */
 	uintptr_t wr_id;
 	int i, err = 0;
 	size_t total_len = ofi_total_iov_len(msg->msg_iov, msg->iov_count);


### PR DESCRIPTION
Thanks Alexey for pointing this out!

When msg->iov_count is 0 (0-byte read/write), the VLA declaration struct ibv_sge sge_list[msg->iov_count] allocates a zero-length array. The subsequent 0-byte handling code writes to sge_list[0], causing a stack buffer overflow detected by AddressSanitizer.

Use msg->iov_count ?: 1 to ensure at least one element is allocated.

Co-authored-by:Alexey Novikov <nalexey@amazon.com>
Signed-off-by: Seth Zegelstein <szegel@amazon.com>