### PR TITLE
fabtests/pytest/efa: skip fi_mr_abort RMA tests when RMA unsupported

### DIFF
--- a/fabtests/pytest/efa/test_mr_abort.py
+++ b/fabtests/pytest/efa/test_mr_abort.py
@@ -25,8 +25,8 @@ MR_ABORT_NUM_MRS = 2046
     # workers.
     pytest.param(10485760, marks=pytest.mark.serial),
 ])
-def test_mr_abort(cmdline_args, fabric, rma_op, cancel_order, close_side, ops_per_mr, message_size, memory_type_symm):
-    if fabric == "efa" and cmdline_args.server_id == cmdline_args.client_id:
+def test_mr_abort(cmdline_args, rma_fabric, rma_op, cancel_order, close_side, ops_per_mr, message_size, memory_type_symm):
+    if rma_fabric == "efa" and cmdline_args.server_id == cmdline_args.client_id:
         pytest.skip("fi_mr_abort not supported with efa with SHM")
 
     if message_size == 10485760 and (cancel_order == 'random' or ops_per_mr == 4):
@@ -35,7 +35,7 @@ def test_mr_abort(cmdline_args, fabric, rma_op, cancel_order, close_side, ops_pe
     command = (f"fi_mr_abort -T abort -o {rma_op} -C {cancel_order}"
                f" -R {close_side} -N {ops_per_mr} -W {MR_ABORT_NUM_MRS}"
                f" -S {message_size}")
-    test = ClientServerTest(cmdline_args, command, timeout=300, fabric=fabric, memory_type=memory_type_symm)
+    test = ClientServerTest(cmdline_args, command, timeout=300, fabric=rma_fabric, memory_type=memory_type_symm)
     test.run()
 
 
@@ -50,12 +50,12 @@ def test_mr_abort(cmdline_args, fabric, rma_op, cancel_order, close_side, ops_pe
     # 10 MiB: run serially to avoid resource contention (see test_mr_abort).
     pytest.param(10485760, marks=pytest.mark.serial),
 ])
-def test_mr_abort_partial(cmdline_args, fabric, rma_op, message_size, memory_type_symm):
-    if fabric == "efa" and cmdline_args.server_id == cmdline_args.client_id:
+def test_mr_abort_partial(cmdline_args, rma_fabric, rma_op, message_size, memory_type_symm):
+    if rma_fabric == "efa" and cmdline_args.server_id == cmdline_args.client_id:
         pytest.skip("fi_mr_abort not supported with efa with SHM")
 
     command = (f"fi_mr_abort -T partial -o {rma_op} -S {message_size}")
-    test = ClientServerTest(cmdline_args, command, timeout=300, fabric=fabric, memory_type=memory_type_symm)
+    test = ClientServerTest(cmdline_args, command, timeout=300, fabric=rma_fabric, memory_type=memory_type_symm)
     test.run()
 
 


### PR DESCRIPTION
The fi_mr_abort write/read/writedata tests run the RMA data path, which on efa-direct requires the device to support the corresponding RDMA operation. On instance types without RMA capability these tests would fail instead of being skipped.

Mirror the existing has_rdma() pattern used by test_cq.py and the rma_fabric fixture: in test_mr_abort and test_mr_abort_partial, skip the efa-direct case when has_rdma(cmdline_args, rma_op) is false. The check is per-rma_op so a device supporting only some RMA operations still runs the supported ones. The send/tagged modes are unaffected since they use only FI_SEND/FI_RECV and do not exercise the RMA path.