### PR TITLE
prov/util, prov/shm: Properly initialize memory monitors

### DIFF
--- a/prov/shm/src/smr_init.c
+++ b/prov/shm/src/smr_init.c
@@ -179,7 +179,9 @@ static int smr_getinfo(uint32_t version, const char *node, const char *service,
 static void smr_fini(void)
 {
 #if HAVE_SHM_DL
+	ofi_monitors_cleanup();
 	ofi_hmem_cleanup();
+	ofi_mem_fini();
 #endif
 	smr_dsa_cleanup();
 	smr_cleanup();
@@ -204,7 +206,9 @@ struct util_prov smr_util_prov = {
 SHM_INI
 {
 #if HAVE_SHM_DL
+	ofi_mem_init();
 	ofi_hmem_init();
+	ofi_monitors_init();
 	ofi_params_init();
 #endif
 	fi_param_define(&smr_prov, "tx_size", FI_PARAM_SIZE_T,

--- a/prov/util/src/cuda_ipc_monitor.c
+++ b/prov/util/src/cuda_ipc_monitor.c
@@ -56,6 +56,7 @@ static bool cuda_ipc_monitor_valid(struct ofi_mem_monitor *monitor,
 
 #endif /* HAVE_CUDA */
 static struct ofi_mem_monitor cuda_ipc_monitor_ = {
+	.iface = FI_HMEM_CUDA,
 	.init = ofi_monitor_init,
 	.cleanup = ofi_monitor_cleanup,
 	.start = ofi_monitor_start_no_op,

--- a/prov/util/src/rocr_ipc_monitor.c
+++ b/prov/util/src/rocr_ipc_monitor.c
@@ -57,6 +57,7 @@ static bool rocr_ipc_monitor_valid(struct ofi_mem_monitor *monitor,
 #endif /* HAVE_ROCR */
 
 static struct ofi_mem_monitor rocr_ipc_monitor_ = {
+	.iface = FI_HMEM_ROCR,
 	.init = ofi_monitor_init,
 	.cleanup = ofi_monitor_cleanup,
 	.start = ofi_monitor_start_no_op,

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -47,6 +47,7 @@
 
 struct ofi_mr_cache_params cache_params = {
 	.max_cnt = 1024,
+	.max_size = SIZE_MAX,
 	.cuda_monitor_enabled = true,
 	.rocr_monitor_enabled = true,
 	.ze_monitor_enabled = true,

--- a/prov/util/src/ze_ipc_monitor.c
+++ b/prov/util/src/ze_ipc_monitor.c
@@ -57,6 +57,7 @@ static bool ze_ipc_monitor_valid(struct ofi_mem_monitor *monitor,
 
 #endif /* HAVE_ZE */
 static struct ofi_mem_monitor ze_ipc_monitor_ = {
+	.iface = FI_HMEM_ZE,
 	.init = ofi_monitor_init,
 	.cleanup = ofi_monitor_cleanup,
 	.start = ofi_monitor_start_no_op,

--- a/src/hmem_ze.c
+++ b/src/hmem_ze.c
@@ -635,9 +635,10 @@ static int ze_hmem_cleanup_internal(int fini_workaround)
 					"Failed to destroy ZE cmd_queue\n");
 				ret = -FI_EINVAL;
 			}
+
+			if (dev_info[i].cl_pool)
+				ofi_bufpool_destroy(dev_info[i].cl_pool);
 		}
-		if (dev_info[i].cl_pool)
-			ofi_bufpool_destroy(dev_info[i].cl_pool);
 	}
 
 	free(devices);


### PR DESCRIPTION
Initialize cache_params.max_size to be SIZE_MAX (will turn into an environment variable later)
Initialize mem and monitors for shm dl builds