### PR TITLE
prov/efa: Always build rdma-core WQE post functions in header

### DIFF
--- a/prov/efa/src/efa_data_path_ops.h
+++ b/prov/efa/src/efa_data_path_ops.h
@@ -30,53 +30,6 @@
 #include "efa_data_path_direct_entry.h"
 #endif
 
-#if EFA_UNIT_TEST
-/* For unit tests, declare functions that are defined in efa_unit_test_data_path_ops.c */
-int efa_qp_post_recv(struct efa_qp *qp, struct ibv_recv_wr *wr, struct ibv_recv_wr **bad);
-int efa_qp_post_send(struct efa_qp *qp, const struct ibv_sge *sge_list,
-		      const struct ibv_data_buf *inline_data_list,
-		      size_t iov_count, bool use_inline, uintptr_t wr_id,
-		      uint64_t data, uint64_t flags, struct efa_ah *ah,
-		      uint32_t qpn, uint32_t qkey);
-int efa_qp_post_read(struct efa_qp *qp, const struct ibv_sge *sge_list,
-		      size_t sge_count, uint32_t remote_key,
-		      uint64_t remote_addr, uintptr_t wr_id, uint64_t flags,
-		      struct efa_ah *ah, uint32_t qpn, uint32_t qkey);
-int efa_qp_post_write(struct efa_qp *qp, const struct ibv_sge *sge_list,
-		       size_t sge_count, uint32_t remote_key,
-		       uint64_t remote_addr, uintptr_t wr_id, uint64_t data,
-		       uint64_t flags, struct efa_ah *ah, uint32_t qpn,
-		       uint32_t qkey);
-int efa_ibv_cq_start_poll(struct efa_ibv_cq *ibv_cq, struct ibv_poll_cq_attr *attr);
-int efa_ibv_cq_next_poll(struct efa_ibv_cq *ibv_cq);
-enum ibv_wc_opcode efa_ibv_cq_wc_read_opcode(struct efa_ibv_cq *ibv_cq);
-void efa_ibv_cq_end_poll(struct efa_ibv_cq *ibv_cq);
-uint32_t efa_ibv_cq_wc_read_qp_num(struct efa_ibv_cq *ibv_cq);
-uint32_t efa_ibv_cq_wc_read_vendor_err(struct efa_ibv_cq *ibv_cq);
-uint32_t efa_ibv_cq_wc_read_src_qp(struct efa_ibv_cq *ibv_cq);
-uint32_t efa_ibv_cq_wc_read_slid(struct efa_ibv_cq *ibv_cq);
-uint32_t efa_ibv_cq_wc_read_byte_len(struct efa_ibv_cq *ibv_cq);
-unsigned int efa_ibv_cq_wc_read_wc_flags(struct efa_ibv_cq *ibv_cq);
-__be32 efa_ibv_cq_wc_read_imm_data(struct efa_ibv_cq *ibv_cq);
-bool efa_ibv_cq_wc_is_unsolicited(struct efa_ibv_cq *ibv_cq);
-
-int efa_ibv_cq_wc_read_sgid(struct efa_ibv_cq *ibv_cq, union ibv_gid *sgid);
-
-int efa_ibv_get_cq_event(struct efa_ibv_cq *ibv_cq, void **cq_context);
-int efa_ibv_req_notify_cq(struct efa_ibv_cq *ibv_cq, int solicited_only);
-
-#else
-/* For production, define static inline functions */
-
-/* QP wrapper functions */
-static inline int efa_qp_post_recv(struct efa_qp *qp, struct ibv_recv_wr *wr, struct ibv_recv_wr **bad)
-{
-#if HAVE_EFA_DATA_PATH_DIRECT
-	if (qp->data_path_direct_enabled)
-		return efa_data_path_direct_post_recv(qp, wr, bad);
-#endif
-	return ibv_post_recv(qp->ibv_qp, wr, bad);
-}
 
 /**
  * @brief RDMA-core version of send operation using ibv_* APIs
@@ -209,6 +162,55 @@ efa_ibv_post_write(
 	}
 
 	return 0;
+}
+
+
+#if EFA_UNIT_TEST
+/* For unit tests, declare functions that are defined in efa_unit_test_data_path_ops.c */
+int efa_qp_post_recv(struct efa_qp *qp, struct ibv_recv_wr *wr, struct ibv_recv_wr **bad);
+int efa_qp_post_send(struct efa_qp *qp, const struct ibv_sge *sge_list,
+		      const struct ibv_data_buf *inline_data_list,
+		      size_t iov_count, bool use_inline, uintptr_t wr_id,
+		      uint64_t data, uint64_t flags, struct efa_ah *ah,
+		      uint32_t qpn, uint32_t qkey);
+int efa_qp_post_read(struct efa_qp *qp, const struct ibv_sge *sge_list,
+		      size_t sge_count, uint32_t remote_key,
+		      uint64_t remote_addr, uintptr_t wr_id, uint64_t flags,
+		      struct efa_ah *ah, uint32_t qpn, uint32_t qkey);
+int efa_qp_post_write(struct efa_qp *qp, const struct ibv_sge *sge_list,
+		       size_t sge_count, uint32_t remote_key,
+		       uint64_t remote_addr, uintptr_t wr_id, uint64_t data,
+		       uint64_t flags, struct efa_ah *ah, uint32_t qpn,
+		       uint32_t qkey);
+int efa_ibv_cq_start_poll(struct efa_ibv_cq *ibv_cq, struct ibv_poll_cq_attr *attr);
+int efa_ibv_cq_next_poll(struct efa_ibv_cq *ibv_cq);
+enum ibv_wc_opcode efa_ibv_cq_wc_read_opcode(struct efa_ibv_cq *ibv_cq);
+void efa_ibv_cq_end_poll(struct efa_ibv_cq *ibv_cq);
+uint32_t efa_ibv_cq_wc_read_qp_num(struct efa_ibv_cq *ibv_cq);
+uint32_t efa_ibv_cq_wc_read_vendor_err(struct efa_ibv_cq *ibv_cq);
+uint32_t efa_ibv_cq_wc_read_src_qp(struct efa_ibv_cq *ibv_cq);
+uint32_t efa_ibv_cq_wc_read_slid(struct efa_ibv_cq *ibv_cq);
+uint32_t efa_ibv_cq_wc_read_byte_len(struct efa_ibv_cq *ibv_cq);
+unsigned int efa_ibv_cq_wc_read_wc_flags(struct efa_ibv_cq *ibv_cq);
+__be32 efa_ibv_cq_wc_read_imm_data(struct efa_ibv_cq *ibv_cq);
+bool efa_ibv_cq_wc_is_unsolicited(struct efa_ibv_cq *ibv_cq);
+
+int efa_ibv_cq_wc_read_sgid(struct efa_ibv_cq *ibv_cq, union ibv_gid *sgid);
+
+int efa_ibv_get_cq_event(struct efa_ibv_cq *ibv_cq, void **cq_context);
+int efa_ibv_req_notify_cq(struct efa_ibv_cq *ibv_cq, int solicited_only);
+
+#else
+/* For production, define static inline functions */
+
+/* QP wrapper functions */
+static inline int efa_qp_post_recv(struct efa_qp *qp, struct ibv_recv_wr *wr, struct ibv_recv_wr **bad)
+{
+#if HAVE_EFA_DATA_PATH_DIRECT
+	if (qp->data_path_direct_enabled)
+		return efa_data_path_direct_post_recv(qp, wr, bad);
+#endif
+	return ibv_post_recv(qp->ibv_qp, wr, bad);
 }
 
 /**


### PR DESCRIPTION
Current efa_ibv_post_* are defined only in non-unit-test build. Make them built for unit-test build as well so they can be unit-tested.