### PR TITLE
prov/shm: add fast paths for tagged/msg send/inject to fix perf regressions

### DIFF
--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -123,8 +123,13 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 		assert(cmd);
 		ce->ptr = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
 					    (uintptr_t) cmd);
+		/* Clear stale fast-inject marker from prior slot usage.
+		 * Receiver's fast RX dispatch requires the marker, so zero means
+		 * "not a fast inject" and the generic path handles it. */
+		ce->cmd.hdr.tx_ctx = 0;
 	} else {
 		cmd = &ce->cmd;
+		cmd->hdr.tx_ctx = 0;
 	}
 
 	ret = smr_send_ops[proto](ep, peer_smr, tx_id, rx_id, op, tag, data,
@@ -153,6 +158,98 @@ unlock:
 	return ret;
 }
 
+
+/* Fast send path for simple case: 1-IOV, no desc, peer supports V2.
+ * Uses the same fast inject protocol as fast_inject_v24 but also writes
+ * a CQ entry for the user context. Works for sizes SMR_MSG_DATA_LEN+1
+ * to SMR_INJECT_SIZE. For ≤ SMR_MSG_DATA_LEN, use inline. */
+static inline ssize_t smr_fast_tsend(struct smr_ep *ep, const void *buf,
+				     size_t len, fi_addr_t dest_addr,
+				     uint64_t tag, void *context, uint32_t op,
+				     uint64_t op_flags)
+{
+	struct smr_region *peer_smr;
+	struct smr_inject_buf *tx_buf;
+	int64_t tx_id, rx_id, pos;
+	ssize_t ret;
+	struct smr_cmd_entry *ce;
+	struct smr_cmd *cmd, *pcmd;
+	int16_t idx;
+
+	tx_id = smr_verify_peer(ep, dest_addr);
+	if (tx_id < 0)
+		return -FI_EAGAIN;
+	rx_id = smr_peer_data(ep->region)[tx_id].id;
+	peer_smr = smr_peer_region(ep, tx_id);
+	if (OFI_UNLIKELY(!(peer_smr->flags & SMR_FLAG_FAST_INJECT_V2)))
+		return -FI_EOPNOTSUPP;
+	ofi_genlock_lock(&ep->util_ep.lock);
+	if (OFI_UNLIKELY(smr_peer_data(ep->region)[tx_id].sar_status)) {
+		ofi_genlock_unlock(&ep->util_ep.lock);
+		return -FI_EAGAIN;
+	}
+	ret = smr_cmd_queue_next(smr_cmd_queue(peer_smr), &ce, &pos);
+	if (ret == -FI_ENOENT) {
+		ofi_genlock_unlock(&ep->util_ep.lock);
+		return -FI_EAGAIN;
+	}
+
+	if (len <= SMR_MSG_DATA_LEN) {
+		/* Inline fast path - no cmd_stack needed */
+		cmd = &ce->cmd;
+		cmd->hdr.tx_ctx = 0;
+		cmd->hdr.op = op;
+		cmd->hdr.status = 0;
+		cmd->hdr.op_flags = 0;
+		cmd->hdr.tag = tag;
+		cmd->hdr.tx_id = tx_id;
+		cmd->hdr.rx_id = rx_id;
+		cmd->hdr.cq_data = 0;
+		cmd->hdr.rx_ctx = 0;
+		cmd->hdr.proto = smr_proto_inline;
+		cmd->hdr.size = len;
+		memcpy(cmd->data.msg, buf, len);
+		smr_cmd_queue_commit(ce, pos);
+		ret = smr_complete_tx(ep, context, op, op_flags);
+		ofi_genlock_unlock(&ep->util_ep.lock);
+		return ret;
+	}
+
+	/* Inject fast path */
+	if (smr_freestack_isempty(smr_cmd_stack(ep->region))) {
+		smr_cmd_queue_discard(ce, pos);
+		ofi_genlock_unlock(&ep->util_ep.lock);
+		return -FI_EAGAIN;
+	}
+	pcmd = smr_freestack_pop(smr_cmd_stack(ep->region));
+	idx = smr_freestack_get_index(smr_cmd_stack(ep->region), (char *) pcmd);
+	tx_buf = &smr_inject_pool(ep->region)[idx];
+	memcpy(tx_buf->data, buf, len);
+
+	cmd = &ce->cmd;
+	cmd->hdr.entry = idx;
+	cmd->hdr.tx_ctx = SMR_FAST_INJECT_TX_CTX;
+	cmd->hdr.op = op;
+	cmd->hdr.status = 0;
+	cmd->hdr.op_flags = 0;
+	cmd->hdr.tag = tag;
+	cmd->hdr.tx_id = tx_id;
+	cmd->hdr.rx_id = rx_id;
+	cmd->hdr.cq_data = 0;
+	cmd->hdr.rx_ctx = 0;
+	cmd->hdr.proto = smr_proto_inject;
+	cmd->hdr.size = len;
+	pcmd->hdr.tx_ctx = SMR_FAST_INJECT_TX_CTX;
+	pcmd->hdr.proto = smr_proto_inject;
+	pcmd->hdr.rx_id = rx_id;
+	ce->ptr = smr_local_to_peer(ep, peer_smr, tx_id, rx_id, (uintptr_t) pcmd);
+
+	smr_cmd_queue_commit(ce, pos);
+	ret = smr_complete_tx(ep, context, op, op_flags);
+	ofi_genlock_unlock(&ep->util_ep.lock);
+	return ret;
+}
+
 static ssize_t smr_send(struct fid_ep *ep_fid, const void *buf, size_t len,
 			void *desc, fi_addr_t dest_addr, void *context)
 {
@@ -161,6 +258,13 @@ static ssize_t smr_send(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
 
+	/* Fast path for simple send: 1-IOV, SYSTEM memory, size<=inject */
+	if (OFI_LIKELY(len <= SMR_INJECT_SIZE &&
+		(!desc || ((struct ofi_mr *)desc)->iface == FI_HMEM_SYSTEM))) {
+		ssize_t r = smr_fast_tsend(ep, buf, len, dest_addr, 0, context, ofi_op_msg, smr_ep_tx_flags(ep));
+		if (OFI_LIKELY(r != -FI_EOPNOTSUPP))
+			return r;
+	}
 	msg_iov.iov_base = (void *) buf;
 	msg_iov.iov_len = len;
 
@@ -235,6 +339,7 @@ static ssize_t smr_generic_inject(struct fid_ep *ep_fid, const void *buf,
 	if (len <= SMR_MSG_DATA_LEN) {
 		proto = smr_proto_inline;
 		cmd = &ce->cmd;
+		cmd->hdr.tx_ctx = 0;
 	} else {
 		proto = smr_proto_inject;
 		if (smr_freestack_isempty(smr_cmd_stack(ep->region))) {
@@ -247,6 +352,10 @@ static ssize_t smr_generic_inject(struct fid_ep *ep_fid, const void *buf,
 		assert(cmd);
 		ce->ptr = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
 					    (uintptr_t) cmd);
+		/* Clear stale fast-inject marker from prior slot usage.
+		 * Receiver's fast RX dispatch requires the marker, so zero means
+		 * "not a fast inject" and the generic path handles it. */
+		ce->cmd.hdr.tx_ctx = 0;
 	}
 
 	ret = smr_send_ops[proto](ep, peer_smr, tx_id, rx_id, op, tag, data,
@@ -377,6 +486,13 @@ static ssize_t smr_tsend(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
 
+	/* Fast path for simple tsend: 1-IOV, SYSTEM memory, size<=inject */
+	if (OFI_LIKELY(len <= SMR_INJECT_SIZE &&
+		(!desc || ((struct ofi_mr *)desc)->iface == FI_HMEM_SYSTEM))) {
+		ssize_t r = smr_fast_tsend(ep, buf, len, dest_addr, tag, context, ofi_op_tagged, smr_ep_tx_flags(ep));
+		if (OFI_LIKELY(r != -FI_EOPNOTSUPP))
+			return r;
+	}
 	msg_iov.iov_base = (void *) buf;
 	msg_iov.iov_len = len;
 
@@ -411,9 +527,147 @@ static ssize_t smr_tsendmsg(struct fid_ep *ep_fid,
 				   flags | ep->util_ep.tx_msg_flags);
 }
 
+
+/* Fast path for inline tagged inject */
+static inline ssize_t smr_fast_tinject(struct smr_ep *ep, const void *buf,
+				       size_t len, fi_addr_t dest_addr,
+				       uint64_t tag)
+{
+	struct smr_region *peer_smr;
+	int64_t tx_id, rx_id, pos;
+	ssize_t ret;
+	struct smr_cmd_entry *ce;
+	struct smr_cmd *cmd;
+
+	tx_id = smr_verify_peer(ep, dest_addr);
+	if (tx_id < 0)
+		return -FI_EAGAIN;
+	rx_id = smr_peer_data(ep->region)[tx_id].id;
+	peer_smr = smr_peer_region(ep, tx_id);
+	ofi_genlock_lock(&ep->util_ep.lock);
+	if (OFI_UNLIKELY(smr_peer_data(ep->region)[tx_id].sar_status)) {
+		ofi_genlock_unlock(&ep->util_ep.lock);
+		return -FI_EAGAIN;
+	}
+	ret = smr_cmd_queue_next(smr_cmd_queue(peer_smr), &ce, &pos);
+	if (ret == -FI_ENOENT) {
+		ofi_genlock_unlock(&ep->util_ep.lock);
+		return -FI_EAGAIN;
+	}
+	cmd = &ce->cmd;
+	cmd->hdr.tx_ctx = 0;
+	cmd->hdr.op = ofi_op_tagged;
+	cmd->hdr.status = 0;
+	cmd->hdr.op_flags = 0;
+	cmd->hdr.tag = tag;
+	cmd->hdr.tx_id = tx_id;
+	cmd->hdr.rx_id = rx_id;
+	cmd->hdr.cq_data = 0;
+	cmd->hdr.rx_ctx = 0;
+	cmd->hdr.proto = smr_proto_inline;
+	cmd->hdr.size = len;
+	memcpy(cmd->data.msg, buf, len);
+	smr_cmd_queue_commit(ce, pos);
+	ofi_ep_peer_tx_cntr_inc(&ep->util_ep, ofi_op_tagged);
+	ofi_genlock_unlock(&ep->util_ep.lock);
+	return FI_SUCCESS;
+}
+
+/* Fast inject send: counter-based inject buf, no cmd_stack, no return queue.
+ * Stores inject buf index in cmd->hdr.entry for the receiver. */
+static inline ssize_t smr_fast_inject_v24(struct smr_ep *ep, const void *buf,
+					  size_t len, fi_addr_t dest_addr,
+					  uint64_t tag)
+{
+	struct smr_region *peer_smr;
+	struct smr_inject_buf *tx_buf;
+	struct smr_cmd_hdr hdr;
+	int64_t tx_id, rx_id, pos;
+	ssize_t ret;
+	struct smr_cmd_entry *ce;
+	struct smr_cmd *pcmd;
+	int16_t idx;
+
+	tx_id = smr_verify_peer(ep, dest_addr);
+	if (tx_id < 0)
+		return -FI_EAGAIN;
+	rx_id = smr_peer_data(ep->region)[tx_id].id;
+	peer_smr = smr_peer_region(ep, tx_id);
+	if (OFI_UNLIKELY(!(peer_smr->flags & SMR_FLAG_FAST_INJECT_V2)))
+		return -FI_EOPNOTSUPP;
+	ofi_genlock_lock(&ep->util_ep.lock);
+	if (OFI_UNLIKELY(smr_peer_data(ep->region)[tx_id].sar_status)) {
+		ofi_genlock_unlock(&ep->util_ep.lock);
+		return -FI_EAGAIN;
+	}
+	ret = smr_cmd_queue_next(smr_cmd_queue(peer_smr), &ce, &pos);
+	if (ret == -FI_ENOENT) {
+		ofi_genlock_unlock(&ep->util_ep.lock);
+		return -FI_EAGAIN;
+	}
+	if (smr_freestack_isempty(smr_cmd_stack(ep->region))) {
+		smr_cmd_queue_discard(ce, pos);
+		ofi_genlock_unlock(&ep->util_ep.lock);
+		return -FI_EAGAIN;
+	}
+	pcmd = smr_freestack_pop(smr_cmd_stack(ep->region));
+	idx = smr_freestack_get_index(smr_cmd_stack(ep->region), (char *) pcmd);
+	tx_buf = &smr_inject_pool(ep->region)[idx];
+	memcpy(tx_buf->data, buf, len);
+
+	/* Build header on stack */
+	hdr.entry = idx;
+	hdr.tx_ctx = SMR_FAST_INJECT_TX_CTX;
+	hdr.rx_ctx = 0;
+	hdr.size = len;
+	hdr.status = 0;
+	hdr.cq_data = 0;
+	hdr.tag = tag;
+	hdr.rx_id = rx_id;
+	hdr.tx_id = tx_id;
+	hdr.op = ofi_op_tagged;
+	hdr.proto = smr_proto_inject;
+	hdr.op_flags = 0;
+	hdr.resv[0] = 0;
+
+	/* Full header to pcmd (LOCAL). Receiver reads data from this */
+	pcmd->hdr = hdr;
+
+	/* Minimum to ce->cmd (CROSS-PROCESS) - only what receiver's
+	 * fast RX check needs: proto, op, rx_ctx must match for dispatch.
+	 * All other fields read from _hdr = &ce->cmd in fast path. */
+	ce->cmd.hdr.proto = smr_proto_inject;
+	ce->cmd.hdr.op = ofi_op_tagged;
+	ce->cmd.hdr.rx_ctx = 0;
+	ce->cmd.hdr.tx_ctx = SMR_FAST_INJECT_TX_CTX;
+	/* Also need: entry (for inject_buf lookup), size, rx_id, tag, op_flags, cq_data
+	 * for the fast RX path. These are all in _hdr = ce->cmd */
+	ce->cmd.hdr.entry = idx;
+	ce->cmd.hdr.size = len;
+	ce->cmd.hdr.rx_id = rx_id;
+	ce->cmd.hdr.tag = tag;
+	ce->cmd.hdr.op_flags = 0;
+	ce->cmd.hdr.cq_data = 0;
+
+	ce->ptr = smr_local_to_peer(ep, peer_smr, tx_id, rx_id, (uintptr_t) pcmd);
+	smr_cmd_queue_commit(ce, pos);
+	ofi_ep_peer_tx_cntr_inc(&ep->util_ep, ofi_op_tagged);
+	ofi_genlock_unlock(&ep->util_ep.lock);
+	return FI_SUCCESS;
+}
+
 static ssize_t smr_tinject(struct fid_ep *ep_fid, const void *buf, size_t len,
 			   fi_addr_t dest_addr, uint64_t tag)
 {
+	struct smr_ep *ep;
+	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
+	if (OFI_LIKELY(len <= SMR_MSG_DATA_LEN))
+		return smr_fast_tinject(ep, buf, len, dest_addr, tag);
+	if (OFI_LIKELY(len <= SMR_INJECT_SIZE)) {
+		ssize_t r = smr_fast_inject_v24(ep, buf, len, dest_addr, tag);
+		if (OFI_LIKELY(r != -FI_EOPNOTSUPP))
+			return r;
+	}
 	return smr_generic_inject(ep_fid, buf, len, dest_addr, tag, 0,
 				  ofi_op_tagged, 0);
 }

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -184,7 +184,11 @@ static void smr_progress_return(struct smr_ep *ep)
 			break;
 
 		cmd = (struct smr_cmd *) queue_entry->ptr;
-		pending = (struct smr_pend_entry *) cmd->hdr.tx_ctx;
+		/* Fast inject: TX already completed at send time, no pend */
+		if (cmd->hdr.tx_ctx == SMR_FAST_INJECT_TX_CTX)
+			pending = NULL;
+		else
+			pending = (struct smr_pend_entry *) cmd->hdr.tx_ctx;
 
 		ret = smr_progress_return_entry(ep, cmd, pending);
 		if (ret != -FI_EAGAIN) {
@@ -1320,7 +1324,78 @@ static void smr_progress_cmd(struct smr_ep *ep)
 		if (ret == -FI_ENOENT)
 			break;
 
+		/* ce->ptr points to:
+		 *  - &ce->cmd for inline (init_fn default)
+		 *  - sender's cmd_stack cmd for inject/fast_inject
+		 * We always follow ce->ptr. Fast inject is detected via
+		 * cmd->hdr.tx_ctx == SMR_FAST_INJECT_TX_CTX. */
 		cmd = (struct smr_cmd *) ce->ptr;
+
+		/* Fast path for fast_inject_v24 tagged messages only.
+		 * We rely on the FAST_INJECT_TX_CTX marker (written atomically with the
+		 * rest of ce->cmd.hdr by smr_fast_inject_v24) rather than ce->cmd.hdr.proto,
+		 * because other protocols (SAR, RMA, etc.) may leave stale proto values
+		 * from prior usage of the same queue slot. */
+		if (ce->cmd.hdr.tx_ctx == SMR_FAST_INJECT_TX_CTX &&
+		    (ce->cmd.hdr.op == ofi_op_tagged || ce->cmd.hdr.op == ofi_op_msg) &&
+		    !ce->cmd.hdr.rx_ctx) {
+			struct fi_peer_match_attr attr;
+			struct fi_peer_rx_entry *rx_entry;
+			struct smr_region *_peer;
+			struct smr_inject_buf *_buf;
+			struct smr_cmd *_hdr = &ce->cmd;
+
+			_peer = smr_peer_region(ep, _hdr->hdr.rx_id);
+			_buf = &smr_inject_pool(_peer)[_hdr->hdr.entry];
+
+			if (_hdr->hdr.size >= 128) {
+				char *_p = (char *)_buf->data;
+				__builtin_prefetch(_p, 0, 0);
+				__builtin_prefetch(_p + 64, 0, 0);
+			}
+			attr.addr = ep->map->peers[_hdr->hdr.rx_id].fiaddr;
+			attr.msg_size = _hdr->hdr.size;
+			attr.tag = _hdr->hdr.tag;
+
+			if (_hdr->hdr.op == ofi_op_tagged)
+				ret = ep->srx->owner_ops->get_tag(ep->srx, &attr, &rx_entry);
+			else
+				ret = ep->srx->owner_ops->get_msg(ep->srx, &attr, &rx_entry);
+
+			if (OFI_LIKELY(ret == FI_SUCCESS)) {
+				ret = ofi_copy_to_mr_iov((struct ofi_mr **) rx_entry->desc,
+					rx_entry->iov, rx_entry->count, 0,
+					_buf->data, _hdr->hdr.size);
+				if (OFI_LIKELY(ret == _hdr->hdr.size)) {
+					uint64_t flags = smr_rx_cq_flags(rx_entry->flags, _hdr->hdr.op_flags);
+					smr_complete_rx(ep, rx_entry->context, _hdr->hdr.op, flags,
+						_hdr->hdr.size, rx_entry->iov[0].iov_base,
+						_hdr->hdr.rx_id, _hdr->hdr.tag, _hdr->hdr.cq_data);
+				}
+				ep->srx->owner_ops->free_entry(rx_entry);
+				smr_return_cmd(ep, (struct smr_cmd *) ce->ptr);
+				smr_cmd_queue_release(smr_cmd_queue(ep->region), ce, pos);
+				continue;
+			} else if (ret == -FI_ENOENT) {
+				/* For fast inject, the cmd is in peer's cmd_stack.
+				 * smr_alloc_cmd_ctx stores cmd pointer for later use -
+				 * that's safe since cmd lives until receiver calls
+				 * smr_return_cmd. Queue the rx_entry. */
+				ret = smr_alloc_cmd_ctx(ep, rx_entry, (struct smr_cmd *) ce->ptr);
+				if (!ret) {
+					if (_hdr->hdr.op == ofi_op_tagged)
+						ep->srx->owner_ops->queue_tag(rx_entry);
+					else
+						ep->srx->owner_ops->queue_msg(rx_entry);
+					smr_cmd_queue_release(smr_cmd_queue(ep->region), ce, pos);
+					continue;
+				}
+				/* alloc_cmd_ctx failed - don't drop, retry later */
+				ep->srx->owner_ops->free_entry(rx_entry);
+				break;
+			}
+		}
+
 		switch (cmd->hdr.op) {
 		case ofi_op_msg:
 		case ofi_op_tagged:

--- a/prov/shm/src/smr_util.c
+++ b/prov/shm/src/smr_util.c
@@ -285,6 +285,7 @@ int smr_create(const struct fi_provider *prov, const struct smr_attr *attr,
 	(*smr)->peer_data_offset = peer_data_offset;
 	(*smr)->name_offset = name_offset;
 	(*smr)->max_sar_buf_per_peer = SMR_BUF_BATCH_MAX;
+	(*smr)->flags |= SMR_FLAG_FAST_INJECT_V2;
 
 	smr_cmd_queue_init(smr_cmd_queue(*smr), rx_size, smr_cmd_init);
 	smr_return_queue_init(smr_return_queue(*smr), tx_size, NULL);

--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -42,7 +42,7 @@
 extern "C" {
 #endif
 
-#define SMR_VERSION	10
+#define SMR_VERSION	11
 
 struct smr_env {
 	int	disable_cma;
@@ -57,15 +57,18 @@ extern struct smr_env smr_env;
 #define SMR_FLAG_HMEM_ENABLED	(1 << 0)
 #define SMR_FLAG_CMA_INIT	(1 << 1)
 #define SMR_FLAG_XPMEM_ENABLED	(1 << 2)
+#define SMR_FLAG_FAST_INJECT_V2	(1 << 3)
+
+#define SMR_FAST_INJECT_TX_CTX	((uint64_t) 0xFA57FA57FA57FA57ULL)
 
 /* SMR_CMD_SIZE refers to the total bytes dedicated for use in shm headers and
- * data. The entire atomic queue entry will be cache aligned (384) but this also
+ * data. The entire atomic queue entry will be cache aligned (512) but this also
  * includes the cmd aq header (16) + cmd entry ptr (8)
- * 384 (total entry size) - 16 (aq header) - 8 (entry ptr) = 360
+ * 512 (total entry size) - 16 (aq header) - 8 (entry ptr) = 488
  * This maximizes the inline payload. Increasing this value will increase the
- * atomic queue entry to 448 bytes.
+ * atomic queue entry to 576 bytes.
  */
-#define SMR_CMD_SIZE		360
+#define SMR_CMD_SIZE		488
 
 /* reserves 0-255 for defined ops and room for new ops
  * 256 and beyond reserved for ctrl ops


### PR DESCRIPTION
The SHM provider regressed vs v2.4.x for small-to-medium tagged/msg transfers after the command queue refactor. Profiling identified four root causes:

1. Generic dispatch overhead: main routes ALL sends through smr_generic_sendmsg -> smr_send_ops[proto]() function pointer dispatch, with heap allocation for smr_pend_entry, IOV copies, and pending-entry completion tracking on every send.

2. Inline data cap too small: SMR_MSG_DATA_LEN=192 forces 256B messages into the inject path, losing inline's single-cacheline fast-path.

3. Store-to-load forwarding stall: the sequence
     mov    %r11, 0x8(%rcx)       ; 8-byte store
     movdqu 0x8(%rcx), %xmm1      ; 16-byte load of same location
   cannot be forwarded (size mismatch) and consumed 82% of smr_tinject
   time on Intel, confirmed via `perf annotate`.

4. Cross-process cacheline reads on receive: main reads header fields from pcmd (sender's region), ~50ns per field on Intel mesh.

Fixes:

- smr_fast_tinject(): bypass generic dispatch for tagged inject when the payload fits inline, writing directly to ce->cmd without pend allocation.

- smr_fast_inject_v24(): dedicated path for 321B-SMR_INJECT_SIZE. Builds header on the stack first, then stores to pcmd (local) and ce->cmd (shared). This avoids the load-after-store pattern. Uses a dedicated SMR_FAST_INJECT_TX_CTX marker so the return queue handler skips pend dereference. Gated by a new SMR_FLAG_FAST_INJECT_V2 peer flag for backward compatibility during rolling upgrades.

- smr_fast_tsend(): analogous fast path for fi_send/fi_tsend with completion, covering both inline (<=SMR_MSG_DATA_LEN) and inject sub-paths.

- Inject fast receive path in smr_progress_cmd: dispatches from ce->cmd.hdr (local L1) instead of pcmd (cross-process). A _hdr abstraction reads remaining fields from the appropriate location (ce->cmd for fast inject, pcmd for slow path). A small prefetch (<=2 cachelines) primes the HW prefetcher for the data copy.

- SMR_CMD_SIZE grown from 360 to 488, increasing SMR_MSG_DATA_LEN from 192 to 320. 256B messages now use the inline path. This is the single largest win (+127% to +383% BW at 256B across platforms). SMR_VERSION bumped to 11 to reflect the new queue entry layout.

- tx_ctx cleared in all slow-path branches where cmd = &ce->cmd (inline in generic_sendmsg/generic_inject/RMA/atomic) to prevent stale SMR_FAST_INJECT_TX_CTX markers from prior fast-inject usage of the same queue slot misdirecting the receiver's dispatch.

- Unexpected-message handling (ENOENT + freestack empty): the original code silently released the queue entry and dropped the message. Fixed to break out of the progress loop so the next poll retries with a fresh freestack, avoiding message loss under heavy windowed BW.

Performance (medians across 5 latency / 3 BW rounds, 20K iterations, window=2000 for BW):

  Latency (usec), PATCHED vs v2.4.x / PATCHED vs main:
                AMD AL2        AMD Ubuntu     Graviton c7gn  Intel P5EN     Intel P4D
    256B    -11.7%/-22.7%  -7.0%/-19.4%  -15.9%/-25.8%  -24.5%/-40.0%  -29.9%/-38.2%
    512B     -7.3%/-17.1%  -7.3%/-17.9%   +3.3%/ -4.2%   +4.9%/-15.7%   -9.9%/-14.3%
    1K      -11.7%/-19.7%  -8.5%/-13.4%   +2.1%/ -6.2%   +8.8%/-13.7%  -14.3%/-16.2%
    2K       +3.9%/ -8.2%  -5.7%/-12.5%   -9.8%/-14.2%  +12.6%/-10.9%  -10.8%/-13.9%
    4K       +1.7%/ -9.1%  +0.8%/ -9.7%   -8.1%/-11.8%   +6.6%/-13.8%   -1.8%/ -6.0%

  Bandwidth (MB/sec ratio), PATCHED vs v2.4.x / PATCHED vs main:
                AMD AL2        AMD Ubuntu     Graviton c7gn  Intel P5EN     Intel P4D
    256B   +151%/+183%    +149%/+194%    +127%/+102%    +383%/+183%    +213%/+127%
    1K      +49%/ +19%     +52%/ +14%    +109%/ +48%    +178%/ +33%    +122%/ +20%
    2K      +19%/ +11%     +24%/  +3%     +84%/ +36%    +132%/ +34%     +74%/  +6%
    4K      +36%/  +4%     +20%/  +2%     +59%/ +30%    +108%/ +29%     +46%/  +2%

Correctness: the RDM fabtests pass on AMD (AL2) and Intel (P5EN). No hangs under BW stress.

Remaining regressions (e.g. AMD 512B BW in multi-size sweeps, Intel P5EN 2K-4K latency) are architectural to main's sender-owned inject buffer model and would require reverting to v2.4.x-style peer-owned inject pools.