### PR TITLE
.github/pr-ci.yml: use gcc:15 container image for gcc15 build job

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -80,15 +80,15 @@ jobs:
       contents: read
       pull-requests: read
     runs-on: ubuntu-24.04
+    container: gcc:15
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Install dependencies (Linux)
         run: |
-          sudo apt-get update
-          sudo apt-get install -y ${{ env.APT_PACKAGES }}
-          sudo add-apt-repository -y ppa:puni070/gcc-noble
-          sudo apt-get update
-          sudo apt-get install -y gcc-15 g++-15
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-15 60 --slave /usr/bin/g++ g++ /usr/bin/g++-15
+          apt-get update
+          apt-get install -y ${{ env.APT_PACKAGES }} cmake
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v4.3.1
       - name: Build Check
         run: |


### PR DESCRIPTION
Replace the puni070/gcc-noble PPA with the official gcc:15 Docker container image. The PPA is unreliable and causes intermittent CI failures due to connection timeouts to ppa.launchpadcontent.net.