### PR TITLE
prov/efa: Evaluate p2p support lazily

### DIFF
--- a/prov/efa/src/efa_hmem.c
+++ b/prov/efa/src/efa_hmem.c
@@ -44,7 +44,7 @@ static int efa_hmem_info_init_protocol_thresholds(enum fi_hmem_iface iface)
 
 	/* Fall back to FI_HMEM_SYSTEM initialization logic when p2p is
 	 * unavailable */
-	if (ofi_hmem_p2p_disabled() || !info->p2p_supported_by_device)
+	if (ofi_hmem_p2p_disabled() || info->p2p_supported_by_device != EFA_P2P_SUPPORTED)
 		iface = FI_HMEM_SYSTEM;
 
 	switch (iface) {
@@ -175,7 +175,7 @@ static inline void efa_hmem_info_check_p2p_support_cuda(struct efa_hmem_info *in
 #endif
 
 	if (!ibv_mr) {
-		info->p2p_supported_by_device = false;
+		info->p2p_supported_by_device = EFA_P2P_UNSUPPORTED;
 		EFA_WARN(FI_LOG_CORE,
 			 "Failed to register CUDA buffer with the EFA device, FI_HMEM transfers that require peer to peer support will fail.\n");
 		ofi_cudaFree(ptr);
@@ -193,7 +193,7 @@ static inline void efa_hmem_info_check_p2p_support_cuda(struct efa_hmem_info *in
 		return;
 	}
 
-	info->p2p_supported_by_device = true;
+	info->p2p_supported_by_device = EFA_P2P_SUPPORTED;
 	return;
 
 #endif
@@ -258,7 +258,7 @@ static inline void efa_hmem_info_check_p2p_support_rocr(struct efa_hmem_info *in
 #endif
 
 	if (!ibv_mr) {
-		info->p2p_supported_by_device = false;
+		info->p2p_supported_by_device = EFA_P2P_UNSUPPORTED;
 		EFA_WARN(FI_LOG_CORE,
 			 "Failed to register ROCr buffer with the EFA device, FI_HMEM transfers that require peer to peer support will fail.\n");
 		rocr_free(ptr);
@@ -276,7 +276,7 @@ static inline void efa_hmem_info_check_p2p_support_rocr(struct efa_hmem_info *in
 		return;
 	}
 
-	info->p2p_supported_by_device = true;
+	info->p2p_supported_by_device = EFA_P2P_SUPPORTED;
 	return;
 
 #endif
@@ -317,7 +317,7 @@ efa_hmem_info_init_iface(enum fi_hmem_iface iface)
 	}
 
 	info->initialized = true;
-	info->p2p_supported_by_device = false;
+	info->p2p_supported_by_device = EFA_P2P_UNSUPPORTED;
 	info->dmabuf_fallback_enabled = false;
 #if HAVE_EFA_DMABUF_MR
 	info->dmabuf_supported_by_device = EFA_DMABUF_ASSUMED;
@@ -341,7 +341,7 @@ efa_hmem_info_init_iface(enum fi_hmem_iface iface)
 			info->initialized = false;
 			return;
 		}
-		info->p2p_supported_by_device = true;
+		info->p2p_supported_by_device = EFA_P2P_SUPPORTED;
 		info->dmabuf_fallback_enabled = true;
 		efa_hmem_info_disable_dmabuf_if_env_unset(info, iface);
 		break;
@@ -361,12 +361,12 @@ efa_hmem_info_init_iface(enum fi_hmem_iface iface)
 			info->initialized = false;
 			return;
 		}
-		info->p2p_supported_by_device = true;
+		info->p2p_supported_by_device = EFA_P2P_SUPPORTED;
 		efa_hmem_info_disable_dmabuf_if_env_unset(info, iface);
 		break;
 
 	case FI_HMEM_SYSTEM:
-		info->p2p_supported_by_device = true;
+		info->p2p_supported_by_device = EFA_P2P_SUPPORTED;
 		efa_hmem_info_disable_dmabuf_if_env_unset(info, iface);
 		break;
 
@@ -374,7 +374,7 @@ efa_hmem_info_init_iface(enum fi_hmem_iface iface)
 		if (ofi_hmem_p2p_disabled())
 			break;
 		efa_hmem_info_check_p2p_support_cuda(info);
-		if (!info->p2p_supported_by_device)
+		if (info->p2p_supported_by_device != EFA_P2P_SUPPORTED)
 			EFA_INFO(FI_LOG_CORE, "%s P2P support is not available.\n",
 				 fi_tostr(&iface, FI_TYPE_HMEM_IFACE));
 		break;
@@ -383,7 +383,7 @@ efa_hmem_info_init_iface(enum fi_hmem_iface iface)
 		if (ofi_hmem_p2p_disabled())
 			break;
 		efa_hmem_info_check_p2p_support_rocr(info);
-		if (!info->p2p_supported_by_device)
+		if (info->p2p_supported_by_device != EFA_P2P_SUPPORTED)
 			EFA_INFO(FI_LOG_CORE, "%s P2P support is not available.\n",
 				 fi_tostr(&iface, FI_TYPE_HMEM_IFACE));
 		break;
@@ -416,7 +416,7 @@ int efa_hmem_validate_p2p_opt(enum fi_hmem_iface iface, int p2p_opt, uint32_t ap
 
 	switch (p2p_opt) {
 	case FI_HMEM_P2P_REQUIRED:
-		if (OFI_UNLIKELY(ofi_hmem_p2p_disabled()) || !info->p2p_supported_by_device)
+		if (OFI_UNLIKELY(ofi_hmem_p2p_disabled()) || info->p2p_supported_by_device != EFA_P2P_SUPPORTED)
 			return -FI_EOPNOTSUPP;
 
 		return 0;

--- a/prov/efa/src/efa_hmem.c
+++ b/prov/efa/src/efa_hmem.c
@@ -30,14 +30,14 @@ static size_t efa_max_eager_msg_size_with_largest_header() {
 #endif
 
 /**
- * @brief  Initialize the various protocol thresholds tracked in efa_hmem_info
+ * @brief  Set the various protocol thresholds tracked in efa_hmem_info
  *         according to the given FI_HMEM interface.
  *
  * @param[in]      iface       The FI_HMEM interface to initialize
  *
  * @return  0
  */
-static int efa_hmem_info_init_protocol_thresholds(enum fi_hmem_iface iface)
+int efa_hmem_info_apply_protocol_thresholds(enum fi_hmem_iface iface)
 {
 	struct efa_hmem_info *info = &g_efa_hmem_info[iface];
 	size_t tmp_value;
@@ -113,174 +113,6 @@ static int efa_hmem_info_init_protocol_thresholds(enum fi_hmem_iface iface)
 		break;
 	}
 	return 0;
-}
-
-static inline void efa_hmem_info_check_p2p_support_cuda(struct efa_hmem_info *info) {
-#if HAVE_CUDA
-	cudaError_t cuda_ret;
-	void *ptr = NULL;
-	struct ibv_mr *ibv_mr;
-	struct ibv_pd *ibv_pd;
-	int ibv_access = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ;
-	size_t len = ofi_get_page_size() * 2;
-	int ret;
-	int dmabuf_fd;
-	uint64_t dmabuf_offset;
-
-	cuda_ret = ofi_cudaMalloc(&ptr, len);
-	if (cuda_ret != cudaSuccess) {
-		info->initialized = false;
-		EFA_WARN(FI_LOG_CORE, "Failed to allocate CUDA buffer: %s\n",
-			 ofi_cudaGetErrorString(cuda_ret));
-		return;
-	}
-
-	ibv_pd = ibv_alloc_pd(g_efa_selected_device_list[0].ibv_ctx);
-	if (!ibv_pd) {
-		EFA_WARN(FI_LOG_CORE, "failed to allocate ibv_pd: %d", errno);
-		ofi_cudaFree(ptr);
-		return;
-	}
-
-#if HAVE_EFA_DMABUF_MR
-	if (ofi_hmem_is_dmabuf_env_var_enabled(FI_HMEM_CUDA)) {
-		ret = ofi_hmem_get_dmabuf_fd(FI_HMEM_CUDA, ptr, len, &dmabuf_fd, &dmabuf_offset);
-		if (ret == FI_SUCCESS) {
-			ibv_mr = ibv_reg_dmabuf_mr(ibv_pd, dmabuf_offset,
-						   len, (uint64_t)ptr, dmabuf_fd, ibv_access);
-			(void)ofi_hmem_put_dmabuf_fd(FI_HMEM_CUDA, dmabuf_fd);
-			if (!ibv_mr) {
-				EFA_INFO(FI_LOG_CORE,
-					"Unable to register CUDA device buffer via dmabuf: %s. "
-					"Fall back to ibv_reg_mr\n", fi_strerror(-errno));
-				ibv_mr = ibv_reg_mr(ibv_pd, ptr, len, ibv_access);
-				info->dmabuf_supported_by_device = EFA_DMABUF_NOT_SUPPORTED;
-			} else {
-				info->dmabuf_supported_by_device = EFA_DMABUF_SUPPORTED;
-			}
-		} else {
-			EFA_INFO(FI_LOG_CORE,
-				"Unable to retrieve dmabuf fd of CUDA device buffer: %d. "
-				"Fall back to ibv_reg_mr\n", ret);
-			ibv_mr = ibv_reg_mr(ibv_pd, ptr, len, ibv_access);
-			info->dmabuf_supported_by_device = EFA_DMABUF_NOT_SUPPORTED;
-		}
-	} else {
-		EFA_INFO(FI_LOG_CORE, "FI_HMEM_CUDA_USE_DMABUF set to false. Not using DMABUF for CUDA.\n");
-		ibv_mr = ibv_reg_mr(ibv_pd, ptr, len, ibv_access);
-		info->dmabuf_supported_by_device = EFA_DMABUF_NOT_SUPPORTED;
-	}
-#else
-	ibv_mr = ibv_reg_mr(ibv_pd, ptr, len, ibv_access);
-#endif
-
-	if (!ibv_mr) {
-		info->p2p_supported_by_device = EFA_P2P_UNSUPPORTED;
-		EFA_WARN(FI_LOG_CORE,
-			 "Failed to register CUDA buffer with the EFA device, FI_HMEM transfers that require peer to peer support will fail.\n");
-		ofi_cudaFree(ptr);
-		(void) ibv_dealloc_pd(ibv_pd);
-		return;
-	}
-
-	ret = ibv_dereg_mr(ibv_mr);
-	ofi_cudaFree(ptr);
-	(void) ibv_dealloc_pd(ibv_pd);
-	if (ret) {
-		EFA_WARN(FI_LOG_CORE,
-			 "Failed to deregister CUDA buffer: %s\n",
-			 fi_strerror(-ret));
-		return;
-	}
-
-	info->p2p_supported_by_device = EFA_P2P_SUPPORTED;
-	return;
-
-#endif
-	return;
-}
-
-static inline void efa_hmem_info_check_p2p_support_rocr(struct efa_hmem_info *info) {
-#if HAVE_ROCR
-	void *ptr = NULL;
-	struct ibv_mr *ibv_mr;
-	struct ibv_pd *ibv_pd;
-	int ibv_access = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ;
-	size_t len = ofi_get_page_size() * 2;
-	int ret;
-	int dmabuf_fd;
-	uint64_t dmabuf_offset;
-
-	ptr = rocr_alloc(len);
-	if (!ptr) {
-		info->initialized = false;
-		EFA_WARN(FI_LOG_CORE, "Failed to allocate ROCr buffer\n");
-		return;
-	}
-
-	ibv_pd = ibv_alloc_pd(g_efa_selected_device_list[0].ibv_ctx);
-	if (!ibv_pd) {
-		EFA_WARN(FI_LOG_CORE, "Failed to allocate ibv_pd: %d\n", errno);
-		rocr_free(ptr);
-		return;
-	}
-
-#if HAVE_EFA_DMABUF_MR
-	if (ofi_hmem_is_dmabuf_env_var_enabled(FI_HMEM_ROCR)) {
-		ret = rocr_hmem_get_dmabuf_fd(ptr, len, &dmabuf_fd, &dmabuf_offset);
-		if (ret == FI_SUCCESS) {
-			ibv_mr = ibv_reg_dmabuf_mr(ibv_pd, dmabuf_offset,
-						   len, (uint64_t) ptr, dmabuf_fd, ibv_access);
-			(void) rocr_hmem_put_dmabuf_fd(dmabuf_fd);
-			if (!ibv_mr) {
-				EFA_INFO(FI_LOG_CORE,
-					"Unable to register ROCr device buffer via dmabuf: %s. "
-					"Fall back to ibv_reg_mr\n", fi_strerror(-errno));
-				ibv_mr = ibv_reg_mr(ibv_pd, ptr, len, ibv_access);
-				info->dmabuf_supported_by_device = EFA_DMABUF_NOT_SUPPORTED;
-			} else {
-				info->dmabuf_supported_by_device = EFA_DMABUF_SUPPORTED;
-			}
-		} else {
-			EFA_INFO(FI_LOG_CORE,
-				"Unable to retrieve dmabuf fd of ROCr device buffer: %d. "
-				"Fall back to ibv_reg_mr\n", ret);
-			ibv_mr = ibv_reg_mr(ibv_pd, ptr, len, ibv_access);
-			info->dmabuf_supported_by_device = EFA_DMABUF_NOT_SUPPORTED;
-		}
-	} else {
-		EFA_INFO(FI_LOG_CORE, "FI_HMEM_ROCR_USE_DMABUF set to false. Not using DMABUF for ROCr.\n");
-		ibv_mr = ibv_reg_mr(ibv_pd, ptr, len, ibv_access);
-		info->dmabuf_supported_by_device = EFA_DMABUF_NOT_SUPPORTED;
-	}
-#else
-	ibv_mr = ibv_reg_mr(ibv_pd, ptr, len, ibv_access);
-#endif
-
-	if (!ibv_mr) {
-		info->p2p_supported_by_device = EFA_P2P_UNSUPPORTED;
-		EFA_WARN(FI_LOG_CORE,
-			 "Failed to register ROCr buffer with the EFA device, FI_HMEM transfers that require peer to peer support will fail.\n");
-		rocr_free(ptr);
-		(void) ibv_dealloc_pd(ibv_pd);
-		return;
-	}
-
-	ret = ibv_dereg_mr(ibv_mr);
-	rocr_free(ptr);
-	(void) ibv_dealloc_pd(ibv_pd);
-	if (ret) {
-		EFA_WARN(FI_LOG_CORE,
-			 "Failed to deregister ROCr buffer: %s\n",
-			 fi_strerror(-ret));
-		return;
-	}
-
-	info->p2p_supported_by_device = EFA_P2P_SUPPORTED;
-	return;
-
-#endif
-	return;
 }
 
 /**
@@ -371,28 +203,20 @@ efa_hmem_info_init_iface(enum fi_hmem_iface iface)
 		break;
 
 	case FI_HMEM_CUDA:
-		if (ofi_hmem_p2p_disabled())
-			break;
-		efa_hmem_info_check_p2p_support_cuda(info);
-		if (info->p2p_supported_by_device != EFA_P2P_SUPPORTED)
-			EFA_INFO(FI_LOG_CORE, "%s P2P support is not available.\n",
-				 fi_tostr(&iface, FI_TYPE_HMEM_IFACE));
+		info->p2p_supported_by_device = ofi_hmem_p2p_disabled() ?
+			EFA_P2P_UNSUPPORTED : EFA_P2P_UNDETERMINED;
 		break;
 
 	case FI_HMEM_ROCR:
-		if (ofi_hmem_p2p_disabled())
-			break;
-		efa_hmem_info_check_p2p_support_rocr(info);
-		if (info->p2p_supported_by_device != EFA_P2P_SUPPORTED)
-			EFA_INFO(FI_LOG_CORE, "%s P2P support is not available.\n",
-				 fi_tostr(&iface, FI_TYPE_HMEM_IFACE));
+		info->p2p_supported_by_device = ofi_hmem_p2p_disabled() ?
+			EFA_P2P_UNSUPPORTED : EFA_P2P_UNDETERMINED;
 		break;
 
 	default:
 		break;
 	}
 
-	efa_hmem_info_init_protocol_thresholds(iface);
+	efa_hmem_info_apply_protocol_thresholds(iface);
 }
 
 /**

--- a/prov/efa/src/efa_hmem.h
+++ b/prov/efa/src/efa_hmem.h
@@ -65,10 +65,18 @@ struct efa_hmem_info {
 #define DMABUF_IS_ASSUMED(info) \
 	((info)->dmabuf_supported_by_device == EFA_DMABUF_ASSUMED)
 
+/*
+ * NB: p2p_supported_by_device and protocol thresholds may be updated by
+ * application code when p2p support is probed at first registration. This could
+ * lead to thread-safety questions. These updates are pure writes and idempotent,
+ * so ought to be safe. Alternatives are pushing this down to the domain level or
+ * similar to take a lock.
+ */
 extern struct efa_hmem_info	g_efa_hmem_info[OFI_HMEM_MAX];
 
 int efa_hmem_validate_p2p_opt(enum fi_hmem_iface iface, int p2p_opt, uint32_t api_version);
 int efa_hmem_info_initialize();
+int efa_hmem_info_apply_protocol_thresholds(enum fi_hmem_iface iface);
 int efa_copy_from_hmem(void *desc, void *dest, const void *src, size_t size);
 int efa_copy_to_hmem(void *desc, void *dest, const void *src, size_t size);
 ssize_t efa_copy_from_hmem_iov(void **desc, char *buff, size_t buff_size, const struct iovec *hmem_iov, size_t iov_count);

--- a/prov/efa/src/efa_hmem.h
+++ b/prov/efa/src/efa_hmem.h
@@ -37,9 +37,15 @@ enum efa_dmabuf_support {
 	EFA_DMABUF_ASSUMED
 };
 
+enum efa_p2p_support {
+	EFA_P2P_UNSUPPORTED,
+	EFA_P2P_SUPPORTED,
+	EFA_P2P_UNDETERMINED,
+};
+
 struct efa_hmem_info {
 	bool initialized; 	/* do we support it at all */
-	bool p2p_supported_by_device;	/* do we support p2p with this device */
+	enum efa_p2p_support p2p_supported_by_device;	/* do we support p2p with this device */
 	bool dmabuf_fallback_enabled;
 	enum efa_dmabuf_support dmabuf_supported_by_device;	/* do we support dmabuf with this device */
 

--- a/prov/efa/src/efa_prov_info.c
+++ b/prov/efa/src/efa_prov_info.c
@@ -423,7 +423,7 @@ void efa_prov_info_direct_set_hmem_flags(struct fi_info *prov_info)
 	/* EFA direct only supports HMEM when p2p support is available */
 	EFA_HMEM_IFACE_FOREACH_NON_SYSTEM(iface) {
 		hmem_info = &g_efa_hmem_info[iface];
-		if (hmem_info->initialized && hmem_info->p2p_supported_by_device != EFA_P2P_SUPPORTED) {
+		if (hmem_info->initialized && hmem_info->p2p_supported_by_device == EFA_P2P_UNSUPPORTED) {
 			EFA_INFO(FI_LOG_CORE,
 				"EFA direct provider was compiled with support for %s HMEM interface "
 				"but the interface does not support p2p transfers. "

--- a/prov/efa/src/efa_prov_info.c
+++ b/prov/efa/src/efa_prov_info.c
@@ -423,7 +423,7 @@ void efa_prov_info_direct_set_hmem_flags(struct fi_info *prov_info)
 	/* EFA direct only supports HMEM when p2p support is available */
 	EFA_HMEM_IFACE_FOREACH_NON_SYSTEM(iface) {
 		hmem_info = &g_efa_hmem_info[iface];
-		if (hmem_info->initialized && !hmem_info->p2p_supported_by_device) {
+		if (hmem_info->initialized && hmem_info->p2p_supported_by_device != EFA_P2P_SUPPORTED) {
 			EFA_INFO(FI_LOG_CORE,
 				"EFA direct provider was compiled with support for %s HMEM interface "
 				"but the interface does not support p2p transfers. "

--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -307,7 +307,7 @@ int efa_rdm_ep_use_p2p(struct efa_rdm_ep *efa_rdm_ep, struct efa_mr *efa_mr)
 	if (!efa_mr || efa_mr->iface == FI_HMEM_SYSTEM)
 		return 1;
 
-	if (g_efa_hmem_info[efa_mr->iface].p2p_supported_by_device)
+	if (g_efa_hmem_info[efa_mr->iface].p2p_supported_by_device == EFA_P2P_SUPPORTED)
 		return (efa_rdm_ep->hmem_p2p_opt != FI_HMEM_P2P_DISABLED);
 
 	if (efa_rdm_ep->hmem_p2p_opt == FI_HMEM_P2P_REQUIRED) {

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -556,7 +556,7 @@ int efa_rdm_ep_open(struct fid_domain *domain, struct fi_info *info,
 	 */
 	EFA_HMEM_IFACE_FOREACH_NON_SYSTEM(iface) {
 		if (g_efa_hmem_info[iface].initialized &&
-		    g_efa_hmem_info[iface].p2p_supported_by_device) {
+		    g_efa_hmem_info[iface].p2p_supported_by_device == EFA_P2P_SUPPORTED) {
 			/* If user is using libfabric API 1.18 or later, by default EFA
 	 		 * provider is permitted to use CUDA library to support CUDA
 	 		 * memory, therefore p2p is not required.
@@ -1573,7 +1573,7 @@ static int efa_rdm_ep_set_cuda_api_permitted(struct efa_rdm_ep *ep, bool cuda_ap
 	/* CUDA memory can be supported by using either peer to peer or CUDA API. If neither is
 	 * available, we cannot support CUDA memory
 	 */
-	if (!g_efa_hmem_info[FI_HMEM_CUDA].p2p_supported_by_device)
+	if (g_efa_hmem_info[FI_HMEM_CUDA].p2p_supported_by_device != EFA_P2P_SUPPORTED)
 		return -FI_EOPNOTSUPP;
 
 	ep->cuda_api_permitted = false;

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -1571,9 +1571,12 @@ static int efa_rdm_ep_set_cuda_api_permitted(struct efa_rdm_ep *ep, bool cuda_ap
 	}
 
 	/* CUDA memory can be supported by using either peer to peer or CUDA API. If neither is
-	 * available, we cannot support CUDA memory
+	 * available, we cannot support CUDA memory.
+	 *
+	 * When p2p is EFA_P2P_UNDETERMINED (not yet probed), we allow this optimistically.
+	 * If p2p later turns out to be unavailable, data transfers will fail with -FI_ENOSYS.
 	 */
-	if (g_efa_hmem_info[FI_HMEM_CUDA].p2p_supported_by_device != EFA_P2P_SUPPORTED)
+	if (g_efa_hmem_info[FI_HMEM_CUDA].p2p_supported_by_device == EFA_P2P_UNSUPPORTED)
 		return -FI_EOPNOTSUPP;
 
 	ep->cuda_api_permitted = false;

--- a/prov/efa/src/rdm/efa_rdm_mr.c
+++ b/prov/efa/src/rdm/efa_rdm_mr.c
@@ -498,18 +498,39 @@ static int efa_rdm_mr_reg_impl(struct efa_rdm_mr *efa_rdm_mr, uint64_t flags,
 		ofi_mr_cache_flush(efa_rdm_mr->efa_mr.domain->cache, false);
 
 	/*
-	 * For cuda and rocr iface when p2p is unavailable, skip ibv_reg_mr() and
-	 * generate proprietary mr_fid key.
+	 * For cuda/rocr, the p2p probe is deferred to first HMEM MR
+	 * registration to avoid provider-initiated device allocations
+	 * during initialization.
 	 */
-	if ((mr_attr->iface == FI_HMEM_CUDA || mr_attr->iface == FI_HMEM_ROCR)
-		&& g_efa_hmem_info[mr_attr->iface].p2p_supported_by_device != EFA_P2P_SUPPORTED) {
-		ret = efa_mr_hmem_setup(&efa_rdm_mr->efa_mr, mr_attr, flags);
-		if (ret)
-			return ret;
-		efa_rdm_mr->efa_mr.mr_fid.key = efa_rdm_mr_non_p2p_keygen();
-		efa_rdm_mr->efa_mr.mr_fid.mem_desc = &efa_rdm_mr->efa_mr;
+	if (mr_attr->iface == FI_HMEM_CUDA || mr_attr->iface == FI_HMEM_ROCR) {
+		switch (g_efa_hmem_info[mr_attr->iface].p2p_supported_by_device) {
+		case EFA_P2P_UNDETERMINED:
+			/* Probe: attempt ibv_reg_mr with the app's buffer */
+			ret = efa_mr_reg_impl(&efa_rdm_mr->efa_mr, flags, mr_attr);
+			if (ret == 0) {
+				g_efa_hmem_info[mr_attr->iface].p2p_supported_by_device = EFA_P2P_SUPPORTED;
+				efa_hmem_info_apply_protocol_thresholds(mr_attr->iface);
+				break;
+			}
+			g_efa_hmem_info[mr_attr->iface].p2p_supported_by_device = EFA_P2P_UNSUPPORTED;
+			EFA_INFO(FI_LOG_MR,
+				 "%s P2P support is not available, using non-p2p path.\n",
+				 fi_tostr(&mr_attr->iface, FI_TYPE_HMEM_IFACE));
+			/* fall through */
+		case EFA_P2P_UNSUPPORTED:
+			ret = efa_mr_hmem_setup(&efa_rdm_mr->efa_mr, mr_attr, flags);
+			if (ret)
+				return ret;
+			efa_rdm_mr->efa_mr.mr_fid.key = efa_rdm_mr_non_p2p_keygen();
+			efa_rdm_mr->efa_mr.mr_fid.mem_desc = &efa_rdm_mr->efa_mr;
+			break;
+		case EFA_P2P_SUPPORTED:
+			ret = efa_mr_reg_impl(&efa_rdm_mr->efa_mr, flags, mr_attr);
+			if (ret)
+				return ret;
+			break;
+		}
 	} else {
-		/* base mr registration (ibv mr), must be called the first before RDM specific fields are setup */
 		ret = efa_mr_reg_impl(&efa_rdm_mr->efa_mr, flags, mr_attr);
 		if (ret)
 			return ret;

--- a/prov/efa/src/rdm/efa_rdm_mr.c
+++ b/prov/efa/src/rdm/efa_rdm_mr.c
@@ -502,7 +502,7 @@ static int efa_rdm_mr_reg_impl(struct efa_rdm_mr *efa_rdm_mr, uint64_t flags,
 	 * generate proprietary mr_fid key.
 	 */
 	if ((mr_attr->iface == FI_HMEM_CUDA || mr_attr->iface == FI_HMEM_ROCR)
-		&& !g_efa_hmem_info[mr_attr->iface].p2p_supported_by_device) {
+		&& g_efa_hmem_info[mr_attr->iface].p2p_supported_by_device != EFA_P2P_SUPPORTED) {
 		ret = efa_mr_hmem_setup(&efa_rdm_mr->efa_mr, mr_attr, flags);
 		if (ret)
 			return ret;

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -389,7 +389,7 @@ void test_efa_rdm_pke_get_available_copy_methods_align128(struct efa_resource **
 	efa_rdm_ep->sendrecv_in_order_aligned_128_bytes = 1;
 
 	/* p2p is available */
-	g_efa_hmem_info[FI_HMEM_CUDA].p2p_supported_by_device = true;
+	g_efa_hmem_info[FI_HMEM_CUDA].p2p_supported_by_device = EFA_P2P_SUPPORTED;
 	efa_rdm_ep->hmem_p2p_opt = FI_HMEM_P2P_ENABLED;
 
 	/* RDMA read is supported */

--- a/prov/efa/test/efa_unit_test_hmem.c
+++ b/prov/efa/test/efa_unit_test_hmem.c
@@ -33,7 +33,7 @@ void test_efa_hmem_info_p2p_dmabuf_assumed_neuron(struct efa_resource **state)
 
         assert_int_equal(ret, 0);
         assert_true(g_efa_hmem_info[FI_HMEM_NEURON].initialized);
-        assert_true(g_efa_hmem_info[FI_HMEM_NEURON].p2p_supported_by_device);
+        assert_int_equal(g_efa_hmem_info[FI_HMEM_NEURON].p2p_supported_by_device, EFA_P2P_SUPPORTED);
 #if HAVE_EFA_DMABUF_MR
         assert_int_equal(g_efa_hmem_info[FI_HMEM_NEURON].dmabuf_supported_by_device, EFA_DMABUF_ASSUMED);
 #else /* !HAVE_EFA_DMABUF_MR */
@@ -128,7 +128,7 @@ void test_efa_hmem_info_p2p_disabled_synapse()
 #if HAVE_CUDA
 /**
  * @brief Verify when p2p is disabled, we don't check p2p support with ofi_cudaMalloc.
- * Just leave p2p_supported_by_device to false for cuda.
+ * Just leave p2p_supported_by_device to EFA_P2P_UNSUPPORTED for cuda.
  *
  * @param[in]	state		struct efa_resource that is managed by the framework
  */
@@ -159,7 +159,7 @@ void test_efa_hmem_info_disable_p2p_cuda(struct efa_resource **state)
 
         assert_int_equal(ret, 0);
         assert_true(g_efa_hmem_info[FI_HMEM_CUDA].initialized);
-        assert_false(g_efa_hmem_info[FI_HMEM_CUDA].p2p_supported_by_device);
+        assert_int_equal(g_efa_hmem_info[FI_HMEM_CUDA].p2p_supported_by_device, EFA_P2P_UNSUPPORTED);
 }
 #else
 void test_efa_hmem_info_disable_p2p_cuda()

--- a/prov/efa/test/efa_unit_test_hmem.c
+++ b/prov/efa/test/efa_unit_test_hmem.c
@@ -127,29 +127,21 @@ void test_efa_hmem_info_p2p_disabled_synapse()
 
 #if HAVE_CUDA
 /**
- * @brief Verify when p2p is disabled, we don't check p2p support with ofi_cudaMalloc.
- * Just leave p2p_supported_by_device to EFA_P2P_UNSUPPORTED for cuda.
+ * @brief Verify when p2p is disabled, efa_hmem_info_initialize marks CUDA as
+ * EFA_P2P_UNSUPPORTED (not EFA_P2P_UNDETERMINED), preventing any lazy probe
+ * from running at MR registration time.
  *
  * @param[in]	state		struct efa_resource that is managed by the framework
  */
 void test_efa_hmem_info_disable_p2p_cuda(struct efa_resource **state)
 {
         int ret;
-        struct efa_resource *resource = *state;
         bool cuda_initialized_orig;
 
         ofi_hmem_disable_p2p = 1;
 
-	resource->hints = efa_unit_test_alloc_hints(FI_EP_RDM, EFA_FABRIC_NAME);
-        assert_non_null(resource->hints);
-
-        ret = fi_getinfo(FI_VERSION(1, 14), NULL, NULL, 0ULL, resource->hints, &resource->info);
-        assert_int_equal(ret, 0);
-
         cuda_initialized_orig = hmem_ops[FI_HMEM_CUDA].initialized;
         hmem_ops[FI_HMEM_CUDA].initialized = true;
-        /* ofi_cudaMalloc should not be called when p2p is disabled. efa_mock_ofi_cudaMalloc_return_mock will fail the test when it is called. */
-        g_efa_unit_test_mocks.ofi_cudaMalloc = efa_mock_ofi_cudaMalloc_return_mock;
 
         ret = efa_hmem_info_initialize();
 
@@ -163,6 +155,36 @@ void test_efa_hmem_info_disable_p2p_cuda(struct efa_resource **state)
 }
 #else
 void test_efa_hmem_info_disable_p2p_cuda()
+{
+        skip();
+}
+#endif /* HAVE_CUDA */
+
+#if HAVE_CUDA
+/**
+ * @brief Verify that when p2p is not disabled, efa_hmem_info_initialize marks
+ * CUDA as EFA_P2P_UNDETERMINED, deferring the probe to first MR registration.
+ *
+ * @param[in]	state		struct efa_resource that is managed by the framework
+ */
+void test_efa_hmem_info_cuda_p2p_deferred(struct efa_resource **state)
+{
+        int ret;
+        bool cuda_initialized_orig;
+
+        cuda_initialized_orig = hmem_ops[FI_HMEM_CUDA].initialized;
+        hmem_ops[FI_HMEM_CUDA].initialized = true;
+
+        ret = efa_hmem_info_initialize();
+
+        hmem_ops[FI_HMEM_CUDA].initialized = cuda_initialized_orig;
+
+        assert_int_equal(ret, 0);
+        assert_true(g_efa_hmem_info[FI_HMEM_CUDA].initialized);
+        assert_int_equal(g_efa_hmem_info[FI_HMEM_CUDA].p2p_supported_by_device, EFA_P2P_UNDETERMINED);
+}
+#else
+void test_efa_hmem_info_cuda_p2p_deferred()
 {
         skip();
 }

--- a/prov/efa/test/efa_unit_test_info.c
+++ b/prov/efa/test/efa_unit_test_info.c
@@ -194,7 +194,7 @@ void test_info_direct_hmem_support_p2p()
 	 * efa_unit_test_mocks_teardown. So no need to save and reset these fields
 	 */
 	g_efa_hmem_info[FI_HMEM_CUDA].initialized = true;
-	g_efa_hmem_info[FI_HMEM_CUDA].p2p_supported_by_device = true;
+	g_efa_hmem_info[FI_HMEM_CUDA].p2p_supported_by_device = EFA_P2P_SUPPORTED;
 
 	efa_prov_info_direct_set_hmem_flags(info);
 	assert_true(info->caps & FI_HMEM);
@@ -205,7 +205,7 @@ void test_info_direct_hmem_support_p2p()
 	info = fi_allocinfo();
 	info->ep_attr->type = FI_EP_RDM;
 	g_efa_hmem_info[FI_HMEM_CUDA].initialized = true;
-	g_efa_hmem_info[FI_HMEM_CUDA].p2p_supported_by_device = false;
+	g_efa_hmem_info[FI_HMEM_CUDA].p2p_supported_by_device = EFA_P2P_UNSUPPORTED;
 
 	efa_prov_info_direct_set_hmem_flags(info);
 	assert_false(info->caps & FI_HMEM);

--- a/prov/efa/test/efa_unit_test_mr.c
+++ b/prov/efa/test/efa_unit_test_mr.c
@@ -179,7 +179,7 @@ void test_efa_rdm_mr_reg_cuda_memory(struct efa_resource **state)
 	int err, baseline_ct, baseline_sz;
 
 	if (hmem_ops[FI_HMEM_CUDA].initialized &&
-	    g_efa_hmem_info[FI_HMEM_CUDA].p2p_supported_by_device) {
+	    g_efa_hmem_info[FI_HMEM_CUDA].p2p_supported_by_device == EFA_P2P_SUPPORTED) {
 		resource->hints = efa_unit_test_alloc_hints_hmem(
 			FI_EP_RDM, EFA_FABRIC_NAME);
 		efa_unit_test_resource_construct_with_hints(resource, FI_EP_RDM,
@@ -237,7 +237,7 @@ void test_efa_direct_mr_reg_cuda_memory(struct efa_resource **state)
 	int err, baseline_ct, baseline_sz;
 
 	if (g_efa_hmem_info[FI_HMEM_CUDA].initialized &&
-	    g_efa_hmem_info[FI_HMEM_CUDA].p2p_supported_by_device) {
+	    g_efa_hmem_info[FI_HMEM_CUDA].p2p_supported_by_device == EFA_P2P_SUPPORTED) {
 		resource->hints = efa_unit_test_alloc_hints_hmem(
 			FI_EP_RDM, EFA_DIRECT_FABRIC_NAME);
 		efa_unit_test_resource_construct_with_hints(resource, FI_EP_RDM,
@@ -1394,7 +1394,7 @@ void test_efa_rdm_mr_reg_cuda_memory_non_p2p(struct efa_resource **state)
 				  util_domain.domain_fid);
 
 	/* Mock p2p as not supported to force non-p2p path */
-	g_efa_hmem_info[FI_HMEM_CUDA].p2p_supported_by_device = false;
+	g_efa_hmem_info[FI_HMEM_CUDA].p2p_supported_by_device = EFA_P2P_UNSUPPORTED;
 
 	/* fi_endpoint calls ofi_bufpool_grow, which registers mr */
 	baseline_ct = ofi_atomic_get64(&efa_domain->ibv_mr_reg_ct);

--- a/prov/efa/test/efa_unit_test_mr.c
+++ b/prov/efa/test/efa_unit_test_mr.c
@@ -172,50 +172,76 @@ void test_efa_rdm_mr_reg_cuda_memory(struct efa_resource **state)
 	struct efa_resource *resource = *state;
 	struct efa_domain *efa_domain;
 	size_t mr_size = 64;
-	void *buf;
-	struct fid_mr *mr = NULL;
+	void *buf1, *buf2;
+	struct fid_mr *mr1 = NULL, *mr2 = NULL;
 	struct fi_mr_attr mr_reg_attr = { 0 };
 	struct iovec iovec;
 	int err, baseline_ct, baseline_sz;
 
-	if (hmem_ops[FI_HMEM_CUDA].initialized &&
-	    g_efa_hmem_info[FI_HMEM_CUDA].p2p_supported_by_device == EFA_P2P_SUPPORTED) {
-		resource->hints = efa_unit_test_alloc_hints_hmem(
-			FI_EP_RDM, EFA_FABRIC_NAME);
-		efa_unit_test_resource_construct_with_hints(resource, FI_EP_RDM,
-							    FI_VERSION(2, 0),
-							    resource->hints,
-							    true, true);
-
-		efa_domain = container_of(resource->domain, struct efa_domain,
-					  util_domain.domain_fid);
-		/* fi_endpoint calls ofi_bufpool_grow, which registers mr */
-		baseline_ct = ofi_atomic_get64(&efa_domain->ibv_mr_reg_ct);
-		baseline_sz = ofi_atomic_get64(&efa_domain->ibv_mr_reg_sz);
-
-		err = ofi_cudaMalloc(&buf, mr_size);
-		assert_int_equal(err, 0);
-		assert_non_null(buf);
-
-		mr_reg_attr.access = FI_SEND | FI_RECV;
-		mr_reg_attr.iface = FI_HMEM_CUDA;
-		iovec.iov_base = buf;
-		iovec.iov_len = mr_size;
-		mr_reg_attr.mr_iov = &iovec;
-		mr_reg_attr.iov_count = 1;
-
-		err = fi_mr_regattr(resource->domain, &mr_reg_attr, 0, &mr);
-		assert_int_equal(err, 0);
-
-		/* FI_MR_DMABUF flag was not set, so GDRCopy should be registered if available */
-		test_efa_rdm_mr_impl(efa_domain, mr, baseline_ct + 1, baseline_sz + mr_size, true);
-
-		assert_int_equal(fi_close(&mr->fid), 0);
-		test_efa_rdm_mr_impl(efa_domain, NULL, baseline_ct, baseline_sz, false);
-
-		err = ofi_cudaFree(buf);
-		assert_int_equal(err, 0);
+	if (!hmem_ops[FI_HMEM_CUDA].initialized) {
+		skip();
+		return;
 	}
+
+	resource->hints = efa_unit_test_alloc_hints_hmem(
+		FI_EP_RDM, EFA_FABRIC_NAME);
+	efa_unit_test_resource_construct_with_hints(resource, FI_EP_RDM,
+						    FI_VERSION(2, 0),
+						    resource->hints,
+						    true, true);
+
+	efa_domain = container_of(resource->domain, struct efa_domain,
+				  util_domain.domain_fid);
+
+	/* Start with UNDETERMINED to exercise the lazy probe */
+	g_efa_hmem_info[FI_HMEM_CUDA].p2p_supported_by_device = EFA_P2P_UNDETERMINED;
+
+	baseline_ct = ofi_atomic_get64(&efa_domain->ibv_mr_reg_ct);
+	baseline_sz = ofi_atomic_get64(&efa_domain->ibv_mr_reg_sz);
+
+	err = ofi_cudaMalloc(&buf1, mr_size);
+	assert_int_equal(err, 0);
+
+	/* First registration: triggers the lazy p2p probe */
+	mr_reg_attr.access = FI_SEND | FI_RECV;
+	mr_reg_attr.iface = FI_HMEM_CUDA;
+	iovec.iov_base = buf1;
+	iovec.iov_len = mr_size;
+	mr_reg_attr.mr_iov = &iovec;
+	mr_reg_attr.iov_count = 1;
+
+	err = fi_mr_regattr(resource->domain, &mr_reg_attr, 0, &mr1);
+	assert_int_equal(err, 0);
+
+	/* Probe must have resolved to a definitive state */
+	assert_int_not_equal(g_efa_hmem_info[FI_HMEM_CUDA].p2p_supported_by_device, EFA_P2P_UNDETERMINED);
+
+	if (g_efa_hmem_info[FI_HMEM_CUDA].p2p_supported_by_device == EFA_P2P_SUPPORTED) {
+		/* p2p path: ibv_reg_mr was called */
+		assert_int_equal(ofi_atomic_get64(&efa_domain->ibv_mr_reg_ct), baseline_ct + 1);
+		assert_int_equal(ofi_atomic_get64(&efa_domain->ibv_mr_reg_sz), baseline_sz + mr_size);
+
+		/* Second registration: takes the normal SUPPORTED path */
+		err = ofi_cudaMalloc(&buf2, mr_size);
+		assert_int_equal(err, 0);
+
+		iovec.iov_base = buf2;
+		err = fi_mr_regattr(resource->domain, &mr_reg_attr, 0, &mr2);
+		assert_int_equal(err, 0);
+
+		assert_int_equal(ofi_atomic_get64(&efa_domain->ibv_mr_reg_ct), baseline_ct + 2);
+		assert_int_equal(ofi_atomic_get64(&efa_domain->ibv_mr_reg_sz), baseline_sz + 2 * mr_size);
+
+		fi_close(&mr2->fid);
+		ofi_cudaFree(buf2);
+	} else {
+		/* non-p2p path: ibv_reg_mr was NOT called (probe failed, fell through) */
+		assert_int_equal(ofi_atomic_get64(&efa_domain->ibv_mr_reg_ct), baseline_ct);
+		assert_int_equal(ofi_atomic_get64(&efa_domain->ibv_mr_reg_sz), baseline_sz);
+	}
+
+	fi_close(&mr1->fid);
+	ofi_cudaFree(buf1);
 }
 #else
 void test_efa_rdm_mr_reg_cuda_memory(struct efa_resource **state)

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -320,6 +320,7 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_hmem_info_p2p_disabled_neuron, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_hmem_info_p2p_disabled_synapse, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_hmem_info_disable_p2p_cuda, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_hmem_info_cuda_p2p_deferred, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_srx_min_multi_recv_size, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_srx_cq, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_srx_lock, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -229,6 +229,7 @@ void test_efa_hmem_info_p2p_dmabuf_assumed_neuron();
 void test_efa_hmem_info_p2p_disabled_neuron();
 void test_efa_hmem_info_p2p_disabled_synapse();
 void test_efa_hmem_info_disable_p2p_cuda();
+void test_efa_hmem_info_cuda_p2p_deferred();
 void test_efa_nic_select_all_devices_matches();
 void test_efa_nic_select_first_device_matches();
 void test_efa_nic_select_first_device_with_surrounding_comma_matches();


### PR DESCRIPTION
# Problem

Support for peer-to-peer communication between NIC and HMEM device was being probed in the `fi_getinfo` path. Determination of p2p support involves an earnest attempt at registering device buffers with the NIC to see if it will work; this required initializing the CUDA stack, allocating a device buffer and freeing it when done. The big issues with this beyond its cost is that all processes/threads performing this action generally have yet to establish any device affinity, meaning that they all pile onto device zero, open a context and never clean it up.

The net effect is that fi initialization takes seconds worth of time dealing with CUDA stand-up, even if you don't intend to use CUDA, and on multi-device systems, might need to initialize all over again. Also, there are limits on the number of GPU processes, which this eats into.

# Solution

Defer the determination of p2p support until first attempt to register a device buffer. This allows us to use the buffer provided by the user, who has presumably configured the CUDA stack to their liking. Out of fi_getinfo, we advertise support for p2p optimistically. If the first attempt at registering the dmabuf fails, we issue a warning and fall back to the bounce buffer approach and latch this failure to prevent trying again.