### PR TITLE
fabtests/prov/verbs: Correct coverity issue

### DIFF
--- a/fabtests/prov/verbs/src/nic_affinity_test.c
+++ b/fabtests/prov/verbs/src/nic_affinity_test.c
@@ -360,8 +360,8 @@ static int check_no_interference(struct fi_info *info) {
 
 static int validate_consistency()
 {
-        struct fi_info *policy_info1;
-	struct fi_info *policy_info2;
+        struct fi_info *policy_info1 = NULL;
+	struct fi_info *policy_info2 = NULL;
 	const char *name1;
 	const char *name2;
         int ret;


### PR DESCRIPTION
Initialize policy_info2 to NULL to fix use of uninitialized variable when the first fi_getinfo call fails and jumps to the cleanup label.