### PR TITLE
prov/efa: add unit tests covering rdm_pke_rtm init functions

### DIFF
--- a/prov/efa/test/gtest/efa_gtest_rdm_pke_rtm.cc
+++ b/prov/efa/test/gtest/efa_gtest_rdm_pke_rtm.cc
@@ -6,11 +6,12 @@
 #include "efa_gtest_common_resource.h"
 #include "efa_gtest_rdm_pke_utils.h"
 #include <gtest/gtest.h>
+#include <string>
 
 using testing::Bool;
 using testing::StrictMock;
 using testing::TestWithParam;
-using testing::Invoke;
+using testing::ValuesIn;
 
 class EfaRtmTest : public TestWithParam<bool>
 {
@@ -61,3 +62,128 @@ INSTANTIATE_TEST_SUITE_P(, EfaRtmTest, Bool(),
 			 [](const testing::TestParamInfo<bool> &info) {
 				 return info.param ? "tagrtm" : "msgrtm";
 			 });
+
+// 16 init functions in efa_rdm_pke_rtm.c plus the eager/zero-header branch
+static const enum efa_test_rtm_variant kRtmInitVariants[] = {
+	EFA_TEST_RTM_EAGER_MSG,		 EFA_TEST_RTM_EAGER_TAG,
+	EFA_TEST_RTM_DC_EAGER_MSG,	 EFA_TEST_RTM_DC_EAGER_TAG,
+	EFA_TEST_RTM_MEDIUM_MSG,	 EFA_TEST_RTM_MEDIUM_TAG,
+	EFA_TEST_RTM_DC_MEDIUM_MSG,	 EFA_TEST_RTM_DC_MEDIUM_TAG,
+	EFA_TEST_RTM_LONGCTS_MSG,	 EFA_TEST_RTM_LONGCTS_TAG,
+	EFA_TEST_RTM_DC_LONGCTS_MSG,	 EFA_TEST_RTM_DC_LONGCTS_TAG,
+	EFA_TEST_RTM_LONGREAD_MSG,	 EFA_TEST_RTM_LONGREAD_TAG,
+	EFA_TEST_RTM_RUNTREAD_MSG,	 EFA_TEST_RTM_RUNTREAD_TAG,
+	EFA_TEST_RTM_EAGER_MSG_ZERO_HDR,
+};
+
+/* gtest test-name suffix, reconstructed from the variant bits. */
+static std::string rtm_variant_name(enum efa_test_rtm_variant v)
+{
+	static const char *family[] = {"eager", "medium", "longcts", "longread",
+				       "runtread"};
+	std::string s;
+	if (EFA_TEST_RTM_IS_DC(v))
+		s += "dc_";
+	s += family[EFA_TEST_RTM_FAMILY(v)];
+	s += EFA_TEST_RTM_IS_TAGGED(v) ? "_tag" : "_msg";
+	if (EFA_TEST_RTM_IS_ZERO_HDR(v))
+		s += "_zero_hdr";
+	return s;
+}
+
+/**
+ * @brief Covers the RTM TX-init functions (efa_rdm_pke_init_*rtm), which stamp
+ * a packet header and copy/describe payload from a txe.
+ */
+class EfaRdmPkeRtmInitTest : public TestWithParam<enum efa_test_rtm_variant>
+{
+	protected:
+	struct efa_resource resource = {};
+
+	void SetUp() override
+	{
+		memset(&resource, 0, sizeof(resource));
+		efa_test_resource_construct(
+			&resource, efa_test_alloc_default_hints(
+					   FI_EP_RDM, EFA_FABRIC_NAME));
+		ASSERT_NE(resource.ep, nullptr);
+	}
+
+	void TearDown() override
+	{
+		efa_test_resource_destruct(&resource);
+	}
+};
+
+/**
+ * @brief Each init function stamps the header fields and payload its protocol
+ * family is responsible for; the variant bits select which fields are asserted
+ * and to which sentinel.
+ */
+TEST_P(EfaRdmPkeRtmInitTest, stamps_header_and_payload)
+{
+	enum efa_test_rtm_variant v = GetParam();
+	bool dc = EFA_TEST_RTM_IS_DC(v);
+	bool tagged = EFA_TEST_RTM_IS_TAGGED(v);
+	struct efa_test_rtm_init_result res;
+
+	efa_test_rtm_init_build(resource.ep, resource.av, v, &res);
+	ASSERT_EQ(res.ret, 0) << "init failed for " << rtm_variant_name(v);
+
+	if (EFA_TEST_RTM_IS_ZERO_HDR(v)) {
+		EXPECT_EQ(res.payload_size, EFA_TEST_RTM_EAGER_LEN);
+		return;
+	}
+
+	EXPECT_EQ(res.base_type, efa_test_rtm_pkt_type(v));
+	EXPECT_TRUE(res.has_msg_flag);
+	EXPECT_EQ(res.msg_id, EFA_TEST_RTM_MSG_ID);
+
+	EXPECT_EQ(res.has_tagged_flag, tagged);
+	EXPECT_EQ(res.tag, tagged ? EFA_TEST_RTM_TAG : 0u);
+
+	EXPECT_EQ(res.dc_requested, dc);
+
+	switch (EFA_TEST_RTM_FAMILY(v)) {
+	case EFA_TEST_RTM_FAM_EAGER:
+		EXPECT_EQ(res.payload_size, EFA_TEST_RTM_EAGER_LEN);
+		EXPECT_EQ(res.send_id, dc ? EFA_TEST_RTM_SEND_ID : 0u);
+		break;
+	case EFA_TEST_RTM_FAM_MEDIUM:
+		EXPECT_EQ(res.payload_size, EFA_TEST_RTM_MEDIUM_DATA);
+		EXPECT_EQ(res.msg_length, EFA_TEST_RTM_LONG_LEN);
+		EXPECT_EQ(res.seg_offset, EFA_TEST_RTM_MEDIUM_SEG);
+		EXPECT_EQ(res.send_id, dc ? EFA_TEST_RTM_SEND_ID : 0u);
+		break;
+	case EFA_TEST_RTM_FAM_LONGCTS:
+		// longcts payload size is mtu_size - req_hdr_size
+		// so it depends on the device
+		EXPECT_GT(res.payload_size, 0u);
+		EXPECT_LT(res.payload_size, EFA_TEST_RTM_LONG_LEN);
+		EXPECT_EQ(res.msg_length, EFA_TEST_RTM_LONG_LEN);
+		EXPECT_EQ(res.send_id, EFA_TEST_RTM_SEND_ID);
+		EXPECT_EQ(res.credit_request,
+			  (uint32_t) efa_test_get_tx_min_credits());
+		break;
+	case EFA_TEST_RTM_FAM_LONGREAD:
+		EXPECT_EQ(res.payload_size, 0u);
+		EXPECT_EQ(res.msg_length, EFA_TEST_RTM_LONG_LEN);
+		EXPECT_EQ(res.send_id, EFA_TEST_RTM_SEND_ID);
+		EXPECT_EQ(res.read_iov_count, 1u);
+		break;
+	case EFA_TEST_RTM_FAM_RUNTREAD:
+		EXPECT_EQ(res.payload_size, EFA_TEST_RTM_RUNT_DATA);
+		EXPECT_EQ(res.msg_length, EFA_TEST_RTM_LONG_LEN);
+		EXPECT_EQ(res.send_id, EFA_TEST_RTM_SEND_ID);
+		EXPECT_EQ(res.seg_offset, EFA_TEST_RTM_RUNT_SEG);
+		EXPECT_EQ(res.runt_length, EFA_TEST_RTM_RUNT_LEN);
+		EXPECT_EQ(res.read_iov_count, 1u);
+		break;
+	}
+}
+
+INSTANTIATE_TEST_SUITE_P(
+	, EfaRdmPkeRtmInitTest, ValuesIn(kRtmInitVariants),
+	[](const testing::TestParamInfo<enum efa_test_rtm_variant> &info) {
+		return rtm_variant_name(info.param);
+	});

--- a/prov/efa/test/gtest/efa_gtest_rdm_pke_utils.c
+++ b/prov/efa/test/gtest/efa_gtest_rdm_pke_utils.c
@@ -1,13 +1,16 @@
 /* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
 /* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
 
+#include "efa_gtest_common_helpers.h"
+#include "efa_gtest_rdm_pke_utils.h"
+#include "efa.h"
+#include "efa_env.h"
 #include "ofi_mem.h"
 #include "rdm/efa_rdm_ep.h"
+#include "rdm/efa_rdm_ope.h"
 #include "rdm/efa_rdm_pke.h"
-#include "efa.h"
-#include "rdm/efa_rdm_ep.h"
 #include "rdm/efa_rdm_pke_rtm.h"
-#include "efa_gtest_rdm_pke_utils.h"
+#include "rdm/efa_rdm_protocol.h"
 
 int efa_test_rtm_read_nack_missing_rxe(struct fid_ep *ep, fi_addr_t peer_addr,
 				       int tagged, ssize_t *ret)
@@ -182,4 +185,261 @@ int efa_test_failed_reorder_msg_overflow_releases_rx_pkt_and_entry(
 	*overflow_free_after =
 		efa_test_bufpool_free_count(efa_rdm_ep->overflow_pke_pool);
 	return 0;
+}
+
+int efa_test_get_tx_min_credits(void)
+{
+	return efa_env.tx_min_credits;
+}
+
+int efa_test_rtm_pkt_type(enum efa_test_rtm_variant variant)
+{
+	switch (variant) {
+	case EFA_TEST_RTM_EAGER_MSG:
+		/* fallthrough */
+	case EFA_TEST_RTM_EAGER_MSG_ZERO_HDR:
+		return EFA_RDM_EAGER_MSGRTM_PKT;
+	case EFA_TEST_RTM_EAGER_TAG:
+		return EFA_RDM_EAGER_TAGRTM_PKT;
+	case EFA_TEST_RTM_DC_EAGER_MSG:
+		return EFA_RDM_DC_EAGER_MSGRTM_PKT;
+	case EFA_TEST_RTM_DC_EAGER_TAG:
+		return EFA_RDM_DC_EAGER_TAGRTM_PKT;
+	case EFA_TEST_RTM_MEDIUM_MSG:
+		return EFA_RDM_MEDIUM_MSGRTM_PKT;
+	case EFA_TEST_RTM_MEDIUM_TAG:
+		return EFA_RDM_MEDIUM_TAGRTM_PKT;
+	case EFA_TEST_RTM_DC_MEDIUM_MSG:
+		return EFA_RDM_DC_MEDIUM_MSGRTM_PKT;
+	case EFA_TEST_RTM_DC_MEDIUM_TAG:
+		return EFA_RDM_DC_MEDIUM_TAGRTM_PKT;
+	case EFA_TEST_RTM_LONGCTS_MSG:
+		return EFA_RDM_LONGCTS_MSGRTM_PKT;
+	case EFA_TEST_RTM_LONGCTS_TAG:
+		return EFA_RDM_LONGCTS_TAGRTM_PKT;
+	case EFA_TEST_RTM_DC_LONGCTS_MSG:
+		return EFA_RDM_DC_LONGCTS_MSGRTM_PKT;
+	case EFA_TEST_RTM_DC_LONGCTS_TAG:
+		return EFA_RDM_DC_LONGCTS_TAGRTM_PKT;
+	case EFA_TEST_RTM_LONGREAD_MSG:
+		return EFA_RDM_LONGREAD_MSGRTM_PKT;
+	case EFA_TEST_RTM_LONGREAD_TAG:
+		return EFA_RDM_LONGREAD_TAGRTM_PKT;
+	case EFA_TEST_RTM_RUNTREAD_MSG:
+		return EFA_RDM_RUNTREAD_MSGRTM_PKT;
+	case EFA_TEST_RTM_RUNTREAD_TAG:
+		return EFA_RDM_RUNTREAD_TAGRTM_PKT;
+	}
+	return -1;
+}
+
+// Construct a txe populated with sentinels
+static struct efa_rdm_ope *efa_test_rtm_alloc_txe(struct efa_rdm_ep *ep,
+						  struct fid_av *av,
+						  uint32_t op, size_t len,
+						  void *buf)
+{
+	fi_addr_t peer_addr;
+	struct efa_rdm_peer *peer;
+	struct iovec iov;
+	struct fi_msg msg = {0};
+	struct efa_rdm_ope *txe;
+
+	if (efa_test_av_insert_self(&ep->base_ep.util_ep.ep_fid, av,
+				    &peer_addr) != 1)
+		return NULL;
+	peer = efa_rdm_ep_get_peer(ep, peer_addr);
+
+	iov.iov_base = buf;
+	iov.iov_len = len;
+	msg.msg_iov = &iov;
+	msg.iov_count = 1;
+	msg.addr = peer_addr;
+
+	txe = ofi_buf_alloc(ep->base_ep.ope_pool);
+	if (!txe)
+		return NULL;
+	efa_rdm_txe_construct(txe, ep, peer, &msg, op, 0, 0);
+
+	txe->msg_id = EFA_TEST_RTM_MSG_ID;
+	txe->tx_id = EFA_TEST_RTM_SEND_ID;
+	txe->tag = EFA_TEST_RTM_TAG;
+	return txe;
+}
+
+void efa_test_rtm_init_build(struct fid_ep *ep, struct fid_av *av,
+			     enum efa_test_rtm_variant variant,
+			     struct efa_test_rtm_init_result *out)
+{
+	struct efa_rdm_ep *efa_rdm_ep =
+		container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
+	struct efa_rdm_ope *txe;
+	struct efa_rdm_pke *pkt_entry;
+	struct efa_rdm_base_hdr *base_hdr;
+	enum efa_test_rtm_family family = EFA_TEST_RTM_FAMILY(variant);
+	uint32_t op =
+		EFA_TEST_RTM_IS_TAGGED(variant) ? ofi_op_tagged : ofi_op_msg;
+
+	size_t total_len = (family == EFA_TEST_RTM_FAM_EAGER) ?
+				   EFA_TEST_RTM_EAGER_LEN :
+				   EFA_TEST_RTM_LONG_LEN;
+	// One buffer large enough for the longest message
+	static char buf[EFA_TEST_RTM_LONG_LEN];
+
+	memset(out, 0, sizeof(*out));
+
+	txe = efa_test_rtm_alloc_txe(efa_rdm_ep, av, op, total_len, buf);
+	if (!txe) {
+		out->ret = -FI_ENOMEM;
+		return;
+	}
+	if (family == EFA_TEST_RTM_FAM_RUNTREAD)
+		txe->bytes_runt = EFA_TEST_RTM_RUNT_LEN;
+
+	pkt_entry = efa_rdm_pke_alloc(efa_rdm_ep, efa_rdm_ep->efa_tx_pkt_pool,
+				      EFA_RDM_PKE_FROM_EFA_TX_POOL);
+	if (!pkt_entry) {
+		efa_rdm_txe_release(txe);
+		out->ret = -FI_ENOMEM;
+		return;
+	}
+
+	switch (variant) {
+	case EFA_TEST_RTM_EAGER_MSG_ZERO_HDR:
+		pkt_entry->flags |= EFA_RDM_PKE_HAS_NO_BASE_HDR;
+		/* fallthrough */
+	case EFA_TEST_RTM_EAGER_MSG:
+		out->ret = efa_rdm_pke_init_eager_msgrtm(pkt_entry, txe);
+		break;
+	case EFA_TEST_RTM_EAGER_TAG:
+		out->ret = efa_rdm_pke_init_eager_tagrtm(pkt_entry, txe);
+		break;
+	case EFA_TEST_RTM_DC_EAGER_MSG:
+		out->ret = efa_rdm_pke_init_dc_eager_msgrtm(pkt_entry, txe);
+		break;
+	case EFA_TEST_RTM_DC_EAGER_TAG:
+		out->ret = efa_rdm_pke_init_dc_eager_tagrtm(pkt_entry, txe);
+		break;
+	case EFA_TEST_RTM_MEDIUM_MSG:
+		out->ret = efa_rdm_pke_init_medium_msgrtm(
+			pkt_entry, txe, EFA_TEST_RTM_MEDIUM_SEG,
+			EFA_TEST_RTM_MEDIUM_DATA);
+		break;
+	case EFA_TEST_RTM_MEDIUM_TAG:
+		out->ret = efa_rdm_pke_init_medium_tagrtm(
+			pkt_entry, txe, EFA_TEST_RTM_MEDIUM_SEG,
+			EFA_TEST_RTM_MEDIUM_DATA);
+		break;
+	case EFA_TEST_RTM_DC_MEDIUM_MSG:
+		out->ret = efa_rdm_pke_init_dc_medium_msgrtm(
+			pkt_entry, txe, EFA_TEST_RTM_MEDIUM_SEG,
+			EFA_TEST_RTM_MEDIUM_DATA);
+		break;
+	case EFA_TEST_RTM_DC_MEDIUM_TAG:
+		out->ret = efa_rdm_pke_init_dc_medium_tagrtm(
+			pkt_entry, txe, EFA_TEST_RTM_MEDIUM_SEG,
+			EFA_TEST_RTM_MEDIUM_DATA);
+		break;
+	case EFA_TEST_RTM_LONGCTS_MSG:
+		out->ret = efa_rdm_pke_init_longcts_msgrtm(pkt_entry, txe);
+		break;
+	case EFA_TEST_RTM_LONGCTS_TAG:
+		out->ret = efa_rdm_pke_init_longcts_tagrtm(pkt_entry, txe);
+		break;
+	case EFA_TEST_RTM_DC_LONGCTS_MSG:
+		out->ret = efa_rdm_pke_init_dc_longcts_msgrtm(pkt_entry, txe);
+		break;
+	case EFA_TEST_RTM_DC_LONGCTS_TAG:
+		out->ret = efa_rdm_pke_init_dc_longcts_tagrtm(pkt_entry, txe);
+		break;
+	case EFA_TEST_RTM_LONGREAD_MSG:
+		out->ret = efa_rdm_pke_init_longread_msgrtm(pkt_entry, txe);
+		break;
+	case EFA_TEST_RTM_LONGREAD_TAG:
+		out->ret = efa_rdm_pke_init_longread_tagrtm(pkt_entry, txe);
+		break;
+	case EFA_TEST_RTM_RUNTREAD_MSG:
+		out->ret = efa_rdm_pke_init_runtread_msgrtm(
+			pkt_entry, txe, EFA_TEST_RTM_RUNT_SEG,
+			EFA_TEST_RTM_RUNT_DATA);
+		break;
+	case EFA_TEST_RTM_RUNTREAD_TAG:
+		out->ret = efa_rdm_pke_init_runtread_tagrtm(
+			pkt_entry, txe, EFA_TEST_RTM_RUNT_SEG,
+			EFA_TEST_RTM_RUNT_DATA);
+		break;
+	}
+
+	if (out->ret)
+		goto release;
+
+	out->payload_size = pkt_entry->payload_size;
+	out->dc_requested = !!(txe->internal_flags &
+			       EFA_RDM_TXE_DELIVERY_COMPLETE_REQUESTED);
+
+	// The zero-hdr eager packet carries no header so stop before dereferencing wiredata
+	if (EFA_TEST_RTM_IS_ZERO_HDR(variant))
+		goto release;
+
+	base_hdr = (struct efa_rdm_base_hdr *) pkt_entry->wiredata;
+	out->base_type = base_hdr->type;
+	out->has_msg_flag = !!(base_hdr->flags & EFA_RDM_REQ_MSG);
+	out->has_tagged_flag = !!(base_hdr->flags & EFA_RDM_REQ_TAGGED);
+	out->msg_id = efa_rdm_pke_get_rtm_base_hdr(pkt_entry)->msg_id;
+	if (EFA_TEST_RTM_IS_TAGGED(variant))
+		out->tag = efa_rdm_pke_get_rtm_tag(pkt_entry);
+
+	switch (family) {
+	case EFA_TEST_RTM_FAM_EAGER:
+		/* Only the DC eager header carries send_id. */
+		if (EFA_TEST_RTM_IS_DC(variant))
+			out->send_id =
+				efa_rdm_pke_get_dc_eager_rtm_base_hdr(pkt_entry)
+					->send_id;
+		break;
+	case EFA_TEST_RTM_FAM_MEDIUM:
+		if (EFA_TEST_RTM_IS_DC(variant)) {
+			struct efa_rdm_dc_medium_rtm_base_hdr *h =
+				efa_rdm_pke_get_dc_medium_rtm_base_hdr(pkt_entry);
+			out->msg_length = h->msg_length;
+			out->seg_offset = h->seg_offset;
+			out->send_id = h->send_id;
+		} else {
+			struct efa_rdm_medium_rtm_base_hdr *h =
+				efa_rdm_pke_get_medium_rtm_base_hdr(pkt_entry);
+			out->msg_length = h->msg_length;
+			out->seg_offset = h->seg_offset;
+		}
+		break;
+	case EFA_TEST_RTM_FAM_LONGCTS: {
+		struct efa_rdm_longcts_rtm_base_hdr *h =
+			efa_rdm_pke_get_longcts_rtm_base_hdr(pkt_entry);
+		out->msg_length = h->msg_length;
+		out->send_id = h->send_id;
+		out->credit_request = h->credit_request;
+		break;
+	}
+	case EFA_TEST_RTM_FAM_LONGREAD: {
+		struct efa_rdm_longread_rtm_base_hdr *h =
+			efa_rdm_pke_get_longread_rtm_base_hdr(pkt_entry);
+		out->msg_length = h->msg_length;
+		out->send_id = h->send_id;
+		out->read_iov_count = h->read_iov_count;
+		break;
+	}
+	case EFA_TEST_RTM_FAM_RUNTREAD: {
+		struct efa_rdm_runtread_rtm_base_hdr *h =
+			efa_rdm_pke_get_runtread_rtm_base_hdr(pkt_entry);
+		out->msg_length = h->msg_length;
+		out->send_id = h->send_id;
+		out->seg_offset = h->seg_offset;
+		out->runt_length = h->runt_length;
+		out->read_iov_count = h->read_iov_count;
+		break;
+	}
+	}
+
+release:
+	efa_rdm_pke_release_tx(pkt_entry);
+	efa_rdm_txe_release(txe);
 }

--- a/prov/efa/test/gtest/efa_gtest_rdm_pke_utils.h
+++ b/prov/efa/test/gtest/efa_gtest_rdm_pke_utils.h
@@ -2,13 +2,14 @@
 /* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All
  * rights reserved. */
 
-/* C-linkage bridge for rdm pke tests. 
+/* C-linkage bridge for rdm pke tests.
  * See efa_gtest_common_helpers.h for why this exists. */
 
 #ifndef EFA_GTEST_RDM_PKE_UTILS_H
 #define EFA_GTEST_RDM_PKE_UTILS_H
 
 #include <rdma/fabric.h>
+#include <rdma/fi_domain.h>
 #include <rdma/fi_endpoint.h>
 
 #ifdef __cplusplus
@@ -52,6 +53,106 @@ int efa_test_failed_reorder_msg_overflow_releases_rx_pkt_and_entry(
 	struct fid_ep *ep, fi_addr_t peer_addr, size_t *to_post_before,
 	size_t *to_post_after, size_t *overflow_free_before,
 	size_t *overflow_free_after);
+
+// Sentinel values that will be used in assertions
+#define EFA_TEST_RTM_TAG	 0x1234567890abcdefULL
+#define EFA_TEST_RTM_MSG_ID	 0x4321u
+#define EFA_TEST_RTM_SEND_ID	 0x5678u
+#define EFA_TEST_RTM_EAGER_LEN	 64u
+#define EFA_TEST_RTM_LONG_LEN	 65536u
+#define EFA_TEST_RTM_MEDIUM_SEG	 128u
+#define EFA_TEST_RTM_MEDIUM_DATA 256u
+#define EFA_TEST_RTM_RUNT_LEN	 4096u
+#define EFA_TEST_RTM_RUNT_SEG	 2048u
+#define EFA_TEST_RTM_RUNT_DATA	 2048u
+
+enum efa_test_rtm_family {
+	EFA_TEST_RTM_FAM_EAGER,
+	EFA_TEST_RTM_FAM_MEDIUM,
+	EFA_TEST_RTM_FAM_LONGCTS,
+	EFA_TEST_RTM_FAM_LONGREAD,
+	EFA_TEST_RTM_FAM_RUNTREAD,
+};
+
+#define EFA_TEST_RTM_FAMILY_MASK 0x7u
+#define EFA_TEST_RTM_TAGGED	 (1u << 3)
+#define EFA_TEST_RTM_DC		 (1u << 4)
+#define EFA_TEST_RTM_ZERO_HDR	 (1u << 5)
+
+#define EFA_TEST_RTM_FAMILY(v) \
+	((enum efa_test_rtm_family)((v) & EFA_TEST_RTM_FAMILY_MASK))
+#define EFA_TEST_RTM_IS_TAGGED(v)   (!!((v) & EFA_TEST_RTM_TAGGED))
+#define EFA_TEST_RTM_IS_DC(v)	    (!!((v) & EFA_TEST_RTM_DC))
+#define EFA_TEST_RTM_IS_ZERO_HDR(v) (!!((v) & EFA_TEST_RTM_ZERO_HDR))
+
+// All 16 init functions in efa_rdm_pke_rtm.c + eager w/o base header
+enum efa_test_rtm_variant {
+	EFA_TEST_RTM_EAGER_MSG = EFA_TEST_RTM_FAM_EAGER,
+	EFA_TEST_RTM_EAGER_TAG = EFA_TEST_RTM_FAM_EAGER | EFA_TEST_RTM_TAGGED,
+	EFA_TEST_RTM_DC_EAGER_MSG = EFA_TEST_RTM_FAM_EAGER | EFA_TEST_RTM_DC,
+	EFA_TEST_RTM_DC_EAGER_TAG =
+		EFA_TEST_RTM_FAM_EAGER | EFA_TEST_RTM_TAGGED | EFA_TEST_RTM_DC,
+	EFA_TEST_RTM_MEDIUM_MSG = EFA_TEST_RTM_FAM_MEDIUM,
+	EFA_TEST_RTM_MEDIUM_TAG = EFA_TEST_RTM_FAM_MEDIUM | EFA_TEST_RTM_TAGGED,
+	EFA_TEST_RTM_DC_MEDIUM_MSG = EFA_TEST_RTM_FAM_MEDIUM | EFA_TEST_RTM_DC,
+	EFA_TEST_RTM_DC_MEDIUM_TAG =
+		EFA_TEST_RTM_FAM_MEDIUM | EFA_TEST_RTM_TAGGED | EFA_TEST_RTM_DC,
+	EFA_TEST_RTM_LONGCTS_MSG = EFA_TEST_RTM_FAM_LONGCTS,
+	EFA_TEST_RTM_LONGCTS_TAG =
+		EFA_TEST_RTM_FAM_LONGCTS | EFA_TEST_RTM_TAGGED,
+	EFA_TEST_RTM_DC_LONGCTS_MSG =
+		EFA_TEST_RTM_FAM_LONGCTS | EFA_TEST_RTM_DC,
+	EFA_TEST_RTM_DC_LONGCTS_TAG = EFA_TEST_RTM_FAM_LONGCTS |
+				      EFA_TEST_RTM_TAGGED | EFA_TEST_RTM_DC,
+	EFA_TEST_RTM_LONGREAD_MSG = EFA_TEST_RTM_FAM_LONGREAD,
+	EFA_TEST_RTM_LONGREAD_TAG =
+		EFA_TEST_RTM_FAM_LONGREAD | EFA_TEST_RTM_TAGGED,
+	EFA_TEST_RTM_RUNTREAD_MSG = EFA_TEST_RTM_FAM_RUNTREAD,
+	EFA_TEST_RTM_RUNTREAD_TAG =
+		EFA_TEST_RTM_FAM_RUNTREAD | EFA_TEST_RTM_TAGGED,
+	EFA_TEST_RTM_EAGER_MSG_ZERO_HDR =
+		EFA_TEST_RTM_FAM_EAGER | EFA_TEST_RTM_ZERO_HDR,
+};
+
+// Header fields read from the built packet
+struct efa_test_rtm_init_result {
+	ssize_t ret; /* return code of the init function */
+	int base_type;
+	int has_msg_flag;
+	int has_tagged_flag;
+	int dc_requested;
+	uint32_t msg_id;
+	uint64_t tag;
+	uint32_t send_id;
+	uint32_t credit_request;
+	uint32_t read_iov_count;
+	uint64_t msg_length;
+	uint64_t seg_offset;
+	uint64_t runt_length;
+	size_t payload_size;
+};
+
+/**
+ * @brief Build one RTM packet via its init function and report header fields.
+ *
+ * Inserts a peer, constructs a txe populated with sentinels, allocates
+ * a TX packet, calls the variant's init function, reads the result into @p out,
+ * and releases the packet and txe.
+ *
+ * @param[in]	ep	the endpoint
+ * @param[in]	av	the endpoint's AV (peer is inserted here)
+ * @param[in]	variant	which init function and protocol family to exercise
+ * @param[out]	out	populated header fields and init return code
+ */
+void efa_test_rtm_init_build(struct fid_ep *ep, struct fid_av *av,
+			     enum efa_test_rtm_variant variant,
+			     struct efa_test_rtm_init_result *out);
+
+/** @brief rtm variant -> EFA_RDM_*_PKT lookup.
+ */
+int efa_test_rtm_pkt_type(enum efa_test_rtm_variant variant);
+
+int efa_test_get_tx_min_credits(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Exhaustively exercise all rdm_pke_rtm init functions, with 16 inits and 1 additional zero header branch in eager_msg