### PR TITLE
fabtests/efa/pytest: Move multi_ep_stress to stable

### DIFF
--- a/fabtests/pytest/efa/test_multi_ep_stress.py
+++ b/fabtests/pytest/efa/test_multi_ep_stress.py
@@ -1,7 +1,6 @@
 import pytest
 from common import ClientServerTest
 
-@pytest.mark.unstable
 @pytest.mark.parametrize("remove_av", [True, False])
 def test_multi_ep_stress_standard(cmdline_args, remove_av):
     cmd = f"fi_efa_multi_ep_stress"
@@ -10,7 +9,6 @@ def test_multi_ep_stress_standard(cmdline_args, remove_av):
     test = ClientServerTest(cmdline_args, cmd, message_size=1024, fabric="efa", additional_env="FI_EFA_ENABLE_SHM_TRANSFER=0")
     test.run()
 
-@pytest.mark.unstable
 @pytest.mark.parametrize("remove_av", [True, False])
 def test_multi_ep_stress_tagged(cmdline_args, remove_av):
     cmd = f"fi_efa_multi_ep_stress --op-type tagged"
@@ -19,7 +17,6 @@ def test_multi_ep_stress_tagged(cmdline_args, remove_av):
     test = ClientServerTest(cmdline_args, cmd, message_size=1024, fabric="efa", additional_env="FI_EFA_ENABLE_SHM_TRANSFER=0")
     test.run()
 
-@pytest.mark.unstable
 @pytest.mark.parametrize("remove_av", [True, False])
 def test_multi_ep_stress_writedata(cmdline_args, remove_av):
     cmd = f"fi_efa_multi_ep_stress --op-type writedata"
@@ -28,7 +25,6 @@ def test_multi_ep_stress_writedata(cmdline_args, remove_av):
     test = ClientServerTest(cmdline_args, cmd, message_size=1024, fabric="efa", additional_env="FI_EFA_ENABLE_SHM_TRANSFER=0")
     test.run()
 
-@pytest.mark.unstable
 @pytest.mark.parametrize("remove_av", [True, False])
 def test_multi_ep_stress_multi_receivers(cmdline_args, remove_av):
     cmd = f"fi_efa_multi_ep_stress --receiver-workers 4"
@@ -38,7 +34,6 @@ def test_multi_ep_stress_multi_receivers(cmdline_args, remove_av):
     test.run()
 
 
-@pytest.mark.unstable
 @pytest.mark.parametrize("remove_av", [True, False])
 def test_multi_ep_stress_multi_senders(cmdline_args, remove_av):
     cmd = f"fi_efa_multi_ep_stress --sender-workers 10"
@@ -47,7 +42,6 @@ def test_multi_ep_stress_multi_senders(cmdline_args, remove_av):
     test = ClientServerTest(cmdline_args, cmd, message_size=1024, fabric="efa", additional_env="FI_EFA_ENABLE_SHM_TRANSFER=0")
     test.run()
 
-@pytest.mark.unstable
 @pytest.mark.parametrize("remove_av", [True, False])
 def test_multi_ep_stress_shared_cq(cmdline_args, remove_av):
     cmd = f"fi_efa_multi_ep_stress --receiver-workers 4 --shared-cq"
@@ -56,7 +50,6 @@ def test_multi_ep_stress_shared_cq(cmdline_args, remove_av):
     test = ClientServerTest(cmdline_args, cmd, message_size=1024, fabric="efa", additional_env="FI_EFA_ENABLE_SHM_TRANSFER=0")
     test.run()
 
-@pytest.mark.unstable
 @pytest.mark.parametrize("remove_av", [True, False])
 def test_multi_ep_stress_shared_av(cmdline_args, remove_av):
     cmd = f"fi_efa_multi_ep_stress --sender-workers 8 --receiver-workers 2 --shared-av"
@@ -65,7 +58,6 @@ def test_multi_ep_stress_shared_av(cmdline_args, remove_av):
     test = ClientServerTest(cmdline_args, cmd, message_size=1024, fabric="efa", additional_env="FI_EFA_ENABLE_SHM_TRANSFER=0")
     test.run()
 
-@pytest.mark.unstable
 @pytest.mark.parametrize("remove_av", [True, False])
 def test_multi_ep_stress_shared_av_and_cq(cmdline_args, remove_av):
     cmd = f"fi_efa_multi_ep_stress --sender-workers 8 --receiver-workers 2 --shared-av --shared-cq"
@@ -74,7 +66,6 @@ def test_multi_ep_stress_shared_av_and_cq(cmdline_args, remove_av):
     test = ClientServerTest(cmdline_args, cmd, message_size=1024, fabric="efa", additional_env="FI_EFA_ENABLE_SHM_TRANSFER=0")
     test.run()
 
-@pytest.mark.unstable
 @pytest.mark.parametrize("remove_av", [True, False])
 def test_multi_ep_stress_transient_client(cmdline_args, remove_av):
     cmd = f"fi_efa_multi_ep_stress --sender-ep-cycles 5"
@@ -83,7 +74,6 @@ def test_multi_ep_stress_transient_client(cmdline_args, remove_av):
     test = ClientServerTest(cmdline_args, cmd, message_size=1024, fabric="efa", additional_env="FI_EFA_ENABLE_SHM_TRANSFER=0")
     test.run()
 
-@pytest.mark.unstable
 @pytest.mark.parametrize("remove_av", [True, False])
 @pytest.mark.parametrize("configuration", [{"sender_workers": 2, "receiver_workers": 4, "sender_ep_cycles": 10, "receiver_ep_cycles": 20},
                                            {"sender_workers": 4, "receiver_workers": 2, "sender_ep_cycles": 20, "receiver_ep_cycles": 10},


### PR DESCRIPTION
Removing unstable mark form  muti_ep_stress tests as they had not show any failure for the last week.