### PR TITLE
prov/efa: refactor fabric component into efa-rdm and efa-direct

### DIFF
--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -879,6 +879,7 @@
     <ClCompile Include="prov\efa\src\efa_domain.c" />
     <ClCompile Include="prov\efa\src\efa_domain_util.c" />
     <ClCompile Include="prov\efa\src\efa_fabric.c" />
+    <ClCompile Include="prov\efa\src\efa_fabric_util.c" />
     <ClCompile Include="prov\efa\src\efa_mr.c" />
     <ClCompile Include="prov\efa\src\efa_shm.c" />
     <ClCompile Include="prov\efa\src\efa_strerror.c" />
@@ -896,6 +897,7 @@
     <ClCompile Include="prov\efa\src\efa_ep.c" />
     <ClCompile Include="prov\efa\src\efa_direct_ope.c" />
     <ClCompile Include="prov\efa\src\rdm\efa_rdm_domain.c" />
+    <ClCompile Include="prov\efa\src\rdm\efa_rdm_fabric.c" />
     <ClCompile Include="prov\efa\src\rdm\efa_rdm_ope.c" />
     <ClCompile Include="prov\efa\src\rdm\efa_rdm_rxe_map.c" />
     <ClCompile Include="prov\efa\src\rdm\efa_rdm_atomic.c" />
@@ -1019,6 +1021,7 @@
     <ClInclude Include="prov\efa\src\windows\infiniband\verbs.h" />
     <ClInclude Include="prov\efa\src\windows\infiniband\verbs_defs.h" />
     <ClInclude Include="prov\efa\src\efa.h" />
+    <ClInclude Include="prov\efa\src\efa_fabric_util.h" />
     <ClInclude Include="prov\efa\src\efa_av.h" />
     <ClInclude Include="prov\efa\src\efa_ah.h" />
     <ClInclude Include="prov\efa\src\efa_conn.h" />
@@ -1026,6 +1029,7 @@
     <ClInclude Include="prov\efa\src\efa_cntr.h" />
     <ClInclude Include="prov\efa\src\efa_hw_cntr.h" />
     <ClInclude Include="prov\efa\src\rdm\efa_rdm_ep.h" />
+    <ClInclude Include="prov\efa\src\rdm\efa_rdm_fabric.h" />
     <ClInclude Include="prov\efa\src\rdm\efa_rdm_cntr.h" />
     <ClInclude Include="prov\efa\src\rdm\efa_rdm_pke_utils.h" />
     <ClInclude Include="prov\efa\src\rdm\efa_rdm_pke_nonreq.h" />

--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -41,6 +41,8 @@ _efa_files = \
 	prov/efa/src/efa_domain.c \
 	prov/efa/src/efa_domain_util.c \
 	prov/efa/src/efa_fabric.c \
+	prov/efa/src/efa_fabric_util.c \
+	prov/efa/src/rdm/efa_rdm_fabric.c \
 	prov/efa/src/efa_mr.c \
 	prov/efa/src/efa_strerror.c \
 	prov/efa/src/efa_user_info.c \
@@ -99,6 +101,7 @@ _efa_headers = \
 	prov/efa/src/efa_device.h \
 	prov/efa/src/efa_domain.h \
 	prov/efa/src/efa_domain_util.h \
+	prov/efa/src/efa_fabric_util.h \
 	prov/efa/src/efa_errno.h \
 	prov/efa/src/efa_user_info.h \
 	prov/efa/src/efa_prov_info.h \
@@ -123,6 +126,7 @@ _efa_headers = \
 	prov/efa/src/efa_mmio.h \
 	prov/efa/src/rdm/efa_rdm_peer.h	\
 	prov/efa/src/rdm/efa_rdm_domain.h \
+	prov/efa/src/rdm/efa_rdm_fabric.h \
 	prov/efa/src/rdm/efa_rdm_cq.h \
 	prov/efa/src/rdm/efa_rdm_cntr.h \
 	prov/efa/src/rdm/efa_rdm_ep.h \

--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -164,6 +164,7 @@ nodist_prov_efa_test_efa_unit_test_SOURCES = \
 	prov/efa/test/efa_unit_test_common.c \
 	prov/efa/test/efa_unit_test_domain.c \
 	prov/efa/test/efa_unit_test_rdm_domain.c \
+	prov/efa/test/efa_unit_test_fabric.c \
 	prov/efa/test/efa_unit_test_ep.c \
 	prov/efa/test/efa_unit_test_av.c \
 	prov/efa/test/efa_unit_test_cq.c \

--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -108,19 +108,6 @@ struct efa_fabric {
 	struct util_fabric	util_fabric;
 };
 
-/* efa_rdm_fabric extends struct efa_fabric */
-struct efa_rdm_fabric {
-	struct efa_fabric	efa_fabric;
-
-	struct fid_fabric	*shm_fabric;
-#ifdef EFA_PERF_ENABLED
-	struct ofi_perfset	perf_set;
-#endif
-};
-
-_Static_assert(offsetof(struct efa_rdm_fabric, efa_fabric) == 0,
-	       "efa_fabric must be the first member of efa_rdm_fabric for safe casting");
-
 struct efa_context {
 	uint64_t completion_flags;
 	fi_addr_t addr;
@@ -281,25 +268,6 @@ int efa_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric_fid,
 enum efa_perf_counters {
 	EFA_PERF_FOREACH(OFI_ENUM_VAL)
 };
-
-extern const char *efa_perf_counters_str[];
-
-static inline void efa_perfset_start(struct efa_rdm_ep *ep, size_t index)
-{
-	struct efa_domain *domain = efa_rdm_ep_domain(ep);
-	struct efa_rdm_fabric *rdm_fabric = (struct efa_rdm_fabric *) domain->fabric;
-	ofi_perfset_start(&rdm_fabric->perf_set, index);
-}
-
-static inline void efa_perfset_end(struct efa_rdm_ep *ep, size_t index)
-{
-	struct efa_domain *domain = efa_rdm_ep_domain(ep);
-	struct efa_rdm_fabric *rdm_fabric = (struct efa_rdm_fabric *) domain->fabric;
-	ofi_perfset_end(&rdm_fabric->perf_set, index);
-}
-#else
-#define efa_perfset_start(ep, index) do {} while (0)
-#define efa_perfset_end(ep, index) do {} while (0)
 #endif
 
 static inline

--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -106,11 +106,20 @@
 
 struct efa_fabric {
 	struct util_fabric	util_fabric;
-	struct fid_fabric *shm_fabric;
+};
+
+/* efa_rdm_fabric extends struct efa_fabric */
+struct efa_rdm_fabric {
+	struct efa_fabric	efa_fabric;
+
+	struct fid_fabric	*shm_fabric;
 #ifdef EFA_PERF_ENABLED
-	struct ofi_perfset perf_set;
+	struct ofi_perfset	perf_set;
 #endif
 };
+
+_Static_assert(offsetof(struct efa_rdm_fabric, efa_fabric) == 0,
+	       "efa_fabric must be the first member of efa_rdm_fabric for safe casting");
 
 struct efa_context {
 	uint64_t completion_flags;
@@ -278,19 +287,15 @@ extern const char *efa_perf_counters_str[];
 static inline void efa_perfset_start(struct efa_rdm_ep *ep, size_t index)
 {
 	struct efa_domain *domain = efa_rdm_ep_domain(ep);
-	struct efa_fabric *fabric = container_of(domain->util_domain.fabric,
-						 struct efa_fabric,
-						 util_fabric);
-	ofi_perfset_start(&fabric->perf_set, index);
+	struct efa_rdm_fabric *rdm_fabric = (struct efa_rdm_fabric *) domain->fabric;
+	ofi_perfset_start(&rdm_fabric->perf_set, index);
 }
 
 static inline void efa_perfset_end(struct efa_rdm_ep *ep, size_t index)
 {
 	struct efa_domain *domain = efa_rdm_ep_domain(ep);
-	struct efa_fabric *fabric = container_of(domain->util_domain.fabric,
-						 struct efa_fabric,
-						 util_fabric);
-	ofi_perfset_end(&fabric->perf_set, index);
+	struct efa_rdm_fabric *rdm_fabric = (struct efa_rdm_fabric *) domain->fabric;
+	ofi_perfset_end(&rdm_fabric->perf_set, index);
 }
 #else
 #define efa_perfset_start(ep, index) do {} while (0)

--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -904,7 +904,7 @@ int efa_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 		goto err_close_util_av_implicit;
 
 	if (efa_domain->info_type == EFA_INFO_RDM && efa_domain->fabric &&
-	    efa_domain->fabric->shm_fabric) {
+	    ((struct efa_rdm_fabric *) efa_domain->fabric)->shm_fabric) {
 		struct efa_rdm_domain *rdm_domain =
 			(struct efa_rdm_domain *) efa_domain;
 		/*

--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -12,6 +12,7 @@
 #include "efa.h"
 #include "efa_av.h"
 #include "rdm/efa_rdm_domain.h"
+#include "rdm/efa_rdm_fabric.h"
 #include "rdm/efa_rdm_pke_utils.h"
 
 static inline struct efa_conn *efa_av_addr_to_conn_impl(struct util_av *util_av,

--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -29,22 +29,46 @@ const char *efa_perf_counters_str[] = {
 #endif
 
 
+static int efa_fabric_destruct_base(struct efa_fabric *efa_fabric)
+{
+	int ret;
+
+	ret = ofi_fabric_close(&efa_fabric->util_fabric);
+	if (ret)
+		EFA_WARN(FI_LOG_FABRIC,
+			 "Unable to close fabric: %s\n",
+			 fi_strerror(-ret));
+	return ret;
+}
+
 static int efa_fabric_close(fid_t fid)
 {
 	struct efa_fabric *efa_fabric;
 	int ret;
 
 	efa_fabric = container_of(fid, struct efa_fabric, util_fabric.fabric_fid.fid);
-	ret = ofi_fabric_close(&efa_fabric->util_fabric);
-	if (ret) {
-		EFA_WARN(FI_LOG_FABRIC,
-			"Unable to close fabric: %s\n",
-			fi_strerror(-ret));
+	ret = efa_fabric_destruct_base(efa_fabric);
+	if (ret)
 		return ret;
-	}
 
-	if (efa_fabric->shm_fabric) {
-		ret = fi_close(&efa_fabric->shm_fabric->fid);
+	free(efa_fabric);
+	return 0;
+}
+
+static int efa_rdm_fabric_close(fid_t fid)
+{
+	struct efa_rdm_fabric *rdm_fabric;
+	int ret;
+
+	rdm_fabric = container_of(fid, struct efa_rdm_fabric,
+				  efa_fabric.util_fabric.fabric_fid.fid);
+
+	ret = efa_fabric_destruct_base(&rdm_fabric->efa_fabric);
+	if (ret)
+		return ret;
+
+	if (rdm_fabric->shm_fabric) {
+		ret = fi_close(&rdm_fabric->shm_fabric->fid);
 		if (ret) {
 			EFA_WARN(FI_LOG_FABRIC,
 				"Unable to close fabric: %s\n",
@@ -54,53 +78,69 @@ static int efa_fabric_close(fid_t fid)
 	}
 
 #ifdef EFA_PERF_ENABLED
-	ofi_perfset_log(&efa_fabric->perf_set, efa_perf_counters_str);
-	ofi_perfset_close(&efa_fabric->perf_set);
+	ofi_perfset_log(&rdm_fabric->perf_set, efa_perf_counters_str);
+	ofi_perfset_close(&rdm_fabric->perf_set);
 #endif
-	free(efa_fabric);
+	free(rdm_fabric);
 
 	return 0;
+}
+
+static int efa_non_cq_trywait(struct fid *fid)
+{
+	struct util_wait *wait;
+
+	switch (fid->fclass) {
+	case FI_CLASS_EQ:
+		wait = container_of(fid, struct util_eq, eq_fid.fid)->wait;
+		break;
+	case FI_CLASS_CNTR:
+		wait = container_of(fid, struct util_cntr, cntr_fid.fid)->wait;
+		break;
+	case FI_CLASS_WAIT:
+		wait = container_of(fid, struct util_wait, wait_fid.fid);
+		break;
+	default:
+		return -FI_EINVAL;
+	}
+
+	return wait->wait_try(wait);
 }
 
 static int efa_trywait(struct fid_fabric *fabric, struct fid **fids, int count)
 {
 	struct efa_cq *efa_cq;
-	struct util_wait *wait;
 	int ret, i;
 
 	for (i = 0; i < count; i++) {
 		if (fids[i]->fclass == FI_CLASS_CQ) {
-			/* Use EFA-specific CQ trywait */
 			efa_cq = container_of(fids[i], struct efa_cq, util_cq.cq_fid.fid);
-			if (container_of(efa_cq->util_cq.domain, struct efa_domain, util_domain)->info_type == EFA_INFO_RDM) {
-				if (!efa_cq->util_cq.wait)
-					return -FI_EINVAL;
-				ret = efa_cq->util_cq.wait->wait_try(efa_cq->util_cq.wait);
-			} else {
-				ret = efa_cq_trywait(efa_cq);
-			}
-			if (ret)
-				return ret;
+			ret = efa_cq_trywait(efa_cq);
 		} else {
-			/* Use generic util trywait logic for non-CQ types */
-			switch (fids[i]->fclass) {
-			case FI_CLASS_EQ:
-				wait = container_of(fids[i], struct util_eq, eq_fid.fid)->wait;
-				break;
-			case FI_CLASS_CNTR:
-				wait = container_of(fids[i], struct util_cntr, cntr_fid.fid)->wait;
-				break;
-			case FI_CLASS_WAIT:
-				wait = container_of(fids[i], struct util_wait, wait_fid.fid);
-				break;
-			default:
-				return -FI_EINVAL;
-			}
-
-			ret = wait->wait_try(wait);
-			if (ret)
-				return ret;
+			ret = efa_non_cq_trywait(fids[i]);
 		}
+		if (ret)
+			return ret;
+	}
+	return FI_SUCCESS;
+}
+
+static int efa_rdm_trywait(struct fid_fabric *fabric, struct fid **fids, int count)
+{
+	struct efa_cq *efa_cq;
+	int ret, i;
+
+	for (i = 0; i < count; i++) {
+		if (fids[i]->fclass == FI_CLASS_CQ) {
+			efa_cq = container_of(fids[i], struct efa_cq, util_cq.cq_fid.fid);
+			if (!efa_cq->util_cq.wait)
+				return -FI_EINVAL;
+			ret = efa_cq->util_cq.wait->wait_try(efa_cq->util_cq.wait);
+		} else {
+			ret = efa_non_cq_trywait(fids[i]);
+		}
+		if (ret)
+			return ret;
 	}
 	return FI_SUCCESS;
 }
@@ -109,9 +149,9 @@ static int efa_trywait(struct fid_fabric *fabric, struct fid **fids, int count)
  * Feature strings advertised by this build, per fabric.
  *
  * Features are runtime-discoverable flags whose answer may differ
- * between efa-direct and efa (efa-proto) because the two fabrics
+ * between efa-direct and efa (efa-rdm) because the two fabrics
  * exercise different code paths. efa_features_direct contains strings
- * valid for the efa-direct fabric; efa_features_proto contains
+ * valid for the efa-direct fabric; efa_rdm_features contains
  * strings valid for the efa fabric (RDM and DGRAM). A string absent
  * from the matching list returns false.
  *
@@ -122,7 +162,7 @@ static const char * const efa_features_direct[] = {
 	"mixed_hmem_iov",
 };
 
-static const char * const efa_features_proto[] = {
+static const char * const efa_rdm_features[] = {
 	/*
 	 * "mixed_hmem_iov" is not advertised on the efa (RDM) fabric:
 	 * efa_rdm_pke_copy_payload_to_ope() still dispatches copy
@@ -137,8 +177,7 @@ static const char * const efa_features_proto[] = {
 	NULL,
 };
 
-static bool efa_feature_in(const char * const *list, size_t n,
-			   const char *feature)
+static bool efa_feature_in(const char * const *list, size_t n, const char *feature)
 {
 	size_t i;
 
@@ -158,33 +197,37 @@ static bool efa_fabric_feature_query_direct(const char *feature)
 			      ARRAY_SIZE(efa_features_direct), feature);
 }
 
-static bool efa_fabric_feature_query_proto(const char *feature)
+static bool efa_rdm_fabric_feature_query(const char *feature)
 {
-	return efa_feature_in(efa_features_proto,
-			      ARRAY_SIZE(efa_features_proto), feature);
+	return efa_feature_in(efa_rdm_features,
+			      ARRAY_SIZE(efa_rdm_features), feature);
 }
 
 static struct fi_efa_feature_ops efa_feature_ops_direct = {
-	.query = efa_fabric_feature_query_direct,
+	.query = efa_fabric_feature_query_direct
 };
 
-static struct fi_efa_feature_ops efa_feature_ops_proto = {
-	.query = efa_fabric_feature_query_proto,
+static struct fi_efa_feature_ops efa_rdm_feature_ops = {
+	.query = efa_rdm_fabric_feature_query
 };
 
 static int efa_fabric_ops_open(struct fid *fid, const char *ops_name,
 			       uint64_t flags, void **ops, void *context)
 {
-	struct efa_fabric *efa_fabric;
-
 	if (strcmp(ops_name, FI_EFA_FEATURE_OPS) == 0) {
-		efa_fabric = container_of(fid, struct efa_fabric,
-					  util_fabric.fabric_fid.fid);
-		if (strcasecmp(efa_fabric->util_fabric.name,
-			       EFA_DIRECT_FABRIC_NAME) == 0)
-			*ops = &efa_feature_ops_direct;
-		else
-			*ops = &efa_feature_ops_proto;
+		*ops = &efa_feature_ops_direct;
+		return FI_SUCCESS;
+	}
+
+	EFA_WARN(FI_LOG_FABRIC, "Unknown ops name: %s\n", ops_name);
+	return -FI_EINVAL;
+}
+
+static int efa_rdm_fabric_ops_open(struct fid *fid, const char *ops_name,
+				   uint64_t flags, void **ops, void *context)
+{
+	if (strcmp(ops_name, FI_EFA_FEATURE_OPS) == 0) {
+		*ops = &efa_rdm_feature_ops;
 		return FI_SUCCESS;
 	}
 
@@ -197,16 +240,15 @@ static struct fi_ops efa_fi_ops = {
 	.close = efa_fabric_close,
 	.bind = fi_no_bind,
 	.control = fi_no_control,
-	.ops_open = efa_fabric_ops_open,
+	.ops_open = efa_fabric_ops_open
 };
 
-static struct fi_ops_fabric efa_ops_fabric = {
-	.size = sizeof(struct fi_ops_fabric),
-	.domain = efa_rdm_domain_open,
-	.passive_ep = fi_no_passive_ep,
-	.eq_open = ofi_eq_create,
-	.wait_open = ofi_wait_fd_open,
-	.trywait = efa_trywait
+static struct fi_ops efa_rdm_fi_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = efa_rdm_fabric_close,
+	.bind = fi_no_bind,
+	.control = fi_no_control,
+	.ops_open = efa_rdm_fabric_ops_open
 };
 
 static struct fi_ops_fabric efa_ops_fabric_direct = {
@@ -218,16 +260,27 @@ static struct fi_ops_fabric efa_ops_fabric_direct = {
 	.trywait = efa_trywait
 };
 
-int efa_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric_fid,
-	       void *context)
+static struct fi_ops_fabric efa_rdm_ops_fabric = {
+	.size = sizeof(struct fi_ops_fabric),
+	.domain = efa_rdm_domain_open,
+	.passive_ep = fi_no_passive_ep,
+	.eq_open = ofi_eq_create,
+	.wait_open = ofi_wait_fd_open,
+	.trywait = efa_rdm_trywait
+};
+
+/*
+ * Walk efa_util_prov.info, calling ofi_fabric_init for each entry until
+ * something other than -FI_ENODATA is returned. The first matching info
+ * configures @p efa_fabric->util_fabric. Shared by efa_fabric_open_base
+ * and efa_rdm_fabric_open.
+ */
+static int efa_fabric_init_base(struct efa_fabric *efa_fabric,
+				struct fi_fabric_attr *attr,
+				void *context)
 {
 	const struct fi_info *info;
-	struct efa_fabric *efa_fabric;
-	int ret = 0;
-
-	efa_fabric = calloc(1, sizeof(*efa_fabric));
-	if (!efa_fabric)
-		return -FI_ENOMEM;
+	int ret = -FI_ENODATA;
 
 	for (info = efa_util_prov.info; info; info = info->next) {
 		ret = ofi_fabric_init(&efa_prov, info->fabric_attr, attr,
@@ -236,34 +289,78 @@ int efa_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric_fid,
 			break;
 	}
 
+	return ret;
+}
+
+static int efa_fabric_open_base(struct fi_fabric_attr *attr,
+				struct fid_fabric **fabric_fid, void *context)
+{
+	struct efa_fabric *efa_fabric;
+	int ret;
+
+	efa_fabric = calloc(1, sizeof(*efa_fabric));
+	if (!efa_fabric)
+		return -FI_ENOMEM;
+
+	ret = efa_fabric_init_base(efa_fabric, attr, context);
 	if (ret)
 		goto err_free_fabric;
-
-#ifdef EFA_PERF_ENABLED
-	ret = ofi_perfset_create(&efa_prov, &efa_fabric->perf_set,
-				 efa_perf_size, perf_domain, perf_cntr,
-				 perf_flags);
-
-	if (ret)
-		EFA_WARN(FI_LOG_FABRIC,
-			"Error initializing EFA perfset: %s\n",
-			fi_strerror(-ret));
-#endif
-
 
 	*fabric_fid = &efa_fabric->util_fabric.fabric_fid;
 	(*fabric_fid)->fid.fclass = FI_CLASS_FABRIC;
 	(*fabric_fid)->fid.ops = &efa_fi_ops;
-	if (strcasecmp(efa_fabric->util_fabric.name, EFA_DIRECT_FABRIC_NAME) == 0)
-		(*fabric_fid)->ops = &efa_ops_fabric_direct;
-	else
-		(*fabric_fid)->ops = &efa_ops_fabric;
+	(*fabric_fid)->ops = &efa_ops_fabric_direct;
 	(*fabric_fid)->api_version = attr->api_version;
 
 	return 0;
 
 err_free_fabric:
 	free(efa_fabric);
-
 	return ret;
+}
+
+static int efa_rdm_fabric_open(struct fi_fabric_attr *attr,
+			struct fid_fabric **fabric_fid, void *context)
+{
+	struct efa_rdm_fabric *rdm_fabric;
+	int ret;
+
+	rdm_fabric = calloc(1, sizeof(*rdm_fabric));
+	if (!rdm_fabric)
+		return -FI_ENOMEM;
+
+	ret = efa_fabric_init_base(&rdm_fabric->efa_fabric, attr, context);
+	if (ret)
+		goto err_free_fabric;
+
+#ifdef EFA_PERF_ENABLED
+	ret = ofi_perfset_create(&efa_prov, &rdm_fabric->perf_set,
+				 efa_perf_size, perf_domain, perf_cntr,
+				 perf_flags);
+	if (ret)
+		EFA_WARN(FI_LOG_FABRIC,
+			"Error initializing EFA perfset: %s\n",
+			fi_strerror(-ret));
+#endif
+
+	*fabric_fid = &rdm_fabric->efa_fabric.util_fabric.fabric_fid;
+	(*fabric_fid)->fid.fclass = FI_CLASS_FABRIC;
+	(*fabric_fid)->fid.ops = &efa_rdm_fi_ops;
+	(*fabric_fid)->ops = &efa_rdm_ops_fabric;
+	(*fabric_fid)->api_version = attr->api_version;
+
+	return 0;
+
+err_free_fabric:
+	free(rdm_fabric);
+	return ret;
+}
+
+int efa_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric_fid,
+	       void *context)
+{
+	if (attr && attr->name &&
+	    strcasecmp(attr->name, EFA_DIRECT_FABRIC_NAME) == 0)
+		return efa_fabric_open_base(attr, fabric_fid, context);
+	return efa_rdm_fabric_open(attr, fabric_fid, context);
 }

--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -20,26 +20,10 @@
 
 #include "efa_cq.h"
 #include "efa_domain.h"
+#include "efa_fabric_util.h"
 #include "rdm/efa_rdm_domain.h"
+#include "rdm/efa_rdm_fabric.h"
 #include "efa_prov_info.h"
-#ifdef EFA_PERF_ENABLED
-const char *efa_perf_counters_str[] = {
-	EFA_PERF_FOREACH(OFI_STR)
-};
-#endif
-
-
-static int efa_fabric_destruct_base(struct efa_fabric *efa_fabric)
-{
-	int ret;
-
-	ret = ofi_fabric_close(&efa_fabric->util_fabric);
-	if (ret)
-		EFA_WARN(FI_LOG_FABRIC,
-			 "Unable to close fabric: %s\n",
-			 fi_strerror(-ret));
-	return ret;
-}
 
 static int efa_fabric_close(fid_t fid)
 {
@@ -53,58 +37,6 @@ static int efa_fabric_close(fid_t fid)
 
 	free(efa_fabric);
 	return 0;
-}
-
-static int efa_rdm_fabric_close(fid_t fid)
-{
-	struct efa_rdm_fabric *rdm_fabric;
-	int ret;
-
-	rdm_fabric = container_of(fid, struct efa_rdm_fabric,
-				  efa_fabric.util_fabric.fabric_fid.fid);
-
-	ret = efa_fabric_destruct_base(&rdm_fabric->efa_fabric);
-	if (ret)
-		return ret;
-
-	if (rdm_fabric->shm_fabric) {
-		ret = fi_close(&rdm_fabric->shm_fabric->fid);
-		if (ret) {
-			EFA_WARN(FI_LOG_FABRIC,
-				"Unable to close fabric: %s\n",
-				fi_strerror(-ret));
-			return ret;
-		}
-	}
-
-#ifdef EFA_PERF_ENABLED
-	ofi_perfset_log(&rdm_fabric->perf_set, efa_perf_counters_str);
-	ofi_perfset_close(&rdm_fabric->perf_set);
-#endif
-	free(rdm_fabric);
-
-	return 0;
-}
-
-static int efa_non_cq_trywait(struct fid *fid)
-{
-	struct util_wait *wait;
-
-	switch (fid->fclass) {
-	case FI_CLASS_EQ:
-		wait = container_of(fid, struct util_eq, eq_fid.fid)->wait;
-		break;
-	case FI_CLASS_CNTR:
-		wait = container_of(fid, struct util_cntr, cntr_fid.fid)->wait;
-		break;
-	case FI_CLASS_WAIT:
-		wait = container_of(fid, struct util_wait, wait_fid.fid);
-		break;
-	default:
-		return -FI_EINVAL;
-	}
-
-	return wait->wait_try(wait);
 }
 
 static int efa_trywait(struct fid_fabric *fabric, struct fid **fids, int count)
@@ -125,35 +57,13 @@ static int efa_trywait(struct fid_fabric *fabric, struct fid **fids, int count)
 	return FI_SUCCESS;
 }
 
-static int efa_rdm_trywait(struct fid_fabric *fabric, struct fid **fids, int count)
-{
-	struct efa_cq *efa_cq;
-	int ret, i;
-
-	for (i = 0; i < count; i++) {
-		if (fids[i]->fclass == FI_CLASS_CQ) {
-			efa_cq = container_of(fids[i], struct efa_cq, util_cq.cq_fid.fid);
-			if (!efa_cq->util_cq.wait)
-				return -FI_EINVAL;
-			ret = efa_cq->util_cq.wait->wait_try(efa_cq->util_cq.wait);
-		} else {
-			ret = efa_non_cq_trywait(fids[i]);
-		}
-		if (ret)
-			return ret;
-	}
-	return FI_SUCCESS;
-}
-
 /*
- * Feature strings advertised by this build, per fabric.
+ * Feature strings advertised by the efa-direct fabric.
  *
  * Features are runtime-discoverable flags whose answer may differ
  * between efa-direct and efa (efa-rdm) because the two fabrics
- * exercise different code paths. efa_features_direct contains strings
- * valid for the efa-direct fabric; efa_rdm_features contains
- * strings valid for the efa fabric (RDM and DGRAM). A string absent
- * from the matching list returns false.
+ * exercise different code paths. A string absent from this list
+ * returns false.
  *
  * Consumers query by literal string, so renaming is a breaking change;
  * prefer adding new strings over editing existing ones.
@@ -162,53 +72,14 @@ static const char * const efa_features_direct[] = {
 	"mixed_hmem_iov",
 };
 
-static const char * const efa_rdm_features[] = {
-	/*
-	 * "mixed_hmem_iov" is not advertised on the efa (RDM) fabric:
-	 * efa_rdm_pke_copy_payload_to_ope() still dispatches copy
-	 * methods based on desc[0] only, so a multi-iov request mixing
-	 * host and HMEM descriptors can still misbehave even after the
-	 * send-path descriptor scans are in place.
-	 *
-	 * The NULL placeholder keeps this a valid initializer under
-	 * pre-C23 compilers (notably MSVC), which reject an empty {}.
-	 * efa_feature_in() skips NULL entries.
-	 */
-	NULL,
-};
-
-static bool efa_feature_in(const char * const *list, size_t n, const char *feature)
-{
-	size_t i;
-
-	if (!feature)
-		return false;
-
-	for (i = 0; i < n; i++)
-		if (list[i] && strcmp(list[i], feature) == 0)
-			return true;
-
-	return false;
-}
-
 static bool efa_fabric_feature_query_direct(const char *feature)
 {
 	return efa_feature_in(efa_features_direct,
 			      ARRAY_SIZE(efa_features_direct), feature);
 }
 
-static bool efa_rdm_fabric_feature_query(const char *feature)
-{
-	return efa_feature_in(efa_rdm_features,
-			      ARRAY_SIZE(efa_rdm_features), feature);
-}
-
 static struct fi_efa_feature_ops efa_feature_ops_direct = {
 	.query = efa_fabric_feature_query_direct
-};
-
-static struct fi_efa_feature_ops efa_rdm_feature_ops = {
-	.query = efa_rdm_fabric_feature_query
 };
 
 static int efa_fabric_ops_open(struct fid *fid, const char *ops_name,
@@ -216,18 +87,6 @@ static int efa_fabric_ops_open(struct fid *fid, const char *ops_name,
 {
 	if (strcmp(ops_name, FI_EFA_FEATURE_OPS) == 0) {
 		*ops = &efa_feature_ops_direct;
-		return FI_SUCCESS;
-	}
-
-	EFA_WARN(FI_LOG_FABRIC, "Unknown ops name: %s\n", ops_name);
-	return -FI_EINVAL;
-}
-
-static int efa_rdm_fabric_ops_open(struct fid *fid, const char *ops_name,
-				   uint64_t flags, void **ops, void *context)
-{
-	if (strcmp(ops_name, FI_EFA_FEATURE_OPS) == 0) {
-		*ops = &efa_rdm_feature_ops;
 		return FI_SUCCESS;
 	}
 
@@ -243,14 +102,6 @@ static struct fi_ops efa_fi_ops = {
 	.ops_open = efa_fabric_ops_open
 };
 
-static struct fi_ops efa_rdm_fi_ops = {
-	.size = sizeof(struct fi_ops),
-	.close = efa_rdm_fabric_close,
-	.bind = fi_no_bind,
-	.control = fi_no_control,
-	.ops_open = efa_rdm_fabric_ops_open
-};
-
 static struct fi_ops_fabric efa_ops_fabric_direct = {
 	.size = sizeof(struct fi_ops_fabric),
 	.domain = efa_domain_open,
@@ -259,38 +110,6 @@ static struct fi_ops_fabric efa_ops_fabric_direct = {
 	.wait_open = ofi_wait_fd_open,
 	.trywait = efa_trywait
 };
-
-static struct fi_ops_fabric efa_rdm_ops_fabric = {
-	.size = sizeof(struct fi_ops_fabric),
-	.domain = efa_rdm_domain_open,
-	.passive_ep = fi_no_passive_ep,
-	.eq_open = ofi_eq_create,
-	.wait_open = ofi_wait_fd_open,
-	.trywait = efa_rdm_trywait
-};
-
-/*
- * Walk efa_util_prov.info, calling ofi_fabric_init for each entry until
- * something other than -FI_ENODATA is returned. The first matching info
- * configures @p efa_fabric->util_fabric. Shared by efa_fabric_open_base
- * and efa_rdm_fabric_open.
- */
-static int efa_fabric_init_base(struct efa_fabric *efa_fabric,
-				struct fi_fabric_attr *attr,
-				void *context)
-{
-	const struct fi_info *info;
-	int ret = -FI_ENODATA;
-
-	for (info = efa_util_prov.info; info; info = info->next) {
-		ret = ofi_fabric_init(&efa_prov, info->fabric_attr, attr,
-				      &efa_fabric->util_fabric, context);
-		if (ret != -FI_ENODATA)
-			break;
-	}
-
-	return ret;
-}
 
 static int efa_fabric_open_base(struct fi_fabric_attr *attr,
 				struct fid_fabric **fabric_fid, void *context)
@@ -316,43 +135,6 @@ static int efa_fabric_open_base(struct fi_fabric_attr *attr,
 
 err_free_fabric:
 	free(efa_fabric);
-	return ret;
-}
-
-static int efa_rdm_fabric_open(struct fi_fabric_attr *attr,
-			struct fid_fabric **fabric_fid, void *context)
-{
-	struct efa_rdm_fabric *rdm_fabric;
-	int ret;
-
-	rdm_fabric = calloc(1, sizeof(*rdm_fabric));
-	if (!rdm_fabric)
-		return -FI_ENOMEM;
-
-	ret = efa_fabric_init_base(&rdm_fabric->efa_fabric, attr, context);
-	if (ret)
-		goto err_free_fabric;
-
-#ifdef EFA_PERF_ENABLED
-	ret = ofi_perfset_create(&efa_prov, &rdm_fabric->perf_set,
-				 efa_perf_size, perf_domain, perf_cntr,
-				 perf_flags);
-	if (ret)
-		EFA_WARN(FI_LOG_FABRIC,
-			"Error initializing EFA perfset: %s\n",
-			fi_strerror(-ret));
-#endif
-
-	*fabric_fid = &rdm_fabric->efa_fabric.util_fabric.fabric_fid;
-	(*fabric_fid)->fid.fclass = FI_CLASS_FABRIC;
-	(*fabric_fid)->fid.ops = &efa_rdm_fi_ops;
-	(*fabric_fid)->ops = &efa_rdm_ops_fabric;
-	(*fabric_fid)->api_version = attr->api_version;
-
-	return 0;
-
-err_free_fabric:
-	free(rdm_fabric);
 	return ret;
 }
 

--- a/prov/efa/src/efa_fabric_util.c
+++ b/prov/efa/src/efa_fabric_util.c
@@ -1,0 +1,78 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#include <ofi_util.h>
+
+#include "config.h"
+#include "efa.h"
+#include "efa_fabric_util.h"
+
+int efa_fabric_destruct_base(struct efa_fabric *efa_fabric)
+{
+	int ret;
+
+	ret = ofi_fabric_close(&efa_fabric->util_fabric);
+	if (ret)
+		EFA_WARN(FI_LOG_FABRIC,
+			 "Unable to close fabric: %s\n",
+			 fi_strerror(-ret));
+	return ret;
+}
+
+int efa_non_cq_trywait(struct fid *fid)
+{
+	struct util_wait *wait;
+
+	switch (fid->fclass) {
+	case FI_CLASS_EQ:
+		wait = container_of(fid, struct util_eq, eq_fid.fid)->wait;
+		break;
+	case FI_CLASS_CNTR:
+		wait = container_of(fid, struct util_cntr, cntr_fid.fid)->wait;
+		break;
+	case FI_CLASS_WAIT:
+		wait = container_of(fid, struct util_wait, wait_fid.fid);
+		break;
+	default:
+		return -FI_EINVAL;
+	}
+
+	return wait->wait_try(wait);
+}
+
+bool efa_feature_in(const char * const *list, size_t n, const char *feature)
+{
+	size_t i;
+
+	if (!feature)
+		return false;
+
+	for (i = 0; i < n; i++)
+		if (list[i] && strcmp(list[i], feature) == 0)
+			return true;
+
+	return false;
+}
+
+/*
+ * Walk efa_util_prov.info, calling ofi_fabric_init for each entry until
+ * something other than -FI_ENODATA is returned. The first matching info
+ * configures @p efa_fabric->util_fabric. Shared by efa_fabric_open_base
+ * and efa_rdm_fabric_open.
+ */
+int efa_fabric_init_base(struct efa_fabric *efa_fabric,
+			 struct fi_fabric_attr *attr,
+			 void *context)
+{
+	const struct fi_info *info;
+	int ret = -FI_ENODATA;
+
+	for (info = efa_util_prov.info; info; info = info->next) {
+		ret = ofi_fabric_init(&efa_prov, info->fabric_attr, attr,
+				      &efa_fabric->util_fabric, context);
+		if (ret != -FI_ENODATA)
+			break;
+	}
+
+	return ret;
+}

--- a/prov/efa/src/efa_fabric_util.h
+++ b/prov/efa/src/efa_fabric_util.h
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#ifndef EFA_FABRIC_UTIL_H
+#define EFA_FABRIC_UTIL_H
+
+#include "efa.h"
+
+int efa_fabric_init_base(struct efa_fabric *efa_fabric,
+			 struct fi_fabric_attr *attr,
+			 void *context);
+
+int efa_fabric_destruct_base(struct efa_fabric *efa_fabric);
+
+int efa_non_cq_trywait(struct fid *fid);
+
+bool efa_feature_in(const char * const *list, size_t n, const char *feature);
+
+#endif /* EFA_FABRIC_UTIL_H */

--- a/prov/efa/src/rdm/efa_rdm_atomic.c
+++ b/prov/efa/src/rdm/efa_rdm_atomic.c
@@ -4,6 +4,7 @@
 #include <ofi_iov.h>
 #include <ofi_atomic.h>
 #include "efa.h"
+#include "efa_rdm_fabric.h"
 #include "efa_rdm_rma.h"
 #include "efa_cntr.h"
 #include "efa_rdm_atomic.h"

--- a/prov/efa/src/rdm/efa_rdm_domain.c
+++ b/prov/efa/src/rdm/efa_rdm_domain.c
@@ -45,6 +45,7 @@ static struct fi_ops_domain efa_domain_ops_rdm = {
 static int efa_rdm_domain_init(struct efa_rdm_domain *rdm_domain, struct fi_info *info)
 {
 	struct efa_domain *efa_domain = &rdm_domain->efa_domain;
+	struct efa_rdm_fabric *rdm_fabric = (struct efa_rdm_fabric *) efa_domain->fabric;
 	struct fi_info *shm_info = NULL;
 	int err;
 
@@ -67,9 +68,9 @@ static int efa_rdm_domain_init(struct efa_rdm_domain *rdm_domain, struct fi_info
 	efa_domain->util_domain.domain_fid.mr = &efa_rdm_domain_mr_ops;
 
 	efa_shm_info_create(info, &shm_info);
-	if (shm_info && !efa_domain->fabric->shm_fabric) {
+	if (shm_info && !rdm_fabric->shm_fabric) {
 		err = fi_fabric(shm_info->fabric_attr,
-				&efa_domain->fabric->shm_fabric,
+				&rdm_fabric->shm_fabric,
 				efa_domain->fabric->util_fabric.fabric_fid.fid.context);
 		if (err) {
 			EFA_WARN(FI_LOG_DOMAIN, 
@@ -79,8 +80,8 @@ static int efa_rdm_domain_init(struct efa_rdm_domain *rdm_domain, struct fi_info
 		}
 	}
 
-	if (efa_domain->fabric->shm_fabric) {
-		err = fi_domain(efa_domain->fabric->shm_fabric, shm_info,
+	if (rdm_fabric->shm_fabric) {
+		err = fi_domain(rdm_fabric->shm_fabric, shm_info,
 				&rdm_domain->shm_domain, NULL);
 		if (err)
 			return err;

--- a/prov/efa/src/rdm/efa_rdm_domain.c
+++ b/prov/efa/src/rdm/efa_rdm_domain.c
@@ -13,6 +13,7 @@
 #include "efa_rdm_cq.h"
 #include "efa_rdm_atomic.h"
 #include "efa_rdm_domain.h"
+#include "efa_rdm_fabric.h"
 #include "efa_rdm_mr.h"
 
 static int efa_rdm_domain_close(fid_t fid);

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -1203,8 +1203,8 @@ int efa_rdm_ep_close_shm_resources(struct efa_rdm_ep *efa_rdm_ep)
 	struct efa_domain *efa_domain;
 	struct efa_av *efa_av;
 	struct efa_rdm_domain *rdm_domain;
+	struct efa_rdm_fabric *rdm_fabric;
 	struct efa_rdm_cq *efa_rdm_cq;
-
 
 	ret = efa_rdm_ep_close_shm_ep_resources(efa_rdm_ep);
 	if (ret) {
@@ -1244,6 +1244,7 @@ int efa_rdm_ep_close_shm_resources(struct efa_rdm_ep *efa_rdm_ep)
 
 	efa_domain = efa_rdm_ep_domain(efa_rdm_ep);
 	rdm_domain = efa_rdm_ep_rdm_domain(efa_rdm_ep);
+	rdm_fabric = (struct efa_rdm_fabric *) efa_domain->fabric;
 
 	if (rdm_domain->shm_domain) {
 		ret = fi_close(&rdm_domain->shm_domain->fid);
@@ -1254,13 +1255,13 @@ int efa_rdm_ep_close_shm_resources(struct efa_rdm_ep *efa_rdm_ep)
 		rdm_domain->shm_domain = NULL;
 	}
 
-	if (efa_domain->fabric->shm_fabric) {
-		ret = fi_close(&efa_domain->fabric->shm_fabric->fid);
+	if (rdm_fabric->shm_fabric) {
+		ret = fi_close(&rdm_fabric->shm_fabric->fid);
 		if (ret) {
 			EFA_WARN(FI_LOG_EP_CTRL, "Unable to close shm fabric: %s\n", fi_strerror(-ret));
 			retv = ret;
 		}
-		efa_domain->fabric->shm_fabric = NULL;
+		rdm_fabric->shm_fabric = NULL;
 	}
 
 	return retv;

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -4,6 +4,7 @@
 #include "efa.h"
 #include "efa_av.h"
 #include "efa_rdm_ep.h"
+#include "efa_rdm_fabric.h"
 #include "efa_rdm_cq.h"
 #include "efa_rdm_srx.h"
 #include "efa_rdm_rma.h"

--- a/prov/efa/src/rdm/efa_rdm_fabric.c
+++ b/prov/efa/src/rdm/efa_rdm_fabric.c
@@ -1,0 +1,166 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright (c) 2014-2016, Cisco Systems, Inc. All rights reserved. */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#include "config.h"
+
+#include <rdma/fabric.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_errno.h>
+
+#include <ofi_util.h>
+
+#include "efa.h"
+#include "efa_cq.h"
+#include "efa_domain.h"
+#include "efa_fabric_util.h"
+#include "rdm/efa_rdm_domain.h"
+#include "rdm/efa_rdm_fabric.h"
+
+#ifdef EFA_PERF_ENABLED
+static const char *efa_perf_counters_str[] = {
+	EFA_PERF_FOREACH(OFI_STR)
+};
+#endif
+
+static int efa_rdm_fabric_close(fid_t fid)
+{
+	struct efa_rdm_fabric *rdm_fabric;
+	int ret;
+
+	rdm_fabric = container_of(fid, struct efa_rdm_fabric,
+				  efa_fabric.util_fabric.fabric_fid.fid);
+
+	ret = efa_fabric_destruct_base(&rdm_fabric->efa_fabric);
+	if (ret)
+		return ret;
+
+	if (rdm_fabric->shm_fabric) {
+		ret = fi_close(&rdm_fabric->shm_fabric->fid);
+		if (ret) {
+			EFA_WARN(FI_LOG_FABRIC,
+				"Unable to close fabric: %s\n",
+				fi_strerror(-ret));
+			return ret;
+		}
+	}
+
+#ifdef EFA_PERF_ENABLED
+	ofi_perfset_log(&rdm_fabric->perf_set, efa_perf_counters_str);
+	ofi_perfset_close(&rdm_fabric->perf_set);
+#endif
+	free(rdm_fabric);
+
+	return 0;
+}
+
+static const char * const efa_rdm_features[] = {
+	/*
+	 * "mixed_hmem_iov" is not advertised on the efa (RDM) fabric:
+	 * efa_rdm_pke_copy_payload_to_ope() still dispatches copy
+	 * methods based on desc[0] only, so a multi-iov request mixing
+	 * host and HMEM descriptors can still misbehave even after the
+	 * send-path descriptor scans are in place.
+	 *
+	 * The NULL placeholder keeps this a valid initializer under
+	 * pre-C23 compilers (notably MSVC), which reject an empty {}.
+	 * efa_feature_in() skips NULL entries.
+	 */
+	NULL,
+};
+
+static bool efa_rdm_fabric_feature_query(const char *feature)
+{
+	return efa_feature_in(efa_rdm_features,
+			      ARRAY_SIZE(efa_rdm_features), feature);
+}
+
+static struct fi_efa_feature_ops efa_rdm_feature_ops = {
+	.query = efa_rdm_fabric_feature_query
+};
+
+static int efa_rdm_fabric_ops_open(struct fid *fid, const char *ops_name,
+				   uint64_t flags, void **ops, void *context)
+{
+	if (strcmp(ops_name, FI_EFA_FEATURE_OPS) == 0) {
+		*ops = &efa_rdm_feature_ops;
+		return FI_SUCCESS;
+	}
+
+	EFA_WARN(FI_LOG_FABRIC, "Unknown ops name: %s\n", ops_name);
+	return -FI_EINVAL;
+}
+
+static struct fi_ops efa_rdm_fi_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = efa_rdm_fabric_close,
+	.bind = fi_no_bind,
+	.control = fi_no_control,
+	.ops_open = efa_rdm_fabric_ops_open
+};
+
+static int efa_rdm_trywait(struct fid_fabric *fabric, struct fid **fids, int count)
+{
+	struct efa_cq *efa_cq;
+	int ret, i;
+
+	for (i = 0; i < count; i++) {
+		if (fids[i]->fclass == FI_CLASS_CQ) {
+			efa_cq = container_of(fids[i], struct efa_cq, util_cq.cq_fid.fid);
+			if (!efa_cq->util_cq.wait)
+				return -FI_EINVAL;
+			ret = efa_cq->util_cq.wait->wait_try(efa_cq->util_cq.wait);
+		} else {
+			ret = efa_non_cq_trywait(fids[i]);
+		}
+		if (ret)
+			return ret;
+	}
+	return FI_SUCCESS;
+}
+
+static struct fi_ops_fabric efa_rdm_ops_fabric = {
+	.size = sizeof(struct fi_ops_fabric),
+	.domain = efa_rdm_domain_open,
+	.passive_ep = fi_no_passive_ep,
+	.eq_open = ofi_eq_create,
+	.wait_open = ofi_wait_fd_open,
+	.trywait = efa_rdm_trywait
+};
+
+int efa_rdm_fabric_open(struct fi_fabric_attr *attr,
+			struct fid_fabric **fabric_fid, void *context)
+{
+	struct efa_rdm_fabric *rdm_fabric;
+	int ret;
+
+	rdm_fabric = calloc(1, sizeof(*rdm_fabric));
+	if (!rdm_fabric)
+		return -FI_ENOMEM;
+
+	ret = efa_fabric_init_base(&rdm_fabric->efa_fabric, attr, context);
+	if (ret)
+		goto err_free_fabric;
+
+#ifdef EFA_PERF_ENABLED
+	ret = ofi_perfset_create(&efa_prov, &rdm_fabric->perf_set,
+				 efa_perf_size, perf_domain, perf_cntr,
+				 perf_flags);
+	if (ret)
+		EFA_WARN(FI_LOG_FABRIC,
+			"Error initializing EFA perfset: %s\n",
+			fi_strerror(-ret));
+#endif
+
+	*fabric_fid = &rdm_fabric->efa_fabric.util_fabric.fabric_fid;
+	(*fabric_fid)->fid.fclass = FI_CLASS_FABRIC;
+	(*fabric_fid)->fid.ops = &efa_rdm_fi_ops;
+	(*fabric_fid)->ops = &efa_rdm_ops_fabric;
+	(*fabric_fid)->api_version = attr->api_version;
+
+	return 0;
+
+err_free_fabric:
+	free(rdm_fabric);
+	return ret;
+}

--- a/prov/efa/src/rdm/efa_rdm_fabric.h
+++ b/prov/efa/src/rdm/efa_rdm_fabric.h
@@ -1,0 +1,46 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#ifndef EFA_RDM_FABRIC_H
+#define EFA_RDM_FABRIC_H
+
+#include <stddef.h>
+
+#include "efa.h"
+
+/* efa_rdm-fabric extends struct efa_fabric */
+struct efa_rdm_fabric {
+	struct efa_fabric	efa_fabric;
+
+	struct fid_fabric	*shm_fabric;
+#ifdef EFA_PERF_ENABLED
+	struct ofi_perfset	perf_set;
+#endif
+};
+
+_Static_assert(offsetof(struct efa_rdm_fabric, efa_fabric) == 0,
+	       "efa_fabric must be the first member of efa_rdm_fabric for safe casting");
+
+int efa_rdm_fabric_open(struct fi_fabric_attr *attr,
+			struct fid_fabric **fabric_fid, void *context);
+
+#ifdef EFA_PERF_ENABLED
+static inline void efa_perfset_start(struct efa_rdm_ep *ep, size_t index)
+{
+	struct efa_domain *domain = efa_rdm_ep_domain(ep);
+	struct efa_rdm_fabric *rdm_fabric = (struct efa_rdm_fabric *) domain->fabric;
+	ofi_perfset_start(&rdm_fabric->perf_set, index);
+}
+
+static inline void efa_perfset_end(struct efa_rdm_ep *ep, size_t index)
+{
+	struct efa_domain *domain = efa_rdm_ep_domain(ep);
+	struct efa_rdm_fabric *rdm_fabric = (struct efa_rdm_fabric *) domain->fabric;
+	ofi_perfset_end(&rdm_fabric->perf_set, index);
+}
+#else
+#define efa_perfset_start(ep, index) do {} while (0)
+#define efa_perfset_end(ep, index) do {} while (0)
+#endif
+
+#endif /* EFA_RDM_FABRIC_H */

--- a/prov/efa/src/rdm/efa_rdm_msg.c
+++ b/prov/efa/src/rdm/efa_rdm_msg.c
@@ -9,6 +9,7 @@
 #include <ofi_iov.h>
 
 #include "efa.h"
+#include "efa_rdm_fabric.h"
 
 #include "efa_rdm_msg.h"
 #include "efa_rdm_srx.h"

--- a/prov/efa/src/rdm/efa_rdm_rma.c
+++ b/prov/efa/src/rdm/efa_rdm_rma.c
@@ -7,6 +7,7 @@
 #include <ofi_iov.h>
 #include "efa.h"
 
+#include "efa_rdm_fabric.h"
 #include "efa_rdm_msg.h"
 #include "efa_rdm_rma.h"
 #include "efa_rdm_pke_cmd.h"

--- a/prov/efa/test/efa_unit_test_domain.c
+++ b/prov/efa/test/efa_unit_test_domain.c
@@ -502,62 +502,6 @@ void test_efa_domain_open_ops_get_mr_lkey(void **state)
 }
 
 /**
- * @brief Verify query("mixed_hmem_iov") returns true on efa-direct,
- * which is the fabric where this feature is advertised.
- */
-void test_efa_fabric_open_ops_feature_known(void **state)
-{
-    struct efa_resource *resource = *state;
-    struct fi_efa_feature_ops *feat_ops;
-    int ret;
-
-    efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_DIRECT_FABRIC_NAME);
-
-    ret = fi_open_ops(&resource->fabric->fid, FI_EFA_FEATURE_OPS, 0,
-                      (void **) &feat_ops, NULL);
-    assert_int_equal(ret, 0);
-    assert_non_null(feat_ops->query);
-    assert_true(feat_ops->query("mixed_hmem_iov"));
-}
-
-/**
- * @brief Verify query("mixed_hmem_iov") returns false on efa (RDM),
- * which does not currently advertise the feature.
- */
-void test_efa_fabric_open_ops_feature_not_on_proto(void **state)
-{
-    struct efa_resource *resource = *state;
-    struct fi_efa_feature_ops *feat_ops;
-    int ret;
-
-    efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_FABRIC_NAME);
-
-    ret = fi_open_ops(&resource->fabric->fid, FI_EFA_FEATURE_OPS, 0,
-                      (void **) &feat_ops, NULL);
-    assert_int_equal(ret, 0);
-    assert_non_null(feat_ops->query);
-    assert_false(feat_ops->query("mixed_hmem_iov"));
-}
-
-/**
- * @brief Verify query() returns false for an unknown feature and for NULL.
- */
-void test_efa_fabric_open_ops_feature_unknown(void **state)
-{
-    struct efa_resource *resource = *state;
-    struct fi_efa_feature_ops *feat_ops;
-    int ret;
-
-    efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_DIRECT_FABRIC_NAME);
-
-    ret = fi_open_ops(&resource->fabric->fid, FI_EFA_FEATURE_OPS, 0,
-                      (void **) &feat_ops, NULL);
-    assert_int_equal(ret, 0);
-    assert_false(feat_ops->query("no_such_feature"));
-    assert_false(feat_ops->query(NULL));
-}
-
-/**
  * @brief Test cntr_open_ext returns -FI_ENOSYS when efadv_create_comp_cntr is unavailable,
  * or succeeds with mocked efadv_create_comp_cntr.
  */

--- a/prov/efa/test/efa_unit_test_fabric.c
+++ b/prov/efa/test/efa_unit_test_fabric.c
@@ -1,0 +1,59 @@
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#include "efa_unit_tests.h"
+
+/**
+ * @brief Verify query("mixed_hmem_iov") returns true on efa-direct,
+ * which is the fabric where this feature is advertised.
+ */
+void test_efa_fabric_open_ops_feature_known(void **state)
+{
+	struct efa_resource *resource = *state;
+	struct fi_efa_feature_ops *feat_ops;
+	int ret;
+
+	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_DIRECT_FABRIC_NAME);
+
+	ret = fi_open_ops(&resource->fabric->fid, FI_EFA_FEATURE_OPS, 0,
+			  (void **) &feat_ops, NULL);
+	assert_int_equal(ret, 0);
+	assert_non_null(feat_ops->query);
+	assert_true(feat_ops->query("mixed_hmem_iov"));
+}
+
+/**
+ * @brief Verify query("mixed_hmem_iov") returns false on efa (RDM),
+ * which does not currently advertise the feature.
+ */
+void test_efa_fabric_open_ops_feature_not_on_proto(void **state)
+{
+	struct efa_resource *resource = *state;
+	struct fi_efa_feature_ops *feat_ops;
+	int ret;
+
+	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_FABRIC_NAME);
+
+	ret = fi_open_ops(&resource->fabric->fid, FI_EFA_FEATURE_OPS, 0,
+			  (void **) &feat_ops, NULL);
+	assert_int_equal(ret, 0);
+	assert_non_null(feat_ops->query);
+	assert_false(feat_ops->query("mixed_hmem_iov"));
+}
+
+/**
+ * @brief Verify query() returns false for an unknown feature and for NULL.
+ */
+void test_efa_fabric_open_ops_feature_unknown(void **state)
+{
+	struct efa_resource *resource = *state;
+	struct fi_efa_feature_ops *feat_ops;
+	int ret;
+
+	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_DIRECT_FABRIC_NAME);
+
+	ret = fi_open_ops(&resource->fabric->fid, FI_EFA_FEATURE_OPS, 0,
+			  (void **) &feat_ops, NULL);
+	assert_int_equal(ret, 0);
+	assert_false(feat_ops->query("no_such_feature"));
+	assert_false(feat_ops->query(NULL));
+}

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -370,15 +370,18 @@ void test_efa_domain_open_ops_query_cq(void **state);
 void test_efa_domain_open_ops_cq_open_ext(void **state);
 void test_efa_domain_open_ops_cntr_open_ext(void **state);
 void test_efa_domain_open_ops_get_mr_lkey(void **state);
-void test_efa_fabric_open_ops_feature_known(void **state);
-void test_efa_fabric_open_ops_feature_not_on_proto(void **state);
-void test_efa_fabric_open_ops_feature_unknown(void **state);
 void test_efa_domain_direct_mr_ops(void **state);
 void test_efa_domain_dgram_mr_ops(void **state);
 void test_efa_domain_open_installs_base_domain_ops_efa_direct(void **state);
 void test_efa_domain_open_installs_base_domain_ops_dgram(void **state);
 void test_efa_domain_gda_ops_rejected_for_dgram(void **state);
 /* end efa_unit_test_domain.c */
+
+/* begin efa_unit_test_fabric.c */
+void test_efa_fabric_open_ops_feature_known(void **state);
+void test_efa_fabric_open_ops_feature_not_on_proto(void **state);
+void test_efa_fabric_open_ops_feature_unknown(void **state);
+/* end efa_unit_test_fabric.c */
 
 /* begin efa_unit_test_rdm_domain.c */
 void test_efa_domain_info_type_efa_rdm(void **state);


### PR DESCRIPTION
This patchset does some repo cleanup in preparation for the actual changes.

The actual changes are then that we split the single fabric component into an efa-direct and an efa-rdm protocol components.

Finally, we split these into separate files.