### PR TITLE
prov/shm: Replace return queue with inline IOV + resp-slots

### DIFF
--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -50,6 +50,13 @@ struct smr_ep {
 	struct ofi_bufpool	*unexp_buf_pool;
 	struct ofi_bufpool	*pend_pool;
 
+	/* Resp-slot return tracking: one bit per in-flight borrowed cmd,
+	 * indexed by the cmd's command-stack index. last_comp_count gates
+	 * the drain scan against the peer-incremented completion count. */
+	uint64_t		*return_bitmap;
+	size_t			bitmap_words;
+	uint64_t		last_comp_count;
+
 	struct slist		overflow_list;
 	struct dlist_entry	sar_list;
 	struct dlist_entry	async_cpy_list;
@@ -119,29 +126,19 @@ static inline uintptr_t smr_peer_to_owner(struct smr_ep *ep,
 static inline void smr_return_cmd(struct smr_ep *ep, struct smr_cmd *cmd)
 {
 	struct smr_region *peer_smr = smr_peer_region(ep, cmd->hdr.rx_id);
-	uintptr_t peer_ptr;
-	int64_t pos;
-	struct smr_return_entry *queue_entry;
-	int ret;
+	int16_t slot;
 
-	ret = smr_return_queue_next(smr_return_queue(peer_smr), &queue_entry,
-				    &pos);
-	if (ret == -FI_ENOENT) {
-		/* return queue runs in parallel to command stack
-		 * ie we will never run out of space
-		 */
-		assert(0);
-		return;
-	}
-
-	peer_ptr = smr_peer_to_owner(ep, peer_smr, cmd->hdr.rx_id,
-				     (uintptr_t) cmd);
-	assert(peer_ptr >= (uintptr_t) peer_smr->base_addr &&
-	       peer_ptr < (uintptr_t) peer_smr->base_addr +
-	       peer_smr->total_size);
-	queue_entry->ptr = peer_ptr;
-
-	smr_return_queue_commit(queue_entry, pos);
+	/* The command was borrowed from the peer's (sender's) command
+	 * stack; its freestack index is the resp-slot id. Bump the slot
+	 * status (only one peer touches a given slot at a time) and the
+	 * completion count, which the sender reads with acquire to gate
+	 * its drain scan. The release on comp_count orders the prior
+	 * status store and the payload, so no atomic RMW is needed on the
+	 * status itself.
+	 */
+	slot = smr_freestack_get_index(smr_cmd_stack(peer_smr), (char *) cmd);
+	smr_resp_slots(peer_smr)[slot].status++;
+	__atomic_add_fetch(smr_comp_count(peer_smr), 1, __ATOMIC_RELEASE);
 }
 
 extern struct fi_provider smr_prov;
@@ -186,6 +183,7 @@ struct smr_pend_entry {
 	size_t				iov_count;
 	struct ofi_mr			*mr[SMR_IOV_LIMIT];
 	size_t				bytes_done;
+	uint64_t			last_resp_seen;
 	void				*comp_ctx;
 	uint64_t			comp_flags;
 	int				sar_dir;
@@ -193,6 +191,34 @@ struct smr_pend_entry {
 						struct smr_ep *ep,
 						struct smr_pend_entry *pend);
 };
+
+/* Reserve the per-command resp slot for a borrowed (SMR_RETURN_CMD)
+ * command. The slot id is the command's index in the local command
+ * stack, so it needs no header field and matches command-stack capacity.
+ * Call only after all fallible setup so a failure path cannot leak a
+ * slot from the bitmap.
+ */
+static inline void smr_alloc_resp_slot(struct smr_ep *ep, struct smr_cmd *cmd,
+				       struct smr_pend_entry *pend)
+{
+	int16_t slot = smr_freestack_get_index(smr_cmd_stack(ep->region),
+					       (char *) cmd);
+
+	ep->return_bitmap[slot >> 6] |= 1ULL << (slot & 63);
+	smr_resp_slots(ep->region)[slot].status = 0;
+	pend->last_resp_seen = 0;
+}
+
+/* Release a resp slot from outside the drain (e.g. when an async DSA
+ * copy completes a borrowed command's return directly). The drain clears
+ * its own bit inline. */
+static inline void smr_free_resp_slot(struct smr_ep *ep, struct smr_cmd *cmd)
+{
+	int16_t slot = smr_freestack_get_index(smr_cmd_stack(ep->region),
+					       (char *) cmd);
+
+	ep->return_bitmap[slot >> 6] &= ~(1ULL << (slot & 63));
+}
 
 struct smr_cmd_ctx {
 	struct dlist_entry	entry;

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -152,6 +152,7 @@ static int smr_do_atomic_inject(
 		cmd->hdr.tx_ctx = (uintptr_t) pend;
 		smr_format_tx_pend(pend, cmd, context, res_desc, resultv,
 				   result_count, op_flags);
+		smr_alloc_resp_slot(ep, cmd, pend);
 	} else {
 		cmd->hdr.tx_ctx = 0;
 	}

--- a/prov/shm/src/smr_dsa.c
+++ b/prov/shm/src/smr_dsa.c
@@ -641,6 +641,9 @@ static void dsa_complete_tx_work(struct smr_ep *ep, struct smr_pend_entry *pend)
 
 			smr_peer_data(ep->region)[pend->cmd->hdr.tx_id].sar_status =
 								SMR_SAR_FREE;
+			/* Completed out of band; release the resp slot the
+			 * drain would otherwise have cleared. */
+			smr_free_resp_slot(ep, pend->cmd);
 			smr_freestack_push(smr_cmd_stack(ep->region), pend->cmd);
 			ofi_buf_free(pend);
 			return;

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -501,6 +501,9 @@ static ssize_t smr_do_inject(struct smr_ep *ep, struct smr_region *peer_smr,
 	if (pend && op != ofi_op_read_req)
 		pend->bytes_done = cmd->hdr.size;
 
+	if (pend)
+		smr_alloc_resp_slot(ep, cmd, pend);
+
 	return FI_SUCCESS;
 err:
 	if (pend)
@@ -529,6 +532,8 @@ static ssize_t smr_do_iov(struct smr_ep *ep, struct smr_region *peer_smr,
 	if (smr_freestack_avail(smr_cmd_stack(ep->region)) <=
 	    smr_env.buffer_threshold)
 		cmd->hdr.smr_flags |= SMR_BUFFER_RECV;
+
+	smr_alloc_resp_slot(ep, cmd, pend);
 
 	return FI_SUCCESS;
 }
@@ -560,8 +565,12 @@ static ssize_t smr_do_sar(struct smr_ep *ep, struct smr_region *peer_smr,
 	smr_generic_format(cmd, tx_id, rx_id, op, tag, data, smr_flags);
 	ret = smr_format_sar(ep, cmd, desc, iov, iov_count, total_len,
 			     ep->region, peer_smr, pend);
-	if (ret)
+	if (ret) {
 		ofi_buf_free(pend);
+		return ret;
+	}
+
+	smr_alloc_resp_slot(ep, cmd, pend);
 
 	return ret;
 }
@@ -600,6 +609,8 @@ static ssize_t smr_do_ipc(struct smr_ep *ep, struct smr_region *peer_smr,
 	if (smr_freestack_avail(smr_cmd_stack(ep->region)) <=
 	    smr_env.buffer_threshold)
 		cmd->hdr.smr_flags |= SMR_BUFFER_RECV;
+
+	smr_alloc_resp_slot(ep, cmd, pend);
 
 	return FI_SUCCESS;
 }
@@ -659,6 +670,8 @@ static int smr_ep_close(struct fid *fid)
 
 	if (ep->pend_pool)
 		ofi_bufpool_destroy(ep->pend_pool);
+
+	free(ep->return_bitmap);
 
 	free((void *)ep->name);
 	free(ep);
@@ -978,8 +991,21 @@ static int smr_create_pools(struct smr_ep *ep, struct fi_info *info)
 	if (ret)
 		goto free1;
 
+	/* One return-tracking bit per command-stack entry (resp slot). */
+	ep->bitmap_words = (roundup_power_of_two(ep->tx_size) + 63) / 64;
+	if (!ep->bitmap_words)
+		ep->bitmap_words = 1;
+	ep->return_bitmap = calloc(ep->bitmap_words, sizeof(uint64_t));
+	if (!ep->return_bitmap) {
+		ret = -FI_ENOMEM;
+		goto free0;
+	}
+	ep->last_comp_count = 0;
+
 	return FI_SUCCESS;
 
+free0:
+	ofi_bufpool_destroy(ep->pend_pool);
 free1:
 	ofi_bufpool_destroy(ep->unexp_buf_pool);
 free2:

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -169,25 +169,49 @@ static int smr_progress_return_entry(struct smr_ep *ep, struct smr_cmd *cmd,
 
 static void smr_progress_return(struct smr_ep *ep)
 {
-	struct smr_return_entry *queue_entry;
 	struct smr_cmd *cmd;
 	struct smr_pend_entry *pending;
-	int64_t pos;
+	uint64_t cc, status;
+	size_t w;
 	int ret;
 
-	while (1) {
-		ret = smr_return_queue_head(smr_return_queue(ep->region),
-					    &queue_entry, &pos);
-		if (ret == -FI_ENOENT)
-			break;
+	/* comp_count is bumped (release) by peers each time they return a
+	 * borrowed command. Read it with acquire; if unchanged, nothing was
+	 * returned since the last scan and the slots/payloads we would read
+	 * are already accounted for.
+	 */
+	cc = __atomic_load_n(smr_comp_count(ep->region), __ATOMIC_ACQUIRE);
+	if (cc == ep->last_comp_count)
+		return;
+	ep->last_comp_count = cc;
 
-		cmd = (struct smr_cmd *) queue_entry->ptr;
-		pending = (struct smr_pend_entry *) cmd->hdr.tx_ctx;
+	for (w = 0; w < ep->bitmap_words; w++) {
+		uint64_t bits = ep->return_bitmap[w];
 
-		ret = smr_progress_return_entry(ep, cmd, pending);
-		if (ret != -FI_EAGAIN) {
-			assert(pending);
-			if (cmd->hdr.smr_flags & SMR_OP_ERROR) {
+		while (bits) {
+			int b = __builtin_ctzll(bits);
+			int16_t slot = (int16_t) (w * 64) + b;
+
+			bits &= ~(1ULL << b);
+
+			cmd = smr_freestack_get_entry_from_index(
+					smr_cmd_stack(ep->region), slot);
+			pending = (struct smr_pend_entry *) cmd->hdr.tx_ctx;
+
+			/* Plain load: ordered by the comp_count acquire
+			 * above. A slot whose status has not advanced since
+			 * we last saw it has not been (re)signaled.
+			 */
+			status = smr_resp_slots(ep->region)[slot].status;
+			if (status == pending->last_resp_seen)
+				continue;
+			pending->last_resp_seen = status;
+
+			ret = smr_progress_return_entry(ep, cmd, pending);
+			if (ret == -FI_EAGAIN)
+				continue;
+
+			if (ret || (cmd->hdr.smr_flags & SMR_OP_ERROR)) {
 				ret = smr_write_err_comp(
 						ep->util_ep.tx_cq,
 						pending->comp_ctx,
@@ -199,16 +223,14 @@ static void smr_progress_return(struct smr_ep *ep)
 						cmd->hdr.op,
 						pending->comp_flags);
 			}
-			if (ret) {
+			if (ret)
 				FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-					"unable to process "
-					"tx completion\n");
-			}
+					"unable to process tx completion\n");
+
+			ep->return_bitmap[w] &= ~(1ULL << b);
 			ofi_buf_free(pending);
 			smr_freestack_push(smr_cmd_stack(ep->region), cmd);
 		}
-		smr_return_queue_release(smr_return_queue(ep->region),
-					 queue_entry, pos);
 	}
 }
 

--- a/prov/shm/src/smr_util.c
+++ b/prov/shm/src/smr_util.c
@@ -95,7 +95,7 @@ size_t smr_calculate_size_offsets(size_t tx_count, size_t rx_count,
 				  size_t *name_offset)
 {
 	size_t cmd_queue_offset, cmd_stack_offset, inject_pool_offset;
-	size_t ret_queue_offset, sar_pool_offset, peer_data_offset;
+	size_t resp_slots_offset, sar_pool_offset, peer_data_offset;
 	size_t ep_name_offset, tx_size, rx_size, total_size;
 
 	tx_size = roundup_power_of_two(tx_count);
@@ -107,11 +107,12 @@ size_t smr_calculate_size_offsets(size_t tx_count, size_t rx_count,
 		sizeof(struct smr_cmd_queue_entry) * rx_size;
 	cmd_stack_offset = inject_pool_offset +
 		freestack_size(sizeof(struct smr_inject_buf), rx_size);
-	ret_queue_offset = cmd_stack_offset +
+	resp_slots_offset = cmd_stack_offset +
 		freestack_size(sizeof(struct smr_cmd), tx_size);
-	ret_queue_offset = ofi_get_aligned_size(ret_queue_offset, 64);
-	sar_pool_offset = ret_queue_offset + sizeof(struct smr_return_queue) +
-		sizeof(struct smr_return_queue_entry) * tx_size;
+	resp_slots_offset = ofi_get_aligned_size(resp_slots_offset, 64);
+	/* 64B for comp_count (own cache line) + one slot per cmd-stack entry */
+	sar_pool_offset = resp_slots_offset + 64 +
+		sizeof(struct smr_resp_slot) * tx_size;
 	peer_data_offset = sar_pool_offset +
 		freestack_size(sizeof(struct smr_sar_buf), SMR_MAX_PEERS);
 	ep_name_offset = peer_data_offset + sizeof(struct smr_peer_data) *
@@ -126,7 +127,7 @@ size_t smr_calculate_size_offsets(size_t tx_count, size_t rx_count,
 	if (inject_offset)
 		*inject_offset = inject_pool_offset;
 	if (rq_offset)
-		*rq_offset = ret_queue_offset;
+		*rq_offset = resp_slots_offset;
 	if (sar_offset)
 		*sar_offset = sar_pool_offset;
 	if (peer_offset)
@@ -189,7 +190,7 @@ int smr_create(const struct fi_provider *prov, const struct smr_attr *attr,
 	       struct smr_region *volatile *smr)
 {
 	struct smr_ep_name *ep_name;
-	size_t total_size, cmd_queue_offset, ret_queue_offset, peer_data_offset;
+	size_t total_size, cmd_queue_offset, resp_slots_offset, peer_data_offset;
 	size_t cmd_stack_offset, inject_pool_offset, sar_pool_offset;
 	size_t name_offset;
 	int fd, ret, i;
@@ -201,7 +202,7 @@ int smr_create(const struct fi_provider *prov, const struct smr_attr *attr,
 	total_size = smr_calculate_size_offsets(
 				tx_size, rx_size, &cmd_queue_offset,
 				&cmd_stack_offset, &inject_pool_offset,
-				&ret_queue_offset, &sar_pool_offset,
+				&resp_slots_offset, &sar_pool_offset,
 				&peer_data_offset, &name_offset);
 
 	fd = shm_open(attr->name, O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
@@ -281,7 +282,7 @@ int smr_create(const struct fi_provider *prov, const struct smr_attr *attr,
 	(*smr)->cmd_queue_offset = cmd_queue_offset;
 	(*smr)->cmd_stack_offset = cmd_stack_offset;
 	(*smr)->inject_pool_offset = inject_pool_offset;
-	(*smr)->ret_queue_offset = ret_queue_offset;
+	(*smr)->resp_slots_offset = resp_slots_offset;
 	(*smr)->sar_pool_offset = sar_pool_offset;
 	(*smr)->peer_data_offset = peer_data_offset;
 	(*smr)->name_offset = name_offset;
@@ -290,7 +291,7 @@ int smr_create(const struct fi_provider *prov, const struct smr_attr *attr,
 	smr_cmd_queue_init(smr_cmd_queue(*smr), rx_size, smr_cmd_init);
 	smr_freestack_init(smr_inject_pool(*smr), rx_size,
 			   sizeof(struct smr_inject_buf));
-	smr_return_queue_init(smr_return_queue(*smr), tx_size, NULL);
+	*smr_comp_count(*smr) = 0;
 
 	smr_freestack_init(smr_cmd_stack(*smr), tx_size,
 			   sizeof(struct smr_cmd));

--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -267,7 +267,7 @@ struct smr_region {
 		size_t			cmd_queue_offset;
 		size_t			inject_pool_offset;
 		size_t			cmd_stack_offset;
-		size_t			ret_queue_offset;
+		size_t			resp_slots_offset;
 		size_t			sar_pool_offset;
 		size_t			peer_data_offset;
 		size_t			name_offset;
@@ -305,12 +305,16 @@ struct smr_sar_buf {
 	uint8_t		buf[SMR_SAR_SIZE];
 };
 
-struct smr_return_entry {
-	uintptr_t ptr;
+/* Per-command completion slot. The receiver bumps status (single writer
+ * at a time) when it is done with a borrowed command; the sender scans
+ * its in-flight bitmap and completes out-of-order. comp_count gates the
+ * scan. There is one slot per command-stack entry, indexed by the
+ * command's freestack index, so capacity matches the command stack. */
+struct smr_resp_slot {
+	uint64_t	status;
 };
 
 OFI_DECLARE_ATOMIC_Q(struct smr_cmd, smr_cmd_queue);
-OFI_DECLARE_ATOMIC_Q(struct smr_return_entry, smr_return_queue);
 
 /* Queue of offsets of the command blocks obtained from the command pool
  * freestack
@@ -328,10 +332,16 @@ static inline struct smr_freestack *smr_inject_pool(struct smr_region *smr)
 	return (struct smr_freestack *)
 			((char *) smr + smr->inject_pool_offset);
 }
-static inline struct smr_return_queue *smr_return_queue(struct smr_region *smr)
+/* comp_count sits at the start of the resp-slot block (its own cache
+ * line); the slot array follows. */
+static inline uint64_t *smr_comp_count(struct smr_region *smr)
 {
-	return (struct smr_return_queue *)
-			((char *) smr + smr->ret_queue_offset);
+	return (uint64_t *) ((char *) smr + smr->resp_slots_offset);
+}
+static inline struct smr_resp_slot *smr_resp_slots(struct smr_region *smr)
+{
+	return (struct smr_resp_slot *)
+			((char *) smr + smr->resp_slots_offset + 64);
 }
 static inline struct smr_peer_data *smr_peer_data(struct smr_region *smr)
 {


### PR DESCRIPTION
For proto_iov (CMA) operations, eliminate the command borrow and atomic return queue. Instead:
- Use the command queue entry (ce) directly (inline), avoiding freestack pop/push and smr_local_to_peer address translation
- Signal completion via per-op resp_slots: receiver stores resp_slots[slot].status = 1 + atomic_add(comp_count); sender scans its local bitmap out-of-order

This solves head-of-line blocking (each slot completes independently) while being lighter than both the MPMC atomic return queue (main) and the MPSC dlist (PR #12329):
- No atomic_swap or CAS on signal/drain
- No linked-list pointer chasing
- No spin-wait vulnerability window
- No command borrow overhead

SAR/IPC protocols continue to use the existing return queue. Applied to both RMA and msg/tagged IOV paths.