### PR TITLE
[v2.4.x] fabtests/efa: Add fabric marker to test_efa_mr_hmem

### DIFF
--- a/fabtests/pytest/efa/test_mr.py
+++ b/fabtests/pytest/efa/test_mr.py
@@ -37,6 +37,7 @@ def test_mr_hmem(cmdline_args, hmem_type, fabric):
 
 
 @pytest.mark.unit
+@pytest.mark.fabric(params=["efa", "efa-direct"])
 @pytest.mark.short
 def test_efa_mr_hmem(cmdline_args, hmem_type, fabric):
     if hmem_type != "neuron":


### PR DESCRIPTION
Adds fabric marker that was missed during merge conflict resolution.