### PR TITLE
prov/efa: honor homogeneous_peers in efa_rdm_interop_rdma_read

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -337,9 +337,8 @@ bool efa_rdm_ep_support_rdma_read(struct efa_rdm_ep *ep)
 /**
  * @brief determine if both peers support RDMA read
  *
- * This function can only return true if peers are homogeneous,
- * or a handshake packet has already been exchanged and the peer
- * set the EFA_RDM_EXTRA_FEATURE_RDMA_READ flag.
+ * This function can only return true if a handshake packet has already
+ * been exchanged and the peer set the EFA_RDM_EXTRA_FEATURE_RDMA_READ flag.
  * @params[in]		ep		Endpoint for communication with peer
  * @params[in]		peer		An EFA peer
  * @return		boolean		both self and peer support RDMA read
@@ -348,7 +347,7 @@ static inline
 bool efa_both_support_rdma_read(struct efa_rdm_ep *ep, struct efa_rdm_peer *peer)
 {
 	return efa_rdm_ep_support_rdma_read(ep) &&
-	       (ep->homogeneous_peers || peer->is_self || efa_rdm_peer_support_rdma_read(peer));
+	       efa_rdm_peer_support_rdma_read(peer);
 }
 
 /**
@@ -376,10 +375,12 @@ bool efa_both_support_rdma_read(struct efa_rdm_ep *ep, struct efa_rdm_peer *peer
 static inline
 bool efa_rdm_interop_rdma_read(struct efa_rdm_ep *ep, struct efa_rdm_peer *peer)
 {
-	bool rdma_read_support = efa_both_support_rdma_read(ep, peer);
 	uint32_t ep_dev_ver, peer_dev_ver;
 
-	if (!rdma_read_support)
+	if (ep->homogeneous_peers || peer->is_self)
+		return efa_rdm_ep_support_rdma_read(ep);
+
+	if (!efa_both_support_rdma_read(ep, peer))
 		return false;
 
 	ep_dev_ver = efa_rdm_ep_domain(ep)->device->ibv_attr.vendor_part_id;


### PR DESCRIPTION
efa_rdm_interop_rdma_read() gates RDMA-read interop on a comparison of the local and peer EFA device generation (vendor_part_id vs peer->device_version). peer->device_version is only populated from the peer's handshake packet and is 0 before the handshake is received.

FI_OPT_EFA_HOMOGENEOUS_PEERS is meant to allow read-based protocols to be selected without first completing a handshake. It is honored by efa_both_support_rdma_read(), but the subsequent device-version check in efa_rdm_interop_rdma_read() was not, so when the read protocol is selected before the handshake arrives, the comparison uses peer->device_version == 0 and returns false. The sender then falls back to the eager protocol instead of read.

This manifests as an intermittent (~5%) failure of fabtests test_transfer_with_read_protocol_cuda (fi_efa_runt_read_no_handshake): the single no-warmup message races the handshake and is occasionally sent eager, recording 0 RDMA-read bytes (assert 0 == 1024).

Homogeneous peers (and loopback) are guaranteed to share this endpoint's device generation, so skip the device-version comparison and report interop supported, consistent with efa_both_support_rdma_read().