### PR TITLE
fabtests/efa/multi_ep_stress: fix timeout in wait_for_comp

### DIFF
--- a/fabtests/prov/efa/src/multi_ep_stress.c
+++ b/fabtests/prov/efa/src/multi_ep_stress.c
@@ -424,11 +424,12 @@ static int wait_for_comp(struct fid_cq *cq, int num_completions)
 	int completed = 0;
 	struct timespec a, b;
 
-	clock_gettime(CLOCK_REALTIME, &a);
+	clock_gettime(CLOCK_MONOTONIC, &a);
 	if (topts.shared_cq) {
-		memcpy(&b, &a, sizeof(b));
-		b.tv_sec += timeout;
-		ret = pthread_mutex_timedlock(&shared_cq_lock, &b);
+		struct timespec timed_mutex_deadline;
+		clock_gettime(CLOCK_REALTIME, &timed_mutex_deadline);
+		timed_mutex_deadline.tv_sec += timeout;
+		ret = pthread_mutex_timedlock(&shared_cq_lock, &timed_mutex_deadline);
 		if (ret == ETIMEDOUT) {
 			fprintf(stderr,
 				"%ds timeout expired while waiting for shared CQ lock\n",


### PR DESCRIPTION
Use CLOCK_MONOTONIC for elapsed-time measurement and a separate CLOCK_REALTIME deadline for pthread_mutex_timedlock, fixing two clock-source mismatches that could cause spurious timeouts or unbounded waits.