### PR TITLE
prov/cxi: Added FI_SUCCESS return to rnr recv cb

### DIFF
--- a/prov/cxi/src/cxip_msg_rnr.c
+++ b/prov/cxi/src/cxip_msg_rnr.c
@@ -247,6 +247,8 @@ static int cxip_rnr_recv_cb(struct cxip_req *req, const union c_event *event)
 			  cxi_event_to_str(event),
 			  cxi_rc_to_str(cxi_event_rc(event)));
 	}
+
+	return FI_SUCCESS;
 }
 
 static void cxip_rxc_rnr_progress(struct cxip_rxc *rxc, bool internal)


### PR DESCRIPTION
Added default return int in cxip_rnr_recv_cb() this was causing failures when running unoptimized builds testing append retry logic. cxip_evtq_progress() did not complete the C_EVENT_UNLINK progression the retry logic was waiting for.