### PR TITLE
prov/efa: check all descs for HMEM across remaining code paths

### DIFF
--- a/prov/efa/src/efa_mr.h
+++ b/prov/efa/src/efa_mr.h
@@ -38,7 +38,7 @@ extern struct fi_ops_mr efa_domain_mr_ops;
 
 int efa_mr_regattr_validate(struct fid *fid, const struct fi_mr_attr *attr, uint64_t flags);
 
-static inline bool efa_mr_is_hmem(struct efa_mr *efa_mr)
+static inline bool efa_mr_is_non_system_hmem(struct efa_mr *efa_mr)
 {
 	return efa_mr && (
 		efa_mr->iface == FI_HMEM_CUDA ||
@@ -47,24 +47,9 @@ static inline bool efa_mr_is_hmem(struct efa_mr *efa_mr)
 		efa_mr->iface == FI_HMEM_SYNAPSEAI);
 }
 
-static inline bool efa_mr_is_cuda(struct efa_mr *efa_mr)
+static inline bool efa_mr_is_iface(struct efa_mr *efa_mr, enum fi_hmem_iface iface)
 {
-	return efa_mr ? (efa_mr->iface == FI_HMEM_CUDA) : false;
-}
-
-static inline bool efa_mr_is_neuron(struct efa_mr *efa_mr)
-{
-	return efa_mr ? (efa_mr->iface == FI_HMEM_NEURON) : false;
-}
-
-static inline bool efa_mr_is_synapseai(struct efa_mr *efa_mr)
-{
-	return efa_mr ? (efa_mr->iface == FI_HMEM_SYNAPSEAI) : false;
-}
-
-static inline bool efa_mr_is_rocr(struct efa_mr *efa_mr)
-{
-	return efa_mr && efa_mr->iface == FI_HMEM_ROCR;
+	return efa_mr && efa_mr->iface == iface;
 }
 
 #define EFA_MR_IOV_LIMIT 1

--- a/prov/efa/src/efa_mr.h
+++ b/prov/efa/src/efa_mr.h
@@ -52,6 +52,35 @@ static inline bool efa_mr_is_iface(struct efa_mr *efa_mr, enum fi_hmem_iface ifa
 	return efa_mr && efa_mr->iface == iface;
 }
 
+/*
+ * Return true if any descriptor in @desc (size @count) refers to
+ * non-system HMEM.  A NULL @desc array is treated as no HMEM.
+ */
+static inline bool efa_mr_any_is_non_system_hmem(void **desc, size_t count)
+{
+	size_t i;
+
+	if (!desc)
+		return false;
+	for (i = 0; i < count; i++)
+		if (efa_mr_is_non_system_hmem(desc[i]))
+			return true;
+	return false;
+}
+
+static inline bool efa_mr_any_is_iface(void **desc, size_t count,
+				       enum fi_hmem_iface iface)
+{
+	size_t i;
+
+	if (!desc)
+		return false;
+	for (i = 0; i < count; i++)
+		if (efa_mr_is_iface(desc[i], iface))
+			return true;
+	return false;
+}
+
 #define EFA_MR_IOV_LIMIT 1
 #define EFA_MR_SUPPORTED_PERMISSIONS (FI_SEND | FI_RECV | FI_REMOTE_READ | FI_REMOTE_WRITE | FI_READ | FI_WRITE)
 

--- a/prov/efa/src/efa_msg.c
+++ b/prov/efa/src/efa_msg.c
@@ -266,15 +266,7 @@ static inline ssize_t efa_post_send(struct efa_base_ep *base_ep, const struct fi
 
 	/* Determine if we should use inline data */
 	len_fits_inline = len <= base_ep->domain->device->efa_attr.inline_buf_size;
-	is_hmem = false;
-	if (msg->desc) {
-		for (i = 0; i < msg->iov_count; i++) {
-			if (efa_mr_is_non_system_hmem(msg->desc[i])) {
-				is_hmem = true;
-				break;
-			}
-		}
-	}
+	is_hmem = efa_mr_any_is_non_system_hmem(msg->desc, msg->iov_count);
 	if (len_fits_inline && !is_hmem) {
 		use_inline = true;
 		/* Prepare inline data list */

--- a/prov/efa/src/efa_msg.c
+++ b/prov/efa/src/efa_msg.c
@@ -269,7 +269,7 @@ static inline ssize_t efa_post_send(struct efa_base_ep *base_ep, const struct fi
 	is_hmem = false;
 	if (msg->desc) {
 		for (i = 0; i < msg->iov_count; i++) {
-			if (efa_mr_is_hmem(msg->desc[i])) {
+			if (efa_mr_is_non_system_hmem(msg->desc[i])) {
 				is_hmem = true;
 				break;
 			}

--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -1724,7 +1724,7 @@ int efa_rdm_rxe_post_local_read_or_queue(struct efa_rdm_ope *rxe,
 
 	/* setup iov */
 	assert(pkt_entry->ope == rxe);
-	assert(rxe->desc && efa_mr_is_hmem(rxe->desc[0]));
+	assert(rxe->desc && efa_mr_is_non_system_hmem(rxe->desc[0]));
 	iov_count = rxe->iov_count;
 	memcpy(iov, rxe->iov, rxe->iov_count * sizeof(struct iovec));
 	memcpy(desc, rxe->desc, rxe->iov_count * sizeof(void *));
@@ -1736,7 +1736,7 @@ int efa_rdm_rxe_post_local_read_or_queue(struct efa_rdm_ope *rxe,
 		return -FI_ETRUNC;
 	}
 
-	assert(efa_mr_is_hmem(rxe->desc[0]));
+	assert(efa_mr_is_non_system_hmem(rxe->desc[0]));
 	err = ofi_truncate_iov(iov, &iov_count, data_size);
 	if (err) {
 		EFA_WARN(FI_LOG_CQ,

--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -1724,7 +1724,7 @@ int efa_rdm_rxe_post_local_read_or_queue(struct efa_rdm_ope *rxe,
 
 	/* setup iov */
 	assert(pkt_entry->ope == rxe);
-	assert(rxe->desc && efa_mr_is_non_system_hmem(rxe->desc[0]));
+	assert(rxe->desc && efa_mr_any_is_non_system_hmem(rxe->desc, rxe->iov_count));
 	iov_count = rxe->iov_count;
 	memcpy(iov, rxe->iov, rxe->iov_count * sizeof(struct iovec));
 	memcpy(desc, rxe->desc, rxe->iov_count * sizeof(void *));
@@ -1736,7 +1736,7 @@ int efa_rdm_rxe_post_local_read_or_queue(struct efa_rdm_ope *rxe,
 		return -FI_ETRUNC;
 	}
 
-	assert(efa_mr_is_non_system_hmem(rxe->desc[0]));
+	assert(efa_mr_any_is_non_system_hmem(rxe->desc, rxe->iov_count));
 	err = ofi_truncate_iov(iov, &iov_count, data_size);
 	if (err) {
 		EFA_WARN(FI_LOG_CQ,

--- a/prov/efa/src/rdm/efa_rdm_pke.c
+++ b/prov/efa/src/rdm/efa_rdm_pke.c
@@ -486,7 +486,7 @@ ssize_t efa_rdm_pke_sendv(struct efa_rdm_pke **pkt_entry_vec,
 		assert(pkt_entry->peer == peer);
 
 		use_inline = (pkt_entry->pkt_size <= efa_rdm_ep_domain(ep)->device->efa_attr.inline_buf_size &&
-	            !efa_mr_is_hmem((struct efa_mr *)pkt_entry->payload_mr));
+	            !efa_mr_is_non_system_hmem((struct efa_mr *)pkt_entry->payload_mr));
 
 		if (use_inline) {
 			iov_cnt = 1;

--- a/prov/efa/src/rdm/efa_rdm_pke_rtm.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtm.c
@@ -118,7 +118,7 @@ ssize_t efa_rdm_pke_init_rtm_with_payload(struct efa_rdm_pke *pkt_entry,
 				txe->ep->mtu_size - efa_rdm_pke_get_req_hdr_size(pkt_entry));
 
 		if (data_size + segment_offset < txe->total_len) {
-			if (efa_mr_is_iface(txe->desc[0], FI_HMEM_CUDA)) {
+			if (efa_mr_any_is_iface(txe->desc, txe->iov_count, FI_HMEM_CUDA)) {
 				if (txe->ep->sendrecv_in_order_aligned_128_bytes)
 					data_size &= ~(EFA_RDM_IN_ORDER_ALIGNMENT - 1);
 				else

--- a/prov/efa/src/rdm/efa_rdm_pke_rtm.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtm.c
@@ -118,7 +118,7 @@ ssize_t efa_rdm_pke_init_rtm_with_payload(struct efa_rdm_pke *pkt_entry,
 				txe->ep->mtu_size - efa_rdm_pke_get_req_hdr_size(pkt_entry));
 
 		if (data_size + segment_offset < txe->total_len) {
-			if (efa_mr_is_cuda(txe->desc[0])) {
+			if (efa_mr_is_iface(txe->desc[0], FI_HMEM_CUDA)) {
 				if (txe->ep->sendrecv_in_order_aligned_128_bytes)
 					data_size &= ~(EFA_RDM_IN_ORDER_ALIGNMENT - 1);
 				else

--- a/prov/efa/src/rdm/efa_rdm_pke_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_utils.c
@@ -302,7 +302,7 @@ int efa_rdm_pke_copy_payload_to_cuda(struct efa_rdm_pke *pke,
 	int ret, err;
 
 	desc = rxe->desc[0];
-	assert(efa_mr_is_cuda(&desc->efa_mr));
+	assert(efa_mr_is_iface(&desc->efa_mr, FI_HMEM_CUDA));
 
 	ep = pke->ep;
 	assert(ep);
@@ -460,10 +460,10 @@ ssize_t efa_rdm_pke_copy_payload_to_ope(struct efa_rdm_pke *pke,
 
 	desc = ope->desc[0];
 
-	if (efa_mr_is_cuda(desc))
+	if (efa_mr_is_iface(desc, FI_HMEM_CUDA))
 		return efa_rdm_pke_copy_payload_to_cuda(pke, ope);
 
-	if (efa_mr_is_hmem(desc))
+	if (efa_mr_is_non_system_hmem(desc))
 		return efa_rdm_pke_queued_copy_payload_to_hmem(pke, ope);
 
 	assert( !desc || desc->iface == FI_HMEM_SYSTEM);

--- a/prov/efa/src/rdm/efa_rdm_pke_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_utils.c
@@ -424,7 +424,6 @@ int efa_rdm_pke_copy_payload_to_cuda(struct efa_rdm_pke *pke,
 ssize_t efa_rdm_pke_copy_payload_to_ope(struct efa_rdm_pke *pke,
 					struct efa_rdm_ope *ope)
 {
-	struct efa_mr *desc;
 	struct efa_rdm_ep *ep;
 	size_t segment_offset;
 	size_t bytes_copied;
@@ -458,15 +457,13 @@ ssize_t efa_rdm_pke_copy_payload_to_ope(struct efa_rdm_pke *pke,
 		return 0;
 	}
 
-	desc = ope->desc[0];
-
-	if (efa_mr_is_iface(desc, FI_HMEM_CUDA))
+	if (efa_mr_any_is_iface(ope->desc, ope->iov_count, FI_HMEM_CUDA))
 		return efa_rdm_pke_copy_payload_to_cuda(pke, ope);
 
-	if (efa_mr_is_non_system_hmem(desc))
+	if (efa_mr_any_is_non_system_hmem(ope->desc, ope->iov_count))
 		return efa_rdm_pke_queued_copy_payload_to_hmem(pke, ope);
 
-	assert( !desc || desc->iface == FI_HMEM_SYSTEM);
+	assert(!ope->desc[0] || ((struct efa_mr *) ope->desc[0])->iface == FI_HMEM_SYSTEM);
 	efa_rdm_tracepoint(rx_pke_blocking_copy_payload_begin, (size_t) pke, pke->payload_size, ope->msg_id, (size_t) ope->cq_entry.op_context, ope->total_len);
 	bytes_copied = ofi_copy_to_iov(ope->iov, ope->iov_count,
 				       segment_offset + ep->msg_prefix_size,

--- a/prov/efa/src/rdm/efa_rdm_rma.c
+++ b/prov/efa/src/rdm/efa_rdm_rma.c
@@ -143,7 +143,7 @@ ssize_t efa_rdm_rma_post_read(struct efa_rdm_ep *ep, struct efa_rdm_ope *txe)
 		 * so we do not check it here
 		 */
 		use_device_read = true;
-	} else if (efa_mr_is_iface(txe->desc[0], FI_HMEM_NEURON)) {
+	} else if (efa_mr_any_is_iface(txe->desc, txe->iov_count, FI_HMEM_NEURON)) {
 		EFA_WARN(FI_LOG_EP_CTRL, "rdma read is required to post read for AWS trainium memory\n");
 		return -FI_EOPNOTSUPP;
 	}

--- a/prov/efa/src/rdm/efa_rdm_rma.c
+++ b/prov/efa/src/rdm/efa_rdm_rma.c
@@ -143,7 +143,7 @@ ssize_t efa_rdm_rma_post_read(struct efa_rdm_ep *ep, struct efa_rdm_ope *txe)
 		 * so we do not check it here
 		 */
 		use_device_read = true;
-	} else if (efa_mr_is_neuron(txe->desc[0])) {
+	} else if (efa_mr_is_iface(txe->desc[0], FI_HMEM_NEURON)) {
 		EFA_WARN(FI_LOG_EP_CTRL, "rdma read is required to post read for AWS trainium memory\n");
 		return -FI_EOPNOTSUPP;
 	}

--- a/prov/efa/test/efa_unit_test_mr.c
+++ b/prov/efa/test/efa_unit_test_mr.c
@@ -518,11 +518,34 @@ void test_efa_mr_iface_helpers(struct efa_resource **state)
 {
 	struct efa_mr host = { .iface = FI_HMEM_SYSTEM };
 	struct efa_mr cuda = { .iface = FI_HMEM_CUDA };
+	struct efa_mr neuron = { .iface = FI_HMEM_NEURON };
 
 	assert_false(efa_mr_is_iface(NULL, FI_HMEM_CUDA));
 	assert_true(efa_mr_is_iface(&cuda, FI_HMEM_CUDA));
 	assert_false(efa_mr_is_iface(&cuda, FI_HMEM_NEURON));
 	assert_true(efa_mr_is_iface(&host, FI_HMEM_SYSTEM));
+
+	/* efa_mr_any_is_iface: NULL array, zero count, single iov, mixed iovs */
+	assert_false(efa_mr_any_is_iface(NULL, 4, FI_HMEM_CUDA));
+	void *none[1] = {&host};
+	assert_false(efa_mr_any_is_iface(none, 0, FI_HMEM_CUDA));
+	assert_false(efa_mr_any_is_iface(none, 1, FI_HMEM_CUDA));
+
+	void *first_cuda[2] = {&cuda, &host};
+	void *last_cuda[2] = {&host, &cuda};
+	void *null_then_cuda[2] = {NULL, &cuda};
+	assert_true(efa_mr_any_is_iface(first_cuda, 2, FI_HMEM_CUDA));
+	assert_true(efa_mr_any_is_iface(last_cuda, 2, FI_HMEM_CUDA));
+	assert_true(efa_mr_any_is_iface(null_then_cuda, 2, FI_HMEM_CUDA));
+	assert_false(efa_mr_any_is_iface(first_cuda, 2, FI_HMEM_NEURON));
+
+	/* efa_mr_any_is_non_system_hmem: excludes system; any device iface qualifies */
+	void *all_host[2] = {&host, &host};
+	void *host_neuron[2] = {&host, &neuron};
+	assert_false(efa_mr_any_is_non_system_hmem(NULL, 4));
+	assert_false(efa_mr_any_is_non_system_hmem(all_host, 2));
+	assert_true(efa_mr_any_is_non_system_hmem(host_neuron, 2));
+	assert_true(efa_mr_any_is_non_system_hmem(first_cuda, 2));
 }
 
 /**

--- a/prov/efa/test/efa_unit_test_mr.c
+++ b/prov/efa/test/efa_unit_test_mr.c
@@ -512,6 +512,20 @@ void test_efa_mr_attr_init_system_macro(struct efa_resource **state)
 }
 
 /**
+ * @brief Test the efa_mr_is_iface helper predicate.
+ */
+void test_efa_mr_iface_helpers(struct efa_resource **state)
+{
+	struct efa_mr host = { .iface = FI_HMEM_SYSTEM };
+	struct efa_mr cuda = { .iface = FI_HMEM_CUDA };
+
+	assert_false(efa_mr_is_iface(NULL, FI_HMEM_CUDA));
+	assert_true(efa_mr_is_iface(&cuda, FI_HMEM_CUDA));
+	assert_false(efa_mr_is_iface(&cuda, FI_HMEM_NEURON));
+	assert_true(efa_mr_is_iface(&host, FI_HMEM_SYSTEM));
+}
+
+/**
  * @brief Test efa_mr_ofi_to_ibv_access with no access flags
  * 
  * When no access flags are provided, the function should default to 

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -550,6 +550,7 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_mr_validate_regattr_uninitialized_iface, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_mr_structure_casting, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test(test_efa_mr_attr_init_system_macro),
+		cmocka_unit_test(test_efa_mr_iface_helpers),
 		cmocka_unit_test(test_efa_mr_ofi_to_ibv_access_no_access),
 		cmocka_unit_test(test_efa_mr_ofi_to_ibv_access_one_flag),
 		cmocka_unit_test(test_efa_mr_ofi_to_ibv_access_read_not_supported),

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -529,6 +529,7 @@ void test_efa_mr_validate_regattr_invalid_iov_count();
 void test_efa_mr_validate_regattr_uninitialized_iface();
 void test_efa_rdm_mr_structure_casting();
 void test_efa_mr_attr_init_system_macro();
+void test_efa_mr_iface_helpers();
 void test_efa_mr_ofi_to_ibv_access_no_access();
 void test_efa_mr_ofi_to_ibv_access_one_flag();
 void test_efa_mr_ofi_to_ibv_access_read_not_supported();


### PR DESCRIPTION
Following #12163, which fixed the inline path in efa_post_send to consider every descriptor when deciding whether a send touches non-system HMEM. The same `desc[0]`-only pattern existed in several other places, each of which is wrong for multi-iov requests that mix host and device memory across descriptors.

It's possible we'll want to add a detection mechanism for this fix