### PR TITLE
prov/shm: Fix the error flag propagation

### DIFF
--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -361,7 +361,8 @@ static int smr_progress_pending_sar(struct smr_ep *ep, struct smr_cmd *cmd)
 			dlist_insert_tail(&pend->entry, &ep->async_cpy_list);
 			return FI_SUCCESS;
 		}
-		cmd->hdr.smr_flags |= SMR_OP_ERROR;
+		if (ret)
+			cmd->hdr.smr_flags |= SMR_OP_ERROR;
 		goto out;
 	}
 


### PR DESCRIPTION
For successful operation, we shouldn't set SMR_OP_ERROR flags.

fixes: 82e783256c043edf2304aa47dc418608c0a93bf6