### PR TITLE
[v2.6.x] fabtests/hmem: Add ft_hmem_init_thread for per-thread CUDA context setup

### DIFF
--- a/fabtests/benchmarks/rdm_bw_mt.c
+++ b/fabtests/benchmarks/rdm_bw_mt.c
@@ -493,6 +493,8 @@ static void *uni_bandwidth(void *context)
 	int i, ret;
 	const struct thread_args *targs = context;
 
+	ft_hmem_init_thread(opts.iface, opts.device);
+
 	pthread_barrier_wait(&barrier);
 	for (i = 0; i < opts.warmup_iterations; i++) {
 		ret = opts.dst_addr ? bw_send(context) : bw_recv(context);
@@ -524,6 +526,8 @@ static void *bi_bandwidth(void *context)
 {
 	int i, ret;
 	struct thread_args *targs = context;
+
+	ft_hmem_init_thread(opts.iface, opts.device);
 
 	pthread_barrier_wait(&barrier);
 	for (i = 0; i < opts.warmup_iterations; i++) {

--- a/fabtests/common/hmem.c
+++ b/fabtests/common/hmem.c
@@ -145,6 +145,16 @@ int ft_hmem_init(enum fi_hmem_iface iface)
 	return ret;
 }
 
+int ft_hmem_init_thread(enum fi_hmem_iface iface, uint64_t device)
+{
+	switch (iface) {
+	case FI_HMEM_CUDA:
+		return ft_cuda_init_thread(device);
+	default:
+		return FI_SUCCESS;
+	}
+}
+
 int ft_hmem_cleanup(enum fi_hmem_iface iface)
 {
 	int ret = FI_SUCCESS;

--- a/fabtests/common/hmem_cuda.c
+++ b/fabtests/common/hmem_cuda.c
@@ -385,6 +385,27 @@ err:
 	return -FI_ENODATA;
 }
 
+int ft_cuda_init_thread(uint64_t device)
+{
+	cudaError_t cuda_ret;
+
+	cuda_ret = cuda_ops.cudaSetDevice(device);
+	if (cuda_ret != cudaSuccess) {
+		CUDA_ERR(cuda_ret, "cudaSetDevice failed");
+		return -FI_EIO;
+	}
+
+	/* cudaFree() forces context activation since cudaSetDevice() alone 
+	 * may do lazy initialization */
+	cuda_ret = cuda_ops.cudaFree(NULL);
+	if (cuda_ret != cudaSuccess) {
+		CUDA_ERR(cuda_ret, "cudaFree failed");
+		return -FI_EIO;
+	}
+
+	return FI_SUCCESS;
+}
+
 int ft_cuda_cleanup(void)
 {
 	dlclose(cudart_handle);
@@ -600,6 +621,11 @@ enum ft_cuda_memory_support ft_cuda_memory_support(void)
 #else
 
 int ft_cuda_init(void)
+{
+	return -FI_ENOSYS;
+}
+
+int ft_cuda_init_thread(uint64_t device)
 {
 	return -FI_ENOSYS;
 }

--- a/fabtests/include/hmem.h
+++ b/fabtests/include/hmem.h
@@ -180,6 +180,7 @@ int ft_default_alloc_host(void **buf, size_t size);
 int ft_default_free_host(void *buf);
 
 int ft_cuda_init(void);
+int ft_cuda_init_thread(uint64_t device);
 int ft_cuda_cleanup(void);
 int ft_cuda_alloc(uint64_t device, void **buf, size_t size);
 int ft_cuda_alloc_host(void **buf, size_t size);
@@ -241,6 +242,7 @@ int ft_synapseai_copy_from_hmem(uint64_t device, void *dst, const void *src, siz
 int ft_synapseai_get_dmabuf_fd(void *buf, size_t len, int *dmabuf_fd, uint64_t *dmabuf_offset);
 
 int ft_hmem_init(enum fi_hmem_iface iface);
+int ft_hmem_init_thread(enum fi_hmem_iface iface, uint64_t device);
 int ft_hmem_cleanup(enum fi_hmem_iface iface);
 int ft_hmem_alloc(enum fi_hmem_iface iface, uint64_t device, void **buf,
 		  size_t size);


### PR DESCRIPTION
In multi-threaded fabtests, cudaSetDevice() is only called on the
main thread during ft_cuda_init(). Worker threads that invoke libfabric
data-path operations trigger provider calls to CUDA function, which
requires a valid CUDA context on the calling thread.

Add ft_hmem_init_thread(iface, device) that calls cudaSetDevice() +
cudaFree(NULL) to bind the CUDA primary context to the calling thread.
cudaFree(NULL) forces context activation since cudaSetDevice() alone may
do lazy initialization. For non-CUDA ifaces this is a no-op.