### PR TITLE
Revert "prov/shm: enable sender-CMA fast path for writedata"

### DIFF
--- a/prov/shm/src/smr_init.c
+++ b/prov/shm/src/smr_init.c
@@ -43,7 +43,6 @@ struct smr_env smr_env = {
 	.max_gdrcopy_size = SMR_MAX_GDRCOPY_SIZE,
 	.use_xpmem = false,
 	.buffer_threshold = 1,
-	.rma_fast_size = SMR_RMA_FAST_SIZE,
 };
 
 static void smr_init_env(void)
@@ -56,8 +55,6 @@ static void smr_init_env(void)
 	fi_param_get_bool(&smr_prov, "use_xpmem", &smr_env.use_xpmem);
 	fi_param_get_size_t(&smr_prov, "buffer_threshold",
 			    &smr_env.buffer_threshold);
-	fi_param_get_size_t(&smr_prov, "rma_fast_size",
-			    &smr_env.rma_fast_size);
 }
 
 static void smr_resolve_addr(const char *node, const char *service,
@@ -227,11 +224,6 @@ SHM_INI
 	fi_param_define(&smr_prov, "use_xpmem", FI_PARAM_BOOL,
 			"Enable XPMEM over CMA when possible "
 			"(default: false)");
-	fi_param_define(&smr_prov, "rma_fast_size", FI_PARAM_SIZE_T,
-			"Maximum message size for sender-CMA RMA fast"
-			" path (default: %zu). Messages larger than this"
-			" use receiver-CMA for better pipelining.",
-			 SMR_RMA_FAST_SIZE);
 	fi_param_define(&smr_prov, "buffer_threshold", FI_PARAM_SIZE_T,
 			"When to start requesting forced unexpected messaging "
 			"buffering. (default: 1)");

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -1355,15 +1355,6 @@ static void smr_progress_cmd(struct smr_ep *ep)
 			ret = smr_progress_cmd_rma(ep, cmd);
 			break;
 		case ofi_op_write_async:
-			if (cmd->hdr.smr_flags & SMR_REMOTE_CQ_DATA) {
-				ret = smr_complete_rx(ep, NULL, ofi_op_write,
-					smr_rx_cq_flags(0, cmd->hdr.smr_flags),
-					cmd->hdr.size, NULL, cmd->hdr.rx_id, 0,
-					cmd->hdr.cq_data);
-				break;
-			}
-			ofi_ep_peer_rx_cntr_inc(&ep->util_ep, cmd->hdr.op);
-			break;
 		case ofi_op_read_async:
 			ofi_ep_peer_rx_cntr_inc(&ep->util_ep, cmd->hdr.op);
 			break;

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -44,21 +44,17 @@ static void smr_add_rma_cmd(struct smr_region *peer_smr,
 static void smr_format_rma_resp(struct smr_cmd *cmd, int64_t peer_id,
 				const struct fi_rma_iov *rma_iov, size_t count,
 				size_t total_len, uint32_t op,
-				uint64_t data, uint64_t op_flags)
+				uint64_t op_flags)
 {
-	smr_generic_format(cmd, 0, peer_id, op, 0, data, op_flags);
+	smr_generic_format(cmd, 0, peer_id, op, 0, 0, op_flags);
 	cmd->hdr.size = total_len;
-	if (op_flags & FI_REMOTE_CQ_DATA) {
-		cmd->hdr.cq_data = data;
-		cmd->hdr.smr_flags |= SMR_REMOTE_CQ_DATA;
-	}
 }
 
 static ssize_t smr_rma_fast(struct smr_ep *ep, struct smr_region *peer_smr,
 			    const struct iovec *iov, size_t iov_count,
 			    const struct fi_rma_iov *rma_iov, size_t rma_count,
 			    void **desc, int rx_id, int tx_id, void *context,
-			    uint32_t op, uint64_t data, uint64_t op_flags)
+			    uint32_t op, uint64_t op_flags)
 {
 	struct iovec vma_iovec[SMR_IOV_LIMIT], rma_iovec[SMR_IOV_LIMIT];
 	struct ofi_xpmem_client *xpmem;
@@ -95,7 +91,7 @@ static ssize_t smr_rma_fast(struct smr_ep *ep, struct smr_region *peer_smr,
 
 	smr_format_rma_resp(cmd, rx_id, rma_iov, rma_count, total_len,
 			    (op == ofi_op_write) ? ofi_op_write_async :
-			    ofi_op_read_async, data, op_flags);
+			    ofi_op_read_async, op_flags);
 
 	smr_cmd_queue_commit(cmd, pos);
 
@@ -110,16 +106,16 @@ static ssize_t smr_rma_fast(struct smr_ep *ep, struct smr_region *peer_smr,
 
 static inline bool smr_do_fast_rma(struct smr_ep *ep, uint64_t op_flags,
 				   size_t rma_count, size_t total_len,
-				   struct smr_region *peer_smr, uint32_t op)
+				   struct smr_region *peer_smr)
 {
 	struct smr_domain *domain;
 
 	domain = container_of(ep->util_ep.domain, struct smr_domain,
 			      util_domain);
 
-	return domain->fast_rma && !(op_flags & FI_DELIVERY_COMPLETE) &&
-		     rma_count == 1 && smr_vma_enabled(ep, peer_smr) &&
-		     (op == ofi_op_read_req || total_len <= smr_env.rma_fast_size);
+	return domain->fast_rma && !(op_flags &
+		    (FI_REMOTE_CQ_DATA | FI_DELIVERY_COMPLETE)) &&
+		     rma_count == 1 && smr_vma_enabled(ep, peer_smr);
 
 }
 
@@ -155,10 +151,10 @@ static ssize_t smr_generic_rma(
 		goto unlock;
 
 	total_len = ofi_total_iov_len(iov, iov_count);
-	if (smr_do_fast_rma(ep, op_flags, rma_count, total_len, peer_smr, op)) {
+	if (smr_do_fast_rma(ep, op_flags, rma_count, total_len, peer_smr)) {
 		ret = smr_rma_fast(ep, peer_smr, iov, iov_count, rma_iov,
 				   rma_count, desc, rx_id, tx_id, context, op,
-				   data, op_flags);
+				   op_flags);
 		goto unlock;
 	}
 

--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -50,7 +50,6 @@ struct smr_env {
 	size_t	max_gdrcopy_size;
 	int	use_xpmem;
 	size_t	buffer_threshold;
-	size_t	rma_fast_size;
 };
 
 extern struct smr_env smr_env;
@@ -186,7 +185,6 @@ static_assert(sizeof(struct smr_cmd) == SMR_CMD_SIZE,
 
 #define SMR_INJECT_SIZE		4096
 #define SMR_COMP_INJECT_SIZE	(SMR_INJECT_SIZE / 2)
-#define SMR_RMA_FAST_SIZE	16384
 #define SMR_MAX_GDRCOPY_SIZE    3072
 #define SMR_SAR_SIZE		32768
 


### PR DESCRIPTION
More benchmark showed that this change degraded writedata bandwidth in 8KB-16KB, revert it for now and revisit later.

This reverts commit 74a3b7fa736315d81cc175c849b1d1f99ca1bc93.