### PR TITLE
man: Clarify the behavior of FI_MORE when error occurs

### DIFF
--- a/man/fi_atomic.3.md
+++ b/man/fi_atomic.3.md
@@ -605,7 +605,10 @@ with atomic message calls.
 : Indicates that the user has additional requests that will
   immediately be posted after the current call returns.  Use of this
   flag may improve performance by enabling the provider to optimize
-  its access to the fabric hardware.
+  its access to the fabric hardware.  Providers that utilize delayed
+  start optimizations for communication calls with FI_MORE flag set
+  must ensure that all previously delayed calls be flushed when an
+  error is returned from a new call.
 
 *FI_INJECT*
 : Indicates that the control of constant data buffers should be returned to

--- a/man/fi_msg.3.md
+++ b/man/fi_msg.3.md
@@ -243,7 +243,10 @@ fi_sendmsg.
 : Indicates that the user has additional requests that will
   immediately be posted after the current call returns.  Use of this
   flag may improve performance by enabling the provider to optimize
-  its access to the fabric hardware.
+  its access to the fabric hardware.  Providers that utilize delayed
+  start optimizations for communication calls with FI_MORE flag set
+  must ensure that all previously delayed calls be flushed when an
+  error is returned from a new call.
 
 *FI_INJECT*
 : Applies to fi_sendmsg.  Indicates that the outbound data buffer

--- a/man/fi_rma.3.md
+++ b/man/fi_rma.3.md
@@ -237,7 +237,10 @@ fi_writemsg.
 : Indicates that the user has additional requests that will
   immediately be posted after the current call returns.  Use of this
   flag may improve performance by enabling the provider to optimize
-  its access to the fabric hardware.
+  its access to the fabric hardware.  Providers that utilize delayed
+  start optimizations for communication calls with FI_MORE flag set
+  must ensure that all previously delayed calls be flushed when an
+  error is returned from a new call.
 
 *FI_INJECT*
 : Applies to fi_writemsg.  Indicates that the outbound data buffer

--- a/man/fi_tagged.3.md
+++ b/man/fi_tagged.3.md
@@ -256,7 +256,10 @@ and/or fi_tsendmsg.
 : Indicates that the user has additional requests that will
   immediately be posted after the current call returns.  Use of this
   flag may improve performance by enabling the provider to optimize
-  its access to the fabric hardware.
+  its access to the fabric hardware.  Providers that utilize delayed
+  start optimizations for communication calls with FI_MORE flag set
+  must ensure that all previously delayed calls be flushed when an
+  error is returned from a new call.
 
 *FI_INJECT*
 : Applies to fi_tsendmsg.  Indicates that the outbound data buffer


### PR DESCRIPTION
A provider is required to flush requests delayed due to the FI_MORE flag when error occurs. This prevents deadlock scenario such as the request that would have triggered the process of delayed requests fails with -FI_EAGAIN and the resource cannot be freed up until the delayed requests are processed.