### PR TITLE
prov/shm: refactor hdr and align protocols with 2.4

### DIFF
--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -275,6 +275,7 @@ static ssize_t smr_generic_atomic(
 					   compare_iov, compare_count,
 					   total_len, context, smr_flags, cmd);
 		if (ret) {
+			smr_freestack_push(smr_cmd_stack(ep->region), cmd);
 			smr_cmd_queue_discard(ce, pos);
 			goto unlock;
 		}
@@ -433,6 +434,7 @@ static ssize_t smr_atomic_inject(
 					   &iov, 1, NULL, NULL, 0, NULL, NULL,
 					   0, total_len, NULL, 0, cmd);
 		if (ret) {
+			smr_freestack_push(smr_cmd_stack(ep->region), cmd);
 			smr_cmd_queue_discard(ce, pos);
 			goto unlock;
 		}

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -168,8 +168,7 @@ static ssize_t smr_generic_atomic(
 			enum fi_op atomic_op, void *context, uint32_t op,
 			uint64_t op_flags)
 {
-	struct smr_cmd_entry *ce;
-	struct smr_cmd *cmd;
+	struct smr_cmd *ce, *cmd;
 	struct smr_region *peer_smr;
 	struct iovec iov[SMR_IOV_LIMIT];
 	struct iovec compare_iov[SMR_IOV_LIMIT];
@@ -251,7 +250,7 @@ static ssize_t smr_generic_atomic(
 	proto = smr_select_atomic_proto(op, total_len, op_flags);
 
 	if (proto == smr_proto_inline) {
-		cmd = &ce->cmd;
+		cmd = ce;
 		smr_do_atomic_inline(ep, peer_smr, tx_id, rx_id, ofi_op_atomic,
 				     op_flags, datatype, atomic_op,
 				     (struct ofi_mr **) desc, iov, count,
@@ -265,8 +264,8 @@ static ssize_t smr_generic_atomic(
 
 		cmd = smr_freestack_pop(smr_cmd_stack(ep->region));
 		assert(cmd);
-		ce->ptr = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
-					    (uintptr_t) cmd);
+		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
+						  (uintptr_t) cmd);
 		ret = smr_do_atomic_inject(ep, peer_smr, tx_id, rx_id, op,
 					   op_flags, datatype, atomic_op,
 					   (struct ofi_mr **) desc, iov, count,
@@ -362,8 +361,7 @@ static ssize_t smr_atomic_inject(
 			fi_addr_t dest_addr, uint64_t addr, uint64_t key,
 			enum fi_datatype datatype, enum fi_op op)
 {
-	struct smr_cmd_entry *ce;
-	struct smr_cmd *cmd;
+	struct smr_cmd *ce, *cmd;
 	struct smr_ep *ep;
 	struct smr_region *peer_smr;
 	struct iovec iov;
@@ -414,10 +412,10 @@ static ssize_t smr_atomic_inject(
 
 	if (total_len <= SMR_MSG_DATA_LEN) {
 		proto = smr_proto_inline;
-		cmd = &ce->cmd;
+		cmd = ce;
 		smr_do_atomic_inline(ep, peer_smr, id, peer_id, ofi_op_atomic,
 				     0, datatype, op, NULL, &iov, 1, total_len,
-				     &ce->cmd);
+				     cmd);
 	} else {
 		proto = smr_proto_inject;
 		if (smr_freestack_isempty(smr_cmd_stack(ep->region))) {
@@ -428,8 +426,8 @@ static ssize_t smr_atomic_inject(
 
 		cmd = smr_freestack_pop(smr_cmd_stack(ep->region));
 		assert(cmd);
-		ce->ptr = smr_local_to_peer(ep, peer_smr, id, peer_id,
-					    (uintptr_t) cmd);
+		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, id, peer_id,
+						  (uintptr_t) cmd);
 		ret = smr_do_atomic_inject(ep, peer_smr, id, peer_id,
 					   ofi_op_atomic, 0, datatype, op, NULL,
 					   &iov, 1, NULL, NULL, 0, NULL, NULL,

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -253,7 +253,6 @@ void smr_generic_format(struct smr_cmd *cmd, int64_t tx_id, int64_t rx_id,
 	cmd->hdr.tx_id = tx_id;
 	cmd->hdr.cq_data = data;
 	cmd->hdr.tag = tag;
-	cmd->hdr.status = 0;
 	cmd->hdr.rx_ctx = 0;
 
 	if (op_flags & FI_REMOTE_CQ_DATA)

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -172,7 +172,7 @@ static struct fi_ops_ep smr_ep_ops = {
 static void smr_send_name(struct smr_ep *ep, int64_t id)
 {
 	struct smr_region *peer_smr;
-	struct smr_cmd_entry *ce;
+	struct smr_cmd *cmd;
 	int64_t pos;
 	int ret;
 
@@ -181,20 +181,19 @@ static void smr_send_name(struct smr_ep *ep, int64_t id)
 	if (smr_peer_data(ep->region)[id].name_sent)
 		return;
 
-	ret = smr_cmd_queue_next(smr_cmd_queue(peer_smr), &ce, &pos);
+	ret = smr_cmd_queue_next(smr_cmd_queue(peer_smr), &cmd, &pos);
 	if (ret == -FI_ENOENT)
 		return;
 
-	ce->ptr = smr_peer_to_peer(ep, peer_smr, id, (uintptr_t) &ce->cmd);
-	ce->cmd.hdr.op = SMR_OP_MAX + ofi_ctrl_connreq;
-	ce->cmd.hdr.tx_id = id;
-	ce->cmd.hdr.cq_data = ep->region->pid;
+	cmd->hdr.op = SMR_OP_MAX + ofi_ctrl_connreq;
+	cmd->hdr.tx_id = id;
+	cmd->hdr.cq_data = ep->region->pid;
 
-	ce->cmd.hdr.size = strlen(ep->name) + 1;
-	memcpy(ce->cmd.data.msg, ep->name, ce->cmd.hdr.size);
+	cmd->hdr.size = strlen(ep->name) + 1;
+	memcpy(cmd->data.msg, ep->name, cmd->hdr.size);
 
 	smr_peer_data(ep->region)[id].name_sent = 1;
-	smr_cmd_queue_commit(ce, pos);
+	smr_cmd_queue_commit(cmd, pos);
 }
 
 int64_t smr_verify_peer(struct smr_ep *ep, fi_addr_t fi_addr)

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -420,8 +420,6 @@ int smr_select_proto(void **desc, size_t iov_count, bool vma_avail,
 	if (op == ofi_op_read_req) {
 		if (use_ipc)
 			return smr_proto_ipc;
-		if (total_len <= SMR_INJECT_SIZE)
-			return smr_proto_inject;
 		if (vma_avail && FI_HMEM_SYSTEM == iface)
 			return smr_proto_iov;
 		return smr_proto_sar;

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -248,12 +248,12 @@ void smr_generic_format(struct smr_cmd *cmd, int64_t tx_id, int64_t rx_id,
 			uint64_t op_flags)
 {
 	cmd->hdr.op = op;
-	cmd->hdr.status = 0;
 	cmd->hdr.op_flags = 0;
-	cmd->hdr.tag = tag;
-	cmd->hdr.tx_id = tx_id;
 	cmd->hdr.rx_id = rx_id;
+	cmd->hdr.tx_id = tx_id;
 	cmd->hdr.cq_data = data;
+	cmd->hdr.tag = tag;
+	cmd->hdr.status = 0;
 	cmd->hdr.rx_ctx = 0;
 
 	if (op_flags & FI_REMOTE_CQ_DATA)

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -83,8 +83,7 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 	ssize_t ret = -FI_EAGAIN;
 	size_t total_len;
 	int proto;
-	struct smr_cmd_entry *ce;
-	struct smr_cmd *cmd;
+	struct smr_cmd *ce, *cmd;
 
 	assert(iov_count <= SMR_IOV_LIMIT);
 
@@ -121,10 +120,10 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 
 		cmd = smr_freestack_pop(smr_cmd_stack(ep->region));
 		assert(cmd);
-		ce->ptr = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
-					    (uintptr_t) cmd);
+		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
+						  (uintptr_t) cmd);
 	} else {
-		cmd = &ce->cmd;
+		cmd = ce;
 	}
 
 	ret = smr_send_ops[proto](ep, peer_smr, tx_id, rx_id, op, tag, data,
@@ -203,8 +202,7 @@ static ssize_t smr_generic_inject(struct fid_ep *ep_fid, const void *buf,
 	ssize_t ret = 0;
 	struct iovec msg_iov;
 	int proto;
-	struct smr_cmd_entry *ce;
-	struct smr_cmd *cmd;
+	struct smr_cmd *ce, *cmd;
 
 	assert(len <= SMR_INJECT_SIZE);
 
@@ -234,7 +232,7 @@ static ssize_t smr_generic_inject(struct fid_ep *ep_fid, const void *buf,
 
 	if (len <= SMR_MSG_DATA_LEN) {
 		proto = smr_proto_inline;
-		cmd = &ce->cmd;
+		cmd = ce;
 	} else {
 		proto = smr_proto_inject;
 		if (smr_freestack_isempty(smr_cmd_stack(ep->region))) {
@@ -245,8 +243,8 @@ static ssize_t smr_generic_inject(struct fid_ep *ep_fid, const void *buf,
 
 		cmd = smr_freestack_pop(smr_cmd_stack(ep->region));
 		assert(cmd);
-		ce->ptr = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
-					    (uintptr_t) cmd);
+		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
+						  (uintptr_t) cmd);
 	}
 
 	ret = smr_send_ops[proto](ep, peer_smr, tx_id, rx_id, op, tag, data,

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -37,9 +37,8 @@
 
 static void smr_progress_overflow(struct smr_ep *ep)
 {
-	struct smr_cmd_entry *ce;
 	struct smr_region *peer_smr;
-	struct smr_cmd *cmd;
+	struct smr_cmd *ce, *cmd;
 	int64_t pos;
 	struct slist_entry *entry;
 	int ret;
@@ -53,8 +52,9 @@ static void smr_progress_overflow(struct smr_ep *ep)
 		if (ret == -FI_ENOENT)
 			return;
 
-		ce->ptr = smr_local_to_peer(ep, peer_smr, cmd->hdr.tx_id,
-					    cmd->hdr.rx_id, (uintptr_t) cmd);
+		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, cmd->hdr.tx_id,
+						  cmd->hdr.rx_id,
+						  (uintptr_t) cmd);
 
 		slist_remove_head(&ep->overflow_list);
 		smr_cmd_queue_commit(ce, pos);
@@ -1320,8 +1320,7 @@ out:
 
 static void smr_progress_cmd(struct smr_ep *ep)
 {
-	struct smr_cmd_entry *ce;
-	struct smr_cmd *cmd;
+	struct smr_cmd *ce, *cmd;
 	int ret = 0;
 	int64_t pos;
 
@@ -1330,7 +1329,7 @@ static void smr_progress_cmd(struct smr_ep *ep)
 		if (ret == -FI_ENOENT)
 			break;
 
-		cmd = (struct smr_cmd *) ce->ptr;
+		cmd = (struct smr_cmd *) ce->hdr.entry;
 		switch (cmd->hdr.op) {
 		case ofi_op_msg:
 		case ofi_op_tagged:

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -982,28 +982,27 @@ static int smr_unexp_sar(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 	memcpy(&cmd_ctx->cmd_cpy, cmd,
 		sizeof(cmd->hdr) + sizeof(cmd->data));
 
-	if (cmd->hdr.size) {
-		sar_entry = ofi_buf_alloc(ep->pend_pool);
-		if (!sar_entry) {
-			ofi_buf_free(cmd_ctx);
-			ret = -FI_ENOMEM;
-			cmd->hdr.op_flags |= SMR_OP_ERROR;
-			goto out;
-		}
-		cmd->hdr.rx_ctx = (uintptr_t) sar_entry;
+	assert(cmd->hdr.size);
+	sar_entry = ofi_buf_alloc(ep->pend_pool);
+	if (!sar_entry) {
+		ofi_buf_free(cmd_ctx);
+		ret = -FI_ENOMEM;
+		cmd->hdr.op_flags |= SMR_OP_ERROR;
+		goto out;
+	}
+	cmd->hdr.rx_ctx = (uintptr_t) sar_entry;
 
-		smr_init_rx_pend(sar_entry, cmd, rx_entry, NULL, NULL, 0);
-		cmd_ctx->pend = sar_entry;
+	smr_init_rx_pend(sar_entry, cmd, rx_entry, NULL, NULL, 0);
+	cmd_ctx->pend = sar_entry;
 
-		ret = smr_buffer_sar(ep, sar_entry,
-				     sar_entry->rx_entry->peer_context);
-		if (ret == -FI_EAGAIN) {
-			dlist_insert_tail(&sar_entry->entry,
-					  &ep->async_cpy_list);
-			return FI_SUCCESS;
-		} else if (ret && ret != -FI_EAGAIN) {
-			cmd->hdr.op_flags |= SMR_OP_ERROR;
-		}
+	ret = smr_buffer_sar(ep, sar_entry,
+				sar_entry->rx_entry->peer_context);
+	if (ret == -FI_EAGAIN) {
+		dlist_insert_tail(&sar_entry->entry,
+					&ep->async_cpy_list);
+		return FI_SUCCESS;
+	} else if (ret && ret != -FI_EAGAIN) {
+		cmd->hdr.op_flags |= SMR_OP_ERROR;
 	}
 out:
 	smr_return_cmd(ep, cmd);

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -46,7 +46,8 @@ static void smr_progress_overflow(struct smr_ep *ep)
 
 	entry = ep->overflow_list.head;
 	while (entry) {
-		cmd = (struct smr_cmd *) entry;
+		cmd = container_of(container_of(entry, struct smr_cmd_hdr,
+				   entry), struct smr_cmd, hdr);
 		peer_smr = smr_peer_region(ep, cmd->hdr.tx_id);
 		ret = smr_cmd_queue_next(smr_cmd_queue(peer_smr), &ce, &pos);
 		if (ret == -FI_ENOENT)

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -97,9 +97,9 @@ static int smr_progress_return_entry(struct smr_ep *ep, struct smr_cmd *cmd,
 		assert(pend->mr[0]);
 		break;
 	case smr_proto_sar:
-		if (cmd->hdr.status) {
+		if (cmd->hdr.op_flags & SMR_OP_ERROR) {
 			smr_free_sar_bufs(ep, cmd, pend);
-			return cmd->hdr.status;
+			return -FI_EIO;
 		}
 
 		if (cmd->hdr.op == ofi_op_read_req) {
@@ -109,6 +109,7 @@ static int smr_progress_return_entry(struct smr_ep *ep, struct smr_cmd *cmd,
 
 			if (ret && ret != -FI_EBUSY)
 				return ret;
+
 			if (pend->bytes_done == cmd->hdr.size) {
 				smr_free_sar_bufs(ep, cmd, pend);
 				return FI_SUCCESS;
@@ -190,13 +191,12 @@ static void smr_progress_return(struct smr_ep *ep)
 		ret = smr_progress_return_entry(ep, cmd, pending);
 		if (ret != -FI_EAGAIN) {
 			if (pending) {
-				if (cmd->hdr.status) {
+				if (cmd->hdr.op_flags & SMR_OP_ERROR) {
 					ret = smr_write_err_comp(
 							ep->util_ep.tx_cq,
 							pending->comp_ctx,
 							pending->comp_flags,
-							cmd->hdr.tag,
-							cmd->hdr.status);
+							cmd->hdr.tag, -FI_EIO);
 				} else {
 					ret = smr_complete_tx(
 							ep, pending->comp_ctx,
@@ -261,15 +261,16 @@ static ssize_t smr_progress_inject(struct smr_ep *ep, struct smr_cmd *cmd,
 	if (ret < 0) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"inject recv failed with code %lu\n", ret);
+		cmd->hdr.op_flags |= SMR_OP_ERROR;
 	} else if (ret != cmd->hdr.size) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"inject recv truncated\n");
 		ret = -FI_ETRUNC;
+		cmd->hdr.op_flags |= SMR_OP_ERROR;
 	} else {
 		ret = FI_SUCCESS;
 	}
 
-	cmd->hdr.status = ret;
 	return ret;
 }
 
@@ -290,7 +291,9 @@ static ssize_t smr_progress_iov(struct smr_ep *ep, struct smr_cmd *cmd,
 			       cmd->data.iov_count, cmd->hdr.size,
 			       peer_smr->pid, cmd->hdr.op == ofi_op_read_req,
 			       xpmem);
-	cmd->hdr.status = ret;
+	if (ret)
+		cmd->hdr.op_flags |= SMR_OP_ERROR;
+
 	return ret;
 }
 
@@ -344,8 +347,8 @@ static ssize_t smr_try_copy_rx_sar(struct smr_ep *ep,
 	if (ret) {
 		if (ret == -FI_EAGAIN)
 			dlist_insert_tail(&pend->entry, &ep->async_cpy_list);
-		else if (ret != -FI_EBUSY)
-			pend->cmd->hdr.status = ret;
+		else if (ret && ret != -FI_EBUSY)
+			pend->cmd->hdr.op_flags |= SMR_OP_ERROR;
 	}
 	return ret;
 }
@@ -362,7 +365,7 @@ static int smr_progress_pending_sar(struct smr_ep *ep, struct smr_cmd *cmd)
 			dlist_insert_tail(&pend->entry, &ep->async_cpy_list);
 			return FI_SUCCESS;
 		}
-		cmd->hdr.status = ret;
+		cmd->hdr.op_flags |= SMR_OP_ERROR;
 		goto out;
 	}
 
@@ -370,13 +373,13 @@ static int smr_progress_pending_sar(struct smr_ep *ep, struct smr_cmd *cmd)
 	if (ret == -FI_EBUSY || ret == -FI_EAGAIN)
 		return FI_SUCCESS;
 
-	if (pend->bytes_done == cmd->hdr.size || pend->cmd->hdr.status) {
-		if (pend->cmd->hdr.status) {
+	if (pend->bytes_done == cmd->hdr.size ||
+	    pend->cmd->hdr.op_flags & SMR_OP_ERROR) {
+		if (pend->cmd->hdr.op_flags & SMR_OP_ERROR) {
 			ret = smr_write_err_comp(ep->util_ep.rx_cq,
 						 pend->comp_ctx,
 						 pend->comp_flags,
-						 cmd->hdr.tag,
-						 pend->cmd->hdr.status);
+						 cmd->hdr.tag, -FI_EIO);
 		} else {
 			ret = smr_complete_rx(ep, pend->comp_ctx,
 					      cmd->hdr.op,
@@ -468,7 +471,7 @@ static ssize_t smr_progress_sar(struct smr_ep *ep, struct smr_cmd *cmd,
 
 	ret = smr_try_copy_rx_sar(ep, pend);
 
-	if (pend->bytes_done == cmd->hdr.size || pend->cmd->hdr.status) {
+	if (pend->bytes_done == cmd->hdr.size) {
 		cmd->hdr.rx_ctx = 0;
 		ofi_buf_free(pend);
 		ret = FI_SUCCESS;
@@ -573,7 +576,9 @@ static ssize_t smr_progress_ipc(struct smr_ep *ep, struct smr_cmd *cmd,
 uncache:
 	ofi_mr_cache_delete(domain->ipc_cache, mr_entry);
 out:
-	cmd->hdr.status = ret;
+	if (ret)
+		cmd->hdr.op_flags |= SMR_OP_ERROR;
+
 	return ret;
 }
 
@@ -904,7 +909,7 @@ static int smr_unexp_inject(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 	buf = ofi_buf_alloc(ep->unexp_buf_pool);
 	if (!buf) {
 		ret = -FI_ENOMEM;
-		cmd->hdr.status = ret;
+		cmd->hdr.op_flags |= SMR_OP_ERROR;
 		goto out;
 	}
 
@@ -957,7 +962,9 @@ static int smr_unexp_iov(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 		slist_insert_tail(&buf->entry, &cmd_ctx->buf_list);
 	}
 out:
-	cmd->hdr.status = ret;
+	if (ret)
+		cmd->hdr.op_flags |= SMR_OP_ERROR;
+
 	smr_return_cmd(ep, cmd);
 	return ret;
 }
@@ -980,7 +987,7 @@ static int smr_unexp_sar(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 		if (!sar_entry) {
 			ofi_buf_free(cmd_ctx);
 			ret = -FI_ENOMEM;
-			cmd->hdr.status = ret;
+			cmd->hdr.op_flags |= SMR_OP_ERROR;
 			goto out;
 		}
 		cmd->hdr.rx_ctx = (uintptr_t) sar_entry;
@@ -994,8 +1001,9 @@ static int smr_unexp_sar(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 			dlist_insert_tail(&sar_entry->entry,
 					  &ep->async_cpy_list);
 			return FI_SUCCESS;
+		} else if (ret && ret != -FI_EAGAIN) {
+			cmd->hdr.op_flags |= SMR_OP_ERROR;
 		}
-		cmd->hdr.status = ret;
 	}
 out:
 	smr_return_cmd(ep, cmd);
@@ -1052,7 +1060,9 @@ static int smr_unexp_ipc(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 	cmd_ctx->cmd->hdr.size = total_size;
 
 out:
-	cmd->hdr.status = ret;
+	if (ret)
+		cmd->hdr.op_flags |= SMR_OP_ERROR;
+
 	smr_return_cmd(ep, cmd);
 	return ret;
 }
@@ -1282,9 +1292,9 @@ static int smr_progress_cmd_atomic(struct smr_ep *ep, struct smr_cmd *cmd)
 			"unidentified operation type\n");
 		err = -FI_EINVAL;
 	}
-	cmd->hdr.status = -err;
 
 	if (err) {
+		cmd->hdr.op_flags |= SMR_OP_ERROR;
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"error processing atomic op\n");
 		ret = smr_write_err_comp(ep->util_ep.rx_cq, NULL,
@@ -1404,9 +1414,11 @@ static void smr_progress_async_sar(struct smr_ep *ep,
 
 	if (pend->rx_entry && pend->rx_entry->peer_context) {
 		ret = smr_buffer_sar(ep, pend, pend->rx_entry->peer_context);
-		if (ret == -FI_EAGAIN)
+		if (ret == -FI_EAGAIN) {
 			return;
-		pend->cmd->hdr.status = ret;
+		} else if (ret && ret != -FI_EAGAIN) {
+			pend->cmd->hdr.op_flags |= SMR_OP_ERROR;
+		}
 		dlist_remove(&pend->entry);
 		smr_return_cmd(ep, pend->cmd);
 		return;
@@ -1422,8 +1434,9 @@ static void smr_progress_async_sar(struct smr_ep *ep,
 		if (ret == -FI_EBUSY) {
 			dlist_remove(&pend->entry);
 			return;
+		} else if (ret && ret != -FI_EBUSY) {
+			pend->cmd->hdr.op_flags |= SMR_OP_ERROR;
 		}
-		pend->cmd->hdr.status = ret;
 	}
 }
 

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -115,8 +115,7 @@ static inline bool smr_do_fast_rma(struct smr_ep *ep, uint64_t op_flags,
 
 	return domain->fast_rma && !(op_flags &
 		    (FI_REMOTE_CQ_DATA | FI_DELIVERY_COMPLETE)) &&
-		     rma_count == 1 && smr_vma_enabled(ep, peer_smr) &&
-		     total_len > SMR_INJECT_SIZE;
+		     rma_count == 1 && smr_vma_enabled(ep, peer_smr);
 
 }
 

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -58,12 +58,12 @@ static ssize_t smr_rma_fast(struct smr_ep *ep, struct smr_region *peer_smr,
 {
 	struct iovec vma_iovec[SMR_IOV_LIMIT], rma_iovec[SMR_IOV_LIMIT];
 	struct ofi_xpmem_client *xpmem;
-	struct smr_cmd_entry *ce;
+	struct smr_cmd *cmd;
 	size_t total_len;
 	int ret, i;
 	int64_t pos;
 
-	ret = smr_cmd_queue_next(smr_cmd_queue(peer_smr), &ce, &pos);
+	ret = smr_cmd_queue_next(smr_cmd_queue(peer_smr), &cmd, &pos);
 	if (ret == -FI_ENOENT)
 		return -FI_EAGAIN;
 
@@ -85,15 +85,15 @@ static ssize_t smr_rma_fast(struct smr_ep *ep, struct smr_region *peer_smr,
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL, "error doing fast RMA\n");
 		ret = smr_write_err_comp(ep->util_ep.rx_cq, NULL, op_flags, 0,
 					 ret);
-		smr_cmd_queue_discard(ce, pos);
+		smr_cmd_queue_discard(cmd, pos);
 		return -FI_EAGAIN;
 	}
 
-	smr_format_rma_resp(&ce->cmd, rx_id, rma_iov, rma_count, total_len,
+	smr_format_rma_resp(cmd, rx_id, rma_iov, rma_count, total_len,
 			    (op == ofi_op_write) ? ofi_op_write_async :
 			    ofi_op_read_async, op_flags);
 
-	smr_cmd_queue_commit(ce, pos);
+	smr_cmd_queue_commit(cmd, pos);
 
 	ret = smr_complete_tx(ep, context, op, op_flags);
 	if (ret) {
@@ -131,8 +131,7 @@ static ssize_t smr_generic_rma(
 	int proto = smr_proto_inline;
 	ssize_t ret = -FI_EAGAIN;
 	size_t total_len;
-	struct smr_cmd_entry *ce;
-	struct smr_cmd *cmd;
+	struct smr_cmd *ce, *cmd;
 	int64_t pos;
 
 	assert(iov_count <= SMR_IOV_LIMIT);
@@ -178,10 +177,10 @@ static ssize_t smr_generic_rma(
 		}
 		cmd = smr_freestack_pop(smr_cmd_stack(ep->region));
 		assert(cmd);
-		ce->ptr = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
-					    (uintptr_t) cmd);
+		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
+						  (uintptr_t) cmd);
 	} else {
-		cmd = &ce->cmd;
+		cmd = ce;
 	}
 	ret = smr_send_ops[proto](ep, peer_smr, tx_id, rx_id, op, 0, data,
 				  op_flags, (struct ofi_mr **)desc, iov,
@@ -329,8 +328,7 @@ static ssize_t smr_generic_rma_inject(
 	int64_t tx_id, rx_id;
 	int proto = smr_proto_inline;
 	ssize_t ret = -FI_EAGAIN;
-	struct smr_cmd *cmd;
-	struct smr_cmd_entry *ce;
+	struct smr_cmd *ce, *cmd;
 	int64_t pos;
 
 	assert(len <= SMR_INJECT_SIZE);
@@ -361,7 +359,7 @@ static ssize_t smr_generic_rma_inject(
 
 	if (len <= SMR_MSG_DATA_LEN) {
 		proto = smr_proto_inline;
-		cmd = &ce->cmd;
+		cmd = ce;
 	} else {
 		proto = smr_proto_inject;
 		if (smr_freestack_isempty(smr_cmd_stack(ep->region))) {
@@ -372,8 +370,8 @@ static ssize_t smr_generic_rma_inject(
 
 		cmd = smr_freestack_pop(smr_cmd_stack(ep->region));
 		assert(cmd);
-		ce->ptr = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
-					    (uintptr_t) cmd);
+		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
+						  (uintptr_t) cmd);
 	}
 
 	ret = smr_send_ops[proto](ep, peer_smr, tx_id, rx_id, ofi_op_write, 0,

--- a/prov/shm/src/smr_util.c
+++ b/prov/shm/src/smr_util.c
@@ -102,12 +102,12 @@ size_t smr_calculate_size_offsets(size_t tx_count, size_t rx_count,
 
 	/* Align cmd_queue offset to cache line */
 	cmd_queue_offset = ofi_get_aligned_size(sizeof(struct smr_region), 64);
-	cmd_stack_offset = cmd_queue_offset + sizeof(struct smr_cmd_queue) +
+	inject_pool_offset = cmd_queue_offset + sizeof(struct smr_cmd_queue) +
 		sizeof(struct smr_cmd_queue_entry) * rx_size;
-	inject_pool_offset = cmd_stack_offset +
+	cmd_stack_offset = inject_pool_offset +
+		sizeof(struct smr_inject_buf) * tx_size;
+	ret_queue_offset = cmd_stack_offset +
 		freestack_size(sizeof(struct smr_cmd), tx_size);
-	ret_queue_offset = inject_pool_offset + sizeof(struct smr_inject_buf) *
-		tx_size;
 	ret_queue_offset = ofi_get_aligned_size(ret_queue_offset, 64);
 	sar_pool_offset = ret_queue_offset + sizeof(struct smr_return_queue) +
 		sizeof(struct smr_return_queue_entry) * tx_size;

--- a/prov/shm/src/smr_util.c
+++ b/prov/shm/src/smr_util.c
@@ -179,8 +179,8 @@ err:
 
 static inline void smr_cmd_init(void *buf)
 {
-	struct smr_cmd_entry *ce = buf;
-	ce->ptr = (uintptr_t) &ce->cmd;
+	struct smr_cmd *cmd = buf;
+	cmd->hdr.entry = (uintptr_t) cmd;
 }
 
 /* TODO: Determine if aligning SMR data helps performance */

--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -74,6 +74,7 @@ extern struct smr_env smr_env;
 
 #define SMR_REMOTE_CQ_DATA	(1 << 0)
 #define SMR_BUFFER_RECV		(1 << 1)
+#define SMR_OP_ERROR		(1 << 2)
 
 enum {
 	smr_proto_inline,	/* inline payload */
@@ -97,11 +98,14 @@ enum {
  * 	tag		tag for FI_TAGGED API only
  * 	datatype	atomic datatype for FI_ATOMIC API only
  * 	atomic_op	atomic operation for FI_ATOMIC API only
- * 	status		returned status of operation
- * 	CACHE LINE HERE Above fields must be 40 bytes if the cpu does
- *			not support prefetching algorithms. The other 24 bytes
- *			in this cache line come from the atomic queue cmd_entry
  *	entry		for internal use managing commands
+ * 	CACHE LINE HERE Make sure above fields are 40bytes so that they are
+ * 		 	properly cache aligned with the other 24 bytes
+ *			from the atomic queue fields. This is necessary
+			(especially if your cpu does not have prefetching) so
+			that the first cache grab gets the lightweight protocol
+			fields.
+ *	resv2		reserved for future use to keep struct size at 64 bytes
  *	tx_ctx		source side context (unused by target side)
  *	rx_ctx		target side context (unused by source side)
  */
@@ -121,9 +125,9 @@ struct smr_cmd_hdr {
 			uint8_t	atomic_op;
 		};
 	};
-	uint64_t		status;
-	//CACHE LINE HERE - See comment above
 	uint64_t		entry;
+	//CACHE LINE HERE - See comment above
+	uint64_t		resv2;
 	uint64_t		tx_ctx;
 	uint64_t		rx_ctx;
 };

--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -61,11 +61,11 @@ extern struct smr_env smr_env;
 /* SMR_CMD_SIZE refers to the total bytes dedicated for use in shm headers and
  * data. The entire atomic queue entry will be cache aligned (384) but this also
  * includes the cmd aq header (16) + cmd entry ptr (8)
- * 384 (total entry size) - 16 (aq header) - 8 (entry ptr) = 360
+ * 384 (total entry size) - 16 (aq header) = 368
  * This maximizes the inline payload. Increasing this value will increase the
  * atomic queue entry to 448 bytes.
  */
-#define SMR_CMD_SIZE		360
+#define SMR_CMD_SIZE		368
 
 /* reserves 0-255 for defined ops and room for new ops
  * 256 and beyond reserved for ctrl ops
@@ -87,6 +87,7 @@ enum {
 
 /*
  * Unique smr_cmd_hdr for smr message protocol:
+ *	entry		for internal use managing commands
  * 	op		type of op (ex. ofi_op_msg, defined in ofi_proto.h)
  * 	proto		smr protocol (ex. smr_proto_inline, defined above)
  * 	op_flags	operation flags (ex. SMR_REMOTE_CQ_DATA, defined above)
@@ -98,18 +99,18 @@ enum {
  * 	tag		tag for FI_TAGGED API only
  * 	datatype	atomic datatype for FI_ATOMIC API only
  * 	atomic_op	atomic operation for FI_ATOMIC API only
- *	entry		for internal use managing commands
  * 	CACHE LINE HERE Make sure above fields are 40bytes so that they are
  * 		 	properly cache aligned with the other 24 bytes
  *			from the atomic queue fields. This is necessary
 			(especially if your cpu does not have prefetching) so
 			that the first cache grab gets the lightweight protocol
 			fields.
- *	resv2		reserved for future use to keep struct size at 64 bytes
+ * 	resv2		reserved to keep hdr at 64 bytes
  *	tx_ctx		source side context (unused by target side)
  *	rx_ctx		target side context (unused by source side)
  */
 struct smr_cmd_hdr {
+	uint64_t		entry;
 	uint8_t			op;
 	uint8_t			proto;
 	uint8_t			op_flags;
@@ -125,7 +126,6 @@ struct smr_cmd_hdr {
 			uint8_t	atomic_op;
 		};
 	};
-	uint64_t		entry;
 	//CACHE LINE HERE - See comment above
 	uint64_t		resv2;
 	uint64_t		tx_ctx;
@@ -300,16 +300,11 @@ struct smr_sar_buf {
 	uint8_t		buf[SMR_SAR_SIZE];
 };
 
-struct smr_cmd_entry {
-	uintptr_t	ptr;
-	struct smr_cmd	cmd;
-};
-
 struct smr_return_entry {
 	uintptr_t ptr;
 };
 
-OFI_DECLARE_ATOMIC_Q(struct smr_cmd_entry, smr_cmd_queue);
+OFI_DECLARE_ATOMIC_Q(struct smr_cmd, smr_cmd_queue);
 OFI_DECLARE_ATOMIC_Q(struct smr_return_entry, smr_return_queue);
 
 /* Queue of offsets of the command blocks obtained from the command pool

--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -86,27 +86,33 @@ enum {
 
 /*
  * Unique smr_cmd_hdr for smr message protocol:
- *	entry		for internal use managing commands (must be kept first)
- *	tx_ctx		source side context (unused by target side)
- *	rx_ctx		target side context (unused by source side)
- * 	tx_id		local shm_id of peer sending msg (unused by target)
- *	rx_id		remote shm_id of peer sending msg (unused by source)
  * 	op		type of op (ex. ofi_op_msg, defined in ofi_proto.h)
  * 	proto		smr protocol (ex. smr_proto_inline, defined above)
  * 	op_flags	operation flags (ex. SMR_REMOTE_CQ_DATA, defined above)
+ * 	resv		reserved
+ * 	tx_id		local shm_id of peer sending msg (unused by target)
+ *	rx_id		remote shm_id of peer sending msg (unused by source)
  * 	size		size of data transfer
- * 	status		returned status of operation
  * 	cq_data		remote CQ data
  * 	tag		tag for FI_TAGGED API only
  * 	datatype	atomic datatype for FI_ATOMIC API only
  * 	atomic_op	atomic operation for FI_ATOMIC API only
+ * 	status		returned status of operation
+ * 	CACHE LINE HERE Above fields must be 40 bytes if the cpu does
+ *			not support prefetching algorithms. The other 24 bytes
+ *			in this cache line come from the atomic queue cmd_entry
+ *	entry		for internal use managing commands
+ *	tx_ctx		source side context (unused by target side)
+ *	rx_ctx		target side context (unused by source side)
  */
 struct smr_cmd_hdr {
-	uint64_t		entry;
-	uint64_t		tx_ctx;
-	uint64_t		rx_ctx;
+	uint8_t			op;
+	uint8_t			proto;
+	uint8_t			op_flags;
+	uint8_t			resv[1];
+	int16_t			rx_id;
+	int16_t			tx_id;
 	uint64_t		size;
-	int64_t			status;
 	uint64_t		cq_data;
 	union {
 		uint64_t	tag;
@@ -115,12 +121,11 @@ struct smr_cmd_hdr {
 			uint8_t	atomic_op;
 		};
 	};
-	int16_t			rx_id;
-	int16_t			tx_id;
-	uint8_t			op;
-	uint8_t			proto;
-	uint8_t			op_flags;
-	uint8_t			resv[1];
+	uint64_t		status;
+	//CACHE LINE HERE - See comment above
+	uint64_t		entry;
+	uint64_t		tx_ctx;
+	uint64_t		rx_ctx;
 };
 
 #ifdef static_assert

--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -260,8 +260,8 @@ struct smr_region {
 	struct {
 		/* offsets from start of smr_region */
 		size_t			cmd_queue_offset;
-		size_t			cmd_stack_offset;
 		size_t			inject_pool_offset;
+		size_t			cmd_stack_offset;
 		size_t			ret_queue_offset;
 		size_t			sar_pool_offset;
 		size_t			peer_data_offset;


### PR DESCRIPTION
- Reorder cmd hdr so that "hot" fields on lightweight protocols fit on one cacheline
- Move inject pool above cmd stack
- Repurpose hdr->status to be smr_flags so we can remove the status variable from the header
- Turn an if that should always be true into an assert (unexp sar 0 byte msg)
- Use entry field in the cmd->hdr to remove from the struct cmd_entry. This entry field will be used to point to commands in the cmd queue and for in flight sar messages
- Let rma take the fast path for total_len < inject_size
- Take iov on op_read_req instead of inject
