### PR TITLE
[v2.4.x] prov/efa: update LSan suppresion list for aarch64

### DIFF
--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -3,6 +3,12 @@
 
 #include "efa_unit_tests.h"
 
+// Harmless suppression: persistent allocation from glibc outside of EFA provider
+const char *__lsan_default_suppressions(void)
+{
+	return "leak:_dlerror_run\n";
+}
+
 struct efa_env orig_efa_env = {0};
 struct efa_hmem_info g_efa_hmem_info_backup[OFI_HMEM_MAX];
 


### PR DESCRIPTION
Suppress the _dlerror_run known benign "leak" from glibc on aarch64 (harmless to include on x86).

(cherry picked from commit b534149)