### PR TITLE
prov/efa: Remove trailing white spaces from EFA

### DIFF
--- a/prov/efa/docs/efa_fabric_comparison.md
+++ b/prov/efa/docs/efa_fabric_comparison.md
@@ -43,7 +43,7 @@ EFA fabric implements a more complex, layered approach with protocol emulation:
 - Chooses appropriate protocol based on operation type, message size, and EFA NIC capabilities
 - Allocates `efa_rdm_pke` (EFA-RDM packet entry) structures from buffer pool
 - Each packet entry is a 128-byte data structure allocated from ~8KB buffers (comparable to device MTU size) to support staging wiredata from application when
-necessary. 
+necessary.
 
 - Each `pke` corresponds to a WQE that interacts with EFA device
 - One operation entry can map to multiple packet entries (e.g., a 16KB message can be sent via 2 packet entries)

--- a/prov/efa/docs/efa_rdm_protocol_v4.md
+++ b/prov/efa/docs/efa_rdm_protocol_v4.md
@@ -925,7 +925,7 @@ Like in two-sided communication, there are also two endpoints involved in one-si
 However, only on one side will the application call libfabric's one-sided API (such as `fi_write`,
 `fi_read` and `fi_atomic`). In protocol v4, this side is called the requester.
 
-On the other side (which is called the responder), the application does not make calls to 
+On the other side (which is called the responder), the application does not make calls to
 lifabric's API, but the EFA provider requires the application to keep the progress engine running
 to facilitate the communication. This is because the EFA provider only supports `FI_PROGRESS_MANUAL`.
 
@@ -1489,7 +1489,7 @@ Address Handle Number (AHN) and QPN of a received packet. Because the GID can be
 the only unknown part is CONNID.
 
 The extra request "connid header" was introduced to address the issue. Also because this is an extra request,
-an endpoint cannot assume that the peer supports it, thus the endpoint needs to be able to handle the case 
+an endpoint cannot assume that the peer supports it, thus the endpoint needs to be able to handle the case
 that incoming packets do not have the sender connection ID in it. It is up to the implementation to decide
 whether the endpoint should abort the communication or continue without using the extra request in this case.
 
@@ -1572,8 +1572,8 @@ peer's handshake status or `extra_info`. The `EFA_RDM_EXTRA_FEATURE_READ_NACK` f
 advertised in `extra_info` for backwards compatibility with v2.0 peers that check for it.**
 
 Long read and runting read protocols in Libfabric 1.20 and above use a nack protocol
-when the receiver is unable to register a memory region for the RDMA read operation 
-or P2P support is unavailable for the RDMA read operation, typically because of a 
+when the receiver is unable to register a memory region for the RDMA read operation
+or P2P support is unavailable for the RDMA read operation, typically because of a
 hardware limitation.
 
 Table: 4.2 Format of the READ_NACK packet
@@ -1593,9 +1593,9 @@ The nack protocols work as follows
    - One LONGREAD_RTM packet in case of long read protocol
    - Multiple RUNTREAD_RTM packets in case of runting read protocol
    - One LONGREAD_RTW packet in case of emulated long-read write protocol
-* The receiver attempts to register a memory region for the RDMA operation but fails, 
+* The receiver attempts to register a memory region for the RDMA operation but fails,
 or P2P is unavailable for the RDMA operation
-* After all RTM/RTW packets have been processed, the receiver sends a READ_NACK packet to the sender 
+* After all RTM/RTW packets have been processed, the receiver sends a READ_NACK packet to the sender
 * The sender then switches to the long CTS protocol and sends a LONGCTS_RTM/LONGCTS_RTW packet
 * The receiver sends a CTS packet and the data transfer continues as in the long CTS protocol
 

--- a/prov/efa/docs/pkt-processing.md
+++ b/prov/efa/docs/pkt-processing.md
@@ -21,14 +21,14 @@ in progress, sends and receives queued due to resource exhaustion, unexpected
 messages, and structures to track out of order packets and remote peer
 capabilities and status.
 
-`efa_rdm_ope` contains information and structures used in send/receive operations. 
-It is used in send operation for send posted directly by the app or indirectly 
-by emulated read/write operations. When the send is completed a send completion 
+`efa_rdm_ope` contains information and structures used in send/receive operations.
+It is used in send operation for send posted directly by the app or indirectly
+by emulated read/write operations. When the send is completed a send completion
 will be written and the txe (TX entry) will be released.
-It is used in  receive operation for a receive posted by the app. This structure 
-is used for tag matching, to queue unexpected messages to be matched later, and to 
+It is used in  receive operation for a receive posted by the app. This structure
+is used for tag matching, to queue unexpected messages to be matched later, and to
 keep track of whether long message receives are completed. Just like the txe,
-when a receive operation is completed a receive completion is written to the app 
+when a receive operation is completed a receive completion is written to the app
 and the `rxe` (RX entry) is released.
 
 `efa_rdm_cq_progress` is the progress handler we register when the completion queue

--- a/prov/efa/docs/util_cq_bypass.md
+++ b/prov/efa/docs/util_cq_bypass.md
@@ -87,7 +87,7 @@ sequenceDiagram
     Note over DeviceCQ,Application: Normal Operation - Direct Path
     DeviceCQ->>Provider: Completion Event
     Provider->>Application: Write directly to application buffer
-    
+
     Note over DeviceCQ,Application: EP Close Scenario
     Provider->>UtilCQ: Flush outstanding entries during EP close
     Application->>Provider: Poll for completion
@@ -127,7 +127,7 @@ sequenceDiagram
     DeviceCQ->>Provider: CQE 3 (Error)
     Provider->>Provider: Stop processing at error
     Provider->>Application: Return 2 (successful entries)
-    
+
     Note over DeviceCQ,Provider: Device CQ remains in poll-active state
     Note over DeviceCQ,Provider: Error CQE cached for next call
 ```
@@ -144,7 +144,7 @@ sequenceDiagram
     Application->>Provider: fi_cq_read(cq_fid, buf, count)
     Provider->>Provider: Process cached error CQE
     Provider->>Application: Return -FI_EAVAIL
-    
+
     Note over DeviceCQ,Provider: Device CQ remains in poll-active state
     Note over DeviceCQ,Provider: Error must be consumed via fi_cq_readerr
 ```
@@ -161,7 +161,7 @@ sequenceDiagram
     Provider->>Application: Copy error details to err_buf
     Provider->>DeviceCQ: End polling (ibv_end_poll)
     Provider->>Application: Return 1 (error consumed)
-    
+
     Note over DeviceCQ,Provider: Device CQ poll state ended
     Note over DeviceCQ,Provider: Next fi_cq_read can start fresh polling
 ```

--- a/prov/efa/src/efa_cq.c
+++ b/prov/efa/src/efa_cq.c
@@ -304,7 +304,7 @@ static void efa_cq_handle_rx_completion(struct efa_base_ep *base_ep,
  * This function handles hardware-assisted RDMA writes with immediate data at
  * remote endpoint.  These do not have a packet context, nor do they have a
  * connid available.
- * 
+ *
  * @param[in]		base_ep     efa_base_ep
  * @param[in]		ibv_cq_ex   extended ibv cq
  */
@@ -340,7 +340,7 @@ efa_cq_proc_ibv_recv_rdma_with_imm_completion(struct efa_base_ep *base_ep,
 /**
  * @brief poll rdma-core cq and process the cq entry
  *
- * @param[in]	cqe_to_process    Max number of cq entry to poll and process. 
+ * @param[in]	cqe_to_process    Max number of cq entry to poll and process.
  * A negative number means to poll until cq empty.
  * @param[in]   util_cq           util_cq
  */
@@ -567,7 +567,7 @@ int efa_cq_trywait(struct efa_cq *cq) {
 
 /**
  * @brief Poll for completion events with timeout.
- * 
+ *
  * ibv_get_cq_event() waits for the next completion event in the
  * completion event channel. Fills the arguments cq with the
  * CQ that got the event and cq_context with the CQ's context.
@@ -613,7 +613,7 @@ int efa_poll_events(struct efa_cq *cq, int timeout)
 		ofi_atomic_inc32(&cq->nevents);
 		rc--;
 	}
-	
+
 	if (fds[1].revents & POLLIN) {
 		EFA_INFO(FI_LOG_CQ, "efa_poll_events: signal FD triggered by fi_cq_signal\n");
 		fd_signal_reset(&cq->signal);
@@ -691,8 +691,8 @@ static ssize_t efa_cq_sreadfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 			ret = efa_poll_events(cq, timeout);
 			if (ret && ret != -FI_EAGAIN)
 				break;
-		} 
-		
+		}
+
 		ret = cq->util_cq.cq_fid.ops->readfrom(&cq->util_cq.cq_fid, buffer, count - num_completions, src_addr ? src_addr + num_completions : NULL);
 		if (ret > 0) {
 			buffer += ret * cq->entry_size;
@@ -721,7 +721,7 @@ static ssize_t efa_cq_sread(struct fid_cq *cq_fid, void *buf, size_t count,
  * This may be used to wake-up a thread that is blocked waiting to read a
  * completion operation. The fi_cq_signal operation is only available if the CQ
  * was configured with a wait object.
- * 
+ *
  * Returns 0 on success. On error, returns a negative fabric errno.
  */
 int efa_cq_signal(struct fid_cq *cq_fid)
@@ -948,22 +948,22 @@ int efa_cq_close(fid_t fid)
 /**
  * @brief
  * The fi_control call is used to access provider or implementation specific
- * details of the completion queue. Users may use fi_control to retrieve the 
- * underlying wait object associated with a CQ, in order to use it in other 
+ * details of the completion queue. Users may use fi_control to retrieve the
+ * underlying wait object associated with a CQ, in order to use it in other
  * system calls. The following control commands are usable with a CQ.
- * 
+ *
  * FI_GETWAIT
  * This command allows the user to retrieve the low-level wait object associated
- * with the CQ. 
- * 
+ * with the CQ.
+ *
  * FI_GETWAITOBJ
- * This command allows the user to retrieve the type of wait object specified 
+ * This command allows the user to retrieve the type of wait object specified
  * during CQ creation, through the CQ attributes.
  *
  * @param[in]	fid		Completion queue fid
  * @param[in]	command	Command of control operation to perform on CQ.
  * @param[out]	arg		Optional control argument. An address where a
- * pointer to the returned wait object will be written. This should be an 
+ * pointer to the returned wait object will be written. This should be an
  * ‘int *’ for FI_WAIT_FD.
  *
  * @return Returns 0 on success. On error, returns a negative fabric errno.

--- a/prov/efa/src/efa_errno.h
+++ b/prov/efa/src/efa_errno.h
@@ -21,7 +21,7 @@
 
 
 /** @defgroup EfaErrnoXMacros EFA error-handling X macros
- * 
+ *
  * The macros described here are [X
  * macros](https://en.wikipedia.org/wiki/X_macro) or "higher-order" macros,
  * which are designed to take a function-like macro as the sole argument to

--- a/prov/efa/src/efa_hmem.c
+++ b/prov/efa/src/efa_hmem.c
@@ -427,7 +427,7 @@ int efa_hmem_validate_p2p_opt(enum fi_hmem_iface iface, int p2p_opt, uint32_t ap
 	 *     PREFERED means a provider should prefer P2P if it is available.
 	 *
 	 * These options does not require that p2p is supported by device,
-	 * nor do they prohibit that p2p is required by implementation. 
+	 * nor do they prohibit that p2p is required by implementation.
 	 * Therefore they are always supported unless p2p is disabled.
 	 */
 	case FI_HMEM_P2P_PREFERRED:

--- a/prov/efa/src/efa_hw_cntr.c
+++ b/prov/efa/src/efa_hw_cntr.c
@@ -100,8 +100,8 @@ static void efa_hw_cntr_no_progress(struct util_cntr *cntr)
 	 * operations when the SQ or RQ is full. Per the fi_cq man page,
 	 * applications size their CQ to at least the same size as the
 	 * endpoint queues bound to it, so a full SQ/RQ implies the CQ is also
-	 * full. The application must periodically call fi_cq_read() when getting 
-	 * -FI_EAGAIN to consume entries and prevent CQ overrun, even with 
+	 * full. The application must periodically call fi_cq_read() when getting
+	 * -FI_EAGAIN to consume entries and prevent CQ overrun, even with
 	 * FI_SELECTIVE_COMPLETION set.
 	 */
 }

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -385,7 +385,7 @@ static struct ibv_mr *efa_mr_reg_ibv_mr(struct efa_mr *efa_mr,
 					  (void *)mr_attr->mr_iov->iov_base,
 					  mr_attr->mr_iov->iov_len, access);
 		}
-		
+
 		/* get fd failed, no fallback */
 		EFA_WARN(FI_LOG_MR,
 			 "ofi_hmem_get_dmabuf_fd failed for %s: ret=%d (%s)\n",
@@ -528,7 +528,7 @@ static int efa_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	device_support_rdma_write = domain->device->device_caps & EFADV_DEVICE_ATTR_CAPS_RDMA_WRITE;
 #endif
 
-	/* For efa-direct, fail registration if RDMA operations are requested 
+	/* For efa-direct, fail registration if RDMA operations are requested
 	 * but hardware doesn't support them
 	 */
 	if ((attr->access & (FI_READ | FI_REMOTE_READ)) &&

--- a/prov/efa/src/efa_user_info.c
+++ b/prov/efa/src/efa_user_info.c
@@ -112,8 +112,8 @@ int efa_user_info_check_fabric_object(const struct fi_info *hints,
 	if (strcmp(util_fabric->name, prov_info->fabric_attr->name))
 		return -FI_EINVAL;
 
-	ret = ofi_check_fabric_attr(efa_util_prov.prov, 
-				    prov_info->fabric_attr, 
+	ret = ofi_check_fabric_attr(efa_util_prov.prov,
+				    prov_info->fabric_attr,
 				    &fabric_attr);
 	if (ret) {
 		EFA_WARN(FI_LOG_CORE, "Fabric attributes validation failed\n");
@@ -512,8 +512,8 @@ int efa_user_info_alter_direct(int version, struct fi_info *info, const struct f
 	 * When application requests FI_RX_CQ_DATA, efa-direct
 	 * will respect it, and will finally disable unsolicited
 	 * write recv during the QP creation.
-	 * 
-	 * For NULL hints, return FI_RMA and FI_RX_CQ_DATA as 
+	 *
+	 * For NULL hints, return FI_RMA and FI_RX_CQ_DATA as
 	 * efa direct can support them.
 	 */
 	if (!hints || (hints && hints->mode & FI_RX_CQ_DATA)) {

--- a/prov/efa/src/rdm/efa_rdm_atomic.c
+++ b/prov/efa/src/rdm/efa_rdm_atomic.c
@@ -435,7 +435,7 @@ efa_rdm_atomic_compwritemsg(struct fid_ep *ep,
 	struct efa_rdm_atomic_ex atomic_ex = {
 		.resp_iov_count = result_count,
 		.comp_iov_count = compare_count,
-		
+
 	};
 	size_t datatype_size;
 	fi_addr_t shm_addr;

--- a/prov/efa/src/rdm/efa_rdm_cq.c
+++ b/prov/efa/src/rdm/efa_rdm_cq.c
@@ -614,7 +614,7 @@ static void efa_rdm_cq_handle_recv_completion(struct efa_ibv_cq *ibv_cq, struct 
  * @todo Currently, this only checks for unresponsive receiver
  * (#EFA_IO_COMP_STATUS_LOCAL_ERROR_UNRESP_REMOTE) and attempts to promote it to
  * #FI_EFA_ERR_ESTABLISHED_RECV_UNRESP if a handshake was made, or
- * #FI_EFA_ERR_UNESTABLISHED_RECV_UNRESP if the handshake failed. 
+ * #FI_EFA_ERR_UNESTABLISHED_RECV_UNRESP if the handshake failed.
  * This should be expanded to handle other
  * RDMA Core error codes (#EFA_IO_COMP_STATUSES) for the sake of more accurate
  * error reporting
@@ -778,7 +778,7 @@ enum ibv_wc_status efa_rdm_cq_process_wc(struct efa_ibv_cq *cq, struct efa_rdm_e
 				 * EFA-RDM does not require FI_RX_CQ_DATA, so NULL context is safe here.
 				 */
 				struct fi_cq_err_entry err_entry = {0};
-				
+
 				EFA_INFO(FI_LOG_CQ, "Receive error %s (%d) for unsolicited write recv",
 					efa_strerror(prov_errno), prov_errno);
 				err_entry.op_context = NULL;
@@ -935,7 +935,7 @@ static ssize_t efa_rdm_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t coun
 	if (cq->shm_cq) {
 		fi_cq_read(cq->shm_cq, NULL, 0);
 
-		/* 
+		/*
 		 * fi_cq_read(cq->shm_cq, NULL, 0) will progress shm ep and write
 		 * completion to efa. Use ofi_cq_read_entries to get the number of
 		 * shm completions without progressing efa ep again.

--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -137,7 +137,7 @@ void efa_rdm_txe_release(struct efa_rdm_ope *txe)
 	 * Skip removal if receipt was already processed
 	 * (which would have already removed it from the list).
 	 */
-	if (txe->state == EFA_RDM_OPE_SEND && 
+	if (txe->state == EFA_RDM_OPE_SEND &&
 	    !(txe->internal_flags & EFA_RDM_TXE_RECEIPT_RECEIVED))
 		dlist_remove(&txe->entry);
 

--- a/prov/efa/src/rdm/efa_rdm_peer.c
+++ b/prov/efa/src/rdm/efa_rdm_peer.c
@@ -184,7 +184,7 @@ int efa_rdm_peer_reorder_msg(struct efa_rdm_peer *peer, struct efa_rdm_ep *ep,
 			return -FI_EALREADY;
 		} else {
 			/* Current receive window size is too small to hold incoming messages.
-			 * Store the overflow messages in a double linked list, and move it 
+			 * Store the overflow messages in a double linked list, and move it
 			 * back to receive window later.
 			 */
 			struct efa_rdm_peer_overflow_pke_list_entry *overflow_pke_list_entry;
@@ -256,7 +256,7 @@ int efa_rdm_peer_recvwin_queue_or_append_pke(struct efa_rdm_pke *ooo_entry,
  * overflow_pke_list and move the pkt entry to receive window if it fits.
  *
  * @param[in,out]	peer 		peer
- * 
+ *
  */
 void efa_rdm_peer_move_overflow_pke_to_recvwin(struct efa_rdm_peer *peer)
 {

--- a/prov/efa/src/rdm/efa_rdm_peer.h
+++ b/prov/efa/src/rdm/efa_rdm_peer.h
@@ -94,7 +94,7 @@ struct efa_rdm_peer {
 	uint64_t host_id; 		/* Optional peer host id. Default 0 */
 	/**
 	 * @brief reorder buffer
-	 * 
+	 *
 	 * @details temporarily hold packets that are out-of-order, whose msg_id is larger that the one EP is expecting from the peer
 	 */
 	struct efa_rdm_robuf robuf;

--- a/prov/efa/src/rdm/efa_rdm_pke.c
+++ b/prov/efa/src/rdm/efa_rdm_pke.c
@@ -85,7 +85,7 @@ struct efa_rdm_pke *efa_rdm_pke_alloc(struct efa_rdm_ep *ep,
 			return NULL;
 		}
 		pkt_entry->debug_info->counter = 0;
-		memset(pkt_entry->debug_info->entries, 0, 
+		memset(pkt_entry->debug_info->entries, 0,
 		       sizeof(pkt_entry->debug_info->entries));
 	}
 #endif
@@ -805,7 +805,7 @@ ssize_t efa_rdm_pke_recvv(struct efa_rdm_pke **pke_vec,
 
 #if ENABLE_DEBUG
 /* Compile-time assertion that debug_info gen field can hold all possible gen values */
-_Static_assert(EFA_RDM_PKE_DEBUG_GEN_MASK >= EFA_RDM_PACKET_GEN_MASK, 
+_Static_assert(EFA_RDM_PKE_DEBUG_GEN_MASK >= EFA_RDM_PACKET_GEN_MASK,
                "DEBUG_GEN_BITS insufficient to hold EFA_RDM_PACKET_GEN_MASK");
 
 /**

--- a/prov/efa/src/rdm/efa_rdm_pke.h
+++ b/prov/efa/src/rdm/efa_rdm_pke.h
@@ -35,40 +35,40 @@ enum efa_rdm_pke_alloc_type {
 
 /**
  * @brief Packet entry
- * 
+ *
  * efa_rdm_pke (pke stands for packet entry) is used the following occassions:
- * 
+ *
  * First, it is used as the work request ID for the request EFA provider posted to EFA
  * device via rdma-core:
- * 
+ *
  * For each request EFA provider submits to EFA device, it will allocate a packet entry.
- * 
+ *
  * When the request was submitted to rdma-core, the pointer of the packet entry will be used as work
  * request ID (`wr_id`).
- * 
+ *
  * When the request was completed, rdma-core return a completion, with the "wr_id"
  * in it, so EFA provder knows which request has completed.
- * 
+ *
  * Sometimes, the completion can be a Receiver Not Ready (RNR) error completion.
  * In that case the packet entry will be queued and resubmitted. For the resubmission,
  * the packet entry must contain all the information of the request.
- * 
+ *
  * EFA device (rdma-core) supported request types are:
  *  send and receive (by all EFA device)
  *  read and write (by certain EFA device)
- * 
+ *
  * a send/read/write request uses a packet entry allocated from endpoint's efa_tx_pkt_pool.
  * a read request uses a packet entry allocated from efa_rx_pkt_pool. Both pool's memories
  * are registeredd with efa device, the registration is stored in
  * the "mr" field of the packet entry.
- * 
+ *
  * Second, packet entries can be used to store received packet entries that is
  * unexpected or out-of-order. This is because the efa_rx_pkt_pool's size is fixed,
  * therefore it cannot be used to hold unexpected/out-of-order packets. When an unexpected/out-of-order
  * packet is received, a new packet entry will be cloned from unexpected/ooo_pkt_pool.
  * The old packet will be released then reposted to EFA device or SHM. The new packet
  * (allocated from unexpected/ooo_pkt_pool)'s memory is not registered
- * 
+ *
  * Finally, packet entries can be used to support local read copy. Local read copy means
  * to copy data from a packet entry to HMEM receive buffer through EFA device's read capability.
  * Local require a packet entry's memory to be registered with device. If the packet entry's memory
@@ -192,13 +192,13 @@ struct efa_rdm_pke {
 	/** @brief indicate where the memory of this packet entry reside */
 	enum efa_rdm_pke_alloc_type alloc_type;
 
-	/** 
+	/**
 	 * @brief flags indicating the status of the packet entry
-	 * 
+	 *
 	 * @see #EFA_RDM_PKE_IN_USE
 	 * @see #EFA_RDM_PKE_RNR_RETRANSMIT
 	 * @see #EFA_RDM_PKE_LOCAL_READ
-	 * @see #EFA_RDM_PKE_DC_LONGCTS_DATA 
+	 * @see #EFA_RDM_PKE_DC_LONGCTS_DATA
 	 * @see #EFA_RDM_PKE_LOCAL_WRITE
 	 * @see #EFA_RDM_PKE_SEND_TO_USER_RECV_QP
 	 * @see #EFA_RDM_PKE_HAS_NO_BASE_HDR
@@ -218,7 +218,7 @@ struct efa_rdm_pke {
 
 	/**
 	 * @brief a buffer that contains actual user data that is going over wire
-	 * 
+	 *
 	 * @details
 	 * "payload" points to either a location inside user's buffer,
 	 * (when user's buffer is registered with EFA device), or
@@ -230,7 +230,7 @@ struct efa_rdm_pke {
 
 	/**
 	 * @brief memory regstration for user buffer
-	 * 
+	 *
 	 * @details
 	 * payload_mr is same as mr, when payload is pointing to
 	 * a location inside wiredata.
@@ -239,7 +239,7 @@ struct efa_rdm_pke {
 
 	/**
 	 * @brief size of payload buffer
-	 * 
+	 *
 	 */
 	size_t payload_size;
 
@@ -257,10 +257,10 @@ struct efa_rdm_pke {
 	 *
 	 * 1. Packet header. All packet entries have a packet header,
 	 *    except the packet entry allocated from readcopy_pool.
-	 * 
+	 *
 	 * 2. User buffer infomation, which presents
 	 *    only for LONGREAD and RUNTREAD RTM packets.
-	 * 
+	 *
 	 * 3. User data, which presents when:
 	 *    a) pakcet is an outging (TX) packet, and EFA device
 	 *       is not able to send data directory from user's buffer

--- a/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
@@ -226,10 +226,10 @@ int efa_rdm_pke_init_ctsdata(struct efa_rdm_pke *pkt_entry,
 	data_hdr->version = EFA_RDM_PROTOCOL_VERSION;
 	data_hdr->flags = 0;
 
-	/* Data is sent using rxe in the emulated longcts read 
-	 * protocol. The emulated longcts write and the longcts 
+	/* Data is sent using rxe in the emulated longcts read
+	 * protocol. The emulated longcts write and the longcts
 	 * message protocols sends data using txe.
-	 * This check ensures appropriate recv_id is 
+	 * This check ensures appropriate recv_id is
 	 * assigned for the respective protocols */
 	if (ope->type == EFA_RDM_RXE) {
 		data_hdr->recv_id = ope->tx_id;

--- a/prov/efa/src/rdm/efa_rdm_pke_rtm.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtm.c
@@ -682,7 +682,7 @@ ssize_t efa_rdm_pke_proc_matched_eager_rtm(struct efa_rdm_pke *pkt_entry)
 	/*
 	 * On success, efa_rdm_pke_copy_data_to_ope will write rx completion,
 	 * release pkt_entry and rxe
-	 * 
+	 *
 	 * On error, pkt_entry and rxe are released by caller.
 	 */
 	err = efa_rdm_pke_copy_payload_to_ope(pkt_entry, rxe);

--- a/prov/efa/src/rdm/efa_rdm_pke_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_utils.c
@@ -77,7 +77,7 @@ ssize_t efa_rdm_pke_init_payload_from_ope(struct efa_rdm_pke *pke,
 	 * and we use 1st iov for header.
 	 * 2. p2p is available.
 	 * Note that FI_INJECT requires outbound buffer to be reusable
-	 * immediately after function returns, so a copy from the user buffer 
+	 * immediately after function returns, so a copy from the user buffer
 	 * to the internal bounce buffer is needed.
 	 */
 	/* TODO: Disable copies when total packet size with payload is smaller
@@ -230,7 +230,7 @@ int efa_rdm_pke_queued_copy_payload_to_hmem(struct efa_rdm_pke *pke,
  * api.
  *
  * gdrcopy, which is available only when cuda_is_gdrcopy_enabled() is true.
- * 
+ *
  * @param[in]			ep, efa_mr
  * @param[in,out]		local_read_available, cuda_memcpy_available,
  * gdrcopy_available

--- a/prov/efa/src/rdm/efa_rdm_pke_utils.h
+++ b/prov/efa/src/rdm/efa_rdm_pke_utils.h
@@ -157,7 +157,7 @@ efa_rdm_pke_copy_from_hmem_iov(struct efa_rdm_mr *iov_mr, struct efa_rdm_pke *pk
 	return copied;
 }
 
-/** 
+/**
  * @brief This function either posts RDMA read, or sends a NACK packet when p2p
  * is not available or memory registration limit was reached on the receiver.
  *

--- a/prov/efa/src/rdm/efa_rdm_protocol.h
+++ b/prov/efa/src/rdm/efa_rdm_protocol.h
@@ -291,7 +291,7 @@ EFA_RDM_ENSURE_HEADER_SIZE(efa_rdm_read_nack_hdr, 16);
 /**
  * @brief header format of ATOMRSP packet. (Packet Type ID 8)
  * ATOMRSP packet is used in emulated fetch/compare atomic sub-protocol.
- * 
+ *
  * It is sent from responder to requester, which contains the response
  * to a fetch/compare atomic request
  */

--- a/prov/efa/src/windows/README.Efawin
+++ b/prov/efa/src/windows/README.Efawin
@@ -1,6 +1,6 @@
 Efawin headers and loader can be obtained from https://github.com/aws/efawin.
 
-Copy the contents of the folder including subfolders from 
+Copy the contents of the folder including subfolders from
 https://github.com/aws/efawin/tree/v1.0.0/interface
 into the folder containing this file.
 

--- a/prov/efa/test/README.md
+++ b/prov/efa/test/README.md
@@ -27,7 +27,7 @@ If `make check` fails, then directly executing the test executable also works
 
 ## What Should be Tested
 1. We are biased toward testing public, stable functions, e.g. we prefer testing `fi_*` to `efa_*` - the former more closely resembles real user behavior.
-1. We make a conscious trade-off to test larger rather than smaller units. A large test unit consists of more state variables, and testing it gives us more confidence in the overall system. 
+1. We make a conscious trade-off to test larger rather than smaller units. A large test unit consists of more state variables, and testing it gives us more confidence in the overall system.
 1. We avoid testing `static` functions that are implementation details and subject to frequent changes. More importantly, `static` function tests have to be written in the same source files and difficult to manage in a central place.
 1. We are biased toward testing edge cases over "happy cases", especially if the code path under test cannot be covered by integration tests.
 

--- a/prov/efa/test/efa_unit_test_av.c
+++ b/prov/efa/test/efa_unit_test_av.c
@@ -777,7 +777,7 @@ void test_ah_refcnt(struct efa_resource **state)
 	ofi_genlock_unlock(&efa_rdm_ep->base_ep.domain->srx_lock);
 
 	efa_ah = peer->conn->ah;
-	
+
 	assert_int_equal(g_ibv_ah_cnt, 2);
 
 	assert_int_equal(HASH_CNT(hh, efa_domain->ah_map), 1);
@@ -787,7 +787,7 @@ void test_ah_refcnt(struct efa_resource **state)
 	/* Move implicit AV entry to explicit AV entry */
 	err = fi_av_insert(resource->av, &raw_addr, 1, &fi_addr, 0, NULL);
 	assert_int_equal(err, 1);
-	
+
 	assert_int_equal(g_ibv_ah_cnt, 2);
 
 	assert_int_equal(HASH_CNT(hh, efa_domain->ah_map), 1);

--- a/prov/efa/test/efa_unit_test_cq.c
+++ b/prov/efa/test/efa_unit_test_cq.c
@@ -1492,12 +1492,12 @@ static void test_efa_cq_data_path_direct_status(
 	if (ret && wait_obj != FI_WAIT_NONE)
 		/* EFA device doesn't support cq notification. */
 		return;
-		
+
 	assert_int_equal(ret, 0);
 	efa_cq = container_of(cq, struct efa_cq, util_cq.cq_fid);
 
 	assert_true(efa_cq->ibv_cq.data_path_direct_enabled == data_path_direct_enabled);
-	
+
 	assert_int_equal(fi_close(&cq->fid), 0);
 
 	/* Recover the mocked vendor_id */
@@ -2199,7 +2199,7 @@ void test_efa_cq_readerr_util_cq_error(struct efa_resource **state)
  * when efa_cq_start_poll is called while poll is already active, and that
  * the fix properly handles destroyed QPs during CQ polling.
  *
- * Scenario: fi_cq_read hits completion error -> fi_close(ep) destroys QP and 
+ * Scenario: fi_cq_read hits completion error -> fi_close(ep) destroys QP and
  * calls efa_cq_poll_ibv_cq -> should handle NULL base_ep gracefully
  */
 void test_efa_cq_poll_ep_close_bypass_path(struct efa_resource **state)

--- a/prov/efa/test/efa_unit_test_data_path_ops.c
+++ b/prov/efa/test/efa_unit_test_data_path_ops.c
@@ -3,7 +3,7 @@
 
 /*
  * Unit test stub versions of EFA data path operations
- * 
+ *
  * This file provides stub implementations of the data path operations
  * specifically for unit testing. These functions are needed because
  * static inline functions cannot have their addresses taken for

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -2036,7 +2036,7 @@ static void test_efa_base_ep_construct_ibv_qp_init_attr_ex_use_requested_limits(
 	assert_int_equal(efa_base_ep->info->rx_attr->size, rx_size);
 
 	/* Call the function under test */
-	efa_base_ep_construct_ibv_qp_init_attr_ex(efa_base_ep, &attr_ex, 
+	efa_base_ep_construct_ibv_qp_init_attr_ex(efa_base_ep, &attr_ex,
 							  efa_cq->ibv_cq.ibv_cq_ex, efa_cq->ibv_cq.ibv_cq_ex);
 
 	/* Since requested values are within device limits, QP attrs should match requested values */
@@ -2178,7 +2178,7 @@ void test_efa_base_ep_construct_ibv_qp_init_attr_ex_efa_use_device_limits(struct
 	assert_int_equal(efa_base_ep->info->rx_attr->iov_limit, resource->info->rx_attr->iov_limit);
 
 	/* Call the function under test */
-	efa_base_ep_construct_ibv_qp_init_attr_ex(efa_base_ep, &attr_ex, 
+	efa_base_ep_construct_ibv_qp_init_attr_ex(efa_base_ep, &attr_ex,
 							  efa_cq->ibv_cq.ibv_cq_ex, efa_cq->ibv_cq.ibv_cq_ex);
 
 	/* Since EFA fabric limits can be equal or larger than device limits,

--- a/prov/efa/test/efa_unit_test_info.c
+++ b/prov/efa/test/efa_unit_test_info.c
@@ -337,7 +337,7 @@ void test_info_tx_rx_msg_order_dgram_order_sas(struct efa_resource **state)
 
 /**
  * @brief Verify max order size is set correctly according to hints
- * 
+ *
  * @param hints hints
  * @param expected_ret expected rc of fi_getinfo
  * @param expected_size expected value of max_order_*_size. Ignored when expected_ret is non-zero.
@@ -830,11 +830,11 @@ void test_efa_use_device_rdma_opt_old() {
 	test_use_device_rdma(0, 0, 0, FI_VERSION(1,17));
 }
 
-typedef void (*setup_hints_func_t)(struct fi_info *hints, struct fid_fabric *fabric, 
+typedef void (*setup_hints_func_t)(struct fi_info *hints, struct fid_fabric *fabric,
 				   struct fid_domain *domain, struct fi_info *info1);
 
-static void test_info_reuse_fabric_domain(setup_hints_func_t setup_func, 
-				   bool expect_fabric_reuse, 
+static void test_info_reuse_fabric_domain(setup_hints_func_t setup_func,
+				   bool expect_fabric_reuse,
 				   bool expect_domain_reuse)
 {
 	struct fi_info *hints1, *hints2, *info1, *info2;
@@ -877,7 +877,7 @@ static void test_info_reuse_fabric_domain(setup_hints_func_t setup_func,
 	} else {
 		assert_null(info2->fabric_attr->fabric);
 	}
-	
+
 	if (expect_domain_reuse) {
 		assert_ptr_equal(info2->domain_attr->domain, domain);
 		assert_string_equal(info2->fabric_attr->name, util_domain->fabric->name);
@@ -906,25 +906,25 @@ static void test_info_reuse_fabric_domain(setup_hints_func_t setup_func,
 	assert_int_equal(err, 0);
 }
 
-static void setup_fabric_attr_hints(struct fi_info *hints, struct fid_fabric *fabric, 
+static void setup_fabric_attr_hints(struct fi_info *hints, struct fid_fabric *fabric,
 				     struct fid_domain *domain, struct fi_info *info1)
 {
 	hints->fabric_attr->fabric = fabric;
 }
 
-static void setup_domain_attr_hints(struct fi_info *hints, struct fid_fabric *fabric, 
+static void setup_domain_attr_hints(struct fi_info *hints, struct fid_fabric *fabric,
 				     struct fid_domain *domain, struct fi_info *info1)
 {
 	hints->domain_attr->domain = domain;
 }
 
-static void setup_fabric_name_hints(struct fi_info *hints, struct fid_fabric *fabric, 
+static void setup_fabric_name_hints(struct fi_info *hints, struct fid_fabric *fabric,
 				     struct fid_domain *domain, struct fi_info *info1)
 {
 	hints->fabric_attr->name = strdup(info1->fabric_attr->name);
 }
 
-static void setup_domain_name_hints(struct fi_info *hints, struct fid_fabric *fabric, 
+static void setup_domain_name_hints(struct fi_info *hints, struct fid_fabric *fabric,
 				     struct fid_domain *domain, struct fi_info *info1)
 {
 	hints->domain_attr->name = strdup(info1->domain_attr->name);
@@ -966,9 +966,9 @@ void test_info_reuse_domain_via_name()
 	test_info_reuse_fabric_domain(setup_domain_name_hints, true, true);
 }
 
-static void test_info_direct_rma_common(bool mock_unsolicited_write_recv, 
+static void test_info_direct_rma_common(bool mock_unsolicited_write_recv,
 					bool set_rma, bool set_rx_cq_data,
-					int expected_err, size_t expected_cq_data_size, 
+					int expected_err, size_t expected_cq_data_size,
 					bool expect_rx_cq_data_mode, bool expect_rma_caps)
 {
 	struct fi_info *hints, *info;

--- a/prov/efa/test/efa_unit_test_pke.c
+++ b/prov/efa/test/efa_unit_test_pke.c
@@ -371,9 +371,9 @@ void test_efa_rdm_pke_flag_tracking(struct efa_resource **state)
 
 
 /**
- * @brief Test efa_rdm_pke_proc_matched_eager_rtm doesn't free pkt_entry on error 
+ * @brief Test efa_rdm_pke_proc_matched_eager_rtm doesn't free pkt_entry on error
  * because it is handled by the caller.
- * 
+ *
  *
  * @param state
  */
@@ -422,7 +422,7 @@ void test_efa_rdm_pke_proc_matched_eager_rtm_error(struct efa_resource **state)
 /**
  * @brief Helper function to create a medium RTM packet
  */
-static struct efa_rdm_pke *create_medium_rtm_pkt(struct efa_rdm_ep *ep, uint32_t msg_id, 
+static struct efa_rdm_pke *create_medium_rtm_pkt(struct efa_rdm_ep *ep, uint32_t msg_id,
                                                  uint64_t msg_length, uint64_t seg_offset,
                                                  size_t payload_size)
 {
@@ -453,7 +453,7 @@ static struct efa_rdm_pke *create_medium_rtm_pkt(struct efa_rdm_ep *ep, uint32_t
 
 /**
  * @brief Test efa_rdm_pke_proc_matched_mulreq_rtm doesn't double free the first
- * pkt_entry on error. The first packet should be released by the caller, not 
+ * pkt_entry on error. The first packet should be released by the caller, not
  * by the function itself.
  *
  * @param state
@@ -532,7 +532,7 @@ void test_efa_rdm_pke_proc_matched_mulreq_rtm_second_packet_error(struct efa_res
 	rxe->cq_entry.len = 2048;
 	rxe->total_len = 2048;
 	rxe->bytes_received = 0;
-	rxe->bytes_received_via_mulreq = 0; 
+	rxe->bytes_received_via_mulreq = 0;
 	pkt_entry->ope = rxe;
 
 	g_efa_unit_test_mocks.efa_rdm_pke_copy_payload_to_ope = &efa_mock_efa_rdm_pke_copy_payload_to_ope_return_mock;
@@ -546,7 +546,7 @@ void test_efa_rdm_pke_proc_matched_mulreq_rtm_second_packet_error(struct efa_res
 	/* The function should have:
 	 * 1. NOT released the first packet - caller's responsibility
 	 * 2. Released the second packet - function's responsibility
-	 * 
+	 *
 	 * We only release the first packet here. The second packet should have
 	 * been released by the function when it failed.
 	 */

--- a/prov/efa/test/efa_unit_test_rdm_rma.c
+++ b/prov/efa/test/efa_unit_test_rdm_rma.c
@@ -308,7 +308,7 @@ void test_efa_rdm_rma_read_0_byte_no_shm(struct efa_resource **state)
 	ret = fi_read(resource->ep, NULL, 0, NULL, addr, 0x87654321, 123456, NULL);
 	assert_int_equal(ret, 0);
 	assert_int_equal(efa_rdm_ep->efa_outstanding_tx_ops, 1);
-	
+
 }
 
 void test_efa_rdm_rma_readv_0_byte_no_shm(struct efa_resource **state)
@@ -322,7 +322,7 @@ void test_efa_rdm_rma_readv_0_byte_no_shm(struct efa_resource **state)
 
 	ret = fi_readv(resource->ep, &iov, NULL, 0, addr, 0x87654321, 123456, NULL);
 	assert_int_equal(ret, 0);
-	
+
 }
 
 void test_efa_rdm_rma_readmsg_0_byte_no_shm(struct efa_resource **state)
@@ -340,7 +340,7 @@ void test_efa_rdm_rma_readmsg_0_byte_no_shm(struct efa_resource **state)
 
 	ret = fi_readmsg(resource->ep, &msg, 0);
 	assert_int_equal(ret, 0);
-	
+
 }
 
 void test_efa_rdm_rma_write_0_byte_no_shm(struct efa_resource **state)
@@ -370,7 +370,7 @@ void test_efa_rdm_rma_writev_0_byte_no_shm(struct efa_resource **state)
 
 	ret = fi_writev(resource->ep, &iov, NULL, 0, addr, 0x87654321, 123456, NULL);
 	assert_int_equal(ret, 0);
-	
+
 }
 
 void test_efa_rdm_rma_writemsg_0_byte_no_shm(struct efa_resource **state)
@@ -388,7 +388,7 @@ void test_efa_rdm_rma_writemsg_0_byte_no_shm(struct efa_resource **state)
 
 	ret = fi_writemsg(resource->ep, &msg, 0);
 	assert_int_equal(ret, 0);
-	
+
 }
 
 void test_efa_rdm_rma_writedata_0_byte_no_shm(struct efa_resource **state)
@@ -401,7 +401,7 @@ void test_efa_rdm_rma_writedata_0_byte_no_shm(struct efa_resource **state)
 
 	ret = fi_writedata(resource->ep, NULL, 0, NULL, 0, addr, 0x87654321, 123456, NULL);
 	assert_int_equal(ret, 0);
-	
+
 }
 
 void test_efa_rdm_rma_inject_write_0_byte_no_shm(struct efa_resource **state)
@@ -414,7 +414,7 @@ void test_efa_rdm_rma_inject_write_0_byte_no_shm(struct efa_resource **state)
 
 	ret = fi_inject_write(resource->ep, NULL, 0, addr, 0x87654321, 123456);
 	assert_int_equal(ret, 0);
-	
+
 }
 
 void test_efa_rdm_rma_inject_writedata_0_byte_no_shm(struct efa_resource **state)
@@ -427,7 +427,7 @@ void test_efa_rdm_rma_inject_writedata_0_byte_no_shm(struct efa_resource **state
 
 	ret = fi_inject_writedata(resource->ep, NULL, 0, 0, addr, 0x87654321, 123456);
 	assert_int_equal(ret, 0);
-	
+
 }
 
 void test_efa_rdm_rma_write_0_byte_with_inject_flag(struct efa_resource **state)

--- a/prov/efa/test/efa_unit_test_runt.c
+++ b/prov/efa/test/efa_unit_test_runt.c
@@ -142,8 +142,8 @@ void test_efa_rdm_peer_get_runt_size_cuda_memory_128_multiple_alignment(struct e
 	msg_length = 12000;
 	peer_num_runt_bytes_in_flight = 10240;
 	total_runt_size = 16384;
-	/* 16384 - 10240 is smaller than 12000 (total_len), 
-	 * runt size must be (16384 - 10240) // 128 * 128 = 6144 
+	/* 16384 - 10240 is smaller than 12000 (total_len),
+	 * runt size must be (16384 - 10240) // 128 * 128 = 6144
 	 */
 	expected_runt_size = 6144;
 	test_efa_rdm_peer_get_runt_size_impl(resource, FI_HMEM_CUDA, peer_num_runt_bytes_in_flight, total_runt_size, msg_length, expected_runt_size);
@@ -165,8 +165,8 @@ void test_efa_rdm_peer_get_runt_size_cuda_memory_non_128_multiple_alignment(stru
 	msg_length = 12000;
 	peer_num_runt_bytes_in_flight = 512;
 	total_runt_size = 1004;
-	/* 1004 - 512 is smaller than 12000 (total_len), 
-	 * runt size must be (1004 - 512) // 128 * 128 = 384 
+	/* 1004 - 512 is smaller than 12000 (total_len),
+	 * runt size must be (1004 - 512) // 128 * 128 = 384
 	 */
 	expected_runt_size = 384;
 	test_efa_rdm_peer_get_runt_size_impl(resource, FI_HMEM_CUDA, peer_num_runt_bytes_in_flight, total_runt_size, msg_length, expected_runt_size);


### PR DESCRIPTION
the trailing whitespace is annoying, lets just clean it up.  We won't enforce not adding more, but everyones editors should be turned on to avoid it.