### PR TITLE
prov/shm: do not return local cmd copy in smr_discard

### DIFF
--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -727,7 +727,8 @@ static int smr_discard(struct fi_peer_rx_entry *rx_entry)
 		ofi_buf_free(sar_buf);
 	}
 
-	if (cmd_ctx->cmd->hdr.smr_flags & SMR_RETURN_CMD)
+	if (cmd_ctx->cmd != &cmd_ctx->cmd_cpy &&
+	    (cmd_ctx->cmd->hdr.smr_flags & SMR_RETURN_CMD))
 		smr_return_cmd(cmd_ctx->ep, cmd_ctx->cmd);
 
 	ofi_buf_free(cmd_ctx);


### PR DESCRIPTION
  `f1ca63541` changed `smr_discard` to call `smr_return_cmd(cmd_ctx->cmd)`
  whenever `SMR_RETURN_CMD` is set. For SAR and the buffered iov/ipc paths,
  `cmd_ctx->cmd` points to the local `cmd_cpy`, not the borrowed command in the
  peer region (the original was already returned during unexpected-message
  processing). `smr_return_cmd` computes `offset = cmd - peer_smr`, so the local
  copy produces an out-of-bounds pointer and trips the bounds assert
  (`fi_efa_rdm_remote_exit_early`, sizes ≥ 8 KB). `peer_smr` is valid/non-NULL —
  this is not a NULL deref.

  Fix: only return the command when `cmd_ctx->cmd` still points at the borrowed
  peer command (not the local copy):

  ```c
  if (cmd_ctx->cmd != &cmd_ctx->cmd_cpy &&
      (cmd_ctx->cmd->hdr.smr_flags & SMR_RETURN_CMD))
      smr_return_cmd(cmd_ctx->ep, cmd_ctx->cmd);