### PR TITLE
fabtests: Verify nvidia-peermem is loaded before reporting GDR support

### DIFF
--- a/fabtests/common/hmem_cuda.c
+++ b/fabtests/common/hmem_cuda.c
@@ -205,8 +205,31 @@ static int ft_cuda_detect_memory_support(void)
 	// Blackwell or newer: nv-p2p deprecated
 	if (cc_major >= 10)
 		gdr_supported = false;
-	else
+	else {
 		gdr_supported = (gdr_attr == 1);
+		/*
+		 * The CUDA device attribute only indicates GPU-side GDR
+		 * capability. Verify that the kernel peer-memory module
+		 * is actually loaded, since without it the NIC cannot
+		 * register GPU buffers (e.g. g6 instances with L4 GPUs).
+		 */
+		if (gdr_supported) {
+			FILE *f = fopen("/proc/modules", "r");
+			if (f) {
+				char line[256];
+				int found = 0;
+				while (fgets(line, sizeof(line), f)) {
+					if (strstr(line, "nvidia_peermem")) {
+						found = 1;
+						break;
+					}
+				}
+				fclose(f);
+				if (!found)
+					gdr_supported = false;
+			}
+		}
+	}
 
 	// Final truth table
 	if (!gdr_supported && !dmabuf_supported)


### PR DESCRIPTION
cuda_check_dmabuf queries CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_SUPPORTED to determine if GPUDirect RDMA is available. However, this only reflects GPU-side capability. On instances where the NIC cannot register GPU memory (e.g. g6 with L4 GPUs where nvidia-peermem fails to load), the binary falsely reports GDR is available, causing the test framework to invoke CUDA RMA tests that hang.

Add a check for nvidia_peermem in /proc/modules after the CUDA device attribute query. If the module is not loaded, report GDR as unsupported regardless of what the GPU reports.