### PR TITLE
prov/efa: fix 0-byte RDMA write stack overflow on efa-direct

### DIFF
--- a/prov/efa/src/efa_rma.c
+++ b/prov/efa/src/efa_rma.c
@@ -268,6 +268,7 @@ static inline ssize_t efa_rma_post_write(struct efa_base_ep *base_ep,
 
 	/* Handle 0-byte write with bounce buffer */
 	if (total_len == 0) {
+		use_inline = false;
 		sge_list[0].addr = (uint64_t)domain->zero_byte_bounce_buf;
 		sge_list[0].length = 0;
 		sge_list[0].lkey = domain->zero_byte_bounce_buf_mr->ibv_mr->lkey;


### PR DESCRIPTION
For a 0-byte write, use_inline is set (0 <= inject_rma_size), but the 0-byte branch prepares a bounce-buffer SGE without clearing use_inline or populating inline_data_list. The WQE builder then memcpy's an uninitialized length into the inline buffer, smashing the stack. Clear use_inline in the 0-byte branch so the bounce-buffer SGE path is used.