### PR TITLE
fabtests/rma_pingpong, pytest/efa: Enable 0-byte RMA testing for efa-direct

### DIFF
--- a/fabtests/benchmarks/benchmark_shared.c
+++ b/fabtests/benchmarks/benchmark_shared.c
@@ -316,8 +316,8 @@ int pingpong_rma_write(enum ft_rma_opcodes rma_op, struct fi_rma_iov *remote)
 	if (ft_check_opts(FT_OPT_VERIFY_DATA))
 		inject_size = 0;
 
-	if (opts.transfer_size == 0) {
-		FT_ERR("Zero-sized transfers not supported");
+	if (opts.transfer_size == 0 && rma_op == FT_RMA_WRITE) {
+		FT_ERR("Zero-sized transfers not supported for write op");
 		return EXIT_FAILURE;
 	}
 
@@ -391,11 +391,6 @@ int pingpong_rma_write(enum ft_rma_opcodes rma_op, struct fi_rma_iov *remote)
 int pingpong_rma_read(struct fi_rma_iov *remote)
 {
 	int ret, i;
-
-	if (opts.transfer_size == 0) {
-		FT_ERR("Zero-sized transfers not supported");
-		return EXIT_FAILURE;
-	}
 
 	/* Fill tx_buf with data for peer to read from us */
 	if (ft_check_opts(FT_OPT_VERIFY_DATA)) {

--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -2352,7 +2352,7 @@ ssize_t ft_tx_rma(enum ft_rma_opcodes rma_op, struct fi_rma_iov *remote,
 {
 	ssize_t ret;
 
-	if (ft_check_opts(FT_OPT_VERIFY_DATA | FT_OPT_ACTIVE)) {
+	if (ft_check_opts(FT_OPT_VERIFY_DATA | FT_OPT_ACTIVE) && size > 0) {
 		/* Fill data. Last byte reserved for iteration number */
 		ret = ft_fill_buf((char *) tx_buf, size - 1);
 		if (ret)
@@ -2423,7 +2423,7 @@ ssize_t ft_inject_rma(enum ft_rma_opcodes rma_op, struct fi_rma_iov *remote,
 {
 	ssize_t ret;
 
-	if (ft_check_opts(FT_OPT_VERIFY_DATA | FT_OPT_ACTIVE)) {
+	if (ft_check_opts(FT_OPT_VERIFY_DATA | FT_OPT_ACTIVE) && size > 0) {
 		/* Fill data. Last byte reserved for iteration number */
 		ret = ft_fill_buf((char *) tx_buf, size - 1);
 		if (ret)
@@ -2702,7 +2702,7 @@ ssize_t ft_rx_rma(int iter, enum ft_rma_opcodes rma_op, struct fid_ep *ep,
 		return EXIT_FAILURE;
 	}
 
-	if (ft_check_opts(FT_OPT_VERIFY_DATA | FT_OPT_ACTIVE)) {
+	if (ft_check_opts(FT_OPT_VERIFY_DATA | FT_OPT_ACTIVE) && size > 0) {
 		ret = ft_check_buf((char *) rx_buf, size - 1);
 		if (ret)
 			return ret;

--- a/fabtests/pytest/efa/conftest.py
+++ b/fabtests/pytest/efa/conftest.py
@@ -39,7 +39,7 @@ def choose_message_sizes_for_fabric_test_type(fabric, test_type, sizes_marker, n
     Return all matching message-size lists for (fabric, test_type) from a
     @pytest.mark.message_sizes marker.
     example:
-    @pytest.mark.message_sizes(default_efa=PERF_SIZES, pr_ci_efa=DIRECT_RMA_SIZES)
+    @pytest.mark.message_sizes(default_efa=PERF_SIZES, pr_ci_efa=DIRECT_SIZES)
                    ^sizes marker   ^kwarg_name   ^kwarg_sizes
     """
     sizes = []

--- a/fabtests/pytest/efa/efa_common.py
+++ b/fabtests/pytest/efa/efa_common.py
@@ -12,8 +12,6 @@ from retrying import retry
 # EFA-specific message size lists for @pytest.mark.message_sizes decorator.
 # Generic (shared) size lists live in fabtests/pytest/common.py.
 DIRECT_SIZES = ["r:0,4,32", "r:0,1024,8192"]
-# RMA variant: starts at 1 because fabtests RMA benchmarks reject 0-byte.
-DIRECT_RMA_SIZES = ["r:1,4,32", "r:1,1024,8192"]
 REMOTE_EXIT_SIZES = [65536, 131072, 1048576]
 # Use the default behavior of the test, so pass None.
 DGRAM_DEFAULT = [None]

--- a/fabtests/pytest/efa/test_gda.py
+++ b/fabtests/pytest/efa/test_gda.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 from common import ClientServerTest, has_cuda
-from efa.efa_common import DIRECT_SIZES, DIRECT_RMA_SIZES
+from efa.efa_common import DIRECT_SIZES
 
 
 def _skip_if_gda_unavailable(cmdline_args):
@@ -35,7 +35,7 @@ def test_gda_send_recv(cmdline_args, message_sizes, fabric):
 
 @pytest.mark.pr_ci
 @pytest.mark.fabric(params=["efa-direct"])
-@pytest.mark.message_sizes(default_efa_direct=DIRECT_RMA_SIZES, pr_ci_efa_direct=DIRECT_RMA_SIZES)
+@pytest.mark.message_sizes(default_efa_direct=DIRECT_SIZES, pr_ci_efa_direct=DIRECT_SIZES)
 @pytest.mark.short
 @pytest.mark.functional
 @pytest.mark.cuda_memory
@@ -53,7 +53,7 @@ def test_gda_write_bw(cmdline_args, message_sizes, rma_fabric):
 
 @pytest.mark.pr_ci
 @pytest.mark.fabric(params=["efa-direct"])
-@pytest.mark.message_sizes(default_efa_direct=DIRECT_RMA_SIZES, pr_ci_efa_direct=DIRECT_RMA_SIZES)
+@pytest.mark.message_sizes(default_efa_direct=DIRECT_SIZES, pr_ci_efa_direct=DIRECT_SIZES)
 @pytest.mark.short
 @pytest.mark.functional
 @pytest.mark.cuda_memory
@@ -71,7 +71,7 @@ def test_gda_writedata_bw(cmdline_args, message_sizes, rma_fabric):
 
 @pytest.mark.pr_ci
 @pytest.mark.fabric(params=["efa-direct"])
-@pytest.mark.message_sizes(default_efa_direct=DIRECT_RMA_SIZES, pr_ci_efa_direct=DIRECT_RMA_SIZES)
+@pytest.mark.message_sizes(default_efa_direct=DIRECT_SIZES, pr_ci_efa_direct=DIRECT_SIZES)
 @pytest.mark.short
 @pytest.mark.functional
 @pytest.mark.cuda_memory

--- a/fabtests/pytest/efa/test_hw_cntr.py
+++ b/fabtests/pytest/efa/test_hw_cntr.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 from common import ClientServerTest
-from efa.efa_common import DIRECT_SIZES, DIRECT_RMA_SIZES
+from efa.efa_common import DIRECT_SIZES
 
 @pytest.fixture(autouse=True)
 def skip_if_not_built(cmdline_args):
@@ -24,7 +24,7 @@ def test_efa_hw_cntr_pingpong(cmdline_args, message_sizes, fabric):
 
 
 @pytest.mark.fabric(params=["efa-direct"])
-@pytest.mark.message_sizes(default_efa_direct=DIRECT_RMA_SIZES)
+@pytest.mark.message_sizes(default_efa_direct=DIRECT_SIZES)
 @pytest.mark.short
 @pytest.mark.functional
 def test_efa_hw_cntr_rma_write(cmdline_args, message_sizes, rma_fabric):
@@ -50,7 +50,7 @@ def test_efa_hw_cntr_pingpong_ext_mem(cmdline_args, message_sizes, fabric):
 
 
 @pytest.mark.fabric(params=["efa-direct"])
-@pytest.mark.message_sizes(default_efa_direct=DIRECT_RMA_SIZES)
+@pytest.mark.message_sizes(default_efa_direct=DIRECT_SIZES)
 @pytest.mark.short
 @pytest.mark.functional
 def test_efa_hw_cntr_rma_write_ext_mem(cmdline_args, message_sizes, rma_fabric):

--- a/fabtests/pytest/efa/test_rma_bw.py
+++ b/fabtests/pytest/efa/test_rma_bw.py
@@ -1,4 +1,4 @@
-from efa.efa_common import efa_run_client_server_test, DIRECT_RMA_SIZES
+from efa.efa_common import efa_run_client_server_test, DIRECT_SIZES
 from common import (perf_progress_model_cli, ClientServerTest,
                     PERF_SIZES, PERF_PR_CI, RANGE_SIZES, INJECT_SIZES)
 import pytest
@@ -7,8 +7,8 @@ import copy
 
 @pytest.mark.pr_ci
 @pytest.mark.fabric(params=["efa", "efa-direct"])
-@pytest.mark.message_sizes(default_efa=PERF_SIZES, default_efa_direct=DIRECT_RMA_SIZES,
-                           pr_ci_efa=PERF_PR_CI, pr_ci_efa_direct=DIRECT_RMA_SIZES)
+@pytest.mark.message_sizes(default_efa=PERF_SIZES, default_efa_direct=DIRECT_SIZES,
+                           pr_ci_efa=PERF_PR_CI, pr_ci_efa_direct=DIRECT_SIZES)
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
@@ -22,7 +22,7 @@ def test_rma_bw(cmdline_args, iteration_type, rma_operation_type, rma_bw_complet
                                timeout=timeout, fabric=rma_fabric)
 
 @pytest.mark.fabric(params=["efa", "efa-direct"])
-@pytest.mark.message_sizes(default_efa=PERF_SIZES, default_efa_direct=DIRECT_RMA_SIZES)
+@pytest.mark.message_sizes(default_efa=PERF_SIZES, default_efa_direct=DIRECT_SIZES)
 @pytest.mark.parametrize("env_vars", [["FI_EFA_TX_SIZE=64"], ["FI_EFA_RX_SIZE=64"], ["FI_EFA_TX_SIZE=64", "FI_EFA_RX_SIZE=64"]])
 def test_rma_bw_small_tx_rx(cmdline_args, rma_operation_type, rma_bw_completion_semantic, rma_bw_memory_type, env_vars, rma_fabric, message_sizes):
     cmdline_args_copy = copy.copy(cmdline_args)
@@ -38,7 +38,7 @@ def test_rma_bw_small_tx_rx(cmdline_args, rma_operation_type, rma_bw_completion_
                                timeout=timeout, fabric=rma_fabric)
 
 @pytest.mark.fabric(params=["efa", "efa-direct"])
-@pytest.mark.message_sizes(default_efa=RANGE_SIZES, default_efa_direct=DIRECT_RMA_SIZES)
+@pytest.mark.message_sizes(default_efa=RANGE_SIZES, default_efa_direct=DIRECT_SIZES)
 @pytest.mark.functional
 def test_rma_bw_range(cmdline_args, rma_operation_type, rma_bw_completion_semantic, message_sizes, rma_bw_memory_type, rma_fabric):
     command = "fi_rma_bw -e rdm"
@@ -102,7 +102,7 @@ def test_rma_bw_large(cmdline_args, operation_type, rma_bw_completion_semantic, 
                                memory_type="host_to_host", warmup_iteration_type=0, timeout=timeout, fabric=rma_fabric)
 
 @pytest.mark.fabric(params=["efa", "efa-direct"])
-@pytest.mark.message_sizes(default_efa=INJECT_SIZES, default_efa_direct=DIRECT_RMA_SIZES)
+@pytest.mark.message_sizes(default_efa=INJECT_SIZES, default_efa_direct=DIRECT_SIZES)
 @pytest.mark.functional
 @pytest.mark.parametrize("operation_type", ["writedata", "write"])
 @pytest.mark.parametrize("iteration_type",
@@ -120,8 +120,8 @@ def test_rma_bw_use_fi_more(cmdline_args, operation_type, iteration_type, rma_bw
 
 
 @pytest.mark.fabric(params=["efa", "efa-direct"])
-@pytest.mark.message_sizes(default_efa=PERF_SIZES, default_efa_direct=DIRECT_RMA_SIZES,
-                           pr_ci_efa=PERF_PR_CI, pr_ci_efa_direct=DIRECT_RMA_SIZES)
+@pytest.mark.message_sizes(default_efa=PERF_SIZES, default_efa_direct=DIRECT_SIZES,
+                           pr_ci_efa=PERF_PR_CI, pr_ci_efa_direct=DIRECT_SIZES)
 @pytest.mark.functional
 @pytest.mark.parametrize("comp_method", ["sread", "fd"])
 def test_rma_bw_sread(cmdline_args, rma_operation_type, rma_bw_completion_semantic,
@@ -145,8 +145,8 @@ def test_rma_bw_sread(cmdline_args, rma_operation_type, rma_bw_completion_semant
 
 @pytest.mark.pr_ci
 @pytest.mark.fabric(params=["efa", "efa-direct"])
-@pytest.mark.message_sizes(default_efa=PERF_SIZES, default_efa_direct=DIRECT_RMA_SIZES,
-                           pr_ci_efa=PERF_PR_CI, pr_ci_efa_direct=DIRECT_RMA_SIZES)
+@pytest.mark.message_sizes(default_efa=PERF_SIZES, default_efa_direct=DIRECT_SIZES,
+                           pr_ci_efa=PERF_PR_CI, pr_ci_efa_direct=DIRECT_SIZES)
 @pytest.mark.functional
 @pytest.mark.parametrize("operation_type", ["write", "writedata"])
 # Only test host and cuda memory; other HMEM types do not change the RMA path.
@@ -167,8 +167,8 @@ def test_efa_rma_bw_high_pps(cmdline_args, operation_type, mem_type, rma_fabric)
 # Testing the batch mode of fi_efa_rma_bw (--post-list) which batch multiple WQEs with FI_MORE
 @pytest.mark.pr_ci
 @pytest.mark.fabric(params=["efa", "efa-direct"])
-@pytest.mark.message_sizes(default_efa=PERF_SIZES, default_efa_direct=DIRECT_RMA_SIZES,
-                           pr_ci_efa=PERF_PR_CI, pr_ci_efa_direct=DIRECT_RMA_SIZES)
+@pytest.mark.message_sizes(default_efa=PERF_SIZES, default_efa_direct=DIRECT_SIZES,
+                           pr_ci_efa=PERF_PR_CI, pr_ci_efa_direct=DIRECT_SIZES)
 @pytest.mark.functional
 @pytest.mark.parametrize("operation_type", ["write", "writedata"])
 # Only test host and cuda memory; other HMEM types do not change the RMA path.
@@ -189,8 +189,8 @@ def test_efa_rma_bw_batch(cmdline_args, operation_type, mem_type, rma_fabric):
 # Testing the multi-ep + batch mode of fi_efa_rma_bw, which spins multiple EPs to initiate rdma requests
 @pytest.mark.pr_ci
 @pytest.mark.fabric(params=["efa", "efa-direct"])
-@pytest.mark.message_sizes(default_efa=PERF_SIZES, default_efa_direct=DIRECT_RMA_SIZES,
-                           pr_ci_efa=PERF_PR_CI, pr_ci_efa_direct=DIRECT_RMA_SIZES)
+@pytest.mark.message_sizes(default_efa=PERF_SIZES, default_efa_direct=DIRECT_SIZES,
+                           pr_ci_efa=PERF_PR_CI, pr_ci_efa_direct=DIRECT_SIZES)
 @pytest.mark.functional
 @pytest.mark.parametrize("operation_type", ["write", "writedata"])
 # Only test host and cuda memory; other HMEM types do not change the RMA path.

--- a/fabtests/pytest/efa/test_rma_pingpong.py
+++ b/fabtests/pytest/efa/test_rma_pingpong.py
@@ -1,12 +1,12 @@
-from efa.efa_common import efa_run_client_server_test, DIRECT_RMA_SIZES
+from efa.efa_common import efa_run_client_server_test, DIRECT_SIZES
 from common import perf_progress_model_cli, PERF_SIZES, PERF_PR_CI, RMA_PINGPONG_SIZES
 import pytest
 
 
 @pytest.mark.pr_ci
 @pytest.mark.fabric(params=["efa", "efa-direct"])
-@pytest.mark.message_sizes(default_efa=PERF_SIZES, default_efa_direct=DIRECT_RMA_SIZES,
-                           pr_ci_efa=PERF_PR_CI, pr_ci_efa_direct=DIRECT_RMA_SIZES)
+@pytest.mark.message_sizes(default_efa=PERF_SIZES, default_efa_direct=DIRECT_SIZES,
+                           pr_ci_efa=PERF_PR_CI, pr_ci_efa_direct=DIRECT_SIZES)
 @pytest.mark.parametrize("operation_type", ["writedata", "read"])
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
@@ -19,7 +19,7 @@ def test_rma_pingpong(cmdline_args, iteration_type, operation_type, rma_bw_compl
 
 
 @pytest.mark.fabric(params=["efa", "efa-direct"])
-@pytest.mark.message_sizes(default_efa=RMA_PINGPONG_SIZES, default_efa_direct=DIRECT_RMA_SIZES)
+@pytest.mark.message_sizes(default_efa=RMA_PINGPONG_SIZES, default_efa_direct=DIRECT_SIZES)
 @pytest.mark.functional
 @pytest.mark.parametrize("operation_type", ["writedata"])
 def test_rma_pingpong_range(cmdline_args, operation_type, rma_bw_completion_semantic, message_sizes,


### PR DESCRIPTION
Remove DIRECT_RMA_SIZES which started at 1 byte to work around a former efa-direct limitation. Now that efa-direct supports 0-byte RMA, use DIRECT_SIZES (starting at 0) for all RMA tests, matching the coverage already present for the efa fabric.