### PR TITLE
prov/ucx: fix ucx_av_lookup to index ave_array (fixes Spawn / dynamic…

### DIFF
--- a/prov/ucx/src/ucx_av.c
+++ b/prov/ucx/src/ucx_av.c
@@ -230,7 +230,7 @@ static int ucx_av_lookup(struct fid_av *av, fi_addr_t fi_addr, void *addr,
 	size_t realsz;
 
 	mav = container_of(av, struct ucx_av, av.fid);
-	ave = (struct ucx_ave *) ofi_array_at_max(&mav->addr_array, fi_addr,
+	ave = (struct ucx_ave *) ofi_array_at_max(&mav->ave_array, fi_addr,
 						  mav->count);
 	if (!ave)
 		return -FI_EINVAL;


### PR DESCRIPTION
… processes)

ucx_av_lookup() indexed the wrong dynamic array. It looked the entry up in av->addr_array (raw address bytes, element size = addr_len) but then cast the returned element to a 'struct ucx_ave *' and dereferenced ave->addr. Every other AV access in the provider uses av->ave_array (element size = sizeof(struct ucx_ave) = {ucp_ep_h uep; void *addr;}):

  - ucx_av_insert()  populates ep_ave in ave_array and sets ep_ave->addr = <slot in addr_array>
  - ucx_av_remove()  -> ofi_array_at_max(&av->ave_array, ...)
  - ucx_rma.c        -> ofi_array_at_max(&ep->av->ave_array, ...)
  - UCX_GET_UCP_EP() -> ofi_array_at_max(&av->ave_array, ...)

Only ucx_av_lookup() used addr_array, so it reinterpreted raw address bytes as a 'struct ucx_ave' and read a garbage ave->addr pointer, then memcpy'd from it.

Impact: MPI dynamic-process support (MPI_Comm_spawn / connect / accept) is broken on the UCX provider. The CH4/OFI netmod calls fi_av_lookup() to fetch the raw UPID for the dynamic-process address exchange (MPIDI_OFI_get_local_upids / MPIDI_OFI_upids_to_lupids in src/mpid/ch4/netmod/ofi/ofi_init.c). The bogus lookup result makes the spawned children's connect-back fail:

    Fatal error in internal_Comm_spawn: Other MPI error
    MPID_Comm_spawn_multiple(130): Error in spawn call

The fix simply indexes ave_array (the same array all other code paths use), whose entries already carry a valid ->addr pointer (populated during ucx_av_insert when enable_spawn is set; Intel MPI forces FI_UCX_ENABLE_SPAWN=yes for spawn scenarios in ofi_init.c). Non-spawn paths never call fi_av_lookup, so this change is safe for them.