### PR TITLE
prov/verbs: Add an alternative CM

### DIFF
--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -625,6 +625,43 @@ void ofi_bsock_prefetch_done(struct ofi_bsock *bsock, size_t len);
 #define OFI_IB_IP_PS_MASK   0xFFFFFFFFFFFF0000ULL
 #define OFI_IB_IP_PORT_MASK   0x000000000000FFFFULL
 
+/* Portable mirror of libibverbs' union ibv_gid so that shared headers
+ * (ofi_net.h, rxm) can reference the GID type without depending on
+ * <infiniband/verbs.h>. */
+union ofi_ib_gid {
+	uint8_t		raw[16];
+	struct {
+		uint64_t subnet_prefix;	/* network byte order */
+		uint64_t interface_id;	/* network byte order */
+	} global;
+};
+
+/*
+ * FI_ADDR_IB_UD native address format — 32 bytes.
+ *
+ * This is the address stored directly in the AV for UD endpoints
+ * (including the UDCM connection manager path).
+ * It carries all fields needed to create a UD address handle and
+ * route connection-management messages.
+ *
+ * Note: DON'T change the placement of the fields in the structure.
+ *       The placement is to keep structure size = 256 bits (32 byte).
+ *       This struct doubles as the wire format — any layout change
+ *       breaks interop.
+ */
+struct ofi_addr_ib_ud {
+	union ofi_ib_gid gid;		/* 128-bit GID (GRH routing) */
+
+	uint32_t	qpn;		/* Queue Pair Number (BTH) */
+
+	uint16_t	lid;		/* Local ID (LRH) */
+	uint16_t	pkey;		/* Partition Key (BTH) */
+	uint16_t	service;	/* Service port (NS / RXM), 0 = any */
+
+	uint8_t		sl;		/* Service Level (LRH) */
+	uint8_t		padding[5];	/* Pad to 32 bytes */
+}; /* 32 bytes */
+
 struct ofi_sockaddr_ib {
 	unsigned short int  sib_family; /* AF_IB */
 	uint16_t            sib_pkey;
@@ -734,6 +771,8 @@ static inline size_t ofi_sizeof_addr_format(int format)
 		return sizeof(struct sockaddr_in6);
 	case FI_SOCKADDR_IB:
 		return sizeof(struct ofi_sockaddr_ib);
+	case FI_ADDR_IB_UD:
+		return sizeof(struct ofi_addr_ib_ud);
 	default:
 		FI_WARN(&core_prov, FI_LOG_CORE, "Unsupported address format\n");
 		return 0;

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -344,6 +344,7 @@ enum {
 	FI_PROTO_CXI_RNR,
 	FI_PROTO_LPP,
 	FI_PROTO_LNX,
+	FI_PROTO_UD_CM_IB_RC,
 };
 
 enum {

--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -808,6 +808,9 @@
     <ClCompile Include="prov\verbs\src\verbs_cm.c">
       <AdditionalIncludeDirectories>$(ProjectDir)prov\verbs\src;$(ProjectDir)prov\verbs\include;$(ProjectDir)prov\verbs\include\windows;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
+    <ClCompile Include="prov\verbs\src\verbs_cm_rdma.c">
+      <AdditionalIncludeDirectories>$(ProjectDir)prov\verbs\src;$(ProjectDir)prov\verbs\include;$(ProjectDir)prov\verbs\include\windows;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
     <ClCompile Include="prov\verbs\src\verbs_cm_xrc.c">
       <AdditionalIncludeDirectories>$(ProjectDir)prov\verbs\src;$(ProjectDir)prov\verbs\include;$(ProjectDir)prov\verbs\include\windows;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>

--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -811,6 +811,9 @@
     <ClCompile Include="prov\verbs\src\verbs_cm_rdma.c">
       <AdditionalIncludeDirectories>$(ProjectDir)prov\verbs\src;$(ProjectDir)prov\verbs\include;$(ProjectDir)prov\verbs\include\windows;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
+    <ClCompile Include="prov\verbs\src\verbs_cm_ud.c">
+      <AdditionalIncludeDirectories>$(ProjectDir)prov\verbs\src;$(ProjectDir)prov\verbs\include;$(ProjectDir)prov\verbs\include\windows;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
     <ClCompile Include="prov\verbs\src\verbs_cm_xrc.c">
       <AdditionalIncludeDirectories>$(ProjectDir)prov\verbs\src;$(ProjectDir)prov\verbs\include;$(ProjectDir)prov\verbs\include\windows;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -698,6 +698,32 @@ int rxm_start_listen(struct rxm_ep *ep);
 void rxm_stop_listen(struct rxm_ep *ep);
 void rxm_conn_progress(struct rxm_ep *ep);
 
+static inline uint16_t
+rxm_addr_get_port(uint32_t addr_format, const void *addr)
+{
+	if (addr_format == FI_ADDR_IB_UD)
+		return ((const struct ofi_addr_ib_ud *)addr)->service;
+	return (uint16_t)ofi_addr_get_port((const struct sockaddr *)addr);
+}
+
+static inline void
+rxm_addr_set_port(uint32_t addr_format, void *addr, uint16_t port)
+{
+	if (addr_format == FI_ADDR_IB_UD)
+		((struct ofi_addr_ib_ud *)addr)->service = port;
+	else
+		ofi_addr_set_port((struct sockaddr *)addr, port);
+}
+
+static inline int
+rxm_addr_cmp(uint32_t addr_format, const void *a1, const void *a2)
+{
+	if (addr_format == FI_ADDR_IB_UD)
+		return memcmp(a1, a2, sizeof(struct ofi_addr_ib_ud));
+	return ofi_addr_cmp(&rxm_prov, (const struct sockaddr *)a1,
+			    (const struct sockaddr *)a2);
+}
+
 
 extern struct fi_provider rxm_prov;
 extern struct fi_info rxm_thru_info;

--- a/prov/rxm/src/rxm_attr.c
+++ b/prov/rxm/src/rxm_attr.c
@@ -211,6 +211,17 @@ static struct fi_info rxm_coll_info = {
 	.fabric_attr = &rxm_fabric_attr
 };
 
+static struct fi_info rxm_coll_udcm_info = {
+	.caps = RXM_TX_CAPS | RXM_RX_CAPS | RXM_DOMAIN_CAPS | FI_COLLECTIVE,
+	.addr_format = FI_ADDR_IB_UD,
+	.tx_attr = &rxm_tx_attr_coll,
+	.rx_attr = &rxm_rx_attr_coll,
+	.ep_attr = &rxm_ep_attr_coll,
+	.domain_attr = &rxm_domain_attr,
+	.fabric_attr = &rxm_fabric_attr,
+	.next = &rxm_coll_info,
+};
+
 static struct fi_info rxm_base_info = {
 	.caps = RXM_TX_CAPS | RXM_RX_CAPS | RXM_DOMAIN_CAPS | FI_HMEM,
 	.addr_format = FI_SOCKADDR,
@@ -219,7 +230,7 @@ static struct fi_info rxm_base_info = {
 	.ep_attr = &rxm_ep_attr,
 	.domain_attr = &rxm_domain_attr,
 	.fabric_attr = &rxm_fabric_attr,
-	.next = &rxm_coll_info,
+	.next = &rxm_coll_udcm_info,
 };
 
 static struct fi_info rxm_tcp_info = {
@@ -255,8 +266,19 @@ static struct fi_info rxm_verbs_info = {
 	.next = &rxm_thru_info,
 };
 
+static struct fi_info rxm_verbs_udcm_info = {
+	.caps = RXM_TX_CAPS | RXM_RX_CAPS | RXM_DOMAIN_CAPS | FI_HMEM,
+	.addr_format = FI_ADDR_IB_UD,
+	.tx_attr = &rxm_tx_attr,
+	.rx_attr = &rxm_rx_attr,
+	.ep_attr = &rxm_ep_attr,
+	.domain_attr = &rxm_domain_attr,
+	.fabric_attr = &rxm_verbs_fabric_attr,
+	.next = &rxm_verbs_info,
+};
+
 struct util_prov rxm_util_prov = {
 	.prov = &rxm_prov,
-	.info = &rxm_verbs_info,
+	.info = &rxm_verbs_udcm_info,
 	.flags = 0,
 };

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -258,7 +258,8 @@ static int rxm_init_connect_data(struct rxm_conn *conn,
 		return -FI_EOTHER;
 	}
 
-	cm_data->connect.port = ofi_addr_get_port(&conn->ep->addr.sa);
+	cm_data->connect.port = rxm_addr_get_port(conn->ep->msg_info->addr_format,
+						  &conn->ep->addr);
 	cm_data->connect.client_conn_id = rxm_conn_id(conn->peer->index);
 	return 0;
 }
@@ -656,7 +657,8 @@ rxm_process_connreq(struct rxm_ep *ep, struct rxm_eq_cm_entry *cm_entry)
 
 	memcpy(&peer_addr, cm_entry->info->dest_addr,
 	       cm_entry->info->dest_addrlen);
-	ofi_addr_set_port(&peer_addr.sa, cm_entry->data.connect.port);
+	rxm_addr_set_port(cm_entry->info->addr_format, &peer_addr,
+			  cm_entry->data.connect.port);
 
 	av = container_of(ep->util_ep.av, struct rxm_av, util_av);
 	peer = util_get_peer(av, &peer_addr, 0);
@@ -675,7 +677,8 @@ rxm_process_connreq(struct rxm_ep *ep, struct rxm_eq_cm_entry *cm_entry)
 		break;
 	case RXM_CM_CONNECTING:
 		/* simultaneous connections */
-		cmp = ofi_addr_cmp(&rxm_prov, &peer_addr.sa, &ep->addr.sa);
+		cmp = rxm_addr_cmp(ep->msg_info->addr_format,
+				   &peer_addr, &ep->addr);
 		if (cmp < 0) {
 			/* let our request finish */
 			FI_INFO(&rxm_prov, FI_LOG_EP_CTRL,
@@ -987,7 +990,7 @@ int rxm_start_listen(struct rxm_ep *ep)
 		return -FI_ENOMEM;
 
 	ep->msg_info->src_addrlen = addr_len;
-	ofi_addr_set_port(ep->msg_info->src_addr, 0);
+	rxm_addr_set_port(ep->msg_info->addr_format, ep->msg_info->src_addr, 0);
 
 	if (ep->util_ep.domain->data_progress == FI_PROGRESS_AUTO ||
 	    force_auto_progress) {

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -529,11 +529,13 @@ static int rxm_getinfo(uint32_t version, const char *node, const char *service,
 {
 	struct fi_info *cur;
 	struct addrinfo *ai;
+	uint32_t addr_format = hints ? hints->addr_format : FI_FORMAT_UNSPEC;
 	uint16_t port_save = 0;
 	int ret;
 
-	/* Avoid getting wild card address from MSG provider */
-	if (ofi_is_wildcard_listen_addr(node, service, flags, hints)) {
+	/* Only apply wildcard rewrite for sockaddr-based formats. */
+	if (addr_format != FI_ADDR_IB_UD &&
+	    ofi_is_wildcard_listen_addr(node, service, flags, hints)) {
 		if (service) {
 			ret = getaddrinfo(NULL, service, NULL, &ai);
 			if (ret) {
@@ -566,7 +568,7 @@ static int rxm_getinfo(uint32_t version, const char *node, const char *service,
 	if (port_save) {
 		for (cur = *info; cur; cur = cur->next) {
 			assert(cur->src_addr);
-			ofi_addr_set_port(cur->src_addr, port_save);
+			rxm_addr_set_port(cur->addr_format, cur->src_addr, port_save);
 		}
 	}
 

--- a/prov/util/src/rxm_av.c
+++ b/prov/util/src/rxm_av.c
@@ -304,7 +304,30 @@ static int rxm_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 	}
 
 	av = container_of(av_fid, struct rxm_av, util_av.av_fid.fid);
-	ret = ofi_ip_av_insert(av_fid, addr, count, fi_addr, flags, context);
+
+	if (av->util_av.domain->addr_format == FI_ADDR_IB_UD) {
+		size_t addrlen = sizeof(struct ofi_addr_ib_ud);
+		int success_cnt = 0;
+
+		ret = ofi_verify_av_insert(&av->util_av, flags, context);
+		if (ret)
+			goto out;
+
+		for (size_t i = 0; i < count; i++) {
+			const void *a = (const char *)addr + i * addrlen;
+
+			ofi_genlock_lock(&av->util_av.lock);
+			ret = ofi_av_insert_addr(&av->util_av, a,
+						 fi_addr ? &fi_addr[i] : NULL);
+			ofi_genlock_unlock(&av->util_av.lock);
+			if (!ret)
+				success_cnt++;
+		}
+		ret = success_cnt;
+	} else {
+		ret = ofi_ip_av_insert(av_fid, addr, count, fi_addr, flags,
+				       context);
+	}
 	if (ret < 0)
 		goto out;
 
@@ -341,6 +364,10 @@ static int rxm_av_insertsym(struct fid_av *av_fid, const char *node,
 	int ret;
 
 	av = container_of(av_fid, struct rxm_av, util_av.av_fid.fid);
+
+	if (av->util_av.domain->addr_format == FI_ADDR_IB_UD)
+		return -FI_ENOSYS;
+
 	ret = ofi_verify_av_insert(&av->util_av, flags, context);
 	if (ret)
 		return ret;
@@ -376,6 +403,10 @@ int rxm_av_insertsvc(struct fid_av *av, const char *node, const char *service,
 static const char *rxm_av_straddr(struct fid_av *av_fid, const void *addr,
 				  char *buf, size_t *len)
 {
+	struct util_av *av = container_of(av_fid, struct util_av, av_fid);
+
+	if (av->domain->addr_format == FI_ADDR_IB_UD)
+		return ofi_straddr(buf, len, FI_ADDR_IB_UD, addr);
 	return ofi_ip_av_straddr(av_fid, addr, buf, len);
 }
 

--- a/prov/verbs/Makefile.include
+++ b/prov/verbs/Makefile.include
@@ -5,6 +5,7 @@ _verbs_files =							\
 	prov/verbs/src/verbs_cm.c				\
 	prov/verbs/src/verbs_cm_xrc.c				\
 	prov/verbs/src/verbs_cm_rdma.c				\
+	prov/verbs/src/verbs_cm_ud.c				\
 	prov/verbs/src/verbs_cq.c				\
 	prov/verbs/src/verbs_domain.c				\
 	prov/verbs/src/verbs_domain_xrc.c			\

--- a/prov/verbs/Makefile.include
+++ b/prov/verbs/Makefile.include
@@ -4,6 +4,7 @@ _verbs_files =							\
 	prov/verbs/src/verbs_init.c				\
 	prov/verbs/src/verbs_cm.c				\
 	prov/verbs/src/verbs_cm_xrc.c				\
+	prov/verbs/src/verbs_cm_rdma.c				\
 	prov/verbs/src/verbs_cq.c				\
 	prov/verbs/src/verbs_domain.c				\
 	prov/verbs/src/verbs_domain_xrc.c			\

--- a/prov/verbs/src/verbs_cm.c
+++ b/prov/verbs/src/verbs_cm.c
@@ -35,7 +35,7 @@
 #include "verbs_ofi.h"
 
 
-static int vrb_copy_addr(void *dst_addr, size_t *dst_addrlen, void *src_addr)
+int vrb_copy_addr(void *dst_addr, size_t *dst_addrlen, void *src_addr)
 {
 	size_t src_addrlen = ofi_sizeofaddr(src_addr);
 
@@ -55,110 +55,40 @@ static int vrb_copy_addr(void *dst_addr, size_t *dst_addrlen, void *src_addr)
 
 static int vrb_msg_ep_setname(fid_t ep_fid, void *addr, size_t addrlen)
 {
-	void *save_addr;
-	struct rdma_cm_id *id;
-	int ret;
-	struct vrb_ep *ep =
-		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
+	struct vrb_ep *ep = container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 
 	if (addrlen != ep->info_attr.src_addrlen) {
-		VRB_INFO(FI_LOG_EP_CTRL,"addrlen expected: %zu, got: %zu.\n",
-			   ep->info_attr.src_addrlen, addrlen);
+		VRB_INFO(FI_LOG_EP_CTRL, "addrlen expected: %zu, got: %zu.\n",
+			 ep->info_attr.src_addrlen, addrlen);
 		return -FI_EINVAL;
 	}
 
-	save_addr = ep->info_attr.src_addr;
-
-	ep->info_attr.src_addr = malloc(ep->info_attr.src_addrlen);
-	if (!ep->info_attr.src_addr) {
-		VRB_WARN(FI_LOG_EP_CTRL, "memory allocation failure\n");
-		ret = -FI_ENOMEM;
-		goto err1;
-	}
-
-	memcpy(ep->info_attr.src_addr, addr, ep->info_attr.src_addrlen);
-
-	ret = vrb_create_ep(ep, RDMA_PS_TCP, &id);
-	if (ret)
-		goto err2;
-
-	if (ep->id)
-		rdma_destroy_ep(ep->id);
-
-	ep->id = id;
-	ep->ibv_qp = ep->id->qp;
-	free(save_addr);
-
-	return 0;
-err2:
-	free(ep->info_attr.src_addr);
-err1:
-	ep->info_attr.src_addr = save_addr;
-	return ret;
+	return ep->cm_ops->ep_setname(ep, addr, addrlen);
 }
 
-static int vrb_msg_ep_getname(fid_t ep, void *addr, size_t *addrlen)
+static int vrb_msg_ep_getname(fid_t ep_fid, void *addr, size_t *addrlen)
 {
-	struct sockaddr *sa;
-	struct vrb_ep *_ep = container_of(ep, struct vrb_ep, util_ep.ep_fid);
-	sa = rdma_get_local_addr(_ep->id);
-	return vrb_copy_addr(addr, addrlen, sa);
+	struct vrb_ep *ep = container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
+	return ep->cm_ops->ep_getname(ep, addr, addrlen);
 }
 
-static int vrb_msg_ep_getpeer(struct fid_ep *ep, void *addr, size_t *addrlen)
+static int vrb_msg_ep_getpeer(struct fid_ep *ep_fid, void *addr, size_t *addrlen)
 {
-	struct sockaddr *sa;
-	struct vrb_ep *_ep = container_of(ep, struct vrb_ep, util_ep.ep_fid);
-	sa = rdma_get_peer_addr(_ep->id);
-	return vrb_copy_addr(addr, addrlen, sa);
+	struct vrb_ep *ep = container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
+	return ep->cm_ops->getpeer(ep, addr, addrlen);
 }
 
-static inline void
-vrb_msg_ep_prepare_cm_data(const void *param, size_t param_size,
-			      struct vrb_cm_data_hdr *cm_hdr)
+void vrb_msg_ep_prepare_cm_data(const void *param, size_t param_size,
+				struct vrb_cm_data_hdr *cm_hdr)
 {
 	cm_hdr->size = (uint8_t)param_size;
 	memcpy(cm_hdr->data, param, cm_hdr->size);
 }
 
-static inline void
-vrb_ep_prepare_rdma_cm_param(struct rdma_conn_param *conn_param,
-				void *priv_data, size_t priv_data_size)
-{
-	conn_param->private_data = priv_data;
-	conn_param->private_data_len = (uint8_t)priv_data_size;
-	conn_param->responder_resources = RDMA_MAX_RESP_RES;
-	conn_param->initiator_depth = RDMA_MAX_INIT_DEPTH;
-	conn_param->flow_control = 1;
-	conn_param->rnr_retry_count = 7;
-}
-
-void
-vrb_msg_ep_prepare_rdma_cm_hdr(void *priv_data,
-				const struct rdma_cm_id *id)
-{
-	struct vrb_rdma_cm_hdr *rdma_cm_hdr = priv_data;
-
-	/* ip_version=6 would requires IPoIB to be installed and the IP link
-	 * to be UP, which we don't want. As a work-around, we set ip_version to 0,
-	 * which let the CMA kernel code to skip any requirement for IPoIB. */
-	rdma_cm_hdr->ip_version = 0;
-	rdma_cm_hdr->port = htons(ofi_addr_get_port(&id->route.addr.src_addr));
-
-	/* Record the GIDs */
-	memcpy(rdma_cm_hdr->src_addr,
-		   &((struct ofi_sockaddr_ib *)&id->route.addr.src_addr)->sib_addr, 16);
-	memcpy(rdma_cm_hdr->dst_addr,
-		   &((struct ofi_sockaddr_ib *)&id->route.addr.dst_addr)->sib_addr, 16);
-}
-
-static int
-vrb_msg_ep_connect(struct fid_ep *ep_fid, const void *addr,
-		      const void *param, size_t paramlen)
+static int vrb_msg_ep_connect(struct fid_ep *ep_fid, const void *addr,
+			      const void *param, size_t paramlen)
 {
 	struct vrb_ep *ep = container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
-	size_t priv_data_len;
-	struct vrb_cm_data_hdr *cm_hdr;
 	int ret = 0;
 
 	if (ep->profile)
@@ -169,7 +99,7 @@ vrb_msg_ep_connect(struct fid_ep *ep_fid, const void *addr,
 	if (OFI_UNLIKELY(paramlen > VERBS_CM_DATA_SIZE))
 		return -FI_EINVAL;
 
-	if (!ep->id->qp) {
+	if (!ep->ibv_qp) {
 		ret = fi_control(&ep_fid->fid, FI_ENABLE, NULL);
 		if (ret) {
 			VRB_WARN_ERR(FI_LOG_EP_CTRL, "fi_control", ret);
@@ -177,100 +107,30 @@ vrb_msg_ep_connect(struct fid_ep *ep_fid, const void *addr,
 		}
 	}
 
-	priv_data_len = sizeof(*cm_hdr) + paramlen + sizeof(struct vrb_rdma_cm_hdr);
-	ep->cm_priv_data = malloc(priv_data_len);
-	if (!ep->cm_priv_data)
-		return -FI_ENOMEM;
-
-	cm_hdr = (void *)((char *)ep->cm_priv_data + sizeof(struct vrb_rdma_cm_hdr));
-	vrb_msg_ep_prepare_cm_data(param, paramlen, cm_hdr);
-	vrb_ep_prepare_rdma_cm_param(&ep->conn_param, ep->cm_priv_data,
-					priv_data_len);
-	ep->conn_param.retry_count = 15;
-
-	if (ep->srx)
-		ep->conn_param.srq = 1;
-
-	if (addr) {
-		free(ep->info_attr.dest_addr);
-		ep->info_attr.dest_addr = mem_dup(addr, ofi_sizeofaddr(addr));
-		if (!ep->info_attr.dest_addr) {
-			free(ep->cm_priv_data);
-			ep->cm_priv_data = NULL;
-			return -FI_ENOMEM;
-		}
-		ep->info_attr.dest_addrlen = ofi_sizeofaddr(addr);
-	}
-
-	ofi_genlock_lock(&vrb_ep2_progress(ep)->ep_lock);
-	assert(ep->state == VRB_IDLE);
-	ep->state = VRB_RESOLVE_ADDR;
-	vrb_prof_func_start("rdma_resolve_addr");
-	if (rdma_resolve_addr(ep->id, ep->info_attr.src_addr,
-			      ep->info_attr.dest_addr, VERBS_RESOLVE_TIMEOUT)) {
-		ret = -errno;
-		VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "rdma_resolve_addr");
-		ofi_straddr_log(&vrb_prov, FI_LOG_WARN, FI_LOG_EP_CTRL,
-				"src addr", ep->info_attr.src_addr);
-		ofi_straddr_log(&vrb_prov, FI_LOG_WARN, FI_LOG_EP_CTRL,
-				"dst addr", ep->info_attr.dest_addr);
-		free(ep->cm_priv_data);
-		ep->cm_priv_data = NULL;
-		ep->state = VRB_IDLE;
-	}
-	vrb_prof_func_end("rdma_resolve_addr");
-	ofi_genlock_unlock(&vrb_ep2_progress(ep)->ep_lock);
+	ret = ep->cm_ops->connect(ep, addr, param, paramlen);
 	vrb_prof_func_end(__func__);
 	return ret;
 }
 
 static int
-vrb_msg_ep_accept(struct fid_ep *ep, const void *param, size_t paramlen)
+vrb_msg_ep_accept(struct fid_ep *ep_fid, const void *param, size_t paramlen)
 {
-	struct rdma_conn_param conn_param;
-	struct vrb_connreq *connreq;
 	int ret;
-	struct vrb_cm_data_hdr *cm_hdr;
-	struct vrb_ep *_ep = container_of(ep, struct vrb_ep, util_ep.ep_fid);
+	struct vrb_ep *ep = container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 
 	if (OFI_UNLIKELY(paramlen > VERBS_CM_DATA_SIZE))
 		return -FI_EINVAL;
 
-	if (!_ep->id->qp) {
-		ret = fi_control(&ep->fid, FI_ENABLE, NULL);
+	if (!ep->ibv_qp) {
+		ret = fi_control(&ep_fid->fid, FI_ENABLE, NULL);
 		if (ret) {
 			VRB_WARN_ERR(FI_LOG_EP_CTRL, "fi_control", ret);
 			return ret;
 		}
 	}
 
-	cm_hdr = alloca(sizeof(*cm_hdr) + paramlen);
-	vrb_msg_ep_prepare_cm_data(param, paramlen, cm_hdr);
-	vrb_ep_prepare_rdma_cm_param(&conn_param, cm_hdr,
-					sizeof(*cm_hdr) + paramlen);
+	ret = ep->cm_ops->accept(ep, param, paramlen);
 
-	if (_ep->srx)
-		conn_param.srq = 1;
-
-	ofi_genlock_lock(&vrb_ep2_progress(_ep)->ep_lock);
-	assert(_ep->state == VRB_REQ_RCVD);
-	_ep->state = VRB_ACCEPTING;
-	vrb_prof_func_start("rdma_accept");
-	ret = rdma_accept(_ep->id, &conn_param);
-	vrb_prof_func_end("rdma_accept");
-	if (ret) {
-		VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "rdma_accept");
-		_ep->state = VRB_DISCONNECTED;
-		ret = -errno;
-	} else {
-		connreq = container_of(_ep->info_attr.handle,
-				       struct vrb_connreq, handle);
-		free(connreq);
-	}
-	if (!ret && _ep->profile) 
-		vrb_prof_cntr_inc(_ep->profile, FI_VAR_CONN_ACCEPT);
-
-	ofi_genlock_unlock(&vrb_ep2_progress(_ep)->ep_lock);
 	return ret;
 }
 
@@ -348,18 +208,11 @@ vrb_msg_ep_reject(struct fid_pep *pep, fid_t handle,
 	if (connreq->is_xrc) {
 		ret = vrb_msg_xrc_ep_reject(connreq, cm_hdr,
 				(uint8_t)(sizeof(*cm_hdr) + paramlen));
-	} else if (connreq->id) {
-		vrb_prof_func_start("rdma_reject");
-		ret = rdma_reject(connreq->id, cm_hdr,
-			(uint8_t)(sizeof(*cm_hdr) + paramlen)) ? -errno : 0;
-		vrb_prof_func_end("rdma_reject");
-		if (rdma_destroy_id(connreq->id))
-			VRB_WARN_ERR(FI_LOG_EP_CTRL, "rdma_destroy_id", -errno);
-		connreq->id = NULL;
 	} else {
-		ret = -FI_EBUSY;
+		ret = _pep->cm_ops->reject(_pep, connreq, cm_hdr,
+					   sizeof(*cm_hdr) + paramlen);
 	}
-	if (!ret && _pep->profile) 
+	if (!ret && _pep->profile)
 		vrb_prof_cntr_inc(_pep->profile, FI_VAR_CONN_REJECT);
 
 	ofi_mutex_unlock(&_pep->eq->event_lock);
@@ -370,12 +223,12 @@ vrb_msg_ep_reject(struct fid_pep *pep, fid_t handle,
 	return ret;
 }
 
-static int vrb_msg_ep_shutdown(struct fid_ep *ep, uint64_t flags)
+static int vrb_msg_ep_shutdown(struct fid_ep *ep_fid, uint64_t flags)
 {
-	struct vrb_ep *_ep = container_of(ep, struct vrb_ep, util_ep.ep_fid);
+	struct vrb_ep *ep = container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 
-	if (_ep->id)
-		return rdma_disconnect(_ep->id) ? -errno : 0;
+	ep->cm_ops->shutdown(ep, flags);
+
 	return 0;
 }
 
@@ -508,74 +361,25 @@ struct fi_ops_cm vrb_msg_xrc_ep_cm_ops = {
 	.join = fi_no_join,
 };
 
-static int vrb_pep_setname(fid_t pep_fid, void *addr, size_t addrlen)
-{
-	struct vrb_pep *pep;
-	int ret;
-
-	pep = container_of(pep_fid, struct vrb_pep, pep_fid);
-
-	if (pep->src_addrlen && (addrlen != pep->src_addrlen)) {
-		VRB_INFO(FI_LOG_FABRIC, "addrlen expected: %zu, got: %zu.\n",
-			   pep->src_addrlen, addrlen);
-		return -FI_EINVAL;
-	}
-
-	/* Re-create id if already bound */
-	if (pep->bound) {
-		ret = rdma_destroy_id(pep->id);
-		if (ret) {
-			VRB_WARN_ERRNO(FI_LOG_FABRIC, "rdma_destroy_id");
-			return -errno;
-		}
-		ret = rdma_create_id(NULL, &pep->id, &pep->pep_fid.fid, RDMA_PS_TCP);
-		if (ret) {
-			VRB_WARN_ERRNO(FI_LOG_FABRIC, "rdma_cm_id\n");
-			return -errno;
-		}
-	}
-
-	ret = rdma_bind_addr(pep->id, (struct sockaddr *)addr);
-	if (ret) {
-		VRB_WARN_ERRNO(FI_LOG_FABRIC, "rdma_bind_addr");
-		return -errno;
-	}
-
-	return 0;
-}
-
-static int vrb_pep_getname(fid_t pep, void *addr, size_t *addrlen)
-{
-	struct vrb_pep *_pep;
-	struct sockaddr *sa;
-
-	_pep = container_of(pep, struct vrb_pep, pep_fid);
-	sa = rdma_get_local_addr(_pep->id);
-	return vrb_copy_addr(addr, addrlen, sa);
-}
-
 static int vrb_pep_listen(struct fid_pep *pep_fid)
 {
-	struct vrb_pep *pep;
-	struct sockaddr *addr;
-	int ret;
+	struct vrb_pep *pep = container_of(pep_fid, struct vrb_pep, pep_fid);
 
-	pep = container_of(pep_fid, struct vrb_pep, pep_fid);
+	return pep->cm_ops->listen(pep);
+}
 
-	addr = rdma_get_local_addr(pep->id);
-	ofi_straddr_log(&vrb_prov, FI_LOG_INFO,
-			FI_LOG_EP_CTRL, "listening on", addr);
+static int vrb_pep_setname(fid_t pep_fid, void *addr, size_t addrlen)
+{
+	struct vrb_pep *pep =container_of(pep_fid, struct vrb_pep, pep_fid);
 
-	ret = rdma_listen(pep->id, pep->backlog);
-	if (ret)
-		return -errno;
+	return pep->cm_ops->setname(pep, addr, addrlen);
+}
 
-	if (vrb_is_xrc_info(pep->info)) {
-		ret = rdma_listen(pep->xrc_ps_udp_id, pep->backlog);
-		if (ret)
-			ret = -errno;
-	}
-	return ret;
+static int vrb_pep_getname(struct fid *fid, void *addr, size_t *addrlen)
+{
+	struct vrb_pep *pep = container_of(fid, struct vrb_pep, pep_fid);
+
+	return pep->cm_ops->getname(pep, addr, addrlen);
 }
 
 static struct fi_ops_cm vrb_pep_cm_ops = {

--- a/prov/verbs/src/verbs_cm_rdma.c
+++ b/prov/verbs/src/verbs_cm_rdma.c
@@ -1107,10 +1107,11 @@ static int vrb_rdmacm_eq_close(struct vrb_eq *eq)
 	return 0;
 }
 
-static int vrb_rdmacm_disconnect(struct vrb_ep *ep)
+static void vrb_rdmacm_ep_preclose(struct vrb_ep *ep)
 {
-	/* rdma_disconnect is called as part of shutdown; nothing extra needed. */
-	return 0;
+	/* With RDMA-CM, the QP already entered ERROR from the disconnect
+	 * event and rdma_destroy_ep manages the QP lifecycle.  Nothing
+	 * needed here. */
 }
 
 static int vrb_rdmacm_reject(struct vrb_pep *pep, struct vrb_connreq *connreq,
@@ -1214,12 +1215,12 @@ struct vrb_cm_ops vrb_rdmacm_ops = {
 	.connect = vrb_rdmacm_connect,
 	.accept = vrb_rdmacm_accept,
 	.shutdown = vrb_rdmacm_shutdown,
-	.disconnect = vrb_rdmacm_disconnect,
 	.listen = vrb_rdmacm_listen,
 	.reject = vrb_rdmacm_reject,
 	.progress = vrb_rdmacm_progress,
 	.ep_init = vrb_rdmacm_ep_init,
 	.ep_close = vrb_rdmacm_ep_close,
+	.ep_preclose = vrb_rdmacm_ep_preclose,
 	.ep_bind = vrb_rdmacm_ep_bind,
 	.ep_enable = vrb_rdmacm_ep_enable,
 	.ep_setname = vrb_rdmacm_ep_setname,
@@ -1234,6 +1235,7 @@ struct vrb_cm_ops vrb_rdmacm_ops = {
 	.setname = vrb_rdmacm_setname,
 	.getname = vrb_rdmacm_getname,
 	.getpeer = vrb_rdmacm_getpeer,
+	.getinfo_addr = vrb_rdmacm_getinfo_addr,
 	.cm_backend = VRB_CM_RDMACM,
 };
 

--- a/prov/verbs/src/verbs_cm_rdma.c
+++ b/prov/verbs/src/verbs_cm_rdma.c
@@ -1,0 +1,1336 @@
+#include "verbs_ofi.h"
+
+static int vrb_rdmacm_eq_open(struct vrb_eq *eq);
+
+int vrb_xrc_migrade_rdma_id(struct vrb_xrc_ep *ep)
+{
+	struct vrb_rdmacm_eq_ctx *eq_ctx = ep->base_ep.eq ? ep->base_ep.eq->cm_ctx : NULL;
+	if (!eq_ctx) {
+		struct vrb_rdmacm_domain_ctx *domain_ctx = vrb_ep2_domain(&ep->base_ep)->cm_ctx;
+		return rdma_migrate_id(ep->tgt_id, domain_ctx->cm_channel);
+	}
+	return rdma_migrate_id(ep->tgt_id, eq_ctx->cm_channel);
+}
+
+static void
+vrb_msg_ep_prepare_rdma_cm_hdr(void *priv_data,
+				const struct rdma_cm_id *id)
+{
+	struct vrb_rdma_cm_hdr *rdma_cm_hdr = priv_data;
+
+	/* ip_version=6 would requires IPoIB to be installed and the IP link
+	 * to be UP, which we don't want. As a work-around, we set ip_version to 0,
+	 * which let the CMA kernel code to skip any requirement for IPoIB. */
+	rdma_cm_hdr->ip_version = 0;
+	rdma_cm_hdr->port = htons(ofi_addr_get_port(&id->route.addr.src_addr));
+
+	/* Record the GIDs */
+	memcpy(rdma_cm_hdr->src_addr,
+		   &((struct ofi_sockaddr_ib *)&id->route.addr.src_addr)->sib_addr, 16);
+	memcpy(rdma_cm_hdr->dst_addr,
+		   &((struct ofi_sockaddr_ib *)&id->route.addr.dst_addr)->sib_addr, 16);
+}
+
+static int vrb_rdmacm_listen(struct vrb_pep *pep)
+{
+	struct sockaddr *addr;
+	int ret;
+	struct vrb_rdmacm_pep_ctx *ctx = pep->cm_ctx;
+	struct vrb_rdmacm_eq_ctx *eq_ctx = pep->eq->cm_ctx;
+
+	addr = rdma_get_local_addr(ctx->id);
+	ofi_straddr_log(&vrb_prov, FI_LOG_INFO,
+			FI_LOG_EP_CTRL, "listening on", addr);
+
+	VRB_INFO(FI_LOG_EP_CTRL,
+		 "listen: id->channel=%p eq_channel=%p eq_channel_fd=%d\n",
+		 (void *)ctx->id->channel, (void *)eq_ctx->cm_channel,
+		 eq_ctx->cm_channel->fd);
+
+	ret = rdma_listen(ctx->id, pep->backlog);
+	if (ret) {
+		VRB_WARN(FI_LOG_EP_CTRL, "rdma_listen failed: %s\n",
+			 strerror(errno));
+		return -errno;
+	}
+
+	VRB_INFO(FI_LOG_EP_CTRL,
+		 "listen: success, id->channel after listen=%p\n",
+		 (void *)ctx->id->channel);
+
+	if (vrb_is_xrc_info(pep->info)) {
+		ret = rdma_listen(ctx->xrc_ps_udp_id, pep->backlog);
+		if (ret)
+			ret = -errno;
+	}
+	return ret;
+}
+
+static inline void
+vrb_ep_prepare_rdma_cm_param(struct rdma_conn_param *conn_param,
+				void *priv_data, size_t priv_data_size)
+{
+	conn_param->private_data = priv_data;
+	conn_param->private_data_len = (uint8_t)priv_data_size;
+	conn_param->responder_resources = RDMA_MAX_RESP_RES;
+	conn_param->initiator_depth = RDMA_MAX_INIT_DEPTH;
+	conn_param->flow_control = 1;
+	conn_param->rnr_retry_count = 7;
+}
+
+static int vrb_rdmacm_connect(struct vrb_ep *ep, const void *addr,
+			      const void *param, size_t paramlen)
+{
+	struct vrb_rdmacm_ep_ctx *ctx = ep->cm_ctx;
+	struct vrb_cm_data_hdr *cm_hdr;
+	int ret;
+	size_t priv_data_len = sizeof(*cm_hdr) + paramlen + sizeof(struct vrb_rdma_cm_hdr);
+	assert(ctx);
+	ep->cm_priv_data = malloc(priv_data_len);
+	if (!ep->cm_priv_data)
+		return -FI_ENOMEM;
+
+	cm_hdr = (void *)((char *)ep->cm_priv_data + sizeof(struct vrb_rdma_cm_hdr));
+	vrb_msg_ep_prepare_cm_data(param, paramlen, cm_hdr);
+	vrb_ep_prepare_rdma_cm_param(&ep->conn_param, ep->cm_priv_data,
+					priv_data_len);
+	ep->conn_param.retry_count = 15;
+
+	if (ep->srx)
+		ep->conn_param.srq = 1;
+
+	if (addr) {
+		free(ep->info_attr.dest_addr);
+		ep->info_attr.dest_addr = mem_dup(addr, ofi_sizeofaddr(addr));
+		if (!ep->info_attr.dest_addr) {
+			ret = -FI_ENOMEM;
+			goto err1;
+		}
+		ep->info_attr.dest_addrlen = ofi_sizeofaddr(addr);
+	}
+
+	ofi_genlock_lock(&vrb_ep2_progress(ep)->ep_lock);
+	assert(ep->state == VRB_IDLE);
+	ep->state = VRB_RESOLVE_ADDR;
+	vrb_prof_func_start("rdma_resolve_addr");
+	if (rdma_resolve_addr(ctx->id, ep->info_attr.src_addr,
+			      ep->info_attr.dest_addr, VERBS_RESOLVE_TIMEOUT)) {
+		ret = -errno;
+		VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "rdma_resolve_addr");
+		ofi_straddr_log(&vrb_prov, FI_LOG_WARN, FI_LOG_EP_CTRL,
+				"src addr", ep->info_attr.src_addr);
+		ofi_straddr_log(&vrb_prov, FI_LOG_WARN, FI_LOG_EP_CTRL,
+				"dst addr", ep->info_attr.dest_addr);
+		ep->state = VRB_IDLE;
+		goto err2;
+	}
+	vrb_prof_func_end("rdma_resolve_addr");
+	ofi_genlock_unlock(&vrb_ep2_progress(ep)->ep_lock);
+	return 0;
+err2:
+	vrb_prof_func_end("rdma_resolve_addr");
+	ofi_genlock_unlock(&vrb_ep2_progress(ep)->ep_lock);
+	free(ep->info_attr.dest_addr);
+	ep->info_attr.dest_addr = NULL;
+	ep->info_attr.dest_addrlen = 0;
+err1:
+	free(ep->cm_priv_data);
+	ep->cm_priv_data = NULL;
+	return ret;
+}
+
+static int vrb_rdmacm_accept(struct vrb_ep *ep, const void *param,
+			     size_t paramlen)
+{
+	struct vrb_cm_data_hdr *cm_hdr;
+	struct vrb_rdmacm_ep_ctx *ctx = ep->cm_ctx;
+	struct rdma_conn_param conn_param = {0};
+	struct vrb_connreq *connreq;
+	int ret;
+
+	cm_hdr = alloca(sizeof(*cm_hdr) + paramlen);
+	vrb_msg_ep_prepare_cm_data(param, paramlen, cm_hdr);
+	vrb_ep_prepare_rdma_cm_param(&conn_param, cm_hdr,
+					sizeof(*cm_hdr) + paramlen);
+
+	if (ep->srx)
+		conn_param.srq = 1;
+
+	ofi_genlock_lock(&vrb_ep2_progress(ep)->ep_lock);
+	assert(ep->state == VRB_REQ_RCVD);
+	ep->state = VRB_ACCEPTING;
+	vrb_prof_func_start("rdma_accept");
+	ret = rdma_accept(ctx->id, &conn_param);
+	vrb_prof_func_end("rdma_accept");
+	if (ret) {
+		VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "rdma_accept");
+		ep->state = VRB_DISCONNECTED;
+		ret = -errno;
+	} else {
+		connreq = container_of(ep->info_attr.handle,
+				       struct vrb_connreq, handle);
+		free(connreq);
+	}
+	if (!ret && ep->profile)
+		vrb_prof_cntr_inc(ep->profile, FI_VAR_CONN_ACCEPT);
+
+	ofi_genlock_unlock(&vrb_ep2_progress(ep)->ep_lock);
+	return 0;
+}
+
+static int vrb_rdmacm_shutdown(struct vrb_ep *ep, uint64_t flags)
+{
+	struct vrb_rdmacm_ep_ctx *ctx = ep->cm_ctx;
+
+	if (!ctx || !ctx->id)
+		return 0;
+
+	if (rdma_disconnect(ctx->id)) {
+		VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "rdma_disconnect");
+		return -errno;
+	}
+
+	return 0;
+}
+
+static int vrb_rdmacm_ep_init(struct vrb_ep *ep, struct fi_info *info)
+{
+	struct vrb_rdmacm_ep_ctx *ep_ctx;
+	struct vrb_domain *domain = vrb_ep2_domain(ep);
+	struct vrb_pep *pep;
+	struct vrb_connreq *connreq;
+	struct vrb_rdmacm_domain_ctx *domain_ctx = domain->cm_ctx;
+	struct vrb_rdmacm_pep_ctx *pep_ctx;
+	int ret;
+
+	ep_ctx = calloc(1, sizeof(*ep_ctx));
+	if (!ep_ctx)
+		return -FI_ENOMEM;
+
+	ep->cm_ctx = ep_ctx;
+
+	if (domain->ext_flags & VRB_USE_XRC) {
+		if (domain->util_domain.threading == FI_THREAD_SAFE) {
+			*ep->util_ep.ep_fid.msg = vrb_msg_xrc_ep_msg_ops_ts;
+			ep->util_ep.ep_fid.rma = &vrb_msg_xrc_ep_rma_ops_ts;
+		} else {
+			*ep->util_ep.ep_fid.msg = vrb_msg_xrc_ep_msg_ops;
+			ep->util_ep.ep_fid.rma = &vrb_msg_xrc_ep_rma_ops;
+		}
+		ep->util_ep.ep_fid.cm = &vrb_msg_xrc_ep_cm_ops;
+		ep->util_ep.ep_fid.atomic = &vrb_msg_xrc_ep_atomic_ops;
+	} else {
+		if (domain->util_domain.threading == FI_THREAD_SAFE) {
+			*ep->util_ep.ep_fid.msg = vrb_msg_ep_msg_ops_ts;
+			ep->util_ep.ep_fid.rma = &vrb_msg_ep_rma_ops_ts;
+		} else {
+			*ep->util_ep.ep_fid.msg = vrb_msg_ep_msg_ops;
+			ep->util_ep.ep_fid.rma = &vrb_msg_ep_rma_ops;
+		}
+		ep->util_ep.ep_fid.cm = &vrb_msg_ep_cm_ops;
+		ep->util_ep.ep_fid.atomic = &vrb_msg_ep_atomic_ops;
+	}
+
+	if (!info->handle) {
+		/* Only RC, XRC active RDMA CM ID is created at connect */
+		if (!(domain->ext_flags & VRB_USE_XRC)) {
+			ret = vrb_create_ep(ep,
+				vrb_get_port_space(info->addr_format), &ep_ctx->id);
+			if (ret)
+				goto err;
+			ep_ctx->id->context = &ep->util_ep.ep_fid.fid;
+		}
+	} else if (info->handle->fclass == FI_CLASS_CONNREQ) {
+		connreq = container_of(info->handle,
+					struct vrb_connreq, handle);
+		if (domain->ext_flags & VRB_USE_XRC) {
+			assert(connreq->is_xrc);
+
+			if (!connreq->xrc.is_reciprocal) {
+				ret = vrb_process_xrc_connreq(ep, connreq);
+				if (ret)
+					goto err;
+			}
+		} else {
+			/* ep now owns this rdma cm id, prevent trying to access
+				* it outside of ep operations to avoid possible use-after-
+				* free bugs in case the ep is closed
+				*/
+			ofi_genlock_lock(&vrb_ep2_progress(ep)->ep_lock);
+			ep->state = VRB_REQ_RCVD;
+			ep_ctx->id = connreq->id;
+			connreq->id = NULL;
+			ep->ibv_qp = ep_ctx->id->qp;
+			ep_ctx->id->context = &ep->util_ep.ep_fid.fid;
+			ofi_genlock_unlock(&vrb_ep2_progress(ep)->ep_lock);
+		}
+	} else if (info->handle->fclass == FI_CLASS_PEP) {
+		/* Opening an active EP seeded from a PEP's address.
+		 * Create a new ID on the domain channel and resolve
+		 * the address; the PEP itself keeps its own ID. */
+		pep = container_of(info->handle, struct vrb_pep, pep_fid.fid);
+		pep_ctx = pep->cm_ctx;
+		(void)pep_ctx; /* pep_ctx available for future use */
+		ret = rdma_create_id(domain_ctx->cm_channel, &ep_ctx->id,
+				     &ep->util_ep.ep_fid.fid,
+				     vrb_get_port_space(info->addr_format));
+		if (ret) {
+			VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "rdma_create_id");
+			goto err;
+		}
+		vrb_prof_func_start("rdma_resolve_addr");
+		if (rdma_resolve_addr(ep_ctx->id, info->src_addr, info->dest_addr,
+				      VERBS_RESOLVE_TIMEOUT)) {
+			ret = -errno;
+			VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "rdma_resolve_addr");
+			rdma_destroy_id(ep_ctx->id);
+			ep_ctx->id = NULL;
+			vrb_prof_func_end("rdma_resolve_addr");
+			goto err;
+		}
+		vrb_prof_func_end("rdma_resolve_addr");
+		ep_ctx->id->context = &ep->util_ep.ep_fid.fid;
+	} else {
+		ret = -FI_ENOSYS;
+		goto err;
+	}
+
+	return 0;
+err:
+	free(ep_ctx);
+	ep->cm_ctx = NULL;
+	return ret;
+}
+
+static int vrb_rdmacm_ep_close(struct vrb_ep *ep)
+{
+	struct vrb_rdmacm_ep_ctx *ctx = ep->cm_ctx;
+
+	if (ctx) {
+		if (ctx->id)
+			rdma_destroy_ep(ctx->id);
+		free(ctx);
+		ep->cm_ctx = NULL;
+	}
+
+	return 0;
+}
+
+static int vrb_rdmacm_ep_bind(struct vrb_ep *ep, struct vrb_eq *eq)
+{
+	struct vrb_rdmacm_ep_ctx *ctx = ep->cm_ctx;
+	struct vrb_rdmacm_eq_ctx *eq_ctx;
+	int ret;
+
+	if (!eq->cm_ctx) {
+		ret = ep->cm_ops->eq_open(eq);
+		if (ret)
+			return ret;
+	}
+	eq_ctx = eq->cm_ctx;
+	ret = rdma_migrate_id(ctx->id, eq_ctx->cm_channel);
+	if (ret) {
+		VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "rdma_migrate_id");
+		return -errno;
+	}
+
+	return 0;
+}
+
+static int vrb_rdmacm_pep_init(struct vrb_pep *pep)
+{
+	int ret;
+	struct vrb_rdmacm_pep_ctx *ctx = calloc(1, sizeof(struct vrb_rdmacm_pep_ctx));
+	if (!ctx)
+		return -FI_ENOMEM;
+
+	ret = rdma_create_id(NULL, &ctx->id, &pep->pep_fid.fid,
+			     vrb_get_port_space(pep->info->addr_format));
+	if (ret) {
+		VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "rdma_create_id");
+		goto err1;
+	}
+
+	if (pep->info->src_addr) {
+		ret = rdma_bind_addr(ctx->id, (struct sockaddr *) pep->info->src_addr);
+		if (ret) {
+			VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "rdma_bind_addr");
+			ret = -errno;
+			goto err2;
+		}
+		pep->bound = 1;
+	}
+
+	/* XRC listens on both RDMA_PS_TCP and RDMA_PS_UDP */
+	if (vrb_is_xrc_info(pep->info)) {
+		ret = rdma_create_id(NULL, &ctx->xrc_ps_udp_id,
+				     &pep->pep_fid.fid, RDMA_PS_UDP);
+		if (ret) {
+			VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "rdma_create_id");
+			goto err2;
+		}
+		/* Currently both listens must be bound to same port number */
+		ofi_addr_set_port(pep->info->src_addr,
+				  ntohs(rdma_get_src_port(ctx->id)));
+		ret = rdma_bind_addr(ctx->xrc_ps_udp_id,
+				     (struct sockaddr *)pep->info->src_addr);
+		if (ret) {
+			VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "rdma_bind_addr");
+			goto err3;
+		}
+	}
+
+	pep->cm_ctx = ctx;
+	return 0;
+
+err3:
+	/* Only possible for XRC code path */
+	rdma_destroy_id(ctx->xrc_ps_udp_id);
+err2:
+	rdma_destroy_id(ctx->id);
+err1:
+	free(ctx);
+	return ret;
+}
+
+static int vrb_rdmacm_pep_close(struct vrb_pep *pep)
+{
+	struct vrb_rdmacm_pep_ctx *ctx = pep->cm_ctx;
+
+	if (ctx) {
+		if (ctx->id)
+			rdma_destroy_id(ctx->id);
+		if (ctx->xrc_ps_udp_id)
+			rdma_destroy_id(ctx->xrc_ps_udp_id);
+		free(ctx);
+		pep->cm_ctx = NULL;
+	}
+
+	return 0;
+}
+
+static int vrb_rdmacm_pep_bind(struct vrb_pep *pep, struct vrb_eq *eq)
+{
+	struct vrb_rdmacm_pep_ctx *pep_ctx = pep->cm_ctx;
+	struct vrb_rdmacm_eq_ctx *eq_ctx;
+	int ret;
+
+	/*
+	 * This is a restrictive solution that enables an XRC EP to
+	 * inform it's peer the port that should be used in making the
+	 * reciprocal connection request. While it meets RXM requirements
+	 * it limits an EQ to a single passive endpoint. TODO: implement
+	 * a more general solution.
+	 */
+	if (vrb_is_xrc_info(pep->info)) {
+		if (pep->eq->xrc.pep_port) {
+			VRB_WARN(FI_LOG_EP_CTRL,
+				   "XRC limits EQ binding to a single PEP\n");
+			return -FI_EINVAL;
+		}
+		pep->eq->xrc.pep_port = ntohs(rdma_get_src_port(pep_ctx->id));
+	}
+
+	if (!eq->cm_ctx) {
+		ret = vrb_rdmacm_eq_open(eq);
+		if (ret)
+			return ret;
+	}
+	eq_ctx = eq->cm_ctx;
+
+	ret = rdma_migrate_id(pep_ctx->id, eq_ctx->cm_channel);
+	if (ret) {
+		VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "rdma_migrate_id");
+		return -errno;
+	}
+
+	if (vrb_is_xrc_info(pep->info) && pep_ctx->xrc_ps_udp_id) {
+		ret = rdma_migrate_id(pep_ctx->xrc_ps_udp_id,
+				      eq_ctx->cm_channel);
+		if (ret) {
+			VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "rdma_migrate_id xrc");
+			return -errno;
+		}
+		ofi_addr_set_port(pep->info->src_addr,
+				  ntohs(rdma_get_src_port(pep_ctx->id)));
+		ret = rdma_bind_addr(pep_ctx->xrc_ps_udp_id,
+				     (struct sockaddr *)pep->info->src_addr);
+		if (ret) {
+			VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "rdma_bind_addr");
+			return -errno;
+		}
+	}
+
+	VRB_INFO(FI_LOG_EP_CTRL,
+		 "rdmacm pep_bind: recreated on eq channel fd=%d\n",
+		 eq_ctx->cm_channel->fd);
+	return 0;
+}
+
+static int vrb_rdmacm_domain_init(struct vrb_domain *domain)
+{
+	struct vrb_rdmacm_domain_ctx *ctx;
+
+	ctx = calloc(1, sizeof(*ctx));
+	if (!ctx)
+		return -FI_ENOMEM;
+
+	/* Create a bootstrap channel for creating rdmacm IDs before an EQ
+	 * is available.  This channel is migrated away from in ep_bind and
+	 * is never directly polled (not added to any epollfd). */
+	ctx->cm_channel = rdma_create_event_channel();
+	if (!ctx->cm_channel) {
+		free(ctx);
+		return -errno;
+	}
+
+	domain->cm_ctx = ctx;
+	return 0;
+}
+
+static int vrb_rdmacm_domain_close(struct vrb_domain *domain)
+{
+	struct vrb_rdmacm_domain_ctx *ctx = domain->cm_ctx;
+
+	if (ctx) {
+		if (ctx->cm_channel)
+			rdma_destroy_event_channel(ctx->cm_channel);
+		free(ctx);
+		domain->cm_ctx = NULL;
+	}
+
+	return 0;
+}
+
+static int
+vrb_eq_addr_resolved_event(struct vrb_ep *ep)
+{
+	struct vrb_rdmacm_ep_ctx *ctx = ep->cm_ctx;
+	struct vrb_recv_wr *wr;
+	struct slist_entry *entry;
+	struct ibv_qp_init_attr attr = { 0 };
+	int ret;
+
+	assert(ofi_genlock_held(&vrb_ep2_progress(ep)->ep_lock));
+	assert(ep->state == VRB_RESOLVE_ADDR);
+	if (ep->util_ep.type == FI_EP_MSG) {
+		vrb_msg_ep_get_qp_attr(ep, &attr);
+
+		/* Client-side QP creation */
+		vrb_prof_func_start("rdma_create_qp");
+		if (rdma_create_qp(ctx->id, vrb_ep2_domain(ep)->pd, &attr)) {
+			ep->state = VRB_DISCONNECTED;
+			ret = -errno;
+			VRB_WARN(FI_LOG_EP_CTRL,
+				 "rdma_create_qp failed: %d\n", -ret);
+			return ret;
+		}
+		vrb_prof_func_end("rdma_create_qp");
+		if (ep->profile)
+			vrb_prof_cntr_inc(ep->profile, FI_VAR_MSG_QUEUE_CNT);
+
+		/* Allow shared XRC INI QP not controlled by RDMA CM
+		 * to share same post functions as RC QP. */
+		ep->ibv_qp = ctx->id->qp;
+	}
+
+	assert(ep->ibv_qp);
+	while (!slist_empty(&ep->prepost_wr_list)) {
+		entry = ep->prepost_wr_list.head;
+		wr = container_of(entry, struct vrb_recv_wr, entry);
+
+		ret = vrb_post_recv_internal(ep, &wr->wr);
+		if (ret) {
+			VRB_WARN(FI_LOG_EP_CTRL,
+			         "Failed to post receive buffers: %d\n", -ret);
+
+			return ret;
+		}
+		vrb_free_recv_wr(vrb_ep2_progress(ep), wr);
+		slist_remove_head(&ep->prepost_wr_list);
+	}
+
+	ep->state = VRB_RESOLVE_ROUTE;
+	vrb_prof_func_start("rdma_resolve_route");
+	if (rdma_resolve_route(ctx->id, VERBS_RESOLVE_TIMEOUT)) {
+		ep->state = VRB_DISCONNECTED;
+		ret = -errno;
+		VRB_WARN(FI_LOG_EP_CTRL,
+			"rdma_resolve_route failed: %d\n",
+			-ret);
+		return ret;
+	}
+	vrb_prof_func_end("rdma_resolve_route");
+
+	return -FI_EAGAIN;
+}
+
+static int vrb_eq_set_xrc_info(struct rdma_cm_event *event,
+				  struct vrb_xrc_conn_info *info)
+{
+	struct vrb_xrc_cm_data *remote = (struct vrb_xrc_cm_data *)
+						event->param.conn.private_data;
+	int ret;
+
+	ret = vrb_verify_xrc_cm_data(remote,
+					event->param.conn.private_data_len);
+	if (ret)
+		return ret;
+
+	info->is_reciprocal = remote->reciprocal;
+	info->conn_tag = ntohl(remote->conn_tag);
+	info->port = ntohs(remote->port);
+	info->tgt_qpn = ntohl(remote->tgt_qpn);
+	info->peer_srqn = ntohl(remote->srqn);
+	info->conn_param = event->param.conn;
+	info->conn_param.private_data = NULL;
+	info->conn_param.private_data_len = 0;
+
+	return FI_SUCCESS;
+}
+
+static int
+vrb_pep_dev_domain_match(struct fi_info *hints, const char *devname)
+{
+	int ret;
+
+	if ((VRB_EP_PROTO(hints)) == FI_PROTO_RDMA_CM_IB_XRC)
+		ret = vrb_cmp_xrc_domain_name(hints->domain_attr->name,
+						 devname);
+	else
+		ret = strcmp(hints->domain_attr->name, devname);
+
+	return ret;
+}
+
+static int
+vrb_eq_cm_getinfo(struct rdma_cm_event *event, struct fi_info *pep_info,
+		     struct fi_info **info)
+{
+	struct fi_info *hints;
+	struct vrb_connreq *connreq;
+	const char *devname = ibv_get_device_name(event->id->verbs->device);
+	int ret = -FI_ENOMEM;
+
+	if (!(hints = fi_dupinfo(pep_info))) {
+		VRB_WARN(FI_LOG_EP_CTRL, "dupinfo failure\n");
+		return -FI_ENOMEM;
+	}
+
+	/* Free src_addr info from pep to avoid addr reuse errors */
+	free(hints->src_addr);
+	hints->src_addr = NULL;
+	hints->src_addrlen = 0;
+
+	if (!strcmp(hints->domain_attr->name, VERBS_ANY_DOMAIN)) {
+		free(hints->domain_attr->name);
+		if (!(hints->domain_attr->name = strdup(devname)))
+			goto err1;
+	} else {
+		if (vrb_pep_dev_domain_match(hints, devname)) {
+			VRB_WARN(FI_LOG_EQ, "passive endpoint domain: %s does"
+				   " not match device: %s where we got a "
+				   "connection request\n",
+				   hints->domain_attr->name, devname);
+			ret = -FI_ENODATA;
+			goto err1;
+		}
+	}
+
+	if (!strcmp(hints->domain_attr->name, VERBS_ANY_FABRIC)) {
+		free(hints->fabric_attr->name);
+		hints->fabric_attr->name = NULL;
+	}
+
+	ofi_mutex_lock(&vrb_info_mutex);
+	ret = vrb_get_matching_info(hints->fabric_attr->api_version, hints,
+				    info, vrb_util_prov.info, 0);
+	ofi_mutex_unlock(&vrb_info_mutex);
+	if (ret)
+		goto err1;
+
+	ofi_alter_info(*info, hints, hints->fabric_attr->api_version);
+	vrb_alter_info(hints, *info);
+	(*info)->fabric_attr->api_version = pep_info->fabric_attr->api_version;
+	(*info)->fabric_attr->prov_name = strdup(pep_info->fabric_attr->prov_name);
+	if (!(*info)->fabric_attr->prov_name)
+		goto err2;
+
+	free((*info)->src_addr);
+	(*info)->src_addrlen = ofi_sizeofaddr(rdma_get_local_addr(event->id));
+	(*info)->src_addr = malloc((*info)->src_addrlen);
+	if (!((*info)->src_addr))
+		goto err2;
+	memcpy((*info)->src_addr, rdma_get_local_addr(event->id), (*info)->src_addrlen);
+
+	assert(!(*info)->dest_addr);
+	(*info)->dest_addrlen = ofi_sizeofaddr(rdma_get_peer_addr(event->id));
+	(*info)->dest_addr = malloc((*info)->dest_addrlen);
+	if (!((*info)->dest_addr))
+		goto err2;
+	memcpy((*info)->dest_addr, rdma_get_peer_addr(event->id), (*info)->dest_addrlen);
+
+	ofi_straddr_dbg(&vrb_prov, FI_LOG_EQ, "src", (*info)->src_addr);
+	ofi_straddr_dbg(&vrb_prov, FI_LOG_EQ, "dst", (*info)->dest_addr);
+
+	connreq = calloc(1, sizeof *connreq);
+	if (!connreq) {
+		VRB_WARN(FI_LOG_EP_CTRL,
+			   "Unable to allocate connreq memory\n");
+		goto err2;
+	}
+
+	connreq->handle.fclass = FI_CLASS_CONNREQ;
+	connreq->id = event->id;
+
+	if (vrb_is_xrc_info(*info)) {
+		connreq->is_xrc = 1;
+		ret = vrb_eq_set_xrc_info(event, &connreq->xrc);
+		if (ret)
+			goto err3;
+	}
+
+	(*info)->handle = &connreq->handle;
+	fi_freeinfo(hints);
+	return 0;
+
+err3:
+	free(connreq);
+err2:
+	fi_freeinfo(*info);
+err1:
+	fi_freeinfo(hints);
+	return ret;
+}
+
+static void vrb_eq_skip_rdma_cm_hdr(const void **priv_data,
+						size_t *priv_data_len)
+{
+	size_t rdma_cm_hdr_len = sizeof(struct vrb_rdma_cm_hdr);
+
+	if (*priv_data_len > rdma_cm_hdr_len) {
+		*priv_data = (void*)((char *)*priv_data + rdma_cm_hdr_len);
+		*priv_data_len -= rdma_cm_hdr_len;
+	}
+}
+
+static ssize_t
+vrb_eq_cm_process_event(struct vrb_eq *eq,
+	struct rdma_cm_event *cma_event, uint32_t *event,
+	struct fi_eq_cm_entry *entry, size_t len)
+{
+	const struct vrb_cm_data_hdr *cm_hdr;
+	size_t datalen = 0;
+	size_t priv_datalen = cma_event->param.conn.private_data_len;
+	const void *priv_data = cma_event->param.conn.private_data;
+	int ret, acked = 0;;
+	fid_t fid = cma_event->id->context;
+	struct vrb_pep *pep =
+		container_of(fid, struct vrb_pep, pep_fid);
+	struct vrb_ep *ep;
+	struct vrb_xrc_ep *xrc_ep;
+
+	assert(ofi_mutex_held(&eq->event_lock));
+	switch (cma_event->event) {
+	case RDMA_CM_EVENT_ADDR_RESOLVED:
+		ep = container_of(fid, struct vrb_ep, util_ep.ep_fid);
+		if (ep->profile)
+			vrb_prof_set_st_time(ep->profile, (ofi_gettime_ns()),
+					VRB_RESOLVE_ADDR);
+
+		ofi_genlock_lock(&vrb_ep2_progress(ep)->ep_lock);
+		ret = vrb_eq_addr_resolved_event(ep);
+		ofi_genlock_unlock(&vrb_ep2_progress(ep)->ep_lock);
+		if (ret != -FI_EAGAIN) {
+			eq->err.err = -ret;
+			eq->err.prov_errno = ret;
+			goto err;
+		}
+		goto ack;
+
+	case RDMA_CM_EVENT_ROUTE_RESOLVED:
+		ep = container_of(fid, struct vrb_ep, util_ep.ep_fid);
+		if (ep->profile)
+			vrb_prof_set_st_time(ep->profile, (ofi_gettime_ns()),
+					VRB_RESOLVE_ROUTE);
+		ofi_genlock_lock(&vrb_ep2_progress(ep)->ep_lock);
+		assert(ep->state == VRB_RESOLVE_ROUTE);
+		ep->state = VRB_CONNECTING;
+		{
+			struct vrb_rdmacm_ep_ctx *ep_ctx = ep->cm_ctx;
+			if (cma_event->id->route.addr.src_addr.sa_family != AF_IB) {
+				vrb_eq_skip_rdma_cm_hdr((const void **)&ep->conn_param.private_data,
+							(size_t *)&ep->conn_param.private_data_len);
+			} else {
+				vrb_msg_ep_prepare_rdma_cm_hdr(ep->cm_priv_data, ep_ctx->id);
+			}
+			vrb_prof_func_start("rdma_connect");
+			ret = rdma_connect(ep_ctx->id, &ep->conn_param);
+			vrb_prof_func_end("rdma_connect");
+		}
+		if (!ret && ep->profile)
+			vrb_prof_cntr_inc(ep->profile, FI_VAR_CONN_REQUEST);
+
+		if (ret) {
+			ep->state = VRB_DISCONNECTED;
+			ret = -errno;
+			FI_WARN(&vrb_prov, FI_LOG_EP_CTRL,
+				"rdma_connect failed: %s (%d)\n",
+				strerror(-ret), -ret);
+			if (vrb_is_xrc_ep(ep)) {
+				xrc_ep = container_of(fid, struct vrb_xrc_ep,
+						      base_ep.util_ep.ep_fid);
+				vrb_put_shared_ini_conn(xrc_ep);
+			}
+		} else {
+			ret = -FI_EAGAIN;
+		}
+		ofi_genlock_unlock(&vrb_ep2_progress(ep)->ep_lock);
+		if (ret != -FI_EAGAIN) {
+			eq->err.err = -ret;
+			eq->err.prov_errno = ret;
+			goto err;
+		}
+		goto ack;
+	case RDMA_CM_EVENT_CONNECT_REQUEST:
+		*event = FI_CONNREQ;
+		ret = vrb_eq_cm_getinfo(cma_event, pep->info, &entry->info);
+		if (ret) {
+			VRB_WARN(FI_LOG_EP_CTRL,
+				   "CM getinfo error %d\n", ret);
+			rdma_destroy_id(cma_event->id);
+			eq->err.err = -ret;
+			eq->err.prov_errno = ret;
+			goto err;
+		}
+
+		if (vrb_is_xrc_info(entry->info)) {
+			ret = vrb_eq_xrc_connreq_event(eq, entry, len, event,
+							  cma_event, &acked,
+							  &priv_data, &priv_datalen);
+			if (ret == -FI_EAGAIN) {
+				fi_freeinfo(entry->info);
+				entry->info = NULL;
+				goto ack;
+			}
+			if (*event == FI_CONNECTED)
+				goto ack;
+		} else if (cma_event->id->route.addr.src_addr.sa_family == AF_IB) {
+			vrb_eq_skip_rdma_cm_hdr(&priv_data, &priv_datalen);
+		}
+		break;
+	case RDMA_CM_EVENT_CONNECT_RESPONSE:
+	case RDMA_CM_EVENT_ESTABLISHED:
+		*event = FI_CONNECTED;
+		ep = container_of(fid, struct vrb_ep, util_ep.ep_fid);
+		if (ep->profile) {
+			vrb_prof_set_st_time(ep->profile, (ofi_gettime_ns()),
+					VRB_CONNECTED);
+			vrb_prof_cntr_inc(ep->profile,
+					FI_VAR_CONNECTION_CNT);
+		}
+		if (cma_event->id->qp &&
+		    cma_event->id->qp->context->device->transport_type !=
+		    IBV_TRANSPORT_IWARP) {
+			vrb_set_rnr_timer(cma_event->id->qp);
+		}
+		if (vrb_is_xrc_ep(ep)) {
+			ret = vrb_eq_xrc_connected_event(eq, cma_event,
+							    &acked, entry, len,
+							    event);
+			goto ack;
+		}
+		ofi_genlock_lock(&vrb_ep2_progress(ep)->ep_lock);
+		assert(ep->state == VRB_CONNECTING || ep->state == VRB_ACCEPTING);
+		ep->state = VRB_CONNECTED;
+		ofi_genlock_unlock(&vrb_ep2_progress(ep)->ep_lock);
+		entry->info = NULL;
+		break;
+	case RDMA_CM_EVENT_DISCONNECTED:
+		ep = container_of(fid, struct vrb_ep, util_ep.ep_fid);
+		if (ep->profile)
+			vrb_prof_set_st_time(ep->profile, (ofi_gettime_ns()),
+                                            VRB_DISCONNECTED);
+		ofi_genlock_lock(&vrb_ep2_progress(ep)->ep_lock);
+		if (ep->state == VRB_DISCONNECTED) {
+			/* If we saw a transfer error, we already generated
+			 * a shutdown event.
+			 */
+			ret = -FI_EAGAIN;
+			ofi_genlock_unlock(&vrb_ep2_progress(ep)->ep_lock);
+			goto ack;
+		}
+		ep->state = VRB_DISCONNECTED;
+		ofi_genlock_unlock(&vrb_ep2_progress(ep)->ep_lock);
+		if (vrb_is_xrc_ep(ep)) {
+			vrb_eq_xrc_disconnect_event(eq, cma_event, &acked);
+			ret = -FI_EAGAIN;
+			goto ack;
+		}
+		*event = FI_SHUTDOWN;
+		entry->info = NULL;
+		break;
+	case RDMA_CM_EVENT_TIMEWAIT_EXIT:
+		ep = container_of(fid, struct vrb_ep, util_ep.ep_fid);
+		if (vrb_is_xrc_ep(ep))
+			vrb_eq_xrc_timewait_event(eq, cma_event, &acked);
+		ret = -FI_EAGAIN;
+		goto ack;
+	case RDMA_CM_EVENT_ADDR_ERROR:
+	case RDMA_CM_EVENT_ROUTE_ERROR:
+	case RDMA_CM_EVENT_CONNECT_ERROR:
+	case RDMA_CM_EVENT_UNREACHABLE:
+		ep = container_of(fid, struct vrb_ep, util_ep.ep_fid);
+		ofi_genlock_lock(&vrb_ep2_progress(ep)->ep_lock);
+		assert(ep->state != VRB_DISCONNECTED);
+		ep->state = VRB_DISCONNECTED;
+		ofi_genlock_unlock(&vrb_ep2_progress(ep)->ep_lock);
+		if (vrb_is_xrc_ep(ep)) {
+			/* SIDR Reject is reported as UNREACHABLE unless
+			 * status is negative */
+			if (cma_event->id->ps == RDMA_PS_UDP &&
+			    (cma_event->event == RDMA_CM_EVENT_UNREACHABLE &&
+			     cma_event->status >= 0))
+				goto xrc_shared_reject;
+
+			ret = vrb_eq_xrc_cm_err_event(eq, cma_event, &acked);
+			if (ret == -FI_EAGAIN)
+				goto ack;
+
+			*event = FI_SHUTDOWN;
+			entry->info = NULL;
+			break;
+		}
+		eq->err.err = ETIMEDOUT;
+		eq->err.prov_errno = -cma_event->status;
+		if (eq->err.err_data) {
+			free(eq->err.err_data);
+			eq->err.err_data = NULL;
+			eq->err.err_data_size = 0;
+		}
+		goto err;
+	case RDMA_CM_EVENT_REJECTED:
+		ep = container_of(fid, struct vrb_ep, util_ep.ep_fid);
+		ofi_genlock_lock(&vrb_ep2_progress(ep)->ep_lock);
+		assert(ep->state != VRB_DISCONNECTED);
+		ep->state = VRB_DISCONNECTED;
+		ofi_genlock_unlock(&vrb_ep2_progress(ep)->ep_lock);
+		if (vrb_is_xrc_ep(ep)) {
+xrc_shared_reject:
+			ret = vrb_eq_xrc_rej_event(eq, cma_event);
+			if (ret == -FI_EAGAIN)
+				goto ack;
+			vrb_eq_skip_xrc_cm_data(&priv_data, &priv_datalen);
+		}
+		eq->err.err = ECONNREFUSED;
+		eq->err.prov_errno = -cma_event->status;
+		if (eq->err.err_data) {
+			free(eq->err.err_data);
+			eq->err.err_data = NULL;
+			eq->err.err_data_size = 0;
+		}
+		if (priv_datalen) {
+			cm_hdr = priv_data;
+			eq->err.err_data = calloc(1, cm_hdr->size);
+			assert(eq->err.err_data);
+			memcpy(eq->err.err_data, cm_hdr->data,
+			       cm_hdr->size);
+			eq->err.err_data_size = cm_hdr->size;
+		}
+		goto err;
+	case RDMA_CM_EVENT_DEVICE_REMOVAL:
+		eq->err.err = ENODEV;
+		goto err;
+	case RDMA_CM_EVENT_ADDR_CHANGE:
+		eq->err.err = EADDRNOTAVAIL;
+		goto err;
+	default:
+		VRB_WARN(FI_LOG_EP_CTRL, "unknown rdmacm event received: %d\n",
+			   cma_event->event);
+		ret = -FI_EAGAIN;
+		goto ack;
+	}
+
+	entry->fid = fid;
+
+	/* rdmacm has no way to track how much data is sent by peer */
+	if (priv_datalen)
+		datalen = vrb_eq_copy_event_data(entry, len, priv_data,
+						 priv_datalen);
+	if (!acked)
+		rdma_ack_cm_event(cma_event);
+	return sizeof(*entry) + datalen;
+err:
+	ret = -FI_EAVAIL;
+	eq->err.fid = fid;
+ack:
+	if (!acked)
+		rdma_ack_cm_event(cma_event);
+	return ret;
+}
+
+static ssize_t vrb_rdmacm_progress(struct vrb_eq *eq, uint32_t *event,
+				   void *buf, size_t len)
+{
+	struct vrb_rdmacm_eq_ctx *ctx = eq->cm_ctx;
+	struct rdma_cm_event *cma_event;
+	ssize_t ret;
+
+	assert(ctx && ctx->cm_channel);
+
+
+	do {
+		ofi_mutex_lock(&eq->event_lock);
+		vrb_prof_func_start("rdma_get_cm_event");
+		ret = rdma_get_cm_event(ctx->cm_channel, &cma_event);
+		vrb_prof_func_end("rdma_get_cm_event");
+		if (ret) {
+			ofi_mutex_unlock(&eq->event_lock);
+			if (errno == EAGAIN || errno == EWOULDBLOCK)
+				return 0;
+			VRB_INFO(FI_LOG_EP_CTRL,
+				 "rdmacm_progress: rdma_get_cm_event err=%d\n",
+				 errno);
+			return -errno;
+		}
+
+		VRB_INFO(FI_LOG_EP_CTRL,
+			 "rdmacm_progress: got cm_event type=%d\n",
+			 cma_event->event);
+		vrb_prof_func_start("vrb_eq_cm_process_event");
+		ret = vrb_eq_cm_process_event(eq, cma_event, event, buf, len);
+		vrb_prof_func_end("vrb_eq_cm_process_event");
+		VRB_INFO(FI_LOG_EP_CTRL,
+			 "rdmacm_progress: process_event ret=%zd\n", ret);
+		ofi_mutex_unlock(&eq->event_lock);
+	} while (ret == -FI_EAGAIN);
+
+	return ret;
+}
+
+
+static int vrb_rdmacm_setname(struct vrb_pep *pep, void *addr, size_t addrlen)
+{
+	struct vrb_rdmacm_pep_ctx *ctx;
+	int ret;
+
+	ctx = pep->cm_ctx;
+
+	if (pep->src_addrlen && (addrlen != pep->src_addrlen)) {
+		VRB_INFO(FI_LOG_FABRIC, "addrlen expected: %zu, got: %zu.\n",
+			   pep->src_addrlen, addrlen);
+		return -FI_EINVAL;
+	}
+
+	/* Re-create id if already bound */
+	if (pep->bound) {
+		ret = rdma_destroy_id(ctx->id);
+		if (ret) {
+			VRB_WARN_ERRNO(FI_LOG_FABRIC, "rdma_destroy_id");
+			return -errno;
+		}
+		ret = rdma_create_id(NULL, &ctx->id,
+				     &pep->pep_fid.fid, RDMA_PS_TCP);
+		if (ret) {
+			VRB_WARN_ERRNO(FI_LOG_FABRIC, "rdma_cm_id\n");
+			return -errno;
+		}
+	}
+
+	ret = rdma_bind_addr(ctx->id, (struct sockaddr *)addr);
+	if (ret) {
+		VRB_WARN_ERRNO(FI_LOG_FABRIC, "rdma_bind_addr");
+		return -errno;
+	}
+
+	return 0;
+}
+
+static int vrb_rdmacm_getname(struct vrb_pep *pep, void *addr, size_t *addrlen)
+{
+	struct sockaddr *sa;
+	struct vrb_rdmacm_pep_ctx *ctx = pep->cm_ctx;
+
+	sa = rdma_get_local_addr(ctx->id);
+	return vrb_copy_addr(addr, addrlen, sa);
+}
+
+static int vrb_rdmacm_eq_open(struct vrb_eq *eq)
+{
+	struct vrb_rdmacm_eq_ctx *ctx;
+	int ret;
+
+	ctx = calloc(1, sizeof(*ctx));
+	if (!ctx)
+		return -FI_ENOMEM;
+
+	ctx->cm_channel = rdma_create_event_channel();
+	if (!ctx->cm_channel) {
+		ret = -errno;
+		goto err_free;
+	}
+
+	ret = fi_fd_nonblock(ctx->cm_channel->fd);
+	if (ret) {
+		ret = -errno;
+		goto err_chan;
+	}
+
+	if (ofi_epoll_add(eq->epollfd, ctx->cm_channel->fd,
+			  OFI_EPOLL_IN, NULL)) {
+		ret = -errno;
+		goto err_chan;
+	}
+
+	eq->cm_ctx = ctx;
+	eq->cm_ops = &vrb_rdmacm_ops;
+	return 0;
+
+err_chan:
+	rdma_destroy_event_channel(ctx->cm_channel);
+err_free:
+	free(ctx);
+	return ret;
+}
+
+static int vrb_rdmacm_eq_close(struct vrb_eq *eq)
+{
+	struct vrb_rdmacm_eq_ctx *ctx = eq->cm_ctx;
+
+	if (!ctx)
+		return 0;
+
+	ofi_epoll_del(eq->epollfd, ctx->cm_channel->fd);
+	rdma_destroy_event_channel(ctx->cm_channel);
+	free(ctx);
+	eq->cm_ctx = NULL;
+	return 0;
+}
+
+static int vrb_rdmacm_disconnect(struct vrb_ep *ep)
+{
+	/* rdma_disconnect is called as part of shutdown; nothing extra needed. */
+	return 0;
+}
+
+static int vrb_rdmacm_reject(struct vrb_pep *pep, struct vrb_connreq *connreq,
+			     const void *param, size_t paramlen)
+{
+	int ret;
+
+	if (!connreq->id)
+		return -FI_EBUSY;
+
+	vrb_prof_func_start("rdma_reject");
+	ret = rdma_reject(connreq->id, param, (uint8_t)paramlen) ? -errno : 0;
+	vrb_prof_func_end("rdma_reject");
+	if (rdma_destroy_id(connreq->id))
+		VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "rdma_destroy_id");
+	connreq->id = NULL;
+
+	if (ret)
+		VRB_WARN_ERR(FI_LOG_EP_CTRL, "rdma_reject", ret);
+	return ret;
+}
+
+static int vrb_rdmacm_getpeer(struct vrb_ep *ep, void *addr, size_t *addrlen)
+{
+	struct vrb_rdmacm_ep_ctx *ctx = ep->cm_ctx;
+	struct sockaddr *sa;
+
+	if (!ctx || !ctx->id)
+		return -FI_EOPBADSTATE;
+
+	sa = rdma_get_peer_addr(ctx->id);
+	return vrb_copy_addr(addr, addrlen, sa);
+}
+
+static int vrb_rdmacm_ep_enable(struct vrb_ep *ep,
+				struct ibv_qp_init_attr *attr)
+{
+	struct vrb_rdmacm_ep_ctx *ctx = ep->cm_ctx;
+	struct vrb_domain *domain = vrb_ep2_domain(ep);
+
+	if (!ctx || !ctx->id || !ctx->id->verbs || ep->ibv_qp != NULL)
+		return 0;
+
+	/* Server-side QP creation after RDMA_CM_EVENT_CONNECT_REQUEST */
+	vrb_prof_func_start("rdma_create_qp");
+	if (rdma_create_qp(ctx->id, domain->pd, attr)) {
+		VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "rdma_create_qp");
+		return -errno;
+	}
+	vrb_prof_func_end("rdma_create_qp");
+	if (ep->profile)
+		vrb_prof_cntr_inc(ep->profile, FI_VAR_MSG_QUEUE_CNT);
+	ep->ibv_qp = ctx->id->qp;
+	return 0;
+}
+
+static int vrb_rdmacm_ep_setname(struct vrb_ep *ep, void *addr, size_t addrlen)
+{
+	struct vrb_rdmacm_ep_ctx *ctx = ep->cm_ctx;
+	void *save_addr;
+	struct rdma_cm_id *id;
+	int ret;
+
+	save_addr = ep->info_attr.src_addr;
+	ep->info_attr.src_addr = malloc(ep->info_attr.src_addrlen);
+	if (!ep->info_attr.src_addr) {
+		ep->info_attr.src_addr = save_addr;
+		return -FI_ENOMEM;
+	}
+	memcpy(ep->info_attr.src_addr, addr, ep->info_attr.src_addrlen);
+
+	ret = vrb_create_ep(ep, RDMA_PS_TCP, &id);
+	if (ret) {
+		free(ep->info_attr.src_addr);
+		ep->info_attr.src_addr = save_addr;
+		return ret;
+	}
+
+	if (ctx->id)
+		rdma_destroy_ep(ctx->id);
+	ctx->id = id;
+	ep->ibv_qp = ctx->id->qp;
+	free(save_addr);
+	return 0;
+}
+
+static int vrb_rdmacm_ep_getname(struct vrb_ep *ep, void *addr, size_t *addrlen)
+{
+	struct vrb_rdmacm_ep_ctx *ctx = ep->cm_ctx;
+	struct sockaddr *sa;
+
+	if (!ctx || !ctx->id)
+		return -FI_EOPBADSTATE;
+
+	sa = rdma_get_local_addr(ctx->id);
+	return vrb_copy_addr(addr, addrlen, sa);
+}
+
+// RDMA-CM ops structure
+struct vrb_cm_ops vrb_rdmacm_ops = {
+	.connect = vrb_rdmacm_connect,
+	.accept = vrb_rdmacm_accept,
+	.shutdown = vrb_rdmacm_shutdown,
+	.disconnect = vrb_rdmacm_disconnect,
+	.listen = vrb_rdmacm_listen,
+	.reject = vrb_rdmacm_reject,
+	.progress = vrb_rdmacm_progress,
+	.ep_init = vrb_rdmacm_ep_init,
+	.ep_close = vrb_rdmacm_ep_close,
+	.ep_bind = vrb_rdmacm_ep_bind,
+	.ep_enable = vrb_rdmacm_ep_enable,
+	.ep_setname = vrb_rdmacm_ep_setname,
+	.ep_getname = vrb_rdmacm_ep_getname,
+	.pep_init = vrb_rdmacm_pep_init,
+	.pep_close = vrb_rdmacm_pep_close,
+	.pep_bind = vrb_rdmacm_pep_bind,
+	.domain_init = vrb_rdmacm_domain_init,
+	.domain_close = vrb_rdmacm_domain_close,
+	.eq_open = vrb_rdmacm_eq_open,
+	.eq_close = vrb_rdmacm_eq_close,
+	.setname = vrb_rdmacm_setname,
+	.getname = vrb_rdmacm_getname,
+	.getpeer = vrb_rdmacm_getpeer,
+	.cm_backend = VRB_CM_RDMACM,
+};
+
+/* Caller must hold domain:xrc.ini_lock */
+void vrb_sched_ini_conn(struct vrb_ini_shared_conn *ini_conn)
+{
+	struct vrb_xrc_ep *ep;
+	enum vrb_ini_qp_state last_state;
+	struct vrb_rdmacm_eq_ctx *eq_ctx;
+	struct vrb_rdmacm_ep_ctx *ep_ctx;
+	int ret;
+
+	/* Continue to schedule shared connections if the physical connection
+	 * has completed and there are connection requests pending. We could
+	 * implement a throttle here if it is determined that it is better to
+	 * limit the number of outstanding connections. */
+	while (1) {
+		if (dlist_empty(&ini_conn->pending_list) ||
+				ini_conn->state == VRB_INI_QP_CONNECTING)
+			return;
+
+		dlist_pop_front(&ini_conn->pending_list,
+				struct vrb_xrc_ep, ep, ini_conn_entry);
+
+		ep_ctx = ep->base_ep.cm_ctx;
+
+		dlist_insert_tail(&ep->ini_conn_entry,
+				  &ep->ini_conn->active_list);
+		last_state = ep->ini_conn->state;
+
+		ret = vrb_create_ep(&ep->base_ep,
+				       last_state == VRB_INI_QP_UNCONNECTED ?
+				       RDMA_PS_TCP : RDMA_PS_UDP,
+				       &ep_ctx->id);
+		if (ret) {
+			VRB_WARN(FI_LOG_EP_CTRL,
+				   "Failed to create active CM ID %d\n",
+				   ret);
+			goto err;
+		}
+
+		if (last_state == VRB_INI_QP_UNCONNECTED) {
+			assert(!ep->ini_conn->phys_conn_id && ep_ctx->id);
+
+			if (ep->ini_conn->ini_qp &&
+			    ibv_destroy_qp(ep->ini_conn->ini_qp)) {
+				VRB_WARN(FI_LOG_EP_CTRL, "Failed to destroy "
+					   "physical INI QP %d\n", errno);
+			}
+			ret = vrb_create_ini_qp(ep);
+			if (ret) {
+				VRB_WARN(FI_LOG_EP_CTRL, "Failed to create "
+					   "physical INI QP %d\n", ret);
+				goto err;
+			}
+			ep->ini_conn->ini_qp = ep_ctx->id->qp;
+			ep->ini_conn->state = VRB_INI_QP_CONNECTING;
+			ep->ini_conn->phys_conn_id = ep_ctx->id;
+		} else {
+			assert(!ep_ctx->id->qp);
+			VRB_DBG(FI_LOG_EP_CTRL, "Sharing XRC INI QPN %d\n",
+				  ep->ini_conn->ini_qp->qp_num);
+		}
+
+		assert(ep->ini_conn->ini_qp);
+		eq_ctx = ep->base_ep.eq ? ep->base_ep.eq->cm_ctx : NULL;
+		ep_ctx->id->context = &ep->base_ep.util_ep.ep_fid.fid;
+		/* Migrate to EQ channel if available, else fall back to domain
+		 * bootstrap channel (eq_ctx is NULL before ep_bind for XRC). */
+		ret = rdma_migrate_id(ep_ctx->id,
+				      eq_ctx ? eq_ctx->cm_channel :
+				      ((struct vrb_rdmacm_domain_ctx *)
+					vrb_ep2_domain(&ep->base_ep)->cm_ctx)->cm_channel);
+		if (ret) {
+			VRB_WARN(FI_LOG_EP_CTRL,
+				   "Failed to migrate active CM ID %d\n", ret);
+			goto err;
+		}
+
+		ofi_straddr_dbg(&vrb_prov, FI_LOG_EP_CTRL, "XRC connect src_addr",
+				rdma_get_local_addr(ep_ctx->id));
+		ofi_straddr_dbg(&vrb_prov, FI_LOG_EP_CTRL, "XRC connect dest_addr",
+				rdma_get_peer_addr(ep_ctx->id));
+
+		ep->base_ep.ibv_qp = ep->ini_conn->ini_qp;
+		ret = vrb_process_ini_conn(ep, ep->conn_setup->pending_recip,
+					      ep->conn_setup->pending_param,
+					      ep->conn_setup->pending_paramlen);
+err:
+		if (ret) {
+			ep->ini_conn->state = last_state;
+			_vrb_put_shared_ini_conn(ep);
+
+			/* We need to let the application know that the
+			 * connect request has failed. */
+			vrb_create_shutdown_event(ep);
+			break;
+		}
+	}
+}

--- a/prov/verbs/src/verbs_cm_ud.c
+++ b/prov/verbs/src/verbs_cm_ud.c
@@ -1,0 +1,2060 @@
+#include "verbs_ofi.h"
+
+#define VRB_UDCM_RETRY_MAX		8
+#define VRB_UDCM_RETRY_INTERVAL_NS	(2 * 1000000000ULL)
+#define VRB_UDCM_RETRY_JITTER_PCT	25
+
+#define VRB_UDCM_QKEY			0x11111112
+#define VRB_UDCM_GRH_SIZE		40
+#define VRB_UDCM_VERSION		2
+#define VRB_UDCM_PACKET_LIFETIME	16
+#define VRB_UDCM_DEFAULT_MAX_RD		16
+#define VRB_UDCM_DEFAULT_TIMEOUT	17
+
+enum vrb_udcm_msg_type {
+	VRB_UDCM_MSG_CONN_REQ = 1,
+	VRB_UDCM_MSG_CONN_REP = 2,
+	VRB_UDCM_MSG_CONN_RTU = 3,
+	VRB_UDCM_MSG_CONN_REJ = 4,
+	VRB_UDCM_MSG_DISC_REQ = 5,
+};
+
+struct vrb_udcm_msg_hdr {
+	uint8_t		version;
+	uint8_t		msg_type;
+	uint16_t	reserved;
+	uint32_t	conn_id;
+} __attribute__((packed));
+
+struct vrb_udcm_conn_req {
+	struct vrb_udcm_msg_hdr		hdr;
+	struct ofi_addr_ib_ud		src_name;
+	uint32_t			src_rc_qpn;
+	uint8_t				src_addr_len;
+	union ofi_sock_ip		src_addr;
+	uint16_t			priv_data_len;
+	uint8_t				priv_data[VERBS_CM_DATA_SIZE];
+} __attribute__((packed));
+
+struct vrb_udcm_conn_rep {
+	struct vrb_udcm_msg_hdr		hdr;
+	struct ofi_addr_ib_ud		dst_name;
+	uint32_t			dst_rc_qpn;
+	uint32_t			resp_conn_id;
+	uint16_t			priv_data_len;
+	uint8_t				priv_data[VERBS_CM_DATA_SIZE];
+} __attribute__((packed));
+
+struct vrb_udcm_conn_rtu {
+	struct vrb_udcm_msg_hdr		hdr;
+} __attribute__((packed));
+
+struct vrb_udcm_conn_rej {
+	struct vrb_udcm_msg_hdr		hdr;
+	uint16_t			priv_data_len;
+	uint8_t				priv_data[VERBS_CM_DATA_SIZE];
+} __attribute__((packed));
+
+struct vrb_udcm_disc_req {
+	struct vrb_udcm_msg_hdr		hdr;
+} __attribute__((packed));
+
+static const char *vrb_udcm_state_str(enum vrb_udcm_state state)
+{
+	switch (state) {
+	case VRB_UDCM_IDLE:
+		return "IDLE";
+	case VRB_UDCM_REQ_SENT:
+		return "REQ_SENT";
+	case VRB_UDCM_REQ_RCVD:
+		return "REQ_RCVD";
+	case VRB_UDCM_REP_SENT:
+		return "REP_SENT";
+	case VRB_UDCM_RTU_SENT:
+		return "RTU_SENT";
+	case VRB_UDCM_CONNECTED:
+		return "CONNECTED";
+	case VRB_UDCM_REJECTING:
+		return "REJECTING";
+	case VRB_UDCM_DISCONNECTED:
+		return "DISCONNECTED";
+	default:
+		return "UNKNOWN";
+	}
+}
+
+static void vrb_udcm_trace_state_change(struct vrb_udcm_ep_ctx *ep_ctx,
+					 enum vrb_udcm_state new_state,
+					 const char *reason)
+{
+	enum vrb_udcm_state old_state = ep_ctx->state;
+
+	if (old_state == new_state)
+		return;
+
+	VRB_INFO(FI_LOG_EP_CTRL,
+		 "udcm: state %s -> %s conn_id=%u peer_conn_id=%u reason=%s\n",
+		 vrb_udcm_state_str(old_state), vrb_udcm_state_str(new_state),
+		 ep_ctx->conn_id, ep_ctx->peer_conn_id, reason);
+}
+
+static inline uint64_t
+vrb_udcm_jittered_deadline(struct vrb_udcm_domain_ctx *ctx, uint64_t now)
+{
+	uint32_t r = ofi_xorshift_random_r(&ctx->retry_seed);
+	uint64_t jitter_range = VRB_UDCM_RETRY_INTERVAL_NS *
+				VRB_UDCM_RETRY_JITTER_PCT / 100;
+	int64_t jitter = (int64_t)(r % (2 * jitter_range + 1)) -
+			 (int64_t)jitter_range;
+
+	return now + VRB_UDCM_RETRY_INTERVAL_NS + jitter;
+}
+
+static int vrb_udcm_ud_qp_to_rts(struct ibv_qp *qp, uint8_t port_num,
+				  uint16_t pkey_index)
+{
+	struct ibv_qp_attr attr = {
+		.qp_state	= IBV_QPS_INIT,
+		.pkey_index	= pkey_index,
+		.port_num	= port_num,
+		.qkey		= VRB_UDCM_QKEY,
+	};
+	int ret;
+
+	ret = ibv_modify_qp(qp, &attr,
+			    IBV_QP_STATE | IBV_QP_PKEY_INDEX |
+			    IBV_QP_PORT | IBV_QP_QKEY);
+	if (ret)
+		return -errno;
+
+	memset(&attr, 0, sizeof(attr));
+	attr.qp_state = IBV_QPS_RTR;
+	ret = ibv_modify_qp(qp, &attr, IBV_QP_STATE);
+	if (ret)
+		return -errno;
+
+	memset(&attr, 0, sizeof(attr));
+	attr.qp_state	= IBV_QPS_RTS;
+	attr.sq_psn	= 0;
+	ret = ibv_modify_qp(qp, &attr, IBV_QP_STATE | IBV_QP_SQ_PSN);
+	if (ret)
+		return -errno;
+
+	return 0;
+}
+
+static int vrb_udcm_populate_local_name(struct vrb_udcm_ib_ctx *ib)
+{
+	struct ibv_port_attr port_attr;
+	union ibv_gid gid;
+	uint16_t pkey;
+	int gid_idx;
+
+	gid_idx = vrb_resolve_gid_idx_for_device(ib->verbs);
+	if (gid_idx < 0)
+		return gid_idx;
+	ib->gid_idx = gid_idx;
+
+	if (ibv_query_gid(ib->verbs, ib->port_num, ib->gid_idx, &gid))
+		return -errno;
+	if (ibv_query_pkey(ib->verbs, ib->port_num, ib->pkey_index, &pkey))
+		return -errno;
+	if (ibv_query_port(ib->verbs, ib->port_num, &port_attr))
+		return -errno;
+
+	ib->local_name.gid	= *(union ofi_ib_gid *)&gid;
+	ib->local_name.qpn	= ib->ud_qp->qp_num;
+	ib->local_name.lid	= port_attr.lid;
+	ib->local_name.pkey	= pkey;
+	ib->local_name.sl	= port_attr.sm_sl;
+
+	return 0;
+}
+
+static int vrb_udcm_post_recvs(struct vrb_udcm_ib_ctx *ib)
+{
+	struct ibv_recv_wr wr, *bad_wr;
+	struct ibv_sge sge;
+	int i, ret;
+
+	for (i = 0; i < VRB_UDCM_RECV_WR; i++) {
+		sge.addr	= (uintptr_t)(ib->recv_bufs + i * VRB_UDCM_BUF_SIZE);
+		sge.length	= VRB_UDCM_BUF_SIZE;
+		sge.lkey	= ib->recv_mr->lkey;
+
+		wr.wr_id	= (uintptr_t)i;
+		wr.next		= NULL;
+		wr.sg_list	= &sge;
+		wr.num_sge	= 1;
+
+		ret = ibv_post_recv(ib->ud_qp, &wr, &bad_wr);
+		if (ret)
+			return -errno;
+	}
+	return 0;
+}
+
+static void vrb_udcm_repost_recv(struct vrb_udcm_ib_ctx *ib, uint64_t idx)
+{
+	struct ibv_recv_wr wr, *bad;
+	struct ibv_sge sge = {
+		.addr	= (uintptr_t)(ib->recv_bufs + idx * VRB_UDCM_BUF_SIZE),
+		.length	= VRB_UDCM_BUF_SIZE,
+		.lkey	= ib->recv_mr->lkey,
+	};
+
+	wr.wr_id	= idx;
+	wr.next		= NULL;
+	wr.sg_list	= &sge;
+	wr.num_sge	= 1;
+	ibv_post_recv(ib->ud_qp, &wr, &bad);
+}
+
+static struct ibv_device *vrb_udcm_find_ib_device(const char *name)
+{
+	struct ibv_device **list, *dev = NULL;
+	int i, n;
+
+	list = ibv_get_device_list(&n);
+	if (!list)
+		return NULL;
+	for (i = 0; i < n; i++) {
+		if (strcmp(ibv_get_device_name(list[i]), name) == 0) {
+			dev = list[i];
+			break;
+		}
+	}
+	ibv_free_device_list(list);
+	return dev;
+}
+
+static struct vrb_udcm_ib_ctx *
+vrb_udcm_ib_ctx_create(struct ibv_device *dev)
+{
+	struct vrb_udcm_ib_ctx *ib;
+	struct ibv_device_attr dev_attr;
+	struct ibv_port_attr port_attr;
+	uint16_t pkey;
+	uint8_t port_num;
+	int i, ret;
+	struct ibv_qp_init_attr qp_attr = {
+		.qp_type = IBV_QPT_UD,
+		.cap = {
+			.max_send_wr  = VRB_UDCM_SEND_WR,
+			.max_recv_wr  = VRB_UDCM_RECV_WR,
+			.max_send_sge = 1,
+			.max_recv_sge = 1,
+		},
+	};
+
+	ib = calloc(1, sizeof(*ib));
+	if (!ib)
+		return NULL;
+
+	ofi_spin_init(&ib->send_lock);
+	ofi_atomic_initialize32(&ib->ref, 1);
+
+	ib->verbs = ibv_open_device(dev);
+	if (!ib->verbs)
+		goto err;
+
+	if (ibv_query_device(ib->verbs, &dev_attr))
+		goto err;
+	for (port_num = 1; port_num <= dev_attr.phys_port_cnt; port_num++) {
+		if (ibv_query_port(ib->verbs, port_num, &port_attr) == 0 &&
+		    port_attr.state == IBV_PORT_ACTIVE)
+			break;
+	}
+	if (port_num > dev_attr.phys_port_cnt)
+		goto err;
+	ib->port_num = port_num;
+
+	ib->pkey_index = 0;
+	for (i = 0; i < port_attr.pkey_tbl_len; i++) {
+		if (ibv_query_pkey(ib->verbs, port_num, i, &pkey))
+			break;
+		if (ntohs(pkey) == 0xFFFF) {
+			ib->pkey_index = i;
+			break;
+		}
+	}
+
+	ib->pd = ibv_alloc_pd(ib->verbs);
+	if (!ib->pd)
+		goto err;
+
+	ib->comp_channel = ibv_create_comp_channel(ib->verbs);
+	if (!ib->comp_channel)
+		goto err;
+	fi_fd_nonblock(ib->comp_channel->fd);
+
+	ib->ud_recv_cq = ibv_create_cq(ib->verbs, VRB_UDCM_RECV_WR,
+					NULL, ib->comp_channel, 0);
+	if (!ib->ud_recv_cq)
+		goto err;
+	ibv_req_notify_cq(ib->ud_recv_cq, 0);
+
+	ib->ud_send_cq = ibv_create_cq(ib->verbs, VRB_UDCM_SEND_WR,
+					NULL, NULL, 0);
+	if (!ib->ud_send_cq)
+		goto err;
+
+	qp_attr.send_cq = ib->ud_send_cq;
+	qp_attr.recv_cq = ib->ud_recv_cq;
+	ib->ud_qp = ibv_create_qp(ib->pd, &qp_attr);
+	if (!ib->ud_qp)
+		goto err;
+
+	ret = vrb_udcm_ud_qp_to_rts(ib->ud_qp, ib->port_num, ib->pkey_index);
+	if (ret)
+		goto err;
+
+	ret = vrb_udcm_populate_local_name(ib);
+	if (ret)
+		goto err;
+
+	ib->recv_bufs = malloc(VRB_UDCM_RECV_WR * VRB_UDCM_BUF_SIZE);
+	if (!ib->recv_bufs)
+		goto err;
+
+	ib->recv_mr = ibv_reg_mr(ib->pd, ib->recv_bufs,
+				 VRB_UDCM_RECV_WR * VRB_UDCM_BUF_SIZE,
+				 IBV_ACCESS_LOCAL_WRITE);
+	if (!ib->recv_mr)
+		goto err;
+
+	ret = vrb_udcm_post_recvs(ib);
+	if (ret)
+		goto err;
+
+	ib->send_buf = malloc(VRB_UDCM_BUF_SIZE);
+	if (!ib->send_buf)
+		goto err;
+
+	ib->send_mr = ibv_reg_mr(ib->pd, ib->send_buf, VRB_UDCM_BUF_SIZE, 0);
+	if (!ib->send_mr)
+		goto err;
+
+	return ib;
+
+err:
+	if (ib->send_mr)
+		ibv_dereg_mr(ib->send_mr);
+	free(ib->send_buf);
+	if (ib->recv_mr)
+		ibv_dereg_mr(ib->recv_mr);
+	free(ib->recv_bufs);
+	if (ib->ud_qp)
+		ibv_destroy_qp(ib->ud_qp);
+	if (ib->ud_send_cq)
+		ibv_destroy_cq(ib->ud_send_cq);
+	if (ib->ud_recv_cq)
+		ibv_destroy_cq(ib->ud_recv_cq);
+	if (ib->comp_channel)
+		ibv_destroy_comp_channel(ib->comp_channel);
+	if (ib->pd)
+		ibv_dealloc_pd(ib->pd);
+	if (ib->verbs)
+		ibv_close_device(ib->verbs);
+	ofi_spin_destroy(&ib->send_lock);
+	free(ib);
+	return NULL;
+}
+
+static void vrb_udcm_ib_ctx_ref(struct vrb_udcm_ib_ctx *ib)
+{
+	ofi_atomic_inc32(&ib->ref);
+}
+
+static void vrb_udcm_ib_ctx_put(struct vrb_udcm_ib_ctx *ib)
+{
+	if (!ib || ofi_atomic_dec32(&ib->ref))
+		return;
+
+	if (ib->eq) {
+		ofi_epoll_del(ib->eq->epollfd, ib->comp_channel->fd);
+		ib->eq = NULL;
+	}
+
+	ibv_dereg_mr(ib->send_mr);
+	free(ib->send_buf);
+	ibv_dereg_mr(ib->recv_mr);
+	free(ib->recv_bufs);
+	ibv_destroy_qp(ib->ud_qp);
+	ibv_destroy_cq(ib->ud_send_cq);
+	ibv_destroy_cq(ib->ud_recv_cq);
+	ibv_destroy_comp_channel(ib->comp_channel);
+	ibv_dealloc_pd(ib->pd);
+	ibv_close_device(ib->verbs);
+	ofi_spin_destroy(&ib->send_lock);
+	free(ib);
+}
+
+static int vrb_udcm_send_msg(struct vrb_udcm_ib_ctx *ib,
+			     const struct ofi_addr_ib_ud *dst,
+			     const void *msg, size_t len)
+{
+	struct ibv_send_wr wr = {0}, *bad_wr;
+	struct ibv_sge sge;
+	struct ibv_ah *ah;
+	struct ibv_wc wc;
+	int ret = 0, n;
+	struct ibv_ah_attr ah_attr = {
+		.dlid		= dst->lid,
+		.sl		= dst->sl,
+		.port_num	= ib->port_num,
+		.is_global	= 1,
+		.grh = {
+			.dgid		= *(union ibv_gid *)&dst->gid,
+			.sgid_index	= ib->gid_idx,
+			.hop_limit	= 64,
+		},
+	};
+
+	assert(len <= VRB_UDCM_BUF_SIZE);
+
+	ofi_spin_lock(&ib->send_lock);
+	ah = ibv_create_ah(ib->pd, &ah_attr);
+	if (!ah) {
+		ofi_spin_unlock(&ib->send_lock);
+		return -errno;
+	}
+
+	memcpy(ib->send_buf, msg, len);
+	sge.addr	= (uintptr_t)ib->send_buf;
+	sge.length	= len;
+	sge.lkey	= ib->send_mr->lkey;
+
+	wr.opcode		= IBV_WR_SEND;
+	wr.send_flags		= IBV_SEND_SIGNALED;
+	wr.sg_list		= &sge;
+	wr.num_sge		= 1;
+	wr.wr.ud.ah		= ah;
+	wr.wr.ud.remote_qpn	= dst->qpn;
+	wr.wr.ud.remote_qkey	= VRB_UDCM_QKEY;
+
+	ret = ibv_post_send(ib->ud_qp, &wr, &bad_wr);
+	if (ret) {
+		ret = -errno;
+		goto out;
+	}
+
+	do {
+		n = ibv_poll_cq(ib->ud_send_cq, 1, &wc);
+		if (n < 0) {
+			ret = -errno;
+			goto out;
+		}
+	} while (!n);
+
+	if (wc.status != IBV_WC_SUCCESS)
+		ret = -FI_EIO;
+
+out:
+	ibv_destroy_ah(ah);
+	ofi_spin_unlock(&ib->send_lock);
+	return ret;
+}
+
+static struct vrb_udcm_ep_ctx *
+vrb_udcm_ep_lookup(struct vrb_udcm_domain_ctx *ctx, uint32_t conn_id)
+{
+	struct vrb_udcm_ep_ctx *ep_ctx;
+
+	dlist_foreach_container(&ctx->ep_list, struct vrb_udcm_ep_ctx,
+				ep_ctx, list_entry) {
+		if (ep_ctx->conn_id == conn_id)
+			return ep_ctx;
+	}
+	return NULL;
+}
+
+static struct vrb_udcm_ep_ctx *
+vrb_udcm_ep_lookup_by_peer(struct vrb_udcm_domain_ctx *ctx,
+			   uint32_t peer_conn_id, uint32_t peer_qpn)
+{
+	struct vrb_udcm_ep_ctx *ep_ctx;
+
+	dlist_foreach_container(&ctx->ep_list, struct vrb_udcm_ep_ctx,
+				ep_ctx, list_entry) {
+		if (ep_ctx->peer_conn_id == peer_conn_id &&
+		    ep_ctx->peer_name.qpn == peer_qpn)
+			return ep_ctx;
+	}
+	return NULL;
+}
+
+static int vrb_udcm_rc_qp_to_init(struct ibv_qp *qp, uint8_t port_num,
+				   uint16_t pkey_index)
+{
+	struct ibv_qp_attr attr = {
+		.qp_state	  = IBV_QPS_INIT,
+		.pkey_index	  = pkey_index,
+		.port_num	  = port_num,
+		.qp_access_flags  = IBV_ACCESS_REMOTE_WRITE |
+				    IBV_ACCESS_REMOTE_READ  |
+				    IBV_ACCESS_REMOTE_ATOMIC,
+	};
+	return ibv_modify_qp(qp, &attr,
+			     IBV_QP_STATE | IBV_QP_PKEY_INDEX |
+			     IBV_QP_PORT  | IBV_QP_ACCESS_FLAGS) ? -errno : 0;
+}
+
+static int vrb_udcm_rc_qp_to_rtr(struct ibv_qp *qp, uint8_t port_num,
+				  const struct ofi_addr_ib_ud *peer,
+				  uint32_t peer_rc_qpn)
+{
+	struct ibv_qp_attr attr;
+	struct ibv_port_attr port_attr;
+	struct ibv_device_attr dev_attr;
+	enum ibv_mtu mtu = IBV_MTU_1024;
+	uint8_t max_rd = 16;
+	int gid_idx;
+
+	gid_idx = vrb_resolve_gid_idx_for_device(qp->context);
+	if (gid_idx < 0)
+		return gid_idx;
+
+	if (ibv_query_port(qp->context, port_num, &port_attr) == 0)
+		mtu = port_attr.active_mtu;
+	if (ibv_query_device(qp->context, &dev_attr) == 0 &&
+	    dev_attr.max_qp_rd_atom > 0)
+		max_rd = dev_attr.max_qp_rd_atom;
+
+	attr = (struct ibv_qp_attr) {
+		.qp_state	    = IBV_QPS_RTR,
+		.path_mtu	    = mtu,
+		.dest_qp_num	    = peer_rc_qpn,
+		.rq_psn		    = 0,
+		.max_dest_rd_atomic = max_rd,
+		.min_rnr_timer	    = 12,
+		.ah_attr = {
+			.dlid		= peer->lid,
+			.sl		= peer->sl,
+			.port_num	= port_num,
+			.is_global	= 1,
+			.grh = {
+				.dgid		= *(union ibv_gid*)&peer->gid,
+				.sgid_index	= gid_idx,
+				.hop_limit	= 64,
+			},
+		},
+	};
+	return ibv_modify_qp(qp, &attr,
+			     IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU |
+			     IBV_QP_DEST_QPN | IBV_QP_RQ_PSN |
+			     IBV_QP_MAX_DEST_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER) ?
+	       -errno : 0;
+}
+
+static uint8_t vrb_udcm_ack_timeout(uint8_t ca_ack_delay,
+				    uint8_t packet_life_time)
+{
+	int t = packet_life_time + 1;
+
+	if (t >= ca_ack_delay)
+		t += (ca_ack_delay >= (t - 1));
+	else
+		t = ca_ack_delay + (t >= (ca_ack_delay - 1));
+
+	return MIN(31, t);
+}
+
+static int vrb_udcm_rc_qp_to_rts(struct ibv_qp *qp, uint8_t port_num)
+{
+	struct ibv_qp_attr attr;
+	struct ibv_device_attr dev_attr;
+	uint8_t max_rd = VRB_UDCM_DEFAULT_MAX_RD;
+	uint8_t timeout = VRB_UDCM_DEFAULT_TIMEOUT;
+
+	if (ibv_query_device(qp->context, &dev_attr) == 0) {
+		if (dev_attr.max_qp_rd_atom > 0)
+			max_rd = dev_attr.max_qp_rd_atom;
+
+		timeout = vrb_udcm_ack_timeout(dev_attr.local_ca_ack_delay,
+					       VRB_UDCM_PACKET_LIFETIME);
+	}
+
+	attr = (struct ibv_qp_attr) {
+		.qp_state      = IBV_QPS_RTS,
+		.sq_psn        = 0,
+		.timeout       = timeout,
+		.retry_cnt     = 15,
+		.rnr_retry     = 7,
+		.max_rd_atomic = max_rd,
+	};
+	return ibv_modify_qp(qp, &attr,
+			     IBV_QP_STATE | IBV_QP_SQ_PSN | IBV_QP_TIMEOUT |
+			     IBV_QP_RETRY_CNT | IBV_QP_RNR_RETRY |
+			     IBV_QP_MAX_QP_RD_ATOMIC) ? -errno : 0;
+}
+
+static void vrb_udcm_flush_pending_rtu(struct vrb_udcm_domain_ctx *ctx)
+{
+	struct vrb_udcm_ep_ctx *ep_ctx;
+	struct vrb_udcm_conn_rtu rtu;
+	struct ofi_addr_ib_ud dst;
+	bool found;
+
+	if (!ctx->ib)
+		return;
+
+	do {
+		found = false;
+		ofi_spin_lock(&ctx->lock);
+		dlist_foreach_container(&ctx->ep_list, struct vrb_udcm_ep_ctx,
+					ep_ctx, list_entry) {
+			if (ep_ctx->pending_rtu) {
+				ep_ctx->pending_rtu = false;
+				found = true;
+				memset(&rtu, 0, sizeof(rtu));
+				rtu.hdr.version  = VRB_UDCM_VERSION;
+				rtu.hdr.msg_type = VRB_UDCM_MSG_CONN_RTU;
+				rtu.hdr.conn_id  = htonl(ep_ctx->peer_conn_id);
+				dst = ep_ctx->peer_name;
+				break;
+			}
+		}
+		ofi_spin_unlock(&ctx->lock);
+		if (found) {
+			VRB_INFO(FI_LOG_EP_CTRL,
+				 "udcm: sending RTU to QPN %u LID %u conn_id=%u\n",
+				 dst.qpn, dst.lid, ntohl(rtu.hdr.conn_id));
+			vrb_udcm_send_msg(ctx->ib, &dst, &rtu, sizeof(rtu));
+		}
+	} while (found);
+}
+
+static void vrb_udcm_post_connreq(struct vrb_udcm_conn_req *req,
+				   struct vrb_udcm_msg_hdr *hdr,
+				   struct vrb_pep *pep,
+				   struct vrb_domain *domain,
+				   struct vrb_eq *eq)
+{
+	uint8_t evbuf[sizeof(struct fi_eq_cm_entry) + VERBS_CM_DATA_SIZE];
+	struct fi_eq_cm_entry *entry = (struct fi_eq_cm_entry *)evbuf;
+	struct vrb_connreq *connreq;
+	size_t datalen;
+
+	connreq = calloc(1, sizeof(*connreq));
+	if (!connreq)
+		return;
+
+	connreq->handle.fclass    = FI_CLASS_CONNREQ;
+	connreq->udcm_peer_name   = req->src_name;
+	connreq->udcm_peer_rc_qpn = ntohl(req->src_rc_qpn);
+	connreq->udcm_conn_id     = ntohl(hdr->conn_id);
+	connreq->udcm_domain      = domain;
+	if (req->src_addr_len > 0 &&
+	    req->src_addr_len <= sizeof(connreq->udcm_peer_addr)) {
+		memcpy(&connreq->udcm_peer_addr, &req->src_addr,
+		       req->src_addr_len);
+		connreq->udcm_peer_addr_len = req->src_addr_len;
+	}
+
+	memset(evbuf, 0, sizeof(evbuf));
+	entry->info = fi_dupinfo(pep->info);
+	if (!entry->info) {
+		free(connreq);
+		return;
+	}
+	entry->info->handle = &connreq->handle;
+	free(entry->info->dest_addr);
+	entry->info->dest_addr = NULL;
+	entry->info->dest_addrlen = 0;
+	if (req->src_addr_len > 0) {
+		entry->info->dest_addr = malloc(req->src_addr_len);
+		if (entry->info->dest_addr) {
+			memcpy(entry->info->dest_addr, &req->src_addr,
+			       req->src_addr_len);
+			entry->info->dest_addrlen = req->src_addr_len;
+		}
+	}
+
+	entry->fid = &pep->pep_fid.fid;
+	datalen = MIN(ntohs(req->priv_data_len), VERBS_CM_DATA_SIZE);
+	if (datalen)
+		memcpy(entry->data, req->priv_data, datalen);
+
+	vrb_eq_write_event(eq, FI_CONNREQ, entry,
+			   sizeof(*entry) + datalen);
+}
+
+static void vrb_udcm_dispatch_connreq(struct vrb_udcm_domain_ctx *ctx,
+				      struct vrb_udcm_msg_hdr *hdr,
+				      struct vrb_eq *eq)
+{
+	struct vrb_udcm_conn_req *req = (struct vrb_udcm_conn_req *)hdr;
+	struct vrb_udcm_pep_ctx *pep_ctx;
+	struct vrb_pep *pep = NULL, *tmp_pep;
+	struct vrb_udcm_ep_ctx *dup;
+
+	assert(ofi_spin_held(&ctx->lock));
+
+	if (!eq)
+		return;
+
+	dup = vrb_udcm_ep_lookup_by_peer(ctx, ntohl(hdr->conn_id),
+					 req->src_name.qpn);
+	if (dup) {
+		if (dup->state == VRB_UDCM_REP_SENT) {
+			VRB_INFO(FI_LOG_EP_CTRL,
+				 "udcm: duplicate CONN_REQ resets retry conn_id=%u "
+				 "peer_conn_id=%u peer_qpn=%u\n",
+				 dup->conn_id, dup->peer_conn_id, req->src_name.qpn);
+			dup->retry_count = 0;
+			dup->retry_deadline_ns = ofi_gettime_ns();
+		}
+		return;
+	}
+
+	dlist_foreach_container(&eq->pep_list, struct vrb_pep,
+				tmp_pep, eq_entry) {
+		pep_ctx = tmp_pep->cm_ctx;
+		if (pep_ctx && pep_ctx->listening) {
+			pep = tmp_pep;
+			break;
+		}
+	}
+	if (!pep)
+		return;
+
+	vrb_udcm_post_connreq(req, hdr, pep, ctx->domain, eq);
+}
+
+static void vrb_udcm_handle_conn_req(struct vrb_udcm_domain_ctx *dctx,
+				     struct vrb_eq *eq,
+				     struct vrb_udcm_msg_hdr *hdr)
+{
+	struct vrb_udcm_conn_req *req = (struct vrb_udcm_conn_req *)hdr;
+	struct vrb_udcm_pep_ctx *pep_ctx;
+	struct vrb_pep *pep = NULL, *tmp_pep;
+
+	if (!eq)
+		return;
+
+	if (dctx) {
+		vrb_udcm_dispatch_connreq(dctx, hdr, eq);
+		return;
+	}
+
+	dlist_foreach_container(&eq->pep_list, struct vrb_pep,
+				tmp_pep, eq_entry) {
+		pep_ctx = tmp_pep->cm_ctx;
+		if (pep_ctx && pep_ctx->listening) {
+			pep = tmp_pep;
+			break;
+		}
+	}
+	if (pep) {
+		VRB_INFO(FI_LOG_EP_CTRL,
+			 "udcm: PEP received CONN_REQ from QPN %u LID %u\n",
+			 req->src_name.qpn, req->src_name.lid);
+		vrb_udcm_post_connreq(req, hdr, pep, NULL, eq);
+	}
+}
+
+static void vrb_udcm_handle_conn_rep(struct vrb_udcm_ib_ctx *ib,
+				     struct vrb_udcm_domain_ctx *dctx,
+				     struct vrb_udcm_msg_hdr *hdr)
+{
+	struct vrb_udcm_conn_rep *rep = (struct vrb_udcm_conn_rep *)hdr;
+	struct vrb_udcm_ep_ctx *ep_ctx;
+	struct vrb_udcm_conn_rtu rtu;
+	uint8_t evbuf[sizeof(struct fi_eq_cm_entry) + VERBS_CM_DATA_SIZE];
+	struct fi_eq_cm_entry *entry = (struct fi_eq_cm_entry *)evbuf;
+	struct ofi_addr_ib_ud peer_name;
+	uint32_t peer_rc_qpn;
+	size_t datalen;
+
+	if (!dctx)
+		return;
+
+	VRB_INFO(FI_LOG_EP_CTRL,
+		 "udcm: domain recv CONN_REP conn_id=%u\n",
+		 ntohl(hdr->conn_id));
+	ep_ctx = vrb_udcm_ep_lookup(dctx, ntohl(hdr->conn_id));
+	if (!ep_ctx || (ep_ctx->state != VRB_UDCM_REQ_SENT &&
+			ep_ctx->state != VRB_UDCM_CONNECTED)) {
+		VRB_WARN(FI_LOG_EP_CTRL,
+			 "udcm: CONN_REP bad state (ep_ctx=%p)\n",
+			 ep_ctx);
+		return;
+	}
+
+	if (ep_ctx->state == VRB_UDCM_CONNECTED) {
+		VRB_INFO(FI_LOG_EP_CTRL,
+			 "udcm: re-sending RTU for conn_id=%u "
+			 "(peer lost our RTU)\n",
+			 ep_ctx->peer_conn_id);
+		memset(&rtu, 0, sizeof(rtu));
+		rtu.hdr.version  = VRB_UDCM_VERSION;
+		rtu.hdr.msg_type = VRB_UDCM_MSG_CONN_RTU;
+		rtu.hdr.conn_id  = htonl(ep_ctx->peer_conn_id);
+		vrb_udcm_send_msg(dctx->ib, &ep_ctx->peer_name,
+				  &rtu, sizeof(rtu));
+		return;
+	}
+
+	peer_name = rep->dst_name;
+	peer_rc_qpn = ntohl(rep->dst_rc_qpn);
+
+	if (vrb_udcm_rc_qp_to_rtr(ep_ctx->ep->ibv_qp, ib->port_num,
+				  &peer_name, peer_rc_qpn) ||
+	    vrb_udcm_rc_qp_to_rts(ep_ctx->ep->ibv_qp, ib->port_num))
+		return;
+
+	vrb_set_rnr_timer(ep_ctx->ep->ibv_qp);
+
+	ep_ctx->peer_name = peer_name;
+	ep_ctx->peer_conn_id = ntohl(rep->resp_conn_id);
+	vrb_udcm_trace_state_change(ep_ctx, VRB_UDCM_CONNECTED,
+				    "recv CONN_REP");
+	ep_ctx->state = VRB_UDCM_CONNECTED;
+	ep_ctx->ep->state = VRB_CONNECTED;
+	ep_ctx->retry_deadline_ns = 0;
+	ep_ctx->pending_rtu = true;
+
+	memset(evbuf, 0, sizeof(evbuf));
+	entry->fid = &ep_ctx->ep->util_ep.ep_fid.fid;
+	datalen = MIN(ntohs(rep->priv_data_len), VERBS_CM_DATA_SIZE);
+	if (datalen)
+		memcpy(entry->data, rep->priv_data, datalen);
+	if (ep_ctx->ep->eq)
+		vrb_eq_write_event(ep_ctx->ep->eq, FI_CONNECTED,
+				   entry, sizeof(*entry) + datalen);
+	VRB_INFO(FI_LOG_EP_CTRL,
+		 "udcm: FI_CONNECTED (client) conn_id=%u\n",
+		 ep_ctx->conn_id);
+}
+
+static void vrb_udcm_handle_conn_rtu(struct vrb_udcm_domain_ctx *dctx,
+				     struct vrb_udcm_msg_hdr *hdr)
+{
+	struct vrb_udcm_ep_ctx *ep_ctx;
+	uint8_t evbuf[sizeof(struct fi_eq_cm_entry)];
+	struct fi_eq_cm_entry *entry = (struct fi_eq_cm_entry *)evbuf;
+
+	if (!dctx)
+		return;
+
+	VRB_INFO(FI_LOG_EP_CTRL,
+		 "udcm: domain recv CONN_RTU conn_id=%u\n",
+		 ntohl(hdr->conn_id));
+	ep_ctx = vrb_udcm_ep_lookup(dctx, ntohl(hdr->conn_id));
+	if (!ep_ctx || ep_ctx->state != VRB_UDCM_REP_SENT) {
+		VRB_WARN(FI_LOG_EP_CTRL,
+			 "udcm: CONN_RTU lookup miss or wrong state (ep_ctx=%p)\n",
+			 ep_ctx);
+		return;
+	}
+
+	vrb_udcm_trace_state_change(ep_ctx, VRB_UDCM_CONNECTED,
+				    "recv CONN_RTU");
+	ep_ctx->state = VRB_UDCM_CONNECTED;
+	ep_ctx->ep->state = VRB_CONNECTED;
+	ep_ctx->retry_deadline_ns = 0;
+
+	memset(evbuf, 0, sizeof(evbuf));
+	entry->fid = &ep_ctx->ep->util_ep.ep_fid.fid;
+	if (ep_ctx->ep->eq)
+		vrb_eq_write_event(ep_ctx->ep->eq, FI_CONNECTED,
+				   entry, sizeof(*entry));
+	VRB_INFO(FI_LOG_EP_CTRL,
+		 "udcm: dispatched FI_CONNECTED (server) conn_id=%u\n",
+		 ep_ctx->conn_id);
+}
+
+static void vrb_udcm_handle_conn_rej(struct vrb_udcm_domain_ctx *dctx,
+				     struct vrb_udcm_msg_hdr *hdr)
+{
+	struct vrb_udcm_conn_rej *rej = (struct vrb_udcm_conn_rej *)hdr;
+	const struct vrb_cm_data_hdr *cm_hdr;
+	struct vrb_udcm_ep_ctx *ep_ctx;
+	struct vrb_eq *ep_eq;
+	const void *payload;
+	size_t raw_len, payload_len;
+
+	if (!dctx)
+		return;
+
+	VRB_INFO(FI_LOG_EP_CTRL,
+		 "udcm: domain recv CONN_REJ conn_id=%u\n",
+		 ntohl(hdr->conn_id));
+	ep_ctx = vrb_udcm_ep_lookup(dctx, ntohl(hdr->conn_id));
+	if (!ep_ctx || ep_ctx->state != VRB_UDCM_REQ_SENT) {
+		VRB_DBG(FI_LOG_EP_CTRL,
+			"udcm: CONN_REJ bad state (ep_ctx=%p state=%d)\n",
+			ep_ctx, ep_ctx ? ep_ctx->state : -1);
+		return;
+	}
+	ep_eq = ep_ctx->ep->eq;
+	if (!ep_eq)
+		return;
+
+	raw_len = MIN(ntohs(rej->priv_data_len), VERBS_CM_DATA_SIZE);
+	if (raw_len > sizeof(*cm_hdr)) {
+		cm_hdr = (const struct vrb_cm_data_hdr *)rej->priv_data;
+		payload = cm_hdr->data;
+		payload_len = cm_hdr->size;
+		if (payload_len > raw_len - sizeof(*cm_hdr))
+			payload_len = raw_len - sizeof(*cm_hdr);
+	} else {
+		payload = rej->priv_data;
+		payload_len = raw_len;
+	}
+
+	ofi_mutex_lock(&ep_eq->lock);
+	ep_eq->err.err = ECONNREFUSED;
+	ep_eq->err.prov_errno = 0;
+	ep_eq->err.fid = &ep_ctx->ep->util_ep.ep_fid.fid;
+	free(ep_eq->err.err_data);
+	ep_eq->err.err_data = NULL;
+	ep_eq->err.err_data_size = 0;
+	if (payload_len) {
+		ep_eq->err.err_data = malloc(payload_len);
+		if (ep_eq->err.err_data) {
+			memcpy(ep_eq->err.err_data, payload, payload_len);
+			ep_eq->err.err_data_size = payload_len;
+		}
+	}
+	ofi_mutex_unlock(&ep_eq->lock);
+
+	vrb_udcm_trace_state_change(ep_ctx, VRB_UDCM_IDLE, "recv CONN_REJ");
+	ep_ctx->state = VRB_UDCM_IDLE;
+	dlist_remove(&ep_ctx->list_entry);
+	dlist_init(&ep_ctx->list_entry);
+}
+
+static void vrb_udcm_handle_disc_req(struct vrb_udcm_domain_ctx *dctx,
+				     struct vrb_udcm_msg_hdr *hdr)
+{
+	struct vrb_udcm_ep_ctx *ep_ctx;
+	uint8_t evbuf[sizeof(struct fi_eq_cm_entry)];
+	struct fi_eq_cm_entry *entry = (struct fi_eq_cm_entry *)evbuf;
+
+	if (!dctx)
+		return;
+
+	ep_ctx = vrb_udcm_ep_lookup(dctx, ntohl(hdr->conn_id));
+	if (!ep_ctx || ep_ctx->state != VRB_UDCM_CONNECTED)
+		return;
+
+	vrb_udcm_trace_state_change(ep_ctx, VRB_UDCM_DISCONNECTED,
+				    "recv DISC_REQ");
+	ep_ctx->state = VRB_UDCM_DISCONNECTED;
+	ep_ctx->ep->state = VRB_DISCONNECTED;
+
+	memset(evbuf, 0, sizeof(evbuf));
+	entry->fid = &ep_ctx->ep->util_ep.ep_fid.fid;
+	if (ep_ctx->ep->eq)
+		vrb_eq_write_event(ep_ctx->ep->eq, FI_SHUTDOWN,
+				   entry, sizeof(*entry));
+}
+
+static void vrb_udcm_dispatch_recv(struct vrb_udcm_ib_ctx *ib,
+				   struct vrb_udcm_domain_ctx *dctx,
+				   struct vrb_eq *eq,
+				   struct vrb_udcm_msg_hdr *hdr)
+{
+	switch (hdr->msg_type) {
+	case VRB_UDCM_MSG_CONN_REQ:
+		vrb_udcm_handle_conn_req(dctx, eq, hdr);
+		break;
+	case VRB_UDCM_MSG_CONN_REP:
+		vrb_udcm_handle_conn_rep(ib, dctx, hdr);
+		break;
+	case VRB_UDCM_MSG_CONN_RTU:
+		vrb_udcm_handle_conn_rtu(dctx, hdr);
+		break;
+	case VRB_UDCM_MSG_CONN_REJ:
+		vrb_udcm_handle_conn_rej(dctx, hdr);
+		break;
+	case VRB_UDCM_MSG_DISC_REQ:
+		vrb_udcm_handle_disc_req(dctx, hdr);
+		break;
+	default:
+		FI_WARN_ONCE(&vrb_prov, FI_LOG_EP_CTRL,
+			     "unknown udcm msg_type %u\n", hdr->msg_type);
+		break;
+	}
+}
+
+static int vrb_udcm_drain_cq(struct vrb_udcm_ib_ctx *ib,
+			       struct vrb_udcm_domain_ctx *dctx,
+			       struct vrb_eq *eq)
+{
+	struct ibv_cq *ev_cq;
+	void *ev_ctx;
+	struct ibv_wc wc;
+	uint8_t *buf;
+	struct vrb_udcm_msg_hdr *hdr;
+	int ret;
+
+	if (ibv_get_cq_event(ib->comp_channel, &ev_cq, &ev_ctx) == 0) {
+		ibv_ack_cq_events(ev_cq, 1);
+		ret = ibv_req_notify_cq(ib->ud_recv_cq, 0);
+		if (ret)
+			return -errno;
+	}
+
+	if (dctx)
+		ofi_spin_lock(&dctx->lock);
+	while (ibv_poll_cq(ib->ud_recv_cq, 1, &wc) > 0) {
+		if (wc.status != IBV_WC_SUCCESS)
+			goto repost;
+
+		buf = ib->recv_bufs + wc.wr_id * VRB_UDCM_BUF_SIZE;
+		hdr = (struct vrb_udcm_msg_hdr *)(buf + VRB_UDCM_GRH_SIZE);
+		if (hdr->version != VRB_UDCM_VERSION) {
+			FI_WARN_ONCE(&vrb_prov, FI_LOG_EP_CTRL,
+				"unknown udcm version %u\n", hdr->version);
+			goto repost;
+		}
+
+		vrb_udcm_dispatch_recv(ib, dctx, eq, hdr);
+repost:
+		vrb_udcm_repost_recv(ib, wc.wr_id);
+	}
+	if (dctx)
+		ofi_spin_unlock(&dctx->lock);
+
+	if (dctx)
+		vrb_udcm_flush_pending_rtu(dctx);
+	return 0;
+}
+
+static void vrb_udcm_check_retries(struct vrb_udcm_domain_ctx *ctx,
+				   struct vrb_eq *eq)
+{
+	struct vrb_udcm_ep_ctx *ep_ctx;
+	struct dlist_entry *tmp;
+	uint64_t now = ofi_gettime_ns();
+	enum { NONE, RETRY, TIMEOUT } action;
+	enum vrb_udcm_state state;
+	uint32_t conn_id, peer_conn_id, rc_qpn;
+	size_t priv_data_len;
+	uint8_t priv_data[VERBS_CM_DATA_SIZE];
+	union ofi_sock_ip src_addr;
+	uint8_t src_addr_len;
+	struct ofi_addr_ib_ud dst;
+	struct vrb_ep *tep;
+	struct vrb_udcm_conn_req retry_req = {0};
+	struct vrb_udcm_conn_rep retry_rep = {0};
+
+	if (!ctx->ib)
+		return;
+
+	do {
+		action = NONE;
+		tep = NULL;
+
+		ofi_spin_lock(&ctx->lock);
+		dlist_foreach_container_safe(&ctx->ep_list,
+				struct vrb_udcm_ep_ctx, ep_ctx, list_entry, tmp) {
+			if (!ep_ctx->retry_deadline_ns ||
+			    now < ep_ctx->retry_deadline_ns)
+				continue;
+
+			if (ep_ctx->retry_count >= VRB_UDCM_RETRY_MAX) {
+				ep_ctx->retry_deadline_ns = 0;
+				state = ep_ctx->state;
+				conn_id = ep_ctx->conn_id;
+				dst = ep_ctx->peer_name;
+				VRB_INFO(FI_LOG_EP_CTRL,
+					 "udcm: retry max reached state=%s conn_id=%u "
+					 "peer_conn_id=%u retries=%d\n",
+					 vrb_udcm_state_str(ep_ctx->state),
+					 ep_ctx->conn_id, ep_ctx->peer_conn_id,
+					 ep_ctx->retry_count);
+				vrb_udcm_trace_state_change(ep_ctx,
+							VRB_UDCM_DISCONNECTED,
+							"retry_max_timeout");
+				ep_ctx->state = VRB_UDCM_DISCONNECTED;
+				ep_ctx->ep->state = VRB_DISCONNECTED;
+				tep    = ep_ctx->ep;
+				action = TIMEOUT;
+			} else {
+				ep_ctx->retry_count++;
+				ep_ctx->retry_deadline_ns =
+					vrb_udcm_jittered_deadline(ctx, now);
+				VRB_DBG(FI_LOG_EP_CTRL,
+					"udcm: retry state=%s conn_id=%u peer_conn_id=%u "
+					"retry_count=%d next_deadline_ns=%llu\n",
+					vrb_udcm_state_str(ep_ctx->state),
+					ep_ctx->conn_id, ep_ctx->peer_conn_id,
+					ep_ctx->retry_count,
+					(unsigned long long) ep_ctx->retry_deadline_ns);
+				state = ep_ctx->state;
+				conn_id = ep_ctx->conn_id;
+				peer_conn_id = ep_ctx->peer_conn_id;
+				rc_qpn = ep_ctx->ep->ibv_qp ?
+					 ep_ctx->ep->ibv_qp->qp_num : 0;
+				priv_data_len = ep_ctx->priv_data_len;
+				dst = ep_ctx->peer_name;
+				src_addr = ep_ctx->src_addr;
+				src_addr_len  = ep_ctx->src_addr_len;
+				if (priv_data_len)
+					memcpy(priv_data, ep_ctx->priv_data,
+					       priv_data_len);
+				action = RETRY;
+			}
+			break;
+		}
+		ofi_spin_unlock(&ctx->lock);
+
+		if (action == TIMEOUT) {
+			FI_WARN(&vrb_prov, FI_LOG_EP_CTRL,
+				"udcm: connect timed out after %d retries\n",
+				VRB_UDCM_RETRY_MAX);
+			if (eq) {
+				ofi_mutex_lock(&eq->lock);
+				eq->err.err = ETIMEDOUT;
+				eq->err.prov_errno = 0;
+				eq->err.fid = &tep->util_ep.ep_fid.fid;
+				ofi_mutex_unlock(&eq->lock);
+				return;
+			}
+		} else if (action == RETRY) {
+			if (state == VRB_UDCM_REQ_SENT) {
+				retry_req.hdr.version = VRB_UDCM_VERSION;
+				retry_req.hdr.msg_type = VRB_UDCM_MSG_CONN_REQ;
+				retry_req.hdr.conn_id = htonl(conn_id);
+				retry_req.src_name = ctx->ib->local_name;
+				retry_req.src_rc_qpn = htonl(rc_qpn);
+				retry_req.priv_data_len = htons((uint16_t)priv_data_len);
+				if (priv_data_len)
+					memcpy(retry_req.priv_data, priv_data,
+					       priv_data_len);
+				if (src_addr_len) {
+					memcpy(&retry_req.src_addr, &src_addr,
+					       src_addr_len);
+					retry_req.src_addr_len = src_addr_len;
+				}
+				vrb_udcm_send_msg(ctx->ib, &dst, &retry_req,
+						  sizeof(retry_req));
+			} else if (state == VRB_UDCM_REP_SENT) {
+				retry_rep.hdr.version = VRB_UDCM_VERSION;
+				retry_rep.hdr.msg_type = VRB_UDCM_MSG_CONN_REP;
+				retry_rep.hdr.conn_id = htonl(peer_conn_id);
+				retry_rep.resp_conn_id = htonl(conn_id);
+				retry_rep.dst_name = ctx->ib->local_name;
+				retry_rep.dst_rc_qpn = htonl(rc_qpn);
+				retry_rep.priv_data_len = htons((uint16_t)priv_data_len);
+				if (priv_data_len)
+					memcpy(retry_rep.priv_data, priv_data,
+					       priv_data_len);
+				vrb_udcm_send_msg(ctx->ib, &dst, &retry_rep,
+						  sizeof(retry_rep));
+			}
+		}
+	} while (action != NONE);
+}
+
+static ssize_t vrb_udcm_progress(struct vrb_eq *eq, uint32_t *event,
+				 void *buf, size_t len)
+{
+	struct vrb_udcm_eq_ctx *eq_ctx = eq->cm_ctx;
+	struct vrb_udcm_domain_ctx *dctx = NULL;
+	struct vrb_pep *pep;
+	struct vrb_udcm_pep_ctx *pctx;
+	int ret = 0;
+
+	if (eq_ctx && eq_ctx->domain && eq_ctx->domain->cm_ctx)
+		dctx = eq_ctx->domain->cm_ctx;
+
+	/* Drain domain's CQ first — CONN_REPs arrive here */
+	if (dctx && dctx->ib) {
+		ret = vrb_udcm_drain_cq(dctx->ib, dctx, eq);
+		if (ret)
+			return ret;
+	}
+
+	dlist_foreach_container(&eq->pep_list, struct vrb_pep, pep, eq_entry) {
+		pctx = pep->cm_ctx;
+		if (!pctx || !pctx->ib)
+			return 0;
+
+		if (!dctx || pctx->ib != dctx->ib) {
+			ret = vrb_udcm_drain_cq(pctx->ib, dctx, pep->eq);
+			if (ret)
+				return ret;
+		}
+	}
+
+	if (dctx)
+		vrb_udcm_check_retries(dctx, eq);
+
+	return 0;
+}
+
+static int vrb_udcm_connect(struct vrb_ep *ep, const void *addr,
+			    const void *param, size_t paramlen)
+{
+	struct vrb_domain *domain = vrb_ep2_domain(ep);
+	struct vrb_udcm_domain_ctx *ctx = domain->cm_ctx;
+	struct vrb_udcm_ep_ctx *ep_ctx = ep->cm_ctx;
+	struct vrb_udcm_conn_req req = {0};
+	const struct ofi_sockaddr_ib *sib;
+	struct ofi_addr_ib_ud *peer_ud;
+	struct sockaddr *sa = (struct sockaddr*)addr;
+	struct ofi_addr_ib_ud *ud = (struct ofi_addr_ib_ud *)addr;
+	char ip_str[INET6_ADDRSTRLEN];
+	int svc;
+	struct util_ns ns = {0};
+
+	if (!ctx || !ctx->ib || !ep->ibv_qp)
+		return -FI_EOPBADSTATE;
+	if (paramlen > VERBS_CM_DATA_SIZE)
+		return -FI_EINVAL;
+
+	if (ep->info_attr.addr_format == FI_ADDR_IB_UD && ud->qpn != 0) {
+		ep_ctx->peer_name = *ud;
+		VRB_INFO(FI_LOG_EP_CTRL,
+			 "udcm: addr — QPN %u LID %u\n",
+			 ep_ctx->peer_name.qpn, ep_ctx->peer_name.lid);
+	} else if (ep->info_attr.addr_format == FI_ADDR_IB_UD) {
+		if (ud->gid.raw[10] == 0xff && ud->gid.raw[11] == 0xff) {
+			if (!inet_ntop(AF_INET, &ud->gid.raw[12],
+				       ip_str, sizeof(ip_str)))
+				return -errno;
+		} else {
+			if (!inet_ntop(AF_INET6, ud->gid.raw,
+				       ip_str, sizeof(ip_str)))
+				return -errno;
+		}
+		svc = ud->service;
+
+		ns.port = (svc > 1) ? svc : vrb_gl_data.dgram.name_server_port;
+		ns.name_len = sizeof(*peer_ud);
+		ns.service_len = sizeof(svc);
+		ns.service_cmp = vrb_dgram_ns_service_cmp;
+		ns.is_service_wildcard = vrb_dgram_ns_is_service_wildcard;
+
+		ofi_ns_init(&ns);
+		peer_ud = ofi_ns_resolve_name(&ns, ip_str, &svc);
+		if (!peer_ud) {
+			VRB_WARN(FI_LOG_EP_CTRL,
+				 "udcm: failed to resolve server UD CM address at %s:%d\n",
+				 ip_str, svc);
+			return -FI_ENODATA;
+		}
+
+		ep_ctx->peer_name = *peer_ud;
+		free(peer_ud);
+	} else {
+		ns.name_len = sizeof(*peer_ud);
+		ns.service_len = sizeof(svc);
+		ns.service_cmp = vrb_dgram_ns_service_cmp;
+		ns.is_service_wildcard = vrb_dgram_ns_is_service_wildcard;
+
+		switch (sa->sa_family) {
+		case AF_INET:
+			if (!inet_ntop(AF_INET,
+				       &((const struct sockaddr_in *)sa)->sin_addr,
+				       ip_str, sizeof(ip_str)))
+				return -errno;
+			svc = ntohs(((const struct sockaddr_in *)sa)->sin_port);
+			break;
+		case AF_INET6:
+			if (!inet_ntop(AF_INET6,
+				       &((const struct sockaddr_in6 *)sa)->sin6_addr,
+				       ip_str, sizeof(ip_str)))
+				return -errno;
+			svc = ntohs(((const struct sockaddr_in6 *)sa)->sin6_port);
+			break;
+		case AF_IB:
+			sib = (const struct ofi_sockaddr_ib *)sa;
+			if (!inet_ntop(AF_INET6, sib->sib_addr,
+				       ip_str, sizeof(ip_str)))
+				return -errno;
+			svc = (int)(ntohll(sib->sib_sid) & 0xFFFF);
+			break;
+		default:
+			VRB_WARN(FI_LOG_EP_CTRL,
+				 "udcm: unsupported dest addr family %d\n",
+				 sa->sa_family);
+			return -FI_ENOSYS;
+		}
+
+		ns.port = (svc > 1) ? svc : vrb_gl_data.dgram.name_server_port;
+
+		ofi_ns_init(&ns);
+		peer_ud = ofi_ns_resolve_name(&ns, ip_str, &svc);
+		if (!peer_ud) {
+			VRB_WARN(FI_LOG_EP_CTRL,
+				 "udcm: failed to resolve server UD CM address at %s:%d\n",
+				 ip_str, svc);
+			return -FI_ENODATA;
+		}
+
+		ep_ctx->peer_name = *peer_ud;
+		free(peer_ud);
+	}
+
+	ep_ctx->conn_id = (uint32_t)ofi_atomic_inc32(&ctx->next_conn_id);
+
+	if (param && paramlen) {
+		memcpy(ep_ctx->priv_data, param, paramlen);
+		ep_ctx->priv_data_len = paramlen;
+	}
+
+	req.hdr.version = VRB_UDCM_VERSION;
+	req.hdr.msg_type = VRB_UDCM_MSG_CONN_REQ;
+	req.hdr.conn_id = htonl(ep_ctx->conn_id);
+	req.src_name = ctx->ib->local_name;
+	req.src_rc_qpn = htonl(ep->ibv_qp->qp_num);
+	req.priv_data_len = htons((uint16_t)paramlen);
+	if (paramlen)
+		memcpy(req.priv_data, param, paramlen);
+
+	if (ep->info_attr.src_addr && ep->info_attr.src_addrlen &&
+	    ep->info_attr.src_addrlen <= sizeof(req.src_addr)) {
+		memcpy(&req.src_addr, ep->info_attr.src_addr,
+		       ep->info_attr.src_addrlen);
+		req.src_addr_len = (uint8_t)ep->info_attr.src_addrlen;
+		memcpy(&ep_ctx->src_addr, ep->info_attr.src_addr,
+		       ep->info_attr.src_addrlen);
+		ep_ctx->src_addr_len = (uint8_t)ep->info_attr.src_addrlen;
+	}
+
+	ofi_spin_lock(&ctx->lock);
+	vrb_udcm_trace_state_change(ep_ctx, VRB_UDCM_REQ_SENT,
+				    "connect() send CONN_REQ");
+	ep_ctx->state = VRB_UDCM_REQ_SENT;
+	ep_ctx->retry_count = 0;
+	ep_ctx->retry_deadline_ns = vrb_udcm_jittered_deadline(ctx, ofi_gettime_ns());
+	dlist_insert_tail(&ep_ctx->list_entry, &ctx->ep_list);
+	ofi_spin_unlock(&ctx->lock);
+
+	return vrb_udcm_send_msg(ctx->ib, &ep_ctx->peer_name, &req, sizeof(req));
+}
+
+static int vrb_udcm_accept(struct vrb_ep *ep, const void *param,
+			   size_t paramlen)
+{
+	struct vrb_domain *domain = vrb_ep2_domain(ep);
+	struct vrb_udcm_domain_ctx *ctx = domain->cm_ctx;
+	struct vrb_udcm_ep_ctx *ep_ctx = ep->cm_ctx;
+	struct vrb_udcm_conn_rep rep = {0};
+	struct vrb_connreq *connreq;
+	int ret;
+
+	if (!ctx || !ctx->ib || !ep->ibv_qp)
+		return -FI_EOPBADSTATE;
+	if (paramlen > VERBS_CM_DATA_SIZE)
+		return -FI_EINVAL;
+
+	ret = vrb_udcm_rc_qp_to_rts(ep->ibv_qp, ctx->ib->port_num);
+	if (ret)
+		return ret;
+
+	vrb_set_rnr_timer(ep->ibv_qp);
+
+	if (ep->info_attr.handle &&
+	    ((struct fid *)ep->info_attr.handle)->fclass == FI_CLASS_CONNREQ) {
+		connreq = container_of(ep->info_attr.handle,
+				       struct vrb_connreq, handle);
+		free(connreq);
+		ep->info_attr.handle = NULL;
+	}
+
+	rep.hdr.version = VRB_UDCM_VERSION;
+	rep.hdr.msg_type = VRB_UDCM_MSG_CONN_REP;
+	rep.hdr.conn_id = htonl(ep_ctx->peer_conn_id);
+	rep.resp_conn_id = htonl(ep_ctx->conn_id);
+	rep.dst_name = ctx->ib->local_name;
+	rep.dst_rc_qpn = htonl(ep->ibv_qp->qp_num);
+	rep.priv_data_len = htons((uint16_t)paramlen);
+	if (paramlen)
+		memcpy(rep.priv_data, param, paramlen);
+
+	vrb_udcm_trace_state_change(ep_ctx, VRB_UDCM_REP_SENT,
+				    "accept() send CONN_REP");
+	ep_ctx->state = VRB_UDCM_REP_SENT;
+	ep_ctx->retry_count = 0;
+	ep_ctx->retry_deadline_ns = vrb_udcm_jittered_deadline(ctx, ofi_gettime_ns());
+	VRB_INFO(FI_LOG_EP_CTRL,
+		 "udcm: sending CONN_REP to QPN %u LID %u conn_id=%u\n",
+		 ep_ctx->peer_name.qpn, ep_ctx->peer_name.lid, ep_ctx->conn_id);
+	return vrb_udcm_send_msg(ctx->ib, &ep_ctx->peer_name, &rep, sizeof(rep));
+}
+
+static int vrb_udcm_shutdown(struct vrb_ep *ep, uint64_t flags)
+{
+	struct vrb_domain *domain = vrb_ep2_domain(ep);
+	struct vrb_udcm_domain_ctx *ctx = domain->cm_ctx;
+	struct vrb_udcm_ep_ctx *ep_ctx = ep->cm_ctx;
+	struct vrb_udcm_disc_req disc = {0};
+
+	if (!ctx || !ctx->ib || !ep_ctx ||
+	    ep_ctx->state != VRB_UDCM_CONNECTED)
+		return 0;
+
+	vrb_udcm_trace_state_change(ep_ctx, VRB_UDCM_DISCONNECTED,
+				    "shutdown() send DISC_REQ");
+	ep_ctx->state = VRB_UDCM_DISCONNECTED;
+	ep->state = VRB_DISCONNECTED;
+
+	disc.hdr.version = VRB_UDCM_VERSION;
+	disc.hdr.msg_type = VRB_UDCM_MSG_DISC_REQ;
+	disc.hdr.conn_id = htonl(ep_ctx->peer_conn_id);
+	vrb_udcm_send_msg(ctx->ib, &ep_ctx->peer_name, &disc, sizeof(disc));
+	return 0;
+}
+
+static int vrb_udcm_reject(struct vrb_pep *pep, struct vrb_connreq *connreq,
+			   const void *param, size_t paramlen)
+{
+	struct vrb_udcm_domain_ctx *dctx;
+	struct vrb_udcm_pep_ctx *pctx;
+	struct vrb_udcm_ib_ctx *ib = NULL;
+	struct vrb_udcm_conn_rej rej = {0};
+
+	if (connreq->udcm_domain && connreq->udcm_domain->cm_ctx) {
+		dctx = connreq->udcm_domain->cm_ctx;
+		ib = dctx->ib;
+	}
+	if (!ib && pep && pep->cm_ctx) {
+		pctx = pep->cm_ctx;
+		ib = pctx->ib;
+	}
+	if (!ib) {
+		FI_WARN(&vrb_prov, FI_LOG_EP_CTRL,
+			"udcm: REJ DROPPED — no ib_ctx available!\n");
+		return 0;
+	}
+
+	rej.hdr.version = VRB_UDCM_VERSION;
+	rej.hdr.msg_type = VRB_UDCM_MSG_CONN_REJ;
+	rej.hdr.conn_id = htonl(connreq->udcm_conn_id);
+	rej.priv_data_len = htons((uint16_t)paramlen);
+	if (paramlen)
+		memcpy(rej.priv_data, param, paramlen);
+
+	VRB_INFO(FI_LOG_EP_CTRL,
+		 "udcm: REJ → peer QPN %u conn_id %u\n",
+		 connreq->udcm_peer_name.qpn, connreq->udcm_conn_id);
+
+	return vrb_udcm_send_msg(ib, &connreq->udcm_peer_name,
+				 &rej, sizeof(rej));
+}
+
+static int vrb_udcm_eq_open(struct vrb_eq *eq)
+{
+	struct vrb_udcm_eq_ctx *ctx;
+
+	ctx = calloc(1, sizeof(*ctx));
+	if (!ctx)
+		return -FI_ENOMEM;
+
+	eq->cm_ctx = ctx;
+	eq->cm_ops = &vrb_udcm_ops;
+	return 0;
+}
+
+static int vrb_udcm_eq_close(struct vrb_eq *eq)
+{
+	struct vrb_udcm_eq_ctx *eq_ctx = eq->cm_ctx;
+	struct vrb_udcm_domain_ctx *dctx;
+	struct vrb_udcm_ib_ctx *ib = NULL;
+	struct vrb_udcm_pep_ctx *pep_ctx;
+	struct vrb_pep *pep;
+
+	if (eq_ctx->domain) {
+		dctx = eq_ctx->domain->cm_ctx;
+		if (dctx && dctx->ib && dctx->ib->eq == eq) {
+			ofi_epoll_del(eq->epollfd,
+				      dctx->ib->comp_channel->fd);
+			dctx->ib->eq = NULL;
+		}
+	}
+
+	dlist_foreach_container(&eq->pep_list, struct vrb_pep, pep, eq_entry) {
+		pep_ctx = pep->cm_ctx;
+		if (pep_ctx && pep_ctx->ib && pep_ctx->ib->eq == eq) {
+			ib = pep_ctx->ib;
+			break;
+		}
+	}
+
+	if (ib) {
+		ofi_epoll_del(eq->epollfd, ib->comp_channel->fd);
+		ib->eq = NULL;
+	}
+
+	free(eq->cm_ctx);
+	eq->cm_ctx = NULL;
+	return 0;
+}
+
+static int vrb_udcm_domain_get(struct vrb_domain *domain)
+{
+	struct vrb_udcm_domain_ctx *ctx;
+
+	ofi_genlock_lock(&domain->util_domain.lock);
+	ctx = domain->cm_ctx;
+	if (ctx) {
+		ofi_atomic_inc32(&ctx->ref);
+		ofi_genlock_unlock(&domain->util_domain.lock);
+		return 0;
+	}
+
+	ctx = calloc(1, sizeof(*ctx));
+	if (!ctx) {
+		ofi_genlock_unlock(&domain->util_domain.lock);
+		return -FI_ENOMEM;
+	}
+
+	ctx->domain = domain;
+	ofi_spin_init(&ctx->lock);
+	ofi_atomic_initialize32(&ctx->ref, 1);
+	ofi_atomic_initialize32(&ctx->next_conn_id, 1);
+	ctx->retry_seed = ofi_generate_seed();
+	dlist_init(&ctx->ep_list);
+
+	domain->cm_ctx = ctx;
+	ofi_genlock_unlock(&domain->util_domain.lock);
+	return 0;
+}
+
+static void vrb_udcm_domain_put(struct vrb_domain *domain)
+{
+	struct vrb_udcm_domain_ctx *ctx = domain->cm_ctx;
+
+	if (!ctx || ofi_atomic_dec32(&ctx->ref))
+		return;
+
+	domain->cm_ctx = NULL;
+
+	vrb_udcm_ib_ctx_put(ctx->ib);
+	ctx->ib = NULL;
+
+	ofi_spin_destroy(&ctx->lock);
+	free(ctx);
+}
+
+static int vrb_udcm_domain_init(struct vrb_domain *domain)
+{
+	struct vrb_fabric *fab = container_of(domain->util_domain.fabric,
+					      struct vrb_fabric, util_fabric);
+	int ns_port;
+
+	ns_port = vrb_gl_data.msg.udcm_ns_port;
+	if (ns_port <= 0)
+		ns_port = vrb_gl_data.dgram.name_server_port;
+
+	if (!fab->name_server.is_initialized) {
+		fab->name_server.port = ns_port;
+		fab->name_server.name_len = sizeof(struct ofi_addr_ib_ud);
+		fab->name_server.service_len = sizeof(int);
+		fab->name_server.service_cmp = vrb_dgram_ns_service_cmp;
+		fab->name_server.is_service_wildcard = vrb_dgram_ns_is_service_wildcard;
+		ofi_ns_init(&fab->name_server);
+	}
+	ofi_ns_start_server(&fab->name_server);
+	return 0;
+}
+
+static int vrb_udcm_domain_close(struct vrb_domain *domain)
+{
+	struct vrb_fabric *fab = container_of(domain->util_domain.fabric,
+					      struct vrb_fabric, util_fabric);
+
+	if (fab->name_server.is_initialized)
+		ofi_ns_stop_server(&fab->name_server);
+
+	vrb_udcm_domain_put(domain);
+	return 0;
+}
+
+static int vrb_udcm_pep_init(struct vrb_pep *pep)
+{
+	struct vrb_udcm_pep_ctx *ctx;
+	struct ofi_addr_ib_ud *ud;
+
+	ctx = calloc(1, sizeof(*ctx));
+	if (!ctx)
+		return -FI_ENOMEM;
+
+	if (pep->info && pep->info->src_addr) {
+		if (pep->info->addr_format == FI_ADDR_IB_UD) {
+			ud = (struct ofi_addr_ib_ud *)pep->info->src_addr;
+			ctx->service = (int)ud->service;
+		} else {
+			ctx->service = (int)ofi_addr_get_port(
+						pep->info->src_addr);
+		}
+	}
+
+	pep->cm_ctx = ctx;
+	return 0;
+}
+
+static int vrb_udcm_pep_close(struct vrb_pep *pep)
+{
+	struct vrb_udcm_pep_ctx *ctx = pep->cm_ctx;
+	struct vrb_fabric *fab = pep->fabric;
+
+	if (!ctx)
+		return 0;
+
+	if (fab && fab->name_server.is_initialized && ctx->listening)
+		ofi_ns_del_local_name(&fab->name_server,
+				      &ctx->service, &ctx->ib->local_name);
+
+	vrb_udcm_ib_ctx_put(ctx->ib);
+	ctx->ib = NULL;
+
+	free(ctx);
+	pep->cm_ctx = NULL;
+	return 0;
+}
+
+static uint16_t vrb_udcm_alloc_port(const struct sockaddr_in *template)
+{
+	struct sockaddr_in sin = *template;
+	socklen_t len = sizeof(sin);
+	int fd;
+
+	sin.sin_port = 0;
+	fd = socket(AF_INET, SOCK_DGRAM, 0);
+	if (fd < 0)
+		return 0;
+	if (bind(fd, (struct sockaddr *)&sin, sizeof(sin)) ||
+	    getsockname(fd, (struct sockaddr *)&sin, &len)) {
+		ofi_close_socket(fd);
+		return 0;
+	}
+	ofi_close_socket(fd);
+	return ntohs(sin.sin_port);
+}
+
+static int vrb_udcm_listen(struct vrb_pep *pep)
+{
+	struct vrb_udcm_pep_ctx *ctx = pep->cm_ctx;
+	struct vrb_fabric *fab = pep->fabric;
+	struct ofi_addr_ib_ud *ud_addr;
+	struct sockaddr_in any = {0};
+	struct ibv_device *dev;
+	uint16_t port;
+	int ret;
+
+	if (!ctx)
+		return -FI_EOPBADSTATE;
+
+	dev = vrb_udcm_find_ib_device(pep->info->domain_attr->name);
+	if (!dev) {
+		VRB_WARN(FI_LOG_EP_CTRL, "udcm: IB device '%s' not found\n",
+			 pep->info->domain_attr->name);
+		return -FI_ENODATA;
+	}
+
+	ctx->ib = vrb_udcm_ib_ctx_create(dev);
+	if (!ctx->ib)
+		return -FI_ENOMEM;
+
+	if (pep->info->src_addr && pep->info->addr_format == FI_ADDR_IB_UD)
+		port = ((struct ofi_addr_ib_ud *)pep->info->src_addr)->service;
+	else if (pep->info->src_addr)
+		port = ofi_addr_get_port(pep->info->src_addr);
+	else
+		port = 0;
+	if (!port) {
+		any.sin_family = AF_INET;
+		any.sin_addr.s_addr = INADDR_ANY;
+		port = vrb_udcm_alloc_port(&any);
+		if (!port) {
+			VRB_WARN(FI_LOG_EP_CTRL,
+				 "udcm: failed to allocate ephemeral port\n");
+			ret = -FI_EADDRNOTAVAIL;
+			goto err;
+		}
+	}
+
+	if (pep->info->addr_format == FI_ADDR_IB_UD) {
+		ud_addr = calloc(1, sizeof(*ud_addr));
+		if (!ud_addr) {
+			ret = -FI_ENOMEM;
+			goto err;
+		}
+		*ud_addr = ctx->ib->local_name;
+		ud_addr->service = port;
+
+		free(pep->info->src_addr);
+		pep->info->src_addr = ud_addr;
+		pep->info->src_addrlen = sizeof(*ud_addr);
+	} else {
+		if (pep->info->src_addr)
+			ofi_addr_set_port(pep->info->src_addr, port);
+	}
+
+	VRB_INFO(FI_LOG_EP_CTRL,
+		 "udcm: PEP listening QPN %u LID %u port %u\n",
+		 ctx->ib->local_name.qpn, ctx->ib->local_name.lid, port);
+
+	ctx->service = VERBS_IB_UD_NS_ANY_SERVICE;
+	if (fab && fab->name_server.is_initialized) {
+		ret = ofi_ns_add_local_name(&fab->name_server,
+					    &ctx->service,
+					    &ctx->ib->local_name);
+		if (ret)
+			VRB_INFO(FI_LOG_EP_CTRL,
+				 "udcm: NS add_local_name failed (%d)\n",
+				 ret);
+	}
+
+	ibv_req_notify_cq(ctx->ib->ud_recv_cq, 0);
+	if (pep->eq) {
+		if (ofi_epoll_add(pep->eq->epollfd, ctx->ib->comp_channel->fd,
+				  OFI_EPOLL_IN, NULL)) {
+			ret = -errno;
+			VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "ofi_epoll_add (PEP)");
+			goto err;
+		}
+		ctx->ib->eq = pep->eq;
+	}
+
+	ctx->listening = true;
+	return 0;
+err:
+	vrb_udcm_pep_close(pep);
+	return ret;
+}
+
+static int vrb_udcm_pep_bind(struct vrb_pep *pep, struct vrb_eq *eq)
+{
+	if (!eq->cm_ops)
+		eq->cm_ops = &vrb_udcm_ops;
+	if (!eq->cm_ctx)
+		return vrb_udcm_eq_open(eq);
+	return 0;
+}
+
+static int vrb_udcm_ep_init(struct vrb_ep *ep, struct fi_info *info)
+{
+	struct vrb_domain *domain = vrb_ep2_domain(ep);
+	struct vrb_udcm_domain_ctx *dctx;
+	struct vrb_connreq *connreq;
+	struct vrb_udcm_ep_ctx *ctx;
+	int ret;
+
+	ctx = calloc(1, sizeof(*ctx));
+	if (!ctx)
+		return -FI_ENOMEM;
+	ctx->ep = ep;
+	dlist_init(&ctx->list_entry);
+	ep->cm_ctx = ctx;
+
+	if (domain->util_domain.threading == FI_THREAD_SAFE) {
+		*ep->util_ep.ep_fid.msg = vrb_msg_ep_msg_ops_ts;
+		ep->util_ep.ep_fid.rma = &vrb_msg_ep_rma_ops_ts;
+	} else {
+		*ep->util_ep.ep_fid.msg = vrb_msg_ep_msg_ops;
+		ep->util_ep.ep_fid.rma = &vrb_msg_ep_rma_ops;
+	}
+	ep->util_ep.ep_fid.cm = &vrb_msg_ep_cm_ops;
+	ep->util_ep.ep_fid.atomic = &vrb_msg_ep_atomic_ops;
+
+	ret = vrb_udcm_domain_get(domain);
+	if (ret) {
+		free(ctx);
+		ep->cm_ctx = NULL;
+		return ret;
+	}
+
+	if (info->handle && info->handle->fclass == FI_CLASS_CONNREQ) {
+		connreq = container_of(info->handle, struct vrb_connreq, handle);
+		if (connreq->udcm_conn_id || connreq->udcm_peer_rc_qpn) {
+			dctx = domain->cm_ctx;
+
+			ctx->peer_name = connreq->udcm_peer_name;
+			ctx->peer_rc_qpn = connreq->udcm_peer_rc_qpn;
+			ctx->peer_conn_id = connreq->udcm_conn_id;
+			ctx->conn_id = (uint32_t)ofi_atomic_inc32(
+						&dctx->next_conn_id);
+			vrb_udcm_trace_state_change(ctx, VRB_UDCM_REQ_RCVD,
+						    "ep_init() from FI_CONNREQ");
+			ctx->state = VRB_UDCM_REQ_RCVD;
+			ep->state = VRB_REQ_RCVD;
+			if (connreq->udcm_peer_addr_len) {
+				memcpy(&ctx->peer_addr,
+				       &connreq->udcm_peer_addr,
+				       connreq->udcm_peer_addr_len);
+				ctx->peer_addr_len =
+					connreq->udcm_peer_addr_len;
+			}
+
+			ofi_spin_lock(&dctx->lock);
+			dlist_insert_tail(&ctx->list_entry, &dctx->ep_list);
+			ofi_spin_unlock(&dctx->lock);
+		}
+	}
+	return 0;
+}
+
+static void vrb_udcm_ep_preclose(struct vrb_ep *ep)
+{
+	struct vrb_domain *domain = vrb_ep2_domain(ep);
+	struct vrb_udcm_ep_ctx *ctx = ep->cm_ctx;
+	struct vrb_udcm_domain_ctx *dctx = domain->cm_ctx;
+	struct ibv_qp_attr attr = {0};
+
+	/* With RDMA-CM, the QP already entered ERROR from the
+	* disconnect event and rdma_destroy_ep manages the QP
+	* lifecycle, so ep_preclose is a no-op.
+	* With UDCM the QP may still be in RTS when fi_close is
+	* called, so ep_preclose destroys it to clean the CQ. */
+
+	if (ctx && dctx) {
+		ofi_spin_lock(&dctx->lock);
+		if (!dlist_empty(&ctx->list_entry)) {
+			dlist_remove(&ctx->list_entry);
+			dlist_init(&ctx->list_entry);
+		}
+		ofi_spin_unlock(&dctx->lock);
+	}
+
+	if (ep->ibv_qp) {
+		attr.qp_state = IBV_QPS_ERR;
+		(void) ibv_modify_qp(ep->ibv_qp, &attr, IBV_QP_STATE);
+
+		ibv_destroy_qp(ep->ibv_qp);
+		ep->ibv_qp = NULL;
+	}
+}
+
+static int vrb_udcm_ep_close(struct vrb_ep *ep)
+{
+	struct vrb_domain *domain = vrb_ep2_domain(ep);
+	struct vrb_udcm_ep_ctx *ctx = ep->cm_ctx;
+	struct vrb_udcm_domain_ctx *dctx = domain->cm_ctx;
+
+	if (ctx) {
+		if (dctx && !dlist_empty(&ctx->list_entry)) {
+			ofi_spin_lock(&dctx->lock);
+			dlist_remove(&ctx->list_entry);
+			ofi_spin_unlock(&dctx->lock);
+		}
+		free(ctx);
+		ep->cm_ctx = NULL;
+	}
+	vrb_udcm_domain_put(domain);
+	return 0;
+}
+
+static int vrb_udcm_ep_bind(struct vrb_ep *ep, struct vrb_eq *eq)
+{
+	struct vrb_domain *domain = vrb_ep2_domain(ep);
+	struct vrb_udcm_eq_ctx *eq_ctx;
+	struct vrb_udcm_domain_ctx *dctx;
+	struct vrb_udcm_pep_ctx *pctx;
+	struct vrb_pep *pep;
+	struct ibv_device *dev;
+	const char *dev_name;
+	int ret;
+
+	if (!eq->cm_ctx) {
+		ret = vrb_udcm_eq_open(eq);
+		if (ret)
+			return ret;
+	}
+	eq_ctx = eq->cm_ctx;
+	if (!eq_ctx->domain)
+		eq_ctx->domain = domain;
+
+	dctx = domain->cm_ctx;
+	if (!dctx)
+		return 0;
+
+	if (dctx->ib)
+		return 0;
+
+	dlist_foreach_container(&eq->pep_list, struct vrb_pep,
+				pep, eq_entry) {
+		pctx = pep->cm_ctx;
+		if (pctx && pctx->ib) {
+			vrb_udcm_ib_ctx_ref(pctx->ib);
+			dctx->ib = pctx->ib;
+			return 0;
+		}
+	}
+
+	dev_name = ibv_get_device_name(domain->verbs->device);
+	dev = vrb_udcm_find_ib_device(dev_name);
+	if (!dev) {
+		VRB_WARN(FI_LOG_EP_CTRL,
+			 "udcm: IB device '%s' not found\n", dev_name);
+		return -FI_ENODATA;
+	}
+
+	dctx->ib = vrb_udcm_ib_ctx_create(dev);
+	if (!dctx->ib)
+		return -FI_ENOMEM;
+
+	ret = ofi_epoll_add(eq->epollfd, dctx->ib->comp_channel->fd,
+			    OFI_EPOLL_IN, NULL);
+	if (ret) {
+		vrb_udcm_ib_ctx_put(dctx->ib);
+		dctx->ib = NULL;
+		return -errno;
+	}
+	dctx->ib->eq = eq;
+
+	return 0;
+}
+
+static int vrb_udcm_ep_enable(struct vrb_ep *ep, struct ibv_qp_init_attr *attr)
+{
+	struct vrb_domain *domain = vrb_ep2_domain(ep);
+	struct vrb_udcm_domain_ctx *dctx = domain->cm_ctx;
+	struct vrb_udcm_ep_ctx *ep_ctx = ep->cm_ctx;
+	int ret;
+
+	if (ep->ibv_qp)
+		return 0;
+
+	ep->ibv_qp = ibv_create_qp(domain->pd, attr);
+	if (!ep->ibv_qp)
+		return -errno;
+
+	ret = vrb_udcm_rc_qp_to_init(ep->ibv_qp, dctx->ib->port_num,
+				     dctx->ib->pkey_index);
+	if (ret)
+		goto err;
+
+	if (ep->state == VRB_REQ_RCVD) {
+		ret = vrb_udcm_rc_qp_to_rtr(ep->ibv_qp, dctx->ib->port_num,
+					     &ep_ctx->peer_name,
+					     ep_ctx->peer_rc_qpn);
+		if (ret)
+			goto err;
+	}
+	return 0;
+err:
+	ibv_destroy_qp(ep->ibv_qp);
+	ep->ibv_qp = NULL;
+	return ret;
+}
+
+static int vrb_udcm_ep_setname(struct vrb_ep *ep, void *addr, size_t addrlen)
+{
+	void *dup;
+
+	if (!addr || !addrlen)
+		return -FI_EINVAL;
+
+	dup = mem_dup(addr, addrlen);
+	if (!dup)
+		return -FI_ENOMEM;
+
+	free(ep->info_attr.src_addr);
+	ep->info_attr.src_addr = dup;
+	ep->info_attr.src_addrlen = addrlen;
+	return 0;
+}
+
+static int vrb_udcm_ep_getname(struct vrb_ep *ep, void *addr, size_t *addrlen)
+{
+	size_t src_len;
+
+	if (!ep->info_attr.src_addr)
+		return -FI_EOPBADSTATE;
+
+	src_len = ep->info_attr.src_addrlen;
+	if (*addrlen == 0) {
+		*addrlen = src_len;
+		return -FI_ETOOSMALL;
+	}
+	memcpy(addr, ep->info_attr.src_addr, MIN(*addrlen, src_len));
+	*addrlen = src_len;
+	return 0;
+}
+
+static int vrb_udcm_setname(struct vrb_pep *pep, void *addr, size_t addrlen)
+{
+	struct vrb_udcm_pep_ctx *ctx = pep->cm_ctx;
+	void *dup;
+
+	if (!addrlen || !addr)
+		return -FI_EINVAL;
+
+	if (pep->info->addr_format == FI_ADDR_IB_UD) {
+		if (addrlen < sizeof(struct ofi_addr_ib_ud))
+			return -FI_EINVAL;
+		ctx->service = (int)((const struct ofi_addr_ib_ud *)addr)->service;
+	} else if (ctx->service) {
+		ofi_addr_set_port(addr, ctx->service);
+	}
+
+	dup = mem_dup(addr, addrlen);
+	if (!dup)
+		return -FI_ENOMEM;
+
+	free(pep->info->src_addr);
+	pep->info->src_addr = dup;
+	pep->info->src_addrlen = addrlen;
+	return 0;
+}
+
+static int vrb_udcm_getname(struct vrb_pep *pep, void *addr, size_t *addrlen)
+{
+	size_t src_len;
+
+	if (!pep->info || !pep->info->src_addr)
+		return -FI_EOPBADSTATE;
+
+	src_len = pep->info->src_addrlen;
+	if (*addrlen == 0) {
+		*addrlen = src_len;
+		return -FI_ETOOSMALL;
+	}
+	memcpy(addr, pep->info->src_addr, MIN(*addrlen, src_len));
+	*addrlen = src_len;
+	return 0;
+}
+
+static int vrb_udcm_getpeer(struct vrb_ep *ep, void *addr, size_t *addrlen)
+{
+	struct vrb_udcm_ep_ctx *ep_ctx = ep->cm_ctx;
+	size_t src_len = sizeof(struct ofi_addr_ib_ud);
+
+	if (!ep_ctx)
+		return -FI_EOPBADSTATE;
+
+	if (*addrlen == 0) {
+		*addrlen = src_len;
+		return -FI_ETOOSMALL;
+	}
+	memcpy(addr, &ep_ctx->peer_name, MIN(*addrlen, src_len));
+	*addrlen = src_len;
+	return 0;
+}
+
+struct vrb_cm_ops vrb_udcm_ops = {
+	.connect	= vrb_udcm_connect,
+	.accept		= vrb_udcm_accept,
+	.shutdown	= vrb_udcm_shutdown,
+	.listen		= vrb_udcm_listen,
+	.reject		= vrb_udcm_reject,
+	.progress	= vrb_udcm_progress,
+	.ep_init	= vrb_udcm_ep_init,
+	.ep_close	= vrb_udcm_ep_close,
+	.ep_preclose	= vrb_udcm_ep_preclose,
+	.ep_bind	= vrb_udcm_ep_bind,
+	.ep_enable	= vrb_udcm_ep_enable,
+	.ep_setname	= vrb_udcm_ep_setname,
+	.ep_getname	= vrb_udcm_ep_getname,
+	.pep_init	= vrb_udcm_pep_init,
+	.pep_close	= vrb_udcm_pep_close,
+	.pep_bind	= vrb_udcm_pep_bind,
+	.domain_init	= vrb_udcm_domain_init,
+	.domain_close	= vrb_udcm_domain_close,
+	.eq_open	= vrb_udcm_eq_open,
+	.eq_close	= vrb_udcm_eq_close,
+	.setname	= vrb_udcm_setname,
+	.getname	= vrb_udcm_getname,
+	.getpeer	= vrb_udcm_getpeer,
+	.getinfo_addr	= vrb_udcm_getinfo_addr,
+	.cm_backend	= VRB_CM_UDCM,
+};

--- a/prov/verbs/src/verbs_cm_xrc.c
+++ b/prov/verbs/src/verbs_cm_xrc.c
@@ -136,18 +136,18 @@ static void vrb_log_ep_conn(struct vrb_xrc_ep *ep, char *desc)
 	VRB_INFO(FI_LOG_EP_CTRL, "EP %p, %s\n", (void *) ep, desc);
 	VRB_INFO(FI_LOG_EP_CTRL,
 		  "EP %p, CM ID %p, TGT CM ID %p, SRQN %d Peer SRQN %d\n",
-		  (void*) ep, (void *) ep->base_ep.id, (void *) ep->tgt_id,
+		  (void*) ep, (void *) vrb_rdmacm_ep_id(&ep->base_ep), (void *) ep->tgt_id,
 		  ep->srqn, ep->peer_srqn);
 
 
-	if (ep->base_ep.id) {
-		addr = rdma_get_local_addr(ep->base_ep.id);
+	if (vrb_rdmacm_ep_id(&ep->base_ep)) {
+		addr = rdma_get_local_addr(vrb_rdmacm_ep_id(&ep->base_ep));
 		len = sizeof(buf);
 		ofi_straddr(buf, &len, ep->base_ep.info_attr.addr_format, addr);
 		VRB_INFO(FI_LOG_EP_CTRL, "EP %p src_addr: %s\n",
 			   (void *) ep, buf);
 
-		addr = rdma_get_peer_addr(ep->base_ep.id);
+		addr = rdma_get_peer_addr(vrb_rdmacm_ep_id(&ep->base_ep));
 		len = sizeof(buf);
 		ofi_straddr(buf, &len, ep->base_ep.info_attr.addr_format, addr);
 		VRB_INFO(FI_LOG_EP_CTRL, "EP %p dst_addr: %s\n",
@@ -185,9 +185,10 @@ void vrb_free_xrc_conn_setup(struct vrb_xrc_ep *ep, int disconnect)
 			rdma_disconnect(ep->tgt_id);
 		}
 
-		if (ep->base_ep.id->ps == RDMA_PS_UDP) {
-			rdma_destroy_id(ep->base_ep.id);
-			ep->base_ep.id = NULL;
+		if (vrb_rdmacm_ep_id(&ep->base_ep) &&
+		    vrb_rdmacm_ep_id(&ep->base_ep)->ps == RDMA_PS_UDP) {
+			rdma_destroy_id(vrb_rdmacm_ep_id(&ep->base_ep));
+			vrb_rdmacm_ep_set_id(&ep->base_ep, NULL);
 		}
 	}
 
@@ -208,7 +209,7 @@ int vrb_connect_xrc(struct vrb_xrc_ep *ep, struct sockaddr *addr,
 	int ret;
 
 	assert(ofi_mutex_held(&ep->base_ep.eq->event_lock));
-	assert(!ep->base_ep.id && !ep->base_ep.ibv_qp && !ep->ini_conn);
+	assert(!vrb_rdmacm_ep_id(&ep->base_ep) && !ep->base_ep.ibv_qp && !ep->ini_conn);
 
 	domain->xrc.lock_acquire(&domain->xrc.ini_lock);
 	ret = vrb_get_shared_ini_conn(ep, &ep->ini_conn);
@@ -236,7 +237,7 @@ void vrb_ep_ini_conn_done(struct vrb_xrc_ep *ep, uint32_t tgt_qpn)
 	struct vrb_domain *domain = vrb_ep2_domain(&ep->base_ep);
 
 	assert(ofi_mutex_held(&ep->base_ep.eq->event_lock));
-	assert(ep->base_ep.id && ep->ini_conn);
+	assert(vrb_rdmacm_ep_id(&ep->base_ep) && ep->ini_conn);
 
 	domain->xrc.lock_acquire(&domain->xrc.ini_lock);
 	assert(ep->ini_conn->state == VRB_INI_QP_CONNECTING ||
@@ -245,11 +246,11 @@ void vrb_ep_ini_conn_done(struct vrb_xrc_ep *ep, uint32_t tgt_qpn)
 	/* If this was a physical INI/TGT QP connection, remove the QP
 	 * from control of the RDMA CM. We don't want the shared INI QP
 	 * to be destroyed if this endpoint closes. */
-	if (ep->base_ep.id == ep->ini_conn->phys_conn_id) {
+	if (vrb_rdmacm_ep_id(&ep->base_ep) == ep->ini_conn->phys_conn_id) {
 		ep->ini_conn->phys_conn_id = NULL;
 		ep->ini_conn->state = VRB_INI_QP_CONNECTED;
 		ep->ini_conn->tgt_qpn = tgt_qpn;
-		ep->base_ep.id->qp = NULL;
+		vrb_rdmacm_ep_id(&ep->base_ep)->qp = NULL;
 		VRB_DBG(FI_LOG_EP_CTRL,
 			  "Set INI Conn QP %d remote TGT QP %d\n",
 			  ep->ini_conn->ini_qp->qp_num,
@@ -264,7 +265,7 @@ void vrb_ep_ini_conn_done(struct vrb_xrc_ep *ep, uint32_t tgt_qpn)
 void vrb_ep_ini_conn_rejected(struct vrb_xrc_ep *ep)
 {
 	assert(ofi_mutex_held(&ep->base_ep.eq->event_lock));
-	assert(ep->base_ep.id && ep->ini_conn);
+	assert(vrb_rdmacm_ep_id(&ep->base_ep) && ep->ini_conn);
 
 	vrb_log_ep_conn(ep, "INI Connection Rejected");
 	vrb_put_shared_ini_conn(ep);

--- a/prov/verbs/src/verbs_dgram_av.c
+++ b/prov/verbs/src/verbs_dgram_av.c
@@ -35,7 +35,7 @@
 static inline int vrb_dgram_av_is_addr_valid(struct vrb_dgram_av *av,
 						const void *addr)
 {
-	const struct ofi_ib_ud_ep_name *check_name = addr;
+	const struct ofi_addr_ib_ud *check_name = addr;
 	return (check_name->lid > 0);
 }
 
@@ -58,19 +58,20 @@ vrb_dgram_av_insert_addr(struct vrb_dgram_av *av, const void *addr,
 	struct vrb_dgram_av_entry *av_entry;
 	struct vrb_domain *domain =
 		container_of(av->util_av.domain, struct vrb_domain, util_domain);
+	struct ofi_addr_ib_ud *ud = (struct ofi_addr_ib_ud *)addr;
 
 	struct ibv_ah_attr ah_attr = {
 		.is_global = 0,
-		.dlid = ((struct ofi_ib_ud_ep_name *)addr)->lid,
-		.sl = ((struct ofi_ib_ud_ep_name *)addr)->sl,
+		.dlid = ud->lid,
+		.sl = ud->sl,
 		.src_path_bits = 0,
 		.port_num = 1,
 	};
 
-	if (((struct ofi_ib_ud_ep_name *)addr)->gid.global.interface_id) {
+	if (ud->gid.global.interface_id) {
 		ah_attr.is_global = 1;
 		ah_attr.grh.hop_limit = 64;
-		ah_attr.grh.dgid = ((struct ofi_ib_ud_ep_name *)addr)->gid;
+		ah_attr.grh.dgid = *(union ibv_gid *)&ud->gid;
 		ah_attr.grh.sgid_index = vrb_gl_data.gid_idx;
 	} else if (OFI_UNLIKELY(!vrb_dgram_av_is_addr_valid(av, addr))) {
 		ret = -FI_EADDRNOTAVAIL;
@@ -92,7 +93,7 @@ vrb_dgram_av_insert_addr(struct vrb_dgram_av *av, const void *addr,
 			   "Unable to create Address Handle, errno - %d\n", errno);
 		goto fn2;
 	}
-	av_entry->addr = *(struct ofi_ib_ud_ep_name *)addr;
+	av_entry->addr = *(struct ofi_addr_ib_ud *)addr;
 	dlist_insert_tail(&av_entry->list_entry, &av->av_entry_list);
 
 	if (fi_addr)
@@ -122,7 +123,7 @@ static int vrb_dgram_av_insert(struct fid_av *av_fid, const void *addr,
 	VRB_DBG(FI_LOG_AV, "Inserting %"PRIu64" addresses\n", count);
 	for (i = 0; i < count; i++) {
 		ret = vrb_dgram_av_insert_addr(
-				av, (struct ofi_ib_ud_ep_name *)addr + i,
+				av, (struct ofi_addr_ib_ud *)addr + i,
 				fi_addr ? &fi_addr[i] : NULL, context);
 		if (!ret)
 			success_cnt++;

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -224,6 +224,9 @@ static int vrb_domain_close(fid_t fid)
 		domain->pd = NULL;
 	}
 
+	if (domain->cm_ops)
+		domain->cm_ops->domain_close(domain);
+
 	ret = ofi_domain_close(&domain->util_domain);
 	if (ret)
 		return ret;
@@ -423,6 +426,11 @@ vrb_domain(struct fid_fabric *fabric, struct fi_info *info,
 				goto err4;
 		}
 		_domain->util_domain.domain_fid.ops = &vrb_msg_domain_ops;
+		_domain->cm_ops = &vrb_rdmacm_ops;
+		ret = _domain->cm_ops->domain_init(_domain);
+		if (ret)
+			goto err4;
+
 		break;
 	default:
 		VRB_INFO(FI_LOG_DOMAIN, "Ivalid EP type is provided, "

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -426,7 +426,8 @@ vrb_domain(struct fid_fabric *fabric, struct fi_info *info,
 				goto err4;
 		}
 		_domain->util_domain.domain_fid.ops = &vrb_msg_domain_ops;
-		_domain->cm_ops = &vrb_rdmacm_ops;
+		_domain->cm_ops = (vrb_gl_data.msg.prefer_cm == VRB_CM_UDCM) ?
+			&vrb_udcm_ops : &vrb_rdmacm_ops;
 		ret = _domain->cm_ops->domain_init(_domain);
 		if (ret)
 			goto err4;

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -405,7 +405,7 @@ vrb_domain(struct fid_fabric *fabric, struct fi_info *info,
 			 */
 			fab->name_server.port =
 					vrb_gl_data.dgram.name_server_port;
-			fab->name_server.name_len = sizeof(struct ofi_ib_ud_ep_name);
+			fab->name_server.name_len = sizeof(struct ofi_addr_ib_ud);
 			fab->name_server.service_len = sizeof(int);
 			fab->name_server.service_cmp = vrb_dgram_ns_service_cmp;
 			fab->name_server.is_service_wildcard =

--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -42,10 +42,10 @@ struct vrb_ini_conn_key {
 	struct vrb_cq	*tx_cq;
 };
 
-static int vrb_process_ini_conn(struct vrb_xrc_ep *ep,int reciprocal,
+int vrb_process_ini_conn(struct vrb_xrc_ep *ep,int reciprocal,
 				   void *param, size_t paramlen);
 
-static int vrb_create_ini_qp(struct vrb_xrc_ep *ep)
+int vrb_create_ini_qp(struct vrb_xrc_ep *ep)
 {
 #if VERBS_HAVE_XRC
 	struct ibv_qp_init_attr_ex attr_ex;
@@ -60,7 +60,7 @@ static int vrb_create_ini_qp(struct vrb_xrc_ep *ep)
 	attr_ex.qp_context = domain;
 	attr_ex.srq = NULL;
 
-	ret = rdma_create_qp_ex(ep->base_ep.id, &attr_ex);
+	ret = rdma_create_qp_ex(vrb_rdmacm_ep_id(&ep->base_ep), &attr_ex);
 	if (ret) {
 		ret = -errno;
 		VRB_WARN(FI_LOG_EP_CTRL,
@@ -153,12 +153,13 @@ void _vrb_put_shared_ini_conn(struct vrb_xrc_ep *ep)
 	ini_conn = ep->ini_conn;
 	ep->ini_conn = NULL;
 	ep->base_ep.ibv_qp = NULL;
-	if (ep->base_ep.id)
-		ep->base_ep.id->qp = NULL;
+	if (vrb_rdmacm_ep_id(&ep->base_ep))
+		vrb_rdmacm_ep_id(&ep->base_ep)->qp = NULL;
 
 	/* If XRC physical QP connection was not completed, make sure
 	 * any pending connection to that destination will get scheduled. */
-	if (ep->base_ep.id && ep->base_ep.id == ini_conn->phys_conn_id) {
+	if (vrb_rdmacm_ep_id(&ep->base_ep) &&
+	    vrb_rdmacm_ep_id(&ep->base_ep) == ini_conn->phys_conn_id) {
 		if (ini_conn->state == VRB_INI_QP_CONNECTING)
 			ini_conn->state = VRB_INI_QP_UNCONNECTED;
 
@@ -205,7 +206,7 @@ void vrb_add_pending_ini_conn(struct vrb_xrc_ep *ep, int reciprocal,
 }
 
 /* Caller must hold domain:eq:lock */
-static void vrb_create_shutdown_event(struct vrb_xrc_ep *ep)
+void vrb_create_shutdown_event(struct vrb_xrc_ep *ep)
 {
 	struct fi_eq_cm_entry entry = {
 		.fid = &ep->base_ep.util_ep.ep_fid.fid,
@@ -215,95 +216,6 @@ static void vrb_create_shutdown_event(struct vrb_xrc_ep *ep)
 	eq_entry = vrb_eq_alloc_entry(FI_SHUTDOWN, &entry, sizeof(entry));
 	if (eq_entry)
 		dlistfd_insert_tail(&eq_entry->item, &ep->base_ep.eq->list_head);
-}
-
-/* Caller must hold domain:xrc.ini_lock */
-void vrb_sched_ini_conn(struct vrb_ini_shared_conn *ini_conn)
-{
-	struct vrb_xrc_ep *ep;
-	enum vrb_ini_qp_state last_state;
-	int ret;
-
-	/* Continue to schedule shared connections if the physical connection
-	 * has completed and there are connection requests pending. We could
-	 * implement a throttle here if it is determined that it is better to
-	 * limit the number of outstanding connections. */
-	while (1) {
-		if (dlist_empty(&ini_conn->pending_list) ||
-				ini_conn->state == VRB_INI_QP_CONNECTING)
-			return;
-
-		dlist_pop_front(&ini_conn->pending_list,
-				struct vrb_xrc_ep, ep, ini_conn_entry);
-
-		dlist_insert_tail(&ep->ini_conn_entry,
-				  &ep->ini_conn->active_list);
-		last_state = ep->ini_conn->state;
-
-		ret = vrb_create_ep(&ep->base_ep,
-				       last_state == VRB_INI_QP_UNCONNECTED ?
-				       RDMA_PS_TCP : RDMA_PS_UDP,
-				       &ep->base_ep.id);
-		if (ret) {
-			VRB_WARN(FI_LOG_EP_CTRL,
-				   "Failed to create active CM ID %d\n",
-				   ret);
-			goto err;
-		}
-
-		if (last_state == VRB_INI_QP_UNCONNECTED) {
-			assert(!ep->ini_conn->phys_conn_id && ep->base_ep.id);
-
-			if (ep->ini_conn->ini_qp &&
-			    ibv_destroy_qp(ep->ini_conn->ini_qp)) {
-				VRB_WARN(FI_LOG_EP_CTRL, "Failed to destroy "
-					   "physical INI QP %d\n", errno);
-			}
-			ret = vrb_create_ini_qp(ep);
-			if (ret) {
-				VRB_WARN(FI_LOG_EP_CTRL, "Failed to create "
-					   "physical INI QP %d\n", ret);
-				goto err;
-			}
-			ep->ini_conn->ini_qp = ep->base_ep.id->qp;
-			ep->ini_conn->state = VRB_INI_QP_CONNECTING;
-			ep->ini_conn->phys_conn_id = ep->base_ep.id;
-		} else {
-			assert(!ep->base_ep.id->qp);
-			VRB_DBG(FI_LOG_EP_CTRL, "Sharing XRC INI QPN %d\n",
-				  ep->ini_conn->ini_qp->qp_num);
-		}
-
-		assert(ep->ini_conn->ini_qp);
-		ep->base_ep.id->context = &ep->base_ep.util_ep.ep_fid.fid;
-		ret = rdma_migrate_id(ep->base_ep.id,
-				      ep->base_ep.eq->channel);
-		if (ret) {
-			VRB_WARN(FI_LOG_EP_CTRL,
-				   "Failed to migrate active CM ID %d\n", ret);
-			goto err;
-		}
-
-		ofi_straddr_dbg(&vrb_prov, FI_LOG_EP_CTRL, "XRC connect src_addr",
-				rdma_get_local_addr(ep->base_ep.id));
-		ofi_straddr_dbg(&vrb_prov, FI_LOG_EP_CTRL, "XRC connect dest_addr",
-				rdma_get_peer_addr(ep->base_ep.id));
-
-		ep->base_ep.ibv_qp = ep->ini_conn->ini_qp;
-		ret = vrb_process_ini_conn(ep, ep->conn_setup->pending_recip,
-					      ep->conn_setup->pending_param,
-					      ep->conn_setup->pending_paramlen);
-err:
-		if (ret) {
-			ep->ini_conn->state = last_state;
-			_vrb_put_shared_ini_conn(ep);
-
-			/* We need to let the application know that the
-			 * connect request has failed. */
-			vrb_create_shutdown_event(ep);
-			break;
-		}
-	}
 }
 
 /* Caller must hold domain:xrc:eq:lock */
@@ -330,7 +242,7 @@ int vrb_process_ini_conn(struct vrb_xrc_ep *ep,int reciprocal,
 	ep->base_ep.conn_param.rnr_retry_count = 7;
 	ep->base_ep.conn_param.srq = 1;
 
-	if (!ep->base_ep.id->qp)
+	if (!vrb_rdmacm_ep_id(&ep->base_ep)->qp)
 		ep->base_ep.conn_param.qp_num =
 				ep->ini_conn->ini_qp->qp_num;
 
@@ -338,7 +250,7 @@ int vrb_process_ini_conn(struct vrb_xrc_ep *ep,int reciprocal,
 	       ep->conn_state == VRB_XRC_ORIG_CONNECTED);
 	vrb_next_xrc_conn_state(ep);
 
-	ret = rdma_resolve_route(ep->base_ep.id, VERBS_RESOLVE_TIMEOUT);
+	ret = rdma_resolve_route(vrb_rdmacm_ep_id(&ep->base_ep), VERBS_RESOLVE_TIMEOUT);
 	if (ret) {
 		ret = -errno;
 		VRB_WARN(FI_LOG_EP_CTRL,
@@ -435,9 +347,9 @@ int vrb_ep_destroy_xrc_qp(struct vrb_xrc_ep *ep)
 	assert(ofi_mutex_held(&ep->base_ep.eq->event_lock));
 	vrb_put_shared_ini_conn(ep);
 
-	if (ep->base_ep.id) {
-		rdma_destroy_id(ep->base_ep.id);
-		ep->base_ep.id = NULL;
+	if (vrb_rdmacm_ep_id(&ep->base_ep)) {
+		rdma_destroy_id(vrb_rdmacm_ep_id(&ep->base_ep));
+		vrb_rdmacm_ep_set_id(&ep->base_ep, NULL);
 	}
 	if (ep->tgt_ibv_qp)
 		vrb_put_tgt_qp(ep);

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -586,6 +586,9 @@ static int vrb_close_free_ep(struct vrb_ep *ep)
 	ep->util_ep.ep_fid.msg = NULL;
 	free(ep->cm_priv_data);
 
+	if (ep->cm_ops)
+		ep->cm_ops->ep_close(ep);
+
 	ret = ofi_endpoint_close(&ep->util_ep);
 	if (ret)
 		return ret;
@@ -642,8 +645,6 @@ static int vrb_ep_close(fid_t fid)
 
 		if (vrb_is_xrc_ep(ep))
 			vrb_ep_xrc_close(ep);
-		else
-			rdma_destroy_ep(ep->id);
 
 		if (ep->eq)
 			ofi_mutex_unlock(&ep->eq->event_lock);
@@ -697,7 +698,7 @@ static inline int vrb_ep_xrc_set_tgt_chan(struct vrb_ep *ep)
 	struct vrb_xrc_ep *xrc_ep = container_of(ep, struct vrb_xrc_ep,
 						    base_ep);
 	if (xrc_ep->tgt_id)
-		return rdma_migrate_id(xrc_ep->tgt_id, ep->eq->channel);
+		return vrb_xrc_migrade_rdma_id(xrc_ep);
 
 	return FI_SUCCESS;
 }
@@ -732,7 +733,7 @@ static int vrb_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 		if (vrb_is_xrc_ep(ep))
 			ret = vrb_ep_xrc_set_tgt_chan(ep);
 		else
-			ret = rdma_migrate_id(ep->id, ep->eq->channel);
+			ret = ep->cm_ops->ep_bind(ep, ep->eq);
 		ofi_mutex_unlock(&ep->eq->event_lock);
 		if (ret) {
 			VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "rdma_migrate_id");
@@ -1046,24 +1047,9 @@ static int vrb_ep_enable(struct fid_ep *ep_fid)
 			return -FI_EINVAL;
 		}
 
-		/* Server-side QP creation, after RDMA_CM_EVENT_CONNECT_REQUEST
-		 * is recevied */
-		if (ep->id->verbs && ep->ibv_qp == NULL) {
-			vrb_prof_func_start("rdma_create_qp");
-			ret = rdma_create_qp(ep->id, domain->pd, &attr);
-			if (ret) {
-				VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "rdma_create_qp");
-				return -errno;
-			}
-			vrb_prof_func_end("rdma_create_qp");
-			if (ep->profile)
-				vrb_prof_cntr_inc(ep->profile,
-						 FI_VAR_MSG_QUEUE_CNT);
-
-			/* Allow shared XRC INI QP not controlled by RDMA CM
-			 * to share same post functions as RC QP. */
-			ep->ibv_qp = ep->id->qp;
-		}
+		ret = ep->cm_ops->ep_enable(ep, &attr);
+		if (ret)
+			return ret;
 		break;
 	case FI_EP_DGRAM:
 		assert(domain);
@@ -1214,8 +1200,6 @@ int vrb_open_ep(struct fid_domain *domain, struct fi_info *info,
 {
 	struct vrb_domain *dom;
 	struct vrb_ep *ep;
-	struct vrb_connreq *connreq;
-	struct vrb_pep *pep;
 	struct fi_info *fi;
 	int ret;
 
@@ -1290,82 +1274,10 @@ int vrb_open_ep(struct fid_domain *domain, struct fi_info *info,
 
 	switch (info->ep_attr->type) {
 	case FI_EP_MSG:
-		if (dom->ext_flags & VRB_USE_XRC) {
-			if (dom->util_domain.threading == FI_THREAD_SAFE) {
-				*ep->util_ep.ep_fid.msg = vrb_msg_xrc_ep_msg_ops_ts;
-				ep->util_ep.ep_fid.rma = &vrb_msg_xrc_ep_rma_ops_ts;
-			} else {
-				*ep->util_ep.ep_fid.msg = vrb_msg_xrc_ep_msg_ops;
-				ep->util_ep.ep_fid.rma = &vrb_msg_xrc_ep_rma_ops;
-			}
-			ep->util_ep.ep_fid.cm = &vrb_msg_xrc_ep_cm_ops;
-			ep->util_ep.ep_fid.atomic = &vrb_msg_xrc_ep_atomic_ops;
-		} else {
-			if (dom->util_domain.threading == FI_THREAD_SAFE) {
-				*ep->util_ep.ep_fid.msg = vrb_msg_ep_msg_ops_ts;
-				ep->util_ep.ep_fid.rma = &vrb_msg_ep_rma_ops_ts;
-			} else {
-				*ep->util_ep.ep_fid.msg = vrb_msg_ep_msg_ops;
-				ep->util_ep.ep_fid.rma = &vrb_msg_ep_rma_ops;
-			}
-			ep->util_ep.ep_fid.cm = &vrb_msg_ep_cm_ops;
-			ep->util_ep.ep_fid.atomic = &vrb_msg_ep_atomic_ops;
-		}
-
-		if (!info->handle) {
-			/* Only RC, XRC active RDMA CM ID is created at connect */
-			if (!(dom->ext_flags & VRB_USE_XRC)) {
-				ret = vrb_create_ep(ep,
-					vrb_get_port_space(info->addr_format), &ep->id);
-				if (ret)
-					goto close_ep;
-				ep->id->context = &ep->util_ep.ep_fid.fid;
-			}
-		} else if (info->handle->fclass == FI_CLASS_CONNREQ) {
-			connreq = container_of(info->handle,
-					       struct vrb_connreq, handle);
-			if (dom->ext_flags & VRB_USE_XRC) {
-				assert(connreq->is_xrc);
-
-				if (!connreq->xrc.is_reciprocal) {
-					ret = vrb_process_xrc_connreq(ep, connreq);
-					if (ret)
-						goto close_ep;
-				}
-			} else {
-				/* ep now owns this rdma cm id, prevent trying to access
-				 * it outside of ep operations to avoid possible use-after-
-				 * free bugs in case the ep is closed
-				 */
-				ofi_genlock_lock(&vrb_ep2_progress(ep)->ep_lock);
-				ep->state = VRB_REQ_RCVD;
-				ep->id = connreq->id;
-				connreq->id = NULL;
-				ep->ibv_qp = ep->id->qp;
-				ep->id->context = &ep->util_ep.ep_fid.fid;
-				ofi_genlock_unlock(&vrb_ep2_progress(ep)->ep_lock);
-			}
-		} else if (info->handle->fclass == FI_CLASS_PEP) {
-			pep = container_of(info->handle, struct vrb_pep, pep_fid.fid);
-			ep->id = pep->id;
-			ep->ibv_qp = ep->id->qp;
-			pep->id = NULL;
-			vrb_prof_func_start("rdma_resolve_addr");
-			if (rdma_resolve_addr(ep->id, info->src_addr, info->dest_addr,
-					      VERBS_RESOLVE_TIMEOUT)) {
-				ret = -errno;
-				VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "rdma_resolve_addr");
-				/* rdma_destroy_ep will close the id->qp */
-				ep->ibv_qp = NULL;
-				rdma_destroy_ep(ep->id);
-				goto close_ep;
-			}
-			vrb_prof_func_end("rdma_resolve_addr");
-			ep->id->context = &ep->util_ep.ep_fid.fid;
-		} else {
-			ret = -FI_ENOSYS;
+		ret = dom->cm_ops->ep_init(ep, info);
+		if (ret)
 			goto close_ep;
-		}
+		ep->cm_ops = dom->cm_ops;
 		break;
 	case FI_EP_DGRAM:
 		ep->service = (info->src_addr) ?
@@ -1407,40 +1319,23 @@ close_ep:
 static int vrb_pep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 {
 	struct vrb_pep *pep;
+	struct vrb_eq *eq;
 	int ret;
 
 	pep = container_of(fid, struct vrb_pep, pep_fid.fid);
 	if (bfid->fclass != FI_CLASS_EQ)
 		return -FI_EINVAL;
 
-	pep->eq = container_of(bfid, struct vrb_eq, eq_fid.fid);
-	/*
-	 * This is a restrictive solution that enables an XRC EP to
-	 * inform it's peer the port that should be used in making the
-	 * reciprocal connection request. While it meets RXM requirements
-	 * it limits an EQ to a single passive endpoint. TODO: implement
-	 * a more general solution.
-	 */
-	if (vrb_is_xrc_info(pep->info)) {
-		if (pep->eq->xrc.pep_port) {
-			VRB_WARN(FI_LOG_EP_CTRL,
-				   "XRC limits EQ binding to a single PEP\n");
-			return -FI_EINVAL;
-		}
-		pep->eq->xrc.pep_port = ntohs(rdma_get_src_port(pep->id));
-	}
+	eq = container_of(bfid, struct vrb_eq, eq_fid.fid);
+	pep->eq = eq;
 
-	ret = rdma_migrate_id(pep->id, pep->eq->channel);
+	ret = pep->cm_ops->pep_bind(pep, eq);
 	if (ret) {
-		VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "rdma_migrate_id");
-		return -errno;
+		pep->eq = NULL;
+		return ret;
 	}
 
-	if (vrb_is_xrc_info(pep->info)) {
-		ret = rdma_migrate_id(pep->xrc_ps_udp_id, pep->eq->channel);
-		if (ret)
-			return -errno;
-	}
+	dlist_insert_tail(&pep->eq_entry, &eq->pep_list);
 	return FI_SUCCESS;
 }
 
@@ -1476,10 +1371,11 @@ static int vrb_pep_close(fid_t fid)
 	struct vrb_pep *pep;
 
 	pep = container_of(fid, struct vrb_pep, pep_fid.fid);
-	if (pep->id)
-		rdma_destroy_ep(pep->id);
-	if (pep->xrc_ps_udp_id)
-		rdma_destroy_ep(pep->xrc_ps_udp_id);
+
+	if (pep->eq)
+		dlist_remove(&pep->eq_entry);
+
+	(void) pep->cm_ops->pep_close(pep);
 
 	fi_freeinfo(pep->info);
 	free(pep);
@@ -1525,49 +1421,18 @@ int vrb_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 		_pep->info->dest_addrlen = 0;
 	}
 
-	ret = rdma_create_id(NULL, &_pep->id, &_pep->pep_fid.fid,
-			     vrb_get_port_space(_pep->info->addr_format));
-	if (ret) {
-		VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "rdma_create_id");
+	_pep->cm_ops = &vrb_rdmacm_ops;
+	ret = _pep->cm_ops->pep_init(_pep);
+	if (ret)
 		goto err2;
-	}
-
-	if (info->src_addr) {
-		ret = rdma_bind_addr(_pep->id, (struct sockaddr *) info->src_addr);
-		if (ret) {
-			VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "rdma_bind_addr");
-			ret = -errno;
-			goto err3;
-		}
-		_pep->bound = 1;
-	}
-
-	/* XRC listens on both RDMA_PS_TCP and RDMA_PS_UDP */
-	if (vrb_is_xrc_info(info)) {
-		ret = rdma_create_id(NULL, &_pep->xrc_ps_udp_id,
-				     &_pep->pep_fid.fid, RDMA_PS_UDP);
-		if (ret) {
-			VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "rdma_create_id");
-			goto err3;
-		}
-		/* Currently both listens must be bound to same port number */
-		ofi_addr_set_port(_pep->info->src_addr,
-				  ntohs(rdma_get_src_port(_pep->id)));
-		ret = rdma_bind_addr(_pep->xrc_ps_udp_id,
-				     (struct sockaddr *)_pep->info->src_addr);
-		if (ret) {
-			VRB_WARN_ERRNO(FI_LOG_EP_CTRL, "rdma_bind_addr");
-			goto err4;
-		}
-	}
 
 	_pep->pep_fid.fid.fclass = FI_CLASS_PEP;
 	_pep->pep_fid.fid.context = context;
 	_pep->pep_fid.fid.ops = &vrb_pep_fi_ops;
 	_pep->pep_fid.ops = &vrb_pep_ops;
 	_pep->pep_fid.cm = vrb_pep_ops_cm(_pep);
-
 	_pep->src_addrlen = info->src_addrlen;
+	dlist_init(&_pep->eq_entry);
 
 	*pep = &_pep->pep_fid;
 
@@ -1575,11 +1440,6 @@ int vrb_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 
 	return 0;
 
-err4:
-	/* Only possible for XRC code path */
-	rdma_destroy_id(_pep->xrc_ps_udp_id);
-err3:
-	rdma_destroy_id(_pep->id);
 err2:
 	fi_freeinfo(_pep->info);
 err1:

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -649,6 +649,8 @@ static int vrb_ep_close(fid_t fid)
 		if (ep->eq)
 			ofi_mutex_unlock(&ep->eq->event_lock);
 
+		ep->cm_ops->ep_preclose(ep);
+
 		ofi_genlock_lock(&vrb_ep2_progress(ep)->ep_lock);
 		vrb_cleanup_cq(ep);
 		vrb_flush_sq(ep);
@@ -1410,6 +1412,9 @@ int vrb_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 	if (!_pep)
 		return -FI_ENOMEM;
 
+	_pep->fabric = container_of(fabric, struct vrb_fabric,
+				    util_fabric.fabric_fid);
+
 	if (!(_pep->info = fi_dupinfo(info))) {
 		ret = -FI_ENOMEM;
 		goto err1;
@@ -1421,7 +1426,8 @@ int vrb_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 		_pep->info->dest_addrlen = 0;
 	}
 
-	_pep->cm_ops = &vrb_rdmacm_ops;
+	_pep->cm_ops = (vrb_gl_data.msg.prefer_cm == VRB_CM_UDCM) ?
+		&vrb_udcm_ops : &vrb_rdmacm_ops;
 	ret = _pep->cm_ops->pep_init(_pep);
 	if (ret)
 		goto err2;

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -838,7 +838,7 @@ static int vrb_create_dgram_ep(struct vrb_domain *domain, struct vrb_ep *ep,
 
 	ep->ep_name.lid = port_attr.lid;
 	ep->ep_name.sl = port_attr.sm_sl;
-	ep->ep_name.gid = gid;
+	ep->ep_name.gid = *(union ofi_ib_gid *)&gid;
 	ep->ep_name.qpn = ep->ibv_qp->qp_num;
 	ep->ep_name.pkey = p_key;
 
@@ -1369,7 +1369,7 @@ int vrb_open_ep(struct fid_domain *domain, struct fi_info *info,
 		break;
 	case FI_EP_DGRAM:
 		ep->service = (info->src_addr) ?
-			(((struct ofi_ib_ud_ep_name *)info->src_addr)->service) :
+			(((struct ofi_addr_ib_ud *)info->src_addr)->service) :
 			(((getpid() & 0x7FFF) << 16) + ((uintptr_t)ep & 0xFFFF));
 
 		if (dom->util_domain.threading == FI_THREAD_SAFE) {

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -149,123 +149,9 @@ static int vrb_eq_set_xrc_info(struct rdma_cm_event *event,
 	return FI_SUCCESS;
 }
 
-static int
-vrb_pep_dev_domain_match(struct fi_info *hints, const char *devname)
-{
-	int ret;
-
-	if ((VRB_EP_PROTO(hints)) == FI_PROTO_RDMA_CM_IB_XRC)
-		ret = vrb_cmp_xrc_domain_name(hints->domain_attr->name,
-						 devname);
-	else
-		ret = strcmp(hints->domain_attr->name, devname);
-
-	return ret;
-}
-
-static int
-vrb_eq_cm_getinfo(struct rdma_cm_event *event, struct fi_info *pep_info,
-		     struct fi_info **info)
-{
-	struct fi_info *hints;
-	struct vrb_connreq *connreq;
-	const char *devname = ibv_get_device_name(event->id->verbs->device);
-	int ret = -FI_ENOMEM;
-
-	if (!(hints = fi_dupinfo(pep_info))) {
-		VRB_WARN(FI_LOG_EP_CTRL, "dupinfo failure\n");
-		return -FI_ENOMEM;
-	}
-
-	/* Free src_addr info from pep to avoid addr reuse errors */
-	free(hints->src_addr);
-	hints->src_addr = NULL;
-	hints->src_addrlen = 0;
-
-	if (!strcmp(hints->domain_attr->name, VERBS_ANY_DOMAIN)) {
-		free(hints->domain_attr->name);
-		if (!(hints->domain_attr->name = strdup(devname)))
-			goto err1;
-	} else {
-		if (vrb_pep_dev_domain_match(hints, devname)) {
-			VRB_WARN(FI_LOG_EQ, "passive endpoint domain: %s does"
-				   " not match device: %s where we got a "
-				   "connection request\n",
-				   hints->domain_attr->name, devname);
-			ret = -FI_ENODATA;
-			goto err1;
-		}
-	}
-
-	if (!strcmp(hints->domain_attr->name, VERBS_ANY_FABRIC)) {
-		free(hints->fabric_attr->name);
-		hints->fabric_attr->name = NULL;
-	}
-
-	ofi_mutex_lock(&vrb_info_mutex);
-	ret = vrb_get_matching_info(hints->fabric_attr->api_version, hints,
-				    info, vrb_util_prov.info, 0);
-	ofi_mutex_unlock(&vrb_info_mutex);
-	if (ret)
-		goto err1;
-
-	ofi_alter_info(*info, hints, hints->fabric_attr->api_version);
-	vrb_alter_info(hints, *info);
-	(*info)->fabric_attr->api_version = pep_info->fabric_attr->api_version;
-	(*info)->fabric_attr->prov_name = strdup(pep_info->fabric_attr->prov_name);
-	if (!(*info)->fabric_attr->prov_name)
-		goto err2;
-
-	free((*info)->src_addr);
-	(*info)->src_addrlen = ofi_sizeofaddr(rdma_get_local_addr(event->id));
-	(*info)->src_addr = malloc((*info)->src_addrlen);
-	if (!((*info)->src_addr))
-		goto err2;
-	memcpy((*info)->src_addr, rdma_get_local_addr(event->id), (*info)->src_addrlen);
-
-	assert(!(*info)->dest_addr);
-	(*info)->dest_addrlen = ofi_sizeofaddr(rdma_get_peer_addr(event->id));
-	(*info)->dest_addr = malloc((*info)->dest_addrlen);
-	if (!((*info)->dest_addr))
-		goto err2;
-	memcpy((*info)->dest_addr, rdma_get_peer_addr(event->id), (*info)->dest_addrlen);
-
-	ofi_straddr_dbg(&vrb_prov, FI_LOG_EQ, "src", (*info)->src_addr);
-	ofi_straddr_dbg(&vrb_prov, FI_LOG_EQ, "dst", (*info)->dest_addr);
-
-	connreq = calloc(1, sizeof *connreq);
-	if (!connreq) {
-		VRB_WARN(FI_LOG_EP_CTRL,
-			   "Unable to allocate connreq memory\n");
-		goto err2;
-	}
-
-	connreq->handle.fclass = FI_CLASS_CONNREQ;
-	connreq->id = event->id;
-
-	if (vrb_is_xrc_info(*info)) {
-		connreq->is_xrc = 1;
-		ret = vrb_eq_set_xrc_info(event, &connreq->xrc);
-		if (ret)
-			goto err3;
-	}
-
-	(*info)->handle = &connreq->handle;
-	fi_freeinfo(hints);
-	return 0;
-
-err3:
-	free(connreq);
-err2:
-	fi_freeinfo(*info);
-err1:
-	fi_freeinfo(hints);
-	return ret;
-}
-
-static inline int vrb_eq_copy_event_data(struct fi_eq_cm_entry *entry,
-				size_t max_dest_len, const void *priv_data,
-				size_t priv_datalen)
+int vrb_eq_copy_event_data(struct fi_eq_cm_entry *entry,
+			   size_t max_dest_len, const void *priv_data,
+			   size_t priv_datalen)
 {
 	const struct vrb_cm_data_hdr *cm_hdr = priv_data;
 
@@ -276,19 +162,8 @@ static inline int vrb_eq_copy_event_data(struct fi_eq_cm_entry *entry,
 	return datalen;
 }
 
-static void vrb_eq_skip_rdma_cm_hdr(const void **priv_data,
-						size_t *priv_data_len)
-{
-	size_t rdma_cm_hdr_len = sizeof(struct vrb_rdma_cm_hdr);
-
-	if (*priv_data_len > rdma_cm_hdr_len) {
-		*priv_data = (void*)((char *)*priv_data + rdma_cm_hdr_len);
-		*priv_data_len -= rdma_cm_hdr_len;
-	}
-}
-
-static void vrb_eq_skip_xrc_cm_data(const void **priv_data,
-				       size_t *priv_data_len)
+void vrb_eq_skip_xrc_cm_data(const void **priv_data,
+			     size_t *priv_data_len)
 {
 	const struct vrb_xrc_cm_data *cm_data = *priv_data;
 
@@ -449,11 +324,10 @@ vrb_eq_accept_recip_conn(struct vrb_xrc_ep *ep,
 	return -FI_EAGAIN;
 }
 
-static int
-vrb_eq_xrc_connreq_event(struct vrb_eq *eq, struct fi_eq_cm_entry *entry,
-			    size_t len, uint32_t *event,
-			    struct rdma_cm_event *cma_event, int *acked,
-			    const void **priv_data, size_t *priv_datalen)
+int vrb_eq_xrc_connreq_event(struct vrb_eq *eq, struct fi_eq_cm_entry *entry,
+			     size_t len, uint32_t *event,
+			     struct rdma_cm_event *cma_event, int *acked,
+			     const void **priv_data, size_t *priv_datalen)
 {
 	struct vrb_connreq *connreq = container_of(entry->info->handle,
 						struct vrb_connreq, handle);
@@ -513,7 +387,7 @@ vrb_eq_xrc_connreq_event(struct vrb_eq *eq, struct fi_eq_cm_entry *entry,
 	ep->tgt_id->context = &ep->base_ep.util_ep.ep_fid.fid;
 	ep->base_ep.info_attr.handle = entry->info->handle;
 
-	ret = rdma_migrate_id(ep->tgt_id, ep->base_ep.eq->channel);
+	ret = vrb_xrc_migrade_rdma_id(ep);
 	if (ret) {
 		VRB_WARN(FI_LOG_EP_CTRL, "Could not migrate CM ID\n");
 		goto send_reject;
@@ -578,7 +452,7 @@ vrb_eq_xrc_conn_event(struct vrb_xrc_ep *ep,
 		ret = vrb_eq_set_xrc_info(cma_event, &xrc_info);
 		if (ret) {
 			vrb_prev_xrc_conn_state(ep);
-			rdma_disconnect(ep->base_ep.id);
+			rdma_disconnect(vrb_rdmacm_ep_id(&ep->base_ep));
 			goto err;
 		}
 		ep->peer_srqn = xrc_info.peer_srqn;
@@ -654,8 +528,7 @@ vrb_eq_xrc_recip_conn_event(struct vrb_eq *eq,
 	return sizeof(*entry) + len;
 }
 
-static int
-vrb_eq_xrc_rej_event(struct vrb_eq *eq, struct rdma_cm_event *cma_event)
+int vrb_eq_xrc_rej_event(struct vrb_eq *eq, struct rdma_cm_event *cma_event)
 {
 	struct vrb_xrc_ep *ep;
 	fid_t fid = cma_event->id->context;
@@ -671,7 +544,7 @@ vrb_eq_xrc_rej_event(struct vrb_eq *eq, struct rdma_cm_event *cma_event)
 	}
 
 	state = ep->conn_state;
-	if (ep->base_ep.id != cma_event->id ||
+	if (vrb_rdmacm_ep_id(&ep->base_ep) != cma_event->id ||
 	    (state != VRB_XRC_ORIG_CONNECTING &&
 	     state != VRB_XRC_RECIP_CONNECTING)) {
 		VRB_WARN(FI_LOG_EP_CTRL,
@@ -720,8 +593,8 @@ vrb_eq_xrc_connect_retry(struct vrb_xrc_ep *ep,
 
 	*acked = 1;
 	rdma_ack_cm_event(cma_event);
-	rdma_destroy_id(ep->base_ep.id);
-	ep->base_ep.id = NULL;
+	rdma_destroy_id(vrb_rdmacm_ep_id(&ep->base_ep));
+	vrb_rdmacm_ep_set_id(&ep->base_ep, NULL);
 	vrb_eq_clear_xrc_conn_tag(ep);
 	ep->conn_setup->retry_count++;
 	return vrb_connect_xrc(ep, NULL, ep->conn_setup->pending_recip,
@@ -729,9 +602,8 @@ vrb_eq_xrc_connect_retry(struct vrb_xrc_ep *ep,
 			       ep->conn_setup->pending_paramlen);
 }
 
-static int
-vrb_eq_xrc_cm_err_event(struct vrb_eq *eq,
-                        struct rdma_cm_event *cma_event, int *acked)
+int vrb_eq_xrc_cm_err_event(struct vrb_eq *eq, struct rdma_cm_event *cma_event,
+			    int *acked)
 {
 	struct vrb_xrc_ep *ep;
 	fid_t fid = cma_event->id->context;
@@ -746,14 +618,14 @@ vrb_eq_xrc_cm_err_event(struct vrb_eq *eq,
 
 	/* Connect errors can be reported on active or passive side, all other
 	 * errors considered are reported on the active side only */
-	if ((ep->base_ep.id != cma_event->id) &&
+	if ((vrb_rdmacm_ep_id(&ep->base_ep) != cma_event->id) &&
 	    (cma_event->event == RDMA_CM_EVENT_CONNECT_ERROR &&
 	     ep->tgt_id != cma_event->id)) {
 		VRB_WARN(FI_LOG_EP_CTRL, "CM error not valid for EP\n");
 		return -FI_EAGAIN;
 	}
 
-	if (ep->base_ep.id == cma_event->id) {
+	if (vrb_rdmacm_ep_id(&ep->base_ep) == cma_event->id) {
 		vrb_put_shared_ini_conn(ep);
 
 		/* Active side connect errors are retried */
@@ -777,11 +649,10 @@ vrb_eq_xrc_cm_err_event(struct vrb_eq *eq,
         return FI_SUCCESS;
 }
 
-static ssize_t
-vrb_eq_xrc_connected_event(struct vrb_eq *eq,
-			   struct rdma_cm_event *cma_event, int *acked,
-			   struct fi_eq_cm_entry *entry, size_t len,
-			   uint32_t *event)
+ssize_t vrb_eq_xrc_connected_event(struct vrb_eq *eq,
+				   struct rdma_cm_event *cma_event, int *acked,
+				   struct fi_eq_cm_entry *entry, size_t len,
+				   uint32_t *event)
 {
 	struct vrb_xrc_ep *ep;
 	fid_t fid = cma_event->id->context;
@@ -808,9 +679,8 @@ vrb_eq_xrc_connected_event(struct vrb_eq *eq,
 	return ret;
 }
 
-static void
-vrb_eq_xrc_timewait_event(struct vrb_eq *eq,
-			  struct rdma_cm_event *cma_event, int *acked)
+void vrb_eq_xrc_timewait_event(struct vrb_eq *eq,
+			       struct rdma_cm_event *cma_event, int *acked)
 {
 	fid_t fid = cma_event->id->context;
 	struct vrb_xrc_ep *ep = container_of(fid, struct vrb_xrc_ep,
@@ -825,19 +695,18 @@ vrb_eq_xrc_timewait_event(struct vrb_eq *eq,
 		rdma_ack_cm_event(cma_event);
 		rdma_destroy_id(ep->tgt_id);
 		ep->tgt_id = NULL;
-	} else if (cma_event->id == ep->base_ep.id) {
+	} else if (cma_event->id == vrb_rdmacm_ep_id(&ep->base_ep)) {
 		*acked = 1;
 		rdma_ack_cm_event(cma_event);
-		rdma_destroy_id(ep->base_ep.id);
-		ep->base_ep.id = NULL;
+		rdma_destroy_id(vrb_rdmacm_ep_id(&ep->base_ep));
+		vrb_rdmacm_ep_set_id(&ep->base_ep, NULL);
 	}
-	if (!ep->base_ep.id && !ep->tgt_id)
+	if (!vrb_rdmacm_ep_id(&ep->base_ep) && !ep->tgt_id)
 		vrb_free_xrc_conn_setup(ep, 0);
 }
 
-static inline void
-vrb_eq_xrc_disconnect_event(struct vrb_eq *eq,
-			       struct rdma_cm_event *cma_event, int *acked)
+void vrb_eq_xrc_disconnect_event(struct vrb_eq *eq,
+				 struct rdma_cm_event *cma_event, int *acked)
 {
 	fid_t fid = cma_event->id->context;
 	struct vrb_xrc_ep *ep = container_of(fid, struct vrb_xrc_ep,
@@ -846,327 +715,11 @@ vrb_eq_xrc_disconnect_event(struct vrb_eq *eq,
 	assert(ofi_mutex_held(&eq->event_lock));
 	assert(ep->magic == VERBS_XRC_EP_MAGIC);
 
-	if (ep->conn_setup && cma_event->id == ep->base_ep.id) {
+	if (ep->conn_setup && cma_event->id == vrb_rdmacm_ep_id(&ep->base_ep)) {
 		*acked = 1;
 		rdma_ack_cm_event(cma_event);
-		rdma_disconnect(ep->base_ep.id);
+		rdma_disconnect(vrb_rdmacm_ep_id(&ep->base_ep));
 	}
-}
-
-static int
-vrb_eq_addr_resolved_event(struct vrb_ep *ep)
-{
-	struct vrb_recv_wr *wr;
-	struct slist_entry *entry;
-	struct ibv_qp_init_attr attr = { 0 };
-	int ret;
-	//struct vrb_domain *domain = vrb_ep2_domain(ep);
-
-	assert(ofi_genlock_held(&vrb_ep2_progress(ep)->ep_lock));
-	assert(ep->state == VRB_RESOLVE_ADDR);
-	if (ep->util_ep.type == FI_EP_MSG) {
-		vrb_msg_ep_get_qp_attr(ep, &attr);
-
-		/* Client-side QP creation */
-		vrb_prof_func_start("rdma_create_qp");
-		if (rdma_create_qp(ep->id, vrb_ep2_domain(ep)->pd, &attr)) {
-			ep->state = VRB_DISCONNECTED;
-			ret = -errno;
-			VRB_WARN(FI_LOG_EP_CTRL,
-				 "rdma_create_qp failed: %d\n", -ret);
-			return ret;
-		}
-		vrb_prof_func_end("rdma_create_qp");
-		if (ep->profile)
-			vrb_prof_cntr_inc(ep->profile, FI_VAR_MSG_QUEUE_CNT);
-
-		/* Allow shared XRC INI QP not controlled by RDMA CM
-		 * to share same post functions as RC QP. */
-		ep->ibv_qp = ep->id->qp;
-	}
-
-	assert(ep->ibv_qp);
-	while (!slist_empty(&ep->prepost_wr_list)) {
-		entry = ep->prepost_wr_list.head;
-		wr = container_of(entry, struct vrb_recv_wr, entry);
-
-		ret = vrb_post_recv_internal(ep, &wr->wr);
-		if (ret) {
-			VRB_WARN(FI_LOG_EP_CTRL,
-			         "Failed to post receive buffers: %d\n", -ret);
-
-			return ret;
-		}
-		vrb_free_recv_wr(vrb_ep2_progress(ep), wr);
-		slist_remove_head(&ep->prepost_wr_list);
-	}
-
-	ep->state = VRB_RESOLVE_ROUTE;
-	vrb_prof_func_start("rdma_resolve_route");
-	if (rdma_resolve_route(ep->id, VERBS_RESOLVE_TIMEOUT)) {
-		ep->state = VRB_DISCONNECTED;
-		ret = -errno;
-		VRB_WARN(FI_LOG_EP_CTRL,
-			"rdma_resolve_route failed: %d\n",
-			-ret);
-		return ret;
-	}
-	vrb_prof_func_end("rdma_resolve_route");
-
-	return -FI_EAGAIN;
-}
-
-static ssize_t
-vrb_eq_cm_process_event(struct vrb_eq *eq,
-	struct rdma_cm_event *cma_event, uint32_t *event,
-	struct fi_eq_cm_entry *entry, size_t len)
-{
-	const struct vrb_cm_data_hdr *cm_hdr;
-	size_t datalen = 0;
-	size_t priv_datalen = cma_event->param.conn.private_data_len;
-	const void *priv_data = cma_event->param.conn.private_data;
-	int ret, acked = 0;;
-	fid_t fid = cma_event->id->context;
-	struct vrb_pep *pep =
-		container_of(fid, struct vrb_pep, pep_fid);
-	struct vrb_ep *ep;
-	struct vrb_xrc_ep *xrc_ep;
-
-	assert(ofi_mutex_held(&eq->event_lock));
-	switch (cma_event->event) {
-	case RDMA_CM_EVENT_ADDR_RESOLVED:
-		ep = container_of(fid, struct vrb_ep, util_ep.ep_fid);
-		if (ep->profile)
-			vrb_prof_set_st_time(ep->profile, (ofi_gettime_ns()),
-					VRB_RESOLVE_ADDR);
-
-		ofi_genlock_lock(&vrb_ep2_progress(ep)->ep_lock);
-		ret = vrb_eq_addr_resolved_event(ep);
-		ofi_genlock_unlock(&vrb_ep2_progress(ep)->ep_lock);
-		if (ret != -FI_EAGAIN) {
-			eq->err.err = -ret;
-			eq->err.prov_errno = ret;
-			goto err;
-		}
-		goto ack;
-
-	case RDMA_CM_EVENT_ROUTE_RESOLVED:
-		ep = container_of(fid, struct vrb_ep, util_ep.ep_fid);
-		if (ep->profile)
-			vrb_prof_set_st_time(ep->profile, (ofi_gettime_ns()),
-					VRB_RESOLVE_ROUTE);
-		ofi_genlock_lock(&vrb_ep2_progress(ep)->ep_lock);
-		assert(ep->state == VRB_RESOLVE_ROUTE);
-		ep->state = VRB_CONNECTING;
-
-		if (cma_event->id->route.addr.src_addr.sa_family != AF_IB) {
-			vrb_eq_skip_rdma_cm_hdr((const void **)&ep->conn_param.private_data,
-						(size_t *)&ep->conn_param.private_data_len);
-		} else {
-			vrb_msg_ep_prepare_rdma_cm_hdr(ep->cm_priv_data, ep->id);
-		}
-		vrb_prof_func_start("rdma_connect");
-		ret = rdma_connect(ep->id, &ep->conn_param);
-		vrb_prof_func_end("rdma_connect");
-		if (!ret && ep->profile)
-			vrb_prof_cntr_inc(ep->profile, FI_VAR_CONN_REQUEST);
-
-		if (ret) {
-			ep->state = VRB_DISCONNECTED;
-			ret = -errno;
-			FI_WARN(&vrb_prov, FI_LOG_EP_CTRL,
-				"rdma_connect failed: %s (%d)\n",
-				strerror(-ret), -ret);
-			if (vrb_is_xrc_ep(ep)) {
-				xrc_ep = container_of(fid, struct vrb_xrc_ep,
-						      base_ep.util_ep.ep_fid);
-				vrb_put_shared_ini_conn(xrc_ep);
-			}
-		} else {
-			ret = -FI_EAGAIN;
-		}
-		ofi_genlock_unlock(&vrb_ep2_progress(ep)->ep_lock);
-		if (ret != -FI_EAGAIN) {
-			eq->err.err = -ret;
-			eq->err.prov_errno = ret;
-			goto err;
-		}
-		goto ack;
-	case RDMA_CM_EVENT_CONNECT_REQUEST:
-		*event = FI_CONNREQ;
-		ret = vrb_eq_cm_getinfo(cma_event, pep->info, &entry->info);
-		if (ret) {
-			VRB_WARN(FI_LOG_EP_CTRL,
-				   "CM getinfo error %d\n", ret);
-			rdma_destroy_id(cma_event->id);
-			eq->err.err = -ret;
-			eq->err.prov_errno = ret;
-			goto err;
-		}
-
-		if (vrb_is_xrc_info(entry->info)) {
-			ret = vrb_eq_xrc_connreq_event(eq, entry, len, event,
-							  cma_event, &acked,
-							  &priv_data, &priv_datalen);
-			if (ret == -FI_EAGAIN) {
-				fi_freeinfo(entry->info);
-				entry->info = NULL;
-				goto ack;
-			}
-			if (*event == FI_CONNECTED)
-				goto ack;
-		} else if (cma_event->id->route.addr.src_addr.sa_family == AF_IB) {
-			vrb_eq_skip_rdma_cm_hdr(&priv_data, &priv_datalen);
-		}
-		break;
-	case RDMA_CM_EVENT_CONNECT_RESPONSE:
-	case RDMA_CM_EVENT_ESTABLISHED:
-		*event = FI_CONNECTED;
-		ep = container_of(fid, struct vrb_ep, util_ep.ep_fid);
-		if (ep->profile) {
-			vrb_prof_set_st_time(ep->profile, (ofi_gettime_ns()),
-					VRB_CONNECTED);
-			vrb_prof_cntr_inc(ep->profile,
-					FI_VAR_CONNECTION_CNT);
-		}
-		if (cma_event->id->qp &&
-		    cma_event->id->qp->context->device->transport_type !=
-		    IBV_TRANSPORT_IWARP) {
-			vrb_set_rnr_timer(cma_event->id->qp);
-		}
-		if (vrb_is_xrc_ep(ep)) {
-			ret = vrb_eq_xrc_connected_event(eq, cma_event,
-							    &acked, entry, len,
-							    event);
-			goto ack;
-		}
-		ofi_genlock_lock(&vrb_ep2_progress(ep)->ep_lock);
-		assert(ep->state == VRB_CONNECTING || ep->state == VRB_ACCEPTING);
-		ep->state = VRB_CONNECTED;
-		ofi_genlock_unlock(&vrb_ep2_progress(ep)->ep_lock);
-		entry->info = NULL;
-		break;
-	case RDMA_CM_EVENT_DISCONNECTED:
-		ep = container_of(fid, struct vrb_ep, util_ep.ep_fid);
-		if (ep->profile)
-			vrb_prof_set_st_time(ep->profile, (ofi_gettime_ns()),
-                                            VRB_DISCONNECTED);
-		ofi_genlock_lock(&vrb_ep2_progress(ep)->ep_lock);
-		if (ep->state == VRB_DISCONNECTED) {
-			/* If we saw a transfer error, we already generated
-			 * a shutdown event.
-			 */
-			ret = -FI_EAGAIN;
-			ofi_genlock_unlock(&vrb_ep2_progress(ep)->ep_lock);
-			goto ack;
-		}
-		ep->state = VRB_DISCONNECTED;
-		ofi_genlock_unlock(&vrb_ep2_progress(ep)->ep_lock);
-		if (vrb_is_xrc_ep(ep)) {
-			vrb_eq_xrc_disconnect_event(eq, cma_event, &acked);
-			ret = -FI_EAGAIN;
-			goto ack;
-		}
-		*event = FI_SHUTDOWN;
-		entry->info = NULL;
-		break;
-	case RDMA_CM_EVENT_TIMEWAIT_EXIT:
-		ep = container_of(fid, struct vrb_ep, util_ep.ep_fid);
-		if (vrb_is_xrc_ep(ep))
-			vrb_eq_xrc_timewait_event(eq, cma_event, &acked);
-		ret = -FI_EAGAIN;
-		goto ack;
-	case RDMA_CM_EVENT_ADDR_ERROR:
-	case RDMA_CM_EVENT_ROUTE_ERROR:
-	case RDMA_CM_EVENT_CONNECT_ERROR:
-	case RDMA_CM_EVENT_UNREACHABLE:
-		ep = container_of(fid, struct vrb_ep, util_ep.ep_fid);
-		ofi_genlock_lock(&vrb_ep2_progress(ep)->ep_lock);
-		assert(ep->state != VRB_DISCONNECTED);
-		ep->state = VRB_DISCONNECTED;
-		ofi_genlock_unlock(&vrb_ep2_progress(ep)->ep_lock);
-		if (vrb_is_xrc_ep(ep)) {
-			/* SIDR Reject is reported as UNREACHABLE unless
-			 * status is negative */
-			if (cma_event->id->ps == RDMA_PS_UDP &&
-			    (cma_event->event == RDMA_CM_EVENT_UNREACHABLE &&
-			     cma_event->status >= 0))
-				goto xrc_shared_reject;
-
-			ret = vrb_eq_xrc_cm_err_event(eq, cma_event, &acked);
-			if (ret == -FI_EAGAIN)
-				goto ack;
-
-			*event = FI_SHUTDOWN;
-			entry->info = NULL;
-			break;
-		}
-		eq->err.err = ETIMEDOUT;
-		eq->err.prov_errno = -cma_event->status;
-		if (eq->err.err_data) {
-			free(eq->err.err_data);
-			eq->err.err_data = NULL;
-			eq->err.err_data_size = 0;
-		}
-		goto err;
-	case RDMA_CM_EVENT_REJECTED:
-		ep = container_of(fid, struct vrb_ep, util_ep.ep_fid);
-		ofi_genlock_lock(&vrb_ep2_progress(ep)->ep_lock);
-		assert(ep->state != VRB_DISCONNECTED);
-		ep->state = VRB_DISCONNECTED;
-		ofi_genlock_unlock(&vrb_ep2_progress(ep)->ep_lock);
-		if (vrb_is_xrc_ep(ep)) {
-xrc_shared_reject:
-			ret = vrb_eq_xrc_rej_event(eq, cma_event);
-			if (ret == -FI_EAGAIN)
-				goto ack;
-			vrb_eq_skip_xrc_cm_data(&priv_data, &priv_datalen);
-		}
-		eq->err.err = ECONNREFUSED;
-		eq->err.prov_errno = -cma_event->status;
-		if (eq->err.err_data) {
-			free(eq->err.err_data);
-			eq->err.err_data = NULL;
-			eq->err.err_data_size = 0;
-		}
-		if (priv_datalen) {
-			cm_hdr = priv_data;
-			eq->err.err_data = calloc(1, cm_hdr->size);
-			assert(eq->err.err_data);
-			memcpy(eq->err.err_data, cm_hdr->data,
-			       cm_hdr->size);
-			eq->err.err_data_size = cm_hdr->size;
-		}
-		goto err;
-	case RDMA_CM_EVENT_DEVICE_REMOVAL:
-		eq->err.err = ENODEV;
-		goto err;
-	case RDMA_CM_EVENT_ADDR_CHANGE:
-		eq->err.err = EADDRNOTAVAIL;
-		goto err;
-	default:
-		VRB_WARN(FI_LOG_EP_CTRL, "unknown rdmacm event received: %d\n",
-			   cma_event->event);
-		ret = -FI_EAGAIN;
-		goto ack;
-	}
-
-	entry->fid = fid;
-
-	/* rdmacm has no way to track how much data is sent by peer */
-	if (priv_datalen)
-		datalen = vrb_eq_copy_event_data(entry, len, priv_data,
-						 priv_datalen);
-	if (!acked)
-		rdma_ack_cm_event(cma_event);
-	return sizeof(*entry) + datalen;
-err:
-	ret = -FI_EAVAIL;
-	eq->err.fid = fid;
-ack:
-	if (!acked)
-		rdma_ack_cm_event(cma_event);
-	return ret;
 }
 
 int vrb_eq_trywait(struct vrb_eq *eq)
@@ -1299,7 +852,6 @@ vrb_eq_read(struct fid_eq *eq_fid, uint32_t *event,
 	       void *buf, size_t len, uint64_t flags)
 {
 	struct vrb_eq *eq;
-	struct rdma_cm_event *cma_event;
 	ssize_t ret;
 
 	if (len < sizeof(struct fi_eq_cm_entry))
@@ -1308,32 +860,23 @@ vrb_eq_read(struct fid_eq *eq_fid, uint32_t *event,
 	vrb_prof_func_start(__func__);
 
 	eq = container_of(eq_fid, struct vrb_eq, eq_fid.fid);
-	assert(eq->channel);
 
 	ret = vrb_eq_read_event(eq, event, buf, len, flags);
 	if (ret)
 		return ret;
 
-	/* Skip events that are handled internally (e.g. XRC CM events). */
-	do {
-		ofi_mutex_lock(&eq->event_lock);
-		vrb_prof_func_start("rdma_get_cm_event");
-		ret = rdma_get_cm_event(eq->channel, &cma_event);
-		vrb_prof_func_end("rdma_get_cm_event");
-		if (ret) {
-			ofi_mutex_unlock(&eq->event_lock);
-			return -errno;
+	/* Drain this EQ's own CM channel (per-EQ, no lock needed). */
+	if (eq->cm_ctx && eq->cm_ops) {
+		ret = eq->cm_ops->progress(eq, event, buf, len);
+		if (ret > 0) {
+			if (flags & FI_PEEK)
+				ret = vrb_eq_write_event(eq, *event, buf, ret);
+			goto out;
 		}
-		vrb_prof_func_start("vrb_eq_cm_process_event");
-		ret = vrb_eq_cm_process_event(eq, cma_event, event, buf, len);
-		vrb_prof_func_end("vrb_eq_cm_process_event");
-		ofi_mutex_unlock(&eq->event_lock);
+	}
 
-	} while (ret == -FI_EAGAIN);
-
-	if (ret > 0 && flags & FI_PEEK)
-		ret = vrb_eq_write_event(eq, *event, buf, ret);
-
+	ret = vrb_eq_read_event(eq, event, buf, len, flags);
+out:
 	vrb_prof_func_end(__func__);
 	return ret;
 }
@@ -1429,13 +972,14 @@ static int vrb_eq_close(fid_t fid)
 	eq = container_of(fid, struct vrb_eq, eq_fid.fid);
 	/* TODO: use util code, if possible, and add ref counting */
 
+	/* Destroy per-EQ CM channel before closing the epollfd. */
+	if (eq->cm_ctx && eq->cm_ops)
+		eq->cm_ops->eq_close(eq);
+
 	if (!ofi_rbmap_empty(&eq->xrc.sidr_conn_rbmap))
 		VRB_WARN(FI_LOG_EP_CTRL, "SIDR connection RBmap not empty\n");
 
 	free(eq->err.err_data);
-
-	if (eq->channel)
-		rdma_destroy_event_channel(eq->channel);
 
 	ofi_epoll_close(eq->epollfd);
 
@@ -1503,6 +1047,8 @@ int vrb_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 
 	ofi_mutex_init(&_eq->lock);
 	ofi_mutex_init(&_eq->event_lock);
+	dlist_init(&_eq->domain_list);
+	dlist_init(&_eq->pep_list);
 	ret = dlistfd_head_init(&_eq->list_head);
 	if (ret) {
 		VRB_INFO(FI_LOG_EQ, "Unable to initialize dlistfd\n");
@@ -1519,21 +1065,6 @@ int vrb_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 		goto err3;
 	}
 
-	_eq->channel = rdma_create_event_channel();
-	if (!_eq->channel) {
-		ret = -errno;
-		goto err3;
-	}
-
-	ret = fi_fd_nonblock(_eq->channel->fd);
-	if (ret)
-		goto err4;
-
-	if (ofi_epoll_add(_eq->epollfd, _eq->channel->fd, OFI_EPOLL_IN, NULL)) {
-		ret = -errno;
-		goto err4;
-	}
-
 	_eq->flags = attr->flags;
 	_eq->eq_fid.fid.fclass = FI_CLASS_EQ;
 	_eq->eq_fid.fid.context = context;
@@ -1542,9 +1073,6 @@ int vrb_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 
 	*eq = &_eq->eq_fid;
 	return 0;
-err4:
-	if (_eq->channel)
-		rdma_destroy_event_channel(_eq->channel);
 err3:
 	ofi_epoll_close(_eq->epollfd);
 err2:

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -36,6 +36,7 @@
 
 #include <ifaddrs.h>
 #include <net/if.h>
+#include <netdb.h>
 #include <stdint.h>
 #include <rdma/rdma_cma.h>
 
@@ -187,6 +188,7 @@ int vrb_check_ep_attr(const struct fi_info *hints,
 
 	switch (hints->ep_attr->protocol) {
 	case FI_PROTO_UNSPEC:
+	case FI_PROTO_UD_CM_IB_RC:
 	case FI_PROTO_RDMA_CM_IB_RC:
 	case FI_PROTO_RDMA_CM_IB_XRC:
 	case FI_PROTO_IWARP:
@@ -252,8 +254,13 @@ static int vrb_check_hints(uint32_t version, const struct fi_info *hints,
 		return -FI_ENODATA;
 	}
 
-	if (!ofi_valid_addr_format(info->addr_format, hints->addr_format))
-		return -FI_ENODATA;
+	if (!ofi_valid_addr_format(info->addr_format, hints->addr_format)) {
+
+		if (!(vrb_gl_data.msg.prefer_cm == VRB_CM_UDCM &&
+		      info->ep_attr->type == FI_EP_MSG &&
+		      hints->addr_format == FI_ADDR_IB_UD))
+			return -FI_ENODATA;
+	}
 
 	prov_mode = ofi_mr_get_prov_mode(version, hints, info);
 
@@ -809,6 +816,68 @@ static bool vrb_hmem_supported(const char *dev_name)
 	return false;
 }
 
+/*
+ * Auto-detect the best GID index for a device when not explicitly set.
+ * For RoCE: prefer RoCEv2 IPv4-mapped > RoCEv2 link-local > fallback to 0.
+ * For pure IB: use the first valid IB GID entry > fallback to 0.
+ * Returns the resolved GID index.
+ */
+int vrb_resolve_gid_idx_for_device(struct ibv_context *ctx)
+{
+	struct ibv_gid_entry entries[16];
+	ssize_t n;
+	int best = 0;
+	int best_score = 0;
+	bool found_roce_v2 = false;
+
+	/* If user explicitly set gid_idx, use it */
+	if (vrb_gl_data.gid_idx != -1)
+		return vrb_gl_data.gid_idx;
+
+	n = ibv_query_gid_table(ctx, entries, 16, 0);
+	if (n <= 0)
+		return 0;
+
+	/* First pass: look for RoCEv2 entries (IPv4-mapped preferred) */
+	for (ssize_t i = 0; i < n; i++) {
+		int score = 0;
+
+		if (entries[i].port_num != 1)
+			continue;
+		if (entries[i].gid_type != IBV_GID_TYPE_ROCE_V2)
+			continue;
+
+		found_roce_v2 = true;
+		score = 1;
+		/* IPv4-mapped GID: ::ffff:x.x.x.x — bytes 10,11 are 0xff */
+		if (entries[i].gid.raw[10] == 0xff &&
+		    entries[i].gid.raw[11] == 0xff)
+			score = 2;
+		if (score > best_score) {
+			best_score = score;
+			best = entries[i].gid_index;
+		}
+	}
+
+	/* If no RoCEv2 found (pure IB device), use first valid IB GID */
+	if (!found_roce_v2) {
+		for (ssize_t i = 0; i < n; i++) {
+			if (entries[i].port_num != 1)
+				continue;
+			if (entries[i].gid_type == IBV_GID_TYPE_IB) {
+				best = entries[i].gid_index;
+				break;
+			}
+		}
+	}
+
+	FI_INFO(&vrb_prov, FI_LOG_FABRIC,
+		"Resolved gid_idx=%d for device %s\n", best,
+		ibv_get_device_name(ctx->device));
+
+	return best;
+}
+
 static int vrb_alloc_info(struct ibv_context *ctx, struct fi_info **info,
 			     const struct verbs_ep_domain *ep_dom)
 {
@@ -876,8 +945,10 @@ static int vrb_alloc_info(struct ibv_context *ctx, struct fi_info **info,
 		goto err;
 
 	switch (ctx->device->transport_type) {
-	case IBV_TRANSPORT_IB:
-		if (ibv_query_gid(ctx, 1, vrb_gl_data.gid_idx, &gid)) {
+	case IBV_TRANSPORT_IB: {
+		int gid_idx = vrb_resolve_gid_idx_for_device(ctx);
+
+		if (ibv_query_gid(ctx, 1, gid_idx, &gid)) {
 			VRB_WARN_ERRNO(FI_LOG_FABRIC, "ibv_query_gid");
 			ret = -errno;
 			goto err;
@@ -894,9 +965,13 @@ static int vrb_alloc_info(struct ibv_context *ctx, struct fi_info **info,
 
 		switch (ep_dom->type) {
 		case FI_EP_MSG:
+			if (ep_dom->protocol != FI_PROTO_UNSPEC) {
+				fi->ep_attr->protocol = ep_dom->protocol;
+				break;
+			}
 			fi->ep_attr->protocol =
-				ep_dom->protocol == FI_PROTO_UNSPEC ?
-				FI_PROTO_RDMA_CM_IB_RC : ep_dom->protocol;
+				vrb_gl_data.msg.prefer_cm == VRB_CM_RDMACM ?
+				FI_PROTO_RDMA_CM_IB_RC : FI_PROTO_UD_CM_IB_RC;
 			break;
 		case FI_EP_DGRAM:
 			fi->ep_attr->protocol = FI_PROTO_IB_UD;
@@ -907,6 +982,7 @@ static int vrb_alloc_info(struct ibv_context *ctx, struct fi_info **info,
 			goto err;
 		}
 		break;
+	}
 	case IBV_TRANSPORT_IWARP:
 		fi->fabric_attr->name = strdup(VERBS_IWARP_FABRIC);
 		if (!fi->fabric_attr->name) {
@@ -1335,6 +1411,8 @@ static int vrb_get_srcaddr_devs(struct dlist_entry *verbs_devs,
 	for (fi = *info; fi; fi = fi->next) {
 		if (fi->ep_attr->type == FI_EP_DGRAM)
 			continue;
+		if (fi->addr_format == FI_ADDR_IB_UD)
+			continue;
 		dlist_foreach_container(verbs_devs, struct verbs_dev_info,
 					dev, entry) {
 			if (!vrb_cmp_domain_and_dev_name(fi->domain_attr->name,
@@ -1440,6 +1518,105 @@ static int vrb_device_has_ipoib_addr(struct dlist_entry *verbs_devs,
 
 #define VERBS_NUM_DOMAIN_TYPES		3
 
+static int vrb_fill_ib_ud_from_sockaddr(const struct sockaddr *sa,
+					struct ofi_addr_ib_ud *ud_addr)
+{
+	memset(ud_addr, 0, sizeof(*ud_addr));
+
+	if (sa->sa_family == AF_INET) {
+		const struct sockaddr_in *sin = (const struct sockaddr_in *)sa;
+
+		/* IPv4-mapped GID: ::ffff:a.b.c.d */
+		ud_addr->gid.raw[10] = 0xff;
+		ud_addr->gid.raw[11] = 0xff;
+		memcpy(&ud_addr->gid.raw[12], &sin->sin_addr, 4);
+		ud_addr->service = ntohs(sin->sin_port);
+		return FI_SUCCESS;
+	}
+
+	if (sa->sa_family == AF_INET6) {
+		const struct sockaddr_in6 *sin6 = (const struct sockaddr_in6 *)sa;
+
+		memcpy(ud_addr->gid.raw, &sin6->sin6_addr, 16);
+		ud_addr->service = ntohs(sin6->sin6_port);
+		return FI_SUCCESS;
+	}
+
+	if (sa->sa_family == AF_IB) {
+		const struct ofi_sockaddr_ib *sib =
+			(const struct ofi_sockaddr_ib *)sa;
+
+		memcpy(ud_addr->gid.raw, &sib->sib_addr, 16);
+		ud_addr->pkey = sib->sib_pkey;
+		ud_addr->service = ofi_addr_get_port(sa);
+		return FI_SUCCESS;
+	}
+
+	return -FI_EINVAL;
+}
+
+static int vrb_prepend_udcm_msg_dup(struct fi_info *src, struct fi_info **tail)
+{
+	struct fi_info *sa_fi;
+	struct ofi_addr_ib_ud *ud_src = NULL;
+	struct ofi_addr_ib_ud *ud_dst = NULL;
+	int ret;
+
+	if (vrb_gl_data.msg.prefer_cm != VRB_CM_UDCM ||
+	    src->ep_attr->type != FI_EP_MSG)
+		return FI_SUCCESS;
+
+	/* Duplicate src — this copy retains the original sockaddr format */
+	sa_fi = fi_dupinfo(src);
+	if (!sa_fi)
+		return -FI_ENOMEM;
+
+	if (src->src_addr && src->src_addrlen >= sizeof(struct sockaddr)) {
+		ud_src = calloc(1, sizeof(*ud_src));
+		if (!ud_src) {
+			fi_freeinfo(sa_fi);
+			return -FI_ENOMEM;
+		}
+
+		ret = vrb_fill_ib_ud_from_sockaddr((const struct sockaddr *) src->src_addr,
+						   ud_src);
+		if (ret) {
+			free(ud_src);
+			ud_src = NULL;
+		}
+	}
+
+	if (src->dest_addr && src->dest_addrlen >= sizeof(struct sockaddr)) {
+		ud_dst = calloc(1, sizeof(*ud_dst));
+		if (!ud_dst) {
+			free(ud_src);
+			fi_freeinfo(sa_fi);
+			return -FI_ENOMEM;
+		}
+
+		ret = vrb_fill_ib_ud_from_sockaddr((const struct sockaddr *) src->dest_addr,
+						   ud_dst);
+		if (ret) {
+			free(ud_dst);
+			ud_dst = NULL;
+		}
+	}
+
+	free(src->src_addr);
+	src->src_addr = ud_src;
+	src->src_addrlen = ud_src ? sizeof(*ud_src) : 0;
+	free(src->dest_addr);
+	src->dest_addr = ud_dst;
+	src->dest_addrlen = ud_dst ? sizeof(*ud_dst) : 0;
+	src->addr_format = FI_ADDR_IB_UD;
+
+	sa_fi->next = src->next;
+	src->next = sa_fi;
+	*tail = sa_fi;
+
+	return FI_SUCCESS;
+}
+
 static int vrb_init_info(struct dlist_entry *verbs_devs,
 			 struct fi_info **all_infos)
 {
@@ -1463,7 +1640,8 @@ static int vrb_init_info(struct dlist_entry *verbs_devs,
 	}
 
 	/* List XRC MSG_EP domain before default RC MSG_EP if requested */
-	if (vrb_gl_data.msg.prefer_xrc) {
+	if (vrb_gl_data.msg.prefer_xrc &&
+		vrb_gl_data.msg.prefer_cm == VRB_CM_RDMACM) {
 		if (VERBS_HAVE_XRC)
 			ep_type[dom_count++] = &verbs_msg_xrc_domain;
 		else
@@ -1485,7 +1663,8 @@ static int vrb_init_info(struct dlist_entry *verbs_devs,
 	else
 		ep_type[dom_count++] = &verbs_msg_domain;
 
-	if (!vrb_gl_data.msg.prefer_xrc && VERBS_HAVE_XRC)
+	if (!vrb_gl_data.msg.prefer_xrc && VERBS_HAVE_XRC &&
+		vrb_gl_data.msg.prefer_cm == VRB_CM_RDMACM)
 		ep_type[dom_count++] = &verbs_msg_xrc_domain;
 
 	ep_type[dom_count++] = &verbs_dgram_domain;
@@ -1548,6 +1727,8 @@ static int vrb_init_info(struct dlist_entry *verbs_devs,
 				tail->next = fi;
 			tail = fi;
 
+			(void) vrb_prepend_udcm_msg_dup(fi, &tail);
+
 			/* If verbs HMEM is supported, duplicate previously
 			 * allocated fi_info and apply HMEM flags.
 			 */
@@ -1563,6 +1744,8 @@ static int vrb_init_info(struct dlist_entry *verbs_devs,
 
 				tail->next = fi;
 				tail = fi;
+
+				(void) vrb_prepend_udcm_msg_dup(fi, &tail);
 			}
 		}
 	}
@@ -1754,8 +1937,15 @@ static int vrb_resolve_ib_ud_dest_addr(const char *node, const char *service,
 					  struct ofi_addr_ib_ud **dest_addr)
 {
 	int svc = VERBS_IB_UD_NS_ANY_SERVICE;
+	int ns_port;
+
+	if (service)
+		svc = atoi(service);
+
+	ns_port = (svc > 0) ? svc : vrb_gl_data.dgram.name_server_port;
+
 	struct util_ns ns = {
-		.port = vrb_gl_data.dgram.name_server_port,
+		.port = ns_port,
 		.name_len = sizeof(**dest_addr),
 		.service_len = sizeof(svc),
 		.service_cmp = vrb_dgram_ns_service_cmp,
@@ -1764,8 +1954,6 @@ static int vrb_resolve_ib_ud_dest_addr(const char *node, const char *service,
 
 	ofi_ns_init(&ns);
 
-	if (service)
-		svc = atoi(service);
 	*dest_addr = (struct ofi_addr_ib_ud *)
 		ofi_ns_resolve_name(&ns, node, &svc);
 	if (*dest_addr) {
@@ -1802,6 +1990,236 @@ static void vrb_delete_dgram_infos(struct fi_info **info)
 			check_info = check_info->next;
 		}
 	}
+}
+
+static int vrb_set_ib_ud_addr_from_ipv4(const struct sockaddr_in *sin,
+					 struct ofi_addr_ib_ud **ud_addr)
+{
+	struct ofi_addr_ib_ud *addr;
+
+	addr = calloc(1, sizeof(*addr));
+	if (!addr)
+		return -FI_ENOMEM;
+
+	addr->gid.raw[10] = 0xff;
+	addr->gid.raw[11] = 0xff;
+	memcpy(&addr->gid.raw[12], &sin->sin_addr, 4);
+	addr->service = sin->sin_port ? ntohs(sin->sin_port) : 1;
+
+	*ud_addr = addr;
+	return FI_SUCCESS;
+}
+
+static int vrb_set_msg_src_ib_ud(struct fi_info *fi, const struct sockaddr *sa)
+{
+	struct ofi_addr_ib_ud *ud_src;
+	int ret;
+
+	ud_src = calloc(1, sizeof(*ud_src));
+	if (!ud_src)
+		return -FI_ENOMEM;
+
+	ret = vrb_fill_ib_ud_from_sockaddr(sa, ud_src);
+	if (ret) {
+		free(ud_src);
+		return ret;
+	}
+
+	free(fi->src_addr);
+	fi->src_addr = ud_src;
+	fi->src_addrlen = sizeof(*ud_src);
+	return FI_SUCCESS;
+}
+
+static int vrb_set_msg_dest_from_ipv4(struct fi_info *fi,
+				      const struct sockaddr_in *sin,
+				      bool force_nonzero_port)
+{
+	struct sockaddr_in *dsin;
+	struct ofi_addr_ib_ud *ud_dst;
+	int ret;
+
+	if (fi->addr_format == FI_ADDR_IB_UD) {
+		ret = vrb_set_ib_ud_addr_from_ipv4(sin, &ud_dst);
+		if (ret)
+			return ret;
+
+		free(fi->dest_addr);
+		fi->dest_addr = ud_dst;
+		fi->dest_addrlen = sizeof(*ud_dst);
+		return FI_SUCCESS;
+	}
+
+	dsin = calloc(1, sizeof(*dsin));
+	if (!dsin)
+		return -FI_ENOMEM;
+
+	*dsin = *sin;
+	if (force_nonzero_port)
+		dsin->sin_port = htons(1);
+
+	free(fi->dest_addr);
+	fi->dest_addr = dsin;
+	fi->dest_addrlen = sizeof(*dsin);
+	return FI_SUCCESS;
+}
+
+static int vrb_set_all_msg_dest_from_ipv4(struct fi_info *info,
+					  const struct sockaddr_in *sin,
+					  bool force_nonzero_port)
+{
+	struct fi_info *fi;
+	int ret;
+
+	for (fi = info; fi; fi = fi->next) {
+		if (fi->ep_attr->type == FI_EP_DGRAM)
+			continue;
+
+		ret = vrb_set_msg_dest_from_ipv4(fi, sin, force_nonzero_port);
+		if (ret)
+			return ret;
+	}
+
+	return FI_SUCCESS;
+}
+
+
+int vrb_udcm_getinfo_addr(struct dlist_entry *verbs_devs,
+			 const char *node, const char *service,
+			 uint64_t flags, const struct fi_info *hints,
+			 struct fi_info **info)
+{
+	struct fi_info *fi;
+	int ret, found = 0;
+
+	ret = vrb_get_srcaddr_devs(verbs_devs, info);
+	if (ret)
+		return ret;
+
+	for (fi = *info; fi; fi = fi->next) {
+		if (fi->ep_attr->type == FI_EP_DGRAM)
+			continue;
+
+		if (fi->addr_format == FI_ADDR_IB_UD) {
+			struct fi_info *src_fi;
+			const struct sockaddr *sa = NULL;
+
+			for (src_fi = *info; src_fi; src_fi = src_fi->next) {
+				if (src_fi->ep_attr->type != FI_EP_MSG)
+					continue;
+				if (src_fi->addr_format == FI_ADDR_IB_UD)
+					continue;
+				if (!src_fi->src_addr)
+					continue;
+
+				if (!strcmp(fi->domain_attr->name, VERBS_ANY_DOMAIN) ||
+				    !vrb_cmp_domain_and_dev_name(fi->domain_attr->name,
+							  src_fi->domain_attr->name)) {
+					sa = src_fi->src_addr;
+					break;
+				}
+			}
+
+			if (sa) {
+				ret = vrb_set_msg_src_ib_ud(fi, sa);
+				if (ret)
+					continue;
+
+				found++;
+			}
+			continue;
+		}
+
+		if (!fi->src_addr &&
+		    !strcmp(fi->domain_attr->name, VERBS_ANY_DOMAIN)) {
+			struct verbs_dev_info *dev;
+
+			if (!dlist_empty(verbs_devs)) {
+				dlist_foreach_container(verbs_devs,
+							struct verbs_dev_info,
+							dev, entry) {
+					ret = vrb_info_add_dev_addr(&fi, dev);
+					if (ret)
+						return ret;
+					break;
+				}
+			}
+		}
+
+		if (fi->src_addr)
+			found++;
+	}
+
+	if (node && !(flags & FI_SOURCE)) {
+		struct addrinfo ai_hints = {
+			.ai_family   = AF_INET,
+			.ai_socktype = SOCK_STREAM,
+		};
+		struct addrinfo *ai = NULL;
+		int gai_ret;
+
+		gai_ret = getaddrinfo(node, service, &ai_hints, &ai);
+		if (!gai_ret && ai) {
+			ret = vrb_set_all_msg_dest_from_ipv4(*info,
+							 (struct sockaddr_in *)ai->ai_addr,
+							 true);
+			if (ret) {
+				freeaddrinfo(ai);
+				return ret;
+			}
+			freeaddrinfo(ai);
+		} else if (gai_ret) {
+			VRB_INFO(FI_LOG_FABRIC,
+				 "udcm: getaddrinfo(%s) failed: %s\n",
+				 node, gai_strerror(gai_ret));
+			return -FI_ENODATA;
+		}
+	} else if (hints && hints->dest_addr && !(flags & FI_SOURCE)) {
+		const struct sockaddr *sa = hints->dest_addr;
+
+		if (sa->sa_family == AF_INET &&
+		    hints->dest_addrlen >= sizeof(struct sockaddr_in)) {
+			ret = vrb_set_all_msg_dest_from_ipv4(*info,
+							 (const struct sockaddr_in *)sa,
+							 false);
+			if (ret)
+				return ret;
+		} else if (sa->sa_family == AF_IB &&
+			   hints->dest_addrlen >= sizeof(struct ofi_sockaddr_ib)) {
+			for (fi = *info; fi; fi = fi->next) {
+				struct ofi_addr_ib_ud *ud_dst;
+
+				if (fi->ep_attr->type == FI_EP_DGRAM)
+					continue;
+
+				if (fi->addr_format == FI_ADDR_IB_UD) {
+					ud_dst = calloc(1, sizeof(*ud_dst));
+					if (!ud_dst)
+						return -FI_ENOMEM;
+
+					ret = vrb_fill_ib_ud_from_sockaddr(sa, ud_dst);
+					if (ret) {
+						free(ud_dst);
+						return ret;
+					}
+
+					free(fi->dest_addr);
+					fi->dest_addr = ud_dst;
+					fi->dest_addrlen = sizeof(*ud_dst);
+					continue;
+				}
+
+				free(fi->dest_addr);
+				fi->dest_addr = mem_dup(hints->dest_addr,
+							hints->dest_addrlen);
+				if (!fi->dest_addr)
+					return -FI_ENOMEM;
+				fi->dest_addrlen = hints->dest_addrlen;
+			}
+		}
+	}
+
+	return found ? FI_SUCCESS : -FI_ENODATA;
 }
 
 static int vrb_handle_ib_ud_addr(const char *node, const char *service,
@@ -1877,10 +2295,10 @@ out:
 	return ret;
 }
 
-static int vrb_handle_sock_addr(struct dlist_entry *verbs_devs,
-				   const char *node, const char *service,
-				   uint64_t flags, const struct fi_info *hints,
-				   struct fi_info **info)
+int vrb_rdmacm_getinfo_addr(struct dlist_entry *verbs_devs,
+			   const char *node, const char *service,
+			   uint64_t flags, const struct fi_info *hints,
+			   struct fi_info **info)
 {
 	struct rdma_cm_id *id = NULL;
 	struct rdma_addrinfo *rai;
@@ -1923,7 +2341,10 @@ static int vrb_get_match_infos(struct dlist_entry *verbs_devs,
 
 	if (!hints || !hints->ep_attr || hints->ep_attr->type == FI_EP_MSG ||
 	    hints->ep_attr->type == FI_EP_UNSPEC) {
-		ret_sock_addr = vrb_handle_sock_addr(verbs_devs, node, service, flags, hints, info);
+		struct vrb_cm_ops *cm_ops = (vrb_gl_data.msg.prefer_cm == VRB_CM_UDCM) ?
+			&vrb_udcm_ops : &vrb_rdmacm_ops;
+		ret_sock_addr = cm_ops->getinfo_addr(verbs_devs,
+				node, service, flags, hints, info);
 		if (ret_sock_addr) {
 			VRB_INFO(FI_LOG_FABRIC,
 				   "handling of the socket address fails - %d\n",
@@ -1989,7 +2410,21 @@ static void vrb_filter_info_by_addr_format(struct fi_info **info, int addr_forma
 	struct fi_info *cur, *prev= NULL, *next = NULL;
 	for (cur = *info; cur; cur = next) {
 		next = cur->next;
-		if (!ofi_match_addr_format(cur->addr_format, addr_format)) {
+
+		if (cur->addr_format == FI_ADDR_IB_UD) {
+			if (addr_format != FI_FORMAT_UNSPEC &&
+			    addr_format != FI_SOCKADDR &&
+			    addr_format != FI_ADDR_IB_UD) {
+				if (prev)
+					prev->next = cur->next;
+				else
+					*info = cur->next;
+				cur->next = NULL;
+				fi_freeinfo(cur);
+			} else {
+				prev = cur;
+			}
+		} else if (!ofi_match_addr_format(cur->addr_format, addr_format)) {
 			if (prev)
 				prev->next = cur->next;
 			else
@@ -2400,6 +2835,9 @@ int vrb_getinfo(uint32_t version, const char *node, const char *service,
 		fi_freeinfo(vrb_util_prov.info);
 		vrb_util_prov.info = tmp_info;
 	}
+	if (service && atoi(service) > 0)
+		vrb_gl_data.msg.udcm_ns_port = atoi(service);
+
 	ret = vrb_get_match_infos(&vrb_devs, version, node, service,
 				     flags, hints,
 				     vrb_util_prov.info, info);

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -368,14 +368,14 @@ int vrb_set_rai(uint32_t addr_format, void *src_addr, size_t src_addrlen,
 }
 
 static inline
-void *vrb_dgram_ep_name_to_string(const struct ofi_ib_ud_ep_name *name,
+void *vrb_dgram_ep_name_to_string(const struct ofi_addr_ib_ud *name,
 				     size_t *len)
 {
 	char *str;
 	if (!name)
 		return NULL;
 
-	*len = sizeof(struct ofi_ib_ud_ep_name);
+	*len = sizeof(struct ofi_addr_ib_ud);
 
 	str = calloc(*len, 1);
 	if (!str)
@@ -389,7 +389,7 @@ void *vrb_dgram_ep_name_to_string(const struct ofi_ib_ud_ep_name *name,
 	return str;
 }
 
-static int vrb_fill_addr_by_ep_name(struct ofi_ib_ud_ep_name *ep_name,
+static int vrb_fill_addr_by_ep_name(struct ofi_addr_ib_ud *ep_name,
 				       uint32_t fmt, void **addr, size_t *addrlen)
 {
 	if (fmt == FI_ADDR_STR) {
@@ -1355,8 +1355,8 @@ static int vrb_get_srcaddr_devs(struct dlist_entry *verbs_devs,
 static int vrb_set_info_addrs(struct fi_info *info,
 				 struct rdma_addrinfo *rai,
 				 uint32_t fmt,
-				 struct ofi_ib_ud_ep_name *src_addr,
-				 struct ofi_ib_ud_ep_name *dest_addr)
+				 struct ofi_addr_ib_ud *src_addr,
+				 struct ofi_addr_ib_ud *dest_addr)
 {
 	struct fi_info *iter_info = info;
 	int ret;
@@ -1751,7 +1751,7 @@ static int vrb_del_info_not_belong_to_dev(const char *dev_name, struct fi_info *
 }
 
 static int vrb_resolve_ib_ud_dest_addr(const char *node, const char *service,
-					  struct ofi_ib_ud_ep_name **dest_addr)
+					  struct ofi_addr_ib_ud **dest_addr)
 {
 	int svc = VERBS_IB_UD_NS_ANY_SERVICE;
 	struct util_ns ns = {
@@ -1766,7 +1766,7 @@ static int vrb_resolve_ib_ud_dest_addr(const char *node, const char *service,
 
 	if (service)
 		svc = atoi(service);
-	*dest_addr = (struct ofi_ib_ud_ep_name *)
+	*dest_addr = (struct ofi_addr_ib_ud *)
 		ofi_ns_resolve_name(&ns, node, &svc);
 	if (*dest_addr) {
 		VERBS_INFO_NODE_2_UD_ADDR(FI_LOG_CORE, node, svc, *dest_addr);
@@ -1807,8 +1807,8 @@ static void vrb_delete_dgram_infos(struct fi_info **info)
 static int vrb_handle_ib_ud_addr(const char *node, const char *service,
 				    uint64_t flags, struct fi_info **info)
 {
-	struct ofi_ib_ud_ep_name *dest_addr = NULL;
-	struct ofi_ib_ud_ep_name *src_addr = NULL;
+	struct ofi_addr_ib_ud *dest_addr = NULL;
+	struct ofi_addr_ib_ud *src_addr = NULL;
 	void *addr = NULL;
 	size_t len = 0;
 	uint32_t fmt = FI_FORMAT_UNSPEC;

--- a/prov/verbs/src/verbs_init.c
+++ b/prov/verbs/src/verbs_init.c
@@ -54,7 +54,7 @@ struct vrb_gl_data vrb_gl_data = {
 	.use_odp		= 0,
 	.cqread_bunch_size	= 8,
 	.iface			= NULL,
-	.gid_idx		= 0,
+	.gid_idx		= -1,
 	.dgram			= {
 		.use_name_server	= 1,
 		.name_server_port	= 5678,
@@ -64,6 +64,7 @@ struct vrb_gl_data vrb_gl_data = {
 		/* Disabled by default. Use XRC transport for message
 		 * endpoint only if it is explicitly requested */
 		.prefer_xrc		= 0,
+		.prefer_cm		= VRB_CM_RDMACM,
 		.xrcd_filename		= "/tmp/verbs_xrcd",
 	},
 
@@ -696,6 +697,29 @@ static int vrb_read_params(void)
 		return -FI_EINVAL;
 	}
 
+	/* Parse prefer_cm string parameter into enum value */
+	{
+		char *prefer_cm_str = NULL;
+		if (vrb_get_param_str("prefer_cm",
+				      "Preferred connection management: 'rdmacm' (default) or 'udcm'.",
+				      &prefer_cm_str)) {
+			VRB_WARN(FI_LOG_CORE, "Invalid value of prefer_cm\n");
+			return -FI_EINVAL;
+		}
+
+		/* Convert string to enum, with error handling at the front */
+		if (prefer_cm_str != NULL) {
+			if (strcmp(prefer_cm_str, "udcm") == 0) {
+				vrb_gl_data.msg.prefer_cm = VRB_CM_UDCM;
+			} else if (strcmp(prefer_cm_str, "rdmacm") == 0) {
+				vrb_gl_data.msg.prefer_cm = VRB_CM_RDMACM;
+			} else {
+				VRB_WARN(FI_LOG_CORE, "Invalid prefer_cm value '%s', must be 'rdmacm' or 'udcm'. Using default 'rdmacm'.\n", prefer_cm_str);
+				vrb_gl_data.msg.prefer_cm = VRB_CM_RDMACM;
+			}
+		}
+	}
+
 	if (vrb_get_param_bool("prefer_xrc", "Order XRC transport fi_infos "
 			       "ahead of RC.  Default orders RC first.  This "
 			       "setting must usually be combined with setting "
@@ -720,7 +744,8 @@ static int vrb_read_params(void)
 	}
 	if (vrb_get_param_int("gid_idx", "Set which gid index to use "
 			      "attribute (0 - 255)", &vrb_gl_data.gid_idx) ||
-	    (vrb_gl_data.gid_idx < 0 || vrb_gl_data.gid_idx > 255)) {
+	    (vrb_gl_data.gid_idx != -1 &&
+	     (vrb_gl_data.gid_idx < 0 || vrb_gl_data.gid_idx > 255))) {
 		VRB_WARN(FI_LOG_CORE, "Invalid value of gid index\n");
 		return -FI_EINVAL;
 	}

--- a/prov/verbs/src/verbs_ofi.h
+++ b/prov/verbs/src/verbs_ofi.h
@@ -163,6 +163,7 @@
 
 #define VRB_CM_UNKNOWN 0
 #define VRB_CM_RDMACM 1
+#define VRB_CM_UDCM 2
 
 #ifdef HAVE_FABRIC_PROFILE
 struct vrb_profile;
@@ -212,6 +213,8 @@ extern struct vrb_gl_data {
 	struct {
 		int	prefer_xrc;
 		char	*xrcd_filename;
+		int	prefer_cm;
+		int	udcm_ns_port;
 	} msg;
 
 	bool	peer_mem_support;
@@ -353,6 +356,7 @@ int vrb_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 struct vrb_pep {
 	struct fid_pep		pep_fid;
 	struct vrb_eq		*eq;
+	struct vrb_fabric	*fabric;   /* back-pointer, used by UD-CM */
 	struct dlist_entry	eq_entry;
 
 	int			backlog;
@@ -689,8 +693,88 @@ struct vrb_rdmacm_pep_ctx {
 	struct rdma_cm_id		*xrc_ps_udp_id;
 };
 
-/* Inline accessor for the RDMA-CM id stored in ep->cm_ctx.
- * Only valid when the EP is using the RDMA-CM backend. */
+struct vrb_cm_data_hdr {
+	uint8_t	size;
+	char	data[];
+};
+
+#define VRB_UDCM_RECV_WR    512
+#define VRB_UDCM_SEND_WR	256
+#define VRB_UDCM_BUF_SIZE	1024
+
+/* Shared, ref-counted IB resources for UD CM signalling.
+ * Created by PEP listen (server) or lazily at ep_bind (client-only).
+ * All UD send/recv goes through a single ib_ctx per EQ. */
+struct vrb_udcm_ib_ctx {
+	struct ibv_context		*verbs;
+	struct ibv_pd			*pd;
+	struct ibv_comp_channel		*comp_channel;
+	struct ibv_cq			*ud_recv_cq;
+	struct ibv_cq			*ud_send_cq;
+	struct ibv_qp			*ud_qp;
+	struct ofi_addr_ib_ud		local_name;
+	uint8_t				*recv_bufs;
+	struct ibv_mr			*recv_mr;
+	uint8_t				*send_buf;
+	struct ibv_mr			*send_mr;
+	ofi_spin_t			send_lock;
+	ofi_atomic32_t			ref;
+	struct vrb_eq			*eq;
+	int				gid_idx;
+	uint8_t				port_num;
+	uint16_t			pkey_index;
+};
+
+struct vrb_udcm_domain_ctx {
+	struct vrb_domain		*domain;
+	struct vrb_udcm_ib_ctx		*ib;
+	struct dlist_entry		ep_list;
+	ofi_spin_t			lock;
+	ofi_atomic32_t			ref;
+	ofi_atomic32_t			next_conn_id;
+	uint32_t			retry_seed;
+};
+
+struct vrb_udcm_eq_ctx {
+	struct vrb_domain		*domain;
+};
+
+enum vrb_udcm_state {
+	VRB_UDCM_IDLE,
+	VRB_UDCM_REQ_SENT,
+	VRB_UDCM_REQ_RCVD,
+	VRB_UDCM_REP_SENT,
+	VRB_UDCM_RTU_SENT,
+	VRB_UDCM_CONNECTED,
+	VRB_UDCM_REJECTING,
+	VRB_UDCM_DISCONNECTED,
+};
+
+struct vrb_udcm_ep_ctx {
+	struct vrb_ep			*ep;
+	struct dlist_entry		 list_entry;
+	enum vrb_udcm_state		 state;
+	struct ofi_addr_ib_ud		 peer_name;
+	uint32_t			 peer_rc_qpn;
+	uint32_t			 conn_id;
+	uint32_t			 peer_conn_id;
+	uint8_t				 priv_data[VERBS_CM_DATA_SIZE];
+	size_t				 priv_data_len;
+	union ofi_sock_ip		 src_addr;
+	uint8_t				 src_addr_len;
+	union ofi_sock_ip		 peer_addr;
+	uint8_t				 peer_addr_len;
+	bool				 pending_rtu;
+	uint64_t			 retry_deadline_ns;
+	int				 retry_count;
+};
+
+struct vrb_udcm_pep_ctx {
+	bool				listening;
+	struct vrb_udcm_ib_ctx		*ib;
+	int				service;
+};
+
 static inline struct rdma_cm_id *vrb_rdmacm_ep_id(struct vrb_ep *ep)
 {
 	return ep->cm_ctx ? ((struct vrb_rdmacm_ep_ctx *)ep->cm_ctx)->id : NULL;
@@ -710,7 +794,6 @@ struct vrb_cm_ops {
 		       size_t paramlen);
 	int (*accept)(struct vrb_ep *ep, const void *param, size_t paramlen);
 	int (*shutdown)(struct vrb_ep *ep, uint64_t flags);
-	int (*disconnect)(struct vrb_ep *ep);
 
 	//Passive endpoint operations
 	int (*listen)(struct vrb_pep *pep);
@@ -724,6 +807,7 @@ struct vrb_cm_ops {
 	// Resource management
 	int (*ep_init)(struct vrb_ep *ep, struct fi_info *info);
 	int (*ep_close)(struct vrb_ep *ep);
+	void (*ep_preclose)(struct vrb_ep *ep);
 	int (*ep_bind)(struct vrb_ep *ep, struct vrb_eq *eq);
 	int (*ep_enable)(struct vrb_ep *ep, struct ibv_qp_init_attr *attr);
 	int (*ep_setname)(struct vrb_ep *ep, void *addr, size_t addrlen);
@@ -740,6 +824,12 @@ struct vrb_cm_ops {
 	int (*setname)(struct vrb_pep *pep, void *addr, size_t addrlen);
 	int (*getname)(struct vrb_pep *pep, void *addr, size_t *addrlen);
 	int (*getpeer)(struct vrb_ep *ep, void *addr, size_t *addrlen);
+
+	// fi_getinfo address handling
+	int (*getinfo_addr)(struct dlist_entry *verbs_devs,
+			    const char *node, const char *service,
+			    uint64_t flags, const struct fi_info *hints,
+			    struct fi_info **info);
 
 	// Name for debugging
 	int cm_backend;
@@ -839,6 +929,17 @@ extern struct fi_ops_rma vrb_msg_ep_rma_ops;
 extern struct fi_ops_rma vrb_msg_xrc_ep_rma_ops_ts;
 extern struct fi_ops_rma vrb_msg_xrc_ep_rma_ops;
 extern struct vrb_cm_ops vrb_rdmacm_ops;
+extern struct vrb_cm_ops vrb_udcm_ops;
+
+int vrb_rdmacm_getinfo_addr(struct dlist_entry *verbs_devs,
+			   const char *node, const char *service,
+			   uint64_t flags, const struct fi_info *hints,
+			   struct fi_info **info);
+int vrb_udcm_getinfo_addr(struct dlist_entry *verbs_devs,
+			 const char *node, const char *service,
+			 uint64_t flags, const struct fi_info *hints,
+			 struct fi_info **info);
+
 int vrb_copy_addr(void *dst_addr, size_t *dst_addrlen, void *src_addr);
 void vrb_msg_ep_prepare_cm_data(const void *param, size_t param_size,
 				    struct vrb_cm_data_hdr *cm_hdr);
@@ -878,6 +979,14 @@ struct vrb_connreq {
 	 * non-RDMA CM managed QP. */
 	int				is_xrc;
 	struct vrb_xrc_conn_info	xrc;
+
+	/* UD-CM peer identity (valid when used with UDCM backend) */
+	struct ofi_addr_ib_ud		udcm_peer_name;
+	uint32_t			udcm_peer_rc_qpn;
+	uint32_t			udcm_conn_id;
+	struct vrb_domain		*udcm_domain;
+	union ofi_sock_ip		udcm_peer_addr;
+	uint8_t				udcm_peer_addr_len;
 };
 
 /* Structure below is a copy of the RDMA CM header (structure ib_connect_hdr in
@@ -891,10 +1000,6 @@ struct vrb_rdma_cm_hdr {
 	uint32_t dst_addr[4];
 };
 
-struct vrb_cm_data_hdr {
-	uint8_t	size;
-	char	data[];
-};
 
 int vrb_eq_add_sidr_conn(struct vrb_xrc_ep *ep,
 			    void *param_data, size_t param_len);
@@ -974,6 +1079,7 @@ int vrb_get_matching_info(uint32_t version, const struct fi_info *hints,
 			     uint8_t passive);
 int vrb_get_port_space(uint32_t addr_format);
 void vrb_alter_info(const struct fi_info *hints, struct fi_info *info);
+int vrb_resolve_gid_idx_for_device(struct ibv_context *ctx);
 
 struct verbs_ep_domain {
 	char			*suffix;

--- a/prov/verbs/src/verbs_ofi.h
+++ b/prov/verbs/src/verbs_ofi.h
@@ -225,34 +225,6 @@ struct verbs_addr {
 	struct rdma_addrinfo *rai;
 };
 
-/*
- * fields of Infiniband packet headers that are used to
- * represent OFI EP address
- * - LRH (Local Route Header) - Link Layer:
- *   - LID - destination Local Identifier
- *   - SL - Service Level
- * - GRH (Global Route Header) - Network Layer:
- *   - GID - destination Global Identifier
- * - BTH (Base Transport Header) - Transport Layer:
- *   - QPN - destination Queue Pair number
- *   - P_key - Partition Key
- *
- * Note: DON'T change the placement of the fields in the structure.
- *       The placement is to keep structure size = 256 bits (32 byte).
- */
-struct ofi_ib_ud_ep_name {
-	union ibv_gid	gid;		/* 64-bit GUID + 64-bit EUI - GRH */
-
-	uint32_t	qpn;		/* BTH */
-
-	uint16_t	lid; 		/* LRH */
-	uint16_t	pkey;		/* BTH */
-	uint16_t	service;	/* for NS src addr, 0 means any */
-
-	uint8_t 	sl;		/* LRH */
-	uint8_t		padding[5];	/* forced padding to 256 bits (32 byte) */
-}; /* 256 bits */
-
 #define VERBS_IB_UD_NS_ANY_SERVICE	0
 
 static inline
@@ -641,8 +613,8 @@ struct vrb_ep {
 	union {
 		struct rdma_cm_id	*id;
 		struct {
-			struct ofi_ib_ud_ep_name	ep_name;
-			int				service;
+			struct ofi_addr_ib_ud	ep_name;
+			int			service;
 		};
 	};
 
@@ -928,7 +900,7 @@ struct vrb_dgram_av {
 
 struct vrb_dgram_av_entry {
 	struct dlist_entry list_entry;
-	struct ofi_ib_ud_ep_name addr;
+	struct ofi_addr_ib_ud addr;
 	struct ibv_ah *ah;
 };
 

--- a/prov/verbs/src/verbs_ofi.h
+++ b/prov/verbs/src/verbs_ofi.h
@@ -161,6 +161,9 @@
 #define VERBS_ANY_DOMAIN "verbs_any_domain"
 #define VERBS_ANY_FABRIC "verbs_any_fabric"
 
+#define VRB_CM_UNKNOWN 0
+#define VRB_CM_RDMACM 1
+
 #ifdef HAVE_FABRIC_PROFILE
 struct vrb_profile;
 typedef struct vrb_profile    vrb_profile_t;
@@ -303,13 +306,17 @@ struct vrb_eq {
 	struct vrb_fabric	*fab;
 	ofi_mutex_t		lock;
 	ofi_mutex_t		event_lock;
+	struct dlist_entry	domain_list;
+	struct dlist_entry	pep_list;
 	struct dlistfd_head	list_head;
-	struct rdma_event_channel *channel;
 	uint64_t		flags;
 	struct fi_eq_err_entry	err;
 
 	ofi_epoll_t		epollfd;
 	enum fi_wait_obj	wait_obj;
+
+	void			*cm_ctx;
+	struct vrb_cm_ops	*cm_ops;
 
 	struct {
 		/* The connection key map is used during the XRC connection
@@ -346,12 +353,7 @@ int vrb_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 struct vrb_pep {
 	struct fid_pep		pep_fid;
 	struct vrb_eq		*eq;
-	struct rdma_cm_id	*id;
-
-	/* XRC uses SIDR based RDMA CM exchanges for setting up
-	 * shared QP connections. This ID is bound to the same
-	 * port number as "id", but the RDMA_PS_UDP port space. */
-	struct rdma_cm_id	*xrc_ps_udp_id;
+	struct dlist_entry	eq_entry;
 
 	int			backlog;
 	int			bound;
@@ -360,6 +362,9 @@ struct vrb_pep {
 
 	/* for profiling */
 	vrb_profile_t		*profile;
+
+	struct vrb_cm_ops	*cm_ops;
+	void			*cm_ctx;
 };
 
 struct fi_ops_cm *vrb_pep_ops_cm(struct vrb_pep *pep);
@@ -376,8 +381,10 @@ enum {
 	VRB_USE_ODP = BIT(1),
 };
 
+struct vrb_cm_ops;
 struct vrb_domain {
 	struct util_domain		util_domain;
+	struct dlist_entry		eq_entry;
 	struct ibv_context		*verbs;
 	struct ibv_pd			*pd;
 
@@ -415,6 +422,9 @@ struct vrb_domain {
 
 	/* for profiling */
 	vrb_profile_t		*profile;
+
+	struct vrb_cm_ops		*cm_ops;
+    	void				*cm_ctx;
 };
 
 struct vrb_cq;
@@ -610,8 +620,11 @@ struct vrb_ep {
 	int64_t				threshold;
 
 	enum vrb_ep_state		state;
+
+	// Connection Management
+	struct vrb_cm_ops		*cm_ops;
 	union {
-		struct rdma_cm_id	*id;
+		void				*cm_ctx;
 		struct {
 			struct ofi_addr_ib_ud	ep_name;
 			int			service;
@@ -649,6 +662,88 @@ struct vrb_ep {
 	vrb_profile_t			*profile;
 };
 
+/*
+ * RDMA-CM specific context structures. Defined here so that inline
+ * accessors below can reach the 'id' field without requiring all
+ * callers to include verbs_cm_rdma.c internals.
+ */
+struct vrb_rdmacm_domain_ctx {
+	/* Bootstrap channel: only used to create rdmacm IDs before they are
+	 * migrated to the per-EQ channel in ep_bind.  Never added to any
+	 * epollfd and therefore never polled directly. */
+	struct rdma_event_channel *cm_channel;
+};
+
+struct vrb_rdmacm_eq_ctx {
+	struct rdma_event_channel *cm_channel;
+};
+
+/* Only the RDMA-CM id lives here; conn_param and cm_priv_data remain
+ * on vrb_ep for compatibility with XRC and generic close paths. */
+struct vrb_rdmacm_ep_ctx {
+	struct rdma_cm_id *id;
+};
+
+struct vrb_rdmacm_pep_ctx {
+	struct rdma_cm_id		*id;
+	struct rdma_cm_id		*xrc_ps_udp_id;
+};
+
+/* Inline accessor for the RDMA-CM id stored in ep->cm_ctx.
+ * Only valid when the EP is using the RDMA-CM backend. */
+static inline struct rdma_cm_id *vrb_rdmacm_ep_id(struct vrb_ep *ep)
+{
+	return ep->cm_ctx ? ((struct vrb_rdmacm_ep_ctx *)ep->cm_ctx)->id : NULL;
+}
+
+static inline void vrb_rdmacm_ep_set_id(struct vrb_ep *ep, struct rdma_cm_id *id)
+{
+	if (ep->cm_ctx)
+		((struct vrb_rdmacm_ep_ctx *)ep->cm_ctx)->id = id;
+}
+
+struct vrb_connreq;  /* full definition below */
+
+struct vrb_cm_ops {
+	// Endpoint connection operations
+	int (*connect)(struct vrb_ep *ep, const void *addr, const void *param,
+		       size_t paramlen);
+	int (*accept)(struct vrb_ep *ep, const void *param, size_t paramlen);
+	int (*shutdown)(struct vrb_ep *ep, uint64_t flags);
+	int (*disconnect)(struct vrb_ep *ep);
+
+	//Passive endpoint operations
+	int (*listen)(struct vrb_pep *pep);
+	int (*reject)(struct vrb_pep *pep, struct vrb_connreq *connreq,
+		      const void *param, size_t paramlen);
+
+	// Progress and event handling
+	ssize_t (*progress)(struct vrb_eq *eq, uint32_t *event,
+			    void *buf, size_t len);
+
+	// Resource management
+	int (*ep_init)(struct vrb_ep *ep, struct fi_info *info);
+	int (*ep_close)(struct vrb_ep *ep);
+	int (*ep_bind)(struct vrb_ep *ep, struct vrb_eq *eq);
+	int (*ep_enable)(struct vrb_ep *ep, struct ibv_qp_init_attr *attr);
+	int (*ep_setname)(struct vrb_ep *ep, void *addr, size_t addrlen);
+	int (*ep_getname)(struct vrb_ep *ep, void *addr, size_t *addrlen);
+	int (*pep_init)(struct vrb_pep *pep);
+	int (*pep_close)(struct vrb_pep *pep);
+	int (*pep_bind)(struct vrb_pep *pep, struct vrb_eq *eq);
+	int (*domain_init)(struct vrb_domain *domain);
+	int (*domain_close)(struct vrb_domain *domain);
+	int (*eq_open)(struct vrb_eq *eq);
+	int (*eq_close)(struct vrb_eq *eq);
+
+	// Address resolution
+	int (*setname)(struct vrb_pep *pep, void *addr, size_t addrlen);
+	int (*getname)(struct vrb_pep *pep, void *addr, size_t *addrlen);
+	int (*getpeer)(struct vrb_ep *ep, void *addr, size_t *addrlen);
+
+	// Name for debugging
+	int cm_backend;
+};
 
 enum vrb_op_queue {
 	VRB_OP_SQ,
@@ -743,6 +838,16 @@ extern struct fi_ops_rma vrb_msg_ep_rma_ops_ts;
 extern struct fi_ops_rma vrb_msg_ep_rma_ops;
 extern struct fi_ops_rma vrb_msg_xrc_ep_rma_ops_ts;
 extern struct fi_ops_rma vrb_msg_xrc_ep_rma_ops;
+extern struct vrb_cm_ops vrb_rdmacm_ops;
+int vrb_copy_addr(void *dst_addr, size_t *dst_addrlen, void *src_addr);
+void vrb_msg_ep_prepare_cm_data(const void *param, size_t param_size,
+				    struct vrb_cm_data_hdr *cm_hdr);
+int vrb_eq_copy_event_data(struct fi_eq_cm_entry *entry,
+				   size_t max_dest_len, const void *priv_data,
+				   size_t priv_datalen);
+void vrb_eq_skip_xrc_cm_data(const void **priv_data, size_t *priv_data_len);
+void vrb_eq_xrc_disconnect_event(struct vrb_eq *eq,
+				     struct rdma_cm_event *cma_event, int *acked);
 
 #define VRB_XRC_VERSION	2
 
@@ -797,8 +902,6 @@ void vrb_eq_remove_sidr_conn(struct vrb_xrc_ep *ep);
 
 void vrb_msg_ep_get_qp_attr(struct vrb_ep *ep,
 			       struct ibv_qp_init_attr *attr);
-void vrb_msg_ep_prepare_rdma_cm_hdr(void *priv_data,
-				    const struct rdma_cm_id *id);
 
 int vrb_process_xrc_connreq(struct vrb_ep *ep,
 			       struct vrb_connreq *connreq);
@@ -810,6 +913,19 @@ void vrb_eq_clear_xrc_conn_tag(struct vrb_xrc_ep *ep);
 void vrb_set_xrc_cm_data(struct vrb_xrc_cm_data *local, int reciprocal,
 			    uint32_t conn_tag, uint16_t port, uint32_t tgt_qpn,
 			    uint32_t srqn);
+int vrb_eq_xrc_connreq_event(struct vrb_eq *eq, struct fi_eq_cm_entry *entry,
+			     size_t len, uint32_t *event,
+			     struct rdma_cm_event *cma_event, int *acked,
+			     const void **priv_data, size_t *priv_datalen);
+int vrb_eq_xrc_rej_event(struct vrb_eq *eq, struct rdma_cm_event *cma_event);
+int vrb_eq_xrc_cm_err_event(struct vrb_eq *eq, struct rdma_cm_event *cma_event,
+			    int *acked);
+ssize_t vrb_eq_xrc_connected_event(struct vrb_eq *eq,
+				   struct rdma_cm_event *cma_event, int *acked,
+				   struct fi_eq_cm_entry *entry, size_t len,
+				   uint32_t *event);
+void vrb_eq_xrc_timewait_event(struct vrb_eq *eq,
+			       struct rdma_cm_event *cma_event, int *acked);
 int vrb_verify_xrc_cm_data(struct vrb_xrc_cm_data *remote,
 			      int private_data_len);
 int vrb_connect_xrc(struct vrb_xrc_ep *ep, struct sockaddr *addr,
@@ -820,12 +936,18 @@ int vrb_resend_shared_accept_xrc(struct vrb_xrc_ep *ep,
 				    struct vrb_connreq *connreq,
 				    struct rdma_cm_id *id);
 void vrb_free_xrc_conn_setup(struct vrb_xrc_ep *ep, int disconnect);
+int vrb_xrc_migrade_rdma_id(struct vrb_xrc_ep *ep);
 void vrb_add_pending_ini_conn(struct vrb_xrc_ep *ep, int reciprocal,
 				 void *conn_param, size_t conn_paramlen);
 void vrb_sched_ini_conn(struct vrb_ini_shared_conn *ini_conn);
 int vrb_get_shared_ini_conn(struct vrb_xrc_ep *ep,
 			       struct vrb_ini_shared_conn **ini_conn);
 void vrb_put_shared_ini_conn(struct vrb_xrc_ep *ep);
+void _vrb_put_shared_ini_conn(struct vrb_xrc_ep *ep);
+int vrb_create_ini_qp(struct vrb_xrc_ep *ep);
+void vrb_create_shutdown_event(struct vrb_xrc_ep *ep);
+int vrb_process_ini_conn(struct vrb_xrc_ep *ep, int reciprocal,
+				   void *param, size_t paramlen);
 
 void vrb_save_priv_data(struct vrb_xrc_ep *ep, const void *data,
 			   size_t len);

--- a/prov/verbs/src/windows/verbs_nd_ibv.c
+++ b/prov/verbs/src/windows/verbs_nd_ibv.c
@@ -946,3 +946,11 @@ int ibv_post_srq_recv(struct ibv_srq *srq, struct ibv_recv_wr *recv_wr,
 	VRB_TRACE(FI_LOG_FABRIC, "\n");
 	return ENOSYS;
 }
+
+ssize_t _ibv_query_gid_table(struct ibv_context *context,
+							 struct ibv_gid_entry *entries, size_t max_entries,
+							 uint32_t flags)
+{
+	VRB_TRACE(FI_LOG_FABRIC, "\n");
+	return ENOSYS;
+}

--- a/src/common.c
+++ b/src/common.c
@@ -971,6 +971,8 @@ int ofi_addr_cmp(const struct fi_provider *prov, const struct sockaddr *sa1,
 		return cmp ? cmp : memcmp(&ofi_sin6_port(sa1),
 					  &ofi_sin_port(sa2),
 					  sizeof(ofi_sin6_port(sa1)));
+	case AF_IB:
+		return memcmp(sa1, sa2, sizeof(struct ofi_sockaddr_ib));
 	default:
 		FI_WARN(prov, FI_LOG_FABRIC, "Invalid address format!\n");
 		assert(0);

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -261,6 +261,7 @@ static void ofi_tostr_protocol(char *buf, size_t len, uint32_t protocol)
 	CASEENUMSTRN(FI_PROTO_CXI_RNR, len);
 	CASEENUMSTRN(FI_PROTO_LPP, len);
 	CASEENUMSTRN(FI_PROTO_LNX, len);
+	CASEENUMSTRN(FI_PROTO_UD_CM_IB_RC, len);
 	default:
 		ofi_strncatf(buf, len, "Unknown");
 		break;

--- a/util/info.c
+++ b/util/info.c
@@ -191,6 +191,7 @@ static int str2addr_format(char *inputstr, uint32_t *value)
 	ORCASE(FI_ADDR_STR);
 	ORCASE(FI_ADDR_PSMX2);
 	ORCASE(FI_ADDR_EFA);
+	ORCASE(FI_ADDR_IB_UD);
 
 	fprintf(stderr, "error: Unrecognized address format: %s\n", inputstr);
 


### PR DESCRIPTION
This set of changes creates a connection management abstraction based on the existing RDMA-CM touch points and introduces an alternative non-rdmacm based connection management system based on UD queue pairs.

This alternative CM (UDCM) removes the requirement for IP configuration and adds support for cross-subnet connections.  The bulk of the new implementation deals with negotiating new RC QPs over a centralized UD QP co-owned by PEP and Domain and managing QP state progression.  The UDCM includes timeout-based UD retry with controls for avoiding "thundering herd" as well as priority based sgid selection for RoCE; default settings attempt to mimic common RC QP setting selections made by rdma-cm.

RDMA-CM remains current default, selectable via FI_VERBS_PREFER_CM=(rdmacm|udcm), but this may change in the future.

*PR is marked DO_NOT_MERGE, we're still adding validation for this mode to Intel CI*