### PR TITLE
fabtests/pytest: use fi_efa_runt_read_no_handshake in protocol selection test

### DIFF
--- a/fabtests/pytest/efa/test_efa_protocol_selection.py
+++ b/fabtests/pytest/efa/test_efa_protocol_selection.py
@@ -8,7 +8,7 @@ from efa.efa_common import has_gdrcopy, has_rdma
 @pytest.mark.serial
 @pytest.mark.functional
 @pytest.mark.cuda_memory
-@pytest.mark.parametrize("fabtest_name,cntrl_env_var", [("fi_rdm_tagged_bw", "FI_EFA_INTER_MIN_READ_MESSAGE_SIZE"), ("fi_rma_bw", "FI_EFA_INTER_MIN_READ_WRITE_SIZE")])
+@pytest.mark.parametrize("fabtest_name,cntrl_env_var", [("fi_efa_runt_read_no_handshake", "FI_EFA_INTER_MIN_READ_MESSAGE_SIZE"), ("fi_rma_bw", "FI_EFA_INTER_MIN_READ_WRITE_SIZE")])
 def test_transfer_with_read_protocol_cuda(cmdline_args, fabtest_name, cntrl_env_var):
     """
     Verify that the read protocol is used for a 1024 byte message when the env variable


### PR DESCRIPTION
Commit 27913414 changed protocol selection so that the old env var combination (FI_EFA_USE_DEVICE_RDMA=1, FI_EFA_INTER_MIN_READ_MESSAGE_SIZE, FI_EFA_RUNT_SIZE=0) no longer forces the RDMA read path when using fi_rdm_tagged_bw, because ft_sync no longer enforces a handshake for DC.

Replace fi_rdm_tagged_bw with fi_efa_runt_read_no_handshake (introduced by ee26b4a1) which sets FI_OPT_EFA_HOMOGENEOUS_PEERS to skip the handshake and directly use the read-based protocol.

Fixes: test_transfer_with_read_protocol_cuda[fi_rdm_tagged_bw-FI_EFA_INTER_MIN_READ_MESSAGE_SIZE]