### PR TITLE
prov/verbs: Bug in EP state machine captured by an assertion failure

### DIFF
--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -1082,7 +1082,14 @@ vrb_eq_cm_process_event(struct vrb_eq *eq,
 	case RDMA_CM_EVENT_UNREACHABLE:
 		ep = container_of(fid, struct vrb_ep, util_ep.ep_fid);
 		ofi_genlock_lock(&vrb_ep2_progress(ep)->ep_lock);
-		assert(ep->state != VRB_DISCONNECTED);
+		if (ep->state == VRB_DISCONNECTED) {
+			/* If we saw a transfer error, we already generated
+			 * a shutdown event.
+			 */
+			ret = -FI_EAGAIN;
+			ofi_genlock_unlock(&vrb_ep2_progress(ep)->ep_lock);
+			goto ack;
+		}
 		ep->state = VRB_DISCONNECTED;
 		ofi_genlock_unlock(&vrb_ep2_progress(ep)->ep_lock);
 		if (vrb_is_xrc_ep(ep)) {
@@ -1112,7 +1119,14 @@ vrb_eq_cm_process_event(struct vrb_eq *eq,
 	case RDMA_CM_EVENT_REJECTED:
 		ep = container_of(fid, struct vrb_ep, util_ep.ep_fid);
 		ofi_genlock_lock(&vrb_ep2_progress(ep)->ep_lock);
-		assert(ep->state != VRB_DISCONNECTED);
+		if (ep->state == VRB_DISCONNECTED) {
+			/* If we saw a transfer error, we already generated
+			 * a shutdown event.
+			 */
+			ret = -FI_EAGAIN;
+			ofi_genlock_unlock(&vrb_ep2_progress(ep)->ep_lock);
+			goto ack;
+		}
 		ep->state = VRB_DISCONNECTED;
 		ofi_genlock_unlock(&vrb_ep2_progress(ep)->ep_lock);
 		if (vrb_is_xrc_ep(ep)) {


### PR DESCRIPTION
Fix assertion failures that could occur when processing RDMA CM error events if the endpoint was already in VRB_DISCONNECTED state.

The root cause is not fully understood as the issue is not easily reproducible. However, analysis suggests two possible scenarios:

1. Multiple CM events for the same failure (suspected): The kernel RDMA CM subsystem may deliver multiple error events for a single connection failure. For example, when a connection attempt fails, the kernel could potentially deliver RDMA_CM_EVENT_UNREACHABLE followed by RDMA_CM_EVENT_CONNECT_ERROR for the same endpoint.
   - First event would transition ep->state to VRB_DISCONNECTED
   - Second event would hit the assertion ep->state != VRB_DISCONNECTED

2. CM event after work completion error: When a network failure occurs, two independent error detection paths may race:
   - Work completion error detected in vrb_poll_cq() calls vrb_shutdown_ep() which sets ep->state = VRB_DISCONNECTED
   - RDMA CM independently detects the same issue and delivers error events (UNREACHABLE, CONNECT_ERROR, REJECTED, etc.)
   - The assertion ep->state != VRB_DISCONNECTED would fail

The fix replaces the assertions with conditional checks that mirror the existing pattern used for RDMA_CM_EVENT_DISCONNECTED. If the endpoint is already disconnected, the code:
- Skips generating a duplicate shutdown/error event
- Returns -FI_EAGAIN and acknowledges the CM event
- Avoids duplicate error notifications to the application

This defensive approach handles both potential scenarios and prevents assertion failures regardless of the actual root cause.

Fixes https://github.com/ofiwg/libfabric/issues/12362