### PR TITLE
fabtests: Add comment clarifying loop invariant in ft_spin_for_comp

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -2767,6 +2767,12 @@ static int ft_spin_for_comp(struct fid_cq *cq, uint64_t *cur,
 	if (timeout >= 0)
 		clock_gettime(CLOCK_MONOTONIC, &a);
 
+	/*
+	 * Callers must ensure *cur < total; calling with *cur >= total
+	 * is a bug because the do...while loop always executes at least
+	 * once and can increment *cur causing an underflow in the
+	 * loop condition.
+	 */
 	do {
 		ret = fi_cq_read(cq, &comp, 1);
 		if (ret > 0) {


### PR DESCRIPTION
The do...while loop in ft_spin_for_comp use unsigned subtraction
(total - *cur > 0) as the loop condition. This is correct as long as
callers maintain the invariant *cur <= total. Document this requirement
with a comment.