### PR TITLE
prov/efa: Cleanup EP/CQ

### DIFF
--- a/prov/efa/src/efa_base_ep.c
+++ b/prov/efa/src/efa_base_ep.c
@@ -684,6 +684,8 @@ int efa_base_ep_construct(struct efa_base_ep *base_ep,
 				     &base_ep->inject_rma_size);
 
 	base_ep->use_unsolicited_write_recv = true;
+	base_ep->ope_pool = NULL;
+	dlist_init(&base_ep->ope_list);
 	return 0;
 }
 

--- a/prov/efa/src/efa_base_ep.c
+++ b/prov/efa/src/efa_base_ep.c
@@ -414,17 +414,18 @@ static int efa_base_ep_create_qp(struct efa_base_ep *base_ep,
 
 	assert(tx_cq->unsolicited_write_recv_enabled == rx_cq->unsolicited_write_recv_enabled);
 
-	if (EFA_INFO_TYPE_IS_DIRECT(base_ep->info)) {
-		/* If user intend to post rx buffer for cq data, we shouldn't
-		 * enable unsolicited write recv */
-		use_unsolicited_write_recv =
-			tx_cq->unsolicited_write_recv_enabled && !(base_ep->info->mode & FI_RX_CQ_DATA);
-	} else {
-		/* RDM full protocol doesn't support FI_RX_CQ_DATA.
-		 * Set FI_OPT_EFA_USE_UNSOLICITED_WRITE_RECV to false to disable unsolicited write recv. */
-		use_unsolicited_write_recv =
-			tx_cq->unsolicited_write_recv_enabled && base_ep->use_unsolicited_write_recv;
-	}
+	/*
+	 * Unsolicited write recv requires hardware support
+	 * (unsolicited_write_recv_enabled) and that the endpoint opted into it
+	 * (use_unsolicited_write_recv, true by default, cleared by efa-rdm via
+	 * FI_OPT_EFA_USE_UNSOLICITED_WRITE_RECV). It must also be disabled when
+	 * the user intends to post rx buffers for cq data (FI_RX_CQ_DATA); the
+	 * efa-rdm full protocol does not set FI_RX_CQ_DATA in its mode.
+	 */
+	use_unsolicited_write_recv =
+		tx_cq->unsolicited_write_recv_enabled &&
+		base_ep->use_unsolicited_write_recv &&
+		!(base_ep->info->mode & FI_RX_CQ_DATA);
 	EFA_INFO(FI_LOG_EP_CTRL, "creating QP with unsolicited write recv status: %d\n", use_unsolicited_write_recv);
 	ret = efa_qp_create(&base_ep->qp, &attr_ex, base_ep->info->tx_attr->tclass,
 			    use_unsolicited_write_recv);

--- a/prov/efa/src/efa_base_ep.h
+++ b/prov/efa/src/efa_base_ep.h
@@ -91,11 +91,15 @@ struct efa_base_ep {
 
 	bool use_unsolicited_write_recv;
 
+	/* Pool and list for outstanding operation entries. Shared by both
+	 * efa-direct (efa_direct_ope) and efa-rdm (efa_rdm_ope) endpoints;
+	 * entries are linked via ope_list and used to warn on MR close while
+	 * an operation that still references the MR is in flight. */
+	struct ofi_bufpool *ope_pool;
+	struct dlist_entry ope_list;
+
 	/* entry for efa_domain->base_ep_list */
 	struct dlist_entry base_ep_entry;
-	/* Only used by EFA direct */
-	struct ofi_bufpool *efa_direct_ope_pool;	/**< pool for efa_direct_ope */
-	struct dlist_entry efa_direct_ope_list;	/**< list of outstanding ops */
 };
 
 int efa_base_ep_bind_av(struct efa_base_ep *base_ep, struct efa_av *av);

--- a/prov/efa/src/efa_direct_ope.c
+++ b/prov/efa/src/efa_direct_ope.c
@@ -17,13 +17,13 @@ int efa_direct_ope_pool_create(struct efa_base_ep *base_ep)
 	int ret;
 
 	if (!efa_env.track_mr) {
-		base_ep->efa_direct_ope_pool = NULL;
+		base_ep->ope_pool = NULL;
 		return 0;
 	}
 
-	dlist_init(&base_ep->efa_direct_ope_list);
+	dlist_init(&base_ep->ope_list);
 
-	ret = ofi_bufpool_create(&base_ep->efa_direct_ope_pool,
+	ret = ofi_bufpool_create(&base_ep->ope_pool,
 				 sizeof(struct efa_direct_ope),
 				 EFA_RDM_BUFPOOL_ALIGNMENT,
 				 base_ep->info->tx_attr->size + base_ep->info->rx_attr->size,
@@ -36,10 +36,10 @@ int efa_direct_ope_pool_create(struct efa_base_ep *base_ep)
 		return ret;
 	}
 
-	ret = ofi_bufpool_grow(base_ep->efa_direct_ope_pool);
+	ret = ofi_bufpool_grow(base_ep->ope_pool);
 	if (ret) {
-		ofi_bufpool_destroy(base_ep->efa_direct_ope_pool);
-		base_ep->efa_direct_ope_pool = NULL;
+		ofi_bufpool_destroy(base_ep->ope_pool);
+		base_ep->ope_pool = NULL;
 		return ret;
 	}
 
@@ -54,12 +54,12 @@ void efa_direct_ope_pool_destroy(struct efa_base_ep *base_ep)
 	struct efa_direct_ope *direct_ope;
 	struct dlist_entry *tmp;
 
-	if (!base_ep->efa_direct_ope_pool)
+	if (!base_ep->ope_pool)
 		return;
 
 	ofi_genlock_lock(&base_ep->domain->util_domain.lock);
-	if (!dlist_empty(&base_ep->efa_direct_ope_list)) {
-		dlist_foreach_container_safe(&base_ep->efa_direct_ope_list,
+	if (!dlist_empty(&base_ep->ope_list)) {
+		dlist_foreach_container_safe(&base_ep->ope_list,
 					     struct efa_direct_ope,
 					     direct_ope, entry, tmp) {
 			dlist_remove(&direct_ope->entry);
@@ -69,8 +69,8 @@ void efa_direct_ope_pool_destroy(struct efa_base_ep *base_ep)
 	ofi_genlock_unlock(&base_ep->domain->util_domain.lock);
 
 	EFA_INFO(FI_LOG_EP_CTRL, "ep %p: Destroying EFA direct op entry pool\n", base_ep);
-	ofi_bufpool_destroy(base_ep->efa_direct_ope_pool);
-	base_ep->efa_direct_ope_pool = NULL;
+	ofi_bufpool_destroy(base_ep->ope_pool);
+	base_ep->ope_pool = NULL;
 }
 
 struct efa_direct_ope *efa_direct_ope_alloc(struct efa_base_ep *base_ep,
@@ -86,10 +86,10 @@ struct efa_direct_ope *efa_direct_ope_alloc(struct efa_base_ep *base_ep,
 	uint64_t data = msg ? msg->data : msg_rma->data;
 	size_t i;
 
-	if (!base_ep->efa_direct_ope_pool)
+	if (!base_ep->ope_pool)
 		return NULL;
 
-	direct_ope = ofi_buf_alloc(base_ep->efa_direct_ope_pool);
+	direct_ope = ofi_buf_alloc(base_ep->ope_pool);
 	if (OFI_UNLIKELY(!direct_ope)) {
 		EFA_WARN(FI_LOG_EP_DATA,
 			 "Failed to allocate EFA direct OPE\n");
@@ -110,7 +110,7 @@ struct efa_direct_ope *efa_direct_ope_alloc(struct efa_base_ep *base_ep,
 	}
 
 	ofi_genlock_lock(&base_ep->domain->util_domain.lock);
-	dlist_insert_tail(&direct_ope->entry, &base_ep->efa_direct_ope_list);
+	dlist_insert_tail(&direct_ope->entry, &base_ep->ope_list);
 	ofi_genlock_unlock(&base_ep->domain->util_domain.lock);
 
 	return direct_ope;
@@ -119,7 +119,10 @@ struct efa_direct_ope *efa_direct_ope_alloc(struct efa_base_ep *base_ep,
 void efa_direct_ope_release(struct efa_base_ep *base_ep,
 				  struct efa_direct_ope *direct_ope)
 {
-	if (!direct_ope || !base_ep || !base_ep->efa_direct_ope_pool)
+	if (!direct_ope || !base_ep)
+		return;
+
+	if (!base_ep->ope_pool)
 		return;
 
 	ofi_genlock_lock(&base_ep->domain->util_domain.lock);

--- a/prov/efa/src/efa_direct_ope.h
+++ b/prov/efa/src/efa_direct_ope.h
@@ -49,7 +49,7 @@ void efa_direct_ope_pool_destroy(struct efa_base_ep *base_ep);
 /**
  * @brief Allocate and record an operation entry
  *
- * Acquires efa_domain->util_domain.lock to protect the efa_direct_ope_list.
+ * Acquires efa_domain->util_domain.lock to protect the ope_list.
  * This is the same lock used by efa_mr_close when iterating across all EPs.
  *
  * @param[in,out] base_ep	base endpoint
@@ -66,7 +66,7 @@ struct efa_direct_ope *efa_direct_ope_alloc(struct efa_base_ep *base_ep,
 /**
  * @brief Release an operation entry
  *
- * Acquires efa_domain->util_domain.lock to protect the efa_direct_ope_list.
+ * Acquires efa_domain->util_domain.lock to protect the ope_list.
  * This is the same lock used by efa_mr_close when iterating across all EPs.
  *
  * @param[in,out] base_ep	base endpoint

--- a/prov/efa/src/efa_ep.c
+++ b/prov/efa/src/efa_ep.c
@@ -334,23 +334,23 @@ static int efa_ep_setflags(struct fid_ep *ep_fid, uint64_t flags)
 
 static int efa_ep_enable(struct fid_ep *ep_fid)
 {
-	struct efa_base_ep *ep;
+	struct efa_base_ep *base_ep;
 	int err;
 
-	ep = container_of(ep_fid, struct efa_base_ep, util_ep.ep_fid);
+	base_ep = container_of(ep_fid, struct efa_base_ep, util_ep.ep_fid);
 
-	err = efa_base_ep_create_and_enable_qp(ep);
+	err = efa_base_ep_create_and_enable_qp(base_ep);
 	if (err)
 		return err;
 
-	err = efa_base_ep_insert_cntr_ibv_cq_poll_list(ep);
+	err = efa_base_ep_insert_cntr_ibv_cq_poll_list(base_ep);
 	if (err) {
-		efa_base_ep_destruct_qp(ep);
+		efa_base_ep_destruct_qp(base_ep);
 		return err;
 	}
 
 	if (efa_env.track_mr)
-		err = efa_direct_ope_pool_create(ep);
+		err = efa_direct_ope_pool_create(base_ep);
 
 	return err;
 }

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -4,6 +4,7 @@
 #include "config.h"
 #include <ofi_util.h>
 #include "efa.h"
+#include "efa_direct_ope.h"
 #include "rdm/efa_rdm_ep.h"
 #include "rdm/efa_rdm_ope.h"
 #if HAVE_CUDA
@@ -252,8 +253,9 @@ static void efa_mr_close_check_inflight_ope(struct efa_mr *efa_mr)
 	dlist_foreach_container(&efa_domain->base_ep_list, struct efa_base_ep,
 				base_ep, base_ep_entry) {
 		struct efa_direct_ope *direct_ope;
+
 		dlist_foreach_container_safe (
-			&base_ep->efa_direct_ope_list,
+			&base_ep->ope_list,
 			struct efa_direct_ope, direct_ope,
 			entry, tmp) {
 			efa_mr_close_warn_inflight_ope(direct_ope->desc, direct_ope->iov_count, &direct_ope->cq_entry, efa_mr, base_ep);

--- a/prov/efa/src/efa_msg.c
+++ b/prov/efa/src/efa_msg.c
@@ -429,16 +429,3 @@ struct fi_ops_msg efa_msg_ops = {
 	.inject = efa_ep_msg_inject,
 	.injectdata = efa_ep_msg_injectdata,
 };
-
-struct fi_ops_msg efa_dgram_ep_msg_ops = {
-	.size = sizeof(struct fi_ops_msg),
-	.recv = efa_ep_recv,
-	.recvv = efa_ep_recvv,
-	.recvmsg = efa_ep_recvmsg,
-	.send = efa_ep_send,
-	.sendv = efa_ep_sendv,
-	.sendmsg = efa_ep_sendmsg,
-	.senddata = efa_ep_senddata,
-	.inject = fi_no_msg_inject,
-	.injectdata = fi_no_msg_injectdata,
-};

--- a/prov/efa/src/efa_rma.c
+++ b/prov/efa/src/efa_rma.c
@@ -446,18 +446,7 @@ ssize_t efa_rma_inject_writedata(struct fid_ep *ep_fid, const void *buf,
 	return efa_rma_post_write(base_ep, &msg, FI_INJECT | FI_REMOTE_CQ_DATA);
 }
 
-struct fi_ops_rma efa_dgram_ep_rma_ops = {
-	.size = sizeof(struct fi_ops_rma),
-	.read = fi_no_rma_read,
-	.readv = fi_no_rma_readv,
-	.readmsg = fi_no_rma_readmsg,
-	.write = fi_no_rma_write,
-	.writev = fi_no_rma_writev,
-	.writemsg = fi_no_rma_writemsg,
-	.inject = fi_no_rma_inject,
-	.writedata = fi_no_rma_writedata,
-	.injectdata = fi_no_rma_injectdata,
-};
+
 
 struct fi_ops_rma efa_rma_ops = {
 	.size = sizeof(struct fi_ops_rma),

--- a/prov/efa/src/rdm/efa_rdm_atomic.c
+++ b/prov/efa/src/rdm/efa_rdm_atomic.c
@@ -58,7 +58,7 @@ efa_rdm_atomic_alloc_txe(struct efa_rdm_ep *efa_rdm_ep,
 		return NULL;
 	}
 
-	txe = ofi_buf_alloc(efa_rdm_ep->ope_pool);
+	txe = ofi_buf_alloc(efa_rdm_ep->base_ep.ope_pool);
 	if (OFI_UNLIKELY(!txe)) {
 		EFA_DBG(FI_LOG_EP_CTRL, "TX entries exhausted.\n");
 		return NULL;

--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -120,8 +120,6 @@ struct efa_rdm_ep {
 	int rx_readcopy_pkt_pool_used;
 	int rx_readcopy_pkt_pool_max_used;
 
-	/* datastructure to maintain send/recv states */
-	struct ofi_bufpool *ope_pool;
 	/* data structure to maintain overflow pke linked list entry */
 	struct ofi_bufpool *overflow_pke_pool;
 	/* data structure to maintain pkt rx map */
@@ -162,9 +160,7 @@ struct efa_rdm_ep {
 	size_t send_comps;
 	size_t recv_comps;
 #endif
-	/* track allocated rx_entries and tx_entries for endpoint cleanup */
-	struct dlist_entry rxe_list;
-	struct dlist_entry txe_list;
+	/* outstanding ops are tracked in base_ep.ope_list */
 
 	/*
 	 * number of posted RX packets for EFA device

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -239,7 +239,13 @@ int efa_rdm_ep_create_buffer_pools(struct efa_rdm_ep *ep)
 	if (ret)
 		goto err_free;
 
-	ret = ofi_bufpool_create(&ep->ope_pool,
+	/*
+	 * Operation entries are tracked on the shared base_ep.ope_list, so
+	 * they are allocated from the shared base_ep.ope_pool. Unlike
+	 * efa-direct, efa-rdm always needs this pool: it backs live tx/rx
+	 * operation entries, not just the FI_EFA_TRACK_MR in-flight check.
+	 */
+	ret = ofi_bufpool_create(&ep->base_ep.ope_pool,
 				 sizeof(struct efa_rdm_ope),
 				 EFA_RDM_BUFPOOL_ALIGNMENT,
 				 0, /* no limit for max_cnt */
@@ -247,7 +253,7 @@ int efa_rdm_ep_create_buffer_pools(struct efa_rdm_ep *ep)
 	if (ret)
 		goto err_free;
 
-	ret = ofi_bufpool_grow(ep->ope_pool);
+	ret = ofi_bufpool_grow(ep->base_ep.ope_pool);
 	if (ret)
 		goto err_free;
 
@@ -307,8 +313,8 @@ err_free:
 	if (ep->map_entry_pool)
 		ofi_bufpool_destroy(ep->map_entry_pool);
 
-	if (ep->ope_pool)
-		ofi_bufpool_destroy(ep->ope_pool);
+	if (ep->base_ep.ope_pool)
+		ofi_bufpool_destroy(ep->base_ep.ope_pool);
 
 	if (ep->overflow_pke_pool)
 		ofi_bufpool_destroy(ep->overflow_pke_pool);
@@ -355,8 +361,8 @@ void efa_rdm_ep_init_linked_lists(struct efa_rdm_ep *ep)
 	dlist_init(&ep->rx_pkt_list);
 	dlist_init(&ep->tx_pkt_list);
 #endif
-	dlist_init(&ep->rxe_list);
-	dlist_init(&ep->txe_list);
+	/* base_ep.ope_list, which tracks both tx and rx entries, is
+	 * initialized in efa_base_ep_construct(). */
 	dlist_init(&ep->ope_posted_ack_list);
 }
 
@@ -724,8 +730,6 @@ static int efa_rdm_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 static void efa_rdm_ep_destroy_buffer_pools(struct efa_rdm_ep *efa_rdm_ep)
 {
 	struct dlist_entry *entry, *tmp;
-	struct efa_rdm_ope *rxe;
-	struct efa_rdm_ope *txe;
 	struct efa_rdm_peer *peer;
 	struct efa_rdm_peer_overflow_pke_list_entry *overflow_pke_list_entry;
 	struct util_av_entry *util_av_entry;
@@ -775,21 +779,19 @@ static void efa_rdm_ep_destroy_buffer_pools(struct efa_rdm_ep *efa_rdm_ep)
 	}
 #endif
 
-	dlist_foreach_safe(&efa_rdm_ep->rxe_list, entry, tmp) {
-		rxe = container_of(entry, struct efa_rdm_ope,
-					ep_entry);
-		EFA_INFO(FI_LOG_EP_CTRL,
-			"Closing ep with unreleased rxe\n");
-		efa_rdm_rxe_release(rxe);
-	}
-
-	dlist_foreach_safe(&efa_rdm_ep->txe_list, entry, tmp) {
-		txe = container_of(entry, struct efa_rdm_ope,
-					ep_entry);
-		EFA_INFO(FI_LOG_EP_CTRL,
-			"Closing ep with unreleased txe: %p\n",
-			txe);
-		efa_rdm_txe_release(txe);
+	dlist_foreach_safe(&efa_rdm_ep->base_ep.ope_list, entry, tmp) {
+		struct efa_rdm_ope *ope = container_of(entry, struct efa_rdm_ope,
+						       ep_entry);
+		if (ope->type == EFA_RDM_RXE) {
+			EFA_INFO(FI_LOG_EP_CTRL,
+				"Closing ep with unreleased rxe\n");
+			efa_rdm_rxe_release(ope);
+		} else {
+			EFA_INFO(FI_LOG_EP_CTRL,
+				"Closing ep with unreleased txe: %p\n",
+				ope);
+			efa_rdm_txe_release(ope);
+		}
 	}
 
 	/* Clean up any remaining peers before destroying buffer pools */
@@ -821,8 +823,8 @@ static void efa_rdm_ep_destroy_buffer_pools(struct efa_rdm_ep *efa_rdm_ep)
 		ofi_buf_free(peer_map_entry);
 	}
 
-	if (efa_rdm_ep->ope_pool)
-		ofi_bufpool_destroy(efa_rdm_ep->ope_pool);
+	if (efa_rdm_ep->base_ep.ope_pool)
+		ofi_bufpool_destroy(efa_rdm_ep->base_ep.ope_pool);
 
 	if (efa_rdm_ep->overflow_pke_pool)
 		ofi_bufpool_destroy(efa_rdm_ep->overflow_pke_pool);
@@ -1063,8 +1065,10 @@ static int efa_rdm_ep_close(struct fid *fid)
 		* assertion error when the rx_pool is destroyed.
 		*/
 		ofi_genlock_lock(&((struct efa_rdm_domain *) domain)->srx_lock);
-		dlist_foreach_safe (&efa_rdm_ep->rxe_list, entry, tmp) {
+		dlist_foreach_safe (&efa_rdm_ep->base_ep.ope_list, entry, tmp) {
 			rxe = container_of(entry, struct efa_rdm_ope, ep_entry);
+			if (rxe->type != EFA_RDM_RXE)
+				continue;
 			EFA_INFO(FI_LOG_EP_CTRL, "Closing ep with unreleased rxe\n");
 			if (rxe->state != EFA_RDM_RXE_UNEXP)
 				efa_rdm_rxe_release(rxe);

--- a/prov/efa/src/rdm/efa_rdm_ep_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_utils.c
@@ -178,7 +178,7 @@ struct efa_rdm_ope *efa_rdm_ep_alloc_rxe(struct efa_rdm_ep *ep, struct efa_rdm_p
 {
 	struct efa_rdm_ope *rxe;
 
-	rxe = ofi_buf_alloc(ep->ope_pool);
+	rxe = ofi_buf_alloc(ep->base_ep.ope_pool);
 	if (OFI_UNLIKELY(!rxe)) {
 		EFA_WARN(FI_LOG_EP_CTRL, "RX entries exhausted\n");
 		return NULL;
@@ -186,7 +186,7 @@ struct efa_rdm_ope *efa_rdm_ep_alloc_rxe(struct efa_rdm_ep *ep, struct efa_rdm_p
 
 	rxe->ep = ep;
 	efa_rdm_domain_ope_list_lock(efa_rdm_ep_rdm_domain(ep));
-	dlist_insert_tail(&rxe->ep_entry, &ep->rxe_list);
+	dlist_insert_tail(&rxe->ep_entry, &ep->base_ep.ope_list);
 	efa_rdm_domain_ope_list_unlock(efa_rdm_ep_rdm_domain(ep));
 	rxe->type = EFA_RDM_RXE;
 	rxe->internal_flags = 0;
@@ -595,7 +595,7 @@ static ssize_t efa_rdm_ep_handshake_common(struct efa_rdm_ep *ep, struct efa_rdm
 
 	msg.addr = peer->conn->fi_addr;
 
-	txe = ofi_buf_alloc(ep->ope_pool);
+	txe = ofi_buf_alloc(ep->base_ep.ope_pool);
 	if (OFI_UNLIKELY(!txe)) {
 		EFA_WARN(FI_LOG_EP_CTRL, "TX entries exhausted.\n");
 		return -FI_EAGAIN;

--- a/prov/efa/src/rdm/efa_rdm_mr.c
+++ b/prov/efa/src/rdm/efa_rdm_mr.c
@@ -611,16 +611,10 @@ static void efa_rdm_mr_close_check_inflight_ope(struct efa_mr *efa_mr)
 	ofi_genlock_lock(&efa_domain->util_domain.lock);
 	dlist_foreach_container(&efa_domain->base_ep_list, struct efa_base_ep,
 				base_ep, base_ep_entry) {
-		struct efa_rdm_ep *rdm_ep;
 		struct efa_rdm_ope *ope;
-		rdm_ep = container_of(base_ep, struct efa_rdm_ep, base_ep);
+
 		dlist_foreach_container_safe (
-			&rdm_ep->txe_list, struct efa_rdm_ope,
-			ope, ep_entry, tmp) {
-			efa_mr_close_warn_inflight_ope(ope->desc, ope->iov_count, &ope->cq_entry, efa_mr, base_ep);
-		}
-		dlist_foreach_container_safe (
-			&rdm_ep->rxe_list, struct efa_rdm_ope,
+			&base_ep->ope_list, struct efa_rdm_ope,
 			ope, ep_entry, tmp) {
 			efa_mr_close_warn_inflight_ope(ope->desc, ope->iov_count, &ope->cq_entry, efa_mr, base_ep);
 		}

--- a/prov/efa/src/rdm/efa_rdm_msg.c
+++ b/prov/efa/src/rdm/efa_rdm_msg.c
@@ -191,7 +191,7 @@ ssize_t efa_rdm_msg_generic_send(struct efa_rdm_ep *ep, const struct fi_msg *msg
 		goto out;
 	}
 
-	txe = ofi_buf_alloc(ep->ope_pool);
+	txe = ofi_buf_alloc(ep->base_ep.ope_pool);
 	if (OFI_UNLIKELY(!txe)) {
 		err = -FI_EAGAIN;
 		goto out;

--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -102,7 +102,7 @@ void efa_rdm_txe_construct(struct efa_rdm_ope *txe,
 	}
 
 	efa_rdm_domain_ope_list_lock(efa_rdm_ep_rdm_domain(ep));
-	dlist_insert_tail(&txe->ep_entry, &ep->txe_list);
+	dlist_insert_tail(&txe->ep_entry, &ep->base_ep.ope_list);
 	efa_rdm_domain_ope_list_unlock(efa_rdm_ep_rdm_domain(ep));
 }
 

--- a/prov/efa/src/rdm/efa_rdm_ope.h
+++ b/prov/efa/src/rdm/efa_rdm_ope.h
@@ -125,7 +125,7 @@ struct efa_rdm_ope {
 	/* entry is linked with ope_longcts_send_list in efa_domain */
 	struct dlist_entry entry;
 
-	/* ep_entry is linked to tx/rxe_list in efa_rdm_ep */
+	/* ep_entry is linked to base_ep.ope_list */
 	struct dlist_entry ep_entry;
 
 	/* ack_list_entry is linked to ope_posted_ack_list in efa_rdm_ep */

--- a/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
@@ -229,7 +229,7 @@ void efa_rdm_pke_handle_cts_recv(struct efa_rdm_pke *pkt_entry)
 
 	ep = pkt_entry->ep;
 	cts_pkt = (struct efa_rdm_cts_hdr *)pkt_entry->wiredata;
-	ope = ofi_bufpool_get_ibuf(pkt_entry->ep->ope_pool, cts_pkt->send_id);
+	ope = ofi_bufpool_get_ibuf(pkt_entry->ep->base_ep.ope_pool, cts_pkt->send_id);
 
 	ope->rx_id = cts_pkt->recv_id;
 	ope->window = cts_pkt->recv_length;
@@ -391,7 +391,7 @@ void efa_rdm_pke_handle_ctsdata_recv(struct efa_rdm_pke *pkt_entry)
 
 	data_hdr = efa_rdm_pke_get_ctsdata_hdr(pkt_entry);
 
-	ope = ofi_bufpool_get_ibuf(pkt_entry->ep->ope_pool,
+	ope = ofi_bufpool_get_ibuf(pkt_entry->ep->base_ep.ope_pool,
 				   data_hdr->recv_id);
 
 	hdr_size = sizeof(struct efa_rdm_ctsdata_hdr);
@@ -470,7 +470,7 @@ void efa_rdm_pke_handle_readrsp_recv(struct efa_rdm_pke *pkt_entry)
 
 	readrsp_pkt = (struct efa_rdm_readrsp_pkt *)pkt_entry->wiredata;
 	readrsp_hdr = &readrsp_pkt->hdr;
-	txe = ofi_bufpool_get_ibuf(pkt_entry->ep->ope_pool, readrsp_hdr->recv_id);
+	txe = ofi_bufpool_get_ibuf(pkt_entry->ep->base_ep.ope_pool, readrsp_hdr->recv_id);
 	assert(txe->cq_entry.flags & FI_READ);
 	txe->rx_id = readrsp_hdr->send_id;
 	efa_rdm_pke_proc_ctsdata(pkt_entry, txe,
@@ -712,7 +712,7 @@ void efa_rdm_pke_handle_eor_recv(struct efa_rdm_pke *pkt_entry)
 	eor_hdr = (struct efa_rdm_eor_hdr *)pkt_entry->wiredata;
 
 	/* pre-post buf used here, so can NOT track back to txe with x_entry */
-	txe = ofi_bufpool_get_ibuf(pkt_entry->ep->ope_pool, eor_hdr->send_id);
+	txe = ofi_bufpool_get_ibuf(pkt_entry->ep->base_ep.ope_pool, eor_hdr->send_id);
 
 	txe->bytes_acked += txe->total_len - txe->bytes_runt;
 	if (txe->bytes_acked == txe->total_len) {
@@ -745,7 +745,7 @@ void efa_rdm_pke_handle_read_nack_recv(struct efa_rdm_pke *pkt_entry)
 
 	nack_hdr = (struct efa_rdm_read_nack_hdr *) pkt_entry->wiredata;
 
-	txe = ofi_bufpool_get_ibuf(pkt_entry->ep->ope_pool, nack_hdr->send_id);
+	txe = ofi_bufpool_get_ibuf(pkt_entry->ep->base_ep.ope_pool, nack_hdr->send_id);
 
 	efa_rdm_pke_release_rx(pkt_entry);
 	txe->internal_flags |= EFA_RDM_OPE_READ_NACK;
@@ -829,7 +829,7 @@ void efa_rdm_pke_handle_receipt_recv(struct efa_rdm_pke *pkt_entry)
 
 	receipt_hdr = efa_rdm_pke_get_receipt_hdr(pkt_entry);
 	/* Retrieve the txe that will be written into TX CQ*/
-	txe = ofi_bufpool_get_ibuf(pkt_entry->ep->ope_pool,
+	txe = ofi_bufpool_get_ibuf(pkt_entry->ep->base_ep.ope_pool,
 				   receipt_hdr->tx_id);
 	if (!txe) {
 		EFA_WARN(FI_LOG_CQ,
@@ -909,7 +909,7 @@ void efa_rdm_pke_handle_atomrsp_recv(struct efa_rdm_pke *pkt_entry)
 
 	atomrsp_pkt = (struct efa_rdm_atomrsp_pkt *)pkt_entry->wiredata;
 	atomrsp_hdr = &atomrsp_pkt->hdr;
-	txe = ofi_bufpool_get_ibuf(pkt_entry->ep->ope_pool, atomrsp_hdr->recv_id);
+	txe = ofi_bufpool_get_ibuf(pkt_entry->ep->base_ep.ope_pool, atomrsp_hdr->recv_id);
 
 	ret = efa_copy_to_hmem_iov(txe->atomic_ex.result_desc, txe->atomic_ex.resp_iov,
 	                           txe->atomic_ex.resp_iov_count, atomrsp_pkt->data,

--- a/prov/efa/src/rdm/efa_rdm_rma.c
+++ b/prov/efa/src/rdm/efa_rdm_rma.c
@@ -55,7 +55,7 @@ efa_rdm_rma_alloc_txe(struct efa_rdm_ep *efa_rdm_ep,
 	struct efa_rdm_ope *txe;
 	struct fi_msg msg;
 
-	txe = ofi_buf_alloc(efa_rdm_ep->ope_pool);
+	txe = ofi_buf_alloc(efa_rdm_ep->base_ep.ope_pool);
 	if (OFI_UNLIKELY(!txe)) {
 		EFA_DBG(FI_LOG_EP_CTRL, "TX entries exhausted.\n");
 		return NULL;

--- a/prov/efa/test/efa_unit_test_common.c
+++ b/prov/efa/test/efa_unit_test_common.c
@@ -424,7 +424,7 @@ struct efa_rdm_ope *efa_unit_test_alloc_txe(struct efa_resource *resource, uint3
 
 	peer = efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr);
 
-	txe = ofi_buf_alloc(efa_rdm_ep->ope_pool);
+	txe = ofi_buf_alloc(efa_rdm_ep->base_ep.ope_pool);
 	if (!txe)
 		return NULL;
 

--- a/prov/efa/test/efa_unit_test_cq.c
+++ b/prov/efa/test/efa_unit_test_cq.c
@@ -1070,10 +1070,10 @@ static void test_efa_cq_read_prep(struct efa_resource *resource,
 	ibv_cqx = ibv_cq->ibv_cq_ex;
 
 	if (efa_env.track_mr && ctx) {
-		direct_ope = ofi_buf_alloc(base_ep->efa_direct_ope_pool);
+		direct_ope = ofi_buf_alloc(base_ep->ope_pool);
 		assert_non_null(direct_ope);
 		direct_ope->context = ctx;
-		dlist_insert_tail(&direct_ope->entry, &base_ep->efa_direct_ope_list);
+		dlist_insert_tail(&direct_ope->entry, &base_ep->ope_list);
 	}
 
 	/* Make wr_id as 0 for unsolicited write recv as a stress test */
@@ -2349,20 +2349,20 @@ void test_efa_cq_read_mixed_success_error(void **state)
 
 	/* Allocate direct_ope entries when track_mr is enabled */
 	if (efa_env.track_mr) {
-		direct_ope1 = ofi_buf_alloc(base_ep->efa_direct_ope_pool);
+		direct_ope1 = ofi_buf_alloc(base_ep->ope_pool);
 		assert_non_null(direct_ope1);
 		direct_ope1->context = efa_context1;
-		dlist_insert_tail(&direct_ope1->entry, &base_ep->efa_direct_ope_list);
+		dlist_insert_tail(&direct_ope1->entry, &base_ep->ope_list);
 
-		direct_ope2 = ofi_buf_alloc(base_ep->efa_direct_ope_pool);
+		direct_ope2 = ofi_buf_alloc(base_ep->ope_pool);
 		assert_non_null(direct_ope2);
 		direct_ope2->context = efa_context2;
-		dlist_insert_tail(&direct_ope2->entry, &base_ep->efa_direct_ope_list);
+		dlist_insert_tail(&direct_ope2->entry, &base_ep->ope_list);
 
-		direct_ope3 = ofi_buf_alloc(base_ep->efa_direct_ope_pool);
+		direct_ope3 = ofi_buf_alloc(base_ep->ope_pool);
 		assert_non_null(direct_ope3);
 		direct_ope3->context = efa_context3;
-		dlist_insert_tail(&direct_ope3->entry, &base_ep->efa_direct_ope_list);
+		dlist_insert_tail(&direct_ope3->entry, &base_ep->ope_list);
 	}
 
 	/* Setup mocks - need custom mock to simulate status changes */

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -2079,6 +2079,31 @@ void test_efa_base_ep_construct_ibv_qp_init_attr_ex_efa_use_requested_limits(voi
 }
 
 /**
+ * @brief Test efa_base_ep_construct_ibv_qp_init_attr_ex with DGRAM endpoint
+ *
+ * Verifies that DGRAM endpoints get IBV_QPT_UD qp_type.
+ */
+void test_efa_base_ep_construct_ibv_qp_init_attr_ex_dgram(void **state)
+{
+	struct efa_resource *resource = *state;
+	struct efa_base_ep *efa_base_ep;
+	struct ibv_qp_init_attr_ex attr_ex = {0};
+	struct efa_cq *efa_cq;
+
+	resource->hints = efa_unit_test_alloc_hints(FI_EP_DGRAM, EFA_FABRIC_NAME);
+	efa_unit_test_resource_construct_with_hints(resource, FI_EP_DGRAM, FI_VERSION(1, 14),
+						    resource->hints, false, true);
+
+	efa_base_ep = container_of(resource->ep, struct efa_base_ep, util_ep.ep_fid);
+	efa_cq = container_of(resource->cq, struct efa_cq, util_cq.cq_fid);
+
+	efa_base_ep_construct_ibv_qp_init_attr_ex(efa_base_ep, &attr_ex,
+						  efa_cq->ibv_cq.ibv_cq_ex, efa_cq->ibv_cq.ibv_cq_ex);
+
+	assert_int_equal(attr_ex.qp_type, IBV_QPT_UD);
+}
+
+/**
  * @brief Test efa_rdm_ep_get_explicit_shm_fi_addr with valid peer having same GID
  *
  * @param[in] state struct efa_resource managed by the framework

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -482,12 +482,12 @@ void test_efa_rdm_ep_rma_queue_before_handshake(void **state, int op)
 	/* Do not use shm in this unit test because we are testing efa rma path */
 	peer->conn->shm_fi_addr = FI_ADDR_NOTAVAIL;
 	assert_false(efa_rdm_ep->homogeneous_peers);
-	assert_true(dlist_empty(&efa_rdm_ep->txe_list));
+	assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_TXE), 0);
 
 	err = test_efa_rdm_ep_rma_issue_op(resource->ep, op, buf, buf_len,
 				      peer_addr, rma_addr, rma_key);
 	assert_int_equal(err, 0);
-	assert_int_equal(efa_unit_test_get_dlist_length(&efa_rdm_ep->txe_list),  1);
+	assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_TXE),  1);
 	assert_int_equal(efa_unit_test_get_dlist_length(&(efa_rdm_ep_rdm_domain(efa_rdm_ep)->ope_queued_list)), 1);
 	txe = container_of(efa_rdm_ep_rdm_domain(efa_rdm_ep)->ope_queued_list.next, struct efa_rdm_ope, queued_entry);
 	assert_true((txe->op == op));
@@ -551,7 +551,7 @@ void test_efa_rdm_ep_trigger_handshake(void **state)
 	assert_non_null(peer);
 
 	/* No txe should have been allocated yet */
-	assert_true(dlist_empty(&efa_rdm_ep->txe_list));
+	assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_TXE), 0);
 
 	/*
 	 * When the peer already has made , the function should be a no-op
@@ -559,16 +559,16 @@ void test_efa_rdm_ep_trigger_handshake(void **state)
 	 */
 	peer->flags |= EFA_RDM_PEER_HANDSHAKE_RECEIVED | EFA_RDM_PEER_REQ_SENT;
 	assert_int_equal(efa_rdm_ep_trigger_handshake(efa_rdm_ep, peer), FI_SUCCESS);
-	assert_true(dlist_empty(&efa_rdm_ep->txe_list));
+	assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_TXE), 0);
 
 	/*
 	 * Reset the peer flags to 0, now we should expect a txe allocated
 	 */
 	peer->flags = 0;
 	assert_int_equal(efa_rdm_ep_trigger_handshake(efa_rdm_ep, peer), FI_SUCCESS);
-	assert_int_equal(efa_unit_test_get_dlist_length(&efa_rdm_ep->txe_list),  1);
+	assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_TXE),  1);
 
-	txe = container_of(efa_rdm_ep->txe_list.next, struct efa_rdm_ope, ep_entry);
+	txe = efa_unit_test_get_first_ope(efa_rdm_ep, EFA_RDM_TXE);
 
 	assert_true(txe->internal_flags & EFA_RDM_TXE_NO_COMPLETION);
 	assert_true(txe->internal_flags & EFA_RDM_TXE_NO_COUNTER);
@@ -627,7 +627,7 @@ void test_efa_rdm_txe_construct_splits_internal_flags(void **state)
 	 * EFA_RDM_* flags are fine: we only assert that every requested
 	 * bit is set in its own field.
 	 */
-	txe = ofi_buf_alloc(efa_rdm_ep->ope_pool);
+	txe = ofi_buf_alloc(efa_rdm_ep->base_ep.ope_pool);
 	assert_non_null(txe);
 	efa_rdm_txe_construct(txe, efa_rdm_ep, peer, &msg, ofi_op_msg,
 			      fi_flags_in, internal_flags_in);
@@ -643,7 +643,7 @@ void test_efa_rdm_txe_construct_splits_internal_flags(void **state)
 	 * should be set implicitly (catches a regression where the construct
 	 * fn OR's in a default internal flag).
 	 */
-	txe = ofi_buf_alloc(efa_rdm_ep->ope_pool);
+	txe = ofi_buf_alloc(efa_rdm_ep->base_ep.ope_pool);
 	assert_non_null(txe);
 	efa_rdm_txe_construct(txe, efa_rdm_ep, peer, &msg, ofi_op_msg,
 			      fi_flags_in, 0);
@@ -1240,9 +1240,9 @@ void test_efa_rdm_ep_post_handshake_error_handling_pke_exhaustion(void **state)
 	}
 
 	/* txe list should be empty before and after the failed handshake post call */
-	assert_true(dlist_empty(&efa_rdm_ep->txe_list));
+	assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_TXE), 0);
 	assert_int_equal(efa_rdm_ep_post_handshake(efa_rdm_ep, peer), -FI_EAGAIN);
-	assert_true(dlist_empty(&efa_rdm_ep->txe_list));
+	assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_TXE), 0);
 
 	for (i = 0; i < tx_size; i++)
 		efa_rdm_pke_release_tx(pkt_entry_vec[i]);

--- a/prov/efa/test/efa_unit_test_mr.c
+++ b/prov/efa/test/efa_unit_test_mr.c
@@ -656,11 +656,11 @@ void test_efa_mr_close_warn_outstanding_direct_ope(void **state)
 	efa_mr = container_of(mr, struct efa_mr, mr_fid);
 
 	/* Simulate an outstanding direct operation referencing this MR */
-	direct_ope = ofi_buf_alloc(base_ep->efa_direct_ope_pool);
+	direct_ope = ofi_buf_alloc(base_ep->ope_pool);
 	assert_non_null(direct_ope);
 	direct_ope->iov_count = 1;
 	direct_ope->desc[0] = efa_mr;
-	dlist_insert_tail(&direct_ope->entry, &base_ep->efa_direct_ope_list);
+	dlist_insert_tail(&direct_ope->entry, &base_ep->ope_list);
 
 	/* Close MR while operation is outstanding */
 	assert_int_equal(fi_close(&mr->fid), 0);
@@ -718,17 +718,17 @@ void test_efa_mr_close_warn_outstanding_direct_ope_multi_ep(void **state)
 	efa_mr = container_of(mr, struct efa_mr, mr_fid);
 
 	/* Simulate outstanding direct operations on both EPs referencing the same MR */
-	direct_ope1 = ofi_buf_alloc(base_ep1->efa_direct_ope_pool);
+	direct_ope1 = ofi_buf_alloc(base_ep1->ope_pool);
 	assert_non_null(direct_ope1);
 	direct_ope1->iov_count = 1;
 	direct_ope1->desc[0] = efa_mr;
-	dlist_insert_tail(&direct_ope1->entry, &base_ep1->efa_direct_ope_list);
+	dlist_insert_tail(&direct_ope1->entry, &base_ep1->ope_list);
 
-	direct_ope2 = ofi_buf_alloc(base_ep2->efa_direct_ope_pool);
+	direct_ope2 = ofi_buf_alloc(base_ep2->ope_pool);
 	assert_non_null(direct_ope2);
 	direct_ope2->iov_count = 1;
 	direct_ope2->desc[0] = efa_mr;
-	dlist_insert_tail(&direct_ope2->entry, &base_ep2->efa_direct_ope_list);
+	dlist_insert_tail(&direct_ope2->entry, &base_ep2->ope_list);
 
 	/* Close MR while operations are outstanding on both EPs */
 	assert_int_equal(fi_close(&mr->fid), 0);
@@ -1534,7 +1534,7 @@ void test_efa_direct_ope_released_on_recv_error(void **state)
 	assert_int_equal(ret, -FI_EINVAL);
 
 	/* The ope list must be empty - ope released on error path */
-	assert_true(dlist_empty(&base_ep->efa_direct_ope_list));
+	assert_true(dlist_empty(&base_ep->ope_list));
 
 	free(buf);
 }
@@ -1593,7 +1593,7 @@ void test_efa_direct_ope_released_on_send_error(void **state)
 	assert_int_equal(ret, -FI_EINVAL);
 
 	/* The ope list must be empty - ope released on error path */
-	assert_true(dlist_empty(&base_ep->efa_direct_ope_list));
+	assert_true(dlist_empty(&base_ep->ope_list));
 
 	free(buf);
 }
@@ -1662,7 +1662,7 @@ void test_efa_direct_ope_released_on_read_error(void **state)
 	ret = fi_readmsg(resource->ep, &msg, FI_COMPLETION);
 	assert_int_equal(ret, -FI_EINVAL);
 
-	assert_true(dlist_empty(&base_ep->efa_direct_ope_list));
+	assert_true(dlist_empty(&base_ep->ope_list));
 
 	free(buf);
 }
@@ -1731,7 +1731,7 @@ void test_efa_direct_ope_released_on_write_error(void **state)
 	ret = fi_writemsg(resource->ep, &msg, FI_COMPLETION);
 	assert_int_equal(ret, -FI_EINVAL);
 
-	assert_true(dlist_empty(&base_ep->efa_direct_ope_list));
+	assert_true(dlist_empty(&base_ep->ope_list));
 
 	free(buf);
 }

--- a/prov/efa/test/efa_unit_test_ope.c
+++ b/prov/efa/test/efa_unit_test_ope.c
@@ -345,7 +345,7 @@ void test_efa_rdm_rxe_post_local_read_or_queue_impl(struct efa_resource *resourc
 	rxe->iov[0] = iov;
 	efa_rdm_pke_set_ope(pkt_entry, rxe);
 
-	assert_true(dlist_empty(&efa_rdm_ep->txe_list));
+	assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_TXE), 0);
 
 	held_before = efa_rdm_ep->efa_rx_pkts_held;
 	to_post_before = efa_rdm_ep->efa_rx_pkts_to_post;
@@ -363,8 +363,8 @@ void test_efa_rdm_rxe_post_local_read_or_queue_impl(struct efa_resource *resourc
 		assert_true(pkt_entry->flags & EFA_RDM_PKE_HELD_BY_PROGRESS);
 
 		/* The internal txe must be live with local_read_pkt_entry set. */
-		assert_int_equal(efa_unit_test_get_dlist_length(&efa_rdm_ep->txe_list), 1);
-		txe = container_of(efa_rdm_ep->txe_list.next, struct efa_rdm_ope, ep_entry);
+		assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_TXE), 1);
+		txe = efa_unit_test_get_first_ope(efa_rdm_ep, EFA_RDM_TXE);
 		assert_true(txe->internal_flags & EFA_RDM_OPE_INTERNAL);
 		assert_non_null(txe->local_read_pkt_entry);
 
@@ -376,7 +376,7 @@ void test_efa_rdm_rxe_post_local_read_or_queue_impl(struct efa_resource *resourc
 		/* handle_data_copied released the held pkt: held back to baseline, to_post ++ */
 		assert_int_equal(efa_rdm_ep->efa_rx_pkts_held, held_before);
 		assert_int_equal(efa_rdm_ep->efa_rx_pkts_to_post, to_post_before + 1);
-		assert_true(dlist_empty(&efa_rdm_ep->txe_list));
+		assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_TXE), 0);
 	} else {
 		assert_int_equal(efa_rdm_ep->efa_rx_pkts_held, held_before);
 		assert_int_equal(efa_rdm_ep->efa_rx_pkts_to_post, to_post_before);
@@ -397,7 +397,7 @@ void test_efa_rdm_rxe_post_local_read_or_queue_unhappy(void **state)
 	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
 
 	/* Make sure txe is cleaned for a failed read */
-	assert_true(dlist_empty(&efa_rdm_ep->txe_list));
+	assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_TXE), 0);
 }
 
 void test_efa_rdm_rxe_post_local_read_or_queue_happy(void **state)
@@ -724,7 +724,7 @@ void test_efa_rdm_txe_prepare_local_read_pkt_entry(void **state)
 	assert_int_equal(fi_endpoint(resource->domain, resource->info, &ep, NULL), 0);
 	efa_rdm_ep = container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
 
-	txe = ofi_buf_alloc(efa_rdm_ep->ope_pool);
+	txe = ofi_buf_alloc(efa_rdm_ep->base_ep.ope_pool);
 	assert_non_null(txe);
 	efa_rdm_txe_construct(txe, efa_rdm_ep, NULL, &msg, ofi_op_msg, 0, 0);
 
@@ -1289,8 +1289,8 @@ void test_efa_rdm_atomic_compare_desc_persistence(void **state)
 	compare_desc_array[0] = (void *)(uintptr_t)0xDEADBEEF;
 
 	/* Retrieve the txe from the txe_list */
-	assert_false(dlist_empty(&efa_rdm_ep->txe_list));
-	txe = container_of(efa_rdm_ep->txe_list.next, struct efa_rdm_ope, ep_entry);
+	assert_true(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_TXE) > 0);
+	txe = efa_unit_test_get_first_ope(efa_rdm_ep, EFA_RDM_TXE);
 
 	/* Verify compare_desc was copied, not just pointer stored */
 	assert_ptr_equal(txe->atomic_ex.compare_desc[0], original_desc_value);
@@ -1424,12 +1424,12 @@ static void test_efa_rdm_txe_with_resp_release_common(struct efa_resource *resou
 		}
 	}
 
-	assert_int_equal(efa_unit_test_get_dlist_length(&efa_rdm_ep->txe_list), 1);
+	assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_TXE), 1);
 
 	if (send_first) {
 		/* Send completion first - should not release TXE yet */
 		efa_rdm_pke_handle_send_completion(req_pkt_entry);
-		assert_int_equal(efa_unit_test_get_dlist_length(&efa_rdm_ep->txe_list), 1);
+		assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_TXE), 1);
 
 		/* Response arrives - should release TXE now */
 		if (pkt_type == EFA_RDM_FETCH_RTA_PKT || pkt_type == EFA_RDM_COMPARE_RTA_PKT) {
@@ -1465,14 +1465,14 @@ static void test_efa_rdm_txe_with_resp_release_common(struct efa_resource *resou
 			efa_rdm_pke_handle_receipt_recv(resp_pkt_entry);
 			assert_true(txe->internal_flags & EFA_RDM_TXE_REMOTE_ACK_RECEIVED);
 		}
-		assert_int_equal(efa_unit_test_get_dlist_length(&efa_rdm_ep->txe_list), 1);
+		assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_TXE), 1);
 
 		/* Send completion - should release TXE now */
 		efa_rdm_pke_handle_send_completion(req_pkt_entry);
 	}
 
 	/* Verify TXE is released */
-	assert_int_equal(efa_unit_test_get_dlist_length(&efa_rdm_ep->txe_list), 0);
+	assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_TXE), 0);
 }
 
 /**
@@ -1679,18 +1679,18 @@ static void test_efa_rdm_ope_longcts_cts_release_common(struct efa_resource *res
 	cts_hdr->type = EFA_RDM_CTS_PKT;
 
 	if (is_txe)
-		assert_int_equal(efa_unit_test_get_dlist_length(&efa_rdm_ep->txe_list), 1);
+		assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_TXE), 1);
 	else
-		assert_int_equal(efa_unit_test_get_dlist_length(&efa_rdm_ep->rxe_list), 1);
+		assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_RXE), 1);
 
 	if (send_first) {
 		/* CTS send completion first - recv not done, should not release */
 		efa_rdm_pke_handle_send_completion(cts_pkt_entry);
 		assert_int_equal(ope->efa_outstanding_tx_ops, 0);
 		if (is_txe)
-			assert_int_equal(efa_unit_test_get_dlist_length(&efa_rdm_ep->txe_list), 1);
+			assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_TXE), 1);
 		else
-			assert_int_equal(efa_unit_test_get_dlist_length(&efa_rdm_ep->rxe_list), 1);
+			assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_RXE), 1);
 
 		/* Simulate recv completed */
 		ope->bytes_received = ope->total_len;
@@ -1703,9 +1703,9 @@ static void test_efa_rdm_ope_longcts_cts_release_common(struct efa_resource *res
 		efa_rdm_ope_handle_recv_completed(ope);
 		/* ope should NOT be released yet */
 		if (is_txe)
-			assert_int_equal(efa_unit_test_get_dlist_length(&efa_rdm_ep->txe_list), 1);
+			assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_TXE), 1);
 		else
-			assert_int_equal(efa_unit_test_get_dlist_length(&efa_rdm_ep->rxe_list), 1);
+			assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_RXE), 1);
 
 		/* CTS send completion - should release ope now */
 		efa_rdm_pke_handle_send_completion(cts_pkt_entry);
@@ -1713,9 +1713,9 @@ static void test_efa_rdm_ope_longcts_cts_release_common(struct efa_resource *res
 
 	/* Verify ope is released */
 	if (is_txe)
-		assert_int_equal(efa_unit_test_get_dlist_length(&efa_rdm_ep->txe_list), 0);
+		assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_TXE), 0);
 	else
-		assert_int_equal(efa_unit_test_get_dlist_length(&efa_rdm_ep->rxe_list), 0);
+		assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_RXE), 0);
 }
 
 /**
@@ -1816,7 +1816,7 @@ static void test_efa_rdm_rxe_dc_longcts_write_cts_receipt_order_common(
 	struct efa_rdm_base_hdr *cts_hdr = (struct efa_rdm_base_hdr *)cts_pkt_entry->wiredata;
 	cts_hdr->type = EFA_RDM_CTS_PKT;
 
-	assert_int_equal(efa_unit_test_get_dlist_length(&efa_rdm_ep->rxe_list), 1);
+	assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_RXE), 1);
 
 	/*
 	 * Simulate recv completed: efa_rdm_ope_handle_recv_completed will
@@ -1829,7 +1829,7 @@ static void test_efa_rdm_rxe_dc_longcts_write_cts_receipt_order_common(
 	efa_rdm_ope_handle_recv_completed(rxe);
 
 	/* rxe should NOT be released: CTS + RECEIPT outstanding */
-	assert_int_equal(efa_unit_test_get_dlist_length(&efa_rdm_ep->rxe_list), 1);
+	assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_RXE), 1);
 	assert_true(rxe->internal_flags & EFA_RDM_OPE_RECV_COMPLETED);
 	assert_true(rxe->internal_flags & EFA_RDM_RXE_ACK_IN_FLIGHT);
 	assert_int_equal(rxe->efa_outstanding_tx_ops, 2);
@@ -1841,7 +1841,7 @@ static void test_efa_rdm_rxe_dc_longcts_write_cts_receipt_order_common(
 		/* CTS send completion first - RECEIPT still outstanding */
 		efa_rdm_pke_handle_send_completion(cts_pkt_entry);
 		assert_int_equal(rxe->efa_outstanding_tx_ops, 1);
-		assert_int_equal(efa_unit_test_get_dlist_length(&efa_rdm_ep->rxe_list), 1);
+		assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_RXE), 1);
 
 		/* RECEIPT send completion - should release rxe now */
 		efa_rdm_pke_handle_send_completion(receipt_pkt_entry);
@@ -1851,14 +1851,14 @@ static void test_efa_rdm_rxe_dc_longcts_write_cts_receipt_order_common(
 		/* Now we shouldn't have such flag */
 		assert_false(rxe->internal_flags & EFA_RDM_RXE_ACK_IN_FLIGHT);
 		assert_int_equal(rxe->efa_outstanding_tx_ops, 1);
-		assert_int_equal(efa_unit_test_get_dlist_length(&efa_rdm_ep->rxe_list), 1);
+		assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_RXE), 1);
 
 		/* CTS send completion - should release rxe now */
 		efa_rdm_pke_handle_send_completion(cts_pkt_entry);
 	}
 
 	/* Verify rxe is released */
-	assert_int_equal(efa_unit_test_get_dlist_length(&efa_rdm_ep->rxe_list), 0);
+	assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_RXE), 0);
 }
 
 /**

--- a/prov/efa/test/efa_unit_test_pke.c
+++ b/prov/efa/test/efa_unit_test_pke.c
@@ -50,7 +50,7 @@ void test_efa_rdm_pke_handle_send_completion_peer_removed(void **state)
 	assert_int_equal(err, 0);
 	assert_null(pkt_entry->peer);
 	assert_null(pkt_entry->ope);
-	assert_true(dlist_empty(&efa_rdm_ep->txe_list));
+	assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_TXE), 0);
 
 	/* Simulate the send completion arriving after peer removal.
 	 * The handler must not dereference pkt_entry->ope since
@@ -97,7 +97,7 @@ void test_efa_rdm_pke_handle_tx_error_peer_removed(void **state)
 	assert_int_equal(err, 0);
 	assert_null(pkt_entry->peer);
 	assert_null(pkt_entry->ope);
-	assert_true(dlist_empty(&efa_rdm_ep->txe_list));
+	assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_TXE), 0);
 
 	/* Simulate a TX error arriving after peer removal.
 	 * The handler must not dereference pkt_entry->ope since
@@ -148,7 +148,7 @@ void test_efa_rdm_pke_handle_longcts_rtm_send_completion(void **state)
     msg.iov_count = 1;
     msg.msg_iov = &iov;
     msg.desc = NULL;
-    txe = ofi_buf_alloc(efa_rdm_ep->ope_pool);
+    txe = ofi_buf_alloc(efa_rdm_ep->base_ep.ope_pool);
     assert_non_null(txe);
     efa_rdm_txe_construct(txe, efa_rdm_ep, peer, &msg, ofi_op_msg, 0, 0);
     txe->internal_flags |= EFA_RDM_OPE_READ_NACK;
@@ -424,7 +424,7 @@ void test_efa_rdm_pke_flag_tracking(void **state)
 	msg.iov_count = 1;
 	msg.msg_iov = &iov;
 	msg.desc = NULL;
-	txe = ofi_buf_alloc(efa_rdm_ep->ope_pool);
+	txe = ofi_buf_alloc(efa_rdm_ep->base_ep.ope_pool);
 	assert_non_null(txe);
 	efa_rdm_txe_construct(txe, efa_rdm_ep, peer, &msg, ofi_op_msg, 0, 0);
 

--- a/prov/efa/test/efa_unit_test_rdm_peer.c
+++ b/prov/efa/test/efa_unit_test_rdm_peer.c
@@ -433,7 +433,7 @@ void test_efa_rdm_peer_destruct_clears_rnr_flag(void **state)
 	assert_non_null(peer);
 
 	/* Simulate RNR: record completion and queue for retransmit */
-	efa_rdm_pke_set_ope(pkt_entry, container_of(efa_rdm_ep->txe_list.next, struct efa_rdm_ope, ep_entry));
+	efa_rdm_pke_set_ope(pkt_entry, efa_unit_test_get_first_ope(efa_rdm_ep, EFA_RDM_TXE));
 	efa_rdm_ep_record_tx_op_completed(efa_rdm_ep, pkt_entry);
 	efa_rdm_ep_queue_rnr_pkt(efa_rdm_ep, pkt_entry);
 

--- a/prov/efa/test/efa_unit_test_rdm_rma.c
+++ b/prov/efa/test/efa_unit_test_rdm_rma.c
@@ -541,7 +541,7 @@ void test_efa_rdm_rma_post_remote_write_partial_fail_no_txe_release(
 	 * With the fix, the txe must still be live because the first
 	 * segment is in-flight (efa_outstanding_tx_ops > 0).
 	 */
-	assert_int_equal(efa_unit_test_get_dlist_length(&efa_rdm_ep->txe_list), 1);
+	assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_TXE), 1);
 	assert_int_equal(efa_rdm_ep->efa_outstanding_tx_ops,
 			 efa_rdm_ep->efa_max_outstanding_tx_ops);
 	assert_int_equal(peer->efa_outstanding_tx_ops, 1);
@@ -559,7 +559,7 @@ void test_efa_rdm_rma_post_remote_write_partial_fail_no_txe_release(
 	efa_rdm_pke_handle_rma_completion(inflight_pke);
 
 	/* The txe was released by the completion path. No leak. */
-	assert_int_equal(efa_unit_test_get_dlist_length(&efa_rdm_ep->txe_list), 0);
+	assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_TXE), 0);
 	assert_int_equal(efa_rdm_ep->efa_outstanding_tx_ops,
 			 efa_rdm_ep->efa_max_outstanding_tx_ops - 1);
 	assert_int_equal(peer->efa_outstanding_tx_ops, 0);
@@ -670,7 +670,7 @@ void test_efa_rdm_rma_partial_post_retry_no_double_free(
 	assert_int_equal(ret, -FI_EAGAIN);
 	assert_int_equal(g_ibv_submitted_wr_id_cnt, 1);
 	/* txe1 must still be live; retry's txe2 was released inline. */
-	assert_int_equal(efa_unit_test_get_dlist_length(&efa_rdm_ep->txe_list), 1);
+	assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_TXE), 1);
 	assert_int_equal(peer->efa_outstanding_tx_ops, 1);
 
 	/*
@@ -684,7 +684,7 @@ void test_efa_rdm_rma_partial_post_retry_no_double_free(
 	efa_rdm_pke_handle_rma_completion(inflight_pke);
 
 	/* Post-fix: both txes have been released; peer/ep state is clean. */
-	assert_int_equal(efa_unit_test_get_dlist_length(&efa_rdm_ep->txe_list), 0);
+	assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_TXE), 0);
 	assert_int_equal(peer->efa_outstanding_tx_ops, 0);
 	assert_true(dlist_empty(&peer->outstanding_tx_pkts));
 
@@ -794,7 +794,7 @@ void test_efa_rdm_rma_post_remote_read_partial_fail_no_txe_release(
 	 * With the fix, the txe must still be live because the first
 	 * segment is in-flight.
 	 */
-	assert_int_equal(efa_unit_test_get_dlist_length(&efa_rdm_ep->txe_list), 1);
+	assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_TXE), 1);
 	assert_int_equal(efa_rdm_ep->efa_outstanding_tx_ops,
 			 efa_rdm_ep->efa_max_outstanding_tx_ops);
 	assert_int_equal(peer->efa_outstanding_tx_ops, 1);
@@ -812,7 +812,7 @@ void test_efa_rdm_rma_post_remote_read_partial_fail_no_txe_release(
 	efa_rdm_pke_handle_rma_completion(inflight_pke);
 
 	/* The txe was released by the completion path. No leak. */
-	assert_int_equal(efa_unit_test_get_dlist_length(&efa_rdm_ep->txe_list), 0);
+	assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_TXE), 0);
 	assert_int_equal(efa_rdm_ep->efa_outstanding_tx_ops,
 			 efa_rdm_ep->efa_max_outstanding_tx_ops - 1);
 	assert_int_equal(peer->efa_outstanding_tx_ops, 0);
@@ -913,7 +913,7 @@ void test_efa_rdm_rma_partial_post_retry_no_double_free_read(
 	ret = fi_readmsg(resource->ep, &msg, 0);
 	assert_int_equal(ret, -FI_EAGAIN);
 	assert_int_equal(g_ibv_submitted_wr_id_cnt, 1);
-	assert_int_equal(efa_unit_test_get_dlist_length(&efa_rdm_ep->txe_list), 1);
+	assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_TXE), 1);
 	assert_int_equal(peer->efa_outstanding_tx_ops, 1);
 
 	/*
@@ -935,7 +935,7 @@ void test_efa_rdm_rma_partial_post_retry_no_double_free_read(
 	efa_rdm_pke_handle_rma_completion(inflight_pke);
 
 	/* Clean drain: both txes released, peer/ep state clean. */
-	assert_int_equal(efa_unit_test_get_dlist_length(&efa_rdm_ep->txe_list), 0);
+	assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_TXE), 0);
 	assert_int_equal(peer->efa_outstanding_tx_ops, 0);
 	assert_true(dlist_empty(&peer->outstanding_tx_pkts));
 

--- a/prov/efa/test/efa_unit_test_rnr.c
+++ b/prov/efa/test/efa_unit_test_rnr.c
@@ -36,17 +36,17 @@ void test_efa_rnr_queue_and_resend_impl(void **state, uint32_t op)
 	/* Add mock for efa_qp_post_send */
 	g_efa_unit_test_mocks.efa_qp_post_send = &efa_mock_efa_qp_post_send_return_mock;
 	will_return_int_maybe(efa_mock_efa_qp_post_send_return_mock, 0);
-	assert_true(dlist_empty(&efa_rdm_ep->txe_list));
+	assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_TXE), 0);
 
 	if (op == ofi_op_msg)
 		ret = fi_send(resource->ep, send_buff.buff, send_buff.size, fi_mr_desc(send_buff.mr), peer_addr, NULL /* context */);
 	else
 		ret = fi_tsend(resource->ep, send_buff.buff, send_buff.size, fi_mr_desc(send_buff.mr), peer_addr, 1234, NULL /* context */);
 	assert_int_equal(ret, 0);
-	assert_false(dlist_empty(&efa_rdm_ep->txe_list));
+	assert_true(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_TXE) > 0);
 	assert_int_equal(g_ibv_submitted_wr_id_cnt, 1);
 
-	txe = container_of(efa_rdm_ep->txe_list.next, struct efa_rdm_ope, ep_entry);
+	txe = efa_unit_test_get_first_ope(efa_rdm_ep, EFA_RDM_TXE);
 
 	efa_rdm_cq = container_of(resource->cq, struct efa_rdm_cq, efa_cq.util_cq.cq_fid.fid);
 	ibv_cq = &efa_rdm_cq->efa_cq.ibv_cq;
@@ -136,8 +136,7 @@ void test_efa_rdm_ep_post_queued_pkts_releases_pkt_on_error(void **state)
 		      fi_mr_desc(send_buff.mr), peer_addr, NULL);
 	assert_int_equal(ret, 0);
 
-	txe = container_of(efa_rdm_ep->txe_list.next,
-			   struct efa_rdm_ope, ep_entry);
+	txe = efa_unit_test_get_first_ope(efa_rdm_ep, EFA_RDM_TXE);
 
 	efa_rdm_cq = container_of(resource->cq, struct efa_rdm_cq,
 				  efa_cq.util_cq.cq_fid.fid);

--- a/prov/efa/test/efa_unit_test_send.c
+++ b/prov/efa/test/efa_unit_test_send.c
@@ -163,7 +163,7 @@ void test_efa_rdm_msg_send_multi_pkt_sendv_fail_no_inflight(
 	assert_int_equal(efa_unit_test_get_dlist_length(&peer->outstanding_tx_pkts),
 			 peer_outstanding_pkts_before);
 	/* txe was released by the caller (safe: no segments were committed). */
-	assert_int_equal(efa_unit_test_get_dlist_length(&efa_rdm_ep->txe_list), 0);
+	assert_int_equal(efa_unit_test_get_ope_list_length(efa_rdm_ep, EFA_RDM_TXE), 0);
 
 	efa_unit_test_buff_destruct(&send_buff);
 }

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -267,6 +267,7 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_base_ep_construct_ibv_qp_init_attr_ex_efa_direct_use_requested_limits, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_base_ep_construct_ibv_qp_init_attr_ex_efa_use_requested_limits, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_base_ep_construct_ibv_qp_init_attr_ex_efa_use_device_limits, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_base_ep_construct_ibv_qp_init_attr_ex_dgram, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		/* end efa_unit_test_ep.c */
 
 		/* begin efa_unit_test_cq.c */

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -171,6 +171,7 @@ void test_efa_rdm_ep_get_explicit_shm_fi_addr_no_shm(void **state);
 void test_efa_base_ep_construct_ibv_qp_init_attr_ex_efa_direct_use_requested_limits(void **state);
 void test_efa_base_ep_construct_ibv_qp_init_attr_ex_efa_use_requested_limits(void **state);
 void test_efa_base_ep_construct_ibv_qp_init_attr_ex_efa_use_device_limits(void **state);
+void test_efa_base_ep_construct_ibv_qp_init_attr_ex_dgram(void **state);
 void test_dgram_cq_read_empty_cq(void **state);
 void test_ibv_cq_ex_read_empty_cq(void **state);
 void test_ibv_cq_ex_read_failed_poll(void **state);

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -657,6 +657,45 @@ int efa_unit_test_get_dlist_length(struct dlist_entry *head)
 	return i;
 }
 
+/*
+ * efa-rdm tx and rx entries are tracked on the shared base_ep.ope_list,
+ * differentiated by efa_rdm_ope::type. These helpers count / fetch entries
+ * of a given type (EFA_RDM_TXE or EFA_RDM_RXE) so tests can reason about
+ * tx and rx entries independently.
+ */
+static inline
+int efa_unit_test_get_ope_list_length(struct efa_rdm_ep *ep,
+				      enum efa_rdm_ope_type type)
+{
+	int i = 0;
+	struct dlist_entry *item;
+	struct efa_rdm_ope *ope;
+
+	dlist_foreach(&ep->base_ep.ope_list, item) {
+		ope = container_of(item, struct efa_rdm_ope, ep_entry);
+		if (ope->type == type)
+			i++;
+	}
+
+	return i;
+}
+
+static inline
+struct efa_rdm_ope *efa_unit_test_get_first_ope(struct efa_rdm_ep *ep,
+						enum efa_rdm_ope_type type)
+{
+	struct dlist_entry *item;
+	struct efa_rdm_ope *ope;
+
+	dlist_foreach(&ep->base_ep.ope_list, item) {
+		ope = container_of(item, struct efa_rdm_ope, ep_entry);
+		if (ope->type == type)
+			return ope;
+	}
+
+	return NULL;
+}
+
 void efa_unit_test_rdm_0byte_prep(struct efa_resource *resource, fi_addr_t *addr);
 
 #endif


### PR DESCRIPTION
  **Summary**

  Refactor the EFA endpoint (EP) and completion queue (CQ) components to remove
  fabric-dependent branching from shared code paths, as part of the EFA provider
  refactoring effort ([Subspace-3425]).

  Key changes:
  - Remove unused efa_dgram_ep_msg_ops and efa_dgram_ep_rma_ops dead code
  - Move ope_pool/ope_list into efa_base_ep and unify efa-rdm's separate txe_list/rxe_list into one ope_list, eliminating EFA_INFO_TYPE_IS_RDM branching in MR close
  - Remove EFA_INFO_TYPE_IS_DIRECT branching in efa_base_ep_create_qp by having efa-direct initialize use_unsolicited_write_recv at ep open time
  - Add DGRAM unit test for construct_ibv_qp_init_attr_ex

  **Motivation**

  The shared efa_base_ep code contained if (EFA_INFO_TYPE_IS_DIRECT(...)) conditionals
  that complicated maintenance and violated the layered architecture described in the
  refactoring design doc. This PR eliminates those conditions by:
  1. Making each endpoint type configure its own state at construction time
  2. Unifying operation tracking so generic code doesn't need to know which fabric type it's dealing with
  
