### PR TITLE
fabtests/efa: guard fi_efa_rma_bw build on FI_EFA_WR_HIGH_PPS

### DIFF
--- a/fabtests/configure.ac
+++ b/fabtests/configure.ac
@@ -108,9 +108,6 @@ AS_IF([test -z "$CFLAGS"],
 # <3), but it is necessary in AM 1.12.x.
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 
-dnl Call the provider's CONFIGURE and CONDITIONALS macros
-m4_include([prov/efa/configure.m4])
-
 AM_PROG_LIBTOOL
 
 AC_ARG_WITH([valgrind],
@@ -321,6 +318,9 @@ dnl Check for random_r function
 AC_CHECK_FUNC([random_r], [have_random_r=1], [have_random_r=0])
 AC_DEFINE_UNQUOTED([HAVE_RANDOM_R], [$have_random_r],
 		   [Defined to 1 if random_r is available])
+
+dnl Call the provider's CONFIGURE and CONDITIONALS macros
+m4_include([prov/efa/configure.m4])
 
 AC_CONFIG_FILES([Makefile fabtests.spec])
 

--- a/fabtests/prov/efa/Makefile.include
+++ b/fabtests/prov/efa/Makefile.include
@@ -40,8 +40,11 @@ bin_PROGRAMS += prov/efa/src/fi_efa_rnr_read_cq_error \
 		prov/efa/src/fi_efa_multi_ep_stress \
 		prov/efa/src/fi_efa_mmap_test \
 		prov/efa/src/fi_efa_mr_test \
-		prov/efa/src/fi_efa_runt_read_no_handshake \
-		prov/efa/src/fi_efa_rma_bw
+		prov/efa/src/fi_efa_runt_read_no_handshake
+
+if HAVE_FI_EFA_WR_HIGH_PPS
+bin_PROGRAMS += prov/efa/src/fi_efa_rma_bw
+endif HAVE_FI_EFA_WR_HIGH_PPS
 
 if HAVE_VERBS_DEVEL
 if HAVE_EFA_DV
@@ -111,10 +114,12 @@ prov_efa_src_fi_efa_runt_read_no_handshake_SOURCES = \
 	$(benchmarks_srcs)
 prov_efa_src_fi_efa_runt_read_no_handshake_LDADD = libfabtests.la
 
+if HAVE_FI_EFA_WR_HIGH_PPS
 prov_efa_src_fi_efa_rma_bw_SOURCES = \
 	prov/efa/src/efa_rma_bw.c \
 	$(benchmarks_srcs)
 prov_efa_src_fi_efa_rma_bw_LDADD = libfabtests.la
+endif HAVE_FI_EFA_WR_HIGH_PPS
 
 if HAVE_VERBS_DEVEL
 if HAVE_EFA_DV

--- a/fabtests/prov/efa/configure.m4
+++ b/fabtests/prov/efa/configure.m4
@@ -46,6 +46,14 @@ AS_IF([test x"$have_efadv" = x"1"], [
 ])
 AM_CONDITIONAL([HAVE_EFADV_CREATE_COMP_CNTR], [test $have_efadv_create_comp_cntr -eq 1])
 
+dnl Check for FI_EFA_WR_HIGH_PPS in fi_ext_efa.h (needed for efa_rma_bw).
+have_fi_efa_wr_high_pps=0
+AC_CHECK_DECL([FI_EFA_WR_HIGH_PPS],
+	[have_fi_efa_wr_high_pps=1],
+	[have_fi_efa_wr_high_pps=0],
+	[[#include <rdma/fi_ext_efa.h>]])
+AM_CONDITIONAL([HAVE_FI_EFA_WR_HIGH_PPS], [test $have_fi_efa_wr_high_pps -eq 1])
+
 dnl EFA GDA support
 AC_ARG_ENABLE([efagda],
 	[AS_HELP_STRING([--enable-efagda],


### PR DESCRIPTION
fi_efa_rma_bw uses FI_EFA_WR_HIGH_PPS from rdma/fi_ext_efa.h. Only build the test when the symbol is present in the installed libfabric headers.

Add AC_CHECK_DECL for FI_EFA_WR_HIGH_PPS in prov/efa/configure.m4 and wrap the binary target with the resulting HAVE_FI_EFA_WR_HIGH_PPS conditional in Makefile.include.

Move the m4_include of prov/efa/configure.m4 in configure.ac to after --with-libfabric sets CPPFLAGS, so that header checks against the libfabric install tree work correctly.