### PR TITLE
prov/util, efa/test: Fix the unspec queue scanning

### DIFF
--- a/prov/efa/test/efa_unit_test_srx.c
+++ b/prov/efa/test/efa_unit_test_srx.c
@@ -145,3 +145,163 @@ void test_efa_srx_unexp_pkt(struct efa_resource **state)
 	/* Destroy the fake peer constructed above */
 	efa_rdm_peer_destruct(&peer, efa_rdm_ep);
 }
+
+/**
+ * @brief Test that util_foreach_unspec only processes entries belonging to the
+ * calling provider's fid_peer_srx, and skips entries from other providers.
+ *
+ * Both owner and peer providers queue messages from unknown peers into the same
+ * unspec queue, with peer_entry.srx assigned to its own fid_peer_srx. During
+ * fi_av_insert that calls util_foreach_unspec to scan this queue, each provider
+ * should only process entries from its own provider and ignore entries from the
+ * other one.
+ */
+static fi_addr_t test_foreach_unspec_get_addr(struct fi_peer_rx_entry *entry)
+{
+	/* Return a valid address so the entry gets moved out of unspec queue */
+	return 0;
+}
+
+static int test_foreach_unspec_discard_no_op(struct fi_peer_rx_entry *entry)
+{
+	return FI_SUCCESS;
+}
+
+void test_efa_srx_foreach_unspec_skips_other_provider(struct efa_resource **state)
+{
+	struct efa_resource *resource = *state;
+	struct efa_rdm_ep *efa_rdm_ep;
+	struct util_srx_ctx *srx_ctx;
+	struct util_rx_entry *msg_entry_efa, *msg_entry_shm;
+	struct util_rx_entry *tag_entry_efa, *tag_entry_shm;
+	struct fid_peer_srx *efa_srx;
+	struct fid_peer_srx *shm_srx;
+	struct fi_ops_srx_peer *efa_peer_ops;
+	struct fi_ops_srx_peer *shm_peer_ops;
+	int (*saved_efa_discard_msg)(struct fi_peer_rx_entry *);
+	int (*saved_efa_discard_tag)(struct fi_peer_rx_entry *);
+	int (*saved_shm_discard_msg)(struct fi_peer_rx_entry *);
+	int (*saved_shm_discard_tag)(struct fi_peer_rx_entry *);
+	struct util_rx_entry *remaining_msg;
+	struct util_rx_entry *remaining_tag;
+
+	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_FABRIC_NAME);
+
+	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep,
+				  base_ep.util_ep.ep_fid);
+	srx_ctx = efa_rdm_ep_get_peer_srx_ctx(efa_rdm_ep);
+	efa_srx = &srx_ctx->peer_srx;
+	shm_srx = efa_rdm_ep->shm_peer_srx;
+
+	/* Enable directed receive so foreach_unspec will move resolved entries */
+	srx_ctx->dir_recv = true;
+
+	ofi_genlock_lock(srx_ctx->lock);
+
+	/* Allocate entries for the unspec msg queue */
+	msg_entry_efa = (struct util_rx_entry *) ofi_buf_alloc(srx_ctx->rx_pool);
+	assert_non_null(msg_entry_efa);
+	msg_entry_efa->peer_entry.srx = efa_srx;
+	msg_entry_efa->peer_entry.addr = FI_ADDR_UNSPEC;
+	msg_entry_efa->peer_entry.flags = FI_MSG | FI_RECV;
+	msg_entry_efa->status = RX_ENTRY_UNEXP;
+
+	msg_entry_shm = (struct util_rx_entry *) ofi_buf_alloc(srx_ctx->rx_pool);
+	assert_non_null(msg_entry_shm);
+	msg_entry_shm->peer_entry.srx = shm_srx;
+	msg_entry_shm->peer_entry.addr = FI_ADDR_UNSPEC;
+	msg_entry_shm->peer_entry.flags = FI_MSG | FI_RECV;
+	msg_entry_shm->status = RX_ENTRY_UNEXP;
+
+	/* Allocate entries for the unspec tag queue */
+	tag_entry_efa = (struct util_rx_entry *) ofi_buf_alloc(srx_ctx->rx_pool);
+	assert_non_null(tag_entry_efa);
+	tag_entry_efa->peer_entry.srx = efa_srx;
+	tag_entry_efa->peer_entry.addr = FI_ADDR_UNSPEC;
+	tag_entry_efa->peer_entry.flags = FI_TAGGED | FI_RECV;
+	tag_entry_efa->status = RX_ENTRY_UNEXP;
+
+	tag_entry_shm = (struct util_rx_entry *) ofi_buf_alloc(srx_ctx->rx_pool);
+	assert_non_null(tag_entry_shm);
+	tag_entry_shm->peer_entry.srx = shm_srx;
+	tag_entry_shm->peer_entry.addr = FI_ADDR_UNSPEC;
+	tag_entry_shm->peer_entry.flags = FI_TAGGED | FI_RECV;
+	tag_entry_shm->status = RX_ENTRY_UNEXP;
+
+	/* Insert all entries into the unspec queues */
+	dlist_insert_tail(&msg_entry_efa->d_entry,
+			  &srx_ctx->unspec_unexp_msg_queue);
+	dlist_insert_tail(&msg_entry_shm->d_entry,
+			  &srx_ctx->unspec_unexp_msg_queue);
+	dlist_insert_tail(&tag_entry_efa->d_entry,
+			  &srx_ctx->unspec_unexp_tag_queue);
+	dlist_insert_tail(&tag_entry_shm->d_entry,
+			  &srx_ctx->unspec_unexp_tag_queue);
+
+	assert_int_equal(efa_unit_test_get_dlist_length(
+				 &srx_ctx->unspec_unexp_msg_queue), 2);
+	assert_int_equal(efa_unit_test_get_dlist_length(
+				 &srx_ctx->unspec_unexp_tag_queue), 2);
+
+	/* Call foreach_unspec with efa_srx - should only process efa entries */
+	efa_srx->owner_ops->foreach_unspec_addr(efa_srx,
+						&test_foreach_unspec_get_addr);
+
+	/*
+	 * After foreach_unspec, the efa entries should have been moved out
+	 * (address resolved), while the shm provider's entries should remain
+	 * in the unspec queues.
+	 */
+	assert_int_equal(efa_unit_test_get_dlist_length(
+				 &srx_ctx->unspec_unexp_msg_queue), 1);
+	assert_int_equal(efa_unit_test_get_dlist_length(
+				 &srx_ctx->unspec_unexp_tag_queue), 1);
+
+	/* Verify the remaining entries belong to the shm provider */
+	remaining_msg = container_of(srx_ctx->unspec_unexp_msg_queue.next,
+				     struct util_rx_entry, d_entry);
+	assert_ptr_equal(remaining_msg->peer_entry.srx, shm_srx);
+
+	remaining_tag = container_of(srx_ctx->unspec_unexp_tag_queue.next,
+				     struct util_rx_entry, d_entry);
+	assert_ptr_equal(remaining_tag->peer_entry.srx, shm_srx);
+
+	/* Clean up: use shm_srx foreach_unspec to move shm entries out */
+	shm_srx->owner_ops->foreach_unspec_addr(shm_srx,
+						&test_foreach_unspec_get_addr);
+
+	assert_int_equal(efa_unit_test_get_dlist_length(
+				 &srx_ctx->unspec_unexp_msg_queue), 0);
+	assert_int_equal(efa_unit_test_get_dlist_length(
+				 &srx_ctx->unspec_unexp_tag_queue), 0);
+
+	/*
+	 * Replace discard_msg/discard_tag with no-ops on both efa and shm
+	 * peer_ops before ep close, since our test entries don't have valid
+	 * pkt_entry pointers. Save the original function pointers so we
+	 * can restore them before closing.
+	 */
+	efa_peer_ops = efa_srx->peer_ops;
+	shm_peer_ops = shm_srx->peer_ops;
+	saved_efa_discard_msg = efa_peer_ops->discard_msg;
+	saved_efa_discard_tag = efa_peer_ops->discard_tag;
+	saved_shm_discard_msg = shm_peer_ops->discard_msg;
+	saved_shm_discard_tag = shm_peer_ops->discard_tag;
+
+	efa_peer_ops->discard_msg = test_foreach_unspec_discard_no_op;
+	efa_peer_ops->discard_tag = test_foreach_unspec_discard_no_op;
+	shm_peer_ops->discard_msg = test_foreach_unspec_discard_no_op;
+	shm_peer_ops->discard_tag = test_foreach_unspec_discard_no_op;
+
+	ofi_genlock_unlock(srx_ctx->lock);
+
+	/* ep close will call util_srx_close which drains remaining entries */
+	fi_close(&resource->ep->fid);
+	resource->ep = NULL;
+
+	/* Restore original discard ops using saved function pointers */
+	efa_peer_ops->discard_msg = saved_efa_discard_msg;
+	efa_peer_ops->discard_tag = saved_efa_discard_tag;
+	shm_peer_ops->discard_msg = saved_shm_discard_msg;
+	shm_peer_ops->discard_tag = saved_shm_discard_tag;
+}

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -307,6 +307,7 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_srx_cq, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_srx_lock, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_srx_unexp_pkt, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_srx_foreach_unspec_skips_other_provider, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rnr_queue_and_resend_msg, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rnr_queue_and_resend_tagged, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -258,6 +258,7 @@ void test_efa_srx_min_multi_recv_size();
 void test_efa_srx_cq();
 void test_efa_srx_lock();
 void test_efa_srx_unexp_pkt();
+void test_efa_srx_foreach_unspec_skips_other_provider();
 void test_efa_rnr_queue_and_resend_msg();
 void test_efa_rnr_queue_and_resend_tagged();
 

--- a/prov/util/src/util_srx.c
+++ b/prov/util/src/util_srx.c
@@ -454,6 +454,8 @@ static void util_foreach_unspec(struct fid_peer_srx *srx,
 	dlist_foreach_container_safe(&srx_ctx->unspec_unexp_msg_queue,
 				     struct util_rx_entry, rx_entry, d_entry,
 				     tmp) {
+		if (rx_entry->peer_entry.srx != srx)
+			continue;
 		rx_entry->peer_entry.addr = get_addr(&rx_entry->peer_entry);
 		if (rx_entry->peer_entry.addr == FI_ADDR_UNSPEC ||
 		    !srx_ctx->dir_recv)
@@ -472,6 +474,8 @@ static void util_foreach_unspec(struct fid_peer_srx *srx,
 	dlist_foreach_container_safe(&srx_ctx->unspec_unexp_tag_queue,
 				     struct util_rx_entry, rx_entry, d_entry,
 				     tmp) {
+		if (rx_entry->peer_entry.srx != srx)
+			continue;
 		rx_entry->peer_entry.addr = get_addr(&rx_entry->peer_entry);
 		if (rx_entry->peer_entry.addr == FI_ADDR_UNSPEC ||
 		    !srx_ctx->dir_recv)


### PR DESCRIPTION
Both owner and peer providers queue messages from unknown peers into the same unspec queue, with peer_entry.srx assigned its own fid_peer_srx.
During the fi_av_insert that call util_foreach_unspec that scan this queue, each provider should only process the entries from its own provider and ignore the entries from the other one.