### PR TITLE
src, prov/lnx; Fix LNX DL build and DL build cleanup

### DIFF
--- a/prov/lnx/Makefile.include
+++ b/prov/lnx/Makefile.include
@@ -47,14 +47,24 @@ _lnx_headers = \
 
 if HAVE_LNX_DL
 pkglib_LTLIBRARIES += liblnx-fi.la
-liblnx_fi_la_SOURCES = $(_lnx_files) $(_lnx_headers)
-liblnx_fi_la_LIBADD = $(linkback) $(lnx_LIBS)
-liblnx_fi_la_LDFLAGS = -module -avoid-version -shared -export-dynamic
+liblnx_fi_la_SOURCES = $(_lnx_files) $(_lnx_headers) $(common_srcs)
+liblnx_fi_la_CPPFLAGS = 				\
+	-I$(top_srcdir)/include				\
+	-I$(top_srcdir)/prov/lnx/include		\
+	$(AM_CPPFLAGS) $(lnx_CPPFLAGS)
+liblnx_fi_la_LIBADD = $(top_builddir)/src/libfabric.la $(linkback) $(lnx_LIBS)
+libverbs_fi_la_LDFLAGS =				\
+	-module -avoid-version -shared -export-dynamic	\
+	$(lnx_LDFLAGS)
 liblnx_fi_la_DEPENDENCIES = $(linkback)
-else
+else !HAVE_LNX_DL
 src_libfabric_la_SOURCES += $(_lnx_files) $(_lnx_headers)
-src_libfabric_la_CPPFLAGS += -I$(top_srcdir)/prov/lnx/include
-endif
+src_libfabric_la_CPPFLAGS += 				\
+	-I$(top_srcdir)/prov/lnx/include		\
+	$(lnx_CPPFLAGS)
+src_libfabric_la_LDFLAGS += $(lnx_LDFLAGS)
+src_libfabric_la_LIBADD += $(lnx_LIBS)
+endif !HAVE_LNX_DL
 
 prov_install_man_pages += man/man7/fi_lnx.7
 

--- a/prov/lnx/src/lnx_init.c
+++ b/prov/lnx/src/lnx_init.c
@@ -802,6 +802,9 @@ struct util_prov lnx_util_prov = {
 
 LNX_INI
 {
+#if HAVE_LNX_DL
+	ofi_params_init();
+#endif
 	struct ofi_bufpool_attr bp_attrs = {};
 	int ret;
 

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -1015,21 +1015,23 @@ unlock:
 	pthread_mutex_unlock(&common_locks.ini_lock);
 }
 
+static void ofi_free_prov_recursive(struct ofi_prov *prov)
+{
+	if (!prov)
+		return;
+
+	ofi_free_prov_recursive(prov->next);
+	ofi_free_prov(prov);
+}
+
 FI_DESTRUCTOR(fi_fini(void))
 {
-	struct ofi_prov *prov;
-
 	pthread_mutex_lock(&common_locks.ini_lock);
 
 	if (!ofi_init)
 		goto unlock;
 
-	while (prov_head) {
-		prov = prov_head;
-		prov_head = prov->next;
-		ofi_free_prov(prov);
-	}
-
+	ofi_free_prov_recursive(prov_head);
 	ofi_free_filter(&prov_filter);
 	ofi_shm_p2p_cleanup();
 	ofi_monitors_cleanup();


### PR DESCRIPTION
Cleanup DL providers in reverse order from initialization to better avoid unloading library conflicts
Update LNX DL build in Makefile.include so configure's "--enable-lnx=dl" will properly build lnx dynamically.