### PR TITLE
common: skip point-to-point ifaces in ofi_get_list_of_addr

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -2124,6 +2124,17 @@ void ofi_get_list_of_addr(const struct fi_provider *prov, const char *env_name,
 		    (ifa->ifa_addr->sa_family != AF_INET6)))
 			continue;
 
+		/* Skip VPN/PPP tunnels unless explicitly requested. IFF_POINTOPOINT
+		 * is not defined on Windows, so guard accordingly. */
+#ifdef IFF_POINTOPOINT
+		if (!iface && (ifa->ifa_flags & IFF_POINTOPOINT)) {
+			FI_DBG(prov, FI_LOG_CORE,
+				"Skip point-to-point interface (%s)\n",
+				ifa->ifa_name);
+			continue;
+		}
+#endif /* IFF_POINTOPOINT */
+
 		addr_entry = calloc(1, sizeof(*addr_entry));
 		if (!addr_entry)
 			continue;


### PR DESCRIPTION
On hosts with an active VPN, getifaddrs() may return the tunnel interface (IFF_POINTOPOINT) before the physical NIC.  When a tunnel address is selected as the default source, TCP connections between endpoints on the same node are routed through the VPN gateway and never complete, making communication impossible.

Skip IFF_POINTOPOINT interfaces during automatic enumeration unless the user has explicitly named the interface via FI_IFACE.

Affects all providers using ofi_ip_getinfo() (tcp, sockets).