### PR TITLE
prov/cxi: Fix minor size check in RNR send_common

### DIFF
--- a/prov/cxi/src/cxip_msg_rnr.c
+++ b/prov/cxi/src/cxip_msg_rnr.c
@@ -1157,7 +1157,7 @@ cxip_send_common(struct cxip_txc *txc, uint32_t tclass, const void *buf,
 	}
 
 	/* Restrict outstanding success event requests to queue size */
-	if (cxip_txc_otx_reqs_get(txc) > txc->attr.size) {
+	if (cxip_txc_otx_reqs_get(txc) >= txc->attr.size) {
 		ret = -FI_EAGAIN;
 		goto free_req;
 	}


### PR DESCRIPTION
Correctly Check txc outstanding reqs based on txc
attr size in RNR send_common.