### PR TITLE
prov/sm2: remove unnecessary dependency on shm provider enable flag

### DIFF
--- a/prov/sm2/configure.m4
+++ b/prov/sm2/configure.m4
@@ -13,7 +13,7 @@ AC_DEFUN([FI_SM2_CONFIGURE],[
 	cma_happy=0
 	atomics_happy=0
 
-	AS_IF([test x"$enable_shm" != x"no"],
+	AS_IF([test x"$enable_sm2" != x"no"],
 	      [
 	       # check if CMA support are present
 	       AS_IF([test x$linux = x1 && test x$host_cpu = xx86_64],
@@ -23,7 +23,7 @@ AC_DEFUN([FI_SM2_CONFIGURE],[
 				    [cma_happy=0])]
 	       )
 
-	       # check if SHM support are present
+	       # check if shm_open is present (POSIX shared memory API)
 	       AC_CHECK_FUNC([shm_open],
 			     [sm2_happy=1],
 			     [sm2_happy=0])


### PR DESCRIPTION
sm2's configure.m4 gates all its compile checks on `enable_shm != no`, which was likely copy-pasted from the shm provider. sm2 doesn't depend on the shm provider — it only needs shm_open() (POSIX API), CMA, and atomics, all of which it checks for independently.

This gate means `--enable-sm2 --disable-shm` always fails, even on platforms where sm2 can compile fine. Remove the gate so sm2 can be configured independently of the shm provider.