### PR TITLE
fabtests: Add timestamp to fabtests log

### DIFF
--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -37,6 +37,7 @@
 
 #include <stdlib.h>
 #include <inttypes.h>
+#include <time.h>
 #include <netinet/tcp.h>
 #include <sys/uio.h>
 #include <stdbool.h>
@@ -373,8 +374,9 @@ static inline int ft_use_size(int index, int enable_flags)
 #define FT_LOG(level, fmt, ...)						\
 	do {								\
 		int saved_errno = errno;				\
-		fprintf(stderr, "[%s] fabtests:%s:%d: " fmt "\n",	\
-			level, __FILE__, __LINE__, ##__VA_ARGS__);	\
+		fprintf(stderr, "[%s] %ld:fabtests:%s:%d: " fmt "\n",	\
+			level, (long)time(NULL), __FILE__,		\
+			__LINE__, ##__VA_ARGS__);			\
 		errno = saved_errno;					\
 	} while (0)
 


### PR DESCRIPTION
Add epoch timestamp to the FT_LOG macro output, matching the format used by libfabric's fi_log. This helps correlate fabtests log messages with provider-side logs when debugging.

Output format: [level] <epoch>:fabtests:<file>:<line>: <msg>