### PR TITLE
prov/efa/test: fix valgrind warnings in unit tests

### DIFF
--- a/prov/efa/test/efa_unit_test_common.c
+++ b/prov/efa/test/efa_unit_test_common.c
@@ -268,6 +268,7 @@ void efa_unit_test_resource_destruct(struct efa_resource *resource)
 {
 	if (resource->ep) {
 		assert_int_equal(fi_close(&resource->ep->fid), 0);
+		resource->ep = NULL;
 	}
 
 	if (g_ibv_submitted_wr_id_vec) {
@@ -278,30 +279,37 @@ void efa_unit_test_resource_destruct(struct efa_resource *resource)
 
 	if (resource->eq) {
 		assert_int_equal(fi_close(&resource->eq->fid), 0);
+		resource->eq = NULL;
 	}
 
 	if (resource->cq) {
 		assert_int_equal(fi_close(&resource->cq->fid), 0);
+		resource->cq = NULL;
 	}
 
 	if (resource->av) {
 		assert_int_equal(fi_close(&resource->av->fid), 0);
+		resource->av = NULL;
 	}
 
 	if (resource->domain) {
 		assert_int_equal(fi_close(&resource->domain->fid), 0);
+		resource->domain = NULL;
 	}
 
 	if (resource->fabric) {
 		assert_int_equal(fi_close(&resource->fabric->fid), 0);
+		resource->fabric = NULL;
 	}
 
 	if (resource->info) {
 		fi_freeinfo(resource->info);
+		resource->info = NULL;
 	}
 
 	if (resource->hints) {
 		fi_freeinfo(resource->hints);
+		resource->hints = NULL;
 	}
 }
 

--- a/prov/efa/test/efa_unit_test_cq.c
+++ b/prov/efa/test/efa_unit_test_cq.c
@@ -281,7 +281,7 @@ void test_rdm_cq_handshake_bad_send_status_impl(struct efa_resource **state, int
 	struct efa_resource *resource = *state;
 	struct efa_unit_test_handshake_pkt_attr pkt_attr = {0};
 	struct fi_cq_data_entry cq_entry;
-	struct fi_eq_err_entry eq_err_entry;
+	struct fi_eq_err_entry eq_err_entry = {0};
 	struct efa_rdm_ep *efa_rdm_ep;
 	struct efa_rdm_pke *pkt_entry;
 	struct efa_rdm_cq *efa_rdm_cq;
@@ -416,7 +416,7 @@ void test_ibv_cq_ex_read_bad_recv_status(struct efa_resource **state)
 	struct efa_resource *resource = *state;
 	struct efa_rdm_pke *pkt_entry;
 	struct fi_cq_data_entry cq_entry;
-	struct fi_eq_err_entry eq_err_entry;
+	struct fi_eq_err_entry eq_err_entry = {0};
 	int ret;
 	struct efa_rdm_cq *efa_rdm_cq;
 	struct efa_ibv_cq *ibv_cq;
@@ -511,7 +511,7 @@ void test_ibv_cq_ex_read_bad_recv_rdma_with_imm_status_impl(struct efa_resource 
 	struct efa_rdm_ep *efa_rdm_ep;
 	struct efa_resource *resource = *state;
 	struct fi_cq_data_entry cq_entry;
-	struct fi_eq_err_entry eq_err_entry;
+	struct fi_eq_err_entry eq_err_entry = {0};
 	int ret;
 	struct efa_rdm_cq *efa_rdm_cq;
 	struct efa_ibv_cq *ibv_cq;

--- a/prov/efa/test/efa_unit_test_ope.c
+++ b/prov/efa/test/efa_unit_test_ope.c
@@ -17,7 +17,7 @@ void test_efa_rdm_ope_prepare_to_post_send_impl(struct efa_resource *resource,
 	struct efa_ep_addr raw_addr;
 	struct efa_rdm_mr mock_mr;
 	struct efa_rdm_ope mock_txe;
-	struct efa_rdm_peer mock_peer;
+	struct efa_rdm_peer mock_peer = {0};
 	size_t raw_addr_len = sizeof(raw_addr);
 	fi_addr_t addr;
 	size_t pkt_entry_cnt;
@@ -422,7 +422,7 @@ void test_efa_rdm_ope_handle_error_impl(
 {
 	struct fi_cq_data_entry cq_entry;
 	struct fi_cq_err_entry cq_err_entry = {0};
-	struct fi_eq_err_entry eq_err_entry;
+	struct fi_eq_err_entry eq_err_entry = {0};
 
 	efa_rdm_ope_handle_error(ope, FI_ENOTCONN,
 				 EFA_IO_COMP_STATUS_LOCAL_ERROR_UNREACH_REMOTE);


### PR DESCRIPTION
  Fix memory safety issues in EFA unit tests found by valgrind.

