### PR TITLE
common: fix byte order of AF_IB ofi_addr_set_port

### DIFF
--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -824,7 +824,7 @@ static inline void ofi_addr_set_port(struct sockaddr *addr, uint16_t port)
 		break;
     case AF_IB:
 		sib = (struct ofi_sockaddr_ib *)addr;
-		sib->sib_sid = htonll(((uint64_t)OFI_RDMA_PS_IB << 16) + ntohs(port));
+		sib->sib_sid = htonll(((uint64_t)OFI_RDMA_PS_IB << 16) + port);
 		sib->sib_sid_mask = htonll(OFI_IB_IP_PS_MASK | OFI_IB_IP_PORT_MASK);
 		break;
 	default:


### PR DESCRIPTION
The implementation of ofi_addr_get_port and ofi_addr_set_port did not allow for a succsessful round-trip of the sib_sid, which means users of these functions could not properly store and retrieve port information in a sockaddr.  original port information could not be recreated and instead would get a byte flipped port.

instead, construct a host-ordered sid and then convert ordering on the full value