### PR TITLE
configure, contrib/aws, prov/efa: enable coverage reports on PRs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -218,8 +218,6 @@ AS_IF([test x"$enable_coverage" != x"no"],
                        LDFLAGS="$save_LDFLAGS"
                        AC_MSG_ERROR([--coverage requested but compiler/linker support not found.])])])
 
-AM_CONDITIONAL([ENABLE_COVERAGE], [test x"$enable_coverage" != x"no"])
-
 dnl Checks for header files.
 dnl This is only necessary for Autoconf <v2.70.
 m4_version_prereq([2.70],

--- a/contrib/aws/Jenkinsfile
+++ b/contrib/aws/Jenkinsfile
@@ -11,6 +11,9 @@ import groovy.transform.Field
 @Field def venv_path = "/tmp/venv"
 @Field def portafiducia_path = "/tmp/PortaFiducia"
 @Field def subspace_nightly_tests_path = "/tmp/SubspaceNightlyTests"
+// Must match GCOVR_VERSION in subspace-nightly-tests so the agent-side merge
+// uses the same gcovr that generated the per-cluster reports on the clusters.
+@Field def gcovr_version = "8.6"
 @Field def samwise_test_runner_path = "/tmp/SamwiseTestRunner"
 @Field def samwise_test_schema_path = "/tmp/SamwiseTestSchema"
 
@@ -217,6 +220,68 @@ def check_for_relevant_changes() {
     }
 }
 
+def record_coverage() {
+    /*
+     * Publish EFA unit-test coverage with the Jenkins Coverage plugin.
+     *
+     * Coverage generation lives on the PortaFiducia side: each test stage builds
+     * libfabric with --enable-coverage, runs the EFA unit tests, then runs gcovr
+     * on the cluster to emit Cobertura XML scoped to prov/efa/src. Here we only
+     * consume the reports.
+     *
+     * Contract with PortaFiducia: it delivers one tarball per cluster into
+     * outputs/, named 'coverage_<cluster>.tar.gz', each containing the cluster's
+     * 'coverage-<build>[-gtest].xml' reports. The report names encode the PR and
+     * build flags but NOT the cluster, so reports from different clusters share
+     * names — we extract each tarball into its own directory to avoid name conflicts.
+     */
+    def tarballs = sh(
+        script: "find outputs -name 'coverage_*.tar.gz' 2>/dev/null",
+        returnStdout: true
+    ).trim()
+    if (!tarballs) {
+        echo "No coverage tarballs found under outputs/; skipping coverage report."
+        return
+    }
+    sh '''
+        for f in outputs/coverage_*.tar.gz; do
+            d="${f%.tar.gz}"
+            mkdir -p "$d"
+            tar xzf "$f" -C "$d"
+        done
+    '''
+    // Merge all per-cluster reports into a single Cobertura file.
+    def merged = "coverage-merged.xml"
+    def merge_script = sh(
+        script: "find ${subspace_nightly_tests_path} -name merge_coverage.py 2>/dev/null | head -1",
+        returnStdout: true
+    ).trim()
+    if (!merge_script) {
+        echo "merge_coverage.py not found under ${subspace_nightly_tests_path}; skipping coverage report."
+        return
+    }
+    sh """
+        . ${venv_path}/bin/activate
+        python3 -m pip install 'gcovr==${gcovr_version}' || true
+        python3 ${merge_script} outputs ${merged} || true
+    """
+    if (!fileExists(merged)) {
+        echo "No merged coverage report produced; skipping coverage report."
+        return
+    }
+    // Delta coverage vs. the PR target branch (needs the Git Forensics plugin).
+    discoverGitReferenceBuild(targetBranch: env.CHANGE_TARGET ?: 'main')
+    // Informational only for now: no qualityGates, 
+    // Add a gate here later, e.g.
+    // qualityGates: [[threshold: 80.0, metric: 'LINE', baseline: 'MODIFIED_LINES', unstable: true]]
+    recordCoverage(
+        tools: [[parser: 'COBERTURA', pattern: merged]],
+        id: 'efa-unit-tests',
+        name: 'EFA Unit Test Coverage',
+        sourceCodeRetention: 'EVERY_BUILD'
+    )
+}
+
 def post_build_actions() {
     if (env.SKIP_TESTS == 'true') {
         return
@@ -225,6 +290,7 @@ def post_build_actions() {
     sh 'find outputs -name "*.xml" | xargs du -shc'
     junit testResults: 'outputs/**/*.xml', keepLongStdio: false
     archiveArtifacts artifacts: 'outputs/**/*.*'
+    record_coverage()
     // Try To Cleanup Resources
     def regions = ["us-east-1", "eu-north-1", "us-west-2", "ap-southeast-4"]
     def cluster_name_prefix = get_cluster_name_prefix(env.BUILD_TAG)

--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -269,28 +269,6 @@ endif HAVE_EFADV_CREATE_COMP_CNTR
 
 prov_efa_test_efa_unit_test_LIBS = $(efa_LIBS) $(linkback)
 
-if ENABLE_COVERAGE
-coverage:
-	lcov --capture --directory $(top_builddir)/prov/efa/src \
-	     --output-file coverage.info --no-external
-	lcov --remove coverage.info '*/test/*' '*/src/.libs/*' \
-	     --output-file coverage.info
-	lcov --extract coverage.info '*/prov/efa/src/*' \
-	     --output-file coverage.info
-	find $(top_builddir) -name '*.gcno' -delete
-	find $(top_builddir) -name '*.gcda' -delete
-	find $(top_builddir) -name '*.gcov' -delete
-	genhtml coverage.info --output-directory coverage_report
-	@echo "Coverage report: coverage_report/index.html"
-
-coverage-clean:
-	find $(top_builddir) -name '*.gcda' -delete
-	find $(top_builddir) -name '*.gcno' -delete
-	rm -rf coverage.info coverage_report
-
-.PHONY: coverage coverage-clean
-endif ENABLE_COVERAGE
-
 endif ENABLE_EFA_UNIT_TEST
 
 if ENABLE_EFA_GTEST


### PR DESCRIPTION
This PR allows the Jenkinsfile to aggregate the coverage reports from the prov/efa PRCI, and generate an informative (non-blocking) comment on PRs outlining the overall/patch/branch coverage information.