### PR TITLE
prov/efa: Fix segfault on qp_table access during fi_fini teardown

### DIFF
--- a/prov/efa/src/efa_base_ep.c
+++ b/prov/efa/src/efa_base_ep.c
@@ -95,7 +95,9 @@ int efa_base_ep_destruct_qp_unsafe(struct efa_base_ep *base_ep)
 		if (rx_cq != tx_cq)
 			efa_cq_invalidate_cur_wq(rx_cq, qp);
 		efa_qp_destruct(qp);
-		domain->device->qp_table[qp_num & domain->device->qp_table_sz_m1] = NULL;
+		if (OFI_LIKELY(ofi_atomic_load_explicit32(
+			&domain->device->qp_table_initialized, memory_order_acquire)))
+			domain->device->qp_table[qp_num & domain->device->qp_table_sz_m1] = NULL;
 		base_ep->qp = NULL;
 	}
 
@@ -545,6 +547,10 @@ int efa_base_ep_enable_qp(struct efa_base_ep *base_ep, struct efa_qp *qp)
 		rq_wq->shifted_gen = qp->data_path_direct_qp.gen << __builtin_ctz(rq_wq->desc_mask + 1);
 	}
 #endif
+
+	if (OFI_UNLIKELY(!ofi_atomic_load_explicit32(
+		&base_ep->domain->device->qp_table_initialized, memory_order_acquire)))
+		return -FI_ESHUTDOWN;
 
 	base_ep->domain->device->qp_table[qp->qp_num & base_ep->domain->device->qp_table_sz_m1] = qp;
 

--- a/prov/efa/src/efa_data_path_direct_entry.h
+++ b/prov/efa/src/efa_data_path_direct_entry.h
@@ -181,6 +181,10 @@ static inline int efa_data_path_direct_start_poll(struct efa_ibv_cq *ibv_cq,
 	if (!data_path_direct->cur_cqe)
 		return ENOENT;
 
+	if (OFI_UNLIKELY(!ofi_atomic_load_explicit32(
+		&efa_domain->device->qp_table_initialized, memory_order_acquire)))
+		return ENOENT;
+
 	qpn = data_path_direct->cur_cqe->qp_num;
 	data_path_direct->cur_qp =
 		efa_domain->device->qp_table[qpn & efa_domain->device->qp_table_sz_m1];

--- a/prov/efa/src/efa_data_path_ops.h
+++ b/prov/efa/src/efa_data_path_ops.h
@@ -542,7 +542,13 @@ static inline void efa_cq_end_poll(struct efa_ibv_cq *cq)
 
 static inline struct efa_base_ep *efa_ibv_cq_get_base_ep_from_cur_cqe(struct efa_ibv_cq *cq, struct efa_domain *efa_domain)
 {
-	struct efa_qp *qp = efa_domain->device->qp_table[efa_ibv_cq_wc_read_qp_num(cq) & efa_domain->device->qp_table_sz_m1];
+	struct efa_qp *qp;
+
+	if (OFI_UNLIKELY(!ofi_atomic_load_explicit32(
+		&efa_domain->device->qp_table_initialized, memory_order_acquire)))
+		return NULL;
+
+	qp = efa_domain->device->qp_table[efa_ibv_cq_wc_read_qp_num(cq) & efa_domain->device->qp_table_sz_m1];
 
 	return qp ? qp->base_ep : NULL;
 }

--- a/prov/efa/src/efa_device.c
+++ b/prov/efa/src/efa_device.c
@@ -212,6 +212,8 @@ int efa_device_construct_data(struct efa_device *efa_device,
 	if (err)
 		goto err_close;
 
+	ofi_atomic_store_explicit32(&efa_device->qp_table_initialized, 1,
+				    memory_order_release);
 	return 0;
 
 err_close:
@@ -249,6 +251,9 @@ err_close:
 void efa_device_destruct(struct efa_device *device)
 {
 	int err;
+
+	ofi_atomic_store_explicit32(&device->qp_table_initialized, 0,
+				    memory_order_release);
 
 	if (device->qp_table) {
 		free(device->qp_table);

--- a/prov/efa/src/efa_device.h
+++ b/prov/efa/src/efa_device.h
@@ -9,6 +9,7 @@
 #include <infiniband/efadv.h>
 #include <stdbool.h>
 #include "ofi_lock.h"
+#include "ofi_atom.h"
 
 struct efa_qp;
 
@@ -22,7 +23,12 @@ struct efa_device {
 	uint32_t		max_rdma_size;
 	struct fi_info		*rdm_info;
 	struct fi_info		*dgram_info;
-	/* QP table and lock for device-level QP management */
+	/* QP table and lock for device-level QP management.
+	 * qp_table_initialized guards against use-after-free during fi_fini:
+	 * the library destructor may free qp_table while other threads are
+	 * still accessing the qp_table.
+	 */
+	ofi_atomic32_t		qp_table_initialized;
 	struct efa_qp		**qp_table;
 	uint8_t			*qp_gen_table;
 	size_t			qp_table_sz_m1;

--- a/prov/efa/test/efa_unit_test_device.c
+++ b/prov/efa/test/efa_unit_test_device.c
@@ -31,3 +31,49 @@ void test_efa_device_construct_error_handling(void **state)
 	ibv_free_device_list(ibv_device_list);
 }
 
+/**
+ * @brief Verify that qp_table_initialized is set after successful device
+ * construction and that it is accessible from the domain.
+ */
+void test_efa_device_qp_table_initialized_after_construct(void **state)
+{
+	struct efa_resource *resource = *state;
+	struct efa_domain *efa_domain;
+
+	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_FABRIC_NAME);
+
+	efa_domain = container_of(resource->domain, struct efa_domain,
+				  util_domain.domain_fid);
+
+	assert_int_equal(
+		ofi_atomic_load_explicit32(&efa_domain->device->qp_table_initialized,
+					   memory_order_acquire), 1);
+}
+
+/**
+ * @brief Verify that fi_close(ep) does not crash when
+ * qp_table_initialized is 0 (simulates fi_fini teardown race).
+ */
+void test_efa_device_ep_close_after_table_invalidated(void **state)
+{
+	struct efa_resource *resource = *state;
+	struct efa_domain *efa_domain;
+
+	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_FABRIC_NAME);
+
+	efa_domain = container_of(resource->domain, struct efa_domain,
+				  util_domain.domain_fid);
+
+	/* Simulate the destructor clearing the flag */
+	ofi_atomic_store_explicit32(&efa_domain->device->qp_table_initialized, 0,
+				    memory_order_release);
+
+	/* fi_close(ep) should not crash — destruct_qp_unsafe skips the qp_table write */
+	assert_int_equal(fi_close(&resource->ep->fid), 0);
+	resource->ep = NULL;
+
+	/* Restore for clean teardown of remaining resources */
+	ofi_atomic_store_explicit32(&efa_domain->device->qp_table_initialized, 1,
+				    memory_order_release);
+}
+

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -234,8 +234,13 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_ah_lru_eviction_implicit_av_insert, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		/* end efa_unit_test_av.c */
 
-		/* begin efa_unit_test_ep.c */
+		/* begin efa_unit_test_device.c */
 		cmocka_unit_test_setup_teardown(test_efa_device_construct_error_handling, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_device_qp_table_initialized_after_construct, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_device_ep_close_after_table_invalidated, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		/* end efa_unit_test_device.c */
+
+		/* begin efa_unit_test_ep.c */
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ep_ignore_missing_host_id_file, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ep_has_valid_host_id, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ep_ignore_short_host_id, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -129,6 +129,8 @@ void test_ah_lru_eviction_implicit_av_insert(void **state);
 /* end efa_unit_test_av.c */
 
 void test_efa_device_construct_error_handling(void **state);
+void test_efa_device_qp_table_initialized_after_construct(void **state);
+void test_efa_device_ep_close_after_table_invalidated(void **state);
 void test_efa_rdm_ep_ignore_missing_host_id_file(void **state);
 void test_efa_rdm_ep_has_valid_host_id(void **state);
 void test_efa_rdm_ep_ignore_short_host_id(void **state);


### PR DESCRIPTION
When the process calls exit() with threads still active inside the EFA provider (e.g. CQ polling or EP close), the fi_fini library destructor frees device->qp_table while those threads are still dereferencing it, causing a segfault.

On ARM/aarch64, plain pointer loads are not guaranteed to be atomic so we can not do simple NULL check.
Add an atomic qp_table_initialized flag to struct efa_device. The flag is set with release semantics after the table is fully constructed, and cleared with release semantics before the table is freed. All qp_table dereference sites now check this flag with acquire semantics and bail gracefully if the table has been invalidated.