### PR TITLE
man: clarify FI_INJECT + FI_HMEM restriction

### DIFF
--- a/man/fi_atomic.3.md
+++ b/man/fi_atomic.3.md
@@ -429,6 +429,11 @@ has not been configured with FI_SELECTIVE_COMPLETION.  See the flags
 discussion below for more details. The requested message size that
 can be used with fi_inject_atomic is limited by inject_size.
 
+If FI_HMEM is enabled and the provider requires the FI_MR_HMEM mr_mode,
+the fi_inject_atomic call can only accept buffers with iface equal to
+FI_HMEM_SYSTEM. This limitation does not affect how inject_size is
+reported.
+
 The fi_atomicmsg call supports atomic functions over both connected
 and connectionless endpoints, with the ability to control the atomic
 operation per call through the use of flags.  The fi_atomicmsg
@@ -620,6 +625,8 @@ with atomic message calls.
   'const'.  Non-constant or output buffers are unaffected by this flag
   and may be accessed by the provider at anytime until the operation has
   completed. This flag can only be used with messages smaller than inject_size.
+  If FI_HMEM is enabled and the provider requires the FI_MR_HMEM mr_mode, the
+  FI_INJECT flag can only be used with buffers whose iface is FI_HMEM_SYSTEM.
 
 *FI_FENCE*
 : Applies to transmits.  Indicates that the requested operation, also

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -1637,7 +1637,9 @@ value of transmit or receive context attributes of an endpoint.
   that buffer.  A provider can limit the total amount of send data
   that may be buffered and/or the size of a single send that can use
   this flag. This limit is indicated using inject_size (see inject_size
-  above).
+  above). If FI_HMEM is enabled and the provider requires the
+  FI_MR_HMEM mr_mode, the FI_INJECT flag can only be used with buffers
+  whose iface is FI_HMEM_SYSTEM.
 
 *FI_INJECT_COMPLETE*
 : Indicates that a completion should be generated when the

--- a/man/fi_msg.3.md
+++ b/man/fi_msg.3.md
@@ -177,10 +177,9 @@ to write CQ entries for all successful completions.  See the flags
 discussion below for more details. The requested message size that
 can be used with fi_inject is limited by inject_size.
 
-If FI_HMEM is enabled, the fi_inject call can only accept buffer with
-iface equal to FI_HMEM_SYSTEM if the provider requires the FI_MR_HMEM
-mr_mode.  This limitation applies to all the fi_\*inject\* calls and
-does not affect how inject_size is reported.
+If FI_HMEM is enabled and the provider requires the FI_MR_HMEM mr_mode,
+fi_inject can only accept buffers with iface equal to FI_HMEM_SYSTEM.
+This limitation does not affect how inject_size is reported.
 
 ## fi_senddata
 
@@ -254,7 +253,10 @@ fi_sendmsg.
   even if the operation is handled asynchronously.  This may require
   that the underlying provider implementation copy the data into a
   local buffer and transfer out of that buffer. This flag can only
-  be used with messages smaller than inject_size.
+  be used with messages smaller than inject_size. If FI_HMEM is
+  enabled and the provider requires the FI_MR_HMEM mr_mode, the
+  FI_INJECT flag can only be used with buffers whose iface is
+  FI_HMEM_SYSTEM.
 
 *FI_MULTI_RECV*
 : Applies to posted receive operations.  This flag allows the user to

--- a/man/fi_rma.3.md
+++ b/man/fi_rma.3.md
@@ -182,6 +182,11 @@ For 0-byte operations, msg_iov, desc (including FI_MR_LOCAL), and iov_count may 
 The write inject call is an optimized version of fi_write.  It provides
 similar completion semantics as fi_inject [`fi_msg`(3)](fi_msg.3.html).
 
+If FI_HMEM is enabled and the provider requires the FI_MR_HMEM mr_mode,
+the fi_inject_write call can only accept buffers with iface equal to
+FI_HMEM_SYSTEM. This limitation does not affect how inject_size is
+reported.
+
 ## fi_writedata
 
 The write data call is similar to fi_write, but allows for the sending
@@ -191,8 +196,7 @@ transfer.
 ## fi_inject_writedata
 
 The inject write data call is similar to fi_inject_write, but allows for the sending
-of remote CQ data (see FI_REMOTE_CQ_DATA flag) as part of the
-transfer.
+of remote CQ data (see FI_REMOTE_CQ_DATA flag) as part of the transfer.
 
 ## fi_read
 
@@ -248,7 +252,10 @@ fi_writemsg.
    returns, even if the operation is handled asynchronously.  This may
    require that the underlying provider implementation copy the data
    into a local buffer and transfer out of that buffer. This flag can only
-   be used with messages smaller than inject_size.
+   be used with messages smaller than inject_size. If FI_HMEM is
+   enabled and the provider requires the FI_MR_HMEM mr_mode, the
+   FI_INJECT flag can only be used with buffers whose iface is
+   FI_HMEM_SYSTEM.
 
 *FI_INJECT_COMPLETE*
 : Applies to fi_writemsg.  Indicates that a completion should be

--- a/man/fi_tagged.3.md
+++ b/man/fi_tagged.3.md
@@ -198,6 +198,11 @@ For 0-byte operations, msg_iov, desc (including FI_MR_LOCAL) and iov_count may b
 The tagged inject call is an optimized version of fi_tsend.  It provides
 similar completion semantics as fi_inject [`fi_msg`(3)](fi_msg.3.html).
 
+If FI_HMEM is enabled and the provider requires the FI_MR_HMEM mr_mode,
+the fi_tinject call can only accept buffers with iface equal to
+FI_HMEM_SYSTEM.  This limitation does not affect how inject_size is
+reported.
+
 ## fi_tsenddata
 
 The tagged send data call is similar to fi_tsend, but allows for the
@@ -267,7 +272,10 @@ and/or fi_tsendmsg.
   even if the operation is handled asynchronously.  This may require
   that the underlying provider implementation copy the data into a
   local buffer and transfer out of that buffer. This flag can only
-  be used with messages smaller than inject_size.
+  be used with messages smaller than inject_size. If FI_HMEM is
+  enabled and the provider requires the FI_MR_HMEM mr_mode, the
+  FI_INJECT flag can only be used with buffers whose iface is
+  FI_HMEM_SYSTEM.
 
 *FI_MULTI_RECV*
 : Applies to posted tagged receive operations when the FI_TAGGED_MULTI_RECV


### PR DESCRIPTION
The existing documentation only addressed fi_inject and left the behavior of the FI_INJECT flag (used with data transfer calls that take a descriptor) ambiguous with respect to FI_HMEM.

Update the fi_*inject* call descriptions and the FI_INJECT flag descriptions across the relevant man pages to state that when the provider requires the FI_MR_HMEM mr_mode, only buffers with iface FI_HMEM_SYSTEM are accepted. This keeps the fi_inject* calls and the FI_INJECT flag consistent.