### PR TITLE
prov/cxi: Handle LE append failure for RNR recv

### DIFF
--- a/man/fi_cxi.7.md
+++ b/man/fi_cxi.7.md
@@ -1130,6 +1130,11 @@ The CXI provider checks for the following environment variables:
     message should be retried. A value of 0 will return an error completion
     on the first RNR ack status.
 
+*FI_CXI_RNR_APPEND_RETRY_TIMEOUT_US*
+:   When using the endpoint FI_PROTO_CXI_RNR protocol, this setting is used to
+    control the maximum time to retry appending a recv buffer to the LE. It
+    defaults to 200ms and if set to 0, will disable the retry mechanism.
+
 *FI_CXI_EQ_ACK_BATCH_SIZE*
 :   Number of EQ events to process before writing an acknowledgement to HW.
     Batching ACKs amortizes the cost of event acknowledgement over multiple

--- a/prov/cxi/include/cxip.h
+++ b/prov/cxi/include/cxip.h
@@ -360,6 +360,7 @@ struct cxip_environment {
 	enum cxip_mr_target_ordering mr_target_ordering;
 	int disable_cuda_sync_memops;
 	int enable_writedata;
+	int rnr_append_retry_timeout_us;
 };
 
 extern struct cxip_environment cxip_env;
@@ -1258,6 +1259,9 @@ struct cxip_req_recv {
 	struct dlist_entry children;
 	uint64_t src_offset;
 	uint16_t rdzv_mlen;
+	uint64_t rnr_append_retry_ts_us;
+	uint64_t rnr_append_retry_timeout_us;
+	uint64_t rnr_append_retry_attempts;
 };
 
 struct cxip_req_send {
@@ -2103,6 +2107,7 @@ struct cxip_rxc_rnr {
 	/* Used when success events are not required */
 	struct cxip_req *req_selective_comp_msg;
 	struct cxip_req *req_selective_comp_tag;
+	ofi_atomic64_t total_append_retries;
 };
 
 static inline void cxip_copy_to_md(struct cxip_md *md, void *dest,
@@ -2422,6 +2427,8 @@ struct cxip_txc_hpc {
  */
 #define CXIP_RNR_TIMEOUT_US	500000
 #define CXIP_NUM_RNR_WAIT_QUEUE	5
+/* per recv req append retry timeout */
+#define CXIP_RNR_APPEND_RETRY_TIMEOUT_US 200000
 
 struct cxip_txc_rnr {
 	/* Must remain first */

--- a/prov/cxi/include/fi_cxi_ext.h
+++ b/prov/cxi/include/fi_cxi_ext.h
@@ -61,6 +61,7 @@ enum {
 	FI_OPT_CXI_GET_RX_MATCH_MODE_OVERRIDE,		/* char string */
 	FI_OPT_CXI_SET_REQ_BUF_SIZE_OVERRIDE,		/* size_t */
 	FI_OPT_CXI_GET_REQ_BUF_SIZE_OVERRIDE,		/* size_t */
+	FI_OPT_CXI_GET_RNR_APPEND_RETRY_ATTEMPTS,       /* uint64_t */
 
 };
 

--- a/prov/cxi/src/cxip_ep.c
+++ b/prov/cxi/src/cxip_ep.c
@@ -1308,6 +1308,8 @@ struct fi_ops cxip_ep_fi_ops = {
 int cxip_ep_getopt_priv(struct cxip_ep *ep, int level, int optname,
 			void *optval, size_t *optlen)
 {
+	struct cxip_rxc_rnr *rxc_rnr;
+
 	if (level != FI_OPT_ENDPOINT)
 		return -FI_ENOPROTOOPT;
 
@@ -1331,6 +1333,24 @@ int cxip_ep_getopt_priv(struct cxip_ep *ep, int level, int optname,
 		*(bool *)optval =
 			!ep->ep_obj->require_dev_reg_copy[FI_HMEM_CUDA];
 		break;
+
+	case FI_OPT_CXI_GET_RNR_APPEND_RETRY_ATTEMPTS:
+		if (!optval || !optlen)
+			return -FI_EINVAL;
+		if (*optlen < sizeof(u_int64_t))
+			return -FI_ETOOSMALL;
+		if (ep->ep_obj->protocol != FI_PROTO_CXI_RNR) {
+			CXIP_WARN("Not FI_PROTO_CXI_RNR EP\n");
+			return -FI_EINVAL;
+		}
+
+		rxc_rnr = container_of(ep->ep_obj->rxc, struct cxip_rxc_rnr,
+				       base);
+		*(u_int64_t *)optval = ofi_atomic_get64(&rxc_rnr->total_append_retries);
+		CXIP_WARN("rxc_rnr total append retry count %ld\n",
+			ofi_atomic_get64(&rxc_rnr->total_append_retries));
+		break;
+
 	default:
 		return -FI_ENOPROTOOPT;
 	}

--- a/prov/cxi/src/cxip_info.c
+++ b/prov/cxi/src/cxip_info.c
@@ -684,6 +684,7 @@ struct cxip_environment cxip_env = {
 	.mr_target_ordering = MR_ORDER_DEFAULT,
 	.disable_cuda_sync_memops = false,
 	.enable_writedata = false,
+	.rnr_append_retry_timeout_us = CXIP_RNR_APPEND_RETRY_TIMEOUT_US,
 };
 
 static void cxip_env_init(void)
@@ -732,6 +733,11 @@ static void cxip_env_init(void)
 		CXIP_INFO("Invalid RNR timeout, using (%d us)\n",
 			  cxip_env.rnr_max_timeout_us);
 	}
+	fi_param_define(&cxip_prov, "rnr_append_retry_timeout_us", FI_PARAM_INT,
+			"RNR append retry time micro-seconds (default: %d).",
+			cxip_env.rnr_append_retry_timeout_us);
+	fi_param_get_int(&cxip_prov, "rnr_append_retry_timeout_us",
+			 &cxip_env.rnr_append_retry_timeout_us);
 
 	fi_param_define(&cxip_prov, "enable_trig_op_limit", FI_PARAM_BOOL,
 			"Enable enforcement of triggered operation limit. "

--- a/prov/cxi/src/cxip_msg_rnr.c
+++ b/prov/cxi/src/cxip_msg_rnr.c
@@ -192,18 +192,38 @@ static ssize_t cxip_rnr_recv_req(struct cxip_req *req, struct cxip_cntr *cntr,
  */
 static int cxip_rnr_recv_cb(struct cxip_req *req, const union c_event *event)
 {
+	int event_rc = cxi_tgt_event_rc(event), ret;
 	struct cxip_rxc_rnr *rxc = req->recv.rxc_rnr;
-
+	uint64_t ts_delta_us;
 	switch (event->hdr.event_type) {
 	case C_EVENT_LINK:
 		/* Success events are disabled */
-		assert(cxi_tgt_event_rc(event) != C_RC_OK);
+		ts_delta_us = (ofi_gettime_us() - req->recv.rnr_append_retry_ts_us);
+		if (ts_delta_us < req->recv.rnr_append_retry_timeout_us) {
+			ret = cxip_rnr_recv_req(req, req->recv.cntr, true);
+			if(ret) {
+				RXC_WARN(rxc, "Failed to post append command: %d req_id:%d\n",
+				ret, req->req_id);
+			}
+			/* per request count */
+			req->recv.rnr_append_retry_attempts++;
+			/* track aggregate so application can access via fi_getopt
+			 * application can monitor this value to see if they are constantly hitting the
+			 * LE resource limit and adjust their receive posting strategy accordingly.
+			 */
+			ofi_atomic_inc64(&rxc->total_append_retries);
+		} else {
+			RXC_WARN(rxc, "cxip_rnr_recv_cb fatal error append retries %ld etype %d erc %d\n",
+				req->recv.rnr_append_retry_attempts, event->hdr.event_type, event_rc);
+			RXC_WARN(rxc, "ts_delta_us:%ld \n", ts_delta_us);
+			assert(cxi_tgt_event_rc(event) != C_RC_OK);
+			/* Failure to link a receive buffer is a fatal operation and
+			* indicates that FI_PROTO_CXI and portals flow-control is
+			* required.
+			*/
+			RXC_FATAL(rxc, APPEND_LE_FATAL);
+		}
 
-		/* Failure to link a receive buffer is a fatal operation and
-		 * indicates that FI_PROTO_CXI and portals flow-control is
-		 * required.
-		 */
-		RXC_FATAL(rxc, APPEND_LE_FATAL);
 		break;
 
 	case C_EVENT_UNLINK:
@@ -301,6 +321,8 @@ static void cxip_rxc_rnr_init_struct(struct cxip_rxc *rxc_base,
 
 	/* Overrides */
 	rxc->base.recv_ptl_idx = CXIP_PTL_IDX_RNR_RXQ;
+
+	ofi_atomic_initialize64(&rxc->total_append_retries, 0);
 }
 
 static void cxip_rxc_rnr_fini_struct(struct cxip_rxc *rxc)
@@ -543,6 +565,18 @@ cxip_recv_common(struct cxip_rxc *rxc, void *buf, size_t len, void *desc,
 	recv_req->recv.multi_recv = (flags & FI_MULTI_RECV ? true : false);
 
 	if (!(recv_req->recv.flags & (FI_PEEK | FI_CLAIM))) {
+		/* When an append failure occurs, the per-list append-disabled
+		 * flag is set. This prevents subsequent appends to that list
+		 * from being accepted until RESTART_SEQ is used in the append
+		 * command. A successful append clears the append-disabled flag.
+		 * Failure to link a receive buffer is a fatal operation see
+		 * cxip_rnr_recv_cb() so we retry to prevent this fatal
+		 * error in the callback, it is time bound and will ultimately 
+		 * fatally fail once it hits the timeout.
+		 */
+		recv_req->recv.rnr_append_retry_attempts = 0;
+		recv_req->recv.rnr_append_retry_timeout_us = cxip_env.rnr_append_retry_timeout_us;
+		recv_req->recv.rnr_append_retry_ts_us = ofi_gettime_us();
 		ret = cxip_rnr_recv_req(recv_req, cntr, false);
 		if (ret) {
 			RXC_WARN(rxc, "Receive append failed: %d %s\n",

--- a/prov/cxi/test/msg.c
+++ b/prov/cxi/test/msg.c
@@ -13,6 +13,8 @@
 
 #include "cxip.h"
 #include "cxip_test_common.h"
+#define CXIP_DBG(...) _CXIP_DBG(FI_LOG_EP_DATA, __VA_ARGS__)
+#define CXIP_WARN(...) _CXIP_WARN(FI_LOG_EP_DATA, __VA_ARGS__)
 
 /* Test basic send/recv - expected or unexpected*/
 static void ping(bool ux)
@@ -2423,7 +2425,113 @@ Test(rnr_msg, multi_recv_retries)
 	free(send_buf);
 	free(recv_buf);
 }
+Test(rnr_msg, append_oflow, .timeout = 600, .disabled = false)
+{
+	int ret, recv_post_count = 15724;
+	int posted = 0, canceled = 0, req_overflow = 6;
+	uint8_t *recv_buf;
+	int recv_len = 64;
+	struct fi_cq_tagged_entry rx_cqe;
+	struct fi_cq_err_entry err_cqe = {};
+	struct fi_context *ctxt;
+	int recv_post_total = (recv_post_count + req_overflow);
+	uint64_t retry_attempts_start, retry_attempts_end;
+	size_t optlen = sizeof(retry_attempts_start);
 
+	ctxt = calloc(recv_post_total, sizeof(struct fi_context));
+	recv_buf = aligned_alloc(s_page_size, recv_len);
+	cr_assert(recv_buf);
+	cr_assert(ctxt);
+	memset(recv_buf, 0, recv_len);
+	memset(&err_cqe, 0, sizeof(err_cqe));
+
+	/* get the retry count before we start */
+	ret = fi_getopt(&cxit_ep->fid, FI_OPT_ENDPOINT,
+			FI_OPT_CXI_GET_RNR_APPEND_RETRY_ATTEMPTS,
+			&retry_attempts_start, &optlen);
+	cr_assert_eq(ret, FI_SUCCESS, "fi_getopt failed to get start attempts %d", ret);
+	CXIP_WARN("retry_attempts_start %ld\n", retry_attempts_start);
+
+	/* we know that the next append after 15724 will fail, post n
+	 * req_overflow to trigger a post retry in recv_cb.
+	 *
+	 * fi_recv should not fail unless the hw is not accepting commands
+	 * and that will result in FI_EAGAIN. these are posted and the only
+	 * way you know the result is the status of the link and unlink
+	 * commands in recv_cb
+	 */
+	for (posted = 0; posted < recv_post_total; posted++) {
+		ret = fi_recv(cxit_ep, recv_buf, recv_len, NULL,
+			      FI_ADDR_UNSPEC, &ctxt[posted]);
+		cr_assert_eq(ret, FI_SUCCESS, "fi_recv failed %d", ret);
+		/* progress only */
+		fi_cq_read(cxit_rx_cq, NULL, 0);
+	}
+	/* at this point we should have n req_overflow waiting for a free slot*/
+	CXIP_WARN("fi_recv posted count %d trig retry at 15725\n", posted);
+	CXIP_WARN("Cancelling %d recv reqs\n", req_overflow);
+	/* cancel requests to stop retries */
+	for (canceled = 0; canceled < req_overflow; canceled++) {
+		ret = fi_cancel(&cxit_ep->fid, &ctxt[canceled]);
+		cr_assert_eq(ret, FI_SUCCESS, "fi_cancel failed %d", ret);
+		/* Get cancelled entry */
+		do {
+			ret = fi_cq_read(cxit_rx_cq, &rx_cqe, 1);
+			/* wait for the available cancel error */
+			if (ret == -FI_EAVAIL) {
+				break;
+			}
+			cr_assert_eq(ret, -FI_EAGAIN, "unexpected event %d", ret);
+			/* progress only */
+			fi_cq_read(cxit_rx_cq, NULL, 0);
+		} while (1);
+		ret = fi_cq_readerr(cxit_rx_cq, &err_cqe, 0);
+		cr_assert_eq(ret, 1, "Did not get completion with error\n");
+		cr_assert(err_cqe.op_context == &ctxt[canceled], "Error CQE context mismatch\n");
+		cr_assert(err_cqe.err == FI_ECANCELED, "Did not get expected cancel error, %d\n", err_cqe.err);
+		err_cqe.err = 0;
+		/* progress only */
+		fi_cq_read(cxit_rx_cq, NULL, 0);
+	}
+	/* check retry attempt counter, should be non-zero
+	 * the only way we know if the retries succeded is
+	 * we dont timeout and hit the fatal assert in
+	 * cxip_rnr_recv_cb().
+	 */
+	CXIP_WARN("Calling fi_getopt()\n");
+	ret = fi_getopt(&cxit_ep->fid, FI_OPT_ENDPOINT,
+			FI_OPT_CXI_GET_RNR_APPEND_RETRY_ATTEMPTS,
+			&retry_attempts_end, &optlen);
+	cr_assert_eq(ret, FI_SUCCESS, "fi_getopt failed to get end attempts %d", ret);
+	cr_assert_neq(retry_attempts_start, retry_attempts_end, "retry attempts unchanged %ld\n", retry_attempts_end);
+
+	/* now cancel the remaining recv posts that pushed us to the ceiling */
+	CXIP_WARN("Cancelling remaining recv reqs %d\n", (recv_post_total - req_overflow));
+	for (canceled = req_overflow; canceled < recv_post_total; canceled++) {
+		ret = fi_cancel(&cxit_ep->fid, &ctxt[canceled]);
+		cr_assert_eq(ret, FI_SUCCESS, "fi_cancel failed %d", ret);
+		/* Get cancelled entry */
+		do {
+			ret = fi_cq_read(cxit_rx_cq, &rx_cqe, 1);
+			/* wait for the available cancel error */
+			if (ret == -FI_EAVAIL) {
+				break;
+			}
+			cr_assert_eq(ret, -FI_EAGAIN, "unexpected event %d", ret);
+			/* progress only */
+			fi_cq_read(cxit_rx_cq, NULL, 0);
+		} while (1);
+		ret = fi_cq_readerr(cxit_rx_cq, &err_cqe, 0);
+		cr_assert_eq(ret, 1, "Did not get completion with error\n");
+		cr_assert(err_cqe.op_context == &ctxt[canceled], "Error CQE context mismatch\n");
+		cr_assert(err_cqe.err == FI_ECANCELED, "Did not get expected cancel error, %d\n", err_cqe.err);
+		err_cqe.err = 0;
+		/* progress only */
+		fi_cq_read(cxit_rx_cq, NULL, 0);
+	}
+	free(ctxt);
+	free(recv_buf);
+}
 
 /* Verify that FI_AV_USER_ID is returned from fi_cq_readfrom(). */
 Test(msg, av_user_id_domain_cap)


### PR DESCRIPTION
Add logic to handle a RNR LE append failure and avoid the fatal error. Allow retries to re-append the buffer in the recv_cb function.