### PR TITLE
prov/efa: Separate CNTR into independent efa-direct and efa-rdm implementations

### DIFF
--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -911,6 +911,7 @@
     <ClCompile Include="prov\efa\src\rdm\efa_rdm_pke_rtr.c" />
     <ClCompile Include="prov\efa\src\rdm\efa_rdm_pkt_type.c" />
     <ClCompile Include="prov\efa\src\rdm\efa_rdm_rma.c" />
+    <ClCompile Include="prov\efa\src\rdm\efa_rdm_cntr.c" />
     <ClCompile Include="prov\efa\src\rdm\efa_rdm_cq.c" />
     <ClCompile Include="prov\efa\src\rdm\efa_rdm_mr.c" />
     <ClCompile Include="prov\efa\src\rdm\efa_rdm_peer.c" />
@@ -1021,6 +1022,7 @@
     <ClInclude Include="prov\efa\src\efa_base_ep.h" />
     <ClInclude Include="prov\efa\src\efa_cntr.h" />
     <ClInclude Include="prov\efa\src\rdm\efa_rdm_ep.h" />
+    <ClInclude Include="prov\efa\src\rdm\efa_rdm_cntr.h" />
     <ClInclude Include="prov\efa\src\rdm\efa_rdm_pke_utils.h" />
     <ClInclude Include="prov\efa\src\rdm\efa_rdm_pke_nonreq.h" />
     <ClInclude Include="prov\efa\src\rdm\efa_rdm_atomic.h" />

--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -57,6 +57,7 @@ _efa_files = \
 	prov/efa/src/efa_data_path_direct.c \
 	prov/efa/src/rdm/efa_rdm_peer.c	\
 	prov/efa/src/rdm/efa_rdm_cq.c \
+	prov/efa/src/rdm/efa_rdm_cntr.c \
 	prov/efa/src/rdm/efa_rdm_ep_utils.c \
 	prov/efa/src/rdm/efa_rdm_ep_fiops.c \
 	prov/efa/src/rdm/efa_rdm_rma.c	\
@@ -117,6 +118,7 @@ _efa_headers = \
 	prov/efa/src/efa_mmio.h \
 	prov/efa/src/rdm/efa_rdm_peer.h	\
 	prov/efa/src/rdm/efa_rdm_cq.h \
+	prov/efa/src/rdm/efa_rdm_cntr.h \
 	prov/efa/src/rdm/efa_rdm_ep.h \
 	prov/efa/src/rdm/efa_rdm_rma.h \
 	prov/efa/src/rdm/efa_rdm_msg.h \

--- a/prov/efa/src/efa_base_ep.c
+++ b/prov/efa/src/efa_base_ep.c
@@ -820,9 +820,6 @@ int efa_base_ep_insert_cntr_ibv_cq_poll_list(struct efa_base_ep *ep)
 					return ret;
 				efa_base_ep_set_cq_ops_for_cntr(ep, rx_cq);
 			}
-			ofi_genlock_lock(&efa_cntr->util_cntr.ep_list_lock);
-			efa_cntr->need_to_scan_ep_list = true;
-			ofi_genlock_unlock(&efa_cntr->util_cntr.ep_list_lock);
 		}
 	}
 

--- a/prov/efa/src/efa_cntr.c
+++ b/prov/efa/src/efa_cntr.c
@@ -5,9 +5,9 @@
 #include "ofi_util.h"
 #include "efa.h"
 #include "efa_cntr.h"
-#include "rdm/efa_rdm_cq.h"
+#include "efa_cq.h"
 
-static int efa_cntr_wait(struct fid_cntr *cntr_fid, uint64_t threshold, int timeout)
+int efa_cntr_wait(struct fid_cntr *cntr_fid, uint64_t threshold, int timeout)
 {
 	struct util_cntr *cntr;
 	uint64_t start, errcnt;
@@ -58,42 +58,33 @@ unlock:
 	return ret;
 }
 
-static uint64_t efa_cntr_read(struct fid_cntr *cntr_fid)
+uint64_t efa_cntr_read(struct fid_cntr *cntr_fid)
 {
 	struct efa_domain *domain;
-	struct efa_cntr *efa_cntr;
+	struct util_cntr *util_cntr;
 	uint64_t ret;
 
-	efa_cntr = container_of(cntr_fid, struct efa_cntr, util_cntr.cntr_fid);
-
-	domain = container_of(efa_cntr->util_cntr.domain, struct efa_domain, util_domain);
+	util_cntr = container_of(cntr_fid, struct util_cntr, cntr_fid);
+	domain = container_of(util_cntr->domain, struct efa_domain, util_domain);
 
 	ofi_genlock_lock(&domain->srx_lock);
-
-	if (efa_cntr->shm_cntr)
-		fi_cntr_read(efa_cntr->shm_cntr);
 	ret = ofi_cntr_read(cntr_fid);
-
 	ofi_genlock_unlock(&domain->srx_lock);
 
 	return ret;
 }
 
-static uint64_t efa_cntr_readerr(struct fid_cntr *cntr_fid)
+uint64_t efa_cntr_readerr(struct fid_cntr *cntr_fid)
 {
 	struct efa_domain *domain;
-	struct efa_cntr *efa_cntr;
+	struct util_cntr *util_cntr;
 	uint64_t ret;
 
-	efa_cntr = container_of(cntr_fid, struct efa_cntr, util_cntr.cntr_fid);
-
-	domain = container_of(efa_cntr->util_cntr.domain, struct efa_domain, util_domain);
+	util_cntr = container_of(cntr_fid, struct util_cntr, cntr_fid);
+	domain = container_of(util_cntr->domain, struct efa_domain, util_domain);
 
 	ofi_genlock_lock(&domain->srx_lock);
-	if (efa_cntr->shm_cntr)
-		fi_cntr_read(efa_cntr->shm_cntr);
 	ret = ofi_cntr_readerr(cntr_fid);
-
 	ofi_genlock_unlock(&domain->srx_lock);
 
 	return ret;
@@ -113,24 +104,12 @@ static struct fi_ops_cntr efa_cntr_ops = {
 static int efa_cntr_close(struct fid *fid)
 {
 	struct efa_cntr *cntr;
-	int ret, retv;
 
-	retv = 0;
 	cntr = container_of(fid, struct efa_cntr, util_cntr.cntr_fid.fid);
 
-	if (cntr->shm_cntr) {
-		ret = fi_close(&cntr->shm_cntr->fid);
-		if (ret) {
-			EFA_WARN(FI_LOG_CNTR, "Unable to close shm cntr: %s\n", fi_strerror(-ret));
-			retv = ret;
-		}
-	}
-
-	ret = ofi_cntr_cleanup(&cntr->util_cntr);
-	if (ret)
-		return ret;
+	efa_cntr_destruct(cntr);
 	free(cntr);
-	return retv;
+	return 0;
 }
 
 static struct fi_ops efa_cntr_fi_ops = {
@@ -141,66 +120,46 @@ static struct fi_ops efa_cntr_fi_ops = {
 	.ops_open = fi_no_ops_open,
 };
 
-static void efa_rdm_cntr_progress(struct util_cntr *cntr)
+void efa_cntr_progress_ibv_cq_poll_list(struct efa_cntr *efa_cntr)
 {
 	struct dlist_entry *item;
-	struct efa_cntr *efa_cntr;
-	struct efa_domain *efa_domain;
-	struct efa_cq *efa_cq;
 	struct efa_ibv_cq_poll_list_entry *poll_list_entry;
-	struct efa_rdm_ep *efa_rdm_ep;
-	struct fid_list_entry *fid_entry;
+	struct efa_cq *efa_cq;
 
-	ofi_genlock_lock(&cntr->ep_list_lock);
-	efa_cntr = container_of(cntr, struct efa_cntr, util_cntr);
-	efa_domain = container_of(efa_cntr->util_cntr.domain, struct efa_domain, util_domain);
-
-	/**
-	 * TODO: It's better to just post the initial batch of internal rx pkts during ep enable
-	 * so we don't have to iterate cntr->ep_list here.
-	 * However, it is observed that doing that will hurt performance if application opens
-	 * some idle endpoints and never poll completions for them. Move these initial posts to
-	 * the first polling before having a long term fix.
-	 */
-	if (efa_cntr->need_to_scan_ep_list) {
-		dlist_foreach(&cntr->ep_list, item) {
-			fid_entry = container_of(item, struct fid_list_entry, entry);
-			efa_rdm_ep = container_of(fid_entry->fid, struct efa_rdm_ep, base_ep.util_ep.ep_fid.fid);
-			if (efa_rdm_ep->base_ep.efa_qp_enabled)
-				efa_rdm_ep_post_internal_rx_pkts(efa_rdm_ep);
-		}
-		efa_cntr->need_to_scan_ep_list = false;
-	}
+	assert(ofi_genlock_held(&efa_cntr->util_cntr.ep_list_lock));
 
 	dlist_foreach(&efa_cntr->ibv_cq_poll_list, item) {
 		poll_list_entry = container_of(item, struct efa_ibv_cq_poll_list_entry, entry);
 		efa_cq = container_of(poll_list_entry->cq, struct efa_cq, ibv_cq);
 		ofi_genlock_lock(&efa_cq->util_cq.ep_list_lock);
-		(void) efa_rdm_cq_poll_ibv_cq(efa_env.efa_cq_read_size, poll_list_entry->cq);
+		(void) efa_cq->poll_ibv_cq(efa_env.efa_cq_read_size, poll_list_entry->cq);
 		ofi_genlock_unlock(&efa_cq->util_cq.ep_list_lock);
 	}
-	efa_domain_progress_rdm_peers_and_queues(efa_domain);
-	ofi_genlock_unlock(&cntr->ep_list_lock);
 }
 
 static void efa_cntr_progress(struct util_cntr *cntr)
 {
-	struct dlist_entry *item;
-	struct efa_ibv_cq_poll_list_entry *poll_list_entry;
 	struct efa_cntr *efa_cntr;
-	struct efa_cq *efa_cq;
 
 	efa_cntr = container_of(cntr, struct efa_cntr, util_cntr);
 
 	ofi_genlock_lock(&cntr->ep_list_lock);
-	dlist_foreach(&efa_cntr->ibv_cq_poll_list, item) {
-		poll_list_entry = container_of(item, struct efa_ibv_cq_poll_list_entry, entry);
-		efa_cq = container_of(poll_list_entry->cq, struct efa_cq, ibv_cq);
-		ofi_genlock_lock(&efa_cq->util_cq.ep_list_lock);
-		(void) efa_cq_poll_ibv_cq(efa_env.efa_cq_read_size, poll_list_entry->cq);
-		ofi_genlock_unlock(&efa_cq->util_cq.ep_list_lock);
-	}
+	efa_cntr_progress_ibv_cq_poll_list(efa_cntr);
 	ofi_genlock_unlock(&cntr->ep_list_lock);
+}
+
+int efa_cntr_construct(struct efa_cntr *cntr, struct fid_domain *domain,
+		       struct fi_cntr_attr *attr,
+		       ofi_cntr_progress_func progress, void *context)
+{
+	dlist_init(&cntr->ibv_cq_poll_list);
+	return ofi_cntr_init(&efa_prov, domain, attr, &cntr->util_cntr,
+			     progress, context);
+}
+
+void efa_cntr_destruct(struct efa_cntr *cntr)
+{
+	ofi_cntr_cleanup(&cntr->util_cntr);
 }
 
 int efa_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
@@ -213,74 +172,17 @@ int efa_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 	if (!cntr)
 		return -FI_ENOMEM;
 
-	dlist_init(&cntr->ibv_cq_poll_list);
-	cntr->need_to_scan_ep_list = false;
-
-	ret = ofi_cntr_init(&efa_prov, domain, attr, &cntr->util_cntr,
-			    efa_cntr_progress, context);
-
-	if (ret)
-		goto free;
-
-	*cntr_fid = &cntr->util_cntr.cntr_fid;
-	cntr->util_cntr.cntr_fid.ops = &efa_cntr_ops;
-	cntr->util_cntr.cntr_fid.fid.ops = &efa_cntr_fi_ops;
-
-	return FI_SUCCESS;
-
-free:
-	free(cntr);
-	return ret;
-}
-
-
-int efa_rdm_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
-		      struct fid_cntr **cntr_fid, void *context)
-{
-	int ret;
-	struct efa_cntr *cntr;
-	struct efa_domain *efa_domain;
-	struct fi_cntr_attr shm_cntr_attr = {0};
-	struct fi_peer_cntr_context peer_cntr_context = {0};
-
-	cntr = calloc(1, sizeof(*cntr));
-	if (!cntr)
-		return -FI_ENOMEM;
-
-	dlist_init(&cntr->ibv_cq_poll_list);
-	cntr->need_to_scan_ep_list = false;
-	efa_domain = container_of(domain, struct efa_domain,
-				  util_domain.domain_fid);
-
-	ret = ofi_cntr_init(&efa_prov, domain, attr, &cntr->util_cntr,
-			    efa_rdm_cntr_progress, context);
-
-	if (ret)
-		goto free;
-
-	*cntr_fid = &cntr->util_cntr.cntr_fid;
-	cntr->util_cntr.cntr_fid.ops = &efa_cntr_ops;
-	cntr->util_cntr.cntr_fid.fid.ops = &efa_cntr_fi_ops;
-
-	/* open shm cntr as peer cntr */
-	if (efa_domain->shm_domain) {
-		memcpy(&shm_cntr_attr, attr, sizeof(*attr));
-		shm_cntr_attr.flags |= FI_PEER;
-		peer_cntr_context.size = sizeof(peer_cntr_context);
-		peer_cntr_context.cntr = cntr->util_cntr.peer_cntr;
-		ret = fi_cntr_open(efa_domain->shm_domain, &shm_cntr_attr,
-				   &cntr->shm_cntr, &peer_cntr_context);
-		if (ret) {
-			EFA_WARN(FI_LOG_CNTR, "Unable to open shm cntr, err: %s\n", fi_strerror(-ret));
-			goto free;
-		}
+	ret = efa_cntr_construct(cntr, domain, attr, efa_cntr_progress, context);
+	if (ret) {
+		free(cntr);
+		return ret;
 	}
 
-	return FI_SUCCESS;
+	*cntr_fid = &cntr->util_cntr.cntr_fid;
+	cntr->util_cntr.cntr_fid.ops = &efa_cntr_ops;
+	cntr->util_cntr.cntr_fid.fid.ops = &efa_cntr_fi_ops;
 
-free:
-	free(cntr);
-	return ret;
+	return FI_SUCCESS;
 }
 
 void efa_cntr_report_tx_completion(struct util_ep *ep, uint64_t flags)

--- a/prov/efa/src/efa_cntr.h
+++ b/prov/efa/src/efa_cntr.h
@@ -10,17 +10,25 @@
 
 struct efa_cntr {
 	struct util_cntr util_cntr;
-	struct fid_cntr *shm_cntr;
 	struct dlist_entry ibv_cq_poll_list;
-	/* Only used by RDM EP type */
-	bool need_to_scan_ep_list;
 };
 
 int efa_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 		  struct fid_cntr **cntr_fid, void *context);
 
-int efa_rdm_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
-		      struct fid_cntr **cntr_fid, void *context);
+int efa_cntr_construct(struct efa_cntr *cntr, struct fid_domain *domain,
+		       struct fi_cntr_attr *attr,
+		       ofi_cntr_progress_func progress, void *context);
+
+void efa_cntr_destruct(struct efa_cntr *cntr);
+
+void efa_cntr_progress_ibv_cq_poll_list(struct efa_cntr *efa_cntr);
+
+uint64_t efa_cntr_read(struct fid_cntr *cntr_fid);
+
+uint64_t efa_cntr_readerr(struct fid_cntr *cntr_fid);
+
+int efa_cntr_wait(struct fid_cntr *cntr_fid, uint64_t threshold, int timeout);
 
 void efa_cntr_report_tx_completion(struct util_ep *ep, uint64_t flags);
 
@@ -29,4 +37,3 @@ void efa_cntr_report_rx_completion(struct util_ep *ep, uint64_t flags);
 void efa_cntr_report_error(struct util_ep *ep, uint64_t flags);
 
 #endif
-

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -9,6 +9,7 @@
 #include "efa.h"
 #include "efa_av.h"
 #include "efa_cntr.h"
+#include "rdm/efa_rdm_cntr.h"
 #include "rdm/efa_rdm_cq.h"
 #include "rdm/efa_rdm_atomic.h"
 #include "efa_rdm_mr.h"

--- a/prov/efa/src/rdm/efa_rdm_cntr.c
+++ b/prov/efa/src/rdm/efa_rdm_cntr.c
@@ -1,0 +1,208 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright (c) 2013-2018 Intel Corporation, Inc.  All rights reserved. */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#include "ofi_util.h"
+#include "efa.h"
+#include "efa_cntr.h"
+#include "efa_cq.h"
+#include "efa_domain.h"
+#include "rdm/efa_rdm_cntr.h"
+#include "rdm/efa_rdm_cq.h"
+#include "rdm/efa_rdm_ep.h"
+
+static uint64_t efa_rdm_cntr_read(struct fid_cntr *cntr_fid)
+{
+	struct efa_rdm_cntr *efa_rdm_cntr;
+	struct efa_domain *domain;
+
+	efa_rdm_cntr = container_of(cntr_fid, struct efa_rdm_cntr, efa_cntr.util_cntr.cntr_fid);
+	domain = container_of(efa_rdm_cntr->efa_cntr.util_cntr.domain, struct efa_domain, util_domain);
+
+	/* Flush SHM completions into the peer counter before reading */
+	ofi_genlock_lock(&domain->srx_lock);
+	if (efa_rdm_cntr->shm_cntr)
+		fi_cntr_read(efa_rdm_cntr->shm_cntr);
+	ofi_genlock_unlock(&domain->srx_lock);
+
+	return efa_cntr_read(cntr_fid);
+}
+
+static uint64_t efa_rdm_cntr_readerr(struct fid_cntr *cntr_fid)
+{
+	struct efa_rdm_cntr *efa_rdm_cntr;
+	struct efa_domain *domain;
+
+	efa_rdm_cntr = container_of(cntr_fid, struct efa_rdm_cntr, efa_cntr.util_cntr.cntr_fid);
+	domain = container_of(efa_rdm_cntr->efa_cntr.util_cntr.domain, struct efa_domain, util_domain);
+
+	ofi_genlock_lock(&domain->srx_lock);
+	if (efa_rdm_cntr->shm_cntr)
+		fi_cntr_read(efa_rdm_cntr->shm_cntr);
+	ofi_genlock_unlock(&domain->srx_lock);
+
+	return efa_cntr_readerr(cntr_fid);
+}
+
+static struct fi_ops_cntr efa_rdm_cntr_ops = {
+	.size = sizeof(struct fi_ops_cntr),
+	.read = efa_rdm_cntr_read,
+	.readerr = efa_rdm_cntr_readerr,
+	.add = ofi_cntr_add,
+	.adderr = ofi_cntr_adderr,
+	.set = ofi_cntr_set,
+	.seterr = ofi_cntr_seterr,
+	.wait = efa_cntr_wait
+};
+
+static int efa_rdm_cntr_close(struct fid *fid)
+{
+	struct efa_rdm_cntr *cntr;
+	int ret, retv;
+
+	retv = 0;
+	cntr = container_of(fid, struct efa_rdm_cntr, efa_cntr.util_cntr.cntr_fid.fid);
+
+	if (cntr->shm_cntr) {
+		ret = fi_close(&cntr->shm_cntr->fid);
+		if (ret) {
+			EFA_WARN(FI_LOG_CNTR, "Unable to close shm cntr: %s\n", fi_strerror(-ret));
+			retv = ret;
+		}
+	}
+
+	efa_cntr_destruct(&cntr->efa_cntr);
+	free(cntr);
+	return retv;
+}
+
+static struct fi_ops efa_rdm_cntr_fi_ops = {
+	.size = sizeof(efa_rdm_cntr_fi_ops),
+	.close = efa_rdm_cntr_close,
+	.bind = fi_no_bind,
+	.control = fi_no_control,
+	.ops_open = fi_no_ops_open,
+};
+
+static void efa_rdm_cntr_progress(struct util_cntr *cntr)
+{
+	struct dlist_entry *item;
+	struct efa_rdm_cntr *efa_rdm_cntr;
+	struct efa_domain *efa_domain;
+	struct efa_rdm_ep *efa_rdm_ep;
+	struct fid_list_entry *fid_entry;
+
+	ofi_genlock_lock(&cntr->ep_list_lock);
+	efa_rdm_cntr = container_of(cntr, struct efa_rdm_cntr, efa_cntr.util_cntr);
+	efa_domain = container_of(efa_rdm_cntr->efa_cntr.util_cntr.domain, struct efa_domain, util_domain);
+
+	/**
+	 * TODO: It's better to just post the initial batch of internal rx pkts during ep enable
+	 * so we don't have to iterate cntr->ep_list here.
+	 * However, it is observed that doing that will hurt performance if application opens
+	 * some idle endpoints and never poll completions for them. Move these initial posts to
+	 * the first polling before having a long term fix.
+	 */
+	if (efa_rdm_cntr->need_to_scan_ep_list) {
+		dlist_foreach(&cntr->ep_list, item) {
+			fid_entry = container_of(item, struct fid_list_entry, entry);
+			efa_rdm_ep = container_of(fid_entry->fid, struct efa_rdm_ep, base_ep.util_ep.ep_fid.fid);
+			if (efa_rdm_ep->base_ep.efa_qp_enabled)
+				efa_rdm_ep_post_internal_rx_pkts(efa_rdm_ep);
+		}
+		efa_rdm_cntr->need_to_scan_ep_list = false;
+	}
+
+	efa_cntr_progress_ibv_cq_poll_list(&efa_rdm_cntr->efa_cntr);
+	efa_domain_progress_rdm_peers_and_queues(efa_domain);
+	ofi_genlock_unlock(&cntr->ep_list_lock);
+}
+
+int efa_rdm_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
+		      struct fid_cntr **cntr_fid, void *context)
+{
+	int ret;
+	struct efa_rdm_cntr *cntr;
+	struct efa_domain *efa_domain;
+	struct fi_cntr_attr shm_cntr_attr = {0};
+	struct fi_peer_cntr_context peer_cntr_context = {0};
+
+	cntr = calloc(1, sizeof(*cntr));
+	if (!cntr)
+		return -FI_ENOMEM;
+
+	cntr->need_to_scan_ep_list = false;
+	efa_domain = container_of(domain, struct efa_domain,
+				  util_domain.domain_fid);
+
+	ret = efa_cntr_construct(&cntr->efa_cntr, domain, attr,
+				 efa_rdm_cntr_progress, context);
+	if (ret)
+		goto free;
+
+	*cntr_fid = &cntr->efa_cntr.util_cntr.cntr_fid;
+	cntr->efa_cntr.util_cntr.cntr_fid.ops = &efa_rdm_cntr_ops;
+	cntr->efa_cntr.util_cntr.cntr_fid.fid.ops = &efa_rdm_cntr_fi_ops;
+
+	/* open shm cntr as peer cntr */
+	if (efa_domain->shm_domain) {
+		memcpy(&shm_cntr_attr, attr, sizeof(*attr));
+		shm_cntr_attr.flags |= FI_PEER;
+		peer_cntr_context.size = sizeof(peer_cntr_context);
+		peer_cntr_context.cntr = cntr->efa_cntr.util_cntr.peer_cntr;
+		ret = fi_cntr_open(efa_domain->shm_domain, &shm_cntr_attr,
+				   &cntr->shm_cntr, &peer_cntr_context);
+		if (ret) {
+			EFA_WARN(FI_LOG_CNTR, "Unable to open shm cntr, err: %s\n", fi_strerror(-ret));
+			goto free;
+		}
+	}
+
+	return FI_SUCCESS;
+
+free:
+	free(cntr);
+	return ret;
+}
+
+/**
+ * @brief Insert tx/rx cq into the cntr ibv_cq_poll_list for efa-rdm EP
+ *
+ * Reuses efa_base_ep_insert_cntr_ibv_cq_poll_list for the common logic,
+ * then sets need_to_scan_ep_list on each bound efa_rdm_cntr.
+ *
+ * @param ep efa_base_ep
+ * @return int 0 on success, negative integer on failure
+ */
+int efa_rdm_ep_insert_cntr_ibv_cq_poll_list(struct efa_base_ep *ep)
+{
+	int i, ret;
+	struct efa_rdm_cntr *efa_rdm_cntr;
+	struct util_cntr *util_cntr;
+
+	ret = efa_base_ep_insert_cntr_ibv_cq_poll_list(ep);
+	if (ret)
+		return ret;
+
+	for (i = 0; i < CNTR_CNT; i++) {
+		util_cntr = ep->util_ep.cntrs[i];
+		if (util_cntr) {
+			efa_rdm_cntr = container_of(util_cntr, struct efa_rdm_cntr, efa_cntr.util_cntr);
+			ofi_genlock_lock(&efa_rdm_cntr->efa_cntr.util_cntr.ep_list_lock);
+			efa_rdm_cntr->need_to_scan_ep_list = true;
+			ofi_genlock_unlock(&efa_rdm_cntr->efa_cntr.util_cntr.ep_list_lock);
+		}
+	}
+
+	return FI_SUCCESS;
+}
+
+/**
+ * @brief Remove tx/rx cq from the cntr ibv_cq_poll_list for efa-rdm EP
+ *
+ * @param ep efa_base_ep
+ */
+void efa_rdm_ep_remove_cntr_ibv_cq_poll_list(struct efa_base_ep *ep)
+{
+	efa_base_ep_remove_cntr_ibv_cq_poll_list(ep);
+}

--- a/prov/efa/src/rdm/efa_rdm_cntr.h
+++ b/prov/efa/src/rdm/efa_rdm_cntr.h
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#ifndef _EFA_RDM_CNTR_H_
+#define _EFA_RDM_CNTR_H_
+
+#include "efa_cntr.h"
+
+struct efa_rdm_cntr {
+	struct efa_cntr efa_cntr;
+	struct fid_cntr *shm_cntr;
+	bool need_to_scan_ep_list;
+};
+
+_Static_assert(offsetof(struct efa_rdm_cntr, efa_cntr) == 0,
+	       "efa_rdm_cntr::efa_cntr must be the first member");
+
+int efa_rdm_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
+		      struct fid_cntr **cntr_fid, void *context);
+
+int efa_rdm_ep_insert_cntr_ibv_cq_poll_list(struct efa_base_ep *ep);
+
+void efa_rdm_ep_remove_cntr_ibv_cq_poll_list(struct efa_base_ep *ep);
+
+#endif

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -14,6 +14,7 @@
 #include "efa_rdm_pke_req.h"
 #include "efa_rdm_pke_utils.h"
 #include "efa_cntr.h"
+#include "efa_rdm_cntr.h"
 #include "efa_rdm_mr.h"
 
 
@@ -643,7 +644,7 @@ static int efa_rdm_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 		container_of(ep_fid, struct efa_rdm_ep, base_ep.util_ep.ep_fid.fid);
 	struct efa_rdm_cq *cq;
 	struct efa_av *av;
-	struct efa_cntr *cntr;
+	struct efa_rdm_cntr *cntr;
 	struct util_eq *eq;
 	int ret = 0;
 
@@ -682,9 +683,9 @@ static int efa_rdm_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 		}
 		break;
 	case FI_CLASS_CNTR:
-		cntr = container_of(bfid, struct efa_cntr, util_cntr.cntr_fid.fid);
+		cntr = container_of(bfid, struct efa_rdm_cntr, efa_cntr.util_cntr.cntr_fid.fid);
 
-		ret = ofi_ep_bind_cntr(&efa_rdm_ep->base_ep.util_ep, &cntr->util_cntr, flags);
+		ret = ofi_ep_bind_cntr(&efa_rdm_ep->base_ep.util_ep, &cntr->efa_cntr.util_cntr, flags);
 		if (ret)
 			return ret;
 
@@ -1073,7 +1074,7 @@ static int efa_rdm_ep_close(struct fid *fid)
 	 * with other threads progressing the cq. */
 	efa_base_ep_close_util_ep(&efa_rdm_ep->base_ep);
 
-	efa_base_ep_remove_cntr_ibv_cq_poll_list(&efa_rdm_ep->base_ep);
+	efa_rdm_ep_remove_cntr_ibv_cq_poll_list(&efa_rdm_ep->base_ep);
 
 	if (efa_rdm_ep->self_ah)
 		efa_ah_release(efa_rdm_ep->base_ep.domain, efa_rdm_ep->self_ah, false);
@@ -1405,7 +1406,7 @@ static int efa_rdm_ep_ctrl(struct fid *fid, int command, void *arg)
 		if (ret)
 			goto err_destroy_qp;
 
-		ret = efa_base_ep_insert_cntr_ibv_cq_poll_list(&ep->base_ep);
+		ret = efa_rdm_ep_insert_cntr_ibv_cq_poll_list(&ep->base_ep);
 		if (ret)
 			goto err_destroy_qp;
 

--- a/prov/efa/test/efa_unit_test_cntr.c
+++ b/prov/efa/test/efa_unit_test_cntr.c
@@ -2,11 +2,12 @@
 /* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
 #include "efa_unit_tests.h"
 #include "efa_cntr.h"
+#include "rdm/efa_rdm_cntr.h"
 
 /**
- * @brief get the length of the ibv_cq_poll_list for a given efa_rdm_cq
+ * @brief get the length of the ibv_cq_poll_list for a given efa_cntr (efa-direct)
  *
- * @param cq_fid cq fid
+ * @param cntr_fid cntr fid
  * @return int the length of the ibv_cq_poll_list
  */
 static
@@ -24,63 +25,80 @@ int test_efa_cntr_get_ibv_cq_poll_list_length(struct fid_cntr *cntr_fid)
 	return i;
 }
 
+
+
 /**
  * @brief Check the length of ibv_cq_poll_list in cntr when 1 cq is bind to 1 ep
- * as both tx/rx cq.
+ * as both tx/rx cq. (efa-direct)
  *
  * @param state struct efa_resource that is managed by the framework
  */
-static
-void test_efa_cntr_ibv_cq_poll_list_same_tx_rx_cq_single_ep_impl(struct efa_resource *resource)
+void test_efa_cntr_ibv_cq_poll_list_same_tx_rx_cq_single_ep(struct efa_resource **state)
 {
-    struct fid_cntr *cntr;
-    struct fi_cntr_attr cntr_attr = {0};
+	struct efa_resource *resource = *state;
+	struct fid_cntr *cntr;
+	struct fi_cntr_attr cntr_attr = {0};
 
-    assert_int_equal(fi_cntr_open(resource->domain, &cntr_attr, &cntr, NULL), 0);
+	efa_unit_test_resource_construct_ep_not_enabled(resource, FI_EP_RDM, EFA_DIRECT_FABRIC_NAME);
 
-    /* TODO: expand this test to all flags */
+	assert_int_equal(fi_cntr_open(resource->domain, &cntr_attr, &cntr, NULL), 0);
+
+	/* TODO: expand this test to all flags */
 	assert_int_equal(fi_ep_bind(resource->ep, &cntr->fid, FI_TRANSMIT), 0);
 
-    assert_int_equal(fi_enable(resource->ep), 0);
+	assert_int_equal(fi_enable(resource->ep), 0);
 
 	/* efa_unit_test_resource_construct binds single OFI CQ as both tx/rx cq of ep */
 	assert_int_equal(test_efa_cntr_get_ibv_cq_poll_list_length(cntr), 1);
 
-    /* ep must be closed before cq/av/eq... */
+	/* ep must be closed before cq/av/eq... */
 	fi_close(&resource->ep->fid);
 	resource->ep = NULL;
 
-    fi_close(&cntr->fid);
-}
-
-void test_efa_cntr_ibv_cq_poll_list_same_tx_rx_cq_single_ep(struct efa_resource **state)
-{
-	struct efa_resource *resource = *state;
-
-	efa_unit_test_resource_construct_ep_not_enabled(resource, FI_EP_RDM, EFA_DIRECT_FABRIC_NAME);
-	test_efa_cntr_ibv_cq_poll_list_same_tx_rx_cq_single_ep_impl(resource);
+	fi_close(&cntr->fid);
 }
 
 void test_efa_rdm_cntr_ibv_cq_poll_list_same_tx_rx_cq_single_ep(struct efa_resource **state)
 {
 	struct efa_resource *resource = *state;
+	struct fid_cntr *cntr;
+	struct fi_cntr_attr cntr_attr = {0};
 
 	efa_unit_test_resource_construct_ep_not_enabled(resource, FI_EP_RDM, EFA_FABRIC_NAME);
-	test_efa_cntr_ibv_cq_poll_list_same_tx_rx_cq_single_ep_impl(resource);
+
+	assert_int_equal(fi_cntr_open(resource->domain, &cntr_attr, &cntr, NULL), 0);
+
+	/* TODO: expand this test to all flags */
+	assert_int_equal(fi_ep_bind(resource->ep, &cntr->fid, FI_TRANSMIT), 0);
+
+	assert_int_equal(fi_enable(resource->ep), 0);
+
+	/* efa_unit_test_resource_construct binds single OFI CQ as both tx/rx cq of ep */
+	assert_int_equal(efa_unit_test_get_dlist_length(
+		&container_of(cntr, struct efa_rdm_cntr, efa_cntr.util_cntr.cntr_fid)->efa_cntr.ibv_cq_poll_list), 1);
+
+	/* ep must be closed before cq/av/eq... */
+	fi_close(&resource->ep->fid);
+	resource->ep = NULL;
+
+	fi_close(&cntr->fid);
 }
 
 /**
  * @brief Check the length of ibv_cq_poll_list in cntr when separate tx/rx cq is bind to 1 ep.
+ * (efa-direct)
  *
  * @param state struct efa_resource that is managed by the framework
  */
-static
-void test_efa_cntr_ibv_cq_poll_list_separate_tx_rx_cq_single_ep_impl(struct efa_resource *resource)
+void test_efa_cntr_ibv_cq_poll_list_separate_tx_rx_cq_single_ep(struct efa_resource **state)
 {
+	struct efa_resource *resource = *state;
 	struct fid_cq *txcq, *rxcq;
 	struct fi_cq_attr cq_attr = {0};
-    struct fid_cntr *cntr;
-    struct fi_cntr_attr cntr_attr = {0};
+	struct fid_cntr *cntr;
+	struct fi_cntr_attr cntr_attr = {0};
+
+	efa_unit_test_resource_construct_no_cq_and_ep_not_enabled(resource, FI_EP_RDM, EFA_DIRECT_FABRIC_NAME);
 
 	assert_int_equal(fi_cq_open(resource->domain, &cq_attr, &txcq, NULL), 0);
 
@@ -90,9 +108,9 @@ void test_efa_cntr_ibv_cq_poll_list_separate_tx_rx_cq_single_ep_impl(struct efa_
 
 	assert_int_equal(fi_ep_bind(resource->ep, &rxcq->fid, FI_RECV), 0);
 
-    assert_int_equal(fi_cntr_open(resource->domain, &cntr_attr, &cntr, NULL), 0);
+	assert_int_equal(fi_cntr_open(resource->domain, &cntr_attr, &cntr, NULL), 0);
 
-    /* TODO: expand this test to all flags */
+	/* TODO: expand this test to all flags */
 	assert_int_equal(fi_ep_bind(resource->ep, &cntr->fid, FI_TRANSMIT), 0);
 
 	assert_int_equal(fi_enable(resource->ep), 0);
@@ -104,23 +122,43 @@ void test_efa_cntr_ibv_cq_poll_list_separate_tx_rx_cq_single_ep_impl(struct efa_
 	resource->ep = NULL;
 	fi_close(&txcq->fid);
 	fi_close(&rxcq->fid);
-    fi_close(&cntr->fid);
-}
-
-void test_efa_cntr_ibv_cq_poll_list_separate_tx_rx_cq_single_ep(struct efa_resource **state)
-{
-	struct efa_resource *resource = *state;
-
-	efa_unit_test_resource_construct_no_cq_and_ep_not_enabled(resource, FI_EP_RDM, EFA_DIRECT_FABRIC_NAME);
-	test_efa_cntr_ibv_cq_poll_list_separate_tx_rx_cq_single_ep_impl(resource);
+	fi_close(&cntr->fid);
 }
 
 void test_efa_rdm_cntr_ibv_cq_poll_list_separate_tx_rx_cq_single_ep(struct efa_resource **state)
 {
 	struct efa_resource *resource = *state;
+	struct fid_cq *txcq, *rxcq;
+	struct fi_cq_attr cq_attr = {0};
+	struct fid_cntr *cntr;
+	struct fi_cntr_attr cntr_attr = {0};
 
 	efa_unit_test_resource_construct_no_cq_and_ep_not_enabled(resource, FI_EP_RDM, EFA_FABRIC_NAME);
-	test_efa_cntr_ibv_cq_poll_list_separate_tx_rx_cq_single_ep_impl(resource);
+
+	assert_int_equal(fi_cq_open(resource->domain, &cq_attr, &txcq, NULL), 0);
+
+	assert_int_equal(fi_ep_bind(resource->ep, &txcq->fid, FI_SEND), 0);
+
+	assert_int_equal(fi_cq_open(resource->domain, &cq_attr, &rxcq, NULL), 0);
+
+	assert_int_equal(fi_ep_bind(resource->ep, &rxcq->fid, FI_RECV), 0);
+
+	assert_int_equal(fi_cntr_open(resource->domain, &cntr_attr, &cntr, NULL), 0);
+
+	/* TODO: expand this test to all flags */
+	assert_int_equal(fi_ep_bind(resource->ep, &cntr->fid, FI_TRANSMIT), 0);
+
+	assert_int_equal(fi_enable(resource->ep), 0);
+
+	assert_int_equal(efa_unit_test_get_dlist_length(
+		&container_of(cntr, struct efa_rdm_cntr, efa_cntr.util_cntr.cntr_fid)->efa_cntr.ibv_cq_poll_list), 2);
+
+	/* ep must be closed before cq/av/eq... */
+	fi_close(&resource->ep->fid);
+	resource->ep = NULL;
+	fi_close(&txcq->fid);
+	fi_close(&rxcq->fid);
+	fi_close(&cntr->fid);
 }
 
 void test_efa_rdm_cntr_post_initial_rx_pkts(struct efa_resource **state)
@@ -129,7 +167,7 @@ void test_efa_rdm_cntr_post_initial_rx_pkts(struct efa_resource **state)
 	struct efa_rdm_ep *efa_rdm_ep;
 	struct fid_cntr *cntr;
 	struct fi_cntr_attr cntr_attr = {0};
-	struct efa_cntr *efa_cntr;
+	struct efa_rdm_cntr *efa_rdm_cntr;
 	uint64_t cnt;
 
 	efa_unit_test_resource_construct_ep_not_enabled(resource, FI_EP_RDM, EFA_FABRIC_NAME);
@@ -147,10 +185,10 @@ void test_efa_rdm_cntr_post_initial_rx_pkts(struct efa_resource **state)
 
 	assert_int_equal(fi_enable(resource->ep), 0);
 
-	efa_cntr = container_of(cntr, struct efa_cntr, util_cntr.cntr_fid);
+	efa_rdm_cntr = container_of(cntr, struct efa_rdm_cntr, efa_cntr.util_cntr.cntr_fid);
 
 	/* cntr read need to scan the ep list since a ep is bind */
-	assert_true(efa_cntr->need_to_scan_ep_list);
+	assert_true(efa_rdm_cntr->need_to_scan_ep_list);
 
 	cnt = fi_cntr_read(cntr);
 	/* No completion should be read */
@@ -162,7 +200,7 @@ void test_efa_rdm_cntr_post_initial_rx_pkts(struct efa_resource **state)
 	assert_int_equal(efa_rdm_ep->efa_rx_pkts_held, 0);
 
 	/* scan is done */
-	assert_false(efa_cntr->need_to_scan_ep_list);
+	assert_false(efa_rdm_cntr->need_to_scan_ep_list);
 	/* ep must be closed before cq/av/eq... */
 	fi_close(&resource->ep->fid);
 	resource->ep = NULL;


### PR DESCRIPTION
## Summary

  As part of the EFA provider refactoring effort, this PR separates the shared
  `struct efa_cntr` into two independent implementations:

  - **`struct efa_cntr`** (efa-direct): core counter with `util_cntr` + `ibv_cq_poll_list`
  - **`struct efa_rdm_cntr`** (efa-rdm): protocol-level counter with SHM integration
    and EP scan list management

  ### Changes

  **New files:**
  - `prov/efa/src/rdm/efa_rdm_cntr.h` - efa-rdm counter struct and declarations
  - `prov/efa/src/rdm/efa_rdm_cntr.c` - efa-rdm counter open/close/read/readerr/progress,
    EP poll list insert/remove

  **Modified files:**
  - `prov/efa/src/efa_cntr.h` - removed efa-rdm-only fields (`shm_cntr`, `need_to_scan_ep_list`)
  - `prov/efa/src/efa_cntr.c` - removed efa-rdm code, made `efa_cntr_wait` shared
  - `prov/efa/src/efa_base_ep.c` - removed `need_to_scan_ep_list` from efa-direct path
  - `prov/efa/src/efa_domain.c` - added `efa_rdm_cntr.h` include
  - `prov/efa/src/rdm/efa_rdm_ep_fiops.c` - use `efa_rdm_cntr` for EP bind/enable/close
  - `prov/efa/test/efa_unit_test_cntr.c` - updated tests for correct struct types

  ### Design

  Per the EFA refactoring project, CNTR does **not** use efa-direct/efa-rdm
  layering because:
  1. Semantic mismatch (protocol-level vs device-level completions)
  2. Performance impact (binding cntr forces CQ out of bypass mode)
  3. Implementation complexity (counting tied to protocol state machines)

  The two structs are fully independent. Shared functions (`efa_cntr_wait`,
  `efa_cntr_report_tx/rx_completion`, `efa_cntr_report_error`) operate on
  `util_cntr`/`util_ep` abstractions and work for both paths.