### PR TITLE
prov/cxi: refuse cancel for receives with RDMA in flight

### DIFF
--- a/prov/cxi/src/cxip_msg.c
+++ b/prov/cxi/src/cxip_msg.c
@@ -467,6 +467,13 @@ void cxip_rxc_record_req_stat(struct cxip_rxc *rxc, enum c_ptl_list list,
 
 /*
  * cxip_recv_cancel() - Cancel outstanding receive request.
+ *
+ * Per fi_cancel semantics, cancel is best-effort: if the operation is still
+ * pending it can be canceled, but an in-progress operation (RDMA in flight)
+ * cannot be rolled back.
+ *
+ * When a rendezvous Get is in flight (rdzv_events > 0), return -FI_ENOENT to
+ * signal that the cancel did not take effect.
  */
 int cxip_recv_cancel(struct cxip_req *req)
 {
@@ -477,11 +484,23 @@ int cxip_recv_cancel(struct cxip_req *req)
 	 * or software receive list.
 	 */
 	if (!req->recv.hw_offloaded) {
-		dlist_remove_init(&req->recv.rxc_entry);
-		req->recv.canceled = true;
-		req->recv.unlinked = true;
-		cxip_recv_req_report(req);
-		cxip_recv_req_free(req);
+		if (req->recv.rdzv_events) {
+			/* RDMA in flight — cannot cancel.  Return -FI_ENOENT
+			 * so callers (e.g. OpenMPI MTL) know immediately that
+			 * the cancel did not take effect.  The rendezvous will
+			 * complete normally via rdzv_recv_req_event().
+			 */
+			RXC_DBG(rxc,
+				"Cancel refused: RDMA in flight, req: %p rdzv_events: %d\n",
+				req, req->recv.rdzv_events);
+			ret = -FI_ENOENT;
+		} else {
+			dlist_remove_init(&req->recv.rxc_entry);
+			req->recv.canceled = true;
+			req->recv.unlinked = true;
+			cxip_recv_req_report(req);
+			cxip_recv_req_free(req);
+		}
 	} else {
 		ret = cxip_pte_unlink(rxc->rx_pte, C_PTL_LIST_PRIORITY,
 				req->req_id, rxc->rx_cmdq);

--- a/prov/cxi/src/cxip_msg_hpc.c
+++ b/prov/cxi/src/cxip_msg_hpc.c
@@ -1540,8 +1540,18 @@ static int cxip_recv_cb(struct cxip_req *req, const union c_event *event)
 		 * may be freed with pending child requests.
 		 */
 		req->recv.unlinked = true;
-		cxip_recv_req_report(req);
-		cxip_recv_req_free(req);
+
+		if (req->recv.rdzv_events) {
+			/* RDMA in flight — defer free until
+			 * rdzv_recv_req_event() handles completion.
+			 */
+			RXC_DBG(rxc,
+				"Unlink with in-flight RGet, req: %p rdzv_events: %d\n",
+				req, req->recv.rdzv_events);
+		} else {
+			cxip_recv_req_report(req);
+			cxip_recv_req_free(req);
+		}
 
 		return FI_SUCCESS;
 


### PR DESCRIPTION
When fi_cancel is called on a receive that has an active rendezvous Get (rdzv_events > 0), the RDMA may have already modified target memory and cannot be rolled back.

Return -FI_ENOENT for in-flight receives instead of FI_SUCCESS.  This follows the convention used by the sockets, SHM, and PSM providers for uncancellable operations and gives callers (e.g. OpenMPI's MTL OFI layer) an immediate signal that the cancel did not take effect, avoiding a state where the caller expects FI_ECANCELED but receives a normal completion instead.

The C_EVENT_UNLINK handler in cxip_msg_hpc.c also defers report/free when rdzv_events > 0 to prevent use-after-free if an unlink event arrives while an RGet is still outstanding.