### PR TITLE
fabtests/pytest: Add Python ctypes bindings for libfabric and verbs

### DIFF
--- a/fabtests/pytest/efa/efa_common.py
+++ b/fabtests/pytest/efa/efa_common.py
@@ -339,28 +339,22 @@ def has_rdma(cmdline_args, operation):
 @functools.lru_cache(maxsize=None)
 def _has_rdma_cached(server_id, client_id, binpath, timeout, environments, operation):
     assert operation in ["read", "write", "writedata"]
-    binpath = binpath or ""
-    cmd = "timeout " + str(timeout) \
-          + " " + os.path.join(binpath, f"fi_efa_rdma_checker -o {operation}")
-    if environments:
-        cmd = environments + " " + cmd
-    server_proc = subprocess.run("ssh {} {}".format(server_id, cmd),
-               stdout=subprocess.PIPE,
-               stderr=subprocess.STDOUT,
-               shell=True,
-               universal_newlines=True)
-    if has_ssh_connection_err_msg(server_proc.stdout):
-        raise SshConnectionError()
 
-    client_proc = subprocess.run("ssh {} {}".format(client_id, cmd),
-               stdout=subprocess.PIPE,
-               stderr=subprocess.STDOUT,
-               shell=True,
-               universal_newlines=True)
-    if has_ssh_connection_err_msg(client_proc.stdout):
-        raise SshConnectionError()
+    def _check_host(host_id):
+        cmd = "timeout " + str(timeout) \
+              + " python3 -m ofi.efa_rdma_checker -o " + operation
+        if environments:
+            cmd = environments + " " + cmd
+        proc = subprocess.run("ssh {} {}".format(host_id, cmd),
+                   stdout=subprocess.PIPE,
+                   stderr=subprocess.STDOUT,
+                   shell=True,
+                   universal_newlines=True)
+        if has_ssh_connection_err_msg(proc.stdout):
+            raise SshConnectionError()
+        return proc.returncode == 0
 
-    return (server_proc.returncode == 0 and client_proc.returncode == 0)
+    return _check_host(server_id) and _check_host(client_id)
 
 def efa_retrieve_gid(hostname):
     """

--- a/fabtests/pytest/ofi/README.md
+++ b/fabtests/pytest/ofi/README.md
@@ -1,0 +1,95 @@
+# OFI Python Bindings (`fabtests/pytest/ofi/`)
+
+## Overview
+
+This package provides Python ctypes bindings for libfabric and related
+libraries (libibverbs, libefa). It allows pytest tests to call C library
+functions directly from Python, eliminating the need to compile and ship
+separate C test binaries for simple queries and checks.
+
+## Modules
+
+| Module | Description |
+|--------|-------------|
+| `_loader.py` | Shared library discovery and loading utility |
+| `libfabric.py` | Bindings for libfabric core API (`fi_getinfo`, `fi_freeinfo`, `fi_version`) |
+| `verbs.py` | Bindings for libibverbs and libefa (`ibv_get_device_list`, `efadv_query_device`) |
+| `efa_rdma_checker.py` | Python replacement for `fi_efa_rdma_checker` C binary |
+
+## Library Discovery
+
+Libraries are located in the following order:
+
+1. `OFI_LIB_PATH` environment variable (colon-separated directories)
+2. `LD_LIBRARY_PATH` (handled by the dynamic linker)
+3. System library paths (via `ctypes.util.find_library`)
+
+Example:
+```bash
+export OFI_LIB_PATH=/opt/amazon/efa/lib64:/usr/lib64
+```
+
+## Usage Examples
+
+### Check EFA RDMA capability (replaces fi_efa_rdma_checker)
+
+**As a CLI tool (drop-in replacement for the C binary):**
+```bash
+python3 -m ofi.efa_rdma_checker -o read
+python3 -m ofi.efa_rdma_checker -o write
+python3 -m ofi.efa_rdma_checker -o writedata
+```
+
+**Directly from Python test code:**
+```python
+from ofi.verbs import check_rdma_capability
+
+if check_rdma_capability("write"):
+    # RDMA write is supported
+    ...
+```
+
+### Query libfabric providers
+
+```python
+from ofi.libfabric import get_info, FI_EP_RDM, version
+
+print(f"libfabric version: {version()}")
+
+with get_info(provider="efa", ep_type=FI_EP_RDM) as infos:
+    for info in infos:
+        name = info.contents.domain_attr.contents.name
+        print(f"  domain: {name.decode()}")
+```
+
+### Enumerate IB devices
+
+```python
+from ofi.verbs import DeviceList, query_efa_device
+
+with DeviceList() as devices:
+    for dev_ptr, name in devices:
+        print(f"Device: {name}")
+        attr = query_efa_device(dev_ptr)
+        if attr:
+            print(f"  max_rdma_size: {attr.max_rdma_size}")
+            print(f"  device_caps: {attr.device_caps:#x}")
+```
+
+## Adding New Bindings
+
+To wrap additional library functions:
+
+1. Define ctypes structures matching the C headers
+2. Use `load_library("name")` from `_loader.py` to load the `.so`
+3. Set `.argtypes` and `.restype` on the function object
+4. Provide a Pythonic wrapper function
+
+## Notes
+
+- The `efadv_device_attr` struct layout is based on rdma-core. If the struct
+  changes in future rdma-core versions, update `verbs.py` accordingly.
+- Device pointers from `DeviceList` are only valid while the `DeviceList`
+  context manager is active (before `ibv_free_device_list` is called).
+- On macOS, the libraries won't load (no EFA/verbs support) — this is
+  expected. The bindings are designed for Linux hosts with EFA hardware.

--- a/fabtests/pytest/ofi/__init__.py
+++ b/fabtests/pytest/ofi/__init__.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only
+# SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved.
+
+"""
+Python ctypes bindings for libfabric and related libraries.
+
+This package provides thin ctypes wrappers around libfabric's C API,
+allowing pytest tests to call libfabric functions directly from Python
+instead of shelling out to compiled C test binaries.
+
+Usage:
+    from ofi import libfabric
+    info = libfabric.get_info(provider="efa")
+
+    from ofi import verbs
+    devices = verbs.get_device_list()
+"""
+
+from ofi.libfabric import FI_VERSION, get_info, version  # noqa: F401

--- a/fabtests/pytest/ofi/_loader.py
+++ b/fabtests/pytest/ofi/_loader.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only
+# SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved.
+
+"""
+Shared library loader utility for ctypes bindings.
+
+Handles finding and loading .so files by name, supporting both system-installed
+libraries and custom paths via environment variables.
+"""
+
+import ctypes
+import ctypes.util
+import os
+
+
+def load_library(name):
+    """
+    Load a shared library by short name (e.g. "fabric", "ibverbs", "efa").
+
+    Search order:
+      1. OFI_LIB_PATH environment variable (colon-separated directories)
+      2. LD_LIBRARY_PATH (handled by ctypes/dlopen)
+      3. System library paths (via ctypes.util.find_library)
+
+    Args:
+        name: Library short name without "lib" prefix or ".so" suffix.
+
+    Returns:
+        ctypes.CDLL object.
+
+    Raises:
+        OSError: If the library cannot be found.
+    """
+    lib_path = os.environ.get("OFI_LIB_PATH", "")
+    for directory in lib_path.split(":"):
+        if not directory:
+            continue
+        for suffix in (".so", ".dylib"):
+            path = os.path.join(directory, f"lib{name}{suffix}")
+            if os.path.isfile(path):
+                return ctypes.CDLL(path)
+
+    system_path = ctypes.util.find_library(name)
+    if system_path:
+        return ctypes.CDLL(system_path)
+
+    return ctypes.CDLL(f"lib{name}.so")

--- a/fabtests/pytest/ofi/efa_rdma_checker.py
+++ b/fabtests/pytest/ofi/efa_rdma_checker.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only
+# SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved.
+
+"""
+Python replacement for fi_efa_rdma_checker.
+
+Can be used as a CLI tool (drop-in replacement for the C binary) or imported
+and called directly from pytest tests.
+
+CLI usage:
+    python -m ofi.efa_rdma_checker -o read
+    python -m ofi.efa_rdma_checker -o write
+    python -m ofi.efa_rdma_checker -o writedata
+"""
+
+import argparse
+import sys
+
+from ofi.verbs import check_rdma_capability
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Check EFA RDMA capabilities")
+    parser.add_argument(
+        "-o", dest="operation", default="read",
+        choices=["read", "write", "writedata"],
+        help="RDMA operation type: read | write | writedata",
+    )
+    args = parser.parse_args()
+
+    try:
+        enabled = check_rdma_capability(args.operation)
+    except RuntimeError as e:
+        print(str(e), file=sys.stderr)
+        return 1
+
+    if enabled:
+        print(f"rdma {args.operation} is enabled")
+        return 0
+    else:
+        print(f"rdma {args.operation} is NOT enabled", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/fabtests/pytest/ofi/libfabric.py
+++ b/fabtests/pytest/ofi/libfabric.py
@@ -1,0 +1,296 @@
+# SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only
+# SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved.
+
+"""
+ctypes bindings for libfabric core API.
+
+Wraps fi_getinfo, fi_freeinfo, fi_version and related structures.
+"""
+
+import ctypes
+import ctypes.util
+from ctypes import (
+    POINTER,
+    Structure,
+    c_char_p,
+    c_int,
+    c_size_t,
+    c_uint8,
+    c_uint32,
+    c_uint64,
+    c_void_p,
+)
+
+from ofi._loader import load_library
+
+
+def FI_VERSION(major, minor):
+    return (major << 16) | minor
+
+
+# -- Opaque pointer types for fid-based objects --
+
+class fid(Structure):
+    _fields_ = [
+        ("fclass", c_size_t),
+        ("context", c_void_p),
+        ("ops", c_void_p),
+    ]
+
+
+class fid_fabric(Structure):
+    _fields_ = [("fid", fid)]
+
+
+class fid_domain(Structure):
+    _fields_ = [("fid", fid)]
+
+
+class fid_nic(Structure):
+    pass
+
+
+# -- Attribute structures --
+
+class fi_tx_attr(Structure):
+    _fields_ = [
+        ("caps", c_uint64),
+        ("mode", c_uint64),
+        ("op_flags", c_uint64),
+        ("msg_order", c_uint64),
+        ("comp_order", c_uint64),
+        ("inject_size", c_size_t),
+        ("size", c_size_t),
+        ("iov_limit", c_size_t),
+        ("rma_iov_limit", c_size_t),
+        ("tclass", c_uint32),
+    ]
+
+
+class fi_rx_attr(Structure):
+    _fields_ = [
+        ("caps", c_uint64),
+        ("mode", c_uint64),
+        ("op_flags", c_uint64),
+        ("msg_order", c_uint64),
+        ("comp_order", c_uint64),
+        ("total_buffered_recv", c_size_t),
+        ("size", c_size_t),
+        ("iov_limit", c_size_t),
+    ]
+
+
+# fi_ep_type enum values
+FI_EP_UNSPEC = 0
+FI_EP_MSG = 1
+FI_EP_DGRAM = 2
+FI_EP_RDM = 3
+
+
+class fi_ep_attr(Structure):
+    _fields_ = [
+        ("type", c_int),
+        ("protocol", c_uint32),
+        ("protocol_version", c_uint32),
+        ("max_msg_size", c_size_t),
+        ("msg_prefix_size", c_size_t),
+        ("max_order_raw_size", c_size_t),
+        ("max_order_war_size", c_size_t),
+        ("max_order_waw_size", c_size_t),
+        ("mem_tag_format", c_uint64),
+        ("tx_ctx_cnt", c_size_t),
+        ("rx_ctx_cnt", c_size_t),
+        ("auth_key_size", c_size_t),
+        ("auth_key", POINTER(c_uint8)),
+    ]
+
+
+class fi_domain_attr(Structure):
+    _fields_ = [
+        ("domain", POINTER(fid_domain)),
+        ("name", c_char_p),
+        ("threading", c_int),
+        ("control_progress", c_int),
+        ("data_progress", c_int),
+        ("resource_mgmt", c_int),
+        ("av_type", c_int),
+        ("mr_mode", c_int),
+        ("mr_key_size", c_size_t),
+        ("cq_data_size", c_size_t),
+        ("cq_cnt", c_size_t),
+        ("ep_cnt", c_size_t),
+        ("tx_ctx_cnt", c_size_t),
+        ("rx_ctx_cnt", c_size_t),
+        ("max_ep_tx_ctx", c_size_t),
+        ("max_ep_rx_ctx", c_size_t),
+        ("max_ep_stx_ctx", c_size_t),
+        ("max_ep_srx_ctx", c_size_t),
+        ("cntr_cnt", c_size_t),
+        ("mr_iov_limit", c_size_t),
+        ("caps", c_uint64),
+        ("mode", c_uint64),
+        ("auth_key", POINTER(c_uint8)),
+        ("auth_key_size", c_size_t),
+        ("max_err_data", c_size_t),
+        ("mr_cnt", c_size_t),
+        ("tclass", c_uint32),
+        ("max_ep_auth_key", c_size_t),
+        ("max_group_id", c_uint32),
+        ("max_cntr_value", c_uint64),
+        ("max_err_cntr_value", c_uint64),
+    ]
+
+
+class fi_fabric_attr(Structure):
+    _fields_ = [
+        ("fabric", POINTER(fid_fabric)),
+        ("name", c_char_p),
+        ("prov_name", c_char_p),
+        ("prov_version", c_uint32),
+        ("api_version", c_uint32),
+    ]
+
+
+class fi_info(Structure):
+    pass
+
+
+fi_info._fields_ = [
+    ("next", POINTER(fi_info)),
+    ("caps", c_uint64),
+    ("mode", c_uint64),
+    ("addr_format", c_uint32),
+    ("src_addrlen", c_size_t),
+    ("dest_addrlen", c_size_t),
+    ("src_addr", c_void_p),
+    ("dest_addr", c_void_p),
+    ("handle", POINTER(fid)),
+    ("tx_attr", POINTER(fi_tx_attr)),
+    ("rx_attr", POINTER(fi_rx_attr)),
+    ("ep_attr", POINTER(fi_ep_attr)),
+    ("domain_attr", POINTER(fi_domain_attr)),
+    ("fabric_attr", POINTER(fi_fabric_attr)),
+    ("nic", POINTER(fid_nic)),
+]
+
+
+# -- Library loading and function binding --
+
+_lib = None
+
+
+def _get_lib():
+    global _lib
+    if _lib is None:
+        _lib = load_library("fabric")
+        _lib.fi_getinfo.argtypes = [
+            c_uint32, c_char_p, c_char_p, c_uint64,
+            POINTER(fi_info), POINTER(POINTER(fi_info)),
+        ]
+        _lib.fi_getinfo.restype = c_int
+        _lib.fi_freeinfo.argtypes = [POINTER(fi_info)]
+        _lib.fi_freeinfo.restype = None
+        _lib.fi_allocinfo.argtypes = []
+        _lib.fi_allocinfo.restype = POINTER(fi_info)
+        _lib.fi_version.argtypes = []
+        _lib.fi_version.restype = c_uint32
+    return _lib
+
+
+# -- Public API --
+
+def version():
+    """Return the libfabric version as (major, minor) tuple."""
+    lib = _get_lib()
+    v = lib.fi_version()
+    return (v >> 16, v & 0xFFFF)
+
+
+def get_info(provider=None, ep_type=None, caps=0, node=None, service=None, flags=0):
+    """
+    Call fi_getinfo and return a list of fi_info results.
+
+    Args:
+        provider: Provider name filter (e.g. "efa", "tcp")
+        ep_type: Endpoint type (FI_EP_RDM, FI_EP_DGRAM, etc.)
+        caps: Capability flags
+        node: Node address
+        service: Service/port
+        flags: fi_getinfo flags
+
+    Returns:
+        List of fi_info pointer objects. Caller must call free_info() when done.
+    """
+    lib = _get_lib()
+    ver = lib.fi_version()
+
+    hints = lib.fi_allocinfo()
+    if not hints:
+        raise MemoryError("fi_allocinfo failed")
+
+    if caps:
+        hints.contents.caps = caps
+
+    if ep_type is not None:
+        hints.contents.ep_attr.contents.type = ep_type
+
+    if provider:
+        prov_bytes = provider.encode() if isinstance(provider, str) else provider
+        hints.contents.fabric_attr.contents.prov_name = prov_bytes
+
+    node_b = node.encode() if isinstance(node, str) else node
+    service_b = service.encode() if isinstance(service, str) else service
+
+    info_ptr = POINTER(fi_info)()
+    ret = lib.fi_getinfo(ver, node_b, service_b, flags, hints, ctypes.byref(info_ptr))
+
+    lib.fi_freeinfo(hints)
+
+    if ret != 0:
+        return []
+
+    results = []
+    current = info_ptr
+    while current:
+        results.append(current)
+        nxt = current.contents.next
+        current = nxt if nxt else None
+
+    return InfoList(info_ptr, results)
+
+
+class InfoList:
+    """
+    Wrapper around fi_info linked list that supports iteration and auto-cleanup.
+    """
+
+    def __init__(self, head_ptr, items):
+        self._head = head_ptr
+        self._items = items
+        self._freed = False
+
+    def __iter__(self):
+        return iter(self._items)
+
+    def __len__(self):
+        return len(self._items)
+
+    def __getitem__(self, idx):
+        return self._items[idx]
+
+    def __bool__(self):
+        return len(self._items) > 0
+
+    def free(self):
+        if not self._freed and self._head:
+            _get_lib().fi_freeinfo(self._head)
+            self._freed = True
+
+    def __del__(self):
+        self.free()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.free()

--- a/fabtests/pytest/ofi/verbs.py
+++ b/fabtests/pytest/ofi/verbs.py
@@ -1,0 +1,218 @@
+# SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only
+# SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved.
+
+"""
+ctypes bindings for libibverbs and libefa (rdma-core).
+
+Provides access to ibv_get_device_list, ibv_open_device, efadv_query_device
+and related functions needed for device capability queries.
+"""
+
+import ctypes
+from ctypes import (
+    POINTER,
+    Structure,
+    c_char_p,
+    c_int,
+    c_uint8,
+    c_uint16,
+    c_uint32,
+    c_uint64,
+    c_void_p,
+)
+
+from ofi._loader import load_library
+
+# -- ibv structures (minimal, opaque where possible) --
+
+
+class ibv_device(Structure):
+    _fields_ = [
+        ("_ops", c_void_p),
+        ("node_type", c_int),
+        ("transport_type", c_int),
+        ("name", ctypes.c_char * 64),
+        ("dev_name", ctypes.c_char * 64),
+        ("dev_path", ctypes.c_char * 256),
+        ("ibdev_path", ctypes.c_char * 256),
+    ]
+
+
+class ibv_context(Structure):
+    _fields_ = [
+        ("device", POINTER(ibv_device)),
+        ("cmd_fd", c_int),
+        ("async_fd", c_int),
+    ]
+
+
+class efadv_device_attr(Structure):
+    _fields_ = [
+        ("comp_mask", c_uint32),
+        ("max_sq_wr", c_uint32),
+        ("max_rq_wr", c_uint32),
+        ("max_sq_sge", c_uint16),
+        ("max_rq_sge", c_uint16),
+        ("inline_buf_size", c_uint16),
+        ("_reserved", c_uint8),
+        ("device_caps", c_uint32),
+        ("max_rdma_size", c_uint32),
+    ]
+
+
+# efadv device capability flags
+EFADV_DEVICE_ATTR_CAPS_RDMA_READ = 1 << 0
+EFADV_DEVICE_ATTR_CAPS_RDMA_WRITE = 1 << 1
+EFADV_DEVICE_ATTR_CAPS_UNSOLICITED_WRITE_RECV = 1 << 2
+
+
+# -- Library handles --
+
+_ibverbs = None
+_efadv = None
+
+
+def _get_ibverbs():
+    global _ibverbs
+    if _ibverbs is None:
+        _ibverbs = load_library("ibverbs")
+        _ibverbs.ibv_get_device_list.argtypes = [POINTER(c_int)]
+        _ibverbs.ibv_get_device_list.restype = POINTER(POINTER(ibv_device))
+        _ibverbs.ibv_free_device_list.argtypes = [POINTER(POINTER(ibv_device))]
+        _ibverbs.ibv_free_device_list.restype = None
+        _ibverbs.ibv_open_device.argtypes = [POINTER(ibv_device)]
+        _ibverbs.ibv_open_device.restype = POINTER(ibv_context)
+        _ibverbs.ibv_close_device.argtypes = [POINTER(ibv_context)]
+        _ibverbs.ibv_close_device.restype = c_int
+        _ibverbs.ibv_get_device_name.argtypes = [POINTER(ibv_device)]
+        _ibverbs.ibv_get_device_name.restype = c_char_p
+    return _ibverbs
+
+
+def _get_efadv():
+    global _efadv
+    if _efadv is None:
+        _efadv = load_library("efa")
+        _efadv.efadv_query_device.argtypes = [
+            POINTER(ibv_context), POINTER(efadv_device_attr), c_uint32,
+        ]
+        _efadv.efadv_query_device.restype = c_int
+    return _efadv
+
+
+# -- Public API --
+
+
+class DeviceList:
+    """
+    Context manager for ibv_device_list. Device pointers are only valid
+    while this object is alive (before free() is called).
+    """
+
+    def __init__(self):
+        lib = _get_ibverbs()
+        self._lib = lib
+        num_devices = c_int(0)
+        self._raw = lib.ibv_get_device_list(ctypes.byref(num_devices))
+        self._count = num_devices.value if self._raw else 0
+        self.devices = []
+        for i in range(self._count):
+            dev = self._raw[i]
+            name = lib.ibv_get_device_name(dev)
+            self.devices.append((dev, name.decode() if name else ""))
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.free()
+
+    def __len__(self):
+        return self._count
+
+    def __iter__(self):
+        return iter(self.devices)
+
+    def free(self):
+        if self._raw:
+            self._lib.ibv_free_device_list(self._raw)
+            self._raw = None
+
+
+def query_efa_device(device_ptr):
+    """
+    Query EFA device attributes for a given ibv_device pointer.
+
+    The caller must ensure the device list has not been freed.
+
+    Args:
+        device_ptr: Pointer to ibv_device from DeviceList.
+
+    Returns:
+        efadv_device_attr on success, None if not an EFA device.
+
+    Raises:
+        RuntimeError: On unexpected query failure.
+    """
+    ibv = _get_ibverbs()
+    efa = _get_efadv()
+
+    ctx = ibv.ibv_open_device(device_ptr)
+    if not ctx:
+        raise RuntimeError("ibv_open_device failed")
+
+    attr = efadv_device_attr()
+    ctypes.memset(ctypes.byref(attr), 0, ctypes.sizeof(attr))
+    err = efa.efadv_query_device(ctx, ctypes.byref(attr), ctypes.sizeof(attr))
+    ibv.ibv_close_device(ctx)
+
+    if err != 0:
+        import errno as _errno
+        if err == _errno.EOPNOTSUPP:
+            return None
+        raise RuntimeError(f"efadv_query_device failed with error {err}")
+
+    return attr
+
+
+def check_rdma_capability(operation):
+    """
+    Check whether EFA RDMA read/write/writedata is enabled on this host.
+
+    This is the Python equivalent of fi_efa_rdma_checker.
+
+    Args:
+        operation: One of "read", "write", "writedata"
+
+    Returns:
+        True if the capability is enabled, False otherwise.
+
+    Raises:
+        ValueError: If operation is not recognized.
+        RuntimeError: If no EFA device is found or query fails.
+    """
+    if operation not in ("read", "write", "writedata"):
+        raise ValueError(f"Unknown operation '{operation}'. Allowed: read, write, writedata")
+
+    with DeviceList() as dev_list:
+        if not len(dev_list):
+            raise RuntimeError("No ibv device found")
+
+        for device_ptr, name in dev_list:
+            attr = query_efa_device(device_ptr)
+            if attr is None:
+                continue
+
+            if attr.max_rdma_size == 0:
+                return False
+
+            if operation == "read":
+                return True
+
+            if operation == "write":
+                return bool(attr.device_caps & EFADV_DEVICE_ATTR_CAPS_RDMA_WRITE)
+
+            if operation == "writedata":
+                return bool(attr.device_caps & EFADV_DEVICE_ATTR_CAPS_UNSOLICITED_WRITE_RECV)
+
+    raise RuntimeError("No EFA device found")


### PR DESCRIPTION
Add an `ofi` Python package under fabtests/pytest that provides ctypes wrappers for calling libfabric, libibverbs, and libefa functions directly from Python. This enables replacing compiled C test utilities with pure Python equivalents that are easier to maintain and extend.

The package includes:
- _loader.py: shared library discovery (OFI_LIB_PATH, system paths)
- libfabric.py: fi_getinfo, fi_freeinfo, fi_version, attribute structs
- verbs.py: ibv_get_device_list, efadv_query_device, capability checks
- efa_rdma_checker.py: Python replacement for fi_efa_rdma_checker

Update efa_common.py to use the Python rdma checker via `python3 -m ofi.efa_rdma_checker` instead of the C binary.