### PR TITLE
fabtests/efa/multi_ep_stress: Use CLOCK_REALTIME for timed mutex

### DIFF
--- a/fabtests/prov/efa/src/multi_ep_stress.c
+++ b/fabtests/prov/efa/src/multi_ep_stress.c
@@ -424,7 +424,7 @@ static int wait_for_comp(struct fid_cq *cq, int num_completions)
 	int completed = 0;
 	struct timespec a, b;
 
-	clock_gettime(CLOCK_MONOTONIC, &a);
+	clock_gettime(CLOCK_REALTIME, &a);
 	if (topts.shared_cq) {
 		memcpy(&b, &a, sizeof(b));
 		b.tv_sec += timeout;


### PR DESCRIPTION
pthread_mutex_timedlock must be used with CLOCK_REALTIME according to man page: https://pubs.opengroup.org/onlinepubs/009695199/functions/pthread_mutex_timedlock.html