### PR TITLE
[v2.6.x] Cherry-picked fixes for v2.6.0rc2

### DIFF
--- a/include/ofi_atomic_queue.h
+++ b/include/ofi_atomic_queue.h
@@ -33,7 +33,7 @@
 /* Code derived from Dmitry Vyukov */
 /* see:  https://www.1024cores.net/home/lock-free-algorithms/queues/bounded-mpmc-queue */
 
-/*  Multi-producer/multi-consumer bounded queue.
+/*  Multi-producer/single-consumer bounded queue.
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions
  *  are met:
@@ -110,10 +110,10 @@ struct name {							\
 	ofi_atomic64_t	write_pos;				\
 	uint8_t		pad0[OFI_CACHE_LINE_SIZE -		\
 			     sizeof(ofi_atomic64_t)];		\
-	ofi_atomic64_t	read_pos;				\
+	int64_t		read_pos;				\
 	ofi_aq_init_fn	init_fn;				\
 	uint8_t		pad1[OFI_CACHE_LINE_SIZE -		\
-			     (sizeof(ofi_atomic64_t) +		\
+			     (sizeof(int64_t) +			\
 			     sizeof(ofi_aq_init_fn))];		\
 	int		size;					\
 	int		size_mask;				\
@@ -132,7 +132,7 @@ static inline void name ## _init(struct name *aq, size_t size,	\
 	aq->size_mask = aq->size - 1;				\
 	aq->init_fn = init_fn;					\
 	ofi_atomic_initialize64(&aq->write_pos, 0);		\
-	ofi_atomic_initialize64(&aq->read_pos, 0);		\
+	aq->read_pos = 0;					\
 	for (i = 0; i < size; i++) {				\
 		ofi_atomic_initialize64(&aq->entry[i].seq, i);	\
 		if (aq->init_fn)				\
@@ -201,29 +201,16 @@ static inline void name ## _release(struct name *aq,		\
 static inline int name ## _head(struct name *aq,		\
 		entrytype **buf, int64_t *pos)			\
 {								\
-	int64_t diff, seq;					\
+	int64_t seq;						\
 	struct name ## _entry *ce;				\
 again:								\
-	*pos = ofi_atomic_load_explicit64(&aq->read_pos,	\
-			memory_order_relaxed);			\
-	for (;;) {						\
-		ce = &aq->entry[*pos & aq->size_mask];		\
-		seq = ofi_atomic_load_explicit64(&(ce->seq),	\
+	*pos = aq->read_pos;					\
+	ce = &aq->entry[*pos & aq->size_mask];			\
+	seq = ofi_atomic_load_explicit64(&(ce->seq),		\
 			memory_order_acquire);			\
-		diff = seq - (*pos + 1);			\
-		if (diff == 0) {				\
-			if (ofi_atomic_compare_exchange_weak64(	\
-				&aq->read_pos, pos,		\
-				*pos + 1))			\
-				break;				\
-		} else if (diff < 0) {				\
-			return -FI_ENOENT;			\
-		} else {					\
-			*pos = ofi_atomic_load_explicit64(	\
-				&aq->read_pos,			\
-				memory_order_relaxed);		\
-		}						\
-	}							\
+	if (seq != *pos + 1)					\
+		return -FI_ENOENT;				\
+	aq->read_pos = *pos + 1;				\
 	*buf = &ce->buf;					\
 	if (ce->noop) {						\
 		ce->noop = false;				\

--- a/include/ofi_tree.h
+++ b/include/ofi_tree.h
@@ -1,7 +1,8 @@
 /*
  * Copyright (c) 2015 Cray Inc. All rights reserved.
  * Copyright (c) 2018 Intel Corp, Inc.  All rights reserved.
- *
+ * Copyright (C) 2026 Cornelis Networks.
+ * 
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
  * General Public License (GPL) Version 2, available from the file
@@ -92,9 +93,15 @@ struct ofi_rbnode *ofi_rbmap_search(struct ofi_rbmap *map, void *key,
 		int (*compare)(struct ofi_rbmap *map, void *key, void *data));
 int ofi_rbmap_insert(struct ofi_rbmap *map, void *key, void *data,
 		struct ofi_rbnode **node);
+int ofi_rbmap_insert_at(struct ofi_rbmap *map, void *key, void *data,
+		struct ofi_rbnode **ret_node,
+		struct ofi_rbnode *prealloc);
 void ofi_rbmap_delete(struct ofi_rbmap *map, struct ofi_rbnode *node);
 int ofi_rbmap_find_delete(struct ofi_rbmap *map, void *key);
 int ofi_rbmap_empty(struct ofi_rbmap *map);
+
+struct ofi_rbnode *ofi_rbnode_alloc(struct ofi_rbmap *map);
+void ofi_rbnode_free(struct ofi_rbmap *map, struct ofi_rbnode *node);
 
 
 #endif /* OFI_TREE_H_ */

--- a/man/fi_cxi.7.md
+++ b/man/fi_cxi.7.md
@@ -1151,7 +1151,7 @@ The CXI provider checks for the following environment variables:
     *software* - Message matching is fully onloaded.
 
     *hybrid* - Message matching begins fully offloaded, if resources become
-    exhuasted hardware will transition message matching to a hybrid of
+    exhausted hardware will transition message matching to a hybrid of
     hardware and software matching.
 
     For both *"hybrid"* and *"software"* modes and care should be taken to
@@ -1747,7 +1747,7 @@ number of inflight RDMA operations to and from a single endpoint. For users whic
 relying on the provider default value (e.g. MPI), the FI_CXI_DEFAULT_CQ_SIZE environment
 variable can be used to override the provider default value.
 
-### Endpoint Recieve Size Attribute
+### Endpoint Receive Size Attribute
 
 The CXI provider uses the endpoint receive size attribute to size internal command
 and hardware event queues. Failing to size the either command queue correctly can result
@@ -1814,7 +1814,7 @@ posted receive list rather than offloading to hardware. This avoids having to al
 hardware receive resource for each unxpected messsage and posted receive.
 
 *Note*: In practice, dependent processes (e.g. parallel job) will most likely be sharing a
-recieve hardware resource pool.
+receive hardware resource pool.
 
 *Note*: Each match mode may still enter flow control. For example, if a user is not draining
 the libfabric completion queue at a reasonable rate, corresponding hardware events may fill
@@ -1839,7 +1839,7 @@ rank 0 would transition to software match mode instead of all the ranks on the t
 
 The FI_CXI_HYBRID_POSTED_RECV_PREEMPTIVE and FI_CXI_HYBRID_UNEXPECTED_MSG_PREEMPTIVE
 environment variables will force the transition to software match mode if the user
-requested endpoint recieve size attribute is exceeded. The benefit of running with
+requested endpoint receive size attribute is exceeded. The benefit of running with
 these enabled is that software match mode transition is 100% in control of the libfabric
 user through the receive size attribute. One approach users could take here is set
 receive size attribute to expected usage, and if this expected usage is exceeded, only

--- a/man/fi_opx.7.md
+++ b/man/fi_opx.7.md
@@ -264,7 +264,15 @@ OPX is not compatible with Open MPI 4.1.x PML/BTL.
 *FI_OPX_RZV_MIN_PAYLOAD_BYTES*
 : Integer. The minimum length in bytes where rendezvous will be used.
   For messages smaller than this threshold, the send will first try to be completed using eager or multi-packet eager.
-  Value must be between 64 and 65536. Defaults to 16385.
+  Value must be between 64 and 65536.
+  The default, which applies to all memory types, is selected at build time based on the device-memory (HMEM) backend
+  that OPX was configured with:
+
+  - 4096  — HMEM builds with CUDA support
+  - 8192  — HMEM builds with AMD ROCR support
+  - 16385 — host-only builds (one byte above the multi-packet eager maximum),
+    which effectively disables rendezvous for any payload that fits in
+    multi-packet eager.
 
 *FI_OPX_MP_EAGER_DISABLE*
 : Boolean (1/0, on/off, true/false, yes/no). Disables multi-packet eager. Defaults to 0.

--- a/man/fi_shm.7.md
+++ b/man/fi_shm.7.md
@@ -164,6 +164,10 @@ The *shm* provider checks for the following environment variables:
 *FI_SHM_USE_DSA_SAR*
 : Enables memory copy offload to Intel DSA SAR protocol.  Default false
 
+*FI_SHM_MAX_GDRCOPY_SIZE*
+ : Maximum message size for gdrcopy transfers. Messages larger
+   than this size use the IPC protocol with cudaMemcpy.  Default 3072.
+
 *FI_SHM_USE_XPMEM*
  : SHM can use SAR, CMA or XPMEM for host memory transfers. If
    FI_SHM_USE_XPMEM is set to 1, the provider will select XPMEM over CMA if

--- a/man/man7/fi_cxi.7
+++ b/man/man7/fi_cxi.7
@@ -1386,7 +1386,7 @@ message headers will be onloaded to free resources.
 \f[I]software\f[R] - Message matching is fully onloaded.
 .PP
 \f[I]hybrid\f[R] - Message matching begins fully offloaded, if resources
-become exhuasted hardware will transition message matching to a hybrid
+become exhausted hardware will transition message matching to a hybrid
 of hardware and software matching.
 .PP
 For both \f[I]\[lq]hybrid\[rq]\f[R] and \f[I]\[lq]software\[rq]\f[R]
@@ -2098,7 +2098,7 @@ endpoint.
 For users which are relying on the provider default value (e.g.\ MPI),
 the FI_CXI_DEFAULT_CQ_SIZE environment variable can be used to override
 the provider default value.
-.SS Endpoint Recieve Size Attribute
+.SS Endpoint Receive Size Attribute
 .PP
 The CXI provider uses the endpoint receive size attribute to size
 internal command and hardware event queues.
@@ -2177,7 +2177,7 @@ This avoids having to allocated a hardware receive resource for each
 unxpected messsage and posted receive.
 .PP
 \f[I]Note\f[R]: In practice, dependent processes (e.g.\ parallel job)
-will most likely be sharing a recieve hardware resource pool.
+will most likely be sharing a receive hardware resource pool.
 .PP
 \f[I]Note\f[R]: Each match mode may still enter flow control.
 For example, if a user is not draining the libfabric completion queue at
@@ -2208,7 +2208,7 @@ to software match mode instead of all the ranks on the target NIC.
 The FI_CXI_HYBRID_POSTED_RECV_PREEMPTIVE and
 FI_CXI_HYBRID_UNEXPECTED_MSG_PREEMPTIVE environment variables will force
 the transition to software match mode if the user requested endpoint
-recieve size attribute is exceeded.
+receive size attribute is exceeded.
 The benefit of running with these enabled is that software match mode
 transition is 100% in control of the libfabric user through the receive
 size attribute.

--- a/prov/coll/src/coll_coll.c
+++ b/prov/coll/src/coll_coll.c
@@ -1308,7 +1308,7 @@ int coll_query_collective(struct fid_domain *dom_fid,
 	 * limited by the size of the rank portion of the collective tag, which
 	 * is 31 bits.  Future collectives may impose further restrictions which
 	 * will need to update the calculation.  For example, operations which
-	 * require dedicated space in the recieve buffer for each rank would
+	 * require dedicated space in the receive buffer for each rank would
 	 * limit the number of members by buffer size and value type
 	 * (8kB buffer / 64B value = 128 member max).
 	 */

--- a/prov/cxi/include/cxip.h
+++ b/prov/cxi/include/cxip.h
@@ -3133,7 +3133,7 @@ struct cxip_coll_mc {
 	struct cxip_coll_reduction reduction[CXIP_COLL_MAX_CONCUR];
 	/* Logical address context for leaf rdma get */
 	uint64_t rdma_get_lac_va_tx;
-	/* Logical address context recieved by the leaf */
+	/* Logical address context received by the leaf */
 	uint64_t rdma_get_lac_va_rx;
 	/* pointer to the source buffer base used in the RDMA */
 	uint8_t *root_rdma_get_data_p;

--- a/prov/cxi/src/cxip_msg_hpc.c
+++ b/prov/cxi/src/cxip_msg_hpc.c
@@ -250,7 +250,7 @@ static int rdzv_mrecv_req_lookup(struct cxip_req *req,
 }
 
 /*
- * rdzv_mrecv_req_event() - Look up a multi-recieve child request using an
+ * rdzv_mrecv_req_event() - Look up a multi-receive child request using an
  * event and multi-recv request.
  *
  * Each rendezvous Put transaction targeting a multi-receive buffer is tracked
@@ -2653,7 +2653,7 @@ static int cxip_claim_onload_cb(struct cxip_req *req,
 	}
 
 	/* Add to the sw UX list as a claimed entry, it will be ignored in
-	 * recieve matching of UX list entries. Its order no longer matters.
+	 * receive matching of UX list entries. Its order no longer matters.
 	 */
 	dlist_insert_tail(&ux_send->rxc_entry, &rxc->sw_ux_list);
 	rxc->sw_ux_list_len++;

--- a/prov/cxi/src/cxip_msg_rnr.c
+++ b/prov/cxi/src/cxip_msg_rnr.c
@@ -23,7 +23,7 @@
 #define CXIP_DBG(...) _CXIP_DBG(FI_LOG_EP_CTRL, __VA_ARGS__)
 #define CXIP_INFO(...) _CXIP_INFO(FI_LOG_EP_CTRL, __VA_ARGS__)
 
-#define APPEND_LE_FATAL "Recieve LE resources exhuasted. Requires use " \
+#define APPEND_LE_FATAL "Receive LE resources exhausted. Requires use " \
 	" of FI_PROTO_CXI endpoint protocol\n"
 
 static int cxip_rnr_send_cb(struct cxip_req *req, const union c_event *event);

--- a/prov/cxi/test/msg.c
+++ b/prov/cxi/test/msg.c
@@ -3105,7 +3105,7 @@ static void msg_hybrid_append_test_runner(bool recv_truncation,
 	/* Make sure unlink of FI_MULTI_RECV did not update counter */
 	recv_cnt = fi_cntr_read(cxit_recv_cntr);
 	cr_assert(recv_cnt == byte_counts ? trunc_byte_len : iters,
-		  "Unlink updated RX recieve count %ld by software", recv_cnt);
+		  "Unlink updated RX receive count %ld by software", recv_cnt);
 
 	for (i = 0; i < recv_win_len; i++)
 		cr_assert_eq(send_window.mem[i], recv_window.mem[i],

--- a/prov/cxi/test/tagged.c
+++ b/prov/cxi/test/tagged.c
@@ -1560,7 +1560,7 @@ static void verify_peek_claim_order_same_tag(size_t xfer_base_size, bool claim)
 				     ret);
 		}
 
-		/* Recieve unexpected message. If message is FI_CLAIM,
+		/* Receive unexpected message. If message is FI_CLAIM,
 		 * FI_CONTEXT buffer contains data to progress receive.
 		 */
 		ret = fi_trecvmsg(cxit_ep, &tmsg, claim ? FI_CLAIM : 0);

--- a/prov/opx/include/rdma/opx/fi_opx_endpoint.h
+++ b/prov/opx/include/rdma/opx/fi_opx_endpoint.h
@@ -1120,7 +1120,7 @@ void fi_opx_handle_recv_rts_hfisvc(const union opx_hfi1_packet_hdr *const	 hdr,
 	uint64_t xfer_len = hdr->rzv_rts.message_length;
 
 #ifdef OPX_TRACER_ENABLED
-	const uint64_t trace_slid_len = OPX_TRACE_PACK_SLID_LEN(lid, xfer_len);
+	const uint64_t trace_slid_len = OPX_TRACE_PACK_SLID_LEN(OPX_TRACE_GET_SLID(hdr, hfi1_type), xfer_len);
 	OPX_TRACE_RX_BEGIN(OPX_TRACE_EVENT_RX_RZV_RTS_HFISVC, trace_slid_len, origin_tag);
 #endif
 
@@ -4449,13 +4449,12 @@ static inline ssize_t fi_opx_ep_tx_send_internal(struct fid_ep *ep, const void *
 			return -FI_EAGAIN;
 		}
 
-		/* If hmem_iface != FI_HMEM_SYSTEM, we skip MP EGR because RZV yields better performance for devices */
 		if (total_len <= opx_tx->mp_eager_max_payload_bytes && is_contiguous &&
-		    !fi_opx_hfi1_tx_is_shm(opx_ep, addr, caps) && (caps & FI_TAGGED) && hmem_iface == FI_HMEM_SYSTEM) {
+		    !fi_opx_hfi1_tx_is_shm(opx_ep, addr, caps) && (caps & FI_TAGGED)) {
 			assert(total_len >= opx_tx->mp_eager_min_payload_bytes);
 			rc = opx_hfi1_tx_send_try_mp_egr(ep, buf, len, addr, tag, context, data, lock_required,
 							 override_flags, tx_op_flags, caps, reliability,
-							 do_cq_completion, FI_HMEM_SYSTEM, 0ul, OPX_HMEM_NO_HANDLE,
+							 do_cq_completion, hmem_iface, hmem_device, hmem_handle,
 							 hfi1_type, ctx_sharing);
 			if (OFI_LIKELY(rc == FI_SUCCESS)) {
 				OPX_TRACE_TX_END_SUCCESS(OPX_TRACE_EVENT_TX_SEND, 0, 0);

--- a/prov/opx/include/rdma/opx/fi_opx_endpoint.h
+++ b/prov/opx/include/rdma/opx/fi_opx_endpoint.h
@@ -1132,7 +1132,15 @@ void fi_opx_handle_recv_rts_hfisvc(const union opx_hfi1_packet_hdr *const	 hdr,
 	uint64_t	  do_dmabuf = (uint64_t) (context->flags & FI_OPX_CQ_CONTEXT_DMABUF_HMEM);
 	if (do_dmabuf) {
 		opx_mr = ((struct fi_opx_hmem_info *) context->hmem_info_qws)->dmabuf.opx_mr;
-		if (opx_mr->hfisvc.state != OPX_MR_HFISVC_STATE_OPENED) {
+		if (opx_mr->hfisvc.state != OPX_MR_HFISVC_STATE_OPENED && OFI_LIKELY(xfer_len <= recv_len)) {
+			context->byte_counter = niov;
+			context->len	      = xfer_len;
+			context->data	      = ofi_data;
+			context->tag	      = origin_tag;
+			context->next	      = NULL;
+			context->flags |= FI_RECV | FI_OPX_HFI_BTH_OPCODE_GET_CQ_FLAG(opcode) |
+					  FI_OPX_HFI_BTH_OPCODE_GET_MSG_FLAG(opcode);
+
 			int deferred_rc = opx_hfisvc_deferred_recv_rts_enqueue(opx_ep, context, niov, recv_buf,
 									       &payload->rendezvous.hfisvc.iovs[0]);
 			if (OFI_UNLIKELY(deferred_rc)) {

--- a/prov/opx/include/rdma/opx/opx_hfisvc_poll.h
+++ b/prov/opx/include/rdma/opx/opx_hfisvc_poll.h
@@ -106,8 +106,13 @@ void opx_domain_hfisvc_poll(struct fi_opx_domain *opx_domain)
 
 				struct opx_context *context = rzv_comp->context;
 				OPX_HFISVC_DEBUG_LOG(
-					"STRIPE-MR-NOTIFY: MR notify completion for opx_mr=%p rzv_comp=%p context=%p byte_counter=%lu (no decrement/no free)\n",
-					opx_mr, rzv_comp, context, context ? context->byte_counter : 0UL);
+					"STRIPE-MR-NOTIFY: MR notify completion for opx_mr=%p rzv_comp=%p context=%p byte_counter=%lu -> %lu\n",
+					opx_mr, rzv_comp, context, context->byte_counter, context->byte_counter - 1);
+
+				assert(context->byte_counter > 0);
+				context->byte_counter -= 1;
+
+				OPX_BUF_FREE(rzv_comp);
 			} else if (opx_mr->hfisvc.state == OPX_MR_HFISVC_STATE_PENDING_KEY_DISABLE) {
 				opx_hfisvc_keyset_free_key(opx_domain->hfisvc.ctxs[0].access_key_set,
 							   opx_mr->hfisvc.access_key, NULL);

--- a/prov/opx/include/rdma/opx/opx_hfisvc_poll.h
+++ b/prov/opx/include/rdma/opx/opx_hfisvc_poll.h
@@ -106,13 +106,8 @@ void opx_domain_hfisvc_poll(struct fi_opx_domain *opx_domain)
 
 				struct opx_context *context = rzv_comp->context;
 				OPX_HFISVC_DEBUG_LOG(
-					"STRIPE-MR-NOTIFY: MR notify completion for opx_mr=%p rzv_comp=%p context=%p byte_counter=%lu -> %lu\n",
-					opx_mr, rzv_comp, context, context->byte_counter, context->byte_counter - 1);
-
-				assert(context->byte_counter > 0);
-				context->byte_counter -= 1;
-
-				OPX_BUF_FREE(rzv_comp);
+					"STRIPE-MR-NOTIFY: MR notify completion for opx_mr=%p rzv_comp=%p context=%p byte_counter=%lu (no decrement/no free)\n",
+					opx_mr, rzv_comp, context, context ? context->byte_counter : 0UL);
 			} else if (opx_mr->hfisvc.state == OPX_MR_HFISVC_STATE_PENDING_KEY_DISABLE) {
 				opx_hfisvc_keyset_free_key(opx_domain->hfisvc.ctxs[0].access_key_set,
 							   opx_mr->hfisvc.access_key, NULL);

--- a/prov/opx/include/rdma/opx/opx_hmem_domain.h
+++ b/prov/opx/include/rdma/opx/opx_hmem_domain.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 Cornelis Networks.
+ * Copyright (C) 2024-2026 Cornelis Networks.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -41,7 +41,7 @@
 
 #define OPX_HMEM_NO_LOCK_ON_CLEANUP (0)
 
-#define OPX_HMEM_DEV_REG_SEND_THRESHOLD_DEFAULT (4096)
+#define OPX_HMEM_DEV_REG_SEND_THRESHOLD_DEFAULT (512)
 #define OPX_HMEM_DEV_REG_RECV_THRESHOLD_DEFAULT (OPX_HFI1_PKT_SIZE)
 #define OPX_HMEM_DEV_REG_THRESHOLD_MAX		(OPX_HFI1_PKT_SIZE)
 #define OPX_HMEM_DEV_REG_THRESHOLD_MIN		(0)

--- a/prov/opx/src/fi_opx_ep.c
+++ b/prov/opx/src/fi_opx_ep.c
@@ -3845,13 +3845,54 @@ fi_opx_ep_rx_process_context_noinline(struct fi_opx_ep *opx_ep, const uint64_t s
 		struct fi_context	     *op_context  = (struct fi_context *) context->err_entry.op_context;
 		struct fi_opx_hfi1_ue_packet *claimed_pkt = op_context->internal[0];
 
-		const unsigned is_shm = claimed_pkt->is_shm;
+		const unsigned is_shm	   = claimed_pkt->is_shm;
+		uint8_t	       is_mp_eager = (FI_OPX_HFI_BTH_OPCODE_BASE_OPCODE(claimed_pkt->hdr.bth.opcode) ==
+					      FI_OPX_HFI_BTH_OPCODE_MSG_MP_EAGER_FIRST);
 
 		opx_ep_complete_receive_operation(
 			ep, &claimed_pkt->hdr, (union fi_opx_hfi1_packet_payload *) &claimed_pkt->payload,
 			claimed_pkt->hdr.match.ofi_tag, context, claimed_pkt->hdr.bth.opcode, OPX_MULTI_RECV_FALSE,
 			is_shm, rx_op_flags & (FI_OPX_CQ_CONTEXT_HMEM | FI_OPX_CQ_CONTEXT_DMABUF_HMEM), lock_required,
 			reliability, hfi1_type);
+
+		if (is_mp_eager) {
+			/*
+			 * A claimed multi-packet eager message starts from an unexpected FIRST
+			 * packet, just like fi_opx_ep_process_context_match_ue_packets().  The
+			 * FIRST packet initializes context->byte_counter, but the remaining NTH
+			 * packets are matched through mp_egr_queue.  If we skip that bookkeeping
+			 * here, FI_CLAIM receives can wait forever after MPI_Mprobe claims the
+			 * FIRST packet of a multi-packet eager message.
+			 */
+			opx_lid_t slid;
+			if (hfi1_type & (OPX_HFI1_WFR | OPX_HFI1_MIXED_9B)) {
+				slid = (opx_lid_t) __be16_to_cpu24((__be16) claimed_pkt->hdr.lrh_9B.slid);
+			} else {
+				slid = (opx_lid_t) __le24_to_cpu((__le24) (claimed_pkt->hdr.lrh_16B.slid20 << 20) |
+								 (claimed_pkt->hdr.lrh_16B.slid));
+			}
+
+			const uint64_t mp_egr_id =
+				OPX_GET_MP_EGR_ID(claimed_pkt->hdr.reliability.psn, slid, claimed_pkt->subctxt_rx);
+
+			fi_opx_ep_rx_process_pending_mp_eager_ue(ep, context, mp_egr_id, is_shm, lock_required,
+								 reliability, hfi1_type);
+
+			if (context->byte_counter) {
+				context->mp_egr_id = mp_egr_id;
+				slist_insert_tail((struct slist_entry *) context, &opx_ep->rx->mp_egr_queue.mq);
+			} else {
+				FI_OPX_DEBUG_COUNTERS_INC(
+					opx_ep->debug_counters.mp_eager.recv_completed_process_context);
+
+				context->next = NULL;
+				if (OFI_UNLIKELY(context->err_entry.err == FI_ETRUNC)) {
+					slist_insert_tail((struct slist_entry *) context, opx_ep->rx->cq_err_ptr);
+				} else {
+					fi_opx_enqueue_completed(opx_ep->rx->cq_completed_ptr, context, lock_required);
+				}
+			}
+		}
 
 		/* ... and prepend the claimed uepkt to the ue free list.
 		   claimed_pkt->next should have been set to NULL at the time we

--- a/prov/opx/src/fi_opx_mr.c
+++ b/prov/opx/src/fi_opx_mr.c
@@ -183,6 +183,24 @@ static inline int fi_opx_mr_reg_internal(struct fid *fid, const struct iovec *io
 		return -errno;
 	}
 
+#if HAVE_HFISVC
+	/* HFISVC pins the memory region eagerly at registration time via the
+	 * kernel hfi1_mem_region_pin path. A NULL base address cannot be pinned
+	 * (the kernel returns EFAULT), and the HFISVC cmd_mr_open API truncates
+	 * its length argument to 32 bits, so any length exceeding UINT32_MAX
+	 * would silently register only the low 4 GiB of the requested range.
+	 * Reject these cases up front with a libfabric-level error rather than
+	 * letting them propagate to a kernel-side failure or a silent
+	 * truncation. TODO: document this limit along with HFISVC */
+	if (opx_domain->use_hfisvc && (!iov->iov_base || iov->iov_len > UINT32_MAX)) {
+		FI_WARN(fi_opx_global.prov, FI_LOG_MR,
+			"HFISVC cannot register MR with iov_base=%p iov_len=%zu (NULL base or len > UINT32_MAX is unsupported by HFISVC pinning)\n",
+			iov->iov_base, iov->iov_len);
+		errno = FI_EOPNOTSUPP;
+		return -errno;
+	}
+#endif
+
 	struct fi_opx_mr			      *opx_mr;
 	__attribute__((__unused__)) uint64_t	       hmem_device = 0UL;
 	__attribute__((__unused__)) enum fi_hmem_iface hmem_iface  = FI_HMEM_SYSTEM;

--- a/prov/opx/src/fi_opx_tid_cache.c
+++ b/prov/opx/src/fi_opx_tid_cache.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017-2020 Amazon.com, Inc. or its affiliates. All rights reserved.
- * Copyright (C) 2022-2024 Cornelis Networks.
+ * Copyright (C) 2022-2026 Cornelis Networks.
  *
  * Copyright (c) 2016-2017 Cray Inc. All rights reserved.
  * Copyright (c) 2017-2019 Intel Corporation, Inc.  All rights reserved.
@@ -633,7 +633,11 @@ int opx_tid_cache_crte(struct ofi_mr_cache *cache, const struct ofi_mr_info *inf
 	}
 
 	OPX_DEBUG_ENTRY(info);
-	/* drop the mm lock across alloc/register */
+	/* drop the mm lock across alloc/register and rbnode pre-allocation
+	 * to avoid deadlock: malloc() can trigger madvise() which OPAL
+	 * intercepts, calling back into ofi_import_monitor_notify() which
+	 * needs mm_lock.
+	 */
 	pthread_mutex_unlock(&mm_lock);
 	struct opx_mr_tid_info *tid_info;
 	int			ret = opx_mr_entry_alloc_init(cache, info, opx_ep, entry, &tid_info);
@@ -648,17 +652,21 @@ int opx_tid_cache_crte(struct ofi_mr_cache *cache, const struct ofi_mr_info *inf
 	ret			      = opx_register_tid_region_retryable(cache, (uint64_t) info->iov.iov_base,
 									  MIN(info->iov.iov_len, register_max_len), info->iface, info->device,
 									  opx_ep, tid_info);
+	if (ret) {
+		/* Failed, tid_info->ninfo will be zero */
+		FI_DBG(fi_opx_global.prov, FI_LOG_MR, "opx_register_tid_region failed with return code %d (%s)\n", ret,
+		       strerror(ret));
+		goto error;
+	}
+
+	struct ofi_rbnode *rbnode = ofi_rbnode_new(&cache->tree);
+	if (OFI_UNLIKELY(!rbnode)) {
+		FI_DBG(fi_opx_global.prov, FI_LOG_MR, "Failed to alloc rbnode, return -FI_ENOMEM\n");
+		goto error;
+	}
 
 	/* re-acquire mm_lock */
 	pthread_mutex_lock(&mm_lock);
-
-	if (ret) {
-		/* Failed, tid_info->ninfo will be zero */
-		FI_DBG(fi_opx_global.prov, FI_LOG_MR,
-		       "opx_register_tid_region failed with return code %d (%s), FREE node %p\n", ret, strerror(ret),
-		       (*entry)->node);
-		goto error;
-	}
 
 	FI_DBG(fi_opx_global.prov, FI_LOG_MR,
 	       "NEW vaddr [%#lx - %#lx] length %lu, tid vaddr [%#lx - %#lx] , tid length %lu\n",
@@ -669,11 +677,12 @@ int opx_tid_cache_crte(struct ofi_mr_cache *cache, const struct ofi_mr_info *inf
 	(*entry)->info.iov.iov_base = (void *) tid_info->tid_vaddr;
 	(*entry)->info.iov.iov_len  = tid_info->tid_length;
 
-	ret = ofi_rbmap_insert(&cache->tree, (void *) &(*entry)->info, (void *) *entry, &(*entry)->node);
+	ret = ofi_rbmap_insert_at(&cache->tree, (void *) &(*entry)->info, (void *) *entry, &(*entry)->node, rbnode);
 
 	if (OFI_UNLIKELY(ret)) {
 		FI_DBG(fi_opx_global.prov, FI_LOG_MR, "ofi_rbmap_insert returned %d (%s) %p\n", ret, strerror(ret),
 		       (*entry)->node);
+		ofi_rbnode_del(&cache->tree, rbnode);
 		goto error;
 	}
 	cache->cached_cnt++;
@@ -682,9 +691,8 @@ int opx_tid_cache_crte(struct ofi_mr_cache *cache, const struct ofi_mr_info *inf
 	ret = ofi_monitor_subscribe(monitor, info->iov.iov_base, info->iov.iov_len, &(*entry)->hmem_info);
 	if (OFI_UNLIKELY(ret)) {
 		opx_mr_uncache_entry_storage(cache, *entry);
-		cache->uncached_cnt++;
-		cache->uncached_size += (*entry)->info.iov.iov_len;
-		FI_WARN(fi_opx_global.prov, FI_LOG_MR, "MONITOR SUBSCRIBE FAILED UNCACHED ERROR\n");
+		FI_WARN(fi_opx_global.prov, FI_LOG_MR, "MONITOR SUBSCRIBE FAILED UNCACHED ERROR  %d (%s)\n", ret,
+			strerror(ret));
 		goto error;
 	}
 	OPX_DEBUG_EXIT((*entry), OPX_TID_CACHE_ENTRY_FOUND);
@@ -696,7 +704,7 @@ error:
 	       (char *) info->iov.iov_base + info->iov.iov_len, info->iov.iov_len, info->iov.iov_len);
 	tid_info->npairs = 0; /* error == no tid pairs */
 	OPX_DEBUG_EXIT((*entry), OPX_TID_CACHE_ENTRY_NOT_FOUND);
-	return ret; // TODO - handle case for free
+	return ret; // entry freed by caller
 }
 
 __OPX_FORCE_INLINE__

--- a/prov/opx/src/fi_opx_tid_cache.c
+++ b/prov/opx/src/fi_opx_tid_cache.c
@@ -659,7 +659,7 @@ int opx_tid_cache_crte(struct ofi_mr_cache *cache, const struct ofi_mr_info *inf
 		goto error;
 	}
 
-	struct ofi_rbnode *rbnode = ofi_rbnode_new(&cache->tree);
+	struct ofi_rbnode *rbnode = ofi_rbnode_alloc(&cache->tree);
 	if (OFI_UNLIKELY(!rbnode)) {
 		FI_DBG(fi_opx_global.prov, FI_LOG_MR, "Failed to alloc rbnode, return -FI_ENOMEM\n");
 		goto error;
@@ -682,7 +682,7 @@ int opx_tid_cache_crte(struct ofi_mr_cache *cache, const struct ofi_mr_info *inf
 	if (OFI_UNLIKELY(ret)) {
 		FI_DBG(fi_opx_global.prov, FI_LOG_MR, "ofi_rbmap_insert returned %d (%s) %p\n", ret, strerror(ret),
 		       (*entry)->node);
-		ofi_rbnode_del(&cache->tree, rbnode);
+		ofi_rbnode_free(&cache->tree, rbnode);
 		goto error;
 	}
 	cache->cached_cnt++;

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -256,20 +256,21 @@ void smr_format_tx_pend(struct smr_pend_entry *pend, struct smr_cmd *cmd,
 			uint64_t op_flags);
 void smr_generic_format(struct smr_cmd *cmd, int64_t tx_id, int64_t rx_id,
 			uint32_t op, uint64_t tag, uint64_t data,
-			uint64_t op_flags);
+			uint8_t smr_flags);
 size_t smr_copy_to_sar(struct smr_ep *ep, struct smr_region *smr,
 		       struct smr_pend_entry *pend);
 size_t smr_copy_from_sar(struct smr_ep *ep, struct smr_region *smr,
 		         struct smr_pend_entry *pend);
 int smr_select_proto(void **desc, size_t iov_count, bool cma_avail,
 		     bool ipc_valid, uint32_t op, uint64_t total_len,
-		     uint64_t op_flags);
+		     uint64_t op_flags, uint8_t *smr_flags);
 typedef ssize_t (*smr_send_func)(
 		struct smr_ep *ep, struct smr_region *peer_smr,
 		int64_t tx_id, int64_t rx_id, uint32_t op, uint64_t tag,
-		uint64_t data, uint64_t op_flags, struct ofi_mr **desc,
-		const struct iovec *iov, size_t iov_count, size_t total_len,
-		void *context, struct smr_cmd *cmd);
+		uint64_t data, uint64_t op_flags, uint8_t smr_flags,
+		struct ofi_mr **desc, const struct iovec *iov,
+		size_t iov_count, size_t total_len, void *context,
+		struct smr_cmd *cmd);
 extern smr_send_func smr_send_ops[smr_proto_max];
 
 int smr_write_err_comp(struct util_cq *cq, void *context,
@@ -280,9 +281,9 @@ int smr_complete_rx(struct smr_ep *ep, void *context, uint32_t op,
 		    uint64_t flags, size_t len, void *buf, int64_t id,
 		    uint64_t tag, uint64_t data);
 
-static inline uint64_t smr_rx_cq_flags(uint64_t rx_flags, uint16_t op_flags)
+static inline uint64_t smr_rx_cq_flags(uint64_t rx_flags, uint8_t smr_flags)
 {
-	if (op_flags & SMR_REMOTE_CQ_DATA)
+	if (smr_flags & SMR_REMOTE_CQ_DATA)
 		rx_flags |= FI_REMOTE_CQ_DATA;
 	return rx_flags;
 }

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -74,14 +74,11 @@ static void smr_format_inject_atomic(
 			const struct iovec *iov, size_t count,
 			const struct iovec *resultv, size_t result_count,
 			struct ofi_mr **comp_desc, const struct iovec *compv,
-			size_t comp_count, struct smr_region *smr)
+			size_t comp_count, struct smr_inject_buf *tx_buf)
 {
-	struct smr_inject_buf *tx_buf;
 	size_t comp_size;
 
 	cmd->hdr.proto = smr_proto_inject;
-
-	tx_buf = smr_get_inject_buf(smr, cmd);
 	switch (cmd->hdr.op) {
 	case ofi_op_atomic:
 		cmd->hdr.size = ofi_copy_from_mr_iov(
@@ -114,7 +111,7 @@ static void smr_format_inject_atomic(
 	}
 }
 
-static ssize_t smr_do_atomic_inject(
+static int smr_do_atomic_inject(
 			struct smr_ep *ep, struct smr_region *peer_smr,
 			int64_t tx_id, int64_t rx_id, uint32_t op,
 			uint64_t op_flags, uint8_t datatype, uint8_t atomic_op,
@@ -123,18 +120,33 @@ static ssize_t smr_do_atomic_inject(
 			const struct iovec *resultv, size_t result_count,
 			struct ofi_mr **comp_desc, const struct iovec *compv,
 			size_t comp_count, size_t total_len, void *context,
-			uint16_t smr_flags, struct smr_cmd *cmd)
+			uint8_t smr_flags, struct smr_cmd *cmd)
 {
 	struct smr_pend_entry *pend;
+	struct smr_inject_buf *tx_buf;
 
-	smr_generic_format(cmd, tx_id, rx_id, op, 0, 0, op_flags);
+	if (op == ofi_op_atomic_compare || op == ofi_op_atomic_fetch) {
+		smr_flags |= SMR_RETURN_CMD;
+		tx_buf = smr_get_inject_buf(ep->region);
+		cmd->hdr.proto_data = smr_get_offset(ep->region, tx_buf);
+	} else {
+		tx_buf = smr_get_inject_buf(peer_smr);
+		cmd->hdr.proto_data = smr_get_offset(peer_smr, tx_buf);
+	}
+	if (!tx_buf) {
+		FI_DBG(&smr_prov, FI_LOG_EP_DATA,
+		       "No inject buffers available, cannot send inject "
+		       "message\n");
+		return -FI_EAGAIN;
+	}
+
+	smr_generic_format(cmd, tx_id, rx_id, op, 0, 0, smr_flags);
 	smr_generic_atomic_format(cmd, datatype, atomic_op);
 	smr_format_inject_atomic(cmd, desc, iov, iov_count, resultv,
 				 result_count, comp_desc, compv, comp_count,
-				 ep->region);
+				 tx_buf);
 
-	if (op == ofi_op_atomic_fetch || op == ofi_op_atomic_compare ||
-	    atomic_op == FI_ATOMIC_READ || op_flags & FI_DELIVERY_COMPLETE) {
+	if (smr_flags & SMR_RETURN_CMD) {
 		pend = ofi_buf_alloc(ep->pend_pool);
 		assert(pend);
 		cmd->hdr.tx_ctx = (uintptr_t) pend;
@@ -148,13 +160,18 @@ static ssize_t smr_do_atomic_inject(
 }
 
 static int smr_select_atomic_proto(uint32_t op, uint64_t total_len,
-				   uint64_t op_flags)
+				   uint64_t op_flags, uint8_t *smr_flags)
 {
+	*smr_flags = 0;
+	assert(!(op_flags & FI_REMOTE_CQ_DATA));
 	if (op == ofi_op_atomic_compare || op == ofi_op_atomic_fetch ||
-	    op_flags & FI_DELIVERY_COMPLETE || total_len > SMR_MSG_DATA_LEN)
+	    op_flags & FI_DELIVERY_COMPLETE) {
+		*smr_flags |= SMR_RETURN_CMD;
 		return smr_proto_inject;
+	}
 
-	return smr_proto_inline;
+	return total_len > SMR_MSG_DATA_LEN ? smr_proto_inject :
+					      smr_proto_inline;
 }
 
 static ssize_t smr_generic_atomic(
@@ -173,12 +190,12 @@ static ssize_t smr_generic_atomic(
 	struct iovec iov[SMR_IOV_LIMIT];
 	struct iovec compare_iov[SMR_IOV_LIMIT];
 	struct iovec result_iov[SMR_IOV_LIMIT];
-	uint16_t smr_flags = 0;
 	int64_t tx_id, rx_id, pos;
 	int proto;
 	ssize_t ret;
 	size_t total_len;
 	uint64_t atomic_flags;
+	uint8_t smr_flags;
 
 	assert(count <= SMR_IOV_LIMIT);
 	assert(result_count <= SMR_IOV_LIMIT);
@@ -247,15 +264,8 @@ static ssize_t smr_generic_atomic(
 		break;
 	}
 
-	proto = smr_select_atomic_proto(op, total_len, op_flags);
-
-	if (proto == smr_proto_inline) {
-		cmd = ce;
-		smr_do_atomic_inline(ep, peer_smr, tx_id, rx_id, ofi_op_atomic,
-				     op_flags, datatype, atomic_op,
-				     (struct ofi_mr **) desc, iov, count,
-				     total_len, cmd);
-	} else {
+	proto = smr_select_atomic_proto(op, total_len, op_flags, &smr_flags);
+	if (smr_flags & SMR_RETURN_CMD) {
 		if (smr_freestack_isempty(smr_cmd_stack(ep->region))) {
 			smr_cmd_queue_discard(ce, pos);
 			ret = -FI_EAGAIN;
@@ -266,6 +276,16 @@ static ssize_t smr_generic_atomic(
 		assert(cmd);
 		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
 						  (uintptr_t) cmd);
+	} else {
+		cmd = ce;
+	}
+
+	if (proto == smr_proto_inline) {
+		smr_do_atomic_inline(ep, peer_smr, tx_id, rx_id, ofi_op_atomic,
+				     op_flags, datatype, atomic_op,
+				     (struct ofi_mr **) desc, iov, count,
+				     total_len, cmd);
+	} else {
 		ret = smr_do_atomic_inject(ep, peer_smr, tx_id, rx_id, op,
 					   op_flags, datatype, atomic_op,
 					   (struct ofi_mr **) desc, iov, count,
@@ -281,16 +301,17 @@ static ssize_t smr_generic_atomic(
 		}
 	}
 
-	if (!cmd->hdr.tx_ctx) {
-		ret = smr_complete_tx(ep, context, op, op_flags);
-		if (ret) {
-			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-				"unable to process tx completion\n");
-		}
-	}
-
 	smr_format_rma_ioc(cmd, rma_ioc, rma_count);
 	smr_cmd_queue_commit(ce, pos);
+
+	if (smr_flags & SMR_RETURN_CMD)
+		goto unlock;
+
+	ret = smr_complete_tx(ep, context, op, op_flags);
+	if (ret)
+		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+			"unable to process tx completion\n");
+
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -362,7 +383,7 @@ static ssize_t smr_atomic_inject(
 			fi_addr_t dest_addr, uint64_t addr, uint64_t key,
 			enum fi_datatype datatype, enum fi_op op)
 {
-	struct smr_cmd *ce, *cmd;
+	struct smr_cmd *ce;
 	struct smr_ep *ep;
 	struct smr_region *peer_smr;
 	struct iovec iov;
@@ -370,7 +391,6 @@ static ssize_t smr_atomic_inject(
 	int64_t id, peer_id, pos;
 	ssize_t ret;
 	size_t total_len;
-	int proto;
 
 	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
 
@@ -412,39 +432,23 @@ static ssize_t smr_atomic_inject(
 	rma_ioc.key = key;
 
 	if (total_len <= SMR_MSG_DATA_LEN) {
-		proto = smr_proto_inline;
-		cmd = ce;
 		smr_do_atomic_inline(ep, peer_smr, id, peer_id, ofi_op_atomic,
 				     0, datatype, op, NULL, &iov, 1, total_len,
-				     cmd);
+				     ce);
 	} else {
-		proto = smr_proto_inject;
-		if (smr_freestack_isempty(smr_cmd_stack(ep->region))) {
-			smr_cmd_queue_discard(ce, pos);
-			ret = -FI_EAGAIN;
-			goto unlock;
-		}
-
-		cmd = smr_freestack_pop(smr_cmd_stack(ep->region));
-		assert(cmd);
-		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, id, peer_id,
-						  (uintptr_t) cmd);
 		ret = smr_do_atomic_inject(ep, peer_smr, id, peer_id,
 					   ofi_op_atomic, 0, datatype, op, NULL,
 					   &iov, 1, NULL, NULL, 0, NULL, NULL,
-					   0, total_len, NULL, 0, cmd);
+					   0, total_len, NULL, 0, ce);
 		if (ret) {
-			smr_freestack_push(smr_cmd_stack(ep->region), cmd);
 			smr_cmd_queue_discard(ce, pos);
 			goto unlock;
 		}
 	}
 
-	smr_format_rma_ioc(cmd, &rma_ioc, 1);
+	smr_format_rma_ioc(ce, &rma_ioc, 1);
 	smr_cmd_queue_commit(ce, pos);
-
-	if (proto == smr_proto_inline)
-		ofi_ep_peer_tx_cntr_inc(&ep->util_ep, ofi_op_atomic);
+	ofi_ep_peer_tx_cntr_inc(&ep->util_ep, ofi_op_atomic);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -275,6 +275,7 @@ static ssize_t smr_generic_atomic(
 					   compare_iov, compare_count,
 					   total_len, context, smr_flags, cmd);
 		if (ret) {
+			smr_freestack_push(smr_cmd_stack(ep->region), cmd);
 			smr_cmd_queue_discard(ce, pos);
 			goto unlock;
 		}
@@ -433,6 +434,7 @@ static ssize_t smr_atomic_inject(
 					   &iov, 1, NULL, NULL, 0, NULL, NULL,
 					   0, total_len, NULL, 0, cmd);
 		if (ret) {
+			smr_freestack_push(smr_cmd_stack(ep->region), cmd);
 			smr_cmd_queue_discard(ce, pos);
 			goto unlock;
 		}

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -168,8 +168,7 @@ static ssize_t smr_generic_atomic(
 			enum fi_op atomic_op, void *context, uint32_t op,
 			uint64_t op_flags)
 {
-	struct smr_cmd_entry *ce;
-	struct smr_cmd *cmd;
+	struct smr_cmd *ce, *cmd;
 	struct smr_region *peer_smr;
 	struct iovec iov[SMR_IOV_LIMIT];
 	struct iovec compare_iov[SMR_IOV_LIMIT];
@@ -251,7 +250,7 @@ static ssize_t smr_generic_atomic(
 	proto = smr_select_atomic_proto(op, total_len, op_flags);
 
 	if (proto == smr_proto_inline) {
-		cmd = &ce->cmd;
+		cmd = ce;
 		smr_do_atomic_inline(ep, peer_smr, tx_id, rx_id, ofi_op_atomic,
 				     op_flags, datatype, atomic_op,
 				     (struct ofi_mr **) desc, iov, count,
@@ -265,8 +264,8 @@ static ssize_t smr_generic_atomic(
 
 		cmd = smr_freestack_pop(smr_cmd_stack(ep->region));
 		assert(cmd);
-		ce->ptr = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
-					    (uintptr_t) cmd);
+		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
+						  (uintptr_t) cmd);
 		ret = smr_do_atomic_inject(ep, peer_smr, tx_id, rx_id, op,
 					   op_flags, datatype, atomic_op,
 					   (struct ofi_mr **) desc, iov, count,
@@ -362,8 +361,7 @@ static ssize_t smr_atomic_inject(
 			fi_addr_t dest_addr, uint64_t addr, uint64_t key,
 			enum fi_datatype datatype, enum fi_op op)
 {
-	struct smr_cmd_entry *ce;
-	struct smr_cmd *cmd;
+	struct smr_cmd *ce, *cmd;
 	struct smr_ep *ep;
 	struct smr_region *peer_smr;
 	struct iovec iov;
@@ -414,10 +412,10 @@ static ssize_t smr_atomic_inject(
 
 	if (total_len <= SMR_MSG_DATA_LEN) {
 		proto = smr_proto_inline;
-		cmd = &ce->cmd;
+		cmd = ce;
 		smr_do_atomic_inline(ep, peer_smr, id, peer_id, ofi_op_atomic,
 				     0, datatype, op, NULL, &iov, 1, total_len,
-				     &ce->cmd);
+				     cmd);
 	} else {
 		proto = smr_proto_inject;
 		if (smr_freestack_isempty(smr_cmd_stack(ep->region))) {
@@ -428,8 +426,8 @@ static ssize_t smr_atomic_inject(
 
 		cmd = smr_freestack_pop(smr_cmd_stack(ep->region));
 		assert(cmd);
-		ce->ptr = smr_local_to_peer(ep, peer_smr, id, peer_id,
-					    (uintptr_t) cmd);
+		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, id, peer_id,
+						  (uintptr_t) cmd);
 		ret = smr_do_atomic_inject(ep, peer_smr, id, peer_id,
 					   ofi_op_atomic, 0, datatype, op, NULL,
 					   &iov, 1, NULL, NULL, 0, NULL, NULL,

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -275,6 +275,7 @@ static ssize_t smr_generic_atomic(
 
 		cmd = smr_freestack_pop(smr_cmd_stack(ep->region));
 		assert(cmd);
+		ce->hdr.smr_flags = smr_flags;
 		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
 						  (uintptr_t) cmd);
 	} else {

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -60,11 +60,12 @@ static void smr_format_inline_atomic(struct smr_cmd *cmd, struct ofi_mr **mr,
 static void smr_do_atomic_inline(
 			struct smr_ep *ep, struct smr_region *peer_smr,
 			int64_t tx_id, int64_t rx_id, uint32_t op,
-			uint64_t op_flags, uint8_t datatype, uint8_t atomic_op,
+			uint8_t datatype, uint8_t atomic_op,
 			struct ofi_mr **desc, const struct iovec *iov,
-			size_t iov_count, size_t total_len, struct smr_cmd *cmd)
+			size_t iov_count, size_t total_len, uint8_t smr_flags,
+			struct smr_cmd *cmd)
 {
-	smr_generic_format(cmd, tx_id, rx_id, op, 0, 0, op_flags);
+	smr_generic_format(cmd, tx_id, rx_id, op, 0, 0, smr_flags);
 	smr_generic_atomic_format(cmd, datatype, atomic_op);
 	smr_format_inline_atomic(cmd, desc, iov, iov_count);
 }
@@ -282,9 +283,9 @@ static ssize_t smr_generic_atomic(
 
 	if (proto == smr_proto_inline) {
 		smr_do_atomic_inline(ep, peer_smr, tx_id, rx_id, ofi_op_atomic,
-				     op_flags, datatype, atomic_op,
+				     datatype, atomic_op,
 				     (struct ofi_mr **) desc, iov, count,
-				     total_len, cmd);
+				     total_len, smr_flags, cmd);
 	} else {
 		ret = smr_do_atomic_inject(ep, peer_smr, tx_id, rx_id, op,
 					   op_flags, datatype, atomic_op,
@@ -433,8 +434,8 @@ static ssize_t smr_atomic_inject(
 
 	if (total_len <= SMR_MSG_DATA_LEN) {
 		smr_do_atomic_inline(ep, peer_smr, id, peer_id, ofi_op_atomic,
-				     0, datatype, op, NULL, &iov, 1, total_len,
-				     ce);
+				     datatype, op, NULL, &iov, 1, total_len,
+				     0, ce);
 	} else {
 		ret = smr_do_atomic_inject(ep, peer_smr, id, peer_id,
 					   ofi_op_atomic, 0, datatype, op, NULL,

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -253,7 +253,6 @@ void smr_generic_format(struct smr_cmd *cmd, int64_t tx_id, int64_t rx_id,
 	cmd->hdr.tx_id = tx_id;
 	cmd->hdr.cq_data = data;
 	cmd->hdr.tag = tag;
-	cmd->hdr.status = 0;
 	cmd->hdr.rx_ctx = 0;
 
 	if (op_flags & FI_REMOTE_CQ_DATA)

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -244,18 +244,15 @@ void smr_format_tx_pend(struct smr_pend_entry *pend, struct smr_cmd *cmd,
 
 void smr_generic_format(struct smr_cmd *cmd, int64_t tx_id, int64_t rx_id,
 			uint32_t op, uint64_t tag, uint64_t data,
-			uint64_t op_flags)
+			uint8_t smr_flags)
 {
 	cmd->hdr.op = op;
-	cmd->hdr.op_flags = 0;
+	cmd->hdr.smr_flags = smr_flags;
 	cmd->hdr.rx_id = rx_id;
 	cmd->hdr.tx_id = tx_id;
 	cmd->hdr.cq_data = data;
 	cmd->hdr.tag = tag;
 	cmd->hdr.rx_ctx = 0;
-
-	if (op_flags & FI_REMOTE_CQ_DATA)
-		cmd->hdr.op_flags |= SMR_REMOTE_CQ_DATA;
 }
 
 static void smr_format_inline(struct smr_cmd *cmd, struct ofi_mr **mr,
@@ -264,26 +261,6 @@ static void smr_format_inline(struct smr_cmd *cmd, struct ofi_mr **mr,
 	cmd->hdr.proto = smr_proto_inline;
 	cmd->hdr.size = ofi_copy_from_mr_iov(cmd->data.msg, SMR_MSG_DATA_LEN,
 					     mr, iov, count, 0);
-}
-
-static void smr_format_inject(struct smr_ep *ep, struct smr_cmd *cmd,
-			      struct smr_pend_entry *pend)
-{
-	struct smr_inject_buf *tx_buf;
-
-	tx_buf = smr_get_inject_buf(ep->region, cmd);
-
-	cmd->hdr.proto = smr_proto_inject;
-	if (cmd->hdr.op != ofi_op_read_req) {
-		cmd->hdr.size = ofi_copy_from_mr_iov(tx_buf->data,
-						     SMR_INJECT_SIZE,
-						     pend->mr, pend->iov,
-						     pend->iov_count, 0);
-		pend->bytes_done = cmd->hdr.size;
-	} else {
-		cmd->hdr.size = ofi_total_iov_len(pend->iov, pend->iov_count);
-		pend->bytes_done = 0;
-	}
 }
 
 static void smr_format_iov(struct smr_cmd *cmd, struct smr_pend_entry *pend)
@@ -377,9 +354,8 @@ static int smr_format_sar(struct smr_ep *ep, struct smr_cmd *cmd,
 		ret = pend->sar_copy_fn(ep, pend);
 		if (ret < 0 && ret != -FI_EBUSY) {
 			for (i = cmd->data.buf_batch_size - 1; i >= 0; i--) {
-				smr_freestack_push_by_index(
-						smr_sar_pool(ep->region),
-						cmd->data.sar[i]);
+				smr_return_sar_buf_by_index(ep->region,
+							    cmd->data.sar[i]);
 			}
 			return -FI_EAGAIN;
 		}
@@ -396,12 +372,15 @@ static int smr_format_sar(struct smr_ep *ep, struct smr_cmd *cmd,
 
 int smr_select_proto(void **desc, size_t iov_count, bool vma_avail,
 		     bool ipc_valid, uint32_t op, uint64_t total_len,
-		     uint64_t op_flags)
+		     uint64_t op_flags, uint8_t *smr_flags)
 {
 	struct ofi_mr *smr_desc;
 	enum fi_hmem_iface iface = FI_HMEM_SYSTEM;
 	bool fastcopy_avail = false, use_ipc = false;
 
+	*smr_flags = 0;
+	*smr_flags |= (op_flags & FI_DELIVERY_COMPLETE) ? SMR_RETURN_CMD : 0;
+	*smr_flags |= (op_flags & FI_REMOTE_CQ_DATA) ? SMR_REMOTE_CQ_DATA : 0;
 	/* Do not inline/inject if IPC is available so device to device
 	 * transfer may occur if possible. */
 	if (iov_count == 1 && desc && desc[0] && ipc_valid) {
@@ -418,6 +397,7 @@ int smr_select_proto(void **desc, size_t iov_count, bool vma_avail,
 	}
 
 	if (op == ofi_op_read_req) {
+		*smr_flags |= SMR_RETURN_CMD;
 		if (use_ipc)
 			return smr_proto_ipc;
 		if (vma_avail && FI_HMEM_SYSTEM == iface)
@@ -425,32 +405,41 @@ int smr_select_proto(void **desc, size_t iov_count, bool vma_avail,
 		return smr_proto_sar;
 	}
 
-	if (fastcopy_avail && total_len <= smr_env.max_gdrcopy_size)
-		return total_len <= SMR_MSG_DATA_LEN ? smr_proto_inline :
-						       smr_proto_inject;
+	if (fastcopy_avail && total_len <= smr_env.max_gdrcopy_size) {
+		if (total_len <= SMR_MSG_DATA_LEN &&
+		    !(op_flags & FI_DELIVERY_COMPLETE))
+			return smr_proto_inline;
+		else
+			return smr_proto_inject;
+	}
 
-	if (use_ipc && !(op_flags & FI_INJECT))
+	if (use_ipc && !(op_flags & FI_INJECT)) {
+		*smr_flags |= SMR_RETURN_CMD;
 		return smr_proto_ipc;
+	}
 
 	if (op_flags & FI_INJECT || total_len <= SMR_INJECT_SIZE) {
 		if (op_flags & FI_DELIVERY_COMPLETE)
 			return smr_proto_inject;
+
 		return total_len <= SMR_MSG_DATA_LEN ?
 				smr_proto_inline : smr_proto_inject;
 	}
 
+	*smr_flags |= SMR_RETURN_CMD;
 	return vma_avail ? smr_proto_iov: smr_proto_sar;
 }
 
 static ssize_t smr_do_inline(struct smr_ep *ep, struct smr_region *peer_smr,
 			     int64_t tx_id, int64_t rx_id, uint32_t op,
 			     uint64_t tag, uint64_t data, uint64_t op_flags,
-			     struct ofi_mr **desc, const struct iovec *iov,
-			     size_t iov_count, size_t total_len, void *context,
+			     uint8_t smr_flags, struct ofi_mr **desc,
+			     const struct iovec *iov, size_t iov_count,
+			     size_t total_len, void *context,
 			     struct smr_cmd *cmd)
 {
 	cmd->hdr.tx_ctx = 0;
-	smr_generic_format(cmd, tx_id, rx_id, op, tag, data, op_flags);
+	smr_generic_format(cmd, tx_id, rx_id, op, tag, data, smr_flags);
 	smr_format_inline(cmd, desc, iov, iov_count);
 
 	return FI_SUCCESS;
@@ -459,34 +448,72 @@ static ssize_t smr_do_inline(struct smr_ep *ep, struct smr_region *peer_smr,
 static ssize_t smr_do_inject(struct smr_ep *ep, struct smr_region *peer_smr,
 			     int64_t tx_id, int64_t rx_id, uint32_t op,
 			     uint64_t tag, uint64_t data, uint64_t op_flags,
-			     struct ofi_mr **desc, const struct iovec *iov,
-			     size_t iov_count, size_t total_len, void *context,
+			     uint8_t smr_flags, struct ofi_mr **desc,
+			     const struct iovec *iov, size_t iov_count,
+			     size_t total_len, void *context,
 			     struct smr_cmd *cmd)
 {
-	struct smr_pend_entry *pend;
+	struct smr_pend_entry *pend = NULL;
+	struct smr_inject_buf *tx_buf;
+	int ret;
 
-	pend = ofi_buf_alloc(ep->pend_pool);
-	assert(pend);
+	if (op == ofi_op_read_req) {
+		tx_buf = smr_get_inject_buf(ep->region);
+		cmd->hdr.proto_data = smr_get_offset(ep->region, tx_buf);
+	} else {
+		tx_buf = smr_get_inject_buf(peer_smr);
+		cmd->hdr.proto_data = smr_get_offset(peer_smr, tx_buf);
+	}
+	if (!tx_buf) {
+		FI_DBG(&smr_prov, FI_LOG_EP_DATA,
+		       "No inject buffers available, cannot send inject "
+		       "message\n");
+		return -FI_EAGAIN;
+	}
 
-	cmd->hdr.tx_ctx = (uintptr_t) pend;
-	smr_format_tx_pend(pend, cmd, context, desc, iov, iov_count, op_flags);
+	if (smr_flags & SMR_RETURN_CMD) {
+		pend = ofi_buf_alloc(ep->pend_pool);
+		assert(pend);
+		cmd->hdr.tx_ctx = (uintptr_t) pend;
+		smr_format_tx_pend(pend, cmd, context, desc, iov, iov_count,
+				   op_flags);
+		if (smr_freestack_avail(smr_cmd_stack(ep->region)) <=
+		    smr_env.buffer_threshold)
+			smr_flags |= SMR_BUFFER_RECV;
+	} else {
+		cmd->hdr.tx_ctx = 0;
+	}
 
-	smr_generic_format(cmd, tx_id, rx_id, op, tag, data, op_flags);
-	smr_format_inject(ep, cmd, pend);
+	smr_generic_format(cmd, tx_id, rx_id, op, tag, data, smr_flags);
+	cmd->hdr.proto = smr_proto_inject;
+	if (cmd->hdr.op != ofi_op_read_req)
+		cmd->hdr.size = ofi_copy_from_mr_iov(tx_buf->data,
+						     SMR_INJECT_SIZE,
+						     desc, iov, iov_count, 0);
+	else
+		cmd->hdr.size = ofi_total_iov_len(iov, iov_count);
 
-	if (smr_freestack_avail(smr_cmd_stack(ep->region)) <=
-	    smr_env.buffer_threshold)
-		cmd->hdr.op_flags |= SMR_BUFFER_RECV;
+	if (total_len != cmd->hdr.size) {
+		ret = -FI_ETRUNC;
+		goto err;
+	}
+
+	if (pend && op != ofi_op_read_req)
+		pend->bytes_done = cmd->hdr.size;
 
 	return FI_SUCCESS;
+err:
+	if (pend)
+		ofi_buf_free(pend);
+	return ret;
 }
 
 static ssize_t smr_do_iov(struct smr_ep *ep, struct smr_region *peer_smr,
 			  int64_t tx_id, int64_t rx_id, uint32_t op,
 			  uint64_t tag, uint64_t data, uint64_t op_flags,
-			  struct ofi_mr **desc, const struct iovec *iov,
-			  size_t iov_count, size_t total_len, void *context,
-			  struct smr_cmd *cmd)
+			  uint8_t smr_flags, struct ofi_mr **desc,
+			  const struct iovec *iov, size_t iov_count,
+			  size_t total_len, void *context, struct smr_cmd *cmd)
 {
 	struct smr_pend_entry *pend;
 
@@ -496,12 +523,12 @@ static ssize_t smr_do_iov(struct smr_ep *ep, struct smr_region *peer_smr,
 	cmd->hdr.tx_ctx = (uintptr_t) pend;
 	smr_format_tx_pend(pend, cmd, context, desc, iov, iov_count, op_flags);
 
-	smr_generic_format(cmd, tx_id, rx_id, op, tag, data, op_flags);
+	smr_generic_format(cmd, tx_id, rx_id, op, tag, data, smr_flags);
 	smr_format_iov(cmd, pend);
 
 	if (smr_freestack_avail(smr_cmd_stack(ep->region)) <=
 	    smr_env.buffer_threshold)
-		cmd->hdr.op_flags |= SMR_BUFFER_RECV;
+		cmd->hdr.smr_flags |= SMR_BUFFER_RECV;
 
 	return FI_SUCCESS;
 }
@@ -509,9 +536,9 @@ static ssize_t smr_do_iov(struct smr_ep *ep, struct smr_region *peer_smr,
 static ssize_t smr_do_sar(struct smr_ep *ep, struct smr_region *peer_smr,
 			  int64_t tx_id, int64_t rx_id, uint32_t op,
 			  uint64_t tag, uint64_t data, uint64_t op_flags,
-			  struct ofi_mr **desc, const struct iovec *iov,
-			  size_t iov_count, size_t total_len, void *context,
-			  struct smr_cmd *cmd)
+			  uint8_t smr_flags, struct ofi_mr **desc,
+			  const struct iovec *iov, size_t iov_count,
+			  size_t total_len, void *context, struct smr_cmd *cmd)
 {
 	struct smr_pend_entry *pend;
 	int ret;
@@ -530,7 +557,7 @@ static ssize_t smr_do_sar(struct smr_ep *ep, struct smr_region *peer_smr,
 	else
 		pend->sar_copy_fn = &smr_copy_sar;
 
-	smr_generic_format(cmd, tx_id, rx_id, op, tag, data, op_flags);
+	smr_generic_format(cmd, tx_id, rx_id, op, tag, data, smr_flags);
 	ret = smr_format_sar(ep, cmd, desc, iov, iov_count, total_len,
 			     ep->region, peer_smr, pend);
 	if (ret)
@@ -542,9 +569,9 @@ static ssize_t smr_do_sar(struct smr_ep *ep, struct smr_region *peer_smr,
 static ssize_t smr_do_ipc(struct smr_ep *ep, struct smr_region *peer_smr,
 			  int64_t tx_id, int64_t rx_id, uint32_t op,
 			  uint64_t tag, uint64_t data, uint64_t op_flags,
-			  struct ofi_mr **desc, const struct iovec *iov,
-			  size_t iov_count, size_t total_len, void *context,
-			  struct smr_cmd *cmd)
+			  uint8_t smr_flags, struct ofi_mr **desc,
+			  const struct iovec *iov, size_t iov_count,
+			  size_t total_len, void *context, struct smr_cmd *cmd)
 {
 	struct smr_pend_entry *pend;
 	int ret = -FI_EAGAIN;
@@ -553,7 +580,7 @@ static ssize_t smr_do_ipc(struct smr_ep *ep, struct smr_region *peer_smr,
 	assert(pend);
 
 	cmd->hdr.tx_ctx = (uintptr_t) pend;
-	smr_generic_format(cmd, tx_id, rx_id, op, tag, data, op_flags);
+	smr_generic_format(cmd, tx_id, rx_id, op, tag, data, smr_flags);
 	assert(iov_count == 1 && desc && desc[0]);
 	ret = smr_format_ipc(cmd, iov[0].iov_base, total_len, ep->region,
 			     desc[0]->iface, desc[0]->device);
@@ -564,7 +591,7 @@ static ssize_t smr_do_ipc(struct smr_ep *ep, struct smr_region *peer_smr,
 			     "fallback to using SAR\n");
 		ofi_buf_free(pend);
 		return smr_do_sar(ep, peer_smr, tx_id, rx_id, op, tag, data,
-				  op_flags, desc, iov, iov_count,
+				  op_flags, smr_flags, desc, iov, iov_count,
 				  total_len, context, cmd);
 	}
 
@@ -572,7 +599,7 @@ static ssize_t smr_do_ipc(struct smr_ep *ep, struct smr_region *peer_smr,
 
 	if (smr_freestack_avail(smr_cmd_stack(ep->region)) <=
 	    smr_env.buffer_threshold)
-		cmd->hdr.op_flags |= SMR_BUFFER_RECV;
+		cmd->hdr.smr_flags |= SMR_BUFFER_RECV;
 
 	return FI_SUCCESS;
 }
@@ -692,25 +719,16 @@ static int smr_discard(struct fi_peer_rx_entry *rx_entry)
 	struct smr_unexp_buf *sar_buf;
 
 	dlist_remove(&cmd_ctx->entry);
-
-	switch (cmd_ctx->cmd->hdr.proto) {
-	case smr_proto_inline:
-		break;
-	case smr_proto_sar:
-		while (!slist_empty(&cmd_ctx->buf_list)) {
-			slist_remove_head_container(
-					&cmd_ctx->buf_list,
-					struct smr_unexp_buf, sar_buf,
-					entry);
-			ofi_buf_free(sar_buf);
-		}
-		break;
-	case smr_proto_inject:
-	case smr_proto_iov:
-	case smr_proto_ipc:
-		smr_return_cmd(cmd_ctx->ep, cmd_ctx->cmd);
-		break;
+	while (!slist_empty(&cmd_ctx->buf_list)) {
+		slist_remove_head_container(
+				&cmd_ctx->buf_list,
+				struct smr_unexp_buf, sar_buf,
+				entry);
+		ofi_buf_free(sar_buf);
 	}
+
+	if (cmd_ctx->cmd->hdr.smr_flags & SMR_RETURN_CMD)
+		smr_return_cmd(cmd_ctx->ep, cmd_ctx->cmd);
 
 	ofi_buf_free(cmd_ctx);
 

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -172,7 +172,7 @@ static struct fi_ops_ep smr_ep_ops = {
 static void smr_send_name(struct smr_ep *ep, int64_t id)
 {
 	struct smr_region *peer_smr;
-	struct smr_cmd_entry *ce;
+	struct smr_cmd *cmd;
 	int64_t pos;
 	int ret;
 
@@ -181,20 +181,19 @@ static void smr_send_name(struct smr_ep *ep, int64_t id)
 	if (smr_peer_data(ep->region)[id].name_sent)
 		return;
 
-	ret = smr_cmd_queue_next(smr_cmd_queue(peer_smr), &ce, &pos);
+	ret = smr_cmd_queue_next(smr_cmd_queue(peer_smr), &cmd, &pos);
 	if (ret == -FI_ENOENT)
 		return;
 
-	ce->ptr = smr_peer_to_peer(ep, peer_smr, id, (uintptr_t) &ce->cmd);
-	ce->cmd.hdr.op = SMR_OP_MAX + ofi_ctrl_connreq;
-	ce->cmd.hdr.tx_id = id;
-	ce->cmd.hdr.cq_data = ep->region->pid;
+	cmd->hdr.op = SMR_OP_MAX + ofi_ctrl_connreq;
+	cmd->hdr.tx_id = id;
+	cmd->hdr.cq_data = ep->region->pid;
 
-	ce->cmd.hdr.size = strlen(ep->name) + 1;
-	memcpy(ce->cmd.data.msg, ep->name, ce->cmd.hdr.size);
+	cmd->hdr.size = strlen(ep->name) + 1;
+	memcpy(cmd->data.msg, ep->name, cmd->hdr.size);
 
 	smr_peer_data(ep->region)[id].name_sent = 1;
-	smr_cmd_queue_commit(ce, pos);
+	smr_cmd_queue_commit(cmd, pos);
 }
 
 int64_t smr_verify_peer(struct smr_ep *ep, fi_addr_t fi_addr)

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -186,6 +186,7 @@ static void smr_send_name(struct smr_ep *ep, int64_t id)
 		return;
 
 	cmd->hdr.op = SMR_OP_MAX + ofi_ctrl_connreq;
+	cmd->hdr.smr_flags = 0;
 	cmd->hdr.tx_id = id;
 	cmd->hdr.cq_data = ep->region->pid;
 

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -728,7 +728,8 @@ static int smr_discard(struct fi_peer_rx_entry *rx_entry)
 		ofi_buf_free(sar_buf);
 	}
 
-	if (cmd_ctx->cmd->hdr.smr_flags & SMR_RETURN_CMD)
+	if (cmd_ctx->cmd != &cmd_ctx->cmd_cpy &&
+	    (cmd_ctx->cmd->hdr.smr_flags & SMR_RETURN_CMD))
 		smr_return_cmd(cmd_ctx->ep, cmd_ctx->cmd);
 
 	ofi_buf_free(cmd_ctx);

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -420,8 +420,6 @@ int smr_select_proto(void **desc, size_t iov_count, bool vma_avail,
 	if (op == ofi_op_read_req) {
 		if (use_ipc)
 			return smr_proto_ipc;
-		if (total_len <= SMR_INJECT_SIZE)
-			return smr_proto_inject;
 		if (vma_avail && FI_HMEM_SYSTEM == iface)
 			return smr_proto_iov;
 		return smr_proto_sar;

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -248,12 +248,12 @@ void smr_generic_format(struct smr_cmd *cmd, int64_t tx_id, int64_t rx_id,
 			uint64_t op_flags)
 {
 	cmd->hdr.op = op;
-	cmd->hdr.status = 0;
 	cmd->hdr.op_flags = 0;
-	cmd->hdr.tag = tag;
-	cmd->hdr.tx_id = tx_id;
 	cmd->hdr.rx_id = rx_id;
+	cmd->hdr.tx_id = tx_id;
 	cmd->hdr.cq_data = data;
+	cmd->hdr.tag = tag;
+	cmd->hdr.status = 0;
 	cmd->hdr.rx_ctx = 0;
 
 	if (op_flags & FI_REMOTE_CQ_DATA)

--- a/prov/shm/src/smr_init.c
+++ b/prov/shm/src/smr_init.c
@@ -40,7 +40,7 @@ struct sigaction *old_action = NULL;
 struct smr_env smr_env = {
 	.disable_cma = false,
 	.use_dsa_sar = false,
-	.max_gdrcopy_size = 3072,
+	.max_gdrcopy_size = SMR_MAX_GDRCOPY_SIZE,
 	.use_xpmem = false,
 	.buffer_threshold = 1,
 };
@@ -51,6 +51,7 @@ static void smr_init_env(void)
 	fi_param_get_size_t(&smr_prov, "rx_size", &smr_info.rx_attr->size);
 	fi_param_get_bool(&smr_prov, "disable_cma", &smr_env.disable_cma);
 	fi_param_get_bool(&smr_prov, "use_dsa_sar", &smr_env.use_dsa_sar);
+	fi_param_get_size_t(&smr_prov, "max_gdrcopy_size", &smr_env.max_gdrcopy_size);
 	fi_param_get_bool(&smr_prov, "use_xpmem", &smr_env.use_xpmem);
 	fi_param_get_size_t(&smr_prov, "buffer_threshold",
 			    &smr_env.buffer_threshold);
@@ -216,6 +217,10 @@ SHM_INI
 			"Manually disables CMA. Default: false");
 	fi_param_define(&smr_prov, "use_dsa_sar", FI_PARAM_BOOL,
 			"Enable use of DSA in SAR protocol. Default: false");
+	fi_param_define(&smr_prov, "max_gdrcopy_size", FI_PARAM_SIZE_T,
+			"Maximum message size for gdrcopy transfers. Messages "
+			"larger than this size use the IPC protocol with cudaMemcpy.",
+			 SMR_MAX_GDRCOPY_SIZE);
 	fi_param_define(&smr_prov, "use_xpmem", FI_PARAM_BOOL,
 			"Enable XPMEM over CMA when possible "
 			"(default: false)");

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -83,8 +83,7 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 	ssize_t ret = -FI_EAGAIN;
 	size_t total_len;
 	int proto;
-	struct smr_cmd_entry *ce;
-	struct smr_cmd *cmd;
+	struct smr_cmd *ce, *cmd;
 
 	assert(iov_count <= SMR_IOV_LIMIT);
 
@@ -121,10 +120,10 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 
 		cmd = smr_freestack_pop(smr_cmd_stack(ep->region));
 		assert(cmd);
-		ce->ptr = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
-					    (uintptr_t) cmd);
+		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
+						  (uintptr_t) cmd);
 	} else {
-		cmd = &ce->cmd;
+		cmd = ce;
 	}
 
 	ret = smr_send_ops[proto](ep, peer_smr, tx_id, rx_id, op, tag, data,
@@ -203,8 +202,7 @@ static ssize_t smr_generic_inject(struct fid_ep *ep_fid, const void *buf,
 	ssize_t ret = 0;
 	struct iovec msg_iov;
 	int proto;
-	struct smr_cmd_entry *ce;
-	struct smr_cmd *cmd;
+	struct smr_cmd *ce, *cmd;
 
 	assert(len <= SMR_INJECT_SIZE);
 
@@ -234,7 +232,7 @@ static ssize_t smr_generic_inject(struct fid_ep *ep_fid, const void *buf,
 
 	if (len <= SMR_MSG_DATA_LEN) {
 		proto = smr_proto_inline;
-		cmd = &ce->cmd;
+		cmd = ce;
 	} else {
 		proto = smr_proto_inject;
 		if (smr_freestack_isempty(smr_cmd_stack(ep->region))) {
@@ -245,8 +243,8 @@ static ssize_t smr_generic_inject(struct fid_ep *ep_fid, const void *buf,
 
 		cmd = smr_freestack_pop(smr_cmd_stack(ep->region));
 		assert(cmd);
-		ce->ptr = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
-					    (uintptr_t) cmd);
+		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
+						  (uintptr_t) cmd);
 	}
 
 	ret = smr_send_ops[proto](ep, peer_smr, tx_id, rx_id, op, tag, data,

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -120,6 +120,7 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 
 		cmd = smr_freestack_pop(smr_cmd_stack(ep->region));
 		assert(cmd);
+		ce->hdr.smr_flags = smr_flags;
 		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
 						  (uintptr_t) cmd);
 	} else {

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -84,6 +84,7 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 	size_t total_len;
 	int proto;
 	struct smr_cmd *ce, *cmd;
+	uint8_t smr_flags;
 
 	assert(iov_count <= SMR_IOV_LIMIT);
 
@@ -109,9 +110,8 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 
 	proto = smr_select_proto(desc, iov_count, smr_vma_enabled(ep, peer_smr),
 	                         smr_ipc_valid(ep, peer_smr, tx_id, rx_id), op,
-				 total_len, op_flags);
-
-	if (proto != smr_proto_inline) {
+				 total_len, op_flags, &smr_flags);
+	if (smr_flags & SMR_RETURN_CMD) {
 		if (smr_freestack_isempty(smr_cmd_stack(ep->region))) {
 			smr_cmd_queue_discard(ce, pos);
 			ret = -FI_EAGAIN;
@@ -127,17 +127,17 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 	}
 
 	ret = smr_send_ops[proto](ep, peer_smr, tx_id, rx_id, op, tag, data,
-				  op_flags, (struct ofi_mr **) desc, iov,
-				  iov_count, total_len, context, cmd);
+				  op_flags, smr_flags, (struct ofi_mr **) desc,
+				  iov, iov_count, total_len, context, cmd);
 	if (ret) {
 		smr_cmd_queue_discard(ce, pos);
-		if (proto != smr_proto_inline)
+		if (smr_flags & SMR_RETURN_CMD)
 			smr_freestack_push(smr_cmd_stack(ep->region), cmd);
 		goto unlock;
 	}
 	smr_cmd_queue_commit(ce, pos);
 
-	if (proto != smr_proto_inline)
+	if (smr_flags & SMR_RETURN_CMD)
 		goto unlock;
 
 	ret = smr_complete_tx(ep, context, op, op_flags);
@@ -203,6 +203,7 @@ static ssize_t smr_generic_inject(struct fid_ep *ep_fid, const void *buf,
 	struct iovec msg_iov;
 	int proto;
 	struct smr_cmd *ce, *cmd;
+	uint8_t smr_flags;
 
 	assert(len <= SMR_INJECT_SIZE);
 
@@ -230,36 +231,20 @@ static ssize_t smr_generic_inject(struct fid_ep *ep_fid, const void *buf,
 		goto unlock;
 	}
 
-	if (len <= SMR_MSG_DATA_LEN) {
-		proto = smr_proto_inline;
-		cmd = ce;
-	} else {
-		proto = smr_proto_inject;
-		if (smr_freestack_isempty(smr_cmd_stack(ep->region))) {
-			smr_cmd_queue_discard(ce, pos);
-			ret = -FI_EAGAIN;
-			goto unlock;
-		}
+	proto = len <= SMR_MSG_DATA_LEN ? smr_proto_inline : smr_proto_inject;
+	cmd = ce;
 
-		cmd = smr_freestack_pop(smr_cmd_stack(ep->region));
-		assert(cmd);
-		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
-						  (uintptr_t) cmd);
-	}
-
+	smr_flags = (op_flags & FI_REMOTE_CQ_DATA) ? SMR_REMOTE_CQ_DATA : 0;
 	ret = smr_send_ops[proto](ep, peer_smr, tx_id, rx_id, op, tag, data,
-				  op_flags, NULL, &msg_iov, 1, len, NULL, cmd);
+				  op_flags, smr_flags, NULL, &msg_iov, 1, len,
+				  NULL, cmd);
 	if (ret) {
-		if (proto != smr_proto_inline)
-			smr_freestack_push(smr_cmd_stack(ep->region), cmd);
 		smr_cmd_queue_discard(ce, pos);
 		ret = -FI_EAGAIN;
 		goto unlock;
 	}
 	smr_cmd_queue_commit(ce, pos);
-
-	if (proto == smr_proto_inline)
-		ofi_ep_peer_tx_cntr_inc(&ep->util_ep, op);
+	ofi_ep_peer_tx_cntr_inc(&ep->util_ep, op);
 
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -37,9 +37,8 @@
 
 static void smr_progress_overflow(struct smr_ep *ep)
 {
-	struct smr_cmd_entry *ce;
 	struct smr_region *peer_smr;
-	struct smr_cmd *cmd;
+	struct smr_cmd *ce, *cmd;
 	int64_t pos;
 	struct slist_entry *entry;
 	int ret;
@@ -53,8 +52,9 @@ static void smr_progress_overflow(struct smr_ep *ep)
 		if (ret == -FI_ENOENT)
 			return;
 
-		ce->ptr = smr_local_to_peer(ep, peer_smr, cmd->hdr.tx_id,
-					    cmd->hdr.rx_id, (uintptr_t) cmd);
+		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, cmd->hdr.tx_id,
+						  cmd->hdr.rx_id,
+						  (uintptr_t) cmd);
 
 		slist_remove_head(&ep->overflow_list);
 		smr_cmd_queue_commit(ce, pos);
@@ -1320,8 +1320,7 @@ out:
 
 static void smr_progress_cmd(struct smr_ep *ep)
 {
-	struct smr_cmd_entry *ce;
-	struct smr_cmd *cmd;
+	struct smr_cmd *ce, *cmd;
 	int ret = 0;
 	int64_t pos;
 
@@ -1330,7 +1329,7 @@ static void smr_progress_cmd(struct smr_ep *ep)
 		if (ret == -FI_ENOENT)
 			break;
 
-		cmd = (struct smr_cmd *) ce->ptr;
+		cmd = (struct smr_cmd *) ce->hdr.entry;
 		switch (cmd->hdr.op) {
 		case ofi_op_msg:
 		case ofi_op_tagged:

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -361,7 +361,8 @@ static int smr_progress_pending_sar(struct smr_ep *ep, struct smr_cmd *cmd)
 			dlist_insert_tail(&pend->entry, &ep->async_cpy_list);
 			return FI_SUCCESS;
 		}
-		cmd->hdr.smr_flags |= SMR_OP_ERROR;
+		if (ret)
+			cmd->hdr.smr_flags |= SMR_OP_ERROR;
 		goto out;
 	}
 

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -982,28 +982,27 @@ static int smr_unexp_sar(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 	memcpy(&cmd_ctx->cmd_cpy, cmd,
 		sizeof(cmd->hdr) + sizeof(cmd->data));
 
-	if (cmd->hdr.size) {
-		sar_entry = ofi_buf_alloc(ep->pend_pool);
-		if (!sar_entry) {
-			ofi_buf_free(cmd_ctx);
-			ret = -FI_ENOMEM;
-			cmd->hdr.op_flags |= SMR_OP_ERROR;
-			goto out;
-		}
-		cmd->hdr.rx_ctx = (uintptr_t) sar_entry;
+	assert(cmd->hdr.size);
+	sar_entry = ofi_buf_alloc(ep->pend_pool);
+	if (!sar_entry) {
+		ofi_buf_free(cmd_ctx);
+		ret = -FI_ENOMEM;
+		cmd->hdr.op_flags |= SMR_OP_ERROR;
+		goto out;
+	}
+	cmd->hdr.rx_ctx = (uintptr_t) sar_entry;
 
-		smr_init_rx_pend(sar_entry, cmd, rx_entry, NULL, NULL, 0);
-		cmd_ctx->pend = sar_entry;
+	smr_init_rx_pend(sar_entry, cmd, rx_entry, NULL, NULL, 0);
+	cmd_ctx->pend = sar_entry;
 
-		ret = smr_buffer_sar(ep, sar_entry,
-				     sar_entry->rx_entry->peer_context);
-		if (ret == -FI_EAGAIN) {
-			dlist_insert_tail(&sar_entry->entry,
-					  &ep->async_cpy_list);
-			return FI_SUCCESS;
-		} else if (ret && ret != -FI_EAGAIN) {
-			cmd->hdr.op_flags |= SMR_OP_ERROR;
-		}
+	ret = smr_buffer_sar(ep, sar_entry,
+				sar_entry->rx_entry->peer_context);
+	if (ret == -FI_EAGAIN) {
+		dlist_insert_tail(&sar_entry->entry,
+					&ep->async_cpy_list);
+		return FI_SUCCESS;
+	} else if (ret && ret != -FI_EAGAIN) {
+		cmd->hdr.op_flags |= SMR_OP_ERROR;
 	}
 out:
 	smr_return_cmd(ep, cmd);

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -46,7 +46,8 @@ static void smr_progress_overflow(struct smr_ep *ep)
 
 	entry = ep->overflow_list.head;
 	while (entry) {
-		cmd = (struct smr_cmd *) entry;
+		cmd = container_of(container_of(entry, struct smr_cmd_hdr,
+				   entry), struct smr_cmd, hdr);
 		peer_smr = smr_peer_region(ep, cmd->hdr.tx_id);
 		ret = smr_cmd_queue_next(smr_cmd_queue(peer_smr), &ce, &pos);
 		if (ret == -FI_ENOENT)

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -76,8 +76,7 @@ void smr_free_sar_bufs(struct smr_ep *ep, struct smr_cmd *cmd,
 	int i;
 
 	for (i = cmd->data.buf_batch_size - 1; i >= 0; i--) {
-		smr_freestack_push_by_index(smr_sar_pool(ep->region),
-					    cmd->data.sar[i]);
+		smr_return_sar_buf_by_index(ep->region, cmd->data.sar[i]);
 	}
 	smr_peer_data(ep->region)[cmd->hdr.tx_id].sar_status = SMR_SAR_FREE;
 }
@@ -97,7 +96,7 @@ static int smr_progress_return_entry(struct smr_ep *ep, struct smr_cmd *cmd,
 		assert(pend->mr[0]);
 		break;
 	case smr_proto_sar:
-		if (cmd->hdr.op_flags & SMR_OP_ERROR) {
+		if (cmd->hdr.smr_flags & SMR_OP_ERROR) {
 			smr_free_sar_bufs(ep, cmd, pend);
 			return -FI_EIO;
 		}
@@ -134,33 +133,30 @@ static int smr_progress_return_entry(struct smr_ep *ep, struct smr_cmd *cmd,
 		smr_try_send_cmd(ep, cmd);
 		return -FI_EAGAIN;
 	case smr_proto_inject:
-		tx_buf = smr_get_inject_buf(ep->region, cmd);
-		if (pend) {
-			if (pend->bytes_done != cmd->hdr.size &&
-			    cmd->hdr.op != ofi_op_atomic) {
-				src = cmd->hdr.op == ofi_op_atomic_compare ?
-					tx_buf->buf : tx_buf->data;
-				hmem_copy_ret  = ofi_copy_to_mr_iov(
-							pend->mr, pend->iov,
-							pend->iov_count,
-							0, src, cmd->hdr.size);
+		assert(pend);
+		if (pend->bytes_done != cmd->hdr.size &&
+			cmd->hdr.op != ofi_op_atomic) {
+			tx_buf = smr_get_ptr(ep->region, cmd->hdr.proto_data);
+			src = cmd->hdr.op == ofi_op_atomic_compare ?
+				tx_buf->buf : tx_buf->data;
+			hmem_copy_ret  = ofi_copy_to_mr_iov(
+						pend->mr, pend->iov,
+						pend->iov_count,
+						0, src, cmd->hdr.size);
 
-				if (hmem_copy_ret < 0) {
-					FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-						"RMA read/fetch failed "
-						"with code %d\n",
-						(int)(-hmem_copy_ret));
-					ret = hmem_copy_ret;
-				} else if (hmem_copy_ret != cmd->hdr.size) {
-					FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-						"Incomplete rma read/fetch "
-						"buffer copied\n");
-					ret = -FI_ETRUNC;
-				} else {
-					pend->bytes_done =
-						(size_t) hmem_copy_ret;
-				}
+			if (hmem_copy_ret < 0) {
+				FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+					"RMA read/fetch failed "
+					"with code %d\n",
+					(int)(-hmem_copy_ret));
+				ret = hmem_copy_ret;
+			} else if (hmem_copy_ret != cmd->hdr.size) {
+				FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+					"Incomplete rma read/fetch "
+					"buffer copied\n");
+				ret = -FI_ETRUNC;
 			}
+			smr_return_inject_buf(ep->region, tx_buf);
 		}
 		break;
 	default:
@@ -190,26 +186,25 @@ static void smr_progress_return(struct smr_ep *ep)
 
 		ret = smr_progress_return_entry(ep, cmd, pending);
 		if (ret != -FI_EAGAIN) {
-			if (pending) {
-				if (cmd->hdr.op_flags & SMR_OP_ERROR) {
-					ret = smr_write_err_comp(
-							ep->util_ep.tx_cq,
-							pending->comp_ctx,
-							pending->comp_flags,
-							cmd->hdr.tag, -FI_EIO);
-				} else {
-					ret = smr_complete_tx(
-							ep, pending->comp_ctx,
-							cmd->hdr.op,
-							pending->comp_flags);
-				}
-				if (ret) {
-					FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-						"unable to process "
-						"tx completion\n");
-				}
-				ofi_buf_free(pending);
+			assert(pending);
+			if (cmd->hdr.smr_flags & SMR_OP_ERROR) {
+				ret = smr_write_err_comp(
+						ep->util_ep.tx_cq,
+						pending->comp_ctx,
+						pending->comp_flags,
+						cmd->hdr.tag, -FI_EIO);
+			} else {
+				ret = smr_complete_tx(
+						ep, pending->comp_ctx,
+						cmd->hdr.op,
+						pending->comp_flags);
 			}
+			if (ret) {
+				FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+					"unable to process "
+					"tx completion\n");
+			}
+			ofi_buf_free(pending);
 			smr_freestack_push(smr_cmd_stack(ep->region), cmd);
 		}
 		smr_return_queue_release(smr_return_queue(ep->region),
@@ -243,30 +238,31 @@ static ssize_t smr_progress_inject(struct smr_ep *ep, struct smr_cmd *cmd,
 				   struct ofi_mr **mr, struct iovec *iov,
 				   size_t iov_count)
 {
-	struct smr_region *peer_smr;
 	struct smr_inject_buf *tx_buf;
 	ssize_t ret;
 
-	peer_smr = smr_peer_region(ep, cmd->hdr.rx_id);
-	tx_buf = smr_get_inject_buf(peer_smr, cmd);
-
-	if (cmd->hdr.op == ofi_op_read_req) {
-		ret = ofi_copy_from_mr_iov(tx_buf->data, cmd->hdr.size, mr,
-					   iov, iov_count, 0);
-	} else {
+	if (cmd->hdr.op != ofi_op_read_req) {
+		tx_buf = smr_get_ptr(ep->region, cmd->hdr.proto_data);
 		ret = ofi_copy_to_mr_iov(mr, iov, iov_count, 0, tx_buf->data,
 					 cmd->hdr.size);
+		smr_return_inject_buf(ep->region, tx_buf);
+	} else {
+		tx_buf = smr_get_ptr(smr_peer_region(ep, cmd->hdr.tx_id),
+				     cmd->hdr.proto_data);
+		ret = ofi_copy_from_mr_iov(tx_buf->data, cmd->hdr.size, mr,
+					   iov, iov_count, 0);
 	}
 
 	if (ret < 0) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"inject recv failed with code %lu\n", ret);
-		cmd->hdr.op_flags |= SMR_OP_ERROR;
+		cmd->hdr.smr_flags |= SMR_OP_ERROR;
 	} else if (ret != cmd->hdr.size) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-			"inject recv truncated\n");
+			"inject recv truncated. Expected size %zu copied size "
+			"%zu\n", cmd->hdr.size, ret);
 		ret = -FI_ETRUNC;
-		cmd->hdr.op_flags |= SMR_OP_ERROR;
+		cmd->hdr.smr_flags |= SMR_OP_ERROR;
 	} else {
 		ret = FI_SUCCESS;
 	}
@@ -292,7 +288,7 @@ static ssize_t smr_progress_iov(struct smr_ep *ep, struct smr_cmd *cmd,
 			       peer_smr->pid, cmd->hdr.op == ofi_op_read_req,
 			       xpmem);
 	if (ret)
-		cmd->hdr.op_flags |= SMR_OP_ERROR;
+		cmd->hdr.smr_flags |= SMR_OP_ERROR;
 
 	return ret;
 }
@@ -348,7 +344,7 @@ static ssize_t smr_try_copy_rx_sar(struct smr_ep *ep,
 		if (ret == -FI_EAGAIN)
 			dlist_insert_tail(&pend->entry, &ep->async_cpy_list);
 		else if (ret && ret != -FI_EBUSY)
-			pend->cmd->hdr.op_flags |= SMR_OP_ERROR;
+			pend->cmd->hdr.smr_flags |= SMR_OP_ERROR;
 	}
 	return ret;
 }
@@ -365,7 +361,7 @@ static int smr_progress_pending_sar(struct smr_ep *ep, struct smr_cmd *cmd)
 			dlist_insert_tail(&pend->entry, &ep->async_cpy_list);
 			return FI_SUCCESS;
 		}
-		cmd->hdr.op_flags |= SMR_OP_ERROR;
+		cmd->hdr.smr_flags |= SMR_OP_ERROR;
 		goto out;
 	}
 
@@ -374,8 +370,8 @@ static int smr_progress_pending_sar(struct smr_ep *ep, struct smr_cmd *cmd)
 		return FI_SUCCESS;
 
 	if (pend->bytes_done == cmd->hdr.size ||
-	    pend->cmd->hdr.op_flags & SMR_OP_ERROR) {
-		if (pend->cmd->hdr.op_flags & SMR_OP_ERROR) {
+	    pend->cmd->hdr.smr_flags & SMR_OP_ERROR) {
+		if (pend->cmd->hdr.smr_flags & SMR_OP_ERROR) {
 			ret = smr_write_err_comp(ep->util_ep.rx_cq,
 						 pend->comp_ctx,
 						 pend->comp_flags,
@@ -423,10 +419,10 @@ static void smr_init_rx_pend(struct smr_pend_entry *pend, struct smr_cmd *cmd,
 	if (rx_entry) {
 		pend->comp_ctx = rx_entry->context;
 		pend->comp_flags = smr_rx_cq_flags(rx_entry->flags,
-						   cmd->hdr.op_flags);
+						   cmd->hdr.smr_flags);
 	} else {
 		pend->comp_ctx = NULL;
-		pend->comp_flags = smr_rx_cq_flags(0, cmd->hdr.op_flags);
+		pend->comp_flags = smr_rx_cq_flags(0, cmd->hdr.smr_flags);
 	}
 
 	pend->cmd = cmd;
@@ -577,7 +573,7 @@ uncache:
 	ofi_mr_cache_delete(domain->ipc_cache, mr_entry);
 out:
 	if (ret)
-		cmd->hdr.op_flags |= SMR_OP_ERROR;
+		cmd->hdr.smr_flags |= SMR_OP_ERROR;
 
 	return ret;
 }
@@ -597,7 +593,7 @@ static smr_progress_func smr_progress_ops[smr_proto_max] = {
 
 static void smr_do_atomic(struct smr_cmd *cmd, void *src, struct ofi_mr *dst_mr,
 			  void *dst, void *cmp, enum fi_datatype datatype,
-			  enum fi_op op, size_t cnt, uint16_t flags)
+			  enum fi_op op, size_t cnt)
 {
 	char tmp_result[SMR_INJECT_SIZE];
 	char tmp_dst[SMR_INJECT_SIZE];
@@ -653,7 +649,7 @@ static int smr_progress_inline_atomic(struct smr_cmd *cmd, struct ofi_mr **mr,
 	for (i = *len = 0; i < ioc_count && *len < cmd->hdr.size; i++) {
 		smr_do_atomic(cmd, &src[*len], mr[i], ioc[i].addr, NULL,
 			      cmd->hdr.datatype, cmd->hdr.atomic_op,
-			      ioc[i].count, cmd->hdr.op_flags);
+			      ioc[i].count);
 		*len += ioc[i].count * ofi_datatype_size(cmd->hdr.datatype);
 	}
 
@@ -673,7 +669,12 @@ static int smr_progress_inject_atomic(struct smr_cmd *cmd, struct ofi_mr **mr,
 	uint8_t *src, *comp;
 	int i;
 
-	tx_buf = smr_get_inject_buf(smr_peer_region(ep, cmd->hdr.rx_id), cmd);
+	if (cmd->hdr.op == ofi_op_atomic_compare ||
+	    cmd->hdr.op == ofi_op_atomic_fetch)
+		tx_buf = smr_get_ptr(smr_peer_region(ep, cmd->hdr.rx_id),
+				     cmd->hdr.proto_data);
+	else
+		tx_buf = smr_get_ptr(ep->region, cmd->hdr.proto_data);
 
 	switch (cmd->hdr.op) {
 	case ofi_op_atomic_compare:
@@ -689,10 +690,13 @@ static int smr_progress_inject_atomic(struct smr_cmd *cmd, struct ofi_mr **mr,
 	for (i = *len = 0; i < ioc_count && *len < cmd->hdr.size; i++) {
 		smr_do_atomic(cmd, &src[*len], mr[i], ioc[i].addr,
 			      comp ? &comp[*len] : NULL, cmd->hdr.datatype,
-			      cmd->hdr.atomic_op, ioc[i].count,
-			      cmd->hdr.op_flags);
+			      cmd->hdr.atomic_op, ioc[i].count);
 		*len += ioc[i].count * ofi_datatype_size(cmd->hdr.datatype);
 	}
+
+	if (cmd->hdr.op != ofi_op_atomic_compare &&
+	    cmd->hdr.op != ofi_op_atomic_fetch)
+		smr_return_inject_buf(ep->region, tx_buf);
 
 	if (*len != cmd->hdr.size) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL, "recv truncated");
@@ -709,7 +713,7 @@ static int smr_start_common(struct smr_ep *ep, struct smr_cmd *cmd,
 	uint64_t comp_flags;
 	void *comp_buf;
 	int ret;
-	bool return_cmd = cmd->hdr.proto != smr_proto_inline;
+	bool return_cmd = cmd->hdr.smr_flags & SMR_RETURN_CMD;
 
 	rx_entry->peer_context = NULL;
 	assert (cmd->hdr.proto < smr_proto_max);
@@ -717,11 +721,10 @@ static int smr_start_common(struct smr_ep *ep, struct smr_cmd *cmd,
 					ep, cmd, rx_entry,
 					(struct ofi_mr **) rx_entry->desc,
 					rx_entry->iov, rx_entry->count);
-
 	if (!cmd->hdr.rx_ctx) {
 		comp_buf = rx_entry->iov[0].iov_base;
 		comp_flags = smr_rx_cq_flags(rx_entry->flags,
-					     cmd->hdr.op_flags);
+					     cmd->hdr.smr_flags);
 		if (ret) {
 			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 				"error processing op\n");
@@ -762,7 +765,7 @@ static int smr_copy_saved(struct smr_cmd_ctx *cmd_ctx,
 	int ret;
 
 	comp_flags = smr_rx_cq_flags(rx_entry->flags,
-				     cmd_ctx->cmd->hdr.op_flags);
+				     cmd_ctx->cmd->hdr.smr_flags);
 	while (!slist_empty(&cmd_ctx->buf_list)) {
 		slist_remove_head_container(&cmd_ctx->buf_list,
 					    struct smr_unexp_buf, buf, entry);
@@ -820,8 +823,7 @@ int smr_unexp_start(struct fi_peer_rx_entry *rx_entry)
 	int ret = FI_SUCCESS;
 
 	dlist_remove(&cmd_ctx->entry);
-
-	if (cmd_ctx->cmd->hdr.op_flags & SMR_BUFFER_RECV)
+	if (cmd_ctx->cmd->hdr.smr_flags & SMR_BUFFER_RECV)
 		ret = smr_copy_saved(cmd_ctx, rx_entry);
 	else
 		ret = smr_start_common(cmd_ctx->ep, cmd_ctx->cmd, rx_entry);
@@ -891,34 +893,43 @@ static int smr_unexp_inline(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 static int smr_unexp_inject(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 			    struct smr_cmd *cmd)
 {
-	struct smr_region *peer_smr;
-	struct smr_unexp_buf *buf;
 	struct smr_inject_buf *tx_buf;
-	int ret = FI_SUCCESS;
+	struct smr_unexp_buf *buf;
 
-	if (!(cmd->hdr.op_flags & SMR_BUFFER_RECV)) {
-		cmd_ctx->cmd = cmd;
-		return FI_SUCCESS;
-	}
-
-	peer_smr = smr_peer_region(ep, cmd_ctx->cmd->hdr.rx_id);
+	cmd->hdr.smr_flags |= SMR_BUFFER_RECV;
 
 	memcpy(&cmd_ctx->cmd_cpy, cmd, sizeof(cmd_ctx->cmd->hdr));
 	cmd_ctx->cmd = &cmd_ctx->cmd_cpy;
 
-	buf = ofi_buf_alloc(ep->unexp_buf_pool);
-	if (!buf) {
-		ret = -FI_ENOMEM;
-		cmd->hdr.op_flags |= SMR_OP_ERROR;
-		goto out;
+	if (cmd->hdr.op == ofi_op_read_req) {
+		tx_buf = smr_get_ptr(smr_peer_region(ep, cmd->hdr.tx_id),
+				     cmd->hdr.proto_data);
+	} else {
+		tx_buf = smr_get_ptr(ep->region, cmd->hdr.proto_data);
 	}
 
-	tx_buf = smr_get_inject_buf(peer_smr, cmd);
-	memcpy(buf->buf, tx_buf->buf, cmd_ctx->cmd->hdr.size);
+	buf = ofi_buf_alloc(ep->unexp_buf_pool);
+	if (!buf) {
+		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+			"Error allocating buffer\n");
+		cmd->hdr.smr_flags |= SMR_OP_ERROR;
+		ofi_buf_free(cmd_ctx);
+		return -FI_ENOMEM;
+	}
+
+	memcpy(buf->buf, tx_buf->data, cmd->hdr.size);
+	if (cmd->hdr.op != ofi_op_atomic_compare &&
+	    cmd->hdr.op != ofi_op_atomic_fetch &&
+	    cmd->hdr.op != ofi_op_read_req)
+		smr_return_inject_buf(ep->region, tx_buf);
+
+	slist_init(&cmd_ctx->buf_list);
 	slist_insert_tail(&buf->entry, &cmd_ctx->buf_list);
-out:
-	smr_return_cmd(ep, cmd);
-	return ret;
+
+	if (cmd->hdr.smr_flags & SMR_RETURN_CMD)
+		smr_return_cmd(ep, cmd);
+
+	return FI_SUCCESS;
 }
 
 static int smr_unexp_iov(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
@@ -929,7 +940,7 @@ static int smr_unexp_iov(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 	struct iovec iov;
 	int ret = FI_SUCCESS;
 
-	if (!(cmd->hdr.op_flags & SMR_BUFFER_RECV)) {
+	if (!(cmd->hdr.smr_flags & SMR_BUFFER_RECV)) {
 		cmd_ctx->cmd = cmd;
 		return FI_SUCCESS;
 	}
@@ -963,7 +974,7 @@ static int smr_unexp_iov(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 	}
 out:
 	if (ret)
-		cmd->hdr.op_flags |= SMR_OP_ERROR;
+		cmd->hdr.smr_flags |= SMR_OP_ERROR;
 
 	smr_return_cmd(ep, cmd);
 	return ret;
@@ -976,7 +987,7 @@ static int smr_unexp_sar(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 	struct smr_pend_entry *sar_entry;
 	int ret;
 
-	cmd->hdr.op_flags |= SMR_BUFFER_RECV;
+	cmd->hdr.smr_flags |= SMR_BUFFER_RECV;
 
 	cmd_ctx->cmd = &cmd_ctx->cmd_cpy;
 	memcpy(&cmd_ctx->cmd_cpy, cmd,
@@ -987,7 +998,7 @@ static int smr_unexp_sar(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 	if (!sar_entry) {
 		ofi_buf_free(cmd_ctx);
 		ret = -FI_ENOMEM;
-		cmd->hdr.op_flags |= SMR_OP_ERROR;
+		cmd->hdr.smr_flags |= SMR_OP_ERROR;
 		goto out;
 	}
 	cmd->hdr.rx_ctx = (uintptr_t) sar_entry;
@@ -1002,9 +1013,10 @@ static int smr_unexp_sar(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 					&ep->async_cpy_list);
 		return FI_SUCCESS;
 	} else if (ret && ret != -FI_EAGAIN) {
-		cmd->hdr.op_flags |= SMR_OP_ERROR;
+		cmd->hdr.smr_flags |= SMR_OP_ERROR;
 	}
 out:
+	assert(cmd->hdr.smr_flags & SMR_RETURN_CMD);
 	smr_return_cmd(ep, cmd);
 	return FI_SUCCESS;
 }
@@ -1018,7 +1030,7 @@ static int smr_unexp_ipc(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 	struct iovec iov;
 	int ret = FI_SUCCESS;;
 
-	if (!(cmd->hdr.op_flags & SMR_BUFFER_RECV)) {
+	if (!(cmd->hdr.smr_flags & SMR_BUFFER_RECV)) {
 		cmd_ctx->cmd = cmd;
 		return FI_SUCCESS;
 	}
@@ -1060,7 +1072,7 @@ static int smr_unexp_ipc(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 
 out:
 	if (ret)
-		cmd->hdr.op_flags |= SMR_OP_ERROR;
+		cmd->hdr.smr_flags |= SMR_OP_ERROR;
 
 	smr_return_cmd(ep, cmd);
 	return ret;
@@ -1098,7 +1110,7 @@ static int smr_alloc_cmd_ctx(struct smr_ep *ep,
 	slist_init(&cmd_ctx->buf_list);
 
 	rx_entry->msg_size = cmd->hdr.size;
-	if (cmd->hdr.op_flags & SMR_REMOTE_CQ_DATA) {
+	if (cmd->hdr.smr_flags & SMR_REMOTE_CQ_DATA) {
 		rx_entry->flags |= FI_REMOTE_CQ_DATA;
 		rx_entry->cq_data = cmd->hdr.cq_data;
 	}
@@ -1179,7 +1191,7 @@ static int smr_progress_cmd_rma(struct smr_ep *ep, struct smr_cmd *cmd)
 	int ret = 0;
 	struct ofi_mr *mr[SMR_IOV_LIMIT];
 	struct smr_pend_entry *pend;
-	bool return_cmd = cmd->hdr.proto != smr_proto_inline;
+	bool return_cmd = cmd->hdr.smr_flags & SMR_RETURN_CMD;
 
 	if (cmd->hdr.rx_ctx)
 		return smr_progress_pending(ep, cmd);
@@ -1223,11 +1235,11 @@ static int smr_progress_cmd_rma(struct smr_ep *ep, struct smr_cmd *cmd)
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"error processing rma op\n");
 		ret = smr_write_err_comp(ep->util_ep.rx_cq, NULL,
-					 smr_rx_cq_flags(0, cmd->hdr.op_flags),
+					 smr_rx_cq_flags(0, cmd->hdr.smr_flags),
 					 0, ret);
 	} else {
 		ret = smr_complete_rx(ep, NULL, cmd->hdr.op,
-				      smr_rx_cq_flags(0, cmd->hdr.op_flags),
+				      smr_rx_cq_flags(0, cmd->hdr.smr_flags),
 				      cmd->hdr.size,
 				      iov_count ? iov[0].iov_base : NULL,
 				      cmd->hdr.rx_id, 0, cmd->hdr.cq_data);
@@ -1293,16 +1305,16 @@ static int smr_progress_cmd_atomic(struct smr_ep *ep, struct smr_cmd *cmd)
 	}
 
 	if (err) {
-		cmd->hdr.op_flags |= SMR_OP_ERROR;
+		cmd->hdr.smr_flags |= SMR_OP_ERROR;
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"error processing atomic op\n");
 		ret = smr_write_err_comp(ep->util_ep.rx_cq, NULL,
 					 smr_rx_cq_flags(0,
-					 cmd->hdr.op_flags), 0, err);
+					 cmd->hdr.smr_flags), 0, err);
 	} else {
 		ret = smr_complete_rx(ep, NULL, cmd->hdr.op,
 				      smr_rx_cq_flags(0,
-				      cmd->hdr.op_flags), total_len,
+				      cmd->hdr.smr_flags), total_len,
 				      ioc_count ? ioc[0].addr : NULL,
 				      cmd->hdr.rx_id, 0, cmd->hdr.cq_data);
 	}
@@ -1313,7 +1325,7 @@ static int smr_progress_cmd_atomic(struct smr_ep *ep, struct smr_cmd *cmd)
 	}
 
 out:
-	if (cmd->hdr.proto != smr_proto_inline)
+	if (cmd->hdr.smr_flags & SMR_RETURN_CMD)
 		smr_return_cmd(ep, cmd);
 	return err;
 }
@@ -1415,7 +1427,7 @@ static void smr_progress_async_sar(struct smr_ep *ep,
 		if (ret == -FI_EAGAIN) {
 			return;
 		} else if (ret && ret != -FI_EAGAIN) {
-			pend->cmd->hdr.op_flags |= SMR_OP_ERROR;
+			pend->cmd->hdr.smr_flags |= SMR_OP_ERROR;
 		}
 		dlist_remove(&pend->entry);
 		smr_return_cmd(ep, pend->cmd);
@@ -1433,7 +1445,7 @@ static void smr_progress_async_sar(struct smr_ep *ep,
 			dlist_remove(&pend->entry);
 			return;
 		} else if (ret && ret != -FI_EBUSY) {
-			pend->cmd->hdr.op_flags |= SMR_OP_ERROR;
+			pend->cmd->hdr.smr_flags |= SMR_OP_ERROR;
 		}
 	}
 }

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -97,9 +97,9 @@ static int smr_progress_return_entry(struct smr_ep *ep, struct smr_cmd *cmd,
 		assert(pend->mr[0]);
 		break;
 	case smr_proto_sar:
-		if (cmd->hdr.status) {
+		if (cmd->hdr.op_flags & SMR_OP_ERROR) {
 			smr_free_sar_bufs(ep, cmd, pend);
-			return cmd->hdr.status;
+			return -FI_EIO;
 		}
 
 		if (cmd->hdr.op == ofi_op_read_req) {
@@ -109,6 +109,7 @@ static int smr_progress_return_entry(struct smr_ep *ep, struct smr_cmd *cmd,
 
 			if (ret && ret != -FI_EBUSY)
 				return ret;
+
 			if (pend->bytes_done == cmd->hdr.size) {
 				smr_free_sar_bufs(ep, cmd, pend);
 				return FI_SUCCESS;
@@ -190,13 +191,12 @@ static void smr_progress_return(struct smr_ep *ep)
 		ret = smr_progress_return_entry(ep, cmd, pending);
 		if (ret != -FI_EAGAIN) {
 			if (pending) {
-				if (cmd->hdr.status) {
+				if (cmd->hdr.op_flags & SMR_OP_ERROR) {
 					ret = smr_write_err_comp(
 							ep->util_ep.tx_cq,
 							pending->comp_ctx,
 							pending->comp_flags,
-							cmd->hdr.tag,
-							cmd->hdr.status);
+							cmd->hdr.tag, -FI_EIO);
 				} else {
 					ret = smr_complete_tx(
 							ep, pending->comp_ctx,
@@ -261,15 +261,16 @@ static ssize_t smr_progress_inject(struct smr_ep *ep, struct smr_cmd *cmd,
 	if (ret < 0) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"inject recv failed with code %lu\n", ret);
+		cmd->hdr.op_flags |= SMR_OP_ERROR;
 	} else if (ret != cmd->hdr.size) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"inject recv truncated\n");
 		ret = -FI_ETRUNC;
+		cmd->hdr.op_flags |= SMR_OP_ERROR;
 	} else {
 		ret = FI_SUCCESS;
 	}
 
-	cmd->hdr.status = ret;
 	return ret;
 }
 
@@ -290,7 +291,9 @@ static ssize_t smr_progress_iov(struct smr_ep *ep, struct smr_cmd *cmd,
 			       cmd->data.iov_count, cmd->hdr.size,
 			       peer_smr->pid, cmd->hdr.op == ofi_op_read_req,
 			       xpmem);
-	cmd->hdr.status = ret;
+	if (ret)
+		cmd->hdr.op_flags |= SMR_OP_ERROR;
+
 	return ret;
 }
 
@@ -344,8 +347,8 @@ static ssize_t smr_try_copy_rx_sar(struct smr_ep *ep,
 	if (ret) {
 		if (ret == -FI_EAGAIN)
 			dlist_insert_tail(&pend->entry, &ep->async_cpy_list);
-		else if (ret != -FI_EBUSY)
-			pend->cmd->hdr.status = ret;
+		else if (ret && ret != -FI_EBUSY)
+			pend->cmd->hdr.op_flags |= SMR_OP_ERROR;
 	}
 	return ret;
 }
@@ -362,7 +365,7 @@ static int smr_progress_pending_sar(struct smr_ep *ep, struct smr_cmd *cmd)
 			dlist_insert_tail(&pend->entry, &ep->async_cpy_list);
 			return FI_SUCCESS;
 		}
-		cmd->hdr.status = ret;
+		cmd->hdr.op_flags |= SMR_OP_ERROR;
 		goto out;
 	}
 
@@ -370,13 +373,13 @@ static int smr_progress_pending_sar(struct smr_ep *ep, struct smr_cmd *cmd)
 	if (ret == -FI_EBUSY || ret == -FI_EAGAIN)
 		return FI_SUCCESS;
 
-	if (pend->bytes_done == cmd->hdr.size || pend->cmd->hdr.status) {
-		if (pend->cmd->hdr.status) {
+	if (pend->bytes_done == cmd->hdr.size ||
+	    pend->cmd->hdr.op_flags & SMR_OP_ERROR) {
+		if (pend->cmd->hdr.op_flags & SMR_OP_ERROR) {
 			ret = smr_write_err_comp(ep->util_ep.rx_cq,
 						 pend->comp_ctx,
 						 pend->comp_flags,
-						 cmd->hdr.tag,
-						 pend->cmd->hdr.status);
+						 cmd->hdr.tag, -FI_EIO);
 		} else {
 			ret = smr_complete_rx(ep, pend->comp_ctx,
 					      cmd->hdr.op,
@@ -468,7 +471,7 @@ static ssize_t smr_progress_sar(struct smr_ep *ep, struct smr_cmd *cmd,
 
 	ret = smr_try_copy_rx_sar(ep, pend);
 
-	if (pend->bytes_done == cmd->hdr.size || pend->cmd->hdr.status) {
+	if (pend->bytes_done == cmd->hdr.size) {
 		cmd->hdr.rx_ctx = 0;
 		ofi_buf_free(pend);
 		ret = FI_SUCCESS;
@@ -573,7 +576,9 @@ static ssize_t smr_progress_ipc(struct smr_ep *ep, struct smr_cmd *cmd,
 uncache:
 	ofi_mr_cache_delete(domain->ipc_cache, mr_entry);
 out:
-	cmd->hdr.status = ret;
+	if (ret)
+		cmd->hdr.op_flags |= SMR_OP_ERROR;
+
 	return ret;
 }
 
@@ -904,7 +909,7 @@ static int smr_unexp_inject(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 	buf = ofi_buf_alloc(ep->unexp_buf_pool);
 	if (!buf) {
 		ret = -FI_ENOMEM;
-		cmd->hdr.status = ret;
+		cmd->hdr.op_flags |= SMR_OP_ERROR;
 		goto out;
 	}
 
@@ -957,7 +962,9 @@ static int smr_unexp_iov(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 		slist_insert_tail(&buf->entry, &cmd_ctx->buf_list);
 	}
 out:
-	cmd->hdr.status = ret;
+	if (ret)
+		cmd->hdr.op_flags |= SMR_OP_ERROR;
+
 	smr_return_cmd(ep, cmd);
 	return ret;
 }
@@ -980,7 +987,7 @@ static int smr_unexp_sar(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 		if (!sar_entry) {
 			ofi_buf_free(cmd_ctx);
 			ret = -FI_ENOMEM;
-			cmd->hdr.status = ret;
+			cmd->hdr.op_flags |= SMR_OP_ERROR;
 			goto out;
 		}
 		cmd->hdr.rx_ctx = (uintptr_t) sar_entry;
@@ -994,8 +1001,9 @@ static int smr_unexp_sar(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 			dlist_insert_tail(&sar_entry->entry,
 					  &ep->async_cpy_list);
 			return FI_SUCCESS;
+		} else if (ret && ret != -FI_EAGAIN) {
+			cmd->hdr.op_flags |= SMR_OP_ERROR;
 		}
-		cmd->hdr.status = ret;
 	}
 out:
 	smr_return_cmd(ep, cmd);
@@ -1052,7 +1060,9 @@ static int smr_unexp_ipc(struct smr_ep *ep, struct smr_cmd_ctx *cmd_ctx,
 	cmd_ctx->cmd->hdr.size = total_size;
 
 out:
-	cmd->hdr.status = ret;
+	if (ret)
+		cmd->hdr.op_flags |= SMR_OP_ERROR;
+
 	smr_return_cmd(ep, cmd);
 	return ret;
 }
@@ -1282,9 +1292,9 @@ static int smr_progress_cmd_atomic(struct smr_ep *ep, struct smr_cmd *cmd)
 			"unidentified operation type\n");
 		err = -FI_EINVAL;
 	}
-	cmd->hdr.status = -err;
 
 	if (err) {
+		cmd->hdr.op_flags |= SMR_OP_ERROR;
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"error processing atomic op\n");
 		ret = smr_write_err_comp(ep->util_ep.rx_cq, NULL,
@@ -1404,9 +1414,11 @@ static void smr_progress_async_sar(struct smr_ep *ep,
 
 	if (pend->rx_entry && pend->rx_entry->peer_context) {
 		ret = smr_buffer_sar(ep, pend, pend->rx_entry->peer_context);
-		if (ret == -FI_EAGAIN)
+		if (ret == -FI_EAGAIN) {
 			return;
-		pend->cmd->hdr.status = ret;
+		} else if (ret && ret != -FI_EAGAIN) {
+			pend->cmd->hdr.op_flags |= SMR_OP_ERROR;
+		}
 		dlist_remove(&pend->entry);
 		smr_return_cmd(ep, pend->cmd);
 		return;
@@ -1422,8 +1434,9 @@ static void smr_progress_async_sar(struct smr_ep *ep,
 		if (ret == -FI_EBUSY) {
 			dlist_remove(&pend->entry);
 			return;
+		} else if (ret && ret != -FI_EBUSY) {
+			pend->cmd->hdr.op_flags |= SMR_OP_ERROR;
 		}
-		pend->cmd->hdr.status = ret;
 	}
 }
 

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -52,6 +52,7 @@ static void smr_progress_overflow(struct smr_ep *ep)
 		if (ret == -FI_ENOENT)
 			return;
 
+		ce->hdr.smr_flags = cmd->hdr.smr_flags;
 		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, cmd->hdr.tx_id,
 						  cmd->hdr.rx_id,
 						  (uintptr_t) cmd);
@@ -1342,7 +1343,8 @@ static void smr_progress_cmd(struct smr_ep *ep)
 		if (ret == -FI_ENOENT)
 			break;
 
-		cmd = (struct smr_cmd *) ce->hdr.entry;
+		cmd = (ce->hdr.smr_flags & SMR_RETURN_CMD) ?
+		      (struct smr_cmd *) ce->hdr.entry : ce;
 		switch (cmd->hdr.op) {
 		case ofi_op_msg:
 		case ofi_op_tagged:

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -177,6 +177,7 @@ static ssize_t smr_generic_rma(
 		}
 		cmd = smr_freestack_pop(smr_cmd_stack(ep->region));
 		assert(cmd);
+		ce->hdr.smr_flags = smr_flags;
 		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
 						  (uintptr_t) cmd);
 	} else {

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -127,11 +127,12 @@ static ssize_t smr_generic_rma(
 {
 	struct smr_region *peer_smr;
 	int64_t tx_id, rx_id;
-	int proto = smr_proto_inline;
+	int proto;
 	ssize_t ret = -FI_EAGAIN;
 	size_t total_len;
 	struct smr_cmd *ce, *cmd;
 	int64_t pos;
+	uint8_t smr_flags;
 
 	assert(iov_count <= SMR_IOV_LIMIT);
 	assert(rma_count <= SMR_IOV_LIMIT);
@@ -167,8 +168,8 @@ static ssize_t smr_generic_rma(
 
 	proto = smr_select_proto(desc, iov_count, smr_vma_enabled(ep, peer_smr),
 	                         smr_ipc_valid(ep, peer_smr, tx_id, rx_id), op,
-				 total_len, op_flags);
-	if (proto != smr_proto_inline) {
+				 total_len, op_flags, &smr_flags);
+	if (smr_flags & SMR_RETURN_CMD) {
 		if (smr_freestack_isempty(smr_cmd_stack(ep->region))) {
 			smr_cmd_queue_discard(ce, pos);
 			ret = -FI_EAGAIN;
@@ -182,19 +183,19 @@ static ssize_t smr_generic_rma(
 		cmd = ce;
 	}
 	ret = smr_send_ops[proto](ep, peer_smr, tx_id, rx_id, op, 0, data,
-				  op_flags, (struct ofi_mr **)desc, iov,
-				  iov_count, total_len, context, cmd);
+				  op_flags, smr_flags, (struct ofi_mr **)desc,
+				  iov, iov_count, total_len, context, cmd);
 	if (ret) {
-		if (proto != smr_proto_inline)
-			smr_freestack_push(smr_cmd_stack(ep->region), cmd);
 		smr_cmd_queue_discard(ce, pos);
+		if (smr_flags & SMR_RETURN_CMD)
+			smr_freestack_push(smr_cmd_stack(ep->region), cmd);
 		goto unlock;
 	}
 
 	smr_add_rma_cmd(peer_smr, rma_iov, rma_count, cmd);
 	smr_cmd_queue_commit(ce, pos);
 
-	if (proto != smr_proto_inline || op == ofi_op_read_req)
+	if (smr_flags & SMR_RETURN_CMD)
 		goto unlock;
 
 	ret = smr_complete_tx(ep, context, op, op_flags);
@@ -318,7 +319,7 @@ static ssize_t smr_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 static ssize_t smr_generic_rma_inject(
 		struct fid_ep *ep_fid, const void *buf, size_t len,
 		fi_addr_t dest_addr, uint64_t addr, uint64_t key, uint64_t data,
-		uint64_t flags)
+		uint64_t op_flags)
 {
 	struct smr_ep *ep;
 	struct smr_region *peer_smr;
@@ -329,6 +330,7 @@ static ssize_t smr_generic_rma_inject(
 	ssize_t ret = -FI_EAGAIN;
 	struct smr_cmd *ce, *cmd;
 	int64_t pos;
+	uint8_t smr_flags;
 
 	assert(len <= SMR_INJECT_SIZE);
 	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
@@ -356,36 +358,21 @@ static ssize_t smr_generic_rma_inject(
 		goto unlock;
 	}
 
-	if (len <= SMR_MSG_DATA_LEN) {
-		proto = smr_proto_inline;
-		cmd = ce;
-	} else {
-		proto = smr_proto_inject;
-		if (smr_freestack_isempty(smr_cmd_stack(ep->region))) {
-			smr_cmd_queue_discard(ce, pos);
-			ret = -FI_EAGAIN;
-			goto unlock;
-		}
+	proto = len <= SMR_MSG_DATA_LEN ? smr_proto_inline : smr_proto_inject;
+	cmd = ce;
 
-		cmd = smr_freestack_pop(smr_cmd_stack(ep->region));
-		assert(cmd);
-		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
-						  (uintptr_t) cmd);
-	}
-
+	smr_flags = (op_flags & FI_REMOTE_CQ_DATA) ? SMR_REMOTE_CQ_DATA : 0;
 	ret = smr_send_ops[proto](ep, peer_smr, tx_id, rx_id, ofi_op_write, 0,
-				  data, flags, NULL, &iov, 1, len, NULL, cmd);
+				  data, op_flags, smr_flags, NULL, &iov, 1, len,
+				  NULL, cmd);
 	if (ret) {
-		if (proto != smr_proto_inline)
-			smr_freestack_push(smr_cmd_stack(ep->region), cmd);
 		smr_cmd_queue_discard(ce, pos);
 		goto unlock;
 	}
 	smr_add_rma_cmd(peer_smr, &rma_iov, 1, cmd);
 	smr_cmd_queue_commit(ce, pos);
 
-	if (proto == smr_proto_inline)
-		ofi_ep_peer_tx_cntr_inc(&ep->util_ep, ofi_op_write);
+	ofi_ep_peer_tx_cntr_inc(&ep->util_ep, ofi_op_write);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -115,8 +115,7 @@ static inline bool smr_do_fast_rma(struct smr_ep *ep, uint64_t op_flags,
 
 	return domain->fast_rma && !(op_flags &
 		    (FI_REMOTE_CQ_DATA | FI_DELIVERY_COMPLETE)) &&
-		     rma_count == 1 && smr_vma_enabled(ep, peer_smr) &&
-		     total_len > SMR_INJECT_SIZE;
+		     rma_count == 1 && smr_vma_enabled(ep, peer_smr);
 
 }
 

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -58,12 +58,12 @@ static ssize_t smr_rma_fast(struct smr_ep *ep, struct smr_region *peer_smr,
 {
 	struct iovec vma_iovec[SMR_IOV_LIMIT], rma_iovec[SMR_IOV_LIMIT];
 	struct ofi_xpmem_client *xpmem;
-	struct smr_cmd_entry *ce;
+	struct smr_cmd *cmd;
 	size_t total_len;
 	int ret, i;
 	int64_t pos;
 
-	ret = smr_cmd_queue_next(smr_cmd_queue(peer_smr), &ce, &pos);
+	ret = smr_cmd_queue_next(smr_cmd_queue(peer_smr), &cmd, &pos);
 	if (ret == -FI_ENOENT)
 		return -FI_EAGAIN;
 
@@ -85,15 +85,15 @@ static ssize_t smr_rma_fast(struct smr_ep *ep, struct smr_region *peer_smr,
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL, "error doing fast RMA\n");
 		ret = smr_write_err_comp(ep->util_ep.rx_cq, NULL, op_flags, 0,
 					 ret);
-		smr_cmd_queue_discard(ce, pos);
+		smr_cmd_queue_discard(cmd, pos);
 		return -FI_EAGAIN;
 	}
 
-	smr_format_rma_resp(&ce->cmd, rx_id, rma_iov, rma_count, total_len,
+	smr_format_rma_resp(cmd, rx_id, rma_iov, rma_count, total_len,
 			    (op == ofi_op_write) ? ofi_op_write_async :
 			    ofi_op_read_async, op_flags);
 
-	smr_cmd_queue_commit(ce, pos);
+	smr_cmd_queue_commit(cmd, pos);
 
 	ret = smr_complete_tx(ep, context, op, op_flags);
 	if (ret) {
@@ -131,8 +131,7 @@ static ssize_t smr_generic_rma(
 	int proto = smr_proto_inline;
 	ssize_t ret = -FI_EAGAIN;
 	size_t total_len;
-	struct smr_cmd_entry *ce;
-	struct smr_cmd *cmd;
+	struct smr_cmd *ce, *cmd;
 	int64_t pos;
 
 	assert(iov_count <= SMR_IOV_LIMIT);
@@ -178,10 +177,10 @@ static ssize_t smr_generic_rma(
 		}
 		cmd = smr_freestack_pop(smr_cmd_stack(ep->region));
 		assert(cmd);
-		ce->ptr = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
-					    (uintptr_t) cmd);
+		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
+						  (uintptr_t) cmd);
 	} else {
-		cmd = &ce->cmd;
+		cmd = ce;
 	}
 	ret = smr_send_ops[proto](ep, peer_smr, tx_id, rx_id, op, 0, data,
 				  op_flags, (struct ofi_mr **)desc, iov,
@@ -329,8 +328,7 @@ static ssize_t smr_generic_rma_inject(
 	int64_t tx_id, rx_id;
 	int proto = smr_proto_inline;
 	ssize_t ret = -FI_EAGAIN;
-	struct smr_cmd *cmd;
-	struct smr_cmd_entry *ce;
+	struct smr_cmd *ce, *cmd;
 	int64_t pos;
 
 	assert(len <= SMR_INJECT_SIZE);
@@ -361,7 +359,7 @@ static ssize_t smr_generic_rma_inject(
 
 	if (len <= SMR_MSG_DATA_LEN) {
 		proto = smr_proto_inline;
-		cmd = &ce->cmd;
+		cmd = ce;
 	} else {
 		proto = smr_proto_inject;
 		if (smr_freestack_isempty(smr_cmd_stack(ep->region))) {
@@ -372,8 +370,8 @@ static ssize_t smr_generic_rma_inject(
 
 		cmd = smr_freestack_pop(smr_cmd_stack(ep->region));
 		assert(cmd);
-		ce->ptr = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
-					    (uintptr_t) cmd);
+		ce->hdr.entry = smr_local_to_peer(ep, peer_smr, tx_id, rx_id,
+						  (uintptr_t) cmd);
 	}
 
 	ret = smr_send_ops[proto](ep, peer_smr, tx_id, rx_id, ofi_op_write, 0,

--- a/prov/shm/src/smr_util.c
+++ b/prov/shm/src/smr_util.c
@@ -37,6 +37,7 @@
 struct dlist_entry ep_name_list;
 DEFINE_LIST(ep_name_list);
 pthread_mutex_t ep_list_lock = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t inject_pool_lock = PTHREAD_MUTEX_INITIALIZER;
 
 void smr_cleanup(void)
 {
@@ -105,7 +106,7 @@ size_t smr_calculate_size_offsets(size_t tx_count, size_t rx_count,
 	inject_pool_offset = cmd_queue_offset + sizeof(struct smr_cmd_queue) +
 		sizeof(struct smr_cmd_queue_entry) * rx_size;
 	cmd_stack_offset = inject_pool_offset +
-		sizeof(struct smr_inject_buf) * tx_size;
+		freestack_size(sizeof(struct smr_inject_buf), rx_size);
 	ret_queue_offset = cmd_stack_offset +
 		freestack_size(sizeof(struct smr_cmd), tx_size);
 	ret_queue_offset = ofi_get_aligned_size(ret_queue_offset, 64);
@@ -287,6 +288,8 @@ int smr_create(const struct fi_provider *prov, const struct smr_attr *attr,
 	(*smr)->max_sar_buf_per_peer = SMR_BUF_BATCH_MAX;
 
 	smr_cmd_queue_init(smr_cmd_queue(*smr), rx_size, smr_cmd_init);
+	smr_freestack_init(smr_inject_pool(*smr), rx_size,
+			   sizeof(struct smr_inject_buf));
 	smr_return_queue_init(smr_return_queue(*smr), tx_size, NULL);
 
 	smr_freestack_init(smr_cmd_stack(*smr), tx_size,
@@ -300,6 +303,7 @@ int smr_create(const struct fi_provider *prov, const struct smr_attr *attr,
 		smr_peer_data(*smr)[i].xpmem.avail = false;
 	}
 
+	ofi_spin_init(&(*smr)->fs_lock);
 	strncpy((char *) smr_name(*smr), attr->name, total_size - name_offset);
 
 	/* Must be set last to signal full initialization to peers */
@@ -318,6 +322,10 @@ close:
 
 void smr_free(struct smr_region *smr)
 {
+	/*
+	 * TODO: Figure out if we should cleanup resources in the smr before
+	 * unlinking and unmapping.
+	 */
 	if (smr->flags & SMR_FLAG_HMEM_ENABLED)
 		(void) ofi_hmem_host_unregister(smr);
 	shm_unlink(smr_name(smr));

--- a/prov/shm/src/smr_util.c
+++ b/prov/shm/src/smr_util.c
@@ -102,12 +102,12 @@ size_t smr_calculate_size_offsets(size_t tx_count, size_t rx_count,
 
 	/* Align cmd_queue offset to cache line */
 	cmd_queue_offset = ofi_get_aligned_size(sizeof(struct smr_region), 64);
-	cmd_stack_offset = cmd_queue_offset + sizeof(struct smr_cmd_queue) +
+	inject_pool_offset = cmd_queue_offset + sizeof(struct smr_cmd_queue) +
 		sizeof(struct smr_cmd_queue_entry) * rx_size;
-	inject_pool_offset = cmd_stack_offset +
+	cmd_stack_offset = inject_pool_offset +
+		sizeof(struct smr_inject_buf) * tx_size;
+	ret_queue_offset = cmd_stack_offset +
 		freestack_size(sizeof(struct smr_cmd), tx_size);
-	ret_queue_offset = inject_pool_offset + sizeof(struct smr_inject_buf) *
-		tx_size;
 	ret_queue_offset = ofi_get_aligned_size(ret_queue_offset, 64);
 	sar_pool_offset = ret_queue_offset + sizeof(struct smr_return_queue) +
 		sizeof(struct smr_return_queue_entry) * tx_size;

--- a/prov/shm/src/smr_util.c
+++ b/prov/shm/src/smr_util.c
@@ -179,8 +179,8 @@ err:
 
 static inline void smr_cmd_init(void *buf)
 {
-	struct smr_cmd_entry *ce = buf;
-	ce->ptr = (uintptr_t) &ce->cmd;
+	struct smr_cmd *cmd = buf;
+	cmd->hdr.entry = (uintptr_t) cmd;
 }
 
 /* TODO: Determine if aligning SMR data helps performance */

--- a/prov/shm/src/smr_util.c
+++ b/prov/shm/src/smr_util.c
@@ -178,12 +178,6 @@ err:
 	return -FI_EBUSY;
 }
 
-static inline void smr_cmd_init(void *buf)
-{
-	struct smr_cmd *cmd = buf;
-	cmd->hdr.entry = (uintptr_t) cmd;
-}
-
 /* TODO: Determine if aligning SMR data helps performance */
 int smr_create(const struct fi_provider *prov, const struct smr_attr *attr,
 	       struct smr_region *volatile *smr)
@@ -287,7 +281,7 @@ int smr_create(const struct fi_provider *prov, const struct smr_attr *attr,
 	(*smr)->name_offset = name_offset;
 	(*smr)->max_sar_buf_per_peer = SMR_BUF_BATCH_MAX;
 
-	smr_cmd_queue_init(smr_cmd_queue(*smr), rx_size, smr_cmd_init);
+	smr_cmd_queue_init(smr_cmd_queue(*smr), rx_size, NULL);
 	smr_freestack_init(smr_inject_pool(*smr), rx_size,
 			   sizeof(struct smr_inject_buf));
 	smr_return_queue_init(smr_return_queue(*smr), tx_size, NULL);

--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -185,6 +185,7 @@ static_assert(sizeof(struct smr_cmd) == SMR_CMD_SIZE,
 
 #define SMR_INJECT_SIZE		4096
 #define SMR_COMP_INJECT_SIZE	(SMR_INJECT_SIZE / 2)
+#define SMR_MAX_GDRCOPY_SIZE    3072
 #define SMR_SAR_SIZE		32768
 
 #define SMR_DIR		"/dev/shm/"

--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -74,6 +74,7 @@ extern struct smr_env smr_env;
 
 #define SMR_REMOTE_CQ_DATA	(1 << 0)
 #define SMR_BUFFER_RECV		(1 << 1)
+#define SMR_OP_ERROR		(1 << 2)
 
 enum {
 	smr_proto_inline,	/* inline payload */
@@ -97,11 +98,14 @@ enum {
  * 	tag		tag for FI_TAGGED API only
  * 	datatype	atomic datatype for FI_ATOMIC API only
  * 	atomic_op	atomic operation for FI_ATOMIC API only
- * 	status		returned status of operation
- * 	CACHE LINE HERE Above fields must be 40 bytes if the cpu does
- *			not support prefetching algorithms. The other 24 bytes
- *			in this cache line come from the atomic queue cmd_entry
  *	entry		for internal use managing commands
+ * 	CACHE LINE HERE Make sure above fields are 40bytes so that they are
+ * 		 	properly cache aligned with the other 24 bytes
+ *			from the atomic queue fields. This is necessary
+			(especially if your cpu does not have prefetching) so
+			that the first cache grab gets the lightweight protocol
+			fields.
+ *	resv2		reserved for future use to keep struct size at 64 bytes
  *	tx_ctx		source side context (unused by target side)
  *	rx_ctx		target side context (unused by source side)
  */
@@ -121,9 +125,9 @@ struct smr_cmd_hdr {
 			uint8_t	atomic_op;
 		};
 	};
-	uint64_t		status;
-	//CACHE LINE HERE - See comment above
 	uint64_t		entry;
+	//CACHE LINE HERE - See comment above
+	uint64_t		resv2;
 	uint64_t		tx_ctx;
 	uint64_t		rx_ctx;
 };

--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -218,7 +218,7 @@ struct smr_ep_name {
 
 static inline const char *smr_no_prefix(const char *addr)
 {
-	char *start;
+	const char *start;
 
 	return (start = strstr(addr, "://")) ? start + 3 : addr;
 }

--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -61,11 +61,11 @@ extern struct smr_env smr_env;
 /* SMR_CMD_SIZE refers to the total bytes dedicated for use in shm headers and
  * data. The entire atomic queue entry will be cache aligned (384) but this also
  * includes the cmd aq header (16) + cmd entry ptr (8)
- * 384 (total entry size) - 16 (aq header) - 8 (entry ptr) = 360
+ * 384 (total entry size) - 16 (aq header) = 368
  * This maximizes the inline payload. Increasing this value will increase the
  * atomic queue entry to 448 bytes.
  */
-#define SMR_CMD_SIZE		360
+#define SMR_CMD_SIZE		368
 
 /* reserves 0-255 for defined ops and room for new ops
  * 256 and beyond reserved for ctrl ops
@@ -87,6 +87,7 @@ enum {
 
 /*
  * Unique smr_cmd_hdr for smr message protocol:
+ *	entry		for internal use managing commands
  * 	op		type of op (ex. ofi_op_msg, defined in ofi_proto.h)
  * 	proto		smr protocol (ex. smr_proto_inline, defined above)
  * 	op_flags	operation flags (ex. SMR_REMOTE_CQ_DATA, defined above)
@@ -98,18 +99,18 @@ enum {
  * 	tag		tag for FI_TAGGED API only
  * 	datatype	atomic datatype for FI_ATOMIC API only
  * 	atomic_op	atomic operation for FI_ATOMIC API only
- *	entry		for internal use managing commands
  * 	CACHE LINE HERE Make sure above fields are 40bytes so that they are
  * 		 	properly cache aligned with the other 24 bytes
  *			from the atomic queue fields. This is necessary
 			(especially if your cpu does not have prefetching) so
 			that the first cache grab gets the lightweight protocol
 			fields.
- *	resv2		reserved for future use to keep struct size at 64 bytes
+ * 	resv2		reserved to keep hdr at 64 bytes
  *	tx_ctx		source side context (unused by target side)
  *	rx_ctx		target side context (unused by source side)
  */
 struct smr_cmd_hdr {
+	uint64_t		entry;
 	uint8_t			op;
 	uint8_t			proto;
 	uint8_t			op_flags;
@@ -125,7 +126,6 @@ struct smr_cmd_hdr {
 			uint8_t	atomic_op;
 		};
 	};
-	uint64_t		entry;
 	//CACHE LINE HERE - See comment above
 	uint64_t		resv2;
 	uint64_t		tx_ctx;
@@ -300,16 +300,11 @@ struct smr_sar_buf {
 	uint8_t		buf[SMR_SAR_SIZE];
 };
 
-struct smr_cmd_entry {
-	uintptr_t	ptr;
-	struct smr_cmd	cmd;
-};
-
 struct smr_return_entry {
 	uintptr_t ptr;
 };
 
-OFI_DECLARE_ATOMIC_Q(struct smr_cmd_entry, smr_cmd_queue);
+OFI_DECLARE_ATOMIC_Q(struct smr_cmd, smr_cmd_queue);
 OFI_DECLARE_ATOMIC_Q(struct smr_return_entry, smr_return_queue);
 
 /* Queue of offsets of the command blocks obtained from the command pool

--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -35,8 +35,8 @@
 
 #include "ofi.h"
 #include "ofi_atomic_queue.h"
+#include "ofi_lock.h"
 #include "ofi_xpmem.h"
-#include <pthread.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -75,6 +75,7 @@ extern struct smr_env smr_env;
 #define SMR_REMOTE_CQ_DATA	(1 << 0)
 #define SMR_BUFFER_RECV		(1 << 1)
 #define SMR_OP_ERROR		(1 << 2)
+#define SMR_RETURN_CMD		(1 << 3)
 
 enum {
 	smr_proto_inline,	/* inline payload */
@@ -90,7 +91,7 @@ enum {
  *	entry		for internal use managing commands
  * 	op		type of op (ex. ofi_op_msg, defined in ofi_proto.h)
  * 	proto		smr protocol (ex. smr_proto_inline, defined above)
- * 	op_flags	operation flags (ex. SMR_REMOTE_CQ_DATA, defined above)
+ * 	smr_flags	operation flags (ex. SMR_REMOTE_CQ_DATA, defined above)
  * 	resv		reserved
  * 	tx_id		local shm_id of peer sending msg (unused by target)
  *	rx_id		remote shm_id of peer sending msg (unused by source)
@@ -105,7 +106,7 @@ enum {
 			(especially if your cpu does not have prefetching) so
 			that the first cache grab gets the lightweight protocol
 			fields.
- * 	resv2		reserved to keep hdr at 64 bytes
+ * 	proto_data	protocol specific data (ex. inject or SAR buf offset)
  *	tx_ctx		source side context (unused by target side)
  *	rx_ctx		target side context (unused by source side)
  */
@@ -113,7 +114,7 @@ struct smr_cmd_hdr {
 	uint64_t		entry;
 	uint8_t			op;
 	uint8_t			proto;
-	uint8_t			op_flags;
+	uint8_t			smr_flags;
 	uint8_t			resv[1];
 	int16_t			rx_id;
 	int16_t			tx_id;
@@ -127,7 +128,7 @@ struct smr_cmd_hdr {
 		};
 	};
 	//CACHE LINE HERE - See comment above
-	uint64_t		resv2;
+	uint64_t		proto_data;
 	uint64_t		tx_ctx;
 	uint64_t		rx_ctx;
 };
@@ -253,6 +254,8 @@ struct smr_region {
 			uintptr_t		base_addr;
 
 			size_t			total_size;
+
+			ofi_spin_t		fs_lock;
 		};
 		uint8_t		pad[SMR_PREFETCH_SZ];
 	};
@@ -318,9 +321,9 @@ static inline struct smr_freestack *smr_cmd_stack(struct smr_region *smr)
 {
 	return (struct smr_freestack *) ((char *) smr + smr->cmd_stack_offset);
 }
-static inline struct smr_inject_buf *smr_inject_pool(struct smr_region *smr)
+static inline struct smr_freestack *smr_inject_pool(struct smr_region *smr)
 {
-	return (struct smr_inject_buf *)
+	return (struct smr_freestack *)
 			((char *) smr + smr->inject_pool_offset);
 }
 static inline struct smr_return_queue *smr_return_queue(struct smr_region *smr)
@@ -341,11 +344,32 @@ static inline const char *smr_name(struct smr_region *smr)
 	return (const char *) smr + smr->name_offset;
 }
 
-static inline struct smr_inject_buf *smr_get_inject_buf(struct smr_region *smr,
-							struct smr_cmd *cmd)
+static inline struct smr_inject_buf *smr_get_inject_buf(struct smr_region *smr)
 {
-	return &smr_inject_pool(smr)[smr_freestack_get_index(smr_cmd_stack(smr),
-							     (char *) cmd)];
+	struct smr_inject_buf *buf;
+	ofi_spin_lock(&smr->fs_lock);
+	if (!smr_freestack_isempty(smr_inject_pool(smr)))
+		buf = smr_freestack_pop(smr_inject_pool(smr));
+	else
+		buf = NULL;
+	ofi_spin_unlock(&smr->fs_lock);
+	return buf;
+}
+
+static inline void smr_return_inject_buf(struct smr_region *smr,
+					 struct smr_inject_buf *buf)
+{
+	ofi_spin_lock(&smr->fs_lock);
+	smr_freestack_push(smr_inject_pool(smr), buf);
+	ofi_spin_unlock(&smr->fs_lock);
+}
+
+static inline void smr_return_sar_buf_by_index(struct smr_region *smr,
+					       size_t index)
+{
+	ofi_spin_lock(&smr->fs_lock);
+	smr_freestack_push_by_index(smr_sar_pool(smr), index);
+	ofi_spin_unlock(&smr->fs_lock);
 }
 
 struct smr_attr {

--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -86,27 +86,33 @@ enum {
 
 /*
  * Unique smr_cmd_hdr for smr message protocol:
- *	entry		for internal use managing commands (must be kept first)
- *	tx_ctx		source side context (unused by target side)
- *	rx_ctx		target side context (unused by source side)
- * 	tx_id		local shm_id of peer sending msg (unused by target)
- *	rx_id		remote shm_id of peer sending msg (unused by source)
  * 	op		type of op (ex. ofi_op_msg, defined in ofi_proto.h)
  * 	proto		smr protocol (ex. smr_proto_inline, defined above)
  * 	op_flags	operation flags (ex. SMR_REMOTE_CQ_DATA, defined above)
+ * 	resv		reserved
+ * 	tx_id		local shm_id of peer sending msg (unused by target)
+ *	rx_id		remote shm_id of peer sending msg (unused by source)
  * 	size		size of data transfer
- * 	status		returned status of operation
  * 	cq_data		remote CQ data
  * 	tag		tag for FI_TAGGED API only
  * 	datatype	atomic datatype for FI_ATOMIC API only
  * 	atomic_op	atomic operation for FI_ATOMIC API only
+ * 	status		returned status of operation
+ * 	CACHE LINE HERE Above fields must be 40 bytes if the cpu does
+ *			not support prefetching algorithms. The other 24 bytes
+ *			in this cache line come from the atomic queue cmd_entry
+ *	entry		for internal use managing commands
+ *	tx_ctx		source side context (unused by target side)
+ *	rx_ctx		target side context (unused by source side)
  */
 struct smr_cmd_hdr {
-	uint64_t		entry;
-	uint64_t		tx_ctx;
-	uint64_t		rx_ctx;
+	uint8_t			op;
+	uint8_t			proto;
+	uint8_t			op_flags;
+	uint8_t			resv[1];
+	int16_t			rx_id;
+	int16_t			tx_id;
 	uint64_t		size;
-	int64_t			status;
 	uint64_t		cq_data;
 	union {
 		uint64_t	tag;
@@ -115,12 +121,11 @@ struct smr_cmd_hdr {
 			uint8_t	atomic_op;
 		};
 	};
-	int16_t			rx_id;
-	int16_t			tx_id;
-	uint8_t			op;
-	uint8_t			proto;
-	uint8_t			op_flags;
-	uint8_t			resv[1];
+	uint64_t		status;
+	//CACHE LINE HERE - See comment above
+	uint64_t		entry;
+	uint64_t		tx_ctx;
+	uint64_t		rx_ctx;
 };
 
 #ifdef static_assert

--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -260,8 +260,8 @@ struct smr_region {
 	struct {
 		/* offsets from start of smr_region */
 		size_t			cmd_queue_offset;
-		size_t			cmd_stack_offset;
 		size_t			inject_pool_offset;
+		size_t			cmd_stack_offset;
 		size_t			ret_queue_offset;
 		size_t			sar_pool_offset;
 		size_t			peer_data_offset;

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -4,6 +4,7 @@
  * Copyright (c) 2019 Amazon.com, Inc. or its affiliates. All rights reserved.
  * Copyright (c) 2020 Cisco Systems, Inc. All rights reserved.
  * (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+ * Copyright (C) 2026 Cornelis Networks.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -268,6 +269,12 @@ void ofi_mr_cache_delete(struct ofi_mr_cache *cache, struct ofi_mr_entry *entry)
  * new entry, then check under lock that a conflict with another thread
  * hasn't occurred.  If a conflict occurred, we return -EAGAIN and
  * restart the entire operation.
+ *
+ * The rbnode for the tree insertion is also pre-allocated outside the
+ * lock for the same reason: ofi_rbmap_insert() may call malloc() which
+ * can trigger madvise() via the allocator, and an intercepting memory
+ * monitor (e.g. OPAL) would call back into ofi_import_monitor_notify()
+ * which needs mm_lock -- deadlocking the thread.
  */
 static int
 util_mr_cache_create(struct ofi_mr_cache *cache, struct ofi_mr_info *info,
@@ -300,6 +307,12 @@ util_mr_cache_create(struct ofi_mr_cache *cache, struct ofi_mr_info *info,
 	assert(ofi_iov_within(&(*info).iov, &(*entry)->info.iov));
 	*info = (*entry)->info;
 
+	struct ofi_rbnode *rbnode = ofi_rbnode_alloc(&cache->tree);
+	if (OFI_UNLIKELY(!rbnode)) {
+		ret = -FI_ENOMEM;
+		goto free;
+	}
+
 	pthread_mutex_lock(&mm_lock);
 	cur = ofi_mr_rbt_find(&cache->tree, info);
 	if (cur) {
@@ -311,11 +324,14 @@ util_mr_cache_create(struct ofi_mr_cache *cache, struct ofi_mr_info *info,
 		cache->uncached_cnt++;
 		cache->uncached_size += info->iov.iov_len;
 	} else {
-		if (ofi_rbmap_insert(&cache->tree, (void *) &(*entry)->info,
-				     (void *) *entry, &(*entry)->node)) {
-			ret = -FI_ENOMEM;
+		ret = ofi_rbmap_insert_at(&cache->tree,
+					  (void *) &(*entry)->info,
+					  (void *) *entry, &(*entry)->node,
+					  rbnode);
+		if (ret)
 			goto unlock;
-		}
+		rbnode = NULL; /* now owned by the tree */
+
 		cache->cached_cnt++;
 		cache->cached_size += info->iov.iov_len;
 
@@ -328,10 +344,17 @@ util_mr_cache_create(struct ofi_mr_cache *cache, struct ofi_mr_info *info,
 			cache->uncached_size += (*entry)->info.iov.iov_len;
 		}
 	}
+	/* ofi_rbnode_free() only returns the node to the tree free list (never
+	 * allocates), so it is safe to call while holding mm_lock.
+	 */
+	if (rbnode)
+		ofi_rbnode_free(&cache->tree, rbnode);
 	pthread_mutex_unlock(&mm_lock);
 	return 0;
 
 unlock:
+	if (rbnode)
+		ofi_rbnode_free(&cache->tree, rbnode);
 	pthread_mutex_unlock(&mm_lock);
 free:
 	util_mr_free_entry(cache, *entry);

--- a/prov/verbs/include/linux/verbs_osd.h
+++ b/prov/verbs/include/linux/verbs_osd.h
@@ -44,7 +44,7 @@ static inline void vrb_os_fini()
 {
 }
 
-static inline void vrb_os_mem_support(bool *peer_mem, bool *dmabuf)
+static inline void vrb_os_mem_support(int *peer_mem, int *dmabuf)
 {
 	char *line = NULL;
 	size_t line_size = 0;
@@ -57,9 +57,9 @@ static inline void vrb_os_mem_support(bool *peer_mem, bool *dmabuf)
 
 	while ((bytes = getline(&line, &line_size, kallsyms_fd)) != -1) {
 		if (strstr(line, "ib_register_peer_memory_client"))
-			*peer_mem = true;
+			*peer_mem = (int)true;
 		else if (strstr(line, "ib_umem_dmabuf_get"))
-			*dmabuf = true;
+			*dmabuf = (int)true;
 		if (*peer_mem && *dmabuf)
 			break;
 	}

--- a/prov/verbs/src/verbs_init.c
+++ b/prov/verbs/src/verbs_init.c
@@ -735,7 +735,7 @@ static int vrb_read_params(void)
 	if (vrb_gl_data.dmabuf_support) {
 		if (vrb_get_param_bool("use_dmabuf", "Enable dmabuf based memory "
 				       "registrations, if supported. Yes by default.",
-				       (int *)&vrb_gl_data.dmabuf_support)) {
+				       &vrb_gl_data.dmabuf_support)) {
 			VRB_WARN(FI_LOG_CORE, "Invalid value of use_dmabuf\n");
 			return -FI_EINVAL;
 		}

--- a/prov/verbs/src/verbs_ofi.h
+++ b/prov/verbs/src/verbs_ofi.h
@@ -211,8 +211,8 @@ extern struct vrb_gl_data {
 		char	*xrcd_filename;
 	} msg;
 
-	bool	peer_mem_support;
-	bool	dmabuf_support;
+	int	peer_mem_support;
+	int	dmabuf_support;
 
 	vrb_nic_affinity_handler_t	nic_affinity_handler;
 	char	*nic_affinity_policy;

--- a/src/tree.c
+++ b/src/tree.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015 Cray Inc. All rights reserved.
  * Copyright (c) 2018 Intel Corp, Inc.  All rights reserved.
+ * Copyright (C) 2026 Cornelis Networks.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -51,7 +52,7 @@
 #include <rdma/fi_errno.h>
 
 
-static struct ofi_rbnode *ofi_rbnode_alloc(struct ofi_rbmap *map)
+struct ofi_rbnode *ofi_rbnode_alloc(struct ofi_rbmap *map)
 {
 	struct ofi_rbnode *node;
 
@@ -63,7 +64,7 @@ static struct ofi_rbnode *ofi_rbnode_alloc(struct ofi_rbmap *map)
 	return node;
 }
 
-static void ofi_rbnode_free(struct ofi_rbmap *map, struct ofi_rbnode *node)
+void ofi_rbnode_free(struct ofi_rbmap *map, struct ofi_rbnode *node)
 {
 	node->right = map->free_list ? map->free_list : NULL;
 	map->free_list = node;
@@ -231,8 +232,9 @@ ofi_insert_rebalance(struct ofi_rbmap *map, struct ofi_rbnode *x)
 	map->root->color = BLACK;
 }
 
-int ofi_rbmap_insert(struct ofi_rbmap *map, void *key, void *data,
-		     struct ofi_rbnode **ret_node)
+static inline int ofi_rbmap_insert_common(struct ofi_rbmap *map, void *key, void *data,
+				   struct ofi_rbnode **ret_node,
+				   struct ofi_rbnode *prealloc)
 {
 	struct ofi_rbnode *current, *parent, *node;
 	int ret;
@@ -252,9 +254,13 @@ int ofi_rbmap_insert(struct ofi_rbmap *map, void *key, void *data,
 		current = (ret < 0) ? current->left : current->right;
 	}
 
-	node = ofi_rbnode_alloc(map);
-	if (!node)
-		return -FI_ENOMEM;
+	if (prealloc) {
+		node = prealloc;
+	} else {
+		node = ofi_rbnode_alloc(map);
+		if (!node)
+			return -FI_ENOMEM;
+	}
 
 	node->parent = parent;
 	node->left = &map->sentinel;
@@ -275,6 +281,19 @@ int ofi_rbmap_insert(struct ofi_rbmap *map, void *key, void *data,
 	if (ret_node)
 		*ret_node = node;
 	return 0;
+}
+
+int ofi_rbmap_insert(struct ofi_rbmap *map, void *key, void *data,
+		     struct ofi_rbnode **ret_node)
+{
+	return ofi_rbmap_insert_common(map, key, data, ret_node, NULL);
+}
+
+int ofi_rbmap_insert_at(struct ofi_rbmap *map, void *key, void *data,
+			struct ofi_rbnode **ret_node,
+			struct ofi_rbnode *prealloc)
+{
+	return ofi_rbmap_insert_common(map, key, data, ret_node, prealloc);
 }
 
 static void ofi_delete_rebalance(struct ofi_rbmap *map, struct ofi_rbnode *node)


### PR DESCRIPTION
Backport #12109, #12313, #12333, #12337, #12340, #12341, #12345, #12350, #12351, #12352, #12356, #12361.