### PR TITLE
fabtests/pytest: Unify message size parametrization and add PR CI marker

### DIFF
--- a/fabtests/pytest/common.py
+++ b/fabtests/pytest/common.py
@@ -723,3 +723,33 @@ class MultinodeTest(ClientServerTest):
             returncode_list.append(client_process_list[i].returncode)
 
         check_returncode_list(returncode_list, strict)
+
+
+# Message size lists for @pytest.mark.message_sizes decorator.
+# Generic (provider-agnostic) size selections live here so all providers can share them.
+PERF_SIZES = ["all"]
+PERF_PR_CI = ["l:16,4096,16384,131072,1048576"]
+RANGE_SIZES = ["r:0,4,64", "r:4048,4,4148", "r:8000,4,9000", "r:17000,4,18000", "r:0,4096,1048576"]
+INJECT_SIZES = ["r:0,4,64", "r:4048,4,4148", "r:8000,4,9000"]
+RMA_PINGPONG_SIZES = ["r:4048,4,4148", "r:8000,4,9000", "r:17000,4,18000"]
+MULTI_RECV_SIZES = ["1024", "8192"]
+
+
+def test_selected_by_marker(config, test_markers, name):
+    expr_str = config.getoption("markexpr") or ""
+    if not expr_str or name not in test_markers:
+        return False
+    try:
+        from _pytest.mark.expression import Expression
+        expr = Expression.compile(expr_str)
+    except Exception as e:
+        raise RuntimeError(
+            f"test_selected_by_marker failed to compile markexpr {expr_str!r}. "
+            f"This might mean pytest's private _pytest.mark.expression API "
+            f"has changed. Underlying error: {e}"
+        ) from e
+    # would the test still be selected if `name` were removed from its markers?
+    with_marker = expr.evaluate(lambda n: n in test_markers)
+    without_marker = expr.evaluate(lambda n: n in (test_markers - {name}))
+    # true only when `name` is the reason this test got selected
+    return with_marker and not without_marker

--- a/fabtests/pytest/default/test_cntr.py
+++ b/fabtests/pytest/default/test_cntr.py
@@ -1,5 +1,6 @@
 import pytest
 
+@pytest.mark.pr_ci
 @pytest.mark.unit
 def test_cntr(cmdline_args):
     from common import UnitTest

--- a/fabtests/pytest/default/test_cq.py
+++ b/fabtests/pytest/default/test_cq.py
@@ -1,11 +1,13 @@
 import pytest
 
+@pytest.mark.pr_ci
 @pytest.mark.unit
 def test_cq(cmdline_args):
     from common import UnitTest
     test = UnitTest(cmdline_args, "fi_cq_test")
     test.run()
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 @pytest.mark.parametrize("operation_type", ["senddata", "writedata"])
 @pytest.mark.parametrize("endpoint_type", ["msg", "rdm", "dgram"])

--- a/fabtests/pytest/default/test_dgram.py
+++ b/fabtests/pytest/default/test_dgram.py
@@ -15,6 +15,7 @@ def test_dgram(cmdline_args):
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
+@pytest.mark.pr_ci
 def test_dgram_pingpong(cmdline_args, iteration_type, prefix_type):
     from common import ClientServerTest
     test = ClientServerTest(cmdline_args, "fi_dgram_pingpong", iteration_type,

--- a/fabtests/pytest/default/test_dom.py
+++ b/fabtests/pytest/default/test_dom.py
@@ -1,5 +1,6 @@
 import pytest
 
+@pytest.mark.pr_ci
 @pytest.mark.unit
 def test_dom(cmdline_args):
     from common import UnitTest

--- a/fabtests/pytest/default/test_eq.py
+++ b/fabtests/pytest/default/test_eq.py
@@ -1,5 +1,6 @@
 import pytest
 
+@pytest.mark.pr_ci
 @pytest.mark.unit
 def test_eq(cmdline_args):
     from common import UnitTest

--- a/fabtests/pytest/default/test_getinfo.py
+++ b/fabtests/pytest/default/test_getinfo.py
@@ -1,5 +1,6 @@
 import pytest
 
+@pytest.mark.pr_ci
 @pytest.mark.unit
 def test_getinfo(cmdline_args, server_address, good_address):
     from common import UnitTest

--- a/fabtests/pytest/default/test_mr.py
+++ b/fabtests/pytest/default/test_mr.py
@@ -1,5 +1,6 @@
 import pytest
 
+@pytest.mark.pr_ci
 @pytest.mark.unit
 def test_mr(cmdline_args):
     from common import UnitTest

--- a/fabtests/pytest/default/test_multi_recv.py
+++ b/fabtests/pytest/default/test_multi_recv.py
@@ -1,5 +1,6 @@
 import pytest
 
+@pytest.mark.pr_ci
 @pytest.mark.parametrize("endpoint_type", ["rdm", "msg"])
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),

--- a/fabtests/pytest/default/test_rdm.py
+++ b/fabtests/pytest/default/test_rdm.py
@@ -6,6 +6,7 @@ def test_rdm_g00n13s(cmdline_args):
     test = UnitTest(cmdline_args, "fi_rdm g00n13s", is_negative=True)
     test.run()
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 def test_rdm(cmdline_args, completion_semantic):
     from common import ClientServerTest
@@ -24,6 +25,7 @@ def test_rdm_rma_trigger(cmdline_args):
     test = ClientServerTest(cmdline_args, "fi_rdm_rma_trigger")
     test.run()
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 def test_rdm_tagged_peek(cmdline_args):
     from common import ClientServerTest
@@ -36,6 +38,7 @@ def test_rdm_shared_av(cmdline_args):
     test = ClientServerTest(cmdline_args, "fi_rdm_shared_av")
     test.run()
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 def test_rdm_bw_functional(cmdline_args, completion_semantic):
     from common import ClientServerTest
@@ -45,6 +48,7 @@ def test_rdm_bw_functional(cmdline_args, completion_semantic):
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
+@pytest.mark.pr_ci
 def test_rdm_atomic(cmdline_args, iteration_type, completion_semantic):
     from common import ClientServerTest
     test = ClientServerTest(cmdline_args, "fi_rdm_atomic", iteration_type, completion_semantic)
@@ -61,6 +65,7 @@ def test_rdm_cntr_pingpong(cmdline_args, iteration_type):
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
+@pytest.mark.pr_ci
 def test_rdm_pingpong(cmdline_args, iteration_type,
                       prefix_type, datacheck_type, completion_semantic):
     from common import ClientServerTest
@@ -71,6 +76,7 @@ def test_rdm_pingpong(cmdline_args, iteration_type,
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
+@pytest.mark.pr_ci
 def test_rdm_tagged_pingpong(cmdline_args, iteration_type,
                              datacheck_type, completion_semantic):
     from common import ClientServerTest

--- a/fabtests/pytest/default/test_recv_cancel.py
+++ b/fabtests/pytest/default/test_recv_cancel.py
@@ -1,5 +1,6 @@
 import pytest
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 def test_recv_cancel(cmdline_args):
     from common import ClientServerTest

--- a/fabtests/pytest/default/test_rma_bw.py
+++ b/fabtests/pytest/default/test_rma_bw.py
@@ -1,5 +1,6 @@
 import pytest
 
+@pytest.mark.pr_ci
 @pytest.mark.parametrize("operation_type", ["read", "writedata", "write"])
 @pytest.mark.parametrize("endpoint_type", ["msg", "rdm"])
 @pytest.mark.parametrize("iteration_type",

--- a/fabtests/pytest/default/test_rma_pingpong.py
+++ b/fabtests/pytest/default/test_rma_pingpong.py
@@ -1,5 +1,6 @@
 import pytest
 
+@pytest.mark.pr_ci
 @pytest.mark.parametrize("operation_type", ["writedata", "write"])
 @pytest.mark.parametrize("endpoint_type", ["msg", "rdm"])
 @pytest.mark.parametrize("iteration_type",

--- a/fabtests/pytest/default/test_sighandler.py
+++ b/fabtests/pytest/default/test_sighandler.py
@@ -1,5 +1,6 @@
 import pytest
 
+@pytest.mark.pr_ci
 @pytest.mark.unit
 def test_sighandler(cmdline_args):
     from common import UnitTest

--- a/fabtests/pytest/default/test_unexpected_msg.py
+++ b/fabtests/pytest/default/test_unexpected_msg.py
@@ -1,5 +1,6 @@
 import pytest
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 @pytest.mark.parametrize("endpoint_type", ["msg", "rdm"])
 def test_unexpected_msg(cmdline_args, endpoint_type):

--- a/fabtests/pytest/efa/conftest.py
+++ b/fabtests/pytest/efa/conftest.py
@@ -1,11 +1,115 @@
 import pytest
 import time
+from common import test_selected_by_marker
 from efa_common import (
     has_rdma, 
     support_cq_interrupts,
     CudaMemorySupport,
     get_cuda_memory_support,
 )
+
+# Message size lists are defined in efa_common.py and imported by test files directly.
+# The pytest_generate_tests hook reads them from the @pytest.mark.message_sizes decorator.
+
+
+def fabric_present(string, fabric):
+    """
+    Return true if 'fabric' is present in 'string', raises error if the
+    fabric is invalid
+    """
+    if fabric == "efa":
+        return "efa" in string and "efa_direct" not in string
+    if fabric == "efa-direct":
+        return "efa_direct" in string
+    raise ValueError(f"Unknown fabric: {fabric!r}")
+
+
+def get_test_type(test_markers, config):
+    """
+    Return 'pr_ci' if this test is being collected because of the pr_ci marker,
+    else 'default'.
+    """
+    if test_selected_by_marker(config, test_markers, "pr_ci"):
+        return "pr_ci"
+    return "default"
+
+
+def choose_message_sizes_for_fabric_test_type(fabric, test_type, sizes_marker, nodeid):
+    """
+    Return all matching message-size lists for (fabric, test_type) from a
+    @pytest.mark.message_sizes marker.
+    example:
+    @pytest.mark.message_sizes(default_efa=PERF_SIZES, pr_ci_efa=DIRECT_RMA_SIZES)
+                   ^sizes marker   ^kwarg_name   ^kwarg_sizes
+    """
+    sizes = []
+    for kwarg_name, kwarg_sizes in sizes_marker.kwargs.items():
+        # add message sizes if they match both the fabric and the test type
+        if fabric_present(kwarg_name, fabric) and test_type in kwarg_name:
+            sizes.extend(kwarg_sizes)
+    if not sizes:
+        raise ValueError(
+            f"@pytest.mark.message_sizes on {nodeid} is missing a kwarg for "
+            f"fabric={fabric!r} test_type={test_type!r} "
+            f"(have {sorted(sizes_marker.kwargs)})"
+        )
+    return sizes
+
+
+def add_fabric_and_message_size_parametrization(metafunc, fabric_marker, sizes_marker, test_type):
+    # look at markers and find out if this test specifies fabric and message sizes
+    wants_fabric = fabric_marker is not None and "fabric" in metafunc.fixturenames
+    wants_sizes  = sizes_marker  is not None and "message_sizes" in metafunc.fixturenames
+
+    # no parametrization needed
+    if not wants_fabric and not wants_sizes:
+        return
+
+    # get message size based on fabric and test type
+    if wants_fabric and wants_sizes:
+        nodeid = metafunc.definition.nodeid
+        params = []
+        for fabric in fabric_marker.kwargs["params"]:
+            for size in choose_message_sizes_for_fabric_test_type(fabric, test_type, sizes_marker, nodeid):
+                params.append(pytest.param(fabric, size))
+        metafunc.parametrize(("fabric", "message_sizes"), params, indirect=["fabric"])
+        return
+
+    # no message size param, just add fabric parametrization
+    if wants_fabric:
+        metafunc.parametrize("fabric", fabric_marker.kwargs["params"], indirect=True)
+        return
+
+    # no fabric param, just add message sizes parametrization based on test type
+    sizes = []
+    for k, kwarg_sizes in sizes_marker.kwargs.items():
+        if test_type in k:
+            sizes.extend(kwarg_sizes)
+    if not sizes:
+        raise ValueError(
+            f"@pytest.mark.message_sizes on {metafunc.definition.nodeid} has "
+            f"no kwarg naming {test_type!r} (have {sorted(sizes_marker.kwargs)})"
+        )
+    metafunc.parametrize("message_sizes", sizes)
+
+
+def pytest_generate_tests(metafunc):
+    """
+    Derive parametrization from markers
+      - @pytest.mark.pr_ci
+      - @pytest.mark.fabric(params=[...])
+      - @pytest.mark.message_sizes(<test_type>_<fabric>=..., ...)
+    """
+    # get all markers
+    fabric_marker = next(metafunc.definition.iter_markers("fabric"), None)
+    sizes_marker  = next(metafunc.definition.iter_markers("message_sizes"), None)
+
+    # find out the test type running from markers (currently pr_ci or default)
+    test_markers = {m.name for m in metafunc.definition.iter_markers()}
+    test_type = get_test_type(test_markers, metafunc.config)
+
+    # generate parametrization based on found markers and test type
+    add_fabric_and_message_size_parametrization(metafunc, fabric_marker, sizes_marker, test_type)
 
 # The memory types for bi-directional tests.
 memory_type_list_bi_dir = [
@@ -67,42 +171,17 @@ def rma_bw_completion_semantic(cmdline_args, completion_semantic, rma_operation_
     return completion_semantic
 
 
-@pytest.fixture(scope="module", params=["r:0,4,64",
-                                        "r:4048,4,4148",
-                                        "r:8000,4,9000",
-                                        "r:17000,4,18000",
-                                        "r:0,4096,1048576"])
-def message_size(request):
-    return request.param
-
-
-@pytest.fixture(scope="module", params=["r:0,4,64",
-                                        "r:4048,4,4148",
-                                        "r:8000,4,9000",])
-def inject_message_size(request):
-    return request.param
-
-@pytest.fixture(scope="module", params=["r:0,4,32",
-                                        "r:0,1024,8192",])
-def direct_message_size(request):
-    return request.param
-
-# TODO: Include 0 byte test when we support 0 byte rma inject
-@pytest.fixture(scope="module", params=["r:1,4,32",
-                                        "r:1,1024,8192",])
-def direct_rma_size(request):
-    return request.param
-
-@pytest.fixture(scope="module", params=["efa", "efa-direct"])
+@pytest.fixture(scope="function")
 def fabric(request):
     return request.param
 
+
 @pytest.fixture(scope="function")
 def rma_fabric(cmdline_args, fabric):
-    if fabric == 'efa-direct' and (
-        not has_rdma(cmdline_args, 'read') or
-        not has_rdma(cmdline_args, 'write') or
-        not has_rdma(cmdline_args, 'writedata')
+    if fabric == "efa-direct" and (
+        not has_rdma(cmdline_args, "read")
+        or not has_rdma(cmdline_args, "write")
+        or not has_rdma(cmdline_args, "writedata")
     ):
         pytest.skip("FI_RMA is not supported. Skip rma tests on efa-direct.")
     return fabric

--- a/fabtests/pytest/efa/efa_common.py
+++ b/fabtests/pytest/efa/efa_common.py
@@ -2,10 +2,21 @@ import os
 import subprocess
 import functools
 import re
+import pytest
 from enum import IntEnum
 from collections import deque
 from common import SshConnectionError, is_ssh_connection_error, has_ssh_connection_err_msg, ClientServerTest
 from retrying import retry
+
+# EFA-specific message size lists for @pytest.mark.message_sizes decorator.
+# Generic (shared) size lists live in fabtests/pytest/common.py.
+DIRECT_SIZES = ["r:0,4,32", "r:0,1024,8192"]
+# RMA variant: starts at 1 because fabtests RMA benchmarks reject 0-byte.
+DIRECT_RMA_SIZES = ["r:1,4,32", "r:1,1024,8192"]
+REMOTE_EXIT_SIZES = [65536, 131072, 1048576]
+# Use the default behavior of the test, so pass None.
+DGRAM_DEFAULT = [None]
+DGRAM_PR_CI = ["l:16,128,8192"]
 
 
 @functools.lru_cache(2)

--- a/fabtests/pytest/efa/test_av.py
+++ b/fabtests/pytest/efa/test_av.py
@@ -1,6 +1,7 @@
 import pytest
 
 # This test skips efa-direct because it requests FI_TAGGED
+@pytest.mark.pr_ci
 @pytest.mark.functional
 def test_av_xfer(cmdline_args):
     from common import ClientServerTest

--- a/fabtests/pytest/efa/test_cq.py
+++ b/fabtests/pytest/efa/test_cq.py
@@ -3,6 +3,7 @@ from efa.efa_common import has_rdma
 
 # this test must be run in serial mode because it will open the maximal number
 # of cq that efa device can support
+@pytest.mark.pr_ci
 @pytest.mark.serial
 @pytest.mark.unit
 def test_cq(cmdline_args, fabric):
@@ -10,6 +11,7 @@ def test_cq(cmdline_args, fabric):
     test = UnitTest(cmdline_args, f"fi_cq_test -f {fabric}")
     test.run()
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 @pytest.mark.parametrize("operation_type", ["senddata", "writedata"])
 def test_cq_data(cmdline_args, operation_type, fabric):

--- a/fabtests/pytest/efa/test_cq.py
+++ b/fabtests/pytest/efa/test_cq.py
@@ -5,6 +5,7 @@ from efa.efa_common import has_rdma
 # of cq that efa device can support
 @pytest.mark.pr_ci
 @pytest.mark.serial
+@pytest.mark.fabric(params=["efa", "efa-direct"])
 @pytest.mark.unit
 def test_cq(cmdline_args, fabric):
     from common import UnitTest
@@ -13,6 +14,7 @@ def test_cq(cmdline_args, fabric):
 
 @pytest.mark.pr_ci
 @pytest.mark.functional
+@pytest.mark.fabric(params=["efa", "efa-direct"])
 @pytest.mark.parametrize("operation_type", ["senddata", "writedata"])
 def test_cq_data(cmdline_args, operation_type, fabric):
     from common import ClientServerTest

--- a/fabtests/pytest/efa/test_dgram.py
+++ b/fabtests/pytest/efa/test_dgram.py
@@ -3,6 +3,7 @@ import copy
 from efa.efa_common import efa_retrieve_hw_counter_value
 
 # this test must be run in serial mode because it check hw counter
+@pytest.mark.pr_ci
 @pytest.mark.serial
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),

--- a/fabtests/pytest/efa/test_dgram.py
+++ b/fabtests/pytest/efa/test_dgram.py
@@ -1,14 +1,15 @@
 import pytest
 import copy
-from efa.efa_common import efa_retrieve_hw_counter_value
+from efa.efa_common import efa_retrieve_hw_counter_value, DGRAM_DEFAULT, DGRAM_PR_CI
 
 # this test must be run in serial mode because it check hw counter
 @pytest.mark.pr_ci
+@pytest.mark.message_sizes(default_efa=DGRAM_DEFAULT, pr_ci_efa=DGRAM_PR_CI)
 @pytest.mark.serial
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_dgram_pingpong(cmdline_args, iteration_type):
+def test_dgram_pingpong(cmdline_args, iteration_type, message_sizes):
     from common import ClientServerTest
 
     # dgram is unreliable, therefore it is expected that receiver does not always get all the messages
@@ -21,7 +22,7 @@ def test_dgram_pingpong(cmdline_args, iteration_type):
 
     # efa's dgram endpoint requires prefix therefore must always test with prefix mode on
     test = ClientServerTest(cmdline_args_copy, "fi_dgram_pingpong", iteration_type,
-                            prefix_type="with_prefix")
+                            prefix_type="with_prefix", message_size=message_sizes)
     test.run()
 
     client_tx_bytes_after_test = efa_retrieve_hw_counter_value(cmdline_args.client_id, "tx_bytes")

--- a/fabtests/pytest/efa/test_efa_device_selection.py
+++ b/fabtests/pytest/efa/test_efa_device_selection.py
@@ -7,6 +7,7 @@ from common import ClientServerTest
 # This test must be run in serial mode because it checks the hw counter
 @pytest.mark.serial
 @pytest.mark.functional
+@pytest.mark.fabric(params=["efa", "efa-direct"])
 @pytest.mark.parametrize("selection_approach", ["domain name", "environment"])
 def test_efa_device_selection(cmdline_args, fabric, selection_approach):
 
@@ -73,6 +74,7 @@ def test_efa_device_selection(cmdline_args, fabric, selection_approach):
 
 # Verify that fi_getinfo does not return any info objects when FI_EFA_IFACE is set to an invalid value
 @pytest.mark.functional
+@pytest.mark.fabric(params=["efa", "efa-direct"])
 def test_efa_device_selection_negative(cmdline_args, fabric):
     invalid_iface = "r"
 
@@ -84,6 +86,7 @@ def test_efa_device_selection_negative(cmdline_args, fabric):
 
 # Verify that fi_getinfo returns all NICs when FI_EFA_IFACE is set to all
 @pytest.mark.functional
+@pytest.mark.fabric(params=["efa", "efa-direct"])
 def test_efa_device_selection_all(cmdline_args, fabric):
     devices = get_efa_device_names(cmdline_args.server_id)
     assert len(devices) > 0, "No EFA devices found on server"
@@ -104,6 +107,7 @@ def test_efa_device_selection_all(cmdline_args, fabric):
 
 # Verify that fi_getinfo returns two NICs when FI_EFA_IFACE is set to two NICs separated by a comma
 @pytest.mark.functional
+@pytest.mark.fabric(params=["efa", "efa-direct"])
 def test_efa_device_selection_comma(cmdline_args, fabric):
     devices = get_efa_device_names(cmdline_args.server_id)
     assert len(devices) > 0, "No EFA devices found on server"

--- a/fabtests/pytest/efa/test_efa_info.py
+++ b/fabtests/pytest/efa/test_efa_info.py
@@ -2,16 +2,19 @@ import pytest
 from common import UnitTest
 from efa_common import efa_retrieve_gid
 
+@pytest.mark.pr_ci
 @pytest.mark.unit
 def test_efa_info(cmdline_args):
     test = UnitTest(cmdline_args, "fi_efa_info_test")
     test.run()
 
+@pytest.mark.pr_ci
 @pytest.mark.unit
 def test_efa_info_fabric(cmdline_args, fabric):
     test = UnitTest(cmdline_args, f"fi_efa_info_test -f {fabric}")
     test.run()
 
+@pytest.mark.pr_ci
 @pytest.mark.unit
 def test_comm_getinfo(cmdline_args, fabric):
     gid = efa_retrieve_gid(cmdline_args.server_id)

--- a/fabtests/pytest/efa/test_efa_info.py
+++ b/fabtests/pytest/efa/test_efa_info.py
@@ -9,12 +9,14 @@ def test_efa_info(cmdline_args):
     test.run()
 
 @pytest.mark.pr_ci
+@pytest.mark.fabric(params=["efa", "efa-direct"])
 @pytest.mark.unit
 def test_efa_info_fabric(cmdline_args, fabric):
     test = UnitTest(cmdline_args, f"fi_efa_info_test -f {fabric}")
     test.run()
 
 @pytest.mark.pr_ci
+@pytest.mark.fabric(params=["efa", "efa-direct"])
 @pytest.mark.unit
 def test_comm_getinfo(cmdline_args, fabric):
     gid = efa_retrieve_gid(cmdline_args.server_id)

--- a/fabtests/pytest/efa/test_efa_mmap.py
+++ b/fabtests/pytest/efa/test_efa_mmap.py
@@ -2,6 +2,7 @@ import pytest
 from common import UnitTest
 
 
+@pytest.mark.pr_ci
 @pytest.mark.unit
 def test_efa_mmap(cmdline_args):
     test = UnitTest(cmdline_args, "fi_efa_mmap_test")

--- a/fabtests/pytest/efa/test_efa_shm_addr.py
+++ b/fabtests/pytest/efa/test_efa_shm_addr.py
@@ -2,6 +2,7 @@ from common import MultinodeTest
 import pytest
 
 
+@pytest.mark.fabric(params=["efa", "efa-direct"])
 def test_efa_shm_addr(cmdline_args, fabric):
     server_id = cmdline_args.server_id
     client_id = cmdline_args.client_id

--- a/fabtests/pytest/efa/test_flood_peer.py
+++ b/fabtests/pytest/efa/test_flood_peer.py
@@ -1,5 +1,6 @@
 import pytest
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 def test_flood_peer(cmdline_args, fabric):
     from common import ClientServerTest

--- a/fabtests/pytest/efa/test_flood_peer.py
+++ b/fabtests/pytest/efa/test_flood_peer.py
@@ -1,6 +1,7 @@
 import pytest
 
 @pytest.mark.pr_ci
+@pytest.mark.fabric(params=["efa", "efa-direct"])
 @pytest.mark.functional
 def test_flood_peer(cmdline_args, fabric):
     from common import ClientServerTest

--- a/fabtests/pytest/efa/test_fork_support.py
+++ b/fabtests/pytest/efa/test_fork_support.py
@@ -2,6 +2,7 @@ import pytest
 
 
 @pytest.mark.functional
+@pytest.mark.fabric(params=["efa", "efa-direct"])
 @pytest.mark.parametrize("environment_variable", ["FI_EFA_FORK_SAFE", "RDMAV_FORK_SAFE"])
 def test_fork_support(cmdline_args, completion_semantic, environment_variable, fabric):
     from common import ClientServerTest

--- a/fabtests/pytest/efa/test_gda.py
+++ b/fabtests/pytest/efa/test_gda.py
@@ -3,6 +3,7 @@ import pytest
 from common import ClientServerTest, has_cuda
 
 
+@pytest.mark.pr_ci
 @pytest.mark.short
 @pytest.mark.functional
 @pytest.mark.cuda_memory

--- a/fabtests/pytest/efa/test_gda.py
+++ b/fabtests/pytest/efa/test_gda.py
@@ -1,13 +1,16 @@
 import os
 import pytest
 from common import ClientServerTest, has_cuda
+from efa.efa_common import DIRECT_SIZES
 
 
 @pytest.mark.pr_ci
+@pytest.mark.fabric(params=["efa-direct"])
+@pytest.mark.message_sizes(default_efa_direct=DIRECT_SIZES, pr_ci_efa_direct=DIRECT_SIZES)
 @pytest.mark.short
 @pytest.mark.functional
 @pytest.mark.cuda_memory
-def test_gda_send_recv(cmdline_args, direct_message_size, fabric):
+def test_gda_send_recv(cmdline_args, message_sizes, fabric):
     binpath = cmdline_args.binpath or ""
     if not os.path.exists(os.path.join(binpath, "fi_efa_gda")):
         pytest.skip("fi_efa_gda is not built")
@@ -18,11 +21,8 @@ def test_gda_send_recv(cmdline_args, direct_message_size, fabric):
     if not has_cuda(cmdline_args.client_id) or not has_cuda(cmdline_args.server_id):
         pytest.skip("Client and server both need a cuda device")
 
-    if fabric != "efa-direct":
-        pytest.skip("GDA only works for efa-direct fabric")
-
     test = ClientServerTest(cmdline_args, "fi_efa_gda",
-                            message_size=direct_message_size,
+                            message_size=message_sizes,
                             iteration_type="short",
                             memory_type="cuda_to_cuda",
                             fabric=fabric)

--- a/fabtests/pytest/efa/test_mr.py
+++ b/fabtests/pytest/efa/test_mr.py
@@ -4,12 +4,14 @@ import pytest
 from common import UnitTest, has_cuda, has_neuron
 
 
+@pytest.mark.pr_ci
 @pytest.mark.unit
 def test_mr_host(cmdline_args):
     test = UnitTest(cmdline_args, "fi_mr_test")
     test.run()
 
 
+@pytest.mark.pr_ci
 @pytest.mark.unit
 @pytest.mark.short
 def test_mr_hmem(cmdline_args, hmem_type, fabric):

--- a/fabtests/pytest/efa/test_mr.py
+++ b/fabtests/pytest/efa/test_mr.py
@@ -13,6 +13,7 @@ def test_mr_host(cmdline_args):
 
 @pytest.mark.pr_ci
 @pytest.mark.unit
+@pytest.mark.fabric(params=["efa", "efa-direct"])
 @pytest.mark.short
 def test_mr_hmem(cmdline_args, hmem_type, fabric):
     if hmem_type == "cuda" and not has_cuda(cmdline_args.server_id):
@@ -36,6 +37,7 @@ def test_mr_hmem(cmdline_args, hmem_type, fabric):
 
 
 @pytest.mark.unit
+@pytest.mark.fabric(params=["efa", "efa-direct"])
 @pytest.mark.short
 def test_efa_mr_hmem(cmdline_args, hmem_type, fabric):
     if hmem_type != "neuron":

--- a/fabtests/pytest/efa/test_multi_ep.py
+++ b/fabtests/pytest/efa/test_multi_ep.py
@@ -2,6 +2,7 @@ import pytest
 from common import ClientServerTest
 
 @pytest.mark.functional
+@pytest.mark.fabric(params=["efa", "efa-direct"])
 @pytest.mark.parametrize("shared_cq", [True, False])
 @pytest.mark.parametrize("shared_av", [True, False])
 def test_multi_ep(cmdline_args, shared_cq, shared_av, rma_fabric):

--- a/fabtests/pytest/efa/test_multi_recv.py
+++ b/fabtests/pytest/efa/test_multi_recv.py
@@ -1,5 +1,7 @@
 import pytest
 
+
+@pytest.mark.pr_ci
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])

--- a/fabtests/pytest/efa/test_multi_recv.py
+++ b/fabtests/pytest/efa/test_multi_recv.py
@@ -1,17 +1,18 @@
 import pytest
+from common import MULTI_RECV_SIZES
 
 
 @pytest.mark.pr_ci
+@pytest.mark.message_sizes(default_efa=MULTI_RECV_SIZES, pr_ci_efa=MULTI_RECV_SIZES)
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-@pytest.mark.parametrize("message_size", ["1024", "8192"])
 # efa-direct does not support multi-recv
-def test_multi_recv(cmdline_args, iteration_type, message_size):
+def test_multi_recv(cmdline_args, iteration_type, message_sizes):
     from common import ClientServerTest
     test = ClientServerTest(cmdline_args,
             "fi_multi_recv -e rdm",
             iteration_type,
-            message_size=message_size,
+            message_size=message_sizes,
             fabric="efa")
     test.run()

--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -5,6 +5,7 @@ import pytest
 import copy
 
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 def test_rdm_efa(cmdline_args, completion_semantic, fabric):
     from common import ClientServerTest
@@ -21,6 +22,7 @@ def test_rdm_bw_efa_msg_1M(cmdline_args, completion_semantic):
     test.run()
 
 # This test skips efa-direct because it requests FI_ORDER_SAS
+@pytest.mark.pr_ci
 @pytest.mark.functional
 def test_rdm_bw_functional_efa(cmdline_args, completion_semantic):
     from common import ClientServerTest
@@ -30,6 +32,7 @@ def test_rdm_bw_functional_efa(cmdline_args, completion_semantic):
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
+@pytest.mark.pr_ci
 def test_rdm_pingpong(cmdline_args, iteration_type, completion_semantic,
                       memory_type_bi_dir, completion_type, direct_message_size, fabric):
     command = "fi_rdm_pingpong"  + " " + perf_progress_model_cli
@@ -54,6 +57,7 @@ def test_rdm_pingpong_no_inject_range(cmdline_args, completion_semantic, inject_
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
+@pytest.mark.pr_ci
 def test_rdm_tagged_pingpong(cmdline_args, iteration_type, completion_semantic, memory_type_bi_dir, completion_type):
     command = "fi_rdm_tagged_pingpong"  + " " + perf_progress_model_cli
     efa_run_client_server_test(cmdline_args, command, iteration_type,
@@ -114,6 +118,7 @@ def test_rdm_tagged_bw_use_fi_more(cmdline_args, completion_semantic, memory_typ
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
+@pytest.mark.pr_ci
 def test_rdm_atomic(cmdline_args, iteration_type, completion_semantic, memory_type):
     from copy import copy
 
@@ -131,6 +136,7 @@ def test_rdm_atomic(cmdline_args, iteration_type, completion_semantic, memory_ty
                             memory_type=memory_type, timeout=1800, fabric="efa")
     test.run()
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 def test_rdm_tagged_peek(cmdline_args):
     from copy import copy
@@ -178,6 +184,7 @@ def test_rdm_bw_zcpy_recv_use_fi_more(cmdline_args, memory_type, zcpy_recv_max_m
     efa_run_client_server_test(cmdline_args_copy, f"fi_rdm_bw --use-fi-more --max-msg-size {zcpy_recv_max_msg_size}",
                                "short", "transmit_complete", memory_type, zcpy_recv_message_size, fabric="efa")
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 @pytest.mark.parametrize("comp_method", ["sread", "fd"])
 def test_rdm_pingpong_sread(cmdline_args, completion_semantic, memory_type_bi_dir,
@@ -212,6 +219,7 @@ def test_mr_exhaustion_rdm_pingpong(cmdline_args, completion_semantic):
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
+@pytest.mark.pr_ci
 def test_rdm_pingpong_no_mr_local(cmdline_args, iteration_type, completion_semantic,
                       memory_type_bi_dir, completion_type, mr_cache):
     command = "fi_rdm_pingpong -M mr_local"  + " " + perf_progress_model_cli
@@ -229,6 +237,7 @@ def test_rdm_pingpong_no_mr_local(cmdline_args, iteration_type, completion_seman
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
+@pytest.mark.pr_ci
 def test_rma_pingpong_no_mr_local(cmdline_args, iteration_type, completion_semantic,
                       memory_type_bi_dir, mr_cache):
     command = "fi_rma_pingpong -o writedata -M mr_local"  + " " + perf_progress_model_cli
@@ -243,6 +252,7 @@ def test_rma_pingpong_no_mr_local(cmdline_args, iteration_type, completion_seman
                                additional_env=additional_env)
 
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 @pytest.mark.serial
 @pytest.mark.parametrize("unexpected_path", [True, False])
@@ -266,6 +276,7 @@ def test_implicit_av(cmdline_args, unexpected_path, msg_size):
     efa_run_client_server_test(cmdline_args, test_cmd, "short",
                                "transmit_complete", "host_to_host", "all", fabric="efa")
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 @pytest.mark.serial
 # TODO: Add test with larger message size that uses the long read protocol after

--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -5,6 +5,7 @@ import pytest
 import copy
 
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 def test_rdm_efa(cmdline_args, completion_semantic, fabric):
     from common import ClientServerTest
@@ -21,6 +22,7 @@ def test_rdm_bw_efa_msg_1M(cmdline_args, completion_semantic):
     test.run()
 
 # This test skips efa-direct because it requests FI_ORDER_SAS
+@pytest.mark.pr_ci
 @pytest.mark.functional
 def test_rdm_bw_functional_efa(cmdline_args, completion_semantic):
     from common import ClientServerTest
@@ -30,6 +32,7 @@ def test_rdm_bw_functional_efa(cmdline_args, completion_semantic):
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
+@pytest.mark.pr_ci
 def test_rdm_pingpong(cmdline_args, iteration_type, completion_semantic,
                       memory_type_bi_dir, completion_type, direct_message_size, fabric):
     command = "fi_rdm_pingpong"  + " " + perf_progress_model_cli
@@ -54,6 +57,7 @@ def test_rdm_pingpong_no_inject_range(cmdline_args, completion_semantic, inject_
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
+@pytest.mark.pr_ci
 def test_rdm_tagged_pingpong(cmdline_args, iteration_type, completion_semantic, memory_type_bi_dir, completion_type):
     command = "fi_rdm_tagged_pingpong"  + " " + perf_progress_model_cli
     efa_run_client_server_test(cmdline_args, command, iteration_type,
@@ -114,6 +118,7 @@ def test_rdm_tagged_bw_use_fi_more(cmdline_args, completion_semantic, memory_typ
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
+@pytest.mark.pr_ci
 def test_rdm_atomic(cmdline_args, iteration_type, completion_semantic, memory_type):
     from copy import copy
 
@@ -131,6 +136,7 @@ def test_rdm_atomic(cmdline_args, iteration_type, completion_semantic, memory_ty
                             memory_type=memory_type, timeout=1800, fabric="efa")
     test.run()
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 def test_rdm_tagged_peek(cmdline_args):
     from copy import copy
@@ -151,6 +157,7 @@ def test_rdm_pingpong_1G(cmdline_args, completion_semantic):
                                completion_semantic=completion_semantic, message_size=1073741824,
                                memory_type="host_to_host", warmup_iteration_type=0, fabric="efa")
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 @pytest.mark.parametrize("comp_method", ["sread", "fd"])
 def test_rdm_pingpong_sread(cmdline_args, completion_semantic, memory_type_bi_dir,
@@ -185,6 +192,7 @@ def test_mr_exhaustion_rdm_pingpong(cmdline_args, completion_semantic):
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
+@pytest.mark.pr_ci
 def test_rdm_pingpong_no_mr_local(cmdline_args, iteration_type, completion_semantic,
                       memory_type_bi_dir, completion_type, mr_cache):
     command = "fi_rdm_pingpong -M mr_local"  + " " + perf_progress_model_cli
@@ -202,6 +210,7 @@ def test_rdm_pingpong_no_mr_local(cmdline_args, iteration_type, completion_seman
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
+@pytest.mark.pr_ci
 def test_rma_pingpong_no_mr_local(cmdline_args, iteration_type, completion_semantic,
                       memory_type_bi_dir, mr_cache):
     command = "fi_rma_pingpong -o writedata -M mr_local"  + " " + perf_progress_model_cli
@@ -216,6 +225,7 @@ def test_rma_pingpong_no_mr_local(cmdline_args, iteration_type, completion_seman
                                additional_env=additional_env)
 
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 @pytest.mark.serial
 @pytest.mark.parametrize("unexpected_path", [True, False])
@@ -239,6 +249,7 @@ def test_implicit_av(cmdline_args, unexpected_path, msg_size):
     efa_run_client_server_test(cmdline_args, test_cmd, "short",
                                "transmit_complete", "host_to_host", "all", fabric="efa")
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 @pytest.mark.serial
 # TODO: Add test with larger message size that uses the long read protocol after

--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -1,11 +1,13 @@
-from efa.efa_common import efa_run_client_server_test
-from common import perf_progress_model_cli
+from efa.efa_common import efa_run_client_server_test, DIRECT_SIZES
+from common import (perf_progress_model_cli,
+                    PERF_SIZES, PERF_PR_CI, RANGE_SIZES, INJECT_SIZES)
 
 import pytest
 import copy
 
 
 @pytest.mark.pr_ci
+@pytest.mark.fabric(params=["efa", "efa-direct"])
 @pytest.mark.functional
 def test_rdm_efa(cmdline_args, completion_semantic, fabric):
     from common import ClientServerTest
@@ -29,65 +31,77 @@ def test_rdm_bw_functional_efa(cmdline_args, completion_semantic):
     test = ClientServerTest(cmdline_args, "fi_flood -e rdm -v -T 1", completion_semantic=completion_semantic, fabric="efa")
     test.run()
 
+@pytest.mark.fabric(params=["efa", "efa-direct"])
+@pytest.mark.message_sizes(default_efa=PERF_SIZES, default_efa_direct=DIRECT_SIZES,
+                           pr_ci_efa=PERF_PR_CI, pr_ci_efa_direct=DIRECT_SIZES)
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
 @pytest.mark.pr_ci
 def test_rdm_pingpong(cmdline_args, iteration_type, completion_semantic,
-                      memory_type_bi_dir, completion_type, direct_message_size, fabric):
+                      memory_type_bi_dir, completion_type, fabric, message_sizes):
     command = "fi_rdm_pingpong"  + " " + perf_progress_model_cli
     efa_run_client_server_test(cmdline_args, command, iteration_type,
                                completion_semantic, memory_type_bi_dir,
-                               direct_message_size if fabric == "efa-direct" else "all",
+                               message_sizes,
                                completion_type=completion_type, fabric=fabric)
 
+@pytest.mark.fabric(params=["efa", "efa-direct"])
+@pytest.mark.message_sizes(default_efa=RANGE_SIZES, default_efa_direct=DIRECT_SIZES)
 @pytest.mark.functional
-def test_rdm_pingpong_range(cmdline_args, completion_semantic, memory_type_bi_dir, message_size, direct_message_size, fabric):
+def test_rdm_pingpong_range(cmdline_args, completion_semantic, memory_type_bi_dir, message_sizes, fabric):
     efa_run_client_server_test(cmdline_args, "fi_rdm_pingpong", "short",
                                completion_semantic, memory_type_bi_dir,
-                               direct_message_size if fabric == "efa-direct" else message_size, fabric=fabric)
+                               message_sizes, fabric=fabric)
 
+@pytest.mark.fabric(params=["efa", "efa-direct"])
+@pytest.mark.message_sizes(default_efa=INJECT_SIZES, default_efa_direct=DIRECT_SIZES)
 @pytest.mark.functional
-def test_rdm_pingpong_no_inject_range(cmdline_args, completion_semantic, inject_message_size, direct_message_size, fabric):
+def test_rdm_pingpong_no_inject_range(cmdline_args, completion_semantic, message_sizes, fabric):
     efa_run_client_server_test(cmdline_args, "fi_rdm_pingpong -j 0", "short",
                                completion_semantic, "host_to_host",
-                               direct_message_size if fabric == "efa-direct" else inject_message_size, fabric=fabric)
+                               message_sizes, fabric=fabric)
 
 # efa-direct does not support tagged
+@pytest.mark.message_sizes(default_efa=PERF_SIZES, pr_ci_efa=PERF_PR_CI)
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
 @pytest.mark.pr_ci
-def test_rdm_tagged_pingpong(cmdline_args, iteration_type, completion_semantic, memory_type_bi_dir, completion_type):
+def test_rdm_tagged_pingpong(cmdline_args, iteration_type, completion_semantic, memory_type_bi_dir, completion_type, message_sizes):
     command = "fi_rdm_tagged_pingpong"  + " " + perf_progress_model_cli
     efa_run_client_server_test(cmdline_args, command, iteration_type,
-                               completion_semantic, memory_type_bi_dir, "all", completion_type=completion_type,
+                               completion_semantic, memory_type_bi_dir, message_sizes, completion_type=completion_type,
                                fabric="efa")
 
+@pytest.mark.message_sizes(default_efa=RANGE_SIZES)
 @pytest.mark.functional
-def test_rdm_tagged_pingpong_range(cmdline_args, completion_semantic, memory_type_bi_dir, message_size):
+def test_rdm_tagged_pingpong_range(cmdline_args, completion_semantic, memory_type_bi_dir, message_sizes):
     efa_run_client_server_test(cmdline_args, "fi_rdm_tagged_pingpong", "short",
-                               completion_semantic, memory_type_bi_dir, message_size,
+                               completion_semantic, memory_type_bi_dir, message_sizes,
                                fabric="efa")
 
+@pytest.mark.message_sizes(default_efa=PERF_SIZES)
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rdm_tagged_bw(cmdline_args, iteration_type, completion_semantic, memory_type, completion_type):
+def test_rdm_tagged_bw(cmdline_args, iteration_type, completion_semantic, memory_type, completion_type, message_sizes):
     command = "fi_rdm_tagged_bw"  + " " + perf_progress_model_cli
     efa_run_client_server_test(cmdline_args, command, iteration_type,
-                               completion_semantic, memory_type, "all", completion_type=completion_type,
+                               completion_semantic, memory_type, message_sizes, completion_type=completion_type,
                                fabric="efa")
 
+@pytest.mark.message_sizes(default_efa=RANGE_SIZES)
 @pytest.mark.functional
-def test_rdm_tagged_bw_range(cmdline_args, completion_semantic, memory_type, message_size):
+def test_rdm_tagged_bw_range(cmdline_args, completion_semantic, memory_type, message_sizes):
     efa_run_client_server_test(cmdline_args, "fi_rdm_tagged_bw", "short",
-                               completion_semantic, memory_type, message_size, fabric="efa")
+                               completion_semantic, memory_type, message_sizes, fabric="efa")
 
+@pytest.mark.message_sizes(default_efa=INJECT_SIZES)
 @pytest.mark.functional
-def test_rdm_tagged_bw_no_inject_range(cmdline_args, completion_semantic, inject_message_size):
+def test_rdm_tagged_bw_no_inject_range(cmdline_args, completion_semantic, message_sizes):
     efa_run_client_server_test(cmdline_args, "fi_rdm_tagged_bw -j 0", "short",
-                               completion_semantic, "host_to_host", inject_message_size, fabric="efa")
+                               completion_semantic, "host_to_host", message_sizes, fabric="efa")
 
 # Testing both power-2 and non-power-2 sizes
 @pytest.mark.functional
@@ -109,10 +123,11 @@ def test_rdm_tagged_bw_small_recv_window(cmdline_args, completion_semantic, memo
                                completion_semantic, memory_type, "all", completion_type=completion_type,
                                fabric="efa")
 
+@pytest.mark.message_sizes(default_efa=RANGE_SIZES)
 @pytest.mark.functional
-def test_rdm_tagged_bw_use_fi_more(cmdline_args, completion_semantic, memory_type, message_size):
+def test_rdm_tagged_bw_use_fi_more(cmdline_args, completion_semantic, memory_type, message_sizes):
     efa_run_client_server_test(cmdline_args, "fi_rdm_tagged_bw --use-fi-more",
-                               "short", completion_semantic, memory_type, message_size, fabric="efa")
+                               "short", completion_semantic, memory_type, message_sizes, fabric="efa")
 
 # efa-direct does not support atomic
 @pytest.mark.parametrize("iteration_type",
@@ -157,11 +172,12 @@ def test_rdm_pingpong_1G(cmdline_args, completion_semantic):
                                completion_semantic=completion_semantic, message_size=1073741824,
                                memory_type="host_to_host", warmup_iteration_type=0, fabric="efa")
 
-@pytest.mark.pr_ci
+@pytest.mark.fabric(params=["efa", "efa-direct"])
+@pytest.mark.message_sizes(default_efa=PERF_SIZES, default_efa_direct=DIRECT_SIZES)
 @pytest.mark.functional
 @pytest.mark.parametrize("comp_method", ["sread", "fd"])
 def test_rdm_pingpong_sread(cmdline_args, completion_semantic, memory_type_bi_dir,
-                            direct_message_size, support_sread, comp_method, fabric):
+                            support_sread, comp_method, fabric, message_sizes):
     if not support_sread:
         pytest.skip("sread not supported by efa device.")
     additional_env = ''
@@ -171,9 +187,8 @@ def test_rdm_pingpong_sread(cmdline_args, completion_semantic, memory_type_bi_di
         additional_env = "FI_EFA_ENABLE_SHM_TRANSFER=0"
     efa_run_client_server_test(cmdline_args, f"fi_rdm_pingpong -c {comp_method}", "short",
                                completion_semantic, memory_type_bi_dir,
-                               direct_message_size if fabric == "efa-direct" else "all",
+                               message_sizes,
                                fabric=fabric, additional_env=additional_env)
-
 
 # These tests skip efa-direct because efa-direct does not
 # do memory registrations on behalf of the application
@@ -188,13 +203,14 @@ def test_mr_exhaustion_rdm_pingpong(cmdline_args, completion_semantic):
                                completion_semantic, "host_to_host", "all", timeout=1000,
                                fabric="efa")
 
+@pytest.mark.message_sizes(default_efa=PERF_SIZES, pr_ci_efa=PERF_PR_CI)
 @pytest.mark.parametrize("mr_cache", [True, False])
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
 @pytest.mark.pr_ci
 def test_rdm_pingpong_no_mr_local(cmdline_args, iteration_type, completion_semantic,
-                      memory_type_bi_dir, completion_type, mr_cache):
+                      memory_type_bi_dir, completion_type, mr_cache, message_sizes):
     command = "fi_rdm_pingpong -M mr_local"  + " " + perf_progress_model_cli
 
     additional_env = ''
@@ -202,17 +218,18 @@ def test_rdm_pingpong_no_mr_local(cmdline_args, iteration_type, completion_seman
         additional_env = 'FI_EFA_MR_CACHE_ENABLE=0'
 
     efa_run_client_server_test(cmdline_args, command, iteration_type,
-                               completion_semantic, memory_type_bi_dir, "all",
+                               completion_semantic, memory_type_bi_dir, message_sizes,
                                completion_type=completion_type, fabric="efa",
                                additional_env=additional_env)
 
+@pytest.mark.message_sizes(default_efa=PERF_SIZES, pr_ci_efa=PERF_PR_CI)
 @pytest.mark.parametrize("mr_cache", [True, False])
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
 @pytest.mark.pr_ci
 def test_rma_pingpong_no_mr_local(cmdline_args, iteration_type, completion_semantic,
-                      memory_type_bi_dir, mr_cache):
+                      memory_type_bi_dir, mr_cache, message_sizes):
     command = "fi_rma_pingpong -o writedata -M mr_local"  + " " + perf_progress_model_cli
 
     additional_env = ''
@@ -220,7 +237,7 @@ def test_rma_pingpong_no_mr_local(cmdline_args, iteration_type, completion_seman
         additional_env = 'FI_EFA_MR_CACHE_ENABLE=0'
 
     efa_run_client_server_test(cmdline_args, command, iteration_type,
-                               completion_semantic, memory_type_bi_dir, "all",
+                               completion_semantic, memory_type_bi_dir, message_sizes,
                                completion_type="queue", fabric="efa",
                                additional_env=additional_env)
 

--- a/fabtests/pytest/efa/test_remote_exit_early.py
+++ b/fabtests/pytest/efa/test_remote_exit_early.py
@@ -8,24 +8,28 @@ def remote_exit_early_message_size(request):
     # 1M use runtread or longread if rdma read is available
     return request.param
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 def test_remote_exit_early_post_send(cmdline_args, remote_exit_early_message_size):
     test = ClientServerTest(cmdline_args, "fi_efa_rdm_remote_exit_early",
                             message_size=remote_exit_early_message_size)
     test.run()
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 def test_remote_exit_early_post_tagged(cmdline_args, remote_exit_early_message_size):
     test = ClientServerTest(cmdline_args, "fi_efa_rdm_remote_exit_early -o tagged",
                             message_size=remote_exit_early_message_size)
     test.run()
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 def test_remote_exit_early_post_writedata(cmdline_args, remote_exit_early_message_size):
     test = ClientServerTest(cmdline_args, "fi_efa_rdm_remote_exit_early -o writedata",
                             message_size=remote_exit_early_message_size)
     test.run()
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 def test_remote_exit_early_post_rx(cmdline_args, remote_exit_early_message_size):
     test = ClientServerTest(cmdline_args,

--- a/fabtests/pytest/efa/test_remote_exit_early.py
+++ b/fabtests/pytest/efa/test_remote_exit_early.py
@@ -1,38 +1,40 @@
 import pytest
 from common import ClientServerTest
+from efa.efa_common import REMOTE_EXIT_SIZES
 
-@pytest.fixture(params=[65536, 131072, 1048576])
-def remote_exit_early_message_size(request):
-    # 64K use medium
-    # 128K use long CTS
-    # 1M use runtread or longread if rdma read is available
-    return request.param
+# 64K use medium
+# 128K use long CTS
+# 1M use runtread or longread if rdma read is available
 
 @pytest.mark.pr_ci
+@pytest.mark.message_sizes(default_efa=REMOTE_EXIT_SIZES, pr_ci_efa=REMOTE_EXIT_SIZES)
 @pytest.mark.functional
-def test_remote_exit_early_post_send(cmdline_args, remote_exit_early_message_size):
+def test_remote_exit_early_post_send(cmdline_args, message_sizes):
     test = ClientServerTest(cmdline_args, "fi_efa_rdm_remote_exit_early",
-                            message_size=remote_exit_early_message_size)
+                            message_size=message_sizes)
     test.run()
 
 @pytest.mark.pr_ci
+@pytest.mark.message_sizes(default_efa=REMOTE_EXIT_SIZES, pr_ci_efa=REMOTE_EXIT_SIZES)
 @pytest.mark.functional
-def test_remote_exit_early_post_tagged(cmdline_args, remote_exit_early_message_size):
+def test_remote_exit_early_post_tagged(cmdline_args, message_sizes):
     test = ClientServerTest(cmdline_args, "fi_efa_rdm_remote_exit_early -o tagged",
-                            message_size=remote_exit_early_message_size)
+                            message_size=message_sizes)
     test.run()
 
 @pytest.mark.pr_ci
+@pytest.mark.message_sizes(default_efa=REMOTE_EXIT_SIZES, pr_ci_efa=REMOTE_EXIT_SIZES)
 @pytest.mark.functional
-def test_remote_exit_early_post_writedata(cmdline_args, remote_exit_early_message_size):
+def test_remote_exit_early_post_writedata(cmdline_args, message_sizes):
     test = ClientServerTest(cmdline_args, "fi_efa_rdm_remote_exit_early -o writedata",
-                            message_size=remote_exit_early_message_size)
+                            message_size=message_sizes)
     test.run()
 
 @pytest.mark.pr_ci
+@pytest.mark.message_sizes(default_efa=REMOTE_EXIT_SIZES, pr_ci_efa=REMOTE_EXIT_SIZES)
 @pytest.mark.functional
-def test_remote_exit_early_post_rx(cmdline_args, remote_exit_early_message_size):
+def test_remote_exit_early_post_rx(cmdline_args, message_sizes):
     test = ClientServerTest(cmdline_args,
                             "fi_efa_rdm_remote_exit_early --post-rx",
-                            message_size=remote_exit_early_message_size)
+                            message_size=message_sizes)
     test.run()

--- a/fabtests/pytest/efa/test_rma_bw.py
+++ b/fabtests/pytest/efa/test_rma_bw.py
@@ -4,6 +4,7 @@ import pytest
 import copy
 
 
+@pytest.mark.pr_ci
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])

--- a/fabtests/pytest/efa/test_rma_bw.py
+++ b/fabtests/pytest/efa/test_rma_bw.py
@@ -1,24 +1,30 @@
-from efa.efa_common import efa_run_client_server_test
-from common import perf_progress_model_cli, ClientServerTest
+from efa.efa_common import efa_run_client_server_test, DIRECT_RMA_SIZES
+from common import (perf_progress_model_cli, ClientServerTest,
+                    PERF_SIZES, PERF_PR_CI, RANGE_SIZES, INJECT_SIZES)
 import pytest
 import copy
 
 
 @pytest.mark.pr_ci
+@pytest.mark.fabric(params=["efa", "efa-direct"])
+@pytest.mark.message_sizes(default_efa=PERF_SIZES, default_efa_direct=DIRECT_RMA_SIZES,
+                           pr_ci_efa=PERF_PR_CI, pr_ci_efa_direct=DIRECT_RMA_SIZES)
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rma_bw(cmdline_args, iteration_type, rma_operation_type, rma_bw_completion_semantic, rma_bw_memory_type, direct_rma_size, rma_fabric, rx_cq_data_cli):
+def test_rma_bw(cmdline_args, iteration_type, rma_operation_type, rma_bw_completion_semantic, rma_bw_memory_type, rma_fabric, rx_cq_data_cli, message_sizes):
     command = "fi_rma_bw -e rdm"
     command = command + " -o " + rma_operation_type + " " + perf_progress_model_cli + rx_cq_data_cli
     # rma_bw test with data verification takes longer to finish
     timeout = max(540, cmdline_args.timeout)
     efa_run_client_server_test(cmdline_args, command, iteration_type, rma_bw_completion_semantic,
-                               rma_bw_memory_type, direct_rma_size if rma_fabric == "efa-direct" else "all",
+                               rma_bw_memory_type, message_sizes,
                                timeout=timeout, fabric=rma_fabric)
 
+@pytest.mark.fabric(params=["efa", "efa-direct"])
+@pytest.mark.message_sizes(default_efa=PERF_SIZES, default_efa_direct=DIRECT_RMA_SIZES)
 @pytest.mark.parametrize("env_vars", [["FI_EFA_TX_SIZE=64"], ["FI_EFA_RX_SIZE=64"], ["FI_EFA_TX_SIZE=64", "FI_EFA_RX_SIZE=64"]])
-def test_rma_bw_small_tx_rx(cmdline_args, rma_operation_type, rma_bw_completion_semantic, rma_bw_memory_type, env_vars, direct_rma_size, rma_fabric):
+def test_rma_bw_small_tx_rx(cmdline_args, rma_operation_type, rma_bw_completion_semantic, rma_bw_memory_type, env_vars, rma_fabric, message_sizes):
     cmdline_args_copy = copy.copy(cmdline_args)
     for env_var in env_vars:
         cmdline_args_copy.append_environ(env_var)
@@ -28,34 +34,37 @@ def test_rma_bw_small_tx_rx(cmdline_args, rma_operation_type, rma_bw_completion_
     # rma_bw test with data verification takes longer to finish
     timeout = max(540, cmdline_args_copy.timeout)
     efa_run_client_server_test(cmdline_args_copy, command, "short", rma_bw_completion_semantic,
-                               rma_bw_memory_type, direct_rma_size if rma_fabric == "efa-direct" else "all",
+                               rma_bw_memory_type, message_sizes,
                                timeout=timeout, fabric=rma_fabric)
 
+@pytest.mark.fabric(params=["efa", "efa-direct"])
+@pytest.mark.message_sizes(default_efa=RANGE_SIZES, default_efa_direct=DIRECT_RMA_SIZES)
 @pytest.mark.functional
-def test_rma_bw_range(cmdline_args, rma_operation_type, rma_bw_completion_semantic, message_size, direct_rma_size, rma_bw_memory_type, rma_fabric):
+def test_rma_bw_range(cmdline_args, rma_operation_type, rma_bw_completion_semantic, message_sizes, rma_bw_memory_type, rma_fabric):
     command = "fi_rma_bw -e rdm"
     command = command + " -o " + rma_operation_type
     # rma_bw test with data verification takes longer to finish
     timeout = max(1080, cmdline_args.timeout)
     efa_run_client_server_test(cmdline_args, command, "short", rma_bw_completion_semantic,
-                               rma_bw_memory_type, direct_rma_size if rma_fabric == "efa-direct" else message_size,
+                               rma_bw_memory_type, message_sizes,
                                timeout=timeout, fabric=rma_fabric)
 
 
+@pytest.mark.fabric(params=["efa"])
+@pytest.mark.message_sizes(default_efa=INJECT_SIZES)
 @pytest.mark.functional
-def test_rma_bw_range_no_inject(cmdline_args, rma_operation_type, rma_bw_completion_semantic, inject_message_size, rma_fabric):
-    if rma_fabric == "efa-direct":
-        pytest.skip("Duplicate test. efa-direct has inject size = 0")
+def test_rma_bw_range_no_inject(cmdline_args, rma_operation_type, rma_bw_completion_semantic, message_sizes, rma_fabric):
     command = "fi_rma_bw -e rdm -j 0"
     command = command + " -o " + rma_operation_type
     # rma_bw test with data verification takes longer to finish
     timeout = max(540, cmdline_args.timeout)
     efa_run_client_server_test(cmdline_args, command, "short", rma_bw_completion_semantic,
-                                "host_to_host", inject_message_size, timeout=timeout, fabric=rma_fabric)
+                                "host_to_host", message_sizes, timeout=timeout, fabric=rma_fabric)
 
 
 # This test is run in serial mode because it takes a lot of memory
 @pytest.mark.serial
+@pytest.mark.fabric(params=["efa", "efa-direct"])
 @pytest.mark.functional
 @pytest.mark.parametrize("operation_type", ["read", "write", "writedata"])
 def test_rma_bw_1G(cmdline_args, operation_type, rma_bw_completion_semantic, rma_fabric):
@@ -78,6 +87,7 @@ def test_rma_bw_1G(cmdline_args, operation_type, rma_bw_completion_semantic, rma
 
 
 @pytest.mark.serial
+@pytest.mark.fabric(params=["efa", "efa-direct"])
 @pytest.mark.functional
 @pytest.mark.parametrize("operation_type", ["read", "write", "writedata"])
 def test_rma_bw_large(cmdline_args, operation_type, rma_bw_completion_semantic, rma_fabric):
@@ -91,27 +101,32 @@ def test_rma_bw_large(cmdline_args, operation_type, rma_bw_completion_semantic, 
                                completion_semantic=rma_bw_completion_semantic, message_size=67108864,
                                memory_type="host_to_host", warmup_iteration_type=0, timeout=timeout, fabric=rma_fabric)
 
+@pytest.mark.fabric(params=["efa", "efa-direct"])
+@pytest.mark.message_sizes(default_efa=INJECT_SIZES, default_efa_direct=DIRECT_RMA_SIZES)
 @pytest.mark.functional
 @pytest.mark.parametrize("operation_type", ["writedata", "write"])
 @pytest.mark.parametrize("iteration_type",
                          ["5", # smaller than max batch wqe cnt (16)
                           "48", # larger than max batch wqe cnt
                           "128"]) # larger than window size (64)
-def test_rma_bw_use_fi_more(cmdline_args, operation_type, iteration_type, rma_bw_completion_semantic, inject_message_size, direct_rma_size, rma_fabric):
+def test_rma_bw_use_fi_more(cmdline_args, operation_type, iteration_type, rma_bw_completion_semantic, message_sizes, rma_fabric):
     command = "fi_rma_bw -e rdm -j 0 --use-fi-more"
     command = command + " -o " + operation_type
     # rma_bw test with data verification takes longer to finish
     timeout = max(540, cmdline_args.timeout)
     efa_run_client_server_test(cmdline_args, command, iteration_type, rma_bw_completion_semantic,
-                               "host_to_host", direct_rma_size if rma_fabric == "efa-direct" else inject_message_size,
+                               "host_to_host", message_sizes,
                                timeout=timeout, fabric=rma_fabric)
 
 
+@pytest.mark.fabric(params=["efa", "efa-direct"])
+@pytest.mark.message_sizes(default_efa=PERF_SIZES, default_efa_direct=DIRECT_RMA_SIZES,
+                           pr_ci_efa=PERF_PR_CI, pr_ci_efa_direct=DIRECT_RMA_SIZES)
 @pytest.mark.functional
 @pytest.mark.parametrize("comp_method", ["sread", "fd"])
 def test_rma_bw_sread(cmdline_args, rma_operation_type, rma_bw_completion_semantic,
-                      direct_rma_size, rma_bw_memory_type, support_sread, comp_method,
-                      rma_fabric):
+                      rma_bw_memory_type, support_sread, comp_method,
+                      rma_fabric, message_sizes):
     if not support_sread:
         pytest.skip("sread not supported by efa device.")
     additional_env = ''
@@ -124,5 +139,5 @@ def test_rma_bw_sread(cmdline_args, rma_operation_type, rma_bw_completion_semant
     # rma_bw test with data verification takes longer to finish
     timeout = max(1080, cmdline_args.timeout)
     efa_run_client_server_test(cmdline_args, command, "short", rma_bw_completion_semantic,
-                               rma_bw_memory_type, direct_rma_size if rma_fabric == "efa-direct" else "all",
+                               rma_bw_memory_type, message_sizes,
                                timeout=timeout, fabric=rma_fabric, additional_env=additional_env)

--- a/fabtests/pytest/efa/test_rma_pingpong.py
+++ b/fabtests/pytest/efa/test_rma_pingpong.py
@@ -10,6 +10,7 @@ def rma_pingpong_message_size(request):
     return request.param
 
 
+@pytest.mark.pr_ci
 @pytest.mark.parametrize("operation_type", ["writedata"])
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),

--- a/fabtests/pytest/efa/test_rma_pingpong.py
+++ b/fabtests/pytest/efa/test_rma_pingpong.py
@@ -1,43 +1,41 @@
-from efa.efa_common import efa_run_client_server_test
-from common import perf_progress_model_cli
+from efa.efa_common import efa_run_client_server_test, DIRECT_RMA_SIZES
+from common import perf_progress_model_cli, PERF_SIZES, PERF_PR_CI, RMA_PINGPONG_SIZES
 import pytest
 
 
-@pytest.fixture(params=["r:4048,4,4148",
-                        "r:8000,4,9000",
-                        "r:17000,4,18000"])
-def rma_pingpong_message_size(request):
-    return request.param
-
-
 @pytest.mark.pr_ci
+@pytest.mark.fabric(params=["efa", "efa-direct"])
+@pytest.mark.message_sizes(default_efa=PERF_SIZES, default_efa_direct=DIRECT_RMA_SIZES,
+                           pr_ci_efa=PERF_PR_CI, pr_ci_efa_direct=DIRECT_RMA_SIZES)
 @pytest.mark.parametrize("operation_type", ["writedata"])
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rma_pingpong(cmdline_args, iteration_type, operation_type, rma_bw_completion_semantic, memory_type_bi_dir, direct_rma_size, rma_fabric):
+def test_rma_pingpong(cmdline_args, iteration_type, operation_type, rma_bw_completion_semantic, memory_type_bi_dir, rma_fabric, message_sizes):
     command = "fi_rma_pingpong -e rdm"
     command = command + " -o " + operation_type + " " + perf_progress_model_cli
     efa_run_client_server_test(cmdline_args, command, iteration_type, rma_bw_completion_semantic,
-                                memory_type_bi_dir, direct_rma_size if rma_fabric == "efa-direct" else "all", fabric=rma_fabric)
+                                memory_type_bi_dir, message_sizes, fabric=rma_fabric)
 
 
+@pytest.mark.fabric(params=["efa", "efa-direct"])
+@pytest.mark.message_sizes(default_efa=RMA_PINGPONG_SIZES, default_efa_direct=DIRECT_RMA_SIZES)
 @pytest.mark.functional
 @pytest.mark.parametrize("operation_type", ["writedata"])
-def test_rma_pingpong_range(cmdline_args, operation_type, rma_bw_completion_semantic, rma_pingpong_message_size,
-                            direct_rma_size, memory_type_bi_dir, rma_fabric):
+def test_rma_pingpong_range(cmdline_args, operation_type, rma_bw_completion_semantic, message_sizes,
+                            memory_type_bi_dir, rma_fabric):
     command = "fi_rma_pingpong -e rdm"
     command = command + " -o " + operation_type
     efa_run_client_server_test(cmdline_args, command, "short", rma_bw_completion_semantic,
-                               memory_type_bi_dir, direct_rma_size if rma_fabric == "efa-direct" else rma_pingpong_message_size, fabric=rma_fabric)
+                               memory_type_bi_dir, message_sizes, fabric=rma_fabric)
 
 
+@pytest.mark.fabric(params=["efa"])
+@pytest.mark.message_sizes(default_efa=RMA_PINGPONG_SIZES)
 @pytest.mark.functional
 @pytest.mark.parametrize("operation_type", ["writedata"])
-def test_rma_pingpong_range_no_inject(cmdline_args, operation_type, rma_bw_completion_semantic, rma_pingpong_message_size, memory_type_bi_dir, rma_fabric):
-    if rma_fabric == "efa-direct":
-        pytest.skip("Duplicate test. efa-direct has inject size = 0")
+def test_rma_pingpong_range_no_inject(cmdline_args, operation_type, rma_bw_completion_semantic, message_sizes, memory_type_bi_dir, rma_fabric):
     command = "fi_rma_pingpong -e rdm -j 0"
     command = command + " -o " + operation_type
     efa_run_client_server_test(cmdline_args, command, "short", rma_bw_completion_semantic,
-                                memory_type_bi_dir, rma_pingpong_message_size, fabric=rma_fabric)
+                                memory_type_bi_dir, message_sizes, fabric=rma_fabric)

--- a/fabtests/pytest/efa/test_rnr.py
+++ b/fabtests/pytest/efa/test_rnr.py
@@ -2,6 +2,7 @@ import pytest
 import copy
 
 @pytest.mark.functional
+@pytest.mark.fabric(params=["efa", "efa-direct"])
 def test_rnr_read_cq_error(cmdline_args, fabric):
     from common import ClientServerTest
 

--- a/fabtests/pytest/efa/test_runt.py
+++ b/fabtests/pytest/efa/test_runt.py
@@ -12,6 +12,7 @@ import pytest
     pytest.param("cuda_to_cuda", "gdrcopy", marks=pytest.mark.cuda_memory),
     pytest.param("cuda_to_cuda", "localread", marks=pytest.mark.cuda_memory),
     pytest.param("neuron_to_neuron", None, marks=pytest.mark.neuron_memory)])
+@pytest.mark.pr_ci
 def test_runt_read_functional(cmdline_args, memory_type, copy_method):
     """
     Verify runt reading protocol is working as expected by sending 1 message of 256 KB.

--- a/fabtests/pytest/efa/test_runt.py
+++ b/fabtests/pytest/efa/test_runt.py
@@ -12,6 +12,7 @@ import pytest
     pytest.param("cuda_to_cuda", "gdrcopy", marks=pytest.mark.cuda_memory),
     pytest.param("cuda_to_cuda", "localread", marks=pytest.mark.cuda_memory),
     pytest.param("neuron_to_neuron", None, marks=pytest.mark.neuron_memory)])
+@pytest.mark.pr_ci
 def test_runt_read_functional(cmdline_args, memory_type, copy_method):
     """
     Verify runt read protocol works with FI_OPT_EFA_HOMOGENEOUS_PEERS set,

--- a/fabtests/pytest/efa/test_setopt.py
+++ b/fabtests/pytest/efa/test_setopt.py
@@ -1,5 +1,6 @@
 import pytest
 
+@pytest.mark.pr_ci
 @pytest.mark.unit
 def test_setopt(cmdline_args, fabric):
     from common import UnitTest

--- a/fabtests/pytest/efa/test_setopt.py
+++ b/fabtests/pytest/efa/test_setopt.py
@@ -1,6 +1,7 @@
 import pytest
 
 @pytest.mark.pr_ci
+@pytest.mark.fabric(params=["efa", "efa-direct"])
 @pytest.mark.unit
 def test_setopt(cmdline_args, fabric):
     from common import UnitTest

--- a/fabtests/pytest/efa/test_unexpected_msg.py
+++ b/fabtests/pytest/efa/test_unexpected_msg.py
@@ -7,6 +7,7 @@ SHM_DEFAULT_RX_SIZE = 1024
 
 
 # This test skips efa-direct because it does not have unexpected message
+@pytest.mark.pr_ci
 @pytest.mark.functional
 @pytest.mark.parametrize("msg_size", [1, 512, 9000, 1048576]) # cover various switch points of shm/efa protocols
 @pytest.mark.parametrize("msg_count", [1, 1024, 2048]) # below and above shm's default rx size

--- a/fabtests/pytest/pytest.ini
+++ b/fabtests/pytest/pytest.ini
@@ -13,6 +13,7 @@ markers =
     rocr_memory: testing with ROCr device memory
     serial: test must be run in seria mode
     unstable: test is unstable and only run when the marker is specified.
+    pr_ci: test is included in the PR CI suite
 junit_suite_name = fabtests
 junit_logging = all
 junit_log_passing_tests = true

--- a/fabtests/pytest/pytest.ini
+++ b/fabtests/pytest/pytest.ini
@@ -14,6 +14,8 @@ markers =
     serial: test must be run in seria mode
     unstable: test is unstable and only run when the marker is specified.
     pr_ci: test is included in the PR CI suite
+    message_sizes: decorator specifying default and pr_ci message size lists
+    fabric: decorator declaring the set of libfabric fabric values a test runs on
 junit_suite_name = fabtests
 junit_logging = all
 junit_log_passing_tests = true

--- a/fabtests/pytest/shm/conftest.py
+++ b/fabtests/pytest/shm/conftest.py
@@ -1,18 +1,27 @@
 import pytest
 
+from common import test_selected_by_marker
+
+
+def pytest_generate_tests(metafunc):
+    if "message_sizes" not in metafunc.fixturenames:
+        return
+
+    marker = next(metafunc.definition.iter_markers("message_sizes"), None)
+    if marker is None:
+        return
+
+    test_markers = {m.name for m in metafunc.definition.iter_markers()}
+    is_pr_ci = test_selected_by_marker(metafunc.config, test_markers, "pr_ci")
+    default = marker.kwargs["default"]
+    pr_ci = marker.kwargs.get("pr_ci", default)
+
+    metafunc.parametrize("message_sizes", pr_ci if is_pr_ci else default)
+
 
 @pytest.fixture(scope="module", params=["host_to_host",
                                         pytest.param("host_to_cuda", marks=pytest.mark.cuda_memory),
                                         pytest.param("cuda_to_host", marks=pytest.mark.cuda_memory),
                                         pytest.param("cuda_to_cuda", marks=pytest.mark.cuda_memory)])
 def memory_type(request):
-    return request.param
-
-
-@pytest.fixture(scope="module", params=["r:0,4,64",
-                                        "r:4048,4,4148",
-                                        "r:8000,4,9000",
-                                        "r:17000,4,18000",
-                                        "r:0,4096,1048576"])
-def message_size(request):
     return request.param

--- a/fabtests/pytest/shm/test_rdm.py
+++ b/fabtests/pytest/shm/test_rdm.py
@@ -7,6 +7,7 @@ from shm.shm_common import shm_run_client_server_test
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
+@pytest.mark.pr_ci
 def test_rdm_pingpong(cmdline_args, iteration_type, completion_semantic, memory_type, completion_type):
     command = "fi_rdm_pingpong" + " " + perf_progress_model_cli
     shm_run_client_server_test(cmdline_args, command, iteration_type,
@@ -16,6 +17,7 @@ def test_rdm_pingpong(cmdline_args, iteration_type, completion_semantic, memory_
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
+@pytest.mark.pr_ci
 def test_rdm_tagged_pingpong(cmdline_args, iteration_type, completion_semantic, memory_type, completion_type):
     command = "fi_rdm_tagged_pingpong" + " " + perf_progress_model_cli
     shm_run_client_server_test(cmdline_args, command, iteration_type,
@@ -30,6 +32,7 @@ def test_rdm_tagged_bw(cmdline_args, iteration_type, completion_semantic, memory
     shm_run_client_server_test(cmdline_args, command, iteration_type,
                                completion_semantic, memory_type, completion_type=completion_type)
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 def test_rdm_tagged_peek(cmdline_args):
     from copy import copy

--- a/fabtests/pytest/shm/test_rma_bw.py
+++ b/fabtests/pytest/shm/test_rma_bw.py
@@ -1,25 +1,27 @@
 import pytest
 from shm.shm_common import shm_run_client_server_test
-from common import perf_progress_model_cli
+from common import perf_progress_model_cli, PERF_SIZES, PERF_PR_CI, RANGE_SIZES
 
 
 @pytest.mark.pr_ci
+@pytest.mark.message_sizes(default=PERF_SIZES, pr_ci=PERF_PR_CI)
 @pytest.mark.parametrize("operation_type", ["read", "writedata", "write"])
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rma_bw(cmdline_args, iteration_type, operation_type, completion_semantic, memory_type):
+def test_rma_bw(cmdline_args, iteration_type, operation_type, completion_semantic, memory_type, message_sizes):
     command = "fi_rma_bw -e rdm"
     command = command + " -o " + operation_type + " " + perf_progress_model_cli
     # rma_bw test with data verification takes longer to finish
     timeout = max(540, cmdline_args.timeout)
-    shm_run_client_server_test(cmdline_args, command, iteration_type, completion_semantic, memory_type, "all", timeout=timeout)
+    shm_run_client_server_test(cmdline_args, command, iteration_type, completion_semantic, memory_type, message_sizes, timeout=timeout)
 
+@pytest.mark.message_sizes(default=RANGE_SIZES)
 @pytest.mark.functional
 @pytest.mark.parametrize("operation_type", ["read", "writedata", "write"])
-def test_rma_bw_range(cmdline_args, operation_type, completion_semantic, message_size, memory_type):
+def test_rma_bw_range(cmdline_args, operation_type, completion_semantic, message_sizes, memory_type):
     command = "fi_rma_bw -e rdm"
     command = command + " -o " + operation_type
     # rma_bw test with data verification takes longer to finish
     timeout = max(540, cmdline_args.timeout)
-    shm_run_client_server_test(cmdline_args, command, "short", completion_semantic, memory_type, message_size, timeout=timeout)
+    shm_run_client_server_test(cmdline_args, command, "short", completion_semantic, memory_type, message_sizes, timeout=timeout)

--- a/fabtests/pytest/shm/test_rma_bw.py
+++ b/fabtests/pytest/shm/test_rma_bw.py
@@ -3,6 +3,7 @@ from shm.shm_common import shm_run_client_server_test
 from common import perf_progress_model_cli
 
 
+@pytest.mark.pr_ci
 @pytest.mark.parametrize("operation_type", ["read", "writedata", "write"])
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),

--- a/fabtests/pytest/shm/test_rma_pingpong.py
+++ b/fabtests/pytest/shm/test_rma_pingpong.py
@@ -10,6 +10,7 @@ def rma_pingpong_message_size(request):
     return request.param
 
 
+@pytest.mark.pr_ci
 @pytest.mark.parametrize("operation_type", ["writedata"])
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),

--- a/fabtests/pytest/shm/test_rma_pingpong.py
+++ b/fabtests/pytest/shm/test_rma_pingpong.py
@@ -1,28 +1,23 @@
 import pytest
 from shm.shm_common import shm_run_client_server_test
-from common import perf_progress_model_cli
-
-
-@pytest.fixture(params=["r:4048,4,4148",
-                        "r:8000,4,9000",
-                        "r:17000,4,18000"])
-def rma_pingpong_message_size(request):
-    return request.param
+from common import perf_progress_model_cli, PERF_SIZES, PERF_PR_CI, RMA_PINGPONG_SIZES
 
 
 @pytest.mark.pr_ci
+@pytest.mark.message_sizes(default=PERF_SIZES, pr_ci=PERF_PR_CI)
 @pytest.mark.parametrize("operation_type", ["writedata"])
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rma_pingpong(cmdline_args, iteration_type, operation_type, completion_semantic, memory_type):
+def test_rma_pingpong(cmdline_args, iteration_type, operation_type, completion_semantic, memory_type, message_sizes):
     command = "fi_rma_pingpong -e rdm"
     command = command + " -o " + operation_type + " " + perf_progress_model_cli
-    shm_run_client_server_test(cmdline_args, command, iteration_type, completion_semantic, memory_type, "all")
+    shm_run_client_server_test(cmdline_args, command, iteration_type, completion_semantic, memory_type, message_sizes)
 
+@pytest.mark.message_sizes(default=RMA_PINGPONG_SIZES)
 @pytest.mark.functional
 @pytest.mark.parametrize("operation_type", ["writedata"])
-def test_rma_pingpong_range(cmdline_args, operation_type, completion_semantic, rma_pingpong_message_size, memory_type):
+def test_rma_pingpong_range(cmdline_args, operation_type, completion_semantic, message_sizes, memory_type):
     command = "fi_rma_pingpong -e rdm"
     command = command + " -o " + operation_type
-    shm_run_client_server_test(cmdline_args, command, "short", completion_semantic, memory_type, rma_pingpong_message_size)
+    shm_run_client_server_test(cmdline_args, command, "short", completion_semantic, memory_type, message_sizes)

--- a/fabtests/pytest/shm/test_unexpected_msg.py
+++ b/fabtests/pytest/shm/test_unexpected_msg.py
@@ -5,6 +5,7 @@ SHM_DEFAULT_MAX_INJECT_SIZE = 4096
 SHM_DEFAULT_RX_SIZE = 1024
 
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 @pytest.mark.parametrize("msg_size", [1, 512, 9000]) # cover various switch points of shm protocols
 @pytest.mark.parametrize("msg_count", [1, 1024, 2048]) # below and above shm's default rx size


### PR DESCRIPTION
Replace 7 separate message size fixtures with a single decorator-based system using @pytest.mark.message_sizes(default=..., pr_ci=...).

Allows tests to specify a decorator with message sizes to be used for parametrization on a per-test basis. Parameters are specified before each test, on a per-test basis and selection logic for which parameter list to use is chosen in pytest_generate_tests.

This:
1) eliminates duplicate test runs caused by cross-product of unused message size fixtures
2) removes multiple message size fixtures in favor of one uniform approach
3) allows for logic-based parameter selection prior to test runs. This cuts down on the number of skips.
4) maintains flexibility and keeps current paradigm of having each test define its own parameters
5) adds PR message sizes to this framework to cover all EFA protocol paths