### PR TITLE
fabtests/efa: Fix the UAF bug in efa_rma_bw

### DIFF
--- a/fabtests/prov/efa/src/efa_rma_bw.c
+++ b/fabtests/prov/efa/src/efa_rma_bw.c
@@ -256,8 +256,9 @@ static int bandwidth_rma_efa(struct fi_rma_iov *remote)
 	if (opts.rma_op == FT_RMA_WRITEDATA && !opts.dst_addr) {
 		/* Server side for writedata: pre-post rx buffers round-robin. */
 		if (fi->rx_attr->mode & FI_RX_CQ_DATA) {
+			int pre_post_limit = MIN(opts.window_size, total_iterations);
 			for (int ep_idx = 0; ep_idx < num_eps; ep_idx++) {
-				while (per_ep_posted[ep_idx] < opts.window_size) {
+				while (per_ep_posted[ep_idx] < pre_post_limit) {
 					ret = post_rx(ep_idx, per_ep_posted,
 						      per_ep_completed,
 						      &posted_cnt, 0);


### PR DESCRIPTION
In the pre-post rx stage, the test should only post the MIN of window size and the total iterations, otherwise efa provider will get return completions with context ptr that is already released from the last msg size function and cause UAF. This patch fixes it