### PR TITLE
prov/shm: Migrate return queue to smr_fifo queue

### DIFF
--- a/prov/shm/Makefile.include
+++ b/prov/shm/Makefile.include
@@ -18,6 +18,8 @@ _shm_files = \
 	prov/shm/src/smr_dsa.h		\
 	prov/shm/src/smr_dsa.c		\
 	prov/shm/src/smr_util.h		\
+	prov/shm/src/smr_atom.h		\
+	prov/shm/src/smr_fifo.h		\
 	prov/shm/src/smr_util.c
 
 

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -107,41 +107,12 @@ static inline uintptr_t smr_peer_to_peer(struct smr_ep *ep,
 	return (uintptr_t) peer_smr->base_addr + offset;
 }
 
-static inline uintptr_t smr_peer_to_owner(struct smr_ep *ep,
-					  struct smr_region *peer_smr,
-					  int64_t id, uintptr_t local_ptr)
-{
-	uint64_t offset = local_ptr - (uintptr_t) peer_smr;
-
-	return (uintptr_t) peer_smr->base_addr + offset;
-}
-
 static inline void smr_return_cmd(struct smr_ep *ep, struct smr_cmd *cmd)
 {
 	struct smr_region *peer_smr = smr_peer_region(ep, cmd->hdr.rx_id);
-	uintptr_t peer_ptr;
-	int64_t pos;
-	struct smr_return_entry *queue_entry;
-	int ret;
 
-	ret = smr_return_queue_next(smr_return_queue(peer_smr), &queue_entry,
-				    &pos);
-	if (ret == -FI_ENOENT) {
-		/* return queue runs in parallel to command stack
-		 * ie we will never run out of space
-		 */
-		assert(0);
-		return;
-	}
-
-	peer_ptr = smr_peer_to_owner(ep, peer_smr, cmd->hdr.rx_id,
-				     (uintptr_t) cmd);
-	assert(peer_ptr >= (uintptr_t) peer_smr->base_addr &&
-	       peer_ptr < (uintptr_t) peer_smr->base_addr +
-	       peer_smr->total_size);
-	queue_entry->ptr = peer_ptr;
-
-	smr_return_queue_commit(queue_entry, pos);
+	smr_fifo_write(smr_return_queue(peer_smr), (uintptr_t) peer_smr,
+		       (uintptr_t)cmd);
 }
 
 extern struct fi_provider smr_prov;

--- a/prov/shm/src/smr_atom.h
+++ b/prov/shm/src/smr_atom.h
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2018      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2018      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2019-2021 Google, LLC. All rights reserved.
+ * Copyright (c) 2019      Triad National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c)           Amazon.com, Inc. or its affiliates.
+ *                         All Rights reserved.
+ * $COPYRIGHT$
+ * Most files in this release are marked with the copyrights of the
+ * organizations who have edited them.  The copyrights below are in no
+ * particular order and generally reflect members of the Open MPI core
+ * team who have contributed code to this release.  The copyrights for
+ * code used under license from other parties are included in the
+ * corresponding files.
+ *
+ * Copyright (c) 2004-2012 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                        Corporation.  All rights reserved.
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2018 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2008 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2018 Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2006-2021 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2006-2010 Voltaire, Inc. All rights reserved.
+ * Copyright (c) 2006-2021 Sandia National Laboratories. All rights reserved.
+ * Copyright (c) 2006-2010 Sun Microsystems, Inc.  All rights reserved.
+ *                         Use is subject to license terms.
+ * Copyright (c) 2006-2021 The University of Houston. All rights reserved.
+ * Copyright (c) 2006-2009 Myricom, Inc.  All rights reserved.
+ * Copyright (c) 2007-2017 UT-Battelle, LLC. All rights reserved.
+ * Copyright (c) 2007-2021 IBM Corporation.  All rights reserved.
+ * Copyright (c) 1998-2005 Forschungszentrum Juelich, Juelich Supercomputing
+ *                         Centre, Federal Republic of Germany
+ * Copyright (c) 2005-2008 ZIH, TU Dresden, Federal Republic of Germany
+ * Copyright (c) 2007      Evergrid, Inc. All rights reserved.
+ * Copyright (c) 2008-2016 Chelsio, Inc.  All rights reserved.
+ * Copyright (c) 2008-2009 Institut National de Recherche en
+ *                         Informatique.  All rights reserved.
+ * Copyright (c) 2007      Lawrence Livermore National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2007-2019 Mellanox Technologies.  All rights reserved.
+ * Copyright (c) 2006-2010 QLogic Corporation.  All rights reserved.
+ * Copyright (c) 2008-2017 Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2006-2012 Oracle and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2009-2015 Bull SAS.  All rights reserved.
+ * Copyright (c) 2010      ARM ltd.  All rights reserved.
+ * Copyright (c) 2016      ARM, Inc.  All rights reserved.
+ * Copyright (c) 2010-2011 Alex Brick <bricka@ccs.neu.edu>.  All rights
+ * reserved. Copyright (c) 2012      The University of Wisconsin-La Crosse. All
+ * rights reserved. Copyright (c) 2013-2020 Intel, Inc. All rights reserved.
+ * Copyright (c) 2011-2021 NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2016-2018 Broadcom Limited.  All rights reserved.
+ * Copyright (c) 2011-2021 Fujitsu Limited.  All rights reserved.
+ * Copyright (c) 2014-2015 Hewlett-Packard Development Company, LP.  All
+ *                         rights reserved.
+ * Copyright (c) 2013-2021 Research Organization for Information Science (RIST).
+ *                         All rights reserved.
+ * Copyright (c)           Amazon.com, Inc. or its affiliates.  All Rights
+ *                         reserved.
+ * Copyright (c) 2018      DataDirect Networks. All rights reserved.
+ * Copyright (c) 2018-2021 Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2019-2021 Hewlett Packard Enterprise Development, LP.
+ * Copyright (c) 2020-2021 Google, LLC. All rights reserved.
+ * Copyright (c) 2002      University of Chicago
+ * Copyright (c) 2001      Argonne National Laboratory
+ * Copyright (c) 2020-2021 Cornelis Networks, Inc. All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting
+ * Copyright (c) 2017-2019 Iowa State University Research Foundation, Inc.
+ *                         All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer listed
+ *   in this license in the documentation and/or other materials
+ *   provided with the distribution.
+ *
+ * - Neither the name of the copyright holders nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * The copyright holders provide no reassurances that the source code
+ * provided does not infringe any patent, copyright, or any other
+ * intellectual property rights of third parties.  The copyright holders
+ * disclaim any liability to any recipient for claims brought against
+ * recipient by any third party for infringement of that parties
+ * intellectual property rights.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * ----------------[Copyright from inclusion of MPICH code]----------------
+ *
+ * The following is a notice of limited availability of the code, and disclaimer
+ * which must be included in the prologue of the code and in all source listings
+ * of the code.
+ *
+ * Copyright Notice
+ *  + 2002 University of Chicago
+ *
+ * Permission is hereby granted to use, reproduce, prepare derivative works, and
+ * to redistribute to others.  This software was authored by:
+ *
+ * Mathematics and Computer Science Division
+ * Argonne National Laboratory, Argonne IL 60439
+ *
+ * (and)
+ *
+ * Department of Computer Science
+ * University of Illinois at Urbana-Champaign
+ *
+ *
+ * 			      GOVERNMENT LICENSE
+ *
+ * Portions of this material resulted from work developed under a U.S.
+ * Government Contract and are subject to the following license: the Government
+ * is granted for itself and others acting on its behalf a paid-up,
+ * nonexclusive, irrevocable worldwide license in this computer software to
+ * reproduce, prepare derivative works, and perform publicly and display
+ * publicly.
+ *
+ * 				  DISCLAIMER
+ *
+ * This computer code material was prepared, in part, as an account of work
+ * sponsored by an agency of the United States Government.  Neither the United
+ * States, nor the University of Chicago, nor any of their employees, makes any
+ * warranty express or implied, or assumes any legal liability or responsibility
+ * for the accuracy, completeness, or usefulness of any information, apparatus,
+ * product, or process disclosed, or represents that its use would not infringe
+ * privately owned rights.
+ */
+/*
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "config.h"
+#include <stdbool.h>
+
+#ifdef HAVE_ATOMICS
+#include <stdatomic.h>
+
+static inline void atomic_mb(void)
+{
+	atomic_thread_fence(memory_order_seq_cst);
+}
+
+static inline void atomic_rmb(void)
+{
+#if defined(PLATFORM_ARCH_X86_64) && defined(PLATFORM_COMPILER_GNU) && \
+	__GNUC__ < 8
+	/* work around a bug in older gcc versions (observed in gcc 6.x)
+	 * where acquire seems to get treated as a no-op instead of being
+	 * equivalent to __asm__ __volatile__("": : :"memory") on x86_64.
+	 * The issue has been fixed in the GCC 8 release series:
+	 * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80640
+	 */
+	atomic_mb();
+#else
+	atomic_thread_fence(memory_order_acquire);
+#endif
+}
+
+static inline void atomic_wmb(void)
+{
+	atomic_thread_fence(memory_order_release);
+}
+
+#define atomic_compare_exchange(addr, compare, value)       \
+	atomic_compare_exchange_strong_explicit(            \
+		(_Atomic uintptr_t *) addr, compare, value, \
+		memory_order_acquire, memory_order_relaxed)
+
+#define atomic_swap_ptr(addr, value)                                \
+	atomic_exchange_explicit((_Atomic uintptr_t *) addr, value, \
+				 memory_order_relaxed)
+
+#elif defined(HAVE_BUILTIN_MM_ATOMICS)
+
+static inline void atomic_mb(void)
+{
+	__atomic_thread_fence(__ATOMIC_SEQ_CST);
+}
+
+static inline void atomic_rmb(void)
+{
+	__atomic_thread_fence(__ATOMIC_ACQUIRE);
+}
+
+static inline void atomic_wmb(void)
+{
+	__atomic_thread_fence(__ATOMIC_RELEASE);
+}
+
+#define atomic_compare_exchange(x, y, z)                                    \
+	__atomic_compare_exchange_n((uintptr_t *) (x), (int64_t *) (y),     \
+				    (int64_t) (z), false, __ATOMIC_ACQUIRE, \
+				    __ATOMIC_RELAXED)
+
+static inline long int atomic_swap_ptr(long int *addr, long int value)
+{
+	long int oldval;
+	__atomic_exchange(addr, &value, &oldval, __ATOMIC_RELAXED);
+	return oldval;
+}
+
+#else
+#error "No atomics support found for SHM."
+#endif

--- a/prov/shm/src/smr_fifo.h
+++ b/prov/shm/src/smr_fifo.h
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2009 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2007 Voltaire. All rights reserved.
+ * Copyright (c) 2009-2010 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2018 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2020      Google, LLC. All rights reserved.
+ * Copyright (c) Amazon.com, Inc. or its affiliates. All rights reserved.
+ *
+ *  * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer listed
+ *   in this license in the documentation and/or other materials
+ *   provided with the distribution.
+ *
+ * - Neither the name of the copyright holders nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * The copyright holders provide no reassurances that the source code
+ * provided does not infringe any patent, copyright, or any other
+ * intellectual property rights of third parties.  The copyright holders
+ * disclaim any liability to any recipient for claims brought against
+ * recipient by any third party for infringement of that parties
+ * intellectual property rights.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * ----------------[Copyright from inclusion of MPICH code]----------------
+ *
+ * The following is a notice of limited availability of the code, and disclaimer
+ * which must be included in the prologue of the code and in all source listings
+ * of the code.
+ *
+ * Copyright Notice
+ *  + 2002 University of Chicago
+ *
+ * Permission is hereby granted to use, reproduce, prepare derivative works, and
+ * to redistribute to others.  This software was authored by:
+ *
+ * Mathematics and Computer Science Division
+ * Argonne National Laboratory, Argonne IL 60439
+ *
+ * (and)
+ *
+ * Department of Computer Science
+ * University of Illinois at Urbana-Champaign
+ *
+ *
+ * 			      GOVERNMENT LICENSE
+ *
+ * Portions of this material resulted from work developed under a U.S.
+ * Government Contract and are subject to the following license: the Government
+ * is granted for itself and others acting on its behalf a paid-up,
+ * nonexclusive, irrevocable worldwide license in this computer software to
+ * reproduce, prepare derivative works, and perform publicly and display
+ * publicly.
+ *
+ * 				  DISCLAIMER
+ *
+ * This computer code material was prepared, in part, as an account of work
+ * sponsored by an agency of the United States Government.  Neither the United
+ * States, nor the University of Chicago, nor any of their employees, makes any
+ * warranty express or implied, or assumes any legal liability or responsibility
+ * for the accuracy, completeness, or usefulness of any information, apparatus,
+ * product, or process disclosed, or represents that its use would not infringe
+ * privately owned rights.
+ */
+/*
+ * Copyright (c) 2023 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright (c) Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ * Multi Writer, Single Reader FIFO Queue (Not Thread Safe)
+ * This implementation of this Queue is a one directional linked list
+ * with head/tail pointers where every pointer is a relative offset
+ * into the Shared Memory Region.
+ */
+
+#ifndef _SMR_FIFO_H_
+#define _SMR_FIFO_H_
+
+#include "smr_atom.h"
+#include <stdint.h>
+#include <assert.h>
+
+#define SMR_FIFO_FREE (-3)
+#define OFI_CACHE_LINE_SIZE (64)
+
+static inline int64_t smr_local_to_offset(uintptr_t base, uintptr_t local_ptr)
+{
+	return (int64_t)(local_ptr - base);
+}
+
+static inline uintptr_t smr_offset_to_local(uintptr_t base, int64_t offset)
+{
+	return (uintptr_t) base + offset;
+}
+
+struct smr_fifo {
+	uintptr_t	head;
+	uint8_t		pad[OFI_CACHE_LINE_SIZE - sizeof(uintptr_t)];
+	uintptr_t	tail;
+};
+
+static inline void smr_fifo_init(struct smr_fifo *fifo)
+{
+	fifo->head = SMR_FIFO_FREE;
+	fifo->tail = SMR_FIFO_FREE;
+}
+
+static inline void smr_fifo_write(struct smr_fifo *fifo, uintptr_t peer_base,
+				  uintptr_t cmd)
+{
+	uintptr_t ptr_offset = smr_local_to_offset(peer_base, cmd);
+	uintptr_t prev_offset;
+	uintptr_t prev_cmd;
+
+	assert(fifo->head != 0 && fifo->tail != 0);
+
+	// First entry in cmd must be free for use as next pointer in the FIFO
+	*((void **) cmd) = (void *) SMR_FIFO_FREE;
+
+	atomic_wmb();
+	prev_offset = atomic_swap_ptr(&fifo->tail, ptr_offset);
+	atomic_rmb();
+
+	assert(prev_offset != ptr_offset);
+
+	prev_cmd = smr_offset_to_local(peer_base, prev_offset);
+	if (prev_offset != SMR_FIFO_FREE)
+		*((void **) prev_cmd) = (void *) ptr_offset;
+	else
+		fifo->head = ptr_offset;
+
+	atomic_wmb();
+}
+
+static inline void *smr_fifo_read(struct smr_fifo *fifo, uintptr_t base)
+{
+	uintptr_t cmd, cmd_offset, next_offset;
+
+	assert(fifo->head != 0 && fifo->tail != 0);
+
+	if (fifo->head == SMR_FIFO_FREE)
+		return NULL;
+
+	atomic_rmb();
+
+	cmd_offset = fifo->head;
+	fifo->head = SMR_FIFO_FREE;
+
+	cmd = smr_offset_to_local(base, cmd_offset);
+	next_offset = (uintptr_t) *((void **) cmd);
+	assert(next_offset != cmd_offset && cmd && next_offset);
+
+	if (next_offset == SMR_FIFO_FREE) {
+		atomic_rmb();
+		if (!atomic_compare_exchange(&fifo->tail, &cmd_offset,
+					     SMR_FIFO_FREE)) {
+			while ((uintptr_t) *((void **) cmd) == SMR_FIFO_FREE) {
+				atomic_rmb();
+			}
+			fifo->head = (uintptr_t) *((void **) cmd);
+		}
+	} else {
+		fifo->head = next_offset;
+	}
+
+	atomic_wmb();
+	return (void *)cmd;
+}
+
+#endif /* _SMR_FIFO_H_ */

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -170,19 +170,16 @@ static int smr_progress_return_entry(struct smr_ep *ep, struct smr_cmd *cmd,
 
 static void smr_progress_return(struct smr_ep *ep)
 {
-	struct smr_return_entry *queue_entry;
 	struct smr_cmd *cmd;
 	struct smr_pend_entry *pending;
-	int64_t pos;
 	int ret;
 
 	while (1) {
-		ret = smr_return_queue_head(smr_return_queue(ep->region),
-					    &queue_entry, &pos);
-		if (ret == -FI_ENOENT)
+		cmd = smr_fifo_read(smr_return_queue(ep->region),
+				    (uintptr_t)ep->region);
+		if (!cmd)
 			break;
 
-		cmd = (struct smr_cmd *) queue_entry->ptr;
 		pending = (struct smr_pend_entry *) cmd->hdr.tx_ctx;
 
 		ret = smr_progress_return_entry(ep, cmd, pending);
@@ -208,8 +205,6 @@ static void smr_progress_return(struct smr_ep *ep)
 			ofi_buf_free(pending);
 			smr_freestack_push(smr_cmd_stack(ep->region), cmd);
 		}
-		smr_return_queue_release(smr_return_queue(ep->region),
-					 queue_entry, pos);
 	}
 }
 

--- a/prov/shm/src/smr_util.c
+++ b/prov/shm/src/smr_util.c
@@ -110,8 +110,7 @@ size_t smr_calculate_size_offsets(size_t tx_count, size_t rx_count,
 	ret_queue_offset = cmd_stack_offset +
 		freestack_size(sizeof(struct smr_cmd), tx_size);
 	ret_queue_offset = ofi_get_aligned_size(ret_queue_offset, 64);
-	sar_pool_offset = ret_queue_offset + sizeof(struct smr_return_queue) +
-		sizeof(struct smr_return_queue_entry) * tx_size;
+	sar_pool_offset = ret_queue_offset + sizeof(struct smr_fifo);
 	peer_data_offset = sar_pool_offset +
 		freestack_size(sizeof(struct smr_sar_buf), SMR_MAX_PEERS);
 	ep_name_offset = peer_data_offset + sizeof(struct smr_peer_data) *
@@ -284,7 +283,7 @@ int smr_create(const struct fi_provider *prov, const struct smr_attr *attr,
 	smr_cmd_queue_init(smr_cmd_queue(*smr), rx_size, NULL);
 	smr_freestack_init(smr_inject_pool(*smr), rx_size,
 			   sizeof(struct smr_inject_buf));
-	smr_return_queue_init(smr_return_queue(*smr), tx_size, NULL);
+	smr_fifo_init(smr_return_queue(*smr));
 
 	smr_freestack_init(smr_cmd_stack(*smr), tx_size,
 			   sizeof(struct smr_cmd));

--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -38,6 +38,8 @@
 #include "ofi_lock.h"
 #include "ofi_xpmem.h"
 
+#include "smr_fifo.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -310,7 +312,6 @@ struct smr_return_entry {
 };
 
 OFI_DECLARE_ATOMIC_Q(struct smr_cmd, smr_cmd_queue);
-OFI_DECLARE_ATOMIC_Q(struct smr_return_entry, smr_return_queue);
 
 /* Queue of offsets of the command blocks obtained from the command pool
  * freestack
@@ -328,10 +329,9 @@ static inline struct smr_freestack *smr_inject_pool(struct smr_region *smr)
 	return (struct smr_freestack *)
 			((char *) smr + smr->inject_pool_offset);
 }
-static inline struct smr_return_queue *smr_return_queue(struct smr_region *smr)
+static inline struct smr_fifo *smr_return_queue(struct smr_region *smr)
 {
-	return (struct smr_return_queue *)
-			((char *) smr + smr->ret_queue_offset);
+	return (struct smr_fifo *) ((char *) smr + smr->ret_queue_offset);
 }
 static inline struct smr_peer_data *smr_peer_data(struct smr_region *smr)
 {


### PR DESCRIPTION
Move away from the many-reader:many-writer return queue to a single-reader:many-writer return queue. 

This implementation is adapted from the sm2 fifo implementation which was in turn adapted from the OMPI implementation so it retains the OMPI header.