### PR TITLE
prov/efa: unit tests for rdm_pke_rtm handlers

### DIFF
--- a/prov/efa/test/gtest/efa_gtest_rdm_pke_rtm.cc
+++ b/prov/efa/test/gtest/efa_gtest_rdm_pke_rtm.cc
@@ -10,10 +10,12 @@
 
 using testing::Bool;
 using testing::StrictMock;
+using testing::Test;
 using testing::TestWithParam;
 using testing::ValuesIn;
+using testing::WithParamInterface;
 
-class EfaRtmTest : public TestWithParam<bool>
+class EfaRtmRecvTest : public TestWithParam<bool>
 {
 	protected:
 	struct efa_resource resource = {};
@@ -46,7 +48,7 @@ class EfaRtmTest : public TestWithParam<bool>
  * @brief Asserts that a READ_NACK RTM whose msg_id misses the peer's rxe_map is
  * handled (not a NULL deref) in both efa_rdm_pke_proc_{msg/tag}rtm
  */
-TEST_P(EfaRtmTest, read_nack_missing_rxe_no_null_deref)
+TEST_P(EfaRtmRecvTest, read_nack_missing_rxe_no_null_deref)
 {
 	ssize_t ret = 0;
 
@@ -58,7 +60,7 @@ TEST_P(EfaRtmTest, read_nack_missing_rxe_no_null_deref)
 	EXPECT_NE(ret, 0);
 }
 
-INSTANTIATE_TEST_SUITE_P(, EfaRtmTest, Bool(),
+INSTANTIATE_TEST_SUITE_P(, EfaRtmRecvTest, Bool(),
 			 [](const testing::TestParamInfo<bool> &info) {
 				 return info.param ? "tagrtm" : "msgrtm";
 			 });
@@ -91,11 +93,7 @@ static std::string rtm_variant_name(enum efa_test_rtm_variant v)
 	return s;
 }
 
-/**
- * @brief Covers the RTM TX-init functions (efa_rdm_pke_init_*rtm), which stamp
- * a packet header and copy/describe payload from a txe.
- */
-class EfaRdmPkeRtmInitTest : public TestWithParam<enum efa_test_rtm_variant>
+class EfaRtmTxFixture : public Test
 {
 	protected:
 	struct efa_resource resource = {};
@@ -116,11 +114,21 @@ class EfaRdmPkeRtmInitTest : public TestWithParam<enum efa_test_rtm_variant>
 };
 
 /**
+ * @brief Covers the RTM TX-init functions (efa_rdm_pke_init_*rtm), which stamp
+ * a packet header and copy/describe payload from a txe.
+ */
+class EfaRtmTxInitTest :
+	public EfaRtmTxFixture,
+	public WithParamInterface<enum efa_test_rtm_variant>
+{
+};
+
+/**
  * @brief Each init function stamps the header fields and payload its protocol
  * family is responsible for; the variant bits select which fields are asserted
  * and to which sentinel.
  */
-TEST_P(EfaRdmPkeRtmInitTest, stamps_header_and_payload)
+TEST_P(EfaRtmTxInitTest, stamps_header_and_payload)
 {
 	enum efa_test_rtm_variant v = GetParam();
 	bool dc = EFA_TEST_RTM_IS_DC(v);
@@ -183,7 +191,137 @@ TEST_P(EfaRdmPkeRtmInitTest, stamps_header_and_payload)
 }
 
 INSTANTIATE_TEST_SUITE_P(
-	, EfaRdmPkeRtmInitTest, ValuesIn(kRtmInitVariants),
+	, EfaRtmTxInitTest, ValuesIn(kRtmInitVariants),
 	[](const testing::TestParamInfo<enum efa_test_rtm_variant> &info) {
 		return rtm_variant_name(info.param);
 	});
+
+/**
+ * @brief Covers the TX sent and send-completion handlers 
+ */
+class EfaRtmTxSentTest : public EfaRtmTxFixture
+{
+};
+
+/* A non-boundary chunk */
+static constexpr size_t kChunk = 4096;
+
+TEST_F(EfaRtmTxSentTest, medium_sent_and_completion_boundary)
+{
+	struct efa_test_rtm_sent_result res;
+
+	/* sent: bytes_sent advances by the payload, no completion. */
+	efa_test_rtm_sent_build(resource.ep, resource.av,
+				EFA_TEST_RTM_MEDIUM_MSG, EFA_TEST_RTM_OP_SENT,
+				/*payload_size=*/kChunk,
+				/*bytes_already=*/kChunk, 0, &res);
+	EXPECT_EQ(res.bytes_sent, 2 * kChunk);
+
+	/* request completion mid-transfer: bytes_acked advances but no
+	 * completion. */
+	efa_test_rtm_sent_build(
+		resource.ep, resource.av, EFA_TEST_RTM_MEDIUM_MSG,
+		EFA_TEST_RTM_OP_COMPLETION, /*payload_size=*/kChunk,
+		/*bytes_already=*/0, 0, &res);
+	EXPECT_EQ(res.bytes_acked, kChunk);
+	EXPECT_FALSE(res.send_completed);
+	EXPECT_TRUE(res.txe_on_ope_list);
+	EXPECT_FALSE(res.cq_has_completion);
+
+	/* completion at the boundary: the final byte completes the op, frees
+	 * the txe, and writes the SEND completion to the CQ. */
+	efa_test_rtm_sent_build(resource.ep, resource.av,
+				EFA_TEST_RTM_MEDIUM_MSG,
+				EFA_TEST_RTM_OP_COMPLETION,
+				/*payload_size=*/EFA_TEST_RTM_LONG_LEN,
+				/*bytes_already=*/0, 0, &res);
+	EXPECT_TRUE(res.send_completed);
+	EXPECT_FALSE(res.txe_on_ope_list);
+	EXPECT_TRUE(res.cq_has_completion);
+}
+
+TEST_F(EfaRtmTxSentTest, eager_completion_single_shot)
+{
+	struct efa_test_rtm_sent_result res;
+
+	/* payload_size must equal total_len */
+	efa_test_rtm_sent_build(resource.ep, resource.av, EFA_TEST_RTM_EAGER_MSG,
+				EFA_TEST_RTM_OP_COMPLETION,
+				/*payload_size=*/EFA_TEST_RTM_LONG_LEN,
+				/*bytes_already=*/0, 0, &res);
+	EXPECT_TRUE(res.send_completed);
+	EXPECT_FALSE(res.txe_on_ope_list);
+	EXPECT_TRUE(res.cq_has_completion);
+}
+
+TEST_F(EfaRtmTxSentTest, longcts_sent_and_completion_boundary)
+{
+	struct efa_test_rtm_sent_result res;
+
+	efa_test_rtm_sent_build(resource.ep, resource.av,
+				EFA_TEST_RTM_LONGCTS_MSG, EFA_TEST_RTM_OP_SENT,
+				/*payload_size=*/kChunk,
+				/*bytes_already=*/kChunk, 0, &res);
+	EXPECT_EQ(res.bytes_sent, 2 * kChunk);
+
+	efa_test_rtm_sent_build(resource.ep, resource.av,
+				EFA_TEST_RTM_LONGCTS_MSG,
+				EFA_TEST_RTM_OP_COMPLETION,
+				/*payload_size=*/EFA_TEST_RTM_LONG_LEN,
+				/*bytes_already=*/0, 0, &res);
+	EXPECT_TRUE(res.send_completed);
+	EXPECT_TRUE(res.cq_has_completion);
+}
+
+/**
+ * @brief longread "sent" bumps the domain's in-flight read count
+ */
+TEST_F(EfaRtmTxSentTest, longread_sent_bumps_in_flight_read)
+{
+	struct efa_test_rtm_sent_result res;
+
+	efa_test_rtm_sent_build(resource.ep, resource.av,
+				EFA_TEST_RTM_LONGREAD_MSG, EFA_TEST_RTM_OP_SENT,
+				/*payload_size=*/0, /*bytes_already=*/0, 0,
+				&res);
+	EXPECT_EQ(res.num_read_msg_in_flight, 1u);
+}
+
+/**
+ * @brief runtread sent accrues bytes_sent and the peer's runt-in-flight
+ * bytes, and bumps the in-flight read count only for the first segment
+ */
+TEST_F(EfaRtmTxSentTest, runtread_sent_first_segment)
+{
+	struct efa_test_rtm_sent_result res;
+
+	efa_test_rtm_sent_build(resource.ep, resource.av,
+				EFA_TEST_RTM_RUNTREAD_MSG, EFA_TEST_RTM_OP_SENT,
+				/*payload_size=*/kChunk, /*bytes_already=*/0,
+				/*seg_offset=*/0, &res);
+	EXPECT_EQ(res.bytes_sent, kChunk);
+	EXPECT_EQ(res.num_runt_bytes_in_flight, (int64_t) kChunk);
+	EXPECT_EQ(res.num_read_msg_in_flight, 1u);
+
+	efa_test_rtm_sent_build(resource.ep, resource.av,
+				EFA_TEST_RTM_RUNTREAD_MSG, EFA_TEST_RTM_OP_SENT,
+				/*payload_size=*/kChunk, /*bytes_already=*/0,
+				/*seg_offset=*/kChunk, &res);
+	EXPECT_EQ(res.num_read_msg_in_flight, 0u);
+}
+
+TEST_F(EfaRtmTxSentTest, runtread_completion_boundary)
+{
+	struct efa_test_rtm_sent_result res;
+
+	/* num_runt_bytes_in_flight is set to payload_size, so a
+	 * completion drains it back to zero and completes the op. */
+	efa_test_rtm_sent_build(resource.ep, resource.av,
+				EFA_TEST_RTM_RUNTREAD_MSG,
+				EFA_TEST_RTM_OP_COMPLETION,
+				/*payload_size=*/EFA_TEST_RTM_LONG_LEN,
+				/*bytes_already=*/0, 0, &res);
+	EXPECT_TRUE(res.send_completed);
+	EXPECT_EQ(res.num_runt_bytes_in_flight, 0);
+	EXPECT_TRUE(res.cq_has_completion);
+}

--- a/prov/efa/test/gtest/efa_gtest_rdm_pke_utils.c
+++ b/prov/efa/test/gtest/efa_gtest_rdm_pke_utils.c
@@ -10,6 +10,7 @@
 #include "rdm/efa_rdm_ope.h"
 #include "rdm/efa_rdm_pke.h"
 #include "rdm/efa_rdm_pke_rtm.h"
+#include "rdm/efa_rdm_pke_utils.h"
 #include "rdm/efa_rdm_protocol.h"
 
 int efa_test_rtm_read_nack_missing_rxe(struct fid_ep *ep, fi_addr_t peer_addr,
@@ -442,4 +443,144 @@ void efa_test_rtm_init_build(struct fid_ep *ep, struct fid_av *av,
 release:
 	efa_rdm_pke_release_tx(pkt_entry);
 	efa_rdm_txe_release(txe);
+}
+
+static int efa_test_txe_on_ope_list(struct efa_rdm_ep *ep,
+				    struct efa_rdm_ope *txe)
+{
+	struct dlist_entry *item;
+
+	dlist_foreach(&ep->base_ep.ope_list, item) {
+		if (container_of(item, struct efa_rdm_ope, ep_entry) == txe)
+			return 1;
+	}
+	return 0;
+}
+
+void efa_test_rtm_sent_build(struct fid_ep *ep, struct fid_av *av,
+			     enum efa_test_rtm_variant variant,
+			     enum efa_test_rtm_sent_op op, size_t payload_size,
+			     size_t bytes_already, size_t seg_offset,
+			     struct efa_test_rtm_sent_result *out)
+{
+	struct efa_rdm_ep *efa_rdm_ep =
+		container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
+	struct efa_rdm_domain *domain = efa_rdm_ep_rdm_domain(efa_rdm_ep);
+	enum efa_test_rtm_family family = EFA_TEST_RTM_FAMILY(variant);
+	uint32_t fi_op =
+		EFA_TEST_RTM_IS_TAGGED(variant) ? ofi_op_tagged : ofi_op_msg;
+	struct efa_rdm_ope *txe;
+	struct efa_rdm_pke *pkt_entry;
+	struct efa_rdm_peer *peer;
+	static char buf[EFA_TEST_RTM_LONG_LEN];
+
+	memset(out, 0, sizeof(*out));
+
+	txe = efa_test_rtm_alloc_txe(efa_rdm_ep, av, fi_op,
+				     EFA_TEST_RTM_LONG_LEN, buf);
+	if (!txe)
+		return;
+	peer = txe->peer;
+	if (family == EFA_TEST_RTM_FAM_RUNTREAD)
+		txe->bytes_runt = EFA_TEST_RTM_RUNT_LEN;
+	/* A boundary completion writes to the CQ only when completion is
+	 * requested; ask for it so the test can observe the SEND completion. */
+	txe->fi_flags |= FI_COMPLETION;
+	txe->bytes_sent = bytes_already;
+	txe->bytes_acked = bytes_already;
+
+	pkt_entry = efa_rdm_pke_alloc(efa_rdm_ep, efa_rdm_ep->efa_tx_pkt_pool,
+				      EFA_RDM_PKE_FROM_EFA_TX_POOL);
+	if (!pkt_entry) {
+		efa_rdm_txe_release(txe);
+		return;
+	}
+	efa_rdm_pke_set_ope(pkt_entry, txe);
+	pkt_entry->peer = peer;
+	pkt_entry->payload_size = payload_size;
+
+	/* only the runtread send handler checks seg_offset */
+	if (family == EFA_TEST_RTM_FAM_RUNTREAD) {
+		struct efa_rdm_base_hdr *base_hdr =
+			(struct efa_rdm_base_hdr *) pkt_entry->wiredata;
+		base_hdr->type = efa_test_rtm_pkt_type(variant);
+		efa_rdm_pke_get_runtread_rtm_base_hdr(pkt_entry)->seg_offset =
+			seg_offset;
+	}
+
+	if (op == EFA_TEST_RTM_OP_SENT) {
+		/* Report deltas: num_read_msg_in_flight is a domain counter that
+		 * the "sent" handler only bumps (drained elsewhere), so repeated
+		 * builds in one test would see a growing absolute value. The
+		 * fresh peer per build makes its counter effectively a delta. */
+		uint64_t read_in_flight_before = domain->num_read_msg_in_flight;
+
+		switch (family) {
+		case EFA_TEST_RTM_FAM_MEDIUM:
+			efa_rdm_pke_handle_medium_rtm_sent(pkt_entry);
+			break;
+		case EFA_TEST_RTM_FAM_LONGCTS:
+			efa_rdm_pke_handle_longcts_rtm_sent(pkt_entry);
+			break;
+		case EFA_TEST_RTM_FAM_LONGREAD:
+			efa_rdm_pke_handle_longread_rtm_sent(pkt_entry);
+			break;
+		case EFA_TEST_RTM_FAM_RUNTREAD:
+			efa_rdm_pke_handle_runtread_rtm_sent(pkt_entry, peer);
+			break;
+		case EFA_TEST_RTM_FAM_EAGER:
+			break;
+		}
+		/* sent handlers never free the txe; just read the counters. */
+		out->bytes_sent = txe->bytes_sent;
+		out->bytes_acked = txe->bytes_acked;
+		out->num_read_msg_in_flight =
+			domain->num_read_msg_in_flight - read_in_flight_before;
+		out->num_runt_bytes_in_flight = peer->num_runt_bytes_in_flight;
+		out->txe_on_ope_list = 1;
+		efa_rdm_pke_release_tx(pkt_entry);
+		efa_rdm_txe_release(txe);
+		return;
+	}
+
+	/* Completion handlers will free txe, so capture the expected post-state first. */
+	out->bytes_acked = bytes_already + payload_size;
+	out->num_runt_bytes_in_flight =
+		peer->num_runt_bytes_in_flight; /* refreshed below if alive */
+
+	/* The runtread completion handler will assert that this is >= payload_size */
+	if (family == EFA_TEST_RTM_FAM_RUNTREAD)
+		peer->num_runt_bytes_in_flight = payload_size;
+
+	switch (family) {
+	case EFA_TEST_RTM_FAM_EAGER:
+		efa_rdm_pke_handle_eager_rtm_send_completion(pkt_entry);
+		break;
+	case EFA_TEST_RTM_FAM_MEDIUM:
+		efa_rdm_pke_handle_medium_rtm_send_completion(pkt_entry);
+		break;
+	case EFA_TEST_RTM_FAM_LONGCTS:
+		efa_rdm_pke_handle_longcts_rtm_send_completion(pkt_entry);
+		break;
+	case EFA_TEST_RTM_FAM_RUNTREAD:
+		efa_rdm_pke_handle_runtread_rtm_send_completion(pkt_entry);
+		break;
+	case EFA_TEST_RTM_FAM_LONGREAD:
+		/* no dedicated completion handler */
+		break;
+	}
+
+	out->txe_on_ope_list = efa_test_txe_on_ope_list(efa_rdm_ep, txe);
+	out->send_completed = !out->txe_on_ope_list;
+	out->cq_has_completion =
+		(ofi_cq_read_entries(efa_rdm_ep->base_ep.util_ep.tx_cq, NULL, 0,
+				     NULL) != -FI_EAGAIN);
+	out->num_runt_bytes_in_flight = peer->num_runt_bytes_in_flight;
+	if (out->txe_on_ope_list) {
+		out->bytes_acked = txe->bytes_acked;
+		efa_rdm_pke_release_tx(pkt_entry);
+		efa_rdm_txe_release(txe);
+	} else {
+		efa_rdm_pke_release_tx(pkt_entry);
+	}
 }

--- a/prov/efa/test/gtest/efa_gtest_rdm_pke_utils.h
+++ b/prov/efa/test/gtest/efa_gtest_rdm_pke_utils.h
@@ -114,7 +114,7 @@ enum efa_test_rtm_variant {
 		EFA_TEST_RTM_FAM_EAGER | EFA_TEST_RTM_ZERO_HDR,
 };
 
-// Header fields read from the built packet
+/* Header fields read from the built packet */
 struct efa_test_rtm_init_result {
 	ssize_t ret; /* return code of the init function */
 	int base_type;
@@ -153,6 +153,40 @@ void efa_test_rtm_init_build(struct fid_ep *ep, struct fid_av *av,
 int efa_test_rtm_pkt_type(enum efa_test_rtm_variant variant);
 
 int efa_test_get_tx_min_credits(void);
+
+/* --- TX sent / send-completion handler bridge --- */
+enum efa_test_rtm_sent_op {
+	EFA_TEST_RTM_OP_SENT,
+	EFA_TEST_RTM_OP_COMPLETION,
+};
+
+struct efa_test_rtm_sent_result {
+	uint64_t bytes_sent;
+	uint64_t bytes_acked;
+	uint64_t num_read_msg_in_flight;
+	int64_t num_runt_bytes_in_flight;
+	int send_completed;
+	int cq_has_completion;
+	int txe_on_ope_list;
+};
+
+/**
+ * @brief Drive one TX sent/completion handler and report observable counters.
+ *
+ * @param[in]	ep	RDM efa endpoint
+ * @param[in]	av	the endpoint's AV
+ * @param[in]	variant	selects family/tagged/dc
+ * @param[in]	op	sent vs send-completion handler
+ * @param[in]	payload_size	bytes carried by this packet
+ * @param[in]	bytes_already	txe->bytes_sent/bytes_acked before the call
+ * @param[in]	seg_offset	runtread seg_offset header field (ignored else)
+ * @param[out]	out	observable counters after the call
+ */
+void efa_test_rtm_sent_build(struct fid_ep *ep, struct fid_av *av,
+			     enum efa_test_rtm_variant variant,
+			     enum efa_test_rtm_sent_op op, size_t payload_size,
+			     size_t bytes_already, size_t seg_offset,
+			     struct efa_test_rtm_sent_result *out);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Adds unit tests for the sent and send_completion handlers of all protocols,
asserting that the protocol contracts are fulfilled.