### PR TITLE
prov/shm: Fix compile warning coming from shm

### DIFF
--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -209,7 +209,7 @@ struct smr_ep_name {
 
 static inline const char *smr_no_prefix(const char *addr)
 {
-	char *start;
+	const char *start;
 
 	return (start = strstr(addr, "://")) ? start + 3 : addr;
 }


### PR DESCRIPTION
Variable declared non-const returned from function with a const return value. This patch fixes the mismatch.