### PR TITLE
prov/efa: fix overflow pkt entry release assertion in debug mode

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -722,9 +722,26 @@ static void efa_rdm_ep_destroy_buffer_pools(struct efa_rdm_ep *efa_rdm_ep)
 	struct efa_rdm_ope *rxe;
 	struct efa_rdm_ope *txe;
 	struct efa_rdm_peer *peer;
+	struct efa_rdm_peer_overflow_pke_list_entry *overflow_pke_list_entry;
 	struct util_av_entry *util_av_entry;
 	struct efa_av_entry *av_entry;
 	struct efa_conn_ep_peer_map_entry *peer_map_entry;
+
+	/*
+	 * Overflow pkes sit on both peer->overflow_pke_list and (in debug mode) rx_pkt_list.
+	 * Release them before: rx_pkt_list debug sweep & efa_rdm_peer_destruct to avoid a double-free.
+	 */
+	dlist_foreach_container(&efa_rdm_ep->ep_peer_list,
+				struct efa_rdm_peer, peer,
+				ep_peer_list_entry) {
+		dlist_foreach_container_safe(&peer->overflow_pke_list,
+					     struct efa_rdm_peer_overflow_pke_list_entry,
+					     overflow_pke_list_entry, entry, tmp) {
+			dlist_remove(&overflow_pke_list_entry->entry);
+			efa_rdm_pke_release_rx_list(overflow_pke_list_entry->pkt_entry);
+			ofi_buf_free(overflow_pke_list_entry);
+		}
+	}
 
 #if ENABLE_DEBUG
 	struct efa_rdm_pke *pkt_entry;

--- a/prov/efa/src/rdm/efa_rdm_peer.c
+++ b/prov/efa/src/rdm/efa_rdm_peer.c
@@ -87,7 +87,7 @@ void efa_rdm_peer_destruct(struct efa_rdm_peer *peer, struct efa_rdm_ep *ep)
 				     struct efa_rdm_peer_overflow_pke_list_entry,
 				     overflow_pke_list_entry, entry, tmp) {
 		dlist_remove(&overflow_pke_list_entry->entry);
-		efa_rdm_pke_release_rx(overflow_pke_list_entry->pkt_entry);
+		efa_rdm_pke_release_rx_list(overflow_pke_list_entry->pkt_entry);
 		ofi_buf_free(overflow_pke_list_entry);
 	}
 


### PR DESCRIPTION
  Overflow pkes sit on both peer->overflow_pke_list and (under
  ENABLE_DEBUG) ep->rx_pkt_list, so the rx_pkt_list debug sweep and
  efa_rdm_peer_destruct each freed the same pke at ep close.

  Drain peer->overflow_pke_list at the top of
  efa_rdm_ep_destroy_buffer_pools() with efa_rdm_pke_release_rx_list()
  so the chain is freed once and removed from both lists before either
  teardown path runs. Also switch efa_rdm_pke_release_rx() to
  efa_rdm_pke_release_rx_list() to free chained fragments in non-debug
  builds.

  Fixes: efa_rdm_pke_release_rx: Assertion 'pkt_entry->next == NULL' failed