### PR TITLE
prov/efa, man: Add domain ops for ibv_modify_qp

### DIFF
--- a/man/fi_efa.7.md
+++ b/man/fi_efa.7.md
@@ -234,6 +234,8 @@ int fi_open_ops(struct fid *domain, const char *name, uint64_t flags,
     void **ops, void *context);
 ```
 
+### FI_EFA_DOMAIN_OPS
+
 Requesting `FI_EFA_DOMAIN_OPS` in `name` returns `ops` as
 the pointer to the function table `fi_efa_ops_domain` defined as follows:
 
@@ -282,8 +284,10 @@ struct fi_efa_mr_attr {
 (which indicates the failure reason).
 
 
-To enable GPU Direct Async (GDA), which allows the GPU to interact directly with the NIC, 
-request `FI_EFA_GDA_OPS` in the `name` parameter with efa-direct fabirc.
+### FI_EFA_GDA_OPS
+
+To enable GPU Direct Async (GDA), which allows the GPU to interact directly with the NIC,
+request `FI_EFA_GDA_OPS` in the `name` parameter with efa-direct fabric.
 This returns `ops` as a pointer to the function table `fi_efa_ops_gda` defined as follows:
 
 ```c

--- a/man/fi_efa.7.md
+++ b/man/fi_efa.7.md
@@ -526,6 +526,47 @@ struct fi_efa_comp_cntr_init_attr {
 **cntr_open_ext()** returns 0 on success, or a negative value on failure.
 
 
+### FI_EFA_MODIFY_EP_OPS
+
+To modify endpoint attributes at runtime, request `FI_EFA_MODIFY_EP_OPS` in the
+`name` parameter. This returns `ops` as a pointer to the function table
+`fi_efa_ops_modify_ep` defined as follows:
+
+```c
+struct fi_efa_ops_modify_ep {
+	int (*modify_ep)(struct fid_ep *ep, struct fi_efa_ep_attr *ep_attr,
+			 int attr_mask);
+};
+```
+
+#### modify_ep
+This op modifies attributes on the endpoint. The `attr_mask` parameter specifies
+which attributes to modify.
+
+```c
+enum {
+	FI_EFA_EP_ATTR_QKEY = 1 << 0,
+};
+
+struct fi_efa_ep_attr {
+	uint32_t qkey;
+};
+```
+
+*attr_mask*
+:	A bitwise OR of the attributes to modify. Currently supported:
+
+	FI_EFA_EP_ATTR_QKEY:
+		Modify the queue key. The new value is taken from `ep_attr->qkey`.
+
+Unsupported flags in `attr_mask` will cause the call to return `-FI_EOPNOTSUPP`.
+
+#### Return value
+**modify_ep()** returns 0 on success, or a negative error code on failure:
+
+- `-FI_EINVAL`: NULL endpoint or ep_attr, or endpoint not enabled.
+- `-FI_EOPNOTSUPP`: Unsupported flags in `attr_mask`.
+
 ## Fabric Operation Extension
 
 Fabric operation extension is obtained by calling `fi_open_ops`

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -12,6 +12,7 @@
 #include "efa_hw_cntr.h"
 #include "efa_cq.h"
 #include "efa_domain_util.h"
+#include "rdm/efa_rdm_domain.h"
 
 
 struct dlist_entry g_efa_domain_list;
@@ -691,6 +692,74 @@ static struct fi_efa_ops_gda efa_ops_gda = {
 	.cntr_open_ext = efa_domain_cntr_open_ext,
 };
 
+static int efa_domain_modify_ep(struct fid_ep *ep_fid,
+				struct fi_efa_ep_attr *ep_attr, int attr_mask)
+{
+	struct efa_base_ep *base_ep;
+	struct efa_domain *domain;
+	struct ibv_qp_attr ibv_attr = {0};
+	int ibv_mask = 0;
+	int ret;
+	uint32_t old_qkey;
+
+	if (!ep_fid || !ep_attr)
+		return -FI_EINVAL;
+
+	if (attr_mask & ~FI_EFA_EP_ATTR_SUPPORTED_FLAGS) {
+		EFA_WARN(FI_LOG_DOMAIN,
+			 "Unsupported attr_mask: %d\n", attr_mask);
+		return -FI_EOPNOTSUPP;
+	}
+
+	if (!attr_mask)
+		return FI_SUCCESS;
+
+	base_ep = container_of(ep_fid, struct efa_base_ep, util_ep.ep_fid);
+	domain = base_ep->domain;
+
+	if (!base_ep->qp || !base_ep->qp->ibv_qp) {
+		EFA_WARN(FI_LOG_DOMAIN, "Endpoint QP not initialized\n");
+		return -FI_EINVAL;
+	}
+
+	if (attr_mask & FI_EFA_EP_ATTR_QKEY) {
+		ibv_attr.qkey = ep_attr->qkey;
+		ibv_mask |= IBV_QP_QKEY;
+	}
+
+	/*
+	 * The RDM local read path reads qp->qkey to target the
+	 * endpoint's own QP for GPU memory copies. Take the srx_lock
+	 * to synchronize with those data-path reads.
+	 */
+	if (domain->info_type == EFA_INFO_RDM)
+		ofi_genlock_lock(&((struct efa_rdm_domain *) domain)->srx_lock);
+
+	ret = -ibv_modify_qp(base_ep->qp->ibv_qp, &ibv_attr, ibv_mask);
+	if (ret) {
+		EFA_WARN(FI_LOG_DOMAIN,
+			 "ibv_modify_qp failed: %d\n", ret);
+		goto out;
+	}
+
+	if (attr_mask & FI_EFA_EP_ATTR_QKEY) {
+		old_qkey = base_ep->qp->qkey;
+		base_ep->qp->qkey = ep_attr->qkey;
+		EFA_INFO(FI_LOG_DOMAIN, "EP qkey updated: 0x%x -> 0x%x\n",
+			 old_qkey, ep_attr->qkey);
+	}
+
+out:
+	if (domain->info_type == EFA_INFO_RDM)
+		ofi_genlock_unlock(&((struct efa_rdm_domain *) domain)->srx_lock);
+
+	return ret;
+}
+
+struct fi_efa_ops_modify_ep efa_ops_modify_ep = {
+	.modify_ep = efa_domain_modify_ep,
+};
+
 static int
 efa_domain_ops_open(struct fid *fid, const char *ops_name, uint64_t flags,
 		     void **ops, void *context)
@@ -710,6 +779,10 @@ efa_domain_ops_open(struct fid *fid, const char *ops_name, uint64_t flags,
 		}
 
 		*ops = &efa_ops_gda;
+		return ret;
+	}
+	if (strcmp(ops_name, FI_EFA_MODIFY_EP_OPS) == 0) {
+		*ops = &efa_ops_modify_ep;
 		return ret;
 	}
 

--- a/prov/efa/src/efa_domain.h
+++ b/prov/efa/src/efa_domain.h
@@ -52,6 +52,7 @@ struct efa_domain {
 extern struct dlist_entry g_efa_domain_list;
 extern ofi_mutex_t g_efa_domain_list_lock;
 extern struct fi_efa_ops_domain efa_ops_domain;
+extern struct fi_efa_ops_modify_ep efa_ops_modify_ep;
 
 /**
  * @brief domain name suffix according to endpoint type

--- a/prov/efa/src/fi_ext_efa.h
+++ b/prov/efa/src/fi_ext_efa.h
@@ -10,6 +10,7 @@
 #define FI_EFA_DOMAIN_OPS "efa domain ops"
 #define FI_EFA_GDA_OPS "efa gda ops"
 #define FI_EFA_FEATURE_OPS "efa feature ops"
+#define FI_EFA_MODIFY_EP_OPS "efa modify ep ops"
 
 struct fi_efa_mr_attr {
     uint16_t ic_id_validity;
@@ -137,5 +138,20 @@ struct fi_efa_feature_ops {
  * such as fi_writemsg().
  */
 #define FI_EFA_WR_HIGH_PPS (1ULL << 60)
+
+enum {
+	FI_EFA_EP_ATTR_QKEY = 1 << 0,
+};
+
+#define FI_EFA_EP_ATTR_SUPPORTED_FLAGS (FI_EFA_EP_ATTR_QKEY)
+
+struct fi_efa_ep_attr {
+	uint32_t qkey;
+};
+
+struct fi_efa_ops_modify_ep {
+	int (*modify_ep)(struct fid_ep *ep, struct fi_efa_ep_attr *ep_attr,
+			 int attr_mask);
+};
 
 #endif /* _FI_EXT_EFA_H_ */

--- a/prov/efa/src/rdm/efa_rdm_domain.c
+++ b/prov/efa/src/rdm/efa_rdm_domain.c
@@ -260,6 +260,10 @@ efa_rdm_domain_ops_open(struct fid *fid, const char *ops_name, uint64_t flags,
 		EFA_WARN(FI_LOG_DOMAIN, "Only efa direct supports FI_EFA_GDA_OPS\n");
 		return -FI_EOPNOTSUPP;
 	}
+	if (strcmp(ops_name, FI_EFA_MODIFY_EP_OPS) == 0) {
+		*ops = &efa_ops_modify_ep;
+		return ret;
+	}
 
 	EFA_WARN(FI_LOG_DOMAIN, "Unknown ops name: %s\n", ops_name);
 	ret = -FI_EINVAL;


### PR DESCRIPTION
Implement FI_EFA_MODIFY_QP_OPS domain ops that wraps ibv_modify_qp
calls. Currently supports the IBV_QP_QKEY flag, allowing callers to
modify the queue key on an endpoint's QP at runtime.

FI_EFA_QP_ATTR_QKEY is defined equal to IBV_QP_QKEY to make things
easier for the application

The implementation acquires the srx_lock for RDM domains to prevent
races with the local read path that reads qp->qkey.