### PR TITLE
prov/efa: Revert fix pkt_enry double-free durig endpoint teardown

### DIFF
--- a/fabtests/prov/efa/src/multi_ep_stress.c
+++ b/fabtests/prov/efa/src/multi_ep_stress.c
@@ -1076,33 +1076,32 @@ static int run_sender(void)
 		}
 	}
 
-	// Wait for completion
-	for (int i = 0; i < topts.num_sender_workers; i++) {
-		void *retval;
-		ret = pthread_join(threads[i], &retval);
-		if (ret) {
-			FT_PRINTERR("pthread_join", ret);
-			goto out;
-		}
-		if (retval != NULL) {
-			ret = *(int *)retval;
-			free(retval);
-			fprintf(stderr,
-				"Sender %d failed. Exit code: %d, %s\n",
-				i, ret, fi_strerror(-ret));
-			goto out;
-		}
-	}
-
 out:
+	/* Always join all threads before cleanup to avoid
+	 * use-after-free from closing endpoints that worker
+	 * threads are still using.
+	 */
+	if (threads) {
+		for (int i = 0; i < topts.num_sender_workers; i++) {
+			if (!threads[i])
+				continue;
+			void *retval;
+			if (pthread_join(threads[i], &retval))
+				continue;
+			if (retval != NULL) {
+				if (!ret)
+					ret = *(int *)retval;
+				free(retval);
+			}
+		}
+		free(threads);
+	}
 	if (channels) {
 		for (int i = 0; i < topts.num_sender_workers; i++) {
-		       ep_message_queue_destroy(&channels[i]);
+			ep_message_queue_destroy(&channels[i]);
 		}
 		free(channels);
 	}
-	if (threads)
-		free(threads);
 	if (workers) {
 		for (int i = 0; i < topts.num_sender_workers; i++) {
 			cleanup_worker_resourses(&workers[i]);
@@ -1212,27 +1211,26 @@ static int run_receiver(void)
 		goto out;
 	}
 
-	// Wait for thread completion
-	for (int i = 0; i < topts.num_receiver_workers; i++) {
-		void *retval;
-		ret = pthread_join(threads[i], &retval);
-		if (ret) {
-			FT_PRINTERR("pthread_join", ret);
-			goto out;
-		}
-		if (retval != NULL) {
-			ret = *(int *)retval;
-			free(retval);
-			fprintf(stderr,
-				"Receiver %d failed. Exit code: %d, %s\n",
-				i, ret, fi_strerror(-ret));
-			goto out;
-		}
-	}
-
 out:
-	if (threads)
+	/* Always join all threads before cleanup to avoid
+	 * use-after-free from closing endpoints that worker
+	 * threads are still using.
+	 */
+	if (threads) {
+		for (int i = 0; i < topts.num_receiver_workers; i++) {
+			if (!threads[i])
+				continue;
+			void *retval;
+			if (pthread_join(threads[i], &retval))
+				continue;
+			if (retval != NULL) {
+				if (!ret)
+					ret = *(int *)retval;
+				free(retval);
+			}
+		}
 		free(threads);
+	}
 	if (workers) {
 		for (int i = 0; i < topts.num_receiver_workers; i++) {
 			cleanup_worker_resourses(&workers[i]);

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -726,6 +726,39 @@ static void efa_rdm_ep_destroy_buffer_pools(struct efa_rdm_ep *efa_rdm_ep)
 	struct efa_av_entry *av_entry;
 	struct efa_conn_ep_peer_map_entry *peer_map_entry;
 
+	/*
+	 * Destruct peers first so overflow packets are properly
+	 * released (including chained entries) and removed from
+	 * the debug lists before the debug sweep runs.
+	 */
+	dlist_foreach_container_safe (&efa_rdm_ep->ep_peer_list,
+				      struct efa_rdm_peer, peer,
+				      ep_peer_list_entry, tmp) {
+
+		if (peer->conn->fi_addr != FI_ADDR_UNSPEC) {
+			util_av_entry = ofi_bufpool_get_ibuf(
+				efa_rdm_ep->base_ep.av->util_av.av_entry_pool,
+				peer->conn->fi_addr);
+		} else {
+			assert(peer->conn->implicit_fi_addr != FI_ADDR_UNSPEC);
+
+			util_av_entry = ofi_bufpool_get_ibuf(
+				efa_rdm_ep->base_ep.av->util_av_implicit.av_entry_pool,
+				peer->conn->implicit_fi_addr);
+		}
+
+		dlist_remove(&peer->ep_peer_list_entry);
+
+		efa_rdm_peer_destruct(peer, efa_rdm_ep);
+
+		peer_map_entry = container_of(
+			peer, struct efa_conn_ep_peer_map_entry, peer);
+
+		av_entry = (struct efa_av_entry *) util_av_entry->data;
+		HASH_DEL(av_entry->conn.ep_peer_map, peer_map_entry);
+		ofi_buf_free(peer_map_entry);
+	}
+
 #if ENABLE_DEBUG
 	struct efa_rdm_pke *pkt_entry;
 
@@ -770,34 +803,6 @@ static void efa_rdm_ep_destroy_buffer_pools(struct efa_rdm_ep *efa_rdm_ep)
 		efa_rdm_txe_release(txe);
 	}
 
-	/* Clean up any remaining peers before destroying buffer pools */
-	dlist_foreach_container_safe (&efa_rdm_ep->ep_peer_list,
-				      struct efa_rdm_peer, peer,
-				      ep_peer_list_entry, tmp) {
-
-		if (peer->conn->fi_addr != FI_ADDR_UNSPEC) {
-			util_av_entry = ofi_bufpool_get_ibuf(
-				efa_rdm_ep->base_ep.av->util_av.av_entry_pool,
-				peer->conn->fi_addr);
-		} else {
-			assert(peer->conn->implicit_fi_addr != FI_ADDR_UNSPEC);
-
-			util_av_entry = ofi_bufpool_get_ibuf(
-				efa_rdm_ep->base_ep.av->util_av_implicit.av_entry_pool,
-				peer->conn->implicit_fi_addr);
-		}
-
-		dlist_remove(&peer->ep_peer_list_entry);
-
-		efa_rdm_peer_destruct(peer, efa_rdm_ep);
-
-		peer_map_entry = container_of(
-			peer, struct efa_conn_ep_peer_map_entry, peer);
-
-		av_entry = (struct efa_av_entry *) util_av_entry->data;
-		HASH_DEL(av_entry->conn.ep_peer_map, peer_map_entry);
-		ofi_buf_free(peer_map_entry);
-	}
 
 	if (efa_rdm_ep->ope_pool)
 		ofi_bufpool_destroy(efa_rdm_ep->ope_pool);

--- a/prov/efa/src/rdm/efa_rdm_peer.c
+++ b/prov/efa/src/rdm/efa_rdm_peer.c
@@ -87,7 +87,7 @@ void efa_rdm_peer_destruct(struct efa_rdm_peer *peer, struct efa_rdm_ep *ep)
 				     struct efa_rdm_peer_overflow_pke_list_entry,
 				     overflow_pke_list_entry, entry, tmp) {
 		dlist_remove(&overflow_pke_list_entry->entry);
-		efa_rdm_pke_release_rx(overflow_pke_list_entry->pkt_entry);
+		efa_rdm_pke_release_rx_list(overflow_pke_list_entry->pkt_entry);
 		ofi_buf_free(overflow_pke_list_entry);
 	}
 


### PR DESCRIPTION

This PR reverts commit `705742c` (`prov/efa: fix pkt_entry double-free during endpoint teardown`).

## Reason

A consistent failure started after this commit.

The failing tests involve:

- `fi_rma_pingpong -e rdm -o writedata -D neuron -R`
- double-node `trn1.32xlarge`
- Neuron HMEM via dmabuf
- both `host_to_neuron` writedata and `neuron_to_neuron` read-writedata variants
- AL2023 and Ubuntu 22.04
- dmabuf / non-dmabuf
- debug / non-debug builds

The observed symptom is `cq_readerr 107` with EFA provider errno `9`:

```text
QP does not exist or is in error state