### PR TITLE
prov/cxi: fix criterion put_red_pkt_distrib test

### DIFF
--- a/prov/cxi/test/coll.c
+++ b/prov/cxi/test/coll.c
@@ -721,7 +721,7 @@ Test(coll_put, put_red_pkt_distrib)
 	struct cxip_cq *rx_cq;
 	struct cxip_coll_reduction *reduction;
 	struct cxip_coll_data coll_data = {.red_cnt = 1};
-	struct fi_cq_data_entry entry;
+	struct fi_cq_tagged_entry entry;
 	int i, cnt, ret;
 
 	_create_netsim_collective(5, false, FI_SUCCESS);


### PR DESCRIPTION
The RX CQ is opened with FI_CQ_FORMAT_TAGGED, so fi_cq_read() writes a struct fi_cq_tagged_entry (48 bytes) per completion.

In put_red_pkt_distrib, entry was declared as struct fi_cq_data_entry (40 bytes), leading to data corruption and the test crashing