### PR TITLE
prov/efa: minimal GoogleTest unit testing framework

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -123,6 +123,7 @@ m4_version_prereq([2.70],
              AC_MSG_ERROR([Cannot continue])])
      ])
 AM_PROG_CC_C_O
+AC_PROG_CXX
 AC_PROG_CPP
 
 AC_ARG_ENABLE([debug],

--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -260,6 +260,34 @@ prov_efa_test_efa_unit_test_LIBS = $(efa_LIBS) $(linkback)
 
 endif ENABLE_EFA_UNIT_TEST
 
+if ENABLE_EFA_GTEST
+noinst_PROGRAMS += prov/efa/test/gtest/efa_gtest
+TESTS += prov/efa/test/gtest/efa_gtest
+
+nodist_prov_efa_test_gtest_efa_gtest_SOURCES = \
+	prov/efa/test/gtest/efa_gtest_main.cc
+
+prov_efa_test_gtest_efa_gtest_CPPFLAGS = \
+	$(AM_CPPFLAGS) \
+	$(gtest_CPPFLAGS) \
+	-I$(top_srcdir)/include \
+	-I$(top_srcdir)/prov/efa/test/gtest
+
+prov_efa_test_gtest_efa_gtest_CXXFLAGS = -std=c++17
+
+prov_efa_test_gtest_efa_gtest_LDADD = \
+	$(gtest_LIBS) \
+	$(linkback)
+
+prov_efa_test_gtest_efa_gtest_LDFLAGS = \
+	-static \
+	$(efa_LDFLAGS) \
+	$(gtest_LDFLAGS)
+
+prov_efa_test_gtest_efa_gtest_LIBS = $(linkback)
+
+endif ENABLE_EFA_GTEST
+
 efa_CPPFLAGS += \
 	-I$(top_srcdir)/prov/efa/src/ \
 	-I$(top_srcdir)/prov/efa/src/rdm/

--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -185,7 +185,7 @@ efa_CPPFLAGS += -I$(top_srcdir)/include -I$(top_srcdir)/prov/efa/test $(cmocka_C
 
 prov_efa_test_efa_unit_test_CPPFLAGS = $(efa_CPPFLAGS)
 prov_efa_test_efa_unit_test_LDADD = $(cmocka_LIBS) $(linkback)
-prov_efa_test_efa_unit_test_LDFLAGS = $(cmocka_rpath) $(efa_LDFLAGS) $(cmocka_LDFLAGS) \
+prov_efa_test_efa_unit_test_LDFLAGS = -static $(cmocka_rpath) $(efa_LDFLAGS) $(cmocka_LDFLAGS) \
 					-Wl,--wrap=ibv_create_ah \
 					-Wl,--wrap=ibv_destroy_ah \
 					-Wl,--wrap=ibv_is_fork_initialized \

--- a/prov/efa/configure.m4
+++ b/prov/efa/configure.m4
@@ -368,7 +368,7 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 			[],
 			[$cmocka_dir],
 			[],
-			[efa_LIBS+=" $cmocka_LDFLAGS $cmocka_LIBS -static"],
+			[],
 			[AC_MSG_ERROR([Cannot compile EFA unit tests without a valid Cmocka installation directory.])],
 			[
 				#include <stdarg.h>

--- a/prov/efa/configure.m4
+++ b/prov/efa/configure.m4
@@ -393,6 +393,80 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 	AM_CONDITIONAL([HAVE_EFA_DATA_IN_ORDER_ALIGNED_128_BYTES], [ test $efa_support_data_in_order_aligned_128_byte = 1])
 	AM_CONDITIONAL([ENABLE_EFA_UNIT_TEST], [ test x"$enable_efa_unit_test" != xno])
 
+	AC_ARG_ENABLE([efa-gtest],
+		[
+			AS_HELP_STRING([--enable-efa-gtest=GTEST_INSTALL_DIR],
+				[Provide a path to the Google Test installation directory
+				in order to enable EFA GTest/GMock Tests.])
+		],
+		[gtest_dir=$enableval],
+		[enable_efa_gtest=no])
+
+	AS_IF([test x"$enable_efa_gtest" != xno ],
+	[
+		efa_gtest=1
+		AC_LANG_PUSH([C++])
+
+		gtest_CPPFLAGS="-I$gtest_dir/include"
+		gtest_LDFLAGS=""
+		gtest_LIBS=""
+
+		dnl Find the library directory (lib64 or lib)
+		AS_IF([test -d "$gtest_dir/lib64"],
+			[gtest_LDFLAGS="-L$gtest_dir/lib64"],
+			[AS_IF([test -d "$gtest_dir/lib"],
+				[gtest_LDFLAGS="-L$gtest_dir/lib"],
+				[AC_MSG_ERROR([Cannot find lib or lib64 directory in $gtest_dir])])])
+
+		dnl Check for gtest/gtest.h
+		fi_check_gtest_save_CPPFLAGS="$CPPFLAGS"
+		fi_check_gtest_save_LDFLAGS="$LDFLAGS"
+		fi_check_gtest_save_LIBS="$LIBS"
+		fi_check_gtest_save_CXXFLAGS="$CXXFLAGS"
+		CXXFLAGS="$CXXFLAGS -std=c++17"
+		CPPFLAGS="$CPPFLAGS $gtest_CPPFLAGS"
+		LDFLAGS="$LDFLAGS $gtest_LDFLAGS"
+
+		dnl Compile test for gtest and gmock headers
+		AC_MSG_CHECKING([for gtest/gtest.h and gmock/gmock.h])
+		AC_COMPILE_IFELSE(
+			[AC_LANG_PROGRAM(
+				[[#include <gtest/gtest.h>
+				  #include <gmock/gmock.h>]],
+				[[]])],
+			[AC_MSG_RESULT([yes])],
+			[AC_MSG_RESULT([no])
+			 AC_MSG_ERROR([Cannot compile with gtest/gmock headers from $gtest_dir/include])])
+
+		dnl Link test for gtest and gmock
+		LIBS="$LIBS -lgmock -lgtest -lpthread"
+		AC_MSG_CHECKING([whether we can link against gtest and gmock])
+		AC_LINK_IFELSE(
+			[AC_LANG_PROGRAM(
+				[[#include <gtest/gtest.h>
+				  #include <gmock/gmock.h>]],
+				[[int argc = 0; char *argv[] = {nullptr}; testing::InitGoogleMock(&argc, argv);]])],
+			[AC_MSG_RESULT([yes])
+			 gtest_LIBS="-lgmock -lgtest -lpthread"],
+			[AC_MSG_RESULT([no])
+			 AC_MSG_ERROR([Cannot link against gtest/gmock in $gtest_dir])])
+
+		CPPFLAGS="$fi_check_gtest_save_CPPFLAGS"
+		LDFLAGS="$fi_check_gtest_save_LDFLAGS"
+		LIBS="$fi_check_gtest_save_LIBS"
+		CXXFLAGS="$fi_check_gtest_save_CXXFLAGS"
+
+		AC_LANG_POP([C++])
+	],
+	[
+		efa_gtest=0
+	])
+
+	AC_SUBST(gtest_CPPFLAGS)
+	AC_SUBST(gtest_LDFLAGS)
+	AC_SUBST(gtest_LIBS)
+	AM_CONDITIONAL([ENABLE_EFA_GTEST], [ test x"$enable_efa_gtest" != xno])
+
 	AC_SUBST(efa_CPPFLAGS)
 	AC_SUBST(efa_LDFLAGS)
 	AC_SUBST(efa_LIBS)

--- a/prov/efa/test/gtest/efa_gtest_main.cc
+++ b/prov/efa/test/gtest/efa_gtest_main.cc
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+int main(int argc, char **argv)
+{
+	::testing::InitGoogleMock(&argc, argv);
+	return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This PR adds support for writing future unit tests using GoogleTest (GTest/GMock) via a new `configure` option: `--enable-efa-gtest=GTEST_INSTALL_DIR`. 

This is parallel to the existing CMocka framework. A minimal test binary can be compiled with
```
./autogen.sh
./configure --enable-efa-gtest=/path/to/gtest --enable-efa
make prov/efa/test/gtest/efa_gtest
./prov/efa/test/gtest/efa_gtest
```