### PR TITLE
[v2.4.x]prov/efa: Revert "[v2.4.x] prov/efa: Only disable zcpy_rx when p2p is not available but FI_HMEM is requested"

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -463,20 +463,17 @@ void efa_rdm_ep_set_use_zcpy_rx(struct efa_rdm_ep *ep)
 	}
 
 	/* Zero-copy receive requires P2P support. Disable it if any initialized HMEM iface does not support P2P. */
-	/* Only check HMEM P2P support if the application is actually using HMEM capabilities. */
-	if (ep->base_ep.util_ep.caps & FI_HMEM) {
-		EFA_HMEM_IFACE_FOREACH_NON_SYSTEM(iface) {
-			if (g_efa_hmem_info[iface].initialized &&
-			    (ofi_hmem_p2p_disabled() ||
-			    ep->hmem_p2p_opt == FI_HMEM_P2P_DISABLED ||
-			    !g_efa_hmem_info[iface].p2p_supported_by_device)) {
-				EFA_INFO(FI_LOG_EP_CTRL,
-				         "%s does not support P2P, zero-copy receive "
-				         "protocol will be disabled\n",
-				         fi_tostr(&iface, FI_TYPE_HMEM_IFACE));
-				ep->use_zcpy_rx = false;
-				goto out;
-			}
+	EFA_HMEM_IFACE_FOREACH_NON_SYSTEM(iface) {
+		if (g_efa_hmem_info[iface].initialized &&
+		    (ofi_hmem_p2p_disabled() ||
+		    ep->hmem_p2p_opt == FI_HMEM_P2P_DISABLED ||
+		    !g_efa_hmem_info[iface].p2p_supported_by_device)) {
+			EFA_INFO(FI_LOG_EP_CTRL,
+			         "%s does not support P2P, zero-copy receive "
+			         "protocol will be disabled\n",
+			         fi_tostr(&iface, FI_TYPE_HMEM_IFACE));
+			ep->use_zcpy_rx = false;
+			goto out;
 		}
 	}
 

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -1166,8 +1166,7 @@ void test_efa_rdm_ep_user_zcpy_rx_disabled(struct efa_resource **state)
 }
 
 /**
- * @brief Verify zcpy_rx is enabled for host-only workloads even when
- *        HMEM P2P is globally disabled, since host memory doesn't use P2P
+ * @brief Verify zcpy_rx is disabled if CUDA P2P is explictly disabled
  */
 void test_efa_rdm_ep_user_disable_p2p_zcpy_rx_disabled(struct efa_resource **state)
 {
@@ -1179,8 +1178,7 @@ void test_efa_rdm_ep_user_disable_p2p_zcpy_rx_disabled(struct efa_resource **sta
 	resource->hints->mode = FI_MSG_PREFIX;
 	resource->hints->caps = FI_MSG;
 
-	/* Global HMEM P2P disable doesn't affect host-only workloads */
-	test_efa_rdm_ep_use_zcpy_rx_impl(resource, true, false, true);
+	test_efa_rdm_ep_use_zcpy_rx_impl(resource, true, false, false);
 }
 
 /**
@@ -1202,8 +1200,7 @@ void test_efa_rdm_ep_user_zcpy_rx_unhappy_due_to_sas(struct efa_resource **state
 }
 
 /**
- * @brief Verify zcpy_rx is enabled even if CUDA P2P is not supported,
- *        as long as FI_HMEM is not requested (host-only workload)
+ * @brief Verify zcpy_rx is disabled if CUDA P2P is enabled but not supported
  */
 void test_efa_rdm_ep_user_p2p_not_supported_zcpy_rx_happy(struct efa_resource **state)
 {
@@ -1215,9 +1212,7 @@ void test_efa_rdm_ep_user_p2p_not_supported_zcpy_rx_happy(struct efa_resource **
 	resource->hints->mode = FI_MSG_PREFIX;
 	resource->hints->caps = FI_MSG;
 
-	/* With the fix, zcpy_rx should be enabled for host-only workloads
-	 * even when CUDA P2P is not supported */
-	test_efa_rdm_ep_use_zcpy_rx_impl(resource, false, false, true);
+	test_efa_rdm_ep_use_zcpy_rx_impl(resource, false, false, false);
 }
 
 /**


### PR DESCRIPTION
This breaks backwards compatability with v2.0.0 on instances without p2p support.

This reverts commit 039db7b2ae12e99d10ba6b9e5f0ff5bcff08431f.