### PR TITLE
man: document receiver error completion on a matched, aborted message

### DIFF
--- a/man/fi_msg.3.md
+++ b/man/fi_msg.3.md
@@ -197,7 +197,8 @@ transfer.
 
 The fi_recv call posts a data buffer to the receive queue of the
 corresponding endpoint.  Posted receives are searched in the order in
-which they were posted in order to match sends.
+which they were posted in order to match sends. If a matched receive
+cannot be completed, the application receives an error completion.
 Message boundaries are maintained.  The order in which
 the receives complete is dependent on
 the endpoint type and protocol.  For connectionless endpoints, the

--- a/man/fi_tagged.3.md
+++ b/man/fi_tagged.3.md
@@ -124,8 +124,9 @@ send_tag | ignore == recv_tag | ignore
 ```
 
 In general, message tags are checked against receive buffers in the
-order in which messages have been posted to the endpoint.  See the
-ordering discussion below for more details.
+order in which messages have been posted to the endpoint. If a matched
+receive cannot be completed, the application receives an error completion.
+See the ordering discussion below for more details.
 
 The send functions -- fi_tsend, fi_tsendv, fi_tsendmsg,
 fi_tinject, and fi_tsenddata -- are used


### PR DESCRIPTION
fi_msg(3) describes posted-receive matching order but is silent on what a receiver observes when a sender aborts a message after it has been matched Add a sentence to the fi_recv description so the behavior is spec-sanctioned and applications can rely on it: a matched receive whose message fails to deliever mid-transfer completes with an error.