### PR TITLE
prov/shm: Revert inject protocol to use lock-unlock freestack

### DIFF
--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -256,20 +256,21 @@ void smr_format_tx_pend(struct smr_pend_entry *pend, struct smr_cmd *cmd,
 			uint64_t op_flags);
 void smr_generic_format(struct smr_cmd *cmd, int64_t tx_id, int64_t rx_id,
 			uint32_t op, uint64_t tag, uint64_t data,
-			uint64_t op_flags);
+			uint8_t smr_flags);
 size_t smr_copy_to_sar(struct smr_ep *ep, struct smr_region *smr,
 		       struct smr_pend_entry *pend);
 size_t smr_copy_from_sar(struct smr_ep *ep, struct smr_region *smr,
 		         struct smr_pend_entry *pend);
 int smr_select_proto(void **desc, size_t iov_count, bool cma_avail,
 		     bool ipc_valid, uint32_t op, uint64_t total_len,
-		     uint64_t op_flags);
+		     uint64_t op_flags, uint8_t *smr_flags);
 typedef ssize_t (*smr_send_func)(
 		struct smr_ep *ep, struct smr_region *peer_smr,
 		int64_t tx_id, int64_t rx_id, uint32_t op, uint64_t tag,
-		uint64_t data, uint64_t op_flags, struct ofi_mr **desc,
-		const struct iovec *iov, size_t iov_count, size_t total_len,
-		void *context, struct smr_cmd *cmd);
+		uint64_t data, uint64_t op_flags, uint8_t smr_flags,
+		struct ofi_mr **desc, const struct iovec *iov,
+		size_t iov_count, size_t total_len, void *context,
+		struct smr_cmd *cmd);
 extern smr_send_func smr_send_ops[smr_proto_max];
 
 int smr_write_err_comp(struct util_cq *cq, void *context,
@@ -280,9 +281,9 @@ int smr_complete_rx(struct smr_ep *ep, void *context, uint32_t op,
 		    uint64_t flags, size_t len, void *buf, int64_t id,
 		    uint64_t tag, uint64_t data);
 
-static inline uint64_t smr_rx_cq_flags(uint64_t rx_flags, uint16_t op_flags)
+static inline uint64_t smr_rx_cq_flags(uint64_t rx_flags, uint8_t smr_flags)
 {
-	if (op_flags & SMR_REMOTE_CQ_DATA)
+	if (smr_flags & SMR_REMOTE_CQ_DATA)
 		rx_flags |= FI_REMOTE_CQ_DATA;
 	return rx_flags;
 }

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -74,14 +74,11 @@ static void smr_format_inject_atomic(
 			const struct iovec *iov, size_t count,
 			const struct iovec *resultv, size_t result_count,
 			struct ofi_mr **comp_desc, const struct iovec *compv,
-			size_t comp_count, struct smr_region *smr)
+			size_t comp_count, struct smr_inject_buf *tx_buf)
 {
-	struct smr_inject_buf *tx_buf;
 	size_t comp_size;
 
 	cmd->hdr.proto = smr_proto_inject;
-
-	tx_buf = smr_get_inject_buf(smr, cmd);
 	switch (cmd->hdr.op) {
 	case ofi_op_atomic:
 		cmd->hdr.size = ofi_copy_from_mr_iov(
@@ -114,7 +111,7 @@ static void smr_format_inject_atomic(
 	}
 }
 
-static ssize_t smr_do_atomic_inject(
+static int smr_do_atomic_inject(
 			struct smr_ep *ep, struct smr_region *peer_smr,
 			int64_t tx_id, int64_t rx_id, uint32_t op,
 			uint64_t op_flags, uint8_t datatype, uint8_t atomic_op,
@@ -123,18 +120,33 @@ static ssize_t smr_do_atomic_inject(
 			const struct iovec *resultv, size_t result_count,
 			struct ofi_mr **comp_desc, const struct iovec *compv,
 			size_t comp_count, size_t total_len, void *context,
-			uint16_t smr_flags, struct smr_cmd *cmd)
+			uint8_t smr_flags, struct smr_cmd *cmd)
 {
 	struct smr_pend_entry *pend;
+	struct smr_inject_buf *tx_buf;
 
-	smr_generic_format(cmd, tx_id, rx_id, op, 0, 0, op_flags);
+	if (op == ofi_op_atomic_compare || op == ofi_op_atomic_fetch) {
+		smr_flags |= SMR_RETURN_CMD;
+		tx_buf = smr_get_inject_buf(ep->region);
+		cmd->hdr.proto_data = smr_get_offset(ep->region, tx_buf);
+	} else {
+		tx_buf = smr_get_inject_buf(peer_smr);
+		cmd->hdr.proto_data = smr_get_offset(peer_smr, tx_buf);
+	}
+	if (!tx_buf) {
+		FI_DBG(&smr_prov, FI_LOG_EP_DATA,
+		       "No inject buffers available, cannot send inject "
+		       "message\n");
+		return -FI_EAGAIN;
+	}
+
+	smr_generic_format(cmd, tx_id, rx_id, op, 0, 0, smr_flags);
 	smr_generic_atomic_format(cmd, datatype, atomic_op);
 	smr_format_inject_atomic(cmd, desc, iov, iov_count, resultv,
 				 result_count, comp_desc, compv, comp_count,
-				 ep->region);
+				 tx_buf);
 
-	if (op == ofi_op_atomic_fetch || op == ofi_op_atomic_compare ||
-	    atomic_op == FI_ATOMIC_READ || op_flags & FI_DELIVERY_COMPLETE) {
+	if (smr_flags & SMR_RETURN_CMD) {
 		pend = ofi_buf_alloc(ep->pend_pool);
 		assert(pend);
 		cmd->hdr.tx_ctx = (uintptr_t) pend;
@@ -148,13 +160,18 @@ static ssize_t smr_do_atomic_inject(
 }
 
 static int smr_select_atomic_proto(uint32_t op, uint64_t total_len,
-				   uint64_t op_flags)
+				   uint64_t op_flags, uint8_t *smr_flags)
 {
+	*smr_flags = 0;
+	assert(!(op_flags & FI_REMOTE_CQ_DATA));
 	if (op == ofi_op_atomic_compare || op == ofi_op_atomic_fetch ||
-	    op_flags & FI_DELIVERY_COMPLETE || total_len > SMR_MSG_DATA_LEN)
+	    op_flags & FI_DELIVERY_COMPLETE) {
+		*smr_flags |= SMR_RETURN_CMD;
 		return smr_proto_inject;
+	}
 
-	return smr_proto_inline;
+	return total_len > SMR_MSG_DATA_LEN ? smr_proto_inject :
+					      smr_proto_inline;
 }
 
 static ssize_t smr_generic_atomic(
@@ -173,12 +190,12 @@ static ssize_t smr_generic_atomic(
 	struct iovec iov[SMR_IOV_LIMIT];
 	struct iovec compare_iov[SMR_IOV_LIMIT];
 	struct iovec result_iov[SMR_IOV_LIMIT];
-	uint16_t smr_flags = 0;
 	int64_t tx_id, rx_id, pos;
 	int proto;
 	ssize_t ret;
 	size_t total_len;
 	uint64_t atomic_flags;
+	uint8_t smr_flags;
 
 	assert(count <= SMR_IOV_LIMIT);
 	assert(result_count <= SMR_IOV_LIMIT);
@@ -247,15 +264,8 @@ static ssize_t smr_generic_atomic(
 		break;
 	}
 
-	proto = smr_select_atomic_proto(op, total_len, op_flags);
-
-	if (proto == smr_proto_inline) {
-		cmd = ce;
-		smr_do_atomic_inline(ep, peer_smr, tx_id, rx_id, ofi_op_atomic,
-				     op_flags, datatype, atomic_op,
-				     (struct ofi_mr **) desc, iov, count,
-				     total_len, cmd);
-	} else {
+	proto = smr_select_atomic_proto(op, total_len, op_flags, &smr_flags);
+	if (smr_flags & SMR_RETURN_CMD) {
 		if (smr_freestack_isempty(smr_cmd_stack(ep->region))) {
 			smr_cmd_queue_discard(ce, pos);
 			ret = -FI_EAGAIN;
@@ -266,6 +276,16 @@ static ssize_t smr_generic_atomic(
 		assert(cmd);
 		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
 						  (uintptr_t) cmd);
+	} else {
+		cmd = ce;
+	}
+
+	if (proto == smr_proto_inline) {
+		smr_do_atomic_inline(ep, peer_smr, tx_id, rx_id, ofi_op_atomic,
+				     op_flags, datatype, atomic_op,
+				     (struct ofi_mr **) desc, iov, count,
+				     total_len, cmd);
+	} else {
 		ret = smr_do_atomic_inject(ep, peer_smr, tx_id, rx_id, op,
 					   op_flags, datatype, atomic_op,
 					   (struct ofi_mr **) desc, iov, count,
@@ -281,16 +301,17 @@ static ssize_t smr_generic_atomic(
 		}
 	}
 
-	if (!cmd->hdr.tx_ctx) {
-		ret = smr_complete_tx(ep, context, op, op_flags);
-		if (ret) {
-			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-				"unable to process tx completion\n");
-		}
-	}
-
 	smr_format_rma_ioc(cmd, rma_ioc, rma_count);
 	smr_cmd_queue_commit(ce, pos);
+
+	if (smr_flags & SMR_RETURN_CMD)
+		goto unlock;
+
+	ret = smr_complete_tx(ep, context, op, op_flags);
+	if (ret)
+		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+			"unable to process tx completion\n");
+
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -362,7 +383,7 @@ static ssize_t smr_atomic_inject(
 			fi_addr_t dest_addr, uint64_t addr, uint64_t key,
 			enum fi_datatype datatype, enum fi_op op)
 {
-	struct smr_cmd *ce, *cmd;
+	struct smr_cmd *ce;
 	struct smr_ep *ep;
 	struct smr_region *peer_smr;
 	struct iovec iov;
@@ -370,7 +391,6 @@ static ssize_t smr_atomic_inject(
 	int64_t id, peer_id, pos;
 	ssize_t ret;
 	size_t total_len;
-	int proto;
 
 	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
 
@@ -412,39 +432,23 @@ static ssize_t smr_atomic_inject(
 	rma_ioc.key = key;
 
 	if (total_len <= SMR_MSG_DATA_LEN) {
-		proto = smr_proto_inline;
-		cmd = ce;
 		smr_do_atomic_inline(ep, peer_smr, id, peer_id, ofi_op_atomic,
 				     0, datatype, op, NULL, &iov, 1, total_len,
-				     cmd);
+				     ce);
 	} else {
-		proto = smr_proto_inject;
-		if (smr_freestack_isempty(smr_cmd_stack(ep->region))) {
-			smr_cmd_queue_discard(ce, pos);
-			ret = -FI_EAGAIN;
-			goto unlock;
-		}
-
-		cmd = smr_freestack_pop(smr_cmd_stack(ep->region));
-		assert(cmd);
-		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, id, peer_id,
-						  (uintptr_t) cmd);
 		ret = smr_do_atomic_inject(ep, peer_smr, id, peer_id,
 					   ofi_op_atomic, 0, datatype, op, NULL,
 					   &iov, 1, NULL, NULL, 0, NULL, NULL,
-					   0, total_len, NULL, 0, cmd);
+					   0, total_len, NULL, 0, ce);
 		if (ret) {
-			smr_freestack_push(smr_cmd_stack(ep->region), cmd);
 			smr_cmd_queue_discard(ce, pos);
 			goto unlock;
 		}
 	}
 
-	smr_format_rma_ioc(cmd, &rma_ioc, 1);
+	smr_format_rma_ioc(ce, &rma_ioc, 1);
 	smr_cmd_queue_commit(ce, pos);
-
-	if (proto == smr_proto_inline)
-		ofi_ep_peer_tx_cntr_inc(&ep->util_ep, ofi_op_atomic);
+	ofi_ep_peer_tx_cntr_inc(&ep->util_ep, ofi_op_atomic);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -244,18 +244,15 @@ void smr_format_tx_pend(struct smr_pend_entry *pend, struct smr_cmd *cmd,
 
 void smr_generic_format(struct smr_cmd *cmd, int64_t tx_id, int64_t rx_id,
 			uint32_t op, uint64_t tag, uint64_t data,
-			uint64_t op_flags)
+			uint8_t smr_flags)
 {
 	cmd->hdr.op = op;
-	cmd->hdr.op_flags = 0;
+	cmd->hdr.smr_flags = smr_flags;
 	cmd->hdr.rx_id = rx_id;
 	cmd->hdr.tx_id = tx_id;
 	cmd->hdr.cq_data = data;
 	cmd->hdr.tag = tag;
 	cmd->hdr.rx_ctx = 0;
-
-	if (op_flags & FI_REMOTE_CQ_DATA)
-		cmd->hdr.op_flags |= SMR_REMOTE_CQ_DATA;
 }
 
 static void smr_format_inline(struct smr_cmd *cmd, struct ofi_mr **mr,
@@ -264,26 +261,6 @@ static void smr_format_inline(struct smr_cmd *cmd, struct ofi_mr **mr,
 	cmd->hdr.proto = smr_proto_inline;
 	cmd->hdr.size = ofi_copy_from_mr_iov(cmd->data.msg, SMR_MSG_DATA_LEN,
 					     mr, iov, count, 0);
-}
-
-static void smr_format_inject(struct smr_ep *ep, struct smr_cmd *cmd,
-			      struct smr_pend_entry *pend)
-{
-	struct smr_inject_buf *tx_buf;
-
-	tx_buf = smr_get_inject_buf(ep->region, cmd);
-
-	cmd->hdr.proto = smr_proto_inject;
-	if (cmd->hdr.op != ofi_op_read_req) {
-		cmd->hdr.size = ofi_copy_from_mr_iov(tx_buf->data,
-						     SMR_INJECT_SIZE,
-						     pend->mr, pend->iov,
-						     pend->iov_count, 0);
-		pend->bytes_done = cmd->hdr.size;
-	} else {
-		cmd->hdr.size = ofi_total_iov_len(pend->iov, pend->iov_count);
-		pend->bytes_done = 0;
-	}
 }
 
 static void smr_format_iov(struct smr_cmd *cmd, struct smr_pend_entry *pend)
@@ -377,9 +354,8 @@ static int smr_format_sar(struct smr_ep *ep, struct smr_cmd *cmd,
 		ret = pend->sar_copy_fn(ep, pend);
 		if (ret < 0 && ret != -FI_EBUSY) {
 			for (i = cmd->data.buf_batch_size - 1; i >= 0; i--) {
-				smr_freestack_push_by_index(
-						smr_sar_pool(ep->region),
-						cmd->data.sar[i]);
+				smr_return_sar_buf_by_index(ep->region,
+							    cmd->data.sar[i]);
 			}
 			return -FI_EAGAIN;
 		}
@@ -396,12 +372,15 @@ static int smr_format_sar(struct smr_ep *ep, struct smr_cmd *cmd,
 
 int smr_select_proto(void **desc, size_t iov_count, bool vma_avail,
 		     bool ipc_valid, uint32_t op, uint64_t total_len,
-		     uint64_t op_flags)
+		     uint64_t op_flags, uint8_t *smr_flags)
 {
 	struct ofi_mr *smr_desc;
 	enum fi_hmem_iface iface = FI_HMEM_SYSTEM;
 	bool fastcopy_avail = false, use_ipc = false;
 
+	*smr_flags = 0;
+	*smr_flags |= (op_flags & FI_DELIVERY_COMPLETE) ? SMR_RETURN_CMD : 0;
+	*smr_flags |= (op_flags & FI_REMOTE_CQ_DATA) ? SMR_REMOTE_CQ_DATA : 0;
 	/* Do not inline/inject if IPC is available so device to device
 	 * transfer may occur if possible. */
 	if (iov_count == 1 && desc && desc[0] && ipc_valid) {
@@ -418,6 +397,7 @@ int smr_select_proto(void **desc, size_t iov_count, bool vma_avail,
 	}
 
 	if (op == ofi_op_read_req) {
+		*smr_flags |= SMR_RETURN_CMD;
 		if (use_ipc)
 			return smr_proto_ipc;
 		if (vma_avail && FI_HMEM_SYSTEM == iface)
@@ -425,32 +405,41 @@ int smr_select_proto(void **desc, size_t iov_count, bool vma_avail,
 		return smr_proto_sar;
 	}
 
-	if (fastcopy_avail && total_len <= smr_env.max_gdrcopy_size)
-		return total_len <= SMR_MSG_DATA_LEN ? smr_proto_inline :
-						       smr_proto_inject;
+	if (fastcopy_avail && total_len <= smr_env.max_gdrcopy_size) {
+		if (total_len <= SMR_MSG_DATA_LEN &&
+		    !(op_flags & FI_DELIVERY_COMPLETE))
+			return smr_proto_inline;
+		else
+			return smr_proto_inject;
+	}
 
-	if (use_ipc && !(op_flags & FI_INJECT))
+	if (use_ipc && !(op_flags & FI_INJECT)) {
+		*smr_flags |= SMR_RETURN_CMD;
 		return smr_proto_ipc;
+	}
 
 	if (op_flags & FI_INJECT || total_len <= SMR_INJECT_SIZE) {
 		if (op_flags & FI_DELIVERY_COMPLETE)
 			return smr_proto_inject;
+
 		return total_len <= SMR_MSG_DATA_LEN ?
 				smr_proto_inline : smr_proto_inject;
 	}
 
+	*smr_flags |= SMR_RETURN_CMD;
 	return vma_avail ? smr_proto_iov: smr_proto_sar;
 }
 
 static ssize_t smr_do_inline(struct smr_ep *ep, struct smr_region *peer_smr,
 			     int64_t tx_id, int64_t rx_id, uint32_t op,
 			     uint64_t tag, uint64_t data, uint64_t op_flags,
-			     struct ofi_mr **desc, const struct iovec *iov,
-			     size_t iov_count, size_t total_len, void *context,
+			     uint8_t smr_flags, struct ofi_mr **desc,
+			     const struct iovec *iov, size_t iov_count,
+			     size_t total_len, void *context,
 			     struct smr_cmd *cmd)
 {
 	cmd->hdr.tx_ctx = 0;
-	smr_generic_format(cmd, tx_id, rx_id, op, tag, data, op_flags);
+	smr_generic_format(cmd, tx_id, rx_id, op, tag, data, smr_flags);
 	smr_format_inline(cmd, desc, iov, iov_count);
 
 	return FI_SUCCESS;
@@ -459,34 +448,72 @@ static ssize_t smr_do_inline(struct smr_ep *ep, struct smr_region *peer_smr,
 static ssize_t smr_do_inject(struct smr_ep *ep, struct smr_region *peer_smr,
 			     int64_t tx_id, int64_t rx_id, uint32_t op,
 			     uint64_t tag, uint64_t data, uint64_t op_flags,
-			     struct ofi_mr **desc, const struct iovec *iov,
-			     size_t iov_count, size_t total_len, void *context,
+			     uint8_t smr_flags, struct ofi_mr **desc,
+			     const struct iovec *iov, size_t iov_count,
+			     size_t total_len, void *context,
 			     struct smr_cmd *cmd)
 {
-	struct smr_pend_entry *pend;
+	struct smr_pend_entry *pend = NULL;
+	struct smr_inject_buf *tx_buf;
+	int ret;
 
-	pend = ofi_buf_alloc(ep->pend_pool);
-	assert(pend);
+	if (op == ofi_op_read_req) {
+		tx_buf = smr_get_inject_buf(ep->region);
+		cmd->hdr.proto_data = smr_get_offset(ep->region, tx_buf);
+	} else {
+		tx_buf = smr_get_inject_buf(peer_smr);
+		cmd->hdr.proto_data = smr_get_offset(peer_smr, tx_buf);
+	}
+	if (!tx_buf) {
+		FI_DBG(&smr_prov, FI_LOG_EP_DATA,
+		       "No inject buffers available, cannot send inject "
+		       "message\n");
+		return -FI_EAGAIN;
+	}
 
-	cmd->hdr.tx_ctx = (uintptr_t) pend;
-	smr_format_tx_pend(pend, cmd, context, desc, iov, iov_count, op_flags);
+	if (smr_flags & SMR_RETURN_CMD) {
+		pend = ofi_buf_alloc(ep->pend_pool);
+		assert(pend);
+		cmd->hdr.tx_ctx = (uintptr_t) pend;
+		smr_format_tx_pend(pend, cmd, context, desc, iov, iov_count,
+				   op_flags);
+		if (smr_freestack_avail(smr_cmd_stack(ep->region)) <=
+		    smr_env.buffer_threshold)
+			smr_flags |= SMR_BUFFER_RECV;
+	} else {
+		cmd->hdr.tx_ctx = 0;
+	}
 
-	smr_generic_format(cmd, tx_id, rx_id, op, tag, data, op_flags);
-	smr_format_inject(ep, cmd, pend);
+	smr_generic_format(cmd, tx_id, rx_id, op, tag, data, smr_flags);
+	cmd->hdr.proto = smr_proto_inject;
+	if (cmd->hdr.op != ofi_op_read_req)
+		cmd->hdr.size = ofi_copy_from_mr_iov(tx_buf->data,
+						     SMR_INJECT_SIZE,
+						     desc, iov, iov_count, 0);
+	else
+		cmd->hdr.size = ofi_total_iov_len(iov, iov_count);
 
-	if (smr_freestack_avail(smr_cmd_stack(ep->region)) <=
-	    smr_env.buffer_threshold)
-		cmd->hdr.op_flags |= SMR_BUFFER_RECV;
+	if (total_len != cmd->hdr.size) {
+		ret = -FI_ETRUNC;
+		goto err;
+	}
+
+	if (pend && op != ofi_op_read_req)
+		pend->bytes_done = cmd->hdr.size;
 
 	return FI_SUCCESS;
+err:
+	if (pend)
+		ofi_buf_free(pend);
+	return ret;
 }
 
 static ssize_t smr_do_iov(struct smr_ep *ep, struct smr_region *peer_smr,
 			  int64_t tx_id, int64_t rx_id, uint32_t op,
 			  uint64_t tag, uint64_t data, uint64_t op_flags,
-			  struct ofi_mr **desc, const struct iovec *iov,
-			  size_t iov_count, size_t total_len, void *context,
-			  struct smr_cmd *cmd)
+			  uint8_t smr_flags, struct ofi_mr **desc,
+			  const struct iovec *iov, size_t iov_count,
+			  size_t total_len, void *context, struct smr_cmd *cmd)
 {
 	struct smr_pend_entry *pend;
 
@@ -496,12 +523,12 @@ static ssize_t smr_do_iov(struct smr_ep *ep, struct smr_region *peer_smr,
 	cmd->hdr.tx_ctx = (uintptr_t) pend;
 	smr_format_tx_pend(pend, cmd, context, desc, iov, iov_count, op_flags);
 
-	smr_generic_format(cmd, tx_id, rx_id, op, tag, data, op_flags);
+	smr_generic_format(cmd, tx_id, rx_id, op, tag, data, smr_flags);
 	smr_format_iov(cmd, pend);
 
 	if (smr_freestack_avail(smr_cmd_stack(ep->region)) <=
 	    smr_env.buffer_threshold)
-		cmd->hdr.op_flags |= SMR_BUFFER_RECV;
+		cmd->hdr.smr_flags |= SMR_BUFFER_RECV;
 
 	return FI_SUCCESS;
 }
@@ -509,9 +536,9 @@ static ssize_t smr_do_iov(struct smr_ep *ep, struct smr_region *peer_smr,
 static ssize_t smr_do_sar(struct smr_ep *ep, struct smr_region *peer_smr,
 			  int64_t tx_id, int64_t rx_id, uint32_t op,
 			  uint64_t tag, uint64_t data, uint64_t op_flags,
-			  struct ofi_mr **desc, const struct iovec *iov,
-			  size_t iov_count, size_t total_len, void *context,
-			  struct smr_cmd *cmd)
+			  uint8_t smr_flags, struct ofi_mr **desc,
+			  const struct iovec *iov, size_t iov_count,
+			  size_t total_len, void *context, struct smr_cmd *cmd)
 {
 	struct smr_pend_entry *pend;
 	int ret;
@@ -530,7 +557,7 @@ static ssize_t smr_do_sar(struct smr_ep *ep, struct smr_region *peer_smr,
 	else
 		pend->sar_copy_fn = &smr_copy_sar;
 
-	smr_generic_format(cmd, tx_id, rx_id, op, tag, data, op_flags);
+	smr_generic_format(cmd, tx_id, rx_id, op, tag, data, smr_flags);
 	ret = smr_format_sar(ep, cmd, desc, iov, iov_count, total_len,
 			     ep->region, peer_smr, pend);
 	if (ret)
@@ -542,9 +569,9 @@ static ssize_t smr_do_sar(struct smr_ep *ep, struct smr_region *peer_smr,
 static ssize_t smr_do_ipc(struct smr_ep *ep, struct smr_region *peer_smr,
 			  int64_t tx_id, int64_t rx_id, uint32_t op,
 			  uint64_t tag, uint64_t data, uint64_t op_flags,
-			  struct ofi_mr **desc, const struct iovec *iov,
-			  size_t iov_count, size_t total_len, void *context,
-			  struct smr_cmd *cmd)
+			  uint8_t smr_flags, struct ofi_mr **desc,
+			  const struct iovec *iov, size_t iov_count,
+			  size_t total_len, void *context, struct smr_cmd *cmd)
 {
 	struct smr_pend_entry *pend;
 	int ret = -FI_EAGAIN;
@@ -553,7 +580,7 @@ static ssize_t smr_do_ipc(struct smr_ep *ep, struct smr_region *peer_smr,
 	assert(pend);
 
 	cmd->hdr.tx_ctx = (uintptr_t) pend;
-	smr_generic_format(cmd, tx_id, rx_id, op, tag, data, op_flags);
+	smr_generic_format(cmd, tx_id, rx_id, op, tag, data, smr_flags);
 	assert(iov_count == 1 && desc && desc[0]);
 	ret = smr_format_ipc(cmd, iov[0].iov_base, total_len, ep->region,
 			     desc[0]->iface, desc[0]->device);
@@ -564,7 +591,7 @@ static ssize_t smr_do_ipc(struct smr_ep *ep, struct smr_region *peer_smr,
 			     "fallback to using SAR\n");
 		ofi_buf_free(pend);
 		return smr_do_sar(ep, peer_smr, tx_id, rx_id, op, tag, data,
-				  op_flags, desc, iov, iov_count,
+				  op_flags, smr_flags, desc, iov, iov_count,
 				  total_len, context, cmd);
 	}
 
@@ -572,7 +599,7 @@ static ssize_t smr_do_ipc(struct smr_ep *ep, struct smr_region *peer_smr,
 
 	if (smr_freestack_avail(smr_cmd_stack(ep->region)) <=
 	    smr_env.buffer_threshold)
-		cmd->hdr.op_flags |= SMR_BUFFER_RECV;
+		cmd->hdr.smr_flags |= SMR_BUFFER_RECV;
 
 	return FI_SUCCESS;
 }
@@ -692,25 +719,16 @@ static int smr_discard(struct fi_peer_rx_entry *rx_entry)
 	struct smr_unexp_buf *sar_buf;
 
 	dlist_remove(&cmd_ctx->entry);
-
-	switch (cmd_ctx->cmd->hdr.proto) {
-	case smr_proto_inline:
-		break;
-	case smr_proto_sar:
-		while (!slist_empty(&cmd_ctx->buf_list)) {
-			slist_remove_head_container(
-					&cmd_ctx->buf_list,
-					struct smr_unexp_buf, sar_buf,
-					entry);
-			ofi_buf_free(sar_buf);
-		}
-		break;
-	case smr_proto_inject:
-	case smr_proto_iov:
-	case smr_proto_ipc:
-		smr_return_cmd(cmd_ctx->ep, cmd_ctx->cmd);
-		break;
+	while (!slist_empty(&cmd_ctx->buf_list)) {
+		slist_remove_head_container(
+				&cmd_ctx->buf_list,
+				struct smr_unexp_buf, sar_buf,
+				entry);
+		ofi_buf_free(sar_buf);
 	}
+
+	if (cmd_ctx->cmd->hdr.smr_flags & SMR_RETURN_CMD)
+		smr_return_cmd(cmd_ctx->ep, cmd_ctx->cmd);
 
 	ofi_buf_free(cmd_ctx);
 

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -84,6 +84,7 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 	size_t total_len;
 	int proto;
 	struct smr_cmd *ce, *cmd;
+	uint8_t smr_flags;
 
 	assert(iov_count <= SMR_IOV_LIMIT);
 
@@ -109,9 +110,8 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 
 	proto = smr_select_proto(desc, iov_count, smr_vma_enabled(ep, peer_smr),
 	                         smr_ipc_valid(ep, peer_smr, tx_id, rx_id), op,
-				 total_len, op_flags);
-
-	if (proto != smr_proto_inline) {
+				 total_len, op_flags, &smr_flags);
+	if (smr_flags & SMR_RETURN_CMD) {
 		if (smr_freestack_isempty(smr_cmd_stack(ep->region))) {
 			smr_cmd_queue_discard(ce, pos);
 			ret = -FI_EAGAIN;
@@ -127,17 +127,17 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 	}
 
 	ret = smr_send_ops[proto](ep, peer_smr, tx_id, rx_id, op, tag, data,
-				  op_flags, (struct ofi_mr **) desc, iov,
-				  iov_count, total_len, context, cmd);
+				  op_flags, smr_flags, (struct ofi_mr **) desc,
+				  iov, iov_count, total_len, context, cmd);
 	if (ret) {
 		smr_cmd_queue_discard(ce, pos);
-		if (proto != smr_proto_inline)
+		if (smr_flags & SMR_RETURN_CMD)
 			smr_freestack_push(smr_cmd_stack(ep->region), cmd);
 		goto unlock;
 	}
 	smr_cmd_queue_commit(ce, pos);
 
-	if (proto != smr_proto_inline)
+	if (smr_flags & SMR_RETURN_CMD)
 		goto unlock;
 
 	ret = smr_complete_tx(ep, context, op, op_flags);
@@ -203,6 +203,7 @@ static ssize_t smr_generic_inject(struct fid_ep *ep_fid, const void *buf,
 	struct iovec msg_iov;
 	int proto;
 	struct smr_cmd *ce, *cmd;
+	uint8_t smr_flags;
 
 	assert(len <= SMR_INJECT_SIZE);
 
@@ -230,36 +231,20 @@ static ssize_t smr_generic_inject(struct fid_ep *ep_fid, const void *buf,
 		goto unlock;
 	}
 
-	if (len <= SMR_MSG_DATA_LEN) {
-		proto = smr_proto_inline;
-		cmd = ce;
-	} else {
-		proto = smr_proto_inject;
-		if (smr_freestack_isempty(smr_cmd_stack(ep->region))) {
-			smr_cmd_queue_discard(ce, pos);
-			ret = -FI_EAGAIN;
-			goto unlock;
-		}
+	proto = len <= SMR_MSG_DATA_LEN ? smr_proto_inline : smr_proto_inject;
+	cmd = ce;
 
-		cmd = smr_freestack_pop(smr_cmd_stack(ep->region));
-		assert(cmd);
-		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
-						  (uintptr_t) cmd);
-	}
-
+	smr_flags = (op_flags & FI_REMOTE_CQ_DATA) ? SMR_REMOTE_CQ_DATA : 0;
 	ret = smr_send_ops[proto](ep, peer_smr, tx_id, rx_id, op, tag, data,
-				  op_flags, NULL, &msg_iov, 1, len, NULL, cmd);
+				  op_flags, smr_flags, NULL, &msg_iov, 1, len,
+				  NULL, cmd);
 	if (ret) {
-		if (proto != smr_proto_inline)
-			smr_freestack_push(smr_cmd_stack(ep->region), cmd);
 		smr_cmd_queue_discard(ce, pos);
 		ret = -FI_EAGAIN;
 		goto unlock;
 	}
 	smr_cmd_queue_commit(ce, pos);
-
-	if (proto == smr_proto_inline)
-		ofi_ep_peer_tx_cntr_inc(&ep->util_ep, op);
+	ofi_ep_peer_tx_cntr_inc(&ep->util_ep, op);
 
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -76,8 +76,7 @@ void smr_free_sar_bufs(struct smr_ep *ep, struct smr_cmd *cmd,
 	int i;
 
 	for (i = cmd->data.buf_batch_size - 1; i >= 0; i--) {
-		smr_freestack_push_by_index(smr_sar_pool(ep->region),
-					    cmd->data.sar[i]);
+		smr_return_sar_buf_by_index(ep->region, cmd->data.sar[i]);
 	}
 	smr_peer_data(ep->region)[cmd->hdr.tx_id].sar_status = SMR_SAR_FREE;
 }
@@ -97,7 +96,7 @@ static int smr_progress_return_entry(struct smr_ep *ep, struct smr_cmd *cmd,
 		assert(pend->mr[0]);
 		break;
 	case smr_proto_sar:
-		if (cmd->hdr.op_flags & SMR_OP_ERROR) {
+		if (cmd->hdr.smr_flags & SMR_OP_ERROR) {
 			smr_free_sar_bufs(ep, cmd, pend);
 			return -FI_EIO;
 		}
@@ -134,33 +133,30 @@ static int smr_progress_return_entry(struct smr_ep *ep, struct smr_cmd *cmd,
 		smr_try_send_cmd(ep, cmd);
 		return -FI_EAGAIN;
 	case smr_proto_inject:
-		tx_buf = smr_get_inject_buf(ep->region, cmd);
-		if (pend) {
-			if (pend->bytes_done != cmd->hdr.size &&
-			    cmd->hdr.op != ofi_op_atomic) {
-				src = cmd->hdr.op == ofi_op_atomic_compare ?
-					tx_buf->buf : tx_buf->data;
-				hmem_copy_ret  = ofi_copy_to_mr_iov(
-							pend->mr, pend->iov,
-							pend->iov_count,
-							0, src, cmd->hdr.size);
+		assert(pend);
+		if (pend->bytes_done != cmd->hdr.size &&
+			cmd->hdr.op != ofi_op_atomic) {
+			tx_buf = smr_get_ptr(ep->region, cmd->hdr.proto_data);
+			src = cmd->hdr.op == ofi_op_atomic_compare ?
+				tx_buf->buf : tx_buf->data;
+			hmem_copy_ret  = ofi_copy_to_mr_iov(
+						pend->mr, pend->iov,
+						pend->iov_count,
+						0, src, cmd->hdr.size);
 
-				if (hmem_copy_ret < 0) {
-					FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-						"RMA read/fetch failed "
-						"with code %d\n",
-						(int)(-hmem_copy_ret));
-					ret = hmem_copy_ret;
-				} else if (hmem_copy_ret != cmd->hdr.size) {
-					FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-						"Incomplete rma read/fetch "
-						"buffer copied\n");
-					ret = -FI_ETRUNC;
-				} else {
-					pend->bytes_done =
-						(size_t) hmem_copy_ret;
-				}
+			if (hmem_copy_ret < 0) {
+				FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+					"RMA read/fetch failed "
+					"with code %d\n",
+					(int)(-hmem_copy_ret));
+				ret = hmem_copy_ret;
+			} else if (hmem_copy_ret != cmd->hdr.size) {
+				FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+					"Incomplete rma read/fetch "
+					"buffer copied\n");
+				ret = -FI_ETRUNC;
 			}
+			smr_return_inject_buf(ep->region, tx_buf);
 		}
 		break;
 	default:
@@ -190,26 +186,25 @@ static void smr_progress_return(struct smr_ep *ep)
 
 		ret = smr_progress_return_entry(ep, cmd, pending);
 		if (ret != -FI_EAGAIN) {
-			if (pending) {
-				if (cmd->hdr.op_flags & SMR_OP_ERROR) {
-					ret = smr_write_err_comp(
-							ep->util_ep.tx_cq,
-							pending->comp_ctx,
-							pending->comp_flags,
-							cmd->hdr.tag, -FI_EIO);
-				} else {
-					ret = smr_complete_tx(
-							ep, pending->comp_ctx,
-							cmd->hdr.op,
-							pending->comp_flags);
-				}
-				if (ret) {
-					FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-						"unable to process "
-						"tx completion\n");
-				}
-				ofi_buf_free(pending);
+			assert(pending);
+			if (cmd->hdr.smr_flags & SMR_OP_ERROR) {
+				ret = smr_write_err_comp(
+						ep->util_ep.tx_cq,
+						pending->comp_ctx,
+						pending->comp_flags,
+						cmd->hdr.tag, -FI_EIO);
+			} else {
+				ret = smr_complete_tx(
+						ep, pending->comp_ctx,
+						cmd->hdr.op,
+						pending->comp_flags);
 			}
+			if (ret) {
+				FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+					"unable to process "
+					"tx completion\n");
+			}
+			ofi_buf_free(pending);
 			smr_freestack_push(smr_cmd_stack(ep->region), cmd);
 		}
 		smr_return_queue_release(smr_return_queue(ep->region),
@@ -243,30 +238,31 @@ static ssize_t smr_progress_inject(struct smr_ep *ep, struct smr_cmd *cmd,
 				   struct ofi_mr **mr, struct iovec *iov,
 				   size_t iov_count)
 {
-	struct smr_region *peer_smr;
 	struct smr_inject_buf *tx_buf;
 	ssize_t ret;
 
-	peer_smr = smr_peer_region(ep, cmd->hdr.rx_id);
-	tx_buf = smr_get_inject_buf(peer_smr, cmd);
-
-	if (cmd->hdr.op == ofi_op_read_req) {
-		ret = ofi_copy_from_mr_iov(tx_buf->data, cmd->hdr.size, mr,
-					   iov, iov_count, 0);
-	} else {
+	if (cmd->hdr.op != ofi_op_read_req) {
+		tx_buf = smr_get_ptr(ep->region, cmd->hdr.proto_data);
 		ret = ofi_copy_to_mr_iov(mr, iov, iov_count, 0, tx_buf->data,
 					 cmd->hdr.size);
+		smr_return_inject_buf(ep->region, tx_buf);
+	} else {
+		tx_buf = smr_get_ptr(smr_peer_region(ep, cmd->hdr.tx_id),
+				     cmd->hdr.proto_data);
+		ret = ofi_copy_from_mr_iov(tx_buf->data, cmd->hdr.size, mr,
+					   iov, iov_count, 0);
 	}
 
 	if (ret < 0) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"inject recv failed with code %lu\n", ret);
-		cmd->hdr.op_flags |= SMR_OP_ERROR;
+		cmd->hdr.smr_flags |= SMR_OP_ERROR;
 	} else if (ret != cmd->hdr.size) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-			"inject recv truncated\n");
+			"inject recv truncated. Expected size %zu copied size "
+			"%zu\n", cmd->hdr.size, ret);
 		ret = -FI_ETRUNC;
-		cmd->hdr.op_flags |= SMR_OP_ERROR;
+		cmd->hdr.smr_flags |= SMR_OP_ERROR;
 	} else {
 		ret = FI_SUCCESS;
 	}
@@ -292,7 +288,7 @@ static ssize_t smr_progress_iov(struct smr_ep *ep, struct smr_cmd *cmd,
 			       peer_smr->pid, cmd->hdr.op == ofi_op_read_req,
 			       xpmem);
 	if (ret)
-		cmd->hdr.op_flags |= SMR_OP_ERROR;
+		cmd->hdr.smr_flags |= SMR_OP_ERROR;
 
 	return ret;
 }
@@ -348,7 +344,7 @@ static ssize_t smr_try_copy_rx_sar(struct smr_ep *ep,
 		if (ret == -FI_EAGAIN)
 			dlist_insert_tail(&pend->entry, &ep->async_cpy_list);
 		else if (ret && ret != -FI_EBUSY)
-			pend->cmd->hdr.op_flags |= SMR_OP_ERROR;
+			pend->cmd->hdr.smr_flags |= SMR_OP_ERROR;
 	}
 	return ret;
 }
@@ -365,7 +361,7 @@ static int smr_progress_pending_sar(struct smr_ep *ep, struct smr_cmd *cmd)
 			dlist_insert_tail(&pend->entry, &ep->async_cpy_list);
 			return FI_SUCCESS;
 		}
-		cmd->hdr.op_flags |= SMR_OP_ERROR;
+		cmd->hdr.smr_flags |= SMR_OP_ERROR;
 		goto out;
 	}
 
@@ -374,8 +370,8 @@ static int smr_progress_pending_sar(struct smr_ep *ep, struct smr_cmd *cmd)
 		return FI_SUCCESS;
 
 	if (pend->bytes_done == cmd->hdr.size ||
-	    pend->cmd->hdr.op_flags & SMR_OP_ERROR) {
-		if (pend->cmd->hdr.op_flags & SMR_OP_ERROR) {
+	    pend->cmd->hdr.smr_flags & SMR_OP_ERROR) {
+		if (pend->cmd->hdr.smr_flags & SMR_OP_ERROR) {
 			ret = smr_write_err_comp(ep->util_ep.rx_cq,
 						 pend->comp_ctx,
 						 pend->comp_flags,
@@ -423,10 +419,10 @@ static void smr_init_rx_pend(struct smr_pend_entry *pend, struct smr_cmd *cmd,
 	if (rx_entry) {
 		pend->comp_ctx = rx_entry->context;
 		pend->comp_flags = smr_rx_cq_flags(rx_entry->flags,
-						   cmd->hdr.op_flags);
+						   cmd->hdr.smr_flags);
 	} else {
 		pend->comp_ctx = NULL;
-		pend->comp_flags = smr_rx_cq_flags(0, cmd->hdr.op_flags);
+		pend->comp_flags = smr_rx_cq_flags(0, cmd->hdr.smr_flags);
 	}
 
 	pend->cmd = cmd;
@@ -577,7 +573,7 @@ uncache:
 	ofi_mr_cache_delete(domain->ipc_cache, mr_entry);
 out:
 	if (ret)
-		cmd->hdr.op_flags |= SMR_OP_ERROR;
+		cmd->hdr.smr_flags |= SMR_OP_ERROR;
 
 	return ret;
 }
@@ -597,7 +593,7 @@ static smr_progress_func smr_progress_ops[smr_proto_max] = {
 
 static void smr_do_atomic(struct smr_cmd *cmd, void *src, struct ofi_mr *dst_mr,
 			  void *dst, void *cmp, enum fi_datatype datatype,
-			  enum fi_op op, size_t cnt, uint16_t flags)
+			  enum fi_op op, size_t cnt)
 {
 	char tmp_result[SMR_INJECT_SIZE];
 	char tmp_dst[SMR_INJECT_SIZE];
@@ -653,7 +649,7 @@ static int smr_progress_inline_atomic(struct smr_cmd *cmd, struct ofi_mr **mr,
 	for (i = *len = 0; i < ioc_count && *len < cmd->hdr.size; i++) {
 		smr_do_atomic(cmd, &src[*len], mr[i], ioc[i].addr, NULL,
 			      cmd->hdr.datatype, cmd->hdr.atomic_op,
-			      ioc[i].count, cmd->hdr.op_flags);
+			      ioc[i].count);
 		*len += ioc[i].count * ofi_datatype_size(cmd->hdr.datatype);
 	}
 
@@ -673,7 +669,12 @@ static int smr_progress_inject_atomic(struct smr_cmd *cmd, struct ofi_mr **mr,
 	uint8_t *src, *comp;
 	int i;
 
-	tx_buf = smr_get_inject_buf(smr_peer_region(ep, cmd->hdr.rx_id), cmd);
+	if (cmd->hdr.op == ofi_op_atomic_compare ||
+	    cmd->hdr.op == ofi_op_atomic_fetch)
+		tx_buf = smr_get_ptr(smr_peer_region(ep, cmd->hdr.rx_id),
+				     cmd->hdr.proto_data);
+	else
+		tx_buf = smr_get_ptr(ep->region, cmd->hdr.proto_data);
 
 	switch (cmd->hdr.op) {
 	case ofi_op_atomic_compare:
@@ -689,10 +690,13 @@ static int smr_progress_inject_atomic(struct smr_cmd *cmd, struct ofi_mr **mr,
 	for (i = *len = 0; i < ioc_count && *len < cmd->hdr.size; i++) {
 		smr_do_atomic(cmd, &src[*len], mr[i], ioc[i].addr,
 			      comp ? &comp[*len] : NULL, cmd->hdr.datatype,
-			      cmd->hdr.atomic_op, ioc[i].count,
-			      cmd->hdr.op_flags);
+			      cmd->hdr.atomic_op, ioc[i].count);
 		*len += ioc[i].count * ofi_datatype_size(cmd->hdr.datatype);
 	}
+
+	if (cmd->hdr.op != ofi_op_atomic_compare &&
+	    cmd->hdr.op != ofi_op_atomic_fetch)
+		smr_return_inject_buf(ep->region, tx_buf);
 
 	if (*len != cmd->hdr.size) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL, "recv truncated");
@@ -709,7 +713,7 @@ static int smr_start_common(struct smr_ep *ep, struct smr_cmd *cmd,
 	uint64_t comp_flags;
 	void *comp_buf;
 	int ret;
-	bool return_cmd = cmd->hdr.proto != smr_proto_inline;
+	bool return_cmd = cmd->hdr.smr_flags & SMR_RETURN_CMD;
 
 	rx_entry->peer_context = NULL;
 	assert (cmd->hdr.proto < smr_proto_max);
@@ -717,11 +721,10 @@ static int smr_start_common(struct smr_ep *ep, struct smr_cmd *cmd,
 					ep, cmd, rx_entry,
 					(struct ofi_mr **) rx_entry->desc,
 					rx_entry->iov, rx_entry->count);
-
 	if (!cmd->hdr.rx_ctx) {
 		comp_buf = rx_entry->iov[0].iov_base;
 		comp_flags = smr_rx_cq_flags(rx_entry->flags,
-					     cmd->hdr.op_flags);
+					     cmd->hdr.smr_flags);
 		if (ret) {
 			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 				"error processing op\n");
@@ -762,7 +765,7 @@ static int smr_copy_saved(struct smr_cmd_ctx *cmd_ctx,
 	int ret;
 
 	comp_flags = smr_rx_cq_flags(rx_entry->flags,
-				     cmd_ctx->cmd->hdr.op_flags);
+				     cmd_ctx->cmd->hdr.smr_flags);
 	while (!slist_empty(&cmd_ctx->buf_list)) {
 		slist_remove_head_container(&cmd_ctx->buf_list,
 					    struct smr_unexp_buf, buf, entry);
@@ -820,8 +823,7 @@ int smr_unexp_start(struct fi_peer_rx_entry *rx_entry)
 	int ret = FI_SUCCESS;
 
 	dlist_remove(&cmd_ctx->entry);
-
-	if (cmd_ctx->cmd->hdr.op_flags & SMR_BUFFER_RECV)
+	if (cmd_ctx->cmd->hdr.smr_flags & SMR_BUFFER_RECV)
 		ret = smr_copy_saved(cmd_ctx, rx_entry);
 	else
 		ret = smr_start_common(cmd_ctx->ep, cmd_ctx->cmd, rx_entry);
@@ -891,34 +893,43 @@ static int smr_unexp_inline(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 static int smr_unexp_inject(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 			    struct smr_cmd *cmd)
 {
-	struct smr_region *peer_smr;
-	struct smr_unexp_buf *buf;
 	struct smr_inject_buf *tx_buf;
-	int ret = FI_SUCCESS;
+	struct smr_unexp_buf *buf;
 
-	if (!(cmd->hdr.op_flags & SMR_BUFFER_RECV)) {
-		cmd_ctx->cmd = cmd;
-		return FI_SUCCESS;
-	}
-
-	peer_smr = smr_peer_region(ep, cmd_ctx->cmd->hdr.rx_id);
+	cmd->hdr.smr_flags |= SMR_BUFFER_RECV;
 
 	memcpy(&cmd_ctx->cmd_cpy, cmd, sizeof(cmd_ctx->cmd->hdr));
 	cmd_ctx->cmd = &cmd_ctx->cmd_cpy;
 
-	buf = ofi_buf_alloc(ep->unexp_buf_pool);
-	if (!buf) {
-		ret = -FI_ENOMEM;
-		cmd->hdr.op_flags |= SMR_OP_ERROR;
-		goto out;
+	if (cmd->hdr.op == ofi_op_read_req) {
+		tx_buf = smr_get_ptr(smr_peer_region(ep, cmd->hdr.tx_id),
+				     cmd->hdr.proto_data);
+	} else {
+		tx_buf = smr_get_ptr(ep->region, cmd->hdr.proto_data);
 	}
 
-	tx_buf = smr_get_inject_buf(peer_smr, cmd);
-	memcpy(buf->buf, tx_buf->buf, cmd_ctx->cmd->hdr.size);
+	buf = ofi_buf_alloc(ep->unexp_buf_pool);
+	if (!buf) {
+		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+			"Error allocating buffer\n");
+		cmd->hdr.smr_flags |= SMR_OP_ERROR;
+		ofi_buf_free(cmd_ctx);
+		return -FI_ENOMEM;
+	}
+
+	memcpy(buf->buf, tx_buf->data, cmd->hdr.size);
+	if (cmd->hdr.op != ofi_op_atomic_compare &&
+	    cmd->hdr.op != ofi_op_atomic_fetch &&
+	    cmd->hdr.op != ofi_op_read_req)
+		smr_return_inject_buf(ep->region, tx_buf);
+
+	slist_init(&cmd_ctx->buf_list);
 	slist_insert_tail(&buf->entry, &cmd_ctx->buf_list);
-out:
-	smr_return_cmd(ep, cmd);
-	return ret;
+
+	if (cmd->hdr.smr_flags & SMR_RETURN_CMD)
+		smr_return_cmd(ep, cmd);
+
+	return FI_SUCCESS;
 }
 
 static int smr_unexp_iov(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
@@ -929,7 +940,7 @@ static int smr_unexp_iov(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 	struct iovec iov;
 	int ret = FI_SUCCESS;
 
-	if (!(cmd->hdr.op_flags & SMR_BUFFER_RECV)) {
+	if (!(cmd->hdr.smr_flags & SMR_BUFFER_RECV)) {
 		cmd_ctx->cmd = cmd;
 		return FI_SUCCESS;
 	}
@@ -963,7 +974,7 @@ static int smr_unexp_iov(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 	}
 out:
 	if (ret)
-		cmd->hdr.op_flags |= SMR_OP_ERROR;
+		cmd->hdr.smr_flags |= SMR_OP_ERROR;
 
 	smr_return_cmd(ep, cmd);
 	return ret;
@@ -976,7 +987,7 @@ static int smr_unexp_sar(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 	struct smr_pend_entry *sar_entry;
 	int ret;
 
-	cmd->hdr.op_flags |= SMR_BUFFER_RECV;
+	cmd->hdr.smr_flags |= SMR_BUFFER_RECV;
 
 	cmd_ctx->cmd = &cmd_ctx->cmd_cpy;
 	memcpy(&cmd_ctx->cmd_cpy, cmd,
@@ -987,7 +998,7 @@ static int smr_unexp_sar(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 	if (!sar_entry) {
 		ofi_buf_free(cmd_ctx);
 		ret = -FI_ENOMEM;
-		cmd->hdr.op_flags |= SMR_OP_ERROR;
+		cmd->hdr.smr_flags |= SMR_OP_ERROR;
 		goto out;
 	}
 	cmd->hdr.rx_ctx = (uintptr_t) sar_entry;
@@ -1002,9 +1013,10 @@ static int smr_unexp_sar(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 					&ep->async_cpy_list);
 		return FI_SUCCESS;
 	} else if (ret && ret != -FI_EAGAIN) {
-		cmd->hdr.op_flags |= SMR_OP_ERROR;
+		cmd->hdr.smr_flags |= SMR_OP_ERROR;
 	}
 out:
+	assert(cmd->hdr.smr_flags & SMR_RETURN_CMD);
 	smr_return_cmd(ep, cmd);
 	return FI_SUCCESS;
 }
@@ -1018,7 +1030,7 @@ static int smr_unexp_ipc(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 	struct iovec iov;
 	int ret = FI_SUCCESS;;
 
-	if (!(cmd->hdr.op_flags & SMR_BUFFER_RECV)) {
+	if (!(cmd->hdr.smr_flags & SMR_BUFFER_RECV)) {
 		cmd_ctx->cmd = cmd;
 		return FI_SUCCESS;
 	}
@@ -1060,7 +1072,7 @@ static int smr_unexp_ipc(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 
 out:
 	if (ret)
-		cmd->hdr.op_flags |= SMR_OP_ERROR;
+		cmd->hdr.smr_flags |= SMR_OP_ERROR;
 
 	smr_return_cmd(ep, cmd);
 	return ret;
@@ -1098,7 +1110,7 @@ static int smr_alloc_cmd_ctx(struct smr_ep *ep,
 	slist_init(&cmd_ctx->buf_list);
 
 	rx_entry->msg_size = cmd->hdr.size;
-	if (cmd->hdr.op_flags & SMR_REMOTE_CQ_DATA) {
+	if (cmd->hdr.smr_flags & SMR_REMOTE_CQ_DATA) {
 		rx_entry->flags |= FI_REMOTE_CQ_DATA;
 		rx_entry->cq_data = cmd->hdr.cq_data;
 	}
@@ -1179,7 +1191,7 @@ static int smr_progress_cmd_rma(struct smr_ep *ep, struct smr_cmd *cmd)
 	int ret = 0;
 	struct ofi_mr *mr[SMR_IOV_LIMIT];
 	struct smr_pend_entry *pend;
-	bool return_cmd = cmd->hdr.proto != smr_proto_inline;
+	bool return_cmd = cmd->hdr.smr_flags & SMR_RETURN_CMD;
 
 	if (cmd->hdr.rx_ctx)
 		return smr_progress_pending(ep, cmd);
@@ -1223,11 +1235,11 @@ static int smr_progress_cmd_rma(struct smr_ep *ep, struct smr_cmd *cmd)
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"error processing rma op\n");
 		ret = smr_write_err_comp(ep->util_ep.rx_cq, NULL,
-					 smr_rx_cq_flags(0, cmd->hdr.op_flags),
+					 smr_rx_cq_flags(0, cmd->hdr.smr_flags),
 					 0, ret);
 	} else {
 		ret = smr_complete_rx(ep, NULL, cmd->hdr.op,
-				      smr_rx_cq_flags(0, cmd->hdr.op_flags),
+				      smr_rx_cq_flags(0, cmd->hdr.smr_flags),
 				      cmd->hdr.size,
 				      iov_count ? iov[0].iov_base : NULL,
 				      cmd->hdr.rx_id, 0, cmd->hdr.cq_data);
@@ -1293,16 +1305,16 @@ static int smr_progress_cmd_atomic(struct smr_ep *ep, struct smr_cmd *cmd)
 	}
 
 	if (err) {
-		cmd->hdr.op_flags |= SMR_OP_ERROR;
+		cmd->hdr.smr_flags |= SMR_OP_ERROR;
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"error processing atomic op\n");
 		ret = smr_write_err_comp(ep->util_ep.rx_cq, NULL,
 					 smr_rx_cq_flags(0,
-					 cmd->hdr.op_flags), 0, err);
+					 cmd->hdr.smr_flags), 0, err);
 	} else {
 		ret = smr_complete_rx(ep, NULL, cmd->hdr.op,
 				      smr_rx_cq_flags(0,
-				      cmd->hdr.op_flags), total_len,
+				      cmd->hdr.smr_flags), total_len,
 				      ioc_count ? ioc[0].addr : NULL,
 				      cmd->hdr.rx_id, 0, cmd->hdr.cq_data);
 	}
@@ -1313,7 +1325,7 @@ static int smr_progress_cmd_atomic(struct smr_ep *ep, struct smr_cmd *cmd)
 	}
 
 out:
-	if (cmd->hdr.proto != smr_proto_inline)
+	if (cmd->hdr.smr_flags & SMR_RETURN_CMD)
 		smr_return_cmd(ep, cmd);
 	return err;
 }
@@ -1340,9 +1352,9 @@ static void smr_progress_cmd(struct smr_ep *ep)
 			ret = smr_progress_cmd_rma(ep, cmd);
 			break;
 		case ofi_op_write_async:
-			if (cmd->hdr.op_flags & SMR_REMOTE_CQ_DATA) {
+			if (cmd->hdr.smr_flags & SMR_REMOTE_CQ_DATA) {
 				ret = smr_complete_rx(ep, NULL, ofi_op_write,
-					smr_rx_cq_flags(0, cmd->hdr.op_flags),
+					smr_rx_cq_flags(0, cmd->hdr.smr_flags),
 					cmd->hdr.size, NULL, cmd->hdr.rx_id, 0,
 					cmd->hdr.cq_data);
 				break;
@@ -1424,7 +1436,7 @@ static void smr_progress_async_sar(struct smr_ep *ep,
 		if (ret == -FI_EAGAIN) {
 			return;
 		} else if (ret && ret != -FI_EAGAIN) {
-			pend->cmd->hdr.op_flags |= SMR_OP_ERROR;
+			pend->cmd->hdr.smr_flags |= SMR_OP_ERROR;
 		}
 		dlist_remove(&pend->entry);
 		smr_return_cmd(ep, pend->cmd);
@@ -1442,7 +1454,7 @@ static void smr_progress_async_sar(struct smr_ep *ep,
 			dlist_remove(&pend->entry);
 			return;
 		} else if (ret && ret != -FI_EBUSY) {
-			pend->cmd->hdr.op_flags |= SMR_OP_ERROR;
+			pend->cmd->hdr.smr_flags |= SMR_OP_ERROR;
 		}
 	}
 }

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -50,7 +50,7 @@ static void smr_format_rma_resp(struct smr_cmd *cmd, int64_t peer_id,
 	cmd->hdr.size = total_len;
 	if (op_flags & FI_REMOTE_CQ_DATA) {
 		cmd->hdr.cq_data = data;
-		cmd->hdr.op_flags |= SMR_REMOTE_CQ_DATA;
+		cmd->hdr.smr_flags |= SMR_REMOTE_CQ_DATA;
 	}
 }
 
@@ -131,11 +131,12 @@ static ssize_t smr_generic_rma(
 {
 	struct smr_region *peer_smr;
 	int64_t tx_id, rx_id;
-	int proto = smr_proto_inline;
+	int proto;
 	ssize_t ret = -FI_EAGAIN;
 	size_t total_len;
 	struct smr_cmd *ce, *cmd;
 	int64_t pos;
+	uint8_t smr_flags;
 
 	assert(iov_count <= SMR_IOV_LIMIT);
 	assert(rma_count <= SMR_IOV_LIMIT);
@@ -171,8 +172,8 @@ static ssize_t smr_generic_rma(
 
 	proto = smr_select_proto(desc, iov_count, smr_vma_enabled(ep, peer_smr),
 	                         smr_ipc_valid(ep, peer_smr, tx_id, rx_id), op,
-				 total_len, op_flags);
-	if (proto != smr_proto_inline) {
+				 total_len, op_flags, &smr_flags);
+	if (smr_flags & SMR_RETURN_CMD) {
 		if (smr_freestack_isempty(smr_cmd_stack(ep->region))) {
 			smr_cmd_queue_discard(ce, pos);
 			ret = -FI_EAGAIN;
@@ -186,19 +187,19 @@ static ssize_t smr_generic_rma(
 		cmd = ce;
 	}
 	ret = smr_send_ops[proto](ep, peer_smr, tx_id, rx_id, op, 0, data,
-				  op_flags, (struct ofi_mr **)desc, iov,
-				  iov_count, total_len, context, cmd);
+				  op_flags, smr_flags, (struct ofi_mr **)desc,
+				  iov, iov_count, total_len, context, cmd);
 	if (ret) {
-		if (proto != smr_proto_inline)
-			smr_freestack_push(smr_cmd_stack(ep->region), cmd);
 		smr_cmd_queue_discard(ce, pos);
+		if (smr_flags & SMR_RETURN_CMD)
+			smr_freestack_push(smr_cmd_stack(ep->region), cmd);
 		goto unlock;
 	}
 
 	smr_add_rma_cmd(peer_smr, rma_iov, rma_count, cmd);
 	smr_cmd_queue_commit(ce, pos);
 
-	if (proto != smr_proto_inline || op == ofi_op_read_req)
+	if (smr_flags & SMR_RETURN_CMD)
 		goto unlock;
 
 	ret = smr_complete_tx(ep, context, op, op_flags);
@@ -322,7 +323,7 @@ static ssize_t smr_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 static ssize_t smr_generic_rma_inject(
 		struct fid_ep *ep_fid, const void *buf, size_t len,
 		fi_addr_t dest_addr, uint64_t addr, uint64_t key, uint64_t data,
-		uint64_t flags)
+		uint64_t op_flags)
 {
 	struct smr_ep *ep;
 	struct smr_region *peer_smr;
@@ -333,6 +334,7 @@ static ssize_t smr_generic_rma_inject(
 	ssize_t ret = -FI_EAGAIN;
 	struct smr_cmd *ce, *cmd;
 	int64_t pos;
+	uint8_t smr_flags;
 
 	assert(len <= SMR_INJECT_SIZE);
 	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
@@ -360,36 +362,21 @@ static ssize_t smr_generic_rma_inject(
 		goto unlock;
 	}
 
-	if (len <= SMR_MSG_DATA_LEN) {
-		proto = smr_proto_inline;
-		cmd = ce;
-	} else {
-		proto = smr_proto_inject;
-		if (smr_freestack_isempty(smr_cmd_stack(ep->region))) {
-			smr_cmd_queue_discard(ce, pos);
-			ret = -FI_EAGAIN;
-			goto unlock;
-		}
+	proto = len <= SMR_MSG_DATA_LEN ? smr_proto_inline : smr_proto_inject;
+	cmd = ce;
 
-		cmd = smr_freestack_pop(smr_cmd_stack(ep->region));
-		assert(cmd);
-		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
-						  (uintptr_t) cmd);
-	}
-
+	smr_flags = (op_flags & FI_REMOTE_CQ_DATA) ? SMR_REMOTE_CQ_DATA : 0;
 	ret = smr_send_ops[proto](ep, peer_smr, tx_id, rx_id, ofi_op_write, 0,
-				  data, flags, NULL, &iov, 1, len, NULL, cmd);
+				  data, op_flags, smr_flags, NULL, &iov, 1, len,
+				  NULL, cmd);
 	if (ret) {
-		if (proto != smr_proto_inline)
-			smr_freestack_push(smr_cmd_stack(ep->region), cmd);
 		smr_cmd_queue_discard(ce, pos);
 		goto unlock;
 	}
 	smr_add_rma_cmd(peer_smr, &rma_iov, 1, cmd);
 	smr_cmd_queue_commit(ce, pos);
 
-	if (proto == smr_proto_inline)
-		ofi_ep_peer_tx_cntr_inc(&ep->util_ep, ofi_op_write);
+	ofi_ep_peer_tx_cntr_inc(&ep->util_ep, ofi_op_write);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;

--- a/prov/shm/src/smr_util.c
+++ b/prov/shm/src/smr_util.c
@@ -37,6 +37,7 @@
 struct dlist_entry ep_name_list;
 DEFINE_LIST(ep_name_list);
 pthread_mutex_t ep_list_lock = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t inject_pool_lock = PTHREAD_MUTEX_INITIALIZER;
 
 void smr_cleanup(void)
 {
@@ -105,7 +106,7 @@ size_t smr_calculate_size_offsets(size_t tx_count, size_t rx_count,
 	inject_pool_offset = cmd_queue_offset + sizeof(struct smr_cmd_queue) +
 		sizeof(struct smr_cmd_queue_entry) * rx_size;
 	cmd_stack_offset = inject_pool_offset +
-		sizeof(struct smr_inject_buf) * tx_size;
+		freestack_size(sizeof(struct smr_inject_buf), rx_size);
 	ret_queue_offset = cmd_stack_offset +
 		freestack_size(sizeof(struct smr_cmd), tx_size);
 	ret_queue_offset = ofi_get_aligned_size(ret_queue_offset, 64);
@@ -287,6 +288,8 @@ int smr_create(const struct fi_provider *prov, const struct smr_attr *attr,
 	(*smr)->max_sar_buf_per_peer = SMR_BUF_BATCH_MAX;
 
 	smr_cmd_queue_init(smr_cmd_queue(*smr), rx_size, smr_cmd_init);
+	smr_freestack_init(smr_inject_pool(*smr), rx_size,
+			   sizeof(struct smr_inject_buf));
 	smr_return_queue_init(smr_return_queue(*smr), tx_size, NULL);
 
 	smr_freestack_init(smr_cmd_stack(*smr), tx_size,
@@ -300,6 +303,7 @@ int smr_create(const struct fi_provider *prov, const struct smr_attr *attr,
 		smr_peer_data(*smr)[i].xpmem.avail = false;
 	}
 
+	ofi_spin_init(&(*smr)->fs_lock);
 	strncpy((char *) smr_name(*smr), attr->name, total_size - name_offset);
 
 	/* Must be set last to signal full initialization to peers */
@@ -318,6 +322,10 @@ close:
 
 void smr_free(struct smr_region *smr)
 {
+	/*
+	 * TODO: Figure out if we should cleanup resources in the smr before
+	 * unlinking and unmapping.
+	 */
 	if (smr->flags & SMR_FLAG_HMEM_ENABLED)
 		(void) ofi_hmem_host_unregister(smr);
 	shm_unlink(smr_name(smr));

--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -35,8 +35,8 @@
 
 #include "ofi.h"
 #include "ofi_atomic_queue.h"
+#include "ofi_lock.h"
 #include "ofi_xpmem.h"
-#include <pthread.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -76,6 +76,7 @@ extern struct smr_env smr_env;
 #define SMR_REMOTE_CQ_DATA	(1 << 0)
 #define SMR_BUFFER_RECV		(1 << 1)
 #define SMR_OP_ERROR		(1 << 2)
+#define SMR_RETURN_CMD		(1 << 3)
 
 enum {
 	smr_proto_inline,	/* inline payload */
@@ -91,7 +92,7 @@ enum {
  *	entry		for internal use managing commands
  * 	op		type of op (ex. ofi_op_msg, defined in ofi_proto.h)
  * 	proto		smr protocol (ex. smr_proto_inline, defined above)
- * 	op_flags	operation flags (ex. SMR_REMOTE_CQ_DATA, defined above)
+ * 	smr_flags	operation flags (ex. SMR_REMOTE_CQ_DATA, defined above)
  * 	resv		reserved
  * 	tx_id		local shm_id of peer sending msg (unused by target)
  *	rx_id		remote shm_id of peer sending msg (unused by source)
@@ -106,7 +107,7 @@ enum {
 			(especially if your cpu does not have prefetching) so
 			that the first cache grab gets the lightweight protocol
 			fields.
- * 	resv2		reserved to keep hdr at 64 bytes
+ * 	proto_data	protocol specific data (ex. inject or SAR buf offset)
  *	tx_ctx		source side context (unused by target side)
  *	rx_ctx		target side context (unused by source side)
  */
@@ -114,7 +115,7 @@ struct smr_cmd_hdr {
 	uint64_t		entry;
 	uint8_t			op;
 	uint8_t			proto;
-	uint8_t			op_flags;
+	uint8_t			smr_flags;
 	uint8_t			resv[1];
 	int16_t			rx_id;
 	int16_t			tx_id;
@@ -128,7 +129,7 @@ struct smr_cmd_hdr {
 		};
 	};
 	//CACHE LINE HERE - See comment above
-	uint64_t		resv2;
+	uint64_t		proto_data;
 	uint64_t		tx_ctx;
 	uint64_t		rx_ctx;
 };
@@ -255,6 +256,8 @@ struct smr_region {
 			uintptr_t		base_addr;
 
 			size_t			total_size;
+
+			ofi_spin_t		fs_lock;
 		};
 		uint8_t		pad[SMR_PREFETCH_SZ];
 	};
@@ -320,9 +323,9 @@ static inline struct smr_freestack *smr_cmd_stack(struct smr_region *smr)
 {
 	return (struct smr_freestack *) ((char *) smr + smr->cmd_stack_offset);
 }
-static inline struct smr_inject_buf *smr_inject_pool(struct smr_region *smr)
+static inline struct smr_freestack *smr_inject_pool(struct smr_region *smr)
 {
-	return (struct smr_inject_buf *)
+	return (struct smr_freestack *)
 			((char *) smr + smr->inject_pool_offset);
 }
 static inline struct smr_return_queue *smr_return_queue(struct smr_region *smr)
@@ -343,11 +346,32 @@ static inline const char *smr_name(struct smr_region *smr)
 	return (const char *) smr + smr->name_offset;
 }
 
-static inline struct smr_inject_buf *smr_get_inject_buf(struct smr_region *smr,
-							struct smr_cmd *cmd)
+static inline struct smr_inject_buf *smr_get_inject_buf(struct smr_region *smr)
 {
-	return &smr_inject_pool(smr)[smr_freestack_get_index(smr_cmd_stack(smr),
-							     (char *) cmd)];
+	struct smr_inject_buf *buf;
+	ofi_spin_lock(&smr->fs_lock);
+	if (!smr_freestack_isempty(smr_inject_pool(smr)))
+		buf = smr_freestack_pop(smr_inject_pool(smr));
+	else
+		buf = NULL;
+	ofi_spin_unlock(&smr->fs_lock);
+	return buf;
+}
+
+static inline void smr_return_inject_buf(struct smr_region *smr,
+					 struct smr_inject_buf *buf)
+{
+	ofi_spin_lock(&smr->fs_lock);
+	smr_freestack_push(smr_inject_pool(smr), buf);
+	ofi_spin_unlock(&smr->fs_lock);
+}
+
+static inline void smr_return_sar_buf_by_index(struct smr_region *smr,
+					       size_t index)
+{
+	ofi_spin_lock(&smr->fs_lock);
+	smr_freestack_push_by_index(smr_sar_pool(smr), index);
+	ofi_spin_unlock(&smr->fs_lock);
 }
 
 struct smr_attr {


### PR DESCRIPTION
Convert parallel inject stack to be an smr_freestack inject pool instead. Senders will now try to allocate an inject buffer from the receiver's pool to copy their data into (write) or have the receiver copy data into for the sender (read).

These changes are aligning the smr_flags to be a uint8 and renamed the op_flags to smr_flags.

Remove "format_inject" because the steps inside it need to be spread out in the "do_inject" function. We need to try and get an inject buffer first because it is the most expensive grab and has the highest chance to fail. It does not make sense to keep "format_inject" since the allocation of the inject_buffer and copy into it was the main thing the format function would have done.