### PR TITLE
[v2.4.x] hmem_cuda: Skip cuMemGetAddressRange in cuda_get_dmabuf_fd

### DIFF
--- a/fabtests/common/hmem_cuda.c
+++ b/fabtests/common/hmem_cuda.c
@@ -556,12 +556,9 @@ int ft_cuda_get_dmabuf_fd(void *buf, size_t len,
 #if HAVE_CUDA_DMABUF
 	CUdeviceptr aligned_ptr;
 	CUresult cuda_ret;
-	int ret;
 
 	size_t aligned_size;
 	size_t host_page_size = sysconf(_SC_PAGESIZE);
-	void *base_addr;
-	size_t total_size;
 	unsigned long long flags;
 
 	if (!dmabuf_supported) {
@@ -569,12 +566,16 @@ int ft_cuda_get_dmabuf_fd(void *buf, size_t len,
 		return -FI_EOPNOTSUPP;
 	}
 
-	ret = ft_cuda_get_base_addr(buf, len, &base_addr, &total_size);
-	if (ret)
-		return ret;
-
-	aligned_ptr = (uintptr_t) ft_get_page_start(base_addr, host_page_size);
-	aligned_size = (uintptr_t) ft_get_page_end((void *) ((uintptr_t) base_addr + total_size - 1),
+	/*
+	 * Use the caller-provided addr and size directly instead of
+	 * querying cuMemGetAddressRange(). For CUDA VMM allocations with
+	 * multiple physical segments mapped into a contiguous VA range,
+	 * cuMemGetAddressRange() only returns the size of the individual
+	 * segment containing the pointer, not the full reserved VA range.
+	 * cuMemGetHandleForAddressRange only requires page align.
+	 */
+	aligned_ptr = (uintptr_t) ft_get_page_start(buf, host_page_size);
+	aligned_size = (uintptr_t) ft_get_page_end((void *) ((uintptr_t) buf + len - 1),
 						    host_page_size) - (uintptr_t) aligned_ptr + 1;
 
 	flags = 0;

--- a/src/hmem_cuda.c
+++ b/src/hmem_cuda.c
@@ -703,23 +703,24 @@ int cuda_get_dmabuf_fd(const void *addr, uint64_t size, int *fd,
 #if HAVE_CUDA_DMABUF
 	CUdeviceptr aligned_ptr;
 	CUresult cuda_ret;
-	int ret;
 
 	size_t aligned_size;
 	size_t host_page_size = ofi_get_page_size();
-	void *base_addr;
-	size_t total_size;
 	unsigned long long flags;
 
 	if (!cuda_is_dmabuf_supported())
 		return -FI_EOPNOTSUPP;
 
-	ret = cuda_get_base_addr(addr, size, &base_addr, &total_size);
-	if (ret)
-		return ret;
-
-	aligned_ptr = (uintptr_t) ofi_get_page_start(base_addr, host_page_size);
-	aligned_size = (uintptr_t) ofi_get_page_end((void *) ((uintptr_t) base_addr + total_size - 1),
+	/*
+	 * Use the caller-provided addr and size directly instead of
+	 * querying cuMemGetAddressRange(). For CUDA VMM allocations with
+	 * multiple physical segments mapped into a contiguous VA range,
+	 * cuMemGetAddressRange() only returns the size of the individual
+	 * segment containing the pointer, not the full reserved VA range.
+	 * cuMemGetHandleForAddressRange only requires page align.
+	 */
+	aligned_ptr = (uintptr_t) ofi_get_page_start(addr, host_page_size);
+	aligned_size = (uintptr_t) ofi_get_page_end((void *) ((uintptr_t) addr + size - 1),
 						    host_page_size) - (uintptr_t) aligned_ptr + 1;
 
 	flags = 0;


### PR DESCRIPTION
Use the caller-provided addr and size directly instead of querying cuMemGetAddressRange(). For CUDA VMM allocations with multiple physical segments mapped into a contiguous VA range, cuMemGetAddressRange() only returns the size of the individual segment containing the pointer, not the full reserved VA range.
cuMemGetHandleForAddressRange only requires page align.


(cherry picked from commit 9aaff69fa96c3bdbb7663115dc1520890d9f1b66)