### PR TITLE
prov/rxm: add pluggable multi-QP routing with round-robin selector

### DIFF
--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -449,6 +449,7 @@
     <ClCompile Include="prov\rxm\src\rxm_hmem.c" />
     <ClCompile Include="prov\rxm\src\rxm_fabric.c" />
     <ClCompile Include="prov\rxm\src\rxm_atomic.c" />
+    <ClCompile Include="prov\rxm\src\rxm_ep_selector.c" />
     <ClCompile Include="prov\rxm\src\rxm_init.c">
       <ForcedIncludeFiles Condition="'$(Configuration)|$(Platform)'=='Debug-v140|x64'">
       </ForcedIncludeFiles>
@@ -991,6 +992,7 @@
     <ClInclude Include="prov\rxd\src\rxd.h" />
     <ClInclude Include="prov\rxd\src\rxd_proto.h" />
     <ClInclude Include="prov\rxm\src\rxm.h" />
+    <ClInclude Include="prov\rxm\src\rxm_ep_selector.h" />
     <ClInclude Include="prov\sockets\include\sock.h" />
     <ClInclude Include="prov\sockets\include\sock_util.h" />
     <ClInclude Include="prov\udp\src\udpx.h" />

--- a/prov/rxm/Makefile.include
+++ b/prov/rxm/Makefile.include
@@ -13,6 +13,8 @@ _rxm_files = \
        prov/rxm/src/rxm_atomic.c	\
        prov/rxm/src/rxm_eq.c	\
        prov/rxm/src/rxm_hmem.c	\
+       prov/rxm/src/rxm_ep_selector.c	\
+       prov/rxm/src/rxm_ep_selector.h	\
        prov/rxm/src/rxm.h
 
 if HAVE_RXM_DL

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -57,6 +57,8 @@
 #include <ofi_iov.h>
 #include <ofi_hmem.h>
 
+#include "rxm_ep_selector.h"
+
 #ifndef _RXM_H_
 #define _RXM_H_
 
@@ -230,7 +232,9 @@ enum {
 struct rxm_conn {
 	enum rxm_cm_state state;
 	struct util_peer_addr *peer;
-	struct fid_ep *msg_ep;
+	struct fid_ep **msg_eps;
+	uint8_t num_msg_eps;
+	const struct rxm_ep_selector *selector;
 	struct rxm_ep *ep;
 
 	/* Prior versions of libfabric did not guarantee that all connections
@@ -786,6 +790,15 @@ static inline size_t rxm_ep_max_atomic_size(struct fi_info *info)
 	return rxm_buffer_size - sizeof(struct rxm_atomic_hdr);
 }
 
+static inline struct fid_ep *
+rxm_conn_msg_ep(struct rxm_conn *conn, const struct rxm_pkt *pkt)
+{
+	uint8_t idx = conn->selector->select(conn, pkt);
+
+	assert(idx < conn->num_msg_eps);
+	return conn->msg_eps[idx];
+}
+
 static inline ssize_t
 rxm_atomic_send_respmsg(struct rxm_ep *rxm_ep, struct rxm_conn *conn,
 			struct rxm_tx_buf *resp_buf, ssize_t len)
@@ -801,7 +814,8 @@ rxm_atomic_send_respmsg(struct rxm_ep *rxm_ep, struct rxm_conn *conn,
 		.context = resp_buf,
 		.data = 0,
 	};
-	return fi_sendmsg(conn->msg_ep, &msg, FI_COMPLETION);
+	return fi_sendmsg(rxm_conn_msg_ep(conn, &resp_buf->pkt),
+			  &msg, FI_COMPLETION);
 }
 
 void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
@@ -901,7 +915,7 @@ rxm_free_rx_buf(struct rxm_rx_buf *rx_buf)
 	}
 
 	/* Discard rx buffer if its msg_ep was closed */
-	if (rx_buf->repost && (rx_buf->ep->msg_srx || rx_buf->conn->msg_ep)) {
+	if (rx_buf->repost && (rx_buf->ep->msg_srx || rx_buf->conn->msg_eps[0])) {
 		rxm_post_recv(rx_buf);
 	} else {
 		ofi_buf_free(rx_buf);

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -234,7 +234,7 @@ struct rxm_conn {
 	struct util_peer_addr *peer;
 	struct fid_ep **msg_eps;
 	uint8_t num_msg_eps;
-	const struct rxm_ep_selector *selector;
+	struct rxm_ep_selector *selector;
 	struct rxm_ep *ep;
 
 	/* Prior versions of libfabric did not guarantee that all connections
@@ -915,7 +915,9 @@ rxm_free_rx_buf(struct rxm_rx_buf *rx_buf)
 	}
 
 	/* Discard rx buffer if its msg_ep was closed */
-	if (rx_buf->repost && (rx_buf->ep->msg_srx || rx_buf->conn->msg_eps[0])) {
+	if (rx_buf->repost &&
+	    (rx_buf->ep->msg_srx ||
+	     (rx_buf->conn->msg_eps && rx_buf->conn->msg_eps[0]))) {
 		rxm_post_recv(rx_buf);
 	} else {
 		ofi_buf_free(rx_buf);

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -208,6 +208,7 @@ extern int rxm_passthru;
 extern int force_auto_progress;
 extern int rxm_use_write_rndv;
 extern int rxm_detect_hmem_iface;
+extern size_t rxm_num_msg_eps;
 extern enum fi_wait_obj def_wait_obj, def_tcp_wait_obj;
 
 struct rxm_ep;

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -797,6 +797,10 @@ rxm_conn_msg_ep(struct rxm_conn *conn, const struct rxm_pkt *pkt)
 	uint8_t idx = conn->selector->select(conn, pkt);
 
 	assert(idx < conn->num_msg_eps);
+	FI_DBG(&rxm_prov, FI_LOG_EP_DATA,
+	       "ep_sel: conn=%p ctrl=%u msg_id=0x%" PRIx64 " -> ep=%u/%u\n",
+	       conn, pkt ? pkt->ctrl_hdr.type : 0xff,
+	       pkt ? pkt->ctrl_hdr.msg_id : 0, idx, conn->num_msg_eps);
 	return conn->msg_eps[idx];
 }
 

--- a/prov/rxm/src/rxm_atomic.c
+++ b/prov/rxm/src/rxm_atomic.c
@@ -69,9 +69,11 @@ rxm_ep_send_atomic_req(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	 * software generated atomic response message is received. */
 	tx_buf->hdr.state = RXM_ATOMIC_RESP_WAIT;
 	if (len <= rxm_ep->inject_limit)
-		ret = fi_inject(rxm_conn->msg_ep, &tx_buf->pkt, len, 0);
+		ret = fi_inject(rxm_conn_msg_ep(rxm_conn, &tx_buf->pkt),
+				&tx_buf->pkt, len, 0);
 	else
-		ret = fi_send(rxm_conn->msg_ep, &tx_buf->pkt, len,
+		ret = fi_send(rxm_conn_msg_ep(rxm_conn, &tx_buf->pkt),
+			      &tx_buf->pkt, len,
 			      tx_buf->hdr.desc, 0, tx_buf);
 	if (ret == -FI_EAGAIN)
 		rxm_ep_do_progress(&rxm_ep->util_ep);

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -354,6 +354,10 @@ static void rxm_free_conn(struct rxm_conn *conn)
 	if (conn->flags & RXM_CONN_INDEXED)
 		ofi_idm_clear(&conn->ep->conn_idx_map, conn->peer->index);
 
+	if (conn->selector && conn->selector->destroy)
+		conn->selector->destroy(conn->selector);
+	conn->selector = NULL;
+
 	util_put_peer(conn->peer);
 	av = container_of(conn->ep->util_ep.av, struct rxm_av, util_av);
 	rxm_av_free_conn(av, conn);
@@ -426,7 +430,13 @@ rxm_alloc_conn(struct rxm_ep *ep, struct util_peer_addr *peer)
 
 	conn->num_msg_eps = 1;
 	conn->msg_eps = NULL;
-	conn->selector = &rxm_selector_single_ep;
+	conn->selector = rxm_rr_selector_alloc();
+	if (!conn->selector) {
+		RXM_WARN_ERR(FI_LOG_EP_CTRL, "rxm_rr_selector_alloc", -FI_ENOMEM);
+		util_put_peer(peer);
+		rxm_av_free_conn(av, conn);
+		return NULL;
+	}
 
 	FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "allocated conn %p\n", conn);
 	return conn;

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -79,10 +79,8 @@ static void rxm_close_conn(struct rxm_conn *conn)
 		rx_entry = (struct fi_peer_rx_entry*)conn->deferred_sar_msgs.next;
 		rx_entry->srx->owner_ops->free_entry(rx_entry);
 	}
-	for (int i = 0; i < conn->num_msg_eps; i++) {
-		if (conn->msg_eps && conn->msg_eps[i])
-			fi_close(&conn->msg_eps[i]->fid);
-	}
+	if (conn->msg_eps && conn->msg_eps[0])
+		fi_close(&conn->msg_eps[0]->fid);
 	rxm_flush_msg_cq(conn->ep);
 	dlist_remove_init(&conn->loopback_entry);
 	free(conn->msg_eps);
@@ -222,13 +220,13 @@ static int rxm_open_conn(struct rxm_conn *conn, struct fi_info *msg_info)
 			goto err;
 	}
 
-	assert(conn->num_msg_eps == 1);
 	conn->msg_eps = calloc(conn->num_msg_eps, sizeof(*conn->msg_eps));
 	if (!conn->msg_eps) {
 		ret = -FI_ENOMEM;
 		goto err;
 	}
-	conn->msg_eps[0] = msg_ep;
+	for (uint8_t i = 0; i < conn->num_msg_eps; i++)
+		conn->msg_eps[i] = msg_ep;
 	return 0;
 err:
 	fi_close(&msg_ep->fid);
@@ -309,10 +307,8 @@ static int rxm_send_connect(struct rxm_conn *conn)
 	return 0;
 
 err:
-	for (int i = 0; i < conn->num_msg_eps; i++) {
-		if (conn->msg_eps && conn->msg_eps[i])
-			fi_close(&conn->msg_eps[i]->fid);
-	}
+	if (conn->msg_eps && conn->msg_eps[0])
+		fi_close(&conn->msg_eps[0]->fid);
 	free(conn->msg_eps);
 	conn->msg_eps = NULL;
 	return ret;
@@ -428,14 +424,29 @@ rxm_alloc_conn(struct rxm_ep *ep, struct util_peer_addr *peer)
 	conn->peer = peer;
 	rxm_ref_peer(peer);
 
-	conn->num_msg_eps = 1;
+	conn->num_msg_eps = (uint8_t) rxm_num_msg_eps;
+	if (conn->num_msg_eps > 1 &&
+	    strncasecmp(ep->msg_info->fabric_attr->prov_name, "verbs",
+			strlen("verbs"))) {
+		FI_INFO(&rxm_prov, FI_LOG_EP_CTRL,
+			"num_msg_eps > 1 not supported over %s, clamping to 1\n",
+			ep->msg_info->fabric_attr->prov_name);
+		conn->num_msg_eps = 1;
+	}
 	conn->msg_eps = NULL;
-	conn->selector = rxm_rr_selector_alloc();
-	if (!conn->selector) {
-		RXM_WARN_ERR(FI_LOG_EP_CTRL, "rxm_rr_selector_alloc", -FI_ENOMEM);
-		util_put_peer(peer);
-		rxm_av_free_conn(av, conn);
-		return NULL;
+
+	if (conn->num_msg_eps > 1) {
+		conn->selector = rxm_rr_selector_alloc();
+		if (!conn->selector) {
+			RXM_WARN_ERR(FI_LOG_EP_CTRL, "rxm_rr_selector_alloc",
+				     -FI_ENOMEM);
+			util_put_peer(peer);
+			rxm_av_free_conn(av, conn);
+			return NULL;
+		}
+	} else {
+		conn->selector =
+			(struct rxm_ep_selector *) &rxm_selector_single_ep;
 	}
 
 	FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "allocated conn %p\n", conn);

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -79,10 +79,14 @@ static void rxm_close_conn(struct rxm_conn *conn)
 		rx_entry = (struct fi_peer_rx_entry*)conn->deferred_sar_msgs.next;
 		rx_entry->srx->owner_ops->free_entry(rx_entry);
 	}
-	fi_close(&conn->msg_ep->fid);
+	for (int i = 0; i < conn->num_msg_eps; i++) {
+		if (conn->msg_eps && conn->msg_eps[i])
+			fi_close(&conn->msg_eps[i]->fid);
+	}
 	rxm_flush_msg_cq(conn->ep);
 	dlist_remove_init(&conn->loopback_entry);
-	conn->msg_ep = NULL;
+	free(conn->msg_eps);
+	conn->msg_eps = NULL;
 
 	if (conn->state == RXM_CM_CONNECTING || conn->state == RXM_CM_ACCEPTING)
 		conn->ep->connecting_cnt--;
@@ -218,7 +222,13 @@ static int rxm_open_conn(struct rxm_conn *conn, struct fi_info *msg_info)
 			goto err;
 	}
 
-	conn->msg_ep = msg_ep;
+	assert(conn->num_msg_eps == 1);
+	conn->msg_eps = calloc(conn->num_msg_eps, sizeof(*conn->msg_eps));
+	if (!conn->msg_eps) {
+		ret = -FI_ENOMEM;
+		goto err;
+	}
+	conn->msg_eps[0] = msg_ep;
 	return 0;
 err:
 	fi_close(&msg_ep->fid);
@@ -288,7 +298,7 @@ static int rxm_send_connect(struct rxm_conn *conn)
 	if (ret)
 		goto err;
 
-	ret = fi_connect(conn->msg_ep, info->dest_addr, &cm_data,
+	ret = fi_connect(conn->msg_eps[0], info->dest_addr, &cm_data,
 			 sizeof(cm_data));
 	if (ret) {
 		RXM_WARN_ERR(FI_LOG_EP_CTRL, "fi_connect", ret);
@@ -299,8 +309,12 @@ static int rxm_send_connect(struct rxm_conn *conn)
 	return 0;
 
 err:
-	fi_close(&conn->msg_ep->fid);
-	conn->msg_ep = NULL;
+	for (int i = 0; i < conn->num_msg_eps; i++) {
+		if (conn->msg_eps && conn->msg_eps[i])
+			fi_close(&conn->msg_eps[i]->fid);
+	}
+	free(conn->msg_eps);
+	conn->msg_eps = NULL;
 	return ret;
 }
 
@@ -410,6 +424,10 @@ rxm_alloc_conn(struct rxm_ep *ep, struct util_peer_addr *peer)
 	conn->peer = peer;
 	rxm_ref_peer(peer);
 
+	conn->num_msg_eps = 1;
+	conn->msg_eps = NULL;
+	conn->selector = &rxm_selector_single_ep;
+
 	FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "allocated conn %p\n", conn);
 	return conn;
 }
@@ -516,7 +534,7 @@ void rxm_process_connect(struct rxm_eq_cm_entry *cm_entry)
 	if (conn->flow_ctrl && conn->peer_flow_ctrl) {
 		domain = container_of(conn->ep->util_ep.domain,
 				      struct rxm_domain, util_domain);
-		domain->flow_ctrl_ops->enable(conn->msg_ep,
+		domain->flow_ctrl_ops->enable(conn->msg_eps[0],
 					      conn->ep->msg_info->rx_attr->size / 2);
 	}
 
@@ -634,7 +652,7 @@ rxm_accept_connreq(struct rxm_conn *conn, struct rxm_eq_cm_entry *cm_entry)
 	cm_data.accept.align_pad[1] = 0;
 	cm_data.accept.align_pad[2] = 0;
 
-	ret = fi_accept(conn->msg_ep, &cm_data.accept, sizeof(cm_data.accept));
+	ret = fi_accept(conn->msg_eps[0], &cm_data.accept, sizeof(cm_data.accept));
 	if (ret)
 		RXM_WARN_ERR(FI_LOG_EP_CTRL, "fi_accept", ret);
 	return ret;

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -587,7 +587,8 @@ ssize_t rxm_rndv_read(struct rxm_rx_buf *rx_buf)
 	rx_buf->peer_entry->msg_size = total_len;
 	RXM_UPDATE_STATE(FI_LOG_CQ, rx_buf, RXM_RNDV_READ);
 
-	ret = rxm_rndv_xfer(rx_buf->ep, rx_buf->conn->msg_ep,
+	ret = rxm_rndv_xfer(rx_buf->ep,
+			    rxm_conn_msg_ep(rx_buf->conn, NULL),
 			    rx_buf->remote_rndv_hdr,
 			    rx_buf->peer_entry->iov,
 			    rx_buf->peer_entry->desc,
@@ -653,7 +654,9 @@ static ssize_t rxm_rndv_handle_wr_data(struct rxm_rx_buf *rx_buf)
 	else
 		RXM_UPDATE_STATE(FI_LOG_CQ, tx_buf, RXM_RNDV_WRITE_TX_WAIT);
 
-	ret = rxm_rndv_xfer(rx_buf->ep, tx_buf->write_rndv.conn->msg_ep, rx_hdr,
+	ret = rxm_rndv_xfer(rx_buf->ep,
+			    rxm_conn_msg_ep(tx_buf->write_rndv.conn, NULL),
+			    rx_hdr,
 			    tx_buf->write_rndv.iov, tx_buf->write_rndv.desc,
 			    tx_buf->rma.count, total_len, tx_buf);
 
@@ -914,7 +917,8 @@ static void rxm_rndv_send_rd_done(struct rxm_rx_buf *rx_buf)
 	buf->pkt.ctrl_hdr.conn_id = rx_buf->conn->remote_index;
 	buf->pkt.ctrl_hdr.msg_id = rx_buf->pkt.ctrl_hdr.msg_id;
 
-	ret = fi_send(rx_buf->conn->msg_ep, &buf->pkt, sizeof(buf->pkt),
+	ret = fi_send(rxm_conn_msg_ep(rx_buf->conn, &buf->pkt),
+		      &buf->pkt, sizeof(buf->pkt),
 		      buf->hdr.desc, 0, rx_buf);
 	if (ret) {
 		if (ret == -FI_EAGAIN) {
@@ -969,7 +973,8 @@ rxm_rndv_send_wr_done(struct rxm_ep *rxm_ep, struct rxm_tx_buf *tx_buf)
 	buf->pkt.ctrl_hdr.conn_id = tx_buf->pkt.ctrl_hdr.conn_id;
 	buf->pkt.ctrl_hdr.msg_id = tx_buf->pkt.ctrl_hdr.msg_id;
 
-	ret = fi_send(tx_buf->write_rndv.conn->msg_ep, &buf->pkt,
+	ret = fi_send(rxm_conn_msg_ep(tx_buf->write_rndv.conn, &buf->pkt),
+		      &buf->pkt,
 		      sizeof(buf->pkt), buf->hdr.desc, 0, tx_buf);
 	if (ret) {
 		if (ret == -FI_EAGAIN) {
@@ -1033,7 +1038,8 @@ ssize_t rxm_rndv_send_wr_data(struct rxm_rx_buf *rx_buf)
 			  rx_buf->peer_entry->iov,
 			  rx_buf->peer_entry->count, rx_buf->mr);
 
-	ret = fi_send(rx_buf->conn->msg_ep, &buf->pkt, sizeof(buf->pkt) +
+	ret = fi_send(rxm_conn_msg_ep(rx_buf->conn, &buf->pkt),
+		      &buf->pkt, sizeof(buf->pkt) +
 		      sizeof(struct rxm_rndv_hdr), buf->hdr.desc, 0, rx_buf);
 	if (ret) {
 		if (ret == -FI_EAGAIN) {
@@ -1119,7 +1125,8 @@ static ssize_t rxm_atomic_send_resp(struct rxm_ep *rxm_ep,
 	atomic_hdr->result_len = htonl((uint32_t) result_len);
 
 	if (tot_len < rxm_ep->inject_limit) {
-		ret = fi_inject(rx_buf->conn->msg_ep, &resp_buf->pkt,
+		ret = fi_inject(rxm_conn_msg_ep(rx_buf->conn, &resp_buf->pkt),
+				&resp_buf->pkt,
 				tot_len, 0);
 		if (!ret)
 			ofi_buf_free(resp_buf);

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -460,7 +460,9 @@ rxm_ep_progress_sar_deferred_segments(struct rxm_deferred_tx_entry *def_tx_entry
 	struct rxm_tx_buf *tx_buf = def_tx_entry->sar_seg.cur_seg_tx_buf;
 
 	if (tx_buf) {
-		ret = fi_send(def_tx_entry->rxm_conn->msg_ep, &tx_buf->pkt,
+		ret = fi_send(rxm_conn_msg_ep(def_tx_entry->rxm_conn,
+					      &tx_buf->pkt),
+			      &tx_buf->pkt,
 			      sizeof(tx_buf->pkt) + tx_buf->pkt.ctrl_hdr.seg_size,
 			      tx_buf->hdr.desc, 0, tx_buf);
 		if (ret) {
@@ -535,7 +537,8 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 		switch (def_tx_entry->type) {
 		case RXM_DEFERRED_TX_RNDV_ACK:
 			proto_info = def_tx_entry->rndv_ack.rx_buf->proto_info;
-			ret = fi_send(def_tx_entry->rxm_conn->msg_ep,
+			ret = fi_send(rxm_conn_msg_ep(def_tx_entry->rxm_conn,
+						      &proto_info->rndv.tx_buf->pkt),
 				      &proto_info->rndv.tx_buf->pkt,
 				      def_tx_entry->rndv_ack.pkt_size,
 				      proto_info->rndv.tx_buf->hdr.desc,
@@ -559,7 +562,8 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 						 RXM_RNDV_WRITE_DATA_SENT);
 			break;
 		case RXM_DEFERRED_TX_RNDV_DONE:
-			ret = fi_send(def_tx_entry->rxm_conn->msg_ep,
+			ret = fi_send(rxm_conn_msg_ep(def_tx_entry->rxm_conn,
+						      &def_tx_entry->rndv_done.tx_buf->pkt),
 				      &def_tx_entry->rndv_done.tx_buf->write_rndv.done_buf->pkt,
 				      sizeof(struct rxm_pkt),
 				      def_tx_entry->rndv_done.tx_buf->write_rndv.done_buf->hdr.desc,
@@ -578,7 +582,7 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 			break;
 		case RXM_DEFERRED_TX_RNDV_READ:
 			ret = rxm_ep->rndv_ops->xfer(
-				def_tx_entry->rxm_conn->msg_ep,
+				rxm_conn_msg_ep(def_tx_entry->rxm_conn, NULL),
 				def_tx_entry->rndv_read.rxm_iov.iov,
 				def_tx_entry->rndv_read.rxm_iov.desc,
 				def_tx_entry->rndv_read.rxm_iov.count, 0,
@@ -596,7 +600,7 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 			break;
 		case RXM_DEFERRED_TX_RNDV_WRITE:
 			ret = rxm_ep->rndv_ops->xfer(
-				def_tx_entry->rxm_conn->msg_ep,
+				rxm_conn_msg_ep(def_tx_entry->rxm_conn, NULL),
 				def_tx_entry->rndv_write.rxm_iov.iov,
 				def_tx_entry->rndv_write.rxm_iov.desc,
 				def_tx_entry->rndv_write.rxm_iov.count, 0,
@@ -636,8 +640,9 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 			msg.iov_count = 1;
 			msg.msg_iov = &iov;
 
-			ret = fi_sendmsg(def_tx_entry->rxm_conn->msg_ep, &msg,
-					 OFI_PRIORITY);
+			ret = fi_sendmsg(rxm_conn_msg_ep(def_tx_entry->rxm_conn,
+							 &def_tx_entry->credit_msg.tx_buf->pkt),
+					 &msg, OFI_PRIORITY);
 			if (ret) {
 				if (ret != -FI_EAGAIN) {
 					rxm_cq_write_rx_error(

--- a/prov/rxm/src/rxm_ep_selector.c
+++ b/prov/rxm/src/rxm_ep_selector.c
@@ -1,0 +1,14 @@
+#include "rxm.h"
+#include "rxm_ep_selector.h"
+
+static uint8_t rxm_single_ep_select(struct rxm_conn *conn,
+				    const struct rxm_pkt *pkt)
+{
+	OFI_UNUSED(conn);
+	OFI_UNUSED(pkt);
+	return 0;
+}
+
+const struct rxm_ep_selector rxm_selector_single_ep = {
+	.select = rxm_single_ep_select,
+};

--- a/prov/rxm/src/rxm_ep_selector.c
+++ b/prov/rxm/src/rxm_ep_selector.c
@@ -1,3 +1,5 @@
+#include <stdlib.h>
+
 #include "rxm.h"
 #include "rxm_ep_selector.h"
 
@@ -11,4 +13,82 @@ static uint8_t rxm_single_ep_select(struct rxm_conn *conn,
 
 const struct rxm_ep_selector rxm_selector_single_ep = {
 	.select = rxm_single_ep_select,
+	.destroy = NULL,
 };
+
+static uint8_t rxm_rr_next(struct rxm_rr_selector *rr, struct rxm_conn *conn)
+{
+	if (conn->num_msg_eps <= 1)
+		return 0;
+	return 1 + (rr->rr_counter++ % (conn->num_msg_eps - 1));
+}
+
+static uint8_t rxm_rr_select(struct rxm_conn *conn, const struct rxm_pkt *pkt)
+{
+	struct rxm_rr_selector *rr =
+		container_of(conn->selector, struct rxm_rr_selector, base);
+	enum rxm_sar_seg_type seg_type;
+	uint64_t msg_id;
+	void *slot;
+	uint8_t idx;
+
+	if (!pkt)
+                // RMA / rndv-RMA .
+		return rxm_rr_next(rr, conn);
+
+	if (pkt->ctrl_hdr.type != rxm_ctrl_seg)
+                // Not SAR
+		return 0;
+
+	seg_type = rxm_sar_get_seg_type((struct ofi_ctrl_hdr *) &pkt->ctrl_hdr);
+	msg_id = pkt->ctrl_hdr.msg_id;
+
+	switch (seg_type) {
+	case RXM_SAR_SEG_MIDDLE:
+		slot = ofi_idm_lookup(&rr->sar_pins, (int) msg_id);
+		if (slot)
+			return (uint8_t)((uintptr_t) slot - 1);
+		idx = rxm_rr_next(rr, conn);
+		/* On map-grow OOM, fall back to ep 0 for the rest of this
+		 * SAR message. Subsequent segments will also miss the
+		 * lookup and land on 0, preserving in-order delivery. */
+		if (ofi_idm_set(&rr->sar_pins, (int) msg_id,
+				(void *)(uintptr_t)(idx + 1)) < 0)
+			return 0;
+		return idx;
+
+	case RXM_SAR_SEG_LAST:
+		slot = ofi_idm_lookup(&rr->sar_pins, (int) msg_id);
+		if (slot) {
+			ofi_idm_clear(&rr->sar_pins, (int) msg_id);
+			return (uint8_t)((uintptr_t) slot - 1);
+		}
+		return rxm_rr_next(rr, conn);
+
+	default:
+                // SAR first
+		return 0;
+	}
+}
+
+static void rxm_rr_destroy(struct rxm_ep_selector *sel)
+{
+	struct rxm_rr_selector *rr =
+		container_of(sel, struct rxm_rr_selector, base);
+
+	/* Stored values are (idx + 1) cast to void*, not heap pointers. */
+	ofi_idm_reset(&rr->sar_pins, NULL);
+	free(rr);
+}
+
+struct rxm_ep_selector *rxm_rr_selector_alloc(void)
+{
+	struct rxm_rr_selector *rr = calloc(1, sizeof(*rr));
+
+	if (!rr)
+		return NULL;
+
+	rr->base.select = rxm_rr_select;
+	rr->base.destroy = rxm_rr_destroy;
+	return &rr->base;
+}

--- a/prov/rxm/src/rxm_ep_selector.h
+++ b/prov/rxm/src/rxm_ep_selector.h
@@ -1,0 +1,15 @@
+#ifndef RXM_EP_SELECTOR_H
+#define RXM_EP_SELECTOR_H
+
+#include <stdint.h>
+
+struct rxm_conn;
+struct rxm_pkt;
+
+struct rxm_ep_selector {
+	uint8_t (*select)(struct rxm_conn *conn, const struct rxm_pkt *pkt);
+};
+
+extern const struct rxm_ep_selector rxm_selector_single_ep;
+
+#endif /* RXM_EP_SELECTOR_H */

--- a/prov/rxm/src/rxm_ep_selector.h
+++ b/prov/rxm/src/rxm_ep_selector.h
@@ -3,13 +3,28 @@
 
 #include <stdint.h>
 
+#include <ofi_indexer.h>
+
 struct rxm_conn;
 struct rxm_pkt;
 
 struct rxm_ep_selector {
 	uint8_t (*select)(struct rxm_conn *conn, const struct rxm_pkt *pkt);
+	void (*destroy)(struct rxm_ep_selector *sel);
+};
+
+struct rxm_rr_selector {
+	struct rxm_ep_selector base;
+	uint32_t rr_counter;
+	/* msg_id -> (ep_idx + 1) encoded as void*; entry present means
+	 * the SAR message is pinned to that ep. Absent (NULL) means no
+	 * pin yet. +1 encoding distinguishes "pinned to ep 0" from
+	 * "not present". */
+	struct index_map sar_pins;
 };
 
 extern const struct rxm_ep_selector rxm_selector_single_ep;
+
+struct rxm_ep_selector *rxm_rr_selector_alloc(void);
 
 #endif /* RXM_EP_SELECTOR_H */

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -60,6 +60,7 @@ int force_auto_progress;
 int rxm_use_write_rndv;
 int rxm_detect_hmem_iface;
 int rxm_rescan = -1;
+size_t rxm_num_msg_eps = 1;
 enum fi_wait_obj def_wait_obj = FI_WAIT_FD, def_tcp_wait_obj = FI_WAIT_UNSPEC;
 
 char *rxm_proto_state_str[] = {
@@ -708,6 +709,12 @@ RXM_INI
 			"in. This allows such buffers be copied or registered "
 			"internally by RxM. (default: false).");
 
+	fi_param_define(&rxm_prov, "num_msg_eps", FI_PARAM_SIZE_T,
+			"Number of msg endpoints to open per rxm connection "
+			"for multi-ep routing. Currently all slots alias the "
+			"first real msg_ep; the selector still picks among "
+			"them. (default: 1)");
+
 	fi_param_define(&rxm_prov, "rescan", FI_PARAM_BOOL,
 			"Force or disable rescanning for network interface changes. "
 			"Setting this to true will force rescanning on each fi_getinfo() invocation; "
@@ -740,6 +747,11 @@ RXM_INI
 
 	fi_param_get_bool(&rxm_prov, "detect_hmem_iface", &rxm_detect_hmem_iface);
 	fi_param_get_bool(&rxm_prov, "rescan", &rxm_rescan);
+	fi_param_get_size_t(&rxm_prov, "num_msg_eps", &rxm_num_msg_eps);
+	if (rxm_num_msg_eps < 1)
+		rxm_num_msg_eps = 1;
+	if (rxm_num_msg_eps > UINT8_MAX)
+		rxm_num_msg_eps = UINT8_MAX;
 
 #if HAVE_RXM_DL
 	ofi_mem_init();

--- a/prov/rxm/src/rxm_msg.c
+++ b/prov/rxm/src/rxm_msg.c
@@ -163,10 +163,12 @@ rxm_send_rndv(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 			RXM_UPDATE_STATE(FI_LOG_EP_DATA, tx_buf,
 					 RXM_RNDV_READ_DONE_WAIT);
 
-		ret = fi_inject(rxm_conn->msg_ep, &tx_buf->pkt, pkt_size, 0);
+		ret = fi_inject(rxm_conn_msg_ep(rxm_conn, &tx_buf->pkt),
+				&tx_buf->pkt, pkt_size, 0);
 	} else {
 		RXM_UPDATE_STATE(FI_LOG_EP_DATA, tx_buf, RXM_RNDV_TX);
-		ret = fi_send(rxm_conn->msg_ep, &tx_buf->pkt, pkt_size,
+		ret = fi_send(rxm_conn_msg_ep(rxm_conn, &tx_buf->pkt),
+			      &tx_buf->pkt, pkt_size,
 			      tx_buf->hdr.desc, 0, tx_buf);
 	}
 
@@ -258,7 +260,8 @@ rxm_send_segment(struct rxm_ep *rxm_ep,
 
 	*out_tx_buf = tx_buf;
 
-	return fi_send(rxm_conn->msg_ep, &tx_buf->pkt, sizeof(struct rxm_pkt) +
+	return fi_send(rxm_conn_msg_ep(rxm_conn, &tx_buf->pkt),
+		       &tx_buf->pkt, sizeof(struct rxm_pkt) +
 		       tx_buf->pkt.ctrl_hdr.seg_size, tx_buf->hdr.desc, 0, tx_buf);
 }
 
@@ -292,7 +295,8 @@ rxm_send_sar(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 
 	iov_offset += rxm_buffer_size;
 
-	ret = fi_send(rxm_conn->msg_ep, &first_tx_buf->pkt,
+	ret = fi_send(rxm_conn_msg_ep(rxm_conn, &first_tx_buf->pkt),
+		      &first_tx_buf->pkt,
 		      sizeof(struct rxm_pkt) + first_tx_buf->pkt.ctrl_hdr.seg_size,
 		      first_tx_buf->hdr.desc, 0, first_tx_buf);
 	if (ret) {
@@ -372,7 +376,8 @@ rxm_emulate_inject(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 				 &tx_buf->pkt);
 	memcpy(tx_buf->pkt.data, buf, len);
 
-	ret = fi_send(rxm_conn->msg_ep, &tx_buf->pkt, pkt_size,
+	ret = fi_send(rxm_conn_msg_ep(rxm_conn, &tx_buf->pkt),
+		      &tx_buf->pkt, pkt_size,
 		      tx_buf->hdr.desc, 0, tx_buf);
 	if (ret) {
 		if (ret == -FI_EAGAIN)
@@ -396,7 +401,8 @@ rxm_inject_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	if (pkt_size <= rxm_ep->inject_limit && !rxm_ep->util_ep.cntrs[CNTR_TX]) {
 		inject_pkt->hdr.size = len;
 		memcpy(inject_pkt->data, buf, len);
-		ret = fi_inject(rxm_conn->msg_ep, inject_pkt, pkt_size, 0);
+		ret = fi_inject(rxm_conn_msg_ep(rxm_conn, inject_pkt),
+				inject_pkt, pkt_size, 0);
 	} else {
 		ret = rxm_emulate_inject(rxm_ep, rxm_conn, buf, len,
 					 pkt_size, inject_pkt->hdr.data,
@@ -438,10 +444,12 @@ rxm_direct_send(struct rxm_ep *ep, struct rxm_conn *rxm_conn,
 			send_desc[i + 1] = fi_mr_desc(mr->msg_mr);
 		}
 
-		ret = fi_sendv(rxm_conn->msg_ep, send_iov, send_desc,
+		ret = fi_sendv(rxm_conn_msg_ep(rxm_conn, &tx_buf->pkt),
+			       send_iov, send_desc,
 			       count + 1, 0, tx_buf);
 	} else {
-		ret = fi_sendv(rxm_conn->msg_ep, send_iov, NULL,
+		ret = fi_sendv(rxm_conn_msg_ep(rxm_conn, &tx_buf->pkt),
+			       send_iov, NULL,
 			       count + 1, 0, tx_buf);
 	}
 	return ret;
@@ -476,7 +484,8 @@ rxm_send_eager(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 					     eager_buf->pkt.hdr.size, iov,
 					     count, 0);
 		assert((size_t) ret == eager_buf->pkt.hdr.size);
-		ret = fi_send(rxm_conn->msg_ep, &eager_buf->pkt, total_len,
+		ret = fi_send(rxm_conn_msg_ep(rxm_conn, &eager_buf->pkt),
+			      &eager_buf->pkt, total_len,
 			      eager_buf->hdr.desc, 0, eager_buf);
 	}
 
@@ -769,7 +778,8 @@ rxm_send_thru(struct fid_ep *ep_fid, const void *buf, size_t len,
 	if (ret)
 		goto unlock;
 
-	ret = fi_send(conn->msg_ep, buf, len, desc, 0, context);
+	ret = fi_send(rxm_conn_msg_ep(conn, NULL),
+		      buf, len, desc, 0, context);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -790,7 +800,8 @@ rxm_sendv_thru(struct fid_ep *ep_fid, const struct iovec *iov,
 	if (ret)
 		goto unlock;
 
-	ret = fi_sendv(conn->msg_ep, iov, desc, count, 0, context);
+	ret = fi_sendv(rxm_conn_msg_ep(conn, NULL),
+		       iov, desc, count, 0, context);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -811,7 +822,8 @@ rxm_sendmsg_thru(struct fid_ep *ep_fid, const struct fi_msg *msg,
 	if (ret)
 		goto unlock;
 
-	ret = fi_sendmsg(conn->msg_ep, msg, flags);
+	ret = fi_sendmsg(rxm_conn_msg_ep(conn, NULL),
+			 msg, flags);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -832,7 +844,8 @@ rxm_inject_thru(struct fid_ep *ep_fid, const void *buf,
 	if (ret)
 		goto unlock;
 
-	ret = fi_inject(conn->msg_ep, buf, len, 0);
+	ret = fi_inject(rxm_conn_msg_ep(conn, NULL),
+			buf, len, 0);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -853,7 +866,8 @@ rxm_senddata_thru(struct fid_ep *ep_fid, const void *buf, size_t len,
 	if (ret)
 		goto unlock;
 
-	ret = fi_senddata(conn->msg_ep, buf, len, desc, data, 0, context);
+	ret = fi_senddata(rxm_conn_msg_ep(conn, NULL),
+			  buf, len, desc, data, 0, context);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -874,7 +888,8 @@ rxm_injectdata_thru(struct fid_ep *ep_fid, const void *buf, size_t len,
 	if (ret)
 		goto unlock;
 
-	ret = fi_injectdata(conn->msg_ep, buf, len, data, 0);
+	ret = fi_injectdata(rxm_conn_msg_ep(conn, NULL),
+			    buf, len, data, 0);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -101,7 +101,8 @@ rxm_ep_rma_common(struct rxm_ep *rxm_ep, const struct fi_msg_rma *msg,
 	msg_rma.desc = mr_desc;
 	msg_rma.context = rma_buf;
 
-	ret = rma_msg(rxm_conn->msg_ep, &msg_rma, flags);
+	ret = rma_msg(rxm_conn_msg_ep(rxm_conn, NULL),
+		      &msg_rma, flags);
 	if (!ret)
 		goto unlock;
 
@@ -231,7 +232,8 @@ rxm_ep_rma_emulate_inject_msg(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 
 	flags = (flags & ~FI_INJECT) | FI_COMPLETION;
 
-	ret = fi_writemsg(rxm_conn->msg_ep, &rxm_rma_msg, flags);
+	ret = fi_writemsg(rxm_conn_msg_ep(rxm_conn, NULL),
+			  &rxm_rma_msg, flags);
 	if (ret) {
 		if (ret == -FI_EAGAIN)
 			rxm_ep_do_progress(&rxm_ep->util_ep);
@@ -295,13 +297,13 @@ rxm_ep_rma_inject_common(struct rxm_ep *rxm_ep, const struct fi_msg_rma *msg,
 	}
 
 	if (flags & FI_REMOTE_CQ_DATA) {
-		ret = fi_inject_writedata(rxm_conn->msg_ep,
+		ret = fi_inject_writedata(rxm_conn_msg_ep(rxm_conn, NULL),
 					  msg->msg_iov->iov_base,
 					  msg->msg_iov->iov_len, msg->data,
 					  msg->addr, msg->rma_iov->addr,
 					  msg->rma_iov->key);
 	} else {
-		ret = fi_inject_write(rxm_conn->msg_ep,
+		ret = fi_inject_write(rxm_conn_msg_ep(rxm_conn, NULL),
 				      msg->msg_iov->iov_base,
 				      msg->msg_iov->iov_len, msg->addr,
 				      msg->rma_iov->addr,
@@ -450,7 +452,8 @@ static ssize_t rxm_ep_inject_write(struct fid_ep *ep_fid, const void *buf,
 		goto unlock;
 	}
 
-	ret = fi_inject_write(rxm_conn->msg_ep, buf, len, dest_addr, addr, key);
+	ret = fi_inject_write(rxm_conn_msg_ep(rxm_conn, NULL),
+			      buf, len, dest_addr, addr, key);
 	if (ret == -FI_EAGAIN)
 		rxm_ep_do_progress(&rxm_ep->util_ep);
 	else if (ret)
@@ -484,7 +487,8 @@ static ssize_t rxm_ep_inject_writedata(struct fid_ep *ep_fid, const void *buf,
 		goto unlock;
 	}
 
-	ret = fi_inject_writedata(rxm_conn->msg_ep, buf, len,
+	ret = fi_inject_writedata(rxm_conn_msg_ep(rxm_conn, NULL),
+				  buf, len,
 				  data, dest_addr, addr, key);
 	if (ret == -FI_EAGAIN)
 		rxm_ep_do_progress(&rxm_ep->util_ep);
@@ -526,7 +530,8 @@ rxm_read_thru(struct fid_ep *ep_fid, void *buf, size_t len,
 	if (ret)
 		goto unlock;
 
-	ret = fi_read(conn->msg_ep, buf, len, desc, src_addr, addr,
+	ret = fi_read(rxm_conn_msg_ep(conn, NULL),
+		      buf, len, desc, src_addr, addr,
 		      key, context);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
@@ -549,7 +554,8 @@ rxm_readv_thru(struct fid_ep *ep_fid, const struct iovec *iov,
 	if (ret)
 		goto unlock;
 
-	ret = fi_readv(conn->msg_ep, iov, desc, count, src_addr, addr,
+	ret = fi_readv(rxm_conn_msg_ep(conn, NULL),
+		       iov, desc, count, src_addr, addr,
 		       key, context);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
@@ -571,7 +577,8 @@ rxm_readmsg_thru(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 	if (ret)
 		goto unlock;
 
-	ret = fi_readmsg(conn->msg_ep, msg, flags);
+	ret = fi_readmsg(rxm_conn_msg_ep(conn, NULL),
+			 msg, flags);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -593,7 +600,8 @@ rxm_write_thru(struct fid_ep *ep_fid, const void *buf,
 	if (ret)
 		goto unlock;
 
-	ret = fi_write(conn->msg_ep, buf, len, desc, dest_addr, addr,
+	ret = fi_write(rxm_conn_msg_ep(conn, NULL),
+		       buf, len, desc, dest_addr, addr,
 		       key, context);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
@@ -616,7 +624,8 @@ rxm_writev_thru(struct fid_ep *ep_fid, const struct iovec *iov,
 	if (ret)
 		goto unlock;
 
-	ret = fi_writev(conn->msg_ep, iov, desc, count, dest_addr, addr,
+	ret = fi_writev(rxm_conn_msg_ep(conn, NULL),
+			iov, desc, count, dest_addr, addr,
 			key, context);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
@@ -638,7 +647,8 @@ rxm_writemsg_thru(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 	if (ret)
 		goto unlock;
 
-	ret = fi_writemsg(conn->msg_ep, msg, flags);
+	ret = fi_writemsg(rxm_conn_msg_ep(conn, NULL),
+			  msg, flags);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -660,7 +670,8 @@ rxm_inject_write_thru(struct fid_ep *ep_fid, const void *buf,
 	if (ret)
 		goto unlock;
 
-	ret = fi_inject_write(conn->msg_ep, buf, len, dest_addr, addr, key);
+	ret = fi_inject_write(rxm_conn_msg_ep(conn, NULL),
+			      buf, len, dest_addr, addr, key);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -683,7 +694,8 @@ rxm_writedata_thru(struct fid_ep *ep_fid, const void *buf,
 	if (ret)
 		goto unlock;
 
-	ret = fi_writedata(conn->msg_ep, buf, len, desc, data, dest_addr,
+	ret = fi_writedata(rxm_conn_msg_ep(conn, NULL),
+			   buf, len, desc, data, dest_addr,
 			   addr, key, context);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
@@ -706,7 +718,8 @@ rxm_inject_writedata_thru(struct fid_ep *ep_fid, const void *buf,
 	if (ret)
 		goto unlock;
 
-	ret = fi_inject_writedata(conn->msg_ep, buf, len, data, dest_addr,
+	ret = fi_inject_writedata(rxm_conn_msg_ep(conn, NULL),
+				  buf, len, data, dest_addr,
 				  addr, key);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);

--- a/prov/rxm/src/rxm_tagged.c
+++ b/prov/rxm/src/rxm_tagged.c
@@ -330,7 +330,8 @@ rxm_tsend_thru(struct fid_ep *ep_fid, const void *buf, size_t len,
 	if (ret)
 		goto unlock;
 
-	ret = fi_tsend(conn->msg_ep, buf, len, desc, 0, tag, context);
+	ret = fi_tsend(rxm_conn_msg_ep(conn, NULL),
+		       buf, len, desc, 0, tag, context);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -352,7 +353,8 @@ rxm_tsendv_thru(struct fid_ep *ep_fid, const struct iovec *iov,
 	if (ret)
 		goto unlock;
 
-	ret = fi_tsendv(conn->msg_ep, iov, desc, count, 0, tag, context);
+	ret = fi_tsendv(rxm_conn_msg_ep(conn, NULL),
+			iov, desc, count, 0, tag, context);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -373,7 +375,8 @@ rxm_tsendmsg_thru(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
 	if (ret)
 		goto unlock;
 
-	ret = fi_tsendmsg(conn->msg_ep, msg, flags);
+	ret = fi_tsendmsg(rxm_conn_msg_ep(conn, NULL),
+			  msg, flags);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -394,7 +397,8 @@ rxm_tinject_thru(struct fid_ep *ep_fid, const void *buf,
 	if (ret)
 		goto unlock;
 
-	ret = fi_tinject(conn->msg_ep, buf, len, 0, tag);
+	ret = fi_tinject(rxm_conn_msg_ep(conn, NULL),
+			 buf, len, 0, tag);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -416,7 +420,8 @@ rxm_tsenddata_thru(struct fid_ep *ep_fid, const void *buf, size_t len,
 	if (ret)
 		goto unlock;
 
-	ret = fi_tsenddata(conn->msg_ep, buf, len, desc, data, 0, tag, context);
+	ret = fi_tsenddata(rxm_conn_msg_ep(conn, NULL),
+			   buf, len, desc, data, 0, tag, context);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -437,7 +442,8 @@ rxm_tinjectdata_thru(struct fid_ep *ep_fid, const void *buf, size_t len,
 	if (ret)
 		goto unlock;
 
-	ret = fi_tinjectdata(conn->msg_ep, buf, len, data, 0, tag);
+	ret = fi_tinjectdata(rxm_conn_msg_ep(conn, NULL),
+			     buf, len, data, 0, tag);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;


### PR DESCRIPTION
**Summary**
- Introduce a pluggable rxm_qp_selector interface that maps each TX operation to a msg_ep index, replacing the single scalar msg_ep with a msg_eps[] array per connection
- Implement a round-robin selector that steers RMA/rendezvous-RMA traffic across msg_ep[1..N-1] while pinning control-plane ops to msg_ep[0], with per-msg_id SAR segment pinning for in-order delivery
- Add FI_OFI_RXM_NUM_MSG_EPS env var (default 1, clamped to [1, 255]) for runtime configuration; currently all slots alias a single real msg_ep (mock multi-QP), restricted to verbs provider
- Add debug trace logging for QP selection at FI_LOG_EP_DATA level

**Design**

The selector is a simple vtable (select + destroy callbacks) attached to each rxm_conn. Two implementations are provided:

- single_qp — stateless, always returns index 0 (used when num_msg_eps == 1)
- round_robin — heap-allocated, steers RMA/RNDV_RMA round-robin across data QPs with a SAR pin table to maintain segment ordering

Wire behaviour is unchanged in this series — all msg_eps[] slots point to the same underlying endpoint. This lays the groundwork for real multi-QP connections in a follow-up series.
