### PR TITLE
[v2.6.x] Revert "prov/verbs: Enable logging of ibv_async_events"

### DIFF
--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -159,8 +159,8 @@ static int vrb_domain_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 		switch (domain->ep_type) {
 		case FI_EP_MSG:
 			eq = container_of(bfid, struct vrb_eq, eq_fid);
+			domain->eq = eq;
 			domain->eq_flags = flags;
-			vrb_eq_attach_domain(eq, domain);
 			break;
 		case FI_EP_DGRAM:
 			return -FI_EINVAL;
@@ -222,12 +222,6 @@ static int vrb_domain_close(fid_t fid)
 		if (ret)
 			return -ret;
 		domain->pd = NULL;
-	}
-
-	if (domain->eq) {
-		ret = vrb_eq_detach_domain(domain);
-		if (ret)
-			return -ret;
 	}
 
 	ret = ofi_domain_close(&domain->util_domain);
@@ -436,10 +430,6 @@ vrb_domain(struct fid_fabric *fabric, struct fi_info *info,
 		ret = -FI_EINVAL;
 		goto err4;
 	}
-
-	ret = fi_fd_nonblock(_domain->verbs->async_fd);
-	if (ret)
-		goto err4;
 
 	ret = vrb_init_progress(&_domain->progress, _domain->info);
 	if (ret)

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -1294,32 +1294,9 @@ out:
 	return ret;
 }
 
-static void vrb_eq_process_async_events(struct vrb_eq *eq)
-{
-	int ret;
-	struct vrb_domain *domain;
-	struct ibv_async_event async_event;
-
-	ofi_mutex_lock(&eq->fab->util_fabric.lock);
-	dlist_foreach_container(&eq->fab->util_fabric.domain_list,
-				struct vrb_domain, domain,
-				util_domain.list_entry) {
-		do {
-			ret = ibv_get_async_event(domain->verbs, &async_event);
-			if (!ret) {
-				VRB_WARN(FI_LOG_DOMAIN, "Async event for %s: %s\n",
-					 eq->fab->info->domain_attr->name,
-					 ibv_event_type_str(async_event.event_type));
-				ibv_ack_async_event(&async_event);
-			}
-		} while (!ret);
-	}
-	ofi_mutex_unlock(&eq->fab->util_fabric.lock);
-}
-
 static ssize_t
 vrb_eq_read(struct fid_eq *eq_fid, uint32_t *event,
-	    void *buf, size_t len, uint64_t flags)
+	       void *buf, size_t len, uint64_t flags)
 {
 	struct vrb_eq *eq;
 	struct rdma_cm_event *cma_event;
@@ -1345,8 +1322,7 @@ vrb_eq_read(struct fid_eq *eq_fid, uint32_t *event,
 		vrb_prof_func_end("rdma_get_cm_event");
 		if (ret) {
 			ofi_mutex_unlock(&eq->event_lock);
-			ret = -errno;
-			goto out;
+			return -errno;
 		}
 		vrb_prof_func_start("vrb_eq_cm_process_event");
 		ret = vrb_eq_cm_process_event(eq, cma_event, event, buf, len);
@@ -1357,9 +1333,7 @@ vrb_eq_read(struct fid_eq *eq_fid, uint32_t *event,
 
 	if (ret > 0 && flags & FI_PEEK)
 		ret = vrb_eq_write_event(eq, *event, buf, ret);
-out:
-	if (ret <= 0)
-		vrb_eq_process_async_events(eq);
+
 	vrb_prof_func_end(__func__);
 	return ret;
 }
@@ -1453,9 +1427,7 @@ static int vrb_eq_close(fid_t fid)
 	struct vrb_eq_entry *entry;
 
 	eq = container_of(fid, struct vrb_eq, eq_fid.fid);
-	/* TODO: use util code, if possible */
-	if (ofi_atomic_get32(&eq->ref))
-		return -FI_EBUSY;
+	/* TODO: use util code, if possible, and add ref counting */
 
 	if (!ofi_rbmap_empty(&eq->xrc.sidr_conn_rbmap))
 		VRB_WARN(FI_LOG_EP_CTRL, "SIDR connection RBmap not empty\n");
@@ -1568,8 +1540,6 @@ int vrb_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 	_eq->eq_fid.fid.ops = &vrb_eq_fi_ops;
 	_eq->eq_fid.ops = &vrb_eq_ops;
 
-	ofi_atomic_initialize32(&_eq->ref, 0);
-
 	*eq = &_eq->eq_fid;
 	return 0;
 err4:
@@ -1588,23 +1558,3 @@ err0:
 	return ret;
 }
 
-int vrb_eq_attach_domain(struct vrb_eq *eq, struct vrb_domain *domain)
-{
-	if (ofi_epoll_add(eq->epollfd, domain->verbs->async_fd,
-			  OFI_EPOLL_IN, domain))
-		return -errno;
-
-	domain->eq = eq;
-	ofi_atomic_inc32(&eq->ref);
-	return 0;
-}
-
-int vrb_eq_detach_domain(struct vrb_domain *domain)
-{
-	if (ofi_epoll_del(domain->eq->epollfd, domain->verbs->async_fd))
-		return -errno;
-
-	ofi_atomic_dec32(&domain->eq->ref);
-	domain->eq = NULL;
-	return 0;
-}

--- a/prov/verbs/src/verbs_ofi.h
+++ b/prov/verbs/src/verbs_ofi.h
@@ -338,8 +338,6 @@ struct vrb_eq {
 
 	ofi_epoll_t		epollfd;
 	enum fi_wait_obj	wait_obj;
-	ofi_atomic32_t		ref;
-
 
 	struct {
 		/* The connection key map is used during the XRC connection
@@ -446,9 +444,6 @@ struct vrb_domain {
 	/* for profiling */
 	vrb_profile_t		*profile;
 };
-
-int vrb_eq_attach_domain(struct vrb_eq *eq, struct vrb_domain *domain);
-int vrb_eq_detach_domain(struct vrb_domain *domain);
 
 struct vrb_cq;
 

--- a/prov/verbs/src/windows/verbs_nd_ibv.c
+++ b/prov/verbs/src/windows/verbs_nd_ibv.c
@@ -137,33 +137,6 @@ const char *ibv_get_device_name(struct ibv_device *device)
 	return device->name;
 }
 
-/*
- * async event methods are implemented for compatibility
- * but are not currently supported
-*/
-
-int ibv_get_async_event(struct ibv_context *context,
-			struct ibv_async_event *event)
-{
-	VRB_TRACE(FI_LOG_FABRIC, "\n");
-	/*
-	* Normally we use ENOSYS for unsupported features
-	* but ibv_get_async_event returns only -1 for any error.
-	*/
-	return -1;
-}
-
-void ibv_ack_async_event(struct ibv_async_event *event)
-{
-	VRB_TRACE(FI_LOG_FABRIC, "\n");
-}
-
-const char *ibv_event_type_str(enum ibv_event_type event)
-{
-	VRB_TRACE(FI_LOG_FABRIC, "\n");
-	return NULL;
-}
-
 // infiniband/verbs.h defines ibv_query_port to be ___ibv_query_port
 int ___ibv_query_port(struct ibv_context *context, uint8_t port_num,
 		      struct ibv_port_attr *port_attr)


### PR DESCRIPTION
This reverts commit 39b14cb87ca81d38c76bfa5028e8555af0ccf3a8.

relates to #12181


(cherry picked from commit 67ec195976e14bd5e606478d9579f4ee30a42706)