### PR TITLE
prov/rxm: add pluggable QP selector for multi-QP routing

### DIFF
--- a/prov/rxm/Makefile.include
+++ b/prov/rxm/Makefile.include
@@ -13,6 +13,8 @@ _rxm_files = \
        prov/rxm/src/rxm_atomic.c	\
        prov/rxm/src/rxm_eq.c	\
        prov/rxm/src/rxm_hmem.c	\
+       prov/rxm/src/rxm_qp_selector.c	\
+       prov/rxm/src/rxm_qp_selector.h	\
        prov/rxm/src/rxm.h
 
 if HAVE_RXM_DL

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -57,6 +57,8 @@
 #include <ofi_iov.h>
 #include <ofi_hmem.h>
 
+#include "rxm_qp_selector.h"
+
 #ifndef _RXM_H_
 #define _RXM_H_
 
@@ -230,7 +232,9 @@ enum {
 struct rxm_conn {
 	enum rxm_cm_state state;
 	struct util_peer_addr *peer;
-	struct fid_ep *msg_ep;
+	struct fid_ep **msg_eps;
+	uint8_t num_msg_eps;
+	const struct rxm_qp_selector *selector;
 	struct rxm_ep *ep;
 
 	/* Prior versions of libfabric did not guarantee that all connections
@@ -786,6 +790,23 @@ static inline size_t rxm_ep_max_atomic_size(struct fi_info *info)
 	return rxm_buffer_size - sizeof(struct rxm_atomic_hdr);
 }
 
+/* Pick the msg_ep index to use for a TX op on this conn. The selector
+ * is pluggable (see rxm_qp_selector.h); single_qp always returns 0.
+ */
+static inline struct fid_ep *
+rxm_conn_msg_ep(struct rxm_conn *conn, enum rxm_op_type op,
+	       uint64_t msg_id)
+{
+	struct rxm_selector_ctx ctx = {
+		.op = op,
+		.msg_id = msg_id,
+	};
+	uint8_t idx = conn->selector->select(conn, &ctx);
+
+	assert(idx < conn->num_msg_eps);
+	return conn->msg_eps[idx];
+}
+
 static inline ssize_t
 rxm_atomic_send_respmsg(struct rxm_ep *rxm_ep, struct rxm_conn *conn,
 			struct rxm_tx_buf *resp_buf, ssize_t len)
@@ -801,7 +822,9 @@ rxm_atomic_send_respmsg(struct rxm_ep *rxm_ep, struct rxm_conn *conn,
 		.context = resp_buf,
 		.data = 0,
 	};
-	return fi_sendmsg(conn->msg_ep, &msg, FI_COMPLETION);
+	return fi_sendmsg(rxm_conn_msg_ep(conn, RXM_OP_ATOMIC,
+					 resp_buf->pkt.ctrl_hdr.msg_id),
+			  &msg, FI_COMPLETION);
 }
 
 void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
@@ -901,7 +924,7 @@ rxm_free_rx_buf(struct rxm_rx_buf *rx_buf)
 	}
 
 	/* Discard rx buffer if its msg_ep was closed */
-	if (rx_buf->repost && (rx_buf->ep->msg_srx || rx_buf->conn->msg_ep)) {
+	if (rx_buf->repost && (rx_buf->ep->msg_srx || rx_buf->conn->msg_eps[0])) {
 		rxm_post_recv(rx_buf);
 	} else {
 		ofi_buf_free(rx_buf);

--- a/prov/rxm/src/rxm_atomic.c
+++ b/prov/rxm/src/rxm_atomic.c
@@ -69,9 +69,13 @@ rxm_ep_send_atomic_req(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	 * software generated atomic response message is received. */
 	tx_buf->hdr.state = RXM_ATOMIC_RESP_WAIT;
 	if (len <= rxm_ep->inject_limit)
-		ret = fi_inject(rxm_conn->msg_ep, &tx_buf->pkt, len, 0);
+		ret = fi_inject(rxm_conn_msg_ep(rxm_conn, RXM_OP_ATOMIC,
+					       tx_buf->pkt.ctrl_hdr.msg_id),
+				&tx_buf->pkt, len, 0);
 	else
-		ret = fi_send(rxm_conn->msg_ep, &tx_buf->pkt, len,
+		ret = fi_send(rxm_conn_msg_ep(rxm_conn, RXM_OP_ATOMIC,
+					     tx_buf->pkt.ctrl_hdr.msg_id),
+			      &tx_buf->pkt, len,
 			      tx_buf->hdr.desc, 0, tx_buf);
 	if (ret == -FI_EAGAIN)
 		rxm_ep_do_progress(&rxm_ep->util_ep);

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -79,10 +79,14 @@ static void rxm_close_conn(struct rxm_conn *conn)
 		rx_entry = (struct fi_peer_rx_entry*)conn->deferred_sar_msgs.next;
 		rx_entry->srx->owner_ops->free_entry(rx_entry);
 	}
-	fi_close(&conn->msg_ep->fid);
+	for (int i = 0; i < conn->num_msg_eps; i++) {
+		if (conn->msg_eps && conn->msg_eps[i])
+			fi_close(&conn->msg_eps[i]->fid);
+	}
 	rxm_flush_msg_cq(conn->ep);
 	dlist_remove_init(&conn->loopback_entry);
-	conn->msg_ep = NULL;
+	free(conn->msg_eps);
+	conn->msg_eps = NULL;
 
 	if (conn->state == RXM_CM_CONNECTING || conn->state == RXM_CM_ACCEPTING)
 		conn->ep->connecting_cnt--;
@@ -218,7 +222,13 @@ static int rxm_open_conn(struct rxm_conn *conn, struct fi_info *msg_info)
 			goto err;
 	}
 
-	conn->msg_ep = msg_ep;
+	assert(conn->num_msg_eps == 1);
+	conn->msg_eps = calloc(conn->num_msg_eps, sizeof(*conn->msg_eps));
+	if (!conn->msg_eps) {
+		ret = -FI_ENOMEM;
+		goto err;
+	}
+	conn->msg_eps[0] = msg_ep;
 	return 0;
 err:
 	fi_close(&msg_ep->fid);
@@ -288,7 +298,7 @@ static int rxm_send_connect(struct rxm_conn *conn)
 	if (ret)
 		goto err;
 
-	ret = fi_connect(conn->msg_ep, info->dest_addr, &cm_data,
+	ret = fi_connect(conn->msg_eps[0], info->dest_addr, &cm_data,
 			 sizeof(cm_data));
 	if (ret) {
 		RXM_WARN_ERR(FI_LOG_EP_CTRL, "fi_connect", ret);
@@ -299,8 +309,12 @@ static int rxm_send_connect(struct rxm_conn *conn)
 	return 0;
 
 err:
-	fi_close(&conn->msg_ep->fid);
-	conn->msg_ep = NULL;
+	for (int i = 0; i < conn->num_msg_eps; i++) {
+		if (conn->msg_eps && conn->msg_eps[i])
+			fi_close(&conn->msg_eps[i]->fid);
+	}
+	free(conn->msg_eps);
+	conn->msg_eps = NULL;
 	return ret;
 }
 
@@ -410,6 +424,10 @@ rxm_alloc_conn(struct rxm_ep *ep, struct util_peer_addr *peer)
 	conn->peer = peer;
 	rxm_ref_peer(peer);
 
+	conn->num_msg_eps = 1;
+	conn->msg_eps = NULL;
+	conn->selector = &rxm_selector_single_qp;
+
 	FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "allocated conn %p\n", conn);
 	return conn;
 }
@@ -516,7 +534,7 @@ void rxm_process_connect(struct rxm_eq_cm_entry *cm_entry)
 	if (conn->flow_ctrl && conn->peer_flow_ctrl) {
 		domain = container_of(conn->ep->util_ep.domain,
 				      struct rxm_domain, util_domain);
-		domain->flow_ctrl_ops->enable(conn->msg_ep,
+		domain->flow_ctrl_ops->enable(conn->msg_eps[0],
 					      conn->ep->msg_info->rx_attr->size / 2);
 	}
 
@@ -634,7 +652,7 @@ rxm_accept_connreq(struct rxm_conn *conn, struct rxm_eq_cm_entry *cm_entry)
 	cm_data.accept.align_pad[1] = 0;
 	cm_data.accept.align_pad[2] = 0;
 
-	ret = fi_accept(conn->msg_ep, &cm_data.accept, sizeof(cm_data.accept));
+	ret = fi_accept(conn->msg_eps[0], &cm_data.accept, sizeof(cm_data.accept));
 	if (ret)
 		RXM_WARN_ERR(FI_LOG_EP_CTRL, "fi_accept", ret);
 	return ret;

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -587,7 +587,9 @@ ssize_t rxm_rndv_read(struct rxm_rx_buf *rx_buf)
 	rx_buf->peer_entry->msg_size = total_len;
 	RXM_UPDATE_STATE(FI_LOG_CQ, rx_buf, RXM_RNDV_READ);
 
-	ret = rxm_rndv_xfer(rx_buf->ep, rx_buf->conn->msg_ep,
+	ret = rxm_rndv_xfer(rx_buf->ep,
+			    rxm_conn_msg_ep(rx_buf->conn, RXM_OP_RNDV_RMA,
+					   rx_buf->pkt.ctrl_hdr.msg_id),
 			    rx_buf->remote_rndv_hdr,
 			    rx_buf->peer_entry->iov,
 			    rx_buf->peer_entry->desc,
@@ -653,7 +655,11 @@ static ssize_t rxm_rndv_handle_wr_data(struct rxm_rx_buf *rx_buf)
 	else
 		RXM_UPDATE_STATE(FI_LOG_CQ, tx_buf, RXM_RNDV_WRITE_TX_WAIT);
 
-	ret = rxm_rndv_xfer(rx_buf->ep, tx_buf->write_rndv.conn->msg_ep, rx_hdr,
+	ret = rxm_rndv_xfer(rx_buf->ep,
+			    rxm_conn_msg_ep(tx_buf->write_rndv.conn,
+					   RXM_OP_RNDV_RMA,
+					   tx_buf->pkt.ctrl_hdr.msg_id),
+			    rx_hdr,
 			    tx_buf->write_rndv.iov, tx_buf->write_rndv.desc,
 			    tx_buf->rma.count, total_len, tx_buf);
 
@@ -914,7 +920,9 @@ static void rxm_rndv_send_rd_done(struct rxm_rx_buf *rx_buf)
 	buf->pkt.ctrl_hdr.conn_id = rx_buf->conn->remote_index;
 	buf->pkt.ctrl_hdr.msg_id = rx_buf->pkt.ctrl_hdr.msg_id;
 
-	ret = fi_send(rx_buf->conn->msg_ep, &buf->pkt, sizeof(buf->pkt),
+	ret = fi_send(rxm_conn_msg_ep(rx_buf->conn, RXM_OP_RNDV_CTRL,
+				     buf->pkt.ctrl_hdr.msg_id),
+		      &buf->pkt, sizeof(buf->pkt),
 		      buf->hdr.desc, 0, rx_buf);
 	if (ret) {
 		if (ret == -FI_EAGAIN) {
@@ -969,7 +977,9 @@ rxm_rndv_send_wr_done(struct rxm_ep *rxm_ep, struct rxm_tx_buf *tx_buf)
 	buf->pkt.ctrl_hdr.conn_id = tx_buf->pkt.ctrl_hdr.conn_id;
 	buf->pkt.ctrl_hdr.msg_id = tx_buf->pkt.ctrl_hdr.msg_id;
 
-	ret = fi_send(tx_buf->write_rndv.conn->msg_ep, &buf->pkt,
+	ret = fi_send(rxm_conn_msg_ep(tx_buf->write_rndv.conn, RXM_OP_RNDV_CTRL,
+				     buf->pkt.ctrl_hdr.msg_id),
+		      &buf->pkt,
 		      sizeof(buf->pkt), buf->hdr.desc, 0, tx_buf);
 	if (ret) {
 		if (ret == -FI_EAGAIN) {
@@ -1033,7 +1043,9 @@ ssize_t rxm_rndv_send_wr_data(struct rxm_rx_buf *rx_buf)
 			  rx_buf->peer_entry->iov,
 			  rx_buf->peer_entry->count, rx_buf->mr);
 
-	ret = fi_send(rx_buf->conn->msg_ep, &buf->pkt, sizeof(buf->pkt) +
+	ret = fi_send(rxm_conn_msg_ep(rx_buf->conn, RXM_OP_RNDV_CTRL,
+				     buf->pkt.ctrl_hdr.msg_id),
+		      &buf->pkt, sizeof(buf->pkt) +
 		      sizeof(struct rxm_rndv_hdr), buf->hdr.desc, 0, rx_buf);
 	if (ret) {
 		if (ret == -FI_EAGAIN) {
@@ -1119,7 +1131,9 @@ static ssize_t rxm_atomic_send_resp(struct rxm_ep *rxm_ep,
 	atomic_hdr->result_len = htonl((uint32_t) result_len);
 
 	if (tot_len < rxm_ep->inject_limit) {
-		ret = fi_inject(rx_buf->conn->msg_ep, &resp_buf->pkt,
+		ret = fi_inject(rxm_conn_msg_ep(rx_buf->conn, RXM_OP_ATOMIC,
+					       resp_buf->pkt.ctrl_hdr.msg_id),
+				&resp_buf->pkt,
 				tot_len, 0);
 		if (!ret)
 			ofi_buf_free(resp_buf);

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -460,7 +460,12 @@ rxm_ep_progress_sar_deferred_segments(struct rxm_deferred_tx_entry *def_tx_entry
 	struct rxm_tx_buf *tx_buf = def_tx_entry->sar_seg.cur_seg_tx_buf;
 
 	if (tx_buf) {
-		ret = fi_send(def_tx_entry->rxm_conn->msg_ep, &tx_buf->pkt,
+		ret = fi_send(rxm_conn_msg_ep(def_tx_entry->rxm_conn,
+					     rxm_sar_get_seg_type(&tx_buf->pkt.ctrl_hdr) ==
+					     RXM_SAR_SEG_LAST ?
+					     RXM_OP_SAR_LAST : RXM_OP_SAR_MIDDLE,
+					     tx_buf->pkt.ctrl_hdr.msg_id),
+			      &tx_buf->pkt,
 			      sizeof(tx_buf->pkt) + tx_buf->pkt.ctrl_hdr.seg_size,
 			      tx_buf->hdr.desc, 0, tx_buf);
 		if (ret) {
@@ -535,7 +540,9 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 		switch (def_tx_entry->type) {
 		case RXM_DEFERRED_TX_RNDV_ACK:
 			proto_info = def_tx_entry->rndv_ack.rx_buf->proto_info;
-			ret = fi_send(def_tx_entry->rxm_conn->msg_ep,
+			ret = fi_send(rxm_conn_msg_ep(def_tx_entry->rxm_conn,
+						     RXM_OP_RNDV_CTRL,
+						     proto_info->rndv.tx_buf->pkt.ctrl_hdr.msg_id),
 				      &proto_info->rndv.tx_buf->pkt,
 				      def_tx_entry->rndv_ack.pkt_size,
 				      proto_info->rndv.tx_buf->hdr.desc,
@@ -559,7 +566,9 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 						 RXM_RNDV_WRITE_DATA_SENT);
 			break;
 		case RXM_DEFERRED_TX_RNDV_DONE:
-			ret = fi_send(def_tx_entry->rxm_conn->msg_ep,
+			ret = fi_send(rxm_conn_msg_ep(def_tx_entry->rxm_conn,
+						     RXM_OP_RNDV_CTRL,
+						     def_tx_entry->rndv_done.tx_buf->pkt.ctrl_hdr.msg_id),
 				      &def_tx_entry->rndv_done.tx_buf->write_rndv.done_buf->pkt,
 				      sizeof(struct rxm_pkt),
 				      def_tx_entry->rndv_done.tx_buf->write_rndv.done_buf->hdr.desc,
@@ -578,7 +587,9 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 			break;
 		case RXM_DEFERRED_TX_RNDV_READ:
 			ret = rxm_ep->rndv_ops->xfer(
-				def_tx_entry->rxm_conn->msg_ep,
+				rxm_conn_msg_ep(def_tx_entry->rxm_conn,
+					       RXM_OP_RNDV_RMA,
+					       def_tx_entry->rndv_read.rx_buf->pkt.ctrl_hdr.msg_id),
 				def_tx_entry->rndv_read.rxm_iov.iov,
 				def_tx_entry->rndv_read.rxm_iov.desc,
 				def_tx_entry->rndv_read.rxm_iov.count, 0,
@@ -596,7 +607,9 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 			break;
 		case RXM_DEFERRED_TX_RNDV_WRITE:
 			ret = rxm_ep->rndv_ops->xfer(
-				def_tx_entry->rxm_conn->msg_ep,
+				rxm_conn_msg_ep(def_tx_entry->rxm_conn,
+					       RXM_OP_RNDV_RMA,
+					       def_tx_entry->rndv_write.tx_buf->pkt.ctrl_hdr.msg_id),
 				def_tx_entry->rndv_write.rxm_iov.iov,
 				def_tx_entry->rndv_write.rxm_iov.desc,
 				def_tx_entry->rndv_write.rxm_iov.count, 0,
@@ -636,8 +649,9 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 			msg.iov_count = 1;
 			msg.msg_iov = &iov;
 
-			ret = fi_sendmsg(def_tx_entry->rxm_conn->msg_ep, &msg,
-					 OFI_PRIORITY);
+			ret = fi_sendmsg(rxm_conn_msg_ep(def_tx_entry->rxm_conn,
+							RXM_OP_EAGER, 0),
+					 &msg, OFI_PRIORITY);
 			if (ret) {
 				if (ret != -FI_EAGAIN) {
 					rxm_cq_write_rx_error(

--- a/prov/rxm/src/rxm_msg.c
+++ b/prov/rxm/src/rxm_msg.c
@@ -163,10 +163,14 @@ rxm_send_rndv(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 			RXM_UPDATE_STATE(FI_LOG_EP_DATA, tx_buf,
 					 RXM_RNDV_READ_DONE_WAIT);
 
-		ret = fi_inject(rxm_conn->msg_ep, &tx_buf->pkt, pkt_size, 0);
+		ret = fi_inject(rxm_conn_msg_ep(rxm_conn, RXM_OP_RNDV_CTRL,
+					       tx_buf->pkt.ctrl_hdr.msg_id),
+				&tx_buf->pkt, pkt_size, 0);
 	} else {
 		RXM_UPDATE_STATE(FI_LOG_EP_DATA, tx_buf, RXM_RNDV_TX);
-		ret = fi_send(rxm_conn->msg_ep, &tx_buf->pkt, pkt_size,
+		ret = fi_send(rxm_conn_msg_ep(rxm_conn, RXM_OP_RNDV_CTRL,
+					     tx_buf->pkt.ctrl_hdr.msg_id),
+			      &tx_buf->pkt, pkt_size,
 			      tx_buf->hdr.desc, 0, tx_buf);
 	}
 
@@ -258,7 +262,11 @@ rxm_send_segment(struct rxm_ep *rxm_ep,
 
 	*out_tx_buf = tx_buf;
 
-	return fi_send(rxm_conn->msg_ep, &tx_buf->pkt, sizeof(struct rxm_pkt) +
+	return fi_send(rxm_conn_msg_ep(rxm_conn,
+				      seg_type == RXM_SAR_SEG_LAST ?
+				      RXM_OP_SAR_LAST : RXM_OP_SAR_MIDDLE,
+				      tx_buf->pkt.ctrl_hdr.msg_id),
+		       &tx_buf->pkt, sizeof(struct rxm_pkt) +
 		       tx_buf->pkt.ctrl_hdr.seg_size, tx_buf->hdr.desc, 0, tx_buf);
 }
 
@@ -292,7 +300,9 @@ rxm_send_sar(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 
 	iov_offset += rxm_buffer_size;
 
-	ret = fi_send(rxm_conn->msg_ep, &first_tx_buf->pkt,
+	ret = fi_send(rxm_conn_msg_ep(rxm_conn, RXM_OP_SAR_FIRST,
+				     first_tx_buf->pkt.ctrl_hdr.msg_id),
+		      &first_tx_buf->pkt,
 		      sizeof(struct rxm_pkt) + first_tx_buf->pkt.ctrl_hdr.seg_size,
 		      first_tx_buf->hdr.desc, 0, first_tx_buf);
 	if (ret) {
@@ -372,7 +382,8 @@ rxm_emulate_inject(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 				 &tx_buf->pkt);
 	memcpy(tx_buf->pkt.data, buf, len);
 
-	ret = fi_send(rxm_conn->msg_ep, &tx_buf->pkt, pkt_size,
+	ret = fi_send(rxm_conn_msg_ep(rxm_conn, RXM_OP_EAGER, 0),
+		      &tx_buf->pkt, pkt_size,
 		      tx_buf->hdr.desc, 0, tx_buf);
 	if (ret) {
 		if (ret == -FI_EAGAIN)
@@ -396,7 +407,8 @@ rxm_inject_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	if (pkt_size <= rxm_ep->inject_limit && !rxm_ep->util_ep.cntrs[CNTR_TX]) {
 		inject_pkt->hdr.size = len;
 		memcpy(inject_pkt->data, buf, len);
-		ret = fi_inject(rxm_conn->msg_ep, inject_pkt, pkt_size, 0);
+		ret = fi_inject(rxm_conn_msg_ep(rxm_conn, RXM_OP_EAGER, 0),
+				inject_pkt, pkt_size, 0);
 	} else {
 		ret = rxm_emulate_inject(rxm_ep, rxm_conn, buf, len,
 					 pkt_size, inject_pkt->hdr.data,
@@ -438,10 +450,12 @@ rxm_direct_send(struct rxm_ep *ep, struct rxm_conn *rxm_conn,
 			send_desc[i + 1] = fi_mr_desc(mr->msg_mr);
 		}
 
-		ret = fi_sendv(rxm_conn->msg_ep, send_iov, send_desc,
+		ret = fi_sendv(rxm_conn_msg_ep(rxm_conn, RXM_OP_EAGER, 0),
+			       send_iov, send_desc,
 			       count + 1, 0, tx_buf);
 	} else {
-		ret = fi_sendv(rxm_conn->msg_ep, send_iov, NULL,
+		ret = fi_sendv(rxm_conn_msg_ep(rxm_conn, RXM_OP_EAGER, 0),
+			       send_iov, NULL,
 			       count + 1, 0, tx_buf);
 	}
 	return ret;
@@ -476,7 +490,8 @@ rxm_send_eager(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 					     eager_buf->pkt.hdr.size, iov,
 					     count, 0);
 		assert((size_t) ret == eager_buf->pkt.hdr.size);
-		ret = fi_send(rxm_conn->msg_ep, &eager_buf->pkt, total_len,
+		ret = fi_send(rxm_conn_msg_ep(rxm_conn, RXM_OP_EAGER, 0),
+			      &eager_buf->pkt, total_len,
 			      eager_buf->hdr.desc, 0, eager_buf);
 	}
 
@@ -769,7 +784,8 @@ rxm_send_thru(struct fid_ep *ep_fid, const void *buf, size_t len,
 	if (ret)
 		goto unlock;
 
-	ret = fi_send(conn->msg_ep, buf, len, desc, 0, context);
+	ret = fi_send(rxm_conn_msg_ep(conn, RXM_OP_EAGER, 0),
+		      buf, len, desc, 0, context);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -790,7 +806,8 @@ rxm_sendv_thru(struct fid_ep *ep_fid, const struct iovec *iov,
 	if (ret)
 		goto unlock;
 
-	ret = fi_sendv(conn->msg_ep, iov, desc, count, 0, context);
+	ret = fi_sendv(rxm_conn_msg_ep(conn, RXM_OP_EAGER, 0),
+		       iov, desc, count, 0, context);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -811,7 +828,8 @@ rxm_sendmsg_thru(struct fid_ep *ep_fid, const struct fi_msg *msg,
 	if (ret)
 		goto unlock;
 
-	ret = fi_sendmsg(conn->msg_ep, msg, flags);
+	ret = fi_sendmsg(rxm_conn_msg_ep(conn, RXM_OP_EAGER, 0),
+			 msg, flags);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -832,7 +850,8 @@ rxm_inject_thru(struct fid_ep *ep_fid, const void *buf,
 	if (ret)
 		goto unlock;
 
-	ret = fi_inject(conn->msg_ep, buf, len, 0);
+	ret = fi_inject(rxm_conn_msg_ep(conn, RXM_OP_EAGER, 0),
+			buf, len, 0);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -853,7 +872,8 @@ rxm_senddata_thru(struct fid_ep *ep_fid, const void *buf, size_t len,
 	if (ret)
 		goto unlock;
 
-	ret = fi_senddata(conn->msg_ep, buf, len, desc, data, 0, context);
+	ret = fi_senddata(rxm_conn_msg_ep(conn, RXM_OP_EAGER, 0),
+			  buf, len, desc, data, 0, context);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -874,7 +894,8 @@ rxm_injectdata_thru(struct fid_ep *ep_fid, const void *buf, size_t len,
 	if (ret)
 		goto unlock;
 
-	ret = fi_injectdata(conn->msg_ep, buf, len, data, 0);
+	ret = fi_injectdata(rxm_conn_msg_ep(conn, RXM_OP_EAGER, 0),
+			    buf, len, data, 0);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;

--- a/prov/rxm/src/rxm_qp_selector.c
+++ b/prov/rxm/src/rxm_qp_selector.c
@@ -1,0 +1,15 @@
+#include "rxm.h"
+#include "rxm_qp_selector.h"
+
+static uint8_t rxm_single_qp_select(struct rxm_conn *conn,
+				    const struct rxm_selector_ctx *ctx)
+{
+	(void) conn;
+	(void) ctx;
+	return 0;
+}
+
+const struct rxm_qp_selector rxm_selector_single_qp = {
+	.name = "single_qp",
+	.select = rxm_single_qp_select,
+};

--- a/prov/rxm/src/rxm_qp_selector.h
+++ b/prov/rxm/src/rxm_qp_selector.h
@@ -1,0 +1,33 @@
+#ifndef RXM_QP_SELECTOR_H
+#define RXM_QP_SELECTOR_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+struct rxm_conn;
+
+enum rxm_op_type {
+	RXM_OP_EAGER,
+	RXM_OP_SAR_FIRST,
+	RXM_OP_SAR_MIDDLE,
+	RXM_OP_SAR_LAST,
+	RXM_OP_RNDV_CTRL,
+	RXM_OP_RNDV_RMA,
+	RXM_OP_RMA,
+	RXM_OP_ATOMIC,
+};
+
+struct rxm_selector_ctx {
+	enum rxm_op_type op;
+	uint64_t msg_id;
+};
+
+struct rxm_qp_selector {
+	const char *name;
+	uint8_t (*select)(struct rxm_conn *conn,
+			  const struct rxm_selector_ctx *ctx);
+};
+
+extern const struct rxm_qp_selector rxm_selector_single_qp;
+
+#endif /* RXM_QP_SELECTOR_H */

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -101,7 +101,8 @@ rxm_ep_rma_common(struct rxm_ep *rxm_ep, const struct fi_msg_rma *msg,
 	msg_rma.desc = mr_desc;
 	msg_rma.context = rma_buf;
 
-	ret = rma_msg(rxm_conn->msg_ep, &msg_rma, flags);
+	ret = rma_msg(rxm_conn_msg_ep(rxm_conn, RXM_OP_RMA, 0),
+		      &msg_rma, flags);
 	if (!ret)
 		goto unlock;
 
@@ -231,7 +232,8 @@ rxm_ep_rma_emulate_inject_msg(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 
 	flags = (flags & ~FI_INJECT) | FI_COMPLETION;
 
-	ret = fi_writemsg(rxm_conn->msg_ep, &rxm_rma_msg, flags);
+	ret = fi_writemsg(rxm_conn_msg_ep(rxm_conn, RXM_OP_RMA, 0),
+			  &rxm_rma_msg, flags);
 	if (ret) {
 		if (ret == -FI_EAGAIN)
 			rxm_ep_do_progress(&rxm_ep->util_ep);
@@ -295,13 +297,15 @@ rxm_ep_rma_inject_common(struct rxm_ep *rxm_ep, const struct fi_msg_rma *msg,
 	}
 
 	if (flags & FI_REMOTE_CQ_DATA) {
-		ret = fi_inject_writedata(rxm_conn->msg_ep,
+		ret = fi_inject_writedata(rxm_conn_msg_ep(rxm_conn, RXM_OP_RMA,
+							 0),
 					  msg->msg_iov->iov_base,
 					  msg->msg_iov->iov_len, msg->data,
 					  msg->addr, msg->rma_iov->addr,
 					  msg->rma_iov->key);
 	} else {
-		ret = fi_inject_write(rxm_conn->msg_ep,
+		ret = fi_inject_write(rxm_conn_msg_ep(rxm_conn, RXM_OP_RMA,
+						     0),
 				      msg->msg_iov->iov_base,
 				      msg->msg_iov->iov_len, msg->addr,
 				      msg->rma_iov->addr,
@@ -450,7 +454,8 @@ static ssize_t rxm_ep_inject_write(struct fid_ep *ep_fid, const void *buf,
 		goto unlock;
 	}
 
-	ret = fi_inject_write(rxm_conn->msg_ep, buf, len, dest_addr, addr, key);
+	ret = fi_inject_write(rxm_conn_msg_ep(rxm_conn, RXM_OP_RMA, 0),
+			      buf, len, dest_addr, addr, key);
 	if (ret == -FI_EAGAIN)
 		rxm_ep_do_progress(&rxm_ep->util_ep);
 	else if (ret)
@@ -484,7 +489,8 @@ static ssize_t rxm_ep_inject_writedata(struct fid_ep *ep_fid, const void *buf,
 		goto unlock;
 	}
 
-	ret = fi_inject_writedata(rxm_conn->msg_ep, buf, len,
+	ret = fi_inject_writedata(rxm_conn_msg_ep(rxm_conn, RXM_OP_RMA, 0),
+				  buf, len,
 				  data, dest_addr, addr, key);
 	if (ret == -FI_EAGAIN)
 		rxm_ep_do_progress(&rxm_ep->util_ep);
@@ -526,7 +532,8 @@ rxm_read_thru(struct fid_ep *ep_fid, void *buf, size_t len,
 	if (ret)
 		goto unlock;
 
-	ret = fi_read(conn->msg_ep, buf, len, desc, src_addr, addr,
+	ret = fi_read(rxm_conn_msg_ep(conn, RXM_OP_RMA, 0),
+		      buf, len, desc, src_addr, addr,
 		      key, context);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
@@ -549,7 +556,8 @@ rxm_readv_thru(struct fid_ep *ep_fid, const struct iovec *iov,
 	if (ret)
 		goto unlock;
 
-	ret = fi_readv(conn->msg_ep, iov, desc, count, src_addr, addr,
+	ret = fi_readv(rxm_conn_msg_ep(conn, RXM_OP_RMA, 0),
+		       iov, desc, count, src_addr, addr,
 		       key, context);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
@@ -571,7 +579,8 @@ rxm_readmsg_thru(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 	if (ret)
 		goto unlock;
 
-	ret = fi_readmsg(conn->msg_ep, msg, flags);
+	ret = fi_readmsg(rxm_conn_msg_ep(conn, RXM_OP_RMA, 0),
+			 msg, flags);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -593,7 +602,8 @@ rxm_write_thru(struct fid_ep *ep_fid, const void *buf,
 	if (ret)
 		goto unlock;
 
-	ret = fi_write(conn->msg_ep, buf, len, desc, dest_addr, addr,
+	ret = fi_write(rxm_conn_msg_ep(conn, RXM_OP_RMA, 0),
+		       buf, len, desc, dest_addr, addr,
 		       key, context);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
@@ -616,7 +626,8 @@ rxm_writev_thru(struct fid_ep *ep_fid, const struct iovec *iov,
 	if (ret)
 		goto unlock;
 
-	ret = fi_writev(conn->msg_ep, iov, desc, count, dest_addr, addr,
+	ret = fi_writev(rxm_conn_msg_ep(conn, RXM_OP_RMA, 0),
+			iov, desc, count, dest_addr, addr,
 			key, context);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
@@ -638,7 +649,8 @@ rxm_writemsg_thru(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 	if (ret)
 		goto unlock;
 
-	ret = fi_writemsg(conn->msg_ep, msg, flags);
+	ret = fi_writemsg(rxm_conn_msg_ep(conn, RXM_OP_RMA, 0),
+			  msg, flags);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -660,7 +672,8 @@ rxm_inject_write_thru(struct fid_ep *ep_fid, const void *buf,
 	if (ret)
 		goto unlock;
 
-	ret = fi_inject_write(conn->msg_ep, buf, len, dest_addr, addr, key);
+	ret = fi_inject_write(rxm_conn_msg_ep(conn, RXM_OP_RMA, 0),
+			      buf, len, dest_addr, addr, key);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -683,7 +696,8 @@ rxm_writedata_thru(struct fid_ep *ep_fid, const void *buf,
 	if (ret)
 		goto unlock;
 
-	ret = fi_writedata(conn->msg_ep, buf, len, desc, data, dest_addr,
+	ret = fi_writedata(rxm_conn_msg_ep(conn, RXM_OP_RMA, 0),
+			   buf, len, desc, data, dest_addr,
 			   addr, key, context);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
@@ -706,7 +720,8 @@ rxm_inject_writedata_thru(struct fid_ep *ep_fid, const void *buf,
 	if (ret)
 		goto unlock;
 
-	ret = fi_inject_writedata(conn->msg_ep, buf, len, data, dest_addr,
+	ret = fi_inject_writedata(rxm_conn_msg_ep(conn, RXM_OP_RMA, 0),
+				  buf, len, data, dest_addr,
 				  addr, key);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);

--- a/prov/rxm/src/rxm_tagged.c
+++ b/prov/rxm/src/rxm_tagged.c
@@ -330,7 +330,8 @@ rxm_tsend_thru(struct fid_ep *ep_fid, const void *buf, size_t len,
 	if (ret)
 		goto unlock;
 
-	ret = fi_tsend(conn->msg_ep, buf, len, desc, 0, tag, context);
+	ret = fi_tsend(rxm_conn_msg_ep(conn, RXM_OP_EAGER, 0),
+		       buf, len, desc, 0, tag, context);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -352,7 +353,8 @@ rxm_tsendv_thru(struct fid_ep *ep_fid, const struct iovec *iov,
 	if (ret)
 		goto unlock;
 
-	ret = fi_tsendv(conn->msg_ep, iov, desc, count, 0, tag, context);
+	ret = fi_tsendv(rxm_conn_msg_ep(conn, RXM_OP_EAGER, 0),
+			iov, desc, count, 0, tag, context);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -373,7 +375,8 @@ rxm_tsendmsg_thru(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
 	if (ret)
 		goto unlock;
 
-	ret = fi_tsendmsg(conn->msg_ep, msg, flags);
+	ret = fi_tsendmsg(rxm_conn_msg_ep(conn, RXM_OP_EAGER, 0),
+			  msg, flags);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -394,7 +397,8 @@ rxm_tinject_thru(struct fid_ep *ep_fid, const void *buf,
 	if (ret)
 		goto unlock;
 
-	ret = fi_tinject(conn->msg_ep, buf, len, 0, tag);
+	ret = fi_tinject(rxm_conn_msg_ep(conn, RXM_OP_EAGER, 0),
+			 buf, len, 0, tag);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -416,7 +420,8 @@ rxm_tsenddata_thru(struct fid_ep *ep_fid, const void *buf, size_t len,
 	if (ret)
 		goto unlock;
 
-	ret = fi_tsenddata(conn->msg_ep, buf, len, desc, data, 0, tag, context);
+	ret = fi_tsenddata(rxm_conn_msg_ep(conn, RXM_OP_EAGER, 0),
+			   buf, len, desc, data, 0, tag, context);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -437,7 +442,8 @@ rxm_tinjectdata_thru(struct fid_ep *ep_fid, const void *buf, size_t len,
 	if (ret)
 		goto unlock;
 
-	ret = fi_tinjectdata(conn->msg_ep, buf, len, data, 0, tag);
+	ret = fi_tinjectdata(rxm_conn_msg_ep(conn, RXM_OP_EAGER, 0),
+			     buf, len, data, 0, tag);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;


### PR DESCRIPTION
Introduce a pluggable rxm_qp_selector interface that maps each TX operation to a msg_ep index. The selector receives the op type (EAGER, SAR_FIRST/MIDDLE/LAST, RNDV_CTRL/RMA, RMA, ATOMIC) and the SAR msg_id, allowing future policies to steer traffic across multiple underlying QPs.

Wire the selector and a msg_eps[] array into rxm_conn, replacing the single scalar msg_ep alias. All TX paths (eager/tagged sends, SAR, RNDV control and payload, pass-through RMA, atomics) are updated to call rxm_conn_msg_ep() instead of accessing msg_ep directly.

The initial implementation ships rxm_selector_single_qp, which always returns index 0 and preserves current single-QP behaviour.