### PR TITLE
prov/efa: fix use-after-free of cur_wq during EP close CQ drain

### DIFF
--- a/prov/efa/src/efa_base_ep.c
+++ b/prov/efa/src/efa_base_ep.c
@@ -70,6 +70,23 @@ int efa_base_ep_destruct_qp(struct efa_base_ep *base_ep)
 	return 0;
 }
 
+/**
+ * @brief Invalidate stale cur_wq pointer on a CQ if it references the given QP
+ *
+ * When a QP is about to be destroyed, any CQ that has cur_wq pointing into
+ * that QP's work queue must be invalidated to prevent use-after-free during
+ * the subsequent CQ drain.
+ */
+static inline void efa_cq_invalidate_cur_wq(struct efa_cq *cq, struct efa_qp *qp)
+{
+#if HAVE_EFA_DATA_PATH_DIRECT
+	if (cq && cq->ibv_cq.data_path_direct_enabled &&
+	    cq->ibv_cq.data_path_direct.cur_wq &&
+	    cq->ibv_cq.data_path_direct.cur_qp == qp)
+		cq->ibv_cq.data_path_direct.cur_wq = NULL;
+#endif
+}
+
 int efa_base_ep_destruct_qp_unsafe(struct efa_base_ep *base_ep)
 {
 	struct efa_domain *domain;
@@ -89,6 +106,9 @@ int efa_base_ep_destruct_qp_unsafe(struct efa_base_ep *base_ep)
 	if (qp) {
 		domain = qp->base_ep->domain;
 		qp_num = qp->qp_num;
+		efa_cq_invalidate_cur_wq(tx_cq, qp);
+		if (rx_cq != tx_cq)
+			efa_cq_invalidate_cur_wq(rx_cq, qp);
 		efa_qp_destruct(qp);
 		domain->device->qp_table[qp_num & domain->device->qp_table_sz_m1] = NULL;
 		base_ep->qp = NULL;
@@ -97,6 +117,9 @@ int efa_base_ep_destruct_qp_unsafe(struct efa_base_ep *base_ep)
 	if (user_recv_qp) {
 		domain = user_recv_qp->base_ep->domain;
 		qp_num = user_recv_qp->qp_num;
+		efa_cq_invalidate_cur_wq(tx_cq, user_recv_qp);
+		if (rx_cq != tx_cq)
+			efa_cq_invalidate_cur_wq(rx_cq, user_recv_qp);
 		efa_qp_destruct(user_recv_qp);
 		domain->device->qp_table[qp_num & domain->device->qp_table_sz_m1] = NULL;
 		base_ep->user_recv_qp = NULL;

--- a/prov/efa/test/efa_unit_test_cq.c
+++ b/prov/efa/test/efa_unit_test_cq.c
@@ -2214,6 +2214,69 @@ void test_efa_cq_poll_ep_close_bypass_path(struct efa_resource **state)
 	ret = fi_cq_readerr(resource->cq, &cq_err_entry, 0);
 	assert_int_equal(ret, -FI_EAGAIN);
 }
+
+/**
+ * @brief Reproduce the SEGV: EAVAIL → no readerr → fi_close dereferences stale cur_wq
+ *
+ * End-to-end reproduction using the mock framework:
+ * 1. fi_cq_read returns -FI_EAVAIL (error CQE), leaving poll_active=true
+ * 2. Set cur_wq to point into the QP (simulating what process_ex_cqe leaves behind)
+ * 3. fi_close(ep) destroys the QP (freeing cur_wq's target), then drains the CQ
+ * 4. The drain's next_poll mock reads cur_wq->wrid_idx_pool_next → SEGV if dangling
+ *
+ * Without the fix: SEGV/SIGBUS (cur_wq points to freed QP memory)
+ * With the fix (NULLing cur_wq after consumption): passes
+ */
+void test_efa_cq_next_poll_stale_cur_wq_segv_on_ep_close(struct efa_resource **state)
+{
+#if HAVE_EFA_DATA_PATH_DIRECT
+	struct efa_resource *resource = *state;
+	struct efa_cq *efa_cq;
+	struct efa_ibv_cq *ibv_cq;
+	struct efa_base_ep *base_ep;
+	struct efa_context *efa_context;
+	struct fi_context2 ctx;
+	struct fi_cq_data_entry cq_entry;
+	ssize_t ret;
+
+	efa_context = (struct efa_context *) &ctx;
+	efa_context->completion_flags = FI_SEND | FI_MSG;
+
+	/* Set up an error CQE so fi_cq_read returns -FI_EAVAIL */
+	test_efa_cq_read_prep(resource, IBV_WC_SEND, IBV_WC_GENERAL_ERR,
+			      EFA_IO_COMP_STATUS_LOCAL_ERROR_UNRESP_REMOTE, efa_context, 0, false);
+
+	efa_cq = container_of(resource->cq, struct efa_cq, util_cq.cq_fid);
+	ibv_cq = &efa_cq->ibv_cq;
+	base_ep = container_of(resource->ep, struct efa_base_ep, util_ep.ep_fid);
+
+	ret = fi_cq_read(resource->cq, &cq_entry, 1);
+	assert_int_equal(ret, -FI_EAVAIL);
+	assert_true(ibv_cq->poll_active);
+
+	/*
+	 * Simulate what the real data-path-direct poll cycle leaves behind:
+	 * process_ex_cqe sets cur_wq pointing into the QP's work queue.
+	 * The mock CQ path doesn't do this, so set it manually.
+	 */
+	ibv_cq->data_path_direct.cur_wq = &base_ep->qp->data_path_direct_qp.sq.wq;
+	ibv_cq->data_path_direct.cur_qp = base_ep->qp;
+
+	/*
+	 * Install a next_poll mock that reads cur_wq->wrid_idx_pool_next,
+	 * exactly like the real efa_data_path_direct_next_poll.
+	 * If cur_wq is dangling after QP destruction, this will SEGV.
+	 */
+	g_efa_unit_test_mocks.efa_ibv_cq_next_poll = &efa_mock_efa_ibv_cq_next_poll_access_cur_wq;
+
+	/* fi_close destroys QP first, then drains CQ → triggers the access */
+	assert_int_equal(fi_close(&resource->ep->fid), 0);
+	resource->ep = NULL;
+#else
+	skip();
+#endif
+}
+
 /**
  * @brief Test mixed successful and error CQEs handling
  *

--- a/prov/efa/test/efa_unit_test_mocks.c
+++ b/prov/efa/test/efa_unit_test_mocks.c
@@ -185,6 +185,30 @@ int efa_mock_efa_ibv_cq_next_poll_simulate_status_change(struct efa_ibv_cq *ibv_
 	return mock_int();
 }
 
+/**
+ * @brief Mock next_poll that accesses cur_wq like the real data-path-direct impl.
+ *
+ * Reproduces the behavior of efa_data_path_direct_next_poll: if cur_wq is
+ * non-NULL, it reads cur_wq->wrid_idx_pool_next. This will crash (SEGV/SIGBUS)
+ * if cur_wq is a dangling pointer into a freed QP.
+ */
+int efa_mock_efa_ibv_cq_next_poll_access_cur_wq(struct efa_ibv_cq *ibv_cq)
+{
+#if HAVE_EFA_DATA_PATH_DIRECT
+	if (ibv_cq->data_path_direct.cur_wq) {
+		/*
+		 * This is the access that crashes in the real code path:
+		 * efa_wq_put_wrid_idx dereferences cur_wq to read
+		 * wrid_idx_pool_next and write to wrid_idx_pool[].
+		 * A volatile read is enough to trigger the fault.
+		 */
+		volatile uint16_t dummy = ibv_cq->data_path_direct.cur_wq->wrid_idx_pool_next;
+		(void)dummy;
+	}
+#endif
+	return ENOENT;
+}
+
 void efa_mock_efa_ibv_cq_end_poll_check_mock(struct efa_ibv_cq *ibv_cq)
 {
 	function_called();

--- a/prov/efa/test/efa_unit_test_mocks.h
+++ b/prov/efa/test/efa_unit_test_mocks.h
@@ -130,6 +130,7 @@ int efa_mock_efa_qp_post_send_verify_handshake_pkt_local_host_id_and_save_wr(str
 int efa_mock_efa_qp_post_read_return_mock(struct efa_qp *qp, const struct ibv_sge *sge_list, size_t sge_count, uint32_t remote_key, uint64_t remote_addr, uintptr_t wr_id, uint64_t flags, struct efa_ah *ah, uint32_t qpn, uint32_t qkey);
 int efa_mock_efa_qp_post_write_return_mock(struct efa_qp *qp, const struct ibv_sge *sge_list, size_t sge_count, uint32_t remote_key, uint64_t remote_addr, uintptr_t wr_id, uint64_t data, uint64_t flags, struct efa_ah *ah, uint32_t qpn, uint32_t qkey);
 int efa_mock_efa_ibv_cq_start_poll_return_mock(struct efa_ibv_cq *ibv_cq, struct ibv_poll_cq_attr *attr);
+int efa_mock_efa_ibv_cq_next_poll_access_cur_wq(struct efa_ibv_cq *ibv_cq);
 int efa_mock_efa_ibv_cq_next_poll_return_mock(struct efa_ibv_cq *ibv_cq);
 int efa_mock_efa_ibv_cq_next_poll_simulate_status_change(struct efa_ibv_cq *ibv_cq);
 enum ibv_wc_opcode efa_mock_efa_ibv_cq_wc_read_opcode_return_mock(struct efa_ibv_cq *ibv_cq);

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -502,6 +502,7 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_cq_readfrom_util_cq_entries, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_cq_readerr_util_cq_error, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_cq_poll_ep_close_bypass_path, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_cq_next_poll_stale_cur_wq_segv_on_ep_close, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_cq_read_mixed_success_error, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_ep_open, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_ep_cancel, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -463,6 +463,7 @@ void test_efa_cq_readfrom_start_poll_error();
 void test_efa_cq_readfrom_util_cq_entries();
 void test_efa_cq_readerr_util_cq_error();
 void test_efa_cq_poll_ep_close_bypass_path();
+void test_efa_cq_next_poll_stale_cur_wq_segv_on_ep_close();
 void test_efa_cq_read_mixed_success_error();
 void test_efa_ep_open();
 void test_efa_ep_cancel();


### PR DESCRIPTION
When fi_cq_read returns -FI_EAVAIL on the data-path-direct code path, cur_wq is left pointing into the QP's work queue. If the application calls fi_close(ep) without first calling fi_cq_readerr, efa_base_ep_destruct_qp_unsafe frees the QP (via efa_qp_destruct) before draining the CQ. The drain loop's call to next_poll then dereferences the dangling cur_wq pointer, causing a SEGV.

Fix this by NULLing cur_wq in efa_base_ep_destruct_qp_unsafe before calling efa_qp_destruct, for any CQ whose cur_qp matches the QP being destroyed. This is done for both the primary QP and user_recv_qp, and for both tx_cq and rx_cq.

Add a unit test that reproduces the exact crash sequence under ASan: set up an error CQE, leave poll_active=true, install a next_poll mock that dereferences cur_wq like the real data-path-direct implementation, then call fi_close. Without the fix ASan reports heap-use-after-free; with the fix the test passes clean.