### PR TITLE
prov/verbs: Use ints for boolean values in vrb_gl_data for consistency

### DIFF
--- a/prov/verbs/include/linux/verbs_osd.h
+++ b/prov/verbs/include/linux/verbs_osd.h
@@ -44,7 +44,7 @@ static inline void vrb_os_fini()
 {
 }
 
-static inline void vrb_os_mem_support(bool *peer_mem, bool *dmabuf)
+static inline void vrb_os_mem_support(int *peer_mem, int *dmabuf)
 {
 	char *line = NULL;
 	size_t line_size = 0;
@@ -57,9 +57,9 @@ static inline void vrb_os_mem_support(bool *peer_mem, bool *dmabuf)
 
 	while ((bytes = getline(&line, &line_size, kallsyms_fd)) != -1) {
 		if (strstr(line, "ib_register_peer_memory_client"))
-			*peer_mem = true;
+			*peer_mem = (int)true;
 		else if (strstr(line, "ib_umem_dmabuf_get"))
-			*dmabuf = true;
+			*dmabuf = (int)true;
 		if (*peer_mem && *dmabuf)
 			break;
 	}

--- a/prov/verbs/src/verbs_init.c
+++ b/prov/verbs/src/verbs_init.c
@@ -735,7 +735,7 @@ static int vrb_read_params(void)
 	if (vrb_gl_data.dmabuf_support) {
 		if (vrb_get_param_bool("use_dmabuf", "Enable dmabuf based memory "
 				       "registrations, if supported. Yes by default.",
-				       (int *)&vrb_gl_data.dmabuf_support)) {
+				       &vrb_gl_data.dmabuf_support)) {
 			VRB_WARN(FI_LOG_CORE, "Invalid value of use_dmabuf\n");
 			return -FI_EINVAL;
 		}

--- a/prov/verbs/src/verbs_ofi.h
+++ b/prov/verbs/src/verbs_ofi.h
@@ -211,8 +211,8 @@ extern struct vrb_gl_data {
 		char	*xrcd_filename;
 	} msg;
 
-	bool	peer_mem_support;
-	bool	dmabuf_support;
+	int	peer_mem_support;
+	int	dmabuf_support;
 
 	vrb_nic_affinity_handler_t	nic_affinity_handler;
 	char	*nic_affinity_policy;


### PR DESCRIPTION
This fixes a memory access bug: https://github.com/ofiwg/libfabric/issues/12339