### PR TITLE
fabtests/efa: Add FI_THREAD_COMPLETION as an option to multi_ep_stress 

### DIFF
--- a/fabtests/prov/efa/src/multi_ep_stress.c
+++ b/fabtests/prov/efa/src/multi_ep_stress.c
@@ -342,6 +342,12 @@ static int setup_endpoint(struct worker_context *ctx, uint64_t total_ops)
 		goto error;
 	}
 
+	ret = fi_ep_bind(ctx->ep, &eq->fid, 0);
+	if (ret) {
+		FT_PRINTERR("fi_ep_bind(eq)", ret);
+		goto error;
+	}
+
 	ret = fi_enable(ctx->ep);
 	if (ret) {
 		FT_PRINTERR("fi_enable", ret);
@@ -455,6 +461,18 @@ static int wait_for_comp(struct fid_cq *cq, int num_completions)
 				fi_cq_strerror(cq, err_entry.prov_errno,
 					       err_entry.err_data, NULL, 0));
 		} else if (timeout > 0) {
+			/* Check EQ for EFA internal packet errors */
+			struct fi_eq_err_entry eq_err = {0};
+			ret = fi_eq_read(eq, NULL, NULL, 0, 0);
+			if (ret == -FI_EAVAIL) {
+				fi_eq_readerr(eq, &eq_err, 0);
+				fprintf(stderr,
+					"EQ error: %s (prov_errno: %d)\n",
+					fi_strerror(eq_err.err),
+					eq_err.prov_errno);
+				completed = -eq_err.err;
+				break;
+			}
 			clock_gettime(CLOCK_MONOTONIC, &b);
 			if (b.tv_sec - a.tv_sec >= timeout) {
 				fprintf(stderr,
@@ -481,7 +499,7 @@ static void *run_sender_worker(void *arg)
 {
 	struct worker_context *ctx = (struct worker_context*) arg;
 	struct ep_message msg;
-	int ret;
+	int ret, comp_ret;
 	struct random_data random_data;
 	const uint64_t total_ops = ctx->num_peers * topts.msgs_per_sender;
 	const uint64_t msg_per_ep_lifecyle = total_ops / topts.sender_ep_recycling;
@@ -658,7 +676,15 @@ static void *run_sender_worker(void *arg)
 			if (ret == 0) {
 				break;
 			} else if (ret == -FI_EAGAIN) {
-				if (wait_for_comp(ctx->cq, 1) == 0) {
+				comp_ret = wait_for_comp(ctx->cq, 1);
+				if (comp_ret < 0) {
+					fprintf(stderr,
+						"Sender %d: peer endpoint closed, exiting now\n",
+						ctx->worker_id);
+					ret = 0;
+					goto out;
+				}
+				if (comp_ret == 0) {
 					fprintf(stderr,
 						"Sender %d: operation has stuck\n",
 						ctx->worker_id);
@@ -691,7 +717,15 @@ static void *run_sender_worker(void *arg)
 					"completions\n",
 					ctx->worker_id, cycle);
 				uint64_t ops_pending =  ops_total_in_this_cycle - ops_completed_in_this_cycle;
-				ops_completed += wait_for_comp(ctx->cq, ops_pending);
+				comp_ret = wait_for_comp(ctx->cq, ops_pending);
+				if (comp_ret < 0) {
+					fprintf(stderr,
+						"Sender %d: peer endpoint closed, exiting now\n",
+						ctx->worker_id);
+					ret = 0;
+					goto out;
+				}
+				ops_completed += comp_ret;
 			} else {
 				printf("Sender %u EP cycle %d: Not waiting for "
 					"completions\n",

--- a/fabtests/prov/efa/src/multi_ep_stress.c
+++ b/fabtests/prov/efa/src/multi_ep_stress.c
@@ -78,6 +78,7 @@ static struct option test_long_opts[] = {
 	{"shared-cq", no_argument, NULL, OPT_SHARED_CQ},
 	{"op-type", required_argument, NULL, OPT_OP_TYPE},
 	{"random-seed", required_argument, NULL, OPT_RANDOM_SEED},
+	{"threading", required_argument, NULL, LONG_OPT_THREADING},
 	{0, 0, 0, 0}};
 
 // RMA information
@@ -1416,6 +1417,8 @@ static int parse_test_opts(int argc, char **argv)
 			print_test_usage();
 			return -2;
 		default:
+			if (!ft_parse_long_opts(op, optarg))
+				continue;
 			ft_parse_addr_opts(op, optarg, &opts);
 			ft_parseinfo(op, optarg, hints, &opts);
 			ft_parsecsopts(op, optarg, &opts);
@@ -1444,7 +1447,14 @@ int main(int argc, char **argv)
 		goto out;
 
 	// Set up hints
-	opts.threading = FI_THREAD_SAFE;
+	if (!opts.threading)
+		opts.threading = FI_THREAD_SAFE;
+	if (opts.threading == FI_THREAD_COMPLETION && topts.shared_cq) {
+		fprintf(stderr, "--shared-cq is incompatible with "
+			"--threading completion\n");
+		ret = -1;
+		goto out;
+	}
 	hints->caps = FI_MSG | FI_RMA;
 	hints->mode = FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->mr_mode = FI_MR_ALLOCATED | FI_MR_LOCAL |

--- a/fabtests/pytest/efa/test_multi_ep_stress.py
+++ b/fabtests/pytest/efa/test_multi_ep_stress.py
@@ -89,3 +89,18 @@ def test_multi_ep_stress_multi_and_transient_sender_receiver(cmdline_args, remov
         cmd += " --remove-av"
     test = ClientServerTest(cmdline_args, cmd, message_size=1024, fabric="efa", additional_env="FI_EFA_ENABLE_SHM_TRANSFER=0")
     test.run()
+
+@pytest.mark.functional
+@pytest.mark.parametrize("op_type", ["untagged", "tagged", "writedata"])
+def test_multi_ep_stress_thread_completion_shared_av(cmdline_args, op_type):
+    # Test concurrent fi_send/fi_tsend/fi_writedata vs fi_av_insert, fi_cq_read vs fi_av_insert across worker threads under FI_THREAD_COMPLETION
+    cmd = f"fi_efa_multi_ep_stress --threading completion --shared-av --sender-workers 4 --receiver-workers 4 --op-type {op_type}"
+    test = ClientServerTest(cmdline_args, cmd, message_size=1024, fabric="efa", additional_env="FI_EFA_ENABLE_SHM_TRANSFER=0")
+    test.run()
+
+@pytest.mark.functional
+def test_multi_ep_stress_thread_completion_shared_av_ep_recycling(cmdline_args):
+    # With EP recycling, one thread could call fi_enable while other thread fi_av_insert under FI_THREAD_COMPLETION
+    cmd = f"fi_efa_multi_ep_stress --threading completion --shared-av --sender-workers 4 --receiver-workers 4 --sender-ep-cycles 5 --receiver-ep-cycles 5"
+    test = ClientServerTest(cmdline_args, cmd, message_size=1024, fabric="efa", additional_env="FI_EFA_ENABLE_SHM_TRANSFER=0")
+    test.run()


### PR DESCRIPTION
multi_ep_stress supports FI_THREAD_COMPLETION since it creates endpoints with its own CQ and one thread per EP on the same domain.
Add FI_THREAD_COMPLETION tests with shared av to exercise concurrent fi_send/fi_tsend/fi_writedata vs fi_av_insert, fi_cq_read vs fi_av_insert, fi_enable vs fi_av_insert across worker threads.