### PR TITLE
prov/efa: write CQ error instead of EQ error for unsolicited write recv

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_cq.c
+++ b/prov/efa/src/rdm/efa_rdm_cq.c
@@ -773,9 +773,21 @@ enum ibv_wc_status efa_rdm_cq_process_wc(struct efa_ibv_cq *cq, struct efa_rdm_e
 		case IBV_WC_RECV: /* fall through */
 		case IBV_WC_RECV_RDMA_WITH_IMM:
 			if (efa_cq_wc_is_unsolicited(cq)) {
-				EFA_WARN(FI_LOG_CQ, "Receive error %s (%d) for unsolicited write recv",
+				/*
+				 * libfabric allows NULL op_context for target-side CQ events from RMA writes with CQ data.
+				 * EFA-RDM does not require FI_RX_CQ_DATA, so NULL context is safe here.
+				 */
+				struct fi_cq_err_entry err_entry = {0};
+				
+				EFA_INFO(FI_LOG_CQ, "Receive error %s (%d) for unsolicited write recv",
 					efa_strerror(prov_errno), prov_errno);
-				efa_base_ep_write_eq_error(&ep->base_ep, to_fi_errno(prov_errno), prov_errno);
+				err_entry.op_context = NULL;
+				/*To be consistent with the succeed path. Although man page only refered to: FI_REMOTE_WRITE | FI_REMOTE_CQ_DATA)*/
+				err_entry.flags = FI_REMOTE_CQ_DATA | FI_RMA | FI_REMOTE_WRITE;
+				err_entry.err = to_fi_errno(prov_errno);
+				err_entry.prov_errno = prov_errno;
+
+				efa_rdm_cq_write_error(&ep->base_ep, ep->base_ep.util_ep.rx_cq, &err_entry, "unsolicited recv");
 				break;
 			}
 			assert(pkt_entry);

--- a/prov/efa/src/rdm/efa_rdm_cq.h
+++ b/prov/efa/src/rdm/efa_rdm_cq.h
@@ -48,5 +48,16 @@ static inline struct efa_rdm_pke *efa_rdm_cq_get_pke_from_wr_id(struct efa_ibv_c
 
 	return efa_rdm_cq_get_pke_from_wr_id_solicited(wr_id);
 }
+static inline void efa_rdm_cq_write_error(struct efa_base_ep* base_ep,struct util_cq* cq, struct fi_cq_err_entry* err_entry, const char* caller){
+	/*If ofi_cq_write_err failed, at least make sure the app still recv the err; hance, write the err to eq for fallback.*/
+	if (ofi_cq_write_error(cq, err_entry)) {
+		EFA_WARN(FI_LOG_CQ, "Failed to write CQ error entry for %s err: %d, message: %s (%d). Falling back to EQ\n",
+			caller ? caller : "unknown",
+			err_entry->err,
+			efa_strerror(err_entry->prov_errno),
+			err_entry->prov_errno);
+		efa_base_ep_write_eq_error(base_ep, err_entry->err, err_entry->prov_errno);
+	}
+}
 
 #endif

--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -13,6 +13,7 @@
 #include "efa_rdm_pke_req.h"
 #include "efa_rdm_pkt_type.h"
 #include "efa_rdm_mr.h"
+#include "efa_rdm_cq.h"
 
 void efa_rdm_txe_construct(struct efa_rdm_ope *txe,
 			   struct efa_rdm_ep *ep,
@@ -580,7 +581,6 @@ void efa_rdm_rxe_handle_error(struct efa_rdm_ope *rxe, int err, int prov_errno)
 	struct util_cq *util_cq;
 	struct dlist_entry *tmp;
 	struct efa_rdm_pke *pkt_entry;
-	int write_cq_err;
 	char err_msg[EFA_ERROR_MSG_BUFFER_LENGTH] = {0};
 
 	assert(rxe->type == EFA_RDM_RXE);
@@ -675,19 +675,7 @@ void efa_rdm_rxe_handle_error(struct efa_rdm_ope *rxe, int err, int prov_errno)
 	}
 
 	efa_cntr_report_error(&ep->base_ep.util_ep, err_entry.flags);
-	write_cq_err = ofi_cq_write_error(util_cq, &err_entry);
-	if (write_cq_err) {
-		EFA_WARN(FI_LOG_CQ, "Failed to write CQ error entry for rxe err: %d, message: %s (%d)\n",
-			err_entry.err,
-			err_entry.err_data
-				? (const char *) err_entry.err_data
-				: efa_strerror(err_entry.prov_errno),
-		 	err_entry.prov_errno);
-
-		EFA_WARN(FI_LOG_CQ,
-			"Error writing error cq entry when handling RX error\n");
-		efa_base_ep_write_eq_error(&ep->base_ep, err, prov_errno);
-	}
+	efa_rdm_cq_write_error(&ep->base_ep, util_cq, &err_entry, "RXE");
 }
 
 /**
@@ -719,7 +707,6 @@ void efa_rdm_txe_handle_error(struct efa_rdm_ope *txe, int err, int prov_errno)
 	struct util_cq *util_cq;
 	struct dlist_entry *tmp;
 	struct efa_rdm_pke *pkt_entry;
-	int write_cq_err;
 	char err_msg[EFA_ERROR_MSG_BUFFER_LENGTH] = {0};
 
 	ep = txe->ep;
@@ -829,19 +816,7 @@ void efa_rdm_txe_handle_error(struct efa_rdm_ope *txe, int err, int prov_errno)
 		return;
 
 	efa_cntr_report_error(&ep->base_ep.util_ep, txe->cq_entry.flags);
-	write_cq_err = ofi_cq_write_error(util_cq, &err_entry);
-	if (write_cq_err) {
-		EFA_WARN(FI_LOG_CQ, "Failed to write CQ error entry for txe err: %d, message: %s (%d)\n",
-			err_entry.err,
-			err_entry.err_data
-				? (const char *) err_entry.err_data
-				: efa_strerror(err_entry.prov_errno),
-			err_entry.prov_errno);
-
-		EFA_WARN(FI_LOG_CQ,
-			"Error writing error cq entry when handling TX error\n");
-		efa_base_ep_write_eq_error(&ep->base_ep, err, prov_errno);
-	}
+	efa_rdm_cq_write_error(&ep->base_ep, util_cq, &err_entry, "TXE");
 }
 
 /**

--- a/prov/efa/test/efa_unit_test_cq.c
+++ b/prov/efa/test/efa_unit_test_cq.c
@@ -500,9 +500,8 @@ void test_ibv_cq_ex_read_bad_recv_status(struct efa_resource **state)
  * @brief verify that fi_cq_read/fi_eq_read works properly when rdma-core return bad status for
  * recv rdma with imm.
  *
- * When getting a wc error of op code IBV_WC_RECV_RDMA_WITH_IMM, libfabric cannot find the
- * corresponding application operation to write a cq error.
- * It will write an EQ error instead.
+ * libfabric allows NULL op_context for target-side CQ events from RMA writes with CQ data.
+ * EFA-RDM does not require FI_RX_CQ_DATA, so NULL context is safe here.
  *
  * @param[in]	state					struct efa_resource that is managed by the framework
  * @param[in]	use_unsolicited_recv	whether to use unsolicited write recv
@@ -520,7 +519,9 @@ void test_ibv_cq_ex_read_bad_recv_rdma_with_imm_status_impl(struct efa_resource 
 	fi_addr_t peer_addr;
 	struct efa_ep_addr raw_addr = {0};
 	int err, numaddr;
-
+#if !HAVE_CAPS_UNSOLICITED_WRITE_RECV
+	(void) use_unsolicited_recv;
+#endif
 	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_FABRIC_NAME);
 	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
 
@@ -577,17 +578,34 @@ void test_ibv_cq_ex_read_bad_recv_rdma_with_imm_status_impl(struct efa_resource 
 	efa_rdm_ep->efa_rx_pkts_posted = efa_base_ep_get_rx_pool_size(&efa_rdm_ep->base_ep);
 	ibv_cq->ibv_cq_ex->wr_id = (uint64_t)pkt_entry | (uint64_t)pkt_entry->gen;
 #endif
-	/* the recv rdma with imm will not populate to application cq because it's an EFA internal error and
-	 * and not related to any application operations. Currently we can only read the error from eq.
+	/* Unsolicited: no RX pkt --> CQ err w/ NULL op_context.
+	 * Solicited: RX pkt consumed; mock has no ope --> falls back to EQ.
 	 */
 	ibv_cq->ibv_cq_ex->status = IBV_WC_GENERAL_ERR;
 	ret = fi_cq_read(resource->cq, &cq_entry, 1);
-	assert_int_equal(ret, -FI_EAGAIN);
 
-	ret = fi_eq_readerr(resource->eq, &eq_err_entry, 0);
-	assert_int_equal(ret, sizeof(eq_err_entry));
-	assert_int_not_equal(eq_err_entry.err, FI_SUCCESS);
-	assert_int_equal(eq_err_entry.prov_errno, EFA_IO_COMP_STATUS_FLUSHED);
+#if HAVE_CAPS_UNSOLICITED_WRITE_RECV
+	if (use_unsolicited_recv) {
+		struct fi_cq_err_entry cq_err_entry = {0};
+
+		assert_int_equal(ret, -FI_EAVAIL);
+		ret = fi_cq_readerr(resource->cq, &cq_err_entry, 0);
+		assert_int_equal(ret, 1);
+		assert_null(cq_err_entry.op_context);
+		assert_true((cq_err_entry.flags & (FI_REMOTE_CQ_DATA | FI_RMA | FI_REMOTE_WRITE)) == (FI_REMOTE_CQ_DATA | FI_RMA | FI_REMOTE_WRITE));
+		assert_int_not_equal(cq_err_entry.err, FI_SUCCESS);
+		assert_int_equal(cq_err_entry.prov_errno, EFA_IO_COMP_STATUS_FLUSHED);
+		ret = fi_eq_readerr(resource->eq, &eq_err_entry, 0);
+		assert_int_equal(ret, -FI_EAGAIN);
+	} else
+#endif
+	{
+		assert_int_equal(ret, -FI_EAGAIN);
+		ret = fi_eq_readerr(resource->eq, &eq_err_entry, 0);
+		assert_int_equal(ret, sizeof(eq_err_entry));
+		assert_int_not_equal(eq_err_entry.err, FI_SUCCESS);
+		assert_int_equal(eq_err_entry.prov_errno, EFA_IO_COMP_STATUS_FLUSHED);
+	}
 
 	/* reset the mocked cq before it's polled by ep close */
 	will_return_int_always(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);


### PR DESCRIPTION
## Problem

`efa_rdm_cq` writes EQ error for unsolicited `RDMA_WITH_IMM` failures
because there's no associated app op. Per `fi_cq.3`, NULL `op_context`
is valid for target-side CQ events from RMA writes carrying CQ data
when `FI_RX_CQ_DATA` is not required. EFA-RDM never sets
`FI_RX_CQ_DATA`, so this should be a CQ error, not EQ.

Same fix as #10771 (which fixed `efa_cq.c`), now applied to `efa_rdm_cq.c`.

## Changes

- `efa_rdm_cq.c`: write `fi_cq_err_entry` with `op_context=NULL` and
  flags `FI_REMOTE_CQ_DATA | FI_RMA | FI_REMOTE_WRITE` via
  `ofi_cq_write_error`. Fall back to EQ only on CQ write failure.
- `efa_unit_test_cq.c`: update unsolicited assertions to expect
  `-FI_EAVAIL` + CQ error entry; solicited path unchanged. Both
  branches gain a sanity check that the unused queue is empty.

## References

- Bug: https://github.com/ofiwg/libfabric/blob/main/prov/efa/src/rdm/efa_rdm_cq.c#L797
- Prior art: #10771