### PR TITLE
prov/rxm: multi-QP support via pluggable msg_ep selector and lazy multi-ep connect

### DIFF
--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -449,6 +449,7 @@
     <ClCompile Include="prov\rxm\src\rxm_hmem.c" />
     <ClCompile Include="prov\rxm\src\rxm_fabric.c" />
     <ClCompile Include="prov\rxm\src\rxm_atomic.c" />
+    <ClCompile Include="prov\rxm\src\rxm_ep_selector.c" />
     <ClCompile Include="prov\rxm\src\rxm_init.c">
       <ForcedIncludeFiles Condition="'$(Configuration)|$(Platform)'=='Debug-v140|x64'">
       </ForcedIncludeFiles>
@@ -997,6 +998,7 @@
     <ClInclude Include="prov\rxd\src\rxd.h" />
     <ClInclude Include="prov\rxd\src\rxd_proto.h" />
     <ClInclude Include="prov\rxm\src\rxm.h" />
+    <ClInclude Include="prov\rxm\src\rxm_ep_selector.h" />
     <ClInclude Include="prov\sockets\include\sock.h" />
     <ClInclude Include="prov\sockets\include\sock_util.h" />
     <ClInclude Include="prov\udp\src\udpx.h" />

--- a/man/fi_rxm.7.md
+++ b/man/fi_rxm.7.md
@@ -181,6 +181,13 @@ with (default: 256).
   copied or registered (e.g. in Rendezvous) internally by RxM. Note that no
   extra memory registration is performed with this option. (default: false)
 
+*FI_OFI_RXM_NUM_MSG_EPS*
+: Number of MSG endpoints (and underlying connections/QPs) to open per RxM
+  peer connection. Values greater than 1 spread traffic across multiple QPs
+  in a round-robin fashion, which can improve throughput on hardware that
+  benefits from multiple QPs per peer. The value is clamped to the range
+  [1, 255]. (default: 1)
+
 # Tuning
 
 ## Bandwidth

--- a/prov/rxm/Makefile.include
+++ b/prov/rxm/Makefile.include
@@ -13,6 +13,8 @@ _rxm_files = \
        prov/rxm/src/rxm_atomic.c	\
        prov/rxm/src/rxm_eq.c	\
        prov/rxm/src/rxm_hmem.c	\
+       prov/rxm/src/rxm_ep_selector.c	\
+       prov/rxm/src/rxm_ep_selector.h	\
        prov/rxm/src/rxm.h
 
 if HAVE_RXM_DL

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -182,6 +182,14 @@ do {									\
 	((void *) rxm_buf_get_by_index(&(rxm_ep)->buf_pools[pool_type],		\
 				       (uint64_t) msg_id))
 
+/* A SAR msg_id carries a per-endpoint generation in its high 32 bits and the
+ * FIRST tx_buf index in the low ones, so a recycled index cannot alias a
+ * reassembly still in progress at the receiver.
+ */
+#define RXM_SAR_MSG_ID(gen, index)						\
+	((((uint64_t) (uint32_t) (gen)) << 32) | (uint32_t) (index))
+#define RXM_SAR_TX_INDEX(msg_id)	((size_t) ((msg_id) & 0xffffffffULL))
+
 extern struct fi_provider rxm_prov;
 extern struct util_prov rxm_util_prov;
 
@@ -715,6 +723,7 @@ struct rxm_ep {
 	size_t			sar_limit;
 	size_t			tx_credit;
 	size_t			min_multi_recv_size;
+	uint32_t		sar_msg_gen;
 
 	struct ofi_bufpool	*rx_pool;
 	struct ofi_bufpool	*tx_pool;

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -235,7 +235,7 @@ struct rxm_conn {
 	struct fid_ep **msg_eps;
 	enum rxm_cm_state *states;
 	uint8_t num_msg_eps;
-	const struct rxm_ep_selector *selector;
+	struct rxm_ep_selector *selector;
 	struct rxm_ep *ep;
 
 	/* Prior versions of libfabric did not guarantee that all connections

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -531,6 +531,13 @@ struct rxm_tx_buf {
 	void *app_context;
 	uint64_t flags;
 
+	/* FIRST tx_buf only: FIRST and LAST may complete on different msg
+	 * endpoints, so the buffer is freed by whoever observes both. */
+	struct {
+		bool first_seg_done;
+		bool last_seg_done;
+	} sar;
+
 	union {
 		struct {
 			struct fid_mr *mr[RXM_IOV_LIMIT];
@@ -565,6 +572,18 @@ struct rxm_coll_buf {
 /* Used for application transmits, provides credit check */
 struct rxm_tx_buf *rxm_get_tx_buf(struct rxm_ep *ep);
 void rxm_free_tx_buf(struct rxm_ep *ep, struct rxm_tx_buf *buf);
+
+/* Called once the message is resolved, either because LAST completed or
+ * because the transfer was aborted. FIRST's own completion sets the other
+ * flag in rxm_complete_sar().
+ */
+static inline void
+rxm_release_sar_first_tx_buf(struct rxm_ep *ep, struct rxm_tx_buf *first_tx_buf)
+{
+	first_tx_buf->sar.last_seg_done = true;
+	if (first_tx_buf->sar.first_seg_done)
+		rxm_free_tx_buf(ep, first_tx_buf);
+}
 
 /* Context for collective operations */
 struct rxm_coll_buf *rxm_get_coll_buf(struct rxm_ep *ep);

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -87,7 +87,7 @@ union rxm_cm_data {
 		uint8_t op_version;
 		uint16_t port;
 		uint8_t flow_ctrl;
-		uint8_t padding;
+		uint8_t ep_idx;
 		uint32_t eager_limit;
 		uint32_t rx_size; /* used? */
 		uint64_t client_conn_id;
@@ -208,6 +208,7 @@ extern int rxm_passthru;
 extern int force_auto_progress;
 extern int rxm_use_write_rndv;
 extern int rxm_detect_hmem_iface;
+extern size_t rxm_num_msg_eps;
 extern enum fi_wait_obj def_wait_obj, def_tcp_wait_obj;
 
 struct rxm_ep;
@@ -256,6 +257,18 @@ struct rxm_conn {
 };
 
 void rxm_freeall_conns(struct rxm_ep *ep);
+
+static inline int rxm_get_ep_idx(struct rxm_conn *conn, struct fid *fid)
+{
+	uint8_t i;
+
+	for (i = 0; i < conn->num_msg_eps; i++)
+		if (conn->msg_eps[i] && &conn->msg_eps[i]->fid == fid)
+			return i;
+	return -1;
+}
+
+int rxm_send_connect(struct rxm_conn *conn, uint8_t idx);
 
 struct rxm_fabric {
 	struct util_fabric util_fabric;

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -60,6 +60,8 @@
 #ifndef _RXM_H_
 #define _RXM_H_
 
+#include "rxm_ep_selector.h"
+
 
 #define RXM_CM_DATA_VERSION	1
 #define RXM_OP_VERSION		3
@@ -230,7 +232,9 @@ enum {
 struct rxm_conn {
 	enum rxm_cm_state state;
 	struct util_peer_addr *peer;
-	struct fid_ep *msg_ep;
+	struct fid_ep **msg_eps;
+	uint8_t num_msg_eps;
+	const struct rxm_ep_selector *selector;
 	struct rxm_ep *ep;
 
 	/* Prior versions of libfabric did not guarantee that all connections
@@ -786,6 +790,19 @@ static inline size_t rxm_ep_max_atomic_size(struct fi_info *info)
 	return rxm_buffer_size - sizeof(struct rxm_atomic_hdr);
 }
 
+static inline struct fid_ep *
+rxm_conn_msg_ep(struct rxm_conn *conn, const struct rxm_pkt *pkt)
+{
+	uint8_t idx = conn->selector->select(conn, pkt);
+
+	assert(idx < conn->num_msg_eps);
+	FI_DBG(&rxm_prov, FI_LOG_EP_DATA,
+	       "ep_sel: conn=%p ctrl=%u msg_id=0x%" PRIx64 " -> ep=%u of %u\n",
+	       conn, pkt ? pkt->ctrl_hdr.type : 0xff,
+	       pkt ? pkt->ctrl_hdr.msg_id : 0, idx, conn->num_msg_eps);
+	return conn->msg_eps[idx];
+}
+
 static inline ssize_t
 rxm_atomic_send_respmsg(struct rxm_ep *rxm_ep, struct rxm_conn *conn,
 			struct rxm_tx_buf *resp_buf, ssize_t len)
@@ -801,7 +818,8 @@ rxm_atomic_send_respmsg(struct rxm_ep *rxm_ep, struct rxm_conn *conn,
 		.context = resp_buf,
 		.data = 0,
 	};
-	return fi_sendmsg(conn->msg_ep, &msg, FI_COMPLETION);
+	return fi_sendmsg(rxm_conn_msg_ep(conn, &resp_buf->pkt),
+			  &msg, FI_COMPLETION);
 }
 
 void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
@@ -901,7 +919,8 @@ rxm_free_rx_buf(struct rxm_rx_buf *rx_buf)
 	}
 
 	/* Discard rx buffer if its msg_ep was closed */
-	if (rx_buf->repost && (rx_buf->ep->msg_srx || rx_buf->conn->msg_ep)) {
+	if (rx_buf->repost && (rx_buf->ep->msg_srx ||
+	     (rx_buf->conn->msg_eps && rx_buf->conn->msg_eps[0]))) {
 		rxm_post_recv(rx_buf);
 	} else {
 		ofi_buf_free(rx_buf);

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -230,9 +230,9 @@ enum {
  * remote rxm ep's.
  */
 struct rxm_conn {
-	enum rxm_cm_state state;
 	struct util_peer_addr *peer;
 	struct fid_ep **msg_eps;
+	enum rxm_cm_state *states;
 	uint8_t num_msg_eps;
 	const struct rxm_ep_selector *selector;
 	struct rxm_ep *ep;

--- a/prov/rxm/src/rxm_atomic.c
+++ b/prov/rxm/src/rxm_atomic.c
@@ -69,10 +69,11 @@ rxm_ep_send_atomic_req(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	 * software generated atomic response message is received. */
 	tx_buf->hdr.state = RXM_ATOMIC_RESP_WAIT;
 	if (len <= rxm_ep->inject_limit)
-		ret = fi_inject(rxm_conn->msg_ep, &tx_buf->pkt, len, 0);
+		ret = fi_inject(rxm_conn_msg_ep(rxm_conn, &tx_buf->pkt),
+				&tx_buf->pkt, len, 0);
 	else
-		ret = fi_send(rxm_conn->msg_ep, &tx_buf->pkt, len,
-			      tx_buf->hdr.desc, 0, tx_buf);
+		ret = fi_send(rxm_conn_msg_ep(rxm_conn, &tx_buf->pkt),
+			      &tx_buf->pkt, len, tx_buf->hdr.desc, 0, tx_buf);
 	if (ret == -FI_EAGAIN)
 		rxm_ep_do_progress(&rxm_ep->util_ep);
 

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -79,10 +79,14 @@ static void rxm_close_conn(struct rxm_conn *conn)
 		rx_entry = (struct fi_peer_rx_entry*)conn->deferred_sar_msgs.next;
 		rx_entry->srx->owner_ops->free_entry(rx_entry);
 	}
-	fi_close(&conn->msg_ep->fid);
+	for (int i = 0; i < conn->num_msg_eps; i++) {
+		if (conn->msg_eps && conn->msg_eps[i])
+			fi_close(&conn->msg_eps[i]->fid);
+	}
 	rxm_flush_msg_cq(conn->ep);
 	dlist_remove_init(&conn->loopback_entry);
-	conn->msg_ep = NULL;
+	free(conn->msg_eps);
+	conn->msg_eps = NULL;
 
 	if (conn->state == RXM_CM_CONNECTING || conn->state == RXM_CM_ACCEPTING)
 		conn->ep->connecting_cnt--;
@@ -218,7 +222,13 @@ static int rxm_open_conn(struct rxm_conn *conn, struct fi_info *msg_info)
 			goto err;
 	}
 
-	conn->msg_ep = msg_ep;
+	assert(conn->num_msg_eps == 1);
+	conn->msg_eps = calloc(conn->num_msg_eps, sizeof(*conn->msg_eps));
+	if (!conn->msg_eps) {
+		ret = -FI_ENOMEM;
+		goto err;
+	}
+	conn->msg_eps[0] = msg_ep;
 	return 0;
 err:
 	fi_close(&msg_ep->fid);
@@ -288,7 +298,7 @@ static int rxm_send_connect(struct rxm_conn *conn)
 	if (ret)
 		goto err;
 
-	ret = fi_connect(conn->msg_ep, info->dest_addr, &cm_data,
+	ret = fi_connect(conn->msg_eps[0], info->dest_addr, &cm_data,
 			 sizeof(cm_data));
 	if (ret) {
 		RXM_WARN_ERR(FI_LOG_EP_CTRL, "fi_connect", ret);
@@ -299,8 +309,12 @@ static int rxm_send_connect(struct rxm_conn *conn)
 	return 0;
 
 err:
-	fi_close(&conn->msg_ep->fid);
-	conn->msg_ep = NULL;
+	for (int i = 0; i < conn->num_msg_eps; i++) {
+		if (conn->msg_eps && conn->msg_eps[i])
+			fi_close(&conn->msg_eps[i]->fid);
+	}
+	free(conn->msg_eps);
+	conn->msg_eps = NULL;
 	return ret;
 }
 
@@ -410,6 +424,10 @@ rxm_alloc_conn(struct rxm_ep *ep, struct util_peer_addr *peer)
 	conn->peer = peer;
 	rxm_ref_peer(peer);
 
+	conn->num_msg_eps = 1;
+	conn->msg_eps = NULL;
+	conn->selector = &rxm_selector_single_ep;
+
 	FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "allocated conn %p\n", conn);
 	return conn;
 }
@@ -516,7 +534,7 @@ void rxm_process_connect(struct rxm_eq_cm_entry *cm_entry)
 	if (conn->flow_ctrl && conn->peer_flow_ctrl) {
 		domain = container_of(conn->ep->util_ep.domain,
 				      struct rxm_domain, util_domain);
-		domain->flow_ctrl_ops->enable(conn->msg_ep,
+		domain->flow_ctrl_ops->enable(conn->msg_eps[0],
 					      conn->ep->msg_info->rx_attr->size / 2);
 	}
 
@@ -634,7 +652,7 @@ rxm_accept_connreq(struct rxm_conn *conn, struct rxm_eq_cm_entry *cm_entry)
 	cm_data.accept.align_pad[1] = 0;
 	cm_data.accept.align_pad[2] = 0;
 
-	ret = fi_accept(conn->msg_ep, &cm_data.accept, sizeof(cm_data.accept));
+	ret = fi_accept(conn->msg_eps[0], &cm_data.accept, sizeof(cm_data.accept));
 	if (ret)
 		RXM_WARN_ERR(FI_LOG_EP_CTRL, "fi_accept", ret);
 	return ret;

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -79,20 +79,24 @@ static void rxm_close_conn(struct rxm_conn *conn)
 		rx_entry = (struct fi_peer_rx_entry*)conn->deferred_sar_msgs.next;
 		rx_entry->srx->owner_ops->free_entry(rx_entry);
 	}
-	for (int i = 0; i < conn->num_msg_eps; i++) {
-		if (conn->msg_eps && conn->msg_eps[i])
-			fi_close(&conn->msg_eps[i]->fid);
+	if (conn->msg_eps) {
+		for (uint8_t i = 0; i < conn->num_msg_eps; i++) {
+			if (conn->msg_eps[i])
+				fi_close(&conn->msg_eps[i]->fid);
+		}
 	}
 	rxm_flush_msg_cq(conn->ep);
 	dlist_remove_init(&conn->loopback_entry);
 	free(conn->msg_eps);
 	conn->msg_eps = NULL;
 
-	if (conn->states[0] == RXM_CM_CONNECTING ||
-	    conn->states[0] == RXM_CM_ACCEPTING)
-		conn->ep->connecting_cnt--;
+	for (uint8_t i = 0; i < conn->num_msg_eps; i++) {
+		if (conn->states[i] == RXM_CM_CONNECTING ||
+		    conn->states[i] == RXM_CM_ACCEPTING)
+			conn->ep->connecting_cnt--;
+		conn->states[i] = RXM_CM_IDLE;
+	}
 	assert(conn->ep->connecting_cnt >= 0);
-	conn->states[0] = RXM_CM_IDLE;
 }
 
 static int rxm_bind_comp(struct rxm_ep *ep, struct fid_ep *msg_ep)
@@ -172,14 +176,13 @@ static int rxm_bind_comp(struct rxm_ep *ep, struct fid_ep *msg_ep)
 	return 0;
 }
 
-static int rxm_open_conn(struct rxm_conn *conn, struct fi_info *msg_info)
+static int rxm_open_msg_ep(struct rxm_conn *conn, uint8_t idx,
+			   struct fi_info *msg_info)
 {
 	struct rxm_domain *domain;
 	struct rxm_ep *ep;
 	struct fid_ep *msg_ep;
 	int ret;
-
-	FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "open msg ep %p\n", conn);
 
 	assert(ofi_genlock_held(&conn->ep->util_ep.lock));
 	ep = conn->ep;
@@ -190,6 +193,8 @@ static int rxm_open_conn(struct rxm_conn *conn, struct fi_info *msg_info)
 		RXM_WARN_ERR(FI_LOG_EP_CTRL, "fi_endpoint", ret);
 		return ret;
 	}
+
+	conn->msg_eps[idx] = msg_ep;
 
 	ret = fi_ep_bind(msg_ep, &ep->msg_eq->fid, 0);
 	if (ret) {
@@ -215,25 +220,45 @@ static int rxm_open_conn(struct rxm_conn *conn, struct fi_info *msg_info)
 		goto err;
 	}
 
-	conn->flow_ctrl = domain->flow_ctrl_ops->available(msg_ep);
-
 	if (!ep->msg_srx) {
 		ret = rxm_prepost_recv(ep, msg_ep);
 		if (ret)
 			goto err;
 	}
 
-	assert(conn->num_msg_eps == 1);
-	conn->msg_eps = calloc(conn->num_msg_eps, sizeof(*conn->msg_eps));
-	if (!conn->msg_eps) {
-		ret = -FI_ENOMEM;
-		goto err;
-	}
-	conn->msg_eps[0] = msg_ep;
 	return 0;
 err:
 	fi_close(&msg_ep->fid);
+	conn->msg_eps[idx] = NULL;
 	return ret;
+}
+
+static int rxm_open_conn(struct rxm_conn *conn, struct fi_info *msg_info)
+{
+	struct rxm_domain *domain;
+	int ret;
+
+	FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "open msg ep %p\n", conn);
+	assert(ofi_genlock_held(&conn->ep->util_ep.lock));
+
+	conn->msg_eps = calloc(conn->num_msg_eps, sizeof(*conn->msg_eps));
+	if (!conn->msg_eps) {
+		RXM_WARN_ERR(FI_LOG_EP_CTRL, "calloc msg_eps", -FI_ENOMEM);
+		return -FI_ENOMEM;
+	}
+
+	ret = rxm_open_msg_ep(conn, 0, msg_info);
+	if (ret) {
+		free(conn->msg_eps);
+		conn->msg_eps = NULL;
+		return ret;
+	}
+
+	domain = container_of(conn->ep->util_ep.domain, struct rxm_domain,
+			      util_domain);
+	conn->flow_ctrl = domain->flow_ctrl_ops->available(conn->msg_eps[0]);
+
+	return 0;
 }
 
 /* We send passive endpoint's port to the server as connection request
@@ -274,49 +299,62 @@ static int rxm_init_connect_data(struct rxm_conn *conn,
 	return 0;
 }
 
-static int rxm_send_connect(struct rxm_conn *conn)
+int rxm_send_connect(struct rxm_conn *conn, uint8_t idx)
 {
 	union rxm_cm_data cm_data;
 	struct fi_info *info;
 	int ret;
 
-	FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "connecting %p\n", conn);
+	assert(idx < conn->num_msg_eps);
 	assert(ofi_genlock_held(&conn->ep->util_ep.lock));
+	FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "connecting %p ep %u\n", conn, idx);
 
 	info = conn->ep->msg_info;
-	info->dest_addrlen = conn->ep->msg_info->src_addrlen;
-
+	info->dest_addrlen = info->src_addrlen;
 	free(info->dest_addr);
 	info->dest_addr = mem_dup(&conn->peer->addr, info->dest_addrlen);
-	if (!info->dest_addr)
-		return -FI_ENOMEM;
+	if (!info->dest_addr) {
+		ret = -FI_ENOMEM;
+		goto err;
+	}
 
-	ret = rxm_open_conn(conn, info);
+	if (idx == 0)
+		ret = rxm_open_conn(conn, info);
+	else
+		ret = rxm_open_msg_ep(conn, idx, info);
 	if (ret)
-		return ret;
+		goto err;
 
 	ret = rxm_init_connect_data(conn, &cm_data);
 	if (ret)
-		goto err;
+		goto close_ep;
+	cm_data.connect.ep_idx = idx;
 
-	ret = fi_connect(conn->msg_eps[0], info->dest_addr, &cm_data,
+	ret = fi_connect(conn->msg_eps[idx], info->dest_addr, &cm_data,
 			 sizeof(cm_data));
 	if (ret) {
 		RXM_WARN_ERR(FI_LOG_EP_CTRL, "fi_connect", ret);
-		goto err;
+		goto close_ep;
 	}
-	conn->states[0] = RXM_CM_CONNECTING;
+	conn->states[idx] = RXM_CM_CONNECTING;
 	conn->ep->connecting_cnt++;
 	return 0;
 
-err:
-	for (int i = 0; i < conn->num_msg_eps; i++) {
-		if (conn->msg_eps && conn->msg_eps[i])
-			fi_close(&conn->msg_eps[i]->fid);
+close_ep:
+	if (idx == 0) {
+		fi_close(&conn->msg_eps[0]->fid);
+		free(conn->msg_eps);
+		conn->msg_eps = NULL;
+	} else {
+		fi_close(&conn->msg_eps[idx]->fid);
+		conn->msg_eps[idx] = NULL;
 	}
-	free(conn->msg_eps);
-	conn->msg_eps = NULL;
-	conn->states[0] = RXM_CM_IDLE;
+err:
+	if (idx > 0) {
+		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
+			"lazy connect of ep %u failed (%s); truncating conn %p to %u eps\n",
+			idx, fi_strerror(-ret), conn, idx);
+	}
 	return ret;
 }
 
@@ -328,7 +366,7 @@ static int rxm_connect(struct rxm_conn *conn)
 
 	switch (conn->states[0]) {
 	case RXM_CM_IDLE:
-		ret = rxm_send_connect(conn);
+		ret = rxm_send_connect(conn, 0);
 		if (ret)
 			return ret;
 		break;
@@ -428,9 +466,8 @@ rxm_alloc_conn(struct rxm_ep *ep, struct util_peer_addr *peer)
 	conn->peer = peer;
 	rxm_ref_peer(peer);
 
-	conn->num_msg_eps = 1;
+	conn->num_msg_eps = (uint8_t) rxm_num_msg_eps;
 	conn->msg_eps = NULL;
-	conn->selector = &rxm_selector_single_ep;
 
 	conn->states = calloc(conn->num_msg_eps, sizeof(*conn->states));
 	if (!conn->states) {
@@ -439,6 +476,8 @@ rxm_alloc_conn(struct rxm_ep *ep, struct util_peer_addr *peer)
 		rxm_av_free_conn(av, conn);
 		return NULL;
 	}
+
+	conn->selector = &rxm_selector_single_ep;
 
 	FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "allocated conn %p\n", conn);
 	return conn;
@@ -529,13 +568,16 @@ void rxm_process_connect(struct rxm_eq_cm_entry *cm_entry)
 {
 	struct rxm_conn *conn;
 	struct rxm_domain *domain;
+	int idx;
 
 	conn = cm_entry->fid->context;
+	idx = rxm_get_ep_idx(conn, cm_entry->fid);
 	FI_DBG(&rxm_prov, FI_LOG_EP_CTRL,
-	       "processing connected for handle: %p\n", conn);
+	       "processing connected for handle: %p ep %d\n", conn, idx);
 
 	assert(ofi_genlock_held(&conn->ep->util_ep.lock));
-	if (conn->states[0] == RXM_CM_CONNECTING) {
+
+	if (idx == 0 && conn->states[0] == RXM_CM_CONNECTING) {
 		conn->remote_index = rxm_peer_index(cm_entry->data.accept.
 						    server_conn_id);
 		conn->remote_pid = rxm_peer_pid(cm_entry->data.accept.
@@ -546,27 +588,43 @@ void rxm_process_connect(struct rxm_eq_cm_entry *cm_entry)
 	if (conn->flow_ctrl && conn->peer_flow_ctrl) {
 		domain = container_of(conn->ep->util_ep.domain,
 				      struct rxm_domain, util_domain);
-		domain->flow_ctrl_ops->enable(conn->msg_eps[0],
+		domain->flow_ctrl_ops->enable(conn->msg_eps[idx],
 					      conn->ep->msg_info->rx_attr->size / 2);
 	}
 
 	conn->ep->connecting_cnt--;
 	assert(conn->ep->connecting_cnt >= 0);
-	for (uint8_t i = 0; i < conn->num_msg_eps; i++)
-		conn->states[i] = RXM_CM_CONNECTED;
+	conn->states[idx] = RXM_CM_CONNECTED;
+}
+
+static void
+rxm_drop_secondary_ep(struct rxm_conn *conn, uint8_t idx)
+{
+	assert(idx > 0 && idx < conn->num_msg_eps);
+	assert(conn->states[idx] != RXM_CM_CONNECTED);
+
+	if (conn->msg_eps[idx]) {
+		fi_close(&conn->msg_eps[idx]->fid);
+		conn->msg_eps[idx] = NULL;
+	}
+	if (conn->states[idx] == RXM_CM_CONNECTING ||
+	    conn->states[idx] == RXM_CM_ACCEPTING)
+		conn->ep->connecting_cnt--;
+	conn->states[idx] = RXM_CM_IDLE;
 }
 
 /* For simultaneous connection requests, if the peer won the coin
  * flip (reject EALREADY), our connection request is discarded.
  */
 static void
-rxm_process_reject(struct rxm_conn *conn, struct fi_eq_err_entry *entry)
+rxm_process_reject(struct rxm_conn *conn, uint8_t idx,
+		   struct fi_eq_err_entry *entry)
 {
 	union rxm_cm_data *cm_data;
 	uint8_t reason;
 
 	FI_INFO(&rxm_prov, FI_LOG_EP_CTRL,
-	       "Processing reject for handle: %p\n", conn);
+	       "Processing reject for handle: %p ep %u\n", conn, idx);
 	assert(ofi_genlock_held(&conn->ep->util_ep.lock));
 
 	if (entry->err_data_size >= sizeof(cm_data->reject)) {
@@ -579,6 +637,11 @@ rxm_process_reject(struct rxm_conn *conn, struct fi_eq_err_entry *entry)
 		}
 	} else {
 		reason = RXM_REJECT_ECONNREFUSED;
+	}
+
+	if (idx > 0) {
+		rxm_drop_secondary_ep(conn, idx);
+		return;
 	}
 
 	switch (conn->states[0]) {
@@ -652,7 +715,8 @@ rxm_reject_connreq(struct rxm_ep *ep, struct rxm_eq_cm_entry *cm_entry,
 }
 
 static int
-rxm_accept_connreq(struct rxm_conn *conn, struct rxm_eq_cm_entry *cm_entry)
+rxm_accept_connreq(struct rxm_conn *conn, uint8_t idx,
+		   struct rxm_eq_cm_entry *cm_entry)
 {
 	union rxm_cm_data cm_data;
 	int ret;
@@ -665,7 +729,8 @@ rxm_accept_connreq(struct rxm_conn *conn, struct rxm_eq_cm_entry *cm_entry)
 	cm_data.accept.align_pad[1] = 0;
 	cm_data.accept.align_pad[2] = 0;
 
-	ret = fi_accept(conn->msg_eps[0], &cm_data.accept, sizeof(cm_data.accept));
+	ret = fi_accept(conn->msg_eps[idx], &cm_data.accept,
+			sizeof(cm_data.accept));
 	if (ret)
 		RXM_WARN_ERR(FI_LOG_EP_CTRL, "fi_accept", ret);
 	return ret;
@@ -678,12 +743,15 @@ rxm_process_connreq(struct rxm_ep *ep, struct rxm_eq_cm_entry *cm_entry)
 	struct util_peer_addr *peer;
 	struct rxm_conn *conn;
 	struct rxm_av *av;
+	uint8_t idx;
 	ssize_t ret;
 	int cmp;
 
 	assert(ofi_genlock_held(&ep->util_ep.lock));
 	if (rxm_verify_connreq(ep, &cm_entry->data))
 		goto reject;
+
+	idx = cm_entry->data.connect.ep_idx;
 
 	memcpy(&peer_addr, cm_entry->info->dest_addr,
 	       cm_entry->info->dest_addrlen);
@@ -696,12 +764,24 @@ rxm_process_connreq(struct rxm_ep *ep, struct rxm_eq_cm_entry *cm_entry)
 		goto reject;
 	}
 
-	conn = rxm_add_conn(ep, peer);
-	if (!conn)
-		goto remove;
+	if (idx == 0) {
+		conn = rxm_add_conn(ep, peer);
+		if (!conn)
+			goto remove;
+	} else {
+		conn = ofi_idm_lookup(&ep->conn_idx_map, peer->index);
+		if (!conn || conn->states[0] != RXM_CM_CONNECTED ||
+		    idx >= conn->num_msg_eps) {
+			FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
+				"secondary connreq idx=%u rejected: conn=%p states[0]=%d num_eps=%u\n",
+				idx, conn, conn ? conn->states[0] : -1,
+				conn ? conn->num_msg_eps : 0);
+			goto remove;
+		}
+	}
 
 	FI_INFO(&rxm_prov, FI_LOG_EP_CTRL, "connreq for %p\n", conn);
-	switch (conn->states[0]) {
+	switch (conn->states[idx]) {
 	case RXM_CM_IDLE:
 		break;
 	case RXM_CM_CONNECTING:
@@ -710,36 +790,46 @@ rxm_process_connreq(struct rxm_ep *ep, struct rxm_eq_cm_entry *cm_entry)
 		if (cmp < 0) {
 			/* let our request finish */
 			FI_INFO(&rxm_prov, FI_LOG_EP_CTRL,
-				"simultaneous, reject peer %p\n", conn);
-			rxm_reject_connreq(ep, cm_entry,
-					   RXM_REJECT_EALREADY);
+				"simultaneous, reject peer %p ep %u\n", conn, idx);
+			rxm_reject_connreq(ep, cm_entry, RXM_REJECT_EALREADY);
 			goto put;
 		} else if (cmp > 0) {
 			/* accept peer's request */
 			FI_INFO(&rxm_prov, FI_LOG_EP_CTRL,
-				"simultaneous, accept peer %p\n", conn);
-			rxm_close_conn(conn);
-		} else {
+				"simultaneous, accept peer %p ep %u\n", conn, idx);
+			if (idx == 0)
+				rxm_close_conn(conn);
+			else
+				rxm_drop_secondary_ep(conn, idx);
+		} else if (idx == 0) {
 			/* connecting to ourself, create loopback conn */
-			FI_INFO(&rxm_prov, FI_LOG_EP_CTRL,
-				"loopback conn %p\n", conn);
+			FI_INFO(&rxm_prov, FI_LOG_EP_CTRL, "loopback conn %p\n", conn);
 			conn = rxm_alloc_conn(ep, peer);
 			if (!conn)
 				goto remove;
-
 			dlist_insert_tail(&conn->loopback_entry, &ep->loopback_list);
-			break;
+		} else {
+			/* loopback is meaningless for a secondary slot. */
+			FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
+				"loopback secondary connreq idx=%u rejected: conn=%p\n",
+				idx, conn);
+			goto remove;
 		}
 		break;
 	case RXM_CM_ACCEPTING:
 	case RXM_CM_CONNECTED:
+		if (idx > 0) {
+			FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
+				"secondary connreq idx=%u rejected: conn=%p states[idx]=%d\n",
+				idx, conn, conn->states[idx]);
+			goto remove;
+		}
 		if (conn->remote_pid &&
 		    (conn->remote_pid == rxm_peer_pid(cm_entry->data.connect.
-		    				      client_conn_id))) {
+						      client_conn_id))) {
 			FI_INFO(&rxm_prov, FI_LOG_EP_CTRL,
 				"simultaneous, reject peer\n");
-			rxm_reject_connreq(ep, cm_entry,
-					   RXM_REJECT_EALREADY);
+			rxm_reject_connreq(ep, cm_entry, RXM_REJECT_EALREADY);
 			goto put;
 		} else {
 			FI_INFO(&rxm_prov, FI_LOG_EP_CTRL,
@@ -752,19 +842,26 @@ rxm_process_connreq(struct rxm_ep *ep, struct rxm_eq_cm_entry *cm_entry)
 		break;
 	}
 
-	conn->remote_pid = rxm_peer_pid(cm_entry->data.connect.client_conn_id);
-	conn->remote_index = rxm_peer_index(cm_entry->data.connect.client_conn_id);
-	ret = rxm_open_conn(conn, cm_entry->info);
+	if (idx == 0) {
+		conn->remote_pid =
+			rxm_peer_pid(cm_entry->data.connect.client_conn_id);
+		conn->remote_index =
+			rxm_peer_index(cm_entry->data.connect.client_conn_id);
+		ret = rxm_open_conn(conn, cm_entry->info);
+	} else {
+		ret = rxm_open_msg_ep(conn, idx, cm_entry->info);
+	}
 	if (ret)
 		goto free;
 
-	rxm_set_peer_flow_ctrl(conn, cm_entry->data.connect.flow_ctrl);
+	if (idx == 0)
+		rxm_set_peer_flow_ctrl(conn, cm_entry->data.connect.flow_ctrl);
 
-	ret = rxm_accept_connreq(conn, cm_entry);
+	ret = rxm_accept_connreq(conn, idx, cm_entry);
 	if (ret)
 		goto close;
 
-	conn->states[0] = RXM_CM_ACCEPTING;
+	conn->states[idx] = RXM_CM_ACCEPTING;
 	conn->ep->connecting_cnt++;
 put:
 	util_put_peer(peer);
@@ -772,9 +869,15 @@ put:
 	return;
 
 close:
-	rxm_close_conn(conn);
+	if (idx == 0) {
+		rxm_close_conn(conn);
+	} else {
+		fi_close(&conn->msg_eps[idx]->fid);
+		conn->msg_eps[idx] = NULL;
+	}
 free:
-	rxm_free_conn(conn);
+	if (idx == 0)
+		rxm_free_conn(conn);
 remove:
 	util_put_peer(peer);
 reject:
@@ -782,12 +885,20 @@ reject:
 	fi_freeinfo(cm_entry->info);
 }
 
-void rxm_process_shutdown(struct rxm_conn *conn)
+void rxm_process_shutdown(struct rxm_conn *conn, uint8_t idx)
 {
 	assert(ofi_genlock_held(&conn->ep->util_ep.lock));
 
-	FI_INFO(&rxm_prov, FI_LOG_EP_CTRL, "shutdown conn %p (state %d)\n",
-		conn, conn->states[0]);
+	FI_INFO(&rxm_prov, FI_LOG_EP_CTRL, "shutdown conn %p ep %u (state %d)\n",
+		conn, idx, conn->states[idx]);
+
+	/* A secondary ep that's still mid-handshake never carried traffic,
+	 * so we can drop it and keep the conn alive. A CONNECTED secondary
+	 * dying is unrecoverable so tear down the conn. */
+	if (idx > 0 && conn->states[idx] != RXM_CM_CONNECTED) {
+		rxm_drop_secondary_ep(conn, idx);
+		return;
+	}
 
 	switch (conn->states[0]) {
 	case RXM_CM_IDLE:
@@ -806,7 +917,9 @@ void rxm_process_shutdown(struct rxm_conn *conn)
 static void rxm_handle_error(struct rxm_ep *ep)
 {
 	struct fi_eq_err_entry entry = {0};
+	struct rxm_conn *conn;
 	ssize_t ret;
+	int idx;
 
 	assert(ofi_genlock_held(&ep->util_ep.lock));
 	ret = fi_eq_readerr(ep->msg_eq, &entry, 0);
@@ -835,17 +948,24 @@ static void rxm_handle_error(struct rxm_ep *ep)
 	if (!entry.fid || entry.fid->fclass != FI_CLASS_EP)
 		return;
 
-	if (entry.err == ECONNREFUSED) {
-		rxm_process_reject(entry.fid->context, &entry);
-	} else {
-		rxm_process_shutdown(entry.fid->context);
-	}
+	conn = entry.fid->context;
+	idx = rxm_get_ep_idx(conn, entry.fid);
+	if (idx < 0)
+		return;
+
+	if (entry.err == ECONNREFUSED)
+		rxm_process_reject(conn, (uint8_t) idx, &entry);
+	else
+		rxm_process_shutdown(conn, (uint8_t) idx);
 }
 
 static void
 rxm_handle_event(struct rxm_ep *ep, uint32_t event,
 		 struct rxm_eq_cm_entry *cm_entry, size_t len)
 {
+	struct rxm_conn *conn;
+	int idx;
+
 	assert(ofi_genlock_held(&ep->util_ep.lock));
 	switch (event) {
 	case FI_NOTIFY:
@@ -857,7 +977,10 @@ rxm_handle_event(struct rxm_ep *ep, uint32_t event,
 		rxm_process_connect(cm_entry);
 		break;
 	case FI_SHUTDOWN:
-		rxm_process_shutdown(cm_entry->fid->context);
+		conn = cm_entry->fid->context;
+		idx = rxm_get_ep_idx(conn, cm_entry->fid);
+		if (idx >= 0)
+			rxm_process_shutdown(conn, (uint8_t) idx);
 		break;
 	default:
 		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -394,6 +394,10 @@ static void rxm_free_conn(struct rxm_conn *conn)
 	if (conn->flags & RXM_CONN_INDEXED)
 		ofi_idm_clear(&conn->ep->conn_idx_map, conn->peer->index);
 
+	if (conn->selector && conn->selector->destroy)
+		conn->selector->destroy(conn->selector);
+	conn->selector = NULL;
+
 	free(conn->states);
 	conn->states = NULL;
 
@@ -477,7 +481,20 @@ rxm_alloc_conn(struct rxm_ep *ep, struct util_peer_addr *peer)
 		return NULL;
 	}
 
-	conn->selector = &rxm_selector_single_ep;
+	if (conn->num_msg_eps > 1) {
+		conn->selector = rxm_rr_selector_alloc();
+		if (!conn->selector) {
+			RXM_WARN_ERR(FI_LOG_EP_CTRL, "rxm_rr_selector_alloc",
+				     -FI_ENOMEM);
+			free(conn->states);
+			util_put_peer(peer);
+			rxm_av_free_conn(av, conn);
+			return NULL;
+		}
+	} else {
+		conn->selector =
+			(struct rxm_ep_selector *) &rxm_selector_single_ep;
+	}
 
 	FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "allocated conn %p\n", conn);
 	return conn;

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -56,6 +56,7 @@ static void rxm_close_conn(struct rxm_conn *conn)
 {
 	struct rxm_deferred_tx_entry *tx_entry;
 	struct fi_peer_rx_entry *rx_entry;
+	struct rxm_proto_info *proto_info;
 	struct rxm_rx_buf *buf;
 
 	FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "closing conn %p\n", conn);
@@ -76,8 +77,23 @@ static void rxm_close_conn(struct rxm_conn *conn)
 	}
 
 	while (!dlist_empty(&conn->deferred_sar_msgs)) {
-		rx_entry = (struct fi_peer_rx_entry*)conn->deferred_sar_msgs.next;
-		rx_entry->srx->owner_ops->free_entry(rx_entry);
+		proto_info = container_of(conn->deferred_sar_msgs.next,
+					  struct rxm_proto_info, sar.entry);
+		rx_entry = proto_info->sar.rx_entry;
+
+		while (!dlist_empty(&proto_info->sar.pkt_list)) {
+			buf = container_of(proto_info->sar.pkt_list.next,
+					   struct rxm_rx_buf, unexp_entry);
+			dlist_remove(&buf->unexp_entry);
+			rxm_free_rx_buf(buf);
+		}
+
+		dlist_remove(&proto_info->sar.entry);
+		ofi_buf_free(proto_info);
+
+		/* Once matched, the entry belongs to the owner. */
+		if (rx_entry && rx_entry->peer_context)
+			rx_entry->srx->owner_ops->free_entry(rx_entry);
 	}
 	if (conn->msg_eps) {
 		for (uint8_t i = 0; i < conn->num_msg_eps; i++) {

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -88,10 +88,11 @@ static void rxm_close_conn(struct rxm_conn *conn)
 	free(conn->msg_eps);
 	conn->msg_eps = NULL;
 
-	if (conn->state == RXM_CM_CONNECTING || conn->state == RXM_CM_ACCEPTING)
+	if (conn->states[0] == RXM_CM_CONNECTING ||
+	    conn->states[0] == RXM_CM_ACCEPTING)
 		conn->ep->connecting_cnt--;
 	assert(conn->ep->connecting_cnt >= 0);
-	conn->state = RXM_CM_IDLE;
+	conn->states[0] = RXM_CM_IDLE;
 }
 
 static int rxm_bind_comp(struct rxm_ep *ep, struct fid_ep *msg_ep)
@@ -304,7 +305,7 @@ static int rxm_send_connect(struct rxm_conn *conn)
 		RXM_WARN_ERR(FI_LOG_EP_CTRL, "fi_connect", ret);
 		goto err;
 	}
-	conn->state = RXM_CM_CONNECTING;
+	conn->states[0] = RXM_CM_CONNECTING;
 	conn->ep->connecting_cnt++;
 	return 0;
 
@@ -315,6 +316,7 @@ err:
 	}
 	free(conn->msg_eps);
 	conn->msg_eps = NULL;
+	conn->states[0] = RXM_CM_IDLE;
 	return ret;
 }
 
@@ -324,7 +326,7 @@ static int rxm_connect(struct rxm_conn *conn)
 
 	assert(ofi_genlock_held(&conn->ep->util_ep.lock));
 
-	switch (conn->state) {
+	switch (conn->states[0]) {
 	case RXM_CM_IDLE:
 		ret = rxm_send_connect(conn);
 		if (ret)
@@ -337,7 +339,7 @@ static int rxm_connect(struct rxm_conn *conn)
 		return 0;
 	default:
 		assert(0);
-		conn->state = RXM_CM_IDLE;
+		conn->states[0] = RXM_CM_IDLE;
 		break;
 	}
 
@@ -353,6 +355,9 @@ static void rxm_free_conn(struct rxm_conn *conn)
 
 	if (conn->flags & RXM_CONN_INDEXED)
 		ofi_idm_clear(&conn->ep->conn_idx_map, conn->peer->index);
+
+	free(conn->states);
+	conn->states = NULL;
 
 	util_put_peer(conn->peer);
 	av = container_of(conn->ep->util_ep.av, struct rxm_av, util_av);
@@ -381,7 +386,7 @@ void rxm_freeall_conns(struct rxm_ep *ep)
 		if (!conn)
 			continue;
 
-		if (conn->state != RXM_CM_IDLE)
+		if (conn->states[0] != RXM_CM_IDLE)
 			rxm_close_conn(conn);
 		rxm_free_conn(conn);
 	}
@@ -410,7 +415,6 @@ rxm_alloc_conn(struct rxm_ep *ep, struct util_peer_addr *peer)
 	}
 
 	conn->ep = ep;
-	conn->state = RXM_CM_IDLE;
 	conn->remote_index = -1;
 	conn->flags = 0;
 	conn->flow_ctrl = false;
@@ -427,6 +431,14 @@ rxm_alloc_conn(struct rxm_ep *ep, struct util_peer_addr *peer)
 	conn->num_msg_eps = 1;
 	conn->msg_eps = NULL;
 	conn->selector = &rxm_selector_single_ep;
+
+	conn->states = calloc(conn->num_msg_eps, sizeof(*conn->states));
+	if (!conn->states) {
+		RXM_WARN_ERR(FI_LOG_EP_CTRL, "calloc states", -FI_ENOMEM);
+		util_put_peer(peer);
+		rxm_av_free_conn(av, conn);
+		return NULL;
+	}
 
 	FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "allocated conn %p\n", conn);
 	return conn;
@@ -468,7 +480,7 @@ ssize_t rxm_get_conn(struct rxm_ep *ep, fi_addr_t addr, struct rxm_conn **conn)
 	if (!*conn)
 		return -FI_ENOMEM;
 
-	if ((*conn)->state == RXM_CM_CONNECTED) {
+	if ((*conn)->states[0] == RXM_CM_CONNECTED) {
 		if (!dlist_empty(&(*conn)->deferred_tx_queue)) {
 			rxm_ep_do_progress(&ep->util_ep);
 			if (!dlist_empty(&(*conn)->deferred_tx_queue))
@@ -523,7 +535,7 @@ void rxm_process_connect(struct rxm_eq_cm_entry *cm_entry)
 	       "processing connected for handle: %p\n", conn);
 
 	assert(ofi_genlock_held(&conn->ep->util_ep.lock));
-	if (conn->state == RXM_CM_CONNECTING) {
+	if (conn->states[0] == RXM_CM_CONNECTING) {
 		conn->remote_index = rxm_peer_index(cm_entry->data.accept.
 						    server_conn_id);
 		conn->remote_pid = rxm_peer_pid(cm_entry->data.accept.
@@ -540,7 +552,8 @@ void rxm_process_connect(struct rxm_eq_cm_entry *cm_entry)
 
 	conn->ep->connecting_cnt--;
 	assert(conn->ep->connecting_cnt >= 0);
-	conn->state = RXM_CM_CONNECTED;
+	for (uint8_t i = 0; i < conn->num_msg_eps; i++)
+		conn->states[i] = RXM_CM_CONNECTED;
 }
 
 /* For simultaneous connection requests, if the peer won the coin
@@ -568,7 +581,7 @@ rxm_process_reject(struct rxm_conn *conn, struct fi_eq_err_entry *entry)
 		reason = RXM_REJECT_ECONNREFUSED;
 	}
 
-	switch (conn->state) {
+	switch (conn->states[0]) {
 	case RXM_CM_IDLE:
 		/* Unlikely, but can occur if our request was rejected, and
 		 * there was a failure trying to accept the peer's.
@@ -688,7 +701,7 @@ rxm_process_connreq(struct rxm_ep *ep, struct rxm_eq_cm_entry *cm_entry)
 		goto remove;
 
 	FI_INFO(&rxm_prov, FI_LOG_EP_CTRL, "connreq for %p\n", conn);
-	switch (conn->state) {
+	switch (conn->states[0]) {
 	case RXM_CM_IDLE:
 		break;
 	case RXM_CM_CONNECTING:
@@ -751,7 +764,7 @@ rxm_process_connreq(struct rxm_ep *ep, struct rxm_eq_cm_entry *cm_entry)
 	if (ret)
 		goto close;
 
-	conn->state = RXM_CM_ACCEPTING;
+	conn->states[0] = RXM_CM_ACCEPTING;
 	conn->ep->connecting_cnt++;
 put:
 	util_put_peer(peer);
@@ -774,9 +787,9 @@ void rxm_process_shutdown(struct rxm_conn *conn)
 	assert(ofi_genlock_held(&conn->ep->util_ep.lock));
 
 	FI_INFO(&rxm_prov, FI_LOG_EP_CTRL, "shutdown conn %p (state %d)\n",
-		conn, conn->state);
+		conn, conn->states[0]);
 
-	switch (conn->state) {
+	switch (conn->states[0]) {
 	case RXM_CM_IDLE:
 		break;
 	case RXM_CM_CONNECTING:

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -257,6 +257,9 @@ static bool rxm_complete_sar(struct rxm_ep *rxm_ep,
 	assert(ofi_tx_cq_flags(tx_buf->pkt.hdr.op) & FI_SEND);
 	switch (rxm_sar_get_seg_type(&tx_buf->pkt.ctrl_hdr)) {
 	case RXM_SAR_SEG_FIRST:
+		tx_buf->sar.first_seg_done = true;
+		if (tx_buf->sar.last_seg_done)
+			rxm_free_tx_buf(rxm_ep, tx_buf);
 		break;
 	case RXM_SAR_SEG_MIDDLE:
 		rxm_free_tx_buf(rxm_ep, tx_buf);
@@ -264,8 +267,8 @@ static bool rxm_complete_sar(struct rxm_ep *rxm_ep,
 	case RXM_SAR_SEG_LAST:
 		first_tx_buf = ofi_bufpool_get_ibuf(rxm_ep->tx_pool,
 						tx_buf->pkt.ctrl_hdr.msg_id);
-		rxm_free_tx_buf(rxm_ep, first_tx_buf);
 		rxm_free_tx_buf(rxm_ep, tx_buf);
+		rxm_release_sar_first_tx_buf(rxm_ep, first_tx_buf);
 		return true;
 	}
 

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -266,7 +266,7 @@ static bool rxm_complete_sar(struct rxm_ep *rxm_ep,
 		break;
 	case RXM_SAR_SEG_LAST:
 		first_tx_buf = ofi_bufpool_get_ibuf(rxm_ep->tx_pool,
-						tx_buf->pkt.ctrl_hdr.msg_id);
+			RXM_SAR_TX_INDEX(tx_buf->pkt.ctrl_hdr.msg_id));
 		rxm_free_tx_buf(rxm_ep, tx_buf);
 		rxm_release_sar_first_tx_buf(rxm_ep, first_tx_buf);
 		return true;

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -428,18 +428,34 @@ static void rxm_init_sar_proto(struct rxm_rx_buf *rx_buf)
 	proto_info->sar.conn = rx_buf->conn;
 	proto_info->sar.msg_id = rx_buf->pkt.ctrl_hdr.msg_id;
 	proto_info->sar.total_recv_len = 0;
+	/* NULL when a non-FIRST segment arrived first; the entry is acquired
+	 * when FIRST shows up. */
 	proto_info->sar.rx_entry = rx_buf->peer_entry;
 
 	dlist_insert_tail(&proto_info->sar.entry,
 			  &rx_buf->conn->deferred_sar_msgs);
 
 	dlist_init(&proto_info->sar.pkt_list);
-	if (rx_buf->peer_entry->peer_context)
+	if (rx_buf->peer_entry && rx_buf->peer_entry->peer_context)
 		dlist_insert_tail(&rx_buf->unexp_entry,
 				  &proto_info->sar.pkt_list);
 
-
 	rx_buf->proto_info = proto_info;
+}
+
+/* A non-FIRST segment arrived first for its msg_id: start a reassembly with no
+ * SRX entry yet and hold on to the segment.
+ */
+static void rxm_defer_sar_proto(struct rxm_rx_buf *rx_buf)
+{
+	rx_buf->peer_entry = NULL;
+	rxm_init_sar_proto(rx_buf);
+	if (!rx_buf->proto_info)
+		return;
+
+	dlist_insert_tail(&rx_buf->unexp_entry,
+			  &rx_buf->proto_info->sar.pkt_list);
+	rxm_replace_rx_buf(rx_buf);
 }
 
 int rxm_process_seg_data(struct rxm_rx_buf *rx_buf)
@@ -482,57 +498,148 @@ int rxm_process_seg_data(struct rxm_rx_buf *rx_buf)
 	return done;
 }
 
+/* Copy the buffered segments into the matched receive buffer. Returns true if
+ * LAST was processed, in which case proto_info and rx_entry are gone.
+ */
+static bool rxm_sar_drain_pkt_list(struct rxm_proto_info *proto_info,
+				   struct fi_peer_rx_entry *rx_entry)
+{
+	struct rxm_rx_buf *seg_rx_buf, *first_pkt;
+
+	rx_entry->peer_context = NULL;
+
+	/* The running offset in rxm_process_seg_data() needs strict segment
+	 * order, so wait until FIRST is at the head. */
+	if (dlist_empty(&proto_info->sar.pkt_list))
+		return false;
+	first_pkt = container_of(proto_info->sar.pkt_list.next,
+				 struct rxm_rx_buf, unexp_entry);
+	if (rxm_sar_get_seg_type(&first_pkt->pkt.ctrl_hdr) != RXM_SAR_SEG_FIRST)
+		return false;
+
+	while (!dlist_empty(&proto_info->sar.pkt_list)) {
+		dlist_pop_front(&proto_info->sar.pkt_list,
+				struct rxm_rx_buf, seg_rx_buf, unexp_entry);
+		seg_rx_buf->peer_entry = rx_entry;
+		if (rxm_process_seg_data(seg_rx_buf))
+			return true;
+	}
+	return false;
+}
+
+/* Acquire the SRX entry for a deferred reassembly, once FIRST has arrived.
+ * *matched reports whether a posted receive was found or the entry had to be
+ * queued as unexpected.
+ */
+static struct fi_peer_rx_entry *
+rxm_sar_acquire_entry(struct rxm_rx_buf *rx_buf, bool *matched)
+{
+	struct fid_peer_srx *srx = rx_buf->ep->srx;
+	struct fi_peer_rx_entry *rx_entry = NULL;
+	struct fi_peer_match_attr match = {0};
+	int ret;
+
+	switch (rx_buf->pkt.hdr.op) {
+	case ofi_op_msg:
+		match.msg_size = rx_buf->pkt.hdr.size;
+		ret = srx->owner_ops->get_msg(srx, &match, &rx_entry);
+		break;
+	case ofi_op_tagged:
+		match.tag = rx_buf->pkt.hdr.tag;
+		match.msg_size = rx_buf->pkt.hdr.size;
+		ret = srx->owner_ops->get_tag(srx, &match, &rx_entry);
+		break;
+	default:
+		FI_WARN(&rxm_prov, FI_LOG_CQ, "Unknown op!\n");
+		assert(0);
+		*matched = false;
+		return NULL;
+	}
+
+	rx_buf->proto_info->sar.rx_entry = rx_entry;
+
+	if (ret == -FI_ENOENT) {
+		rx_entry->peer_context = rx_buf;
+		rx_buf->peer_entry = rx_entry;
+		if (rx_buf->pkt.hdr.flags & FI_REMOTE_CQ_DATA) {
+			rx_entry->flags |= FI_REMOTE_CQ_DATA;
+			rx_entry->cq_data = rx_buf->pkt.hdr.data;
+		}
+		if (rx_buf->pkt.hdr.op == ofi_op_msg)
+			srx->owner_ops->queue_msg(rx_entry);
+		else
+			srx->owner_ops->queue_tag(rx_entry);
+		*matched = false;
+	} else {
+		rx_entry->peer_context = NULL;
+		*matched = true;
+	}
+	return rx_entry;
+}
+
 static void rxm_handle_seg_data(struct rxm_rx_buf *rx_buf)
 {
-	struct rxm_proto_info *proto_info;
-	struct fi_peer_rx_entry *rx_entry;
+	struct rxm_proto_info *proto_info = rx_buf->proto_info;
+	struct fi_peer_rx_entry *rx_entry = proto_info->sar.rx_entry;
 	struct rxm_conn *conn;
+	struct rxm_rx_buf *seg_rx_buf;
 	uint64_t msg_id;
 	struct dlist_entry *entry;
+	bool matched;
 
-	if (dlist_empty(&rx_buf->proto_info->sar.pkt_list)) {
+	/* In-order arrival into a matched receive: copy straight in. */
+	if (rx_entry && dlist_empty(&proto_info->sar.pkt_list)) {
 		rxm_process_seg_data(rx_buf);
 		return;
 	}
 
-	proto_info = rx_buf->proto_info;
-	dlist_insert_tail(&rx_buf->unexp_entry, &proto_info->sar.pkt_list);
+	/* Keep the list in segment order: FIRST at the head, the rest, which
+	 * share one endpoint and so are already ordered, at the tail. */
+	if (rxm_sar_get_seg_type(&rx_buf->pkt.ctrl_hdr) == RXM_SAR_SEG_FIRST)
+		dlist_insert_head(&rx_buf->unexp_entry, &proto_info->sar.pkt_list);
+	else
+		dlist_insert_tail(&rx_buf->unexp_entry, &proto_info->sar.pkt_list);
 	rxm_replace_rx_buf(rx_buf);
 
-	if ((rxm_sar_get_seg_type(&rx_buf->pkt.ctrl_hdr) == RXM_SAR_SEG_LAST))
-		dlist_remove(&proto_info->sar.entry);
-
-	rx_entry = rx_buf->peer_entry;
+	/* Capture before any drain: rx_buf may be copied and freed below. */
 	conn = rx_buf->conn;
 	msg_id = rx_buf->pkt.ctrl_hdr.msg_id;
 
+	/* Waiting on FIRST before the entry can be acquired. */
+	if (!rx_entry) {
+		if (rxm_sar_get_seg_type(&rx_buf->pkt.ctrl_hdr) != RXM_SAR_SEG_FIRST)
+			return;
+		rx_entry = rxm_sar_acquire_entry(rx_buf, &matched);
+		if (!rx_entry || !matched)
+			return;
+	}
+
+	/* If still unmatched the entry stays queued, and the drain happens from
+	 * rxm_handle_unexp_sar() once a receive is posted. */
+	if (!rx_entry->peer_context) {
+		if (rxm_sar_drain_pkt_list(proto_info, rx_entry))
+			return;
+	}
+
 	dlist_foreach_container_safe(&conn->deferred_sar_segments,
-				     struct rxm_rx_buf, rx_buf,
+				     struct rxm_rx_buf, seg_rx_buf,
 				     unexp_entry, entry) {
-		if (!rxm_rx_buf_match_msg_id(&rx_buf->unexp_entry, &msg_id))
+		if (!rxm_rx_buf_match_msg_id(&seg_rx_buf->unexp_entry, &msg_id))
 			continue;
 
-		dlist_remove(&rx_buf->unexp_entry);
-		rx_buf->peer_entry = rx_entry;
-		if (rxm_process_seg_data(rx_buf))
+		dlist_remove(&seg_rx_buf->unexp_entry);
+		seg_rx_buf->peer_entry = rx_entry;
+		if (rxm_process_seg_data(seg_rx_buf))
 			break;
 	}
 }
 
 ssize_t rxm_handle_unexp_sar(struct fi_peer_rx_entry *peer_entry)
 {
-	struct rxm_proto_info *proto_info;
 	struct rxm_rx_buf *rx_buf;
 
 	rx_buf = (struct rxm_rx_buf *) peer_entry->peer_context;
-	proto_info = rx_buf->proto_info;
-
-	while (!dlist_empty(&proto_info->sar.pkt_list)) {
-		dlist_pop_front(&proto_info->sar.pkt_list,
-				struct rxm_rx_buf, rx_buf, unexp_entry);
-		rxm_process_seg_data(rx_buf);
-	}
-	peer_entry->peer_context = NULL;
+	rxm_sar_drain_pkt_list(rx_buf->proto_info, peer_entry);
 	return FI_SUCCESS;
 }
 
@@ -850,6 +957,7 @@ static ssize_t rxm_handle_recv_comp(struct rxm_rx_buf *rx_buf)
 	}
 	rx_buf->peer_entry = rx_entry;
 
+	/* Only a FIRST segment gets here, so the new proto starts out empty. */
 	if (rx_buf->pkt.ctrl_hdr.type == rxm_ctrl_seg)
 		rxm_init_sar_proto(rx_buf);
 
@@ -881,10 +989,29 @@ static ssize_t rxm_sar_handle_segment(struct rxm_rx_buf *rx_buf)
 	sar_entry = dlist_find_first_match(&rx_buf->conn->deferred_sar_msgs,
 					   rxm_sar_match_msg_id,
 					   &rx_buf->pkt.ctrl_hdr.msg_id);
-	if (!sar_entry)
+	if (!sar_entry) {
+		/* First arrival for this msg_id. */
+		if (rxm_sar_get_seg_type(&rx_buf->pkt.ctrl_hdr) != RXM_SAR_SEG_FIRST) {
+			rxm_defer_sar_proto(rx_buf);
+			return 0;
+		}
 		return rxm_handle_recv_comp(rx_buf);
+	}
 
 	proto_info = container_of(sar_entry, struct rxm_proto_info, sar.entry);
+
+	/* A FIRST that finds a reassembly which already has an entry means the
+	 * sender reused the tx-buf index: the old message is only waiting to be
+	 * drained, and stays reachable through its queued entry. Unlink it from
+	 * the lookup list and start fresh. A reassembly without an entry is one
+	 * that has been waiting for this FIRST, so fall through to it. */
+	if (rxm_sar_get_seg_type(&rx_buf->pkt.ctrl_hdr) == RXM_SAR_SEG_FIRST &&
+	    proto_info->sar.rx_entry) {
+		dlist_remove(&proto_info->sar.entry);
+		dlist_init(&proto_info->sar.entry);
+		return rxm_handle_recv_comp(rx_buf);
+	}
+
 	rx_buf->peer_entry = proto_info->sar.rx_entry;
 	rx_buf->proto_info = proto_info;
 	rxm_handle_seg_data(rx_buf);

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -587,7 +587,7 @@ ssize_t rxm_rndv_read(struct rxm_rx_buf *rx_buf)
 	rx_buf->peer_entry->msg_size = total_len;
 	RXM_UPDATE_STATE(FI_LOG_CQ, rx_buf, RXM_RNDV_READ);
 
-	ret = rxm_rndv_xfer(rx_buf->ep, rx_buf->conn->msg_ep,
+	ret = rxm_rndv_xfer(rx_buf->ep, rxm_conn_msg_ep(rx_buf->conn, NULL),
 			    rx_buf->remote_rndv_hdr,
 			    rx_buf->peer_entry->iov,
 			    rx_buf->peer_entry->desc,
@@ -653,7 +653,8 @@ static ssize_t rxm_rndv_handle_wr_data(struct rxm_rx_buf *rx_buf)
 	else
 		RXM_UPDATE_STATE(FI_LOG_CQ, tx_buf, RXM_RNDV_WRITE_TX_WAIT);
 
-	ret = rxm_rndv_xfer(rx_buf->ep, tx_buf->write_rndv.conn->msg_ep, rx_hdr,
+	ret = rxm_rndv_xfer(rx_buf->ep,
+			    rxm_conn_msg_ep(tx_buf->write_rndv.conn, NULL), rx_hdr,
 			    tx_buf->write_rndv.iov, tx_buf->write_rndv.desc,
 			    tx_buf->rma.count, total_len, tx_buf);
 
@@ -914,7 +915,8 @@ static void rxm_rndv_send_rd_done(struct rxm_rx_buf *rx_buf)
 	buf->pkt.ctrl_hdr.conn_id = rx_buf->conn->remote_index;
 	buf->pkt.ctrl_hdr.msg_id = rx_buf->pkt.ctrl_hdr.msg_id;
 
-	ret = fi_send(rx_buf->conn->msg_ep, &buf->pkt, sizeof(buf->pkt),
+	ret = fi_send(rxm_conn_msg_ep(rx_buf->conn, &buf->pkt),
+		      &buf->pkt, sizeof(buf->pkt),
 		      buf->hdr.desc, 0, rx_buf);
 	if (ret) {
 		if (ret == -FI_EAGAIN) {
@@ -969,8 +971,8 @@ rxm_rndv_send_wr_done(struct rxm_ep *rxm_ep, struct rxm_tx_buf *tx_buf)
 	buf->pkt.ctrl_hdr.conn_id = tx_buf->pkt.ctrl_hdr.conn_id;
 	buf->pkt.ctrl_hdr.msg_id = tx_buf->pkt.ctrl_hdr.msg_id;
 
-	ret = fi_send(tx_buf->write_rndv.conn->msg_ep, &buf->pkt,
-		      sizeof(buf->pkt), buf->hdr.desc, 0, tx_buf);
+	ret = fi_send(rxm_conn_msg_ep(tx_buf->write_rndv.conn, &buf->pkt),
+		      &buf->pkt, sizeof(buf->pkt), buf->hdr.desc, 0, tx_buf);
 	if (ret) {
 		if (ret == -FI_EAGAIN) {
 			def_entry = rxm_ep_alloc_deferred_tx_entry(rxm_ep,
@@ -1033,8 +1035,9 @@ ssize_t rxm_rndv_send_wr_data(struct rxm_rx_buf *rx_buf)
 			  rx_buf->peer_entry->iov,
 			  rx_buf->peer_entry->count, rx_buf->mr);
 
-	ret = fi_send(rx_buf->conn->msg_ep, &buf->pkt, sizeof(buf->pkt) +
-		      sizeof(struct rxm_rndv_hdr), buf->hdr.desc, 0, rx_buf);
+	ret = fi_send(rxm_conn_msg_ep(rx_buf->conn, &buf->pkt), &buf->pkt,
+		      sizeof(buf->pkt) + sizeof(struct rxm_rndv_hdr),
+		      buf->hdr.desc, 0, rx_buf);
 	if (ret) {
 		if (ret == -FI_EAGAIN) {
 			def_entry = rxm_ep_alloc_deferred_tx_entry(rx_buf->ep,
@@ -1119,8 +1122,8 @@ static ssize_t rxm_atomic_send_resp(struct rxm_ep *rxm_ep,
 	atomic_hdr->result_len = htonl((uint32_t) result_len);
 
 	if (tot_len < rxm_ep->inject_limit) {
-		ret = fi_inject(rx_buf->conn->msg_ep, &resp_buf->pkt,
-				tot_len, 0);
+		ret = fi_inject(rxm_conn_msg_ep(rx_buf->conn, &resp_buf->pkt),
+				&resp_buf->pkt, tot_len, 0);
 		if (!ret)
 			ofi_buf_free(resp_buf);
 	} else {

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -799,7 +799,7 @@ static ssize_t rxm_send_credits(struct fid_ep *ep, uint64_t credits)
 	tx_buf->pkt.ctrl_hdr.msg_id = ofi_buf_index(tx_buf);
 	tx_buf->pkt.ctrl_hdr.ctrl_data = credits;
 
-	if (rxm_conn->state != RXM_CM_CONNECTED)
+	if (rxm_conn->states[0] != RXM_CM_CONNECTED)
 		goto defer;
 
 	iov.iov_base = &tx_buf->pkt;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -460,7 +460,8 @@ rxm_ep_progress_sar_deferred_segments(struct rxm_deferred_tx_entry *def_tx_entry
 	struct rxm_tx_buf *tx_buf = def_tx_entry->sar_seg.cur_seg_tx_buf;
 
 	if (tx_buf) {
-		ret = fi_send(def_tx_entry->rxm_conn->msg_ep, &tx_buf->pkt,
+		ret = fi_send(rxm_conn_msg_ep(def_tx_entry->rxm_conn, &tx_buf->pkt),
+			      &tx_buf->pkt,
 			      sizeof(tx_buf->pkt) + tx_buf->pkt.ctrl_hdr.seg_size,
 			      tx_buf->hdr.desc, 0, tx_buf);
 		if (ret) {
@@ -535,7 +536,8 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 		switch (def_tx_entry->type) {
 		case RXM_DEFERRED_TX_RNDV_ACK:
 			proto_info = def_tx_entry->rndv_ack.rx_buf->proto_info;
-			ret = fi_send(def_tx_entry->rxm_conn->msg_ep,
+			ret = fi_send(rxm_conn_msg_ep(def_tx_entry->rxm_conn,
+						      &proto_info->rndv.tx_buf->pkt),
 				      &proto_info->rndv.tx_buf->pkt,
 				      def_tx_entry->rndv_ack.pkt_size,
 				      proto_info->rndv.tx_buf->hdr.desc,
@@ -559,7 +561,8 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 						 RXM_RNDV_WRITE_DATA_SENT);
 			break;
 		case RXM_DEFERRED_TX_RNDV_DONE:
-			ret = fi_send(def_tx_entry->rxm_conn->msg_ep,
+			ret = fi_send(rxm_conn_msg_ep(def_tx_entry->rxm_conn,
+						      &def_tx_entry->rndv_done.tx_buf->pkt),
 				      &def_tx_entry->rndv_done.tx_buf->write_rndv.done_buf->pkt,
 				      sizeof(struct rxm_pkt),
 				      def_tx_entry->rndv_done.tx_buf->write_rndv.done_buf->hdr.desc,
@@ -578,7 +581,7 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 			break;
 		case RXM_DEFERRED_TX_RNDV_READ:
 			ret = rxm_ep->rndv_ops->xfer(
-				def_tx_entry->rxm_conn->msg_ep,
+				rxm_conn_msg_ep(def_tx_entry->rxm_conn, NULL),
 				def_tx_entry->rndv_read.rxm_iov.iov,
 				def_tx_entry->rndv_read.rxm_iov.desc,
 				def_tx_entry->rndv_read.rxm_iov.count, 0,
@@ -596,7 +599,7 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 			break;
 		case RXM_DEFERRED_TX_RNDV_WRITE:
 			ret = rxm_ep->rndv_ops->xfer(
-				def_tx_entry->rxm_conn->msg_ep,
+				rxm_conn_msg_ep(def_tx_entry->rxm_conn, NULL),
 				def_tx_entry->rndv_write.rxm_iov.iov,
 				def_tx_entry->rndv_write.rxm_iov.desc,
 				def_tx_entry->rndv_write.rxm_iov.count, 0,
@@ -636,8 +639,9 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 			msg.iov_count = 1;
 			msg.msg_iov = &iov;
 
-			ret = fi_sendmsg(def_tx_entry->rxm_conn->msg_ep, &msg,
-					 OFI_PRIORITY);
+			ret = fi_sendmsg(rxm_conn_msg_ep(def_tx_entry->rxm_conn,
+							 &def_tx_entry->credit_msg.tx_buf->pkt),
+					 &msg, OFI_PRIORITY);
 			if (ret) {
 				if (ret != -FI_EAGAIN) {
 					rxm_cq_write_rx_error(

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -527,7 +527,7 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 	struct fi_msg msg;
 	ssize_t ret = 0;
 
-	if (rxm_conn->state != RXM_CM_CONNECTED)
+	if (rxm_conn->states[0] != RXM_CM_CONNECTED)
 		return;
 
 	while (!dlist_empty(&rxm_conn->deferred_tx_queue) && !ret) {

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1046,6 +1046,9 @@ static int rxm_ep_msg_cq_open(struct rxm_ep *rxm_ep)
 	if (rxm_ep->msg_info->ep_attr->rx_ctx_cnt != FI_SHARED_CONTEXT)
 		cq_attr.size *= ofi_universe_size;
 	cq_attr.size += rxm_ep->msg_info->tx_attr->size * ofi_universe_size;
+	/* The sizing above assumes one QP per connection, but every slot
+	 * shares this CQ. */
+	cq_attr.size *= rxm_num_msg_eps;
 	cq_attr.format = FI_CQ_FORMAT_DATA;
 	cq_attr.wait_obj = rxm_get_wait_obj(rxm_ep);
 

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -419,8 +419,8 @@ rxm_ep_sar_tx_cleanup(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 
 	first_tx_buf = ofi_bufpool_get_ibuf(rxm_ep->tx_pool,
 					    tx_buf->pkt.ctrl_hdr.msg_id);
-	rxm_free_tx_buf(rxm_ep, first_tx_buf);
 	rxm_free_tx_buf(rxm_ep, tx_buf);
+	rxm_release_sar_first_tx_buf(rxm_ep, first_tx_buf);
 }
 
 struct rxm_deferred_tx_entry *

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -418,7 +418,7 @@ rxm_ep_sar_tx_cleanup(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	struct rxm_tx_buf *first_tx_buf;
 
 	first_tx_buf = ofi_bufpool_get_ibuf(rxm_ep->tx_pool,
-					    tx_buf->pkt.ctrl_hdr.msg_id);
+			RXM_SAR_TX_INDEX(tx_buf->pkt.ctrl_hdr.msg_id));
 	rxm_free_tx_buf(rxm_ep, tx_buf);
 	rxm_release_sar_first_tx_buf(rxm_ep, first_tx_buf);
 }

--- a/prov/rxm/src/rxm_ep_selector.c
+++ b/prov/rxm/src/rxm_ep_selector.c
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright (c) 2026 Intel Corporation, Inc. All rights reserved. */
+
+#include "rxm.h"
+
+static uint8_t rxm_single_ep_select(struct rxm_conn *conn,
+				    const struct rxm_pkt *pkt)
+{
+	OFI_UNUSED(conn);
+	OFI_UNUSED(pkt);
+	return 0;
+}
+
+const struct rxm_ep_selector rxm_selector_single_ep = {
+	.select = rxm_single_ep_select,
+};

--- a/prov/rxm/src/rxm_ep_selector.c
+++ b/prov/rxm/src/rxm_ep_selector.c
@@ -14,3 +14,104 @@ static uint8_t rxm_single_ep_select(struct rxm_conn *conn,
 const struct rxm_ep_selector rxm_selector_single_ep = {
 	.select = rxm_single_ep_select,
 };
+
+static uint8_t rxm_rr_next(struct rxm_rr_selector *rr, struct rxm_conn *conn)
+{
+	uint8_t idx;
+
+	if (OFI_UNLIKELY(conn->num_msg_eps <= 1))
+		return 0;
+
+	/* Self-heal if num_msg_eps shrank and left rr_next past the end. */
+	if (OFI_UNLIKELY(rr->rr_next >= conn->num_msg_eps))
+		rr->rr_next = 1;
+
+	idx = rr->rr_next;
+	if (OFI_UNLIKELY(++rr->rr_next >= conn->num_msg_eps))
+		rr->rr_next = 1;
+
+	if (OFI_LIKELY(conn->states[idx] == RXM_CM_CONNECTED))
+		return idx;
+
+	/* Advancing unconditionally means warm-up walks every slot and fires
+	 * a connect on each, bringing the QPs up in parallel. Until a slot is
+	 * up its share of the traffic goes to the primary; a failed connect
+	 * leaves the slot idle to be retried when the cursor wraps. */
+	if (OFI_UNLIKELY(conn->states[idx] == RXM_CM_IDLE))
+		(void) rxm_send_connect(conn, idx);
+
+	return 0;
+}
+
+static uint8_t rxm_rr_select(struct rxm_conn *conn, const struct rxm_pkt *pkt)
+{
+	struct rxm_rr_selector *rr =
+		container_of(conn->selector, struct rxm_rr_selector, base);
+	enum rxm_sar_seg_type seg_type;
+	uint64_t msg_id;
+	void *slot;
+	uint8_t idx;
+
+	if (!pkt)
+		return rxm_rr_next(rr, conn);
+
+	if (OFI_LIKELY(pkt->ctrl_hdr.type != rxm_ctrl_seg))
+		return 0;
+
+	seg_type = rxm_sar_get_seg_type((struct ofi_ctrl_hdr *) &pkt->ctrl_hdr);
+	msg_id = pkt->ctrl_hdr.msg_id;
+
+	switch (seg_type) {
+	case RXM_SAR_SEG_MIDDLE:
+	case RXM_SAR_SEG_LAST:
+		/* Every non-FIRST segment must take the same ep so the receiver
+		 * sees them in order. The pin has to outlive LAST: clearing it
+		 * there would let a deferred LAST re-pin elsewhere and overtake
+		 * an in-flight MIDDLE. FIRST clears it instead, which is safe
+		 * because the tx-buf index keying the pin is not reused until
+		 * both the first and last sends have completed. */
+		slot = ofi_idm_lookup(&rr->sar_pins, (int) msg_id);
+		if (slot) {
+			idx = (uint8_t) ((uintptr_t) slot - 1);
+			if (OFI_LIKELY(idx < conn->num_msg_eps))
+				return idx;
+			ofi_idm_clear(&rr->sar_pins, (int) msg_id);
+		}
+		idx = rxm_rr_next(rr, conn);
+		/* If the map cannot grow, run the rest of the message on ep 0:
+		 * later segments miss the lookup and land there too. */
+		if (OFI_UNLIKELY(ofi_idm_set(&rr->sar_pins, (int) msg_id,
+					     (void *) (uintptr_t) (idx + 1)) < 0))
+			return 0;
+		return idx;
+	default:
+		/* FIRST always goes out on the primary. */
+		if (ofi_idm_lookup(&rr->sar_pins, (int) msg_id))
+			ofi_idm_clear(&rr->sar_pins, (int) msg_id);
+		return 0;
+	}
+}
+
+static void rxm_rr_destroy(struct rxm_ep_selector *sel)
+{
+	struct rxm_rr_selector *rr =
+		container_of(sel, struct rxm_rr_selector, base);
+
+	/* Values are encoded indices, not pointers, so nothing to free. */
+	ofi_idm_reset(&rr->sar_pins, NULL);
+	free(rr);
+}
+
+struct rxm_ep_selector *rxm_rr_selector_alloc(void)
+{
+	struct rxm_rr_selector *rr;
+
+	rr = calloc(1, sizeof(*rr));
+	if (!rr)
+		return NULL;
+
+	rr->base.select = rxm_rr_select;
+	rr->base.destroy = rxm_rr_destroy;
+	rr->rr_next = 1;
+	return &rr->base;
+}

--- a/prov/rxm/src/rxm_ep_selector.h
+++ b/prov/rxm/src/rxm_ep_selector.h
@@ -6,17 +6,32 @@
 
 #include <stdint.h>
 
+#include <ofi_indexer.h>
+
 struct rxm_conn;
 struct rxm_pkt;
 
 /* Maps a TX operation to an index into rxm_conn::msg_eps. select() receives
  * the rxm_pkt of framed sends, or NULL for the RMA and rendezvous RMA paths,
- * which carry no rxm header.
+ * which carry no rxm header. destroy() is optional and lets a stateful
+ * selector free itself.
  */
 struct rxm_ep_selector {
 	uint8_t (*select)(struct rxm_conn *conn, const struct rxm_pkt *pkt);
+	void (*destroy)(struct rxm_ep_selector *sel);
+};
+
+struct rxm_rr_selector {
+	struct rxm_ep_selector base;
+	/* Next ep index to hand out, in [1, num_msg_eps - 1]. */
+	uint8_t rr_next;
+	/* msg_id -> (ep_idx + 1) stored as void *. The +1 distinguishes a
+	 * pin to ep 0 from an absent entry. */
+	struct index_map sar_pins;
 };
 
 extern const struct rxm_ep_selector rxm_selector_single_ep;
+
+struct rxm_ep_selector *rxm_rr_selector_alloc(void);
 
 #endif /* RXM_EP_SELECTOR_H */

--- a/prov/rxm/src/rxm_ep_selector.h
+++ b/prov/rxm/src/rxm_ep_selector.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright (c) 2026 Intel Corporation, Inc. All rights reserved. */
+
+#ifndef RXM_EP_SELECTOR_H
+#define RXM_EP_SELECTOR_H
+
+#include <stdint.h>
+
+struct rxm_conn;
+struct rxm_pkt;
+
+/* Maps a TX operation to an index into rxm_conn::msg_eps. select() receives
+ * the rxm_pkt of framed sends, or NULL for the RMA and rendezvous RMA paths,
+ * which carry no rxm header.
+ */
+struct rxm_ep_selector {
+	uint8_t (*select)(struct rxm_conn *conn, const struct rxm_pkt *pkt);
+};
+
+extern const struct rxm_ep_selector rxm_selector_single_ep;
+
+#endif /* RXM_EP_SELECTOR_H */

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -60,6 +60,7 @@ int force_auto_progress;
 int rxm_use_write_rndv;
 int rxm_detect_hmem_iface;
 int rxm_rescan = -1;
+size_t rxm_num_msg_eps = 1;
 enum fi_wait_obj def_wait_obj = FI_WAIT_FD, def_tcp_wait_obj = FI_WAIT_UNSPEC;
 
 char *rxm_proto_state_str[] = {
@@ -709,6 +710,12 @@ RXM_INI
 			"in. This allows such buffers be copied or registered "
 			"internally by RxM. (default: false).");
 
+	fi_param_define(&rxm_prov, "num_msg_eps", FI_PARAM_SIZE_T,
+			"Number of msg endpoints, and hence underlying "
+			"connections and QPs, to open per rxm connection. "
+			"Values are clamped to the range [1, 255]. "
+			"(default: 1)");
+
 	fi_param_define(&rxm_prov, "rescan", FI_PARAM_BOOL,
 			"Force or disable rescanning for network interface changes. "
 			"Setting this to true will force rescanning on each fi_getinfo() invocation; "
@@ -741,6 +748,11 @@ RXM_INI
 
 	fi_param_get_bool(&rxm_prov, "detect_hmem_iface", &rxm_detect_hmem_iface);
 	fi_param_get_bool(&rxm_prov, "rescan", &rxm_rescan);
+	fi_param_get_size_t(&rxm_prov, "num_msg_eps", &rxm_num_msg_eps);
+	if (rxm_num_msg_eps < 1)
+		rxm_num_msg_eps = 1;
+	if (rxm_num_msg_eps > UINT8_MAX)
+		rxm_num_msg_eps = UINT8_MAX;
 
 #if HAVE_RXM_DL
 	ofi_mem_init();

--- a/prov/rxm/src/rxm_msg.c
+++ b/prov/rxm/src/rxm_msg.c
@@ -163,11 +163,12 @@ rxm_send_rndv(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 			RXM_UPDATE_STATE(FI_LOG_EP_DATA, tx_buf,
 					 RXM_RNDV_READ_DONE_WAIT);
 
-		ret = fi_inject(rxm_conn->msg_ep, &tx_buf->pkt, pkt_size, 0);
+		ret = fi_inject(rxm_conn_msg_ep(rxm_conn, &tx_buf->pkt),
+				&tx_buf->pkt, pkt_size, 0);
 	} else {
 		RXM_UPDATE_STATE(FI_LOG_EP_DATA, tx_buf, RXM_RNDV_TX);
-		ret = fi_send(rxm_conn->msg_ep, &tx_buf->pkt, pkt_size,
-			      tx_buf->hdr.desc, 0, tx_buf);
+		ret = fi_send(rxm_conn_msg_ep(rxm_conn, &tx_buf->pkt),
+			      &tx_buf->pkt, pkt_size, tx_buf->hdr.desc, 0, tx_buf);
 	}
 
 	if (ret)
@@ -258,7 +259,8 @@ rxm_send_segment(struct rxm_ep *rxm_ep,
 
 	*out_tx_buf = tx_buf;
 
-	return fi_send(rxm_conn->msg_ep, &tx_buf->pkt, sizeof(struct rxm_pkt) +
+	return fi_send(rxm_conn_msg_ep(rxm_conn, &tx_buf->pkt),
+		       &tx_buf->pkt, sizeof(struct rxm_pkt) +
 		       tx_buf->pkt.ctrl_hdr.seg_size, tx_buf->hdr.desc, 0, tx_buf);
 }
 
@@ -292,7 +294,8 @@ rxm_send_sar(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 
 	iov_offset += rxm_buffer_size;
 
-	ret = fi_send(rxm_conn->msg_ep, &first_tx_buf->pkt,
+	ret = fi_send(rxm_conn_msg_ep(rxm_conn, &first_tx_buf->pkt),
+		      &first_tx_buf->pkt,
 		      sizeof(struct rxm_pkt) + first_tx_buf->pkt.ctrl_hdr.seg_size,
 		      first_tx_buf->hdr.desc, 0, first_tx_buf);
 	if (ret) {
@@ -372,8 +375,8 @@ rxm_emulate_inject(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 				 &tx_buf->pkt);
 	memcpy(tx_buf->pkt.data, buf, len);
 
-	ret = fi_send(rxm_conn->msg_ep, &tx_buf->pkt, pkt_size,
-		      tx_buf->hdr.desc, 0, tx_buf);
+	ret = fi_send(rxm_conn_msg_ep(rxm_conn, &tx_buf->pkt),
+		      &tx_buf->pkt, pkt_size, tx_buf->hdr.desc, 0, tx_buf);
 	if (ret) {
 		if (ret == -FI_EAGAIN)
 			rxm_ep_do_progress(&rxm_ep->util_ep);
@@ -396,7 +399,8 @@ rxm_inject_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	if (pkt_size <= rxm_ep->inject_limit && !rxm_ep->util_ep.cntrs[CNTR_TX]) {
 		inject_pkt->hdr.size = len;
 		memcpy(inject_pkt->data, buf, len);
-		ret = fi_inject(rxm_conn->msg_ep, inject_pkt, pkt_size, 0);
+		ret = fi_inject(rxm_conn_msg_ep(rxm_conn, inject_pkt),
+				inject_pkt, pkt_size, 0);
 	} else {
 		ret = rxm_emulate_inject(rxm_ep, rxm_conn, buf, len,
 					 pkt_size, inject_pkt->hdr.data,
@@ -438,11 +442,11 @@ rxm_direct_send(struct rxm_ep *ep, struct rxm_conn *rxm_conn,
 			send_desc[i + 1] = fi_mr_desc(mr->msg_mr);
 		}
 
-		ret = fi_sendv(rxm_conn->msg_ep, send_iov, send_desc,
-			       count + 1, 0, tx_buf);
+		ret = fi_sendv(rxm_conn_msg_ep(rxm_conn, &tx_buf->pkt),
+			       send_iov, send_desc, count + 1, 0, tx_buf);
 	} else {
-		ret = fi_sendv(rxm_conn->msg_ep, send_iov, NULL,
-			       count + 1, 0, tx_buf);
+		ret = fi_sendv(rxm_conn_msg_ep(rxm_conn, &tx_buf->pkt),
+			       send_iov, NULL, count + 1, 0, tx_buf);
 	}
 	return ret;
 }
@@ -476,7 +480,8 @@ rxm_send_eager(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 					     eager_buf->pkt.hdr.size, iov,
 					     count, 0);
 		assert((size_t) ret == eager_buf->pkt.hdr.size);
-		ret = fi_send(rxm_conn->msg_ep, &eager_buf->pkt, total_len,
+		ret = fi_send(rxm_conn_msg_ep(rxm_conn, &eager_buf->pkt),
+			      &eager_buf->pkt, total_len,
 			      eager_buf->hdr.desc, 0, eager_buf);
 	}
 
@@ -769,7 +774,7 @@ rxm_send_thru(struct fid_ep *ep_fid, const void *buf, size_t len,
 	if (ret)
 		goto unlock;
 
-	ret = fi_send(conn->msg_ep, buf, len, desc, 0, context);
+	ret = fi_send(rxm_conn_msg_ep(conn, NULL), buf, len, desc, 0, context);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -790,7 +795,7 @@ rxm_sendv_thru(struct fid_ep *ep_fid, const struct iovec *iov,
 	if (ret)
 		goto unlock;
 
-	ret = fi_sendv(conn->msg_ep, iov, desc, count, 0, context);
+	ret = fi_sendv(rxm_conn_msg_ep(conn, NULL), iov, desc, count, 0, context);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -811,7 +816,7 @@ rxm_sendmsg_thru(struct fid_ep *ep_fid, const struct fi_msg *msg,
 	if (ret)
 		goto unlock;
 
-	ret = fi_sendmsg(conn->msg_ep, msg, flags);
+	ret = fi_sendmsg(rxm_conn_msg_ep(conn, NULL), msg, flags);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -832,7 +837,7 @@ rxm_inject_thru(struct fid_ep *ep_fid, const void *buf,
 	if (ret)
 		goto unlock;
 
-	ret = fi_inject(conn->msg_ep, buf, len, 0);
+	ret = fi_inject(rxm_conn_msg_ep(conn, NULL), buf, len, 0);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -853,7 +858,8 @@ rxm_senddata_thru(struct fid_ep *ep_fid, const void *buf, size_t len,
 	if (ret)
 		goto unlock;
 
-	ret = fi_senddata(conn->msg_ep, buf, len, desc, data, 0, context);
+	ret = fi_senddata(rxm_conn_msg_ep(conn, NULL),
+			  buf, len, desc, data, 0, context);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -874,7 +880,7 @@ rxm_injectdata_thru(struct fid_ep *ep_fid, const void *buf, size_t len,
 	if (ret)
 		goto unlock;
 
-	ret = fi_injectdata(conn->msg_ep, buf, len, data, 0);
+	ret = fi_injectdata(rxm_conn_msg_ep(conn, NULL), buf, len, data, 0);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;

--- a/prov/rxm/src/rxm_msg.c
+++ b/prov/rxm/src/rxm_msg.c
@@ -211,6 +211,9 @@ rxm_init_segment(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 				 &tx_buf->pkt);
 	if (seg_type == RXM_SAR_SEG_FIRST) {
 		*msg_id = tx_buf->pkt.ctrl_hdr.msg_id = ofi_buf_index(tx_buf);
+		/* tx_bufs are recycled without zeroing. */
+		tx_buf->sar.first_seg_done = false;
+		tx_buf->sar.last_seg_done = false;
 	} else {
 		tx_buf->pkt.ctrl_hdr.msg_id = *msg_id;
 	}
@@ -324,7 +327,7 @@ rxm_send_sar(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	return 0;
 
 free:
-	rxm_free_tx_buf(rxm_ep, first_tx_buf);
+	rxm_release_sar_first_tx_buf(rxm_ep, first_tx_buf);
 	return ret;
 defer:
 	def_tx = rxm_ep_alloc_deferred_tx_entry(rxm_ep,

--- a/prov/rxm/src/rxm_msg.c
+++ b/prov/rxm/src/rxm_msg.c
@@ -210,7 +210,9 @@ rxm_init_segment(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	rxm_ep_format_tx_buf_pkt(rxm_conn, total_len, op, data, tag, flags,
 				 &tx_buf->pkt);
 	if (seg_type == RXM_SAR_SEG_FIRST) {
-		*msg_id = tx_buf->pkt.ctrl_hdr.msg_id = ofi_buf_index(tx_buf);
+		*msg_id = tx_buf->pkt.ctrl_hdr.msg_id =
+			RXM_SAR_MSG_ID(rxm_ep->sar_msg_gen++,
+				       ofi_buf_index(tx_buf));
 		/* tx_bufs are recycled without zeroing. */
 		tx_buf->sar.first_seg_done = false;
 		tx_buf->sar.last_seg_done = false;

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -101,7 +101,7 @@ rxm_ep_rma_common(struct rxm_ep *rxm_ep, const struct fi_msg_rma *msg,
 	msg_rma.desc = mr_desc;
 	msg_rma.context = rma_buf;
 
-	ret = rma_msg(rxm_conn->msg_ep, &msg_rma, flags);
+	ret = rma_msg(rxm_conn_msg_ep(rxm_conn, NULL), &msg_rma, flags);
 	if (!ret)
 		goto unlock;
 
@@ -231,7 +231,7 @@ rxm_ep_rma_emulate_inject_msg(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 
 	flags = (flags & ~FI_INJECT) | FI_COMPLETION;
 
-	ret = fi_writemsg(rxm_conn->msg_ep, &rxm_rma_msg, flags);
+	ret = fi_writemsg(rxm_conn_msg_ep(rxm_conn, NULL), &rxm_rma_msg, flags);
 	if (ret) {
 		if (ret == -FI_EAGAIN)
 			rxm_ep_do_progress(&rxm_ep->util_ep);
@@ -295,13 +295,13 @@ rxm_ep_rma_inject_common(struct rxm_ep *rxm_ep, const struct fi_msg_rma *msg,
 	}
 
 	if (flags & FI_REMOTE_CQ_DATA) {
-		ret = fi_inject_writedata(rxm_conn->msg_ep,
+		ret = fi_inject_writedata(rxm_conn_msg_ep(rxm_conn, NULL),
 					  msg->msg_iov->iov_base,
 					  msg->msg_iov->iov_len, msg->data,
 					  msg->addr, msg->rma_iov->addr,
 					  msg->rma_iov->key);
 	} else {
-		ret = fi_inject_write(rxm_conn->msg_ep,
+		ret = fi_inject_write(rxm_conn_msg_ep(rxm_conn, NULL),
 				      msg->msg_iov->iov_base,
 				      msg->msg_iov->iov_len, msg->addr,
 				      msg->rma_iov->addr,
@@ -450,7 +450,8 @@ static ssize_t rxm_ep_inject_write(struct fid_ep *ep_fid, const void *buf,
 		goto unlock;
 	}
 
-	ret = fi_inject_write(rxm_conn->msg_ep, buf, len, dest_addr, addr, key);
+	ret = fi_inject_write(rxm_conn_msg_ep(rxm_conn, NULL),
+			      buf, len, dest_addr, addr, key);
 	if (ret == -FI_EAGAIN)
 		rxm_ep_do_progress(&rxm_ep->util_ep);
 	else if (ret)
@@ -484,8 +485,8 @@ static ssize_t rxm_ep_inject_writedata(struct fid_ep *ep_fid, const void *buf,
 		goto unlock;
 	}
 
-	ret = fi_inject_writedata(rxm_conn->msg_ep, buf, len,
-				  data, dest_addr, addr, key);
+	ret = fi_inject_writedata(rxm_conn_msg_ep(rxm_conn, NULL),
+				  buf, len, data, dest_addr, addr, key);
 	if (ret == -FI_EAGAIN)
 		rxm_ep_do_progress(&rxm_ep->util_ep);
 	else if (ret)
@@ -526,7 +527,7 @@ rxm_read_thru(struct fid_ep *ep_fid, void *buf, size_t len,
 	if (ret)
 		goto unlock;
 
-	ret = fi_read(conn->msg_ep, buf, len, desc, src_addr, addr,
+	ret = fi_read(rxm_conn_msg_ep(conn, NULL), buf, len, desc, src_addr, addr,
 		      key, context);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
@@ -549,8 +550,8 @@ rxm_readv_thru(struct fid_ep *ep_fid, const struct iovec *iov,
 	if (ret)
 		goto unlock;
 
-	ret = fi_readv(conn->msg_ep, iov, desc, count, src_addr, addr,
-		       key, context);
+	ret = fi_readv(rxm_conn_msg_ep(conn, NULL),
+		       iov, desc, count, src_addr, addr, key, context);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -571,7 +572,7 @@ rxm_readmsg_thru(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 	if (ret)
 		goto unlock;
 
-	ret = fi_readmsg(conn->msg_ep, msg, flags);
+	ret = fi_readmsg(rxm_conn_msg_ep(conn, NULL), msg, flags);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -593,8 +594,8 @@ rxm_write_thru(struct fid_ep *ep_fid, const void *buf,
 	if (ret)
 		goto unlock;
 
-	ret = fi_write(conn->msg_ep, buf, len, desc, dest_addr, addr,
-		       key, context);
+	ret = fi_write(rxm_conn_msg_ep(conn, NULL), buf, len, desc, dest_addr, 
+		       addr, key, context);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -616,8 +617,8 @@ rxm_writev_thru(struct fid_ep *ep_fid, const struct iovec *iov,
 	if (ret)
 		goto unlock;
 
-	ret = fi_writev(conn->msg_ep, iov, desc, count, dest_addr, addr,
-			key, context);
+	ret = fi_writev(rxm_conn_msg_ep(conn, NULL),
+			iov, desc, count, dest_addr, addr, key, context);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -638,7 +639,7 @@ rxm_writemsg_thru(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 	if (ret)
 		goto unlock;
 
-	ret = fi_writemsg(conn->msg_ep, msg, flags);
+	ret = fi_writemsg(rxm_conn_msg_ep(conn, NULL), msg, flags);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -660,7 +661,8 @@ rxm_inject_write_thru(struct fid_ep *ep_fid, const void *buf,
 	if (ret)
 		goto unlock;
 
-	ret = fi_inject_write(conn->msg_ep, buf, len, dest_addr, addr, key);
+	ret = fi_inject_write(rxm_conn_msg_ep(conn, NULL),
+			      buf, len, dest_addr, addr, key);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -683,8 +685,8 @@ rxm_writedata_thru(struct fid_ep *ep_fid, const void *buf,
 	if (ret)
 		goto unlock;
 
-	ret = fi_writedata(conn->msg_ep, buf, len, desc, data, dest_addr,
-			   addr, key, context);
+	ret = fi_writedata(rxm_conn_msg_ep(conn, NULL),
+			   buf, len, desc, data, dest_addr, addr, key, context);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -706,8 +708,8 @@ rxm_inject_writedata_thru(struct fid_ep *ep_fid, const void *buf,
 	if (ret)
 		goto unlock;
 
-	ret = fi_inject_writedata(conn->msg_ep, buf, len, data, dest_addr,
-				  addr, key);
+	ret = fi_inject_writedata(rxm_conn_msg_ep(conn, NULL),
+				  buf, len, data, dest_addr, addr, key);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;

--- a/prov/rxm/src/rxm_tagged.c
+++ b/prov/rxm/src/rxm_tagged.c
@@ -330,7 +330,8 @@ rxm_tsend_thru(struct fid_ep *ep_fid, const void *buf, size_t len,
 	if (ret)
 		goto unlock;
 
-	ret = fi_tsend(conn->msg_ep, buf, len, desc, 0, tag, context);
+	ret = fi_tsend(rxm_conn_msg_ep(conn, NULL),
+		       buf, len, desc, 0, tag, context);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -352,7 +353,8 @@ rxm_tsendv_thru(struct fid_ep *ep_fid, const struct iovec *iov,
 	if (ret)
 		goto unlock;
 
-	ret = fi_tsendv(conn->msg_ep, iov, desc, count, 0, tag, context);
+	ret = fi_tsendv(rxm_conn_msg_ep(conn, NULL),
+			iov, desc, count, 0, tag, context);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -373,7 +375,7 @@ rxm_tsendmsg_thru(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
 	if (ret)
 		goto unlock;
 
-	ret = fi_tsendmsg(conn->msg_ep, msg, flags);
+	ret = fi_tsendmsg(rxm_conn_msg_ep(conn, NULL), msg, flags);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -394,7 +396,7 @@ rxm_tinject_thru(struct fid_ep *ep_fid, const void *buf,
 	if (ret)
 		goto unlock;
 
-	ret = fi_tinject(conn->msg_ep, buf, len, 0, tag);
+	ret = fi_tinject(rxm_conn_msg_ep(conn, NULL), buf, len, 0, tag);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -416,7 +418,8 @@ rxm_tsenddata_thru(struct fid_ep *ep_fid, const void *buf, size_t len,
 	if (ret)
 		goto unlock;
 
-	ret = fi_tsenddata(conn->msg_ep, buf, len, desc, data, 0, tag, context);
+	ret = fi_tsenddata(rxm_conn_msg_ep(conn, NULL),
+			   buf, len, desc, data, 0, tag, context);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;
@@ -437,7 +440,7 @@ rxm_tinjectdata_thru(struct fid_ep *ep_fid, const void *buf, size_t len,
 	if (ret)
 		goto unlock;
 
-	ret = fi_tinjectdata(conn->msg_ep, buf, len, data, 0, tag);
+	ret = fi_tinjectdata(rxm_conn_msg_ep(conn, NULL), buf, len, data, 0, tag);
 unlock:
 	ofi_genlock_unlock(&ep->util_ep.lock);
 	return ret;

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -497,6 +497,7 @@ int vrb_cq_open(struct fid_domain *domain_fid, struct fi_cq_attr *attr,
 	struct vrb_domain *domain =
 		container_of(domain_fid, struct vrb_domain,
 			     util_domain.domain_fid);
+	struct ibv_device_attr device_attr;
 	size_t size;
 	int ret;
 	struct fi_cq_attr tmp_attr = *attr;
@@ -562,14 +563,18 @@ int vrb_cq_open(struct fid_domain *domain_fid, struct fi_cq_attr *attr,
 	size = attr->size ? attr->size : VERBS_DEF_CQ_SIZE;
 
 	/*
-	 * Verbs may throw an error if CQ size exceeds ibv_device_attr->max_cqe.
-	 * OFI doesn't expose CQ size to the apps because it's better to fix the
-	 * issue in the provider than the app dealing with it. The fix is to
-	 * open multiple verbs CQs and load balance "MSG EP to CQ binding"* among
-	 * them to avoid any CQ overflow.
-	 * Something like:
-	 * num_qp_per_cq = ibv_device_attr->max_cqe / (qp_send_wr + qp_recv_wr)
+	 * Verbs throws an error if CQ size exceeds ibv_device_attr->max_cqe.
+	 * A single CQ may back many QPs, so the requested size can legitimately
+	 * be larger than the device supports; clamp it rather than fail.
 	 */
+	if (domain->verbs && !ibv_query_device(domain->verbs, &device_attr) &&
+	    device_attr.max_cqe > 0 && size > (size_t) device_attr.max_cqe) {
+		VRB_WARN(FI_LOG_CQ,
+			 "CQ size %zu exceeds device max_cqe %d, clamping\n",
+			 size, device_attr.max_cqe);
+		size = (size_t) device_attr.max_cqe;
+	}
+
 	cq->cq = ibv_create_cq(domain->verbs, size, cq, cq->channel,
 			       comp_vector);
 	if (!cq->cq) {

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -214,6 +214,7 @@ vrb_cq_sread(struct fid_cq *cq, void *buf, size_t count, const void *cond,
 
 int vrb_poll_cq(struct vrb_cq *cq, struct ibv_wc *wc)
 {
+	struct slist_entry *entry, *prev;
 	struct vrb_context *ctx;
 	struct vrb_ep *ep;
 	int ret;
@@ -231,9 +232,14 @@ int vrb_poll_cq(struct vrb_cq *cq, struct ibv_wc *wc)
 		if (ctx->op_queue == VRB_OP_SQ) {
 			ep = ctx->ep;
 			assert(ep);
-			assert(!slist_empty(&ep->sq_list));
-			assert(ep->sq_list.head == &ctx->entry);
-			(void) slist_remove_head(&ep->sq_list);
+			/* The completing send is on this ep's sq_list, but
+			 * not necessarily at its head. */
+			slist_foreach(&ep->sq_list, entry, prev) {
+				if (entry == &ctx->entry)
+					break;
+			}
+			assert(entry == &ctx->entry);
+			slist_remove(&ep->sq_list, &ctx->entry, prev);
 			ep->sq_credits++;
 
 			/* workaround incorrect opcode reported by verbs */

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -87,10 +87,15 @@ static int vrb_enable_ep_flow_ctrl(struct fid_ep *ep_fid, uint64_t threshold)
 		credits_to_give = 0;
 	}
 
-	if (credits_to_give &&
-	    vrb_ep2_domain(ep)->send_credits(&ep->util_ep.ep_fid,
-					     credits_to_give)) {
-		ep->rq_credits_avail += credits_to_give;
+	if (credits_to_give) {
+		ofi_genlock_unlock(&vrb_ep2_progress(ep)->ep_lock);
+		if (vrb_ep2_domain(ep)->send_credits(&ep->util_ep.ep_fid,
+						     credits_to_give)) {
+			ofi_genlock_lock(&vrb_ep2_progress(ep)->ep_lock);
+			ep->rq_credits_avail += credits_to_give;
+			ofi_genlock_unlock(&vrb_ep2_progress(ep)->ep_lock);
+		}
+		return FI_SUCCESS;
 	}
 	ofi_genlock_unlock(&vrb_ep2_progress(ep)->ep_lock);
 


### PR DESCRIPTION
## Summary

This change lets a single rxm endpoint send over multiple underlying msg
endpoints (distinct verbs QPs) instead of one. A pluggable selector routes
each TX op to a msg_ep, secondary QPs open lazily, and the default
configuration behaves exactly as before (single ep).

Set the QP count at runtime with `FI_OFI_RXM_NUM_MSG_EPS` (default 1,
clamped to [1, 255]). Values above 1 are restricted to the verbs provider,
where each msg_ep maps to a distinct QP. Other providers clamp to 1.

## What changed

**Selector infrastructure**
- New pluggable `rxm_ep_selector` interface (`rxm_ep_selector.{c,h}`). It
  maps each TX op to a msg_ep index, reading `ctrl_hdr.type` / `msg_id`
  (and SAR seg type) from the `rxm_pkt`.
- `rxm_conn` now holds a `msg_eps[]` array in place of the single scalar
  `msg_ep` alias. All TX paths (eager/tagged, SAR, RNDV control and
  payload, pass-through RMA, atomics) call `rxm_conn_msg_ep()`.
- Includes `rxm_selector_single_ep` (always index 0), which keeps current
  behavior, and a round-robin selector with SAR pinning.

**Routing policy (RR selector)**
- RMA and rendezvous-RMA round-robin across `msg_ep[1..N-1]`. Control-plane
  traffic (eager, tagged, RNDV_CTRL, atomics) stays pinned to `msg_ep[0]`.
- SAR keeps in-order delivery: `SAR_FIRST` stays on ep[0]; the first
  `SAR_MIDDLE` picks a data ep via RR and pins the choice by `msg_id`;
  later MIDDLEs inherit the pin; `SAR_LAST` clears it.

**CM layer (lazy multi-ep connect)**
- Per-slot CM state: the scalar `conn->state` becomes a parallel `states[]`
  array indexed alongside `msg_eps[]`. Slot 0 keeps its existing semantics.
- Secondary slots back `msg_eps[1..N-1]` with their own
  `fi_endpoint`+`fi_connect` handshakes, opened lazily on the first
  selector pick. Slot 0 still opens during the initial connect.

**Hot-path tuning**
- Replaced the RR modulo (a runtime integer divide) with a stored `rr_next`
  index advanced by compare-and-wrap. It self-heals if the ep count shrinks.
- Added branch hints to the per-packet selector path.

## Configuration

| Var | Default | Range | Notes |
|-----|---------|-------|-------|
| `FI_OFI_RXM_NUM_MSG_EPS` | 1 | [1, 255] | values above 1 restricted to verbs |

## Compatibility

With `num_msg_eps == 1` the stateless single-ep selector runs, which skips
the heap allocation and SAR-pin map. Wire behavior is identical to before.