### PR TITLE
fabtests/pytest: Mark multi_ep_stress tests as functional

### DIFF
--- a/fabtests/pytest/efa/test_multi_ep_stress.py
+++ b/fabtests/pytest/efa/test_multi_ep_stress.py
@@ -1,6 +1,7 @@
 import pytest
 from common import ClientServerTest
 
+@pytest.mark.functional
 @pytest.mark.parametrize("remove_av", [True, False])
 def test_multi_ep_stress_standard(cmdline_args, remove_av):
     cmd = f"fi_efa_multi_ep_stress"
@@ -9,6 +10,7 @@ def test_multi_ep_stress_standard(cmdline_args, remove_av):
     test = ClientServerTest(cmdline_args, cmd, message_size=1024, fabric="efa", additional_env="FI_EFA_ENABLE_SHM_TRANSFER=0")
     test.run()
 
+@pytest.mark.functional
 @pytest.mark.parametrize("remove_av", [True, False])
 def test_multi_ep_stress_tagged(cmdline_args, remove_av):
     cmd = f"fi_efa_multi_ep_stress --op-type tagged"
@@ -17,6 +19,7 @@ def test_multi_ep_stress_tagged(cmdline_args, remove_av):
     test = ClientServerTest(cmdline_args, cmd, message_size=1024, fabric="efa", additional_env="FI_EFA_ENABLE_SHM_TRANSFER=0")
     test.run()
 
+@pytest.mark.functional
 @pytest.mark.parametrize("remove_av", [True, False])
 def test_multi_ep_stress_writedata(cmdline_args, remove_av):
     cmd = f"fi_efa_multi_ep_stress --op-type writedata"
@@ -25,6 +28,7 @@ def test_multi_ep_stress_writedata(cmdline_args, remove_av):
     test = ClientServerTest(cmdline_args, cmd, message_size=1024, fabric="efa", additional_env="FI_EFA_ENABLE_SHM_TRANSFER=0")
     test.run()
 
+@pytest.mark.functional
 @pytest.mark.parametrize("remove_av", [True, False])
 def test_multi_ep_stress_multi_receivers(cmdline_args, remove_av):
     cmd = f"fi_efa_multi_ep_stress --receiver-workers 4"
@@ -33,7 +37,7 @@ def test_multi_ep_stress_multi_receivers(cmdline_args, remove_av):
     test = ClientServerTest(cmdline_args, cmd, message_size=1024, fabric="efa", additional_env="FI_EFA_ENABLE_SHM_TRANSFER=0")
     test.run()
 
-
+@pytest.mark.functional
 @pytest.mark.parametrize("remove_av", [True, False])
 def test_multi_ep_stress_multi_senders(cmdline_args, remove_av):
     cmd = f"fi_efa_multi_ep_stress --sender-workers 10"
@@ -42,6 +46,7 @@ def test_multi_ep_stress_multi_senders(cmdline_args, remove_av):
     test = ClientServerTest(cmdline_args, cmd, message_size=1024, fabric="efa", additional_env="FI_EFA_ENABLE_SHM_TRANSFER=0")
     test.run()
 
+@pytest.mark.functional
 @pytest.mark.parametrize("remove_av", [True, False])
 def test_multi_ep_stress_shared_cq(cmdline_args, remove_av):
     cmd = f"fi_efa_multi_ep_stress --receiver-workers 4 --shared-cq"
@@ -50,6 +55,7 @@ def test_multi_ep_stress_shared_cq(cmdline_args, remove_av):
     test = ClientServerTest(cmdline_args, cmd, message_size=1024, fabric="efa", additional_env="FI_EFA_ENABLE_SHM_TRANSFER=0")
     test.run()
 
+@pytest.mark.functional
 @pytest.mark.parametrize("remove_av", [True, False])
 def test_multi_ep_stress_shared_av(cmdline_args, remove_av):
     cmd = f"fi_efa_multi_ep_stress --sender-workers 8 --receiver-workers 2 --shared-av"
@@ -58,6 +64,7 @@ def test_multi_ep_stress_shared_av(cmdline_args, remove_av):
     test = ClientServerTest(cmdline_args, cmd, message_size=1024, fabric="efa", additional_env="FI_EFA_ENABLE_SHM_TRANSFER=0")
     test.run()
 
+@pytest.mark.functional
 @pytest.mark.parametrize("remove_av", [True, False])
 def test_multi_ep_stress_shared_av_and_cq(cmdline_args, remove_av):
     cmd = f"fi_efa_multi_ep_stress --sender-workers 8 --receiver-workers 2 --shared-av --shared-cq"
@@ -66,6 +73,7 @@ def test_multi_ep_stress_shared_av_and_cq(cmdline_args, remove_av):
     test = ClientServerTest(cmdline_args, cmd, message_size=1024, fabric="efa", additional_env="FI_EFA_ENABLE_SHM_TRANSFER=0")
     test.run()
 
+@pytest.mark.functional
 @pytest.mark.parametrize("remove_av", [True, False])
 def test_multi_ep_stress_transient_client(cmdline_args, remove_av):
     cmd = f"fi_efa_multi_ep_stress --sender-ep-cycles 5"
@@ -74,6 +82,7 @@ def test_multi_ep_stress_transient_client(cmdline_args, remove_av):
     test = ClientServerTest(cmdline_args, cmd, message_size=1024, fabric="efa", additional_env="FI_EFA_ENABLE_SHM_TRANSFER=0")
     test.run()
 
+@pytest.mark.functional
 @pytest.mark.parametrize("remove_av", [True, False])
 @pytest.mark.parametrize("configuration", [{"sender_workers": 2, "receiver_workers": 4, "sender_ep_cycles": 10, "receiver_ep_cycles": 20},
                                            {"sender_workers": 4, "receiver_workers": 2, "sender_ep_cycles": 20, "receiver_ep_cycles": 10},


### PR DESCRIPTION
Currently tests are not marked as functional, therefore they are not being picked up by CI. Adding the mark.