### PR TITLE
prov/efa: Fix rx-pool pkt leak on copy-size mismatch

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -194,6 +194,7 @@ prov_efa_test_efa_unit_test_LDFLAGS = $(cmocka_rpath) $(efa_LDFLAGS) $(cmocka_LD
 					-Wl,--wrap=efa_ah_release \
 					-Wl,--wrap=ofi_cudaMalloc \
 					-Wl,--wrap=ofi_copy_from_hmem_iov \
+					-Wl,--wrap=ofi_copy_to_hmem_iov \
 					-Wl,--wrap=efa_rdm_pke_copy_payload_to_ope \
 					-Wl,--wrap=efa_rdm_pke_read \
 					-Wl,--wrap=efa_rdm_pke_proc_matched_rtm \

--- a/prov/efa/src/rdm/efa_rdm_pke_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_utils.c
@@ -121,7 +121,7 @@ ssize_t efa_rdm_pke_init_payload_from_ope(struct efa_rdm_pke *pke,
  */
 int efa_rdm_ep_flush_queued_blocking_copy_to_hmem(struct efa_rdm_ep *ep)
 {
-	size_t i;
+	size_t i, j;
 	size_t bytes_copied[EFA_RDM_MAX_QUEUED_COPY] = {0};
 	struct efa_rdm_mr *desc;
 	struct efa_rdm_ope *rxe;
@@ -166,10 +166,22 @@ int efa_rdm_ep_flush_queued_blocking_copy_to_hmem(struct efa_rdm_ep *ep)
 					   rxe->cq_entry.len - segment_offset)) {
 			EFA_WARN(FI_LOG_CQ, "wrong size! bytes_copied: %ld\n",
 				bytes_copied[i]);
-			/*TODO: Release pkts at j=i..N-1 (still-alive rxes from other queued messages) and write CQ errors for their rxes.*/
+
+			/* Release ALL pkt entries to avoid leak */
+			for (j = 0; j < ep->queued_copy_num; ++j) {
+				pkt_entry = ep->queued_copy_vec[j].pkt_entry;
+				rxe = pkt_entry->ope;
+				rxe->bytes_queued_blocking_copy -= pkt_entry->payload_size;
+				efa_rdm_pke_release_rx(pkt_entry);
+			}
+			ep->queued_copy_num = 0;
 			return -FI_EIO;
 		}
+	}
 
+	for (i = 0; i < ep->queued_copy_num; ++i) {
+		pkt_entry = ep->queued_copy_vec[i].pkt_entry;
+		rxe = pkt_entry->ope;
 		rxe->bytes_queued_blocking_copy -= pkt_entry->payload_size;
 		efa_rdm_pke_handle_data_copied(pkt_entry);
 	}

--- a/prov/efa/test/efa_unit_test_mocks.c
+++ b/prov/efa/test/efa_unit_test_mocks.c
@@ -397,6 +397,7 @@ struct efa_unit_test_mocks g_efa_unit_test_mocks = {
 	.ofi_cudaMalloc = __real_ofi_cudaMalloc,
 #endif
 	.ofi_copy_from_hmem_iov = __real_ofi_copy_from_hmem_iov,
+	.ofi_copy_to_hmem_iov = __real_ofi_copy_to_hmem_iov,
 	.efa_rdm_pke_copy_payload_to_ope = __real_efa_rdm_pke_copy_payload_to_ope,
 	.efa_rdm_pke_read = __real_efa_rdm_pke_read,
 	.efa_rdm_pke_proc_matched_rtm = __real_efa_rdm_pke_proc_matched_rtm,
@@ -680,6 +681,22 @@ ssize_t __wrap_ofi_copy_from_hmem_iov(void *dest, size_t size,
 				      size_t hmem_iov_count, uint64_t hmem_iov_offset)
 {
 	return g_efa_unit_test_mocks.ofi_copy_from_hmem_iov(dest, size, hmem_iface, device, hmem_iov, hmem_iov_count, hmem_iov_offset);
+}
+
+ssize_t __wrap_ofi_copy_to_hmem_iov(enum fi_hmem_iface hmem_iface, uint64_t device,
+				    const struct iovec *hmem_iov,
+				    size_t hmem_iov_count, uint64_t hmem_iov_offset,
+				    const void *src, size_t size)
+{
+	return g_efa_unit_test_mocks.ofi_copy_to_hmem_iov(hmem_iface, device, hmem_iov, hmem_iov_count, hmem_iov_offset, src, size);
+}
+
+ssize_t efa_mock_ofi_copy_to_hmem_iov_return_mock(enum fi_hmem_iface hmem_iface, uint64_t device,
+						  const struct iovec *hmem_iov,
+						  size_t hmem_iov_count, uint64_t hmem_iov_offset,
+						  const void *src, size_t size)
+{
+	return mock_type(ssize_t);
 }
 
 ssize_t __wrap_efa_rdm_pke_copy_payload_to_ope(struct efa_rdm_pke *pke, struct efa_rdm_ope *ope)

--- a/prov/efa/test/efa_unit_test_mocks.h
+++ b/prov/efa/test/efa_unit_test_mocks.h
@@ -72,6 +72,16 @@ ssize_t __real_ofi_copy_from_hmem_iov(void *dest, size_t size,
 				      const struct iovec *hmem_iov,
 				      size_t hmem_iov_count, uint64_t hmem_iov_offset);
 
+ssize_t __real_ofi_copy_to_hmem_iov(enum fi_hmem_iface hmem_iface, uint64_t device,
+				    const struct iovec *hmem_iov,
+				    size_t hmem_iov_count, uint64_t hmem_iov_offset,
+				    const void *src, size_t size);
+
+ssize_t efa_mock_ofi_copy_to_hmem_iov_return_mock(enum fi_hmem_iface hmem_iface, uint64_t device,
+						  const struct iovec *hmem_iov,
+						  size_t hmem_iov_count, uint64_t hmem_iov_offset,
+						  const void *src, size_t size);
+
 extern int g_ofi_copy_from_hmem_iov_call_counter;
 ssize_t efa_mock_ofi_copy_from_hmem_iov_inc_counter(void *dest, size_t size,
 						    enum fi_hmem_iface hmem_iface, uint64_t device,
@@ -203,6 +213,11 @@ struct efa_unit_test_mocks
 					  enum fi_hmem_iface hmem_iface, uint64_t device,
 					  const struct iovec *hmem_iov,
 					  size_t hmem_iov_count, uint64_t hmem_iov_offset);
+
+	ssize_t (*ofi_copy_to_hmem_iov)(enum fi_hmem_iface hmem_iface, uint64_t device,
+					const struct iovec *hmem_iov,
+					size_t hmem_iov_count, uint64_t hmem_iov_offset,
+					const void *src, size_t size);
 
 	ssize_t (*efa_rdm_pke_copy_payload_to_ope)(struct efa_rdm_pke *pke, struct efa_rdm_ope *ope);
 

--- a/prov/efa/test/efa_unit_test_pke.c
+++ b/prov/efa/test/efa_unit_test_pke.c
@@ -553,3 +553,70 @@ void test_efa_rdm_pke_proc_matched_mulreq_rtm_second_packet_error(struct efa_res
 	efa_rdm_pke_release_rx(pkt_entry);
 	efa_rdm_rxe_release(rxe);
 }
+
+/**
+ * @brief Test that flush_queued_blocking_copy_to_hmem releases all pkt entries
+ * when a copy-size mismatch is detected, avoiding a memory leak.
+ * @param state
+ */
+void test_efa_rdm_pke_flush_queued_blocking_copy_to_hmem_copy_size_mismatch(struct efa_resource **state){
+	struct efa_resource *resource = *state;
+	struct efa_rdm_ep *efa_rdm_ep;
+	struct efa_rdm_pke *pkt_entry[2];
+	struct efa_rdm_ope *rxe;
+	struct efa_rdm_mr mock_mr = {0};
+	char buf[1024];
+	size_t pkts_to_post_before;
+	int ret;
+
+	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_FABRIC_NAME);
+	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
+
+	mock_mr.efa_mr.iface = FI_HMEM_CUDA;
+	mock_mr.device = 0;
+	mock_mr.flags = 0;
+
+	rxe = efa_rdm_ep_alloc_rxe(efa_rdm_ep, NULL, ofi_op_msg);
+	assert_non_null(rxe);
+	rxe->iov_count = 1;
+	rxe->iov[0].iov_base = buf;
+	rxe->iov[0].iov_len = sizeof(buf);
+	rxe->cq_entry.len = sizeof(buf);
+	rxe->desc[0] = &mock_mr;
+	rxe->total_len = sizeof(buf);
+
+	for (int i = 0; i < 2; i++) {
+		pkt_entry[i] = efa_rdm_pke_alloc(efa_rdm_ep, efa_rdm_ep->efa_rx_pkt_pool, EFA_RDM_PKE_FROM_EFA_RX_POOL);
+		assert_non_null(pkt_entry[i]);
+		pkt_entry[i]->payload = pkt_entry[i]->wiredata;
+		pkt_entry[i]->payload_size = 64;
+		pkt_entry[i]->ope = rxe;
+
+		/* Replicate efa_rdm_pke_queued_copy_payload_to_hmem() */
+		efa_rdm_ep->queued_copy_vec[i].pkt_entry = pkt_entry[i];
+		efa_rdm_ep->queued_copy_vec[i].data = pkt_entry[i]->payload;
+		efa_rdm_ep->queued_copy_vec[i].data_size = pkt_entry[i]->payload_size;
+		efa_rdm_ep->queued_copy_vec[i].data_offset = 0;
+		efa_rdm_ep->queued_copy_num++;
+		rxe->bytes_queued_blocking_copy += pkt_entry[i]->payload_size;
+		efa_rdm_pke_mark_held(pkt_entry[i]);
+	}
+
+	/* Mock ofi_copy_to_hmem_iov to return 0 to trigger the copy-size mismatch error path */
+	g_efa_unit_test_mocks.ofi_copy_to_hmem_iov = &efa_mock_ofi_copy_to_hmem_iov_return_mock;
+	will_return_always(efa_mock_ofi_copy_to_hmem_iov_return_mock, 0);
+
+	/*
+	 * efa_rdm_pke_release_rx() increments efa_rx_pkts_to_post for entries allocated from EFA_RX_POOL.
+	 * Snapshot before the call to verify: The 2 queued pkt entries were released back to the pool (i.e. no leak).
+	 */
+	pkts_to_post_before = efa_rdm_ep->efa_rx_pkts_to_post;
+
+	ret = efa_rdm_ep_flush_queued_blocking_copy_to_hmem(efa_rdm_ep);
+	assert_int_equal(ret, -FI_EIO);
+	assert_int_equal(efa_rdm_ep->queued_copy_num, 0);
+	assert_int_equal(efa_rdm_ep->efa_rx_pkts_to_post - pkts_to_post_before, 2);
+	assert_int_equal(rxe->bytes_queued_blocking_copy, 0);
+
+	efa_rdm_rxe_release(rxe);
+}

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -83,6 +83,7 @@ static int efa_unit_test_mocks_teardown(void **state)
 		.ofi_cudaMalloc = __real_ofi_cudaMalloc,
 #endif
 		.ofi_copy_from_hmem_iov = __real_ofi_copy_from_hmem_iov,
+		.ofi_copy_to_hmem_iov = __real_ofi_copy_to_hmem_iov,
 		.efa_rdm_pke_copy_payload_to_ope = __real_efa_rdm_pke_copy_payload_to_ope,
 		.efa_rdm_pke_read = __real_efa_rdm_pke_read,
 		.efa_rdm_pke_proc_matched_rtm = __real_efa_rdm_pke_proc_matched_rtm,
@@ -397,6 +398,7 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_rdm_pke_proc_matched_eager_rtm_error, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_pke_proc_matched_mulreq_rtm_first_packet_error, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_pke_proc_matched_mulreq_rtm_second_packet_error, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_rdm_pke_flush_queued_blocking_copy_to_hmem_copy_size_mismatch, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		/* end of efa_unit_test_pke.c */
 
 		/* begin efa_unit_test_domain.c */

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -406,6 +406,7 @@ void test_efa_rdm_pke_flag_tracking();
 void test_efa_rdm_pke_proc_matched_eager_rtm_error();
 void test_efa_rdm_pke_proc_matched_mulreq_rtm_first_packet_error();
 void test_efa_rdm_pke_proc_matched_mulreq_rtm_second_packet_error();
+void test_efa_rdm_pke_flush_queued_blocking_copy_to_hmem_copy_size_mismatch();
 /* end of efa_unit_test_pke.c */
 
 void test_efa_msg_fi_recv();


### PR DESCRIPTION
## Summary

`efa_rdm_ep_flush_queued_blocking_copy_to_hmem()` leaks queued rx-pool pkts at indices `i..N-1` when `bytes_copied` validation fails at index `i` mid-batch. Restructure into copy / validate / finalize passes so all pkts get released to the pool on the error path, and `handle_data_copied()` runs only after the whole batch validates.

## Test

- Add new unit test `test_efa_rdm_pke_flush_queued_blocking_copy_to_hmem_copy_size_mismatch`