### PR TITLE
src/common: Do not assert on truncated buffers

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -1458,7 +1458,13 @@ int ofi_bsock_async_done(const struct fi_provider *prov,
 		return -errno;
 	}
 
-	assert(!(msg.msg_flags & MSG_CTRUNC));
+	if (msg.msg_flags & (MSG_TRUNC | MSG_CTRUNC)) {
+		FI_WARN(prov, FI_LOG_EP_DATA,
+			"Truncated message on MSG_ERRQUEUE (flags: 0x%x, ctrl len: %zu, received len: %zu)\n",
+			msg.msg_flags, sizeof(ctrl), msg.msg_controllen);
+		return -FI_EINVAL;
+	}
+
 	cmsg = CMSG_FIRSTHDR(&msg);
 	if ((cmsg->cmsg_level != SOL_IP && cmsg->cmsg_type != IP_RECVERR) &&
 	    (cmsg->cmsg_level != SOL_IPV6 && cmsg->cmsg_type != IPV6_RECVERR)) {


### PR DESCRIPTION
This patch replaces an assertion with proper error handling when a truncated control buffer is detected, returning an error to the caller instead of crashing the process.

We observed crashes in debug builds of libfabric in the zero-copy code path when async send operations complete. The crash occurs when the kernel reports a truncated control message, triggering an assertion.

According to the recvmsg(2) man page, msg_controllen should be updated on return to reflect the length of the received control data. However, GDB shows that the buffer is allocated with 48 bytes and msg_controllen remains unchanged after recvmsg() returns, suggesting that truncation should not have occurred.

The root cause is currently unknown, and there is no clear evidence that increasing the control buffer size would resolve the issue. The zero-copy implementation matches existing implementations (e.g. QEMU, SPDK, and Linux kernel unit tests).

Until the underlying issue is better understood, avoid asserting on truncated buffers and handle the condition gracefully by returning an error to the caller. This results in the endpoint being closed and the error reported back to the application.