### PR TITLE
prov/efa: Fix -Wpointer-arith warnings on ARM

### DIFF
--- a/prov/efa/src/efa_mmio.h
+++ b/prov/efa/src/efa_mmio.h
@@ -177,8 +177,8 @@ static inline void _mmio_memcpy_x64(void *dest, const void *src, size_t bytecnt)
 	do {
 		_mmio_memcpy_x64_64b(dest, src);
 		bytecnt -= sizeof(uint64x2x4_t);
-		src += sizeof(uint64x2x4_t);
-		dest += sizeof(uint64x2x4_t);
+		src = (const char *)src + sizeof(uint64x2x4_t);
+		dest = (char *)dest + sizeof(uint64x2x4_t);
 	} while (bytecnt > 0);
 }
 


### PR DESCRIPTION
In _mmio_memcpy_x64(), src and dest are void * pointers. Arithmetic on void * is a GNU extension and triggers -Wpointer-arith when building on aarch64/arm (e.g. c7gn):

    efa_mmio.h:180:21: warning: pointer of type 'void *' used in
                       arithmetic [-Wpointer-arith]
            src += sizeof(uint64x2x4_t);
    efa_mmio.h:181:22: warning: pointer of type 'void *' used in
                       arithmetic [-Wpointer-arith]
            dest += sizeof(uint64x2x4_t);

Cast to char * before incrementing so the arithmetic is standards-conformant. No functional change.