### PR TITLE
prov/efa: Update ibv_qp_attach_comp_cntr_op names

### DIFF
--- a/prov/efa/src/efa_base_ep.c
+++ b/prov/efa/src/efa_base_ep.c
@@ -448,16 +448,16 @@ static int efa_base_ep_create_qp(struct efa_base_ep *base_ep,
 }
 
 /**
- * @brief Map ofi_cntr_index to ibv_comp_cntr_attach_op bit
+ * @brief Map ofi_cntr_index to ibv_qp_attach_comp_cntr_op bit
  */
 #if HAVE_EFADV_CREATE_COMP_CNTR
 static const uint32_t efa_cntr_index_to_ibv_op[] = {
-	[CNTR_TX]     = IBV_COMP_CNTR_ATTACH_OP_SEND,
-	[CNTR_RX]     = IBV_COMP_CNTR_ATTACH_OP_RECV,
-	[CNTR_RD]     = IBV_COMP_CNTR_ATTACH_OP_RDMA_READ,
-	[CNTR_WR]     = IBV_COMP_CNTR_ATTACH_OP_RDMA_WRITE,
-	[CNTR_REM_RD] = IBV_COMP_CNTR_ATTACH_OP_REMOTE_RDMA_READ,
-	[CNTR_REM_WR] = IBV_COMP_CNTR_ATTACH_OP_REMOTE_RDMA_WRITE,
+	[CNTR_TX]     = IBV_QP_ATTACH_COMP_CNTR_OP_SEND,
+	[CNTR_RX]     = IBV_QP_ATTACH_COMP_CNTR_OP_RECV,
+	[CNTR_RD]     = IBV_QP_ATTACH_COMP_CNTR_OP_RDMA_READ,
+	[CNTR_WR]     = IBV_QP_ATTACH_COMP_CNTR_OP_RDMA_WRITE,
+	[CNTR_REM_RD] = IBV_QP_ATTACH_COMP_CNTR_OP_REMOTE_RDMA_READ,
+	[CNTR_REM_WR] = IBV_QP_ATTACH_COMP_CNTR_OP_REMOTE_RDMA_WRITE,
 };
 
 /**
@@ -475,7 +475,7 @@ static int efa_base_ep_attach_comp_cntrs(struct efa_base_ep *base_ep,
 {
 	struct util_cntr *util_cntr;
 	struct efa_cntr *efa_cntr;
-	struct ibv_comp_cntr_attach_attr attr;
+	struct ibv_qp_attach_comp_cntr_attr attr;
 	int i, err;
 
 	for (i = 0; i < CNTR_CNT; i++) {
@@ -486,7 +486,7 @@ static int efa_base_ep_attach_comp_cntrs(struct efa_base_ep *base_ep,
 		efa_cntr = container_of(util_cntr, struct efa_cntr, util_cntr);
 		if (!efa_cntr->ibv_comp_cntr)
 			continue;
-		attr = (struct ibv_comp_cntr_attach_attr){
+		attr = (struct ibv_qp_attach_comp_cntr_attr){
 			.comp_mask = 0,
 			.op_mask = efa_cntr_index_to_ibv_op[i],
 		};

--- a/prov/efa/test/efa_unit_test_mocks.c
+++ b/prov/efa/test/efa_unit_test_mocks.c
@@ -960,21 +960,21 @@ int efa_mock_ibv_destroy_comp_cntr_return_mock(struct ibv_comp_cntr *cntr)
 
 int __wrap_ibv_qp_attach_comp_cntr(struct ibv_qp *qp,
 				   struct ibv_comp_cntr *comp_cntr,
-				   struct ibv_comp_cntr_attach_attr *attr)
+				   struct ibv_qp_attach_comp_cntr_attr *attr)
 {
 	return g_efa_unit_test_mocks.ibv_qp_attach_comp_cntr(qp, comp_cntr, attr);
 }
 
 int efa_mock_ibv_qp_attach_comp_cntr_return_mock(struct ibv_qp *qp,
 						  struct ibv_comp_cntr *comp_cntr,
-						  struct ibv_comp_cntr_attach_attr *attr)
+						  struct ibv_qp_attach_comp_cntr_attr *attr)
 {
 	return 0;
 }
 
 int efa_mock_ibv_qp_attach_comp_cntr_return_enotsup(struct ibv_qp *qp,
 						     struct ibv_comp_cntr *comp_cntr,
-						     struct ibv_comp_cntr_attach_attr *attr)
+						     struct ibv_qp_attach_comp_cntr_attr *attr)
 {
 	return ENOTSUP;
 }

--- a/prov/efa/test/efa_unit_test_mocks.h
+++ b/prov/efa/test/efa_unit_test_mocks.h
@@ -294,7 +294,7 @@ struct efa_unit_test_mocks
 	int (*ibv_read_err_comp_cntr)(struct ibv_comp_cntr *comp_cntr, uint64_t *value);
 	int (*ibv_qp_attach_comp_cntr)(struct ibv_qp *qp,
 				       struct ibv_comp_cntr *comp_cntr,
-				       struct ibv_comp_cntr_attach_attr *attr);
+				       struct ibv_qp_attach_comp_cntr_attr *attr);
 #endif
 };
 
@@ -403,13 +403,13 @@ int efa_mock_ibv_read_comp_cntr_return_mock(struct ibv_comp_cntr *comp_cntr, uin
 int efa_mock_ibv_read_err_comp_cntr_return_mock(struct ibv_comp_cntr *comp_cntr, uint64_t *value);
 int __real_ibv_qp_attach_comp_cntr(struct ibv_qp *qp,
 				   struct ibv_comp_cntr *comp_cntr,
-				   struct ibv_comp_cntr_attach_attr *attr);
+				   struct ibv_qp_attach_comp_cntr_attr *attr);
 int efa_mock_ibv_qp_attach_comp_cntr_return_mock(struct ibv_qp *qp,
 						  struct ibv_comp_cntr *comp_cntr,
-						  struct ibv_comp_cntr_attach_attr *attr);
+						  struct ibv_qp_attach_comp_cntr_attr *attr);
 int efa_mock_ibv_qp_attach_comp_cntr_return_enotsup(struct ibv_qp *qp,
 						     struct ibv_comp_cntr *comp_cntr,
-						     struct ibv_comp_cntr_attach_attr *attr);
+						     struct ibv_qp_attach_comp_cntr_attr *attr);
 #endif
 
 #endif


### PR DESCRIPTION
https://github.com/linux-rdma/rdma-core/pull/1701 renamed ibv_comp_cntr_attach_op to ibv_qp_attach_comp_cntr_op.