### PR TITLE
prov/shm: add IOV fast path with cirque-based completion

### DIFF
--- a/prov/shm/Makefile.include
+++ b/prov/shm/Makefile.include
@@ -18,6 +18,8 @@ _shm_files = \
 	prov/shm/src/smr_dsa.h		\
 	prov/shm/src/smr_dsa.c		\
 	prov/shm/src/smr_util.h		\
+	prov/shm/src/smr_atom.h		\
+	prov/shm/src/smr_fifo.h		\
 	prov/shm/src/smr_util.c
 
 

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -256,20 +256,21 @@ void smr_format_tx_pend(struct smr_pend_entry *pend, struct smr_cmd *cmd,
 			uint64_t op_flags);
 void smr_generic_format(struct smr_cmd *cmd, int64_t tx_id, int64_t rx_id,
 			uint32_t op, uint64_t tag, uint64_t data,
-			uint64_t op_flags);
+			uint8_t smr_flags);
 size_t smr_copy_to_sar(struct smr_ep *ep, struct smr_region *smr,
 		       struct smr_pend_entry *pend);
 size_t smr_copy_from_sar(struct smr_ep *ep, struct smr_region *smr,
 		         struct smr_pend_entry *pend);
 int smr_select_proto(void **desc, size_t iov_count, bool cma_avail,
 		     bool ipc_valid, uint32_t op, uint64_t total_len,
-		     uint64_t op_flags);
+		     uint64_t op_flags, uint8_t *smr_flags);
 typedef ssize_t (*smr_send_func)(
 		struct smr_ep *ep, struct smr_region *peer_smr,
 		int64_t tx_id, int64_t rx_id, uint32_t op, uint64_t tag,
-		uint64_t data, uint64_t op_flags, struct ofi_mr **desc,
-		const struct iovec *iov, size_t iov_count, size_t total_len,
-		void *context, struct smr_cmd *cmd);
+		uint64_t data, uint64_t op_flags, uint8_t smr_flags,
+		struct ofi_mr **desc, const struct iovec *iov,
+		size_t iov_count, size_t total_len, void *context,
+		struct smr_cmd *cmd);
 extern smr_send_func smr_send_ops[smr_proto_max];
 
 int smr_write_err_comp(struct util_cq *cq, void *context,
@@ -280,9 +281,9 @@ int smr_complete_rx(struct smr_ep *ep, void *context, uint32_t op,
 		    uint64_t flags, size_t len, void *buf, int64_t id,
 		    uint64_t tag, uint64_t data);
 
-static inline uint64_t smr_rx_cq_flags(uint64_t rx_flags, uint16_t op_flags)
+static inline uint64_t smr_rx_cq_flags(uint64_t rx_flags, uint8_t smr_flags)
 {
-	if (op_flags & SMR_REMOTE_CQ_DATA)
+	if (smr_flags & SMR_REMOTE_CQ_DATA)
 		rx_flags |= FI_REMOTE_CQ_DATA;
 	return rx_flags;
 }

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -107,41 +107,12 @@ static inline uintptr_t smr_peer_to_peer(struct smr_ep *ep,
 	return (uintptr_t) peer_smr->base_addr + offset;
 }
 
-static inline uintptr_t smr_peer_to_owner(struct smr_ep *ep,
-					  struct smr_region *peer_smr,
-					  int64_t id, uintptr_t local_ptr)
-{
-	uint64_t offset = local_ptr - (uintptr_t) peer_smr;
-
-	return (uintptr_t) peer_smr->base_addr + offset;
-}
-
 static inline void smr_return_cmd(struct smr_ep *ep, struct smr_cmd *cmd)
 {
 	struct smr_region *peer_smr = smr_peer_region(ep, cmd->hdr.rx_id);
-	uintptr_t peer_ptr;
-	int64_t pos;
-	struct smr_return_entry *queue_entry;
-	int ret;
 
-	ret = smr_return_queue_next(smr_return_queue(peer_smr), &queue_entry,
-				    &pos);
-	if (ret == -FI_ENOENT) {
-		/* return queue runs in parallel to command stack
-		 * ie we will never run out of space
-		 */
-		assert(0);
-		return;
-	}
-
-	peer_ptr = smr_peer_to_owner(ep, peer_smr, cmd->hdr.rx_id,
-				     (uintptr_t) cmd);
-	assert(peer_ptr >= (uintptr_t) peer_smr->base_addr &&
-	       peer_ptr < (uintptr_t) peer_smr->base_addr +
-	       peer_smr->total_size);
-	queue_entry->ptr = peer_ptr;
-
-	smr_return_queue_commit(queue_entry, pos);
+	smr_fifo_write(smr_return_queue(peer_smr), (uintptr_t) peer_smr,
+		       (uintptr_t)cmd);
 }
 
 extern struct fi_provider smr_prov;

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -52,6 +52,11 @@ struct smr_ep {
 
 	struct slist		overflow_list;
 	struct dlist_entry	sar_list;
+
+	/* IOV resp tracking (out-of-order completion) */
+	uint64_t		last_comp_count;
+	uint64_t		slot_bitmap; /* bits set = slots in use */
+	struct smr_pend_entry	*slot_pend[SMR_IOV_LIMIT_SLOTS];
 	struct dlist_entry	async_cpy_list;
 	struct dlist_entry	unexp_cmd_list;
 	size_t			min_multi_recv_size;

--- a/prov/shm/src/smr_atom.h
+++ b/prov/shm/src/smr_atom.h
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2018      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2018      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2019-2021 Google, LLC. All rights reserved.
+ * Copyright (c) 2019      Triad National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c)           Amazon.com, Inc. or its affiliates.
+ *                         All Rights reserved.
+ * $COPYRIGHT$
+ * Most files in this release are marked with the copyrights of the
+ * organizations who have edited them.  The copyrights below are in no
+ * particular order and generally reflect members of the Open MPI core
+ * team who have contributed code to this release.  The copyrights for
+ * code used under license from other parties are included in the
+ * corresponding files.
+ *
+ * Copyright (c) 2004-2012 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                        Corporation.  All rights reserved.
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2018 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2008 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2018 Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2006-2021 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2006-2010 Voltaire, Inc. All rights reserved.
+ * Copyright (c) 2006-2021 Sandia National Laboratories. All rights reserved.
+ * Copyright (c) 2006-2010 Sun Microsystems, Inc.  All rights reserved.
+ *                         Use is subject to license terms.
+ * Copyright (c) 2006-2021 The University of Houston. All rights reserved.
+ * Copyright (c) 2006-2009 Myricom, Inc.  All rights reserved.
+ * Copyright (c) 2007-2017 UT-Battelle, LLC. All rights reserved.
+ * Copyright (c) 2007-2021 IBM Corporation.  All rights reserved.
+ * Copyright (c) 1998-2005 Forschungszentrum Juelich, Juelich Supercomputing
+ *                         Centre, Federal Republic of Germany
+ * Copyright (c) 2005-2008 ZIH, TU Dresden, Federal Republic of Germany
+ * Copyright (c) 2007      Evergrid, Inc. All rights reserved.
+ * Copyright (c) 2008-2016 Chelsio, Inc.  All rights reserved.
+ * Copyright (c) 2008-2009 Institut National de Recherche en
+ *                         Informatique.  All rights reserved.
+ * Copyright (c) 2007      Lawrence Livermore National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2007-2019 Mellanox Technologies.  All rights reserved.
+ * Copyright (c) 2006-2010 QLogic Corporation.  All rights reserved.
+ * Copyright (c) 2008-2017 Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2006-2012 Oracle and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2009-2015 Bull SAS.  All rights reserved.
+ * Copyright (c) 2010      ARM ltd.  All rights reserved.
+ * Copyright (c) 2016      ARM, Inc.  All rights reserved.
+ * Copyright (c) 2010-2011 Alex Brick <bricka@ccs.neu.edu>.  All rights
+ * reserved. Copyright (c) 2012      The University of Wisconsin-La Crosse. All
+ * rights reserved. Copyright (c) 2013-2020 Intel, Inc. All rights reserved.
+ * Copyright (c) 2011-2021 NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2016-2018 Broadcom Limited.  All rights reserved.
+ * Copyright (c) 2011-2021 Fujitsu Limited.  All rights reserved.
+ * Copyright (c) 2014-2015 Hewlett-Packard Development Company, LP.  All
+ *                         rights reserved.
+ * Copyright (c) 2013-2021 Research Organization for Information Science (RIST).
+ *                         All rights reserved.
+ * Copyright (c)           Amazon.com, Inc. or its affiliates.  All Rights
+ *                         reserved.
+ * Copyright (c) 2018      DataDirect Networks. All rights reserved.
+ * Copyright (c) 2018-2021 Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2019-2021 Hewlett Packard Enterprise Development, LP.
+ * Copyright (c) 2020-2021 Google, LLC. All rights reserved.
+ * Copyright (c) 2002      University of Chicago
+ * Copyright (c) 2001      Argonne National Laboratory
+ * Copyright (c) 2020-2021 Cornelis Networks, Inc. All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting
+ * Copyright (c) 2017-2019 Iowa State University Research Foundation, Inc.
+ *                         All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer listed
+ *   in this license in the documentation and/or other materials
+ *   provided with the distribution.
+ *
+ * - Neither the name of the copyright holders nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * The copyright holders provide no reassurances that the source code
+ * provided does not infringe any patent, copyright, or any other
+ * intellectual property rights of third parties.  The copyright holders
+ * disclaim any liability to any recipient for claims brought against
+ * recipient by any third party for infringement of that parties
+ * intellectual property rights.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * ----------------[Copyright from inclusion of MPICH code]----------------
+ *
+ * The following is a notice of limited availability of the code, and disclaimer
+ * which must be included in the prologue of the code and in all source listings
+ * of the code.
+ *
+ * Copyright Notice
+ *  + 2002 University of Chicago
+ *
+ * Permission is hereby granted to use, reproduce, prepare derivative works, and
+ * to redistribute to others.  This software was authored by:
+ *
+ * Mathematics and Computer Science Division
+ * Argonne National Laboratory, Argonne IL 60439
+ *
+ * (and)
+ *
+ * Department of Computer Science
+ * University of Illinois at Urbana-Champaign
+ *
+ *
+ * 			      GOVERNMENT LICENSE
+ *
+ * Portions of this material resulted from work developed under a U.S.
+ * Government Contract and are subject to the following license: the Government
+ * is granted for itself and others acting on its behalf a paid-up,
+ * nonexclusive, irrevocable worldwide license in this computer software to
+ * reproduce, prepare derivative works, and perform publicly and display
+ * publicly.
+ *
+ * 				  DISCLAIMER
+ *
+ * This computer code material was prepared, in part, as an account of work
+ * sponsored by an agency of the United States Government.  Neither the United
+ * States, nor the University of Chicago, nor any of their employees, makes any
+ * warranty express or implied, or assumes any legal liability or responsibility
+ * for the accuracy, completeness, or usefulness of any information, apparatus,
+ * product, or process disclosed, or represents that its use would not infringe
+ * privately owned rights.
+ */
+/*
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "config.h"
+#include <stdbool.h>
+
+#ifdef HAVE_ATOMICS
+#include <stdatomic.h>
+
+static inline void atomic_mb(void)
+{
+	atomic_thread_fence(memory_order_seq_cst);
+}
+
+static inline void atomic_rmb(void)
+{
+#if defined(PLATFORM_ARCH_X86_64) && defined(PLATFORM_COMPILER_GNU) && \
+	__GNUC__ < 8
+	/* work around a bug in older gcc versions (observed in gcc 6.x)
+	 * where acquire seems to get treated as a no-op instead of being
+	 * equivalent to __asm__ __volatile__("": : :"memory") on x86_64.
+	 * The issue has been fixed in the GCC 8 release series:
+	 * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80640
+	 */
+	atomic_mb();
+#else
+	atomic_thread_fence(memory_order_acquire);
+#endif
+}
+
+static inline void atomic_wmb(void)
+{
+	atomic_thread_fence(memory_order_release);
+}
+
+#define atomic_compare_exchange(addr, compare, value)       \
+	atomic_compare_exchange_strong_explicit(            \
+		(_Atomic uintptr_t *) addr, compare, value, \
+		memory_order_acquire, memory_order_relaxed)
+
+#define atomic_swap_ptr(addr, value)                                \
+	atomic_exchange_explicit((_Atomic uintptr_t *) addr, value, \
+				 memory_order_relaxed)
+
+#elif defined(HAVE_BUILTIN_MM_ATOMICS)
+
+static inline void atomic_mb(void)
+{
+	__atomic_thread_fence(__ATOMIC_SEQ_CST);
+}
+
+static inline void atomic_rmb(void)
+{
+	__atomic_thread_fence(__ATOMIC_ACQUIRE);
+}
+
+static inline void atomic_wmb(void)
+{
+	__atomic_thread_fence(__ATOMIC_RELEASE);
+}
+
+#define atomic_compare_exchange(x, y, z)                                    \
+	__atomic_compare_exchange_n((uintptr_t *) (x), (int64_t *) (y),     \
+				    (int64_t) (z), false, __ATOMIC_ACQUIRE, \
+				    __ATOMIC_RELAXED)
+
+static inline long int atomic_swap_ptr(long int *addr, long int value)
+{
+	long int oldval;
+	__atomic_exchange(addr, &value, &oldval, __ATOMIC_RELAXED);
+	return oldval;
+}
+
+#else
+#error "No atomics support found for SHM."
+#endif

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -184,8 +184,7 @@ static ssize_t smr_generic_atomic(
 			enum fi_op atomic_op, void *context, uint32_t op,
 			uint64_t op_flags)
 {
-	struct smr_cmd_entry *ce;
-	struct smr_cmd *cmd;
+	struct smr_cmd *ce, *cmd;
 	struct smr_region *peer_smr;
 	struct iovec iov[SMR_IOV_LIMIT];
 	struct iovec compare_iov[SMR_IOV_LIMIT];
@@ -274,10 +273,10 @@ static ssize_t smr_generic_atomic(
 
 		cmd = smr_freestack_pop(smr_cmd_stack(ep->region));
 		assert(cmd);
-		ce->ptr = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
-					(uintptr_t) cmd);
+		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
+						  (uintptr_t) cmd);
 	} else {
-		cmd = &ce->cmd;
+		cmd = ce;
 	}
 
 	if (proto == smr_proto_inline) {
@@ -382,7 +381,6 @@ static ssize_t smr_atomic_inject(
 			fi_addr_t dest_addr, uint64_t addr, uint64_t key,
 			enum fi_datatype datatype, enum fi_op op)
 {
-	struct smr_cmd_entry *ce;
 	struct smr_cmd *cmd;
 	struct smr_ep *ep;
 	struct smr_region *peer_smr;
@@ -415,7 +413,7 @@ static ssize_t smr_atomic_inject(
 		goto unlock;
 	}
 
-	ret = smr_cmd_queue_next(smr_cmd_queue(peer_smr), &ce, &pos);
+	ret = smr_cmd_queue_next(smr_cmd_queue(peer_smr), &cmd, &pos);
 	if (ret == -FI_ENOENT) {
 		ret = -FI_EAGAIN;
 		goto unlock;
@@ -431,24 +429,23 @@ static ssize_t smr_atomic_inject(
 	rma_ioc.count = count;
 	rma_ioc.key = key;
 
-	cmd = &ce->cmd;
 	if (total_len <= SMR_MSG_DATA_LEN) {
 		smr_do_atomic_inline(ep, peer_smr, id, peer_id, ofi_op_atomic,
 				     0, datatype, op, NULL, &iov, 1, total_len,
-				     &ce->cmd);
+				     cmd);
 	} else {
 		ret = smr_do_atomic_inject(ep, peer_smr, id, peer_id,
 					   ofi_op_atomic, 0, datatype, op, NULL,
 					   &iov, 1, NULL, NULL, 0, NULL, NULL,
 					   0, total_len, NULL, 0, cmd);
 		if (ret) {
-			smr_cmd_queue_discard(ce, pos);
+			smr_cmd_queue_discard(cmd, pos);
 			goto unlock;
 		}
 	}
 
 	smr_format_rma_ioc(cmd, &rma_ioc, 1);
-	smr_cmd_queue_commit(ce, pos);
+	smr_cmd_queue_commit(cmd, pos);
 	ofi_ep_peer_tx_cntr_inc(&ep->util_ep, ofi_op_atomic);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -69,7 +69,7 @@ static void smr_do_atomic_inline(
 	smr_format_inline_atomic(cmd, desc, iov, iov_count);
 }
 
-static void smr_format_inject_atomic(
+static int smr_format_inject_atomic(
 			struct smr_cmd *cmd, struct ofi_mr **desc,
 			const struct iovec *iov, size_t count,
 			const struct iovec *resultv, size_t result_count,
@@ -80,8 +80,15 @@ static void smr_format_inject_atomic(
 	size_t comp_size;
 
 	cmd->hdr.proto = smr_proto_inject;
+	tx_buf = smr_get_inject_buf(smr);
+	if (!tx_buf) {
+		FI_DBG(&smr_prov, FI_LOG_EP_DATA,
+		       "No inject buffers available, cannot send inject "
+		       "message\n");
+		return -FI_EAGAIN;
+	}
 
-	tx_buf = smr_get_inject_buf(smr, cmd);
+	cmd->hdr.proto_data = smr_get_offset(smr, tx_buf);
 	switch (cmd->hdr.op) {
 	case ofi_op_atomic:
 		cmd->hdr.size = ofi_copy_from_mr_iov(
@@ -112,9 +119,11 @@ static void smr_format_inject_atomic(
 		assert(0);
 		break;
 	}
+
+	return FI_SUCCESS;
 }
 
-static ssize_t smr_do_atomic_inject(
+static int smr_do_atomic_inject(
 			struct smr_ep *ep, struct smr_region *peer_smr,
 			int64_t tx_id, int64_t rx_id, uint32_t op,
 			uint64_t op_flags, uint8_t datatype, uint8_t atomic_op,
@@ -123,18 +132,20 @@ static ssize_t smr_do_atomic_inject(
 			const struct iovec *resultv, size_t result_count,
 			struct ofi_mr **comp_desc, const struct iovec *compv,
 			size_t comp_count, size_t total_len, void *context,
-			uint16_t smr_flags, struct smr_cmd *cmd)
+			uint8_t smr_flags, struct smr_cmd *cmd)
 {
 	struct smr_pend_entry *pend;
+	int ret;
 
-	smr_generic_format(cmd, tx_id, rx_id, op, 0, 0, op_flags);
+	smr_generic_format(cmd, tx_id, rx_id, op, 0, 0, smr_flags);
 	smr_generic_atomic_format(cmd, datatype, atomic_op);
-	smr_format_inject_atomic(cmd, desc, iov, iov_count, resultv,
-				 result_count, comp_desc, compv, comp_count,
-				 ep->region);
+	ret = smr_format_inject_atomic(cmd, desc, iov, iov_count, resultv,
+				       result_count, comp_desc, compv,
+				       comp_count, peer_smr);
+	if (ret)
+		return ret;
 
-	if (op == ofi_op_atomic_fetch || op == ofi_op_atomic_compare ||
-	    atomic_op == FI_ATOMIC_READ || op_flags & FI_DELIVERY_COMPLETE) {
+	if (smr_flags & SMR_RETURN_CMD) {
 		pend = ofi_buf_alloc(ep->pend_pool);
 		assert(pend);
 		cmd->hdr.tx_ctx = (uintptr_t) pend;
@@ -148,13 +159,18 @@ static ssize_t smr_do_atomic_inject(
 }
 
 static int smr_select_atomic_proto(uint32_t op, uint64_t total_len,
-				   uint64_t op_flags)
+				   uint64_t op_flags, uint8_t *smr_flags)
 {
+	*smr_flags = 0;
+	assert(!(op_flags & FI_REMOTE_CQ_DATA));
 	if (op == ofi_op_atomic_compare || op == ofi_op_atomic_fetch ||
-	    op_flags & FI_DELIVERY_COMPLETE || total_len > SMR_MSG_DATA_LEN)
+	    op_flags & FI_DELIVERY_COMPLETE) {
+		*smr_flags |= SMR_RETURN_CMD;
 		return smr_proto_inject;
+	}
 
-	return smr_proto_inline;
+	return total_len > SMR_MSG_DATA_LEN ? smr_proto_inject :
+					      smr_proto_inline;
 }
 
 static ssize_t smr_generic_atomic(
@@ -174,12 +190,12 @@ static ssize_t smr_generic_atomic(
 	struct iovec iov[SMR_IOV_LIMIT];
 	struct iovec compare_iov[SMR_IOV_LIMIT];
 	struct iovec result_iov[SMR_IOV_LIMIT];
-	uint16_t smr_flags = 0;
 	int64_t tx_id, rx_id, pos;
 	int proto;
 	ssize_t ret;
 	size_t total_len;
 	uint64_t atomic_flags;
+	uint8_t smr_flags;
 
 	assert(count <= SMR_IOV_LIMIT);
 	assert(result_count <= SMR_IOV_LIMIT);
@@ -248,15 +264,8 @@ static ssize_t smr_generic_atomic(
 		break;
 	}
 
-	proto = smr_select_atomic_proto(op, total_len, op_flags);
-
-	if (proto == smr_proto_inline) {
-		cmd = &ce->cmd;
-		smr_do_atomic_inline(ep, peer_smr, tx_id, rx_id, ofi_op_atomic,
-				     op_flags, datatype, atomic_op,
-				     (struct ofi_mr **) desc, iov, count,
-				     total_len, cmd);
-	} else {
+	proto = smr_select_atomic_proto(op, total_len, op_flags, &smr_flags);
+	if (smr_flags & SMR_RETURN_CMD) {
 		if (smr_freestack_isempty(smr_cmd_stack(ep->region))) {
 			smr_cmd_queue_discard(ce, pos);
 			ret = -FI_EAGAIN;
@@ -266,7 +275,17 @@ static ssize_t smr_generic_atomic(
 		cmd = smr_freestack_pop(smr_cmd_stack(ep->region));
 		assert(cmd);
 		ce->ptr = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
-					    (uintptr_t) cmd);
+					(uintptr_t) cmd);
+	} else {
+		cmd = &ce->cmd;
+	}
+
+	if (proto == smr_proto_inline) {
+		smr_do_atomic_inline(ep, peer_smr, tx_id, rx_id, ofi_op_atomic,
+				     op_flags, datatype, atomic_op,
+				     (struct ofi_mr **) desc, iov, count,
+				     total_len, cmd);
+	} else {
 		ret = smr_do_atomic_inject(ep, peer_smr, tx_id, rx_id, op,
 					   op_flags, datatype, atomic_op,
 					   (struct ofi_mr **) desc, iov, count,
@@ -281,16 +300,17 @@ static ssize_t smr_generic_atomic(
 		}
 	}
 
-	if (!cmd->hdr.tx_ctx) {
-		ret = smr_complete_tx(ep, context, op, op_flags);
-		if (ret) {
-			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-				"unable to process tx completion\n");
-		}
-	}
-
 	smr_format_rma_ioc(cmd, rma_ioc, rma_count);
 	smr_cmd_queue_commit(ce, pos);
+
+	if (smr_flags & SMR_RETURN_CMD)
+		goto unlock;
+
+	ret = smr_complete_tx(ep, context, op, op_flags);
+	if (ret)
+		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+			"unable to process tx completion\n");
+
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -371,7 +391,6 @@ static ssize_t smr_atomic_inject(
 	int64_t id, peer_id, pos;
 	ssize_t ret;
 	size_t total_len;
-	int proto;
 
 	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
 
@@ -412,24 +431,12 @@ static ssize_t smr_atomic_inject(
 	rma_ioc.count = count;
 	rma_ioc.key = key;
 
+	cmd = &ce->cmd;
 	if (total_len <= SMR_MSG_DATA_LEN) {
-		proto = smr_proto_inline;
-		cmd = &ce->cmd;
 		smr_do_atomic_inline(ep, peer_smr, id, peer_id, ofi_op_atomic,
 				     0, datatype, op, NULL, &iov, 1, total_len,
 				     &ce->cmd);
 	} else {
-		proto = smr_proto_inject;
-		if (smr_freestack_isempty(smr_cmd_stack(ep->region))) {
-			smr_cmd_queue_discard(ce, pos);
-			ret = -FI_EAGAIN;
-			goto unlock;
-		}
-
-		cmd = smr_freestack_pop(smr_cmd_stack(ep->region));
-		assert(cmd);
-		ce->ptr = smr_local_to_peer(ep, peer_smr, id, peer_id,
-					    (uintptr_t) cmd);
 		ret = smr_do_atomic_inject(ep, peer_smr, id, peer_id,
 					   ofi_op_atomic, 0, datatype, op, NULL,
 					   &iov, 1, NULL, NULL, 0, NULL, NULL,
@@ -442,9 +449,7 @@ static ssize_t smr_atomic_inject(
 
 	smr_format_rma_ioc(cmd, &rma_ioc, 1);
 	smr_cmd_queue_commit(ce, pos);
-
-	if (proto == smr_proto_inline)
-		ofi_ep_peer_tx_cntr_inc(&ep->util_ep, ofi_op_atomic);
+	ofi_ep_peer_tx_cntr_inc(&ep->util_ep, ofi_op_atomic);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -74,21 +74,11 @@ static int smr_format_inject_atomic(
 			const struct iovec *iov, size_t count,
 			const struct iovec *resultv, size_t result_count,
 			struct ofi_mr **comp_desc, const struct iovec *compv,
-			size_t comp_count, struct smr_region *smr)
+			size_t comp_count, struct smr_inject_buf *tx_buf)
 {
-	struct smr_inject_buf *tx_buf;
 	size_t comp_size;
 
 	cmd->hdr.proto = smr_proto_inject;
-	tx_buf = smr_get_inject_buf(smr);
-	if (!tx_buf) {
-		FI_DBG(&smr_prov, FI_LOG_EP_DATA,
-		       "No inject buffers available, cannot send inject "
-		       "message\n");
-		return -FI_EAGAIN;
-	}
-
-	cmd->hdr.proto_data = smr_get_offset(smr, tx_buf);
 	switch (cmd->hdr.op) {
 	case ofi_op_atomic:
 		cmd->hdr.size = ofi_copy_from_mr_iov(
@@ -135,13 +125,23 @@ static int smr_do_atomic_inject(
 			uint8_t smr_flags, struct smr_cmd *cmd)
 {
 	struct smr_pend_entry *pend;
+	struct smr_inject_buf *tx_buf;
 	int ret;
 
+	tx_buf = smr_get_inject_buf(peer_smr);
+	if (!tx_buf) {
+		FI_DBG(&smr_prov, FI_LOG_EP_DATA,
+		       "No inject buffers available, cannot send inject "
+		       "message\n");
+		return -FI_EAGAIN;
+	}
+
+	cmd->hdr.proto_data = smr_get_offset(peer_smr, tx_buf);
 	smr_generic_format(cmd, tx_id, rx_id, op, 0, 0, smr_flags);
 	smr_generic_atomic_format(cmd, datatype, atomic_op);
 	ret = smr_format_inject_atomic(cmd, desc, iov, iov_count, resultv,
 				       result_count, comp_desc, compv,
-				       comp_count, peer_smr);
+				       comp_count, tx_buf);
 	if (ret)
 		return ret;
 

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -253,7 +253,6 @@ void smr_generic_format(struct smr_cmd *cmd, int64_t tx_id, int64_t rx_id,
 	cmd->hdr.tx_id = tx_id;
 	cmd->hdr.cq_data = data;
 	cmd->hdr.tag = tag;
-	cmd->hdr.status = 0;
 	cmd->hdr.rx_ctx = 0;
 
 	if (op_flags & FI_REMOTE_CQ_DATA)

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -172,7 +172,7 @@ static struct fi_ops_ep smr_ep_ops = {
 static void smr_send_name(struct smr_ep *ep, int64_t id)
 {
 	struct smr_region *peer_smr;
-	struct smr_cmd_entry *ce;
+	struct smr_cmd *cmd;
 	int64_t pos;
 	int ret;
 
@@ -181,20 +181,19 @@ static void smr_send_name(struct smr_ep *ep, int64_t id)
 	if (smr_peer_data(ep->region)[id].name_sent)
 		return;
 
-	ret = smr_cmd_queue_next(smr_cmd_queue(peer_smr), &ce, &pos);
+	ret = smr_cmd_queue_next(smr_cmd_queue(peer_smr), &cmd, &pos);
 	if (ret == -FI_ENOENT)
 		return;
 
-	ce->ptr = smr_peer_to_peer(ep, peer_smr, id, (uintptr_t) &ce->cmd);
-	ce->cmd.hdr.op = SMR_OP_MAX + ofi_ctrl_connreq;
-	ce->cmd.hdr.tx_id = id;
-	ce->cmd.hdr.cq_data = ep->region->pid;
+	cmd->hdr.op = SMR_OP_MAX + ofi_ctrl_connreq;
+	cmd->hdr.tx_id = id;
+	cmd->hdr.cq_data = ep->region->pid;
 
-	ce->cmd.hdr.size = strlen(ep->name) + 1;
-	memcpy(ce->cmd.data.msg, ep->name, ce->cmd.hdr.size);
+	cmd->hdr.size = strlen(ep->name) + 1;
+	memcpy(cmd->data.msg, ep->name, cmd->hdr.size);
 
 	smr_peer_data(ep->region)[id].name_sent = 1;
-	smr_cmd_queue_commit(ce, pos);
+	smr_cmd_queue_commit(cmd, pos);
 }
 
 int64_t smr_verify_peer(struct smr_ep *ep, fi_addr_t fi_addr)

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -245,18 +245,15 @@ void smr_format_tx_pend(struct smr_pend_entry *pend, struct smr_cmd *cmd,
 
 void smr_generic_format(struct smr_cmd *cmd, int64_t tx_id, int64_t rx_id,
 			uint32_t op, uint64_t tag, uint64_t data,
-			uint64_t op_flags)
+			uint8_t smr_flags)
 {
 	cmd->hdr.op = op;
-	cmd->hdr.op_flags = 0;
+	cmd->hdr.smr_flags = smr_flags;
 	cmd->hdr.rx_id = rx_id;
 	cmd->hdr.tx_id = tx_id;
 	cmd->hdr.cq_data = data;
 	cmd->hdr.tag = tag;
 	cmd->hdr.rx_ctx = 0;
-
-	if (op_flags & FI_REMOTE_CQ_DATA)
-		cmd->hdr.op_flags |= SMR_REMOTE_CQ_DATA;
 }
 
 static void smr_format_inline(struct smr_cmd *cmd, struct ofi_mr **mr,
@@ -265,26 +262,6 @@ static void smr_format_inline(struct smr_cmd *cmd, struct ofi_mr **mr,
 	cmd->hdr.proto = smr_proto_inline;
 	cmd->hdr.size = ofi_copy_from_mr_iov(cmd->data.msg, SMR_MSG_DATA_LEN,
 					     mr, iov, count, 0);
-}
-
-static void smr_format_inject(struct smr_ep *ep, struct smr_cmd *cmd,
-			      struct smr_pend_entry *pend)
-{
-	struct smr_inject_buf *tx_buf;
-
-	tx_buf = smr_get_inject_buf(ep->region, cmd);
-
-	cmd->hdr.proto = smr_proto_inject;
-	if (cmd->hdr.op != ofi_op_read_req) {
-		cmd->hdr.size = ofi_copy_from_mr_iov(tx_buf->data,
-						     SMR_INJECT_SIZE,
-						     pend->mr, pend->iov,
-						     pend->iov_count, 0);
-		pend->bytes_done = cmd->hdr.size;
-	} else {
-		cmd->hdr.size = ofi_total_iov_len(pend->iov, pend->iov_count);
-		pend->bytes_done = 0;
-	}
 }
 
 static void smr_format_iov(struct smr_cmd *cmd, struct smr_pend_entry *pend)
@@ -378,9 +355,8 @@ static int smr_format_sar(struct smr_ep *ep, struct smr_cmd *cmd,
 		ret = pend->sar_copy_fn(ep, pend);
 		if (ret < 0 && ret != -FI_EBUSY) {
 			for (i = cmd->data.buf_batch_size - 1; i >= 0; i--) {
-				smr_freestack_push_by_index(
-						smr_sar_pool(ep->region),
-						cmd->data.sar[i]);
+				smr_return_sar_buf_by_index(ep->region,
+							    cmd->data.sar[i]);
 			}
 			return -FI_EAGAIN;
 		}
@@ -397,12 +373,15 @@ static int smr_format_sar(struct smr_ep *ep, struct smr_cmd *cmd,
 
 int smr_select_proto(void **desc, size_t iov_count, bool vma_avail,
 		     bool ipc_valid, uint32_t op, uint64_t total_len,
-		     uint64_t op_flags)
+		     uint64_t op_flags, uint8_t *smr_flags)
 {
 	struct ofi_mr *smr_desc;
 	enum fi_hmem_iface iface = FI_HMEM_SYSTEM;
 	bool fastcopy_avail = false, use_ipc = false;
 
+	*smr_flags = 0;
+	*smr_flags |= (op_flags & FI_DELIVERY_COMPLETE) ? SMR_RETURN_CMD : 0;
+	*smr_flags |= (op_flags & FI_REMOTE_CQ_DATA) ? SMR_REMOTE_CQ_DATA : 0;
 	/* Do not inline/inject if IPC is available so device to device
 	 * transfer may occur if possible. */
 	if (iov_count == 1 && desc && desc[0] && ipc_valid) {
@@ -419,6 +398,7 @@ int smr_select_proto(void **desc, size_t iov_count, bool vma_avail,
 	}
 
 	if (op == ofi_op_read_req) {
+		*smr_flags |= SMR_RETURN_CMD;
 		if (use_ipc)
 			return smr_proto_ipc;
 		if (total_len <= SMR_INJECT_SIZE)
@@ -428,32 +408,41 @@ int smr_select_proto(void **desc, size_t iov_count, bool vma_avail,
 		return smr_proto_sar;
 	}
 
-	if (fastcopy_avail && total_len <= smr_env.max_gdrcopy_size)
-		return total_len <= SMR_MSG_DATA_LEN ? smr_proto_inline :
-						       smr_proto_inject;
+	if (fastcopy_avail && total_len <= smr_env.max_gdrcopy_size) {
+		if (total_len <= SMR_MSG_DATA_LEN &&
+		    !(op_flags & FI_DELIVERY_COMPLETE))
+			return smr_proto_inline;
+		else
+			return smr_proto_inject;
+	}
 
-	if (use_ipc && !(op_flags & FI_INJECT))
+	if (use_ipc && !(op_flags & FI_INJECT)) {
+		*smr_flags |= SMR_RETURN_CMD;
 		return smr_proto_ipc;
+	}
 
 	if (op_flags & FI_INJECT || total_len <= SMR_INJECT_SIZE) {
 		if (op_flags & FI_DELIVERY_COMPLETE)
 			return smr_proto_inject;
+
 		return total_len <= SMR_MSG_DATA_LEN ?
 				smr_proto_inline : smr_proto_inject;
 	}
 
+	*smr_flags |= SMR_RETURN_CMD;
 	return vma_avail ? smr_proto_iov: smr_proto_sar;
 }
 
 static ssize_t smr_do_inline(struct smr_ep *ep, struct smr_region *peer_smr,
 			     int64_t tx_id, int64_t rx_id, uint32_t op,
 			     uint64_t tag, uint64_t data, uint64_t op_flags,
-			     struct ofi_mr **desc, const struct iovec *iov,
-			     size_t iov_count, size_t total_len, void *context,
+			     uint8_t smr_flags, struct ofi_mr **desc,
+			     const struct iovec *iov, size_t iov_count,
+			     size_t total_len, void *context,
 			     struct smr_cmd *cmd)
 {
 	cmd->hdr.tx_ctx = 0;
-	smr_generic_format(cmd, tx_id, rx_id, op, tag, data, op_flags);
+	smr_generic_format(cmd, tx_id, rx_id, op, tag, data, smr_flags);
 	smr_format_inline(cmd, desc, iov, iov_count);
 
 	return FI_SUCCESS;
@@ -462,34 +451,68 @@ static ssize_t smr_do_inline(struct smr_ep *ep, struct smr_region *peer_smr,
 static ssize_t smr_do_inject(struct smr_ep *ep, struct smr_region *peer_smr,
 			     int64_t tx_id, int64_t rx_id, uint32_t op,
 			     uint64_t tag, uint64_t data, uint64_t op_flags,
-			     struct ofi_mr **desc, const struct iovec *iov,
-			     size_t iov_count, size_t total_len, void *context,
+			     uint8_t smr_flags, struct ofi_mr **desc,
+			     const struct iovec *iov, size_t iov_count,
+			     size_t total_len, void *context,
 			     struct smr_cmd *cmd)
 {
-	struct smr_pend_entry *pend;
+	struct smr_pend_entry *pend = NULL;
+	struct smr_inject_buf *tx_buf;
+	int ret;
 
-	pend = ofi_buf_alloc(ep->pend_pool);
-	assert(pend);
+	tx_buf = smr_get_inject_buf(peer_smr);
+	if (!tx_buf) {
+		FI_DBG(&smr_prov, FI_LOG_EP_DATA,
+		       "No inject buffers available, cannot send inject "
+		       "message\n");
+		return -FI_EAGAIN;
+	}
 
-	cmd->hdr.tx_ctx = (uintptr_t) pend;
-	smr_format_tx_pend(pend, cmd, context, desc, iov, iov_count, op_flags);
+	cmd->hdr.proto_data = smr_get_offset(peer_smr, tx_buf);
 
-	smr_generic_format(cmd, tx_id, rx_id, op, tag, data, op_flags);
-	smr_format_inject(ep, cmd, pend);
+	if (smr_flags & SMR_RETURN_CMD) {
+		pend = ofi_buf_alloc(ep->pend_pool);
+		assert(pend);
+		cmd->hdr.tx_ctx = (uintptr_t) pend;
+		smr_format_tx_pend(pend, cmd, context, desc, iov, iov_count,
+				   op_flags);
+		if (smr_freestack_avail(smr_cmd_stack(ep->region)) <=
+		    smr_env.buffer_threshold)
+			smr_flags |= SMR_BUFFER_RECV;
+	} else {
+		cmd->hdr.tx_ctx = 0;
+	}
 
-	if (smr_freestack_avail(smr_cmd_stack(ep->region)) <=
-	    smr_env.buffer_threshold)
-		cmd->hdr.op_flags |= SMR_BUFFER_RECV;
+	smr_generic_format(cmd, tx_id, rx_id, op, tag, data, smr_flags);
+	cmd->hdr.proto = smr_proto_inject;
+	if (cmd->hdr.op != ofi_op_read_req)
+		cmd->hdr.size = ofi_copy_from_mr_iov(tx_buf->data,
+						     SMR_INJECT_SIZE,
+						     desc, iov, iov_count, 0);
+	else
+		cmd->hdr.size = ofi_total_iov_len(iov, iov_count);
+
+	if (total_len != cmd->hdr.size) {
+		ret = -FI_ETRUNC;
+		goto err;
+	}
+
+	if (pend && op != ofi_op_read_req)
+		pend->bytes_done = cmd->hdr.size;
 
 	return FI_SUCCESS;
+err:
+	if (pend)
+		ofi_buf_free(pend);
+	return ret;
 }
 
 static ssize_t smr_do_iov(struct smr_ep *ep, struct smr_region *peer_smr,
 			  int64_t tx_id, int64_t rx_id, uint32_t op,
 			  uint64_t tag, uint64_t data, uint64_t op_flags,
-			  struct ofi_mr **desc, const struct iovec *iov,
-			  size_t iov_count, size_t total_len, void *context,
-			  struct smr_cmd *cmd)
+			  uint8_t smr_flags, struct ofi_mr **desc,
+			  const struct iovec *iov, size_t iov_count,
+			  size_t total_len, void *context, struct smr_cmd *cmd)
 {
 	struct smr_pend_entry *pend;
 
@@ -499,12 +522,12 @@ static ssize_t smr_do_iov(struct smr_ep *ep, struct smr_region *peer_smr,
 	cmd->hdr.tx_ctx = (uintptr_t) pend;
 	smr_format_tx_pend(pend, cmd, context, desc, iov, iov_count, op_flags);
 
-	smr_generic_format(cmd, tx_id, rx_id, op, tag, data, op_flags);
+	smr_generic_format(cmd, tx_id, rx_id, op, tag, data, smr_flags);
 	smr_format_iov(cmd, pend);
 
 	if (smr_freestack_avail(smr_cmd_stack(ep->region)) <=
 	    smr_env.buffer_threshold)
-		cmd->hdr.op_flags |= SMR_BUFFER_RECV;
+		cmd->hdr.smr_flags |= SMR_BUFFER_RECV;
 
 	return FI_SUCCESS;
 }
@@ -512,9 +535,9 @@ static ssize_t smr_do_iov(struct smr_ep *ep, struct smr_region *peer_smr,
 static ssize_t smr_do_sar(struct smr_ep *ep, struct smr_region *peer_smr,
 			  int64_t tx_id, int64_t rx_id, uint32_t op,
 			  uint64_t tag, uint64_t data, uint64_t op_flags,
-			  struct ofi_mr **desc, const struct iovec *iov,
-			  size_t iov_count, size_t total_len, void *context,
-			  struct smr_cmd *cmd)
+			  uint8_t smr_flags, struct ofi_mr **desc,
+			  const struct iovec *iov, size_t iov_count,
+			  size_t total_len, void *context, struct smr_cmd *cmd)
 {
 	struct smr_pend_entry *pend;
 	int ret;
@@ -533,7 +556,7 @@ static ssize_t smr_do_sar(struct smr_ep *ep, struct smr_region *peer_smr,
 	else
 		pend->sar_copy_fn = &smr_copy_sar;
 
-	smr_generic_format(cmd, tx_id, rx_id, op, tag, data, op_flags);
+	smr_generic_format(cmd, tx_id, rx_id, op, tag, data, smr_flags);
 	ret = smr_format_sar(ep, cmd, desc, iov, iov_count, total_len,
 			     ep->region, peer_smr, pend);
 	if (ret)
@@ -545,9 +568,9 @@ static ssize_t smr_do_sar(struct smr_ep *ep, struct smr_region *peer_smr,
 static ssize_t smr_do_ipc(struct smr_ep *ep, struct smr_region *peer_smr,
 			  int64_t tx_id, int64_t rx_id, uint32_t op,
 			  uint64_t tag, uint64_t data, uint64_t op_flags,
-			  struct ofi_mr **desc, const struct iovec *iov,
-			  size_t iov_count, size_t total_len, void *context,
-			  struct smr_cmd *cmd)
+			  uint8_t smr_flags, struct ofi_mr **desc,
+			  const struct iovec *iov, size_t iov_count,
+			  size_t total_len, void *context, struct smr_cmd *cmd)
 {
 	struct smr_pend_entry *pend;
 	int ret = -FI_EAGAIN;
@@ -556,7 +579,7 @@ static ssize_t smr_do_ipc(struct smr_ep *ep, struct smr_region *peer_smr,
 	assert(pend);
 
 	cmd->hdr.tx_ctx = (uintptr_t) pend;
-	smr_generic_format(cmd, tx_id, rx_id, op, tag, data, op_flags);
+	smr_generic_format(cmd, tx_id, rx_id, op, tag, data, smr_flags);
 	assert(iov_count == 1 && desc && desc[0]);
 	ret = smr_format_ipc(cmd, iov[0].iov_base, total_len, ep->region,
 			     desc[0]->iface, desc[0]->device);
@@ -567,7 +590,7 @@ static ssize_t smr_do_ipc(struct smr_ep *ep, struct smr_region *peer_smr,
 			     "fallback to using SAR\n");
 		ofi_buf_free(pend);
 		return smr_do_sar(ep, peer_smr, tx_id, rx_id, op, tag, data,
-				  op_flags, desc, iov, iov_count,
+				  op_flags, smr_flags, desc, iov, iov_count,
 				  total_len, context, cmd);
 	}
 
@@ -575,7 +598,7 @@ static ssize_t smr_do_ipc(struct smr_ep *ep, struct smr_region *peer_smr,
 
 	if (smr_freestack_avail(smr_cmd_stack(ep->region)) <=
 	    smr_env.buffer_threshold)
-		cmd->hdr.op_flags |= SMR_BUFFER_RECV;
+		cmd->hdr.smr_flags |= SMR_BUFFER_RECV;
 
 	return FI_SUCCESS;
 }
@@ -695,25 +718,16 @@ static int smr_discard(struct fi_peer_rx_entry *rx_entry)
 	struct smr_unexp_buf *sar_buf;
 
 	dlist_remove(&cmd_ctx->entry);
-
-	switch (cmd_ctx->cmd->hdr.proto) {
-	case smr_proto_inline:
-		break;
-	case smr_proto_sar:
-		while (!slist_empty(&cmd_ctx->buf_list)) {
-			slist_remove_head_container(
-					&cmd_ctx->buf_list,
-					struct smr_unexp_buf, sar_buf,
-					entry);
-			ofi_buf_free(sar_buf);
-		}
-		break;
-	case smr_proto_inject:
-	case smr_proto_iov:
-	case smr_proto_ipc:
-		smr_return_cmd(cmd_ctx->ep, cmd_ctx->cmd);
-		break;
+	while (!slist_empty(&cmd_ctx->buf_list)) {
+		slist_remove_head_container(
+				&cmd_ctx->buf_list,
+				struct smr_unexp_buf, sar_buf,
+				entry);
+		ofi_buf_free(sar_buf);
 	}
+
+	if (cmd_ctx->cmd->hdr.smr_flags & SMR_RETURN_CMD)
+		smr_return_cmd(cmd_ctx->ep, cmd_ctx->cmd);
 
 	ofi_buf_free(cmd_ctx);
 

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -522,6 +522,15 @@ static ssize_t smr_do_iov(struct smr_ep *ep, struct smr_region *peer_smr,
 	smr_generic_format(cmd, tx_id, rx_id, op, tag, data, smr_flags);
 	smr_format_iov(cmd, pend);
 
+	/* Allocate resp slot for out-of-order completion */
+	{
+		int slot = __builtin_ctzll(~ep->slot_bitmap);
+		ep->slot_bitmap |= (1ULL << slot);
+		ep->slot_pend[slot] = pend;
+		cmd->hdr.proto_data = slot;
+		smr_resp_slots(ep->region)[slot].status = 0;
+	}
+
 	if (smr_freestack_avail(smr_cmd_stack(ep->region)) <=
 	    smr_env.buffer_threshold)
 		cmd->hdr.smr_flags |= SMR_BUFFER_RECV;

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -401,8 +401,6 @@ int smr_select_proto(void **desc, size_t iov_count, bool vma_avail,
 		*smr_flags |= SMR_RETURN_CMD;
 		if (use_ipc)
 			return smr_proto_ipc;
-		if (total_len <= SMR_INJECT_SIZE)
-			return smr_proto_inject;
 		if (vma_avail && FI_HMEM_SYSTEM == iface)
 			return smr_proto_iov;
 		return smr_proto_sar;

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -248,12 +248,12 @@ void smr_generic_format(struct smr_cmd *cmd, int64_t tx_id, int64_t rx_id,
 			uint64_t op_flags)
 {
 	cmd->hdr.op = op;
-	cmd->hdr.status = 0;
 	cmd->hdr.op_flags = 0;
-	cmd->hdr.tag = tag;
-	cmd->hdr.tx_id = tx_id;
 	cmd->hdr.rx_id = rx_id;
+	cmd->hdr.tx_id = tx_id;
 	cmd->hdr.cq_data = data;
+	cmd->hdr.tag = tag;
+	cmd->hdr.status = 0;
 	cmd->hdr.rx_ctx = 0;
 
 	if (op_flags & FI_REMOTE_CQ_DATA)

--- a/prov/shm/src/smr_fifo.h
+++ b/prov/shm/src/smr_fifo.h
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2009 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2007 Voltaire. All rights reserved.
+ * Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2018 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2020      Google, LLC. All rights reserved.
+ * Copyright (c) Amazon.com, Inc. or its affiliates. All rights reserved.
+ *
+ *  * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer listed
+ *   in this license in the documentation and/or other materials
+ *   provided with the distribution.
+ *
+ * - Neither the name of the copyright holders nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * The copyright holders provide no reassurances that the source code
+ * provided does not infringe any patent, copyright, or any other
+ * intellectual property rights of third parties.  The copyright holders
+ * disclaim any liability to any recipient for claims brought against
+ * recipient by any third party for infringement of that parties
+ * intellectual property rights.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * ----------------[Copyright from inclusion of MPICH code]----------------
+ *
+ * The following is a notice of limited availability of the code, and disclaimer
+ * which must be included in the prologue of the code and in all source listings
+ * of the code.
+ *
+ * Copyright Notice
+ *  + 2002 University of Chicago
+ *
+ * Permission is hereby granted to use, reproduce, prepare derivative works, and
+ * to redistribute to others.  This software was authored by:
+ *
+ * Mathematics and Computer Science Division
+ * Argonne National Laboratory, Argonne IL 60439
+ *
+ * (and)
+ *
+ * Department of Computer Science
+ * University of Illinois at Urbana-Champaign
+ *
+ *
+ * 			      GOVERNMENT LICENSE
+ *
+ * Portions of this material resulted from work developed under a U.S.
+ * Government Contract and are subject to the following license: the Government
+ * is granted for itself and others acting on its behalf a paid-up,
+ * nonexclusive, irrevocable worldwide license in this computer software to
+ * reproduce, prepare derivative works, and perform publicly and display
+ * publicly.
+ *
+ * 				  DISCLAIMER
+ *
+ * This computer code material was prepared, in part, as an account of work
+ * sponsored by an agency of the United States Government.  Neither the United
+ * States, nor the University of Chicago, nor any of their employees, makes any
+ * warranty express or implied, or assumes any legal liability or responsibility
+ * for the accuracy, completeness, or usefulness of any information, apparatus,
+ * product, or process disclosed, or represents that its use would not infringe
+ * privately owned rights.
+ */
+/*
+ * Copyright (c) 2023 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright (c) Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ * Multi Writer, Single Reader FIFO Queue (Not Thread Safe)
+ * This implementation of this Queue is a one directional linked list
+ * with head/tail pointers where every pointer is a relative offset
+ * into the Shared Memory Region.
+ */
+
+#ifndef _SMR_FIFO_H_
+#define _SMR_FIFO_H_
+
+#include "smr_atom.h"
+#include <stdint.h>
+#include <assert.h>
+
+#define SMR_FIFO_FREE (-3)
+#define OFI_CACHE_LINE_SIZE (64)
+
+static inline int64_t smr_local_to_offset(uintptr_t base, uintptr_t local_ptr)
+{
+	return (int64_t)(local_ptr - base);
+}
+
+static inline uintptr_t smr_offset_to_local(uintptr_t base, int64_t offset)
+{
+	return (uintptr_t) base + offset;
+}
+
+struct smr_fifo {
+	uintptr_t	head;
+	uint8_t		pad[OFI_CACHE_LINE_SIZE - sizeof(uintptr_t)];
+	uintptr_t	tail;
+};
+
+static inline void smr_fifo_init(struct smr_fifo *fifo)
+{
+	fifo->head = SMR_FIFO_FREE;
+	fifo->tail = SMR_FIFO_FREE;
+}
+
+static inline void smr_fifo_write(struct smr_fifo *fifo, uintptr_t peer_base,
+				  uintptr_t cmd)
+{
+	uintptr_t ptr_offset = smr_local_to_offset(peer_base, cmd);
+	uintptr_t prev_offset;
+	uintptr_t prev_cmd;
+
+	assert(fifo->head != 0 && fifo->tail != 0);
+
+	// First entry in cmd must be free for use as next pointer in the FIFO
+	*((void **) cmd) = (void *) SMR_FIFO_FREE;
+
+	atomic_wmb();
+	prev_offset = atomic_swap_ptr(&fifo->tail, ptr_offset);
+	atomic_rmb();
+
+	assert(prev_offset != ptr_offset);
+
+	prev_cmd = smr_offset_to_local(peer_base, prev_offset);
+	if (prev_offset != SMR_FIFO_FREE)
+		*((void **) prev_cmd) = (void *) ptr_offset;
+	else
+		fifo->head = ptr_offset;
+
+	atomic_wmb();
+}
+
+static inline void *smr_fifo_read(struct smr_fifo *fifo, uintptr_t base)
+{
+	uintptr_t cmd, cmd_offset, next_offset;
+
+	assert(fifo->head != 0 && fifo->tail != 0);
+
+	if (fifo->head == SMR_FIFO_FREE)
+		return NULL;
+
+	atomic_rmb();
+
+	cmd_offset = fifo->head;
+	fifo->head = SMR_FIFO_FREE;
+
+	cmd = smr_offset_to_local(base, cmd_offset);
+	next_offset = (uintptr_t) *((void **) cmd);
+	assert(next_offset != cmd_offset && cmd && next_offset);
+
+	if (next_offset == SMR_FIFO_FREE) {
+		atomic_rmb();
+		if (!atomic_compare_exchange(&fifo->tail, &cmd_offset,
+					     SMR_FIFO_FREE)) {
+			while ((uintptr_t) *((void **) cmd) == SMR_FIFO_FREE) {
+				atomic_rmb();
+			}
+			fifo->head = (uintptr_t) *((void **) cmd);
+		}
+	} else {
+		fifo->head = next_offset;
+	}
+
+	atomic_wmb();
+	return (void *)cmd;
+}
+
+#endif /* _SMR_FIFO_H_ */

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -85,6 +85,7 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 	int proto;
 	struct smr_cmd_entry *ce;
 	struct smr_cmd *cmd;
+	uint8_t smr_flags;
 
 	assert(iov_count <= SMR_IOV_LIMIT);
 
@@ -110,9 +111,8 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 
 	proto = smr_select_proto(desc, iov_count, smr_vma_enabled(ep, peer_smr),
 	                         smr_ipc_valid(ep, peer_smr, tx_id, rx_id), op,
-				 total_len, op_flags);
-
-	if (proto != smr_proto_inline) {
+				 total_len, op_flags, &smr_flags);
+	if (smr_flags & SMR_RETURN_CMD) {
 		if (smr_freestack_isempty(smr_cmd_stack(ep->region))) {
 			smr_cmd_queue_discard(ce, pos);
 			ret = -FI_EAGAIN;
@@ -128,17 +128,17 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 	}
 
 	ret = smr_send_ops[proto](ep, peer_smr, tx_id, rx_id, op, tag, data,
-				  op_flags, (struct ofi_mr **) desc, iov,
-				  iov_count, total_len, context, cmd);
+				  op_flags, smr_flags, (struct ofi_mr **) desc,
+				  iov, iov_count, total_len, context, cmd);
 	if (ret) {
 		smr_cmd_queue_discard(ce, pos);
-		if (proto != smr_proto_inline)
+		if (smr_flags & SMR_RETURN_CMD)
 			smr_freestack_push(smr_cmd_stack(ep->region), cmd);
 		goto unlock;
 	}
 	smr_cmd_queue_commit(ce, pos);
 
-	if (proto != smr_proto_inline)
+	if (smr_flags & SMR_RETURN_CMD)
 		goto unlock;
 
 	ret = smr_complete_tx(ep, context, op, op_flags);
@@ -205,6 +205,7 @@ static ssize_t smr_generic_inject(struct fid_ep *ep_fid, const void *buf,
 	int proto;
 	struct smr_cmd_entry *ce;
 	struct smr_cmd *cmd;
+	uint8_t smr_flags;
 
 	assert(len <= SMR_INJECT_SIZE);
 
@@ -232,36 +233,20 @@ static ssize_t smr_generic_inject(struct fid_ep *ep_fid, const void *buf,
 		goto unlock;
 	}
 
-	if (len <= SMR_MSG_DATA_LEN) {
-		proto = smr_proto_inline;
-		cmd = &ce->cmd;
-	} else {
-		proto = smr_proto_inject;
-		if (smr_freestack_isempty(smr_cmd_stack(ep->region))) {
-			smr_cmd_queue_discard(ce, pos);
-			ret = -FI_EAGAIN;
-			goto unlock;
-		}
+	proto = len <= SMR_MSG_DATA_LEN ? smr_proto_inline : smr_proto_inject;
+	cmd = &ce->cmd;
 
-		cmd = smr_freestack_pop(smr_cmd_stack(ep->region));
-		assert(cmd);
-		ce->ptr = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
-					    (uintptr_t) cmd);
-	}
-
+	smr_flags = (op_flags & FI_REMOTE_CQ_DATA) ? SMR_REMOTE_CQ_DATA : 0;
 	ret = smr_send_ops[proto](ep, peer_smr, tx_id, rx_id, op, tag, data,
-				  op_flags, NULL, &msg_iov, 1, len, NULL, cmd);
+				  op_flags, smr_flags, NULL, &msg_iov, 1, len,
+				  NULL, cmd);
 	if (ret) {
-		if (proto != smr_proto_inline)
-			smr_freestack_push(smr_cmd_stack(ep->region), cmd);
 		smr_cmd_queue_discard(ce, pos);
 		ret = -FI_EAGAIN;
 		goto unlock;
 	}
 	smr_cmd_queue_commit(ce, pos);
-
-	if (proto == smr_proto_inline)
-		ofi_ep_peer_tx_cntr_inc(&ep->util_ep, op);
+	ofi_ep_peer_tx_cntr_inc(&ep->util_ep, op);
 
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -83,8 +83,7 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 	ssize_t ret = -FI_EAGAIN;
 	size_t total_len;
 	int proto;
-	struct smr_cmd_entry *ce;
-	struct smr_cmd *cmd;
+	struct smr_cmd *ce, *cmd;
 	uint8_t smr_flags;
 
 	assert(iov_count <= SMR_IOV_LIMIT);
@@ -121,10 +120,10 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 
 		cmd = smr_freestack_pop(smr_cmd_stack(ep->region));
 		assert(cmd);
-		ce->ptr = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
-					    (uintptr_t) cmd);
+		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
+						  (uintptr_t) cmd);
 	} else {
-		cmd = &ce->cmd;
+		cmd = ce;
 	}
 
 	ret = smr_send_ops[proto](ep, peer_smr, tx_id, rx_id, op, tag, data,
@@ -203,7 +202,6 @@ static ssize_t smr_generic_inject(struct fid_ep *ep_fid, const void *buf,
 	ssize_t ret = 0;
 	struct iovec msg_iov;
 	int proto;
-	struct smr_cmd_entry *ce;
 	struct smr_cmd *cmd;
 	uint8_t smr_flags;
 
@@ -227,25 +225,24 @@ static ssize_t smr_generic_inject(struct fid_ep *ep_fid, const void *buf,
 		goto unlock;
 	}
 
-	ret = smr_cmd_queue_next(smr_cmd_queue(peer_smr), &ce, &pos);
+	ret = smr_cmd_queue_next(smr_cmd_queue(peer_smr), &cmd, &pos);
 	if (ret == -FI_ENOENT) {
 		ret = -FI_EAGAIN;
 		goto unlock;
 	}
 
 	proto = len <= SMR_MSG_DATA_LEN ? smr_proto_inline : smr_proto_inject;
-	cmd = &ce->cmd;
 
 	smr_flags = (op_flags & FI_REMOTE_CQ_DATA) ? SMR_REMOTE_CQ_DATA : 0;
 	ret = smr_send_ops[proto](ep, peer_smr, tx_id, rx_id, op, tag, data,
 				  op_flags, smr_flags, NULL, &msg_iov, 1, len,
 				  NULL, cmd);
 	if (ret) {
-		smr_cmd_queue_discard(ce, pos);
+		smr_cmd_queue_discard(cmd, pos);
 		ret = -FI_EAGAIN;
 		goto unlock;
 	}
-	smr_cmd_queue_commit(ce, pos);
+	smr_cmd_queue_commit(cmd, pos);
 	ofi_ep_peer_tx_cntr_inc(&ep->util_ep, op);
 
 unlock:

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -171,6 +171,31 @@ static int smr_progress_return_entry(struct smr_ep *ep, struct smr_cmd *cmd,
 
 static void smr_progress_return(struct smr_ep *ep)
 {
+	/* Out-of-order IOV completion via resp slots */
+	uint64_t cc = __atomic_load_n(smr_comp_count(ep->region), __ATOMIC_ACQUIRE);
+	if (cc != ep->last_comp_count) {
+		uint64_t pending = ep->slot_bitmap;
+		while (pending) {
+			int slot = __builtin_ctzll(pending);
+			if (smr_resp_slots(ep->region)[slot].status) {
+				struct smr_pend_entry *pend = ep->slot_pend[slot];
+				ep->slot_bitmap &= ~(1ULL << slot);
+				if (pend->cmd->hdr.smr_flags & SMR_OP_ERROR)
+					smr_write_err_comp(ep->util_ep.tx_cq,
+						pend->comp_ctx, pend->comp_flags,
+						0, -FI_EIO);
+				else
+					smr_complete_tx(ep, pend->comp_ctx,
+						pend->cmd->hdr.op, pend->comp_flags);
+				smr_freestack_push(smr_cmd_stack(ep->region),
+						   pend->cmd);
+				ofi_buf_free(pend);
+			}
+			pending &= ~(1ULL << slot);
+		}
+		ep->last_comp_count = cc;
+	}
+
 	struct smr_cmd *cmd;
 	struct smr_pend_entry *pending;
 	int ret;
@@ -736,8 +761,15 @@ static int smr_start_common(struct smr_ep *ep, struct smr_cmd *cmd,
 			return_cmd = false;
 	}
 
-	if (return_cmd)
-		smr_return_cmd(ep, cmd);
+	if (return_cmd) {
+		if (cmd->hdr.proto == smr_proto_iov) {
+			struct smr_region *peer_smr = smr_peer_region(ep, cmd->hdr.rx_id);
+			smr_resp_slots(peer_smr)[cmd->hdr.proto_data].status = 1;
+			__atomic_add_fetch(smr_comp_count(peer_smr), 1, __ATOMIC_RELEASE);
+		} else {
+			smr_return_cmd(ep, cmd);
+		}
+	}
 	return ret;
 }
 
@@ -952,7 +984,13 @@ out:
 	if (ret)
 		cmd->hdr.smr_flags |= SMR_OP_ERROR;
 
-	smr_return_cmd(ep, cmd);
+	if (cmd->hdr.proto == smr_proto_iov) {
+		struct smr_region *peer_smr = smr_peer_region(ep, cmd->hdr.rx_id);
+		smr_resp_slots(peer_smr)[cmd->hdr.proto_data].status = 1;
+		__atomic_add_fetch(smr_comp_count(peer_smr), 1, __ATOMIC_RELEASE);
+	} else {
+		smr_return_cmd(ep, cmd);
+	}
 	return ret;
 }
 

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -1313,8 +1313,7 @@ out:
 
 static void smr_progress_cmd(struct smr_ep *ep)
 {
-	struct smr_cmd_entry *ce;
-	struct smr_cmd *cmd;
+	struct smr_cmd *ce, *cmd;
 	int ret = 0;
 	int64_t pos;
 
@@ -1323,7 +1322,7 @@ static void smr_progress_cmd(struct smr_ep *ep)
 		if (ret == -FI_ENOENT)
 			break;
 
-		cmd = (struct smr_cmd *) ce->ptr;
+		cmd = (struct smr_cmd *) ce->hdr.entry;
 		switch (cmd->hdr.op) {
 		case ofi_op_msg:
 		case ofi_op_tagged:

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -46,7 +46,8 @@ static void smr_progress_overflow(struct smr_ep *ep)
 
 	entry = ep->overflow_list.head;
 	while (entry) {
-		cmd = (struct smr_cmd *) entry;
+		cmd = container_of(container_of(entry, struct smr_cmd_hdr,
+				   entry), struct smr_cmd, hdr);
 		peer_smr = smr_peer_region(ep, cmd->hdr.tx_id);
 		ret = smr_cmd_queue_next(smr_cmd_queue(peer_smr), &ce, &pos);
 		if (ret == -FI_ENOENT)

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -76,8 +76,7 @@ void smr_free_sar_bufs(struct smr_ep *ep, struct smr_cmd *cmd,
 	int i;
 
 	for (i = cmd->data.buf_batch_size - 1; i >= 0; i--) {
-		smr_freestack_push_by_index(smr_sar_pool(ep->region),
-					    cmd->data.sar[i]);
+		smr_return_sar_buf_by_index(ep->region, cmd->data.sar[i]);
 	}
 	smr_peer_data(ep->region)[cmd->hdr.tx_id].sar_status = SMR_SAR_FREE;
 }
@@ -88,6 +87,7 @@ static int smr_progress_return_entry(struct smr_ep *ep, struct smr_cmd *cmd,
 	struct smr_inject_buf *tx_buf = NULL;
 	uint8_t *src;
 	ssize_t hmem_copy_ret;
+	struct smr_region *peer_smr;
 	int ret = FI_SUCCESS;
 
 	switch (cmd->hdr.proto) {
@@ -97,7 +97,7 @@ static int smr_progress_return_entry(struct smr_ep *ep, struct smr_cmd *cmd,
 		assert(pend->mr[0]);
 		break;
 	case smr_proto_sar:
-		if (cmd->hdr.op_flags & SMR_OP_ERROR) {
+		if (cmd->hdr.smr_flags & SMR_OP_ERROR) {
 			smr_free_sar_bufs(ep, cmd, pend);
 			return -FI_EIO;
 		}
@@ -134,33 +134,31 @@ static int smr_progress_return_entry(struct smr_ep *ep, struct smr_cmd *cmd,
 		smr_try_send_cmd(ep, cmd);
 		return -FI_EAGAIN;
 	case smr_proto_inject:
-		tx_buf = smr_get_inject_buf(ep->region, cmd);
-		if (pend) {
-			if (pend->bytes_done != cmd->hdr.size &&
-			    cmd->hdr.op != ofi_op_atomic) {
-				src = cmd->hdr.op == ofi_op_atomic_compare ?
-					tx_buf->buf : tx_buf->data;
-				hmem_copy_ret  = ofi_copy_to_mr_iov(
-							pend->mr, pend->iov,
-							pend->iov_count,
-							0, src, cmd->hdr.size);
+		assert(pend);
+		if (pend->bytes_done != cmd->hdr.size &&
+			cmd->hdr.op != ofi_op_atomic) {
+			peer_smr = smr_peer_region(ep, cmd->hdr.tx_id);
+			tx_buf = smr_get_ptr(peer_smr, cmd->hdr.proto_data);
+			src = cmd->hdr.op == ofi_op_atomic_compare ?
+				tx_buf->buf : tx_buf->data;
+			hmem_copy_ret  = ofi_copy_to_mr_iov(
+						pend->mr, pend->iov,
+						pend->iov_count,
+						0, src, cmd->hdr.size);
 
-				if (hmem_copy_ret < 0) {
-					FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-						"RMA read/fetch failed "
-						"with code %d\n",
-						(int)(-hmem_copy_ret));
-					ret = hmem_copy_ret;
-				} else if (hmem_copy_ret != cmd->hdr.size) {
-					FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-						"Incomplete rma read/fetch "
-						"buffer copied\n");
-					ret = -FI_ETRUNC;
-				} else {
-					pend->bytes_done =
-						(size_t) hmem_copy_ret;
-				}
+			if (hmem_copy_ret < 0) {
+				FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+					"RMA read/fetch failed "
+					"with code %d\n",
+					(int)(-hmem_copy_ret));
+				ret = hmem_copy_ret;
+			} else if (hmem_copy_ret != cmd->hdr.size) {
+				FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+					"Incomplete rma read/fetch "
+					"buffer copied\n");
+				ret = -FI_ETRUNC;
 			}
+			smr_return_inject_buf(peer_smr, tx_buf);
 		}
 		break;
 	default:
@@ -191,7 +189,7 @@ static void smr_progress_return(struct smr_ep *ep)
 		ret = smr_progress_return_entry(ep, cmd, pending);
 		if (ret != -FI_EAGAIN) {
 			assert(pending);
-			if (cmd->hdr.op_flags & SMR_OP_ERROR) {
+			if (cmd->hdr.smr_flags & SMR_OP_ERROR) {
 				ret = smr_write_err_comp(
 						ep->util_ep.tx_cq,
 						pending->comp_ctx,
@@ -208,6 +206,7 @@ static void smr_progress_return(struct smr_ep *ep)
 					"unable to process "
 					"tx completion\n");
 			}
+			ofi_buf_free(pending);
 			smr_freestack_push(smr_cmd_stack(ep->region), cmd);
 		}
 		smr_return_queue_release(smr_return_queue(ep->region),
@@ -241,30 +240,29 @@ static ssize_t smr_progress_inject(struct smr_ep *ep, struct smr_cmd *cmd,
 				   struct ofi_mr **mr, struct iovec *iov,
 				   size_t iov_count)
 {
-	struct smr_region *peer_smr;
 	struct smr_inject_buf *tx_buf;
 	ssize_t ret;
 
-	peer_smr = smr_peer_region(ep, cmd->hdr.rx_id);
-	tx_buf = smr_get_inject_buf(peer_smr, cmd);
-
-	if (cmd->hdr.op == ofi_op_read_req) {
-		ret = ofi_copy_from_mr_iov(tx_buf->data, cmd->hdr.size, mr,
-					   iov, iov_count, 0);
-	} else {
+	tx_buf = smr_get_ptr(ep->region, cmd->hdr.proto_data);
+	if (cmd->hdr.op != ofi_op_read_req) {
 		ret = ofi_copy_to_mr_iov(mr, iov, iov_count, 0, tx_buf->data,
 					 cmd->hdr.size);
+		smr_return_inject_buf(ep->region, tx_buf);
+	} else {
+		ret = ofi_copy_from_mr_iov(tx_buf->data, cmd->hdr.size, mr,
+					   iov, iov_count, 0);
 	}
 
 	if (ret < 0) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"inject recv failed with code %lu\n", ret);
-		cmd->hdr.op_flags |= SMR_OP_ERROR;
+		cmd->hdr.smr_flags |= SMR_OP_ERROR;
 	} else if (ret != cmd->hdr.size) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-			"inject recv truncated\n");
+			"inject recv truncated. Expected size %zu copied size "
+			"%zu\n", cmd->hdr.size, ret);
 		ret = -FI_ETRUNC;
-		cmd->hdr.op_flags |= SMR_OP_ERROR;
+		cmd->hdr.smr_flags |= SMR_OP_ERROR;
 	} else {
 		ret = FI_SUCCESS;
 	}
@@ -290,7 +288,7 @@ static ssize_t smr_progress_iov(struct smr_ep *ep, struct smr_cmd *cmd,
 			       peer_smr->pid, cmd->hdr.op == ofi_op_read_req,
 			       xpmem);
 	if (ret)
-		cmd->hdr.op_flags |= SMR_OP_ERROR;
+		cmd->hdr.smr_flags |= SMR_OP_ERROR;
 
 	return ret;
 }
@@ -346,7 +344,7 @@ static ssize_t smr_try_copy_rx_sar(struct smr_ep *ep,
 		if (ret == -FI_EAGAIN)
 			dlist_insert_tail(&pend->entry, &ep->async_cpy_list);
 		else if (ret && ret != -FI_EBUSY)
-			pend->cmd->hdr.op_flags |= SMR_OP_ERROR;
+			pend->cmd->hdr.smr_flags |= SMR_OP_ERROR;
 	}
 	return ret;
 }
@@ -363,7 +361,7 @@ static int smr_progress_pending_sar(struct smr_ep *ep, struct smr_cmd *cmd)
 			dlist_insert_tail(&pend->entry, &ep->async_cpy_list);
 			return FI_SUCCESS;
 		}
-		cmd->hdr.op_flags |= SMR_OP_ERROR;
+		cmd->hdr.smr_flags |= SMR_OP_ERROR;
 		goto out;
 	}
 
@@ -372,8 +370,8 @@ static int smr_progress_pending_sar(struct smr_ep *ep, struct smr_cmd *cmd)
 		return FI_SUCCESS;
 
 	if (pend->bytes_done == cmd->hdr.size ||
-	    pend->cmd->hdr.op_flags & SMR_OP_ERROR) {
-		if (pend->cmd->hdr.op_flags & SMR_OP_ERROR) {
+	    pend->cmd->hdr.smr_flags & SMR_OP_ERROR) {
+		if (pend->cmd->hdr.smr_flags & SMR_OP_ERROR) {
 			ret = smr_write_err_comp(ep->util_ep.rx_cq,
 						 pend->comp_ctx,
 						 pend->comp_flags,
@@ -421,10 +419,10 @@ static void smr_init_rx_pend(struct smr_pend_entry *pend, struct smr_cmd *cmd,
 	if (rx_entry) {
 		pend->comp_ctx = rx_entry->context;
 		pend->comp_flags = smr_rx_cq_flags(rx_entry->flags,
-						   cmd->hdr.op_flags);
+						   cmd->hdr.smr_flags);
 	} else {
 		pend->comp_ctx = NULL;
-		pend->comp_flags = smr_rx_cq_flags(0, cmd->hdr.op_flags);
+		pend->comp_flags = smr_rx_cq_flags(0, cmd->hdr.smr_flags);
 	}
 
 	pend->cmd = cmd;
@@ -575,7 +573,7 @@ uncache:
 	ofi_mr_cache_delete(domain->ipc_cache, mr_entry);
 out:
 	if (ret)
-		cmd->hdr.op_flags |= SMR_OP_ERROR;
+		cmd->hdr.smr_flags |= SMR_OP_ERROR;
 
 	return ret;
 }
@@ -595,7 +593,7 @@ static smr_progress_func smr_progress_ops[smr_proto_max] = {
 
 static void smr_do_atomic(struct smr_cmd *cmd, void *src, struct ofi_mr *dst_mr,
 			  void *dst, void *cmp, enum fi_datatype datatype,
-			  enum fi_op op, size_t cnt, uint16_t flags)
+			  enum fi_op op, size_t cnt)
 {
 	char tmp_result[SMR_INJECT_SIZE];
 	char tmp_dst[SMR_INJECT_SIZE];
@@ -651,7 +649,7 @@ static int smr_progress_inline_atomic(struct smr_cmd *cmd, struct ofi_mr **mr,
 	for (i = *len = 0; i < ioc_count && *len < cmd->hdr.size; i++) {
 		smr_do_atomic(cmd, &src[*len], mr[i], ioc[i].addr, NULL,
 			      cmd->hdr.datatype, cmd->hdr.atomic_op,
-			      ioc[i].count, cmd->hdr.op_flags);
+			      ioc[i].count);
 		*len += ioc[i].count * ofi_datatype_size(cmd->hdr.datatype);
 	}
 
@@ -671,8 +669,7 @@ static int smr_progress_inject_atomic(struct smr_cmd *cmd, struct ofi_mr **mr,
 	uint8_t *src, *comp;
 	int i;
 
-	tx_buf = smr_get_inject_buf(smr_peer_region(ep, cmd->hdr.rx_id), cmd);
-
+	tx_buf = smr_get_ptr(ep->region, cmd->hdr.proto_data);
 	switch (cmd->hdr.op) {
 	case ofi_op_atomic_compare:
 		src = tx_buf->buf;
@@ -687,11 +684,11 @@ static int smr_progress_inject_atomic(struct smr_cmd *cmd, struct ofi_mr **mr,
 	for (i = *len = 0; i < ioc_count && *len < cmd->hdr.size; i++) {
 		smr_do_atomic(cmd, &src[*len], mr[i], ioc[i].addr,
 			      comp ? &comp[*len] : NULL, cmd->hdr.datatype,
-			      cmd->hdr.atomic_op, ioc[i].count,
-			      cmd->hdr.op_flags);
+			      cmd->hdr.atomic_op, ioc[i].count);
 		*len += ioc[i].count * ofi_datatype_size(cmd->hdr.datatype);
 	}
 
+	smr_return_inject_buf(ep->region, tx_buf);
 	if (*len != cmd->hdr.size) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL, "recv truncated");
 		return -FI_ETRUNC;
@@ -707,7 +704,7 @@ static int smr_start_common(struct smr_ep *ep, struct smr_cmd *cmd,
 	uint64_t comp_flags;
 	void *comp_buf;
 	int ret;
-	bool return_cmd = cmd->hdr.proto != smr_proto_inline;
+	bool return_cmd = cmd->hdr.smr_flags & SMR_RETURN_CMD;
 
 	rx_entry->peer_context = NULL;
 	assert (cmd->hdr.proto < smr_proto_max);
@@ -715,11 +712,10 @@ static int smr_start_common(struct smr_ep *ep, struct smr_cmd *cmd,
 					ep, cmd, rx_entry,
 					(struct ofi_mr **) rx_entry->desc,
 					rx_entry->iov, rx_entry->count);
-
 	if (!cmd->hdr.rx_ctx) {
 		comp_buf = rx_entry->iov[0].iov_base;
 		comp_flags = smr_rx_cq_flags(rx_entry->flags,
-					     cmd->hdr.op_flags);
+					     cmd->hdr.smr_flags);
 		if (ret) {
 			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 				"error processing op\n");
@@ -760,7 +756,7 @@ static int smr_copy_saved(struct smr_cmd_ctx *cmd_ctx,
 	int ret;
 
 	comp_flags = smr_rx_cq_flags(rx_entry->flags,
-				     cmd_ctx->cmd->hdr.op_flags);
+				     cmd_ctx->cmd->hdr.smr_flags);
 	while (!slist_empty(&cmd_ctx->buf_list)) {
 		slist_remove_head_container(&cmd_ctx->buf_list,
 					    struct smr_unexp_buf, buf, entry);
@@ -818,8 +814,7 @@ int smr_unexp_start(struct fi_peer_rx_entry *rx_entry)
 	int ret = FI_SUCCESS;
 
 	dlist_remove(&cmd_ctx->entry);
-
-	if (cmd_ctx->cmd->hdr.op_flags & SMR_BUFFER_RECV)
+	if (cmd_ctx->cmd->hdr.smr_flags & SMR_BUFFER_RECV)
 		ret = smr_copy_saved(cmd_ctx, rx_entry);
 	else
 		ret = smr_start_common(cmd_ctx->ep, cmd_ctx->cmd, rx_entry);
@@ -889,34 +884,33 @@ static int smr_unexp_inline(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 static int smr_unexp_inject(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 			    struct smr_cmd *cmd)
 {
-	struct smr_region *peer_smr;
-	struct smr_unexp_buf *buf;
 	struct smr_inject_buf *tx_buf;
-	int ret = FI_SUCCESS;
+	struct smr_unexp_buf *buf;
 
-	if (!(cmd->hdr.op_flags & SMR_BUFFER_RECV)) {
-		cmd_ctx->cmd = cmd;
-		return FI_SUCCESS;
-	}
-
-	peer_smr = smr_peer_region(ep, cmd_ctx->cmd->hdr.rx_id);
+	cmd->hdr.smr_flags |= SMR_BUFFER_RECV;
 
 	memcpy(&cmd_ctx->cmd_cpy, cmd, sizeof(cmd_ctx->cmd->hdr));
 	cmd_ctx->cmd = &cmd_ctx->cmd_cpy;
 
+	tx_buf = smr_get_ptr(ep->region, cmd->hdr.proto_data);
 	buf = ofi_buf_alloc(ep->unexp_buf_pool);
 	if (!buf) {
-		ret = -FI_ENOMEM;
-		cmd->hdr.op_flags |= SMR_OP_ERROR;
-		goto out;
+		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+			"Error allocating buffer\n");
+		cmd->hdr.smr_flags |= SMR_OP_ERROR;
+		ofi_buf_free(cmd_ctx);
+		return -FI_ENOMEM;
 	}
 
-	tx_buf = smr_get_inject_buf(peer_smr, cmd);
-	memcpy(buf->buf, tx_buf->buf, cmd_ctx->cmd->hdr.size);
+	memcpy(buf->buf, tx_buf->data, cmd->hdr.size);
+	smr_return_inject_buf(ep->region, tx_buf);
+	slist_init(&cmd_ctx->buf_list);
 	slist_insert_tail(&buf->entry, &cmd_ctx->buf_list);
-out:
-	smr_return_cmd(ep, cmd);
-	return ret;
+
+	if (cmd->hdr.smr_flags & SMR_RETURN_CMD)
+		smr_return_cmd(ep, cmd);
+
+	return FI_SUCCESS;
 }
 
 static int smr_unexp_iov(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
@@ -927,7 +921,7 @@ static int smr_unexp_iov(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 	struct iovec iov;
 	int ret = FI_SUCCESS;
 
-	if (!(cmd->hdr.op_flags & SMR_BUFFER_RECV)) {
+	if (!(cmd->hdr.smr_flags & SMR_BUFFER_RECV)) {
 		cmd_ctx->cmd = cmd;
 		return FI_SUCCESS;
 	}
@@ -961,7 +955,7 @@ static int smr_unexp_iov(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 	}
 out:
 	if (ret)
-		cmd->hdr.op_flags |= SMR_OP_ERROR;
+		cmd->hdr.smr_flags |= SMR_OP_ERROR;
 
 	smr_return_cmd(ep, cmd);
 	return ret;
@@ -974,7 +968,7 @@ static int smr_unexp_sar(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 	struct smr_pend_entry *sar_entry;
 	int ret;
 
-	cmd->hdr.op_flags |= SMR_BUFFER_RECV;
+	cmd->hdr.smr_flags |= SMR_BUFFER_RECV;
 
 	cmd_ctx->cmd = &cmd_ctx->cmd_cpy;
 	memcpy(&cmd_ctx->cmd_cpy, cmd,
@@ -985,7 +979,7 @@ static int smr_unexp_sar(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 		if (!sar_entry) {
 			ofi_buf_free(cmd_ctx);
 			ret = -FI_ENOMEM;
-			cmd->hdr.op_flags |= SMR_OP_ERROR;
+			cmd->hdr.smr_flags |= SMR_OP_ERROR;
 			goto out;
 		}
 		cmd->hdr.rx_ctx = (uintptr_t) sar_entry;
@@ -1000,10 +994,11 @@ static int smr_unexp_sar(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 					  &ep->async_cpy_list);
 			return FI_SUCCESS;
 		} else if (ret && ret != -FI_EAGAIN) {
-			cmd->hdr.op_flags |= SMR_OP_ERROR;
+			cmd->hdr.smr_flags |= SMR_OP_ERROR;
 		}
 	}
 out:
+	assert(cmd->hdr.smr_flags & SMR_RETURN_CMD);
 	smr_return_cmd(ep, cmd);
 	return FI_SUCCESS;
 }
@@ -1017,7 +1012,7 @@ static int smr_unexp_ipc(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 	struct iovec iov;
 	int ret = FI_SUCCESS;;
 
-	if (!(cmd->hdr.op_flags & SMR_BUFFER_RECV)) {
+	if (!(cmd->hdr.smr_flags & SMR_BUFFER_RECV)) {
 		cmd_ctx->cmd = cmd;
 		return FI_SUCCESS;
 	}
@@ -1059,7 +1054,7 @@ static int smr_unexp_ipc(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 
 out:
 	if (ret)
-		cmd->hdr.op_flags |= SMR_OP_ERROR;
+		cmd->hdr.smr_flags |= SMR_OP_ERROR;
 
 	smr_return_cmd(ep, cmd);
 	return ret;
@@ -1097,7 +1092,7 @@ static int smr_alloc_cmd_ctx(struct smr_ep *ep,
 	slist_init(&cmd_ctx->buf_list);
 
 	rx_entry->msg_size = cmd->hdr.size;
-	if (cmd->hdr.op_flags & SMR_REMOTE_CQ_DATA) {
+	if (cmd->hdr.smr_flags & SMR_REMOTE_CQ_DATA) {
 		rx_entry->flags |= FI_REMOTE_CQ_DATA;
 		rx_entry->cq_data = cmd->hdr.cq_data;
 	}
@@ -1178,7 +1173,7 @@ static int smr_progress_cmd_rma(struct smr_ep *ep, struct smr_cmd *cmd)
 	int ret = 0;
 	struct ofi_mr *mr[SMR_IOV_LIMIT];
 	struct smr_pend_entry *pend;
-	bool return_cmd = cmd->hdr.proto != smr_proto_inline;
+	bool return_cmd = cmd->hdr.smr_flags & SMR_RETURN_CMD;
 
 	if (cmd->hdr.rx_ctx)
 		return smr_progress_pending(ep, cmd);
@@ -1222,11 +1217,11 @@ static int smr_progress_cmd_rma(struct smr_ep *ep, struct smr_cmd *cmd)
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"error processing rma op\n");
 		ret = smr_write_err_comp(ep->util_ep.rx_cq, NULL,
-					 smr_rx_cq_flags(0, cmd->hdr.op_flags),
+					 smr_rx_cq_flags(0, cmd->hdr.smr_flags),
 					 0, ret);
 	} else {
 		ret = smr_complete_rx(ep, NULL, cmd->hdr.op,
-				      smr_rx_cq_flags(0, cmd->hdr.op_flags),
+				      smr_rx_cq_flags(0, cmd->hdr.smr_flags),
 				      cmd->hdr.size,
 				      iov_count ? iov[0].iov_base : NULL,
 				      cmd->hdr.rx_id, 0, cmd->hdr.cq_data);
@@ -1292,16 +1287,16 @@ static int smr_progress_cmd_atomic(struct smr_ep *ep, struct smr_cmd *cmd)
 	}
 
 	if (err) {
-		cmd->hdr.op_flags |= SMR_OP_ERROR;
+		cmd->hdr.smr_flags |= SMR_OP_ERROR;
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"error processing atomic op\n");
 		ret = smr_write_err_comp(ep->util_ep.rx_cq, NULL,
 					 smr_rx_cq_flags(0,
-					 cmd->hdr.op_flags), 0, err);
+					 cmd->hdr.smr_flags), 0, err);
 	} else {
 		ret = smr_complete_rx(ep, NULL, cmd->hdr.op,
 				      smr_rx_cq_flags(0,
-				      cmd->hdr.op_flags), total_len,
+				      cmd->hdr.smr_flags), total_len,
 				      ioc_count ? ioc[0].addr : NULL,
 				      cmd->hdr.rx_id, 0, cmd->hdr.cq_data);
 	}
@@ -1312,7 +1307,7 @@ static int smr_progress_cmd_atomic(struct smr_ep *ep, struct smr_cmd *cmd)
 	}
 
 out:
-	if (cmd->hdr.proto != smr_proto_inline)
+	if (cmd->hdr.smr_flags & SMR_RETURN_CMD)
 		smr_return_cmd(ep, cmd);
 	return err;
 }
@@ -1415,7 +1410,7 @@ static void smr_progress_async_sar(struct smr_ep *ep,
 		if (ret == -FI_EAGAIN) {
 			return;
 		} else if (ret && ret != -FI_EAGAIN) {
-			pend->cmd->hdr.op_flags |= SMR_OP_ERROR;
+			pend->cmd->hdr.smr_flags |= SMR_OP_ERROR;
 		}
 		dlist_remove(&pend->entry);
 		smr_return_cmd(ep, pend->cmd);
@@ -1433,7 +1428,7 @@ static void smr_progress_async_sar(struct smr_ep *ep,
 			dlist_remove(&pend->entry);
 			return;
 		} else if (ret && ret != -FI_EBUSY) {
-			pend->cmd->hdr.op_flags |= SMR_OP_ERROR;
+			pend->cmd->hdr.smr_flags |= SMR_OP_ERROR;
 		}
 	}
 }

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -974,28 +974,27 @@ static int smr_unexp_sar(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 	memcpy(&cmd_ctx->cmd_cpy, cmd,
 		sizeof(cmd->hdr) + sizeof(cmd->data));
 
-	if (cmd->hdr.size) {
-		sar_entry = ofi_buf_alloc(ep->pend_pool);
-		if (!sar_entry) {
-			ofi_buf_free(cmd_ctx);
-			ret = -FI_ENOMEM;
-			cmd->hdr.smr_flags |= SMR_OP_ERROR;
-			goto out;
-		}
-		cmd->hdr.rx_ctx = (uintptr_t) sar_entry;
+	assert(cmd->hdr.size);
+	sar_entry = ofi_buf_alloc(ep->pend_pool);
+	if (!sar_entry) {
+		ofi_buf_free(cmd_ctx);
+		ret = -FI_ENOMEM;
+		cmd->hdr.smr_flags |= SMR_OP_ERROR;
+		goto out;
+	}
+	cmd->hdr.rx_ctx = (uintptr_t) sar_entry;
 
-		smr_init_rx_pend(sar_entry, cmd, rx_entry, NULL, NULL, 0);
-		cmd_ctx->pend = sar_entry;
+	smr_init_rx_pend(sar_entry, cmd, rx_entry, NULL, NULL, 0);
+	cmd_ctx->pend = sar_entry;
 
-		ret = smr_buffer_sar(ep, sar_entry,
-				     sar_entry->rx_entry->peer_context);
-		if (ret == -FI_EAGAIN) {
-			dlist_insert_tail(&sar_entry->entry,
-					  &ep->async_cpy_list);
-			return FI_SUCCESS;
-		} else if (ret && ret != -FI_EAGAIN) {
-			cmd->hdr.smr_flags |= SMR_OP_ERROR;
-		}
+	ret = smr_buffer_sar(ep, sar_entry,
+				sar_entry->rx_entry->peer_context);
+	if (ret == -FI_EAGAIN) {
+		dlist_insert_tail(&sar_entry->entry,
+					&ep->async_cpy_list);
+		return FI_SUCCESS;
+	} else if (ret && ret != -FI_EAGAIN) {
+		cmd->hdr.smr_flags |= SMR_OP_ERROR;
 	}
 out:
 	assert(cmd->hdr.smr_flags & SMR_RETURN_CMD);

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -37,9 +37,8 @@
 
 static void smr_progress_overflow(struct smr_ep *ep)
 {
-	struct smr_cmd_entry *ce;
+	struct smr_cmd *ce, *cmd;
 	struct smr_region *peer_smr;
-	struct smr_cmd *cmd;
 	int64_t pos;
 	struct slist_entry *entry;
 	int ret;
@@ -53,8 +52,9 @@ static void smr_progress_overflow(struct smr_ep *ep)
 		if (ret == -FI_ENOENT)
 			return;
 
-		ce->ptr = smr_local_to_peer(ep, peer_smr, cmd->hdr.tx_id,
-					    cmd->hdr.rx_id, (uintptr_t) cmd);
+		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, cmd->hdr.tx_id,
+						  cmd->hdr.rx_id,
+						  (uintptr_t) cmd);
 
 		slist_remove_head(&ep->overflow_list);
 		smr_cmd_queue_commit(ce, pos);
@@ -171,19 +171,16 @@ static int smr_progress_return_entry(struct smr_ep *ep, struct smr_cmd *cmd,
 
 static void smr_progress_return(struct smr_ep *ep)
 {
-	struct smr_return_entry *queue_entry;
 	struct smr_cmd *cmd;
 	struct smr_pend_entry *pending;
-	int64_t pos;
 	int ret;
 
 	while (1) {
-		ret = smr_return_queue_head(smr_return_queue(ep->region),
-					    &queue_entry, &pos);
-		if (ret == -FI_ENOENT)
+		cmd = smr_fifo_read(smr_return_queue(ep->region),
+				    (uintptr_t)ep->region);
+		if (!cmd)
 			break;
 
-		cmd = (struct smr_cmd *) queue_entry->ptr;
 		pending = (struct smr_pend_entry *) cmd->hdr.tx_ctx;
 
 		ret = smr_progress_return_entry(ep, cmd, pending);
@@ -209,8 +206,6 @@ static void smr_progress_return(struct smr_ep *ep)
 			ofi_buf_free(pending);
 			smr_freestack_push(smr_cmd_stack(ep->region), cmd);
 		}
-		smr_return_queue_release(smr_return_queue(ep->region),
-					 queue_entry, pos);
 	}
 }
 

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -97,9 +97,9 @@ static int smr_progress_return_entry(struct smr_ep *ep, struct smr_cmd *cmd,
 		assert(pend->mr[0]);
 		break;
 	case smr_proto_sar:
-		if (cmd->hdr.status) {
+		if (cmd->hdr.op_flags & SMR_OP_ERROR) {
 			smr_free_sar_bufs(ep, cmd, pend);
-			return cmd->hdr.status;
+			return -FI_EIO;
 		}
 
 		if (cmd->hdr.op == ofi_op_read_req) {
@@ -109,6 +109,7 @@ static int smr_progress_return_entry(struct smr_ep *ep, struct smr_cmd *cmd,
 
 			if (ret && ret != -FI_EBUSY)
 				return ret;
+
 			if (pend->bytes_done == cmd->hdr.size) {
 				smr_free_sar_bufs(ep, cmd, pend);
 				return FI_SUCCESS;
@@ -189,26 +190,23 @@ static void smr_progress_return(struct smr_ep *ep)
 
 		ret = smr_progress_return_entry(ep, cmd, pending);
 		if (ret != -FI_EAGAIN) {
-			if (pending) {
-				if (cmd->hdr.status) {
-					ret = smr_write_err_comp(
-							ep->util_ep.tx_cq,
-							pending->comp_ctx,
-							pending->comp_flags,
-							cmd->hdr.tag,
-							cmd->hdr.status);
-				} else {
-					ret = smr_complete_tx(
-							ep, pending->comp_ctx,
-							cmd->hdr.op,
-							pending->comp_flags);
-				}
-				if (ret) {
-					FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-						"unable to process "
-						"tx completion\n");
-				}
-				ofi_buf_free(pending);
+			assert(pending);
+			if (cmd->hdr.op_flags & SMR_OP_ERROR) {
+				ret = smr_write_err_comp(
+						ep->util_ep.tx_cq,
+						pending->comp_ctx,
+						pending->comp_flags,
+						cmd->hdr.tag, -FI_EIO);
+			} else {
+				ret = smr_complete_tx(
+						ep, pending->comp_ctx,
+						cmd->hdr.op,
+						pending->comp_flags);
+			}
+			if (ret) {
+				FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+					"unable to process "
+					"tx completion\n");
 			}
 			smr_freestack_push(smr_cmd_stack(ep->region), cmd);
 		}
@@ -261,15 +259,16 @@ static ssize_t smr_progress_inject(struct smr_ep *ep, struct smr_cmd *cmd,
 	if (ret < 0) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"inject recv failed with code %lu\n", ret);
+		cmd->hdr.op_flags |= SMR_OP_ERROR;
 	} else if (ret != cmd->hdr.size) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"inject recv truncated\n");
 		ret = -FI_ETRUNC;
+		cmd->hdr.op_flags |= SMR_OP_ERROR;
 	} else {
 		ret = FI_SUCCESS;
 	}
 
-	cmd->hdr.status = ret;
 	return ret;
 }
 
@@ -290,7 +289,9 @@ static ssize_t smr_progress_iov(struct smr_ep *ep, struct smr_cmd *cmd,
 			       cmd->data.iov_count, cmd->hdr.size,
 			       peer_smr->pid, cmd->hdr.op == ofi_op_read_req,
 			       xpmem);
-	cmd->hdr.status = ret;
+	if (ret)
+		cmd->hdr.op_flags |= SMR_OP_ERROR;
+
 	return ret;
 }
 
@@ -344,8 +345,8 @@ static ssize_t smr_try_copy_rx_sar(struct smr_ep *ep,
 	if (ret) {
 		if (ret == -FI_EAGAIN)
 			dlist_insert_tail(&pend->entry, &ep->async_cpy_list);
-		else if (ret != -FI_EBUSY)
-			pend->cmd->hdr.status = ret;
+		else if (ret && ret != -FI_EBUSY)
+			pend->cmd->hdr.op_flags |= SMR_OP_ERROR;
 	}
 	return ret;
 }
@@ -362,7 +363,7 @@ static int smr_progress_pending_sar(struct smr_ep *ep, struct smr_cmd *cmd)
 			dlist_insert_tail(&pend->entry, &ep->async_cpy_list);
 			return FI_SUCCESS;
 		}
-		cmd->hdr.status = ret;
+		cmd->hdr.op_flags |= SMR_OP_ERROR;
 		goto out;
 	}
 
@@ -370,13 +371,13 @@ static int smr_progress_pending_sar(struct smr_ep *ep, struct smr_cmd *cmd)
 	if (ret == -FI_EBUSY || ret == -FI_EAGAIN)
 		return FI_SUCCESS;
 
-	if (pend->bytes_done == cmd->hdr.size || pend->cmd->hdr.status) {
-		if (pend->cmd->hdr.status) {
+	if (pend->bytes_done == cmd->hdr.size ||
+	    pend->cmd->hdr.op_flags & SMR_OP_ERROR) {
+		if (pend->cmd->hdr.op_flags & SMR_OP_ERROR) {
 			ret = smr_write_err_comp(ep->util_ep.rx_cq,
 						 pend->comp_ctx,
 						 pend->comp_flags,
-						 cmd->hdr.tag,
-						 pend->cmd->hdr.status);
+						 cmd->hdr.tag, -FI_EIO);
 		} else {
 			ret = smr_complete_rx(ep, pend->comp_ctx,
 					      cmd->hdr.op,
@@ -468,7 +469,7 @@ static ssize_t smr_progress_sar(struct smr_ep *ep, struct smr_cmd *cmd,
 
 	ret = smr_try_copy_rx_sar(ep, pend);
 
-	if (pend->bytes_done == cmd->hdr.size || pend->cmd->hdr.status) {
+	if (pend->bytes_done == cmd->hdr.size) {
 		cmd->hdr.rx_ctx = 0;
 		ofi_buf_free(pend);
 		ret = FI_SUCCESS;
@@ -573,7 +574,9 @@ static ssize_t smr_progress_ipc(struct smr_ep *ep, struct smr_cmd *cmd,
 uncache:
 	ofi_mr_cache_delete(domain->ipc_cache, mr_entry);
 out:
-	cmd->hdr.status = ret;
+	if (ret)
+		cmd->hdr.op_flags |= SMR_OP_ERROR;
+
 	return ret;
 }
 
@@ -904,7 +907,7 @@ static int smr_unexp_inject(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 	buf = ofi_buf_alloc(ep->unexp_buf_pool);
 	if (!buf) {
 		ret = -FI_ENOMEM;
-		cmd->hdr.status = ret;
+		cmd->hdr.op_flags |= SMR_OP_ERROR;
 		goto out;
 	}
 
@@ -957,7 +960,9 @@ static int smr_unexp_iov(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 		slist_insert_tail(&buf->entry, &cmd_ctx->buf_list);
 	}
 out:
-	cmd->hdr.status = ret;
+	if (ret)
+		cmd->hdr.op_flags |= SMR_OP_ERROR;
+
 	smr_return_cmd(ep, cmd);
 	return ret;
 }
@@ -980,7 +985,7 @@ static int smr_unexp_sar(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 		if (!sar_entry) {
 			ofi_buf_free(cmd_ctx);
 			ret = -FI_ENOMEM;
-			cmd->hdr.status = ret;
+			cmd->hdr.op_flags |= SMR_OP_ERROR;
 			goto out;
 		}
 		cmd->hdr.rx_ctx = (uintptr_t) sar_entry;
@@ -994,8 +999,9 @@ static int smr_unexp_sar(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 			dlist_insert_tail(&sar_entry->entry,
 					  &ep->async_cpy_list);
 			return FI_SUCCESS;
+		} else if (ret && ret != -FI_EAGAIN) {
+			cmd->hdr.op_flags |= SMR_OP_ERROR;
 		}
-		cmd->hdr.status = ret;
 	}
 out:
 	smr_return_cmd(ep, cmd);
@@ -1052,7 +1058,9 @@ static int smr_unexp_ipc(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 	cmd_ctx->cmd->hdr.size = total_size;
 
 out:
-	cmd->hdr.status = ret;
+	if (ret)
+		cmd->hdr.op_flags |= SMR_OP_ERROR;
+
 	smr_return_cmd(ep, cmd);
 	return ret;
 }
@@ -1282,9 +1290,9 @@ static int smr_progress_cmd_atomic(struct smr_ep *ep, struct smr_cmd *cmd)
 			"unidentified operation type\n");
 		err = -FI_EINVAL;
 	}
-	cmd->hdr.status = -err;
 
 	if (err) {
+		cmd->hdr.op_flags |= SMR_OP_ERROR;
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"error processing atomic op\n");
 		ret = smr_write_err_comp(ep->util_ep.rx_cq, NULL,
@@ -1404,9 +1412,11 @@ static void smr_progress_async_sar(struct smr_ep *ep,
 
 	if (pend->rx_entry && pend->rx_entry->peer_context) {
 		ret = smr_buffer_sar(ep, pend, pend->rx_entry->peer_context);
-		if (ret == -FI_EAGAIN)
+		if (ret == -FI_EAGAIN) {
 			return;
-		pend->cmd->hdr.status = ret;
+		} else if (ret && ret != -FI_EAGAIN) {
+			pend->cmd->hdr.op_flags |= SMR_OP_ERROR;
+		}
 		dlist_remove(&pend->entry);
 		smr_return_cmd(ep, pend->cmd);
 		return;
@@ -1422,8 +1432,9 @@ static void smr_progress_async_sar(struct smr_ep *ep,
 		if (ret == -FI_EBUSY) {
 			dlist_remove(&pend->entry);
 			return;
+		} else if (ret && ret != -FI_EBUSY) {
+			pend->cmd->hdr.op_flags |= SMR_OP_ERROR;
 		}
-		pend->cmd->hdr.status = ret;
 	}
 }
 

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -128,12 +128,13 @@ static ssize_t smr_generic_rma(
 {
 	struct smr_region *peer_smr;
 	int64_t tx_id, rx_id;
-	int proto = smr_proto_inline;
+	int proto;
 	ssize_t ret = -FI_EAGAIN;
 	size_t total_len;
 	struct smr_cmd_entry *ce;
 	struct smr_cmd *cmd;
 	int64_t pos;
+	uint8_t smr_flags;
 
 	assert(iov_count <= SMR_IOV_LIMIT);
 	assert(rma_count <= SMR_IOV_LIMIT);
@@ -169,8 +170,8 @@ static ssize_t smr_generic_rma(
 
 	proto = smr_select_proto(desc, iov_count, smr_vma_enabled(ep, peer_smr),
 	                         smr_ipc_valid(ep, peer_smr, tx_id, rx_id), op,
-				 total_len, op_flags);
-	if (proto != smr_proto_inline) {
+				 total_len, op_flags, &smr_flags);
+	if (smr_flags & SMR_RETURN_CMD) {
 		if (smr_freestack_isempty(smr_cmd_stack(ep->region))) {
 			smr_cmd_queue_discard(ce, pos);
 			ret = -FI_EAGAIN;
@@ -184,10 +185,10 @@ static ssize_t smr_generic_rma(
 		cmd = &ce->cmd;
 	}
 	ret = smr_send_ops[proto](ep, peer_smr, tx_id, rx_id, op, 0, data,
-				  op_flags, (struct ofi_mr **)desc, iov,
-				  iov_count, total_len, context, cmd);
+				  op_flags, smr_flags, (struct ofi_mr **)desc,
+				  iov, iov_count, total_len, context, cmd);
 	if (ret) {
-		if (proto != smr_proto_inline)
+		if (smr_flags & SMR_RETURN_CMD)
 			smr_freestack_push(smr_cmd_stack(ep->region), cmd);
 		smr_cmd_queue_discard(ce, pos);
 		goto unlock;
@@ -196,7 +197,7 @@ static ssize_t smr_generic_rma(
 	smr_add_rma_cmd(peer_smr, rma_iov, rma_count, cmd);
 	smr_cmd_queue_commit(ce, pos);
 
-	if (proto != smr_proto_inline || op == ofi_op_read_req)
+	if (smr_flags & SMR_RETURN_CMD)
 		goto unlock;
 
 	ret = smr_complete_tx(ep, context, op, op_flags);
@@ -320,7 +321,7 @@ static ssize_t smr_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 static ssize_t smr_generic_rma_inject(
 		struct fid_ep *ep_fid, const void *buf, size_t len,
 		fi_addr_t dest_addr, uint64_t addr, uint64_t key, uint64_t data,
-		uint64_t flags)
+		uint64_t op_flags)
 {
 	struct smr_ep *ep;
 	struct smr_region *peer_smr;
@@ -332,6 +333,7 @@ static ssize_t smr_generic_rma_inject(
 	struct smr_cmd *cmd;
 	struct smr_cmd_entry *ce;
 	int64_t pos;
+	uint8_t smr_flags;
 
 	assert(len <= SMR_INJECT_SIZE);
 	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
@@ -359,36 +361,21 @@ static ssize_t smr_generic_rma_inject(
 		goto unlock;
 	}
 
-	if (len <= SMR_MSG_DATA_LEN) {
-		proto = smr_proto_inline;
-		cmd = &ce->cmd;
-	} else {
-		proto = smr_proto_inject;
-		if (smr_freestack_isempty(smr_cmd_stack(ep->region))) {
-			smr_cmd_queue_discard(ce, pos);
-			ret = -FI_EAGAIN;
-			goto unlock;
-		}
+	proto = len <= SMR_MSG_DATA_LEN ? smr_proto_inline : smr_proto_inject;
+	cmd = &ce->cmd;
 
-		cmd = smr_freestack_pop(smr_cmd_stack(ep->region));
-		assert(cmd);
-		ce->ptr = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
-					    (uintptr_t) cmd);
-	}
-
+	smr_flags = (op_flags & FI_REMOTE_CQ_DATA) ? SMR_REMOTE_CQ_DATA : 0;
 	ret = smr_send_ops[proto](ep, peer_smr, tx_id, rx_id, ofi_op_write, 0,
-				  data, flags, NULL, &iov, 1, len, NULL, cmd);
+				  data, op_flags, smr_flags, NULL, &iov, 1, len,
+				  NULL, cmd);
 	if (ret) {
-		if (proto != smr_proto_inline)
-			smr_freestack_push(smr_cmd_stack(ep->region), cmd);
 		smr_cmd_queue_discard(ce, pos);
 		goto unlock;
 	}
 	smr_add_rma_cmd(peer_smr, &rma_iov, 1, cmd);
 	smr_cmd_queue_commit(ce, pos);
 
-	if (proto == smr_proto_inline)
-		ofi_ep_peer_tx_cntr_inc(&ep->util_ep, ofi_op_write);
+	ofi_ep_peer_tx_cntr_inc(&ep->util_ep, ofi_op_write);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -188,9 +188,9 @@ static ssize_t smr_generic_rma(
 				  op_flags, smr_flags, (struct ofi_mr **)desc,
 				  iov, iov_count, total_len, context, cmd);
 	if (ret) {
+		smr_cmd_queue_discard(ce, pos);
 		if (smr_flags & SMR_RETURN_CMD)
 			smr_freestack_push(smr_cmd_stack(ep->region), cmd);
-		smr_cmd_queue_discard(ce, pos);
 		goto unlock;
 	}
 

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -106,12 +106,21 @@ static ssize_t smr_rma_fast(struct smr_ep *ep, struct smr_region *peer_smr,
 
 static inline bool smr_do_fast_rma(struct smr_ep *ep, uint64_t op_flags,
 				   size_t rma_count, size_t total_len,
-				   struct smr_region *peer_smr)
+				   struct smr_region *peer_smr, uint32_t op)
 {
 	struct smr_domain *domain;
 
 	domain = container_of(ep->util_ep.domain, struct smr_domain,
 			      util_domain);
+
+	/* For reads, sender-side CMA is safe at all sizes: delivery is
+	 * inherently complete when process_vm_readv returns (data is in
+	 * local buffer), and the target memory is always a registered MR
+	 * with pinned pages. */
+	if (op == ofi_op_read_req && total_len <= SMR_INJECT_SIZE)
+		return domain->fast_rma &&
+		       !(op_flags & FI_REMOTE_CQ_DATA) &&
+		       rma_count == 1 && smr_vma_enabled(ep, peer_smr);
 
 	return domain->fast_rma && !(op_flags &
 		    (FI_REMOTE_CQ_DATA | FI_DELIVERY_COMPLETE)) &&
@@ -152,7 +161,7 @@ static ssize_t smr_generic_rma(
 		goto unlock;
 
 	total_len = ofi_total_iov_len(iov, iov_count);
-	if (smr_do_fast_rma(ep, op_flags, rma_count, total_len, peer_smr)) {
+	if (smr_do_fast_rma(ep, op_flags, rma_count, total_len, peer_smr, op)) {
 		ret = smr_rma_fast(ep, peer_smr, iov, iov_count, rma_iov,
 				   rma_count, desc, rx_id, tx_id, context, op,
 				   op_flags);

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -58,12 +58,12 @@ static ssize_t smr_rma_fast(struct smr_ep *ep, struct smr_region *peer_smr,
 {
 	struct iovec vma_iovec[SMR_IOV_LIMIT], rma_iovec[SMR_IOV_LIMIT];
 	struct ofi_xpmem_client *xpmem;
-	struct smr_cmd_entry *ce;
+	struct smr_cmd *cmd;
 	size_t total_len;
 	int ret, i;
 	int64_t pos;
 
-	ret = smr_cmd_queue_next(smr_cmd_queue(peer_smr), &ce, &pos);
+	ret = smr_cmd_queue_next(smr_cmd_queue(peer_smr), &cmd, &pos);
 	if (ret == -FI_ENOENT)
 		return -FI_EAGAIN;
 
@@ -85,15 +85,15 @@ static ssize_t smr_rma_fast(struct smr_ep *ep, struct smr_region *peer_smr,
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL, "error doing fast RMA\n");
 		ret = smr_write_err_comp(ep->util_ep.rx_cq, NULL, op_flags, 0,
 					 ret);
-		smr_cmd_queue_discard(ce, pos);
+		smr_cmd_queue_discard(cmd, pos);
 		return -FI_EAGAIN;
 	}
 
-	smr_format_rma_resp(&ce->cmd, rx_id, rma_iov, rma_count, total_len,
+	smr_format_rma_resp(cmd, rx_id, rma_iov, rma_count, total_len,
 			    (op == ofi_op_write) ? ofi_op_write_async :
 			    ofi_op_read_async, op_flags);
 
-	smr_cmd_queue_commit(ce, pos);
+	smr_cmd_queue_commit(cmd, pos);
 
 	ret = smr_complete_tx(ep, context, op, op_flags);
 	if (ret) {
@@ -131,8 +131,7 @@ static ssize_t smr_generic_rma(
 	int proto;
 	ssize_t ret = -FI_EAGAIN;
 	size_t total_len;
-	struct smr_cmd_entry *ce;
-	struct smr_cmd *cmd;
+	struct smr_cmd *ce, *cmd;
 	int64_t pos;
 	uint8_t smr_flags;
 
@@ -179,10 +178,10 @@ static ssize_t smr_generic_rma(
 		}
 		cmd = smr_freestack_pop(smr_cmd_stack(ep->region));
 		assert(cmd);
-		ce->ptr = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
-					    (uintptr_t) cmd);
+		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
+						  (uintptr_t) cmd);
 	} else {
-		cmd = &ce->cmd;
+		cmd = ce;
 	}
 	ret = smr_send_ops[proto](ep, peer_smr, tx_id, rx_id, op, 0, data,
 				  op_flags, smr_flags, (struct ofi_mr **)desc,
@@ -331,7 +330,6 @@ static ssize_t smr_generic_rma_inject(
 	int proto = smr_proto_inline;
 	ssize_t ret = -FI_EAGAIN;
 	struct smr_cmd *cmd;
-	struct smr_cmd_entry *ce;
 	int64_t pos;
 	uint8_t smr_flags;
 
@@ -355,25 +353,24 @@ static ssize_t smr_generic_rma_inject(
 	rma_iov.len = len;
 	rma_iov.key = key;
 
-	ret = smr_cmd_queue_next(smr_cmd_queue(peer_smr), &ce, &pos);
+	ret = smr_cmd_queue_next(smr_cmd_queue(peer_smr), &cmd, &pos);
 	if (ret == -FI_ENOENT) {
 		ret = -FI_EAGAIN;
 		goto unlock;
 	}
 
 	proto = len <= SMR_MSG_DATA_LEN ? smr_proto_inline : smr_proto_inject;
-	cmd = &ce->cmd;
 
 	smr_flags = (op_flags & FI_REMOTE_CQ_DATA) ? SMR_REMOTE_CQ_DATA : 0;
 	ret = smr_send_ops[proto](ep, peer_smr, tx_id, rx_id, ofi_op_write, 0,
 				  data, op_flags, smr_flags, NULL, &iov, 1, len,
 				  NULL, cmd);
 	if (ret) {
-		smr_cmd_queue_discard(ce, pos);
+		smr_cmd_queue_discard(cmd, pos);
 		goto unlock;
 	}
 	smr_add_rma_cmd(peer_smr, &rma_iov, 1, cmd);
-	smr_cmd_queue_commit(ce, pos);
+	smr_cmd_queue_commit(cmd, pos);
 
 	ofi_ep_peer_tx_cntr_inc(&ep->util_ep, ofi_op_write);
 unlock:

--- a/prov/shm/src/smr_util.c
+++ b/prov/shm/src/smr_util.c
@@ -103,14 +103,13 @@ size_t smr_calculate_size_offsets(size_t tx_count, size_t rx_count,
 
 	/* Align cmd_queue offset to cache line */
 	cmd_queue_offset = ofi_get_aligned_size(sizeof(struct smr_region), 64);
-	cmd_stack_offset = cmd_queue_offset + sizeof(struct smr_cmd_queue) +
-		sizeof(struct smr_cmd_queue_entry) * rx_size;
-	inject_pool_offset = cmd_stack_offset +
-		freestack_size(sizeof(struct smr_cmd), tx_size);
-	ret_queue_offset = inject_pool_offset +
+	inject_pool_offset = cmd_queue_offset + sizeof(struct smr_cmd_queue) +
+			     sizeof(struct smr_cmd_queue_entry) * rx_size;
+	cmd_stack_offset = inject_pool_offset +
 			   freestack_size(sizeof(struct smr_inject_buf),
-			   rx_size);
-	ret_queue_offset = ofi_get_aligned_size(ret_queue_offset, 64);
+					  rx_size);
+	ret_queue_offset = ofi_get_aligned_size(cmd_stack_offset +
+			   freestack_size(sizeof(struct smr_cmd), tx_size), 64);
 	sar_pool_offset = ret_queue_offset + sizeof(struct smr_return_queue) +
 		sizeof(struct smr_return_queue_entry) * tx_size;
 	peer_data_offset = sar_pool_offset +

--- a/prov/shm/src/smr_util.c
+++ b/prov/shm/src/smr_util.c
@@ -37,6 +37,7 @@
 struct dlist_entry ep_name_list;
 DEFINE_LIST(ep_name_list);
 pthread_mutex_t ep_list_lock = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t inject_pool_lock = PTHREAD_MUTEX_INITIALIZER;
 
 void smr_cleanup(void)
 {
@@ -106,8 +107,9 @@ size_t smr_calculate_size_offsets(size_t tx_count, size_t rx_count,
 		sizeof(struct smr_cmd_queue_entry) * rx_size;
 	inject_pool_offset = cmd_stack_offset +
 		freestack_size(sizeof(struct smr_cmd), tx_size);
-	ret_queue_offset = inject_pool_offset + sizeof(struct smr_inject_buf) *
-		tx_size;
+	ret_queue_offset = inject_pool_offset +
+			   freestack_size(sizeof(struct smr_inject_buf),
+			   rx_size);
 	ret_queue_offset = ofi_get_aligned_size(ret_queue_offset, 64);
 	sar_pool_offset = ret_queue_offset + sizeof(struct smr_return_queue) +
 		sizeof(struct smr_return_queue_entry) * tx_size;
@@ -287,6 +289,8 @@ int smr_create(const struct fi_provider *prov, const struct smr_attr *attr,
 	(*smr)->max_sar_buf_per_peer = SMR_BUF_BATCH_MAX;
 
 	smr_cmd_queue_init(smr_cmd_queue(*smr), rx_size, smr_cmd_init);
+	smr_freestack_init(smr_inject_pool(*smr), rx_size,
+			   sizeof(struct smr_inject_buf));
 	smr_return_queue_init(smr_return_queue(*smr), tx_size, NULL);
 
 	smr_freestack_init(smr_cmd_stack(*smr), tx_size,
@@ -300,6 +304,7 @@ int smr_create(const struct fi_provider *prov, const struct smr_attr *attr,
 		smr_peer_data(*smr)[i].xpmem.avail = false;
 	}
 
+	ofi_spin_init(&(*smr)->fs_lock);
 	strncpy((char *) smr_name(*smr), attr->name, total_size - name_offset);
 
 	/* Must be set last to signal full initialization to peers */
@@ -318,6 +323,10 @@ close:
 
 void smr_free(struct smr_region *smr)
 {
+	/*
+	 * TODO: Figure out if we should cleanup resources in the smr before
+	 * unlinking and unmapping.
+	 */
 	if (smr->flags & SMR_FLAG_HMEM_ENABLED)
 		(void) ofi_hmem_host_unregister(smr);
 	shm_unlink(smr_name(smr));

--- a/prov/shm/src/smr_util.c
+++ b/prov/shm/src/smr_util.c
@@ -180,8 +180,8 @@ err:
 
 static inline void smr_cmd_init(void *buf)
 {
-	struct smr_cmd_entry *ce = buf;
-	ce->ptr = (uintptr_t) &ce->cmd;
+	struct smr_cmd *cmd = buf;
+	cmd->hdr.entry = (uintptr_t) cmd;
 }
 
 /* TODO: Determine if aligning SMR data helps performance */

--- a/prov/shm/src/smr_util.c
+++ b/prov/shm/src/smr_util.c
@@ -117,7 +117,9 @@ size_t smr_calculate_size_offsets(size_t tx_count, size_t rx_count,
 	ep_name_offset = peer_data_offset + sizeof(struct smr_peer_data) *
 		SMR_MAX_PEERS;
 
-	total_size = ep_name_offset + SMR_NAME_MAX;
+	total_size = ep_name_offset + SMR_NAME_MAX +
+		     sizeof(struct smr_resp_slot) * SMR_IOV_LIMIT_SLOTS +
+		     sizeof(uint64_t);
 
 	if (cmd_offset)
 		*cmd_offset = cmd_queue_offset;
@@ -288,6 +290,9 @@ int smr_create(const struct fi_provider *prov, const struct smr_attr *attr,
 	(*smr)->max_sar_buf_per_peer = SMR_BUF_BATCH_MAX;
 
 	smr_cmd_queue_init(smr_cmd_queue(*smr), rx_size, smr_cmd_init);
+	*smr_comp_count(*smr) = 0;
+	memset(smr_resp_slots(*smr), 0, sizeof(struct smr_resp_slot) * SMR_IOV_LIMIT_SLOTS);
+
 	smr_freestack_init(smr_inject_pool(*smr), rx_size,
 			   sizeof(struct smr_inject_buf));
 	smr_fifo_init(smr_return_queue(*smr));

--- a/prov/shm/src/smr_util.c
+++ b/prov/shm/src/smr_util.c
@@ -110,8 +110,8 @@ size_t smr_calculate_size_offsets(size_t tx_count, size_t rx_count,
 					  rx_size);
 	ret_queue_offset = ofi_get_aligned_size(cmd_stack_offset +
 			   freestack_size(sizeof(struct smr_cmd), tx_size), 64);
-	sar_pool_offset = ret_queue_offset + sizeof(struct smr_return_queue) +
-		sizeof(struct smr_return_queue_entry) * tx_size;
+	sar_pool_offset = ret_queue_offset + sizeof(struct smr_fifo);
+
 	peer_data_offset = sar_pool_offset +
 		freestack_size(sizeof(struct smr_sar_buf), SMR_MAX_PEERS);
 	ep_name_offset = peer_data_offset + sizeof(struct smr_peer_data) *
@@ -290,7 +290,7 @@ int smr_create(const struct fi_provider *prov, const struct smr_attr *attr,
 	smr_cmd_queue_init(smr_cmd_queue(*smr), rx_size, smr_cmd_init);
 	smr_freestack_init(smr_inject_pool(*smr), rx_size,
 			   sizeof(struct smr_inject_buf));
-	smr_return_queue_init(smr_return_queue(*smr), tx_size, NULL);
+	smr_fifo_init(smr_return_queue(*smr));
 
 	smr_freestack_init(smr_cmd_stack(*smr), tx_size,
 			   sizeof(struct smr_cmd));

--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -263,8 +263,8 @@ struct smr_region {
 	struct {
 		/* offsets from start of smr_region */
 		size_t			cmd_queue_offset;
-		size_t			cmd_stack_offset;
 		size_t			inject_pool_offset;
+		size_t			cmd_stack_offset;
 		size_t			ret_queue_offset;
 		size_t			sar_pool_offset;
 		size_t			peer_data_offset;

--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -38,6 +38,8 @@
 #include "ofi_lock.h"
 #include "ofi_xpmem.h"
 
+#include "smr_fifo.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -308,7 +310,6 @@ struct smr_return_entry {
 };
 
 OFI_DECLARE_ATOMIC_Q(struct smr_cmd, smr_cmd_queue);
-OFI_DECLARE_ATOMIC_Q(struct smr_return_entry, smr_return_queue);
 
 /* Queue of offsets of the command blocks obtained from the command pool
  * freestack
@@ -326,10 +327,9 @@ static inline struct smr_freestack *smr_inject_pool(struct smr_region *smr)
 	return (struct smr_freestack *)
 			((char *) smr + smr->inject_pool_offset);
 }
-static inline struct smr_return_queue *smr_return_queue(struct smr_region *smr)
+static inline struct smr_fifo *smr_return_queue(struct smr_region *smr)
 {
-	return (struct smr_return_queue *)
-			((char *) smr + smr->ret_queue_offset);
+	return (struct smr_fifo *) ((char *) smr + smr->ret_queue_offset);
 }
 static inline struct smr_peer_data *smr_peer_data(struct smr_region *smr)
 {

--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -61,11 +61,11 @@ extern struct smr_env smr_env;
 /* SMR_CMD_SIZE refers to the total bytes dedicated for use in shm headers and
  * data. The entire atomic queue entry will be cache aligned (384) but this also
  * includes the cmd aq header (16) + cmd entry ptr (8)
- * 384 (total entry size) - 16 (aq header) - 8 (entry ptr) = 360
+ * 384 (total entry size) - 16 (aq header) = 368
  * This maximizes the inline payload. Increasing this value will increase the
  * atomic queue entry to 448 bytes.
  */
-#define SMR_CMD_SIZE		360
+#define SMR_CMD_SIZE		368
 
 /* reserves 0-255 for defined ops and room for new ops
  * 256 and beyond reserved for ctrl ops
@@ -111,6 +111,7 @@ enum {
  *	rx_ctx		target side context (unused by source side)
  */
 struct smr_cmd_hdr {
+	uint64_t		entry;
 	uint8_t			op;
 	uint8_t			proto;
 	uint8_t			smr_flags;
@@ -128,7 +129,6 @@ struct smr_cmd_hdr {
 	};
 	uint64_t		proto_data;
 	//CACHE LINE HERE - See comment above
-	uint64_t		entry;
 	uint64_t		tx_ctx;
 	uint64_t		rx_ctx;
 };
@@ -303,16 +303,11 @@ struct smr_sar_buf {
 	uint8_t		buf[SMR_SAR_SIZE];
 };
 
-struct smr_cmd_entry {
-	uintptr_t	ptr;
-	struct smr_cmd	cmd;
-};
-
 struct smr_return_entry {
 	uintptr_t ptr;
 };
 
-OFI_DECLARE_ATOMIC_Q(struct smr_cmd_entry, smr_cmd_queue);
+OFI_DECLARE_ATOMIC_Q(struct smr_cmd, smr_cmd_queue);
 OFI_DECLARE_ATOMIC_Q(struct smr_return_entry, smr_return_queue);
 
 /* Queue of offsets of the command blocks obtained from the command pool

--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -186,6 +186,13 @@ static_assert(sizeof(struct smr_cmd) == SMR_CMD_SIZE,
 #endif
 
 #define SMR_INJECT_SIZE		4096
+
+/* IOV completion: per-operation status slots in sender's shared region.
+ * Receiver writes status=1 after CMA. Sender scans out-of-order. */
+#define SMR_IOV_LIMIT_SLOTS	64
+struct smr_resp_slot {
+	uint64_t	status;
+} __attribute__((aligned(8)));
 #define SMR_COMP_INJECT_SIZE	(SMR_INJECT_SIZE / 2)
 #define SMR_SAR_SIZE		32768
 
@@ -322,6 +329,17 @@ static inline struct smr_freestack *smr_cmd_stack(struct smr_region *smr)
 {
 	return (struct smr_freestack *) ((char *) smr + smr->cmd_stack_offset);
 }
+static inline struct smr_resp_slot *smr_resp_slots(struct smr_region *smr)
+{
+	return (struct smr_resp_slot *)((char *) smr + smr->name_offset + SMR_NAME_MAX);
+}
+
+static inline uint64_t *smr_comp_count(struct smr_region *smr)
+{
+	return (uint64_t *)((char *) smr + smr->name_offset + SMR_NAME_MAX +
+		sizeof(struct smr_resp_slot) * SMR_IOV_LIMIT_SLOTS);
+}
+
 static inline struct smr_freestack *smr_inject_pool(struct smr_region *smr)
 {
 	return (struct smr_freestack *)

--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -74,6 +74,7 @@ extern struct smr_env smr_env;
 
 #define SMR_REMOTE_CQ_DATA	(1 << 0)
 #define SMR_BUFFER_RECV		(1 << 1)
+#define SMR_OP_ERROR		(1 << 2)
 
 enum {
 	smr_proto_inline,	/* inline payload */
@@ -98,9 +99,12 @@ enum {
  * 	datatype	atomic datatype for FI_ATOMIC API only
  * 	atomic_op	atomic operation for FI_ATOMIC API only
  * 	status		returned status of operation
- * 	CACHE LINE HERE Above fields must be 40 bytes if the cpu does
- *			not support prefetching algorithms. The other 24 bytes
- *			in this cache line come from the atomic queue cmd_entry
+ * 	CACHE LINE HERE Make sure above fields are 40bytes so that they are
+ * 		 	properly cache aligned with the other 24 bytes
+ *			from the atomic queue fields. This is necessary
+			(especially if your cpu does not have prefetching) so
+			that the first cache grab gets the lightweight protocol
+			fields.
  *	entry		for internal use managing commands
  *	tx_ctx		source side context (unused by target side)
  *	rx_ctx		target side context (unused by source side)
@@ -121,7 +125,7 @@ struct smr_cmd_hdr {
 			uint8_t	atomic_op;
 		};
 	};
-	uint64_t		status;
+	uint64_t		proto_data;
 	//CACHE LINE HERE - See comment above
 	uint64_t		entry;
 	uint64_t		tx_ctx;

--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -35,8 +35,8 @@
 
 #include "ofi.h"
 #include "ofi_atomic_queue.h"
+#include "ofi_lock.h"
 #include "ofi_xpmem.h"
-#include <pthread.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -75,6 +75,7 @@ extern struct smr_env smr_env;
 #define SMR_REMOTE_CQ_DATA	(1 << 0)
 #define SMR_BUFFER_RECV		(1 << 1)
 #define SMR_OP_ERROR		(1 << 2)
+#define SMR_RETURN_CMD		(1 << 3)
 
 enum {
 	smr_proto_inline,	/* inline payload */
@@ -89,7 +90,7 @@ enum {
  * Unique smr_cmd_hdr for smr message protocol:
  * 	op		type of op (ex. ofi_op_msg, defined in ofi_proto.h)
  * 	proto		smr protocol (ex. smr_proto_inline, defined above)
- * 	op_flags	operation flags (ex. SMR_REMOTE_CQ_DATA, defined above)
+ * 	smr_flags	operation flags (ex. SMR_REMOTE_CQ_DATA, defined above)
  * 	resv		reserved
  * 	tx_id		local shm_id of peer sending msg (unused by target)
  *	rx_id		remote shm_id of peer sending msg (unused by source)
@@ -112,7 +113,7 @@ enum {
 struct smr_cmd_hdr {
 	uint8_t			op;
 	uint8_t			proto;
-	uint8_t			op_flags;
+	uint8_t			smr_flags;
 	uint8_t			resv[1];
 	int16_t			rx_id;
 	int16_t			tx_id;
@@ -253,6 +254,8 @@ struct smr_region {
 			uintptr_t		base_addr;
 
 			size_t			total_size;
+
+			ofi_spin_t		fs_lock;
 		};
 		uint8_t		pad[SMR_PREFETCH_SZ];
 	};
@@ -323,9 +326,9 @@ static inline struct smr_freestack *smr_cmd_stack(struct smr_region *smr)
 {
 	return (struct smr_freestack *) ((char *) smr + smr->cmd_stack_offset);
 }
-static inline struct smr_inject_buf *smr_inject_pool(struct smr_region *smr)
+static inline struct smr_freestack *smr_inject_pool(struct smr_region *smr)
 {
-	return (struct smr_inject_buf *)
+	return (struct smr_freestack *)
 			((char *) smr + smr->inject_pool_offset);
 }
 static inline struct smr_return_queue *smr_return_queue(struct smr_region *smr)
@@ -346,11 +349,32 @@ static inline const char *smr_name(struct smr_region *smr)
 	return (const char *) smr + smr->name_offset;
 }
 
-static inline struct smr_inject_buf *smr_get_inject_buf(struct smr_region *smr,
-							struct smr_cmd *cmd)
+static inline struct smr_inject_buf *smr_get_inject_buf(struct smr_region *smr)
 {
-	return &smr_inject_pool(smr)[smr_freestack_get_index(smr_cmd_stack(smr),
-							     (char *) cmd)];
+	struct smr_inject_buf *buf;
+	ofi_spin_lock(&smr->fs_lock);
+	if (!smr_freestack_isempty(smr_inject_pool(smr)))
+		buf = smr_freestack_pop(smr_inject_pool(smr));
+	else
+		buf = NULL;
+	ofi_spin_unlock(&smr->fs_lock);
+	return buf;
+}
+
+static inline void smr_return_inject_buf(struct smr_region *smr,
+					 struct smr_inject_buf *buf)
+{
+	ofi_spin_lock(&smr->fs_lock);
+	smr_freestack_push(smr_inject_pool(smr), buf);
+	ofi_spin_unlock(&smr->fs_lock);
+}
+
+static inline void smr_return_sar_buf_by_index(struct smr_region *smr,
+					       size_t index)
+{
+	ofi_spin_lock(&smr->fs_lock);
+	smr_freestack_push_by_index(smr_sar_pool(smr), index);
+	ofi_spin_unlock(&smr->fs_lock);
 }
 
 struct smr_attr {

--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -86,27 +86,33 @@ enum {
 
 /*
  * Unique smr_cmd_hdr for smr message protocol:
- *	entry		for internal use managing commands (must be kept first)
- *	tx_ctx		source side context (unused by target side)
- *	rx_ctx		target side context (unused by source side)
- * 	tx_id		local shm_id of peer sending msg (unused by target)
- *	rx_id		remote shm_id of peer sending msg (unused by source)
  * 	op		type of op (ex. ofi_op_msg, defined in ofi_proto.h)
  * 	proto		smr protocol (ex. smr_proto_inline, defined above)
  * 	op_flags	operation flags (ex. SMR_REMOTE_CQ_DATA, defined above)
+ * 	resv		reserved
+ * 	tx_id		local shm_id of peer sending msg (unused by target)
+ *	rx_id		remote shm_id of peer sending msg (unused by source)
  * 	size		size of data transfer
- * 	status		returned status of operation
  * 	cq_data		remote CQ data
  * 	tag		tag for FI_TAGGED API only
  * 	datatype	atomic datatype for FI_ATOMIC API only
  * 	atomic_op	atomic operation for FI_ATOMIC API only
+ * 	status		returned status of operation
+ * 	CACHE LINE HERE Above fields must be 40 bytes if the cpu does
+ *			not support prefetching algorithms. The other 24 bytes
+ *			in this cache line come from the atomic queue cmd_entry
+ *	entry		for internal use managing commands
+ *	tx_ctx		source side context (unused by target side)
+ *	rx_ctx		target side context (unused by source side)
  */
 struct smr_cmd_hdr {
-	uint64_t		entry;
-	uint64_t		tx_ctx;
-	uint64_t		rx_ctx;
+	uint8_t			op;
+	uint8_t			proto;
+	uint8_t			op_flags;
+	uint8_t			resv[1];
+	int16_t			rx_id;
+	int16_t			tx_id;
 	uint64_t		size;
-	int64_t			status;
 	uint64_t		cq_data;
 	union {
 		uint64_t	tag;
@@ -115,12 +121,11 @@ struct smr_cmd_hdr {
 			uint8_t	atomic_op;
 		};
 	};
-	int16_t			rx_id;
-	int16_t			tx_id;
-	uint8_t			op;
-	uint8_t			proto;
-	uint8_t			op_flags;
-	uint8_t			resv[1];
+	uint64_t		status;
+	//CACHE LINE HERE - See comment above
+	uint64_t		entry;
+	uint64_t		tx_ctx;
+	uint64_t		rx_ctx;
 };
 
 #ifdef static_assert


### PR DESCRIPTION
 │ Stacked on #12109. First 6 commits are from #12109 unchanged; only the final commit is new. Will rebase once #12109 merges.

Summary

  Adds a lightweight cirque-based completion path for IOV/CMA operations in the SHM provider, replacing the atomic return queue with a single store + pointer comparison for the high-concurrency case. Recovers v2.4.x performance for many-to-many RMA reads without regressing low-concurrency workloads.

Design

  Sender (smr_do_iov_fast): uses &ce->cmd directly, reserves a resp slot via cirque, allocates a lightweight smr_iov_pend, encodes the resp slot offset in cmd->hdr.proto_data, and does not set SMR_RETURN_CMD. Receiver (smr_progress_iov): writes resp->status after the CMA copy when SMR_RETURN_CMD is clear. The status write happens-after the CMA copy in program order, satisfying FI_DELIVERY_COMPLETE.

  Sender progress (smr_progress_resp): in-order head processing, breaks on first BUSY slot. Guarded by pending_resp_cnt. Dispatch heuristic (peer fan-out): the fast path engages only when recent ops are to different peers. A fan_out_score saturates on peer change and decays on repeats — all-to-all workloads use the fast path; pair-based workloads stay on the slow path.

Performance
  Severe IOV regressions resolved:

  │ Test                           │ Without fast path │ With fast path │
  │ All_get_all_aggregate 1024     │ 78%               │ 127%           │
  │ All_get_all_aggregate 4096     │ 82%               │ 124%           │
  │ All_get_all_non_aggregate 4096 │ 81%               │ 125%           │

  Low-concurrency workloads (Exchange_get pairs) match the v2.5.x baseline rather than degrading from cirque overhead.