### PR TITLE
prov/shm: Remove init_fn from cmd queue release path

### DIFF
--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -275,6 +275,7 @@ static ssize_t smr_generic_atomic(
 
 		cmd = smr_freestack_pop(smr_cmd_stack(ep->region));
 		assert(cmd);
+		ce->hdr.smr_flags = smr_flags;
 		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
 						  (uintptr_t) cmd);
 	} else {

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -186,6 +186,7 @@ static void smr_send_name(struct smr_ep *ep, int64_t id)
 		return;
 
 	cmd->hdr.op = SMR_OP_MAX + ofi_ctrl_connreq;
+	cmd->hdr.smr_flags = 0;
 	cmd->hdr.tx_id = id;
 	cmd->hdr.cq_data = ep->region->pid;
 

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -120,6 +120,7 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 
 		cmd = smr_freestack_pop(smr_cmd_stack(ep->region));
 		assert(cmd);
+		ce->hdr.smr_flags = smr_flags;
 		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
 						  (uintptr_t) cmd);
 	} else {

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -52,6 +52,7 @@ static void smr_progress_overflow(struct smr_ep *ep)
 		if (ret == -FI_ENOENT)
 			return;
 
+		ce->hdr.smr_flags = cmd->hdr.smr_flags;
 		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, cmd->hdr.tx_id,
 						  cmd->hdr.rx_id,
 						  (uintptr_t) cmd);
@@ -1341,7 +1342,8 @@ static void smr_progress_cmd(struct smr_ep *ep)
 		if (ret == -FI_ENOENT)
 			break;
 
-		cmd = (struct smr_cmd *) ce->hdr.entry;
+		cmd = (ce->hdr.smr_flags & SMR_RETURN_CMD) ?
+		      (struct smr_cmd *) ce->hdr.entry : ce;
 		switch (cmd->hdr.op) {
 		case ofi_op_msg:
 		case ofi_op_tagged:

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -181,6 +181,7 @@ static ssize_t smr_generic_rma(
 		}
 		cmd = smr_freestack_pop(smr_cmd_stack(ep->region));
 		assert(cmd);
+		ce->hdr.smr_flags = smr_flags;
 		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
 						  (uintptr_t) cmd);
 	} else {

--- a/prov/shm/src/smr_util.c
+++ b/prov/shm/src/smr_util.c
@@ -178,12 +178,6 @@ err:
 	return -FI_EBUSY;
 }
 
-static inline void smr_cmd_init(void *buf)
-{
-	struct smr_cmd *cmd = buf;
-	cmd->hdr.entry = (uintptr_t) cmd;
-}
-
 /* TODO: Determine if aligning SMR data helps performance */
 int smr_create(const struct fi_provider *prov, const struct smr_attr *attr,
 	       struct smr_region *volatile *smr)
@@ -287,7 +281,7 @@ int smr_create(const struct fi_provider *prov, const struct smr_attr *attr,
 	(*smr)->name_offset = name_offset;
 	(*smr)->max_sar_buf_per_peer = SMR_BUF_BATCH_MAX;
 
-	smr_cmd_queue_init(smr_cmd_queue(*smr), rx_size, smr_cmd_init);
+	smr_cmd_queue_init(smr_cmd_queue(*smr), rx_size, NULL);
 	smr_freestack_init(smr_inject_pool(*smr), rx_size,
 			   sizeof(struct smr_inject_buf));
 	smr_return_queue_init(smr_return_queue(*smr), tx_size, NULL);


### PR DESCRIPTION
Remove the indirect init_fn call from smr_cmd_queue release which reset ce->hdr.entry on every dequeued message. Instead, the sender writes ce->hdr.smr_flags on the queue entry before commit, and the receiver checks ce->hdr.smr_flags & SMR_RETURN_CMD to decide whether to use ce directly (inline) or follow ce->hdr.entry (freestack). This eliminates an indirect call and store per received message, improving small message
rate by 3-5%.
