### PR TITLE
prov/cxi: Extend timeout for sw_max_recv msg test

### DIFF
--- a/prov/cxi/test/msg.c
+++ b/prov/cxi/test/msg.c
@@ -1010,7 +1010,7 @@ Test(msg, sizes_desc)
 }
 
 /* Test software posted receives greater than hardware limits */
-Test(msg, sw_max_recv, .timeout = CXIT_DEFAULT_TIMEOUT)
+Test(msg, sw_max_recv, .timeout = CXIT_DEFAULT_TIMEOUT + 10)
 {
 	int i, ret;
 	uint8_t *recv_buf,


### PR DESCRIPTION
This should address intermittent CI failures where this test takes just over the default timeout to complete.