### PR TITLE
prov/cxi: Extend timeout for sw_max_recv msg test

### DIFF
--- a/prov/cxi/test/fork.c
+++ b/prov/cxi/test/fork.c
@@ -375,12 +375,14 @@ static void child_memory_free_runner(bool huge_page, int thread_count)
  * MR cache lock if threads are forking while other threads are doing memory
  * registration.
  */
-Test(fork, child_memory_free_system_page_size)
+Test(fork, child_memory_free_system_page_size,
+     .timeout = CXIT_DEFAULT_TIMEOUT + 10)
 {
 	child_memory_free_runner(false, 16);
 }
 
-Test(fork, child_memory_free_huge_page_size)
+Test(fork, child_memory_free_huge_page_size,
+     .timeout = CXIT_DEFAULT_TIMEOUT + 10)
 {
 	child_memory_free_runner(true, 16);
 }


### PR DESCRIPTION
A few additional fork tests were identified which take just over the default timeout to complete.