### PR TITLE
prov/shm: enable sender-CMA fast path for writedata

### DIFF
--- a/prov/shm/src/smr_init.c
+++ b/prov/shm/src/smr_init.c
@@ -43,6 +43,7 @@ struct smr_env smr_env = {
 	.max_gdrcopy_size = 3072,
 	.use_xpmem = false,
 	.buffer_threshold = 1,
+	.rma_fast_size = SMR_RMA_FAST_SIZE,
 };
 
 static void smr_init_env(void)
@@ -54,6 +55,8 @@ static void smr_init_env(void)
 	fi_param_get_bool(&smr_prov, "use_xpmem", &smr_env.use_xpmem);
 	fi_param_get_size_t(&smr_prov, "buffer_threshold",
 			    &smr_env.buffer_threshold);
+	fi_param_get_size_t(&smr_prov, "rma_fast_size",
+			    &smr_env.rma_fast_size);
 }
 
 static void smr_resolve_addr(const char *node, const char *service,
@@ -219,6 +222,11 @@ SHM_INI
 	fi_param_define(&smr_prov, "use_xpmem", FI_PARAM_BOOL,
 			"Enable XPMEM over CMA when possible "
 			"(default: false)");
+	fi_param_define(&smr_prov, "rma_fast_size", FI_PARAM_SIZE_T,
+			"Maximum message size for sender-CMA RMA fast"
+			" path (default: %zu). Messages larger than this"
+			" use receiver-CMA for better pipelining.",
+			 SMR_RMA_FAST_SIZE);
 	fi_param_define(&smr_prov, "buffer_threshold", FI_PARAM_SIZE_T,
 			"When to start requesting forced unexpected messaging "
 			"buffering. (default: 1)");

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -1340,6 +1340,15 @@ static void smr_progress_cmd(struct smr_ep *ep)
 			ret = smr_progress_cmd_rma(ep, cmd);
 			break;
 		case ofi_op_write_async:
+			if (cmd->hdr.op_flags & SMR_REMOTE_CQ_DATA) {
+				ret = smr_complete_rx(ep, NULL, ofi_op_write,
+					smr_rx_cq_flags(0, cmd->hdr.op_flags),
+					cmd->hdr.size, NULL, cmd->hdr.rx_id, 0,
+					cmd->hdr.cq_data);
+				break;
+			}
+			ofi_ep_peer_rx_cntr_inc(&ep->util_ep, cmd->hdr.op);
+			break;
 		case ofi_op_read_async:
 			ofi_ep_peer_rx_cntr_inc(&ep->util_ep, cmd->hdr.op);
 			break;

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -44,17 +44,21 @@ static void smr_add_rma_cmd(struct smr_region *peer_smr,
 static void smr_format_rma_resp(struct smr_cmd *cmd, int64_t peer_id,
 				const struct fi_rma_iov *rma_iov, size_t count,
 				size_t total_len, uint32_t op,
-				uint64_t op_flags)
+				uint64_t data, uint64_t op_flags)
 {
-	smr_generic_format(cmd, 0, peer_id, op, 0, 0, op_flags);
+	smr_generic_format(cmd, 0, peer_id, op, 0, data, op_flags);
 	cmd->hdr.size = total_len;
+	if (op_flags & FI_REMOTE_CQ_DATA) {
+		cmd->hdr.cq_data = data;
+		cmd->hdr.op_flags |= SMR_REMOTE_CQ_DATA;
+	}
 }
 
 static ssize_t smr_rma_fast(struct smr_ep *ep, struct smr_region *peer_smr,
 			    const struct iovec *iov, size_t iov_count,
 			    const struct fi_rma_iov *rma_iov, size_t rma_count,
 			    void **desc, int rx_id, int tx_id, void *context,
-			    uint32_t op, uint64_t op_flags)
+			    uint32_t op, uint64_t data, uint64_t op_flags)
 {
 	struct iovec vma_iovec[SMR_IOV_LIMIT], rma_iovec[SMR_IOV_LIMIT];
 	struct ofi_xpmem_client *xpmem;
@@ -91,7 +95,7 @@ static ssize_t smr_rma_fast(struct smr_ep *ep, struct smr_region *peer_smr,
 
 	smr_format_rma_resp(cmd, rx_id, rma_iov, rma_count, total_len,
 			    (op == ofi_op_write) ? ofi_op_write_async :
-			    ofi_op_read_async, op_flags);
+			    ofi_op_read_async, data, op_flags);
 
 	smr_cmd_queue_commit(cmd, pos);
 
@@ -106,16 +110,16 @@ static ssize_t smr_rma_fast(struct smr_ep *ep, struct smr_region *peer_smr,
 
 static inline bool smr_do_fast_rma(struct smr_ep *ep, uint64_t op_flags,
 				   size_t rma_count, size_t total_len,
-				   struct smr_region *peer_smr)
+				   struct smr_region *peer_smr, uint32_t op)
 {
 	struct smr_domain *domain;
 
 	domain = container_of(ep->util_ep.domain, struct smr_domain,
 			      util_domain);
 
-	return domain->fast_rma && !(op_flags &
-		    (FI_REMOTE_CQ_DATA | FI_DELIVERY_COMPLETE)) &&
-		     rma_count == 1 && smr_vma_enabled(ep, peer_smr);
+	return domain->fast_rma && !(op_flags & FI_DELIVERY_COMPLETE) &&
+		     rma_count == 1 && smr_vma_enabled(ep, peer_smr) &&
+		     (op == ofi_op_read_req || total_len <= smr_env.rma_fast_size);
 
 }
 
@@ -150,10 +154,10 @@ static ssize_t smr_generic_rma(
 		goto unlock;
 
 	total_len = ofi_total_iov_len(iov, iov_count);
-	if (smr_do_fast_rma(ep, op_flags, rma_count, total_len, peer_smr)) {
+	if (smr_do_fast_rma(ep, op_flags, rma_count, total_len, peer_smr, op)) {
 		ret = smr_rma_fast(ep, peer_smr, iov, iov_count, rma_iov,
 				   rma_count, desc, rx_id, tx_id, context, op,
-				   op_flags);
+				   data, op_flags);
 		goto unlock;
 	}
 

--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -50,6 +50,7 @@ struct smr_env {
 	size_t	max_gdrcopy_size;
 	int	use_xpmem;
 	size_t	buffer_threshold;
+	size_t	rma_fast_size;
 };
 
 extern struct smr_env smr_env;
@@ -184,6 +185,7 @@ static_assert(sizeof(struct smr_cmd) == SMR_CMD_SIZE,
 
 #define SMR_INJECT_SIZE		4096
 #define SMR_COMP_INJECT_SIZE	(SMR_INJECT_SIZE / 2)
+#define SMR_RMA_FAST_SIZE	16384
 #define SMR_SAR_SIZE		32768
 
 #define SMR_DIR		"/dev/shm/"


### PR DESCRIPTION
The fast RMA path (smr_rma_fast) excluded FI_REMOTE_CQ_DATA operations because smr_format_rma_resp did not carry cq_data, preventing the receiver from generating a CQ entry for writedata. This forced writedata onto the receiver-CMA IOV path with its return-queue round trip, regressing rma_pingpong latency by ~5-12% vs v2.4.x.

Enable the fast path for writedata by:
- Threading cq_data through smr_format_rma_resp and flagging it with SMR_REMOTE_CQ_DATA (already defined for message paths).
- Having the receiver's ofi_op_write_async handler call smr_complete_rx with cq_data when the flag is set.
- Dropping FI_REMOTE_CQ_DATA from the smr_do_fast_rma exclusion.
- Capping writes at 16KB (op == ofi_op_read_req has no cap) to avoid large-size bandwidth regression from sender-side copy serialization.

Safe because process_vm_writev is synchronous (data is in the target buffer before it returns) and smr_cmd_queue_commit provides a write barrier before the notification is visible to the receiver.

Recovers rma_pingpong writedata latency by ~10-12% on Graviton cluster (c7gn) and writedata_bw at 8KB by +3-5%. Verified with fi_rma_bw -v.