### PR TITLE
prov/efa: log selected two-sided transfer protocol

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_msg.c
+++ b/prov/efa/src/rdm/efa_rdm_msg.c
@@ -18,6 +18,8 @@
 #include "efa_rdm_pke_utils.h"
 #include "efa_rdm_pke_req.h"
 
+#include "efa_rdm_util.h"
+
 #include "efa_rdm_tracepoint.h"
 
 /**
@@ -136,6 +138,10 @@ ssize_t efa_rdm_msg_post_rtm(struct efa_rdm_ep *ep, struct efa_rdm_ope *txe)
 
 	rtm_type = efa_rdm_msg_select_rtm(ep, txe, use_p2p);
 	assert(rtm_type >= EFA_RDM_REQ_PKT_BEGIN);
+
+	EFA_DBG(FI_LOG_EP_DATA,
+		"efa-rdm selecting transfer protocol %s (rtm_type=%d) total_len=%zu endpoint=%p txe=%p\n",
+		efa_rdm_rtm_type_to_str(rtm_type), rtm_type, txe->total_len, ep, txe);
 
 	if (rtm_type < EFA_RDM_EXTRA_REQ_PKT_BEGIN) {
 		/* rtm requires only baseline feature, which peer should always support. */

--- a/prov/efa/src/rdm/efa_rdm_util.c
+++ b/prov/efa/src/rdm/efa_rdm_util.c
@@ -167,3 +167,68 @@ int efa_rdm_write_error_msg(struct efa_rdm_ep *ep, struct efa_rdm_peer *peer, in
 
 	return 0;
 }
+
+/**
+ * @brief return the exact name of an EFA RDM packet type
+ * @param[in] pkt_type  an EFA_RDM_*_PKT id (see efa_rdm_protocol.h)
+ * @return constant string naming the exact packet type
+ */
+const char *efa_rdm_rtm_type_to_str(int pkt_type)
+{
+	switch (pkt_type) {
+	/* Non-REQ / control packets */
+	case EFA_RDM_RETIRED_RTS_PKT:		return "RETIRED_RTS";
+	case EFA_RDM_RETIRED_CONNACK_PKT:	return "RETIRED_CONNACK";
+	case EFA_RDM_CTS_PKT:			return "CTS";
+	case EFA_RDM_CTSDATA_PKT:		return "CTSDATA";
+	case EFA_RDM_READRSP_PKT:		return "READRSP";
+	case EFA_RDM_RMA_CONTEXT_PKT:		return "RMA_CONTEXT";
+	case EFA_RDM_EOR_PKT:			return "EOR";
+	case EFA_RDM_ATOMRSP_PKT:		return "ATOMRSP";
+	case EFA_RDM_HANDSHAKE_PKT:		return "HANDSHAKE";
+	case EFA_RDM_RECEIPT_PKT:		return "RECEIPT";
+	case EFA_RDM_READ_NACK_PKT:		return "READ_NACK";
+
+	/* Baseline REQ packets */
+	case EFA_RDM_EAGER_MSGRTM_PKT:		return "EAGER_MSGRTM";
+	case EFA_RDM_EAGER_TAGRTM_PKT:		return "EAGER_TAGRTM";
+	case EFA_RDM_MEDIUM_MSGRTM_PKT:		return "MEDIUM_MSGRTM";
+	case EFA_RDM_MEDIUM_TAGRTM_PKT:		return "MEDIUM_TAGRTM";
+	case EFA_RDM_LONGCTS_MSGRTM_PKT:	return "LONGCTS_MSGRTM";
+	case EFA_RDM_LONGCTS_TAGRTM_PKT:	return "LONGCTS_TAGRTM";
+	case EFA_RDM_EAGER_RTW_PKT:		return "EAGER_RTW";
+	case EFA_RDM_LONGCTS_RTW_PKT:		return "LONGCTS_RTW";
+	case EFA_RDM_SHORT_RTR_PKT:		return "SHORT_RTR";
+	case EFA_RDM_LONGCTS_RTR_PKT:		return "LONGCTS_RTR";
+	case EFA_RDM_WRITE_RTA_PKT:		return "WRITE_RTA";
+	case EFA_RDM_FETCH_RTA_PKT:		return "FETCH_RTA";
+	case EFA_RDM_COMPARE_RTA_PKT:		return "COMPARE_RTA";
+
+	/* Extra-feature REQ packets (read-based) */
+	case EFA_RDM_LONGREAD_MSGRTM_PKT:	return "LONGREAD_MSGRTM";
+	case EFA_RDM_LONGREAD_TAGRTM_PKT:	return "LONGREAD_TAGRTM";
+	case EFA_RDM_LONGREAD_RTW_PKT:		return "LONGREAD_RTW";
+	case EFA_RDM_READ_RTR_PKT:		return "READ_RTR";
+
+	/* Delivery-complete (DC) REQ packets */
+	case EFA_RDM_DC_EAGER_MSGRTM_PKT:	return "DC_EAGER_MSGRTM";
+	case EFA_RDM_DC_EAGER_TAGRTM_PKT:	return "DC_EAGER_TAGRTM";
+	case EFA_RDM_DC_MEDIUM_MSGRTM_PKT:	return "DC_MEDIUM_MSGRTM";
+	case EFA_RDM_DC_MEDIUM_TAGRTM_PKT:	return "DC_MEDIUM_TAGRTM";
+	case EFA_RDM_DC_LONGCTS_MSGRTM_PKT:	return "DC_LONGCTS_MSGRTM";
+	case EFA_RDM_DC_LONGCTS_TAGRTM_PKT:	return "DC_LONGCTS_TAGRTM";
+	case EFA_RDM_DC_EAGER_RTW_PKT:		return "DC_EAGER_RTW";
+	case EFA_RDM_DC_LONGCTS_RTW_PKT:	return "DC_LONGCTS_RTW";
+	case EFA_RDM_DC_WRITE_RTA_PKT:		return "DC_WRITE_RTA";
+
+	/* Runting REQ packets */
+	case EFA_RDM_RUNTCTS_MSGRTM_PKT:	return "RUNTCTS_MSGRTM";
+	case EFA_RDM_RUNTCTS_TAGRTM_PKT:	return "RUNTCTS_TAGRTM";
+	case EFA_RDM_RUNTCTS_RTW_PKT:		return "RUNTCTS_RTW";
+	case EFA_RDM_RUNTREAD_MSGRTM_PKT:	return "RUNTREAD_MSGRTM";
+	case EFA_RDM_RUNTREAD_TAGRTM_PKT:	return "RUNTREAD_TAGRTM";
+	case EFA_RDM_RUNTREAD_RTW_PKT:		return "RUNTREAD_RTW";
+
+	default:				return "UNKNOWN";
+	}
+}

--- a/prov/efa/src/rdm/efa_rdm_util.h
+++ b/prov/efa/src/rdm/efa_rdm_util.h
@@ -23,6 +23,8 @@ int efa_rdm_construct_msg_with_local_and_peer_information(struct efa_rdm_ep *ep,
 
 int efa_rdm_write_error_msg(struct efa_rdm_ep *ep, struct efa_rdm_peer *peer, int prov_errno, char *err_msg, size_t *buflen);
 
+const char *efa_rdm_rtm_type_to_str(int pkt_type);
+
 #ifdef ENABLE_EFA_POISONING
 static inline void efa_rdm_poison_mem_region(void *ptr, size_t size)
 {


### PR DESCRIPTION
Add a debug log line in efa_rdm_msg_post_rtm() that records which RTM wire protocol was selected for each two-sided send (EAGER, MEDIUM, LONGCTS, LONGREAD, or RUNTREAD). This makes protocol selection observable for debugging and lets tests confirm a given message exercised the intended protocol.

The log is emitted at FI_LOG_DEBUG, so it has no effect unless debug logging is enabled (and is compiled out entirely in non-debug builds). Because FI_LOG expands the format arguments inside the fi_log_enabled() guard, the rtm_type-to-string conversion is only evaluated when the message is actually logged -- the only data-path cost is for fi_log_enabled().

Add efa_rdm_rtm_type_to_str() to efa_rdm_util.{c,h} to map an EFA_RDM_*_RTM_PKT id to a human-readable protocol name (handles the baseline and DC variants).