### PR TITLE
prov/efa: add gtest unit tests for efa_rma_post_read

### DIFF
--- a/prov/efa/test/gtest/efa_gtest_ah.cc
+++ b/prov/efa/test/gtest/efa_gtest_ah.cc
@@ -77,10 +77,10 @@ TEST_F(EfaAhTest, alloc_enomem_evict_and_retry_succeeds)
 		}));
 
 
-	addr_a = efa_test_insert_peer_new_gid(resource.ep, resource.av);
+	addr_a = efa_test_av_insert_new_ah(resource.ep, resource.av);
 	EXPECT_NE(addr_a, (fi_addr_t) FI_ADDR_NOTAVAIL);
 
-	addr_b = efa_test_insert_peer_new_gid(resource.ep, resource.av);
+	addr_b = efa_test_av_insert_new_ah(resource.ep, resource.av);
 	EXPECT_NE(addr_b, (fi_addr_t) FI_ADDR_NOTAVAIL);
 
 	/* This proves A specifically was the evicted entry */
@@ -111,6 +111,6 @@ TEST_F(EfaAhTest, alloc_enomem_no_evictable_ah_fails)
 			return nullptr;
 		}));
 
-	addr = efa_test_insert_peer_new_gid(resource.ep, resource.av);
+	addr = efa_test_av_insert_new_ah(resource.ep, resource.av);
 	EXPECT_EQ(addr, (fi_addr_t) FI_ADDR_NOTAVAIL);
 }

--- a/prov/efa/test/gtest/efa_gtest_common_helpers.c
+++ b/prov/efa/test/gtest/efa_gtest_common_helpers.c
@@ -4,6 +4,8 @@
 #include "efa.h"
 #include "efa_av.h"
 #include "efa_cq.h"
+#include "efa_mr.h"
+#include "efa_device.h"
 #include "rdm/efa_rdm_ep.h"
 #include "efa_gtest_common_helpers.h"
 
@@ -140,6 +142,28 @@ int efa_test_set_track_mr(int value)
 	return prev;
 }
 
+fi_addr_t efa_test_rma_insert_peer(struct fid_ep *ep, struct fid_av *av)
+{
+	struct efa_ep_addr raw_addr;
+	size_t raw_addr_len = sizeof(raw_addr);
+	fi_addr_t fi_addr = FI_ADDR_NOTAVAIL;
+	int ret;
+
+	/* Reuse the EP's own GID; fi_av_insert's real ibv_create_ah rejects a
+	 * fabricated one. qpn/qkey are not validated, so any value works. */
+	ret = fi_getname(&ep->fid, &raw_addr, &raw_addr_len);
+	if (ret)
+		return FI_ADDR_NOTAVAIL;
+	raw_addr.qpn = 1;
+	raw_addr.qkey = 0x1234;
+
+	ret = fi_av_insert(av, &raw_addr, 1, &fi_addr, 0, NULL);
+	if (ret != 1)
+		return FI_ADDR_NOTAVAIL;
+
+	return fi_addr;
+}
+
 int efa_test_device_supports_rma(void)
 {
 	if (g_efa_selected_device_cnt <= 0)
@@ -160,6 +184,17 @@ size_t efa_test_ope_list_count(struct fid_ep *ep)
 		count++;
 
 	return count;
+}
+
+void efa_test_get_zero_byte_bounce_buf(struct fid_ep *ep, uint64_t *addr,
+				       uint32_t *lkey)
+{
+	struct efa_base_ep *base_ep =
+		container_of(ep, struct efa_base_ep, util_ep.ep_fid);
+	struct efa_domain *domain = base_ep->domain;
+
+	*addr = (uint64_t) domain->zero_byte_bounce_buf;
+	*lkey = domain->zero_byte_bounce_buf_mr->lkey;
 }
 
 struct ibv_ah *efa_test_implicit_addr_to_ibv_ah(struct fid_av *av,

--- a/prov/efa/test/gtest/efa_gtest_common_helpers.c
+++ b/prov/efa/test/gtest/efa_gtest_common_helpers.c
@@ -24,7 +24,7 @@ void efa_test_fabricate_addr(struct fid_ep *ep, struct efa_ep_addr *addr)
 	addr->qkey = 0x5678;
 }
 
-int efa_test_explicit_av_insert(struct fid_ep *ep, struct fid_av *av,
+int efa_test_av_insert_fake_gid(struct fid_ep *ep, struct fid_av *av,
 				fi_addr_t *addr)
 {
 	struct efa_ep_addr raw_addr;
@@ -33,8 +33,8 @@ int efa_test_explicit_av_insert(struct fid_ep *ep, struct fid_av *av,
 	return fi_av_insert(av, &raw_addr, 1, addr, 0, NULL);
 }
 
-int efa_test_insert_self_peer(struct fid_ep *ep, struct fid_av *av,
-			      fi_addr_t *addr)
+int efa_test_av_insert_self(struct fid_ep *ep, struct fid_av *av,
+			    fi_addr_t *addr)
 {
 	struct efa_ep_addr raw_addr = {0};
 	size_t raw_addr_len = sizeof(raw_addr);
@@ -49,7 +49,7 @@ int efa_test_insert_self_peer(struct fid_ep *ep, struct fid_av *av,
 	return fi_av_insert(av, &raw_addr, 1, addr, 0, NULL);
 }
 
-fi_addr_t efa_test_insert_peer_new_gid(struct fid_ep *ep, struct fid_av *av)
+fi_addr_t efa_test_av_insert_new_ah(struct fid_ep *ep, struct fid_av *av)
 {
 	struct efa_rdm_ep *efa_rdm_ep;
 	struct efa_av *efa_av;
@@ -72,21 +72,6 @@ fi_addr_t efa_test_insert_peer_new_gid(struct fid_ep *ep, struct fid_av *av)
 		return FI_ADDR_NOTAVAIL;
 
 	return fi_addr;
-}
-
-fi_addr_t efa_test_insert_self_gid_peer(struct fid_ep *ep, struct fid_av *av)
-{
-	struct efa_ep_addr raw_addr = {0};
-	size_t raw_addr_len = sizeof(raw_addr);
-	fi_addr_t peer_addr = FI_ADDR_NOTAVAIL;
-
-	if (fi_getname(&ep->fid, &raw_addr, &raw_addr_len))
-		return FI_ADDR_NOTAVAIL;
-	raw_addr.qpn = 0;
-	raw_addr.qkey = 0x1234;
-	if (fi_av_insert(av, &raw_addr, 1, &peer_addr, 0, NULL) != 1)
-		return FI_ADDR_NOTAVAIL;
-	return peer_addr;
 }
 
 struct efa_context *efa_test_alloc_context(uint64_t completion_flags,
@@ -140,28 +125,6 @@ int efa_test_set_track_mr(int value)
 
 	efa_env.track_mr = value;
 	return prev;
-}
-
-fi_addr_t efa_test_rma_insert_peer(struct fid_ep *ep, struct fid_av *av)
-{
-	struct efa_ep_addr raw_addr;
-	size_t raw_addr_len = sizeof(raw_addr);
-	fi_addr_t fi_addr = FI_ADDR_NOTAVAIL;
-	int ret;
-
-	/* Reuse the EP's own GID; fi_av_insert's real ibv_create_ah rejects a
-	 * fabricated one. qpn/qkey are not validated, so any value works. */
-	ret = fi_getname(&ep->fid, &raw_addr, &raw_addr_len);
-	if (ret)
-		return FI_ADDR_NOTAVAIL;
-	raw_addr.qpn = 1;
-	raw_addr.qkey = 0x1234;
-
-	ret = fi_av_insert(av, &raw_addr, 1, &fi_addr, 0, NULL);
-	if (ret != 1)
-		return FI_ADDR_NOTAVAIL;
-
-	return fi_addr;
 }
 
 int efa_test_device_supports_rma(void)

--- a/prov/efa/test/gtest/efa_gtest_common_helpers.h
+++ b/prov/efa/test/gtest/efa_gtest_common_helpers.h
@@ -25,64 +25,39 @@ extern "C" {
 #endif
 
 /**
- * @brief Whether the real selected EFA device advertises both RDMA read and
- * write (the condition under which the efa-direct provider advertises FI_RMA).
- * The RMA tests require this: fi_enable creates a real QP with RDMA send-ops
- * flags that a non-RDMA device rejects with -FI_EOPNOTSUPP, so tests query this
- * and GTEST_SKIP on hosts that lack it.
+ * @brief Whether the real selected EFA device advertises both RDMA read and write.
  */
 int efa_test_device_supports_rma(void);
 
 /**
- * @brief Set efa_env.track_mr and return its previous value. Toggling track_mr
- * before EP construction controls whether the direct-ope tracking pool (and
- * thus the efa_direct_ope_alloc/release branch in the post paths) is created.
+ * @brief Set efa_env.track_mr and return its previous value.
  */
 int efa_test_set_track_mr(int value);
 
 /**
- * @brief Insert a fabricated peer via fi_av_insert so efa_av_addr_to_conn
- * returns a valid conn (with ah + ep_addr) for the RMA post paths.
- * @return the fi_addr on success, or FI_ADDR_NOTAVAIL on failure.
- */
-fi_addr_t efa_test_rma_insert_peer(struct fid_ep *ep, struct fid_av *av);
-
-/**
  * @brief Read the domain's zero-byte bounce buffer address and lkey for the
- * endpoint behind @p ep. The 0-byte RMA post paths build their single SGE from
- * these, so a test can assert the SGE was wired to the bounce buffer rather
- * than to caller memory.
+ * endpoint behind @p ep.
  */
 void efa_test_get_zero_byte_bounce_buf(struct fid_ep *ep, uint64_t *addr,
 				       uint32_t *lkey);
 
 /**
- * @brief Fabricate a unique address and insert it via fi_av_insert (explicit
- * path).
- * @return Number of addresses successfully inserted (0 on expected failure).
+ * @brief Insert a peer with a fabricated GID via fi_av_insert.
  */
-int efa_test_explicit_av_insert(struct fid_ep *ep, struct fid_av *av,
+int efa_test_av_insert_fake_gid(struct fid_ep *ep, struct fid_av *av,
 				fi_addr_t *addr);
 
 /**
- * @brief Insert the ep's own address as a peer via an (explicit) fi_av_insert.
- * @return Number of addresses inserted (1 on success), or negative on error.
+ * @brief Insert the ep's own (self) GID as a peer via fi_av_insert.
  */
-int efa_test_insert_self_peer(struct fid_ep *ep, struct fid_av *av,
-			      fi_addr_t *addr);
+int efa_test_av_insert_self(struct fid_ep *ep, struct fid_av *av,
+			    fi_addr_t *addr);
 
 /**
- * @brief Insert a peer with a fabricated GID that won't be in the ah_map.
- * This forces efa_ah_alloc to call ibv_create_ah for a new GID.
- * @return The fi_addr, or FI_ADDR_NOTAVAIL on failure.
+ * @brief Insert a fabricated-GID peer via the RDM-internal efa_av_insert_one.
  */
-fi_addr_t efa_test_insert_peer_new_gid(struct fid_ep *ep, struct fid_av *av);
+fi_addr_t efa_test_av_insert_new_ah(struct fid_ep *ep, struct fid_av *av);
 
-/**
- * @brief Insert a peer using the EP's own GID.
- * @return the fi_addr, or FI_ADDR_NOTAVAIL on failure
- */
-fi_addr_t efa_test_insert_self_gid_peer(struct fid_ep *ep, struct fid_av *av);
 struct efa_ibv_cq;
 struct efa_context;
 
@@ -124,9 +99,7 @@ void efa_test_set_ibv_cq_ex(struct efa_ibv_cq *ibv_cq, int status,
 struct ibv_ah;
 
 /**
- * @brief Resolve an implicit-AV fi_addr to the ibv_ah backing its conn.
- * Lets a test assert which underlying AH a peer insert ended up using
- * (e.g. that an ENOMEM retry kept the newly created AH).
+ * @brief Resolve an implicit-AV fi_addr to the underlying ibv_ah.
  */
 struct ibv_ah *efa_test_implicit_addr_to_ibv_ah(struct fid_av *av,
 						fi_addr_t fi_addr);

--- a/prov/efa/test/gtest/efa_gtest_common_helpers.h
+++ b/prov/efa/test/gtest/efa_gtest_common_helpers.h
@@ -14,6 +14,8 @@
 #ifndef EFA_GTEST_COMMON_HELPERS_H
 #define EFA_GTEST_COMMON_HELPERS_H
 
+#include <stdbool.h>
+#include <stdint.h>
 #include <rdma/fabric.h>
 #include <rdma/fi_domain.h>
 #include <rdma/fi_endpoint.h>
@@ -21,6 +23,38 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @brief Whether the real selected EFA device advertises both RDMA read and
+ * write (the condition under which the efa-direct provider advertises FI_RMA).
+ * The RMA tests require this: fi_enable creates a real QP with RDMA send-ops
+ * flags that a non-RDMA device rejects with -FI_EOPNOTSUPP, so tests query this
+ * and GTEST_SKIP on hosts that lack it.
+ */
+int efa_test_device_supports_rma(void);
+
+/**
+ * @brief Set efa_env.track_mr and return its previous value. Toggling track_mr
+ * before EP construction controls whether the direct-ope tracking pool (and
+ * thus the efa_direct_ope_alloc/release branch in the post paths) is created.
+ */
+int efa_test_set_track_mr(int value);
+
+/**
+ * @brief Insert a fabricated peer via fi_av_insert so efa_av_addr_to_conn
+ * returns a valid conn (with ah + ep_addr) for the RMA post paths.
+ * @return the fi_addr on success, or FI_ADDR_NOTAVAIL on failure.
+ */
+fi_addr_t efa_test_rma_insert_peer(struct fid_ep *ep, struct fid_av *av);
+
+/**
+ * @brief Read the domain's zero-byte bounce buffer address and lkey for the
+ * endpoint behind @p ep. The 0-byte RMA post paths build their single SGE from
+ * these, so a test can assert the SGE was wired to the bounce buffer rather
+ * than to caller memory.
+ */
+void efa_test_get_zero_byte_bounce_buf(struct fid_ep *ep, uint64_t *addr,
+				       uint32_t *lkey);
 
 /**
  * @brief Fabricate a unique address and insert it via fi_av_insert (explicit
@@ -96,10 +130,6 @@ struct ibv_ah;
  */
 struct ibv_ah *efa_test_implicit_addr_to_ibv_ah(struct fid_av *av,
 						fi_addr_t fi_addr);
-
-int efa_test_set_track_mr(int value);
-
-int efa_test_device_supports_rma(void);
 
 size_t efa_test_ope_list_count(struct fid_ep *ep);
 

--- a/prov/efa/test/gtest/efa_gtest_conn.cc
+++ b/prov/efa/test/gtest/efa_gtest_conn.cc
@@ -55,7 +55,7 @@ TEST_F(EfaConnTest, alloc_reverse_av_add_failure_rdm_cleanup)
 	EFA_EXPECT_CALL(mock_efa, efa_av_reverse_av_add)
 		.WillOnce(Return(-FI_ENOMEM));
 
-	addr = efa_test_insert_peer_new_gid(resource.ep, resource.av);
+	addr = efa_test_av_insert_new_ah(resource.ep, resource.av);
 	EXPECT_EQ(addr, (fi_addr_t) FI_ADDR_NOTAVAIL);
 }
 
@@ -88,6 +88,6 @@ TEST_F(EfaConnTest, alloc_reverse_av_add_failure_explicit_insert)
 	EFA_EXPECT_CALL(mock_efa, efa_av_reverse_av_add)
 		.WillOnce(Return(-FI_ENOMEM));
 
-	num_addr = efa_test_explicit_av_insert(resource.ep, resource.av, &addr);
+	num_addr = efa_test_av_insert_fake_gid(resource.ep, resource.av, &addr);
 	EXPECT_EQ(num_addr, 0);
 }

--- a/prov/efa/test/gtest/efa_gtest_msg.cc
+++ b/prov/efa/test/gtest/efa_gtest_msg.cc
@@ -41,9 +41,9 @@ class EfaMsgTest : public Test
 		ASSERT_EQ(ret, 0) << "fi_mr_reg failed: " << fi_strerror(-ret);
 		local_desc = fi_mr_desc(local_mr);
 
-		peer_addr =
-			efa_test_insert_self_gid_peer(resource.ep, resource.av);
-		ASSERT_NE(peer_addr, (fi_addr_t) FI_ADDR_NOTAVAIL);
+		ASSERT_EQ(efa_test_av_insert_self(resource.ep, resource.av,
+						  &peer_addr),
+			  1);
 
 		MockEfa::set(&mock_efa);
 	}

--- a/prov/efa/test/gtest/efa_gtest_rdm_ope_helpers.c
+++ b/prov/efa/test/gtest/efa_gtest_rdm_ope_helpers.c
@@ -18,7 +18,7 @@ int efa_test_drive_rxe_unexp_handle_error(struct fid_ep *ep, void *op_context,
 	int prov_errno = EFA_IO_COMP_STATUS_LOCAL_ERROR_UNREACH_REMOTE;
 	int ret;
 
-	ret = efa_test_insert_self_peer(
+	ret = efa_test_av_insert_self(
 		ep, &efa_rdm_ep->base_ep.util_ep.av->av_fid, &peer_addr);
 	if (ret != 1)
 		return -FI_EINVAL;

--- a/prov/efa/test/gtest/efa_gtest_rdm_peer.cc
+++ b/prov/efa/test/gtest/efa_gtest_rdm_peer.cc
@@ -26,9 +26,9 @@ class EfaRdmPeerTest : public testing::Test
 					   FI_EP_RDM, EFA_FABRIC_NAME));
 		ASSERT_NE(resource.ep, nullptr);
 
-		peer_addr =
-			efa_test_insert_self_gid_peer(resource.ep, resource.av);
-		ASSERT_NE(peer_addr, (fi_addr_t) FI_ADDR_NOTAVAIL);
+		ASSERT_EQ(efa_test_av_insert_self(resource.ep, resource.av,
+						  &peer_addr),
+			  1);
 
 		MockEfa::set(&mock_efa);
 	}

--- a/prov/efa/test/gtest/efa_gtest_rdm_pke_rtm.cc
+++ b/prov/efa/test/gtest/efa_gtest_rdm_pke_rtm.cc
@@ -27,9 +27,9 @@ class EfaRtmTest : public TestWithParam<bool>
 					   FI_EP_RDM, EFA_FABRIC_NAME));
 		ASSERT_NE(resource.ep, nullptr);
 
-		peer_addr =
-			efa_test_insert_self_gid_peer(resource.ep, resource.av);
-		ASSERT_NE(peer_addr, (fi_addr_t) FI_ADDR_NOTAVAIL);
+		ASSERT_EQ(efa_test_av_insert_self(resource.ep, resource.av,
+						  &peer_addr),
+			  1);
 
 		MockEfa::set(&mock_efa);
 	}

--- a/prov/efa/test/gtest/efa_gtest_rma.cc
+++ b/prov/efa/test/gtest/efa_gtest_rma.cc
@@ -18,10 +18,8 @@ static constexpr uint64_t kRemoteAddr = 0x87654321;
 static constexpr uint32_t kRemoteKey = 123456;
 
 /**
- * @brief Covers efa_rma_post_read / efa_rma_post_write, reached through the
- * public fi_read / fi_write ops on an efa-direct EP that requested FI_RMA.
- * Requires a device with RDMA read+write caps; skips otherwise, since fi_enable
- * creates a real QP with RDMA send-ops flags that a non-RDMA device rejects.
+ * @brief Covers efa_rma_post_read / efa_rma_post_write.
+ * Requires a device with RDMA read+write caps; skips otherwise.
  */
 class EfaRmaTest : public Test
 {
@@ -39,11 +37,9 @@ class EfaRmaTest : public Test
 		efa_test_resource_construct(&resource, hints);
 		ASSERT_NE(resource.ep, nullptr);
 
-		/* Insert the peer before installing the mock so fi_av_insert's
-		 * wrapped ibv_create_ah/efadv_query_ah run for real and
-		 * populate conn->ah; we only want to intercept the QP post. */
-		peer_addr = efa_test_rma_insert_peer(resource.ep, resource.av);
-		ASSERT_NE(peer_addr, (fi_addr_t) FI_ADDR_NOTAVAIL);
+		ASSERT_EQ(efa_test_av_insert_self(resource.ep, resource.av,
+						  &peer_addr),
+			  1);
 
 		MockEfa::set(&mock_efa);
 	}

--- a/prov/efa/test/gtest/efa_gtest_rma.cc
+++ b/prov/efa/test/gtest/efa_gtest_rma.cc
@@ -17,6 +17,12 @@ using testing::Truly;
 static constexpr uint64_t kRemoteAddr = 0x87654321;
 static constexpr uint32_t kRemoteKey = 123456;
 
+/**
+ * @brief Covers efa_rma_post_read / efa_rma_post_write, reached through the
+ * public fi_read / fi_write ops on an efa-direct EP that requested FI_RMA.
+ * Requires a device with RDMA read+write caps; skips otherwise, since fi_enable
+ * creates a real QP with RDMA send-ops flags that a non-RDMA device rejects.
+ */
 class EfaRmaTest : public Test
 {
 	protected:
@@ -28,31 +34,45 @@ class EfaRmaTest : public Test
 	void *local_desc = nullptr;
 	int prev_track_mr = 0;
 
-	void construct(size_t buf_size)
+	void construct(struct fi_info *hints)
 	{
-		int ret;
-		struct fi_info *hints = efa_test_alloc_default_hints(
-			FI_EP_RDM, EFA_DIRECT_FABRIC_NAME);
-		ASSERT_NE(hints, nullptr);
-		hints->caps |= FI_RMA;
-		hints->mode |= FI_RX_CQ_DATA;
-
 		efa_test_resource_construct(&resource, hints);
 		ASSERT_NE(resource.ep, nullptr);
 
-		local_buf = (uint8_t *) calloc(buf_size, 1);
+		/* Insert the peer before installing the mock so fi_av_insert's
+		 * wrapped ibv_create_ah/efadv_query_ah run for real and
+		 * populate conn->ah; we only want to intercept the QP post. */
+		peer_addr = efa_test_rma_insert_peer(resource.ep, resource.av);
+		ASSERT_NE(peer_addr, (fi_addr_t) FI_ADDR_NOTAVAIL);
+
+		MockEfa::set(&mock_efa);
+	}
+
+	/* FI_RX_CQ_DATA is required for FI_RMA when the device lacks
+	 * unsolicited-write-recv support, so we always set it. */
+	struct fi_info *make_hints()
+	{
+		struct fi_info *hints = efa_test_alloc_default_hints(
+			FI_EP_RDM, EFA_DIRECT_FABRIC_NAME);
+
+		if (hints) {
+			hints->caps |= FI_RMA;
+			hints->mode |= FI_RX_CQ_DATA;
+		}
+		return hints;
+	}
+
+	void reg_buffer(size_t size)
+	{
+		int ret;
+
+		local_buf = (uint8_t *) calloc(size, 1);
 		ASSERT_NE(local_buf, nullptr);
-		ret = fi_mr_reg(resource.domain, local_buf, buf_size,
+		ret = fi_mr_reg(resource.domain, local_buf, size,
 				FI_SEND | FI_RECV | FI_READ | FI_WRITE, 0, 0, 0,
 				&local_mr, NULL);
 		ASSERT_EQ(ret, 0) << "fi_mr_reg failed: " << fi_strerror(-ret);
 		local_desc = fi_mr_desc(local_mr);
-
-		peer_addr =
-			efa_test_insert_self_gid_peer(resource.ep, resource.av);
-		ASSERT_NE(peer_addr, (fi_addr_t) FI_ADDR_NOTAVAIL);
-
-		MockEfa::set(&mock_efa);
 	}
 
 	void SetUp() override
@@ -62,10 +82,15 @@ class EfaRmaTest : public Test
 				<< "device does not support RDMA read+write";
 
 		memset(&resource, 0, sizeof(resource));
+		/* Normalize track_mr to 0 and remember the real default so a
+		 * test that toggles it stays order-independent. */
+		prev_track_mr = efa_test_set_track_mr(0);
 	}
 
 	void TearDown() override
 	{
+		/* Clear the mock first so teardown's wrapped calls (e.g.
+		 * ibv_destroy_ah) run for real and aren't checked. */
 		MockEfa::set(nullptr);
 
 		if (local_mr) {
@@ -75,28 +100,101 @@ class EfaRmaTest : public Test
 		free(local_buf);
 		local_buf = nullptr;
 
+		/* Reset track_mr only after destruct: efa_ep_close frees the
+		 * direct-ope pool only while track_mr is still set. */
 		efa_test_resource_destruct(&resource);
 		efa_test_set_track_mr(prev_track_mr);
 	}
 };
 
 /**
- * @brief Asserts that efa_rma_post_read with track_mr posts a direct_ope which
- * persists
+ * @brief A 0-byte read takes the zero-byte bounce-buffer branch instead of the
+ * normal SGE-loop path.
  */
-TEST_F(EfaRmaTest, read_success_keeps_direct_ope_alive)
+TEST_F(EfaRmaTest, read_zero_byte_uses_bounce_buffer)
+{
+	ASSERT_NO_FATAL_FAILURE(construct(make_hints()));
+
+	uint64_t bounce_addr;
+	uint32_t bounce_lkey;
+	efa_test_get_zero_byte_bounce_buf(resource.ep, &bounce_addr,
+					  &bounce_lkey);
+
+	/* The single SGE must point at the bounce buffer (addr + lkey) with
+	 * length 0, not at caller memory. */
+	auto sge_is_bounce_buf = Truly([=](const struct ibv_sge *sge) {
+		return sge[0].addr == bounce_addr && sge[0].length == 0 &&
+		       sge[0].lkey == bounce_lkey;
+	});
+
+	/* sge_count forced to 1 even though the caller passed NULL/0-length. */
+	EFA_EXPECT_CALL(mock_efa, efa_qp_post_read, _, sge_is_bounce_buf, 1,
+			kRemoteKey, kRemoteAddr, 0, _, _, _, _)
+		.WillOnce(Return(0));
+
+	int ret = fi_read(resource.ep, NULL, 0, NULL, peer_addr, kRemoteAddr,
+			  kRemoteKey, NULL);
+	EXPECT_EQ(ret, 0);
+}
+
+/**
+ * @brief A post returning ENOMEM is remapped to -FI_EAGAIN.
+ */
+TEST_F(EfaRmaTest, read_post_enomem_maps_to_eagain)
+{
+	ASSERT_NO_FATAL_FAILURE(construct(make_hints()));
+	reg_buffer(4096);
+
+	EFA_EXPECT_CALL(mock_efa, efa_qp_post_read, _, _, 1, kRemoteKey,
+			kRemoteAddr, 0, _, _, _, _)
+		.WillOnce(Return(ENOMEM));
+
+	int ret = fi_read(resource.ep, local_buf, 4096, local_desc, peer_addr,
+			  kRemoteAddr, kRemoteKey, NULL);
+	EXPECT_EQ(ret, -FI_EAGAIN);
+}
+
+/**
+ * @brief A post returning a non-ENOMEM errno is returned negated.
+ */
+TEST_F(EfaRmaTest, read_post_generic_errno_negated)
+{
+	ASSERT_NO_FATAL_FAILURE(construct(make_hints()));
+	reg_buffer(4096);
+
+	/* EFAULT (not ENOMEM) so we exercise the generic "return -err" arm. */
+	EFA_EXPECT_CALL(mock_efa, efa_qp_post_read, _, _, 1, kRemoteKey,
+			kRemoteAddr, 0, _, _, _, _)
+		.WillOnce(Return(EFAULT));
+
+	int ret = fi_read(resource.ep, local_buf, 4096, local_desc, peer_addr,
+			  kRemoteAddr, kRemoteKey, NULL);
+	EXPECT_EQ(ret, -EFAULT);
+}
+
+/**
+ * @brief With track_mr set and a non-NULL context, the read path takes the
+ * direct-ope branch: it posts the direct-ope address (not the efa_context) as
+ * wr_id, and the direct-ope persists on the ope_list past the post.
+ */
+TEST_F(EfaRmaTest, read_track_mr_keeps_direct_ope_alive)
 {
 	struct fi_context2 ctx = {};
 
-	prev_track_mr = efa_test_set_track_mr(1);
+	/* Enable track_mr before construct() so the EP allocates the
+	 * direct-ope pool. */
+	efa_test_set_track_mr(1);
 
-	ASSERT_NO_FATAL_FAILURE(construct(4096));
+	ASSERT_NO_FATAL_FAILURE(construct(make_hints()));
+	reg_buffer(4096);
 
-	auto wr_id_is_not_ctx = Truly([&ctx](uintptr_t wr_id) {
+	/* wr_id is the direct-ope, not &ctx: proves the track_mr branch ran
+	 * rather than the plain efa_context path (&ctx != direct_ope). */
+	auto wr_id_is_direct_ope = Truly([&ctx](uintptr_t wr_id) {
 		return wr_id != 0 && wr_id != (uintptr_t) &ctx;
 	});
 	EFA_EXPECT_CALL(mock_efa, efa_qp_post_read, _, _, 1, kRemoteKey,
-			kRemoteAddr, wr_id_is_not_ctx, _, _, _, _)
+			kRemoteAddr, wr_id_is_direct_ope, _, _, _, _)
 		.WillOnce(Return(0));
 
 	int ret = fi_read(resource.ep, local_buf, 4096, local_desc, peer_addr,
@@ -107,22 +205,23 @@ TEST_F(EfaRmaTest, read_success_keeps_direct_ope_alive)
 }
 
 /**
- * @brief Asserts that efa_rma_post_write with track_mr posts a direct_ope which
- * persists
+ * @brief The efa_rma_post_write track_mr branch: posts the direct-ope as wr_id
+ * and leaves it on the ope_list past the post.
  */
-TEST_F(EfaRmaTest, write_success_keeps_direct_ope_alive)
+TEST_F(EfaRmaTest, write_track_mr_keeps_direct_ope_alive)
 {
 	struct fi_context2 ctx = {};
 
-	prev_track_mr = efa_test_set_track_mr(1);
+	efa_test_set_track_mr(1);
 
-	ASSERT_NO_FATAL_FAILURE(construct(4096));
+	ASSERT_NO_FATAL_FAILURE(construct(make_hints()));
+	reg_buffer(4096);
 
-	auto wr_id_is_not_ctx = Truly([&ctx](uintptr_t wr_id) {
+	auto wr_id_is_direct_ope = Truly([&ctx](uintptr_t wr_id) {
 		return wr_id != 0 && wr_id != (uintptr_t) &ctx;
 	});
 	EFA_EXPECT_CALL(mock_efa, efa_qp_post_write, _, _, 1, _, _, kRemoteKey,
-			kRemoteAddr, wr_id_is_not_ctx, _, _, _, _, _)
+			kRemoteAddr, wr_id_is_direct_ope, _, _, _, _, _)
 		.WillOnce(Return(0));
 
 	int ret = fi_write(resource.ep, local_buf, 4096, local_desc, peer_addr,


### PR DESCRIPTION
Add efa_gtest_rma.cc covering uncovered paths in efa_rma_post_read The following behaviors are covered:
1. A 0-byte read takes the zero-byte bounce-buffer branch instead of the normal SGE-loop path
2. A post returning ENOMEM is remapped to -FI_EAGAIN
3. A post returning a non-ENOMEM errno is returned negated.
4. With track_mr set and a non-NULL context, the read path takes the direct-ope branch