### PR TITLE
[v2.6.x]prov/efa/cntr: Remove counter locking from efa-direct path

### DIFF
--- a/prov/efa/src/efa_cntr.c
+++ b/prov/efa/src/efa_cntr.c
@@ -17,12 +17,8 @@ int efa_cntr_wait(struct fid_cntr *cntr_fid, uint64_t threshold, int timeout)
 	int tryid = 0;
 	int waitim = 1;
 	static const int waitim_max = 1000; /* cap at 1ms */
-	struct efa_domain *domain;
 
 	cntr = container_of(cntr_fid, struct util_cntr, cntr_fid);
-	domain = container_of(cntr->domain, struct efa_domain, util_domain);
-
-	ofi_genlock_lock(&domain->srx_lock);
 
 	assert(cntr->wait);
 	errcnt = ofi_atomic_get64(&cntr->err);
@@ -30,22 +26,16 @@ int efa_cntr_wait(struct fid_cntr *cntr_fid, uint64_t threshold, int timeout)
 
 	for (tryid = 0; tryid < numtry; ++tryid) {
 		cntr->progress(cntr);
-		if (threshold <= ofi_atomic_get64(&cntr->cnt)) {
-		        ret = FI_SUCCESS;
-			goto unlock;
-		}
+		if (threshold <= ofi_atomic_get64(&cntr->cnt))
+			return FI_SUCCESS;
 
-		if (errcnt != ofi_atomic_get64(&cntr->err)) {
-			ret = -FI_EAVAIL;
-			goto unlock;
-		}
+		if (errcnt != ofi_atomic_get64(&cntr->err))
+			return -FI_EAVAIL;
 
 		if (timeout >= 0) {
 			timeout -= (int)(ofi_gettime_ms() - start);
-			if (timeout <= 0) {
-				ret = -FI_ETIMEDOUT;
-				goto unlock;
-			}
+			if (timeout <= 0)
+				return -FI_ETIMEDOUT;
 		} else {
 			tryid = 0;
 		}
@@ -58,47 +48,13 @@ int efa_cntr_wait(struct fid_cntr *cntr_fid, uint64_t threshold, int timeout)
 			waitim *= 2;
 	}
 
-unlock:
-	ofi_genlock_unlock(&domain->srx_lock);
-	return ret;
-}
-
-uint64_t efa_cntr_read(struct fid_cntr *cntr_fid)
-{
-	struct efa_domain *domain;
-	struct util_cntr *util_cntr;
-	uint64_t ret;
-
-	util_cntr = container_of(cntr_fid, struct util_cntr, cntr_fid);
-	domain = container_of(util_cntr->domain, struct efa_domain, util_domain);
-
-	ofi_genlock_lock(&domain->srx_lock);
-	ret = ofi_cntr_read(cntr_fid);
-	ofi_genlock_unlock(&domain->srx_lock);
-
-	return ret;
-}
-
-uint64_t efa_cntr_readerr(struct fid_cntr *cntr_fid)
-{
-	struct efa_domain *domain;
-	struct util_cntr *util_cntr;
-	uint64_t ret;
-
-	util_cntr = container_of(cntr_fid, struct util_cntr, cntr_fid);
-	domain = container_of(util_cntr->domain, struct efa_domain, util_domain);
-
-	ofi_genlock_lock(&domain->srx_lock);
-	ret = ofi_cntr_readerr(cntr_fid);
-	ofi_genlock_unlock(&domain->srx_lock);
-
 	return ret;
 }
 
 static struct fi_ops_cntr efa_cntr_ops = {
 	.size = sizeof(struct fi_ops_cntr),
-	.read = efa_cntr_read,
-	.readerr = efa_cntr_readerr,
+	.read = ofi_cntr_read,
+	.readerr = ofi_cntr_readerr,
 	.add = ofi_cntr_add,
 	.adderr = ofi_cntr_adderr,
 	.set = ofi_cntr_set,

--- a/prov/efa/src/efa_cntr.h
+++ b/prov/efa/src/efa_cntr.h
@@ -32,10 +32,6 @@ void efa_cntr_destruct(struct efa_cntr *cntr);
 
 void efa_cntr_progress_ibv_cq_poll_list(struct efa_cntr *efa_cntr);
 
-uint64_t efa_cntr_read(struct fid_cntr *cntr_fid);
-
-uint64_t efa_cntr_readerr(struct fid_cntr *cntr_fid);
-
 int efa_cntr_wait(struct fid_cntr *cntr_fid, uint64_t threshold, int timeout);
 
 void efa_cntr_report_tx_completion(struct util_ep *ep, uint64_t flags);

--- a/prov/efa/src/rdm/efa_rdm_cntr.c
+++ b/prov/efa/src/rdm/efa_rdm_cntr.c
@@ -15,6 +15,7 @@ static uint64_t efa_rdm_cntr_read(struct fid_cntr *cntr_fid)
 {
 	struct efa_rdm_cntr *efa_rdm_cntr;
 	struct efa_domain *domain;
+	uint64_t ret;
 
 	efa_rdm_cntr = container_of(cntr_fid, struct efa_rdm_cntr, efa_cntr.util_cntr.cntr_fid);
 	domain = container_of(efa_rdm_cntr->efa_cntr.util_cntr.domain, struct efa_domain, util_domain);
@@ -23,15 +24,24 @@ static uint64_t efa_rdm_cntr_read(struct fid_cntr *cntr_fid)
 	ofi_genlock_lock(&domain->srx_lock);
 	if (efa_rdm_cntr->shm_cntr)
 		fi_cntr_read(efa_rdm_cntr->shm_cntr);
+
+	/*
+	 * keep srx_lock for ofi_cntr_read because the registered
+	 * progress callback (efa_rdm_cntr_progress) drives ibv_cq polling,
+	 * and the CQ poll path calls efa_rdm_ep_get_peer_explicit which
+	 * asserts srx_lock is held.
+	 */
+	ret = ofi_cntr_read(cntr_fid);
 	ofi_genlock_unlock(&domain->srx_lock);
 
-	return efa_cntr_read(cntr_fid);
+	return ret;
 }
 
 static uint64_t efa_rdm_cntr_readerr(struct fid_cntr *cntr_fid)
 {
 	struct efa_rdm_cntr *efa_rdm_cntr;
 	struct efa_domain *domain;
+	uint64_t ret;
 
 	efa_rdm_cntr = container_of(cntr_fid, struct efa_rdm_cntr, efa_cntr.util_cntr.cntr_fid);
 	domain = container_of(efa_rdm_cntr->efa_cntr.util_cntr.domain, struct efa_domain, util_domain);
@@ -39,9 +49,17 @@ static uint64_t efa_rdm_cntr_readerr(struct fid_cntr *cntr_fid)
 	ofi_genlock_lock(&domain->srx_lock);
 	if (efa_rdm_cntr->shm_cntr)
 		fi_cntr_read(efa_rdm_cntr->shm_cntr);
+
+	/*
+	 * keep srx_lock for ofi_cntr_readerr because the registered
+	 * progress callback (efa_rdm_cntr_progress) drives ibv_cq polling,
+	 * and the CQ poll path calls efa_rdm_ep_get_peer_explicit which
+	 * asserts srx_lock is held.
+	 */
+	ret = ofi_cntr_readerr(cntr_fid);
 	ofi_genlock_unlock(&domain->srx_lock);
 
-	return efa_cntr_readerr(cntr_fid);
+	return ret;
 }
 
 static struct fi_ops_cntr efa_rdm_cntr_ops = {


### PR DESCRIPTION
Because efa-direct only uses atomic lock operations, it no longer needs locking and can be switched over to the generic ofi counter read functions. The efa-rdm path still needs to take locks, but will then call the ofi counter read apis directly, since the efa-direct read functions are no longer needed.


(cherry picked from commit 31d3114b1effa2a0218956f729b56998e05200eb)