### PR TITLE
fabtests/pytest: remove unstable mark

### DIFF
--- a/fabtests/pytest/pytest.ini
+++ b/fabtests/pytest/pytest.ini
@@ -12,7 +12,6 @@ markers =
     neuron_memory: testing with neuron device memory
     rocr_memory: testing with ROCr device memory
     serial: test must be run in seria mode
-    unstable: test is unstable and only run when the marker is specified.
     pr_ci: test is included in the PR CI suite
     message_sizes: decorator specifying default and pr_ci message size lists
     fabric: decorator declaring the set of libfabric fabric values a test runs on


### PR DESCRIPTION
Removing `unstable` mark from pytest.ini as it is not used any more.