### PR TITLE
prov/efa: Fix efa_conn_alloc error path deadlock

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -269,7 +269,8 @@ nodist_prov_efa_test_gtest_efa_gtest_SOURCES = \
 	prov/efa/test/gtest/efa_gtest_main.cc \
 	prov/efa/test/gtest/efa_gtest_common_mocks.cc \
 	prov/efa/test/gtest/efa_gtest_common_resource.cc \
-	prov/efa/test/gtest/efa_gtest_common_helpers.c
+	prov/efa/test/gtest/efa_gtest_common_helpers.c \
+	prov/efa/test/gtest/efa_gtest_conn.cc
 
 prov_efa_test_gtest_efa_gtest_CPPFLAGS = \
 	$(AM_CPPFLAGS) \

--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -266,12 +266,17 @@ noinst_PROGRAMS += prov/efa/test/gtest/efa_gtest
 TESTS += prov/efa/test/gtest/efa_gtest
 
 nodist_prov_efa_test_gtest_efa_gtest_SOURCES = \
-	prov/efa/test/gtest/efa_gtest_main.cc
+	prov/efa/test/gtest/efa_gtest_main.cc \
+	prov/efa/test/gtest/efa_gtest_common_mocks.cc \
+	prov/efa/test/gtest/efa_gtest_common_resource.cc \
+	prov/efa/test/gtest/efa_gtest_common_helpers.c
 
 prov_efa_test_gtest_efa_gtest_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
 	$(gtest_CPPFLAGS) \
 	-I$(top_srcdir)/include \
+	-I$(top_srcdir)/prov/efa/src \
+	-I$(top_srcdir)/prov/efa/src/rdm \
 	-I$(top_srcdir)/prov/efa/test/gtest
 
 prov_efa_test_gtest_efa_gtest_CXXFLAGS = -std=c++17
@@ -283,7 +288,11 @@ prov_efa_test_gtest_efa_gtest_LDADD = \
 prov_efa_test_gtest_efa_gtest_LDFLAGS = \
 	-static \
 	$(efa_LDFLAGS) \
-	$(gtest_LDFLAGS)
+	$(gtest_LDFLAGS) \
+	-Wl,--wrap=ibv_create_ah \
+	-Wl,--wrap=ibv_destroy_ah \
+	-Wl,--wrap=efadv_query_ah \
+	-Wl,--wrap=efa_av_reverse_av_add
 
 prov_efa_test_gtest_efa_gtest_LIBS = $(linkback)
 

--- a/prov/efa/src/efa_conn.c
+++ b/prov/efa/src/efa_conn.c
@@ -303,13 +303,8 @@ struct efa_conn *efa_conn_alloc(struct efa_av *av, struct efa_ep_addr *raw_addr,
 	err = efa_av_reverse_av_add(av, cur_reverse_av, prv_reverse_av, conn);
 	if (err) {
 		if (av->domain->info_type == EFA_INFO_RDM) {
-			/* insert_implicit_av is only true for the CQ read path
-			 * which already has the SRX lock */
-			if (insert_implicit_av)
-				ofi_genlock_lock(&av->domain->srx_lock);
+			assert(ofi_genlock_held(&av->domain->srx_lock));
 			efa_conn_rdm_deinit(av, conn);
-			if (insert_implicit_av)
-				ofi_genlock_unlock(&av->domain->srx_lock);
 		}
 		goto err_release;
 	}
@@ -319,8 +314,11 @@ struct efa_conn *efa_conn_alloc(struct efa_av *av, struct efa_ep_addr *raw_addr,
 	return conn;
 
 err_release:
-	if (conn->ah)
+	if (conn->ah) {
+		if (insert_implicit_av)
+			dlist_remove(&conn->ah_implicit_conn_list_entry);
 		efa_ah_release(av->domain, conn->ah, insert_implicit_av);
+	}
 
 	conn->ep_addr = NULL;
 	err = ofi_av_remove_addr(util_av, fi_addr);

--- a/prov/efa/test/README.md
+++ b/prov/efa/test/README.md
@@ -2,8 +2,8 @@
 
 ## How to run
 
-To run efa unit tests, you will need to have cmocka installed.
-* [Cmocka Mirror](https://cmocka.org/files/)
+To run efa unit tests, you will need to have cmocka 1.1.5 installed.
+* [Cmocka Mirror](https://cmocka.org/files/1.1/cmocka-1.1.5.tar.xz)
 * [Install Instructions](https://gitlab.com/cmocka/cmocka/-/blob/master/INSTALL.md)
 
 You will need to configure libfabric with `--enable-efa-unit-test=<path_to_cmocka_install>`.

--- a/prov/efa/test/gtest/README.md
+++ b/prov/efa/test/gtest/README.md
@@ -1,0 +1,73 @@
+# GoogleTest-based EFA unit tests
+
+## How to run
+
+To run efa unit tests, you will need to have [GoogleTest 1.17](https://github.com/google/googletest/releases/tag/v1.17.0) installed.
+See installation instructions [here](https://google.github.io/googletest/quickstart-cmake.html).
+
+You will need to configure libfabric with `--enable-efa-gtest=<path_to_gtest_install>`.
+
+An example build and run command would look like:
+
+```bash
+./autogen.sh && ./configure --enable-efa-gtest=/home/ec2-user/googletest/install
+make /prov/efa/test/gtest/efa_gtest -j
+```
+
+You can then directly execute the test executable:
+```
+./prov/efa/test/gtest/efa_gtest
+```
+
+## File Structure
+* `efa_gtest_main.cc`: Test entry point. Its `main` calls `InitGoogleMock` and `RUN_ALL_TESTS()`. Tests register themselves through the `TEST`/`TEST_F` macros, so — unlike cmocka — there is nothing to declare or add to `main` by hand.
+* `efa_gtest_common_resource.{cc,h}`: Defines `struct efa_resource` and `efa_test_resource_construct`/`efa_test_resource_destruct`, which build and tear down a full set of OFI objects (fabric, domain, endpoint, EQ, AV, CQ).
+* `efa_gtest_common_mocks.{cc,h}`: The `MockEfa` gmock class for libibverbs/efadv calls (e.g. `ibv_create_ah`), plus the `__wrap_*` trampolines that route those calls to the installed mock.
+* `efa_gtest_common_helpers.{c,h}`: C-linkage helpers. EFA internal headers (`efa.h`, `efa_av.h`, ...) transitively pull in `unix/osd.h`, which uses C `_Complex` types that don't compile under C++. Anything a test needs from EFA internals is wrapped by a C function here and declared `extern "C"` in the header.
+* `efa_gtest_{component}.cc`: The tests themselves, one file per component (e.g. `efa_gtest_conn.cc`).
+
+## What Should be Tested
+1. We are biased toward testing public, stable functions, e.g. we prefer testing `fi_*` to `efa_*` - the former more closely resembles real user behavior.
+1. We make a conscious trade-off to test larger rather than smaller units. A large test unit consists of more state variables, and testing it gives us more confidence in the overall system.
+2. We are biased toward testing edge cases over "happy cases", especially if the code path under test cannot be covered by integration tests.
+
+## How to write
+1. Read the [GoogleTest documentation](https://google.github.io/googletest/), particularly the [primer](https://google.github.io/googletest/primer.html), and the [gMock Cookbook](https://google.github.io/googletest/gmock_cook_book.html).
+2. Pick the component file `efa_gtest_{component}.cc` (create one if needed and add it to `nodist_..._SOURCES` in `prov/efa/Makefile.include`).
+3. Write a fixture class deriving from `::testing::Test`. Embed a `struct efa_resource` and any mocks (e.g. `MockEfa`); call `efa_test_resource_construct` to set up and `efa_test_resource_destruct` + `MockEfa::set(nullptr)` to tear down. See `EfaConnTest` in `efa_gtest_conn.cc`.
+4. Write tests with `TEST_F(Fixture, name)`. There is no header to update and no group to register — gtest discovers tests automatically.
+5. If a test needs EFA internals, expose them through a helper in `efa_gtest_common_helpers.c` rather than including the EFA headers from C++.
+
+## Mocking
+We intercept functions with the GNU linker's `--wrap` and back them with gmock for expressive expectations. The `EFA_MOCK_FUNCTIONS` X macro in `efa_gtest_common_mocks.h` is the single source of truth — it generates `MOCK_METHOD` declarations, `__real_` extern declarations, and `__wrap_` trampolines automatically.
+
+### Adding a new mock
+
+1. Define `EFA_MOCK_PARAMS_<fn>` (full parameter declarations) and `EFA_MOCK_ARGS_<fn>` (argument names only) in `efa_gtest_common_mocks.h`.
+2. Add `X(return_type, fn)` to the `EFA_MOCK_FUNCTIONS` list.
+3. Add any needed forward struct declarations at the top of the header.
+4. Add `-Wl,--wrap=<fn>` to `prov_efa_test_gtest_efa_gtest_LDFLAGS` in `prov/efa/Makefile.include`.
+
+If adding a mock breaks other tests, it's likely due to the new mock is being unintentionally called in a test where a real function call is expected. By default, mocked functions will return 0/false/NULL/default construct, and this may not be the expected behavior of the real functions. There are two solutions to this:
+
+1. Define multiple mock classes analogous to `MockEfa`, to isolate the mocks, and only install the mocks you need by `MockEfa::set(&mock_efa);`
+2. Set up the correct expectation to route all calls to a specific wrapped function to the real function, like
+```
+ON_CALL(*this, ibv_create_ah(_,:_))
+        .WillByDefault(Invoke(__real_ibv_create_ah));
+```
+A mixture of both strategy can be used, to minimize the changes required.
+
+### Using mocks in tests
+
+Install the mock with `MockEfa::set(&mock)` and set up `EXPECT_CALL(mock, ...)` expectations (e.g. `.WillOnce(testing::Return(...))`). When no mock is installed, the trampoline falls through to the real `__real_<fn>` implementation.
+
+Because `--wrap` rewires every call to the function across the whole test binary, always restore the default in the fixture's `TearDown` — clear the mock with `MockEfa::set(nullptr)` — so mocks don't leak between tests.
+
+### Strictness and explicit actions
+
+Declare the mock member as `testing::StrictMock<MockEfa>`, not bare `MockEfa`. A bare mock only prints a warning when a wrapped function fires with no matching `EXPECT_CALL`; `StrictMock` makes it a hard failure. That is the behavior we want here: `--wrap` intercepts the function process-wide, so every wrapped call that fires during a test is significant and should be accounted for. Reserve `testing::NiceMock<MockEfa>` for the rare, commented case where a helper fires a high-volume call you deliberately don't want to enumerate.
+
+Strictness is a separate concern from the *return value* of an expected call: `StrictMock` only governs whether a call was expected, never what it returns. A `StrictMock` whose `EXPECT_CALL` omits an action still returns the gMock default (0/false/NULL/default-constructed). So always give every `EXPECT_CALL` an explicit action (`WillOnce`/`WillRepeatedly`/`Times(0)`) rather than relying on that implicit default.
+
+Note that the mock is typically installed *after* `efa_test_resource_construct` and cleared in `TearDown`, so any wrapped call made while tearing the resources down (e.g. destroying the endpoint's `self_ah` via `ibv_destroy_ah`) is also subject to strict checking — expect those calls too.

--- a/prov/efa/test/gtest/efa_gtest_common_helpers.c
+++ b/prov/efa/test/gtest/efa_gtest_common_helpers.c
@@ -1,0 +1,56 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#include "efa.h"
+#include "efa_av.h"
+#include "rdm/efa_rdm_ep.h"
+#include "efa_gtest_common_helpers.h"
+
+void efa_test_fabricate_addr(struct fid_ep *ep, struct efa_ep_addr *addr)
+{
+	size_t addr_len = sizeof(*addr);
+	static uint8_t gid_suffix = 1;
+
+	memset(addr, 0, addr_len);
+	// Get ep's actual address
+	fi_getname(&ep->fid, addr, &addr_len);
+	// Flip the first bit
+	addr->raw[0] ^= 0xFF;
+	addr->raw[15] = gid_suffix++;
+	addr->qpn = 1;
+	addr->qkey = 0x5678;
+}
+
+int efa_test_explicit_av_insert(struct fid_ep *ep, struct fid_av *av,
+				fi_addr_t *addr)
+{
+	struct efa_ep_addr raw_addr;
+
+	efa_test_fabricate_addr(ep, &raw_addr);
+	return fi_av_insert(av, &raw_addr, 1, addr, 0, NULL);
+}
+
+fi_addr_t efa_test_insert_peer_new_gid(struct fid_ep *ep, struct fid_av *av)
+{
+	struct efa_rdm_ep *efa_rdm_ep;
+	struct efa_av *efa_av;
+	struct efa_ep_addr raw_addr;
+	fi_addr_t fi_addr = FI_ADDR_NOTAVAIL;
+	int err;
+
+	efa_rdm_ep =
+		container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
+	efa_av = container_of(av, struct efa_av, util_av.av_fid);
+
+	efa_test_fabricate_addr(ep, &raw_addr);
+
+	ofi_genlock_lock(&efa_rdm_ep->base_ep.domain->srx_lock);
+	err = efa_av_insert_one(efa_av, &raw_addr, &fi_addr, 0, NULL, true,
+				true);
+	ofi_genlock_unlock(&efa_rdm_ep->base_ep.domain->srx_lock);
+
+	if (err)
+		return FI_ADDR_NOTAVAIL;
+
+	return fi_addr;
+}

--- a/prov/efa/test/gtest/efa_gtest_common_helpers.h
+++ b/prov/efa/test/gtest/efa_gtest_common_helpers.h
@@ -1,0 +1,44 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+/*
+ * C-linkage helper functions for gtest.
+ *
+ * EFA internal headers (efa.h, efa_av.h, etc.) cannot be included from C++
+ * because they transitively pull in unix/osd.h which uses C _Complex types.
+ * Functions in this file are implemented in efa_gtest_common_helpers.c
+ * (compiled as C) and provide a C++-callable interface to EFA internals that
+ * the test files need but cannot access directly.
+ */
+
+#ifndef EFA_GTEST_COMMON_HELPERS_H
+#define EFA_GTEST_COMMON_HELPERS_H
+
+#include <rdma/fabric.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_endpoint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Fabricate a unique address and insert it via fi_av_insert (explicit
+ * path).
+ * @return Number of addresses successfully inserted (0 on expected failure).
+ */
+int efa_test_explicit_av_insert(struct fid_ep *ep, struct fid_av *av,
+				fi_addr_t *addr);
+
+/**
+ * @brief Insert a peer with a fabricated GID that won't be in the ah_map.
+ * This forces efa_ah_alloc to call ibv_create_ah for a new GID.
+ * @return The fi_addr, or FI_ADDR_NOTAVAIL on failure.
+ */
+fi_addr_t efa_test_insert_peer_new_gid(struct fid_ep *ep, struct fid_av *av);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFA_GTEST_COMMON_HELPERS_H */

--- a/prov/efa/test/gtest/efa_gtest_common_mocks.cc
+++ b/prov/efa/test/gtest/efa_gtest_common_mocks.cc
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#include "efa_gtest_common_mocks.h"
+
+static MockEfa *g_mock_efa = nullptr;
+
+MockEfa *MockEfa::get()
+{
+	return g_mock_efa;
+}
+
+void MockEfa::set(MockEfa *instance)
+{
+	g_mock_efa = instance;
+}
+
+// Generate the definitions of the __wrap_* functions
+#define EFA_MOCK_GEN_WRAP(ret, name)                             \
+	ret __wrap_##name(EFA_MOCK_PARAMS_##name)                \
+	{                                                        \
+		auto *mock = MockEfa::get();                     \
+		if (mock)                                        \
+			return mock->name(EFA_MOCK_ARGS_##name); \
+		return __real_##name(EFA_MOCK_ARGS_##name);      \
+	}
+
+extern "C" {
+EFA_MOCK_FUNCTIONS(EFA_MOCK_GEN_WRAP)
+}

--- a/prov/efa/test/gtest/efa_gtest_common_mocks.h
+++ b/prov/efa/test/gtest/efa_gtest_common_mocks.h
@@ -1,0 +1,78 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#ifndef EFA_GTEST_COMMON_MOCKS_H
+#define EFA_GTEST_COMMON_MOCKS_H
+
+#include <gmock/gmock.h>
+#include <infiniband/efadv.h>
+#include <infiniband/verbs.h>
+
+struct efa_av;
+struct efa_cur_reverse_av;
+struct efa_prv_reverse_av;
+struct efa_conn;
+
+/*
+ * X macro infrastructure for mock generation.
+ *
+ * To add a new mocked function:
+ *   1. Define EFA_MOCK_PARAMS_<name> and EFA_MOCK_ARGS_<name> below
+ *   2. Add X(ret, name) to EFA_MOCK_FUNCTIONS
+ *   3. Add any needed forward struct declarations above
+ *   4. Add -Wl,--wrap=<name> to prov_efa_test_gtest_efa_gtest_LDFLAGS
+ *      in prov/efa/Makefile.include
+ */
+
+/* --- Per-function parameter definitions --- */
+
+#define EFA_MOCK_PARAMS_ibv_create_ah \
+	struct ibv_pd *pd, struct ibv_ah_attr *attr
+#define EFA_MOCK_ARGS_ibv_create_ah pd, attr
+
+#define EFA_MOCK_PARAMS_ibv_destroy_ah struct ibv_ah *ibv_ah
+#define EFA_MOCK_ARGS_ibv_destroy_ah   ibv_ah
+
+#define EFA_MOCK_PARAMS_efadv_query_ah \
+	struct ibv_ah *ibv_ah, struct efadv_ah_attr *attr, uint32_t inlen
+#define EFA_MOCK_ARGS_efadv_query_ah ibv_ah, attr, inlen
+
+#define EFA_MOCK_PARAMS_efa_av_reverse_av_add                          \
+	struct efa_av *av, struct efa_cur_reverse_av **cur_reverse_av, \
+		struct efa_prv_reverse_av **prv_reverse_av,            \
+		struct efa_conn *conn
+#define EFA_MOCK_ARGS_efa_av_reverse_av_add \
+	av, cur_reverse_av, prv_reverse_av, conn
+
+/* --- Function list --- */
+
+#define EFA_MOCK_FUNCTIONS(X)             \
+	X(struct ibv_ah *, ibv_create_ah) \
+	X(int, ibv_destroy_ah)            \
+	X(int, efadv_query_ah)            \
+	X(int, efa_av_reverse_av_add)
+
+/* --- Generator macros --- */
+
+#define EFA_MOCK_GEN_METHOD(ret, name) \
+	MOCK_METHOD(ret, name, (EFA_MOCK_PARAMS_##name));
+
+#define EFA_MOCK_GEN_REAL_DECL(ret, name) \
+	ret __real_##name(EFA_MOCK_PARAMS_##name);
+
+// Generate the definitions of the MOCK_METHOD's in the MockEfa class
+class MockEfa
+{
+	public:
+	EFA_MOCK_FUNCTIONS(EFA_MOCK_GEN_METHOD)
+
+	static MockEfa *get();
+	static void set(MockEfa *instance);
+};
+
+// Generate the declarations of the real function prototypes
+extern "C" {
+EFA_MOCK_FUNCTIONS(EFA_MOCK_GEN_REAL_DECL)
+}
+
+#endif /* EFA_GTEST_COMMON_MOCKS_H */

--- a/prov/efa/test/gtest/efa_gtest_common_resource.cc
+++ b/prov/efa/test/gtest/efa_gtest_common_resource.cc
@@ -1,0 +1,128 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#include "efa_gtest_common_resource.h"
+
+struct fi_info *efa_test_alloc_default_hints(enum fi_ep_type ep_type,
+					     const char *fabric_name)
+{
+	struct fi_info *hints;
+
+	hints = fi_allocinfo();
+	if (!hints)
+		return NULL;
+
+	if (fabric_name)
+		hints->fabric_attr->name = strdup(fabric_name);
+	hints->ep_attr->type = ep_type;
+	hints->domain_attr->mr_mode = MR_MODE_BITS;
+
+	if (!fabric_name || !strcasecmp(fabric_name, EFA_DIRECT_FABRIC_NAME))
+		hints->mode |= FI_CONTEXT2;
+
+	if (ep_type == FI_EP_DGRAM)
+		hints->mode |= FI_MSG_PREFIX | FI_CONTEXT2;
+
+	return hints;
+}
+
+void efa_test_resource_construct(struct efa_resource *resource,
+				 struct fi_info *hints)
+{
+	int ret;
+	struct fi_av_attr av_attr = {};
+	struct fi_cq_attr cq_attr = {};
+	struct fi_eq_attr eq_attr = {};
+	const char *fabric_name;
+	uint32_t fi_version;
+
+	cq_attr.format = FI_CQ_FORMAT_DATA;
+
+	ASSERT_NE(hints, nullptr);
+	resource->hints = hints;
+
+	/* The fabric and ep type are already encoded in hints; derive the API
+	 * version from the fabric name rather than taking it as a separate
+	 * argument that could disagree with hints. */
+	fabric_name = hints->fabric_attr ? hints->fabric_attr->name : NULL;
+	fi_version =
+		(fabric_name && !strcmp(EFA_DIRECT_FABRIC_NAME, fabric_name)) ?
+			FI_VERSION(2, 0) :
+			FI_VERSION(1, 14);
+
+	ret = fi_getinfo(fi_version, NULL, NULL, 0ULL, resource->hints,
+			 &resource->info);
+	ASSERT_EQ(ret, 0) << "fi_getinfo failed: " << fi_strerror(-ret);
+
+	ret = fi_fabric(resource->info->fabric_attr, &resource->fabric, NULL);
+	ASSERT_EQ(ret, 0) << "fi_fabric failed: " << fi_strerror(-ret);
+
+	ret = fi_domain(resource->fabric, resource->info, &resource->domain,
+			NULL);
+	ASSERT_EQ(ret, 0) << "fi_domain failed: " << fi_strerror(-ret);
+
+	ret = fi_endpoint(resource->domain, resource->info, &resource->ep,
+			  NULL);
+	ASSERT_EQ(ret, 0) << "fi_endpoint failed: " << fi_strerror(-ret);
+
+	ret = fi_eq_open(resource->fabric, &eq_attr, &resource->eq, NULL);
+	ASSERT_EQ(ret, 0) << "fi_eq_open failed: " << fi_strerror(-ret);
+
+	fi_ep_bind(resource->ep, &resource->eq->fid, 0);
+
+	ret = fi_av_open(resource->domain, &av_attr, &resource->av, NULL);
+	ASSERT_EQ(ret, 0) << "fi_av_open failed: " << fi_strerror(-ret);
+
+	fi_ep_bind(resource->ep, &resource->av->fid, 0);
+
+	ret = fi_cq_open(resource->domain, &cq_attr, &resource->cq, NULL);
+	ASSERT_EQ(ret, 0) << "fi_cq_open failed: " << fi_strerror(-ret);
+
+	fi_ep_bind(resource->ep, &resource->cq->fid, FI_SEND | FI_RECV);
+
+	ret = fi_enable(resource->ep);
+	ASSERT_EQ(ret, 0) << "fi_enable failed: " << fi_strerror(-ret);
+}
+
+void efa_test_resource_destruct(struct efa_resource *resource)
+{
+	if (resource->ep) {
+		EXPECT_EQ(fi_close(&resource->ep->fid), 0);
+		resource->ep = NULL;
+	}
+
+	if (resource->eq) {
+		EXPECT_EQ(fi_close(&resource->eq->fid), 0);
+		resource->eq = NULL;
+	}
+
+	if (resource->cq) {
+		EXPECT_EQ(fi_close(&resource->cq->fid), 0);
+		resource->cq = NULL;
+	}
+
+	if (resource->av) {
+		EXPECT_EQ(fi_close(&resource->av->fid), 0);
+		resource->av = NULL;
+	}
+
+	if (resource->domain) {
+		EXPECT_EQ(fi_close(&resource->domain->fid), 0);
+		resource->domain = NULL;
+	}
+
+	if (resource->fabric) {
+		EXPECT_EQ(fi_close(&resource->fabric->fid), 0);
+		resource->fabric = NULL;
+	}
+
+	if (resource->info) {
+		fi_freeinfo(resource->info);
+		resource->info = NULL;
+	}
+
+	if (resource->hints) {
+		fi_freeinfo(resource->hints);
+		resource->hints = NULL;
+	}
+}

--- a/prov/efa/test/gtest/efa_gtest_common_resource.h
+++ b/prov/efa/test/gtest/efa_gtest_common_resource.h
@@ -1,0 +1,69 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#ifndef EFA_GTEST_COMMON_RESOURCE_H
+#define EFA_GTEST_COMMON_RESOURCE_H
+
+#include <gtest/gtest.h>
+#include <rdma/fabric.h>
+#include <rdma/fi_cm.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_eq.h>
+
+#define EFA_FABRIC_NAME	       "efa"
+#define EFA_DIRECT_FABRIC_NAME "efa-direct"
+
+#define MR_MODE_BITS \
+	(FI_MR_VIRT_ADDR | FI_MR_ALLOCATED | FI_MR_PROV_KEY | FI_MR_LOCAL)
+
+struct efa_resource {
+	struct fi_info *hints;
+	struct fi_info *info;
+	struct fid_fabric *fabric;
+	struct fid_domain *domain;
+	struct fid_ep *ep;
+	struct fid_eq *eq;
+	struct fid_av *av;
+	struct fid_cq *cq;
+};
+
+/**
+ * @brief Allocate a default fi_info hints struct for testing.
+ * Sets the endpoint type, fabric name, MR mode bits, and mode flags
+ * appropriate for the given fabric/endpoint type.
+ *
+ * @param[in]	ep_type		endpoint type (FI_EP_RDM or FI_EP_DGRAM)
+ * @param[in]	fabric_name	fabric name (EFA_FABRIC_NAME or
+ * EFA_DIRECT_FABRIC_NAME)
+ * @return	allocated hints struct (caller frees via fi_freeinfo), or NULL
+ * on failure
+ */
+struct fi_info *efa_test_alloc_default_hints(enum fi_ep_type ep_type,
+					     const char *fabric_name);
+
+/**
+ * @brief Construct a full set of OFI resources for testing.
+ * Creates fabric, domain, endpoint, EQ, AV, and CQ, then enables the endpoint.
+ * Uses gtest ASSERT macros — test is aborted on any failure.
+ *
+ * @param[out]	resource	struct to populate with created resources
+ * @param[in]	hints		hints struct passed to fi_getinfo; ownership is
+ *				transferred to resource (freed by destruct). The
+ *				ep type and fabric name are taken from hints;
+ * the API version is derived from the fabric name. Typically
+ * efa_test_alloc_default_hints(ep_type, fabric_name).
+ */
+void efa_test_resource_construct(struct efa_resource *resource,
+				 struct fi_info *hints);
+
+/**
+ * @brief Destroy all OFI resources in the resource struct.
+ * Closes resources in correct order. Uses gtest EXPECT macros so that
+ * all cleanup is attempted even if one close fails.
+ *
+ * @param[in,out]	resource	struct with resources to close
+ */
+void efa_test_resource_destruct(struct efa_resource *resource);
+
+#endif /* EFA_GTEST_COMMON_RESOURCE_H */

--- a/prov/efa/test/gtest/efa_gtest_conn.cc
+++ b/prov/efa/test/gtest/efa_gtest_conn.cc
@@ -1,0 +1,89 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#include "efa_gtest_common_helpers.h"
+#include "efa_gtest_common_mocks.h"
+#include "efa_gtest_common_resource.h"
+#include <gtest/gtest.h>
+
+using testing::Test;
+using testing::_;
+using testing::Return;
+using testing::Invoke;
+using testing::StrictMock;
+
+class EfaConnTest : public Test
+{
+	protected:
+	struct efa_resource resource = {};
+	StrictMock<MockEfa> mock_efa;
+
+	void SetUp() override
+	{
+		memset(&resource, 0, sizeof(resource));
+	}
+
+	void TearDown() override
+	{
+		efa_test_resource_destruct(&resource);
+		MockEfa::set(nullptr);
+	}
+};
+
+/**
+ * @brief Test that efa_conn_alloc cleans up RDM resources when
+ * efa_av_reverse_av_add fails (efa_conn.c:304-316).
+ * Verifies the cleanup path calls efa_conn_rdm_deinit without crash.
+ */
+TEST_F(EfaConnTest, alloc_reverse_av_add_failure_rdm_cleanup)
+{
+	fi_addr_t addr;
+	static struct ibv_ah dummy_ibv_ah;
+
+	efa_test_resource_construct(
+		&resource,
+		efa_test_alloc_default_hints(FI_EP_RDM, EFA_FABRIC_NAME));
+	ASSERT_NE(resource.ep, nullptr);
+
+	MockEfa::set(&mock_efa);
+	EXPECT_CALL(mock_efa, ibv_create_ah(_, _))
+		.WillOnce(Return(&dummy_ibv_ah));
+	EXPECT_CALL(mock_efa, ibv_destroy_ah(_)).WillRepeatedly(Return(0));
+	EXPECT_CALL(mock_efa, efadv_query_ah(_, _, _))
+		.WillRepeatedly(Return(0));
+	EXPECT_CALL(mock_efa, efa_av_reverse_av_add(_, _, _, _))
+		.WillOnce(Return(-FI_ENOMEM));
+
+	addr = efa_test_insert_peer_new_gid(resource.ep, resource.av);
+	EXPECT_EQ(addr, (fi_addr_t) FI_ADDR_NOTAVAIL);
+}
+
+/**
+ * @brief Test that efa_conn_alloc cleans up RDM resources when
+ * efa_av_reverse_av_add fails via the explicit fi_av_insert path
+ * (insert_implicit_av=false). The explicit path acquires the SRX lock
+ * itself before calling efa_av_insert_one.
+ */
+TEST_F(EfaConnTest, alloc_reverse_av_add_failure_explicit_insert)
+{
+	fi_addr_t addr;
+	int num_addr;
+	static struct ibv_ah dummy_ibv_ah;
+
+	efa_test_resource_construct(
+		&resource,
+		efa_test_alloc_default_hints(FI_EP_RDM, EFA_FABRIC_NAME));
+	ASSERT_NE(resource.ep, nullptr);
+
+	MockEfa::set(&mock_efa);
+	EXPECT_CALL(mock_efa, ibv_create_ah(_, _))
+		.WillOnce(Return(&dummy_ibv_ah));
+	EXPECT_CALL(mock_efa, ibv_destroy_ah(_)).WillRepeatedly(Return(0));
+	EXPECT_CALL(mock_efa, efadv_query_ah(_, _, _))
+		.WillRepeatedly(Return(0));
+	EXPECT_CALL(mock_efa, efa_av_reverse_av_add(_, _, _, _))
+		.WillOnce(Return(-FI_ENOMEM));
+
+	num_addr = efa_test_explicit_av_insert(resource.ep, resource.av, &addr);
+	EXPECT_EQ(num_addr, 0);
+}

--- a/prov/efa/test/gtest/efa_gtest_main.cc
+++ b/prov/efa/test/gtest/efa_gtest_main.cc
@@ -1,8 +1,27 @@
 /* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
 /* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
 
-#include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+/*
+ * Suppress LeakSanitizer reports for rdma-core's load-time driver
+ * registration (verbs_register_driver) and device discovery cache, which
+ * are intentionally never freed. ibv_close_device() properly frees all
+ * per-context state; only these one-time framework allocations persist.
+ *
+ * The cmocka suite doesn't need this because its --wrap=calloc (for OOM
+ * fault injection) accidentally hides rdma-core allocations from LSan.
+ * We don't wrap calloc here to preserve leak detection for genuine leaks.
+ */
+#if __has_include(<sanitizer/lsan_interface.h>)
+#include <sanitizer/lsan_interface.h>
+
+extern "C" const char *__lsan_default_suppressions(void)
+{
+	return "leak:libefa.so\n";
+}
+#endif
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
When `efa_av_reverse_av_add` fails in `efa_conn_alloc`, the cleanup path acquires the SRX lock if `insert_implicit_av` is true. However, the only caller with `insert_implicit_av=true` is the CQ read path, which already holds the SRX lock. The SRX lock is a non-recursive mutex, so this double-lock would deadlock.

In fact, since the explicit path (`efa_av_insert`) also has the SRX lock, the locks in this cleanup path can be removed.

Unit tests to be added in the upcoming gtest framework.