### PR TITLE
github/workflows: Add more comprehensive CodeQL query pack

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -62,8 +62,7 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
 
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
-
+        queries: security-and-quality
 
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     # If this step fails, then you should remove it and run the build manually (see below)


### PR DESCRIPTION
CodeQL is configured with the default query suite which is designed to produce very few false-positives, but can miss quite a lot of things. Adding security-and-quality suite will produce many more findings of interest, if a bit chatty. See
https://docs.github.com/en/code-security/concepts/code-scanning/codeql/codeql-query-suites for more information about each of the built-in suites.