### PR TITLE
hmem/cuda, prov/shm: Introduce async cuda ipc copy support

### DIFF
--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -113,6 +113,7 @@ hsa_status_t ofi_hsa_amd_reg_dealloc_cb(void *ptr,
 
 struct ofi_hmem_ops {
 	bool initialized;
+	bool async_copy_enabled;
 	int (*init)(void);
 	int (*cleanup)(void);
 	int (*create_async_copy_event)(uint64_t device,
@@ -192,6 +193,13 @@ bool rocr_is_dmabuf_requested(void);
 
 int cuda_copy_to_dev(uint64_t device, void *dev, const void *host, size_t size);
 int cuda_copy_from_dev(uint64_t device, void *host, const void *dev, size_t size);
+int cuda_create_async_copy_event(uint64_t device, ofi_hmem_async_event_t *event);
+int cuda_free_async_copy_event(uint64_t device, ofi_hmem_async_event_t event);
+int cuda_async_copy_to_dev(uint64_t device, void *dst, const void *src,
+			   size_t size, ofi_hmem_async_event_t event);
+int cuda_async_copy_from_dev(uint64_t device, void *dst, const void *src,
+			     size_t size, ofi_hmem_async_event_t event);
+int cuda_async_copy_query(ofi_hmem_async_event_t event);
 int cuda_hmem_init(void);
 int cuda_hmem_cleanup(void);
 bool cuda_is_addr_valid(const void *addr, uint64_t *device, uint64_t *flags);
@@ -408,6 +416,13 @@ static inline bool ofi_hmem_p2p_disabled(void)
 {
 	return ofi_hmem_disable_p2p;
 }
+
+static inline bool ofi_hmem_async_copy_enabled(enum fi_hmem_iface iface)
+{
+	return hmem_ops[iface].async_copy_enabled;
+}
+
+void ofi_hmem_set_async_copy_enabled(void);
 
 int ofi_create_async_copy_event(enum fi_hmem_iface iface, uint64_t device,
 				ofi_hmem_async_event_t *event);

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -1400,18 +1400,34 @@ static void smr_progress_async_ipc(struct smr_ep *ep,
 	iface = ipc_entry->cmd->data.ipc_info.iface;
 	device = ipc_entry->cmd->data.ipc_info.device;
 
-	if (ofi_async_copy_query(iface, ipc_entry->async_event))
+	ret = ofi_async_copy_query(iface, ipc_entry->async_event);
+	if (ret == -FI_EBUSY)
 		return;
+
+	if (ret) {
+		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+			"async IPC copy failed: %d\n", ret);
+		ipc_entry->cmd->hdr.smr_flags |= SMR_OP_ERROR;
+	}
 
 	ofi_mr_cache_delete(domain->ipc_cache, ipc_entry->ipc_entry);
 	ofi_free_async_copy_event(iface, device, ipc_entry->async_event);
 
-	ret = smr_complete_rx(ep, ipc_entry->comp_ctx, ipc_entry->cmd->hdr.op,
-			      ipc_entry->comp_flags, ipc_entry->cmd->hdr.size,
-			      ipc_entry->iov[0].iov_base,
-			      ipc_entry->cmd->hdr.rx_id,
-			      ipc_entry->cmd->hdr.tag,
-			      ipc_entry->cmd->hdr.cq_data);
+	if (ret) {
+		ret = smr_write_err_comp(ep->util_ep.rx_cq,
+					ipc_entry->comp_ctx,
+					ipc_entry->comp_flags,
+					ipc_entry->cmd->hdr.tag, ret);
+	} else {
+		ret = smr_complete_rx(ep, ipc_entry->comp_ctx,
+				      ipc_entry->cmd->hdr.op,
+				      ipc_entry->comp_flags,
+				      ipc_entry->cmd->hdr.size,
+				      ipc_entry->iov[0].iov_base,
+				      ipc_entry->cmd->hdr.rx_id,
+				      ipc_entry->cmd->hdr.tag,
+				      ipc_entry->cmd->hdr.cq_data);
+	}
 	if (ret) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"unable to process rx completion\n");

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -548,7 +548,7 @@ static ssize_t smr_progress_ipc(struct smr_ep *ep, struct smr_cmd *cmd,
 	ptr = (char *) (uintptr_t) mr_entry->info.mapped_addr +
 		(uintptr_t) cmd->data.ipc_info.offset;
 
-	if (cmd->data.ipc_info.iface == FI_HMEM_ROCR) {
+	if (ofi_hmem_async_copy_enabled(cmd->data.ipc_info.iface)) {
 		ret = smr_ipc_async_copy(ep, cmd, rx_entry, mr_entry, iov,
 					 iov_count, ptr);
 		if (ret)

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -548,7 +548,8 @@ static ssize_t smr_progress_ipc(struct smr_ep *ep, struct smr_cmd *cmd,
 	ptr = (char *) (uintptr_t) mr_entry->info.mapped_addr +
 		(uintptr_t) cmd->data.ipc_info.offset;
 
-	if (ofi_hmem_async_copy_enabled(cmd->data.ipc_info.iface)) {
+	if (ofi_hmem_async_copy_enabled(cmd->data.ipc_info.iface) &&
+	    !(cmd->hdr.smr_flags & SMR_BUFFER_RECV)) {
 		ret = smr_ipc_async_copy(ep, cmd, rx_entry, mr_entry, iov,
 					 iov_count, ptr);
 		if (ret)

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -750,6 +750,8 @@ static int smr_start_common(struct smr_ep *ep, struct smr_cmd *cmd,
 		pend = (struct smr_pend_entry *) cmd->hdr.rx_ctx;
 		if (pend->sar_copy_fn == &smr_dsa_copy_sar)
 			return_cmd = false;
+	} else if (cmd->hdr.proto == smr_proto_ipc && cmd->hdr.rx_ctx) {
+		return_cmd = false;
 	}
 
 	if (return_cmd)
@@ -1229,6 +1231,8 @@ static int smr_progress_cmd_rma(struct smr_ep *ep, struct smr_cmd *cmd)
 			pend = (struct smr_pend_entry *) cmd->hdr.rx_ctx;
 			if (pend->sar_copy_fn == &smr_dsa_copy_sar)
 				return_cmd = false;
+		} else if (cmd->hdr.proto == smr_proto_ipc) {
+			return_cmd = false;
 		}
 		goto out;
 	}

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -119,6 +119,7 @@ static int ofi_hmem_system_dev_reg_copy(uint64_t handle, void *dest,
 struct ofi_hmem_ops hmem_ops[] = {
 	[FI_HMEM_SYSTEM] = {
 		.initialized = true,
+		.async_copy_enabled = false,
 		.init = ofi_hmem_init_noop,
 		.cleanup = ofi_hmem_cleanup_noop,
 		.copy_to_hmem = ofi_memcpy,
@@ -145,15 +146,16 @@ struct ofi_hmem_ops hmem_ops[] = {
 	},
 	[FI_HMEM_CUDA] = {
 		.initialized = false,
+		.async_copy_enabled = false,
 		.init = cuda_hmem_init,
 		.cleanup = cuda_hmem_cleanup,
 		.copy_to_hmem = cuda_copy_to_dev,
 		.copy_from_hmem = cuda_copy_from_dev,
-		.create_async_copy_event = ofi_no_create_async_copy_event,
-		.free_async_copy_event = ofi_no_free_async_copy_event,
-		.async_copy_to_hmem = ofi_no_async_memcpy,
-		.async_copy_from_hmem = ofi_no_async_memcpy,
-		.async_copy_query = ofi_no_async_copy_query,
+		.create_async_copy_event = cuda_create_async_copy_event,
+		.free_async_copy_event = cuda_free_async_copy_event,
+		.async_copy_to_hmem = cuda_async_copy_to_dev,
+		.async_copy_from_hmem = cuda_async_copy_from_dev,
+		.async_copy_query = cuda_async_copy_query,
 		.is_addr_valid = cuda_is_addr_valid,
 		.get_handle = cuda_get_handle,
 		.open_handle = cuda_open_handle,
@@ -172,6 +174,7 @@ struct ofi_hmem_ops hmem_ops[] = {
 	},
 	[FI_HMEM_ROCR] = {
 		.initialized = false,
+		.async_copy_enabled = false,
 		.init = rocr_hmem_init,
 		.cleanup = rocr_hmem_cleanup,
 		.copy_to_hmem = rocr_copy_to_dev,
@@ -199,6 +202,7 @@ struct ofi_hmem_ops hmem_ops[] = {
 	},
 	[FI_HMEM_ZE] = {
 		.initialized = false,
+		.async_copy_enabled = false,
 		.init = ze_hmem_init,
 		.cleanup = ze_hmem_cleanup,
 		.copy_to_hmem = ze_hmem_copy,
@@ -226,6 +230,7 @@ struct ofi_hmem_ops hmem_ops[] = {
 	},
 	[FI_HMEM_NEURON] = {
 		.initialized = false,
+		.async_copy_enabled = false,
 		.init = neuron_hmem_init,
 		.cleanup = neuron_hmem_cleanup,
 		.copy_to_hmem = neuron_copy_to_dev,
@@ -252,6 +257,7 @@ struct ofi_hmem_ops hmem_ops[] = {
 	},
 	[FI_HMEM_SYNAPSEAI] = {
 		.initialized = false,
+		.async_copy_enabled = false,
 		.init = synapseai_init,
 		.cleanup = synapseai_cleanup,
 		.copy_to_hmem = synapseai_copy_to_hmem,
@@ -683,6 +689,22 @@ void ofi_hmem_init(void)
 		if (disable_p2p == 1)
 			ofi_hmem_disable_p2p = true;
 	}
+
+	ofi_hmem_set_async_copy_enabled();
+}
+
+void ofi_hmem_set_async_copy_enabled(void)
+{
+	int enable = 1;
+
+	if (ofi_hmem_is_initialized(FI_HMEM_CUDA)) {
+		fi_param_get_bool(NULL, "hmem_cuda_enable_async_copy",
+				  &enable);
+		hmem_ops[FI_HMEM_CUDA].async_copy_enabled = enable;
+	}
+
+	if (ofi_hmem_is_initialized(FI_HMEM_ROCR))
+		hmem_ops[FI_HMEM_ROCR].async_copy_enabled = true;
 }
 
 void ofi_hmem_cleanup(void)

--- a/src/hmem_cuda.c
+++ b/src/hmem_cuda.c
@@ -94,6 +94,7 @@ CUresult CUDAAPI cuCtxCreate_v2(CUcontext *pctx, unsigned int flags, CUdevice de
 
 #define CUDA_RUNTIME_FUNCS_DEF(_)	\
 	_(cudaMemcpy)			\
+	_(cudaMemcpyAsync)		\
 	_(cudaDeviceSynchronize)	\
 	_(cudaFree)			\
 	_(cudaMalloc)			\
@@ -140,6 +141,8 @@ static struct {
 static struct {
 	cudaError_t (*cudaMemcpy)(void *dst, const void *src, size_t size,
 				  enum cudaMemcpyKind kind);
+	cudaError_t (*cudaMemcpyAsync)(void *dst, const void *src, size_t size,
+				       enum cudaMemcpyKind kind, CUstream stream);
 	cudaError_t (*cudaDeviceSynchronize)(void);
 	cudaError_t (*cudaFree)(void* ptr);
 	cudaError_t (*cudaMalloc)(void** ptr, size_t size);
@@ -903,6 +906,9 @@ int cuda_put_dmabuf_fd(int fd)
 #endif /* HAVE_CUDA_DMABUF */
 }
 
+static int cuda_ipc_event_pool_init(void);
+static void cuda_ipc_event_pool_cleanup(void);
+
 int cuda_hmem_init(void)
 {
 	int ret;
@@ -915,6 +921,10 @@ int cuda_hmem_init(void)
 
 	fi_param_define(NULL, "hmem_cuda_use_dmabuf", FI_PARAM_BOOL,
 			"Use dma-buf for sharing buffer with hardware. (default: true)");
+
+	fi_param_define(NULL, "hmem_cuda_enable_async_copy", FI_PARAM_BOOL,
+			"Allow async copy for CUDA transfers. "
+			"(default: true)");
 
 	ret = cuda_hmem_dl_init();
 	if (ret != FI_SUCCESS)
@@ -970,6 +980,7 @@ int cuda_hmem_cleanup(void)
 	cuda_hmem_dl_cleanup();
 	if (cuda_attr.use_gdrcopy)
 		cuda_gdrcopy_hmem_cleanup();
+	cuda_ipc_event_pool_cleanup();
 	return FI_SUCCESS;
 }
 
@@ -1082,6 +1093,181 @@ int cuda_get_ipc_handle_size(size_t *size)
 	return FI_SUCCESS;
 }
 
+/*
+ * Async copy event: wraps a CUDA stream + event for non-blocking IPC copies.
+ * Pool of CUDA stream+event pairs for async IPC copies.
+ * Fixed-size array of pre-created stream+event pairs, assigned round-robin.
+ * If more copies are in-flight than pool entries, copies share a stream
+ * (serialized by CUDA stream ordering). Matches UCX's approach of
+ * key->stream_id % max_streams.
+ */
+struct cuda_async_copy_event {
+	CUstream stream;
+	CUevent  event;
+};
+
+#define CUDA_IPC_EVENT_POOL_SIZE 128
+
+static struct cuda_async_copy_event cuda_ipc_events[CUDA_IPC_EVENT_POOL_SIZE];
+static ofi_atomic32_t cuda_ipc_event_pool_initialized;
+static ofi_atomic32_t cuda_ipc_event_next;
+static pthread_mutex_t cuda_ipc_event_pool_lock = PTHREAD_MUTEX_INITIALIZER;
+
+static int cuda_ipc_event_pool_init(void)
+{
+	CUresult ret;
+	int i;
+
+	pthread_mutex_lock(&cuda_ipc_event_pool_lock);
+	if (ofi_atomic_load_explicit32(&cuda_ipc_event_pool_initialized,
+				       memory_order_acquire)) {
+		pthread_mutex_unlock(&cuda_ipc_event_pool_lock);
+		return FI_SUCCESS;
+	}
+
+	for (i = 0; i < CUDA_IPC_EVENT_POOL_SIZE; i++) {
+		ret = cuda_ops.cuStreamCreate(&cuda_ipc_events[i].stream,
+					      CU_STREAM_NON_BLOCKING);
+		if (ret != CUDA_SUCCESS) {
+			FI_WARN(&core_prov, FI_LOG_CORE,
+				"cuStreamCreate failed: %d\n", ret);
+			goto fail;
+		}
+
+		ret = cuda_ops.cuEventCreate(&cuda_ipc_events[i].event,
+					     CU_EVENT_DISABLE_TIMING);
+		if (ret != CUDA_SUCCESS) {
+			FI_WARN(&core_prov, FI_LOG_CORE,
+				"cuEventCreate failed: %d\n", ret);
+			cuda_ops.cuStreamDestroy(cuda_ipc_events[i].stream);
+			goto fail;
+		}
+	}
+
+	ofi_atomic_initialize32(&cuda_ipc_event_next, 0);
+	ofi_atomic_store_explicit32(&cuda_ipc_event_pool_initialized, 1,
+				    memory_order_release);
+	pthread_mutex_unlock(&cuda_ipc_event_pool_lock);
+	return FI_SUCCESS;
+
+fail:
+	for (i--; i >= 0; i--) {
+		cuda_ops.cuEventDestroy(cuda_ipc_events[i].event);
+		cuda_ops.cuStreamDestroy(cuda_ipc_events[i].stream);
+	}
+	pthread_mutex_unlock(&cuda_ipc_event_pool_lock);
+	return -FI_ENOSYS;
+}
+
+static void cuda_ipc_event_pool_cleanup(void)
+{
+	int i;
+
+	if (!ofi_atomic_load_explicit32(&cuda_ipc_event_pool_initialized,
+					memory_order_acquire))
+		return;
+
+	for (i = 0; i < CUDA_IPC_EVENT_POOL_SIZE; i++) {
+		cuda_ops.cuEventDestroy(cuda_ipc_events[i].event);
+		cuda_ops.cuStreamDestroy(cuda_ipc_events[i].stream);
+	}
+	ofi_atomic_store_explicit32(&cuda_ipc_event_pool_initialized, 0,
+				    memory_order_release);
+}
+
+int cuda_create_async_copy_event(uint64_t device,
+				 ofi_hmem_async_event_t *event)
+{
+	int idx, ret;
+
+	if (!ofi_atomic_load_explicit32(&cuda_ipc_event_pool_initialized,
+					memory_order_acquire)) {
+		ret = cuda_ipc_event_pool_init();
+		if (ret)
+			return ret;
+	}
+
+	idx = ofi_atomic_inc32(&cuda_ipc_event_next) % CUDA_IPC_EVENT_POOL_SIZE;
+	*event = &cuda_ipc_events[idx];
+	return FI_SUCCESS;
+}
+
+int cuda_free_async_copy_event(uint64_t device, ofi_hmem_async_event_t event)
+{
+	return FI_SUCCESS;
+}
+
+int cuda_async_copy_to_dev(uint64_t device, void *dst, const void *src,
+			   size_t size, ofi_hmem_async_event_t event)
+{
+	struct cuda_async_copy_event *ev = event;
+	cudaError_t cuda_ret;
+	CUresult ret;
+
+	cuda_ret = cuda_ops.cudaMemcpyAsync(dst, src, size,
+					    cudaMemcpyDefault, ev->stream);
+	if (cuda_ret != cudaSuccess) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"cudaMemcpyAsync failed: %s:%s\n",
+			ofi_cudaGetErrorName(cuda_ret),
+			ofi_cudaGetErrorString(cuda_ret));
+		return -FI_EIO;
+	}
+
+	ret = cuda_ops.cuEventRecord(ev->event, ev->stream);
+	if (ret != CUDA_SUCCESS) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"cuEventRecord failed: %d\n", ret);
+		return -FI_EIO;
+	}
+
+	return FI_SUCCESS;
+}
+
+int cuda_async_copy_from_dev(uint64_t device, void *dst, const void *src,
+			     size_t size, ofi_hmem_async_event_t event)
+{
+	struct cuda_async_copy_event *ev = event;
+	cudaError_t cuda_ret;
+	CUresult ret;
+
+	cuda_ret = cuda_ops.cudaMemcpyAsync(dst, src, size,
+					    cudaMemcpyDefault, ev->stream);
+	if (cuda_ret != cudaSuccess) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"cudaMemcpyAsync failed: %s:%s\n",
+			ofi_cudaGetErrorName(cuda_ret),
+			ofi_cudaGetErrorString(cuda_ret));
+		return -FI_EIO;
+	}
+
+	ret = cuda_ops.cuEventRecord(ev->event, ev->stream);
+	if (ret != CUDA_SUCCESS) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"cuEventRecord failed: %d\n", ret);
+		return -FI_EIO;
+	}
+
+	return FI_SUCCESS;
+}
+
+int cuda_async_copy_query(ofi_hmem_async_event_t event)
+{
+	struct cuda_async_copy_event *ev = event;
+	CUresult ret;
+
+	ret = cuda_ops.cuEventQuery(ev->event);
+	if (ret == CUDA_SUCCESS)
+		return FI_SUCCESS;
+
+	if (ret == CUDA_ERROR_NOT_READY)
+		return -FI_EBUSY;
+
+	FI_WARN(&core_prov, FI_LOG_CORE,
+		"cuEventQuery failed: %d\n", ret);
+	return -FI_EIO;
+}
+
 bool cuda_is_gdrcopy_enabled(void)
 {
 	return cuda_attr.use_gdrcopy;
@@ -1108,6 +1294,33 @@ int cuda_copy_to_dev(uint64_t device, void *dev, const void *host, size_t size)
 }
 
 int cuda_copy_from_dev(uint64_t device, void *host, const void *dev, size_t size)
+{
+	return -FI_ENOSYS;
+}
+
+int cuda_create_async_copy_event(uint64_t device, ofi_hmem_async_event_t *event)
+{
+	return -FI_ENOSYS;
+}
+
+int cuda_free_async_copy_event(uint64_t device, ofi_hmem_async_event_t event)
+{
+	return -FI_ENOSYS;
+}
+
+int cuda_async_copy_to_dev(uint64_t device, void *dst, const void *src,
+			   size_t size, ofi_hmem_async_event_t event)
+{
+	return -FI_ENOSYS;
+}
+
+int cuda_async_copy_from_dev(uint64_t device, void *dst, const void *src,
+			     size_t size, ofi_hmem_async_event_t event)
+{
+	return -FI_ENOSYS;
+}
+
+int cuda_async_copy_query(ofi_hmem_async_event_t event)
 {
 	return -FI_ENOSYS;
 }


### PR DESCRIPTION
A series of commits that route CUDA IPC through async copy path, like RoCM