### PR TITLE
[v2.5.x]prov/efa: fix NULL deref in efa_av_reverse_av_remove on QPN collision

### DIFF
--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -307,7 +307,7 @@ void efa_av_reverse_av_remove(struct efa_cur_reverse_av **cur_reverse_av,
 	cur_key.qpn = conn->ep_addr->qpn;
 	HASH_FIND(hh, *cur_reverse_av, &cur_key, sizeof(cur_key),
 		  cur_reverse_av_entry);
-	if (cur_reverse_av_entry) {
+	if (cur_reverse_av_entry && cur_reverse_av_entry->conn == conn) {
 		HASH_DEL(*cur_reverse_av, cur_reverse_av_entry);
 		free(cur_reverse_av_entry);
 	} else {
@@ -317,7 +317,8 @@ void efa_av_reverse_av_remove(struct efa_cur_reverse_av **cur_reverse_av,
 		prv_key.connid = conn->ep_addr->qkey;
 		HASH_FIND(hh, *prv_reverse_av, &prv_key, sizeof(prv_key),
 			  prv_reverse_av_entry);
-		assert(prv_reverse_av_entry);
+		assert(prv_reverse_av_entry &&
+		       prv_reverse_av_entry->conn == conn);
 		HASH_DEL(*prv_reverse_av, prv_reverse_av_entry);
 		free(prv_reverse_av_entry);
 	}

--- a/prov/efa/test/efa_unit_test_av.c
+++ b/prov/efa/test/efa_unit_test_av.c
@@ -329,6 +329,78 @@ void test_av_reinsertion(struct efa_resource **state)
 }
 
 /**
+ * @brief Insert two peers that collide on (AHN, QPN) but differ in QKEY, then
+ * remove the first-inserted peer before the second. This reproduces the bug
+ * in efa_av_reverse_av_remove() where the code blindly deletes the
+ * cur_reverse_av entry matching (ahn, qpn) even though that entry belongs to
+ * a different (newer) conn. Removing the surviving second peer afterwards
+ * then hits a NULL prv_reverse_av_entry and SEGVs.
+ *
+ * @param[in]	state	struct efa_resource that is managed by the framework
+ */
+void test_av_reverse_av_remove_qpn_collision(struct efa_resource **state)
+{
+	struct efa_resource *resource = *state;
+	struct efa_ep_addr raw_addr;
+	size_t raw_addr_len = sizeof(struct efa_ep_addr);
+	fi_addr_t fi_addr1, fi_addr2;
+	struct efa_av *av;
+	struct efa_rdm_ep *efa_rdm_ep;
+	uint32_t ahn;
+	int err;
+
+	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_FABRIC_NAME);
+
+	err = fi_getname(&resource->ep->fid, &raw_addr, &raw_addr_len);
+	assert_int_equal(err, 0);
+
+	av = container_of(resource->av, struct efa_av, util_av.av_fid);
+	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep,
+				  base_ep.util_ep.ep_fid);
+	ahn = efa_rdm_ep->self_ah->ahn;
+
+	/* Insert peer1: same GID as self, qpn=100, qkey=0xAAAA */
+	raw_addr.qpn = 100;
+	raw_addr.qkey = 0xAAAA;
+	err = fi_av_insert(resource->av, &raw_addr, 1, &fi_addr1, 0, NULL);
+	assert_int_equal(err, 1);
+	test_av_verify_av_hash_cnt(av, 1, 0, 0, 0);
+	/* cur_reverse_av (ahn, 100) -> conn1 (fi_addr1) */
+	assert_int_equal(efa_av_reverse_lookup_rdm(av, ahn, 100, NULL),
+			 fi_addr1);
+
+	/* Insert peer2: same GID and qpn, different qkey. This pushes peer1's
+	 * reverse-AV entry from cur_reverse_av into prv_reverse_av. */
+	raw_addr.qpn = 100;
+	raw_addr.qkey = 0xBBBB;
+	err = fi_av_insert(resource->av, &raw_addr, 1, &fi_addr2, 0, NULL);
+	assert_int_equal(err, 1);
+	assert_int_not_equal(fi_addr1, fi_addr2);
+	test_av_verify_av_hash_cnt(av, 1, 1, 0, 0);
+	/* cur_reverse_av (ahn, 100) now points to conn2 (fi_addr2); peer1 is
+	 * in prv_reverse_av keyed by its own qkey. */
+	assert_int_equal(efa_av_reverse_lookup_rdm(av, ahn, 100, NULL),
+			 fi_addr2);
+
+	/* Remove peer1 first. Without the fix this would incorrectly delete
+	 * peer2's cur_reverse_av entry and leave peer1's prv entry orphaned. */
+	err = fi_av_remove(resource->av, &fi_addr1, 1, 0);
+	assert_int_equal(err, 0);
+	/* peer1's prv entry is gone; peer2's cur entry must still be intact. */
+	test_av_verify_av_hash_cnt(av, 1, 0, 0, 0);
+	assert_int_equal(efa_av_reverse_lookup_rdm(av, ahn, 100, NULL),
+			 fi_addr2);
+
+	/* Remove peer2. Without the fix this hits a NULL prv_reverse_av_entry
+	 * in efa_av_reverse_av_remove() -> SEGV / assertion failure. */
+	err = fi_av_remove(resource->av, &fi_addr2, 1, 0);
+	assert_int_equal(err, 0);
+	test_av_verify_av_hash_cnt(av, 0, 0, 0, 0);
+	assert_int_equal(efa_av_reverse_lookup_rdm(av, ahn, 100, NULL),
+			 FI_ADDR_NOTAVAIL);
+}
+
+/**
  * @brief Generate a peer with random QPN and QKEY and insert it into the implicit AV
  *
  * @param[in]	state	struct efa_resource that is managed by the framework

--- a/prov/efa/test/efa_unit_test_av.c
+++ b/prov/efa/test/efa_unit_test_av.c
@@ -401,7 +401,13 @@ void test_av_reverse_av_remove_qpn_collision(struct efa_resource **state)
 }
 
 /**
- * @brief Generate a peer with random QPN and QKEY and insert it into the implicit AV
+ * @brief Generate a peer with a unique QPN and a random QKEY and insert it
+ *        into the implicit AV
+ *
+ * The QPN is drawn from a static monotonic counter so every peer minted by
+ * this helper has a distinct (ahn, qpn) key in the reverse AV. Callers rely
+ * on this uniqueness to exercise LRU ordering and eviction behavior without
+ * tripping over the provider's QPN-collision path.
  *
  * @param[in]	state	struct efa_resource that is managed by the framework
  */
@@ -422,7 +428,8 @@ static struct efa_rdm_peer *test_av_get_peer_from_implicit_av(struct efa_resourc
 	err = fi_getname(&resource->ep->fid, &raw_addr, &raw_addr_len);
 	assert_int_equal(err, 0);
 
-	raw_addr.qpn = rand();
+	static uint16_t next_qpn = 0;
+	raw_addr.qpn = next_qpn++;
 	raw_addr.qkey = rand();
 	ahn = efa_rdm_ep->self_ah->ahn;
 

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -148,6 +148,7 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_av_multiple_ep_efa, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_av_multiple_ep_efa_direct, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_av_reinsertion, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_av_reverse_av_remove_qpn_collision, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_av_implicit, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_av_implicit_to_explicit, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_av_implicit_av_lru_insertion, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -118,6 +118,7 @@ void test_efa_ah_cnt_multi_av_efa_direct();
 void test_av_multiple_ep_efa();
 void test_av_multiple_ep_efa_direct();
 void test_av_reinsertion();
+void test_av_reverse_av_remove_qpn_collision();
 void test_av_implicit();
 void test_av_implicit_to_explicit();
 void test_av_implicit_av_lru_insertion();


### PR DESCRIPTION
The EFA provider maintains two reverse-lookup hash tables so that incoming packets (which carry only AHN and QPN on the wire) can be mapped back to a fi_addr:

  cur_reverse_av: keyed by (ahn, qpn)        -> newest conn for that slot
  prv_reverse_av: keyed by (ahn, qpn, qkey)  -> older conns that were
                                                displaced from cur

Each conn lives in exactly one of the two tables: cur if it is the most recent conn for its (ahn, qpn), prv otherwise.

A collision on (ahn, qpn) happens when a peer endpoint is destroyed and a new endpoint is created that reuses the same GID and QPN but with a fresh QKEY. efa_av_reverse_av_add() handles this by moving the existing cur entry's conn into a newly-allocated prv entry (keyed by that conn's own qkey), then overwriting cur_reverse_av to point at the new conn. Note that the add path does not remove the old conn from the AV - that only happens when the application calls fi_av_remove() for it. The old conn is kept around so that late packets arriving from the dead peer can still be resolved to its fi_addr, both for peer-state lookup on the receive path and for reporting src_addr on FI_SOURCE completions.

As a result, it is normal for the AV to hold two live registrations on the same (ahn, qpn) at the same time: the newer one sitting in cur and the older one sitting in prv. Whichever of the two the application removes first, efa_av_reverse_av_remove() has to clean up only that conn's entry and leave the other alone.

The removal side did not honor this. It looked up cur by (ahn, qpn) and deleted whatever it found, without verifying that cur_reverse_av_entry->conn was actually the conn being removed. When the application removed the older (displaced) conn first, cur_reverse_av_entry pointed at the newer, still-live conn - and the code freed that entry anyway, leaving the older conn's prv entry behind.

The next fi_av_remove (or AV teardown during fi_close) for the newer conn then missed cur (we deleted it), missed prv (the prv entry is keyed by the older qkey, not the newer one), and dereferenced a NULL hash entry, producing the SEGV at efa_av.c:307 / assert(prv_reverse_av_entry) seen under
fi_efa_multi_ep_stress --remove-av.

Fix the invariant on the remove side to mirror the add side:

  * Delete the cur entry only when it actually owns the conn being removed. Any surviving prv entries for the same (ahn, qpn) belong to already-displaced peers that are still being drained; they stay put and will be freed when the application removes them.

  * Otherwise, fall through to the prv lookup. prv is keyed by the conn's own qkey and uniquely identifies the displaced entry, so this both finds the right entry and leaves the live peer's cur entry untouched.

Also tighten the prv-branch assertion from non-NULL to "non-NULL and owned by the conn being removed", which makes any future drift from this invariant fail loudly in debug builds instead of silently freeing someone else's entry.

Add test_av_reverse_av_remove_qpn_collision which inserts two peers on the same (ahn, qpn) with different qkeys, removes the older one first, then removes the newer one. The test also checks reverse-AV hash counts and efa_av_reverse_lookup_rdm() results after each step so regressions that avoid the crash but still corrupt the tables are caught too.


(cherry picked from commit 4658d4577d6bf6ea6574a54f4b415181d496f21c)