### PR TITLE
fabtests/pytest: Skip read protocol CUDA test when RDMA read is unsupported.

### DIFF
--- a/fabtests/pytest/efa/efa_common.py
+++ b/fabtests/pytest/efa/efa_common.py
@@ -240,13 +240,20 @@ def has_rdma(cmdline_args, operation):
     operation: rdma operation name, allowed values are read and write
     return: a boolean
     """
+    return _has_rdma_cached(cmdline_args.server_id, cmdline_args.client_id,
+                            cmdline_args.binpath, cmdline_args.timeout,
+                            cmdline_args.environments, operation)
+
+
+@functools.lru_cache(maxsize=None)
+def _has_rdma_cached(server_id, client_id, binpath, timeout, environments, operation):
     assert operation in ["read", "write", "writedata"]
-    binpath = cmdline_args.binpath or ""
-    cmd = "timeout " + str(cmdline_args.timeout) \
+    binpath = binpath or ""
+    cmd = "timeout " + str(timeout) \
           + " " + os.path.join(binpath, f"fi_efa_rdma_checker -o {operation}")
-    if cmdline_args.environments:
-        cmd = cmdline_args.environments + " " + cmd
-    server_proc = subprocess.run("ssh {} {}".format(cmdline_args.server_id, cmd),
+    if environments:
+        cmd = environments + " " + cmd
+    server_proc = subprocess.run("ssh {} {}".format(server_id, cmd),
                stdout=subprocess.PIPE,
                stderr=subprocess.STDOUT,
                shell=True,
@@ -254,7 +261,7 @@ def has_rdma(cmdline_args, operation):
     if has_ssh_connection_err_msg(server_proc.stdout):
         raise SshConnectionError()
 
-    client_proc = subprocess.run("ssh {} {}".format(cmdline_args.client_id, cmd),
+    client_proc = subprocess.run("ssh {} {}".format(client_id, cmd),
                stdout=subprocess.PIPE,
                stderr=subprocess.STDOUT,
                shell=True,

--- a/fabtests/pytest/efa/test_efa_protocol_selection.py
+++ b/fabtests/pytest/efa/test_efa_protocol_selection.py
@@ -21,6 +21,9 @@ def test_transfer_with_read_protocol_cuda(cmdline_args, fabtest_name, cntrl_env_
     if cntrl_env_var == "FI_EFA_INTER_MIN_READ_WRITE_SIZE" and has_rdma(cmdline_args, "write"):
         pytest.skip("FI_EFA_INTER_MIN_READ_WRITE_SIZE is only applied to emulated write protocols")
 
+    if not has_rdma(cmdline_args, "read"):
+        pytest.skip("RDMA read not supported, cannot test read protocol")
+
     if cmdline_args.server_id == cmdline_args.client_id:
         pytest.skip("No read for intra-node communication")
 


### PR DESCRIPTION
 Problem

  test_transfer_with_read_protocol_cuda sets FI_EFA_USE_DEVICE_RDMA=1 unconditionally, which causes the EFA provider to abort on instances that don't support RDMA read (e.g. g4dn). The test already uses has_rdma() to check write capability but doesn't check read.

  Fix

  Add has_rdma(cmdline_args, "read") check to skip the test gracefully on non-RDMA instances, matching the existing pattern used for the write check.

  Testing

  - g4dn instances (no RDMA read): test correctly skips instead of aborting
  - Instances with RDMA read: test runs as before (no behavior change)