### PR TITLE
prov/efa: fix ep teardown crashes and overflow pkt leak; fabtests: fix thread cleanup

### DIFF
--- a/fabtests/prov/efa/src/multi_ep_stress.c
+++ b/fabtests/prov/efa/src/multi_ep_stress.c
@@ -1076,33 +1076,32 @@ static int run_sender(void)
 		}
 	}
 
-	// Wait for completion
-	for (int i = 0; i < topts.num_sender_workers; i++) {
-		void *retval;
-		ret = pthread_join(threads[i], &retval);
-		if (ret) {
-			FT_PRINTERR("pthread_join", ret);
-			goto out;
-		}
-		if (retval != NULL) {
-			ret = *(int *)retval;
-			free(retval);
-			fprintf(stderr,
-				"Sender %d failed. Exit code: %d, %s\n",
-				i, ret, fi_strerror(-ret));
-			goto out;
-		}
-	}
-
 out:
+	/* Always join all threads before cleanup to avoid
+	 * use-after-free from closing endpoints that worker
+	 * threads are still using.
+	 */
+	if (threads) {
+		for (int i = 0; i < topts.num_sender_workers; i++) {
+			if (!threads[i])
+				continue;
+			void *retval;
+			if (pthread_join(threads[i], &retval))
+				continue;
+			if (retval != NULL) {
+				if (!ret)
+					ret = *(int *)retval;
+				free(retval);
+			}
+		}
+		free(threads);
+	}
 	if (channels) {
 		for (int i = 0; i < topts.num_sender_workers; i++) {
-		       ep_message_queue_destroy(&channels[i]);
+			ep_message_queue_destroy(&channels[i]);
 		}
 		free(channels);
 	}
-	if (threads)
-		free(threads);
 	if (workers) {
 		for (int i = 0; i < topts.num_sender_workers; i++) {
 			cleanup_worker_resourses(&workers[i]);
@@ -1212,27 +1211,26 @@ static int run_receiver(void)
 		goto out;
 	}
 
-	// Wait for thread completion
-	for (int i = 0; i < topts.num_receiver_workers; i++) {
-		void *retval;
-		ret = pthread_join(threads[i], &retval);
-		if (ret) {
-			FT_PRINTERR("pthread_join", ret);
-			goto out;
-		}
-		if (retval != NULL) {
-			ret = *(int *)retval;
-			free(retval);
-			fprintf(stderr,
-				"Receiver %d failed. Exit code: %d, %s\n",
-				i, ret, fi_strerror(-ret));
-			goto out;
-		}
-	}
-
 out:
-	if (threads)
+	/* Always join all threads before cleanup to avoid
+	 * use-after-free from closing endpoints that worker
+	 * threads are still using.
+	 */
+	if (threads) {
+		for (int i = 0; i < topts.num_receiver_workers; i++) {
+			if (!threads[i])
+				continue;
+			void *retval;
+			if (pthread_join(threads[i], &retval))
+				continue;
+			if (retval != NULL) {
+				if (!ret)
+					ret = *(int *)retval;
+				free(retval);
+			}
+		}
 		free(threads);
+	}
 	if (workers) {
 		for (int i = 0; i < topts.num_receiver_workers; i++) {
 			cleanup_worker_resourses(&workers[i]);

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -816,51 +816,11 @@ static void efa_rdm_ep_destroy_buffer_pools(struct efa_rdm_ep *efa_rdm_ep)
 	struct efa_av_entry *av_entry;
 	struct efa_conn_ep_peer_map_entry *peer_map_entry;
 
-#if ENABLE_DEBUG
-	struct efa_rdm_pke *pkt_entry;
-
-	dlist_foreach_safe(&efa_rdm_ep->rx_posted_buf_list, entry, tmp) {
-		pkt_entry = container_of(entry, struct efa_rdm_pke, dbg_entry);
-		efa_rdm_pke_release_rx(pkt_entry);
-	}
-
-	dlist_foreach_safe(&efa_rdm_ep->rx_pkt_list, entry, tmp) {
-		pkt_entry = container_of(entry, struct efa_rdm_pke, dbg_entry);
-		EFA_WARN(FI_LOG_EP_CTRL,
-			"Closing ep with unreleased RX pkt_entry: %p\n",
-			pkt_entry);
-		/* Unlink the packet entries before releasing */
-		pkt_entry->next = NULL;
-		efa_rdm_pke_release_rx(pkt_entry);
-	}
-
-	dlist_foreach_safe(&efa_rdm_ep->tx_pkt_list, entry, tmp) {
-		pkt_entry = container_of(entry, struct efa_rdm_pke, dbg_entry);
-		EFA_WARN(FI_LOG_EP_CTRL,
-			"Closing ep with unreleased TX pkt_entry: %p\n",
-			pkt_entry);
-		efa_rdm_pke_release_tx(pkt_entry);
-	}
-#endif
-
-	dlist_foreach_safe(&efa_rdm_ep->rxe_list, entry, tmp) {
-		rxe = container_of(entry, struct efa_rdm_ope,
-					ep_entry);
-		EFA_INFO(FI_LOG_EP_CTRL,
-			"Closing ep with unreleased rxe\n");
-		efa_rdm_rxe_release(rxe);
-	}
-
-	dlist_foreach_safe(&efa_rdm_ep->txe_list, entry, tmp) {
-		txe = container_of(entry, struct efa_rdm_ope,
-					ep_entry);
-		EFA_INFO(FI_LOG_EP_CTRL,
-			"Closing ep with unreleased txe: %p\n",
-			txe);
-		efa_rdm_txe_release(txe);
-	}
-
-	/* Clean up any remaining peers before destroying buffer pools */
+	/*
+	 * Destruct peers first so overflow packets are properly
+	 * released (including chained entries) and removed from
+	 * the debug lists before the debug sweep runs.
+	 */
 	dlist_foreach_container_safe (&efa_rdm_ep->ep_peer_list,
 				      struct efa_rdm_peer, peer,
 				      ep_peer_list_entry, tmp) {
@@ -889,6 +849,74 @@ static void efa_rdm_ep_destroy_buffer_pools(struct efa_rdm_ep *efa_rdm_ep)
 		ofi_buf_free(peer_map_entry);
 	}
 
+#if ENABLE_DEBUG
+	struct efa_rdm_pke *pkt_entry;
+
+	while (!dlist_empty(&efa_rdm_ep->rx_posted_buf_list)) {
+		pkt_entry = container_of(efa_rdm_ep->rx_posted_buf_list.next,
+					 struct efa_rdm_pke, dbg_entry);
+#ifdef ENABLE_EFA_POISONING
+		if (pkt_entry->alloc_type == (enum efa_rdm_pke_alloc_type)0xdeadbeef) {
+			EFA_WARN(FI_LOG_EP_CTRL,
+				"rx_posted_buf_list corrupted: poisoned pkt_entry %p, stopping sweep\n",
+				pkt_entry);
+			break;
+		}
+#endif
+		efa_rdm_pke_release_rx(pkt_entry);
+	}
+
+	while (!dlist_empty(&efa_rdm_ep->rx_pkt_list)) {
+		pkt_entry = container_of(efa_rdm_ep->rx_pkt_list.next,
+					 struct efa_rdm_pke, dbg_entry);
+#ifdef ENABLE_EFA_POISONING
+		if (pkt_entry->alloc_type == (enum efa_rdm_pke_alloc_type)0xdeadbeef) {
+			EFA_WARN(FI_LOG_EP_CTRL,
+				"rx_pkt_list corrupted: poisoned pkt_entry %p, stopping sweep\n",
+				pkt_entry);
+			break;
+		}
+#endif
+		EFA_WARN(FI_LOG_EP_CTRL,
+			"Closing ep with unreleased RX pkt_entry: %p\n",
+			pkt_entry);
+		efa_rdm_pke_release_rx_list(pkt_entry);
+	}
+
+	while (!dlist_empty(&efa_rdm_ep->tx_pkt_list)) {
+		pkt_entry = container_of(efa_rdm_ep->tx_pkt_list.next,
+					 struct efa_rdm_pke, dbg_entry);
+#ifdef ENABLE_EFA_POISONING
+		if (pkt_entry->alloc_type == (enum efa_rdm_pke_alloc_type)0xdeadbeef) {
+			EFA_WARN(FI_LOG_EP_CTRL,
+				"tx_pkt_list corrupted: poisoned pkt_entry %p, stopping sweep\n",
+				pkt_entry);
+			break;
+		}
+#endif
+		EFA_WARN(FI_LOG_EP_CTRL,
+			"Closing ep with unreleased TX pkt_entry: %p\n",
+			pkt_entry);
+		efa_rdm_pke_release_tx(pkt_entry);
+	}
+#endif
+
+	dlist_foreach_safe(&efa_rdm_ep->rxe_list, entry, tmp) {
+		rxe = container_of(entry, struct efa_rdm_ope,
+					ep_entry);
+		EFA_INFO(FI_LOG_EP_CTRL,
+			"Closing ep with unreleased rxe\n");
+		efa_rdm_rxe_release(rxe);
+	}
+
+	dlist_foreach_safe(&efa_rdm_ep->txe_list, entry, tmp) {
+		txe = container_of(entry, struct efa_rdm_ope,
+					ep_entry);
+		EFA_INFO(FI_LOG_EP_CTRL,
+			"Closing ep with unreleased txe: %p\n",
+			txe);
+		efa_rdm_txe_release(txe);
+	}
 	if (efa_rdm_ep->ope_pool)
 		ofi_bufpool_destroy(efa_rdm_ep->ope_pool);
 

--- a/prov/efa/src/rdm/efa_rdm_peer.c
+++ b/prov/efa/src/rdm/efa_rdm_peer.c
@@ -76,18 +76,42 @@ void efa_rdm_peer_destruct(struct efa_rdm_peer *peer, struct efa_rdm_ep *ep)
 	/* we cannot release outstanding TX packets because device
 	 * will report completion of these packets later. Setting
 	 * pkt_entry->peer to NULL so the completion will be ignored.
+	 *
+	 * Unlink pkt_entry->entry from peer->outstanding_tx_pkts and
+	 * clear EFA_RDM_PKE_IN_PEER_OUTSTANDING_TX_PKTS before the
+	 * peer struct is poisoned, so that efa_rdm_pke_release_tx()
+	 * will not dlist_remove(&pkt_entry->entry) against a poisoned
+	 * list head.
 	 */
-	dlist_foreach_container(&peer->outstanding_tx_pkts,
+	dlist_foreach_container_safe(&peer->outstanding_tx_pkts,
 				struct efa_rdm_pke,
-				pkt_entry, entry) {
+				pkt_entry, entry, tmp) {
 		pkt_entry->peer = NULL;
+		dlist_remove(&pkt_entry->entry);
+		pkt_entry->flags &= ~EFA_RDM_PKE_IN_PEER_OUTSTANDING_TX_PKTS;
 	}
-
+	
 	dlist_foreach_container_safe(&peer->overflow_pke_list,
 				     struct efa_rdm_peer_overflow_pke_list_entry,
 				     overflow_pke_list_entry, entry, tmp) {
 		dlist_remove(&overflow_pke_list_entry->entry);
-		efa_rdm_pke_release_rx(overflow_pke_list_entry->pkt_entry);
+#ifdef ENABLE_EFA_POISONING
+		/*
+		 * overflow_pke_list_entry->pkt_entry can be a dangling
+		 * pointer if the pkt_entry was already released through
+		 * normal message processing. Detect this by checking for
+		 * the poison pattern before attempting to release.
+		 */
+		if (overflow_pke_list_entry->pkt_entry->alloc_type ==
+		    (enum efa_rdm_pke_alloc_type)0xdeadbeef) {
+			EFA_WARN(FI_LOG_EP_CTRL,
+				"Skipping already-freed overflow pkt_entry: %p\n",
+				overflow_pke_list_entry->pkt_entry);
+		} else
+#endif
+		{
+			efa_rdm_pke_release_rx_list(overflow_pke_list_entry->pkt_entry);
+		}
 		ofi_buf_free(overflow_pke_list_entry);
 	}
 

--- a/prov/efa/src/rdm/efa_rdm_pke.c
+++ b/prov/efa/src/rdm/efa_rdm_pke.c
@@ -245,6 +245,19 @@ void efa_rdm_pke_release_rx_list(struct efa_rdm_pke *pkt_entry)
 {
 	struct efa_rdm_pke *curr, *next;
 
+#if ENABLE_DEBUG
+/*
+* Remove all dbg_entry from the debug list before releasing
+* any entry. Releasing poisons the pkt_entry, which corrupts
+* adjacent dbg_entry prev/next pointers in the debug list.
+*/
+	curr = pkt_entry;
+	while (curr) {
+		dlist_remove_init(&curr->dbg_entry);
+		curr = curr->next;
+	}
+#endif
+
 	curr = pkt_entry;
 	while (curr) {
 		next = curr->next;


### PR DESCRIPTION
This PR fixes two issues:

prov/efa: fix ep teardown crashes and overflow pkt chain leak

When a receiver gets more out-of-order messages than the reorder buffer can hold,
excess packets are chained in peer->overflow_pke_list. On endpoint close, only
the chain head was freed, leaking the rest. Additionally, under
ENABLE_DEBUG + ENABLE_EFA_POISONING, the debug sweep in
efa_rdm_ep_destroy_buffer_pools() crashed due to ordering issues and poisoned
pointers. Fixes include:
- Use efa_rdm_pke_release_rx_list() to free the full overflow chain
- Move peer destruct before debug sweeps
- Fix iteration over poisoned debug list entries
- Unlink outstanding TX packets before peer destruction
- Add poison-pattern checks as a workaround for dangling pointers

fabtests/multi_ep_stress: join worker threads before resource cleanup

pthread_join() was only in the success path. On error, resources were freed
while worker threads were still running. Fix moves the join loop into the
cleanup path so threads are always joined before resources are freed.
