### PR TITLE
prov/efa: add signal-triggered RDM endpoint state dumper

### DIFF
--- a/man/fi_efa.7.md
+++ b/man/fi_efa.7.md
@@ -588,6 +588,16 @@ still reference an MR when it is closed. When enabled, the provider will print
 a warning message if an MR is closed while TX or RX operations still reference it.
 This is useful for debugging memory registration issues. (Default: false).
 
+*FI_EFA_STATE_DUMP_SIGNAL*
+
+: Signal number that triggers an RDM endpoint state dump for debugging hangs.
+When the specified signal is received, the provider prints endpoint counters,
+outstanding TX/RX operations, and per-peer state to stderr. Currently only
+covers the EFA RDM (protocol) path. Set to 0 to disable.
+Example: 12 for SIGUSR2, 10 for SIGUSR1. (Default: 0, disabled).
+See [efa_rdm_ep_dump.md](prov/efa/docs/efa_rdm_ep_dump.md) for output format
+and hang pattern interpretation.
+
 # SEE ALSO
 
 [`fabric`(7)](fabric.7.html),

--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -79,7 +79,8 @@ _efa_files = \
 	prov/efa/src/rdm/efa_rdm_tracepoint_def.c \
 	prov/efa/src/rdm/efa_rdm_srx.c \
 	prov/efa/src/rdm/efa_rdm_util.c \
-	prov/efa/src/rdm/efa_rdm_mr.c
+	prov/efa/src/rdm/efa_rdm_mr.c \
+	prov/efa/src/rdm/efa_rdm_ep_dump.c
 
 if ENABLE_EFA_UNIT_TEST
 _efa_files += prov/efa/test/efa_unit_test_data_path_ops.c
@@ -142,7 +143,8 @@ _efa_headers = \
 	prov/efa/src/rdm/efa_rdm_tracepoint.h \
 	prov/efa/src/rdm/efa_rdm_srx.h \
 	prov/efa/src/rdm/efa_rdm_util.h \
-	prov/efa/src/rdm/efa_rdm_mr.h
+	prov/efa/src/rdm/efa_rdm_mr.h \
+	prov/efa/src/rdm/efa_rdm_ep_dump.h
 
 if HAVE_LTTNG
 efa_LDFLAGS += -llttng-ust

--- a/prov/efa/docs/efa_rdm_ep_dump.md
+++ b/prov/efa/docs/efa_rdm_ep_dump.md
@@ -1,0 +1,248 @@
+# Debugging EFA RDM Hangs with State Dump
+
+## Overview
+
+The EFA RDM provider includes a signal-triggered state dumper that prints
+the internal state of all endpoints and peers when a process receives a
+configured signal. This is designed for diagnosing hangs where the
+application is busy-polling with no forward progress.
+
+## Enabling
+
+Set `FI_EFA_STATE_DUMP_SIGNAL` to the signal number you want to trigger
+the dump. Default is 0 (disabled).
+
+```bash
+# Use SIGUSR2 (signal 12)
+export FI_EFA_STATE_DUMP_SIGNAL=12
+
+# Use SIGUSR1 (signal 10)
+export FI_EFA_STATE_DUMP_SIGNAL=10
+```
+
+## Usage
+
+```bash
+# Find the hung process
+ps aux | grep <application_name>
+
+# Trigger the state dump (assuming FI_EFA_STATE_DUMP_SIGNAL=12)
+kill -12 <pid>
+```
+
+The dump is printed to stderr at `FI_LOG_LEVEL=warn` (or higher).
+
+## Output Format
+
+```
+=== EFA RDM EP STATE DUMP ===
+--- EP-level counters ---
+efa_outstanding_tx_ops=3 efa_rnr_queued_pkt_cnt=0 efa_rx_pkts_posted=512 efa_rx_pkts_held=2 efa_max_outstanding_tx_ops=8192 efa_max_outstanding_rx_ops=8192
+queued_copy_num=0 ope_queued_before_handshake_cnt=0 txe_cnt=2 rxe_cnt=1
+--- Peer-level state ---
+  PEER 0x5555deadbeef fi_addr=0 flags=0x4 exp_msg_id=10 next_msg_id=12 txe_cnt=0 rxe_cnt=0 overflow_cnt=0 rnr_queued=0 backoff_wait=0 us outstanding_tx=0
+  PEER 0x5555cafebabe fi_addr=1 flags=0x4 exp_msg_id=42 next_msg_id=45 txe_cnt=1 rxe_cnt=0 overflow_cnt=0 rnr_queued=0 backoff_wait=0 us outstanding_tx=1
+    TXE peer=0x5555cafebabe fi_addr=1 msg_id=44 op=2 total_len=1310720 bytes_sent=0 window=0 internal_flags=0x0
+=== END EFA RDM EP STATE DUMP ===
+```
+
+All peers are dumped regardless of whether they have outstanding operations.
+The `peer=` pointer in TXE/RXE lines can be used to cross-reference with the
+`PEER` line above.
+
+In debug builds, queued packet entries are additionally printed under each
+TXE/RXE via `efa_rdm_pke_print()`.
+
+## Interpreting the Dump
+
+### Endpoint-Level Fields
+
+| Field | Meaning |
+|-------|---------|
+| `efa_outstanding_tx_ops` | Number of send/read operations submitted to EFA device but not yet completed |
+| `efa_rnr_queued_pkt_cnt` | Packets queued due to RNR (Receiver Not Ready) errors |
+| `efa_rx_pkts_posted` | Receive buffers posted to the EFA device |
+| `efa_rx_pkts_held` | RX packets held by progress engine (pending copy or local read) |
+| `queued_copy_num` | Number of queued memory copies (HMEM) |
+| `ope_queued_before_handshake_cnt` | Operations waiting for peer handshake |
+| `txe_cnt` | Total outstanding TX operations across all peers |
+| `rxe_cnt` | Total outstanding RX operations across all peers |
+
+### Per-Peer Fields
+
+| Field | Meaning |
+|-------|---------|
+| `PEER <ptr>` | Pointer to the peer structure (for cross-referencing with TXE/RXE) |
+| `fi_addr` | Fabric address of the peer |
+| `flags` | Peer state flags (see below) |
+| `exp_msg_id` | Next expected message ID in the reorder buffer |
+| `next_msg_id` | Next message ID to assign when sending to this peer |
+| `txe_cnt` | Outstanding send operations to this peer |
+| `rxe_cnt` | Outstanding receive operations from this peer |
+| `overflow_cnt` | Messages in the overflow list (exceeded reorder window) |
+| `rnr_queued` | Packets queued for RNR retry to this peer |
+| `backoff_wait` | Current RNR backoff wait time in microseconds |
+| `outstanding_tx` | TX operations outstanding on EFA device for this peer |
+
+### Peer Flags
+
+| Flag | Hex | Meaning |
+|------|-----|---------|
+| `EFA_RDM_PEER_REQ_SENT` | 0x1 | Initial request sent to peer |
+| `EFA_RDM_PEER_HANDSHAKE_SENT` | 0x2 | Handshake packet sent |
+| `EFA_RDM_PEER_HANDSHAKE_RECEIVED` | 0x4 | Handshake received from peer |
+| `EFA_RDM_PEER_IN_BACKOFF` | 0x8 | Peer is in RNR backoff mode |
+
+### Per-Peer Operation Fields (TXE/RXE)
+
+| Field | Meaning |
+|-------|---------|
+| `peer` | Pointer to the peer structure (matches `PEER <ptr>` above) |
+| `fi_addr` | Fabric address of the peer |
+| `msg_id` | Message sequence number |
+| `op` | Operation type (2=msg, 3=tagged, etc.) |
+| `total_len` | Total message length in bytes |
+| `bytes_sent` | Bytes transmitted so far |
+| `window` | CTS credit window remaining (long-CTS protocol) |
+| `internal_flags` | Queued state flags (see below) |
+
+### Operation Internal Flags
+
+| Flag | Meaning |
+|------|---------|
+| `[QUEUED_RNR]` | Operation queued due to RNR, waiting for backoff to expire |
+| `[QUEUED_CTRL]` | Control packet queued (e.g., CTS, EOR) |
+| `[QUEUED_READ]` | RDMA read operation queued (waiting for resources) |
+| `[QUEUED_HANDSHAKE]` | Operation waiting for handshake to complete |
+
+## Common Hang Patterns
+
+### Pattern 1: Waiting for CTS (Long-CTS Protocol)
+
+```
+  PEER 0x5555cafebabe fi_addr=1 flags=0x4 exp_msg_id=100 next_msg_id=101 txe_cnt=1 ...
+    TXE peer=0x5555cafebabe fi_addr=1 msg_id=100 op=2 total_len=1310720 bytes_sent=0 window=0 internal_flags=0x0
+```
+
+**Diagnosis**: Sender has a TXE with `bytes_sent=0` and `window=0`. This
+means the sender sent a LONGCTS_RTM request and is waiting for the
+receiver to reply with a CTS (Clear To Send) packet. The CTS never
+arrived.
+
+**Root cause**: CTS packet lost at the SRD fabric level, or receiver
+never processed the RTM (check receiver's dump).
+
+### Pattern 2: Waiting for RDMA Read Completion (Long-Read Protocol)
+
+```
+  PEER 0x5555cafebabe fi_addr=1 flags=0x4 exp_msg_id=100 next_msg_id=101 txe_cnt=1 ...
+    TXE peer=0x5555cafebabe fi_addr=1 msg_id=100 op=2 total_len=1310720 bytes_sent=1310720 window=0 internal_flags=0x0
+```
+
+On the receiver side:
+```
+  PEER 0x5555deadbeef fi_addr=0 flags=0x4 ... rxe_cnt=1 ...
+    RXE peer=0x5555deadbeef fi_addr=0 msg_id=100 op=2 total_len=1310720 bytes_sent=0 window=1310720 internal_flags=0x0
+```
+
+**Diagnosis**: Sender shows `bytes_sent=total_len` (RTM sent with memory
+key). Receiver has an RXE with `window > 0` indicating it issued an RDMA
+read but the read never completed.
+
+**Root cause**: RDMA read operation failed silently at the fabric level,
+or the EOR (End Of Read) packet from receiver to sender was lost.
+
+### Pattern 3: RNR Backoff Storm
+
+```
+  PEER 0x5555cafebabe fi_addr=1 flags=0xc ... rnr_queued=15 backoff_wait=1000000 us outstanding_tx=0
+    TXE peer=0x5555cafebabe fi_addr=1 msg_id=50 op=2 total_len=65536 bytes_sent=0 window=0 internal_flags=0x200 [QUEUED_RNR]
+```
+
+**Diagnosis**: Peer is in backoff (`flags` has `0x8`), with packets
+queued for RNR retry. The `backoff_wait` shows how long the backoff
+period is (1 second in this example).
+
+**Root cause**: Receiver's RQ was full when the sender tried to send.
+With exponential backoff, wait times can grow large. If the receiver
+never posts new receive buffers, this becomes a permanent hang.
+
+**Action**: Check if `efa_rx_pkts_posted` on the receiver is 0 or very
+low. Increase `FI_EFA_RX_SIZE` if needed.
+
+### Pattern 4: Handshake Deadlock
+
+```
+  PEER 0x5555cafebabe fi_addr=1 flags=0x2 ... txe_cnt=1 ...
+    TXE peer=0x5555cafebabe fi_addr=1 msg_id=0 op=2 total_len=1310720 bytes_sent=0 window=0 internal_flags=0x4000 [QUEUED_HANDSHAKE]
+```
+
+**Diagnosis**: Operation is queued waiting for handshake (`flags=0x2`
+means handshake sent but not received back). The peer hasn't responded
+to the handshake.
+
+**Root cause**: Handshake packet lost, or peer hasn't started yet, or
+peer's RQ is full (RNR on handshake).
+
+### Pattern 5: Receive Window Overflow
+
+```
+  PEER 0x5555cafebabe fi_addr=1 flags=0x4 exp_msg_id=42 next_msg_id=100 ... overflow_cnt=50 ...
+```
+
+**Diagnosis**: Large gap between `exp_msg_id` (42) and `next_msg_id`
+(100) with many entries in the overflow list. The receiver is waiting
+for message 42 which never arrived, blocking all subsequent messages.
+
+**Root cause**: Message 42 was lost. All messages 43-99+ are buffered
+but can't be processed until 42 arrives.
+
+**Action**: Increase `FI_EFA_RECVWIN_SIZE` to buffer more out-of-order
+messages while investigating the packet loss.
+
+### Pattern 6: No Outstanding Operations (Idle Hang)
+
+```
+=== EFA RDM EP STATE DUMP ===
+--- EP-level counters ---
+efa_outstanding_tx_ops=0 efa_rnr_queued_pkt_cnt=0 ... txe_cnt=0 rxe_cnt=0
+--- Peer-level state ---
+  PEER 0x5555deadbeef fi_addr=0 flags=0x4 exp_msg_id=10 next_msg_id=10 txe_cnt=0 rxe_cnt=0 overflow_cnt=0 rnr_queued=0 backoff_wait=0 us outstanding_tx=0
+=== END EFA RDM EP STATE DUMP ===
+```
+
+**Diagnosis**: No outstanding operations on any peer. The EFA provider
+has nothing pending.
+
+**Root cause**: The hang is above the provider level — likely in the
+MPI layer or application. The provider completed all its work but the
+upper layer is waiting for something else (e.g., a message from a peer
+that the peer never sent because *it* is hung).
+
+**Action**: Check the dump on the peer side. One side will show
+outstanding operations.
+
+## Multi-Rank Debugging
+
+For MPI hangs, dump all ranks:
+
+```bash
+# Dump all MPI processes on this node (assuming FI_EFA_STATE_DUMP_SIGNAL=12)
+for pid in $(pgrep -f "my_application"); do
+    echo "=== PID $pid ===" >&2
+    kill -12 $pid
+    sleep 0.1
+done
+```
+
+Then correlate: find the rank with outstanding TXE/RXE and use the
+`peer=` pointer and `fi_addr` to identify which pair of ranks is stuck.
+
+## Environment Variables
+
+| Variable | Effect on Dump |
+|----------|---------------|
+| `FI_EFA_STATE_DUMP_SIGNAL=<N>` | Signal number to trigger dump (0=disabled, 10=SIGUSR1, 12=SIGUSR2) |
+| `FI_LOG_LEVEL=warn` | Minimum level to see dump output (default) |
+| `FI_EFA_RECVWIN_SIZE=N` | Changes reorder buffer size (affects overflow_cnt) |
+| `FI_EFA_MAX_TIMEOUT=N` | Caps RNR backoff wait time in microseconds (affects backoff_wait) |

--- a/prov/efa/src/efa_env.c
+++ b/prov/efa/src/efa_env.c
@@ -41,6 +41,7 @@ struct efa_env efa_env = {
 	.use_data_path_direct = true,
 	.implicit_av_size = 0,
 	.track_mr = 0,
+	.state_dump_signal = 0,
 };
 
 /* @brief Read and store the FI_EFA_* environment variables.
@@ -140,6 +141,7 @@ void efa_env_param_get(void)
 	}
 	fi_param_get_bool(&efa_prov, "use_data_path_direct", &efa_env.use_data_path_direct);
 	fi_param_get_bool(&efa_prov, "track_mr", &efa_env.track_mr);
+	fi_param_get_int(&efa_prov, "state_dump_signal", &efa_env.state_dump_signal);
 
 	efa_fork_support_request_initialize();
 }
@@ -236,6 +238,15 @@ void efa_env_define()
 			"any outstanding operations still reference an MR when "
 			"it is closed. This is useful for debugging memory "
 			"registration issues. (Default: false)");
+	fi_param_define(&efa_prov, "state_dump_signal", FI_PARAM_INT,
+			"Signal number that triggers an endpoint state dump "
+			"for debugging hangs in the RDM (protocol) path. "
+			"When the specified signal is received, RDM endpoint "
+			"and peer state is printed to stderr. "
+			"Currently only covers the EFA RDM protocol path. "
+			"Set to 0 to disable. "
+			"Example: 12 for SIGUSR2, 10 for SIGUSR1. "
+			"(Default: 0, disabled)");
 }
 
 

--- a/prov/efa/src/efa_env.h
+++ b/prov/efa/src/efa_env.h
@@ -79,6 +79,7 @@ struct efa_env {
 	 * operations still reference an MR when it is closed.
 	 */
 	int track_mr;
+	int state_dump_signal;
 };
 
 extern struct efa_env efa_env;

--- a/prov/efa/src/efa_prov.c
+++ b/prov/efa/src/efa_prov.c
@@ -7,6 +7,7 @@
 #include "efa_prov.h"
 #include "efa_prov_info.h"
 #include "efa_env.h"
+#include "rdm/efa_rdm_ep_dump.h"
 
 #ifndef _WIN32
 
@@ -242,6 +243,8 @@ EFA_INI
 
 	ofi_mutex_init(&g_efa_domain_list_lock);
 	dlist_init(&g_efa_domain_list);
+
+	efa_rdm_dump_init();
 
 	return &efa_prov;
 

--- a/prov/efa/src/rdm/efa_rdm_cq.c
+++ b/prov/efa/src/rdm/efa_rdm_cq.c
@@ -3,6 +3,7 @@
 
 #include "efa.h"
 #include "efa_rdm_cq.h"
+#include "efa_rdm_ep_dump.h"
 #include "efa_data_path_ops.h"
 #include "ofi_util.h"
 #include "efa_av.h"
@@ -1134,6 +1135,17 @@ static void efa_rdm_cq_progress(struct util_cq *cq)
 		(void) efa_rdm_cq_poll_ibv_cq(efa_env.efa_cq_read_size, poll_list_entry->cq);
 	}
 	efa_domain_progress_rdm_peers_and_queues(efa_domain);
+
+	/* Check for state dump request triggered by FI_EFA_STATE_DUMP_SIGNAL */
+	if (efa_env.state_dump_signal && g_efa_rdm_dump_requested) {
+		dlist_foreach(&cq->ep_list, item) {
+			fid_entry = container_of(item, struct fid_list_entry, entry);
+			efa_rdm_ep = container_of(fid_entry->fid, struct efa_rdm_ep, base_ep.util_ep.ep_fid.fid);
+			efa_rdm_dump_ep_state(efa_rdm_ep);
+		}
+		g_efa_rdm_dump_requested = 0;
+	}
+
 	ofi_genlock_unlock(&cq->ep_list_lock);
 }
 

--- a/prov/efa/src/rdm/efa_rdm_ep_dump.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_dump.c
@@ -1,0 +1,210 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+/*
+ * EFA RDM endpoint state dumper.
+ *
+ * Triggered by a user-configured signal (FI_EFA_STATE_DUMP_SIGNAL),
+ * dumps the current state of all EFA RDM endpoints to stderr at WARN
+ * level. This is useful for diagnosing hangs where the application is
+ * busy-polling with no forward progress.
+ *
+ * Usage:
+ *   export FI_EFA_STATE_DUMP_SIGNAL=12   # SIGUSR2
+ *   kill -12 <pid>
+ */
+
+#include "efa_rdm_ep.h"
+#include "efa_rdm_peer.h"
+#include "efa_rdm_ope.h"
+#include "efa.h"
+#include "efa_env.h"
+#if ENABLE_DEBUG
+#include "efa_rdm_pke.h"
+#include "efa_rdm_pke_print.h"
+#endif
+
+#include <signal.h>
+
+volatile sig_atomic_t g_efa_rdm_dump_requested = 0;
+
+static void efa_rdm_dump_signal_handler(int sig)
+{
+	g_efa_rdm_dump_requested = 1;
+}
+
+/**
+ * @brief Install signal handler for state dumping.
+ * Called once during provider initialization.
+ * Only installs the handler if FI_EFA_STATE_DUMP_SIGNAL is set to a nonzero value.
+ */
+void efa_rdm_dump_init(void)
+{
+	struct sigaction sa;
+
+	if (!efa_env.state_dump_signal)
+		return;
+
+	sa.sa_handler = efa_rdm_dump_signal_handler;
+	sa.sa_flags = 0;
+	sigemptyset(&sa.sa_mask);
+	sigaction(efa_env.state_dump_signal, &sa, NULL);
+}
+
+static void efa_rdm_dump_peer(struct efa_rdm_peer *peer)
+{
+	struct efa_rdm_ope *ope;
+	struct dlist_entry *tmp;
+#if ENABLE_DEBUG
+	struct efa_rdm_pke *pke;
+	struct dlist_entry *tmp2;
+#endif
+	int txe_cnt = 0, rxe_cnt = 0;
+	int overflow_cnt = 0;
+	struct efa_rdm_peer_overflow_pke_list_entry *overflow_entry;
+
+	if (!peer->conn)
+		return;
+
+	/* Count txe/rxe */
+	dlist_foreach_container_safe(&peer->txe_list,
+				    struct efa_rdm_ope, ope, peer_entry, tmp)
+		txe_cnt++;
+	dlist_foreach_container_safe(&peer->rxe_list,
+				    struct efa_rdm_ope, ope, peer_entry, tmp)
+		rxe_cnt++;
+
+	/* Count overflow list */
+	dlist_foreach_container_safe(&peer->overflow_pke_list,
+				    struct efa_rdm_peer_overflow_pke_list_entry,
+				    overflow_entry, entry, tmp)
+		overflow_cnt++;
+
+	EFA_WARN(FI_LOG_EP_CTRL,
+		 "  PEER %p fi_addr=%lu flags=0x%x "
+		 "exp_msg_id=%u next_msg_id=%u "
+		 "txe_cnt=%d rxe_cnt=%d overflow_cnt=%d "
+		 "rnr_queued=%d backoff_wait=%lu us "
+		 "outstanding_tx=%zu\n",
+		 (void *)peer,
+		 peer->conn->fi_addr,
+		 peer->flags,
+		 ofi_recvwin_next_exp_id((&peer->robuf)),
+		 peer->next_msg_id,
+		 txe_cnt, rxe_cnt, overflow_cnt,
+		 peer->rnr_queued_pkt_cnt,
+		 (unsigned long)peer->rnr_backoff_wait_time,
+		 peer->efa_outstanding_tx_ops);
+
+	/* Dump outstanding txe details */
+	dlist_foreach_container_safe(&peer->txe_list,
+				    struct efa_rdm_ope, ope, peer_entry, tmp) {
+		EFA_WARN(FI_LOG_EP_CTRL,
+			 "    TXE peer=%p fi_addr=%lu msg_id=%u op=%u total_len=%lu "
+			 "bytes_sent=%lu window=%ld "
+			 "internal_flags=0x%x%s%s%s%s\n",
+			 (void *)peer,
+			 peer->conn->fi_addr,
+			 ope->msg_id, ope->op,
+			 (unsigned long)ope->total_len,
+			 (unsigned long)ope->bytes_sent,
+			 (long)ope->window,
+			 ope->internal_flags,
+			 (ope->internal_flags & EFA_RDM_OPE_QUEUED_RNR) ? " [QUEUED_RNR]" : "",
+			 (ope->internal_flags & EFA_RDM_OPE_QUEUED_CTRL) ? " [QUEUED_CTRL]" : "",
+			 (ope->internal_flags & EFA_RDM_OPE_QUEUED_READ) ? " [QUEUED_READ]" : "",
+			 (ope->internal_flags & EFA_RDM_OPE_QUEUED_BEFORE_HANDSHAKE) ? " [QUEUED_HANDSHAKE]" : "");
+
+		#if ENABLE_DEBUG
+		dlist_foreach_container_safe(&ope->queued_pkts,
+					    struct efa_rdm_pke, pke, entry, tmp2) {
+			efa_rdm_pke_print(pke, "      queued_pkt");
+		}
+		#endif
+	}
+
+	/* Dump outstanding rxe details */
+	dlist_foreach_container_safe(&peer->rxe_list,
+				    struct efa_rdm_ope, ope, peer_entry, tmp) {
+		EFA_WARN(FI_LOG_EP_CTRL,
+			 "    RXE peer=%p fi_addr=%lu msg_id=%u op=%u total_len=%lu "
+			 "bytes_sent=%lu window=%ld "
+			 "internal_flags=0x%x\n",
+			 (void *)peer,
+			 peer->conn->fi_addr,
+			 ope->msg_id, ope->op,
+			 (unsigned long)ope->total_len,
+			 (unsigned long)ope->bytes_sent,
+			 (long)ope->window,
+			 ope->internal_flags);
+
+		#if ENABLE_DEBUG
+		dlist_foreach_container_safe(&ope->queued_pkts,
+					    struct efa_rdm_pke, pke, entry, tmp2) {
+			efa_rdm_pke_print(pke, "      queued_pkt");
+		}
+		#endif
+	}
+}
+
+/**
+ * @brief Dump the state of an EFA RDM endpoint.
+ *
+ * Prints endpoint-level counters and per-peer state for all
+ * peers with outstanding operations.
+ */
+void efa_rdm_dump_ep_state(struct efa_rdm_ep *ep)
+{
+	struct efa_rdm_peer *peer;
+	struct efa_rdm_ope *ope;
+	struct dlist_entry *tmp;
+	int ep_txe_cnt = 0, ep_rxe_cnt = 0;
+
+	/* Count EP-level TXE/RXE totals */
+	dlist_foreach_container_safe(&ep->txe_list,
+				    struct efa_rdm_ope, ope, ep_entry, tmp)
+		ep_txe_cnt++;
+	dlist_foreach_container_safe(&ep->rxe_list,
+				    struct efa_rdm_ope, ope, ep_entry, tmp)
+		ep_rxe_cnt++;
+
+	EFA_WARN(FI_LOG_EP_CTRL,
+		 "=== EFA RDM EP STATE DUMP ===\n");
+
+	EFA_WARN(FI_LOG_EP_CTRL,
+		 "--- EP-level counters ---\n");
+	EFA_WARN(FI_LOG_EP_CTRL,
+		 "efa_outstanding_tx_ops=%zu "
+		 "efa_rnr_queued_pkt_cnt=%zu "
+		 "efa_rx_pkts_posted=%zu "
+		 "efa_rx_pkts_held=%zu "
+		 "efa_max_outstanding_tx_ops=%zu "
+		 "efa_max_outstanding_rx_ops=%zu\n",
+		 ep->efa_outstanding_tx_ops,
+		 ep->efa_rnr_queued_pkt_cnt,
+		 ep->efa_rx_pkts_posted,
+		 ep->efa_rx_pkts_held,
+		 ep->efa_max_outstanding_tx_ops,
+		 ep->efa_max_outstanding_rx_ops);
+	EFA_WARN(FI_LOG_EP_CTRL,
+		 "queued_copy_num=%d "
+		 "ope_queued_before_handshake_cnt=%zu "
+		 "txe_cnt=%d rxe_cnt=%d\n",
+		 ep->queued_copy_num,
+		 ep->ope_queued_before_handshake_cnt,
+		 ep_txe_cnt, ep_rxe_cnt);
+
+	EFA_WARN(FI_LOG_EP_CTRL,
+		 "--- Peer-level state ---\n");
+
+	/* Iterate all peers */
+	dlist_foreach_container_safe(&ep->ep_peer_list,
+				    struct efa_rdm_peer, peer,
+				    ep_peer_list_entry, tmp) {
+		efa_rdm_dump_peer(peer);
+	}
+
+	EFA_WARN(FI_LOG_EP_CTRL,
+		 "=== END EFA RDM EP STATE DUMP ===\n");
+}
+

--- a/prov/efa/src/rdm/efa_rdm_ep_dump.h
+++ b/prov/efa/src/rdm/efa_rdm_ep_dump.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#ifndef EFA_RDM_EP_DUMP_H
+#define EFA_RDM_EP_DUMP_H
+
+#include <signal.h>
+#include "efa_rdm_ep.h"
+
+extern volatile sig_atomic_t g_efa_rdm_dump_requested;
+
+void efa_rdm_dump_init(void);
+void efa_rdm_dump_ep_state(struct efa_rdm_ep *ep);
+
+#endif /* EFA_RDM_EP_DUMP_H */


### PR DESCRIPTION
Add a configurable state dump facility for debugging EFA RDM hangs. When FI_EFA_STATE_DUMP_SIGNAL is set to a signal number (e.g. 12 for SIGUSR2), the provider installs a handler that dumps EP counters and per-peer state (outstanding TXE/RXE, reorder buffer, RNR backoff, overflow) to stderr on the next CQ progress call.

In debug builds, queued packet headers are additionally printed via efa_rdm_pke_print().