### PR TITLE
prov/efa: Add generation counter to efa_rdm_ope for use-after-free detection

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -101,7 +101,7 @@
 /*
  * Define bitmask to compare packet generation
  */
-#define EFA_RDM_PACKET_GEN_MASK (EFA_RDM_BUFPOOL_ALIGNMENT - 1)
+#define EFA_RDM_GEN_MASK (EFA_RDM_BUFPOOL_ALIGNMENT - 1)
 
 
 struct efa_fabric {

--- a/prov/efa/src/rdm/efa_rdm_cq.c
+++ b/prov/efa/src/rdm/efa_rdm_cq.c
@@ -168,7 +168,7 @@ static struct fi_ops efa_rdm_cq_fi_ops = {
 static inline void efa_rdm_cq_increment_pkt_entry_gen(struct efa_rdm_pke *pkt_entry)
 {
 	pkt_entry->gen++;
-	pkt_entry->gen &= EFA_RDM_PACKET_GEN_MASK;
+	pkt_entry->gen &= EFA_RDM_GEN_MASK;
 }
 
 /**

--- a/prov/efa/src/rdm/efa_rdm_cq.c
+++ b/prov/efa/src/rdm/efa_rdm_cq.c
@@ -687,6 +687,7 @@ enum ibv_wc_status efa_rdm_cq_process_wc_closing_ep(struct efa_ibv_cq *cq, struc
 #if HAVE_LTTNG
 	efa_rdm_tracepoint(poll_cq, (size_t) wr_id);
 	if (pkt_entry && pkt_entry->ope)
+		efa_rdm_pke_assert_ope_valid(pkt_entry);
 		efa_rdm_tracepoint(poll_cq_ope, pkt_entry->ope->msg_id,
 				   (size_t) pkt_entry->ope->cq_entry.op_context,
 				   pkt_entry->ope->total_len, pkt_entry->ope->cq_entry.tag,
@@ -753,6 +754,7 @@ enum ibv_wc_status efa_rdm_cq_process_wc(struct efa_ibv_cq *cq, struct efa_rdm_e
 #if HAVE_LTTNG
 	efa_rdm_tracepoint(poll_cq, (size_t) wr_id);
 	if (pkt_entry && pkt_entry->ope)
+		efa_rdm_pke_assert_ope_valid(pkt_entry);
 		efa_rdm_tracepoint(poll_cq_ope, pkt_entry->ope->msg_id,
 				   (size_t) pkt_entry->ope->cq_entry.op_context,
 				   pkt_entry->ope->total_len, pkt_entry->ope->cq_entry.tag,

--- a/prov/efa/src/rdm/efa_rdm_cq.h
+++ b/prov/efa/src/rdm/efa_rdm_cq.h
@@ -28,9 +28,9 @@ int efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq);
 static inline struct efa_rdm_pke *efa_rdm_cq_get_pke_from_wr_id_solicited(uint64_t wr_id)
 {
 	struct efa_rdm_pke *pkt_entry;
-	uint8_t gen = wr_id & EFA_RDM_PACKET_GEN_MASK;
+	uint8_t gen = wr_id & EFA_RDM_GEN_MASK;
 
-	wr_id &= ~((uint64_t)EFA_RDM_PACKET_GEN_MASK);
+	wr_id &= ~((uint64_t)EFA_RDM_GEN_MASK);
 	pkt_entry = (struct efa_rdm_pke *) wr_id;
 	if (OFI_UNLIKELY(pkt_entry->gen != gen)) {
 		EFA_WARN(FI_LOG_CQ, "Received packet from wrong generation! pkt_entry %p expected gen %d received gen %d\n", pkt_entry, pkt_entry->gen, gen);

--- a/prov/efa/src/rdm/efa_rdm_ep_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_utils.c
@@ -373,6 +373,9 @@ void efa_rdm_ep_record_tx_op_completed(struct efa_rdm_ep *ep, struct efa_rdm_pke
 {
 	struct efa_rdm_ope *ope = NULL;
 
+	if (pkt_entry->ope)
+		efa_rdm_pke_assert_ope_valid(pkt_entry);
+
 #if ENABLE_DEBUG
 	/*
 	 * Record completion event based on operation type.
@@ -605,7 +608,7 @@ static ssize_t efa_rdm_ep_handshake_common(struct efa_rdm_ep *ep, struct efa_rdm
 		return -FI_EAGAIN;
 	}
 
-	pkt_entry->ope = txe;
+	efa_rdm_pke_set_ope(pkt_entry, txe);
 	pkt_entry->peer = peer;
 
 	if (trigger_mode) {

--- a/prov/efa/src/rdm/efa_rdm_msg.c
+++ b/prov/efa/src/rdm/efa_rdm_msg.c
@@ -824,7 +824,7 @@ efa_rdm_msg_alloc_rxe_for_msgrtm(struct efa_rdm_ep *ep,
 			efa_base_ep_write_eq_error(&ep->base_ep, FI_ENOBUFS, FI_EFA_ERR_RXE_POOL_EXHAUSTED);
 			return NULL;
 		}
-		(*pkt_entry_ptr)->ope = rxe;
+		efa_rdm_pke_set_ope(*pkt_entry_ptr, rxe);
 		peer_rxe->peer_context = (*pkt_entry_ptr);
 		rxe->peer_rxe = peer_rxe;
 
@@ -912,7 +912,7 @@ efa_rdm_msg_alloc_rxe_for_tagrtm(struct efa_rdm_ep *ep,
 			efa_base_ep_write_eq_error(&ep->base_ep, FI_ENOBUFS, FI_EFA_ERR_RXE_POOL_EXHAUSTED);
 			return NULL;
 		}
-		(*pkt_entry_ptr)->ope = rxe;
+		efa_rdm_pke_set_ope(*pkt_entry_ptr, rxe);
 
 		if (efa_rdm_pke_get_base_hdr(*pkt_entry_ptr)->flags &
 		    EFA_RDM_REQ_OPT_CQ_DATA_HDR) {

--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -151,6 +151,8 @@ void efa_rdm_txe_release(struct efa_rdm_ope *txe)
 		txe->internal_flags &= ~EFA_RDM_OPE_QUEUED_FLAGS;
 	}
 
+	txe->gen++;
+	txe->gen &= EFA_RDM_GEN_MASK;
 #ifdef ENABLE_EFA_POISONING
 	efa_rdm_poison_mem_region(txe,
 			      sizeof(struct efa_rdm_ope));
@@ -209,6 +211,8 @@ void efa_rdm_rxe_release_internal(struct efa_rdm_ope *rxe)
 		rxe->internal_flags &= ~EFA_RDM_OPE_QUEUED_FLAGS;
 	}
 
+	rxe->gen++;
+	rxe->gen &= EFA_RDM_GEN_MASK;
 #ifdef ENABLE_EFA_POISONING
 	efa_rdm_poison_mem_region(rxe,
 			      sizeof(struct efa_rdm_ope));

--- a/prov/efa/src/rdm/efa_rdm_ope.h
+++ b/prov/efa/src/rdm/efa_rdm_ope.h
@@ -69,6 +69,7 @@ enum efa_rdm_cuda_copy_method {
  */
 struct efa_rdm_ope {
 	enum efa_rdm_ope_type type;
+	uint8_t gen; /**< generation counter, incremented on release for use-after-free detection */
 
 	struct efa_rdm_ep *ep;
 	struct efa_rdm_peer *peer;

--- a/prov/efa/src/rdm/efa_rdm_pke.c
+++ b/prov/efa/src/rdm/efa_rdm_pke.c
@@ -67,7 +67,7 @@ struct efa_rdm_pke *efa_rdm_pke_alloc(struct efa_rdm_ep *ep,
 #endif
 	/* Without poisoning, debug_info pointer is naturally preserved in memory. */
 
-	pkt_entry->gen &= EFA_RDM_PACKET_GEN_MASK;
+	pkt_entry->gen &= EFA_RDM_GEN_MASK;
 	dlist_init(&pkt_entry->entry);
 
 #if ENABLE_DEBUG
@@ -436,8 +436,8 @@ void efa_rdm_pke_append(struct efa_rdm_pke *dst,
 
 static inline uint64_t efa_rdm_pke_get_wr_id(struct efa_rdm_pke *pkt_entry)
 {
-	assert((uint64_t)pkt_entry->gen == ((uint64_t)pkt_entry->gen & EFA_RDM_PACKET_GEN_MASK));
-	assert((uint64_t)pkt_entry == ((uint64_t)pkt_entry & ~((uint64_t)EFA_RDM_PACKET_GEN_MASK)));
+	assert((uint64_t)pkt_entry->gen == ((uint64_t)pkt_entry->gen & EFA_RDM_GEN_MASK));
+	assert((uint64_t)pkt_entry == ((uint64_t)pkt_entry & ~((uint64_t)EFA_RDM_GEN_MASK)));
 	return (uint64_t) pkt_entry | (uint64_t) pkt_entry->gen;
 }
 
@@ -782,8 +782,8 @@ ssize_t efa_rdm_pke_recvv(struct efa_rdm_pke **pke_vec,
 
 #if ENABLE_DEBUG
 /* Compile-time assertion that debug_info gen field can hold all possible gen values */
-_Static_assert(EFA_RDM_PKE_DEBUG_GEN_MASK >= EFA_RDM_PACKET_GEN_MASK, 
-               "DEBUG_GEN_BITS insufficient to hold EFA_RDM_PACKET_GEN_MASK");
+_Static_assert(EFA_RDM_PKE_DEBUG_GEN_MASK >= EFA_RDM_GEN_MASK, 
+               "DEBUG_GEN_BITS insufficient to hold EFA_RDM_GEN_MASK");
 
 /**
  * @brief Print debug info history for packet entry

--- a/prov/efa/src/rdm/efa_rdm_pke.c
+++ b/prov/efa/src/rdm/efa_rdm_pke.c
@@ -22,6 +22,7 @@
 #include "efa_rdm_pke_req.h"
 #include "efa_rdm_tracepoint.h"
 #include "efa_rdm_pke_print.h"
+#include "efa_rdm_pke_utils.h"
 
 /**
  * @brief allocate a packet entry
@@ -269,7 +270,10 @@ void efa_rdm_pke_copy(struct efa_rdm_pke *dest,
 	 * is tied to the memory region, therefore should
 	 * not be changed.
 	 */
-	dest->ope = src->ope;
+	if (src->ope)
+		efa_rdm_pke_set_ope(dest, src->ope);
+	else
+		dest->ope = NULL;
 
 	/* Pkt from read-copy pkt pool is only used for staging data
 	 * that will be copied to application buffer via rdma-read,
@@ -514,6 +518,7 @@ ssize_t efa_rdm_pke_sendv(struct efa_rdm_pke **pkt_entry_vec,
 			/* Currently this is only expected for eager pkts */
 			assert(pkt_entry_cnt == 1);
 			assert(peer->extra_info[0] & EFA_RDM_EXTRA_FEATURE_REQUEST_USER_RECV_QP);
+			efa_rdm_pke_assert_ope_valid(pkt_entry);
 			if (pkt_entry->ope->fi_flags & FI_REMOTE_CQ_DATA) {
 				flags_in_loop |= FI_REMOTE_CQ_DATA;
 				cq_data = pkt_entry->ope->cq_entry.data;

--- a/prov/efa/src/rdm/efa_rdm_pke.h
+++ b/prov/efa/src/rdm/efa_rdm_pke.h
@@ -155,6 +155,8 @@ struct efa_rdm_pke {
 
 	/** @brief pointer to #efa_rdm_ope */
 	struct efa_rdm_ope *ope;
+	/** @brief generation of ope when this pke was associated with it */
+	uint8_t ope_gen;
 
 	/** @brief number of bytes sent/received over wire */
 	size_t pkt_size;

--- a/prov/efa/src/rdm/efa_rdm_pke_cmd.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_cmd.c
@@ -420,6 +420,7 @@ void efa_rdm_pke_handle_tx_error(struct efa_rdm_pke *pkt_entry, int prov_errno)
 		return;
 	}
 
+	efa_rdm_pke_assert_ope_valid(pkt_entry);
 	switch (pkt_entry->ope->type) {
 	case EFA_RDM_TXE:
 		txe = pkt_entry->ope;
@@ -536,6 +537,7 @@ void efa_rdm_pke_handle_send_completion(struct efa_rdm_pke *pkt_entry)
 {
 	struct efa_rdm_ep *ep;
 
+	efa_rdm_pke_assert_ope_valid(pkt_entry);
 	ep = pkt_entry->ep;
 
 	efa_rdm_ep_record_tx_op_completed(ep, pkt_entry);
@@ -563,6 +565,7 @@ void efa_rdm_pke_handle_send_completion(struct efa_rdm_pke *pkt_entry)
 	/* Start handling pkts with hdrs */
 	switch (efa_rdm_pkt_type_of(pkt_entry)) {
 	case EFA_RDM_HANDSHAKE_PKT:
+		efa_rdm_pke_assert_ope_valid(pkt_entry);
 		efa_rdm_tracepoint(handshake_send_completion,
 				   (size_t) pkt_entry, pkt_entry->pkt_size,
 				   pkt_entry->ope->msg_id,
@@ -650,7 +653,7 @@ void efa_rdm_pke_handle_send_completion(struct efa_rdm_pke *pkt_entry)
 		 * so this check must come after that call.
 		 * Only release TXE when both TX ops complete and receipt is received.
 		 */
-		assert(pkt_entry->ope);
+		efa_rdm_pke_assert_ope_valid(pkt_entry);
 		if (efa_rdm_txe_dc_ready_for_release(pkt_entry->ope))
 			efa_rdm_txe_release(pkt_entry->ope);
 		break;
@@ -712,6 +715,7 @@ void efa_rdm_pke_handle_rx_error(struct efa_rdm_pke *pkt_entry, int prov_errno)
 		return;
 	}
 
+	efa_rdm_pke_assert_ope_valid(pkt_entry);
 	if (pkt_entry->ope->type == EFA_RDM_TXE) {
 		efa_rdm_txe_handle_error(pkt_entry->ope, err, prov_errno);
 	} else if (pkt_entry->ope->type == EFA_RDM_RXE) {

--- a/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
@@ -175,7 +175,7 @@ ssize_t efa_rdm_pke_init_cts(struct efa_rdm_pke *pkt_entry,
 	cts_hdr->connid = efa_rdm_ep_raw_addr(ope->ep)->qkey;
 
 	pkt_entry->peer = ope->peer;
-	pkt_entry->ope = (void *)ope;
+	efa_rdm_pke_set_ope(pkt_entry, (void *)ope);
 	return 0;
 }
 
@@ -261,7 +261,7 @@ int efa_rdm_pke_init_ctsdata(struct efa_rdm_pke *pkt_entry,
 	if (ret)
 		return ret;
 
-	pkt_entry->ope = (void *)ope;
+	efa_rdm_pke_set_ope(pkt_entry, (void *)ope);
 	pkt_entry->peer = ope->peer;
 
 	return 0;
@@ -454,7 +454,7 @@ void efa_rdm_pke_init_write_context(struct efa_rdm_pke *pkt_entry,
 {
 	struct efa_rdm_rma_context_pkt *rma_context_pkt;
 
-	pkt_entry->ope = (void *)txe;
+	efa_rdm_pke_set_ope(pkt_entry, (void *)txe);
 	pkt_entry->peer = txe->peer;
 	rma_context_pkt = (struct efa_rdm_rma_context_pkt *)pkt_entry->wiredata;
 	rma_context_pkt->type = EFA_RDM_RMA_CONTEXT_PKT;
@@ -476,7 +476,7 @@ void efa_rdm_pke_init_read_context(struct efa_rdm_pke *pkt_entry,
 {
 	struct efa_rdm_rma_context_pkt *ctx_pkt;
 
-	pkt_entry->ope = ope;
+	efa_rdm_pke_set_ope(pkt_entry, ope);
 	pkt_entry->peer = ope->peer;
 	pkt_entry->pkt_size = sizeof(struct efa_rdm_rma_context_pkt);
 
@@ -517,6 +517,7 @@ void efa_rdm_pke_handle_rma_read_completion(struct efa_rdm_pke *context_pkt_entr
 					assert(txe->ep->efa_rx_pkts_held > 0);
 					txe->ep->efa_rx_pkts_held--;
 				}
+				efa_rdm_pke_assert_ope_valid(data_pkt_entry);
 				efa_rdm_tracepoint(rx_pke_local_read_copy_payload_end, (size_t) data_pkt_entry, data_pkt_entry->payload_size, data_pkt_entry->ope->msg_id, (size_t) data_pkt_entry->ope->cq_entry.op_context, data_pkt_entry->ope->total_len);
 				efa_rdm_pke_handle_data_copied(data_pkt_entry);
 			} else {
@@ -626,7 +627,7 @@ int efa_rdm_pke_init_eor(struct efa_rdm_pke *pkt_entry, struct efa_rdm_ope *rxe)
 	eor_hdr->connid = efa_rdm_ep_raw_addr(rxe->ep)->qkey;
 	pkt_entry->pkt_size = sizeof(struct efa_rdm_eor_hdr);
 	pkt_entry->peer = rxe->peer;
-	pkt_entry->ope = rxe;
+	efa_rdm_pke_set_ope(pkt_entry, rxe);
 	return 0;
 }
 
@@ -659,7 +660,7 @@ int efa_rdm_pke_init_read_nack(struct efa_rdm_pke *pkt_entry, struct efa_rdm_ope
 	nack_hdr->connid = efa_rdm_ep_raw_addr(rxe->ep)->qkey;
 	pkt_entry->pkt_size = sizeof(struct efa_rdm_read_nack_hdr);
 	pkt_entry->peer = rxe->peer;
-	pkt_entry->ope = rxe;
+	efa_rdm_pke_set_ope(pkt_entry, rxe);
 	return 0;
 }
 
@@ -754,7 +755,7 @@ int efa_rdm_pke_init_receipt(struct efa_rdm_pke *pkt_entry, struct efa_rdm_ope *
 
 	pkt_entry->pkt_size = sizeof(struct efa_rdm_receipt_hdr);
 	pkt_entry->peer = rxe->peer;
-	pkt_entry->ope = rxe;
+	efa_rdm_pke_set_ope(pkt_entry, rxe);
 
 	return 0;
 }
@@ -813,7 +814,7 @@ int efa_rdm_pke_init_atomrsp(struct efa_rdm_pke *pkt_entry, struct efa_rdm_ope *
 
 	assert(rxe->atomrsp_data);
 	pkt_entry->peer = rxe->peer;
-	pkt_entry->ope = rxe;
+	efa_rdm_pke_set_ope(pkt_entry, rxe);
 
 	atomrsp_pkt = (struct efa_rdm_atomrsp_pkt *)pkt_entry->wiredata;
 	atomrsp_hdr = &atomrsp_pkt->hdr;

--- a/prov/efa/src/rdm/efa_rdm_pke_rta.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_rta.c
@@ -15,6 +15,7 @@
 #include "efa_rdm_protocol.h"
 #include "efa_rdm_pke_rta.h"
 #include "efa_rdm_pke_req.h"
+#include "efa_rdm_pke_utils.h"
 
 /**
  * @brief initialize the common elements of WRITE_RTA, FETCH_RTA and COMPARE_RTA
@@ -72,7 +73,7 @@ ssize_t efa_rdm_pke_init_rta_common(struct efa_rdm_pke *pkt_entry,
 	data_size = ret;
 
 	pkt_entry->pkt_size = hdr_size + data_size;
-	pkt_entry->ope = txe;
+	efa_rdm_pke_set_ope(pkt_entry, txe);
 	pkt_entry->peer = txe->peer;
 	return 0;
 }
@@ -161,6 +162,7 @@ ssize_t efa_rdm_pke_init_write_rta(struct efa_rdm_pke *pkt_entry,
  */
 void efa_rdm_pke_handle_write_rta_send_completion(struct efa_rdm_pke *pkt_entry)
 {
+	efa_rdm_pke_assert_ope_valid(pkt_entry);
 	efa_rdm_ope_handle_send_completed(pkt_entry->ope);
 }
 

--- a/prov/efa/src/rdm/efa_rdm_pke_rtm.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtm.c
@@ -295,7 +295,7 @@ ssize_t efa_rdm_pke_proc_msgrtm(struct efa_rdm_pke *pkt_entry)
 		}
 	}
 
-	pkt_entry->ope = rxe;
+	efa_rdm_pke_set_ope(pkt_entry, rxe);
 
 	if (rxe->state == EFA_RDM_RXE_MATCHED) {
 		err = efa_rdm_pke_proc_matched_rtm(pkt_entry);
@@ -343,7 +343,7 @@ static ssize_t efa_rdm_pke_proc_tagrtm(struct efa_rdm_pke *pkt_entry)
 		}
 	}
 
-	pkt_entry->ope = rxe;
+	efa_rdm_pke_set_ope(pkt_entry, rxe);
 
 	if (rxe->state == EFA_RDM_RXE_MATCHED) {
 		err = efa_rdm_pke_proc_matched_rtm(pkt_entry);
@@ -454,13 +454,13 @@ void efa_rdm_pke_handle_rtm_rta_recv(struct efa_rdm_pke *pkt_entry)
 		rxe = efa_rdm_rxe_map_lookup(&peer->rxe_map, efa_rdm_pke_get_rtm_msg_id(pkt_entry));
 		if (rxe) {
 			if (rxe->state == EFA_RDM_RXE_MATCHED) {
-				pkt_entry->ope = rxe;
+				efa_rdm_pke_set_ope(pkt_entry, rxe);
 				efa_rdm_pke_proc_matched_mulreq_rtm(pkt_entry);
 			} else {
 				assert(rxe->unexp_pkt);
 				unexp_pkt_entry = efa_rdm_pke_get_unexp(&pkt_entry);
 				efa_rdm_pke_append(rxe->unexp_pkt, unexp_pkt_entry);
-				unexp_pkt_entry->ope = rxe;
+				efa_rdm_pke_set_ope(pkt_entry, rxe);
 			}
 
 			return;
@@ -544,7 +544,7 @@ static inline
 ssize_t efa_rdm_pke_init_eager_msgrtm_zero_hdr(struct efa_rdm_pke *pkt_entry,
 				      struct efa_rdm_ope *txe)
 {
-	pkt_entry->ope = txe;
+	efa_rdm_pke_set_ope(pkt_entry, txe);
 	pkt_entry->peer = txe->peer;
 
 	return efa_rdm_pke_init_payload_from_ope(pkt_entry, txe,
@@ -1141,7 +1141,7 @@ ssize_t efa_rdm_pke_init_longread_rtm(struct efa_rdm_pke *pkt_entry,
 		return err;
 
 	pkt_entry->pkt_size = hdr_size + txe->iov_count * sizeof(struct fi_rma_iov);
-	pkt_entry->ope = txe;
+	efa_rdm_pke_set_ope(pkt_entry, txe);
 	pkt_entry->peer = txe->peer;
 	return 0;
 }

--- a/prov/efa/src/rdm/efa_rdm_pke_rtr.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtr.c
@@ -11,6 +11,7 @@
 #include "efa_rdm_ep.h"
 #include "efa_rdm_rma.h"
 #include "efa_rdm_ope.h"
+#include "efa_rdm_pke_utils.h"
 #include "efa_rdm_pke.h"
 #include "efa_rdm_protocol.h"
 #include "efa_rdm_pke_req.h"
@@ -37,7 +38,7 @@ void efa_rdm_pke_init_rtr_common(struct efa_rdm_pke *pkt_entry,
 	}
 
 	pkt_entry->pkt_size = efa_rdm_pke_get_req_hdr_size(pkt_entry);
-	pkt_entry->ope = txe;
+	efa_rdm_pke_set_ope(pkt_entry, txe);
 	pkt_entry->peer = txe->peer;
 }
 

--- a/prov/efa/src/rdm/efa_rdm_pke_rtw.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtw.c
@@ -511,7 +511,7 @@ ssize_t efa_rdm_pke_init_longread_rtw(struct efa_rdm_pke *pkt_entry,
 		return err;
 
 	pkt_entry->pkt_size = hdr_size + txe->iov_count * sizeof(struct efa_rma_iov);
-	pkt_entry->ope = txe;
+	efa_rdm_pke_set_ope(pkt_entry, txe);
 	return 0;
 }
 

--- a/prov/efa/src/rdm/efa_rdm_pke_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_utils.c
@@ -45,7 +45,7 @@ ssize_t efa_rdm_pke_init_payload_from_ope(struct efa_rdm_pke *pke,
 	size_t tx_iov_offset, copied;
 	struct efa_rdm_mr *iov_mr;
 
-	pke->ope = ope;
+	efa_rdm_pke_set_ope(pke, ope);
 	pke->peer = ope->peer;
 	if (data_size == 0) {
 		pke->pkt_size = payload_offset;
@@ -134,6 +134,7 @@ int efa_rdm_ep_flush_queued_blocking_copy_to_hmem(struct efa_rdm_ep *ep)
 		data = ep->queued_copy_vec[i].data;
 		segment_offset = ep->queued_copy_vec[i].data_offset;
 
+		efa_rdm_pke_assert_ope_valid(pkt_entry);
 		rxe = pkt_entry->ope;
 		desc = rxe->desc[0];
 		assert(desc && desc->efa_mr.iface != FI_HMEM_SYSTEM);
@@ -161,6 +162,7 @@ int efa_rdm_ep_flush_queued_blocking_copy_to_hmem(struct efa_rdm_ep *ep)
 		pkt_entry = ep->queued_copy_vec[i].pkt_entry;
 		segment_offset = ep->queued_copy_vec[i].data_offset;
 		rxe = pkt_entry->ope;
+		efa_rdm_pke_assert_ope_valid(pkt_entry);
 		if (pkt_entry->alloc_type == EFA_RDM_PKE_FROM_EFA_RX_POOL) {
 			assert(ep->efa_rx_pkts_held > 0);
 			ep->efa_rx_pkts_held--;
@@ -432,7 +434,7 @@ ssize_t efa_rdm_pke_copy_payload_to_ope(struct efa_rdm_pke *pke,
 	ep = pke->ep;
 	assert(ep);
 
-	pke->ope = ope;
+	efa_rdm_pke_set_ope(pke, ope);
 	segment_offset = efa_rdm_pke_get_segment_offset(pke);
 	/*
 	 * Under 3 rare situations, this function does not perform the copy

--- a/prov/efa/src/rdm/efa_rdm_pke_utils.h
+++ b/prov/efa/src/rdm/efa_rdm_pke_utils.h
@@ -250,4 +250,23 @@ int efa_rdm_pke_get_available_copy_methods(struct efa_rdm_ep *ep,
 
 struct efa_rdm_pke *efa_rdm_pke_get_ooo_pke(struct efa_rdm_pke *pkt_entry);
 
+/**
+ * @brief Set the ope pointer on a pke and capture the ope's current gen.
+ */
+static inline void efa_rdm_pke_set_ope(struct efa_rdm_pke *pke, struct efa_rdm_ope *ope)
+{
+	assert(ope);
+	pke->ope = ope;
+	pke->ope_gen = ope->gen;
+}
+
+/**
+ * @brief Assert that the pke's ope reference is still valid (not freed/reused).
+ */
+static inline void efa_rdm_pke_assert_ope_valid(struct efa_rdm_pke *pke)
+{
+	assert(pke->ope);
+	assert(pke->ope->gen == pke->ope_gen);
+}
+
 #endif


### PR DESCRIPTION
Add a gen counter to efa_rdm_ope that is incremented each time the OPE
is released. When a PKE points to an OPE (via pke->ope), it captures
the OPE's current gen in pke->ope_gen via efa_rdm_pke_set_ope(). At
every site where pke->ope is read, efa_rdm_pke_assert_ope_valid()
verifies that the OPE's gen still matches, detecting use-after-free bugs
where the OPE pool has recycled the memory for a different operation.

This mirrors the existing gen counter mechanism used for PKEs
(efa_rdm_cq_increment_pkt_entry_gen / efa_rdm_cq_get_pke_from_wr_id_solicited).

The OPE pool is aligned to EFA_RDM_BUFPOOL_ALIGNMENT (64 bytes), leaving
the lower 6 bits of the address always zero. The gen counter uses
EFA_RDM_GEN_MASK (0x3F) to wrap around within those bits.