### PR TITLE
prov/rxm: Fix ignored domain_attr->cq_data_size hint

### DIFF
--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -229,6 +229,7 @@ int rxm_info_to_core(uint32_t version, const struct fi_info *hints,
 			core_info->domain_attr->caps |= hints->domain_attr->caps;
 			core_info->domain_attr->threading =
 				hints->domain_attr->threading;
+			core_info->domain_attr->cq_data_size = hints->domain_attr->cq_data_size;
 		}
 		if (hints->tx_attr) {
 			core_info->tx_attr->op_flags =


### PR DESCRIPTION
Due to ignored domain_attr->cq_data_size hint, fi_getinfo() may return incorrect info records