### PR TITLE
prov/efa: add gtest unit tests for efa_rma_post_read/write

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -308,6 +308,7 @@ nodist_prov_efa_test_gtest_efa_gtest_SOURCES = \
 	prov/efa/test/gtest/efa_gtest_common_resource.cc \
 	prov/efa/test/gtest/efa_gtest_common_helpers.c \
 	prov/efa/test/gtest/efa_gtest_conn.cc \
+	prov/efa/test/gtest/efa_gtest_rma.cc \
 	prov/efa/test/gtest/efa_gtest_ah.cc
 
 prov_efa_test_gtest_efa_gtest_CPPFLAGS = \
@@ -331,7 +332,9 @@ prov_efa_test_gtest_efa_gtest_LDFLAGS = \
 	-Wl,--wrap=ibv_create_ah \
 	-Wl,--wrap=ibv_destroy_ah \
 	-Wl,--wrap=efadv_query_ah \
-	-Wl,--wrap=efa_av_reverse_av_add
+	-Wl,--wrap=efa_av_reverse_av_add \
+	-Wl,--wrap=efa_qp_post_read \
+	-Wl,--wrap=efa_qp_post_write
 
 prov_efa_test_gtest_efa_gtest_LIBS = $(linkback)
 

--- a/prov/efa/test/gtest/efa_gtest_common_helpers.c
+++ b/prov/efa/test/gtest/efa_gtest_common_helpers.c
@@ -4,6 +4,8 @@
 #include "efa_gtest_common_helpers.h"
 #include "efa.h"
 #include "efa_av.h"
+#include "efa_mr.h"
+#include "efa_device.h"
 #include "rdm/efa_rdm_ep.h"
 
 void efa_test_fabricate_addr(struct fid_ep *ep, struct efa_ep_addr *addr)
@@ -53,6 +55,71 @@ fi_addr_t efa_test_insert_peer_new_gid(struct fid_ep *ep, struct fid_av *av)
 		return FI_ADDR_NOTAVAIL;
 
 	return fi_addr;
+}
+
+void efa_test_set_inject_rma_size(struct fid_ep *ep, size_t size)
+{
+	struct efa_base_ep *base_ep =
+		container_of(ep, struct efa_base_ep, util_ep.ep_fid);
+
+	base_ep->inject_rma_size = size;
+}
+
+int efa_test_set_track_mr(int value)
+{
+	int prev = efa_env.track_mr;
+
+	efa_env.track_mr = value;
+	return prev;
+}
+
+void efa_test_mr_set_iface_cuda(struct fid_mr *mr)
+{
+	struct efa_mr *efa_mr = container_of(mr, struct efa_mr, mr_fid);
+
+	efa_mr->iface = FI_HMEM_CUDA;
+}
+
+fi_addr_t efa_test_rma_insert_peer(struct fid_ep *ep, struct fid_av *av)
+{
+	struct efa_ep_addr raw_addr;
+	size_t raw_addr_len = sizeof(raw_addr);
+	fi_addr_t fi_addr = FI_ADDR_NOTAVAIL;
+	int ret;
+
+	/* Reuse the EP's own GID; fi_av_insert's real ibv_create_ah rejects a
+	 * fabricated one. qpn/qkey are not validated, so any value works. */
+	ret = fi_getname(&ep->fid, &raw_addr, &raw_addr_len);
+	if (ret)
+		return FI_ADDR_NOTAVAIL;
+	raw_addr.qpn = 1;
+	raw_addr.qkey = 0x1234;
+
+	ret = fi_av_insert(av, &raw_addr, 1, &fi_addr, 0, NULL);
+	if (ret != 1)
+		return FI_ADDR_NOTAVAIL;
+
+	return fi_addr;
+}
+
+bool efa_test_device_supports_rma(void)
+{
+	if (g_efa_selected_device_cnt <= 0)
+		return false;
+
+	return efa_device_support_rdma_read() &&
+	       efa_device_support_rdma_write();
+}
+
+void efa_test_get_zero_byte_bounce_buf(struct fid_ep *ep, uint64_t *addr,
+				       uint32_t *lkey)
+{
+	struct efa_base_ep *base_ep =
+		container_of(ep, struct efa_base_ep, util_ep.ep_fid);
+	struct efa_domain *domain = base_ep->domain;
+
+	*addr = (uint64_t) domain->zero_byte_bounce_buf;
+	*lkey = domain->zero_byte_bounce_buf_mr->lkey;
 }
 
 struct ibv_ah *efa_test_implicit_addr_to_ibv_ah(struct fid_av *av,

--- a/prov/efa/test/gtest/efa_gtest_common_helpers.h
+++ b/prov/efa/test/gtest/efa_gtest_common_helpers.h
@@ -14,6 +14,8 @@
 #ifndef EFA_GTEST_COMMON_HELPERS_H
 #define EFA_GTEST_COMMON_HELPERS_H
 
+#include <stdbool.h>
+#include <stdint.h>
 #include <rdma/fabric.h>
 #include <rdma/fi_domain.h>
 #include <rdma/fi_endpoint.h>
@@ -21,6 +23,52 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @brief Whether the real selected EFA device advertises both RDMA read and
+ * write (the condition under which the efa-direct provider advertises FI_RMA).
+ * The RMA tests require this: fi_enable creates a real QP with RDMA send-ops
+ * flags that a non-RDMA device rejects with -FI_EOPNOTSUPP, so tests query this
+ * and GTEST_SKIP on hosts that lack it.
+ */
+bool efa_test_device_supports_rma(void);
+
+/**
+ * @brief Set base_ep->inject_rma_size for the endpoint behind @p ep. The write
+ * path uses this field at runtime to decide the inline branch, so this lets a
+ * test exercise inline writes without forcing wide WQE through fi_getinfo
+ * (which would hit a real efadv_get_max_sq_depth device call).
+ */
+void efa_test_set_inject_rma_size(struct fid_ep *ep, size_t size);
+
+/**
+ * @brief Set efa_env.track_mr and return its previous value. Toggling track_mr
+ * before EP construction controls whether the direct-ope tracking pool (and
+ * thus the efa_direct_ope_alloc/release branch in the post paths) is created.
+ */
+int efa_test_set_track_mr(int value);
+
+/**
+ * @brief Make a registered MR's descriptor report as HMEM (FI_HMEM_CUDA) so the
+ * write path takes the is_hmem branch, without needing real device memory.
+ */
+void efa_test_mr_set_iface_cuda(struct fid_mr *mr);
+
+/**
+ * @brief Insert a fabricated peer via fi_av_insert so efa_av_addr_to_conn
+ * returns a valid conn (with ah + ep_addr) for the RMA post paths.
+ * @return the fi_addr on success, or FI_ADDR_NOTAVAIL on failure.
+ */
+fi_addr_t efa_test_rma_insert_peer(struct fid_ep *ep, struct fid_av *av);
+
+/**
+ * @brief Read the domain's zero-byte bounce buffer address and lkey for the
+ * endpoint behind @p ep. The 0-byte RMA post paths build their single SGE from
+ * these, so a test can assert the SGE was wired to the bounce buffer rather
+ * than to caller memory.
+ */
+void efa_test_get_zero_byte_bounce_buf(struct fid_ep *ep, uint64_t *addr,
+				       uint32_t *lkey);
 
 /**
  * @brief Fabricate a unique address and insert it via fi_av_insert (explicit

--- a/prov/efa/test/gtest/efa_gtest_common_mocks.h
+++ b/prov/efa/test/gtest/efa_gtest_common_mocks.h
@@ -12,6 +12,8 @@ struct efa_av;
 struct efa_cur_reverse_av;
 struct efa_prv_reverse_av;
 struct efa_conn;
+struct efa_qp;
+struct efa_ah;
 
 /*
  * X macro infrastructure for mock generation.
@@ -44,13 +46,32 @@ struct efa_conn;
 #define EFA_MOCK_ARGS_efa_av_reverse_av_add \
 	av, cur_reverse_av, prv_reverse_av, conn
 
+#define EFA_MOCK_PARAMS_efa_qp_post_read                                       \
+	struct efa_qp *qp, const struct ibv_sge *sge_list, size_t sge_count,  \
+		uint32_t remote_key, uint64_t remote_addr, uintptr_t wr_id,   \
+		uint64_t flags, struct efa_ah *ah, uint32_t qpn, uint32_t qkey
+#define EFA_MOCK_ARGS_efa_qp_post_read \
+	qp, sge_list, sge_count, remote_key, remote_addr, wr_id, flags, ah, qpn, qkey
+
+#define EFA_MOCK_PARAMS_efa_qp_post_write                                       \
+	struct efa_qp *qp, const struct ibv_sge *sge_list, size_t sge_count,   \
+		const struct ibv_data_buf *inline_data_list, bool use_inline,  \
+		uint32_t remote_key, uint64_t remote_addr, uintptr_t wr_id,    \
+		uint64_t data, uint64_t flags, struct efa_ah *ah, uint32_t qpn,\
+		uint32_t qkey
+#define EFA_MOCK_ARGS_efa_qp_post_write                                  \
+	qp, sge_list, sge_count, inline_data_list, use_inline, remote_key, \
+		remote_addr, wr_id, data, flags, ah, qpn, qkey
+
 /* --- Function list --- */
 
 #define EFA_MOCK_FUNCTIONS(X)             \
 	X(struct ibv_ah *, ibv_create_ah) \
 	X(int, ibv_destroy_ah)            \
 	X(int, efadv_query_ah)            \
-	X(int, efa_av_reverse_av_add)
+	X(int, efa_av_reverse_av_add)     \
+	X(int, efa_qp_post_read)          \
+	X(int, efa_qp_post_write)
 
 /* --- Generator macros --- */
 

--- a/prov/efa/test/gtest/efa_gtest_common_resource.cc
+++ b/prov/efa/test/gtest/efa_gtest_common_resource.cc
@@ -41,9 +41,6 @@ void efa_test_resource_construct(struct efa_resource *resource,
 	ASSERT_NE(hints, nullptr);
 	resource->hints = hints;
 
-	/* The fabric and ep type are already encoded in hints; derive the API
-	 * version from the fabric name rather than taking it as a separate
-	 * argument that could disagree with hints. */
 	fabric_name = hints->fabric_attr ? hints->fabric_attr->name : NULL;
 	fi_version =
 		(fabric_name && !strcmp(EFA_DIRECT_FABRIC_NAME, fabric_name)) ?

--- a/prov/efa/test/gtest/efa_gtest_rma.cc
+++ b/prov/efa/test/gtest/efa_gtest_rma.cc
@@ -1,0 +1,455 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#include "efa_gtest_common_helpers.h"
+#include "efa_gtest_common_mocks.h"
+#include "efa_gtest_common_resource.h"
+#include <gtest/gtest.h>
+#include <rdma/fi_rma.h>
+
+using testing::_;
+using testing::Return;
+using testing::StrictMock;
+using testing::Test;
+using testing::Truly;
+
+static constexpr uint64_t kRemoteAddr = 0x87654321;
+static constexpr uint32_t kRemoteKey = 123456;
+
+/**
+ * @brief Base fixture for efa_rma_post_read / efa_rma_post_write, reached
+ * through the public fi_read / fi_write ops on an efa-direct EP that
+ * requested FI_RMA. Requires a device with RDMA read+write caps, otherwise skips test.
+ */
+class EfaRmaTestBase : public Test
+{
+	protected:
+	struct efa_resource resource = {};
+	StrictMock<MockEfa> mock_efa;
+	fi_addr_t peer_addr = FI_ADDR_NOTAVAIL;
+	/* A registered local buffer + its descriptor, set by reg_buffer(). */
+	uint8_t *local_buf = nullptr;
+	struct fid_mr *local_mr = nullptr;
+	void *local_desc = nullptr;
+
+	/* When non-zero, the write inline branch will be taken. */
+	size_t inject_rma_size = 0;
+
+	void construct(struct fi_info *hints)
+	{
+		efa_test_resource_construct(&resource, hints);
+		ASSERT_NE(resource.ep, nullptr);
+
+		if (inject_rma_size)
+			efa_test_set_inject_rma_size(resource.ep,
+						     inject_rma_size);
+
+		/* Insert the peer before installing the mock so fi_av_insert's
+		 * wrapped ibv_create_ah/efadv_query_ah run for real and populate
+		 * conn->ah; we only want to intercept the QP post. */
+		peer_addr = efa_test_rma_insert_peer(resource.ep, resource.av);
+		ASSERT_NE(peer_addr, (fi_addr_t) FI_ADDR_NOTAVAIL);
+
+		MockEfa::set(&mock_efa);
+	}
+
+	/* efa-direct hints that request FI_RMA. FI_RX_CQ_DATA is required for
+	 * FI_RMA when the device lacks unsolicited-write-recv support, so we
+	 * always set it. */
+	struct fi_info *make_hints()
+	{
+		struct fi_info *hints = efa_test_alloc_default_hints(
+			FI_EP_RDM, EFA_DIRECT_FABRIC_NAME);
+
+		if (hints) {
+			hints->caps |= FI_RMA;
+			hints->mode |= FI_RX_CQ_DATA;
+		}
+		return hints;
+	}
+
+	void reg_buffer(size_t size)
+	{
+		int ret;
+
+		local_buf = (uint8_t *) calloc(size, 1);
+		ASSERT_NE(local_buf, nullptr);
+		ret = fi_mr_reg(resource.domain, local_buf, size,
+				FI_SEND | FI_RECV, 0, 0, 0, &local_mr, NULL);
+		ASSERT_EQ(ret, 0) << "fi_mr_reg failed: " << fi_strerror(-ret);
+		local_desc = fi_mr_desc(local_mr);
+	}
+
+	void SetUp() override
+	{
+		if (!efa_test_device_supports_rma())
+			GTEST_SKIP()
+				<< "device does not support RDMA read+write";
+
+		memset(&resource, 0, sizeof(resource));
+	}
+
+	void TearDown() override
+	{
+		/* Clear the mock first so teardown's wrapped calls (e.g.
+		 * ibv_destroy_ah) run for real and aren't checked. */
+		MockEfa::set(nullptr);
+
+		if (local_mr) {
+			EXPECT_EQ(fi_close(&local_mr->fid), 0);
+			local_mr = nullptr;
+		}
+		free(local_buf);
+		local_buf = nullptr;
+
+		/* Reset track_mr only after destruct: efa_ep_close frees the
+		 * direct-ope pool only while track_mr is still set. */
+		efa_test_resource_destruct(&resource);
+		efa_test_set_track_mr(0);
+	}
+};
+
+/* ---------------------------------------------------------------------------
+ * efa_rma_post_read
+ * ------------------------------------------------------------------------- */
+
+class EfaRmaReadTest : public EfaRmaTestBase
+{
+};
+
+/**
+ * @brief 0-byte read takes the bounce-buffer branch: iov_count is forced to 1
+ * and the single SGE is wired to the domain's zero-byte bounce buffer
+ * (addr + lkey) with length 0, rather than to any caller memory (no desc
+ * required). Asserting the SGE contents is what distinguishes this branch from
+ * the normal SGE-loop path.
+ */
+TEST_F(EfaRmaReadTest, read_zero_byte_uses_bounce_buffer)
+{
+	struct fi_info *hints = make_hints();
+	ASSERT_NO_FATAL_FAILURE(construct(hints));
+
+	uint64_t bounce_addr;
+	uint32_t bounce_lkey;
+	efa_test_get_zero_byte_bounce_buf(resource.ep, &bounce_addr,
+					  &bounce_lkey);
+
+	/* The single SGE must point at the bounce buffer (addr + lkey) with
+	 * length 0, not at caller memory. */
+	auto sge_is_bounce_buf = Truly([=](const struct ibv_sge *sge) {
+		return sge[0].addr == bounce_addr && sge[0].length == 0 &&
+		       sge[0].lkey == bounce_lkey;
+	});
+
+	/* sge_count forced to 1 even though the caller passed NULL/0-length. */
+	EXPECT_CALL(mock_efa,
+		    efa_qp_post_read(_, sge_is_bounce_buf, 1, kRemoteKey,
+				     kRemoteAddr, 0, _, _, _, _))
+		.WillOnce(Return(0));
+
+	int ret = fi_read(resource.ep, NULL, 0, NULL, peer_addr, kRemoteAddr,
+			  kRemoteKey, NULL);
+	EXPECT_EQ(ret, 0);
+}
+
+/**
+ * @brief When the underlying post returns ENOMEM, efa_rma_post_read remaps it
+ * to -FI_EAGAIN; any other positive errno is returned negated.
+ */
+TEST_F(EfaRmaReadTest, read_post_enomem_maps_to_eagain)
+{
+	struct fi_info *hints = make_hints();
+	ASSERT_NO_FATAL_FAILURE(construct(hints));
+	reg_buffer(4096);
+
+	EXPECT_CALL(mock_efa, efa_qp_post_read(_, _, 1, kRemoteKey, kRemoteAddr,
+					       0, _, _, _, _))
+		.WillOnce(Return(ENOMEM));
+
+	int ret = fi_read(resource.ep, local_buf, 4096, local_desc, peer_addr,
+			  kRemoteAddr, kRemoteKey, NULL);
+	EXPECT_EQ(ret, -FI_EAGAIN);
+}
+
+TEST_F(EfaRmaReadTest, read_post_generic_errno_negated)
+{
+	struct fi_info *hints = make_hints();
+	ASSERT_NO_FATAL_FAILURE(construct(hints));
+	reg_buffer(4096);
+
+	/* EFAULT (not ENOMEM) so we exercise the generic "return -err" arm. */
+	EXPECT_CALL(mock_efa, efa_qp_post_read(_, _, 1, kRemoteKey, kRemoteAddr,
+					       0, _, _, _, _))
+		.WillOnce(Return(EFAULT));
+
+	int ret = fi_read(resource.ep, local_buf, 4096, local_desc, peer_addr,
+			  kRemoteAddr, kRemoteKey, NULL);
+	EXPECT_EQ(ret, -EFAULT);
+}
+
+/**
+ * @brief With track_mr set and a non-NULL context, the read path allocates a
+ * direct-ope and posts its address as wr_id instead of the efa_context. The
+ * non-track path would post wr_id == &ctx, so wr_id non-zero and != &ctx
+ * confirms the direct-ope branch.
+ */
+TEST_F(EfaRmaReadTest, read_track_mr_allocates_direct_ope)
+{
+	struct fi_info *hints = make_hints();
+	struct fi_context2 ctx = {};
+
+	/* Enable track_mr before construct() so the EP allocates the
+	 * direct-ope pool. */
+	efa_test_set_track_mr(1);
+
+	ASSERT_NO_FATAL_FAILURE(construct(hints));
+	reg_buffer(4096);
+
+	/* The branch needs efa_ctx non-NULL: both a non-NULL context (&ctx) and
+	 * FI_COMPLETION in the tx flags. Without it wr_id would be 0 and the
+	 * matcher would fail. */
+	auto wr_id_is_direct_ope = Truly([&ctx](uintptr_t wr_id) {
+		return wr_id != 0 && wr_id != (uintptr_t) &ctx;
+	});
+	EXPECT_CALL(mock_efa, efa_qp_post_read(_, _, 1, kRemoteKey, kRemoteAddr,
+					       wr_id_is_direct_ope, _, _, _, _))
+		.WillOnce(Return(0));
+
+	int ret = fi_read(resource.ep, local_buf, 4096, local_desc, peer_addr,
+			  kRemoteAddr, kRemoteKey, &ctx);
+	EXPECT_EQ(ret, 0);
+}
+
+/* ---------------------------------------------------------------------------
+ * efa_rma_post_write
+ * ------------------------------------------------------------------------- */
+
+class EfaRmaWriteTest : public EfaRmaTestBase
+{
+};
+
+/**
+ * @brief fi_writedata forwards FI_REMOTE_CQ_DATA and the 64-bit immediate to
+ * efa_qp_post_write.
+ */
+TEST_F(EfaRmaWriteTest, writedata_forwards_remote_cq_data)
+{
+	struct fi_info *hints = make_hints();
+	ASSERT_NO_FATAL_FAILURE(construct(hints));
+	reg_buffer(4096);
+
+	const uint64_t imm = 0xdeadbeef;
+	/* data (9th arg) is the immediate; flags (10th arg) must carry
+	 * FI_REMOTE_CQ_DATA. */
+	auto has_remote_cq_data = Truly([](uint64_t flags) {
+		return (flags & FI_REMOTE_CQ_DATA) != 0;
+	});
+	EXPECT_CALL(mock_efa, efa_qp_post_write(_, _, 1, _, false, kRemoteKey,
+						kRemoteAddr, 0, imm,
+						has_remote_cq_data, _, _, _))
+		.WillOnce(Return(0));
+
+	int ret = fi_writedata(resource.ep, local_buf, 4096, local_desc, imm,
+			       peer_addr, kRemoteAddr, kRemoteKey, NULL);
+	EXPECT_EQ(ret, 0);
+}
+
+/**
+ * @brief When the underlying post returns ENOMEM, efa_rma_post_write remaps it
+ * to -FI_EAGAIN; any other positive errno is returned negated.
+ */
+TEST_F(EfaRmaWriteTest, write_post_enomem_maps_to_eagain)
+{
+	struct fi_info *hints = make_hints();
+	ASSERT_NO_FATAL_FAILURE(construct(hints));
+	reg_buffer(4096);
+
+	EXPECT_CALL(mock_efa, efa_qp_post_write(_, _, 1, _, false, kRemoteKey,
+						kRemoteAddr, 0, 0, _, _, _, _))
+		.WillOnce(Return(ENOMEM));
+
+	int ret = fi_write(resource.ep, local_buf, 4096, local_desc, peer_addr,
+			   kRemoteAddr, kRemoteKey, NULL);
+	EXPECT_EQ(ret, -FI_EAGAIN);
+}
+
+TEST_F(EfaRmaWriteTest, write_post_generic_errno_negated)
+{
+	struct fi_info *hints = make_hints();
+	ASSERT_NO_FATAL_FAILURE(construct(hints));
+	reg_buffer(4096);
+
+	/* EFAULT (not ENOMEM) so we exercise the generic "return -err" arm. */
+	EXPECT_CALL(mock_efa, efa_qp_post_write(_, _, 1, _, false, kRemoteKey,
+						kRemoteAddr, 0, 0, _, _, _, _))
+		.WillOnce(Return(EFAULT));
+
+	int ret = fi_write(resource.ep, local_buf, 4096, local_desc, peer_addr,
+			   kRemoteAddr, kRemoteKey, NULL);
+	EXPECT_EQ(ret, -EFAULT);
+}
+
+/**
+ * @brief 0-byte write takes the bounce-buffer branch: use_inline is forced
+ * false, iov_count becomes 1, and the single SGE is wired to the domain's
+ * zero-byte bounce buffer (addr + lkey, length 0) rather than caller memory.
+ * Asserting the SGE contents (and use_inline false) distinguishes this branch
+ * from both the inline and normal SGE-loop paths.
+ */
+TEST_F(EfaRmaWriteTest, write_zero_byte_uses_bounce_buffer)
+{
+	struct fi_info *hints = make_hints();
+	ASSERT_NO_FATAL_FAILURE(construct(hints));
+
+	uint64_t bounce_addr;
+	uint32_t bounce_lkey;
+	efa_test_get_zero_byte_bounce_buf(resource.ep, &bounce_addr,
+					  &bounce_lkey);
+
+	auto sge_is_bounce_buf = Truly([=](const struct ibv_sge *sge) {
+		return sge[0].addr == bounce_addr && sge[0].length == 0 &&
+		       sge[0].lkey == bounce_lkey;
+	});
+
+	/* use_inline (5th arg) forced false even though total_len fits inline.
+	 */
+	EXPECT_CALL(mock_efa, efa_qp_post_write(_, sge_is_bounce_buf, 1, _,
+						false, kRemoteKey, kRemoteAddr,
+						0, 0, _, _, _, _))
+		.WillOnce(Return(0));
+
+	int ret = fi_write(resource.ep, NULL, 0, NULL, peer_addr, kRemoteAddr,
+			   kRemoteKey, NULL);
+	EXPECT_EQ(ret, 0);
+}
+
+/**
+ * @brief FI_INJECT with a message exceeding inject_rma_size fails with
+ * -FI_EINVAL (the !len_fits_inline arm) before any post. This fixture sets no
+ * inject_size hint, so inject_rma_size is 0 and the 4096-byte message always
+ * exceeds it.
+ */
+TEST_F(EfaRmaWriteTest, write_inject_too_large_returns_einval)
+{
+	struct fi_info *hints = make_hints();
+	ASSERT_NO_FATAL_FAILURE(construct(hints));
+	reg_buffer(4096);
+
+	struct iovec iov = {local_buf, 4096};
+	struct fi_rma_iov rma_iov = {kRemoteAddr, 4096, kRemoteKey};
+	struct fi_msg_rma msg = {};
+	msg.msg_iov = &iov;
+	msg.desc = &local_desc;
+	msg.iov_count = 1;
+	msg.addr = peer_addr;
+	msg.rma_iov = &rma_iov;
+	msg.rma_iov_count = 1;
+
+	EXPECT_CALL(mock_efa, efa_qp_post_write).Times(0);
+
+	int ret = fi_writemsg(resource.ep, &msg, FI_INJECT);
+	EXPECT_EQ(ret, -FI_EINVAL);
+}
+
+/**
+ * @brief Write fixture with a non-zero inject_rma_size so the inline-write
+ * branch is reachable.
+ */
+class EfaRmaWriteInlineTest : public EfaRmaTestBase
+{
+	protected:
+	void SetUp() override
+	{
+		EfaRmaTestBase::SetUp();
+		inject_rma_size = 64;
+	}
+};
+
+/**
+ * @brief Happy-path inline write: a small (<= inject_rma_size) non-HMEM write
+ * takes the inline path, so efa_qp_post_write is called with use_inline true
+ * and the inline_data_list (not the SGE list) is built from the caller's iov.
+ */
+TEST_F(EfaRmaWriteInlineTest, write_small_uses_inline)
+{
+	struct fi_info *hints = make_hints();
+	ASSERT_NO_FATAL_FAILURE(construct(hints));
+	reg_buffer(32);
+
+	/* The inline path builds inline_data_list[0] from the caller's iov
+	 * (addr + length), not from a desc; assert it points at local_buf. */
+	auto inline_buf_is_local = Truly([=](const struct ibv_data_buf *dbuf) {
+		return dbuf[0].addr == (void *) local_buf &&
+		       dbuf[0].length == 32;
+	});
+
+	/* use_inline (5th arg) true; inline_data_list (4th arg) carries the
+	 * iov. */
+	EXPECT_CALL(mock_efa, efa_qp_post_write(_, _, 1, inline_buf_is_local,
+						true, kRemoteKey, kRemoteAddr,
+						0, 0, _, _, _, _))
+		.WillOnce(Return(0));
+
+	int ret = fi_write(resource.ep, local_buf, 32, local_desc, peer_addr,
+			   kRemoteAddr, kRemoteKey, NULL);
+	EXPECT_EQ(ret, 0);
+}
+
+/**
+ * @brief A small write whose desc reports HMEM does NOT use inline: is_hmem
+ * forces use_inline false even though the 32-byte message fits inject_rma_size
+ * (64). The post then fires with use_inline false and the SGE list (not the
+ * inline_data_list) built from the caller's iov.
+ */
+TEST_F(EfaRmaWriteInlineTest, write_hmem_small_not_inline)
+{
+	struct fi_info *hints = make_hints();
+	ASSERT_NO_FATAL_FAILURE(construct(hints));
+	reg_buffer(32);
+	efa_test_mr_set_iface_cuda(local_mr);
+
+	/* Because use_inline is false, the SGE/desc path runs and builds
+	 * sge_list[0] from the iov; assert it points at local_buf. */
+	auto sge_is_local = Truly([=](const struct ibv_sge *sge) {
+		return sge[0].addr == (uint64_t) local_buf &&
+		       sge[0].length == 32;
+	});
+
+	EXPECT_CALL(mock_efa,
+		    efa_qp_post_write(_, sge_is_local, 1, _, false, kRemoteKey,
+				      kRemoteAddr, 0, 0, _, _, _, _))
+		.WillOnce(Return(0));
+
+	int ret = fi_write(resource.ep, local_buf, 32, local_desc, peer_addr,
+			   kRemoteAddr, kRemoteKey, NULL);
+	EXPECT_EQ(ret, 0);
+}
+
+/**
+ * @brief FI_INJECT of an HMEM buffer that fits inject_rma_size fails with
+ * -FI_ENOSYS: the len_fits_inline-but-is_hmem else arm of the FI_INJECT block,
+ * distinct from the too-large arm in write_inject_too_large_returns_einval. No
+ * post fires.
+ */
+TEST_F(EfaRmaWriteInlineTest, write_inject_hmem_returns_enosys)
+{
+	struct fi_info *hints = make_hints();
+	ASSERT_NO_FATAL_FAILURE(construct(hints));
+	reg_buffer(32);
+	efa_test_mr_set_iface_cuda(local_mr);
+
+	struct iovec iov = {local_buf, 32};
+	struct fi_rma_iov rma_iov = {kRemoteAddr, 32, kRemoteKey};
+	struct fi_msg_rma msg = {};
+	msg.msg_iov = &iov;
+	msg.desc = &local_desc;
+	msg.iov_count = 1;
+	msg.addr = peer_addr;
+	msg.rma_iov = &rma_iov;
+	msg.rma_iov_count = 1;
+
+	EXPECT_CALL(mock_efa, efa_qp_post_write).Times(0);
+
+	int ret = fi_writemsg(resource.ep, &msg, FI_INJECT);
+	EXPECT_EQ(ret, -FI_ENOSYS);
+}


### PR DESCRIPTION
Add efa_gtest_rma.cc covering the efa-direct RMA post paths (efa_rma_post_read / efa_rma_post_write).

Tests target the branches cmocka leaves uncovered: the ENOMEM->EAGAIN and generic errno remaps, the inline-write and is_hmem paths, the FI_INJECT HMEM ENOSYS arm, the zero-byte bounce-buffer wiring, and the track_mr direct-ope allocation. Tests requiring RDMA read+write skip on hosts whose device does not advertise it.

Adds efa_qp_post_read/write to the gtest MockEfa set and two helpers (efa_test_device_supports_rma, efa_test_get_zero_byte_bounce_buf).