### PR TITLE
prov/efa/test: fix flaky QPN collision in implicit AV unit tests

### DIFF
--- a/prov/efa/test/efa_unit_test_av.c
+++ b/prov/efa/test/efa_unit_test_av.c
@@ -401,7 +401,13 @@ void test_av_reverse_av_remove_qpn_collision(struct efa_resource **state)
 }
 
 /**
- * @brief Generate a peer with random QPN and QKEY and insert it into the implicit AV
+ * @brief Generate a peer with a unique QPN and a random QKEY and insert it
+ *        into the implicit AV
+ *
+ * The QPN is drawn from a static monotonic counter so every peer minted by
+ * this helper has a distinct (ahn, qpn) key in the reverse AV. Callers rely
+ * on this uniqueness to exercise LRU ordering and eviction behavior without
+ * tripping over the provider's QPN-collision path.
  *
  * @param[in]	state	struct efa_resource that is managed by the framework
  */
@@ -422,7 +428,8 @@ static struct efa_rdm_peer *test_av_get_peer_from_implicit_av(struct efa_resourc
 	err = fi_getname(&resource->ep->fid, &raw_addr, &raw_addr_len);
 	assert_int_equal(err, 0);
 
-	raw_addr.qpn = rand();
+	static uint16_t next_qpn = 0;
+	raw_addr.qpn = next_qpn++;
 	raw_addr.qkey = rand();
 	ahn = efa_rdm_ep->self_ah->ahn;
 


### PR DESCRIPTION
test_av_get_peer_from_implicit_av() generated each fake peer's QPN with rand(). struct efa_ep_addr::qpn is uint16_t, so the effective QPN space is only 65536 values. All peers inserted by the helper share the same GID (copied from fi_getname) and therefore the same AHN, so the reverse AV's (ahn, qpn) key collapses onto a 16-bit space as well.

Every caller of this helper expects the peers it returns to be distinct from one another:

  - test_av_implicit and test_av_implicit_to_explicit only call the helper once, so they are unaffected in practice, but the helper's contract - "mint a new peer and register it in the implicit AV" - implies uniqueness.
  - test_av_implicit_av_lru_insertion calls it 3 times and asserts that cur_reverse_av_implicit holds 3 entries (and prv_reverse_av_implicit holds 0). Its LRU-ordering checks only make sense if the 3 peers are genuinely distinct.
  - test_av_implicit_av_lru_eviction calls it 4 times with implicit_av_size=2 to drive specific evictions. If two of those peers share (ahn, qpn), the eviction order the test verifies is no longer well-defined.

If any two of those rand()-drawn QPNs happen to match, efa_av_reverse_av_add() correctly treats it as a QPN collision: the displaced conn is moved from cur into prv (keyed by its qkey), and cur is overwritten with the new conn. The resulting hash counts no longer match what the test expects.

The failure signature is:

  [  ERROR   ] --- 0x2 != 0x3
  [   LINE   ] --- prov/efa/test/efa_unit_test_av.c:264: Failure!
  [  FAILED  ] test_av_implicit_av_lru_insertion

i.e. cur_reverse_av_implicit had 2 entries instead of 3 because two of the three rand() QPNs collided.

The provider's collision handling is correct and is in fact exercised on purpose by test_av_reverse_av_remove_qpn_collision, so the bug is in the test's input generation, not in efa_av.c.

Replace rand() with a static monotonic uint16_t counter so every peer minted by the helper has a unique QPN for the lifetime of the test process. qkey stays random so each peer still has a distinct connid, which is what the lookup paths actually key on when disambiguating displaced vs. current entries.