### PR TITLE
prov/shm: Add null check in smr_get_addr

### DIFF
--- a/prov/shm/src/smr_av.c
+++ b/prov/shm/src/smr_av.c
@@ -101,6 +101,10 @@ static fi_addr_t smr_get_addr(struct fi_peer_rx_entry *rx_entry)
 {
 	struct smr_cmd_ctx *cmd_ctx = rx_entry->peer_context;
 
+	if (!cmd_ctx || !cmd_ctx->ep || !cmd_ctx->ep->region ||
+	    !cmd_ctx->ep->region->map)
+		return FI_ADDR_UNSPEC;
+
 	return cmd_ctx->ep->region->map->peers[cmd_ctx->cmd.msg.hdr.id].fiaddr;
 }
 


### PR DESCRIPTION
Add NULL pointer checks for cmd_ctx, ep, region, and map before dereferencing the pointer chain in smr_get_addr. Returns FI_ADDR_UNSPEC if any pointer is NULL, preventing a segmentation fault during endpoint teardown or race conditions where the shared memory region may not be mapped.