### PR TITLE
prov/shm: allow sender-side CMA for RMA writes with FI_REMOTE_CQ_DATA

### DIFF
--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -1331,6 +1331,16 @@ static void smr_progress_cmd(struct smr_ep *ep)
 			ret = smr_progress_cmd_rma(ep, cmd);
 			break;
 		case ofi_op_write_async:
+			if (cmd->hdr.op_flags & SMR_REMOTE_CQ_DATA) {
+				smr_complete_rx(ep, NULL, ofi_op_write,
+					smr_rx_cq_flags(0, cmd->hdr.op_flags),
+					cmd->hdr.size, NULL,
+					cmd->hdr.rx_id, 0, cmd->hdr.cq_data);
+			} else {
+				ofi_ep_peer_rx_cntr_inc(&ep->util_ep,
+							cmd->hdr.op);
+			}
+			break;
 		case ofi_op_read_async:
 			ofi_ep_peer_rx_cntr_inc(&ep->util_ep, cmd->hdr.op);
 			break;

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -44,9 +44,9 @@ static void smr_add_rma_cmd(struct smr_region *peer_smr,
 static void smr_format_rma_resp(struct smr_cmd *cmd, int64_t peer_id,
 				const struct fi_rma_iov *rma_iov, size_t count,
 				size_t total_len, uint32_t op,
-				uint64_t op_flags)
+				uint64_t op_flags, uint64_t data)
 {
-	smr_generic_format(cmd, 0, peer_id, op, 0, 0, op_flags);
+	smr_generic_format(cmd, 0, peer_id, op, 0, data, op_flags);
 	cmd->hdr.size = total_len;
 }
 
@@ -54,7 +54,7 @@ static ssize_t smr_rma_fast(struct smr_ep *ep, struct smr_region *peer_smr,
 			    const struct iovec *iov, size_t iov_count,
 			    const struct fi_rma_iov *rma_iov, size_t rma_count,
 			    void **desc, int rx_id, int tx_id, void *context,
-			    uint32_t op, uint64_t op_flags)
+			    uint32_t op, uint64_t op_flags, uint64_t data)
 {
 	struct iovec vma_iovec[SMR_IOV_LIMIT], rma_iovec[SMR_IOV_LIMIT];
 	struct ofi_xpmem_client *xpmem;
@@ -91,7 +91,7 @@ static ssize_t smr_rma_fast(struct smr_ep *ep, struct smr_region *peer_smr,
 
 	smr_format_rma_resp(&ce->cmd, rx_id, rma_iov, rma_count, total_len,
 			    (op == ofi_op_write) ? ofi_op_write_async :
-			    ofi_op_read_async, op_flags);
+			    ofi_op_read_async, op_flags, data);
 
 	smr_cmd_queue_commit(ce, pos);
 
@@ -113,8 +113,8 @@ static inline bool smr_do_fast_rma(struct smr_ep *ep, uint64_t op_flags,
 	domain = container_of(ep->util_ep.domain, struct smr_domain,
 			      util_domain);
 
-	return domain->fast_rma && !(op_flags &
-		    (FI_REMOTE_CQ_DATA | FI_DELIVERY_COMPLETE)) &&
+	return domain->fast_rma &&
+		     !(op_flags & FI_DELIVERY_COMPLETE) &&
 		     rma_count == 1 && smr_vma_enabled(ep, peer_smr) &&
 		     total_len > SMR_INJECT_SIZE;
 
@@ -155,7 +155,7 @@ static ssize_t smr_generic_rma(
 	if (smr_do_fast_rma(ep, op_flags, rma_count, total_len, peer_smr)) {
 		ret = smr_rma_fast(ep, peer_smr, iov, iov_count, rma_iov,
 				   rma_count, desc, rx_id, tx_id, context, op,
-				   op_flags);
+				   op_flags, data);
 		goto unlock;
 	}
 


### PR DESCRIPTION
For RMA writes > SMR_INJECT_SIZE with FI_REMOTE_CQ_DATA (writedata), allow smr_rma_fast (sender-side CMA) instead of falling through to the receiver-side CMA path. The sender does process_vm_writev directly into the target's registered MR, then posts ofi_op_write_async with the cq_data embedded. The receiver generates the remote CQ entry on seeing SMR_REMOTE_CQ_DATA in the write_async notification.

This eliminates the freestack allocation and return-queue round-trip for writedata, recovering 20-25% bandwidth regression at 1-8MB on Graviton and AMD platforms.