### PR TITLE
prov/efa: fix and simplify 'make coverage'

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -268,19 +268,15 @@ if ENABLE_COVERAGE
 coverage:
 	lcov --capture --directory $(top_builddir)/prov/efa/src \
 	     --output-file coverage.info --no-external
-	lcov --remove coverage.info '*/test/*' '*/src/.libs/*' \
-	     --output-file coverage.info
 	lcov --extract coverage.info '*/prov/efa/src/*' \
 	     --output-file coverage.info
-	find $(top_builddir) -name '*.gcno' -delete
-	find $(top_builddir) -name '*.gcda' -delete
-	find $(top_builddir) -name '*.gcov' -delete
 	genhtml coverage.info --output-directory coverage_report
 	@echo "Coverage report: coverage_report/index.html"
 
 coverage-clean:
 	find $(top_builddir) -name '*.gcda' -delete
 	find $(top_builddir) -name '*.gcno' -delete
+	find $(top_builddir) -name '*.gcov' -delete
 	rm -rf coverage.info coverage_report
 
 .PHONY: coverage coverage-clean


### PR DESCRIPTION
Previously re-runs of the `make coverage` recipe like
```
make -j
./prov/efa/test/efa_unit_test
make coverage
./prov/efa/test/gtest/efa_unit_test
make coverage
```
would only work for lcov 1.x but break for lcov 2.x, which has made some warnings into errors.
This PR stops deleting `.gcda` files in the `coverage` recipe and drop the redundant `--remove` stage; `coverage-clean` handles resets.