### PR TITLE
prov/efa: update LSan suppresion list for aarch64

### DIFF
--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -3,6 +3,12 @@
 
 #include "efa_unit_tests.h"
 
+// Harmless suppression: persistent allocation from glibc outside of EFA provider
+const char *__lsan_default_suppressions(void)
+{
+	return "leak:_dlerror_run\n";
+}
+
 struct efa_env orig_efa_env = {0};
 struct efa_hmem_info g_efa_hmem_info_backup[OFI_HMEM_MAX];
 

--- a/prov/efa/test/gtest/efa_gtest_ah.cc
+++ b/prov/efa/test/gtest/efa_gtest_ah.cc
@@ -50,15 +50,9 @@ class EfaAhTest : public Test
 };
 
 /**
- * @brief ibv_create_ah fails with ENOMEM, an existing implicit AH is evicted,
- * and the retried ibv_create_ah succeeds (the ENOMEM eviction branch in
- * efa_ah_alloc, via efa_ah_implicit_av_evict_ah).
- *
- * Two distinct GIDs are inserted into the implicit AV. The first insert
- * succeeds and populates the AH map / LRU list. The second insert's initial
- * ibv_create_ah returns ENOMEM, which triggers efa_ah_implicit_av_evict_ah to
- * release the first (implicit-only) AH; the subsequent retry then succeeds, so
- * the second insert returns a valid fi_addr.
+ * @brief efa_ah_alloc's ENOMEM eviction branch where the retry succeeds: a
+ * second insert hits ENOMEM, efa_ah_implicit_av_evict_ah releases the first
+ * (implicit-only) AH, and the retried ibv_create_ah succeeds.
  */
 TEST_F(EfaAhTest, alloc_enomem_evict_and_retry_succeeds)
 {
@@ -69,7 +63,7 @@ TEST_F(EfaAhTest, alloc_enomem_evict_and_retry_succeeds)
 	 * Three ibv_create_ah calls in order:
 	 *   1. first GID  -> success (populates AH map + LRU)
 	 *   2. second GID -> ENOMEM (drives the errno == FI_ENOMEM branch)
-	 *   3. second GID retry after eviction -> success
+	 *   3. second GID retry after eviction of dummy_ah_a -> success
 	 */
 	EXPECT_CALL(mock_efa, ibv_create_ah)
 		.WillOnce(Return(&dummy_ah_a))
@@ -80,8 +74,6 @@ TEST_F(EfaAhTest, alloc_enomem_evict_and_retry_succeeds)
 		}))
 		.WillOnce(Return(&dummy_ah_b));
 
-	/* efadv_query_ah runs once per successful ibv_create_ah (GIDs A and B).
-	 */
 	EXPECT_CALL(mock_efa, efadv_query_ah)
 		.Times(2)
 		.WillRepeatedly(Return(0));
@@ -98,30 +90,14 @@ TEST_F(EfaAhTest, alloc_enomem_evict_and_retry_succeeds)
 			return __real_ibv_destroy_ah(ah);
 		}));
 
-	/*
-	 * Route reverse-AV bookkeeping to the real implementation so the
-	 * cur/prv reverse-AV hashes stay consistent across the eviction (which
-	 * removes A's entry) and the later teardown removal.
-	 */
+	// run the real reverse_av_add to populate the reverse av hash
 	EXPECT_CALL(mock_efa, efa_av_reverse_av_add)
 		.WillRepeatedly(Invoke(__real_efa_av_reverse_av_add));
 
-	/*
-	 * Insert through efa_av_insert_one, the only production entry to
-	 * efa_ah_alloc. The eviction path releases a fully-wired implicit
-	 * efa_conn (conn->av, implicit_fi_addr, implicit_conn_list linkage)
-	 * that efa_conn_alloc builds under the AV locks insert_one holds; a
-	 * bare efa_ah_alloc would leave an empty implicit_conn_list with no
-	 * AH to evict.
-	 */
 	addr_a = efa_test_insert_peer_new_gid(resource.ep, resource.av);
 	EXPECT_NE(addr_a, (fi_addr_t) FI_ADDR_NOTAVAIL);
 
-	/*
-	 * Inserting B is what drives the ENOMEM eviction: its first
-	 * ibv_create_ah fails, A (the only entry with no explicit refs) is
-	 * evicted, and the retry succeeds.
-	 */
+	// we have configured this insertion to fail-retry-succeed
 	addr_b = efa_test_insert_peer_new_gid(resource.ep, resource.av);
 	EXPECT_NE(addr_b, (fi_addr_t) FI_ADDR_NOTAVAIL);
 
@@ -141,15 +117,9 @@ TEST_F(EfaAhTest, alloc_enomem_evict_and_retry_succeeds)
 }
 
 /**
- * @brief ibv_create_ah fails with ENOMEM but no AH can be evicted, so the
- * insert fails (the ENOMEM eviction branch in efa_ah_alloc, where
- * efa_ah_implicit_av_evict_ah returns -FI_ENOMEM).
- *
- * A single implicit AV insert is attempted with an empty AH map / LRU list.
- * ibv_create_ah returns ENOMEM, the eviction helper finds no releasable AH and
- * returns -FI_ENOMEM, so efa_ah_alloc bails out via err_free_efa_ah without
- * ever reaching efadv_query_ah or creating a reverse-AV entry. The insert
- * therefore fails with FI_ADDR_NOTAVAIL.
+ * @brief efa_ah_alloc's ENOMEM eviction branch where the retry never happens:
+ * with an empty AH map efa_ah_implicit_av_evict_ah returns -FI_ENOMEM, so
+ * efa_ah_alloc bails via err_free_efa_ah and the insert fails.
  */
 TEST_F(EfaAhTest, alloc_enomem_no_evictable_ah_fails)
 {

--- a/prov/efa/test/gtest/efa_gtest_ah.cc
+++ b/prov/efa/test/gtest/efa_gtest_ah.cc
@@ -87,14 +87,16 @@ TEST_F(EfaAhTest, alloc_enomem_evict_and_retry_succeeds)
 		.WillRepeatedly(Return(0));
 
 	/*
-	 * ibv_destroy_ah fires three times: when AH A is evicted during the
-	 * second insert, for AH B during teardown, and for the endpoint's
-	 * self_ah during teardown (created by fi_enable before the mock was
-	 * installed, but destroyed while the mock is still active).
+	 * ibv_destroy_ah is called for three AH's: we need to fake
+	 * dummy_ah_a/b's destroy calls, but actually call destroy on self_ah.
 	 */
 	EXPECT_CALL(mock_efa, ibv_destroy_ah)
 		.Times(3)
-		.WillRepeatedly(Return(0));
+		.WillRepeatedly(Invoke([](struct ibv_ah *ah) -> int {
+			if (ah == &dummy_ah_a || ah == &dummy_ah_b)
+				return 0;
+			return __real_ibv_destroy_ah(ah);
+		}));
 
 	/*
 	 * Route reverse-AV bookkeeping to the real implementation so the
@@ -162,10 +164,11 @@ TEST_F(EfaAhTest, alloc_enomem_no_evictable_ah_fails)
 			return nullptr;
 		}));
 
-	/* The failed insert creates no AH, so the only ibv_destroy_ah is for
-	 * the endpoint's self_ah (created by fi_enable before the mock was
-	 * installed) during teardown while the mock is still active. */
-	EXPECT_CALL(mock_efa, ibv_destroy_ah).Times(1).WillOnce(Return(0));
+	/* The failed insert creates no AH, so ibv_destroy_ah is only expected
+	 * to be called once on the real AH. */
+	EXPECT_CALL(mock_efa, ibv_destroy_ah)
+		.Times(1)
+		.WillOnce(Invoke(__real_ibv_destroy_ah));
 
 	addr = efa_test_insert_peer_new_gid(resource.ep, resource.av);
 	EXPECT_EQ(addr, (fi_addr_t) FI_ADDR_NOTAVAIL);

--- a/prov/efa/test/gtest/efa_gtest_common_resource.cc
+++ b/prov/efa/test/gtest/efa_gtest_common_resource.cc
@@ -41,9 +41,6 @@ void efa_test_resource_construct(struct efa_resource *resource,
 	ASSERT_NE(hints, nullptr);
 	resource->hints = hints;
 
-	/* The fabric and ep type are already encoded in hints; derive the API
-	 * version from the fabric name rather than taking it as a separate
-	 * argument that could disagree with hints. */
 	fabric_name = hints->fabric_attr ? hints->fabric_attr->name : NULL;
 	fi_version =
 		(fabric_name && !strcmp(EFA_DIRECT_FABRIC_NAME, fabric_name)) ?

--- a/prov/efa/test/gtest/efa_gtest_conn.cc
+++ b/prov/efa/test/gtest/efa_gtest_conn.cc
@@ -48,8 +48,18 @@ TEST_F(EfaConnTest, alloc_reverse_av_add_failure_rdm_cleanup)
 	MockEfa::set(&mock_efa);
 	EXPECT_CALL(mock_efa, ibv_create_ah(_, _))
 		.WillOnce(Return(&dummy_ibv_ah));
-	EXPECT_CALL(mock_efa, ibv_destroy_ah(_)).WillRepeatedly(Return(0));
-	EXPECT_CALL(mock_efa, efadv_query_ah(_, _, _))
+	/*
+	 * Fake the dummy ah destroy but route
+	 * the self_ah to the real destroy so it and its PD are not leaked.
+	 */
+	EXPECT_CALL(mock_efa, ibv_destroy_ah(_))
+		.Times(2)
+		.WillRepeatedly(Invoke([](struct ibv_ah *ah) -> int {
+			if (ah == &dummy_ibv_ah)
+				return 0;
+			return __real_ibv_destroy_ah(ah);
+		}));
+	EXPECT_CALL(mock_efa, efadv_query_ah)
 		.WillRepeatedly(Return(0));
 	EXPECT_CALL(mock_efa, efa_av_reverse_av_add(_, _, _, _))
 		.WillOnce(Return(-FI_ENOMEM));
@@ -78,8 +88,14 @@ TEST_F(EfaConnTest, alloc_reverse_av_add_failure_explicit_insert)
 	MockEfa::set(&mock_efa);
 	EXPECT_CALL(mock_efa, ibv_create_ah(_, _))
 		.WillOnce(Return(&dummy_ibv_ah));
-	EXPECT_CALL(mock_efa, ibv_destroy_ah(_)).WillRepeatedly(Return(0));
-	EXPECT_CALL(mock_efa, efadv_query_ah(_, _, _))
+	EXPECT_CALL(mock_efa, ibv_destroy_ah(_))
+		.Times(2)
+		.WillRepeatedly(Invoke([](struct ibv_ah *ah) -> int {
+			if (ah == &dummy_ibv_ah)
+				return 0;
+			return __real_ibv_destroy_ah(ah);
+		}));
+	EXPECT_CALL(mock_efa, efadv_query_ah)
 		.WillRepeatedly(Return(0));
 	EXPECT_CALL(mock_efa, efa_av_reverse_av_add(_, _, _, _))
 		.WillOnce(Return(-FI_ENOMEM));

--- a/prov/efa/test/gtest/efa_gtest_conn.cc
+++ b/prov/efa/test/gtest/efa_gtest_conn.cc
@@ -31,9 +31,8 @@ class EfaConnTest : public Test
 };
 
 /**
- * @brief Test that efa_conn_alloc cleans up RDM resources when
- * efa_av_reverse_av_add fails (efa_conn.c:304-316).
- * Verifies the cleanup path calls efa_conn_rdm_deinit without crash.
+ * @brief efa_conn_alloc unwinds the conn via efa_conn_rdm_deinit when
+ * efa_av_reverse_av_add fails, so the insert fails cleanly.
  */
 TEST_F(EfaConnTest, alloc_reverse_av_add_failure_rdm_cleanup)
 {
@@ -46,7 +45,7 @@ TEST_F(EfaConnTest, alloc_reverse_av_add_failure_rdm_cleanup)
 	ASSERT_NE(resource.ep, nullptr);
 
 	MockEfa::set(&mock_efa);
-	EXPECT_CALL(mock_efa, ibv_create_ah(_, _))
+	EXPECT_CALL(mock_efa, ibv_create_ah)
 		.WillOnce(Return(&dummy_ibv_ah));
 	/*
 	 * Fake the dummy ah destroy but route
@@ -61,7 +60,7 @@ TEST_F(EfaConnTest, alloc_reverse_av_add_failure_rdm_cleanup)
 		}));
 	EXPECT_CALL(mock_efa, efadv_query_ah)
 		.WillRepeatedly(Return(0));
-	EXPECT_CALL(mock_efa, efa_av_reverse_av_add(_, _, _, _))
+	EXPECT_CALL(mock_efa, efa_av_reverse_av_add)
 		.WillOnce(Return(-FI_ENOMEM));
 
 	addr = efa_test_insert_peer_new_gid(resource.ep, resource.av);
@@ -97,7 +96,7 @@ TEST_F(EfaConnTest, alloc_reverse_av_add_failure_explicit_insert)
 		}));
 	EXPECT_CALL(mock_efa, efadv_query_ah)
 		.WillRepeatedly(Return(0));
-	EXPECT_CALL(mock_efa, efa_av_reverse_av_add(_, _, _, _))
+	EXPECT_CALL(mock_efa, efa_av_reverse_av_add)
 		.WillOnce(Return(-FI_ENOMEM));
 
 	num_addr = efa_test_explicit_av_insert(resource.ep, resource.av, &addr);

--- a/prov/efa/test/gtest/efa_gtest_main.cc
+++ b/prov/efa/test/gtest/efa_gtest_main.cc
@@ -4,24 +4,11 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-/*
- * Suppress LeakSanitizer reports for rdma-core's load-time driver
- * registration (verbs_register_driver) and device discovery cache, which
- * are intentionally never freed. ibv_close_device() properly frees all
- * per-context state; only these one-time framework allocations persist.
- *
- * The cmocka suite doesn't need this because its --wrap=calloc (for OOM
- * fault injection) accidentally hides rdma-core allocations from LSan.
- * We don't wrap calloc here to preserve leak detection for genuine leaks.
- */
-#if __has_include(<sanitizer/lsan_interface.h>)
-#include <sanitizer/lsan_interface.h>
-
+// Harmless suppression: persistent allocation from glibc outside of EFA provider
 extern "C" const char *__lsan_default_suppressions(void)
 {
-	return "leak:libefa.so\n";
+	return "leak:_dlerror_run\n";
 }
-#endif
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
Suppress known-benign/spurious "leaks" detected by LSan on aarch64.
This PR removes a previous suppression of libefa.so, which came from a real accidental leak from test resource management (not a real production leak), which has been fixed.
Also included some improvements to the documentation of the existing gtest suite.