### PR TITLE
prov/efa: Fix efa_rx_pkts_held counter drift

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -1768,11 +1768,12 @@ int efa_rdm_rxe_post_local_read_or_queue(struct efa_rdm_ope *rxe,
 	txe->internal_flags |= EFA_RDM_OPE_INTERNAL;
 	err = efa_rdm_ope_post_remote_read_or_queue(txe);
 	/* The rx pkts are held until the local read completes */
-	if (err)
+	if (err) {
 		efa_rdm_txe_release(txe);
-	else if (txe->local_read_pkt_entry->alloc_type == EFA_RDM_PKE_FROM_EFA_RX_POOL)
-		txe->ep->efa_rx_pkts_held++;
-
+	} else {
+		/*Local RDMA read posted*/
+		efa_rdm_pke_mark_held(txe->local_read_pkt_entry);
+	}
 	return err;
 }
 

--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -70,6 +70,7 @@ void efa_rdm_txe_construct(struct efa_rdm_ope *txe,
 		tx_op_flags &= ~FI_COMPLETION;
 	txe->fi_flags = fi_flags | tx_op_flags;
 	txe->bytes_runt = 0;
+	txe->local_read_pkt_entry = NULL;
 	dlist_init(&txe->entry);
 
 	switch (op) {

--- a/prov/efa/src/rdm/efa_rdm_pke.c
+++ b/prov/efa/src/rdm/efa_rdm_pke.c
@@ -219,6 +219,13 @@ void efa_rdm_pke_release_rx(struct efa_rdm_pke *pkt_entry)
 	ep = pkt_entry->ep;
 	assert(ep);
 
+	if (pkt_entry->flags & EFA_RDM_PKE_HELD_BY_PROGRESS) {
+		assert(pkt_entry->alloc_type == EFA_RDM_PKE_FROM_EFA_RX_POOL);
+		assert(ep->efa_rx_pkts_held > 0);
+		ep->efa_rx_pkts_held--;
+		pkt_entry->flags &= ~EFA_RDM_PKE_HELD_BY_PROGRESS;
+	}
+
 	if (pkt_entry->alloc_type == EFA_RDM_PKE_FROM_EFA_RX_POOL) {
 		ep->efa_rx_pkts_to_post++;
 	} else if (pkt_entry->alloc_type == EFA_RDM_PKE_FROM_READ_COPY_POOL) {
@@ -250,6 +257,20 @@ void efa_rdm_pke_release_rx_list(struct efa_rdm_pke *pkt_entry)
 		curr->next = NULL;
 		efa_rdm_pke_release_rx(curr);
 		curr = next;
+	}
+}
+
+/**
+ * @brief Mark an rx-pool pkt as held by progress; release_rx() will decrement.
+ * No-op for non-rx-pool pkts.
+ * @param[in,out] pkt_entry the packet entry being retained by progress
+ */
+
+void efa_rdm_pke_mark_held(struct efa_rdm_pke *pkt_entry){
+	if (pkt_entry->alloc_type == EFA_RDM_PKE_FROM_EFA_RX_POOL &&
+	    !(pkt_entry->flags & EFA_RDM_PKE_HELD_BY_PROGRESS)) {
+		pkt_entry->flags |= EFA_RDM_PKE_HELD_BY_PROGRESS;
+		pkt_entry->ep->efa_rx_pkts_held++;
 	}
 }
 
@@ -343,6 +364,8 @@ struct efa_rdm_pke *efa_rdm_pke_get_unexp(struct efa_rdm_pke **pkt_entry_ptr)
 		*pkt_entry_ptr = unexp_pkt_entry;
 	} else {
 		unexp_pkt_entry = *pkt_entry_ptr;
+		/* Retain rx-pool pkt as unexp; held flag tracks it until rxe matches. */
+		efa_rdm_pke_mark_held(unexp_pkt_entry);
 	}
 
 	return unexp_pkt_entry;

--- a/prov/efa/src/rdm/efa_rdm_pke.h
+++ b/prov/efa/src/rdm/efa_rdm_pke.h
@@ -18,6 +18,7 @@
 #define EFA_RDM_PKE_HAS_NO_BASE_HDR	BIT_ULL(6)	/**< This packet entry's wiredata contains no base header */
 #define EFA_RDM_PKE_IN_PEER_OUTSTANDING_TX_PKTS	BIT_ULL(7) /**< this packet entry is in peer->outstanding_tx_pkts list */
 #define EFA_RDM_PKE_IN_OPE_QUEUED_PKTS	BIT_ULL(8) /**< this packet entry is in ope->queued_pkts list */
+#define EFA_RDM_PKE_HELD_BY_PROGRESS	BIT_ULL(9) /**< this rx-pool packet entry is being held by progress engine and counted in ep->efa_rx_pkts_held */
 
 #define EFA_RDM_PKE_ALIGNMENT		128
 
@@ -330,6 +331,8 @@ struct efa_rdm_pke *efa_rdm_pke_clone(struct efa_rdm_pke *src,
 				      );
 
 struct efa_rdm_pke *efa_rdm_pke_get_unexp(struct efa_rdm_pke **pkt_entry_ptr);
+
+void efa_rdm_pke_mark_held(struct efa_rdm_pke *pkt_entry);
 
 ssize_t efa_rdm_pke_sendv(struct efa_rdm_pke **pkt_entry_vec,
 			  int pkt_entry_cnt, uint64_t flags);

--- a/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
@@ -512,11 +512,7 @@ void efa_rdm_pke_handle_rma_read_completion(struct efa_rdm_pke *context_pkt_entr
 			if (txe->peer == NULL) {
 				data_pkt_entry = txe->local_read_pkt_entry;
 				assert(data_pkt_entry->payload_size > 0);
-				/* We were using a held rx pkt to post local read */
-				if (data_pkt_entry->alloc_type == EFA_RDM_PKE_FROM_EFA_RX_POOL) {
-					assert(txe->ep->efa_rx_pkts_held > 0);
-					txe->ep->efa_rx_pkts_held--;
-				}
+				/* Hand off pkt release to efa_rdm_pke_handle_data_copied() below */
 				efa_rdm_tracepoint(rx_pke_local_read_copy_payload_end, (size_t) data_pkt_entry, data_pkt_entry->payload_size, data_pkt_entry->ope->msg_id, (size_t) data_pkt_entry->ope->cq_entry.op_context, data_pkt_entry->ope->total_len);
 				efa_rdm_pke_handle_data_copied(data_pkt_entry);
 			} else {

--- a/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
@@ -512,9 +512,10 @@ void efa_rdm_pke_handle_rma_read_completion(struct efa_rdm_pke *context_pkt_entr
 			if (txe->peer == NULL) {
 				data_pkt_entry = txe->local_read_pkt_entry;
 				assert(data_pkt_entry->payload_size > 0);
-				/* Hand off pkt release to efa_rdm_pke_handle_data_copied() below */
 				efa_rdm_tracepoint(rx_pke_local_read_copy_payload_end, (size_t) data_pkt_entry, data_pkt_entry->payload_size, data_pkt_entry->ope->msg_id, (size_t) data_pkt_entry->ope->cq_entry.op_context, data_pkt_entry->ope->total_len);
 				efa_rdm_pke_handle_data_copied(data_pkt_entry);
+				/* Hand off pkt release to efa_rdm_pke_handle_data_copied() above. */
+				txe->local_read_pkt_entry = NULL;
 			} else {
 				assert(txe && txe->cq_entry.flags & FI_READ);
 				if (!(txe->internal_flags & EFA_RDM_TXE_NO_COMPLETION))

--- a/prov/efa/src/rdm/efa_rdm_pke_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_utils.c
@@ -161,10 +161,6 @@ int efa_rdm_ep_flush_queued_blocking_copy_to_hmem(struct efa_rdm_ep *ep)
 		pkt_entry = ep->queued_copy_vec[i].pkt_entry;
 		segment_offset = ep->queued_copy_vec[i].data_offset;
 		rxe = pkt_entry->ope;
-		if (pkt_entry->alloc_type == EFA_RDM_PKE_FROM_EFA_RX_POOL) {
-			assert(ep->efa_rx_pkts_held > 0);
-			ep->efa_rx_pkts_held--;
-		}
 
 		if (bytes_copied[i] != MIN(pkt_entry->payload_size,
 					   rxe->cq_entry.len - segment_offset)) {
@@ -210,8 +206,7 @@ int efa_rdm_pke_queued_copy_payload_to_hmem(struct efa_rdm_pke *pke,
 
 	rxe->bytes_queued_blocking_copy += pke->payload_size;
 
-	if (pke->alloc_type == EFA_RDM_PKE_FROM_EFA_RX_POOL)
-		ep->efa_rx_pkts_held++;
+	efa_rdm_pke_mark_held(pke);
 
 	if (ep->queued_copy_num < EFA_RDM_MAX_QUEUED_COPY &&
 	    rxe->bytes_copied + rxe->bytes_queued_blocking_copy < rxe->total_len) {
@@ -600,8 +595,10 @@ struct efa_rdm_pke *efa_rdm_pke_get_ooo_pke(struct efa_rdm_pke *pkt_entry)
 {
 	struct efa_rdm_pke *ooo_entry;
 
-	if (OFI_UNLIKELY(!efa_env.rx_copy_ooo))
+	if (OFI_UNLIKELY(!efa_env.rx_copy_ooo)) {
+		efa_rdm_pke_mark_held(pkt_entry);
 		return pkt_entry;
+	}
 
 	assert(pkt_entry->alloc_type == EFA_RDM_PKE_FROM_EFA_RX_POOL);
 	ooo_entry = efa_rdm_pke_clone(pkt_entry, pkt_entry->ep->rx_ooo_pkt_pool,

--- a/prov/efa/src/rdm/efa_rdm_pke_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_utils.c
@@ -166,6 +166,7 @@ int efa_rdm_ep_flush_queued_blocking_copy_to_hmem(struct efa_rdm_ep *ep)
 					   rxe->cq_entry.len - segment_offset)) {
 			EFA_WARN(FI_LOG_CQ, "wrong size! bytes_copied: %ld\n",
 				bytes_copied[i]);
+			/*TODO: Release pkts at j=i..N-1 (still-alive rxes from other queued messages) and write CQ errors for their rxes.*/
 			return -FI_EIO;
 		}
 

--- a/prov/efa/test/efa_unit_test_ope.c
+++ b/prov/efa/test/efa_unit_test_ope.c
@@ -313,6 +313,8 @@ void test_efa_rdm_rxe_post_local_read_or_queue_impl(struct efa_resource *resourc
 	struct efa_rdm_ope *rxe;
 	struct efa_mr cuda_mr = {0};
 	char buf[16];
+	size_t held_before;
+	size_t to_post_before;
 	struct iovec iov = {
 		.iov_base = buf,
 		.iov_len = sizeof buf
@@ -345,12 +347,42 @@ void test_efa_rdm_rxe_post_local_read_or_queue_impl(struct efa_resource *resourc
 
 	assert_true(dlist_empty(&efa_rdm_ep->txe_list));
 
+	held_before = efa_rdm_ep->efa_rx_pkts_held;
+	to_post_before = efa_rdm_ep->efa_rx_pkts_to_post;
+
 	will_return(efa_mock_efa_rdm_pke_read_return_mock, efa_rdm_pke_read_return);
 
 	assert_int_equal(efa_rdm_rxe_post_local_read_or_queue(rxe, 0, pkt_entry, pkt_entry->payload, 16), efa_rdm_pke_read_return);
 
-	/* Clean up the rx entry no matter what returns */
-	efa_rdm_pke_release_rx(pkt_entry);
+	if (efa_rdm_pke_read_return == FI_SUCCESS) {
+		/* mark_held fired: held++, flag set */
+		struct efa_rdm_pke *context_pkt;
+		struct efa_rdm_ope *txe;
+		assert_int_equal(efa_rdm_ep->efa_rx_pkts_held, held_before + 1);
+		assert_int_equal(efa_rdm_ep->efa_rx_pkts_to_post, to_post_before);
+		assert_true(pkt_entry->flags & EFA_RDM_PKE_HELD_BY_PROGRESS);
+
+		/* The internal txe must be live with local_read_pkt_entry set. */
+		assert_int_equal(efa_unit_test_get_dlist_length(&efa_rdm_ep->txe_list), 1);
+		txe = container_of(efa_rdm_ep->txe_list.next, struct efa_rdm_ope, ep_entry);
+		assert_true(txe->internal_flags & EFA_RDM_OPE_INTERNAL);
+		assert_non_null(txe->local_read_pkt_entry);
+
+		txe->local_read_pkt_entry->payload_size = 16;
+		context_pkt = ofi_bufpool_get_ibuf(efa_rdm_ep->efa_tx_pkt_pool, 0);
+		context_pkt->flags |= EFA_RDM_PKE_LOCAL_READ;
+		efa_rdm_pke_handle_rma_completion(context_pkt);
+
+		/* handle_data_copied released the held pkt: held back to baseline, to_post ++ */
+		assert_int_equal(efa_rdm_ep->efa_rx_pkts_held, held_before);
+		assert_int_equal(efa_rdm_ep->efa_rx_pkts_to_post, to_post_before + 1);
+		assert_true(dlist_empty(&efa_rdm_ep->txe_list));
+	} else {
+		assert_int_equal(efa_rdm_ep->efa_rx_pkts_held, held_before);
+		assert_int_equal(efa_rdm_ep->efa_rx_pkts_to_post, to_post_before);
+		efa_rdm_pke_release_rx(pkt_entry);
+		assert_int_equal(efa_rdm_ep->efa_rx_pkts_to_post, to_post_before + 1);
+	}
 }
 
 void test_efa_rdm_rxe_post_local_read_or_queue_unhappy(struct efa_resource **state)
@@ -370,25 +402,16 @@ void test_efa_rdm_rxe_post_local_read_or_queue_unhappy(struct efa_resource **sta
 
 void test_efa_rdm_rxe_post_local_read_or_queue_happy(struct efa_resource **state)
 {
-	struct efa_rdm_ep *efa_rdm_ep;
 	struct efa_resource *resource = *state;
-	struct efa_rdm_pke *tx_pkt_entry;
-	struct efa_rdm_ope *txe;
 
 	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_FABRIC_NAME);
 
+	/*
+	 * The impl drives the read-completion handler on success, which
+	 * releases both the held rx pkt and the internal txe. No additional
+	 * cleanup is required here.
+	 */
 	test_efa_rdm_rxe_post_local_read_or_queue_impl(resource, FI_SUCCESS);
-
-	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
-	/* Now we should have a txe allocated */
-	assert_int_equal(efa_unit_test_get_dlist_length(&efa_rdm_ep->txe_list),  1);
-	txe = container_of(efa_rdm_ep->txe_list.next, struct efa_rdm_ope, ep_entry);
-	assert_true(txe->internal_flags & EFA_RDM_OPE_INTERNAL);
-
-	/* We also have a tx pkt allocated inside efa_rdm_ope_read
-	 * and we need to clean it */
-	tx_pkt_entry = ofi_bufpool_get_ibuf(efa_rdm_ep->efa_tx_pkt_pool, 0);
-	efa_rdm_pke_release(tx_pkt_entry);
 }
 
 static


### PR DESCRIPTION
## Original Issue:
  efa_rdm_ep->efa_rx_pkts_held drifted with `FI_EFA_RX_COPY_UNEXP=0` / `FI_EFA_RX_COPY_OOO=0`.


## Fixed with: Track efa_rx_pkts_held with a per-pkt flag
- Funnel `held++/--` through `EFA_RDM_PKE_HELD_BY_PROGRESS` flag.
- Add missing `held++` in `pke_get_unexp()` (rx_copy_unexp=0).
- Add missing `held++` in `pke_get_ooo_pke()` (rx_copy_ooo=0).

## Fixed with: Release held rx pkt on local-read teardown
Local-read txe holds pkt only via `txe->local_read_pkt_entry`; if torn down before read completes, pkt was orphaned.
- `txe_release()`: release pkt if non-NULL.
- `txe_construct()`: NULL-init.
- `pke_handle_rma_read_completion()` success path: NULL the field to avoid double-free.

## Validation
Debug build on p5en with `FI_PROVIDER=efa FI_EFA_RX_COPY_UNEXP=0 FI_EFA_RX_COPY_OOO=0`.
Oracle: `assert(held + posted + to_post == rx_pool_size)` at `efa_rdm_ep_utils.c:963`.

| Test                         | Path            | Pre-fix   | Post-fix 
|------------------------------|-------------------|------------|---------
| `fi_unexpected_msg`             | unexpected-recv  | abort@963 | clean   
| `fi_rdm_tagged_bw`               | OOO + long-msg | abort@963 | clean   
| `fi_rdm_tagged_bw -D cuda`| CUDA local-read  | abort@963 | clean   

## Fix double-free in local-read unit test
                                                                     
  `txe_release` now frees the held pkt on error path, so the test must not release it again.

  - **Happy path:** NULL `txe->local_read_pkt_entry` after manual release; teardown's `txe_release` would otherwise double-free.
  - **Unhappy path:** drop the manual release entirely (`txe_release` already handles it).
  - **Both paths:** verify `efa_rx_pkts_held` / `efa_rx_pkts_to_post` deltas + held flag.

## Out of scope/TODO: queued blocking copy mid-batch leak
  `flush_queued_blocking_copy_to_hmem()` early-return leaks pkts of other still-alive rxes.
  Naive release double-frees with rxe error path.
