### PR TITLE
prov/verbs: support lists for FI_VERBS_DEVICE_NAME and FI_VERBS_IFACE

### DIFF
--- a/man/fi_verbs.7.md
+++ b/man/fi_verbs.7.md
@@ -222,8 +222,8 @@ The verbs provider checks for the following environment variables.
 ### Variables specific to MSG endpoints
 
 *FI_VERBS_IFACE*
-: The prefix or the full name of the network interface associated with the verbs
-  device (default: ib)
+: A comma separated list of prefixes or full names of network interfaces
+  associated with the verbs devices to use (default: none)
 
 ### Variables specific to DGRAM endpoints
 

--- a/man/fi_verbs.7.md
+++ b/man/fi_verbs.7.md
@@ -201,7 +201,8 @@ The verbs provider checks for the following environment variables.
 : The GID index to use (default: 0)
 
 *FI_VERBS_DEVICE_NAME*
-: Specify a specific verbs device to use by name
+: A comma separated list of prefixes or full names of verbs devices to use.
+  (default: none)
 
 *FI_VERBS_USE_DMABUF*
 : If supported, try to use ibv_reg_dmabuf_mr first to register dmabuf-based

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -1428,6 +1428,8 @@ static int vrb_init_info(struct dlist_entry *verbs_devs,
 	struct fi_info *fi = NULL, *tail = NULL;
 	const struct verbs_ep_domain *ep_type[VERBS_NUM_DOMAIN_TYPES];
 	int ret = 0, i, j, num_devices, dom_count = 0;
+	char **device_names;
+	int device_name_found;
 
 	vrb_prof_func_start(__func__);
 
@@ -1476,6 +1478,8 @@ static int vrb_init_info(struct dlist_entry *verbs_devs,
 		goto done;
 	}
 
+	device_names = ofi_split_and_alloc(vrb_gl_data.device_name, ",", NULL);
+
 	vrb_prof_func_start("alloc_info_loop");
 	for (i = 0; i < num_devices; i++) {
 		if (!ctx_list[i]) {
@@ -1486,11 +1490,22 @@ static int vrb_init_info(struct dlist_entry *verbs_devs,
 			continue;
 		}
 
-		if (vrb_gl_data.device_name &&
-		    strncasecmp(ctx_list[i]->device->name,
-				vrb_gl_data.device_name,
-				strlen(vrb_gl_data.device_name)))
+		device_name_found = 0;
+		for (j=0; device_names && device_names[j]; j++) {
+			if (!strncasecmp(ctx_list[i]->device->name,
+					 device_names[j],
+					 strlen(device_names[j]))) {
+				device_name_found = 1;
+				break;
+			}
+		}
+
+		if (vrb_gl_data.device_name && !device_name_found) {
+			FI_INFO(&vrb_prov, FI_LOG_FABRIC,
+				"skipping device: %s, not in the list of "
+				"requested devices\n", ctx_list[i]->device->name);
 			continue;
+		}
 
 		for (j = 0; j < dom_count; j++) {
 			if (ep_type[j]->type == FI_EP_MSG &&
@@ -1538,6 +1553,7 @@ static int vrb_init_info(struct dlist_entry *verbs_devs,
 	ret = *all_infos ? 0 : ret;
 
 	rdma_free_devices(ctx_list);
+	ofi_free_string_array(device_names);
 done:
 	vrb_prof_func_end(__func__);
 	return ret;

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -32,6 +32,7 @@
  */
 
 #include <ofi_util.h>
+#include <ofi_str.h>
 
 #include <ifaddrs.h>
 #include <net/if.h>
@@ -1187,56 +1188,46 @@ close_device:
 	return num_verbs_ifs ? 0 : -FI_ENODATA;
 }
 
-/* Builds a list of interfaces that correspond to active verbs devices */
-static int vrb_getifaddrs(struct dlist_entry *verbs_devs)
-{
-	struct ifaddrs *ifaddr, *ifa;
+static int vrb_filter_ifaddrs(struct dlist_entry *verbs_devs,
+			      struct ifaddrs *ifaddrs, const char* iface_name) {
+	struct ifaddrs *ifa;
 	struct rdma_addrinfo *rai = NULL;
 	char *dev_name = NULL;
-	char *iface = vrb_gl_data.iface;
 	int ret, num_verbs_ifs = 0;
 	size_t iface_len = 0;
 	int exact_match = 0;
 
-	ret = ofi_getifaddrs(&ifaddr);
-	if (ret) {
-		VRB_WARN(FI_LOG_FABRIC,
-			   "unable to get interface addresses\n");
-		return ret;
-	}
-
-	/* select best iface name based on user's input */
-	if (iface) {
-		iface_len = strlen(iface);
+	if (iface_name) {
+		iface_len = strlen(iface_name);
 		if (iface_len > IFNAMSIZ) {
 			VRB_INFO(FI_LOG_FABRIC, "iface name: %s, too long "
-				   "max: %d\n", iface, IFNAMSIZ);
+				   "max: %d\n", iface_name, IFNAMSIZ);
 
 		}
-		for (ifa = ifaddr; ifa && !exact_match; ifa = ifa->ifa_next)
-			exact_match = !strcmp(ifa->ifa_name, iface);
+		for (ifa = ifaddrs; ifa && !exact_match; ifa = ifa->ifa_next)
+			exact_match = !strcmp(ifa->ifa_name, iface_name);
 	}
 
-	for (ifa = ifaddr; ifa; ifa = ifa->ifa_next) {
+	for (ifa = ifaddrs; ifa; ifa = ifa->ifa_next) {
 		if (!ifa->ifa_addr || !(ifa->ifa_flags & IFF_UP) ||
 				(ifa->ifa_flags & IFF_LOOPBACK))
 			continue;
 
-		if (iface) {
+		if (iface_name) {
 			if (exact_match) {
-				if (strcmp(ifa->ifa_name, iface)) {
+				if (strcmp(ifa->ifa_name, iface_name)) {
 					FI_INFO(&vrb_prov, FI_LOG_FABRIC,
 						"skipping interface: %s for FI_EP_MSG"
 						" as it doesn't match filter: %s\n",
-						ifa->ifa_name, iface);
+						ifa->ifa_name, iface_name);
 					continue;
 				}
 			} else {
-				if (strncmp(ifa->ifa_name, iface, iface_len)) {
+				if (strncmp(ifa->ifa_name, iface_name, iface_len)) {
 					FI_INFO(&vrb_prov, FI_LOG_FABRIC,
 						"skipping interface: %s for FI_EP_MSG"
 						" as it doesn't match filter: %s\n",
-						ifa->ifa_name, iface);
+						ifa->ifa_name, iface_name);
 					continue;
 				}
 			}
@@ -1255,9 +1246,37 @@ static int vrb_getifaddrs(struct dlist_entry *verbs_devs)
 		num_verbs_ifs++;
 	}
 
+	return num_verbs_ifs;
+}
+
+/* Builds a list of interfaces that correspond to active verbs devices */
+static int vrb_getifaddrs(struct dlist_entry *verbs_devs)
+{
+	int ret, num_verbs_ifs = 0, i;
+	char **iface_list = NULL;
+	struct ifaddrs *ifaddrs = NULL;
+
+	ret = ofi_getifaddrs(&ifaddrs);
+	if (ret) {
+		VRB_WARN(FI_LOG_FABRIC,
+			   "unable to get interface addresses\n");
+		return ret;
+	}
+
+	/* select best iface name based on user's input */
+	if (vrb_gl_data.iface) {
+		iface_list = ofi_split_and_alloc(vrb_gl_data.iface, ",", NULL);
+		for (i = 0; iface_list && iface_list[i]; i++)
+			num_verbs_ifs += vrb_filter_ifaddrs(verbs_devs, ifaddrs,
+							    iface_list[i]);
+		ofi_free_string_array(iface_list);
+	} else {
+		num_verbs_ifs = vrb_filter_ifaddrs(verbs_devs, ifaddrs, NULL);
+	}
+
 	verbs_devs_print(verbs_devs);
 
-	freeifaddrs(ifaddr);
+	freeifaddrs(ifaddrs);
 	return num_verbs_ifs ? 0 : -FI_ENODATA;
 }
 

--- a/prov/verbs/src/verbs_init.c
+++ b/prov/verbs/src/verbs_init.c
@@ -744,9 +744,9 @@ static int vrb_read_params(void)
 		 vrb_gl_data.dmabuf_support ? "enabled" : "disabled");
 
 	/* MSG-specific parameter */
-	if (vrb_get_param_str("iface", "The prefix or the full name of the "
-			      "network interface associated with the verbs "
-			      "device", &vrb_gl_data.iface)) {
+	if (vrb_get_param_str("iface", "A comma separated list of prefixes or "
+			      "full names of network interfaces associated with "
+			      "the verbs devices to use", &vrb_gl_data.iface)) {
 		VRB_WARN(FI_LOG_CORE, "Invalid value of iface\n");
 		return -FI_EINVAL;
 	}

--- a/prov/verbs/src/verbs_init.c
+++ b/prov/verbs/src/verbs_init.c
@@ -725,8 +725,9 @@ static int vrb_read_params(void)
 		return -FI_EINVAL;
 	}
 
-	if (vrb_get_param_str("device_name", "The prefix or the full name of the "
-			      "verbs device to use", &vrb_gl_data.device_name)) {
+	if (vrb_get_param_str("device_name", "A comma separated list of prefixes "
+			      "or full names of verbs devices to use",
+			      &vrb_gl_data.device_name)) {
 		VRB_WARN(FI_LOG_CORE, "Invalid value of device_name\n");
 		return -FI_EINVAL;
 	}


### PR DESCRIPTION
We sometimes want to limit to specific devices rather than all devices that match a prefix