### PR TITLE
prov/efa: drop in-order aligned 128-byte support on RDM endpoints

### DIFF
--- a/man/fi_efa.7.md
+++ b/man/fi_efa.7.md
@@ -175,7 +175,9 @@ provider for AWS Neuron or Habana SynapseAI.
   revisions.
 
 *FI_OPT_EFA_SENDRECV_IN_ORDER_ALIGNED_128_BYTES - bool*
-: This option only applies to the fi_setopt() call.
+: This option only applies to the fi_setopt() call on efa-direct endpoints.
+  RDM endpoints on the efa fabric do not support this option and fi_setopt()
+  will return -FI_EOPNOTSUPP for them.
   It is used to force the endpoint to use in-order send/recv operation for each 128 bytes
   aligned block. Enabling the option will guarantee data inside each 128 bytes
   aligned block being sent and received in order, it will also guarantee data
@@ -184,7 +186,9 @@ provider for AWS Neuron or Habana SynapseAI.
 
 
 *FI_OPT_EFA_WRITE_IN_ORDER_ALIGNED_128_BYTES - bool*
-: This option only applies to the fi_setopt() call.
+: This option only applies to the fi_setopt() call on efa-direct endpoints.
+  RDM endpoints on the efa fabric do not support this option and fi_setopt()
+  will return -FI_EOPNOTSUPP for them from v2.6.x onwards.
   It is used to set the endpoint to use in-order RDMA write operation for each 128 bytes
   aligned block. Enabling the option will guarantee data inside each 128 bytes
   aligned block being written in order, it will also guarantee data to be

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -1789,25 +1789,17 @@ static int efa_rdm_ep_setopt(fid_t fid, int level, int optname,
 			return ret;
 		break;
 	case FI_OPT_EFA_SENDRECV_IN_ORDER_ALIGNED_128_BYTES:
-		if (optlen != sizeof(bool))
-			return -FI_EINVAL;
-		/**
-		 * TODO: support this option after we fix the data copy atomicity
-		 * for general memory types of rx buffer
-		 */
-		EFA_WARN(FI_LOG_EP_CTRL,
-			"FI_OPT_EFA_SENDRECV_IN_ORDER_ALIGNED_128_BYTES is currently not supported\n");
-		return -FI_EOPNOTSUPP;
 	case FI_OPT_EFA_WRITE_IN_ORDER_ALIGNED_128_BYTES:
 		if (optlen != sizeof(bool))
 			return -FI_EINVAL;
-		if (*(bool *)optval) {
-			ret = efa_base_ep_check_qp_in_order_aligned_128_bytes(&efa_rdm_ep->base_ep, IBV_WR_RDMA_WRITE);
-			if (ret)
-				return ret;
-		}
-		efa_rdm_ep->write_in_order_aligned_128_bytes = *(bool *)optval;
-		break;
+		/*
+		 * The 128-byte once-only-delivery guarantee is supported
+		 * only on efa-direct endpoints from v2.6.x onwards.
+		 */
+		EFA_WARN(FI_LOG_EP_CTRL,
+			"In-order aligned 128-byte options are only supported "
+			"on efa-direct endpoints\n");
+		return -FI_EOPNOTSUPP;
 	case FI_OPT_EFA_HOMOGENEOUS_PEERS:
 		if (optlen != sizeof(bool))
 			return -FI_EINVAL;

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -921,62 +921,53 @@ void test_efa_rdm_ep_setopt_homogeneous_peers(struct efa_resource **state)
 }
 
 /**
- * @brief Test fi_enable with different optval of fi_setopt for
- * FI_OPT_EFA_WRITE_IN_ORDER_ALIGNED_128_BYTES optname.
+ * @brief Test fi_setopt for FI_OPT_EFA_WRITE_IN_ORDER_ALIGNED_128_BYTES on
+ * RDM endpoints.
+ *
+ * The 128-byte once-only-delivery guarantee is supported only on
+ * efa-direct endpoints; the RDM provider rejects the option
+ * unconditionally with -FI_EOPNOTSUPP, regardless of underlying
+ * device capability or the requested optval. The `*_good` and
+ * `*_bad` wrappers exercise both optval paths under separate
+ * cmocka setup/teardown so each test gets a fresh endpoint and
+ * neither leaks resources from the other.
+ *
  * @param state struct efa_resource that is managed by the framework
- * @param expected_status expected return status of fi_enable
  * @param optval the optval passed to fi_setopt
  */
-void test_efa_rdm_ep_enable_qp_in_order_aligned_128_bytes_common(struct efa_resource **state, int expected_status, bool optval)
+void test_efa_rdm_ep_enable_qp_in_order_aligned_128_bytes_common(struct efa_resource **state, bool optval)
 {
 	struct efa_resource *resource = *state;
 
 	efa_unit_test_resource_construct_ep_not_enabled(resource, FI_EP_RDM, EFA_FABRIC_NAME);
 
-	/* fi_setopt should always succeed */
 	assert_int_equal(fi_setopt(&resource->ep->fid, FI_OPT_ENDPOINT,
 				   FI_OPT_EFA_WRITE_IN_ORDER_ALIGNED_128_BYTES, &optval,
-				   sizeof(optval)), expected_status);
+				   sizeof(optval)),
+			 -FI_EOPNOTSUPP);
 }
 
-#if HAVE_EFA_DATA_IN_ORDER_ALIGNED_128_BYTES
 /**
- * @brief Test the case where fi_enable should return success
+ * @brief Verify RDM rejects FI_OPT_EFA_WRITE_IN_ORDER_ALIGNED_128_BYTES
+ *        with optval=true.
  *
  * @param state struct efa_resource that is managed by the framework
  */
 void test_efa_rdm_ep_enable_qp_in_order_aligned_128_bytes_good(struct efa_resource **state)
 {
-	/* mock ibv_query_qp_data_in_order to return required capability */
-	g_efa_unit_test_mocks.ibv_query_qp_data_in_order = &efa_mock_ibv_query_qp_data_in_order_return_in_order_aligned_128_bytes;
-	test_efa_rdm_ep_enable_qp_in_order_aligned_128_bytes_common(state, FI_SUCCESS, true);
+	test_efa_rdm_ep_enable_qp_in_order_aligned_128_bytes_common(state, true);
 }
 
 /**
- * @brief Test the case where fi_enable should return -FI_EOPNOTSUPP
+ * @brief Verify RDM rejects FI_OPT_EFA_WRITE_IN_ORDER_ALIGNED_128_BYTES
+ *        with optval=false.
  *
  * @param state struct efa_resource that is managed by the framework
  */
 void test_efa_rdm_ep_enable_qp_in_order_aligned_128_bytes_bad(struct efa_resource **state)
 {
-	/* mock ibv_query_qp_data_in_order to return zero capability */
-	g_efa_unit_test_mocks.ibv_query_qp_data_in_order = &efa_mock_ibv_query_qp_data_in_order_return_0;
-	test_efa_rdm_ep_enable_qp_in_order_aligned_128_bytes_common(state, -FI_EOPNOTSUPP, true);
+	test_efa_rdm_ep_enable_qp_in_order_aligned_128_bytes_common(state, false);
 }
-
-#else
-
-void test_efa_rdm_ep_enable_qp_in_order_aligned_128_bytes_good(struct efa_resource **state)
-{
-	test_efa_rdm_ep_enable_qp_in_order_aligned_128_bytes_common(state, FI_SUCCESS, false);
-}
-
-void test_efa_rdm_ep_enable_qp_in_order_aligned_128_bytes_bad(struct efa_resource **state)
-{
-	test_efa_rdm_ep_enable_qp_in_order_aligned_128_bytes_common(state, -FI_EOPNOTSUPP, true);
-}
-
-#endif
 
 /**
  * @brief [Backwards compat] Verify that when zero-copy conditions are met,


### PR DESCRIPTION
The 128-byte once-only-delivery options
`FI_OPT_EFA_SENDRECV_IN_ORDER_ALIGNED_128_BYTES` and `FI_OPT_EFA_WRITE_IN_ORDER_ALIGNED_128_BYTES` are supported only on efa-direct endpoints.

Reject both options up-front with `-FI_EOPNOTSUPP` on RDM endpoints. The SENDRECV variant was already rejected; this commit folds WRITE into the same path and clarifies the failure log.

Refresh the existing setopt unit tests to assert the new behavior on RDM (`-FI_EOPNOTSUPP` for any optval, regardless of the underlying device's data-in-order capability).