### PR TITLE
[v2.6.x] prov/ucx: fix setting FI_UCX_TLS

### DIFF
--- a/prov/ucx/src/ucx_init.c
+++ b/prov/ucx/src/ucx_init.c
@@ -283,8 +283,7 @@ static int ucx_getinfo(uint32_t version, const char *node,
 	if (status != FI_SUCCESS)
 		tls = auto_val;
 
-	if (strncmp(tls, auto_val, strlen(auto_val)) != 0 &&
-	    getenv("UCX_TLS"))
+	if (strncmp(tls, auto_val, strlen(auto_val)))
 		setenv("UCX_TLS", tls, 0);
 
 	status = fi_param_get(&ucx_prov, "ep_flush", &ucx_descriptor.ep_flush);


### PR DESCRIPTION
We want to only apply FI_UCX_TLS to UCX_TLS if UCX_TLS is not already set in the environment, but the existing getenv check would only allow falling into the setenv call if UCX_TLS exists in the environment

Instead, just rely on the setenv (without override).


(cherry picked from commit 4cbe593da67958685c9bbb8e17379df4b34bffa2)