### PR TITLE
configure, prov/efa: enable code coverage

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -198,6 +198,27 @@ m4_map([FI_ARG_ENABLE_SANITIZER],[
        [ubsan, undefined, UndefinedBehavior]
 ])
 
+AC_ARG_ENABLE([coverage],
+              [AS_HELP_STRING([--enable-coverage],
+                              [Enable code coverage instrumentation via gcov @<:@default=no@:>@])],
+              [],
+              [enable_coverage=no])
+
+AS_IF([test x"$enable_coverage" != x"no"],
+      [save_CFLAGS="$CFLAGS"
+       save_LDFLAGS="$LDFLAGS"
+       CFLAGS="-O0 -g --coverage $CFLAGS"
+       LDFLAGS="--coverage $LDFLAGS"
+       AC_MSG_CHECKING([for --coverage support])
+       AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[return 0;]])],
+                      [AC_MSG_RESULT([yes])],
+                      [AC_MSG_RESULT([no])
+                       CFLAGS="$save_CFLAGS"
+                       LDFLAGS="$save_LDFLAGS"
+                       AC_MSG_ERROR([--coverage requested but compiler/linker support not found.])])])
+
+AM_CONDITIONAL([ENABLE_COVERAGE], [test x"$enable_coverage" != x"no"])
+
 dnl Checks for header files.
 dnl This is only necessary for Autoconf <v2.70.
 m4_version_prereq([2.70],

--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -259,6 +259,28 @@ endif HAVE_EFADV_CREATE_COMP_CNTR
 
 prov_efa_test_efa_unit_test_LIBS = $(efa_LIBS) $(linkback)
 
+if ENABLE_COVERAGE
+coverage:
+	lcov --capture --directory $(top_builddir)/prov/efa/src \
+	     --output-file coverage.info --no-external
+	lcov --remove coverage.info '*/test/*' '*/src/.libs/*' \
+	     --output-file coverage.info
+	lcov --extract coverage.info '*/prov/efa/src/*' \
+	     --output-file coverage.info
+	find $(top_builddir) -name '*.gcno' -delete
+	find $(top_builddir) -name '*.gcda' -delete
+	find $(top_builddir) -name '*.gcov' -delete
+	genhtml coverage.info --output-directory coverage_report
+	@echo "Coverage report: coverage_report/index.html"
+
+coverage-clean:
+	find $(top_builddir) -name '*.gcda' -delete
+	find $(top_builddir) -name '*.gcno' -delete
+	rm -rf coverage.info coverage_report
+
+.PHONY: coverage coverage-clean
+endif ENABLE_COVERAGE
+
 endif ENABLE_EFA_UNIT_TEST
 
 efa_CPPFLAGS += \


### PR DESCRIPTION
This PR adds the ability to instrument the EFA provider code with `gcov` by the configure flag `--enable-coverage`. This generates instrumented binaries that provide line-level coverage information after tests are run against them.

To see a local coverage report, configure libfabric with the `--enable-coverage` option, and run relevant tests, and then run `make coverage`, which generates  `coverage.info`, and `coverage_report`, which contains html files for local inspection. Run `make coverage-clean` to clean up all coverage-related files.