### PR TITLE
prov/efa: subtract prefix size in inject assertion for dgram

### DIFF
--- a/prov/efa/src/efa_msg.c
+++ b/prov/efa/src/efa_msg.c
@@ -369,7 +369,8 @@ static ssize_t efa_ep_msg_inject(struct fid_ep *ep_fid, const void *buf, size_t 
 	struct fi_msg msg;
 	struct iovec iov;
 
-	assert(len <= base_ep->domain->device->efa_attr.inline_buf_size);
+	/* For non-dgram endpoints, msg_prefix_size is 0 */
+	assert(len <= base_ep->domain->device->efa_attr.inline_buf_size + base_ep->info->ep_attr->msg_prefix_size);
 
 	EFA_SETUP_IOV(iov, buf, len);
 	EFA_SETUP_MSG(msg, &iov, NULL, 1, dest_addr, NULL, 0);
@@ -385,7 +386,8 @@ static ssize_t efa_ep_msg_injectdata(struct fid_ep *ep_fid, const void *buf,
 	struct fi_msg msg;
 	struct iovec iov;
 
-	assert(len <= base_ep->domain->device->efa_attr.inline_buf_size);
+	/* For non-dgram endpoints, msg_prefix_size is 0 */
+	assert(len <= base_ep->domain->device->efa_attr.inline_buf_size + base_ep->info->ep_attr->msg_prefix_size);
 
 	EFA_SETUP_IOV(iov, buf, len);
 	EFA_SETUP_MSG(msg, &iov, NULL, 1, dest_addr, NULL, data);


### PR DESCRIPTION
The assertions in efa_ep_msg_inject() and efa_ep_msg_injectdata() compared the raw len (including the dgram prefix) against inline_buf_size. For dgram endpoints with a 40-byte prefix, this caused a false assertion failure when the application called fi_inject with payload that fits in inline_buf_size but total len (payload + prefix) exceeds it.

Subtract msg_prefix_size before comparing, consistent with how efa_post_send() already handles it. For non-dgram endpoints, msg_prefix_size is 0 so behavior is unchanged.