### PR TITLE
prov/efa/rdm: use safe list iteration for ope_longcts_send_list

### DIFF
--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -1024,8 +1024,9 @@ void efa_domain_progress_rdm_peers_and_queues(struct efa_domain *domain)
 	/*
 	 * Send data packets until window or data queue is exhausted.
 	 */
-	dlist_foreach_container(&domain->ope_longcts_send_list, struct efa_rdm_ope,
-				ope, entry) {
+	dlist_foreach_container_safe(&domain->ope_longcts_send_list,
+				     struct efa_rdm_ope,
+				     ope, entry, tmp) {
 		peer = ope->peer;
 		assert(peer);
 		if (peer->flags & EFA_RDM_PEER_IN_BACKOFF)


### PR DESCRIPTION
The long-CTS data drip loop iterates ope_longcts_send_list using dlist_foreach_container. If efa_rdm_ope_post_send returns a non-EAGAIN error, efa_rdm_txe_handle_error removes the ope from the list during iteration, corrupting the iterator.

Switch to dlist_foreach_container_safe to allow safe removal of the current entry mid-iteration.