### PR TITLE
[v2.4.x] prov/efa: use dmabuf for CUDA MR registration

### DIFF
--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -542,11 +542,8 @@ static struct ibv_mr *efa_mr_reg_ibv_mr(struct efa_mr *efa_mr, struct fi_mr_attr
 				dmabuf_fd, access);
 	}
 
-	/*
-	 * TODO: need such fallback for cuda as well when
-	 * FI_CUDA_API_PERMITTED is true
-	 */
-	if (efa_mr_is_neuron(efa_mr) || efa_mr_is_rocr(efa_mr)) {
+	if (efa_mr_is_neuron(efa_mr) || efa_mr_is_rocr(efa_mr) ||
+	    efa_mr_is_cuda(efa_mr)) {
 		ret = ofi_hmem_get_dmabuf_fd(
 				efa_mr->peer.iface,
 				mr_attr->mr_iov->iov_base,


### PR DESCRIPTION
## Summary

- include CUDA in the EFA provider's implicit dmabuf MR registration path
- use the existing `ofi_hmem_get_dmabuf_fd()` and `ibv_reg_dmabuf_mr()` flow for `FI_HMEM_CUDA`
- remove the stale TODO that said CUDA still needed this fallback

## Root Cause

CUDA HMEM registrations without `FI_MR_DMABUF` were not included in the EFA provider's dmabuf path, unlike Neuron and ROCr. That made CUDA memory fall through to plain `ibv_reg_mr()` with a GPU virtual address, which can fail with `EFAULT`.

References https://github.com/ofiwg/libfabric/issues/12019.

## Validation

Tested in a GB200 cluster
